### PR TITLE
Breadcrumbs: Only dedupe the lowest child node of `sectionNav`

### DIFF
--- a/public/app/core/components/Breadcrumbs/utils.test.ts
+++ b/public/app/core/components/Breadcrumbs/utils.test.ts
@@ -141,28 +141,5 @@ describe('breadcrumb utils', () => {
         { text: 'My page', href: '/my-page' },
       ]);
     });
-
-    it('does not ignore duplicates with different text', () => {
-      const pageNav: NavModelItem = {
-        text: 'My page',
-        url: '/my-page',
-        parentItem: {
-          text: 'Another section',
-          // same url as section nav, but this one should win/overwrite it
-          url: '/my-section?from=1h&to=now',
-        },
-      };
-
-      const sectionNav: NavModelItem = {
-        text: 'My section',
-        url: '/my-section',
-      };
-
-      expect(buildBreadcrumbs(sectionNav, pageNav, mockHomeNav)).toEqual([
-        { text: 'My section', href: '/my-section' },
-        { text: 'Another section', href: '/my-section?from=1h&to=now' },
-        { text: 'My page', href: '/my-page' },
-      ]);
-    });
   });
 });

--- a/public/app/core/components/Breadcrumbs/utils.ts
+++ b/public/app/core/components/Breadcrumbs/utils.ts
@@ -7,9 +7,8 @@ export function buildBreadcrumbs(sectionNav: NavModelItem, pageNav?: NavModelIte
   const crumbs: Breadcrumb[] = [];
   let foundHome = false;
   let lastPath: string | undefined = undefined;
-  let lastText: string | undefined = undefined;
 
-  function addCrumbs(node: NavModelItem) {
+  function addCrumbs(node: NavModelItem, shouldDedupe = false) {
     if (foundHome) {
       return;
     }
@@ -32,16 +31,14 @@ export function buildBreadcrumbs(sectionNav: NavModelItem, pageNav?: NavModelIte
       return;
     }
 
-    // This enabled app plugins to control breadcrumbs of their root pages
     const isSamePathAsLastBreadcrumb = urlToMatch.length > 0 && lastPath === urlToMatch;
-    const isSameTextAsLastBreadcrumb = node.text === lastText;
 
     // Remember this path for the next breadcrumb
     lastPath = urlToMatch;
-    lastText = node.text;
 
-    const shouldMergeBreadcrumb = isSamePathAsLastBreadcrumb && isSameTextAsLastBreadcrumb;
-    if (!node.hideFromBreadcrumbs && !shouldMergeBreadcrumb) {
+    const shouldAddCrumb = !node.hideFromBreadcrumbs && !(shouldDedupe && isSamePathAsLastBreadcrumb);
+
+    if (shouldAddCrumb) {
       crumbs.unshift({ text: node.text, href: node.url ?? '' });
     }
 
@@ -54,7 +51,8 @@ export function buildBreadcrumbs(sectionNav: NavModelItem, pageNav?: NavModelIte
     addCrumbs(pageNav);
   }
 
-  addCrumbs(sectionNav);
+  // shouldDedupe = true enables app plugins to control breadcrumbs of their root pages
+  addCrumbs(sectionNav, true);
 
   return crumbs;
 }


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

- only applies deduping logic to the lowest child of `SectionNav`
  - @torkelo i think this is the only node that app plugins want to dedupe? 🤔 could be wrong here tho

**Why do we need this feature?**

- prevent having the deduping logic everywhere. it's a bit of a bandaid so the smaller we can make that bandaid the better

**Who is this feature for?**

- everyone!

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

follow up to https://github.com/grafana/grafana/pull/78077

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
