### PR TITLE
Plugins: Fix status_source always being "plugin" in plugin request logs

### DIFF
--- a/pkg/services/pluginsintegration/clientmiddleware/metrics_middleware_test.go
+++ b/pkg/services/pluginsintegration/clientmiddleware/metrics_middleware_test.go
@@ -156,10 +156,12 @@ func TestInstrumentationMiddlewareStatusSource(t *testing.T) {
 	features := featuremgmt.WithFeatures(featuremgmt.FlagPluginsInstrumentationStatusSource)
 	metricsMw := newMetricsMiddleware(promRegistry, pluginsRegistry, features)
 	cdt := clienttest.NewClientDecoratorTest(t, clienttest.WithMiddlewares(
+		NewPluginRequestMetaMiddleware(),
 		plugins.ClientMiddlewareFunc(func(next plugins.Client) plugins.Client {
 			metricsMw.next = next
 			return metricsMw
 		}),
+		NewStatusSourceMiddleware(),
 	))
 
 	t.Run("Metrics", func(t *testing.T) {

--- a/pkg/services/pluginsintegration/clientmiddleware/plugin_request_meta_middleware.go
+++ b/pkg/services/pluginsintegration/clientmiddleware/plugin_request_meta_middleware.go
@@ -1,0 +1,67 @@
+package clientmiddleware
+
+import (
+	"context"
+
+	"github.com/grafana/grafana-plugin-sdk-go/backend"
+
+	"github.com/grafana/grafana/pkg/plugins"
+	"github.com/grafana/grafana/pkg/plugins/pluginrequestmeta"
+)
+
+// NewPluginRequestMetaMiddleware returns a new plugins.ClientMiddleware that sets up the default
+// values for the plugin request meta in the context.Context. All middlewares that are executed
+// after this one are be able to access plugin request meta via the pluginrequestmeta package.
+func NewPluginRequestMetaMiddleware() plugins.ClientMiddleware {
+	return plugins.ClientMiddlewareFunc(func(next plugins.Client) plugins.Client {
+		return &PluginRequestMetaMiddleware{
+			next: next,
+		}
+	})
+}
+
+type PluginRequestMetaMiddleware struct {
+	next plugins.Client
+}
+
+func withDefaultPluginRequestMeta(ctx context.Context) context.Context {
+	// Setup plugin request status source
+	ctx = pluginrequestmeta.WithStatusSource(ctx, pluginrequestmeta.StatusSourcePlugin)
+
+	return ctx
+}
+
+func (m *PluginRequestMetaMiddleware) QueryData(ctx context.Context, req *backend.QueryDataRequest) (*backend.QueryDataResponse, error) {
+	ctx = withDefaultPluginRequestMeta(ctx)
+	return m.next.QueryData(ctx, req)
+}
+
+func (m *PluginRequestMetaMiddleware) CallResource(ctx context.Context, req *backend.CallResourceRequest, sender backend.CallResourceResponseSender) error {
+	ctx = withDefaultPluginRequestMeta(ctx)
+	return m.next.CallResource(ctx, req, sender)
+}
+
+func (m *PluginRequestMetaMiddleware) CheckHealth(ctx context.Context, req *backend.CheckHealthRequest) (*backend.CheckHealthResult, error) {
+	ctx = withDefaultPluginRequestMeta(ctx)
+	return m.next.CheckHealth(ctx, req)
+}
+
+func (m *PluginRequestMetaMiddleware) CollectMetrics(ctx context.Context, req *backend.CollectMetricsRequest) (*backend.CollectMetricsResult, error) {
+	ctx = withDefaultPluginRequestMeta(ctx)
+	return m.next.CollectMetrics(ctx, req)
+}
+
+func (m *PluginRequestMetaMiddleware) SubscribeStream(ctx context.Context, req *backend.SubscribeStreamRequest) (*backend.SubscribeStreamResponse, error) {
+	ctx = withDefaultPluginRequestMeta(ctx)
+	return m.next.SubscribeStream(ctx, req)
+}
+
+func (m *PluginRequestMetaMiddleware) PublishStream(ctx context.Context, req *backend.PublishStreamRequest) (*backend.PublishStreamResponse, error) {
+	ctx = withDefaultPluginRequestMeta(ctx)
+	return m.next.PublishStream(ctx, req)
+}
+
+func (m *PluginRequestMetaMiddleware) RunStream(ctx context.Context, req *backend.RunStreamRequest, sender *backend.StreamSender) error {
+	ctx = withDefaultPluginRequestMeta(ctx)
+	return m.next.RunStream(ctx, req, sender)
+}

--- a/pkg/services/pluginsintegration/clientmiddleware/plugin_request_meta_middleware.go
+++ b/pkg/services/pluginsintegration/clientmiddleware/plugin_request_meta_middleware.go
@@ -15,53 +15,55 @@ import (
 func NewPluginRequestMetaMiddleware() plugins.ClientMiddleware {
 	return plugins.ClientMiddlewareFunc(func(next plugins.Client) plugins.Client {
 		return &PluginRequestMetaMiddleware{
-			next: next,
+			next:                next,
+			defaultStatusSource: pluginrequestmeta.StatusSourcePlugin,
 		}
 	})
 }
 
 type PluginRequestMetaMiddleware struct {
-	next plugins.Client
+	next                plugins.Client
+	defaultStatusSource pluginrequestmeta.StatusSource
 }
 
-func withDefaultPluginRequestMeta(ctx context.Context) context.Context {
+func (m *PluginRequestMetaMiddleware) withDefaultPluginRequestMeta(ctx context.Context) context.Context {
 	// Setup plugin request status source
-	ctx = pluginrequestmeta.WithStatusSource(ctx, pluginrequestmeta.StatusSourcePlugin)
+	ctx = pluginrequestmeta.WithStatusSource(ctx, m.defaultStatusSource)
 
 	return ctx
 }
 
 func (m *PluginRequestMetaMiddleware) QueryData(ctx context.Context, req *backend.QueryDataRequest) (*backend.QueryDataResponse, error) {
-	ctx = withDefaultPluginRequestMeta(ctx)
+	ctx = m.withDefaultPluginRequestMeta(ctx)
 	return m.next.QueryData(ctx, req)
 }
 
 func (m *PluginRequestMetaMiddleware) CallResource(ctx context.Context, req *backend.CallResourceRequest, sender backend.CallResourceResponseSender) error {
-	ctx = withDefaultPluginRequestMeta(ctx)
+	ctx = m.withDefaultPluginRequestMeta(ctx)
 	return m.next.CallResource(ctx, req, sender)
 }
 
 func (m *PluginRequestMetaMiddleware) CheckHealth(ctx context.Context, req *backend.CheckHealthRequest) (*backend.CheckHealthResult, error) {
-	ctx = withDefaultPluginRequestMeta(ctx)
+	ctx = m.withDefaultPluginRequestMeta(ctx)
 	return m.next.CheckHealth(ctx, req)
 }
 
 func (m *PluginRequestMetaMiddleware) CollectMetrics(ctx context.Context, req *backend.CollectMetricsRequest) (*backend.CollectMetricsResult, error) {
-	ctx = withDefaultPluginRequestMeta(ctx)
+	ctx = m.withDefaultPluginRequestMeta(ctx)
 	return m.next.CollectMetrics(ctx, req)
 }
 
 func (m *PluginRequestMetaMiddleware) SubscribeStream(ctx context.Context, req *backend.SubscribeStreamRequest) (*backend.SubscribeStreamResponse, error) {
-	ctx = withDefaultPluginRequestMeta(ctx)
+	ctx = m.withDefaultPluginRequestMeta(ctx)
 	return m.next.SubscribeStream(ctx, req)
 }
 
 func (m *PluginRequestMetaMiddleware) PublishStream(ctx context.Context, req *backend.PublishStreamRequest) (*backend.PublishStreamResponse, error) {
-	ctx = withDefaultPluginRequestMeta(ctx)
+	ctx = m.withDefaultPluginRequestMeta(ctx)
 	return m.next.PublishStream(ctx, req)
 }
 
 func (m *PluginRequestMetaMiddleware) RunStream(ctx context.Context, req *backend.RunStreamRequest, sender *backend.StreamSender) error {
-	ctx = withDefaultPluginRequestMeta(ctx)
+	ctx = m.withDefaultPluginRequestMeta(ctx)
 	return m.next.RunStream(ctx, req, sender)
 }

--- a/pkg/services/pluginsintegration/clientmiddleware/plugin_request_meta_middleware_test.go
+++ b/pkg/services/pluginsintegration/clientmiddleware/plugin_request_meta_middleware_test.go
@@ -1,0 +1,40 @@
+package clientmiddleware
+
+import (
+	"context"
+	"testing"
+
+	"github.com/grafana/grafana-plugin-sdk-go/backend"
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/grafana/pkg/plugins"
+	"github.com/grafana/grafana/pkg/plugins/manager/client/clienttest"
+	"github.com/grafana/grafana/pkg/plugins/pluginrequestmeta"
+)
+
+func TestPluginRequestMetaMiddleware(t *testing.T) {
+	t.Run("default", func(t *testing.T) {
+		cdt := clienttest.NewClientDecoratorTest(t,
+			clienttest.WithMiddlewares(NewPluginRequestMetaMiddleware()),
+		)
+		_, err := cdt.Decorator.QueryData(context.Background(), &backend.QueryDataRequest{})
+		require.NoError(t, err)
+		ss := pluginrequestmeta.StatusSourceFromContext(cdt.QueryDataCtx)
+		require.Equal(t, pluginrequestmeta.StatusSourcePlugin, ss)
+	})
+
+	t.Run("other value", func(t *testing.T) {
+		cdt := clienttest.NewClientDecoratorTest(t,
+			clienttest.WithMiddlewares(plugins.ClientMiddlewareFunc(func(next plugins.Client) plugins.Client {
+				return &PluginRequestMetaMiddleware{
+					next:                next,
+					defaultStatusSource: "test",
+				}
+			})),
+		)
+		_, err := cdt.Decorator.QueryData(context.Background(), &backend.QueryDataRequest{})
+		require.NoError(t, err)
+		ss := pluginrequestmeta.StatusSourceFromContext(cdt.QueryDataCtx)
+		require.Equal(t, pluginrequestmeta.StatusSource("test"), ss)
+	})
+}

--- a/pkg/services/pluginsintegration/clientmiddleware/status_source_middleware.go
+++ b/pkg/services/pluginsintegration/clientmiddleware/status_source_middleware.go
@@ -1,0 +1,83 @@
+package clientmiddleware
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/grafana/grafana-plugin-sdk-go/backend"
+
+	"github.com/grafana/grafana/pkg/plugins"
+	"github.com/grafana/grafana/pkg/plugins/pluginrequestmeta"
+)
+
+// NewStatusSourceMiddleware returns a new plugins.ClientMiddleware that sets the status source in the
+// plugin request meta stored in the context.Context, according to the query data responses returned by QueryError.
+// If at least one query data response has a "downstream" status source and there isn't one with a "plugin" status source,
+// the plugin request meta in the context is set to "downstream".
+func NewStatusSourceMiddleware() plugins.ClientMiddleware {
+	return plugins.ClientMiddlewareFunc(func(next plugins.Client) plugins.Client {
+		return &StatusSourceMiddleware{
+			next: next,
+		}
+	})
+}
+
+type StatusSourceMiddleware struct {
+	next plugins.Client
+}
+
+func (m *StatusSourceMiddleware) QueryData(ctx context.Context, req *backend.QueryDataRequest) (*backend.QueryDataResponse, error) {
+	resp, err := m.next.QueryData(ctx, req)
+	if resp == nil || len(resp.Responses) == 0 {
+		return resp, err
+	}
+
+	// Set downstream status source in the context if there's at least one response with downstream status source,
+	// and if there's no plugin error
+	var hasPluginError bool
+	var hasDownstreamError bool
+	for _, r := range resp.Responses {
+		if r.Error == nil {
+			continue
+		}
+		if r.ErrorSource == backend.ErrorSourceDownstream {
+			hasDownstreamError = true
+		} else {
+			hasPluginError = true
+		}
+	}
+
+	// A plugin error has higher priority than a downstream error,
+	// so set to downstream only if there's no plugin error
+	if hasDownstreamError && !hasPluginError {
+		if err := pluginrequestmeta.WithDownstreamStatusSource(ctx); err != nil {
+			return resp, fmt.Errorf("failed to set downstream status source: %w", err)
+		}
+	}
+
+	return resp, err
+}
+
+func (m *StatusSourceMiddleware) CallResource(ctx context.Context, req *backend.CallResourceRequest, sender backend.CallResourceResponseSender) error {
+	return m.next.CallResource(ctx, req, sender)
+}
+
+func (m *StatusSourceMiddleware) CheckHealth(ctx context.Context, req *backend.CheckHealthRequest) (*backend.CheckHealthResult, error) {
+	return m.next.CheckHealth(ctx, req)
+}
+
+func (m *StatusSourceMiddleware) CollectMetrics(ctx context.Context, req *backend.CollectMetricsRequest) (*backend.CollectMetricsResult, error) {
+	return m.next.CollectMetrics(ctx, req)
+}
+
+func (m *StatusSourceMiddleware) SubscribeStream(ctx context.Context, req *backend.SubscribeStreamRequest) (*backend.SubscribeStreamResponse, error) {
+	return m.next.SubscribeStream(ctx, req)
+}
+
+func (m *StatusSourceMiddleware) PublishStream(ctx context.Context, req *backend.PublishStreamRequest) (*backend.PublishStreamResponse, error) {
+	return m.next.PublishStream(ctx, req)
+}
+
+func (m *StatusSourceMiddleware) RunStream(ctx context.Context, req *backend.RunStreamRequest, sender *backend.StreamSender) error {
+	return m.next.RunStream(ctx, req, sender)
+}

--- a/pkg/services/pluginsintegration/clientmiddleware/status_source_middleware_test.go
+++ b/pkg/services/pluginsintegration/clientmiddleware/status_source_middleware_test.go
@@ -1,0 +1,88 @@
+package clientmiddleware
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/grafana/grafana-plugin-sdk-go/backend"
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/grafana/pkg/plugins/manager/client/clienttest"
+	"github.com/grafana/grafana/pkg/plugins/pluginrequestmeta"
+)
+
+func TestStatusSourceMiddleware(t *testing.T) {
+	someErr := errors.New("oops")
+
+	for _, tc := range []struct {
+		name string
+
+		queryDataResponse *backend.QueryDataResponse
+
+		expStatusSource pluginrequestmeta.StatusSource
+	}{
+		{
+			name:              `no error should be "plugin" status source`,
+			queryDataResponse: nil,
+			expStatusSource:   pluginrequestmeta.StatusSourcePlugin,
+		},
+		{
+			name: `single downstream error should be "downstream" status source`,
+			queryDataResponse: &backend.QueryDataResponse{
+				Responses: map[string]backend.DataResponse{
+					"A": {Error: someErr, ErrorSource: backend.ErrorSourceDownstream},
+				},
+			},
+			expStatusSource: pluginrequestmeta.StatusSourceDownstream,
+		},
+		{
+			name: `single plugin error should be "plugin" status source`,
+			queryDataResponse: &backend.QueryDataResponse{
+				Responses: map[string]backend.DataResponse{
+					"A": {Error: someErr, ErrorSource: backend.ErrorSourcePlugin},
+				},
+			},
+			expStatusSource: pluginrequestmeta.StatusSourcePlugin,
+		},
+		{
+			name: `multiple downstream errors should be "downstream" status source`,
+			queryDataResponse: &backend.QueryDataResponse{
+				Responses: map[string]backend.DataResponse{
+					"A": {Error: someErr, ErrorSource: backend.ErrorSourceDownstream},
+					"B": {Error: someErr, ErrorSource: backend.ErrorSourceDownstream},
+				},
+			},
+			expStatusSource: pluginrequestmeta.StatusSourceDownstream,
+		},
+		{
+			name: `single plugin error mixed with downstream errors should be "plugin" status source`,
+			queryDataResponse: &backend.QueryDataResponse{
+				Responses: map[string]backend.DataResponse{
+					"A": {Error: someErr, ErrorSource: backend.ErrorSourceDownstream},
+					"B": {Error: someErr, ErrorSource: backend.ErrorSourcePlugin},
+					"C": {Error: someErr, ErrorSource: backend.ErrorSourceDownstream},
+				},
+			},
+			expStatusSource: pluginrequestmeta.StatusSourcePlugin,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			cdt := clienttest.NewClientDecoratorTest(t,
+				clienttest.WithMiddlewares(
+					NewPluginRequestMetaMiddleware(),
+					NewStatusSourceMiddleware(),
+				),
+			)
+			cdt.TestClient.QueryDataFunc = func(ctx context.Context, req *backend.QueryDataRequest) (*backend.QueryDataResponse, error) {
+				cdt.QueryDataCtx = ctx
+				return tc.queryDataResponse, nil
+			}
+
+			_, _ = cdt.Decorator.QueryData(context.Background(), &backend.QueryDataRequest{})
+
+			ss := pluginrequestmeta.StatusSourceFromContext(cdt.QueryDataCtx)
+			require.Equal(t, tc.expStatusSource, ss)
+		})
+	}
+}


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

Fixes a bug where `status_source` in plugin request logs is always `plugin`, even if it was set to `downstream` by a plugin.

This happened because the logic for the status source was all contained in the metrics middleware, and the logger middleware is at a deeper level:

```mermaid
flowchart TD
a["MetricsMiddleware pre: Create pluginrequestmeta"]
--> QueryData
--> b["LoggerMiddleware post: Log status_source from context.Context"]
--> c["MetricsMiddleware post: Set status_source in context.Context"]
--> d["MetricsMiddleware post: Instrument using status_source in context.Context"]
```

This PR adds two new middlewares:

- `PluginRequestMetaMiddleware`, which is at the top of the middleware stack, creates the plugin request meta in the `context.Context`, which is then available to all subsequent middlewares
- `StatusSourceMiddleware`, at the bottom of the middleware stack, which sets the status source in the `context.Context` before returning, so all middlewares above it can access the correct status source *after* QueryData has returned

```mermaid
flowchart TD
a["PluginRequestMetaMiddleware: Create pluginrequestmeta"]
--> QueryData
--> c["StatusSourceMiddleware post: Set status_source in context.Context"]
--> b["LoggerMiddleware post: Log status_source from context.Context"]
--> d["MetricsMiddleware post: Instrument using status_source in context.Context"]
```

**Why do we need this feature?**

Bugfix

**Who is this feature for?**

Grafana operators

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle.
- [x] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
