### PR TITLE
Chore: Deprecate FolderIDs only used by Swagger

### DIFF
--- a/pkg/api/alerting.go
+++ b/pkg/api/alerting.go
@@ -921,6 +921,8 @@ type GetAlertsParams struct {
 	// required:false
 	// type array
 	// collectionFormat: multi
+	//
+	// Deprecated: use FolderUID instead
 	FolderID []string `json:"folderId"`
 	// Limit response to alerts having a dashboard name like this value./ Limit response to alerts having a dashboard name like this value.
 	// in:query

--- a/pkg/api/folder.go
+++ b/pkg/api/folder.go
@@ -514,6 +514,8 @@ type UpdateFolderParams struct {
 type GetFolderByIDParams struct {
 	// in:path
 	// required:true
+	//
+	// Deprecated: use FolderUID instead
 	FolderID int64 `json:"folder_id"`
 }
 

--- a/pkg/api/search.go
+++ b/pkg/api/search.go
@@ -157,6 +157,8 @@ type SearchParams struct {
 	// in:query
 	// required: false
 	// deprecated: true
+	//
+	// Deprecated: use FolderUIDs instead
 	FolderIds []int64 `json:"folderIds"`
 	// List of folder UID’s to search in for dashboards
 	// If it's an empty string then it will query for the top level folders

--- a/pkg/services/plugindashboards/plugindashboards.go
+++ b/pkg/services/plugindashboards/plugindashboards.go
@@ -8,14 +8,15 @@ import (
 
 // PluginDashboard plugin dashboard model..
 type PluginDashboard struct {
-	UID              string `json:"uid"`
-	PluginId         string `json:"pluginId"`
-	Title            string `json:"title"`
-	Imported         bool   `json:"imported"`
-	ImportedUri      string `json:"importedUri"`
-	ImportedUrl      string `json:"importedUrl"`
-	Slug             string `json:"slug"`
-	DashboardId      int64  `json:"dashboardId"`
+	UID         string `json:"uid"`
+	PluginId    string `json:"pluginId"`
+	Title       string `json:"title"`
+	Imported    bool   `json:"imported"`
+	ImportedUri string `json:"importedUri"`
+	ImportedUrl string `json:"importedUrl"`
+	Slug        string `json:"slug"`
+	DashboardId int64  `json:"dashboardId"`
+	// Deprecated: use FolderUID instead
 	FolderId         int64  `json:"folderId"`
 	ImportedRevision int64  `json:"importedRevision"`
 	Revision         int64  `json:"revision"`


### PR DESCRIPTION
Deprecate `FolderID`s from:

- [x] `FolderID` from`PluginDashboard`
- [x] `GetFolderByIDParams` (unused struct)
- [x] `FolderIds` from`SearchParams`
- [x] `FolderID` from`GetAlertsParams`

Part of a series of PRs to deprecate sequential folder IDs.

Ref https://github.com/grafana/grafana/issues/61232