### PR TITLE
Logs: Deprecated `showContextToggle` in DataSourceWithLogsContextSupport

### DIFF
--- a/packages/grafana-data/src/types/logs.ts
+++ b/packages/grafana-data/src/types/logs.ts
@@ -139,8 +139,8 @@ export interface DataSourceWithLogsContextSupport<TQuery extends DataQuery = Dat
    */
   getLogRowContextQuery?: (row: LogRowModel, options?: LogRowContextOptions, query?: TQuery) => Promise<TQuery | null>;
 
-  /**
-   * This method can be used to show "context" button based on runtime conditions (for example row model data or plugin settings, etc.)
+  /** 
+   * @deprecated Deprecated since 10.3. To display the context option and support the feature implement this interface instead.
    */
   showContextToggle(row?: LogRowModel): boolean;
 
@@ -157,7 +157,7 @@ export const hasLogsContextSupport = (datasource: unknown): datasource is DataSo
     return false;
   }
 
-  return 'getLogRowContext' in datasource && 'showContextToggle' in datasource;
+  return 'getLogRowContext' in datasource;
 };
 
 /**

--- a/packages/grafana-data/src/types/logs.ts
+++ b/packages/grafana-data/src/types/logs.ts
@@ -142,7 +142,7 @@ export interface DataSourceWithLogsContextSupport<TQuery extends DataQuery = Dat
   /** 
    * @deprecated Deprecated since 10.3. To display the context option and support the feature implement this interface instead.
    */
-  showContextToggle(row?: LogRowModel): boolean;
+  showContextToggle?(row?: LogRowModel): boolean;
 
   /**
    * This method can be used to display a custom UI in the context view.

--- a/packages/grafana-data/src/types/logs.ts
+++ b/packages/grafana-data/src/types/logs.ts
@@ -139,7 +139,7 @@ export interface DataSourceWithLogsContextSupport<TQuery extends DataQuery = Dat
    */
   getLogRowContextQuery?: (row: LogRowModel, options?: LogRowContextOptions, query?: TQuery) => Promise<TQuery | null>;
 
-  /** 
+  /**
    * @deprecated Deprecated since 10.3. To display the context option and support the feature implement DataSourceWithLogsContextSupport interface instead.
    */
   showContextToggle?(row?: LogRowModel): boolean;

--- a/packages/grafana-data/src/types/logs.ts
+++ b/packages/grafana-data/src/types/logs.ts
@@ -140,7 +140,7 @@ export interface DataSourceWithLogsContextSupport<TQuery extends DataQuery = Dat
   getLogRowContextQuery?: (row: LogRowModel, options?: LogRowContextOptions, query?: TQuery) => Promise<TQuery | null>;
 
   /** 
-   * @deprecated Deprecated since 10.3. To display the context option and support the feature implement this interface instead.
+   * @deprecated Deprecated since 10.3. To display the context option and support the feature implement DataSourceWithLogsContextSupport interface instead.
    */
   showContextToggle?(row?: LogRowModel): boolean;
 

--- a/public/app/features/explore/Logs/Logs.tsx
+++ b/public/app/features/explore/Logs/Logs.tsx
@@ -84,7 +84,7 @@ interface Props extends Themeable2 {
   logsVolumeData: DataQueryResponse | undefined;
   onSetLogsVolumeEnabled: (enabled: boolean) => void;
   loadLogsVolumeData: () => void;
-  showContextToggle?: (row?: LogRowModel) => boolean;
+  showContextToggle?: (row: LogRowModel) => boolean;
   onChangeTime: (range: AbsoluteTimeRange) => void;
   onClickFilterLabel?: (key: string, value: string, refId?: string) => void;
   onClickFilterOutLabel?: (key: string, value: string, refId?: string) => void;

--- a/public/app/features/explore/Logs/LogsContainer.tsx
+++ b/public/app/features/explore/Logs/LogsContainer.tsx
@@ -206,7 +206,7 @@ class LogsContainer extends PureComponent<LogsContainerProps, LogsContainerState
   };
 
   showContextToggle = (row?: LogRowModel): boolean => {
-    if (!row || !row.dataFrame.refId || !this.state.logContextSupport[row.dataFrame.refId]) {
+    if (!row?.dataFrame.refId || !this.state.logContextSupport[row.dataFrame.refId]) {
       return false;
     }
 

--- a/public/app/features/explore/Logs/LogsContainer.tsx
+++ b/public/app/features/explore/Logs/LogsContainer.tsx
@@ -210,8 +210,7 @@ class LogsContainer extends PureComponent<LogsContainerProps, LogsContainerState
       return false;
     }
 
-    const ds = this.state.logContextSupport[row.dataFrame.refId];
-    return ds.showContextToggle(row);
+    return true;
   };
 
   getFieldLinks = (field: Field, rowIndex: number, dataFrame: DataFrame) => {

--- a/public/app/features/logs/components/LogRow.tsx
+++ b/public/app/features/logs/components/LogRow.tsx
@@ -33,7 +33,7 @@ interface Props extends Themeable2 {
   onClickFilterOutLabel?: (key: string, value: string, refId?: string) => void;
   onContextClick?: () => void;
   getFieldLinks?: (field: Field, rowIndex: number, dataFrame: DataFrame) => Array<LinkModel<Field>>;
-  showContextToggle?: (row?: LogRowModel) => boolean;
+  showContextToggle?: (row: LogRowModel) => boolean;
   onClickShowField?: (key: string) => void;
   onClickHideField?: (key: string) => void;
   onLogRowHover?: (row?: LogRowModel) => void;

--- a/public/app/features/logs/components/LogRowMenuCell.tsx
+++ b/public/app/features/logs/components/LogRowMenuCell.tsx
@@ -8,7 +8,7 @@ import { LogRowStyles } from './getLogRowStyles';
 interface Props {
   logText: string;
   row: LogRowModel;
-  showContextToggle?: (row?: LogRowModel) => boolean;
+  showContextToggle?: (row: LogRowModel) => boolean;
   onOpenContext: (row: LogRowModel) => void;
   onPermalinkClick?: (row: LogRowModel) => Promise<void>;
   onPinLine?: (row: LogRowModel) => void;

--- a/public/app/features/logs/components/LogRowMessage.tsx
+++ b/public/app/features/logs/components/LogRowMessage.tsx
@@ -14,7 +14,7 @@ interface Props {
   wrapLogMessage: boolean;
   prettifyLogMessage: boolean;
   app?: CoreApp;
-  showContextToggle?: (row?: LogRowModel) => boolean;
+  showContextToggle?: (row: LogRowModel) => boolean;
   onOpenContext: (row: LogRowModel) => void;
   onPermalinkClick?: (row: LogRowModel) => Promise<void>;
   onPinLine?: (row: LogRowModel) => void;

--- a/public/app/features/logs/components/LogRowMessageDisplayedFields.tsx
+++ b/public/app/features/logs/components/LogRowMessageDisplayedFields.tsx
@@ -13,7 +13,7 @@ export interface Props {
   wrapLogMessage: boolean;
   getFieldLinks?: (field: Field, rowIndex: number, dataFrame: DataFrame) => Array<LinkModel<Field>>;
   styles: LogRowStyles;
-  showContextToggle?: (row?: LogRowModel) => boolean;
+  showContextToggle?: (row: LogRowModel) => boolean;
   onOpenContext: (row: LogRowModel) => void;
   onPermalinkClick?: (row: LogRowModel) => Promise<void>;
   onPinLine?: (row: LogRowModel) => void;

--- a/public/app/features/logs/components/LogRows.tsx
+++ b/public/app/features/logs/components/LogRows.tsx
@@ -38,7 +38,7 @@ export interface Props extends Themeable2 {
   forceEscape?: boolean;
   displayedFields?: string[];
   app?: CoreApp;
-  showContextToggle?: (row?: LogRowModel) => boolean;
+  showContextToggle?: (row: LogRowModel) => boolean;
   onClickFilterLabel?: (key: string, value: string, refId?: string) => void;
   onClickFilterOutLabel?: (key: string, value: string, refId?: string) => void;
   getFieldLinks?: (field: Field, rowIndex: number, dataFrame: DataFrame) => Array<LinkModel<Field>>;

--- a/public/app/plugins/datasource/cloudwatch/datasource.ts
+++ b/public/app/plugins/datasource/cloudwatch/datasource.ts
@@ -156,10 +156,6 @@ export class CloudWatchDatasource
     );
   }
 
-  showContextToggle() {
-    return true;
-  }
-
   getQueryDisplayText(query: CloudWatchQuery) {
     if (isCloudWatchLogsQuery(query)) {
       return query.expression ?? '';

--- a/public/app/plugins/datasource/elasticsearch/datasource.ts
+++ b/public/app/plugins/datasource/elasticsearch/datasource.ts
@@ -501,10 +501,6 @@ export class ElasticDatasource
     return text;
   }
 
-  showContextToggle(): boolean {
-    return true;
-  }
-
   getLogRowContext = async (row: LogRowModel, options?: LogRowContextOptions): Promise<{ data: DataFrame[] }> => {
     const { enableElasticsearchBackendQuerying } = config.featureToggles;
     if (enableElasticsearchBackendQuerying) {

--- a/public/app/plugins/datasource/loki/datasource.test.ts
+++ b/public/app/plugins/datasource/loki/datasource.test.ts
@@ -1579,14 +1579,6 @@ describe('Variable support', () => {
   });
 });
 
-describe('showContextToggle()', () => {
-  it('always displays logs context', () => {
-    const ds = createLokiDatasource(templateSrvStub);
-
-    expect(ds.showContextToggle()).toBe(true);
-  });
-});
-
 describe('queryHasFilter()', () => {
   let ds: LokiDatasource;
   beforeEach(() => {

--- a/public/app/plugins/datasource/loki/datasource.ts
+++ b/public/app/plugins/datasource/loki/datasource.ts
@@ -868,10 +868,6 @@ export class LokiDatasource
     return annotations;
   }
 
-  showContextToggle(row?: LogRowModel): boolean {
-    return true;
-  }
-
   addAdHocFilters(queryExpr: string) {
     const adhocFilters = this.templateSrv.getAdhocFilters(this.name);
     let expr = replaceVariables(queryExpr);


### PR DESCRIPTION
This function used to control the visibility of the show context button, but that has changed and it was now returning a hardcoded true.

Currently, the method to identify log data sources that support Logs Context is to check if they implement `DataSourceWithLogsContextSupport` through the `hasLogsContextSupport` guard. Without implementing this interface it's impossible to support the feature, thus this is the way data sources indicate if the option should be available or not.

Additionally, made the row argument mandatory, first because it was being sent by the caller (LogRowMessage), but more importantly because it helps to provide support for Logs Context in mixed data sources. See https://github.com/grafana/grafana/pull/76623

## Deprecation notice

Since Grafana 10.3 we're deprecating the `showContextToggle` data source method. To signal support of Logs Context, it is enough to implement the `DataSourceWithLogsContextSupport` interface.


**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/grafana/issues/66819
Related with https://github.com/grafana/grafana/issues/73568 and https://github.com/grafana/grafana/issues/73565

**Special notes for your reviewer:**

There should be no function change with this deprecation.