### PR TITLE
Chore: Deprecate FolderIds in Query

### DIFF
--- a/pkg/api/alerting.go
+++ b/pkg/api/alerting.go
@@ -112,7 +112,7 @@ func (hs *HTTPServer) GetAlerts(c *contextmodel.ReqContext) response.Response {
 			OrgId:        c.SignedInUser.GetOrgID(),
 			DashboardIds: dashboardIDs,
 			Type:         string(model.DashHitDB),
-			FolderIds:    folderIDs,
+			FolderIds:    folderIDs, // nolint:staticcheck
 			Permission:   dashboards.PERMISSION_VIEW,
 		}
 

--- a/pkg/api/folder.go
+++ b/pkg/api/folder.go
@@ -444,7 +444,7 @@ func (hs *HTTPServer) searchFolders(c *contextmodel.ReqContext) ([]*folder.Folde
 	searchQuery := search.Query{
 		SignedInUser: c.SignedInUser,
 		DashboardIds: make([]int64, 0),
-		FolderIds:    make([]int64, 0),
+		FolderIds:    make([]int64, 0), // nolint:staticcheck
 		Limit:        c.QueryInt64("limit"),
 		OrgId:        c.SignedInUser.GetOrgID(),
 		Type:         "dash-folder",

--- a/pkg/api/search.go
+++ b/pkg/api/search.go
@@ -80,7 +80,7 @@ func (hs *HTTPServer) Search(c *contextmodel.ReqContext) response.Response {
 		DashboardIds:  dbIDs,
 		DashboardUIDs: dbUIDs,
 		Type:          dashboardType,
-		FolderIds:     folderIDs,
+		FolderIds:     folderIDs, // nolint:staticcheck
 		FolderUIDs:    folderUIDs,
 		Permission:    permission,
 		Sort:          sort,

--- a/pkg/services/search/service.go
+++ b/pkg/services/search/service.go
@@ -37,10 +37,11 @@ type Query struct {
 	Type          string
 	DashboardUIDs []string
 	DashboardIds  []int64
-	FolderIds     []int64
-	FolderUIDs    []string
-	Permission    dashboards.PermissionType
-	Sort          string
+	// Deprecated: use FolderUID instead
+	FolderIds  []int64
+	FolderUIDs []string
+	Permission dashboards.PermissionType
+	Sort       string
 }
 
 type Service interface {
@@ -83,7 +84,7 @@ func (s *SearchService) SearchHandler(ctx context.Context, query *Query) (model.
 		DashboardUIDs: query.DashboardUIDs,
 		DashboardIds:  query.DashboardIds,
 		Type:          query.Type,
-		FolderIds:     query.FolderIds,
+		FolderIds:     query.FolderIds, // nolint:staticcheck
 		FolderUIDs:    query.FolderUIDs,
 		Tags:          query.Tags,
 		Limit:         query.Limit,


### PR DESCRIPTION
Deprecate `FolderIds` in `Query` struct. Part of a series of PRs to deprecate sequential folder IDs.

Ref https://github.com/grafana/grafana/issues/61232