### PR TITLE
Build: Faster external plugin builds

### DIFF
--- a/packages/grafana-plugin-configs/package.json
+++ b/packages/grafana-plugin-configs/package.json
@@ -13,6 +13,7 @@
     "fork-ts-checker-webpack-plugin": "8.0.0",
     "glob": "10.3.3",
     "replace-in-file-webpack-plugin": "1.0.6",
+    "swc-loader": "0.2.3",
     "webpack": "5.89.0"
   },
   "packageManager": "yarn@3.6.0"

--- a/packages/grafana-plugin-configs/webpack.config.ts
+++ b/packages/grafana-plugin-configs/webpack.config.ts
@@ -3,7 +3,7 @@ import ESLintPlugin from 'eslint-webpack-plugin';
 import ForkTsCheckerWebpackPlugin from 'fork-ts-checker-webpack-plugin';
 import path from 'path';
 import ReplaceInFileWebpackPlugin from 'replace-in-file-webpack-plugin';
-import { Configuration } from 'webpack';
+import { Configuration, DefinePlugin } from 'webpack';
 
 import { DIST_DIR } from './constants';
 import { getPackageJson, getPluginJson, getEntries, hasLicense } from './utils';
@@ -29,12 +29,6 @@ const config = async (env: Record<string, unknown>): Promise<Configuration> => {
         config: [__filename],
       },
       cacheDirectory: path.resolve(__dirname, '../../.yarn/.cache/webpack', path.basename(process.cwd())),
-      cacheLocation: path.resolve(
-        __dirname,
-        '../../.yarn/.cache/eslint-webpack-plugin',
-        path.basename(process.cwd()),
-        '.eslintcache'
-      ),
     },
 
     context: process.cwd(),
@@ -186,23 +180,35 @@ const config = async (env: Record<string, unknown>): Promise<Configuration> => {
           ],
         },
       ]),
-      new ForkTsCheckerWebpackPlugin({
-        async: Boolean(env.development),
-        issue: {
-          include: [{ file: '**/*.{ts,tsx}' }],
-        },
-        typescript: { configFile: path.join(process.cwd(), 'tsconfig.json') },
-      }),
-      new ESLintPlugin({
-        extensions: ['.ts', '.tsx'],
-        lintDirtyModulesOnly: Boolean(env.development), // don't lint on start, only lint changed files
-      }),
+      env.development
+        ? new ForkTsCheckerWebpackPlugin({
+            async: true,
+            issue: {
+              include: [{ file: '**/*.{ts,tsx}' }],
+            },
+            typescript: { configFile: path.join(process.cwd(), 'tsconfig.json') },
+          })
+        : new DefinePlugin({}),
+      env.development
+        ? new ESLintPlugin({
+            extensions: ['.ts', '.tsx'],
+            lintDirtyModulesOnly: true, // don't lint on start, only lint changed files
+            cacheLocation: path.resolve(
+              __dirname,
+              '../../.yarn/.cache/eslint-webpack-plugin',
+              path.basename(process.cwd()),
+              '.eslintcache'
+            ),
+          })
+        : new DefinePlugin({}),
     ],
 
     resolve: {
-      extensions: ['.js', '.jsx', '.ts', '.tsx'],
+      extensions: ['.ts', '.tsx', '.js', '.jsx'],
       unsafeCache: true,
     },
+
+    stats: env.production ? 'errors-only' : 'normal',
 
     watchOptions: {
       ignored: ['**/node_modules', '**/dist', '**/.yarn'],

--- a/packages/grafana-plugin-configs/webpack.config.ts
+++ b/packages/grafana-plugin-configs/webpack.config.ts
@@ -208,8 +208,6 @@ const config = async (env: Record<string, unknown>): Promise<Configuration> => {
       unsafeCache: true,
     },
 
-    stats: env.production ? 'errors-only' : 'normal',
-
     watchOptions: {
       ignored: ['**/node_modules', '**/dist', '**/.yarn'],
     },

--- a/packages/grafana-plugin-configs/webpack.config.ts
+++ b/packages/grafana-plugin-configs/webpack.config.ts
@@ -89,7 +89,7 @@ const config = async (env: Record<string, unknown>): Promise<Configuration> => {
           exclude: /(node_modules)/,
           test: /\.[tj]sx?$/,
           use: {
-            loader: 'swc-loader',
+            loader: require.resolve('swc-loader'),
             options: {
               jsc: {
                 baseUrl: '.',

--- a/public/app/plugins/datasource/grafana-testdata-datasource/package.json
+++ b/public/app/plugins/datasource/grafana-testdata-datasource/package.json
@@ -26,7 +26,6 @@
     "@types/node": "18.18.5",
     "@types/react": "18.2.15",
     "@types/testing-library__jest-dom": "5.14.8",
-    "swc-loader": "0.2.3",
     "ts-node": "10.9.1",
     "webpack": "5.89.0"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -2857,7 +2857,6 @@ __metadata:
     react: 18.2.0
     react-use: 17.4.0
     rxjs: 7.8.1
-    swc-loader: 0.2.3
     ts-node: 10.9.1
     tslib: 2.6.0
     webpack: 5.89.0
@@ -3255,6 +3254,7 @@ __metadata:
     fork-ts-checker-webpack-plugin: 8.0.0
     glob: 10.3.3
     replace-in-file-webpack-plugin: 1.0.6
+    swc-loader: 0.2.3
     tslib: 2.6.0
     webpack: 5.89.0
   languageName: unknown


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

This PR makes the following changes to the plugin-configs to speed up builds:

- Only run TsCheck and EsLint plugins in development mode. CI runs typecheck and lint tasks for the entire project that already validate this code.
- Prioritise typescript files when resolving extensions

This PR also removes the need for every plugin to define `swc-loader` and moves the `cacheLocation` from webpack cache settings to ESLintPlugin settings (so no node_modules directory is created).

## before

```
hyperfine --prepare "rm -rf .yarn/.cache/webpack/grafana-testdata-datasource" -r 8 "yarn run plugin:build"
Benchmark 1: yarn run plugin:build
  Time (mean ± σ):     11.127 s ±  0.382 s    [User: 23.434 s, System: 1.883 s]
  Range (min … max):   10.859 s … 11.904 s    8 runs
```

## after

```
hyperfine --prepare "rm -rf .yarn/.cache/webpack/grafana-testdata-datasource" -r 8 "yarn run plugin:build"
Benchmark 1: yarn run plugin:build
  Time (mean ± σ):      5.196 s ±  0.280 s    [User: 7.301 s, System: 1.303 s]
  Range (min … max):    5.061 s …  5.886 s    8 runs
```



**Why do we need this feature?**

To reduce time taken to build frontend plugin assets

**Who is this feature for?**

Grafana developers

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
