### PR TITLE
Docs: Clarify open source documentation

### DIFF
--- a/docs/sources/_index.md
+++ b/docs/sources/_index.md
@@ -3,19 +3,20 @@ aliases:
   - /docs/grafana/v1.1/
   - /docs/grafana/v3.1/
   - guides/reference/admin/
-description: Guides, installation, and feature documentation
+description: Open source documentation for Grafana
 keywords:
   - grafana
+  - open source
   - installation
   - documentation
 labels:
   products:
     - enterprise
     - oss
-title: Grafana documentation
+title: Grafana OSS documentation
 ---
 
-# Grafana documentation
+# Grafana open source documentation
 
 ## Installing Grafana
 

--- a/docs/sources/_index.md
+++ b/docs/sources/_index.md
@@ -13,7 +13,7 @@ labels:
   products:
     - enterprise
     - oss
-title: Grafana OSS documentation
+title: Grafana open source documentation
 ---
 
 # Grafana open source documentation


### PR DESCRIPTION
**What is this feature?**

Clarify open source documentation given user confusion.

**Why do we need this feature?**

User are confused when searching for get started

**Who is this feature for?**

Readers of our docs


- [x] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
