### PR TITLE
K8s: Do not allow default namespace when a stack-id exists

### DIFF
--- a/pkg/services/grafana-apiserver/auth/authorizer/stack/stack_id.go
+++ b/pkg/services/grafana-apiserver/auth/authorizer/stack/stack_id.go
@@ -32,6 +32,10 @@ func (auth StackIDAuthorizer) Authorize(ctx context.Context, a authorizer.Attrib
 		return authorizer.DecisionDeny, fmt.Sprintf("error getting signed in user: %v", err), nil
 	}
 
+	if a.GetNamespace() == "default" {
+		return authorizer.DecisionDeny, "use `stack-${id}` for the namespace", nil
+	}
+
 	info, err := grafanarequest.ParseNamespace(a.GetNamespace())
 	if err != nil {
 		return authorizer.DecisionDeny, fmt.Sprintf("error reading namespace: %v", err), nil


### PR DESCRIPTION
The current authz code will allow "default",  we should force using the stack-id flavor