### PR TITLE
PromQail: use metric type when available else use fallback heuristic

### DIFF
--- a/public/app/plugins/datasource/prometheus/querybuilder/components/promQail/state/helpers.test.ts
+++ b/public/app/plugins/datasource/prometheus/querybuilder/components/promQail/state/helpers.test.ts
@@ -25,7 +25,7 @@ const metricListWithType = [
 const metricList = metricListWithType.map((item) => item[0]);
 
 describe('guessMetricType', () => {
-  it.each(metricListWithType)("where input is '%s'", (metric: string, metricType: string[]) => {
+  it.each(metricListWithType)("where input is '%s'", (metric: string, metricType: string) => {
     expect(guessMetricType(metric, metricList)).toBe(metricType);
   });
 });

--- a/public/app/plugins/datasource/prometheus/querybuilder/components/promQail/state/helpers.test.ts
+++ b/public/app/plugins/datasource/prometheus/querybuilder/components/promQail/state/helpers.test.ts
@@ -1,0 +1,31 @@
+import { guessMetricType } from './helpers';
+
+const metricListWithType = [
+  // below is summary metric family
+  ['go_gc_duration_seconds', 'summary'],
+  ['go_gc_duration_seconds_count', 'summary'],
+  ['go_gc_duration_seconds_sum', 'summary'],
+  // below is histogram metric family
+  ['go_gc_heap_allocs_by_size_bytes_total_bucket', 'histogram'],
+  ['go_gc_heap_allocs_by_size_bytes_total_count', 'histogram'],
+  ['go_gc_heap_allocs_by_size_bytes_total_sum', 'histogram'],
+  // below are counters
+  ['go_gc_heap_allocs_bytes_total', 'counter'],
+  ['scrape_samples_post_metric_relabeling', 'counter'],
+  // below are gauges
+  ['go_gc_heap_goal_bytes', 'gauge'],
+  ['nounderscorename', 'gauge'],
+  // below is both a histogram & summary
+  ['alertmanager_http_response_size_bytes', 'histogram,summary'],
+  ['alertmanager_http_response_size_bytes_bucket', 'histogram,summary'],
+  ['alertmanager_http_response_size_bytes_count', 'histogram,summary'],
+  ['alertmanager_http_response_size_bytes_sum', 'histogram,summary'],
+];
+
+const metricList = metricListWithType.map((item) => item[0]);
+
+describe('guessMetricType', () => {
+  it.each(metricListWithType)("where input is '%s'", (metric: string, metricType: string[]) => {
+    expect(guessMetricType(metric, metricList)).toBe(metricType);
+  });
+});

--- a/public/app/plugins/datasource/prometheus/querybuilder/components/promQail/state/helpers.ts
+++ b/public/app/plugins/datasource/prometheus/querybuilder/components/promQail/state/helpers.ts
@@ -193,12 +193,33 @@ export async function promQailSuggest(
     if (interaction?.suggestionType === SuggestionType.AI) {
       feedTheAI = { ...feedTheAI, prompt: interaction.prompt };
 
-      // TODO: filter by metric type
+      let metricType = '';
+      if (datasource.languageProvider.metricsMetadata) {
+        metricType = getMetadataType(query.metric, datasource.languageProvider.metricsMetadata) ?? '';
+      }
+
       // @ts-ignore llms types issue
       results = await llms.vector.search<TemplateSearchResult>({
         query: interaction.prompt,
         collection: promQLTemplatesCollection,
         topK: 5,
+        filter:
+          metricType === ''
+            ? undefined
+            : {
+                $or: [
+                  {
+                    metric_type: {
+                      $eq: metricType,
+                    },
+                  },
+                  {
+                    metric_type: {
+                      $eq: '*',
+                    },
+                  },
+                ],
+              },
       });
       // TODO: handle errors from vector search
     }

--- a/public/app/plugins/datasource/prometheus/querybuilder/components/promQail/state/helpers.ts
+++ b/public/app/plugins/datasource/prometheus/querybuilder/components/promQail/state/helpers.ts
@@ -282,8 +282,12 @@ export async function promQailSuggest(
   const interactionToUpdate = interaction ? interaction : createInteraction(SuggestionType.Historical);
 
   // Decide metric type
-  await datasource.languageProvider.start(); //why do I need to do this to prepropulate the list??
   let metricType = '';
+  // Makes sure we loaded the metadata for metrics. Usually this is done in the start() method of the
+  // provider but we only need the metadata here.
+  if (!datasource.languageProvider.metricsMetadata) {
+    await datasource.languageProvider.loadMetricsMetadata();
+  }
   if (datasource.languageProvider.metricsMetadata) {
     // `datasource.languageProvider.metricsMetadata` is a list of metric family names (with desired type)
     // from the datasource metadata endoint, but unfortunately the expanded _sum, _count, _bucket raw


### PR DESCRIPTION
**What is this feature?**

PromQail query suggestions work best when the correct metric type is supplied. This fetches the metric type from the metric metadata, but if not it uses a heuristic to guess the type.

**Why do we need this feature?**

Improve quality of PromQail query suggestions

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
