### PR TITLE
Swagger: Fix `getLibraryElementByName` response

### DIFF
--- a/pkg/services/libraryelements/api.go
+++ b/pkg/services/libraryelements/api.go
@@ -270,7 +270,7 @@ func (l *LibraryElementService) getConnectionsHandler(c *contextmodel.ReqContext
 // Returns a library element with the given name.
 //
 // Responses:
-// 200: getLibraryElementResponse
+// 200: getLibraryElementArrayResponse
 // 401: unauthorisedError
 // 404: notFoundError
 // 500: internalServerError
@@ -446,6 +446,12 @@ type GetLibraryElementsResponse struct {
 type GetLibraryElementResponse struct {
 	// in: body
 	Body model.LibraryElementResponse `json:"body"`
+}
+
+// swagger:response getLibraryElementArrayResponse
+type GetLibraryElementArrayResponse struct {
+	// in: body
+	Body model.LibraryElementArrayResponse `json:"body"`
 }
 
 // swagger:response getLibraryElementConnectionsResponse

--- a/public/api-enterprise-spec.json
+++ b/public/api-enterprise-spec.json
@@ -4764,6 +4764,18 @@
         }
       }
     },
+    "LibraryElementArrayResponse": {
+      "type": "object",
+      "title": "LibraryElementArrayResponse is a response struct for an array of LibraryElementDTO.",
+      "properties": {
+        "result": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/LibraryElementDTO"
+          }
+        }
+      }
+    },
     "LibraryElementConnectionDTO": {
       "type": "object",
       "title": "LibraryElementConnectionDTO is the frontend DTO for element connections.",
@@ -8478,6 +8490,12 @@
       "description": "",
       "schema": {
         "$ref": "#/definitions/GetHomeDashboardResponse"
+      }
+    },
+    "getLibraryElementArrayResponse": {
+      "description": "",
+      "schema": {
+        "$ref": "#/definitions/LibraryElementArrayResponse"
       }
     },
     "getLibraryElementConnectionsResponse": {

--- a/public/api-merged.json
+++ b/public/api-merged.json
@@ -6017,7 +6017,7 @@
         ],
         "responses": {
           "200": {
-            "$ref": "#/responses/getLibraryElementResponse"
+            "$ref": "#/responses/getLibraryElementArrayResponse"
           },
           "401": {
             "$ref": "#/responses/unauthorisedError"
@@ -15313,6 +15313,18 @@
         }
       }
     },
+    "LibraryElementArrayResponse": {
+      "type": "object",
+      "title": "LibraryElementArrayResponse is a response struct for an array of LibraryElementDTO.",
+      "properties": {
+        "result": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/LibraryElementDTO"
+          }
+        }
+      }
+    },
     "LibraryElementConnectionDTO": {
       "type": "object",
       "title": "LibraryElementConnectionDTO is the frontend DTO for element connections.",
@@ -21652,6 +21664,12 @@
       "description": "(empty)",
       "schema": {
         "$ref": "#/definitions/GetHomeDashboardResponse"
+      }
+    },
+    "getLibraryElementArrayResponse": {
+      "description": "(empty)",
+      "schema": {
+        "$ref": "#/definitions/LibraryElementArrayResponse"
       }
     },
     "getLibraryElementConnectionsResponse": {

--- a/public/openapi3.json
+++ b/public/openapi3.json
@@ -862,6 +862,16 @@
         },
         "description": "(empty)"
       },
+      "getLibraryElementArrayResponse": {
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/LibraryElementArrayResponse"
+            }
+          }
+        },
+        "description": "(empty)"
+      },
       "getLibraryElementConnectionsResponse": {
         "content": {
           "application/json": {
@@ -6319,6 +6329,18 @@
             "type": "integer"
           }
         },
+        "type": "object"
+      },
+      "LibraryElementArrayResponse": {
+        "properties": {
+          "result": {
+            "items": {
+              "$ref": "#/components/schemas/LibraryElementDTO"
+            },
+            "type": "array"
+          }
+        },
+        "title": "LibraryElementArrayResponse is a response struct for an array of LibraryElementDTO.",
         "type": "object"
       },
       "LibraryElementConnectionDTO": {
@@ -18659,7 +18681,7 @@
         ],
         "responses": {
           "200": {
-            "$ref": "#/components/responses/getLibraryElementResponse"
+            "$ref": "#/components/responses/getLibraryElementArrayResponse"
           },
           "401": {
             "$ref": "#/components/responses/unauthorisedError"


### PR DESCRIPTION
It returns an array of library elements, not a single one. This has been tested by generating the OpenAPI client and using it in Terraform
