### PR TITLE
Dashboards: Fix dashboard listing when user can't list any folders

### DIFF
--- a/public/app/features/browse-dashboards/api/services.ts
+++ b/public/app/features/browse-dashboards/api/services.ts
@@ -4,6 +4,9 @@ import { getGrafanaSearcher, NestedFolderDTO } from 'app/features/search/service
 import { queryResultToViewItem } from 'app/features/search/service/utils';
 import { DashboardViewItem } from 'app/features/search/types';
 
+import { contextSrv } from '../../../core/core';
+import { AccessControlAction } from '../../../types';
+
 export const PAGE_SIZE = 50;
 
 export async function listFolders(
@@ -18,11 +21,14 @@ export async function listFolders(
 
   const backendSrv = getBackendSrv();
 
-  const folders = await backendSrv.get<NestedFolderDTO[]>('/api/folders', {
-    parentUid: parentUID,
-    page,
-    limit: pageSize,
-  });
+  let folders = <NestedFolderDTO[]>{};
+  if (contextSrv.hasPermission(AccessControlAction.FoldersRead)) {
+    folders = await backendSrv.get<NestedFolderDTO[]>('/api/folders', {
+      parentUid: parentUID,
+      page,
+      limit: pageSize,
+    });
+  }
 
   return folders.map((item) => ({
     kind: 'folder',

--- a/public/app/features/browse-dashboards/api/services.ts
+++ b/public/app/features/browse-dashboards/api/services.ts
@@ -21,7 +21,7 @@ export async function listFolders(
 
   const backendSrv = getBackendSrv();
 
-  let folders = <NestedFolderDTO[]>{};
+  let folders: NestedFolderDTO[] = [];
   if (contextSrv.hasPermission(AccessControlAction.FoldersRead)) {
     folders = await backendSrv.get<NestedFolderDTO[]>('/api/folders', {
       parentUid: parentUID,


### PR DESCRIPTION
**What is this feature?**

Allow a user to correctly list dashboards when no folders exist in the organization or when the user isn't allow to list any folders in this organization.

Before the change:

https://github.com/grafana/grafana/assets/9482349/f016c7f7-835d-4283-bfe0-b6a93c3e7b63

After the change:

https://github.com/grafana/grafana/assets/9482349/3c679bc9-c1c2-4dea-88f9-c4b668a059c2

**Why do we need this feature?**

Currently dashboard and folder listing page is broken if the user isn't allowed to list any folders.

**Who is this feature for?**

All users.

**Which issue(s) does this PR fix?**:

Related to https://github.com/grafana/grafana/issues/77803#issuecomment-1800145601

Fixes https://github.com/grafana/grafana/issues/77985

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
