### PR TITLE
Page: Add support for tab counters

### DIFF
--- a/packages/grafana-data/src/types/navModel.ts
+++ b/packages/grafana-data/src/types/navModel.ts
@@ -34,6 +34,7 @@ export interface NavModelItem extends NavLinkDTO {
   parentItem?: NavModelItem;
   onClick?: () => void;
   tabSuffix?: ComponentType<{ className?: string }>;
+  tabCounter?: number;
   hideFromBreadcrumbs?: boolean;
   emptyMessage?: string;
 }

--- a/public/app/core/components/Page/PageTabs.test.tsx
+++ b/public/app/core/components/Page/PageTabs.test.tsx
@@ -1,0 +1,23 @@
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+
+import { NavModelItem } from '@grafana/data';
+
+import { PageTabs } from './PageTabs';
+
+describe('PageTabs', () => {
+  it('should render a tab with a counter', () => {
+    const navItem: NavModelItem = {
+      text: 'My page',
+      children: [
+        {
+          text: 'My tab',
+          tabCounter: 10,
+        },
+      ],
+    };
+
+    render(<PageTabs navItem={navItem} />);
+    expect(screen.getByText('10')).toBeInTheDocument();
+  });
+});

--- a/public/app/core/components/Page/PageTabs.tsx
+++ b/public/app/core/components/Page/PageTabs.tsx
@@ -23,6 +23,7 @@ export function PageTabs({ navItem }: Props) {
                 active={child.active}
                 key={`${child.url}-${index}`}
                 icon={icon}
+                counter={child.tabCounter}
                 href={child.url}
                 suffix={child.tabSuffix}
               />


### PR DESCRIPTION
**What is this feature?**

This PR adds the ability to pass a `counter` to a child nav model (tab) from the [Tab component](https://developers.grafana.com/ui/latest/index.html?path=/story/layout-tabs--counter).

**Why do we need this feature?**

The new alert detail page ([WIP](https://github.com/grafana/grafana/pull/77795)) would benefit from being able to show the number of instances for a particular alert rule before rendering the tab.

**Notes for reviewers**

I'm not sure if I added all of the tags to inform the right folks, feel free to add additional ones or tag folks for review :)