### PR TITLE
Chore: track share link options

### DIFF
--- a/public/app/features/dashboard/components/ShareModal/ShareLink.tsx
+++ b/public/app/features/dashboard/components/ShareModal/ShareLink.tsx
@@ -74,7 +74,11 @@ export class ShareLink extends PureComponent<Props, State> {
   };
 
   onCopy() {
-    trackDashboardSharingActionPerType('copy_link', shareDashboardType.link);
+    trackDashboardSharingActionPerType('copy_link', shareDashboardType.link, {
+      currentTimeRange: this.state.useCurrentTimeRange,
+      theme: this.state.selectedTheme,
+      shortenURL: this.state.useShortUrl,
+    });
   }
 
   render() {

--- a/public/app/features/dashboard/components/ShareModal/ShareLink.tsx
+++ b/public/app/features/dashboard/components/ShareModal/ShareLink.tsx
@@ -30,6 +30,7 @@ export class ShareLink extends PureComponent<Props, State> {
       shareUrl: '',
       imageUrl: '',
     };
+    this.onCopy = this.onCopy.bind(this);
   }
 
   componentDidMount() {

--- a/public/app/features/dashboard/components/ShareModal/analytics.ts
+++ b/public/app/features/dashboard/components/ShareModal/analytics.ts
@@ -11,9 +11,14 @@ export function trackDashboardSharingTypeOpen(sharingType: string) {
   reportInteraction(shareAnalyticsEventNames.sharingCategoryClicked, { item: sharingType });
 }
 
-export function trackDashboardSharingActionPerType(action: string, sharingType: string) {
+export function trackDashboardSharingActionPerType(
+  action: string,
+  sharingType: string,
+  options?: Record<string, unknown>
+) {
   reportInteraction(shareAnalyticsEventNames.sharingActionClicked, {
     item: action,
     sharing_category: sharingType,
+    ...options,
   });
 }


### PR DESCRIPTION
**What is this feature?**

Add info about selected values when a user copies a link for sharing

**Why do we need this feature?**

To measure option usage and be able to make decisions about removing any option or changing default values.

**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/grafana/issues/77243

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
