### PR TITLE
Sandbox: Disable incident app inside the sandbox code

### DIFF
--- a/public/app/features/plugins/sandbox/utils.ts
+++ b/public/app/features/plugins/sandbox/utils.ts
@@ -38,6 +38,8 @@ export function logError(error: Error, context?: LogContext) {
   logErrorRuntime(error, context);
 }
 
+const pluginsDisableList = ['grafana-incident-app'];
+
 export function isFrontendSandboxSupported({
   isAngular,
   pluginId,
@@ -47,7 +49,8 @@ export function isFrontendSandboxSupported({
 }): boolean {
   // To fast test and debug the sandbox in the browser.
   const sandboxQueryParam = location.search.includes('nosandbox') && config.buildInfo.env === 'development';
-  const isPluginExcepted = config.disableFrontendSandboxForPlugins.includes(pluginId);
+  const isPluginExcepted =
+    config.disableFrontendSandboxForPlugins.includes(pluginId) || pluginsDisableList.includes(pluginId);
   return (
     !isAngular &&
     Boolean(config.featureToggles.pluginsFrontendSandbox) &&


### PR DESCRIPTION
**What is this feature?**

Disables the frontend sandbox for grafana-incident-app

**Why do we need this feature?**

The incident app is not working properly inside the sandbox

**Who is this feature for?**

grafana-incident-app

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:

- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
