### PR TITLE
[v10.0.x] Use latest grafana/docs-base image

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -1035,8 +1035,9 @@ steps:
     true\n---\n'' > /hugo/content/docs/grafana/_index.md'
   - cp -r docs/sources/* /hugo/content/docs/grafana/latest/
   - cd /hugo && make prod
-  image: grafana/docs-base:dbd975af06
+  image: grafana/docs-base:latest
   name: build-docs-website
+  pull: always
 - commands:
   - '# It is required that code generated from Thema/CUE be committed and in sync
     with its inputs.'
@@ -1328,8 +1329,9 @@ steps:
     true\n---\n'' > /hugo/content/docs/grafana/_index.md'
   - cp -r docs/sources/* /hugo/content/docs/grafana/latest/
   - cd /hugo && make prod
-  image: grafana/docs-base:dbd975af06
+  image: grafana/docs-base:latest
   name: build-docs-website
+  pull: always
 - commands:
   - '# It is required that code generated from Thema/CUE be committed and in sync
     with its inputs.'
@@ -4311,7 +4313,7 @@ steps:
   - trivy --exit-code 0 --severity UNKNOWN,LOW,MEDIUM osixia/openldap:1.4.0
   - trivy --exit-code 0 --severity UNKNOWN,LOW,MEDIUM grafana/drone-downstream
   - trivy --exit-code 0 --severity UNKNOWN,LOW,MEDIUM grafana/docker-puppeteer:1.1.0
-  - trivy --exit-code 0 --severity UNKNOWN,LOW,MEDIUM grafana/docs-base:dbd975af06
+  - trivy --exit-code 0 --severity UNKNOWN,LOW,MEDIUM grafana/docs-base:latest
   - trivy --exit-code 0 --severity UNKNOWN,LOW,MEDIUM cypress/included:9.5.1-node16.14.0-slim-chrome99-ff97
   - trivy --exit-code 0 --severity UNKNOWN,LOW,MEDIUM jwilder/dockerize:0.6.1
   - trivy --exit-code 0 --severity UNKNOWN,LOW,MEDIUM koalaman/shellcheck:stable
@@ -4345,7 +4347,7 @@ steps:
   - trivy --exit-code 1 --severity HIGH,CRITICAL osixia/openldap:1.4.0
   - trivy --exit-code 1 --severity HIGH,CRITICAL grafana/drone-downstream
   - trivy --exit-code 1 --severity HIGH,CRITICAL grafana/docker-puppeteer:1.1.0
-  - trivy --exit-code 1 --severity HIGH,CRITICAL grafana/docs-base:dbd975af06
+  - trivy --exit-code 1 --severity HIGH,CRITICAL grafana/docs-base:latest
   - trivy --exit-code 1 --severity HIGH,CRITICAL cypress/included:9.5.1-node16.14.0-slim-chrome99-ff97
   - trivy --exit-code 1 --severity HIGH,CRITICAL jwilder/dockerize:0.6.1
   - trivy --exit-code 1 --severity HIGH,CRITICAL koalaman/shellcheck:stable
@@ -4574,6 +4576,6 @@ kind: secret
 name: gcr_credentials
 ---
 kind: signature
-hmac: bd4667bdf07e27acd72af16f7c115137248fa3acbf414d3f055123d461f236bf
+hmac: 7e86b9bd381466f8e40c464789bf6742bb014255aa8650658985dd414b724f91
 
 ...

--- a/scripts/drone/steps/lib.star
+++ b/scripts/drone/steps/lib.star
@@ -786,6 +786,7 @@ def build_docs_website_step():
         "name": "build-docs-website",
         # Use latest revision here, since we want to catch if it breaks
         "image": images["docs"],
+        "pull": "always",
         "commands": [
             "mkdir -p /hugo/content/docs/grafana/latest",
             "echo -e '---\\nredirectURL: /docs/grafana/latest/\\ntype: redirect\\nversioned: true\\n---\\n' > /hugo/content/docs/grafana/_index.md",

--- a/scripts/drone/utils/images.star
+++ b/scripts/drone/utils/images.star
@@ -29,7 +29,7 @@ images = {
     "openldap": "osixia/openldap:1.4.0",
     "drone_downstream": "grafana/drone-downstream",
     "docker_puppeteer": "grafana/docker-puppeteer:1.1.0",
-    "docs": "grafana/docs-base:dbd975af06",
+    "docs": "grafana/docs-base:latest",
     "cypress": "cypress/included:9.5.1-node16.14.0-slim-chrome99-ff97",
     "dockerize": "jwilder/dockerize:0.6.1",
     "shellcheck": "koalaman/shellcheck:stable",


### PR DESCRIPTION
Backport d8d7a40d13f1a5741561fae71d8deed70dba369b from #77299

---

The pinned tag does not support recent shortcodes like `docs/public-preview`.

Signed-off-by: Jack Baldry <jack.baldry@grafana.com>
