### PR TITLE
Logs: Use "labels" data frame field if type "other" in log details

### DIFF
--- a/public/app/features/logs/components/logParser.test.ts
+++ b/public/app/features/logs/components/logParser.test.ts
@@ -46,15 +46,10 @@ describe('logParser', () => {
       expect(getAllFields(createScenario(-0))).toHaveLength(1);
     });
 
-    it('should filter out field with labels name old-loki-style frame', () => {
+    it('should filter out field with labels in frame', () => {
       const logRow = createLogRow({
         entryFieldIndex: 1,
         dataFrame: new MutableDataFrame({
-          meta: {
-            custom: {
-              frameType: 'LabeledTimeValues',
-            },
-          },
           refId: 'A',
           fields: [
             testTimeField,

--- a/public/app/features/logs/legacyLogsFrame.ts
+++ b/public/app/features/logs/legacyLogsFrame.ts
@@ -1,6 +1,6 @@
 import { DataFrame, FieldCache, FieldType, Field, Labels, FieldWithIndex } from '@grafana/data';
 
-import type { LogsFrame } from './logsFrame';
+import { logFrameLabelsToLabels, LogsFrame } from './logsFrame';
 
 // take the labels from the line-field, and "stretch" it into an array
 // with the length of the frame (so there are the same labels for every row)
@@ -15,7 +15,7 @@ function makeLabelsArray(lineField: Field, length: number): Labels[] | null {
   }
 }
 
-// we decide if the frame is old-loki-style frame, and adjust the behavior.
+// if the frame has "labels" field with type "other", adjust the behavior.
 // we also have to return the labels-field (if we used it),
 // to be able to remove it from the unused-fields, later.
 function makeLabelsGetter(
@@ -23,11 +23,13 @@ function makeLabelsGetter(
   lineField: Field,
   frame: DataFrame
 ): [FieldWithIndex | null, () => Labels[] | null] {
-  if (frame.meta?.custom?.frameType === 'LabeledTimeValues') {
-    const labelsField = cache.getFieldByName('labels');
-    return labelsField === undefined ? [null, () => null] : [labelsField, () => labelsField.values];
+  // If we have labels field with type "other", use that
+  const labelsField = cache.getFieldByName('labels');
+  if (labelsField !== undefined && labelsField.type === FieldType.other) {
+    const values = labelsField.values.map(logFrameLabelsToLabels);
+    return [labelsField, () => values];
   } else {
-    // we use the labels on the line-field, and make an array with it
+    // Otherwise we use the labels on the line-field, and make an array with it
     return [null, () => makeLabelsArray(lineField, frame.length)];
   }
 }

--- a/public/app/features/logs/logsFrame.test.ts
+++ b/public/app/features/logs/logsFrame.test.ts
@@ -129,6 +129,44 @@ describe('parseLogsFrame should parse different logs-dataframe formats', () => {
     expect(result?.extraFields).toStrictEqual([]);
   });
 
+  it('should parse a Loki-style frame (single-frame, labels-in-json)', () => {
+    const time = makeTime('Time', [1687185711795, 1687185711995]);
+    const line = makeString('Line', ['line1', 'line2']);
+    const id = makeString('id', ['id1', 'id2']);
+    const ns = makeString('tsNs', ['1687185711795123456', '1687185711995987654']);
+    const labels = makeObject('labels', [
+      { counter: '38141', label: 'val2', level: 'warning' },
+      { counter: '38143', label: 'val2', level: 'info' },
+    ]);
+
+    const result = parseLogsFrame({
+      meta: {
+        custom: {
+          frameType: 'LabeledTimeValues',
+        },
+      },
+      fields: [labels, time, line, ns, id],
+      length: 2,
+    });
+
+    expect(result).not.toBeNull();
+
+    expect(result!.timeField.values[0]).toBe(time.values[0]);
+    expect(result!.bodyField.values[0]).toBe(line.values[0]);
+    expect(result!.idField?.values[0]).toBe(id.values[0]);
+    expect(result!.timeNanosecondField?.values[0]).toBe(ns.values[0]);
+    expect(result!.severityField).toBeNull();
+    expect(result!.getLogFrameLabels()).toStrictEqual([
+      { counter: '38141', label: 'val2', level: 'warning' },
+      { counter: '38143', label: 'val2', level: 'info' },
+    ]);
+    expect(result!.getLogFrameLabelsAsLabels()).toStrictEqual([
+      { counter: '38141', label: 'val2', level: 'warning' },
+      { counter: '38143', label: 'val2', level: 'info' },
+    ]);
+    expect(result?.extraFields).toStrictEqual([]);
+  });
+
   it('should parse elastic-style frame (has level-field, no labels parsed, with extra unused fields)', () => {
     const time = makeTime('Time', [1687185711795, 1687185711995]);
     const line = makeString('Line', ['line1', 'line2']);

--- a/public/app/features/logs/logsFrame.test.ts
+++ b/public/app/features/logs/logsFrame.test.ts
@@ -96,7 +96,7 @@ describe('parseLogsFrame should parse different logs-dataframe formats', () => {
     expect(result?.extraFields).toStrictEqual([]);
   });
 
-  it('should parse a Loki-style frame (single-frame, labels-in-json)', () => {
+  it('should parse frames with labels field of type other', () => {
     const time = makeTime('Time', [1687185711795, 1687185711995]);
     const line = makeString('Line', ['line1', 'line2']);
     const id = makeString('id', ['id1', 'id2']);
@@ -107,11 +107,6 @@ describe('parseLogsFrame should parse different logs-dataframe formats', () => {
     ]);
 
     const result = parseLogsFrame({
-      meta: {
-        custom: {
-          frameType: 'LabeledTimeValues',
-        },
-      },
       fields: [labels, time, line, ns, id],
       length: 2,
     });
@@ -145,11 +140,6 @@ describe('parseLogsFrame should parse different logs-dataframe formats', () => {
     const level = makeString('level', ['info', 'error']);
 
     const result = parseLogsFrame({
-      meta: {
-        custom: {
-          frameType: 'LabeledTimeValues',
-        },
-      },
       fields: [time, line, source, level, host],
       length: 2,
     });

--- a/public/app/features/logs/logsModel.test.ts
+++ b/public/app/features/logs/logsModel.test.ts
@@ -436,9 +436,6 @@ describe('dataFrameToLogsModel', () => {
         ],
         meta: {
           limit: 1000,
-          custom: {
-            frameType: 'LabeledTimeValues',
-          },
         },
         refId: 'A',
       }),
@@ -516,25 +513,15 @@ describe('dataFrameToLogsModel', () => {
       type: FieldType.string,
       values: ['line1'],
     };
-
-    const meta = {
-      custom: {
-        frameType: 'LabeledTimeValues',
-      },
-    };
-
     const frame1 = new MutableDataFrame({
-      meta,
       fields: [labels, time, line],
     });
 
     const frame2 = new MutableDataFrame({
-      meta,
       fields: [time, labels, line],
     });
 
     const frame3 = new MutableDataFrame({
-      meta,
       fields: [time, line, labels],
     });
 

--- a/public/app/features/logs/logsModel_parse.test.ts
+++ b/public/app/features/logs/logsModel_parse.test.ts
@@ -373,7 +373,7 @@ describe('logSeriesToLogsModel should parse different logs-dataframe formats', (
     expect(logSeriesToLogsModel(frames)).toStrictEqual(expected);
   });
 
-  it('should parse a Loki-style frame (single-frame, labels-in-json)', () => {
+  it('should parse a frame with a labels field (single-frame, labels-in-json)', () => {
     const frames: DataFrame[] = [
       {
         refId: 'A',
@@ -427,11 +427,6 @@ describe('logSeriesToLogsModel should parse different logs-dataframe formats', (
           },
         ],
         length: 3,
-        meta: {
-          custom: {
-            frameType: 'LabeledTimeValues',
-          },
-        },
       },
     ];
 


### PR DESCRIPTION
Related to https://github.com/grafana/grafana/pull/77708, this updates logic for non-dataplane frames. If the frame has "labels" field of type "other", we will consider it a special field and show its values in log details. 

This removes the necessity to use `LabeledTimeValues` as we:
1. Process frames as dataPlane frames with type of `DataFrameType.LogLines`
2. Otherwise we look at the fields and if we have "labels" field with type "other" we show its values as individual log details rows/fields. 


Please test that all functionality works as expected with: Loki , Loki with `lokiLogsDataplane = true`,  Elasticsearch, and following frame using test data source:

```
[
  {
    "schema": {
      "refId": "A",
      "meta": {
        "preferredVisualisationType": "logs",
        "custom": {
          "limit": 5,
          "searchWords": [
            ""
          ]
        }
      },
      "fields": [
        {
          "name": "timestamp",
          "type": "time",
          "config": {}
        },
        {
          "name": "body",
          "type": "string",
          "config": {}
        },
        {
          "name": "severity",
          "type": "string",
          "config": {}
        },
        {
          "name": "id",
          "type": "string",
          "config": {}
        },
        {
          "name": "labels",
          "type": "other",
          "config": {}
        },
        {
          "name": "additional",
          "type": "string",
          "config": {}
        }
      ]
    },
    "data": {
      "values": [
        [
          1699350723378,
          1699354975977,
          1699357722384,
          1699360980900,
          1699367120494
        ],
        [
          "timestamp=1699350723378 line=1 id=id 169935055790416993721579041 number=1001 string=string 1",
          "timestamp=1699354975977 line=4 id=id 169935055790416993721579044 number=1004 string=string 4",
          "timestamp=1699357722384 line=0 id=id 169935055790416993721579040 number=1000 string=string 0",
          "timestamp=1699360980900 line=2 id=id 169935055790416993721579042 number=1002 string=string 2",
          "timestamp=1699367120494 line=3 id=id 169935055790416993721579043 number=1003 string=string 3"
        ],
        [
          "error",
          "info",
          "info",
          "info",
          "info"
        ],
        [
          "id 169935055790416993721579041",
          "id 169935055790416993721579044",
          "id 169935055790416993721579040",
          "id 169935055790416993721579042",
          "id 169935055790416993721579043"
        ],
        [
          {
            "stringField": "string 1",
            "numberField": 1001,
            "objectField": {
              "key": "value 1"
            },
            "commonAttribute": "common"
          },
          {
            "stringField": "string 4",
            "numberField": 1004,
            "objectField": {
              "key": "value 4"
            },
            "commonAttribute": "common"
          },
          {
            "stringField": "string 0",
            "numberField": 1000,
            "objectField": {
              "key": "value 0"
            },
            "commonAttribute": "common"
          },
          {
            "stringField": "string 2",
            "numberField": 1002,
            "objectField": {
              "key": "value 2"
            },
            "commonAttribute": "common"
          },
          {
            "stringField": "string 3",
            "numberField": 1003,
            "objectField": {
              "key": "value 3"
            },
            "commonAttribute": "common"
          }
        ],
        [
          "string1",
          "string2",
          "string3",
          "string4",
          "string5"
        ]
      ]
    }
  }
]
```

