### PR TITLE
Elasticsearch: decouple from timeSrv and templateSrv

### DIFF
--- a/public/app/plugins/datasource/elasticsearch/LanguageProvider.test.ts
+++ b/public/app/plugins/datasource/elasticsearch/LanguageProvider.test.ts
@@ -1,7 +1,5 @@
 import { AbstractLabelOperator, AbstractQuery } from '@grafana/data';
 
-import { TemplateSrv } from '../../../features/templating/template_srv';
-
 import LanguageProvider from './LanguageProvider';
 import { ElasticDatasource } from './datasource';
 import { createElasticDatasource } from './mocks';
@@ -14,12 +12,7 @@ const baseLogsQuery: Partial<ElasticsearchQuery> = {
 describe('transform abstract query to elasticsearch query', () => {
   let datasource: ElasticDatasource;
   beforeEach(() => {
-    const templateSrvStub = {
-      getAdhocFilters: jest.fn(() => []),
-      replace: jest.fn((a: string) => a),
-    } as unknown as TemplateSrv;
-
-    datasource = createElasticDatasource({}, templateSrvStub);
+    datasource = createElasticDatasource();
   });
 
   it('With some labels', () => {

--- a/public/app/plugins/datasource/elasticsearch/datasource.test.ts
+++ b/public/app/plugins/datasource/elasticsearch/datasource.test.ts
@@ -78,11 +78,7 @@ interface Data {
   [key: string]: undefined | string | string[] | number | Data | Data[];
 }
 
-function getTestContext({
-  data = { responses: [] },
-  jsonData,
-  fetchMockImplementation,
-}: TestContext = {}) {
+function getTestContext({ data = { responses: [] }, jsonData, fetchMockImplementation }: TestContext = {}) {
   const defaultMock = (options: BackendSrvRequest) => of(createFetchResponse(data));
 
   const fetchMock = jest.spyOn(backendSrv, 'fetch');
@@ -1305,7 +1301,7 @@ describe('addAdhocFilters', () => {
     });
 
     it('should not fail if the filter value is a number', () => {
-        // @ts-expect-error
+      // @ts-expect-error
       expect(ds.addAdHocFilters('', [{ key: 'key', operator: '=', value: 1, condition: '' }])).toBe('key:"1"');
     });
 
@@ -1314,7 +1310,7 @@ describe('addAdhocFilters', () => {
       (operator: string) => {
         const filters = [{ key: 'key', operator, value: 'value', condition: '' }];
         const query = ds.addAdHocFilters('foo:"bar"', filters);
-        
+
         switch (operator) {
           case '=':
             expect(query).toBe('foo:"bar" AND key:"value"');
@@ -1361,7 +1357,7 @@ describe('addAdhocFilters', () => {
     ];
     beforeEach(() => {
       const { ds: datasource } = getTestContext();
-      ds = datasource;;
+      ds = datasource;
     });
 
     it('should correctly add ad hoc filters when query is not empty', () => {

--- a/public/app/plugins/datasource/elasticsearch/datasource.ts
+++ b/public/app/plugins/datasource/elasticsearch/datasource.ts
@@ -38,7 +38,14 @@ import {
   DataSourceGetTagValuesOptions,
   AdHocVariableFilter,
 } from '@grafana/data';
-import { DataSourceWithBackend, getDataSourceSrv, config, BackendSrvRequest, TemplateSrv, getTemplateSrv } from '@grafana/runtime';
+import {
+  DataSourceWithBackend,
+  getDataSourceSrv,
+  config,
+  BackendSrvRequest,
+  TemplateSrv,
+  getTemplateSrv,
+} from '@grafana/runtime';
 
 import { queryLogsSample, queryLogsVolume } from '../../../features/logs/logsModel';
 import { getLogLevelFromKey } from '../../../features/logs/utils';
@@ -397,7 +404,11 @@ export class ElasticDatasource
     return this.templateSrv.replace(queryString, scopedVars, 'lucene');
   }
 
-  interpolateVariablesInQueries(queries: ElasticsearchQuery[], scopedVars: ScopedVars, filters?: AdHocVariableFilter[]): ElasticsearchQuery[] {
+  interpolateVariablesInQueries(
+    queries: ElasticsearchQuery[],
+    scopedVars: ScopedVars,
+    filters?: AdHocVariableFilter[]
+  ): ElasticsearchQuery[] {
     return queries.map((q) => this.applyTemplateVariables(q, scopedVars, filters));
   }
 
@@ -954,7 +965,11 @@ export class ElasticDatasource
   }
 
   // Used when running queries through backend
-  applyTemplateVariables(query: ElasticsearchQuery, scopedVars: ScopedVars, filters?: AdHocVariableFilter[]): ElasticsearchQuery {
+  applyTemplateVariables(
+    query: ElasticsearchQuery,
+    scopedVars: ScopedVars,
+    filters?: AdHocVariableFilter[]
+  ): ElasticsearchQuery {
     // We need a separate interpolation format for lucene queries, therefore we first interpolate any
     // lucene query string and then everything else
     const interpolateBucketAgg = (bucketAgg: BucketAggregation): BucketAggregation => {

--- a/public/app/plugins/datasource/elasticsearch/datasource.ts
+++ b/public/app/plugins/datasource/elasticsearch/datasource.ts
@@ -35,9 +35,9 @@ import {
   DataSourceWithToggleableQueryFiltersSupport,
   QueryFilterOptions,
   ToggleFilterAction,
+  DataSourceGetTagValuesOptions,
 } from '@grafana/data';
 import { DataSourceWithBackend, getDataSourceSrv, config, BackendSrvRequest } from '@grafana/runtime';
-import { getTimeSrv, TimeSrv } from 'app/features/dashboard/services/TimeSrv';
 import { getTemplateSrv, TemplateSrv } from 'app/features/templating/template_srv';
 
 import { queryLogsSample, queryLogsVolume } from '../../../features/logs/logsModel';
@@ -114,7 +114,6 @@ export class ElasticDatasource
   languageProvider: LanguageProvider;
   includeFrozen: boolean;
   isProxyAccess: boolean;
-  timeSrv: TimeSrv;
   databaseVersion: SemVer | null;
   legacyQueryRunner: LegacyQueryRunner;
 
@@ -157,7 +156,6 @@ export class ElasticDatasource
       this.logLevelField = undefined;
     }
     this.languageProvider = new LanguageProvider(this);
-    this.timeSrv = getTimeSrv();
     this.legacyQueryRunner = new LegacyQueryRunner(this, this.templateSrv);
   }
 
@@ -832,9 +830,8 @@ export class ElasticDatasource
     return lastValueFrom(this.getFields());
   }
 
-  getTagValues(options: { key: string }) {
-    const range = this.timeSrv.timeRange();
-    return lastValueFrom(this.getTerms({ field: options.key }, range));
+  getTagValues(options: DataSourceGetTagValuesOptions) {
+    return lastValueFrom(this.getTerms({ field: options.key }, options.timeRange));
   }
 
   targetContainsTemplate(target: ElasticsearchQuery) {

--- a/public/app/plugins/datasource/elasticsearch/mocks.ts
+++ b/public/app/plugins/datasource/elasticsearch/mocks.ts
@@ -45,17 +45,18 @@ export function createElasticDatasource(settings: Partial<DataSourceInstanceSett
     ...rest,
   };
 
-  const templateSrv = {
+  const templateSrv: TemplateSrv = {
+    getVariables: () => ([]),
     replace: (text?: string) => {
       if (text?.startsWith('$')) {
         return `resolvedVariable`;
       } else {
-        return text;
+        return text || '';
       }
     },
-    containsTemplate: jest.fn().mockImplementation((text?: string) => text?.includes('$') ?? false),
-    getAdhocFilters: jest.fn().mockReturnValue([]),
-  } as unknown as TemplateSrv;
+    containsTemplate: (text?: string) => text?.includes('$') ?? false,
+    updateTimeRange: () => {},
+  };
 
   return new ElasticDatasource(instanceSettings, templateSrv);
 }

--- a/public/app/plugins/datasource/elasticsearch/mocks.ts
+++ b/public/app/plugins/datasource/elasticsearch/mocks.ts
@@ -1,12 +1,11 @@
 import { DataSourceInstanceSettings, PluginType } from '@grafana/data';
-import { TemplateSrv } from 'app/features/templating/template_srv';
+import { TemplateSrv } from '@grafana/runtime';
 
 import { ElasticDatasource } from './datasource';
 import { ElasticsearchOptions } from './types';
 
 export function createElasticDatasource(
-  settings: Partial<DataSourceInstanceSettings<ElasticsearchOptions>> = {},
-  templateSrv: TemplateSrv
+  settings: Partial<DataSourceInstanceSettings<ElasticsearchOptions>> = {}
 ) {
   const { jsonData, ...rest } = settings;
 
@@ -47,6 +46,18 @@ export function createElasticDatasource(
     database: '[test-]YYYY.MM.DD',
     ...rest,
   };
+
+  const templateSrv = {
+    replace: (text?: string) => {
+      if (text?.startsWith('$')) {
+        return `resolvedVariable`;
+      } else {
+        return text;
+      }
+    },
+    containsTemplate: jest.fn().mockImplementation((text?: string) => text?.includes('$') ?? false),
+    getAdhocFilters: jest.fn().mockReturnValue([]),
+  } as unknown as TemplateSrv
 
   return new ElasticDatasource(instanceSettings, templateSrv);
 }

--- a/public/app/plugins/datasource/elasticsearch/mocks.ts
+++ b/public/app/plugins/datasource/elasticsearch/mocks.ts
@@ -46,7 +46,7 @@ export function createElasticDatasource(settings: Partial<DataSourceInstanceSett
   };
 
   const templateSrv: TemplateSrv = {
-    getVariables: () => ([]),
+    getVariables: () => [],
     replace: (text?: string) => {
       if (text?.startsWith('$')) {
         return `resolvedVariable`;

--- a/public/app/plugins/datasource/elasticsearch/mocks.ts
+++ b/public/app/plugins/datasource/elasticsearch/mocks.ts
@@ -4,9 +4,7 @@ import { TemplateSrv } from '@grafana/runtime';
 import { ElasticDatasource } from './datasource';
 import { ElasticsearchOptions } from './types';
 
-export function createElasticDatasource(
-  settings: Partial<DataSourceInstanceSettings<ElasticsearchOptions>> = {}
-) {
+export function createElasticDatasource(settings: Partial<DataSourceInstanceSettings<ElasticsearchOptions>> = {}) {
   const { jsonData, ...rest } = settings;
 
   const instanceSettings: DataSourceInstanceSettings<ElasticsearchOptions> = {
@@ -57,7 +55,7 @@ export function createElasticDatasource(
     },
     containsTemplate: jest.fn().mockImplementation((text?: string) => text?.includes('$') ?? false),
     getAdhocFilters: jest.fn().mockReturnValue([]),
-  } as unknown as TemplateSrv
+  } as unknown as TemplateSrv;
 
   return new ElasticDatasource(instanceSettings, templateSrv);
 }


### PR DESCRIPTION
Removing core dependencies to decouple from Grafana.
- TimeSrv
- TemplateSrv

**Which issue(s) does this PR fix?**:

Part of https://github.com/grafana/grafana/issues/72632

**Special notes for your reviewer:**

The data source should continue working with no evident changes.