### PR TITLE
Azure Monitor: Select all Event Types by default

### DIFF
--- a/public/app/plugins/datasource/azuremonitor/components/TracesQueryEditor/TraceTypeField.test.tsx
+++ b/public/app/plugins/datasource/azuremonitor/components/TracesQueryEditor/TraceTypeField.test.tsx
@@ -24,11 +24,10 @@ describe('TraceTypeField', () => {
       ...props.query,
       azureTraces: {
         ...props.query.azureTraces,
-        traceTypes: [],
       },
     };
+
     render(<TraceTypeField {...props} query={query} />);
-    expect(screen.getByText('Choose event types')).toBeInTheDocument();
 
     const menu = screen.getByLabelText(selectors.components.queryEditor.tracesQueryEditor.traceTypes.select);
     openMenu(menu);

--- a/public/app/plugins/datasource/azuremonitor/components/TracesQueryEditor/TraceTypeField.tsx
+++ b/public/app/plugins/datasource/azuremonitor/components/TracesQueryEditor/TraceTypeField.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useMemo } from 'react';
+import React, { useCallback, useMemo } from 'react';
 
 import { SelectableValue } from '@grafana/data';
 import { MultiSelect } from '@grafana/ui';

--- a/public/app/plugins/datasource/azuremonitor/components/TracesQueryEditor/TraceTypeField.tsx
+++ b/public/app/plugins/datasource/azuremonitor/components/TracesQueryEditor/TraceTypeField.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useMemo } from 'react';
+import React, { useCallback, useEffect, useMemo } from 'react';
 
 import { SelectableValue } from '@grafana/data';
 import { MultiSelect } from '@grafana/ui';
@@ -30,12 +30,23 @@ const TraceTypeField = ({ query, variableOptionGroup, onQueryChange }: AzureQuer
 
   const options = useMemo(() => [...tables, variableOptionGroup], [tables, variableOptionGroup]);
 
+  // Select all Event Types by default
+  const getDefaultOptions = () => {
+    const allEventTypes = tables.map((t) => t.value);
+    const defaultQuery = setTraceTypes(query, allEventTypes);
+    onQueryChange(defaultQuery);
+    return allEventTypes;
+  };
+
   return (
     <Field label="Event Type">
       <MultiSelect
         placeholder="Choose event types"
         inputId="azure-monitor-traces-type-field"
-        value={findOptions([...tables, ...variableOptionGroup.options], query.azureTraces?.traceTypes ?? [])}
+        value={findOptions(
+          [...tables, ...variableOptionGroup.options],
+          query.azureTraces?.traceTypes ?? getDefaultOptions()
+        )}
         onChange={handleChange}
         options={options}
         allowCustomValue

--- a/public/app/plugins/datasource/azuremonitor/components/TracesQueryEditor/TraceTypeField.tsx
+++ b/public/app/plugins/datasource/azuremonitor/components/TracesQueryEditor/TraceTypeField.tsx
@@ -30,7 +30,7 @@ const TraceTypeField = ({ query, variableOptionGroup, onQueryChange }: AzureQuer
 
   const options = useMemo(() => [...tables, variableOptionGroup], [tables, variableOptionGroup]);
 
-  // Select all Event Types by default
+  // Select all trace event ypes by default
   const getDefaultOptions = () => {
     const allEventTypes = tables.map((t) => t.value);
     const defaultQuery = setTraceTypes(query, allEventTypes);


### PR DESCRIPTION
This PR selects all Event Types by default when creating a Traces query so the user can see all event types at once instead of selecting each event individually. 

Fixes: #68464 