### PR TITLE
Navigation: Correctly highlight a `SectionNavItem` if it has children that are active

### DIFF
--- a/public/app/core/components/AppChrome/SectionNav/SectionNavItem.tsx
+++ b/public/app/core/components/AppChrome/SectionNav/SectionNavItem.tsx
@@ -6,6 +6,8 @@ import { selectors } from '@grafana/e2e-selectors';
 import { reportInteraction } from '@grafana/runtime';
 import { useStyles2, Icon } from '@grafana/ui';
 
+import { getActiveItem, hasChildMatch } from '../MegaMenu/utils';
+
 export interface Props {
   item: NavModelItem;
   isSectionRoot?: boolean;
@@ -19,13 +21,14 @@ export function SectionNavItem({ item, isSectionRoot = false, level = 0 }: Props
   const styles = useStyles2(getStyles);
 
   const children = item.children?.filter((x) => !x.hideFromTabs);
+  const activeItem = item.children && getActiveItem(item.children, location.pathname);
 
   // If first root child is a section skip the bottom margin (as sections have top margin already)
   const noRootMargin = isSectionRoot && Boolean(item.children![0].children?.length);
 
   const linkClass = cx({
     [styles.link]: true,
-    [styles.activeStyle]: item.active,
+    [styles.activeStyle]: item.active || (level === MAX_DEPTH && hasChildMatch(item, activeItem)),
     [styles.isSection]: level < MAX_DEPTH && (Boolean(children?.length) || item.isSection),
     [styles.isSectionRoot]: isSectionRoot,
     [styles.noRootMargin]: noRootMargin,


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

- check if the bottom level items in the section nav have active children

**Why do we need this feature?**

- so items with active children are highlighted correctly in the section nav

**Who is this feature for?**

- everyone

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**
- see https://raintank-corp.slack.com/archives/C0613C87EAX/p1697791863938159?thread_ts=1697748355.271129&cid=C0613C87EAX for context
- note: we don't need this for `DockedMegaMenu` as it already has this logic

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
