### PR TITLE
[v10.2.x] Plugins: Keep working when there is no internet access

### DIFF
--- a/public/app/features/plugins/admin/state/actions.ts
+++ b/public/app/features/plugins/admin/state/actions.ts
@@ -1,5 +1,5 @@
 import { createAction, createAsyncThunk, Update } from '@reduxjs/toolkit';
-import { from, forkJoin, timeout, lastValueFrom, catchError, throwError } from 'rxjs';
+import { from, forkJoin, timeout, lastValueFrom, catchError, of } from 'rxjs';
 
 import { PanelPlugin, PluginError } from '@grafana/data';
 import { getBackendSrv, isFetchError } from '@grafana/runtime';
@@ -25,9 +25,18 @@ export const fetchAll = createAsyncThunk(`${STATE_PREFIX}/fetchAll`, async (_, t
     thunkApi.dispatch({ type: `${STATE_PREFIX}/fetchLocal/pending` });
     thunkApi.dispatch({ type: `${STATE_PREFIX}/fetchRemote/pending` });
 
-    const local$ = from(getLocalPlugins());
-    const remote$ = from(getRemotePlugins());
+    const TIMEOUT = 500;
     const pluginErrors$ = from(getPluginErrors());
+    const local$ = from(getLocalPlugins());
+    // Unknown error while fetching remote plugins from GCOM.
+    // (In this case we still operate, but only with locally available plugins.)
+    const remote$ = from(getRemotePlugins()).pipe(
+      catchError((err) => {
+        thunkApi.dispatch({ type: `${STATE_PREFIX}/fetchRemote/rejected` });
+        console.error(err);
+        return of([]);
+      })
+    );
 
     forkJoin({
       local: local$,
@@ -35,20 +44,14 @@ export const fetchAll = createAsyncThunk(`${STATE_PREFIX}/fetchAll`, async (_, t
       pluginErrors: pluginErrors$,
     })
       .pipe(
-        // Fetching the list of plugins from GCOM is slow / errors out
+        // Fetching the list of plugins from GCOM is slow / times out
+        // (We are waiting for TIMEOUT, and if there is still no response from GCOM we continue with locally
+        // installed plugins only by returning a new observable. We also still wait for the remote request to finish or
+        // time out, but we don't block the main execution flow.)
         timeout({
-          each: 500,
+          each: TIMEOUT,
           with: () => {
             remote$
-              // The request to fetch remote plugins from GCOM failed
-              .pipe(
-                catchError((err) => {
-                  thunkApi.dispatch({ type: `${STATE_PREFIX}/fetchRemote/rejected` });
-                  return throwError(
-                    () => new Error('Failed to fetch plugins from catalog (default https://grafana.com/api/plugins)')
-                  );
-                })
-              )
               // Remote plugins loaded after a timeout, updating the store
               .subscribe(async (remote: RemotePlugin[]) => {
                 thunkApi.dispatch({ type: `${STATE_PREFIX}/fetchRemote/fulfilled` });
@@ -75,16 +78,23 @@ export const fetchAll = createAsyncThunk(`${STATE_PREFIX}/fetchAll`, async (_, t
           remote?: RemotePlugin[];
           pluginErrors: PluginError[];
         }) => {
-          thunkApi.dispatch({ type: `${STATE_PREFIX}/fetchLocal/fulfilled` });
-
           // Both local and remote plugins are loaded
           if (local && remote) {
+            thunkApi.dispatch({ type: `${STATE_PREFIX}/fetchLocal/fulfilled` });
+            thunkApi.dispatch({ type: `${STATE_PREFIX}/fetchRemote/fulfilled` });
             thunkApi.dispatch(addPlugins(mergeLocalsAndRemotes(local, remote, pluginErrors)));
 
             // Only remote plugins are loaded (remote timed out)
           } else if (local) {
+            thunkApi.dispatch({ type: `${STATE_PREFIX}/fetchLocal/fulfilled` });
             thunkApi.dispatch(addPlugins(mergeLocalsAndRemotes(local, [], pluginErrors)));
           }
+        },
+        (error) => {
+          console.error(error);
+          thunkApi.dispatch({ type: `${STATE_PREFIX}/fetchLocal/rejected` });
+          thunkApi.dispatch({ type: `${STATE_PREFIX}/fetchRemote/rejected` });
+          return thunkApi.rejectWithValue('Unknown error.');
         }
       );
 


### PR DESCRIPTION
Backport ea12eecac593548b3c024b096cd6e4f329a6e532 from #77978

---

**Related issues:** https://github.com/grafana/grafana/issues/77905, https://github.com/grafana/support-escalations/issues/8305

### What is the problem?
The "Add new connection" and "Plugins catalog" pages are not loading in case there is no internet access.

### Why?
Although releasing https://github.com/grafana/grafana/pull/75272 made it possible to load these pages seamlessly in case the connection to GCOM times out, it didn't cater for any other network errors properly when fetching GCOM. 
 
### Solution
This PR is fixing the issue by not blocking the main UI flow in case the remote plugins are not available. 

### Testing
Tested the following flows manually:
- [x] The "Plugins Catalog" and the "Add new connection" pages are still working if there is no internet
- [x] The "Plugins Catalog" and the "Add new connection" pages do not hang if the GCOM connection is slow or times out. In case the connection is slow, then the remotely available plugins will load later.
- [x] The "Plugins Catalog" and the "Add new connection" operate correctly when there is internet connection
