### PR TITLE
Sandbox: Exclude incidents app 

### DIFF
--- a/conf/defaults.ini
+++ b/conf/defaults.ini
@@ -382,7 +382,7 @@ angular_support_enabled = true
 csrf_always_check = false
 
 # Comma-separated list of plugins ids that won't be loaded inside the frontend sandbox
-disable_frontend_sandbox_for_plugins =
+disable_frontend_sandbox_for_plugins = grafana-incident-app
 
 [security.encryption]
 # Defines the time-to-live (TTL) for decrypted data encryption keys stored in memory (cache).

--- a/public/app/features/plugins/sandbox/utils.ts
+++ b/public/app/features/plugins/sandbox/utils.ts
@@ -38,8 +38,6 @@ export function logError(error: Error, context?: LogContext) {
   logErrorRuntime(error, context);
 }
 
-const excludePluginSandbox = ['grafana-incident-app'];
-
 export function isFrontendSandboxSupported({
   isAngular,
   pluginId,
@@ -49,8 +47,7 @@ export function isFrontendSandboxSupported({
 }): boolean {
   // To fast test and debug the sandbox in the browser.
   const sandboxQueryParam = location.search.includes('nosandbox') && config.buildInfo.env === 'development';
-  const isPluginExcepted =
-    config.disableFrontendSandboxForPlugins.includes(pluginId) || excludePluginSandbox.includes(pluginId);
+  const isPluginExcepted = config.disableFrontendSandboxForPlugins.includes(pluginId);
   return (
     !isAngular &&
     Boolean(config.featureToggles.pluginsFrontendSandbox) &&

--- a/public/app/features/plugins/sandbox/utils.ts
+++ b/public/app/features/plugins/sandbox/utils.ts
@@ -38,6 +38,8 @@ export function logError(error: Error, context?: LogContext) {
   logErrorRuntime(error, context);
 }
 
+const excludePluginSandbox = ['grafana-incident-app'];
+
 export function isFrontendSandboxSupported({
   isAngular,
   pluginId,
@@ -47,7 +49,8 @@ export function isFrontendSandboxSupported({
 }): boolean {
   // To fast test and debug the sandbox in the browser.
   const sandboxQueryParam = location.search.includes('nosandbox') && config.buildInfo.env === 'development';
-  const isPluginExcepted = config.disableFrontendSandboxForPlugins.includes(pluginId);
+  const isPluginExcepted =
+    config.disableFrontendSandboxForPlugins.includes(pluginId) || excludePluginSandbox.includes(pluginId);
   return (
     !isAngular &&
     Boolean(config.featureToggles.pluginsFrontendSandbox) &&


### PR DESCRIPTION
**What is this feature?**

Excludes grafana-incident-app from running inside the frontend sandbox

**Why do we need this feature?**

Incident app is not optimized for the frontend sandbox yet

**Who is this feature for?**

grafana-incident-app

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:

- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
