### PR TITLE
Stat: Minor wide layout option cleanup

### DIFF
--- a/docs/sources/panels-visualizations/visualizations/stat/index.md
+++ b/docs/sources/panels-visualizations/visualizations/stat/index.md
@@ -96,7 +96,7 @@ Set whether wide layout is enabled or not. Wide layout is enabled by default.
 - **Off -** Wide layout is disabled.
 
 {{% admonition type="note" %}}
-This option is only applicable when **Text mode** is set to **Value and name**. When wide layout is enabled, the value and name are displayed side-by-side with the value on the right, if the panel is wide enough. When wide layout is disabled, the value is always rendered underneath the name.
+This option is only applicable when **Text mode** is set to **Auto** or **Value and name**. When wide layout is enabled, the value and name are displayed side-by-side with the value on the right, if the panel is wide enough. When wide layout is disabled, the value is always rendered underneath the name.
 {{% /admonition %}}
 
 ### Color mode

--- a/packages/grafana-ui/src/components/BigValue/BigValue.tsx
+++ b/packages/grafana-ui/src/components/BigValue/BigValue.tsx
@@ -76,9 +76,11 @@ export interface Props extends Themeable2 {
   count?: number;
 
   /**
-   * Disable the wide layout for the BigValue
+   * Enable / disable wide layout for the BigValue
+   * When wide layout is enabled, the value and name are displayed side-by-side with the value on the right, if the panel is wide enough.
+   * When wide layout is disabled, the value is always rendered underneath the name.
    */
-  disableWideLayout?: boolean;
+  wideLayout?: boolean;
 }
 
 export class BigValue extends PureComponent<Props> {

--- a/packages/grafana-ui/src/components/BigValue/BigValueLayout.tsx
+++ b/packages/grafana-ui/src/components/BigValue/BigValueLayout.tsx
@@ -445,7 +445,7 @@ export class StackedWithNoChartLayout extends BigValueLayout {
 
 export function buildLayout(props: Props): BigValueLayout {
   const { width, height, sparkline } = props;
-  const useWideLayout = width / height > 2.5 && !props.disableWideLayout;
+  const useWideLayout = width / height > 2.5 && props.wideLayout;
 
   if (useWideLayout) {
     if (height > 50 && !!sparkline && sparkline.y.values.length > 1) {

--- a/public/app/plugins/panel/stat/StatPanel.tsx
+++ b/public/app/plugins/panel/stat/StatPanel.tsx
@@ -48,7 +48,7 @@ export class StatPanel extends PureComponent<PanelProps<Options>> {
         theme={config.theme2}
         onClick={openMenu}
         className={targetClassName}
-        disableWideLayout={!options.wideLayout}
+        wideLayout={options.wideLayout}
       />
     );
   };

--- a/public/app/plugins/panel/stat/module.tsx
+++ b/public/app/plugins/panel/stat/module.tsx
@@ -45,7 +45,8 @@ export const plugin = new PanelPlugin<Options>(StatPanel)
           ],
         },
         defaultValue: defaultOptions.wideLayout,
-        showIf: (config) => config.textMode === BigValueTextMode.ValueAndName,
+        showIf: (config) =>
+          config.textMode === BigValueTextMode.Auto || config.textMode === BigValueTextMode.ValueAndName,
       });
 
     builder


### PR DESCRIPTION
Minor refactor of stat panel wide layout prop - making it less convoluted by having the option match the internal prop.

Also enable the option for case where "Text Mode" is "Auto" as the wide layout option can apply in this case as well.

https://github.com/grafana/grafana/assets/22381771/c6aa5aa0-8a95-4595-a734-6eddba62c0d8




Related to https://github.com/grafana/grafana/pull/77018