### PR TITLE
K8s/Authorizer: Move allow from fallback to org_role

### DIFF
--- a/pkg/services/grafana-apiserver/auth/authorizer/org/org_role.go
+++ b/pkg/services/grafana-apiserver/auth/authorizer/org/org_role.go
@@ -4,10 +4,11 @@ import (
 	"context"
 	"fmt"
 
+	"k8s.io/apiserver/pkg/authorization/authorizer"
+
 	"github.com/grafana/grafana/pkg/infra/appcontext"
 	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/services/org"
-	"k8s.io/apiserver/pkg/authorization/authorizer"
 )
 
 var _ authorizer.Authorizer = &OrgIDAuthorizer{}
@@ -28,18 +29,18 @@ func (auth OrgRoleAuthorizer) Authorize(ctx context.Context, a authorizer.Attrib
 
 	switch signedInUser.OrgRole {
 	case org.RoleAdmin:
-		return authorizer.DecisionNoOpinion, "", nil
+		return authorizer.DecisionAllow, "", nil
 	case org.RoleEditor:
 		switch a.GetVerb() {
 		case "get", "list", "watch", "create", "update", "patch", "delete", "put", "post":
-			return authorizer.DecisionNoOpinion, "", nil
+			return authorizer.DecisionAllow, "", nil
 		default:
 			return authorizer.DecisionDeny, errorMessageForGrafanaOrgRole(string(signedInUser.OrgRole), a), nil
 		}
 	case org.RoleViewer:
 		switch a.GetVerb() {
 		case "get", "list", "watch":
-			return authorizer.DecisionNoOpinion, "", nil
+			return authorizer.DecisionAllow, "", nil
 		default:
 			return authorizer.DecisionDeny, errorMessageForGrafanaOrgRole(string(signedInUser.OrgRole), a), nil
 		}

--- a/pkg/services/grafana-apiserver/auth/authorizer/provider.go
+++ b/pkg/services/grafana-apiserver/auth/authorizer/provider.go
@@ -29,6 +29,7 @@ func ProvideAuthorizer(
 	}
 
 	// org role is last -- and will return allow for verbs that match expectations
+	// Ideally FGAC happens earlier and returns an explicit answer
 	authorizers = append(authorizers, orgRoleAuthorizer)
 	return union.New(authorizers...)
 }

--- a/pkg/services/grafana-apiserver/auth/authorizer/provider.go
+++ b/pkg/services/grafana-apiserver/auth/authorizer/provider.go
@@ -28,11 +28,7 @@ func ProvideAuthorizer(
 		authorizers = append(authorizers, orgIDAuthorizer)
 	}
 
-	authorizers = append(authorizers,
-		orgRoleAuthorizer,
-
-		// Add this last so that if nothing says authorizer.DecisionDeny, it will pass
-		authorizerfactory.NewAlwaysAllowAuthorizer(),
-	)
+	// org role is last -- and will return allow for verbs that match expectations
+	authorizers = append(authorizers, orgRoleAuthorizer)
 	return union.New(authorizers...)
 }


### PR DESCRIPTION
After more discussions on https://github.com/grafana/grafana/pull/77218 -- this seems a bit more clear than falling back to allow