### PR TITLE
Alerting: Add actions extension point to alert instances table view

### DIFF
--- a/packages/grafana-data/src/types/pluginExtensions.ts
+++ b/packages/grafana-data/src/types/pluginExtensions.ts
@@ -117,6 +117,7 @@ export type PluginExtensionEventHelpers<Context extends object = object> = {
 
 // Extension Points available in core Grafana
 export enum PluginExtensionPoints {
+  AlertInstanceAction = 'grafana/alerting/instance/action',
   DashboardPanelMenu = 'grafana/dashboard/panel/menu',
   DataSourceConfig = 'grafana/datasources/config',
   ExploreToolbarAction = 'grafana/explore/toolbar/action',

--- a/public/app/features/alerting/unified/RuleList.test.tsx
+++ b/public/app/features/alerting/unified/RuleList.test.tsx
@@ -5,7 +5,14 @@ import React from 'react';
 import { TestProvider } from 'test/helpers/TestProvider';
 import { byRole, byTestId, byText } from 'testing-library-selector';
 
-import { DataSourceSrv, locationService, setBackendSrv, setDataSourceSrv } from '@grafana/runtime';
+import { PluginExtensionTypes } from '@grafana/data';
+import {
+  DataSourceSrv,
+  getPluginLinkExtensions,
+  locationService,
+  setBackendSrv,
+  setDataSourceSrv,
+} from '@grafana/runtime';
 import { backendSrv } from 'app/core/services/backend_srv';
 import * as ruleActionButtons from 'app/features/alerting/unified/components/rules/RuleActionsButtons';
 import * as actions from 'app/features/alerting/unified/state/actions';
@@ -32,6 +39,10 @@ import {
 import * as config from './utils/config';
 import { DataSourceType, GRAFANA_RULES_SOURCE_NAME } from './utils/datasource';
 
+jest.mock('@grafana/runtime', () => ({
+  ...jest.requireActual('@grafana/runtime'),
+  getPluginLinkExtensions: jest.fn(),
+}));
 jest.mock('./api/buildInfo');
 jest.mock('./api/prometheus');
 jest.mock('./api/ruler');
@@ -53,6 +64,7 @@ jest.spyOn(actions, 'rulesInSameGroupHaveInvalidFor').mockReturnValue([]);
 
 const mocks = {
   getAllDataSourcesMock: jest.mocked(config.getAllDataSources),
+  getPluginLinkExtensionsMock: jest.mocked(getPluginLinkExtensions),
   rulesInSameGroupHaveInvalidForMock: jest.mocked(actions.rulesInSameGroupHaveInvalidFor),
 
   api: {
@@ -137,6 +149,19 @@ describe('RuleList', () => {
       AccessControlAction.AlertingRuleExternalWrite,
     ]);
     mocks.rulesInSameGroupHaveInvalidForMock.mockReturnValue([]);
+    mocks.getPluginLinkExtensionsMock.mockReturnValue({
+      extensions: [
+        {
+          pluginId: 'grafana-ml-app',
+          id: '1',
+          type: PluginExtensionTypes.link,
+          title: 'Run investigation',
+          category: 'Sift',
+          description: 'Run a Sift investigation for this alert',
+          onClick: jest.fn(),
+        },
+      ],
+    });
   });
 
   afterEach(() => {

--- a/public/app/features/alerting/unified/components/extensions/AlertInstanceExtensionPoint.tsx
+++ b/public/app/features/alerting/unified/components/extensions/AlertInstanceExtensionPoint.tsx
@@ -40,17 +40,14 @@ export const AlertInstanceExtensionPoint = ({
   );
 };
 
-export type PluginExtensionAlertListItemContext = {
-  instance: Alert;
-};
-
 export type PluginExtensionAlertInstanceContext = {
   instance: Alert;
 };
 
-type Context = PluginExtensionAlertListItemContext | PluginExtensionAlertInstanceContext;
-
-function useExtensionLinks(context: Context, extensionPointId: PluginExtensionPoints): PluginExtensionLink[] {
+function useExtensionLinks(
+  context: PluginExtensionAlertInstanceContext,
+  extensionPointId: PluginExtensionPoints
+): PluginExtensionLink[] {
   return useMemo(() => {
     const { extensions } = getPluginLinkExtensions({
       extensionPointId,

--- a/public/app/features/alerting/unified/components/extensions/AlertInstanceExtensionPoint.tsx
+++ b/public/app/features/alerting/unified/components/extensions/AlertInstanceExtensionPoint.tsx
@@ -4,21 +4,23 @@ import { PluginExtensionLink, PluginExtensionPoints } from '@grafana/data';
 import { getPluginLinkExtensions } from '@grafana/runtime';
 import { Dropdown, IconButton } from '@grafana/ui';
 import { ConfirmNavigationModal } from 'app/features/explore/extensions/ConfirmNavigationModal';
-import { Alert } from 'app/types/unified-alerting';
+import { Alert, CombinedRule } from 'app/types/unified-alerting';
 
 import { AlertExtensionPointMenu } from './AlertInstanceExtensionPointMenu';
 
 interface AlertInstanceExtensionPointProps {
+  rule?: CombinedRule;
   instance: Alert;
   extensionPointId: PluginExtensionPoints;
 }
 
 export const AlertInstanceExtensionPoint = ({
+  rule,
   instance,
   extensionPointId,
 }: AlertInstanceExtensionPointProps): ReactElement | null => {
   const [selectedExtension, setSelectedExtension] = useState<PluginExtensionLink | undefined>();
-  const context = { instance };
+  const context = { instance, rule };
   const extensions = useExtensionLinks(context, extensionPointId);
 
   const menu = <AlertExtensionPointMenu extensions={extensions} onSelect={setSelectedExtension} />;
@@ -41,6 +43,7 @@ export const AlertInstanceExtensionPoint = ({
 };
 
 export type PluginExtensionAlertInstanceContext = {
+  rule?: CombinedRule;
   instance: Alert;
 };
 

--- a/public/app/features/alerting/unified/components/extensions/AlertInstanceExtensionPoint.tsx
+++ b/public/app/features/alerting/unified/components/extensions/AlertInstanceExtensionPoint.tsx
@@ -27,9 +27,7 @@ export const AlertInstanceExtensionPoint = ({
   return (
     <>
       <Dropdown placement="bottom-start" overlay={menu}>
-        <IconButton name="bars" aria-label="Actions" disabled={extensions.length === 0} variant="secondary">
-          Actions
-        </IconButton>
+        <IconButton name="bars" aria-label="Actions" disabled={extensions.length === 0} variant="secondary" />
       </Dropdown>
       {!!selectedExtension && !!selectedExtension.path && (
         <ConfirmNavigationModal

--- a/public/app/features/alerting/unified/components/extensions/AlertInstanceExtensionPoint.tsx
+++ b/public/app/features/alerting/unified/components/extensions/AlertInstanceExtensionPoint.tsx
@@ -23,11 +23,15 @@ export const AlertInstanceExtensionPoint = ({
   const context = { instance, rule };
   const extensions = useExtensionLinks(context, extensionPointId);
 
+  if (extensions.length === 0) {
+    return null;
+  }
+
   const menu = <AlertExtensionPointMenu extensions={extensions} onSelect={setSelectedExtension} />;
   return (
     <>
       <Dropdown placement="bottom-start" overlay={menu}>
-        <IconButton name="ellipsis-v" aria-label="Actions" disabled={extensions.length === 0} variant="secondary" />
+        <IconButton name="ellipsis-v" aria-label="Actions" variant="secondary" />
       </Dropdown>
       {!!selectedExtension && !!selectedExtension.path && (
         <ConfirmNavigationModal

--- a/public/app/features/alerting/unified/components/extensions/AlertInstanceExtensionPoint.tsx
+++ b/public/app/features/alerting/unified/components/extensions/AlertInstanceExtensionPoint.tsx
@@ -1,0 +1,63 @@
+import React, { ReactElement, useMemo, useState } from 'react';
+
+import { PluginExtensionLink, PluginExtensionPoints } from '@grafana/data';
+import { getPluginLinkExtensions } from '@grafana/runtime';
+import { Dropdown, IconButton } from '@grafana/ui';
+import { ConfirmNavigationModal } from 'app/features/explore/extensions/ConfirmNavigationModal';
+import { Alert } from 'app/types/unified-alerting';
+
+import { AlertExtensionPointMenu } from './AlertInstanceExtensionPointMenu';
+
+interface AlertInstanceExtensionPointProps {
+  instance: Alert;
+  extensionPointId: PluginExtensionPoints;
+}
+
+export const AlertInstanceExtensionPoint = ({
+  instance,
+  extensionPointId,
+}: AlertInstanceExtensionPointProps): ReactElement | null => {
+  const [selectedExtension, setSelectedExtension] = useState<PluginExtensionLink | undefined>();
+  const context = { instance };
+  const extensions = useExtensionLinks(context, extensionPointId);
+
+  const menu = <AlertExtensionPointMenu extensions={extensions} onSelect={setSelectedExtension} />;
+  return (
+    <>
+      <Dropdown placement="bottom-start" overlay={menu}>
+        <IconButton name="bars" aria-label="Actions" disabled={extensions.length === 0} variant="secondary">
+          Actions
+        </IconButton>
+      </Dropdown>
+      {!!selectedExtension && !!selectedExtension.path && (
+        <ConfirmNavigationModal
+          path={selectedExtension.path}
+          title={selectedExtension.title}
+          onDismiss={() => setSelectedExtension(undefined)}
+        />
+      )}
+    </>
+  );
+};
+
+export type PluginExtensionAlertListItemContext = {
+  instance: Alert;
+};
+
+export type PluginExtensionAlertInstanceContext = {
+  instance: Alert;
+};
+
+type Context = PluginExtensionAlertListItemContext | PluginExtensionAlertInstanceContext;
+
+function useExtensionLinks(context: Context, extensionPointId: PluginExtensionPoints): PluginExtensionLink[] {
+  return useMemo(() => {
+    const { extensions } = getPluginLinkExtensions({
+      extensionPointId,
+      context,
+      limitPerPlugin: 3,
+    });
+
+    return extensions;
+  }, [context, extensionPointId]);
+}

--- a/public/app/features/alerting/unified/components/extensions/AlertInstanceExtensionPoint.tsx
+++ b/public/app/features/alerting/unified/components/extensions/AlertInstanceExtensionPoint.tsx
@@ -27,7 +27,7 @@ export const AlertInstanceExtensionPoint = ({
   return (
     <>
       <Dropdown placement="bottom-start" overlay={menu}>
-        <IconButton name="bars" aria-label="Actions" disabled={extensions.length === 0} variant="secondary" />
+        <IconButton name="ellipsis-v" aria-label="Actions" disabled={extensions.length === 0} variant="secondary" />
       </Dropdown>
       {!!selectedExtension && !!selectedExtension.path && (
         <ConfirmNavigationModal

--- a/public/app/features/alerting/unified/components/extensions/AlertInstanceExtensionPointMenu.tsx
+++ b/public/app/features/alerting/unified/components/extensions/AlertInstanceExtensionPointMenu.tsx
@@ -1,0 +1,2 @@
+// We might want to customise this in future but right now the toolbar menu from the Explore view is fine.
+export { ToolbarExtensionPointMenu as AlertExtensionPointMenu } from 'app/features/explore/extensions/ToolbarExtensionPointMenu';

--- a/public/app/features/alerting/unified/components/rule-viewer/RuleViewer.v1.test.tsx
+++ b/public/app/features/alerting/unified/components/rule-viewer/RuleViewer.v1.test.tsx
@@ -4,7 +4,8 @@ import React from 'react';
 import { TestProvider } from 'test/helpers/TestProvider';
 import { byRole, byText } from 'testing-library-selector';
 
-import { locationService, setBackendSrv } from '@grafana/runtime';
+import { PluginExtensionTypes } from '@grafana/data';
+import { getPluginLinkExtensions, locationService, setBackendSrv } from '@grafana/runtime';
 import { GrafanaRouteComponentProps } from 'app/core/navigation/types';
 import { backendSrv } from 'app/core/services/backend_srv';
 import { contextSrv } from 'app/core/services/context_srv';
@@ -48,10 +49,15 @@ const mockRoute = (id?: string): GrafanaRouteComponentProps<{ id?: string; sourc
   staticContext: {},
 });
 
+jest.mock('@grafana/runtime', () => ({
+  ...jest.requireActual('@grafana/runtime'),
+  getPluginLinkExtensions: jest.fn(),
+}));
 jest.mock('../../hooks/useIsRuleEditable');
 jest.mock('../../api/buildInfo');
 
 const mocks = {
+  getPluginLinkExtensionsMock: jest.mocked(getPluginLinkExtensions),
   useIsRuleEditable: jest.mocked(useIsRuleEditable),
 };
 
@@ -143,6 +149,19 @@ beforeEach(() => {
       ],
     },
     status: 'success',
+  });
+  mocks.getPluginLinkExtensionsMock.mockReturnValue({
+    extensions: [
+      {
+        pluginId: 'grafana-ml-app',
+        id: '1',
+        type: PluginExtensionTypes.link,
+        title: 'Run investigation',
+        category: 'Sift',
+        description: 'Run a Sift investigation for this alert',
+        onClick: jest.fn(),
+      },
+    ],
   });
 });
 

--- a/public/app/features/alerting/unified/components/rules/AlertInstancesTable.tsx
+++ b/public/app/features/alerting/unified/components/rules/AlertInstancesTable.tsx
@@ -1,11 +1,12 @@
 import React, { useMemo } from 'react';
 
-import { dateTime, findCommonLabels } from '@grafana/data';
+import { PluginExtensionPoints, dateTime, findCommonLabels } from '@grafana/data';
 import { Alert, PaginationProps } from 'app/types/unified-alerting';
 
 import { alertInstanceKey } from '../../utils/rules';
 import { AlertLabels } from '../AlertLabels';
 import { DynamicTable, DynamicTableColumnProps, DynamicTableItemProps } from '../DynamicTable';
+import { AlertInstanceExtensionPoint } from '../extensions/AlertInstanceExtensionPoint';
 
 import { AlertInstanceDetails } from './AlertInstanceDetails';
 import { AlertStateTag } from './AlertStateTag';
@@ -75,5 +76,17 @@ const columns: AlertTableColumnProps[] = [
       <>{activeAt.startsWith('0001') ? '-' : dateTime(activeAt).format('YYYY-MM-DD HH:mm:ss')}</>
     ),
     size: '150px',
+  },
+  {
+    id: 'actions',
+    label: '',
+    renderCell: ({ data: alert }) => (
+      <AlertInstanceExtensionPoint
+        instance={alert}
+        extensionPointId={PluginExtensionPoints.AlertInstanceAction}
+        key="alert-instance-extension-point"
+      />
+    ),
+    size: '40px',
   },
 ];

--- a/public/app/features/alerting/unified/components/rules/AlertInstancesTable.tsx
+++ b/public/app/features/alerting/unified/components/rules/AlertInstancesTable.tsx
@@ -1,7 +1,7 @@
 import React, { useMemo } from 'react';
 
 import { PluginExtensionPoints, dateTime, findCommonLabels } from '@grafana/data';
-import { Alert, PaginationProps } from 'app/types/unified-alerting';
+import { Alert, CombinedRule, PaginationProps } from 'app/types/unified-alerting';
 
 import { alertInstanceKey } from '../../utils/rules';
 import { AlertLabels } from '../AlertLabels';
@@ -12,6 +12,7 @@ import { AlertInstanceDetails } from './AlertInstanceDetails';
 import { AlertStateTag } from './AlertStateTag';
 
 interface Props {
+  rule?: CombinedRule;
   instances: Alert[];
   pagination?: PaginationProps;
   footerRow?: JSX.Element;
@@ -21,10 +22,15 @@ interface AlertWithCommonLabels extends Alert {
   commonLabels?: Record<string, string>;
 }
 
-type AlertTableColumnProps = DynamicTableColumnProps<AlertWithCommonLabels>;
-type AlertTableItemProps = DynamicTableItemProps<AlertWithCommonLabels>;
+interface RuleAndAlert {
+  rule?: CombinedRule;
+  alert: AlertWithCommonLabels;
+}
 
-export const AlertInstancesTable = ({ instances, pagination, footerRow }: Props) => {
+type AlertTableColumnProps = DynamicTableColumnProps<RuleAndAlert>;
+type AlertTableItemProps = DynamicTableItemProps<RuleAndAlert>;
+
+export const AlertInstancesTable = ({ rule, instances, pagination, footerRow }: Props) => {
   const commonLabels = useMemo(() => {
     // only compute the common labels if we have more than 1 instance, if we don't then that single instance
     // will have the complete set of common labels and no unique ones
@@ -34,10 +40,10 @@ export const AlertInstancesTable = ({ instances, pagination, footerRow }: Props)
   const items = useMemo(
     (): AlertTableItemProps[] =>
       instances.map((instance) => ({
-        data: { ...instance, commonLabels },
+        data: { rule, alert: { ...instance, commonLabels } },
         id: alertInstanceKey(instance),
       })),
-    [commonLabels, instances]
+    [commonLabels, instances, rule]
   );
 
   return (
@@ -45,7 +51,7 @@ export const AlertInstancesTable = ({ instances, pagination, footerRow }: Props)
       cols={columns}
       isExpandable={true}
       items={items}
-      renderExpandedContent={({ data }) => <AlertInstanceDetails instance={data} />}
+      renderExpandedContent={({ data }) => <AlertInstanceDetails instance={data.alert} />}
       pagination={pagination}
       footerRow={footerRow}
     />
@@ -57,31 +63,40 @@ const columns: AlertTableColumnProps[] = [
     id: 'state',
     label: 'State',
     // eslint-disable-next-line react/display-name
-    renderCell: ({ data: { state } }) => <AlertStateTag state={state} />,
+    renderCell: ({
+      data: {
+        alert: { state },
+      },
+    }) => <AlertStateTag state={state} />,
     size: '80px',
   },
   {
     id: 'labels',
     label: 'Labels',
     // eslint-disable-next-line react/display-name
-    renderCell: ({ data: { labels, commonLabels } }) => (
-      <AlertLabels labels={labels} commonLabels={commonLabels} size="sm" />
-    ),
+    renderCell: ({
+      data: {
+        alert: { labels, commonLabels },
+      },
+    }) => <AlertLabels labels={labels} commonLabels={commonLabels} size="sm" />,
   },
   {
     id: 'created',
     label: 'Created',
     // eslint-disable-next-line react/display-name
-    renderCell: ({ data: { activeAt } }) => (
-      <>{activeAt.startsWith('0001') ? '-' : dateTime(activeAt).format('YYYY-MM-DD HH:mm:ss')}</>
-    ),
+    renderCell: ({
+      data: {
+        alert: { activeAt },
+      },
+    }) => <>{activeAt.startsWith('0001') ? '-' : dateTime(activeAt).format('YYYY-MM-DD HH:mm:ss')}</>,
     size: '150px',
   },
   {
     id: 'actions',
     label: '',
-    renderCell: ({ data: alert }) => (
+    renderCell: ({ data: { alert, rule } }) => (
       <AlertInstanceExtensionPoint
+        rule={rule}
         instance={alert}
         extensionPointId={PluginExtensionPoints.AlertInstanceAction}
         key="alert-instance-extension-point"

--- a/public/app/features/alerting/unified/components/rules/RuleDetails.test.tsx
+++ b/public/app/features/alerting/unified/components/rules/RuleDetails.test.tsx
@@ -5,7 +5,8 @@ import { Provider } from 'react-redux';
 import { MemoryRouter } from 'react-router-dom';
 import { byRole } from 'testing-library-selector';
 
-import { setBackendSrv } from '@grafana/runtime';
+import { PluginExtensionTypes } from '@grafana/data';
+import { getPluginLinkExtensions, setBackendSrv } from '@grafana/runtime';
 import { backendSrv } from 'app/core/services/backend_srv';
 import { contextSrv } from 'app/core/services/context_srv';
 import { AlertmanagerChoice } from 'app/plugins/datasource/alertmanager/types';
@@ -20,9 +21,15 @@ import { mockAlertmanagerChoiceResponse } from '../../mocks/alertmanagerApi';
 
 import { RuleDetails } from './RuleDetails';
 
+jest.mock('@grafana/runtime', () => ({
+  ...jest.requireActual('@grafana/runtime'),
+  getPluginLinkExtensions: jest.fn(),
+}));
+
 jest.mock('../../hooks/useIsRuleEditable');
 
 const mocks = {
+  getPluginLinkExtensionsMock: jest.mocked(getPluginLinkExtensions),
   useIsRuleEditable: jest.mocked(useIsRuleEditable),
 };
 
@@ -52,6 +59,19 @@ afterAll(() => {
 });
 
 beforeEach(() => {
+  mocks.getPluginLinkExtensionsMock.mockReturnValue({
+    extensions: [
+      {
+        pluginId: 'grafana-ml-app',
+        id: '1',
+        type: PluginExtensionTypes.link,
+        title: 'Run investigation',
+        category: 'Sift',
+        description: 'Run a Sift investigation for this alert',
+        onClick: jest.fn(),
+      },
+    ],
+  });
   server.resetHandlers();
 });
 

--- a/public/app/features/alerting/unified/components/rules/RuleDetailsMatchingInstances.test.tsx
+++ b/public/app/features/alerting/unified/components/rules/RuleDetailsMatchingInstances.test.tsx
@@ -4,12 +4,24 @@ import { times } from 'lodash';
 import React from 'react';
 import { byLabelText, byRole, byTestId } from 'testing-library-selector';
 
+import { PluginExtensionTypes } from '@grafana/data';
+import { getPluginLinkExtensions } from '@grafana/runtime';
+
 import { CombinedRuleNamespace } from '../../../../../types/unified-alerting';
 import { GrafanaAlertState, PromAlertingRuleState } from '../../../../../types/unified-alerting-dto';
 import { mockCombinedRule, mockDataSource, mockPromAlert, mockPromAlertingRule } from '../../mocks';
 import { alertStateToReadable } from '../../utils/rules';
 
 import { RuleDetailsMatchingInstances } from './RuleDetailsMatchingInstances';
+
+jest.mock('@grafana/runtime', () => ({
+  ...jest.requireActual('@grafana/runtime'),
+  getPluginLinkExtensions: jest.fn(),
+}));
+
+const mocks = {
+  getPluginLinkExtensionsMock: jest.mocked(getPluginLinkExtensions),
+};
 
 const ui = {
   stateFilter: byTestId('alert-instance-state-filter'),
@@ -30,6 +42,22 @@ const ui = {
 };
 
 describe('RuleDetailsMatchingInstances', () => {
+  beforeEach(() => {
+    mocks.getPluginLinkExtensionsMock.mockReturnValue({
+      extensions: [
+        {
+          pluginId: 'grafana-ml-app',
+          id: '1',
+          type: PluginExtensionTypes.link,
+          title: 'Run investigation',
+          category: 'Sift',
+          description: 'Run a Sift investigation for this alert',
+          onClick: jest.fn(),
+        },
+      ],
+    });
+  });
+
   describe('Filtering', () => {
     it('For Grafana Managed rules instances filter should contain five states', () => {
       const rule = mockCombinedRule();

--- a/public/app/features/alerting/unified/components/rules/RuleDetailsMatchingInstances.tsx
+++ b/public/app/features/alerting/unified/components/rules/RuleDetailsMatchingInstances.tsx
@@ -53,12 +53,8 @@ function ShowMoreInstances(props: { onClick: () => void; stats: ShowMoreStats })
 
 export function RuleDetailsMatchingInstances(props: Props): JSX.Element | null {
   const history = useHistory();
-  const {
-    rule: { promRule, namespace, instanceTotals },
-    itemsDisplayLimit = Number.POSITIVE_INFINITY,
-    pagination,
-    enableFiltering = false,
-  } = props;
+  const { rule, itemsDisplayLimit = Number.POSITIVE_INFINITY, pagination, enableFiltering = false } = props;
+  const { promRule, namespace, instanceTotals } = rule;
 
   const [queryString, setQueryString] = useState<string>();
   const [alertState, setAlertState] = useState<InstanceStateFilter>();
@@ -129,7 +125,7 @@ export function RuleDetailsMatchingInstances(props: Props): JSX.Element | null {
         </div>
       )}
       {!enableFiltering && <div className={styles.stats}>{statsComponents}</div>}
-      <AlertInstancesTable instances={visibleInstances} pagination={pagination} footerRow={footerRow} />
+      <AlertInstancesTable rule={rule} instances={visibleInstances} pagination={pagination} footerRow={footerRow} />
     </DetailsField>
   );
 }

--- a/public/app/plugins/panel/alertlist/AlertInstances.tsx
+++ b/public/app/plugins/panel/alertlist/AlertInstances.tsx
@@ -8,7 +8,7 @@ import { Button, clearButtonStyles, Icon, useStyles2 } from '@grafana/ui';
 import { AlertInstancesTable } from 'app/features/alerting/unified/components/rules/AlertInstancesTable';
 import { INSTANCES_DISPLAY_LIMIT } from 'app/features/alerting/unified/components/rules/RuleDetails';
 import { sortAlerts } from 'app/features/alerting/unified/utils/misc';
-import { Alert } from 'app/types/unified-alerting';
+import { Alert, CombinedRule } from 'app/types/unified-alerting';
 
 import { DEFAULT_PER_PAGE_PAGINATION } from '../../../core/constants';
 
@@ -16,6 +16,7 @@ import { GroupMode, UnifiedAlertListOptions } from './types';
 import { filterAlerts } from './util';
 
 interface Props {
+  rule?: CombinedRule;
   alerts: Alert[];
   options: PanelProps<UnifiedAlertListOptions>['options'];
   grafanaTotalInstances?: number;
@@ -25,6 +26,7 @@ interface Props {
 }
 
 export const AlertInstances = ({
+  rule,
   alerts,
   options,
   grafanaTotalInstances,
@@ -125,6 +127,7 @@ export const AlertInstances = ({
       )}
       {displayInstances && (
         <AlertInstancesTable
+          rule={rule}
           instances={filteredAlerts}
           pagination={{ itemsPerPage: 2 * DEFAULT_PER_PAGE_PAGINATION }}
           footerRow={footerRow}

--- a/public/app/plugins/panel/alertlist/UnifiedalertList.test.tsx
+++ b/public/app/plugins/panel/alertlist/UnifiedalertList.test.tsx
@@ -5,8 +5,8 @@ import { Provider } from 'react-redux';
 import { act } from 'react-test-renderer';
 import { byRole, byText } from 'testing-library-selector';
 
-import { FieldConfigSource, getDefaultTimeRange, LoadingState, PanelProps } from '@grafana/data';
-import { TimeRangeUpdatedEvent } from '@grafana/runtime';
+import { FieldConfigSource, getDefaultTimeRange, LoadingState, PanelProps, PluginExtensionTypes } from '@grafana/data';
+import { getPluginLinkExtensions, TimeRangeUpdatedEvent } from '@grafana/runtime';
 import { setupMswServer } from 'app/features/alerting/unified/mockApi';
 import { mockPromRulesApiResponse } from 'app/features/alerting/unified/mocks/alertRuleApi';
 import { mockRulerRulesApiResponse } from 'app/features/alerting/unified/mocks/rulerApi';
@@ -56,7 +56,15 @@ const grafanaRuleMock = {
   },
 };
 
+jest.mock('@grafana/runtime', () => ({
+  ...jest.requireActual('@grafana/runtime'),
+  getPluginLinkExtensions: jest.fn(),
+}));
 jest.mock('app/features/alerting/unified/api/alertmanager');
+
+const mocks = {
+  getPluginLinkExtensionsMock: jest.mocked(getPluginLinkExtensions),
+};
 
 const fakeResponse: PromRulesResponse = {
   data: { groups: grafanaRuleMock.promRules.grafana.result[0].groups as PromRuleGroupDTO[] },
@@ -77,6 +85,19 @@ beforeEach(() => {
   );
   mockRulerRulesApiResponse(server, 'grafana', {
     'folder-one': [{ name: 'group1', interval: '20s', rules: [originRule] }],
+  });
+  mocks.getPluginLinkExtensionsMock.mockReturnValue({
+    extensions: [
+      {
+        pluginId: 'grafana-ml-app',
+        id: '1',
+        type: PluginExtensionTypes.link,
+        title: 'Run investigation',
+        category: 'Sift',
+        description: 'Run a Sift investigation for this alert',
+        onClick: jest.fn(),
+      },
+    ],
   });
 });
 

--- a/public/app/plugins/panel/alertlist/types.ts
+++ b/public/app/plugins/panel/alertlist/types.ts
@@ -1,5 +1,3 @@
-import { Alert } from 'app/types/unified-alerting';
-
 export enum SortOrder {
   AlphaAsc = 1,
   AlphaDesc,
@@ -65,5 +63,3 @@ export interface UnifiedAlertListOptions {
   datasource: string;
   viewMode: ViewMode;
 }
-
-export type GroupedRules = Map<string, Alert[]>;

--- a/public/app/plugins/panel/alertlist/unified-alerting/UngroupedView.tsx
+++ b/public/app/plugins/panel/alertlist/unified-alerting/UngroupedView.tsx
@@ -119,6 +119,7 @@ const UngroupedModeView = ({ rules, options, handleInstancesLimit, limitInstance
                     </div>
                   </div>
                   <AlertInstances
+                    rule={ruleWithLocation}
                     alerts={alertingRule.alerts ?? []}
                     options={options}
                     grafanaTotalInstances={grafanaInstancesTotal}


### PR DESCRIPTION
**What is this feature?**

This PR adds a new [extension point](https://grafana.com/developers/plugin-tools/ui-extensions/create-an-extension-point) to each row of the alert instances table, which is shown in both the 'Rule list' and the 'Rule details' pages. This allows plugins to add actions to a dropdown menu in the rightmost column of the table. Those actions are passed the alert instance so can use it for contextual handling. This is similar to the dropdown menu in the 'Explore' page (when you click 'Add') or in the panel menu dropdown (under 'Extensions').

See https://github.com/grafana/machine-learning/pull/3461 for an video example of how this can be used (e.g. by Grafana Sift here).

**Why do we need this feature?**

So far if plugins have wanted to add functionality to the alerting page it's been O(N) in the number of UI features added - e.g. adding the Grafana Incident button required work on the alerting page that was specific to that plugin. By adding a plugin extension point, any plugin can easily inject useful functionality in a non-intrusive way without needing further development on the alerting side.

**Who is this feature for?**

Plugin developers who would like to hook into the alerting page (specifically the Sift team, right now), and users who can then interact with alert instances in more varied ways.

**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/machine-learning/issues/3458.

**Special notes for your reviewer:**

Things to consider:

- UX: is it immediately obvious that the icon is a clickable button? what could we replace it with, if not?
  - I chose to omit a heading and keep the column nice and narrow so it was as unintrusive as possible, but it's not massively discoverable now 🤔 
- I've updated existing tests but haven't added any specifically for this, happy to do so but might need some guidance.
- The `PluginExtensionAlertInstanceContext` should probably be exported as part of `@grafana/data` (similar to `PluginExtensionPanelContext`), but it contains private types i.e. (`Alert`). Is there a subset of this `Alert` interface we could add to `@grafana/data`?

Screenshots:

unexpanded: 
<img width="1047" alt="image" src="https://github.com/grafana/grafana/assets/5464991/526f32f5-93c5-493b-ba78-7c22d6f14b7b">

expanded with one action:
<img width="1047" alt="image" src="https://github.com/grafana/grafana/assets/5464991/316dc8b9-d0de-4bd5-82b3-85c408d21ddc">

Please check that:
- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
