### PR TITLE
Navigation: Minor tweak to `dockedMegaMenu` to make it slightly tighter

### DIFF
--- a/public/app/core/components/AppChrome/DockedMegaMenu/MegaMenuItem.tsx
+++ b/public/app/core/components/AppChrome/DockedMegaMenu/MegaMenuItem.tsx
@@ -63,7 +63,7 @@ export function MegaMenuItem({ link, activeItem, level = 0, onClick }: Props) {
     <li ref={item} className={styles.listItem}>
       <div
         className={cx(styles.menuItem, {
-          [styles.hasIcon]: Boolean(level === 0 && link.icon),
+          [styles.menuItemWithIcon]: Boolean(level === 0 && link.icon),
         })}
       >
         {level !== 0 && <Indent level={level === MAX_DEPTH ? level - 1 : level} spacing={3} />}
@@ -93,6 +93,7 @@ export function MegaMenuItem({ link, activeItem, level = 0, onClick }: Props) {
             <div
               className={cx(styles.labelWrapper, {
                 [styles.hasActiveChild]: hasActiveChild,
+                [styles.labelWrapperWithIcon]: Boolean(level === 0 && link.icon),
               })}
             >
               {level === 0 && link.icon && (
@@ -141,8 +142,11 @@ const getStyles = (theme: GrafanaTheme2) => ({
     alignItems: 'center',
     gap: theme.spacing(1),
     height: theme.spacing(4),
-    paddingLeft: theme.spacing(1),
+    paddingLeft: theme.spacing(0.5),
     position: 'relative',
+  }),
+  menuItemWithIcon: css({
+    paddingLeft: theme.spacing(0),
   }),
   collapseButtonWrapper: css({
     display: 'flex',
@@ -178,9 +182,10 @@ const getStyles = (theme: GrafanaTheme2) => ({
     alignItems: 'center',
     gap: theme.spacing(2),
     minWidth: 0,
+    paddingLeft: theme.spacing(1),
   }),
-  hasIcon: css({
-    paddingLeft: theme.spacing(0),
+  labelWrapperWithIcon: css({
+    paddingLeft: theme.spacing(0.5),
   }),
   hasActiveChild: css({
     color: theme.colors.text.primary,

--- a/public/app/core/components/AppChrome/DockedMegaMenu/MegaMenuItemText.tsx
+++ b/public/app/core/components/AppChrome/DockedMegaMenu/MegaMenuItemText.tsx
@@ -88,7 +88,6 @@ const getStyles = (theme: GrafanaTheme2, isActive: Props['isActive']) => ({
     display: 'flex',
     gap: '0.5rem',
     height: '100%',
-    paddingLeft: theme.spacing(1),
     width: '100%',
   }),
 });


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

- adjusts the padding on items in the megamenu to make them slightly tighter
- this is really minor, but the 2 things to notice are:
  - everything has shifted left by 4px
  - padding between active indicator and icon is now more consistent with padding between active indicator and text when no icon is present

|  |  |  |  |
| --- | --- | --- | --- |
| before | ![image](https://github.com/grafana/grafana/assets/20999846/a4fdff3a-2259-4f8f-94e1-b462149ca257) | ![image](https://github.com/grafana/grafana/assets/20999846/dd3643c5-40db-4795-a6f0-5e602512ef31) | ![image](https://github.com/grafana/grafana/assets/20999846/f874e9f5-f5c3-4ef5-9d61-bce7428d2a7b) |
| after | ![image](https://github.com/grafana/grafana/assets/20999846/e217e02d-88ed-4066-aa84-d43ed3c0a6cb) | ![image](https://github.com/grafana/grafana/assets/20999846/69a06c9b-4209-45c2-bea1-f1b58421a6c9) | ![image](https://github.com/grafana/grafana/assets/20999846/53c2b5b9-13cf-4c5a-a7fe-b1409c7be021) |

**Why do we need this feature?**

- looks better

**Who is this feature for?**

- anyone using `dockedMegaMenu`

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
