### PR TITLE
Chore: Fix failure when importing dashboard

### DIFF
--- a/pkg/services/libraryelements/database.go
+++ b/pkg/services/libraryelements/database.go
@@ -60,6 +60,10 @@ func syncFieldsWithModel(libraryElement *model.LibraryElement) error {
 		return err
 	}
 
+	if modelLibraryElement == nil {
+		modelLibraryElement = make(map[string]any)
+	}
+
 	if model.LibraryElementKind(libraryElement.Kind) == model.VariableElement {
 		modelLibraryElement["name"] = libraryElement.Name
 	}


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

[Add a brief description of what the feature or update does.]

**Why do we need this feature?**

Fixes failure in library elements when importing the dashboard supplied in #76869:

<details><summary>Failed response</summary>
<p>

```
{
    "error": "assignment to entry in nil map - /opt/homebrew/opt/go/libexec/src/runtime/map_faststr.go:205 (0x1022185bb)\n\tmapassign_faststr: panic(plainError(\"assignment to entry in nil map\"))\n/Users/josefk/go/src/github.com/grafana/grafana/pkg/services/libraryelements/database.go:71 (0x10380c2ab)\n\tsyncFieldsWithModel: modelLibraryElement[\"type\"] = libraryElement.Type\n/Users/josefk/go/src/github.com/grafana/grafana/pkg/services/libraryelements/database.go:163 (0x10380ccd7)\n\t(*LibraryElementService).createLibraryElement: if err := syncFieldsWithModel(\u0026element); err != nil {\n/Users/josefk/go/src/github.com/grafana/grafana/pkg/services/libraryelements/libraryelements.go:60 (0x1038137a3)\n\t(*LibraryElementService).CreateElement: return l.createLibraryElement(c, signedInUser, cmd)\n/Users/josefk/go/src/github.com/grafana/grafana/pkg/services/librarypanels/librarypanels.go:173 (0x103f6481f)\n\timportLibraryPanelsRecursively: _, err = service.CreateElement(c, signedInUser, cmd)\n/Users/josefk/go/src/github.com/grafana/grafana/pkg/services/librarypanels/librarypanels.go:118 (0x103f63ef3)\n\t(*LibraryPanelService).ImportLibraryPanelsForDashboard: return importLibraryPanelsRecursively(c, lps.LibraryElementService, signedInUser, libraryPanels, panels, folderID)\n/Users/josefk/go/src/github.com/grafana/grafana/pkg/services/dashboardimport/service/service.go:138 (0x106463f67)\n\t(*ImportDashboardService).ImportDashboard: err = s.libraryPanelService.ImportLibraryPanelsForDashboard(ctx, req.User, libraryElements, generatedDash.Get(\"panels\").MustArray(), req.FolderId)\n/Users/josefk/go/src/github.com/grafana/grafana/pkg/services/dashboardimport/api/api.go:78 (0x106462453)\n\t(*ImportDashboardAPI).ImportDashboard: resp, err := api.dashboardImportService.ImportDashboard(c.Req.Context(), \u0026req)\n/Users/josefk/go/src/github.com/grafana/grafana/pkg/api/routing/routing.go:17 (0x103803627)\n\tWrap.func1: if res := handler(c); res != nil {\n/Users/josefk/go/src/github.com/grafana/grafana/pkg/api/response/web_hack.go:40 (0x103326ce7)\n\twrap_handler.func3: handle(reqCtx(w, r))\n/opt/homebrew/opt/go/libexec/src/net/http/server.go:2122 (0x102561227)\n\tHandlerFunc.ServeHTTP: f(w, r)\n/Users/josefk/go/src/github.com/grafana/grafana/pkg/web/macaron.go:134 (0x10331a433)\n\tmwFromHandler.func1.1: h.ServeHTTP(mrw, r)\n/opt/homebrew/opt/go/libexec/src/net/http/server.go:2122 (0x102561227)\n\tHandlerFunc.ServeHTTP: f(w, r)\n/Users/josefk/go/src/github.com/grafana/grafana/pkg/web/macaron.go:140 (0x10331a4d7)\n\tmwFromHandler.func1.1: next.ServeHTTP(ctx.Resp, ctx.Req)\n/opt/homebrew/opt/go/libexec/src/net/http/server.go:2122 (0x102561227)\n\tHandlerFunc.ServeHTTP: f(w, r)\n/Users/josefk/go/src/github.com/grafana/grafana/pkg/web/macaron.go:140 (0x10331a4d7)\n\tmwFromHandler.func1.1: next.ServeHTTP(ctx.Resp, ctx.Req)\n/opt/homebrew/opt/go/libexec/src/net/http/server.go:2122 (0x102561227)\n\tHandlerFunc.ServeHTTP: f(w, r)\n/Users/josefk/go/src/github.com/grafana/grafana/pkg/extensions/ratelimiting/ratelimiting.go:54 (0x1062d7bbf)\n\t(*HTTPRateLimiting).rateLimitingMiddleware.func1.1.1: next.ServeHTTP(w, r)\n/opt/homebrew/opt/go/libexec/src/net/http/server.go:2122 (0x102561227)\n\tHandlerFunc.ServeHTTP: f(w, r)\n/Users/josefk/go/src/github.com/grafana/grafana/pkg/web/macaron.go:140 (0x10331a4d7)\n\tmwFromHandler.func1.1: next.ServeHTTP(ctx.Resp, ctx.Req)\n/opt/homebrew/opt/go/libexec/src/net/http/server.go:2122 (0x102561227)\n\tHandlerFunc.ServeHTTP: f(w, r)\n/Users/josefk/go/src/github.com/grafana/grafana/pkg/web/macaron.go:140 (0x10331a4d7)\n\tmwFromHandler.func1.1: next.ServeHTTP(ctx.Resp, ctx.Req)\n/opt/homebrew/opt/go/libexec/src/net/http/server.go:2122 (0x102561227)\n\tHandlerFunc.ServeHTTP: f(w, r)\n/Users/josefk/go/src/github.com/grafana/grafana/pkg/web/macaron.go:140 (0x10331a4d7)\n\tmwFromHandler.func1.1: next.ServeHTTP(ctx.Resp, ctx.Req)\n/opt/homebrew/opt/go/libexec/src/net/http/server.go:2122 (0x102561227)\n\tHandlerFunc.ServeHTTP: f(w, r)\n/Users/josefk/go/src/github.com/grafana/grafana/pkg/services/contexthandler/contexthandler.go:137 (0x1037ed703)\n\t(*ContextHandler).Middleware.func1: next.ServeHTTP(w, r)\n/opt/homebrew/opt/go/libexec/src/net/http/server.go:2122 (0x102561227)\n\tHandlerFunc.ServeHTTP: f(w, r)\n/Users/josefk/go/src/github.com/grafana/grafana/pkg/web/macaron.go:140 (0x10331a4d7)\n\tmwFromHandler.func1.1: next.ServeHTTP(ctx.Resp, ctx.Req)\n/opt/homebrew/opt/go/libexec/src/net/http/server.go:2122 (0x102561227)\n\tHandlerFunc.ServeHTTP: f(w, r)\n/Users/josefk/go/src/github.com/grafana/grafana/pkg/web/macaron.go:140 (0x10331a4d7)\n\tmwFromHandler.func1.1: next.ServeHTTP(ctx.Resp, ctx.Req)\n/opt/homebrew/opt/go/libexec/src/net/http/server.go:2122 (0x102561227)\n\tHandlerFunc.ServeHTTP: f(w, r)\n/Users/josefk/go/src/github.com/grafana/grafana/pkg/web/macaron.go:140 (0x10331a4d7)\n\tmwFromHandler.func1.1: next.ServeHTTP(ctx.Resp, ctx.Req)\n/opt/homebrew/opt/go/libexec/src/net/http/server.go:2122 (0x102561227)\n\tHandlerFunc.ServeHTTP: f(w, r)\n/Users/josefk/go/src/github.com/grafana/grafana/pkg/web/macaron.go:140 (0x10331a4d7)\n\tmwFromHandler.func1.1: next.ServeHTTP(ctx.Resp, ctx.Req)\n/opt/homebrew/opt/go/libexec/src/net/http/server.go:2122 (0x102561227)\n\tHandlerFunc.ServeHTTP: f(w, r)\n/Users/josefk/go/src/github.com/grafana/grafana/pkg/web/macaron.go:140 (0x10331a4d7)\n\tmwFromHandler.func1.1: next.ServeHTTP(ctx.Resp, ctx.Req)\n/opt/homebrew/opt/go/libexec/src/net/http/server.go:2122 (0x102561227)\n\tHandlerFunc.ServeHTTP: f(w, r)\n/Users/josefk/go/src/github.com/grafana/grafana/pkg/web/render.go:44 (0x10331afb3)\n\tRenderer.func1.1: next.ServeHTTP(rw, req)\n/opt/homebrew/opt/go/libexec/src/net/http/server.go:2122 (0x102561227)\n\tHandlerFunc.ServeHTTP: f(w, r)\n/Users/josefk/go/src/github.com/grafana/grafana/pkg/web/macaron.go:140 (0x10331a4d7)\n\tmwFromHandler.func1.1: next.ServeHTTP(ctx.Resp, ctx.Req)\n/opt/homebrew/opt/go/libexec/src/net/http/server.go:2122 (0x102561227)\n\tHandlerFunc.ServeHTTP: f(w, r)\n/Users/josefk/go/src/github.com/grafana/grafana/pkg/web/macaron.go:140 (0x10331a4d7)\n\tmwFromHandler.func1.1: next.ServeHTTP(ctx.Resp, ctx.Req)\n/opt/homebrew/opt/go/libexec/src/net/http/server.go:2122 (0x102561227)\n\tHandlerFunc.ServeHTTP: f(w, r)\n/Users/josefk/go/src/github.com/grafana/grafana/pkg/web/macaron.go:140 (0x10331a4d7)\n\tmwFromHandler.func1.1: next.ServeHTTP(ctx.Resp, ctx.Req)\n/opt/homebrew/opt/go/libexec/src/net/http/server.go:2122 (0x102561227)\n\tHandlerFunc.ServeHTTP: f(w, r)\n/Users/josefk/go/src/github.com/grafana/grafana/pkg/web/macaron.go:140 (0x10331a4d7)\n\tmwFromHandler.func1.1: next.ServeHTTP(ctx.Resp, ctx.Req)\n/opt/homebrew/opt/go/libexec/src/net/http/server.go:2122 (0x102561227)\n\tHandlerFunc.ServeHTTP: f(w, r)\n/Users/josefk/go/src/github.com/grafana/grafana/pkg/middleware/csrf/csrf.go:66 (0x103f1ae8f)\n\t(*CSRF).Middleware.func1.1: next.ServeHTTP(w, r)\n/opt/homebrew/opt/go/libexec/src/net/http/server.go:2122 (0x102561227)\n\tHandlerFunc.ServeHTTP: f(w, r)\n/Users/josefk/go/src/github.com/grafana/grafana/pkg/middleware/recovery.go:171 (0x1037fd34b)\n\tRecovery.func1.1: next.ServeHTTP(w, req)\n/opt/homebrew/opt/go/libexec/src/net/http/server.go:2122 (0x102561227)\n\tHandlerFunc.ServeHTTP: f(w, r)\n/Users/josefk/go/src/github.com/grafana/grafana/pkg/middleware/loggermw/logger.go:72 (0x103f1bdb3)\n\t(*loggerImpl).Middleware.func1.1: next.ServeHTTP(rw, r)\n/opt/homebrew/opt/go/libexec/src/net/http/server.go:2122 (0x102561227)\n\tHandlerFunc.ServeHTTP: f(w, r)\n/Users/josefk/go/src/github.com/grafana/grafana/pkg/middleware/request_metrics.go:83 (0x1037fe35b)\n\tRequestMetrics.func1.1: next.ServeHTTP(w, r)\n/opt/homebrew/opt/go/libexec/src/net/http/server.go:2122 (0x102561227)\n\tHandlerFunc.ServeHTTP: f(w, r)\n/Users/josefk/go/src/github.com/grafana/grafana/pkg/middleware/request_tracing.go:88 (0x1037ffbef)\n\tRequestTracing.func1.1: next.ServeHTTP(w, req)\n/opt/homebrew/opt/go/libexec/src/net/http/server.go:2122 (0x102561227)\n\tHandlerFunc.ServeHTTP: f(w, r)\n/Users/josefk/go/src/github.com/grafana/grafana/pkg/middleware/requestmeta/request_metadata.go:66 (0x1033245d7)\n\tSetupRequestMetadata.func1.1: next.ServeHTTP(w, r)\n/opt/homebrew/opt/go/libexec/src/net/http/server.go:2122 (0x102561227)\n\tHandlerFunc.ServeHTTP: f(w, r)\n/Users/josefk/go/src/github.com/grafana/grafana/pkg/web/context.go:52 (0x103318ce3)\n\t(*Context).run: h.ServeHTTP(ctx.Resp, ctx.Req)\n/Users/josefk/go/src/github.com/grafana/grafana/pkg/web/router.go:155 (0x10331c46b)\n\t(*Router).Handle.func1: c.run()\n/Users/josefk/go/src/github.com/grafana/grafana/pkg/web/router.go:211 (0x10331cf1f)\n\t(*Router).ServeHTTP: leaf.handle(rw, req, nil)\n/Users/josefk/go/src/github.com/grafana/grafana/pkg/web/macaron.go:166 (0x10331a90b)\n\t(*Macaron).ServeHTTP: m.Router.ServeHTTP(rw, req)\n/opt/homebrew/opt/go/libexec/src/net/http/server.go:2936 (0x102563ec7)\n\tserverHandler.ServeHTTP: handler.ServeHTTP(rw, req)\n/opt/homebrew/opt/go/libexec/src/net/http/server.go:1995 (0x10256000f)\n\t(*conn).serve: serverHandler{c.server}.ServeHTTP(w, w.req)\n/opt/homebrew/opt/go/libexec/src/runtime/asm_arm64.s:1172 (0x102274903)\n\tgoexit: MOVD\tR0, R0\t// NOP\n",
    "message": "Internal Server Error - please inspect Grafana server log for details"
}
```

</p>
</details> 

**Who is this feature for?**

[Add information on what kind of user the feature is for.]

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
