### PR TITLE
CI: Fix path for ./pkg/kindsys/report.go on Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -106,7 +106,7 @@ gen-cue: ## Do all CUE/Thema code generation
 	go generate ./pkg/plugins/plugindef
 	go generate ./kinds/gen.go
 	go generate ./public/app/plugins/gen.go
-# go generate ./pkg/kindsysreport/codegen/report.go
+	go generate ./pkg/kindsys/report.go
 
 gen-go: $(WIRE)
 	@echo "generate go files"


### PR DESCRIPTION
This was a merge conflict that wasn't solved properly on https://github.com/grafana/grafana/pull/76874