### PR TITLE
Loki: Add error source to DataQuery

### DIFF
--- a/pkg/tsdb/loki/api.go
+++ b/pkg/tsdb/loki/api.go
@@ -217,6 +217,8 @@ func (api *LokiAPI) DataQuery(ctx context.Context, query lokiQuery, responseOpts
 		span.SetStatus(codes.Error, err.Error())
 		instrumentation.UpdatePluginParsingResponseDurationSeconds(ctx, time.Since(start), "error")
 		api.log.Error("Error parsing response from loki", "error", res.Error, "metricDataplane", responseOpts.metricDataplane, "duration", time.Since(start), "stage", stageParseResponse)
+		// Here the response.Error is set by converter.ReadPrometheusStyleResult without ErrorSource, which means it will always be PluginError.
+		// @todo: We should look into when successful response is returned with error field and what type of ErrorSource we should set for that
 		return res
 	}
 	instrumentation.UpdatePluginParsingResponseDurationSeconds(ctx, time.Since(start), "ok")

--- a/pkg/tsdb/loki/api.go
+++ b/pkg/tsdb/loki/api.go
@@ -13,12 +13,13 @@ import (
 	"strconv"
 	"time"
 
-	"github.com/grafana/grafana-plugin-sdk-go/data"
 	jsoniter "github.com/json-iterator/go"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
 	"go.opentelemetry.io/otel/trace"
 
+	"github.com/grafana/grafana-plugin-sdk-go/backend"
+	"github.com/grafana/grafana-plugin-sdk-go/experimental/errorsource"
 	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/infra/tracing"
 	"github.com/grafana/grafana/pkg/tsdb/loki/instrumentation"
@@ -155,10 +156,10 @@ func readLokiError(body io.ReadCloser) error {
 	return makeLokiError(bytes)
 }
 
-func (api *LokiAPI) DataQuery(ctx context.Context, query lokiQuery, responseOpts ResponseOpts) (data.Frames, error) {
+func (api *LokiAPI) DataQuery(ctx context.Context, query lokiQuery, responseOpts ResponseOpts) backend.DataResponse {
 	req, err := makeDataRequest(ctx, api.url, query)
 	if err != nil {
-		return nil, err
+		return errorsource.Response(errorsource.PluginError(err, false))
 	}
 
 	queryAttrs := []any{"start", query.Start, "end", query.End, "step", query.Step, "query", query.Expr, "queryType", query.QueryType, "direction", query.Direction, "maxLines", query.MaxLines, "supportingQueryType", query.SupportingQueryType, "lokiHost", req.URL.Host, "lokiPath", req.URL.Path}
@@ -176,7 +177,8 @@ func (api *LokiAPI) DataQuery(ctx context.Context, query lokiQuery, responseOpts
 			lp = append(lp, "statusCode", resp.StatusCode)
 		}
 		api.log.Error("Error received from Loki", lp...)
-		return nil, err
+		// Here, errors source is provided by errorsource middleware
+		return errorsource.Response(err)
 	}
 
 	defer func() {
@@ -191,7 +193,11 @@ func (api *LokiAPI) DataQuery(ctx context.Context, query lokiQuery, responseOpts
 		err := readLokiError(resp.Body)
 		lp = append(lp, "status", "error", "error", err)
 		api.log.Error("Error received from Loki", lp...)
-		return nil, err
+		// errors should be processed by errorsource middleware
+		// here we do here something extra - turning non-200 to error
+		//  we will consider this Plugin error, but let's re-evaluate if we need this
+		// @todo Re-evaluate if we need to turn non-200 to error
+		return errorsource.Response(errorsource.PluginError(err, false))
 	} else {
 		lp = append(lp, "status", "ok")
 		api.log.Info("Response received from loki", lp...)
@@ -211,12 +217,12 @@ func (api *LokiAPI) DataQuery(ctx context.Context, query lokiQuery, responseOpts
 		span.SetStatus(codes.Error, err.Error())
 		instrumentation.UpdatePluginParsingResponseDurationSeconds(ctx, time.Since(start), "error")
 		api.log.Error("Error parsing response from loki", "error", res.Error, "metricDataplane", responseOpts.metricDataplane, "duration", time.Since(start), "stage", stageParseResponse)
-		return nil, res.Error
+		return res
 	}
 	instrumentation.UpdatePluginParsingResponseDurationSeconds(ctx, time.Since(start), "ok")
 	api.log.Info("Response parsed from loki", "duration", time.Since(start), "metricDataplane", responseOpts.metricDataplane, "framesLength", len(res.Frames), "stage", stageParseResponse)
 
-	return res.Frames, nil
+	return res
 }
 
 func makeRawRequest(ctx context.Context, lokiDsUrl string, resourcePath string) (*http.Request, error) {

--- a/pkg/tsdb/loki/api_test.go
+++ b/pkg/tsdb/loki/api_test.go
@@ -28,8 +28,8 @@ func TestApiLogVolume(t *testing.T) {
 			require.Equal(t, "Source=logvolhist", req.Header.Get("X-Query-Tags"))
 		})
 
-		_, err := api.DataQuery(context.Background(), lokiQuery{Expr: "", SupportingQueryType: SupportingQueryLogsVolume, QueryType: QueryTypeRange}, ResponseOpts{})
-		require.NoError(t, err)
+		res := api.DataQuery(context.Background(), lokiQuery{Expr: "", SupportingQueryType: SupportingQueryLogsVolume, QueryType: QueryTypeRange}, ResponseOpts{})
+		require.Equal(t, nil, res.Error)
 		require.True(t, called)
 	})
 
@@ -40,8 +40,8 @@ func TestApiLogVolume(t *testing.T) {
 			require.Equal(t, "Source=logsample", req.Header.Get("X-Query-Tags"))
 		})
 
-		_, err := api.DataQuery(context.Background(), lokiQuery{Expr: "", SupportingQueryType: SupportingQueryLogsSample, QueryType: QueryTypeRange}, ResponseOpts{})
-		require.NoError(t, err)
+		res := api.DataQuery(context.Background(), lokiQuery{Expr: "", SupportingQueryType: SupportingQueryLogsSample, QueryType: QueryTypeRange}, ResponseOpts{})
+		require.Equal(t, nil, res.Error)
 		require.True(t, called)
 	})
 
@@ -52,8 +52,8 @@ func TestApiLogVolume(t *testing.T) {
 			require.Equal(t, "Source=datasample", req.Header.Get("X-Query-Tags"))
 		})
 
-		_, err := api.DataQuery(context.Background(), lokiQuery{Expr: "", SupportingQueryType: SupportingQueryDataSample, QueryType: QueryTypeRange}, ResponseOpts{})
-		require.NoError(t, err)
+		res := api.DataQuery(context.Background(), lokiQuery{Expr: "", SupportingQueryType: SupportingQueryDataSample, QueryType: QueryTypeRange}, ResponseOpts{})
+		require.Equal(t, nil, res.Error)
 		require.True(t, called)
 	})
 
@@ -64,8 +64,8 @@ func TestApiLogVolume(t *testing.T) {
 			require.Equal(t, "", req.Header.Get("X-Query-Tags"))
 		})
 
-		_, err := api.DataQuery(context.Background(), lokiQuery{Expr: "", SupportingQueryType: SupportingQueryNone, QueryType: QueryTypeRange}, ResponseOpts{})
-		require.NoError(t, err)
+		res := api.DataQuery(context.Background(), lokiQuery{Expr: "", SupportingQueryType: SupportingQueryNone, QueryType: QueryTypeRange}, ResponseOpts{})
+		require.Equal(t, nil, res.Error)
 		require.True(t, called)
 	})
 }
@@ -133,8 +133,8 @@ func TestApiUrlHandling(t *testing.T) {
 				QueryType: QueryTypeRange,
 			}
 
-			_, err := api.DataQuery(context.Background(), query, ResponseOpts{})
-			require.NoError(t, err)
+			res := api.DataQuery(context.Background(), query, ResponseOpts{})
+			require.Equal(t, nil, res.Error)
 			require.True(t, called)
 		})
 	}
@@ -154,8 +154,8 @@ func TestApiUrlHandling(t *testing.T) {
 				QueryType: QueryTypeInstant,
 			}
 
-			_, err := api.DataQuery(context.Background(), query, ResponseOpts{})
-			require.NoError(t, err)
+			res := api.DataQuery(context.Background(), query, ResponseOpts{})
+			require.Equal(t, nil, res.Error)
 			require.True(t, called)
 		})
 	}

--- a/pkg/tsdb/loki/loki.go
+++ b/pkg/tsdb/loki/loki.go
@@ -13,10 +13,10 @@ import (
 	"github.com/grafana/dskit/concurrency"
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
 	"github.com/grafana/grafana-plugin-sdk-go/backend/datasource"
+	sdkhttpclient "github.com/grafana/grafana-plugin-sdk-go/backend/httpclient"
 	"github.com/grafana/grafana-plugin-sdk-go/backend/instancemgmt"
 	"github.com/grafana/grafana-plugin-sdk-go/data"
 	"github.com/grafana/grafana-plugin-sdk-go/experimental/errorsource"
-	exphttpclient "github.com/grafana/grafana-plugin-sdk-go/experimental/errorsource/httpclient"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
 	"go.opentelemetry.io/otel/trace"
@@ -97,8 +97,8 @@ func newInstanceSettings(httpClientProvider httpclient.Provider) datasource.Inst
 			return nil, err
 		}
 
-		// enable experimental http client to support errors with source
-		client, err := exphttpclient.New(opts)
+		opts.Middlewares = append(sdkhttpclient.DefaultMiddlewares(), errorsource.Middleware("errorsource"))
+		client, err := httpClientProvider.New(opts)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/tsdb/loki/loki.go
+++ b/pkg/tsdb/loki/loki.go
@@ -15,6 +15,8 @@ import (
 	"github.com/grafana/grafana-plugin-sdk-go/backend/datasource"
 	"github.com/grafana/grafana-plugin-sdk-go/backend/instancemgmt"
 	"github.com/grafana/grafana-plugin-sdk-go/data"
+	"github.com/grafana/grafana-plugin-sdk-go/experimental/errorsource"
+	exphttpclient "github.com/grafana/grafana-plugin-sdk-go/experimental/errorsource/httpclient"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
 	"go.opentelemetry.io/otel/trace"
@@ -95,7 +97,8 @@ func newInstanceSettings(httpClientProvider httpclient.Provider) datasource.Inst
 			return nil, err
 		}
 
-		client, err := httpClientProvider.New(opts)
+		// enable experimental http client to support errors with source
+		client, err := exphttpclient.New(opts)
 		if err != nil {
 			return nil, err
 		}
@@ -239,37 +242,28 @@ func executeQuery(ctx context.Context, query *lokiQuery, req *backend.QueryDataR
 
 	defer span.End()
 
-	frames, err := runQuery(ctx, api, query, responseOpts, plog)
-	queryRes := backend.DataResponse{}
-	if err != nil {
-		span.RecordError(err)
-		span.SetStatus(codes.Error, err.Error())
-		queryRes.Error = err
-	} else {
-		queryRes.Frames = frames
-	}
-
-	return queryRes
+	res := runQuery(ctx, api, query, responseOpts, plog)
+	return res
 }
 
 // we extracted this part of the functionality to make it easy to unit-test it
-func runQuery(ctx context.Context, api *LokiAPI, query *lokiQuery, responseOpts ResponseOpts, plog log.Logger) (data.Frames, error) {
-	frames, err := api.DataQuery(ctx, *query, responseOpts)
-	if err != nil {
-		plog.Error("Error querying loki", "error", err)
-		return data.Frames{}, err
+func runQuery(ctx context.Context, api *LokiAPI, query *lokiQuery, responseOpts ResponseOpts, plog log.Logger) backend.DataResponse {
+	dataResponse := api.DataQuery(ctx, *query, responseOpts)
+	if dataResponse.Error != nil {
+		plog.Error("Error querying loki", "error", dataResponse.Error)
+		return dataResponse
 	}
 
-	for _, frame := range frames {
-		err = adjustFrame(frame, query, !responseOpts.metricDataplane, responseOpts.logsDataplane)
+	for _, frame := range dataResponse.Frames {
+		err := adjustFrame(frame, query, !responseOpts.metricDataplane, responseOpts.logsDataplane)
 
 		if err != nil {
 			plog.Error("Error adjusting frame", "error", err)
-			return data.Frames{}, err
+			return errorsource.Response(errorsource.PluginError(err, false))
 		}
 	}
 
-	return frames, nil
+	return dataResponse
 }
 
 func (s *Service) getDSInfo(ctx context.Context, pluginCtx backend.PluginContext) (*datasourceInfo, error) {

--- a/pkg/tsdb/loki/loki_bench_test.go
+++ b/pkg/tsdb/loki/loki_bench_test.go
@@ -19,7 +19,7 @@ func BenchmarkMatrixJson(b *testing.B) {
 
 	b.ResetTimer()
 	for n := 0; n < b.N; n++ {
-		_, _ = runQuery(context.Background(), makeMockedAPI(http.StatusOK, "application/json", bytes, nil), &lokiQuery{}, ResponseOpts{}, log.New("test"))
+		_ = runQuery(context.Background(), makeMockedAPI(http.StatusOK, "application/json", bytes, nil), &lokiQuery{}, ResponseOpts{}, log.New("test"))
 	}
 }
 


### PR DESCRIPTION
Same as https://github.com/grafana/grafana/pull/77386 done for Elasticsearch. In this PR, we are adding logic to support `status_source` for `DataQuery`. 

Fixes https://github.com/grafana/grafana/issues/77357


We are doing 2 things:
- using `exphttpclient.New(opts)` to enrich our http errors with error source
- sending errors back in response together with source, instead of returning `err`

Important part here was that the resp and error is received in `func (api *LokiAPI) DataQuery` and so instead of returning frames and err, I refactored this to return `backend.DataResponse` that either has frames or error. 