### PR TITLE
Logs: create DataSourceWithQueryModificationSupport + determine popover menu support

### DIFF
--- a/packages/grafana-data/src/types/datasource.ts
+++ b/packages/grafana-data/src/types/datasource.ts
@@ -8,7 +8,6 @@ import { AnnotationEvent, AnnotationQuery, AnnotationSupport } from './annotatio
 import { CoreApp } from './app';
 import { KeyValue, LoadingState, TableData, TimeSeries } from './data';
 import { DataFrame, DataFrameDTO } from './dataFrame';
-import { QueryFixAction } from './logs';
 import { PanelData } from './panel';
 import { GrafanaPlugin, PluginMeta } from './plugin';
 import { DataQuery } from './query';
@@ -579,6 +578,14 @@ export interface QueryFix {
   title?: string;
   label: string;
   action?: QueryFixAction;
+}
+
+export type QueryFixType = 'ADD_FILTER' | 'ADD_FILTER_OUT' | 'ADD_STRING_FILTER' | 'ADD_STRING_FILTER_OUT';
+export interface QueryFixAction {
+  type: QueryFixType | string;
+  query?: string;
+  preventSubmit?: boolean;
+  options?: KeyValue<string>;
 }
 
 export interface QueryHint {

--- a/packages/grafana-data/src/types/datasource.ts
+++ b/packages/grafana-data/src/types/datasource.ts
@@ -8,6 +8,7 @@ import { AnnotationEvent, AnnotationQuery, AnnotationSupport } from './annotatio
 import { CoreApp } from './app';
 import { KeyValue, LoadingState, TableData, TimeSeries } from './data';
 import { DataFrame, DataFrameDTO } from './dataFrame';
+import { QueryFixAction } from './logs';
 import { PanelData } from './panel';
 import { GrafanaPlugin, PluginMeta } from './plugin';
 import { DataQuery } from './query';
@@ -578,13 +579,6 @@ export interface QueryFix {
   title?: string;
   label: string;
   action?: QueryFixAction;
-}
-
-export interface QueryFixAction {
-  type: string;
-  query?: string;
-  preventSubmit?: boolean;
-  options?: KeyValue<string>;
 }
 
 export interface QueryHint {

--- a/packages/grafana-data/src/types/logs.ts
+++ b/packages/grafana-data/src/types/logs.ts
@@ -4,7 +4,7 @@ import { DataQuery } from '@grafana/schema';
 
 import { KeyValue, Labels } from './data';
 import { DataFrame } from './dataFrame';
-import { DataQueryRequest, DataQueryResponse, QueryFixAction } from './datasource';
+import { DataQueryRequest, DataQueryResponse, QueryFixAction, QueryFixType } from './datasource';
 import { AbsoluteTimeRange } from './time';
 export { LogsDedupStrategy, LogsSortOrder } from '@grafana/schema';
 
@@ -319,7 +319,7 @@ export interface DataSourceWithQueryModificationSupport<TQuery extends DataQuery
   /**
    * Returns a list of supported action types for `modifyQuery()`.
    */
-  getSupportedQueryModifications(): string[];
+  getSupportedQueryModifications(): Array<QueryFixType | String>;
 }
 
 /**

--- a/packages/grafana-data/src/types/logs.ts
+++ b/packages/grafana-data/src/types/logs.ts
@@ -4,7 +4,7 @@ import { DataQuery } from '@grafana/schema';
 
 import { KeyValue, Labels } from './data';
 import { DataFrame } from './dataFrame';
-import { DataQueryRequest, DataQueryResponse } from './datasource';
+import { DataQueryRequest, DataQueryResponse, QueryFixAction } from './datasource';
 import { AbsoluteTimeRange } from './time';
 export { LogsDedupStrategy, LogsSortOrder } from '@grafana/schema';
 
@@ -298,14 +298,6 @@ export const hasToggleableQueryFiltersSupport = <TQuery extends DataQuery>(
     'queryHasFilter' in datasource
   );
 };
-
-export type QueryFixType = 'ADD_FILTER' | 'ADD_FILTER_OUT' | 'ADD_STRING_FILTER' | 'ADD_STRING_FILTER_OUT';
-export interface QueryFixAction {
-  type: QueryFixType | string;
-  query?: string;
-  preventSubmit?: boolean;
-  options?: KeyValue<string>;
-}
 
 /**
  * Data sources that support query modification actions from Log Details (ADD_FILTER, ADD_FILTER_OUT),

--- a/packages/grafana-data/src/types/logs.ts
+++ b/packages/grafana-data/src/types/logs.ts
@@ -4,7 +4,7 @@ import { DataQuery } from '@grafana/schema';
 
 import { KeyValue, Labels } from './data';
 import { DataFrame } from './dataFrame';
-import { DataQueryRequest, DataQueryResponse } from './datasource';
+import { DataQueryRequest, DataQueryResponse, QueryFixAction } from './datasource';
 import { AbsoluteTimeRange } from './time';
 export { LogsDedupStrategy, LogsSortOrder } from '@grafana/schema';
 
@@ -283,6 +283,23 @@ export interface DataSourceWithToggleableQueryFiltersSupport<TQuery extends Data
    * Given a query, determine if it has a filter that matches the options.
    */
   queryHasFilter(query: TQuery, filter: QueryFilterOptions): boolean;
+}
+
+export interface DataSourceWithQueryModificationSupportSupport<TQuery extends DataQuery> {
+  /**
+   * Given a query, applies a query modification `action`, returning the updated query.
+   * Explore currently supports the following action types:
+   * - ADD_FILTER: adds a <key, value> filter to the query.
+   * - ADD_FILTER_OUT: adds a negative <key, value> filter to the query.
+   * - ADD_STRING_FILTER: adds a string filter to the query.
+   * - ADD_STRING_FILTER_OUT: adds a negative string filter to the query.
+   */
+  modifyQuery(query: TQuery, action: QueryFixAction): TQuery;
+
+  /**
+   * Returns a list of supported action types for `modifyQuery()`.
+   */
+  getSupportedQueryModifications(): string[];
 }
 
 /**

--- a/packages/grafana-data/src/types/logs.ts
+++ b/packages/grafana-data/src/types/logs.ts
@@ -299,7 +299,7 @@ export const hasToggleableQueryFiltersSupport = <TQuery extends DataQuery>(
   );
 };
 
-export interface DataSourceWithQueryModificationSupportSupport<TQuery extends DataQuery> {
+export interface DataSourceWithQueryModificationSupport<TQuery extends DataQuery> {
   /**
    * Given a query, applies a query modification `action`, returning the updated query.
    * Explore currently supports the following action types:
@@ -321,7 +321,7 @@ export interface DataSourceWithQueryModificationSupportSupport<TQuery extends Da
  */
 export const hasQueryModificationSupport = <TQuery extends DataQuery>(
   datasource: unknown
-): datasource is DataSourceWithQueryModificationSupportSupport<TQuery> => {
+): datasource is DataSourceWithQueryModificationSupport<TQuery> => {
   return (
     datasource !== null &&
     typeof datasource === 'object' &&

--- a/packages/grafana-data/src/types/logs.ts
+++ b/packages/grafana-data/src/types/logs.ts
@@ -299,6 +299,12 @@ export const hasToggleableQueryFiltersSupport = <TQuery extends DataQuery>(
   );
 };
 
+/**
+ * Data sources that support query modification actions from Log Details (ADD_FILTER, ADD_FILTER_OUT),
+ * and Popover Menu (ADD_STRING_FILTER, ADD_STRING_FILTER_OUT) in Explore.
+ * @internal
+ * @alpha
+ */
 export interface DataSourceWithQueryModificationSupport<TQuery extends DataQuery> {
   /**
    * Given a query, applies a query modification `action`, returning the updated query.

--- a/packages/grafana-data/src/types/logs.ts
+++ b/packages/grafana-data/src/types/logs.ts
@@ -285,6 +285,20 @@ export interface DataSourceWithToggleableQueryFiltersSupport<TQuery extends Data
   queryHasFilter(query: TQuery, filter: QueryFilterOptions): boolean;
 }
 
+/**
+ * @internal
+ */
+export const hasToggleableQueryFiltersSupport = <TQuery extends DataQuery>(
+  datasource: unknown
+): datasource is DataSourceWithToggleableQueryFiltersSupport<TQuery> => {
+  return (
+    datasource !== null &&
+    typeof datasource === 'object' &&
+    'toggleQueryFilter' in datasource &&
+    'queryHasFilter' in datasource
+  );
+};
+
 export interface DataSourceWithQueryModificationSupportSupport<TQuery extends DataQuery> {
   /**
    * Given a query, applies a query modification `action`, returning the updated query.
@@ -305,13 +319,13 @@ export interface DataSourceWithQueryModificationSupportSupport<TQuery extends Da
 /**
  * @internal
  */
-export const hasToggleableQueryFiltersSupport = <TQuery extends DataQuery>(
+export const hasQueryModificationSupport = <TQuery extends DataQuery>(
   datasource: unknown
-): datasource is DataSourceWithToggleableQueryFiltersSupport<TQuery> => {
+): datasource is DataSourceWithQueryModificationSupportSupport<TQuery> => {
   return (
     datasource !== null &&
     typeof datasource === 'object' &&
-    'toggleQueryFilter' in datasource &&
-    'queryHasFilter' in datasource
+    'modifyQuery' in datasource &&
+    'getSupportedQueryModifications' in datasource
   );
 };

--- a/packages/grafana-data/src/types/logs.ts
+++ b/packages/grafana-data/src/types/logs.ts
@@ -4,7 +4,7 @@ import { DataQuery } from '@grafana/schema';
 
 import { KeyValue, Labels } from './data';
 import { DataFrame } from './dataFrame';
-import { DataQueryRequest, DataQueryResponse, QueryFixAction } from './datasource';
+import { DataQueryRequest, DataQueryResponse } from './datasource';
 import { AbsoluteTimeRange } from './time';
 export { LogsDedupStrategy, LogsSortOrder } from '@grafana/schema';
 
@@ -298,6 +298,14 @@ export const hasToggleableQueryFiltersSupport = <TQuery extends DataQuery>(
     'queryHasFilter' in datasource
   );
 };
+
+export type QueryFixType = 'ADD_FILTER' | 'ADD_FILTER_OUT' | 'ADD_STRING_FILTER' | 'ADD_STRING_FILTER_OUT';
+export interface QueryFixAction {
+  type: QueryFixType | string;
+  query?: string;
+  preventSubmit?: boolean;
+  options?: KeyValue<string>;
+}
 
 /**
  * Data sources that support query modification actions from Log Details (ADD_FILTER, ADD_FILTER_OUT),

--- a/packages/grafana-data/src/types/logs.ts
+++ b/packages/grafana-data/src/types/logs.ts
@@ -292,7 +292,7 @@ export const hasToggleableQueryFiltersSupport = <TQuery extends DataQuery>(
   datasource: unknown
 ): datasource is DataSourceWithToggleableQueryFiltersSupport<TQuery> => {
   return (
-    datasource !== null &&
+    datasource != null &&
     typeof datasource === 'object' &&
     'toggleQueryFilter' in datasource &&
     'queryHasFilter' in datasource
@@ -323,7 +323,7 @@ export const hasQueryModificationSupport = <TQuery extends DataQuery>(
   datasource: unknown
 ): datasource is DataSourceWithQueryModificationSupport<TQuery> => {
   return (
-    datasource !== null &&
+    datasource != null &&
     typeof datasource === 'object' &&
     'modifyQuery' in datasource &&
     'getSupportedQueryModifications' in datasource

--- a/packages/grafana-data/src/types/logs.ts
+++ b/packages/grafana-data/src/types/logs.ts
@@ -319,7 +319,7 @@ export interface DataSourceWithQueryModificationSupport<TQuery extends DataQuery
   /**
    * Returns a list of supported action types for `modifyQuery()`.
    */
-  getSupportedQueryModifications(): Array<QueryFixType | String>;
+  getSupportedQueryModifications(): Array<QueryFixType | string>;
 }
 
 /**

--- a/public/app/features/explore/Logs/LogsContainer.tsx
+++ b/public/app/features/explore/Logs/LogsContainer.tsx
@@ -109,9 +109,7 @@ class LogsContainer extends PureComponent<LogsContainerProps, LogsContainerState
       if (!query.datasource) {
         continue;
       }
-      const mustCheck =
-        !dsInstances[query.refId] ||
-        dsInstances[query.refId].uid !== query.datasource.uid;
+      const mustCheck = !dsInstances[query.refId] || dsInstances[query.refId].uid !== query.datasource.uid;
       if (mustCheck) {
         dsPromises.push(
           new Promise((resolve) => {
@@ -169,7 +167,7 @@ class LogsContainer extends PureComponent<LogsContainerProps, LogsContainerState
     if (!hasLogsContextSupport(ds)) {
       return Promise.resolve([]);
     }
-    
+
     const query = this.getQuery(logsQueries, origRow, ds);
     return query ? ds.getLogRowContext(row, options, query) : Promise.resolve([]);
   };
@@ -223,16 +221,20 @@ class LogsContainer extends PureComponent<LogsContainerProps, LogsContainerState
   };
 
   logDetailsFilterAvailable = () => {
-    return Object.values(this.state.dsInstances).some(ds => ds?.modifyQuery || hasToggleableQueryFiltersSupport(ds));
-  }
-  
+    return Object.values(this.state.dsInstances).some((ds) => ds?.modifyQuery || hasToggleableQueryFiltersSupport(ds));
+  };
+
   filterValueAvailable = () => {
-    return Object.values(this.state.dsInstances).some(ds => hasQueryModificationSupport(ds) && ds?.getSupportedQueryModifications().includes('ADD_STRING_FILTER'));
-  }
+    return Object.values(this.state.dsInstances).some(
+      (ds) => hasQueryModificationSupport(ds) && ds?.getSupportedQueryModifications().includes('ADD_STRING_FILTER')
+    );
+  };
 
   filterOutValueAvailable = () => {
-    return Object.values(this.state.dsInstances).some(ds => hasQueryModificationSupport(ds) && ds?.getSupportedQueryModifications().includes('ADD_STRING_FILTER_OUT'));
-  }
+    return Object.values(this.state.dsInstances).some(
+      (ds) => hasQueryModificationSupport(ds) && ds?.getSupportedQueryModifications().includes('ADD_STRING_FILTER_OUT')
+    );
+  };
 
   render() {
     const {

--- a/public/app/features/explore/Logs/LogsContainer.tsx
+++ b/public/app/features/explore/Logs/LogsContainer.tsx
@@ -77,16 +77,16 @@ class LogsContainer extends PureComponent<LogsContainerProps, LogsContainerState
   };
 
   componentDidMount() {
-    this.checkDataSourcesFeatures();
+    this.updateDataSourceInstances();
   }
 
   componentDidUpdate(prevProps: LogsContainerProps) {
     if (prevProps.logsQueries !== this.props.logsQueries) {
-      this.checkDataSourcesFeatures();
+      this.updateDataSourceInstances();
     }
   }
 
-  private checkDataSourcesFeatures() {
+  private updateDataSourceInstances() {
     const { logsQueries, datasourceInstance } = this.props;
     if (!logsQueries || !datasourceInstance) {
       return;

--- a/public/app/features/explore/Logs/LogsContainer.tsx
+++ b/public/app/features/explore/Logs/LogsContainer.tsx
@@ -221,7 +221,9 @@ class LogsContainer extends PureComponent<LogsContainerProps, LogsContainerState
   };
 
   logDetailsFilterAvailable = () => {
-    return Object.values(this.state.dsInstances).some((ds) => ds?.modifyQuery || hasToggleableQueryFiltersSupport(ds));
+    return Object.values(this.state.dsInstances).some(
+      (ds) => ds?.modifyQuery || hasQueryModificationSupport(ds) || hasToggleableQueryFiltersSupport(ds)
+    );
   };
 
   filterValueAvailable = () => {

--- a/public/app/features/explore/Logs/LogsContainer.tsx
+++ b/public/app/features/explore/Logs/LogsContainer.tsx
@@ -214,7 +214,6 @@ class LogsContainer extends PureComponent<LogsContainerProps, LogsContainerState
     if (!row?.dataFrame.refId || !this.state.dsInstances[row.dataFrame.refId]) {
       return false;
     }
-
     return hasLogsContextSupport(this.state.dsInstances[row.dataFrame.refId]);
   };
 

--- a/public/app/features/logs/components/LogRows.tsx
+++ b/public/app/features/logs/components/LogRows.tsx
@@ -120,17 +120,11 @@ class UnThemedLogRows extends PureComponent<Props, State> {
       popoverMenuCoordinates: { x: e.clientX - parentBounds.left, y: e.clientY - parentBounds.top },
       selectedRow: row,
     });
+    document.addEventListener('click', this.handleDeselection);
     return true;
   };
 
   handleDeselection = (e: Event) => {
-    if (
-      targetIsElement(e.target) &&
-      (e.target?.getAttribute('role') === 'menuitem' || e.target?.parentElement?.getAttribute('role') === 'menuitem')
-    ) {
-      // Delegate closing the menu to the popover component.
-      return;
-    }
     if (targetIsElement(e.target) && !this.logRowsRef.current?.contains(e.target)) {
       // The mouseup event comes from outside the log rows, close the menu.
       this.closePopoverMenu();
@@ -143,6 +137,7 @@ class UnThemedLogRows extends PureComponent<Props, State> {
   };
 
   closePopoverMenu = () => {
+    document.removeEventListener('click', this.handleDeselection);
     this.setState({
       selection: '',
       popoverMenuCoordinates: { x: 0, y: 0 },
@@ -161,11 +156,10 @@ class UnThemedLogRows extends PureComponent<Props, State> {
     } else {
       this.renderAllTimer = window.setTimeout(() => this.setState({ renderAll: true }), 2000);
     }
-    document.addEventListener('mouseup', this.handleDeselection);
   }
 
   componentWillUnmount() {
-    document.removeEventListener('mouseup', this.handleDeselection);
+    document.removeEventListener('click', this.handleDeselection);
     if (this.renderAllTimer) {
       clearTimeout(this.renderAllTimer);
     }

--- a/public/app/plugins/datasource/elasticsearch/datasource.ts
+++ b/public/app/plugins/datasource/elasticsearch/datasource.ts
@@ -965,12 +965,7 @@ export class ElasticDatasource
   }
 
   getSupportedQueryModifications() {
-    return [
-      'ADD_FILTER',
-      'ADD_FILTER_OUT',
-      'ADD_STRING_FILTER',
-      'ADD_STRING_FILTER_OUT',
-    ];
+    return ['ADD_FILTER', 'ADD_FILTER_OUT', 'ADD_STRING_FILTER', 'ADD_STRING_FILTER_OUT'];
   }
 
   addAdHocFilters(query: string, adhocFilters?: AdHocVariableFilter[]) {

--- a/public/app/plugins/datasource/elasticsearch/datasource.ts
+++ b/public/app/plugins/datasource/elasticsearch/datasource.ts
@@ -37,6 +37,7 @@ import {
   ToggleFilterAction,
   DataSourceGetTagValuesOptions,
   AdHocVariableFilter,
+  DataSourceWithQueryModificationSupportSupport,
 } from '@grafana/data';
 import {
   DataSourceWithBackend,
@@ -107,7 +108,8 @@ export class ElasticDatasource
     DataSourceWithLogsContextSupport,
     DataSourceWithQueryImportSupport<ElasticsearchQuery>,
     DataSourceWithSupplementaryQueriesSupport<ElasticsearchQuery>,
-    DataSourceWithToggleableQueryFiltersSupport<ElasticsearchQuery>
+    DataSourceWithToggleableQueryFiltersSupport<ElasticsearchQuery>,
+    DataSourceWithQueryModificationSupportSupport<ElasticsearchQuery>
 {
   basicAuth?: string;
   withCredentials?: boolean;
@@ -960,6 +962,15 @@ export class ElasticDatasource
     }
 
     return { ...query, query: expression };
+  }
+
+  getSupportedQueryModifications() {
+    return [
+      'ADD_FILTER',
+      'ADD_FILTER_OUT',
+      'ADD_STRING_FILTER',
+      'ADD_STRING_FILTER_OUT',
+    ];
   }
 
   addAdHocFilters(query: string, adhocFilters?: AdHocVariableFilter[]) {

--- a/public/app/plugins/datasource/elasticsearch/datasource.ts
+++ b/public/app/plugins/datasource/elasticsearch/datasource.ts
@@ -37,7 +37,7 @@ import {
   ToggleFilterAction,
   DataSourceGetTagValuesOptions,
   AdHocVariableFilter,
-  DataSourceWithQueryModificationSupportSupport,
+  DataSourceWithQueryModificationSupport,
 } from '@grafana/data';
 import {
   DataSourceWithBackend,
@@ -109,7 +109,7 @@ export class ElasticDatasource
     DataSourceWithQueryImportSupport<ElasticsearchQuery>,
     DataSourceWithSupplementaryQueriesSupport<ElasticsearchQuery>,
     DataSourceWithToggleableQueryFiltersSupport<ElasticsearchQuery>,
-    DataSourceWithQueryModificationSupportSupport<ElasticsearchQuery>
+    DataSourceWithQueryModificationSupport<ElasticsearchQuery>
 {
   basicAuth?: string;
   withCredentials?: boolean;

--- a/public/app/plugins/datasource/loki/datasource.ts
+++ b/public/app/plugins/datasource/loki/datasource.ts
@@ -956,8 +956,7 @@ export class LokiDatasource
    * Implemented as part of `DataSourceWithQueryModificationSupport`. Returns a list of operation
    * types that are supported by `modifyQuery()`.
    */
-  getSupportedQueryModifications()
-  {
+  getSupportedQueryModifications() {
     return [
       'ADD_FILTER',
       'ADD_FILTER_OUT',
@@ -968,7 +967,7 @@ export class LokiDatasource
       'ADD_LEVEL_LABEL_FORMAT',
       'ADD_LABEL_FILTER',
       'ADD_STRING_FILTER',
-      'ADD_STRING_FILTER_OUT'
+      'ADD_STRING_FILTER_OUT',
     ];
   }
 

--- a/public/app/plugins/datasource/loki/datasource.ts
+++ b/public/app/plugins/datasource/loki/datasource.ts
@@ -37,7 +37,7 @@ import {
   LegacyMetricFindQueryOptions,
   AdHocVariableFilter,
   urlUtil,
-  DataSourceWithQueryModificationSupportSupport,
+  DataSourceWithQueryModificationSupport,
 } from '@grafana/data';
 import { Duration } from '@grafana/lezer-logql';
 import { BackendSrvRequest, config, DataSourceWithBackend, getTemplateSrv, TemplateSrv } from '@grafana/runtime';
@@ -138,7 +138,7 @@ export class LokiDatasource
     DataSourceWithQueryImportSupport<LokiQuery>,
     DataSourceWithQueryExportSupport<LokiQuery>,
     DataSourceWithToggleableQueryFiltersSupport<LokiQuery>,
-    DataSourceWithQueryModificationSupportSupport<LokiQuery>
+    DataSourceWithQueryModificationSupport<LokiQuery>
 {
   private streams = new LiveStreams();
   private logContextProvider: LogContextProvider;
@@ -866,7 +866,7 @@ export class LokiDatasource
   }
 
   /**
-   * Implemented as part of `DataSourceWithQueryModificationSupportSupport`. Used to modify a query based on the provided action.
+   * Implemented as part of `DataSourceWithQueryModificationSupport`. Used to modify a query based on the provided action.
    * It is used, for example, in the Query Builder to apply hints such as parsers, operations, etc.
    * @returns A new LokiQuery with the specified modification applied.
    */
@@ -953,7 +953,7 @@ export class LokiDatasource
   }
 
   /**
-   * Implemented as part of `DataSourceWithQueryModificationSupportSupport`. Returns a list of operation
+   * Implemented as part of `DataSourceWithQueryModificationSupport`. Returns a list of operation
    * types that are supported by `modifyQuery()`.
    */
   getSupportedQueryModifications()

--- a/public/app/plugins/datasource/loki/datasource.ts
+++ b/public/app/plugins/datasource/loki/datasource.ts
@@ -37,6 +37,7 @@ import {
   LegacyMetricFindQueryOptions,
   AdHocVariableFilter,
   urlUtil,
+  DataSourceWithQueryModificationSupportSupport,
 } from '@grafana/data';
 import { Duration } from '@grafana/lezer-logql';
 import { BackendSrvRequest, config, DataSourceWithBackend, getTemplateSrv, TemplateSrv } from '@grafana/runtime';
@@ -136,7 +137,8 @@ export class LokiDatasource
     DataSourceWithSupplementaryQueriesSupport<LokiQuery>,
     DataSourceWithQueryImportSupport<LokiQuery>,
     DataSourceWithQueryExportSupport<LokiQuery>,
-    DataSourceWithToggleableQueryFiltersSupport<LokiQuery>
+    DataSourceWithToggleableQueryFiltersSupport<LokiQuery>,
+    DataSourceWithQueryModificationSupportSupport<LokiQuery>
 {
   private streams = new LiveStreams();
   private logContextProvider: LogContextProvider;
@@ -864,7 +866,7 @@ export class LokiDatasource
   }
 
   /**
-   * Implemented as part of `DataSourceApi`. Used to modify a query based on the provided action.
+   * Implemented as part of `DataSourceWithQueryModificationSupportSupport`. Used to modify a query based on the provided action.
    * It is used, for example, in the Query Builder to apply hints such as parsers, operations, etc.
    * @returns A new LokiQuery with the specified modification applied.
    */
@@ -948,6 +950,26 @@ export class LokiDatasource
         break;
     }
     return { ...query, expr: expression };
+  }
+
+  /**
+   * Implemented as part of `DataSourceWithQueryModificationSupportSupport`. Returns a list of operation
+   * types that are supported by `modifyQuery()`.
+   */
+  getSupportedQueryModifications()
+  {
+    return [
+      'ADD_FILTER',
+      'ADD_FILTER_OUT',
+      'ADD_LOGFMT_PARSER',
+      'ADD_JSON_PARSER',
+      'ADD_UNPACK_PARSER',
+      'ADD_NO_PIPELINE_ERROR',
+      'ADD_LEVEL_LABEL_FORMAT',
+      'ADD_LABEL_FILTER',
+      'ADD_STRING_FILTER',
+      'ADD_STRING_FILTER_OUT'
+    ];
   }
 
   /**


### PR DESCRIPTION
This PR introduces `DataSourceWithQueryModificationSupport`, for better identification of data sources with `modifyQuery` support, and to add a new method `getSupportedQueryModifications()` which should return a list of the supported modifications by the data source.

The `getSupportedQueryModifications()` list will be used to determine support of certain features, in particular the new popover menu for easier search and filter.

Additionally, feature support resolution in `LogsContainer` have been refactored to hold data source instances in the state, and then use the type guards `hasToggleableQueryFiltersSupport()`, `hasQueryModificationSupport()`, and `hasLogsContextSupport()` to determine if a feature is supported or not.

**Why do we need this feature?**

We currently don't have a reliable way to tell which query modifications are supported by each data source, so it's not possible to know if a given feature is supported or not, and should show up in the UI.

**Which issue(s) does this PR fix?**:

Closes https://github.com/grafana/grafana/issues/76129

**Special notes for your reviewer:**

- If the feature flag (`logRowsPopoverMenu`) is enabled, the popover menu should show up for Elasticsearch and Loki.
- Log detail filters should show up for data sources that support them.
- Log context should show up for data sources that support them.
- It should work in normal or mixed data source mode.
