### PR TITLE
Alerting: Fix export with modifications URL when mounted on subpath

### DIFF
--- a/public/app/features/alerting/unified/components/rules/RuleDetailsActionButtons.tsx
+++ b/public/app/features/alerting/unified/components/rules/RuleDetailsActionButtons.tsx
@@ -4,7 +4,7 @@ import React, { Fragment, useState } from 'react';
 import { useLocation } from 'react-router-dom';
 
 import { GrafanaTheme2, textUtil, urlUtil } from '@grafana/data';
-import { config, locationService } from '@grafana/runtime';
+import { config } from '@grafana/runtime';
 import {
   Button,
   ClipboardButton,
@@ -238,17 +238,11 @@ export const RuleDetailsActionButtons = ({ rule, rulesSource, isViewMode }: Prop
     }
 
     if (isGrafanaRulerRule(rulerRule)) {
-      moreActionsButtons.push(
-        <Menu.Item
-          label="Modify export"
-          icon="edit"
-          onClick={() =>
-            locationService.push(
-              createUrl(`/alerting/${encodeURIComponent(ruleId.stringifyIdentifier(identifier))}/modify-export`)
-            )
-          }
-        />
+      const modifyUrl = createUrl(
+        `/alerting/${encodeURIComponent(ruleId.stringifyIdentifier(identifier))}/modify-export`
       );
+
+      moreActionsButtons.push(<Menu.Item label="Modify export" icon="edit" url={modifyUrl} />);
     }
 
     if (hasCreateRulePermission && !isFederated) {


### PR DESCRIPTION
**What is this feature?**

This PR fixes incorrect redirect when exporting a rule with changes. The bug initially surfaced because `history.push` was being combined with `createUrl` – `history.push` from the location service already prepends the subUrl.

This PR uses the `url` property for a menu item with the result of `createUrl()`.

**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/grafana/issues/77149

**Special notes for your reviewer:**
