### PR TITLE
SSE: Resubmit fix DSNode to not panic when response has empty response

### DIFF
--- a/pkg/expr/nodes.go
+++ b/pkg/expr/nodes.go
@@ -445,7 +445,11 @@ func convertDataFramesToResults(ctx context.Context, frames data.Frames, datasou
 	}
 
 	if len(filtered) == 0 {
-		return "no data", mathexp.Results{Values: mathexp.Values{mathexp.NoData{Frame: frames[0]}}}, nil
+		noData := mathexp.NewNoData()
+		if len(frames) > 0 {
+			noData.Frame = frames[0]
+		}
+		return "no data", mathexp.Results{Values: mathexp.Values{noData}}, nil
 	}
 
 	maybeFixerFn := checkIfSeriesNeedToBeFixed(filtered, datasourceType)

--- a/pkg/expr/nodes_test.go
+++ b/pkg/expr/nodes_test.go
@@ -177,7 +177,20 @@ func TestConvertDataFramesToResults(t *testing.T) {
 		tracer:   tracing.InitializeTracerForTest(),
 		metrics:  newMetrics(nil),
 	}
-
+	var features featuremgmt.FeatureToggles = &featuremgmt.FeatureManager{}
+	t.Run("when it is not dataplane", func(t *testing.T) {
+		f := features
+		t.Cleanup(func() {
+			features = f
+		})
+		features = featuremgmt.WithFeatures(featuremgmt.FlagDisableSSEDataplane)
+		t.Run("should return NoData if no frames", func(t *testing.T) {
+			resultType, res, err := convertDataFramesToResults(context.Background(), []*data.Frame{}, datasources.DS_GRAPHITE, s, &logtest.Fake{})
+			require.NoError(t, err)
+			require.Equal(t, "no-data", resultType)
+			require.Equal(t, mathexp.NewNoData(), res.Values[0].Value())
+		})
+	})
 	t.Run("should add name label if no labels and specific data source", func(t *testing.T) {
 		supported := []string{datasources.DS_GRAPHITE, datasources.DS_TESTDATA}
 		t.Run("when only field name is specified", func(t *testing.T) {


### PR DESCRIPTION
This PR cherry-picks https://github.com/grafana/grafana/pull/74866 + adds some minor changes for it to work.