### PR TITLE
InfluxDB: Fix table parsing with backend mode

### DIFF
--- a/.betterer.results
+++ b/.betterer.results
@@ -6249,8 +6249,8 @@ exports[`better eslint`] = {
       [0, 0, 0, "Styles should be written using objects.", "0"]
     ],
     "public/app/plugins/datasource/influxdb/datasource.ts:5381": [
-      [0, 0, 0, "Unexpected any. Specify a different type.", "0"],
-      [0, 0, 0, "Do not use any type assertions.", "1"],
+      [0, 0, 0, "Do not use any type assertions.", "0"],
+      [0, 0, 0, "Unexpected any. Specify a different type.", "1"],
       [0, 0, 0, "Unexpected any. Specify a different type.", "2"],
       [0, 0, 0, "Unexpected any. Specify a different type.", "3"],
       [0, 0, 0, "Unexpected any. Specify a different type.", "4"],
@@ -6266,8 +6266,7 @@ exports[`better eslint`] = {
       [0, 0, 0, "Unexpected any. Specify a different type.", "14"],
       [0, 0, 0, "Unexpected any. Specify a different type.", "15"],
       [0, 0, 0, "Unexpected any. Specify a different type.", "16"],
-      [0, 0, 0, "Unexpected any. Specify a different type.", "17"],
-      [0, 0, 0, "Do not use any type assertions.", "18"]
+      [0, 0, 0, "Do not use any type assertions.", "17"]
     ],
     "public/app/plugins/datasource/influxdb/influx_query_model.ts:5381": [
       [0, 0, 0, "Unexpected any. Specify a different type.", "0"],

--- a/pkg/tsdb/influxdb/influxql/response_parser.go
+++ b/pkg/tsdb/influxdb/influxql/response_parser.go
@@ -209,7 +209,7 @@ func newDataFrame(name string, queryString string, timeField *data.Field, valueF
 
 func formatFrameName(row models.Row, column string, query models.Query, frameName []byte) []byte {
 	if query.Alias == "" {
-		return buildFrameNameFromQuery(row, column, frameName)
+		return buildFrameNameFromQuery(row, column, frameName, query.ResultFormat)
 	}
 	nameSegment := strings.Split(row.Name, ".")
 
@@ -247,9 +247,11 @@ func formatFrameName(row models.Row, column string, query models.Query, frameNam
 	return result
 }
 
-func buildFrameNameFromQuery(row models.Row, column string, frameName []byte) []byte {
-	frameName = append(frameName, row.Name...)
-	frameName = append(frameName, '.')
+func buildFrameNameFromQuery(row models.Row, column string, frameName []byte, resultFormat string) []byte {
+	if resultFormat != "table" {
+		frameName = append(frameName, row.Name...)
+		frameName = append(frameName, '.')
+	}
 	frameName = append(frameName, column...)
 
 	if len(row.Tags) > 0 {

--- a/pkg/tsdb/influxdb/influxql/response_parser_test.go
+++ b/pkg/tsdb/influxdb/influxql/response_parser_test.go
@@ -28,6 +28,10 @@ func generateQuery(query models.Query) *models.Query {
 	if query.RawQuery == "" {
 		query.RawQuery = "Test raw query"
 	}
+
+	if query.ResultFormat == "" {
+		query.ResultFormat = "time_series"
+	}
 	return &query
 }
 
@@ -82,7 +86,7 @@ func TestInfluxdbResponseParser(t *testing.T) {
 				}),
 			floatField,
 		)
-		floatFrame.Meta = &data.FrameMeta{ExecutedQueryString: "Test raw query"}
+		floatFrame.Meta = &data.FrameMeta{PreferredVisualization: graphVisType, ExecutedQueryString: "Test raw query"}
 
 		string_test := "/usr/path"
 		stringField := data.NewField("Value", labels, []*string{
@@ -98,7 +102,7 @@ func TestInfluxdbResponseParser(t *testing.T) {
 				}),
 			stringField,
 		)
-		stringFrame.Meta = &data.FrameMeta{ExecutedQueryString: "Test raw query"}
+		stringFrame.Meta = &data.FrameMeta{PreferredVisualization: graphVisType, ExecutedQueryString: "Test raw query"}
 
 		bool_true := true
 		bool_false := false
@@ -115,7 +119,7 @@ func TestInfluxdbResponseParser(t *testing.T) {
 				}),
 			boolField,
 		)
-		boolFrame.Meta = &data.FrameMeta{ExecutedQueryString: "Test raw query"}
+		boolFrame.Meta = &data.FrameMeta{PreferredVisualization: graphVisType, ExecutedQueryString: "Test raw query"}
 
 		result := ResponseParse(prepare(response), 200, generateQuery(query))
 
@@ -265,7 +269,7 @@ func TestInfluxdbResponseParser(t *testing.T) {
 				}),
 			newField,
 		)
-		testFrame.Meta = &data.FrameMeta{ExecutedQueryString: "Test raw query"}
+		testFrame.Meta = &data.FrameMeta{PreferredVisualization: graphVisType, ExecutedQueryString: "Test raw query"}
 
 		result := ResponseParse(prepare(response), 200, generateQuery(query))
 
@@ -310,7 +314,7 @@ func TestInfluxdbResponseParser(t *testing.T) {
 				}),
 			newField,
 		)
-		testFrame.Meta = &data.FrameMeta{ExecutedQueryString: "Test raw query"}
+		testFrame.Meta = &data.FrameMeta{PreferredVisualization: graphVisType, ExecutedQueryString: "Test raw query"}
 
 		result := ResponseParse(prepare(response), 200, generateQuery(query))
 
@@ -359,7 +363,7 @@ func TestInfluxdbResponseParser(t *testing.T) {
 				}),
 			newField,
 		)
-		testFrame.Meta = &data.FrameMeta{ExecutedQueryString: "Test raw query"}
+		testFrame.Meta = &data.FrameMeta{PreferredVisualization: graphVisType, ExecutedQueryString: "Test raw query"}
 		result := ResponseParse(prepare(response), 200, generateQuery(query))
 		t.Run("should parse aliases", func(t *testing.T) {
 			if diff := cmp.Diff(testFrame, result.Frames[0], data.FrameTestCompareOptions()...); diff != "" {
@@ -586,7 +590,7 @@ func TestInfluxdbResponseParser(t *testing.T) {
 				}),
 			newField,
 		)
-		testFrame.Meta = &data.FrameMeta{ExecutedQueryString: "Test raw query"}
+		testFrame.Meta = &data.FrameMeta{PreferredVisualization: graphVisType, ExecutedQueryString: "Test raw query"}
 		result := ResponseParse(prepare(response), 200, generateQuery(query))
 
 		require.EqualError(t, result.Error, "query-timeout limit exceeded")
@@ -736,7 +740,7 @@ func TestResponseParser_Parse(t *testing.T) {
 						}),
 					newField,
 				)
-				testFrame.Meta = &data.FrameMeta{ExecutedQueryString: "Test raw query"}
+				testFrame.Meta = &data.FrameMeta{PreferredVisualization: graphVisType, ExecutedQueryString: "Test raw query"}
 				assert.Equal(t, testFrame, got.Frames[0])
 			},
 		},
@@ -764,7 +768,7 @@ func TestResponseParser_Parse(t *testing.T) {
 						}),
 					newField,
 				)
-				testFrame.Meta = &data.FrameMeta{ExecutedQueryString: "Test raw query"}
+				testFrame.Meta = &data.FrameMeta{PreferredVisualization: graphVisType, ExecutedQueryString: "Test raw query"}
 				assert.Equal(t, testFrame, got.Frames[0])
 			},
 		},

--- a/pkg/tsdb/influxdb/models/model_parser.go
+++ b/pkg/tsdb/influxdb/models/model_parser.go
@@ -26,8 +26,8 @@ func QueryParse(query backend.DataQuery) (*Query, error) {
 	limit := model.Get("limit").MustString("")
 	slimit := model.Get("slimit").MustString("")
 	orderByTime := model.Get("orderByTime").MustString("")
-
 	measurement := model.Get("measurement").MustString("")
+	resultFormat := model.Get("resultFormat").MustString("")
 
 	tags, err := parseTags(model)
 	if err != nil {
@@ -54,19 +54,20 @@ func QueryParse(query backend.DataQuery) (*Query, error) {
 	}
 
 	return &Query{
-		Measurement: measurement,
-		Policy:      policy,
-		GroupBy:     groupBys,
-		Tags:        tags,
-		Selects:     selects,
-		RawQuery:    rawQuery,
-		Interval:    interval,
-		Alias:       alias,
-		UseRawQuery: useRawQuery,
-		Tz:          tz,
-		Limit:       limit,
-		Slimit:      slimit,
-		OrderByTime: orderByTime,
+		Measurement:  measurement,
+		Policy:       policy,
+		GroupBy:      groupBys,
+		Tags:         tags,
+		Selects:      selects,
+		RawQuery:     rawQuery,
+		Interval:     interval,
+		Alias:        alias,
+		UseRawQuery:  useRawQuery,
+		Tz:           tz,
+		Limit:        limit,
+		Slimit:       slimit,
+		OrderByTime:  orderByTime,
+		ResultFormat: resultFormat,
 	}, nil
 }
 

--- a/pkg/tsdb/influxdb/models/models.go
+++ b/pkg/tsdb/influxdb/models/models.go
@@ -3,20 +3,21 @@ package models
 import "time"
 
 type Query struct {
-	Measurement string
-	Policy      string
-	Tags        []*Tag
-	GroupBy     []*QueryPart
-	Selects     []*Select
-	RawQuery    string
-	UseRawQuery bool
-	Alias       string
-	Interval    time.Duration
-	Tz          string
-	Limit       string
-	Slimit      string
-	OrderByTime string
-	RefID       string
+	Measurement  string
+	Policy       string
+	Tags         []*Tag
+	GroupBy      []*QueryPart
+	Selects      []*Select
+	RawQuery     string
+	UseRawQuery  bool
+	Alias        string
+	Interval     time.Duration
+	Tz           string
+	Limit        string
+	Slimit       string
+	OrderByTime  string
+	RefID        string
+	ResultFormat string
 }
 
 type Tag struct {

--- a/public/app/plugins/datasource/influxdb/datasource.ts
+++ b/public/app/plugins/datasource/influxdb/datasource.ts
@@ -1,4 +1,4 @@
-import { cloneDeep, extend, groupBy, has, isString, map as _map, omit, pick, reduce } from 'lodash';
+import { cloneDeep, extend, has, isString, map as _map, omit, pick, reduce } from 'lodash';
 import { lastValueFrom, merge, Observable, of, throwError } from 'rxjs';
 import { catchError, map } from 'rxjs/operators';
 
@@ -138,49 +138,8 @@ export default class InfluxDatasource extends DataSourceWithBackend<InfluxQuery,
       return merge(...streams);
     }
 
-    if (this.version === InfluxVersion.Flux || this.version === InfluxVersion.SQL) {
-      return super.query(filteredRequest);
-    }
-
     if (this.isMigrationToggleOnAndIsAccessProxy()) {
-      return super.query(filteredRequest).pipe(
-        map((res) => {
-          if (res.error) {
-            throw {
-              message: 'InfluxDB Error: ' + res.error.message,
-              res,
-            };
-          }
-
-          const groupedFrames = groupBy(res.data, (x) => x.refId);
-          if (Object.keys(groupedFrames).length === 0) {
-            return { data: [] };
-          }
-
-          const seriesList: any[] = [];
-          filteredRequest.targets.forEach((target) => {
-            const filteredFrames = groupedFrames[target.refId] ?? [];
-            switch (target.resultFormat) {
-              case 'logs':
-              case 'table':
-                seriesList.push(
-                  this.responseParser.getTable(filteredFrames, target, {
-                    preferredVisualisationType: target.resultFormat,
-                  })
-                );
-                break;
-              default: {
-                for (let i = 0; i < filteredFrames.length; i++) {
-                  seriesList.push(filteredFrames[i]);
-                }
-                break;
-              }
-            }
-          });
-
-          return { data: seriesList };
-        })
-      );
+      return super.query(filteredRequest);
     }
 
     // Fallback to classic query support


### PR DESCRIPTION
**What is this feature?**

This PR is addressing a couple of issues altogether. 
- We were using custom table parsing logic for backend mode. That's not needed anymore
- Also we were adding rowName to the field names. For instance when you query something `select qqq, eee from somewhere` we return the names as `somewhere.qqq and somewhere.eee`. This is not compatible with what we have with the frontend mode. 
- Panels with influxdb frontend mode if have transformations (i.e. `join by field`) is failing since backend is sending field names with rows
- Table parsing logic relies on query model but with raw queries we don't have it. So it is not working.


**Who is this feature for?**

InfluxDB influxql users with backend mode enabled.

**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/grafana/issues/76897

**Special notes for your reviewer:**

### How to test
- Set feature toggle `influxdbBackendMigration=false`
- Create a panel that uses InfluxDB InfluxQL raw code editor in frontend mode
- Use query `SELECT usage_idle, usage_iowait FROM "cpu" WHERE $timeFilter`
- Select "Table" format
- Apply transformation "Join by Field"
- Apply field override to `usage_idle` and `usage_iowait`
- Run the query and observe you got `Time`, `usage_idle`, `usage_iowait` columns back
- enable feature toggle `influxdbBackendMigration=true`
- Refresh and see the table is not same or potentially broken
- Switch to this branch and run the same query on same panel
- Observe you have the same result and transformation, field overrides are working


# Release notice breaking change

For the existing backend mode users who have table visualization might see some inconsistencies on their panels. We have updated the table column naming. This will potentially affect field transformations and/or field overrides.  To resolve this either:
- Update transformation 
- Update field override