### PR TITLE
Chore: Bump grafana-experimental from 1.7.0 to 1.7.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -248,7 +248,7 @@
     "@grafana/aws-sdk": "0.2.0",
     "@grafana/data": "workspace:*",
     "@grafana/e2e-selectors": "workspace:*",
-    "@grafana/experimental": "1.7.0",
+    "@grafana/experimental": "1.7.4",
     "@grafana/faro-core": "1.2.1",
     "@grafana/faro-web-sdk": "1.2.1",
     "@grafana/flamegraph": "workspace:*",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3118,6 +3118,26 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@grafana/experimental@npm:1.7.4":
+  version: 1.7.4
+  resolution: "@grafana/experimental@npm:1.7.4"
+  dependencies:
+    "@types/uuid": ^8.3.3
+    semver: ^7.5.4
+    uuid: ^8.3.2
+  peerDependencies:
+    "@emotion/css": 11.1.3
+    "@grafana/data": ^10.0.0
+    "@grafana/runtime": ^10.0.0
+    "@grafana/ui": ^10.0.0
+    react: 17.0.2
+    react-dom: 17.0.2
+    react-select: ^5.2.1
+    rxjs: 7.8.0
+  checksum: f5d7074cfe1e2efebcb16d458d1e3715ab4cf2d90b4be7b16612fdd0c0269527b9b9394a6f265f1cfc4958b046416f52c6d6f5f6647c051ee5dccd9884859ba7
+  languageName: node
+  linkType: hard
+
 "@grafana/faro-core@npm:1.2.1, @grafana/faro-core@npm:^1.2.1":
   version: 1.2.1
   resolution: "@grafana/faro-core@npm:1.2.1"
@@ -17760,7 +17780,7 @@ __metadata:
     "@grafana/e2e-selectors": "workspace:*"
     "@grafana/eslint-config": 6.0.1
     "@grafana/eslint-plugin": "link:./packages/grafana-eslint-rules"
-    "@grafana/experimental": 1.7.0
+    "@grafana/experimental": 1.7.4
     "@grafana/faro-core": 1.2.1
     "@grafana/faro-web-sdk": 1.2.1
     "@grafana/flamegraph": "workspace:*"


### PR DESCRIPTION
**What is this feature?**

Bumps version of @grafana/experimental the 1.7.4 release.
Release 1.7.4 adds vector support, misc other changes

**Why do we need this feature?**
Bugfix for https://github.com/grafana/grafana/pull/73020
```
Uncaught (in promise) TypeError: Cannot read properties of undefined (reading 'enabled')
    at promQailSuggest (helpers.ts:157:57)
```

That PR requires 1.7.1 minimum since it utilizes vector search features. Somewhere during a rebase / merge the version got reverted to 1.7.0 meaning the `llms.vector.enabled()` call breaks. Bumping to >=1.7.1. fixes it

**Who is this feature for?**

[Add information on what kind of user the feature is for.]

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**
bump to 1.7.2 https://github.com/grafana/grafana/pull/73020/commits/861086db09686667b4c30b75526856b0b4e4951b got reverted in https://github.com/grafana/grafana/pull/73020/commits/78fd867f210e7d2ecaa84c64c000139be86c3189

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
