### PR TITLE
Alerting: Fix flaky test TestExportRules

### DIFF
--- a/pkg/services/ngalert/api/api_ruler_export_test.go
+++ b/pkg/services/ngalert/api/api_ruler_export_test.go
@@ -260,7 +260,7 @@ func TestExportRules(t *testing.T) {
 		))
 
 	ruleStore.PutRule(context.Background(), noAccessByFolder...)
-	// overwrite the folders visible to user because PutRule automatically creates folders in production.
+	// overwrite the folders visible to user because PutRule automatically creates folders in the fake store.
 	ruleStore.Folders[orgID] = []*folder2.Folder{f1, f2}
 
 	srv := createService(ruleStore)

--- a/pkg/services/ngalert/api/api_ruler_export_test.go
+++ b/pkg/services/ngalert/api/api_ruler_export_test.go
@@ -202,7 +202,6 @@ func TestExportRules(t *testing.T) {
 	f2 := randFolder()
 
 	ruleStore := fakes.NewRuleStore(t)
-	ruleStore.Folders[orgID] = append(ruleStore.Folders[orgID], f1, f2)
 
 	hasAccessKey1 := ngmodels.AlertRuleGroupKey{
 		OrgID:        orgID,
@@ -253,12 +252,16 @@ func TestExportRules(t *testing.T) {
 		))
 	ruleStore.PutRule(context.Background(), hasAccess2...)
 
-	_, noAccess2 := ngmodels.GenerateUniqueAlertRules(10,
+	_, noAccessByFolder := ngmodels.GenerateUniqueAlertRules(10,
 		ngmodels.AlertRuleGen(
 			ngmodels.WithUniqueUID(&uids),
 			ngmodels.WithQuery(accessQuery), // no access because of folder
+			ngmodels.WithNamespaceUIDNotIn(f1.UID, f2.UID),
 		))
-	ruleStore.PutRule(context.Background(), noAccess2...)
+
+	ruleStore.PutRule(context.Background(), noAccessByFolder...)
+	// overwrite the folders visible to user because PutRule automatically creates folders.
+	ruleStore.Folders[orgID] = []*folder2.Folder{f1, f2}
 
 	srv := createService(ruleStore)
 
@@ -351,7 +354,7 @@ func TestExportRules(t *testing.T) {
 		{
 			title: "unauthorized if folders are not accessible",
 			params: url.Values{
-				"folderUid": []string{noAccess2[0].NamespaceUID},
+				"folderUid": []string{noAccessByFolder[0].NamespaceUID},
 			},
 			expectedStatus: 401,
 			expectedRules:  nil,

--- a/pkg/services/ngalert/api/api_ruler_export_test.go
+++ b/pkg/services/ngalert/api/api_ruler_export_test.go
@@ -260,7 +260,7 @@ func TestExportRules(t *testing.T) {
 		))
 
 	ruleStore.PutRule(context.Background(), noAccessByFolder...)
-	// overwrite the folders visible to user because PutRule automatically creates folders.
+	// overwrite the folders visible to user because PutRule automatically creates folders in production.
 	ruleStore.Folders[orgID] = []*folder2.Folder{f1, f2}
 
 	srv := createService(ruleStore)

--- a/pkg/services/ngalert/models/testing.go
+++ b/pkg/services/ngalert/models/testing.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"math/rand"
+	"slices"
 	"sync"
 	"time"
 
@@ -155,6 +156,18 @@ func WithUniqueOrgID() AlertRuleMutator {
 		}
 		orgs[orgID] = struct{}{}
 		rule.OrgID = orgID
+	}
+}
+
+// WithNamespaceUIDNotIn generates a random namespace UID if it is among excluded
+func WithNamespaceUIDNotIn(exclude ...string) AlertRuleMutator {
+	return func(rule *AlertRule) {
+		for {
+			if !slices.Contains(exclude, rule.NamespaceUID) {
+				return
+			}
+			rule.NamespaceUID = uuid.NewString()
+		}
 	}
 }
 


### PR DESCRIPTION
Fixes bug in test TestExportRules that causes the following test cases to fail:

TestExportRules/return_all_rules_user_has_access_to_when_no_parameters
TestExportRules/unauthorized_if_folders_are_not_accessible
TestExportRules/return_in_JSON_if_header_is_specified
TestExportRules/return_in_HCL_if_format_is_specified

This happens because the faked data store does some extra work to maintain folder list that is not done by production code.