### PR TITLE
Auto-generate: Update history link to send user to Grafana LLM plugin page

### DIFF
--- a/public/app/features/dashboard/components/GenAI/GenAIHistory.tsx
+++ b/public/app/features/dashboard/components/GenAI/GenAIHistory.tsx
@@ -157,9 +157,14 @@ export const GenAIHistory = ({
       <div className={styles.footer}>
         <Icon name="exclamation-circle" aria-label="exclamation-circle" className={styles.infoColor} />
         <Text variant="bodySmall" color="secondary">
-          This content is AI-generated.{' '}
-          <TextLink variant="bodySmall" href="https://grafana.com/grafana/dashboards/" external onClick={onClickDocs}>
-            Learn more
+          This content is AI-generated using the{' '}
+          <TextLink
+            variant="bodySmall"
+            href="https://grafana.com/docs/grafana-cloud/alerting-and-irm/machine-learning/llm-plugin/"
+            external
+            onClick={onClickDocs}
+          >
+            Grafana LLM plugin
           </TextLink>
         </Text>
       </div>


### PR DESCRIPTION
Update gen history link to go to [Grafana LLM plugin page](https://grafana.com/docs/grafana-cloud/alerting-and-irm/machine-learning/llm-plugin/) instead of generic Grafana dashboards page 😬 

![updated version](https://github.com/grafana/grafana/assets/22381771/2bd0efb0-8262-49d3-92f3-d3cd9365ae41)
