### PR TITLE
User: remove empty email / username check from update in service

### DIFF
--- a/pkg/api/user.go
+++ b/pkg/api/user.go
@@ -221,6 +221,15 @@ func (hs *HTTPServer) handleUpdateUser(ctx context.Context, cmd user.UpdateUserC
 		return response.Error(http.StatusForbidden, "User info cannot be updated for external Users", nil)
 	}
 
+	if len(cmd.Login) == 0 {
+		cmd.Login = cmd.Email
+	}
+
+	// if login is still empty both email and login field is missing
+	if len(cmd.Login) == 0 {
+		return response.Err(user.ErrEmptyUsernameAndEmail.Errorf("user cannot be created with empty username and email"))
+	}
+
 	if err := hs.userService.Update(ctx, &cmd); err != nil {
 		if errors.Is(err, user.ErrCaseInsensitive) {
 			return response.Error(http.StatusConflict, "Update would result in user login conflict", err)

--- a/pkg/services/user/userimpl/user.go
+++ b/pkg/services/user/userimpl/user.go
@@ -224,15 +224,6 @@ func (s *Service) GetByEmail(ctx context.Context, query *user.GetUserByEmailQuer
 }
 
 func (s *Service) Update(ctx context.Context, cmd *user.UpdateUserCommand) error {
-	if len(cmd.Login) == 0 {
-		cmd.Login = cmd.Email
-	}
-
-	// if login is still empty both email and login field is missing
-	if len(cmd.Login) == 0 {
-		return user.ErrEmptyUsernameAndEmail.Errorf("user cannot be created with empty username and email")
-	}
-
 	if s.cfg.CaseInsensitiveLogin {
 		cmd.Login = strings.ToLower(cmd.Login)
 		cmd.Email = strings.ToLower(cmd.Email)

--- a/pkg/services/user/userimpl/user_test.go
+++ b/pkg/services/user/userimpl/user_test.go
@@ -98,16 +98,6 @@ func TestUserService(t *testing.T) {
 		require.NoError(t, err)
 	})
 
-	t.Run("update user should fail with empty username and password", func(t *testing.T) {
-		err := userService.Update(context.Background(), &user.UpdateUserCommand{
-			Email: "",
-			Login: "",
-			Name:  "name",
-		})
-
-		require.ErrorIs(t, err, user.ErrEmptyUsernameAndEmail)
-	})
-
 	t.Run("GetByID - email conflict", func(t *testing.T) {
 		userService.cfg.CaseInsensitiveLogin = true
 		userStore.ExpectedError = errors.New("email conflict")


### PR DESCRIPTION
**What is this feature?**
In https://github.com/grafana/grafana/pull/76330 I moved the checks for empty email and username into user service.
This was correct for when creating the user but not for update. Update works on fields that are set and are ignoring empty ones. This is a problem when in the case when only name has changed but not email or username.

**Which issue(s) does this PR fix?**:

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
