### PR TITLE
Prometheus: Fix updating timeRange on builder mode when range is changed

### DIFF
--- a/public/app/plugins/datasource/prometheus/querybuilder/components/MetricsLabelsSection.tsx
+++ b/public/app/plugins/datasource/prometheus/querybuilder/components/MetricsLabelsSection.tsx
@@ -60,7 +60,6 @@ export function MetricsLabelsSection({
   const onGetLabelNames = async (forLabel: Partial<QueryBuilderLabelFilter>): Promise<SelectableValue[]> => {
     // If no metric we need to use a different method
     if (!query.metric) {
-      // FIXME pass timeRange to fetchLabels method
       await datasource.languageProvider.fetchLabels();
       return datasource.languageProvider.getLabelKeys().map((k) => ({ value: k }));
     }

--- a/public/app/plugins/datasource/prometheus/querybuilder/components/PromQueryBuilderContainer.tsx
+++ b/public/app/plugins/datasource/prometheus/querybuilder/components/PromQueryBuilderContainer.tsx
@@ -51,6 +51,10 @@ export function PromQueryBuilderContainer(props: Props) {
     }
   }, [query]);
 
+  useEffect(() => {
+    datasource.languageProvider.start(data?.timeRange);
+  }, [data?.timeRange, datasource.languageProvider]);
+
   const onVisQueryChange = (visQuery: PromVisualQuery) => {
     const expr = promQueryModeller.renderQuery(visQuery);
     dispatch(visualQueryChange({ visQuery, expr }));
@@ -77,7 +81,7 @@ export function PromQueryBuilderContainer(props: Props) {
         data={data}
         showExplain={showExplain}
       />
-      {<QueryPreview query={query.expr} />}
+      <QueryPreview query={query.expr} />
     </>
   );
 }


### PR DESCRIPTION
**What is this feature?**

When we change the time range on builder mode language provider doesn't get the latest values. It was working before because the language provider was using singleton `timeSrv` and we removed those usages in this PR https://github.com/grafana/grafana/pull/76118

In this PR we make sure we provide the up-to-date timerange to the language provider.

**Why do we need this feature?**

[Add a description of the problem the feature is trying to solve.]

**Who is this feature for?**

Prometheus builder mode users

**Special notes for your reviewer:**
### How to test?
- Spin up a dev environment with prometheus datasource
- On explore switch to Prometheus builder mode
- Select a metric click "select labels" dropdown. 
- Check the network tab for labels query and its payload (or query string parameters) (start and end)
- Change the time range
- Click the "select labels" dropdown once more
- Observe that the labels query was sent with the previous time range
- Switch to this branch and try again

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
