### PR TITLE
OpenTSDB: Use refid to support alerting on multiple queries

### DIFF
--- a/pkg/tsdb/opentsdb/opentsdb.go
+++ b/pkg/tsdb/opentsdb/opentsdb.go
@@ -70,6 +70,8 @@ func (s *Service) QueryData(ctx context.Context, req *backend.QueryDataRequest) 
 
 	q := req.Queries[0]
 
+	myRefID := q.RefID
+
 	tsdbQuery.Start = q.TimeRange.From.UnixNano() / int64(time.Millisecond)
 	tsdbQuery.End = q.TimeRange.To.UnixNano() / int64(time.Millisecond)
 
@@ -105,7 +107,7 @@ func (s *Service) QueryData(ctx context.Context, req *backend.QueryDataRequest) 
 		}
 	}()
 
-	result, err := s.parseResponse(logger, res)
+	result, err := s.parseResponse(logger, res, myRefID)
 	if err != nil {
 		return &backend.QueryDataResponse{}, err
 	}
@@ -136,7 +138,7 @@ func (s *Service) createRequest(ctx context.Context, logger log.Logger, dsInfo *
 	return req, nil
 }
 
-func (s *Service) parseResponse(logger log.Logger, res *http.Response) (*backend.QueryDataResponse, error) {
+func (s *Service) parseResponse(logger log.Logger, res *http.Response, myRefID string) (*backend.QueryDataResponse, error) {
 	resp := backend.NewQueryDataResponse()
 
 	body, err := io.ReadAll(res.Body)
@@ -181,9 +183,9 @@ func (s *Service) parseResponse(logger log.Logger, res *http.Response) (*backend
 			data.NewField("time", nil, timeVector),
 			data.NewField("value", tags, values)))
 	}
-	result := resp.Responses["A"]
+	result := resp.Responses[myRefID]
 	result.Frames = frames
-	resp.Responses["A"] = result
+	resp.Responses[myRefID] = result
 	return resp, nil
 }
 

--- a/pkg/tsdb/opentsdb/opentsdb_test.go
+++ b/pkg/tsdb/opentsdb/opentsdb_test.go
@@ -33,7 +33,7 @@ func TestOpenTsdbExecutor(t *testing.T) {
 	t.Run("Parse response should handle invalid JSON", func(t *testing.T) {
 		response := `{ invalid }`
 
-		result, err := service.parseResponse(logger, &http.Response{Body: io.NopCloser(strings.NewReader(response))})
+		result, err := service.parseResponse(logger, &http.Response{Body: io.NopCloser(strings.NewReader(response))}, "A")
 		require.Nil(t, result)
 		require.Error(t, err)
 	})
@@ -63,7 +63,7 @@ func TestOpenTsdbExecutor(t *testing.T) {
 
 		resp := http.Response{Body: io.NopCloser(strings.NewReader(response))}
 		resp.StatusCode = 200
-		result, err := service.parseResponse(logger, &resp)
+		result, err := service.parseResponse(logger, &resp, "A")
 		require.NoError(t, err)
 
 		frame := result.Responses["A"]


### PR DESCRIPTION
Fixes: https://github.com/grafana/grafana/issues/71617#issuecomment-1788941640
Fixes: https://github.com/grafana/grafana/issues/73324
Ref id was hard coded. This is fixed now. 

To test, create two opentsdb queries in alerting. 

Please check that:
- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
