### PR TITLE
Chore: avoid using deprecated ArrayVector

### DIFF
--- a/public/app/plugins/datasource/azuremonitor/components/TracesQueryEditor/Filters.test.tsx
+++ b/public/app/plugins/datasource/azuremonitor/components/TracesQueryEditor/Filters.test.tsx
@@ -5,7 +5,7 @@ import React from 'react';
 import { of } from 'rxjs';
 import { selectOptionInTest } from 'test/helpers/selectOptionInTest';
 
-import { ArrayVector, CoreApp } from '@grafana/data';
+import { CoreApp } from '@grafana/data';
 
 import createMockDatasource from '../../__mocks__/datasource';
 import createMockQuery from '../../__mocks__/query';
@@ -51,9 +51,6 @@ const addFilter = async (
   rerender: (ui: React.ReactElement) => void
 ) => {
   const { property, operation, index } = filter;
-  const resultVector = new ArrayVector([
-    `{"${property}":[${filter.filters.map(({ count, value }) => `{"${property}":"${value}", "count":${count}}`)}]}`,
-  ]);
   mockDatasource.azureLogAnalyticsDatasource.query = jest.fn().mockReturnValue(
     of({
       data: [
@@ -82,7 +79,11 @@ const addFilter = async (
                   },
                 ],
               },
-              values: resultVector,
+              values: [
+                `{"${property}":[${filter.filters.map(
+                  ({ count, value }) => `{"${property}":"${value}", "count":${count}}`
+                )}]}`,
+              ],
               entities: {},
             },
           ],

--- a/public/app/plugins/panel/datagrid/DataGridPanel.test.tsx
+++ b/public/app/plugins/panel/datagrid/DataGridPanel.test.tsx
@@ -1,7 +1,7 @@
 import { render, screen, fireEvent, act, waitFor } from '@testing-library/react';
 import * as React from 'react';
 
-import { ArrayVector, DataFrame, dateTime, EventBus, Field, FieldType, LoadingState } from '@grafana/data';
+import { DataFrame, dateTime, EventBus, Field, FieldType, LoadingState } from '@grafana/data';
 
 import { DataGridPanel, DataGridProps } from './DataGridPanel';
 import * as utils from './utils';
@@ -312,7 +312,7 @@ describe('DataGrid', () => {
             expect.objectContaining({
               name: 'newColumn',
               type: 'string',
-              values: new ArrayVector(['', '', '', '']),
+              values: ['', '', '', ''],
             }),
           ]),
         }),

--- a/public/app/plugins/panel/timeseries/utils.ts
+++ b/public/app/plugins/panel/timeseries/utils.ts
@@ -1,5 +1,4 @@
 import {
-  ArrayVector,
   DataFrame,
   Field,
   FieldType,
@@ -22,7 +21,7 @@ type ScaleKey = string;
 
 // this will re-enumerate all enum fields on the same scale to create one ordinal progression
 // e.g. ['a','b'][0,1,0] + ['c','d'][1,0,1] -> ['a','b'][0,1,0] + ['c','d'][3,2,3]
-function reEnumFields(frames: DataFrame[]) {
+function reEnumFields(frames: DataFrame[]): DataFrame[] {
   let allTextsByKey: Map<ScaleKey, string[]> = new Map();
 
   let frames2: DataFrame[] = frames.map((frame) => {
@@ -55,7 +54,7 @@ function reEnumFields(frames: DataFrame[]) {
 
           return {
             ...field,
-            values: new ArrayVector(idxs),
+            values: idxs,
           };
 
           // TODO: update displayProcessor?


### PR DESCRIPTION
**What is this feature?**

removes the uses of ArrayVector -- it can now just be an array


**Why do we need this feature?**

In the next major version, we should remove ArrayVector

**Who is this feature for?**

Array lovers
