### PR TITLE
Plugins: Fix outline for elements inside a plugin page

### DIFF
--- a/public/app/features/plugins/admin/components/PluginDetailsPage.tsx
+++ b/public/app/features/plugins/admin/components/PluginDetailsPage.tsx
@@ -111,6 +111,7 @@ export const getStyles = (theme: GrafanaTheme2) => {
     tabContent: css`
       overflow: auto;
       height: 100%;
+      padding-left: 5px;
     `,
   };
 };


### PR DESCRIPTION
**What is this feature?**

Adds a small left-padding to the app details page to prevent fields outlines not showing correctly

Before:
![image](https://github.com/grafana/grafana/assets/227916/cb51d916-2ec2-423c-bfe5-30a9fcf9cbe1)

After:
![image](https://github.com/grafana/grafana/assets/227916/daea9af2-b62f-44b2-8ee6-c1f1dbe4b060)


**Why do we need this feature?**

To fix a visual bug in the app details page introduced in https://github.com/grafana/grafana/pull/58741

**Who is this feature for?**

All users visiting an app details page

**Which issue(s) does this PR fix?**:

fixes https://github.com/grafana/grafana/issues/70820

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:

- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
