### PR TITLE
[v10.1.x] CI: Test backend on feature-toggles documentation changes

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -365,6 +365,7 @@ trigger:
     - go.sum
     - go.mod
     - public/app/plugins/**/plugin.json
+    - docs/sources/setup-grafana/configure-grafana/feature-toggles/**
     - devenv/**
 type: docker
 volumes:
@@ -4611,6 +4612,6 @@ kind: secret
 name: gcr_credentials
 ---
 kind: signature
-hmac: c092214746f21d38c59a37e82298ae7fe1af9ab0b651df3b7ea83938798dcc8c
+hmac: 36f0250ca4de288c8514654343ba64b35374893ebae83912b7cb3631096be602
 
 ...

--- a/scripts/drone/events/pr.star
+++ b/scripts/drone/events/pr.star
@@ -99,6 +99,7 @@ def pr_pipelines():
                     "go.sum",
                     "go.mod",
                     "public/app/plugins/**/plugin.json",
+                    "docs/sources/setup-grafana/configure-grafana/feature-toggles/**",
                     "devenv/**",
                 ],
             ),


### PR DESCRIPTION
Backport d78b3fea2f9d8b6ca426bda631bcd776df31e4ee from #78177

---

This is something that we've now run into at least twice where the documentation was fixed but there was now drift between it and the the docstrings in the feature-toggles themselves. The goal of this PR is to also run the backend tests when the feature-toggle documentation changes in order to catch that drift.
