### PR TITLE
[v9.4.x] fix(alerting): fallback to dashboard to get the full targets…

### DIFF
--- a/pkg/services/sqlstore/migrations/ualert/alert_rule_graphite.go
+++ b/pkg/services/sqlstore/migrations/ualert/alert_rule_graphite.go
@@ -66,7 +66,8 @@ func fixGraphiteReferencedSubQueries(l log.Logger, queryData map[string]json.Raw
 	successfulGraphiteMigrationDashboard++
 	l.Debug("graphite query migration: successfully unwrapped query using the dashboard", "query", fullQueryRaw, "rule_id", ruleID)
 	queryData[graphite.TargetModelField] = b
-
+	// Always delete target full, as it might be set and always used as the first option by the query engine.
+	delete(queryData, graphite.TargetFullModelField)
 	return queryData
 }
 


### PR DESCRIPTION
The second part of the manual backport of https://github.com/grafana/grafana/pull/77518

Tested locally.