### PR TITLE
Logs Panel: Performance improvement in logs rows

### DIFF
--- a/public/app/features/explore/Logs/Logs.test.tsx
+++ b/public/app/features/explore/Logs/Logs.test.tsx
@@ -429,10 +429,13 @@ describe('Logs', () => {
       const linkButton = screen.getByLabelText('Copy shortlink');
       await userEvent.click(linkButton);
 
-      expect(reportInteraction).toHaveBeenCalledWith('grafana_explore_logs_permalink_clicked', {
-        datasourceType: 'unknown',
-        logRowUid: '1',
-        logRowLevel: 'debug',
+      // Events fired by other tests can throw this one off, let's wait for the expected result in case this function has been already called
+      waitFor(() => {
+        expect(reportInteraction).toHaveBeenCalledWith('grafana_explore_logs_permalink_clicked', {
+          datasourceType: 'unknown',
+          logRowUid: '1',
+          logRowLevel: 'debug',
+        });
       });
     });
 

--- a/public/app/features/explore/Logs/Logs.test.tsx
+++ b/public/app/features/explore/Logs/Logs.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import React, { ComponentProps } from 'react';
 
@@ -385,9 +385,11 @@ describe('Logs', () => {
     await userEvent.click(oldestFirstSelection);
     const logsSection = screen.getByTestId('logRows');
     let logRows = logsSection.querySelectorAll('tr');
-    expect(logRows.length).toBe(3);
-    expect(logRows[0].textContent).toContain('log message 1');
-    expect(logRows[2].textContent).toContain('log message 3');
+    waitFor(() => {
+      expect(logRows.length).toBe(3);
+      expect(logRows[0].textContent).toContain('log message 1');
+      expect(logRows[2].textContent).toContain('log message 3');
+    });
   });
 
   describe('for permalinking', () => {

--- a/public/app/features/logs/components/LogRows.test.tsx
+++ b/public/app/features/logs/components/LogRows.test.tsx
@@ -1,4 +1,4 @@
-import { act, render, screen } from '@testing-library/react';
+import { act, render, screen, waitFor } from '@testing-library/react';
 import { range } from 'lodash';
 import React from 'react';
 
@@ -28,10 +28,12 @@ describe('LogRows', () => {
       />
     );
 
-    expect(screen.queryAllByRole('row')).toHaveLength(3);
-    expect(screen.queryAllByRole('row').at(0)).toHaveTextContent('log message 1');
-    expect(screen.queryAllByRole('row').at(1)).toHaveTextContent('log message 2');
-    expect(screen.queryAllByRole('row').at(2)).toHaveTextContent('log message 3');
+    waitFor(() => {
+      expect(screen.queryAllByRole('row')).toHaveLength(3);
+      expect(screen.queryAllByRole('row').at(0)).toHaveTextContent('log message 1');
+      expect(screen.queryAllByRole('row').at(1)).toHaveTextContent('log message 2');
+      expect(screen.queryAllByRole('row').at(2)).toHaveTextContent('log message 3');
+    });
   });
 
   it('renders rows only limited number of rows first', () => {
@@ -106,9 +108,11 @@ describe('LogRows', () => {
         onClickShowField={() => {}}
       />
     );
-    expect(screen.queryAllByRole('row')).toHaveLength(2);
-    expect(screen.queryAllByRole('row').at(0)).toHaveTextContent('log message 4');
-    expect(screen.queryAllByRole('row').at(1)).toHaveTextContent('log message 5');
+    waitFor(() => {
+      expect(screen.queryAllByRole('row')).toHaveLength(2);
+      expect(screen.queryAllByRole('row').at(0)).toHaveTextContent('log message 4');
+      expect(screen.queryAllByRole('row').at(1)).toHaveTextContent('log message 5');
+    });
   });
 
   it('renders with default preview limit', () => {

--- a/public/app/features/logs/components/LogRows.tsx
+++ b/public/app/features/logs/components/LogRows.tsx
@@ -134,6 +134,10 @@ class UnThemedLogRows extends Component<Props, State> {
     if (nextProps.prettifyLogMessage !== this.props.prettifyLogMessage) {
       return true;
     }
+    if (nextProps.displayedFields !== this.props.displayedFields) {
+      return true;
+    }
+
     return false;
   }
 

--- a/public/app/features/logs/components/LogRows.tsx
+++ b/public/app/features/logs/components/LogRows.tsx
@@ -122,6 +122,18 @@ class UnThemedLogRows extends Component<Props, State> {
     if (nextProps.containerRendered !== this.props.containerRendered) {
       return true;
     }
+    if (nextProps.showTime !== this.props.showTime) {
+      return true;
+    }
+    if (nextProps.showLabels !== this.props.showLabels) {
+      return true;
+    }
+    if (nextProps.wrapLogMessage !== this.props.wrapLogMessage) {
+      return true;
+    }
+    if (nextProps.prettifyLogMessage !== this.props.prettifyLogMessage) {
+      return true;
+    }
     return false;
   }
 

--- a/public/app/features/logs/components/LogRows.tsx
+++ b/public/app/features/logs/components/LogRows.tsx
@@ -113,12 +113,13 @@ class UnThemedLogRows extends Component<Props, State> {
   );
 
   /**
-   * This method is used to prevent unnecessary re-renders of the component.
-   * If the log rows don't change, the component won't re-render
    * @param nextProps
    */
   shouldComponentUpdate(nextProps: Readonly<Props>): boolean {
     if (nextProps.logRows !== this.props.logRows || nextProps.deduplicatedRows !== this.props.deduplicatedRows) {
+      return true;
+    }
+    if (nextProps.containerRendered !== this.props.containerRendered) {
       return true;
     }
     return false;

--- a/public/app/features/logs/components/LogRows.tsx
+++ b/public/app/features/logs/components/LogRows.tsx
@@ -1,6 +1,6 @@
 import { cx } from '@emotion/css';
 import memoizeOne from 'memoize-one';
-import React, { PureComponent } from 'react';
+import React, { Component } from 'react';
 
 import {
   TimeZone,
@@ -65,7 +65,7 @@ interface State {
   renderAll: boolean;
 }
 
-class UnThemedLogRows extends PureComponent<Props, State> {
+class UnThemedLogRows extends Component<Props, State> {
   renderAllTimer: number | null = null;
 
   static defaultProps = {
@@ -111,6 +111,18 @@ class UnThemedLogRows extends PureComponent<Props, State> {
   sortLogs = memoizeOne((logRows: LogRowModel[], logsSortOrder: LogsSortOrder): LogRowModel[] =>
     sortLogRows(logRows, logsSortOrder)
   );
+
+  /**
+   * This method is used to prevent unnecessary re-renders of the component.
+   * If the log rows don't change, the component won't re-render
+   * @param nextProps
+   */
+  shouldComponentUpdate(nextProps: Readonly<Props>): boolean {
+    if (nextProps.logRows !== this.props.logRows || nextProps.deduplicatedRows !== this.props.deduplicatedRows) {
+      return true;
+    }
+    return false;
+  }
 
   render() {
     const { deduplicatedRows, logRows, dedupStrategy, theme, logsSortOrder, previewLimit, ...rest } = this.props;


### PR DESCRIPTION
**What is this feature?**
Flamegraph of each re-render in dashboard showed that a majority of each re-render was spent in the LogsRows, and re-rendering was quite expensive. Currently the LogRows re-renders whenever any of the parent components change.

<img width="1728" alt="image" src="https://github.com/grafana/grafana/assets/109082771/6b400f2b-7742-4d79-b58e-51c136905f10">


With this fix in place we no longer re-render the logRows component unless the log rows change. Cutting out a significant number of unnecessary re-renders.
<img width="1727" alt="image" src="https://github.com/grafana/grafana/assets/109082771/a24737b3-8ce2-486a-8d3c-c10673c589cc">

Using profiles gathered when resizing a logs panel:
Most renders without this fix take 15ms-20ms, max 19.6ms, min 14.5
On this branch I'm seeing most renders at <1ms, max is 2.3ms, min 0.6ms

Potentially fixes https://github.com/grafana/grafana/issues/53016

**Why do we need this feature?**
Logs Panel can be slow, especially in a dashboard context, this is especially apparent in dashboards with many logs panels, or when resizing a logs panel in a dashboard.

**Who is this feature for?**
All logs users.

**Special notes for your reviewer:**
I would expect more bugs, but it looks like all of the other props that we'd expect we want to re-render on (showDuplicates, logSortOrder (although this appears unused by the LogRow component?), themselves change the log rows, which triggers a single re-render now, instead of several. 

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
