### PR TITLE
docs: Adjust the update command documentation of the public dashboard endpoint

### DIFF
--- a/docs/sources/developers/http_api/dashboard_public.md
+++ b/docs/sources/developers/http_api/dashboard_public.md
@@ -111,7 +111,9 @@ Content-Length: 107
 
 ## Update a public dashboard
 
-`PATCH /api/dashboards/uid/:uid/public-dashboards/`
+`PATCH /api/dashboards/uid/:uid/public-dashboards/:publicDashboardUid`
+
+Will update the public dashboard given the specified unique identifier (uid).
 
 **Required permissions**
 
@@ -124,7 +126,7 @@ See note in the [introduction](#public-dashboard-api) for an explanation.
 **Example Request for updating a public dashboard**:
 
 ```http
-PATCH /api/dashboards/uid/xCpsVuc4z/public-dashboards/ HTTP/1.1
+PATCH /api/dashboards/uid/xCpsVuc4z/public-dashboards/cd56d9fd-f3d4-486d-afba-a21760e2acbe HTTP/1.1
 Accept: application/json
 Content-Type: application/json
 Authorization: Bearer eyJrIjoiT0tTcG1pUlY2RnVKZTFVaDFsNFZXdE9ZWmNrMkZYbk


### PR DESCRIPTION
**What is this feature?**

Update the documentation and adjust the update part of the public dashboard.

**Why do we need this feature?**

Good documentation is necessary to call the API correctly.

**Who is this feature for?**

For all people who use the public dashboard API.

**Labels and Milestones:**
I'm an external contributor, so, it's not possible to add any related labels or milestones, but I would suggest porting the documentation change back.

backport v10.2.0
no-changelog

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
