### PR TITLE
Teams: Search by team ids

### DIFF
--- a/pkg/services/team/model.go
+++ b/pkg/services/team/model.go
@@ -92,6 +92,7 @@ type SearchTeamsQuery struct {
 	Page         int
 	OrgID        int64 `xorm:"org_id"`
 	SortOpts     []model.SortOption
+	TeamIds      []int64
 	SignedInUser identity.Requester
 	HiddenUsers  map[string]struct{}
 }

--- a/pkg/services/team/teamapi/team.go
+++ b/pkg/services/team/teamapi/team.go
@@ -154,10 +154,20 @@ func (tapi *TeamAPI) searchTeams(c *contextmodel.ReqContext) response.Response {
 		return response.Err(err)
 	}
 
+	stringTeamIDs := c.QueryStrings("teamId")
+	queryTeamIDs := make([]int64, 0)
+	for _, id := range stringTeamIDs {
+		teamID, err := strconv.ParseInt(id, 10, 64)
+		if err == nil {
+			queryTeamIDs = append(queryTeamIDs, teamID)
+		}
+	}
+
 	query := team.SearchTeamsQuery{
 		OrgID:        c.SignedInUser.GetOrgID(),
 		Query:        c.Query("query"),
 		Name:         c.Query("name"),
+		TeamIds:      queryTeamIDs,
 		Page:         page,
 		Limit:        perPage,
 		SignedInUser: c.SignedInUser,

--- a/pkg/services/team/teamimpl/store.go
+++ b/pkg/services/team/teamimpl/store.go
@@ -212,6 +212,13 @@ func (ss *xormStore) Search(ctx context.Context, query *team.SearchTeamsQuery) (
 			params = append(params, query.Name)
 		}
 
+		if len(query.TeamIds) > 0 {
+			sql.WriteString(` and team.id IN (?` + strings.Repeat(",?", len(query.TeamIds)-1) + ")")
+			for _, id := range query.TeamIds {
+				params = append(params, id)
+			}
+		}
+
 		acFilter, err := ac.Filter(query.SignedInUser, "team.id", "teams:id:", ac.ActionTeamsRead)
 		if err != nil {
 			return err

--- a/pkg/services/team/teamimpl/store_test.go
+++ b/pkg/services/team/teamimpl/store_test.go
@@ -268,6 +268,26 @@ func TestIntegrationTeamCommandsAndQueries(t *testing.T) {
 				require.Equal(t, queryResult.Teams[1].Name, team1.Name)
 			})
 
+			t.Run("Should be able to query teams by ids", func(t *testing.T) {
+				allTeamsQuery := &team.SearchTeamsQuery{OrgID: testOrgID, Query: "", SignedInUser: testUser}
+				allTeamsQueryResult, err := teamSvc.SearchTeams(context.Background(), allTeamsQuery)
+				require.NoError(t, err)
+				require.Equal(t, len(allTeamsQueryResult.Teams), 2)
+
+				teamIds := make([]int64, 0)
+				for _, team := range allTeamsQueryResult.Teams {
+					teamIds = append(teamIds, team.ID)
+				}
+
+				query := &team.SearchTeamsQuery{OrgID: testOrgID, SignedInUser: testUser, TeamIds: teamIds}
+				queryResult, err := teamSvc.SearchTeams(context.Background(), query)
+				require.NoError(t, err)
+				require.Equal(t, len(queryResult.Teams), 2)
+				require.EqualValues(t, queryResult.TotalCount, 2)
+				require.Equal(t, queryResult.Teams[0].Name, team2.Name)
+				require.Equal(t, queryResult.Teams[1].Name, team1.Name)
+			})
+
 			t.Run("Should be able to return all teams a user is member of", func(t *testing.T) {
 				sqlStore = db.InitTestDB(t)
 				setup()

--- a/pkg/services/team/teamimpl/store_test.go
+++ b/pkg/services/team/teamimpl/store_test.go
@@ -284,8 +284,8 @@ func TestIntegrationTeamCommandsAndQueries(t *testing.T) {
 				require.NoError(t, err)
 				require.Equal(t, len(queryResult.Teams), 2)
 				require.EqualValues(t, queryResult.TotalCount, 2)
-				require.Equal(t, queryResult.Teams[0].Name, team2.Name)
-				require.Equal(t, queryResult.Teams[1].Name, team1.Name)
+				require.Equal(t, queryResult.Teams[0].ID, teamIds[0])
+				require.Equal(t, queryResult.Teams[1].ID, teamIds[1])
 			})
 
 			t.Run("Should be able to return all teams a user is member of", func(t *testing.T) {


### PR DESCRIPTION
**What is this feature?**

Add `TeamIds` parameter to teams search.

**Why do we need this feature?**

This is required for fetching a list of the teams by ids in one request in the Team LBAC component.

**Who is this feature for?**

[Add information on what kind of user the feature is for.]

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
