### PR TITLE
Grafana/ui: Unify flex shorthand props

### DIFF
--- a/packages/grafana-ui/src/components/Layout/Box/Box.tsx
+++ b/packages/grafana-ui/src/components/Layout/Box/Box.tsx
@@ -4,7 +4,7 @@ import React, { ElementType, forwardRef, PropsWithChildren } from 'react';
 import { GrafanaTheme2, ThemeSpacingTokens, ThemeShape, ThemeShadows } from '@grafana/data';
 
 import { useStyles2 } from '../../../themes';
-import { AlignItems, JustifyContent } from '../Stack/Stack';
+import { AlignItems, FlexProps, JustifyContent } from '../types';
 import { ResponsiveProp, getResponsiveStyle } from '../utils/responsiveness';
 
 type Display = 'flex' | 'block' | 'inline' | 'none';
@@ -14,7 +14,7 @@ export type BorderColor = keyof GrafanaTheme2['colors']['border'] | 'error' | 's
 export type BorderRadius = keyof ThemeShape['radius'];
 export type BoxShadow = keyof ThemeShadows;
 
-interface BoxProps extends Omit<React.HTMLAttributes<HTMLElement>, 'className' | 'style'> {
+interface BoxProps extends FlexProps, Omit<React.HTMLAttributes<HTMLElement>, 'className' | 'style'> {
   // Margin props
   /** Sets the property `margin` */
   margin?: ResponsiveProp<ThemeSpacingTokens>;
@@ -53,10 +53,6 @@ interface BoxProps extends Omit<React.HTMLAttributes<HTMLElement>, 'className' |
   borderRadius?: ResponsiveProp<BorderRadius>;
 
   // Flex Props
-  /** Sets the property `flex` */
-  grow?: ResponsiveProp<number>;
-  /** Sets the property `flex-shrink` */
-  shrink?: ResponsiveProp<number>;
   alignItems?: ResponsiveProp<AlignItems>;
   justifyContent?: ResponsiveProp<JustifyContent>;
   gap?: ResponsiveProp<ThemeSpacingTokens>;
@@ -90,6 +86,8 @@ export const Box = forwardRef<HTMLElement, PropsWithChildren<BoxProps>>((props, 
     backgroundColor,
     grow,
     shrink,
+    basis,
+    flex,
     borderColor,
     borderStyle,
     borderRadius,
@@ -120,6 +118,8 @@ export const Box = forwardRef<HTMLElement, PropsWithChildren<BoxProps>>((props, 
     backgroundColor,
     grow,
     shrink,
+    basis,
+    flex,
     borderColor,
     borderStyle,
     borderRadius,
@@ -183,6 +183,8 @@ const getStyles = (
   backgroundColor: BoxProps['backgroundColor'],
   grow: BoxProps['grow'],
   shrink: BoxProps['shrink'],
+  basis: BoxProps['basis'],
+  flex: BoxProps['flex'],
   borderColor: BoxProps['borderColor'],
   borderStyle: BoxProps['borderStyle'],
   borderRadius: BoxProps['borderRadius'],
@@ -246,10 +248,16 @@ const getStyles = (
         backgroundColor: customBackgroundColor(val, theme),
       })),
       getResponsiveStyle(theme, grow, (val) => ({
-        flex: val,
+        flexGrow: val,
       })),
       getResponsiveStyle(theme, shrink, (val) => ({
         flexShrink: val,
+      })),
+      getResponsiveStyle(theme, basis, (val) => ({
+        flexBasis: val,
+      })),
+      getResponsiveStyle(theme, flex, (val) => ({
+        flex: val,
       })),
       getResponsiveStyle(theme, borderStyle, (val) => ({
         borderStyle: val,

--- a/packages/grafana-ui/src/components/Layout/Stack/Stack.story.tsx
+++ b/packages/grafana-ui/src/components/Layout/Stack/Stack.story.tsx
@@ -5,8 +5,9 @@ import { ThemeSpacingTokens } from '@grafana/data';
 
 import { useTheme2 } from '../../../themes';
 import { SpacingTokenControl } from '../../../utils/storybook/themeStorybookControls';
+import { JustifyContent, Wrap, Direction } from '../types';
 
-import { Stack, JustifyContent, Wrap, Direction } from './Stack';
+import { Stack } from './Stack';
 import mdx from './Stack.mdx';
 
 const Item = ({ color, text, height }: { color: string; text?: string | number; height?: string }) => {

--- a/packages/grafana-ui/src/components/Layout/Stack/Stack.tsx
+++ b/packages/grafana-ui/src/components/Layout/Stack/Stack.tsx
@@ -1,59 +1,31 @@
 import { css } from '@emotion/css';
-import React, { CSSProperties } from 'react';
+import React from 'react';
 
 import { GrafanaTheme2, ThemeSpacingTokens } from '@grafana/data';
 
 import { useStyles2 } from '../../../themes';
+import { AlignItems, Direction, FlexProps, JustifyContent, Wrap } from '../types';
 import { ResponsiveProp, getResponsiveStyle } from '../utils/responsiveness';
 
-export type AlignItems =
-  | 'stretch'
-  | 'flex-start'
-  | 'flex-end'
-  | 'center'
-  | 'baseline'
-  | 'start'
-  | 'end'
-  | 'self-start'
-  | 'self-end';
-
-export type JustifyContent =
-  | 'flex-start'
-  | 'flex-end'
-  | 'center'
-  | 'space-between'
-  | 'space-around'
-  | 'space-evenly'
-  | 'start'
-  | 'end'
-  | 'left'
-  | 'right';
-
-export type Direction = 'row' | 'row-reverse' | 'column' | 'column-reverse';
-
-export type Wrap = 'nowrap' | 'wrap' | 'wrap-reverse';
-
-interface StackProps extends Omit<React.HTMLAttributes<HTMLElement>, 'className' | 'style'> {
+interface StackProps extends FlexProps, Omit<React.HTMLAttributes<HTMLElement>, 'className' | 'style'> {
   gap?: ResponsiveProp<ThemeSpacingTokens>;
   alignItems?: ResponsiveProp<AlignItems>;
   justifyContent?: ResponsiveProp<JustifyContent>;
   direction?: ResponsiveProp<Direction>;
   wrap?: ResponsiveProp<Wrap>;
   children?: React.ReactNode;
-  flexGrow?: ResponsiveProp<CSSProperties['flexGrow']>;
 }
 
-export const Stack = React.forwardRef<HTMLDivElement, StackProps>(
-  ({ gap = 1, alignItems, justifyContent, direction, wrap, children, flexGrow, ...rest }, ref) => {
-    const styles = useStyles2(getStyles, gap, alignItems, justifyContent, direction, wrap, flexGrow);
+export const Stack = React.forwardRef<HTMLDivElement, StackProps>((props, ref) => {
+  const { gap = 1, alignItems, justifyContent, direction, wrap, children, grow, shrink, basis, flex, ...rest } = props;
+  const styles = useStyles2(getStyles, gap, alignItems, justifyContent, direction, wrap, grow, shrink, basis, flex);
 
-    return (
-      <div ref={ref} className={styles.flex} {...rest}>
-        {children}
-      </div>
-    );
-  }
-);
+  return (
+    <div ref={ref} className={styles.flex} {...rest}>
+      {children}
+    </div>
+  );
+});
 
 Stack.displayName = 'Stack';
 
@@ -64,7 +36,10 @@ const getStyles = (
   justifyContent: StackProps['justifyContent'],
   direction: StackProps['direction'],
   wrap: StackProps['wrap'],
-  flexGrow: StackProps['flexGrow']
+  grow: StackProps['grow'],
+  shrink: StackProps['shrink'],
+  basis: StackProps['basis'],
+  flex: StackProps['flex']
 ) => {
   return {
     flex: css([
@@ -86,8 +61,17 @@ const getStyles = (
       getResponsiveStyle(theme, gap, (val) => ({
         gap: theme.spacing(val),
       })),
-      getResponsiveStyle(theme, flexGrow, (val) => ({
+      getResponsiveStyle(theme, grow, (val) => ({
         flexGrow: val,
+      })),
+      getResponsiveStyle(theme, shrink, (val) => ({
+        flexShrink: val,
+      })),
+      getResponsiveStyle(theme, basis, (val) => ({
+        flexBasis: val,
+      })),
+      getResponsiveStyle(theme, flex, (val) => ({
+        flex: val,
       })),
     ]),
   };

--- a/packages/grafana-ui/src/components/Layout/types.ts
+++ b/packages/grafana-ui/src/components/Layout/types.ts
@@ -1,0 +1,51 @@
+import { ResponsiveProp } from './utils/responsiveness';
+
+export type AlignItems =
+  | 'stretch'
+  | 'flex-start'
+  | 'flex-end'
+  | 'center'
+  | 'baseline'
+  | 'start'
+  | 'end'
+  | 'self-start'
+  | 'self-end';
+
+export type JustifyContent =
+  | 'flex-start'
+  | 'flex-end'
+  | 'center'
+  | 'space-between'
+  | 'space-around'
+  | 'space-evenly'
+  | 'start'
+  | 'end'
+  | 'left'
+  | 'right';
+
+export type Direction = 'row' | 'row-reverse' | 'column' | 'column-reverse';
+export type Wrap = 'nowrap' | 'wrap' | 'wrap-reverse';
+
+type FlexGrow = number;
+type FlexShrink = number;
+type FlexBasis = 'auto' | 'initial' | '0' | `${number}%` | `${number}px`;
+
+// Support the following formats for the "flex" shorthand property:
+// - 1
+// - '1'
+// - '1 1'
+// - '1 1 0'
+// - '1 1 0px'
+// - '1 1 auto'
+type Flex = FlexGrow | `${FlexGrow}` | `${FlexGrow} ${FlexShrink}` | `${FlexGrow} ${FlexShrink} ${FlexBasis}`;
+
+export type FlexProps = {
+  /** Sets the property `flex-grow` */
+  grow?: ResponsiveProp<FlexGrow>;
+  /** Sets the property `flex-shrink` */
+  shrink?: ResponsiveProp<FlexShrink>;
+  /** Sets the property `flex-basis` */
+  basis?: ResponsiveProp<FlexBasis>;
+  /** Sets the property `flex` */
+  flex?: Flex;
+};

--- a/packages/grafana-ui/src/components/Layout/types.ts
+++ b/packages/grafana-ui/src/components/Layout/types.ts
@@ -47,5 +47,5 @@ export type FlexProps = {
   /** Sets the property `flex-basis` */
   basis?: ResponsiveProp<FlexBasis>;
   /** Sets the property `flex` */
-  flex?: Flex;
+  flex?: ResponsiveProp<Flex>;
 };

--- a/public/app/features/dashboard/dashgrid/DashboardEmpty.tsx
+++ b/public/app/features/dashboard/dashgrid/DashboardEmpty.tsx
@@ -59,7 +59,7 @@ const DashboardEmpty = ({ dashboard, canCreate }: Props) => {
           </Box>
           <Stack direction={{ xs: 'column', md: 'row' }} wrap="wrap" gap={4}>
             {config.featureToggles.vizAndWidgetSplit && (
-              <Box borderColor="strong" borderStyle="dashed" padding={3} grow={1}>
+              <Box borderColor="strong" borderStyle="dashed" padding={3} flex={1}>
                 <Stack direction="column" alignItems="center" gap={1}>
                   <Text element="h3" textAlignment="center" weight="medium">
                     <Trans i18nKey="dashboard.empty.add-widget-header">Add a widget</Trans>
@@ -84,7 +84,7 @@ const DashboardEmpty = ({ dashboard, canCreate }: Props) => {
                 </Stack>
               </Box>
             )}
-            <Box borderColor="strong" borderStyle="dashed" padding={3} grow={1}>
+            <Box borderColor="strong" borderStyle="dashed" padding={3} flex={1}>
               <Stack direction="column" alignItems="center" gap={1}>
                 <Text element="h3" textAlignment="center" weight="medium">
                   <Trans i18nKey="dashboard.empty.add-library-panel-header">Import panel</Trans>
@@ -110,7 +110,7 @@ const DashboardEmpty = ({ dashboard, canCreate }: Props) => {
                 </Button>
               </Stack>
             </Box>
-            <Box borderColor="strong" borderStyle="dashed" padding={3} grow={1}>
+            <Box borderColor="strong" borderStyle="dashed" padding={3} flex={1}>
               <Stack direction="column" alignItems="center" gap={1}>
                 <Text element="h3" textAlignment="center" weight="medium">
                   <Trans i18nKey="dashboard.empty.import-a-dashboard-header">Import a dashboard</Trans>


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

Currently, the API between the `Stack` and `Box` components is inconsistent: `Stack` supports a `flexGrow` prop, while `Box` has a `grow` prop, which is then used to set the value of the `flex` shorthand property. Beyond this inconsistency, assigning only the `grow` value as the complete value of `flex` sets the `shrink` and `basis` implicitly. While this approach works fine in most cases, it creates some edge cases that are not immediately obvious. For instance, by setting `flex: 1` on the element, `flex-basis` is set to `0`, and this value will overwrite any `width` value on the component should we add those in the future (`flex-basis`, unless set to `auto`, has precedence over `width`).  For this reason, it is better to be explicit when setting flex values.


**What is this feature?**

- Unify the flex shorthand props across Box and Stack components. 
- Enable passing individual flex props (grow, shrink and basis) as well as the shorthand `flex` prop. 
- Move common types to a separate file.
- Make the Stack story not to be internal-only.

**Why do we need this feature?**

Consistent API across the layout components. 

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Part of #https://github.com/grafana/grafana/issues/76516

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
