### PR TITLE
Alerting: Update docs with the new create alert menu option in panels

### DIFF
--- a/docs/sources/alerting/alerting-rules/create-grafana-managed-rule.md
+++ b/docs/sources/alerting/alerting-rules/create-grafana-managed-rule.md
@@ -198,9 +198,9 @@ Stale alert instances that are in the **Alerting**/**NoData**/**Error** states a
 
 ### Create alert from any panel
 
-You can create an alert from any panel type. That means you will be able to reuse the queries in this panel and create a new alert based on them.
+Create alerts from any panel type. This means you can reuse the queries in the panel and create alerts based on them.
 
-1. Navigate to your desired dashboard in the **Dashboards** section.
+1. Navigate to a dashboard in the **Dashboards** section.
 2. In the top right corner of the panel, click on the three dots (ellipses).
 3. From the dropdown menu, select **More...** and then choose **Create alert**.
 

--- a/docs/sources/alerting/alerting-rules/create-grafana-managed-rule.md
+++ b/docs/sources/alerting/alerting-rules/create-grafana-managed-rule.md
@@ -196,6 +196,16 @@ An alert instance is considered stale if its dimension or series has disappeared
 
 Stale alert instances that are in the **Alerting**/**NoData**/**Error** states are automatically marked as **Resolved** and the grafana_state_reason annotation is added to the alert instance with the reason **MissingSeries**.
 
+### Create alert from any panel
+
+You can create an alert from any panel type. That means you will be able to re-use the queries in this panel and create a new alert based on these qeries.
+
+1. Navigate to your desired dashboard in the **Dashboards** section.
+2. In the top right corner of the panel, click on the three dots (ellipses).
+3. From the dropdown menu, select **More...** and then choose **Create alert**.
+
+This will open the alert rule form, allowing you to configure and create your alert based on the current panel's query.
+
 {{% docs/reference %}}
 [add-a-query]: "/docs/grafana/ -> /docs/grafana/<GRAFANA VERSION>/panels-visualizations/query-transform-data#add-a-query"
 [add-a-query]: "/docs/grafana-cloud/ -> /docs/grafana/<GRAFANA VERSION>/panels-visualizations/query-transform-data#add-a-query"

--- a/docs/sources/alerting/alerting-rules/create-grafana-managed-rule.md
+++ b/docs/sources/alerting/alerting-rules/create-grafana-managed-rule.md
@@ -198,7 +198,7 @@ Stale alert instances that are in the **Alerting**/**NoData**/**Error** states a
 
 ### Create alert from any panel
 
-You can create an alert from any panel type. That means you will be able to re-use the queries in this panel and create a new alert based on these qeries.
+You can create an alert from any panel type. That means you will be able to reuse the queries in this panel and create a new alert based on them.
 
 1. Navigate to your desired dashboard in the **Dashboards** section.
 2. In the top right corner of the panel, click on the three dots (ellipses).

--- a/docs/sources/alerting/alerting-rules/create-grafana-managed-rule.md
+++ b/docs/sources/alerting/alerting-rules/create-grafana-managed-rule.md
@@ -196,7 +196,7 @@ An alert instance is considered stale if its dimension or series has disappeared
 
 Stale alert instances that are in the **Alerting**/**NoData**/**Error** states are automatically marked as **Resolved** and the grafana_state_reason annotation is added to the alert instance with the reason **MissingSeries**.
 
-### Create alert from any panel
+### Create alerts from panels
 
 Create alerts from any panel type. This means you can reuse the queries in the panel and create alerts based on them.
 


### PR DESCRIPTION
This PR adds the documentation section for the new Create alert  menu option on panels.
[PR](https://github.com/grafana/grafana/pull/76618) introducing this change.

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
