### PR TITLE
Snapshots: Do not return internal database ids

### DIFF
--- a/pkg/services/dashboardsnapshots/models.go
+++ b/pkg/services/dashboardsnapshots/models.go
@@ -29,7 +29,7 @@ type DashboardSnapshot struct {
 
 // DashboardSnapshotDTO without dashboard map
 type DashboardSnapshotDTO struct {
-	ID          int64  `json:"id" xorm:"id"`
+	ID          int64  `json:"-" xorm:"id"`
 	Name        string `json:"name"`
 	Key         string `json:"key"`
 	OrgID       int64  `json:"orgId" xorm:"org_id"`

--- a/pkg/services/dashboardsnapshots/models.go
+++ b/pkg/services/dashboardsnapshots/models.go
@@ -32,8 +32,8 @@ type DashboardSnapshotDTO struct {
 	ID          int64  `json:"-" xorm:"id"`
 	Name        string `json:"name"`
 	Key         string `json:"key"`
-	OrgID       int64  `json:"orgId" xorm:"org_id"`
-	UserID      int64  `json:"userId" xorm:"user_id"`
+	OrgID       int64  `json:"-" xorm:"org_id"`
+	UserID      int64  `json:"-" xorm:"user_id"`
 	External    bool   `json:"external"`
 	ExternalURL string `json:"externalUrl" xorm:"external_url"`
 

--- a/public/api-enterprise-spec.json
+++ b/public/api-enterprise-spec.json
@@ -4046,27 +4046,15 @@
         "externalUrl": {
           "type": "string"
         },
-        "id": {
-          "type": "integer",
-          "format": "int64"
-        },
         "key": {
           "type": "string"
         },
         "name": {
           "type": "string"
         },
-        "orgId": {
-          "type": "integer",
-          "format": "int64"
-        },
         "updated": {
           "type": "string",
           "format": "date-time"
-        },
-        "userId": {
-          "type": "integer",
-          "format": "int64"
         }
       }
     },

--- a/public/api-merged.json
+++ b/public/api-merged.json
@@ -13629,27 +13629,15 @@
         "externalUrl": {
           "type": "string"
         },
-        "id": {
-          "type": "integer",
-          "format": "int64"
-        },
         "key": {
           "type": "string"
         },
         "name": {
           "type": "string"
         },
-        "orgId": {
-          "type": "integer",
-          "format": "int64"
-        },
         "updated": {
           "type": "string",
           "format": "date-time"
-        },
-        "userId": {
-          "type": "integer",
-          "format": "int64"
         }
       }
     },

--- a/public/app/features/manage-dashboards/types.ts
+++ b/public/app/features/manage-dashboards/types.ts
@@ -7,13 +7,10 @@ export interface Snapshot {
   expires: string;
   external: boolean;
   externalUrl: string;
-  id: number;
   key: string;
   name: string;
-  orgId: number;
   updated: string;
   url?: string;
-  userId: number;
 }
 
 export type DeleteDashboardResponse = {

--- a/public/openapi3.json
+++ b/public/openapi3.json
@@ -4552,17 +4552,9 @@
           "name": {
             "type": "string"
           },
-          "orgId": {
-            "format": "int64",
-            "type": "integer"
-          },
           "updated": {
             "format": "date-time",
             "type": "string"
-          },
-          "userId": {
-            "format": "int64",
-            "type": "integer"
           }
         },
         "type": "object"

--- a/public/openapi3.json
+++ b/public/openapi3.json
@@ -4542,10 +4542,6 @@
           "externalUrl": {
             "type": "string"
           },
-          "id": {
-            "format": "int64",
-            "type": "integer"
-          },
           "key": {
             "type": "string"
           },


### PR DESCRIPTION
The snapshots API currently returns three internal database ids that are not needed or used by clients:
* id (the internal database id)
* org_id (it is required from the request user, and externally is irrelevant anyway)
* user_id (not used, and externally irrelevant)

Limiting usage of internal database ids greatly simplifies any multi-tenant migration efforts.  Since they are not required here, lets just remove them.  See https://github.com/grafana/grafana/pull/77667