### PR TITLE
fix(alerting): fallback to dashboard to get the full targets

### DIFF
--- a/pkg/services/ngalert/migration/alert_rule_graphite.go
+++ b/pkg/services/ngalert/migration/alert_rule_graphite.go
@@ -1,0 +1,149 @@
+package migration
+
+import (
+	"encoding/json"
+	"fmt"
+	"regexp"
+	"strings"
+
+	"github.com/grafana/grafana/pkg/infra/log"
+	"github.com/grafana/grafana/pkg/services/dashboards"
+	"github.com/grafana/grafana/pkg/services/datasources"
+	"github.com/grafana/grafana/pkg/tsdb/graphite"
+)
+
+var (
+	hasPlaceholdersRe = regexp.MustCompile(`#([A-Za-z]+)`)
+)
+
+type panel struct {
+	ID      int64    `json:"id"`
+	Targets []target `json:"targets"`
+}
+
+type target struct {
+	RefID  string `json:"refId"`
+	Target string `json:"target"`
+}
+
+// fixGraphiteReferencedSubQueries attempts to fix graphite referenced sub queries, given unified alerting does not support this.
+// targetFull of Graphite data source contains the expanded version of field 'target', so let's copy that.
+func fixGraphiteReferencedSubQueries(l log.Logger, queryData map[string]json.RawMessage, panelID int64, dashboard *dashboards.Dashboard) map[string]json.RawMessage {
+	if !isFixable(l, queryData) {
+		return queryData
+	}
+	fullQuery, ok := queryData[graphite.TargetFullModelField]
+	if ok {
+		delete(queryData, graphite.TargetFullModelField)
+		queryData[graphite.TargetModelField] = fullQuery
+	} else {
+		// Sometimes it can happen that the "targetFull" field is not there. In this case we can
+		// extract this information from the panel of the dashboard.
+		fullQueryRaw, err := unwrapFromDashboard(queryData, panelID, dashboard)
+		if err != nil {
+			l.Error("graphite query migration: failed to unwrap query from dashboard", "err", err)
+			return queryData
+		}
+		b, err := json.Marshal(fullQueryRaw)
+		if err != nil {
+			l.Error("graphite query migration: failed to marshal the unwrapped query", "query", fullQueryRaw, "err", err)
+			return queryData
+		}
+		l.Info("graphite query migration: successfully unwrapped query using the dashboard", "query", fullQueryRaw)
+		queryData[graphite.TargetModelField] = b
+	}
+	return queryData
+}
+
+func isFixable(l log.Logger, queryData map[string]json.RawMessage) bool {
+	// Check if it's a graphite Query.
+	ok, err := isGraphiteQuery(queryData)
+	if err != nil || !ok {
+		return false
+	}
+	// Check if the target field has any placeholders.
+	targetRaw, ok := queryData[graphite.TargetModelField]
+	if !ok {
+		l.Error("query data does not have field 'target'")
+		return false
+	}
+	var target string
+	err = json.Unmarshal(targetRaw, &target)
+	if err != nil {
+		l.Error("failed to unmarshal target", "err", err)
+		return false
+	}
+	if !hasPlaceholders(target) {
+		return false
+	}
+	return true
+}
+
+func unwrapFromDashboard(queryData map[string]json.RawMessage, panelID int64, dashboard *dashboards.Dashboard) (string, error) {
+	refIDRaw, ok := queryData["refId"]
+	if !ok {
+		return "", fmt.Errorf("query data does not have field 'refId'")
+	}
+	var refID string
+	err := json.Unmarshal(refIDRaw, &refID)
+	if err != nil {
+		return "", fmt.Errorf("failed to unmarshal refId: %w", err)
+	}
+	panelsRaw := dashboard.Data.Get("panels")
+	// Simplejson doesn't let you unmarshal in a type, so we need to work around this.
+	b, err := panelsRaw.MarshalJSON()
+	if err != nil {
+		return "", fmt.Errorf("failed to marshal panels: %w", err)
+	}
+	var panels []panel
+	err = json.Unmarshal(b, &panels)
+	if err != nil {
+		return "", fmt.Errorf("failed to unmarshal panels: %w", err)
+	}
+	for _, panel := range panels {
+		if panel.ID == panelID {
+			return unwrapTarget(refID, panel.Targets), nil
+		}
+	}
+	return "", fmt.Errorf("failed to find panel with id %d", panelID)
+}
+
+func unwrapTarget(refID string, targets []target) string {
+	m := make(map[string]string)
+	for _, t := range targets {
+		m[t.RefID] = t.Target
+	}
+	result := m[refID]
+
+	for {
+		matches := hasPlaceholdersRe.FindStringSubmatch(result)
+		if len(matches) == 0 {
+			break
+		}
+		ref := matches[1]
+		result = strings.ReplaceAll(result, "#"+ref, m[ref])
+	}
+	return result
+}
+
+func isGraphiteQuery(queryData map[string]json.RawMessage) (bool, error) {
+	ds, ok := queryData["datasource"]
+	if !ok {
+		return false, fmt.Errorf("missing datasource field")
+	}
+	var datasource struct {
+		Type string `json:"type"`
+	}
+	if err := json.Unmarshal(ds, &datasource); err != nil {
+		return false, fmt.Errorf("failed to parse datasource '%s': %w", string(ds), err)
+	}
+	if datasource.Type == "" {
+		return false, fmt.Errorf("missing type field '%s'", string(ds))
+	}
+	return datasource.Type == datasources.DS_GRAPHITE, nil
+}
+
+func hasPlaceholders(s string) bool {
+	// Use the regular expression to match the string
+	return hasPlaceholdersRe.MatchString(s)
+}

--- a/pkg/services/ngalert/migration/alert_rule_graphite_test.go
+++ b/pkg/services/ngalert/migration/alert_rule_graphite_test.go
@@ -1,0 +1,91 @@
+package migration
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/grafana/pkg/components/simplejson"
+	"github.com/grafana/grafana/pkg/infra/log/logtest"
+	"github.com/grafana/grafana/pkg/services/dashboards"
+	"github.com/grafana/grafana/pkg/services/ngalert/models"
+)
+
+func TestMigrateAlertRuleGraphiteQueries(t *testing.T) {
+	tc := []struct {
+		name      string
+		input     *simplejson.Json
+		dashboard *dashboards.Dashboard
+		panelID   int64
+		expected  string
+	}{
+		{
+			name: "when a query has a sub query - it is not unwrapped if unavailable through dasboards",
+			input: simplejson.NewFromAny(map[string]any{
+				"refId":  "C",
+				"target": "scale(asPercent(diffSeries(#B, #A), #B), 100)",
+				"datasource": map[string]any{
+					"type": "graphite",
+				},
+			}),
+			expected: `{"datasource":{"type": "graphite"}, "refId":"C", "target":"scale(asPercent(diffSeries(second.query.count, first.query.count), second.query.count), 100)"}`,
+			panelID:  123,
+			dashboard: &dashboards.Dashboard{
+				Data: simplejson.NewFromAny(map[string]any{
+					"panels": []map[string]any{
+						{
+							"id": 123,
+							"targets": []target{
+								{
+									RefID:  "A",
+									Target: "first.query.count",
+								},
+								{
+									RefID:  "B",
+									Target: "second.query.count",
+								},
+								{
+									RefID:  "C",
+									Target: "scale(asPercent(diffSeries(#B, #A), #B), 100)",
+								},
+							},
+						},
+					},
+				}),
+			},
+		},
+	}
+
+	for _, tt := range tc {
+		t.Run(tt.name, func(t *testing.T) {
+			model, err := tt.input.Encode()
+			require.NoError(t, err)
+			queries, err := migrateAlertRuleQueries(&logtest.Fake{}, []models.AlertQuery{{Model: model}}, tt.panelID, tt.dashboard)
+			require.NoError(t, err)
+
+			r, err := queries[0].Model.MarshalJSON()
+			require.NoError(t, err)
+			require.JSONEq(t, tt.expected, string(r))
+		})
+	}
+}
+
+func TestUnwrapTarget(t *testing.T) {
+	targets := []target{
+		{
+			RefID:  "A",
+			Target: "first.query.count",
+		},
+		{
+			RefID:  "B",
+			Target: "second.query.count",
+		},
+		{
+			RefID:  "C",
+			Target: "scale(asPercent(diffSeries(#B, #A), #B), 100)",
+		},
+	}
+	expected := "scale(asPercent(diffSeries(second.query.count, first.query.count), second.query.count), 100)"
+	result := unwrapTarget("C", targets)
+	require.Equal(t, expected, result)
+}

--- a/pkg/services/ngalert/migration/alert_rule_test.go
+++ b/pkg/services/ngalert/migration/alert_rule_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/grafana/grafana/pkg/infra/db"
 	"github.com/grafana/grafana/pkg/infra/log/logtest"
 	legacymodels "github.com/grafana/grafana/pkg/services/alerting/models"
+	"github.com/grafana/grafana/pkg/services/dashboards"
 	migmodels "github.com/grafana/grafana/pkg/services/ngalert/migration/models"
 	migrationStore "github.com/grafana/grafana/pkg/services/ngalert/migration/store"
 	"github.com/grafana/grafana/pkg/services/ngalert/models"
@@ -79,7 +80,7 @@ func TestMigrateAlertRuleQueries(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			model, err := tt.input.Encode()
 			require.NoError(t, err)
-			queries, err := migrateAlertRuleQueries(&logtest.Fake{}, []models.AlertQuery{{Model: model}})
+			queries, err := migrateAlertRuleQueries(&logtest.Fake{}, []models.AlertQuery{{Model: model}}, 0, &dashboards.Dashboard{})
 			if tt.err != nil {
 				require.Error(t, err)
 				require.EqualError(t, err, tt.err.Error())


### PR DESCRIPTION
This PR falls back to the dashboard to compute the full target of an alerting query. Sometimes the full target field is missing and thus the migration is not successful for the users.