### PR TITLE
[v10.2.2] SaveDashboardPrompt: Reduce time to open drawer when many changes applied

### DIFF
--- a/public/app/features/dashboard/components/GenAI/GenAIButton.test.tsx
+++ b/public/app/features/dashboard/components/GenAI/GenAIButton.test.tsx
@@ -67,7 +67,6 @@ describe('GenAIButton', () => {
     const setMessagesMock = jest.fn();
     beforeEach(() => {
       setMessagesMock.mockClear();
-      setShouldStopMock.mockClear();
 
       jest.mocked(useOpenAIStream).mockReturnValue({
         messages: [],
@@ -182,7 +181,6 @@ describe('GenAIButton', () => {
     const setMessagesMock = jest.fn();
     beforeEach(() => {
       setMessagesMock.mockClear();
-      setShouldStopMock.mockClear();
 
       jest.mocked(useOpenAIStream).mockReturnValue({
         messages: [],

--- a/public/app/features/dashboard/components/GenAI/GenAIButton.tsx
+++ b/public/app/features/dashboard/components/GenAI/GenAIButton.tsx
@@ -18,7 +18,7 @@ export interface GenAIButtonProps {
   // Button click handler
   onClick?: (e: React.MouseEvent<HTMLButtonElement>) => void;
   // Messages to send to the LLM plugin
-  messages: Message[];
+  messages: Message[] | (() => Message[]);
   // Callback function that the LLM plugin streams responses to
   onGenerate: (response: string) => void;
   // Temperature for the LLM plugin. Default is 1.
@@ -43,8 +43,14 @@ export const GenAIButton = ({
 }: GenAIButtonProps) => {
   const styles = useStyles2(getStyles);
 
-  const { setMessages, reply, value, error, streamStatus } = useOpenAIStream(OPEN_AI_MODEL, temperature);
-
+  const {
+    messages: streamMessages,
+    setMessages,
+    reply,
+    value,
+    error,
+    streamStatus,
+  } = useOpenAIStream(OPEN_AI_MODEL, temperature);
   const [history, setHistory] = useState<string[]>([]);
   const [showHistory, setShowHistory] = useState(true);
 
@@ -56,7 +62,7 @@ export const GenAIButton = ({
   const onClick = (e: React.MouseEvent<HTMLButtonElement>) => {
     if (!hasHistory) {
       onClickProp?.(e);
-      setMessages(messages);
+      setMessages(typeof messages === 'function' ? messages() : messages);
     } else {
       if (setShowHistory) {
         setShowHistory(true);
@@ -154,7 +160,7 @@ export const GenAIButton = ({
           content={
             <GenAIHistory
               history={history}
-              messages={messages}
+              messages={streamMessages}
               onApplySuggestion={onApplySuggestion}
               updateHistory={pushHistoryEntry}
               eventTrackingSrc={eventTrackingSrc}

--- a/public/app/features/dashboard/components/GenAI/GenAIDashboardChangesButton.tsx
+++ b/public/app/features/dashboard/components/GenAI/GenAIDashboardChangesButton.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo } from 'react';
+import React, { useCallback } from 'react';
 
 import { DashboardModel } from '../../state';
 
@@ -27,7 +27,7 @@ const CHANGES_GENERATION_STANDARD_PROMPT = [
 ].join('.\n');
 
 export const GenAIDashboardChangesButton = ({ dashboard, onGenerate, disabled }: GenAIDashboardChangesButtonProps) => {
-  const messages = useMemo(() => getMessages(dashboard), [dashboard]);
+  const messages = useCallback(() => getMessages(dashboard), [dashboard]);
 
   return (
     <GenAIButton

--- a/public/app/features/dashboard/components/GenAI/hooks.ts
+++ b/public/app/features/dashboard/components/GenAI/hooks.ts
@@ -26,6 +26,7 @@ export function useOpenAIStream(
   temperature = 1
 ): {
   setMessages: React.Dispatch<React.SetStateAction<Message[]>>;
+  messages: Message[];
   reply: string;
   streamStatus: StreamStatus;
   error: Error | undefined;
@@ -138,6 +139,7 @@ export function useOpenAIStream(
 
   return {
     setMessages,
+    messages,
     reply,
     streamStatus,
     error,


### PR DESCRIPTION
Backport f32f8a160eca77a909a1195eaf8ca94f15e5f08c from #78283

---

<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

These changes improve the performance when clicking on the save toolbar button to open the drawer. Because the Auto-generate button was pre-generating messages based on changes no matter if the LLM plugin is enabled or not, the drawer was taking a long time for no reason. 

Now, the button support receives the `messages` prop as a callback, so the component consumer can decide when to compose the messages, at rendering time or when clicking.

**Why do we need this feature?**

For long dashboards, when a change is made, generating the messages gets very expensive, and this blocks the drawer for some seconds before is displayed.

![Performance monitoring showing the time it takes generating the messages](https://github.com/grafana/grafana/assets/5699976/9fa4a1fd-e768-45ba-90e2-acf13668037f)

**Who is this feature for?**
This applies to any version after 10.2.0 where the `dasghgpt` feature toggle is enabled by default.


**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #78234

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
