### PR TITLE
Prometheus: (Chore) Switch from infra to sdk logger

### DIFF
--- a/pkg/tsdb/prometheus/client/transport.go
+++ b/pkg/tsdb/prometheus/client/transport.go
@@ -8,7 +8,7 @@ import (
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
 	sdkhttpclient "github.com/grafana/grafana-plugin-sdk-go/backend/httpclient"
 
-	"github.com/grafana/grafana/pkg/infra/log"
+	"github.com/grafana/grafana-plugin-sdk-go/backend/log"
 	"github.com/grafana/grafana/pkg/setting"
 	"github.com/grafana/grafana/pkg/tsdb/prometheus/azureauth"
 	"github.com/grafana/grafana/pkg/tsdb/prometheus/middleware"

--- a/pkg/tsdb/prometheus/client/transport_test.go
+++ b/pkg/tsdb/prometheus/client/transport_test.go
@@ -8,7 +8,6 @@ import (
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
 	"github.com/stretchr/testify/require"
 
-	"github.com/grafana/grafana-plugin-sdk-go/backend/log/logtest"
 	"github.com/grafana/grafana/pkg/setting"
 )
 
@@ -22,7 +21,7 @@ func TestCreateTransportOptions(t *testing.T) {
 				"httpHeaderValue1": "bar",
 			},
 		}
-		opts, err := CreateTransportOptions(context.Background(), settings, &setting.Cfg{}, &logtest.Fake{})
+		opts, err := CreateTransportOptions(context.Background(), settings, &setting.Cfg{}, backend.NewLoggerWith("logger", "test"))
 		require.NoError(t, err)
 		require.Equal(t, map[string]string{"foo": "bar"}, opts.Headers)
 		require.Equal(t, 2, len(opts.Middlewares))
@@ -39,7 +38,7 @@ func TestCreateTransportOptions(t *testing.T) {
 			}`),
 			DecryptedSecureJSONData: map[string]string{},
 		}
-		opts, err := CreateTransportOptions(context.Background(), settings, &setting.Cfg{AzureAuthEnabled: true, Azure: &azsettings.AzureSettings{}}, &logtest.Fake{})
+		opts, err := CreateTransportOptions(context.Background(), settings, &setting.Cfg{AzureAuthEnabled: true, Azure: &azsettings.AzureSettings{}}, backend.NewLoggerWith("logger", "test"))
 		require.NoError(t, err)
 		require.Equal(t, 3, len(opts.Middlewares))
 	})

--- a/pkg/tsdb/prometheus/client/transport_test.go
+++ b/pkg/tsdb/prometheus/client/transport_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
 	"github.com/stretchr/testify/require"
 
-	"github.com/grafana/grafana/pkg/infra/log/logtest"
+	"github.com/grafana/grafana-plugin-sdk-go/backend/log/logtest"
 	"github.com/grafana/grafana/pkg/setting"
 )
 

--- a/pkg/tsdb/prometheus/healthcheck.go
+++ b/pkg/tsdb/prometheus/healthcheck.go
@@ -10,7 +10,7 @@ import (
 	"github.com/grafana/kindsys"
 
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
-	"github.com/grafana/grafana/pkg/infra/log"
+	"github.com/grafana/grafana-plugin-sdk-go/backend/log"
 	"github.com/grafana/grafana/pkg/tsdb/prometheus/kinds/dataquery"
 	"github.com/grafana/grafana/pkg/tsdb/prometheus/models"
 )
@@ -19,7 +19,7 @@ const (
 	refID = "__healthcheck__"
 )
 
-var logger log.Logger = log.New("tsdb.prometheus")
+var logger log.Logger = backend.NewLoggerWith("logger", "tsdb.prometheus")
 
 func (s *Service) CheckHealth(ctx context.Context, req *backend.CheckHealthRequest) (*backend.CheckHealthResult,
 	error) {

--- a/pkg/tsdb/prometheus/healthcheck_test.go
+++ b/pkg/tsdb/prometheus/healthcheck_test.go
@@ -79,7 +79,7 @@ func Test_healthcheck(t *testing.T) {
 	t.Run("should do a successful health check", func(t *testing.T) {
 		httpProvider := getMockProvider[*healthCheckSuccessRoundTripper]()
 		s := &Service{
-			im: datasource.NewInstanceManager(newInstanceSettings(httpProvider, &setting.Cfg{}, &featuremgmt.FeatureManager{}, nil)),
+			im: datasource.NewInstanceManager(newInstanceSettings(httpProvider, &setting.Cfg{}, &featuremgmt.FeatureManager{}, nil, backend.NewLoggerWith("logger", "test"))),
 		}
 
 		req := &backend.CheckHealthRequest{
@@ -95,7 +95,7 @@ func Test_healthcheck(t *testing.T) {
 	t.Run("should return an error for an unsuccessful health check", func(t *testing.T) {
 		httpProvider := getMockProvider[*healthCheckFailRoundTripper]()
 		s := &Service{
-			im: datasource.NewInstanceManager(newInstanceSettings(httpProvider, &setting.Cfg{}, &featuremgmt.FeatureManager{}, nil)),
+			im: datasource.NewInstanceManager(newInstanceSettings(httpProvider, &setting.Cfg{}, &featuremgmt.FeatureManager{}, nil, backend.NewLoggerWith("logger", "test"))),
 		}
 
 		req := &backend.CheckHealthRequest{

--- a/pkg/tsdb/prometheus/heuristics_test.go
+++ b/pkg/tsdb/prometheus/heuristics_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/grafana/grafana-plugin-sdk-go/backend"
 	"github.com/grafana/grafana-plugin-sdk-go/backend/datasource"
 	sdkHttpClient "github.com/grafana/grafana-plugin-sdk-go/backend/httpclient"
 	"github.com/grafana/grafana/pkg/infra/httpclient"
@@ -63,7 +64,7 @@ func Test_GetHeuristics(t *testing.T) {
 		}
 		httpProvider := getHeuristicsMockProvider(&rt)
 		s := &Service{
-			im: datasource.NewInstanceManager(newInstanceSettings(httpProvider, &setting.Cfg{}, &featuremgmt.FeatureManager{}, nil)),
+			im: datasource.NewInstanceManager(newInstanceSettings(httpProvider, &setting.Cfg{}, &featuremgmt.FeatureManager{}, nil, backend.NewLoggerWith("logger", "test"))),
 		}
 
 		req := HeuristicsRequest{
@@ -83,7 +84,7 @@ func Test_GetHeuristics(t *testing.T) {
 		}
 		httpProvider := getHeuristicsMockProvider(&rt)
 		s := &Service{
-			im: datasource.NewInstanceManager(newInstanceSettings(httpProvider, &setting.Cfg{}, &featuremgmt.FeatureManager{}, nil)),
+			im: datasource.NewInstanceManager(newInstanceSettings(httpProvider, &setting.Cfg{}, &featuremgmt.FeatureManager{}, nil, backend.NewLoggerWith("logger", "test"))),
 		}
 
 		req := HeuristicsRequest{

--- a/pkg/tsdb/prometheus/middleware/custom_query_params.go
+++ b/pkg/tsdb/prometheus/middleware/custom_query_params.go
@@ -6,7 +6,7 @@ import (
 
 	sdkhttpclient "github.com/grafana/grafana-plugin-sdk-go/backend/httpclient"
 
-	"github.com/grafana/grafana/pkg/infra/log"
+	"github.com/grafana/grafana-plugin-sdk-go/backend/log"
 )
 
 const (

--- a/pkg/tsdb/prometheus/middleware/custom_query_params_test.go
+++ b/pkg/tsdb/prometheus/middleware/custom_query_params_test.go
@@ -6,10 +6,9 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/grafana/grafana-plugin-sdk-go/backend"
 	"github.com/grafana/grafana-plugin-sdk-go/backend/httpclient"
 	"github.com/stretchr/testify/require"
-
-	"github.com/grafana/grafana/pkg/infra/log"
 )
 
 func TestCustomQueryParametersMiddleware(t *testing.T) {
@@ -20,7 +19,7 @@ func TestCustomQueryParametersMiddleware(t *testing.T) {
 	})
 
 	t.Run("Without custom query parameters set should not apply middleware", func(t *testing.T) {
-		mw := CustomQueryParameters(log.New("test"))
+		mw := CustomQueryParameters(backend.NewLoggerWith("logger", "test"))
 		rt := mw.CreateMiddleware(httpclient.Options{}, finalRoundTripper)
 		require.NotNil(t, rt)
 		middlewareName, ok := mw.(httpclient.MiddlewareName)
@@ -40,7 +39,7 @@ func TestCustomQueryParametersMiddleware(t *testing.T) {
 	})
 
 	t.Run("Without custom query parameters set as string should not apply middleware", func(t *testing.T) {
-		mw := CustomQueryParameters(log.New("test"))
+		mw := CustomQueryParameters(backend.NewLoggerWith("logger", "test"))
 		rt := mw.CreateMiddleware(httpclient.Options{
 			CustomOptions: map[string]any{
 				customQueryParametersKey: 64,
@@ -64,7 +63,7 @@ func TestCustomQueryParametersMiddleware(t *testing.T) {
 	})
 
 	t.Run("With custom query parameters set as empty string should not apply middleware", func(t *testing.T) {
-		mw := CustomQueryParameters(log.New("test"))
+		mw := CustomQueryParameters(backend.NewLoggerWith("logger", "test"))
 		rt := mw.CreateMiddleware(httpclient.Options{
 			CustomOptions: map[string]any{
 				customQueryParametersKey: "",
@@ -88,7 +87,7 @@ func TestCustomQueryParametersMiddleware(t *testing.T) {
 	})
 
 	t.Run("With custom query parameters set as invalid query string should not apply middleware", func(t *testing.T) {
-		mw := CustomQueryParameters(log.New("test"))
+		mw := CustomQueryParameters(backend.NewLoggerWith("logger", "test"))
 		rt := mw.CreateMiddleware(httpclient.Options{
 			CustomOptions: map[string]any{
 				customQueryParametersKey: "custom=%%abc&test=abc",
@@ -112,7 +111,7 @@ func TestCustomQueryParametersMiddleware(t *testing.T) {
 	})
 
 	t.Run("With custom query parameters set should apply middleware for request URL containing query parameters ", func(t *testing.T) {
-		mw := CustomQueryParameters(log.New("test"))
+		mw := CustomQueryParameters(backend.NewLoggerWith("logger", "test"))
 		rt := mw.CreateMiddleware(httpclient.Options{
 			CustomOptions: map[string]any{
 				grafanaDataKey: map[string]any{
@@ -144,7 +143,7 @@ func TestCustomQueryParametersMiddleware(t *testing.T) {
 	})
 
 	t.Run("With custom query parameters set should apply middleware for request URL not containing query parameters", func(t *testing.T) {
-		mw := CustomQueryParameters(log.New("test"))
+		mw := CustomQueryParameters(backend.NewLoggerWith("logger", "test"))
 		rt := mw.CreateMiddleware(httpclient.Options{
 			CustomOptions: map[string]any{
 				grafanaDataKey: map[string]any{

--- a/pkg/tsdb/prometheus/middleware/force_http_get.go
+++ b/pkg/tsdb/prometheus/middleware/force_http_get.go
@@ -5,7 +5,7 @@ import (
 
 	sdkhttpclient "github.com/grafana/grafana-plugin-sdk-go/backend/httpclient"
 
-	"github.com/grafana/grafana/pkg/infra/log"
+	"github.com/grafana/grafana-plugin-sdk-go/backend/log"
 )
 
 func ForceHttpGet(logger log.Logger) sdkhttpclient.Middleware {

--- a/pkg/tsdb/prometheus/middleware/force_http_get_test.go
+++ b/pkg/tsdb/prometheus/middleware/force_http_get_test.go
@@ -4,10 +4,9 @@ import (
 	"net/http"
 	"testing"
 
+	"github.com/grafana/grafana-plugin-sdk-go/backend"
 	"github.com/grafana/grafana-plugin-sdk-go/backend/httpclient"
 	"github.com/stretchr/testify/require"
-
-	"github.com/grafana/grafana/pkg/infra/log"
 )
 
 func TestEnsureHttpMethodMiddleware(t *testing.T) {
@@ -15,7 +14,7 @@ func TestEnsureHttpMethodMiddleware(t *testing.T) {
 		finalRoundTripper := httpclient.RoundTripperFunc(func(req *http.Request) (*http.Response, error) {
 			return &http.Response{StatusCode: http.StatusOK}, nil
 		})
-		mw := ForceHttpGet(log.New("test"))
+		mw := ForceHttpGet(backend.NewLoggerWith("logger", "test"))
 		rt := mw.CreateMiddleware(httpclient.Options{}, finalRoundTripper)
 		require.NotNil(t, rt)
 		middlewareName, ok := mw.(httpclient.MiddlewareName)
@@ -28,7 +27,7 @@ func TestEnsureHttpMethodMiddleware(t *testing.T) {
 			return &http.Response{StatusCode: http.StatusOK}, nil
 		})
 
-		mw := ForceHttpGet(log.New("test"))
+		mw := ForceHttpGet(backend.NewLoggerWith("logger", "test"))
 		rt := mw.CreateMiddleware(httpclient.Options{}, finalRoundTripper)
 		require.NotNil(t, rt)
 

--- a/pkg/tsdb/prometheus/prometheus.go
+++ b/pkg/tsdb/prometheus/prometheus.go
@@ -14,7 +14,6 @@ import (
 	apiv1 "github.com/prometheus/client_golang/api/prometheus/v1"
 
 	"github.com/grafana/grafana/pkg/infra/httpclient"
-	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/infra/tracing"
 	"github.com/grafana/grafana/pkg/services/featuremgmt"
 	"github.com/grafana/grafana/pkg/setting"
@@ -24,7 +23,7 @@ import (
 	"github.com/grafana/grafana/pkg/tsdb/prometheus/resource"
 )
 
-var plog = log.New("tsdb.prometheus")
+var plog = backend.NewLoggerWith("logger", "tsdb.prometheus")
 
 type Service struct {
 	im       instancemgmt.InstanceManager

--- a/pkg/tsdb/prometheus/prometheus.go
+++ b/pkg/tsdb/prometheus/prometheus.go
@@ -10,6 +10,7 @@ import (
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
 	"github.com/grafana/grafana-plugin-sdk-go/backend/datasource"
 	"github.com/grafana/grafana-plugin-sdk-go/backend/instancemgmt"
+	"github.com/grafana/grafana-plugin-sdk-go/backend/log"
 	"github.com/patrickmn/go-cache"
 	apiv1 "github.com/prometheus/client_golang/api/prometheus/v1"
 
@@ -23,11 +24,10 @@ import (
 	"github.com/grafana/grafana/pkg/tsdb/prometheus/resource"
 )
 
-var plog = backend.NewLoggerWith("logger", "tsdb.prometheus")
-
 type Service struct {
 	im       instancemgmt.InstanceManager
 	features featuremgmt.FeatureToggles
+	logger   log.Logger
 }
 
 type instance struct {
@@ -37,17 +37,19 @@ type instance struct {
 }
 
 func ProvideService(httpClientProvider httpclient.Provider, cfg *setting.Cfg, features featuremgmt.FeatureToggles, tracer tracing.Tracer) *Service {
+	plog := backend.NewLoggerWith("logger", "tsdb.prometheus")
 	plog.Debug("Initializing")
 	return &Service{
-		im:       datasource.NewInstanceManager(newInstanceSettings(httpClientProvider, cfg, features, tracer)),
+		im:       datasource.NewInstanceManager(newInstanceSettings(httpClientProvider, cfg, features, tracer, plog)),
 		features: features,
+		logger:   plog,
 	}
 }
 
-func newInstanceSettings(httpClientProvider httpclient.Provider, cfg *setting.Cfg, features featuremgmt.FeatureToggles, tracer tracing.Tracer) datasource.InstanceFactoryFunc {
+func newInstanceSettings(httpClientProvider httpclient.Provider, cfg *setting.Cfg, features featuremgmt.FeatureToggles, tracer tracing.Tracer, log log.Logger) datasource.InstanceFactoryFunc {
 	return func(ctx context.Context, settings backend.DataSourceInstanceSettings) (instancemgmt.Instance, error) {
 		// Creates a http roundTripper.
-		opts, err := client.CreateTransportOptions(ctx, settings, cfg, plog)
+		opts, err := client.CreateTransportOptions(ctx, settings, cfg, log)
 		if err != nil {
 			return nil, fmt.Errorf("error creating transport options: %v", err)
 		}
@@ -57,13 +59,13 @@ func newInstanceSettings(httpClientProvider httpclient.Provider, cfg *setting.Cf
 		}
 
 		// New version using custom client and better response parsing
-		qd, err := querydata.New(httpClient, features, tracer, settings, plog)
+		qd, err := querydata.New(httpClient, features, tracer, settings, log)
 		if err != nil {
 			return nil, err
 		}
 
 		// Resource call management using new custom client same as querydata
-		r, err := resource.New(httpClient, settings, plog)
+		r, err := resource.New(httpClient, settings, log)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/tsdb/prometheus/prometheus_test.go
+++ b/pkg/tsdb/prometheus/prometheus_test.go
@@ -60,7 +60,7 @@ func TestService(t *testing.T) {
 			t.Run("creates correct request", func(t *testing.T) {
 				httpProvider := &fakeHTTPClientProvider{}
 				service := &Service{
-					im: datasource.NewInstanceManager(newInstanceSettings(httpProvider, &setting.Cfg{}, &featuremgmt.FeatureManager{}, nil)),
+					im: datasource.NewInstanceManager(newInstanceSettings(httpProvider, &setting.Cfg{}, &featuremgmt.FeatureManager{}, nil, backend.NewLoggerWith("logger", "test"))),
 				}
 
 				req := &backend.CallResourceRequest{

--- a/pkg/tsdb/prometheus/querydata/request.go
+++ b/pkg/tsdb/prometheus/querydata/request.go
@@ -11,7 +11,7 @@ import (
 	"github.com/grafana/grafana-plugin-sdk-go/data"
 	"go.opentelemetry.io/otel/attribute"
 
-	"github.com/grafana/grafana/pkg/infra/log"
+	"github.com/grafana/grafana-plugin-sdk-go/backend/log"
 	"github.com/grafana/grafana/pkg/infra/tracing"
 	"github.com/grafana/grafana/pkg/services/featuremgmt"
 	"github.com/grafana/grafana/pkg/tsdb/intervalv2"

--- a/pkg/tsdb/prometheus/querydata/request_test.go
+++ b/pkg/tsdb/prometheus/querydata/request_test.go
@@ -22,8 +22,8 @@ import (
 
 	"github.com/grafana/kindsys"
 
+	"github.com/grafana/grafana-plugin-sdk-go/backend/log"
 	"github.com/grafana/grafana/pkg/infra/httpclient"
-	"github.com/grafana/grafana/pkg/infra/log/logtest"
 	"github.com/grafana/grafana/pkg/infra/tracing"
 	"github.com/grafana/grafana/pkg/setting"
 	"github.com/grafana/grafana/pkg/tsdb/prometheus/client"
@@ -445,7 +445,7 @@ func setup() (*testContext, error) {
 
 	features := &fakeFeatureToggles{flags: map[string]bool{"prometheusBufferedClient": false}}
 
-	opts, err := client.CreateTransportOptions(context.Background(), settings, &setting.Cfg{}, &logtest.Fake{})
+	opts, err := client.CreateTransportOptions(context.Background(), settings, &setting.Cfg{}, log.New())
 	if err != nil {
 		return nil, err
 	}
@@ -455,7 +455,7 @@ func setup() (*testContext, error) {
 		return nil, err
 	}
 
-	queryData, _ := querydata.New(httpClient, features, tracer, settings, &logtest.Fake{})
+	queryData, _ := querydata.New(httpClient, features, tracer, settings, log.New())
 
 	return &testContext{
 		httpProvider: httpProvider,

--- a/pkg/tsdb/prometheus/resource/resource.go
+++ b/pkg/tsdb/prometheus/resource/resource.go
@@ -7,7 +7,7 @@ import (
 	"net/http"
 
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
-	"github.com/grafana/grafana/pkg/infra/log"
+	"github.com/grafana/grafana-plugin-sdk-go/backend/log"
 	"github.com/grafana/grafana/pkg/tsdb/prometheus/client"
 	"github.com/grafana/grafana/pkg/tsdb/prometheus/utils"
 	"github.com/grafana/grafana/pkg/util/maputil"


### PR DESCRIPTION
**What is this feature?**

Switch from infra to sdk logging to make datasource more inline with external datasources.

Fixes #

**Special notes for your reviewer:**

Related: https://github.com/grafana/grafana/pull/76833

Seems to work as expected:
![image](https://github.com/grafana/grafana/assets/1692624/65cd98a6-ec45-469c-a6cf-6da65862136c)


```shell
# kbrandt @ kbrandt-ws in ~/go/github.com/grafana/grafana/pkg/tsdb/prometheus on git:promSDKLog o [12:03:50] 
$ sed -i 's@github.com/grafana/grafana/pkg/infra/log@github.com/grafana/grafana-plugin-sdk-go/backend/log@g' **/*.go
```


Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
