### PR TITLE
RadioButtonGroup: Fixes icon alignment

### DIFF
--- a/packages/grafana-ui/src/components/Forms/RadioButtonGroup/RadioButton.tsx
+++ b/packages/grafana-ui/src/components/Forms/RadioButtonGroup/RadioButton.tsx
@@ -108,6 +108,8 @@ const getRadioButtonStyles = stylesFactory((theme: GrafanaTheme2, size: RadioBut
       },
     }),
     radioLabel: css({
+      display: 'flex',
+      alignItems: 'center',
       fontSize,
       height: `${labelHeight}px`,
       // Deduct border from line-height for perfect vertical centering on windows and linux


### PR DESCRIPTION
Noticed this in storybook:
![Screenshot from 2023-10-26 11-17-59](https://github.com/grafana/grafana/assets/10999/121b1f46-e0b5-4998-a454-dbc7dfb5ec23)

Don't think we have notified because I think we don't use the icon + text combo that much.

After:
![Screenshot from 2023-10-26 11-17-17](https://github.com/grafana/grafana/assets/10999/5685c008-edfa-4474-bc47-50007eeb3fb0)
