### PR TITLE
Transformations: Fix Timeseries to table transformation trend reduction when result is 0

### DIFF
--- a/public/app/features/transformers/timeSeriesTable/timeSeriesTableTransformer.test.ts
+++ b/public/app/features/transformers/timeSeriesTable/timeSeriesTableTransformer.test.ts
@@ -78,11 +78,16 @@ describe('timeSeriesTableTransformer', () => {
     const series = [
       getTimeSeries('A', { instance: 'A', pod: 'B' }, [4, 2, 3]),
       getTimeSeries('B', { instance: 'A', pod: 'C' }, [3, 4, 5]),
+      getTimeSeries('C', { instance: 'B', pod: 'X' }, [4, 2, 0]),
+      getTimeSeries('D', { instance: 'B', pod: 'Y' }, [0, 0, 0]),
     ];
 
     const results = timeSeriesToTableTransform(
       {
         B: {
+          stat: ReducerID.mean,
+        },
+        D: {
           stat: ReducerID.mean,
         },
       },
@@ -91,6 +96,8 @@ describe('timeSeriesTableTransformer', () => {
 
     expect(results[0].fields[2].values[0].value).toEqual(3);
     expect(results[1].fields[2].values[0].value).toEqual(4);
+    expect(results[2].fields[2].values[0].value).toEqual(0);
+    expect(results[3].fields[2].values[0].value).toEqual(0);
   });
 });
 

--- a/public/app/features/transformers/timeSeriesTable/timeSeriesTableTransformer.test.ts
+++ b/public/app/features/transformers/timeSeriesTable/timeSeriesTableTransformer.test.ts
@@ -99,6 +99,24 @@ describe('timeSeriesTableTransformer', () => {
     expect(results[2].fields[2].values[0].value).toEqual(0);
     expect(results[3].fields[2].values[0].value).toEqual(0);
   });
+
+  it('calculate the value for an empty series to null', () => {
+    const series = [getTimeSeries('D', { instance: 'B', pod: 'Y' }, [])];
+
+    const results = timeSeriesToTableTransform(
+      {
+        B: {
+          stat: ReducerID.mean,
+        },
+        D: {
+          stat: ReducerID.mean,
+        },
+      },
+      series
+    );
+
+    expect(results[0].fields[2].values[0].value).toEqual(null);
+  });
 });
 
 it('Will transform multiple data series with the same label', () => {

--- a/public/app/features/transformers/timeSeriesTable/timeSeriesTableTransformer.ts
+++ b/public/app/features/transformers/timeSeriesTable/timeSeriesTableTransformer.ts
@@ -172,7 +172,7 @@ export function timeSeriesToTableTransform(options: TimeSeriesTableTransformerOp
         // and push the frame with reduction
         // into the the appropriate field
         const reducerId = options[refId]?.stat ?? ReducerID.lastNotNull;
-        const value = reduceField({ field, reducers: [reducerId] })[reducerId];
+        const value = reduceField({ field, reducers: [reducerId] })[reducerId] ?? null;
 
         // Push the appropriate time and value frame
         // to the trend frame for the sparkline

--- a/public/app/features/transformers/timeSeriesTable/timeSeriesTableTransformer.ts
+++ b/public/app/features/transformers/timeSeriesTable/timeSeriesTableTransformer.ts
@@ -172,7 +172,7 @@ export function timeSeriesToTableTransform(options: TimeSeriesTableTransformerOp
         // and push the frame with reduction
         // into the the appropriate field
         const reducerId = options[refId]?.stat ?? ReducerID.lastNotNull;
-        const value = reduceField({ field, reducers: [reducerId] })[reducerId] || null;
+        const value = reduceField({ field, reducers: [reducerId] })[reducerId];
 
         // Push the appropriate time and value frame
         // to the trend frame for the sparkline


### PR DESCRIPTION
When reduceField function returns 0, the reduced value is set to null. I think we can remove this "|| null" statement, as:
- There is a check a few lines above to make sure the field type is a number. This might be a reasonable guarantee that the calculation we are doing will make sense and there will be no need to set to null.
- Sparkline cell type already has an option to hide value if we believe the calculation does not make sense.

Fixes #78025
