### PR TITLE
Chore: Deprecate ID from Folder

### DIFF
--- a/pkg/api/dashboard_test.go
+++ b/pkg/api/dashboard_test.go
@@ -416,6 +416,7 @@ func TestDashboardAPIEndpoint(t *testing.T) {
 			// nolint:staticcheck
 			dashboardService.On("SaveDashboard", mock.Anything, mock.AnythingOfType("*dashboards.SaveDashboardDTO"), mock.AnythingOfType("bool")).
 				Return(&dashboards.Dashboard{ID: dashID, UID: "uid", Title: "Dash", Slug: "dash", Version: 2, FolderUID: folderUID, FolderID: folderID}, nil)
+			// nolint:staticcheck
 			mockFolderService := &foldertest.FakeService{
 				ExpectedFolder: &folder.Folder{ID: 1, UID: folderUID, Title: "Folder"},
 			}
@@ -452,6 +453,7 @@ func TestDashboardAPIEndpoint(t *testing.T) {
 			dashboardService.On("SaveDashboard", mock.Anything, mock.AnythingOfType("*dashboards.SaveDashboardDTO"), mock.AnythingOfType("bool")).
 				Return(&dashboards.Dashboard{ID: dashID, UID: "uid", Title: "Dash", Slug: "dash", Version: 2}, nil)
 
+			// nolint:staticcheck
 			mockFolder := &foldertest.FakeService{
 				ExpectedFolder: &folder.Folder{ID: 1, UID: "folderUID", Title: "Folder"},
 			}

--- a/pkg/api/folder.go
+++ b/pkg/api/folder.go
@@ -62,7 +62,7 @@ func (hs *HTTPServer) GetFolders(c *contextmodel.ReqContext) response.Response {
 	result := make([]dtos.FolderSearchHit, 0)
 	for _, f := range folders {
 		result = append(result, dtos.FolderSearchHit{
-			Id:        f.ID,
+			Id:        f.ID, // nolint:staticcheck
 			Uid:       f.UID,
 			Title:     f.Title,
 			ParentUID: f.ParentUID,
@@ -462,7 +462,7 @@ func (hs *HTTPServer) searchFolders(c *contextmodel.ReqContext) ([]*folder.Folde
 
 	for _, hit := range hits {
 		folders = append(folders, &folder.Folder{
-			ID:    hit.ID,
+			ID:    hit.ID, // nolint:staticcheck
 			UID:   hit.UID,
 			Title: hit.Title,
 		})

--- a/pkg/api/folder_permission.go
+++ b/pkg/api/folder_permission.go
@@ -94,7 +94,7 @@ func (hs *HTTPServer) UpdateFolderPermissions(c *contextmodel.ReqContext) respon
 	for _, item := range apiCmd.Items {
 		items = append(items, &dashboards.DashboardACL{
 			OrgID:       c.SignedInUser.GetOrgID(),
-			DashboardID: folder.ID,
+			DashboardID: folder.ID, // nolint:staticcheck
 			UserID:      item.UserID,
 			TeamID:      item.TeamID,
 			Role:        item.Role,
@@ -146,7 +146,7 @@ func (hs *HTTPServer) getFolderACL(ctx context.Context, user identity.Requester,
 
 		acl = append(acl, &dashboards.DashboardACLInfoDTO{
 			OrgID:          folder.OrgID,
-			DashboardID:    folder.ID,
+			DashboardID:    folder.ID, // nolint:staticcheck
 			FolderUID:      folder.ParentUID,
 			Created:        p.Created,
 			Updated:        p.Updated,

--- a/pkg/api/folder_permission_test.go
+++ b/pkg/api/folder_permission_test.go
@@ -30,6 +30,7 @@ func TestHTTPServer_GetFolderPermissionList(t *testing.T) {
 
 	t.Run("should be able to list acl with correct permission", func(t *testing.T) {
 		server := SetupAPITestServer(t, func(hs *HTTPServer) {
+			// nolint:staticcheck
 			hs.folderService = &foldertest.FakeService{ExpectedFolder: &folder.Folder{ID: 1, UID: "1"}}
 			hs.folderPermissionsService = &actest.FakePermissionsService{
 				ExpectedPermissions: []accesscontrol.ResourcePermission{},
@@ -50,6 +51,7 @@ func TestHTTPServer_GetFolderPermissionList(t *testing.T) {
 			cfg := setting.NewCfg()
 			cfg.HiddenUsers = map[string]struct{}{"hidden": {}}
 			hs.Cfg = cfg
+			// nolint:staticcheck
 			hs.folderService = &foldertest.FakeService{ExpectedFolder: &folder.Folder{ID: 1, UID: "1"}}
 
 			hs.folderPermissionsService = &actest.FakePermissionsService{
@@ -88,6 +90,7 @@ func TestHTTPServer_UpdateFolderPermissions(t *testing.T) {
 
 	t.Run("should be able to update acl with correct permissions", func(t *testing.T) {
 		server := SetupAPITestServer(t, func(hs *HTTPServer) {
+			// nolint:staticcheck
 			hs.folderService = &foldertest.FakeService{ExpectedFolder: &folder.Folder{ID: 1, UID: "1"}}
 			hs.folderPermissionsService = &actest.FakePermissionsService{}
 		})
@@ -104,6 +107,7 @@ func TestHTTPServer_UpdateFolderPermissions(t *testing.T) {
 
 	t.Run("should not be able to specify team and user in same acl", func(t *testing.T) {
 		server := SetupAPITestServer(t, func(hs *HTTPServer) {
+			// nolint:staticcheck
 			hs.folderService = &foldertest.FakeService{ExpectedFolder: &folder.Folder{ID: 1, UID: "1"}}
 			hs.folderPermissionsService = &actest.FakePermissionsService{}
 		})
@@ -120,6 +124,7 @@ func TestHTTPServer_UpdateFolderPermissions(t *testing.T) {
 
 	t.Run("should not be able to specify team and role in same acl", func(t *testing.T) {
 		server := SetupAPITestServer(t, func(hs *HTTPServer) {
+			// nolint:staticcheck
 			hs.folderService = &foldertest.FakeService{ExpectedFolder: &folder.Folder{ID: 1, UID: "1"}}
 			hs.folderPermissionsService = &actest.FakePermissionsService{}
 		})
@@ -136,6 +141,7 @@ func TestHTTPServer_UpdateFolderPermissions(t *testing.T) {
 
 	t.Run("should not be able to specify user and role in same acl", func(t *testing.T) {
 		server := SetupAPITestServer(t, func(hs *HTTPServer) {
+			// nolint:staticcheck
 			hs.folderService = &foldertest.FakeService{ExpectedFolder: &folder.Folder{ID: 1, UID: "1"}}
 			hs.folderPermissionsService = &actest.FakePermissionsService{}
 		})

--- a/pkg/api/folder_test.go
+++ b/pkg/api/folder_test.go
@@ -47,7 +47,7 @@ func TestFoldersCreateAPIEndpoint(t *testing.T) {
 			description:    "folder creation succeeds given the correct request for creating a folder",
 			input:          folderWithoutParentInput,
 			expectedCode:   http.StatusOK,
-			expectedFolder: &folder.Folder{ID: 1, UID: "uid", Title: "Folder"},
+			expectedFolder: &folder.Folder{ID: 1, UID: "uid", Title: "Folder"}, // nolint:staticcheck
 			permissions:    []accesscontrol.Permission{{Action: dashboards.ActionFoldersCreate}},
 		},
 		{
@@ -169,7 +169,7 @@ func TestFoldersUpdateAPIEndpoint(t *testing.T) {
 		{
 			description:    "folder updating succeeds given the correct request and permissions to update a folder",
 			expectedCode:   http.StatusOK,
-			expectedFolder: &folder.Folder{ID: 1, UID: "uid", Title: "Folder upd"},
+			expectedFolder: &folder.Folder{ID: 1, UID: "uid", Title: "Folder upd"}, // nolint:staticcheck
 			permissions:    []accesscontrol.Permission{{Action: dashboards.ActionFoldersWrite, Scope: dashboards.ScopeFoldersAll}},
 		},
 		{
@@ -421,7 +421,7 @@ func TestFolderMoveAPIEndpoint(t *testing.T) {
 func TestFolderGetAPIEndpoint(t *testing.T) {
 	folderService := &foldertest.FakeService{
 		ExpectedFolder: &folder.Folder{
-			ID:    1,
+			ID:    1, // nolint:staticcheck
 			UID:   "uid",
 			Title: "uid title",
 		},

--- a/pkg/services/annotations/annotationsimpl/annotations_test.go
+++ b/pkg/services/annotations/annotationsimpl/annotations_test.go
@@ -253,7 +253,7 @@ func TestIntegrationAnnotationListingWithInheritedRBAC(t *testing.T) {
 				Dashboard: simplejson.NewFromAny(map[string]any{
 					"title": fmt.Sprintf("Dashboard under %s", f.UID),
 				}),
-				FolderID:  f.ID,
+				FolderID:  f.ID, // nolint:staticcheck
 				FolderUID: f.UID,
 			})
 

--- a/pkg/services/dashboardimport/service/service_test.go
+++ b/pkg/services/dashboardimport/service/service_test.go
@@ -58,7 +58,7 @@ func TestImportDashboardService(t *testing.T) {
 		}
 		folderService := &foldertest.FakeService{
 			ExpectedFolder: &folder.Folder{
-				ID:  5,
+				ID:  5, // nolint:staticcheck
 				UID: "123",
 			},
 		}
@@ -122,7 +122,7 @@ func TestImportDashboardService(t *testing.T) {
 		libraryPanelService := &libraryPanelServiceMock{}
 		folderService := &foldertest.FakeService{
 			ExpectedFolder: &folder.Folder{
-				ID:  5,
+				ID:  5, // nolint:staticcheck
 				UID: "123",
 			},
 		}

--- a/pkg/services/dashboards/accesscontrol_test.go
+++ b/pkg/services/dashboards/accesscontrol_test.go
@@ -26,6 +26,7 @@ func TestNewFolderNameScopeResolver(t *testing.T) {
 	t.Run("resolver should convert to uid scope", func(t *testing.T) {
 		orgId := rand.Int63()
 		title := "Very complex :title with: and /" + util.GenerateShortUID()
+		// nolint:staticcheck
 		db := &folder.Folder{Title: title, ID: rand.Int63(), UID: util.GenerateShortUID()}
 		folderStore := foldertest.NewFakeFolderStore(t)
 		folderStore.On("GetFolderByTitle", mock.Anything, mock.Anything, mock.Anything).Return(db, nil).Once()
@@ -43,6 +44,7 @@ func TestNewFolderNameScopeResolver(t *testing.T) {
 		orgId := rand.Int63()
 		title := "Very complex :title with: and /" + util.GenerateShortUID()
 
+		// nolint:staticcheck
 		db := &folder.Folder{Title: title, ID: rand.Int63(), UID: util.GenerateShortUID()}
 
 		folderStore := foldertest.NewFakeFolderStore(t)
@@ -114,15 +116,18 @@ func TestNewFolderIDScopeResolver(t *testing.T) {
 
 		orgId := rand.Int63()
 		uid := util.GenerateShortUID()
+		// nolint:staticcheck
 		db := &folder.Folder{ID: rand.Int63(), UID: uid}
 		folderStore.On("GetFolderByID", mock.Anything, mock.Anything, mock.Anything).Return(db, nil).Once()
 
+		// nolint:staticcheck
 		scope := "folders:id:" + strconv.FormatInt(db.ID, 10)
 		resolvedScopes, err := resolver.Resolve(context.Background(), orgId, scope)
 		require.NoError(t, err)
 		require.Len(t, resolvedScopes, 1)
 		require.Equal(t, fmt.Sprintf("folders:uid:%v", db.UID), resolvedScopes[0])
 
+		// nolint:staticcheck
 		folderStore.AssertCalled(t, "GetFolderByID", mock.Anything, orgId, db.ID)
 	})
 	t.Run("resolver should should include inherited scopes if any", func(t *testing.T) {
@@ -140,9 +145,11 @@ func TestNewFolderIDScopeResolver(t *testing.T) {
 
 		orgId := rand.Int63()
 		uid := util.GenerateShortUID()
+		// nolint:staticcheck
 		db := &folder.Folder{ID: rand.Int63(), UID: uid}
 		folderStore.On("GetFolderByID", mock.Anything, mock.Anything, mock.Anything).Return(db, nil).Once()
 
+		// nolint:staticcheck
 		scope := "folders:id:" + strconv.FormatInt(db.ID, 10)
 
 		resolvedScopes, err := resolver.Resolve(context.Background(), orgId, scope)
@@ -157,6 +164,7 @@ func TestNewFolderIDScopeResolver(t *testing.T) {
 			t.Errorf("Result mismatch (-want +got):\n%s", diff)
 		}
 
+		// nolint:staticcheck
 		folderStore.AssertCalled(t, "GetFolderByID", mock.Anything, orgId, db.ID)
 	})
 	t.Run("resolver should fail if input scope is not expected", func(t *testing.T) {
@@ -211,10 +219,12 @@ func TestNewDashboardIDScopeResolver(t *testing.T) {
 		_, resolver := NewDashboardIDScopeResolver(folderStore, dashSvc, foldertest.NewFakeService())
 
 		orgID := rand.Int63()
+		// nolint:staticcheck
 		folder := &folder.Folder{ID: 2, UID: "2"}
 		// nolint:staticcheck
 		dashboard := &Dashboard{ID: 1, FolderID: folder.ID, UID: "1"}
 		dashSvc.On("G")
+		// nolint:staticcheck
 		folderStore.On("GetFolderByID", mock.Anything, orgID, folder.ID).Return(folder, nil).Once()
 		dashSvc.On("GetDashboard", mock.Anything, mock.Anything).Return(dashboard, nil).Once()
 		scope := ac.Scope("dashboards", "id", strconv.FormatInt(dashboard.ID, 10))
@@ -240,11 +250,13 @@ func TestNewDashboardIDScopeResolver(t *testing.T) {
 		_, resolver := NewDashboardIDScopeResolver(folderStore, dashSvc, folderSvc)
 
 		orgID := rand.Int63()
+		// nolint:staticcheck
 		folder := &folder.Folder{ID: 2, UID: "2"}
 		// nolint:staticcheck
 		dashboard := &Dashboard{ID: 1, FolderID: folder.ID, UID: "1"}
 
 		dashSvc.On("GetDashboard", mock.Anything, mock.Anything).Return(dashboard, nil).Once()
+		// nolint:staticcheck
 		folderStore.On("GetFolderByID", mock.Anything, orgID, folder.ID).Return(folder, nil).Once()
 
 		scope := ac.Scope("dashboards", "id", strconv.FormatInt(dashboard.ID, 10))
@@ -296,11 +308,13 @@ func TestNewDashboardUIDScopeResolver(t *testing.T) {
 		_, resolver := NewDashboardUIDScopeResolver(folderStore, dashSvc, foldertest.NewFakeService())
 
 		orgID := rand.Int63()
+		// nolint:staticcheck
 		folder := &folder.Folder{ID: 2, UID: "2"}
 		// nolint:staticcheck
 		dashboard := &Dashboard{ID: 1, FolderID: folder.ID, UID: "1"}
 
 		dashSvc.On("GetDashboard", mock.Anything, mock.Anything).Return(dashboard, nil).Once()
+		// nolint:staticcheck
 		folderStore.On("GetFolderByID", mock.Anything, orgID, folder.ID).Return(folder, nil).Once()
 		scope := ac.Scope("dashboards", "uid", dashboard.UID)
 		resolvedScopes, err := resolver.Resolve(context.Background(), orgID, scope)
@@ -325,6 +339,7 @@ func TestNewDashboardUIDScopeResolver(t *testing.T) {
 		_, resolver := NewDashboardUIDScopeResolver(folderStore, dashSvc, folderSvc)
 
 		orgID := rand.Int63()
+		// nolint:staticcheck
 		folder := &folder.Folder{ID: 2, UID: "2"}
 		// nolint:staticcheck
 		dashboard := &Dashboard{ID: 1, FolderID: folder.ID, UID: "1"}

--- a/pkg/services/dashboards/database/database_test.go
+++ b/pkg/services/dashboards/database/database_test.go
@@ -885,6 +885,7 @@ func TestIntegrationFindDashboardsByFolder(t *testing.T) {
 		SignedInUser: user,
 	})
 	require.NoError(t, err)
+	// nolint:staticcheck
 	insertTestDashboard(t, dashboardStore, "dashboard under f1", orgID, f1.ID, f1.UID, false)
 
 	subfolder, err := folderServiceWithFlagOn.Create(context.Background(), &folder.CreateFolderCommand{

--- a/pkg/services/dashboards/database/database_test.go
+++ b/pkg/services/dashboards/database/database_test.go
@@ -759,6 +759,7 @@ func TestIntegrationFindDashboardsByTitle(t *testing.T) {
 		SignedInUser: user,
 	})
 	require.NoError(t, err)
+	// nolint:staticcheck
 	insertTestDashboard(t, dashboardStore, "dashboard under f0", orgID, f0.ID, f0.UID, false)
 
 	subfolder, err := folderServiceWithFlagOn.Create(context.Background(), &folder.CreateFolderCommand{
@@ -768,6 +769,7 @@ func TestIntegrationFindDashboardsByTitle(t *testing.T) {
 		SignedInUser: user,
 	})
 	require.NoError(t, err)
+	// nolint:staticcheck
 	insertTestDashboard(t, dashboardStore, "dashboard under subfolder", orgID, subfolder.ID, subfolder.UID, false)
 
 	type res struct {
@@ -874,6 +876,7 @@ func TestIntegrationFindDashboardsByFolder(t *testing.T) {
 		SignedInUser: user,
 	})
 	require.NoError(t, err)
+	// nolint:staticcheck
 	insertTestDashboard(t, dashboardStore, "dashboard under f0", orgID, f0.ID, f0.UID, false)
 
 	f1, err := folderServiceWithFlagOn.Create(context.Background(), &folder.CreateFolderCommand{

--- a/pkg/services/dashboards/models.go
+++ b/pkg/services/dashboards/models.go
@@ -387,7 +387,7 @@ type CountDashboardsInFolderRequest struct {
 
 func FromDashboard(dash *Dashboard) *folder.Folder {
 	return &folder.Folder{
-		ID:        dash.ID,
+		ID:        dash.ID, // nolint:staticcheck
 		UID:       dash.UID,
 		OrgID:     dash.OrgID,
 		Title:     dash.Title,

--- a/pkg/services/dashboards/service/dashboard_service_test.go
+++ b/pkg/services/dashboards/service/dashboard_service_test.go
@@ -224,6 +224,7 @@ func TestDashboardService(t *testing.T) {
 
 		t.Run("Count dashboards in folder", func(t *testing.T) {
 			fakeStore.On("CountDashboardsInFolder", mock.Anything, mock.AnythingOfType("*dashboards.CountDashboardsInFolderRequest")).Return(int64(3), nil)
+			// nolint:staticcheck
 			folderSvc.ExpectedFolder = &folder.Folder{ID: 1}
 			// set up a ctx with signed in user
 			usr := &user.SignedInUser{UserID: 1}

--- a/pkg/services/folder/folderimpl/dashboard_folder_store_test.go
+++ b/pkg/services/folder/folderimpl/dashboard_folder_store_test.go
@@ -44,6 +44,7 @@ func TestIntegrationDashboardFolderStore(t *testing.T) {
 		t.Run("GetFolderByTitle should find the folder", func(t *testing.T) {
 			result, err := folderStore.GetFolderByTitle(context.Background(), orgId, title)
 			require.NoError(t, err)
+			// nolint:staticcheck
 			require.Equal(t, folder1.ID, result.ID)
 		})
 	})
@@ -57,6 +58,7 @@ func TestIntegrationDashboardFolderStore(t *testing.T) {
 
 		t.Run("should return folder by UID", func(t *testing.T) {
 			d, err := folderStore.GetFolderByUID(context.Background(), orgId, folder.UID)
+			// nolint:staticcheck
 			require.Equal(t, folder.ID, d.ID)
 			require.NoError(t, err)
 		})
@@ -81,6 +83,7 @@ func TestIntegrationDashboardFolderStore(t *testing.T) {
 
 		t.Run("should return folder by ID", func(t *testing.T) {
 			d, err := folderStore.GetFolderByID(context.Background(), orgId, folder.ID)
+			// nolint:staticcheck
 			require.Equal(t, folder.ID, d.ID)
 			require.NoError(t, err)
 		})

--- a/pkg/services/folder/folderimpl/folder.go
+++ b/pkg/services/folder/folderimpl/folder.go
@@ -173,6 +173,7 @@ func (s *Service) Get(ctx context.Context, cmd *folder.GetFolderQuery) (*folder.
 	}
 
 	// always expose the dashboard store sequential ID
+	// nolint:staticcheck
 	f.ID = dashFolder.ID
 	f.Version = dashFolder.Version
 
@@ -225,6 +226,7 @@ func (s *Service) GetChildren(ctx context.Context, cmd *folder.GetChildrenQuery)
 		}
 
 		// always expose the dashboard store sequential ID
+		// nolint:staticcheck
 		f.ID = dashFolder.ID
 
 		if cmd.UID != "" {
@@ -443,7 +445,7 @@ func (s *Service) Create(ctx context.Context, cmd *folder.CreateFolderCommand) (
 		logger.Error("error saving folder to nested folder store", "error", err)
 		// do not shallow create error if the legacy folder delete fails
 		if deleteErr := s.dashboardStore.DeleteDashboard(ctx, &dashboards.DeleteDashboardCommand{
-			ID:    createdFolder.ID,
+			ID:    createdFolder.ID, // nolint:staticcheck
 			OrgID: createdFolder.OrgID,
 		}); deleteErr != nil {
 			logger.Error("error deleting folder after failed save to nested folder store", "error", err)
@@ -488,6 +490,7 @@ func (s *Service) Update(ctx context.Context, cmd *folder.UpdateFolderCommand) (
 	}
 
 	// always expose the dashboard store sequential ID
+	// nolint:staticcheck
 	foldr.ID = dashFolder.ID
 	foldr.Version = dashFolder.Version
 
@@ -660,6 +663,7 @@ func (s *Service) deleteChildrenInFolder(ctx context.Context, orgID int64, folde
 }
 
 func (s *Service) legacyDelete(ctx context.Context, cmd *folder.DeleteFolderCommand, dashFolder *folder.Folder) error {
+	// nolint:staticcheck
 	deleteCmd := dashboards.DeleteDashboardCommand{OrgID: cmd.OrgID, ID: dashFolder.ID, ForceDeleteFolderRules: cmd.ForceDeleteRules}
 
 	if err := s.dashboardStore.DeleteDashboard(ctx, &deleteCmd); err != nil {

--- a/pkg/services/folder/folderimpl/folder_test.go
+++ b/pkg/services/folder/folderimpl/folder_test.go
@@ -94,6 +94,7 @@ func TestIntegrationFolderService(t *testing.T) {
 			folderUID := util.GenerateShortUID()
 
 			f := folder.NewFolder("Folder", "")
+			// nolint:staticcheck
 			f.ID = folderId
 			f.UID = folderUID
 
@@ -117,6 +118,7 @@ func TestIntegrationFolderService(t *testing.T) {
 					SignedInUser: usr,
 				})
 				require.NoError(t, err)
+				// nolint:staticcheck
 				require.Equal(t, foldr, &folder.Folder{ID: 0, Title: "General"})
 			})
 
@@ -239,6 +241,7 @@ func TestIntegrationFolderService(t *testing.T) {
 
 			t.Run("When deleting folder by uid should not return access denied error", func(t *testing.T) {
 				f := folder.NewFolder(util.GenerateShortUID(), "")
+				// nolint:staticcheck
 				f.ID = rand.Int63()
 				f.UID = util.GenerateShortUID()
 				folderStore.On("GetFolders", mock.Anything, orgID, []string{f.UID}).Return(map[string]*folder.Folder{f.UID: f}, nil)
@@ -258,6 +261,7 @@ func TestIntegrationFolderService(t *testing.T) {
 				})
 				require.NoError(t, err)
 				require.NotNil(t, actualCmd)
+				// nolint:staticcheck
 				require.Equal(t, f.ID, actualCmd.ID)
 				require.Equal(t, orgID, actualCmd.OrgID)
 				require.Equal(t, expectedForceDeleteRules, actualCmd.ForceDeleteFolderRules)
@@ -274,10 +278,13 @@ func TestIntegrationFolderService(t *testing.T) {
 
 			t.Run("When get folder by id should return folder", func(t *testing.T) {
 				expected := folder.NewFolder(util.GenerateShortUID(), "")
+				// nolint:staticcheck
 				expected.ID = rand.Int63()
 
+				// nolint:staticcheck
 				folderStore.On("GetFolderByID", mock.Anything, orgID, expected.ID).Return(expected, nil)
 
+				// nolint:staticcheck
 				actual, err := service.getFolderByID(context.Background(), expected.ID, orgID)
 				require.Equal(t, expected, actual)
 				require.NoError(t, err)
@@ -418,7 +425,9 @@ func TestIntegrationNestedFolderService(t *testing.T) {
 			require.NoError(t, err)
 			subfolder, err := serviceWithFlagOn.dashboardFolderStore.GetFolderByUID(context.Background(), orgID, ancestorUIDs[1])
 			require.NoError(t, err)
+			// nolint:staticcheck
 			_ = insertTestDashboard(t, serviceWithFlagOn.dashboardStore, "dashboard in parent", orgID, parent.ID, parent.UID, "prod")
+			// nolint:staticcheck
 			_ = insertTestDashboard(t, serviceWithFlagOn.dashboardStore, "dashboard in subfolder", orgID, subfolder.ID, subfolder.UID, "prod")
 			_ = createRule(t, alertStore, parent.UID, "parent alert")
 			_ = createRule(t, alertStore, subfolder.UID, "sub alert")
@@ -495,7 +504,9 @@ func TestIntegrationNestedFolderService(t *testing.T) {
 			require.NoError(t, err)
 			subfolder, err := serviceWithFlagOn.dashboardFolderStore.GetFolderByUID(context.Background(), orgID, ancestorUIDs[1])
 			require.NoError(t, err)
+			// nolint:staticcheck
 			_ = insertTestDashboard(t, serviceWithFlagOn.dashboardStore, "dashboard in parent", orgID, parent.ID, parent.UID, "prod")
+			// nolint:staticcheck
 			_ = insertTestDashboard(t, serviceWithFlagOn.dashboardStore, "dashboard in subfolder", orgID, subfolder.ID, subfolder.UID, "prod")
 			_ = createRule(t, alertStore, parent.UID, "parent alert")
 			_ = createRule(t, alertStore, subfolder.UID, "sub alert")
@@ -1202,6 +1213,7 @@ func CreateSubtreeInStore(t *testing.T, store *sqlStore, service *Service, depth
 		f, err := service.Create(context.Background(), &cmd)
 		require.NoError(t, err)
 		require.Equal(t, title, f.Title)
+		// nolint:staticcheck
 		require.NotEmpty(t, f.ID)
 		require.NotEmpty(t, f.UID)
 

--- a/pkg/services/folder/folderimpl/sqlstore_test.go
+++ b/pkg/services/folder/folderimpl/sqlstore_test.go
@@ -439,6 +439,7 @@ func TestIntegrationGet(t *testing.T) {
 			ID: &f.ID, // nolint:staticcheck
 		})
 		require.NoError(t, err)
+		// nolint:staticcheck
 		assert.Equal(t, f.ID, ff.ID)
 		assert.Equal(t, f.UID, ff.UID)
 		assert.Equal(t, f.OrgID, ff.OrgID)

--- a/pkg/services/folder/folderimpl/sqlstore_test.go
+++ b/pkg/services/folder/folderimpl/sqlstore_test.go
@@ -70,6 +70,7 @@ func TestIntegrationCreate(t *testing.T) {
 
 		assert.Equal(t, folderTitle, f.Title)
 		assert.Equal(t, folderDsc, f.Description)
+		// nolint:staticcheck
 		assert.NotEmpty(t, f.ID)
 		assert.Equal(t, uid, f.UID)
 		assert.Empty(t, f.ParentUID)
@@ -97,6 +98,7 @@ func TestIntegrationCreate(t *testing.T) {
 		})
 		require.NoError(t, err)
 		require.Equal(t, "parent", parent.Title)
+		// nolint:staticcheck
 		require.NotEmpty(t, parent.ID)
 		assert.Equal(t, parentUID, parent.UID)
 		assert.NotEmpty(t, parent.URL)
@@ -123,6 +125,7 @@ func TestIntegrationCreate(t *testing.T) {
 
 		assert.Equal(t, folderTitle, f.Title)
 		assert.Equal(t, folderDsc, f.Description)
+		// nolint:staticcheck
 		assert.NotEmpty(t, f.ID)
 		assert.Equal(t, uid, f.UID)
 		assert.Equal(t, parentUID, f.ParentUID)
@@ -401,6 +404,7 @@ func TestIntegrationGet(t *testing.T) {
 			OrgID: orgID,
 		})
 		require.NoError(t, err)
+		// nolint:staticcheck
 		assert.Equal(t, f.ID, ff.ID)
 		assert.Equal(t, f.UID, ff.UID)
 		assert.Equal(t, f.OrgID, ff.OrgID)
@@ -418,6 +422,7 @@ func TestIntegrationGet(t *testing.T) {
 			OrgID: orgID,
 		})
 		require.NoError(t, err)
+		// nolint:staticcheck
 		assert.Equal(t, f.ID, ff.ID)
 		assert.Equal(t, f.UID, ff.UID)
 		assert.Equal(t, f.OrgID, ff.OrgID)
@@ -751,6 +756,7 @@ func TestIntegrationGetFolders(t *testing.T) {
 			})
 			assert.NotEqual(t, -1, folderInResponseIdx)
 			rf := ff[folderInResponseIdx]
+			// nolint:staticcheck
 			assert.Equal(t, f.ID, rf.ID)
 			assert.Equal(t, f.OrgID, rf.OrgID)
 			assert.Equal(t, f.Title, rf.Title)
@@ -795,6 +801,7 @@ func CreateSubtree(t *testing.T, store *sqlStore, orgID int64, parentUID string,
 		f, err := store.Create(context.Background(), cmd)
 		require.NoError(t, err)
 		require.Equal(t, title, f.Title)
+		// nolint:staticcheck
 		require.NotEmpty(t, f.ID)
 		require.NotEmpty(t, f.UID)
 

--- a/pkg/services/folder/model.go
+++ b/pkg/services/folder/model.go
@@ -26,6 +26,7 @@ const (
 var ErrFolderNotFound = errutil.NotFound("folder.notFound")
 
 type Folder struct {
+	// Deprecated: use UID instead
 	ID          int64  `xorm:"pk autoincr 'id'"`
 	OrgID       int64  `xorm:"org_id"`
 	UID         string `xorm:"uid"`

--- a/pkg/services/folder/model.go
+++ b/pkg/services/folder/model.go
@@ -49,6 +49,7 @@ type Folder struct {
 var GeneralFolder = Folder{ID: 0, Title: "General"}
 
 func (f *Folder) IsGeneral() bool {
+	// nolint:staticcheck
 	return f.ID == GeneralFolder.ID && f.Title == GeneralFolder.Title
 }
 

--- a/pkg/services/guardian/accesscontrol_guardian_test.go
+++ b/pkg/services/guardian/accesscontrol_guardian_test.go
@@ -1019,6 +1019,7 @@ func setupAccessControlGuardianTest(
 	folderSvc := foldertest.NewFakeService()
 
 	folderStore := foldertest.NewFakeFolderStore(t)
+	// nolint:staticcheck
 	folderStore.On("GetFolderByID", mock.Anything, mock.Anything, mock.Anything).Maybe().Return(&folder.Folder{ID: folderID, UID: folderUID, OrgID: orgID}, nil)
 
 	ac.RegisterScopeAttributeResolver(dashboards.NewDashboardUIDScopeResolver(folderStore, fakeDashboardService, folderSvc))

--- a/pkg/services/guardian/guardian.go
+++ b/pkg/services/guardian/guardian.go
@@ -112,6 +112,7 @@ func MockDashboardGuardian(mock *FakeDashboardGuardian) {
 	NewByFolder = func(_ context.Context, f *folder.Folder, orgId int64, user identity.Requester) (DashboardGuardian, error) {
 		mock.OrgID = orgId
 		mock.DashUID = f.UID
+		// nolint:staticcheck
 		mock.DashID = f.ID
 		mock.User = user
 		return mock, nil

--- a/pkg/services/libraryelements/libraryelements_create_test.go
+++ b/pkg/services/libraryelements/libraryelements_create_test.go
@@ -14,6 +14,7 @@ import (
 func TestCreateLibraryElement(t *testing.T) {
 	scenarioWithPanel(t, "When an admin tries to create a library panel that already exists, it should fail",
 		func(t *testing.T, sc scenarioContext) {
+			// nolint:staticcheck
 			command := getCreatePanelCommand(sc.folder.ID, "Text - Library Panel")
 			sc.reqContext.Req.Body = mockRequestBody(command)
 			resp := sc.service.createHandler(sc.reqContext)
@@ -66,6 +67,7 @@ func TestCreateLibraryElement(t *testing.T) {
 
 	testScenario(t, "When an admin tries to create a library panel that does not exists using an nonexistent UID, it should succeed",
 		func(t *testing.T, sc scenarioContext) {
+			// nolint:staticcheck
 			command := getCreatePanelCommand(sc.folder.ID, "Nonexistent UID")
 			command.UID = util.GenerateShortUID()
 			sc.reqContext.Req.Body = mockRequestBody(command)
@@ -115,6 +117,7 @@ func TestCreateLibraryElement(t *testing.T) {
 
 	scenarioWithPanel(t, "When an admin tries to create a library panel that does not exists using an existent UID, it should fail",
 		func(t *testing.T, sc scenarioContext) {
+			// nolint:staticcheck
 			command := getCreatePanelCommand(sc.folder.ID, "Existing UID")
 			command.UID = sc.initialResult.Result.UID
 			sc.reqContext.Req.Body = mockRequestBody(command)
@@ -124,6 +127,7 @@ func TestCreateLibraryElement(t *testing.T) {
 
 	scenarioWithPanel(t, "When an admin tries to create a library panel that does not exists using an invalid UID, it should fail",
 		func(t *testing.T, sc scenarioContext) {
+			// nolint:staticcheck
 			command := getCreatePanelCommand(sc.folder.ID, "Invalid UID")
 			command.UID = "Testing an invalid UID"
 			sc.reqContext.Req.Body = mockRequestBody(command)
@@ -133,6 +137,7 @@ func TestCreateLibraryElement(t *testing.T) {
 
 	scenarioWithPanel(t, "When an admin tries to create a library panel that does not exists using an UID that is too long, it should fail",
 		func(t *testing.T, sc scenarioContext) {
+			// nolint:staticcheck
 			command := getCreatePanelCommand(sc.folder.ID, "Invalid UID")
 			command.UID = "j6T00KRZzj6T00KRZzj6T00KRZzj6T00KRZzj6T00K"
 			sc.reqContext.Req.Body = mockRequestBody(command)

--- a/pkg/services/libraryelements/libraryelements_delete_test.go
+++ b/pkg/services/libraryelements/libraryelements_delete_test.go
@@ -73,6 +73,7 @@ func TestDeleteLibraryElement(t *testing.T) {
 				Title: "Testing deleteHandler ",
 				Data:  simplejson.NewFromAny(dashJSON),
 			}
+			// nolint:staticcheck
 			dashInDB := createDashboard(t, sc.sqlStore, sc.user, &dash, sc.folder.ID)
 			err := sc.service.ConnectElementsToDashboard(sc.reqContext.Req.Context(), sc.reqContext.SignedInUser, []string{sc.initialResult.Result.UID}, dashInDB.ID)
 			require.NoError(t, err)

--- a/pkg/services/libraryelements/libraryelements_get_all_test.go
+++ b/pkg/services/libraryelements/libraryelements_get_all_test.go
@@ -38,6 +38,7 @@ func TestGetAllLibraryElements(t *testing.T) {
 
 	scenarioWithPanel(t, "When an admin tries to get all panel elements and both panels and variables exist, it should only return panels",
 		func(t *testing.T, sc scenarioContext) {
+			// nolint:staticcheck
 			command := getCreateVariableCommand(sc.folder.ID, "query0")
 			sc.reqContext.Req.Body = mockRequestBody(command)
 			resp := sc.service.createHandler(sc.reqContext)
@@ -104,6 +105,7 @@ func TestGetAllLibraryElements(t *testing.T) {
 
 	scenarioWithPanel(t, "When an admin tries to get all variable elements and both panels and variables exist, it should only return panels",
 		func(t *testing.T, sc scenarioContext) {
+			// nolint:staticcheck
 			command := getCreateVariableCommand(sc.folder.ID, "query0")
 			sc.reqContext.Req.Body = mockRequestBody(command)
 			resp := sc.service.createHandler(sc.reqContext)
@@ -169,6 +171,7 @@ func TestGetAllLibraryElements(t *testing.T) {
 
 	scenarioWithPanel(t, "When an admin tries to get all library panels and two exist, it should succeed",
 		func(t *testing.T, sc scenarioContext) {
+			// nolint:staticcheck
 			command := getCreatePanelCommand(sc.folder.ID, "Text - Library Panel2")
 			sc.reqContext.Req.Body = mockRequestBody(command)
 			resp := sc.service.createHandler(sc.reqContext)
@@ -266,6 +269,7 @@ func TestGetAllLibraryElements(t *testing.T) {
 
 	scenarioWithPanel(t, "When an admin tries to get all library panels and two exist and sort desc is set, it should succeed and the result should be correct",
 		func(t *testing.T, sc scenarioContext) {
+			// nolint:staticcheck
 			command := getCreatePanelCommand(sc.folder.ID, "Text - Library Panel2")
 			sc.reqContext.Req.Body = mockRequestBody(command)
 			resp := sc.service.createHandler(sc.reqContext)
@@ -366,6 +370,7 @@ func TestGetAllLibraryElements(t *testing.T) {
 
 	scenarioWithPanel(t, "When an admin tries to get all library panels and two exist and typeFilter is set to existing types, it should succeed and the result should be correct",
 		func(t *testing.T, sc scenarioContext) {
+			// nolint:staticcheck
 			command := getCreateCommandWithModel(sc.folder.ID, "Gauge - Library Panel", model.PanelElement, []byte(`
 			{
 			  "datasource": "${DS_GDEV-TESTDATA}",
@@ -379,6 +384,7 @@ func TestGetAllLibraryElements(t *testing.T) {
 			resp := sc.service.createHandler(sc.reqContext)
 			require.Equal(t, 200, resp.Status())
 
+			// nolint:staticcheck
 			command = getCreateCommandWithModel(sc.folder.ID, "BarGauge - Library Panel", model.PanelElement, []byte(`
 			{
 			  "datasource": "${DS_GDEV-TESTDATA}",
@@ -487,6 +493,7 @@ func TestGetAllLibraryElements(t *testing.T) {
 
 	scenarioWithPanel(t, "When an admin tries to get all library panels and two exist and typeFilter is set to a nonexistent type, it should succeed and the result should be correct",
 		func(t *testing.T, sc scenarioContext) {
+			// nolint:staticcheck
 			command := getCreateCommandWithModel(sc.folder.ID, "Gauge - Library Panel", model.PanelElement, []byte(`
 			{
 			  "datasource": "${DS_GDEV-TESTDATA}",
@@ -525,10 +532,12 @@ func TestGetAllLibraryElements(t *testing.T) {
 	scenarioWithPanel(t, "When an admin tries to get all library panels and two exist and folderFilter is set to existing folders, it should succeed and the result should be correct",
 		func(t *testing.T, sc scenarioContext) {
 			newFolder := createFolder(t, sc, "NewFolder")
+			// nolint:staticcheck
 			command := getCreatePanelCommand(newFolder.ID, "Text - Library Panel2")
 			sc.reqContext.Req.Body = mockRequestBody(command)
 			resp := sc.service.createHandler(sc.reqContext)
 			require.Equal(t, 200, resp.Status())
+			// nolint:staticcheck
 			folderFilter := strconv.FormatInt(newFolder.ID, 10)
 
 			err := sc.reqContext.Req.ParseForm()
@@ -592,6 +601,7 @@ func TestGetAllLibraryElements(t *testing.T) {
 	scenarioWithPanel(t, "When an admin tries to get all library panels and two exist and folderFilter is set to a nonexistent folders, it should succeed and the result should be correct",
 		func(t *testing.T, sc scenarioContext) {
 			newFolder := createFolder(t, sc, "NewFolder")
+			// nolint:staticcheck
 			command := getCreatePanelCommand(newFolder.ID, "Text - Library Panel2")
 			sc.reqContext.Req.Body = mockRequestBody(command)
 			resp := sc.service.createHandler(sc.reqContext)
@@ -622,6 +632,7 @@ func TestGetAllLibraryElements(t *testing.T) {
 
 	scenarioWithPanel(t, "When an admin tries to get all library panels and two exist and folderFilter is set to General folder, it should succeed and the result should be correct",
 		func(t *testing.T, sc scenarioContext) {
+			// nolint:staticcheck
 			command := getCreatePanelCommand(sc.folder.ID, "Text - Library Panel2")
 			sc.reqContext.Req.Body = mockRequestBody(command)
 			resp := sc.service.createHandler(sc.reqContext)
@@ -723,6 +734,7 @@ func TestGetAllLibraryElements(t *testing.T) {
 
 	scenarioWithPanel(t, "When an admin tries to get all library panels and two exist and excludeUID is set, it should succeed and the result should be correct",
 		func(t *testing.T, sc scenarioContext) {
+			// nolint:staticcheck
 			command := getCreatePanelCommand(sc.folder.ID, "Text - Library Panel2")
 			sc.reqContext.Req.Body = mockRequestBody(command)
 			resp := sc.service.createHandler(sc.reqContext)
@@ -788,6 +800,7 @@ func TestGetAllLibraryElements(t *testing.T) {
 
 	scenarioWithPanel(t, "When an admin tries to get all library panels and two exist and perPage is 1, it should succeed and the result should be correct",
 		func(t *testing.T, sc scenarioContext) {
+			// nolint:staticcheck
 			command := getCreatePanelCommand(sc.folder.ID, "Text - Library Panel2")
 			sc.reqContext.Req.Body = mockRequestBody(command)
 			resp := sc.service.createHandler(sc.reqContext)
@@ -853,6 +866,7 @@ func TestGetAllLibraryElements(t *testing.T) {
 
 	scenarioWithPanel(t, "When an admin tries to get all library panels and two exist and perPage is 1 and page is 2, it should succeed and the result should be correct",
 		func(t *testing.T, sc scenarioContext) {
+			// nolint:staticcheck
 			command := getCreatePanelCommand(sc.folder.ID, "Text - Library Panel2")
 			sc.reqContext.Req.Body = mockRequestBody(command)
 			resp := sc.service.createHandler(sc.reqContext)
@@ -919,6 +933,7 @@ func TestGetAllLibraryElements(t *testing.T) {
 
 	scenarioWithPanel(t, "When an admin tries to get all library panels and two exist and searchString exists in the description, it should succeed and the result should be correct",
 		func(t *testing.T, sc scenarioContext) {
+			// nolint:staticcheck
 			command := getCreateCommandWithModel(sc.folder.ID, "Text - Library Panel2", model.PanelElement, []byte(`
 			{
 			  "datasource": "${DS_GDEV-TESTDATA}",
@@ -994,6 +1009,7 @@ func TestGetAllLibraryElements(t *testing.T) {
 
 	scenarioWithPanel(t, "When an admin tries to get all library panels and two exist and searchString exists in both name and description, it should succeed and the result should be correct",
 		func(t *testing.T, sc scenarioContext) {
+			// nolint:staticcheck
 			command := getCreateCommandWithModel(sc.folder.ID, "Some Other", model.PanelElement, []byte(`
 			{
 			  "datasource": "${DS_GDEV-TESTDATA}",
@@ -1102,6 +1118,7 @@ func TestGetAllLibraryElements(t *testing.T) {
 
 	scenarioWithPanel(t, "When an admin tries to get all library panels and two exist and perPage is 1 and page is 1 and searchString is panel2, it should succeed and the result should be correct",
 		func(t *testing.T, sc scenarioContext) {
+			// nolint:staticcheck
 			command := getCreatePanelCommand(sc.folder.ID, "Text - Library Panel2")
 			sc.reqContext.Req.Body = mockRequestBody(command)
 			resp := sc.service.createHandler(sc.reqContext)
@@ -1169,6 +1186,7 @@ func TestGetAllLibraryElements(t *testing.T) {
 
 	scenarioWithPanel(t, "When an admin tries to get all library panels and two exist and perPage is 1 and page is 3 and searchString is panel, it should succeed and the result should be correct",
 		func(t *testing.T, sc scenarioContext) {
+			// nolint:staticcheck
 			command := getCreatePanelCommand(sc.folder.ID, "Text - Library Panel2")
 			sc.reqContext.Req.Body = mockRequestBody(command)
 			resp := sc.service.createHandler(sc.reqContext)
@@ -1200,6 +1218,7 @@ func TestGetAllLibraryElements(t *testing.T) {
 
 	scenarioWithPanel(t, "When an admin tries to get all library panels and two exist and perPage is 1 and page is 3 and searchString does not exist, it should succeed and the result should be correct",
 		func(t *testing.T, sc scenarioContext) {
+			// nolint:staticcheck
 			command := getCreatePanelCommand(sc.folder.ID, "Text - Library Panel2")
 			sc.reqContext.Req.Body = mockRequestBody(command)
 			resp := sc.service.createHandler(sc.reqContext)

--- a/pkg/services/libraryelements/libraryelements_get_test.go
+++ b/pkg/services/libraryelements/libraryelements_get_test.go
@@ -122,6 +122,7 @@ func TestGetLibraryElement(t *testing.T) {
 				Title: "Testing getHandler",
 				Data:  simplejson.NewFromAny(dashJSON),
 			}
+			// nolint:staticcheck
 			dashInDB := createDashboard(t, sc.sqlStore, sc.user, &dash, sc.folder.ID)
 			err := sc.service.ConnectElementsToDashboard(sc.reqContext.Req.Context(), sc.reqContext.SignedInUser, []string{sc.initialResult.Result.UID}, dashInDB.ID)
 			require.NoError(t, err)

--- a/pkg/services/libraryelements/libraryelements_patch_test.go
+++ b/pkg/services/libraryelements/libraryelements_patch_test.go
@@ -189,6 +189,7 @@ func TestPatchLibraryElement(t *testing.T) {
 
 	scenarioWithPanel(t, "When an admin tries to patch a library panel with an existing UID, it should fail",
 		func(t *testing.T, sc scenarioContext) {
+			// nolint:staticcheck
 			command := getCreatePanelCommand(sc.folder.ID, "Existing UID")
 			command.UID = util.GenerateShortUID()
 			sc.reqContext.Req.Body = mockRequestBody(command)
@@ -310,6 +311,7 @@ func TestPatchLibraryElement(t *testing.T) {
 
 	scenarioWithPanel(t, "When an admin tries to patch a library panel with a name that already exists, it should fail",
 		func(t *testing.T, sc scenarioContext) {
+			// nolint:staticcheck
 			command := getCreatePanelCommand(sc.folder.ID, "Another Panel")
 			sc.ctx.Req.Body = mockRequestBody(command)
 			resp := sc.service.createHandler(sc.reqContext)
@@ -328,6 +330,7 @@ func TestPatchLibraryElement(t *testing.T) {
 	scenarioWithPanel(t, "When an admin tries to patch a library panel with a folder where a library panel with the same name already exists, it should fail",
 		func(t *testing.T, sc scenarioContext) {
 			newFolder := createFolder(t, sc, "NewFolder")
+			// nolint:staticcheck
 			command := getCreatePanelCommand(newFolder.ID, "Text - Library Panel")
 			sc.ctx.Req.Body = mockRequestBody(command)
 			resp := sc.service.createHandler(sc.reqContext)

--- a/pkg/services/libraryelements/libraryelements_permissions_test.go
+++ b/pkg/services/libraryelements/libraryelements_permissions_test.go
@@ -39,6 +39,7 @@ func TestLibraryElementPermissionsGeneralFolder(t *testing.T) {
 		testScenario(t, fmt.Sprintf("When %s tries to patch a library panel by moving it to the General folder, it should return correct status", testCase.role),
 			func(t *testing.T, sc scenarioContext) {
 				folder := createFolder(t, sc, "Folder")
+				// nolint:staticcheck
 				command := getCreatePanelCommand(folder.ID, "Library Panel Name")
 				sc.reqContext.Req.Body = mockRequestBody(command)
 				resp := sc.service.createHandler(sc.reqContext)
@@ -181,6 +182,7 @@ func TestLibraryElementCreatePermissions(t *testing.T) {
 					1: testCase.permissions,
 				}
 
+				// nolint:staticcheck
 				command := getCreatePanelCommand(folder.ID, "Library Panel Name")
 				sc.reqContext.Req.Body = mockRequestBody(command)
 				resp := sc.service.createHandler(sc.reqContext)
@@ -233,6 +235,7 @@ func TestLibraryElementPatchPermissions(t *testing.T) {
 		testScenario(t, testCase.desc,
 			func(t *testing.T, sc scenarioContext) {
 				fromFolder := createFolder(t, sc, "FromFolder")
+				// nolint:staticcheck
 				command := getCreatePanelCommand(fromFolder.ID, "Library Panel Name")
 				sc.reqContext.Req.Body = mockRequestBody(command)
 				resp := sc.service.createHandler(sc.reqContext)
@@ -294,6 +297,7 @@ func TestLibraryElementDeletePermissions(t *testing.T) {
 		testScenario(t, testCase.desc,
 			func(t *testing.T, sc scenarioContext) {
 				folder := createFolder(t, sc, "Folder")
+				// nolint:staticcheck
 				command := getCreatePanelCommand(folder.ID, "Library Panel Name")
 				sc.reqContext.Req.Body = mockRequestBody(command)
 				resp := sc.service.createHandler(sc.reqContext)
@@ -322,6 +326,7 @@ func TestLibraryElementsWithMissingFolders(t *testing.T) {
 	testScenario(t, "When a user tries to patch a library panel by moving it to a folder that doesn't exist, it should fail",
 		func(t *testing.T, sc scenarioContext) {
 			folder := createFolder(t, sc, "Folder")
+			// nolint:staticcheck
 			command := getCreatePanelCommand(folder.ID, "Library Panel Name")
 			sc.reqContext.Req.Body = mockRequestBody(command)
 			resp := sc.service.createHandler(sc.reqContext)
@@ -361,6 +366,7 @@ func TestLibraryElementsGetPermissions(t *testing.T) {
 		testScenario(t, testCase.desc,
 			func(t *testing.T, sc scenarioContext) {
 				folder := createFolder(t, sc, "Folder")
+				// nolint:staticcheck
 				cmd := getCreatePanelCommand(folder.ID, "Library Panel")
 				sc.reqContext.Req.Body = mockRequestBody(cmd)
 				resp := sc.service.createHandler(sc.reqContext)
@@ -411,6 +417,7 @@ func TestLibraryElementsGetAllPermissions(t *testing.T) {
 			func(t *testing.T, sc scenarioContext) {
 				for i := 1; i <= 2; i++ {
 					folder := createFolder(t, sc, fmt.Sprintf("Folder%d", i))
+					// nolint:staticcheck
 					cmd := getCreatePanelCommand(folder.ID, fmt.Sprintf("Library Panel %d", i))
 					sc.reqContext.Req.Body = mockRequestBody(cmd)
 					resp := sc.service.createHandler(sc.reqContext)

--- a/pkg/services/libraryelements/libraryelements_test.go
+++ b/pkg/services/libraryelements/libraryelements_test.go
@@ -83,6 +83,7 @@ func TestDeleteLibraryPanelsInFolder(t *testing.T) {
 				Title: "Testing DeleteLibraryElementsInFolder",
 				Data:  simplejson.NewFromAny(dashJSON),
 			}
+			// nolint:staticcheck
 			dashInDB := createDashboard(t, sc.sqlStore, sc.user, &dash, sc.folder.ID)
 			err := sc.service.ConnectElementsToDashboard(sc.reqContext.Req.Context(), sc.reqContext.SignedInUser, []string{sc.initialResult.Result.UID}, dashInDB.ID)
 			require.NoError(t, err)
@@ -99,6 +100,7 @@ func TestDeleteLibraryPanelsInFolder(t *testing.T) {
 
 	scenarioWithPanel(t, "When an admin tries to delete a folder that contains disconnected elements, it should delete all disconnected elements too",
 		func(t *testing.T, sc scenarioContext) {
+			// nolint:staticcheck
 			command := getCreateVariableCommand(sc.folder.ID, "query0")
 			sc.reqContext.Req.Body = mockRequestBody(command)
 			resp := sc.service.createHandler(sc.reqContext)
@@ -156,6 +158,7 @@ func TestGetLibraryPanelConnections(t *testing.T) {
 				Title: "Testing GetLibraryPanelConnections",
 				Data:  simplejson.NewFromAny(dashJSON),
 			}
+			// nolint:staticcheck
 			dashInDB := createDashboard(t, sc.sqlStore, sc.user, &dash, sc.folder.ID)
 			err := sc.service.ConnectElementsToDashboard(sc.reqContext.Req.Context(), sc.reqContext.SignedInUser, []string{sc.initialResult.Result.UID}, dashInDB.ID)
 			require.NoError(t, err)
@@ -387,6 +390,7 @@ func scenarioWithPanel(t *testing.T, desc string, fn func(t *testing.T, sc scena
 	guardian.InitAccessControlGuardian(sqlStore.Cfg, ac, dashboardService)
 
 	testScenario(t, desc, func(t *testing.T, sc scenarioContext) {
+		// nolint:staticcheck
 		command := getCreatePanelCommand(sc.folder.ID, "Text - Library Panel")
 		sc.reqContext.Req.Body = mockRequestBody(command)
 		resp := sc.service.createHandler(sc.reqContext)

--- a/pkg/services/librarypanels/librarypanels.go
+++ b/pkg/services/librarypanels/librarypanels.go
@@ -193,7 +193,7 @@ func (lps LibraryPanelService) CountInFolder(ctx context.Context, orgID int64, f
 		if err != nil {
 			return err
 		}
-
+		// nolint:staticcheck
 		q := sess.Table("library_element").Where("org_id = ?", u.GetOrgID()).
 			Where("folder_id = ?", folder.ID).Where("kind = ?", int64(model.PanelElement))
 		count, err = q.Count()

--- a/pkg/services/librarypanels/librarypanels_test.go
+++ b/pkg/services/librarypanels/librarypanels_test.go
@@ -80,6 +80,7 @@ func TestConnectLibraryPanelsForDashboard(t *testing.T) {
 				Title: "Testing ConnectLibraryPanelsForDashboard",
 				Data:  simplejson.NewFromAny(dashJSON),
 			}
+			// nolint:staticcheck
 			dashInDB := createDashboard(t, sc.sqlStore, sc.user, &dash, sc.folder.ID)
 
 			err := sc.service.ConnectLibraryPanelsForDashboard(sc.ctx, sc.user, dashInDB)
@@ -178,6 +179,7 @@ func TestConnectLibraryPanelsForDashboard(t *testing.T) {
 				Title: "Testing ConnectLibraryPanelsForDashboard",
 				Data:  simplejson.NewFromAny(dashJSON),
 			}
+			// nolint:staticcheck
 			dashInDB := createDashboard(t, sc.sqlStore, sc.user, &dash, sc.folder.ID)
 
 			err = sc.service.ConnectLibraryPanelsForDashboard(sc.ctx, sc.user, dashInDB)
@@ -224,6 +226,7 @@ func TestConnectLibraryPanelsForDashboard(t *testing.T) {
 				Title: "Testing ConnectLibraryPanelsForDashboard",
 				Data:  simplejson.NewFromAny(dashJSON),
 			}
+			// nolint:staticcheck
 			dashInDB := createDashboard(t, sc.sqlStore, sc.user, &dash, sc.folder.ID)
 
 			err := sc.service.ConnectLibraryPanelsForDashboard(sc.ctx, sc.user, dashInDB)
@@ -280,6 +283,7 @@ func TestConnectLibraryPanelsForDashboard(t *testing.T) {
 				Title: "Testing ConnectLibraryPanelsForDashboard",
 				Data:  simplejson.NewFromAny(dashJSON),
 			}
+			// nolint:staticcheck
 			dashInDB := createDashboard(t, sc.sqlStore, sc.user, &dash, sc.folder.ID)
 			err = sc.elementService.ConnectElementsToDashboard(sc.ctx, sc.user, []string{sc.initialResult.Result.UID}, dashInDB.ID)
 			require.NoError(t, err)
@@ -429,6 +433,7 @@ func TestImportLibraryPanelsForDashboard(t *testing.T) {
 				model.GetLibraryElementCommand{UID: existingUID, FolderName: dashboards.RootFolderName})
 			require.NoError(t, err)
 
+			// nolint:staticcheck
 			err = sc.service.ImportLibraryPanelsForDashboard(sc.ctx, sc.user, simplejson.New(), panels, sc.folder.ID)
 			require.NoError(t, err)
 
@@ -880,7 +885,7 @@ func testScenario(t *testing.T, desc string, fn func(t *testing.T, sc scenarioCo
 
 		foldr := createFolder(t, sc, "ScenarioFolder")
 		sc.folder = &folder.Folder{
-			ID:        foldr.ID,
+			ID:        foldr.ID, // nolint:staticcheck
 			UID:       foldr.UID,
 			Title:     foldr.Title,
 			URL:       dashboards.GetFolderURL(foldr.UID, slugify.Slugify(foldr.Title)),

--- a/pkg/services/ngalert/api/api_ruler.go
+++ b/pkg/services/ngalert/api/api_ruler.go
@@ -161,6 +161,7 @@ func (srv RulerSrv) RouteGetNamespaceRulesConfig(c *contextmodel.ReqContext, nam
 	result := apimodels.NamespaceConfigResponse{}
 
 	for groupKey, rules := range ruleGroups {
+		// nolint:staticcheck
 		result[namespaceTitle] = append(result[namespaceTitle], toGettableRuleGroupConfig(groupKey.RuleGroup, rules, namespace.ID, provenanceRecords))
 	}
 
@@ -190,6 +191,7 @@ func (srv RulerSrv) RouteGetRulesGroupConfig(c *contextmodel.ReqContext, namespa
 	}
 
 	result := apimodels.RuleGroupConfigResponse{
+		// nolint:staticcheck
 		GettableRuleGroupConfig: toGettableRuleGroupConfig(ruleGroup, rules, namespace.ID, provenanceRecords),
 	}
 	return response.JSON(http.StatusAccepted, result)
@@ -239,6 +241,7 @@ func (srv RulerSrv) RouteGetRulesConfig(c *contextmodel.ReqContext) response.Res
 			continue
 		}
 		namespace := folder.Title
+		// nolint:staticcheck
 		result[namespace] = append(result[namespace], toGettableRuleGroupConfig(groupKey.RuleGroup, rules, folder.ID, provenanceRecords))
 	}
 	return response.JSON(http.StatusOK, result)

--- a/pkg/services/ngalert/api/api_ruler_validation_test.go
+++ b/pkg/services/ngalert/api/api_ruler_validation_test.go
@@ -85,7 +85,7 @@ func validGroup(cfg *setting.UnifiedAlertingSettings, rules ...apimodels.Postabl
 
 func randFolder() *folder.Folder {
 	return &folder.Folder{
-		ID:    rand.Int63(),
+		ID:    rand.Int63(), // nolint:staticcheck
 		UID:   util.GenerateShortUID(),
 		Title: "TEST-FOLDER-" + util.GenerateShortUID(),
 		// URL:       "",

--- a/pkg/services/ngalert/migration/permissions.go
+++ b/pkg/services/ngalert/migration/permissions.go
@@ -103,6 +103,7 @@ func (om *OrgMigration) getOrCreateMigratedFolder(ctx context.Context, l log.Log
 
 	// Check if the dashboard has custom permissions. If it does, we need to create a new folder for it.
 	// This folder will be cached for re-use for each dashboard in the folder with the same permissions.
+	// nolint:staticcheck
 	permissionsToFolder, ok := om.permissionsMap[parentFolder.ID]
 	if !ok {
 		permissionsToFolder = make(map[permissionHash]*folder.Folder)

--- a/pkg/services/ngalert/ngalert_test.go
+++ b/pkg/services/ngalert/ngalert_test.go
@@ -26,7 +26,7 @@ import (
 func Test_subscribeToFolderChanges(t *testing.T) {
 	orgID := rand.Int63()
 	folder := &folder.Folder{
-		ID:    0,
+		ID:    0, // nolint:staticcheck
 		UID:   util.GenerateShortUID(),
 		Title: "Folder" + util.GenerateShortUID(),
 	}
@@ -42,7 +42,7 @@ func Test_subscribeToFolderChanges(t *testing.T) {
 	err := bus.Publish(context.Background(), &events.FolderTitleUpdated{
 		Timestamp: time.Now(),
 		Title:     "Folder" + util.GenerateShortUID(),
-		ID:        folder.ID,
+		ID:        folder.ID, // nolint:staticcheck
 		UID:       folder.UID,
 		OrgID:     orgID,
 	})

--- a/pkg/services/ngalert/store/alert_rule.go
+++ b/pkg/services/ngalert/store/alert_rule.go
@@ -458,7 +458,7 @@ func (st DBstore) GetUserVisibleNamespaces(ctx context.Context, orgID int64, use
 				continue
 			}
 			namespaceMap[hit.UID] = &folder.Folder{
-				ID:    hit.ID,
+				ID:    hit.ID, // nolint:staticcheck
 				UID:   hit.UID,
 				Title: hit.Title,
 			}

--- a/pkg/services/ngalert/store/deltas_test.go
+++ b/pkg/services/ngalert/store/deltas_test.go
@@ -457,7 +457,7 @@ func withUIDs(uids map[string]*models.AlertRule) func(rule *models.AlertRule) {
 
 func randFolder() *folder.Folder {
 	return &folder.Folder{
-		ID:        rand.Int63(),
+		ID:        rand.Int63(), // nolint:staticcheck
 		UID:       util.GenerateShortUID(),
 		Title:     "TEST-FOLDER-" + util.GenerateShortUID(),
 		URL:       "",

--- a/pkg/services/ngalert/tests/fakes/rules.go
+++ b/pkg/services/ngalert/tests/fakes/rules.go
@@ -68,7 +68,7 @@ mainloop:
 		}
 		if existing == nil {
 			folders = append(folders, &folder.Folder{
-				ID:    rand.Int63(),
+				ID:    rand.Int63(), // nolint:staticcheck
 				UID:   r.NamespaceUID,
 				Title: "TEST-FOLDER-" + util.GenerateShortUID(),
 			})


### PR DESCRIPTION
Deprecate `ID` in `Folder` struct. Part of a series of PRs to deprecate sequential folder IDs.

Ref https://github.com/grafana/grafana/issues/61232