### PR TITLE
PluginExtensions: Returns a clone of moment objects in context

### DIFF
--- a/public/app/features/plugins/extensions/utils.test.tsx
+++ b/public/app/features/plugins/extensions/utils.test.tsx
@@ -313,22 +313,14 @@ describe('Plugin Extensions / Utils', () => {
       expect(proxy.a()).toBe('testing');
     });
 
-    it('should return a moment/datetime object as ISO string', () => {
+    it('should return a clone of moment/datetime in context', () => {
+      const source = dateTime('2023-10-26T18:25:01Z');
       const proxy = getReadOnlyProxy({
-        a: dateTime('2023-10-26T18:25:01Z'),
+        a: source,
       });
 
-      expect(proxy.a).toBe('2023-10-26T18:25:01Z');
-    });
-
-    it('should return a moment/datetime object as ISO string', () => {
-      const proxy = getReadOnlyProxy({
-        a: dateTimeParse('2023-10-26T11:52:36', {
-          timeZone: 'MST',
-        }),
-      });
-
-      expect(proxy.a).toBe('2023-10-26T18:52:36Z');
+      expect(source.isSame(proxy.a)).toBe(true);
+      expect(source).not.toBe(proxy.a);
     });
   });
 

--- a/public/app/features/plugins/extensions/utils.test.tsx
+++ b/public/app/features/plugins/extensions/utils.test.tsx
@@ -2,7 +2,7 @@ import { render, screen } from '@testing-library/react';
 import React from 'react';
 import { type Unsubscribable } from 'rxjs';
 
-import { type PluginExtensionLinkConfig, PluginExtensionTypes } from '@grafana/data';
+import { type PluginExtensionLinkConfig, PluginExtensionTypes, dateTime, dateTimeParse } from '@grafana/data';
 import appEvents from 'app/core/app_events';
 import { ShowModalReactEvent } from 'app/types/events';
 
@@ -311,6 +311,24 @@ describe('Plugin Extensions / Utils', () => {
       });
 
       expect(proxy.a()).toBe('testing');
+    });
+
+    it('should return a moment/datetime object as ISO string', () => {
+      const proxy = getReadOnlyProxy({
+        a: dateTime('2023-10-26T18:25:01Z'),
+      });
+
+      expect(proxy.a).toBe('2023-10-26T18:25:01Z');
+    });
+
+    it('should return a moment/datetime object as ISO string', () => {
+      const proxy = getReadOnlyProxy({
+        a: dateTimeParse('2023-10-26T11:52:36', {
+          timeZone: 'MST',
+        }),
+      });
+
+      expect(proxy.a).toBe('2023-10-26T18:52:36Z');
     });
   });
 

--- a/public/app/features/plugins/extensions/utils.test.tsx
+++ b/public/app/features/plugins/extensions/utils.test.tsx
@@ -2,7 +2,7 @@ import { render, screen } from '@testing-library/react';
 import React from 'react';
 import { type Unsubscribable } from 'rxjs';
 
-import { type PluginExtensionLinkConfig, PluginExtensionTypes, dateTime, dateTimeParse } from '@grafana/data';
+import { type PluginExtensionLinkConfig, PluginExtensionTypes, dateTime } from '@grafana/data';
 import appEvents from 'app/core/app_events';
 import { ShowModalReactEvent } from 'app/types/events';
 

--- a/public/app/features/plugins/extensions/utils.tsx
+++ b/public/app/features/plugins/extensions/utils.tsx
@@ -10,7 +10,7 @@ import {
   PluginExtensionTypes,
   type PluginExtensionOpenModalOptions,
   isDateTime,
-  dateTimeFormatISO,
+  dateTime,
 } from '@grafana/data';
 import { Modal } from '@grafana/ui';
 import appEvents from 'app/core/app_events';
@@ -161,10 +161,11 @@ export function getReadOnlyProxy<T extends object>(obj: T): T {
 
       const value = Reflect.get(target, prop, receiver);
 
+      // This will create a clone of the date time object
+      // instead of creating a proxy because the underlying
+      // momentjs object needs to be able to mutate itself.
       if (isDateTime(value)) {
-        return dateTimeFormatISO(value, {
-          timeZone: 'UTC',
-        });
+        return dateTime(value);
       }
 
       if (isObject(value) || isArray(value)) {

--- a/public/app/features/plugins/extensions/utils.tsx
+++ b/public/app/features/plugins/extensions/utils.tsx
@@ -9,6 +9,8 @@ import {
   type PluginExtensionEventHelpers,
   PluginExtensionTypes,
   type PluginExtensionOpenModalOptions,
+  isDateTime,
+  dateTimeFormatISO,
 } from '@grafana/data';
 import { Modal } from '@grafana/ui';
 import appEvents from 'app/core/app_events';
@@ -158,6 +160,12 @@ export function getReadOnlyProxy<T extends object>(obj: T): T {
       }
 
       const value = Reflect.get(target, prop, receiver);
+
+      if (isDateTime(value)) {
+        return dateTimeFormatISO(value, {
+          timeZone: 'UTC',
+        });
+      }
 
       if (isObject(value) || isArray(value)) {
         if (!cache.has(value)) {


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**
It will clone all momentjs objects passed via the context so they can be mutated.

**Why do we need this feature?**

When `momentjs` objects are being shared via the plugin extension context they can't be used as expected. The reason behind this is that we wrap the context with a read only proxy to make it immutable and safe to share across multiple plugins. `momentjs` assume that it can mutate it self and won't work within the read only proxy. 

We are encouraging developers that provides UI extension points to only expose primitive values. But this will function as a safety net for momentjs objects since there is a known issue with those kind of objects. 

**Who is this feature for?**

Plugin developers

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
