### PR TITLE
Use latest grafana/docs-base image

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -1058,6 +1058,7 @@ steps:
   - cd /hugo && make prod
   image: grafana/docs-base:latest
   name: build-docs-website
+  pull: always
 - commands:
   - '# It is required that code generated from Thema/CUE be committed and in sync
     with its inputs.'
@@ -1412,6 +1413,7 @@ steps:
   - cd /hugo && make prod
   image: grafana/docs-base:latest
   name: build-docs-website
+  pull: always
 - commands:
   - '# It is required that code generated from Thema/CUE be committed and in sync
     with its inputs.'
@@ -4668,6 +4670,6 @@ kind: secret
 name: gcr_credentials
 ---
 kind: signature
-hmac: a45bf36baf7b013438483a8d13e1dc8169a38a65c59a7440d6d1d70b6df12101
+hmac: 64de498d74f13b64f233fe5d37751903a0efb03b3cab28e046797dc80d390965
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -1056,7 +1056,7 @@ steps:
     true\n---\n'' > /hugo/content/docs/grafana/_index.md'
   - cp -r docs/sources/* /hugo/content/docs/grafana/latest/
   - cd /hugo && make prod
-  image: grafana/docs-base:dbd975af06
+  image: grafana/docs-base:latest
   name: build-docs-website
 - commands:
   - '# It is required that code generated from Thema/CUE be committed and in sync
@@ -1410,7 +1410,7 @@ steps:
     true\n---\n'' > /hugo/content/docs/grafana/_index.md'
   - cp -r docs/sources/* /hugo/content/docs/grafana/latest/
   - cd /hugo && make prod
-  image: grafana/docs-base:dbd975af06
+  image: grafana/docs-base:latest
   name: build-docs-website
 - commands:
   - '# It is required that code generated from Thema/CUE be committed and in sync
@@ -4405,7 +4405,7 @@ steps:
   - trivy --exit-code 0 --severity UNKNOWN,LOW,MEDIUM osixia/openldap:1.4.0
   - trivy --exit-code 0 --severity UNKNOWN,LOW,MEDIUM grafana/drone-downstream
   - trivy --exit-code 0 --severity UNKNOWN,LOW,MEDIUM grafana/docker-puppeteer:1.1.0
-  - trivy --exit-code 0 --severity UNKNOWN,LOW,MEDIUM grafana/docs-base:dbd975af06
+  - trivy --exit-code 0 --severity UNKNOWN,LOW,MEDIUM grafana/docs-base:latest
   - trivy --exit-code 0 --severity UNKNOWN,LOW,MEDIUM cypress/included:13.1.0
   - trivy --exit-code 0 --severity UNKNOWN,LOW,MEDIUM jwilder/dockerize:0.6.1
   - trivy --exit-code 0 --severity UNKNOWN,LOW,MEDIUM koalaman/shellcheck:stable
@@ -4439,7 +4439,7 @@ steps:
   - trivy --exit-code 1 --severity HIGH,CRITICAL osixia/openldap:1.4.0
   - trivy --exit-code 1 --severity HIGH,CRITICAL grafana/drone-downstream
   - trivy --exit-code 1 --severity HIGH,CRITICAL grafana/docker-puppeteer:1.1.0
-  - trivy --exit-code 1 --severity HIGH,CRITICAL grafana/docs-base:dbd975af06
+  - trivy --exit-code 1 --severity HIGH,CRITICAL grafana/docs-base:latest
   - trivy --exit-code 1 --severity HIGH,CRITICAL cypress/included:13.1.0
   - trivy --exit-code 1 --severity HIGH,CRITICAL jwilder/dockerize:0.6.1
   - trivy --exit-code 1 --severity HIGH,CRITICAL koalaman/shellcheck:stable
@@ -4668,6 +4668,6 @@ kind: secret
 name: gcr_credentials
 ---
 kind: signature
-hmac: 2a51cf7ded5c749dc6b3664e5cadc6378910e772bf44ea8c80457b5ddb61e3a5
+hmac: a45bf36baf7b013438483a8d13e1dc8169a38a65c59a7440d6d1d70b6df12101
 
 ...

--- a/scripts/drone/steps/lib.star
+++ b/scripts/drone/steps/lib.star
@@ -786,6 +786,7 @@ def build_docs_website_step():
         "name": "build-docs-website",
         # Use latest revision here, since we want to catch if it breaks
         "image": images["docs"],
+        "pull": "always",
         "commands": [
             "mkdir -p /hugo/content/docs/grafana/latest",
             "echo -e '---\\nredirectURL: /docs/grafana/latest/\\ntype: redirect\\nversioned: true\\n---\\n' > /hugo/content/docs/grafana/_index.md",

--- a/scripts/drone/utils/images.star
+++ b/scripts/drone/utils/images.star
@@ -29,7 +29,7 @@ images = {
     "openldap": "osixia/openldap:1.4.0",
     "drone_downstream": "grafana/drone-downstream",
     "docker_puppeteer": "grafana/docker-puppeteer:1.1.0",
-    "docs": "grafana/docs-base:dbd975af06",
+    "docs": "grafana/docs-base:latest",
     "cypress": "cypress/included:13.1.0",
     "dockerize": "jwilder/dockerize:0.6.1",
     "shellcheck": "koalaman/shellcheck:stable",


### PR DESCRIPTION
The pinned tag does not support recent shortcodes like `docs/public-preview`.

Signed-off-by: Jack Baldry <jack.baldry@grafana.com>
