### PR TITLE
Alerting: Replace FileStore() for CleanUp() in the Alertmanager interface

### DIFF
--- a/pkg/services/ngalert/notifier/alertmanager.go
+++ b/pkg/services/ngalert/notifier/alertmanager.go
@@ -403,8 +403,9 @@ func (am *alertmanager) OrgID() int64 {
 	return am.orgID
 }
 
-func (am *alertmanager) FileStore() *FileStore {
-	return am.fileStore
+// CleanUp removes the directory containing the alertmanager files from disk.
+func (am *alertmanager) CleanUp() {
+	am.fileStore.CleanUp()
 }
 
 // AlertValidationError is the error capturing the validation errors

--- a/pkg/services/ngalert/notifier/multiorg_alertmanager.go
+++ b/pkg/services/ngalert/notifier/multiorg_alertmanager.go
@@ -54,9 +54,9 @@ type Alertmanager interface {
 	TestTemplate(ctx context.Context, c apimodels.TestTemplatesConfigBodyParams) (*TestTemplatesResults, error)
 
 	// State
+	CleanUp()
 	StopAndWait()
 	Ready() bool
-	FileStore() *FileStore
 	OrgID() int64
 	ConfigHash() [16]byte
 }
@@ -314,8 +314,8 @@ func (moa *MultiOrgAlertmanager) SyncAlertmanagersForOrgs(ctx context.Context, o
 		moa.logger.Info("Stopping Alertmanager", "org", orgID)
 		am.StopAndWait()
 		moa.logger.Info("Stopped Alertmanager", "org", orgID)
-		// Cleanup all the remaining resources from this alertmanager.
-		am.FileStore().CleanUp()
+		// Clean up all the remaining resources from this alertmanager.
+		am.CleanUp()
 	}
 
 	// We look for orphan directories and remove them. Orphan directories can
@@ -350,7 +350,7 @@ func (moa *MultiOrgAlertmanager) cleanupOrphanLocalOrgState(ctx context.Context,
 			moa.logger.Info("Found orphan organization directory", "orgID", orgID)
 			workingDirPath := filepath.Join(dataDir, strconv.FormatInt(orgID, 10))
 			fileStore := NewFileStore(orgID, moa.kvStore, workingDirPath)
-			// Cleanup all the remaining resources from this alertmanager.
+			// Clean up all the remaining resources from this alertmanager.
 			fileStore.CleanUp()
 		}
 	}

--- a/pkg/services/ngalert/remote/alertmanager.go
+++ b/pkg/services/ngalert/remote/alertmanager.go
@@ -294,9 +294,8 @@ func (am *Alertmanager) Ready() bool {
 	return am.ready
 }
 
-func (am *Alertmanager) FileStore() *notifier.FileStore {
-	return &notifier.FileStore{}
-}
+// We don't have files on disk, no-op.
+func (am *Alertmanager) CleanUp() {}
 
 func (am *Alertmanager) OrgID() int64 {
 	return am.orgID


### PR DESCRIPTION
The only reason why we needed to access the internal Alertmanager's file store was to clean up the working directory when shutting down an Alertmanager for an org. This PR replaces the `alertmanager.FileStore()` method for `alertmanager.CleanUp()` in the Alertmanager interface, which deletes the local working directory from disk for internal Alertmanagers and is a no-op for remote Alertmanagers.