### PR TITLE
InfluxDB: Fix handle multiple frames in metricFindQuery and runMetadataQuery

### DIFF
--- a/public/app/plugins/datasource/influxdb/datasource.ts
+++ b/public/app/plugins/datasource/influxdb/datasource.ts
@@ -296,12 +296,7 @@ export default class InfluxDatasource extends DataSourceWithBackend<InfluxQuery,
       super.query({
         targets: [target],
       } as DataQueryRequest)
-    ).then((rsp) => {
-      if (rsp.data?.length) {
-        return frameToMetricFindValue(rsp.data[0]);
-      }
-      return [];
-    });
+    ).then(this.toMetricFindValue);
   }
 
   async metricFindQuery(query: string, options?: any): Promise<MetricFindValue[]> {
@@ -316,12 +311,7 @@ export default class InfluxDatasource extends DataSourceWithBackend<InfluxQuery,
           ...(options ?? {}), // includes 'range'
           targets: [target],
         })
-      ).then((rsp) => {
-        if (rsp.data?.length) {
-          return frameToMetricFindValue(rsp.data[0]);
-        }
-        return [];
-      });
+      ).then(this.toMetricFindValue);
     }
 
     const interpolated = this.templateSrv.replace(query, options?.scopedVars, this.interpolateQueryExpr);
@@ -329,6 +319,14 @@ export default class InfluxDatasource extends DataSourceWithBackend<InfluxQuery,
     return lastValueFrom(this._seriesQuery(interpolated, options)).then((resp) => {
       return this.responseParser.parse(query, resp);
     });
+  }
+
+  toMetricFindValue(rsp: DataQueryResponse): MetricFindValue[] {
+    const data = rsp.data ?? [];
+    // Create MetricFindValue object for all frames
+    const values = data.map((d) => frameToMetricFindValue(d)).flat();
+    // Filter out duplicate elements
+    return values.filter((elm, idx, self) => idx === self.findIndex((t) => t.text === elm.text));
   }
 
   // By implementing getTagKeys and getTagValues we add ad-hoc filters functionality

--- a/public/app/plugins/datasource/influxdb/datasource_backend_mode.test.ts
+++ b/public/app/plugins/datasource/influxdb/datasource_backend_mode.test.ts
@@ -286,4 +286,67 @@ describe('InfluxDataSource Backend Mode', () => {
       expect(qData).toBe(qe);
     });
   });
+
+  describe('metric find query', () => {
+    let ds = getMockInfluxDS(getMockDSInstanceSettings());
+    it('handles multiple frames', async () => {
+      const fetchMockImpl = () => {
+        return of(mockMetricFindQueryResponse);
+      };
+
+      fetchMock.mockImplementation(fetchMockImpl);
+      const values = await ds.getTagValues({ key: 'test_id', filters: [] });
+      expect(fetchMock).toHaveBeenCalled();
+      expect(values.length).toBe(5);
+      expect(values[0].text).toBe('test-t2-1');
+    });
+  });
 });
+
+const mockMetricFindQueryResponse = {
+  data: {
+    results: {
+      metricFindQuery: {
+        status: 200,
+        frames: [
+          {
+            schema: {
+              name: 'NoneNone',
+              refId: 'metricFindQuery',
+              fields: [
+                {
+                  name: 'Value',
+                  type: 'string',
+                  typeInfo: {
+                    frame: 'string',
+                  },
+                },
+              ],
+            },
+            data: {
+              values: [['test-t2-1', 'test-t2-10']],
+            },
+          },
+          {
+            schema: {
+              name: 'some-other',
+              refId: 'metricFindQuery',
+              fields: [
+                {
+                  name: 'Value',
+                  type: 'string',
+                  typeInfo: {
+                    frame: 'string',
+                  },
+                },
+              ],
+            },
+            data: {
+              values: [['test-t2-1', 'test-t2-10', 'test-t2-2', 'test-t2-3', 'test-t2-4']],
+            },
+          },
+        ],
+      },
+    },
+  },
+};


### PR DESCRIPTION
**What is this feature?**

This is fixing handling of multiple frame responses in `metricFindQuery` and `runMetadataQuery` methods.


**Who is this feature for?**

InfluxDB InfluxQL language users on backend mode 

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
