### PR TITLE
Auth: Handle when access token has already been refreshed in OAuth token sync

### DIFF
--- a/pkg/services/authn/authnimpl/sync/oauth_token_sync.go
+++ b/pkg/services/authn/authnimpl/sync/oauth_token_sync.go
@@ -104,7 +104,10 @@ func (s *OAuthTokenSync) SyncOauthTokenHook(ctx context.Context, identity *authn
 		return nil
 	}
 
-	_, err, _ = s.sf.Do(identity.ID, func() (interface{}, error) {
+	lockKey := fmt.Sprintf("oauth-token-sync-%s", identity.ID)
+	_, err, _ = s.sf.Do(lockKey, func() (interface{}, error) {
+		s.log.Debug("Singleflight request for OAuth token sync", "key", lockKey)
+
 		// FIXME: Consider using context.WithoutCancel instead of context.Background after Go 1.21 update
 		updateCtx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
 		defer cancel()

--- a/pkg/services/authn/authnimpl/sync/oauth_token_sync_test.go
+++ b/pkg/services/authn/authnimpl/sync/oauth_token_sync_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"golang.org/x/sync/singleflight"
 
 	"github.com/grafana/grafana/pkg/infra/localcache"
 	"github.com/grafana/grafana/pkg/infra/log"
@@ -75,7 +76,7 @@ func TestOAuthTokenSync_SyncOAuthTokenHook(t *testing.T) {
 			expectedHasEntryToken: &login.UserAuth{OAuthExpiry: time.Now().Add(10 * time.Minute)},
 		},
 		{
-			desc:                        "should refresh access token when is has expired",
+			desc:                        "should refresh access token when it has expired",
 			identity:                    &authn.Identity{ID: "user:1", SessionToken: &auth.UserToken{}},
 			expectHasEntryCalled:        true,
 			expectTryRefreshTokenCalled: true,
@@ -155,6 +156,7 @@ func TestOAuthTokenSync_SyncOAuthTokenHook(t *testing.T) {
 				service:        service,
 				sessionService: sessionService,
 				socialService:  socialService,
+				sf:             new(singleflight.Group),
 			}
 
 			err := sync.SyncOauthTokenHook(context.Background(), tt.identity, nil)

--- a/pkg/services/oauthtoken/oauth_token.go
+++ b/pkg/services/oauthtoken/oauth_token.go
@@ -173,7 +173,7 @@ func checkOAuthRefreshToken(authInfo *login.UserAuth) error {
 	}
 
 	if authInfo.OAuthRefreshToken == "" {
-		logger.Debug("No refresh token available",
+		logger.Warn("No refresh token available",
 			"authmodule", authInfo.AuthModule, "userid", authInfo.UserId)
 		return ErrNoRefreshTokenFound
 	}


### PR DESCRIPTION
**What is this feature?**
Improves the way the OAuth token sync hook works by reducing the number of error messages and handling the case when the access token is already refreshed by another request/node.

**Why do we need this feature?**


**Who is this feature for?**

**Which issue(s) does this PR fix?**:

Fixes #

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
