### PR TITLE
mysql: do not import `httpClient` from core grafana

### DIFF
--- a/pkg/tsdb/mysql/mysql.go
+++ b/pkg/tsdb/mysql/mysql.go
@@ -15,6 +15,7 @@ import (
 	"github.com/go-sql-driver/mysql"
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
 	"github.com/grafana/grafana-plugin-sdk-go/backend/datasource"
+	sdkhttpclient "github.com/grafana/grafana-plugin-sdk-go/backend/httpclient"
 	"github.com/grafana/grafana-plugin-sdk-go/backend/instancemgmt"
 	sdkproxy "github.com/grafana/grafana-plugin-sdk-go/backend/proxy"
 	"github.com/grafana/grafana-plugin-sdk-go/data"
@@ -46,11 +47,11 @@ func characterEscape(s string, escapeChar string) string {
 
 func ProvideService(cfg *setting.Cfg, httpClientProvider httpclient.Provider) *Service {
 	return &Service{
-		im: datasource.NewInstanceManager(newInstanceSettings(cfg, httpClientProvider)),
+		im: datasource.NewInstanceManager(newInstanceSettings(cfg)),
 	}
 }
 
-func newInstanceSettings(cfg *setting.Cfg, httpClientProvider httpclient.Provider) datasource.InstanceFactoryFunc {
+func newInstanceSettings(cfg *setting.Cfg) datasource.InstanceFactoryFunc {
 	return func(ctx context.Context, settings backend.DataSourceInstanceSettings) (instancemgmt.Instance, error) {
 		jsonData := sqleng.JsonData{
 			MaxOpenConns:            cfg.SqlDatasourceMaxOpenConnsDefault,
@@ -114,7 +115,7 @@ func newInstanceSettings(cfg *setting.Cfg, httpClientProvider httpclient.Provide
 			return nil, err
 		}
 
-		tlsConfig, err := httpClientProvider.GetTLSConfig(opts)
+		tlsConfig, err := sdkhttpclient.GetTLSConfig(opts)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
fixes https://github.com/grafana/grafana/issues/77719

we adjust the code to use a function from grafana-plugin-sdk-go, and not from core-grafana.

how to test:
- there are scenarios at https://github.com/grafana/oss-big-tent-tools/tree/main/tls-setups/mysql that simulate different tls configurations
- try these and make sure they still work after the changes.
- try situations where it should fail, and verify that it fails. for example:
    - try the verify-server-cert scenario
    - when you see it works, then:
        - keep the server still running
        - run `./gen_cert.sh` again, this will generate new certificates
        - add the new certificate to grafana
        - test that it now fails to connect (because the still-running server uses the old certificate)