### PR TITLE
sql: remove `xorm` dependency from postgres/mysql/mssql

### DIFF
--- a/pkg/tsdb/grafana-postgresql-datasource/proxy.go
+++ b/pkg/tsdb/grafana-postgresql-datasource/proxy.go
@@ -5,22 +5,18 @@ import (
 	"database/sql"
 	"database/sql/driver"
 	"net"
+	"slices"
 	"time"
 
 	sdkproxy "github.com/grafana/grafana-plugin-sdk-go/backend/proxy"
-	"github.com/grafana/grafana/pkg/tsdb/sqleng"
 	"github.com/grafana/grafana/pkg/util"
 	"github.com/lib/pq"
 	"golang.org/x/net/proxy"
-	"xorm.io/core"
 )
 
 // createPostgresProxyDriver creates and registers a new sql driver that uses a postgres connector and updates the dialer to
 // route connections through the secure socks proxy
 func createPostgresProxyDriver(cnnstr string, opts *sdkproxy.Options) (string, error) {
-	sqleng.XormDriverMu.Lock()
-	defer sqleng.XormDriverMu.Unlock()
-
 	// create a unique driver per connection string
 	hash, err := util.Md5SumString(cnnstr)
 	if err != nil {
@@ -29,7 +25,7 @@ func createPostgresProxyDriver(cnnstr string, opts *sdkproxy.Options) (string, e
 	driverName := "postgres-proxy-" + hash
 
 	// only register the driver once
-	if core.QueryDriver(driverName) == nil {
+	if !slices.Contains(sql.Drivers(), driverName) {
 		connector, err := pq.NewConnector(cnnstr)
 		if err != nil {
 			return "", err
@@ -41,7 +37,6 @@ func createPostgresProxyDriver(cnnstr string, opts *sdkproxy.Options) (string, e
 		}
 
 		sql.Register(driverName, driver)
-		core.RegisterDriver(driverName, driver)
 	}
 	return driverName, nil
 }
@@ -53,7 +48,6 @@ type postgresProxyDriver struct {
 }
 
 var _ driver.DriverContext = (*postgresProxyDriver)(nil)
-var _ core.Driver = (*postgresProxyDriver)(nil)
 
 // newPostgresProxyDriver updates the dialer for a postgres connector with a dialer that proxies connections through the secure socks proxy
 // and returns a new postgres driver to register
@@ -85,14 +79,6 @@ func (p *postgresProxyDialer) DialTimeout(network, address string, timeout time.
 	defer cancel()
 
 	return p.d.(proxy.ContextDialer).DialContext(ctx, network, address)
-}
-
-// Parse uses the xorm postgres dialect for the driver (this has to be implemented to register the driver with xorm)
-func (d *postgresProxyDriver) Parse(a string, b string) (*core.Uri, error) {
-	sqleng.XormDriverMu.RLock()
-	defer sqleng.XormDriverMu.RUnlock()
-
-	return core.QueryDriver("postgres").Parse(a, b)
 }
 
 // OpenConnector returns the normal postgres connector that has the updated dialer context

--- a/pkg/tsdb/grafana-postgresql-datasource/proxy.go
+++ b/pkg/tsdb/grafana-postgresql-datasource/proxy.go
@@ -2,14 +2,15 @@ package postgres
 
 import (
 	"context"
+	"crypto/md5"
 	"database/sql"
 	"database/sql/driver"
+	"fmt"
 	"net"
 	"slices"
 	"time"
 
 	sdkproxy "github.com/grafana/grafana-plugin-sdk-go/backend/proxy"
-	"github.com/grafana/grafana/pkg/util"
 	"github.com/lib/pq"
 	"golang.org/x/net/proxy"
 )
@@ -18,10 +19,7 @@ import (
 // route connections through the secure socks proxy
 func createPostgresProxyDriver(cnnstr string, opts *sdkproxy.Options) (string, error) {
 	// create a unique driver per connection string
-	hash, err := util.Md5SumString(cnnstr)
-	if err != nil {
-		return "", err
-	}
+	hash := fmt.Sprintf("%x", md5.Sum([]byte(cnnstr)))
 	driverName := "postgres-proxy-" + hash
 
 	// only register the driver once

--- a/pkg/tsdb/grafana-postgresql-datasource/proxy_test.go
+++ b/pkg/tsdb/grafana-postgresql-datasource/proxy_test.go
@@ -10,11 +10,9 @@ import (
 	"github.com/grafana/grafana/pkg/tsdb/sqleng/proxyutil"
 	"github.com/lib/pq"
 	"github.com/stretchr/testify/require"
-	"xorm.io/core"
 )
 
 func TestPostgresProxyDriver(t *testing.T) {
-	dialect := "postgres"
 	settings := proxyutil.SetupTestSecureSocksProxySettings(t)
 	proxySettings := setting.SecureSocksDSProxySettings{
 		Enabled:      true,
@@ -40,17 +38,6 @@ func TestPostgresProxyDriver(t *testing.T) {
 		testDriver, err := createPostgresProxyDriver("server=localhost;user id=sa;password=yourStrong(!)Password;database=db2", opts)
 		require.NoError(t, err)
 		require.NotEqual(t, driverName, testDriver)
-	})
-
-	t.Run("Parse should have the same result as xorm mssql parse", func(t *testing.T) {
-		xormDriver := core.QueryDriver(dialect)
-		xormResult, err := xormDriver.Parse(dialect, cnnstr)
-		require.NoError(t, err)
-
-		xormNewDriver := core.QueryDriver(driverName)
-		xormNewResult, err := xormNewDriver.Parse(dialect, cnnstr)
-		require.NoError(t, err)
-		require.Equal(t, xormResult, xormNewResult)
 	})
 
 	t.Run("Connector should use dialer context that routes through the socks proxy to db", func(t *testing.T) {

--- a/pkg/tsdb/mssql/proxy.go
+++ b/pkg/tsdb/mssql/proxy.go
@@ -6,21 +6,17 @@ import (
 	"database/sql/driver"
 	"errors"
 	"net"
+	"slices"
 
 	sdkproxy "github.com/grafana/grafana-plugin-sdk-go/backend/proxy"
-	"github.com/grafana/grafana/pkg/tsdb/sqleng"
 	"github.com/grafana/grafana/pkg/util"
 	mssql "github.com/microsoft/go-mssqldb"
 	"golang.org/x/net/proxy"
-	"xorm.io/core"
 )
 
 // createMSSQLProxyDriver creates and registers a new sql driver that uses a mssql connector and updates the dialer to
 // route connections through the secure socks proxy
 func createMSSQLProxyDriver(cnnstr string, hostName string, opts *sdkproxy.Options) (string, error) {
-	sqleng.XormDriverMu.Lock()
-	defer sqleng.XormDriverMu.Unlock()
-
 	// create a unique driver per connection string
 	hash, err := util.Md5SumString(cnnstr)
 	if err != nil {
@@ -29,7 +25,7 @@ func createMSSQLProxyDriver(cnnstr string, hostName string, opts *sdkproxy.Optio
 	driverName := "mssql-proxy-" + hash
 
 	// only register the driver once
-	if core.QueryDriver(driverName) == nil {
+	if !slices.Contains(sql.Drivers(), driverName) {
 		connector, err := mssql.NewConnector(cnnstr)
 		if err != nil {
 			return "", err
@@ -40,7 +36,6 @@ func createMSSQLProxyDriver(cnnstr string, hostName string, opts *sdkproxy.Optio
 			return "", err
 		}
 		sql.Register(driverName, driver)
-		core.RegisterDriver(driverName, driver)
 	}
 
 	return driverName, nil
@@ -66,7 +61,6 @@ type mssqlProxyDriver struct {
 }
 
 var _ driver.DriverContext = (*mssqlProxyDriver)(nil)
-var _ core.Driver = (*mssqlProxyDriver)(nil)
 
 // newMSSQLProxyDriver updates the dialer for a mssql connector with a dialer that proxys connections through the secure socks proxy
 // and returns a new mssql driver to register
@@ -83,14 +77,6 @@ func newMSSQLProxyDriver(connector *mssql.Connector, hostName string, opts *sdkp
 
 	connector.Dialer = HostTransportDialer{contextDialer, hostName}
 	return &mssqlProxyDriver{c: connector}, nil
-}
-
-// Parse uses the xorm mssql dialect for the driver (this has to be implemented to register the driver with xorm)
-func (d *mssqlProxyDriver) Parse(a string, b string) (*core.Uri, error) {
-	sqleng.XormDriverMu.RLock()
-	defer sqleng.XormDriverMu.RUnlock()
-
-	return core.QueryDriver("mssql").Parse(a, b)
 }
 
 // OpenConnector returns the normal mssql connector that has the updated dialer context

--- a/pkg/tsdb/mssql/proxy.go
+++ b/pkg/tsdb/mssql/proxy.go
@@ -2,14 +2,15 @@ package mssql
 
 import (
 	"context"
+	"crypto/md5"
 	"database/sql"
 	"database/sql/driver"
 	"errors"
+	"fmt"
 	"net"
 	"slices"
 
 	sdkproxy "github.com/grafana/grafana-plugin-sdk-go/backend/proxy"
-	"github.com/grafana/grafana/pkg/util"
 	mssql "github.com/microsoft/go-mssqldb"
 	"golang.org/x/net/proxy"
 )
@@ -18,10 +19,7 @@ import (
 // route connections through the secure socks proxy
 func createMSSQLProxyDriver(cnnstr string, hostName string, opts *sdkproxy.Options) (string, error) {
 	// create a unique driver per connection string
-	hash, err := util.Md5SumString(cnnstr)
-	if err != nil {
-		return "", err
-	}
+	hash := fmt.Sprintf("%x", md5.Sum([]byte(cnnstr)))
 	driverName := "mssql-proxy-" + hash
 
 	// only register the driver once

--- a/pkg/tsdb/mssql/proxy_test.go
+++ b/pkg/tsdb/mssql/proxy_test.go
@@ -10,7 +10,6 @@ import (
 	"github.com/grafana/grafana/pkg/tsdb/sqleng/proxyutil"
 	mssql "github.com/microsoft/go-mssqldb"
 	"github.com/stretchr/testify/require"
-	"xorm.io/core"
 )
 
 func TestMSSQLProxyDriver(t *testing.T) {
@@ -23,7 +22,6 @@ func TestMSSQLProxyDriver(t *testing.T) {
 		ProxyAddress: settings.ProxyAddress,
 		ServerName:   settings.ServerName,
 	}
-	dialect := "mssql"
 	opts := proxyutil.GetSQLProxyOptions(proxySettings, sqleng.DataSourceInfo{UID: "1", JsonData: sqleng.JsonData{SecureDSProxy: true}})
 	cnnstr := "server=127.0.0.1;port=1433;user id=sa;password=yourStrong(!)Password;database=db"
 	driverName, err := createMSSQLProxyDriver(cnnstr, "127.0.0.1", opts)
@@ -39,17 +37,6 @@ func TestMSSQLProxyDriver(t *testing.T) {
 		testDriver, err := createMSSQLProxyDriver("server=localhost;user id=sa;password=yourStrong(!)Password;database=db2", "localhost", opts)
 		require.NoError(t, err)
 		require.NotEqual(t, driverName, testDriver)
-	})
-
-	t.Run("Parse should have the same result as xorm mssql parse", func(t *testing.T) {
-		xormDriver := core.QueryDriver(dialect)
-		xormResult, err := xormDriver.Parse(dialect, cnnstr)
-		require.NoError(t, err)
-
-		xormNewDriver := core.QueryDriver(driverName)
-		xormNewResult, err := xormNewDriver.Parse(dialect, cnnstr)
-		require.NoError(t, err)
-		require.Equal(t, xormResult, xormNewResult)
 	})
 
 	t.Run("Connector should use dialer context that routes through the socks proxy to db", func(t *testing.T) {

--- a/pkg/tsdb/mysql/proxy.go
+++ b/pkg/tsdb/mysql/proxy.go
@@ -2,11 +2,12 @@ package mysql
 
 import (
 	"context"
+	"crypto/md5"
+	"fmt"
 	"net"
 
 	"github.com/go-sql-driver/mysql"
 	sdkproxy "github.com/grafana/grafana-plugin-sdk-go/backend/proxy"
-	"github.com/grafana/grafana/pkg/util"
 	"golang.org/x/net/proxy"
 )
 
@@ -21,10 +22,7 @@ func registerProxyDialerContext(protocol, cnnstr string, opts *sdkproxy.Options)
 
 	// the dialer context can be updated everytime the datasource is updated
 	// have a unique network per connection string
-	hash, err := util.Md5SumString(cnnstr)
-	if err != nil {
-		return "", err
-	}
+	hash := fmt.Sprintf("%x", md5.Sum([]byte(cnnstr)))
 	network := "proxy-" + hash
 	mysql.RegisterDialContext(network, dialer.DialContext)
 

--- a/pkg/tsdb/sqleng/sql_engine.go
+++ b/pkg/tsdb/sqleng/sql_engine.go
@@ -16,17 +16,12 @@ import (
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
 	"github.com/grafana/grafana-plugin-sdk-go/data"
 	"github.com/grafana/grafana-plugin-sdk-go/data/sqlutil"
-	"xorm.io/core"
-	"xorm.io/xorm"
 
 	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/setting"
 	"github.com/grafana/grafana/pkg/tsdb/intervalv2"
 	"github.com/grafana/grafana/pkg/util/errutil"
 )
-
-// XormDriverMu is used to allow safe concurrent registering and querying of drivers in xorm
-var XormDriverMu sync.RWMutex
 
 // MetaKeyExecutedQueryString is the key where the executed query should get stored
 const MetaKeyExecutedQueryString = "executedQueryString"
@@ -48,11 +43,11 @@ type SqlQueryResultTransformer interface {
 
 var sqlIntervalCalculator = intervalv2.NewCalculator()
 
-// NewXormEngine is an xorm.Engine factory, that can be stubbed by tests.
+// NewDB is a sql.DB factory, that can be stubbed by tests.
 //
 //nolint:gocritic
-var NewXormEngine = func(driverName string, connectionString string) (*xorm.Engine, error) {
-	return xorm.NewEngine(driverName, connectionString)
+var NewDB = func(driverName string, connectionString string) (*sql.DB, error) {
+	return sql.Open(driverName, connectionString)
 }
 
 type JsonData struct {
@@ -89,13 +84,6 @@ type DataSourceInfo struct {
 	DecryptedSecureJSONData map[string]string
 }
 
-// Defaults for the xorm connection pool
-type DefaultConnectionInfo struct {
-	MaxOpenConns    int
-	MaxIdleConns    int
-	ConnMaxLifetime int
-}
-
 type DataPluginConfiguration struct {
 	DriverName        string
 	DSInfo            DataSourceInfo
@@ -108,7 +96,7 @@ type DataPluginConfiguration struct {
 type DataSourceHandler struct {
 	macroEngine            SQLMacroEngine
 	queryResultTransformer SqlQueryResultTransformer
-	engine                 *xorm.Engine
+	db                     *sql.DB
 	timeColumnNames        []string
 	metricColumnTypes      []string
 	log                    log.Logger
@@ -165,16 +153,16 @@ func NewQueryDataHandler(cfg *setting.Cfg, config DataPluginConfiguration, query
 		queryDataHandler.metricColumnTypes = config.MetricColumnTypes
 	}
 
-	engine, err := NewXormEngine(config.DriverName, config.ConnectionString)
+	db, err := NewDB(config.DriverName, config.ConnectionString)
 	if err != nil {
 		return nil, err
 	}
 
-	engine.SetMaxOpenConns(config.DSInfo.JsonData.MaxOpenConns)
-	engine.SetMaxIdleConns(config.DSInfo.JsonData.MaxIdleConns)
-	engine.SetConnMaxLifetime(time.Duration(config.DSInfo.JsonData.ConnMaxLifetime) * time.Second)
+	db.SetMaxOpenConns(config.DSInfo.JsonData.MaxOpenConns)
+	db.SetMaxIdleConns(config.DSInfo.JsonData.MaxIdleConns)
+	db.SetConnMaxLifetime(time.Duration(config.DSInfo.JsonData.ConnMaxLifetime) * time.Second)
 
-	queryDataHandler.engine = engine
+	queryDataHandler.db = db
 	return &queryDataHandler, nil
 }
 
@@ -184,17 +172,17 @@ type DBDataResponse struct {
 }
 
 func (e *DataSourceHandler) Dispose() {
-	e.log.Debug("Disposing engine...")
-	if e.engine != nil {
-		if err := e.engine.Close(); err != nil {
-			e.log.Error("Failed to dispose engine", "error", err)
+	e.log.Debug("Disposing DB...")
+	if e.db != nil {
+		if err := e.db.Close(); err != nil {
+			e.log.Error("Failed to dispose db", "error", err)
 		}
 	}
-	e.log.Debug("Engine disposed")
+	e.log.Debug("DB disposed")
 }
 
 func (e *DataSourceHandler) Ping() error {
-	return e.engine.Ping()
+	return e.db.Ping()
 }
 
 func (e *DataSourceHandler) QueryData(ctx context.Context, req *backend.QueryDataRequest) (*backend.QueryDataResponse, error) {
@@ -285,11 +273,7 @@ func (e *DataSourceHandler) executeQuery(query backend.DataQuery, wg *sync.WaitG
 		return
 	}
 
-	session := e.engine.NewSession()
-	defer session.Close()
-	db := session.DB()
-
-	rows, err := db.QueryContext(queryContext, interpolatedQuery)
+	rows, err := e.db.QueryContext(queryContext, interpolatedQuery)
 	if err != nil {
 		errAppendDebug("db query error", e.TransformQueryError(logger, err), interpolatedQuery)
 		return
@@ -308,7 +292,7 @@ func (e *DataSourceHandler) executeQuery(query backend.DataQuery, wg *sync.WaitG
 
 	// Convert row.Rows to dataframe
 	stringConverters := e.queryResultTransformer.GetConverterList()
-	frame, err := sqlutil.FrameFromRows(rows.Rows, e.rowLimit, sqlutil.ToConverters(stringConverters...)...)
+	frame, err := sqlutil.FrameFromRows(rows, e.rowLimit, sqlutil.ToConverters(stringConverters...)...)
 	if err != nil {
 		errAppendDebug("convert frame from rows error", err, interpolatedQuery)
 		return
@@ -418,7 +402,7 @@ var Interpolate = func(query backend.DataQuery, timeRange backend.TimeRange, tim
 }
 
 func (e *DataSourceHandler) newProcessCfg(query backend.DataQuery, queryContext context.Context,
-	rows *core.Rows, interpolatedQuery string) (*dataQueryModel, error) {
+	rows *sql.Rows, interpolatedQuery string) (*dataQueryModel, error) {
 	columnNames, err := rows.Columns()
 	if err != nil {
 		return nil, err
@@ -431,7 +415,6 @@ func (e *DataSourceHandler) newProcessCfg(query backend.DataQuery, queryContext 
 	qm := &dataQueryModel{
 		columnTypes:  columnTypes,
 		columnNames:  columnNames,
-		rows:         rows,
 		timeIndex:    -1,
 		timeEndIndex: -1,
 		metricIndex:  -1,
@@ -525,7 +508,6 @@ type dataQueryModel struct {
 	timeIndex         int
 	timeEndIndex      int
 	metricIndex       int
-	rows              *core.Rows
 	metricPrefix      bool
 	queryContext      context.Context
 }


### PR DESCRIPTION
we remove the `xorm` dependency from the sql datasource plugins.

the sql datasources use xorm the following way:
- they call `xorm`'s `QueryContext` with a sql string, that function returns a `sql.Rows` structure, and the datasource builds dataframes based on that structure

this PR replaces the usage of `xorm` with go's sql constructs, which provide the same `QueryContext` function

(NOTE: this PR also includes the removal of an import of a md5-sum-calculating function ( https://github.com/grafana/grafana/pull/78821 ))

TODO:
- there are comments like: https://github.com/grafana/grafana/blob/7a46d6a1b391febc4057897ef4e7f75daf6afdce/pkg/tsdb/grafana-postgresql-datasource/proxy.go#L50
    - investigate if maybe without xorm, these proxies can be written simpler?

how to test:
- try to run various sql queries, make sure they work
- make sure list-of-things work in the query editor
    - list of databases
    - list of tables
    - list of fields
- run the database-specific tests
    - mssql
        - `make devenv sources=mssql_tests`
        - `GRAFANA_TEST_DB=mssql go test -v  ./pkg/tsdb/mssql`
    - postgres
        - `make devenv sources=postgres_tests`
        - `GRAFANA_TEST_DB=postgres go test -tags=integration -v ./pkg/tsdb/grafana-postgresql-datasource`
    - mysql
        - `make devenv sources=mysql_tests`
        - `GRAFANA_TEST_DB=mysql go test -v  ./pkg/tsdb/mysql`

(fixes https://github.com/grafana/grafana/issues/77781)