### PR TITLE
<Dashboard>: Use plurals for time values greater than 1.0

### DIFF
--- a/packages/grafana-data/src/valueFormats/dateTimeFormatters.ts
+++ b/packages/grafana-data/src/valueFormats/dateTimeFormatters.ts
@@ -56,11 +56,11 @@ export function toNanoSeconds(size: number, decimals?: DecimalCount): FormattedV
   } else if (Math.abs(size) < 60000000000) {
     return toFixedScaled(size / 1000000000, decimals, ' s');
   } else if (Math.abs(size) < 3600000000000) {
-    return toFixedScaled(size / 60000000000, decimals, ' min');
+    return toFixedScaled(size / 60000000000, decimals, size === 1 ? ' min' : ' mins');
   } else if (Math.abs(size) < 86400000000000) {
-    return toFixedScaled(size / 3600000000000, decimals, ' hour');
+    return toFixedScaled(size / 3600000000000, decimals, size === 1 ? ' hour' : ' hours');
   } else {
-    return toFixedScaled(size / 86400000000000, decimals, ' day');
+    return toFixedScaled(size / 86400000000000, decimals, size === 1 ? ' day' : ' days');
   }
 }
 
@@ -90,16 +90,16 @@ export function toMilliSeconds(size: number, decimals?: DecimalCount, scaledDeci
     return toFixedScaled(size / 1000, decimals, ' s');
   } else if (Math.abs(size) < 3600000) {
     // Less than 1 hour, divide in minutes
-    return toFixedScaled(size / 60000, decimals, ' min');
+    return toFixedScaled(size / 60000, decimals, size === 1 ? ' min' : ' mins');
   } else if (Math.abs(size) < 86400000) {
     // Less than one day, divide in hours
-    return toFixedScaled(size / 3600000, decimals, ' hour');
+    return toFixedScaled(size / 3600000, decimals, size === 1 ? ' hour' : ' hours');
   } else if (Math.abs(size) < 31536000000) {
     // Less than one year, divide in days
-    return toFixedScaled(size / 86400000, decimals, ' day');
+    return toFixedScaled(size / 86400000, decimals, size === 1 ? ' day' : ' days');
   }
 
-  return toFixedScaled(size / 31536000000, decimals, ' year');
+  return toFixedScaled(size / 31536000000, decimals, size === 1 ? ' year' : ' years');
 }
 
 export function trySubstract(value1: DecimalCount, value2: DecimalCount): DecimalCount {
@@ -136,19 +136,19 @@ export function toSeconds(size: number, decimals?: DecimalCount): FormattedValue
     return { text: toFixed(size, decimals), suffix: ' s' };
   } else if (Math.abs(size) < 3600) {
     // Less than 1 hour, divide in minutes
-    return toFixedScaled(size / 60, decimals, ' min');
+    return toFixedScaled(size / 60, decimals, size === 1 ? ' min' : ' mins');
   } else if (Math.abs(size) < 86400) {
     // Less than one day, divide in hours
-    return toFixedScaled(size / 3600, decimals, ' hour');
+    return toFixedScaled(size / 3600, decimals, size === 1 ? ' hour' : ' hours');
   } else if (Math.abs(size) < 604800) {
     // Less than one week, divide in days
-    return toFixedScaled(size / 86400, decimals, ' day');
+    return toFixedScaled(size / 86400, decimals, size === 1 ? ' day' : ' days');
   } else if (Math.abs(size) < 31536000) {
     // Less than one year, divide in week
-    return toFixedScaled(size / 604800, decimals, ' week');
+    return toFixedScaled(size / 604800, decimals, size === 1 ? ' week' : ' weeks');
   }
 
-  return toFixedScaled(size / 3.15569e7, decimals, ' year');
+  return toFixedScaled(size / 3.15569e7, decimals, size === 1 ? ' year' : ' years');
 }
 
 export function toMinutes(size: number, decimals?: DecimalCount): FormattedValue {
@@ -157,15 +157,15 @@ export function toMinutes(size: number, decimals?: DecimalCount): FormattedValue
   }
 
   if (Math.abs(size) < 60) {
-    return { text: toFixed(size, decimals), suffix: ' min' };
+    return { text: toFixed(size, decimals), suffix: ' mins' };
   } else if (Math.abs(size) < 1440) {
-    return toFixedScaled(size / 60, decimals, ' hour');
+    return toFixedScaled(size / 60, decimals, size === 1 ? ' hour' : ' hours');
   } else if (Math.abs(size) < 10080) {
-    return toFixedScaled(size / 1440, decimals, ' day');
+    return toFixedScaled(size / 1440, decimals, size === 1 ? ' day' : ' days');
   } else if (Math.abs(size) < 604800) {
-    return toFixedScaled(size / 10080, decimals, ' week');
+    return toFixedScaled(size / 10080, decimals, size === 1 ? ' week' : ' weeks');
   } else {
-    return toFixedScaled(size / 5.25948e5, decimals, ' year');
+    return toFixedScaled(size / 5.25948e5, decimals, size === 1 ? ' year' : ' years');
   }
 }
 
@@ -175,13 +175,13 @@ export function toHours(size: number, decimals?: DecimalCount): FormattedValue {
   }
 
   if (Math.abs(size) < 24) {
-    return { text: toFixed(size, decimals), suffix: ' hour' };
+    return { text: toFixed(size, decimals), suffix: ' hours' };
   } else if (Math.abs(size) < 168) {
-    return toFixedScaled(size / 24, decimals, ' day');
+    return toFixedScaled(size / 24, decimals, size === 1 ? ' day' : ' days');
   } else if (Math.abs(size) < 8760) {
-    return toFixedScaled(size / 168, decimals, ' week');
+    return toFixedScaled(size / 168, decimals, size === 1 ? ' week' : ' weeks');
   } else {
-    return toFixedScaled(size / 8760, decimals, ' year');
+    return toFixedScaled(size / 8760, decimals, size === 1 ? ' year' : ' years');
   }
 }
 
@@ -191,11 +191,11 @@ export function toDays(size: number, decimals?: DecimalCount): FormattedValue {
   }
 
   if (Math.abs(size) < 7) {
-    return { text: toFixed(size, decimals), suffix: ' day' };
+    return { text: toFixed(size, decimals), suffix: ' days' };
   } else if (Math.abs(size) < 365) {
-    return toFixedScaled(size / 7, decimals, ' week');
+    return toFixedScaled(size / 7, decimals, size === 1 ? ' week' : ' weeks');
   } else {
-    return toFixedScaled(size / 365, decimals, ' year');
+    return toFixedScaled(size / 365, decimals, size === 1 ? ' year' : ' years');
   }
 }
 


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**
use of plurals for time values greater than 1.0

**Why do we need this feature?**
Grafana dashboard panels support various time units like seconds, milliseconds, etc. At display time, values with a time unit are converted into something like "1 day, 1 week".

**Who is this feature for?**
All dashboard users

**Which issue(s) does this PR fix?**:
Fixes #77182 

**Special notes for your reviewer:**
Please check that:
- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
