### PR TITLE
Elasticsearch: Fix processing of raw_data with not-recognized time format

### DIFF
--- a/pkg/tsdb/elasticsearch/data_query.go
+++ b/pkg/tsdb/elasticsearch/data_query.go
@@ -97,7 +97,9 @@ func (e *elasticsearchDataQuery) processQuery(q *Query, ms *es.MultiSearchReques
 	if isLogsQuery(q) {
 		processLogsQuery(q, b, from, to, defaultTimeField)
 	} else if isDocumentQuery(q) {
-		processDocumentQuery(q, b, from, to, defaultTimeField)
+		// For raw data query, we want to add standardized time field so we are able to correctly parse it
+		shouldAddStandardizedTimeField := isRawDataQuery(q)
+		processDocumentQuery(q, b, from, to, defaultTimeField, shouldAddStandardizedTimeField)
 	} else {
 		// Otherwise, it is a time series query and we process it
 		processTimeSeriesQuery(q, b, from, to, defaultTimeField)
@@ -384,14 +386,16 @@ func processLogsQuery(q *Query, b *es.SearchRequestBuilder, from, to int64, defa
 	_ = addDateHistogramAgg(aggBuilder, bucketAgg, from, to, defaultTimeField)
 }
 
-func processDocumentQuery(q *Query, b *es.SearchRequestBuilder, from, to int64, defaultTimeField string) {
+func processDocumentQuery(q *Query, b *es.SearchRequestBuilder, from, to int64, defaultTimeField string, shouldAddStandardizedTimeField bool) {
 	metric := q.Metrics[0]
 	b.Sort(es.SortOrderDesc, defaultTimeField, "boolean")
 	b.Sort(es.SortOrderDesc, "_doc", "")
 	b.AddDocValueField(defaultTimeField)
-	// We need to add timeField as field with standardized time format to not receive
-	// invalid formats that elasticsearch can parse, but our frontend can't (e.g. yyyy_MM_dd_HH_mm_ss)
-	b.AddTimeFieldWithStandardizedFormat(defaultTimeField)
+	if shouldAddStandardizedTimeField {
+		// If shouldAddStandardizedTimeField = true, we add timeField as field with standardized time format
+		// to not receive invalid formats that elasticsearch can parse, but our frontend can't (e.g. yyyy_MM_dd_HH_mm_ss)
+		b.AddTimeFieldWithStandardizedFormat(defaultTimeField)
+	}
 	b.Size(stringToIntWithDefaultValue(metric.Settings.Get("size").MustString(), defaultSize))
 }
 

--- a/pkg/tsdb/elasticsearch/data_query.go
+++ b/pkg/tsdb/elasticsearch/data_query.go
@@ -389,6 +389,9 @@ func processDocumentQuery(q *Query, b *es.SearchRequestBuilder, from, to int64, 
 	b.Sort(es.SortOrderDesc, defaultTimeField, "boolean")
 	b.Sort(es.SortOrderDesc, "_doc", "")
 	b.AddDocValueField(defaultTimeField)
+	// We need to add timeField as field with standardized time format to not receive
+	// invalid formats that elasticsearch can parse, but our frontend can't (e.g. yyyy_MM_dd_HH_mm_ss)
+	b.AddTimeFieldWithStandardizedFormat(defaultTimeField)
 	b.Size(stringToIntWithDefaultValue(metric.Settings.Get("size").MustString(), defaultSize))
 }
 

--- a/pkg/tsdb/elasticsearch/response_parser.go
+++ b/pkg/tsdb/elasticsearch/response_parser.go
@@ -231,6 +231,15 @@ func processRawDataResponse(res *es.SearchResponse, target *Query, configuredFie
 			doc[k] = v
 		}
 
+		if hit["fields"] != nil {
+			source, ok := hit["fields"].(map[string]interface{})
+			if ok {
+				for k, v := range source {
+					doc[k] = v
+				}
+			}
+		}
+
 		for key := range doc {
 			propNames[key] = true
 		}

--- a/pkg/tsdb/elasticsearch/response_parser_test.go
+++ b/pkg/tsdb/elasticsearch/response_parser_test.go
@@ -601,6 +601,92 @@ func TestProcessRawDataResponse(t *testing.T) {
 			require.Equal(t, filterableConfig, *field.Config)
 		}
 	})
+
+	t.Run("gets correct time field from fields", func(t *testing.T) {
+		query := []byte(`
+			[
+				{
+				  "refId": "A",
+				  "metrics": [{ "type": "raw_data", "id": "1" }]
+				}
+			]
+		`)
+
+		response := []byte(`
+			{
+				"responses": [
+				  {
+					"aggregations": {},
+					"hits": {
+					  "hits": [
+						{
+						  "_id": "fdsfs",
+						  "_type": "_doc",
+						  "_index": "mock-index",
+						  "_source": {
+							"testtime": "06/24/2019",
+							"host": "djisaodjsoad",
+							"number": 1,
+							"line": "hello, i am a message",
+							"level": "debug",
+							"fields": { "lvl": "debug" }
+						  },
+						  "highlight": {
+								"message": [
+							  	"@HIGHLIGHT@hello@/HIGHLIGHT@, i am a @HIGHLIGHT@message@/HIGHLIGHT@"
+								]
+						  },
+							"fields": {
+								"testtime": [ "2019-06-24T09:51:19.765Z" ]
+							}
+						},
+						{
+						  "_id": "kdospaidopa",
+						  "_type": "_doc",
+						  "_index": "mock-index",
+						  "_source": {
+							"testtime": "06/24/2019",
+							"host": "dsalkdakdop",
+							"number": 2,
+							"line": "hello, i am also message",
+							"level": "error",
+							"fields": { "lvl": "info" }
+						  },
+						  "highlight": {
+								"message": [
+							  	"@HIGHLIGHT@hello@/HIGHLIGHT@, i am a @HIGHLIGHT@message@/HIGHLIGHT@"
+								]
+						  },
+							"fields": {
+								"testtime": [ "2019-06-24T09:52:19.765Z" ]
+							}
+						}
+					  ]
+					}
+				  }
+				]
+			}
+			`)
+		result, err := queryDataTest(query, response)
+		require.NoError(t, err)
+
+		require.Len(t, result.response.Responses, 1)
+		frames := result.response.Responses["A"].Frames
+		require.Len(t, frames, 1)
+
+		logsFrame := frames[0]
+
+		logsFieldMap := make(map[string]*data.Field)
+		for _, field := range logsFrame.Fields {
+			logsFieldMap[field.Name] = field
+		}
+		t0 := time.Date(2019, time.June, 24, 9, 51, 19, 765000000, time.UTC)
+		t1 := time.Date(2019, time.June, 24, 9, 52, 19, 765000000, time.UTC)
+		require.Contains(t, logsFieldMap, "testtime")
+		require.Equal(t, data.FieldTypeNullableTime, logsFieldMap["testtime"].Type())
+		require.Equal(t, &t0, logsFieldMap["testtime"].At(0))
+		require.Equal(t, &t1, logsFieldMap["testtime"].At(1))
+	})
 }
 
 func TestProcessRawDocumentResponse(t *testing.T) {

--- a/pkg/tsdb/elasticsearch/testdata_request/raw_data.request.line1.json
+++ b/pkg/tsdb/elasticsearch/testdata_request/raw_data.request.line1.json
@@ -26,5 +26,12 @@
       "_doc": {
         "order": "desc"
       }
-    }
+    },
+  "fields": 
+    [ 
+      {
+        "field": "testtime",
+        "format": "strict_date_optional_time_nanos"
+      }
+    ]
 }


### PR DESCRIPTION
This is pretty much the same as https://github.com/grafana/grafana/pull/67767 where we fixed processing of `logs` queries with not-recognized time format. At that time, I did not realized that this is going to be an issue for `raw_data` queries as well. Therefore in this PR, we are fixing processing of unrecognized time formats for `raw_data` queries. For `raw_document` queries this is not needed as we are not parsing time field. 

**More detailed information:**
This is a bug fix for processing time field in ES on backend, when time field uses format that golang does not recognize (e.g. MM/DD/YYY, unix timestamp with nanoseconds decimal point, ...). To fix this for `raw_data` queries, we are using `fields` to get time field in `strict_date_optional_time_nanos` format that is recognizable by golang and also supports nanosecond precision.

**To test this:**

1. Run `make devenv sources=elastic`
2. Make sure that `enableElasticsearchBackendQuerying` is set to `true`
3. Create a new elastic data source pointing to `https://localhost:9200` and for time field add `@timestamp_custom`. 
4. Run `raw_data` query - you should not see `null` values in time column 
5. You can also switch to `@timestamp`, `@timestamp_unix`, `@timestamp_nanos` to ensure all formats work as expected.

Fixed: 

<img width="1903" alt="image" src="https://github.com/grafana/grafana/assets/30407135/759b457f-f560-46ff-9adb-504961ce09ed">

Current main (broken):

<img width="1877" alt="image" src="https://github.com/grafana/grafana/assets/30407135/e5ee4fc3-5282-40f8-a8c5-d51758cfbc27">


Fixes: https://github.com/grafana/grafana/issues/77114

 