### PR TITLE
Units: Add SI prefix for empty unit

### DIFF
--- a/packages/grafana-data/src/valueFormats/categories.ts
+++ b/packages/grafana-data/src/valueFormats/categories.ts
@@ -47,7 +47,7 @@ export const getCategories = (): ValueFormatCategory[] => [
       },
       {
         name: 'SI prefix',
-        id: 'siprefixed',
+        id: 'siprefix',
         fn: SIPrefix(''),
       },
       { name: 'Percent (0-100)', id: 'percent', fn: toPercent },

--- a/packages/grafana-data/src/valueFormats/categories.ts
+++ b/packages/grafana-data/src/valueFormats/categories.ts
@@ -45,6 +45,11 @@ export const getCategories = (): ValueFormatCategory[] => [
         id: 'short',
         fn: scaledUnits(1000, ['', ' K', ' Mil', ' Bil', ' Tri', ' Quadr', ' Quint', ' Sext', ' Sept']),
       },
+      {
+        name: 'SI prefix',
+        id: 'siprefixed',
+        fn: SIPrefix(''),
+      },
       { name: 'Percent (0-100)', id: 'percent', fn: toPercent },
       { name: 'Percent (0.0-1.0)', id: 'percentunit', fn: toPercentUnit },
       { name: 'Humidity (%H)', id: 'humidity', fn: toFixedUnit('%H') },


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

It adds a new unit under the Misc category called SI prefix, which converts unitless number labels on the y axis to the SI prefix notation. 

**Why do we need this feature?**

Add the possibility to have SI prefix for empty units, for example convert 10000 to 10 k.

**Who is this feature for?**

Any user who wants the shortened notation of numbers accomplished by creating SI prefix when a unit is not necessary or possible on the y axis.

**Which issue(s) does this PR fix?**:

#78022 

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #78022 

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
