### PR TITLE
Prometheus: Query advisor new rudderstack events

### DIFF
--- a/public/app/plugins/datasource/prometheus/querybuilder/components/promQail/PromQail.tsx
+++ b/public/app/plugins/datasource/prometheus/querybuilder/components/promQail/PromQail.tsx
@@ -2,6 +2,7 @@ import { css, cx } from '@emotion/css';
 import React, { useEffect, useReducer, useRef, useState } from 'react';
 
 import { GrafanaTheme2 } from '@grafana/data';
+import { reportInteraction } from '@grafana/runtime';
 import { Button, Checkbox, Input, Spinner, useTheme2 } from '@grafana/ui';
 import store from 'app/core/store';
 
@@ -184,7 +185,10 @@ export const PromQail = (props: PromQailProps) => {
                         const isLoading = true;
                         const suggestionType = SuggestionType.Historical;
                         dispatch(addInteraction({ suggestionType, isLoading }));
-                        //CHECK THIS???
+                        reportInteraction('grafana_prometheus_promqail_know_what_you_want_to_query', {
+                          promVisualQuery: query,
+                          doYouKnow: 'no',
+                        });
                         promQailSuggest(dispatch, 0, query, labelNames, datasource);
                       }}
                     >
@@ -195,6 +199,10 @@ export const PromQail = (props: PromQailProps) => {
                       variant="primary"
                       data-testid={testIds.clickForAi}
                       onClick={() => {
+                        reportInteraction('grafana_prometheus_promqail_know_what_you_want_to_query', {
+                          promVisualQuery: query,
+                          doYouKnow: 'yes',
+                        });
                         const isLoading = false;
                         const suggestionType = SuggestionType.AI;
                         dispatch(addInteraction({ suggestionType, isLoading }));
@@ -271,6 +279,10 @@ export const PromQail = (props: PromQailProps) => {
                                       interaction: newInteraction,
                                     };
 
+                                    reportInteraction('grafana_prometheus_promqail_suggest_query_instead', {
+                                      promVisualQuery: query,
+                                    });
+
                                     dispatch(updateInteraction(payload));
                                     promQailSuggest(dispatch, idx, query, labelNames, datasource, newInteraction);
                                   }}
@@ -291,6 +303,11 @@ export const PromQail = (props: PromQailProps) => {
                                       idx: idx,
                                       interaction: newInteraction,
                                     };
+
+                                    reportInteraction('grafana_prometheus_promqail_prompt_submitted', {
+                                      promVisualQuery: query,
+                                      prompt: interaction.prompt,
+                                    });
 
                                     dispatch(updateInteraction(payload));
                                     // add the suggestions in the API call


### PR DESCRIPTION
Add the following events for https://github.com/grafana/grafana/issues/77822

```
reportInteraction('grafana_prometheus_promqail_know_what_you_want_to_query', {
  promVisualQuery: query,
  doYouKnow: '' // yes or no
});

reportInteraction('grafana_prometheus_promqail_prompt_submitted', {
  promVisualQuery: query,
  prompt: interaction.prompt,
});

// bonus event
reportInteraction('grafana_prometheus_promqail_suggest_query_instead', {
  promVisualQuery: query,
});
```

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
