### PR TITLE
Correlations: Allow the insert query to be retried in a test

### DIFF
--- a/pkg/tests/api/correlations/correlations_read_test.go
+++ b/pkg/tests/api/correlations/correlations_read_test.go
@@ -106,8 +106,10 @@ func TestIntegrationReadCorrelation(t *testing.T) {
 	// Given all tests in this file work on the assumption that only a single correlation exists,
 	// this covers the case where bad data exists in the database.
 	nonExistingDsUID := "THIS-DOES-NOT_EXIST"
+	var created int64 = 0
 	err := ctx.env.SQLStore.WithDbSession(context.Background(), func(sess *db.Session) error {
-		created, err := sess.InsertMulti(&[]correlations.Correlation{
+		var innerError error
+		created, innerError = sess.InsertMulti(&[]correlations.Correlation{
 			{
 				UID:       "uid-1",
 				SourceUID: dsWithoutCorrelations.UID,
@@ -119,11 +121,10 @@ func TestIntegrationReadCorrelation(t *testing.T) {
 				TargetUID: &dsWithoutCorrelations.UID,
 			},
 		})
-		require.NoError(t, err)
-		require.Equal(t, int64(2), created)
-		return err
+		return innerError
 	})
 	require.NoError(t, err)
+	require.Equal(t, int64(2), created)
 
 	t.Run("Get all correlations", func(t *testing.T) {
 		t.Run("Unauthenticated users shouldn't be able to read correlations", func(t *testing.T) {


### PR DESCRIPTION
This is a small improvement to our test that is failing intermittently due to error `database table is locked`. I have not found the root cause of why the database is locked, but what I've noticed is:

- `ctx.env.SQLStore.WithDbSession(...)` has a built-in retry mechanism (that retries the query when db is locked), but...
-  assertions are part of the callback passed to the retryer (pkg/util/retryer), which never has a chance to retry the query - `require.NoError(...)` simply interrupts entire routine

By moving assertions out of the callback at least give it will now have a chance to retry the query (3 times by default), so hopefully it should be more stable.

Fixes #76878