### PR TITLE
Auth: id response header

### DIFF
--- a/conf/defaults.ini
+++ b/conf/defaults.ini
@@ -513,6 +513,8 @@ revoke = true
 # When set, Grafana will not allow the creation of tokens with expiry greater than this setting.
 token_expiration_day_limit =
 
+
+
 [auth]
 # Login cookie name
 login_cookie_name = grafana_session
@@ -564,6 +566,16 @@ azure_auth_enabled = false
 
 # Use email lookup in addition to the unique ID provided by the IdP
 oauth_allow_insecure_email_lookup = false
+
+# Set to true to include id of identity as a response header
+id_response_header_enabled = false
+
+# Prefix used for the id response header, e.g. for service-account this would result in X-Grafana-Service-Account-Id
+id_response_header_prefix = X-Grafana-
+
+# List of identity namespaces to add id response headers for, seperate namespaces by space
+# Available namespaces are user, api-key and service-account
+id_response_header_namespaces =
 
 #################################### Anonymous Auth ######################
 [auth.anonymous]

--- a/conf/defaults.ini
+++ b/conf/defaults.ini
@@ -513,8 +513,6 @@ revoke = true
 # When set, Grafana will not allow the creation of tokens with expiry greater than this setting.
 token_expiration_day_limit =
 
-
-
 [auth]
 # Login cookie name
 login_cookie_name = grafana_session

--- a/conf/defaults.ini
+++ b/conf/defaults.ini
@@ -568,12 +568,13 @@ oauth_allow_insecure_email_lookup = false
 # Set to true to include id of identity as a response header
 id_response_header_enabled = false
 
-# Prefix used for the id response header, e.g. for service-account this would result in X-Grafana-Service-Account-Id
-id_response_header_prefix = X-Grafana-
+# Prefix used for the id response header, X-Grafana-Identity-Id
+id_response_header_prefix = X-Grafana
 
-# List of identity namespaces to add id response headers for, seperate namespaces by space
-# Available namespaces are user, api-key and service-account
-id_response_header_namespaces =
+# List of identity namespaces to add id response headers for, separated by space.
+# Available namespaces are user, api-key and service-account.
+# The header value will encode the namespace ("user:<id>", "api-key:<id>", "service-account:<id>")
+id_response_header_namespaces = user api-key service-account
 
 #################################### Anonymous Auth ######################
 [auth.anonymous]

--- a/conf/sample.ini
+++ b/conf/sample.ini
@@ -554,6 +554,16 @@
 # Use email lookup in addition to the unique ID provided by the IdP
 ;oauth_allow_insecure_email_lookup = false
 
+# Set to true to include id of identity as a response header
+;id_response_header_enabled = false
+
+# Prefix used for the id response header, e.g. for service-account this would result in X-Grafana-Service-Account-Id
+;id_response_header_prefix = X-Grafana-
+
+# List of identity namespaces to add id response headers for, seperate namespaces by space
+# Available namespaces are user, api-key and service-account
+;id_response_header_namespaces =
+
 #################################### Anonymous Auth ######################
 [auth.anonymous]
 # enable anonymous access

--- a/conf/sample.ini
+++ b/conf/sample.ini
@@ -557,12 +557,13 @@
 # Set to true to include id of identity as a response header
 ;id_response_header_enabled = false
 
-# Prefix used for the id response header, e.g. for service-account this would result in X-Grafana-Service-Account-Id
-;id_response_header_prefix = X-Grafana-
+# Prefix used for the id response header, X-Grafana-Identity-Id
+;id_response_header_prefix = X-Grafana
 
-# List of identity namespaces to add id response headers for, seperate namespaces by space
-# Available namespaces are user, api-key and service-account
-;id_response_header_namespaces =
+# List of identity namespaces to add id response headers for, separated by space.
+# Available namespaces are user, api-key and service-account.
+# The header value will encode the namespace ("user:<id>", "api-key:<id>", "service-account:<id>")
+;id_response_header_namespaces = user api-key service-account
 
 #################################### Anonymous Auth ######################
 [auth.anonymous]

--- a/pkg/services/contexthandler/contexthandler.go
+++ b/pkg/services/contexthandler/contexthandler.go
@@ -128,7 +128,6 @@ func (h *ContextHandler) Middleware(next http.Handler) http.Handler {
 			reqContext.IsSignedIn = !reqContext.SignedInUser.IsAnonymous
 			reqContext.AllowAnonymous = reqContext.SignedInUser.IsAnonymous
 			reqContext.IsRenderCall = identity.AuthenticatedBy == login.RenderModule
-
 		}
 
 		reqContext.Logger = reqContext.Logger.New("userId", reqContext.UserID, "orgId", reqContext.OrgID, "uname", reqContext.Login)

--- a/pkg/services/contexthandler/contexthandler.go
+++ b/pkg/services/contexthandler/contexthandler.go
@@ -4,6 +4,7 @@ package contexthandler
 import (
 	"context"
 	"errors"
+	"fmt"
 	"net/http"
 	"strconv"
 
@@ -163,12 +164,6 @@ func getNamespaceAndID(user *user.SignedInUser) (string, string) {
 	return namespace, id
 }
 
-var namespaceToHeader = map[string]string{
-	"user":            "User",
-	"api-key":         "Api-Key",
-	"service-account": "Service-Account",
-}
-
 func (h *ContextHandler) addIDHeaderEndOfRequestFunc(namespace, id string) web.BeforeFunc {
 	return func(w web.ResponseWriter) {
 		if w.Written() {
@@ -183,8 +178,8 @@ func (h *ContextHandler) addIDHeaderEndOfRequestFunc(namespace, id string) web.B
 			return
 		}
 
-		headerName := h.Cfg.IDResponseHeaderPrefix + namespaceToHeader[namespace] + "-Id"
-		w.Header().Add(headerName, id)
+		headerName := fmt.Sprintf("%s-Identity-Id", h.Cfg.IDResponseHeaderPrefix)
+		w.Header().Add(headerName, fmt.Sprintf("%s:%s", namespace, id))
 	}
 }
 

--- a/pkg/setting/setting.go
+++ b/pkg/setting/setting.go
@@ -285,6 +285,9 @@ type Cfg struct {
 	AdminEmail                   string
 	DisableLoginForm             bool
 	SignoutRedirectUrl           string
+	IDResponseHeaderEnabled      bool
+	IDResponseHeaderPrefix       string
+	IDResponseHeaderNamespaces   map[string]struct{}
 	// Not documented & not supported
 	// stand in until a more complete solution is implemented
 	AuthConfigUIAdminAccess bool
@@ -1605,6 +1608,17 @@ func readAuthSettings(iniFile *ini.File, cfg *Cfg) (err error) {
 	// Azure Auth
 	AzureAuthEnabled = auth.Key("azure_auth_enabled").MustBool(false)
 	cfg.AzureAuthEnabled = AzureAuthEnabled
+
+	// ID response header
+	cfg.IDResponseHeaderEnabled = auth.Key("id_response_header_enabled").MustBool(false)
+	cfg.IDResponseHeaderPrefix = auth.Key("id_response_header_prefix").MustString("X-Grafana-")
+
+	idHeaderNamespaces := strings.Split(auth.Key("id_response_header_namespaces").MustString(""), " ")
+	cfg.IDResponseHeaderNamespaces = make(map[string]struct{}, len(idHeaderNamespaces))
+	for _, namespace := range idHeaderNamespaces {
+		cfg.IDResponseHeaderNamespaces[namespace] = struct{}{}
+	}
+
 	readAuthAzureADSettings(cfg)
 
 	// Google Auth

--- a/pkg/setting/setting.go
+++ b/pkg/setting/setting.go
@@ -1613,7 +1613,7 @@ func readAuthSettings(iniFile *ini.File, cfg *Cfg) (err error) {
 	cfg.IDResponseHeaderEnabled = auth.Key("id_response_header_enabled").MustBool(false)
 	cfg.IDResponseHeaderPrefix = auth.Key("id_response_header_prefix").MustString("X-Grafana-")
 
-	idHeaderNamespaces := strings.Split(auth.Key("id_response_header_namespaces").MustString(""), " ")
+	idHeaderNamespaces := util.SplitString(auth.Key("id_response_header_namespaces").MustString(""))
 	cfg.IDResponseHeaderNamespaces = make(map[string]struct{}, len(idHeaderNamespaces))
 	for _, namespace := range idHeaderNamespaces {
 		cfg.IDResponseHeaderNamespaces[namespace] = struct{}{}


### PR DESCRIPTION
**What is this feature?**
Add config options and functionality to include the id of the identity making a request to all response headers.
I decided make the implementation a little more generic than what the issue describes.
I also intentionally only used fields / functions I know exist on 9.5.x because we want to backport this feature.

The response header will use the specified prefix, with default values it would be `X-Grafana-Identitity-Id` and the value will be use the namespace and id of identitiy (`user:<id>`, `api-key:<id>` or `service-account:<id>`

**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/identity-access-team/issues/394

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
