### PR TITLE
Prometheus: Don't post-process native heatmap-cells responses

### DIFF
--- a/public/app/plugins/datasource/prometheus/result_transformer.ts
+++ b/public/app/plugins/datasource/prometheus/result_transformer.ts
@@ -58,7 +58,11 @@ const isTableResult = (dataFrame: DataFrame, options: DataQueryRequest<PromQuery
   return target?.format === 'table';
 };
 
-const isHeatmapResult = (dataFrame: DataFrame, options: DataQueryRequest<PromQuery>): boolean => {
+const isCumulativeHeatmapResult = (dataFrame: DataFrame, options: DataQueryRequest<PromQuery>): boolean => {
+  if (dataFrame.meta?.type === DataFrameType.HeatmapCells) {
+    return false;
+  }
+
   const target = options.targets.find((target) => target.refId === dataFrame.refId);
   return target?.format === 'heatmap';
 };
@@ -114,7 +118,7 @@ export function transformV2(
 
   const [heatmapResults, framesWithoutTableHeatmapsAndExemplars] = partition<DataFrame>(
     framesWithoutTableAndExemplars,
-    (df) => isHeatmapResult(df, request)
+    (df) => isCumulativeHeatmapResult(df, request)
   );
 
   // this works around the fact that we only get back frame.name with le buckets when legendFormat == {{le}}...which is not the default


### PR DESCRIPTION
this fixes native histogram responses with Heatmap format selected in the datasource query editor.

without this fix you have to leave it as Time series type to avoid heatmap post-processing. Time series is the default format, but it should not break when switching to Heatmap.

see bottom two panels in:

https://nativehistogram.grafana-dev.net/d/dc5080b6-5d30-40cf-8e97-c0b82100cecb/histogram-demo?query=&orgId=1&var-container=compactor&var-route=All