### PR TITLE
Plugins: Add statusSource to partial data response error log

### DIFF
--- a/pkg/plugins/pluginrequestmeta/plugin_request_meta.go
+++ b/pkg/plugins/pluginrequestmeta/plugin_request_meta.go
@@ -3,6 +3,8 @@ package pluginrequestmeta
 import (
 	"context"
 	"errors"
+
+	"github.com/grafana/grafana-plugin-sdk-go/backend"
 )
 
 // StatusSource is an enum-like string value representing the source of a
@@ -27,6 +29,16 @@ func StatusSourceFromContext(ctx context.Context) StatusSource {
 		return *value
 	}
 	return DefaultStatusSource
+}
+
+// StatusSourceFromPluginErrorSource takes an error source returned by a plugin and returns the corresponding
+// StatusSource. If the provided value is a zero-value (i.e.: the plugin did not set it), the function returns
+// DefaultStatusSource.
+func StatusSourceFromPluginErrorSource(pluginErrorSource backend.ErrorSource) StatusSource {
+	if pluginErrorSource == "" {
+		return DefaultStatusSource
+	}
+	return StatusSource(pluginErrorSource)
 }
 
 // WithStatusSource sets the plugin request status source for the context.

--- a/pkg/plugins/pluginrequestmeta/plugin_request_meta.go
+++ b/pkg/plugins/pluginrequestmeta/plugin_request_meta.go
@@ -31,16 +31,6 @@ func StatusSourceFromContext(ctx context.Context) StatusSource {
 	return DefaultStatusSource
 }
 
-// StatusSourceFromPluginErrorSource takes an error source returned by a plugin and returns the corresponding
-// StatusSource. If the provided value is a zero-value (i.e.: the plugin did not set it), the function returns
-// DefaultStatusSource.
-func StatusSourceFromPluginErrorSource(pluginErrorSource backend.ErrorSource) StatusSource {
-	if pluginErrorSource == "" {
-		return DefaultStatusSource
-	}
-	return StatusSource(pluginErrorSource)
-}
-
 // WithStatusSource sets the plugin request status source for the context.
 func WithStatusSource(ctx context.Context, s StatusSource) context.Context {
 	return context.WithValue(ctx, statusSourceCtxKey{}, &s)
@@ -56,4 +46,14 @@ func WithDownstreamStatusSource(ctx context.Context) error {
 	}
 	*v = StatusSourceDownstream
 	return nil
+}
+
+// StatusSourceFromPluginErrorSource takes an error source returned by a plugin and returns the corresponding
+// StatusSource. If the provided value is a zero-value (i.e.: the plugin did not set it), the function returns
+// DefaultStatusSource.
+func StatusSourceFromPluginErrorSource(pluginErrorSource backend.ErrorSource) StatusSource {
+	if pluginErrorSource == "" {
+		return DefaultStatusSource
+	}
+	return StatusSource(pluginErrorSource)
 }

--- a/pkg/plugins/pluginrequestmeta/plugin_request_meta.go
+++ b/pkg/plugins/pluginrequestmeta/plugin_request_meta.go
@@ -14,16 +14,19 @@ const (
 	StatusSourceDownstream StatusSource = "downstream"
 )
 
+// DefaultStatusSource is the default StatusSource that should be used when it is not explicitly set by the plugin.
+const DefaultStatusSource StatusSource = StatusSourcePlugin
+
 type statusSourceCtxKey struct{}
 
 // StatusSourceFromContext returns the plugin request status source stored in the context.
-// If no plugin request status source is stored in the context, [StatusSourcePlugin] is returned.
+// If no plugin request status source is stored in the context, [DefaultStatusSource] is returned.
 func StatusSourceFromContext(ctx context.Context) StatusSource {
 	value, ok := ctx.Value(statusSourceCtxKey{}).(*StatusSource)
 	if ok {
 		return *value
 	}
-	return StatusSourcePlugin
+	return DefaultStatusSource
 }
 
 // WithStatusSource sets the plugin request status source for the context.

--- a/pkg/services/pluginsintegration/clientmiddleware/logger_middleware.go
+++ b/pkg/services/pluginsintegration/clientmiddleware/logger_middleware.go
@@ -82,8 +82,12 @@ func (m *LoggerMiddleware) QueryData(ctx context.Context, req *backend.QueryData
 		for refID, dr := range resp.Responses {
 			if dr.Error != nil {
 				logParams := []any{"refID", refID, "error", dr.Error}
-				if m.features.IsEnabled(featuremgmt.FlagPluginsInstrumentationStatusSource) && dr.ErrorSource != "" {
-					logParams = append(logParams, "statusSource", dr.ErrorSource)
+				if m.features.IsEnabled(featuremgmt.FlagPluginsInstrumentationStatusSource) {
+					statusSource := pluginrequestmeta.DefaultStatusSource
+					if dr.ErrorSource != "" {
+						statusSource = pluginrequestmeta.StatusSource(dr.ErrorSource)
+					}
+					logParams = append(logParams, "statusSource", statusSource)
 				}
 				ctxLogger.Error("Partial data response error", logParams...)
 			}

--- a/pkg/services/pluginsintegration/clientmiddleware/logger_middleware.go
+++ b/pkg/services/pluginsintegration/clientmiddleware/logger_middleware.go
@@ -83,11 +83,7 @@ func (m *LoggerMiddleware) QueryData(ctx context.Context, req *backend.QueryData
 			if dr.Error != nil {
 				logParams := []any{"refID", refID, "error", dr.Error}
 				if m.features.IsEnabled(featuremgmt.FlagPluginsInstrumentationStatusSource) {
-					statusSource := pluginrequestmeta.DefaultStatusSource
-					if dr.ErrorSource != "" {
-						statusSource = pluginrequestmeta.StatusSource(dr.ErrorSource)
-					}
-					logParams = append(logParams, "statusSource", statusSource)
+					logParams = append(logParams, "statusSource", pluginrequestmeta.StatusSourceFromPluginErrorSource(dr.ErrorSource))
 				}
 				ctxLogger.Error("Partial data response error", logParams...)
 			}

--- a/pkg/services/pluginsintegration/clientmiddleware/logger_middleware.go
+++ b/pkg/services/pluginsintegration/clientmiddleware/logger_middleware.go
@@ -51,7 +51,7 @@ func (m *LoggerMiddleware) logRequest(ctx context.Context, fn func(ctx context.C
 		logParams = append(logParams, "error", err)
 	}
 	if m.features.IsEnabled(featuremgmt.FlagPluginsInstrumentationStatusSource) {
-		logParams = append(logParams, "status_source", pluginrequestmeta.StatusSourceFromContext(ctx))
+		logParams = append(logParams, "statusSource", pluginrequestmeta.StatusSourceFromContext(ctx))
 	}
 
 	ctxLogger := m.logger.FromContext(ctx)
@@ -81,7 +81,11 @@ func (m *LoggerMiddleware) QueryData(ctx context.Context, req *backend.QueryData
 		ctxLogger := m.logger.FromContext(ctx)
 		for refID, dr := range resp.Responses {
 			if dr.Error != nil {
-				ctxLogger.Error("Partial data response error", "refID", refID, "error", dr.Error)
+				logParams := []any{"refID", refID, "error", dr.Error}
+				if m.features.IsEnabled(featuremgmt.FlagPluginsInstrumentationStatusSource) && dr.ErrorSource != "" {
+					logParams = append(logParams, "statusSource", dr.ErrorSource)
+				}
+				ctxLogger.Error("Partial data response error", logParams...)
 			}
 		}
 

--- a/pkg/services/pluginsintegration/clientmiddleware/logger_middleware.go
+++ b/pkg/services/pluginsintegration/clientmiddleware/logger_middleware.go
@@ -81,7 +81,7 @@ func (m *LoggerMiddleware) QueryData(ctx context.Context, req *backend.QueryData
 		ctxLogger := m.logger.FromContext(ctx)
 		for refID, dr := range resp.Responses {
 			if dr.Error != nil {
-				logParams := []any{"refID", refID, "error", dr.Error}
+				logParams := []any{"refID", refID, "status", int(dr.Status), "error", dr.Error}
 				if m.features.IsEnabled(featuremgmt.FlagPluginsInstrumentationStatusSource) {
 					logParams = append(logParams, "statusSource", pluginrequestmeta.StatusSourceFromPluginErrorSource(dr.ErrorSource))
 				}

--- a/pkg/services/pluginsintegration/clientmiddleware/plugin_request_meta_middleware.go
+++ b/pkg/services/pluginsintegration/clientmiddleware/plugin_request_meta_middleware.go
@@ -16,7 +16,7 @@ func NewPluginRequestMetaMiddleware() plugins.ClientMiddleware {
 	return plugins.ClientMiddlewareFunc(func(next plugins.Client) plugins.Client {
 		return &PluginRequestMetaMiddleware{
 			next:                next,
-			defaultStatusSource: pluginrequestmeta.StatusSourcePlugin,
+			defaultStatusSource: pluginrequestmeta.DefaultStatusSource,
 		}
 	})
 }


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

Adds `statusSource` log parameter to "Partial data response error" error log, if the feature flag `FlagPluginsInstrumentationStatusSource` is enabled.  If the error source is not set by the plugin, the log param is still present and defaults to `plugin`.

**Why do we need this feature?**

Better instrumentation.


**Who is this feature for?**

Plugins platform and Grafana operators.

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle.
- [x] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
