### PR TITLE
Alerting: Fix confusion around what can and cannot be customized in notifications

### DIFF
--- a/docs/sources/alerting/manage-notifications/template-notifications/_index.md
+++ b/docs/sources/alerting/manage-notifications/template-notifications/_index.md
@@ -26,7 +26,7 @@ Notification templates are not tied to specific contact point integrations, such
 You can use notification templates to:
 
 - Customize the subject of an email or the title of a message.
-- Add, change or remove text in notifications. For example, to select or omit certain labels and annotations.
+- Add, change or remove text in notifications. For example, to select or omit certain labels, annotations and links.
 - Format text in bold and italic, and add or remove line breaks.
 
 You cannot use notification templates to:

--- a/docs/sources/alerting/manage-notifications/template-notifications/_index.md
+++ b/docs/sources/alerting/manage-notifications/template-notifications/_index.md
@@ -34,7 +34,7 @@ You cannot use notification templates to:
 - Add HTML and CSS to email notifications to change their visual appearance.
 - Change the design of notifications in instant messaging services such as Slack and Microsoft Teams. For example, to add or remove custom blocks with Slack Block Kit or adaptive cards with Microsoft Teams.
 - Choose the number and size of images, or where in the notification images are shown.
-- Customize the data in webhooks, including the fields or structure of the JSON data or sending the data in other formats such as XML.
+- Customize the data in webhooks, including the fields or structure of the JSON data or send the data in other formats such as XML.
 - Add or remove HTTP headers in webhooks other than those in the contact point configuration.
 
 [Using Go's templating language][using-go-templating-language]

--- a/docs/sources/alerting/manage-notifications/template-notifications/_index.md
+++ b/docs/sources/alerting/manage-notifications/template-notifications/_index.md
@@ -25,15 +25,17 @@ Notification templates are not tied to specific contact point integrations, such
 
 You can use notification templates to:
 
-- Add, remove, or re-order information in the notification including the summary, description, labels and annotations, values, and links
-- Format text in bold and italic, and add or remove line breaks
+- Customize the subject of an email or the title of a message.
+- Add, change or remove text in notifications. For example, to select or omit certain labels and annotations.
+- Format text in bold and italic, and add or remove line breaks.
 
 You cannot use notification templates to:
 
-- Change how images are included in notifications, such as the number of images in each notification or where in the notification inline images are shown
-- Change the design of notifications in instant messaging services such as Slack and Microsoft Teams
-- Change the data in webhook notifications, including the structure of the JSON request or sending data in other formats such as XML
-- Add or remove HTTP headers in webhook notifications other than those in the contact point configuration
+- Add HTML and CSS to email notifications to change their visual appearance.
+- Change the design of notifications in instant messaging services such as Slack and Microsoft Teams. For example, to add or remove custom blocks with Slack Block Kit or adaptive cards with Microsoft Teams.
+- Choose the number and size of images, or where in the notification images are shown.
+- Customize the data in webhooks, including the fields or structure of the JSON data or sending the data in other formats such as XML.
+- Add or remove HTTP headers in webhooks other than those in the contact point configuration.
 
 [Using Go's templating language][using-go-templating-language]
 


### PR DESCRIPTION
**What is this feature?**

This pull request attempts to address some confusion a customer had about what can and cannot be customized with notification templates.

**Why do we need this feature?**

[Add a description of the problem the feature is trying to solve.]

**Who is this feature for?**

[Add information on what kind of user the feature is for.]

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
