### PR TITLE
Table: Optimization - remove plaintext cell wrapper

### DIFF
--- a/packages/grafana-ui/src/components/Table/DefaultCell.tsx
+++ b/packages/grafana-ui/src/components/Table/DefaultCell.tsx
@@ -24,7 +24,6 @@ export const DefaultCell = (props: TableCellProps) => {
   const showFilters = props.onCellFilterAdded && field.config.filterable;
   const showActions = (showFilters && cell.value !== undefined) || inspectEnabled;
   const cellOptions = getCellOptions(field);
-  const cellStyle = getCellStyle(tableStyles, cellOptions, displayValue, inspectEnabled);
   const hasLinks = Boolean(getCellLinks(field, row)?.length);
   const clearButtonStyle = useStyles2(clearLinkButtonStyles);
   const [hover, setHover] = useState(false);
@@ -48,6 +47,17 @@ export const DefaultCell = (props: TableCellProps) => {
     }
   }
 
+  const cellStyle = getCellStyle(tableStyles, cellOptions, displayValue, inspectEnabled, value);
+
+  if (typeof value === 'string') {
+    if (cellProps.style?.justifyContent === 'flex-end') {
+      cellProps.style!.textAlign = 'right';
+    }
+
+    // hack! todo: remove mutation?
+    delete cellProps.style!.justifyContent;
+  }
+
   return (
     <div
       {...cellProps}
@@ -55,7 +65,7 @@ export const DefaultCell = (props: TableCellProps) => {
       onMouseLeave={showActions ? onMouseLeave : undefined}
       className={cellStyle}
     >
-      {!hasLinks && <div className={tableStyles.cellText}>{value}</div>}
+      {!hasLinks && (typeof value === 'string' ? `${value}` : <div className={tableStyles.cellText}>{value}</div>)}
 
       {hasLinks && (
         <DataLinksContextMenu links={() => getCellLinks(field, row) || []}>
@@ -85,7 +95,8 @@ function getCellStyle(
   tableStyles: TableStyles,
   cellOptions: TableCellOptions,
   displayValue: DisplayValue,
-  disableOverflowOnHover = false
+  disableOverflowOnHover = false,
+  value: string | ReactElement,
 ) {
   // How much to darken elements depends upon if we're in dark mode
   const darkeningFactor = tableStyles.theme.isDark ? 1 : -0.7;
@@ -114,10 +125,14 @@ function getCellStyle(
   // If we have definied colors return those styles
   // Otherwise we return default styles
   if (textColor !== undefined || bgColor !== undefined) {
-    return tableStyles.buildCellContainerStyle(textColor, bgColor, !disableOverflowOnHover);
+    return tableStyles.buildCellContainerStyle(textColor, bgColor, !disableOverflowOnHover, typeof value === 'string');
   }
 
-  return disableOverflowOnHover ? tableStyles.cellContainerNoOverflow : tableStyles.cellContainer;
+  if (typeof value === 'string') {
+    return disableOverflowOnHover ? tableStyles.cellContainerTextNoOverflow : tableStyles.cellContainerText;
+  } else {
+    return disableOverflowOnHover ? tableStyles.cellContainerNoOverflow : tableStyles.cellContainer;
+  }
 }
 
 function getLinkStyle(tableStyles: TableStyles, cellOptions: TableCellOptions, targetClassName: string | undefined) {

--- a/packages/grafana-ui/src/components/Table/DefaultCell.tsx
+++ b/packages/grafana-ui/src/components/Table/DefaultCell.tsx
@@ -47,9 +47,11 @@ export const DefaultCell = (props: TableCellProps) => {
     }
   }
 
-  const cellStyle = getCellStyle(tableStyles, cellOptions, displayValue, inspectEnabled, value);
+  const isStringValue = typeof value === 'string';
 
-  if (typeof value === 'string') {
+  const cellStyle = getCellStyle(tableStyles, cellOptions, displayValue, inspectEnabled, isStringValue);
+
+  if (isStringValue) {
     if (cellProps.style?.justifyContent === 'flex-end') {
       cellProps.style!.textAlign = 'right';
     }
@@ -65,7 +67,7 @@ export const DefaultCell = (props: TableCellProps) => {
       onMouseLeave={showActions ? onMouseLeave : undefined}
       className={cellStyle}
     >
-      {!hasLinks && (typeof value === 'string' ? `${value}` : <div className={tableStyles.cellText}>{value}</div>)}
+      {!hasLinks && (isStringValue ? `${value}` : <div className={tableStyles.cellText}>{value}</div>)}
 
       {hasLinks && (
         <DataLinksContextMenu links={() => getCellLinks(field, row) || []}>
@@ -96,7 +98,7 @@ function getCellStyle(
   cellOptions: TableCellOptions,
   displayValue: DisplayValue,
   disableOverflowOnHover = false,
-  value: string | ReactElement,
+  isStringValue = false
 ) {
   // How much to darken elements depends upon if we're in dark mode
   const darkeningFactor = tableStyles.theme.isDark ? 1 : -0.7;
@@ -125,10 +127,10 @@ function getCellStyle(
   // If we have definied colors return those styles
   // Otherwise we return default styles
   if (textColor !== undefined || bgColor !== undefined) {
-    return tableStyles.buildCellContainerStyle(textColor, bgColor, !disableOverflowOnHover, typeof value === 'string');
+    return tableStyles.buildCellContainerStyle(textColor, bgColor, !disableOverflowOnHover, isStringValue);
   }
 
-  if (typeof value === 'string') {
+  if (isStringValue) {
     return disableOverflowOnHover ? tableStyles.cellContainerTextNoOverflow : tableStyles.cellContainerText;
   } else {
     return disableOverflowOnHover ? tableStyles.cellContainerNoOverflow : tableStyles.cellContainer;

--- a/packages/grafana-ui/src/components/Table/DefaultCell.tsx
+++ b/packages/grafana-ui/src/components/Table/DefaultCell.tsx
@@ -51,13 +51,8 @@ export const DefaultCell = (props: TableCellProps) => {
 
   const cellStyle = getCellStyle(tableStyles, cellOptions, displayValue, inspectEnabled, isStringValue);
 
-  if (isStringValue) {
-    if (cellProps.style?.justifyContent === 'flex-end') {
-      cellProps.style!.textAlign = 'right';
-    }
-
-    // hack! todo: remove mutation?
-    delete cellProps.style!.justifyContent;
+  if (isStringValue && cellProps.style?.justifyContent === 'flex-end') {
+    cellProps.style!.textAlign = 'right';
   }
 
   return (

--- a/packages/grafana-ui/src/components/Table/styles.ts
+++ b/packages/grafana-ui/src/components/Table/styles.ts
@@ -11,14 +11,28 @@ export function useTableStyles(theme: GrafanaTheme2, cellHeightOption: TableCell
   const rowHeight = cellHeight + 2;
   const headerHeight = 28;
 
-  const buildCellContainerStyle = (color?: string, background?: string, overflowOnHover?: boolean) => {
+  const buildCellContainerStyle = (
+    color?: string,
+    background?: string,
+    overflowOnHover?: boolean,
+    asCellText?: boolean
+  ) => {
     return css({
       label: overflowOnHover ? 'cellContainerOverflow' : 'cellContainerNoOverflow',
       padding: `${cellPadding}px`,
       width: '100%',
       // Cell height need to account for row border
       height: `${rowHeight - 1}px`,
-      display: 'flex',
+
+      display: asCellText ? 'block' : 'flex',
+
+      ...(asCellText ? {
+        overflow: 'hidden',
+        textOverflow: 'ellipsis',
+        userSelect: 'text',
+        whiteSpace: 'nowrap',
+      } : {}),
+
       alignItems: 'center',
       borderRight: `1px solid ${borderColor}`,
 
@@ -141,8 +155,11 @@ export function useTableStyles(theme: GrafanaTheme2, cellHeightOption: TableCell
         color: theme.colors.text.link,
       },
     }),
-    cellContainer: buildCellContainerStyle(undefined, undefined, true),
-    cellContainerNoOverflow: buildCellContainerStyle(undefined, undefined, false),
+    cellContainerText: buildCellContainerStyle(undefined, undefined, true, true),
+    cellContainerTextNoOverflow: buildCellContainerStyle(undefined, undefined, false, true),
+
+    cellContainer: buildCellContainerStyle(undefined, undefined, true, false),
+    cellContainerNoOverflow: buildCellContainerStyle(undefined, undefined, false, false),
     cellText: css({
       overflow: 'hidden',
       textOverflow: 'ellipsis',

--- a/packages/grafana-ui/src/components/Table/styles.ts
+++ b/packages/grafana-ui/src/components/Table/styles.ts
@@ -26,12 +26,14 @@ export function useTableStyles(theme: GrafanaTheme2, cellHeightOption: TableCell
 
       display: asCellText ? 'block' : 'flex',
 
-      ...(asCellText ? {
-        overflow: 'hidden',
-        textOverflow: 'ellipsis',
-        userSelect: 'text',
-        whiteSpace: 'nowrap',
-      } : {}),
+      ...(asCellText
+        ? {
+            overflow: 'hidden',
+            textOverflow: 'ellipsis',
+            userSelect: 'text',
+            whiteSpace: 'nowrap',
+          }
+        : {}),
 
       alignItems: 'center',
       borderRight: `1px solid ${borderColor}`,


### PR DESCRIPTION
this is on top of the optimization in https://github.com/grafana/grafana/pull/76906 (which renders the cell action menu on demand).

tables become slow in a hurry. 10 columns by 100 visible rows (a common scenario) means a single extra element per cell results in 1000 extra React vnodes and DOM elements.

here we try to remove the inner wrapper on every plain text cell, which significantly improves rendering and interaction performance.