### PR TITLE
InfluxDB: Fix aliasing with $measurement or $m on backend mode

### DIFF
--- a/pkg/tsdb/influxdb/influxql/response_parser.go
+++ b/pkg/tsdb/influxdb/influxql/response_parser.go
@@ -220,7 +220,7 @@ func formatFrameName(row models.Row, column string, query models.Query, frameNam
 		aliasFormat = strings.Replace(aliasFormat, "$", "", 1)
 
 		if aliasFormat == "m" || aliasFormat == "measurement" {
-			return []byte(query.Measurement)
+			return []byte(row.Name)
 		}
 		if aliasFormat == "col" {
 			return []byte(column)


### PR DESCRIPTION
**What is this feature?**

When you have multiple measurements in the response and have `$measurement` or `$m` as alias, the result is not being rendered properly. This PR is addressing that issue by getting the measurement from the response itself. 

**Who is this feature for?**

InfluxDB backend mode users who have `$measurement` or `$m` as alias and have multiple measurements 

**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/grafana/issues/52844

**Special notes for your reviewer:**

### How to test it?
- enable InfluxDB backend mode `influxdbBackendMigration=true`
- Go to explore and select influxdb datasource (ideally 1.x version for easy testing)
- Switch to code editor 
- Paste this query `SELECT mean("value") FROM /.*/ WHERE $timeFilter GROUP BY time($__interval) fill(null)`
- Paste `$measurement` as alias
- Observe you get no measurement in the legend and in the table columns
- Switch to this branch and try again
- Observe that you get your measurements
