### PR TITLE
Prometheus: query builder, handle regex in parentheses for label filters value

### DIFF
--- a/public/app/plugins/datasource/prometheus/querybuilder/components/LabelFilterItem.tsx
+++ b/public/app/plugins/datasource/prometheus/querybuilder/components/LabelFilterItem.tsx
@@ -52,9 +52,17 @@ export function LabelFilterItem({
 
   const getSelectOptionsFromString = (item?: string): string[] => {
     if (item) {
+      const regExp = /\(([^)]+)\)/;
+      const matches = item?.match(regExp);
+
+      if (matches && matches[0].indexOf('|') > 0) {
+        return [item];
+      }
+
       if (item.indexOf('|') > 0) {
         return item.split('|');
       }
+
       return [item];
     }
     return [];

--- a/public/app/plugins/datasource/prometheus/querybuilder/components/LabelFilters.test.tsx
+++ b/public/app/plugins/datasource/prometheus/querybuilder/components/LabelFilters.test.tsx
@@ -90,6 +90,18 @@ describe('LabelFilters', () => {
     expect(getAddButton()).toBeInTheDocument();
   });
 
+  it('does split regex in the middle of a label value when the value contains the char |', () => {
+    setup({ labelsFilters: [{ label: 'foo', op: '=~', value: 'boop|par' }] });
+
+    expect(screen.getByText('boop')).toBeInTheDocument();
+    expect(screen.getByText('par')).toBeInTheDocument();
+  });
+  it('does not split regex in between parentheses inside of a label value that contains the char |', () => {
+    setup({ labelsFilters: [{ label: 'foo', op: '=~', value: '(b|p)ar' }] });
+
+    expect(screen.getByText('(b|p)ar')).toBeInTheDocument();
+  });
+
   it('shows error when filter with empty strings  and label filter is required', async () => {
     setup({ labelsFilters: [{ label: '', op: '=', value: '' }], labelFilterRequired: true });
     expect(screen.getByText(MISSING_LABEL_FILTER_ERROR_MESSAGE)).toBeInTheDocument();


### PR DESCRIPTION
Fixes https://github.com/grafana/support-escalations/issues/8328

When a label filter value in the query builder has a `|` character, the value is split into two select options for the multiselect. This breaks when using regex in the middle of a label value inside of parentheses, i.e. `(2|4)00` will split break.
<img width="491" alt="Screenshot 2023-11-15 at 3 41 10 PM" src="https://github.com/grafana/grafana/assets/25674746/2647d95f-118e-479a-9933-5cce1ffcd74a">


This is a fix for that.
<img width="490" alt="Screenshot 2023-11-15 at 3 40 48 PM" src="https://github.com/grafana/grafana/assets/25674746/1b46a0ed-9566-4ae2-a2d9-2edbaf163366">

Please check that:
- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
