### PR TITLE
Correlations: Ensure datasource uid property exists when a link is created

### DIFF
--- a/public/app/features/correlations/utils.test.ts
+++ b/public/app/features/correlations/utils.test.ts
@@ -19,6 +19,7 @@ describe('correlations utils', () => {
           datasourceUid: prometheus.uid,
           datasourceName: prometheus.name,
           query: {
+            datasource: { uid: prometheus.uid },
             expr: 'target Prometheus query',
           },
         },
@@ -29,6 +30,7 @@ describe('correlations utils', () => {
           datasourceUid: elastic.uid,
           datasourceName: elastic.name,
           query: {
+            datasource: { uid: elastic.uid },
             expr: 'target Elastic query',
           },
         },

--- a/public/app/features/correlations/utils.ts
+++ b/public/app/features/correlations/utils.ts
@@ -54,9 +54,10 @@ const decorateDataFrameWithInternalDataLinks = (dataFrame: DataFrame, correlatio
     field.config.links = field.config.links?.filter((link) => link.origin !== DataLinkConfigOrigin.Correlations) || [];
     correlations.map((correlation) => {
       if (correlation.config?.field === field.name) {
+        const targetQuery = correlation.config?.target || {};
         field.config.links!.push({
           internal: {
-            query: correlation.config?.target,
+            query: { ...targetQuery, datasource: { uid: correlation.target.uid } },
             datasourceUid: correlation.target.uid,
             datasourceName: correlation.target.name,
             transformations: correlation.config?.transformations,


### PR DESCRIPTION
Missing `datasource` may cause some Explore functionality to stop working. More details in #78166.

Fixes: #78166