### PR TITLE
Revert "InfluxDB: Response parser improvements (#76852)"

### DIFF
--- a/pkg/tsdb/influxdb/influxql/response_parser_test.go
+++ b/pkg/tsdb/influxdb/influxql/response_parser_test.go
@@ -798,7 +798,7 @@ func TestResponseParser_Parse_RetentionPolicy(t *testing.T) {
 		query := models.Query{RefID: "metricFindQuery", RawQuery: "SHOW RETENTION POLICIES"}
 		policyFrame := data.NewFrame("",
 			data.NewField("Value", nil, []string{
-				"autogen", "bar", "5m_avg", "1m_avg",
+				"bar", "autogen", "5m_avg", "1m_avg",
 			}),
 		)
 
@@ -929,28 +929,4 @@ func TestResponseParser_Parse(t *testing.T) {
 			}
 		})
 	}
-}
-
-func TestParseTimestamp(t *testing.T) {
-	validValue := json.Number("1609459200000") // Milliseconds since epoch (January 1, 2021)
-	invalidValue := "invalid"
-
-	t.Run("ValidTimestamp", func(t *testing.T) {
-		parsedTime, err := parseTimestamp(validValue)
-		if err != nil {
-			t.Errorf("Expected no error, got: %v", err)
-		}
-
-		expectedTime := time.Date(2021, 1, 1, 0, 0, 0, 0, time.UTC)
-		if !parsedTime.Equal(expectedTime) {
-			t.Errorf("Expected time: %v, got: %v", expectedTime, parsedTime)
-		}
-	})
-
-	t.Run("InvalidTimestamp", func(t *testing.T) {
-		_, err := parseTimestamp(invalidValue)
-		if err == nil {
-			t.Errorf("Expected an error, got nil")
-		}
-	})
 }


### PR DESCRIPTION
This reverts commit 046791e2be937031c0da44dfdef7c95d29274ee2 from PR https://github.com/grafana/grafana/pull/76852

Is causing malformed frames, and resulting in errors about mismatched field lengths in the logs, No data in the UI, and will cause SSE to panic.

I think this is because of the global slice vars since it seems to take concurrency to replicate it.

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
