### PR TITLE
Tempo: Fix TraceQL autocompletion with missing `}`

### DIFF
--- a/public/app/plugins/datasource/tempo/traceql/autocomplete.test.ts
+++ b/public/app/plugins/datasource/tempo/traceql/autocomplete.test.ts
@@ -342,6 +342,27 @@ describe('CompletionProvider', () => {
       [...scopes, ...intrinsics].map((s) => expect.objectContaining({ label: s }))
     );
   });
+
+  it.each([
+    ['{span.ht', 8],
+    ['{span.http', 10],
+    ['{span.http.', 11],
+    ['{span.http.status', 17],
+  ])(
+    'suggests attributes when containing trigger characters and missing `}`- %s, %i',
+    async (input: string, offset: number) => {
+      const { provider, model } = setup(input, offset, undefined, [
+        {
+          name: 'span',
+          tags: ['http.status_code'],
+        },
+      ]);
+      const result = await provider.provideCompletionItems(model, emptyPosition);
+      expect((result! as monacoTypes.languages.CompletionList).suggestions).toEqual([
+        expect.objectContaining({ label: 'http.status_code', insertText: 'http.status_code' }),
+      ]);
+    }
+  );
 });
 
 function setup(value: string, offset: number, tagsV1?: string[], tagsV2?: Scope[]) {


### PR DESCRIPTION
Currently, when a `}` is missing and thus a spanset is incomplete, the autocompletion system doesn't properly handle attributes containing trigger characters such as `.`. This PR fixes this.

Fixes https://github.com/grafana/grafana/issues/77319