### PR TITLE
Avatar: Allow browser caching of /avatar/

### DIFF
--- a/pkg/middleware/middleware.go
+++ b/pkg/middleware/middleware.go
@@ -48,6 +48,7 @@ func AddDefaultResponseHeaders(cfg *setting.Cfg) web.Handler {
 			_, _, resourceURLMatch := t.Match(c.Req.URL.Path)
 			resourceCachable := resourceURLMatch && allowCacheControl(c.Resp)
 			if !strings.HasPrefix(c.Req.URL.Path, "/public/plugins/") &&
+				!strings.HasPrefix(c.Req.URL.Path, "/avatar/") &&
 				!strings.HasPrefix(c.Req.URL.Path, "/api/datasources/proxy/") && !resourceCachable {
 				addNoCacheHeaders(c.Resp)
 			}


### PR DESCRIPTION

**What is this feature?**

This let's the browser cache the avatar.

**Why do we need this feature?**
![image](https://github.com/grafana/grafana/assets/468940/e3523350-99d6-48b5-ba1a-bda46d012795)

When a frontend component containing an avatar is redrawn, this causes the avatar to be fetched again. This is especially problematic on the admin/users page where each avatar can be fetched multiple times from a single user action, 8 times in the screenshot. The page is made up of 30 users which adds up to > 200 requests to the avatar endpoint in this case.

The avatar handler sets the Cache-Control header, which is later removed by the middleware. This PR exempts any /avatar/* url from the addNoCacheHeaders in the middleware.