### PR TITLE
Explore: Wrap RawPrometheusContainer with PanelChrome

### DIFF
--- a/public/app/features/explore/RawPrometheus/RawPrometheusContainer.test.tsx
+++ b/public/app/features/explore/RawPrometheus/RawPrometheusContainer.test.tsx
@@ -2,6 +2,7 @@ import { fireEvent, render, screen, within } from '@testing-library/react';
 import React from 'react';
 
 import { FieldType, getDefaultTimeRange, InternalTimeZones, toDataFrame, LoadingState } from '@grafana/data';
+import { getTemplateSrv } from 'app/features/templating/template_srv';
 import { TABLE_RESULTS_STYLE } from 'app/types';
 
 import { RawPrometheusContainer } from './RawPrometheusContainer';
@@ -65,6 +66,10 @@ const defaultProps = {
 };
 
 describe('RawPrometheusContainer', () => {
+  beforeAll(() => {
+    getTemplateSrv();
+  });
+
   it('should render component for prometheus', () => {
     render(<RawPrometheusContainer {...defaultProps} showRawPrometheus={true} />);
 

--- a/public/app/features/explore/RawPrometheus/RawPrometheusContainer.test.tsx
+++ b/public/app/features/explore/RawPrometheus/RawPrometheusContainer.test.tsx
@@ -1,7 +1,7 @@
 import { fireEvent, render, screen, within } from '@testing-library/react';
 import React from 'react';
 
-import { FieldType, getDefaultTimeRange, InternalTimeZones, toDataFrame } from '@grafana/data';
+import { FieldType, getDefaultTimeRange, InternalTimeZones, toDataFrame, LoadingState } from '@grafana/data';
 import { TABLE_RESULTS_STYLE } from 'app/types';
 
 import { RawPrometheusContainer } from './RawPrometheusContainer';
@@ -53,7 +53,7 @@ const dataFrame = toDataFrame({
 
 const defaultProps = {
   exploreId: 'left',
-  loading: false,
+  loading: LoadingState.NotStarted,
   width: 800,
   onCellFilterAdded: jest.fn(),
   tableResult: [dataFrame],

--- a/public/app/features/explore/RawPrometheus/RawPrometheusContainer.tsx
+++ b/public/app/features/explore/RawPrometheus/RawPrometheusContainer.tsx
@@ -2,7 +2,7 @@ import { css } from '@emotion/css';
 import React, { PureComponent } from 'react';
 import { connect, ConnectedProps } from 'react-redux';
 
-import { applyFieldOverrides, DataFrame, SelectableValue, SplitOpen, LoadingState, TimeZone } from '@grafana/data';
+import { applyFieldOverrides, DataFrame, SelectableValue, SplitOpen, TimeZone } from '@grafana/data';
 import { getTemplateSrv, reportInteraction } from '@grafana/runtime';
 import { RadioButtonGroup, Table, AdHocFilterItem, PanelChrome } from '@grafana/ui';
 import { config } from 'app/core/config';
@@ -12,7 +12,6 @@ import { ExploreItemState, TABLE_RESULTS_STYLES, TableResultsStyle } from 'app/t
 
 import { MetaInfoText } from '../MetaInfoText';
 import RawListContainer from '../PrometheusListView/RawListContainer';
-import { selectIsWaitingForData } from '../state/query';
 import { exploreDataLinkPostProcessorFactory } from '../utils/links';
 
 interface RawPrometheusContainerProps {
@@ -32,11 +31,10 @@ interface PrometheusContainerState {
 function mapStateToProps(state: StoreState, { exploreId }: RawPrometheusContainerProps) {
   const explore = state.explore;
   const item: ExploreItemState = explore.panes[exploreId]!;
-  const { tableResult, rawPrometheusResult, range } = item;
-  const loadingInState = selectIsWaitingForData(exploreId)(state);
+  const { tableResult, rawPrometheusResult, range, queryResponse } = item;
   const rawPrometheusFrame: DataFrame[] = rawPrometheusResult ? [rawPrometheusResult] : [];
   const result = (tableResult?.length ?? 0) > 0 && rawPrometheusResult ? tableResult : rawPrometheusFrame;
-  const loading = result && result.length > 0 ? false : loadingInState;
+  const loading = queryResponse.state;
 
   return { loading, tableResult: result, range };
 }
@@ -139,7 +137,7 @@ export class RawPrometheusContainer extends PureComponent<Props, PrometheusConta
     const renderTable = !this.state?.resultsStyle || this.state?.resultsStyle === TABLE_RESULTS_STYLE.table;
 
     return (
-      <PanelChrome title={title} actions={label} loadingState={loading ? LoadingState.Loading : LoadingState.Done}>
+      <PanelChrome title={title} actions={label} loadingState={loading}>
         {frames?.length && (
           <>
             {renderTable && (

--- a/public/app/features/explore/RawPrometheus/RawPrometheusContainer.tsx
+++ b/public/app/features/explore/RawPrometheus/RawPrometheusContainer.tsx
@@ -2,9 +2,9 @@ import { css } from '@emotion/css';
 import React, { PureComponent } from 'react';
 import { connect, ConnectedProps } from 'react-redux';
 
-import { applyFieldOverrides, DataFrame, SelectableValue, SplitOpen, TimeZone } from '@grafana/data';
+import { applyFieldOverrides, DataFrame, SelectableValue, SplitOpen, LoadingState, TimeZone } from '@grafana/data';
 import { getTemplateSrv, reportInteraction } from '@grafana/runtime';
-import { Collapse, RadioButtonGroup, Table, AdHocFilterItem } from '@grafana/ui';
+import { RadioButtonGroup, Table, AdHocFilterItem, PanelChrome } from '@grafana/ui';
 import { config } from 'app/core/config';
 import { PANEL_BORDER } from 'app/core/constants';
 import { StoreState, TABLE_RESULTS_STYLE } from 'app/types';
@@ -86,7 +86,6 @@ export class RawPrometheusContainer extends PureComponent<Props, PrometheusConta
 
     return (
       <div className={spacing}>
-        {this.state.resultsStyle === TABLE_RESULTS_STYLE.raw ? 'Raw' : 'Table'}
         <RadioButtonGroup
           onClick={() => {
             const props = {
@@ -133,13 +132,14 @@ export class RawPrometheusContainer extends PureComponent<Props, PrometheusConta
       (frame: DataFrame | undefined): frame is DataFrame => !!frame && frame.length !== 0
     );
 
+    const title = this.state.resultsStyle === TABLE_RESULTS_STYLE.raw ? 'Raw' : 'Table';
     const label = this.state?.resultsStyle !== undefined ? this.renderLabel() : 'Table';
 
     // Render table as default if resultsStyle is not set.
     const renderTable = !this.state?.resultsStyle || this.state?.resultsStyle === TABLE_RESULTS_STYLE.table;
 
     return (
-      <Collapse label={label} loading={loading} isOpen>
+      <PanelChrome title={title} actions={label} loadingState={loading ? LoadingState.Loading : LoadingState.Done}>
         {frames?.length && (
           <>
             {renderTable && (
@@ -155,7 +155,7 @@ export class RawPrometheusContainer extends PureComponent<Props, PrometheusConta
           </>
         )}
         {!frames?.length && <MetaInfoText metaItems={[{ value: '0 series returned' }]} />}
-      </Collapse>
+      </PanelChrome>
     );
   }
 }


### PR DESCRIPTION
**What is this feature?**

This feature wraps RawPrometheusContainer with PanelChrome. 

**Why do we need this feature?**

Since all other containers in Explore use `PanelChrome` (see #61563) to provide a better UX and consistency, it makes sense to have `RawPrometheusContainer` use `PanelChrome` too. This feature replaces the `Collapse` component that `RawPrometheusContainer` uses. This component makes the graph title text look clickable (the pointer shows up when hovering), but this is unnecessary/confusing because the container doesn't have any collapsible behavior. 

**Which issue(s) does this PR fix?**:

Fixes #78058 

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective
