### PR TITLE
Canvas: Button API update toaster error message

### DIFF
--- a/public/app/plugins/panel/canvas/editor/element/utils.ts
+++ b/public/app/plugins/panel/canvas/editor/element/utils.ts
@@ -23,7 +23,8 @@ export const callApi = (api: APIEditorConfig, updateLoadingStateCallback?: IsLoa
       .fetch(request)
       .subscribe({
         error: (error) => {
-          appEvents.emit(AppEvents.alertError, ['An error has occurred: ', JSON.stringify(error)]);
+          appEvents.emit(AppEvents.alertError, ['An error has occurred. Check console output for more details.']);
+          console.error('API call error: ', error);
           updateLoadingStateCallback && updateLoadingStateCallback(false);
         },
         complete: () => {


### PR DESCRIPTION
This PR simplify the error message displayed in the toaster and adds more context in console.

Before
![error_before](https://github.com/grafana/grafana/assets/88068998/55760ac2-b4f8-4441-99b8-b16b335be4f5)

After
![error](https://github.com/grafana/grafana/assets/88068998/dc58ff84-0556-4fe1-98dd-93b483a631ea)


**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
