### PR TITLE
I18n: Github action to fix up i18n files in Crowdin files

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -668,6 +668,7 @@ embed.go @grafana/grafana-as-code
 /.github/workflows/ephemeral-instances-pr-opened-closed.yml @grafana/grafana-operator-experience-squad
 /.github/workflows/create-security-patch-from-security-mirror.yml @grafana/grafana-delivery
 /.github/workflows/core-plugins-build-and-release.yml @grafana/plugins-platform-frontend @grafana/plugins-platform-backend
+/.github/workflows/i18n-crowdin-fix-files.yml @grafana/grafana-frontend-platform
 
 # Generated files not requiring owner approval
 /packages/grafana-data/src/types/featureToggles.gen.ts @grafanabot

--- a/.github/workflows/i18n-crowdin-fix-files.yml
+++ b/.github/workflows/i18n-crowdin-fix-files.yml
@@ -1,3 +1,7 @@
+# When Crowdin creates a pull request from the crowdin-service-branch branch,
+# run `yarn i18n:extract` and commit the changed grafana.json files back into the PR
+# to reformat crowdin's changes to prevent conflicts with our CI checks.
+
 name: Fix Crowdin I18n files
 
 on:
@@ -5,15 +9,20 @@ on:
     paths:
       - 'public/locales/*/grafana.json'
     branches:
-      - main
+      - main # Only run on pull requests *target* main (will be merged into main)
 
 jobs:
   fix-files:
+    # Only run on pull requests *from* the crowdin-service-branch branch
     if: github.head_ref == 'crowdin-service-branch'
+
     name: Fix files
     runs-on: ubuntu-latest
+
+    # write permission needed to commit changes back in
     permissions:
-      contents: write # write permission needed to commit changes back in
+      contents: write
+
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/i18n-crowdin-fix-files.yml
+++ b/.github/workflows/i18n-crowdin-fix-files.yml
@@ -1,0 +1,32 @@
+name: Fix Crowdin I18n files
+
+on:
+  pull_request:
+    paths:
+      - 'public/locales/*/grafana.json'
+    branches:
+      - main
+
+jobs:
+  fix-files:
+    if: github.head_ref == 'crowdin-service-branch'
+    name: Fix files
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 2
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20.9.0
+          cache: 'yarn'
+
+      - name: Install dependencies
+        run: yarn install
+
+      - name: Extract I18n files
+        run: yarn i18n:extract
+
+      - name: Get changed files
+        run: git diff --name-only -r HEAD^1 HEAD

--- a/.github/workflows/i18n-crowdin-fix-files.yml
+++ b/.github/workflows/i18n-crowdin-fix-files.yml
@@ -12,10 +12,12 @@ jobs:
     if: github.head_ref == 'crowdin-service-branch'
     name: Fix files
     runs-on: ubuntu-latest
+    permissions:
+      contents: write # write permission needed to commit changes back in
     steps:
       - uses: actions/checkout@v4
         with:
-          fetch-depth: 2
+          ref: ${{ github.head_ref }}
 
       - uses: actions/setup-node@v4
         with:
@@ -28,5 +30,8 @@ jobs:
       - name: Extract I18n files
         run: yarn i18n:extract
 
-      - name: Get changed files
-        run: git diff --name-only -r HEAD^1 HEAD
+      - name: Commit changes
+        uses: stefanzweifel/git-auto-commit-action@v5
+        with:
+          commit_message: Fix up I18n files
+          file_pattern: public/locales/*/grafana.json

--- a/.github/workflows/i18n-crowdin-fix-files.yml
+++ b/.github/workflows/i18n-crowdin-fix-files.yml
@@ -33,5 +33,5 @@ jobs:
       - name: Commit changes
         uses: stefanzweifel/git-auto-commit-action@v5
         with:
-          commit_message: Fix up I18n files
+          commit_message: "Github Action: Auto-fix i18n files"
           file_pattern: public/locales/*/grafana.json


### PR DESCRIPTION
Our current CI checks that make sure developers correctly extracts translation phrases gets caught up on Crowdin PRs due to slight subtleties in how Crowdin generates JSON files compared to i18next. 

An example of this is in [this file](https://github.com/grafana/grafana/pull/78174/files#diff-732f678d2c004326fa74424edba48dbca48ffb33849ebe5551f3a56ff5e7eb84) where it has removed the `_many` strings, which then fails our [CI checks](https://drone.grafana.net/grafana/grafana/146424/2/6).

This PR introduces a github action that only runs on pull requests coming from the `crowdin-service-branch` branch. It will run `yarn i18n:extract` and commit the changes back into the PR. There's an example of this in this PR in my fork https://github.com/joshhunt/grafana/pull/1 