### PR TITLE
Docs: Add missing step to install plugin doc

### DIFF
--- a/docs/sources/administration/plugin-management/index.md
+++ b/docs/sources/administration/plugin-management/index.md
@@ -100,6 +100,7 @@ To browse for available plugins:
 To install a plugin:
 
 1. In Grafana, click **Administration > Plugins** in the side navigation menu to view installed plugins.
+1. Click the **All** filter to browse all available plugins.
 1. Browse and find a plugin.
 1. Click on the plugin logo.
 1. Click **Install**.


### PR DESCRIPTION
**What is this feature?**

Gap in the docs here: https://grafana.com/docs/grafana/latest/administration/plugin-management/#install-a-plugin

![Screenshot from 2023-10-20 09-40-41](https://github.com/grafana/grafana/assets/350728/30ebe58c-8b2d-4e58-b920-ca40edf385b6)

When I first open the Plugins page, it shows "Installed" plugins, so whichever new plugin I want to install now won't be listed.

I copied the wording for switching the view from other steps on the same page so that's consistent.

(No connected GitHub issue AFAIK)