### PR TITLE
Chore: Change ownership of the `golang.org/x/net` dependency

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -109,7 +109,7 @@ require (
 	go.opentelemetry.io/otel/trace v1.19.0 // @grafana/backend-platform
 	golang.org/x/crypto v0.14.0 // @grafana/backend-platform
 	golang.org/x/exp v0.0.0-20230321023759-10a507213a29 // @grafana/alerting-squad-backend
-	golang.org/x/net v0.17.0 // @grafana/grafana-bi-squad
+	golang.org/x/net v0.17.0 // @grafana/oss-big-tent
 	golang.org/x/oauth2 v0.13.0 // @grafana/grafana-authnz-team
 	golang.org/x/sync v0.4.0 // @grafana/alerting-squad-backend
 	golang.org/x/time v0.3.0 // @grafana/backend-platform

--- a/go.mod
+++ b/go.mod
@@ -109,7 +109,7 @@ require (
 	go.opentelemetry.io/otel/trace v1.19.0 // @grafana/backend-platform
 	golang.org/x/crypto v0.14.0 // @grafana/backend-platform
 	golang.org/x/exp v0.0.0-20230321023759-10a507213a29 // @grafana/alerting-squad-backend
-	golang.org/x/net v0.17.0 // @grafana/oss-big-tent
+	golang.org/x/net v0.17.0 // @grafana/oss-big-tent @grafana/partner-datasources 
 	golang.org/x/oauth2 v0.13.0 // @grafana/grafana-authnz-team
 	golang.org/x/sync v0.4.0 // @grafana/alerting-squad-backend
 	golang.org/x/time v0.3.0 // @grafana/backend-platform


### PR DESCRIPTION
**What is this feature?**

The `golang.org/x/net` dependency is mainly used in SQL data sources. Since @grafana/oss-big-tent owns most of these data sources now, it makes sense that this dependency changes ownership.