### PR TITLE
K8s: Share legacy storage configs with etcd based configs

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -123,7 +123,7 @@ require (
 	gopkg.in/mail.v2 v2.3.1 // @grafana/backend-platform
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // @grafana/alerting-squad-backend
-	xorm.io/builder v0.3.6 // indirect; @grafana/backend-platform
+	xorm.io/builder v0.3.6 // @grafana/backend-platform
 	xorm.io/core v0.7.3 // @grafana/backend-platform
 	xorm.io/xorm v0.8.2 // @grafana/alerting-squad-backend
 )
@@ -175,7 +175,7 @@ require (
 	github.com/grpc-ecosystem/go-grpc-prometheus v1.2.1-0.20191002090509-6af20e3a5340 // indirect
 	github.com/hashicorp/errwrap v1.1.0 // indirect
 	github.com/hashicorp/go-msgpack v0.5.5 // indirect
-	github.com/hashicorp/go-multierror v1.1.1 // indirect; @grafana/alerting-squad
+	github.com/hashicorp/go-multierror v1.1.1 // @grafana/alerting-squad
 	github.com/hashicorp/go-sockaddr v1.0.2 // indirect
 	github.com/hashicorp/golang-lru v0.6.0 // indirect
 	github.com/hashicorp/yamux v0.1.1 // indirect

--- a/pkg/apis/playlist/v0alpha1/register.go
+++ b/pkg/apis/playlist/v0alpha1/register.go
@@ -69,36 +69,37 @@ func (b *PlaylistAPIBuilder) GetAPIGroupInfo(
 	storage := map[string]rest.Storage{}
 
 	legacyStore := &legacyStorage{
-		service:    b.service,
-		namespacer: b.namespacer,
-		tableConverter: utils.NewTableConverter(
-			b.gv.WithResource("playlists").GroupResource(),
-			[]metav1.TableColumnDefinition{
-				{Name: "Name", Type: "string", Format: "name"},
-				{Name: "Title", Type: "string", Format: "string", Description: "The playlist name"},
-				{Name: "Interval", Type: "string", Format: "string", Description: "How often the playlist will update"},
-				{Name: "Created At", Type: "date"},
-			},
-			func(obj runtime.Object) ([]interface{}, error) {
-				m, ok := obj.(*Playlist)
-				if !ok {
-					return nil, fmt.Errorf("expected playlist")
-				}
-				return []interface{}{
-					m.Name,
-					m.Spec.Title,
-					m.Spec.Interval,
-					m.CreationTimestamp.UTC().Format(time.RFC3339),
-				}, nil
-			},
-		),
+		service:                   b.service,
+		namespacer:                b.namespacer,
+		DefaultQualifiedResource:  b.gv.WithResource("playlists").GroupResource(),
+		SingularQualifiedResource: b.gv.WithResource("playlist").GroupResource(),
 	}
+	legacyStore.tableConverter = utils.NewTableConverter(
+		legacyStore.DefaultQualifiedResource,
+		[]metav1.TableColumnDefinition{
+			{Name: "Name", Type: "string", Format: "name"},
+			{Name: "Title", Type: "string", Format: "string", Description: "The playlist name"},
+			{Name: "Interval", Type: "string", Format: "string", Description: "How often the playlist will update"},
+			{Name: "Created At", Type: "date"},
+		},
+		func(obj runtime.Object) ([]interface{}, error) {
+			m, ok := obj.(*Playlist)
+			if !ok {
+				return nil, fmt.Errorf("expected playlist")
+			}
+			return []interface{}{
+				m.Name,
+				m.Spec.Title,
+				m.Spec.Interval,
+				m.CreationTimestamp.UTC().Format(time.RFC3339),
+			}, nil
+		},
+	)
 	storage["playlists"] = legacyStore
 
 	// enable dual writes if a RESTOptionsGetter is provided
 	if optsGetter != nil {
-		store, err := newStorage(scheme, optsGetter, b.gv)
-		store.TableConvertor = legacyStore.tableConverter
+		store, err := newStorage(scheme, optsGetter, legacyStore)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/apis/playlist/v0alpha1/storage.go
+++ b/pkg/apis/playlist/v0alpha1/storage.go
@@ -2,7 +2,6 @@ package v0alpha1
 
 import (
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apiserver/pkg/registry/generic"
 	genericregistry "k8s.io/apiserver/pkg/registry/generic/registry"
 
@@ -16,15 +15,16 @@ type storage struct {
 	*genericregistry.Store
 }
 
-func newStorage(scheme *runtime.Scheme, optsGetter generic.RESTOptionsGetter, gv schema.GroupVersion) (*storage, error) {
+func newStorage(scheme *runtime.Scheme, optsGetter generic.RESTOptionsGetter, legacy *legacyStorage) (*storage, error) {
 	strategy := grafanaregistry.NewStrategy(scheme)
 
 	store := &genericregistry.Store{
 		NewFunc:                   func() runtime.Object { return &Playlist{} },
 		NewListFunc:               func() runtime.Object { return &PlaylistList{} },
 		PredicateFunc:             grafanaregistry.Matcher,
-		DefaultQualifiedResource:  gv.WithResource("playlists").GroupResource(),
-		SingularQualifiedResource: gv.WithResource("playlist").GroupResource(),
+		DefaultQualifiedResource:  legacy.DefaultQualifiedResource,
+		SingularQualifiedResource: legacy.SingularQualifiedResource,
+		TableConvertor:            legacy.tableConverter,
 
 		CreateStrategy: strategy,
 		UpdateStrategy: strategy,


### PR DESCRIPTION
The changs in https://github.com/grafana/grafana/pull/77098 broke things when testing with dual write.

This updates the config setup so the common parameters defined in legacyStorage are reused in the new storage.

custom.ini:
```
app_mode = development 

[feature_toggles]
grafanaAPIServer = true
grafanaAPIServerWithExperimentalAPIs = true
kubernetesPlaylists = true

[grafana-apiserver]
etcd_servers = localhost:2379 # enables dual write!
```