### PR TITLE
Grafana app platform: drop etcd requirement in example-apiserver

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ WIRE_TAGS = "oss"
 -include local/Makefile
 include .bingo/Variables.mk
 
-.PHONY: all deps-go deps-js deps build-go build-backend build-server build-cli build-js build build-docker-full build-docker-full-ubuntu lint-go golangci-lint test-go test-js gen-ts test run run-frontend clean devenv devenv-down protobuf drone help gen-go gen-cue fix-cue
+.PHONY: all deps-go deps-js deps build-go build-backend build-example-apiserver build-server build-cli build-js build build-docker-full build-docker-full-ubuntu lint-go golangci-lint test-go test-js gen-ts test run run-frontend clean devenv devenv-down protobuf drone help gen-go gen-cue fix-cue
 
 GO = go
 GO_FILES ?= ./pkg/...

--- a/pkg/cmd/grafana-example-apiserver/README.md
+++ b/pkg/cmd/grafana-example-apiserver/README.md
@@ -3,34 +3,23 @@
 The example-apiserver closely resembles the 
 [sample-apiserver](https://github.com/kubernetes/sample-apiserver/tree/master) project in code and thus
 allows the same
-[CLI flags](https://kubernetes.io/docs/reference/command-line-tools-reference/kube-apiserver/) as kube-apiserver
+[CLI flags](https://kubernetes.io/docs/reference/command-line-tools-reference/kube-apiserver/) as kube-apiserver.
 It is currently used for testing our deployment pipelines for aggregated servers.
 
 ## Prerequisites:
-1. etcd
-  ```shell
-  brew install etcd
-  ```
-2. kind: you will need kind (or another local K8s setup) if you want to test aggregation.
+1. kind: you will need kind (or another local K8s setup) if you want to test aggregation.
   ```
   go install sigs.k8s.io/kind@v0.20.0 && kind create cluster
   ```
 
 ## Usage
 
-Have `etcd` running in your environment:
-
-```shell
-etcd &
-```
-
-With etcd running, you can now start the example-apiserver. The Authn / Authz flags are set up so that the kind cluster
+You can start the example-apiserver with an invocation as shown below. The Authn / Authz flags are set up so that the kind cluster
 can be used as a root server for this example-apiserver (in aggregated mode). Here, it's assumed that you have a local
 kind cluster and that you can provide its kubeconfig in the parameters to the example-apiserver.
 
 ```shell
 go run ./pkg/cmd/grafana-example-apiserver \
-  --etcd-servers=http://127.0.0.1:2379 \
   --authentication-kubeconfig ~/.kube/config \
   --authorization-kubeconfig ~/.kube/config \
   --kubeconfig ~/.kube/config \

--- a/pkg/cmd/grafana-example-apiserver/main.go
+++ b/pkg/cmd/grafana-example-apiserver/main.go
@@ -18,10 +18,6 @@ func NewCommandStartExampleAPIServer(defaults *ExampleServerOptions, stopCh <-ch
 				return err
 			}
 
-			if err := o.Validate(args); err != nil {
-				return err
-			}
-
 			config, err := o.Config()
 			if err != nil {
 				return err

--- a/pkg/cmd/grafana-example-apiserver/server.go
+++ b/pkg/cmd/grafana-example-apiserver/server.go
@@ -80,6 +80,7 @@ func (o ExampleServerOptions) Config() (*genericapiserver.RecommendedConfig, err
 
 	o.RecommendedOptions.Admission = nil
 	o.RecommendedOptions.CoreAPI = nil
+	o.RecommendedOptions.Etcd = nil
 
 	serverConfig := genericapiserver.NewRecommendedConfig(Codecs)
 
@@ -91,6 +92,8 @@ func (o ExampleServerOptions) Config() (*genericapiserver.RecommendedConfig, err
 }
 
 // Validate validates ExampleServerOptions
+// NOTE: we don't call validate on the top level recommended options as it doesn't like skipping etcd-servers
+// the function is left here for troubleshooting any other config issues
 func (o ExampleServerOptions) Validate(args []string) error {
 	errors := []error{}
 	errors = append(errors, o.RecommendedOptions.Validate()...)


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

Removes the need to specify etcd configuration.

**Why do we need this feature?**

In target architecture, we will be depending on our storage interface through a gRPC service or another API contract. Hence, there is no need for `etcd`.

**Who is this feature for?**

Grafana App Platform Squad