### PR TITLE
Chore: Deprecate Id from Folder in DTOs

### DIFF
--- a/pkg/api/dtos/folder.go
+++ b/pkg/api/dtos/folder.go
@@ -7,6 +7,7 @@ import (
 )
 
 type Folder struct {
+	// Deprecated: use Uid instead
 	Id            int64                  `json:"id"`
 	Uid           string                 `json:"uid"`
 	Title         string                 `json:"title"`

--- a/pkg/api/folder.go
+++ b/pkg/api/folder.go
@@ -365,7 +365,7 @@ func (hs *HTTPServer) newToFolderDto(c *contextmodel.ReqContext, f *folder.Folde
 		}
 
 		return dtos.Folder{
-			Id:            f.ID,
+			Id:            f.ID, // nolint:staticcheck
 			Uid:           f.UID,
 			Title:         f.Title,
 			Url:           f.URL,

--- a/pkg/api/folder_test.go
+++ b/pkg/api/folder_test.go
@@ -145,6 +145,7 @@ func TestFoldersCreateAPIEndpoint(t *testing.T) {
 			require.NoError(t, resp.Body.Close())
 
 			if tc.expectedCode == http.StatusOK {
+				// nolint:staticcheck
 				assert.Equal(t, int64(1), folder.Id)
 				assert.Equal(t, "uid", folder.Uid)
 				assert.Equal(t, "Folder", folder.Title)
@@ -249,6 +250,7 @@ func TestFoldersUpdateAPIEndpoint(t *testing.T) {
 			require.NoError(t, resp.Body.Close())
 
 			if tc.expectedCode == http.StatusOK {
+				// nolint:staticcheck
 				assert.Equal(t, int64(1), folder.Id)
 				assert.Equal(t, "uid", folder.Uid)
 				assert.Equal(t, "Folder upd", folder.Title)

--- a/pkg/tests/api/dashboards/api_dashboards_test.go
+++ b/pkg/tests/api/dashboards/api_dashboards_test.go
@@ -358,7 +358,7 @@ func TestIntegrationCreate(t *testing.T) {
 		buf1 := &bytes.Buffer{}
 		err = json.NewEncoder(buf1).Encode(dashboards.SaveDashboardCommand{
 			Dashboard: dashboardDataOne,
-			FolderID:  folder.Id,
+			FolderID:  folder.Id, // nolint:staticcheck
 		})
 		require.NoError(t, err)
 		u := fmt.Sprintf("http://admin:admin@%s/api/dashboards/db", grafanaListedAddr)

--- a/public/api-merged.json
+++ b/public/api-merged.json
@@ -14489,6 +14489,7 @@
           "type": "boolean"
         },
         "id": {
+          "description": "Deprecated: use Uid instead",
           "type": "integer",
           "format": "int64"
         },

--- a/public/openapi3.json
+++ b/public/openapi3.json
@@ -5393,6 +5393,7 @@
             "type": "boolean"
           },
           "id": {
+            "description": "Deprecated: use Uid instead",
             "format": "int64",
             "type": "integer"
           },


### PR DESCRIPTION
Deprecate `Id` in `DTOs pkg` `Folder` struct. Part of a series of PRs to deprecate sequential folder IDs.

Ref https://github.com/grafana/grafana/issues/61232