### PR TITLE
Loki: Add `supportingQueryType` to datasample queries

### DIFF
--- a/public/app/plugins/datasource/loki/datasource.test.ts
+++ b/public/app/plugins/datasource/loki/datasource.test.ts
@@ -1254,6 +1254,15 @@ describe('LokiDatasource', () => {
         })
       );
     });
+    it('sets the supporting query type in the request', () => {
+      const spy = jest.spyOn(ds, 'query').mockImplementation(() => of({} as DataQueryResponse));
+      ds.getDataSamples({ expr: '{job="bar"}', refId: 'A' });
+      expect(spy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          targets: [expect.objectContaining({ supportingQueryType: SupportingQueryType.DataSample })],
+        })
+      );
+    });
   });
 
   describe('Query splitting', () => {

--- a/public/app/plugins/datasource/loki/datasource.ts
+++ b/public/app/plugins/datasource/loki/datasource.ts
@@ -763,6 +763,7 @@ export class LokiDatasource
       refId: REF_ID_DATA_SAMPLES,
       // For samples we limit the request to 10 lines, so queries are small and fast
       maxLines: 10,
+      supportingQueryType: SupportingQueryType.DataSample,
     };
 
     const timeRange = this.getTimeRange();


### PR DESCRIPTION
**What is this feature?**

Adds the `supportingQueryType` property to correctly flag data sample queries.

**Why do we need this feature?**

To track meta queries correctly.

**Special notes for your reviewer:**

Tested via mitmproxy that the change will trigger the setting of `X-Query-Tags` header:
<img width="606" alt="image" src="https://github.com/grafana/grafana/assets/8092184/b4cb3f84-6faf-4543-9598-f5a2a2fa80de">
