### PR TITLE
[v10.2.x] CI: Test backend on feature-toggles documentation changes

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -365,6 +365,7 @@ trigger:
     - go.sum
     - go.mod
     - public/app/plugins/**/plugin.json
+    - docs/sources/setup-grafana/configure-grafana/feature-toggles/**
     - devenv/**
 type: docker
 volumes:
@@ -4646,6 +4647,6 @@ kind: secret
 name: gcr_credentials
 ---
 kind: signature
-hmac: 91bdf33c65b3a12b92d5990a6843c4e7d6ab35fd77b4ccf64da7cc8594917c45
+hmac: 4c7b649577b838d8f6590b14b52fe6b7d19859f69f70f51ea22acbe4f6c8ea5d
 
 ...

--- a/scripts/drone/events/pr.star
+++ b/scripts/drone/events/pr.star
@@ -99,6 +99,7 @@ def pr_pipelines():
                     "go.sum",
                     "go.mod",
                     "public/app/plugins/**/plugin.json",
+                    "docs/sources/setup-grafana/configure-grafana/feature-toggles/**",
                     "devenv/**",
                 ],
             ),


### PR DESCRIPTION
Backport d78b3fea2f9d8b6ca426bda631bcd776df31e4ee from #78177

---

This is something that we've now run into at least twice where the documentation was fixed but there was now drift between it and the the docstrings in the feature-toggles themselves. The goal of this PR is to also run the backend tests when the feature-toggle documentation changes in order to catch that drift.
