### PR TITLE
[v9.5.x] CI: Rename scripts that build artifacts to use _build_

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -2723,7 +2723,7 @@ services: []
 steps:
 - commands:
   - export GRAFANA_DIR=$$(pwd)
-  - cd /src && ./scripts/drone_publish_main.sh
+  - cd /src && ./scripts/drone_build_main.sh
   environment:
     _EXPERIMENTAL_DAGGER_CLOUD_TOKEN:
       from_secret: dagger_token
@@ -2972,7 +2972,7 @@ services: []
 steps:
 - commands:
   - export GRAFANA_DIR=$$(pwd)
-  - cd /src && ./scripts/drone_publish_tag_grafana.sh
+  - cd /src && ./scripts/drone_build_tag_grafana.sh
   environment:
     _EXPERIMENTAL_DAGGER_CLOUD_TOKEN:
       from_secret: dagger_token
@@ -3150,7 +3150,7 @@ services: []
 steps:
 - commands:
   - export GRAFANA_DIR=$$(pwd)
-  - cd /src && ./scripts/drone_publish_tag_grafana.sh
+  - cd /src && ./scripts/drone_build_tag_grafana.sh
   environment:
     _EXPERIMENTAL_DAGGER_CLOUD_TOKEN:
       from_secret: dagger_token
@@ -4559,6 +4559,6 @@ kind: secret
 name: gcr_credentials
 ---
 kind: signature
-hmac: 4c68ef8aedb7202b86f077dbccc04504b81eaa1729276238d90a06672198487e
+hmac: aca8af17bf23f40ebc7015377f8ec559d0ab2280be959d74aa076aca67975550
 
 ...

--- a/scripts/drone/rgm.star
+++ b/scripts/drone/rgm.star
@@ -221,7 +221,7 @@ def rgm_main():
     return pipeline(
         name = "rgm-main-prerelease",
         trigger = main_trigger,
-        steps = rgm_run("rgm-build", "drone_publish_main.sh"),
+        steps = rgm_run("rgm-build", "drone_build_main.sh"),
         depends_on = ["main-test-backend", "main-test-frontend"],
     )
 
@@ -230,7 +230,7 @@ def rgm_tag():
     return pipeline(
         name = "rgm-tag-prerelease",
         trigger = tag_trigger,
-        steps = rgm_run("rgm-build", "drone_publish_tag_grafana.sh"),
+        steps = rgm_run("rgm-build", "drone_build_tag_grafana.sh"),
         depends_on = ["release-test-backend", "release-test-frontend"],
     )
 
@@ -251,7 +251,7 @@ def rgm_version_branch():
     return pipeline(
         name = "rgm-version-branch-prerelease",
         trigger = version_branch_trigger,
-        steps = rgm_run("rgm-build", "drone_publish_tag_grafana.sh"),
+        steps = rgm_run("rgm-build", "drone_build_tag_grafana.sh"),
         depends_on = ["release-test-backend", "release-test-frontend"],
     )
 


### PR DESCRIPTION
Backport 442e533803c100b531b4cb505ccb64173bfd48c8 from #77005

---

Part of https://github.com/grafana/grafana-build/pull/210 to be more concise.