### PR TITLE
Table: fix `cellProps.style.textAlign` being readOnly in some cases

### DIFF
--- a/packages/grafana-ui/src/components/Table/DefaultCell.tsx
+++ b/packages/grafana-ui/src/components/Table/DefaultCell.tsx
@@ -52,7 +52,7 @@ export const DefaultCell = (props: TableCellProps) => {
   const cellStyle = getCellStyle(tableStyles, cellOptions, displayValue, inspectEnabled, isStringValue);
 
   if (isStringValue && cellProps.style?.justifyContent === 'flex-end') {
-    cellProps.style!.textAlign = 'right';
+    cellProps.style = { ...cellProps.style, textAlign: 'right' };
   }
 
   return (


### PR DESCRIPTION
**What is this feature?**

https://github.com/grafana/grafana/pull/76906 introduced setting `cellProps.style.textAlign` to `right`. However `cellProps.style.textAlign` is read only in some occasions, thus it will lead to browser errors:
![image](https://github.com/grafana/grafana/assets/8092184/d57a7d82-e892-4a98-abe8-e504b61814c1)
