### PR TITLE
Chore: Library Element folderUID migration

### DIFF
--- a/pkg/services/libraryelements/database.go
+++ b/pkg/services/libraryelements/database.go
@@ -146,14 +146,19 @@ func (l *LibraryElementService) createLibraryElement(c context.Context, signedIn
 		}
 	}
 
+	folderUID := ""
+	if cmd.FolderUID != nil {
+		folderUID = *cmd.FolderUID
+	}
 	element := model.LibraryElement{
-		OrgID:    signedInUser.GetOrgID(),
-		FolderID: cmd.FolderID, // nolint:staticcheck
-		UID:      createUID,
-		Name:     cmd.Name,
-		Model:    updatedModel,
-		Version:  1,
-		Kind:     cmd.Kind,
+		OrgID:     signedInUser.GetOrgID(),
+		FolderID:  cmd.FolderID, // nolint:staticcheck
+		FolderUID: folderUID,
+		UID:       createUID,
+		Name:      cmd.Name,
+		Model:     updatedModel,
+		Version:   1,
+		Kind:      cmd.Kind,
 
 		Created: time.Now(),
 		Updated: time.Now(),

--- a/pkg/services/libraryelements/database.go
+++ b/pkg/services/libraryelements/database.go
@@ -147,7 +147,7 @@ func (l *LibraryElementService) createLibraryElement(c context.Context, signedIn
 	}
 
 	folderUID := ""
-	if cmd.FolderUID != nil {
+	if cmd.FolderUID != nil && *cmd.FolderUID != "" {
 		folderUID = *cmd.FolderUID
 	}
 	element := model.LibraryElement{
@@ -578,10 +578,15 @@ func (l *LibraryElementService) patchLibraryElement(c context.Context, signedInU
 			}
 		}
 
+		folderUID := ""
+		if cmd.FolderUID != nil && *cmd.FolderUID != "" {
+			folderUID = *cmd.FolderUID
+		}
 		var libraryElement = model.LibraryElement{
 			ID:          elementInDB.ID,
 			OrgID:       signedInUser.GetOrgID(),
 			FolderID:    cmd.FolderID, // nolint:staticcheck
+			FolderUID:   folderUID,
 			UID:         updateUID,
 			Name:        cmd.Name,
 			Kind:        elementInDB.Kind,
@@ -721,6 +726,7 @@ func (l *LibraryElementService) getElementsForDashboardID(c context.Context, das
 				ID:          element.ID,
 				OrgID:       element.OrgID,
 				FolderID:    element.FolderID, // nolint:staticcheck
+				FolderUID:   element.FolderUID,
 				UID:         element.UID,
 				Name:        element.Name,
 				Kind:        element.Kind,

--- a/pkg/services/libraryelements/libraryelements_create_test.go
+++ b/pkg/services/libraryelements/libraryelements_create_test.go
@@ -28,6 +28,7 @@ func TestCreateLibraryElement(t *testing.T) {
 					ID:          1,
 					OrgID:       1,
 					FolderID:    1, // nolint:staticcheck
+					FolderUID:   "ScenarioFolder",
 					UID:         sc.initialResult.Result.UID,
 					Name:        "Text - Library Panel",
 					Kind:        int64(model.PanelElement),
@@ -78,6 +79,7 @@ func TestCreateLibraryElement(t *testing.T) {
 					ID:          1,
 					OrgID:       1,
 					FolderID:    1, // nolint:staticcheck
+					FolderUID:   "ScenarioFolder",
 					UID:         command.UID,
 					Name:        "Nonexistent UID",
 					Kind:        int64(model.PanelElement),
@@ -156,6 +158,7 @@ func TestCreateLibraryElement(t *testing.T) {
 					ID:          1,
 					OrgID:       1,
 					FolderID:    1, // nolint:staticcheck
+					FolderUID:   "ScenarioFolder",
 					UID:         result.Result.UID,
 					Name:        "Library Panel Name",
 					Kind:        int64(model.PanelElement),

--- a/pkg/services/libraryelements/libraryelements_get_all_test.go
+++ b/pkg/services/libraryelements/libraryelements_get_all_test.go
@@ -64,6 +64,7 @@ func TestGetAllLibraryElements(t *testing.T) {
 							ID:          1,
 							OrgID:       1,
 							FolderID:    1, // nolint:staticcheck
+							FolderUID:   "ScenarioFolder",
 							UID:         result.Result.Elements[0].UID,
 							Name:        "Text - Library Panel",
 							Kind:        int64(model.PanelElement),
@@ -131,6 +132,7 @@ func TestGetAllLibraryElements(t *testing.T) {
 							ID:          2,
 							OrgID:       1,
 							FolderID:    1, // nolint:staticcheck
+							FolderUID:   "ScenarioFolder",
 							UID:         result.Result.Elements[0].UID,
 							Name:        "query0",
 							Kind:        int64(model.VariableElement),
@@ -193,6 +195,7 @@ func TestGetAllLibraryElements(t *testing.T) {
 							ID:          1,
 							OrgID:       1,
 							FolderID:    1, // nolint:staticcheck
+							FolderUID:   "ScenarioFolder",
 							UID:         result.Result.Elements[0].UID,
 							Name:        "Text - Library Panel",
 							Kind:        int64(model.PanelElement),
@@ -228,6 +231,7 @@ func TestGetAllLibraryElements(t *testing.T) {
 							ID:          2,
 							OrgID:       1,
 							FolderID:    1, // nolint:staticcheck
+							FolderUID:   "ScenarioFolder",
 							UID:         result.Result.Elements[1].UID,
 							Name:        "Text - Library Panel2",
 							Kind:        int64(model.PanelElement),
@@ -294,6 +298,7 @@ func TestGetAllLibraryElements(t *testing.T) {
 							ID:          2,
 							OrgID:       1,
 							FolderID:    1, // nolint:staticcheck
+							FolderUID:   "ScenarioFolder",
 							UID:         result.Result.Elements[0].UID,
 							Name:        "Text - Library Panel2",
 							Kind:        int64(model.PanelElement),
@@ -329,6 +334,7 @@ func TestGetAllLibraryElements(t *testing.T) {
 							ID:          1,
 							OrgID:       1,
 							FolderID:    1, // nolint:staticcheck
+							FolderUID:   "ScenarioFolder",
 							UID:         result.Result.Elements[1].UID,
 							Name:        "Text - Library Panel",
 							Kind:        int64(model.PanelElement),
@@ -417,6 +423,7 @@ func TestGetAllLibraryElements(t *testing.T) {
 							ID:          3,
 							OrgID:       1,
 							FolderID:    1, // nolint:staticcheck
+							FolderUID:   "ScenarioFolder",
 							UID:         result.Result.Elements[0].UID,
 							Name:        "BarGauge - Library Panel",
 							Kind:        int64(model.PanelElement),
@@ -452,6 +459,7 @@ func TestGetAllLibraryElements(t *testing.T) {
 							ID:          2,
 							OrgID:       1,
 							FolderID:    1, // nolint:staticcheck
+							FolderUID:   "ScenarioFolder",
 							UID:         result.Result.Elements[1].UID,
 							Name:        "Gauge - Library Panel",
 							Kind:        int64(model.PanelElement),
@@ -559,6 +567,7 @@ func TestGetAllLibraryElements(t *testing.T) {
 							ID:          2,
 							OrgID:       1,
 							FolderID:    newFolder.ID, // nolint:staticcheck
+							FolderUID:   "NewFolder",
 							UID:         result.Result.Elements[0].UID,
 							Name:        "Text - Library Panel2",
 							Kind:        int64(model.PanelElement),
@@ -658,6 +667,7 @@ func TestGetAllLibraryElements(t *testing.T) {
 							ID:          1,
 							OrgID:       1,
 							FolderID:    1, // nolint:staticcheck
+							FolderUID:   "ScenarioFolder",
 							UID:         result.Result.Elements[0].UID,
 							Name:        "Text - Library Panel",
 							Kind:        int64(model.PanelElement),
@@ -693,6 +703,7 @@ func TestGetAllLibraryElements(t *testing.T) {
 							ID:          2,
 							OrgID:       1,
 							FolderID:    1, // nolint:staticcheck
+							FolderUID:   "ScenarioFolder",
 							UID:         result.Result.Elements[1].UID,
 							Name:        "Text - Library Panel2",
 							Kind:        int64(model.PanelElement),
@@ -759,6 +770,7 @@ func TestGetAllLibraryElements(t *testing.T) {
 							ID:          2,
 							OrgID:       1,
 							FolderID:    1, // nolint:staticcheck
+							FolderUID:   "ScenarioFolder",
 							UID:         result.Result.Elements[0].UID,
 							Name:        "Text - Library Panel2",
 							Kind:        int64(model.PanelElement),
@@ -825,6 +837,7 @@ func TestGetAllLibraryElements(t *testing.T) {
 							ID:          1,
 							OrgID:       1,
 							FolderID:    1, // nolint:staticcheck
+							FolderUID:   "ScenarioFolder",
 							UID:         result.Result.Elements[0].UID,
 							Name:        "Text - Library Panel",
 							Kind:        int64(model.PanelElement),
@@ -892,6 +905,7 @@ func TestGetAllLibraryElements(t *testing.T) {
 							ID:          2,
 							OrgID:       1,
 							FolderID:    1, // nolint:staticcheck
+							FolderUID:   "ScenarioFolder",
 							UID:         result.Result.Elements[0].UID,
 							Name:        "Text - Library Panel2",
 							Kind:        int64(model.PanelElement),
@@ -968,6 +982,7 @@ func TestGetAllLibraryElements(t *testing.T) {
 							ID:          1,
 							OrgID:       1,
 							FolderID:    1, // nolint:staticcheck
+							FolderUID:   "ScenarioFolder",
 							UID:         result.Result.Elements[0].UID,
 							Name:        "Text - Library Panel",
 							Kind:        int64(model.PanelElement),
@@ -1042,6 +1057,7 @@ func TestGetAllLibraryElements(t *testing.T) {
 							ID:          2,
 							OrgID:       1,
 							FolderID:    1, // nolint:staticcheck
+							FolderUID:   "ScenarioFolder",
 							UID:         result.Result.Elements[0].UID,
 							Name:        "Some Other",
 							Kind:        int64(model.PanelElement),
@@ -1077,6 +1093,7 @@ func TestGetAllLibraryElements(t *testing.T) {
 							ID:          1,
 							OrgID:       1,
 							FolderID:    1, // nolint:staticcheck
+							FolderUID:   "ScenarioFolder",
 							UID:         result.Result.Elements[1].UID,
 							Name:        "Text - Library Panel",
 							Kind:        int64(model.PanelElement),
@@ -1145,6 +1162,7 @@ func TestGetAllLibraryElements(t *testing.T) {
 							ID:          2,
 							OrgID:       1,
 							FolderID:    1, // nolint:staticcheck
+							FolderUID:   "ScenarioFolder",
 							UID:         result.Result.Elements[0].UID,
 							Name:        "Text - Library Panel2",
 							Kind:        int64(model.PanelElement),
@@ -1259,6 +1277,7 @@ func TestGetAllLibraryElements(t *testing.T) {
 			require.Equal(t, 1, len(result.Result.Elements))
 			// nolint:staticcheck
 			require.Equal(t, int64(1), result.Result.Elements[0].FolderID)
+			require.Equal(t, "ScenarioFolder", result.Result.Elements[0].FolderUID)
 			require.Equal(t, "Text - Library Panel", result.Result.Elements[0].Name)
 
 			sc.reqContext.SignedInUser.OrgID = 2

--- a/pkg/services/libraryelements/libraryelements_get_test.go
+++ b/pkg/services/libraryelements/libraryelements_get_test.go
@@ -35,6 +35,7 @@ func TestGetLibraryElement(t *testing.T) {
 						ID:          1,
 						OrgID:       1,
 						FolderID:    1, // nolint:staticcheck
+						FolderUID:   "ScenarioFolder",
 						UID:         res.Result.UID,
 						Name:        "Text - Library Panel",
 						Kind:        int64(model.PanelElement),
@@ -133,6 +134,7 @@ func TestGetLibraryElement(t *testing.T) {
 						ID:          1,
 						OrgID:       1,
 						FolderID:    1, // nolint:staticcheck
+						FolderUID:   "ScenarioFolder",
 						UID:         res.Result.UID,
 						Name:        "Text - Library Panel",
 						Kind:        int64(model.PanelElement),

--- a/pkg/services/libraryelements/libraryelements_patch_test.go
+++ b/pkg/services/libraryelements/libraryelements_patch_test.go
@@ -50,6 +50,7 @@ func TestPatchLibraryElement(t *testing.T) {
 					ID:          1,
 					OrgID:       1,
 					FolderID:    newFolder.ID, // nolint:staticcheck
+					FolderUID:   newFolder.UID,
 					UID:         sc.initialResult.Result.UID,
 					Name:        "Panel - New name",
 					Kind:        int64(model.PanelElement),
@@ -91,9 +92,9 @@ func TestPatchLibraryElement(t *testing.T) {
 		func(t *testing.T, sc scenarioContext) {
 			newFolder := createFolder(t, sc, "NewFolder")
 			cmd := model.PatchLibraryElementCommand{
-				FolderID: newFolder.ID, // nolint:staticcheck
-				Kind:     int64(model.PanelElement),
-				Version:  1,
+				FolderUID: &newFolder.UID,
+				Kind:      int64(model.PanelElement),
+				Version:   1,
 			}
 			sc.ctx.Req = web.SetURLParams(sc.ctx.Req, map[string]string{":uid": sc.initialResult.Result.UID})
 			sc.reqContext.Req.Body = mockRequestBody(cmd)
@@ -102,6 +103,7 @@ func TestPatchLibraryElement(t *testing.T) {
 			var result = validateAndUnMarshalResponse(t, resp)
 			// nolint:staticcheck
 			sc.initialResult.Result.FolderID = newFolder.ID
+			sc.initialResult.Result.FolderUID = newFolder.UID
 			sc.initialResult.Result.Meta.CreatedBy.Name = userInDbName
 			sc.initialResult.Result.Meta.CreatedBy.AvatarUrl = userInDbAvatar
 			sc.initialResult.Result.Meta.Updated = result.Result.Meta.Updated

--- a/pkg/services/libraryelements/libraryelements_test.go
+++ b/pkg/services/libraryelements/libraryelements_test.go
@@ -198,6 +198,7 @@ type libraryElement struct {
 	OrgID int64 `json:"orgId"`
 	// Deprecated: use FolderUID instead
 	FolderID    int64                       `json:"folderId"`
+	FolderUID   string                      `json:"folderUid"`
 	UID         string                      `json:"uid"`
 	Name        string                      `json:"name"`
 	Kind        int64                       `json:"kind"`

--- a/pkg/services/libraryelements/model/model.go
+++ b/pkg/services/libraryelements/model/model.go
@@ -24,6 +24,7 @@ type LibraryElement struct {
 	OrgID int64 `xorm:"org_id"`
 	// Deprecated: use FolderUID instead
 	FolderID    int64  `xorm:"folder_id"`
+	FolderUID   string `xorm:"folder_uid"`
 	UID         string `xorm:"uid"`
 	Name        string
 	Kind        int64

--- a/pkg/services/sqlstore/migrations/libraryelements.go
+++ b/pkg/services/sqlstore/migrations/libraryelements.go
@@ -61,4 +61,10 @@ func addLibraryElementsMigrations(mg *migrator.Migrator) {
 
 	mg.AddMigration("alter library_element model to mediumtext", migrator.NewRawSQLMigration("").
 		Mysql("ALTER TABLE library_element MODIFY model MEDIUMTEXT NOT NULL;"))
+
+	mg.AddMigration("add library_element folder uid", migrator.NewAddColumnMigration(libraryElementsV1, &migrator.Column{
+		Name: "folder_uid", Type: migrator.DB_NVarchar, Length: 40, Nullable: false, Default: "''",
+	}))
+	mg.AddMigration("populate library_element folder_uid", migrator.NewRawSQLMigration("").
+		Default("UPDATE library_element SET folder_uid = (SELECT uid FROM dashboard WHERE id = library_element.folder_id)"))
 }


### PR DESCRIPTION
This PR adds folderUID to the library elements, potentially replacing folderID everywhere.