### PR TITLE
Alerting: Remove ConfigHash() from the Alertmanager interface

### DIFF
--- a/pkg/services/ngalert/notifier/alertmanager.go
+++ b/pkg/services/ngalert/notifier/alertmanager.go
@@ -395,10 +395,6 @@ func (am *alertmanager) PutAlerts(_ context.Context, postableAlerts apimodels.Po
 	return am.Base.PutAlerts(alerts)
 }
 
-func (am *alertmanager) ConfigHash() [16]byte {
-	return am.Base.ConfigHash()
-}
-
 func (am *alertmanager) OrgID() int64 {
 	return am.orgID
 }

--- a/pkg/services/ngalert/notifier/multiorg_alertmanager.go
+++ b/pkg/services/ngalert/notifier/multiorg_alertmanager.go
@@ -58,7 +58,6 @@ type Alertmanager interface {
 	StopAndWait()
 	Ready() bool
 	OrgID() int64
-	ConfigHash() [16]byte
 }
 
 type MultiOrgAlertmanager struct {

--- a/pkg/services/ngalert/notifier/multiorg_alertmanager_test.go
+++ b/pkg/services/ngalert/notifier/multiorg_alertmanager_test.go
@@ -288,7 +288,6 @@ func TestMultiOrgAlertmanager_AlertmanagerFor(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, "N/A", *am.GetStatus().VersionInfo.Version)
 		require.Equal(t, int64(2), am.OrgID())
-		require.NotNil(t, am.ConfigHash())
 	}
 
 	// Let's now remove the previous queried organization.

--- a/pkg/services/ngalert/remote/alertmanager.go
+++ b/pkg/services/ngalert/remote/alertmanager.go
@@ -301,10 +301,6 @@ func (am *Alertmanager) OrgID() int64 {
 	return am.orgID
 }
 
-func (am *Alertmanager) ConfigHash() [16]byte {
-	return [16]byte{}
-}
-
 type roundTripper struct {
 	tenantID          string
 	basicAuthPassword string


### PR DESCRIPTION
This PR removes the `ConfigHash()` method from the Alertmanager interface. We don't need to expose the configuration hash.