### PR TITLE
Transformations: make reduceField return null when there is no data and no fallback

### DIFF
--- a/packages/grafana-data/src/transformations/fieldReducer.test.ts
+++ b/packages/grafana-data/src/transformations/fieldReducer.test.ts
@@ -1,6 +1,6 @@
 import { difference } from 'lodash';
 
-import { createDataFrame, guessFieldTypeFromValue } from '../dataframe/processDataFrame';
+import { createDataFrame, guessFieldTypeFromValue, toDataFrame } from '../dataframe/processDataFrame';
 import { Field, FieldType, NullValueMode } from '../types/index';
 
 import { fieldReducers, ReducerID, reduceField } from './fieldReducer';
@@ -241,5 +241,18 @@ describe('Stats Calculators', () => {
     someNulls.config.nullValueMode = NullValueMode.Null;
 
     expect(reduce(someNulls, ReducerID.count)).toEqual(4);
+  });
+
+  it('should calculate empty data to null', () => {
+    const stats = reduceField({
+      field: toDataFrame({ fields: [{ name: 'x', values: [] }] }).fields[0],
+      reducers: [ReducerID.first, ReducerID.last, ReducerID.mean, ReducerID.count, ReducerID.allIsNull],
+    });
+
+    expect(stats.first).toEqual(null);
+    expect(stats.last).toEqual(null);
+    expect(stats.mean).toEqual(null);
+    expect(stats.count).toEqual(0);
+    expect(stats.allIsNull).toEqual(true);
   });
 });

--- a/packages/grafana-data/src/transformations/fieldReducer.test.ts
+++ b/packages/grafana-data/src/transformations/fieldReducer.test.ts
@@ -243,7 +243,7 @@ describe('Stats Calculators', () => {
     expect(reduce(someNulls, ReducerID.count)).toEqual(4);
   });
 
-  it('should calculate empty data to null', () => {
+  it('should calculate empty data to null when emptyInputResult is not set', () => {
     const stats = reduceField({
       field: toDataFrame({ fields: [{ name: 'x', values: [] }] }).fields[0],
       reducers: [ReducerID.first, ReducerID.last, ReducerID.mean, ReducerID.count, ReducerID.allIsNull],

--- a/packages/grafana-data/src/transformations/fieldReducer.ts
+++ b/packages/grafana-data/src/transformations/fieldReducer.ts
@@ -60,7 +60,6 @@ export function reduceField(options: ReduceFieldOptions): FieldCalcs {
   if (!field || !reducers || reducers.length < 1) {
     return {};
   }
-
   if (field.state?.calcs) {
     // Find the values we need to calculate
     const missing: string[] = [];
@@ -87,7 +86,7 @@ export function reduceField(options: ReduceFieldOptions): FieldCalcs {
   if (data.length < 1) {
     const calcs: FieldCalcs = { ...field.state.calcs };
     for (const reducer of queue) {
-      calcs[reducer.id] = reducer.emptyInputResult !== null ? reducer.emptyInputResult : null;
+      calcs[reducer.id] = reducer.emptyInputResult ?? null;
     }
     return (field.state.calcs = calcs);
   }


### PR DESCRIPTION
**What is this feature?**

Before the change `reduceField` checks if `emptyInputResult` is null, and if it's null it returns null. The intention seems to be to return null if `emptyInputResult` of the reducer is not set. As it is right now, `emptyInputResult` is not set to null to indicate we don't care, it is instead left undefined. This makes `reduceField` return undefined instead of what seems to be the intended; null.

Fixing this behavior is potentially a breaking change. I've gone through the code that uses the stats downstream, and it looks like it would handle null instead of undefined without issues, but I could easily have missed something.