### PR TITLE
Timeseries to table transformation: Improve time series detection

### DIFF
--- a/packages/grafana-data/src/dataframe/index.ts
+++ b/packages/grafana-data/src/dataframe/index.ts
@@ -7,5 +7,5 @@ export * from './dimensions';
 export * from './ArrayDataFrame';
 export * from './DataFrameJSON';
 export * from './frameComparisons';
-export { anySeriesWithTimeField, isTimeSeriesFrame, isTimeSeriesFrames } from './utils';
+export { anySeriesWithTimeField, isTimeSeriesFrame, isTimeSeriesFrames, isTimeSeriesField } from './utils';
 export { StreamingDataFrame, StreamingFrameAction, type StreamingFrameOptions, closestIdx } from './StreamingDataFrame';

--- a/packages/grafana-data/src/dataframe/utils.ts
+++ b/packages/grafana-data/src/dataframe/utils.ts
@@ -13,7 +13,6 @@ export function isTimeSeriesFrame(frame: DataFrame) {
   const timeField = frame.fields.find((field) => field.type === FieldType.time);
   const numberField = frame.fields.find((field) => field.type === FieldType.number);
 
-  
   // There are certain query types in which we will
   // get times but they will be the same or not be
   // in increasing order. To have a time-series the
@@ -21,17 +20,15 @@ export function isTimeSeriesFrame(frame: DataFrame) {
   if (timeField !== undefined) {
     let greatestTime: number | null = null;
 
-
     for (let i = 0; i < timeField.values.length; i++) {
       const time = timeField.values[i];
 
       // Check to see if the current time is greater than
-      // the great time. If we get to the end then we 
+      // the great time. If we get to the end then we
       // have a time series otherwise we return false
       if (greatestTime === null || time > greatestTime) {
         greatestTime = time;
-      }
-      else {
+      } else {
         return false;
       }
     }

--- a/packages/grafana-data/src/dataframe/utils.ts
+++ b/packages/grafana-data/src/dataframe/utils.ts
@@ -24,7 +24,7 @@ export function isTimeSeriesFrame(frame: DataFrame) {
       const time = timeField.values[i];
 
       // Check to see if the current time is greater than
-      // the great time. If we get to the end then we
+      // the last time. If we get to the end then we
       // have a time series otherwise we return false
       if (greatestTime === null || time > greatestTime) {
         greatestTime = time;

--- a/packages/grafana-data/src/dataframe/utils.ts
+++ b/packages/grafana-data/src/dataframe/utils.ts
@@ -36,8 +36,8 @@ export function isTimeSeriesFrames(data: DataFrame[]) {
  * Determines if a field is a time field in ascending
  * order within the sampling range specified by
  * MAX_TIME_COMPARISONS
- * 
- * @param field 
+ *
+ * @param field
  * @returns boolean
  */
 export function isTimeSeriesField(field: Field) {
@@ -59,10 +59,9 @@ export function isTimeSeriesField(field: Field) {
       greatestTime = time;
     } else {
       return false;
-    } 
+    }
   }
 
-    
   return true;
 }
 

--- a/packages/grafana-data/src/dataframe/utils.ts
+++ b/packages/grafana-data/src/dataframe/utils.ts
@@ -12,6 +12,31 @@ export function isTimeSeriesFrame(frame: DataFrame) {
   // and at least one number field
   const timeField = frame.fields.find((field) => field.type === FieldType.time);
   const numberField = frame.fields.find((field) => field.type === FieldType.number);
+
+  
+  // There are certain query types in which we will
+  // get times but they will be the same or not be
+  // in increasing order. To have a time-series the
+  // times need to be ordered from past to present
+  if (timeField !== undefined) {
+    let greatestTime: number | null = null;
+
+
+    for (let i = 0; i < timeField.values.length; i++) {
+      const time = timeField.values[i];
+
+      // Check to see if the current time is greater than
+      // the great time. If we get to the end then we 
+      // have a time series otherwise we return false
+      if (greatestTime === null || time > greatestTime) {
+        greatestTime = time;
+      }
+      else {
+        return false;
+      }
+    }
+  }
+
   return timeField !== undefined && numberField !== undefined;
 }
 

--- a/public/app/features/transformers/timeSeriesTable/TimeSeriesTableTransformEditor.tsx
+++ b/public/app/features/transformers/timeSeriesTable/TimeSeriesTableTransformEditor.tsx
@@ -9,6 +9,7 @@ import {
   SelectableValue,
   Field,
   FieldType,
+  isTimeSeriesField
 } from '@grafana/data';
 import { InlineFieldRow, InlineField, StatsPicker, Select, InlineLabel } from '@grafana/ui';
 
@@ -70,7 +71,7 @@ export function TimeSeriesTableTransformEditor({
     for (const frame of input) {
       if (frame.refId === refId) {
         for (const field of frame.fields) {
-          if (field.type === 'time') {
+          if (isTimeSeriesField(field)) {
             timeFields[field.name] = field;
           }
         }

--- a/public/app/features/transformers/timeSeriesTable/TimeSeriesTableTransformEditor.tsx
+++ b/public/app/features/transformers/timeSeriesTable/TimeSeriesTableTransformEditor.tsx
@@ -9,7 +9,7 @@ import {
   SelectableValue,
   Field,
   FieldType,
-  isTimeSeriesField
+  isTimeSeriesField,
 } from '@grafana/data';
 import { InlineFieldRow, InlineField, StatsPicker, Select, InlineLabel } from '@grafana/ui';
 

--- a/public/app/features/transformers/timeSeriesTable/timeSeriesTableTransformer.test.ts
+++ b/public/app/features/transformers/timeSeriesTable/timeSeriesTableTransformer.test.ts
@@ -93,53 +93,50 @@ describe('timeSeriesTableTransformer', () => {
     expect(results[1].fields[2].values[0].value).toEqual(4);
   });
 
-
   it('Will transform multiple data series with the same label', () => {
     const series = [
       getTimeSeries('A', { instance: 'A', pod: 'B' }, [4, 2, 3]),
       getTimeSeries('B', { instance: 'A', pod: 'B' }, [3, 4, 5]),
       getTimeSeries('C', { instance: 'A', pod: 'B' }, [3, 4, 5]),
     ];
-  
+
     const results = timeSeriesToTableTransform({}, series);
-  
+
     // Check series A
     expect(results[0].fields).toHaveLength(3);
     expect(results[0].fields[0].values[0]).toBe('A');
     expect(results[0].fields[1].values[0]).toBe('B');
-  
+
     // Check series B
     expect(results[1].fields).toHaveLength(3);
     expect(results[1].fields[0].values[0]).toBe('A');
     expect(results[1].fields[1].values[0]).toBe('B');
-  
+
     // Check series C
     expect(results[2].fields).toHaveLength(3);
     expect(results[2].fields[0].values[0]).toBe('A');
     expect(results[2].fields[1].values[0]).toBe('B');
   });
-  
+
   it('will not transform frames with time fields that are non-timeseries', () => {
     const series = [
       getTimeSeries('A', { instance: 'A', pod: 'B' }, [4, 2, 3]),
       getNonTimeSeries('B', { instance: 'A', pod: 'B' }, [3, 4, 5]),
     ];
-  
+
     const results = timeSeriesToTableTransform({}, series);
-  
+
     // Expect the timeseries to be transformed
     // Having a trend field will show this
     expect(results[1].fields[2].name).toBe('Trend #A');
-  
+
     // We should expect the field length to remain at
     // 2 with a time field and a value field
     expect(results[0].fields.length).toBe(2);
   });
-  
+
   it('will not transform series that have the same value for all times', () => {
-    const series = [
-      getNonTimeSeries('A', { instance: 'A' }, [4, 2, 5], [1699476339, 1699476339, 1699476339]),
-    ];
+    const series = [getNonTimeSeries('A', { instance: 'A' }, [4, 2, 5], [1699476339, 1699476339, 1699476339])];
 
     const results = timeSeriesToTableTransform({}, series);
 
@@ -152,7 +149,7 @@ describe('timeSeriesTableTransformer', () => {
       refId: 'A',
       fields: [
         { name: 'Time', type: FieldType.time, values: [0, 50, 90] },
-        { name: 'UpdateTime', type: FieldType.time, values: [10, 100, 100]},
+        { name: 'UpdateTime', type: FieldType.time, values: [10, 100, 100] },
         {
           name: 'Value',
           type: FieldType.number,
@@ -161,10 +158,9 @@ describe('timeSeriesTableTransformer', () => {
       ],
     });
 
-
     const results = timeSeriesToTableTransform({}, [frame]);
 
-    // We should have a created trend field 
+    // We should have a created trend field
     // with the first time field used as a time
     // and the values coming along with that
     expect(results[0].fields[0].name).toBe('Trend #A');
@@ -177,7 +173,7 @@ describe('timeSeriesTableTransformer', () => {
       refId: 'A',
       fields: [
         { name: 'Time', type: FieldType.time, values: [0, 50, 90] },
-        { name: 'UpdateTime', type: FieldType.time, values: [10, 100, 100]},
+        { name: 'UpdateTime', type: FieldType.time, values: [10, 100, 100] },
         {
           name: 'Value',
           type: FieldType.number,
@@ -186,21 +182,16 @@ describe('timeSeriesTableTransformer', () => {
       ],
     });
 
+    const results = timeSeriesToTableTransform({ A: { timeField: 'UpdateTime' } }, [frame]);
 
-    const results = timeSeriesToTableTransform({A: { timeField: 'UpdateTime'} }, [frame]);
-
-    // We should have a created trend field 
+    // We should have a created trend field
     // with the "UpdateTime" time field used as a time
     // and the values coming along with that
     expect(results[0].fields[0].name).toBe('Trend #A');
     expect(results[0].fields[0].values[0].fields[0].values[0]).toBe(10);
     expect(results[0].fields[0].values[0].fields[1].values[0]).toBe(2);
   });
-
 });
-
-
-
 
 function assertFieldsEqual(field1: Field, field2: Field) {
   expect(field1.type).toEqual(field2.type);
@@ -236,16 +227,15 @@ function getTimeSeries(refId: string, labels: Labels, values: number[] = [10]) {
 
 function getNonTimeSeries(refId: string, labels: Labels, values: number[], times?: number[]) {
   if (times === undefined) {
-    times = [1699476339, 1699475339, 1699476300]
+    times = [1699476339, 1699475339, 1699476300];
   }
-
 
   return toDataFrame({
     refId,
     fields: [
       // These times are in non-ascending order
       // and thus this isn't a timeseries
-      { name: 'Time', type: FieldType.time, values: times},
+      { name: 'Time', type: FieldType.time, values: times },
       {
         name: 'Value',
         type: FieldType.number,

--- a/public/app/features/transformers/timeSeriesTable/timeSeriesTableTransformer.test.ts
+++ b/public/app/features/transformers/timeSeriesTable/timeSeriesTableTransformer.test.ts
@@ -119,6 +119,23 @@ it('Will transform multiple data series with the same label', () => {
   expect(results[2].fields[1].values[0]).toBe('B');
 });
 
+it('will not transform frames with time fields that are non-timeseries', () => {
+  const series = [
+    getTimeSeries('A', { instance: 'A', pod: 'B' }, [4, 2, 3]),
+    getNonTimeSeries('B', { instance: 'A', pod: 'B' }, [3, 4, 5]),
+  ];
+
+  const results = timeSeriesToTableTransform({}, series);
+
+  // Expect the timeseries to be transformed
+  // Having a trend field will show this
+  expect(results[1].fields[2].name).toBe('Trend #A');
+
+  // We should expect the field length to remain at
+  // 2 with a time field and a value field
+  expect(results[0].fields.length).toBe(2);
+});
+
 function assertFieldsEqual(field1: Field, field2: Field) {
   expect(field1.type).toEqual(field2.type);
   expect(field1.name).toEqual(field2.name);
@@ -141,6 +158,23 @@ function getTimeSeries(refId: string, labels: Labels, values: number[] = [10]) {
     refId,
     fields: [
       { name: 'Time', type: FieldType.time, values: [10] },
+      {
+        name: 'Value',
+        type: FieldType.number,
+        values,
+        labels,
+      },
+    ],
+  });
+}
+
+function getNonTimeSeries(refId: string, labels: Labels, values: Array<number>) {
+  return toDataFrame({
+    refId,
+    fields: [
+      // These times are in non-ascending order
+      // and thus this isn't a timeseries
+      { name: 'Time', type: FieldType.time, values: [1699476339, 1699475339, 1699476300] },
       {
         name: 'Value',
         type: FieldType.number,

--- a/public/app/features/transformers/timeSeriesTable/timeSeriesTableTransformer.test.ts
+++ b/public/app/features/transformers/timeSeriesTable/timeSeriesTableTransformer.test.ts
@@ -92,49 +92,115 @@ describe('timeSeriesTableTransformer', () => {
     expect(results[0].fields[2].values[0].value).toEqual(3);
     expect(results[1].fields[2].values[0].value).toEqual(4);
   });
+
+
+  it('Will transform multiple data series with the same label', () => {
+    const series = [
+      getTimeSeries('A', { instance: 'A', pod: 'B' }, [4, 2, 3]),
+      getTimeSeries('B', { instance: 'A', pod: 'B' }, [3, 4, 5]),
+      getTimeSeries('C', { instance: 'A', pod: 'B' }, [3, 4, 5]),
+    ];
+  
+    const results = timeSeriesToTableTransform({}, series);
+  
+    // Check series A
+    expect(results[0].fields).toHaveLength(3);
+    expect(results[0].fields[0].values[0]).toBe('A');
+    expect(results[0].fields[1].values[0]).toBe('B');
+  
+    // Check series B
+    expect(results[1].fields).toHaveLength(3);
+    expect(results[1].fields[0].values[0]).toBe('A');
+    expect(results[1].fields[1].values[0]).toBe('B');
+  
+    // Check series C
+    expect(results[2].fields).toHaveLength(3);
+    expect(results[2].fields[0].values[0]).toBe('A');
+    expect(results[2].fields[1].values[0]).toBe('B');
+  });
+  
+  it('will not transform frames with time fields that are non-timeseries', () => {
+    const series = [
+      getTimeSeries('A', { instance: 'A', pod: 'B' }, [4, 2, 3]),
+      getNonTimeSeries('B', { instance: 'A', pod: 'B' }, [3, 4, 5]),
+    ];
+  
+    const results = timeSeriesToTableTransform({}, series);
+  
+    // Expect the timeseries to be transformed
+    // Having a trend field will show this
+    expect(results[1].fields[2].name).toBe('Trend #A');
+  
+    // We should expect the field length to remain at
+    // 2 with a time field and a value field
+    expect(results[0].fields.length).toBe(2);
+  });
+  
+  it('will not transform series that have the same value for all times', () => {
+    const series = [
+      getNonTimeSeries('A', { instance: 'A' }, [4, 2, 5], [1699476339, 1699476339, 1699476339]),
+    ];
+
+    const results = timeSeriesToTableTransform({}, series);
+
+    expect(results[0].fields[0].values[0]).toBe(1699476339);
+    expect(results[0].fields[1].values[0]).toBe(4);
+  });
+
+  it('will transform a series with two time fields', () => {
+    const frame = toDataFrame({
+      refId: 'A',
+      fields: [
+        { name: 'Time', type: FieldType.time, values: [0, 50, 90] },
+        { name: 'UpdateTime', type: FieldType.time, values: [10, 100, 100]},
+        {
+          name: 'Value',
+          type: FieldType.number,
+          values: [2, 3, 4],
+        },
+      ],
+    });
+
+
+    const results = timeSeriesToTableTransform({}, [frame]);
+
+    // We should have a created trend field 
+    // with the first time field used as a time
+    // and the values coming along with that
+    expect(results[0].fields[0].name).toBe('Trend #A');
+    expect(results[0].fields[0].values[0].fields[0].values[0]).toBe(0);
+    expect(results[0].fields[0].values[0].fields[1].values[0]).toBe(2);
+  });
+
+  it('will transform a series with two time fields and a time field configured', () => {
+    const frame = toDataFrame({
+      refId: 'A',
+      fields: [
+        { name: 'Time', type: FieldType.time, values: [0, 50, 90] },
+        { name: 'UpdateTime', type: FieldType.time, values: [10, 100, 100]},
+        {
+          name: 'Value',
+          type: FieldType.number,
+          values: [2, 3, 4],
+        },
+      ],
+    });
+
+
+    const results = timeSeriesToTableTransform({A: { timeField: 'UpdateTime'} }, [frame]);
+
+    // We should have a created trend field 
+    // with the "UpdateTime" time field used as a time
+    // and the values coming along with that
+    expect(results[0].fields[0].name).toBe('Trend #A');
+    expect(results[0].fields[0].values[0].fields[0].values[0]).toBe(10);
+    expect(results[0].fields[0].values[0].fields[1].values[0]).toBe(2);
+  });
+
 });
 
-it('Will transform multiple data series with the same label', () => {
-  const series = [
-    getTimeSeries('A', { instance: 'A', pod: 'B' }, [4, 2, 3]),
-    getTimeSeries('B', { instance: 'A', pod: 'B' }, [3, 4, 5]),
-    getTimeSeries('C', { instance: 'A', pod: 'B' }, [3, 4, 5]),
-  ];
 
-  const results = timeSeriesToTableTransform({}, series);
 
-  // Check series A
-  expect(results[0].fields).toHaveLength(3);
-  expect(results[0].fields[0].values[0]).toBe('A');
-  expect(results[0].fields[1].values[0]).toBe('B');
-
-  // Check series B
-  expect(results[1].fields).toHaveLength(3);
-  expect(results[1].fields[0].values[0]).toBe('A');
-  expect(results[1].fields[1].values[0]).toBe('B');
-
-  // Check series C
-  expect(results[2].fields).toHaveLength(3);
-  expect(results[2].fields[0].values[0]).toBe('A');
-  expect(results[2].fields[1].values[0]).toBe('B');
-});
-
-it('will not transform frames with time fields that are non-timeseries', () => {
-  const series = [
-    getTimeSeries('A', { instance: 'A', pod: 'B' }, [4, 2, 3]),
-    getNonTimeSeries('B', { instance: 'A', pod: 'B' }, [3, 4, 5]),
-  ];
-
-  const results = timeSeriesToTableTransform({}, series);
-
-  // Expect the timeseries to be transformed
-  // Having a trend field will show this
-  expect(results[1].fields[2].name).toBe('Trend #A');
-
-  // We should expect the field length to remain at
-  // 2 with a time field and a value field
-  expect(results[0].fields.length).toBe(2);
-});
 
 function assertFieldsEqual(field1: Field, field2: Field) {
   expect(field1.type).toEqual(field2.type);
@@ -168,13 +234,18 @@ function getTimeSeries(refId: string, labels: Labels, values: number[] = [10]) {
   });
 }
 
-function getNonTimeSeries(refId: string, labels: Labels, values: Array<number>) {
+function getNonTimeSeries(refId: string, labels: Labels, values: number[], times?: number[]) {
+  if (times === undefined) {
+    times = [1699476339, 1699475339, 1699476300]
+  }
+
+
   return toDataFrame({
     refId,
     fields: [
       // These times are in non-ascending order
       // and thus this isn't a timeseries
-      { name: 'Time', type: FieldType.time, values: [1699476339, 1699475339, 1699476300] },
+      { name: 'Time', type: FieldType.time, values: times},
       {
         name: 'Value',
         type: FieldType.number,

--- a/public/app/features/transformers/timeSeriesTable/timeSeriesTableTransformer.ts
+++ b/public/app/features/transformers/timeSeriesTable/timeSeriesTableTransformer.ts
@@ -12,6 +12,7 @@ import {
   ReducerID,
   reduceField,
   TransformationApplicabilityLevels,
+  isTimeSeriesField,
 } from '@grafana/data';
 
 /**
@@ -148,15 +149,16 @@ export function timeSeriesToTableTransform(options: TimeSeriesTableTransformerOp
       // Retrieve the time field that's been configured
       // If one isn't configured then use the first found
       let timeField = null;
-      if (options[refId]?.timeField !== undefined) {
-        timeField = frame.fields.find((field) => field.name === options[refId]?.timeField);
+      let timeFieldName = options[refId]?.timeField;
+      if (timeFieldName && timeFieldName.length > 0) {
+        timeField = frame.fields.find((field) => field.name === timeFieldName);
       } else {
-        timeField = frame.fields.find((field) => field.type === FieldType.time);
+        timeField = frame.fields.find((field) => isTimeSeriesField(field));
       }
 
       // If it's not a time series frame we add
       // it unmodified to the result
-      if (!isTimeSeriesFrame(frame, timeField)) {
+      if (!isTimeSeriesFrame(frame)) {
         result.push(frame);
         continue;
       }

--- a/public/app/features/transformers/timeSeriesTable/timeSeriesTableTransformer.ts
+++ b/public/app/features/transformers/timeSeriesTable/timeSeriesTableTransformer.ts
@@ -145,13 +145,6 @@ export function timeSeriesToTableTransform(options: TimeSeriesTableTransformerOp
     for (let i = 0; i < framesForRef.length; i++) {
       const frame = framesForRef[i];
 
-      // If it's not a time series frame we add
-      // it unmodified to the result
-      if (!isTimeSeriesFrame(frame)) {
-        result.push(frame);
-        continue;
-      }
-
       // Retrieve the time field that's been configured
       // If one isn't configured then use the first found
       let timeField = null;
@@ -159,6 +152,13 @@ export function timeSeriesToTableTransform(options: TimeSeriesTableTransformerOp
         timeField = frame.fields.find((field) => field.name === options[refId]?.timeField);
       } else {
         timeField = frame.fields.find((field) => field.type === FieldType.time);
+      }
+
+      // If it's not a time series frame we add
+      // it unmodified to the result
+      if (!isTimeSeriesFrame(frame, timeField)) {
+        result.push(frame);
+        continue;
       }
 
       for (const field of frame.fields) {


### PR DESCRIPTION
**What is this feature?**

This PR improves the detection of time series in the _Timeseries to table_ transformation. Previously, the transformation had assumed that any frame with greater than two fields to be non-timeseries. Unfortunately, this prevents a fair number of datasources from being used as the source of timeseries data (e.g. SQL databases often have multiple time and value fields returned that constitute multiple time series). 

However, the conditions we added failed to take into account queries with time fields that aren't in increasing value, i.e. Prometheus instant queries will return a single time, so this would break output in that case. This updates to ensure that each time is greater than the one before it, thus ensuring that the times are in ascending order.

Leaving this in draft to add tests for this.

**Why do we need this feature?**

This makes our time series detection better in the Timeseries to table transformation, allowing it be used under a wider array of conditions.


Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
