### PR TITLE
Fix: Accessibility labels for Inline Switch

### DIFF
--- a/packages/grafana-ui/src/components/Switch/Switch.tsx
+++ b/packages/grafana-ui/src/components/Switch/Switch.tsx
@@ -36,9 +36,10 @@ export const Switch = React.forwardRef<HTMLInputElement, Props>(
           }}
           id={switchIdRef.current}
           {...inputProps}
+          aria-label={label ?? 'Toggle switch'}
           ref={ref}
         />
-        <label htmlFor={switchIdRef.current} aria-label={label ?? 'Toggle switch'} />
+        <label htmlFor={switchIdRef.current} />
       </div>
     );
   }


### PR DESCRIPTION
**What is this feature?**
Inconsistency on screen reader (voice over) and some browsers while reading labels for InlineSwitch component

**Why do we need this feature?**

To ensure that all users that use screen readers will have the same  experience while interacting with Switchs.

**Who is this feature for?**

Users

**Which issue(s) does this PR fix?**:

Fixes #73641

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
