### PR TITLE
Bug: fix a typo in dashboard permission logic

### DIFF
--- a/pkg/services/dashboards/service/dashboard_service.go
+++ b/pkg/services/dashboards/service/dashboard_service.go
@@ -482,9 +482,7 @@ func (dr *DashboardServiceImpl) setDefaultPermissions(ctx context.Context, dto *
 
 		if err != nil {
 			dr.log.Error("Could not make user admin", "dashboard", dash.Title, "namespaceID", namespaceID, "userID", userID, "error", err)
-		}
-
-		if err != nil && namespaceID == identity.NamespaceUser && userID > 0 {
+		} else if namespaceID == identity.NamespaceUser && userID > 0 {
 			permissions = append(permissions, accesscontrol.SetResourcePermissionCommand{
 				UserID: userID, Permission: dashboards.PERMISSION_ADMIN.String(),
 			})


### PR DESCRIPTION
**What is this feature?**

Fix an error handling typo introduced in https://github.com/grafana/grafana/pull/77155

We should set user permissions if error **is** nil, not when it's not.
