### PR TITLE
[v9.4.x] Alerting: During legacy migration do not create one silence per rule

### DIFF
--- a/pkg/services/sqlstore/migrations/ualert/alert_rule.go
+++ b/pkg/services/sqlstore/migrations/ualert/alert_rule.go
@@ -156,20 +156,18 @@ func (m *migration) makeAlertRule(cond condition, da dashAlert, folderUID string
 		return nil, err
 	}
 
-	// Label for routing and silences.
-	n, v := getLabelForSilenceMatching(ar.UID)
-	ar.Labels[n] = v
-
-	if err := m.addSilence(da, ar); err != nil {
-		m.mg.Logger.Error("alert migration error: failed to create silence", "rule_name", ar.Title, "err", err)
+	// Label for routing silences.
+	if da.State == "paused" {
+		n, v := getLabelForPauseSilenceMatching()
+		ar.Labels[n] = v
 	}
-
-	if err := m.addErrorSilence(da, ar); err != nil {
-		m.mg.Logger.Error("alert migration error: failed to create silence for Error", "rule_name", ar.Title, "err", err)
+	if da.ParsedSettings.ExecutionErrorState == "keep_state" {
+		n, v := getLabelForErrorSilenceMatching()
+		ar.Labels[n] = v
 	}
-
-	if err := m.addNoDataSilence(da, ar); err != nil {
-		m.mg.Logger.Error("alert migration error: failed to create silence for NoData", "rule_name", ar.Title, "err", err)
+	if da.ParsedSettings.NoDataState == "keep_state" {
+		n, v := getLabelForNoDataSilenceMatching()
+		ar.Labels[n] = v
 	}
 
 	return ar, nil

--- a/pkg/services/sqlstore/migrations/ualert/alert_rule_test.go
+++ b/pkg/services/sqlstore/migrations/ualert/alert_rule_test.go
@@ -138,6 +138,45 @@ func TestMakeAlertRule(t *testing.T) {
 		require.NoError(t, err)
 		require.True(t, ar.IsPaused)
 	})
+
+	t.Run("pased dash alert is silenced", func(t *testing.T) {
+		m := newTestMigration(t)
+		da := createTestDashAlert()
+		da.State = "paused"
+		cnd := createTestDashAlertCondition()
+
+		ar, err := m.makeAlertRule(cnd, da, "folder")
+		require.NoError(t, err)
+
+		n, v := getLabelForPauseSilenceMatching()
+		require.Equal(t, ar.Labels[n], v)
+	})
+
+	t.Run("keep last state error dash alert is silenced", func(t *testing.T) {
+		m := newTestMigration(t)
+		da := createTestDashAlert()
+		da.ParsedSettings.ExecutionErrorState = "keep_state"
+		cnd := createTestDashAlertCondition()
+
+		ar, err := m.makeAlertRule(cnd, da, "folder")
+		require.NoError(t, err)
+
+		n, v := getLabelForErrorSilenceMatching()
+		require.Equal(t, ar.Labels[n], v)
+	})
+
+	t.Run("keep last state nodata dash alert is silenced", func(t *testing.T) {
+		m := newTestMigration(t)
+		da := createTestDashAlert()
+		da.ParsedSettings.NoDataState = "keep_state"
+		cnd := createTestDashAlertCondition()
+
+		ar, err := m.makeAlertRule(cnd, da, "folder")
+		require.NoError(t, err)
+
+		n, v := getLabelForNoDataSilenceMatching()
+		require.Equal(t, ar.Labels[n], v)
+	})
 }
 
 func createTestDashAlert() dashAlert {

--- a/pkg/services/sqlstore/migrations/ualert/alert_rule_test.go
+++ b/pkg/services/sqlstore/migrations/ualert/alert_rule_test.go
@@ -139,7 +139,7 @@ func TestMakeAlertRule(t *testing.T) {
 		require.True(t, ar.IsPaused)
 	})
 
-	t.Run("pased dash alert is silenced", func(t *testing.T) {
+	t.Run("paused dash alert is silenced", func(t *testing.T) {
 		m := newTestMigration(t)
 		da := createTestDashAlert()
 		da.State = "paused"

--- a/pkg/services/sqlstore/migrations/ualert/silences.go
+++ b/pkg/services/sqlstore/migrations/ualert/silences.go
@@ -46,7 +46,7 @@ func (m *migration) addPauseSilence(orgId int64) error {
 			StartsAt:  time.Now(),
 			EndsAt:    time.Now().Add(365 * 20 * time.Hour), // 1 year.
 			CreatedBy: "Grafana Migration",
-			Comment:   "Created during auto migration to unified alerting",
+			Comment:   "Created during migration to unified alerting to silence paused alerts",
 		},
 		ExpiresAt: time.Now().Add(365 * 20 * time.Hour), // 1 year.
 	}
@@ -84,7 +84,7 @@ func (m *migration) addErrorSilence(orgId int64) error {
 			StartsAt:  time.Now(),
 			EndsAt:    time.Now().AddDate(1, 0, 0), // 1 year
 			CreatedBy: "Grafana Migration",
-			Comment:   fmt.Sprintf("Created during migration to unified alerting to silence Error state when the option 'Keep Last State' was selected for Error state"),
+			Comment:   "Created during migration to unified alerting to silence Error state when the option 'Keep Last State' was selected for Error state",
 		},
 		ExpiresAt: time.Now().AddDate(1, 0, 0), // 1 year
 	}
@@ -120,7 +120,7 @@ func (m *migration) addNoDataSilence(orgId int64) error {
 			StartsAt:  time.Now(),
 			EndsAt:    time.Now().AddDate(1, 0, 0), // 1 year.
 			CreatedBy: "Grafana Migration",
-			Comment:   fmt.Sprintf("Created during migration to unified alerting to silence NoData state when the option 'Keep Last State' was selected for NoData state"),
+			Comment:   "Created during migration to unified alerting to silence NoData state when the option 'Keep Last State' was selected for NoData state",
 		},
 		ExpiresAt: time.Now().AddDate(1, 0, 0), // 1 year.
 	}

--- a/pkg/services/sqlstore/migrations/ualert/ualert.go
+++ b/pkg/services/sqlstore/migrations/ualert/ualert.go
@@ -392,6 +392,15 @@ func (m *migration) Exec(sess *xorm.Session, mg *migrator.Migrator) error {
 	}
 
 	for orgID := range rulesPerOrg {
+		if err := m.addPauseSilence(orgID); err != nil {
+			m.mg.Logger.Error("alert migration error: failed to create silence for paused alerts")
+		}
+		if err := m.addErrorSilence(orgID); err != nil {
+			m.mg.Logger.Error("alert migration error: failed to create silence for Error keep last state")
+		}
+		if err := m.addNoDataSilence(orgID); err != nil {
+			m.mg.Logger.Error("alert migration error: failed to create silence for Error keep last state")
+		}
 		if err := m.writeSilencesFile(orgID); err != nil {
 			m.mg.Logger.Error("alert migration error: failed to write silence file", "err", err)
 		}


### PR DESCRIPTION
During legacy migration every migrated rule is given a label `rule_uid=<uid>`. This is used to silence migrated alerts if they were:

- Paused in legacy alerting.
- Had Error state set to keep last state.
- Had NoData state set to keep last state.

This can potentially create a large amount of silences and a high cardinality label. Both of these scenarios have poor outcomes for CPU load and latency in unified alerting.

Instead, this change opts to create one or more of three labels on each migrated alert rule as well as three silence rules:

- `migration_paused = true`
- `migration_keep_last_state_error = true`
- `migration_keep_last_state_nodata = true`

 This will drastically reduce the number of created silence rules in most cases as well as not create the potentially high cardinalty label `rule_uid`.

![Screenshot from 2023-11-03 13-11-21](https://github.com/grafana/grafana/assets/8484471/dfdd19eb-eec7-4d44-b0c9-8c0444f57aad)

![Screenshot from 2023-11-03 13-15-26](https://github.com/grafana/grafana/assets/8484471/9ac46501-e7f4-4a6c-a395-294081cc4144)
