### PR TITLE
Plugins: Remove usage of deprecated folder id

### DIFF
--- a/pkg/services/plugindashboards/service/dashboard_updater.go
+++ b/pkg/services/plugindashboards/service/dashboard_updater.go
@@ -177,7 +177,6 @@ func (du *DashboardUpdater) autoUpdateAppDashboard(ctx context.Context, pluginDa
 			{Action: dashboards.ActionDashboardsWrite, Scope: dashboards.ScopeFoldersAll},
 		}),
 		Path:      pluginDashInfo.Reference,
-		FolderId:  0, // nolint:staticcheck
 		Dashboard: resp.Dashboard.Data,
 		Overwrite: true,
 		Inputs:    nil,


### PR DESCRIPTION
**What is this feature?**

Remove usage of deprecated folder id when importing dashboard.

**Why do we need this feature?**

Folder id is deprecated and uid should be used instead. Empty uid means "general" folder.

**Who is this feature for?**

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle.
- [x] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
