### PR TITLE
Docs: Remove reliance on oneshell multiline feature for building transformation docs

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -10,7 +10,6 @@ include docs.mk
 .PHONY: sources/panels-visualizations/query-transform-data/transform-data/index.md
 sources/panels-visualizations/query-transform-data/transform-data/index.md: ## Generate the Transform Data page source.
 sources/panels-visualizations/query-transform-data/transform-data/index.md:
-	cd $(CURDIR)/..
-	npx tsc ./scripts/docs/generate-transformations.ts
-	node ./scripts/docs/generate-transformations.js > $(CURDIR)/$@
-	npx prettier -w $(CURDIR)/$@
+	cd $(CURDIR)/.. && npx tsc ./scripts/docs/generate-transformations.ts && \
+node ./scripts/docs/generate-transformations.js > $(CURDIR)/$@ && \
+npx prettier -w $(CURDIR)/$@

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -11,5 +11,5 @@ include docs.mk
 sources/panels-visualizations/query-transform-data/transform-data/index.md: ## Generate the Transform Data page source.
 sources/panels-visualizations/query-transform-data/transform-data/index.md:
 	cd $(CURDIR)/.. && npx tsc ./scripts/docs/generate-transformations.ts && \
-node ./scripts/docs/generate-transformations.js > $(CURDIR)/$@ && \
-npx prettier -w $(CURDIR)/$@
+	node ./scripts/docs/generate-transformations.js > $(CURDIR)/$@ && \
+	npx prettier -w $(CURDIR)/$@


### PR DESCRIPTION
**What is this feature?**

Assures that all users of `make`, despite running version 3 or 4, can run the commands in the transformation makefile.

**Why do we need this feature?**

So everyone can run the makefile commands.

**Who is this feature for?**

Grafana contributors

**Which issue(s) does this PR fix?**:

Fixes #77513

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [x] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
