### PR TITLE
Testdata: Use contextual logging

### DIFF
--- a/pkg/tsdb/grafana-testdata-datasource/scenarios.go
+++ b/pkg/tsdb/grafana-testdata-datasource/scenarios.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
+	"github.com/grafana/grafana-plugin-sdk-go/backend/log"
 	"github.com/grafana/grafana-plugin-sdk-go/backend/tracing"
 	"github.com/grafana/grafana-plugin-sdk-go/data"
 	"go.opentelemetry.io/otel/attribute"
@@ -231,16 +232,19 @@ Timestamps will line up evenly on timeStepSeconds (For example, 60 seconds means
 
 func (s *Service) registerScenario(scenario *Scenario) {
 	s.scenarios[scenario.ID] = scenario
-	s.queryMux.HandleFunc(scenario.ID, traceScenarioHandler(scenario.ID, scenario.handler))
+	s.queryMux.HandleFunc(scenario.ID, instrumentScenarioHandler(s.logger, scenario.ID, scenario.handler))
 }
 
-func traceScenarioHandler(scenario string, fn backend.QueryDataHandlerFunc) backend.QueryDataHandlerFunc {
+func instrumentScenarioHandler(logger log.Logger, scenario string, fn backend.QueryDataHandlerFunc) backend.QueryDataHandlerFunc {
 	return backend.QueryDataHandlerFunc(func(ctx context.Context, req *backend.QueryDataRequest) (*backend.QueryDataResponse, error) {
 		ctx, span := tracing.DefaultTracer().Start(ctx, "testdatasource.queryData",
 			trace.WithAttributes(
 				attribute.String("scenario", scenario),
 			))
 		defer span.End()
+
+		ctxLogger := logger.FromContext(ctx)
+		ctxLogger.Debug("queryData", "scenario", scenario)
 
 		return fn(ctx, req)
 	})
@@ -298,12 +302,13 @@ func GetJSONModel(j json.RawMessage) (JSONModel, error) {
 
 // handleFallbackScenario handles the scenario where queryType is not set and fallbacks to scenarioId.
 func (s *Service) handleFallbackScenario(ctx context.Context, req *backend.QueryDataRequest) (*backend.QueryDataResponse, error) {
+	ctxLogger := s.logger.FromContext(ctx)
 	scenarioQueries := map[string][]backend.DataQuery{}
 
 	for _, q := range req.Queries {
 		model, err := GetJSONModel(q.JSON)
 		if err != nil {
-			s.logger.Error("Failed to unmarshal query model to JSON", "error", err)
+			ctxLogger.Error("Failed to unmarshal query model to JSON", "error", err)
 			continue
 		}
 
@@ -315,7 +320,7 @@ func (s *Service) handleFallbackScenario(ctx context.Context, req *backend.Query
 
 			scenarioQueries[scenarioID] = append(scenarioQueries[scenarioID], q)
 		} else {
-			s.logger.Error("Scenario not found", "scenarioId", scenarioID)
+			ctxLogger.Error("Scenario not found", "scenarioId", scenarioID)
 		}
 	}
 
@@ -327,9 +332,9 @@ func (s *Service) handleFallbackScenario(ctx context.Context, req *backend.Query
 				Headers:       req.Headers,
 				Queries:       queries,
 			}
-			handler := traceScenarioHandler(scenarioID, scenario.handler)
+			handler := instrumentScenarioHandler(s.logger, scenarioID, scenario.handler)
 			if sResp, err := handler(ctx, sReq); err != nil {
-				s.logger.Error("Failed to handle scenario", "scenarioId", scenarioID, "error", err)
+				ctxLogger.Error("Failed to handle scenario", "scenarioId", scenarioID, "error", err)
 			} else {
 				for refID, dr := range sResp.Responses {
 					resp.Responses[refID] = dr

--- a/pkg/tsdb/grafana-testdata-datasource/stream_handler.go
+++ b/pkg/tsdb/grafana-testdata-datasource/stream_handler.go
@@ -15,7 +15,8 @@ import (
 var random20HzStreamRegex = regexp.MustCompile(`random-20Hz-stream(-\d+)?`)
 
 func (s *Service) SubscribeStream(ctx context.Context, req *backend.SubscribeStreamRequest) (*backend.SubscribeStreamResponse, error) {
-	s.logger.Debug("Allowing access to stream", "path", req.Path, "user", req.PluginContext.User)
+	ctxLogger := s.logger.FromContext(ctx)
+	ctxLogger.Debug("Allowing access to stream", "path", req.Path, "user", req.PluginContext.User)
 
 	if strings.HasPrefix(req.Path, "sim/") {
 		return s.sims.SubscribeStream(ctx, req)
@@ -40,7 +41,8 @@ func (s *Service) SubscribeStream(ctx context.Context, req *backend.SubscribeStr
 }
 
 func (s *Service) PublishStream(ctx context.Context, req *backend.PublishStreamRequest) (*backend.PublishStreamResponse, error) {
-	s.logger.Debug("Attempt to publish into stream", "path", req.Path, "user", req.PluginContext.User)
+	ctxLogger := s.logger.FromContext(ctx)
+	ctxLogger.Debug("Attempt to publish into stream", "path", req.Path, "user", req.PluginContext.User)
 
 	if strings.HasPrefix(req.Path, "sim/") {
 		return s.sims.PublishStream(ctx, req)
@@ -52,7 +54,8 @@ func (s *Service) PublishStream(ctx context.Context, req *backend.PublishStreamR
 }
 
 func (s *Service) RunStream(ctx context.Context, request *backend.RunStreamRequest, sender *backend.StreamSender) error {
-	s.logger.Debug("New stream call", "path", request.Path)
+	ctxLogger := s.logger.FromContext(ctx)
+	ctxLogger.Debug("New stream call", "path", request.Path)
 
 	if strings.HasPrefix(request.Path, "sim/") {
 		return s.sims.RunStream(ctx, request, sender)
@@ -92,6 +95,7 @@ type testStreamConfig struct {
 }
 
 func (s *Service) runTestStream(ctx context.Context, path string, conf testStreamConfig, sender *backend.StreamSender) error {
+	ctxLogger := s.logger.FromContext(ctx)
 	spread := 50.0
 	walker := rand.Float64() * 100
 
@@ -107,7 +111,7 @@ func (s *Service) runTestStream(ctx context.Context, path string, conf testStrea
 	for {
 		select {
 		case <-ctx.Done():
-			s.logger.Debug("Stop streaming data for path", "path", path)
+			ctxLogger.Debug("Stop streaming data for path", "path", path)
 			return ctx.Err()
 		case t := <-ticker.C:
 			if rand.Float64() < conf.Drop {


### PR DESCRIPTION
Uses contextual logging based on work in #73115 to exemplify how you would use this in a core plugin.

Example output:
```shell
DEBUG[10-19|18:21:26] queryData                                logger=tsdb.testdata endpoint=queryData pluginId=testdata dsName=gdev-testdata dsUID=PD8C576611E62080A uname=admin traceID=0c870b575c537a8f6fba2c8af61f81db scenario=no_data_points
INFO [10-19|18:21:26] Plugin Request Completed                 logger=plugin.instrumentation endpoint=queryData pluginId=testdata dsName=gdev-testdata dsUID=PD8C576611E62080A uname=admin traceID=0c870b575c537a8f6fba2c8af61f81db status=ok duration=2.733447ms eventName=grafana-data-egress time_before_plugin_request=2.239971ms
DEBUG[10-19|18:21:26] queryData                                logger=tsdb.testdata endpoint=queryData pluginId=testdata dsName=gdev-testdata dsUID=PD8C576611E62080A uname=admin traceID=450d77142c5ab3cc2c3d8954d37deaa1 scenario=datapoints_outside_range
INFO [10-19|18:21:26] Plugin Request Completed                 logger=plugin.instrumentation endpoint=queryData pluginId=testdata dsName=gdev-testdata dsUID=PD8C576611E62080A uname=admin traceID=450d77142c5ab3cc2c3d8954d37deaa1 status=ok duration=2.960661ms eventName=grafana-data-egress time_before_plugin_request=1.387098ms
DEBUG[10-19|18:21:26] queryData                                logger=tsdb.testdata endpoint=queryData pluginId=testdata dsName=gdev-testdata dsUID=PD8C576611E62080A uname=admin traceID=396e191279ea7e1cfd58af527b87fa81 scenario=random_walk
INFO [10-19|18:21:26] Request Completed                        logger=context traceID=0c870b575c537a8f6fba2c8af61f81db userId=1 orgId=1 uname=admin method=POST path=/api/ds/query status=200 remote_addr=[::1] time_ms=5 duration=5.66623ms size=15 referer="http://localhost:3000/d/5SdHCadmz/panel-tests-graph?orgId=1" db_call_count=3 handler=/api/ds/query status_source=server
DEBUG[10-19|18:21:26] queryData                                logger=tsdb.testdata endpoint=queryData pluginId=testdata dsName=gdev-testdata dsUID=PD8C576611E62080A uname=admin traceID=e31ce7fb23abe640bf4ed04e4e6ecc2a scenario=random_walk
INFO [10-19|18:21:26] Request Completed                        logger=context traceID=450d77142c5ab3cc2c3d8954d37deaa1 userId=1 orgId=1 uname=admin method=POST path=/api/ds/query status=200 remote_addr=[::1] time_ms=4 duration=4.876475ms size=266 referer="http://localhost:3000/d/5SdHCadmz/panel-tests-graph?orgId=1" db_call_count=1 handler=/api/ds/query status_source=server
DEBUG[10-19|18:21:26] queryData                                logger=tsdb.testdata endpoint=queryData pluginId=testdata dsName=gdev-testdata dsUID=PD8C576611E62080A uname=admin traceID=072a8a9dfdda05b0f34922319a87e274 scenario=csv_metric_values
INFO [10-19|18:21:26] Plugin Request Completed                 logger=plugin.instrumentation endpoint=queryData pluginId=testdata dsName=gdev-testdata dsUID=PD8C576611E62080A uname=admin traceID=072a8a9dfdda05b0f34922319a87e274 status=ok duration=164.223µs eventName=grafana-data-egress time_before_plugin_request=1.748658ms
INFO [10-19|18:21:26] Plugin Request Completed                 logger=plugin.instrumentation endpoint=queryData pluginId=testdata dsName=gdev-testdata dsUID=PD8C576611E62080A uname=admin traceID=396e191279ea7e1cfd58af527b87fa81 status=ok duration=610.885µs eventName=grafana-data-egress time_before_plugin_request=1.466275ms
INFO [10-19|18:21:26] Plugin Request Completed                 logger=plugin.instrumentation endpoint=queryData pluginId=testdata dsName=gdev-testdata dsUID=PD8C576611E62080A uname=admin traceID=e31ce7fb23abe640bf4ed04e4e6ecc2a status=ok duration=1.55833ms eventName=grafana-data-egress time_before_plugin_request=1.488276ms
INFO [10-19|18:21:26] Request Completed                        logger=context traceID=072a8a9dfdda05b0f34922319a87e274 userId=1 orgId=1 uname=admin method=POST path=/api/ds/query status=200 remote_addr=[::1] time_ms=2 duration=2.316099ms size=696 referer="http://localhost:3000/d/5SdHCadmz/panel-tests-graph?orgId=1" db_call_count=1 handler=/api/ds/query status_source=server
INFO [10-19|18:21:26] Request Completed                        logger=context traceID=e31ce7fb23abe640bf4ed04e4e6ecc2a userId=1 orgId=1 uname=admin method=POST path=/api/ds/query status=200 remote_addr=[::1] time_ms=7 duration=7.770083ms size=23543 referer="http://localhost:3000/d/5SdHCadmz/panel-tests-graph?orgId=1" db_call_count=1 handler=/api/ds/query status_source=server
INFO [10-19|18:21:26] Request Completed                        logger=context traceID=396e191279ea7e1cfd58af527b87fa81 userId=1 orgId=1 uname=admin method=POST path=/api/ds/query status=200 remote_addr=[::1] time_ms=12 duration=12.389136ms size=64611 referer="http://localhost:3000/d/5SdHCadmz/panel-tests-graph?orgId=1" db_call_count=1 handler=/api/ds/query status_source=server
DEBUG[10-19|18:23:11] Received resource call                   logger=tsdb.testdata endpoint=callResource pluginId=grafana-testdata-datasource dsName=gdev-testdata dsUID=PD8C576611E62080A uname=admin traceID=4f23f9853406e0871bb328b3ff487c5f url=/ method=GET
INFO [10-19|18:23:11] Plugin Request Completed                 logger=plugin.instrumentation endpoint=callResource pluginId=grafana-testdata-datasource dsName=gdev-testdata dsUID=PD8C576611E62080A uname=admin traceID=4f23f9853406e0871bb328b3ff487c5f status=ok duration=2.73859ms eventName=grafana-data-egress time_before_plugin_request=38.89482ms
INFO [10-19|18:23:11] Request Completed                        logger=context traceID=4f23f9853406e0871bb328b3ff487c5f userId=1 orgId=1 uname=admin method=GET path=/api/datasources/uid/PD8C576611E62080A/resources status=200 remote_addr=[::1] time_ms=41 duration=41.712257ms size=33 referer= db_call_count=7 handler=/api/datasources/uid/:uid/resources status_source=server
```

Ref #68973