### PR TITLE
[DOC] Add videos for Tempo data source

### DIFF
--- a/docs/sources/datasources/tempo/configure-tempo-data-source.md
+++ b/docs/sources/datasources/tempo/configure-tempo-data-source.md
@@ -113,6 +113,8 @@ If you use Grafana Cloud, open a [support ticket in the Cloud Portal](/profile/o
 
 The **Trace to metrics** setting configures the [trace to metrics feature](/blog/2022/08/18/new-in-grafana-9.1-trace-to-metrics-allows-users-to-navigate-from-a-trace-span-to-a-selected-data-source/) available when integrating Grafana with Tempo.
 
+{{< youtube id="TkapvLeMMpc" >}}
+
 To configure trace to metrics:
 
 1. Select the target data source from the drop-down list.

--- a/docs/sources/datasources/tempo/span-filters.md
+++ b/docs/sources/datasources/tempo/span-filters.md
@@ -30,7 +30,6 @@ You can add one or more of the following filters:
 
 To only show the spans you have matched, select the `Show matches only` toggle.
 
-For details about span filters, refer to the
 
 <!-- Adding these in case they are needed. -->
 

--- a/docs/sources/datasources/tempo/span-filters.md
+++ b/docs/sources/datasources/tempo/span-filters.md
@@ -30,7 +30,6 @@ You can add one or more of the following filters:
 
 To only show the spans you have matched, select the `Show matches only` toggle.
 
-
 <!-- Adding these in case they are needed. -->
 
 {{% docs/reference %}}

--- a/docs/sources/datasources/tempo/span-filters.md
+++ b/docs/sources/datasources/tempo/span-filters.md
@@ -30,6 +30,8 @@ You can add one or more of the following filters:
 
 To only show the spans you have matched, select the `Show matches only` toggle.
 
+For details about span filters, refer to the
+
 <!-- Adding these in case they are needed. -->
 
 {{% docs/reference %}}

--- a/docs/sources/explore/trace-integration.md
+++ b/docs/sources/explore/trace-integration.md
@@ -39,7 +39,7 @@ For information on querying each data source, refer to their documentation:
 - [Zipkin query editor]({{< relref "../datasources/zipkin/#query-the-data-source" >}})
 - [Azure Monitor Application Insights query editor]({{< relref "../datasources/azure-monitor/query-editor/#query-application-insights-traces" >}})
 
-## Trace View
+## Trace view
 
 This section explains the elements of the Trace View.
 
@@ -59,7 +59,7 @@ This section explains the elements of the Trace View.
 
 Shows condensed view or the trace timeline. Drag your mouse over the minimap to zoom into smaller time range. Zooming will also update the main timeline, so it is easy to see shorter spans. Hovering over the minimap, when zoomed, will show Reset Selection button which resets the zoom.
 
-### Span Filters
+### Span filters
 
 ![Screenshot of span filtering](/media/docs/tempo/screenshot-grafana-tempo-span-filters-v10-1.png)
 
@@ -67,12 +67,14 @@ Using span filters, you can filter your spans in the trace timeline viewer. The 
 
 You can add one or more of the following filters:
 
-- Service name
+- Resource service name
 - Span name
 - Duration
 - Tags (which include tags, process tags, and log fields)
 
 To only show the spans you have matched, you can press the `Show matches only` toggle.
+
+{{< youtube id="VP2XV3IIc80" >}}
 
 ### Timeline
 
@@ -112,12 +114,12 @@ Click the document icon to open a split view in Explore with the configured data
 ### Trace to metrics
 
 {{% admonition type="note" %}}
-This feature is currently in beta & behind the `traceToMetrics` feature toggle.
+This feature is currently in beta and behind the `traceToMetrics` feature toggle.
 {{% /admonition %}}
 
 You can navigate from a span in a trace view directly to metrics relevant for that span. This feature is available for Tempo, Jaeger, and Zipkin data sources. Refer to their [relevant documentation](/docs/grafana/latest/datasources/tempo/#trace-to-metrics) for configuration instructions.
 
-## Node Graph
+## Node graph
 
 You can optionally expand the node graph for the displayed trace. Depending on the data source, this can show spans of the trace as nodes in the graph, or as some additional context like service graph based on the current trace.
 

--- a/docs/sources/shared/datasources/tempo-editor-traceql.md
+++ b/docs/sources/shared/datasources/tempo-editor-traceql.md
@@ -46,6 +46,10 @@ To access the query editor, follow these steps:
 1. Optional: Use the Time picker drop-down to change the time and range for the query (refer to the [documentation for instructions](https://grafana.com/docs/grafana/latest/dashboards/use-dashboards/#set-dashboard-time-range)).
 1. Once you have finished your query, select **Run query**.
 
+This video provides and example of creating a TraceQL query using the custom tag grouping.
+
+{{< youtube id="fraepWra00Y" >}}
+
 ## Query by TraceID
 
 To query a particular trace by its trace ID:
@@ -60,7 +64,7 @@ To query a particular trace by its trace ID:
 
 You can use the query editor’s autocomplete suggestions to write queries.
 The editor detects span sets to provide relevant autocomplete options.
-It uses regular expressions (regex) to detect where it is inside a spanset and provide attribute names, scopes, intrinsic names, logic operators, or attribute values from Tempo's API, depending on what is expected for the current situation.
+It uses regular expressions (regex) to detect where it's inside a spanset and provide attribute names, scopes, intrinsic names, logic operators, or attribute values from Tempo's API, depending on what's expected for the current situation.
 
 ![Query editor showing the auto-complete feature](/static/img/docs/tempo/screenshot-traceql-query-editor-auto-complete-v10.png)
 
@@ -80,4 +84,16 @@ Query results for both the editor and the builder are returned in a table. Selec
 
 ![Query editor showing span results](/static/img/docs/tempo/screenshot-traceql-query-editor-results-v10.png)
 
-Selecting the trace ID from the returned results will open a trace diagram. Selecting a span from the returned results opens a trace diagram and reveals the relevant span in the trace diagram (above, the highlighted blue line).
+Selecting the trace ID from the returned results opens a trace diagram. Selecting a span from the returned results opens a trace diagram and reveals the relevant span in the trace diagram (above, the highlighted blue line).
+
+### Streaming results
+
+The Tempo data source supports streaming responses to TraceQL queries so you can see partial query results as they come in without waiting for the whole query to finish.
+
+{{% admonition type="note" %}}
+To use this experimental feature, enable the `traceQLStreaming` feature toggle. If you’re using Grafana Cloud and would like to enable this feature, please contact customer support.
+{{% /admonition %}}
+
+Streaming is available for both the **Search** and **TraceQL** query types, and you'll get immediate visibility of incoming traces on the results table.
+
+{{< video-embed src="/media/docs/grafana/data-sources/tempo-streaming-v2.mp4" >}}

--- a/docs/sources/shared/datasources/tempo-search-traceql.md
+++ b/docs/sources/shared/datasources/tempo-search-traceql.md
@@ -59,11 +59,11 @@ To access Search, use the following steps:
 
 1. Sign into Grafana.
 1. Select your Tempo data source.
-1. From the menu, choose Explore and select Query type > Search.
+1. From the menu, choose **Explore** and select **Query type > Search**.
 
 ## Define filters
 
-Using filters, you refine the data returned from the query by selecting Resource Service Name, Span Name, or Duration. The **Duration** represents span time, calculated by subtracting the end time from the start time of the span.
+Using filters, you refine the data returned from the query by selecting **Resource Service Name**, **Span Name**, or **Duration**. The **Duration** represents span time, calculated by subtracting the end time from the start time of the span.
 
 Grafana administrators can change the default filters using the Tempo data source configuration.
 Filters can be limited by the operators. The available operators are determined by the field type.
@@ -110,6 +110,8 @@ Using **Aggregate by**, you can calculate RED metrics (total span count, percent
 This capability is based on the [metrics summary API](/docs/grafana-cloud/monitor-infrastructure/traces/metrics-summary-api/).
 Metrics summary only calculates summaries based on spans received within the last hour.
 
+{{< youtube id="g97CjKOZqT4" >}}
+
 When you use **Aggregate by**, the selections you make determine how the information is reported in the Table. Every combination that matches selections in your data is listed in the table.
 Each aggregate value, for example `intrinsic`:`name`, has a corresponding column in the results table.
 
@@ -146,3 +148,15 @@ Select **Run query** to run the TraceQL query (1 in the screenshot).
 Queries can take a little while to return results. The results appear in a table underneath the query builder. Selecting a Trace ID (2 in the screenshot) displays more detailed information (3 in the screenshot).
 
 {{< figure src="/static/img/docs/queries/screenshot-tempods-query-results.png" class="docs-image--no-shadow" max-width="750px" caption="Tempo Search query type results" >}}
+
+#### Streaming results
+
+The Tempo data source supports streaming responses to TraceQL queries so you can see partial query results as they come in without waiting for the whole query to finish.
+
+{{% admonition type="note" %}}
+To use this experimental feature, enable the `traceQLStreaming` feature toggle. If you’re using Grafana Cloud and would like to enable this feature, please contact customer support.
+{{% /admonition %}}
+
+Streaming is available for both the **Search** and **TraceQL** query types, and you'll get immediate visibility of incoming traces on the results table.
+
+{{< video-embed src="/media/docs/grafana/data-sources/tempo-streaming-v2.mp4" >}}


### PR DESCRIPTION
This PR adds demo videos for Tempo data source features added in Grafana 10.1 and 10.2 to the Tempo data source and query editor/builder pages. 

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [X] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
