### PR TITLE
RBAC: Default to None role on SA creation if accesscontrol enabled

### DIFF
--- a/public/app/features/serviceaccounts/ServiceAccountCreatePage.test.tsx
+++ b/public/app/features/serviceaccounts/ServiceAccountCreatePage.test.tsx
@@ -83,7 +83,7 @@ describe('ServiceAccountCreatePage tests', () => {
     await waitFor(() =>
       expect(postMock).toHaveBeenCalledWith('/api/serviceaccounts/', {
         name: 'Data source scavenger',
-        role: 'None',
+        role: 'Viewer',
       })
     );
   });

--- a/public/app/features/serviceaccounts/ServiceAccountCreatePage.tsx
+++ b/public/app/features/serviceaccounts/ServiceAccountCreatePage.tsx
@@ -29,7 +29,7 @@ export const ServiceAccountCreatePage = ({}: Props): JSX.Element => {
   const [serviceAccount, setServiceAccount] = useState<ServiceAccountDTO>({
     id: 0,
     orgId: contextSrv.user.orgId,
-    role: OrgRole.None,
+    role: contextSrv.licensedAccessControlEnabled() ? OrgRole.None  : OrgRole.Viewer,
     tokens: 0,
     name: '',
     login: '',

--- a/public/app/features/serviceaccounts/ServiceAccountCreatePage.tsx
+++ b/public/app/features/serviceaccounts/ServiceAccountCreatePage.tsx
@@ -29,7 +29,7 @@ export const ServiceAccountCreatePage = ({}: Props): JSX.Element => {
   const [serviceAccount, setServiceAccount] = useState<ServiceAccountDTO>({
     id: 0,
     orgId: contextSrv.user.orgId,
-    role: contextSrv.licensedAccessControlEnabled() ? OrgRole.None  : OrgRole.Viewer,
+    role: contextSrv.licensedAccessControlEnabled() ? OrgRole.None : OrgRole.Viewer,
     tokens: 0,
     name: '',
     login: '',


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**
We want to make it default to None role when accesscontrol enabled otherwise we want Viewer to be the default

[Add a brief description of what the feature or update does.]

**Why do we need this feature?**

[Add a description of the problem the feature is trying to solve.]

**Who is this feature for?**

[Add information on what kind of user the feature is for.]

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
