### PR TITLE
Chore: Deprecate FolderID in GetLibraryElementCommand

### DIFF
--- a/pkg/services/folder/folderimpl/folder_test.go
+++ b/pkg/services/folder/folderimpl/folder_test.go
@@ -661,14 +661,14 @@ func TestIntegrationNestedFolderService(t *testing.T) {
 
 				_, err = lps.LibraryElementService.GetElement(context.Background(), &signedInUser, model.GetLibraryElementCommand{
 					FolderName: parent.Title,
-					FolderID:   parent.ID,
+					FolderID:   parent.ID, // nolint:staticcheck
 					UID:        parentPanel.UID,
 				})
 				require.ErrorIs(t, err, tc.libPanelParentErr)
 				if tc.depth > 1 {
 					_, err = lps.LibraryElementService.GetElement(context.Background(), &signedInUser, model.GetLibraryElementCommand{
 						FolderName: subfolder.Title,
-						FolderID:   subfolder.ID,
+						FolderID:   subfolder.ID, // nolint:staticcheck
 						UID:        subPanel.UID,
 					})
 					require.ErrorIs(t, err, tc.libPanelSubErr)

--- a/pkg/services/libraryelements/database.go
+++ b/pkg/services/libraryelements/database.go
@@ -277,6 +277,7 @@ func (l *LibraryElementService) getLibraryElements(c context.Context, store db.D
 		builder.Write(", ? as folder_name ", cmd.FolderName)
 		builder.Write(", '' as folder_uid ")
 		builder.Write(getFromLibraryElementDTOWithMeta(store.GetDialect()))
+		// nolint:staticcheck
 		writeParamSelectorSQL(&builder, append(params, Pair{"folder_id", cmd.FolderID})...)
 		builder.Write(" UNION ")
 		builder.Write(selectLibraryElementDTOWithMeta)

--- a/pkg/services/libraryelements/model/model.go
+++ b/pkg/services/libraryelements/model/model.go
@@ -233,8 +233,9 @@ type PatchLibraryElementCommand struct {
 // GetLibraryElementCommand is the command for getting a library element.
 type GetLibraryElementCommand struct {
 	FolderName string
-	FolderID   int64
-	UID        string
+	// Deprecated: use FolderUID instead
+	FolderID int64
+	UID      string
 }
 
 // SearchLibraryElementsQuery is the query used for searching for Elements


### PR DESCRIPTION
Deprecate `FolderID` in `GetLibraryElementCommand`. Part of a series of PRs to deprecate sequential IDs in library elements.

Ref https://github.com/grafana/grafana/issues/61232