### PR TITLE
InfluxDB: Add new truthiness operators (`Is` and `Is Not`) to InfluxQL Query Builder

### DIFF
--- a/pkg/tsdb/influxdb/models/query.go
+++ b/pkg/tsdb/influxdb/models/query.go
@@ -74,6 +74,14 @@ func (query *Query) renderTags() []string {
 			textValue = tag.Value
 		case "<", ">", ">=", "<=":
 			textValue = tag.Value
+		case "Is":
+			tag.Operator = "="
+			// Drop to lowercase so the user doesn't need
+			// to worry about getting the correct case
+			textValue = strings.ToLower(tag.Value)
+		case "Is Not":
+			tag.Operator = "!="
+			textValue = strings.ToLower(tag.Value)
 		default:
 			textValue = fmt.Sprintf("'%s'", strings.ReplaceAll(tag.Value, `\`, `\\`))
 		}

--- a/pkg/tsdb/influxdb/models/query_test.go
+++ b/pkg/tsdb/influxdb/models/query_test.go
@@ -255,6 +255,31 @@ func TestInfluxdbQueryBuilder(t *testing.T) {
 			require.Equal(t, strings.Join(query.renderTags(), ""), `"key" = false`)
 		})
 
+		t.Run("can use strings with Is", func(t *testing.T) {
+			query := &Query{Tags: []*Tag{{Operator: "Is", Value: "A string", Key: "key"}}}
+			require.Equal(t, strings.Join(query.renderTags(), ""), `"key" = 'A string'`)
+		})
+
+		t.Run("can use integers with Is", func(t *testing.T) {
+			query := &Query{Tags: []*Tag{{Operator: "Is", Value: "123", Key: "key"}}}
+			require.Equal(t, strings.Join(query.renderTags(), ""), `"key" = 123`)
+		})
+
+		t.Run("can use negative integers with Is", func(t *testing.T) {
+			query := &Query{Tags: []*Tag{{Operator: "Is", Value: "-123", Key: "key"}}}
+			require.Equal(t, strings.Join(query.renderTags(), ""), `"key" = -123`)
+		})
+
+		t.Run("can use floats with Is", func(t *testing.T) {
+			query := &Query{Tags: []*Tag{{Operator: "Is", Value: "1.23", Key: "key"}}}
+			require.Equal(t, strings.Join(query.renderTags(), ""), `"key" = 1.23`)
+		})
+
+		t.Run("can use negative floats with Is", func(t *testing.T) {
+			query := &Query{Tags: []*Tag{{Operator: "Is", Value: "-1.23", Key: "key"}}}
+			require.Equal(t, strings.Join(query.renderTags(), ""), `"key" = -1.23`)
+		})
+
 		t.Run("can render string tags", func(t *testing.T) {
 			query := &Query{Tags: []*Tag{{Operator: "=", Value: "value", Key: "key"}}}
 

--- a/pkg/tsdb/influxdb/models/query_test.go
+++ b/pkg/tsdb/influxdb/models/query_test.go
@@ -239,6 +239,22 @@ func TestInfluxdbQueryBuilder(t *testing.T) {
 			require.Equal(t, strings.Join(query.renderTags(), ""), `"key" <= 10001`)
 		})
 
+		t.Run("can render boolean equality tags", func(t *testing.T) {
+			query := &Query{Tags: []*Tag{{Operator: "Is", Value: "false", Key: "key"}}}
+
+			require.Equal(t, strings.Join(query.renderTags(), ""), `"key" = false`)
+		})
+
+		t.Run("can render boolean inequality tags", func(t *testing.T) {
+			query := &Query{Tags: []*Tag{{Operator: "Is Not", Value: "true", Key: "key"}}}
+			require.Equal(t, strings.Join(query.renderTags(), ""), `"key" != true`)
+		})
+
+		t.Run("can correct case of boolean tags", func(t *testing.T) {
+			query := &Query{Tags: []*Tag{{Operator: "Is", Value: "False", Key: "key"}}}
+			require.Equal(t, strings.Join(query.renderTags(), ""), `"key" = false`)
+		})
+
 		t.Run("can render string tags", func(t *testing.T) {
 			query := &Query{Tags: []*Tag{{Operator: "=", Value: "value", Key: "key"}}}
 

--- a/public/app/plugins/datasource/influxdb/components/editor/query/influxql/visual/TagsSection.tsx
+++ b/public/app/plugins/datasource/influxdb/components/editor/query/influxql/visual/TagsSection.tsx
@@ -10,8 +10,9 @@ import { toSelectableValue } from '../utils/toSelectableValue';
 import { AddButton } from './AddButton';
 import { Seg } from './Seg';
 
-type KnownOperator = '=' | '!=' | '<>' | '<' | '>' | '>=' | '<=' | '=~' | '!~';
-const knownOperators: KnownOperator[] = ['=', '!=', '<>', '<', '>', '>=', '<=', '=~', '!~'];
+
+type KnownOperator = '=' | '!=' | '<>' | '<' | '>' | '>=' | '<=' | '=~' | '!~' | 'Is' | 'Is Not';
+const knownOperators: KnownOperator[] = ['=', '!=', '<>', '<', '>', '>=', '<=', '=~', '!~', 'Is', 'Is Not'];
 
 type KnownCondition = 'AND' | 'OR';
 const knownConditions: KnownCondition[] = ['AND', 'OR'];

--- a/public/app/plugins/datasource/influxdb/components/editor/query/influxql/visual/TagsSection.tsx
+++ b/public/app/plugins/datasource/influxdb/components/editor/query/influxql/visual/TagsSection.tsx
@@ -10,7 +10,6 @@ import { toSelectableValue } from '../utils/toSelectableValue';
 import { AddButton } from './AddButton';
 import { Seg } from './Seg';
 
-
 type KnownOperator = '=' | '!=' | '<>' | '<' | '>' | '>=' | '<=' | '=~' | '!~' | 'Is' | 'Is Not';
 const knownOperators: KnownOperator[] = ['=', '!=', '<>', '<', '>', '>=', '<=', '=~', '!~', 'Is', 'Is Not'];
 

--- a/public/app/plugins/datasource/influxdb/influx_query_model.test.ts
+++ b/public/app/plugins/datasource/influxdb/influx_query_model.test.ts
@@ -395,7 +395,6 @@ describe('InfluxQuery', () => {
     });
   });
 
-
   describe('series with groupByTag', () => {
     it('should generate correct query', () => {
       const query = new InfluxQueryModel(

--- a/public/app/plugins/datasource/influxdb/influx_query_model.test.ts
+++ b/public/app/plugins/datasource/influxdb/influx_query_model.test.ts
@@ -205,7 +205,6 @@ describe('InfluxQuery', () => {
       expect(queryText).toBe('SELECT mean("value") FROM "autogen"."cpu" WHERE ("value" > 5) AND $timeFilter');
     });
   });
-
   describe('query with greater-than-or-equal-to condition', () => {
     it('should use >=', () => {
       const query = new InfluxQueryModel(
@@ -243,6 +242,159 @@ describe('InfluxQuery', () => {
       expect(queryText).toBe('SELECT mean("value") FROM "autogen"."cpu" WHERE ("value" <= 5) AND $timeFilter');
     });
   });
+
+  describe('query with Is operator', () => {
+    it('should use =', () => {
+      const query = new InfluxQueryModel(
+        {
+          refId: 'A',
+          measurement: 'cpu',
+          policy: 'autogen',
+          groupBy: [],
+          tags: [{ key: 'value', value: 'False', operator: 'Is' }],
+        },
+        templateSrv,
+        {}
+      );
+
+      const queryText = query.render();
+      expect(queryText).toBe('SELECT mean("value") FROM "autogen"."cpu" WHERE ("value" = false) AND $timeFilter');
+    });
+  });
+
+  describe('query with Is Not operator', () => {
+    it('should use !=', () => {
+      const query = new InfluxQueryModel(
+        {
+          refId: 'A',
+          measurement: 'cpu',
+          policy: 'autogen',
+          groupBy: [],
+          tags: [{ key: 'value', value: 'False', operator: 'Is Not' }],
+        },
+        templateSrv,
+        {}
+      );
+
+      const queryText = query.render();
+      expect(queryText).toBe('SELECT mean("value") FROM "autogen"."cpu" WHERE ("value" != false) AND $timeFilter');
+    });
+  });
+
+  describe('query with Is boolean condition', () => {
+    it('should convert to lowercase and not quote value', () => {
+      const query = new InfluxQueryModel(
+        {
+          refId: 'A',
+          measurement: 'cpu',
+          policy: 'autogen',
+          groupBy: [],
+          tags: [{ key: 'value', value: 'True', operator: 'Is' }],
+        },
+        templateSrv,
+        {}
+      );
+
+      const queryText = query.render();
+      expect(queryText).toBe('SELECT mean("value") FROM "autogen"."cpu" WHERE ("value" = true) AND $timeFilter');
+    });
+  });
+
+  describe('query with Is string condition', () => {
+    it('should quote value', () => {
+      const query = new InfluxQueryModel(
+        {
+          refId: 'A',
+          measurement: 'cpu',
+          policy: 'autogen',
+          groupBy: [],
+          tags: [{ key: 'value', value: 'Server2', operator: 'Is' }],
+        },
+        templateSrv,
+        {}
+      );
+
+      const queryText = query.render();
+      expect(queryText).toBe('SELECT mean("value") FROM "autogen"."cpu" WHERE ("value" = \'Server2\') AND $timeFilter');
+    });
+  });
+
+  describe('query with Is integer condition', () => {
+    it('should not quote value', () => {
+      const query = new InfluxQueryModel(
+        {
+          refId: 'A',
+          measurement: 'cpu',
+          policy: 'autogen',
+          groupBy: [],
+          tags: [{ key: 'value', value: '5', operator: 'Is' }],
+        },
+        templateSrv,
+        {}
+      );
+
+      const queryText = query.render();
+      expect(queryText).toBe('SELECT mean("value") FROM "autogen"."cpu" WHERE ("value" = 5) AND $timeFilter');
+    });
+  });
+
+  describe('query with Is float condition', () => {
+    it('should not quote value', () => {
+      const query = new InfluxQueryModel(
+        {
+          refId: 'A',
+          measurement: 'cpu',
+          policy: 'autogen',
+          groupBy: [],
+          tags: [{ key: 'value', value: '1.234', operator: 'Is' }],
+        },
+        templateSrv,
+        {}
+      );
+
+      const queryText = query.render();
+      expect(queryText).toBe('SELECT mean("value") FROM "autogen"."cpu" WHERE ("value" = 1.234) AND $timeFilter');
+    });
+  });
+
+  describe('query with Is negative float condition', () => {
+    it('should not quote value', () => {
+      const query = new InfluxQueryModel(
+        {
+          refId: 'A',
+          measurement: 'cpu',
+          policy: 'autogen',
+          groupBy: [],
+          tags: [{ key: 'value', value: '-1.234', operator: 'Is' }],
+        },
+        templateSrv,
+        {}
+      );
+
+      const queryText = query.render();
+      expect(queryText).toBe('SELECT mean("value") FROM "autogen"."cpu" WHERE ("value" = -1.234) AND $timeFilter');
+    });
+  });
+
+  describe('query with Is boolean condition', () => {
+    it('should convert to lowercase and not quote value', () => {
+      const query = new InfluxQueryModel(
+        {
+          refId: 'A',
+          measurement: 'cpu',
+          policy: 'autogen',
+          groupBy: [],
+          tags: [{ key: 'value', value: 'True', operator: 'Is' }],
+        },
+        templateSrv,
+        {}
+      );
+
+      const queryText = query.render();
+      expect(queryText).toBe('SELECT mean("value") FROM "autogen"."cpu" WHERE ("value" = true) AND $timeFilter');
+    });
+  });
+
 
   describe('series with groupByTag', () => {
     it('should generate correct query', () => {

--- a/public/app/plugins/datasource/influxdb/influx_query_model.ts
+++ b/public/app/plugins/datasource/influxdb/influx_query_model.ts
@@ -163,7 +163,12 @@ export default class InfluxQueryModel {
       if (interpolate) {
         value = this.templateSrv.replace(value, this.scopedVars);
       }
-      if ((!operator.startsWith('>') && !operator.startsWith('<')) || operator === '<>') {
+
+      if (operator == 'Is') {
+        operator = '=';
+      } else if (operator == 'Is Not') {
+        operator = '!=';
+      } else if ((!operator.startsWith('>') && !operator.startsWith('<')) || operator === '<>') {
         value = "'" + value.replace(/\\/g, '\\\\').replace(/\'/g, "\\'") + "'";
       }
     } else if (interpolate) {

--- a/public/app/plugins/datasource/influxdb/influx_query_model.ts
+++ b/public/app/plugins/datasource/influxdb/influx_query_model.ts
@@ -143,7 +143,7 @@ export default class InfluxQueryModel {
 
   private isOperatorTypeHandler(operator: string, value: string, fieldName: string) {
     let textValue;
-    if (operator == 'Is Not') {
+    if (operator === 'Is Not') {
       operator = '!=';
     } else {
       operator = '=';

--- a/public/app/plugins/datasource/influxdb/influx_query_model.ts
+++ b/public/app/plugins/datasource/influxdb/influx_query_model.ts
@@ -200,7 +200,6 @@ export default class InfluxQueryModel {
         value = this.templateSrv.replace(value, this.scopedVars);
       }
 
-
       if (operator.startsWith('Is')) {
         let r = this.isOperatorTypeHandler(operator, value, tag.key);
         operator = r.operator;

--- a/public/app/plugins/datasource/influxdb/influx_query_model.ts
+++ b/public/app/plugins/datasource/influxdb/influx_query_model.ts
@@ -141,6 +141,42 @@ export default class InfluxQueryModel {
     this.updatePersistedParts();
   }
 
+  private isOperatorTypeHandler(operator: string, value: string, fieldName: string) {
+    let textValue;
+    if (operator == 'Is Not') {
+      operator = '!=';
+    } else {
+      operator = '=';
+    }
+
+    // Tags should always quote
+    if (fieldName.endsWith('::tag')) {
+      textValue = "'" + value.replace(/\\/g, '\\\\').replace(/\'/g, "\\'") + "'";
+      return {
+        operator: operator,
+        value: textValue,
+      };
+    }
+
+    let lowerValue = value.toLowerCase();
+
+    // Try and discern type
+    if (!isNaN(parseFloat(value))) {
+      // Integer or float, don't quote
+      textValue = value;
+    } else if (['true', 'false'].includes(lowerValue)) {
+      // It's a boolean, don't quite
+      textValue = lowerValue;
+    } else {
+      // String or unrecognised: quote
+      textValue = "'" + value.replace(/\\/g, '\\\\').replace(/\'/g, "\\'") + "'";
+    }
+    return {
+      operator: operator,
+      value: textValue,
+    };
+  }
+
   private renderTagCondition(tag: InfluxQueryTag, index: number, interpolate?: boolean) {
     // FIXME: merge this function with query_builder/renderTagCondition
     let str = '';
@@ -164,10 +200,11 @@ export default class InfluxQueryModel {
         value = this.templateSrv.replace(value, this.scopedVars);
       }
 
-      if (operator == 'Is') {
-        operator = '=';
-      } else if (operator == 'Is Not') {
-        operator = '!=';
+
+      if (operator.startsWith('Is')) {
+        let r = this.isOperatorTypeHandler(operator, value, tag.key);
+        operator = r.operator;
+        value = r.value;
       } else if ((!operator.startsWith('>') && !operator.startsWith('<')) || operator === '<>') {
         value = "'" + value.replace(/\\/g, '\\\\').replace(/\'/g, "\\'") + "'";
       }

--- a/public/app/plugins/datasource/influxdb/queryUtils.test.ts
+++ b/public/app/plugins/datasource/influxdb/queryUtils.test.ts
@@ -147,6 +147,18 @@ describe('InfluxDB query utils', () => {
               operator: '!~',
               value: '/cpu0/',
             },
+            {
+              condition: 'AND',
+              key: 'cpu',
+              operator: 'Is',
+              value: 'false',
+            },
+            {
+              condition: 'AND',
+              key: 'cpu',
+              operator: 'Is Not',
+              value: 'false',
+            },
           ],
           groupBy: [],
         })
@@ -154,7 +166,7 @@ describe('InfluxDB query utils', () => {
         `SELECT "value" ` +
           `FROM "autogen"."measurement" ` +
           `WHERE ("cpu" = 'cpu0' AND "cpu" != 'cpu0' AND "cpu" <> 'cpu0' AND "cpu" < cpu0 AND ` +
-          `"cpu" > cpu0 AND "cpu" =~ /cpu0/ AND "cpu" !~ /cpu0/) AND $timeFilter`
+          `"cpu" > cpu0 AND "cpu" =~ /cpu0/ AND "cpu" !~ /cpu0/ AND "cpu" = false AND "cpu" != false) AND $timeFilter`
       );
     });
     it('should handle a complex query', () => {


### PR DESCRIPTION
**What is this feature?**

Implements support for including query conditions based upon boolean field values using new Is and Is Not operators (see note below) (https://github.com/grafana/grafana/issues/77794).

**Why do we need this feature?**

There's a pre-existing issue where [it's not possible](https://github.com/grafana/grafana/issues/2674#issuecomment-1446564677) because after submission, the value will be coerced to a string (e.g. false will be coerced to 'false').

**Who is this feature for?**

Users who want to use the InfluxQL Query Builder to build WHERE conditions based on Boolean fields

**Which issue(s) does this PR fix?**:


Fixes #77794

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
