### PR TITLE
Alerting: Fix GetStarted container width for big screens

### DIFF
--- a/public/app/features/alerting/unified/home/GettingStarted.tsx
+++ b/public/app/features/alerting/unified/home/GettingStarted.tsx
@@ -93,6 +93,7 @@ const getWelcomePageStyles = (theme: GrafanaTheme2) => ({
     grid-template-rows: min-content auto auto;
     grid-template-columns: 1fr 1fr 1fr 1fr 1fr;
     gap: ${theme.spacing(2)};
+    width: 100%;
   `,
   ctaContainer: css`
     grid-column: 1 / span 5;


### PR DESCRIPTION
The Getting Started view was not taking all width in big resolutions. This PR fixes that.

Before:

<img width="1494" alt="image" src="https://github.com/grafana/grafana/assets/6271380/33d35a1c-1b2f-4e0f-9755-dd97427d8f50">


After:

<img width="1506" alt="image" src="https://github.com/grafana/grafana/assets/6271380/00f3664d-416e-4f00-ba9d-2fec51317771">