### PR TITLE
Explore TraceView: Remove 'Scroll to top' button

### DIFF
--- a/public/app/features/explore/Explore.tsx
+++ b/public/app/features/explore/Explore.tsx
@@ -504,7 +504,6 @@ export class Explore extends React.PureComponent<Props, ExploreState> {
             splitOpenFn={this.onSplitOpen('traceView')}
             scrollElement={this.scrollElement}
             queryResponse={queryResponse}
-            topOfViewRef={this.topOfViewRef}
           />
         </ContentOutlineItem>
       )

--- a/public/app/features/explore/TraceView/TraceView.tsx
+++ b/public/app/features/explore/TraceView/TraceView.tsx
@@ -64,8 +64,8 @@ type Props = {
   traceProp: Trace;
   queryResponse: PanelData;
   datasource: DataSourceApi<DataQuery, DataSourceJsonData, {}> | undefined;
-  topOfViewRef: RefObject<HTMLDivElement>;
-  topOfViewRefType: TopOfViewRefType;
+  topOfViewRef?: RefObject<HTMLDivElement>;
+  topOfViewRefType?: TopOfViewRefType;
   createSpanLink?: SpanLinkFunc;
 };
 

--- a/public/app/features/explore/TraceView/TraceViewContainer.test.tsx
+++ b/public/app/features/explore/TraceView/TraceViewContainer.test.tsx
@@ -1,6 +1,6 @@
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import React, { createRef } from 'react';
+import React from 'react';
 import { Provider } from 'react-redux';
 
 import { getDefaultTimeRange, LoadingState } from '@grafana/data';
@@ -24,17 +24,10 @@ function renderTraceViewContainer(frames = [frameOld]) {
     series: [],
     timeRange: getDefaultTimeRange(),
   };
-  const topOfViewRef = createRef<HTMLDivElement>();
 
   const { container, baseElement } = render(
     <Provider store={store}>
-      <TraceViewContainer
-        exploreId="left"
-        dataFrames={frames}
-        splitOpenFn={() => {}}
-        queryResponse={mockPanelData}
-        topOfViewRef={topOfViewRef}
-      />
+      <TraceViewContainer exploreId="left" dataFrames={frames} splitOpenFn={() => {}} queryResponse={mockPanelData} />
     </Provider>
   );
   return {

--- a/public/app/features/explore/TraceView/TraceViewContainer.tsx
+++ b/public/app/features/explore/TraceView/TraceViewContainer.tsx
@@ -14,7 +14,7 @@ interface Props {
   exploreId: string;
   scrollElement?: Element;
   queryResponse: PanelData;
-  topOfViewRef: RefObject<HTMLDivElement>;
+  topOfViewRef?: RefObject<HTMLDivElement>;
 }
 
 export function TraceViewContainer(props: Props) {
@@ -40,8 +40,6 @@ export function TraceViewContainer(props: Props) {
         traceProp={traceProp}
         queryResponse={queryResponse}
         datasource={datasource}
-        topOfViewRef={topOfViewRef}
-        topOfViewRefType={TopOfViewRefType.Explore}
       />
     </PanelChrome>
   );

--- a/public/app/features/explore/TraceView/TraceViewContainer.tsx
+++ b/public/app/features/explore/TraceView/TraceViewContainer.tsx
@@ -1,11 +1,10 @@
-import React, { RefObject, useMemo } from 'react';
+import React, { useMemo } from 'react';
 
 import { DataFrame, SplitOpen, PanelData } from '@grafana/data';
 import { PanelChrome } from '@grafana/ui/src/components/PanelChrome/PanelChrome';
 import { StoreState, useSelector } from 'app/types';
 
 import { TraceView } from './TraceView';
-import { TopOfViewRefType } from './components/TraceTimelineViewer/VirtualizedTraceView';
 import { transformDataFrames } from './utils/transform';
 
 interface Props {
@@ -14,13 +13,12 @@ interface Props {
   exploreId: string;
   scrollElement?: Element;
   queryResponse: PanelData;
-  topOfViewRef?: RefObject<HTMLDivElement>;
 }
 
 export function TraceViewContainer(props: Props) {
   // At this point we only show single trace
   const frame = props.dataFrames[0];
-  const { dataFrames, splitOpenFn, exploreId, scrollElement, topOfViewRef, queryResponse } = props;
+  const { dataFrames, splitOpenFn, exploreId, scrollElement, queryResponse } = props;
   const traceProp = useMemo(() => transformDataFrames(frame), [frame]);
   const datasource = useSelector(
     (state: StoreState) => state.explore.panes[props.exploreId]?.datasourceInstance ?? undefined

--- a/public/app/features/explore/TraceView/components/TraceTimelineViewer/VirtualizedTraceView.test.tsx
+++ b/public/app/features/explore/TraceView/components/TraceTimelineViewer/VirtualizedTraceView.test.tsx
@@ -72,27 +72,16 @@ describe('<VirtualizedTraceViewImpl>', () => {
   it('renders without exploding', () => {
     render(<VirtualizedTraceView {...props} />);
     expect(screen.getByTestId('ListView')).toBeInTheDocument();
-    expect(screen.getByTitle('Scroll to top')).toBeInTheDocument();
   });
 
   it('renders when a trace is not set', () => {
     props = { ...props, trace: null as unknown as Trace };
     render(<VirtualizedTraceView {...props} />);
     expect(screen.getByTestId('ListView')).toBeInTheDocument();
-    expect(screen.getByTitle('Scroll to top')).toBeInTheDocument();
   });
 
   it('renders ListView', () => {
     render(<VirtualizedTraceView {...props} />);
     expect(screen.getByTestId('ListView')).toBeInTheDocument();
-  });
-
-  it('renders scrollToTopButton', () => {
-    render(<VirtualizedTraceView {...props} />);
-    expect(
-      screen.getByRole('button', {
-        name: /Scroll to top/i,
-      })
-    ).toBeInTheDocument();
   });
 });

--- a/public/app/features/explore/TraceView/components/TraceTimelineViewer/VirtualizedTraceView.test.tsx
+++ b/public/app/features/explore/TraceView/components/TraceTimelineViewer/VirtualizedTraceView.test.tsx
@@ -25,7 +25,7 @@ import VirtualizedTraceView, { VirtualizedTraceViewProps } from './VirtualizedTr
 jest.mock('./SpanTreeOffset');
 
 const trace = transformTraceData(traceGenerator.trace({ numberOfSpans: 2 }))!;
-const topOfExploreViewRef = jest.fn();
+
 let props = {
   childrenHiddenIDs: new Set(),
   childrenToggle: jest.fn(),
@@ -41,7 +41,7 @@ let props = {
   spanNameColumnWidth: 0.5,
   trace,
   uiFind: 'uiFind',
-  topOfExploreViewRef,
+  topOfViewRef: jest.fn(),
 } as unknown as VirtualizedTraceViewProps;
 
 describe('<VirtualizedTraceViewImpl>', () => {
@@ -72,16 +72,27 @@ describe('<VirtualizedTraceViewImpl>', () => {
   it('renders without exploding', () => {
     render(<VirtualizedTraceView {...props} />);
     expect(screen.getByTestId('ListView')).toBeInTheDocument();
+    expect(screen.getByTitle('Scroll to top')).toBeInTheDocument();
   });
 
   it('renders when a trace is not set', () => {
     props = { ...props, trace: null as unknown as Trace };
     render(<VirtualizedTraceView {...props} />);
     expect(screen.getByTestId('ListView')).toBeInTheDocument();
+    expect(screen.getByTitle('Scroll to top')).toBeInTheDocument();
   });
 
   it('renders ListView', () => {
     render(<VirtualizedTraceView {...props} />);
     expect(screen.getByTestId('ListView')).toBeInTheDocument();
+  });
+
+  it('renders scrollToTopButton', () => {
+    render(<VirtualizedTraceView {...props} />);
+    expect(
+      screen.getByRole('button', {
+        name: /Scroll to top/i,
+      })
+    ).toBeInTheDocument();
   });
 });

--- a/public/app/features/explore/TraceView/components/TraceTimelineViewer/VirtualizedTraceView.tsx
+++ b/public/app/features/explore/TraceView/components/TraceTimelineViewer/VirtualizedTraceView.tsx
@@ -566,6 +566,14 @@ export class UnthemedVirtualizedTraceView extends React.Component<VirtualizedTra
           windowScroller={false}
           scrollElement={scrollElement}
         />
+        {this.props.topOfViewRef && (
+          <ToolbarButton
+            className={styles.scrollToTopButton}
+            onClick={this.scrollToTop}
+            title="Scroll to top"
+            icon="arrow-up"
+          ></ToolbarButton>
+        )}
       </>
     );
   }

--- a/public/app/features/explore/TraceView/components/TraceTimelineViewer/VirtualizedTraceView.tsx
+++ b/public/app/features/explore/TraceView/components/TraceTimelineViewer/VirtualizedTraceView.tsx
@@ -566,12 +566,6 @@ export class UnthemedVirtualizedTraceView extends React.Component<VirtualizedTra
           windowScroller={false}
           scrollElement={scrollElement}
         />
-        <ToolbarButton
-          className={styles.scrollToTopButton}
-          onClick={this.scrollToTop}
-          title="Scroll to top"
-          icon="arrow-up"
-        ></ToolbarButton>
       </>
     );
   }


### PR DESCRIPTION
**What is this feature?**

With the implementation of [Content outline in Explore](https://github.com/grafana/grafana/pull/74536), the need for scroll to the top button in Trace View with its current functionality is obsolete. This PR removes the scroll to the top button in Explore. However, since the TracesPanel plugin relies on the TraceView component from Explore:

https://github.com/grafana/grafana/blob/eb62e0225985dfeef6637304541f88ad4c8c3073/public/app/plugins/panel/traces/TracesPanel.tsx#L7

the TracesPanel will still have the scroll to the top button and therefore will not remove it from other applications and plugins that rely on TracesPanel. Determining if the button should be displayed is done by passing `topOfViewRef` because ultimately that prop is drilled down and used inside the `VirtualizedTraceView`'s scroll to the top button. 

Fixes #76391 

Please check that:
- [ ] It works as expected from a user's perspective.

