### PR TITLE
Provisioning: orgs

### DIFF
--- a/docs/sources/administration/provisioning/index.md
+++ b/docs/sources/administration/provisioning/index.md
@@ -68,6 +68,40 @@ Currently we do not provide any scripts/manifests for configuring Grafana. Rathe
 | Jsonnet   | [https://github.com/grafana/grafonnet-lib/](https://github.com/grafana/grafonnet-lib/)                                          |
 | NixOS     | [services.grafana.provision module](https://github.com/NixOS/nixpkgs/blob/master/nixos/modules/services/monitoring/grafana.nix) |
 
+## Orgs
+
+{{% admonition type="note" %}}
+Available in Grafana v10.3 and higher.
+{{% /admonition %}}
+
+You can manage orgs in Grafana by adding YAML configuration files in the [`provisioning/orgs`]({{< relref "../../setup-grafana/configure-grafana#provisioning" >}}) directory.
+Each config file can contain a list of `orgs` to add or update during startup.
+
+The configuration file can also list orgs to automatically delete, called `deleteOrgs`.
+Grafana deletes the orgs listed in `deleteOrgs` _after_ adding or updating those in the `orgs` list.
+
+### Example org config file
+
+This example provisions two orgs:
+
+```yaml
+# Configuration file version
+apiVersion: 1
+
+orgs:
+  # <string> org name
+- name: Org One
+  # <string> initial admin login or email, mandatory
+  initialAdminLoginOrEmail: user1
+  # another org
+- name: Org Two
+  initialAdminLoginOrEmail: user2@example.org
+
+# List of orgs to delete from the database.
+deleteOrgs:
+- name: Existing Org
+```
+
 ## Data sources
 
 {{% admonition type="note" %}}

--- a/docs/sources/developers/http_api/admin.md
+++ b/docs/sources/developers/http_api/admin.md
@@ -648,6 +648,8 @@ Content-Type: application/json
 
 ## Reload provisioning configurations
 
+`POST /api/admin/provisioning/orgs/reload`
+
 `POST /api/admin/provisioning/dashboards/reload`
 
 `POST /api/admin/provisioning/datasources/reload`

--- a/pkg/api/accesscontrol.go
+++ b/pkg/api/accesscontrol.go
@@ -21,6 +21,7 @@ const (
 // API related scopes
 var (
 	ScopeProvisionersAll           = ac.Scope("provisioners", "*")
+	ScopeProvisionersOrgs          = ac.Scope("provisioners", "orgs")
 	ScopeProvisionersDashboards    = ac.Scope("provisioners", "dashboards")
 	ScopeProvisionersPlugins       = ac.Scope("provisioners", "plugins")
 	ScopeProvisionersDatasources   = ac.Scope("provisioners", "datasources")

--- a/pkg/api/admin_provisioning.go
+++ b/pkg/api/admin_provisioning.go
@@ -8,6 +8,29 @@ import (
 	contextmodel "github.com/grafana/grafana/pkg/services/contexthandler/model"
 )
 
+// swagger:route POST /admin/provisioning/orgs/reload admin_provisioning adminProvisioningReloadOrgs
+//
+// Reload org provisioning configurations.
+//
+// Reloads the provisioning config files for orgs again. It won’t return until the new provisioned entities are already stored in the database. In case of dashboards, it will stop polling for changes in dashboard files and then restart it with new configurations after returning.
+// If you are running Grafana Enterprise and have Fine-grained access control enabled, you need to have a permission with action `provisioning:reload` and scope `provisioners:orgs`.
+//
+// Security:
+// - basic:
+//
+// Responses:
+// 200: okResponse
+// 401: unauthorisedError
+// 403: forbiddenError
+// 500: internalServerError
+func (hs *HTTPServer) AdminProvisioningReloadOrgs(c *contextmodel.ReqContext) response.Response {
+	err := hs.ProvisioningService.ProvisionOrgs(c.Req.Context())
+	if err != nil && !errors.Is(err, context.Canceled) {
+		return response.Error(500, "", err)
+	}
+	return response.Success("Orgs config reloaded")
+}
+
 // swagger:route POST /admin/provisioning/dashboards/reload admin_provisioning adminProvisioningReloadDashboards
 //
 // Reload dashboard provisioning configurations.

--- a/pkg/api/admin_provisioning_test.go
+++ b/pkg/api/admin_provisioning_test.go
@@ -26,6 +26,52 @@ func TestAPI_AdminProvisioningReload_AccessControl(t *testing.T) {
 	}
 	tests := []testCase{
 		{
+			desc:         "should work for orgs with specific scope",
+			expectedCode: http.StatusOK,
+			expectedBody: `{"message":"Orgs config reloaded"}`,
+			permissions: []accesscontrol.Permission{
+				{
+					Action: ActionProvisioningReload,
+					Scope:  ScopeProvisionersOrgs,
+				},
+			},
+			url: "/api/admin/provisioning/orgs/reload",
+			checkCall: func(mock provisioning.ProvisioningServiceMock) {
+				assert.Len(t, mock.Calls.ProvisionOrgs, 1)
+			},
+		},
+		{
+			desc:         "should work for orgs with broader scope",
+			expectedCode: http.StatusOK,
+			expectedBody: `{"message":"Orgs config reloaded"}`,
+			permissions: []accesscontrol.Permission{
+				{
+					Action: ActionProvisioningReload,
+					Scope:  ScopeProvisionersAll,
+				},
+			},
+			url: "/api/admin/provisioning/orgs/reload",
+			checkCall: func(mock provisioning.ProvisioningServiceMock) {
+				assert.Len(t, mock.Calls.ProvisionOrgs, 1)
+			},
+		},
+		{
+			desc:         "should fail for orgs with wrong scope",
+			expectedCode: http.StatusForbidden,
+			permissions: []accesscontrol.Permission{
+				{
+					Action: ActionProvisioningReload,
+					Scope:  "services:noservice",
+				},
+			},
+			url: "/api/admin/provisioning/orgs/reload",
+		},
+		{
+			desc:         "should fail for orgs with no permission",
+			expectedCode: http.StatusForbidden,
+			url:          "/api/admin/provisioning/orgs/reload",
+		},
+		{
 			desc:         "should work for dashboards with specific scope",
 			expectedCode: http.StatusOK,
 			expectedBody: `{"message":"Dashboards config reloaded"}`,

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -588,6 +588,7 @@ func (hs *HTTPServer) registerRoutes() {
 		adminRoute.Post("/encryption/migrate-secrets/from-plugin", reqGrafanaAdmin, routing.Wrap(hs.AdminMigrateSecretsFromPlugin))
 		adminRoute.Post("/encryption/delete-secretsmanagerplugin-secrets", reqGrafanaAdmin, routing.Wrap(hs.AdminDeleteAllSecretsManagerPluginSecrets))
 
+		adminRoute.Post("/provisioning/orgs/reload", authorize(ac.EvalPermission(ActionProvisioningReload, ScopeProvisionersOrgs)), routing.Wrap(hs.AdminProvisioningReloadOrgs))
 		adminRoute.Post("/provisioning/dashboards/reload", authorize(ac.EvalPermission(ActionProvisioningReload, ScopeProvisionersDashboards)), routing.Wrap(hs.AdminProvisioningReloadDashboards))
 		adminRoute.Post("/provisioning/plugins/reload", authorize(ac.EvalPermission(ActionProvisioningReload, ScopeProvisionersPlugins)), routing.Wrap(hs.AdminProvisioningReloadPlugins))
 		adminRoute.Post("/provisioning/datasources/reload", authorize(ac.EvalPermission(ActionProvisioningReload, ScopeProvisionersDatasources)), routing.Wrap(hs.AdminProvisioningReloadDatasources))

--- a/pkg/services/provisioning/orgs/config_reader.go
+++ b/pkg/services/provisioning/orgs/config_reader.go
@@ -1,0 +1,101 @@
+package orgs
+
+import (
+	"context"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/grafana/grafana/pkg/infra/log"
+	"gopkg.in/yaml.v2"
+)
+
+type configReader interface {
+	readConfig(ctx context.Context, path string) ([]*orgFile, error)
+}
+
+type configReaderImpl struct {
+	log log.Logger
+}
+
+func newConfigReader(logger log.Logger) configReader {
+	return &configReaderImpl{log: logger}
+}
+
+func (cr *configReaderImpl) readConfig(ctx context.Context, path string) ([]*orgFile, error) {
+	var orgFiles []*orgFile
+
+	files, err := os.ReadDir(path)
+	if err != nil {
+		cr.log.Error("can't read org provisioning files from directory", "path", path, "error", err)
+		return orgFiles, nil
+	}
+
+	for _, file := range files {
+		if strings.HasSuffix(file.Name(), ".yaml") || strings.HasSuffix(file.Name(), ".yml") {
+			org, err := cr.parseOrgConfig(path, file)
+			if err != nil {
+				return nil, err
+			}
+
+			if org != nil {
+				orgFiles = append(orgFiles, org)
+			}
+		}
+	}
+
+	if err := validateRequiredField(orgFiles); err != nil {
+		return nil, err
+	}
+
+	return orgFiles, nil
+}
+
+func (cr *configReaderImpl) parseOrgConfig(path string, file fs.DirEntry) (*orgFile, error) {
+	filename, _ := filepath.Abs(filepath.Join(path, file.Name()))
+
+	// nolint:gosec
+	// We can ignore the gosec G304 warning on this one because `filename` comes from ps.Cfg.ProvisioningPath
+	yamlFile, err := os.ReadFile(filename)
+	if err != nil {
+		return nil, err
+	}
+
+	var cfg *orgFileV1
+	err = yaml.Unmarshal(yamlFile, &cfg)
+	if err != nil {
+		return nil, err
+	}
+
+	r := cfg.mapToModel()
+
+	return &r, nil
+}
+
+func validateRequiredField(orgFiles []*orgFile) error {
+	for i := range orgFiles {
+		var errStrings []string
+		for index, createOrg := range orgFiles[i].CreateOrgs {
+			if createOrg.Name == "" {
+				errStrings = append(
+					errStrings,
+					fmt.Sprintf("org item %d in configuration doesn't contain required field name", index+1),
+				)
+			}
+			if createOrg.InitialAdminLoginOrEmail == "" {
+				errStrings = append(
+					errStrings,
+					fmt.Sprintf("org item %d in configuration doesn't contain required field initialAdminLoginOrEmail", index+1),
+				)
+			}
+		}
+
+		if len(errStrings) != 0 {
+			return fmt.Errorf(strings.Join(errStrings, "\n"))
+		}
+	}
+
+	return nil
+}

--- a/pkg/services/provisioning/orgs/config_reader_test.go
+++ b/pkg/services/provisioning/orgs/config_reader_test.go
@@ -1,0 +1,57 @@
+package orgs
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/grafana/pkg/infra/log"
+)
+
+const (
+	incorrectSettings = "./testdata/test-configs/incorrect-settings"
+	brokenYaml        = "./testdata/test-configs/broken-yaml"
+	emptyFolder       = "./testdata/test-configs/empty_folder"
+	correctProperties = "./testdata/test-configs/correct-properties"
+)
+
+func TestConfigReader(t *testing.T) {
+	t.Run("Broken yaml should return error", func(t *testing.T) {
+		reader := newConfigReader(log.New("test logger"))
+		_, err := reader.readConfig(context.Background(), brokenYaml)
+		require.Error(t, err)
+	})
+
+	t.Run("Skip invalid directory", func(t *testing.T) {
+		cfgProvider := newConfigReader(log.New("test logger"))
+		cfg, err := cfgProvider.readConfig(context.Background(), emptyFolder)
+		require.NoError(t, err)
+		require.Len(t, cfg, 0)
+	})
+
+	t.Run("Read incorrect properties", func(t *testing.T) {
+		cfgProvider := newConfigReader(log.New("test logger"))
+		_, err := cfgProvider.readConfig(context.Background(), incorrectSettings)
+		require.Error(t, err)
+		require.Equal(t, "org item 1 in configuration doesn't contain required field name", err.Error())
+	})
+
+	t.Run("Can read correct properties", func(t *testing.T) {
+		t.Setenv("ENABLE_PLUGIN_VAR", "test-plugin")
+
+		cfgProvider := newConfigReader(log.New("test logger"))
+		cfg, err := cfgProvider.readConfig(context.Background(), correctProperties)
+		require.NoError(t, err)
+		require.Len(t, cfg, 1)
+
+		require.Len(t, cfg[0].CreateOrgs, 2)
+		require.Len(t, cfg[0].DeleteOrgs, 1)
+
+		require.Equal(t, "Org One", cfg[0].CreateOrgs[0].Name)
+		require.Equal(t, "user1", cfg[0].CreateOrgs[0].InitialAdminLoginOrEmail)
+		require.Equal(t, "Org Two", cfg[0].CreateOrgs[1].Name)
+		require.Equal(t, "user2@example.org", cfg[0].CreateOrgs[0].InitialAdminLoginOrEmail)
+		require.Equal(t, "Existing Org", cfg[0].DeleteOrgs[0].Name)
+	})
+}

--- a/pkg/services/provisioning/orgs/org_provisioner.go
+++ b/pkg/services/provisioning/orgs/org_provisioner.go
@@ -1,0 +1,96 @@
+package orgs
+
+import (
+	"context"
+
+	"github.com/grafana/grafana/pkg/infra/log"
+	"github.com/grafana/grafana/pkg/services/org"
+	"github.com/grafana/grafana/pkg/services/user"
+)
+
+// Provision scans a directory for provisioning config files
+// and provisions the orgs in those files.
+func Provision(ctx context.Context, configDirectory string, orgService org.Service) error {
+	logger := log.New("provisioning.orgs")
+	op := OrgProvisioner{
+		log:         logger,
+		cfgProvider: newConfigReader(logger),
+		orgService:  orgService,
+	}
+	return op.applyChanges(ctx, configDirectory)
+}
+
+// OrgProvisioner is responsible for provisioning orgs based on
+// configuration read by the `configReader`
+type OrgProvisioner struct {
+	log         log.Logger
+	cfgProvider configReader
+	orgService  org.Service
+	userService user.Service
+}
+
+func (op *OrgProvisioner) applyChanges(ctx context.Context, configPath string) error {
+	configs, err := op.cfgProvider.readConfig(ctx, configPath)
+	if err != nil {
+		return err
+	}
+
+	for _, cfg := range configs {
+		if err := op.apply(ctx, cfg); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (op *OrgProvisioner) apply(ctx context.Context, cfg *orgFile) error {
+	for _, createOrg := range cfg.CreateOrgs {
+		_, err := op.orgService.GetByName(ctx, &org.GetOrgByNameQuery{
+			Name: createOrg.Name,
+		})
+
+		if err == nil {
+			// org already exists
+			continue
+		}
+
+		existingUser, err := op.userService.GetByLogin(ctx, &user.GetUserByLoginQuery{
+			LoginOrEmail: createOrg.InitialAdminLoginOrEmail,
+		})
+
+		if err != nil {
+			op.log.Warn("user not found when creating org ", "name", createOrg.Name, "initialAdminLoginOrEmail", createOrg.InitialAdminLoginOrEmail)
+			continue
+		}
+
+		op.log.Info("creating org from configuration ", "name", createOrg.Name)
+		_, err = op.orgService.CreateWithMember(ctx, &org.CreateOrgCommand{
+			Name:   createOrg.Name,
+			UserID: existingUser.ID,
+		})
+		if err != nil {
+			return err
+		}
+	}
+	for _, deleteOrg := range cfg.DeleteOrgs {
+		existingOrg, err := op.orgService.GetByName(ctx, &org.GetOrgByNameQuery{
+			Name: deleteOrg.Name,
+		})
+
+		if err != nil {
+			// ignore not existing org or other errors
+			continue
+		}
+
+		op.log.Info("deleting org from configuration ", "name", deleteOrg.Name)
+		err = op.orgService.Delete(ctx, &org.DeleteOrgCommand{
+			ID: existingOrg.ID,
+		})
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}

--- a/pkg/services/provisioning/orgs/org_provisioner_test.go
+++ b/pkg/services/provisioning/orgs/org_provisioner_test.go
@@ -1,0 +1,121 @@
+package orgs
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/grafana/grafana/pkg/infra/db"
+	"github.com/grafana/grafana/pkg/infra/log"
+	"github.com/grafana/grafana/pkg/services/org"
+	"github.com/grafana/grafana/pkg/services/org/orgimpl"
+	"github.com/grafana/grafana/pkg/services/quota/quotaimpl"
+	"github.com/grafana/grafana/pkg/services/quota/quotatest"
+	"github.com/grafana/grafana/pkg/services/sqlstore"
+	"github.com/grafana/grafana/pkg/services/supportbundles/supportbundlestest"
+	"github.com/grafana/grafana/pkg/services/user"
+	"github.com/grafana/grafana/pkg/services/user/userimpl"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNotificationAsConfig(t *testing.T) {
+	var sqlStore *sqlstore.SQLStore
+	var orgService org.Service
+	var userService user.Service
+	ctx := context.TODO()
+	logger := log.New("fake.log")
+
+	t.Run("Testing notification as configuration", func(t *testing.T) {
+		setup := func() {
+			var err error
+			sqlStore = db.InitTestDB(t)
+			orgService, err = orgimpl.ProvideService(sqlStore, sqlStore.Cfg, quotatest.New(false, nil))
+			require.NoError(t, err)
+
+			quotaService := quotaimpl.ProvideService(sqlStore, sqlStore.Cfg)
+
+			userService, err = userimpl.ProvideService(sqlStore, orgService, sqlStore.Cfg, nil, nil, quotaService, supportbundlestest.NewFakeBundleService())
+			require.NoError(t, err)
+
+			for i := 1; i <= 3; i++ {
+				createdUser, err := userService.Create(ctx, &user.CreateUserCommand{
+					Login:        fmt.Sprintf("user%v", i),
+					SkipOrgSetup: true,
+				})
+				require.NoError(t, err)
+
+				_, err = orgService.CreateWithMember(context.Background(), &org.CreateOrgCommand{Name: fmt.Sprintf("Org %v", i), UserID: createdUser.ID})
+				require.NoError(t, err)
+			}
+		}
+
+		t.Run("Can read correct properties", func(t *testing.T) {
+			setup()
+
+			orgProvisioner := OrgProvisioner{
+				log: logger,
+				cfgProvider: testConfigReader{
+					orgFiles: []*orgFile{
+						{
+							CreateOrgs: []*orgFromConfig{{
+								Name:                     "Org 3",
+								InitialAdminLoginOrEmail: "user1",
+							}, {
+								Name:                     "Org New",
+								InitialAdminLoginOrEmail: "user1",
+							}},
+							DeleteOrgs: []*deleteOrgConfig{{Name: "Org 1"}},
+						},
+					},
+				},
+				orgService:  orgService,
+				userService: userService,
+			}
+
+			orgProvisioner.applyChanges(ctx, "")
+
+			orgDTOs, err := orgService.Search(ctx, &org.SearchOrgsQuery{})
+			require.NoError(t, err)
+			require.Equal(t, 3, len(orgDTOs))
+
+			// Org 1 deleted
+			_, err = orgService.GetByName(ctx, &org.GetOrgByNameQuery{Name: "Org 1"})
+			require.ErrorIs(t, err, org.ErrOrgNotFound)
+
+			// Org 2 kept
+			_, err = orgService.GetByName(ctx, &org.GetOrgByNameQuery{Name: "Org 2"})
+			require.NoError(t, err)
+
+			// Org 3 kept, user unchanged
+			org3, err := orgService.GetByName(ctx, &org.GetOrgByNameQuery{Name: "Org 3"})
+			require.NoError(t, err)
+			orgUserDTOs, err := orgService.GetOrgUsers(ctx, &org.GetOrgUsersQuery{
+				OrgID:                    org3.ID,
+				DontEnforceAccessControl: true,
+			})
+			require.NoError(t, err)
+			require.Equal(t, 1, len(orgUserDTOs))
+			require.Equal(t, "user3", orgUserDTOs[0].Login)
+
+			// Org New added
+			orgNew, err := orgService.GetByName(ctx, &org.GetOrgByNameQuery{Name: "Org New"})
+			require.NoError(t, err)
+			orgNewUserDTOs, err := orgService.GetOrgUsers(ctx, &org.GetOrgUsersQuery{
+				OrgID:                    orgNew.ID,
+				DontEnforceAccessControl: true,
+			})
+			require.NoError(t, err)
+			require.Equal(t, 1, len(orgNewUserDTOs))
+			require.Equal(t, "user1", orgNewUserDTOs[0].Login)
+		})
+	})
+}
+
+type testConfigReader struct {
+	orgFiles []*orgFile
+	err      error
+}
+
+func (cr testConfigReader) readConfig(ctx context.Context, path string) ([]*orgFile, error) {
+	return cr.orgFiles, cr.err
+}

--- a/pkg/services/provisioning/orgs/testdata/test-configs/broken-yaml/broken.yaml
+++ b/pkg/services/provisioning/orgs/testdata/test-configs/broken-yaml/broken.yaml
@@ -1,0 +1,3 @@
+orgs:
+  - name: something
+      foo: bar

--- a/pkg/services/provisioning/orgs/testdata/test-configs/broken-yaml/not.yaml.text
+++ b/pkg/services/provisioning/orgs/testdata/test-configs/broken-yaml/not.yaml.text
@@ -1,0 +1,6 @@
+#sfxzgnsxzcvnbzcvn
+cvbn
+cvbn
+c
+vbn
+cvbncvbn

--- a/pkg/services/provisioning/orgs/testdata/test-configs/correct-properties/correct-properties.yaml
+++ b/pkg/services/provisioning/orgs/testdata/test-configs/correct-properties/correct-properties.yaml
@@ -1,0 +1,10 @@
+apiVersion: 1
+
+orgs:
+- name: Org One
+  initialAdminLoginOrEmail: user1
+- name: Org Two
+  initialAdminLoginOrEmail: user2@example.org
+
+deleteOrgs:
+- name: Existing Org

--- a/pkg/services/provisioning/orgs/testdata/test-configs/empty_folder/.gitignore
+++ b/pkg/services/provisioning/orgs/testdata/test-configs/empty_folder/.gitignore
@@ -1,0 +1,4 @@
+# Ignore everything in this directory
+*
+# Except this file
+!.gitignore

--- a/pkg/services/provisioning/orgs/testdata/test-configs/incorrect-settings/incorrect-settings.yaml
+++ b/pkg/services/provisioning/orgs/testdata/test-configs/incorrect-settings/incorrect-settings.yaml
@@ -1,0 +1,2 @@
+orgs:
+  - planet: earth

--- a/pkg/services/provisioning/orgs/types.go
+++ b/pkg/services/provisioning/orgs/types.go
@@ -1,0 +1,61 @@
+package orgs
+
+import "github.com/grafana/grafana/pkg/services/provisioning/values"
+
+type configVersion struct {
+	APIVersion int64 `json:"apiVersion" yaml:"apiVersion"`
+}
+
+type orgFile struct {
+	configVersion
+
+	CreateOrgs []*orgFromConfig
+	DeleteOrgs []*deleteOrgConfig
+}
+
+type orgFromConfig struct {
+	Name                     string
+	InitialAdminLoginOrEmail string
+}
+
+type deleteOrgConfig struct {
+	Name string
+}
+
+type orgFileV1 struct {
+	configVersion
+
+	CreateOrgs []*orgFromConfigV1   `json:"orgs" yaml:"orgs"`
+	DeleteOrgs []*deleteOrgConfigV1 `json:"deleteOrgs" yaml:"deleteOrgs"`
+}
+
+type orgFromConfigV1 struct {
+	Name                     values.StringValue `json:"name" yaml:"name"`
+	InitialAdminLoginOrEmail values.StringValue `json:"initialAdminLoginOrEmail" yaml:"initialAdminLoginOrEmail"`
+}
+
+type deleteOrgConfigV1 struct {
+	Name values.StringValue `json:"name" yaml:"name"`
+}
+
+func (cfg *orgFileV1) mapToModel() orgFile {
+	r := orgFile{}
+	if cfg == nil {
+		return r
+	}
+
+	for _, createOrg := range cfg.CreateOrgs {
+		r.CreateOrgs = append(r.CreateOrgs, &orgFromConfig{
+			Name:                     createOrg.Name.Value(),
+			InitialAdminLoginOrEmail: createOrg.InitialAdminLoginOrEmail.Value(),
+		})
+	}
+
+	for _, deleteOrg := range cfg.DeleteOrgs {
+		r.DeleteOrgs = append(r.DeleteOrgs, &deleteOrgConfig{
+			Name: deleteOrg.Name.Value(),
+		})
+	}
+
+	return r
+}

--- a/pkg/services/provisioning/provisioning_mock.go
+++ b/pkg/services/provisioning/provisioning_mock.go
@@ -4,6 +4,7 @@ import "context"
 
 type Calls struct {
 	RunInitProvisioners                 []any
+	ProvisionOrgs                       []any
 	ProvisionDatasources                []any
 	ProvisionPlugins                    []any
 	ProvisionNotifications              []any
@@ -17,6 +18,7 @@ type Calls struct {
 type ProvisioningServiceMock struct {
 	Calls                                   *Calls
 	RunInitProvisionersFunc                 func(ctx context.Context) error
+	ProvisionOrgsFunc                       func(ctx context.Context) error
 	ProvisionDatasourcesFunc                func(ctx context.Context) error
 	ProvisionPluginsFunc                    func() error
 	ProvisionNotificationsFunc              func() error
@@ -36,6 +38,14 @@ func (mock *ProvisioningServiceMock) RunInitProvisioners(ctx context.Context) er
 	mock.Calls.RunInitProvisioners = append(mock.Calls.RunInitProvisioners, nil)
 	if mock.RunInitProvisionersFunc != nil {
 		return mock.RunInitProvisionersFunc(ctx)
+	}
+	return nil
+}
+
+func (mock *ProvisioningServiceMock) ProvisionOrgs(ctx context.Context) error {
+	mock.Calls.ProvisionOrgs = append(mock.Calls.ProvisionOrgs, nil)
+	if mock.ProvisionOrgsFunc != nil {
+		return mock.ProvisionOrgsFunc(ctx)
 	}
 	return nil
 }


### PR DESCRIPTION
**What is this feature?**

Add support for provisioning Orgs thru files.

**Why do we need this feature?**

We currently create several orgs, manually.

We want to automate this.

**Who is this feature for?**

Users with multiple Orgs wanting to create those with provisioning.

**Which issue(s) does this PR fix?**:

Fixes #

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle.
- [x] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
