### PR TITLE
Settings: Actually deprecate access to feature flags

### DIFF
--- a/pkg/api/frontendsettings_test.go
+++ b/pkg/api/frontendsettings_test.go
@@ -33,6 +33,7 @@ import (
 func setupTestEnvironment(t *testing.T, cfg *setting.Cfg, features *featuremgmt.FeatureManager, pstore pluginstore.Store, psettings pluginsettings.Service) (*web.Mux, *HTTPServer) {
 	t.Helper()
 	db.InitTestDB(t)
+	// nolint:staticcheck
 	cfg.IsFeatureToggleEnabled = features.IsEnabled
 
 	{

--- a/pkg/services/featuremgmt/service.go
+++ b/pkg/services/featuremgmt/service.go
@@ -73,6 +73,7 @@ func ProvideManagerService(cfg *setting.Cfg, licensing licensing.Licensing) (*Fe
 	mgmt.update()
 
 	// Minimum approach to avoid circular dependency
+	// nolint:staticcheck
 	cfg.IsFeatureToggleEnabled = mgmt.IsEnabled
 	return mgmt, nil
 }

--- a/pkg/services/grafana-apiserver/config.go
+++ b/pkg/services/grafana-apiserver/config.go
@@ -27,7 +27,7 @@ type config struct {
 	logLevel int
 }
 
-func newConfig(cfg *setting.Cfg) *config {
+func newConfig(cfg *setting.Cfg, features featuremgmt.FeatureToggles) *config {
 	defaultLogLevel := 0
 	ip := net.ParseIP(cfg.HTTPAddr)
 	apiURL := cfg.AppURL
@@ -46,7 +46,7 @@ func newConfig(cfg *setting.Cfg) *config {
 	host := fmt.Sprintf("%s:%d", ip, port)
 
 	return &config{
-		enabled:     cfg.IsFeatureToggleEnabled(featuremgmt.FlagGrafanaAPIServer),
+		enabled:     features.IsEnabled(featuremgmt.FlagGrafanaAPIServer),
 		devMode:     cfg.Env == setting.Dev,
 		dataPath:    filepath.Join(cfg.DataPath, "grafana-apiserver"),
 		ip:          ip,

--- a/pkg/services/grafana-apiserver/config_test.go
+++ b/pkg/services/grafana-apiserver/config_test.go
@@ -11,8 +11,7 @@ import (
 )
 
 func TestNewConfig(t *testing.T) {
-	// nolint:staticcheck
-	cfg := setting.NewCfgWithFeatures(featuremgmt.WithFeatures(featuremgmt.FlagGrafanaAPIServer).IsEnabled)
+	cfg := setting.NewCfg()
 	cfg.Env = setting.Prod
 	cfg.DataPath = "/tmp/grafana"
 	cfg.HTTPAddr = "10.0.0.1"
@@ -23,7 +22,7 @@ func TestNewConfig(t *testing.T) {
 	section.Key("log_level").SetValue("5")
 	section.Key("etcd_servers").SetValue("http://localhost:2379")
 
-	actual := newConfig(cfg)
+	actual := newConfig(cfg, featuremgmt.WithFeatures(featuremgmt.FlagGrafanaAPIServer))
 
 	expected := &config{
 		enabled:     true,

--- a/pkg/services/grafana-apiserver/service.go
+++ b/pkg/services/grafana-apiserver/service.go
@@ -34,6 +34,7 @@ import (
 	"github.com/grafana/grafana/pkg/modules"
 	"github.com/grafana/grafana/pkg/registry"
 	contextmodel "github.com/grafana/grafana/pkg/services/contexthandler/model"
+	"github.com/grafana/grafana/pkg/services/featuremgmt"
 	filestorage "github.com/grafana/grafana/pkg/services/grafana-apiserver/storage/file"
 	"github.com/grafana/grafana/pkg/setting"
 )
@@ -113,12 +114,13 @@ type service struct {
 
 func ProvideService(
 	cfg *setting.Cfg,
+	features featuremgmt.FeatureToggles,
 	rr routing.RouteRegister,
 	authz authorizer.Authorizer,
 	tracing *tracing.TracingService,
 ) (*service, error) {
 	s := &service{
-		config:     newConfig(cfg),
+		config:     newConfig(cfg, features),
 		rr:         rr,
 		stopCh:     make(chan struct{}),
 		builders:   []APIGroupBuilder{},

--- a/pkg/services/grpcserver/service.go
+++ b/pkg/services/grpcserver/service.go
@@ -38,12 +38,14 @@ type gPRCServerService struct {
 	logger  log.Logger
 	server  *grpc.Server
 	address string
+	enabled bool
 }
 
-func ProvideService(cfg *setting.Cfg, authenticator interceptors.Authenticator, tracer tracing.Tracer, registerer prometheus.Registerer) (Provider, error) {
+func ProvideService(cfg *setting.Cfg, features featuremgmt.FeatureToggles, authenticator interceptors.Authenticator, tracer tracing.Tracer, registerer prometheus.Registerer) (Provider, error) {
 	s := &gPRCServerService{
-		cfg:    cfg,
-		logger: log.New("grpc-server"),
+		cfg:     cfg,
+		logger:  log.New("grpc-server"),
+		enabled: features.IsEnabled(featuremgmt.FlagGrpcServer),
 	}
 
 	// Register the metric here instead of an init() function so that we do
@@ -123,10 +125,7 @@ func (s *gPRCServerService) Run(ctx context.Context) error {
 }
 
 func (s *gPRCServerService) IsDisabled() bool {
-	if s.cfg == nil {
-		return true
-	}
-	return !s.cfg.IsFeatureToggleEnabled(featuremgmt.FlagGrpcServer)
+	return !s.enabled
 }
 
 func (s *gPRCServerService) GetServer() *grpc.Server {

--- a/pkg/services/ngalert/migration/store/testing.go
+++ b/pkg/services/ngalert/migration/store/testing.go
@@ -41,7 +41,6 @@ func NewTestMigrationStore(t *testing.T, sqlStore *sqlstore.SQLStore, cfg *setti
 		cfg.UnifiedAlerting.BaseInterval = time.Second * 10
 	}
 	features := featuremgmt.WithFeatures()
-	cfg.IsFeatureToggleEnabled = features.IsEnabled
 	alertingStore := store.DBstore{
 		SQLStore: sqlStore,
 		Cfg:      cfg.UnifiedAlerting,

--- a/pkg/services/ngalert/tests/util.go
+++ b/pkg/services/ngalert/tests/util.go
@@ -44,6 +44,7 @@ func SetupTestEnv(tb testing.TB, baseInterval time.Duration) (*ngalert.AlertNG, 
 	tb.Helper()
 
 	cfg := setting.NewCfg()
+	// nolint:staticcheck
 	cfg.IsFeatureToggleEnabled = featuremgmt.WithFeatures().IsEnabled
 	cfg.UnifiedAlerting = setting.UnifiedAlertingSettings{
 		BaseInterval: setting.SchedulerBaseInterval,

--- a/pkg/services/pluginsintegration/plugins_integration_test.go
+++ b/pkg/services/pluginsintegration/plugins_integration_test.go
@@ -69,10 +69,12 @@ func TestIntegrationPluginManager(t *testing.T) {
 
 	features := featuremgmt.WithFeatures()
 	cfg := &setting.Cfg{
-		Raw:                    raw,
-		StaticRootPath:         staticRootPath,
-		BundledPluginsPath:     bundledPluginsPath,
-		Azure:                  &azsettings.AzureSettings{},
+		Raw:                raw,
+		StaticRootPath:     staticRootPath,
+		BundledPluginsPath: bundledPluginsPath,
+		Azure:              &azsettings.AzureSettings{},
+
+		// nolint:staticcheck
 		IsFeatureToggleEnabled: features.IsEnabled,
 	}
 

--- a/pkg/services/sqlstore/migrations/accesscontrol/test/ac_test.go
+++ b/pkg/services/sqlstore/migrations/accesscontrol/test/ac_test.go
@@ -153,7 +153,8 @@ func TestMigrations(t *testing.T) {
 		{
 			desc: "with editors can admin",
 			config: &setting.Cfg{
-				EditorsCanAdmin:        true,
+				EditorsCanAdmin: true,
+				// nolint:staticcheck
 				IsFeatureToggleEnabled: func(key string) bool { return key == "accesscontrol" },
 				Raw:                    ini.Empty(),
 			},

--- a/pkg/services/sqlstore/migrations/migrations.go
+++ b/pkg/services/sqlstore/migrations/migrations.go
@@ -94,7 +94,9 @@ func (*OSSMigrations) AddMigration(mg *Migrator) {
 	AddExternalAlertmanagerToDatasourceMigration(mg)
 
 	addFolderMigrations(mg)
+	// nolint:staticcheck
 	if mg.Cfg != nil && mg.Cfg.IsFeatureToggleEnabled != nil {
+		// nolint:staticcheck
 		if mg.Cfg.IsFeatureToggleEnabled(featuremgmt.FlagExternalServiceAuth) {
 			oauthserver.AddMigration(mg)
 		}

--- a/pkg/services/sqlstore/sqlstore.go
+++ b/pkg/services/sqlstore/sqlstore.go
@@ -68,6 +68,7 @@ func ProvideService(cfg *setting.Cfg, cacheService *localcache.CacheService, mig
 		return nil, err
 	}
 
+	// nolint:staticcheck
 	if err := s.Migrate(cfg.IsFeatureToggleEnabled(featuremgmt.FlagMigrationLocking)); err != nil {
 		return nil, err
 	}
@@ -306,10 +307,12 @@ func (ss *SQLStore) buildConnectionString() (string, error) {
 			cnnstr += fmt.Sprintf("&transaction_isolation=%s", val)
 		}
 
+		// nolint:staticcheck
 		if ss.Cfg.IsFeatureToggleEnabled(featuremgmt.FlagMysqlAnsiQuotes) || ss.Cfg.IsFeatureToggleEnabled(featuremgmt.FlagNewDBLibrary) {
 			cnnstr += "&sql_mode='ANSI_QUOTES'"
 		}
 
+		// nolint:staticcheck
 		if ss.Cfg.IsFeatureToggleEnabled(featuremgmt.FlagNewDBLibrary) {
 			cnnstr += "&parseTime=true"
 		}
@@ -638,6 +641,7 @@ func initTestDB(testCfg *setting.Cfg, migration registry.DatabaseMigrator, opts 
 
 		// set test db config
 		cfg := setting.NewCfg()
+		// nolint:staticcheck
 		cfg.IsFeatureToggleEnabled = func(key string) bool {
 			for _, enabledFeature := range features {
 				if enabledFeature == key {
@@ -732,6 +736,7 @@ func initTestDB(testCfg *setting.Cfg, migration registry.DatabaseMigrator, opts 
 		return testSQLStore, nil
 	}
 
+	// nolint:staticcheck
 	testSQLStore.Cfg.IsFeatureToggleEnabled = func(key string) bool {
 		for _, enabledFeature := range features {
 			if enabledFeature == key {

--- a/pkg/setting/provider.go
+++ b/pkg/setting/provider.go
@@ -144,7 +144,9 @@ func (o *OSSImpl) Section(section string) Section {
 
 func (*OSSImpl) RegisterReloadHandler(string, ReloadHandler) {}
 
+// Deprecated: use feature toggles
 func (o *OSSImpl) IsFeatureToggleEnabled(name string) bool {
+	// nolint:staticcheck
 	return o.Cfg.IsFeatureToggleEnabled(name)
 }
 

--- a/pkg/setting/setting.go
+++ b/pkg/setting/setting.go
@@ -361,7 +361,7 @@ type Cfg struct {
 	ApiKeyMaxSecondsToLive int64
 
 	// Check if a feature toggle is enabled
-	// @deprecated
+	// Deprecated: use featuremgmt.FeatureFlags
 	IsFeatureToggleEnabled func(key string) bool // filled in dynamically
 
 	AnonymousEnabled     bool
@@ -1168,6 +1168,7 @@ func (cfg *Cfg) Load(args CommandLineArgs) error {
 		return err
 	}
 
+	// nolint:staticcheck
 	if err := cfg.readFeatureToggles(iniFile); err != nil {
 		return err
 	}

--- a/pkg/setting/setting_feature_toggles.go
+++ b/pkg/setting/setting_feature_toggles.go
@@ -8,13 +8,14 @@ import (
 	"github.com/grafana/grafana/pkg/util"
 )
 
-// @deprecated -- should use `featuremgmt.FeatureToggles`
+// Deprecated: should use `featuremgmt.FeatureToggles`
 func (cfg *Cfg) readFeatureToggles(iniFile *ini.File) error {
 	section := iniFile.Section("feature_toggles")
 	toggles, err := ReadFeatureTogglesFromInitFile(section)
 	if err != nil {
 		return err
 	}
+	// nolint:staticcheck
 	cfg.IsFeatureToggleEnabled = func(key string) bool { return toggles[key] }
 	return nil
 }


### PR DESCRIPTION
Two years ago, `settings.IsFeatureToggleEnabled` was replaced with a more full featured feature flag system, but has access though the same function.  It was annotated with the typescript syntax `// @deprecated` not the golang flavor 🤦🏻 

This PR fixes the annotation, adds nolint rules where replacing is hard, and replaces the ones where it is easy