### PR TITLE
Alerting: Handle edge cases without panicking during template migration

### DIFF
--- a/pkg/services/ngalert/migration/template.go
+++ b/pkg/services/ngalert/migration/template.go
@@ -108,7 +108,7 @@ func tokenizeVariable(in []rune) (Token, int, error) {
 	)
 
 	if !startVariable(in) {
-		return Token{}, pos, fmt.Errorf("expected variable")
+		return Token{}, pos, fmt.Errorf("expected '${', got '%s'", string(in[:2]))
 	}
 	pos += 2 // seek past opening delimiter
 
@@ -118,11 +118,11 @@ func tokenizeVariable(in []rune) (Token, int, error) {
 		r = in[pos]
 
 		if unicode.IsSpace(r) && r != ' ' {
-			return Token{}, pos, fmt.Errorf("unexpected whitespace")
+			return Token{}, pos, errors.New("unexpected whitespace")
 		}
 
 		if startVariable(in[pos:]) {
-			return Token{}, pos, fmt.Errorf("ambiguous delimiter")
+			return Token{}, pos, errors.New("ambiguous delimiter")
 		}
 
 		if r == '}' {
@@ -141,7 +141,7 @@ func tokenizeVariable(in []rune) (Token, int, error) {
 
 	token := Token{Variable: string(runes)}
 	if !token.IsVariable() {
-		return Token{}, pos, fmt.Errorf("empty variable")
+		return Token{}, pos, errors.New("empty variable")
 	}
 
 	return token, pos, nil

--- a/pkg/services/ngalert/migration/template.go
+++ b/pkg/services/ngalert/migration/template.go
@@ -35,7 +35,7 @@ func (t Token) String() string {
 	} else if t.IsVariable() {
 		return t.Variable
 	} else {
-		panic("empty token")
+		return ""
 	}
 }
 
@@ -108,7 +108,7 @@ func tokenizeVariable(in []rune) (Token, int, error) {
 	)
 
 	if !startVariable(in) {
-		panic("tokenizeVariable called with input that doesn't start with delimiter")
+		return Token{}, pos, fmt.Errorf("expected variable")
 	}
 	pos += 2 // seek past opening delimiter
 
@@ -139,7 +139,12 @@ func tokenizeVariable(in []rune) (Token, int, error) {
 		return Token{}, pos, fmt.Errorf("expected '}', got '%c'", r)
 	}
 
-	return Token{Variable: string(runes)}, pos, nil
+	token := Token{Variable: string(runes)}
+	if !token.IsVariable() {
+		return Token{}, pos, fmt.Errorf("empty variable")
+	}
+
+	return token, pos, nil
 }
 
 func startVariable(in []rune) bool {

--- a/pkg/services/ngalert/migration/template_test.go
+++ b/pkg/services/ngalert/migration/template_test.go
@@ -303,6 +303,12 @@ func TestMigrateTmpl(t *testing.T) {
 			expected: withDeduplicateMap("{{$mergedLabels.instance}}{{` is down ${`}}{{$mergedLabels.nestedVar}}}"),
 			vars:     true,
 		},
+		{
+			name:     "edge cases",
+			input:    "Test test 123 \n$(metric)\n${.}\n${}\n${Condition[0]}",
+			expected: withDeduplicateMap("Test test 123 \n$(metric)\n{{index $mergedLabels \".\"}}\n${}\n{{index $mergedLabels \"Condition[0]\"}}"),
+			vars:     true,
+		},
 	}
 
 	for _, tc := range cases {


### PR DESCRIPTION
**What is this feature?**

This PR does 2 things:
- Handles empty variables, i.e. `${}`
- Removes panics as template migration is always recoverable

**Why do we need this feature?**

Template migration does not correctly handle this case currently, and can panic in rare cases which is not desired behavior.

**Who is this feature for?**

Users upgrading to Unified Alerting
