### PR TITLE
Cloudwatch: Add DB_PERF_INSIGHTS to Metric Math

### DIFF
--- a/public/app/plugins/datasource/cloudwatch/language/metric-math/language.ts
+++ b/public/app/plugins/datasource/cloudwatch/language/metric-math/language.ts
@@ -7,6 +7,7 @@ export const METRIC_MATH_FNS = [
   'AVG',
   'CEIL',
   'DATAPOINT_COUNT',
+  'DB_PERF_INSIGHTS',
   'DIFF',
   'DIFF_TIME',
   'FILL',


### PR DESCRIPTION
Add [DB_PERF_INSIGHTS](https://aws.amazon.com/about-aws/whats-new/2023/09/amazon-cloudwatch-metric-math-rds-insights/
https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/using-metric-math.html#metric-math-syntax-functions-list:~:text=%E2%9C%93-,DB_PERF_INSIGHTS,-String%2C%20String%2C%20String) to list of metric math functions for the query editor.

Fixes #75464 

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
