### PR TITLE
Dashboards: Remove dummy trim dashboard api

### DIFF
--- a/docs/sources/setup-grafana/configure-grafana/feature-toggles/index.md
+++ b/docs/sources/setup-grafana/configure-grafana/feature-toggles/index.md
@@ -59,7 +59,6 @@ Some features are enabled by default. You can disable these feature by setting t
 
 | Feature toggle name              | Description                                                                                                                                                                                  |
 | -------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `trimDefaults`                   | Use cue schema to remove values that will be applied automatically                                                                                                                           |
 | `panelTitleSearch`               | Search for dashboards using panel title                                                                                                                                                      |
 | `migrationLocking`               | Lock database during migrations                                                                                                                                                              |
 | `correlations`                   | Correlations page                                                                                                                                                                            |

--- a/packages/grafana-data/src/types/featureToggles.gen.ts
+++ b/packages/grafana-data/src/types/featureToggles.gen.ts
@@ -18,7 +18,6 @@
  * @public
  */
 export interface FeatureToggles {
-  trimDefaults?: boolean;
   disableEnvelopeEncryption?: boolean;
   ['live-service-web-worker']?: boolean;
   queryOverLive?: boolean;

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -471,7 +471,6 @@ func (hs *HTTPServer) registerRoutes() {
 
 			dashboardRoute.Post("/calculate-diff", authorize(ac.EvalPermission(dashboards.ActionDashboardsWrite)), routing.Wrap(hs.CalculateDashboardDiff))
 			dashboardRoute.Post("/validate", authorize(ac.EvalPermission(dashboards.ActionDashboardsWrite)), routing.Wrap(hs.ValidateDashboard))
-			dashboardRoute.Post("/trim", routing.Wrap(hs.TrimDashboard))
 
 			dashboardRoute.Post("/db", authorize(ac.EvalAny(ac.EvalPermission(dashboards.ActionDashboardsCreate), ac.EvalPermission(dashboards.ActionDashboardsWrite))), routing.Wrap(hs.PostDashboard))
 			dashboardRoute.Get("/home", routing.Wrap(hs.GetHomeDashboard))

--- a/pkg/api/dashboard.go
+++ b/pkg/api/dashboard.go
@@ -68,32 +68,6 @@ func dashboardGuardianResponse(err error) response.Response {
 	return response.Error(http.StatusForbidden, "Access denied to this dashboard", nil)
 }
 
-// swagger:route POST /dashboards/trim dashboards trimDashboard
-//
-// Trim defaults from dashboard.
-//
-// Responses:
-// 200: trimDashboardResponse
-// 401: unauthorisedError
-// 500: internalServerError
-func (hs *HTTPServer) TrimDashboard(c *contextmodel.ReqContext) response.Response {
-	cmd := dashboards.TrimDashboardCommand{}
-	if err := web.Bind(c.Req, &cmd); err != nil {
-		return response.Error(http.StatusBadRequest, "bad request data", err)
-	}
-	dash := cmd.Dashboard
-	meta := cmd.Meta
-
-	// TODO temporarily just return the input as a no-op while we convert to thema calls
-	dto := dtos.TrimDashboardFullWithMeta{
-		Dashboard: dash,
-		Meta:      meta,
-	}
-
-	c.TimeRequest(metrics.MApiDashboardGet)
-	return response.JSON(http.StatusOK, dto)
-}
-
 // swagger:route GET /dashboards/uid/{uid} dashboards getDashboardByUID
 //
 // Get dashboard by uid.
@@ -1233,13 +1207,6 @@ type CalcDashboardDiffParams struct {
 	}
 }
 
-// swagger:parameters trimDashboard
-type TrimDashboardParams struct {
-	// in:body
-	// required:true
-	Body dashboards.TrimDashboardCommand
-}
-
 // swagger:response dashboardResponse
 type DashboardResponse struct {
 	// The response message
@@ -1313,12 +1280,6 @@ type PostDashboardResponse struct {
 type CalculateDashboardDiffResponse struct {
 	// in: body
 	Body []byte `json:"body"`
-}
-
-// swagger:response trimDashboardResponse
-type TrimDashboardResponse struct {
-	// in: body
-	Body dtos.TrimDashboardFullWithMeta `json:"body"`
 }
 
 // swagger:response getHomeDashboardResponse

--- a/pkg/api/dtos/dashboard.go
+++ b/pkg/api/dtos/dashboard.go
@@ -51,11 +51,6 @@ type DashboardFullWithMeta struct {
 	Dashboard *simplejson.Json `json:"dashboard"`
 }
 
-type TrimDashboardFullWithMeta struct {
-	Meta      *simplejson.Json `json:"meta"`
-	Dashboard *simplejson.Json `json:"dashboard"`
-}
-
 type DashboardRedirect struct {
 	RedirectUri string `json:"redirectUri"`
 }

--- a/pkg/services/featuremgmt/registry.go
+++ b/pkg/services/featuremgmt/registry.go
@@ -10,12 +10,6 @@ var (
 	// Register each toggle here
 	standardFeatureFlags = []FeatureFlag{
 		{
-			Name:        "trimDefaults",
-			Description: "Use cue schema to remove values that will be applied automatically",
-			Stage:       FeatureStagePublicPreview,
-			Owner:       grafanaAsCodeSquad,
-		},
-		{
 			Name:        "disableEnvelopeEncryption",
 			Description: "Disable envelope encryption (emergency only)",
 			Stage:       FeatureStageGeneralAvailability,

--- a/pkg/services/featuremgmt/toggles_gen.csv
+++ b/pkg/services/featuremgmt/toggles_gen.csv
@@ -1,5 +1,4 @@
 Name,Stage,Owner,requiresDevMode,RequiresLicense,RequiresRestart,FrontendOnly
-trimDefaults,preview,@grafana/grafana-as-code,false,false,false,false
 disableEnvelopeEncryption,GA,@grafana/grafana-as-code,false,false,false,false
 live-service-web-worker,experimental,@grafana/grafana-app-platform-squad,false,false,false,true
 queryOverLive,experimental,@grafana/grafana-app-platform-squad,false,false,false,true

--- a/pkg/services/featuremgmt/toggles_gen.go
+++ b/pkg/services/featuremgmt/toggles_gen.go
@@ -7,10 +7,6 @@
 package featuremgmt
 
 const (
-	// FlagTrimDefaults
-	// Use cue schema to remove values that will be applied automatically
-	FlagTrimDefaults = "trimDefaults"
-
 	// FlagDisableEnvelopeEncryption
 	// Disable envelope encryption (emergency only)
 	FlagDisableEnvelopeEncryption = "disableEnvelopeEncryption"

--- a/pkg/services/featuremgmt/usage_stats_test.go
+++ b/pkg/services/featuremgmt/usage_stats_test.go
@@ -9,7 +9,6 @@ import (
 
 func TestFeatureUsageStats(t *testing.T) {
 	featureManagerWithAllFeatures := WithFeatures(
-		"trimDefaults",
 		"database_metrics",
 		"live-config",
 		"UPPER_SNAKE_CASE",
@@ -17,7 +16,6 @@ func TestFeatureUsageStats(t *testing.T) {
 	)
 
 	require.Equal(t, map[string]any{
-		"stats.features.trim_defaults.count":      1,
 		"stats.features.database_metrics.count":   1,
 		"stats.features.live_config.count":        1,
 		"stats.features.upper_snake_case.count":   1,

--- a/public/api-merged.json
+++ b/public/api-merged.json
@@ -3926,36 +3926,6 @@
         }
       }
     },
-    "/dashboards/trim": {
-      "post": {
-        "tags": [
-          "dashboards"
-        ],
-        "summary": "Trim defaults from dashboard.",
-        "operationId": "trimDashboard",
-        "parameters": [
-          {
-            "name": "Body",
-            "in": "body",
-            "required": true,
-            "schema": {
-              "$ref": "#/definitions/TrimDashboardCommand"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "$ref": "#/responses/trimDashboardResponse"
-          },
-          "401": {
-            "$ref": "#/responses/unauthorisedError"
-          },
-          "500": {
-            "$ref": "#/responses/internalServerError"
-          }
-        }
-      }
-    },
     "/dashboards/uid/{dashboardUid}/public-dashboards": {
       "get": {
         "description": "Get public dashboard by dashboardUid",

--- a/public/app/features/dashboard-scene/sharing/ShareExportTab.tsx
+++ b/public/app/features/dashboard-scene/sharing/ShareExportTab.tsx
@@ -3,7 +3,6 @@ import React from 'react';
 import { useAsync } from 'react-use';
 import AutoSizer from 'react-virtualized-auto-sizer';
 
-import { getBackendSrv } from '@grafana/runtime';
 import { SceneComponentProps, SceneObjectBase, SceneObjectRef } from '@grafana/scenes';
 import { Button, ClipboardButton, CodeEditor, Field, Modal, Switch, VerticalGroup } from '@grafana/ui';
 import { t, Trans } from 'app/core/internationalization';
@@ -78,7 +77,11 @@ export class ShareExportTab extends SceneObjectBase<ShareExportTabState> {
     });
 
     const time = new Date().getTime();
-    saveAs(blob, `${dashboardJson.title}-${time}.json`);
+    let title = 'dashboard';
+    if ('title' in dashboardJson && dashboardJson.title) {
+      title = dashboardJson.title;
+    }
+    saveAs(blob, `${title}-${time}.json`);
     trackDashboardSharingActionPerType('save_export', shareDashboardType.export);
   }
 }

--- a/public/app/features/dashboard-scene/sharing/ShareExportTab.tsx
+++ b/public/app/features/dashboard-scene/sharing/ShareExportTab.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 import { useAsync } from 'react-use';
 import AutoSizer from 'react-virtualized-auto-sizer';
 
-import { config, getBackendSrv } from '@grafana/runtime';
+import { getBackendSrv } from '@grafana/runtime';
 import { SceneComponentProps, SceneObjectBase, SceneObjectRef } from '@grafana/scenes';
 import { Button, ClipboardButton, CodeEditor, Field, Modal, Switch, VerticalGroup } from '@grafana/ui';
 import { t, Trans } from 'app/core/internationalization';
@@ -18,12 +18,10 @@ import { transformSceneToSaveModel } from '../serialization/transformSceneToSave
 import { SceneShareTabState } from './types';
 
 const exportExternallyTranslation = t('share-modal.export.share-externally-label', `Export for sharing externally`);
-const exportDefaultTranslation = t('share-modal.export.share-default-label', `Export with default values removed`);
 
 interface ShareExportTabState extends SceneShareTabState {
   dashboardRef: SceneObjectRef<DashboardScene>;
   isSharingExternally?: boolean;
-  shouldTrimDefaults?: boolean;
   isViewingJSON?: boolean;
 }
 
@@ -35,7 +33,6 @@ export class ShareExportTab extends SceneObjectBase<ShareExportTabState> {
   constructor(state: Omit<ShareExportTabState, 'panelRef'>) {
     super({
       isSharingExternally: false,
-      shouldTrimDefaults: false,
       isViewingJSON: false,
       ...state,
     });
@@ -51,12 +48,6 @@ export class ShareExportTab extends SceneObjectBase<ShareExportTabState> {
     });
   };
 
-  public onTrimDefaultsChange = () => {
-    this.setState({
-      shouldTrimDefaults: !this.state.shouldTrimDefaults,
-    });
-  };
-
   public onViewJSON = () => {
     this.setState({
       isViewingJSON: !this.state.isViewingJSON,
@@ -68,19 +59,14 @@ export class ShareExportTab extends SceneObjectBase<ShareExportTabState> {
   }
 
   public async getExportableDashboardJson() {
-    const { dashboardRef, isSharingExternally, shouldTrimDefaults } = this.state;
+    const { dashboardRef, isSharingExternally } = this.state;
     const saveModel = transformSceneToSaveModel(dashboardRef.resolve());
 
     const exportable = isSharingExternally
       ? await this._exporter.makeExportable(new DashboardModel(saveModel))
       : saveModel;
 
-    if (shouldTrimDefaults) {
-      const trimmed = await getBackendSrv().post('/api/dashboards/trim', { dashboard: exportable });
-      return trimmed.dashboard;
-    } else {
-      return exportable;
-    }
+    return exportable;
   }
 
   public async onSaveAsFile() {
@@ -98,7 +84,7 @@ export class ShareExportTab extends SceneObjectBase<ShareExportTabState> {
 }
 
 function ShareExportTabRenderer({ model }: SceneComponentProps<ShareExportTab>) {
-  const { isSharingExternally, shouldTrimDefaults, isViewingJSON, modalRef } = model.useState();
+  const { isSharingExternally, isViewingJSON, modalRef } = model.useState();
 
   const dashboardJson = useAsync(async () => {
     if (isViewingJSON) {
@@ -124,12 +110,6 @@ function ShareExportTabRenderer({ model }: SceneComponentProps<ShareExportTab>) 
                 onChange={model.onShareExternallyChange}
               />
             </Field>
-
-            {config.featureToggles.trimDefaults && (
-              <Field label={exportDefaultTranslation}>
-                <Switch id="trim-defaults-toggle" value={shouldTrimDefaults} onChange={model.onTrimDefaultsChange} />
-              </Field>
-            )}
           </VerticalGroup>
 
           <Modal.ButtonRow>

--- a/public/app/features/dashboard/components/ShareModal/ShareExport.tsx
+++ b/public/app/features/dashboard/components/ShareModal/ShareExport.tsx
@@ -18,7 +18,6 @@ interface Props extends ShareModalTabProps {}
 
 interface State {
   shareExternally: boolean;
-  trimDefaults: boolean;
 }
 
 export class ShareExport extends PureComponent<Props, State> {
@@ -28,7 +27,6 @@ export class ShareExport extends PureComponent<Props, State> {
     super(props);
     this.state = {
       shareExternally: false,
-      trimDefaults: false,
     };
 
     this.exporter = new DashboardExporter();
@@ -40,69 +38,29 @@ export class ShareExport extends PureComponent<Props, State> {
     });
   };
 
-  onTrimDefaultsChange = () => {
-    this.setState({
-      trimDefaults: !this.state.trimDefaults,
-    });
-  };
-
   onSaveAsFile = () => {
     const { dashboard } = this.props;
     const { shareExternally } = this.state;
-    const { trimDefaults } = this.state;
 
     if (shareExternally) {
       this.exporter.makeExportable(dashboard).then((dashboardJson) => {
-        if (trimDefaults) {
-          getBackendSrv()
-            .post('/api/dashboards/trim', { dashboard: dashboardJson })
-            .then((resp) => {
-              this.openSaveAsDialog(resp.dashboard);
-            });
-        } else {
-          this.openSaveAsDialog(dashboardJson);
-        }
+        this.openSaveAsDialog(dashboardJson);
       });
     } else {
-      if (trimDefaults) {
-        getBackendSrv()
-          .post('/api/dashboards/trim', { dashboard: dashboard.getSaveModelClone() })
-          .then((resp) => {
-            this.openSaveAsDialog(resp.dashboard);
-          });
-      } else {
-        this.openSaveAsDialog(dashboard.getSaveModelClone());
-      }
+      this.openSaveAsDialog(dashboard.getSaveModelClone());
     }
   };
 
   onViewJson = () => {
     const { dashboard } = this.props;
     const { shareExternally } = this.state;
-    const { trimDefaults } = this.state;
 
     if (shareExternally) {
       this.exporter.makeExportable(dashboard).then((dashboardJson) => {
-        if (trimDefaults) {
-          getBackendSrv()
-            .post('/api/dashboards/trim', { dashboard: dashboardJson })
-            .then((resp) => {
-              this.openJsonModal(resp.dashboard);
-            });
-        } else {
-          this.openJsonModal(dashboardJson);
-        }
+        this.openJsonModal(dashboardJson);
       });
     } else {
-      if (trimDefaults) {
-        getBackendSrv()
-          .post('/api/dashboards/trim', { dashboard: dashboard.getSaveModelClone() })
-          .then((resp) => {
-            this.openJsonModal(resp.dashboard);
-          });
-      } else {
-        this.openJsonModal(dashboard.getSaveModelClone());
-      }
+      this.openJsonModal(dashboard.getSaveModelClone());
     }
   };
 
@@ -132,7 +90,6 @@ export class ShareExport extends PureComponent<Props, State> {
   render() {
     const { onDismiss } = this.props;
     const { shareExternally } = this.state;
-    const { trimDefaults } = this.state;
 
     const exportExternallyTranslation = t('share-modal.export.share-externally-label', `Export for sharing externally`);
 
@@ -146,11 +103,6 @@ export class ShareExport extends PureComponent<Props, State> {
         <Field label={exportExternallyTranslation}>
           <Switch id="share-externally-toggle" value={shareExternally} onChange={this.onShareExternallyChange} />
         </Field>
-        {config.featureToggles.trimDefaults && (
-          <Field label={exportDefaultTranslation}>
-            <Switch id="trim-defaults-toggle" value={trimDefaults} onChange={this.onTrimDefaultsChange} />
-          </Field>
-        )}
         <Modal.ButtonRow>
           <Button variant="secondary" onClick={onDismiss} fill="outline">
             <Trans i18nKey="share-modal.export.cancel-button">Cancel</Trans>

--- a/public/app/features/dashboard/components/ShareModal/ShareExport.tsx
+++ b/public/app/features/dashboard/components/ShareModal/ShareExport.tsx
@@ -1,11 +1,9 @@
 import { saveAs } from 'file-saver';
 import React, { PureComponent } from 'react';
 
-import { config } from '@grafana/runtime';
 import { Button, Field, Modal, Switch } from '@grafana/ui';
 import { appEvents } from 'app/core/core';
 import { t, Trans } from 'app/core/internationalization';
-import { getBackendSrv } from 'app/core/services/backend_srv';
 import { DashboardExporter } from 'app/features/dashboard/components/DashExportModal';
 import { ShowModalReactEvent } from 'app/types/events';
 
@@ -92,8 +90,6 @@ export class ShareExport extends PureComponent<Props, State> {
     const { shareExternally } = this.state;
 
     const exportExternallyTranslation = t('share-modal.export.share-externally-label', `Export for sharing externally`);
-
-    const exportDefaultTranslation = t('share-modal.export.share-default-label', `Export with default values removed`);
 
     return (
       <>

--- a/public/locales/de-DE/grafana.json
+++ b/public/locales/de-DE/grafana.json
@@ -1044,7 +1044,6 @@
       "cancel-button": "Abbrechen",
       "info-text": "Dieses Dashboard exportieren.",
       "save-button": "In Datei speichern …",
-      "share-default-label": "Export mit entfernten Standardwerten",
       "share-externally-label": "Export für externe Freigabe",
       "view-button": "JSON anzeigen"
     },

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -1044,7 +1044,6 @@
       "cancel-button": "Cancel",
       "info-text": "Export this dashboard.",
       "save-button": "Save to file",
-      "share-default-label": "Export with default values removed",
       "share-externally-label": "Export for sharing externally",
       "view-button": "View JSON"
     },

--- a/public/locales/es-ES/grafana.json
+++ b/public/locales/es-ES/grafana.json
@@ -1050,7 +1050,6 @@
       "cancel-button": "Cancelar",
       "info-text": "Exporte este panel de control.",
       "save-button": "Guardar en archivo",
-      "share-default-label": "Exportar con los valores predeterminados eliminados",
       "share-externally-label": "Exportar para compartir externamente",
       "view-button": "Ver JSON"
     },

--- a/public/locales/fr-FR/grafana.json
+++ b/public/locales/fr-FR/grafana.json
@@ -1050,7 +1050,6 @@
       "cancel-button": "Annuler",
       "info-text": "Exporter ce tableau de bord.",
       "save-button": "Enregistrer dans un fichier",
-      "share-default-label": "Exporter avec les valeurs par défaut supprimées",
       "share-externally-label": "Exporter pour un partage externe",
       "view-button": "Afficher au format JSON"
     },

--- a/public/locales/pseudo-LOCALE/grafana.json
+++ b/public/locales/pseudo-LOCALE/grafana.json
@@ -1044,7 +1044,6 @@
       "cancel-button": "Cäŉčęľ",
       "info-text": "Ēχpőřŧ ŧĥįş đäşĥþőäřđ.",
       "save-button": "Ŝävę ŧő ƒįľę",
-      "share-default-label": "Ēχpőřŧ ŵįŧĥ đęƒäūľŧ väľūęş řęmővęđ",
       "share-externally-label": "Ēχpőřŧ ƒőř şĥäřįŉģ ęχŧęřŉäľľy",
       "view-button": "Vįęŵ ĴŜØŃ"
     },

--- a/public/locales/zh-Hans/grafana.json
+++ b/public/locales/zh-Hans/grafana.json
@@ -1038,7 +1038,6 @@
       "cancel-button": "取消",
       "info-text": "导出此仪表板。",
       "save-button": "保存至文件",
-      "share-default-label": "导出时清除默认值",
       "share-externally-label": "导出以供外部分享",
       "view-button": "查看 JSON"
     },

--- a/public/openapi3.json
+++ b/public/openapi3.json
@@ -16569,37 +16569,6 @@
         ]
       }
     },
-    "/dashboards/trim": {
-      "post": {
-        "operationId": "trimDashboard",
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/TrimDashboardCommand"
-              }
-            }
-          },
-          "required": true,
-          "x-originalParamName": "Body"
-        },
-        "responses": {
-          "200": {
-            "$ref": "#/components/responses/trimDashboardResponse"
-          },
-          "401": {
-            "$ref": "#/components/responses/unauthorisedError"
-          },
-          "500": {
-            "$ref": "#/components/responses/internalServerError"
-          }
-        },
-        "summary": "Trim defaults from dashboard.",
-        "tags": [
-          "dashboards"
-        ]
-      }
-    },
     "/dashboards/uid/{dashboardUid}/public-dashboards": {
       "get": {
         "description": "Get public dashboard by dashboardUid",


### PR DESCRIPTION
**What is this feature?**

This removes the `/api/dashboards/trim` endpoint -- it currently does not do anything, and does not have a clear path todo anything interesting anytime soon.

This was marked as FeatureStagePublicPreview -- but I think we can just remove it since it never did anything 🤷🏻 

**Why do we need this feature?**

We should reduce the number of unused/unsupported feature toggles.  

**Who is this feature for?**

all grafana developers
