### PR TITLE
 Logs Panel: Table UI - Label names that are too long push out usage percentage in table column multi-select

### DIFF
--- a/public/app/features/explore/Logs/LogsTableNavColumn.tsx
+++ b/public/app/features/explore/Logs/LogsTableNavColumn.tsx
@@ -19,7 +19,25 @@ function getStyles(theme: GrafanaTheme2) {
       marginBottom: theme.spacing(1),
       justifyContent: 'space-between',
     }),
-    checkbox: css({}),
+    // Making the checkbox sticky and label scrollable for labels that are wider then the container
+    // However, the checkbox component does not support this, so we need to do some css hackery for now until the API of that component is updated.
+    checkboxLabel: css({
+      '> :first-child': {
+        position: 'sticky',
+        left: 0,
+        bottom: 0,
+        top: 0,
+      },
+      '> span': {
+        overflow: 'scroll',
+        '&::-webkit-scrollbar': {
+          display: 'none',
+        },
+        '&::-moz-scrollbar': {
+          display: 'none',
+        },
+      },
+    }),
     columnWrapper: css({
       marginBottom: theme.spacing(1.5),
       // need some space or the outline of the checkbox is cut off
@@ -107,7 +125,7 @@ export const LogsTableNavColumn = (props: {
         {labelKeys.sort(sortLabels(labels)).map((labelName) => (
           <div className={styles.wrap} key={labelName}>
             <Checkbox
-              className={styles.checkbox}
+              className={styles.checkboxLabel}
               label={labelName}
               onChange={() => toggleColumn(labelName)}
               checked={labels[labelName]?.active ?? false}


### PR DESCRIPTION
**What is this feature?**
Currently labels with long names will introduce horizontal scrolling in the parent container. This PR aims to fix that by making the input sticky, and allowing horizontal scroll within longer labels.
<img width="223" alt="image" src="https://github.com/grafana/grafana/assets/109082771/ee5839b4-0933-4e69-b0db-223020b82303">
<img width="238" alt="image" src="https://github.com/grafana/grafana/assets/109082771/2e386191-3066-4276-8b18-13fe006f9388">

Now it should always display in the available space:
<img width="212" alt="image" src="https://github.com/grafana/grafana/assets/109082771/b2e1a3aa-0550-4fbe-b74f-d5155a0ed544">


**Why do we need this feature?**
To prevent users from scrolling right in the multiselect container and being unable to interact with the columns in their table. (fixes UI papercut)

**Who is this feature for?**
Logs users in explore

**Special notes for your reviewer:**
Had to hack the CSS a teensy bit, ideally we could pass in class name overrides for each DOM element in the checkbox component, but this works without any changes to grafana/ui

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
