### PR TITLE
Dashboards: Fix creating dashboard under folder using deprecated API

### DIFF
--- a/pkg/api/dashboard.go
+++ b/pkg/api/dashboard.go
@@ -1302,6 +1302,10 @@ type PostDashboardResponse struct {
 		// required: true
 		// example: /d/nHz3SXiiz/my-dashboard
 		URL string `json:"url"`
+
+		// FolderUID The unique identifier (uid) of the folder the dashboard belongs to.
+		// required: false
+		FolderUID string `json:"folderUid"`
 	} `json:"body"`
 }
 

--- a/pkg/api/dashboard.go
+++ b/pkg/api/dashboard.go
@@ -521,12 +521,13 @@ func (hs *HTTPServer) postDashboard(c *contextmodel.ReqContext, cmd dashboards.S
 
 	c.TimeRequest(metrics.MApiDashboardSave)
 	return response.JSON(http.StatusOK, util.DynMap{
-		"status":  "success",
-		"slug":    dashboard.Slug,
-		"version": dashboard.Version,
-		"id":      dashboard.ID,
-		"uid":     dashboard.UID,
-		"url":     dashboard.GetURL(),
+		"status":    "success",
+		"slug":      dashboard.Slug,
+		"version":   dashboard.Version,
+		"id":        dashboard.ID,
+		"uid":       dashboard.UID,
+		"url":       dashboard.GetURL(),
+		"folderUid": dashboard.FolderUID,
 	})
 }
 

--- a/pkg/services/folder/folderimpl/folder.go
+++ b/pkg/services/folder/folderimpl/folder.go
@@ -116,7 +116,7 @@ func (s *Service) Get(ctx context.Context, cmd *folder.GetFolderQuery) (*folder.
 	var dashFolder *folder.Folder
 	var err error
 	switch {
-	case cmd.UID != nil:
+	case cmd.UID != nil && *cmd.UID != "":
 		dashFolder, err = s.getFolderByUID(ctx, cmd.OrgID, *cmd.UID)
 		if err != nil {
 			return nil, err

--- a/pkg/services/folder/service.go
+++ b/pkg/services/folder/service.go
@@ -13,9 +13,9 @@ type Service interface {
 	Create(ctx context.Context, cmd *CreateFolderCommand) (*Folder, error)
 
 	// GetFolder takes a GetFolderCommand and returns a folder matching the
-	// request. One of ID, UID, or Title must be included. If multiple values
+	// request. One of UID, ID or Title must be included. If multiple values
 	// are included in the request, Grafana will select one in order of
-	// specificity (ID, UID, Title).
+	// specificity (UID, ID, Title).
 	Get(ctx context.Context, cmd *GetFolderQuery) (*Folder, error)
 
 	// Update is used to update a folder's UID, Title and Description. To change

--- a/pkg/tests/api/dashboards/api_dashboards_test.go
+++ b/pkg/tests/api/dashboards/api_dashboards_test.go
@@ -15,9 +15,11 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/grafana/grafana/pkg/api/dtos"
 	"github.com/grafana/grafana/pkg/components/simplejson"
 	"github.com/grafana/grafana/pkg/services/dashboardimport"
 	"github.com/grafana/grafana/pkg/services/dashboards"
+	"github.com/grafana/grafana/pkg/services/folder"
 	"github.com/grafana/grafana/pkg/services/org"
 	"github.com/grafana/grafana/pkg/services/org/orgimpl"
 	"github.com/grafana/grafana/pkg/services/plugindashboards"
@@ -28,6 +30,7 @@ import (
 	"github.com/grafana/grafana/pkg/services/user"
 	"github.com/grafana/grafana/pkg/services/user/userimpl"
 	"github.com/grafana/grafana/pkg/tests/testinfra"
+	"github.com/grafana/grafana/pkg/util"
 )
 
 func TestIntegrationDashboardQuota(t *testing.T) {
@@ -271,4 +274,164 @@ providers:
 			assert.Equal(t, dashboards.ErrDashboardCannotDeleteProvisionedDashboard.Reason, dashboardErr.Message)
 		})
 	})
+}
+
+func TestIntegrationCreate(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
+
+	// Setup Grafana and its Database
+	dir, path := testinfra.CreateGrafDir(t, testinfra.GrafanaOpts{
+		DisableAnonymous: true,
+	})
+
+	grafanaListedAddr, store := testinfra.StartGrafana(t, dir, path)
+	// Create user
+	createUser(t, store, user.CreateUserCommand{
+		DefaultOrgRole: string(org.RoleAdmin),
+		Password:       "admin",
+		Login:          "admin",
+	})
+
+	t.Run("create dashboard should succeed", func(t *testing.T) {
+		dashboardDataOne, err := simplejson.NewJson([]byte(`{"title":"just testing"}`))
+		require.NoError(t, err)
+		buf1 := &bytes.Buffer{}
+		err = json.NewEncoder(buf1).Encode(dashboards.SaveDashboardCommand{
+			Dashboard: dashboardDataOne,
+		})
+		require.NoError(t, err)
+		u := fmt.Sprintf("http://admin:admin@%s/api/dashboards/db", grafanaListedAddr)
+		// nolint:gosec
+		resp, err := http.Post(u, "application/json", buf1)
+		require.NoError(t, err)
+		assert.Equal(t, http.StatusOK, resp.StatusCode)
+		t.Cleanup(func() {
+			err := resp.Body.Close()
+			require.NoError(t, err)
+		})
+		b, err := io.ReadAll(resp.Body)
+		require.NoError(t, err)
+		var m util.DynMap
+		err = json.Unmarshal(b, &m)
+		require.NoError(t, err)
+		assert.NotEmpty(t, m["id"])
+		assert.NotEmpty(t, m["uid"])
+	})
+
+	t.Run("create dashboard under folder should succeed", func(t *testing.T) {
+		folder := createFolder(t, grafanaListedAddr, "test folder")
+
+		dashboardDataOne, err := simplejson.NewJson([]byte(`{"title":"just testing"}`))
+		require.NoError(t, err)
+		buf1 := &bytes.Buffer{}
+		err = json.NewEncoder(buf1).Encode(dashboards.SaveDashboardCommand{
+			Dashboard: dashboardDataOne,
+			FolderUID: folder.Uid,
+		})
+		require.NoError(t, err)
+		u := fmt.Sprintf("http://admin:admin@%s/api/dashboards/db", grafanaListedAddr)
+		// nolint:gosec
+		resp, err := http.Post(u, "application/json", buf1)
+		require.NoError(t, err)
+		require.Equal(t, http.StatusOK, resp.StatusCode)
+		t.Cleanup(func() {
+			err := resp.Body.Close()
+			require.NoError(t, err)
+		})
+		b, err := io.ReadAll(resp.Body)
+		require.NoError(t, err)
+		var m util.DynMap
+		err = json.Unmarshal(b, &m)
+		require.NoError(t, err)
+		assert.NotEmpty(t, m["id"])
+		assert.NotEmpty(t, m["uid"])
+		assert.Equal(t, folder.Uid, m["folderUid"])
+	})
+
+	t.Run("create dashboard under folder (using deprecated folder sequential ID) should succeed", func(t *testing.T) {
+		folder := createFolder(t, grafanaListedAddr, "test folder 2")
+
+		dashboardDataOne, err := simplejson.NewJson([]byte(`{"title":"just testing"}`))
+		require.NoError(t, err)
+		buf1 := &bytes.Buffer{}
+		err = json.NewEncoder(buf1).Encode(dashboards.SaveDashboardCommand{
+			Dashboard: dashboardDataOne,
+			FolderID:  folder.Id,
+		})
+		require.NoError(t, err)
+		u := fmt.Sprintf("http://admin:admin@%s/api/dashboards/db", grafanaListedAddr)
+		// nolint:gosec
+		resp, err := http.Post(u, "application/json", buf1)
+		require.NoError(t, err)
+		require.Equal(t, http.StatusOK, resp.StatusCode)
+		t.Cleanup(func() {
+			err := resp.Body.Close()
+			require.NoError(t, err)
+		})
+		b, err := io.ReadAll(resp.Body)
+		require.NoError(t, err)
+		var m util.DynMap
+		err = json.Unmarshal(b, &m)
+		require.NoError(t, err)
+		assert.NotEmpty(t, m["id"])
+		assert.NotEmpty(t, m["uid"])
+		assert.Equal(t, folder.Uid, m["folderUid"])
+	})
+
+	t.Run("create dashboard under unknow folder should fail", func(t *testing.T) {
+		folderUID := "unknown"
+		// Import dashboard
+		dashboardDataOne, err := simplejson.NewJson([]byte(`{"title":"just testing"}`))
+		require.NoError(t, err)
+		buf1 := &bytes.Buffer{}
+		err = json.NewEncoder(buf1).Encode(dashboards.SaveDashboardCommand{
+			Dashboard: dashboardDataOne,
+			FolderUID: folderUID,
+		})
+		require.NoError(t, err)
+		u := fmt.Sprintf("http://admin:admin@%s/api/dashboards/db", grafanaListedAddr)
+		// nolint:gosec
+		resp, err := http.Post(u, "application/json", buf1)
+		require.NoError(t, err)
+		assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
+		t.Cleanup(func() {
+			err := resp.Body.Close()
+			require.NoError(t, err)
+		})
+		b, err := io.ReadAll(resp.Body)
+		require.NoError(t, err)
+		var m util.DynMap
+		err = json.Unmarshal(b, &m)
+		require.NoError(t, err)
+		assert.Equal(t, "Folder not found", m["message"])
+	})
+}
+
+func createFolder(t *testing.T, grafanaListedAddr string, title string) *dtos.Folder {
+	t.Helper()
+
+	buf1 := &bytes.Buffer{}
+	err := json.NewEncoder(buf1).Encode(folder.CreateFolderCommand{
+		Title: title,
+	})
+	require.NoError(t, err)
+	u := fmt.Sprintf("http://admin:admin@%s/api/folders", grafanaListedAddr)
+	// nolint:gosec
+	resp, err := http.Post(u, "application/json", buf1)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	t.Cleanup(func() {
+		err := resp.Body.Close()
+		require.NoError(t, err)
+	})
+	b, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	var f *dtos.Folder
+	err = json.Unmarshal(b, &f)
+	require.NoError(t, err)
+
+	return f
 }

--- a/public/api-merged.json
+++ b/public/api-merged.json
@@ -22456,6 +22456,10 @@
           "url"
         ],
         "properties": {
+          "folderUid": {
+            "description": "FolderUID The unique identifier (uid) of the folder the dashboard belongs to.",
+            "type": "string"
+          },
           "id": {
             "description": "ID The unique identifier (id) of the created/updated dashboard.",
             "type": "integer",

--- a/public/openapi3.json
+++ b/public/openapi3.json
@@ -1579,6 +1579,10 @@
           "application/json": {
             "schema": {
               "properties": {
+                "folderUid": {
+                  "description": "FolderUID The unique identifier (uid) of the folder the dashboard belongs to.",
+                  "type": "string"
+                },
                 "id": {
                   "description": "ID The unique identifier (id) of the created/updated dashboard.",
                   "example": 1,


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

A regression was introduced in #76504 and HTTP API `POST api/dashboards/db` would fail when creating dashboard under folder using the deprecated `folderId` field like:

<details><summary>Details</summary>
<p>

```
curl -X 'POST'   'http://admin:admin@localhost:3000/api/dashboards/db'   -H 'accept: application/json'   -H 'Content-Type: application/json'   -d '{
  "dashboard": {"title": "just testing"},
  "folderId": 1
}'
{"message":"Error while checking folder ID","traceID":""}
```

</p>
</details> 

More specifically in the above PR we have introduced setting the UID:
https://github.com/grafana/grafana/blob/8b43d1b1abe5b3f28a3a6291359ac4fb0974dea4/pkg/api/dashboard.go#L416-L423

The folder service [Get()]() returns a folder matching in order of specificity (UID, ID, Title):
https://github.com/grafana/grafana/blob/8b43d1b1abe5b3f28a3a6291359ac4fb0974dea4/pkg/services/folder/folderimpl/folder.go#L118-L136
However, the `UID` is a pointer so we have to check also if is empty otherwise `getFolderByUID()` fails.

The UI does not use this API, therefore creating a dashboard under a folder using the UI works fine.

**Why do we need this feature?**

This fixes the above switch in the folder service `Get()`. It also introduces some integrations tests (the existing tests didn't catch this case because we used to mock the folder service responses).
It also includes the folder UID in the response.

**Who is this feature for?**

[Add information on what kind of user the feature is for.]

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
