### PR TITLE
Fix scenes runtime error for legacy angular panels

### DIFF
--- a/public/app/angular/panel/AngularPanelReactWrapper.tsx
+++ b/public/app/angular/panel/AngularPanelReactWrapper.tsx
@@ -3,6 +3,7 @@ import { Observable, ReplaySubject } from 'rxjs';
 
 import { EventBusSrv, PanelData, PanelPlugin, PanelProps, FieldConfigSource } from '@grafana/data';
 import { AngularComponent, getAngularLoader, RefreshEvent } from '@grafana/runtime';
+import { getDashboardSrv } from 'app/features/dashboard/services/DashboardSrv';
 import { DashboardModelCompatibilityWrapper } from 'app/features/dashboard-scene/utils/DashboardModelCompatibilityWrapper';
 import { GetDataOptions } from 'app/features/query/state/PanelQueryRunner';
 import { RenderEvent } from 'app/types/events';


### PR DESCRIPTION
`ts-ignore` made this error hidden  😬 