### PR TITLE
CI: Temporarily disable arm build-tooling

### DIFF
--- a/pkg/build/config/variant.go
+++ b/pkg/build/config/variant.go
@@ -16,9 +16,10 @@ const (
 )
 
 var AllVariants = []Variant{
-	VariantArmV6,
-	VariantArmV7,
-	VariantArmV7Musl,
+	// https://github.com/golang/go/issues/58425 disabling arm builds until go issue is resolved
+	// VariantArmV6,
+	// VariantArmV7,
+	// VariantArmV7Musl,
 	VariantArm64,
 	VariantArm64Musl,
 	VariantDarwinAmd64,

--- a/pkg/build/config/versions.go
+++ b/pkg/build/config/versions.go
@@ -101,9 +101,10 @@ var Versions = VersionMap{
 	},
 	ReleaseBranchMode: {
 		Variants: []Variant{
-			VariantArmV6,
-			VariantArmV7,
-			VariantArmV7Musl,
+			// https://github.com/golang/go/issues/58425 disabling arm builds until go issue is resolved
+			// VariantArmV6,
+			// VariantArmV7,
+			// VariantArmV7Musl,
 			VariantArm64,
 			VariantArm64Musl,
 			VariantDarwinAmd64,
@@ -136,9 +137,10 @@ var Versions = VersionMap{
 	},
 	TagMode: {
 		Variants: []Variant{
-			VariantArmV6,
-			VariantArmV7,
-			VariantArmV7Musl,
+			// https://github.com/golang/go/issues/58425 disabling arm builds until go issue is resolved
+			// VariantArmV6,
+			// VariantArmV7,
+			// VariantArmV7Musl,
 			VariantArm64,
 			VariantArm64Musl,
 			VariantDarwinAmd64,
@@ -155,7 +157,8 @@ var Versions = VersionMap{
 			Architectures: []Architecture{
 				ArchAMD64,
 				ArchARM64,
-				ArchARMv7,
+				// https://github.com/golang/go/issues/58425 disabling arm builds until go issue is resolved
+				// ArchARMv7,
 			},
 			Distribution: []Distribution{
 				Alpine,

--- a/pkg/build/docker/init.go
+++ b/pkg/build/docker/init.go
@@ -8,7 +8,7 @@ import (
 )
 
 // AllArchs is a list of all supported Docker image architectures.
-var AllArchs = []string{"amd64", "armv7", "arm64"}
+var AllArchs = []string{"amd64", "arm64"}
 
 // emulatorImage is the docker image used as the cross-platform emulator
 var emulatorImage = "tonistiigi/binfmt:qemu-v7.0.0"

--- a/pkg/build/packaging/artifacts.go
+++ b/pkg/build/packaging/artifacts.go
@@ -81,32 +81,33 @@ var ArtifactConfigs = []buildArtifact{
 		Arch:       "arm64",
 		urlPostfix: ".linux-arm64.tar.gz",
 	},
-	{
-		Os:         debOS,
-		Arch:       "armv7",
-		urlPostfix: "_armhf.deb",
-	},
-	{
-		Os:             debOS,
-		Arch:           "armv6",
-		packagePostfix: "-rpi",
-		urlPostfix:     "_armhf.deb",
-	},
-	{
-		Os:         rhelOS,
-		Arch:       "armv7",
-		urlPostfix: ".armhfp.rpm",
-	},
-	{
-		Os:         "linux",
-		Arch:       "armv6",
-		urlPostfix: ".linux-armv6.tar.gz",
-	},
-	{
-		Os:         "linux",
-		Arch:       "armv7",
-		urlPostfix: ".linux-armv7.tar.gz",
-	},
+	// https://github.com/golang/go/issues/58425 disabling arm builds until go issue is resolved
+	// {
+	// 	Os:         debOS,
+	// 	Arch:       "armv7",
+	// 	urlPostfix: "_armhf.deb",
+	// },
+	// {
+	// 	Os:             debOS,
+	// 	Arch:           "armv6",
+	// 	packagePostfix: "-rpi",
+	// 	urlPostfix:     "_armhf.deb",
+	// },
+	// {
+	// 	Os:         rhelOS,
+	// 	Arch:       "armv7",
+	// 	urlPostfix: ".armhfp.rpm",
+	// },
+	// {
+	// 	Os:         "linux",
+	// 	Arch:       "armv6",
+	// 	urlPostfix: ".linux-armv6.tar.gz",
+	// },
+	// {
+	// 	Os:         "linux",
+	// 	Arch:       "armv7",
+	// 	urlPostfix: ".linux-armv7.tar.gz",
+	// },
 	{
 		Os:         "darwin",
 		Arch:       "amd64",


### PR DESCRIPTION
Related to https://github.com/golang/go/issues/58425. Once this has been resolve, we can enable it again.