### PR TITLE
Plugins: Keep working when there is no internet access

### DIFF
--- a/public/app/features/plugins/admin/state/actions.ts
+++ b/public/app/features/plugins/admin/state/actions.ts
@@ -1,5 +1,5 @@
 import { createAction, createAsyncThunk, Update } from '@reduxjs/toolkit';
-import { from, forkJoin, timeout, lastValueFrom, catchError, throwError, of } from 'rxjs';
+import { from, forkJoin, timeout, lastValueFrom, catchError, of } from 'rxjs';
 
 import { PanelPlugin, PluginError } from '@grafana/data';
 import { config, getBackendSrv, isFetchError } from '@grafana/runtime';


### PR DESCRIPTION
**Related issues:** https://github.com/grafana/grafana/issues/77905, https://github.com/grafana/support-escalations/issues/8305

### What is the problem?
The "Add new connection" and "Plugins catalog" pages are not loading in case there is no internet access.

### Why?
Although releasing https://github.com/grafana/grafana/pull/75272 made it possible to load these pages seamlessly in case the connection to GCOM times out, it didn't cater for any other network errors properly when fetching GCOM. 
 
### Solution
This PR is fixing the issue by not blocking the main UI flow in case the remote plugins are not available. 

### Testing
Tested the following flows manually:
- [x] The "Plugins Catalog" and the "Add new connection" pages are still working if there is no internet
- [x] The "Plugins Catalog" and the "Add new connection" pages do not hang if the GCOM connection is slow or times out. In case the connection is slow, then the remotely available plugins will load later.
- [x] The "Plugins Catalog" and the "Add new connection" operate correctly when there is internet connection