### PR TITLE
Plugins: Add referer and user login params to plugin CDN redirect logs

### DIFF
--- a/pkg/api/plugins.go
+++ b/pkg/api/plugins.go
@@ -380,6 +380,8 @@ func (hs *HTTPServer) redirectCDNPluginAsset(c *contextmodel.ReqContext, plugin 
 		"pluginVersion", plugin.Info.Version,
 		"assetPath", assetPath,
 		"remoteURL", remoteURL,
+		"referer", c.Req.Referer(),
+		"user", c.Login,
 	)
 	pluginsCDNFallbackRedirectRequests.With(prometheus.Labels{
 		"plugin_id":      plugin.ID,


### PR DESCRIPTION
**What is this feature?**

Adds more log labels to the cdn asset redirect logs.

**Why do we need this feature?**

This will hopefully help us better understand how/where redirects are invoked.

**Who is this feature for?**

Plugins Platform.

<!--
**Which issue(s) does this PR fix?**:


- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"



Fixes #
-->
**Special notes for your reviewer:**
Since the assets API is public (IE no signed in user is required), I have confirmed that `c.Login` will just be empty `""` in that case.

Please check that:
- [X] It works as expected from a user's perspective.
- [X] If this is a pre-GA feature, it is behind a feature toggle.
- [X] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
