### PR TITLE
Log rows: memoize row processing

### DIFF
--- a/public/app/features/explore/Logs/Logs.tsx
+++ b/public/app/features/explore/Logs/Logs.tsx
@@ -102,6 +102,7 @@ interface Props extends Themeable2 {
   isFilterLabelActive?: (key: string, value: string, refId?: string) => Promise<boolean>;
   logsFrames?: DataFrame[];
   range: TimeRange;
+  loadMore?(range: AbsoluteTimeRange, refIds: string[]): void;
 }
 
 export type LogsVisualisationType = 'table' | 'logs';
@@ -523,6 +524,7 @@ class UnthemedLogs extends PureComponent<Props, State> {
       getRowContext,
       getLogRowContextUi,
       getRowContextQuery,
+      loadMore
     } = this.props;
 
     const {
@@ -806,6 +808,9 @@ class UnthemedLogs extends PureComponent<Props, State> {
               scrollToTopLogs={this.scrollToTopLogs}
               addResultsToCache={addResultsToCache}
               clearCache={clearCache}
+              loadMore={(range: AbsoluteTimeRange) => {
+                loadMore?.(range, logsQueries?.map((q) => q.refId) ?? []);
+              }}
             />
           </div>
         </PanelChrome>

--- a/public/app/features/explore/Logs/LogsContainer.tsx
+++ b/public/app/features/explore/Logs/LogsContainer.tsx
@@ -34,7 +34,7 @@ import {
   selectIsWaitingForData,
   setSupplementaryQueryEnabled,
 } from '../state/query';
-import { updateTimeRange } from '../state/time';
+import { updateTimeRange, loadMore } from '../state/time';
 import { LiveTailControls } from '../useLiveTailControls';
 import { getFieldLinksForExplore } from '../utils/links';
 
@@ -144,6 +144,11 @@ class LogsContainer extends PureComponent<LogsContainerProps, LogsContainerState
   onChangeTime = (absoluteRange: AbsoluteTimeRange) => {
     const { exploreId, updateTimeRange } = this.props;
     updateTimeRange({ exploreId, absoluteRange });
+  };
+
+  loadMore = (absoluteRange: AbsoluteTimeRange, refIds: string[]) => {
+    const { exploreId, loadMore } = this.props;
+    loadMore({ exploreId, absoluteRange, refIds });
   };
 
   private getQuery(
@@ -291,6 +296,7 @@ class LogsContainer extends PureComponent<LogsContainerProps, LogsContainerState
             loadingState={loadingState}
             loadLogsVolumeData={() => loadSupplementaryQueryData(exploreId, SupplementaryQueryType.LogsVolume)}
             onChangeTime={this.onChangeTime}
+            loadMore={this.loadMore}
             onClickFilterLabel={logDetailsFilterAvailable ? onClickFilterLabel : undefined}
             onClickFilterOutLabel={logDetailsFilterAvailable ? onClickFilterOutLabel : undefined}
             onStartScanning={onStartScanning}
@@ -362,6 +368,7 @@ function mapStateToProps(state: StoreState, { exploreId }: { exploreId: string }
 
 const mapDispatchToProps = {
   updateTimeRange,
+  loadMore,
   addResultsToCache,
   clearCache,
   loadSupplementaryQueryData,

--- a/public/app/features/explore/Logs/LogsNavigation.tsx
+++ b/public/app/features/explore/Logs/LogsNavigation.tsx
@@ -21,6 +21,7 @@ type Props = {
   scrollToTopLogs: () => void;
   addResultsToCache: () => void;
   clearCache: () => void;
+  loadMore?: (range: AbsoluteTimeRange) => void;
 };
 
 export type LogsPage = {
@@ -39,6 +40,7 @@ function LogsNavigation({
   queries,
   clearCache,
   addResultsToCache,
+  loadMore,
 }: Props) {
   const [pages, setPages] = useState<LogsPage[]>([]);
   const [currentPageIndex, setCurrentPageIndex] = useState(0);
@@ -118,13 +120,25 @@ function LogsNavigation({
         });
         if (!onLastPage) {
           const indexChange = oldestLogsFirst ? -1 : 1;
-          changeTime({
-            from: pages[currentPageIndex + indexChange].queryRange.from,
-            to: pages[currentPageIndex + indexChange].queryRange.to,
-          });
+          if (loadMore) {
+            loadMore({
+              from: pages[currentPageIndex + indexChange].queryRange.from,
+              to: pages[currentPageIndex + indexChange].queryRange.to,
+            });
+          } else {
+            changeTime({
+              from: pages[currentPageIndex + indexChange].queryRange.from,
+              to: pages[currentPageIndex + indexChange].queryRange.to,
+            });
+          }
+          
         } else {
           //If we are on the last page, create new range
-          changeTime({ from: visibleRange.from - rangeSpanRef.current, to: visibleRange.from });
+          if (loadMore) {
+            loadMore({ from: visibleRange.from - rangeSpanRef.current, to: visibleRange.from });
+          } else {
+            changeTime({ from: visibleRange.from - rangeSpanRef.current, to: visibleRange.from });
+          }
         }
         scrollToTopLogs();
       }}

--- a/public/app/features/explore/Logs/LogsNavigation.tsx
+++ b/public/app/features/explore/Logs/LogsNavigation.tsx
@@ -93,6 +93,39 @@ function LogsNavigation({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
+  useEffect(() => {
+    const scrollView = document.querySelector('.scrollbar-view');
+    if (!scrollView) {
+      return;
+    }
+    const delta = 0;
+    function handleScroll(e: Event) {
+      if (!e.target || !loadMore) {
+        return;
+      }
+      const target: HTMLDivElement = e.target as HTMLDivElement;
+      const diff = (target.scrollHeight - target.scrollTop) - target.clientHeight;
+      if (diff > delta) {
+        return;
+      }
+      if (!onLastPage) {
+        const indexChange = oldestLogsFirst ? -1 : 1;
+          loadMore({
+            from: pages[currentPageIndex + indexChange].queryRange.from,
+            to: pages[currentPageIndex + indexChange].queryRange.to,
+          });
+      } else {
+        loadMore({ from: visibleRange.from - rangeSpanRef.current, to: visibleRange.from });
+      }
+      scrollView?.removeEventListener('scroll', handleScroll);
+    }
+    scrollView.addEventListener('scroll', handleScroll);
+
+    return () => {
+      scrollView.removeEventListener('scroll', handleScroll);
+    }
+  }, [currentPageIndex, loadMore, oldestLogsFirst, onLastPage, pages, visibleRange.from]);
+
   const changeTime = useCallback(
     ({ from, to }: AbsoluteTimeRange) => {
       expectedRangeRef.current = { from, to };
@@ -108,40 +141,40 @@ function LogsNavigation({
     return a.queryRange.to > b.queryRange.to ? -1 : 1;
   };
 
+  const handleLoadMore = () => {
+    //If we are not on the last page, use next page's range
+    reportInteraction('grafana_explore_logs_pagination_clicked', {
+      pageType: 'olderLogsButton',
+    });
+    if (!onLastPage) {
+      const indexChange = oldestLogsFirst ? -1 : 1;
+      if (loadMore) {
+        loadMore({
+          from: pages[currentPageIndex + indexChange].queryRange.from,
+          to: pages[currentPageIndex + indexChange].queryRange.to,
+        });
+      } else {
+        changeTime({
+          from: pages[currentPageIndex + indexChange].queryRange.from,
+          to: pages[currentPageIndex + indexChange].queryRange.to,
+        });
+      }
+    } else {
+      //If we are on the last page, create new range
+      if (loadMore) {
+        loadMore({ from: visibleRange.from - rangeSpanRef.current, to: visibleRange.from });
+      } else {
+        changeTime({ from: visibleRange.from - rangeSpanRef.current, to: visibleRange.from });
+      }
+    }
+  };
+
   const olderLogsButton = (
     <Button
       data-testid="olderLogsButton"
       className={styles.navButton}
       variant="secondary"
-      onClick={() => {
-        //If we are not on the last page, use next page's range
-        reportInteraction('grafana_explore_logs_pagination_clicked', {
-          pageType: 'olderLogsButton',
-        });
-        if (!onLastPage) {
-          const indexChange = oldestLogsFirst ? -1 : 1;
-          if (loadMore) {
-            loadMore({
-              from: pages[currentPageIndex + indexChange].queryRange.from,
-              to: pages[currentPageIndex + indexChange].queryRange.to,
-            });
-          } else {
-            changeTime({
-              from: pages[currentPageIndex + indexChange].queryRange.from,
-              to: pages[currentPageIndex + indexChange].queryRange.to,
-            });
-          }
-          
-        } else {
-          //If we are on the last page, create new range
-          if (loadMore) {
-            loadMore({ from: visibleRange.from - rangeSpanRef.current, to: visibleRange.from });
-          } else {
-            changeTime({ from: visibleRange.from - rangeSpanRef.current, to: visibleRange.from });
-          }
-        }
-        scrollToTopLogs();
-      }}
+      onClick={handleLoadMore}
       disabled={loading}
     >
       <div className={styles.navButtonContent}>
@@ -168,7 +201,6 @@ function LogsNavigation({
             to: pages[currentPageIndex + indexChange].queryRange.to,
           });
         }
-        scrollToTopLogs();
         //If we are on the first page, button is disabled and we do nothing
       }}
       disabled={loading || onFirstPage}

--- a/public/app/features/explore/Logs/LogsNavigation.tsx
+++ b/public/app/features/explore/Logs/LogsNavigation.tsx
@@ -98,7 +98,7 @@ function LogsNavigation({
     if (!scrollView) {
       return;
     }
-    const delta = 0;
+    const delta = 1;
     function handleScroll(e: Event) {
       if (!e.target || !loadMore) {
         return;

--- a/public/app/features/explore/state/query.ts
+++ b/public/app/features/explore/state/query.ts
@@ -53,7 +53,7 @@ import { ExploreState, QueryOptions, SupplementaryQueries } from 'app/types/expl
 import { notifyApp } from '../../../core/actions';
 import { createErrorNotification } from '../../../core/copy/appNotification';
 import { runRequest } from '../../query/state/runRequest';
-import { decorateData, decorateLoadMoreData, mergeDataSeries } from '../utils/decorators';
+import { decorateData, mergeDataSeries } from '../utils/decorators';
 import {
   getSupplementaryQueryProvider,
   storeSupplementaryQueryEnabled,

--- a/public/app/features/explore/state/query.ts
+++ b/public/app/features/explore/state/query.ts
@@ -780,7 +780,8 @@ export const runLoadMoreQueries = createAsyncThunk<void, RunLoadMoreQueriesOptio
     ]).pipe(
       mergeMap(([data, correlations]) =>
         decorateData(
-          mergeDataSeries(queryResponse, data),
+          // Query splitting, otherwise duplicates results
+          data.state === LoadingState.Done ? mergeDataSeries(queryResponse, data) : data,
           queryResponse,
           absoluteRange,
           undefined,

--- a/public/app/features/explore/state/query.ts
+++ b/public/app/features/explore/state/query.ts
@@ -10,6 +10,7 @@ import {
   DataQueryErrorType,
   DataQueryResponse,
   DataSourceApi,
+  dateTimeForTimeZone,
   hasQueryExportSupport,
   hasQueryImportSupport,
   HistoryItem,
@@ -29,13 +30,14 @@ import {
   generateEmptyQuery,
   generateNewKeyAndAddRefIdIfMissing,
   getQueryKeys,
+  getTimeRange,
   hasNonEmptyQuery,
   stopQueryState,
   updateHistory,
 } from 'app/core/utils/explore';
 import { getShiftedTimeRange } from 'app/core/utils/timePicker';
 import { getCorrelationsBySourceUIDs } from 'app/features/correlations/utils';
-import { getTimeZone } from 'app/features/profile/state/selectors';
+import { getFiscalYearStartMonth, getTimeZone } from 'app/features/profile/state/selectors';
 import { MIXED_DATASOURCE_NAME } from 'app/plugins/datasource/mixed/MixedDataSource';
 import {
   createAsyncThunk,
@@ -712,7 +714,6 @@ export const runLoadMoreQueries = createAsyncThunk<void, RunLoadMoreQueriesOptio
     const {
       datasourceInstance,
       containerWidth,
-      range,
       queryResponse,
       correlationEditorHelperData,
       queries: exploreQueries,
@@ -759,6 +760,10 @@ export const runLoadMoreQueries = createAsyncThunk<void, RunLoadMoreQueriesOptio
     }
 
     const timeZone = getTimeZone(getState().user);
+    const range =  getTimeRange(timeZone, {
+      from: dateTimeForTimeZone(timeZone, absoluteRange.from),
+      to: dateTimeForTimeZone(timeZone, absoluteRange.to),
+    }, getFiscalYearStartMonth(getState().user));
     const transaction = buildQueryTransaction(
       exploreId,
       queries,
@@ -774,7 +779,8 @@ export const runLoadMoreQueries = createAsyncThunk<void, RunLoadMoreQueriesOptio
       correlations$,
     ]).pipe(
       mergeMap(([data, correlations]) =>
-        decorateLoadMoreData(
+       {
+        return  decorateLoadMoreData(
           data,
           queryResponse,
           absoluteRange,
@@ -783,6 +789,7 @@ export const runLoadMoreQueries = createAsyncThunk<void, RunLoadMoreQueriesOptio
           showCorrelationEditorLinks,
           defaultCorrelationEditorDatasource
         )
+       }
       )
     );
 

--- a/public/app/features/explore/state/query.ts
+++ b/public/app/features/explore/state/query.ts
@@ -53,7 +53,7 @@ import { ExploreState, QueryOptions, SupplementaryQueries } from 'app/types/expl
 import { notifyApp } from '../../../core/actions';
 import { createErrorNotification } from '../../../core/copy/appNotification';
 import { runRequest } from '../../query/state/runRequest';
-import { decorateData, decorateLoadMoreData } from '../utils/decorators';
+import { decorateData, decorateLoadMoreData, mergeDataSeries } from '../utils/decorators';
 import {
   getSupplementaryQueryProvider,
   storeSupplementaryQueryEnabled,
@@ -779,17 +779,16 @@ export const runLoadMoreQueries = createAsyncThunk<void, RunLoadMoreQueriesOptio
       correlations$,
     ]).pipe(
       mergeMap(([data, correlations]) =>
-       {
-        return  decorateLoadMoreData(
-          data,
+        decorateData(
+          mergeDataSeries(queryResponse, data),
           queryResponse,
           absoluteRange,
+          undefined,
           queries,
           correlations,
           showCorrelationEditorLinks,
           defaultCorrelationEditorDatasource
         )
-       }
       )
     );
 

--- a/public/app/features/explore/state/query.ts
+++ b/public/app/features/explore/state/query.ts
@@ -725,7 +725,6 @@ export const runLoadMoreQueries = createAsyncThunk<void, RunLoadMoreQueriesOptio
     const interpolateCorrelationHelperVars =
       isCorrelationEditorMode && !isLeftPane && correlationEditorHelperData !== undefined;
     let newQuerySource: Observable<ExplorePanelData>;
-    let newQuerySubscription: SubscriptionLike;
 
     // Filter queries by those explicitly requested by refId
     const queries = exploreQueries.map((query) => ({
@@ -787,7 +786,7 @@ export const runLoadMoreQueries = createAsyncThunk<void, RunLoadMoreQueriesOptio
       )
     );
 
-    newQuerySubscription = newQuerySource.subscribe({
+    newQuerySource.subscribe({
       next(data) {
         if (data.logsResult !== null && data.state === LoadingState.Done) {
           reportInteraction('grafana_explore_logs_result_displayed', {

--- a/public/app/features/explore/state/query.ts
+++ b/public/app/features/explore/state/query.ts
@@ -51,7 +51,7 @@ import { ExploreState, QueryOptions, SupplementaryQueries } from 'app/types/expl
 import { notifyApp } from '../../../core/actions';
 import { createErrorNotification } from '../../../core/copy/appNotification';
 import { runRequest } from '../../query/state/runRequest';
-import { decorateData } from '../utils/decorators';
+import { decorateData, decorateLoadMoreData } from '../utils/decorators';
 import {
   getSupplementaryQueryProvider,
   storeSupplementaryQueryEnabled,
@@ -693,6 +693,114 @@ export const runQueries = createAsyncThunk<void, RunQueriesOptions>(
     }
 
     dispatch(queryStoreSubscriptionAction({ exploreId, querySubscription: newQuerySubscription }));
+  }
+);
+
+interface RunLoadMoreQueriesOptions {
+  exploreId: string;
+  refIds: string[];
+  absoluteRange: AbsoluteTimeRange;
+}
+/**
+ * Supplementary action to run queries that request more results, and dispatches sub-actions based 
+ * on which result viewers are active
+ */
+export const runLoadMoreQueries = createAsyncThunk<void, RunLoadMoreQueriesOptions>(
+  'explore/runQueries',
+  async ({ exploreId, absoluteRange, refIds }, { dispatch, getState }) => {
+    const correlations$ = getCorrelations(exploreId);
+    const {
+      datasourceInstance,
+      containerWidth,
+      range,
+      queryResponse,
+      correlationEditorHelperData,
+      queries: exploreQueries,
+    } = getState().explore.panes[exploreId]!;
+
+    const isCorrelationEditorMode = getState().explore.correlationEditorDetails?.editorMode || false;
+    const isLeftPane = Object.keys(getState().explore.panes)[0] === exploreId;
+    const showCorrelationEditorLinks = isCorrelationEditorMode && isLeftPane;
+    const defaultCorrelationEditorDatasource = showCorrelationEditorLinks ? await getDataSourceSrv().get() : undefined;
+    const interpolateCorrelationHelperVars =
+      isCorrelationEditorMode && !isLeftPane && correlationEditorHelperData !== undefined;
+    let newQuerySource: Observable<ExplorePanelData>;
+    let newQuerySubscription: SubscriptionLike;
+
+    // Filter queries by those explicitly requested by refId
+    const queries = exploreQueries.map((query) => ({
+      ...query,
+      datasource: query.datasource || datasourceInstance?.getRef(),
+    })).filter((query) => refIds.includes(query.refId));
+
+    if (!hasNonEmptyQuery(queries) || !datasourceInstance) {
+      return;
+    }
+
+    // Some datasource's query builders allow per-query interval limits,
+    // but we're using the datasource interval limit for now
+    const minInterval = datasourceInstance?.interval;
+
+    const queryOptions: QueryOptions = {
+      minInterval,
+      // maxDataPoints is used in:
+      // Loki - used for logs streaming for buffer size, with undefined it falls back to datasource config if it supports that.
+      // Elastic - limits the number of datapoints for the counts query and for logs it has hardcoded limit.
+      // Influx - used to correctly display logs in graph
+      // TODO:unification
+      // maxDataPoints: mode === ExploreMode.Logs && datasourceId === 'loki' ? undefined : containerWidth,
+      maxDataPoints: containerWidth,
+    };
+
+    let scopedVars: ScopedVars = {};
+    if (interpolateCorrelationHelperVars && correlationEditorHelperData !== undefined) {
+      Object.entries(correlationEditorHelperData?.vars).forEach((variable) => {
+        scopedVars[variable[0]] = { value: variable[1] };
+      });
+    }
+
+    const timeZone = getTimeZone(getState().user);
+    const transaction = buildQueryTransaction(
+      exploreId,
+      queries,
+      queryOptions,
+      range,
+      false,
+      timeZone,
+      scopedVars
+    );
+
+    newQuerySource = combineLatest([
+      runRequest(datasourceInstance, transaction.request),
+      correlations$,
+    ]).pipe(
+      mergeMap(([data, correlations]) =>
+        decorateLoadMoreData(
+          data,
+          queryResponse,
+          absoluteRange,
+          queries,
+          correlations,
+          showCorrelationEditorLinks,
+          defaultCorrelationEditorDatasource
+        )
+      )
+    );
+
+    newQuerySubscription = newQuerySource.subscribe({
+      next(data) {
+        if (data.logsResult !== null && data.state === LoadingState.Done) {
+          reportInteraction('grafana_explore_logs_result_displayed', {
+            datasourceType: datasourceInstance.type,
+          });
+        }
+        dispatch(queryStreamUpdatedAction({ exploreId, response: data }));
+      },
+      error(error) {
+        dispatch(notifyApp(createErrorNotification('Query processing error', error)));
+        console.error(error);
+      },
+    });
   }
 );
 

--- a/public/app/features/explore/state/time.ts
+++ b/public/app/features/explore/state/time.ts
@@ -11,7 +11,7 @@ import { getFiscalYearStartMonth, getTimeZone } from 'app/features/profile/state
 import { ExploreItemState, ThunkDispatch, ThunkResult } from 'app/types';
 
 import { syncTimesAction } from './main';
-import { runQueries } from './query';
+import { runLoadMoreQueries, runQueries } from './query';
 
 //
 // Actions and Payloads
@@ -51,6 +51,16 @@ export const updateTimeRange = (options: {
       dispatch(updateTime({ ...options }));
       dispatch(runQueries({ exploreId: options.exploreId, preserveCache: true }));
     }
+  };
+};
+
+export const loadMore = (options: {
+  exploreId: string;
+  absoluteRange: AbsoluteTimeRange;
+  refIds: string[];
+}): ThunkResult<void> => {
+  return (dispatch) => {
+    dispatch(runLoadMoreQueries({ ...options }));
   };
 };
 

--- a/public/app/features/explore/utils/decorators.ts
+++ b/public/app/features/explore/utils/decorators.ts
@@ -283,22 +283,6 @@ export const decorateWithLogsResult =
     return { ...data, logsResult };
   };
 
-export const decorateWithNewLogsResult = (data: ExplorePanelData, lastData: ExplorePanelData | undefined, absoluteRange: AbsoluteTimeRange, queries?: DataQuery[]): ExplorePanelData => {
-  if (data.logsFrames.length === 0) {
-    return { ...data, logsResult: null };
-  }
-
-  const logsFrames = lastData ? [...lastData.logsFrames, ...data.logsFrames] : data.logsFrames;
-
-  const intervalMs = data.request?.intervalMs;
-  const newResults = dataFrameToLogsModel(logsFrames, intervalMs, absoluteRange, queries);
-  const sortOrder = refreshIntervalToSortOrder();
-  const sortedNewResults = sortLogsResult(newResults, sortOrder);
-  const logsResult = { ...sortedNewResults };
-
-  return { ...(lastData || data), logsResult };
-};
-
 // decorateData applies all decorators
 export function decorateData(
   data: PanelData,

--- a/public/app/features/explore/utils/decorators.ts
+++ b/public/app/features/explore/utils/decorators.ts
@@ -16,6 +16,7 @@ import {
 } from '@grafana/data';
 import { config } from '@grafana/runtime';
 import { DataQuery } from '@grafana/schema';
+import { combineResponses } from 'app/plugins/datasource/loki/responseUtils';
 
 import { refreshIntervalToSortOrder } from '../../../core/utils/explore';
 import { ExplorePanelData } from '../../../types';
@@ -24,7 +25,6 @@ import { attachCorrelationsToDataFrames } from '../../correlations/utils';
 import { dataFrameToLogsModel } from '../../logs/logsModel';
 import { sortLogsResult } from '../../logs/utils';
 import { hasPanelPlugin } from '../../plugins/importPanelPlugin';
-import { combineResponses } from 'app/plugins/datasource/loki/responseUtils';
 
 /**
  * When processing response first we try to determine what kind of dataframes we got as one query can return multiple

--- a/public/app/features/explore/utils/decorators.ts
+++ b/public/app/features/explore/utils/decorators.ts
@@ -329,7 +329,7 @@ export function decorateData(
 
 export function decorateLoadMoreData(
   data: PanelData,
-  lastData: PanelData,
+  lastExploreData: ExplorePanelData,
   absoluteRange: AbsoluteTimeRange,
   queries: DataQuery[] | undefined,
   correlations: CorrelationData[] | undefined,
@@ -347,7 +347,7 @@ export function decorateLoadMoreData(
       })
     ),
     map(decorateWithFrameTypeMetadata),
-    map((data: ExplorePanelData) => decorateWithNewLogsResult(data, decorateWithFrameTypeMetadata(preProcessPanelData(lastData)), absoluteRange, queries)),
+    map((data: ExplorePanelData) => decorateWithNewLogsResult(data, lastExploreData, absoluteRange, queries)),
   );
 }
 

--- a/public/app/features/logs/components/LogRow.tsx
+++ b/public/app/features/logs/components/LogRow.tsx
@@ -1,5 +1,6 @@
 import { cx } from '@emotion/css';
 import { debounce } from 'lodash';
+import memoizeOne from 'memoize-one';
 import React, { PureComponent } from 'react';
 
 import { Field, LinkModel, LogRowModel, LogsSortOrder, dateTimeFormat, CoreApp, DataFrame } from '@grafana/data';
@@ -157,6 +158,12 @@ class UnThemedLogRow extends PureComponent<Props, State> {
     }
   };
 
+  processRow = memoizeOne((row: LogRowModel, forceEscape: boolean | undefined) => {
+    return row.hasUnescapedContent && forceEscape
+      ? { ...row, entry: escapeUnescapedString(row.entry), raw: escapeUnescapedString(row.raw) }
+      : row
+  });
+
   render() {
     const {
       getRows,
@@ -191,10 +198,7 @@ class UnThemedLogRow extends PureComponent<Props, State> {
       [styles.highlightBackground]: permalinked && !this.state.showDetails,
     });
 
-    const processedRow =
-      row.hasUnescapedContent && forceEscape
-        ? { ...row, entry: escapeUnescapedString(row.entry), raw: escapeUnescapedString(row.raw) }
-        : row;
+    const processedRow = this.processRow(row, forceEscape);
 
     return (
       <>

--- a/public/app/features/logs/utils.test.ts
+++ b/public/app/features/logs/utils.test.ts
@@ -14,6 +14,7 @@ import {
   calculateLogsLabelStats,
   calculateStats,
   checkLogsError,
+  escapeUnescapedString,
   getLogLevel,
   getLogLevelFromKey,
   getLogsVolumeMaximumRange,
@@ -467,5 +468,14 @@ describe('getLogsVolumeDimensions', () => {
     ]);
 
     expect(maximumRange).toEqual({ from: 5, to: 25 });
+  });
+});
+
+describe('escapeUnescapedString', () => {
+  it('does not modify strings without unescaped characters', () => {
+    expect(escapeUnescapedString('a simple string')).toBe('a simple string');
+  });
+  it('escapes unescaped strings', () => {
+    expect(escapeUnescapedString(`\\r\\n|\\n|\\t|\\r`)).toBe(`\n|\n|\t|\n`);
   });
 });


### PR DESCRIPTION
A user complained that, when dealing with JSON log lines that had escaped content, toggling "Escape newlines" and "Remove escaping" was freezing the browser.

After investigating and replicating the issue, I found that we were creating a new object on every render, as: 

```
const processedRow =
      row.hasUnescapedContent && forceEscape
        ? { ...row, entry: escapeUnescapedString(row.entry), raw: escapeUnescapedString(row.raw) }
        : row;
``` 

With `forceEscape` enabled, on every render we will get a new `processedRow` object, causing unnecessary re-renders and other strict-equality related issues.

If this was a functional component, I would have wrapped `processedRow` with `useMemo`,  but since this is a class component I added a method with `memoizeOne`. [Read more](https://legacy.reactjs.org/blog/2018/06/07/you-probably-dont-need-derived-state.html#what-about-memoization).

This fixed the issue and allowed to toggle the option on and off with no crashes.

**Which issue(s) does this PR fix?**:

Escalation 8216

**Special notes for your reviewer:**

Demo:

https://github.com/grafana/grafana/assets/1069378/9216a202-5bf5-4264-9061-d47328af19b0

