### PR TITLE
Alerting: Fix export of notification policy to JSON

### DIFF
--- a/pkg/services/ngalert/api/api_provisioning.go
+++ b/pkg/services/ngalert/api/api_provisioning.go
@@ -570,7 +570,7 @@ func exportHcl(download bool, body definitions.AlertingFileExport) response.Resp
 	}
 
 	for idx, cp := range body.Policies {
-		policy := cp.Policy
+		policy := cp.RouteExport
 		resources = append(resources, hcl.Resource{
 			Type: "grafana_notification_policy",
 			Name: fmt.Sprintf("notification_policy_%d", idx+1),

--- a/pkg/services/ngalert/api/api_provisioning_test.go
+++ b/pkg/services/ngalert/api/api_provisioning_test.go
@@ -1113,7 +1113,7 @@ func TestProvisioningApi(t *testing.T) {
 				rc := createTestRequestCtx()
 
 				rc.Context.Req.Header.Add("Accept", "application/json")
-				expectedResponse := `{"apiVersion":1,"policies":[{"orgId":1,"Policy":{"receiver":"default-receiver","group_by":["g1","g2"],"routes":[{"receiver":"nested-receiver","group_by":["g3","g4"],"matchers":["a=\"b\""],"object_matchers":[["foo","=","bar"]],"mute_time_intervals":["interval"],"continue":true,"group_wait":"5m","group_interval":"5m","repeat_interval":"5m"}],"group_wait":"30s","group_interval":"5m","repeat_interval":"1h"}}]}`
+				expectedResponse := `{"apiVersion":1,"policies":[{"orgId":1,"receiver":"default-receiver","group_by":["g1","g2"],"routes":[{"receiver":"nested-receiver","group_by":["g3","g4"],"matchers":["a=\"b\""],"object_matchers":[["foo","=","bar"]],"mute_time_intervals":["interval"],"continue":true,"group_wait":"5m","group_interval":"5m","repeat_interval":"5m"}],"group_wait":"30s","group_interval":"5m","repeat_interval":"1h"}]}`
 
 				response := sut.RouteGetPolicyTreeExport(&rc)
 

--- a/pkg/services/ngalert/api/compat.go
+++ b/pkg/services/ngalert/api/compat.go
@@ -272,8 +272,8 @@ func AlertingFileExportFromRoute(orgID int64, route definitions.Route) (definiti
 	f := definitions.AlertingFileExport{
 		APIVersion: 1,
 		Policies: []definitions.NotificationPolicyExport{{
-			OrgID:  orgID,
-			Policy: RouteExportFromRoute(&route),
+			OrgID:       orgID,
+			RouteExport: RouteExportFromRoute(&route),
 		}},
 	}
 	return f, nil

--- a/pkg/services/ngalert/api/tooling/definitions/provisioning_policies.go
+++ b/pkg/services/ngalert/api/tooling/definitions/provisioning_policies.go
@@ -50,8 +50,8 @@ type Policytree struct {
 
 // NotificationPolicyExport is the provisioned file export of alerting.NotificiationPolicyV1.
 type NotificationPolicyExport struct {
-	OrgID  int64        `json:"orgId" yaml:"orgId"`
-	Policy *RouteExport `json:",inline" yaml:",inline"`
+	OrgID        int64 `json:"orgId" yaml:"orgId"`
+	*RouteExport `yaml:",inline"`
 }
 
 // RouteExport is the provisioned file export of definitions.Route. This is needed to hide fields that aren't useable in

--- a/pkg/services/ngalert/api/tooling/definitions/provisioning_policies_test.go
+++ b/pkg/services/ngalert/api/tooling/definitions/provisioning_policies_test.go
@@ -1,0 +1,29 @@
+package definitions
+
+import (
+	"encoding/json"
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
+	"testing"
+)
+
+func TestNotificationPolicyExportMarshal(t *testing.T) {
+	c := true
+	npe := &NotificationPolicyExport{
+		OrgID: 1,
+		RouteExport: &RouteExport{
+			Receiver: "receiver",
+			Continue: &c,
+		},
+	}
+	t.Run("json", func(t *testing.T) {
+		val, err := json.Marshal(npe)
+		require.NoError(t, err)
+		require.Equal(t, "{\"orgId\":1,\"receiver\":\"receiver\",\"continue\":true}", string(val))
+	})
+	t.Run("yaml", func(t *testing.T) {
+		val, err := yaml.Marshal(npe)
+		require.NoError(t, err)
+		require.Equal(t, "orgId: 1\nreceiver: receiver\ncontinue: true\n", string(val))
+	})
+}

--- a/pkg/services/ngalert/api/tooling/definitions/provisioning_policies_test.go
+++ b/pkg/services/ngalert/api/tooling/definitions/provisioning_policies_test.go
@@ -2,9 +2,10 @@ package definitions
 
 import (
 	"encoding/json"
+	"testing"
+
 	"github.com/stretchr/testify/require"
 	"gopkg.in/yaml.v3"
-	"testing"
 )
 
 func TestNotificationPolicyExportMarshal(t *testing.T) {


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

It exports correctly a Notification Policy in json format, so that it can be provisioned correctly.

**Why do we need this feature?**

Because currently it is not possible to export the default Notification Policy and then provision it in json file format, this due to the Policy fields are not inlined, unlike the yaml format.

**Who is this feature for?**

Any Grafana user I guess

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #78020

**Before this PR**

The JSON version includes the `Policy` attribute which is not included in the Yaml version.

Exported Notification Policy - Json

![image](https://github.com/grafana/grafana/assets/1508272/4dda6031-330c-4daa-a664-87702ed1ff31)

Exported Notification Policy - Yaml

![image](https://github.com/grafana/grafana/assets/1508272/500f87e3-7f57-4ba5-88cf-1ac829d48778)

**With this PR**

The JSON verion now inlines the fields correctly

![image](https://github.com/grafana/grafana/assets/1508272/e3bde049-c8b9-473f-a530-bb5896415a64)

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
