### PR TITLE
InfluxDB: Fix parsing empty response

### DIFF
--- a/pkg/tsdb/influxdb/influxql/response_parser.go
+++ b/pkg/tsdb/influxdb/influxql/response_parser.go
@@ -83,6 +83,10 @@ func transformRows(rows []models.Row, query models.Query) data.Frames {
 		}
 	}
 
+	if len(rows) == 0 {
+		return make([]*data.Frame, 0)
+	}
+
 	// Preallocate for the worst-case scenario
 	frames := make([]*data.Frame, 0, len(rows)*len(rows[0].Columns))
 

--- a/pkg/tsdb/influxdb/influxql/response_parser_test.go
+++ b/pkg/tsdb/influxdb/influxql/response_parser_test.go
@@ -407,6 +407,7 @@ func TestInfluxdbResponseParser(t *testing.T) {
 		)
 		testFrame.Meta = &data.FrameMeta{PreferredVisualization: graphVisType, ExecutedQueryString: "Test raw query"}
 		result := ResponseParse(prepare(response), 200, generateQuery(query))
+
 		t.Run("should parse aliases", func(t *testing.T) {
 			if diff := cmp.Diff(testFrame, result.Frames[0], data.FrameTestCompareOptions()...); diff != "" {
 				t.Errorf("Result mismatch (-want +got):\n%s", diff)
@@ -575,6 +576,7 @@ func TestInfluxdbResponseParser(t *testing.T) {
 				t.Errorf("Result mismatch (-want +got):\n%s", diff)
 			}
 		})
+
 		t.Run("shouldn't parse aliases", func(t *testing.T) {
 			query = models.Query{Alias: "alias words with no brackets"}
 			result = ResponseParse(prepare(response), 200, generateQuery(query))
@@ -680,6 +682,23 @@ func TestInfluxdbResponseParser(t *testing.T) {
 	t.Run("Influxdb response parser parseNumber invalid type", func(t *testing.T) {
 		_, err := parseTimestamp("hello")
 		require.Error(t, err)
+	})
+
+	t.Run("InfluxDB returns empty DataResponse when there is empty response", func(t *testing.T) {
+		response := `
+		{
+			"results": [
+				{
+					"statement_id": 0
+				}
+			]
+		}
+		`
+
+		query := models.Query{}
+		result := ResponseParse(prepare(response), 200, generateQuery(query))
+		assert.NotNil(t, result.Frames)
+		assert.Equal(t, 0, len(result.Frames))
 	})
 }
 


### PR DESCRIPTION
**What is this feature?**

Handle the case and return empty dataframe when there is no series to parse in the InfluxDB query response.

**Who is this feature for?**

InfluxDB InfluxQL users on backend mode

**Which issue(s) does this PR fix?**:


Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
