### PR TITLE
Explore: Fixes issue with adhoc filters when coming from dashboards

### DIFF
--- a/public/app/core/utils/explore.ts
+++ b/public/app/core/utils/explore.ts
@@ -61,7 +61,7 @@ export function generateExploreId() {
  * Returns an Explore-URL that contains a panel's queries and the dashboard time range.
  */
 export async function getExploreUrl(args: GetExploreUrlArguments): Promise<string | undefined> {
-  const { queries, dsRef, timeRange, scopedVars } = args;
+  const { queries, dsRef, timeRange, scopedVars, adhocFilters } = args;
   const interpolatedQueries = (
     await Promise.allSettled(
       queries
@@ -74,7 +74,7 @@ export async function getExploreUrl(args: GetExploreUrlArguments): Promise<strin
 
           return {
             // interpolate the query using its datasource `interpolateVariablesInQueries` method if defined, othewise return the query as-is.
-            ...(queryDs.interpolateVariablesInQueries?.([q], scopedVars ?? {}, args.adhocFilters)[0] || q),
+            ...(queryDs.interpolateVariablesInQueries?.([q], scopedVars ?? {}, adhocFilters)[0] || q),
             // But always set the datasource as it's  required in Explore.
             // NOTE: if for some reason the query has the "mixed" datasource, we omit the property;
             // Upon initialization, Explore use its own logic to determine the datasource.

--- a/public/app/core/utils/explore.ts
+++ b/public/app/core/utils/explore.ts
@@ -3,6 +3,7 @@ import { Unsubscribable } from 'rxjs';
 import { v4 as uuidv4 } from 'uuid';
 
 import {
+  AdHocVariableFilter,
   CoreApp,
   DataQuery,
   DataQueryRequest,
@@ -49,6 +50,7 @@ export interface GetExploreUrlArguments {
   dsRef: DataSourceRef | null | undefined;
   timeRange: TimeRange;
   scopedVars: ScopedVars | undefined;
+  adhocFilters?: AdHocVariableFilter[];
 }
 
 export function generateExploreId() {
@@ -72,7 +74,7 @@ export async function getExploreUrl(args: GetExploreUrlArguments): Promise<strin
 
           return {
             // interpolate the query using its datasource `interpolateVariablesInQueries` method if defined, othewise return the query as-is.
-            ...(queryDs.interpolateVariablesInQueries?.([q], scopedVars ?? {})[0] || q),
+            ...(queryDs.interpolateVariablesInQueries?.([q], scopedVars ?? {}, args.adhocFilters)[0] || q),
             // But always set the datasource as it's  required in Explore.
             // NOTE: if for some reason the query has the "mixed" datasource, we omit the property;
             // Upon initialization, Explore use its own logic to determine the datasource.

--- a/public/app/features/explore/state/main.test.ts
+++ b/public/app/features/explore/state/main.test.ts
@@ -12,6 +12,13 @@ import { ExploreItemState, ExploreState, StoreState, ThunkDispatch } from '../..
 
 import { exploreReducer, navigateToExplore, splitClose, splitOpen } from './main';
 
+jest.mock('@grafana/runtime', () => ({
+  ...jest.requireActual('@grafana/runtime'),
+  getDataSourceSrv: () => ({
+    getInstanceSettings: jest.fn().mockReturnValue({}),
+  }),
+}));
+
 const getNavigateToExploreContext = async (openInNewWindow?: (url: string) => void) => {
   const url = '/explore';
   const panel: Partial<PanelModel> = {
@@ -53,6 +60,7 @@ describe('navigateToExplore', () => {
           queries: panel.targets,
           timeRange,
           dsRef: panel.datasource,
+          adhocFilters: [],
         });
       });
     });
@@ -73,6 +81,7 @@ describe('navigateToExplore', () => {
           queries: panel.targets,
           timeRange,
           dsRef: panel.datasource,
+          adhocFilters: [],
         });
       });
 

--- a/public/app/features/explore/state/main.ts
+++ b/public/app/features/explore/state/main.ts
@@ -5,6 +5,7 @@ import { SplitOpenOptions, TimeRange, EventBusSrv } from '@grafana/data';
 import { locationService } from '@grafana/runtime';
 import { generateExploreId, GetExploreUrlArguments } from 'app/core/utils/explore';
 import { PanelModel } from 'app/features/dashboard/state';
+import { getTemplateSrv } from 'app/features/templating/template_srv';
 import { CorrelationEditorDetailsUpdate, ExploreItemState, ExploreState } from 'app/types/explore';
 
 import { RichHistoryResults } from '../../../core/history/RichHistoryStorage';
@@ -131,6 +132,7 @@ export const navigateToExplore = (
       dsRef: panel.datasource,
       scopedVars: panel.scopedVars,
       timeRange,
+      adhocFilters: getTemplateSrv().getAdhocFilters(panel.datasource?.uid ?? '', true),
     });
 
     if (openInNewWindow && path) {

--- a/public/app/features/query/state/PanelQueryRunner.ts
+++ b/public/app/features/query/state/PanelQueryRunner.ts
@@ -303,7 +303,7 @@ export class PanelQueryRunner {
 
       request.interval = norm.interval;
       request.intervalMs = norm.intervalMs;
-      request.filters = this.templateSrv.getAdhocFilters(ds.name);
+      request.filters = this.templateSrv.getAdhocFilters(ds.name, true);
 
       this.lastRequest = request;
 

--- a/public/app/features/templating/template_srv.ts
+++ b/public/app/features/templating/template_srv.ts
@@ -123,7 +123,7 @@ export class TemplateSrv implements BaseTemplateSrv {
    * Use filters property on the request (DataQueryRequest) or if this is called from
    * interpolateVariablesInQueries or applyTemplateVariables it is passed as a new argument
    **/
-  getAdhocFilters(datasourceName: string): AdHocVariableFilter[] {
+  getAdhocFilters(datasourceName: string, skipDeprecationWarning?: boolean): AdHocVariableFilter[] {
     let filters: any = [];
     let ds = getDataSourceSrv().getInstanceSettings(datasourceName);
 
@@ -131,7 +131,7 @@ export class TemplateSrv implements BaseTemplateSrv {
       return [];
     }
 
-    if (!this._adhocFiltersDeprecationWarningLogged.get(ds.type)) {
+    if (!this._adhocFiltersDeprecationWarningLogged.get(ds.type) && !skipDeprecationWarning) {
       if (process.env.NODE_ENV !== 'test') {
         deprecationWarning(
           `DataSource ${ds.type}`,

--- a/public/app/features/templating/template_srv.ts
+++ b/public/app/features/templating/template_srv.ts
@@ -131,7 +131,7 @@ export class TemplateSrv implements BaseTemplateSrv {
       return [];
     }
 
-    if (!this._adhocFiltersDeprecationWarningLogged.get(ds.type) && !skipDeprecationWarning) {
+    if (!skipDeprecationWarning && !this._adhocFiltersDeprecationWarningLogged.get(ds.type)) {
       if (process.env.NODE_ENV !== 'test') {
         deprecationWarning(
           `DataSource ${ds.type}`,


### PR DESCRIPTION
* [x] Removes deprecation warning when we use templateSrv.getAdHocFilters internally (should not be used from plugins). It is deprecated and not used in new scenes architecture but the old dashboards still use it. 
* [x] Add it to getExploreUrl so it can pass it to interpolateVariablesInQueries

For scenes panel menu (call) to getExploreUrl we need a change in SceneQueryRunner to expose the AdHocFilterSet it has found. Will update that later 
