### PR TITLE
InfluxDB: Don't sort retention policies on the backend

### DIFF
--- a/pkg/tsdb/influxdb/influxql/response_parser_test.go
+++ b/pkg/tsdb/influxdb/influxql/response_parser_test.go
@@ -798,7 +798,7 @@ func TestResponseParser_Parse_RetentionPolicy(t *testing.T) {
 		query := models.Query{RefID: "metricFindQuery", RawQuery: "SHOW RETENTION POLICIES"}
 		policyFrame := data.NewFrame("",
 			data.NewField("Value", nil, []string{
-				"bar", "autogen", "5m_avg", "1m_avg",
+				"autogen", "bar", "5m_avg", "1m_avg",
 			}),
 		)
 


### PR DESCRIPTION
**What is this feature?**

This is bringing back the partial functionality that was reverted in this PR https://github.com/grafana/grafana/pull/78224

**Why do we need this feature?**

We don't need to sort retention policies on the backend so we don't need such logic

**Who is this feature for?**

InfluxDB Backend mode users

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
