### PR TITLE
Transformations: Move transformation addition into drawer

### DIFF
--- a/packages/grafana-e2e-selectors/src/selectors/components.ts
+++ b/packages/grafana-e2e-selectors/src/selectors/components.ts
@@ -224,6 +224,7 @@ export const Components = {
   },
   Transforms: {
     card: (name: string) => `data-testid New transform ${name}`,
+    noTransformationsMessage: 'no transformations message',
     Reduce: {
       modeLabel: 'Transform mode label',
       calculationsLabel: 'Transform calculations label',

--- a/public/app/features/dashboard/components/TransformationsEditor/TransformationsEditor.test.tsx
+++ b/public/app/features/dashboard/components/TransformationsEditor/TransformationsEditor.test.tsx
@@ -24,11 +24,10 @@ describe('TransformationsEditor', () => {
     function renderList() {
       setup();
 
-      
       const addButton = screen.getAllByTestId(selectors.components.Transforms.addTransformationButton + 'i');
       const emptyMessage = screen.getAllByTestId(selectors.components.Transforms.noTransformationsMessage);
-      
-      console.log({addButton, emptyMessage});
+
+      console.log({ addButton, emptyMessage });
 
       expect(2).toEqual(2);
     }

--- a/public/app/features/dashboard/components/TransformationsEditor/TransformationsEditor.test.tsx
+++ b/public/app/features/dashboard/components/TransformationsEditor/TransformationsEditor.test.tsx
@@ -24,12 +24,11 @@ describe('TransformationsEditor', () => {
     function renderList() {
       setup();
 
-      const addButton = screen.getAllByTestId(selectors.components.Transforms.addTransformationButton + 'i');
+      const addButton = screen.getAllByTestId(selectors.components.Transforms.addTransformationButton);
       const emptyMessage = screen.getAllByTestId(selectors.components.Transforms.noTransformationsMessage);
 
-      console.log({ addButton, emptyMessage });
-
-      expect(2).toEqual(2);
+      expect(addButton).toHaveLength(1);
+      expect(emptyMessage).toHaveLength(1);
     }
 
     it('renders trasnformation empty message', renderList);

--- a/public/app/features/dashboard/components/TransformationsEditor/TransformationsEditor.test.tsx
+++ b/public/app/features/dashboard/components/TransformationsEditor/TransformationsEditor.test.tsx
@@ -24,11 +24,16 @@ describe('TransformationsEditor', () => {
     function renderList() {
       setup();
 
-      const cards = screen.getAllByTestId(/New transform/i);
-      expect(cards.length).toEqual(standardTransformersRegistry.list().length);
+      
+      const addButton = screen.getAllByTestId(selectors.components.Transforms.addTransformationButton + 'i');
+      const emptyMessage = screen.getAllByTestId(selectors.components.Transforms.noTransformationsMessage);
+      
+      console.log({addButton, emptyMessage});
+
+      expect(2).toEqual(2);
     }
 
-    it('renders transformations selection list', renderList);
+    it('renders trasnformation empty message', renderList);
     it('renders transformations selection list with transformationsRedesign feature toggled on', () => {
       config.featureToggles.transformationsRedesign = true;
       renderList();

--- a/public/app/features/dashboard/components/TransformationsEditor/TransformationsEditor.tsx
+++ b/public/app/features/dashboard/components/TransformationsEditor/TransformationsEditor.tsx
@@ -170,7 +170,7 @@ class UnThemedTransformationsEditor extends React.PureComponent<TransformationsE
     }
 
     return `${name}-${nextId}`;
-  };
+  }
 
   onTransformationAdd(selectable: SelectableValue<string>) {
     let eventName = 'panel_editor_tabs_transformations_management';
@@ -196,7 +196,7 @@ class UnThemedTransformationsEditor extends React.PureComponent<TransformationsE
         },
       },
     ]);
-  };
+  }
 
   onTransformationChange = (idx: number, dataConfig: DataTransformerConfig) => {
     const { transformations } = this.state;
@@ -330,7 +330,7 @@ class UnThemedTransformationsEditor extends React.PureComponent<TransformationsE
       );
     }
 
-    const oldPicker = 
+    const oldPicker = (
       <>
         <Box marginBottom={1}>
           <Input
@@ -340,27 +340,26 @@ class UnThemedTransformationsEditor extends React.PureComponent<TransformationsE
             placeholder="Search for transformation"
             onChange={this.onSearchChange}
             onKeyDown={this.onSearchKeyDown}
-            suffix={suffix} 
+            suffix={suffix}
           />
         </Box>
-        <Flex direction='column' gap={1}>
-          {
-            xforms.map((t) => {
-              return (
-                <TransformationCard
-                  key={t.name}
-                  transform={t}
-                  onClick={() => {
-                    this.onTransformationAdd({ value: t.id });
-                  }}
-                />
-              );
-            })
-          }
+        <Flex direction="column" gap={1}>
+          {xforms.map((t) => {
+            return (
+              <TransformationCard
+                key={t.name}
+                transform={t}
+                onClick={() => {
+                  this.onTransformationAdd({ value: t.id });
+                }}
+              />
+            );
+          })}
         </Flex>
-      </>;
+      </>
+    );
 
-    const newPicker = 
+    const newPicker = (
       <>
         <div className={styles.searchWrapper}>
           <Input
@@ -390,9 +389,12 @@ class UnThemedTransformationsEditor extends React.PureComponent<TransformationsE
           showIllustrations={this.state.showIllustrations}
           transformations={xforms}
           data={this.state.data}
-          onClick={(id) => { this.onTransformationAdd({ value: id }) }} 
+          onClick={(id) => {
+            this.onTransformationAdd({ value: id });
+          }}
         />
-      </>;
+      </>
+    );
 
     const transformPicker = config.featureToggles.transformationsRedesign ? newPicker : oldPicker;
 
@@ -436,39 +438,41 @@ class UnThemedTransformationsEditor extends React.PureComponent<TransformationsE
           </Container>
         )}
         {showPicker && (
-          <Drawer onClose={() => { this.setState({ showPicker: false}) }}>
+          <Drawer
+            onClose={() => {
+              this.setState({ showPicker: false });
+            }}
+          >
             {transformPicker}
           </Drawer>
         )}
         {noTransforms && (
-
-          <Box
-            alignItems="center"
-            padding={4}>
+          <Box alignItems="center" padding={4}>
             <Flex direction="column" alignItems="center" gap={2}>
-              <Text element='h3' textAlignment='center'>
-                <Trans key='transformations.empty.add-transformation-header'>
-                  Start transforming data
-                </Trans>
+              <Text element="h3" textAlignment="center">
+                <Trans key="transformations.empty.add-transformation-header">Start transforming data</Trans>
               </Text>
-              <Text 
-                element='p' 
-                textAlignment='center' 
-                data-testid={selectors.components.Transforms.noTransformationsMessage}>
-                <Trans key='transformations.empty.add-transformation-body'>
-                  Transformations allow data to be changed in various ways before your visualization is shown.<br/> 
-                  This includes joining data together, renaming fields, making calculations, formatting data for display, and more.
+              <Text
+                element="p"
+                textAlignment="center"
+                data-testid={selectors.components.Transforms.noTransformationsMessage}
+              >
+                <Trans key="transformations.empty.add-transformation-body">
+                  Transformations allow data to be changed in various ways before your visualization is shown.
+                  <br />
+                  This includes joining data together, renaming fields, making calculations, formatting data for
+                  display, and more.
                 </Trans>
               </Text>
               <Button
-              icon="plus"
-              variant="primary"
-              size="md"
-              onClick={() => {
-                this.setState({ showPicker: true });
-              }}
-              data-testid={selectors.components.Transforms.addTransformationButton}>
-
+                icon="plus"
+                variant="primary"
+                size="md"
+                onClick={() => {
+                  this.setState({ showPicker: true });
+                }}
+                data-testid={selectors.components.Transforms.addTransformationButton}
+              >
                 Add transformation
               </Button>
             </Flex>
@@ -488,12 +492,13 @@ class UnThemedTransformationsEditor extends React.PureComponent<TransformationsE
                 Add another transformation
               </Button>
               <Button
-                  variant="secondary"
-                  icon="trash-alt"
-                  onClick={() => {
-                    this.setState({ showRemoveAllModal: true });
-                  }}>
-                  Delete all transformations
+                variant="secondary"
+                icon="trash-alt"
+                onClick={() => {
+                  this.setState({ showRemoveAllModal: true });
+                }}
+              >
+                Delete all transformations
               </Button>
             </Flex>
             <ConfirmModal
@@ -508,7 +513,7 @@ class UnThemedTransformationsEditor extends React.PureComponent<TransformationsE
         )}
       </>
     );
-  }
+  };
 
   render() {
     const {

--- a/public/app/features/dashboard/components/TransformationsEditor/TransformationsEditor.tsx
+++ b/public/app/features/dashboard/components/TransformationsEditor/TransformationsEditor.tsx
@@ -451,7 +451,10 @@ class UnThemedTransformationsEditor extends React.PureComponent<TransformationsE
                   Start transforming data
                 </Trans>
               </Text>
-              <Text element='p' textAlignment='center'>
+              <Text 
+                element='p' 
+                textAlignment='center' 
+                data-testid={selectors.components.Transforms.noTransformationsMessage}>
                 <Trans key='transformations.empty.add-transformation-body'>
                   Transformations allow data to be changed in various ways before your visualization is shown.<br/> 
                   This includes joining data together, renaming fields, making calculations, formatting data for display, and more.


### PR DESCRIPTION
**What is this feature?**

This PR moves the addition of new transforms into a drawer component. Additionally, rather than immediately showing the transformation picker, it shows an empty message for adding transformations.

---

The empty state is as follows and is meant to mimic the empty state of a dashboard:

<img width="1162" alt="transform-empty" src="https://github.com/grafana/grafana/assets/199847/17bcbb98-c03b-40e9-b929-b6906a4a4f42">

While this does result in an extra click when no transformations have been added it helps improve clarity for users of transformations, especially those who are not familiar with the feature.

---

When selected the following interface is shown:

<img width="1662" alt="transform-drawer" src="https://github.com/grafana/grafana/assets/199847/0a24acab-3b32-4f38-a263-871f6560ffd1">

---

In addition to working with the transformation redesign it also works with the old transformation interface as well. This looks like the following:

<img width="1655" alt="transform-drawer-old" src="https://github.com/grafana/grafana/assets/199847/c2501836-517d-4e0a-8018-272b66ca06be">

Beyond the addition of the drawer a few UI tweaks have been made:

- The heading is removed from the interface as it's redundant with the tab title and brings the display closer to the _Query_ tab.
- The delete all transformations button is moved to be alongside the add transformation button
- The toggle for _Show Images_ in the transformation redesign has been removed, as there's now more space for these images.

**Why do we need this feature?**

The current transformation interface doesn't have much room in which to show transformations although there are quite a large number. This improves the space to select transformations while also allowing the current visualization and configured transformations to still be seen.

Beyond that, it improves the experience for newer users of by providing guidance on how transformations function.

**Who is this feature for?**

This is for users of transformations, especially users less familiar with transformations.

**Which issue(s) does this PR fix?**:

Fixes #74197

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
