### PR TITLE
Webhooks: Introduce `[webhooks][timeout]` configuration option to control the maximum timeout of Webhook notifications.

### DIFF
--- a/conf/defaults.ini
+++ b/conf/defaults.ini
@@ -897,6 +897,13 @@ reset_basic_roles = false
 # Validate permissions' action and scope on role creation and update
 permission_validation_enabled = true
 
+#################################### Webhooks #####################
+[webhooks]
+# The timeout for delivering webhook notifications. Most of the alerting integrations use webhooks to deliver notifications.
+# If you're running a Highly Available setup and use Unified Alerting this should be less than [unified_alerting][ha_peer_timeout] to avoid duplicate notifications.
+# The timeout string is a possibly signed sequence of decimal numbers, followed by a unit suffix (ms, s, m, h, d), e.g. 30s or 1m
+timeout = 30s
+
 #################################### SMTP / Emailing #####################
 [smtp]
 enabled = false

--- a/pkg/services/ngalert/notifier/multiorg_alertmanager.go
+++ b/pkg/services/ngalert/notifier/multiorg_alertmanager.go
@@ -138,6 +138,9 @@ func (moa *MultiOrgAlertmanager) setupClustering(cfg *setting.Cfg) error {
 	}
 	// Memberlist setup.
 	if len(cfg.UnifiedAlerting.HAPeers) > 0 {
+		if cfg.UnifiedAlerting.HAPeerTimeout <= cfg.Webhooks.Timeout {
+			moa.logger.Warn("[unified_alerting][ha_peer_timeout] is higher than [webhooks][timeout] - this poses a risk of duplicate notification. You should raise the ha_peer_timeout or lower the webhook_timeout.")
+		}
 		peer, err := cluster.Create(
 			clusterLogger,
 			moa.metrics.Registerer,

--- a/pkg/services/notifications/testing.go
+++ b/pkg/services/notifications/testing.go
@@ -30,11 +30,3 @@ func NewFakeDisconnectedMailer() *FakeDisconnectedMailer {
 func (fdm *FakeDisconnectedMailer) Send(messages ...*Message) (int, error) {
 	return 0, fmt.Errorf("connect: connection refused")
 }
-
-// NetClient is used to export original in test.
-var NetClient = &netClient
-
-// SetWebhookClient is used to mock in test.
-func SetWebhookClient(client WebhookClient) {
-	netClient = client
-}

--- a/pkg/services/notifications/webhook.go
+++ b/pkg/services/notifications/webhook.go
@@ -3,12 +3,9 @@ package notifications
 import (
 	"bytes"
 	"context"
-	"crypto/tls"
 	"fmt"
 	"io"
-	"net"
 	"net/http"
-	"time"
 
 	"github.com/grafana/grafana/pkg/util"
 )
@@ -30,21 +27,6 @@ type Webhook struct {
 // WebhookClient exists to mock the client in tests.
 type WebhookClient interface {
 	Do(req *http.Request) (*http.Response, error)
-}
-
-var netTransport = &http.Transport{
-	TLSClientConfig: &tls.Config{
-		Renegotiation: tls.RenegotiateFreelyAsClient,
-	},
-	Proxy: http.ProxyFromEnvironment,
-	Dial: (&net.Dialer{
-		Timeout: 30 * time.Second,
-	}).Dial,
-	TLSHandshakeTimeout: 5 * time.Second,
-}
-var netClient WebhookClient = &http.Client{
-	Timeout:   time.Second * 30,
-	Transport: netTransport,
 }
 
 func (ns *NotificationService) sendWebRequestSync(ctx context.Context, webhook *Webhook) error {
@@ -78,7 +60,7 @@ func (ns *NotificationService) sendWebRequestSync(ctx context.Context, webhook *
 		request.Header.Set(k, v)
 	}
 
-	resp, err := netClient.Do(request)
+	resp, err := ns.client.Do(request)
 	if err != nil {
 		return err
 	}

--- a/pkg/setting/setting.go
+++ b/pkg/setting/setting.go
@@ -199,6 +199,8 @@ type Cfg struct {
 	// SMTP email settings
 	Smtp SmtpSettings
 
+	Webhooks WebhooksSettings
+
 	// Rendering
 	ImagesDir                      string
 	CSVsDir                        string
@@ -1171,6 +1173,7 @@ func (cfg *Cfg) Load(args CommandLineArgs) error {
 	cfg.readAzureSettings()
 	cfg.readSessionConfig()
 	cfg.readSmtpSettings()
+	cfg.readWebhooksSettings()
 	if err := cfg.readAnnotationSettings(); err != nil {
 		return err
 	}

--- a/pkg/setting/setting_webhook.go
+++ b/pkg/setting/setting_webhook.go
@@ -1,0 +1,18 @@
+package setting
+
+import (
+	"time"
+)
+
+const (
+	DefaultWebhooksTimeout = 30 * time.Second
+)
+
+type WebhooksSettings struct {
+	Timeout time.Duration
+}
+
+func (cfg *Cfg) readWebhooksSettings() {
+	sec := cfg.Raw.Section("webhooks")
+	cfg.Webhooks.Timeout = sec.Key("timeout").MustDuration(DefaultWebhooksTimeout)
+}

--- a/pkg/setting/setting_webhook_test.go
+++ b/pkg/setting/setting_webhook_test.go
@@ -1,0 +1,19 @@
+package setting
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestCfg_readWebhooksSettings(t *testing.T) {
+	cfg := NewCfg()
+	err := cfg.Load(CommandLineArgs{HomePath: "../../", Config: "../../conf/defaults.ini"})
+	require.NoError(t, err)
+
+	{
+		require.Equal(t, cfg.Webhooks.Timeout, 30*time.Second)
+	}
+
+}

--- a/pkg/setting/setting_webhook_test.go
+++ b/pkg/setting/setting_webhook_test.go
@@ -15,5 +15,4 @@ func TestCfg_readWebhooksSettings(t *testing.T) {
 	{
 		require.Equal(t, cfg.Webhooks.Timeout, 30*time.Second)
 	}
-
 }


### PR DESCRIPTION
Introduces a new configuration section and option that allows us to control the maximum timeout for Grafana's webhook sub-system.
This sub-system is leveraged by alerting to deliver notification to many of the integrations we support (e.g. Line, Telegram, Pagerduty - to name a few).

It's important to note two things:

1. When using Unified Alerting and Grafana is running in high-availability mode, the webhooks timeout must be less than `ha_peer_timeout` as we expect notifications to be delivered *before* the replica sending it fails over (via the peer timeout). To that avail, we've introduced a check that warns the operator as grafana is starting up.

2. This also affects legacy alerting, but we've reached EOL with it and I'd rather have it stay out of the documentation.


Fixes https://github.com/grafana/grafana/issues/73657