### PR TITLE
Alerting: Add clean_upgrade config and deprecate force_migration

### DIFF
--- a/conf/defaults.ini
+++ b/conf/defaults.ini
@@ -9,6 +9,10 @@ app_mode = production
 # instance name, defaults to HOSTNAME environment variable value or hostname if HOSTNAME var is empty
 instance_name = ${HOSTNAME}
 
+# force migration will run migrations that might cause dataloss
+# Deprecated, use clean_upgrade option in [unified_alerting.upgrade] instead.
+force_migration = false
+
 #################################### Paths ###############################
 [paths]
 # Path to where grafana can store temp files, sessions, and the sqlite3 db (if that is used)

--- a/conf/defaults.ini
+++ b/conf/defaults.ini
@@ -9,9 +9,6 @@ app_mode = production
 # instance name, defaults to HOSTNAME environment variable value or hostname if HOSTNAME var is empty
 instance_name = ${HOSTNAME}
 
-# force migration will run migrations that might cause dataloss
-force_migration = false
-
 #################################### Paths ###############################
 [paths]
 # Path to where grafana can store temp files, sessions, and the sqlite3 db (if that is used)
@@ -1237,6 +1234,13 @@ loki_basic_auth_password =
 #
 # ex.
 # mylabelkey = mylabelvalue
+
+[unified_alerting.upgrade]
+# If set to true when upgrading from legacy alerting to Unified Alerting, grafana will first delete all existing
+# Unified Alerting resources, thus re-upgrading all organizations from scratch. If false or unset, organizations that
+# have previously upgraded will not lose their existing Unified Alerting data when switching between legacy and
+# Unified Alerting. Should be kept false when not needed as it may cause unintended data-loss if left enabled.
+clean_upgrade = false
 
 # NOTE: this configuration options are not used yet.
 [remote.alertmanager]

--- a/conf/sample.ini
+++ b/conf/sample.ini
@@ -9,6 +9,10 @@
 # instance name, defaults to HOSTNAME environment variable value or hostname if HOSTNAME var is empty
 ;instance_name = ${HOSTNAME}
 
+# force migration will run migrations that might cause dataloss
+# Deprecated, use clean_upgrade option in [unified_alerting.upgrade] instead.
+;force_migration = false
+
 #################################### Paths ####################################
 [paths]
 # Path to where grafana can store temp files, sessions, and the sqlite3 db (if that is used)

--- a/conf/sample.ini
+++ b/conf/sample.ini
@@ -9,9 +9,6 @@
 # instance name, defaults to HOSTNAME environment variable value or hostname if HOSTNAME var is empty
 ;instance_name = ${HOSTNAME}
 
-# force migration will run migrations that might cause dataloss
-;force_migration = false
-
 #################################### Paths ####################################
 [paths]
 # Path to where grafana can store temp files, sessions, and the sqlite3 db (if that is used)
@@ -1154,6 +1151,13 @@
 # Optional extra labels to attach to outbound state history records or log streams.
 # Any number of label key-value-pairs can be provided.
 ; mylabelkey = mylabelvalue
+
+[unified_alerting.upgrade]
+# If set to true when upgrading from legacy alerting to Unified Alerting, grafana will first delete all existing
+# Unified Alerting resources, thus re-upgrading all organizations from scratch. If false or unset, organizations that
+# have previously upgraded will not lose their existing Unified Alerting data when switching between legacy and
+# Unified Alerting. Should be kept false when not needed as it may cause unintended data-loss if left enabled.
+;clean_upgrade = false
 
 #################################### Alerting ############################
 [alerting]

--- a/docs/sources/alerting/set-up/migrating-alerts/_index.md
+++ b/docs/sources/alerting/set-up/migrating-alerts/_index.md
@@ -23,7 +23,7 @@ Existing installations that do not use legacy alerting will have Grafana Alertin
 
 Likewise, existing installations that use legacy alerting will be automatically upgraded to Grafana Alerting unless you have opted out of Grafana Alerting before migration takes place. During the upgrade, legacy alerts are migrated to the new alerts type and no alerts or alerting data are lost.
 
-Once the upgrade has taken place, you still have the option to roll back to legacy alerting. However, we do not recommend choosing this option. If you do choose to roll back, Grafana will restore your alerts to the alerts you had at the point in time when the upgrade took place. All new alerts and changes made exclusively in Grafana Alerting will be deleted.
+Once the upgrade has taken place, you still have the option to roll back to legacy alerting. However, we do not recommend choosing this option. If you do choose to roll back, Grafana will restore your alerts to the alerts you had at the point in time when the upgrade took place.
 
 {{% admonition type="note" %}}
 Cloud customers, who do not want to upgrade to Grafana Alerting, should contact customer support.
@@ -91,13 +91,9 @@ If you want to turn alerting back on, you can remove both flags to enable Grafan
 
 Once the upgrade has taken place, you still have the option to roll back to legacy alerting. If you choose to roll back, Grafana will restore your alerts to the alerts you had at the point in time when the upgrade took place.
 
-All new alerts and changes made exclusively in Grafana Alerting will be deleted.
-
 To roll back to legacy alerting, enter the following in your configuration:
 
 ```toml
-force_migration = true
-
 [alerting]
 enabled = true
 
@@ -105,7 +101,14 @@ enabled = true
 enabled = false
 ```
 
-> **Note**: We do not recommend this option. If you choose to roll back, Grafana will restore your alerts to the alerts you had at the point in time when the upgrade took place. All new alerts and changes made exclusively in Grafana Alerting will be deleted.
+> **Note**: The next time you upgrade to Grafana Alerting, Grafana will restore your Grafana Alerting alerts and configuration to those you had before rolling back. 
+
+If, after rolling back, you wish to delete any existing Grafana Alerting configuration and upgrade your legacy alerting configuration again from scratch, you can enable the `clean_upgrade` option:
+
+```toml
+[unified_alerting.upgrade]
+clean_upgrade = true
+```
 
 ## Opt in
 

--- a/docs/sources/alerting/set-up/migrating-alerts/_index.md
+++ b/docs/sources/alerting/set-up/migrating-alerts/_index.md
@@ -101,7 +101,7 @@ enabled = true
 enabled = false
 ```
 
-> **Note**: The next time you upgrade to Grafana Alerting, Grafana will restore your Grafana Alerting alerts and configuration to those you had before rolling back. 
+> **Note**: The next time you upgrade to Grafana Alerting, Grafana will restore your Grafana Alerting alerts and configuration to those you had before rolling back.
 
 If, after rolling back, you wish to delete any existing Grafana Alerting configuration and upgrade your legacy alerting configuration again from scratch, you can enable the `clean_upgrade` option:
 

--- a/docs/sources/setup-grafana/configure-grafana/_index.md
+++ b/docs/sources/setup-grafana/configure-grafana/_index.md
@@ -1625,15 +1625,18 @@ For example: `disabled_labels=grafana_folder`
 
 ## [unified_alerting.upgrade]
 
-For more information about upgrading to Grafana Alerting, refer to [Upgrade Alerting](/docs/grafana/next/alerting/set-up/migrating-alerts/)
+For more information about upgrading to Grafana Alerting, refer to [Upgrade Alerting](/docs/grafana/next/alerting/set-up/migrating-alerts/).
 
 ### clean_upgrade
 
-When restarting Grafana to upgrade from legacy alerting to Grafana Alerting, first delete any existing Grafana Alerting data from a previous upgrade such as alert rules, contact points, and notification policies. Default is `false`.
+When you restart Grafana to upgrade from legacy alerting to Grafana Alerting, delete any existing Grafana Alerting data from a previous upgrade, such as alert rules, contact points, and notification policies. Default is `false`.
 
-If `false` or unset, existing Grafana Alerting data will not be changed or deleted when switching between legacy and Unified Alerting.
+If `false` or unset, existing Grafana Alerting data is not changed or deleted when you switch between legacy and Unified Alerting.
 
-> **Note.** Should be kept false when not needed as it may cause unintended data-loss if left enabled.
+{{% admonition type="note" %}}
+It should be kept false when not needed, as it may cause unintended data loss if left enabled.
+{{% /admonition %}}
+
 
 <hr>
 

--- a/docs/sources/setup-grafana/configure-grafana/_index.md
+++ b/docs/sources/setup-grafana/configure-grafana/_index.md
@@ -148,12 +148,6 @@ Options are `production` and `development`. Default is `production`. _Do not_ ch
 Set the name of the grafana-server instance. Used in logging, internal metrics, and clustering info. Defaults to: `${HOSTNAME}`, which will be replaced with
 environment variable `HOSTNAME`, if that is empty or does not exist Grafana will try to use system calls to get the machine name.
 
-### force_migration
-
-Force migration will run migrations that might cause data loss. Default is `false`.
-
-Set force_migration=true in your grafana.ini and restart Grafana to roll back and delete Unified Alerting configuration data. Any alert rules created while using Unified Alerting will be deleted by rolling back.
-
 <hr />
 
 ## [paths]
@@ -1489,7 +1483,7 @@ For more information about the Grafana alerts, refer to [About Grafana Alerting]
 
 ### enabled
 
-Enable or disable Grafana Alerting. If disabled, all your legacy alerting data will be available again, but the data you created using Grafana Alerting will be deleted. Set force_migration=true to avoid deletion of data. The default value is `true`.
+Enable or disable Grafana Alerting. If disabled, all your legacy alerting data will be available again. The default value is `true`.
 
 Alerting Rules migrated from dashboards and panels will include a link back via the `annotations`.
 
@@ -1626,6 +1620,20 @@ For more information about Grafana Reserved Labels, refer to [Labels in Grafana 
 Comma-separated list of reserved labels added by the Grafana Alerting engine that should be disabled.
 
 For example: `disabled_labels=grafana_folder`
+
+<hr>
+
+## [unified_alerting.upgrade]
+
+For more information about upgrading to Grafana Alerting, refer to [Upgrade Alerting](/docs/grafana/next/alerting/set-up/migrating-alerts/)
+
+### clean_upgrade
+
+When restarting Grafana to upgrade from legacy alerting to Grafana Alerting, first delete any existing Grafana Alerting data from a previous upgrade such as alert rules, contact points, and notification policies. Default is `false`.
+
+If `false` or unset, existing Grafana Alerting data will not be changed or deleted when switching between legacy and Unified Alerting.
+
+> **Note.** Should be kept false when not needed as it may cause unintended data-loss if left enabled.
 
 <hr>
 

--- a/docs/sources/setup-grafana/configure-grafana/_index.md
+++ b/docs/sources/setup-grafana/configure-grafana/_index.md
@@ -148,6 +148,20 @@ Options are `production` and `development`. Default is `production`. _Do not_ ch
 Set the name of the grafana-server instance. Used in logging, internal metrics, and clustering info. Defaults to: `${HOSTNAME}`, which will be replaced with
 environment variable `HOSTNAME`, if that is empty or does not exist Grafana will try to use system calls to get the machine name.
 
+## force_migration
+
+{{% admonition type="note" %}}
+This option is deprecated - [See `clean_upgrade` option]({{< relref "#clean_upgrade" >}}) instead.
+{{% /admonition %}}
+
+When you restart Grafana to rollback from Grafana Alerting to legacy alerting, delete any existing Grafana Alerting data, such as alert rules, contact points, and notification policies. Default is `false`.
+
+If `false` or unset, existing Grafana Alerting data is not changed or deleted when rolling back to legacy alerting.
+
+{{% admonition type="note" %}}
+It should be kept false or unset when not needed, as it may cause unintended data loss if left enabled.
+{{% /admonition %}}
+
 <hr />
 
 ## [paths]

--- a/docs/sources/setup-grafana/configure-grafana/_index.md
+++ b/docs/sources/setup-grafana/configure-grafana/_index.md
@@ -1651,7 +1651,6 @@ If `false` or unset, existing Grafana Alerting data is not changed or deleted wh
 It should be kept false when not needed, as it may cause unintended data loss if left enabled.
 {{% /admonition %}}
 
-
 <hr>
 
 ## [alerting]

--- a/pkg/services/ngalert/migration/migration_test.go
+++ b/pkg/services/ngalert/migration/migration_test.go
@@ -72,8 +72,8 @@ func TestServiceStart(t *testing.T) {
 					},
 				},
 			},
-			starting:    migrationStore.UnifiedAlerting,
-			expected:    migrationStore.Legacy,
+			starting: migrationStore.UnifiedAlerting,
+			expected: migrationStore.Legacy,
 		},
 		{
 			name: "when unified alerting enabled and migration is already run, then do nothing",
@@ -93,6 +93,28 @@ func TestServiceStart(t *testing.T) {
 				},
 			},
 			starting: migrationStore.Legacy,
+			expected: migrationStore.Legacy,
+		},
+		{
+			name: "when unified alerting disabled, migration is already run and force migration is enabled, then revert migration",
+			config: &setting.Cfg{
+				UnifiedAlerting: setting.UnifiedAlertingSettings{
+					Enabled: pointer(false),
+				},
+				ForceMigration: true,
+			},
+			starting: migrationStore.UnifiedAlerting,
+			expected: migrationStore.Legacy,
+		},
+		{
+			name: "when unified alerting disabled, migration is already run and force migration is disabled, then the migration status should set to false",
+			config: &setting.Cfg{
+				UnifiedAlerting: setting.UnifiedAlertingSettings{
+					Enabled: pointer(false),
+				},
+				ForceMigration: false,
+			},
+			starting: migrationStore.UnifiedAlerting,
 			expected: migrationStore.Legacy,
 		},
 	}

--- a/pkg/services/ngalert/migration/migration_test.go
+++ b/pkg/services/ngalert/migration/migration_test.go
@@ -50,27 +50,30 @@ func TestServiceStart(t *testing.T) {
 			expected: migrationStore.UnifiedAlerting,
 		},
 		{
-			name: "when unified alerting disabled, migration is already run and force migration is enabled, then revert migration",
+			name: "when unified alerting disabled, migration is already run and CleanUpgrade is enabled, then revert migration",
 			config: &setting.Cfg{
 				UnifiedAlerting: setting.UnifiedAlertingSettings{
 					Enabled: pointer(false),
+					Upgrade: setting.UnifiedAlertingUpgradeSettings{
+						CleanUpgrade: true,
+					},
 				},
-				ForceMigration: true,
 			},
 			starting: migrationStore.UnifiedAlerting,
 			expected: migrationStore.Legacy,
 		},
 		{
-			name: "when unified alerting disabled, migration is already run and force migration is disabled, then the migration should panic",
+			name: "when unified alerting disabled, migration is already run and CleanUpgrade is disabled, then the migration status should set to false",
 			config: &setting.Cfg{
 				UnifiedAlerting: setting.UnifiedAlertingSettings{
 					Enabled: pointer(false),
+					Upgrade: setting.UnifiedAlertingUpgradeSettings{
+						CleanUpgrade: false,
+					},
 				},
-				ForceMigration: false,
 			},
 			starting:    migrationStore.UnifiedAlerting,
-			expected:    migrationStore.UnifiedAlerting,
-			expectedErr: true,
+			expected:    migrationStore.Legacy,
 		},
 		{
 			name: "when unified alerting enabled and migration is already run, then do nothing",

--- a/pkg/services/ngalert/migration/service.go
+++ b/pkg/services/ngalert/migration/service.go
@@ -16,9 +16,6 @@ import (
 // actionName is the unique row-level lock name for serverlock.ServerLockService.
 const actionName = "alerting migration"
 
-//nolint:stylecheck
-var ForceMigrationError = fmt.Errorf("Grafana has already been migrated to Unified Alerting. Any alert rules created while using Unified Alerting will be deleted by rolling back. Set force_migration=true in your grafana.ini and restart Grafana to roll back and delete Unified Alerting configuration data.")
-
 type UpgradeService interface {
 	Run(ctx context.Context) error
 }
@@ -81,17 +78,17 @@ func newTransition(currentType migrationStore.AlertingType, cfg *setting.Cfg) tr
 		desiredType = migrationStore.UnifiedAlerting
 	}
 	return transition{
-		CurrentType:      currentType,
-		DesiredType:      desiredType,
-		CleanOnDowngrade: cfg.ForceMigration,
+		CurrentType:    currentType,
+		DesiredType:    desiredType,
+		CleanOnUpgrade: cfg.UnifiedAlerting.Upgrade.CleanUpgrade,
 	}
 }
 
 // transition represents a migration from one alerting type to another.
 type transition struct {
-	CurrentType      migrationStore.AlertingType
-	DesiredType      migrationStore.AlertingType
-	CleanOnDowngrade bool
+	CurrentType    migrationStore.AlertingType
+	DesiredType    migrationStore.AlertingType
+	CleanOnUpgrade bool
 }
 
 // isNoChange returns true if the migration is a no-op.
@@ -111,28 +108,23 @@ func (t transition) isDowngrading() bool {
 
 // shouldClean returns true if the migration should delete all unified alerting data.
 func (t transition) shouldClean() bool {
-	return t.isDowngrading() && t.CleanOnDowngrade
+	return t.isUpgrading() && t.CleanOnUpgrade
 }
 
 // applyTransition applies the transition to the database.
 // If the transition is a no-op, nothing will be done.
-// If the transition is a downgrade and CleanOnDowngrade is true, all unified alerting data will be deleted.
-// If the transition is a downgrade and CleanOnDowngrade is false, an error will be returned.
+// If the transition is a downgrade, nothing will be done.
 // If the transition is an upgrade, all orgs will be migrated.
+// If the transition is an upgrade and CleanOnUpgrade is true, all unified alerting data will be deleted and then all orgs will be migrated.
 func (ms *migrationService) applyTransition(ctx context.Context, t transition) error {
 	l := ms.log.New(
 		"CurrentType", t.CurrentType,
 		"DesiredType", t.DesiredType,
-		"CleanOnDowngrade", t.CleanOnDowngrade,
+		"CleanOnUpgrade", t.CleanOnUpgrade,
 	)
 	if t.isNoChange() {
 		l.Info("Migration already complete")
 		return nil
-	}
-
-	// Safeguard to prevent accidental data loss when reverting from UA to LA.
-	if t.isDowngrading() && !ms.cfg.ForceMigration {
-		return ForceMigrationError
 	}
 
 	if t.shouldClean() {

--- a/pkg/services/ngalert/migration/service_test.go
+++ b/pkg/services/ngalert/migration/service_test.go
@@ -199,9 +199,7 @@ func TestServiceRevert(t *testing.T) {
 		cfg := &setting.Cfg{
 			UnifiedAlerting: setting.UnifiedAlertingSettings{
 				Enabled: pointer(true),
-				Upgrade: setting.UnifiedAlertingUpgradeSettings{
-					CleanUpgrade: true,
-				},
+				Upgrade: setting.UnifiedAlertingUpgradeSettings{},
 			},
 		}
 		service := NewTestMigrationService(t, sqlStore, cfg)
@@ -315,7 +313,7 @@ func TestServiceRevert(t *testing.T) {
 		checkAlertRulesCount(t, x, 1, 1)
 
 		// Add another alert.
-		// Enable UA without force flag.
+		// Enable UA without clean flag.
 		// This run should not remigrate org, new alert is not migrated.
 		_, alertErr := x.Insert(createAlert(t, 1, 1, 2, "alert2", []string{"notifier1"}))
 		require.NoError(t, alertErr)
@@ -325,7 +323,7 @@ func TestServiceRevert(t *testing.T) {
 		checkMigrationStatus(t, ctx, service, 1, true)
 		checkAlertRulesCount(t, x, 1, 1) // Still 1
 
-		// Disable UA with force flag.
+		// Disable UA with clean flag.
 		// This run should not revert UA data.
 		service.cfg.UnifiedAlerting.Enabled = pointer(false)
 		service.cfg.UnifiedAlerting.Upgrade.CleanUpgrade = true
@@ -334,13 +332,25 @@ func TestServiceRevert(t *testing.T) {
 		checkMigrationStatus(t, ctx, service, 1, true)
 		checkAlertRulesCount(t, x, 1, 1) // Still 1
 
-		// Enable UA with force flag.
+		// Enable UA with clean flag.
 		// This run should revert and remigrate org, new alert is migrated.
 		service.cfg.UnifiedAlerting.Enabled = pointer(true)
 		require.NoError(t, service.Run(ctx))
 		checkAlertingType(t, ctx, service, migrationStore.UnifiedAlerting)
 		checkMigrationStatus(t, ctx, service, 1, true)
 		checkAlertRulesCount(t, x, 1, 2) // Now we have 2
+
+		// The following tests ForceMigration which is deprecated and will be removed in v11.
+		service.cfg.UnifiedAlerting.Upgrade.CleanUpgrade = false
+
+		// Disable UA with force flag.
+		// This run should not revert UA data.
+		service.cfg.UnifiedAlerting.Enabled = pointer(false)
+		service.cfg.ForceMigration = true
+		require.NoError(t, service.Run(ctx))
+		checkAlertingType(t, ctx, service, migrationStore.Legacy)
+		checkMigrationStatus(t, ctx, service, 1, false)
+		checkAlertRulesCount(t, x, 1, 0)
 	})
 }
 

--- a/pkg/services/ngalert/migration/service_test.go
+++ b/pkg/services/ngalert/migration/service_test.go
@@ -197,9 +197,11 @@ func TestServiceRevert(t *testing.T) {
 		// Run migration.
 		ctx := context.Background()
 		cfg := &setting.Cfg{
-			ForceMigration: true,
 			UnifiedAlerting: setting.UnifiedAlertingSettings{
 				Enabled: pointer(true),
+				Upgrade: setting.UnifiedAlertingUpgradeSettings{
+					CleanUpgrade: true,
+				},
 			},
 		}
 		service := NewTestMigrationService(t, sqlStore, cfg)
@@ -280,7 +282,7 @@ func TestServiceRevert(t *testing.T) {
 		}
 	})
 
-	t.Run("ForceMigration story", func(t *testing.T) {
+	t.Run("CleanUpgrade story", func(t *testing.T) {
 		sqlStore := db.InitTestDB(t)
 		x := sqlStore.GetEngine()
 
@@ -304,29 +306,36 @@ func TestServiceRevert(t *testing.T) {
 		checkMigrationStatus(t, ctx, service, 1, true)
 		checkAlertRulesCount(t, x, 1, 1)
 
-		// Disable UA without ForceMigration.
-		// This run should throw an error.
+		// Disable UA.
+		// This run should just set migration status to false.
 		service.cfg.UnifiedAlerting.Enabled = pointer(false)
-		require.ErrorContains(t, service.Run(ctx), ForceMigrationError.Error())
-		checkAlertingType(t, ctx, service, migrationStore.UnifiedAlerting)
+		require.NoError(t, service.Run(ctx))
+		checkAlertingType(t, ctx, service, migrationStore.Legacy)
 		checkMigrationStatus(t, ctx, service, 1, true)
 		checkAlertRulesCount(t, x, 1, 1)
+
+		// Add another alert.
+		// Enable UA without force flag.
+		// This run should not remigrate org, new alert is not migrated.
+		_, alertErr := x.Insert(createAlert(t, 1, 1, 2, "alert2", []string{"notifier1"}))
+		require.NoError(t, alertErr)
+		service.cfg.UnifiedAlerting.Enabled = pointer(true)
+		require.NoError(t, service.Run(ctx))
+		checkAlertingType(t, ctx, service, migrationStore.UnifiedAlerting)
+		checkMigrationStatus(t, ctx, service, 1, true)
+		checkAlertRulesCount(t, x, 1, 1) // Still 1
 
 		// Disable UA with force flag.
 		// This run should not revert UA data.
 		service.cfg.UnifiedAlerting.Enabled = pointer(false)
-		service.cfg.ForceMigration = true
+		service.cfg.UnifiedAlerting.Upgrade.CleanUpgrade = true
 		require.NoError(t, service.Run(ctx))
 		checkAlertingType(t, ctx, service, migrationStore.Legacy)
-		checkMigrationStatus(t, ctx, service, 1, false)
-		checkAlertRulesCount(t, x, 1, 0) // Alerts are gone.
+		checkMigrationStatus(t, ctx, service, 1, true)
+		checkAlertRulesCount(t, x, 1, 1) // Still 1
 
-		// Add another alert.
-		_, alertErr := x.Insert(createAlert(t, 1, 1, 2, "alert2", []string{"notifier1"}))
-		require.NoError(t, alertErr)
-
-		// Enable UA.
-		// This run should remigrate org, new alert is migrated.
+		// Enable UA with force flag.
+		// This run should revert and remigrate org, new alert is migrated.
 		service.cfg.UnifiedAlerting.Enabled = pointer(true)
 		require.NoError(t, service.Run(ctx))
 		checkAlertingType(t, ctx, service, migrationStore.UnifiedAlerting)

--- a/pkg/services/ngalert/ngalert.go
+++ b/pkg/services/ngalert/ngalert.go
@@ -104,8 +104,9 @@ func ProvideService(
 		upgradeService:       upgradeService,
 	}
 
-	// Migration is called even if UA is disabled. If UA is disabled, this will do nothing except handle logic around
-	// reverting the migration.
+	// Migration is called, even if UA is disabled. If UA is disabled though, this will do nothing except set the
+	// instance-wide migration state to false. This is necessary to allow clean_upgrade to revert UA only when moving
+	// from legacy to UA.
 	err := ng.upgradeService.Run(context.Background())
 	if err != nil {
 		return nil, err

--- a/pkg/services/ngalert/ngalert.go
+++ b/pkg/services/ngalert/ngalert.go
@@ -104,9 +104,8 @@ func ProvideService(
 		upgradeService:       upgradeService,
 	}
 
-	// Migration is called, even if UA is disabled. If UA is disabled though, this will do nothing except set the
-	// instance-wide migration state to false. This is necessary to allow clean_upgrade to revert UA only when moving
-	// from legacy to UA.
+	// Migration is called even if UA is disabled. If UA is disabled, this will do nothing except handle logic around
+	// reverting the migration.
 	err := ng.upgradeService.Run(context.Background())
 	if err != nil {
 		return nil, err

--- a/pkg/setting/setting.go
+++ b/pkg/setting/setting.go
@@ -416,8 +416,6 @@ type Cfg struct {
 	StackID string
 	Slug    string
 
-	ForceMigration bool
-
 	// Analytics
 	CheckForGrafanaUpdates              bool
 	CheckForPluginUpdates               bool
@@ -1061,7 +1059,6 @@ func (cfg *Cfg) Load(args CommandLineArgs) error {
 	cfg.Env = Env
 	cfg.StackID = valueAsString(iniFile.Section("environment"), "stack_id", "")
 	cfg.Slug = valueAsString(iniFile.Section("environment"), "stack_slug", "")
-	cfg.ForceMigration = iniFile.Section("").Key("force_migration").MustBool(false)
 	InstanceName = valueAsString(iniFile.Section(""), "instance_name", "unknown_instance_name")
 	plugins := valueAsString(iniFile.Section("paths"), "plugins", "")
 	cfg.PluginsPath = makeAbsolute(plugins, HomePath)

--- a/pkg/setting/setting.go
+++ b/pkg/setting/setting.go
@@ -416,6 +416,9 @@ type Cfg struct {
 	StackID string
 	Slug    string
 
+	// Deprecated
+	ForceMigration bool
+
 	// Analytics
 	CheckForGrafanaUpdates              bool
 	CheckForPluginUpdates               bool
@@ -1059,6 +1062,8 @@ func (cfg *Cfg) Load(args CommandLineArgs) error {
 	cfg.Env = Env
 	cfg.StackID = valueAsString(iniFile.Section("environment"), "stack_id", "")
 	cfg.Slug = valueAsString(iniFile.Section("environment"), "stack_slug", "")
+	//nolint:staticcheck
+	cfg.ForceMigration = iniFile.Section("").Key("force_migration").MustBool(false)
 	InstanceName = valueAsString(iniFile.Section(""), "instance_name", "unknown_instance_name")
 	plugins := valueAsString(iniFile.Section("paths"), "plugins", "")
 	cfg.PluginsPath = makeAbsolute(plugins, HomePath)

--- a/pkg/setting/setting_unified_alerting.go
+++ b/pkg/setting/setting_unified_alerting.go
@@ -96,6 +96,7 @@ type UnifiedAlertingSettings struct {
 	ReservedLabels                UnifiedAlertingReservedLabelSettings
 	StateHistory                  UnifiedAlertingStateHistorySettings
 	RemoteAlertmanager            RemoteAlertmanagerSettings
+	Upgrade                       UnifiedAlertingUpgradeSettings
 	// MaxStateSaveConcurrency controls the number of goroutines (per rule) that can save alert state in parallel.
 	MaxStateSaveConcurrency int
 }
@@ -134,6 +135,11 @@ type UnifiedAlertingStateHistorySettings struct {
 	MultiPrimary          string
 	MultiSecondaries      []string
 	ExternalLabels        map[string]string
+}
+
+type UnifiedAlertingUpgradeSettings struct {
+	// CleanUpgrade controls whether the upgrade process should clean up UA data when upgrading from legacy alerting.
+	CleanUpgrade bool
 }
 
 // IsEnabled returns true if UnifiedAlertingSettings.Enabled is either nil or true.
@@ -398,6 +404,12 @@ func (cfg *Cfg) ReadUnifiedAlertingSettings(iniFile *ini.File) error {
 	uaCfg.StateHistory = uaCfgStateHistory
 
 	uaCfg.MaxStateSaveConcurrency = ua.Key("max_state_save_concurrency").MustInt(1)
+
+	upgrade := iniFile.Section("unified_alerting.upgrade")
+	uaCfgUpgrade := UnifiedAlertingUpgradeSettings{
+		CleanUpgrade: upgrade.Key("clean_upgrade").MustBool(false),
+	}
+	uaCfg.Upgrade = uaCfgUpgrade
 
 	cfg.UnifiedAlerting = uaCfg
 	return nil


### PR DESCRIPTION
Note: https://github.com/grafana/grafana/pull/78369 is a prerequisite for this PR.

**What is this feature?**

This change has two main components:

- Upgrading to UA and rolling back will no longer delete any data by default. Instead, each set of tables will remain unchanged when switching between legacy and UA. As such, the `force_migration` config has been deprecated and no extra configuration is required to roll back to legacy anymore.
- If you want to re-perform the upgrade from scratch, you should no longer set `force_migration` when rolling back. Instead, you set the new `clean_upgrade` when upgrading (though `force_migration` will continue to work as-is for now):
```yaml
[unified_alerting.upgrade]
clean_upgrade=true
```
This config takes effect when upgrading from legacy->UA and, if enabled, will first revert all UA data before performing the upgrade from a clean slate.

Note:  Similar to `force_migration`, `clean_upgrade` should be kept false when not needed as it may cause unintended data-loss if left enabled.

**Why do we need this feature?**

This is a general improvement and precursor to upcoming migration dry-run functionality.

**Who is this feature for?**

Users migrating from legacy alerting to Grafana Alerting (UA).

Please check that:
- [x] It works as expected from a user's perspective.
- [x] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
