### PR TITLE
[v10.0.x] CI: Test backend on feature-toggles documentation changes

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -350,6 +350,7 @@ trigger:
     - go.sum
     - go.mod
     - public/app/plugins/**/plugin.json
+    - docs/sources/setup-grafana/configure-grafana/feature-toggles/**
     - devenv/**
 type: docker
 volumes:
@@ -4573,6 +4574,6 @@ kind: secret
 name: gcr_credentials
 ---
 kind: signature
-hmac: 317357c169e0d0b857d21f215664d5d0ef4c01585691c48281a18bdec54b974d
+hmac: bd4667bdf07e27acd72af16f7c115137248fa3acbf414d3f055123d461f236bf
 
 ...

--- a/scripts/drone/events/pr.star
+++ b/scripts/drone/events/pr.star
@@ -99,6 +99,7 @@ def pr_pipelines():
                     "go.sum",
                     "go.mod",
                     "public/app/plugins/**/plugin.json",
+                    "docs/sources/setup-grafana/configure-grafana/feature-toggles/**",
                     "devenv/**",
                 ],
             ),


### PR DESCRIPTION
Backport d78b3fea2f9d8b6ca426bda631bcd776df31e4ee from #78177

---

This is something that we've now run into at least twice where the documentation was fixed but there was now drift between it and the the docstrings in the feature-toggles themselves. The goal of this PR is to also run the backend tests when the feature-toggle documentation changes in order to catch that drift.
