### PR TITLE
fix: Add vendored dependencies to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -48,6 +48,9 @@ WORKDIR /tmp/grafana
 COPY go.* ./
 COPY .bingo .bingo
 
+# Include vendored dependencies
+COPY pkg/util/xorm/go.* pkg/util/xorm/
+
 RUN go mod download
 RUN if [[ "$BINGO" = "true" ]]; then \
       go install github.com/bwplotka/bingo@latest && \


### PR DESCRIPTION
Running `make build-docker-full` fails because `pkg/util/xorm/go.mod` is not copied to the docker image before running `go mod download` when building. This provides a fix.

Related to https://github.com/grafana/grafana/pull/77388