### PR TITLE
RBAC: Add OAuth provider scopes separately to fixed:authentication.config:writer

### DIFF
--- a/pkg/services/accesscontrol/models.go
+++ b/pkg/services/accesscontrol/models.go
@@ -396,7 +396,6 @@ const (
 
 	// Settings scope
 	ScopeSettingsAll  = "settings:*"
-	ScopeSettingsAuth = "settings:auth:*"
 	ScopeSettingsSAML = "settings:auth.saml:*"
 
 	// Team related actions
@@ -466,6 +465,10 @@ const (
 var (
 	// Team scope
 	ScopeTeamsID = Scope("teams", "id", Parameter(":teamId"))
+
+	ScopeSettingsOAuth = func(provider string) string {
+		return Scope("settings", "auth."+provider, "*")
+	}
 
 	// Annotation scopes
 	ScopeAnnotationsRoot             = "annotations"

--- a/pkg/services/accesscontrol/roles.go
+++ b/pkg/services/accesscontrol/roles.go
@@ -202,19 +202,59 @@ var (
 		Permissions: []Permission{
 			{
 				Action: ActionSettingsRead,
-				Scope:  ScopeSettingsAuth,
+				Scope:  ScopeSettingsSAML,
 			},
 			{
 				Action: ActionSettingsWrite,
-				Scope:  ScopeSettingsAuth,
+				Scope:  ScopeSettingsSAML,
 			},
 			{
 				Action: ActionSettingsRead,
-				Scope:  ScopeSettingsSAML,
+				Scope:  ScopeSettingsOAuth("azuread"),
 			},
 			{
 				Action: ActionSettingsWrite,
-				Scope:  ScopeSettingsSAML,
+				Scope:  ScopeSettingsOAuth("azuread"),
+			},
+			{
+				Action: ActionSettingsRead,
+				Scope:  ScopeSettingsOAuth("okta"),
+			},
+			{
+				Action: ActionSettingsWrite,
+				Scope:  ScopeSettingsOAuth("okta"),
+			},
+			{
+				Action: ActionSettingsRead,
+				Scope:  ScopeSettingsOAuth("github"),
+			},
+			{
+				Action: ActionSettingsWrite,
+				Scope:  ScopeSettingsOAuth("github"),
+			},
+			{
+				Action: ActionSettingsRead,
+				Scope:  ScopeSettingsOAuth("gitlab"),
+			},
+			{
+				Action: ActionSettingsWrite,
+				Scope:  ScopeSettingsOAuth("gitlab"),
+			},
+			{
+				Action: ActionSettingsRead,
+				Scope:  ScopeSettingsOAuth("google"),
+			},
+			{
+				Action: ActionSettingsWrite,
+				Scope:  ScopeSettingsOAuth("google"),
+			},
+			{
+				Action: ActionSettingsRead,
+				Scope:  ScopeSettingsOAuth("generic_oauth"),
+			},
+			{
+				Action: ActionSettingsWrite,
+				Scope:  ScopeSettingsOAuth("generic_oauth"),
 			},
 		},
 	}

--- a/pkg/services/ssosettings/api/api.go
+++ b/pkg/services/ssosettings/api/api.go
@@ -43,13 +43,11 @@ func (api *Api) RegisterAPIEndpoints() {
 		auth := ac.Middleware(api.AccessControl)
 
 		scopeKey := ac.Parameter(":key")
-		settingsScope := ac.Scope("settings", "auth."+scopeKey, "*")
+		settingsScope := ac.ScopeSettingsOAuth(scopeKey)
 
-		reqWriteAccess := auth(ac.EvalAny(
-			ac.EvalPermission(ac.ActionSettingsWrite, ac.ScopeSettingsAuth),
-			ac.EvalPermission(ac.ActionSettingsWrite, settingsScope)))
+		reqWriteAccess := auth(ac.EvalPermission(ac.ActionSettingsWrite, settingsScope))
 
-		router.Get("/", auth(ac.EvalPermission(ac.ActionSettingsRead, ac.ScopeSettingsAuth)), routing.Wrap(api.listAllProvidersSettings))
+		router.Get("/", auth(ac.EvalPermission(ac.ActionSettingsRead)), routing.Wrap(api.listAllProvidersSettings))
 		router.Get("/:key", auth(ac.EvalPermission(ac.ActionSettingsRead, settingsScope)), routing.Wrap(api.getProviderSettings))
 		router.Put("/:key", reqWriteAccess, routing.Wrap(api.updateProviderSettings))
 		router.Delete("/:key", reqWriteAccess, routing.Wrap(api.removeProviderSettings))


### PR DESCRIPTION
**What is this feature?**

Instead of using the unsupported `settings:auth:*` scope, add the OAuth provider scopes separately to the `fixed:authentication.config:writer` role.

**Why do we need this feature?**

[Add a description of the problem the feature is trying to solve.]

**Who is this feature for?**

**Which issue(s) does this PR fix?**:

Fixes #

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
