### PR TITLE
Update documentation for timezones in mute timings

### DIFF
--- a/docs/sources/alerting/manage-notifications/mute-timings.md
+++ b/docs/sources/alerting/manage-notifications/mute-timings.md
@@ -63,7 +63,7 @@ A time interval is a definition for a moment in time. If an alert fires during t
 
 Supported time interval options are:
 
-- Time range: The time inclusive of the starting time and exclusive of the end time in UTC.
+- Time range: The time inclusive of the start and exclusive of the end time (in UTC if no location has been selected, otherwise local time).
 - Days of the week: The day or range of days of the week. Example: `monday:thursday`.
 - Days of the month: The date 1-31 of a month. Negative values can also be used to represent days that begin at the end of the month. For example: `-1` for the last day of the month.
 - Months: The months of the year in either numerical or the full calendar month. For example: `1, may:august`.

--- a/public/app/features/alerting/unified/components/mute-timings/MuteTimingTimeRange.tsx
+++ b/public/app/features/alerting/unified/components/mute-timings/MuteTimingTimeRange.tsx
@@ -35,7 +35,7 @@ export const MuteTimingTimeRange = ({ intervalIndex }: Props) => {
       <Field
         className={styles.field}
         label="Time range"
-        description="The time inclusive of the starting time and exclusive of the end time in UTC"
+        description="The time inclusive of the start and exclusive of the end time (in UTC if no location has been selected, otherwise local time)"
         invalid={timeRangeInvalid}
       >
         <>


### PR DESCRIPTION
**What is this feature?**

Some users got confused that our documentation still required time ranges in UTC despite having a Location field. This pull request attempts to prevent such confusion in future.

**Why do we need this feature?**

[Add a description of the problem the feature is trying to solve.]

**Who is this feature for?**

[Add information on what kind of user the feature is for.]

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
