### PR TITLE
DashboardScene: Render share snapshot radio button translations

### DIFF
--- a/public/app/features/dashboard-scene/sharing/ShareSnapshotTab.tsx
+++ b/public/app/features/dashboard-scene/sharing/ShareSnapshotTab.tsx
@@ -15,26 +15,29 @@ import { transformSceneToSaveModel, trimDashboardForSnapshot } from '../serializ
 import { SceneShareTabState } from './types';
 
 const SNAPSHOTS_API_ENDPOINT = '/api/snapshots';
-const DEFAULT_EXPIRE_OPTION: SelectableValue<number> = {
-  label: t('share-modal.snapshot.expire-never', `Never`),
-  value: 0,
-};
 
-const EXPIRE_OPTIONS = [
-  DEFAULT_EXPIRE_OPTION,
-  {
-    label: t('share-modal.snapshot.expire-hour', `1 Hour`),
-    value: 60 * 60,
-  },
-  {
-    label: t('share-modal.snapshot.expire-day', `1 Day`),
-    value: 60 * 60 * 24,
-  },
-  {
-    label: t('share-modal.snapshot.expire-week', `7 Days`),
-    value: 60 * 60 * 24 * 7,
-  },
-];
+const getExpireOptions = () => {
+  const DEFAULT_EXPIRE_OPTION: SelectableValue<number> = {
+    label: t('share-modal.snapshot.expire-never', `Never`),
+    value: 0,
+  };
+
+  return [
+    DEFAULT_EXPIRE_OPTION,
+    {
+      label: t('share-modal.snapshot.expire-hour', '1 Hour'),
+      value: 60 * 60,
+    },
+    {
+      label: t('share-modal.snapshot.expire-day', '1 Day'),
+      value: 60 * 60 * 24,
+    },
+    {
+      label: t('share-modal.snapshot.expire-week', '7 Days'),
+      value: 60 * 60 * 24 * 7,
+    },
+  ];
+};
 
 type SnapshotSharingOptions = {
   externalEnabled: boolean;
@@ -58,7 +61,7 @@ export class ShareSnapshotTab extends SceneObjectBase<ShareSnapshotTabState> {
     super({
       ...state,
       snapshotName: state.dashboardRef.resolve().state.title,
-      selectedExpireOption: DEFAULT_EXPIRE_OPTION,
+      selectedExpireOption: getExpireOptions()[0],
     });
 
     this.addActivationHandler(() => {
@@ -88,7 +91,7 @@ export class ShareSnapshotTab extends SceneObjectBase<ShareSnapshotTabState> {
 
   public onExpireChange = (option: number) => {
     this.setState({
-      selectedExpireOption: EXPIRE_OPTIONS.find((o) => o.value === option),
+      selectedExpireOption: getExpireOptions().find((o) => o.value === option),
     });
   };
 
@@ -184,7 +187,7 @@ function ShareSnapshoTabRenderer({ model }: SceneComponentProps<ShareSnapshotTab
           <Field label={t('share-modal.snapshot.expire', `Expire`)}>
             <RadioButtonGroup<number>
               id="expire-select-input"
-              options={EXPIRE_OPTIONS}
+              options={getExpireOptions()}
               value={selectedExpireOption?.value}
               onChange={model.onExpireChange}
             />


### PR DESCRIPTION
Labels on the radio button in the share snapshot are visible now.