### PR TITLE
Chore: Replace ts-loader in e2e and input-datasource

### DIFF
--- a/e2e/cypress/plugins/typescriptPreprocessor.js
+++ b/e2e/cypress/plugins/typescriptPreprocessor.js
@@ -1,32 +1,18 @@
 const wp = require('@cypress/webpack-preprocessor');
-const { resolve } = require('path');
-
-const anyNodeModules = /node_modules/;
-const packageRoot = resolve(`${__dirname}/../../`);
-const packageModules = `${packageRoot}/node_modules`;
 
 const webpackOptions = {
   module: {
     rules: [
       {
-        include: (modulePath) => {
-          if (!anyNodeModules.test(modulePath)) {
-            // Is a file within the project
-            return true;
-          } else {
-            // Is a file within this package
-            return modulePath.startsWith(packageRoot) && !modulePath.startsWith(packageModules);
-          }
-        },
         test: /\.ts$/,
-        use: [
-          {
-            loader: 'ts-loader',
-            options: {
-              transpileOnly: true,
-            },
+        exclude: /node_modules/,
+        use: {
+          loader: 'esbuild-loader',
+          options: {
+            target: 'es2020',
+            format: undefined,
           },
-        ],
+        },
       },
     ],
   },

--- a/package.json
+++ b/package.json
@@ -225,7 +225,6 @@
     "testing-library-selector": "0.3.1",
     "tracelib": "1.0.1",
     "ts-jest": "29.1.1",
-    "ts-loader": "9.3.1",
     "ts-node": "10.9.1",
     "typescript": "4.8.4",
     "wait-on": "7.0.1",

--- a/plugins-bundled/internal/input-datasource/package.json
+++ b/plugins-bundled/internal/input-datasource/package.json
@@ -22,8 +22,8 @@
     "fork-ts-checker-webpack-plugin": "8.0.0",
     "jest": "29.3.1",
     "jest-environment-jsdom": "29.3.1",
+    "swc-loader": "0.2.3",
     "ts-jest": "29.0.5",
-    "ts-loader": "9.3.1",
     "ts-node": "10.9.1",
     "webpack": "5.76.0"
   },

--- a/plugins-bundled/internal/input-datasource/webpack.config.ts
+++ b/plugins-bundled/internal/input-datasource/webpack.config.ts
@@ -70,7 +70,20 @@ const config = async (env: Record<string, string>): Promise<Configuration> => ({
         exclude: /(node_modules)/,
         test: /\.[tj]sx?$/,
         use: {
-          loader: 'ts-loader',
+          loader: 'swc-loader',
+          options: {
+            jsc: {
+              baseUrl: '.',
+              target: 'es2015',
+              loose: false,
+              parser: {
+                syntax: 'typescript',
+                tsx: true,
+                decorators: false,
+                dynamicImport: true,
+              },
+            },
+          },
         },
       },
       {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2881,8 +2881,8 @@ __metadata:
     jest: 29.3.1
     jest-environment-jsdom: 29.3.1
     react: 18.2.0
+    swc-loader: 0.2.3
     ts-jest: 29.0.5
-    ts-loader: 9.3.1
     ts-node: 10.9.1
     tslib: 2.5.0
     webpack: 5.76.0
@@ -15220,7 +15220,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"enhanced-resolve@npm:^5.0.0, enhanced-resolve@npm:^5.10.0, enhanced-resolve@npm:^5.15.0":
+"enhanced-resolve@npm:^5.10.0, enhanced-resolve@npm:^5.15.0":
   version: 5.15.0
   resolution: "enhanced-resolve@npm:5.15.0"
   dependencies:
@@ -18064,7 +18064,6 @@ __metadata:
     tinycolor2: 1.6.0
     tracelib: 1.0.1
     ts-jest: 29.1.1
-    ts-loader: 9.3.1
     ts-node: 10.9.1
     tslib: 2.6.0
     tween-functions: ^1.2.0
@@ -29025,21 +29024,6 @@ __metadata:
     typescript: "*"
     webpack: "*"
   checksum: 79da0f364c013231bff28baede3f4f4081b1cca30b24df2d9f31a0517e0524eca2c8e4d438b853b1566a3a8eb9ff51ab0b36743346f0b3d5daa7001c98e5c738
-  languageName: node
-  linkType: hard
-
-"ts-loader@npm:9.3.1":
-  version: 9.3.1
-  resolution: "ts-loader@npm:9.3.1"
-  dependencies:
-    chalk: ^4.1.0
-    enhanced-resolve: ^5.0.0
-    micromatch: ^4.0.0
-    semver: ^7.3.4
-  peerDependencies:
-    typescript: "*"
-    webpack: ^5.0.0
-  checksum: 462a8ac315017cf4961dafd2be29d5abe7c3af63c4515e325269f79b9d0212b35c59184d7fd01fc378749c88454752e1599301d2190eb6844ea5fe332de5f695
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

This PR replaces usage of ts-loader in e2e tests and input-datasource webpack configs.

input-datasource works as expected.

![image](https://github.com/grafana/grafana/assets/73201/6047d1d8-6141-4cb0-8a87-0dc602e05743)

**Why do we need this feature?**

To align our bundlers and remove ts-loader. I don't think we'll see much of a speed boost from this.

- **esbuild** is used for core so using that for e2e tests
- **swc** is used for plugins so using that for input-datasource builds

**Who is this feature for?**

Grafana developers

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
