### PR TITLE
Docs: add service accounts to the list of entities that can be assigned permissions

### DIFF
--- a/docs/sources/administration/data-source-management/index.md
+++ b/docs/sources/administration/data-source-management/index.md
@@ -40,7 +40,7 @@ For links to data source-specific documentation, see [Data sources]({{< relref "
 
 ## Data source permissions
 
-You can configure data source permissions to allow or deny certain users the ability to query, edit, or administrate a data source. Each data source’s configuration includes a Permissions tab where you can restrict data source permissions to specific users, teams, or roles.
+You can configure data source permissions to allow or deny certain users the ability to query, edit, or administrate a data source. Each data source’s configuration includes a Permissions tab where you can restrict data source permissions to specific users, service accounts, teams, or roles.
 Query permission allows users to query the data source. Edit permission allows users to query the data source, edit the data source’s configuration and delete the data source. Admin permission allows users to query and edit the data source, change permissions on the data source and enable or disable query caching for the data source.
 
 {{% admonition type="note" %}}
@@ -51,37 +51,37 @@ By default, data sources in an organization can be queried by any user in that o
 
 <div class="clearfix"></div>
 
-### Assign data source permissions to users, teams, or roles
+### Assign data source permissions to users, service accounts, teams, or roles
 
-You can assign data source permissions to users, teams, and roles which will allow access to query, edit, or administrate the data source.
+You can assign data source permissions to users, service accounts, teams, and roles which will allow access to query, edit, or administrate the data source.
 
 1. Click **Connections** in the left-side menu.
 1. Under Your connections, click **Data sources**.
 1. Select the data source to which you want to assign permissions.
 1. On the Permissions tab, click **Add a permission**.
-1. Select **User**, **Team**, or **Role**.
+1. Select **User**, **Service Account**, **Team**, or **Role**.
 1. Select the entity for which you want to modify permissions.
 1. Select the **Query**, **Edit**, or **Admin** permission.
 1. Click **Save**.
 
 <div class="clearfix"></div>
 
-### Edit data source permissions for users, teams, or roles
+### Edit data source permissions for users, service accounts, teams, or roles
 
 1. Click **Connections** in the left-side menu.
 1. Under Your connections, click **Data sources**.
 1. Select the data source for which you want to edit permissions.
-1. On the Permissions tab, find the user, team, or role permission you want to update.
+1. On the Permissions tab, find the user, service accounts, team, or role permission you want to update.
 1. Select a different option in the **Permission** dropdown.
 
 <div class="clearfix"></div>
 
-### Remove data source permissions for users, teams, or roles
+### Remove data source permissions for users, service accounts, teams, or roles
 
 1. Click **Connections** in the left-side menu.
 1. Under Your connections, click **Data sources**.
 1. Select the data source from which you want to remove permissions.
-1. On the Permissions tab, find the user, team, or role permission you want to remove.
+1. On the Permissions tab, find the user, service accounts, team, or role permission you want to remove.
 1. Click the **X** next to the permission.
 
 <div class="clearfix"></div>

--- a/docs/sources/administration/roles-and-permissions/_index.md
+++ b/docs/sources/administration/roles-and-permissions/_index.md
@@ -169,7 +169,7 @@ While Grafana OSS includes a robust set of permissions and settings that you can
 
 By default, a user can query any data source in an organization, even if the data source is not linked to the user's dashboards.
 
-Data source permissions enable you to restrict data source query permissions to specific **Users** and **Teams**. For more information about assigning data source permissions, refer to [Data source permissions]({{< relref "../data-source-management/#data-source-permissions/" >}}).
+Data source permissions enable you to restrict data source query permissions to specific **Users**, **Service Accounts**, and **Teams**. For more information about assigning data source permissions, refer to [Data source permissions]({{< relref "../data-source-management/#data-source-permissions/" >}}).
 
 ### Role-based access control
 

--- a/docs/sources/administration/user-management/manage-dashboard-permissions/index.md
+++ b/docs/sources/administration/user-management/manage-dashboard-permissions/index.md
@@ -32,7 +32,7 @@ When you grant user permissions for folders, that setting applies to all dashboa
 1. Hover your mouse cursor over a folder and click **Go to folder**.
 1. Click the **Permissions** tab, and then click **Add a permission**.
 1. In the **Add Permission For** dropdown menu, select **User**, **Service Account**, **Team**, or **Role**.
-1. Select the user, team, or role.
+1. Select the user, service account, team, or role.
 1. Select the permission and click **Save**.
 
 ## Grant dashboard permissions
@@ -50,7 +50,7 @@ Grant dashboard permissions when you want to restrict or enhance dashboard acces
 ### Before you begin
 
 - Ensure you have organization administrator privileges
-- Identify the dashboard permissions you want to modify and the users or teams to which you want to grant access
+- Identify the dashboard permissions you want to modify and the users, service accounts, or teams to which you want to grant access
 
 **To grant dashboard permissions**:
 
@@ -60,7 +60,7 @@ Grant dashboard permissions when you want to restrict or enhance dashboard acces
 1. In the top right corner of the dashboard, click **Dashboard settings** (the cog icon).
 1. Click **Permissions** in left-side menu, and then **Add a permission**.
 1. In the **Add Permission For** dropdown menu, select **User**, **Service Account**, **Team**, or **Role**.
-1. Select the user, team, or role.
+1. Select the user, service account, team, or role.
 1. Select the permission and click **Save**.
 
 ## Enable viewers to edit (but not save) dashboards and use Explore


### PR DESCRIPTION
**What is this feature?**

Extend the docs to make it clear that dashboard, folder and data source permissions can be assigned to service accounts.
