### PR TITLE
I18n: Specify i18next_json as the type in crowdin config

### DIFF
--- a/crowdin.yml
+++ b/crowdin.yml
@@ -1,6 +1,7 @@
 files:
   - source: /public/locales/en-US/grafana.json
     translation: /public/locales/%locale%/%original_file_name%
+    type: i18next_json
 pull_request_title: 'I18n: Crowdin sync'
 pull_request_labels:
   - area/internationalization


### PR DESCRIPTION
Updates the crowdin config file to specify the `i18next_json` type to fix plurals upload.

Fixes https://github.com/grafana/grafana/issues/77971