### PR TITLE
QueryHistory: Improve test performance

### DIFF
--- a/public/app/features/explore/spec/helper/assert.ts
+++ b/public/app/features/explore/spec/helper/assert.ts
@@ -1,6 +1,6 @@
-import { waitFor, within } from '@testing-library/react';
+import { waitFor } from '@testing-library/react';
 
-import { withinExplore } from './setup';
+import { getAllByRoleInQueryHistoryTab, withinExplore } from './setup';
 
 export const assertQueryHistoryExists = async (query: string, exploreId = 'left') => {
   const selector = withinExplore(exploreId);
@@ -49,10 +49,7 @@ export const assertQueryHistoryComment = async (expectedQueryComments: string[],
 };
 
 export const assertQueryHistoryIsStarred = async (expectedStars: boolean[], exploreId = 'left') => {
-  const selector = withinExplore(exploreId);
-  // Test ID is used to avoid test timeouts reported in #70158, #59116 and #47635
-  const queriesContainer = selector.getByTestId('query-history-queries-tab');
-  const starButtons = within(queriesContainer).getAllByRole('button', { name: /Star query|Unstar query/ });
+  const starButtons = getAllByRoleInQueryHistoryTab(exploreId, 'button', /Star query|Unstar query/);
 
   await waitFor(() =>
     expectedStars.forEach((starred, queryIndex) => {

--- a/public/app/features/explore/spec/helper/interactions.ts
+++ b/public/app/features/explore/spec/helper/interactions.ts
@@ -3,7 +3,7 @@ import userEvent from '@testing-library/user-event';
 
 import { selectors } from '@grafana/e2e-selectors';
 
-import { withinExplore } from './setup';
+import { getAllByRoleInQueryHistoryTab, withinExplore } from './setup';
 
 export const changeDatasource = async (name: string) => {
   const datasourcePicker = (await screen.findByTestId(selectors.components.DataSourcePicker.container)).children[0];
@@ -74,8 +74,7 @@ export const loadMoreQueryHistory = async (exploreId = 'left') => {
   await userEvent.click(button);
 };
 
-const invokeAction = async (queryIndex: number, actionAccessibleName: string, exploreId: string) => {
-  const selector = withinExplore(exploreId);
-  const buttons = selector.getAllByRole('button', { name: actionAccessibleName });
+const invokeAction = async (queryIndex: number, actionAccessibleName: string | RegExp, exploreId: string) => {
+  const buttons = getAllByRoleInQueryHistoryTab(exploreId, 'button', actionAccessibleName);
   await userEvent.click(buttons[queryIndex]);
 };

--- a/public/app/features/explore/spec/helper/setup.tsx
+++ b/public/app/features/explore/spec/helper/setup.tsx
@@ -1,4 +1,4 @@
-import { waitFor, within } from '@testing-library/dom';
+import { ByRoleMatcher, waitFor, within } from '@testing-library/dom';
 import { render, screen } from '@testing-library/react';
 import { createMemoryHistory } from 'history';
 import { fromPairs } from 'lodash';
@@ -287,3 +287,13 @@ const exploreTestsHelper: { setupExplore: typeof setupExplore; tearDownExplore?:
     setupExplore,
     tearDownExplore: undefined,
   };
+
+/**
+ * Optimized version of getAllByRole to avoid timeouts in tests. Please check #70158, #59116 and #47635, #78236.
+ */
+export const getAllByRoleInQueryHistoryTab = (exploreId: string, role: ByRoleMatcher, name: string | RegExp) => {
+  const selector = withinExplore(exploreId);
+  // Test ID is used to avoid test timeouts reported in
+  const queriesContainer = selector.getByTestId('query-history-queries-tab');
+  return within(queriesContainer).getAllByRole(role, { name });
+};

--- a/public/app/features/explore/spec/queryHistory.test.tsx
+++ b/public/app/features/explore/spec/queryHistory.test.tsx
@@ -205,7 +205,6 @@ describe('Explore: Query History', () => {
     await waitForExplore();
     await openQueryHistory();
     await assertQueryHistory(['{"expr":"query #1"}'], 'left');
-
     await commentQueryHistory(0, 'test comment');
     await assertQueryHistoryComment(['test comment'], 'left');
   });


### PR DESCRIPTION
Fixes #78236 

Used the same approach as in https://github.com/grafana/grafana/pull/71190 with a slightly improved version of getAllByRole but applied to `invokeAction` which should improve all tests in the file.

Benchmarks: ([branch](https://drone.grafana.net/grafana/grafana/146672/1/1)) ([main](https://drone.grafana.net/grafana/grafana/146671/1/6))

Entire `Explore: Query History` (~10% faster)

|  | 1 | 2 | 3 | avg |
|--|--|--|--|---|
| main | 100.122 | 105.193 | 103.803 | **103.039** |
| branch | 92.924 | 91.973 | 96.004 | **93.637** |

`add comments to query history` (~32% faster)

|  | 1 | 2 | 3 | avg |
|--|--|--|--|---|
| main | 12.926 | 13.621 | 13.415 | **13.321** |
| branch | 10.001 | 9.856 | 10.292 | **10.050** |