### PR TITLE
Alerting: Update 'Create alert' to 'New alert rule' in the panel and docs

### DIFF
--- a/docs/sources/alerting/alerting-rules/create-grafana-managed-rule.md
+++ b/docs/sources/alerting/alerting-rules/create-grafana-managed-rule.md
@@ -202,7 +202,7 @@ Create alerts from any panel type. This means you can reuse the queries in the p
 
 1. Navigate to a dashboard in the **Dashboards** section.
 2. In the top right corner of the panel, click on the three dots (ellipses).
-3. From the dropdown menu, select **More...** and then choose **Create alert**.
+3. From the dropdown menu, select **More...** and then choose **New alert rule**.
 
 This will open the alert rule form, allowing you to configure and create your alert based on the current panel's query.
 

--- a/docs/sources/tutorials/create-alerts-with-logs/index.md
+++ b/docs/sources/tutorials/create-alerts-with-logs/index.md
@@ -44,7 +44,7 @@ In these steps you'll create an alert and define an expression to evaluate. Thes
 
 ### Create a Grafana-managed alert
 
-1. Navigate in Grafana to **Alerting**, then to **Alert Rules** and click **+ Create alert rule**.
+1. Navigate in Grafana to **Alerting**, then to **Alert Rules** and click **+ New alert rule**.
 1. Choose **Grafana Managed Alert** to create an alert that uses expressions.
 1. Select your Loki datasource from the drop-down.
 1. Enter the alert query in the query editor, switch to **code** mode in the top right corner of the editor to paste the query below:

--- a/docs/sources/tutorials/grafana-fundamentals/index.md
+++ b/docs/sources/tutorials/grafana-fundamentals/index.md
@@ -328,7 +328,7 @@ We have now created a dummy webhook endpoint and created a new Alerting Contact 
 Now that Grafana knows how to notify us, it's time to set up an alert rule:
 
 1. In the sidebar, click **Alert rules**.
-1. Click **Create alert rule**.
+1. Click **New alert rule**.
 1. In section **1**, name the rule `fundamentals-test`.
 1. For section **2**, select **Grafana Managed Alert** as the rule type. Next, find query box **A**. Choose your Prometheus datasource and enter the same query that we used in our earlier panel: `sum(rate(tns_request_duration_seconds_count[5m])) by(route)`. Click **Run queries**. You should see some data in the graph.
 1. Now scroll down to query box **B**. Change the operation from **Reduce** to **Classic condition**. [You can read more about classic and multi-dimensional conditions here](/docs/grafana/latest/alerting/unified-alerting/alerting-rules/create-grafana-managed-rule/#single-and-multi-dimensional-rule). For conditions enter the following: `WHEN last() OF A IS ABOVE 0.2`. Delete query **C**.

--- a/public/app/core/utils/navBarItem-translations.ts
+++ b/public/app/core/utils/navBarItem-translations.ts
@@ -21,7 +21,7 @@ export function getNavTitle(navId: string | undefined) {
     case 'import':
       return t('nav.create-import.title', 'Import dashboard');
     case 'alert':
-      return t('nav.create-alert.title', 'Create alert rule');
+      return t('nav.create-alert.title', 'New alert rule');
     case 'starred':
       return t('nav.starred.title', 'Starred');
     case 'starred-empty':

--- a/public/app/features/alerting/unified/components/panel-alerts-tab/NewRuleFromPanelButton.test.tsx
+++ b/public/app/features/alerting/unified/components/panel-alerts-tab/NewRuleFromPanelButton.test.tsx
@@ -46,7 +46,7 @@ describe('Analytics', () => {
     });
     render(<NewRuleFromPanelButton panel={panel} dashboard={dashboard} />);
 
-    const button = screen.getByText('Create alert rule from this panel');
+    const button = screen.getByText('New alert rule');
 
     button.addEventListener('click', (event) => event.preventDefault(), false);
 

--- a/public/app/features/alerting/unified/components/panel-alerts-tab/NewRuleFromPanelButton.tsx
+++ b/public/app/features/alerting/unified/components/panel-alerts-tab/NewRuleFromPanelButton.tsx
@@ -31,7 +31,7 @@ export const NewRuleFromPanelButton = ({ dashboard, panel, className }: Props) =
   );
 
   if (loading) {
-    return <Button disabled={true}>Create alert rule from this panel</Button>;
+    return <Button disabled={true}>New alert rule</Button>;
   }
 
   if (!formValues) {
@@ -55,7 +55,7 @@ export const NewRuleFromPanelButton = ({ dashboard, panel, className }: Props) =
       className={className}
       data-testid="create-alert-rule-button"
     >
-      Create alert rule from this panel
+      New alert rule
     </LinkButton>
   );
 };

--- a/public/app/features/connections/__mocks__/store.navIndex.mock.ts
+++ b/public/app/features/connections/__mocks__/store.navIndex.mock.ts
@@ -157,7 +157,7 @@ export const navIndex: NavIndex = {
       },
       {
         id: 'alert',
-        text: 'Create alert rule',
+        text: 'New alert rule',
         subTitle: 'Create an alert rule',
         icon: 'plus',
         url: '/alerting/new',
@@ -215,7 +215,7 @@ export const navIndex: NavIndex = {
   },
   alert: {
     id: 'alert',
-    text: 'Create alert rule',
+    text: 'New alert rule',
     subTitle: 'Create an alert rule',
     icon: 'plus',
     url: '/alerting/new',

--- a/public/app/features/dashboard/utils/getPanelMenu.test.ts
+++ b/public/app/features/dashboard/utils/getPanelMenu.test.ts
@@ -625,7 +625,7 @@ describe('getPanelMenu()', () => {
     });
   });
   describe('Alerting menu', () => {
-    it('should render Create alert menu item if user has permissions to read and update alerts ', () => {
+    it('should render "New alert rule" menu item if user has permissions to read and update alerts ', () => {
       const panel = new PanelModel({});
 
       const dashboard = createDashboardModelFixture({});
@@ -637,13 +637,13 @@ describe('getPanelMenu()', () => {
       expect(moreSubMenu).toEqual(
         expect.arrayContaining([
           expect.objectContaining({
-            text: 'Create alert',
+            text: 'New alert rule',
           }),
         ])
       );
     });
 
-    it('should not render Create alert menu item, if user does not have permissions to update alerts ', () => {
+    it('should not render "New alert rule" menu item, if user does not have permissions to update alerts ', () => {
       const panel = new PanelModel({});
       const dashboard = createDashboardModelFixture({});
 
@@ -657,12 +657,12 @@ describe('getPanelMenu()', () => {
       expect(moreSubMenu).toEqual(
         expect.arrayContaining([
           expect.not.objectContaining({
-            text: 'Create alert',
+            text: 'New alert rule',
           }),
         ])
       );
     });
-    it('should not render Create alert menu item, if user does not have permissions to read update alerts ', () => {
+    it('should not render "New alert rule" menu item, if user does not have permissions to read update alerts ', () => {
       const panel = new PanelModel({});
 
       const dashboard = createDashboardModelFixture({});
@@ -672,7 +672,7 @@ describe('getPanelMenu()', () => {
       const menuItems = getPanelMenu(dashboard, panel);
 
       const moreSubMenu = menuItems.find((i) => i.text === 'More...')?.subMenu;
-      const createAlertOption = moreSubMenu?.find((i) => i.text === 'Create alert')?.subMenu;
+      const createAlertOption = moreSubMenu?.find((i) => i.text === 'New alert rule')?.subMenu;
 
       expect(createAlertOption).toBeUndefined();
     });

--- a/public/app/features/dashboard/utils/getPanelMenu.ts
+++ b/public/app/features/dashboard/utils/getPanelMenu.ts
@@ -261,7 +261,7 @@ export function getPanelMenu(
 
   if (isCreateAlertMenuOptionAvailable) {
     subMenu.push({
-      text: t('panel.header-menu.create-alert', `Create alert`),
+      text: t('panel.header-menu.new-alert-rule', `New alert rule`),
       onClick: onCreateAlert,
     });
   }
@@ -304,7 +304,7 @@ export function getPanelMenu(
     subMenu.length = 0;
     if (isCreateAlertMenuOptionAvailable) {
       subMenu.push({
-        text: t('panel.header-menu.create-alert', `Create alert`),
+        text: t('panel.header-menu.new-alert-rule', `New alert rule`),
         onClick: onCreateAlert,
       });
     }

--- a/public/app/features/datasources/__mocks__/store.navIndex.mock.ts
+++ b/public/app/features/datasources/__mocks__/store.navIndex.mock.ts
@@ -563,7 +563,7 @@ export const navIndex: NavIndex = {
       },
       {
         id: 'alert',
-        text: 'Create alert rule',
+        text: 'New alert rule',
         subTitle: 'Create an alert rule',
         icon: 'plus',
         url: '/alerting/new',
@@ -622,7 +622,7 @@ export const navIndex: NavIndex = {
         },
         {
           id: 'alert',
-          text: 'Create alert rule',
+          text: 'New alert rule',
           subTitle: 'Create an alert rule',
           icon: 'plus',
           url: '/alerting/new',
@@ -682,7 +682,7 @@ export const navIndex: NavIndex = {
         },
         {
           id: 'alert',
-          text: 'Create alert rule',
+          text: 'New alert rule',
           subTitle: 'Create an alert rule',
           icon: 'plus',
           url: '/alerting/new',
@@ -742,7 +742,7 @@ export const navIndex: NavIndex = {
         },
         {
           id: 'alert',
-          text: 'Create alert rule',
+          text: 'New alert rule',
           subTitle: 'Create an alert rule',
           icon: 'plus',
           url: '/alerting/new',
@@ -802,7 +802,7 @@ export const navIndex: NavIndex = {
         },
         {
           id: 'alert',
-          text: 'Create alert rule',
+          text: 'New alert rule',
           subTitle: 'Create an alert rule',
           icon: 'plus',
           url: '/alerting/new',
@@ -862,7 +862,7 @@ export const navIndex: NavIndex = {
         },
         {
           id: 'alert',
-          text: 'Create alert rule',
+          text: 'New alert rule',
           subTitle: 'Create an alert rule',
           icon: 'plus',
           url: '/alerting/new',
@@ -922,7 +922,7 @@ export const navIndex: NavIndex = {
         },
         {
           id: 'alert',
-          text: 'Create alert rule',
+          text: 'New alert rule',
           subTitle: 'Create an alert rule',
           icon: 'plus',
           url: '/alerting/new',
@@ -933,7 +933,7 @@ export const navIndex: NavIndex = {
   },
   alert: {
     id: 'alert',
-    text: 'Create alert rule',
+    text: 'New alert rule',
     subTitle: 'Create an alert rule',
     icon: 'plus',
     url: '/alerting/new',
@@ -984,7 +984,7 @@ export const navIndex: NavIndex = {
         },
         {
           id: 'alert',
-          text: 'Create alert rule',
+          text: 'New alert rule',
           subTitle: 'Create an alert rule',
           icon: 'plus',
           url: '/alerting/new',

--- a/public/locales/de-DE/grafana.json
+++ b/public/locales/de-DE/grafana.json
@@ -773,7 +773,6 @@
   "panel": {
     "header-menu": {
       "copy": "Kopieren",
-      "create-alert": "",
       "create-library-panel": "Bibliotheksleiste erstellen",
       "duplicate": "Duplikat",
       "edit": "Bearbeiten",
@@ -784,6 +783,7 @@
       "inspect-data": "Daten",
       "inspect-json": "Panel-JSON",
       "more": "Mehr …",
+      "new-alert-rule": "",
       "query": "Abfrage",
       "remove": "Entfernen",
       "share": "Teilen",

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -773,7 +773,6 @@
   "panel": {
     "header-menu": {
       "copy": "Copy",
-      "create-alert": "Create alert",
       "create-library-panel": "Create library panel",
       "duplicate": "Duplicate",
       "edit": "Edit",
@@ -784,6 +783,7 @@
       "inspect-data": "Data",
       "inspect-json": "Panel JSON",
       "more": "More...",
+      "new-alert-rule": "New alert rule",
       "query": "Query",
       "remove": "Remove",
       "share": "Share",

--- a/public/locales/es-ES/grafana.json
+++ b/public/locales/es-ES/grafana.json
@@ -779,7 +779,6 @@
   "panel": {
     "header-menu": {
       "copy": "Copiar",
-      "create-alert": "",
       "create-library-panel": "Crear panel de librería",
       "duplicate": "Duplicar",
       "edit": "Editar",
@@ -790,6 +789,7 @@
       "inspect-data": "Datos",
       "inspect-json": "JSON de panel",
       "more": "Más...",
+      "new-alert-rule": "",
       "query": "Consulta",
       "remove": "Eliminar",
       "share": "Compartir",

--- a/public/locales/fr-FR/grafana.json
+++ b/public/locales/fr-FR/grafana.json
@@ -779,7 +779,6 @@
   "panel": {
     "header-menu": {
       "copy": "Copier",
-      "create-alert": "",
       "create-library-panel": "Créer un panneau Bibliothèque",
       "duplicate": "Dupliquer",
       "edit": "Modifier",
@@ -790,6 +789,7 @@
       "inspect-data": "Données",
       "inspect-json": "Panneau JSON",
       "more": "Plus...",
+      "new-alert-rule": "",
       "query": "Requête",
       "remove": "Supprimer",
       "share": "Partager",

--- a/public/locales/pseudo-LOCALE/grafana.json
+++ b/public/locales/pseudo-LOCALE/grafana.json
@@ -773,7 +773,6 @@
   "panel": {
     "header-menu": {
       "copy": "Cőpy",
-      "create-alert": "Cřęäŧę äľęřŧ",
       "create-library-panel": "Cřęäŧę ľįþřäřy päŉęľ",
       "duplicate": "Đūpľįčäŧę",
       "edit": "Ēđįŧ",
@@ -784,6 +783,7 @@
       "inspect-data": "Đäŧä",
       "inspect-json": "Päŉęľ ĴŜØŃ",
       "more": "Mőřę...",
+      "new-alert-rule": "Ńęŵ äľęřŧ řūľę",
       "query": "Qūęřy",
       "remove": "Ŗęmővę",
       "share": "Ŝĥäřę",

--- a/public/locales/zh-Hans/grafana.json
+++ b/public/locales/zh-Hans/grafana.json
@@ -767,7 +767,6 @@
   "panel": {
     "header-menu": {
       "copy": "复制",
-      "create-alert": "",
       "create-library-panel": "创建库面板",
       "duplicate": "复制",
       "edit": "编辑",
@@ -778,6 +777,7 @@
       "inspect-data": "数据",
       "inspect-json": "面板 JSON",
       "more": "更多...",
+      "new-alert-rule": "",
       "query": "查询",
       "remove": "删除",
       "share": "分享",


### PR DESCRIPTION
**What is this feature?**

This PR updates the text `Create alert `to `New alert rule` in the panel (menu option under `.../More... `and `alert tab`).
The reason behind this change, is that we made some changes in the **new alert creation workflow** where we decided using `New alert rule` for this action in the alerting page.

**Why do we need this feature?**

We need to make the UI consistent. 

**Who is this feature for?**

All users.

**Special notes for your reviewer:**

<img width="686" alt="Screenshot 2023-10-23 at 12 20 07" src="https://github.com/grafana/grafana/assets/33540275/667a131d-808b-466c-986f-fa8c0868434e">
<img width="470" alt="Screenshot 2023-10-23 at 12 19 57" src="https://github.com/grafana/grafana/assets/33540275/b6d3f71d-06c8-47bf-a762-acb196ada138">


Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
