### PR TITLE
CloudWatch: Use context in aws ListMetricsPages

### DIFF
--- a/pkg/tsdb/cloudwatch/clients/metrics.go
+++ b/pkg/tsdb/cloudwatch/clients/metrics.go
@@ -1,6 +1,8 @@
 package clients
 
 import (
+	"context"
+
 	"github.com/aws/aws-sdk-go/aws/awsutil"
 	"github.com/aws/aws-sdk-go/service/cloudwatch"
 	"github.com/grafana/grafana/pkg/infra/metrics"
@@ -19,10 +21,10 @@ func NewMetricsClient(api models.CloudWatchMetricsAPIProvider, config *setting.C
 	return &metricsClient{CloudWatchMetricsAPIProvider: api, config: config}
 }
 
-func (l *metricsClient) ListMetricsWithPageLimit(params *cloudwatch.ListMetricsInput) ([]resources.MetricResponse, error) {
+func (l *metricsClient) ListMetricsWithPageLimit(ctx context.Context, params *cloudwatch.ListMetricsInput) ([]resources.MetricResponse, error) {
 	var cloudWatchMetrics []resources.MetricResponse
 	pageNum := 0
-	err := l.ListMetricsPages(params, func(page *cloudwatch.ListMetricsOutput, lastPage bool) bool {
+	err := l.ListMetricsPagesWithContext(ctx, params, func(page *cloudwatch.ListMetricsOutput, lastPage bool) bool {
 		pageNum++
 		metrics.MAwsCloudWatchListMetrics.Inc()
 		metrics, err := awsutil.ValuesAtPath(page, "Metrics")

--- a/pkg/tsdb/cloudwatch/clients/metrics_test.go
+++ b/pkg/tsdb/cloudwatch/clients/metrics_test.go
@@ -1,6 +1,7 @@
 package clients
 
 import (
+	"context"
 	"testing"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -25,12 +26,13 @@ func TestMetricsClient(t *testing.T) {
 		{MetricName: aws.String("Test_MetricName9")},
 		{MetricName: aws.String("Test_MetricName10")},
 	}
+	ctx := context.Background()
 
 	t.Run("List Metrics and page limit is reached", func(t *testing.T) {
 		pageLimit := 3
 		fakeApi := &mocks.FakeMetricsAPI{Metrics: metrics, MetricsPerPage: 2}
 		client := NewMetricsClient(fakeApi, &setting.Cfg{AWSListMetricsPageLimit: pageLimit})
-		response, err := client.ListMetricsWithPageLimit(&cloudwatch.ListMetricsInput{})
+		response, err := client.ListMetricsWithPageLimit(ctx, &cloudwatch.ListMetricsInput{})
 		require.NoError(t, err)
 
 		expectedMetrics := fakeApi.MetricsPerPage * pageLimit
@@ -42,7 +44,7 @@ func TestMetricsClient(t *testing.T) {
 		fakeApi := &mocks.FakeMetricsAPI{Metrics: metrics}
 		client := NewMetricsClient(fakeApi, &setting.Cfg{AWSListMetricsPageLimit: pageLimit})
 
-		response, err := client.ListMetricsWithPageLimit(&cloudwatch.ListMetricsInput{})
+		response, err := client.ListMetricsWithPageLimit(ctx, &cloudwatch.ListMetricsInput{})
 		require.NoError(t, err)
 
 		assert.Equal(t, len(metrics), len(response))
@@ -56,7 +58,7 @@ func TestMetricsClient(t *testing.T) {
 		}, OwningAccounts: []*string{aws.String("1234567890"), aws.String("1234567890"), aws.String("1234567895")}}
 		client := NewMetricsClient(fakeApi, &setting.Cfg{AWSListMetricsPageLimit: 100})
 
-		response, err := client.ListMetricsWithPageLimit(&cloudwatch.ListMetricsInput{IncludeLinkedAccounts: aws.Bool(true)})
+		response, err := client.ListMetricsWithPageLimit(ctx, &cloudwatch.ListMetricsInput{IncludeLinkedAccounts: aws.Bool(true)})
 		require.NoError(t, err)
 		expected := []resources.MetricResponse{
 			{Metric: &cloudwatch.Metric{MetricName: aws.String("Test_MetricName1")}, AccountId: stringPtr("1234567890")},
@@ -70,7 +72,7 @@ func TestMetricsClient(t *testing.T) {
 		fakeApi := &mocks.FakeMetricsAPI{Metrics: []*cloudwatch.Metric{{MetricName: aws.String("Test_MetricName1")}}, OwningAccounts: []*string{aws.String("1234567890")}}
 		client := NewMetricsClient(fakeApi, &setting.Cfg{AWSListMetricsPageLimit: 100})
 
-		response, err := client.ListMetricsWithPageLimit(&cloudwatch.ListMetricsInput{IncludeLinkedAccounts: aws.Bool(false)})
+		response, err := client.ListMetricsWithPageLimit(ctx, &cloudwatch.ListMetricsInput{IncludeLinkedAccounts: aws.Bool(false)})
 		require.NoError(t, err)
 		assert.Nil(t, response[0].AccountId)
 	})

--- a/pkg/tsdb/cloudwatch/cloudwatch.go
+++ b/pkg/tsdb/cloudwatch/cloudwatch.go
@@ -226,7 +226,7 @@ func (e *cloudWatchExecutor) checkHealthMetrics(ctx context.Context, pluginCtx b
 		return err
 	}
 	metricClient := clients.NewMetricsClient(NewMetricsAPI(session), e.cfg)
-	_, err = metricClient.ListMetricsWithPageLimit(params)
+	_, err = metricClient.ListMetricsWithPageLimit(ctx, params)
 	return err
 }
 

--- a/pkg/tsdb/cloudwatch/get_dimension_values_for_wildcards.go
+++ b/pkg/tsdb/cloudwatch/get_dimension_values_for_wildcards.go
@@ -1,6 +1,7 @@
 package cloudwatch
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
@@ -13,7 +14,7 @@ import (
 )
 
 // getDimensionValues gets the actual dimension values for dimensions with a wildcard
-func (e *cloudWatchExecutor) getDimensionValuesForWildcards(pluginCtx backend.PluginContext, region string,
+func (e *cloudWatchExecutor) getDimensionValuesForWildcards(ctx context.Context, pluginCtx backend.PluginContext, region string,
 	client models.CloudWatchMetricsAPIProvider, origQueries []*models.CloudWatchQuery, tagValueCache *cache.Cache, logger log.Logger) ([]*models.CloudWatchQuery, error) {
 	metricsClient := clients.NewMetricsClient(client, e.cfg)
 	service := services.NewListMetricsService(metricsClient)
@@ -50,7 +51,7 @@ func (e *cloudWatchExecutor) getDimensionValuesForWildcards(pluginCtx backend.Pl
 				DimensionKey: dimensionKey,
 			}
 
-			dimensions, err := service.GetDimensionValuesByDimensionFilter(request)
+			dimensions, err := service.GetDimensionValuesByDimensionFilter(ctx, request)
 			if err != nil {
 				return nil, err
 			}

--- a/pkg/tsdb/cloudwatch/get_dimension_values_for_wildcards_test.go
+++ b/pkg/tsdb/cloudwatch/get_dimension_values_for_wildcards_test.go
@@ -1,6 +1,7 @@
 package cloudwatch
 
 import (
+	"context"
 	"testing"
 	"time"
 
@@ -17,6 +18,7 @@ import (
 func TestGetDimensionValuesForWildcards(t *testing.T) {
 	logger := &logtest.Fake{}
 	executor := &cloudWatchExecutor{}
+	ctx := context.Background()
 	pluginCtx := backend.PluginContext{
 		DataSourceInstanceSettings: &backend.DataSourceInstanceSettings{ID: 1, Updated: time.Now()},
 	}
@@ -26,7 +28,7 @@ func TestGetDimensionValuesForWildcards(t *testing.T) {
 		query := getBaseQuery()
 		query.MetricName = "Test_MetricName1"
 		query.Dimensions = map[string][]string{"Test_DimensionName1": {"Value1"}}
-		queries, err := executor.getDimensionValuesForWildcards(pluginCtx, "us-east-1", nil, []*models.CloudWatchQuery{query}, tagValueCache, logger)
+		queries, err := executor.getDimensionValuesForWildcards(ctx, pluginCtx, "us-east-1", nil, []*models.CloudWatchQuery{query}, tagValueCache, logger)
 		assert.Nil(t, err)
 		assert.Len(t, queries, 1)
 		assert.NotNil(t, queries[0].Dimensions["Test_DimensionName1"], 1)
@@ -37,7 +39,7 @@ func TestGetDimensionValuesForWildcards(t *testing.T) {
 		query := getBaseQuery()
 		query.MetricName = "Test_MetricName1"
 		query.Dimensions = map[string][]string{"Test_DimensionName1": {"*"}}
-		queries, err := executor.getDimensionValuesForWildcards(pluginCtx, "us-east-1", nil, []*models.CloudWatchQuery{query}, tagValueCache, logger)
+		queries, err := executor.getDimensionValuesForWildcards(ctx, pluginCtx, "us-east-1", nil, []*models.CloudWatchQuery{query}, tagValueCache, logger)
 		assert.Nil(t, err)
 		assert.Len(t, queries, 1)
 		assert.NotNil(t, queries[0].Dimensions["Test_DimensionName1"])
@@ -55,8 +57,8 @@ func TestGetDimensionValuesForWildcards(t *testing.T) {
 			{MetricName: utils.Pointer("Test_MetricName3"), Dimensions: []*cloudwatch.Dimension{{Name: utils.Pointer("Test_DimensionName1"), Value: utils.Pointer("Value4")}}},
 			{MetricName: utils.Pointer("Test_MetricName4"), Dimensions: []*cloudwatch.Dimension{{Name: utils.Pointer("Test_DimensionName1"), Value: utils.Pointer("Value2")}}},
 		}}
-		api.On("ListMetricsPages").Return(nil)
-		queries, err := executor.getDimensionValuesForWildcards(pluginCtx, "us-east-1", api, []*models.CloudWatchQuery{query}, tagValueCache, logger)
+		api.On("ListMetricsPagesWithContext").Return(nil)
+		queries, err := executor.getDimensionValuesForWildcards(ctx, pluginCtx, "us-east-1", api, []*models.CloudWatchQuery{query}, tagValueCache, logger)
 		assert.Nil(t, err)
 		assert.Len(t, queries, 1)
 		assert.Equal(t, map[string][]string{"Test_DimensionName1": {"Value1", "Value2", "Value3", "Value4"}}, queries[0].Dimensions)
@@ -71,14 +73,14 @@ func TestGetDimensionValuesForWildcards(t *testing.T) {
 		api := &mocks.MetricsAPI{Metrics: []*cloudwatch.Metric{
 			{MetricName: utils.Pointer("Test_MetricName"), Dimensions: []*cloudwatch.Dimension{{Name: utils.Pointer("Test_DimensionName"), Value: utils.Pointer("Value")}}},
 		}}
-		api.On("ListMetricsPages").Return(nil)
-		_, err := executor.getDimensionValuesForWildcards(pluginCtx, "us-east-1", api, []*models.CloudWatchQuery{query}, tagValueCache, logger)
+		api.On("ListMetricsPagesWithContext").Return(nil)
+		_, err := executor.getDimensionValuesForWildcards(ctx, pluginCtx, "us-east-1", api, []*models.CloudWatchQuery{query}, tagValueCache, logger)
 		assert.Nil(t, err)
 		// make sure the original query wasn't altered
 		assert.Equal(t, map[string][]string{"Test_DimensionName": {"*"}}, query.Dimensions)
 
 		//setting the api to nil confirms that it's using the cached value
-		queries, err := executor.getDimensionValuesForWildcards(pluginCtx, "us-east-1", nil, []*models.CloudWatchQuery{query}, tagValueCache, logger)
+		queries, err := executor.getDimensionValuesForWildcards(ctx, pluginCtx, "us-east-1", nil, []*models.CloudWatchQuery{query}, tagValueCache, logger)
 		assert.Nil(t, err)
 		assert.Len(t, queries, 1)
 		assert.Equal(t, map[string][]string{"Test_DimensionName": {"Value"}}, queries[0].Dimensions)
@@ -91,8 +93,8 @@ func TestGetDimensionValuesForWildcards(t *testing.T) {
 		query.Dimensions = map[string][]string{"Test_DimensionName2": {"*"}}
 		query.MatchExact = false
 		api := &mocks.MetricsAPI{Metrics: []*cloudwatch.Metric{}}
-		api.On("ListMetricsPages").Return(nil)
-		queries, err := executor.getDimensionValuesForWildcards(pluginCtx, "us-east-1", api, []*models.CloudWatchQuery{query}, tagValueCache, logger)
+		api.On("ListMetricsPagesWithContext").Return(nil)
+		queries, err := executor.getDimensionValuesForWildcards(ctx, pluginCtx, "us-east-1", api, []*models.CloudWatchQuery{query}, tagValueCache, logger)
 		assert.Nil(t, err)
 		assert.Len(t, queries, 1)
 		// assert that the values was set to an empty array
@@ -102,8 +104,8 @@ func TestGetDimensionValuesForWildcards(t *testing.T) {
 		api.Metrics = []*cloudwatch.Metric{
 			{MetricName: utils.Pointer("Test_MetricName"), Dimensions: []*cloudwatch.Dimension{{Name: utils.Pointer("Test_DimensionName2"), Value: utils.Pointer("Value")}}},
 		}
-		api.On("ListMetricsPages").Return(nil)
-		queries, err = executor.getDimensionValuesForWildcards(pluginCtx, "us-east-1", api, []*models.CloudWatchQuery{query}, tagValueCache, logger)
+		api.On("ListMetricsPagesWithContext").Return(nil)
+		queries, err = executor.getDimensionValuesForWildcards(ctx, pluginCtx, "us-east-1", api, []*models.CloudWatchQuery{query}, tagValueCache, logger)
 		assert.Nil(t, err)
 		assert.Len(t, queries, 1)
 		assert.Equal(t, map[string][]string{"Test_DimensionName2": {"Value"}}, queries[0].Dimensions)

--- a/pkg/tsdb/cloudwatch/mocks/cloudwatch_metric_api.go
+++ b/pkg/tsdb/cloudwatch/mocks/cloudwatch_metric_api.go
@@ -14,7 +14,7 @@ type FakeMetricsAPI struct {
 	MetricsPerPage int
 }
 
-func (c *FakeMetricsAPI) ListMetricsPages(input *cloudwatch.ListMetricsInput, fn func(*cloudwatch.ListMetricsOutput, bool) bool) error {
+func (c *FakeMetricsAPI) ListMetricsPagesWithContext(ctx aws.Context, input *cloudwatch.ListMetricsInput, fn func(*cloudwatch.ListMetricsOutput, bool) bool, opts ...request.Option) error {
 	if c.MetricsPerPage == 0 {
 		c.MetricsPerPage = 1000
 	}
@@ -62,7 +62,7 @@ func (m *MetricsAPI) GetMetricDataWithContext(ctx aws.Context, input *cloudwatch
 	return args.Get(0).(*cloudwatch.GetMetricDataOutput), args.Error(1)
 }
 
-func (m *MetricsAPI) ListMetricsPages(input *cloudwatch.ListMetricsInput, fn func(*cloudwatch.ListMetricsOutput, bool) bool) error {
+func (m *MetricsAPI) ListMetricsPagesWithContext(ctx aws.Context, input *cloudwatch.ListMetricsInput, fn func(*cloudwatch.ListMetricsOutput, bool) bool, opts ...request.Option) error {
 	fn(&cloudwatch.ListMetricsOutput{
 		Metrics: m.Metrics,
 	}, true)

--- a/pkg/tsdb/cloudwatch/mocks/list_metrics_service.go
+++ b/pkg/tsdb/cloudwatch/mocks/list_metrics_service.go
@@ -1,6 +1,8 @@
 package mocks
 
 import (
+	"context"
+
 	"github.com/grafana/grafana/pkg/tsdb/cloudwatch/models/resources"
 	"github.com/stretchr/testify/mock"
 )
@@ -9,19 +11,19 @@ type ListMetricsServiceMock struct {
 	mock.Mock
 }
 
-func (a *ListMetricsServiceMock) GetDimensionKeysByDimensionFilter(r resources.DimensionKeysRequest) ([]resources.ResourceResponse[string], error) {
+func (a *ListMetricsServiceMock) GetDimensionKeysByDimensionFilter(ctx context.Context, r resources.DimensionKeysRequest) ([]resources.ResourceResponse[string], error) {
 	args := a.Called(r)
 
 	return args.Get(0).([]resources.ResourceResponse[string]), args.Error(1)
 }
 
-func (a *ListMetricsServiceMock) GetDimensionValuesByDimensionFilter(r resources.DimensionValuesRequest) ([]resources.ResourceResponse[string], error) {
+func (a *ListMetricsServiceMock) GetDimensionValuesByDimensionFilter(ctx context.Context, r resources.DimensionValuesRequest) ([]resources.ResourceResponse[string], error) {
 	args := a.Called(r)
 
 	return args.Get(0).([]resources.ResourceResponse[string]), args.Error(1)
 }
 
-func (a *ListMetricsServiceMock) GetMetricsByNamespace(r resources.MetricsRequest) ([]resources.ResourceResponse[resources.Metric], error) {
+func (a *ListMetricsServiceMock) GetMetricsByNamespace(ctx context.Context, r resources.MetricsRequest) ([]resources.ResourceResponse[resources.Metric], error) {
 	args := a.Called(r)
 
 	return args.Get(0).([]resources.ResourceResponse[resources.Metric]), args.Error(1)

--- a/pkg/tsdb/cloudwatch/mocks/metrics_client.go
+++ b/pkg/tsdb/cloudwatch/mocks/metrics_client.go
@@ -1,6 +1,8 @@
 package mocks
 
 import (
+	"context"
+
 	"github.com/aws/aws-sdk-go/service/cloudwatch"
 	"github.com/grafana/grafana/pkg/tsdb/cloudwatch/models/resources"
 	"github.com/stretchr/testify/mock"
@@ -10,7 +12,7 @@ type FakeMetricsClient struct {
 	mock.Mock
 }
 
-func (m *FakeMetricsClient) ListMetricsWithPageLimit(params *cloudwatch.ListMetricsInput) ([]resources.MetricResponse, error) {
+func (m *FakeMetricsClient) ListMetricsWithPageLimit(ctx context.Context, params *cloudwatch.ListMetricsInput) ([]resources.MetricResponse, error) {
 	args := m.Called(params)
 	return args.Get(0).([]resources.MetricResponse), args.Error(1)
 }

--- a/pkg/tsdb/cloudwatch/models/api.go
+++ b/pkg/tsdb/cloudwatch/models/api.go
@@ -31,9 +31,9 @@ type RequestContext struct {
 
 // Services
 type ListMetricsProvider interface {
-	GetDimensionKeysByDimensionFilter(resources.DimensionKeysRequest) ([]resources.ResourceResponse[string], error)
-	GetDimensionValuesByDimensionFilter(resources.DimensionValuesRequest) ([]resources.ResourceResponse[string], error)
-	GetMetricsByNamespace(r resources.MetricsRequest) ([]resources.ResourceResponse[resources.Metric], error)
+	GetDimensionKeysByDimensionFilter(ctx context.Context, r resources.DimensionKeysRequest) ([]resources.ResourceResponse[string], error)
+	GetDimensionValuesByDimensionFilter(ctx context.Context, r resources.DimensionValuesRequest) ([]resources.ResourceResponse[string], error)
+	GetMetricsByNamespace(ctx context.Context, r resources.MetricsRequest) ([]resources.ResourceResponse[resources.Metric], error)
 }
 
 type LogGroupsProvider interface {
@@ -51,12 +51,12 @@ type RegionsAPIProvider interface {
 
 // Clients
 type MetricsClientProvider interface {
-	ListMetricsWithPageLimit(params *cloudwatch.ListMetricsInput) ([]resources.MetricResponse, error)
+	ListMetricsWithPageLimit(ctx context.Context, params *cloudwatch.ListMetricsInput) ([]resources.MetricResponse, error)
 }
 
 // APIs - instead of using the API defined in the services within the aws-sdk-go directly, specify a subset of the API with methods that are actually used in a service or a client
 type CloudWatchMetricsAPIProvider interface {
-	ListMetricsPages(*cloudwatch.ListMetricsInput, func(*cloudwatch.ListMetricsOutput, bool) bool) error
+	ListMetricsPagesWithContext(ctx context.Context, in *cloudwatch.ListMetricsInput, fn func(*cloudwatch.ListMetricsOutput, bool) bool, opts ...request.Option) error
 }
 
 type CloudWatchLogsAPIProvider interface {

--- a/pkg/tsdb/cloudwatch/routes/dimension_keys.go
+++ b/pkg/tsdb/cloudwatch/routes/dimension_keys.go
@@ -26,7 +26,7 @@ func DimensionKeysHandler(ctx context.Context, pluginCtx backend.PluginContext, 
 	var response []resources.ResourceResponse[string]
 	switch dimensionKeysRequest.Type() {
 	case resources.FilterDimensionKeysRequest:
-		response, err = service.GetDimensionKeysByDimensionFilter(dimensionKeysRequest)
+		response, err = service.GetDimensionKeysByDimensionFilter(ctx, dimensionKeysRequest)
 	default:
 		response, err = services.GetHardCodedDimensionKeysByNamespace(dimensionKeysRequest.Namespace)
 	}

--- a/pkg/tsdb/cloudwatch/routes/dimension_values.go
+++ b/pkg/tsdb/cloudwatch/routes/dimension_values.go
@@ -22,7 +22,7 @@ func DimensionValuesHandler(ctx context.Context, pluginCtx backend.PluginContext
 		return nil, models.NewHttpError("error in DimensionValuesHandler", http.StatusInternalServerError, err)
 	}
 
-	response, err := service.GetDimensionValuesByDimensionFilter(dimensionValuesRequest)
+	response, err := service.GetDimensionValuesByDimensionFilter(ctx, dimensionValuesRequest)
 	if err != nil {
 		return nil, models.NewHttpError("error in DimensionValuesHandler", http.StatusInternalServerError, err)
 	}

--- a/pkg/tsdb/cloudwatch/routes/metrics.go
+++ b/pkg/tsdb/cloudwatch/routes/metrics.go
@@ -30,7 +30,7 @@ func MetricsHandler(ctx context.Context, pluginCtx backend.PluginContext, reqCtx
 	case resources.MetricsByNamespaceRequestType:
 		response, err = services.GetHardCodedMetricsByNamespace(metricsRequest.Namespace)
 	case resources.CustomNamespaceRequestType:
-		response, err = service.GetMetricsByNamespace(metricsRequest)
+		response, err = service.GetMetricsByNamespace(ctx, metricsRequest)
 	}
 	if err != nil {
 		return nil, models.NewHttpError("error in MetricsHandler", http.StatusInternalServerError, err)

--- a/pkg/tsdb/cloudwatch/services/list_metrics.go
+++ b/pkg/tsdb/cloudwatch/services/list_metrics.go
@@ -1,6 +1,7 @@
 package services
 
 import (
+	"context"
 	"fmt"
 	"sort"
 
@@ -18,7 +19,7 @@ func NewListMetricsService(metricsClient models.MetricsClientProvider) models.Li
 	return &ListMetricsService{metricsClient}
 }
 
-func (l *ListMetricsService) GetDimensionKeysByDimensionFilter(r resources.DimensionKeysRequest) ([]resources.ResourceResponse[string], error) {
+func (l *ListMetricsService) GetDimensionKeysByDimensionFilter(ctx context.Context, r resources.DimensionKeysRequest) ([]resources.ResourceResponse[string], error) {
 	input := &cloudwatch.ListMetricsInput{}
 	if r.Namespace != "" {
 		input.Namespace = aws.String(r.Namespace)
@@ -29,7 +30,7 @@ func (l *ListMetricsService) GetDimensionKeysByDimensionFilter(r resources.Dimen
 	setDimensionFilter(input, r.DimensionFilter)
 	setAccount(input, r.ResourceRequest)
 
-	metrics, err := l.ListMetricsWithPageLimit(input)
+	metrics, err := l.ListMetricsWithPageLimit(ctx, input)
 	if err != nil {
 		return nil, fmt.Errorf("%v: %w", "unable to call AWS API", err)
 	}
@@ -64,7 +65,7 @@ func (l *ListMetricsService) GetDimensionKeysByDimensionFilter(r resources.Dimen
 	return response, nil
 }
 
-func (l *ListMetricsService) GetDimensionValuesByDimensionFilter(r resources.DimensionValuesRequest) ([]resources.ResourceResponse[string], error) {
+func (l *ListMetricsService) GetDimensionValuesByDimensionFilter(ctx context.Context, r resources.DimensionValuesRequest) ([]resources.ResourceResponse[string], error) {
 	input := &cloudwatch.ListMetricsInput{
 		Namespace:  aws.String(r.Namespace),
 		MetricName: aws.String(r.MetricName),
@@ -72,7 +73,7 @@ func (l *ListMetricsService) GetDimensionValuesByDimensionFilter(r resources.Dim
 	setDimensionFilter(input, r.DimensionFilter)
 	setAccount(input, r.ResourceRequest)
 
-	metrics, err := l.ListMetricsWithPageLimit(input)
+	metrics, err := l.ListMetricsWithPageLimit(ctx, input)
 	if err != nil {
 		return nil, fmt.Errorf("%v: %w", "unable to call AWS API", err)
 	}
@@ -98,10 +99,10 @@ func (l *ListMetricsService) GetDimensionValuesByDimensionFilter(r resources.Dim
 	return response, nil
 }
 
-func (l *ListMetricsService) GetMetricsByNamespace(r resources.MetricsRequest) ([]resources.ResourceResponse[resources.Metric], error) {
+func (l *ListMetricsService) GetMetricsByNamespace(ctx context.Context, r resources.MetricsRequest) ([]resources.ResourceResponse[resources.Metric], error) {
 	input := &cloudwatch.ListMetricsInput{Namespace: aws.String(r.Namespace)}
 	setAccount(input, r.ResourceRequest)
-	metrics, err := l.ListMetricsWithPageLimit(input)
+	metrics, err := l.ListMetricsWithPageLimit(ctx, input)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/tsdb/cloudwatch/services/list_metrics_test.go
+++ b/pkg/tsdb/cloudwatch/services/list_metrics_test.go
@@ -1,6 +1,7 @@
 package services
 
 import (
+	"context"
 	"testing"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -62,7 +63,7 @@ func TestListMetricsService_GetDimensionKeysByDimensionFilter(t *testing.T) {
 		fakeMetricsClient.On("ListMetricsWithPageLimit", mock.Anything).Return(metricResponse, nil)
 		listMetricsService := NewListMetricsService(fakeMetricsClient)
 
-		resp, err := listMetricsService.GetDimensionKeysByDimensionFilter(resources.DimensionKeysRequest{
+		resp, err := listMetricsService.GetDimensionKeysByDimensionFilter(context.Background(), resources.DimensionKeysRequest{
 			ResourceRequest: &resources.ResourceRequest{Region: "us-east-1"},
 			Namespace:       "AWS/EC2",
 			MetricName:      "CPUUtilization",
@@ -122,7 +123,7 @@ func TestListMetricsService_GetDimensionKeysByDimensionFilter(t *testing.T) {
 			fakeMetricsClient := &mocks.FakeMetricsClient{}
 			fakeMetricsClient.On("ListMetricsWithPageLimit", mock.Anything).Return(metricResponse, nil)
 			listMetricsService := NewListMetricsService(fakeMetricsClient)
-			res, err := listMetricsService.GetDimensionKeysByDimensionFilter(tc.input)
+			res, err := listMetricsService.GetDimensionKeysByDimensionFilter(context.Background(), tc.input)
 			require.NoError(t, err)
 			require.NotEmpty(t, res)
 			fakeMetricsClient.AssertCalled(t, "ListMetricsWithPageLimit", tc.listMetricsWithPageLimitInput)
@@ -136,7 +137,7 @@ func TestListMetricsService_GetDimensionValuesByDimensionFilter(t *testing.T) {
 		fakeMetricsClient.On("ListMetricsWithPageLimit", mock.Anything).Return(metricResponse, nil)
 		listMetricsService := NewListMetricsService(fakeMetricsClient)
 
-		resp, err := listMetricsService.GetDimensionValuesByDimensionFilter(resources.DimensionValuesRequest{
+		resp, err := listMetricsService.GetDimensionValuesByDimensionFilter(context.Background(), resources.DimensionValuesRequest{
 			ResourceRequest: &resources.ResourceRequest{Region: "us-east-1"},
 			Namespace:       "AWS/EC2",
 			MetricName:      "CPUUtilization",
@@ -189,7 +190,7 @@ func TestListMetricsService_GetDimensionValuesByDimensionFilter(t *testing.T) {
 			fakeMetricsClient := &mocks.FakeMetricsClient{}
 			fakeMetricsClient.On("ListMetricsWithPageLimit", mock.Anything).Return(metricResponse, nil)
 			listMetricsService := NewListMetricsService(fakeMetricsClient)
-			res, err := listMetricsService.GetDimensionValuesByDimensionFilter(tc.input)
+			res, err := listMetricsService.GetDimensionValuesByDimensionFilter(context.Background(), tc.input)
 			require.NoError(t, err)
 			require.Empty(t, res)
 			fakeMetricsClient.AssertCalled(t, "ListMetricsWithPageLimit", tc.listMetricsWithPageLimitInput)

--- a/pkg/tsdb/cloudwatch/test_utils.go
+++ b/pkg/tsdb/cloudwatch/test_utils.go
@@ -200,7 +200,7 @@ type fakeCheckHealthClient struct {
 	describeLogGroups func(input *cloudwatchlogs.DescribeLogGroupsInput) (*cloudwatchlogs.DescribeLogGroupsOutput, error)
 }
 
-func (c fakeCheckHealthClient) ListMetricsPages(input *cloudwatch.ListMetricsInput, fn func(*cloudwatch.ListMetricsOutput, bool) bool) error {
+func (c fakeCheckHealthClient) ListMetricsPagesWithContext(ctx aws.Context, input *cloudwatch.ListMetricsInput, fn func(*cloudwatch.ListMetricsOutput, bool) bool, opts ...request.Option) error {
 	if c.listMetricsPages != nil {
 		return c.listMetricsPages(input, fn)
 	}

--- a/pkg/tsdb/cloudwatch/time_series_query.go
+++ b/pkg/tsdb/cloudwatch/time_series_query.go
@@ -96,7 +96,7 @@ func (e *cloudWatchExecutor) executeTimeSeriesQuery(ctx context.Context, logger 
 				}
 
 				if e.features.IsEnabled(featuremgmt.FlagCloudWatchWildCardDimensionValues) {
-					requestQueries, err = e.getDimensionValuesForWildcards(req.PluginContext, region, client, requestQueries, instance.tagValueCache, logger)
+					requestQueries, err = e.getDimensionValuesForWildcards(ctx, req.PluginContext, region, client, requestQueries, instance.tagValueCache, logger)
 					if err != nil {
 						return err
 					}

--- a/pkg/tsdb/cloudwatch/time_series_query_test.go
+++ b/pkg/tsdb/cloudwatch/time_series_query_test.go
@@ -419,7 +419,7 @@ func Test_QueryData_response_data_frame_name_is_always_response_label(t *testing
 	api := mocks.MetricsAPI{Metrics: []*cloudwatch.Metric{
 		{MetricName: aws.String(""), Dimensions: []*cloudwatch.Dimension{{Name: aws.String("InstanceId"), Value: aws.String("i-00645d91ed77d87ac")}}},
 	}}
-	api.On("ListMetricsPages").Return(nil)
+	api.On("ListMetricsPagesWithContext").Return(nil)
 
 	NewCWClient = func(sess *session.Session) cloudwatchiface.CloudWatchAPI {
 		return &api


### PR DESCRIPTION
Use ListMetricsPagesWithContext and pass context in related sub calls

<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

In the current way, ListMetricsPages is used which doesn't allow canceling the request if the context changes. Using ListMetricsPagesWithContext is the preferred way.

**Why do we need this feature?**

Using context in the go-based application is always the preferred way wherever it is possible to do so. With this change, we are making the application aware of context when it calls ListMetricsPagesWithContext.

**Who is this feature for?**

Users

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Contributes to #75498

**Special notes for your reviewer:**

I have used context.Backgroud() in some places where I am not sure what to do.

Please check that:
- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
