### PR TITLE
ExtSvcAuth: Refactor external service registry to use ExternalServiceRegistry variables

### DIFF
--- a/pkg/plugins/auth/models.go
+++ b/pkg/plugins/auth/models.go
@@ -13,7 +13,7 @@ type ExternalService struct {
 }
 
 type ExternalServiceRegistry interface {
-	HasExternalService(ctx context.Context, pluginID string) bool
+	HasExternalService(ctx context.Context, pluginID string) (bool, error)
 	RegisterExternalService(ctx context.Context, pluginID string, pType plugindef.Type, svc *plugindef.ExternalServiceRegistration) (*ExternalService, error)
 	RemoveExternalService(ctx context.Context, pluginID string) error
 }

--- a/pkg/plugins/manager/fakes/fakes.go
+++ b/pkg/plugins/manager/fakes/fakes.go
@@ -437,8 +437,8 @@ type FakeAuthService struct {
 	Result *auth.ExternalService
 }
 
-func (f *FakeAuthService) HasExternalService(ctx context.Context, pluginID string) bool {
-	return f.Result != nil
+func (f *FakeAuthService) HasExternalService(ctx context.Context, pluginID string) (bool, error) {
+	return f.Result != nil, nil
 }
 
 func (f *FakeAuthService) RegisterExternalService(ctx context.Context, pluginID string, pType plugindef.Type, svc *plugindef.ExternalServiceRegistration) (*auth.ExternalService, error) {

--- a/pkg/plugins/manager/installer.go
+++ b/pkg/plugins/manager/installer.go
@@ -160,10 +160,11 @@ func (m *PluginInstaller) Remove(ctx context.Context, pluginID string) error {
 		}
 	}
 
-	if m.serviceRegistry.HasExternalService(ctx, pluginID) {
+	has, err := m.serviceRegistry.HasExternalService(ctx, pluginID)
+	if err == nil && has {
 		return m.serviceRegistry.RemoveExternalService(ctx, pluginID)
 	}
-	return nil
+	return err
 }
 
 // plugin finds a plugin with `pluginID` from the store

--- a/pkg/services/extsvcauth/models.go
+++ b/pkg/services/extsvcauth/models.go
@@ -18,7 +18,7 @@ type AuthProvider string
 
 type ExternalServiceRegistry interface {
 	// HasExternalService returns whether an external service has been saved with that name.
-	HasExternalService(ctx context.Context, name string) bool
+	HasExternalService(ctx context.Context, name string) (bool, error)
 
 	// RemoveExternalService removes an external service and its associated resources from the database (ex: service account, token).
 	RemoveExternalService(ctx context.Context, name string) error

--- a/pkg/services/extsvcauth/oauthserver/oasimpl/service.go
+++ b/pkg/services/extsvcauth/oauthserver/oasimpl/service.go
@@ -119,6 +119,16 @@ func newProvider(config *fosite.Config, storage any, signingKeyService signingke
 	)
 }
 
+// HasExternalService returns whether an external service has been saved with that name.
+func (s *OAuth2ServiceImpl) HasExternalService(ctx context.Context, name string) (bool, error) {
+	client, errRetrieve := s.sqlstore.GetExternalServiceByName(ctx, name)
+	if errRetrieve != nil && !errors.Is(errRetrieve, oauthserver.ErrClientNotFound) {
+		return false, errRetrieve
+	}
+
+	return client != nil, nil
+}
+
 // GetExternalService retrieves an external service from store by client_id. It populates the SelfPermissions and
 // SignedInUser from the associated service account.
 // For performance reason, the service uses caching.

--- a/pkg/services/pluginsintegration/serviceregistration/serviceregistration.go
+++ b/pkg/services/pluginsintegration/serviceregistration/serviceregistration.go
@@ -31,10 +31,10 @@ func ProvideService(cfg *config.Cfg, reg extsvcauth.ExternalServiceRegistry, set
 	return s
 }
 
-func (s *Service) HasExternalService(ctx context.Context, pluginID string) bool {
+func (s *Service) HasExternalService(ctx context.Context, pluginID string) (bool, error) {
 	if !s.featureEnabled {
 		s.log.Debug("Skipping HasExternalService call. The feature is behind a feature toggle and needs to be enabled.")
-		return false
+		return false, nil
 	}
 
 	return s.reg.HasExternalService(ctx, pluginID)

--- a/pkg/services/serviceaccounts/extsvcaccounts/service.go
+++ b/pkg/services/serviceaccounts/extsvcaccounts/service.go
@@ -64,6 +64,18 @@ func (esa *ExtSvcAccountsService) EnableExtSvcAccount(ctx context.Context, cmd *
 	return esa.saSvc.EnableServiceAccount(ctx, cmd.OrgID, saID, cmd.Enabled)
 }
 
+// HasExternalService returns whether an external service has been saved with that name.
+func (esa *ExtSvcAccountsService) HasExternalService(ctx context.Context, name string) (bool, error) {
+	saName := sa.ExtSvcPrefix + slugify.Slugify(name)
+
+	saID, errRetrieve := esa.saSvc.RetrieveServiceAccountIdByName(ctx, extsvcauth.TmpOrgID, saName)
+	if errRetrieve != nil && !errors.Is(errRetrieve, sa.ErrServiceAccountNotFound) {
+		return false, errRetrieve
+	}
+
+	return saID > 0, nil
+}
+
 // RetrieveExtSvcAccount fetches an external service account by ID
 func (esa *ExtSvcAccountsService) RetrieveExtSvcAccount(ctx context.Context, orgID, saID int64) (*sa.ExtSvcAccount, error) {
 	svcAcc, err := esa.saSvc.RetrieveServiceAccount(ctx, orgID, saID)


### PR DESCRIPTION
**What is this feature?**

This is just a small refactor to make it obvious that the `OAuth2Server` and the `ExtSvcAccountsService` are `ExternalServiceRegistry`. The nice thing about this is that if we remove the `OAuth2Server` code, we can just remove the `extsvcauth.Registry` service and use the `ExtSvcAccountsService` service straight away.

**Why do we need this feature?**

[Add a description of the problem the feature is trying to solve.]

**Who is this feature for?**

[Add information on what kind of user the feature is for.]

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
