### PR TITLE
Table: Optimization - render icons on hover

### DIFF
--- a/packages/grafana-ui/src/components/Table/CellActions.tsx
+++ b/packages/grafana-ui/src/components/Table/CellActions.tsx
@@ -11,6 +11,7 @@ import { getTextAlign } from './utils';
 
 interface CellActionProps extends TableCellProps {
   previewMode: 'text' | 'code';
+  hover: boolean;
 }
 
 interface CommonButtonProps {
@@ -19,7 +20,7 @@ interface CommonButtonProps {
   tooltipPlacement: TooltipPlacement;
 }
 
-export function CellActions({ field, cell, previewMode, showFilters, onCellFilterAdded }: CellActionProps) {
+export function CellActions({ field, cell, previewMode, showFilters, onCellFilterAdded, hover }: CellActionProps) {
   const [isInspecting, setIsInspecting] = useState(false);
 
   const isRightAligned = getTextAlign(field) === 'flex-end';
@@ -60,10 +61,10 @@ export function CellActions({ field, cell, previewMode, showFilters, onCellFilte
               {...commonButtonProps}
             />
           )}
-          {showFilters && (
+          {hover && showFilters && (
             <IconButton name={'search-plus'} onClick={onFilterFor} tooltip="Filter for value" {...commonButtonProps} />
           )}
-          {showFilters && (
+          {hover && showFilters && (
             <IconButton name={'search-minus'} onClick={onFilterOut} tooltip="Filter out value" {...commonButtonProps} />
           )}
         </HorizontalGroup>

--- a/packages/grafana-ui/src/components/Table/CellActions.tsx
+++ b/packages/grafana-ui/src/components/Table/CellActions.tsx
@@ -11,7 +11,6 @@ import { getTextAlign } from './utils';
 
 interface CellActionProps extends TableCellProps {
   previewMode: 'text' | 'code';
-  hover: boolean;
 }
 
 interface CommonButtonProps {
@@ -20,7 +19,7 @@ interface CommonButtonProps {
   tooltipPlacement: TooltipPlacement;
 }
 
-export function CellActions({ field, cell, previewMode, showFilters, onCellFilterAdded, hover }: CellActionProps) {
+export function CellActions({ field, cell, previewMode, showFilters, onCellFilterAdded }: CellActionProps) {
   const [isInspecting, setIsInspecting] = useState(false);
 
   const isRightAligned = getTextAlign(field) === 'flex-end';
@@ -61,10 +60,10 @@ export function CellActions({ field, cell, previewMode, showFilters, onCellFilte
               {...commonButtonProps}
             />
           )}
-          {hover && showFilters && (
+          {showFilters && (
             <IconButton name={'search-plus'} onClick={onFilterFor} tooltip="Filter for value" {...commonButtonProps} />
           )}
-          {hover && showFilters && (
+          {showFilters && (
             <IconButton name={'search-minus'} onClick={onFilterOut} tooltip="Filter out value" {...commonButtonProps} />
           )}
         </HorizontalGroup>

--- a/packages/grafana-ui/src/components/Table/DefaultCell.tsx
+++ b/packages/grafana-ui/src/components/Table/DefaultCell.tsx
@@ -1,5 +1,5 @@
 import { cx } from '@emotion/css';
-import React, { ReactElement } from 'react';
+import React, { ReactElement, useState } from 'react';
 import tinycolor from 'tinycolor2';
 
 import { DisplayValue, formattedValueToString } from '@grafana/data';
@@ -27,7 +27,15 @@ export const DefaultCell = (props: TableCellProps) => {
   const cellStyle = getCellStyle(tableStyles, cellOptions, displayValue, inspectEnabled);
   const hasLinks = Boolean(getCellLinks(field, row)?.length);
   const clearButtonStyle = useStyles2(clearLinkButtonStyles);
+  const [hover, setHover] = useState(false);
   let value: string | ReactElement;
+
+  const onMouseLeave = () => {
+    setHover(false);
+  };
+  const onMouseEnter = () => {
+    setHover(true);
+  };
 
   if (cellOptions.type === TableCellDisplayMode.Custom) {
     const CustomCellComponent: React.ComponentType<CustomCellRendererProps> = cellOptions.cellComponent;
@@ -41,7 +49,7 @@ export const DefaultCell = (props: TableCellProps) => {
   }
 
   return (
-    <div {...cellProps} className={cellStyle}>
+    <div {...cellProps} onMouseEnter={onMouseEnter} onMouseLeave={onMouseLeave} className={cellStyle}>
       {!hasLinks && <div className={tableStyles.cellText}>{value}</div>}
 
       {hasLinks && (
@@ -63,7 +71,7 @@ export const DefaultCell = (props: TableCellProps) => {
         </DataLinksContextMenu>
       )}
 
-      {showActions && <CellActions {...props} previewMode="text" showFilters={showFilters} />}
+      {showActions && <CellActions hover={hover} {...props} previewMode="text" showFilters={showFilters} />}
     </div>
   );
 };

--- a/packages/grafana-ui/src/components/Table/DefaultCell.tsx
+++ b/packages/grafana-ui/src/components/Table/DefaultCell.tsx
@@ -71,7 +71,7 @@ export const DefaultCell = (props: TableCellProps) => {
         </DataLinksContextMenu>
       )}
 
-      {hover && showActions && <CellActions hover={hover} {...props} previewMode="text" showFilters={showFilters} />}
+      {hover && showActions && <CellActions {...props} previewMode="text" showFilters={showFilters} />}
     </div>
   );
 };

--- a/packages/grafana-ui/src/components/Table/DefaultCell.tsx
+++ b/packages/grafana-ui/src/components/Table/DefaultCell.tsx
@@ -71,7 +71,7 @@ export const DefaultCell = (props: TableCellProps) => {
         </DataLinksContextMenu>
       )}
 
-      {showActions && <CellActions hover={hover} {...props} previewMode="text" showFilters={showFilters} />}
+      {hover && showActions && <CellActions hover={hover} {...props} previewMode="text" showFilters={showFilters} />}
     </div>
   );
 };

--- a/packages/grafana-ui/src/components/Table/DefaultCell.tsx
+++ b/packages/grafana-ui/src/components/Table/DefaultCell.tsx
@@ -49,7 +49,12 @@ export const DefaultCell = (props: TableCellProps) => {
   }
 
   return (
-    <div {...cellProps} onMouseEnter={onMouseEnter} onMouseLeave={onMouseLeave} className={cellStyle}>
+    <div
+      {...cellProps}
+      onMouseEnter={showActions ? onMouseEnter : undefined}
+      onMouseLeave={showActions ? onMouseLeave : undefined}
+      className={cellStyle}
+    >
       {!hasLinks && <div className={tableStyles.cellText}>{value}</div>}
 
       {hasLinks && (

--- a/packages/grafana-ui/src/components/Table/DefaultCell.tsx
+++ b/packages/grafana-ui/src/components/Table/DefaultCell.tsx
@@ -53,9 +53,10 @@ export const DefaultCell = (props: TableCellProps) => {
       {...cellProps}
       onMouseEnter={showActions ? onMouseEnter : undefined}
       onMouseLeave={showActions ? onMouseLeave : undefined}
-      className={cx(cellStyle, tableStyles.cellText)}
+      className={cellStyle}
     >
-      {!hasLinks && `${value}`}
+      {!hasLinks && <div className={tableStyles.cellText}>{value}</div>}
+
       {hasLinks && (
         <DataLinksContextMenu links={() => getCellLinks(field, row) || []}>
           {(api) => {
@@ -74,6 +75,7 @@ export const DefaultCell = (props: TableCellProps) => {
           }}
         </DataLinksContextMenu>
       )}
+
       {hover && showActions && <CellActions {...props} previewMode="text" showFilters={showFilters} />}
     </div>
   );

--- a/packages/grafana-ui/src/components/Table/DefaultCell.tsx
+++ b/packages/grafana-ui/src/components/Table/DefaultCell.tsx
@@ -24,7 +24,6 @@ export const DefaultCell = (props: TableCellProps) => {
   const showFilters = props.onCellFilterAdded && field.config.filterable;
   const showActions = (showFilters && cell.value !== undefined) || inspectEnabled;
   const cellOptions = getCellOptions(field);
-  const cellStyle = getCellStyle(tableStyles, cellOptions, displayValue, inspectEnabled);
   const hasLinks = Boolean(getCellLinks(field, row)?.length);
   const clearButtonStyle = useStyles2(clearLinkButtonStyles);
   const [hover, setHover] = useState(false);
@@ -48,6 +47,14 @@ export const DefaultCell = (props: TableCellProps) => {
     }
   }
 
+  const isStringValue = typeof value === 'string';
+
+  const cellStyle = getCellStyle(tableStyles, cellOptions, displayValue, inspectEnabled, isStringValue);
+
+  if (isStringValue && cellProps.style?.justifyContent === 'flex-end') {
+    cellProps.style!.textAlign = 'right';
+  }
+
   return (
     <div
       {...cellProps}
@@ -55,7 +62,7 @@ export const DefaultCell = (props: TableCellProps) => {
       onMouseLeave={showActions ? onMouseLeave : undefined}
       className={cellStyle}
     >
-      {!hasLinks && <div className={tableStyles.cellText}>{value}</div>}
+      {!hasLinks && (isStringValue ? `${value}` : <div className={tableStyles.cellText}>{value}</div>)}
 
       {hasLinks && (
         <DataLinksContextMenu links={() => getCellLinks(field, row) || []}>
@@ -85,7 +92,8 @@ function getCellStyle(
   tableStyles: TableStyles,
   cellOptions: TableCellOptions,
   displayValue: DisplayValue,
-  disableOverflowOnHover = false
+  disableOverflowOnHover = false,
+  isStringValue = false
 ) {
   // How much to darken elements depends upon if we're in dark mode
   const darkeningFactor = tableStyles.theme.isDark ? 1 : -0.7;
@@ -114,10 +122,14 @@ function getCellStyle(
   // If we have definied colors return those styles
   // Otherwise we return default styles
   if (textColor !== undefined || bgColor !== undefined) {
-    return tableStyles.buildCellContainerStyle(textColor, bgColor, !disableOverflowOnHover);
+    return tableStyles.buildCellContainerStyle(textColor, bgColor, !disableOverflowOnHover, isStringValue);
   }
 
-  return disableOverflowOnHover ? tableStyles.cellContainerNoOverflow : tableStyles.cellContainer;
+  if (isStringValue) {
+    return disableOverflowOnHover ? tableStyles.cellContainerTextNoOverflow : tableStyles.cellContainerText;
+  } else {
+    return disableOverflowOnHover ? tableStyles.cellContainerNoOverflow : tableStyles.cellContainer;
+  }
 }
 
 function getLinkStyle(tableStyles: TableStyles, cellOptions: TableCellOptions, targetClassName: string | undefined) {

--- a/packages/grafana-ui/src/components/Table/DefaultCell.tsx
+++ b/packages/grafana-ui/src/components/Table/DefaultCell.tsx
@@ -53,10 +53,9 @@ export const DefaultCell = (props: TableCellProps) => {
       {...cellProps}
       onMouseEnter={showActions ? onMouseEnter : undefined}
       onMouseLeave={showActions ? onMouseLeave : undefined}
-      className={cellStyle}
+      className={cx(cellStyle, tableStyles.cellText)}
     >
-      {!hasLinks && <div className={tableStyles.cellText}>{value}</div>}
-
+      {!hasLinks && `${value}`}
       {hasLinks && (
         <DataLinksContextMenu links={() => getCellLinks(field, row) || []}>
           {(api) => {
@@ -75,7 +74,6 @@ export const DefaultCell = (props: TableCellProps) => {
           }}
         </DataLinksContextMenu>
       )}
-
       {hover && showActions && <CellActions {...props} previewMode="text" showFilters={showFilters} />}
     </div>
   );

--- a/packages/grafana-ui/src/components/Table/styles.ts
+++ b/packages/grafana-ui/src/components/Table/styles.ts
@@ -11,14 +11,30 @@ export function useTableStyles(theme: GrafanaTheme2, cellHeightOption: TableCell
   const rowHeight = cellHeight + 2;
   const headerHeight = 28;
 
-  const buildCellContainerStyle = (color?: string, background?: string, overflowOnHover?: boolean) => {
+  const buildCellContainerStyle = (
+    color?: string,
+    background?: string,
+    overflowOnHover?: boolean,
+    asCellText?: boolean
+  ) => {
     return css({
       label: overflowOnHover ? 'cellContainerOverflow' : 'cellContainerNoOverflow',
       padding: `${cellPadding}px`,
       width: '100%',
       // Cell height need to account for row border
       height: `${rowHeight - 1}px`,
-      display: 'flex',
+
+      display: asCellText ? 'block' : 'flex',
+
+      ...(asCellText
+        ? {
+            overflow: 'hidden',
+            textOverflow: 'ellipsis',
+            userSelect: 'text',
+            whiteSpace: 'nowrap',
+          }
+        : {}),
+
       alignItems: 'center',
       borderRight: `1px solid ${borderColor}`,
 
@@ -141,8 +157,11 @@ export function useTableStyles(theme: GrafanaTheme2, cellHeightOption: TableCell
         color: theme.colors.text.link,
       },
     }),
-    cellContainer: buildCellContainerStyle(undefined, undefined, true),
-    cellContainerNoOverflow: buildCellContainerStyle(undefined, undefined, false),
+    cellContainerText: buildCellContainerStyle(undefined, undefined, true, true),
+    cellContainerTextNoOverflow: buildCellContainerStyle(undefined, undefined, false, true),
+
+    cellContainer: buildCellContainerStyle(undefined, undefined, true, false),
+    cellContainerNoOverflow: buildCellContainerStyle(undefined, undefined, false, false),
     cellText: css({
       overflow: 'hidden',
       textOverflow: 'ellipsis',


### PR DESCRIPTION
**What is this feature?**

Only rendering icons on hover

**Why do we need this feature?**
Table component has too many DOM nodes, removing the SVG icons from being rendered in each component speeds up render significantly.

**Who is this feature for?**
Users of Table component

**Special notes for your reviewer:**
Table cells don't seem to get keyboard focus, once they do this will need to be changed to include onFocus/onBlur

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
