### PR TITLE
Alerting: Fix order of the Alerting docs

### DIFF
--- a/docs/sources/alerting/alerting-rules/_index.md
+++ b/docs/sources/alerting/alerting-rules/_index.md
@@ -13,7 +13,7 @@ labels:
     - oss
 menuTitle: Configure
 title: Configure Alerting
-weight: 130
+weight: 120
 ---
 
 # Configure Alerting

--- a/docs/sources/alerting/fundamentals/_index.md
+++ b/docs/sources/alerting/fundamentals/_index.md
@@ -11,7 +11,7 @@ labels:
     - oss
 menuTitle: Introduction
 title: Introduction to Alerting
-weight: 150
+weight: 100
 ---
 
 # Introduction to Alerting

--- a/docs/sources/alerting/manage-notifications/_index.md
+++ b/docs/sources/alerting/manage-notifications/_index.md
@@ -12,7 +12,7 @@ labels:
     - oss
 menuTitle: Manage
 title: Manage your alerts
-weight: 160
+weight: 130
 ---
 
 # Manage your alerts

--- a/docs/sources/alerting/monitor/_index.md
+++ b/docs/sources/alerting/monitor/_index.md
@@ -14,7 +14,7 @@ labels:
     - oss
 menuTitle: Monitor
 title: Meta monitoring
-weight: 200
+weight: 140
 ---
 
 # Meta monitoring

--- a/docs/sources/alerting/set-up/_index.md
+++ b/docs/sources/alerting/set-up/_index.md
@@ -8,7 +8,7 @@ labels:
     - oss
 menuTitle: Set up
 title: Set up Alerting
-weight: 107
+weight: 110
 ---
 
 # Set up Alerting


### PR DESCRIPTION
**What is this feature?**

I happened to break the order of the Alerting top menu in the recent docs changes. It should be:

- Introduction
- Setup
- Configure
- Manage
- Monitor

I broke it so it was instead:

- Setup
- Configure
- Introduction
- Manage
- Monitor

This pull request fixes it.






**Why do we need this feature?**

[Add a description of the problem the feature is trying to solve.]

**Who is this feature for?**

[Add information on what kind of user the feature is for.]

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
