### PR TITLE
Remove check for ONESHELL support

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -7,16 +7,9 @@ MAKEFLAGS += --no-builtin-rule
 
 include docs.mk
 
-PRECHECK :=
-ifneq ($(filter oneshell,$(.FEATURES)),)
-else
-$(error This Makefile requires GNU Make version 4 or higher)
-endif
-
 .PHONY: sources/panels-visualizations/query-transform-data/transform-data/index.md
 sources/panels-visualizations/query-transform-data/transform-data/index.md: ## Generate the Transform Data page source.
 sources/panels-visualizations/query-transform-data/transform-data/index.md:
-	@$(PRECHECK)
 	cd $(CURDIR)/..
 	npx tsc ./scripts/docs/generate-transformations.ts
 	node ./scripts/docs/generate-transformations.js > $(CURDIR)/$@


### PR DESCRIPTION
It was meant to demonstrate the feature mismatch between in a PR but it was merged as part of other changes and is blocking some users.

Signed-off-by: Jack Baldry <jack.baldry@grafana.com>
