### PR TITLE
RBAC: Allow scoping access to root level dashboards

### DIFF
--- a/pkg/services/accesscontrol/ossaccesscontrol/permissions_services.go
+++ b/pkg/services/accesscontrol/ossaccesscontrol/permissions_services.go
@@ -163,7 +163,7 @@ func ProvideDashboardPermissions(
 				}
 				return append([]string{parentScope}, nestedScopes...), nil
 			}
-			return []string{}, nil
+			return []string{dashboards.ScopeFoldersProvider.GetResourceScopeUID(folder.GeneralFolderUID)}, nil
 		},
 		Assignments: resourcepermissions.Assignments{
 			Users:           true,

--- a/pkg/services/sqlstore/permissions/dashboard.go
+++ b/pkg/services/sqlstore/permissions/dashboard.go
@@ -233,8 +233,7 @@ func (f *accessControlDashboardPermissionFilter) buildClauses() {
 			builder.WriteString(") AND NOT dashboard.is_folder)")
 
 			// Include all the dashboards under the root if the user has the required permissions on the root (used to be the General folder)
-			hasAccessToDashboardsInGeneralFolder := hasAccessToRoot(toCheck, f.user)
-			if hasAccessToDashboardsInGeneralFolder {
+			if hasAccessToRoot(toCheck, f.user) {
 				builder.WriteString(" OR (dashboard.folder_id = 0 AND NOT dashboard.is_folder)")
 			}
 		} else {

--- a/pkg/services/sqlstore/permissions/dashboard_filter_no_subquery.go
+++ b/pkg/services/sqlstore/permissions/dashboard_filter_no_subquery.go
@@ -146,6 +146,12 @@ func (f *accessControlDashboardPermissionFilterNoFolderSubquery) buildClauses() 
 				}
 				builder.WriteString(" AND NOT dashboard.is_folder)")
 			}
+
+			// Include all the dashboards under the root if the user has the required permissions on the root (used to be the General folder)
+			hasAccessToDashboardsInGeneralFolder := hasAccessToRoot(toCheck, f.user)
+			if hasAccessToDashboardsInGeneralFolder {
+				builder.WriteString(" OR (dashboard.folder_id = 0 AND NOT dashboard.is_folder)")
+			}
 		} else {
 			builder.WriteString("NOT dashboard.is_folder")
 		}

--- a/pkg/services/sqlstore/permissions/dashboard_filter_no_subquery.go
+++ b/pkg/services/sqlstore/permissions/dashboard_filter_no_subquery.go
@@ -148,8 +148,7 @@ func (f *accessControlDashboardPermissionFilterNoFolderSubquery) buildClauses() 
 			}
 
 			// Include all the dashboards under the root if the user has the required permissions on the root (used to be the General folder)
-			hasAccessToDashboardsInGeneralFolder := hasAccessToRoot(toCheck, f.user)
-			if hasAccessToDashboardsInGeneralFolder {
+			if hasAccessToRoot(toCheck, f.user) {
 				builder.WriteString(" OR (dashboard.folder_id = 0 AND NOT dashboard.is_folder)")
 			}
 		} else {

--- a/pkg/services/sqlstore/permissions/dashboard_test.go
+++ b/pkg/services/sqlstore/permissions/dashboard_test.go
@@ -52,7 +52,7 @@ func TestIntegration_DashboardPermissionFilter(t *testing.T) {
 			permissions: []accesscontrol.Permission{
 				{Action: dashboards.ActionDashboardsRead, Scope: dashboards.ScopeDashboardsAll},
 			},
-			expectedResult: 100,
+			expectedResult: 110,
 		},
 		{
 			desc:       "Should be able to view all dashboards with folder wildcard scope",
@@ -60,7 +60,32 @@ func TestIntegration_DashboardPermissionFilter(t *testing.T) {
 			permissions: []accesscontrol.Permission{
 				{Action: dashboards.ActionDashboardsRead, Scope: dashboards.ScopeFoldersAll},
 			},
-			expectedResult: 100,
+			expectedResult: 110,
+		},
+		{
+			desc:       "Should be able to view dashboards under the root with folders:uid:general scope",
+			permission: dashboards.PERMISSION_VIEW,
+			permissions: []accesscontrol.Permission{
+				{Action: dashboards.ActionDashboardsRead, Scope: dashboards.ScopeFoldersProvider.GetResourceScopeUID(folder.GeneralFolderUID)},
+			},
+			expectedResult: 10,
+		},
+		{
+			desc:       "Should not be able to view editable dashboards under the root with folders:uid:general scope if missing write action",
+			permission: dashboards.PERMISSION_EDIT,
+			permissions: []accesscontrol.Permission{
+				{Action: dashboards.ActionDashboardsRead, Scope: dashboards.ScopeFoldersProvider.GetResourceScopeUID(folder.GeneralFolderUID)},
+			},
+			expectedResult: 0,
+		},
+		{
+			desc:       "Should be able to view editable dashboards under the root with folders:uid:general scope if has write action",
+			permission: dashboards.PERMISSION_EDIT,
+			permissions: []accesscontrol.Permission{
+				{Action: dashboards.ActionDashboardsRead, Scope: dashboards.ScopeFoldersProvider.GetResourceScopeUID(folder.GeneralFolderUID)},
+				{Action: dashboards.ActionDashboardsWrite, Scope: dashboards.ScopeFoldersProvider.GetResourceScopeUID(folder.GeneralFolderUID)},
+			},
+			expectedResult: 10,
 		},
 		{
 			desc:       "Should be able to view a subset of dashboards with dashboard scopes",
@@ -163,7 +188,7 @@ func TestIntegration_DashboardPermissionFilter(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		store := setupTest(t, 10, 100, tt.permissions)
+		store := setupTest(t, 10, 110, tt.permissions)
 		recursiveQueriesAreSupported, err := store.RecursiveQueriesAreSupported()
 		require.NoError(t, err)
 
@@ -219,7 +244,7 @@ func TestIntegration_DashboardPermissionFilter_WithSelfContainedPermissions(t *t
 			signedInUserPermissions: []accesscontrol.Permission{
 				{Action: dashboards.ActionDashboardsRead, Scope: dashboards.ScopeDashboardsAll},
 			},
-			expectedResult: 100,
+			expectedResult: 110,
 		},
 		{
 			desc:       "Should be able to view all dashboards with folder wildcard scope",
@@ -227,7 +252,7 @@ func TestIntegration_DashboardPermissionFilter_WithSelfContainedPermissions(t *t
 			signedInUserPermissions: []accesscontrol.Permission{
 				{Action: dashboards.ActionDashboardsRead, Scope: dashboards.ScopeFoldersAll},
 			},
-			expectedResult: 100,
+			expectedResult: 110,
 		},
 		{
 			desc:                    "Should not be able to view any dashboards or folders without any permissions",
@@ -257,6 +282,31 @@ func TestIntegration_DashboardPermissionFilter_WithSelfContainedPermissions(t *t
 				{Action: dashboards.ActionDashboardsRead, Scope: "folders:uid:10"},
 			},
 			expectedResult: 20,
+		},
+		{
+			desc:       "Should be able to view dashboards under the root with folders:uid:general scope",
+			permission: dashboards.PERMISSION_VIEW,
+			signedInUserPermissions: []accesscontrol.Permission{
+				{Action: dashboards.ActionDashboardsRead, Scope: dashboards.ScopeFoldersProvider.GetResourceScopeUID(folder.GeneralFolderUID)},
+			},
+			expectedResult: 10,
+		},
+		{
+			desc:       "Should not be able to view editable dashboards under the root with folders:uid:general scope if missing write action",
+			permission: dashboards.PERMISSION_EDIT,
+			signedInUserPermissions: []accesscontrol.Permission{
+				{Action: dashboards.ActionDashboardsRead, Scope: dashboards.ScopeFoldersProvider.GetResourceScopeUID(folder.GeneralFolderUID)},
+			},
+			expectedResult: 0,
+		},
+		{
+			desc:       "Should be able to view editable dashboards under the root with folders:uid:general scope if has write action",
+			permission: dashboards.PERMISSION_EDIT,
+			signedInUserPermissions: []accesscontrol.Permission{
+				{Action: dashboards.ActionDashboardsRead, Scope: dashboards.ScopeFoldersProvider.GetResourceScopeUID(folder.GeneralFolderUID)},
+				{Action: dashboards.ActionDashboardsWrite, Scope: dashboards.ScopeFoldersProvider.GetResourceScopeUID(folder.GeneralFolderUID)},
+			},
+			expectedResult: 10,
 		},
 		{
 			desc:       "Should be able to view all folders with folder wildcard",
@@ -337,7 +387,7 @@ func TestIntegration_DashboardPermissionFilter_WithSelfContainedPermissions(t *t
 	}
 
 	for _, tt := range tests {
-		store := setupTest(t, 10, 100, []accesscontrol.Permission{})
+		store := setupTest(t, 10, 110, []accesscontrol.Permission{})
 		recursiveQueriesAreSupported, err := store.RecursiveQueriesAreSupported()
 		require.NoError(t, err)
 
@@ -717,12 +767,12 @@ func setupTest(t *testing.T, numFolders, numDashboards int, permissions []access
 				Updated:  time.Now(),
 			})
 		}
-		// Seed 100 dashboard
+		// Seed dashboards
 		for i := numFolders + 1; i <= numFolders+numDashboards; i++ {
 			str := strconv.Itoa(i)
-			folderID := numFolders
-			if i%numFolders != 0 {
-				folderID = i % numFolders
+			folderID := 0
+			if i%(numFolders+1) != 0 {
+				folderID = i % (numFolders + 1)
 			}
 			dashes = append(dashes, dashboards.Dashboard{
 				OrgID:    1,


### PR DESCRIPTION
**What is this feature?**

Take into account dashboard listing permissions scoped to the root (`folders:uid:general`) when listing dashboards.

**Why do we need this feature?**

To allow scoping access to root level dashboards.

**Who is this feature for?**

Anyone

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes https://github.com/grafana/grafana-enterprise/issues/5920

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
