### PR TITLE
Plugins: Show a not found error page when accessing an app for a not-found plugin

### DIFF
--- a/public/app/features/plugins/components/AppRootPage.test.tsx
+++ b/public/app/features/plugins/components/AppRootPage.test.tsx
@@ -102,6 +102,13 @@ describe('AppRootPage', () => {
     enabled: true,
   });
 
+  it("should show a not found page if the plugin settings can't load", async () => {
+    getPluginSettingsMock.mockRejectedValue(new Error('Unknown Plugin'));
+    // Renders once for the first time
+    await renderUnderRouter();
+    expect(await screen.findByText('App not found')).toBeVisible();
+  });
+
   it('should not render the component if we are not under a plugin path', async () => {
     getPluginSettingsMock.mockResolvedValue(pluginMeta);
 

--- a/public/app/features/plugins/components/AppRootPage.tsx
+++ b/public/app/features/plugins/components/AppRootPage.tsx
@@ -28,19 +28,20 @@ interface Props {
 
 interface State {
   loading: boolean;
+  loadingError: boolean;
   plugin?: AppPlugin | null;
   // Used to display a tab navigation (used before the new Top Nav)
   pluginNav: NavModel | null;
 }
 
-const initialState: State = { loading: true, pluginNav: null, plugin: null };
+const initialState: State = { loading: true, loadingError: false, pluginNav: null, plugin: null };
 
 export function AppRootPage({ pluginId, pluginNavSection }: Props) {
   const match = useRouteMatch();
   const location = useLocation();
   const [state, dispatch] = useReducer(stateSlice.reducer, initialState);
   const currentUrl = config.appSubUrl + location.pathname + location.search;
-  const { plugin, loading, pluginNav } = state;
+  const { plugin, loading, loadingError, pluginNav } = state;
   const navModel = buildPluginSectionNav(pluginNavSection, pluginNav, currentUrl);
   const queryParams = useMemo(() => locationSearchToObject(location.search), [location.search]);
   const context = useMemo(() => buildPluginPageContext(navModel), [navModel]);
@@ -61,7 +62,7 @@ export function AppRootPage({ pluginId, pluginNavSection }: Props) {
     return (
       <Page navModel={navModel} pageNav={{ text: '' }} layout={currentLayout}>
         {loading && <PageLoader />}
-        {!loading && <EntityNotFound entity="App" />}
+        {!loading && loadingError && <EntityNotFound entity="App" />}
       </Page>
     );
   }
@@ -169,12 +170,13 @@ async function loadAppPlugin(pluginId: string, dispatch: React.Dispatch<AnyActio
       }
       return importAppPlugin(info);
     });
-    dispatch(stateSlice.actions.setState({ plugin: app, loading: false, pluginNav: null }));
+    dispatch(stateSlice.actions.setState({ plugin: app, loading: false, loadingError: false, pluginNav: null }));
   } catch (err) {
     dispatch(
       stateSlice.actions.setState({
         plugin: null,
         loading: false,
+        loadingError: true,
         pluginNav: process.env.NODE_ENV === 'development' ? getExceptionNav(err) : getNotFoundNav(),
       })
     );

--- a/public/app/features/plugins/components/AppRootPage.tsx
+++ b/public/app/features/plugins/components/AppRootPage.tsx
@@ -8,6 +8,7 @@ import { config, locationSearchToObject } from '@grafana/runtime';
 import { Alert } from '@grafana/ui';
 import { Page } from 'app/core/components/Page/Page';
 import PageLoader from 'app/core/components/PageLoader/PageLoader';
+import { EntityNotFound } from 'app/core/components/PageNotFound/EntityNotFound';
 import { useGrafana } from 'app/core/context/GrafanaContext';
 import { appEvents, contextSrv } from 'app/core/core';
 import { getNotFoundNav, getWarningNav, getExceptionNav } from 'app/core/navigation/errorModels';
@@ -60,6 +61,7 @@ export function AppRootPage({ pluginId, pluginNavSection }: Props) {
     return (
       <Page navModel={navModel} pageNav={{ text: '' }} layout={currentLayout}>
         {loading && <PageLoader />}
+        {!loading && <EntityNotFound entity="App" />}
       </Page>
     );
   }


### PR DESCRIPTION
**What is this feature?**

It shows a not-found page when the user access an app plugin that can't be loaded

![image](https://github.com/grafana/grafana/assets/227916/44f84ec9-b98d-44d9-a75a-4738425ae27f)


**Why do we need this feature?**

Currently when an app plugin can't be loaded, the user is presented with a blank page that briefly shows an alert with a loading error message
and then remains blank

**Who is this feature for?**

All users for app plugins

**Which issue(s) does this PR fix?**:

Closes: https://github.com/grafana/grafana/issues/55977

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:

- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
