### PR TITLE
Loki: Add optional stream selector to fetchLabelValues API

### DIFF
--- a/public/app/plugins/datasource/loki/LanguageProvider.test.ts
+++ b/public/app/plugins/datasource/loki/LanguageProvider.test.ts
@@ -233,7 +233,10 @@ describe('Language completion provider', () => {
       const provider = await getLanguageProvider(datasource);
       const requestSpy = jest.spyOn(provider, 'request');
       const labelValues = await provider.fetchLabelValues('testkey');
-      expect(requestSpy).toHaveBeenCalled();
+      expect(requestSpy).toHaveBeenCalledWith('label/testkey/values', {
+        end: 1560163909000,
+        start: 1560153109000,
+      });
       expect(labelValues).toEqual(['label1_val1', 'label1_val2']);
     });
 
@@ -242,7 +245,11 @@ describe('Language completion provider', () => {
       const provider = await getLanguageProvider(datasource);
       const requestSpy = jest.spyOn(provider, 'request');
       const labelValues = await provider.fetchLabelValues('testkey', { streamSelector: '{foo="bar"}' });
-      expect(requestSpy).toHaveBeenCalled();
+      expect(requestSpy).toHaveBeenCalledWith('label/testkey/values', {
+        end: 1560163909000,
+        query: '%7Bfoo%3D%22bar%22%7D',
+        start: 1560153109000,
+      });
       expect(labelValues).toEqual(['label1_val1', 'label1_val2']);
     });
 
@@ -256,6 +263,10 @@ describe('Language completion provider', () => {
 
       const nextLabelValues = await provider.fetchLabelValues('testkey');
       expect(requestSpy).toHaveBeenCalledTimes(1);
+      expect(requestSpy).toHaveBeenCalledWith('label/testkey/values', {
+        end: 1560163909000,
+        start: 1560153109000,
+      });
       expect(nextLabelValues).toEqual(['label1_val1', 'label1_val2']);
     });
 
@@ -265,6 +276,11 @@ describe('Language completion provider', () => {
       const requestSpy = jest.spyOn(provider, 'request');
       const labelValues = await provider.fetchLabelValues('testkey', { streamSelector: '{foo="bar"}' });
       expect(requestSpy).toHaveBeenCalledTimes(1);
+      expect(requestSpy).toHaveBeenCalledWith('label/testkey/values', {
+        end: 1560163909000,
+        query: '%7Bfoo%3D%22bar%22%7D',
+        start: 1560153109000,
+      });
       expect(labelValues).toEqual(['label1_val1', 'label1_val2']);
 
       const nextLabelValues = await provider.fetchLabelValues('testkey', { streamSelector: '{foo="bar"}' });

--- a/public/app/plugins/datasource/loki/docs/app_plugin_developer_documentation.md
+++ b/public/app/plugins/datasource/loki/docs/app_plugin_developer_documentation.md
@@ -58,18 +58,34 @@ The `datasource.languageProvider.fetchLabelValues()` method is designed for fetc
  * It returns a promise that resolves to an array of strings containing the label values.
  *
  * @param labelName - The name of the label for which you want to retrieve values.
+ * @param options - (Optional) An object containing additional options - currently only stream selector.
+ * @param options.streamSelector - (Optional) The stream selector to filter label values. If not provided, all label values are fetched.
+ * @returns A promise containing an array of label values.
  * @returns A promise containing an array of label values.
  * @throws An error if the fetch operation fails.
  */
-async function fetchLabelValues(labelName: string): Promise<string[]>;
+async function fetchLabelValues(labelName: string, options?: { streamSelector?: string }): Promise<string[]>;
 
 /**
- * Example usage:
+ * Example usage without stream selector:
  */
 
 const labelName = 'job';
 try {
   const values = await fetchLabelValues(labelName);
+  console.log(values);
+} catch (error) {
+  console.error(`Error fetching label values: ${error.message}`);
+}
+
+/**
+ * Example usage with stream selector:
+ */
+
+const labelName = 'job';
+const streamSelector = '{app="grafana"}';
+try {
+  const values = await fetchLabelValues(labelName, { streamSelector });
   console.log(values);
 } catch (error) {
   console.error(`Error fetching label values: ${error.message}`);

--- a/public/app/plugins/datasource/loki/docs/app_plugin_developer_documentation.md
+++ b/public/app/plugins/datasource/loki/docs/app_plugin_developer_documentation.md
@@ -61,7 +61,6 @@ The `datasource.languageProvider.fetchLabelValues()` method is designed for fetc
  * @param options - (Optional) An object containing additional options - currently only stream selector.
  * @param options.streamSelector - (Optional) The stream selector to filter label values. If not provided, all label values are fetched.
  * @returns A promise containing an array of label values.
- * @returns A promise containing an array of label values.
  * @throws An error if the fetch operation fails.
  */
 async function fetchLabelValues(labelName: string, options?: { streamSelector?: string }): Promise<string[]>;


### PR DESCRIPTION
In this PR, we are adding optional options to `fetchLabelValues` with possibility to specify `streamSelector`. The API for fetching label values includes options to add `query` which is basically `streamSelector` (I decided to name parameter `streamSelector` cause `query` is vague and we can't include things like parsers or other operations) https://grafana.com/docs/loki/latest/reference/api/#list-label-values-within-a-range-of-time

The reason why we are creating `options` rather than just passing `streamSelector` as second parameter is because in the future we could expand this to other things, such as specifying custom `timeRange` or something else. 

This was requested by @trevorwhitney to help them develop app plugin. 
