### PR TITLE
Transformers: Avoid mutating field.values in Concatenate transformation

### DIFF
--- a/packages/grafana-data/src/transformations/transformers/concat.ts
+++ b/packages/grafana-data/src/transformations/transformers/concat.ts
@@ -89,7 +89,7 @@ export function concatenateFields(data: DataFrame[], opts: ConcatenateTransforme
       if (f.values.length === maxLength) {
         return f;
       }
-      const values = f.values;
+      const values = f.values.slice();
       values.length = maxLength;
       return {
         ...f,


### PR DESCRIPTION
this affects panels that re-use query results from another panel as a Dashboard datasource.

here we discovered that a stat panel with a Concatenate transformer was affecting the frames of the TimeSeries panel it was using as a Dashboard datasource. don't ask how long this took to root-cause :sweat_smile:.

there is something similar going on in Explore/Logs, but still not sure if this is caused by the same transformer, a different transformer, or by frame processing/sharing done elsewhere.

<details><summary>test-bars-no-data.json</summary>

```json
{
  "annotations": {
    "list": [
      {
        "builtIn": 1,
        "datasource": {
          "type": "grafana",
          "uid": "-- Grafana --"
        },
        "enable": true,
        "hide": true,
        "iconColor": "rgba(0, 211, 255, 1)",
        "name": "Annotations & Alerts",
        "type": "dashboard"
      }
    ]
  },
  "editable": true,
  "fiscalYearStartMonth": 0,
  "graphTooltip": 0,
  "id": 808,
  "links": [],
  "liveNow": false,
  "panels": [
    {
      "datasource": {
        "type": "grafana-testdata-datasource",
        "uid": "PD8C576611E62080A"
      },
      "fieldConfig": {
        "defaults": {
          "color": {
            "mode": "palette-classic"
          },
          "custom": {
            "axisBorderShow": false,
            "axisCenteredZero": false,
            "axisColorMode": "text",
            "axisLabel": "",
            "axisPlacement": "auto",
            "barAlignment": 0,
            "drawStyle": "bars",
            "fillOpacity": 21,
            "gradientMode": "none",
            "hideFrom": {
              "legend": false,
              "tooltip": false,
              "viz": false
            },
            "insertNulls": false,
            "lineInterpolation": "linear",
            "lineWidth": 1,
            "pointSize": 5,
            "scaleDistribution": {
              "type": "linear"
            },
            "showPoints": "auto",
            "spanNulls": false,
            "stacking": {
              "group": "A",
              "mode": "none"
            },
            "thresholdsStyle": {
              "mode": "off"
            }
          },
          "mappings": [],
          "thresholds": {
            "mode": "absolute",
            "steps": [
              {
                "color": "green",
                "value": null
              },
              {
                "color": "red",
                "value": 80
              }
            ]
          }
        },
        "overrides": []
      },
      "gridPos": {
        "h": 8,
        "w": 12,
        "x": 0,
        "y": 0
      },
      "id": 1,
      "options": {
        "legend": {
          "calcs": [],
          "displayMode": "list",
          "placement": "bottom",
          "showLegend": true
        },
        "tooltip": {
          "mode": "single",
          "sort": "none"
        }
      },
      "targets": [
        {
          "datasource": {
            "type": "grafana-testdata-datasource",
            "uid": "PD8C576611E62080A"
          },
          "rawFrameContent": "[\n  {\n    \"schema\": {\n      \"refId\": \"A\",\n      \"meta\": {\n        \"type\": \"timeseries-multi\"\n      },\n      \"fields\": [\n        {\n          \"name\": \"Time\",\n          \"type\": \"time\",\n          \"typeInfo\": {\n            \"frame\": \"time.Time\"\n          },\n          \"config\": {\n            \"interval\": 10\n          }\n        },\n        {\n          \"name\": \"Value\",\n          \"type\": \"number\",\n          \"labels\": {\n            \"status\": \"cancelled\"\n          },\n          \"config\": {\n            \"displayNameFromDS\": \"cancelled\"\n          }\n        }\n      ]\n    },\n    \"data\": {\n      \"values\": [\n        [\n            1698247459780\n        ],\n        [\n            100\n        ]\n      ]\n    }\n  },\n  {\n    \"schema\": {\n      \"refId\": \"A\",\n      \"meta\": {\n        \"type\": \"timeseries-multi\"\n      },\n      \"fields\": [\n        {\n          \"name\": \"Time\",\n          \"type\": \"time\",\n          \"typeInfo\": {\n            \"frame\": \"time.Time\"\n          },\n          \"config\": {\n            \"interval\": 10\n          }\n        },\n        {\n          \"name\": \"Value\",\n          \"type\": \"number\",\n          \"typeInfo\": {\n            \"frame\": \"float64\"\n          },\n          \"labels\": {\n            \"status\": \"ok\"\n          },\n          \"config\": {\n            \"displayNameFromDS\": \"ok\"\n          }\n        }\n      ]\n    },\n    \"data\": {\n      \"values\": [\n        [\n            1698247459360,\n            1698247459380,\n            1698247459390,\n            1698247459430,\n            1698247459440,\n            1698247459470,\n            1698247459480,\n            1698247459500,\n            1698247459510,\n            1698247459520,\n            1698247459540,\n            1698247459550,\n            1698247459560,\n            1698247459570,\n            1698247459590,\n            1698247459620,\n            1698247459650,\n            1698247459660,\n            1698247459690,\n            1698247459700,\n            1698247459720,\n            1698247459730,\n            1698247459820,\n            1698247459840,\n            1698247459860,\n            1698247459880,\n            1698247459890,\n            1698247459940,\n            1698247459950,\n            1698247460070,\n            1698247460080,\n            1698247460100,\n            1698247460110,\n            1698247460230,\n            1698247460280,\n            1698247460340,\n            1698247460350\n        ],\n        [\n            300,\n            100,\n            200,\n            100,\n            200,\n            200,\n            200,\n            100,\n            400,\n            100,\n            200,\n            200,\n            100,\n            300,\n            200,\n            300,\n            300,\n            100,\n            100,\n            100,\n            200,\n            200,\n            100,\n            100,\n            100,\n            100,\n            100,\n            300,\n            300,\n            100,\n            100,\n            100,\n            100,\n            100,\n            100,\n            100,\n            100\n        ]\n      ]\n    }\n  }\n]",
          "refId": "A",
          "scenarioId": "raw_frame"
        }
      ],
      "title": "Panel Title",
      "type": "timeseries"
    },
    {
      "datasource": {
        "type": "datasource",
        "uid": "-- Dashboard --"
      },
      "fieldConfig": {
        "defaults": {
          "color": {
            "fixedColor": "red",
            "mode": "fixed"
          },
          "mappings": [],
          "thresholds": {
            "mode": "absolute",
            "steps": [
              {
                "color": "green",
                "value": null
              }
            ]
          }
        },
        "overrides": []
      },
      "gridPos": {
        "h": 8,
        "w": 12,
        "x": 0,
        "y": 8
      },
      "id": 2,
      "options": {
        "colorMode": "none",
        "graphMode": "none",
        "justifyMode": "auto",
        "orientation": "auto",
        "reduceOptions": {
          "calcs": [
            "mean"
          ],
          "fields": "",
          "values": false
        },
        "textMode": "auto"
      },
      "pluginVersion": "10.3.0-pre",
      "targets": [
        {
          "datasource": {
            "type": "datasource",
            "uid": "-- Dashboard --"
          },
          "panelId": 1,
          "refId": "A"
        }
      ],
      "title": "Panel Title",
      "transformations": [
        {
          "id": "concatenate",
          "options": {}
        }
      ],
      "type": "stat"
    }
  ],
  "refresh": false,
  "schemaVersion": 38,
  "tags": [],
  "templating": {
    "list": []
  },
  "time": {
    "from": "2023-10-25T15:24:19.365Z",
    "to": "2023-10-25T15:24:20.365Z"
  },
  "timepicker": {},
  "timezone": "",
  "title": "test-bars-no-data",
  "uid": "cb756580-9a3c-413a-9dd1-fff646b5775d",
  "version": 11,
  "weekStart": ""
}
```
</details>

before:

![image](https://github.com/grafana/grafana/assets/43234/0feaa8d6-48fd-4225-aa0e-a9dc4eaae8f1)


after:

![image](https://github.com/grafana/grafana/assets/43234/9516a68d-c443-4eb7-aa31-c13d8d282dc7)
