### PR TITLE
ValueFormats: Currency: Add support for Bulgarian Lev (BGN)

### DIFF
--- a/devenv/dev-dashboards-without-uid/panel_tests_polystat.json
+++ b/devenv/dev-dashboards-without-uid/panel_tests_polystat.json
@@ -453,6 +453,10 @@
               "text": "CFP franc (XPF)",
               "value": "currencyXPF"
             }
+            {
+              "text": "Bulgarian Lev (BGN)",
+              "value": "currencyBGN"
+            }
           ],
           "text": "currency"
         },
@@ -1612,6 +1616,10 @@
               "text": "Malaysian Ringgit (RM)",
               "value": "currencyMYR"
             }
+            {
+              "text": "Bulgarian Lev (BGN)",
+              "value": "currencyBGN"
+            }
           ],
           "text": "currency"
         },
@@ -2710,6 +2718,10 @@
             {
               "text": "Malaysian Ringgit (RM)",
               "value": "currencyMYR"
+            }
+            {
+              "text": "Bulgarian Lev (BGN)",
+              "value": "currencyBGN"
             }
           ],
           "text": "currency"

--- a/devenv/dev-dashboards/panel-polystat/polystat_test.json
+++ b/devenv/dev-dashboards/panel-polystat/polystat_test.json
@@ -449,9 +449,13 @@
               "text": "Malaysian Ringgit (RM)",
               "value": "currencyMYR"
             },
-	    {
+	          {
               "text": "CFP franc (XPF)",
               "value": "currencyXPF"
+            }
+            {
+              "text": "Bulgarian Lev (BGN)",
+              "value": "currencyBGN"
             }
           ],
           "text": "currency"
@@ -1612,6 +1616,10 @@
               "text": "Malaysian Ringgit (RM)",
               "value": "currencyMYR"
             }
+            {
+              "text": "Bulgarian Lev (BGN)",
+              "value": "currencyBGN"
+            }
           ],
           "text": "currency"
         },
@@ -2706,6 +2714,10 @@
             {
               "text": "Malaysian Ringgit (RM)",
               "value": "currencyMYR"
+            }
+            {
+              "text": "Bulgarian Lev (BGN)",
+              "value": "currencyBGN"
             }
           ],
           "text": "currency"

--- a/packages/grafana-data/src/valueFormats/categories.ts
+++ b/packages/grafana-data/src/valueFormats/categories.ts
@@ -144,6 +144,7 @@ export const getCategories = (): ValueFormatCategory[] => [
       { name: 'Turkish Lira (₺)', id: 'currencyTRY', fn: currency('₺', true) },
       { name: 'Malaysian Ringgit (RM)', id: 'currencyMYR', fn: currency('RM') },
       { name: 'CFP franc (XPF)', id: 'currencyXPF', fn: currency('XPF') },
+      { name: 'Bulgarian Lev (BGN)', id: 'currencyBGN', fn: currency('BGN') },
     ],
   },
   {


### PR DESCRIPTION
Hello,

Why is this component needed:
The addition of the Bulgarian Lev (BGN) as a currency formatting option is needed to facilitate users in Bulgaria or those dealing with the Bulgarian Lev  in their data visualizations. Currently, Grafana supports various currencies, but Bulgarian Lev  is not one of them. This update would extend Grafana's versatility and usability for a broader range of financial data visualization scenarios.

[x] Is/could it be used in more than one place in Grafana?

Where is/could it be used?:
The Bulgarian Lev formatting option could be used anywhere in Grafana where currency formatting options are provided. This includes, but is not limited to, panels displaying financial data, in the Graph, Table, Singlestat, and other panel types where monetary values might be represented.

[x] It has a single use case.
[x] It is/could be used in multiple places.

Thank you!