### PR TITLE
Tempo: Add new structural operators

### DIFF
--- a/package.json
+++ b/package.json
@@ -254,7 +254,7 @@
     "@grafana/flamegraph": "workspace:*",
     "@grafana/google-sdk": "0.1.1",
     "@grafana/lezer-logql": "0.2.1",
-    "@grafana/lezer-traceql": "0.0.7",
+    "@grafana/lezer-traceql": "0.0.8",
     "@grafana/monaco-logql": "^0.0.7",
     "@grafana/runtime": "workspace:*",
     "@grafana/scenes": "^1.18.0",

--- a/public/app/plugins/datasource/tempo/traceql/TraceQLEditor.test.tsx
+++ b/public/app/plugins/datasource/tempo/traceql/TraceQLEditor.test.tsx
@@ -72,6 +72,10 @@ describe('Check for syntax errors in query', () => {
     ['{span.status = $code}'],
     ['{span.${attribute} = "GET"}'],
     ['{span.${attribute:format} = ${value:format} }'],
+    ['{true} >> {true}'],
+    ['{true} << {true}'],
+    ['{true} !>> {true}'],
+    ['{true} !<< {true}'],
   ])('valid query - %s', (query: string) => {
     expect(getErrorNodes(query)).toStrictEqual([]);
   });

--- a/public/app/plugins/datasource/tempo/traceql/autocomplete.ts
+++ b/public/app/plugins/datasource/tempo/traceql/autocomplete.ts
@@ -138,6 +138,20 @@ export class CompletionProvider implements monacoTypes.languages.CompletionItemP
         'Child operator. Looks for spans matching {condB} that are direct child spans of a parent matching {condA}',
     },
     {
+      label: '<<',
+      insertText: '<<',
+      detail: 'Ancestor',
+      documentation:
+        'Ancestor operator. Looks for spans matching {condB} that are ancestors of a span matching {condA}',
+    },
+    {
+      label: '<',
+      insertText: '<',
+      detail: 'Parent',
+      documentation:
+        'Parent operator. Looks for spans matching {condB} that are direct parent spans of a child matching {condA}',
+    },
+    {
       label: '~',
       insertText: '~',
       detail: 'Sibling',

--- a/yarn.lock
+++ b/yarn.lock
@@ -3226,12 +3226,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@grafana/lezer-traceql@npm:0.0.7":
-  version: 0.0.7
-  resolution: "@grafana/lezer-traceql@npm:0.0.7"
+"@grafana/lezer-traceql@npm:0.0.8":
+  version: 0.0.8
+  resolution: "@grafana/lezer-traceql@npm:0.0.8"
   peerDependencies:
     "@lezer/lr": ^1.3.0
-  checksum: 920f8116d61907e12ca1dd51949242abf435e675105699c7b2fcd8c024999ed0ddfd3500b1802111f3ed9ad37e16f40826790658bdf94224cd5b615e20360ab9
+  checksum: cd257010689de4c3177fd3e3bb74460d0d8669b9c25530c4ad1efa3cb2793a73c99f34a38058463b93790d3b80bf585992165801d6fd4b617823f1570c8dffad
   languageName: node
   linkType: hard
 
@@ -17142,7 +17142,7 @@ __metadata:
     "@grafana/flamegraph": "workspace:*"
     "@grafana/google-sdk": 0.1.1
     "@grafana/lezer-logql": 0.2.1
-    "@grafana/lezer-traceql": 0.0.7
+    "@grafana/lezer-traceql": 0.0.8
     "@grafana/monaco-logql": ^0.0.7
     "@grafana/runtime": "workspace:*"
     "@grafana/scenes": ^1.18.0


### PR DESCRIPTION
As requested in https://github.com/grafana/grafana/issues/76818, we add the support for a few new TraceQL operators. In particular:
- `<<` and `<` are supported and also suggested by the autocompletion system:
![image](https://github.com/grafana/grafana/assets/135109076/a1d9034c-1589-46fd-86c7-1d895e20948c)
![image](https://github.com/grafana/grafana/assets/135109076/be383c46-8af3-49c4-91f5-b08d85254cd8)
- the experimental operators (`!<<`, etc.) are supported, meaning that they are not highlighted as invalid in the editor, but they are not proposed by the autocompletion system because they are experimental:
![image](https://github.com/grafana/grafana/assets/135109076/0f26dc7c-6798-42ed-b824-2d23c8fecb60)

Fixes https://github.com/grafana/grafana/issues/76818