### PR TITLE
Geomap: Fix broken symbol alignment options for older geomap panels

### DIFF
--- a/public/app/plugins/panel/geomap/editor/StyleEditor.tsx
+++ b/public/app/plugins/panel/geomap/editor/StyleEditor.tsx
@@ -110,11 +110,11 @@ export const StyleEditor = (props: Props) => {
   };
 
   const onAlignHorizontalChange = (alignHorizontal: HorizontalAlign) => {
-    onChange({ ...value, symbolAlign: { ...value.symbolAlign, horizontal: alignHorizontal } });
+    onChange({ ...value, symbolAlign: { ...value?.symbolAlign, horizontal: alignHorizontal } });
   };
 
   const onAlignVerticalChange = (alignVertical: VerticalAlign) => {
-    onChange({ ...value, symbolAlign: { ...value.symbolAlign, vertical: alignVertical } });
+    onChange({ ...value, symbolAlign: { ...value?.symbolAlign, vertical: alignVertical } });
   };
 
   const propertyOptions = useObservable(settings?.layerInfo ?? of());


### PR DESCRIPTION
Turns out the fix for this doesn't require any migrations :) 

Before 

https://github.com/grafana/grafana/assets/22381771/9c4b94b9-060e-4ea1-b3c9-be999f980ef7



After


https://github.com/grafana/grafana/assets/22381771/6784337c-a133-4e3f-8f5b-145eb833185d



Tested using [the basic geomap gdev dashboard](http://localhost:3000/d/2xuwrgV7z/panel-tests-geomap?orgId=1)

Fixes https://github.com/grafana/grafana/issues/76715