### PR TITLE
Icon: Restore default fa-spin to spinner in icon

### DIFF
--- a/packages/grafana-ui/src/components/Button/Button.test.tsx
+++ b/packages/grafana-ui/src/components/Button/Button.test.tsx
@@ -1,0 +1,11 @@
+import { render } from '@testing-library/react';
+import React from 'react';
+
+import { Button } from './Button';
+
+describe('Button', () => {
+  it('spins the spinner when specified as an icon', () => {
+    const { container } = render(<Button icon="spinner">Loading...</Button>);
+    expect(container.querySelector('.fa-spin')).toBeInTheDocument();
+  });
+});

--- a/packages/grafana-ui/src/components/Icon/Icon.tsx
+++ b/packages/grafana-ui/src/components/Icon/Icon.tsx
@@ -51,6 +51,13 @@ export const Icon = React.forwardRef<SVGElement, IconProps>(
     const subDir = getIconSubDir(iconName, type);
     const svgPath = `${iconRoot}${subDir}/${iconName}.svg`;
 
+    const composedClassName = cx(
+      styles.icon,
+      className,
+      type === 'mono' ? { [styles.orange]: name === 'favorite' } : '',
+      iconName === 'spinner' && 'fa-spin'
+    );
+
     return (
       <SVG
         innerRef={ref}
@@ -58,7 +65,7 @@ export const Icon = React.forwardRef<SVGElement, IconProps>(
         width={svgWid}
         height={svgHgt}
         title={title}
-        className={cx(styles.icon, className, type === 'mono' ? { [styles.orange]: name === 'favorite' } : '')}
+        className={composedClassName}
         style={style}
         {...rest}
       />


### PR DESCRIPTION
https://github.com/grafana/grafana/pull/76819 Introduced a regression where the the spinner would stop spinning because it removes the `fa-spin` class from automatically being applied in Icon when the icon name is `spinner`.

https://github.com/grafana/grafana/pull/77135 partially resolved this by adding the class in `<Spinner />`. However, this does not resolve it where the `spinner` named icon is used elsewhere, such as with the `icon` prop on `<Button />`.

This PR should address the issue completely by restoring `fa-spin` to `spinner` in Icon unconditionally. Later we will assess whether this is the correct long-term solution.
 
Fixes https://github.com/grafana/grafana/issues/77200
