### PR TITLE
Correlations: Only show original field list in transformation field list

### DIFF
--- a/public/app/features/explore/CorrelationHelper.tsx
+++ b/public/app/features/explore/CorrelationHelper.tsx
@@ -150,7 +150,7 @@ export const CorrelationHelper = ({ exploreId, correlations }: Props) => {
             }
             setShowTransformationAddModal(false);
           }}
-          fieldList={correlations.vars}
+          fieldList={correlations.origVars}
           transformationToEdit={
             transformationIdxToEdit !== undefined ? transformations[transformationIdxToEdit] : undefined
           }


### PR DESCRIPTION
**What is this feature?**

In the Explore editor's transformations modal, there is a list of fields. This should only populate with fields from the data, not any variables created by prior transformations

**Which issue(s) does this PR fix?**:

Fixes #78124

**Special notes for your reviewer:**

Replication steps

1. Test datasource, logs scenario. Create correlation
2. Add transformation, select message and logfmt
3. Add the transformation. Add another transformation
4. Newly added variables created with logfmt should not show up in field list.

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
