### PR TITLE
K8s: Use client-go to test legacy playlist changes

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -282,7 +282,6 @@ require (
 	k8s.io/component-base v0.27.1 // @grafana/grafana-app-platform-squad
 	k8s.io/klog/v2 v2.90.1 // @grafana/grafana-app-platform-squad
 	k8s.io/kube-openapi v0.0.0-20230501164219-8b0f38b5fd1f // @grafana/grafana-app-platform-squad
-	sigs.k8s.io/yaml v1.3.0 // @grafana/grafana-app-platform-squad
 )
 
 require github.com/grafana/gofpdf v0.0.0-20231002120153-857cc45be447 // @grafana/sharing-squad
@@ -426,6 +425,7 @@ require (
 	sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.1.2 // indirect
 	sigs.k8s.io/json v0.0.0-20221116044647-bc3834ca7abd // indirect
 	sigs.k8s.io/structured-merge-diff/v4 v4.2.3 // indirect
+	sigs.k8s.io/yaml v1.3.0 // indirect
 )
 
 require (

--- a/go.mod
+++ b/go.mod
@@ -282,6 +282,7 @@ require (
 	k8s.io/component-base v0.27.1 // @grafana/grafana-app-platform-squad
 	k8s.io/klog/v2 v2.90.1 // @grafana/grafana-app-platform-squad
 	k8s.io/kube-openapi v0.0.0-20230501164219-8b0f38b5fd1f // @grafana/grafana-app-platform-squad
+	sigs.k8s.io/yaml v1.3.0 // @grafana/grafana-app-platform-squad
 )
 
 require github.com/grafana/gofpdf v0.0.0-20231002120153-857cc45be447 // @grafana/sharing-squad
@@ -289,8 +290,6 @@ require github.com/grafana/gofpdf v0.0.0-20231002120153-857cc45be447 // @grafana
 require github.com/grafana/pyroscope/api v0.2.0 // @grafana/observability-traces-and-profiling
 
 require github.com/apache/arrow/go/v13 v13.0.0 // @grafana/observability-metrics
-
-require sigs.k8s.io/yaml v1.3.0
 
 require (
 	cloud.google.com/go v0.110.8 // indirect

--- a/go.mod
+++ b/go.mod
@@ -290,6 +290,8 @@ require github.com/grafana/pyroscope/api v0.2.0 // @grafana/observability-traces
 
 require github.com/apache/arrow/go/v13 v13.0.0 // @grafana/observability-metrics
 
+require sigs.k8s.io/yaml v1.3.0
+
 require (
 	cloud.google.com/go v0.110.8 // indirect
 	cloud.google.com/go/compute/metadata v0.2.3 // indirect
@@ -425,7 +427,6 @@ require (
 	sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.1.2 // indirect
 	sigs.k8s.io/json v0.0.0-20221116044647-bc3834ca7abd // indirect
 	sigs.k8s.io/structured-merge-diff/v4 v4.2.3 // indirect
-	sigs.k8s.io/yaml v1.3.0 // indirect
 )
 
 require (

--- a/pkg/tests/apis/helper.go
+++ b/pkg/tests/apis/helper.go
@@ -7,14 +7,17 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"os"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	"sigs.k8s.io/yaml"
+	"k8s.io/apimachinery/pkg/runtime/serializer/yaml"
+	yamlutil "k8s.io/apimachinery/pkg/util/yaml"
 
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/rest"
@@ -98,24 +101,10 @@ func (c *K8sTestHelper) GetResourceClient(args ResourceClientArgs) *K8sResourceC
 		args.Namespace = c.namespacer(args.User.Identity.GetOrgID())
 	}
 
-	addr := c.env.Server.HTTPServer.Listener.Addr()
-	baseUrl := fmt.Sprintf("http://%s", addr)
-	login := args.User.Identity.GetLogin()
-	if login != "" && args.User.password != "" {
-		baseUrl = fmt.Sprintf("http://%s:%s@%s", login, args.User.password, addr)
-	}
-
-	config := &rest.Config{
-		Host: baseUrl,
-		//	BearerToken: "example",
-	}
-
-	client, err := dynamic.NewForConfig(config)
-	require.NoError(c.t, err)
 	return &K8sResourceClient{
 		t:        c.t,
 		Args:     args,
-		Resource: client.Resource(args.GVR).Namespace(args.Namespace),
+		Resource: args.User.Client.Resource(args.GVR).Namespace(args.Namespace),
 	}
 }
 
@@ -162,6 +151,7 @@ type OrgUsers struct {
 
 type User struct {
 	Identity identity.Requester
+	Client   *dynamic.DynamicClient
 	password string
 }
 
@@ -295,10 +285,36 @@ func DoRequest[T any](c *K8sTestHelper, params RequestParams, result *T) K8sResp
 			r.Status = s
 			r.Result = nil
 		}
-	} else {
-		_ = yaml.Unmarshal(r.Body, r.Result)
 	}
 	return r
+}
+
+// Read local JSON or YAML file into a resource
+func (c *K8sTestHelper) LoadYAMLOrJSONFile(fpath string) *unstructured.Unstructured {
+	c.t.Helper()
+
+	//nolint:gosec
+	raw, err := os.ReadFile(fpath)
+	require.NoError(c.t, err)
+	require.NotEmpty(c.t, raw)
+	return c.LoadYAMLOrJSON(string(raw))
+}
+
+// Read local JSON or YAML file into a resource
+func (c *K8sTestHelper) LoadYAMLOrJSON(body string) *unstructured.Unstructured {
+	c.t.Helper()
+
+	decoder := yamlutil.NewYAMLOrJSONDecoder(bytes.NewReader([]byte(body)), 100)
+	var rawObj runtime.RawExtension
+	err := decoder.Decode(&rawObj)
+	require.NoError(c.t, err)
+
+	obj, _, err := yaml.NewDecodingSerializer(unstructured.UnstructuredJSONScheme).Decode(rawObj.Raw, nil, nil)
+	require.NoError(c.t, err)
+	unstructuredMap, err := runtime.DefaultUnstructuredConverter.ToUnstructured(obj)
+	require.NoError(c.t, err)
+
+	return &unstructured.Unstructured{Object: unstructuredMap}
 }
 
 func (c K8sTestHelper) createTestUsers(orgId int64) OrgUsers {
@@ -323,6 +339,7 @@ func (c K8sTestHelper) createTestUsers(orgId int64) OrgUsers {
 		supportbundlestest.NewFakeBundleService())
 	require.NoError(c.t, err)
 
+	baseUrl := fmt.Sprintf("http://%s", c.env.Server.HTTPServer.Listener.Addr())
 	createUser := func(key string, role org.RoleType) User {
 		u, err := userSvc.Create(context.Background(), &user.CreateUserCommand{
 			DefaultOrgRole: string(role),
@@ -343,8 +360,19 @@ func (c K8sTestHelper) createTestUsers(orgId int64) OrgUsers {
 		require.NoError(c.t, err)
 		require.Equal(c.t, orgId, s.OrgID)
 		require.Equal(c.t, role, s.OrgRole) // make sure the role was set properly
+
+		config := &rest.Config{
+			Host:     baseUrl,
+			Username: s.Login,
+			Password: key,
+		}
+
+		client, err := dynamic.NewForConfig(config)
+		require.NoError(c.t, err)
+
 		return User{
 			Identity: s,
+			Client:   client,
 			password: key,
 		}
 	}

--- a/pkg/tests/apis/playlist/playlist_test.go
+++ b/pkg/tests/apis/playlist/playlist_test.go
@@ -2,13 +2,15 @@ package playlist
 
 import (
 	"context"
+	"net/http"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
-	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 
+	"github.com/grafana/grafana/pkg/services/playlist"
 	"github.com/grafana/grafana/pkg/tests/apis"
 )
 
@@ -44,7 +46,7 @@ func TestPlaylist(t *testing.T) {
 		require.Equal(t, metav1.StatusReasonForbidden, rsp.Status.Reason)
 	})
 
-	t.Run("Check clients List from different org users", func(t *testing.T) {
+	t.Run("Check k8s client-go List from different org users", func(t *testing.T) {
 		// Check Org1 Viewer
 		client := helper.GetResourceClient(apis.ResourceClientArgs{
 			User:      helper.Org1.Viewer,
@@ -62,8 +64,7 @@ func TestPlaylist(t *testing.T) {
 			GVR:       gvr,
 		})
 		rsp, err = client.Resource.List(context.Background(), metav1.ListOptions{})
-		statusError, ok := err.(*errors.StatusError)
-		require.True(t, ok)
+		statusError := helper.AsStatusError(err)
 		require.Nil(t, rsp)
 		require.Equal(t, metav1.StatusReasonForbidden, statusError.Status().Reason)
 
@@ -74,9 +75,120 @@ func TestPlaylist(t *testing.T) {
 			GVR:       gvr,
 		})
 		rsp, err = client.Resource.List(context.Background(), metav1.ListOptions{})
-		statusError, ok = err.(*errors.StatusError)
-		require.True(t, ok)
+		statusError = helper.AsStatusError(err)
 		require.Nil(t, rsp)
 		require.Equal(t, metav1.StatusReasonForbidden, statusError.Status().Reason)
+	})
+
+	t.Run("Check playlist CRUD in legacy API appears in k8s apis", func(t *testing.T) {
+		client := helper.GetResourceClient(apis.ResourceClientArgs{
+			User: helper.Org1.Editor,
+			GVR:  gvr,
+		})
+
+		// This includes the raw dashboard values that are currently sent (but should not be and are ignored)
+		legacyPayload := `{
+			"name": "Test",
+			"interval": "20s",
+			"items": [
+			  {
+				"type": "dashboard_by_uid",
+				"value": "xCmMwXdVz",
+				"dashboards": [
+				  {
+					"name": "The dashboard",
+					"kind": "dashboard",
+					"uid": "xCmMwXdVz",
+					"url": "/d/xCmMwXdVz/barchart-label-rotation-and-skipping",
+					"tags": ["barchart", "gdev", "graph-ng", "panel-tests"],
+					"location": "d1de6240-fd2e-4e13-99b6-f9d0c6b0550d"
+				  }
+				]
+			  },
+			  {
+				"type": "dashboard_by_tag",
+				"value": "graph-ng",
+				"dashboards": [ "..." ]
+			  }
+			],
+			"uid": ""
+		  }`
+		legacyCreate := apis.DoRequest(helper, apis.RequestParams{
+			User:   client.Args.User,
+			Method: http.MethodPost,
+			Path:   "/api/playlists",
+			Body:   []byte(legacyPayload),
+		}, &playlist.Playlist{})
+		require.NotNil(t, legacyCreate.Result)
+		uid := legacyCreate.Result.UID
+		require.NotEmpty(t, uid)
+
+		expectedResult := `{
+			"apiVersion": "playlist.grafana.app/v0alpha1",
+			"kind": "Playlist",
+			"metadata": {
+			  "creationTimestamp": "${creationTimestamp}",
+			  "name": "` + uid + `",
+			  "namespace": "default",
+			  "resourceVersion": "${resourceVersion}",
+			  "uid": "${uid}"
+			},
+			"spec": {
+			  "title": "Test",
+			  "interval": "20s",
+			  "items": [
+				{
+				  "type": "dashboard_by_uid",
+				  "value": "xCmMwXdVz"
+				},
+				{
+				  "type": "dashboard_by_tag",
+				  "value": "graph-ng"
+				}
+			  ]
+			}
+		  }`
+
+		// List includes the expected result
+		k8sList, err := client.Resource.List(context.Background(), metav1.ListOptions{})
+		require.NoError(t, err)
+		require.Equal(t, 1, len(k8sList.Items))
+		require.JSONEq(t, expectedResult, client.SanitizeJSON(&k8sList.Items[0]))
+
+		// Get should return the same result
+		found, err := client.Resource.Get(context.Background(), uid, metav1.GetOptions{})
+		require.NoError(t, err)
+		require.JSONEq(t, expectedResult, client.SanitizeJSON(found))
+
+		// Now modify the interval
+		updatedInterval := `"interval": "10m"`
+		legacyPayload = strings.Replace(legacyPayload, `"interval": "20s"`, updatedInterval, 1)
+		expectedResult = strings.Replace(expectedResult, `"interval": "20s"`, updatedInterval, 1)
+		dtoResponse := apis.DoRequest(helper, apis.RequestParams{
+			User:   client.Args.User,
+			Method: http.MethodPut,
+			Path:   "/api/playlists/" + uid,
+			Body:   []byte(legacyPayload),
+		}, &playlist.PlaylistDTO{})
+		require.Equal(t, uid, dtoResponse.Result.Uid)
+		require.Equal(t, "10m", dtoResponse.Result.Interval)
+
+		// Make sure the changed interval is now returned from k8s
+		found, err = client.Resource.Get(context.Background(), uid, metav1.GetOptions{})
+		require.NoError(t, err)
+		require.JSONEq(t, expectedResult, client.SanitizeJSON(found))
+
+		// Delete does not return anything
+		_ = apis.DoRequest(helper, apis.RequestParams{
+			User:   client.Args.User,
+			Method: http.MethodDelete,
+			Path:   "/api/playlists/" + uid,
+			Body:   []byte(legacyPayload),
+		}, &playlist.PlaylistDTO{}) // response is empty
+
+		found, err = client.Resource.Get(context.Background(), uid, metav1.GetOptions{})
+		statusError := helper.AsStatusError(err)
+		require.Nil(t, found)
+		require.Equal(t, metav1.StatusReasonNotFound, statusError.Status().Reason)
 	})
 }

--- a/pkg/tests/apis/playlist/playlist_test.go
+++ b/pkg/tests/apis/playlist/playlist_test.go
@@ -1,9 +1,11 @@
 package playlist
 
 import (
+	"context"
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 
@@ -15,31 +17,66 @@ func TestPlaylist(t *testing.T) {
 		t.Skip("skipping integration test")
 	}
 	helper := apis.NewK8sTestHelper(t)
-	helper.SetGroupVersionResource(
-		schema.GroupVersionResource{
-			Group:    "playlist.grafana.app",
-			Version:  "v0alpha1",
-			Resource: "playlists",
-		})
+	gvr := schema.GroupVersionResource{
+		Group:    "playlist.grafana.app",
+		Version:  "v0alpha1",
+		Resource: "playlists",
+	}
 
-	t.Run("Check List from different org users", func(t *testing.T) {
+	t.Run("Check direct List permissions from different org users", func(t *testing.T) {
 		// Check view permissions
-		rsp := helper.List(helper.Org1.Viewer, "default")
+		rsp := helper.List(helper.Org1.Viewer, "default", gvr)
 		require.Equal(t, 200, rsp.Response.StatusCode)
 		require.NotNil(t, rsp.Result)
 		require.Empty(t, rsp.Result.Items)
 		require.Nil(t, rsp.Status)
 
 		// Check view permissions
-		rsp = helper.List(helper.Org2.Viewer, "default")
+		rsp = helper.List(helper.Org2.Viewer, "default", gvr)
 		require.Equal(t, 403, rsp.Response.StatusCode) // Org2 can not see default namespace
 		require.Nil(t, rsp.Result)
 		require.Equal(t, metav1.StatusReasonForbidden, rsp.Status.Reason)
 
 		// Check view permissions
-		rsp = helper.List(helper.Org2.Viewer, "org-22")
+		rsp = helper.List(helper.Org2.Viewer, "org-22", gvr)
 		require.Equal(t, 403, rsp.Response.StatusCode) // Unknown/not a member
 		require.Nil(t, rsp.Result)
 		require.Equal(t, metav1.StatusReasonForbidden, rsp.Status.Reason)
+	})
+
+	t.Run("Check clients List from different org users", func(t *testing.T) {
+		// Check Org1 Viewer
+		client := helper.GetResourceClient(apis.ResourceClientArgs{
+			User:      helper.Org1.Viewer,
+			Namespace: "", // << fills in the value org1 is allowed to see!
+			GVR:       gvr,
+		})
+		rsp, err := client.Resource.List(context.Background(), metav1.ListOptions{})
+		require.NoError(t, err)
+		require.Empty(t, rsp.Items)
+
+		// Check org2 viewer can not see org1 (default namespace)
+		client = helper.GetResourceClient(apis.ResourceClientArgs{
+			User:      helper.Org2.Viewer,
+			Namespace: "default", // actually org1
+			GVR:       gvr,
+		})
+		rsp, err = client.Resource.List(context.Background(), metav1.ListOptions{})
+		statusError, ok := err.(*errors.StatusError)
+		require.True(t, ok)
+		require.Nil(t, rsp)
+		require.Equal(t, metav1.StatusReasonForbidden, statusError.Status().Reason)
+
+		// Check invalid namespace
+		client = helper.GetResourceClient(apis.ResourceClientArgs{
+			User:      helper.Org2.Viewer,
+			Namespace: "org-22", // org 22 does not exist
+			GVR:       gvr,
+		})
+		rsp, err = client.Resource.List(context.Background(), metav1.ListOptions{})
+		statusError, ok = err.(*errors.StatusError)
+		require.True(t, ok)
+		require.Nil(t, rsp)
+		require.Equal(t, metav1.StatusReasonForbidden, statusError.Status().Reason)
 	})
 }

--- a/pkg/tests/apis/types.go
+++ b/pkg/tests/apis/types.go
@@ -1,12 +1,7 @@
 package apis
 
 import (
-	"encoding/json"
-	"os"
-
-	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"sigs.k8s.io/yaml"
 )
 
 type AnyResource struct {
@@ -23,23 +18,4 @@ type AnyResourceList struct {
 	metav1.ListMeta `json:"metadata,omitempty"`
 
 	Items []map[string]any `json:"items,omitempty"`
-}
-
-// Read local JSON or YAML file into a resource
-func (c *K8sTestHelper) LoadAnyResource(fpath string) AnyResource {
-	c.t.Helper()
-
-	//nolint:gosec
-	raw, err := os.ReadFile(fpath)
-	require.NoError(c.t, err)
-	require.NotEmpty(c.t, raw)
-
-	res := &AnyResource{}
-	if json.Valid(raw) {
-		err = json.Unmarshal(raw, res)
-	} else {
-		err = yaml.Unmarshal(raw, res)
-	}
-	require.NoError(c.t, err)
-	return *res
 }


### PR DESCRIPTION
This adds more k8s integration test helpers.

This updates the playlist integration tests so we now:
1. **create** playlist over legacy `/api/playlist` HTTP api
2. check that the result shows up in the new k8s client
3. **update** the the value over legacy `/api/playlist/{uid}` HTTP endpoint
2. check that the result shows up in the new k8s client
3. **delete** the the value over legacy `/api/playlist/{uid}` HTTP endpoint
2. check that the result is not found using the k8s client
