### PR TITLE
Organize fields transformation: Fix re-ordering of fields using drag and drop

### DIFF
--- a/public/app/features/transformers/editors/OrganizeFieldsTransformerEditor.tsx
+++ b/public/app/features/transformers/editors/OrganizeFieldsTransformerEditor.tsx
@@ -134,13 +134,9 @@ const DraggableFieldName = ({
         <div className="gf-form-inline" ref={provided.innerRef} {...provided.draggableProps}>
           <div className="gf-form gf-form--grow">
             <div className="gf-form-label gf-form-label--justify-left width-30">
-              <Icon
-                name="draggabledots"
-                title="Drag and drop to reorder"
-                size="lg"
-                className={styles.draggable}
-                {...provided.dragHandleProps}
-              />
+              <span {...provided.dragHandleProps}>
+                <Icon name="draggabledots" title="Drag and drop to reorder" size="lg" className={styles.draggable} />
+              </span>
               <IconButton
                 className={styles.toggle}
                 size="md"


### PR DESCRIPTION
Looks like [svg elements are not supported as drag handlers](https://github.com/atlassian/react-beautiful-dnd/blob/master/docs/guides/dragging-svgs.md#dragging-svgs).

Before 

https://github.com/grafana/grafana/assets/88068998/a94b269b-31bf-4e5b-b629-7c2af62ad9c4

After

https://github.com/grafana/grafana/assets/88068998/7b04e1ab-4b78-4e29-9143-35e9c23609c9


**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
