### PR TITLE
Table: Fix `no data` message alignment and table selector name

### DIFF
--- a/packages/grafana-data/src/field/fieldState.ts
+++ b/packages/grafana-data/src/field/fieldState.ts
@@ -31,7 +31,7 @@ export function getFrameDisplayName(frame: DataFrame, index?: number) {
   }
 
   // list all the
-  if (index === undefined && frame.length > 0) {
+  if (index === undefined && frame.fields.length > 0) {
     return frame.fields
       .filter((f) => f.type !== FieldType.time)
       .map((f) => getFieldDisplayName(f, frame))

--- a/packages/grafana-data/src/field/fieldState.ts
+++ b/packages/grafana-data/src/field/fieldState.ts
@@ -31,7 +31,7 @@ export function getFrameDisplayName(frame: DataFrame, index?: number) {
   }
 
   // list all the
-  if (index === undefined) {
+  if (index === undefined && frame.length > 0) {
     return frame.fields
       .filter((f) => f.type !== FieldType.time)
       .map((f) => getFieldDisplayName(f, frame))

--- a/packages/grafana-ui/src/components/Table/Table.tsx
+++ b/packages/grafana-ui/src/components/Table/Table.tsx
@@ -372,7 +372,7 @@ export const Table = memo((props: Props) => {
               </CustomScrollbar>
             </div>
           ) : (
-            <div style={{ height: height - headerHeight, width: width }} className={tableStyles.noData}>
+            <div style={{ height: height - headerHeight, width }} className={tableStyles.noData}>
               No data
             </div>
           )}

--- a/packages/grafana-ui/src/components/Table/Table.tsx
+++ b/packages/grafana-ui/src/components/Table/Table.tsx
@@ -372,7 +372,7 @@ export const Table = memo((props: Props) => {
               </CustomScrollbar>
             </div>
           ) : (
-            <div style={{ height: height - headerHeight }} className={tableStyles.noData}>
+            <div style={{ height: height - headerHeight, width: width }} className={tableStyles.noData}>
               No data
             </div>
           )}


### PR DESCRIPTION
In the case of multiple queries where one returns no data the error message is wrongly aligned and the table selector shows no title for the empty series.
Before:
![Screenshot 2023-11-06 at 13 40 12](https://github.com/grafana/grafana/assets/36818606/93183520-7cfd-491d-9d2e-1b98b3abbea5)

After:
![Screenshot 2023-11-06 at 13 40 59](https://github.com/grafana/grafana/assets/36818606/83fefcf3-d72f-41e6-9a61-a99b74482bcd)

To reproduce I used TestDB with 2 CSV Content queries:
- the first had some data, e.g.:
```
x,y
1,2
2,3
```
- the second had only a header, e.g.:
`x,y`

This is also reproducible with prometheus if one query returns no data, e.g.:
Query A - `absent(notExists{common="me",a="a"}) * 3`
Query B - `notExists{common="me",a="a"} * 2`