### PR TITLE
Prometheus: AI assistant add rudderstack events

### DIFF
--- a/public/app/plugins/datasource/prometheus/querybuilder/components/PromQueryBuilder.tsx
+++ b/public/app/plugins/datasource/prometheus/querybuilder/components/PromQueryBuilder.tsx
@@ -3,7 +3,7 @@ import React, { useState } from 'react';
 
 import { DataSourceApi, PanelData } from '@grafana/data';
 import { EditorRow } from '@grafana/experimental';
-import { config } from '@grafana/runtime';
+import { config, reportInteraction } from '@grafana/runtime';
 import { Button, Drawer } from '@grafana/ui';
 
 import { PrometheusDatasource } from '../../datasource';
@@ -101,6 +101,9 @@ export const PromQueryBuilder = React.memo<Props>((props) => {
             <Button
               variant={'secondary'}
               onClick={() => {
+                reportInteraction('grafana_prometheus_promqail_ai_button_clicked', {
+                  metric: query.metric,
+                });
                 setShowDrawer(true);
               }}
               title={'Get query suggestions.'}

--- a/public/app/plugins/datasource/prometheus/querybuilder/components/promQail/QuerySuggestionItem.tsx
+++ b/public/app/plugins/datasource/prometheus/querybuilder/components/promQail/QuerySuggestionItem.tsx
@@ -168,6 +168,9 @@ export function QuerySuggestionItem(props: Props) {
             variant="primary"
             size="sm"
             onClick={() => {
+              reportInteraction('grafana_prometheus_promqail_use_query_button_clicked', {
+                query: querySuggestion.query,
+              });
               const pvq = buildVisualQueryFromString(querySuggestion.query);
               // check for errors!
               onChange(pvq.query);

--- a/public/app/plugins/datasource/prometheus/querybuilder/components/promQail/state/helpers.ts
+++ b/public/app/plugins/datasource/prometheus/querybuilder/components/promQail/state/helpers.ts
@@ -1,6 +1,7 @@
 import { AnyAction } from 'redux';
 
 import { llms } from '@grafana/experimental';
+import { reportInteraction } from '@grafana/runtime';
 import { PrometheusDatasource } from 'app/plugins/datasource/prometheus/datasource';
 import { getMetadataHelp, getMetadataType } from 'app/plugins/datasource/prometheus/language_provider';
 
@@ -199,6 +200,11 @@ export async function promQailSuggest(
         query: interaction.prompt,
         collection: promQLTemplatesCollection,
         topK: 5,
+      });
+      reportInteraction('grafana_prometheus_promqail_vector_results', {
+        metric: query.metric,
+        prompt: interaction.prompt,
+        results: results,
       });
       // TODO: handle errors from vector search
     }


### PR DESCRIPTION
**What is this?** Adding events for https://github.com/grafana/grafana/issues/77822

```
reportInteraction('grafana_prometheus_promqail_ai_button_clicked', {
  metric: query.metric,
});

reportInteraction('grafana_prometheus_promqail_use_query_button_clicked', {
  query: querySuggestion.query,
});

reportInteraction('grafana_prometheus_promqail_vector_results', {
  metric: query.metric,
  prompt: interaction.prompt,
  results: results,
});
```

Next steps after merging is to add to the dashboard in ops.
https://ops.grafana-ops.net/d/Guq9HihVz/metrics?orgId=1

Please check that:
- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
