### PR TITLE
Cloudwatch: Use context in aws DescribeLogGroupsWithContext

### DIFF
--- a/pkg/tsdb/cloudwatch/cloudwatch.go
+++ b/pkg/tsdb/cloudwatch/cloudwatch.go
@@ -236,7 +236,7 @@ func (e *cloudWatchExecutor) checkHealthLogs(ctx context.Context, pluginCtx back
 		return err
 	}
 	logsClient := NewLogsAPI(session)
-	_, err = logsClient.DescribeLogGroups(&cloudwatchlogs.DescribeLogGroupsInput{Limit: aws.Int64(1)})
+	_, err = logsClient.DescribeLogGroupsWithContext(ctx, &cloudwatchlogs.DescribeLogGroupsInput{Limit: aws.Int64(1)})
 	return err
 }
 

--- a/pkg/tsdb/cloudwatch/cloudwatch_test.go
+++ b/pkg/tsdb/cloudwatch/cloudwatch_test.go
@@ -220,7 +220,7 @@ func TestQuery_ResourceRequest_DescribeLogGroups_with_CrossAccountQuerying(t *te
 
 	t.Run("maps log group api response to resource response of log-groups", func(t *testing.T) {
 		logsApi = mocks.LogsAPI{}
-		logsApi.On("DescribeLogGroups", mock.Anything).Return(&cloudwatchlogs.DescribeLogGroupsOutput{
+		logsApi.On("DescribeLogGroupsWithContext", mock.Anything).Return(&cloudwatchlogs.DescribeLogGroupsOutput{
 			LogGroups: []*cloudwatchlogs.LogGroup{
 				{Arn: aws.String("arn:aws:logs:us-east-1:111:log-group:group_a"), LogGroupName: aws.String("group_a")},
 			},
@@ -248,7 +248,7 @@ func TestQuery_ResourceRequest_DescribeLogGroups_with_CrossAccountQuerying(t *te
 		   }
 		]`, string(sender.Response.Body))
 
-		logsApi.AssertCalled(t, "DescribeLogGroups",
+		logsApi.AssertCalled(t, "DescribeLogGroupsWithContext",
 			&cloudwatchlogs.DescribeLogGroupsInput{
 				AccountIdentifiers:    []*string{utils.Pointer("some-account-id")},
 				IncludeLinkedAccounts: utils.Pointer(true),

--- a/pkg/tsdb/cloudwatch/metric_find_query.go
+++ b/pkg/tsdb/cloudwatch/metric_find_query.go
@@ -307,7 +307,7 @@ func (e *cloudWatchExecutor) handleGetLogGroups(ctx context.Context, pluginCtx b
 		input.LogGroupNamePrefix = aws.String(logGroupNamePrefix)
 	}
 	var response *cloudwatchlogs.DescribeLogGroupsOutput
-	response, err = logsClient.DescribeLogGroups(input)
+	response, err = logsClient.DescribeLogGroupsWithContext(ctx, input)
 	if err != nil || response == nil {
 		return nil, err
 	}

--- a/pkg/tsdb/cloudwatch/mocks/logs.go
+++ b/pkg/tsdb/cloudwatch/mocks/logs.go
@@ -31,7 +31,7 @@ type LogsService struct {
 	mock.Mock
 }
 
-func (l *LogsService) GetLogGroups(request resources.LogGroupsRequest) ([]resources.ResourceResponse[resources.LogGroup], error) {
+func (l *LogsService) GetLogGroupsWithContext(ctx context.Context, request resources.LogGroupsRequest) ([]resources.ResourceResponse[resources.LogGroup], error) {
 	args := l.Called(request)
 
 	return args.Get(0).([]resources.ResourceResponse[resources.LogGroup]), args.Error(1)

--- a/pkg/tsdb/cloudwatch/mocks/logs.go
+++ b/pkg/tsdb/cloudwatch/mocks/logs.go
@@ -15,7 +15,7 @@ type LogsAPI struct {
 	mock.Mock
 }
 
-func (l *LogsAPI) DescribeLogGroups(input *cloudwatchlogs.DescribeLogGroupsInput) (*cloudwatchlogs.DescribeLogGroupsOutput, error) {
+func (l *LogsAPI) DescribeLogGroupsWithContext(ctx context.Context, input *cloudwatchlogs.DescribeLogGroupsInput, option ...request.Option) (*cloudwatchlogs.DescribeLogGroupsOutput, error) {
 	args := l.Called(input)
 
 	return args.Get(0).(*cloudwatchlogs.DescribeLogGroupsOutput), args.Error(1)

--- a/pkg/tsdb/cloudwatch/models/api.go
+++ b/pkg/tsdb/cloudwatch/models/api.go
@@ -60,7 +60,7 @@ type CloudWatchMetricsAPIProvider interface {
 }
 
 type CloudWatchLogsAPIProvider interface {
-	DescribeLogGroups(*cloudwatchlogs.DescribeLogGroupsInput) (*cloudwatchlogs.DescribeLogGroupsOutput, error)
+	DescribeLogGroupsWithContext(ctx context.Context, in *cloudwatchlogs.DescribeLogGroupsInput, opts ...request.Option) (*cloudwatchlogs.DescribeLogGroupsOutput, error)
 	GetLogGroupFieldsWithContext(ctx context.Context, in *cloudwatchlogs.GetLogGroupFieldsInput, option ...request.Option) (*cloudwatchlogs.GetLogGroupFieldsOutput, error)
 }
 

--- a/pkg/tsdb/cloudwatch/models/api.go
+++ b/pkg/tsdb/cloudwatch/models/api.go
@@ -37,7 +37,7 @@ type ListMetricsProvider interface {
 }
 
 type LogGroupsProvider interface {
-	GetLogGroups(request resources.LogGroupsRequest) ([]resources.ResourceResponse[resources.LogGroup], error)
+	GetLogGroupsWithContext(ctx context.Context, request resources.LogGroupsRequest) ([]resources.ResourceResponse[resources.LogGroup], error)
 	GetLogGroupFieldsWithContext(ctx context.Context, request resources.LogGroupFieldsRequest, option ...request.Option) ([]resources.ResourceResponse[resources.LogGroupField], error)
 }
 

--- a/pkg/tsdb/cloudwatch/routes/log_groups.go
+++ b/pkg/tsdb/cloudwatch/routes/log_groups.go
@@ -24,7 +24,7 @@ func LogGroupsHandler(ctx context.Context, pluginCtx backend.PluginContext, reqC
 		return nil, models.NewHttpError("newLogGroupsService error", http.StatusInternalServerError, err)
 	}
 
-	logGroups, err := service.GetLogGroups(request)
+	logGroups, err := service.GetLogGroupsWithContext(ctx, request)
 	if err != nil {
 		return nil, models.NewHttpError("GetLogGroups error", http.StatusInternalServerError, err)
 	}

--- a/pkg/tsdb/cloudwatch/routes/log_groups_test.go
+++ b/pkg/tsdb/cloudwatch/routes/log_groups_test.go
@@ -31,7 +31,7 @@ func TestLogGroupsRoute(t *testing.T) {
 
 	t.Run("successfully returns 1 log group with account id", func(t *testing.T) {
 		mockLogsService := mocks.LogsService{}
-		mockLogsService.On("GetLogGroups", mock.Anything).Return([]resources.ResourceResponse[resources.LogGroup]{{
+		mockLogsService.On("GetLogGroupsWithContext", mock.Anything).Return([]resources.ResourceResponse[resources.LogGroup]{{
 			Value: resources.LogGroup{
 				Arn:  "some arn",
 				Name: "some name",
@@ -53,7 +53,7 @@ func TestLogGroupsRoute(t *testing.T) {
 
 	t.Run("successfully returns multiple log groups with account id", func(t *testing.T) {
 		mockLogsService := mocks.LogsService{}
-		mockLogsService.On("GetLogGroups", mock.Anything).Return(
+		mockLogsService.On("GetLogGroupsWithContext", mock.Anything).Return(
 			[]resources.ResourceResponse[resources.LogGroup]{
 				{
 					Value: resources.LogGroup{
@@ -99,7 +99,7 @@ func TestLogGroupsRoute(t *testing.T) {
 
 	t.Run("returns error when both logGroupPrefix and logGroup Pattern are provided", func(t *testing.T) {
 		mockLogsService := mocks.LogsService{}
-		mockLogsService.On("GetLogGroups", mock.Anything).Return([]resources.ResourceResponse[resources.LogGroup]{}, nil)
+		mockLogsService.On("GetLogGroupsWithContext", mock.Anything).Return([]resources.ResourceResponse[resources.LogGroup]{}, nil)
 		newLogGroupsService = func(_ context.Context, pluginCtx backend.PluginContext, reqCtxFactory models.RequestContextFactoryFunc, region string) (models.LogGroupsProvider, error) {
 			return &mockLogsService, nil
 		}
@@ -115,7 +115,7 @@ func TestLogGroupsRoute(t *testing.T) {
 
 	t.Run("passes default log group limit and nil for logGroupNamePrefix, accountId, and logGroupPattern", func(t *testing.T) {
 		mockLogsService := mocks.LogsService{}
-		mockLogsService.On("GetLogGroups", mock.Anything).Return([]resources.ResourceResponse[resources.LogGroup]{}, nil)
+		mockLogsService.On("GetLogGroupsWithContext", mock.Anything).Return([]resources.ResourceResponse[resources.LogGroup]{}, nil)
 		newLogGroupsService = func(_ context.Context, pluginCtx backend.PluginContext, reqCtxFactory models.RequestContextFactoryFunc, region string) (models.LogGroupsProvider, error) {
 			return &mockLogsService, nil
 		}
@@ -125,7 +125,7 @@ func TestLogGroupsRoute(t *testing.T) {
 		handler := http.HandlerFunc(ResourceRequestMiddleware(LogGroupsHandler, logger, reqCtxFunc))
 		handler.ServeHTTP(rr, req)
 
-		mockLogsService.AssertCalled(t, "GetLogGroups", resources.LogGroupsRequest{
+		mockLogsService.AssertCalled(t, "GetLogGroupsWithContext", resources.LogGroupsRequest{
 			Limit:               50,
 			ResourceRequest:     resources.ResourceRequest{},
 			LogGroupNamePrefix:  nil,
@@ -135,7 +135,7 @@ func TestLogGroupsRoute(t *testing.T) {
 
 	t.Run("passes default log group limit and nil for logGroupNamePrefix when both are absent", func(t *testing.T) {
 		mockLogsService := mocks.LogsService{}
-		mockLogsService.On("GetLogGroups", mock.Anything).Return([]resources.ResourceResponse[resources.LogGroup]{}, nil)
+		mockLogsService.On("GetLogGroupsWithContext", mock.Anything).Return([]resources.ResourceResponse[resources.LogGroup]{}, nil)
 		newLogGroupsService = func(_ context.Context, pluginCtx backend.PluginContext, reqCtxFactory models.RequestContextFactoryFunc, region string) (models.LogGroupsProvider, error) {
 			return &mockLogsService, nil
 		}
@@ -145,7 +145,7 @@ func TestLogGroupsRoute(t *testing.T) {
 		handler := http.HandlerFunc(ResourceRequestMiddleware(LogGroupsHandler, logger, reqCtxFunc))
 		handler.ServeHTTP(rr, req)
 
-		mockLogsService.AssertCalled(t, "GetLogGroups", resources.LogGroupsRequest{
+		mockLogsService.AssertCalled(t, "GetLogGroupsWithContext", resources.LogGroupsRequest{
 			Limit:              50,
 			LogGroupNamePrefix: nil,
 		})
@@ -153,7 +153,7 @@ func TestLogGroupsRoute(t *testing.T) {
 
 	t.Run("passes log group limit from query parameter", func(t *testing.T) {
 		mockLogsService := mocks.LogsService{}
-		mockLogsService.On("GetLogGroups", mock.Anything).Return([]resources.ResourceResponse[resources.LogGroup]{}, nil)
+		mockLogsService.On("GetLogGroupsWithContext", mock.Anything).Return([]resources.ResourceResponse[resources.LogGroup]{}, nil)
 		newLogGroupsService = func(_ context.Context, pluginCtx backend.PluginContext, reqCtxFactory models.RequestContextFactoryFunc, region string) (models.LogGroupsProvider, error) {
 			return &mockLogsService, nil
 		}
@@ -163,14 +163,14 @@ func TestLogGroupsRoute(t *testing.T) {
 		handler := http.HandlerFunc(ResourceRequestMiddleware(LogGroupsHandler, logger, reqCtxFunc))
 		handler.ServeHTTP(rr, req)
 
-		mockLogsService.AssertCalled(t, "GetLogGroups", resources.LogGroupsRequest{
+		mockLogsService.AssertCalled(t, "GetLogGroupsWithContext", resources.LogGroupsRequest{
 			Limit: 2,
 		})
 	})
 
 	t.Run("passes logGroupPrefix from query parameter", func(t *testing.T) {
 		mockLogsService := mocks.LogsService{}
-		mockLogsService.On("GetLogGroups", mock.Anything).Return([]resources.ResourceResponse[resources.LogGroup]{}, nil)
+		mockLogsService.On("GetLogGroupsWithContext", mock.Anything).Return([]resources.ResourceResponse[resources.LogGroup]{}, nil)
 		newLogGroupsService = func(_ context.Context, pluginCtx backend.PluginContext, reqCtxFactory models.RequestContextFactoryFunc, region string) (models.LogGroupsProvider, error) {
 			return &mockLogsService, nil
 		}
@@ -180,7 +180,7 @@ func TestLogGroupsRoute(t *testing.T) {
 		handler := http.HandlerFunc(ResourceRequestMiddleware(LogGroupsHandler, logger, reqCtxFunc))
 		handler.ServeHTTP(rr, req)
 
-		mockLogsService.AssertCalled(t, "GetLogGroups", resources.LogGroupsRequest{
+		mockLogsService.AssertCalled(t, "GetLogGroupsWithContext", resources.LogGroupsRequest{
 			Limit:              50,
 			LogGroupNamePrefix: utils.Pointer("some-prefix"),
 		})
@@ -188,7 +188,7 @@ func TestLogGroupsRoute(t *testing.T) {
 
 	t.Run("passes logGroupPattern from query parameter", func(t *testing.T) {
 		mockLogsService := mocks.LogsService{}
-		mockLogsService.On("GetLogGroups", mock.Anything).Return([]resources.ResourceResponse[resources.LogGroup]{}, nil)
+		mockLogsService.On("GetLogGroupsWithContext", mock.Anything).Return([]resources.ResourceResponse[resources.LogGroup]{}, nil)
 		newLogGroupsService = func(_ context.Context, pluginCtx backend.PluginContext, reqCtxFactory models.RequestContextFactoryFunc, region string) (models.LogGroupsProvider, error) {
 			return &mockLogsService, nil
 		}
@@ -198,7 +198,7 @@ func TestLogGroupsRoute(t *testing.T) {
 		handler := http.HandlerFunc(ResourceRequestMiddleware(LogGroupsHandler, logger, reqCtxFunc))
 		handler.ServeHTTP(rr, req)
 
-		mockLogsService.AssertCalled(t, "GetLogGroups", resources.LogGroupsRequest{
+		mockLogsService.AssertCalled(t, "GetLogGroupsWithContext", resources.LogGroupsRequest{
 			Limit:               50,
 			LogGroupNamePattern: utils.Pointer("some-pattern"),
 		})
@@ -206,7 +206,7 @@ func TestLogGroupsRoute(t *testing.T) {
 
 	t.Run("passes logGroupPattern from query parameter", func(t *testing.T) {
 		mockLogsService := mocks.LogsService{}
-		mockLogsService.On("GetLogGroups", mock.Anything).Return([]resources.ResourceResponse[resources.LogGroup]{}, nil)
+		mockLogsService.On("GetLogGroupsWithContext", mock.Anything).Return([]resources.ResourceResponse[resources.LogGroup]{}, nil)
 		newLogGroupsService = func(_ context.Context, pluginCtx backend.PluginContext, reqCtxFactory models.RequestContextFactoryFunc, region string) (models.LogGroupsProvider, error) {
 			return &mockLogsService, nil
 		}
@@ -216,7 +216,7 @@ func TestLogGroupsRoute(t *testing.T) {
 		handler := http.HandlerFunc(ResourceRequestMiddleware(LogGroupsHandler, logger, reqCtxFunc))
 		handler.ServeHTTP(rr, req)
 
-		mockLogsService.AssertCalled(t, "GetLogGroups", resources.LogGroupsRequest{
+		mockLogsService.AssertCalled(t, "GetLogGroupsWithContext", resources.LogGroupsRequest{
 			Limit:           50,
 			ResourceRequest: resources.ResourceRequest{AccountId: utils.Pointer("some-account-id")},
 		})
@@ -224,7 +224,7 @@ func TestLogGroupsRoute(t *testing.T) {
 
 	t.Run("returns error if service returns error", func(t *testing.T) {
 		mockLogsService := mocks.LogsService{}
-		mockLogsService.On("GetLogGroups", mock.Anything).
+		mockLogsService.On("GetLogGroupsWithContext", mock.Anything).
 			Return([]resources.ResourceResponse[resources.LogGroup]{}, fmt.Errorf("some error"))
 		newLogGroupsService = func(_ context.Context, pluginCtx backend.PluginContext, reqCtxFactory models.RequestContextFactoryFunc, region string) (models.LogGroupsProvider, error) {
 			return &mockLogsService, nil

--- a/pkg/tsdb/cloudwatch/services/log_groups.go
+++ b/pkg/tsdb/cloudwatch/services/log_groups.go
@@ -39,7 +39,7 @@ func (s *LogGroupsService) GetLogGroupsWithContext(ctx context.Context, req reso
 	result := []resources.ResourceResponse[resources.LogGroup]{}
 
 	for {
-		response, err := s.logGroupsAPI.DescribeLogGroupsWithContext(context.Background(), input)
+		response, err := s.logGroupsAPI.DescribeLogGroupsWithContext(ctx, input)
 		if err != nil || response == nil {
 			return nil, err
 		}

--- a/pkg/tsdb/cloudwatch/services/log_groups.go
+++ b/pkg/tsdb/cloudwatch/services/log_groups.go
@@ -20,7 +20,7 @@ func NewLogGroupsService(logsClient models.CloudWatchLogsAPIProvider, isCrossAcc
 	return &LogGroupsService{logGroupsAPI: logsClient, isCrossAccountEnabled: isCrossAccountEnabled}
 }
 
-func (s *LogGroupsService) GetLogGroups(req resources.LogGroupsRequest) ([]resources.ResourceResponse[resources.LogGroup], error) {
+func (s *LogGroupsService) GetLogGroupsWithContext(ctx context.Context, req resources.LogGroupsRequest) ([]resources.ResourceResponse[resources.LogGroup], error) {
 	input := &cloudwatchlogs.DescribeLogGroupsInput{
 		Limit:              aws.Int64(req.Limit),
 		LogGroupNamePrefix: req.LogGroupNamePrefix,

--- a/pkg/tsdb/cloudwatch/services/log_groups.go
+++ b/pkg/tsdb/cloudwatch/services/log_groups.go
@@ -39,7 +39,7 @@ func (s *LogGroupsService) GetLogGroups(req resources.LogGroupsRequest) ([]resou
 	result := []resources.ResourceResponse[resources.LogGroup]{}
 
 	for {
-		response, err := s.logGroupsAPI.DescribeLogGroups(input)
+		response, err := s.logGroupsAPI.DescribeLogGroupsWithContext(context.Background(), input)
 		if err != nil || response == nil {
 			return nil, err
 		}

--- a/pkg/tsdb/cloudwatch/services/log_groups_test.go
+++ b/pkg/tsdb/cloudwatch/services/log_groups_test.go
@@ -27,7 +27,7 @@ func TestGetLogGroups(t *testing.T) {
 			}, nil)
 		service := NewLogGroupsService(mockLogsAPI, false)
 
-		resp, err := service.GetLogGroups(resources.LogGroupsRequest{})
+		resp, err := service.GetLogGroupsWithContext(context.Background(), resources.LogGroupsRequest{})
 
 		assert.NoError(t, err)
 		assert.Equal(t, []resources.ResourceResponse[resources.LogGroup]{
@@ -51,7 +51,7 @@ func TestGetLogGroups(t *testing.T) {
 		mockLogsAPI.On("DescribeLogGroupsWithContext", mock.Anything).Return(&cloudwatchlogs.DescribeLogGroupsOutput{}, nil)
 		service := NewLogGroupsService(mockLogsAPI, false)
 
-		resp, err := service.GetLogGroups(resources.LogGroupsRequest{})
+		resp, err := service.GetLogGroupsWithContext(context.Background(), resources.LogGroupsRequest{})
 
 		assert.NoError(t, err)
 		assert.Equal(t, []resources.ResourceResponse[resources.LogGroup]{}, resp)
@@ -63,7 +63,7 @@ func TestGetLogGroups(t *testing.T) {
 		mockLogsAPI.On("DescribeLogGroupsWithContext", mock.Anything).Return(&cloudwatchlogs.DescribeLogGroupsOutput{}, nil)
 		service := NewLogGroupsService(mockLogsAPI, false)
 
-		_, err := service.GetLogGroups(resources.LogGroupsRequest{
+		_, err := service.GetLogGroupsWithContext(context.Background(), resources.LogGroupsRequest{
 			Limit:              0,
 			LogGroupNamePrefix: utils.Pointer("test"),
 		})
@@ -80,7 +80,7 @@ func TestGetLogGroups(t *testing.T) {
 		mockLogsAPI.On("DescribeLogGroupsWithContext", mock.Anything).Return(&cloudwatchlogs.DescribeLogGroupsOutput{}, nil)
 		service := NewLogGroupsService(mockLogsAPI, false)
 
-		_, err := service.GetLogGroups(resources.LogGroupsRequest{})
+		_, err := service.GetLogGroupsWithContext(context.Background(), resources.LogGroupsRequest{})
 
 		assert.NoError(t, err)
 		mockLogsAPI.AssertCalled(t, "DescribeLogGroupsWithContext", &cloudwatchlogs.DescribeLogGroupsInput{
@@ -94,7 +94,7 @@ func TestGetLogGroups(t *testing.T) {
 			fmt.Errorf("some error"))
 		service := NewLogGroupsService(mockLogsAPI, false)
 
-		_, err := service.GetLogGroups(resources.LogGroupsRequest{})
+		_, err := service.GetLogGroupsWithContext(context.Background(), resources.LogGroupsRequest{})
 
 		assert.Error(t, err)
 		assert.Equal(t, "some error", err.Error())
@@ -119,7 +119,7 @@ func TestGetLogGroups(t *testing.T) {
 		}, nil)
 
 		service := NewLogGroupsService(mockLogsAPI, false)
-		resp, err := service.GetLogGroups(req)
+		resp, err := service.GetLogGroupsWithContext(context.Background(), req)
 
 		assert.NoError(t, err)
 		mockLogsAPI.AssertNumberOfCalls(t, "DescribeLogGroupsWithContext", 1)
@@ -161,7 +161,7 @@ func TestGetLogGroups(t *testing.T) {
 			},
 		}, nil)
 		service := NewLogGroupsService(mockLogsAPI, false)
-		resp, err := service.GetLogGroups(req)
+		resp, err := service.GetLogGroupsWithContext(context.Background(), req)
 		assert.NoError(t, err)
 		mockLogsAPI.AssertNumberOfCalls(t, "DescribeLogGroupsWithContext", 2)
 		assert.Equal(t, []resources.ResourceResponse[resources.LogGroup]{
@@ -183,7 +183,7 @@ func TestGetLogGroupsCrossAccountQuerying(t *testing.T) {
 		mockLogsAPI.On("DescribeLogGroupsWithContext", mock.Anything).Return(&cloudwatchlogs.DescribeLogGroupsOutput{}, nil)
 		service := NewLogGroupsService(mockLogsAPI, false)
 
-		_, err := service.GetLogGroups(resources.LogGroupsRequest{
+		_, err := service.GetLogGroupsWithContext(context.Background(), resources.LogGroupsRequest{
 			ResourceRequest:    resources.ResourceRequest{AccountId: utils.Pointer("accountId")},
 			LogGroupNamePrefix: utils.Pointer("prefix"),
 		})
@@ -200,7 +200,7 @@ func TestGetLogGroupsCrossAccountQuerying(t *testing.T) {
 		mockLogsAPI.On("DescribeLogGroupsWithContext", mock.Anything).Return(&cloudwatchlogs.DescribeLogGroupsOutput{}, nil)
 		service := NewLogGroupsService(mockLogsAPI, true)
 
-		_, err := service.GetLogGroups(resources.LogGroupsRequest{
+		_, err := service.GetLogGroupsWithContext(context.Background(), resources.LogGroupsRequest{
 			ResourceRequest:     resources.ResourceRequest{AccountId: utils.Pointer("accountId")},
 			LogGroupNamePrefix:  utils.Pointer("prefix"),
 			LogGroupNamePattern: utils.Pointer("pattern"),
@@ -220,7 +220,7 @@ func TestGetLogGroupsCrossAccountQuerying(t *testing.T) {
 		mockLogsAPI.On("DescribeLogGroupsWithContext", mock.Anything).Return(&cloudwatchlogs.DescribeLogGroupsOutput{}, nil)
 		service := NewLogGroupsService(mockLogsAPI, true)
 
-		_, err := service.GetLogGroups(resources.LogGroupsRequest{
+		_, err := service.GetLogGroupsWithContext(context.Background(), resources.LogGroupsRequest{
 			ResourceRequest: resources.ResourceRequest{AccountId: utils.Pointer("accountId")},
 		})
 
@@ -237,7 +237,7 @@ func TestGetLogGroupsCrossAccountQuerying(t *testing.T) {
 		mockLogsAPI.On("DescribeLogGroupsWithContext", mock.Anything).Return(&cloudwatchlogs.DescribeLogGroupsOutput{}, nil)
 		service := NewLogGroupsService(mockLogsAPI, true)
 
-		_, err := service.GetLogGroups(resources.LogGroupsRequest{
+		_, err := service.GetLogGroupsWithContext(context.Background(), resources.LogGroupsRequest{
 			ResourceRequest:    resources.ResourceRequest{AccountId: utils.Pointer("accountId")},
 			LogGroupNamePrefix: utils.Pointer("prefix"),
 		})
@@ -255,7 +255,7 @@ func TestGetLogGroupsCrossAccountQuerying(t *testing.T) {
 		mockLogsAPI.On("DescribeLogGroupsWithContext", mock.Anything).Return(&cloudwatchlogs.DescribeLogGroupsOutput{}, nil)
 		service := NewLogGroupsService(mockLogsAPI, true)
 
-		_, err := service.GetLogGroups(resources.LogGroupsRequest{
+		_, err := service.GetLogGroupsWithContext(context.Background(), resources.LogGroupsRequest{
 			LogGroupNamePrefix: utils.Pointer("prefix"),
 		})
 
@@ -271,7 +271,7 @@ func TestGetLogGroupsCrossAccountQuerying(t *testing.T) {
 		mockLogsAPI.On("DescribeLogGroupsWithContext", mock.Anything).Return(&cloudwatchlogs.DescribeLogGroupsOutput{}, nil)
 		service := NewLogGroupsService(mockLogsAPI, true)
 
-		_, err := service.GetLogGroups(resources.LogGroupsRequest{
+		_, err := service.GetLogGroupsWithContext(context.Background(), resources.LogGroupsRequest{
 			ResourceRequest: resources.ResourceRequest{
 				AccountId: utils.Pointer("accountId"),
 			},

--- a/pkg/tsdb/cloudwatch/services/log_groups_test.go
+++ b/pkg/tsdb/cloudwatch/services/log_groups_test.go
@@ -17,7 +17,7 @@ import (
 func TestGetLogGroups(t *testing.T) {
 	t.Run("Should map log groups response", func(t *testing.T) {
 		mockLogsAPI := &mocks.LogsAPI{}
-		mockLogsAPI.On("DescribeLogGroups", mock.Anything).Return(
+		mockLogsAPI.On("DescribeLogGroupsWithContext", mock.Anything).Return(
 			&cloudwatchlogs.DescribeLogGroupsOutput{
 				LogGroups: []*cloudwatchlogs.LogGroup{
 					{Arn: utils.Pointer("arn:aws:logs:us-east-1:111:log-group:group_a"), LogGroupName: utils.Pointer("group_a")},
@@ -48,7 +48,7 @@ func TestGetLogGroups(t *testing.T) {
 
 	t.Run("Should return an empty error if api doesn't return any data", func(t *testing.T) {
 		mockLogsAPI := &mocks.LogsAPI{}
-		mockLogsAPI.On("DescribeLogGroups", mock.Anything).Return(&cloudwatchlogs.DescribeLogGroupsOutput{}, nil)
+		mockLogsAPI.On("DescribeLogGroupsWithContext", mock.Anything).Return(&cloudwatchlogs.DescribeLogGroupsOutput{}, nil)
 		service := NewLogGroupsService(mockLogsAPI, false)
 
 		resp, err := service.GetLogGroups(resources.LogGroupsRequest{})
@@ -60,7 +60,7 @@ func TestGetLogGroups(t *testing.T) {
 	t.Run("Should only use LogGroupNamePrefix even if LogGroupNamePattern passed in resource call", func(t *testing.T) {
 		// TODO: use LogGroupNamePattern when we have accounted for its behavior, still a little unexpected at the moment
 		mockLogsAPI := &mocks.LogsAPI{}
-		mockLogsAPI.On("DescribeLogGroups", mock.Anything).Return(&cloudwatchlogs.DescribeLogGroupsOutput{}, nil)
+		mockLogsAPI.On("DescribeLogGroupsWithContext", mock.Anything).Return(&cloudwatchlogs.DescribeLogGroupsOutput{}, nil)
 		service := NewLogGroupsService(mockLogsAPI, false)
 
 		_, err := service.GetLogGroups(resources.LogGroupsRequest{
@@ -69,7 +69,7 @@ func TestGetLogGroups(t *testing.T) {
 		})
 
 		assert.NoError(t, err)
-		mockLogsAPI.AssertCalled(t, "DescribeLogGroups", &cloudwatchlogs.DescribeLogGroupsInput{
+		mockLogsAPI.AssertCalled(t, "DescribeLogGroupsWithContext", &cloudwatchlogs.DescribeLogGroupsInput{
 			Limit:              utils.Pointer(int64(0)),
 			LogGroupNamePrefix: utils.Pointer("test"),
 		})
@@ -77,20 +77,20 @@ func TestGetLogGroups(t *testing.T) {
 
 	t.Run("Should call api without LogGroupNamePrefix nor LogGroupNamePattern if not passed in resource call", func(t *testing.T) {
 		mockLogsAPI := &mocks.LogsAPI{}
-		mockLogsAPI.On("DescribeLogGroups", mock.Anything).Return(&cloudwatchlogs.DescribeLogGroupsOutput{}, nil)
+		mockLogsAPI.On("DescribeLogGroupsWithContext", mock.Anything).Return(&cloudwatchlogs.DescribeLogGroupsOutput{}, nil)
 		service := NewLogGroupsService(mockLogsAPI, false)
 
 		_, err := service.GetLogGroups(resources.LogGroupsRequest{})
 
 		assert.NoError(t, err)
-		mockLogsAPI.AssertCalled(t, "DescribeLogGroups", &cloudwatchlogs.DescribeLogGroupsInput{
+		mockLogsAPI.AssertCalled(t, "DescribeLogGroupsWithContext", &cloudwatchlogs.DescribeLogGroupsInput{
 			Limit: utils.Pointer(int64(0)),
 		})
 	})
 
 	t.Run("Should return an error when API returns error", func(t *testing.T) {
 		mockLogsAPI := &mocks.LogsAPI{}
-		mockLogsAPI.On("DescribeLogGroups", mock.Anything).Return(&cloudwatchlogs.DescribeLogGroupsOutput{},
+		mockLogsAPI.On("DescribeLogGroupsWithContext", mock.Anything).Return(&cloudwatchlogs.DescribeLogGroupsOutput{},
 			fmt.Errorf("some error"))
 		service := NewLogGroupsService(mockLogsAPI, false)
 
@@ -108,7 +108,7 @@ func TestGetLogGroups(t *testing.T) {
 			ListAllLogGroups:   false,
 		}
 
-		mockLogsAPI.On("DescribeLogGroups", &cloudwatchlogs.DescribeLogGroupsInput{
+		mockLogsAPI.On("DescribeLogGroupsWithContext", &cloudwatchlogs.DescribeLogGroupsInput{
 			Limit:              aws.Int64(req.Limit),
 			LogGroupNamePrefix: req.LogGroupNamePrefix,
 		}).Return(&cloudwatchlogs.DescribeLogGroupsOutput{
@@ -122,7 +122,7 @@ func TestGetLogGroups(t *testing.T) {
 		resp, err := service.GetLogGroups(req)
 
 		assert.NoError(t, err)
-		mockLogsAPI.AssertNumberOfCalls(t, "DescribeLogGroups", 1)
+		mockLogsAPI.AssertNumberOfCalls(t, "DescribeLogGroupsWithContext", 1)
 		assert.Equal(t, []resources.ResourceResponse[resources.LogGroup]{
 			{
 				AccountId: utils.Pointer("111"),
@@ -140,7 +140,7 @@ func TestGetLogGroups(t *testing.T) {
 		}
 
 		// first call
-		mockLogsAPI.On("DescribeLogGroups", &cloudwatchlogs.DescribeLogGroupsInput{
+		mockLogsAPI.On("DescribeLogGroupsWithContext", &cloudwatchlogs.DescribeLogGroupsInput{
 			Limit:              aws.Int64(req.Limit),
 			LogGroupNamePrefix: req.LogGroupNamePrefix,
 		}).Return(&cloudwatchlogs.DescribeLogGroupsOutput{
@@ -151,7 +151,7 @@ func TestGetLogGroups(t *testing.T) {
 		}, nil)
 
 		// second call
-		mockLogsAPI.On("DescribeLogGroups", &cloudwatchlogs.DescribeLogGroupsInput{
+		mockLogsAPI.On("DescribeLogGroupsWithContext", &cloudwatchlogs.DescribeLogGroupsInput{
 			Limit:              aws.Int64(req.Limit),
 			LogGroupNamePrefix: req.LogGroupNamePrefix,
 			NextToken:          utils.Pointer("token"),
@@ -163,7 +163,7 @@ func TestGetLogGroups(t *testing.T) {
 		service := NewLogGroupsService(mockLogsAPI, false)
 		resp, err := service.GetLogGroups(req)
 		assert.NoError(t, err)
-		mockLogsAPI.AssertNumberOfCalls(t, "DescribeLogGroups", 2)
+		mockLogsAPI.AssertNumberOfCalls(t, "DescribeLogGroupsWithContext", 2)
 		assert.Equal(t, []resources.ResourceResponse[resources.LogGroup]{
 			{
 				AccountId: utils.Pointer("111"),
@@ -180,7 +180,7 @@ func TestGetLogGroups(t *testing.T) {
 func TestGetLogGroupsCrossAccountQuerying(t *testing.T) {
 	t.Run("Should not includeLinkedAccounts or accountId if isCrossAccountEnabled is set to false", func(t *testing.T) {
 		mockLogsAPI := &mocks.LogsAPI{}
-		mockLogsAPI.On("DescribeLogGroups", mock.Anything).Return(&cloudwatchlogs.DescribeLogGroupsOutput{}, nil)
+		mockLogsAPI.On("DescribeLogGroupsWithContext", mock.Anything).Return(&cloudwatchlogs.DescribeLogGroupsOutput{}, nil)
 		service := NewLogGroupsService(mockLogsAPI, false)
 
 		_, err := service.GetLogGroups(resources.LogGroupsRequest{
@@ -189,7 +189,7 @@ func TestGetLogGroupsCrossAccountQuerying(t *testing.T) {
 		})
 
 		assert.NoError(t, err)
-		mockLogsAPI.AssertCalled(t, "DescribeLogGroups", &cloudwatchlogs.DescribeLogGroupsInput{
+		mockLogsAPI.AssertCalled(t, "DescribeLogGroupsWithContext", &cloudwatchlogs.DescribeLogGroupsInput{
 			Limit:              utils.Pointer(int64(0)),
 			LogGroupNamePrefix: utils.Pointer("prefix"),
 		})
@@ -197,7 +197,7 @@ func TestGetLogGroupsCrossAccountQuerying(t *testing.T) {
 
 	t.Run("Should replace LogGroupNamePrefix if LogGroupNamePattern passed in resource call", func(t *testing.T) {
 		mockLogsAPI := &mocks.LogsAPI{}
-		mockLogsAPI.On("DescribeLogGroups", mock.Anything).Return(&cloudwatchlogs.DescribeLogGroupsOutput{}, nil)
+		mockLogsAPI.On("DescribeLogGroupsWithContext", mock.Anything).Return(&cloudwatchlogs.DescribeLogGroupsOutput{}, nil)
 		service := NewLogGroupsService(mockLogsAPI, true)
 
 		_, err := service.GetLogGroups(resources.LogGroupsRequest{
@@ -207,7 +207,7 @@ func TestGetLogGroupsCrossAccountQuerying(t *testing.T) {
 		})
 
 		assert.NoError(t, err)
-		mockLogsAPI.AssertCalled(t, "DescribeLogGroups", &cloudwatchlogs.DescribeLogGroupsInput{
+		mockLogsAPI.AssertCalled(t, "DescribeLogGroupsWithContext", &cloudwatchlogs.DescribeLogGroupsInput{
 			AccountIdentifiers:    []*string{utils.Pointer("accountId")},
 			Limit:                 utils.Pointer(int64(0)),
 			LogGroupNamePrefix:    utils.Pointer("pattern"),
@@ -217,7 +217,7 @@ func TestGetLogGroupsCrossAccountQuerying(t *testing.T) {
 
 	t.Run("Should includeLinkedAccounts,and accountId if isCrossAccountEnabled is set to true", func(t *testing.T) {
 		mockLogsAPI := &mocks.LogsAPI{}
-		mockLogsAPI.On("DescribeLogGroups", mock.Anything).Return(&cloudwatchlogs.DescribeLogGroupsOutput{}, nil)
+		mockLogsAPI.On("DescribeLogGroupsWithContext", mock.Anything).Return(&cloudwatchlogs.DescribeLogGroupsOutput{}, nil)
 		service := NewLogGroupsService(mockLogsAPI, true)
 
 		_, err := service.GetLogGroups(resources.LogGroupsRequest{
@@ -225,7 +225,7 @@ func TestGetLogGroupsCrossAccountQuerying(t *testing.T) {
 		})
 
 		assert.NoError(t, err)
-		mockLogsAPI.AssertCalled(t, "DescribeLogGroups", &cloudwatchlogs.DescribeLogGroupsInput{
+		mockLogsAPI.AssertCalled(t, "DescribeLogGroupsWithContext", &cloudwatchlogs.DescribeLogGroupsInput{
 			Limit:                 utils.Pointer(int64(0)),
 			IncludeLinkedAccounts: utils.Pointer(true),
 			AccountIdentifiers:    []*string{utils.Pointer("accountId")},
@@ -234,7 +234,7 @@ func TestGetLogGroupsCrossAccountQuerying(t *testing.T) {
 
 	t.Run("Should should not override prefix is there is no logGroupNamePattern", func(t *testing.T) {
 		mockLogsAPI := &mocks.LogsAPI{}
-		mockLogsAPI.On("DescribeLogGroups", mock.Anything).Return(&cloudwatchlogs.DescribeLogGroupsOutput{}, nil)
+		mockLogsAPI.On("DescribeLogGroupsWithContext", mock.Anything).Return(&cloudwatchlogs.DescribeLogGroupsOutput{}, nil)
 		service := NewLogGroupsService(mockLogsAPI, true)
 
 		_, err := service.GetLogGroups(resources.LogGroupsRequest{
@@ -242,7 +242,7 @@ func TestGetLogGroupsCrossAccountQuerying(t *testing.T) {
 			LogGroupNamePrefix: utils.Pointer("prefix"),
 		})
 		assert.NoError(t, err)
-		mockLogsAPI.AssertCalled(t, "DescribeLogGroups", &cloudwatchlogs.DescribeLogGroupsInput{
+		mockLogsAPI.AssertCalled(t, "DescribeLogGroupsWithContext", &cloudwatchlogs.DescribeLogGroupsInput{
 			AccountIdentifiers:    []*string{utils.Pointer("accountId")},
 			Limit:                 utils.Pointer(int64(0)),
 			LogGroupNamePrefix:    utils.Pointer("prefix"),
@@ -252,7 +252,7 @@ func TestGetLogGroupsCrossAccountQuerying(t *testing.T) {
 
 	t.Run("Should not includeLinkedAccounts, or accountId if accountId is nil", func(t *testing.T) {
 		mockLogsAPI := &mocks.LogsAPI{}
-		mockLogsAPI.On("DescribeLogGroups", mock.Anything).Return(&cloudwatchlogs.DescribeLogGroupsOutput{}, nil)
+		mockLogsAPI.On("DescribeLogGroupsWithContext", mock.Anything).Return(&cloudwatchlogs.DescribeLogGroupsOutput{}, nil)
 		service := NewLogGroupsService(mockLogsAPI, true)
 
 		_, err := service.GetLogGroups(resources.LogGroupsRequest{
@@ -260,7 +260,7 @@ func TestGetLogGroupsCrossAccountQuerying(t *testing.T) {
 		})
 
 		assert.NoError(t, err)
-		mockLogsAPI.AssertCalled(t, "DescribeLogGroups", &cloudwatchlogs.DescribeLogGroupsInput{
+		mockLogsAPI.AssertCalled(t, "DescribeLogGroupsWithContext", &cloudwatchlogs.DescribeLogGroupsInput{
 			Limit:              utils.Pointer(int64(0)),
 			LogGroupNamePrefix: utils.Pointer("prefix"),
 		})
@@ -268,7 +268,7 @@ func TestGetLogGroupsCrossAccountQuerying(t *testing.T) {
 
 	t.Run("Should should not override prefix is there is no logGroupNamePattern", func(t *testing.T) {
 		mockLogsAPI := &mocks.LogsAPI{}
-		mockLogsAPI.On("DescribeLogGroups", mock.Anything).Return(&cloudwatchlogs.DescribeLogGroupsOutput{}, nil)
+		mockLogsAPI.On("DescribeLogGroupsWithContext", mock.Anything).Return(&cloudwatchlogs.DescribeLogGroupsOutput{}, nil)
 		service := NewLogGroupsService(mockLogsAPI, true)
 
 		_, err := service.GetLogGroups(resources.LogGroupsRequest{
@@ -279,7 +279,7 @@ func TestGetLogGroupsCrossAccountQuerying(t *testing.T) {
 		})
 
 		assert.NoError(t, err)
-		mockLogsAPI.AssertCalled(t, "DescribeLogGroups", &cloudwatchlogs.DescribeLogGroupsInput{
+		mockLogsAPI.AssertCalled(t, "DescribeLogGroupsWithContext", &cloudwatchlogs.DescribeLogGroupsInput{
 			AccountIdentifiers:    []*string{utils.Pointer("accountId")},
 			IncludeLinkedAccounts: utils.Pointer(true),
 			Limit:                 utils.Pointer(int64(0)),

--- a/pkg/tsdb/cloudwatch/test_utils.go
+++ b/pkg/tsdb/cloudwatch/test_utils.go
@@ -71,14 +71,8 @@ func (m *mockLogsSyncClient) StartQueryWithContext(ctx context.Context, input *c
 	return args.Get(0).(*cloudwatchlogs.StartQueryOutput), args.Error(1)
 }
 
-func (m *fakeCWLogsClient) DescribeLogGroups(input *cloudwatchlogs.DescribeLogGroupsInput) (*cloudwatchlogs.DescribeLogGroupsOutput, error) {
-	m.calls.describeLogGroups = append(m.calls.describeLogGroups, input)
-	output := &m.logGroups[m.logGroupsIndex]
-	m.logGroupsIndex++
-	return output, nil
-}
-
 func (m *fakeCWLogsClient) DescribeLogGroupsWithContext(ctx context.Context, input *cloudwatchlogs.DescribeLogGroupsInput, option ...request.Option) (*cloudwatchlogs.DescribeLogGroupsOutput, error) {
+	m.calls.describeLogGroups = append(m.calls.describeLogGroups, input)
 	output := &m.logGroups[m.logGroupsIndex]
 	m.logGroupsIndex++
 	return output, nil
@@ -207,7 +201,7 @@ func (c fakeCheckHealthClient) ListMetricsPagesWithContext(ctx aws.Context, inpu
 	return nil
 }
 
-func (c fakeCheckHealthClient) DescribeLogGroups(input *cloudwatchlogs.DescribeLogGroupsInput) (*cloudwatchlogs.DescribeLogGroupsOutput, error) {
+func (c fakeCheckHealthClient) DescribeLogGroupsWithContext(ctx context.Context, input *cloudwatchlogs.DescribeLogGroupsInput, option ...request.Option) (*cloudwatchlogs.DescribeLogGroupsOutput, error) {
 	if c.describeLogGroups != nil {
 		return c.describeLogGroups(input)
 	}


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

In the current way, DescribeLogGroups is used which doesn't allow cancelling the request if the context changes. Using DescribeLogGroupsWithContext is the preferred way.

**Why do we need this feature?**

Using context in the go-based application is always the preferred way wherever it is possible to do so. With this change, we are making the application aware of context when it calls DescribeLogGroupsWithContext.

**Who is this feature for?**

Users

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Relates #75498

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
