### PR TITLE
Use context version for ListMetricsPages function

### DIFF
--- a/pkg/tsdb/cloudwatch/clients/metrics.go
+++ b/pkg/tsdb/cloudwatch/clients/metrics.go
@@ -22,7 +22,7 @@ func NewMetricsClient(api models.CloudWatchMetricsAPIProvider, config *setting.C
 func (l *metricsClient) ListMetricsWithPageLimit(params *cloudwatch.ListMetricsInput) ([]resources.MetricResponse, error) {
 	var cloudWatchMetrics []resources.MetricResponse
 	pageNum := 0
-	err := l.ListMetricsPages(params, func(page *cloudwatch.ListMetricsOutput, lastPage bool) bool {
+	err := l.ListMetricsPagesWithContext(ctx, params, func(page *cloudwatch.ListMetricsOutput, lastPage bool) bool {
 		pageNum++
 		metrics.MAwsCloudWatchListMetrics.Inc()
 		metrics, err := awsutil.ValuesAtPath(page, "Metrics")

--- a/pkg/tsdb/cloudwatch/cloudwatch_test.go
+++ b/pkg/tsdb/cloudwatch/cloudwatch_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws"
 	awsclient "github.com/aws/aws-sdk-go/aws/client"
+	"github.com/aws/aws-sdk-go/aws/request"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/cloudwatch"
 	"github.com/aws/aws-sdk-go/service/cloudwatchlogs"
@@ -153,7 +154,7 @@ func Test_CheckHealth(t *testing.T) {
 
 	t.Run("successfully queries logs, fails during metrics query", func(t *testing.T) {
 		client = fakeCheckHealthClient{
-			listMetricsPages: func(input *cloudwatch.ListMetricsInput, fn func(*cloudwatch.ListMetricsOutput, bool) bool) error {
+			listMetricsPagesWithContext: func(ctx aws.Context, input *cloudwatch.ListMetricsInput, fn func(*cloudwatch.ListMetricsOutput, bool) bool, opts ...request.Option) error {
 				return fmt.Errorf("some list metrics error")
 			}}
 

--- a/pkg/tsdb/cloudwatch/get_dimension_values_for_wildcards_test.go
+++ b/pkg/tsdb/cloudwatch/get_dimension_values_for_wildcards_test.go
@@ -55,7 +55,7 @@ func TestGetDimensionValuesForWildcards(t *testing.T) {
 			{MetricName: utils.Pointer("Test_MetricName3"), Dimensions: []*cloudwatch.Dimension{{Name: utils.Pointer("Test_DimensionName1"), Value: utils.Pointer("Value4")}}},
 			{MetricName: utils.Pointer("Test_MetricName4"), Dimensions: []*cloudwatch.Dimension{{Name: utils.Pointer("Test_DimensionName1"), Value: utils.Pointer("Value2")}}},
 		}}
-		api.On("ListMetricsPages").Return(nil)
+		api.On("ListMetricsPagesWithContext", ctx, &cloudwatch.ListMetricsInput{}).Return(nil)
 		queries, err := executor.getDimensionValuesForWildcards(pluginCtx, "us-east-1", api, []*models.CloudWatchQuery{query}, tagValueCache, logger)
 		assert.Nil(t, err)
 		assert.Len(t, queries, 1)
@@ -71,7 +71,7 @@ func TestGetDimensionValuesForWildcards(t *testing.T) {
 		api := &mocks.MetricsAPI{Metrics: []*cloudwatch.Metric{
 			{MetricName: utils.Pointer("Test_MetricName"), Dimensions: []*cloudwatch.Dimension{{Name: utils.Pointer("Test_DimensionName"), Value: utils.Pointer("Value")}}},
 		}}
-		api.On("ListMetricsPages").Return(nil)
+		api.On("ListMetricsPagesWithContext", ctx, &cloudwatch.ListMetricsInput{}).Return(nil)
 		_, err := executor.getDimensionValuesForWildcards(pluginCtx, "us-east-1", api, []*models.CloudWatchQuery{query}, tagValueCache, logger)
 		assert.Nil(t, err)
 		// make sure the original query wasn't altered
@@ -91,7 +91,7 @@ func TestGetDimensionValuesForWildcards(t *testing.T) {
 		query.Dimensions = map[string][]string{"Test_DimensionName2": {"*"}}
 		query.MatchExact = false
 		api := &mocks.MetricsAPI{Metrics: []*cloudwatch.Metric{}}
-		api.On("ListMetricsPages").Return(nil)
+		api.On("ListMetricsPagesWithContext", ctx, &cloudwatch.ListMetricsInput{}).Return(nil)
 		queries, err := executor.getDimensionValuesForWildcards(pluginCtx, "us-east-1", api, []*models.CloudWatchQuery{query}, tagValueCache, logger)
 		assert.Nil(t, err)
 		assert.Len(t, queries, 1)
@@ -102,7 +102,7 @@ func TestGetDimensionValuesForWildcards(t *testing.T) {
 		api.Metrics = []*cloudwatch.Metric{
 			{MetricName: utils.Pointer("Test_MetricName"), Dimensions: []*cloudwatch.Dimension{{Name: utils.Pointer("Test_DimensionName2"), Value: utils.Pointer("Value")}}},
 		}
-		api.On("ListMetricsPages").Return(nil)
+		api.On("ListMetricsPagesWithContext", ctx, &cloudwatch.ListMetricsInput{}).Return(nil)
 		queries, err = executor.getDimensionValuesForWildcards(pluginCtx, "us-east-1", api, []*models.CloudWatchQuery{query}, tagValueCache, logger)
 		assert.Nil(t, err)
 		assert.Len(t, queries, 1)

--- a/pkg/tsdb/cloudwatch/mocks/cloudwatch_metric_api.go
+++ b/pkg/tsdb/cloudwatch/mocks/cloudwatch_metric_api.go
@@ -14,7 +14,7 @@ type FakeMetricsAPI struct {
 	MetricsPerPage int
 }
 
-func (c *FakeMetricsAPI) ListMetricsPages(input *cloudwatch.ListMetricsInput, fn func(*cloudwatch.ListMetricsOutput, bool) bool) error {
+func (c *FakeMetricsAPI) ListMetricsPagesWithContext(ctx aws.Context, input *cloudwatch.ListMetricsInput, fn func(*cloudwatch.ListMetricsOutput, bool) bool, opts ...request.Option) error {
 	if c.MetricsPerPage == 0 {
 		c.MetricsPerPage = 1000
 	}
@@ -62,7 +62,7 @@ func (m *MetricsAPI) GetMetricDataWithContext(ctx aws.Context, input *cloudwatch
 	return args.Get(0).(*cloudwatch.GetMetricDataOutput), args.Error(1)
 }
 
-func (m *MetricsAPI) ListMetricsPages(input *cloudwatch.ListMetricsInput, fn func(*cloudwatch.ListMetricsOutput, bool) bool) error {
+func (m *MetricsAPI) ListMetricsPagesWithContext(ctx aws.Context, input *cloudwatch.ListMetricsInput, fn func(*cloudwatch.ListMetricsOutput, bool) bool, opts ...request.Option) error {
 	fn(&cloudwatch.ListMetricsOutput{
 		Metrics: m.Metrics,
 	}, true)

--- a/pkg/tsdb/cloudwatch/models/api.go
+++ b/pkg/tsdb/cloudwatch/models/api.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"net/url"
 
+	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/request"
 	"github.com/aws/aws-sdk-go/service/cloudwatch"
 	"github.com/aws/aws-sdk-go/service/cloudwatchlogs"
@@ -20,13 +21,14 @@ type RequestContextFactoryFunc func(ctx context.Context, pluginCtx backend.Plugi
 type RouteHandlerFunc func(ctx context.Context, pluginCtx backend.PluginContext, reqContextFactory RequestContextFactoryFunc, parameters url.Values) ([]byte, *HttpError)
 
 type RequestContext struct {
-	MetricsClientProvider MetricsClientProvider
-	LogsAPIProvider       CloudWatchLogsAPIProvider
-	OAMAPIProvider        OAMAPIProvider
-	EC2APIProvider        EC2APIProvider
-	Settings              CloudWatchSettings
-	Features              featuremgmt.FeatureToggles
-	Logger                log.Logger
+	MetricsClientProvider        MetricsClientProvider
+	LogsAPIProvider              CloudWatchLogsAPIProvider
+	OAMAPIProvider               OAMAPIProvider
+	EC2APIProvider               EC2APIProvider
+	CloudWatchMetricsAPIProvider ListMetricsPagesWithContext
+	Settings                     CloudWatchSettings
+	Features                     featuremgmt.FeatureToggles
+	Logger                       log.Logger
 }
 
 // Services
@@ -56,7 +58,7 @@ type MetricsClientProvider interface {
 
 // APIs - instead of using the API defined in the services within the aws-sdk-go directly, specify a subset of the API with methods that are actually used in a service or a client
 type CloudWatchMetricsAPIProvider interface {
-	ListMetricsPages(*cloudwatch.ListMetricsInput, func(*cloudwatch.ListMetricsOutput, bool) bool) error
+	ListMetricsPagesWithContext(ctx aws.Context, input *cloudwatch.ListMetricsInput, fn func(*cloudwatch.ListMetricsOutput, bool) bool, opts ...request.Option) error
 }
 
 type CloudWatchLogsAPIProvider interface {

--- a/pkg/tsdb/cloudwatch/test_utils.go
+++ b/pkg/tsdb/cloudwatch/test_utils.go
@@ -196,13 +196,13 @@ func (c fakeRGTAClient) GetResourcesPages(in *resourcegroupstaggingapi.GetResour
 }
 
 type fakeCheckHealthClient struct {
-	listMetricsPages  func(input *cloudwatch.ListMetricsInput, fn func(*cloudwatch.ListMetricsOutput, bool) bool) error
-	describeLogGroups func(input *cloudwatchlogs.DescribeLogGroupsInput) (*cloudwatchlogs.DescribeLogGroupsOutput, error)
+	listMetricsPagesWithContext func(ctx aws.Context, input *cloudwatch.ListMetricsInput, fn func(*cloudwatch.ListMetricsOutput, bool) bool, opts ...request.Option) error
+	describeLogGroups           func(input *cloudwatchlogs.DescribeLogGroupsInput) (*cloudwatchlogs.DescribeLogGroupsOutput, error)
 }
 
-func (c fakeCheckHealthClient) ListMetricsPages(input *cloudwatch.ListMetricsInput, fn func(*cloudwatch.ListMetricsOutput, bool) bool) error {
-	if c.listMetricsPages != nil {
-		return c.listMetricsPages(input, fn)
+func (c fakeCheckHealthClient) ListMetricsPagesWithContext(ctx aws.Context, input *cloudwatch.ListMetricsInput, fn func(*cloudwatch.ListMetricsOutput, bool) bool, opts ...request.Option) error {
+	if c.listMetricsPagesWithContext != nil {
+		return c.listMetricsPagesWithContext(ctx, input, fn, opts...)
 	}
 	return nil
 }

--- a/pkg/tsdb/cloudwatch/time_series_query_test.go
+++ b/pkg/tsdb/cloudwatch/time_series_query_test.go
@@ -419,7 +419,7 @@ func Test_QueryData_response_data_frame_name_is_always_response_label(t *testing
 	api := mocks.MetricsAPI{Metrics: []*cloudwatch.Metric{
 		{MetricName: aws.String(""), Dimensions: []*cloudwatch.Dimension{{Name: aws.String("InstanceId"), Value: aws.String("i-00645d91ed77d87ac")}}},
 	}}
-	api.On("ListMetricsPages").Return(nil)
+	api.On("ListMetricsPagesWithContext", ctx, &cloudwatch.ListMetricsInput{}).Return(nil)
 
 	NewCWClient = func(sess *session.Session) cloudwatchiface.CloudWatchAPI {
 		return &api


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

CloudWatch: Use the WithContext versions of ListMetricsPages functions for resource handlers

**Why do we need this feature?**

CloudWatch resource handlers should use the 'WithContext' versions of API calls like ListMetricsPages to make requests cancelable.


**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #75498 

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
