### PR TITLE
Alerting: Allow to clear datasource selection in panel list

### DIFF
--- a/public/app/plugins/panel/alertlist/module.tsx
+++ b/public/app/plugins/panel/alertlist/module.tsx
@@ -250,7 +250,7 @@ const unifiedAlertList = new PanelPlugin<UnifiedAlertListOptions>(UnifiedAlertLi
     .addCustomEditor({
       path: 'datasource',
       name: 'Datasource',
-      description: 'Filter alerts from rule datasource',
+      description: 'Filter from alert source',
       id: 'datasource',
       defaultValue: null,
       editor: function RenderDatasourcePicker(props) {

--- a/public/app/plugins/panel/alertlist/module.tsx
+++ b/public/app/plugins/panel/alertlist/module.tsx
@@ -262,7 +262,6 @@ const unifiedAlertList = new PanelPlugin<UnifiedAlertListOptions>(UnifiedAlertLi
               noDefault
               current={props.value}
               onChange={(ds: DataSourceInstanceSettings) => props.onChange(ds.name)}
-              onClear={() => props.onChange(null)}
             />
             <Button variant="secondary" onClick={() => props.onChange(null)}>
               Clear

--- a/public/app/plugins/panel/alertlist/module.tsx
+++ b/public/app/plugins/panel/alertlist/module.tsx
@@ -250,7 +250,7 @@ const unifiedAlertList = new PanelPlugin<UnifiedAlertListOptions>(UnifiedAlertLi
     .addCustomEditor({
       path: 'datasource',
       name: 'Datasource',
-      description: 'Filter alerts from selected datasource',
+      description: 'Filter alerts from rule datasource',
       id: 'datasource',
       defaultValue: null,
       editor: function RenderDatasourcePicker(props) {

--- a/public/app/plugins/panel/alertlist/module.tsx
+++ b/public/app/plugins/panel/alertlist/module.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 
 import { DataSourceInstanceSettings, PanelPlugin } from '@grafana/data';
 import { config } from '@grafana/runtime';
-import { TagsInput } from '@grafana/ui';
+import { Button, Stack, TagsInput } from '@grafana/ui';
 import { OldFolderPicker } from 'app/core/components/Select/OldFolderPicker';
 import {
   ALL_FOLDER,
@@ -228,8 +228,8 @@ const unifiedAlertList = new PanelPlugin<UnifiedAlertListOptions>(UnifiedAlertLi
     })
     .addBooleanSwitch({
       path: 'dashboardAlerts',
-      name: 'Alerts from this dashboard',
-      description: 'Show alerts from this dashboard',
+      name: 'Alerts linked to this dashboard',
+      description: 'Only show alerts linked to this dashboard',
       defaultValue: false,
       category: ['Options'],
     })
@@ -255,14 +255,19 @@ const unifiedAlertList = new PanelPlugin<UnifiedAlertListOptions>(UnifiedAlertLi
       defaultValue: null,
       editor: function RenderDatasourcePicker(props) {
         return (
-          <DataSourcePicker
-            {...props}
-            type={['prometheus', 'loki', 'grafana']}
-            noDefault
-            current={props.value}
-            onChange={(ds: DataSourceInstanceSettings) => props.onChange(ds.name)}
-            onClear={() => props.onChange(null)}
-          />
+          <Stack gap={1}>
+            <DataSourcePicker
+              {...props}
+              type={['prometheus', 'loki', 'grafana']}
+              noDefault
+              current={props.value}
+              onChange={(ds: DataSourceInstanceSettings) => props.onChange(ds.name)}
+              onClear={() => props.onChange(null)}
+            />
+            <Button variant="secondary" onClick={() => props.onChange(null)}>
+              Clear
+            </Button>
+          </Stack>
         );
       },
       category: ['Filter'],


### PR DESCRIPTION
**What is this feature?**

Adds a "Clear" button that allows to remove the data source selection in the filters section of the alert panel. 
Also improves the text regarding the switch to only show linked alerts.

**Why do we need this feature?**

Previously it wasn't allowed to clear the datasource selection. 

**Who is this feature for?**

All users.

**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/support-escalations/issues/8250

<img width="372" alt="image" src="https://github.com/grafana/grafana/assets/6271380/d7c44d03-c9da-4880-81ea-4e3cf980046a">

![2023-11-09 15 36 42](https://github.com/grafana/grafana/assets/6271380/61070f0a-1c9b-49e1-a501-b186c33b226c)
