### PR TITLE
Update `doc-validator` workflow

### DIFF
--- a/.github/workflows/doc-validator.yml
+++ b/.github/workflows/doc-validator.yml
@@ -7,7 +7,7 @@ jobs:
   doc-validator:
     runs-on: "ubuntu-latest"
     container:
-      image: "grafana/doc-validator:v3.2.1"
+      image: "grafana/doc-validator:v4.0.0"
     steps:
       - name: "Checkout code"
         uses: "actions/checkout@v4"


### PR DESCRIPTION
No longer produce errors for the use of https://grafana.com/ links. This is the first step towards just using fully qualified URLs everywhere. The website link render-hook will internally transform these URLs into the partial URL that works across all hostnames.

Signed-off-by: Jack Baldry <jack.baldry@grafana.com>
