### PR TITLE
Navigation: Basic e2e tests for docked mega menu

### DIFF
--- a/e2e/various-suite/navigation.spec.ts
+++ b/e2e/various-suite/navigation.spec.ts
@@ -3,6 +3,7 @@ import { fromBaseUrl } from '../utils/support/url';
 
 describe('Docked Navigation', () => {
   beforeEach(() => {
+    cy.viewport(1280, 800);
     e2e.flows.login(Cypress.env('USERNAME'), Cypress.env('PASSWORD'));
 
     cy.visit(fromBaseUrl('/'), {
@@ -13,7 +14,7 @@ describe('Docked Navigation', () => {
   });
 
   it('should remain docked when reloading the page', () => {
-    // First, expand the mega menu
+    // Expand, then dock the mega menu
     cy.get('[aria-label="Toggle menu"]').click();
     cy.get('[aria-label="Dock menu"]').click();
 
@@ -24,7 +25,7 @@ describe('Docked Navigation', () => {
   });
 
   it('should remain docked when navigating to another page', () => {
-    // First, expand the mega menu
+    // Expand, then dock the mega menu
     cy.get('[aria-label="Toggle menu"]').click();
     cy.get('[aria-label="Dock menu"]').click();
 
@@ -32,6 +33,15 @@ describe('Docked Navigation', () => {
     e2e.components.NavMenu.Menu().should('be.visible');
 
     cy.contains('a', 'Users').click();
+    e2e.components.NavMenu.Menu().should('be.visible');
+  });
+
+  it('should become docked at larger viewport sizes', () => {
+    e2e.components.NavMenu.Menu().should('not.exist');
+
+    cy.viewport(1920, 1080);
+    cy.reload();
+
     e2e.components.NavMenu.Menu().should('be.visible');
   });
 });

--- a/e2e/various-suite/navigation.spec.ts
+++ b/e2e/various-suite/navigation.spec.ts
@@ -1,12 +1,6 @@
 import { e2e } from '../utils';
 import { fromBaseUrl } from '../utils/support/url';
 
-function megaMenuShouldBeDocked() {
-  // TODO: is this a good way to assert the menu is docked?
-  cy.get('[aria-label="Dock menu"]').should('not.exist');
-  cy.get('[aria-label="Undock menu"]').should('exist');
-}
-
 describe('Docked Navigation', () => {
   beforeEach(() => {
     e2e.flows.login(Cypress.env('USERNAME'), Cypress.env('PASSWORD'));
@@ -23,10 +17,10 @@ describe('Docked Navigation', () => {
     cy.get('[aria-label="Toggle menu"]').click();
     cy.get('[aria-label="Dock menu"]').click();
 
-    megaMenuShouldBeDocked();
+    e2e.components.NavMenu.Menu().should('be.visible');
 
     cy.reload();
-    megaMenuShouldBeDocked();
+    e2e.components.NavMenu.Menu().should('be.visible');
   });
 
   it('should remain docked when navigating to another page', () => {
@@ -35,9 +29,9 @@ describe('Docked Navigation', () => {
     cy.get('[aria-label="Dock menu"]').click();
 
     cy.contains('a', 'Administration').click();
-    megaMenuShouldBeDocked();
+    e2e.components.NavMenu.Menu().should('be.visible');
 
     cy.contains('a', 'Users').click();
-    megaMenuShouldBeDocked();
+    e2e.components.NavMenu.Menu().should('be.visible');
   });
 });

--- a/e2e/various-suite/navigation.spec.ts
+++ b/e2e/various-suite/navigation.spec.ts
@@ -1,0 +1,43 @@
+import { e2e } from '../utils';
+import { fromBaseUrl } from '../utils/support/url';
+
+function megaMenuShouldBeDocked() {
+  // TODO: is this a good way to assert the menu is docked?
+  cy.get('[aria-label="Dock menu"]').should('not.exist');
+  cy.get('[aria-label="Undock menu"]').should('exist');
+}
+
+describe('Docked Navigation', () => {
+  beforeEach(() => {
+    e2e.flows.login(Cypress.env('USERNAME'), Cypress.env('PASSWORD'));
+
+    cy.visit(fromBaseUrl('/'), {
+      onBeforeLoad(window) {
+        window.localStorage.setItem('grafana.featureToggles', 'dockedMegaMenu=1');
+      },
+    });
+  });
+
+  it('should remain docked when reloading the page', () => {
+    // First, expand the mega menu
+    cy.get('[aria-label="Toggle menu"]').click();
+    cy.get('[aria-label="Dock menu"]').click();
+
+    megaMenuShouldBeDocked();
+
+    cy.reload();
+    megaMenuShouldBeDocked();
+  });
+
+  it('should remain docked when navigating to another page', () => {
+    // First, expand the mega menu
+    cy.get('[aria-label="Toggle menu"]').click();
+    cy.get('[aria-label="Dock menu"]').click();
+
+    cy.contains('a', 'Administration').click();
+    megaMenuShouldBeDocked();
+
+    cy.contains('a', 'Users').click();
+    megaMenuShouldBeDocked();
+  });
+});

--- a/packages/grafana-e2e-selectors/src/selectors/components.ts
+++ b/packages/grafana-e2e-selectors/src/selectors/components.ts
@@ -264,6 +264,7 @@ export const Components = {
     },
   },
   NavMenu: {
+    Menu: 'data-testid navigation mega-menu',
     item: 'data-testid Nav menu item',
   },
   NavToolbar: {

--- a/public/app/core/components/AppChrome/DockedMegaMenu/MegaMenu.test.tsx
+++ b/public/app/core/components/AppChrome/DockedMegaMenu/MegaMenu.test.tsx
@@ -5,6 +5,7 @@ import { Router } from 'react-router-dom';
 import { getGrafanaContextMock } from 'test/mocks/getGrafanaContextMock';
 
 import { NavModelItem } from '@grafana/data';
+import { selectors } from '@grafana/e2e-selectors';
 import { locationService } from '@grafana/runtime';
 
 import { TestProvider } from '../../../../../test/helpers/TestProvider';
@@ -53,7 +54,7 @@ describe('MegaMenu', () => {
   it('should render component', async () => {
     setup();
 
-    expect(await screen.findByTestId('navbarmenu')).toBeInTheDocument();
+    expect(await screen.findByTestId(selectors.components.NavMenu.Menu)).toBeInTheDocument();
     expect(await screen.findByRole('link', { name: 'Section name' })).toBeInTheDocument();
   });
 

--- a/public/app/core/components/AppChrome/DockedMegaMenu/MegaMenu.tsx
+++ b/public/app/core/components/AppChrome/DockedMegaMenu/MegaMenu.tsx
@@ -4,6 +4,7 @@ import React, { forwardRef } from 'react';
 import { useLocation } from 'react-router-dom';
 
 import { GrafanaTheme2 } from '@grafana/data';
+import { selectors } from '@grafana/e2e-selectors';
 import { CustomScrollbar, Icon, IconButton, useStyles2 } from '@grafana/ui';
 import { Flex } from '@grafana/ui/src/unstable';
 import { useGrafana } from 'app/core/context/GrafanaContext';
@@ -39,7 +40,7 @@ export const MegaMenu = React.memo(
     };
 
     return (
-      <div data-testid="navbarmenu" ref={ref} {...restProps}>
+      <div data-testid={selectors.components.NavMenu.Menu} ref={ref} {...restProps}>
         <div className={styles.mobileHeader}>
           <Icon name="bars" size="xl" />
           <IconButton

--- a/public/app/core/components/AppChrome/MegaMenu/MegaMenu.test.tsx
+++ b/public/app/core/components/AppChrome/MegaMenu/MegaMenu.test.tsx
@@ -4,6 +4,7 @@ import { Router } from 'react-router-dom';
 import { getGrafanaContextMock } from 'test/mocks/getGrafanaContextMock';
 
 import { NavModelItem } from '@grafana/data';
+import { selectors } from '@grafana/e2e-selectors';
 import { locationService } from '@grafana/runtime';
 
 import { TestProvider } from '../../../../../test/helpers/TestProvider';
@@ -44,7 +45,7 @@ describe('MegaMenu', () => {
   it('should render component', async () => {
     setup();
 
-    expect(await screen.findByTestId('navbarmenu')).toBeInTheDocument();
+    expect(await screen.findByTestId(selectors.components.NavMenu.Menu)).toBeInTheDocument();
     expect(await screen.findByRole('link', { name: 'Section name' })).toBeInTheDocument();
   });
 

--- a/public/app/core/components/AppChrome/MegaMenu/NavBarMenu.tsx
+++ b/public/app/core/components/AppChrome/MegaMenu/NavBarMenu.tsx
@@ -6,6 +6,7 @@ import React, { useEffect, useRef, useState } from 'react';
 import CSSTransition from 'react-transition-group/CSSTransition';
 
 import { GrafanaTheme2, NavModelItem } from '@grafana/data';
+import { selectors } from '@grafana/e2e-selectors';
 import { CustomScrollbar, Icon, IconButton, useTheme2 } from '@grafana/ui';
 import { useGrafana } from 'app/core/context/GrafanaContext';
 
@@ -62,7 +63,13 @@ export function NavBarMenu({ activeItem, navItems, searchBarHidden, onClose }: P
         onExited={onClose}
       >
         <FocusScope contain autoFocus>
-          <div data-testid="navbarmenu" ref={ref} {...overlayProps} {...dialogProps} className={styles.container}>
+          <div
+            data-testid={selectors.components.NavMenu.Menu}
+            ref={ref}
+            {...overlayProps}
+            {...dialogProps}
+            className={styles.container}
+          >
             <div className={styles.mobileHeader}>
               <Icon name="bars" size="xl" />
               <IconButton


### PR DESCRIPTION
Adds some basic e2e tests for dockedMegaMenu functionality:
 - should remain docked when reloading the page
 - should remain docked when navigating to another page
 - should become docked at larger viewport sizes

I did something mildly controversial - i set the `dockedMegaMenu` feature flag in local storage before the tests run, which allows us to test this feature flagged behaviour without changing the e2e custom.ini. Thoughts?

Fixes https://github.com/grafana/grafana/issues/76518 