### PR TITLE
Logs: For LogLines frames, don't show additional fields in log details

### DIFF
--- a/public/app/features/logs/components/LogDetails.test.tsx
+++ b/public/app/features/logs/components/LogDetails.test.tsx
@@ -2,7 +2,16 @@ import { render, screen, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import React from 'react';
 
-import { Field, LogLevel, LogRowModel, MutableDataFrame, createTheme, FieldType } from '@grafana/data';
+import {
+  Field,
+  LogLevel,
+  LogRowModel,
+  MutableDataFrame,
+  createTheme,
+  FieldType,
+  createDataFrame,
+  DataFrameType,
+} from '@grafana/data';
 
 import { LogDetails, Props } from './LogDetails';
 import { createLogRow } from './__mocks__/logRow';
@@ -172,5 +181,67 @@ describe('LogDetails', () => {
     const link = within(traceIdRow!).getByRole('link', { name: 'link' });
     expect(link).toBeInTheDocument();
     expect(link).toHaveAttribute('href', 'localhost:3210/1234');
+  });
+
+  it('should show correct log details fields, links and labels for DataFrameType.LogLines frames', () => {
+    const entry = 'test';
+    const dataFrame = createDataFrame({
+      fields: [
+        { name: 'timestamp', config: {}, type: FieldType.time, values: [1] },
+        { name: 'body', type: FieldType.string, values: [entry] },
+        {
+          name: 'labels',
+          type: FieldType.other,
+          values: [
+            {
+              label1: 'value1',
+            },
+          ],
+        },
+        {
+          name: 'shouldNotShowFieldName',
+          type: FieldType.string,
+          values: ['shouldNotShowFieldValue'],
+        },
+        {
+          name: 'shouldShowLinkName',
+          type: FieldType.string,
+          values: ['shouldShowLinkValue'],
+          config: { links: [{ title: 'link', url: 'localhost:3210/${__value.text}' }] },
+        },
+      ],
+      meta: {
+        type: DataFrameType.LogLines,
+      },
+    });
+
+    setup(
+      {
+        getFieldLinks: (field: Field, rowIndex: number) => {
+          if (field.config && field.config.links) {
+            return field.config.links.map((link) => {
+              return {
+                href: link.url.replace('${__value.text}', field.values[rowIndex]),
+                title: link.title,
+                target: '_blank',
+                origin: field,
+              };
+            });
+          }
+          return [];
+        },
+      },
+      { entry, dataFrame, entryFieldIndex: 0, rowIndex: 0, labels: { label1: 'value1' } }
+    );
+
+    // Don't show additional fields for DataFrameType.LogLines
+    expect(screen.queryByText('shouldNotShowFieldName')).not.toBeInTheDocument();
+    expect(screen.queryByText('shouldNotShowFieldValue')).not.toBeInTheDocument();
+
+    // Show labels and links
+    expect(screen.getByText('label1')).toBeInTheDocument();
+    expect(screen.getByText('value1')).toBeInTheDocument();
+    expect(screen.getByText('shouldShowLinkName')).toBeInTheDocument();
+    expect(screen.getByText('shouldShowLinkValue')).toBeInTheDocument();
   });
 });

--- a/public/app/features/logs/components/LogDetails.tsx
+++ b/public/app/features/logs/components/LogDetails.tsx
@@ -56,6 +56,9 @@ class UnThemedLogDetails extends PureComponent<Props> {
     const displayedFieldsWithLinks = fieldsWithLinks.filter((f) => f.fieldIndex !== row.entryFieldIndex).sort();
     const hiddenFieldsWithLinks = fieldsWithLinks.filter((f) => f.fieldIndex === row.entryFieldIndex).sort();
     const fieldsWithLinksFromVariableMap = createLogLineLinks(hiddenFieldsWithLinks);
+    const fieldsWithLinksAvailable =
+      (displayedFieldsWithLinks && displayedFieldsWithLinks.length > 0) ||
+      (fieldsWithLinksFromVariableMap && fieldsWithLinksFromVariableMap.length > 0);
 
     // do not show the log message unless there is a link attached
     const fields =
@@ -64,9 +67,6 @@ class UnThemedLogDetails extends PureComponent<Props> {
           []
         : fieldsAndLinks.filter((f) => f.links?.length === 0 && f.fieldIndex !== row.entryFieldIndex).sort();
     const fieldsAvailable = fields && fields.length > 0;
-    const fieldsWithLinksAvailable =
-      (displayedFieldsWithLinks && displayedFieldsWithLinks.length > 0) ||
-      (fieldsWithLinksFromVariableMap && fieldsWithLinksFromVariableMap.length > 0);
 
     // If logs with error, we are not showing the level color
     const levelClassName = hasError

--- a/public/app/features/logs/components/LogDetails.tsx
+++ b/public/app/features/logs/components/LogDetails.tsx
@@ -60,12 +60,12 @@ class UnThemedLogDetails extends PureComponent<Props> {
       (displayedFieldsWithLinks && displayedFieldsWithLinks.length > 0) ||
       (fieldsWithLinksFromVariableMap && fieldsWithLinksFromVariableMap.length > 0);
 
-    // do not show the log message unless there is a link attached
     const fields =
       row.dataFrame.meta?.type === DataFrameType.LogLines
-        ? // for DataFrameType.LogLines frames we don't want to show any additional fields besides already extracted labels and links
+        ? // for LogLines frames (dataplane) we don't want to show any additional fields besides already extracted labels and links
           []
-        : fieldsAndLinks.filter((f) => f.links?.length === 0 && f.fieldIndex !== row.entryFieldIndex).sort();
+        : // for other frames, do not show the log message unless there is a link attached
+          fieldsAndLinks.filter((f) => f.links?.length === 0 && f.fieldIndex !== row.entryFieldIndex).sort();
     const fieldsAvailable = fields && fields.length > 0;
 
     // If logs with error, we are not showing the level color

--- a/public/app/features/logs/components/LogDetails.tsx
+++ b/public/app/features/logs/components/LogDetails.tsx
@@ -63,7 +63,7 @@ class UnThemedLogDetails extends PureComponent<Props> {
     // do not show the log message unless there is a link attached
     const fields =
       row.dataFrame.meta?.type === DataFrameType.LogLines
-        ? // for DataFrameType.LogLines frames we don't want to show any additional fields besides the labels
+        ? // for DataFrameType.LogLines frames we don't want to show any additional fields besides already extracted labels and links
           []
         : fieldsAndLinks.filter((f) => f.links?.length === 0 && f.fieldIndex !== row.entryFieldIndex).sort();
     const fieldsAvailable = fields && fields.length > 0;

--- a/public/app/features/logs/components/LogDetails.tsx
+++ b/public/app/features/logs/components/LogDetails.tsx
@@ -1,7 +1,7 @@
 import { cx } from '@emotion/css';
 import React, { PureComponent } from 'react';
 
-import { CoreApp, DataFrame, Field, LinkModel, LogRowModel } from '@grafana/data';
+import { CoreApp, DataFrame, DataFrameType, Field, LinkModel, LogRowModel } from '@grafana/data';
 import { Themeable2, withTheme2 } from '@grafana/ui';
 
 import { calculateLogsLabelStats, calculateStats } from '../utils';
@@ -58,7 +58,11 @@ class UnThemedLogDetails extends PureComponent<Props> {
     const fieldsWithLinksFromVariableMap = createLogLineLinks(hiddenFieldsWithLinks);
 
     // do not show the log message unless there is a link attached
-    const fields = fieldsAndLinks.filter((f) => f.links?.length === 0 && f.fieldIndex !== row.entryFieldIndex).sort();
+    const fields =
+      row.dataFrame.meta?.type === DataFrameType.LogLines
+        ? // for DataFrameType.LogLines frames we don't want to show any additional fields besides the labels
+          []
+        : fieldsAndLinks.filter((f) => f.links?.length === 0 && f.fieldIndex !== row.entryFieldIndex).sort();
     const fieldsAvailable = fields && fields.length > 0;
     const fieldsWithLinksAvailable =
       (displayedFieldsWithLinks && displayedFieldsWithLinks.length > 0) ||


### PR DESCRIPTION
Based on Logs data plane specification in https://grafana.github.io/dataplane/logs/ , the logs visualisation should ignore any other field besides the ones documented in the specs. Other visualisations/features should not be affected by this change. 

This PR fixes it and adds test. I recommend to check the first commit as that's where the main change happens, other commits just reorder variables and change comments. 

**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/grafana/issues/75562

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
