### PR TITLE
InfluxDB: Add Missing Operators for Field based WHERE conditions

### DIFF
--- a/pkg/tsdb/influxdb/models/query.go
+++ b/pkg/tsdb/influxdb/models/query.go
@@ -76,10 +76,10 @@ func (query *Query) renderTags() []string {
 			textValue = tag.Value
 		case "Is":
 			tag.Operator = "="
-			textValue = tag.Value
+			textValue = strings.ToLower(tag.Value)
 		case "is Not":
 			tag.Operator = "!="
-			textValue = tag.Value
+			textValue = strings.ToLower(tag.Value)
 		default:
 			textValue = fmt.Sprintf("'%s'", strings.ReplaceAll(tag.Value, `\`, `\\`))
 		}

--- a/pkg/tsdb/influxdb/models/query.go
+++ b/pkg/tsdb/influxdb/models/query.go
@@ -77,7 +77,7 @@ func (query *Query) renderTags() []string {
 		case "Is":
 			tag.Operator = "="
 			textValue = strings.ToLower(tag.Value)
-		case "is Not":
+		case "Is Not":
 			tag.Operator = "!="
 			textValue = strings.ToLower(tag.Value)
 		default:

--- a/pkg/tsdb/influxdb/models/query.go
+++ b/pkg/tsdb/influxdb/models/query.go
@@ -72,7 +72,7 @@ func (query *Query) renderTags() []string {
 		switch tag.Operator {
 		case "=~", "!~":
 			textValue = tag.Value
-		case "<", ">", "<>":
+		case "<", ">", "<>", ">=", "<=":
 			textValue = tag.Value
 		default:
 			textValue = fmt.Sprintf("'%s'", strings.ReplaceAll(tag.Value, `\`, `\\`))

--- a/pkg/tsdb/influxdb/models/query.go
+++ b/pkg/tsdb/influxdb/models/query.go
@@ -72,7 +72,7 @@ func (query *Query) renderTags() []string {
 		switch tag.Operator {
 		case "=~", "!~":
 			textValue = tag.Value
-		case "<", ">":
+		case "<", ">", "<>":
 			textValue = tag.Value
 		default:
 			textValue = fmt.Sprintf("'%s'", strings.ReplaceAll(tag.Value, `\`, `\\`))

--- a/pkg/tsdb/influxdb/models/query.go
+++ b/pkg/tsdb/influxdb/models/query.go
@@ -3,7 +3,6 @@ package models
 import (
 	"fmt"
 	"regexp"
-	"slices"
 	"strconv"
 	"strings"
 	"time"
@@ -68,21 +67,15 @@ func (query *Query) renderTags() []string {
 			}
 		}
 
-		// quote value unless regex, number or boolean
+		// quote value unless regex or number
 		var textValue string
-		booleanValues := []string{"true", "false"}
-
-		if slices.Contains(booleanValues, strings.ToLower(tag.Value)) {
+		switch tag.Operator {
+		case "=~", "!~":
 			textValue = tag.Value
-		} else {
-			switch tag.Operator {
-			case "=~", "!~":
-				textValue = tag.Value
-			case "<", ">", "<>":
-				textValue = tag.Value
-			default:
-				textValue = fmt.Sprintf("'%s'", strings.ReplaceAll(tag.Value, `\`, `\\`))
-			}
+		case "<", ">", "<>":
+			textValue = tag.Value
+		default:
+			textValue = fmt.Sprintf("'%s'", strings.ReplaceAll(tag.Value, `\`, `\\`))
 		}
 
 		escapedKey := fmt.Sprintf(`"%s"`, tag.Key)

--- a/pkg/tsdb/influxdb/models/query.go
+++ b/pkg/tsdb/influxdb/models/query.go
@@ -3,6 +3,7 @@ package models
 import (
 	"fmt"
 	"regexp"
+	"slices"
 	"strconv"
 	"strings"
 	"time"
@@ -67,15 +68,21 @@ func (query *Query) renderTags() []string {
 			}
 		}
 
-		// quote value unless regex or number
+		// quote value unless regex, number or boolean
 		var textValue string
-		switch tag.Operator {
-		case "=~", "!~":
+		booleanValues := []string{"true", "false"}
+
+		if slices.Contains(booleanValues, strings.ToLower(tag.Value)) {
 			textValue = tag.Value
-		case "<", ">", "<>":
-			textValue = tag.Value
-		default:
-			textValue = fmt.Sprintf("'%s'", strings.ReplaceAll(tag.Value, `\`, `\\`))
+		} else {
+			switch tag.Operator {
+			case "=~", "!~":
+				textValue = tag.Value
+			case "<", ">", "<>":
+				textValue = tag.Value
+			default:
+				textValue = fmt.Sprintf("'%s'", strings.ReplaceAll(tag.Value, `\`, `\\`))
+			}
 		}
 
 		escapedKey := fmt.Sprintf(`"%s"`, tag.Key)

--- a/pkg/tsdb/influxdb/models/query.go
+++ b/pkg/tsdb/influxdb/models/query.go
@@ -74,6 +74,12 @@ func (query *Query) renderTags() []string {
 			textValue = tag.Value
 		case "<", ">", "<>", ">=", "<=":
 			textValue = tag.Value
+		case "Is":
+			tag.Operator = "="
+			textValue = tag.Value
+		case "is Not":
+			tag.Operator = "!="
+			textValue = tag.Value
 		default:
 			textValue = fmt.Sprintf("'%s'", strings.ReplaceAll(tag.Value, `\`, `\\`))
 		}

--- a/pkg/tsdb/influxdb/models/query_test.go
+++ b/pkg/tsdb/influxdb/models/query_test.go
@@ -234,6 +234,22 @@ func TestInfluxdbQueryBuilder(t *testing.T) {
 			require.Equal(t, strings.Join(query.renderTags(), ""), `"key" = 'value'`)
 		})
 
+		t.Run("can render boolean equality tags", func(t *testing.T) {
+			query := &Query{Tags: []*Tag{{Operator: "Is", Value: "false", Key: "key"}}}
+
+			require.Equal(t, strings.Join(query.renderTags(), ""), `"key" = false`)
+		})
+
+		t.Run("can render boolean inequality tags", func(t *testing.T) {
+			query := &Query{Tags: []*Tag{{Operator: "Is Not", Value: "true", Key: "key"}}}
+			require.Equal(t, strings.Join(query.renderTags(), ""), `"key" != true`)
+		})
+
+		t.Run("can correct case of boolean tags", func(t *testing.T) {
+			query := &Query{Tags: []*Tag{{Operator: "Is", Value: "False", Key: "key"}}}
+			require.Equal(t, strings.Join(query.renderTags(), ""), `"key" = false`)
+		})
+
 		t.Run("can escape backslashes when rendering string tags", func(t *testing.T) {
 			query := &Query{Tags: []*Tag{{Operator: "=", Value: `C:\test\`, Key: "key"}}}
 

--- a/public/app/plugins/datasource/influxdb/components/editor/query/influxql/visual/TagsSection.tsx
+++ b/public/app/plugins/datasource/influxdb/components/editor/query/influxql/visual/TagsSection.tsx
@@ -10,8 +10,8 @@ import { toSelectableValue } from '../utils/toSelectableValue';
 import { AddButton } from './AddButton';
 import { Seg } from './Seg';
 
-type KnownOperator = '=' | '!=' | '<>' | '<' | '>' | '=~' | '!~';
-const knownOperators: KnownOperator[] = ['=', '!=', '<>', '<', '>', '=~', '!~'];
+type KnownOperator = '=' | '!=' | '<>' | '<=' | '<' | '>=' | '>' | '=~' | '!~';
+const knownOperators: KnownOperator[] = ['=', '!=', '<>', '<=', '<', '>=', '>', '=~', '!~', '>='];
 
 type KnownCondition = 'AND' | 'OR';
 const knownConditions: KnownCondition[] = ['AND', 'OR'];

--- a/public/app/plugins/datasource/influxdb/components/editor/query/influxql/visual/TagsSection.tsx
+++ b/public/app/plugins/datasource/influxdb/components/editor/query/influxql/visual/TagsSection.tsx
@@ -10,8 +10,8 @@ import { toSelectableValue } from '../utils/toSelectableValue';
 import { AddButton } from './AddButton';
 import { Seg } from './Seg';
 
-type KnownOperator = '=' | '!=' | '<>' | '<=' | '<' | '>=' | '>' | '=~' | '!~';
-const knownOperators: KnownOperator[] = ['=', '!=', '<>', '<=', '<', '>=', '>', '=~', '!~', '>='];
+type KnownOperator = '=' | '!=' | '<>' | '<=' | '<' | '>=' | '>' | '=~' | '!~' | 'Is' | 'Is Not';
+const knownOperators: KnownOperator[] = ['=', '!=', '<>', '<=', '<', '>=', '>', '=~', '!~', '>=', 'Is', 'Is Not'];
 
 type KnownCondition = 'AND' | 'OR';
 const knownConditions: KnownCondition[] = ['AND', 'OR'];


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

- Introduces missing query operators to the InfluxQL Query Builder
- Fixes type handling for an existing operator (`<>`: https://github.com/grafana/grafana/issues/77793)
- Implements support for including query conditions based upon boolean field values using new `Is` and `Is Not` operators (see note below) (https://github.com/grafana/grafana/issues/77794).

![Screenshot_2023-11-07_12-07-14](https://github.com/grafana/grafana/assets/88340935/8db9d528-fd88-4056-9338-2cf21a9d67e5)



**Why do we need this feature?**

- InfluxQL supports a [range of comparison operators](https://docs.influxdata.com/influxdb/v1/query_language/explore-data/#fields) for field values. Prior to this PR, Grafana did not include support for `>=` or `<=` at all.
- Handling for the operator `<>` was incorrect. It had been omitted from the `case` statement, so a submission of `field <> 4` would be coerced to `field <> '4'`.
- There's a pre-existing issue where [it isn't possible to query based on boolean fields](https://github.com/grafana/grafana/issues/2674#issuecomment-1446564677) because after submission, the value will be coerced to a string (e.g. `false` will be coerced to `'false'`).



**Who is this feature for?**

InfluxDB users who want to use the InfluxQL Query Editor to build queries which reference non-string fields in their query's `WHERE` condition.


**Relevant Issues**

- https://github.com/grafana/grafana/issues/4744 
- https://github.com/grafana/grafana/issues/2674
- https://github.com/grafana/grafana/issues/34577 (links out to others)
- https://github.com/grafana/grafana/issues/77793
- https://github.com/grafana/grafana/issues/77794


Fixes https://github.com/grafana/grafana/issues/77793
Fixes https://github.com/grafana/grafana/issues/77794

**Special notes for your reviewer:**

New operators (`Is` and `Is Not`) were used for boolean equality tests in order to preserve backwards compatibility: I originally implemented a solution that checked if the supplied value looked like a boolean (i.e. was `true` or `false`) so that `=` and `!=` could be used. However, on testing, I found that this broke any pre-existing (and query editor originated) dashboard cells which queried a *string* field for `true` or `false`

I have not added a test for the typescript changes - there didn't seem to be an existing test for the other operators, so I didn't think it was necessary (there **is** a test for the backend changes, however).


Please check that:
- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
