### PR TITLE
CI: Fix validate-npm-packages regex to work without version suffix

### DIFF
--- a/scripts/validate-npm-packages.sh
+++ b/scripts/validate-npm-packages.sh
@@ -8,7 +8,7 @@ ARTIFACTS_DIR="./npm-artifacts"
 for file in "$ARTIFACTS_DIR"/*.tgz; do
   echo "🔍 Checking NPM package: $file"
   # get filename then strip everything after package name.
-  dir_name=$(basename "$file" .tgz | sed 's/^@\(.*\)-[0-9]*[.]*[0-9]*[.]*[0-9]*-\([0-9]*[a-zA-Z]*\)/\1/')
+  dir_name=$(basename "$file" .tgz | sed -E 's/@([a-zA-Z0-9-]+)-[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9-]+)?/\1/')
   mkdir -p "./npm-artifacts/$dir_name"
   tar -xzf "$file" -C "./npm-artifacts/$dir_name" --strip-components=1
 


### PR DESCRIPTION
The `sed` present in the script is used to extract package names, that works well on main since we always have the `-pre` suffix on the version number. However when updating pipelines on v10.1.x I found out this wouldn't work if the version was simply "10.1.6", so I modified the regex so it correclty extracts the package names for versions with and without prefix.

It extracts "grafana-toolkit" from both "@grafana-toolkit-10.1.6.tgz" and "@grafana-toolkit-10.1.6-pre.tgz"