### PR TITLE
fix: `label_values` w/ empty filters in prom datasource variable query

### DIFF
--- a/public/app/plugins/datasource/prometheus/metric_find_query.test.ts
+++ b/public/app/plugins/datasource/prometheus/metric_find_query.test.ts
@@ -107,9 +107,10 @@ describe('PrometheusMetricFindQuery', () => {
     const emptyFilters = ['{}', '{   }', ' {   }  ', '   {}  '];
 
     emptyFilters.forEach((emptyFilter) => {
-      it(`Empty filter, label_values(${emptyFilter}, resource), should just generate label search query`, async () => {
+      const queryString = `label_values(${emptyFilter}, resource)`;
+      it(`Empty filter, query, ${queryString} should just generate label search query`, async () => {
         const query = setupMetricFindQuery({
-          query: 'label_values({}, resource)',
+          query: queryString,
           response: {
             data: ['value1', 'value2', 'value3'],
           },

--- a/public/app/plugins/datasource/prometheus/metric_find_query.test.ts
+++ b/public/app/plugins/datasource/prometheus/metric_find_query.test.ts
@@ -104,6 +104,29 @@ describe('PrometheusMetricFindQuery', () => {
       });
     });
 
+    const emptyFilters = ['{}', '{   }', ' {   }  ', '   {}  '];
+
+    emptyFilters.forEach((emptyFilter) => {
+      it(`Empty filter, label_values(${emptyFilter}, resource), should just generate label search query`, async () => {
+        const query = setupMetricFindQuery({
+          query: 'label_values({}, resource)',
+          response: {
+            data: ['value1', 'value2', 'value3'],
+          },
+        });
+        const results = await query.process(raw);
+
+        expect(results).toHaveLength(3);
+        expect(fetchMock).toHaveBeenCalledTimes(1);
+        expect(fetchMock).toHaveBeenCalledWith({
+          method: 'GET',
+          url: `/api/datasources/uid/ABCDEF/resources/api/v1/label/resource/values?start=${raw.from.unix()}&end=${raw.to.unix()}`,
+          hideFromInspector: true,
+          headers: {},
+        });
+      });
+    });
+
     // <LegacyPrometheus>
     it('label_values(metric, resource) should generate series query with correct time', async () => {
       const query = setupMetricFindQuery({

--- a/public/app/plugins/datasource/prometheus/metric_find_query.ts
+++ b/public/app/plugins/datasource/prometheus/metric_find_query.ts
@@ -48,11 +48,13 @@ export default class PrometheusMetricFindQuery {
 
     const labelValuesQuery = this.query.match(labelValuesRegex);
     if (labelValuesQuery) {
-      const hasEmptyFilter = () => labelValuesQuery[1].split(' ').join('') === '{}';
-      if (labelValuesQuery[1] && !hasEmptyFilter()) {
-        return this.labelValuesQuery(labelValuesQuery[2], labelValuesQuery[1]);
+      const filter = labelValuesQuery[1];
+      const label = labelValuesQuery[2];
+      if (isFilterDefined(filter)) {
+        return this.labelValuesQuery(label, filter);
       } else {
-        return this.labelValuesQuery(labelValuesQuery[2]);
+        // Exclude the filter part of the expression because it is blank or empty
+        return this.labelValuesQuery(label);
       }
     }
 
@@ -192,4 +194,9 @@ export default class PrometheusMetricFindQuery {
       });
     });
   }
+}
+
+function isFilterDefined(filter: string) {
+  // We consider blank strings or the empty filter {} as an undefined filter
+  return filter && filter.split(' ').join('') !== '{}';
 }

--- a/public/app/plugins/datasource/prometheus/metric_find_query.ts
+++ b/public/app/plugins/datasource/prometheus/metric_find_query.ts
@@ -48,7 +48,8 @@ export default class PrometheusMetricFindQuery {
 
     const labelValuesQuery = this.query.match(labelValuesRegex);
     if (labelValuesQuery) {
-      if (labelValuesQuery[1]) {
+      const hasEmptyFilter = () => labelValuesQuery[1].split(' ').join('') === '{}';
+      if (labelValuesQuery[1] && !hasEmptyFilter()) {
         return this.labelValuesQuery(labelValuesQuery[2], labelValuesQuery[1]);
       } else {
         return this.labelValuesQuery(labelValuesQuery[2]);


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**



When constructing queries for variable queries using scenes, and you want to use something similar to an adhoc filter for the `label_values`, there is a chance that the ad hoc filter might be empty, being represented by `{}`.

This fix allows the prometheus datasource to handle empty filters by behaving as if no filters have been chosen instead of encountering a backend query error.

**Why do we need this feature?**

This allows data trails to provide label names before an explicit filter has been set.

**Who is this feature for?**

Users of data trails.

**Which issue(s) does this PR fix?**:

- Fixes #78186

BEFORE:
![image](https://github.com/grafana/grafana/assets/38694490/ba7f2512-5ae4-456d-9f59-009e6f0766df)

AFTER:
![image](https://github.com/grafana/grafana/assets/38694490/45b628bf-27a2-40a0-8638-f18d12866208)

This approach won't solve all cases and is currently prioritized to work with scenes, as is done through the data-trails prototype. Currently, if you attempt to use an ad-hoc filter in a normal dashboard, the interpolated query on this line:

See:
- https://github.com/grafana/grafana/blob/a3827333514de8c198f2ac842ecdf3e4d5c6418c/public/app/plugins/datasource/prometheus/variables.ts#L52
will still end up with `label_values(,__name__)` for `label_values(${filter},__name__}` which will not be detected by the enhancements to `PrometheusMetricFindQuery` in this PR. Further, even if the ad hoc filter does have selections, they are not currently being represented in the interpolation of `${filter}`. So more work will be required for this to work generally in dashboards.


<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->


**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
  - Start Grafana via `GF_FEATURE_TOGGLES_ENABLE=datatrails make run`
  - Before this PR, `http://localhost:3000/data-trails/trail?var-ds=gdev-prometheus` would result in an empty trail due to a query error (empty filter
  - With this PR, the trail is populated with a set of initial labels
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
  - [ ] I will need some feedback to evaluate if we want to update the docs and make a note
- [ ] Are there other spots where we might want to ensure similar behavior is set up?

