### PR TITLE
Move datagrid e2e tests to panels-suite

### DIFF
--- a/e2e/panels-suite/datagrid-data-change.spec.ts
+++ b/e2e/panels-suite/datagrid-data-change.spec.ts
@@ -3,7 +3,8 @@ import { e2e } from '../utils';
 const DASHBOARD_ID = 'c01bf42b-b783-4447-a304-8554cee1843b';
 const DATAGRID_SELECT_SERIES = 'Datagrid Select series';
 
-describe('Datagrid data changes', () => {
+//TODO enable this test when panel goes live
+describe.skip('Datagrid data changes', () => {
   beforeEach(() => {
     e2e.flows.login(Cypress.env('USERNAME'), Cypress.env('PASSWORD'));
   });

--- a/e2e/panels-suite/datagrid-editing-features.spec.ts
+++ b/e2e/panels-suite/datagrid-editing-features.spec.ts
@@ -3,7 +3,8 @@ import { e2e } from '../utils';
 const DASHBOARD_ID = 'c01bf42b-b783-4447-a304-8554cee1843b';
 const DATAGRID_CANVAS = 'data-grid-canvas';
 
-describe('Datagrid data changes', () => {
+//TODO enable this test when panel goes live
+describe.skip('Datagrid data changes', () => {
   beforeEach(() => {
     e2e.flows.login(Cypress.env('USERNAME'), Cypress.env('PASSWORD'));
   });


### PR DESCRIPTION
Move the currently unreleased datagrid e2e tests into the `panels-suite` and skip them.