### PR TITLE
Alerting: Avoid alert list view component being unmounted every time we fetch new data

### DIFF
--- a/public/app/plugins/panel/alertlist/UnifiedAlertList.tsx
+++ b/public/app/plugins/panel/alertlist/UnifiedAlertList.tsx
@@ -1,6 +1,6 @@
 import { css } from '@emotion/css';
 import { sortBy } from 'lodash';
-import React, { useEffect, useMemo, useRef } from 'react';
+import React, { useEffect, useMemo } from 'react';
 import { useEffectOnce, useToggle } from 'react-use';
 
 import { GrafanaTheme2, PanelProps } from '@grafana/data';
@@ -213,18 +213,9 @@ export function UnifiedAlertList(props: PanelProps<UnifiedAlertListOptions>) {
 
   const noAlertsMessage = rules.length === 0 ? 'No alerts matching filters' : undefined;
 
-  const isFirstLoading = useRef<undefined | boolean>(undefined);
-
   const renderLoading = grafanaRulesLoading || (dispatched && loading && !haveResults);
 
-  useEffect(() => {
-    if (isFirstLoading.current === undefined && renderLoading) {
-      isFirstLoading.current = true;
-    }
-    if (!renderLoading && isFirstLoading.current) {
-      isFirstLoading.current = false;
-    }
-  }, [renderLoading]);
+  const havePreviousResults = Object.values(promRulesRequests).some((state) => state.result);
 
   if (
     !contextSrv.hasPermission(AccessControlAction.AlertingRuleRead) &&
@@ -238,8 +229,8 @@ export function UnifiedAlertList(props: PanelProps<UnifiedAlertListOptions>) {
   return (
     <CustomScrollbar autoHeightMin="100%" autoHeightMax="100%">
       <div className={styles.container}>
-        {!isFirstLoading.current && noAlertsMessage && <div className={styles.noAlertsMessage}>{noAlertsMessage}</div>}
-        {!isFirstLoading.current && (
+        {havePreviousResults && noAlertsMessage && <div className={styles.noAlertsMessage}>{noAlertsMessage}</div>}
+        {havePreviousResults && (
           <section>
             {props.options.viewMode === ViewMode.Stat && (
               <BigValue

--- a/public/app/plugins/panel/alertlist/UnifiedAlertList.tsx
+++ b/public/app/plugins/panel/alertlist/UnifiedAlertList.tsx
@@ -225,10 +225,10 @@ export function UnifiedAlertList(props: PanelProps<UnifiedAlertListOptions>) {
   return (
     <CustomScrollbar autoHeightMin="100%" autoHeightMax="100%">
       <div className={styles.container}>
-        {(grafanaRulesLoading || (dispatched && loading && !haveResults)) && <LoadingPlaceholder text="Loading..." />}
         {noAlertsMessage && <div className={styles.noAlertsMessage}>{noAlertsMessage}</div>}
+
         <section>
-          {props.options.viewMode === ViewMode.Stat && haveResults && (
+          {props.options.viewMode === ViewMode.Stat && (
             <BigValue
               width={props.width}
               height={props.height}
@@ -239,10 +239,10 @@ export function UnifiedAlertList(props: PanelProps<UnifiedAlertListOptions>) {
               value={{ text: `${rules.length}`, numeric: rules.length }}
             />
           )}
-          {props.options.viewMode === ViewMode.List && props.options.groupMode === GroupMode.Custom && haveResults && (
+          {props.options.viewMode === ViewMode.List && props.options.groupMode === GroupMode.Custom && (
             <GroupedModeView rules={rules} options={parsedOptions} />
           )}
-          {props.options.viewMode === ViewMode.List && props.options.groupMode === GroupMode.Default && haveResults && (
+          {props.options.viewMode === ViewMode.List && props.options.groupMode === GroupMode.Default && (
             <UngroupedModeView
               rules={rules}
               options={parsedOptions}
@@ -252,6 +252,8 @@ export function UnifiedAlertList(props: PanelProps<UnifiedAlertListOptions>) {
             />
           )}
         </section>
+        {/* loading moved here to avoid twitching  */}
+        {(grafanaRulesLoading || (dispatched && loading && !haveResults)) && <LoadingPlaceholder text="Loading..." />}
       </div>
     </CustomScrollbar>
   );


### PR DESCRIPTION
**What is this feature?**

This PR avoids alert list view being unmounted and mounted every time we got new data when fetching rules.
This resolves the issue of the list flickering whenever new data is retrieved (when panel data is refreshed).
Additionally, it relocates the loading indicator below the list to eliminate any further flickering between the list and the loading indicator.


**Why do we need this feature?**

Panel should not twitch every time panel data is refreshed.

**Who is this feature for?**

All users.

**Which issue(s) does this PR fix?**:

Fixes #74971 

**Special notes for your reviewer:**

**Before the change:**

https://github.com/grafana/grafana/assets/33540275/1ae14675-46ed-43cd-b11c-95aafdc64c13

**After the change:**

https://github.com/grafana/grafana/assets/33540275/14978deb-4eb9-45f0-9d32-12ea54771b46


**When loading data for the first time:**


https://github.com/grafana/grafana/assets/33540275/2af69691-7e5b-4518-8e84-cb00dc1eb1af





Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
