### PR TITLE
Chore: Deprecate FolderId in ImportDashboardRequest and ImportDashboardResponse

### DIFF
--- a/pkg/services/dashboardimport/dashboardimport.go
+++ b/pkg/services/dashboardimport/dashboardimport.go
@@ -22,8 +22,9 @@ type ImportDashboardRequest struct {
 	Overwrite bool                   `json:"overwrite"`
 	Dashboard *simplejson.Json       `json:"dashboard"`
 	Inputs    []ImportDashboardInput `json:"inputs"`
-	FolderId  int64                  `json:"folderId"`
-	FolderUid string                 `json:"folderUid"`
+	// Deprecated: use FolderUID instead
+	FolderId  int64  `json:"folderId"`
+	FolderUid string `json:"folderUid"`
 
 	User identity.Requester `json:"-"`
 }

--- a/pkg/services/dashboardimport/dashboardimport.go
+++ b/pkg/services/dashboardimport/dashboardimport.go
@@ -31,14 +31,15 @@ type ImportDashboardRequest struct {
 
 // ImportDashboardResponse response object returned when importing a dashboard.
 type ImportDashboardResponse struct {
-	UID              string `json:"uid"`
-	PluginId         string `json:"pluginId"`
-	Title            string `json:"title"`
-	Imported         bool   `json:"imported"`
-	ImportedUri      string `json:"importedUri"`
-	ImportedUrl      string `json:"importedUrl"`
-	Slug             string `json:"slug"`
-	DashboardId      int64  `json:"dashboardId"`
+	UID         string `json:"uid"`
+	PluginId    string `json:"pluginId"`
+	Title       string `json:"title"`
+	Imported    bool   `json:"imported"`
+	ImportedUri string `json:"importedUri"`
+	ImportedUrl string `json:"importedUrl"`
+	Slug        string `json:"slug"`
+	DashboardId int64  `json:"dashboardId"`
+	// Deprecated: use FolderUID instead
 	FolderId         int64  `json:"folderId"`
 	FolderUID        string `json:"folderUid"`
 	ImportedRevision int64  `json:"importedRevision,omitempty"` // Only used for plugin imports

--- a/pkg/services/dashboardimport/service/service.go
+++ b/pkg/services/dashboardimport/service/service.go
@@ -154,8 +154,8 @@ func (s *ImportDashboardService) ImportDashboard(ctx context.Context, req *dashb
 		PluginId:         req.PluginId,
 		Title:            savedDashboard.Title,
 		Path:             req.Path,
-		Revision:         revision, // only used for plugin version tracking
-		FolderId:         savedDashboard.FolderID,
+		Revision:         revision,                // only used for plugin version tracking
+		FolderId:         savedDashboard.FolderID, // nolint:staticcheck
 		FolderUID:        req.FolderUid,
 		ImportedUri:      "db/" + savedDashboard.Slug,
 		ImportedUrl:      savedDashboard.GetURL(),

--- a/pkg/services/dashboardimport/service/service.go
+++ b/pkg/services/dashboardimport/service/service.go
@@ -97,7 +97,7 @@ func (s *ImportDashboardService) ImportDashboard(ctx context.Context, req *dashb
 		req.FolderId = folder.ID
 	} else {
 		folder, err := s.folderService.Get(ctx, &folder.GetFolderQuery{
-			ID:           &req.FolderId,
+			ID:           &req.FolderId, // nolint:staticcheck
 			OrgID:        req.User.GetOrgID(),
 			SignedInUser: req.User,
 		})

--- a/pkg/services/dashboardimport/service/service.go
+++ b/pkg/services/dashboardimport/service/service.go
@@ -93,6 +93,7 @@ func (s *ImportDashboardService) ImportDashboard(ctx context.Context, req *dashb
 		if err != nil {
 			return nil, err
 		}
+		// nolint:staticcheck
 		req.FolderId = folder.ID
 	} else {
 		folder, err := s.folderService.Get(ctx, &folder.GetFolderQuery{
@@ -120,7 +121,7 @@ func (s *ImportDashboardService) ImportDashboard(ctx context.Context, req *dashb
 		UserID:    userID,
 		Overwrite: req.Overwrite,
 		PluginID:  req.PluginId,
-		FolderID:  req.FolderId,
+		FolderID:  req.FolderId, // nolint:staticcheck
 		FolderUID: req.FolderUid,
 	}
 
@@ -136,6 +137,7 @@ func (s *ImportDashboardService) ImportDashboard(ctx context.Context, req *dashb
 		return nil, err
 	}
 
+	// nolint:staticcheck
 	err = s.libraryPanelService.ImportLibraryPanelsForDashboard(ctx, req.User, libraryElements, generatedDash.Get("panels").MustArray(), req.FolderId)
 	if err != nil {
 		return nil, err

--- a/pkg/services/dashboardimport/service/service_test.go
+++ b/pkg/services/dashboardimport/service/service_test.go
@@ -77,7 +77,7 @@ func TestImportDashboardService(t *testing.T) {
 				{Name: "*", Type: "datasource", Value: "prom"},
 			},
 			User:     &user.SignedInUser{UserID: 2, OrgRole: org.RoleAdmin, OrgID: 3},
-			FolderId: 5,
+			FolderId: 5, // nolint:staticcheck
 		}
 		resp, err := s.ImportDashboard(context.Background(), req)
 		require.NoError(t, err)
@@ -144,7 +144,7 @@ func TestImportDashboardService(t *testing.T) {
 				{Name: "*", Type: "datasource", Value: "prom"},
 			},
 			User:     &user.SignedInUser{UserID: 2, OrgRole: org.RoleAdmin, OrgID: 3},
-			FolderId: 5,
+			FolderId: 5, // nolint:staticcheck
 		}
 		resp, err := s.ImportDashboard(context.Background(), req)
 		require.NoError(t, err)

--- a/pkg/services/plugindashboards/service/dashboard_updater.go
+++ b/pkg/services/plugindashboards/service/dashboard_updater.go
@@ -177,7 +177,7 @@ func (du *DashboardUpdater) autoUpdateAppDashboard(ctx context.Context, pluginDa
 			{Action: dashboards.ActionDashboardsWrite, Scope: dashboards.ScopeFoldersAll},
 		}),
 		Path:      pluginDashInfo.Reference,
-		FolderId:  0,
+		FolderId:  0, // nolint:staticcheck
 		Dashboard: resp.Dashboard.Data,
 		Overwrite: true,
 		Inputs:    nil,

--- a/pkg/services/plugindashboards/service/dashboard_updater_test.go
+++ b/pkg/services/plugindashboards/service/dashboard_updater_test.go
@@ -195,6 +195,7 @@ func TestDashboardUpdater(t *testing.T) {
 				require.Equal(t, "updated.json", ctx.importDashboardArgs[0].Path)
 				require.Equal(t, int64(2), ctx.importDashboardArgs[0].User.GetOrgID())
 				require.Equal(t, org.RoleAdmin, ctx.importDashboardArgs[0].User.GetOrgRole())
+				// nolint:staticcheck
 				require.Equal(t, int64(0), ctx.importDashboardArgs[0].FolderId)
 				require.True(t, ctx.importDashboardArgs[0].Overwrite)
 			})
@@ -322,6 +323,7 @@ func TestDashboardUpdater(t *testing.T) {
 			require.Equal(t, "dashboard1.json", ctx.importDashboardArgs[0].Path)
 			require.Equal(t, int64(2), ctx.importDashboardArgs[0].User.GetOrgID())
 			require.Equal(t, org.RoleAdmin, ctx.importDashboardArgs[0].User.GetOrgRole())
+			// nolint:staticcheck
 			require.Equal(t, int64(0), ctx.importDashboardArgs[0].FolderId)
 			require.True(t, ctx.importDashboardArgs[0].Overwrite)
 
@@ -329,6 +331,7 @@ func TestDashboardUpdater(t *testing.T) {
 			require.Equal(t, "dashboard2.json", ctx.importDashboardArgs[1].Path)
 			require.Equal(t, int64(2), ctx.importDashboardArgs[1].User.GetOrgID())
 			require.Equal(t, org.RoleAdmin, ctx.importDashboardArgs[1].User.GetOrgRole())
+			// nolint:staticcheck
 			require.Equal(t, int64(0), ctx.importDashboardArgs[1].FolderId)
 			require.True(t, ctx.importDashboardArgs[1].Overwrite)
 
@@ -336,6 +339,7 @@ func TestDashboardUpdater(t *testing.T) {
 			require.Equal(t, "dashboard3.json", ctx.importDashboardArgs[2].Path)
 			require.Equal(t, int64(2), ctx.importDashboardArgs[2].User.GetOrgID())
 			require.Equal(t, org.RoleAdmin, ctx.importDashboardArgs[2].User.GetOrgRole())
+			// nolint:staticcheck
 			require.Equal(t, int64(0), ctx.importDashboardArgs[2].FolderId)
 			require.True(t, ctx.importDashboardArgs[2].Overwrite)
 		})

--- a/public/api-merged.json
+++ b/public/api-merged.json
@@ -15335,6 +15335,7 @@
           "$ref": "#/definitions/Json"
         },
         "folderId": {
+          "description": "Deprecated: use FolderUID instead",
           "type": "integer",
           "format": "int64"
         },
@@ -15370,6 +15371,7 @@
           "type": "string"
         },
         "folderId": {
+          "description": "Deprecated: use FolderUID instead",
           "type": "integer",
           "format": "int64"
         },

--- a/public/openapi3.json
+++ b/public/openapi3.json
@@ -6257,6 +6257,7 @@
             "$ref": "#/components/schemas/Json"
           },
           "folderId": {
+            "description": "Deprecated: use FolderUID instead",
             "format": "int64",
             "type": "integer"
           },
@@ -6292,6 +6293,7 @@
             "type": "string"
           },
           "folderId": {
+            "description": "Deprecated: use FolderUID instead",
             "format": "int64",
             "type": "integer"
           },


### PR DESCRIPTION
Deprecate `FolderId` in `ImportDashboardRequest`  and `ImportDashboardResponse` struct. Part of a series of PRs to deprecate sequential folder IDs.

Ref https://github.com/grafana/grafana/issues/61232