### PR TITLE
Navigation: Improve docked auto scroll behaviour

### DIFF
--- a/public/app/core/components/AppChrome/DockedMegaMenu/MegaMenuItem.tsx
+++ b/public/app/core/components/AppChrome/DockedMegaMenu/MegaMenuItem.tsx
@@ -1,9 +1,11 @@
 import { css, cx } from '@emotion/css';
 import React, { useEffect, useRef } from 'react';
+import { useLocation } from 'react-router-dom';
 import { useLocalStorage } from 'react-use';
 
 import { GrafanaTheme2, NavModelItem, toIconName } from '@grafana/data';
 import { useStyles2, Text, IconButton, Icon } from '@grafana/ui';
+import { useGrafana } from 'app/core/context/GrafanaContext';
 
 import { Indent } from '../../Indent/Indent';
 
@@ -21,6 +23,10 @@ interface Props {
 const MAX_DEPTH = 2;
 
 export function MegaMenuItem({ link, activeItem, level = 0, onClick }: Props) {
+  const { chrome } = useGrafana();
+  const state = chrome.useState();
+  const menuIsDocked = state.megaMenu === 'docked';
+  const location = useLocation();
   const FeatureHighlightWrapper = link.highlightText ? FeatureHighlight : React.Fragment;
   const hasActiveChild = hasChildMatch(link, activeItem);
   const isActive = link === activeItem || (level === MAX_DEPTH && hasActiveChild);
@@ -38,16 +44,16 @@ export function MegaMenuItem({ link, activeItem, level = 0, onClick }: Props) {
     if (hasActiveChild) {
       setSectionExpanded(true);
     }
-  }, [hasActiveChild, setSectionExpanded]);
+  }, [hasActiveChild, location, menuIsDocked, setSectionExpanded]);
 
   // scroll active element into center if it's offscreen
   useEffect(() => {
-    if (isActive && item.current && isElementOffscreen(item.current)) {
+    if (menuIsDocked && isActive && item.current && isElementOffscreen(item.current)) {
       item.current.scrollIntoView({
         block: 'center',
       });
     }
-  }, [isActive]);
+  }, [isActive, menuIsDocked]);
 
   if (!link.url) {
     return null;


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

- changes to always expand parent items on any location change (this ensures the active item is always shown when you next navigate/open the menu)
- changes to only scroll active item into view when the menu is docked

**Why do we need this feature?**

- better UX

**Who is this feature for?**

- anyone using `dockedMegaMenu`

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
