### PR TITLE
Chore: Replace grafana-authnz-team with identity-access-team as code owners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -69,8 +69,8 @@
 /pkg/apis/ @grafana/grafana-app-platform-squad
 /pkg/bus/ @grafana/backend-platform
 /pkg/cmd/ @grafana/backend-platform
-/pkg/components/apikeygen/ @grafana/grafana-authnz-team
-/pkg/components/satokengen/ @grafana/grafana-authnz-team
+/pkg/components/apikeygen/ @grafana/identity-access-team
+/pkg/components/satokengen/ @grafana/identity-access-team
 /pkg/components/dashdiffs/ @grafana/backend-platform
 /pkg/components/imguploader/ @grafana/backend-platform
 /pkg/components/loki/ @grafana/backend-platform
@@ -97,7 +97,7 @@
 /pkg/models/ @grafana/backend-platform
 /pkg/server/ @grafana/backend-platform
 /pkg/services/annotations/ @grafana/backend-platform
-/pkg/services/apikey/ @grafana/grafana-authnz-team
+/pkg/services/apikey/ @grafana/identity-access-team
 /pkg/services/cleanup/ @grafana/backend-platform
 /pkg/services/contexthandler/ @grafana/backend-platform
 /pkg/services/correlations/ @grafana/explore-squad
@@ -130,10 +130,10 @@
 /pkg/services/star/ @grafana/backend-platform
 /pkg/services/stats/ @grafana/backend-platform
 /pkg/services/tag/ @grafana/backend-platform
-/pkg/services/team/ @grafana/grafana-authnz-team
+/pkg/services/team/ @grafana/identity-access-team
 /pkg/services/temp_user/ @grafana/backend-platform
 /pkg/services/updatechecker/ @grafana/backend-platform
-/pkg/services/user/ @grafana/grafana-authnz-team
+/pkg/services/user/ @grafana/identity-access-team
 /pkg/services/validations/ @grafana/backend-platform
 /pkg/setting/ @grafana/backend-platform
 /pkg/tests/ @grafana/backend-platform
@@ -155,7 +155,7 @@
 
 # devenv
 # Backend code, developers environment
-/devenv/docker/blocks/auth/ @grafana/grafana-authnz-team
+/devenv/docker/blocks/auth/ @grafana/identity-access-team
 
 # Logs code, developers environment
 /devenv/docker/blocks/loki* @grafana/observability-logs
@@ -369,10 +369,10 @@ cypress.config.js @grafana/grafana-frontend-platform
 /public/app/core/components/GraphNG/ @grafana/dataviz-squad
 /public/app/core/components/TimeSeries/ @grafana/dataviz-squad
 /public/app/features/all.ts @grafana/grafana-frontend-platform
-/public/app/features/admin/ @grafana/grafana-authnz-team
-/public/app/features/auth-config/ @grafana/grafana-authnz-team
+/public/app/features/admin/ @grafana/identity-access-team
+/public/app/features/auth-config/ @grafana/identity-access-team
 /public/app/features/annotations/ @grafana/grafana-frontend-platform
-/public/app/features/api-keys/ @grafana/grafana-authnz-team
+/public/app/features/api-keys/ @grafana/identity-access-team
 /public/app/features/canvas/ @grafana/dataviz-squad
 /public/app/features/geo/ @grafana/dataviz-squad
 /public/app/features/visualization/data-hover/ @grafana/dataviz-squad
@@ -407,12 +407,12 @@ cypress.config.js @grafana/grafana-frontend-platform
 /public/app/features/scenes/ @grafana/dashboards-squad
 /public/app/features/browse-dashboards/ @grafana/grafana-frontend-platform
 /public/app/features/search/ @grafana/grafana-frontend-platform
-/public/app/features/serviceaccounts/ @grafana/grafana-authnz-team
+/public/app/features/serviceaccounts/ @grafana/identity-access-team
 /public/app/features/storage/ @grafana/grafana-app-platform-squad
-/public/app/features/teams/ @grafana/grafana-authnz-team
+/public/app/features/teams/ @grafana/identity-access-team
 /public/app/features/templating/ @grafana/dashboards-squad
 /public/app/features/transformers/ @grafana/grafana-bi-squad
-/public/app/features/users/ @grafana/grafana-authnz-team
+/public/app/features/users/ @grafana/identity-access-team
 /public/app/features/variables/ @grafana/dashboards-squad
 /public/app/plugins/panel/alertGroups/ @grafana/alerting-frontend
 /public/app/plugins/panel/alertlist/ @grafana/alerting-frontend
@@ -488,7 +488,7 @@ cypress.config.js @grafana/grafana-frontend-platform
 
 
 
-/scripts/benchmark-access-control.sh @grafana/grafana-authnz-team
+/scripts/benchmark-access-control.sh @grafana/identity-access-team
 /scripts/check-breaking-changes.sh @grafana/plugins-platform-frontend
 /scripts/ci-* @grafana/grafana-delivery
 /scripts/circle-* @grafana/grafana-delivery
@@ -566,25 +566,25 @@ scripts/generate-icon-bundle.js @grafana/plugins-platform-frontend @grafana/graf
 /grafana-mixin/ @grafana/hosted-grafana-team
 
 # Grafana authentication and authorization
-/pkg/login/ @grafana/grafana-authnz-team
-/pkg/services/accesscontrol/ @grafana/grafana-authnz-team
-/pkg/services/anonymous/ @grafana/grafana-authnz-team
-/pkg/services/auth/ @grafana/grafana-authnz-team
-/pkg/services/authn/ @grafana/grafana-authnz-team
-/pkg/services/signingkeys/ @grafana/grafana-authnz-team
-/pkg/services/dashboards/accesscontrol.go @grafana/grafana-authnz-team
-/pkg/services/datasources/guardian/ @grafana/grafana-authnz-team
-/pkg/services/guardian/ @grafana/grafana-authnz-team
-/pkg/services/ldap/ @grafana/grafana-authnz-team
-/pkg/services/login/ @grafana/grafana-authnz-team
-/pkg/services/loginattempt/ @grafana/grafana-authnz-team
-/pkg/services/extsvcauth/ @grafana/grafana-authnz-team
-/pkg/services/oauthtoken/ @grafana/grafana-authnz-team
-/pkg/services/serviceaccounts/ @grafana/grafana-authnz-team
+/pkg/login/ @grafana/identity-access-team
+/pkg/services/accesscontrol/ @grafana/identity-access-team
+/pkg/services/anonymous/ @grafana/identity-access-team
+/pkg/services/auth/ @grafana/identity-access-team
+/pkg/services/authn/ @grafana/identity-access-team
+/pkg/services/signingkeys/ @grafana/identity-access-team
+/pkg/services/dashboards/accesscontrol.go @grafana/identity-access-team
+/pkg/services/datasources/guardian/ @grafana/identity-access-team
+/pkg/services/guardian/ @grafana/identity-access-team
+/pkg/services/ldap/ @grafana/identity-access-team
+/pkg/services/login/ @grafana/identity-access-team
+/pkg/services/loginattempt/ @grafana/identity-access-team
+/pkg/services/extsvcauth/ @grafana/identity-access-team
+/pkg/services/oauthtoken/ @grafana/identity-access-team
+/pkg/services/serviceaccounts/ @grafana/identity-access-team
 
 # Support bundles
-/public/app/features/support-bundles/ @grafana/grafana-authnz-team
-/pkg/services/supportbundles/ @grafana/grafana-authnz-team
+/public/app/features/support-bundles/ @grafana/identity-access-team
+/pkg/services/supportbundles/ @grafana/identity-access-team
 
 # Grafana Operator Experience Team
 /pkg/infra/httpclient/httpclientprovider/sigv4_middleware.go @grafana/grafana-operator-experience-squad
@@ -674,9 +674,9 @@ embed.go @grafana/grafana-as-code
 # Conf
 /conf/defaults.ini @torkelo
 /conf/sample.ini @torkelo
-/conf/ldap.toml @grafana/grafana-authnz-team
-/conf/ldap_multiple.toml @grafana/grafana-authnz-team
-/conf/provisioning/access-control/ @grafana/grafana-authnz-team
+/conf/ldap.toml @grafana/identity-access-team
+/conf/ldap_multiple.toml @grafana/identity-access-team
+/conf/provisioning/access-control/ @grafana/identity-access-team
 /conf/provisioning/alerting/ @grafana/alerting-backend-product
 /conf/provisioning/dashboards/ @grafana/dashboards-squad
 /conf/provisioning/datasources/ @grafana/plugins-platform-backend

--- a/pkg/api/org_users.go
+++ b/pkg/api/org_users.go
@@ -325,7 +325,7 @@ func (hs *HTTPServer) searchOrgUsersHelper(c *contextmodel.ReqContext, query *or
 	// Get accesscontrol metadata and IPD labels for users in the target org
 	accessControlMetadata := map[string]accesscontrol.Metadata{}
 	if c.QueryBool("accesscontrol") && c.SignedInUser.Permissions != nil {
-		// TODO https://github.com/grafana/grafana-authnz-team/issues/268 - user access control service for fetching permissions from another organization
+		// TODO https://github.com/grafana/identity-access-team/issues/268 - user access control service for fetching permissions from another organization
 		permissions, ok := c.SignedInUser.Permissions[query.OrgID]
 		if ok {
 			accessControlMetadata = accesscontrol.GetResourcesMetadata(c.Req.Context(), permissions, "users:id:", userIDs)

--- a/pkg/services/featuremgmt/codeowners.go
+++ b/pkg/services/featuremgmt/codeowners.go
@@ -14,7 +14,7 @@ const (
 	grafanaBackendPlatformSquad                 codeowner = "@grafana/backend-platform"
 	grafanaPluginsPlatformSquad                 codeowner = "@grafana/plugins-platform-backend"
 	grafanaAsCodeSquad                          codeowner = "@grafana/grafana-as-code"
-	identityAndAccessSquad                      codeowner = "@grafana/identity-access-team"
+	identityAccessTeam                          codeowner = "@grafana/identity-access-team"
 	grafanaObservabilityLogsSquad               codeowner = "@grafana/observability-logs"
 	grafanaObservabilityTracesAndProfilingSquad codeowner = "@grafana/observability-traces-and-profiling"
 	grafanaObservabilityMetricsSquad            codeowner = "@grafana/observability-metrics"

--- a/pkg/services/featuremgmt/codeowners.go
+++ b/pkg/services/featuremgmt/codeowners.go
@@ -14,7 +14,7 @@ const (
 	grafanaBackendPlatformSquad                 codeowner = "@grafana/backend-platform"
 	grafanaPluginsPlatformSquad                 codeowner = "@grafana/plugins-platform-backend"
 	grafanaAsCodeSquad                          codeowner = "@grafana/grafana-as-code"
-	grafanaAuthnzSquad                          codeowner = "@grafana/grafana-authnz-team"
+	identityAndAccessSquad                      codeowner = "@grafana/identity-access-team"
 	grafanaObservabilityLogsSquad               codeowner = "@grafana/observability-logs"
 	grafanaObservabilityTracesAndProfilingSquad codeowner = "@grafana/observability-traces-and-profiling"
 	grafanaObservabilityMetricsSquad            codeowner = "@grafana/observability-metrics"

--- a/pkg/services/featuremgmt/registry.go
+++ b/pkg/services/featuremgmt/registry.go
@@ -228,7 +228,7 @@ var (
 			Name:        "accessControlOnCall",
 			Description: "Access control primitives for OnCall",
 			Stage:       FeatureStagePublicPreview,
-			Owner:       grafanaAuthnzSquad,
+			Owner:       identityAndAccessSquad,
 		},
 		{
 			Name:        "nestedFolders",
@@ -248,7 +248,7 @@ var (
 			Name:        "accessTokenExpirationCheck",
 			Description: "Enable OAuth access_token expiration check and token refresh using the refresh_token",
 			Stage:       FeatureStageGeneralAvailability,
-			Owner:       grafanaAuthnzSquad,
+			Owner:       identityAndAccessSquad,
 		},
 		{
 			Name:         "emptyDashboardPage",
@@ -317,7 +317,7 @@ var (
 			Name:        "gcomOnlyExternalOrgRoleSync",
 			Description: "Prohibits a user from changing organization roles synced with Grafana Cloud auth provider",
 			Stage:       FeatureStageGeneralAvailability,
-			Owner:       grafanaAuthnzSquad,
+			Owner:       identityAndAccessSquad,
 		},
 		{
 			Name:         "prometheusMetricEncyclopedia",
@@ -339,7 +339,7 @@ var (
 			Name:        "clientTokenRotation",
 			Description: "Replaces the current in-request token rotation so that the client initiates the rotation",
 			Stage:       FeatureStageExperimental,
-			Owner:       grafanaAuthnzSquad,
+			Owner:       identityAndAccessSquad,
 		},
 		{
 			Name:        "prometheusDataplane",
@@ -418,7 +418,7 @@ var (
 			Description:     "Starts an OAuth2 authentication provider for external services",
 			Stage:           FeatureStageExperimental,
 			RequiresDevMode: true,
-			Owner:           grafanaAuthnzSquad,
+			Owner:           identityAndAccessSquad,
 		},
 		{
 			Name:        "refactorVariablesTimeRange",
@@ -637,7 +637,7 @@ var (
 			Description:     "Support faster dashboard and folder search by splitting permission scopes into parts",
 			Stage:           FeatureStagePublicPreview,
 			FrontendOnly:    false,
-			Owner:           grafanaAuthnzSquad,
+			Owner:           identityAndAccessSquad,
 			RequiresRestart: true,
 		},
 		{
@@ -799,7 +799,7 @@ var (
 			Name:            "idForwarding",
 			Description:     "Generate signed id token for identity that can be forwarded to plugins and external services",
 			Stage:           FeatureStageExperimental,
-			Owner:           grafanaAuthnzSquad,
+			Owner:           identityAndAccessSquad,
 			RequiresDevMode: true,
 		},
 		{
@@ -814,7 +814,7 @@ var (
 			Description:     "Automatic service account and token setup for plugins",
 			Stage:           FeatureStageExperimental,
 			RequiresDevMode: true,
-			Owner:           grafanaAuthnzSquad,
+			Owner:           identityAndAccessSquad,
 		},
 		{
 			Name:         "panelMonitoring",
@@ -884,7 +884,7 @@ var (
 			Description:  "Enables datasources to apply team headers to the client requests",
 			Stage:        FeatureStageExperimental,
 			FrontendOnly: false,
-			Owner:        grafanaAuthnzSquad,
+			Owner:        identityAndAccessSquad,
 		},
 		{
 			Name:         "awsDatasourcesNewFormStyling",
@@ -958,7 +958,7 @@ var (
 			Description:     "Separate annotation permissions from dashboard permissions to allow for more granular control.",
 			Stage:           FeatureStageExperimental,
 			RequiresDevMode: false,
-			Owner:           grafanaAuthnzSquad,
+			Owner:           identityAndAccessSquad,
 		},
 		{
 			Name:         "extractFieldsNameDeduplication",

--- a/pkg/services/featuremgmt/registry.go
+++ b/pkg/services/featuremgmt/registry.go
@@ -228,7 +228,7 @@ var (
 			Name:        "accessControlOnCall",
 			Description: "Access control primitives for OnCall",
 			Stage:       FeatureStagePublicPreview,
-			Owner:       identityAndAccessSquad,
+			Owner:       identityAccessTeam,
 		},
 		{
 			Name:        "nestedFolders",
@@ -248,7 +248,7 @@ var (
 			Name:        "accessTokenExpirationCheck",
 			Description: "Enable OAuth access_token expiration check and token refresh using the refresh_token",
 			Stage:       FeatureStageGeneralAvailability,
-			Owner:       identityAndAccessSquad,
+			Owner:       identityAccessTeam,
 		},
 		{
 			Name:         "emptyDashboardPage",
@@ -317,7 +317,7 @@ var (
 			Name:        "gcomOnlyExternalOrgRoleSync",
 			Description: "Prohibits a user from changing organization roles synced with Grafana Cloud auth provider",
 			Stage:       FeatureStageGeneralAvailability,
-			Owner:       identityAndAccessSquad,
+			Owner:       identityAccessTeam,
 		},
 		{
 			Name:         "prometheusMetricEncyclopedia",
@@ -339,7 +339,7 @@ var (
 			Name:        "clientTokenRotation",
 			Description: "Replaces the current in-request token rotation so that the client initiates the rotation",
 			Stage:       FeatureStageExperimental,
-			Owner:       identityAndAccessSquad,
+			Owner:       identityAccessTeam,
 		},
 		{
 			Name:        "prometheusDataplane",
@@ -418,7 +418,7 @@ var (
 			Description:     "Starts an OAuth2 authentication provider for external services",
 			Stage:           FeatureStageExperimental,
 			RequiresDevMode: true,
-			Owner:           identityAndAccessSquad,
+			Owner:           identityAccessTeam,
 		},
 		{
 			Name:        "refactorVariablesTimeRange",
@@ -637,7 +637,7 @@ var (
 			Description:     "Support faster dashboard and folder search by splitting permission scopes into parts",
 			Stage:           FeatureStagePublicPreview,
 			FrontendOnly:    false,
-			Owner:           identityAndAccessSquad,
+			Owner:           identityAccessTeam,
 			RequiresRestart: true,
 		},
 		{
@@ -799,7 +799,7 @@ var (
 			Name:            "idForwarding",
 			Description:     "Generate signed id token for identity that can be forwarded to plugins and external services",
 			Stage:           FeatureStageExperimental,
-			Owner:           identityAndAccessSquad,
+			Owner:           identityAccessTeam,
 			RequiresDevMode: true,
 		},
 		{
@@ -814,7 +814,7 @@ var (
 			Description:     "Automatic service account and token setup for plugins",
 			Stage:           FeatureStageExperimental,
 			RequiresDevMode: true,
-			Owner:           identityAndAccessSquad,
+			Owner:           identityAccessTeam,
 		},
 		{
 			Name:         "panelMonitoring",
@@ -884,7 +884,7 @@ var (
 			Description:  "Enables datasources to apply team headers to the client requests",
 			Stage:        FeatureStageExperimental,
 			FrontendOnly: false,
-			Owner:        identityAndAccessSquad,
+			Owner:        identityAccessTeam,
 		},
 		{
 			Name:         "awsDatasourcesNewFormStyling",
@@ -958,7 +958,7 @@ var (
 			Description:     "Separate annotation permissions from dashboard permissions to allow for more granular control.",
 			Stage:           FeatureStageExperimental,
 			RequiresDevMode: false,
-			Owner:           identityAndAccessSquad,
+			Owner:           identityAccessTeam,
 		},
 		{
 			Name:         "extractFieldsNameDeduplication",

--- a/pkg/services/featuremgmt/toggles_gen.csv
+++ b/pkg/services/featuremgmt/toggles_gen.csv
@@ -31,10 +31,10 @@ athenaAsyncQueryDataSupport,GA,@grafana/aws-datasources,false,false,false,true
 cloudwatchNewRegionsHandler,experimental,@grafana/aws-datasources,false,false,false,false
 showDashboardValidationWarnings,experimental,@grafana/dashboards-squad,false,false,false,false
 mysqlAnsiQuotes,experimental,@grafana/backend-platform,false,false,false,false
-accessControlOnCall,preview,@grafana/grafana-authnz-team,false,false,false,false
+accessControlOnCall,preview,@grafana/identity-access-team,false,false,false,false
 nestedFolders,preview,@grafana/backend-platform,false,false,false,false
 nestedFolderPicker,GA,@grafana/grafana-frontend-platform,false,false,false,true
-accessTokenExpirationCheck,GA,@grafana/grafana-authnz-team,false,false,false,false
+accessTokenExpirationCheck,GA,@grafana/identity-access-team,false,false,false,false
 emptyDashboardPage,GA,@grafana/dashboards-squad,false,false,false,true
 disablePrometheusExemplarSampling,GA,@grafana/observability-metrics,false,false,false,false
 alertingBacktesting,experimental,@grafana/alerting-squad,false,false,false,false
@@ -44,10 +44,10 @@ logsContextDatasourceUi,GA,@grafana/observability-logs,false,false,false,true
 lokiQuerySplitting,GA,@grafana/observability-logs,false,false,false,true
 lokiQuerySplittingConfig,experimental,@grafana/observability-logs,false,false,false,true
 individualCookiePreferences,experimental,@grafana/backend-platform,false,false,false,false
-gcomOnlyExternalOrgRoleSync,GA,@grafana/grafana-authnz-team,false,false,false,false
+gcomOnlyExternalOrgRoleSync,GA,@grafana/identity-access-team,false,false,false,false
 prometheusMetricEncyclopedia,GA,@grafana/observability-metrics,false,false,false,true
 influxdbBackendMigration,GA,@grafana/observability-metrics,false,false,false,true
-clientTokenRotation,experimental,@grafana/grafana-authnz-team,false,false,false,false
+clientTokenRotation,experimental,@grafana/identity-access-team,false,false,false,false
 prometheusDataplane,GA,@grafana/observability-metrics,false,false,false,false
 lokiMetricDataplane,GA,@grafana/observability-logs,false,false,false,false
 lokiLogsDataplane,experimental,@grafana/observability-logs,false,false,false,false
@@ -59,7 +59,7 @@ alertStateHistoryLokiPrimary,experimental,@grafana/alerting-squad,false,false,fa
 alertStateHistoryLokiOnly,experimental,@grafana/alerting-squad,false,false,false,false
 unifiedRequestLog,experimental,@grafana/backend-platform,false,false,false,false
 renderAuthJWT,preview,@grafana/grafana-as-code,false,false,false,false
-externalServiceAuth,experimental,@grafana/grafana-authnz-team,true,false,false,false
+externalServiceAuth,experimental,@grafana/identity-access-team,true,false,false,false
 refactorVariablesTimeRange,preview,@grafana/dashboards-squad,false,false,false,false
 useCachingService,GA,@grafana/grafana-operator-experience-squad,false,false,true,false
 enableElasticsearchBackendQuerying,GA,@grafana/observability-logs,false,false,false,false
@@ -90,7 +90,7 @@ grafanaAPIServer,experimental,@grafana/grafana-app-platform-squad,false,false,fa
 grafanaAPIServerWithExperimentalAPIs,experimental,@grafana/grafana-app-platform-squad,false,false,false,false
 featureToggleAdminPage,experimental,@grafana/grafana-operator-experience-squad,false,false,true,false
 awsAsyncQueryCaching,preview,@grafana/aws-datasources,false,false,false,false
-splitScopes,preview,@grafana/grafana-authnz-team,false,false,true,false
+splitScopes,preview,@grafana/identity-access-team,false,false,true,false
 azureMonitorDataplane,GA,@grafana/partner-datasources,false,false,false,false
 traceToProfiles,experimental,@grafana/observability-traces-and-profiling,false,false,false,true
 permissionsFilterRemoveSubquery,experimental,@grafana/backend-platform,false,false,false,false
@@ -112,9 +112,9 @@ alertingContactPointsV2,preview,@grafana/alerting-squad,false,false,false,true
 externalCorePlugins,experimental,@grafana/plugins-platform-backend,false,false,false,false
 pluginsAPIMetrics,experimental,@grafana/plugins-platform-backend,false,false,false,true
 httpSLOLevels,experimental,@grafana/hosted-grafana-team,false,false,true,false
-idForwarding,experimental,@grafana/grafana-authnz-team,true,false,false,false
+idForwarding,experimental,@grafana/identity-access-team,true,false,false,false
 cloudWatchWildCardDimensionValues,GA,@grafana/aws-datasources,false,false,false,false
-externalServiceAccounts,experimental,@grafana/grafana-authnz-team,true,false,false,false
+externalServiceAccounts,experimental,@grafana/identity-access-team,true,false,false,false
 panelMonitoring,experimental,@grafana/dataviz-squad,false,false,false,true
 enableNativeHTTPHistogram,experimental,@grafana/hosted-grafana-team,false,false,false,false
 formatString,experimental,@grafana/grafana-bi-squad,false,false,false,true
@@ -124,7 +124,7 @@ kubernetesPlaylistsAPI,experimental,@grafana/grafana-app-platform-squad,false,fa
 cloudWatchBatchQueries,preview,@grafana/aws-datasources,false,false,false,false
 navAdminSubsections,experimental,@grafana/grafana-frontend-platform,false,false,false,false
 recoveryThreshold,experimental,@grafana/alerting-squad,false,false,true,false
-teamHttpHeaders,experimental,@grafana/grafana-authnz-team,false,false,false,false
+teamHttpHeaders,experimental,@grafana/identity-access-team,false,false,false,false
 awsDatasourcesNewFormStyling,experimental,@grafana/aws-datasources,false,false,false,true
 cachingOptimizeSerializationMemoryUsage,experimental,@grafana/grafana-operator-experience-squad,false,false,false,false
 panelTitleSearchInV1,experimental,@grafana/backend-platform,true,false,false,false
@@ -135,6 +135,6 @@ prometheusPromQAIL,experimental,@grafana/observability-metrics,false,false,false
 alertmanagerRemoteSecondary,experimental,@grafana/alerting-squad,false,false,false,false
 alertmanagerRemotePrimary,experimental,@grafana/alerting-squad,false,false,false,false
 alertmanagerRemoteOnly,experimental,@grafana/alerting-squad,false,false,false,false
-annotationPermissionUpdate,experimental,@grafana/grafana-authnz-team,false,false,false,false
+annotationPermissionUpdate,experimental,@grafana/identity-access-team,false,false,false,false
 extractFieldsNameDeduplication,experimental,@grafana/grafana-bi-squad,false,false,false,true
 dashboardSceneForViewers,experimental,@grafana/dashboards-squad,false,false,false,true

--- a/scripts/modowners/README.md
+++ b/scripts/modowners/README.md
@@ -47,7 +47,7 @@ Example output:
 @grafana/dataviz-squad 1
 @grafana/backend-platform 75
 @grafana/grafana-as-code 11
-@grafana/grafana-authnz-team 6
+@grafana/identity-access-team 6
 @grafana/partner-datasources 4
 ```
 
@@ -67,7 +67,7 @@ List all dependencies of given owner(s).
 
 Example CLI command to list all direct dependencies owned by Delivery and Authnz:
 
-`go run scripts/modowners/modowners.go modules -o @grafana/grafana-delivery,@grafana/grafana-authnz-team go.mod`
+`go run scripts/modowners/modowners.go modules -o @grafana/grafana-delivery,@grafana/identity-access-team go.mod`
 
 Example output:
 

--- a/scripts/modowners/modowners.go
+++ b/scripts/modowners/modowners.go
@@ -129,7 +129,7 @@ func owners(fileSystem fs.FS, logger *log.Logger, args []string) error {
 }
 
 // Print dependencies for a given owner. Can specify one or more owners.
-// An example CLI command to list all direct dependencies owned by Delivery and Authnz `go run scripts/modowners/modowners.go modules -o @grafana/grafana-delivery,@grafana/grafana-authnz-team go.mod`
+// An example CLI command to list all direct dependencies owned by Delivery and Authnz `go run scripts/modowners/modowners.go modules -o @grafana/grafana-delivery,@grafana/identity-access-team go.mod`
 func modules(fileSystem fs.FS, logger *log.Logger, args []string) error {
 	fs := flag.NewFlagSet("modules", flag.ExitOnError)
 	indirect := fs.Bool("i", false, "print indirect dependencies")


### PR DESCRIPTION
Grafana AuthNZ team does not exist anymore and we have formed a new, Identity and Access team. `@gafana/identity-access-team` exists for a while and despite the fact that there are two squads within the team, the team shares ownership of entire domain at the moment, therefore one owner of all components. 