### PR TITLE
Tooltip: Fixes tooltip positioning when using lazy content

### DIFF
--- a/packages/grafana-ui/src/components/Tooltip/Tooltip.story.tsx
+++ b/packages/grafana-ui/src/components/Tooltip/Tooltip.story.tsx
@@ -2,6 +2,7 @@ import { Meta, StoryFn } from '@storybook/react';
 import React from 'react';
 
 import { Button } from '../Button';
+import { Stack } from '../Layout/Stack/Stack';
 import mdx from '../Tooltip/Tooltip.mdx';
 
 import { Tooltip } from './Tooltip';
@@ -59,6 +60,23 @@ export const Basic: StoryFn<typeof Tooltip> = ({ content, ...args }) => {
     <Tooltip content={content} {...args}>
       <Button>Hover me for Tooltip </Button>
     </Tooltip>
+  );
+};
+
+export const OverflowViewport: StoryFn<typeof Tooltip> = ({}) => {
+  const content = () => <div>A really long tooltip that will overflow the viewport.</div>;
+
+  return (
+    <Stack justifyContent={'flex-end'}>
+      <Stack direction="column" alignItems={'flex-end'}>
+        <Tooltip content="Static string tooltip" placement="bottom">
+          <Button>Static string tooltip</Button>
+        </Tooltip>
+        <Tooltip content={content} placement="bottom">
+          <Button>Lazy content defined in a function</Button>
+        </Tooltip>
+      </Stack>
+    </Stack>
   );
 };
 

--- a/packages/grafana-ui/src/components/Tooltip/Tooltip.tsx
+++ b/packages/grafana-ui/src/components/Tooltip/Tooltip.tsx
@@ -53,6 +53,18 @@ export const Tooltip = React.forwardRef<HTMLElement, TooltipProps>(
       onVisibleChange: setControlledVisible,
     });
 
+    const contentIsFunction = typeof content === 'function';
+
+    /**
+     * If content is a function we need to call popper update function to make sure the tooltip is positioned correctly
+     * if it's close to the viewport boundary
+     **/
+    useEffect(() => {
+      if (update && contentIsFunction) {
+        update();
+      }
+    }, [visible, update, contentIsFunction]);
+
     const styles = useStyles2(getStyles);
     const style = styles[theme ?? 'info'];
 
@@ -91,7 +103,7 @@ export const Tooltip = React.forwardRef<HTMLElement, TooltipProps>(
               <div {...getArrowProps({ className: style.arrow })} />
               {typeof content === 'string' && content}
               {React.isValidElement(content) && React.cloneElement(content)}
-              {typeof content === 'function' &&
+              {contentIsFunction &&
                 update &&
                 content({
                   updatePopperPosition: update,


### PR DESCRIPTION
Started seeing a strange behavior with the tooltip of TimeRangePicker. The Zoom out button tooltip was shown outside viewport and triggered a horizontal scrollbar being added. See video below. 

After more investigation I discovered I could not replicate the problem with string/react node Tooltip content, only when the Tooltip content was a function did the normal preventOverflow behavior of usePopper not work. 

I checked if there was any updates to popperjs/core or react-popper-tooltip but we are using latest. 

Changes
* [x] I found one solution to the problem and that is to call usePopper's update function when visible state changes and the content is a function. 
* [x] Added storybook story to test and verify this scenario 

[Nested-scenes-and-variables---Demos---Scenes-Test-App---Apps---Grafana (1).webm](https://github.com/grafana/grafana/assets/10999/60f8afa8-7843-4608-8a96-3337327a21bd)

Before:
![image](https://github.com/grafana/grafana/assets/10999/75d92156-3540-429d-8d52-8fbb935285b8)

After:
![Screenshot from 2023-11-05 11-15-58](https://github.com/grafana/grafana/assets/10999/2fdc1c90-32f8-45e0-989f-bee677ea1373)
