### PR TITLE
Alerting: Move `ExternalAlertmanager` to its own package

### DIFF
--- a/pkg/services/ngalert/notifier/multiorg_alertmanager.go
+++ b/pkg/services/ngalert/notifier/multiorg_alertmanager.go
@@ -64,7 +64,6 @@ type Alertmanager interface {
 type MultiOrgAlertmanager struct {
 	Crypto    Crypto
 	ProvStore provisioningStore
-	factory   orgAlertmanagerFactory
 
 	alertmanagersMtx sync.RWMutex
 	alertmanagers    map[int64]Alertmanager
@@ -79,6 +78,7 @@ type MultiOrgAlertmanager struct {
 	configStore AlertingStore
 	orgStore    store.OrgStore
 	kvStore     kvstore.KVStore
+	factory     orgAlertmanagerFactory
 
 	decryptFn alertingNotify.GetDecryptedValueFn
 

--- a/pkg/services/ngalert/notifier/multiorg_alertmanager.go
+++ b/pkg/services/ngalert/notifier/multiorg_alertmanager.go
@@ -64,6 +64,7 @@ type Alertmanager interface {
 type MultiOrgAlertmanager struct {
 	Crypto    Crypto
 	ProvStore provisioningStore
+	factory   orgAlertmanagerFactory
 
 	alertmanagersMtx sync.RWMutex
 	alertmanagers    map[int64]Alertmanager
@@ -83,7 +84,6 @@ type MultiOrgAlertmanager struct {
 
 	metrics *metrics.MultiOrgAlertmanager
 	ns      notifications.Service
-	factory orgAlertmanagerFactory
 }
 
 type orgAlertmanagerFactory func(ctx context.Context, orgID int64) (Alertmanager, error)
@@ -101,8 +101,9 @@ func NewMultiOrgAlertmanager(cfg *setting.Cfg, configStore AlertingStore, orgSto
 	m *metrics.MultiOrgAlertmanager, ns notifications.Service, l log.Logger, s secrets.Service, opts ...Option,
 ) (*MultiOrgAlertmanager, error) {
 	moa := &MultiOrgAlertmanager{
-		Crypto:        NewCrypto(s, configStore, l),
-		ProvStore:     provStore,
+		Crypto:    NewCrypto(s, configStore, l),
+		ProvStore: provStore,
+
 		logger:        l,
 		settings:      cfg,
 		alertmanagers: map[int64]Alertmanager{},

--- a/pkg/services/ngalert/notifier/multiorg_alertmanager.go
+++ b/pkg/services/ngalert/notifier/multiorg_alertmanager.go
@@ -83,16 +83,26 @@ type MultiOrgAlertmanager struct {
 
 	metrics *metrics.MultiOrgAlertmanager
 	ns      notifications.Service
+	factory orgAlertmanagerFactory
+}
+
+type orgAlertmanagerFactory func(ctx context.Context, orgID int64) (Alertmanager, error)
+
+type Option func(*MultiOrgAlertmanager)
+
+func WithAlertmanagerOverride(f orgAlertmanagerFactory) Option {
+	return func(moa *MultiOrgAlertmanager) {
+		moa.factory = f
+	}
 }
 
 func NewMultiOrgAlertmanager(cfg *setting.Cfg, configStore AlertingStore, orgStore store.OrgStore,
 	kvStore kvstore.KVStore, provStore provisioningStore, decryptFn alertingNotify.GetDecryptedValueFn,
-	m *metrics.MultiOrgAlertmanager, ns notifications.Service, l log.Logger, s secrets.Service,
+	m *metrics.MultiOrgAlertmanager, ns notifications.Service, l log.Logger, s secrets.Service, opts ...Option,
 ) (*MultiOrgAlertmanager, error) {
 	moa := &MultiOrgAlertmanager{
-		Crypto:    NewCrypto(s, configStore, l),
-		ProvStore: provStore,
-
+		Crypto:        NewCrypto(s, configStore, l),
+		ProvStore:     provStore,
 		logger:        l,
 		settings:      cfg,
 		alertmanagers: map[int64]Alertmanager{},
@@ -104,9 +114,21 @@ func NewMultiOrgAlertmanager(cfg *setting.Cfg, configStore AlertingStore, orgSto
 		ns:            ns,
 		peer:          &NilPeer{},
 	}
+
 	if err := moa.setupClustering(cfg); err != nil {
 		return nil, err
 	}
+
+	// Set up the default per tenant Alertmanager factory.
+	moa.factory = func(ctx context.Context, orgID int64) (Alertmanager, error) {
+		m := metrics.NewAlertmanagerMetrics(moa.metrics.GetOrCreateOrgRegistry(orgID))
+		return newAlertmanager(ctx, orgID, moa.settings, moa.configStore, moa.kvStore, moa.peer, moa.decryptFn, moa.ns, m)
+	}
+
+	for _, opt := range opts {
+		opt(moa)
+	}
+
 	return moa, nil
 }
 
@@ -244,8 +266,7 @@ func (moa *MultiOrgAlertmanager) SyncAlertmanagersForOrgs(ctx context.Context, o
 			// These metrics are not exported by Grafana and are mostly a placeholder.
 			// To export them, we need to translate the metrics from each individual registry and,
 			// then aggregate them on the main registry.
-			m := metrics.NewAlertmanagerMetrics(moa.metrics.GetOrCreateOrgRegistry(orgID))
-			am, err := newAlertmanager(ctx, orgID, moa.settings, moa.configStore, moa.kvStore, moa.peer, moa.decryptFn, moa.ns, m)
+			am, err := moa.factory(ctx, orgID)
 			if err != nil {
 				moa.logger.Error("Unable to create Alertmanager for org", "org", orgID, "error", err)
 			}

--- a/pkg/services/ngalert/remote/external_alertmanager_test.go
+++ b/pkg/services/ngalert/remote/external_alertmanager_test.go
@@ -1,4 +1,4 @@
-package notifier
+package remote
 
 import (
 	"context"
@@ -70,13 +70,13 @@ func TestNewExternalAlertmanager(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(tt *testing.T) {
-			cfg := externalAlertmanagerConfig{
+			cfg := ExternalAlertmanagerConfig{
 				URL:               test.url,
 				TenantID:          test.tenantID,
 				BasicAuthPassword: test.password,
 				DefaultConfig:     test.defaultConfig,
 			}
-			am, err := newExternalAlertmanager(cfg, test.orgID)
+			am, err := NewExternalAlertmanager(cfg, test.orgID)
 			if test.expErr != "" {
 				require.EqualError(tt, err, test.expErr)
 				return
@@ -105,13 +105,13 @@ func TestIntegrationRemoteAlertmanagerSilences(t *testing.T) {
 	tenantID := os.Getenv("AM_TENANT_ID")
 	password := os.Getenv("AM_PASSWORD")
 
-	cfg := externalAlertmanagerConfig{
+	cfg := ExternalAlertmanagerConfig{
 		URL:               amURL + "/alertmanager",
 		TenantID:          tenantID,
 		BasicAuthPassword: password,
 		DefaultConfig:     validConfig,
 	}
-	am, err := newExternalAlertmanager(cfg, 1)
+	am, err := NewExternalAlertmanager(cfg, 1)
 	require.NoError(t, err)
 
 	// We should have no silences at first.
@@ -185,13 +185,13 @@ func TestIntegrationRemoteAlertmanagerAlerts(t *testing.T) {
 	tenantID := os.Getenv("AM_TENANT_ID")
 	password := os.Getenv("AM_PASSWORD")
 
-	cfg := externalAlertmanagerConfig{
+	cfg := ExternalAlertmanagerConfig{
 		URL:               amURL + "/alertmanager",
 		TenantID:          tenantID,
 		BasicAuthPassword: password,
 		DefaultConfig:     validConfig,
 	}
-	am, err := newExternalAlertmanager(cfg, 1)
+	am, err := NewExternalAlertmanager(cfg, 1)
 	require.NoError(t, err)
 
 	// We should have no alerts and no groups at first.

--- a/pkg/services/ngalert/remote/external_alertmanager_test.go
+++ b/pkg/services/ngalert/remote/external_alertmanager_test.go
@@ -241,14 +241,14 @@ func TestIntegrationRemoteAlertmanagerReceivers(t *testing.T) {
 	tenantID := os.Getenv("AM_TENANT_ID")
 	password := os.Getenv("AM_PASSWORD")
 
-	cfg := externalAlertmanagerConfig{
+	cfg := ExternalAlertmanagerConfig{
 		URL:               amURL + "/alertmanager",
 		TenantID:          tenantID,
 		BasicAuthPassword: password,
 		DefaultConfig:     validConfig,
 	}
 
-	am, err := newExternalAlertmanager(cfg, 1)
+	am, err := NewExternalAlertmanager(cfg, 1)
 	require.NoError(t, err)
 
 	// We should start with the default config.
@@ -293,12 +293,12 @@ func genAlert(active bool, labels map[string]string) amv2.PostableAlert {
 	}
 
 	return amv2.PostableAlert{
-		Annotations: amv2.LabelSet(map[string]string{"test_annotation": "test_annotation_value"}),
+		Annotations: map[string]string{"test_annotation": "test_annotation_value"},
 		StartsAt:    strfmt.DateTime(time.Now()),
 		EndsAt:      strfmt.DateTime(endsAt),
 		Alert: amv2.Alert{
-			GeneratorURL: strfmt.URI("http://localhost:8080"),
-			Labels:       amv2.LabelSet(labels),
+			GeneratorURL: "http://localhost:8080",
+			Labels:       labels,
 		},
 	}
 }


### PR DESCRIPTION
We'll avoid import cycles when using components from other packages. In addition to that, I've created an `Options` approach for the multiorg alertmanger to allow us to override how per tenant alertmanagers are created.
