### PR TITLE
Alerting: Disable cache in rktq when fetching export data.

### DIFF
--- a/public/app/features/alerting/unified/api/alertRuleApi.ts
+++ b/public/app/features/alerting/unified/api/alertRuleApi.ts
@@ -209,6 +209,7 @@ export const alertRuleApi = alertingApi.injectEndpoints({
         params: { format: format, decrypt: decrypt, name: receiverName },
         responseType: 'text',
       }),
+      keepUnusedDataFor: 0,
     }),
     exportReceivers: build.query<string, { decrypt: boolean; format: ExportFormats }>({
       query: ({ decrypt, format }) => ({
@@ -216,6 +217,7 @@ export const alertRuleApi = alertingApi.injectEndpoints({
         params: { format: format, decrypt: decrypt },
         responseType: 'text',
       }),
+      keepUnusedDataFor: 0,
     }),
     exportPolicies: build.query<string, { format: ExportFormats }>({
       query: ({ format }) => ({
@@ -223,6 +225,7 @@ export const alertRuleApi = alertingApi.injectEndpoints({
         params: { format: format },
         responseType: 'text',
       }),
+      keepUnusedDataFor: 0,
     }),
     exportModifiedRuleGroup: build.mutation<
       string,

--- a/public/app/features/alerting/unified/api/alertRuleApi.ts
+++ b/public/app/features/alerting/unified/api/alertRuleApi.ts
@@ -201,6 +201,7 @@ export const alertRuleApi = alertingApi.injectEndpoints({
         params: { format: format, folderUid: folderUid, group: group, ruleUid: ruleUid },
         responseType: 'text',
       }),
+      keepUnusedDataFor: 0,
     }),
     exportReceiver: build.query<string, { receiverName: string; decrypt: boolean; format: ExportFormats }>({
       query: ({ receiverName, decrypt, format }) => ({

--- a/public/app/features/alerting/unified/components/export/GrafanaRuleFolderExporter.tsx
+++ b/public/app/features/alerting/unified/components/export/GrafanaRuleFolderExporter.tsx
@@ -37,10 +37,13 @@ interface GrafanaRuleFolderExportPreviewProps {
 }
 
 function GrafanaRuleFolderExportPreview({ folder, exportFormat, onClose }: GrafanaRuleFolderExportPreviewProps) {
-  const { currentData: exportFolderDefinition = '', isFetching } = alertRuleApi.endpoints.exportRules.useQuery({
-    folderUid: folder.uid,
-    format: exportFormat,
-  });
+  const { currentData: exportFolderDefinition = '', isFetching } = alertRuleApi.endpoints.exportRules.useQuery(
+    {
+      folderUid: folder.uid,
+      format: exportFormat,
+    },
+    { refetchOnMountOrArgChange: true }
+  );
 
   if (isFetching) {
     return <LoadingPlaceholder text="Loading...." />;

--- a/public/app/features/alerting/unified/components/export/GrafanaRuleFolderExporter.tsx
+++ b/public/app/features/alerting/unified/components/export/GrafanaRuleFolderExporter.tsx
@@ -37,13 +37,10 @@ interface GrafanaRuleFolderExportPreviewProps {
 }
 
 function GrafanaRuleFolderExportPreview({ folder, exportFormat, onClose }: GrafanaRuleFolderExportPreviewProps) {
-  const { currentData: exportFolderDefinition = '', isFetching } = alertRuleApi.endpoints.exportRules.useQuery(
-    {
-      folderUid: folder.uid,
-      format: exportFormat,
-    },
-    { refetchOnMountOrArgChange: true }
-  );
+  const { currentData: exportFolderDefinition = '', isFetching } = alertRuleApi.endpoints.exportRules.useQuery({
+    folderUid: folder.uid,
+    format: exportFormat,
+  });
 
   if (isFetching) {
     return <LoadingPlaceholder text="Loading...." />;


### PR DESCRIPTION
**What is this feature?**

This PR disable caching results when fetching exported data.
This includes when exporting:
- alert group 
- all alert rules
- all  receivers
- receiver
- notification policies

**Why do we need this feature?**

Exported data should represent the current data.

**Who is this feature for?**

All users.


**Special notes for your reviewer:**

**After change , exporting a group:**

https://github.com/grafana/grafana/assets/33540275/1a1bf7ee-9603-453f-a9e3-51a44c683105

**After the change, exporting all alert rules:**

https://github.com/grafana/grafana/assets/33540275/2454dd24-ff01-4ced-8fa8-dd03723b99f5




Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
