### PR TITLE
Alerting: Do not show missing integration while loading oncall plugin status

### DIFF
--- a/public/app/features/alerting/unified/components/contact-points/useContactPoints.tsx
+++ b/public/app/features/alerting/unified/components/contact-points/useContactPoints.tsx
@@ -7,7 +7,7 @@ import { produce } from 'immer';
 import { remove } from 'lodash';
 
 import { alertmanagerApi } from '../../api/alertmanagerApi';
-import { onCallApi } from '../../api/onCallApi';
+import { onCallApi, OnCallIntegrationDTO } from '../../api/onCallApi';
 import { usePluginBridge } from '../../hooks/usePluginBridge';
 import { useAlertmanager } from '../../state/AlertmanagerContext';
 import { SupportedPlugin } from '../../types/pluginBridges';
@@ -29,7 +29,7 @@ const RECEIVER_STATUS_POLLING_INTERVAL = 10 * 1000; // 10 seconds
  */
 export function useContactPointsWithStatus() {
   const { selectedAlertmanager, isGrafanaAlertmanager } = useAlertmanager();
-  const { installed: onCallPluginInstalled = false, loading: onCallPluginStatusLoading } = usePluginBridge(
+  const { installed: onCallPluginInstalled, loading: onCallPluginStatusLoading } = usePluginBridge(
     SupportedPlugin.OnCall
   );
 
@@ -55,6 +55,14 @@ export function useContactPointsWithStatus() {
       skip: !onCallPluginInstalled || !isGrafanaAlertmanager,
     });
 
+  // null = no installed, undefined = loading, [n] is installed with integrations
+  let onCallMetadata: null | undefined | OnCallIntegrationDTO[] = undefined;
+  if (onCallPluginInstalled) {
+    onCallMetadata = onCallIntegrations ?? [];
+  } else if (onCallPluginInstalled === false) {
+    onCallMetadata = null;
+  }
+
   // fetch the latest config from the Alertmanager
   const fetchAlertmanagerConfiguration = alertmanagerApi.endpoints.getAlertmanagerConfiguration.useQuery(
     selectedAlertmanager!,
@@ -68,7 +76,7 @@ export function useContactPointsWithStatus() {
               result.data,
               fetchContactPointsStatus.data,
               fetchReceiverMetadata.data,
-              onCallPluginInstalled ? onCallIntegrations ?? [] : null
+              onCallMetadata
             )
           : [],
       }),

--- a/public/app/features/alerting/unified/components/contact-points/utils.ts
+++ b/public/app/features/alerting/unified/components/contact-points/utils.ts
@@ -96,7 +96,7 @@ export function enhanceContactPointsWithMetadata(
   result: AlertManagerCortexConfig,
   status: ReceiversStateDTO[] = [],
   notifiers: NotifierDTO[] = [],
-  onCallIntegrations: OnCallIntegrationDTO[] | null
+  onCallIntegrations: OnCallIntegrationDTO[] | undefined | null
 ): ContactPointWithMetadata[] {
   const contactPoints = result.alertmanager_config.receivers ?? [];
 

--- a/public/app/features/alerting/unified/components/receivers/grafanaAppReceivers/useReceiversMetadata.ts
+++ b/public/app/features/alerting/unified/components/receivers/grafanaAppReceivers/useReceiversMetadata.ts
@@ -26,7 +26,7 @@ const onCallReceiverMeta: ReceiverPluginMetadata = {
 };
 
 export const useReceiversMetadata = (receivers: Receiver[]): Map<Receiver, ReceiverPluginMetadata> => {
-  const { installed: isOnCallEnabled, loading } = usePluginBridge(SupportedPlugin.OnCall);
+  const { installed: isOnCallEnabled } = usePluginBridge(SupportedPlugin.OnCall);
   const { data: onCallIntegrations = [] } = onCallApi.useGrafanaOnCallIntegrationsQuery(undefined, {
     skip: !isOnCallEnabled,
   });
@@ -38,10 +38,6 @@ export const useReceiversMetadata = (receivers: Receiver[]): Map<Receiver, Recei
       const onCallReceiver = receiver.grafana_managed_receiver_configs?.find((c) => c.type === ReceiverTypes.OnCall);
 
       if (onCallReceiver) {
-        if (loading) {
-          return;
-        }
-
         if (!isOnCallEnabled) {
           result.set(receiver, getOnCallMetadata(null, onCallReceiver));
           return;
@@ -52,7 +48,7 @@ export const useReceiversMetadata = (receivers: Receiver[]): Map<Receiver, Recei
     });
 
     return result;
-  }, [receivers, loading, isOnCallEnabled, onCallIntegrations]);
+  }, [receivers, isOnCallEnabled, onCallIntegrations]);
 };
 
 export function getOnCallMetadata(

--- a/public/app/features/alerting/unified/components/receivers/grafanaAppReceivers/useReceiversMetadata.ts
+++ b/public/app/features/alerting/unified/components/receivers/grafanaAppReceivers/useReceiversMetadata.ts
@@ -26,7 +26,7 @@ const onCallReceiverMeta: ReceiverPluginMetadata = {
 };
 
 export const useReceiversMetadata = (receivers: Receiver[]): Map<Receiver, ReceiverPluginMetadata> => {
-  const { installed: isOnCallEnabled } = usePluginBridge(SupportedPlugin.OnCall);
+  const { installed: isOnCallEnabled, loading } = usePluginBridge(SupportedPlugin.OnCall);
   const { data: onCallIntegrations = [] } = onCallApi.useGrafanaOnCallIntegrationsQuery(undefined, {
     skip: !isOnCallEnabled,
   });
@@ -38,6 +38,10 @@ export const useReceiversMetadata = (receivers: Receiver[]): Map<Receiver, Recei
       const onCallReceiver = receiver.grafana_managed_receiver_configs?.find((c) => c.type === ReceiverTypes.OnCall);
 
       if (onCallReceiver) {
+        if (loading) {
+          return;
+        }
+
         if (!isOnCallEnabled) {
           result.set(receiver, getOnCallMetadata(null, onCallReceiver));
           return;
@@ -48,13 +52,18 @@ export const useReceiversMetadata = (receivers: Receiver[]): Map<Receiver, Recei
     });
 
     return result;
-  }, [isOnCallEnabled, receivers, onCallIntegrations]);
+  }, [receivers, loading, isOnCallEnabled, onCallIntegrations]);
 };
 
 export function getOnCallMetadata(
-  onCallIntegrations: OnCallIntegrationDTO[] | null,
+  onCallIntegrations: OnCallIntegrationDTO[] | undefined | null,
   receiver: GrafanaManagedReceiverConfig
 ): ReceiverPluginMetadata {
+  // oncall status is still loading
+  if (onCallIntegrations === undefined) {
+    return onCallReceiverMeta;
+  }
+
   // indication that onCall is not enabled
   if (onCallIntegrations == null) {
     return {


### PR DESCRIPTION
**What is this feature?**

A small PR that prevents showing "missing oncall integrations" while we're still loading the plugin status.