### PR TITLE
PanelChrome: Fixes z-index issue with status message when hover header is true

### DIFF
--- a/packages/grafana-ui/src/components/PanelChrome/PanelChrome.tsx
+++ b/packages/grafana-ui/src/components/PanelChrome/PanelChrome.tsx
@@ -465,7 +465,7 @@ const getStyles = (theme: GrafanaTheme2) => {
       position: 'absolute',
       left: 0,
       top: 0,
-      zIndex: theme.zIndex.tooltip,
+      zIndex: 1,
     }),
     rightActions: css({
       display: 'flex',


### PR DESCRIPTION
When hover header is true, the error status message is shown with zIndex of tooltip which is above dropdown menus resulting in this
![image](https://github.com/grafana/grafana/assets/10999/4f198d06-d9ad-4ed7-85cb-268c06e16985)

This issue only appears in scene flex layouts not in core dashboards grid layouts 
