### PR TITLE
Logs Panel: Explore url sync for table visualization

### DIFF
--- a/packages/grafana-data/src/types/explore.ts
+++ b/packages/grafana-data/src/types/explore.ts
@@ -46,8 +46,6 @@ export interface ExploreTracePanelState {
 
 export interface ExploreLogsPanelState {
   id?: string;
-  columns?: Record<number, string>;
-  visualisationType?: 'table' | 'logs';
 }
 
 export interface SplitOpenOptions<T extends AnyQuery = AnyQuery> {

--- a/public/app/features/explore/Logs/Logs.test.tsx
+++ b/public/app/features/explore/Logs/Logs.test.tsx
@@ -436,7 +436,7 @@ describe('Logs', () => {
     });
 
     it('should call createAndCopyShortLink on permalinkClick - logs', async () => {
-      const panelState: Partial<ExplorePanelsState> = { logs: { id: 'not-included', visualisationType: 'logs' } };
+      const panelState: Partial<ExplorePanelsState> = { logs: { id: 'not-included' } };
       setup({ loading: false, panelState });
 
       const row = screen.getAllByRole('row');
@@ -450,7 +450,6 @@ describe('Logs', () => {
           'range%22:%7B%22from%22:%222019-01-01T10:00:00.000Z%22,%22to%22:%222019-01-01T16:00:00.000Z%22%7D'
         )
       );
-      expect(createAndCopyShortLink).toHaveBeenCalledWith(expect.stringMatching('visualisationType%22:%22logs'));
     });
   });
 

--- a/public/app/features/explore/Logs/Logs.tsx
+++ b/public/app/features/explore/Logs/Logs.tsx
@@ -152,7 +152,7 @@ class UnthemedLogs extends PureComponent<Props, State> {
     contextOpen: false,
     contextRow: undefined,
     tableFrame: undefined,
-    visualisationType: this.props.panelState?.logs?.visualisationType ?? 'logs',
+    visualisationType: 'logs',
     logsContainer: undefined,
   };
 
@@ -177,8 +177,6 @@ class UnthemedLogs extends PureComponent<Props, State> {
       dispatch(
         changePanelState(this.props.exploreId, 'logs', {
           ...state.panelsState.logs,
-          columns: logsPanelState.columns ?? this.props.panelState?.logs?.columns,
-          visualisationType: logsPanelState.visualisationType ?? this.state.visualisationType,
         })
       );
     }
@@ -402,7 +400,7 @@ class UnthemedLogs extends PureComponent<Props, State> {
     const urlState = getUrlStateFromPaneState(getState().explore.panes[this.props.exploreId]!);
     urlState.panelsState = {
       ...this.props.panelState,
-      logs: { id: row.uid, visualisationType: this.state.visualisationType ?? 'logs' },
+      logs: { id: row.uid },
     };
     urlState.range = {
       from: new Date(this.props.absoluteRange.from).toISOString(),

--- a/public/app/features/explore/Logs/LogsTableWrap.test.tsx
+++ b/public/app/features/explore/Logs/LogsTableWrap.test.tsx
@@ -69,47 +69,10 @@ describe('LogsTableWrap', () => {
     });
   });
 
-  it('updatePanelState should be called when a column is selected', async () => {
-    const updatePanelState = jest.fn() as (panelState: Partial<ExploreLogsPanelState>) => void;
-    setup({
-      panelState: {
-        visualisationType: 'table',
-        columns: undefined,
-      },
-      updatePanelState: updatePanelState,
-    });
-
-    expect.assertions(3);
-
-    const checkboxLabel = screen.getByLabelText('app');
-    expect(checkboxLabel).toBeInTheDocument();
-
-    // Add a new column
-    await waitFor(() => {
-      checkboxLabel.click();
-      expect(updatePanelState).toBeCalledWith({
-        visualisationType: 'table',
-        columns: { 0: 'app' },
-      });
-    });
-
-    // Remove the same column
-    await waitFor(() => {
-      checkboxLabel.click();
-      expect(updatePanelState).toBeCalledWith({
-        visualisationType: 'table',
-        columns: {},
-      });
-    });
-  });
-
   it('search input should search matching columns', async () => {
     const updatePanelState = jest.fn() as (panelState: Partial<ExploreLogsPanelState>) => void;
     setup({
-      panelState: {
-        visualisationType: 'table',
-        columns: undefined,
-      },
+      panelState: {},
       updatePanelState: updatePanelState,
     });
 

--- a/public/app/features/explore/Logs/LogsTableWrap.tsx
+++ b/public/app/features/explore/Logs/LogsTableWrap.tsx
@@ -1,7 +1,7 @@
 import { css } from '@emotion/css';
 import { debounce } from 'lodash';
 import memoizeOne from 'memoize-one';
-import React, { useState, useEffect, useCallback } from 'react';
+import React, { useEffect, useState } from 'react';
 
 import {
   DataFrame,
@@ -48,22 +48,6 @@ export function LogsTableWrap(props: Props) {
   const [filteredColumnsWithMeta, setFilteredColumnsWithMeta] = useState<fieldNameMetaStore | undefined>(undefined);
 
   const dataFrame = logsFrames[0];
-
-  const getColumnsFromProps = useCallback(
-    (fieldNames: fieldNameMetaStore) => {
-      const previouslySelected = props.panelState?.columns;
-      if (previouslySelected) {
-        Object.values(previouslySelected).forEach((key) => {
-          if (fieldNames[key]) {
-            fieldNames[key].active = true;
-          }
-        });
-      }
-
-      return fieldNames;
-    },
-    [props.panelState?.columns]
-  );
 
   /**
    * when the query results change, we need to update the columnsWithMeta state
@@ -133,13 +117,11 @@ export function LogsTableWrap(props: Props) {
       };
     });
 
-    pendingLabelState = getColumnsFromProps(pendingLabelState);
-
     setColumnsWithMeta(pendingLabelState);
 
     // The panel state is updated when the user interacts with the multi-select sidebar
     // This updates the url, which updates the props of this component, we don't want to re-calculate the column state in this case even though it's used by this hook
-  }, [dataFrame, getColumnsFromProps]);
+  }, [dataFrame]);
 
   if (!columnsWithMeta) {
     return null;
@@ -167,22 +149,6 @@ export function LogsTableWrap(props: Props) {
       };
       setFilteredColumnsWithMeta(pendingFilteredLabelState);
     }
-
-    const newPanelState: ExploreLogsPanelState = {
-      ...props.panelState,
-      // URL format requires our array of values be an object, so we convert it using object.assign
-      columns: Object.assign(
-        {},
-        // Get the keys of the object as an array
-        Object.keys(pendingLabelState)
-          // Only include active filters
-          .filter((key) => pendingLabelState[key]?.active)
-      ),
-      visualisationType: 'table',
-    };
-
-    // Update url state
-    props.updatePanelState(newPanelState);
   };
 
   // uFuzzy search dispatcher, adds any matches to the local state

--- a/public/app/features/explore/hooks/useStateSync/index.ts
+++ b/public/app/features/explore/hooks/useStateSync/index.ts
@@ -10,7 +10,7 @@ import { MIXED_DATASOURCE_NAME } from 'app/plugins/datasource/mixed/MixedDataSou
 import { addListener, ExploreItemState, ExploreQueryParams, useDispatch, useSelector } from 'app/types';
 
 import { changeDatasource } from '../../state/datasource';
-import { changePanelsStateAction, initializeExplore } from '../../state/explorePane';
+import { initializeExplore } from '../../state/explorePane';
 import { clearPanes, splitClose, splitOpen, syncTimesAction } from '../../state/main';
 import { runQueries, setQueriesAction } from '../../state/query';
 import { selectPanes } from '../../state/selectors';
@@ -49,14 +49,9 @@ export function useStateSync(params: ExploreQueryParams) {
           // - a pane is opened or closed
           // - a query is run
           // - range is changed
-          // - panel state is updated
-          [
-            splitClose.type,
-            splitOpen.fulfilled.type,
-            runQueries.pending.type,
-            changeRangeAction.type,
-            changePanelsStateAction.type,
-          ].includes(action.type),
+          [splitClose.type, splitOpen.fulfilled.type, runQueries.pending.type, changeRangeAction.type].includes(
+            action.type
+          ),
         effect: async (_, { cancelActiveListeners, delay, getState }) => {
           // The following 2 lines will throttle updates to avoid creating history entries when rapid changes
           // are committed to the store.

--- a/public/app/features/explore/state/explorePane.ts
+++ b/public/app/features/explore/state/explorePane.ts
@@ -53,7 +53,7 @@ interface ChangePanelsState {
   exploreId: string;
   panelsState: ExplorePanelsState;
 }
-export const changePanelsStateAction = createAction<ChangePanelsState>('explore/changePanels');
+const changePanelsStateAction = createAction<ChangePanelsState>('explore/changePanels');
 export function changePanelState(
   exploreId: string,
   panel: PreferredVisualisationType,


### PR DESCRIPTION
**What is this feature?**
_Experimental_ 
New UI for selecting columns in table visualization (under `logsExploreTableVisualisation` feature flag) introduced in https://github.com/grafana/grafana/pull/71120. 

Syncing selected columns and visualization type with explore URL so selected columns can be shared via explore URLs.

Users need a way to share configured tables from log queries.

**Why do we need this feature?**

So users can share logs table results

**Who is this feature for?**
Logs users

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
