### PR TITLE
ButtonSelect: Fix missing border when dropdown menu is shown

### DIFF
--- a/packages/grafana-ui/src/components/Dropdown/ButtonSelect.internal.story.tsx
+++ b/packages/grafana-ui/src/components/Dropdown/ButtonSelect.internal.story.tsx
@@ -27,6 +27,7 @@ export const Basic: StoryFn<typeof ButtonSelect> = (args) => {
   return (
     <div style={{ marginLeft: '100px', position: 'relative', display: 'inline-block' }}>
       <ButtonSelect
+        variant="canvas"
         {...args}
         onChange={(value) => {
           action('onChange fired')(value);

--- a/packages/grafana-ui/src/components/Dropdown/ButtonSelect.tsx
+++ b/packages/grafana-ui/src/components/Dropdown/ButtonSelect.tsx
@@ -8,7 +8,6 @@ import React, { HTMLAttributes } from 'react';
 import { GrafanaTheme2, SelectableValue } from '@grafana/data';
 
 import { useStyles2 } from '../../themes/ThemeContext';
-import { ButtonGroup } from '../Button';
 import { ClickOutsideWrapper } from '../ClickOutsideWrapper/ClickOutsideWrapper';
 import { Menu } from '../Menu/Menu';
 import { MenuItem } from '../Menu/MenuItem';
@@ -46,7 +45,7 @@ const ButtonSelectComponent = <T,>(props: Props<T>) => {
   };
 
   return (
-    <ButtonGroup className={styles.wrapper}>
+    <div className={styles.wrapper}>
       <ToolbarButton
         className={className}
         isOpen={state.isOpen}
@@ -83,7 +82,7 @@ const ButtonSelectComponent = <T,>(props: Props<T>) => {
           </ClickOutsideWrapper>
         </div>
       )}
-    </ButtonGroup>
+    </div>
   );
 };
 


### PR DESCRIPTION
I noticed this bug in the RefreshPicker, it's missing a right side border when it's opened 
![Screenshot from 2023-11-05 11-30-10](https://github.com/grafana/grafana/assets/10999/139be513-2724-4624-b238-f0aa975e0c4c)

* [x] Remove ButtonGroup (not sure why ButtonSelect was wrapped in this when it only contains a single ToolbarButton, maybe in the past it was composed of two?) 

the missing border is due to ButtonGroup removing the right side border of buttons inside the group (unless it's last child), to not have double borders, the dropdown menu was an element added inside the ButtonGroup and hence the first ToolbarButton was no longer last child and hence its border was removed while the menu was showing. 