### PR TITLE
Alerting: Remove OrgID() from the Alertmanager interface

### DIFF
--- a/pkg/services/ngalert/notifier/alertmanager.go
+++ b/pkg/services/ngalert/notifier/alertmanager.go
@@ -395,10 +395,6 @@ func (am *alertmanager) PutAlerts(_ context.Context, postableAlerts apimodels.Po
 	return am.Base.PutAlerts(alerts)
 }
 
-func (am *alertmanager) OrgID() int64 {
-	return am.orgID
-}
-
 // CleanUp removes the directory containing the alertmanager files from disk.
 func (am *alertmanager) CleanUp() {
 	am.fileStore.CleanUp()

--- a/pkg/services/ngalert/notifier/multiorg_alertmanager.go
+++ b/pkg/services/ngalert/notifier/multiorg_alertmanager.go
@@ -57,7 +57,6 @@ type Alertmanager interface {
 	CleanUp()
 	StopAndWait()
 	Ready() bool
-	OrgID() int64
 }
 
 type MultiOrgAlertmanager struct {

--- a/pkg/services/ngalert/notifier/multiorg_alertmanager_test.go
+++ b/pkg/services/ngalert/notifier/multiorg_alertmanager_test.go
@@ -286,8 +286,10 @@ func TestMultiOrgAlertmanager_AlertmanagerFor(t *testing.T) {
 	{
 		am, err := mam.AlertmanagerFor(2)
 		require.NoError(t, err)
+		internalAm, ok := am.(*alertmanager)
+		require.True(t, ok)
 		require.Equal(t, "N/A", *am.GetStatus().VersionInfo.Version)
-		require.Equal(t, int64(2), am.OrgID())
+		require.Equal(t, int64(2), internalAm.orgID)
 	}
 
 	// Let's now remove the previous queried organization.

--- a/pkg/services/ngalert/remote/alertmanager.go
+++ b/pkg/services/ngalert/remote/alertmanager.go
@@ -297,10 +297,6 @@ func (am *Alertmanager) Ready() bool {
 // We don't have files on disk, no-op.
 func (am *Alertmanager) CleanUp() {}
 
-func (am *Alertmanager) OrgID() int64 {
-	return am.orgID
-}
-
 type roundTripper struct {
 	tenantID          string
 	basicAuthPassword string

--- a/pkg/services/ngalert/remote/alertmanager_test.go
+++ b/pkg/services/ngalert/remote/alertmanager_test.go
@@ -59,7 +59,7 @@ func TestNewAlertmanager(t *testing.T) {
 			require.NoError(tt, err)
 			require.Equal(tt, am.tenantID, test.tenantID)
 			require.Equal(tt, am.url, test.url)
-			require.Equal(tt, am.OrgID(), test.orgID)
+			require.Equal(tt, am.orgID, test.orgID)
 			require.NotNil(tt, am.amClient)
 			require.NotNil(tt, am.httpClient)
 		})


### PR DESCRIPTION
We don't need this method as part of the interface, we only access the `orgID` field in tests.