### PR TITLE
Team LBAC: Fix multiple header values

### DIFF
--- a/pkg/util/proxyutil/proxyutil.go
+++ b/pkg/util/proxyutil/proxyutil.go
@@ -173,11 +173,12 @@ func GetTeamHTTPHeaders(ds *datasources.DataSource, teams []int64) (map[string]s
 		for _, header := range headers {
 			// Header values should be properly escaped.
 			if value, ok := teamHTTPHeadersMap[header.Header]; ok {
+				// Add multiple header values as a comma-separated strings according to RFC 7230
+				// https://datatracker.ietf.org/doc/html/rfc7230#section-3.2.6
 				teamHTTPHeadersMap[header.Header] = fmt.Sprintf("%s,%s", value, url.PathEscape(header.Value))
 			} else {
 				teamHTTPHeadersMap[header.Header] = url.PathEscape(header.Value)
 			}
-
 		}
 	}
 

--- a/pkg/util/proxyutil/proxyutil.go
+++ b/pkg/util/proxyutil/proxyutil.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"net"
 	"net/http"
+	"net/url"
 	"sort"
 	"strconv"
 	"strings"
@@ -170,9 +171,13 @@ func GetTeamHTTPHeaders(ds *datasources.DataSource, teams []int64) (map[string]s
 		}
 
 		for _, header := range headers {
-			// TODO: handle multiple header values
-			// add tests for these cases
-			teamHTTPHeadersMap[header.Header] = header.Value
+			// Header values should be properly escaped.
+			if value, ok := teamHTTPHeadersMap[header.Header]; ok {
+				teamHTTPHeadersMap[header.Header] = fmt.Sprintf("%s,%s", value, url.PathEscape(header.Value))
+			} else {
+				teamHTTPHeadersMap[header.Header] = url.PathEscape(header.Value)
+			}
+
 		}
 	}
 


### PR DESCRIPTION
**What is this feature?**

This PR fixes 2 issues related to team LBAC feature:
- Commas inside LBAC rules are not handled properly (which leads to the error at the Loki side)
- Multiple header values are not supported, so if you have multiple LBAC rules for the same team, then only the last one is applied.

**Why do we need this feature?**

This is a part of https://github.com/grafana/identity-access-team/issues/333

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Header value escaping part is taken from Mimir code. It's a bit tricky, the `url.PathEscape()` works correctly, but not the `url.QueryEscape()`. That functions escape a bit different set of characters, so we took the same as mimir uses to format access policies.

https://github.com/grafana/mimir/blob/fe72ed4d226f88ed695840f550d2892d62f0c43e/pkg/mimirtool/commands/access_control.go#L43

`url.QueryEscape()` escapes everything,
```go
case '$', '&', '+', ',', '/', ':', ';', '=', '?', '@': // §2.2 Reserved characters (reserved)
```
https://cs.opensource.google/go/go/+/refs/tags/go1.21.3:src/net/url/url.go;l=127

but `url.PathEscape()` escapes only subset of characters:
```go
case encodePathSegment: // §3.3
  // The RFC allows : @ & = + $ but saves / ; , for assigning
  // meaning to individual path segments.
  return c == '/' || c == ';' || c == ',' || c == '?'
```
https://cs.opensource.google/go/go/+/refs/tags/go1.21.3:src/net/url/url.go;l=138

