### PR TITLE
Dashboards: Fix issue causing crashes when saving new dashboard

### DIFF
--- a/.betterer.results
+++ b/.betterer.results
@@ -3000,9 +3000,10 @@ exports[`better eslint`] = {
       [0, 0, 0, "Do not use any type assertions.", "2"],
       [0, 0, 0, "Do not use any type assertions.", "3"],
       [0, 0, 0, "Do not use any type assertions.", "4"],
-      [0, 0, 0, "Unexpected any. Specify a different type.", "5"],
-      [0, 0, 0, "Do not use any type assertions.", "6"],
-      [0, 0, 0, "Unexpected any. Specify a different type.", "7"]
+      [0, 0, 0, "Do not use any type assertions.", "5"],
+      [0, 0, 0, "Unexpected any. Specify a different type.", "6"],
+      [0, 0, 0, "Do not use any type assertions.", "7"],
+      [0, 0, 0, "Unexpected any. Specify a different type.", "8"]
     ],
     "public/app/features/dashboard/components/DashboardRow/DashboardRow.test.tsx:5381": [
       [0, 0, 0, "Unexpected any. Specify a different type.", "0"]

--- a/public/app/features/dashboard/components/DashboardPrompt/DashboardPrompt.tsx
+++ b/public/app/features/dashboard/components/DashboardPrompt/DashboardPrompt.tsx
@@ -146,6 +146,11 @@ export function ignoreChanges(current: DashboardModel | null, original: object |
     return true;
   }
 
+  // Ignore changes if original is unsaved
+  if ((original as DashboardModel).version === 0) {
+    return true;
+  }
+
   // Ignore changes if the user has been signed out
   if (!contextSrv.isSignedIn) {
     return true;

--- a/public/app/features/dashboard/state/__fixtures__/dashboardFixtures.ts
+++ b/public/app/features/dashboard/state/__fixtures__/dashboardFixtures.ts
@@ -22,6 +22,7 @@ export function createDashboardModelFixture(
     editable: true,
     graphTooltip: defaultDashboardCursorSync,
     schemaVersion: 1,
+    version: 1,
     timezone: '',
     ...dashboardInput,
   };


### PR DESCRIPTION
Maybe "avoids issue" is a better title. The underlying issue is here:
https://github.com/grafana/grafana/blob/d624a5d490ce845eeba9c8bfb98aa0f7f8be3e56/public/app/features/dashboard/components/SaveDashboard/SaveDashboardErrorProxy.tsx#L32-L36

Specifically line 34 where `error.isHandled` is set to `true`.

It seems like what happens is:
1. User creates new dashboard
2. User adds panel, edit view is opened
3. User hits save, drawer opens, then confirms save
4. POST request is made with dashboard json, is saved successfully
5. After save, tries to exit panel edit view
6. `DashboardPrompt` `onHistoryBlock` function is called.
7. `hasChanges(dashboard, original)` is called, but at this stage `original` still has `version` 0, while `dashboard` has `version` 1. Note that there is code in `DashboardPrompt` to update `original` when a `DashboardSavedEvent` is emitted, but I guess `hasChanges` gets executed first
8. Unsaved changes prompt appears, user hits save
9. POST request is made with the same dashboard json, error gets returned since it already exists
10. Line 34 in `SaveDashboardErrorProxy` occurs, causing the crash.

So with this PR the issue is sort of avoided by saying "ignore changes if all we're changing is a dashboard that hasn't been saved yet", but I guess a "real" fix would figure out how to update `original` in `DashboardPrompt` before it looks for unsaved changes.

Closes #77593 
