### PR TITLE
(WIP) Alerting: Manage remote Alertmanagers' configurations

### DIFF
--- a/pkg/services/ngalert/remote/alertmanager_test.go
+++ b/pkg/services/ngalert/remote/alertmanager_test.go
@@ -2,13 +2,18 @@ package remote
 
 import (
 	"context"
+	"encoding/json"
 	"math/rand"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"testing"
 	"time"
 
 	"github.com/go-openapi/strfmt"
 	apimodels "github.com/grafana/grafana/pkg/services/ngalert/api/tooling/definitions"
+	ngmodels "github.com/grafana/grafana/pkg/services/ngalert/models"
+	"github.com/grafana/grafana/pkg/services/ngalert/notifier"
 	"github.com/grafana/grafana/pkg/util"
 	amv2 "github.com/prometheus/alertmanager/api/v2/models"
 	"github.com/stretchr/testify/require"
@@ -16,6 +21,9 @@ import (
 
 // Valid config for Cloud AM, no `grafana_managed_receievers` field.
 const upstreamConfig = `{"template_files": {}, "alertmanager_config": "{\"global\": {\"smtp_from\": \"test@test.com\"}, \"route\": {\"receiver\": \"discord\"}, \"receivers\": [{\"name\": \"discord\", \"discord_configs\": [{\"webhook_url\": \"http://localhost:1234\"}]}]}"}`
+
+// Valid Grafana Alertmanager configuration.
+const testGrafanaConfig = `{"template_files":{},"alertmanager_config":{"route":{"receiver":"grafana-default-email","group_by":["grafana_folder","alertname"]},"templates":null,"receivers":[{"name":"grafana-default-email","grafana_managed_receiver_configs":[{"uid":"","name":"some other name","type":"email","disableResolveMessage":false,"settings":{"addresses":"\u003cexample@email.com\u003e"},"secureSettings":null}]}]}}`
 
 func TestNewAlertmanager(t *testing.T) {
 	tests := []struct {
@@ -50,7 +58,7 @@ func TestNewAlertmanager(t *testing.T) {
 				TenantID:          test.tenantID,
 				BasicAuthPassword: test.password,
 			}
-			am, err := NewAlertmanager(cfg, test.orgID)
+			am, err := NewAlertmanager(cfg, test.orgID, nil)
 			if test.expErr != "" {
 				require.EqualError(tt, err, test.expErr)
 				return
@@ -64,6 +72,111 @@ func TestNewAlertmanager(t *testing.T) {
 			require.NotNil(tt, am.httpClient)
 		})
 	}
+}
+
+func TestApplyConfig(t *testing.T) {
+	errorHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	})
+	okHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+
+	// ApplyConfig performs a readiness check at startup.
+	// A non-200 response should result in an error.
+	server := httptest.NewServer(errorHandler)
+	cfg := AlertmanagerConfig{
+		URL: server.URL,
+	}
+	am, err := NewAlertmanager(cfg, 1, nil)
+	require.NoError(t, err)
+
+	ctx := context.Background()
+	require.Error(t, am.ApplyConfig(ctx, nil))
+	require.False(t, am.Ready())
+
+	// A 200 status code response should make the check succeed.
+	server.Config.Handler = okHandler
+	require.NoError(t, am.ApplyConfig(ctx, nil))
+	require.True(t, am.Ready())
+
+	// If we already got a 200 status code response, we shouldn't make the HTTP request again.
+	server.Config.Handler = errorHandler
+	require.NoError(t, am.ApplyConfig(ctx, nil))
+	require.True(t, am.Ready())
+}
+
+func TestIntegrationRemoteAlertmanagerConfiguration(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
+
+	amURL, ok := os.LookupEnv("AM_URL")
+	if !ok {
+		t.Skip("No Alertmanager URL provided")
+	}
+	tenantID := os.Getenv("AM_TENANT_ID")
+	password := os.Getenv("AM_PASSWORD")
+
+	// ApplyConfig performs a readiness check.
+	cfg := AlertmanagerConfig{
+		URL:               amURL + "/alertmanager",
+		TenantID:          tenantID,
+		BasicAuthPassword: password,
+		ConfigEndpoint:    "/api/v1/grafana/config",
+	}
+	store := notifier.NewFakeConfigStore(t, make(map[int64]*ngmodels.AlertConfiguration))
+	am, err := NewAlertmanager(cfg, 1, store)
+	require.NoError(t, err)
+
+	// We should have no configuration at first.
+	ctx := context.Background()
+	_, err = am.getConfig(ctx)
+	require.Error(t, err)
+	require.Equal(t, "config not found", err.Error())
+
+	// ApplyConfig performs a readiness check.
+	require.NoError(t, am.ApplyConfig(ctx, nil))
+
+	// SaveAndApplyConfig should send the configuration to the remote Alertmanager and store it locally.
+	config, err := notifier.Load([]byte(testGrafanaConfig))
+	require.NoError(t, err)
+	require.NoError(t, am.SaveAndApplyConfig(ctx, config))
+
+	// Retrieving the config should succeed, the configurations should be the same.
+	config, err = am.getConfig(ctx)
+	require.NoError(t, err)
+
+	b, err := json.Marshal(config)
+	require.NoError(t, err)
+	require.JSONEq(t, testGrafanaConfig, string(b))
+
+	savedConfig, err := store.GetLatestAlertmanagerConfiguration(ctx, &ngmodels.GetLatestAlertmanagerConfigurationQuery{
+		OrgID: 1,
+	})
+	require.NoError(t, err)
+	require.Equal(t, testGrafanaConfig, savedConfig.AlertmanagerConfiguration)
+
+	// SaveAndApplyDefaultConfig should pull the configuration from the remote Alertmanager and save it locally.
+	// Let's save an empty config to the store.
+	require.NoError(t, store.SaveAlertmanagerConfiguration(ctx, &ngmodels.SaveAlertmanagerConfigurationCmd{
+		OrgID: 1,
+	}))
+
+	// Check that the previous config is not returned.
+	savedConfig, err = store.GetLatestAlertmanagerConfiguration(ctx, &ngmodels.GetLatestAlertmanagerConfigurationQuery{
+		OrgID: 1,
+	})
+	require.NoError(t, err)
+	require.NotEqual(t, testGrafanaConfig, savedConfig.AlertmanagerConfiguration)
+
+	// Call SavenAndApplyDefaultConfig and check the configuration in the store.
+	require.NoError(t, am.SaveAndApplyDefaultConfig(ctx))
+	savedConfig, err = store.GetLatestAlertmanagerConfiguration(ctx, &ngmodels.GetLatestAlertmanagerConfigurationQuery{
+		OrgID: 1,
+	})
+	require.NoError(t, err)
+	require.Equal(t, testGrafanaConfig, savedConfig.AlertmanagerConfiguration)
 }
 
 func TestIntegrationRemoteAlertmanagerSilences(t *testing.T) {
@@ -83,7 +196,7 @@ func TestIntegrationRemoteAlertmanagerSilences(t *testing.T) {
 		TenantID:          tenantID,
 		BasicAuthPassword: password,
 	}
-	am, err := NewAlertmanager(cfg, 1)
+	am, err := NewAlertmanager(cfg, 1, nil)
 	require.NoError(t, err)
 
 	// We should have no silences at first.
@@ -162,7 +275,7 @@ func TestIntegrationRemoteAlertmanagerAlerts(t *testing.T) {
 		TenantID:          tenantID,
 		BasicAuthPassword: password,
 	}
-	am, err := NewAlertmanager(cfg, 1)
+	am, err := NewAlertmanager(cfg, 1, nil)
 	require.NoError(t, err)
 
 	// Wait until the Alertmanager is ready to send alerts.
@@ -224,7 +337,7 @@ func TestIntegrationRemoteAlertmanagerReceivers(t *testing.T) {
 		BasicAuthPassword: password,
 	}
 
-	am, err := NewAlertmanager(cfg, 1)
+	am, err := NewAlertmanager(cfg, 1, nil)
 	require.NoError(t, err)
 
 	// We should start with the default config.
@@ -233,7 +346,9 @@ func TestIntegrationRemoteAlertmanagerReceivers(t *testing.T) {
 	require.Equal(t, "empty-receiver", *rcvs[0].Name)
 
 	// After changing the configuration, we should have a new `discord` receiver.
-	require.NoError(t, am.postConfig(context.Background(), upstreamConfig))
+	remoteCfg, err := notifier.Load([]byte(upstreamConfig))
+	require.NoError(t, err)
+	require.NoError(t, am.postConfig(context.Background(), remoteCfg))
 	require.Eventually(t, func() bool {
 		rcvs, err = am.GetReceivers(context.Background())
 		require.NoError(t, err)


### PR DESCRIPTION
This PR enables the external Alertmanager client struct to update the configuration in the remote Alertmanager. It does so by sending a `POST` request to `api/v1/alerts`

The methods implemented are:
- `ApplyConfig()`
- `SaveAndApplyConfig()`
- `SaveAndApplyDefaultConfig()`