### PR TITLE
InfluxDB: Fix adhoc filter calls by properly checking optional parameter in metricFindQuery

### DIFF
--- a/public/app/plugins/datasource/influxdb/datasource.test.ts
+++ b/public/app/plugins/datasource/influxdb/datasource.test.ts
@@ -161,12 +161,63 @@ describe('InfluxDataSource Frontend Mode', () => {
     const mockTemplateService = new TemplateSrv();
     mockTemplateService.getAdhocFilters = jest.fn((_: string) => adhocFilters);
     let ds = getMockInfluxDS(getMockDSInstanceSettings(), mockTemplateService);
+
+    // const fetchMock = jest.fn().mockReturnValue(fetchResult);
+
     it('query should contain the ad-hoc variable', () => {
       ds.query(mockInfluxQueryRequest());
       const expected = encodeURIComponent(
         'SELECT mean("value") FROM "cpu" WHERE time >= 0ms and time <= 10ms AND "adhoc_key" = \'adhoc_val\' GROUP BY time($__interval) fill(null)'
       );
       expect(fetchMock.mock.calls[0][0].data).toBe(`q=${expected}`);
+    });
+
+    it('should make the fetch call for adhoc filter keys', () => {
+      fetchMock.mockReturnValue(
+        of({
+          results: [
+            {
+              statement_id: 0,
+              series: [
+                {
+                  name: 'cpu',
+                  columns: ['tagKey'],
+                  values: [['datacenter'], ['geohash'], ['source']],
+                },
+              ],
+            },
+          ],
+        })
+      );
+      ds.getTagKeys();
+      expect(fetchMock).toHaveBeenCalled();
+      const fetchReq = fetchMock.mock.calls[0][0];
+      expect(fetchReq).not.toBeNull();
+      expect(fetchReq.data).toMatch(encodeURIComponent(`SHOW TAG KEYS`));
+    });
+
+    it('should make the fetch call for adhoc filter values', () => {
+      fetchMock.mockReturnValue(
+        of({
+          results: [
+            {
+              statement_id: 0,
+              series: [
+                {
+                  name: 'mykey',
+                  columns: ['key', 'value'],
+                  values: [['mykey', 'value']],
+                },
+              ],
+            },
+          ],
+        })
+      );
+      ds.getTagValues({ key: 'mykey', filters: [] });
+      expect(fetchMock).toHaveBeenCalled();
+      const fetchReq = fetchMock.mock.calls[0][0];
+      expect(fetchReq).not.toBeNull();
+      expect(fetchReq.data).toMatch(encodeURIComponent(`SHOW TAG VALUES WITH KEY = "mykey"`));
     });
   });
 

--- a/public/app/plugins/datasource/influxdb/datasource.ts
+++ b/public/app/plugins/datasource/influxdb/datasource.ts
@@ -313,7 +313,7 @@ export default class InfluxDatasource extends DataSourceWithBackend<InfluxQuery,
       };
       return lastValueFrom(
         super.query({
-          ...options, // includes 'range'
+          ...(options ?? {}), // includes 'range'
           targets: [target],
         })
       ).then((rsp) => {
@@ -324,7 +324,7 @@ export default class InfluxDatasource extends DataSourceWithBackend<InfluxQuery,
       });
     }
 
-    const interpolated = this.templateSrv.replace(query, options.scopedVars, this.interpolateQueryExpr);
+    const interpolated = this.templateSrv.replace(query, options?.scopedVars, this.interpolateQueryExpr);
 
     return lastValueFrom(this._seriesQuery(interpolated, options)).then((resp) => {
       return this.responseParser.parse(query, resp);


### PR DESCRIPTION
**What is this feature?**

Check the optional `options` parameter in `metricFindQuery` method. 

**Who is this feature for?**

InfluxDB frontend mode users

**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/grafana/issues/77105

**Special notes for your reviewer:**

### How to test?
- run grafana with `influxdbBackendMigration=false`
- set up and influxdb dashboard
- add a new ad-hoc filter and save the dashboard
- go to the dashboard and try to see the ad-hoc filter keys, it will be failed to load
- switch to this branch and try again

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
