### PR TITLE
Revert "Loki: Add error source to DataQuery (#77876)"

### DIFF
--- a/pkg/tsdb/loki/api_test.go
+++ b/pkg/tsdb/loki/api_test.go
@@ -28,8 +28,8 @@ func TestApiLogVolume(t *testing.T) {
 			require.Equal(t, "Source=logvolhist", req.Header.Get("X-Query-Tags"))
 		})
 
-		res := api.DataQuery(context.Background(), lokiQuery{Expr: "", SupportingQueryType: SupportingQueryLogsVolume, QueryType: QueryTypeRange}, ResponseOpts{})
-		require.Equal(t, nil, res.Error)
+		_, err := api.DataQuery(context.Background(), lokiQuery{Expr: "", SupportingQueryType: SupportingQueryLogsVolume, QueryType: QueryTypeRange}, ResponseOpts{})
+		require.NoError(t, err)
 		require.True(t, called)
 	})
 
@@ -40,8 +40,8 @@ func TestApiLogVolume(t *testing.T) {
 			require.Equal(t, "Source=logsample", req.Header.Get("X-Query-Tags"))
 		})
 
-		res := api.DataQuery(context.Background(), lokiQuery{Expr: "", SupportingQueryType: SupportingQueryLogsSample, QueryType: QueryTypeRange}, ResponseOpts{})
-		require.Equal(t, nil, res.Error)
+		_, err := api.DataQuery(context.Background(), lokiQuery{Expr: "", SupportingQueryType: SupportingQueryLogsSample, QueryType: QueryTypeRange}, ResponseOpts{})
+		require.NoError(t, err)
 		require.True(t, called)
 	})
 
@@ -52,8 +52,8 @@ func TestApiLogVolume(t *testing.T) {
 			require.Equal(t, "Source=datasample", req.Header.Get("X-Query-Tags"))
 		})
 
-		res := api.DataQuery(context.Background(), lokiQuery{Expr: "", SupportingQueryType: SupportingQueryDataSample, QueryType: QueryTypeRange}, ResponseOpts{})
-		require.Equal(t, nil, res.Error)
+		_, err := api.DataQuery(context.Background(), lokiQuery{Expr: "", SupportingQueryType: SupportingQueryDataSample, QueryType: QueryTypeRange}, ResponseOpts{})
+		require.NoError(t, err)
 		require.True(t, called)
 	})
 
@@ -64,8 +64,8 @@ func TestApiLogVolume(t *testing.T) {
 			require.Equal(t, "", req.Header.Get("X-Query-Tags"))
 		})
 
-		res := api.DataQuery(context.Background(), lokiQuery{Expr: "", SupportingQueryType: SupportingQueryNone, QueryType: QueryTypeRange}, ResponseOpts{})
-		require.Equal(t, nil, res.Error)
+		_, err := api.DataQuery(context.Background(), lokiQuery{Expr: "", SupportingQueryType: SupportingQueryNone, QueryType: QueryTypeRange}, ResponseOpts{})
+		require.NoError(t, err)
 		require.True(t, called)
 	})
 }
@@ -133,8 +133,8 @@ func TestApiUrlHandling(t *testing.T) {
 				QueryType: QueryTypeRange,
 			}
 
-			res := api.DataQuery(context.Background(), query, ResponseOpts{})
-			require.Equal(t, nil, res.Error)
+			_, err := api.DataQuery(context.Background(), query, ResponseOpts{})
+			require.NoError(t, err)
 			require.True(t, called)
 		})
 	}
@@ -154,8 +154,8 @@ func TestApiUrlHandling(t *testing.T) {
 				QueryType: QueryTypeInstant,
 			}
 
-			res := api.DataQuery(context.Background(), query, ResponseOpts{})
-			require.Equal(t, nil, res.Error)
+			_, err := api.DataQuery(context.Background(), query, ResponseOpts{})
+			require.NoError(t, err)
 			require.True(t, called)
 		})
 	}

--- a/pkg/tsdb/loki/framing_test.go
+++ b/pkg/tsdb/loki/framing_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/grafana/grafana-plugin-sdk-go/backend"
 	"github.com/grafana/grafana-plugin-sdk-go/experimental"
 	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/stretchr/testify/require"
@@ -60,10 +61,14 @@ func TestSuccessResponse(t *testing.T) {
 		bytes, err := os.ReadFile(responseFileName)
 		require.NoError(t, err)
 
-		resp := runQuery(context.Background(), makeMockedAPI(http.StatusOK, "application/json", bytes, nil), &query, responseOpts, log.New("test"))
-		require.Equal(t, nil, resp.Error)
+		frames, err := runQuery(context.Background(), makeMockedAPI(http.StatusOK, "application/json", bytes, nil), &query, responseOpts, log.New("test"))
+		require.NoError(t, err)
 
-		experimental.CheckGoldenJSONResponse(t, folder, goldenFileName, &resp, true)
+		dr := &backend.DataResponse{
+			Frames: frames,
+			Error:  err,
+		}
+		experimental.CheckGoldenJSONResponse(t, folder, goldenFileName, dr, true)
 	}
 
 	for _, test := range tt {
@@ -121,11 +126,11 @@ func TestErrorResponse(t *testing.T) {
 
 	for _, test := range tt {
 		t.Run(test.name, func(t *testing.T) {
-			resp := runQuery(context.Background(), makeMockedAPI(400, test.contentType, test.body, nil), &lokiQuery{QueryType: QueryTypeRange, Direction: DirectionBackward}, ResponseOpts{}, log.New("test"))
+			frames, err := runQuery(context.Background(), makeMockedAPI(400, test.contentType, test.body, nil), &lokiQuery{QueryType: QueryTypeRange, Direction: DirectionBackward}, ResponseOpts{}, log.New("test"))
 
-			require.Len(t, resp.Frames, 0)
-			require.Error(t, resp.Error)
-			require.EqualError(t, resp.Error, test.errorMessage)
+			require.Len(t, frames, 0)
+			require.Error(t, err)
+			require.EqualError(t, err, test.errorMessage)
 		})
 	}
 }

--- a/pkg/tsdb/loki/loki.go
+++ b/pkg/tsdb/loki/loki.go
@@ -13,10 +13,8 @@ import (
 	"github.com/grafana/dskit/concurrency"
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
 	"github.com/grafana/grafana-plugin-sdk-go/backend/datasource"
-	sdkhttpclient "github.com/grafana/grafana-plugin-sdk-go/backend/httpclient"
 	"github.com/grafana/grafana-plugin-sdk-go/backend/instancemgmt"
 	"github.com/grafana/grafana-plugin-sdk-go/data"
-	"github.com/grafana/grafana-plugin-sdk-go/experimental/errorsource"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
 	"go.opentelemetry.io/otel/trace"
@@ -97,7 +95,6 @@ func newInstanceSettings(httpClientProvider httpclient.Provider) datasource.Inst
 			return nil, err
 		}
 
-		opts.Middlewares = append(sdkhttpclient.DefaultMiddlewares(), errorsource.Middleware("errorsource"))
 		client, err := httpClientProvider.New(opts)
 		if err != nil {
 			return nil, err
@@ -242,28 +239,37 @@ func executeQuery(ctx context.Context, query *lokiQuery, req *backend.QueryDataR
 
 	defer span.End()
 
-	res := runQuery(ctx, api, query, responseOpts, plog)
-	return res
+	frames, err := runQuery(ctx, api, query, responseOpts, plog)
+	queryRes := backend.DataResponse{}
+	if err != nil {
+		span.RecordError(err)
+		span.SetStatus(codes.Error, err.Error())
+		queryRes.Error = err
+	} else {
+		queryRes.Frames = frames
+	}
+
+	return queryRes
 }
 
 // we extracted this part of the functionality to make it easy to unit-test it
-func runQuery(ctx context.Context, api *LokiAPI, query *lokiQuery, responseOpts ResponseOpts, plog log.Logger) backend.DataResponse {
-	dataResponse := api.DataQuery(ctx, *query, responseOpts)
-	if dataResponse.Error != nil {
-		plog.Error("Error querying loki", "error", dataResponse.Error)
-		return dataResponse
+func runQuery(ctx context.Context, api *LokiAPI, query *lokiQuery, responseOpts ResponseOpts, plog log.Logger) (data.Frames, error) {
+	frames, err := api.DataQuery(ctx, *query, responseOpts)
+	if err != nil {
+		plog.Error("Error querying loki", "error", err)
+		return data.Frames{}, err
 	}
 
-	for _, frame := range dataResponse.Frames {
-		err := adjustFrame(frame, query, !responseOpts.metricDataplane, responseOpts.logsDataplane)
+	for _, frame := range frames {
+		err = adjustFrame(frame, query, !responseOpts.metricDataplane, responseOpts.logsDataplane)
 
 		if err != nil {
 			plog.Error("Error adjusting frame", "error", err)
-			return errorsource.Response(errorsource.PluginError(err, false))
+			return data.Frames{}, err
 		}
 	}
 
-	return dataResponse
+	return frames, nil
 }
 
 func (s *Service) getDSInfo(ctx context.Context, pluginCtx backend.PluginContext) (*datasourceInfo, error) {

--- a/pkg/tsdb/loki/loki_bench_test.go
+++ b/pkg/tsdb/loki/loki_bench_test.go
@@ -19,7 +19,7 @@ func BenchmarkMatrixJson(b *testing.B) {
 
 	b.ResetTimer()
 	for n := 0; n < b.N; n++ {
-		_ = runQuery(context.Background(), makeMockedAPI(http.StatusOK, "application/json", bytes, nil), &lokiQuery{}, ResponseOpts{}, log.New("test"))
+		_, _ = runQuery(context.Background(), makeMockedAPI(http.StatusOK, "application/json", bytes, nil), &lokiQuery{}, ResponseOpts{}, log.New("test"))
 	}
 }
 


### PR DESCRIPTION
This reverts commit 934456dc1cf6a108765508138fcd9e36334ecbba.

We learned that with the PR, error gets hidden:

Correct: 
<img width="344" alt="image" src="https://github.com/grafana/grafana/assets/30407135/5d3897c6-c44a-4c3c-b94c-8f8a6c5bd451">

Incorrect: 
<img width="1388" alt="image" src="https://github.com/grafana/grafana/assets/30407135/646f81c4-4089-4296-ab3f-6e331c94fbdc">

