### PR TITLE
TimePicker: Close overlay content when toolbar button is clicked for the second time

### DIFF
--- a/packages/grafana-e2e-selectors/src/selectors/components.ts
+++ b/packages/grafana-e2e-selectors/src/selectors/components.ts
@@ -15,6 +15,7 @@ export const Components = {
   },
   TimePicker: {
     openButton: 'data-testid TimePicker Open Button',
+    overlayContent: 'data-testid TimePicker Overlay Content',
     fromField: 'Time Range from field',
     toField: 'Time Range to field',
     applyTimeRange: 'data-testid TimePicker submit button',

--- a/packages/grafana-ui/src/components/DateTimePickers/TimeRangePicker.test.tsx
+++ b/packages/grafana-ui/src/components/DateTimePickers/TimeRangePicker.test.tsx
@@ -1,4 +1,5 @@
-import { fireEvent, render, screen } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import React from 'react';
 
 import { dateTime, TimeRange } from '@grafana/data';
@@ -32,7 +33,7 @@ describe('TimePicker', () => {
 
     expect(container.queryByLabelText(/Time range selected/i)).toBeInTheDocument();
   });
-  it('switches overlay content visibility when toolbar button is clicked twice', () => {
+  it('switches overlay content visibility when toolbar button is clicked twice', async () => {
     render(
       <TimeRangePicker
         onChangeTimeZone={() => {}}
@@ -48,9 +49,9 @@ describe('TimePicker', () => {
     const overlayContent = screen.queryByTestId(selectors.overlayContent);
 
     expect(overlayContent).not.toBeInTheDocument();
-    fireEvent.click(openButton);
+    await userEvent.click(openButton);
     expect(screen.getByTestId(selectors.overlayContent)).toBeInTheDocument();
-    fireEvent.click(openButton);
+    await userEvent.click(openButton);
     expect(overlayContent).not.toBeInTheDocument();
   });
 });

--- a/packages/grafana-ui/src/components/DateTimePickers/TimeRangePicker.test.tsx
+++ b/packages/grafana-ui/src/components/DateTimePickers/TimeRangePicker.test.tsx
@@ -1,9 +1,12 @@
-import { render } from '@testing-library/react';
+import { fireEvent, render, screen } from '@testing-library/react';
 import React from 'react';
 
 import { dateTime, TimeRange } from '@grafana/data';
+import { selectors as e2eSelectors } from '@grafana/e2e-selectors/src';
 
 import { TimeRangePicker } from './TimeRangePicker';
+
+const selectors = e2eSelectors.components.TimePicker;
 
 const from = dateTime('2019-12-17T07:48:27.433Z');
 const to = dateTime('2019-12-18T07:48:27.433Z');
@@ -28,5 +31,26 @@ describe('TimePicker', () => {
     );
 
     expect(container.queryByLabelText(/Time range selected/i)).toBeInTheDocument();
+  });
+  it('switches overlay content visibility when toolbar button is clicked twice', () => {
+    render(
+      <TimeRangePicker
+        onChangeTimeZone={() => {}}
+        onChange={(value) => {}}
+        value={value}
+        onMoveBackward={() => {}}
+        onMoveForward={() => {}}
+        onZoom={() => {}}
+      />
+    );
+
+    const openButton = screen.getByTestId(selectors.openButton);
+    const overlayContent = screen.queryByTestId(selectors.overlayContent);
+
+    expect(overlayContent).not.toBeInTheDocument();
+    fireEvent.click(openButton);
+    expect(screen.getByTestId(selectors.overlayContent)).toBeInTheDocument();
+    fireEvent.click(openButton);
+    expect(overlayContent).not.toBeInTheDocument();
   });
 });

--- a/packages/grafana-ui/src/components/DateTimePickers/TimeRangePicker.test.tsx
+++ b/packages/grafana-ui/src/components/DateTimePickers/TimeRangePicker.test.tsx
@@ -3,7 +3,7 @@ import userEvent from '@testing-library/user-event';
 import React from 'react';
 
 import { dateTime, TimeRange } from '@grafana/data';
-import { selectors as e2eSelectors } from '@grafana/e2e-selectors/src';
+import { selectors as e2eSelectors } from '@grafana/e2e-selectors';
 
 import { TimeRangePicker } from './TimeRangePicker';
 

--- a/packages/grafana-ui/src/components/DateTimePickers/TimeRangePicker.tsx
+++ b/packages/grafana-ui/src/components/DateTimePickers/TimeRangePicker.tsx
@@ -83,9 +83,20 @@ export function TimeRangePicker(props: TimeRangePickerProps) {
     setOpen(false);
   };
 
-  const ref = createRef<HTMLDivElement>();
-  const { overlayProps, underlayProps } = useOverlay({ onClose, isDismissable: true, isOpen }, ref);
-  const { dialogProps } = useDialog({}, ref);
+  const overlayRef = createRef<HTMLElement>();
+  const buttonRef = createRef<HTMLElement>();
+  const { overlayProps, underlayProps } = useOverlay(
+    {
+      onClose,
+      isDismissable: true,
+      isOpen,
+      shouldCloseOnInteractOutside: (element) => {
+        return !buttonRef.current?.contains(element);
+      },
+    },
+    overlayRef
+  );
+  const { dialogProps } = useDialog({}, overlayRef);
 
   const theme = useTheme2();
   const styles = useStyles2(getStyles);
@@ -106,49 +117,49 @@ export function TimeRangePicker(props: TimeRangePickerProps) {
           narrow
         />
       )}
-      <div ref={ref} {...overlayProps}>
-        <Tooltip content={<TimePickerTooltip timeRange={value} timeZone={timeZone} />} placement="bottom" interactive>
-          <ToolbarButton
-            data-testid={selectors.components.TimePicker.openButton}
-            aria-label={t(
-              'time-picker.range-picker.current-time-selected',
-              'Time range selected: {{currentTimeRange}}',
-              {
-                currentTimeRange,
-              }
-            )}
-            aria-controls="TimePickerContent"
-            onClick={onToolbarButtonSwitch}
-            icon="clock-nine"
-            isOpen={isOpen}
-            variant={variant}
-          >
-            <TimePickerButtonLabel {...props} />
-          </ToolbarButton>
-        </Tooltip>
-        {isOpen && (
-          <div data-testid={selectors.components.TimePicker.overlayContent}>
-            <div role="presentation" className={cx(modalBackdrop, styles.backdrop)} {...underlayProps} />
-            <FocusScope contain autoFocus>
-              <section className={styles.content} {...dialogProps}>
-                <TimePickerContent
-                  timeZone={timeZone}
-                  fiscalYearStartMonth={fiscalYearStartMonth}
-                  value={value}
-                  onChange={onChange}
-                  quickOptions={quickOptions}
-                  history={history}
-                  showHistory
-                  widthOverride={widthOverride}
-                  onChangeTimeZone={onChangeTimeZone}
-                  onChangeFiscalYearStartMonth={onChangeFiscalYearStartMonth}
-                  hideQuickRanges={hideQuickRanges}
-                />
-              </section>
-            </FocusScope>
-          </div>
-        )}
-      </div>
+
+      <Tooltip
+        ref={buttonRef}
+        content={<TimePickerTooltip timeRange={value} timeZone={timeZone} />}
+        placement="bottom"
+        interactive
+      >
+        <ToolbarButton
+          data-testid={selectors.components.TimePicker.openButton}
+          aria-label={t('time-picker.range-picker.current-time-selected', 'Time range selected: {{currentTimeRange}}', {
+            currentTimeRange,
+          })}
+          aria-controls="TimePickerContent"
+          onClick={onToolbarButtonSwitch}
+          icon="clock-nine"
+          isOpen={isOpen}
+          variant={variant}
+        >
+          <TimePickerButtonLabel {...props} />
+        </ToolbarButton>
+      </Tooltip>
+      {isOpen && (
+        <div data-testid={selectors.components.TimePicker.overlayContent}>
+          <div role="presentation" className={cx(modalBackdrop, styles.backdrop)} {...underlayProps} />
+          <FocusScope contain autoFocus>
+            <section className={styles.content} ref={overlayRef} {...overlayProps} {...dialogProps}>
+              <TimePickerContent
+                timeZone={timeZone}
+                fiscalYearStartMonth={fiscalYearStartMonth}
+                value={value}
+                onChange={onChange}
+                quickOptions={quickOptions}
+                history={history}
+                showHistory
+                widthOverride={widthOverride}
+                onChangeTimeZone={onChangeTimeZone}
+                onChangeFiscalYearStartMonth={onChangeFiscalYearStartMonth}
+                hideQuickRanges={hideQuickRanges}
+              />
+            </section>
+          </FocusScope>
+        </div>
+      )}
 
       {timeSyncButton}
 

--- a/packages/grafana-ui/src/components/DateTimePickers/TimeRangePicker.tsx
+++ b/packages/grafana-ui/src/components/DateTimePickers/TimeRangePicker.tsx
@@ -2,7 +2,7 @@ import { css, cx } from '@emotion/css';
 import { useDialog } from '@react-aria/dialog';
 import { FocusScope } from '@react-aria/focus';
 import { useOverlay } from '@react-aria/overlays';
-import React, { memo, FormEvent, createRef, useState } from 'react';
+import React, { memo, createRef, useState } from 'react';
 
 import {
   isDateTime,
@@ -75,17 +75,15 @@ export function TimeRangePicker(props: TimeRangePickerProps) {
     setOpen(false);
   };
 
-  const onOpen = (event: FormEvent<HTMLButtonElement>) => {
-    event.stopPropagation();
-    event.preventDefault();
-    setOpen(!isOpen);
+  const onToolbarButtonSwitch = () => {
+    setOpen((prevState) => !prevState);
   };
 
   const onClose = () => {
     setOpen(false);
   };
 
-  const ref = createRef<HTMLElement>();
+  const ref = createRef<HTMLDivElement>();
   const { overlayProps, underlayProps } = useOverlay({ onClose, isDismissable: true, isOpen }, ref);
   const { dialogProps } = useDialog({}, ref);
 
@@ -108,44 +106,49 @@ export function TimeRangePicker(props: TimeRangePickerProps) {
           narrow
         />
       )}
-
-      <Tooltip content={<TimePickerTooltip timeRange={value} timeZone={timeZone} />} placement="bottom" interactive>
-        <ToolbarButton
-          data-testid={selectors.components.TimePicker.openButton}
-          aria-label={t('time-picker.range-picker.current-time-selected', 'Time range selected: {{currentTimeRange}}', {
-            currentTimeRange,
-          })}
-          aria-controls="TimePickerContent"
-          onClick={onOpen}
-          icon="clock-nine"
-          isOpen={isOpen}
-          variant={variant}
-        >
-          <TimePickerButtonLabel {...props} />
-        </ToolbarButton>
-      </Tooltip>
-      {isOpen && (
-        <div>
-          <div role="presentation" className={cx(modalBackdrop, styles.backdrop)} {...underlayProps} />
-          <FocusScope contain autoFocus>
-            <section className={styles.content} ref={ref} {...overlayProps} {...dialogProps}>
-              <TimePickerContent
-                timeZone={timeZone}
-                fiscalYearStartMonth={fiscalYearStartMonth}
-                value={value}
-                onChange={onChange}
-                quickOptions={quickOptions}
-                history={history}
-                showHistory
-                widthOverride={widthOverride}
-                onChangeTimeZone={onChangeTimeZone}
-                onChangeFiscalYearStartMonth={onChangeFiscalYearStartMonth}
-                hideQuickRanges={hideQuickRanges}
-              />
-            </section>
-          </FocusScope>
-        </div>
-      )}
+      <div ref={ref} {...overlayProps}>
+        <Tooltip content={<TimePickerTooltip timeRange={value} timeZone={timeZone} />} placement="bottom" interactive>
+          <ToolbarButton
+            data-testid={selectors.components.TimePicker.openButton}
+            aria-label={t(
+              'time-picker.range-picker.current-time-selected',
+              'Time range selected: {{currentTimeRange}}',
+              {
+                currentTimeRange,
+              }
+            )}
+            aria-controls="TimePickerContent"
+            onClick={onToolbarButtonSwitch}
+            icon="clock-nine"
+            isOpen={isOpen}
+            variant={variant}
+          >
+            <TimePickerButtonLabel {...props} />
+          </ToolbarButton>
+        </Tooltip>
+        {isOpen && (
+          <div data-testid={selectors.components.TimePicker.overlayContent}>
+            <div role="presentation" className={cx(modalBackdrop, styles.backdrop)} {...underlayProps} />
+            <FocusScope contain autoFocus>
+              <section className={styles.content} {...dialogProps}>
+                <TimePickerContent
+                  timeZone={timeZone}
+                  fiscalYearStartMonth={fiscalYearStartMonth}
+                  value={value}
+                  onChange={onChange}
+                  quickOptions={quickOptions}
+                  history={history}
+                  showHistory
+                  widthOverride={widthOverride}
+                  onChangeTimeZone={onChangeTimeZone}
+                  onChangeFiscalYearStartMonth={onChangeFiscalYearStartMonth}
+                  hideQuickRanges={hideQuickRanges}
+                />
+              </section>
+            </FocusScope>
+          </div>
+        )}
+      </div>
 
       {timeSyncButton}
 

--- a/public/app/core/components/TimePicker/TimePickerWithHistory.test.tsx
+++ b/public/app/core/components/TimePicker/TimePickerWithHistory.test.tsx
@@ -116,11 +116,11 @@ describe('TimePickerWithHistory', () => {
     await userEvent.click(screen.getByLabelText(/Time range selected/));
 
     for (const [inputFrom, inputTo] of inputRanges) {
-      await userEvent.click(screen.getByLabelText(/Time range selected/));
       await clearAndType(getFromField(), inputFrom);
       await clearAndType(getToField(), inputTo);
 
       await userEvent.click(getApplyButton());
+      await userEvent.click(screen.getByLabelText(/Time range selected/));
     }
 
     const newLsValue = JSON.parse(window.localStorage.getItem(LOCAL_STORAGE_KEY) ?? '[]');

--- a/public/app/core/components/TimePicker/TimePickerWithHistory.test.tsx
+++ b/public/app/core/components/TimePicker/TimePickerWithHistory.test.tsx
@@ -113,14 +113,13 @@ describe('TimePickerWithHistory', () => {
 
     const timeRange = getDefaultTimeRange();
     render(<TimePickerWithHistory value={timeRange} {...props} />);
-    await userEvent.click(screen.getByLabelText(/Time range selected/));
 
     for (const [inputFrom, inputTo] of inputRanges) {
+      await userEvent.click(screen.getByLabelText(/Time range selected/));
       await clearAndType(getFromField(), inputFrom);
       await clearAndType(getToField(), inputTo);
 
       await userEvent.click(getApplyButton());
-      await userEvent.click(screen.getByLabelText(/Time range selected/));
     }
 
     const newLsValue = JSON.parse(window.localStorage.getItem(LOCAL_STORAGE_KEY) ?? '[]');


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

It closes the overlay content when the toolbar button is clicked for the second time

**Why do we need this feature?**

This is a bug fix, since a double set state is being triggered and, therefore, the overlay content keeps open.

**Who is this feature for?**

[Add information on what kind of user the feature is for.]

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

| Previous behavior  | Fixed behavior |
| ------------- | ------------- |
| <video src="https://github.com/grafana/grafana/assets/11707172/4b2df5cd-1e3c-4930-8fe3-b4a1e6edefc8"> | <video src="https://github.com/grafana/grafana/assets/11707172/1a97ed6b-b733-4896-8501-746eb27a9f9f">  |


Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
