### PR TITLE
K8s: Improve table converter (support non runtime.Object values)

### DIFF
--- a/pkg/registry/apis/playlist/register.go
+++ b/pkg/registry/apis/playlist/register.go
@@ -99,7 +99,7 @@ func (b *PlaylistAPIBuilder) GetAPIGroupInfo(
 			{Name: "Interval", Type: "string", Format: "string", Description: "How often the playlist will update"},
 			{Name: "Created At", Type: "date"},
 		},
-		func(obj runtime.Object) ([]interface{}, error) {
+		func(obj any) ([]interface{}, error) {
 			m, ok := obj.(*playlist.Playlist)
 			if !ok {
 				return nil, fmt.Errorf("expected playlist")


### PR DESCRIPTION
The current table converter only supports runtime objects -- this is typically OK, but when used against an array value where the elements are not each rutime.Objects we need to be more flexible.

Wanted in https://github.com/grafana/grafana/pull/77667 and https://github.com/grafana/grafana/pull/76155 (both early WIP)