### PR TITLE
SaveDashboardPrompt: Reduce time to open drawer when many changes applied

### DIFF
--- a/public/app/features/dashboard/components/GenAI/GenAIButton.test.tsx
+++ b/public/app/features/dashboard/components/GenAI/GenAIButton.test.tsx
@@ -13,6 +13,7 @@ import { EventTrackingSrc } from './tracking';
 import { Role } from './utils';
 
 const mockedUseOpenAiStreamState = {
+  messages: [],
   setMessages: jest.fn(),
   reply: 'I am a robot',
   streamStatus: StreamStatus.IDLE,
@@ -43,6 +44,7 @@ describe('GenAIButton', () => {
   describe('when LLM plugin is not configured', () => {
     beforeAll(() => {
       jest.mocked(useOpenAIStream).mockReturnValue({
+        messages: [],
         error: undefined,
         streamStatus: StreamStatus.IDLE,
         reply: 'Some completed genereated text',
@@ -66,7 +68,11 @@ describe('GenAIButton', () => {
     const setMessagesMock = jest.fn();
     const setShouldStopMock = jest.fn();
     beforeEach(() => {
+      setMessagesMock.mockClear();
+      setShouldStopMock.mockClear();
+
       jest.mocked(useOpenAIStream).mockReturnValue({
+        messages: [],
         error: undefined,
         streamStatus: StreamStatus.IDLE,
         reply: 'Some completed genereated text',
@@ -103,6 +109,20 @@ describe('GenAIButton', () => {
       expect(setMessagesMock).toHaveBeenCalledWith([{ content: 'Generate X', role: 'system' as Role }]);
     });
 
+    it('should call the messages when they are provided as callback', async () => {
+      const onGenerate = jest.fn();
+      const messages = jest.fn().mockReturnValue([{ content: 'Generate X', role: 'system' as Role }]);
+      const onClick = jest.fn();
+      setup({ onGenerate, messages, temperature: 3, onClick, eventTrackingSrc });
+
+      const generateButton = await screen.findByRole('button');
+      await fireEvent.click(generateButton);
+
+      expect(messages).toHaveBeenCalledTimes(1);
+      expect(setMessagesMock).toHaveBeenCalledTimes(1);
+      expect(setMessagesMock).toHaveBeenCalledWith([{ content: 'Generate X', role: 'system' as Role }]);
+    });
+
     it('should call the onClick callback', async () => {
       const onGenerate = jest.fn();
       const onClick = jest.fn();
@@ -121,6 +141,7 @@ describe('GenAIButton', () => {
 
     beforeEach(() => {
       jest.mocked(useOpenAIStream).mockReturnValue({
+        messages: [],
         error: undefined,
         streamStatus: StreamStatus.GENERATING,
         reply: 'Some incomplete generated text',
@@ -177,7 +198,11 @@ describe('GenAIButton', () => {
     const setMessagesMock = jest.fn();
     const setShouldStopMock = jest.fn();
     beforeEach(() => {
+      setMessagesMock.mockClear();
+      setShouldStopMock.mockClear();
+
       jest.mocked(useOpenAIStream).mockReturnValue({
+        messages: [],
         error: new Error('Something went wrong'),
         streamStatus: StreamStatus.IDLE,
         reply: '',
@@ -241,6 +266,20 @@ describe('GenAIButton', () => {
       await fireEvent.click(generateButton);
 
       await waitFor(() => expect(onClick).toHaveBeenCalledTimes(1));
+    });
+
+    it('should call the messages when they are provided as callback', async () => {
+      const onGenerate = jest.fn();
+      const messages = jest.fn().mockReturnValue([{ content: 'Generate X', role: 'system' as Role }]);
+      const onClick = jest.fn();
+      setup({ onGenerate, messages, temperature: 3, onClick, eventTrackingSrc });
+
+      const generateButton = await screen.findByRole('button');
+      await fireEvent.click(generateButton);
+
+      expect(messages).toHaveBeenCalledTimes(1);
+      expect(setMessagesMock).toHaveBeenCalledTimes(1);
+      expect(setMessagesMock).toHaveBeenCalledWith([{ content: 'Generate X', role: 'system' as Role }]);
     });
   });
 });

--- a/public/app/features/dashboard/components/GenAI/GenAIButton.tsx
+++ b/public/app/features/dashboard/components/GenAI/GenAIButton.tsx
@@ -16,7 +16,7 @@ export interface GenAIButtonProps {
   // Button click handler
   onClick?: (e: React.MouseEvent<HTMLButtonElement>) => void;
   // Messages to send to the LLM plugin
-  messages: Message[];
+  messages: Message[] | (() => Message[]);
   // Callback function that the LLM plugin streams responses to
   onGenerate: (response: string) => void;
   // Temperature for the LLM plugin. Default is 1.
@@ -43,7 +43,15 @@ export const GenAIButton = ({
 }: GenAIButtonProps) => {
   const styles = useStyles2(getStyles);
 
-  const { setMessages, setStopGeneration, reply, value, error, streamStatus } = useOpenAIStream(model, temperature);
+  const {
+    messages: streamMessages,
+    setMessages,
+    setStopGeneration,
+    reply,
+    value,
+    error,
+    streamStatus,
+  } = useOpenAIStream(model, temperature);
 
   const [history, setHistory] = useState<string[]>([]);
   const [showHistory, setShowHistory] = useState(true);
@@ -59,7 +67,7 @@ export const GenAIButton = ({
     } else {
       if (!hasHistory) {
         onClickProp?.(e);
-        setMessages(messages);
+        setMessages(typeof messages === 'function' ? messages() : messages);
       } else {
         if (setShowHistory) {
           setShowHistory(true);
@@ -161,7 +169,7 @@ export const GenAIButton = ({
           content={
             <GenAIHistory
               history={history}
-              messages={messages}
+              messages={streamMessages}
               onApplySuggestion={onApplySuggestion}
               updateHistory={pushHistoryEntry}
               eventTrackingSrc={eventTrackingSrc}

--- a/public/app/features/dashboard/components/GenAI/GenAIDashboardChangesButton.tsx
+++ b/public/app/features/dashboard/components/GenAI/GenAIDashboardChangesButton.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo } from 'react';
+import React, { useCallback } from 'react';
 
 import { DashboardModel } from '../../state';
 
@@ -35,7 +35,7 @@ const CHANGES_GENERATION_POSTFIX_PROMPT = [
 ].join('.\n');
 
 export const GenAIDashboardChangesButton = ({ dashboard, onGenerate, disabled }: GenAIDashboardChangesButtonProps) => {
-  const messages = useMemo(() => getMessages(dashboard), [dashboard]);
+  const messages = useCallback(() => getMessages(dashboard), [dashboard]);
 
   return (
     <GenAIButton

--- a/public/app/features/dashboard/components/GenAI/hooks.ts
+++ b/public/app/features/dashboard/components/GenAI/hooks.ts
@@ -27,6 +27,7 @@ export function useOpenAIStream(
 ): {
   setMessages: React.Dispatch<React.SetStateAction<Message[]>>;
   setStopGeneration: React.Dispatch<React.SetStateAction<boolean>>;
+  messages: Message[];
   reply: string;
   streamStatus: StreamStatus;
   error: Error | undefined;
@@ -154,6 +155,7 @@ export function useOpenAIStream(
   return {
     setMessages,
     setStopGeneration,
+    messages,
     reply,
     streamStatus,
     error,


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

These changes improve the performance when clicking on the save toolbar button to open the drawer. Because the Auto-generate button was pre-generating messages based on changes no matter if the LLM plugin is enabled or not, the drawer was taking a long time for no reason. 

Now, the button support receives the `messages` prop as a callback, so the component consumer can decide when to compose the messages, at rendering time or when clicking.

**Why do we need this feature?**

For long dashboards, when a change is made, generating the messages gets very expensive, and this blocks the drawer for some seconds before is displayed.

![Performance monitoring showing the time it takes generating the messages](https://github.com/grafana/grafana/assets/5699976/9fa4a1fd-e768-45ba-90e2-acf13668037f)

**Who is this feature for?**
This applies to any version after 10.2.0 where the `dasghgpt` feature toggle is enabled by default.


**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #78234

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.