### PR TITLE
Plugins: Add plugin version field to proto interface

### DIFF
--- a/pkg/plugins/backendplugin/grpcplugin/client_proto.go
+++ b/pkg/plugins/backendplugin/grpcplugin/client_proto.go
@@ -26,19 +26,22 @@ type ProtoClient interface {
 
 	PID() (string, error)
 	PluginID() string
+	PluginVersion() string
 	Logger() log.Logger
 	Start(context.Context) error
 	Stop(context.Context) error
 }
 
 type protoClient struct {
-	plugin *grpcPlugin
+	plugin        *grpcPlugin
+	pluginVersion string
 
 	mu sync.RWMutex
 }
 
 type ProtoClientOpts struct {
 	PluginID       string
+	PluginVersion  string
 	ExecutablePath string
 	ExecutableArgs []string
 	Env            []string
@@ -58,7 +61,7 @@ func NewProtoClient(opts ProtoClientOpts) (ProtoClient, error) {
 		func() []string { return opts.Env },
 	)
 
-	return &protoClient{plugin: p}, nil
+	return &protoClient{plugin: p, pluginVersion: opts.PluginVersion}, nil
 }
 
 func (r *protoClient) PID() (string, error) {
@@ -70,6 +73,10 @@ func (r *protoClient) PID() (string, error) {
 
 func (r *protoClient) PluginID() string {
 	return r.plugin.descriptor.pluginID
+}
+
+func (r *protoClient) PluginVersion() string {
+	return r.pluginVersion
 }
 
 func (r *protoClient) Logger() log.Logger {


### PR DESCRIPTION
**What is this feature?**

Adds plugin version to the plugin protobuf client interface

**Why do we need this feature?**

Adds extra meta info that is useful for identifying plugins

**Who is this feature for?**

Plugins Platform
