### PR TITLE
Alerting: Add support for responders to Opsgenie integration

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -61,7 +61,7 @@ require (
 	github.com/google/uuid v1.3.1 // @grafana/backend-platform
 	github.com/google/wire v0.5.0 // @grafana/backend-platform
 	github.com/gorilla/websocket v1.5.0 // @grafana/grafana-app-platform-squad
-	github.com/grafana/alerting v0.0.0-20231017091417-a53b5db2235d // @grafana/alerting-squad-backend
+	github.com/grafana/alerting v0.0.0-20231026192550-079966731bbe // @grafana/alerting-squad-backend
 	github.com/grafana/cuetsy v0.1.10 // @grafana/grafana-as-code
 	github.com/grafana/grafana-aws-sdk v0.19.1 // @grafana/aws-datasources
 	github.com/grafana/grafana-azure-sdk-go v1.9.0 // @grafana/backend-platform

--- a/go.sum
+++ b/go.sum
@@ -1798,6 +1798,8 @@ github.com/gotestyourself/gotestyourself v1.3.0/go.mod h1:zZKM6oeNM8k+FRljX1mnzV
 github.com/gotestyourself/gotestyourself v2.2.0+incompatible/go.mod h1:zZKM6oeNM8k+FRljX1mnzVYeS8wiGgQyvST1/GafPbY=
 github.com/grafana/alerting v0.0.0-20231017091417-a53b5db2235d h1:fxHDUyKFc1mfyJAtW+Qxi66dMahYu+o5/lH+f8SoMHg=
 github.com/grafana/alerting v0.0.0-20231017091417-a53b5db2235d/go.mod h1:6BES5CyEqz7fDAG3MYvJLe0hqGwvIoGDN8A1aNrLGus=
+github.com/grafana/alerting v0.0.0-20231026192550-079966731bbe h1:6jY5mWR//GbYOjvqpnoncgkdxbeYImkTsy9rPvVFOlk=
+github.com/grafana/alerting v0.0.0-20231026192550-079966731bbe/go.mod h1:6BES5CyEqz7fDAG3MYvJLe0hqGwvIoGDN8A1aNrLGus=
 github.com/grafana/codejen v0.0.3 h1:tAWxoTUuhgmEqxJPOLtJoxlPBbMULFwKFOcRsPRPXDw=
 github.com/grafana/codejen v0.0.3/go.mod h1:zmwwM/DRyQB7pfuBjTWII3CWtxcXh8LTwAYGfDfpR6s=
 github.com/grafana/cue v0.0.0-20230926092038-971951014e3f h1:TmYAMnqg3d5KYEAaT6PtTguL2GjLfvr6wnAX8Azw6tQ=

--- a/pkg/services/ngalert/api/tooling/definitions/contact_points.go
+++ b/pkg/services/ngalert/api/tooling/definitions/contact_points.go
@@ -100,17 +100,25 @@ type OnCallIntegration struct {
 	Message                  *string `json:"message,omitempty" yaml:"message,omitempty" hcl:"message"`
 }
 
+type OpsgenieIntegrationResponder struct {
+	ID       *string `json:"id,omitempty" yaml:"id,omitempty" hcl:"id"`
+	Name     *string `json:"name,omitempty" yaml:"name,omitempty" hcl:"name"`
+	Username *string `json:"username,omitempty" yaml:"username,omitempty" hcl:"username"`
+	Type     string  `json:"type" yaml:"type" hcl:"type"`
+}
+
 type OpsgenieIntegration struct {
 	DisableResolveMessage *bool `json:"-" yaml:"-" hcl:"disable_resolve_message"`
 
 	APIKey Secret `json:"apiKey" yaml:"apiKey" hcl:"api_key"`
 
-	APIUrl           *string `json:"apiUrl,omitempty" yaml:"apiUrl,omitempty" hcl:"url"`
-	Message          *string `json:"message,omitempty" yaml:"message,omitempty" hcl:"message"`
-	Description      *string `json:"description,omitempty" yaml:"description,omitempty" hcl:"description"`
-	AutoClose        *bool   `json:"autoClose,omitempty" yaml:"autoClose,omitempty" hcl:"auto_close"`
-	OverridePriority *bool   `json:"overridePriority,omitempty" yaml:"overridePriority,omitempty" hcl:"override_priority"`
-	SendTagsAs       *string `json:"sendTagsAs,omitempty" yaml:"sendTagsAs,omitempty" hcl:"send_tags_as"`
+	APIUrl           *string                        `json:"apiUrl,omitempty" yaml:"apiUrl,omitempty" hcl:"url"`
+	Message          *string                        `json:"message,omitempty" yaml:"message,omitempty" hcl:"message"`
+	Description      *string                        `json:"description,omitempty" yaml:"description,omitempty" hcl:"description"`
+	AutoClose        *bool                          `json:"autoClose,omitempty" yaml:"autoClose,omitempty" hcl:"auto_close"`
+	OverridePriority *bool                          `json:"overridePriority,omitempty" yaml:"overridePriority,omitempty" hcl:"override_priority"`
+	SendTagsAs       *string                        `json:"sendTagsAs,omitempty" yaml:"sendTagsAs,omitempty" hcl:"send_tags_as"`
+	Responders       []OpsgenieIntegrationResponder `json:"responders,omitempty" yaml:"responders,omitempty" hcl:"responders,block"`
 }
 
 type PagerdutyIntegration struct {

--- a/pkg/services/ngalert/notifier/channels_config/available_channels.go
+++ b/pkg/services/ngalert/notifier/channels_config/available_channels.go
@@ -1298,12 +1298,12 @@ func GetAvailableNotifiers() []*NotifierPlugin {
 				{
 					Label:        "Responders",
 					PropertyName: "responders",
-					Description:  "If API key belongs to a team, this field is ignored.",
+					Description:  "If the API key belongs to a team, this field is ignored.",
 					Element:      ElementSubformArray,
 					SubformOptions: []NotifierOption{
 						{
 							Label:        "Type",
-							Description:  fmt.Sprintf("%s or a template", strings.Join(alertingOpsgenie.SupportedResponderTypes, ",")),
+							Description:  fmt.Sprintf("%s or a template", strings.Join(alertingOpsgenie.SupportedResponderTypes, ", ")),
 							Element:      ElementTypeInput,
 							Required:     true,
 							PropertyName: "type",
@@ -1323,7 +1323,7 @@ func GetAvailableNotifiers() []*NotifierPlugin {
 						{
 							Label:        "Username",
 							Element:      ElementTypeInput,
-							Description:  "Name of the responder. Must be specified if id and name are empty.",
+							Description:  "Username of the responder. Must be specified if id and name are empty.",
 							PropertyName: "username",
 						},
 					},

--- a/pkg/services/ngalert/notifier/channels_config/available_channels.go
+++ b/pkg/services/ngalert/notifier/channels_config/available_channels.go
@@ -1294,6 +1294,7 @@ func GetAvailableNotifiers() []*NotifierPlugin {
 					Description:  "Send the common annotations to Opsgenie as either Extra Properties, Tags or both",
 					PropertyName: "sendTagsAs",
 				},
+				// New in 10.3
 				{
 					Label:        "Responders",
 					PropertyName: "responders",
@@ -1308,18 +1309,21 @@ func GetAvailableNotifiers() []*NotifierPlugin {
 							PropertyName: "type",
 						},
 						{
-							Label:        "ID",
-							Element:      ElementTypeInput,
-							PropertyName: "id",
-						},
-						{
 							Label:        "Name",
 							Element:      ElementTypeInput,
+							Description:  "Name of the responder. Must be specified if id and username are empty or if the type is 'teams'.",
 							PropertyName: "name",
+						},
+						{
+							Label:        "ID",
+							Element:      ElementTypeInput,
+							Description:  "ID of the responder. Must be specified if name and username are empty.",
+							PropertyName: "id",
 						},
 						{
 							Label:        "Username",
 							Element:      ElementTypeInput,
+							Description:  "Name of the responder. Must be specified if id and name.",
 							PropertyName: "username",
 						},
 					},

--- a/pkg/services/ngalert/notifier/channels_config/available_channels.go
+++ b/pkg/services/ngalert/notifier/channels_config/available_channels.go
@@ -1323,7 +1323,7 @@ func GetAvailableNotifiers() []*NotifierPlugin {
 						{
 							Label:        "Username",
 							Element:      ElementTypeInput,
-							Description:  "Name of the responder. Must be specified if id and name.",
+							Description:  "Name of the responder. Must be specified if id and name are empty.",
 							PropertyName: "username",
 						},
 					},

--- a/pkg/services/ngalert/notifier/channels_config/available_channels.go
+++ b/pkg/services/ngalert/notifier/channels_config/available_channels.go
@@ -1311,19 +1311,19 @@ func GetAvailableNotifiers() []*NotifierPlugin {
 						{
 							Label:        "Name",
 							Element:      ElementTypeInput,
-							Description:  "Name of the responder. Must be specified if id and username are empty or if the type is 'teams'.",
+							Description:  "Name of the responder. Must be specified if ID and Username are empty or if the type is 'teams'.",
 							PropertyName: "name",
 						},
 						{
 							Label:        "ID",
 							Element:      ElementTypeInput,
-							Description:  "ID of the responder. Must be specified if name and username are empty.",
+							Description:  "ID of the responder. Must be specified if name and Username are empty.",
 							PropertyName: "id",
 						},
 						{
 							Label:        "Username",
 							Element:      ElementTypeInput,
-							Description:  "Username of the responder. Must be specified if id and name are empty.",
+							Description:  "User name of the responder. Must be specified if ID and Name are empty.",
 							PropertyName: "username",
 						},
 					},

--- a/pkg/services/ngalert/notifier/channels_config/available_channels.go
+++ b/pkg/services/ngalert/notifier/channels_config/available_channels.go
@@ -3,6 +3,7 @@ package channels_config
 import (
 	"fmt"
 	"os"
+	"strings"
 
 	alertingOpsgenie "github.com/grafana/alerting/receivers/opsgenie"
 	alertingTemplates "github.com/grafana/alerting/templates"
@@ -1292,6 +1293,36 @@ func GetAvailableNotifiers() []*NotifierPlugin {
 					},
 					Description:  "Send the common annotations to Opsgenie as either Extra Properties, Tags or both",
 					PropertyName: "sendTagsAs",
+				},
+				{
+					Label:        "Responders",
+					PropertyName: "responders",
+					Description:  "If API key belongs to a team, this field is ignored.",
+					Element:      ElementSubformArray,
+					SubformOptions: []NotifierOption{
+						{
+							Label:        "Type",
+							Description:  fmt.Sprintf("%s or a template", strings.Join(alertingOpsgenie.SupportedResponderTypes, ",")),
+							Element:      ElementTypeInput,
+							Required:     true,
+							PropertyName: "type",
+						},
+						{
+							Label:        "ID",
+							Element:      ElementTypeInput,
+							PropertyName: "id",
+						},
+						{
+							Label:        "Name",
+							Element:      ElementTypeInput,
+							PropertyName: "name",
+						},
+						{
+							Label:        "Username",
+							Element:      ElementTypeInput,
+							PropertyName: "username",
+						},
+					},
 				},
 			},
 		},

--- a/pkg/services/ngalert/notifier/channels_config/plugin.go
+++ b/pkg/services/ngalert/notifier/channels_config/plugin.go
@@ -12,18 +12,19 @@ type NotifierPlugin struct {
 
 // NotifierOption holds information about options specific for the NotifierPlugin.
 type NotifierOption struct {
-	Element        ElementType    `json:"element"`
-	InputType      InputType      `json:"inputType"`
-	Label          string         `json:"label"`
-	Description    string         `json:"description"`
-	Placeholder    string         `json:"placeholder"`
-	PropertyName   string         `json:"propertyName"`
-	SelectOptions  []SelectOption `json:"selectOptions"`
-	ShowWhen       ShowWhen       `json:"showWhen"`
-	Required       bool           `json:"required"`
-	ValidationRule string         `json:"validationRule"`
-	Secure         bool           `json:"secure"`
-	DependsOn      string         `json:"dependsOn"`
+	Element        ElementType      `json:"element"`
+	InputType      InputType        `json:"inputType"`
+	Label          string           `json:"label"`
+	Description    string           `json:"description"`
+	Placeholder    string           `json:"placeholder"`
+	PropertyName   string           `json:"propertyName"`
+	SelectOptions  []SelectOption   `json:"selectOptions"`
+	ShowWhen       ShowWhen         `json:"showWhen"`
+	Required       bool             `json:"required"`
+	ValidationRule string           `json:"validationRule"`
+	Secure         bool             `json:"secure"`
+	DependsOn      string           `json:"dependsOn"`
+	SubformOptions []NotifierOption `json:"subformOptions"`
 }
 
 // ElementType is the type of element that can be rendered in the frontend.
@@ -40,6 +41,10 @@ const (
 	ElementTypeTextArea = "textarea"
 	// ElementTypeKeyValueMap will render inputs to add arbitrary key-value pairs
 	ElementTypeKeyValueMap = "key_value_map"
+	// ElementSubformArray will render a sub-form with schema defined in SubformOptions
+	ElementTypeSubform = "subform"
+	// ElementSubformArray will render a multiple sub-forms with schema defined in SubformOptions
+	ElementSubformArray = "subform_array"
 )
 
 // InputType is the type of input that can be rendered in the frontend.


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**
This PR adds support for field Responders to OpsGenie integration. 

![image](https://github.com/grafana/grafana/assets/25988953/3cc704b9-c281-4dc2-afd2-643fbac21ac8)



**Why do we need this feature?**
Let alerting users to configure OpsGenie more flexibly. Reduce drift with vanilla Alertmanager.

**Who is this feature for?**
Grafana Alerting users that send alerts to OpsGenie

**Which issue(s) does this PR fix?**:

Related to https://github.com/grafana/grafana/issues/50462

**Special notes for your reviewer:**
This PR should be reviewed together with https://github.com/grafana/alerting/pull/131.

Please check that:
- [x] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle.
- [x] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
