### PR TITLE
IDForwarding: remove dev mode restriction

### DIFF
--- a/docs/sources/setup-grafana/configure-grafana/feature-toggles/index.md
+++ b/docs/sources/setup-grafana/configure-grafana/feature-toggles/index.md
@@ -142,6 +142,7 @@ Experimental features might be changed or removed without prior notice.
 | `externalCorePlugins`                       | Allow core plugins to be loaded as external                                                                                                                                                                                                                                       |
 | `pluginsAPIMetrics`                         | Sends metrics of public grafana packages usage by plugins                                                                                                                                                                                                                         |
 | `httpSLOLevels`                             | Adds SLO level to http request metrics                                                                                                                                                                                                                                            |
+| `idForwarding`                              | Generate signed id token for identity that can be forwarded to plugins and external services                                                                                                                                                                                      |
 | `panelMonitoring`                           | Enables panel monitoring through logs and measurements                                                                                                                                                                                                                            |
 | `enableNativeHTTPHistogram`                 | Enables native HTTP Histograms                                                                                                                                                                                                                                                    |
 | `formatString`                              | Enable format string transformer                                                                                                                                                                                                                                                  |
@@ -161,10 +162,9 @@ Experimental features might be changed or removed without prior notice.
 
 The following toggles require explicitly setting Grafana's [app mode]({{< relref "../_index.md#app_mode" >}}) to 'development' before you can enable this feature toggle. These features tend to be experimental.
 
-| Feature toggle name       | Description                                                                                  |
-| ------------------------- | -------------------------------------------------------------------------------------------- |
-| `entityStore`             | SQL-based entity store (requires storage flag also)                                          |
-| `externalServiceAuth`     | Starts an OAuth2 authentication provider for external services                               |
-| `idForwarding`            | Generate signed id token for identity that can be forwarded to plugins and external services |
-| `externalServiceAccounts` | Automatic service account and token setup for plugins                                        |
-| `panelTitleSearchInV1`    | Enable searching for dashboards using panel title in search v1                               |
+| Feature toggle name       | Description                                                    |
+| ------------------------- | -------------------------------------------------------------- |
+| `entityStore`             | SQL-based entity store (requires storage flag also)            |
+| `externalServiceAuth`     | Starts an OAuth2 authentication provider for external services |
+| `externalServiceAccounts` | Automatic service account and token setup for plugins          |
+| `panelTitleSearchInV1`    | Enable searching for dashboards using panel title in search v1 |

--- a/pkg/services/featuremgmt/registry.go
+++ b/pkg/services/featuremgmt/registry.go
@@ -794,11 +794,10 @@ var (
 			RequiresRestart: true,
 		},
 		{
-			Name:            "idForwarding",
-			Description:     "Generate signed id token for identity that can be forwarded to plugins and external services",
-			Stage:           FeatureStageExperimental,
-			Owner:           grafanaAuthnzSquad,
-			RequiresDevMode: true,
+			Name:        "idForwarding",
+			Description: "Generate signed id token for identity that can be forwarded to plugins and external services",
+			Stage:       FeatureStageExperimental,
+			Owner:       grafanaAuthnzSquad,
 		},
 		{
 			Name:        "cloudWatchWildCardDimensionValues",

--- a/pkg/services/featuremgmt/toggles_gen.csv
+++ b/pkg/services/featuremgmt/toggles_gen.csv
@@ -112,7 +112,7 @@ alertingContactPointsV2,preview,@grafana/alerting-squad,false,false,false,true
 externalCorePlugins,experimental,@grafana/plugins-platform-backend,false,false,false,false
 pluginsAPIMetrics,experimental,@grafana/plugins-platform-backend,false,false,false,true
 httpSLOLevels,experimental,@grafana/hosted-grafana-team,false,false,true,false
-idForwarding,experimental,@grafana/grafana-authnz-team,true,false,false,false
+idForwarding,experimental,@grafana/grafana-authnz-team,false,false,false,false
 cloudWatchWildCardDimensionValues,GA,@grafana/aws-datasources,false,false,false,false
 externalServiceAccounts,experimental,@grafana/grafana-authnz-team,true,false,false,false
 panelMonitoring,experimental,@grafana/dataviz-squad,false,false,false,true


### PR DESCRIPTION
**What is this feature?**
Next week we want to start testing id forwarding in our dev environment so we need to remove the dev mode restriction

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
