### PR TITLE
Chore: Add more deprecation notices to packages/grafana-ui/src/components/Graph/

### DIFF
--- a/packages/grafana-ui/src/components/Graph/Graph.tsx
+++ b/packages/grafana-ui/src/components/Graph/Graph.tsx
@@ -15,6 +15,7 @@ import { GraphDimensions } from './GraphTooltip/types';
 import { FlotPosition, FlotItem } from './types';
 import { graphTimeFormat, graphTickFormatter } from './utils';
 
+/** @deprecated */
 export interface GraphProps {
   ariaLabel?: string;
   children?: JSX.Element | JSX.Element[];
@@ -31,6 +32,7 @@ export interface GraphProps {
   onHorizontalRegionSelected?: (from: number, to: number) => void;
 }
 
+/** @deprecated */
 interface GraphState {
   pos?: FlotPosition;
   contextPos?: FlotPosition;

--- a/packages/grafana-ui/src/components/Graph/GraphContextMenu.tsx
+++ b/packages/grafana-ui/src/components/Graph/GraphContextMenu.tsx
@@ -21,8 +21,10 @@ import { SeriesIcon } from '../VizLegend/SeriesIcon';
 
 import { GraphDimensions } from './GraphTooltip/types';
 
+/** @deprecated */
 export type ContextDimensions<T extends Dimensions = any> = { [key in keyof T]: [number, number | undefined] | null };
 
+/** @deprecated */
 export type GraphContextMenuProps = ContextMenuProps & {
   getContextMenuSource: () => FlotDataPoint | null;
   timeZone?: TimeZone;

--- a/packages/grafana-ui/src/components/Graph/GraphSeriesToggler.tsx
+++ b/packages/grafana-ui/src/components/Graph/GraphSeriesToggler.tsx
@@ -3,22 +3,26 @@ import React, { Component } from 'react';
 
 import { GraphSeriesXY } from '@grafana/data';
 
+/** @deprecated */
 export interface GraphSeriesTogglerAPI {
   onSeriesToggle: (label: string, event: React.MouseEvent<HTMLElement>) => void;
   toggledSeries: GraphSeriesXY[];
 }
 
+/** @deprecated */
 export interface GraphSeriesTogglerProps {
   children: (api: GraphSeriesTogglerAPI) => JSX.Element;
   series: GraphSeriesXY[];
   onHiddenSeriesChanged?: (hiddenSeries: string[]) => void;
 }
 
+/** @deprecated */
 export interface GraphSeriesTogglerState {
   hiddenSeries: string[];
   toggledSeries: GraphSeriesXY[];
 }
 
+/** @deprecated */
 export class GraphSeriesToggler extends Component<GraphSeriesTogglerProps, GraphSeriesTogglerState> {
   constructor(props: GraphSeriesTogglerProps) {
     super(props);

--- a/packages/grafana-ui/src/components/Graph/GraphTooltip/GraphTooltip.tsx
+++ b/packages/grafana-ui/src/components/Graph/GraphTooltip/GraphTooltip.tsx
@@ -8,6 +8,7 @@ import { MultiModeGraphTooltip } from './MultiModeGraphTooltip';
 import { SingleModeGraphTooltip } from './SingleModeGraphTooltip';
 import { GraphDimensions } from './types';
 
+/** @deprecated */
 export const GraphTooltip = ({
   mode = TooltipDisplayMode.Single,
   dimensions,

--- a/packages/grafana-ui/src/components/Graph/GraphTooltip/MultiModeGraphTooltip.tsx
+++ b/packages/grafana-ui/src/components/Graph/GraphTooltip/MultiModeGraphTooltip.tsx
@@ -8,11 +8,13 @@ import { getMultiSeriesGraphHoverInfo } from '../utils';
 
 import { GraphTooltipContentProps } from './types';
 
+/** @deprecated */
 type Props = GraphTooltipContentProps & {
   // We expect position to figure out correct values when not hovering over a datapoint
   pos: FlotPosition;
 };
 
+/** @deprecated */
 export const MultiModeGraphTooltip = ({ dimensions, activeDimensions, pos, timeZone }: Props) => {
   let activeSeriesIndex: number | null = null;
   // when no x-axis provided, skip rendering

--- a/packages/grafana-ui/src/components/Graph/GraphTooltip/SingleModeGraphTooltip.tsx
+++ b/packages/grafana-ui/src/components/Graph/GraphTooltip/SingleModeGraphTooltip.tsx
@@ -11,6 +11,7 @@ import { SeriesTable } from '../../VizTooltip';
 
 import { GraphTooltipContentProps } from './types';
 
+/** @deprecated */
 export const SingleModeGraphTooltip = ({ dimensions, activeDimensions, timeZone }: GraphTooltipContentProps) => {
   // not hovering over a point, skip rendering
   if (

--- a/packages/grafana-ui/src/components/Graph/GraphTooltip/types.ts
+++ b/packages/grafana-ui/src/components/Graph/GraphTooltip/types.ts
@@ -2,11 +2,13 @@ import { Dimension, Dimensions, TimeZone } from '@grafana/data';
 
 import { ActiveDimensions } from '../../VizTooltip';
 
+/** @deprecated */
 export interface GraphDimensions extends Dimensions {
   xAxis: Dimension<number>;
   yAxis: Dimension<number>;
 }
 
+/** @deprecated */
 export interface GraphTooltipContentProps {
   dimensions: GraphDimensions; // Dimension[]
   activeDimensions: ActiveDimensions<GraphDimensions>;

--- a/packages/grafana-ui/src/components/Graph/types.ts
+++ b/packages/grafana-ui/src/components/Graph/types.ts
@@ -1,3 +1,4 @@
+/** @deprecated */
 export interface FlotPosition {
   pageX: number;
   pageY: number;
@@ -7,6 +8,7 @@ export interface FlotPosition {
   y1: number;
 }
 
+/** @deprecated */
 export interface FlotItem<T> {
   datapoint: [number, number];
   dataIndex: number;

--- a/packages/grafana-ui/src/components/Graph/utils.ts
+++ b/packages/grafana-ui/src/components/Graph/utils.ts
@@ -13,6 +13,7 @@ import {
  *
  * @param posX
  * @param series
+ * @deprecated
  */
 export const findHoverIndexFromData = (xAxisDimension: Field, xPos: number) => {
   let lower = 0;
@@ -50,6 +51,7 @@ interface MultiSeriesHoverInfo {
  *
  * @param seriesList list of series visible on the Graph
  * @param pos mouse cursor position, based on jQuery.flot position
+ * @deprecated
  */
 export const getMultiSeriesGraphHoverInfo = (
   // x and y axis dimensions order is aligned
@@ -102,6 +104,7 @@ export const getMultiSeriesGraphHoverInfo = (
   };
 };
 
+/** @deprecated */
 export const graphTickFormatter = (epoch: number, axis: any) => {
   return dateTimeFormat(epoch, {
     format: axis?.options?.timeformat,
@@ -109,6 +112,7 @@ export const graphTickFormatter = (epoch: number, axis: any) => {
   });
 };
 
+/** @deprecated */
 export const graphTimeFormat = (ticks: number | null, min: number | null, max: number | null): string => {
   if (min && max && ticks) {
     const range = max - min;


### PR DESCRIPTION
**What is this feature?**

The [grafana-ui/src/components/Graph](https://github.com/grafana/grafana/tree/main/packages/grafana-ui/src/components/Graph) package has been deprecated for a long long time and should be removed (or moved to an internal package).  There is still a bit of refactoring needed to make that possible.

This PR adds more deprecation notices on all elements rather than just the key/core ones.


**Why do we need this feature?**

We should make it more obvious that this package should not be used

**Who is this feature for?**

Developers.

See also https://github.com/grafana/grafana-enterprise/pull/5969