### PR TITLE
Chore: Deprecate FolderID in LibraryElementWithMeta

### DIFF
--- a/pkg/services/libraryelements/database.go
+++ b/pkg/services/libraryelements/database.go
@@ -227,6 +227,7 @@ func (l *LibraryElementService) deleteLibraryElement(c context.Context, signedIn
 		if err != nil {
 			return err
 		}
+		// nolint:staticcheck
 		if err := l.requireEditPermissionsOnFolder(c, signedInUser, element.FolderID); err != nil {
 			return err
 		}
@@ -313,7 +314,7 @@ func (l *LibraryElementService) getLibraryElements(c context.Context, store db.D
 		leDtos[i] = model.LibraryElementDTO{
 			ID:          libraryElement.ID,
 			OrgID:       libraryElement.OrgID,
-			FolderID:    libraryElement.FolderID,
+			FolderID:    libraryElement.FolderID, // nolint:staticcheck
 			FolderUID:   libraryElement.FolderUID,
 			UID:         libraryElement.UID,
 			Name:        libraryElement.Name,
@@ -435,7 +436,7 @@ func (l *LibraryElementService) getAllLibraryElements(c context.Context, signedI
 			retDTOs = append(retDTOs, model.LibraryElementDTO{
 				ID:          element.ID,
 				OrgID:       element.OrgID,
-				FolderID:    element.FolderID,
+				FolderID:    element.FolderID, // nolint:staticcheck
 				FolderUID:   element.FolderUID,
 				UID:         element.UID,
 				Name:        element.Name,
@@ -592,6 +593,7 @@ func (l *LibraryElementService) patchLibraryElement(c context.Context, signedInU
 		if cmd.Model == nil {
 			libraryElement.Model = elementInDB.Model
 		}
+		// nolint:staticcheck
 		if err := l.handleFolderIDPatches(c, &libraryElement, elementInDB.FolderID, cmd.FolderID, signedInUser); err != nil {
 			return err
 		}
@@ -710,7 +712,7 @@ func (l *LibraryElementService) getElementsForDashboardID(c context.Context, das
 			libraryElementMap[element.UID] = model.LibraryElementDTO{
 				ID:          element.ID,
 				OrgID:       element.OrgID,
-				FolderID:    element.FolderID,
+				FolderID:    element.FolderID, // nolint:staticcheck
 				UID:         element.UID,
 				Name:        element.Name,
 				Kind:        element.Kind,
@@ -756,6 +758,7 @@ func (l *LibraryElementService) connectElementsToDashboardID(c context.Context, 
 			if err != nil {
 				return err
 			}
+			// nolint:staticcheck
 			if err := l.requireViewPermissionsOnFolder(c, signedInUser, element.FolderID); err != nil {
 				return err
 			}

--- a/pkg/services/libraryelements/model/model.go
+++ b/pkg/services/libraryelements/model/model.go
@@ -40,8 +40,9 @@ type LibraryElement struct {
 
 // LibraryElementWithMeta is the model used to retrieve entities with additional meta information.
 type LibraryElementWithMeta struct {
-	ID          int64  `xorm:"pk autoincr 'id'"`
-	OrgID       int64  `xorm:"org_id"`
+	ID    int64 `xorm:"pk autoincr 'id'"`
+	OrgID int64 `xorm:"org_id"`
+	// Deprecated: use FolderUID instead
 	FolderID    int64  `xorm:"folder_id"`
 	UID         string `xorm:"uid"`
 	Name        string


### PR DESCRIPTION
Deprecate `FolderID` in `LibraryElementWithMeta`. Deprecate FolderID in CreateLibraryElementComand. Part of a series of PRs to deprecate sequential IDs in library elements.

Ref https://github.com/grafana/grafana/issues/61232