### PR TITLE
Backend: Fix library panel permissions when `viewers_can_edit` set

### DIFF
--- a/pkg/services/libraryelements/guard.go
+++ b/pkg/services/libraryelements/guard.go
@@ -46,7 +46,7 @@ func (l *LibraryElementService) requireEditPermissionsOnFolder(ctx context.Conte
 		return err
 	}
 
-	canEdit, err := g.CanEdit()
+	canEdit, err := g.CanSave()
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
**Bug Fix**

This PR changes the behavior of the library panel permissions check to exclude viewers with limited edit capability from being able to save changes to library panels. 

It seems to me that the spirit of the [viewers_can_edit](https://grafana.com/docs/grafana/latest/setup-grafana/configure-grafana/#viewers_can_edit) setting was to allow users with view permissions to understand the functionality of the panel without modifying it. This is the case with regular panels, but currently, this setting gives them permission to modify library panels.

The change switches from the CanEdit to CanSave function when checking "edit" permissions for library panels:

```golang
func (a *accessControlFolderGuardian) CanSave() (bool, error) {
	if a.folder == nil {
		return false, ErrGuardianFolderNotFound.Errorf("failed to check save permissions for folder")
	}

	return a.evaluate(accesscontrol.EvalPermission(dashboards.ActionFoldersWrite, dashboards.ScopeFoldersProvider.GetResourceScopeUID(a.folder.UID)))
}

func (a *accessControlDashboardGuardian) CanEdit() (bool, error) {
	if a.dashboard == nil {
		return false, ErrGuardianDashboardNotFound.Errorf("failed to check edit permissions for dashboard")
	}

	if a.cfg.ViewersCanEdit {
		return a.CanView()
	}

	return a.evaluate(
		accesscontrol.EvalPermission(dashboards.ActionDashboardsWrite, dashboards.ScopeDashboardsProvider.GetResourceScopeUID(a.dashboard.UID)),
	)
}
```

New behavior:
![image](https://github.com/grafana/grafana/assets/13695322/e95d0e86-551d-468f-89b9-b2402ce844c2)


Please check that:
- [x] It works as expected from a user's perspective.
- [N/A] If this is a pre-GA feature, it is behind a feature toggle.
- [N/A] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
