### PR TITLE
Plugins: Support markdown in custom plugin deprecation messages

### DIFF
--- a/public/app/features/plugins/admin/components/PluginDetailsDeprecatedWarning.tsx
+++ b/public/app/features/plugins/admin/components/PluginDetailsDeprecatedWarning.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
 
+import { renderMarkdown } from '@grafana/data';
 import { Alert } from '@grafana/ui';
 
 import { CatalogPlugin } from '../types';
@@ -16,13 +17,19 @@ export function PluginDetailsDeprecatedWarning(props: Props): React.ReactElement
   let deprecationMessage = `This ${plugin.type} plugin is deprecated and has been removed from the catalog. No further updates will be made to the
   plugin.`;
 
-  if (plugin.details?.statusContext) {
-    deprecationMessage += ` More information: ${plugin.details.statusContext}`;
-  }
-
   return isWarningVisible ? (
     <Alert severity="warning" title="Deprecated" className={className} onRemove={() => setDismissed(true)}>
       <p>{deprecationMessage}</p>
+
+      {/* Additional contextual deprecation message supporting markdown */}
+      {plugin.details?.statusContext && (
+        <p
+          className="markdown-html"
+          dangerouslySetInnerHTML={{
+            __html: renderMarkdown(plugin.details.statusContext),
+          }}
+        />
+      )}
     </Alert>
   ) : null;
 }

--- a/public/app/features/plugins/admin/components/PluginDetailsDeprecatedWarning.tsx
+++ b/public/app/features/plugins/admin/components/PluginDetailsDeprecatedWarning.tsx
@@ -23,7 +23,7 @@ export function PluginDetailsDeprecatedWarning(props: Props): React.ReactElement
 
       {/* Additional contextual deprecation message supporting markdown */}
       {plugin.details?.statusContext && (
-        <p
+        <div
           className="markdown-html"
           dangerouslySetInnerHTML={{
             __html: renderMarkdown(plugin.details.statusContext),

--- a/public/app/features/plugins/admin/components/PluginDetailsDeprecatedWarning.tsx
+++ b/public/app/features/plugins/admin/components/PluginDetailsDeprecatedWarning.tsx
@@ -14,12 +14,21 @@ export function PluginDetailsDeprecatedWarning(props: Props): React.ReactElement
   const { className, plugin } = props;
   const [dismissed, setDismissed] = useState(false);
   const isWarningVisible = plugin.isDeprecated && !dismissed;
-  let deprecationMessage = `This ${plugin.type} plugin is deprecated and has been removed from the catalog. No further updates will be made to the
-  plugin.`;
 
   return isWarningVisible ? (
     <Alert severity="warning" title="Deprecated" className={className} onRemove={() => setDismissed(true)}>
-      <p>{deprecationMessage}</p>
+      <p>
+        This {plugin.type} plugin is{' '}
+        <a
+          className="external-link"
+          href="https://grafana.com/legal/plugin-deprecation/"
+          rel="noreferrer"
+          target="_blank"
+        >
+          deprecated
+        </a>{' '}
+        and has been removed from the catalog.
+      </p>
 
       {/* Additional contextual deprecation message supporting markdown */}
       {plugin.details?.statusContext && (

--- a/public/app/features/plugins/admin/pages/PluginDetails.test.tsx
+++ b/public/app/features/plugins/admin/pages/PluginDetails.test.tsx
@@ -768,8 +768,10 @@ describe('Plugin details page', () => {
     });
 
     it('should display a custom deprecation message if the plugin has it set', async () => {
+      const defaultMessage =
+        'This app plugin is deprecated and has been removed from the catalog. No further updates will be made to the plugin.';
       const statusContext = 'A detailed explanation of why this plugin is deprecated.';
-      const { queryByText } = renderPluginDetails({
+      const { findByText } = renderPluginDetails({
         id,
         isInstalled: true,
         isDeprecated: true,
@@ -779,9 +781,30 @@ describe('Plugin details page', () => {
         },
       });
 
-      const re = new RegExp(`No further updates will be made to the plugin. More information: ${statusContext}`, 'i');
+      expect(await findByText(defaultMessage)).toBeInTheDocument();
+      expect(await findByText(statusContext)).toBeInTheDocument();
+    });
 
-      await waitFor(() => expect(queryByText(re)).toBeInTheDocument());
+    it('should be possible to render markdown inside a custom deprecation message', async () => {
+      const defaultMessage =
+        'This app plugin is deprecated and has been removed from the catalog. No further updates will be made to the plugin.';
+      const statusContext =
+        '**This is a custom deprecation message.** [Link 1](https://grafana.com) <a href="https://grafana.com" target="_blank">Link 2</a>';
+      const { findByText, findByRole } = renderPluginDetails({
+        id,
+        isInstalled: true,
+        isDeprecated: true,
+        details: {
+          statusContext,
+          links: [],
+        },
+      });
+
+      expect(await findByText(defaultMessage)).toBeInTheDocument();
+      expect(await findByText('This is a custom deprecation message.')).toBeInTheDocument();
+      expect(await findByRole('link', { name: 'Link 1' })).toBeInTheDocument();
+      expect(await findByRole('link', { name: 'Link 2' })).toBeInTheDocument();
+      expect(await findByRole('link', { name: 'Link 2' })).toHaveAttribute('href', 'https://grafana.com');
     });
   });
 

--- a/public/app/features/plugins/admin/pages/PluginDetails.test.tsx
+++ b/public/app/features/plugins/admin/pages/PluginDetails.test.tsx
@@ -744,34 +744,28 @@ describe('Plugin details page', () => {
     });
 
     it('should display a deprecation warning if the plugin is deprecated', async () => {
-      const { queryByText } = renderPluginDetails({
+      const { findByRole } = renderPluginDetails({
         id,
         isInstalled: true,
         isDeprecated: true,
       });
 
-      await waitFor(() =>
-        expect(queryByText(/plugin is deprecated and has been removed from the catalog/i)).toBeInTheDocument()
-      );
+      expect(await findByRole('link', { name: 'deprecated' })).toBeInTheDocument();
     });
 
     it('should not display a deprecation warning in the plugin is not deprecated', async () => {
-      const { queryByText } = renderPluginDetails({
+      const { queryByRole } = renderPluginDetails({
         id,
         isInstalled: true,
         isDeprecated: false,
       });
 
-      await waitFor(() =>
-        expect(queryByText(/plugin is deprecated and has been removed from the catalog/i)).not.toBeInTheDocument()
-      );
+      await waitFor(() => expect(queryByRole('link', { name: 'deprecated' })).not.toBeInTheDocument());
     });
 
     it('should display a custom deprecation message if the plugin has it set', async () => {
-      const defaultMessage =
-        'This app plugin is deprecated and has been removed from the catalog. No further updates will be made to the plugin.';
       const statusContext = 'A detailed explanation of why this plugin is deprecated.';
-      const { findByText } = renderPluginDetails({
+      const { findByText, findByRole } = renderPluginDetails({
         id,
         isInstalled: true,
         isDeprecated: true,
@@ -781,13 +775,11 @@ describe('Plugin details page', () => {
         },
       });
 
-      expect(await findByText(defaultMessage)).toBeInTheDocument();
+      expect(await findByRole('link', { name: 'deprecated' })).toBeInTheDocument();
       expect(await findByText(statusContext)).toBeInTheDocument();
     });
 
     it('should be possible to render markdown inside a custom deprecation message', async () => {
-      const defaultMessage =
-        'This app plugin is deprecated and has been removed from the catalog. No further updates will be made to the plugin.';
       const statusContext =
         '**This is a custom deprecation message.** [Link 1](https://grafana.com) <a href="https://grafana.com" target="_blank">Link 2</a>';
       const { findByText, findByRole } = renderPluginDetails({
@@ -800,7 +792,7 @@ describe('Plugin details page', () => {
         },
       });
 
-      expect(await findByText(defaultMessage)).toBeInTheDocument();
+      expect(await findByRole('link', { name: 'deprecated' })).toBeInTheDocument();
       expect(await findByText('This is a custom deprecation message.')).toBeInTheDocument();
       expect(await findByRole('link', { name: 'Link 1' })).toBeInTheDocument();
       expect(await findByRole('link', { name: 'Link 2' })).toBeInTheDocument();


### PR DESCRIPTION
### What changed?
Even though it was already possible to display a custom message when a plugin got deprecated, now it is also possible to use markdown in the custom message, which can both make it easier to read and more helpful by allowing to contain links.


https://github.com/grafana/grafana/assets/9974811/117d346c-ce30-4359-81a4-ec50c26c15ad

Fixes https://github.com/grafana/grafana-com/issues/7631.