### PR TITLE
CloudWatch: Use context in aws DescribeRegionsWithContext

### DIFF
--- a/pkg/tsdb/cloudwatch/cloudwatch_integration_test.go
+++ b/pkg/tsdb/cloudwatch/cloudwatch_integration_test.go
@@ -39,7 +39,7 @@ func Test_CloudWatch_CallResource_Integration_Test(t *testing.T) {
 		return &logApi
 	}
 	ec2Mock := &mocks.EC2Mock{}
-	ec2Mock.On("DescribeRegions", mock.Anything, mock.Anything).Return(&ec2.DescribeRegionsOutput{}, nil)
+	ec2Mock.On("DescribeRegionsWithContext", mock.Anything, mock.Anything).Return(&ec2.DescribeRegionsOutput{}, nil)
 	NewEC2Client = func(provider client.ConfigProvider) models.EC2APIProvider {
 		return ec2Mock
 	}

--- a/pkg/tsdb/cloudwatch/metric_find_query.go
+++ b/pkg/tsdb/cloudwatch/metric_find_query.go
@@ -60,7 +60,7 @@ func (e *cloudWatchExecutor) handleGetRegions(ctx context.Context, pluginCtx bac
 		return nil, err
 	}
 	regions := constants.Regions()
-	ec2Regions, err := client.DescribeRegions(&ec2.DescribeRegionsInput{})
+	ec2Regions, err := client.DescribeRegionsWithContext(ctx, &ec2.DescribeRegionsInput{})
 	if err != nil {
 		// ignore error for backward compatibility
 		logger.Error("Failed to get regions", "error", err)

--- a/pkg/tsdb/cloudwatch/metric_find_query_test.go
+++ b/pkg/tsdb/cloudwatch/metric_find_query_test.go
@@ -39,7 +39,7 @@ func TestQuery_Regions(t *testing.T) {
 	}
 	t.Run("An extra region", func(t *testing.T) {
 		const regionName = "xtra-region"
-		ec2Mock.On("DescribeRegions", mock.Anything, mock.Anything).Return(&ec2.DescribeRegionsOutput{
+		ec2Mock.On("DescribeRegionsWithContext", mock.Anything, mock.Anything).Return(&ec2.DescribeRegionsOutput{
 			Regions: []*ec2.Region{
 				{
 					RegionName: utils.Pointer(regionName),
@@ -109,7 +109,7 @@ func Test_handleGetRegions_regionCache(t *testing.T) {
 	})
 
 	t.Run("AWS only called once for multiple calls to handleGetRegions", func(t *testing.T) {
-		cli.On("DescribeRegions", mock.Anything, mock.Anything).Return(&ec2.DescribeRegionsOutput{}, nil)
+		cli.On("DescribeRegionsWithContext", mock.Anything, mock.Anything).Return(&ec2.DescribeRegionsOutput{}, nil)
 		executor := newExecutor(im, newTestConfig(), &fakeSessionCache{}, featuremgmt.WithFeatures())
 		_, err := executor.handleGetRegions(
 			context.Background(),
@@ -121,7 +121,7 @@ func Test_handleGetRegions_regionCache(t *testing.T) {
 			backend.PluginContext{DataSourceInstanceSettings: &backend.DataSourceInstanceSettings{}}, nil)
 		require.NoError(t, err)
 
-		cli.AssertNumberOfCalls(t, "DescribeRegions", 1)
+		cli.AssertNumberOfCalls(t, "DescribeRegionsWithContext", 1)
 	})
 }
 func TestQuery_InstanceAttributes(t *testing.T) {

--- a/pkg/tsdb/cloudwatch/mocks/regions.go
+++ b/pkg/tsdb/cloudwatch/mocks/regions.go
@@ -1,6 +1,8 @@
 package mocks
 
 import (
+	"context"
+
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/request"
 	"github.com/aws/aws-sdk-go/service/ec2"
@@ -12,9 +14,9 @@ type RegionsService struct {
 	mock.Mock
 }
 
-func (r *RegionsService) GetRegionsWithContext() (ctx aws.Context, in []resources.ResourceResponse[resources.Region], e error) {
+func (r *RegionsService) GetRegionsWithContext(ctx context.Context) (in []resources.ResourceResponse[resources.Region], e error) {
 	args := r.Called()
-	return ctx, args.Get(0).(([]resources.ResourceResponse[resources.Region])), args.Error(1)
+	return args.Get(0).(([]resources.ResourceResponse[resources.Region])), args.Error(1)
 }
 
 type EC2Mock struct {

--- a/pkg/tsdb/cloudwatch/mocks/regions.go
+++ b/pkg/tsdb/cloudwatch/mocks/regions.go
@@ -12,16 +12,16 @@ type RegionsService struct {
 	mock.Mock
 }
 
-func (r *RegionsService) GetRegions() ([]resources.ResourceResponse[resources.Region], error) {
+func (r *RegionsService) GetRegionsWithContext() (ctx aws.Context, in []resources.ResourceResponse[resources.Region], e error) {
 	args := r.Called()
-	return args.Get(0).(([]resources.ResourceResponse[resources.Region])), args.Error(1)
+	return ctx, args.Get(0).(([]resources.ResourceResponse[resources.Region])), args.Error(1)
 }
 
 type EC2Mock struct {
 	mock.Mock
 }
 
-func (e *EC2Mock) DescribeRegions(in *ec2.DescribeRegionsInput) (*ec2.DescribeRegionsOutput, error) {
+func (e *EC2Mock) DescribeRegionsWithContext(ctx aws.Context, in *ec2.DescribeRegionsInput, opts ...request.Option) (*ec2.DescribeRegionsOutput, error) {
 	args := e.Called()
 	return args.Get(0).(*ec2.DescribeRegionsOutput), args.Error(1)
 }

--- a/pkg/tsdb/cloudwatch/mocks/regions.go
+++ b/pkg/tsdb/cloudwatch/mocks/regions.go
@@ -14,7 +14,7 @@ type RegionsService struct {
 	mock.Mock
 }
 
-func (r *RegionsService) GetRegionsWithContext(ctx context.Context) (in []resources.ResourceResponse[resources.Region], e error) {
+func (r *RegionsService) GetRegions(ctx context.Context) (in []resources.ResourceResponse[resources.Region], e error) {
 	args := r.Called()
 	return args.Get(0).(([]resources.ResourceResponse[resources.Region])), args.Error(1)
 }

--- a/pkg/tsdb/cloudwatch/models/api.go
+++ b/pkg/tsdb/cloudwatch/models/api.go
@@ -46,7 +46,7 @@ type AccountsProvider interface {
 }
 
 type RegionsAPIProvider interface {
-	GetRegions() ([]resources.ResourceResponse[resources.Region], error)
+	GetRegionsWithContext(ctx context.Context) ([]resources.ResourceResponse[resources.Region], error)
 }
 
 // Clients
@@ -70,6 +70,6 @@ type OAMAPIProvider interface {
 }
 
 type EC2APIProvider interface {
-	DescribeRegions(in *ec2.DescribeRegionsInput) (*ec2.DescribeRegionsOutput, error)
+	DescribeRegionsWithContext(ctx context.Context, in *ec2.DescribeRegionsInput, opts ...request.Option) (*ec2.DescribeRegionsOutput, error)
 	DescribeInstancesPagesWithContext(ctx context.Context, in *ec2.DescribeInstancesInput, fn func(*ec2.DescribeInstancesOutput, bool) bool, opts ...request.Option) error
 }

--- a/pkg/tsdb/cloudwatch/models/api.go
+++ b/pkg/tsdb/cloudwatch/models/api.go
@@ -46,7 +46,7 @@ type AccountsProvider interface {
 }
 
 type RegionsAPIProvider interface {
-	GetRegionsWithContext(ctx context.Context) ([]resources.ResourceResponse[resources.Region], error)
+	GetRegions(ctx context.Context) ([]resources.ResourceResponse[resources.Region], error)
 }
 
 // Clients

--- a/pkg/tsdb/cloudwatch/routes/regions.go
+++ b/pkg/tsdb/cloudwatch/routes/regions.go
@@ -25,7 +25,7 @@ func RegionsHandler(ctx context.Context, pluginCtx backend.PluginContext, reqCtx
 		return nil, models.NewHttpError("Error in Regions Handler when connecting to aws", http.StatusInternalServerError, err)
 	}
 
-	regions, err := service.GetRegionsWithContext(ctx)
+	regions, err := service.GetRegions(ctx)
 	if err != nil {
 		return nil, models.NewHttpError("Error in Regions Handler while fetching regions", http.StatusInternalServerError, err)
 	}

--- a/pkg/tsdb/cloudwatch/routes/regions.go
+++ b/pkg/tsdb/cloudwatch/routes/regions.go
@@ -25,7 +25,7 @@ func RegionsHandler(ctx context.Context, pluginCtx backend.PluginContext, reqCtx
 		return nil, models.NewHttpError("Error in Regions Handler when connecting to aws", http.StatusInternalServerError, err)
 	}
 
-	regions, err := service.GetRegions()
+	regions, err := service.GetRegionsWithContext(ctx)
 	if err != nil {
 		return nil, models.NewHttpError("Error in Regions Handler while fetching regions", http.StatusInternalServerError, err)
 	}

--- a/pkg/tsdb/cloudwatch/routes/regions_test.go
+++ b/pkg/tsdb/cloudwatch/routes/regions_test.go
@@ -26,7 +26,7 @@ func TestRegionsRoute(t *testing.T) {
 		newRegionsService = func(_ context.Context, pluginCtx backend.PluginContext, reqCtxFactory models.RequestContextFactoryFunc, region string) (models.RegionsAPIProvider, error) {
 			return &mockRegionService, nil
 		}
-		mockRegionService.On("GetRegionsWithContext", mock.Anything).Return([]resources.ResourceResponse[resources.Region]{{
+		mockRegionService.On("GetRegions", mock.Anything).Return([]resources.ResourceResponse[resources.Region]{{
 			Value: resources.Region{
 				Name: "us-east-1",
 			},
@@ -72,7 +72,7 @@ func TestRegionsRoute(t *testing.T) {
 		newRegionsService = func(_ context.Context, pluginCtx backend.PluginContext, reqCtxFactory models.RequestContextFactoryFunc, region string) (models.RegionsAPIProvider, error) {
 			return &mockRegionService, nil
 		}
-		mockRegionService.On("GetRegionsWithContext", mock.Anything).Return([]resources.ResourceResponse[resources.Region](nil), errors.New("aws is having some kind of outage")).Once()
+		mockRegionService.On("GetRegions", mock.Anything).Return([]resources.ResourceResponse[resources.Region](nil), errors.New("aws is having some kind of outage")).Once()
 		rr := httptest.NewRecorder()
 		handler := http.HandlerFunc(ResourceRequestMiddleware(RegionsHandler, logger, nil))
 		req := httptest.NewRequest("GET", `/regions`, nil)

--- a/pkg/tsdb/cloudwatch/routes/regions_test.go
+++ b/pkg/tsdb/cloudwatch/routes/regions_test.go
@@ -26,7 +26,7 @@ func TestRegionsRoute(t *testing.T) {
 		newRegionsService = func(_ context.Context, pluginCtx backend.PluginContext, reqCtxFactory models.RequestContextFactoryFunc, region string) (models.RegionsAPIProvider, error) {
 			return &mockRegionService, nil
 		}
-		mockRegionService.On("GetRegions", mock.Anything).Return([]resources.ResourceResponse[resources.Region]{{
+		mockRegionService.On("GetRegionsWithContext", mock.Anything).Return([]resources.ResourceResponse[resources.Region]{{
 			Value: resources.Region{
 				Name: "us-east-1",
 			},
@@ -72,7 +72,7 @@ func TestRegionsRoute(t *testing.T) {
 		newRegionsService = func(_ context.Context, pluginCtx backend.PluginContext, reqCtxFactory models.RequestContextFactoryFunc, region string) (models.RegionsAPIProvider, error) {
 			return &mockRegionService, nil
 		}
-		mockRegionService.On("GetRegions", mock.Anything).Return([]resources.ResourceResponse[resources.Region](nil), errors.New("aws is having some kind of outage")).Once()
+		mockRegionService.On("GetRegionsWithContext", mock.Anything).Return([]resources.ResourceResponse[resources.Region](nil), errors.New("aws is having some kind of outage")).Once()
 		rr := httptest.NewRecorder()
 		handler := http.HandlerFunc(ResourceRequestMiddleware(RegionsHandler, logger, nil))
 		req := httptest.NewRequest("GET", `/regions`, nil)

--- a/pkg/tsdb/cloudwatch/services/regions.go
+++ b/pkg/tsdb/cloudwatch/services/regions.go
@@ -31,7 +31,7 @@ func mergeEC2RegionsAndConstantRegions(regions map[string]struct{}, ec2Regions [
 	}
 }
 
-func (r *RegionsService) GetRegionsWithContext(ctx context.Context) ([]resources.ResourceResponse[resources.Region], error) {
+func (r *RegionsService) GetRegions(ctx context.Context) ([]resources.ResourceResponse[resources.Region], error) {
 	regions := constants.Regions()
 
 	result := make([]resources.ResourceResponse[resources.Region], 0)

--- a/pkg/tsdb/cloudwatch/services/regions.go
+++ b/pkg/tsdb/cloudwatch/services/regions.go
@@ -1,11 +1,11 @@
 package services
 
 import (
+	"context"
 	"sort"
 
-	"github.com/grafana/grafana/pkg/infra/log"
-
 	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/tsdb/cloudwatch/constants"
 	"github.com/grafana/grafana/pkg/tsdb/cloudwatch/models"
 	"github.com/grafana/grafana/pkg/tsdb/cloudwatch/models/resources"
@@ -31,12 +31,12 @@ func mergeEC2RegionsAndConstantRegions(regions map[string]struct{}, ec2Regions [
 	}
 }
 
-func (r *RegionsService) GetRegions() ([]resources.ResourceResponse[resources.Region], error) {
+func (r *RegionsService) GetRegionsWithContext(ctx context.Context) ([]resources.ResourceResponse[resources.Region], error) {
 	regions := constants.Regions()
 
 	result := make([]resources.ResourceResponse[resources.Region], 0)
 
-	ec2Regions, err := r.DescribeRegions(&ec2.DescribeRegionsInput{})
+	ec2Regions, err := r.DescribeRegionsWithContext(ctx, &ec2.DescribeRegionsInput{})
 	// we ignore this error and always send default regions
 	// we only fetch incase a user has enabled additional regions
 	// but we still log it in case the user is expecting to fetch regions specific to their account and are unable to

--- a/pkg/tsdb/cloudwatch/services/regions_test.go
+++ b/pkg/tsdb/cloudwatch/services/regions_test.go
@@ -25,7 +25,7 @@ func TestRegions(t *testing.T) {
 		}
 		ec2Mock := &mocks.EC2Mock{}
 		ec2Mock.On("DescribeRegionsWithContext").Return(mockRegions, nil)
-		regions, err := NewRegionsService(ec2Mock, testLogger).GetRegionsWithContext(context.Background())
+		regions, err := NewRegionsService(ec2Mock, testLogger).GetRegions(context.Background())
 		assert.NoError(t, err)
 		assert.Contains(t, regions, resources.ResourceResponse[resources.Region]{
 			Value: resources.Region{
@@ -45,7 +45,7 @@ func TestRegions(t *testing.T) {
 			Regions: []*ec2.Region{},
 		}
 		ec2Mock.On("DescribeRegionsWithContext").Return(mockRegions, assert.AnError)
-		regions, err := NewRegionsService(ec2Mock, testLogger).GetRegionsWithContext(context.Background())
+		regions, err := NewRegionsService(ec2Mock, testLogger).GetRegions(context.Background())
 		assert.NoError(t, err)
 		assert.Contains(t, regions, resources.ResourceResponse[resources.Region]{
 			Value: resources.Region{

--- a/pkg/tsdb/cloudwatch/services/regions_test.go
+++ b/pkg/tsdb/cloudwatch/services/regions_test.go
@@ -1,6 +1,7 @@
 package services
 
 import (
+	"context"
 	"testing"
 
 	"github.com/aws/aws-sdk-go/service/ec2"
@@ -24,7 +25,7 @@ func TestRegions(t *testing.T) {
 		}
 		ec2Mock := &mocks.EC2Mock{}
 		ec2Mock.On("DescribeRegionsWithContext").Return(mockRegions, nil)
-		regions, err := NewRegionsService(ec2Mock, testLogger).GetRegionsWithContext(ctx)
+		regions, err := NewRegionsService(ec2Mock, testLogger).GetRegionsWithContext(context.Background())
 		assert.NoError(t, err)
 		assert.Contains(t, regions, resources.ResourceResponse[resources.Region]{
 			Value: resources.Region{
@@ -44,7 +45,7 @@ func TestRegions(t *testing.T) {
 			Regions: []*ec2.Region{},
 		}
 		ec2Mock.On("DescribeRegionsWithContext").Return(mockRegions, assert.AnError)
-		regions, err := NewRegionsService(ec2Mock, testLogger).GetRegionsWithContext(ctx)
+		regions, err := NewRegionsService(ec2Mock, testLogger).GetRegionsWithContext(context.Background())
 		assert.NoError(t, err)
 		assert.Contains(t, regions, resources.ResourceResponse[resources.Region]{
 			Value: resources.Region{

--- a/pkg/tsdb/cloudwatch/services/regions_test.go
+++ b/pkg/tsdb/cloudwatch/services/regions_test.go
@@ -23,8 +23,8 @@ func TestRegions(t *testing.T) {
 			},
 		}
 		ec2Mock := &mocks.EC2Mock{}
-		ec2Mock.On("DescribeRegions").Return(mockRegions, nil)
-		regions, err := NewRegionsService(ec2Mock, testLogger).GetRegions()
+		ec2Mock.On("DescribeRegionsWithContext").Return(mockRegions, nil)
+		regions, err := NewRegionsService(ec2Mock, testLogger).GetRegionsWithContext(ctx)
 		assert.NoError(t, err)
 		assert.Contains(t, regions, resources.ResourceResponse[resources.Region]{
 			Value: resources.Region{
@@ -43,8 +43,8 @@ func TestRegions(t *testing.T) {
 		mockRegions := &ec2.DescribeRegionsOutput{
 			Regions: []*ec2.Region{},
 		}
-		ec2Mock.On("DescribeRegions").Return(mockRegions, assert.AnError)
-		regions, err := NewRegionsService(ec2Mock, testLogger).GetRegions()
+		ec2Mock.On("DescribeRegionsWithContext").Return(mockRegions, assert.AnError)
+		regions, err := NewRegionsService(ec2Mock, testLogger).GetRegionsWithContext(ctx)
 		assert.NoError(t, err)
 		assert.Contains(t, regions, resources.ResourceResponse[resources.Region]{
 			Value: resources.Region{

--- a/pkg/tsdb/cloudwatch/test_utils.go
+++ b/pkg/tsdb/cloudwatch/test_utils.go
@@ -125,7 +125,7 @@ type mockEC2Client struct {
 	mock.Mock
 }
 
-func (c *mockEC2Client) DescribeRegions(in *ec2.DescribeRegionsInput) (*ec2.DescribeRegionsOutput, error) {
+func (c *mockEC2Client) DescribeRegionsWithContext(ctx aws.Context, in *ec2.DescribeRegionsInput, option ...request.Option) (*ec2.DescribeRegionsOutput, error) {
 	args := c.Called(in)
 	return args.Get(0).(*ec2.DescribeRegionsOutput), args.Error(1)
 }
@@ -143,7 +143,7 @@ type oldEC2Client struct {
 	reservations []*ec2.Reservation
 }
 
-func (c oldEC2Client) DescribeRegions(*ec2.DescribeRegionsInput) (*ec2.DescribeRegionsOutput, error) {
+func (c oldEC2Client) DescribeRegionsWithContext(ctx aws.Context, in *ec2.DescribeRegionsInput, option ...request.Option) (*ec2.DescribeRegionsOutput, error) {
 	regions := []*ec2.Region{}
 	for _, region := range c.regions {
 		regions = append(regions, &ec2.Region{


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

In the current way, DescribeRegions is used which doesn't allow canceling the request if the context changes. Using DescribeRegionsWithContext is the preferred way.

The test is run with the command go test -v ./pkg/tsdb/cloudwatch/ and is successful.

**Why do we need this feature?**

Using context in the go-based application is always the preferred way wherever it is possible to do so. With this change, we are making the application aware of context when it calls DescribeRegionsWithContext.

**Who is this feature for?**

Users

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Contributes to #75498

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
