### PR TITLE
Log Row: memoize row processing

### DIFF
--- a/public/app/features/logs/components/LogRow.tsx
+++ b/public/app/features/logs/components/LogRow.tsx
@@ -1,5 +1,6 @@
 import { cx } from '@emotion/css';
 import { debounce } from 'lodash';
+import memoizeOne from 'memoize-one';
 import React, { PureComponent } from 'react';
 
 import { Field, LinkModel, LogRowModel, LogsSortOrder, dateTimeFormat, CoreApp, DataFrame } from '@grafana/data';
@@ -157,6 +158,12 @@ class UnThemedLogRow extends PureComponent<Props, State> {
     }
   };
 
+  processRow = memoizeOne((row: LogRowModel, forceEscape: boolean | undefined) => {
+    return row.hasUnescapedContent && forceEscape
+      ? { ...row, entry: escapeUnescapedString(row.entry), raw: escapeUnescapedString(row.raw) }
+      : row
+  });
+
   render() {
     const {
       getRows,
@@ -191,10 +198,7 @@ class UnThemedLogRow extends PureComponent<Props, State> {
       [styles.highlightBackground]: permalinked && !this.state.showDetails,
     });
 
-    const processedRow =
-      row.hasUnescapedContent && forceEscape
-        ? { ...row, entry: escapeUnescapedString(row.entry), raw: escapeUnescapedString(row.raw) }
-        : row;
+    const processedRow = this.processRow(row, forceEscape);
 
     return (
       <>

--- a/public/app/features/logs/components/LogRow.tsx
+++ b/public/app/features/logs/components/LogRow.tsx
@@ -158,7 +158,7 @@ class UnThemedLogRow extends PureComponent<Props, State> {
     }
   };
 
-  processRow = memoizeOne((row: LogRowModel, forceEscape: boolean | undefined) => {
+  escapeRow = memoizeOne((row: LogRowModel, forceEscape: boolean | undefined) => {
     return row.hasUnescapedContent && forceEscape
       ? { ...row, entry: escapeUnescapedString(row.entry), raw: escapeUnescapedString(row.raw) }
       : row
@@ -198,7 +198,7 @@ class UnThemedLogRow extends PureComponent<Props, State> {
       [styles.highlightBackground]: permalinked && !this.state.showDetails,
     });
 
-    const processedRow = this.processRow(row, forceEscape);
+    const processedRow = this.escapeRow(row, forceEscape);
 
     return (
       <>

--- a/public/app/features/logs/components/LogRow.tsx
+++ b/public/app/features/logs/components/LogRow.tsx
@@ -161,7 +161,7 @@ class UnThemedLogRow extends PureComponent<Props, State> {
   escapeRow = memoizeOne((row: LogRowModel, forceEscape: boolean | undefined) => {
     return row.hasUnescapedContent && forceEscape
       ? { ...row, entry: escapeUnescapedString(row.entry), raw: escapeUnescapedString(row.raw) }
-      : row
+      : row;
   });
 
   render() {

--- a/public/app/features/logs/utils.test.ts
+++ b/public/app/features/logs/utils.test.ts
@@ -14,6 +14,7 @@ import {
   calculateLogsLabelStats,
   calculateStats,
   checkLogsError,
+  escapeUnescapedString,
   getLogLevel,
   getLogLevelFromKey,
   getLogsVolumeMaximumRange,
@@ -467,5 +468,14 @@ describe('getLogsVolumeDimensions', () => {
     ]);
 
     expect(maximumRange).toEqual({ from: 5, to: 25 });
+  });
+});
+
+describe('escapeUnescapedString', () => {
+  it('does not modify strings without unescaped characters', () => {
+    expect(escapeUnescapedString('a simple string')).toBe('a simple string');
+  });
+  it('escapes unescaped strings', () => {
+    expect(escapeUnescapedString(`\\r\\n|\\n|\\t|\\r`)).toBe(`\n|\n|\t|\n`);
   });
 });


### PR DESCRIPTION
A user complained that, when dealing with JSON log lines that had escaped content, toggling "Escape newlines" and "Remove escaping" was freezing the browser.

After investigating and replicating the issue, I found that we were creating a new object on every render, as: 

```
const processedRow =
      row.hasUnescapedContent && forceEscape
        ? { ...row, entry: escapeUnescapedString(row.entry), raw: escapeUnescapedString(row.raw) }
        : row;
``` 

With `forceEscape` enabled, on every render we will get a new `processedRow` object, causing unnecessary re-renders and other strict-equality related issues.

If this was a functional component, I would have wrapped `processedRow` with `useMemo`,  but since this is a class component I added a method with `memoizeOne`. [Read more](https://legacy.reactjs.org/blog/2018/06/07/you-probably-dont-need-derived-state.html#what-about-memoization).

This fixed the issue and allowed to toggle the option on and off with no crashes.

**Which issue(s) does this PR fix?**:

Escalation 8216

**Special notes for your reviewer:**

Demo:

https://github.com/grafana/grafana/assets/1069378/9216a202-5bf5-4264-9061-d47328af19b0

