### PR TITLE
Page: Remove Canvas background from primary background pages

### DIFF
--- a/public/app/core/components/AppChrome/AppChrome.tsx
+++ b/public/app/core/components/AppChrome/AppChrome.tsx
@@ -141,7 +141,7 @@ const getStyles = (theme: GrafanaTheme2) => {
       zIndex: theme.zIndex.navbarFixed,
       left: 0,
       right: 0,
-      boxShadow: shadow,
+      boxShadow: config.featureToggles.dockedMegaMenu ? undefined : shadow,
       background: theme.colors.background.primary,
       flexDirection: 'column',
       borderBottom: `1px solid ${theme.colors.border.weak}`,

--- a/public/app/core/components/Page/Page.tsx
+++ b/public/app/core/components/Page/Page.tsx
@@ -54,7 +54,7 @@ export const Page: PageType = ({
     <div className={cx(styles.wrapper, className)} {...otherProps}>
       {layout === PageLayoutType.Standard && (
         <CustomScrollbar autoHeightMin={'100%'} scrollTop={scrollTop} scrollRefCallback={scrollRef}>
-          <div className={styles.pageInner}>
+          <div className={cx(styles.pageInner, config.featureToggles.dockedMegaMenu && styles.newPageInner)}>
             {pageHeaderNav && (
               <PageHeader
                 actions={actions}
@@ -99,8 +99,8 @@ const getStyles = (theme: GrafanaTheme2) => {
     pageInner: css({
       label: 'page-inner',
       padding: theme.spacing(2),
-      borderRadius: theme.shape.radius.default,
-      border: `1px solid ${theme.colors.border.weak}`,
+      borderRadius: theme.shape.radius.default, // removed by dockedMegaMenu toggle
+      border: `1px solid ${theme.colors.border.weak}`, // removed by dockedMegaMenu toggle
       borderBottom: 'none',
       background: theme.colors.background.primary,
       display: 'flex',
@@ -109,10 +109,22 @@ const getStyles = (theme: GrafanaTheme2) => {
       margin: theme.spacing(0, 0, 0, 0),
 
       [theme.breakpoints.up('md')]: {
-        margin: theme.spacing(2, 2, 0, config.featureToggles.dockedMegaMenu ? 2 : 1),
-        padding: theme.spacing(3),
+        margin: theme.spacing(2, 2, 0, config.featureToggles.dockedMegaMenu ? 2 : 1), // removed by dockedMegaMenu toggle
+        padding: theme.spacing(3), // changed by dockedMegaMenu toggle
       },
     }),
+
+    // Only applied when the dockedMegaMenu feature toggle is enabled
+    newPageInner: css({
+      borderRadius: 0,
+      border: 'none',
+
+      [theme.breakpoints.up('md')]: {
+        margin: 0,
+        padding: theme.spacing(4),
+      },
+    }),
+
     canvasContent: css({
       label: 'canvas-content',
       display: 'flex',

--- a/public/app/core/components/Page/Page.tsx
+++ b/public/app/core/components/Page/Page.tsx
@@ -54,7 +54,7 @@ export const Page: PageType = ({
     <div className={cx(styles.wrapper, className)} {...otherProps}>
       {layout === PageLayoutType.Standard && (
         <CustomScrollbar autoHeightMin={'100%'} scrollTop={scrollTop} scrollRefCallback={scrollRef}>
-          <div className={cx(styles.pageInner, config.featureToggles.dockedMegaMenu && styles.newPageInner)}>
+          <div className={styles.pageInner}>
             {pageHeaderNav && (
               <PageHeader
                 actions={actions}
@@ -96,34 +96,33 @@ const getStyles = (theme: GrafanaTheme2) => {
       label: 'page-content',
       flexGrow: 1,
     }),
-    pageInner: css({
-      label: 'page-inner',
-      padding: theme.spacing(2),
-      borderRadius: theme.shape.radius.default, // removed by dockedMegaMenu toggle
-      border: `1px solid ${theme.colors.border.weak}`, // removed by dockedMegaMenu toggle
-      borderBottom: 'none',
-      background: theme.colors.background.primary,
-      display: 'flex',
-      flexDirection: 'column',
-      flexGrow: 1,
-      margin: theme.spacing(0, 0, 0, 0),
-
-      [theme.breakpoints.up('md')]: {
-        margin: theme.spacing(2, 2, 0, config.featureToggles.dockedMegaMenu ? 2 : 1), // removed by dockedMegaMenu toggle
-        padding: theme.spacing(3), // changed by dockedMegaMenu toggle
+    pageInner: css(
+      {
+        label: 'page-inner',
+        padding: theme.spacing(2),
+        borderBottom: 'none',
+        background: theme.colors.background.primary,
+        display: 'flex',
+        flexDirection: 'column',
+        flexGrow: 1,
+        margin: theme.spacing(0, 0, 0, 0),
       },
-    }),
+      config.featureToggles.dockedMegaMenu
+        ? {
+            [theme.breakpoints.up('md')]: {
+              padding: theme.spacing(4),
+            },
+          }
+        : {
+            borderRadius: theme.shape.radius.default,
+            border: `1px solid ${theme.colors.border.weak}`,
 
-    // Only applied when the dockedMegaMenu feature toggle is enabled
-    newPageInner: css({
-      borderRadius: 0,
-      border: 'none',
-
-      [theme.breakpoints.up('md')]: {
-        margin: 0,
-        padding: theme.spacing(4),
-      },
-    }),
+            [theme.breakpoints.up('md')]: {
+              margin: theme.spacing(2, 2, 0, 1),
+              padding: theme.spacing(3),
+            },
+          }
+    ),
 
     canvasContent: css({
       label: 'canvas-content',


### PR DESCRIPTION
 - Removes the margin from the default Page so the content no longer appears in a 'frame' on a canvas background
 - Adjusts the Page padding to 32px

I think this is good for now, but I think it would like to change the main HTML background colour to Primary, and then for pages on Canvas (like Explore or Dashboards), set that specifically for those pages.

#### Before
![6353_2023-10-31-16-51_firefox](https://github.com/grafana/grafana/assets/46142/007a3778-82cd-4615-a600-2ecc6853f5d9)


![6355_2023-10-31-16-51_firefox](https://github.com/grafana/grafana/assets/46142/1c4028ea-c1f2-44c5-b6a6-40fe2c3ac7c4)


#### After 
![6354_2023-10-31-16-51_firefox](https://github.com/grafana/grafana/assets/46142/b1fc855f-dc28-4825-92ea-c58eb7885b59)

![6356_2023-10-31-16-51_firefox](https://github.com/grafana/grafana/assets/46142/73abdef2-81c7-48b3-82f2-a0e477dfc49e)

