### PR TITLE
PanelInspector: Always use the latest panel data

### DIFF
--- a/public/app/features/dashboard/components/Inspector/PanelInspector.tsx
+++ b/public/app/features/dashboard/components/Inspector/PanelInspector.tsx
@@ -35,7 +35,7 @@ const PanelInspectorUnconnected = ({ panel, dashboard, plugin }: Props) => {
     withFieldConfig: true,
   });
 
-  const { data, isLoading, hasError } = usePanelLatestData(panel, dataOptions, true);
+  const { data, isLoading, hasError } = usePanelLatestData(panel, dataOptions, false);
   const metaDs = useDatasourceMetadata(data);
   const tabs = useInspectTabs(panel, dashboard, plugin, hasError, metaDs);
 


### PR DESCRIPTION
Fixes https://github.com/grafana/support-escalations/issues/8185

With #73344 panel inspector did not use the latest panel data anymore, but used a 10s buffer for throttling updates if the data structure hasn't changed. This made the query inspector get stuck on Loading stat for cases where we are just re-querying the same data. 

@ryantxu - I'm not sure if this change was intentional or not? Overall, for inspect and the query inspector in particular it seems to me like it makes sense to skip any optimizations like this.
@gtk-grafana  - thanks for bisecting this!