### PR TITLE
Alerting: Adds the new alertingSimplifiedRouting feature toggle

### DIFF
--- a/packages/grafana-data/src/types/featureToggles.gen.ts
+++ b/packages/grafana-data/src/types/featureToggles.gen.ts
@@ -161,4 +161,5 @@ export interface FeatureToggles {
   logsInfiniteScrolling?: boolean;
   flameGraphItemCollapsing?: boolean;
   alertingDetailsViewV2?: boolean;
+  alertingSimplifiedRouting?: boolean;
 }

--- a/pkg/services/featuremgmt/registry.go
+++ b/pkg/services/featuremgmt/registry.go
@@ -1038,6 +1038,14 @@ var (
 			Owner:        grafanaAlertingSquad,
 			HideFromDocs: true,
 		},
+		{
+			Name:         "alertingSimplifiedRouting",
+			Description:  "Enables the simplified routing for alerting",
+			Stage:        FeatureStageExperimental,
+			FrontendOnly: false,
+			Owner:        grafanaAlertingSquad,
+			HideFromDocs: true,
+		},
 	}
 )
 

--- a/pkg/services/featuremgmt/toggles_gen.csv
+++ b/pkg/services/featuremgmt/toggles_gen.csv
@@ -142,3 +142,4 @@ ssoSettingsApi,experimental,@grafana/identity-access-team,true,false,false,false
 logsInfiniteScrolling,experimental,@grafana/observability-logs,false,false,false,true
 flameGraphItemCollapsing,experimental,@grafana/observability-traces-and-profiling,false,false,false,true
 alertingDetailsViewV2,experimental,@grafana/alerting-squad,false,false,false,true
+alertingSimplifiedRouting,experimental,@grafana/alerting-squad,false,false,false,false

--- a/pkg/services/featuremgmt/toggles_gen.go
+++ b/pkg/services/featuremgmt/toggles_gen.go
@@ -578,4 +578,8 @@ const (
 	// FlagAlertingDetailsViewV2
 	// Enables the preview of the new alert details view
 	FlagAlertingDetailsViewV2 = "alertingDetailsViewV2"
+
+	// FlagAlertingSimplifiedRouting
+	// Enables the simplified routing for alerting
+	FlagAlertingSimplifiedRouting = "alertingSimplifiedRouting"
 )


### PR DESCRIPTION
**What is this feature?**

This PR adds the a feature toggle for the new  simplified alert routing feature.

In order to enable the feature, it can be done via query params by accessing `/alerting?__feature.alertingSimplifiedRouting=true` in development mode or `window.localStorage.setItem('grafana.featureToggles', 'alertingSimplifiedRouting=true')` in production.

**Why do we need this feature?**

We want to gradually incorporate the work-in-progress code for this new feature, but without enabling the feature until it's fully completed.

**Who is this feature for?**

All users.

**Which issue(s) does this PR fix?**:

Fixes #77929 


Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
