### PR TITLE
Logs Popover Menu: add feature flag and interaction tracking

### DIFF
--- a/docs/sources/setup-grafana/configure-grafana/feature-toggles/index.md
+++ b/docs/sources/setup-grafana/configure-grafana/feature-toggles/index.md
@@ -164,6 +164,7 @@ Experimental features might be changed or removed without prior notice.
 | `annotationPermissionUpdate`                | Separate annotation permissions from dashboard permissions to allow for more granular control.                                                                                                                                                                                    |
 | `extractFieldsNameDeduplication`            | Make sure extracted field names are unique in the dataframe                                                                                                                                                                                                                       |
 | `dashboardSceneForViewers`                  | Enables dashboard rendering using Scenes for viewer roles                                                                                                                                                                                                                         |
+| `logRowsPopoverMenu`                        | Enable filtering menu displayed when text of a log line is selected                                                                                                                                                                                                               |
 
 ## Development feature toggles
 

--- a/packages/grafana-data/src/types/featureToggles.gen.ts
+++ b/packages/grafana-data/src/types/featureToggles.gen.ts
@@ -160,4 +160,5 @@ export interface FeatureToggles {
   dashboardSceneForViewers?: boolean;
   panelFilterVariable?: boolean;
   pdfTables?: boolean;
+  logsRowsPopoverMenu?: boolean;
 }

--- a/packages/grafana-data/src/types/featureToggles.gen.ts
+++ b/packages/grafana-data/src/types/featureToggles.gen.ts
@@ -160,5 +160,5 @@ export interface FeatureToggles {
   dashboardSceneForViewers?: boolean;
   panelFilterVariable?: boolean;
   pdfTables?: boolean;
-  logsRowsPopoverMenu?: boolean;
+  logRowsPopoverMenu?: boolean;
 }

--- a/pkg/services/featuremgmt/registry.go
+++ b/pkg/services/featuremgmt/registry.go
@@ -1035,7 +1035,7 @@ var (
 		{
 			Name:         "logRowsPopoverMenu",
 			Description:  "Enable filtering menu displayed when text of a log line is selected",
-			Stage:        FeatureStagePrivatePreview,
+			Stage:        FeatureStageExperimental,
 			FrontendOnly: true,
 			Owner:        grafanaObservabilityLogsSquad,
 		},

--- a/pkg/services/featuremgmt/registry.go
+++ b/pkg/services/featuremgmt/registry.go
@@ -1033,7 +1033,7 @@ var (
 			Owner:        grafanaSharingSquad,
 		},
 		{
-			Name:         "logsRowsPopoverMenu",
+			Name:         "logRowsPopoverMenu",
 			Description:  "Enable filtering menu displayed when text of a log line is selected",
 			Stage:        FeatureStagePrivatePreview,
 			FrontendOnly: true,

--- a/pkg/services/featuremgmt/registry.go
+++ b/pkg/services/featuremgmt/registry.go
@@ -1032,6 +1032,13 @@ var (
 			FrontendOnly: false,
 			Owner:        grafanaSharingSquad,
 		},
+		{
+			Name:         "logsRowsPopoverMenu",
+			Description:  "Enable filtering menu displayed when text of a log line is selected",
+			Stage:        FeatureStagePrivatePreview,
+			FrontendOnly: true,
+			Owner:        grafanaObservabilityLogsSquad,
+		},
 	}
 )
 

--- a/pkg/services/featuremgmt/toggles_gen.csv
+++ b/pkg/services/featuremgmt/toggles_gen.csv
@@ -141,4 +141,4 @@ extractFieldsNameDeduplication,experimental,@grafana/grafana-bi-squad,false,fals
 dashboardSceneForViewers,experimental,@grafana/dashboards-squad,false,false,false,true
 panelFilterVariable,experimental,@grafana/dashboards-squad,false,false,false,true
 pdfTables,privatePreview,@grafana/sharing-squad,false,false,false,false
-logRowsPopoverMenu,privatePreview,@grafana/observability-logs,false,false,false,true
+logRowsPopoverMenu,experimental,@grafana/observability-logs,false,false,false,true

--- a/pkg/services/featuremgmt/toggles_gen.csv
+++ b/pkg/services/featuremgmt/toggles_gen.csv
@@ -141,4 +141,4 @@ extractFieldsNameDeduplication,experimental,@grafana/grafana-bi-squad,false,fals
 dashboardSceneForViewers,experimental,@grafana/dashboards-squad,false,false,false,true
 panelFilterVariable,experimental,@grafana/dashboards-squad,false,false,false,true
 pdfTables,privatePreview,@grafana/sharing-squad,false,false,false,false
-logsRowsPopoverMenu,privatePreview,@grafana/observability-logs,false,false,false,true
+logRowsPopoverMenu,privatePreview,@grafana/observability-logs,false,false,false,true

--- a/pkg/services/featuremgmt/toggles_gen.csv
+++ b/pkg/services/featuremgmt/toggles_gen.csv
@@ -141,3 +141,4 @@ extractFieldsNameDeduplication,experimental,@grafana/grafana-bi-squad,false,fals
 dashboardSceneForViewers,experimental,@grafana/dashboards-squad,false,false,false,true
 panelFilterVariable,experimental,@grafana/dashboards-squad,false,false,false,true
 pdfTables,privatePreview,@grafana/sharing-squad,false,false,false,false
+logsRowsPopoverMenu,privatePreview,@grafana/observability-logs,false,false,false,true

--- a/pkg/services/featuremgmt/toggles_gen.go
+++ b/pkg/services/featuremgmt/toggles_gen.go
@@ -575,7 +575,7 @@ const (
 	// Enables generating table data as PDF in reporting
 	FlagPdfTables = "pdfTables"
 
-	// FlagLogsRowsPopoverMenu
+	// FlagLogRowsPopoverMenu
 	// Enable filtering menu displayed when text of a log line is selected
-	FlagLogsRowsPopoverMenu = "logsRowsPopoverMenu"
+	FlagLogRowsPopoverMenu = "logRowsPopoverMenu"
 )

--- a/pkg/services/featuremgmt/toggles_gen.go
+++ b/pkg/services/featuremgmt/toggles_gen.go
@@ -574,4 +574,8 @@ const (
 	// FlagPdfTables
 	// Enables generating table data as PDF in reporting
 	FlagPdfTables = "pdfTables"
+
+	// FlagLogsRowsPopoverMenu
+	// Enable filtering menu displayed when text of a log line is selected
+	FlagLogsRowsPopoverMenu = "logsRowsPopoverMenu"
 )

--- a/public/app/features/logs/components/LogRows.test.tsx
+++ b/public/app/features/logs/components/LogRows.test.tsx
@@ -13,8 +13,8 @@ jest.mock('@grafana/runtime', () => ({
   config: {
     featureToggles: {
       logRowsPopoverMenu: true,
-    }
-  }
+    },
+  },
 }));
 
 describe('LogRows', () => {

--- a/public/app/features/logs/components/LogRows.test.tsx
+++ b/public/app/features/logs/components/LogRows.test.tsx
@@ -12,7 +12,7 @@ jest.mock('@grafana/runtime', () => ({
   ...jest.requireActual('@grafana/runtime'),
   config: {
     featureToggles: {
-      logsRowsPopoverMenu: true,
+      logRowsPopoverMenu: true,
     }
   }
 }));

--- a/public/app/features/logs/components/LogRows.test.tsx
+++ b/public/app/features/logs/components/LogRows.test.tsx
@@ -8,6 +8,15 @@ import { LogRowModel, LogsDedupStrategy, LogsSortOrder } from '@grafana/data';
 import { LogRows, PREVIEW_LIMIT } from './LogRows';
 import { createLogRow } from './__mocks__/logRow';
 
+jest.mock('@grafana/runtime', () => ({
+  ...jest.requireActual('@grafana/runtime'),
+  config: {
+    featureToggles: {
+      logsRowsPopoverMenu: true,
+    }
+  }
+}));
+
 describe('LogRows', () => {
   it('renders rows', () => {
     const rows: LogRowModel[] = [createLogRow({ uid: '1' }), createLogRow({ uid: '2' }), createLogRow({ uid: '3' })];

--- a/public/app/features/logs/components/LogRows.tsx
+++ b/public/app/features/logs/components/LogRows.tsx
@@ -96,7 +96,7 @@ class UnThemedLogRows extends PureComponent<Props, State> {
   };
 
   handleSelection = (e: MouseEvent<HTMLTableRowElement>, row: LogRowModel): boolean => {
-    if (!config.featureToggles.logsRowsPopoverMenu) {
+    if (!config.featureToggles.logRowsPopoverMenu) {
       return false;
     }
     // Selection is ignored if the filter functions are not defined.

--- a/public/app/features/logs/components/LogRows.tsx
+++ b/public/app/features/logs/components/LogRows.tsx
@@ -12,6 +12,7 @@ import {
   CoreApp,
   DataFrame,
 } from '@grafana/data';
+import { config } from '@grafana/runtime';
 import { withTheme2, Themeable2 } from '@grafana/ui';
 
 import { UniqueKeyMaker } from '../UniqueKeyMaker';
@@ -95,6 +96,9 @@ class UnThemedLogRows extends PureComponent<Props, State> {
   };
 
   handleSelection = (e: MouseEvent<HTMLTableRowElement>, row: LogRowModel): boolean => {
+    if (!config.featureToggles.logsRowsPopoverMenu) {
+      return false;
+    }
     // Selection is ignored if the filter functions are not defined.
     if (!this.props.onClickFilterOutValue && !this.props.onClickFilterValue) {
       return false;

--- a/public/app/features/logs/components/PopoverMenu.tsx
+++ b/public/app/features/logs/components/PopoverMenu.tsx
@@ -56,7 +56,7 @@ export const PopoverMenu = ({
           onClick={() => {
             copyText(selection, containerRef);
             close();
-            track('copy_selection_clicked', selection.length);
+            track('copy_selection_clicked', selection.length, row.datasourceType);
           }}
         />
         {onClickFilterValue && (
@@ -65,7 +65,7 @@ export const PopoverMenu = ({
             onClick={() => {
               onClickFilterValue(selection, row.dataFrame.refId);
               close();
-              track('line_filter_clicked', selection.length);
+              track('line_filter_clicked', selection.length, row.datasourceType);
             }}
           />
         )}
@@ -75,7 +75,7 @@ export const PopoverMenu = ({
             onClick={() => {
               onClickFilterOutValue(selection, row.dataFrame.refId);
               close();
-              track('line_filter_out_clicked', selection.length);
+              track('line_filter_out_clicked', selection.length, row.datasourceType);
             }}
           />
         )}
@@ -84,9 +84,10 @@ export const PopoverMenu = ({
   );
 };
 
-function track(event: string, selectionLength: number) {
+function track(event: string, selectionLength: number, dataSourceType: string | undefined) {
   reportInteraction(`grafana_explore_logs_${event}`, {
-    selectionLength,
+    selection_length: selectionLength,
+    ds_type: dataSourceType || 'unknown',
   });
 }
 

--- a/public/app/features/logs/components/PopoverMenu.tsx
+++ b/public/app/features/logs/components/PopoverMenu.tsx
@@ -2,6 +2,7 @@ import { css } from '@emotion/css';
 import React, { useEffect, useRef } from 'react';
 
 import { GrafanaTheme2, LogRowModel } from '@grafana/data';
+import { reportInteraction } from '@grafana/runtime';
 import { Menu, useStyles2 } from '@grafana/ui';
 
 import { copyText } from '../utils';
@@ -55,6 +56,7 @@ export const PopoverMenu = ({
           onClick={() => {
             copyText(selection, containerRef);
             close();
+            track('copy_selection_clicked', selection.length);
           }}
         />
         {onClickFilterValue && (
@@ -63,6 +65,7 @@ export const PopoverMenu = ({
             onClick={() => {
               onClickFilterValue(selection, row.dataFrame.refId);
               close();
+              track('line_filter_clicked', selection.length);
             }}
           />
         )}
@@ -72,6 +75,7 @@ export const PopoverMenu = ({
             onClick={() => {
               onClickFilterOutValue(selection, row.dataFrame.refId);
               close();
+              track('line_filter_out_clicked', selection.length);
             }}
           />
         )}
@@ -79,6 +83,12 @@ export const PopoverMenu = ({
     </div>
   );
 };
+
+function track(event: string, selectionLength: number) {
+  reportInteraction(`grafana_explore_logs_${event}`, {
+    selectionLength,
+  });
+}
 
 const getStyles = (theme: GrafanaTheme2) => ({
   menu: css({


### PR DESCRIPTION
* Added `logRowsPopoverMenu` feature flag for the new popover menu.
* Added interaction events:
  - Copy selection `grafana_explore_logs_copy_selection_clicked`
  - Filter for `grafana_explore_logs_line_filter_clicked`
  - Filter out `grafana_explore_logs_line_filter_out_clicked`

**Which issue(s) does this PR fix?**:

Part of https://github.com/grafana/grafana/issues/76129