### PR TITLE
[v10.2.x] InfluxDB: Fix parsing multiple tags on backend mode

### DIFF
--- a/pkg/tsdb/influxdb/influxql/response_parser.go
+++ b/pkg/tsdb/influxdb/influxql/response_parser.go
@@ -266,6 +266,7 @@ func buildFrameNameFromQuery(row models.Row, column string, frameName []byte, re
 		first := true
 		for k, v := range row.Tags {
 			if !first {
+				frameName = append(frameName, ',')
 				frameName = append(frameName, ' ')
 			} else {
 				first = false


### PR DESCRIPTION
Backport 6b13064cf6a5f544f558783cda8d3a2b7bc7f7e7 from #77340

---

**What is this feature?**

This is fixing the response when we have multiple tags in the response. Multiple tags must be separated by a comma in the result. This also allows us to be in sync with the frontend mode result.

**Why do we need this feature?**

To have a proper output

**Who is this feature for?**

InfluxDB InfluxQL backend mode users

**Special notes for your reviewer:**

### How to test?
- Run dev environment with feature flag `influxdbBackendMigration=true`
- Use this query as an example `SELECT "usage_idle" FROM "cpu" WHERE $timeFilter GROUP BY "cpu"::tag, "host"::tag`
- Observe that you get the response (see it on the legend) back as `cpu.usage_idle {cpu: cpu3 host: 41c9dcf3b960}`
- Switch to this branch and run the query again
- Observe that you get the response (see it on the legend) back as `cpu.usage_idle {cpu: cpu3, host: 41c9dcf3b960}`
