### PR TITLE
sql: refactor code, eliminate from-core-grafana import

### DIFF
--- a/pkg/tsdb/sqleng/resample_test.go
+++ b/pkg/tsdb/sqleng/resample_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
 	"github.com/grafana/grafana-plugin-sdk-go/data"
-	"github.com/grafana/grafana/pkg/util"
+	"github.com/grafana/grafana/pkg/tsdb/sqleng/util"
 	"github.com/stretchr/testify/require"
 )
 

--- a/pkg/tsdb/sqleng/sql_engine_test.go
+++ b/pkg/tsdb/sqleng/sql_engine_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/grafana/grafana/pkg/infra/log"
-	"github.com/grafana/grafana/pkg/util"
+	"github.com/grafana/grafana/pkg/tsdb/sqleng/util"
 )
 
 func TestSQLEngine(t *testing.T) {

--- a/pkg/tsdb/sqleng/util/util.go
+++ b/pkg/tsdb/sqleng/util/util.go
@@ -1,0 +1,3 @@
+package util
+
+func Pointer[T any](v T) *T { return &v }


### PR DESCRIPTION
fixes https://github.com/grafana/grafana/issues/77725

we are removing every import in the sql datasources that imports from core grafana.

in this case the helper-function was just a single line, so i copied it over.
a chose the same package-name so the diff will be minimal.

if anyone has a better idea, i'm all ears.