### PR TITLE
Chore: Deprecate FolderID in Hit

### DIFF
--- a/pkg/services/dashboards/database/database_test.go
+++ b/pkg/services/dashboards/database/database_test.go
@@ -452,6 +452,7 @@ func TestIntegrationDashboardDataAccess(t *testing.T) {
 		hit := hits[0]
 		require.Equal(t, hit.ID, savedDash.ID)
 		require.Equal(t, hit.URL, fmt.Sprintf("/d/%s/%s", savedDash.UID, savedDash.Slug))
+		// nolint:staticcheck
 		require.Equal(t, hit.FolderID, savedFolder.ID)
 		require.Equal(t, hit.FolderUID, savedFolder.UID)
 		require.Equal(t, hit.FolderTitle, savedFolder.Title)
@@ -479,6 +480,7 @@ func TestIntegrationDashboardDataAccess(t *testing.T) {
 		hit := hits[0]
 		require.Equal(t, hit.ID, savedDash.ID)
 		require.Equal(t, hit.URL, fmt.Sprintf("/d/%s/%s", savedDash.UID, savedDash.Slug))
+		// nolint:staticcheck
 		require.Equal(t, hit.FolderID, savedFolder.ID)
 		require.Equal(t, hit.FolderUID, savedFolder.UID)
 		require.Equal(t, hit.FolderTitle, savedFolder.Title)
@@ -1230,7 +1232,7 @@ func makeQueryResult(query *dashboards.FindPersistedDashboardsQuery, res []dashb
 				URI:         "db/" + item.Slug,
 				URL:         dashboards.GetDashboardFolderURL(item.IsFolder, item.UID, item.Slug),
 				Type:        hitType,
-				FolderID:    item.FolderID,
+				FolderID:    item.FolderID, // nolint:staticcheck
 				FolderUID:   item.FolderUID,
 				FolderTitle: item.FolderTitle,
 				Tags:        []string{},

--- a/pkg/services/dashboards/models.go
+++ b/pkg/services/dashboards/models.go
@@ -483,13 +483,14 @@ type FindPersistedDashboardsQuery struct {
 	DashboardIds  []int64
 	DashboardUIDs []string
 	Type          string
-	FolderIds     []int64
-	FolderUIDs    []string
-	Tags          []string
-	Limit         int64
-	Page          int64
-	Permission    PermissionType
-	Sort          model.SortOption
+	// Deprecated: use FolderUID instead
+	FolderIds  []int64
+	FolderUIDs []string
+	Tags       []string
+	Limit      int64
+	Page       int64
+	Permission PermissionType
+	Sort       model.SortOption
 
 	Filters []any
 }

--- a/pkg/services/dashboards/models.go
+++ b/pkg/services/dashboards/models.go
@@ -483,14 +483,13 @@ type FindPersistedDashboardsQuery struct {
 	DashboardIds  []int64
 	DashboardUIDs []string
 	Type          string
-	// Deprecated: use FolderUID instead
-	FolderIds  []int64
-	FolderUIDs []string
-	Tags       []string
-	Limit      int64
-	Page       int64
-	Permission PermissionType
-	Sort       model.SortOption
+	FolderIds     []int64
+	FolderUIDs    []string
+	Tags          []string
+	Limit         int64
+	Page          int64
+	Permission    PermissionType
+	Sort          model.SortOption
 
 	Filters []any
 }

--- a/pkg/services/dashboards/service/dashboard_service.go
+++ b/pkg/services/dashboards/service/dashboard_service.go
@@ -558,7 +558,7 @@ func makeQueryResult(query *dashboards.FindPersistedDashboardsQuery, res []dashb
 				URI:         "db/" + item.Slug,
 				URL:         dashboards.GetDashboardFolderURL(item.IsFolder, item.UID, item.Slug),
 				Type:        getHitType(item),
-				FolderID:    item.FolderID,
+				FolderID:    item.FolderID, // nolint:staticcheck
 				FolderUID:   item.FolderUID,
 				FolderTitle: item.FolderTitle,
 				Tags:        []string{},

--- a/pkg/services/search/model/model.go
+++ b/pkg/services/search/model/model.go
@@ -62,21 +62,22 @@ const (
 )
 
 type Hit struct {
-	ID           int64    `json:"id"`
-	UID          string   `json:"uid"`
-	Title        string   `json:"title"`
-	URI          string   `json:"uri"`
-	URL          string   `json:"url"`
-	Slug         string   `json:"slug"`
-	Type         HitType  `json:"type"`
-	Tags         []string `json:"tags"`
-	IsStarred    bool     `json:"isStarred"`
-	FolderID     int64    `json:"folderId,omitempty"`
-	FolderUID    string   `json:"folderUid,omitempty"`
-	FolderTitle  string   `json:"folderTitle,omitempty"`
-	FolderURL    string   `json:"folderUrl,omitempty"`
-	SortMeta     int64    `json:"sortMeta"`
-	SortMetaName string   `json:"sortMetaName,omitempty"`
+	ID        int64    `json:"id"`
+	UID       string   `json:"uid"`
+	Title     string   `json:"title"`
+	URI       string   `json:"uri"`
+	URL       string   `json:"url"`
+	Slug      string   `json:"slug"`
+	Type      HitType  `json:"type"`
+	Tags      []string `json:"tags"`
+	IsStarred bool     `json:"isStarred"`
+	// Deprecated: use FolderUID instead
+	FolderID     int64  `json:"folderId,omitempty"`
+	FolderUID    string `json:"folderUid,omitempty"`
+	FolderTitle  string `json:"folderTitle,omitempty"`
+	FolderURL    string `json:"folderUrl,omitempty"`
+	SortMeta     int64  `json:"sortMeta"`
+	SortMetaName string `json:"sortMetaName,omitempty"`
 }
 
 type HitList []*Hit

--- a/public/api-merged.json
+++ b/public/api-merged.json
@@ -15215,6 +15215,7 @@
       "type": "object",
       "properties": {
         "folderId": {
+          "description": "Deprecated: use FolderUID instead",
           "type": "integer",
           "format": "int64"
         },

--- a/public/openapi3.json
+++ b/public/openapi3.json
@@ -6138,6 +6138,7 @@
       "Hit": {
         "properties": {
           "folderId": {
+            "description": "Deprecated: use FolderUID instead",
             "format": "int64",
             "type": "integer"
           },


### PR DESCRIPTION
Deprecate `FolderID` in `Hit` struct. Part of a series of PRs to deprecate sequential folder IDs.

Ref https://github.com/grafana/grafana/issues/61232