### PR TITLE
Chore: Deprecate FolderId in DashboardMeta

### DIFF
--- a/pkg/api/dashboard.go
+++ b/pkg/api/dashboard.go
@@ -164,7 +164,7 @@ func (hs *HTTPServer) GetDashboard(c *contextmodel.ReqContext) response.Response
 		Version:                dash.Version,
 		HasACL:                 dash.HasACL,
 		IsFolder:               dash.IsFolder,
-		FolderId:               dash.FolderID,
+		FolderId:               dash.FolderID, // nolint:staticcheck
 		Url:                    dash.GetURL(),
 		FolderTitle:            "General",
 		AnnotationsPermissions: annotationPermissions,

--- a/pkg/api/dtos/dashboard.go
+++ b/pkg/api/dtos/dashboard.go
@@ -7,24 +7,25 @@ import (
 )
 
 type DashboardMeta struct {
-	IsStarred              bool                  `json:"isStarred,omitempty"`
-	IsSnapshot             bool                  `json:"isSnapshot,omitempty"`
-	Type                   string                `json:"type,omitempty"`
-	CanSave                bool                  `json:"canSave"`
-	CanEdit                bool                  `json:"canEdit"`
-	CanAdmin               bool                  `json:"canAdmin"`
-	CanStar                bool                  `json:"canStar"`
-	CanDelete              bool                  `json:"canDelete"`
-	Slug                   string                `json:"slug"`
-	Url                    string                `json:"url"`
-	Expires                time.Time             `json:"expires"`
-	Created                time.Time             `json:"created"`
-	Updated                time.Time             `json:"updated"`
-	UpdatedBy              string                `json:"updatedBy"`
-	CreatedBy              string                `json:"createdBy"`
-	Version                int                   `json:"version"`
-	HasACL                 bool                  `json:"hasAcl" xorm:"has_acl"`
-	IsFolder               bool                  `json:"isFolder"`
+	IsStarred  bool      `json:"isStarred,omitempty"`
+	IsSnapshot bool      `json:"isSnapshot,omitempty"`
+	Type       string    `json:"type,omitempty"`
+	CanSave    bool      `json:"canSave"`
+	CanEdit    bool      `json:"canEdit"`
+	CanAdmin   bool      `json:"canAdmin"`
+	CanStar    bool      `json:"canStar"`
+	CanDelete  bool      `json:"canDelete"`
+	Slug       string    `json:"slug"`
+	Url        string    `json:"url"`
+	Expires    time.Time `json:"expires"`
+	Created    time.Time `json:"created"`
+	Updated    time.Time `json:"updated"`
+	UpdatedBy  string    `json:"updatedBy"`
+	CreatedBy  string    `json:"createdBy"`
+	Version    int       `json:"version"`
+	HasACL     bool      `json:"hasAcl" xorm:"has_acl"`
+	IsFolder   bool      `json:"isFolder"`
+	// Deprecated: use FolderUID instead
 	FolderId               int64                 `json:"folderId"`
 	FolderUid              string                `json:"folderUid"`
 	FolderTitle            string                `json:"folderTitle"`

--- a/pkg/services/publicdashboards/service/service.go
+++ b/pkg/services/publicdashboards/service/service.go
@@ -83,7 +83,7 @@ func (pd *PublicDashboardServiceImpl) GetPublicDashboardForView(ctx context.Cont
 		Updated:                dash.Updated,
 		Version:                dash.Version,
 		IsFolder:               false,
-		FolderId:               dash.FolderID,
+		FolderId:               dash.FolderID, // nolint:staticcheck
 		PublicDashboardEnabled: pubdash.IsEnabled,
 	}
 	dash.Data.Get("timepicker").Set("hidden", !pubdash.TimeSelectionEnabled)

--- a/pkg/services/publicdashboards/service/service_test.go
+++ b/pkg/services/publicdashboards/service/service_test.go
@@ -344,7 +344,7 @@ func TestGetPublicDashboardForView(t *testing.T) {
 					Updated:                d.Updated,
 					Version:                d.Version,
 					IsFolder:               false,
-					FolderId:               d.FolderID,
+					FolderId:               d.FolderID, // nolint:staticcheck
 					PublicDashboardEnabled: true,
 				},
 			},
@@ -372,7 +372,7 @@ func TestGetPublicDashboardForView(t *testing.T) {
 					Updated:                d.Updated,
 					Version:                d.Version,
 					IsFolder:               false,
-					FolderId:               d.FolderID,
+					FolderId:               d.FolderID, // nolint:staticcheck
 					PublicDashboardEnabled: true,
 				},
 			},
@@ -411,6 +411,7 @@ func TestGetPublicDashboardForView(t *testing.T) {
 				assert.Equal(t, test.DashResp.Meta.Updated, dashboardFullWithMeta.Meta.Updated)
 				assert.Equal(t, test.DashResp.Meta.Version, dashboardFullWithMeta.Meta.Version)
 				assert.Equal(t, false, dashboardFullWithMeta.Meta.IsFolder)
+				// nolint:staticcheck
 				assert.Equal(t, test.DashResp.Meta.FolderId, dashboardFullWithMeta.Meta.FolderId)
 				assert.Equal(t, test.DashResp.Meta.PublicDashboardEnabled, dashboardFullWithMeta.Meta.PublicDashboardEnabled)
 

--- a/public/api-merged.json
+++ b/public/api-merged.json
@@ -13456,6 +13456,7 @@
           "format": "date-time"
         },
         "folderId": {
+          "description": "Deprecated: use FolderUID instead",
           "type": "integer",
           "format": "int64"
         },

--- a/public/openapi3.json
+++ b/public/openapi3.json
@@ -4379,6 +4379,7 @@
             "type": "string"
           },
           "folderId": {
+            "description": "Deprecated: use FolderUID instead",
             "format": "int64",
             "type": "integer"
           },


### PR DESCRIPTION
Deprecate `FolderId` in `DashboardMeta` struct. Part of a series of PRs to deprecate sequential folder IDs.

Ref https://github.com/grafana/grafana/issues/61232