### PR TITLE
Transformations: Deduplicate names when using `extract fields` transformation.

### DIFF
--- a/docs/sources/setup-grafana/configure-grafana/feature-toggles/index.md
+++ b/docs/sources/setup-grafana/configure-grafana/feature-toggles/index.md
@@ -162,6 +162,7 @@ Experimental features might be changed or removed without prior notice.
 | `alertmanagerRemotePrimary`                 | Enable Grafana to have a remote Alertmanager instance as the primary Alertmanager.                                                                                                                                                                                                |
 | `alertmanagerRemoteOnly`                    | Disable the internal Alertmanager and only use the external one defined.                                                                                                                                                                                                          |
 | `annotationPermissionUpdate`                | Separate annotation permissions from dashboard permissions to allow for more granular control.                                                                                                                                                                                    |
+| `extractFieldsNameDeduplication`            | Make sure extracted field names are unique in the dataframe                                                                                                                                                                                                                       |
 
 ## Development feature toggles
 

--- a/packages/grafana-data/src/field/fieldState.ts
+++ b/packages/grafana-data/src/field/fieldState.ts
@@ -159,7 +159,7 @@ export function calculateFieldDisplayName(field: Field, frame?: DataFrame, allFr
   return displayName;
 }
 
-function getUniqueFieldName(field: Field, frame?: DataFrame) {
+export function getUniqueFieldName(field: Field, frame?: DataFrame) {
   let dupeCount = 0;
   let foundSelf = false;
 

--- a/packages/grafana-data/src/field/index.ts
+++ b/packages/grafana-data/src/field/index.ts
@@ -14,5 +14,5 @@ export { FieldConfigOptionsRegistry } from './FieldConfigOptionsRegistry';
 export { sortThresholds, getActiveThreshold } from './thresholds';
 export { applyFieldOverrides, validateFieldConfig, applyRawFieldOverrides, useFieldOverrides } from './fieldOverrides';
 export { getFieldDisplayValuesProxy } from './getFieldDisplayValuesProxy';
-export { getFieldDisplayName, getFrameDisplayName, cacheFieldDisplayNames } from './fieldState';
+export { getFieldDisplayName, getFrameDisplayName, cacheFieldDisplayNames, getUniqueFieldName } from './fieldState';
 export { getScaleCalculator, getFieldConfigWithMinMax, getMinMaxAndDelta } from './scale';

--- a/packages/grafana-data/src/types/featureToggles.gen.ts
+++ b/packages/grafana-data/src/types/featureToggles.gen.ts
@@ -156,4 +156,5 @@ export interface FeatureToggles {
   alertmanagerRemotePrimary?: boolean;
   alertmanagerRemoteOnly?: boolean;
   annotationPermissionUpdate?: boolean;
+  extractFieldsNameDeduplication?: boolean;
 }

--- a/pkg/services/featuremgmt/registry.go
+++ b/pkg/services/featuremgmt/registry.go
@@ -966,5 +966,12 @@ var (
 			RequiresDevMode: false,
 			Owner:           grafanaAuthnzSquad,
 		},
+		{
+			Name:         "extractFieldsNameDeduplication",
+			Description:  "Make sure extracted field names are unique in the dataframe",
+			Stage:        FeatureStageExperimental,
+			FrontendOnly: true,
+			Owner:        grafanaBiSquad,
+		},
 	}
 )

--- a/pkg/services/featuremgmt/toggles_gen.csv
+++ b/pkg/services/featuremgmt/toggles_gen.csv
@@ -137,3 +137,4 @@ alertmanagerRemoteSecondary,experimental,@grafana/alerting-squad,false,false,fal
 alertmanagerRemotePrimary,experimental,@grafana/alerting-squad,false,false,false,false
 alertmanagerRemoteOnly,experimental,@grafana/alerting-squad,false,false,false,false
 annotationPermissionUpdate,experimental,@grafana/grafana-authnz-team,false,false,false,false
+extractFieldsNameDeduplication,experimental,@grafana/grafana-bi-squad,false,false,false,true

--- a/pkg/services/featuremgmt/toggles_gen.go
+++ b/pkg/services/featuremgmt/toggles_gen.go
@@ -558,4 +558,8 @@ const (
 	// FlagAnnotationPermissionUpdate
 	// Separate annotation permissions from dashboard permissions to allow for more granular control.
 	FlagAnnotationPermissionUpdate = "annotationPermissionUpdate"
+
+	// FlagExtractFieldsNameDeduplication
+	// Make sure extracted field names are unique in the dataframe
+	FlagExtractFieldsNameDeduplication = "extractFieldsNameDeduplication"
 )

--- a/public/app/features/transformers/extractFields/extractFields.ts
+++ b/public/app/features/transformers/extractFields/extractFields.ts
@@ -7,8 +7,10 @@ import {
   Field,
   FieldType,
   getFieldTypeFromValue,
+  getUniqueFieldName,
   SynchronousDataTransformerInfo,
 } from '@grafana/data';
+import { config } from '@grafana/runtime';
 import { findField } from 'app/features/dimensions';
 
 import { fieldExtractors } from './fieldExtractors';
@@ -30,7 +32,7 @@ export const extractFieldsTransformer: SynchronousDataTransformerInfo<ExtractFie
   },
 };
 
-function addExtractedFields(frame: DataFrame, options: ExtractFieldsOptions): DataFrame {
+export function addExtractedFields(frame: DataFrame, options: ExtractFieldsOptions): DataFrame {
   if (!options.source) {
     return frame;
   }
@@ -94,12 +96,16 @@ function addExtractedFields(frame: DataFrame, options: ExtractFieldsOptions): Da
 
   const fields = names.map((name) => {
     const buffer = values.get(name);
-    return {
+    const field = {
       name,
       values: buffer,
       type: buffer ? getFieldTypeFromValue(buffer.find((v) => v != null)) : FieldType.other,
       config: {},
     } as Field;
+    if (config.featureToggles.extractFieldsNameDeduplication) {
+      field.name = getUniqueFieldName(field, frame);
+    }
+    return field;
   });
 
   if (options.keepTime) {

--- a/public/app/features/transformers/extractFields/fieldExtractor.test.ts
+++ b/public/app/features/transformers/extractFields/fieldExtractor.test.ts
@@ -126,4 +126,15 @@ describe('Extract fields from text', () => {
     expect(newFrame.fields.length).toBe(2);
     expect(newFrame.fields[1].name).toBe('foo 1');
   });
+
+  it('keeps correct names when deduplication is active', async () => {
+    const frame = toDataFrame({
+      fields: [{ name: 'foo', type: FieldType.string, values: ['{"bar":"extracedValue1"}'] }],
+    });
+    config.featureToggles.extractFieldsNameDeduplication = true;
+    const newFrame = addExtractedFields(frame, { format: FieldExtractorID.JSON, source: 'foo' });
+    config.featureToggles.extractFieldsNameDeduplication = false;
+    expect(newFrame.fields.length).toBe(2);
+    expect(newFrame.fields[1].name).toBe('bar');
+  });
 });

--- a/public/app/features/transformers/extractFields/fieldExtractor.test.ts
+++ b/public/app/features/transformers/extractFields/fieldExtractor.test.ts
@@ -1,3 +1,7 @@
+import { FieldType, toDataFrame } from '@grafana/data';
+import { config } from '@grafana/runtime';
+
+import { addExtractedFields } from './extractFields';
 import { fieldExtractors } from './fieldExtractors';
 import { FieldExtractorID } from './types';
 
@@ -110,5 +114,16 @@ describe('Extract fields from text', () => {
         "foo": "bar",
       }
     `);
+  });
+
+  it('deduplicates names', async () => {
+    const frame = toDataFrame({
+      fields: [{ name: 'foo', type: FieldType.string, values: ['{"foo":"extracedValue1"}'] }],
+    });
+    config.featureToggles.extractFieldsNameDeduplication = true;
+    const newFrame = addExtractedFields(frame, { format: FieldExtractorID.JSON, source: 'foo' });
+    config.featureToggles.extractFieldsNameDeduplication = false;
+    expect(newFrame.fields.length).toBe(2);
+    expect(newFrame.fields[1].name).toBe('foo 1');
   });
 });


### PR DESCRIPTION
**What is this feature?**

This assigns unique names to extracted fields that collide with an already existing name on the frame. This is a breaking change and as such is behind a feature toggle.

**Why do we need this feature?**

If there is a name collision the frame will not be valid.

**Which issue(s) does this PR fix?**:

Fixes #72331

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.


# Release notice breaking change

In panels using the `extract fields` transformation, where one of the extracted names collides with one of the already existing fields, the extracted field will be renamed.