### PR TITLE
[v10.2.x] Prometheus: set httpMethod as POST for new query client when not defined

### DIFF
--- a/pkg/tsdb/prometheus/querydata/request.go
+++ b/pkg/tsdb/prometheus/querydata/request.go
@@ -64,6 +64,10 @@ func New(
 		return nil, err
 	}
 
+	if httpMethod == "" {
+		httpMethod = http.MethodPost
+	}
+
 	promClient := client.NewClient(httpClient, httpMethod, settings.URL)
 
 	// standard deviation sampler is the default for backwards compatibility
@@ -97,6 +101,7 @@ func (s *QueryData) Execute(ctx context.Context, req *backend.QueryDataRequest) 
 		if err != nil {
 			return &result, err
 		}
+
 		r := s.fetch(ctx, s.client, query, req.Headers)
 		if r == nil {
 			s.log.FromContext(ctx).Debug("Received nil response from runQuery", "query", query.Expr)


### PR DESCRIPTION
Manual backport for bug fix for https://github.com/grafana/support-escalations/issues/8170
and https://github.com/grafana/support-escalations/issues/7630

(cherry picked from commit c3b333b762251b3f9251d16846f533682e8f35e6)

Please check that:
- [X] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
