### PR TITLE
Feature Management: Link to grafana.com docs from feature toggle admin page

### DIFF
--- a/pkg/services/navtree/navtreeimpl/admin.go
+++ b/pkg/services/navtree/navtreeimpl/admin.go
@@ -103,7 +103,10 @@ func (s *ServiceImpl) getAdminNode(c *contextmodel.ReqContext) (*navtree.NavLink
 
 	if s.features.IsEnabled(featuremgmt.FlagFeatureToggleAdminPage) && hasAccess(ac.EvalPermission(ac.ActionFeatureManagementRead)) {
 		configNodes = append(configNodes, &navtree.NavLink{
-			Text: "Feature Toggles", SubTitle: "View and edit feature toggles", Id: "feature-toggles", Url: s.cfg.AppSubURL + "/admin/featuretoggles", Icon: "toggle-on",
+			Text: "Feature Toggles",
+			Id:   "feature-toggles",
+			Url:  s.cfg.AppSubURL + "/admin/featuretoggles",
+			Icon: "toggle-on",
 		})
 	}
 

--- a/pkg/services/navtree/navtreeimpl/admin.go
+++ b/pkg/services/navtree/navtreeimpl/admin.go
@@ -103,10 +103,11 @@ func (s *ServiceImpl) getAdminNode(c *contextmodel.ReqContext) (*navtree.NavLink
 
 	if s.features.IsEnabled(featuremgmt.FlagFeatureToggleAdminPage) && hasAccess(ac.EvalPermission(ac.ActionFeatureManagementRead)) {
 		configNodes = append(configNodes, &navtree.NavLink{
-			Text: "Feature Toggles",
-			Id:   "feature-toggles",
-			Url:  s.cfg.AppSubURL + "/admin/featuretoggles",
-			Icon: "toggle-on",
+			Text:     "Feature Toggles",
+			SubTitle: "View and edit feature toggles",
+			Id:       "feature-toggles",
+			Url:      s.cfg.AppSubURL + "/admin/featuretoggles",
+			Icon:     "toggle-on",
 		})
 	}
 

--- a/public/app/features/admin/AdminFeatureTogglesPage.tsx
+++ b/public/app/features/admin/AdminFeatureTogglesPage.tsx
@@ -38,8 +38,22 @@ export default function AdminFeatureTogglesPage() {
     );
   };
 
+  const subTitle = (
+    <div>
+      View and edit feature toggles. Read more about feature toggles at{' '}
+      <a
+        className="external-link"
+        target="_new"
+        href="https://grafana.com/docs/grafana/latest/setup-grafana/configure-grafana/feature-toggles/"
+      >
+        grafana.com
+      </a>
+      .
+    </div>
+  );
+
   return (
-    <Page navId="feature-toggles">
+    <Page navId="feature-toggles" subTitle={subTitle}>
       <Page.Contents>
         <>
           {isError && getErrorMessage()}


### PR DESCRIPTION
**What is this feature?**
Adds a link to the feature toggles page on grafana.com

<img width="1442" alt="image" src="https://github.com/grafana/grafana/assets/41969079/b48f3e1a-f4f2-41a2-98ae-333978777620">

**Why do we need this feature?**

To provide users more information about what feature toggles are and how they work.

**Who is this feature for?**

End users with feature toggle admin page access

**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/grafana/issues/72606
