### PR TITLE
Nested folders: Write to folders table even if the feature toggle is off

### DIFF
--- a/pkg/services/folder/folderimpl/folder.go
+++ b/pkg/services/folder/folderimpl/folder.go
@@ -8,7 +8,6 @@ import (
 	"sync"
 
 	"github.com/grafana/grafana/pkg/bus"
-	"github.com/grafana/grafana/pkg/cmd/grafana-cli/logger"
 	"github.com/grafana/grafana/pkg/events"
 	"github.com/grafana/grafana/pkg/infra/db"
 	"github.com/grafana/grafana/pkg/infra/log"
@@ -377,6 +376,8 @@ func (s *Service) Create(ctx context.Context, cmd *folder.CreateFolderCommand) (
 }
 
 func (s *Service) Update(ctx context.Context, cmd *folder.UpdateFolderCommand) (*folder.Folder, error) {
+	logger := s.log.FromContext(ctx)
+
 	if cmd.SignedInUser == nil {
 		return nil, folder.ErrBadRequest.Errorf("missing signed in user")
 	}

--- a/pkg/services/folder/folderimpl/folder.go
+++ b/pkg/services/folder/folderimpl/folder.go
@@ -8,6 +8,7 @@ import (
 	"sync"
 
 	"github.com/grafana/grafana/pkg/bus"
+	"github.com/grafana/grafana/pkg/cmd/grafana-cli/logger"
 	"github.com/grafana/grafana/pkg/events"
 	"github.com/grafana/grafana/pkg/infra/db"
 	"github.com/grafana/grafana/pkg/infra/log"
@@ -343,31 +344,29 @@ func (s *Service) Create(ctx context.Context, cmd *folder.CreateFolderCommand) (
 	}
 
 	var nestedFolder *folder.Folder
-	if s.features.IsEnabled(featuremgmt.FlagNestedFolders) {
-		cmd := &folder.CreateFolderCommand{
-			// TODO: Today, if a UID isn't specified, the dashboard store
-			// generates a new UID. The new folder store will need to do this as
-			// well, but for now we take the UID from the newly created folder.
-			UID:         dash.UID,
-			OrgID:       cmd.OrgID,
-			Title:       cmd.Title,
-			Description: cmd.Description,
-			ParentUID:   cmd.ParentUID,
+	cmd = &folder.CreateFolderCommand{
+		// TODO: Today, if a UID isn't specified, the dashboard store
+		// generates a new UID. The new folder store will need to do this as
+		// well, but for now we take the UID from the newly created folder.
+		UID:         dash.UID,
+		OrgID:       cmd.OrgID,
+		Title:       cmd.Title,
+		Description: cmd.Description,
+		ParentUID:   cmd.ParentUID,
+	}
+	nestedFolder, err = s.nestedFolderCreate(ctx, cmd)
+	if err != nil {
+		// We'll log the error and also roll back the previously-created
+		// (legacy) folder.
+		logger.Error("error saving folder to nested folder store", "error", err)
+		// do not shallow create error if the legacy folder delete fails
+		if deleteErr := s.dashboardStore.DeleteDashboard(ctx, &dashboards.DeleteDashboardCommand{
+			ID:    createdFolder.ID,
+			OrgID: createdFolder.OrgID,
+		}); deleteErr != nil {
+			logger.Error("error deleting folder after failed save to nested folder store", "error", err)
 		}
-		nestedFolder, err = s.nestedFolderCreate(ctx, cmd)
-		if err != nil {
-			// We'll log the error and also roll back the previously-created
-			// (legacy) folder.
-			logger.Error("error saving folder to nested folder store", "error", err)
-			// do not shallow create error if the legacy folder delete fails
-			if deleteErr := s.dashboardStore.DeleteDashboard(ctx, &dashboards.DeleteDashboardCommand{
-				ID:    createdFolder.ID,
-				OrgID: createdFolder.OrgID,
-			}); deleteErr != nil {
-				logger.Error("error deleting folder after failed save to nested folder store", "error", err)
-			}
-			return dashboards.FromDashboard(dash), err
-		}
+		return dashboards.FromDashboard(dash), err
 	}
 
 	f := dashboards.FromDashboard(dash)
@@ -388,10 +387,6 @@ func (s *Service) Update(ctx context.Context, cmd *folder.UpdateFolderCommand) (
 		return nil, err
 	}
 
-	if !s.features.IsEnabled(featuremgmt.FlagNestedFolders) {
-		return dashFolder, nil
-	}
-
 	foldr, err := s.store.Update(ctx, folder.UpdateFolderCommand{
 		UID:            cmd.UID,
 		OrgID:          cmd.OrgID,
@@ -400,6 +395,11 @@ func (s *Service) Update(ctx context.Context, cmd *folder.UpdateFolderCommand) (
 		SignedInUser:   user,
 	})
 	if err != nil {
+		if errors.Is(err, folder.ErrFolderNotFound) {
+			logger.Warn("attempt to update folder that does not exist in the folders table", "folderUID", cmd.UID)
+			return dashFolder, nil
+		}
+
 		return nil, err
 	}
 
@@ -530,15 +530,13 @@ func (s *Service) Delete(ctx context.Context, cmd *folder.DeleteFolderCommand) e
 
 	result := []string{cmd.UID}
 	err = s.db.InTransaction(ctx, func(ctx context.Context) error {
-		if s.features.IsEnabled(featuremgmt.FlagNestedFolders) {
-			subfolders, err := s.nestedFolderDelete(ctx, cmd)
+		subfolders, err := s.nestedFolderDelete(ctx, cmd)
 
-			if err != nil {
-				logger.Error("the delete folder on folder table failed with err: ", "error", err)
-				return err
-			}
-			result = append(result, subfolders...)
+		if err != nil {
+			logger.Error("the delete folder on folder table failed with err: ", "error", err)
+			return err
 		}
+		result = append(result, subfolders...)
 
 		dashFolders, err := s.dashboardFolderStore.GetFolders(ctx, cmd.OrgID, result)
 		if err != nil {

--- a/pkg/services/folder/folderimpl/folder_test.go
+++ b/pkg/services/folder/folderimpl/folder_test.go
@@ -189,7 +189,6 @@ func TestIntegrationFolderService(t *testing.T) {
 
 				dashStore.On("ValidateDashboardBeforeSave", mock.Anything, mock.AnythingOfType("*dashboards.Dashboard"), mock.AnythingOfType("bool")).Return(true, nil)
 				dashStore.On("SaveDashboard", mock.Anything, mock.AnythingOfType("dashboards.SaveDashboardCommand")).Return(dash, nil).Once()
-				dashStore.On("DeleteDashboard", mock.Anything, mock.AnythingOfType("*dashboards.DeleteDashboardCommand")).Return(nil).Once()
 				folderStore.On("GetFolderByID", mock.Anything, orgID, dash.ID).Return(f, nil)
 
 				actualFolder, err := service.Create(context.Background(), &folder.CreateFolderCommand{
@@ -246,11 +245,9 @@ func TestIntegrationFolderService(t *testing.T) {
 				folderStore.On("GetFolderByUID", mock.Anything, orgID, f.UID).Return(f, nil)
 
 				var actualCmd *dashboards.DeleteDashboardCommand
-				dashStore := &dashboards.FakeDashboardStore{}
-				dashStore.On("DeleteDashboard", mock.Anything, mock.AnythingOfType("*dashboards.DeleteDashboardCommand")).Run(func(args mock.Arguments) {
+				dashStore.On("DeleteDashboard", mock.Anything, mock.Anything).Run(func(args mock.Arguments) {
 					actualCmd = args.Get(1).(*dashboards.DeleteDashboardCommand)
 				}).Return(nil).Once()
-				service.dashboardStore = dashStore
 
 				expectedForceDeleteRules := rand.Int63()%2 == 0
 				err := service.Delete(context.Background(), &folder.DeleteFolderCommand{

--- a/pkg/services/folder/folderimpl/sqlstore.go
+++ b/pkg/services/folder/folderimpl/sqlstore.go
@@ -139,7 +139,7 @@ func (ss *sqlStore) Update(ctx context.Context, cmd folder.UpdateFolderCommand) 
 			return folder.ErrInternal.Errorf("failed to get affected row: %w", err)
 		}
 		if affected == 0 {
-			return folder.ErrFolderNotFound
+			return folder.ErrInternal.Errorf("no folders are updated: %w", folder.ErrFolderNotFound)
 		}
 
 		foldr, err = ss.Get(ctx, folder.GetFolderQuery{

--- a/pkg/services/folder/folderimpl/sqlstore.go
+++ b/pkg/services/folder/folderimpl/sqlstore.go
@@ -139,7 +139,7 @@ func (ss *sqlStore) Update(ctx context.Context, cmd folder.UpdateFolderCommand) 
 			return folder.ErrInternal.Errorf("failed to get affected row: %w", err)
 		}
 		if affected == 0 {
-			return folder.ErrInternal.Errorf("no folders are updated")
+			return folder.ErrFolderNotFound
 		}
 
 		foldr, err = ss.Get(ctx, folder.GetFolderQuery{


### PR DESCRIPTION
**Why do we need this feature?**

This PR enables writing to both `dashboard` and `folders` tables regardless of the `nestedFolders` feature toggle state. It is required to keep both tables in sync.

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**
I've tested it with SQLite, PostgreSQL and MySQL, just in case :) 