### PR TITLE
Plugins: Add grafana/user/profile/tab plugin extension point

### DIFF
--- a/packages/grafana-data/src/types/pluginExtensions.ts
+++ b/packages/grafana-data/src/types/pluginExtensions.ts
@@ -120,6 +120,7 @@ export enum PluginExtensionPoints {
   DashboardPanelMenu = 'grafana/dashboard/panel/menu',
   DataSourceConfig = 'grafana/datasources/config',
   ExploreToolbarAction = 'grafana/explore/toolbar/action',
+  UserProfileSettings = 'grafana/user/profile/settings',
 }
 
 export type PluginExtensionPanelContext = {

--- a/packages/grafana-data/src/types/pluginExtensions.ts
+++ b/packages/grafana-data/src/types/pluginExtensions.ts
@@ -120,7 +120,7 @@ export enum PluginExtensionPoints {
   DashboardPanelMenu = 'grafana/dashboard/panel/menu',
   DataSourceConfig = 'grafana/datasources/config',
   ExploreToolbarAction = 'grafana/explore/toolbar/action',
-  UserProfileSettings = 'grafana/user/profile/settings',
+  UserProfileTab = 'grafana/user/profile/tab',
 }
 
 export type PluginExtensionPanelContext = {

--- a/packages/grafana-e2e-selectors/src/selectors/components.ts
+++ b/packages/grafana-e2e-selectors/src/selectors/components.ts
@@ -414,6 +414,8 @@ export const Components = {
     preferencesSaveButton: 'data-testid-shared-prefs-save',
     orgsTable: 'data-testid-user-orgs-table',
     sessionsTable: 'data-testid-user-sessions-table',
+    extensionPointTabs: 'data-testid-extension-point-tabs',
+    extensionPointTab: (tabTitle: string) => `data-testid-extension-point-tab-${tabTitle}`,
   },
   FileUpload: {
     inputField: 'data-testid-file-upload-input-field',

--- a/packages/grafana-e2e-selectors/src/selectors/components.ts
+++ b/packages/grafana-e2e-selectors/src/selectors/components.ts
@@ -415,7 +415,7 @@ export const Components = {
     orgsTable: 'data-testid-user-orgs-table',
     sessionsTable: 'data-testid-user-sessions-table',
     extensionPointTabs: 'data-testid-extension-point-tabs',
-    extensionPointTab: (tabTitle: string) => `data-testid-extension-point-tab-${tabTitle}`,
+    extensionPointTab: (tabId: string) => `data-testid-extension-point-tab-${tabId}`,
   },
   FileUpload: {
     inputField: 'data-testid-file-upload-input-field',

--- a/public/app/features/profile/UserProfileEditPage.test.tsx
+++ b/public/app/features/profile/UserProfileEditPage.test.tsx
@@ -117,30 +117,47 @@ function getSelectors() {
   };
 }
 
+enum ExtensionPointComponentId {
+  One = '1',
+  Two = '2',
+  Three = '3',
+}
+
 enum ExtensionPointComponentTabs {
   One = '1',
   Two = '2',
 }
 
 const _createTabName = (tab: ExtensionPointComponentTabs) => `Tab ${tab}`;
+const _createTabContent = (tabId: ExtensionPointComponentId) => `this is settings for component ${tabId}`;
+
 const tabOneName = _createTabName(ExtensionPointComponentTabs.One);
 const tabTwoName = _createTabName(ExtensionPointComponentTabs.Two);
 
 const _createPluginExtensionPointComponent = (
-  id: string,
+  id: ExtensionPointComponentId,
   tab: ExtensionPointComponentTabs
 ): PluginExtensionComponent => ({
   id,
   type: PluginExtensionTypes.component,
   title: _createTabName(tab),
   description: '', // description isn't used here..
-  component: () => <p>{`this is settings for component ${id}`}</p>,
+  component: () => <p>{_createTabContent(id)}</p>,
   pluginId: 'grafana-plugin',
 });
 
-const PluginExtensionPointComponent1 = _createPluginExtensionPointComponent('1', ExtensionPointComponentTabs.One);
-const PluginExtensionPointComponent2 = _createPluginExtensionPointComponent('2', ExtensionPointComponentTabs.One);
-const PluginExtensionPointComponent3 = _createPluginExtensionPointComponent('3', ExtensionPointComponentTabs.Two);
+const PluginExtensionPointComponent1 = _createPluginExtensionPointComponent(
+  ExtensionPointComponentId.One,
+  ExtensionPointComponentTabs.One
+);
+const PluginExtensionPointComponent2 = _createPluginExtensionPointComponent(
+  ExtensionPointComponentId.Two,
+  ExtensionPointComponentTabs.One
+);
+const PluginExtensionPointComponent3 = _createPluginExtensionPointComponent(
+  ExtensionPointComponentId.Three,
+  ExtensionPointComponentTabs.Two
+);
 
 async function getTestContext(overrides: Partial<Props & { extensions: PluginExtensionComponent[] }> = {}) {
   const extensions = overrides.extensions || [];
@@ -310,6 +327,12 @@ describe('UserProfileEditPage', () => {
     });
 
     describe('and a plugin registers a component against the user profile settings extension point', () => {
+      const extensions = [
+        PluginExtensionPointComponent1,
+        PluginExtensionPointComponent2,
+        PluginExtensionPointComponent3,
+      ];
+
       it('should not show tabs when no components are registered', async () => {
         await getTestContext();
         const { extensionPointTabs } = getSelectors();
@@ -317,10 +340,7 @@ describe('UserProfileEditPage', () => {
       });
 
       it('should group registered components into tabs', async () => {
-        await getTestContext({
-          extensions: [PluginExtensionPointComponent1, PluginExtensionPointComponent2, PluginExtensionPointComponent3],
-        });
-
+        await getTestContext({ extensions });
         const { extensionPointTabs, extensionPointTab } = getSelectors();
 
         const _assertTab = (tabName: string, isDefault = false) => {
@@ -333,6 +353,44 @@ describe('UserProfileEditPage', () => {
         _assertTab('Core', true);
         _assertTab(tabOneName);
         _assertTab(tabTwoName);
+      });
+
+      it('should change the active tab when a tab is clicked and update the "tab" query param', async () => {
+        const mockUpdateQueryParams = jest.fn();
+        mockUseQueryParams.useQueryParams = () => [{}, mockUpdateQueryParams];
+
+        await getTestContext({ extensions });
+        const { extensionPointTab } = getSelectors();
+
+        /**
+         * Tab one has two extension components registered against it, they'll both be registered in the same tab
+         * Tab two only has one extension component registered against it.
+         */
+        const tabOneContent1 = _createTabContent(ExtensionPointComponentId.One);
+        const tabOneContent2 = _createTabContent(ExtensionPointComponentId.Two);
+        const tabTwoContent = _createTabContent(ExtensionPointComponentId.Three);
+
+        // core should be the default content
+        expect(screen.queryByText(tabOneContent1)).toBeNull();
+        expect(screen.queryByText(tabOneContent2)).toBeNull();
+        expect(screen.queryByText(tabTwoContent)).toBeNull();
+
+        await userEvent.click(extensionPointTab(tabOneName));
+
+        expect(mockUpdateQueryParams).toHaveBeenCalledTimes(1);
+        expect(mockUpdateQueryParams).toHaveBeenCalledWith({ tab: tabOneName.toLowerCase() });
+        expect(screen.queryByText(tabOneContent1)).not.toBeNull();
+        expect(screen.queryByText(tabOneContent2)).not.toBeNull();
+        expect(screen.queryByText(tabTwoContent)).toBeNull();
+
+        mockUpdateQueryParams.mockClear();
+        await userEvent.click(extensionPointTab(tabTwoName));
+
+        expect(mockUpdateQueryParams).toHaveBeenCalledTimes(1);
+        expect(mockUpdateQueryParams).toHaveBeenCalledWith({ tab: tabTwoName.toLowerCase() });
+        expect(screen.queryByText(tabOneContent1)).toBeNull();
+        expect(screen.queryByText(tabOneContent2)).toBeNull();
+        expect(screen.queryByText(tabTwoContent)).not.toBeNull();
       });
 
       it.each([tabOneName, tabOneName.toUpperCase(), tabOneName.toLowerCase()])(

--- a/public/app/features/profile/UserProfileEditPage.test.tsx
+++ b/public/app/features/profile/UserProfileEditPage.test.tsx
@@ -131,7 +131,7 @@ enum ExtensionPointComponentTabs {
 const _createTabName = (tab: ExtensionPointComponentTabs) => `Tab ${tab}`;
 const _createTabContent = (tabId: ExtensionPointComponentId) => `this is settings for component ${tabId}`;
 
-const coreTabName = 'Core';
+const generalTabName = 'General';
 const tabOneName = _createTabName(ExtensionPointComponentTabs.One);
 const tabTwoName = _createTabName(ExtensionPointComponentTabs.Two);
 
@@ -351,7 +351,7 @@ describe('UserProfileEditPage', () => {
         };
 
         expect(extensionPointTabs()).toBeInTheDocument();
-        _assertTab(coreTabName.toLowerCase(), true);
+        _assertTab(generalTabName.toLowerCase(), true);
         _assertTab(tabOneName.toLowerCase());
         _assertTab(tabTwoName.toLowerCase());
       });
@@ -371,7 +371,7 @@ describe('UserProfileEditPage', () => {
         const tabOneContent2 = _createTabContent(ExtensionPointComponentId.Two);
         const tabTwoContent = _createTabContent(ExtensionPointComponentId.Three);
 
-        // core should be the default content
+        // "General" should be the default content
         expect(screen.queryByText(tabOneContent1)).toBeNull();
         expect(screen.queryByText(tabOneContent2)).toBeNull();
         expect(screen.queryByText(tabTwoContent)).toBeNull();

--- a/public/app/features/profile/UserProfileEditPage.test.tsx
+++ b/public/app/features/profile/UserProfileEditPage.test.tsx
@@ -110,9 +110,9 @@ function getSelectors() {
     /**
      * here lets use getByTestId because a specific tab should always be rendered within the tabs container
      */
-    extensionPointTab: (tabTitle: string) =>
+    extensionPointTab: (tabId: string) =>
       within(screen.getByTestId(selectors.components.UserProfile.extensionPointTabs)).getByTestId(
-        selectors.components.UserProfile.extensionPointTab(tabTitle)
+        selectors.components.UserProfile.extensionPointTab(tabId)
       ),
   };
 }
@@ -131,6 +131,7 @@ enum ExtensionPointComponentTabs {
 const _createTabName = (tab: ExtensionPointComponentTabs) => `Tab ${tab}`;
 const _createTabContent = (tabId: ExtensionPointComponentId) => `this is settings for component ${tabId}`;
 
+const coreTabName = 'Core';
 const tabOneName = _createTabName(ExtensionPointComponentTabs.One);
 const tabTwoName = _createTabName(ExtensionPointComponentTabs.Two);
 
@@ -343,16 +344,16 @@ describe('UserProfileEditPage', () => {
         await getTestContext({ extensions });
         const { extensionPointTabs, extensionPointTab } = getSelectors();
 
-        const _assertTab = (tabName: string, isDefault = false) => {
-          const tab = extensionPointTab(tabName);
+        const _assertTab = (tabId: string, isDefault = false) => {
+          const tab = extensionPointTab(tabId);
           expect(tab).toBeInTheDocument();
           expect(tab).toHaveAttribute('aria-selected', isDefault.toString());
         };
 
         expect(extensionPointTabs()).toBeInTheDocument();
-        _assertTab('Core', true);
-        _assertTab(tabOneName);
-        _assertTab(tabTwoName);
+        _assertTab(coreTabName.toLowerCase(), true);
+        _assertTab(tabOneName.toLowerCase());
+        _assertTab(tabTwoName.toLowerCase());
       });
 
       it('should change the active tab when a tab is clicked and update the "tab" query param', async () => {
@@ -375,7 +376,7 @@ describe('UserProfileEditPage', () => {
         expect(screen.queryByText(tabOneContent2)).toBeNull();
         expect(screen.queryByText(tabTwoContent)).toBeNull();
 
-        await userEvent.click(extensionPointTab(tabOneName));
+        await userEvent.click(extensionPointTab(tabOneName.toLowerCase()));
 
         expect(mockUpdateQueryParams).toHaveBeenCalledTimes(1);
         expect(mockUpdateQueryParams).toHaveBeenCalledWith({ tab: tabOneName.toLowerCase() });
@@ -384,7 +385,7 @@ describe('UserProfileEditPage', () => {
         expect(screen.queryByText(tabTwoContent)).toBeNull();
 
         mockUpdateQueryParams.mockClear();
-        await userEvent.click(extensionPointTab(tabTwoName));
+        await userEvent.click(extensionPointTab(tabTwoName.toLowerCase()));
 
         expect(mockUpdateQueryParams).toHaveBeenCalledTimes(1);
         expect(mockUpdateQueryParams).toHaveBeenCalledWith({ tab: tabTwoName.toLowerCase() });
@@ -392,32 +393,6 @@ describe('UserProfileEditPage', () => {
         expect(screen.queryByText(tabOneContent2)).toBeNull();
         expect(screen.queryByText(tabTwoContent)).not.toBeNull();
       });
-
-      it.each([tabOneName, tabOneName.toUpperCase(), tabOneName.toLowerCase()])(
-        'should set the active tab based on the "tab" query param and be case-insensitive',
-        async (tabQueryParam) => {
-          mockUseQueryParams.useQueryParams = () => [{ tab: tabQueryParam }, () => {}];
-
-          await getTestContext({
-            extensions: [
-              PluginExtensionPointComponent1,
-              PluginExtensionPointComponent2,
-              PluginExtensionPointComponent3,
-            ],
-          });
-
-          const { extensionPointTab } = getSelectors();
-
-          const _assertTab = (tabName: string, isDefault = false) => {
-            const tab = extensionPointTab(tabName);
-            expect(tab).toBeInTheDocument();
-            expect(tab).toHaveAttribute('aria-selected', isDefault.toString());
-          };
-
-          _assertTab('Core');
-          _assertTab(tabOneName, true);
-        }
-      );
     });
   });
 });

--- a/public/app/features/profile/UserProfileEditPage.tsx
+++ b/public/app/features/profile/UserProfileEditPage.tsx
@@ -4,6 +4,7 @@ import { connect, ConnectedProps } from 'react-redux';
 import { useMount } from 'react-use';
 
 import { PluginExtensionComponent, PluginExtensionPoints } from '@grafana/data';
+import { selectors } from '@grafana/e2e-selectors';
 import { getPluginComponentExtensions } from '@grafana/runtime';
 import { Tab, TabsBar, TabContent, VerticalGroup } from '@grafana/ui';
 import { Page } from 'app/core/components/Page/Page';
@@ -16,7 +17,7 @@ import UserSessions from './UserSessions';
 import { UserTeams } from './UserTeams';
 import { changeUserOrg, initUserProfilePage, revokeUserSession, updateUserProfile } from './state/actions';
 
-const CORE_SETTINGS_TAB = 'Core Settings';
+const CORE_SETTINGS_TAB = 'Core';
 
 export interface OwnProps {}
 
@@ -103,41 +104,42 @@ export function UserProfileEditPage({
     </VerticalGroup>
   );
 
+  const UserProfileWithTabs = () => (
+    <div data-testid={selectors.components.UserProfile.extensionPointTabs}>
+      <VerticalGroup spacing="md">
+        <TabsBar>
+          {tabs.map((tabTitle) => (
+            <Tab
+              key={tabTitle}
+              label={tabTitle}
+              active={activeTab === tabTitle}
+              onChangeTab={() => setActiveTab(tabTitle)}
+              data-testid={selectors.components.UserProfile.extensionPointTab(tabTitle)}
+            />
+          ))}
+        </TabsBar>
+        <TabContent>
+          {activeTab === CORE_SETTINGS_TAB && <UserProfile />}
+          {toPairs(groupedExtensionComponents).map(([title, pluginExtensionComponents]) => {
+            if (activeTab === title) {
+              return (
+                <React.Fragment key={title}>
+                  {pluginExtensionComponents.map(({ component: Component }, index) => (
+                    <Component key={`${title}-${index}`} />
+                  ))}
+                </React.Fragment>
+              );
+            }
+            return null;
+          })}
+        </TabContent>
+      </VerticalGroup>
+    </div>
+  );
+
   return (
     <Page navId="profile/settings">
-      <Page.Contents isLoading={!user}>
-        {showTabs ? (
-          <VerticalGroup spacing="md">
-            <TabsBar>
-              {tabs.map((tabTitle) => (
-                <Tab
-                  key={tabTitle}
-                  label={tabTitle}
-                  active={activeTab === tabTitle}
-                  onChangeTab={() => setActiveTab(tabTitle)}
-                />
-              ))}
-            </TabsBar>
-            <TabContent>
-              {activeTab === CORE_SETTINGS_TAB && <UserProfile />}
-              {toPairs(groupedExtensionComponents).map(([title, pluginExtensionComponents]) => {
-                if (activeTab === title) {
-                  return (
-                    <React.Fragment key={title}>
-                      {pluginExtensionComponents.map(({ component: Component }, index) => (
-                        <Component key={`${title}-${index}`} />
-                      ))}
-                    </React.Fragment>
-                  );
-                }
-                return null;
-              })}
-            </TabContent>
-          </VerticalGroup>
-        ) : (
-          <UserProfile />
-        )}
-      </Page.Contents>
+      <Page.Contents isLoading={!user}>{showTabs ? <UserProfileWithTabs /> : <UserProfile />}</Page.Contents>
     </Page>
   );
 }

--- a/public/app/features/profile/UserProfileEditPage.tsx
+++ b/public/app/features/profile/UserProfileEditPage.tsx
@@ -73,7 +73,7 @@ export function UserProfileEditPage({
 
   const extensionComponents = useMemo(() => {
     const { extensions } = getPluginComponentExtensions({
-      extensionPointId: PluginExtensionPoints.UserProfileSettings,
+      extensionPointId: PluginExtensionPoints.UserProfileTab,
       context: {},
     });
 

--- a/public/app/features/profile/UserProfileEditPage.tsx
+++ b/public/app/features/profile/UserProfileEditPage.tsx
@@ -60,6 +60,10 @@ export function UserProfileEditPage({
   changeUserOrg,
   updateUserProfile,
 }: Props) {
+  /**
+   * TODO: a nice thing to have would be the ability to read the active tab initial state from a URL
+   * query param. This would allow users to link to a specific tab in the user profile page.
+   */
   const [activeTab, setActiveTab] = useState<string>(CORE_SETTINGS_TAB);
 
   useMount(() => initUserProfilePage());

--- a/public/app/features/profile/UserProfileEditPage.tsx
+++ b/public/app/features/profile/UserProfileEditPage.tsx
@@ -1,7 +1,9 @@
-import React from 'react';
+import React, { useMemo } from 'react';
 import { connect, ConnectedProps } from 'react-redux';
 import { useMount } from 'react-use';
 
+import { PluginExtensionPoints } from '@grafana/data';
+import { getPluginComponentExtensions } from '@grafana/runtime';
 import { VerticalGroup } from '@grafana/ui';
 import { Page } from 'app/core/components/Page/Page';
 import SharedPreferences from 'app/core/components/SharedPreferences/SharedPreferences';
@@ -57,6 +59,16 @@ export function UserProfileEditPage({
 }: Props) {
   useMount(() => initUserProfilePage());
 
+  const extensionComponents = useMemo(() => {
+    const { extensions } = getPluginComponentExtensions({
+      extensionPointId: PluginExtensionPoints.UserProfileSettings,
+      context: {},
+      limitPerPlugin: 3,
+    });
+
+    return extensions;
+  }, []);
+
   return (
     <Page navId="profile/settings">
       <Page.Contents isLoading={!user}>
@@ -66,6 +78,9 @@ export function UserProfileEditPage({
           <UserTeams isLoading={teamsAreLoading} teams={teams} />
           <UserOrganizations isLoading={orgsAreLoading} setUserOrg={changeUserOrg} orgs={orgs} user={user} />
           <UserSessions isLoading={sessionsAreLoading} revokeUserSession={revokeUserSession} sessions={sessions} />
+          {extensionComponents.map(({ component: Component }, index) => (
+            <Component key={index} />
+          ))}
         </VerticalGroup>
       </Page.Contents>
     </Page>

--- a/public/app/features/profile/UserProfileEditPage.tsx
+++ b/public/app/features/profile/UserProfileEditPage.tsx
@@ -19,7 +19,7 @@ import { UserTeams } from './UserTeams';
 import { changeUserOrg, initUserProfilePage, revokeUserSession, updateUserProfile } from './state/actions';
 
 const TAB_QUERY_PARAM = 'tab';
-const CORE_SETTINGS_TAB = 'core';
+const GENERAL_SETTINGS_TAB = 'general';
 
 type TabInfo = {
   id: string;
@@ -71,7 +71,7 @@ export function UserProfileEditPage({
   const [queryParams, updateQueryParams] = useQueryParams();
   const tabQueryParam = queryParams[TAB_QUERY_PARAM];
   const [activeTab, setActiveTab] = useState<string>(
-    typeof tabQueryParam === 'string' ? tabQueryParam : CORE_SETTINGS_TAB
+    typeof tabQueryParam === 'string' ? tabQueryParam : GENERAL_SETTINGS_TAB
   );
 
   useMount(() => initUserProfilePage());
@@ -103,8 +103,8 @@ export function UserProfileEditPage({
   const showTabs = extensionComponents.length > 0;
   const tabs: TabInfo[] = [
     {
-      id: CORE_SETTINGS_TAB,
-      title: t('user-profile.tabs.core', 'Core'),
+      id: GENERAL_SETTINGS_TAB,
+      title: t('user-profile.tabs.general', 'General'),
     },
     ...Object.keys(groupedExtensionComponents).map((title) => ({
       id: convertExtensionComponentTitleToTabId(title),
@@ -142,7 +142,7 @@ export function UserProfileEditPage({
           })}
         </TabsBar>
         <TabContent>
-          {activeTab === CORE_SETTINGS_TAB && <UserProfile />}
+          {activeTab === GENERAL_SETTINGS_TAB && <UserProfile />}
           {Object.entries(groupedExtensionComponents).map(([title, pluginExtensionComponents]) => {
             const tabId = convertExtensionComponentTitleToTabId(title);
 

--- a/public/locales/de-DE/grafana.json
+++ b/public/locales/de-DE/grafana.json
@@ -1216,6 +1216,9 @@
       "name-error": "Name ist erforderlich",
       "name-label": "Name",
       "username-label": "Benutzername"
+    },
+    "tabs": {
+      "core": ""
     }
   },
   "user-session": {

--- a/public/locales/de-DE/grafana.json
+++ b/public/locales/de-DE/grafana.json
@@ -1218,7 +1218,7 @@
       "username-label": "Benutzername"
     },
     "tabs": {
-      "core": ""
+      "general": ""
     }
   },
   "user-session": {

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -1218,7 +1218,7 @@
       "username-label": "Username"
     },
     "tabs": {
-      "core": "Core"
+      "general": "General"
     }
   },
   "user-session": {

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -1216,6 +1216,9 @@
       "name-error": "Name is required",
       "name-label": "Name",
       "username-label": "Username"
+    },
+    "tabs": {
+      "core": "Core"
     }
   },
   "user-session": {

--- a/public/locales/es-ES/grafana.json
+++ b/public/locales/es-ES/grafana.json
@@ -1224,7 +1224,7 @@
       "username-label": "Nombre de usuario"
     },
     "tabs": {
-      "core": ""
+      "general": ""
     }
   },
   "user-session": {

--- a/public/locales/es-ES/grafana.json
+++ b/public/locales/es-ES/grafana.json
@@ -1222,6 +1222,9 @@
       "name-error": "El nombre es obligatorio",
       "name-label": "Nombre",
       "username-label": "Nombre de usuario"
+    },
+    "tabs": {
+      "core": ""
     }
   },
   "user-session": {

--- a/public/locales/fr-FR/grafana.json
+++ b/public/locales/fr-FR/grafana.json
@@ -1224,7 +1224,7 @@
       "username-label": "Nom d’utilisateur"
     },
     "tabs": {
-      "core": ""
+      "general": ""
     }
   },
   "user-session": {

--- a/public/locales/fr-FR/grafana.json
+++ b/public/locales/fr-FR/grafana.json
@@ -1222,6 +1222,9 @@
       "name-error": "Un nom est obligatoire",
       "name-label": "Nom",
       "username-label": "Nom d’utilisateur"
+    },
+    "tabs": {
+      "core": ""
     }
   },
   "user-session": {

--- a/public/locales/pseudo-LOCALE/grafana.json
+++ b/public/locales/pseudo-LOCALE/grafana.json
@@ -1218,7 +1218,7 @@
       "username-label": "Ůşęřŉämę"
     },
     "tabs": {
-      "core": "Cőřę"
+      "general": "Ğęŉęřäľ"
     }
   },
   "user-session": {

--- a/public/locales/pseudo-LOCALE/grafana.json
+++ b/public/locales/pseudo-LOCALE/grafana.json
@@ -1216,6 +1216,9 @@
       "name-error": "Ńämę įş řęqūįřęđ",
       "name-label": "Ńämę",
       "username-label": "Ůşęřŉämę"
+    },
+    "tabs": {
+      "core": "Cőřę"
     }
   },
   "user-session": {

--- a/public/locales/zh-Hans/grafana.json
+++ b/public/locales/zh-Hans/grafana.json
@@ -1212,7 +1212,7 @@
       "username-label": "用户名"
     },
     "tabs": {
-      "core": ""
+      "general": ""
     }
   },
   "user-session": {

--- a/public/locales/zh-Hans/grafana.json
+++ b/public/locales/zh-Hans/grafana.json
@@ -1210,6 +1210,9 @@
       "name-error": "姓名是必填项",
       "name-label": "姓名",
       "username-label": "用户名"
+    },
+    "tabs": {
+      "core": ""
     }
   },
   "user-session": {


### PR DESCRIPTION
**What is this feature?**

This PR adds a new plugin component extension point, `grafana/user/profile/tab`, allowing plugins to render content on the `/profile`.
- If no plugins have registered components against this extension point, the profile page is unchanged
- If at least one plugin has registered a component, tabs are shown at the top of the page. `Core` is the default tab and represents the pre-existing settings. The remaining tab(s) are dependant based on what plugin(s) have registered against this extension point. For example, the following code within a plugin would result in this:
```tsx
const extensionPointId = 'grafana/user/profile/settings';

const IRMSettingsTabTitle = 'IRM';
const OnCallSettingsTabTitle = 'OnCall';

plugin.configureExtensionComponent({
  title: IRMSettingsTabTitle,
  description: "", // not used with this extension point, but required by the TS type
  extensionPointId,
  component: MobileAppConnectionQRCode,
});

plugin.configureExtensionComponent({
  title: IRMSettingsTabTitle,
  description: "", // not used with this extension point, but required by the TS type
  extensionPointId,
  component: SomeMoreIRMSettings,
});

plugin.configureExtensionComponent({
  title: OnCallSettingsTabTitle,
  description: '', // not used with this extension point, but required by the TS type
  extensionPointId,
  component: GrafanaOnCallSettings,
});
```
![Screenshot 2023-11-24 at 14 06 56](https://github.com/grafana/grafana/assets/9406895/1f6903f8-6e67-4bbd-af9c-3a8a03d40285)
- the `/profile` page will now look for a `tab` query parameter. If this is equal to any of the tab titles (case-insensitive), that tab will be rendered directly on page load.

**Note**: multiple plugins can render content to the same tab. Tabs + tab content are decided based on unique `title` attributes. Any duplicates are grouped together and rendered within the same tab (this will be useful for example in the "IRM" use-case where Grafana OnCall and Grafana Incident may each need to render some shared IRM-level settings; example mobile app QR code).

**Why do we need this feature?**

Grafana OnCall and Grafana Incident teams have a quarterly milestone to add Grafana Incident features to the IRM mobile app (previously OnCall mobile app). Part of this project involves moving the QR authentication code from within Grafana OnCall to somewhere "higher-up" within core Grafana. Since this is a shared setting between OnCall and Incident it made sense to move it to `/profile`.

**Who is this feature for?**

Plugin developers.

**Which issue(s) does this PR fix?**:

This unblocks https://github.com/grafana/oncall/pull/3296

Please check that:
- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [x] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
