### PR TITLE
Chore: update kind annotation names to grafana.app/*

### DIFF
--- a/pkg/apis/playlist/v0alpha1/types_test.go
+++ b/pkg/apis/playlist/v0alpha1/types_test.go
@@ -16,7 +16,7 @@ func TestPlaylistClone(t *testing.T) {
 			ResourceVersion:   "12345",
 			CreationTimestamp: metav1.NewTime(time.Now()),
 			Annotations: map[string]string{
-				"grafana.com/updatedTime": time.Now().Format(time.RFC3339),
+				"grafana.app/updatedTimestamp": time.Now().Format(time.RFC3339),
 			},
 		},
 		Spec: Spec{

--- a/pkg/kinds/general.go
+++ b/pkg/kinds/general.go
@@ -23,7 +23,7 @@ type ResourceOriginInfo struct {
 	Timestamp *time.Time `json:"time,omitempty"`
 
 	// Avoid extending
-	_ any
+	_ any `json:"-"`
 }
 
 // GrafanaResourceMetadata is standard k8s object metadata with helper functions
@@ -40,23 +40,31 @@ type GrafanaResource[Spec any, Status any] struct {
 	Status   *Status                 `json:"status,omitempty"`
 
 	// Avoid extending
-	_ any
+	_ any `json:"-"`
 }
 
 // Annotation keys
-const annoKeyCreatedBy = "grafana.com/createdBy"
-const annoKeyUpdatedTimestamp = "grafana.com/updatedTimestamp"
-const annoKeyUpdatedBy = "grafana.com/updatedBy"
+const annoKeyCreatedBy = "grafana.app/createdBy"
+const annoKeyUpdatedTimestamp = "grafana.app/updatedTimestamp"
+const annoKeyUpdatedBy = "grafana.app/updatedBy"
 
 // The folder identifier
-const annoKeyFolder = "grafana.com/folder"
-const annoKeySlug = "grafana.com/slug"
+const annoKeyFolder = "grafana.app/folder"
+const annoKeySlug = "grafana.app/slug"
 
 // Identify where values came from
-const annoKeyOriginName = "grafana.com/originName"
-const annoKeyOriginPath = "grafana.com/originPath"
-const annoKeyOriginKey = "grafana.com/originKey"
-const annoKeyOriginTime = "grafana.com/originTime"
+const annoKeyOriginName = "grafana.app/originName"
+const annoKeyOriginPath = "grafana.app/originPath"
+const annoKeyOriginKey = "grafana.app/originKey"
+const annoKeyOriginTimestamp = "grafana.app/originTimestamp"
+
+func (m *GrafanaResourceMetadata) set(key string, val string) {
+	if val == "" {
+		delete(m.Annotations, key)
+	} else {
+		m.Annotations[key] = val
+	}
+}
 
 func (m *GrafanaResourceMetadata) GetUpdatedTimestamp() *time.Time {
 	v, ok := m.Annotations[annoKeyUpdatedTimestamp]
@@ -82,7 +90,7 @@ func (m *GrafanaResourceMetadata) GetCreatedBy() string {
 }
 
 func (m *GrafanaResourceMetadata) SetCreatedBy(user string) {
-	m.Annotations[annoKeyCreatedBy] = user // user GRN
+	m.set(annoKeyCreatedBy, user)
 }
 
 func (m *GrafanaResourceMetadata) GetUpdatedBy() string {
@@ -90,7 +98,7 @@ func (m *GrafanaResourceMetadata) GetUpdatedBy() string {
 }
 
 func (m *GrafanaResourceMetadata) SetUpdatedBy(user string) {
-	m.Annotations[annoKeyUpdatedBy] = user // user GRN
+	m.set(annoKeyUpdatedBy, user)
 }
 
 func (m *GrafanaResourceMetadata) GetFolder() string {
@@ -98,7 +106,7 @@ func (m *GrafanaResourceMetadata) GetFolder() string {
 }
 
 func (m *GrafanaResourceMetadata) SetFolder(uid string) {
-	m.Annotations[annoKeyFolder] = uid
+	m.set(annoKeyFolder, uid)
 }
 
 func (m *GrafanaResourceMetadata) GetSlug() string {
@@ -106,14 +114,14 @@ func (m *GrafanaResourceMetadata) GetSlug() string {
 }
 
 func (m *GrafanaResourceMetadata) SetSlug(v string) {
-	m.Annotations[annoKeySlug] = v
+	m.set(annoKeySlug, v)
 }
 
 func (m *GrafanaResourceMetadata) SetOriginInfo(info *ResourceOriginInfo) {
 	delete(m.Annotations, annoKeyOriginName)
 	delete(m.Annotations, annoKeyOriginPath)
 	delete(m.Annotations, annoKeyOriginKey)
-	delete(m.Annotations, annoKeyOriginTime)
+	delete(m.Annotations, annoKeyOriginTimestamp)
 	if info != nil || info.Name != "" {
 		m.Annotations[annoKeyOriginName] = info.Name
 		if info.Path != "" {
@@ -123,7 +131,7 @@ func (m *GrafanaResourceMetadata) SetOriginInfo(info *ResourceOriginInfo) {
 			m.Annotations[annoKeyOriginKey] = info.Key
 		}
 		if info.Timestamp != nil {
-			m.Annotations[annoKeyOriginTime] = info.Timestamp.Format(time.RFC3339)
+			m.Annotations[annoKeyOriginTimestamp] = info.Timestamp.Format(time.RFC3339)
 		}
 	}
 }
@@ -139,7 +147,7 @@ func (m *GrafanaResourceMetadata) GetOriginInfo() *ResourceOriginInfo {
 		Path: m.Annotations[annoKeyOriginPath],
 		Key:  m.Annotations[annoKeyOriginKey],
 	}
-	v, ok = m.Annotations[annoKeyOriginTime]
+	v, ok = m.Annotations[annoKeyOriginTimestamp]
 	if ok {
 		t, err := time.Parse(time.RFC3339, v)
 		if err != nil {

--- a/pkg/services/dashboards/models_test.go
+++ b/pkg/services/dashboards/models_test.go
@@ -121,13 +121,13 @@ func TestResourceConversion(t *testing.T) {
 		  "resourceVersion": "10",
 		  "creationTimestamp": "2000-01-01T08:00:00Z",
 		  "annotations": {
-			"grafana.com/createdBy": "user:10",
-			"grafana.com/folder": "folder:1234",
-			"grafana.com/originKey": "plugin-xyz",
-			"grafana.com/originName": "plugin",
-			"grafana.com/slug": "test-dash",
-			"grafana.com/updatedBy": "user:11",
-			"grafana.com/updatedTimestamp": "2010-01-01T08:00:00Z"
+			"grafana.app/createdBy": "user:10",
+			"grafana.app/folder": "folder:1234",
+			"grafana.app/originKey": "plugin-xyz",
+			"grafana.app/originName": "plugin",
+			"grafana.app/slug": "test-dash",
+			"grafana.app/updatedBy": "user:11",
+			"grafana.app/updatedTimestamp": "2010-01-01T08:00:00Z"
 		  }
 		},
 		"spec": {

--- a/pkg/services/libraryelements/model/model_test.go
+++ b/pkg/services/libraryelements/model/model_test.go
@@ -46,10 +46,10 @@ func TestLibaryPanelConversion(t *testing.T) {
 		  "resourceVersion": "10",
 		  "creationTimestamp": "2000-01-01T08:00:00Z",
 		  "annotations": {
-			"grafana.com/createdBy": "user:11",
-			"grafana.com/folder": "TheFolderUID",
-			"grafana.com/updatedBy": "user:12",
-			"grafana.com/updatedTimestamp": "2010-01-01T08:00:00Z"
+			"grafana.app/createdBy": "user:11",
+			"grafana.app/folder": "TheFolderUID",
+			"grafana.app/updatedBy": "user:12",
+			"grafana.app/updatedTimestamp": "2010-01-01T08:00:00Z"
 		  }
 		},
 		"spec": {}

--- a/pkg/services/team/model_test.go
+++ b/pkg/services/team/model_test.go
@@ -34,7 +34,7 @@ func TestTeamConversion(t *testing.T) {
 		  "name": "abc",
 		  "creationTimestamp": "2000-01-01T08:00:00Z",
 		  "annotations": {
-			"grafana.com/updatedTimestamp": "2010-01-01T08:00:00Z"
+			"grafana.app/updatedTimestamp": "2010-01-01T08:00:00Z"
 		  }
 		},
 		"spec": {


### PR DESCRIPTION
This PR implements the changes proposed by @malcolmholmes and I, using grafana.app as the namespace and making the labels themselves more consistent. It also implements logic to delete empty annotations rather than setting them to an empty string.