### PR TITLE
CloudWatch: Call query method from DataSourceWithBackend to support public dashboards

### DIFF
--- a/.betterer.results
+++ b/.betterer.results
@@ -5562,9 +5562,6 @@ exports[`better eslint`] = {
       [0, 0, 0, "Unexpected any. Specify a different type.", "0"],
       [0, 0, 0, "Unexpected any. Specify a different type.", "1"]
     ],
-    "public/app/plugins/datasource/cloudwatch/query-runner/CloudWatchLogsQueryRunner.ts:5381": [
-      [0, 0, 0, "Do not use any type assertions.", "0"]
-    ],
     "public/app/plugins/datasource/cloudwatch/types.ts:5381": [
       [0, 0, 0, "Unexpected any. Specify a different type.", "0"],
       [0, 0, 0, "Unexpected any. Specify a different type.", "1"],

--- a/packages/grafana-data/src/types/datasource.ts
+++ b/packages/grafana-data/src/types/datasource.ts
@@ -547,6 +547,7 @@ export interface DataQueryRequest<TQuery extends DataQuery = DataQuery> {
 
   cacheTimeout?: string | null;
   queryCachingTTL?: number | null;
+  skipQueryCache?: boolean;
   rangeRaw?: RawTimeRange;
   timeInfo?: string; // The query time description (blue text in the upper right)
   panelId?: number;

--- a/packages/grafana-runtime/src/utils/DataSourceWithBackend.test.ts
+++ b/packages/grafana-runtime/src/utils/DataSourceWithBackend.test.ts
@@ -350,6 +350,74 @@ describe('DataSourceWithBackend', () => {
     });
   });
 
+  test('check that queries can skip the query cache', () => {
+    const { mock, ds } = createMockDatasource();
+    ds.query({
+      maxDataPoints: 10,
+      intervalMs: 5000,
+      targets: [{ refId: 'A' }, { refId: 'B', datasource: { type: '__expr__' } }],
+      dashboardUID: 'dashA',
+      panelId: 123,
+      range: getDefaultTimeRange(),
+      queryGroupId: 'abc',
+      skipQueryCache: true,
+      requestId: 'request-123',
+      interval: '5s',
+      scopedVars: {},
+      timezone: '',
+      app: '',
+      startTime: 0,
+    });
+
+    const args = mock.calls[0][0];
+
+    expect(mock.calls.length).toBe(1);
+    expect(args).toMatchInlineSnapshot(`
+      {
+        "data": {
+          "from": "1697133600000",
+          "queries": [
+            {
+              "applyTemplateVariablesCalled": true,
+              "datasource": {
+                "type": "dummy",
+                "uid": "abc",
+              },
+              "datasourceId": 1234,
+              "filters": undefined,
+              "intervalMs": 5000,
+              "maxDataPoints": 10,
+              "queryCachingTTL": undefined,
+              "refId": "A",
+            },
+            {
+              "datasource": {
+                "name": "Expression",
+                "type": "__expr__",
+                "uid": "__expr__",
+              },
+              "refId": "B",
+            },
+          ],
+          "to": "1697155200000",
+        },
+        "headers": {
+          "X-Cache-Skip": "true",
+          "X-Dashboard-Uid": "dashA",
+          "X-Datasource-Uid": "abc",
+          "X-Grafana-From-Expr": "true",
+          "X-Panel-Id": "123",
+          "X-Plugin-Id": "dummy",
+          "X-Query-Group-Id": "abc",
+        },
+        "hideFromInspector": false,
+        "method": "POST",
+        "requestId": "request-123",
+        "url": "/api/ds/query?ds_type=dummy&expression=true&requestId=request-123",
+      }
+    `);
+  });
+
   describe('isExpressionReference', () => {
     test('check all possible expression references', () => {
       expect(isExpressionReference('__expr__')).toBeTruthy(); // New UID

--- a/packages/grafana-runtime/src/utils/DataSourceWithBackend.test.ts
+++ b/packages/grafana-runtime/src/utils/DataSourceWithBackend.test.ts
@@ -355,11 +355,10 @@ describe('DataSourceWithBackend', () => {
     ds.query({
       maxDataPoints: 10,
       intervalMs: 5000,
-      targets: [{ refId: 'A' }, { refId: 'B', datasource: { type: '__expr__' } }],
+      targets: [{ refId: 'A' }],
       dashboardUID: 'dashA',
       panelId: 123,
       range: getDefaultTimeRange(),
-      queryGroupId: 'abc',
       skipQueryCache: true,
       requestId: 'request-123',
       interval: '5s',
@@ -390,14 +389,6 @@ describe('DataSourceWithBackend', () => {
               "queryCachingTTL": undefined,
               "refId": "A",
             },
-            {
-              "datasource": {
-                "name": "Expression",
-                "type": "__expr__",
-                "uid": "__expr__",
-              },
-              "refId": "B",
-            },
           ],
           "to": "1697155200000",
         },
@@ -405,15 +396,13 @@ describe('DataSourceWithBackend', () => {
           "X-Cache-Skip": "true",
           "X-Dashboard-Uid": "dashA",
           "X-Datasource-Uid": "abc",
-          "X-Grafana-From-Expr": "true",
           "X-Panel-Id": "123",
           "X-Plugin-Id": "dummy",
-          "X-Query-Group-Id": "abc",
         },
         "hideFromInspector": false,
         "method": "POST",
         "requestId": "request-123",
-        "url": "/api/ds/query?ds_type=dummy&expression=true&requestId=request-123",
+        "url": "/api/ds/query?ds_type=dummy&requestId=request-123",
       }
     `);
   });

--- a/packages/grafana-runtime/src/utils/DataSourceWithBackend.ts
+++ b/packages/grafana-runtime/src/utils/DataSourceWithBackend.ts
@@ -82,6 +82,7 @@ enum PluginRequestHeaders {
   PanelID = 'X-Panel-Id', // mainly useful for debugging slow queries
   QueryGroupID = 'X-Query-Group-Id', // mainly useful to find related queries with query splitting
   FromExpression = 'X-Grafana-From-Expr', // used by datasources to identify expression queries
+  SkipQueryCache = 'X-Cache-Skip', // used by datasources to skip the query cache
 }
 
 /**
@@ -227,6 +228,9 @@ class DataSourceWithBackend<
     }
     if (request.queryGroupId) {
       headers[PluginRequestHeaders.QueryGroupID] = `${request.queryGroupId}`;
+    }
+    if (request.skipQueryCache) {
+      headers[PluginRequestHeaders.SkipQueryCache] = 'true';
     }
     return getBackendSrv()
       .fetch<BackendDataSourceResponse>({

--- a/pkg/tsdb/cloudwatch/cloudwatch.go
+++ b/pkg/tsdb/cloudwatch/cloudwatch.go
@@ -170,7 +170,7 @@ func (e *cloudWatchExecutor) QueryData(ctx context.Context, req *backend.QueryDa
 
 	_, fromAlert := req.Headers[ngalertmodels.FromAlertHeaderName]
 	fromExpression := req.GetHTTPHeader(query.HeaderFromExpression) != ""
-	isSyncLogQuery := (fromAlert || fromExpression) && model.QueryMode == logsQueryMode
+	isSyncLogQuery := (fromAlert || fromExpression) && model.QueryMode == logsQueryMode || (model.Type == "" && model.QueryMode == logsQueryMode)
 	if isSyncLogQuery {
 		return executeSyncLogQuery(ctx, e, req)
 	}

--- a/pkg/tsdb/cloudwatch/cloudwatch.go
+++ b/pkg/tsdb/cloudwatch/cloudwatch.go
@@ -170,7 +170,7 @@ func (e *cloudWatchExecutor) QueryData(ctx context.Context, req *backend.QueryDa
 
 	_, fromAlert := req.Headers[ngalertmodels.FromAlertHeaderName]
 	fromExpression := req.GetHTTPHeader(query.HeaderFromExpression) != ""
-	isSyncLogQuery := (fromAlert || fromExpression) && model.QueryMode == logsQueryMode || (model.Type == "" && model.QueryMode == logsQueryMode)
+	isSyncLogQuery := ((fromAlert || fromExpression) && model.QueryMode == logsQueryMode) || (model.Type == "" && model.QueryMode == logsQueryMode)
 	if isSyncLogQuery {
 		return executeSyncLogQuery(ctx, e, req)
 	}

--- a/pkg/tsdb/cloudwatch/log_sync_query_test.go
+++ b/pkg/tsdb/cloudwatch/log_sync_query_test.go
@@ -160,6 +160,9 @@ func Test_executeSyncLogQuery(t *testing.T) {
 			syncCalled = true
 			return nil, nil
 		}
+		t.Cleanup(func() {
+			executeSyncLogQuery = origExecuteSyncLogQuery
+		})
 
 		cli = fakeCWLogsClient{queryResults: cloudwatchlogs.GetQueryResultsOutput{Status: aws.String("Complete")}}
 		im := datasource.NewInstanceManager(func(ctx context.Context, s backend.DataSourceInstanceSettings) (instancemgmt.Instance, error) {
@@ -184,7 +187,6 @@ func Test_executeSyncLogQuery(t *testing.T) {
 
 		assert.NoError(t, err)
 		assert.Equal(t, true, syncCalled)
-		executeSyncLogQuery = origExecuteSyncLogQuery
 	})
 }
 func Test_executeSyncLogQuery_handles_RefId_from_input_queries(t *testing.T) {

--- a/public/app/plugins/datasource/cloudwatch/__mocks__/AnnotationQueryRunner.ts
+++ b/public/app/plugins/datasource/cloudwatch/__mocks__/AnnotationQueryRunner.ts
@@ -1,7 +1,6 @@
 import { of } from 'rxjs';
 
 import { CustomVariableModel, DataQueryRequest } from '@grafana/data';
-import { getBackendSrv, setBackendSrv } from '@grafana/runtime';
 import { TemplateSrv } from 'app/features/templating/template_srv';
 
 import { CloudWatchAnnotationQueryRunner } from '../query-runner/CloudWatchAnnotationQueryRunner';
@@ -16,13 +15,8 @@ export function setupMockedAnnotationQueryRunner({ variables }: { variables?: Cu
     templateService = setupMockedTemplateService(variables);
   }
 
-  const runner = new CloudWatchAnnotationQueryRunner(CloudWatchSettings, templateService);
-  const fetchMock = jest.fn().mockReturnValue(of({}));
-
-  setBackendSrv({
-    ...getBackendSrv(),
-    fetch: fetchMock,
-  });
+  const queryMock = jest.fn().mockReturnValue(of({}));
+  const runner = new CloudWatchAnnotationQueryRunner(CloudWatchSettings, templateService, queryMock);
 
   const request: DataQueryRequest<CloudWatchQuery> = {
     range: TimeRangeMock,
@@ -37,5 +31,5 @@ export function setupMockedAnnotationQueryRunner({ variables }: { variables?: Cu
     startTime: 0,
   };
 
-  return { runner, fetchMock, templateService, request, timeRange: TimeRangeMock };
+  return { runner, queryMock, templateService, request, timeRange: TimeRangeMock };
 }

--- a/public/app/plugins/datasource/cloudwatch/__mocks__/CloudWatchDataSource.ts
+++ b/public/app/plugins/datasource/cloudwatch/__mocks__/CloudWatchDataSource.ts
@@ -8,13 +8,16 @@ import {
   PluginType,
   VariableHide,
 } from '@grafana/data';
-import { getBackendSrv, setBackendSrv } from '@grafana/runtime';
+import { getBackendSrv, setBackendSrv, DataSourceWithBackend } from '@grafana/runtime';
 import { getTimeSrv } from 'app/features/dashboard/services/TimeSrv';
 import { TemplateSrv } from 'app/features/templating/template_srv';
 import { initialCustomVariableModelState } from 'app/features/variables/custom/reducer';
 
 import { CloudWatchDatasource } from '../datasource';
 import { CloudWatchJsonData } from '../types';
+
+const queryMock = jest.fn().mockReturnValue(of({ data: [] }));
+jest.spyOn(DataSourceWithBackend.prototype, 'query').mockImplementation((args) => queryMock(args));
 
 export function setupMockedTemplateService(variables: CustomVariableModel[]) {
   const templateService = new TemplateSrv();
@@ -93,7 +96,7 @@ export function setupMockedDataSource({
     get: getMock,
   });
 
-  return { datasource, fetchMock, templateService, timeSrv };
+  return { datasource, fetchMock, queryMock, templateService, timeSrv };
 }
 
 export const metricVariable: CustomVariableModel = {

--- a/public/app/plugins/datasource/cloudwatch/__mocks__/LogsQueryRunner.ts
+++ b/public/app/plugins/datasource/cloudwatch/__mocks__/LogsQueryRunner.ts
@@ -1,7 +1,7 @@
 import { of } from 'rxjs';
 
 import { CustomVariableModel, DataFrame, DataSourceInstanceSettings } from '@grafana/data';
-import { BackendDataSourceResponse, getBackendSrv, setBackendSrv } from '@grafana/runtime';
+import { BackendDataSourceResponse, toDataQueryResponse } from '@grafana/runtime';
 import { getTimeSrv, TimeSrv } from 'app/features/dashboard/services/TimeSrv';
 import { TemplateSrv } from 'app/features/templating/template_srv';
 
@@ -33,14 +33,10 @@ export function setupMockedLogsQueryRunner({
     }
   }
 
-  const runner = new CloudWatchLogsQueryRunner(settings, templateService, timeSrv);
-  const fetchMock = jest.fn().mockReturnValue(of({ data }));
-  setBackendSrv({
-    ...getBackendSrv(),
-    fetch: fetchMock,
-  });
+  const queryMock = jest.fn().mockReturnValue(of(toDataQueryResponse({ data })));
+  const runner = new CloudWatchLogsQueryRunner(settings, templateService, timeSrv, queryMock);
 
-  return { runner, fetchMock, templateService };
+  return { runner, queryMock, templateService };
 }
 
 export function genMockFrames(numResponses: number): DataFrame[] {

--- a/public/app/plugins/datasource/cloudwatch/__mocks__/MetricsQueryRunner.ts
+++ b/public/app/plugins/datasource/cloudwatch/__mocks__/MetricsQueryRunner.ts
@@ -51,5 +51,5 @@ export function setupMockedMetricsQueryRunner({
     startTime: 0,
   };
 
-  return { runner, queryMock: queryMock, templateService, instanceSettings, request, timeRange: TimeRangeMock };
+  return { runner, queryMock, templateService, instanceSettings, request, timeRange: TimeRangeMock };
 }

--- a/public/app/plugins/datasource/cloudwatch/__mocks__/logsTestContext.ts
+++ b/public/app/plugins/datasource/cloudwatch/__mocks__/logsTestContext.ts
@@ -2,8 +2,8 @@ import { Observable, of } from 'rxjs';
 
 import {
   DataFrame,
+  createDataFrame,
   dataFrameToJSON,
-  MutableDataFrame,
   DataSourceInstanceSettings,
   DataSourceJsonData,
   DataSourceRef,
@@ -14,7 +14,7 @@ import {
   DataQueryResponse,
   TestDataSourceResponse,
 } from '@grafana/data';
-import { GetDataSourceListFilters, setDataSourceSrv } from '@grafana/runtime';
+import { GetDataSourceListFilters, setDataSourceSrv, toDataQueryResponse } from '@grafana/runtime';
 
 import { CloudWatchLogsQueryStatus } from '../types';
 
@@ -22,15 +22,15 @@ import { meta, setupMockedDataSource } from './CloudWatchDataSource';
 
 export function setupForLogs() {
   function envelope(frame: DataFrame) {
-    return { data: { results: { a: { refId: 'a', frames: [dataFrameToJSON(frame)] } } } };
+    return toDataQueryResponse({ data: { results: { a: { refId: 'a', frames: [dataFrameToJSON(frame)] } } } });
   }
 
-  const { datasource, fetchMock, timeSrv } = setupMockedDataSource();
+  const { datasource, queryMock, timeSrv } = setupMockedDataSource();
 
-  const startQueryFrame = new MutableDataFrame({ fields: [{ name: 'queryId', values: ['queryid'] }] });
-  fetchMock.mockReturnValueOnce(of(envelope(startQueryFrame)));
+  const startQueryFrame: DataFrame = createDataFrame({ fields: [{ name: 'queryId', values: ['queryid'] }] });
+  queryMock.mockReturnValueOnce(of(envelope(startQueryFrame)));
 
-  const logsFrame = new MutableDataFrame({
+  const logsFrame: DataFrame = createDataFrame({
     fields: [
       {
         name: '@message',
@@ -48,7 +48,7 @@ export function setupForLogs() {
     meta: { custom: { Status: CloudWatchLogsQueryStatus.Complete } },
   });
 
-  fetchMock.mockReturnValueOnce(of(envelope(logsFrame)));
+  queryMock.mockReturnValueOnce(of(envelope(logsFrame)));
 
   setDataSourceSrv({
     async get() {
@@ -89,5 +89,5 @@ export function setupForLogs() {
     },
   });
 
-  return { datasource, fetchMock, timeSrv };
+  return { datasource, queryMock, timeSrv };
 }

--- a/public/app/plugins/datasource/cloudwatch/datasource.test.ts
+++ b/public/app/plugins/datasource/cloudwatch/datasource.test.ts
@@ -28,7 +28,7 @@ describe('datasource', () => {
   });
   describe('query', () => {
     it('should not run a query if log groups is not specified', async () => {
-      const { datasource, fetchMock } = setupMockedDataSource();
+      const { datasource, queryMock } = setupMockedDataSource();
       await lastValueFrom(
         datasource.query({
           targets: [
@@ -59,8 +59,8 @@ describe('datasource', () => {
         })
       );
 
-      expect(fetchMock.mock.calls[0][0].data.queries).toHaveLength(1);
-      expect(fetchMock.mock.calls[0][0].data.queries[0]).toMatchObject({
+      expect(queryMock.mock.calls[0][0].targets).toHaveLength(1);
+      expect(queryMock.mock.calls[0][0].targets[0]).toMatchObject({
         queryString: 'some query string',
         logGroupNames: ['/some/group'],
         region: 'us-west-1',
@@ -68,7 +68,7 @@ describe('datasource', () => {
     });
 
     it('should not run a query if query expression is not specified', async () => {
-      const { datasource, fetchMock } = setupMockedDataSource();
+      const { datasource, queryMock } = setupMockedDataSource();
       await lastValueFrom(
         datasource.query({
           targets: [
@@ -99,8 +99,8 @@ describe('datasource', () => {
         })
       );
 
-      expect(fetchMock.mock.calls[0][0].data.queries).toHaveLength(1);
-      expect(fetchMock.mock.calls[0][0].data.queries[0]).toMatchObject({
+      expect(queryMock.mock.calls[0][0].targets).toHaveLength(1);
+      expect(queryMock.mock.calls[0][0].targets[0]).toMatchObject({
         queryString: 'some query string',
         logGroupNames: ['/some/group'],
         region: 'us-west-1',
@@ -141,7 +141,7 @@ describe('datasource', () => {
     });
 
     it('should interpolate variables in the query', async () => {
-      const { datasource, fetchMock } = setupMockedDataSource({
+      const { datasource, queryMock } = setupMockedDataSource({
         variables: [fieldsVariable, regionVariable],
       });
       await lastValueFrom(
@@ -168,7 +168,7 @@ describe('datasource', () => {
           })
           .pipe(toArray())
       );
-      expect(fetchMock.mock.calls[0][0].data.queries[0]).toMatchObject({
+      expect(queryMock.mock.calls[0][0].targets[0]).toMatchObject({
         queryString: 'fields templatedField',
         logGroupNames: ['/some/group'],
         region: 'templatedRegion',
@@ -176,7 +176,7 @@ describe('datasource', () => {
     });
 
     it('should interpolate multi-value template variable for log group names in the query', async () => {
-      const { datasource, fetchMock } = setupMockedDataSource({
+      const { datasource, queryMock } = setupMockedDataSource({
         variables: [fieldsVariable, logGroupNamesVariable, regionVariable],
         mockGetVariableName: false,
       });
@@ -204,7 +204,7 @@ describe('datasource', () => {
           })
           .pipe(toArray())
       );
-      expect(fetchMock.mock.calls[0][0].data.queries[0]).toMatchObject({
+      expect(queryMock.mock.calls[0][0].targets[0]).toMatchObject({
         queryString: 'fields templatedField',
         logGroupNames: ['templatedGroup-1', 'templatedGroup-2'],
         region: 'templatedRegion',

--- a/public/app/plugins/datasource/cloudwatch/datasource.ts
+++ b/public/app/plugins/datasource/cloudwatch/datasource.ts
@@ -66,10 +66,19 @@ export class CloudWatchDatasource
     this.languageProvider = new CloudWatchLogsLanguageProvider(this);
     this.sqlCompletionItemProvider = new SQLCompletionItemProvider(this.resources, this.templateSrv);
     this.metricMathCompletionItemProvider = new MetricMathCompletionItemProvider(this.resources, this.templateSrv);
-    this.metricsQueryRunner = new CloudWatchMetricsQueryRunner(instanceSettings, templateSrv);
+    this.metricsQueryRunner = new CloudWatchMetricsQueryRunner(instanceSettings, templateSrv, super.query.bind(this));
     this.logsCompletionItemProvider = new LogsCompletionItemProvider(this.resources, this.templateSrv);
-    this.logsQueryRunner = new CloudWatchLogsQueryRunner(instanceSettings, templateSrv, timeSrv);
-    this.annotationQueryRunner = new CloudWatchAnnotationQueryRunner(instanceSettings, templateSrv);
+    this.logsQueryRunner = new CloudWatchLogsQueryRunner(
+      instanceSettings,
+      templateSrv,
+      timeSrv,
+      super.query.bind(this)
+    );
+    this.annotationQueryRunner = new CloudWatchAnnotationQueryRunner(
+      instanceSettings,
+      templateSrv,
+      super.query.bind(this)
+    );
     this.variables = new CloudWatchVariableSupport(this.resources);
     this.annotations = CloudWatchAnnotationSupport;
     this.defaultLogGroups = instanceSettings.jsonData.defaultLogGroups;

--- a/public/app/plugins/datasource/cloudwatch/query-runner/CloudWatchAnnotationQueryRunner.test.ts
+++ b/public/app/plugins/datasource/cloudwatch/query-runner/CloudWatchAnnotationQueryRunner.test.ts
@@ -22,11 +22,11 @@ describe('CloudWatchAnnotationQueryRunner', () => {
   ];
 
   it('should issue the correct query', async () => {
-    const { runner, fetchMock, request } = setupMockedAnnotationQueryRunner({
+    const { runner, queryMock, request } = setupMockedAnnotationQueryRunner({
       variables: [namespaceVariable, regionVariable],
     });
     await expect(runner.handleAnnotationQuery(queries, request)).toEmitValuesWith(() => {
-      expect(fetchMock.mock.calls[0][0].data.queries[0]).toMatchObject(
+      expect(queryMock.mock.calls[0][0].targets[0]).toMatchObject(
         expect.objectContaining({
           region: regionVariable.current.value,
           namespace: namespaceVariable.current.value,

--- a/public/app/plugins/datasource/cloudwatch/query-runner/CloudWatchAnnotationQueryRunner.ts
+++ b/public/app/plugins/datasource/cloudwatch/query-runner/CloudWatchAnnotationQueryRunner.ts
@@ -1,7 +1,6 @@
-import { map, Observable } from 'rxjs';
+import { Observable } from 'rxjs';
 
 import { DataQueryRequest, DataQueryResponse, DataSourceInstanceSettings } from '@grafana/data';
-import { toDataQueryResponse } from '@grafana/runtime';
 import { TemplateSrv } from 'app/features/templating/template_srv';
 
 import { CloudWatchAnnotationQuery, CloudWatchJsonData, CloudWatchQuery } from '../types';
@@ -10,18 +9,21 @@ import { CloudWatchRequest } from './CloudWatchRequest';
 
 // This class handles execution of CloudWatch annotation queries
 export class CloudWatchAnnotationQueryRunner extends CloudWatchRequest {
-  constructor(instanceSettings: DataSourceInstanceSettings<CloudWatchJsonData>, templateSrv: TemplateSrv) {
-    super(instanceSettings, templateSrv);
+  constructor(
+    instanceSettings: DataSourceInstanceSettings<CloudWatchJsonData>,
+    templateSrv: TemplateSrv,
+    queryFn: (request: DataQueryRequest<CloudWatchQuery>) => Observable<DataQueryResponse>
+  ) {
+    super(instanceSettings, templateSrv, queryFn);
   }
 
   handleAnnotationQuery(
     queries: CloudWatchAnnotationQuery[],
     options: DataQueryRequest<CloudWatchQuery>
   ): Observable<DataQueryResponse> {
-    return this.awsRequest(this.dsQueryEndpoint, {
-      from: options.range.from.valueOf().toString(),
-      to: options.range.to.valueOf().toString(),
-      queries: queries.map((query) => ({
+    return this.query({
+      ...options,
+      targets: queries.map((query) => ({
         ...query,
         statistic: this.templateSrv.replace(query.statistic),
         region: this.templateSrv.replace(this.getActualRegion(query.region)),
@@ -34,11 +36,6 @@ export class CloudWatchAnnotationQueryRunner extends CloudWatchRequest {
         type: 'annotationQuery',
         datasource: this.ref,
       })),
-    }).pipe(
-      map((r) => {
-        const frames = toDataQueryResponse(r).data;
-        return { data: frames };
-      })
-    );
+    });
   }
 }

--- a/public/app/plugins/datasource/cloudwatch/query-runner/CloudWatchLogsQueryRunner.ts
+++ b/public/app/plugins/datasource/cloudwatch/query-runner/CloudWatchLogsQueryRunner.ts
@@ -102,15 +102,7 @@ export class CloudWatchLogsQueryRunner extends CloudWatchRequest {
       return of({
         data: frames,
         key: 'test-key',
-        state: frames.every((dataFrame) =>
-          [
-            CloudWatchLogsQueryStatus.Complete,
-            CloudWatchLogsQueryStatus.Cancelled,
-            CloudWatchLogsQueryStatus.Failed,
-          ].includes(dataFrame.meta?.custom?.['Status'])
-        )
-          ? LoadingState.Done
-          : LoadingState.Loading,
+        state: LoadingState.Done,
       });
     }
 

--- a/public/app/plugins/datasource/cloudwatch/query-runner/CloudWatchLogsQueryRunner.ts
+++ b/public/app/plugins/datasource/cloudwatch/query-runner/CloudWatchLogsQueryRunner.ts
@@ -8,6 +8,7 @@ import {
   map,
   mergeMap,
   Observable,
+  of,
   repeat,
   scan,
   share,
@@ -29,7 +30,7 @@ import {
   LogRowModel,
   rangeUtil,
 } from '@grafana/data';
-import { BackendDataSourceResponse, config, FetchError, FetchResponse, toDataQueryResponse } from '@grafana/runtime';
+import { config, FetchError } from '@grafana/runtime';
 import { TimeSrv } from 'app/features/dashboard/services/TimeSrv';
 import { TemplateSrv } from 'app/features/templating/template_srv';
 
@@ -63,13 +64,73 @@ export class CloudWatchLogsQueryRunner extends CloudWatchRequest {
   constructor(
     instanceSettings: DataSourceInstanceSettings<CloudWatchJsonData>,
     templateSrv: TemplateSrv,
-    private readonly timeSrv: TimeSrv
+    private readonly timeSrv: TimeSrv,
+    queryFn: (request: DataQueryRequest<CloudWatchQuery>) => Observable<DataQueryResponse>
   ) {
-    super(instanceSettings, templateSrv);
+    super(instanceSettings, templateSrv, queryFn);
 
     this.tracingDataSourceUid = instanceSettings.jsonData.tracingDatasourceUid;
     this.logsTimeout = instanceSettings.jsonData.logsTimeout || '30m';
   }
+
+  /**
+   * Check if the query is complete and returns results if it is. Otherwise it will poll for results.
+   */
+  getQueryResults = ({
+    frames,
+    error,
+    logQueries,
+    timeoutFunc,
+  }: {
+    frames: DataFrame[];
+    logQueries: CloudWatchLogsQuery[];
+    timeoutFunc: () => boolean;
+    error?: DataQueryError;
+  }) => {
+    // If every frame is already finished, we can return the result as the
+    // query was run synchronously. Otherwise, we return `this.logsQuery`
+    // which will poll for the results.
+    if (
+      frames.every((frame) =>
+        [
+          CloudWatchLogsQueryStatus.Complete,
+          CloudWatchLogsQueryStatus.Cancelled,
+          CloudWatchLogsQueryStatus.Failed,
+        ].includes(frame.meta?.custom?.['Status'])
+      )
+    ) {
+      return of({
+        data: frames,
+        key: 'test-key',
+        state: frames.every((dataFrame) =>
+          [
+            CloudWatchLogsQueryStatus.Complete,
+            CloudWatchLogsQueryStatus.Cancelled,
+            CloudWatchLogsQueryStatus.Failed,
+          ].includes(dataFrame.meta?.custom?.['Status'])
+        )
+          ? LoadingState.Done
+          : LoadingState.Loading,
+      });
+    }
+
+    return this.logsQuery(
+      frames.map((dataFrame) => ({
+        queryId: dataFrame.fields[0].values[0],
+        region: dataFrame.meta?.custom?.['Region'] ?? 'default',
+        refId: dataFrame.refId!,
+        statsGroups: logQueries.find((target) => target.refId === dataFrame.refId)?.statsGroups,
+      })),
+      timeoutFunc
+    ).pipe(
+      map((response: DataQueryResponse) => {
+        if (!response.error && error) {
+          response.error = error;
+        }
+        return response;
+      })
+    );
+  };
 
   /**
    * Handle log query. The log query works by starting the query on the CloudWatch and then periodically polling for
@@ -118,30 +179,14 @@ export class CloudWatchLogsQueryRunner extends CloudWatchRequest {
     };
 
     return runWithRetry(
-      (targets: StartQueryRequest[]) => {
+      (targets) => {
         return this.makeLogActionRequest('StartQuery', targets, options);
       },
       startQueryRequests,
       timeoutFunc
     ).pipe(
       mergeMap(({ frames, error }: { frames: DataFrame[]; error?: DataQueryError }) =>
-        // This queries for the results
-        this.logsQuery(
-          frames.map((dataFrame) => ({
-            queryId: dataFrame.fields[0].values[0],
-            region: dataFrame.meta?.custom?.['Region'] ?? 'default',
-            refId: dataFrame.refId!,
-            statsGroups: logQueries.find((target) => target.refId === dataFrame.refId)?.statsGroups,
-          })),
-          timeoutFunc
-        ).pipe(
-          map((response: DataQueryResponse) => {
-            if (!response.error && error) {
-              response.error = error;
-            }
-            return response;
-          })
-        )
+        this.getQueryResults({ frames, logQueries, timeoutFunc, error })
       ),
       mergeMap((dataQueryResponse) => {
         return from(
@@ -277,32 +322,32 @@ export class CloudWatchLogsQueryRunner extends CloudWatchRequest {
   ): Observable<DataFrame[]> {
     const range = options?.range || this.timeSrv.timeRange();
 
-    const requestParams = {
-      from: range.from.valueOf().toString(),
-      to: range.to.valueOf().toString(),
-      queries: queryParams.map((param: CloudWatchLogsRequest) => ({
-        // eslint-ignore-next-line
-        refId: (param as StartQueryRequest).refId || 'A',
+    const requestParams: DataQueryRequest<CloudWatchLogsQuery> = {
+      ...options,
+      range,
+      skipQueryCache: true,
+      requestId: options?.requestId || '', // dummy
+      interval: options?.interval || '', // dummy
+      intervalMs: options?.intervalMs || 1, // dummy
+      scopedVars: options?.scopedVars || {}, // dummy
+      timezone: options?.timezone || '', // dummy
+      app: options?.app || '', // dummy
+      startTime: options?.startTime || 0, // dummy
+      targets: queryParams.map((param) => ({
+        ...param,
+        id: '',
+        queryMode: 'Logs',
+        refId: param.refId || 'A',
         intervalMs: 1, // dummy
         maxDataPoints: 1, // dummy
         datasource: this.ref,
         type: 'logAction',
         subtype: subtype,
-        ...param,
       })),
     };
 
-    const resultsToDataFrames = (
-      val:
-        | { data: BackendDataSourceResponse | undefined }
-        | FetchResponse<BackendDataSourceResponse | undefined>
-        | DataQueryError
-    ): DataFrame[] => toDataQueryResponse(val).data || [];
-
-    return this.awsRequest(this.dsQueryEndpoint, requestParams, {
-      'X-Cache-Skip': 'true',
-    }).pipe(
-      map((response) => resultsToDataFrames(response)),
+    return this.query(requestParams).pipe(
+      map((response) => response.data),
       catchError((err: FetchError) => {
         if (config.featureToggles.datasourceQueryMultiStatus && err.status === 207) {
           throw err;
@@ -347,9 +392,10 @@ export class CloudWatchLogsQueryRunner extends CloudWatchRequest {
     }
 
     const requestParams: GetLogEventsRequest = {
+      refId: query?.refId || 'A', // dummy
       limit,
       startFromHead: direction !== LogRowContextQueryDirection.Backward,
-      region: query?.region,
+      region: query?.region || '',
       logGroupName: parseLogGroupName(logField!.values[row.rowIndex]),
       logStreamName: logStreamField!.values[row.rowIndex],
     };

--- a/public/app/plugins/datasource/cloudwatch/query-runner/CloudWatchMetricsQueryRunner.test.ts
+++ b/public/app/plugins/datasource/cloudwatch/query-runner/CloudWatchMetricsQueryRunner.test.ts
@@ -16,13 +16,13 @@ import {
   accountIdVariable,
 } from '../__mocks__/CloudWatchDataSource';
 import { setupMockedMetricsQueryRunner } from '../__mocks__/MetricsQueryRunner';
-import { validMetricSearchBuilderQuery } from '../__mocks__/queries';
+import { validMetricSearchBuilderQuery, validMetricSearchCodeQuery } from '../__mocks__/queries';
 import { MetricQueryType, MetricEditorMode, CloudWatchMetricsQuery, DataQueryError } from '../types';
 
 describe('CloudWatchMetricsQueryRunner', () => {
   describe('performTimeSeriesQuery', () => {
     it('should return the same length of data as result', async () => {
-      const { runner, timeRange } = setupMockedMetricsQueryRunner({
+      const { runner, timeRange, request } = setupMockedMetricsQueryRunner({
         data: {
           results: {
             a: { refId: 'a', series: [{ target: 'cpu', datapoints: [[1, 1]] }] },
@@ -33,12 +33,9 @@ describe('CloudWatchMetricsQueryRunner', () => {
 
       const observable = runner.performTimeSeriesQuery(
         {
-          queries: [
-            { datasourceId: 1, refId: 'a' },
-            { datasourceId: 1, refId: 'b' },
-          ],
-          from: '',
-          to: '',
+          ...request,
+          targets: [validMetricSearchCodeQuery, validMetricSearchCodeQuery],
+          range: timeRange,
         },
         timeRange
       );
@@ -50,7 +47,7 @@ describe('CloudWatchMetricsQueryRunner', () => {
     });
 
     it('sets fields.config.interval based on period', async () => {
-      const { runner, timeRange } = setupMockedMetricsQueryRunner({
+      const { runner, timeRange, request } = setupMockedMetricsQueryRunner({
         data: {
           results: {
             a: {
@@ -67,9 +64,9 @@ describe('CloudWatchMetricsQueryRunner', () => {
 
       const observable = runner.performTimeSeriesQuery(
         {
-          queries: [{ datasourceId: 1, refId: 'a' }],
-          from: '',
-          to: '',
+          ...request,
+          targets: [validMetricSearchCodeQuery, validMetricSearchCodeQuery],
+          range: timeRange,
         },
         timeRange
       );
@@ -125,10 +122,10 @@ describe('CloudWatchMetricsQueryRunner', () => {
       };
 
       it('should generate the correct query', async () => {
-        const { runner, fetchMock, request } = setupMockedMetricsQueryRunner({ data });
+        const { runner, queryMock, request } = setupMockedMetricsQueryRunner({ data });
 
         await expect(runner.handleMetricQueries(queries, request)).toEmitValuesWith(() => {
-          expect(fetchMock.mock.calls[0][0].data.queries).toMatchObject(
+          expect(queryMock.mock.calls[0][0].targets).toMatchObject(
             expect.arrayContaining([
               expect.objectContaining({
                 namespace: queries[0].namespace,
@@ -161,13 +158,13 @@ describe('CloudWatchMetricsQueryRunner', () => {
           },
         ];
 
-        const { runner, fetchMock, request } = setupMockedMetricsQueryRunner({
+        const { runner, queryMock, request } = setupMockedMetricsQueryRunner({
           data,
           variables: [periodIntervalVariable],
         });
 
         await expect(runner.handleMetricQueries(queries, request)).toEmitValuesWith(() => {
-          expect(fetchMock.mock.calls[0][0].data.queries[0].period).toEqual('600');
+          expect(queryMock.mock.calls[0][0].targets[0].period).toEqual('600');
         });
       });
 
@@ -267,7 +264,7 @@ describe('CloudWatchMetricsQueryRunner', () => {
         });
 
         it('should display one alert error message per region+datasource combination', async () => {
-          const { runner, request } = setupMockedMetricsQueryRunner({ data: backendErrorResponse, throws: true });
+          const { runner, request } = setupMockedMetricsQueryRunner({ errorResponse: backendErrorResponse });
           const memoizedDebounceSpy = jest.spyOn(runner, 'debouncedAlert');
 
           await expect(runner.handleMetricQueries(queries, request)).toEmitValuesWith(() => {
@@ -360,7 +357,7 @@ describe('CloudWatchMetricsQueryRunner', () => {
     });
 
     it('interpolates variables correctly', async () => {
-      const { runner, fetchMock, request } = setupMockedMetricsQueryRunner({
+      const { runner, queryMock, request } = setupMockedMetricsQueryRunner({
         variables: [namespaceVariable, metricVariable, labelsVariable, limitVariable],
       });
       runner.handleMetricQueries(
@@ -384,15 +381,13 @@ describe('CloudWatchMetricsQueryRunner', () => {
         ],
         request
       );
-      expect(fetchMock).toHaveBeenCalledWith(
+      expect(queryMock).toHaveBeenCalledWith(
         expect.objectContaining({
-          data: expect.objectContaining({
-            queries: expect.arrayContaining([
-              expect.objectContaining({
-                sqlExpression: `SELECT SUM(CPUUtilization) FROM "AWS/EC2" GROUP BY InstanceId,InstanceType LIMIT 100`,
-              }),
-            ]),
-          }),
+          targets: expect.arrayContaining([
+            expect.objectContaining({
+              sqlExpression: `SELECT SUM(CPUUtilization) FROM "AWS/EC2" GROUP BY InstanceId,InstanceType LIMIT 100`,
+            }),
+          ]),
         })
       );
     });
@@ -464,7 +459,7 @@ describe('CloudWatchMetricsQueryRunner', () => {
       };
 
       it('should generate the correct query for single template variable', async () => {
-        const { runner, fetchMock, request } = setupMockedMetricsQueryRunner({ variables: [var1, var2, var3, var4] });
+        const { runner, queryMock, request } = setupMockedMetricsQueryRunner({ variables: [var1, var2, var3, var4] });
         const queries: CloudWatchMetricsQuery[] = [
           {
             id: '',
@@ -483,12 +478,12 @@ describe('CloudWatchMetricsQueryRunner', () => {
           },
         ];
         await expect(runner.handleMetricQueries(queries, request)).toEmitValuesWith(() => {
-          expect(fetchMock.mock.calls[0][0].data.queries[0].dimensions['dim2']).toStrictEqual(['var2-foo']);
+          expect(queryMock.mock.calls[0][0].targets[0].dimensions['dim2']).toStrictEqual(['var2-foo']);
         });
       });
 
       it('should generate the correct query in the case of one multiple template variables', async () => {
-        const { runner, fetchMock, request } = setupMockedMetricsQueryRunner({ variables: [var1, var2, var3, var4] });
+        const { runner, queryMock, request } = setupMockedMetricsQueryRunner({ variables: [var1, var2, var3, var4] });
         const queries: CloudWatchMetricsQuery[] = [
           {
             id: '',
@@ -518,14 +513,14 @@ describe('CloudWatchMetricsQueryRunner', () => {
             },
           })
         ).toEmitValuesWith(() => {
-          expect(fetchMock.mock.calls[0][0].data.queries[0].dimensions['dim1']).toStrictEqual(['var1-foo']);
-          expect(fetchMock.mock.calls[0][0].data.queries[0].dimensions['dim2']).toStrictEqual(['var2-foo']);
-          expect(fetchMock.mock.calls[0][0].data.queries[0].dimensions['dim3']).toStrictEqual(['var3-foo', 'var3-baz']);
+          expect(queryMock.mock.calls[0][0].targets[0].dimensions['dim1']).toStrictEqual(['var1-foo']);
+          expect(queryMock.mock.calls[0][0].targets[0].dimensions['dim2']).toStrictEqual(['var2-foo']);
+          expect(queryMock.mock.calls[0][0].targets[0].dimensions['dim3']).toStrictEqual(['var3-foo', 'var3-baz']);
         });
       });
 
       it('should generate the correct query in the case of multiple multi template variables', async () => {
-        const { runner, fetchMock, request } = setupMockedMetricsQueryRunner({ variables: [var1, var2, var3, var4] });
+        const { runner, queryMock, request } = setupMockedMetricsQueryRunner({ variables: [var1, var2, var3, var4] });
         const queries: CloudWatchMetricsQuery[] = [
           {
             id: '',
@@ -547,14 +542,14 @@ describe('CloudWatchMetricsQueryRunner', () => {
         ];
 
         await expect(runner.handleMetricQueries(queries, request)).toEmitValuesWith(() => {
-          expect(fetchMock.mock.calls[0][0].data.queries[0].dimensions['dim1']).toStrictEqual(['var1-foo']);
-          expect(fetchMock.mock.calls[0][0].data.queries[0].dimensions['dim3']).toStrictEqual(['var3-foo', 'var3-baz']);
-          expect(fetchMock.mock.calls[0][0].data.queries[0].dimensions['dim4']).toStrictEqual(['var4-foo', 'var4-baz']);
+          expect(queryMock.mock.calls[0][0].targets[0].dimensions['dim1']).toStrictEqual(['var1-foo']);
+          expect(queryMock.mock.calls[0][0].targets[0].dimensions['dim3']).toStrictEqual(['var3-foo', 'var3-baz']);
+          expect(queryMock.mock.calls[0][0].targets[0].dimensions['dim4']).toStrictEqual(['var4-foo', 'var4-baz']);
         });
       });
 
       it('should generate the correct query for multiple template variables, lack scopedVars', async () => {
-        const { runner, fetchMock, request } = setupMockedMetricsQueryRunner({ variables: [var1, var2, var3, var4] });
+        const { runner, queryMock, request } = setupMockedMetricsQueryRunner({ variables: [var1, var2, var3, var4] });
         const queries: CloudWatchMetricsQuery[] = [
           {
             id: '',
@@ -583,9 +578,9 @@ describe('CloudWatchMetricsQueryRunner', () => {
             },
           })
         ).toEmitValuesWith(() => {
-          expect(fetchMock.mock.calls[0][0].data.queries[0].dimensions['dim1']).toStrictEqual(['var1-foo']);
-          expect(fetchMock.mock.calls[0][0].data.queries[0].dimensions['dim2']).toStrictEqual(['var2-foo']);
-          expect(fetchMock.mock.calls[0][0].data.queries[0].dimensions['dim3']).toStrictEqual(['var3-foo', 'var3-baz']);
+          expect(queryMock.mock.calls[0][0].targets[0].dimensions['dim1']).toStrictEqual(['var1-foo']);
+          expect(queryMock.mock.calls[0][0].targets[0].dimensions['dim2']).toStrictEqual(['var2-foo']);
+          expect(queryMock.mock.calls[0][0].targets[0].dimensions['dim3']).toStrictEqual(['var3-foo', 'var3-baz']);
         });
       });
     });
@@ -622,22 +617,20 @@ describe('CloudWatchMetricsQueryRunner', () => {
       ['UTC', '+0000'],
     ];
     test.each(testTable)('should use the right time zone offset', (ianaTimezone, expectedOffset) => {
-      const { runner, fetchMock, request } = setupMockedMetricsQueryRunner();
+      const { runner, queryMock, request } = setupMockedMetricsQueryRunner();
       runner.handleMetricQueries([testQuery], {
         ...request,
         range: { ...request.range, from: dateTime(), to: dateTime() },
         timezone: ianaTimezone,
       });
 
-      expect(fetchMock).toHaveBeenCalledWith(
+      expect(queryMock).toHaveBeenCalledWith(
         expect.objectContaining({
-          data: expect.objectContaining({
-            queries: expect.arrayContaining([
-              expect.objectContaining({
-                timezoneUTCOffset: expectedOffset,
-              }),
-            ]),
-          }),
+          targets: expect.arrayContaining([
+            expect.objectContaining({
+              timezoneUTCOffset: expectedOffset,
+            }),
+          ]),
         })
       );
     });
@@ -879,7 +872,7 @@ describe('CloudWatchMetricsQueryRunner', () => {
       ];
 
       await expect(runner.handleMetricQueries(queries, request)).toEmitValuesWith(() => {
-        expect(performTimeSeriesQueryMock.mock.calls[0][0].queries[0].region).toBe(
+        expect(performTimeSeriesQueryMock.mock.calls[0][0].targets[0].region).toBe(
           instanceSettings.jsonData.defaultRegion
         );
       });

--- a/public/app/plugins/datasource/cloudwatch/query-runner/CloudWatchRequest.ts
+++ b/public/app/plugins/datasource/cloudwatch/query-runner/CloudWatchRequest.ts
@@ -1,6 +1,13 @@
-import { Observable } from 'rxjs';
+import { Observable, of } from 'rxjs';
 
-import { DataSourceInstanceSettings, DataSourceRef, getDataSourceRef, ScopedVars } from '@grafana/data';
+import {
+  DataQueryRequest,
+  DataQueryResponse,
+  DataSourceInstanceSettings,
+  DataSourceRef,
+  getDataSourceRef,
+  ScopedVars,
+} from '@grafana/data';
 import { BackendDataSourceResponse, FetchResponse, getBackendSrv } from '@grafana/runtime';
 import { notifyApp } from 'app/core/actions';
 import { createErrorNotification } from 'app/core/copy/appNotification';
@@ -9,12 +16,13 @@ import { store } from 'app/store/store';
 import { AppNotificationTimeout } from 'app/types';
 
 import memoizedDebounce from '../memoizedDebounce';
-import { CloudWatchJsonData, Dimensions, MetricRequest, MultiFilters } from '../types';
+import { CloudWatchJsonData, CloudWatchQuery, Dimensions, MetricRequest, MultiFilters } from '../types';
 
 export abstract class CloudWatchRequest {
   templateSrv: TemplateSrv;
   ref: DataSourceRef;
   dsQueryEndpoint = '/api/ds/query';
+  query: (request: DataQueryRequest<CloudWatchQuery>) => Observable<DataQueryResponse>;
   debouncedCustomAlert: (title: string, message: string) => void = memoizedDebounce(
     displayCustomError,
     AppNotificationTimeout.Error
@@ -22,10 +30,12 @@ export abstract class CloudWatchRequest {
 
   constructor(
     public instanceSettings: DataSourceInstanceSettings<CloudWatchJsonData>,
-    templateSrv: TemplateSrv
+    templateSrv: TemplateSrv,
+    queryFn: (request: DataQueryRequest<CloudWatchQuery>) => Observable<DataQueryResponse> = () => of({ data: [] })
   ) {
     this.templateSrv = templateSrv;
     this.ref = getDataSourceRef(instanceSettings);
+    this.query = queryFn;
   }
 
   awsRequest(

--- a/public/app/plugins/datasource/cloudwatch/types.ts
+++ b/public/app/plugins/datasource/cloudwatch/types.ts
@@ -56,7 +56,7 @@ export interface CloudWatchSecureJsonData extends AwsAuthDataSourceSecureJsonDat
 
 export type CloudWatchLogsRequest = GetLogEventsRequest | StartQueryRequest | QueryParam;
 
-export interface GetLogEventsRequest {
+export interface GetLogEventsRequest extends DataQuery {
   /**
    * The name of the log group.
    */
@@ -85,7 +85,7 @@ export interface GetLogEventsRequest {
    * If the value is true, the earliest log events are returned first. If the value is false, the latest log events are returned first. The default value is false. If you are using nextToken in this operation, you must specify true for startFromHead.
    */
   startFromHead?: boolean;
-  region?: string;
+  region: string;
 }
 
 export interface TSDBResponse<T = any> {
@@ -135,7 +135,7 @@ export interface LogGroupField {
   percent?: number;
 }
 
-export interface StartQueryRequest {
+export interface StartQueryRequest extends DataQuery {
   /**
    * The log group on which to perform the query. A StartQuery operation must include a logGroupNames or a logGroupName parameter, but not both.
    */
@@ -157,7 +157,7 @@ export interface StartQueryRequest {
   region: string;
 }
 
-export interface QueryParam {
+export interface QueryParam extends DataQuery {
   queryId: string;
   refId: string;
   limit?: number;


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

CloudWatch queries now call `super.query` instead of calling the query api directly. This will allow it to be used in public dashboards.

**Why do we need this feature?**

The `query` method in `DataSourceWithBackend`, which the CloudWatch data source extends, provides handling of public dashboard queries. By calling that method directly CloudWatch users will be able to use public dashboards.

**Who is this feature for?**

This is for CloudWatch data source users who want to use public dashboards

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #74872

**Special notes for your reviewer:**

You can test this by:
1. Creating a dashboard with CloudWatch metrics and logs queries
2. Save dashboard
3. Click the share icon at the top of the dashboard
4. Click the Public dashboard tab
5. Enable sharing
6. Copy the Dashboard URL and open it in an incognito window

> Only annotations that query the -- Grafana -- data source are supported.
> – https://grafana.com/docs/grafana/latest/dashboards/dashboard-public/
Therefore CloudWatch annotation won't show up in the public dashboard

Please check that:
- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
