### PR TITLE
NodeGraph: Fix edges dataframe miscategorization

### DIFF
--- a/public/app/plugins/panel/nodeGraph/utils.ts
+++ b/public/app/plugins/panel/nodeGraph/utils.ts
@@ -607,7 +607,7 @@ export const getGraphFrame = (frames: DataFrame[]) => {
   return frames.reduce<GraphFrame>(
     (acc, frame) => {
       const sourceField = frame.fields.filter((f) => f.name === 'source');
-      if (sourceField.length) {
+      if (frame.name === "edges" || sourceField.length) {
         acc.edges.push(frame);
       } else {
         acc.nodes.push(frame);

--- a/public/app/plugins/panel/nodeGraph/utils.ts
+++ b/public/app/plugins/panel/nodeGraph/utils.ts
@@ -607,7 +607,7 @@ export const getGraphFrame = (frames: DataFrame[]) => {
   return frames.reduce<GraphFrame>(
     (acc, frame) => {
       const sourceField = frame.fields.filter((f) => f.name === 'source');
-      if (frame.name === "edges" || sourceField.length) {
+      if (frame.name === 'edges' || sourceField.length) {
         acc.edges.push(frame);
       } else {
         acc.nodes.push(frame);


### PR DESCRIPTION
A dataframe named "edges" could end up getting categorized as a nodes dataframe if it was missing a "source" field, resulting in a very confusing error message "id field is required for nodes dataframe" instead of a more sensible error message about the missing source field.
