### PR TITLE
DashList: Update variables in links when they change

### DIFF
--- a/devenv/dev-dashboards/panel-dashlist/dashlist_url_variables.json
+++ b/devenv/dev-dashboards/panel-dashlist/dashlist_url_variables.json
@@ -1,0 +1,139 @@
+{
+  "__inputs": [
+    {
+      "name": "DS_GDEV-TESTDATA",
+      "label": "gdev-testdata",
+      "description": "",
+      "type": "datasource",
+      "pluginId": "grafana-testdata-datasource",
+      "pluginName": "TestData"
+    }
+  ],
+  "__elements": {},
+  "__requires": [
+    {
+      "type": "panel",
+      "id": "dashlist",
+      "name": "Dashboard list",
+      "version": ""
+    },
+    {
+      "type": "grafana",
+      "id": "grafana",
+      "name": "Grafana",
+      "version": "10.3.0-pre"
+    },
+    {
+      "type": "datasource",
+      "id": "grafana-testdata-datasource",
+      "name": "TestData",
+      "version": "1.0.0"
+    }
+  ],
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "grafana",
+          "uid": "-- Grafana --"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 0,
+  "id": null,
+  "links": [],
+  "liveNow": false,
+  "panels": [
+    {
+      "datasource": {
+        "type": "grafana-testdata-datasource",
+        "uid": "${DS_GDEV-TESTDATA}"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 0
+      },
+      "id": 2,
+      "options": {
+        "folderUID": "",
+        "includeVars": true,
+        "keepTime": false,
+        "maxItems": 10,
+        "query": "",
+        "showHeadings": true,
+        "showRecentlyViewed": true,
+        "showSearch": false,
+        "showStarred": false,
+        "tags": []
+      },
+      "pluginVersion": "10.3.0-pre",
+      "title": "Dashboard list panel",
+      "type": "dashlist"
+    }
+  ],
+  "refresh": "",
+  "schemaVersion": 39,
+  "tags": [],
+  "templating": {
+    "list": [
+      {
+        "current": {
+          "selected": true,
+          "text": "a",
+          "value": "a"
+        },
+        "hide": 0,
+        "includeAll": false,
+        "multi": false,
+        "name": "query0",
+        "options": [
+          {
+            "selected": true,
+            "text": "a",
+            "value": "a"
+          },
+          {
+            "selected": false,
+            "text": "b",
+            "value": "b"
+          },
+          {
+            "selected": false,
+            "text": "c",
+            "value": "c"
+          },
+          {
+            "selected": false,
+            "text": "d",
+            "value": "d"
+          }
+        ],
+        "query": "a,b,c,d",
+        "queryValue": "",
+        "skipUrlSync": false,
+        "type": "custom"
+      }
+    ]
+  },
+  "time": {
+    "from": "now-6h",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "",
+  "title": "Panel Tests - DashList variables",
+  "uid": "a6801696-cc53-4196-b1f9-2403e3909185",
+  "version": 1,
+  "weekStart": ""
+}

--- a/devenv/jsonnet/dev-dashboards.libsonnet
+++ b/devenv/jsonnet/dev-dashboards.libsonnet
@@ -149,6 +149,13 @@ local dashboard = grafana.dashboard;
         id: 0,
       }
     },
+    dashboard.new('dashlist_url_variables', import '../dev-dashboards/panel-dashlist/dashlist_url_variables.json') +
+    resource.addMetadata('folder', 'dev-dashboards') +
+    {
+      spec+: {
+        id: 0,
+      }
+    },
     dashboard.new('datadata-macros', import '../dev-dashboards/feature-templating/datadata-macros.json') +
     resource.addMetadata('folder', 'dev-dashboards') +
     {

--- a/e2e/panels-suite/dashlist.spec.ts
+++ b/e2e/panels-suite/dashlist.spec.ts
@@ -6,6 +6,7 @@ describe('DashList panel', () => {
     e2e.flows.login(Cypress.env('USERNAME'), Cypress.env('PASSWORD'));
   });
 
+  // this is to prevent the fix for https://github.com/grafana/grafana/issues/76800 from regressing
   it('should pass current variable values correctly when `Include current template variable values` is set', () => {
     e2e.flows.openDashboard({ uid: PAGE_UNDER_TEST });
 

--- a/e2e/panels-suite/dashlist.spec.ts
+++ b/e2e/panels-suite/dashlist.spec.ts
@@ -1,0 +1,36 @@
+import { e2e } from '../utils';
+const PAGE_UNDER_TEST = 'a6801696-cc53-4196-b1f9-2403e3909185/panel-tests-dashlist-variables';
+
+describe('DashList panel', () => {
+  beforeEach(() => {
+    e2e.flows.login(Cypress.env('USERNAME'), Cypress.env('PASSWORD'));
+  });
+
+  it('should pass current variable values correctly when `Include current template variable values` is set', () => {
+    e2e.flows.openDashboard({ uid: PAGE_UNDER_TEST });
+
+    // check the initial value of the urls contain the variable value correctly
+    e2e.components.Panels.Panel.title('Dashboard list panel')
+      .should('be.visible')
+      .within(() => {
+        cy.get('a').each(($el) => {
+          cy.wrap($el).should('have.attr', 'href').and('contain', 'var-query0=a');
+        });
+      });
+
+    // update variable to b
+    e2e.pages.Dashboard.SubMenu.submenuItemLabels('query0').click();
+    e2e.pages.Dashboard.SubMenu.submenuItemValueDropDownOptionTexts('b').click();
+    // blur the dropdown
+    cy.get('body').click();
+
+    // check the urls are updated with the new variable value
+    e2e.components.Panels.Panel.title('Dashboard list panel')
+      .should('be.visible')
+      .within(() => {
+        cy.get('a').each(($el) => {
+          cy.wrap($el).should('have.attr', 'href').and('contain', 'var-query0=b');
+        });
+      });
+  });
+});

--- a/public/app/plugins/panel/dashlist/DashList.tsx
+++ b/public/app/plugins/panel/dashlist/DashList.tsx
@@ -98,6 +98,10 @@ export function DashList(props: PanelProps<Options>) {
     });
   }, [props.options, props.replaceVariables, props.renderCounter]);
 
+  useEffect(() => {
+    console.log(props);
+  }, [props]);
+
   const toggleDashboardStar = async (e: React.SyntheticEvent, dash: Dashboard) => {
     const { uid, title, url } = dash;
     e.preventDefault();


### PR DESCRIPTION
Dashboard List panel has a feature that passes the variables of the current variables to each of the listed dashboards via the URL. However, the variables would not reliably update because the DashList panel does not contain any explicit references to variables (and grafana will 'smartly' only rerender panels if it uses a changed variable).

This PR adds a subscription to the appEvents event bus to listen for changed variables and gets the new variables. It's not a great solution - it wouldn't work for external plugins - but best we've spotten so far.

Fixes https://github.com/grafana/grafana/issues/76800