### PR TITLE
Prometheus: Fix UI bug where a label with empty string shows as populated with the deleted label filter value

### DIFF
--- a/public/app/plugins/datasource/prometheus/querybuilder/components/LabelFilterItem.tsx
+++ b/public/app/plugins/datasource/prometheus/querybuilder/components/LabelFilterItem.tsx
@@ -171,7 +171,7 @@ export function LabelFilterItem({
           }}
           invalid={invalidValue}
         />
-        <AccessoryButton aria-label="remove" icon="times" variant="secondary" onClick={onDelete} />
+        <AccessoryButton aria-label={`remove-${item.label}`} icon="times" variant="secondary" onClick={onDelete} />
       </InputGroup>
     </div>
   );

--- a/public/app/plugins/datasource/prometheus/querybuilder/components/LabelFilterItem.tsx
+++ b/public/app/plugins/datasource/prometheus/querybuilder/components/LabelFilterItem.tsx
@@ -65,6 +65,8 @@ export function LabelFilterItem({
     debounceDuration
   );
 
+  const itemValue = item?.value ? item?.value : '';
+
   return (
     <div data-testid="prometheus-dimensions-filter-item">
       <InputGroup>
@@ -128,8 +130,8 @@ export function LabelFilterItem({
           width="auto"
           value={
             isMultiSelect()
-              ? getSelectOptionsFromString(item?.value).map(toOption)
-              : getSelectOptionsFromString(item?.value).map(toOption)[0]
+              ? getSelectOptionsFromString(itemValue).map(toOption)
+              : getSelectOptionsFromString(itemValue).map(toOption)[0]
           }
           allowCustomValue
           onOpenMenu={async () => {

--- a/public/app/plugins/datasource/prometheus/querybuilder/components/LabelFilterItem.tsx
+++ b/public/app/plugins/datasource/prometheus/querybuilder/components/LabelFilterItem.tsx
@@ -65,10 +65,10 @@ export function LabelFilterItem({
     debounceDuration
   );
 
-  const itemValue = item?.value ? item?.value : '';
+  const itemValue = item?.value ?? '';
 
   return (
-    <div data-testid="prometheus-dimensions-filter-item">
+    <div key={itemValue} data-testid="prometheus-dimensions-filter-item">
       <InputGroup>
         {/* Label name select, loads all values at once */}
         <Select

--- a/public/app/plugins/datasource/prometheus/querybuilder/components/LabelFilters.test.tsx
+++ b/public/app/plugins/datasource/prometheus/querybuilder/components/LabelFilters.test.tsx
@@ -66,8 +66,19 @@ describe('LabelFilters', () => {
 
   it('removes label', async () => {
     const { onChange } = setup({ labelsFilters: [{ label: 'foo', op: '=', value: 'bar' }] });
-    await userEvent.click(screen.getByLabelText(/remove/));
+    await userEvent.click(screen.getByLabelText(/remove-foo/));
     expect(onChange).toBeCalledWith([]);
+  });
+
+  it('removes label but preserves a label with a value of empty string', async () => {
+    const { onChange } = setup({
+      labelsFilters: [
+        { label: 'foo', op: '=', value: 'bar' },
+        { label: 'le', op: '=', value: '' },
+      ],
+    });
+    await userEvent.click(screen.getByLabelText(/remove-foo/));
+    expect(onChange).toBeCalledWith([{ label: 'le', op: '=', value: '' }]);
   });
 
   it('renders empty input when labels are deleted from outside ', async () => {

--- a/public/app/plugins/datasource/prometheus/querybuilder/components/LabelFilters.test.tsx
+++ b/public/app/plugins/datasource/prometheus/querybuilder/components/LabelFilters.test.tsx
@@ -73,12 +73,17 @@ describe('LabelFilters', () => {
   it('removes label but preserves a label with a value of empty string', async () => {
     const { onChange } = setup({
       labelsFilters: [
+        { label: 'lab', op: '=', value: 'bel' },
         { label: 'foo', op: '=', value: 'bar' },
         { label: 'le', op: '=', value: '' },
       ],
     });
     await userEvent.click(screen.getByLabelText(/remove-foo/));
-    expect(onChange).toBeCalledWith([{ label: 'le', op: '=', value: '' }]);
+    expect(onChange).toBeCalledWith([
+      { label: 'lab', op: '=', value: 'bel' },
+      { label: 'le', op: '=', value: '' },
+    ]);
+    expect(screen.queryByText('bar')).toBeNull();
   });
 
   it('renders empty input when labels are deleted from outside ', async () => {

--- a/public/app/plugins/datasource/prometheus/querybuilder/components/LabelFilters.tsx
+++ b/public/app/plugins/datasource/prometheus/querybuilder/components/LabelFilters.tsx
@@ -50,7 +50,6 @@ export function LabelFilters({
 
     // Extract full label filters with both label & value
     const newLabels = newItems.filter((x) => x.label != null && x.value != null);
-
     if (!isEqual(newLabels, labelsFilters)) {
       onChange(newLabels);
     }

--- a/public/app/plugins/datasource/prometheus/querybuilder/components/LabelFilters.tsx
+++ b/public/app/plugins/datasource/prometheus/querybuilder/components/LabelFilters.tsx
@@ -49,7 +49,8 @@ export function LabelFilters({
     setItems(newItems);
 
     // Extract full label filters with both label & value
-    const newLabels = newItems.filter((x) => x.label != null && x.value != null);
+    const newLabels = newItems.filter((x) => x.label !== null && (x.value !== null || x.value !== ''));
+    debugger;
     if (!isEqual(newLabels, labelsFilters)) {
       onChange(newLabels);
     }

--- a/public/app/plugins/datasource/prometheus/querybuilder/components/LabelFilters.tsx
+++ b/public/app/plugins/datasource/prometheus/querybuilder/components/LabelFilters.tsx
@@ -49,8 +49,8 @@ export function LabelFilters({
     setItems(newItems);
 
     // Extract full label filters with both label & value
-    const newLabels = newItems.filter((x) => x.label !== null && (x.value !== null || x.value !== ''));
-    debugger;
+    const newLabels = newItems.filter((x) => x.label != null && x.value != null);
+
     if (!isEqual(newLabels, labelsFilters)) {
       onChange(newLabels);
     }


### PR DESCRIPTION
Fixes https://github.com/grafana/grafana/issues/78079
fix in esc epic https://github.com/grafana/support-escalations/issues/8272

Bug fix for the following case:

UI bug: Deleting a label filter when there is a subsequent label filter without a value shows in the UI as populated by the value of the second value with the deleted label filter value.


https://github.com/grafana/grafana/assets/25674746/ada0a4de-f0f3-4abe-b27c-a80ff1779097


1. Create a query in the code editor with three label filters but leave the last one blank. i.e., access_evaluation_duration_bucket{instance="localhost:3005",job="go-app",le="" }

2. Switch to the query editor and it is parsed correctly.

3. Delete the middle label filter job="go-app"

4. See that the le label filter UI now shows the value of the deleted label's value.

Please check that:
- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
