### PR TITLE
Plugins: Share plugin context with the component-type extensions

### DIFF
--- a/public/app/features/plugins/extensions/getPluginExtensions.ts
+++ b/public/app/features/plugins/extensions/getPluginExtensions.ts
@@ -18,6 +18,7 @@ import {
   generateExtensionId,
   getEventHelpers,
   isPluginExtensionComponentConfig,
+  wrapWithPluginContext,
 } from './utils';
 import {
   assertIsReactComponent,
@@ -101,7 +102,7 @@ export const getPluginExtensions: GetExtensions = ({ context, extensionPointId, 
 
           title: extensionConfig.title,
           description: extensionConfig.description,
-          component: extensionConfig.component,
+          component: wrapWithPluginContext(pluginId, extensionConfig.component),
         };
 
         extensions.push(extension);

--- a/public/app/features/plugins/extensions/utils.test.tsx
+++ b/public/app/features/plugins/extensions/utils.test.tsx
@@ -6,7 +6,14 @@ import { type PluginExtensionLinkConfig, PluginExtensionTypes, dateTime, usePlug
 import appEvents from 'app/core/app_events';
 import { ShowModalReactEvent } from 'app/types/events';
 
-import { deepFreeze, isPluginExtensionLinkConfig, handleErrorsInFn, getReadOnlyProxy, getEventHelpers } from './utils';
+import {
+  deepFreeze,
+  isPluginExtensionLinkConfig,
+  handleErrorsInFn,
+  getReadOnlyProxy,
+  getEventHelpers,
+  wrapWithPluginContext,
+} from './utils';
 
 jest.mock('app/features/plugins/pluginSettings', () => ({
   ...jest.requireActual('app/features/plugins/pluginSettings'),
@@ -434,6 +441,28 @@ describe('Plugin Extensions / Utils', () => {
         const { context } = getEventHelpers(pluginId, source);
         expect(context).toBe(source);
       });
+    });
+  });
+
+  describe('wrapExtensionComponentWithContext()', () => {
+    const ExampleComponent = () => {
+      const { meta } = usePluginContext();
+
+      return (
+        <div>
+          <h1>Hello Grafana!</h1> Version: {meta.info.version}
+        </div>
+      );
+    };
+
+    it('should make the plugin context available for the wrapped component', async () => {
+      const pluginId = 'grafana-worldmap-panel';
+      const Component = wrapWithPluginContext(pluginId, ExampleComponent);
+
+      render(<Component />);
+
+      expect(await screen.findByText('Hello Grafana!')).toBeVisible();
+      expect(screen.getByText('Version: 1.0.0')).toBeVisible();
     });
   });
 });


### PR DESCRIPTION
### What changed?
Share the plugin context with component type extensions (until now only app components and modals opened from link extensions received this React context).

**Other changes**
- [x] Add test coverage
- [x] Refactor the logic for link extensions to use the same wrapper for modals

**Example**
```javascript
// Plugin -> module.ts
.configureExtensionComponent<PluginExtensionDataSourceConfigContext>({
    title: 'Test component',
    description: 'Test component extension',
    extensionPointId: 'grafana/datasources/config',
    component: TestExtensionComponent as any,
});

// Plugin -> TestExtensionComponent.tsx
export function TestExtensionComponent(): ReactElement {
  const version = usePluginVersion();

  return (
    <div>
      Plugin Version: {version}
    </div>
  );
}

```