### PR TITLE
Loki: Fix escaping in cheatsheet

### DIFF
--- a/public/app/plugins/datasource/loki/components/LokiCheatSheet.test.tsx
+++ b/public/app/plugins/datasource/loki/components/LokiCheatSheet.test.tsx
@@ -1,0 +1,41 @@
+import { render, screen } from '@testing-library/react';
+import React, { ComponentProps } from 'react';
+
+import { LokiDatasource } from '../datasource';
+import { LokiQuery } from '../types';
+
+import LokiCheatSheet from './LokiCheatSheet';
+
+const setup = () => {
+  const props: ComponentProps<typeof LokiCheatSheet> = {
+    datasource: {
+      languageProvider: {
+        started: true,
+        getLabelKeys: jest.fn().mockReturnValue(['job']),
+        fetchLabelValues: jest.fn().mockResolvedValue(['"grafana/data"']),
+      },
+    } as unknown as LokiDatasource,
+    query: {} as unknown as LokiQuery,
+    onClickExample: jest.fn(),
+  };
+  return props;
+};
+
+describe('Loki Cheat Sheet', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('escapes label values in examples', async () => {
+    const props = setup();
+    render(<LokiCheatSheet {...props} />);
+    jest.runAllTimers();
+
+    const streamSelector = await screen.findByText('{job="\\"grafana/data\\""}');
+    expect(streamSelector).toBeInTheDocument();
+  });
+});

--- a/public/app/plugins/datasource/loki/components/LokiCheatSheet.tsx
+++ b/public/app/plugins/datasource/loki/components/LokiCheatSheet.tsx
@@ -5,6 +5,7 @@ import { QueryEditorHelpProps } from '@grafana/data';
 import { reportInteraction } from '@grafana/runtime';
 
 import LokiLanguageProvider from '../LanguageProvider';
+import { escapeLabelValueInExactSelector } from '../languageUtils';
 import { LokiQuery } from '../types';
 
 const DEFAULT_EXAMPLES = ['{job="default/prometheus"}'];
@@ -65,7 +66,7 @@ export default class LokiCheatSheet extends PureComponent<QueryEditorHelpProps<L
         const values = await provider.fetchLabelValues(preferredLabel);
         const userExamples = shuffle(values)
           .slice(0, EXAMPLES_LIMIT)
-          .map((value) => `{${preferredLabel}="${value}"}`);
+          .map((value) => `{${preferredLabel}="${escapeLabelValueInExactSelector(value)}"}`);
         this.setState({ userExamples });
       }
     } else {
@@ -85,7 +86,7 @@ export default class LokiCheatSheet extends PureComponent<QueryEditorHelpProps<L
         type="button"
         className="cheat-sheet-item__example"
         key={expr}
-        onClick={(e) => onClick({ refId: 'A', expr })}
+        onClick={() => onClick({ refId: 'A', expr })}
       >
         <code>{expr}</code>
       </button>


### PR DESCRIPTION
The values in cheatsheet were not escaped properly. This PR adds escaping + test.

Before:

<img width="1313" alt="image" src="https://github.com/grafana/grafana/assets/30407135/0a708985-22ad-4202-83f9-afc6b81d9ff3">

<img width="831" alt="image" src="https://github.com/grafana/grafana/assets/30407135/db026784-eb6c-4eb9-82d0-a7d5421f0a68">


After:

<img width="989" alt="image" src="https://github.com/grafana/grafana/assets/30407135/5640d8c0-732e-431c-8c83-43461a499f5e">

<img width="1896" alt="image" src="https://github.com/grafana/grafana/assets/30407135/f8a01c12-79d0-4175-8da3-ec86e08c859f">


**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
