### PR TITLE
Prometheus: (Chore) Switch to sdk httpclient from infra httpclient

### DIFF
--- a/pkg/tsdb/prometheus/healthcheck_test.go
+++ b/pkg/tsdb/prometheus/healthcheck_test.go
@@ -11,7 +11,6 @@ import (
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
 	"github.com/grafana/grafana-plugin-sdk-go/backend/datasource"
 	"github.com/grafana/grafana-plugin-sdk-go/backend/httpclient"
-	sdkHttpClient "github.com/grafana/grafana-plugin-sdk-go/backend/httpclient"
 	"github.com/grafana/grafana/pkg/services/featuremgmt"
 	"github.com/grafana/grafana/pkg/setting"
 	"github.com/stretchr/testify/assert"
@@ -58,14 +57,14 @@ func (rt *healthCheckFailRoundTripper) RoundTrip(req *http.Request) (*http.Respo
 	}, nil
 }
 
-func (provider *healthCheckProvider[T]) New(opts ...sdkHttpClient.Options) (*http.Client, error) {
+func (provider *healthCheckProvider[T]) New(opts ...httpclient.Options) (*http.Client, error) {
 	client := &http.Client{}
 	provider.RoundTripper = new(T)
 	client.Transport = *provider.RoundTripper
 	return client, nil
 }
 
-func (provider *healthCheckProvider[T]) GetTransport(opts ...sdkHttpClient.Options) (http.RoundTripper, error) {
+func (provider *healthCheckProvider[T]) GetTransport(opts ...httpclient.Options) (http.RoundTripper, error) {
 	return *new(T), nil
 }
 

--- a/pkg/tsdb/prometheus/healthcheck_test.go
+++ b/pkg/tsdb/prometheus/healthcheck_test.go
@@ -10,8 +10,8 @@ import (
 
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
 	"github.com/grafana/grafana-plugin-sdk-go/backend/datasource"
+	"github.com/grafana/grafana-plugin-sdk-go/backend/httpclient"
 	sdkHttpClient "github.com/grafana/grafana-plugin-sdk-go/backend/httpclient"
-	"github.com/grafana/grafana/pkg/infra/httpclient"
 	"github.com/grafana/grafana/pkg/services/featuremgmt"
 	"github.com/grafana/grafana/pkg/setting"
 	"github.com/stretchr/testify/assert"

--- a/pkg/tsdb/prometheus/heuristics_test.go
+++ b/pkg/tsdb/prometheus/heuristics_test.go
@@ -14,7 +14,6 @@ import (
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
 	"github.com/grafana/grafana-plugin-sdk-go/backend/datasource"
 	"github.com/grafana/grafana-plugin-sdk-go/backend/httpclient"
-	sdkHttpClient "github.com/grafana/grafana-plugin-sdk-go/backend/httpclient"
 	"github.com/grafana/grafana/pkg/services/featuremgmt"
 	"github.com/grafana/grafana/pkg/setting"
 )
@@ -40,20 +39,13 @@ func (rt *heuristicsSuccessRoundTripper) RoundTrip(req *http.Request) (*http.Res
 	}, nil
 }
 
-func (provider *heuristicsProvider) New(opts ...sdkHttpClient.Options) (*http.Client, error) {
-	client := &http.Client{}
-	client.Transport = provider.RoundTripper
-	return client, nil
-}
-
-func (provider *heuristicsProvider) GetTransport(opts ...sdkHttpClient.Options) (http.RoundTripper, error) {
-	return provider.RoundTripper, nil
-}
-
-func getHeuristicsMockProvider(rt http.RoundTripper) *heuristicsProvider {
-	return &heuristicsProvider{
-		RoundTripper: rt,
+func newHeuristicsSDKProvider(hrt heuristicsSuccessRoundTripper) *httpclient.Provider {
+	anotherFN := func(o httpclient.Options, next http.RoundTripper) http.RoundTripper {
+		return &hrt
 	}
+	fn := httpclient.MiddlewareFunc(anotherFN)
+	mid := httpclient.NamedMiddlewareFunc("mock", fn)
+	return httpclient.NewProvider(httpclient.ProviderOptions{Middlewares: []httpclient.Middleware{mid}})
 }
 
 func Test_GetHeuristics(t *testing.T) {
@@ -62,7 +54,8 @@ func Test_GetHeuristics(t *testing.T) {
 			res:    io.NopCloser(strings.NewReader("{\"status\":\"success\",\"data\":{\"version\":\"1.0\"}}")),
 			status: http.StatusOK,
 		}
-		httpProvider := getHeuristicsMockProvider(&rt)
+		//httpProvider := getHeuristicsMockProvider(&rt)
+		httpProvider := newHeuristicsSDKProvider(rt)
 		s := &Service{
 			im: datasource.NewInstanceManager(newInstanceSettings(httpProvider, &setting.Cfg{}, &featuremgmt.FeatureManager{}, nil, backend.NewLoggerWith("logger", "test"))),
 		}
@@ -82,7 +75,7 @@ func Test_GetHeuristics(t *testing.T) {
 			res:    io.NopCloser(strings.NewReader("{\"status\":\"success\",\"data\":{\"features\":{\"foo\":\"bar\"},\"version\":\"1.0\"}}")),
 			status: http.StatusOK,
 		}
-		httpProvider := getHeuristicsMockProvider(&rt)
+		httpProvider := newHeuristicsSDKProvider(rt)
 		s := &Service{
 			im: datasource.NewInstanceManager(newInstanceSettings(httpProvider, &setting.Cfg{}, &featuremgmt.FeatureManager{}, nil, backend.NewLoggerWith("logger", "test"))),
 		}

--- a/pkg/tsdb/prometheus/heuristics_test.go
+++ b/pkg/tsdb/prometheus/heuristics_test.go
@@ -18,11 +18,6 @@ import (
 	"github.com/grafana/grafana/pkg/setting"
 )
 
-type heuristicsProvider struct {
-	httpclient.Provider
-	http.RoundTripper
-}
-
 type heuristicsSuccessRoundTripper struct {
 	res    io.ReadCloser
 	status int

--- a/pkg/tsdb/prometheus/heuristics_test.go
+++ b/pkg/tsdb/prometheus/heuristics_test.go
@@ -13,8 +13,8 @@ import (
 
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
 	"github.com/grafana/grafana-plugin-sdk-go/backend/datasource"
+	"github.com/grafana/grafana-plugin-sdk-go/backend/httpclient"
 	sdkHttpClient "github.com/grafana/grafana-plugin-sdk-go/backend/httpclient"
-	"github.com/grafana/grafana/pkg/infra/httpclient"
 	"github.com/grafana/grafana/pkg/services/featuremgmt"
 	"github.com/grafana/grafana/pkg/setting"
 )

--- a/pkg/tsdb/prometheus/prometheus.go
+++ b/pkg/tsdb/prometheus/prometheus.go
@@ -14,7 +14,7 @@ import (
 	"github.com/patrickmn/go-cache"
 	apiv1 "github.com/prometheus/client_golang/api/prometheus/v1"
 
-	"github.com/grafana/grafana/pkg/infra/httpclient"
+	"github.com/grafana/grafana-plugin-sdk-go/backend/httpclient"
 	"github.com/grafana/grafana/pkg/infra/tracing"
 	"github.com/grafana/grafana/pkg/services/featuremgmt"
 	"github.com/grafana/grafana/pkg/setting"
@@ -36,7 +36,7 @@ type instance struct {
 	versionCache *cache.Cache
 }
 
-func ProvideService(httpClientProvider httpclient.Provider, cfg *setting.Cfg, features featuremgmt.FeatureToggles, tracer tracing.Tracer) *Service {
+func ProvideService(httpClientProvider *httpclient.Provider, cfg *setting.Cfg, features featuremgmt.FeatureToggles, tracer tracing.Tracer) *Service {
 	plog := backend.NewLoggerWith("logger", "tsdb.prometheus")
 	plog.Debug("Initializing")
 	return &Service{
@@ -46,7 +46,7 @@ func ProvideService(httpClientProvider httpclient.Provider, cfg *setting.Cfg, fe
 	}
 }
 
-func newInstanceSettings(httpClientProvider httpclient.Provider, cfg *setting.Cfg, features featuremgmt.FeatureToggles, tracer tracing.Tracer, log log.Logger) datasource.InstanceFactoryFunc {
+func newInstanceSettings(httpClientProvider *httpclient.Provider, cfg *setting.Cfg, features featuremgmt.FeatureToggles, tracer tracing.Tracer, log log.Logger) datasource.InstanceFactoryFunc {
 	return func(ctx context.Context, settings backend.DataSourceInstanceSettings) (instancemgmt.Instance, error) {
 		// Creates a http roundTripper.
 		opts, err := client.CreateTransportOptions(ctx, settings, cfg, log)

--- a/pkg/tsdb/prometheus/prometheus_test.go
+++ b/pkg/tsdb/prometheus/prometheus_test.go
@@ -9,12 +9,10 @@ import (
 
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
 	"github.com/grafana/grafana-plugin-sdk-go/backend/datasource"
-	sdkHttpClient "github.com/grafana/grafana-plugin-sdk-go/backend/httpclient"
+	"github.com/grafana/grafana-plugin-sdk-go/backend/httpclient"
 	"github.com/grafana/grafana/pkg/services/featuremgmt"
 	"github.com/grafana/grafana/pkg/setting"
 	"github.com/stretchr/testify/require"
-
-	"github.com/grafana/grafana-plugin-sdk-go/backend/httpclient"
 )
 
 type fakeSender struct{}
@@ -43,14 +41,14 @@ type fakeHTTPClientProvider struct {
 	Roundtripper *fakeRoundtripper
 }
 
-func (provider *fakeHTTPClientProvider) New(opts ...sdkHttpClient.Options) (*http.Client, error) {
+func (provider *fakeHTTPClientProvider) New(opts ...httpclient.Options) (*http.Client, error) {
 	client := &http.Client{}
 	provider.Roundtripper = &fakeRoundtripper{}
 	client.Transport = provider.Roundtripper
 	return client, nil
 }
 
-func (provider *fakeHTTPClientProvider) GetTransport(opts ...sdkHttpClient.Options) (http.RoundTripper, error) {
+func (provider *fakeHTTPClientProvider) GetTransport(opts ...httpclient.Options) (http.RoundTripper, error) {
 	return &fakeRoundtripper{}, nil
 }
 

--- a/pkg/tsdb/prometheus/prometheus_test.go
+++ b/pkg/tsdb/prometheus/prometheus_test.go
@@ -10,11 +10,11 @@ import (
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
 	"github.com/grafana/grafana-plugin-sdk-go/backend/datasource"
 	sdkHttpClient "github.com/grafana/grafana-plugin-sdk-go/backend/httpclient"
+	"github.com/grafana/grafana/pkg/services/featuremgmt"
+	"github.com/grafana/grafana/pkg/setting"
 	"github.com/stretchr/testify/require"
 
 	"github.com/grafana/grafana-plugin-sdk-go/backend/httpclient"
-	"github.com/grafana/grafana/pkg/services/featuremgmt"
-	"github.com/grafana/grafana/pkg/setting"
 )
 
 type fakeSender struct{}
@@ -54,11 +54,22 @@ func (provider *fakeHTTPClientProvider) GetTransport(opts ...sdkHttpClient.Optio
 	return &fakeRoundtripper{}, nil
 }
 
+func getMockPromTestSDKProvider(f *fakeHTTPClientProvider) *httpclient.Provider {
+	anotherFN := func(o httpclient.Options, next http.RoundTripper) http.RoundTripper {
+		_, _ = f.New()
+		return f.Roundtripper
+	}
+	fn := httpclient.MiddlewareFunc(anotherFN)
+	mid := httpclient.NamedMiddlewareFunc("mock", fn)
+	return httpclient.NewProvider(httpclient.ProviderOptions{Middlewares: []httpclient.Middleware{mid}})
+}
+
 func TestService(t *testing.T) {
 	t.Run("Service", func(t *testing.T) {
 		t.Run("CallResource", func(t *testing.T) {
 			t.Run("creates correct request", func(t *testing.T) {
-				httpProvider := &fakeHTTPClientProvider{}
+				f := &fakeHTTPClientProvider{}
+				httpProvider := getMockPromTestSDKProvider(f)
 				service := &Service{
 					im: datasource.NewInstanceManager(newInstanceSettings(httpProvider, &setting.Cfg{}, &featuremgmt.FeatureManager{}, nil, backend.NewLoggerWith("logger", "test"))),
 				}
@@ -98,12 +109,12 @@ func TestService(t *testing.T) {
 						"Content-Type":    {"application/x-www-form-urlencoded"},
 						"Idempotency-Key": []string(nil),
 					},
-					httpProvider.Roundtripper.Req.Header)
-				require.Equal(t, http.MethodPost, httpProvider.Roundtripper.Req.Method)
-				body, err := io.ReadAll(httpProvider.Roundtripper.Req.Body)
+					f.Roundtripper.Req.Header)
+				require.Equal(t, http.MethodPost, f.Roundtripper.Req.Method)
+				body, err := io.ReadAll(f.Roundtripper.Req.Body)
 				require.NoError(t, err)
 				require.Equal(t, []byte("match%5B%5D: ALERTS\nstart: 1655271408\nend: 1655293008"), body)
-				require.Equal(t, "http://localhost:9090/api/v1/series", httpProvider.Roundtripper.Req.URL.String())
+				require.Equal(t, "http://localhost:9090/api/v1/series", f.Roundtripper.Req.URL.String())
 			})
 		})
 	})

--- a/pkg/tsdb/prometheus/prometheus_test.go
+++ b/pkg/tsdb/prometheus/prometheus_test.go
@@ -12,7 +12,7 @@ import (
 	sdkHttpClient "github.com/grafana/grafana-plugin-sdk-go/backend/httpclient"
 	"github.com/stretchr/testify/require"
 
-	"github.com/grafana/grafana/pkg/infra/httpclient"
+	"github.com/grafana/grafana-plugin-sdk-go/backend/httpclient"
 	"github.com/grafana/grafana/pkg/services/featuremgmt"
 	"github.com/grafana/grafana/pkg/setting"
 )

--- a/pkg/tsdb/prometheus/querydata/request_test.go
+++ b/pkg/tsdb/prometheus/querydata/request_test.go
@@ -11,9 +11,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/grafana/grafana-plugin-sdk-go/backend"
-	sdkhttpclient "github.com/grafana/grafana-plugin-sdk-go/backend/httpclient"
-	"github.com/grafana/grafana-plugin-sdk-go/data"
 	apiv1 "github.com/prometheus/client_golang/api/prometheus/v1"
 	p "github.com/prometheus/common/model"
 	"github.com/stretchr/testify/require"
@@ -22,8 +19,10 @@ import (
 
 	"github.com/grafana/kindsys"
 
+	"github.com/grafana/grafana-plugin-sdk-go/backend"
 	"github.com/grafana/grafana-plugin-sdk-go/backend/httpclient"
 	"github.com/grafana/grafana-plugin-sdk-go/backend/log"
+	"github.com/grafana/grafana-plugin-sdk-go/data"
 	"github.com/grafana/grafana/pkg/infra/tracing"
 	"github.com/grafana/grafana/pkg/setting"
 	"github.com/grafana/grafana/pkg/tsdb/prometheus/client"
@@ -430,8 +429,8 @@ type testContext struct {
 func setup() (*testContext, error) {
 	tracer := tracing.InitializeTracerForTest()
 	httpProvider := &fakeHttpClientProvider{
-		opts: sdkhttpclient.Options{
-			Timeouts: &sdkhttpclient.DefaultTimeoutOptions,
+		opts: httpclient.Options{
+			Timeouts: &httpclient.DefaultTimeoutOptions,
 		},
 		res: &http.Response{
 			StatusCode: 200,
@@ -473,14 +472,14 @@ func (f *fakeFeatureToggles) IsEnabled(feature string) bool {
 
 type fakeHttpClientProvider struct {
 	httpclient.Provider
-	opts sdkhttpclient.Options
+	opts httpclient.Options
 	req  *http.Request
 	res  *http.Response
 }
 
-func (p *fakeHttpClientProvider) New(opts ...sdkhttpclient.Options) (*http.Client, error) {
+func (p *fakeHttpClientProvider) New(opts ...httpclient.Options) (*http.Client, error) {
 	p.opts = opts[0]
-	c, err := sdkhttpclient.New(opts[0])
+	c, err := httpclient.New(opts[0])
 	if err != nil {
 		return nil, err
 	}
@@ -488,7 +487,7 @@ func (p *fakeHttpClientProvider) New(opts ...sdkhttpclient.Options) (*http.Clien
 	return c, nil
 }
 
-func (p *fakeHttpClientProvider) GetTransport(opts ...sdkhttpclient.Options) (http.RoundTripper, error) {
+func (p *fakeHttpClientProvider) GetTransport(opts ...httpclient.Options) (http.RoundTripper, error) {
 	p.opts = opts[0]
 	return http.DefaultTransport, nil
 }

--- a/pkg/tsdb/prometheus/querydata/request_test.go
+++ b/pkg/tsdb/prometheus/querydata/request_test.go
@@ -22,8 +22,8 @@ import (
 
 	"github.com/grafana/kindsys"
 
+	"github.com/grafana/grafana-plugin-sdk-go/backend/httpclient"
 	"github.com/grafana/grafana-plugin-sdk-go/backend/log"
-	"github.com/grafana/grafana/pkg/infra/httpclient"
 	"github.com/grafana/grafana/pkg/infra/tracing"
 	"github.com/grafana/grafana/pkg/setting"
 	"github.com/grafana/grafana/pkg/tsdb/prometheus/client"


### PR DESCRIPTION
**What is this feature?**

Line up internal prometheus data source code with external datasource code by using the SDK httpclient instead of infra.
