### PR TITLE
Annotations settings: Do not preserve query properties when changing data source

### DIFF
--- a/public/app/features/dashboard/components/AnnotationSettings/AnnotationSettingsEdit.tsx
+++ b/public/app/features/dashboard/components/AnnotationSettings/AnnotationSettingsEdit.tsx
@@ -73,8 +73,15 @@ export const AnnotationSettingsEdit = ({ editIdx, dashboard }: Props) => {
 
   const onDataSourceChange = (ds: DataSourceInstanceSettings) => {
     onUpdate({
-      ...annotation,
       datasource: getDataSourceRef(ds),
+      builtIn: annotation.builtIn,
+      enable: annotation.enable,
+      iconColor: annotation.iconColor,
+      name: annotation.name,
+      hide: annotation.hide,
+      filter: annotation.filter,
+      mappings: annotation.mappings,
+      type: annotation.type,
     });
   };
 

--- a/public/app/features/dashboard/components/AnnotationSettings/AnnotationSettingsEdit.tsx
+++ b/public/app/features/dashboard/components/AnnotationSettings/AnnotationSettingsEdit.tsx
@@ -72,17 +72,26 @@ export const AnnotationSettingsEdit = ({ editIdx, dashboard }: Props) => {
   };
 
   const onDataSourceChange = (ds: DataSourceInstanceSettings) => {
-    onUpdate({
-      datasource: getDataSourceRef(ds),
-      builtIn: annotation.builtIn,
-      enable: annotation.enable,
-      iconColor: annotation.iconColor,
-      name: annotation.name,
-      hide: annotation.hide,
-      filter: annotation.filter,
-      mappings: annotation.mappings,
-      type: annotation.type,
-    });
+    const dsRef = getDataSourceRef(ds);
+
+    if (annotation.datasource?.type !== dsRef.type) {
+      onUpdate({
+        datasource: dsRef,
+        builtIn: annotation.builtIn,
+        enable: annotation.enable,
+        iconColor: annotation.iconColor,
+        name: annotation.name,
+        hide: annotation.hide,
+        filter: annotation.filter,
+        mappings: annotation.mappings,
+        type: annotation.type,
+      });
+    } else {
+      onUpdate({
+        ...annotation,
+        datasource: dsRef,
+      });
+    }
   };
 
   const onChange = (ev: React.FocusEvent<HTMLInputElement>) => {


### PR DESCRIPTION
A simple remedy to https://github.com/grafana/support-escalations/issues/8118, basically cleaning all properties from the annotation query, that might have been added to the object. Long term we should implement a datasource change handler similar to the one we use in panel edit so that queries can be imported, or default query can be used, as described in https://github.com/grafana/support-escalations/issues/8118#issuecomment-1786777106