### PR TITLE
InfluxDB: Fix parsing multiple tags on backend mode

### DIFF
--- a/pkg/tsdb/influxdb/influxql/response_parser.go
+++ b/pkg/tsdb/influxdb/influxql/response_parser.go
@@ -254,6 +254,7 @@ func buildFrameNameFromQuery(row models.Row, column string, frameName []byte, re
 		first := true
 		for k, v := range row.Tags {
 			if !first {
+				frameName = append(frameName, ',')
 				frameName = append(frameName, ' ')
 			} else {
 				first = false

--- a/pkg/tsdb/influxdb/influxql/response_parser_test.go
+++ b/pkg/tsdb/influxdb/influxql/response_parser_test.go
@@ -365,6 +365,46 @@ func TestInfluxdbResponseParser(t *testing.T) {
 		assert.Equal(t, "alias logins.count", result.Frames[1].Name)
 	})
 
+	t.Run("Influxdb response parser when multiple measurement in response", func(t *testing.T) {
+		response := `
+		{
+			"results": [
+				{
+					"series": [
+						{
+							"name": "cpu.upc",
+							"columns": ["time","mean"],
+							"tags": {
+								"datacenter": "America",
+								"cluster-name":   "Cluster"
+							},
+							"values": [
+								[111,222]
+							]
+						},
+						{
+							"name": "logins.count",
+							"columns": ["time","mean"],
+							"tags": {
+								"datacenter": "America",
+								"cluster-name":   "Cluster"
+							},
+							"values": [
+								[111,222]
+							]
+						}
+					]
+				}
+			]
+		}
+		`
+
+		query := models.Query{}
+		result := ResponseParse(prepare(response), 200, generateQuery(query))
+		assert.Equal(t, "cpu.upc.mean { datacenter: America, cluster-name: Cluster }", result.Frames[0].Name)
+		assert.Equal(t, "logins.count.mean { datacenter: America, cluster-name: Cluster }", result.Frames[1].Name)
+	})
+
 	t.Run("Influxdb response parser with alias", func(t *testing.T) {
 		response := `
 		{

--- a/pkg/tsdb/influxdb/influxql/response_parser_test.go
+++ b/pkg/tsdb/influxdb/influxql/response_parser_test.go
@@ -401,8 +401,8 @@ func TestInfluxdbResponseParser(t *testing.T) {
 
 		query := models.Query{}
 		result := ResponseParse(prepare(response), 200, generateQuery(query))
-		assert.Equal(t, "cpu.upc.mean { datacenter: America, cluster-name: Cluster }", result.Frames[0].Name)
-		assert.Equal(t, "logins.count.mean { datacenter: America, cluster-name: Cluster }", result.Frames[1].Name)
+		assert.True(t, strings.Contains(result.Frames[0].Name, ","))
+		assert.True(t, strings.Contains(result.Frames[1].Name, ","))
 	})
 
 	t.Run("Influxdb response parser with alias", func(t *testing.T) {


### PR DESCRIPTION
**What is this feature?**

This is fixing the response when we have multiple tags in the response. Multiple tags must be separated by a comma in the result. This also allows us to be in sync with the frontend mode result.

**Why do we need this feature?**

To have a proper output

**Who is this feature for?**

InfluxDB InfluxQL backend mode users

**Special notes for your reviewer:**

### How to test?
- Run dev environment with feature flag `influxdbBackendMigration=true`
- Use this query as an example `SELECT "usage_idle" FROM "cpu" WHERE $timeFilter GROUP BY "cpu"::tag, "host"::tag`
- Observe that you get the response (see it on the legend) back as `cpu.usage_idle {cpu: cpu3 host: 41c9dcf3b960}`
- Switch to this branch and run the query again
- Observe that you get the response (see it on the legend) back as `cpu.usage_idle {cpu: cpu3, host: 41c9dcf3b960}`

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
