### PR TITLE
Explore: Ensure logs volume data points are in order

### DIFF
--- a/public/app/features/logs/utils.test.ts
+++ b/public/app/features/logs/utils.test.ts
@@ -407,6 +407,33 @@ describe('mergeLogsVolumeDataFrames', () => {
     ]);
     expect(maximum).toBe(6);
   });
+
+  it('produces merged results order by time', () => {
+    const frame1 = mockLogVolume('info', [1600000000001, 1600000000009], [1, 1]);
+    const frame2 = mockLogVolume('info', [1600000000000, 1600000000005], [1, 1]);
+
+    const { dataFrames: merged } = mergeLogsVolumeDataFrames([frame1, frame2]);
+
+    expect(merged).toMatchObject([
+      {
+        fields: [
+          {
+            name: 'Time',
+            type: FieldType.time,
+            values: [1600000000000, 1600000000001, 1600000000005, 1600000000009],
+          },
+          {
+            name: 'Value',
+            type: FieldType.number,
+            values: [1, 1, 1, 1],
+            config: {
+              displayNameFromDS: 'info',
+            },
+          },
+        ],
+      },
+    ]);
+  });
 });
 
 describe('getLogsVolumeDimensions', () => {

--- a/public/app/features/logs/utils.ts
+++ b/public/app/features/logs/utils.ts
@@ -243,13 +243,14 @@ export const mergeLogsVolumeDataFrames = (dataFrames: DataFrame[]): { dataFrames
     levelDataFrame.addField({ name: 'Time', type: FieldType.time, config: timeFieldConfig });
     levelDataFrame.addField({ name: 'Value', type: FieldType.number, config: valueFieldConfig });
 
-    for (const time in aggregated[level]) {
-      const value = aggregated[level][time];
-      levelDataFrame.add({
-        Time: Number(time),
-        Value: value,
+    Object.entries(aggregated[level])
+      .sort((a, b) => Number(a[0]) - Number(b[0]))
+      .forEach(([time, value]) => {
+        levelDataFrame.add({
+          Time: Number(time),
+          Value: value,
+        });
       });
-    }
 
     results.push(levelDataFrame);
   });


### PR DESCRIPTION
When grouping logs volume by level it may happen that data points in aggregated frame are not ordered by timestamp. This happens because we add all data points to a temporary array using timestamp as index `aggregated[level][time] = (aggregated[level][time] || 0) + value;` and later iterate over it with `for (const time in aggregated[level])` to add points to the final data frame. This way there's no guarantee that newly added data points stay in order because:
-  in each data frames they may have non-consecutive order (e.g. `frame 1: [1, 3, 4]`, `frame 2: [2, 5]` 
- and using `for .. in` doesn't guarantee indices are in numerical order at the end.

When data points are not ordered by timestamp, the visualization should show up correctly by it may lead to displaying incorrect "data out of range" message. Showing this message depends on checking the time of the first and last point in the frame. Time series panel requires data points in data frames to be ordered by time to make those checks work properly.

In order to ensure we pass data points in the right order the fix is to sort data frames after aggregation. 

Thanks @Elfo404 for investigating and finding the fix!

The test that was added fails in `main`.

Please check #72507 for reproduction steps.

Fixes #72507