### PR TITLE
Folders: Fix fetching empty folder

### DIFF
--- a/pkg/services/folder/folderimpl/dashboard_folder_store.go
+++ b/pkg/services/folder/folderimpl/dashboard_folder_store.go
@@ -88,6 +88,10 @@ func (d *DashboardFolderStoreImpl) GetFolderByUID(ctx context.Context, orgID int
 
 func (d *DashboardFolderStoreImpl) GetFolders(ctx context.Context, orgID int64, uids []string) (map[string]*folder.Folder, error) {
 	m := make(map[string]*folder.Folder, len(uids))
+	if len(uids) == 0 {
+		return m, nil
+	}
+
 	var folders []*folder.Folder
 	if err := d.store.WithDbSession(ctx, func(sess *db.Session) error {
 		b := strings.Builder{}


### PR DESCRIPTION
**What is this feature?**

This PR fixes performance issue when empty folder is expanded. If list of children is empty, then filter in query is also empty and query fetches all the dashboards from the DB.

**Why do we need this feature?**

It fixes weird slow performance on some folders on large instances.

**Who is this feature for?**

[Add information on what kind of user the feature is for.]

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
