### PR TITLE
CloudWatch Logs: Add labels to alert and expression queries

### DIFF
--- a/pkg/tsdb/cloudwatch/log_query.go
+++ b/pkg/tsdb/cloudwatch/log_query.go
@@ -205,14 +205,16 @@ func groupResults(results *data.Frame, groupingFieldNames []string, fromSyncQuer
 			if fromSyncQuery {
 				// remove grouping indices
 				newFrame.Fields = removeFieldsByIndex(newFrame.Fields, removeFieldIndices)
+				groupLabels := generateLabels(groupingFields, i)
 
 				// set the group key as the display name for sync queries
-				for i := 1; i < len(newFrame.Fields); i++ {
-					valueField := newFrame.Fields[i]
+				for j := 1; j < len(newFrame.Fields); j++ {
+					valueField := newFrame.Fields[j]
 					if valueField.Config == nil {
 						valueField.Config = &data.FieldConfig{}
 					}
 					valueField.Config.DisplayNameFromDS = groupKey
+					valueField.Labels = groupLabels
 				}
 			}
 
@@ -275,8 +277,19 @@ func generateGroupKey(fields []*data.Field, row int) string {
 			}
 		}
 	}
-
 	return groupKey
+}
+
+func generateLabels(fields []*data.Field, row int) data.Labels {
+	labels := data.Labels{}
+	for _, field := range fields {
+		if strField, ok := field.At(row).(*string); ok {
+			if strField != nil {
+				labels[field.Name] = *strField
+			}
+		}
+	}
+	return labels
 }
 
 func numericFieldToStringField(field *data.Field) (*data.Field, error) {

--- a/pkg/tsdb/cloudwatch/log_query_test.go
+++ b/pkg/tsdb/cloudwatch/log_query_test.go
@@ -583,7 +583,7 @@ func TestGroupingResultsWithFromSyncQueryTrue(t *testing.T) {
 			Name: "fakelog-a1",
 			Fields: []*data.Field{
 				data.NewField("@timestamp", data.Labels{}, []*time.Time{&timeA, &timeB}),
-				data.NewField("count", data.Labels{}, []*string{
+				data.NewField("count", data.Labels{"@log": "fakelog-a", "stream": "1"}, []*string{
 					aws.String("100"),
 					aws.String("57"),
 				}),
@@ -594,7 +594,7 @@ func TestGroupingResultsWithFromSyncQueryTrue(t *testing.T) {
 			Name: "fakelog-b1",
 			Fields: []*data.Field{
 				data.NewField("@timestamp", data.Labels{}, []*time.Time{&timeA, &timeB}),
-				data.NewField("count", data.Labels{}, []*string{
+				data.NewField("count", data.Labels{"@log": "fakelog-b", "stream": "1"}, []*string{
 					aws.String("150"),
 					aws.String("62"),
 				}),


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

Labels the grouped fields for sync CloudWatch Logs queries with the fields they were grouped on.

**Why do we need this feature?**

In order for CloudWatch Logs queries returning multiple time series to be useful in alerts, the different time series need to be labeled with their grouping information

**Who is this feature for?**

Users that want to use CloudWatch Logs queries with multiple time series in alerts.

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #63388 

**Special notes for your reviewer:**

Making this a bug because it should work, even if it never has.

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
