### PR TITLE
InfluxDB: Add support for `>=` and `<=` comparison operators to IQL Query Builder

### DIFF
--- a/pkg/tsdb/influxdb/models/query.go
+++ b/pkg/tsdb/influxdb/models/query.go
@@ -72,7 +72,7 @@ func (query *Query) renderTags() []string {
 		switch tag.Operator {
 		case "=~", "!~":
 			textValue = tag.Value
-		case "<", ">":
+		case "<", ">", ">=", "<=":
 			textValue = tag.Value
 		default:
 			textValue = fmt.Sprintf("'%s'", strings.ReplaceAll(tag.Value, `\`, `\\`))

--- a/pkg/tsdb/influxdb/models/query_test.go
+++ b/pkg/tsdb/influxdb/models/query_test.go
@@ -228,6 +228,17 @@ func TestInfluxdbQueryBuilder(t *testing.T) {
 			require.Equal(t, strings.Join(query.renderTags(), ""), `"key" > 10001`)
 		})
 
+		t.Run("can render number greater than or equal to condition tags", func(t *testing.T) {
+			query := &Query{Tags: []*Tag{{Operator: ">=", Value: "10001", Key: "key"}}}
+
+			require.Equal(t, strings.Join(query.renderTags(), ""), `"key" >= 10001`)
+		})
+		t.Run("can render number less than or equal to condition tags", func(t *testing.T) {
+			query := &Query{Tags: []*Tag{{Operator: "<=", Value: "10001", Key: "key"}}}
+
+			require.Equal(t, strings.Join(query.renderTags(), ""), `"key" <= 10001`)
+		})
+
 		t.Run("can render string tags", func(t *testing.T) {
 			query := &Query{Tags: []*Tag{{Operator: "=", Value: "value", Key: "key"}}}
 

--- a/public/app/plugins/datasource/influxdb/components/editor/query/influxql/visual/TagsSection.tsx
+++ b/public/app/plugins/datasource/influxdb/components/editor/query/influxql/visual/TagsSection.tsx
@@ -10,8 +10,8 @@ import { toSelectableValue } from '../utils/toSelectableValue';
 import { AddButton } from './AddButton';
 import { Seg } from './Seg';
 
-type KnownOperator = '=' | '!=' | '<>' | '<' | '>' | '=~' | '!~';
-const knownOperators: KnownOperator[] = ['=', '!=', '<>', '<', '>', '=~', '!~'];
+type KnownOperator = '=' | '!=' | '<>' | '<' | '>' | '>=' | '<=' | '=~' | '!~';
+const knownOperators: KnownOperator[] = ['=', '!=', '<>', '<', '>', '>=', '<=', '=~', '!~'];
 
 type KnownCondition = 'AND' | 'OR';
 const knownConditions: KnownCondition[] = ['AND', 'OR'];

--- a/public/app/plugins/datasource/influxdb/influx_query_model.test.ts
+++ b/public/app/plugins/datasource/influxdb/influx_query_model.test.ts
@@ -206,6 +206,44 @@ describe('InfluxQuery', () => {
     });
   });
 
+  describe('query with greater-than-or-equal-to condition', () => {
+    it('should use >=', () => {
+      const query = new InfluxQueryModel(
+        {
+          refId: 'A',
+          measurement: 'cpu',
+          policy: 'autogen',
+          groupBy: [],
+          tags: [{ key: 'value', value: '5', operator: '>=' }],
+        },
+        templateSrv,
+        {}
+      );
+
+      const queryText = query.render();
+      expect(queryText).toBe('SELECT mean("value") FROM "autogen"."cpu" WHERE ("value" >= 5) AND $timeFilter');
+    });
+  });
+
+  describe('query with less-than-or-equal-to condition', () => {
+    it('should use <=', () => {
+      const query = new InfluxQueryModel(
+        {
+          refId: 'A',
+          measurement: 'cpu',
+          policy: 'autogen',
+          groupBy: [],
+          tags: [{ key: 'value', value: '5', operator: '<=' }],
+        },
+        templateSrv,
+        {}
+      );
+
+      const queryText = query.render();
+      expect(queryText).toBe('SELECT mean("value") FROM "autogen"."cpu" WHERE ("value" <= 5) AND $timeFilter');
+    });
+  });
+
   describe('series with groupByTag', () => {
     it('should generate correct query', () => {
       const query = new InfluxQueryModel(

--- a/public/app/plugins/datasource/influxdb/influx_query_model.ts
+++ b/public/app/plugins/datasource/influxdb/influx_query_model.ts
@@ -163,7 +163,7 @@ export default class InfluxQueryModel {
       if (interpolate) {
         value = this.templateSrv.replace(value, this.scopedVars);
       }
-      if (!operator.startsWith('>') && !operator.startsWith('<')) {
+      if (!operator.startsWith('>') && !operator.startsWith('<') && operator != '<>') {
         value = "'" + value.replace(/\\/g, '\\\\').replace(/\'/g, "\\'") + "'";
       }
     } else if (interpolate) {

--- a/public/app/plugins/datasource/influxdb/influx_query_model.ts
+++ b/public/app/plugins/datasource/influxdb/influx_query_model.ts
@@ -163,7 +163,7 @@ export default class InfluxQueryModel {
       if (interpolate) {
         value = this.templateSrv.replace(value, this.scopedVars);
       }
-      if (operator !== '>' && operator !== '<') {
+      if (!operator.startsWith('>') && !operator.startsWith('<')) {
         value = "'" + value.replace(/\\/g, '\\\\').replace(/\'/g, "\\'") + "'";
       }
     } else if (interpolate) {

--- a/public/app/plugins/datasource/influxdb/influx_query_model.ts
+++ b/public/app/plugins/datasource/influxdb/influx_query_model.ts
@@ -163,7 +163,7 @@ export default class InfluxQueryModel {
       if (interpolate) {
         value = this.templateSrv.replace(value, this.scopedVars);
       }
-      if (!operator.startsWith('>') && !operator.startsWith('<') && operator != '<>') {
+      if ((!operator.startsWith('>') && !operator.startsWith('<')) || operator === '<>') {
         value = "'" + value.replace(/\\/g, '\\\\').replace(/\'/g, "\\'") + "'";
       }
     } else if (interpolate) {


### PR DESCRIPTION
**What is this feature?**

Adds support to the InfluxQL Query Editor for the `>=` and `<=` comparison operators

**Why do we need this feature?**

To simplify queries against numeric fields

**Who is this feature for?**

InfluxQL Query Builder users who wish to include WHERE conditions using greater/less than or equal to

**Which issue(s) does this PR fix?**:

Fixes #77916

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
