### PR TITLE
Alerting: Rename remote.ExternalAlertmanager to remote.Alertmanager

### DIFF
--- a/pkg/services/ngalert/ngalert.go
+++ b/pkg/services/ngalert/ngalert.go
@@ -176,8 +176,8 @@ func (ng *AlertNG) init() error {
 	var overrides []notifier.Option
 	if ng.Cfg.UnifiedAlerting.RemoteAlertmanager.Enable {
 		override := notifier.WithAlertmanagerOverride(func(ctx context.Context, orgID int64) (notifier.Alertmanager, error) {
-			externalAMCfg := remote.ExternalAlertmanagerConfig{}
-			return remote.NewExternalAlertmanager(externalAMCfg, orgID)
+			externalAMCfg := remote.AlertmanagerConfig{}
+			return remote.NewAlertmanager(externalAMCfg, orgID)
 		})
 
 		overrides = append(overrides, override)

--- a/pkg/services/ngalert/remote/alertmanager.go
+++ b/pkg/services/ngalert/remote/alertmanager.go
@@ -22,7 +22,7 @@ import (
 	amsilence "github.com/prometheus/alertmanager/api/v2/client/silence"
 )
 
-type ExternalAlertmanager struct {
+type Alertmanager struct {
 	log           log.Logger
 	url           string
 	tenantID      string
@@ -32,14 +32,14 @@ type ExternalAlertmanager struct {
 	defaultConfig string
 }
 
-type ExternalAlertmanagerConfig struct {
+type AlertmanagerConfig struct {
 	URL               string
 	TenantID          string
 	BasicAuthPassword string
 	DefaultConfig     string
 }
 
-func NewExternalAlertmanager(cfg ExternalAlertmanagerConfig, orgID int64) (*ExternalAlertmanager, error) {
+func NewAlertmanager(cfg AlertmanagerConfig, orgID int64) (*Alertmanager, error) {
 	client := http.Client{
 		Transport: &roundTripper{
 			tenantID:          cfg.TenantID,
@@ -65,7 +65,7 @@ func NewExternalAlertmanager(cfg ExternalAlertmanagerConfig, orgID int64) (*Exte
 		return nil, err
 	}
 
-	return &ExternalAlertmanager{
+	return &Alertmanager{
 		amClient:      amclient.New(transport, nil),
 		httpClient:    &client,
 		log:           log.New("ngalert.notifier.external-alertmanager"),
@@ -76,19 +76,19 @@ func NewExternalAlertmanager(cfg ExternalAlertmanagerConfig, orgID int64) (*Exte
 	}, nil
 }
 
-func (am *ExternalAlertmanager) ApplyConfig(ctx context.Context, config *models.AlertConfiguration) error {
+func (am *Alertmanager) ApplyConfig(ctx context.Context, config *models.AlertConfiguration) error {
 	return nil
 }
 
-func (am *ExternalAlertmanager) SaveAndApplyConfig(ctx context.Context, cfg *apimodels.PostableUserConfig) error {
+func (am *Alertmanager) SaveAndApplyConfig(ctx context.Context, cfg *apimodels.PostableUserConfig) error {
 	return nil
 }
 
-func (am *ExternalAlertmanager) SaveAndApplyDefaultConfig(ctx context.Context) error {
+func (am *Alertmanager) SaveAndApplyDefaultConfig(ctx context.Context) error {
 	return nil
 }
 
-func (am *ExternalAlertmanager) CreateSilence(ctx context.Context, silence *apimodels.PostableSilence) (string, error) {
+func (am *Alertmanager) CreateSilence(ctx context.Context, silence *apimodels.PostableSilence) (string, error) {
 	defer func() {
 		if r := recover(); r != nil {
 			am.log.Error("Panic while creating silence", "err", r)
@@ -104,7 +104,7 @@ func (am *ExternalAlertmanager) CreateSilence(ctx context.Context, silence *apim
 	return res.Payload.SilenceID, nil
 }
 
-func (am *ExternalAlertmanager) DeleteSilence(ctx context.Context, silenceID string) error {
+func (am *Alertmanager) DeleteSilence(ctx context.Context, silenceID string) error {
 	defer func() {
 		if r := recover(); r != nil {
 			am.log.Error("Panic while deleting silence", "err", r)
@@ -119,7 +119,7 @@ func (am *ExternalAlertmanager) DeleteSilence(ctx context.Context, silenceID str
 	return nil
 }
 
-func (am *ExternalAlertmanager) GetSilence(ctx context.Context, silenceID string) (apimodels.GettableSilence, error) {
+func (am *Alertmanager) GetSilence(ctx context.Context, silenceID string) (apimodels.GettableSilence, error) {
 	defer func() {
 		if r := recover(); r != nil {
 			am.log.Error("Panic while getting silence", "err", r)
@@ -135,7 +135,7 @@ func (am *ExternalAlertmanager) GetSilence(ctx context.Context, silenceID string
 	return *res.Payload, nil
 }
 
-func (am *ExternalAlertmanager) ListSilences(ctx context.Context, filter []string) (apimodels.GettableSilences, error) {
+func (am *Alertmanager) ListSilences(ctx context.Context, filter []string) (apimodels.GettableSilences, error) {
 	defer func() {
 		if r := recover(); r != nil {
 			am.log.Error("Panic while listing silences", "err", r)
@@ -151,7 +151,7 @@ func (am *ExternalAlertmanager) ListSilences(ctx context.Context, filter []strin
 	return res.Payload, nil
 }
 
-func (am *ExternalAlertmanager) GetAlerts(ctx context.Context, active, silenced, inhibited bool, filter []string, receiver string) (apimodels.GettableAlerts, error) {
+func (am *Alertmanager) GetAlerts(ctx context.Context, active, silenced, inhibited bool, filter []string, receiver string) (apimodels.GettableAlerts, error) {
 	defer func() {
 		if r := recover(); r != nil {
 			am.log.Error("Panic while getting alerts", "err", r)
@@ -173,7 +173,7 @@ func (am *ExternalAlertmanager) GetAlerts(ctx context.Context, active, silenced,
 	return res.Payload, nil
 }
 
-func (am *ExternalAlertmanager) GetAlertGroups(ctx context.Context, active, silenced, inhibited bool, filter []string, receiver string) (apimodels.AlertGroups, error) {
+func (am *Alertmanager) GetAlertGroups(ctx context.Context, active, silenced, inhibited bool, filter []string, receiver string) (apimodels.AlertGroups, error) {
 	defer func() {
 		if r := recover(); r != nil {
 			am.log.Error("Panic while getting alert groups", "err", r)
@@ -198,7 +198,7 @@ func (am *ExternalAlertmanager) GetAlertGroups(ctx context.Context, active, sile
 // TODO: implement PutAlerts in a way that is similar to what Prometheus does.
 // This current implementation is only good for testing methods that retrieve alerts from the remote Alertmanager.
 // More details in issue https://github.com/grafana/grafana/issues/76692
-func (am *ExternalAlertmanager) PutAlerts(ctx context.Context, postableAlerts apimodels.PostableAlerts) error {
+func (am *Alertmanager) PutAlerts(ctx context.Context, postableAlerts apimodels.PostableAlerts) error {
 	defer func() {
 		if r := recover(); r != nil {
 			am.log.Error("Panic while putting alerts", "err", r)
@@ -220,11 +220,11 @@ func (am *ExternalAlertmanager) PutAlerts(ctx context.Context, postableAlerts ap
 	return err
 }
 
-func (am *ExternalAlertmanager) GetStatus() apimodels.GettableStatus {
+func (am *Alertmanager) GetStatus() apimodels.GettableStatus {
 	return apimodels.GettableStatus{}
 }
 
-func (am *ExternalAlertmanager) GetReceivers(ctx context.Context) ([]apimodels.Receiver, error) {
+func (am *Alertmanager) GetReceivers(ctx context.Context) ([]apimodels.Receiver, error) {
 	params := amreceiver.NewGetReceiversParamsWithContext(ctx)
 	res, err := am.amClient.Receiver.GetReceivers(params)
 	if err != nil {
@@ -238,30 +238,30 @@ func (am *ExternalAlertmanager) GetReceivers(ctx context.Context) ([]apimodels.R
 	return rcvs, nil
 }
 
-func (am *ExternalAlertmanager) TestReceivers(ctx context.Context, c apimodels.TestReceiversConfigBodyParams) (*notifier.TestReceiversResult, error) {
+func (am *Alertmanager) TestReceivers(ctx context.Context, c apimodels.TestReceiversConfigBodyParams) (*notifier.TestReceiversResult, error) {
 	return &notifier.TestReceiversResult{}, nil
 }
 
-func (am *ExternalAlertmanager) TestTemplate(ctx context.Context, c apimodels.TestTemplatesConfigBodyParams) (*notifier.TestTemplatesResults, error) {
+func (am *Alertmanager) TestTemplate(ctx context.Context, c apimodels.TestTemplatesConfigBodyParams) (*notifier.TestTemplatesResults, error) {
 	return &notifier.TestTemplatesResults{}, nil
 }
 
-func (am *ExternalAlertmanager) StopAndWait() {
+func (am *Alertmanager) StopAndWait() {
 }
 
-func (am *ExternalAlertmanager) Ready() bool {
+func (am *Alertmanager) Ready() bool {
 	return false
 }
 
-func (am *ExternalAlertmanager) FileStore() *notifier.FileStore {
+func (am *Alertmanager) FileStore() *notifier.FileStore {
 	return &notifier.FileStore{}
 }
 
-func (am *ExternalAlertmanager) OrgID() int64 {
+func (am *Alertmanager) OrgID() int64 {
 	return am.orgID
 }
 
-func (am *ExternalAlertmanager) ConfigHash() [16]byte {
+func (am *Alertmanager) ConfigHash() [16]byte {
 	return [16]byte{}
 }
 
@@ -283,7 +283,7 @@ func (r *roundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
 }
 
 // TODO: change implementation, this is only useful for testing other methods.
-func (am *ExternalAlertmanager) postConfig(ctx context.Context, rawConfig string) error {
+func (am *Alertmanager) postConfig(ctx context.Context, rawConfig string) error {
 	alertsURL := strings.TrimSuffix(am.url, "/alertmanager") + "/api/v1/alerts"
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, alertsURL, strings.NewReader(rawConfig))
 	if err != nil {

--- a/pkg/services/ngalert/remote/alertmanager_test.go
+++ b/pkg/services/ngalert/remote/alertmanager_test.go
@@ -21,7 +21,7 @@ const (
 	upstreamConfig = `{"template_files": {}, "alertmanager_config": "{\"global\": {\"smtp_from\": \"test@test.com\"}, \"route\": {\"receiver\": \"discord\"}, \"receivers\": [{\"name\": \"discord\", \"discord_configs\": [{\"webhook_url\": \"http://localhost:1234\"}]}]}"}`
 )
 
-func TestNewExternalAlertmanager(t *testing.T) {
+func TestNewAlertmanager(t *testing.T) {
 	tests := []struct {
 		name          string
 		url           string
@@ -70,13 +70,13 @@ func TestNewExternalAlertmanager(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(tt *testing.T) {
-			cfg := ExternalAlertmanagerConfig{
+			cfg := AlertmanagerConfig{
 				URL:               test.url,
 				TenantID:          test.tenantID,
 				BasicAuthPassword: test.password,
 				DefaultConfig:     test.defaultConfig,
 			}
-			am, err := NewExternalAlertmanager(cfg, test.orgID)
+			am, err := NewAlertmanager(cfg, test.orgID)
 			if test.expErr != "" {
 				require.EqualError(tt, err, test.expErr)
 				return
@@ -105,13 +105,13 @@ func TestIntegrationRemoteAlertmanagerSilences(t *testing.T) {
 	tenantID := os.Getenv("AM_TENANT_ID")
 	password := os.Getenv("AM_PASSWORD")
 
-	cfg := ExternalAlertmanagerConfig{
+	cfg := AlertmanagerConfig{
 		URL:               amURL + "/alertmanager",
 		TenantID:          tenantID,
 		BasicAuthPassword: password,
 		DefaultConfig:     validConfig,
 	}
-	am, err := NewExternalAlertmanager(cfg, 1)
+	am, err := NewAlertmanager(cfg, 1)
 	require.NoError(t, err)
 
 	// We should have no silences at first.
@@ -185,13 +185,13 @@ func TestIntegrationRemoteAlertmanagerAlerts(t *testing.T) {
 	tenantID := os.Getenv("AM_TENANT_ID")
 	password := os.Getenv("AM_PASSWORD")
 
-	cfg := ExternalAlertmanagerConfig{
+	cfg := AlertmanagerConfig{
 		URL:               amURL + "/alertmanager",
 		TenantID:          tenantID,
 		BasicAuthPassword: password,
 		DefaultConfig:     validConfig,
 	}
-	am, err := NewExternalAlertmanager(cfg, 1)
+	am, err := NewAlertmanager(cfg, 1)
 	require.NoError(t, err)
 
 	// We should have no alerts and no groups at first.
@@ -241,14 +241,14 @@ func TestIntegrationRemoteAlertmanagerReceivers(t *testing.T) {
 	tenantID := os.Getenv("AM_TENANT_ID")
 	password := os.Getenv("AM_PASSWORD")
 
-	cfg := ExternalAlertmanagerConfig{
+	cfg := AlertmanagerConfig{
 		URL:               amURL + "/alertmanager",
 		TenantID:          tenantID,
 		BasicAuthPassword: password,
 		DefaultConfig:     validConfig,
 	}
 
-	am, err := NewExternalAlertmanager(cfg, 1)
+	am, err := NewAlertmanager(cfg, 1)
 	require.NoError(t, err)
 
 	// We should start with the default config.


### PR DESCRIPTION
This PR renames structs and file names to avoid redundancy in names in the `remote` package.
- `.../remote/external_alertmanager.go` -> `.../remote/alertmanager.go`
    - `remote.ExternalAlertmanager` -> `remote.Alertmanager`
    - `remote.ExternalAlertmanagerConfig`-> `remote.AlertmanagerConfig`
- `.../remote/external_alertmanager_test.go` -> `.../remote/alertmanager_test.go`
    - `TestNewExternalAlertmanager` -> `TestNewAlertmanager`