### PR TITLE
Chore: Deprecate ID in GetFolderQuery

### DIFF
--- a/pkg/api/folder.go
+++ b/pkg/api/folder.go
@@ -117,6 +117,7 @@ func (hs *HTTPServer) GetFolderByID(c *contextmodel.ReqContext) response.Respons
 	if err != nil {
 		return response.Error(http.StatusBadRequest, "id is invalid", err)
 	}
+	// nolint:staticcheck
 	folder, err := hs.folderService.Get(c.Req.Context(), &folder.GetFolderQuery{ID: &id, OrgID: c.SignedInUser.GetOrgID(), SignedInUser: c.SignedInUser})
 	if err != nil {
 		return apierrors.ToFolderErrorResponse(err)

--- a/pkg/services/dashboardimport/service/service.go
+++ b/pkg/services/dashboardimport/service/service.go
@@ -96,7 +96,7 @@ func (s *ImportDashboardService) ImportDashboard(ctx context.Context, req *dashb
 		req.FolderId = folder.ID
 	} else {
 		folder, err := s.folderService.Get(ctx, &folder.GetFolderQuery{
-			ID:           &req.FolderId,
+			ID:           &req.FolderId, // nolint:staticcheck
 			OrgID:        req.User.GetOrgID(),
 			SignedInUser: req.User,
 		})

--- a/pkg/services/folder/folderimpl/folder.go
+++ b/pkg/services/folder/folderimpl/folder.go
@@ -121,6 +121,7 @@ func (s *Service) Get(ctx context.Context, cmd *folder.GetFolderQuery) (*folder.
 		if err != nil {
 			return nil, err
 		}
+	// nolint:staticcheck
 	case cmd.ID != nil:
 		dashFolder, err = s.getFolderByID(ctx, *cmd.ID, cmd.OrgID)
 		if err != nil {
@@ -158,6 +159,7 @@ func (s *Service) Get(ctx context.Context, cmd *folder.GetFolderQuery) (*folder.
 		return dashFolder, nil
 	}
 
+	// nolint:staticcheck
 	if cmd.ID != nil {
 		cmd.ID = nil
 		cmd.UID = &dashFolder.UID

--- a/pkg/services/folder/folderimpl/folder_test.go
+++ b/pkg/services/folder/folderimpl/folder_test.go
@@ -102,7 +102,7 @@ func TestIntegrationFolderService(t *testing.T) {
 
 			t.Run("When get folder by id should return access denied error", func(t *testing.T) {
 				_, err := service.Get(context.Background(), &folder.GetFolderQuery{
-					ID:           &folderId,
+					ID:           &folderId, // nolint:staticcheck
 					OrgID:        orgID,
 					SignedInUser: usr,
 				})
@@ -112,7 +112,7 @@ func TestIntegrationFolderService(t *testing.T) {
 			var zeroInt int64 = 0
 			t.Run("When get folder by id, with id = 0 should return default folder", func(t *testing.T) {
 				foldr, err := service.Get(context.Background(), &folder.GetFolderQuery{
-					ID:           &zeroInt,
+					ID:           &zeroInt, // nolint:staticcheck
 					OrgID:        orgID,
 					SignedInUser: usr,
 				})
@@ -1177,7 +1177,7 @@ func TestNestedFolderService(t *testing.T) {
 			}, dbtest.NewFakeDB())
 			_, err := folderSvc.Get(context.Background(), &folder.GetFolderQuery{
 				OrgID:        orgID,
-				ID:           &folder.GeneralFolder.ID,
+				ID:           &folder.GeneralFolder.ID, // nolint:staticcheck
 				SignedInUser: usr,
 			})
 			require.NoError(t, err)

--- a/pkg/services/folder/folderimpl/sqlstore.go
+++ b/pkg/services/folder/folderimpl/sqlstore.go
@@ -66,7 +66,7 @@ func (ss *sqlStore) Create(ctx context.Context, cmd folder.CreateFolderCommand) 
 		}
 
 		foldr, err = ss.Get(ctx, folder.GetFolderQuery{
-			ID: &lastInsertedID,
+			ID: &lastInsertedID, // nolint:staticcheck
 		})
 		if err != nil {
 			return err
@@ -163,6 +163,7 @@ func (ss *sqlStore) Get(ctx context.Context, q folder.GetFolderQuery) (*folder.F
 		switch {
 		case q.UID != nil:
 			exists, err = sess.SQL("SELECT * FROM folder WHERE uid = ? AND org_id = ?", q.UID, q.OrgID).Get(foldr)
+		// nolint:staticcheck
 		case q.ID != nil:
 			exists, err = sess.SQL("SELECT * FROM folder WHERE id = ?", q.ID).Get(foldr)
 		case q.Title != nil:

--- a/pkg/services/folder/folderimpl/sqlstore_test.go
+++ b/pkg/services/folder/folderimpl/sqlstore_test.go
@@ -430,7 +430,7 @@ func TestIntegrationGet(t *testing.T) {
 
 	t.Run("get folder by title should succeed", func(t *testing.T) {
 		ff, err := folderStore.Get(context.Background(), folder.GetFolderQuery{
-			ID: &f.ID,
+			ID: &f.ID, // nolint:staticcheck
 		})
 		require.NoError(t, err)
 		assert.Equal(t, f.ID, ff.ID)

--- a/pkg/services/folder/model.go
+++ b/pkg/services/folder/model.go
@@ -128,7 +128,8 @@ type DeleteFolderCommand struct {
 // service will select the field with the most specificity, in order: ID, UID,
 // Title.
 type GetFolderQuery struct {
-	UID   *string
+	UID *string
+	// Deprecated: use FolderUID instead
 	ID    *int64
 	Title *string
 	OrgID int64

--- a/pkg/services/libraryelements/api.go
+++ b/pkg/services/libraryelements/api.go
@@ -82,6 +82,7 @@ func (l *LibraryElementService) createHandler(c *contextmodel.ReqContext) respon
 	}
 
 	if element.FolderID != 0 {
+		// nolint:staticcheck
 		folder, err := l.folderService.Get(c.Req.Context(), &folder.GetFolderQuery{OrgID: c.SignedInUser.GetOrgID(), ID: &element.FolderID, SignedInUser: c.SignedInUser})
 		if err != nil {
 			return response.ErrOrFallback(http.StatusInternalServerError, "failed to get folder", err)
@@ -224,6 +225,7 @@ func (l *LibraryElementService) patchHandler(c *contextmodel.ReqContext) respons
 	}
 
 	if element.FolderID != 0 {
+		// nolint:staticcheck
 		folder, err := l.folderService.Get(c.Req.Context(), &folder.GetFolderQuery{OrgID: c.SignedInUser.GetOrgID(), ID: &element.FolderID, SignedInUser: c.SignedInUser})
 		if err != nil {
 			return response.Error(http.StatusInternalServerError, "failed to get folder", err)

--- a/pkg/services/ngalert/migration/permissions.go
+++ b/pkg/services/ngalert/migration/permissions.go
@@ -341,6 +341,7 @@ func (om *OrgMigration) getFolder(ctx context.Context, dash *dashboards.Dashboar
 		return migratedFolder, err
 	}
 
+	// nolint:staticcheck
 	f, err := om.migrationStore.GetFolder(ctx, &folder.GetFolderQuery{ID: &dash.FolderID, OrgID: om.orgID, SignedInUser: getMigrationUser(om.orgID)})
 	if err != nil {
 		if errors.Is(err, dashboards.ErrFolderNotFound) {


### PR DESCRIPTION
Deprecate `ID` in `GetFolderQuery` struct. Part of a series of PRs to deprecate sequential folder IDs.

Ref https://github.com/grafana/grafana/issues/61232