### PR TITLE
Fix: Prevent default configs overriding plugin default configs

### DIFF
--- a/packages/grafana-data/src/panel/getPanelOptionsWithDefaults.ts
+++ b/packages/grafana-data/src/panel/getPanelOptionsWithDefaults.ts
@@ -56,8 +56,8 @@ function applyFieldConfigDefaults(existingFieldConfig: FieldConfigSource, plugin
   const result: FieldConfigSource = {
     defaults: mergeWith(
       {},
-      pluginDefaults.defaults,
       existingFieldConfig ? existingFieldConfig.defaults : {},
+      pluginDefaults.defaults,
       (objValue, srcValue) => {
         if (isArray(srcValue)) {
           return srcValue;


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

Trying to set default thresholds for a plugin with `useFieldConfig` doesn't currently work. e.g

```
.useFieldConfig({
  standardOptions: {
    [FieldConfigProperty.Thresholds]: {
      defaultValue: {
        mode: ThresholdsMode.Percentage,
        steps: [
          { color: 'red', value: -Infinity },
          { color: 'red', value: 0 },
          { color: '#EAB839', value: 50 },
          { color: '#73BF69', value: 80 },
        ],
      },
    },
  },
})
```

Instead the default thresholds that are set by Grafana [here](https://github.com/grafana/grafana/blob/main/public/app/core/components/OptionsUI/registry.tsx#L394-L400) always replace defaults a plugin attempts to set for thresholds.

Changing the order of the params passed to `mergeWith` appears to fix this issue however I don't know whether this is by design or a bug. I'm also not too sure if this will introduce other bugs. 🤔 

**Why do we need this feature?**

So plugins can set defaults for panel config options without being replaced by the grafana defaults.

**Who is this feature for?**

Plugin devs? Grafana users?

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
