### PR TITLE
chore: add basic tracing to playlist service

### DIFF
--- a/pkg/services/playlist/playlistimpl/playlist.go
+++ b/pkg/services/playlist/playlistimpl/playlist.go
@@ -4,34 +4,47 @@ import (
 	"context"
 
 	"github.com/grafana/grafana/pkg/infra/db"
+	"github.com/grafana/grafana/pkg/infra/tracing"
 	"github.com/grafana/grafana/pkg/services/playlist"
 )
 
 type Service struct {
-	store store
+	store  store
+	tracer tracing.Tracer
 }
 
 var _ playlist.Service = &Service{}
 
-func ProvideService(db db.DB) playlist.Service {
-	return &Service{store: &sqlStore{
-		db: db,
-	}}
+func ProvideService(db db.DB, tracer tracing.Tracer) playlist.Service {
+	return &Service{
+		tracer: tracer,
+		store: &sqlStore{
+			db: db,
+		},
+	}
 }
 
 func (s *Service) Create(ctx context.Context, cmd *playlist.CreatePlaylistCommand) (*playlist.Playlist, error) {
+	ctx, span := s.tracer.Start(ctx, "playlists.Create")
+	defer span.End()
 	return s.store.Insert(ctx, cmd)
 }
 
 func (s *Service) Update(ctx context.Context, cmd *playlist.UpdatePlaylistCommand) (*playlist.PlaylistDTO, error) {
+	ctx, span := s.tracer.Start(ctx, "playlists.Update")
+	defer span.End()
 	return s.store.Update(ctx, cmd)
 }
 
 func (s *Service) GetWithoutItems(ctx context.Context, q *playlist.GetPlaylistByUidQuery) (*playlist.Playlist, error) {
+	ctx, span := s.tracer.Start(ctx, "playlists.GetWithoutItems")
+	defer span.End()
 	return s.store.Get(ctx, q)
 }
 
 func (s *Service) Get(ctx context.Context, q *playlist.GetPlaylistByUidQuery) (*playlist.PlaylistDTO, error) {
+	ctx, span := s.tracer.Start(ctx, "playlists.Get")
+	defer span.End()
 	v, err := s.store.Get(ctx, q)
 	if err != nil {
 		return nil, err
@@ -66,9 +79,13 @@ func (s *Service) Get(ctx context.Context, q *playlist.GetPlaylistByUidQuery) (*
 }
 
 func (s *Service) Search(ctx context.Context, q *playlist.GetPlaylistsQuery) (playlist.Playlists, error) {
+	ctx, span := s.tracer.Start(ctx, "playlists.Search")
+	defer span.End()
 	return s.store.List(ctx, q)
 }
 
 func (s *Service) Delete(ctx context.Context, cmd *playlist.DeletePlaylistCommand) error {
+	ctx, span := s.tracer.Start(ctx, "playlists.Delete")
+	defer span.End()
 	return s.store.Delete(ctx, cmd)
 }


### PR DESCRIPTION
This PR adds basic tracing spans to the playlist service. The screenshot below shows the new `playlists.*` spans properly merging with the HTTP & authn middleware traces (🎉)

To test this locally:

1. run `make devenv sources=self-instrumentation`
1. Start Grafana
1. Configure a tempo datasource (only adding the default address)
1. mess about with playlists
1.  Go to Explore and query the tempo datasource (`{resource.service.name="grafana" && name="playlists.Get"}` is a good start)

<img width="827" alt="Screenshot 2023-10-25 at 2 19 04 PM" src="https://github.com/grafana/grafana/assets/6210214/27ae0383-8bad-4afc-afce-7440fb7da2da">

This is pretty basic, and I'm happy to take suggestions, though keep in mind that this is mainly so we have something to compare to as we switch over to the new APIs. (unless we want EVEN MORE traces so we can follow exactly which storage engine a given playlist goes through! 🤷🏻 I can always add more as we go)