### PR TITLE
Alerting: Fix NoRulesSplash being rendered for some seconds, fater creating a rule

### DIFF
--- a/public/app/features/alerting/unified/RuleList.tsx
+++ b/public/app/features/alerting/unified/RuleList.tsx
@@ -66,12 +66,16 @@ const RuleList = withErrorBoundary(
     const allPromLoaded = promRequests.every(
       ([_, state]) => state.dispatched && (state?.result !== undefined || state?.error !== undefined)
     );
+    const allRulerLoaded = rulerRequests.every(
+      ([_, state]) => state.dispatched && (state?.result !== undefined || state?.error !== undefined)
+    );
+
     const allPromEmpty = promRequests.every(([_, state]) => state.dispatched && state?.result?.length === 0);
 
     const allRulerEmpty = rulerRequests.every(([_, state]) => {
       const rulerRules = Object.entries(state?.result ?? {});
       const noRules = rulerRules.every(([_, result]) => result?.length === 0);
-      return noRules;
+      return noRules && state.dispatched;
     });
 
     const limitAlerts = hasActiveFilters ? undefined : LIMIT_ALERTS;
@@ -93,7 +97,8 @@ const RuleList = withErrorBoundary(
     useInterval(fetchRules, RULE_LIST_POLL_INTERVAL_MS);
 
     // Show splash only when we loaded all of the data sources and none of them has alerts
-    const hasNoAlertRulesCreatedYet = allPromLoaded && allPromEmpty && promRequests.length > 0 && allRulerEmpty;
+    const hasNoAlertRulesCreatedYet =
+      allPromLoaded && allPromEmpty && promRequests.length > 0 && allRulerEmpty && allRulerLoaded;
 
     const combinedNamespaces: CombinedRuleNamespace[] = useCombinedRuleNamespaces();
     const filteredNamespaces = useFilteredRules(combinedNamespaces, filterState);

--- a/public/app/features/alerting/unified/RuleList.tsx
+++ b/public/app/features/alerting/unified/RuleList.tsx
@@ -61,10 +61,18 @@ const RuleList = withErrorBoundary(
     );
 
     const promRequests = Object.entries(promRuleRequests);
+    const rulerRequests = Object.entries(rulerRuleRequests);
+
     const allPromLoaded = promRequests.every(
       ([_, state]) => state.dispatched && (state?.result !== undefined || state?.error !== undefined)
     );
     const allPromEmpty = promRequests.every(([_, state]) => state.dispatched && state?.result?.length === 0);
+
+    const allRulerEmpty = rulerRequests.every(([_, state]) => {
+      const rulerRules = Object.entries(state?.result ?? {});
+      const noRules = rulerRules.every(([_, result]) => result?.length === 0);
+      return noRules;
+    });
 
     const limitAlerts = hasActiveFilters ? undefined : LIMIT_ALERTS;
     // Trigger data refresh only when the RULE_LIST_POLL_INTERVAL_MS elapsed since the previous load FINISHED
@@ -85,7 +93,7 @@ const RuleList = withErrorBoundary(
     useInterval(fetchRules, RULE_LIST_POLL_INTERVAL_MS);
 
     // Show splash only when we loaded all of the data sources and none of them has alerts
-    const hasNoAlertRulesCreatedYet = allPromLoaded && allPromEmpty && promRequests.length > 0;
+    const hasNoAlertRulesCreatedYet = allPromLoaded && allPromEmpty && promRequests.length > 0 && allRulerEmpty;
 
     const combinedNamespaces: CombinedRuleNamespace[] = useCombinedRuleNamespaces();
     const filteredNamespaces = useFilteredRules(combinedNamespaces, filterState);


### PR DESCRIPTION
**What is this feature?**

This pull request addresses an issue where, just after creating a new alert rule, the alert list view initially renders the message "You have not created alert rules" along with an empty list. However, within a few seconds, the user interface (UI) is updated to correctly display the list of rules.

**Context:** 

This behavior occurs because when a rule is created in the ruler, it immediately appears in the` /api/ruler/grafana/api/v1/rules`, but there is a slight delay before the rule's status is reflected in `/api/prometheus/grafana/api/v1/rules`. 
The rendering logic for the `NoRulesSplash` was originally based on the Prometheus rules response, which caused the delay in UI updates.

**Why do we need this feature?**

The alert list view should display an accurate and up-to-date state of alert rules, immediately after they are created, without any delay or misleading messages. 

**Who is this feature for?**

All users

**Special notes for your reviewer:**

After the change: 


https://github.com/grafana/grafana/assets/33540275/be511fb5-6ad2-40b8-a332-b9a456fe52c7


Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
