### PR TITLE
Provisioning: Set `dashboard.folder_uid` column for provisioned dashboards

### DIFF
--- a/pkg/services/provisioning/dashboards/file_reader.go
+++ b/pkg/services/provisioning/dashboards/file_reader.go
@@ -140,14 +140,14 @@ func (fr *FileReader) isDatabaseAccessRestricted() bool {
 // storeDashboardsInFolder saves dashboards from the filesystem on disk to the folder from config
 func (fr *FileReader) storeDashboardsInFolder(ctx context.Context, filesFoundOnDisk map[string]os.FileInfo,
 	dashboardRefs map[string]*dashboards.DashboardProvisioning, usageTracker *usageTracker) error {
-	folderID, err := fr.getOrCreateFolderID(ctx, fr.Cfg, fr.dashboardProvisioningService, fr.Cfg.Folder)
+	folderID, folderUID, err := fr.getOrCreateFolder(ctx, fr.Cfg, fr.dashboardProvisioningService, fr.Cfg.Folder)
 	if err != nil && !errors.Is(err, ErrFolderNameMissing) {
 		return err
 	}
 
 	// save dashboards based on json files
 	for path, fileInfo := range filesFoundOnDisk {
-		provisioningMetadata, err := fr.saveDashboard(ctx, path, folderID, fileInfo, dashboardRefs)
+		provisioningMetadata, err := fr.saveDashboard(ctx, path, folderID, folderUID, fileInfo, dashboardRefs)
 		if err != nil {
 			fr.log.Error("failed to save dashboard", "file", path, "error", err)
 			continue
@@ -170,12 +170,12 @@ func (fr *FileReader) storeDashboardsInFoldersFromFileStructure(ctx context.Cont
 			folderName = filepath.Base(dashboardsFolder)
 		}
 
-		folderID, err := fr.getOrCreateFolderID(ctx, fr.Cfg, fr.dashboardProvisioningService, folderName)
+		folderID, folderUID, err := fr.getOrCreateFolder(ctx, fr.Cfg, fr.dashboardProvisioningService, folderName)
 		if err != nil && !errors.Is(err, ErrFolderNameMissing) {
 			return fmt.Errorf("can't provision folder %q from file system structure: %w", folderName, err)
 		}
 
-		provisioningMetadata, err := fr.saveDashboard(ctx, path, folderID, fileInfo, dashboardRefs)
+		provisioningMetadata, err := fr.saveDashboard(ctx, path, folderID, folderUID, fileInfo, dashboardRefs)
 		usageTracker.track(provisioningMetadata)
 		if err != nil {
 			fr.log.Error("failed to save dashboard", "file", path, "error", err)
@@ -219,7 +219,7 @@ func (fr *FileReader) handleMissingDashboardFiles(ctx context.Context, provision
 }
 
 // saveDashboard saves or updates the dashboard provisioning file at path.
-func (fr *FileReader) saveDashboard(ctx context.Context, path string, folderID int64, fileInfo os.FileInfo,
+func (fr *FileReader) saveDashboard(ctx context.Context, path string, folderID int64, folderUID string, fileInfo os.FileInfo,
 	provisionedDashboardRefs map[string]*dashboards.DashboardProvisioning) (provisioningMetadata, error) {
 	provisioningMetadata := provisioningMetadata{}
 	resolvedFileInfo, err := resolveSymlink(fileInfo, path)
@@ -229,7 +229,7 @@ func (fr *FileReader) saveDashboard(ctx context.Context, path string, folderID i
 
 	provisionedData, alreadyProvisioned := provisionedDashboardRefs[path]
 
-	jsonFile, err := fr.readDashboardFromFile(path, resolvedFileInfo.ModTime(), folderID)
+	jsonFile, err := fr.readDashboardFromFile(path, resolvedFileInfo.ModTime(), folderID, folderUID)
 	if err != nil {
 		fr.log.Error("failed to load dashboard from ", "file", path, "error", err)
 		return provisioningMetadata, nil
@@ -245,7 +245,25 @@ func (fr *FileReader) saveDashboard(ctx context.Context, path string, folderID i
 	provisioningMetadata.uid = dash.Dashboard.UID
 	provisioningMetadata.identity = dashboardIdentity{title: dash.Dashboard.Title, folderID: dash.Dashboard.FolderID}
 
+	// fix empty folder_uid from already provisioned dashboards
+	if upToDate && folderUID != "" {
+		d, err := fr.dashboardStore.GetDashboard(
+			ctx,
+			&dashboards.GetDashboardQuery{
+				OrgID: jsonFile.dashboard.OrgID,
+				UID:   jsonFile.dashboard.Dashboard.UID,
+			},
+		)
+		if err != nil {
+			return provisioningMetadata, err
+		}
+		if d.FolderUID != folderUID {
+			upToDate = false
+		}
+	}
+
 	if upToDate {
+		fr.log.Debug("provisioned dashboard is up to date", "provisioner", fr.Cfg.Name, "file", path, "folderId", dash.Dashboard.FolderID, "folderUid", dash.Dashboard.FolderUID)
 		return provisioningMetadata, nil
 	}
 
@@ -259,7 +277,7 @@ func (fr *FileReader) saveDashboard(ctx context.Context, path string, folderID i
 	}
 
 	if !fr.isDatabaseAccessRestricted() {
-		fr.log.Debug("saving new dashboard", "provisioner", fr.Cfg.Name, "file", path, "folderId", dash.Dashboard.FolderID)
+		fr.log.Debug("saving new dashboard", "provisioner", fr.Cfg.Name, "file", path, "folderId", dash.Dashboard.FolderID, "folderUid", dash.Dashboard.FolderUID)
 		dp := &dashboards.DashboardProvisioning{
 			ExternalID: path,
 			Name:       fr.Cfg.Name,
@@ -293,9 +311,9 @@ func getProvisionedDashboardsByPath(ctx context.Context, service dashboards.Dash
 	return byPath, nil
 }
 
-func (fr *FileReader) getOrCreateFolderID(ctx context.Context, cfg *config, service dashboards.DashboardProvisioningService, folderName string) (int64, error) {
+func (fr *FileReader) getOrCreateFolder(ctx context.Context, cfg *config, service dashboards.DashboardProvisioningService, folderName string) (int64, string, error) {
 	if folderName == "" {
-		return 0, ErrFolderNameMissing
+		return 0, "", ErrFolderNameMissing
 	}
 
 	cmd := &dashboards.GetDashboardQuery{
@@ -306,7 +324,7 @@ func (fr *FileReader) getOrCreateFolderID(ctx context.Context, cfg *config, serv
 	result, err := fr.dashboardStore.GetDashboard(ctx, cmd)
 
 	if err != nil && !errors.Is(err, dashboards.ErrDashboardNotFound) {
-		return 0, err
+		return 0, "", err
 	}
 
 	// dashboard folder not found. create one.
@@ -318,22 +336,22 @@ func (fr *FileReader) getOrCreateFolderID(ctx context.Context, cfg *config, serv
 		dash.OrgID = cfg.OrgID
 		// set dashboard folderUid if given
 		if cfg.FolderUID == accesscontrol.GeneralFolderUID {
-			return 0, dashboards.ErrFolderInvalidUID
+			return 0, "", dashboards.ErrFolderInvalidUID
 		}
 		dash.Dashboard.SetUID(cfg.FolderUID)
 		dbDash, err := service.SaveFolderForProvisionedDashboards(ctx, dash)
 		if err != nil {
-			return 0, err
+			return 0, "", err
 		}
 
-		return dbDash.ID, nil
+		return dbDash.ID, dbDash.UID, nil
 	}
 
 	if !result.IsFolder {
-		return 0, fmt.Errorf("got invalid response. expected folder, found dashboard")
+		return 0, "", fmt.Errorf("got invalid response. expected folder, found dashboard")
 	}
 
-	return result.ID, nil
+	return result.ID, result.UID, nil
 }
 
 func resolveSymlink(fileinfo os.FileInfo, path string) (os.FileInfo, error) {
@@ -387,7 +405,7 @@ type dashboardJSONFile struct {
 	lastModified time.Time
 }
 
-func (fr *FileReader) readDashboardFromFile(path string, lastModified time.Time, folderID int64) (*dashboardJSONFile, error) {
+func (fr *FileReader) readDashboardFromFile(path string, lastModified time.Time, folderID int64, folderUID string) (*dashboardJSONFile, error) {
 	// nolint:gosec
 	// We can ignore the gosec G304 warning on this one because `path` comes from the provisioning configuration file.
 	reader, err := os.Open(path)
@@ -415,7 +433,7 @@ func (fr *FileReader) readDashboardFromFile(path string, lastModified time.Time,
 		return nil, err
 	}
 
-	dash, err := createDashboardJSON(data, lastModified, fr.Cfg, folderID)
+	dash, err := createDashboardJSON(data, lastModified, fr.Cfg, folderID, folderUID)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/services/provisioning/dashboards/file_reader_test.go
+++ b/pkg/services/provisioning/dashboards/file_reader_test.go
@@ -364,7 +364,7 @@ func TestDashboardFileReader(t *testing.T) {
 		r, err := NewDashboardFileReader(cfg, logger, nil, nil)
 		require.NoError(t, err)
 
-		_, err = r.getOrCreateFolderID(context.Background(), cfg, fakeService, cfg.Folder)
+		_, _, err = r.getOrCreateFolder(context.Background(), cfg, fakeService, cfg.Folder)
 		require.Equal(t, err, ErrFolderNameMissing)
 	})
 
@@ -384,7 +384,7 @@ func TestDashboardFileReader(t *testing.T) {
 		r, err := NewDashboardFileReader(cfg, logger, nil, fakeStore)
 		require.NoError(t, err)
 
-		_, err = r.getOrCreateFolderID(context.Background(), cfg, fakeService, cfg.Folder)
+		_, _, err = r.getOrCreateFolder(context.Background(), cfg, fakeService, cfg.Folder)
 		require.NoError(t, err)
 	})
 
@@ -404,7 +404,7 @@ func TestDashboardFileReader(t *testing.T) {
 		r, err := NewDashboardFileReader(cfg, logger, nil, fakeStore)
 		require.NoError(t, err)
 
-		_, err = r.getOrCreateFolderID(context.Background(), cfg, fakeService, cfg.Folder)
+		_, _, err = r.getOrCreateFolder(context.Background(), cfg, fakeService, cfg.Folder)
 		require.ErrorIs(t, err, dashboards.ErrFolderInvalidUID)
 	})
 

--- a/pkg/services/provisioning/dashboards/types.go
+++ b/pkg/services/provisioning/dashboards/types.go
@@ -56,7 +56,7 @@ type configs struct {
 	AllowUIUpdates        values.BoolValue   `json:"allowUiUpdates" yaml:"allowUiUpdates"`
 }
 
-func createDashboardJSON(data *simplejson.Json, lastModified time.Time, cfg *config, folderID int64) (*dashboards.SaveDashboardDTO, error) {
+func createDashboardJSON(data *simplejson.Json, lastModified time.Time, cfg *config, folderID int64, folderUID string) (*dashboards.SaveDashboardDTO, error) {
 	dash := &dashboards.SaveDashboardDTO{}
 	dash.Dashboard = dashboards.NewDashboardFromJson(data)
 	dash.UpdatedAt = lastModified
@@ -64,6 +64,7 @@ func createDashboardJSON(data *simplejson.Json, lastModified time.Time, cfg *con
 	dash.OrgID = cfg.OrgID
 	dash.Dashboard.OrgID = cfg.OrgID
 	dash.Dashboard.FolderID = folderID
+	dash.Dashboard.FolderUID = folderUID
 
 	if dash.Dashboard.Title == "" {
 		return nil, dashboards.ErrDashboardTitleEmpty

--- a/pkg/services/provisioning/dashboards/validator_test.go
+++ b/pkg/services/provisioning/dashboards/validator_test.go
@@ -39,7 +39,7 @@ func TestDuplicatesValidator(t *testing.T) {
 		fakeService.On("SaveFolderForProvisionedDashboards", mock.Anything, mock.Anything).Return(&dashboards.Dashboard{}, nil).Times(6)
 		fakeService.On("GetProvisionedDashboardData", mock.Anything, mock.AnythingOfType("string")).Return([]*dashboards.DashboardProvisioning{}, nil).Times(4)
 		fakeService.On("SaveProvisionedDashboard", mock.Anything, mock.Anything, mock.Anything).Return(&dashboards.Dashboard{}, nil).Times(5)
-		folderID, err := r.getOrCreateFolderID(context.Background(), cfg, fakeService, folderName)
+		folderID, _, err := r.getOrCreateFolder(context.Background(), cfg, fakeService, folderName)
 		require.NoError(t, err)
 
 		identity := dashboardIdentity{folderID: folderID, title: "Grafana"}
@@ -92,7 +92,7 @@ func TestDuplicatesValidator(t *testing.T) {
 		fakeStore := &fakeDashboardStore{}
 		r, err := NewDashboardFileReader(cfg, logger, nil, fakeStore)
 		require.NoError(t, err)
-		folderID, err := r.getOrCreateFolderID(context.Background(), cfg, fakeService, folderName)
+		folderID, _, err := r.getOrCreateFolder(context.Background(), cfg, fakeService, folderName)
 		require.NoError(t, err)
 
 		identity := dashboardIdentity{folderID: folderID, title: "Grafana"}
@@ -194,7 +194,7 @@ func TestDuplicatesValidator(t *testing.T) {
 
 		r, err := NewDashboardFileReader(cfg, logger, nil, fakeStore)
 		require.NoError(t, err)
-		folderID, err := r.getOrCreateFolderID(context.Background(), cfg, fakeService, cfg1.Folder)
+		folderID, _, err := r.getOrCreateFolder(context.Background(), cfg, fakeService, cfg1.Folder)
 		require.NoError(t, err)
 
 		identity := dashboardIdentity{folderID: folderID, title: "Grafana"}
@@ -211,7 +211,7 @@ func TestDuplicatesValidator(t *testing.T) {
 
 		r, err = NewDashboardFileReader(cfg3, logger, nil, fakeStore)
 		require.NoError(t, err)
-		folderID, err = r.getOrCreateFolderID(context.Background(), cfg3, fakeService, cfg3.Folder)
+		folderID, _, err = r.getOrCreateFolder(context.Background(), cfg3, fakeService, cfg3.Folder)
 		require.NoError(t, err)
 
 		identity = dashboardIdentity{folderID: folderID, title: "Grafana"}


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

In #76504 we have introduced a `folder_uid` column in `dashboard` table. This is used by `/api/search`when nested folders are set.
However, we have missed setting it properly when creating/updating provisioned dashboards.

**Why do we need this feature?**

Without this fix provisioned dashboards that have been updated after this change was merged, no longer appear under the expected folder (if nested folders are enabled)

This fix sets the `folder_uid` to:
- newly provisioned dashboards
- existing provisioned dashboards

**Who is this feature for?**

[Add information on what kind of user the feature is for.]

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**
1. in main branch provision some new dashboards under a folder
2. check `dashboard` table and observe that `folder_uid` column is NULL
3. switch to this branch
4. start grafana and make sure that the `folder_uid` column is no more NULL for the provisioned dashboards
5. make sure that newly introduced provisioned dashboards have not NULL `folder_uid`
6. enable nested folders and make sure that that provisioned dashboard are properly listed under the expected folders

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
