### PR TITLE
Data sources: show data source menu to users who only have access to create a data source

### DIFF
--- a/pkg/services/datasources/accesscontrol.go
+++ b/pkg/services/datasources/accesscontrol.go
@@ -26,10 +26,10 @@ var (
 	// ConfigurationPageAccess is used to protect the "Configure > Data sources" tab access
 	ConfigurationPageAccess = accesscontrol.EvalAny(
 		accesscontrol.EvalPermission(accesscontrol.ActionDatasourcesExplore),
+		accesscontrol.EvalPermission(ActionCreate),
 		accesscontrol.EvalAll(
 			accesscontrol.EvalPermission(ActionRead),
 			accesscontrol.EvalAny(
-				accesscontrol.EvalPermission(ActionCreate),
 				accesscontrol.EvalPermission(ActionDelete),
 				accesscontrol.EvalPermission(ActionWrite),
 			),

--- a/public/app/features/datasources/state/actions.ts
+++ b/public/app/features/datasources/state/actions.ts
@@ -178,7 +178,10 @@ export const testDataSource = (
 export function loadDataSources(): ThunkResult<Promise<void>> {
   return async (dispatch) => {
     dispatch(dataSourcesLoad());
-    const response = await api.getDataSources();
+    let response: DataSourceSettings[] = [];
+    if (contextSrv.hasPermission(AccessControlAction.DataSourcesRead)) {
+      response = await api.getDataSources();
+    }
     dispatch(dataSourcesLoaded(response));
   };
 }

--- a/public/app/features/datasources/state/actions.ts
+++ b/public/app/features/datasources/state/actions.ts
@@ -22,7 +22,7 @@ import { ROUTES as CONNECTIONS_ROUTES } from 'app/features/connections/constants
 import { getDatasourceSrv } from 'app/features/plugins/datasource_srv';
 import { getPluginSettings } from 'app/features/plugins/pluginSettings';
 import { importDataSourcePlugin } from 'app/features/plugins/plugin_loader';
-import { DataSourcePluginCategory, ThunkDispatch, ThunkResult } from 'app/types';
+import { AccessControlAction, DataSourcePluginCategory, ThunkDispatch, ThunkResult } from 'app/types';
 
 import * as api from '../api';
 import { DATASOURCES_ROUTES } from '../constants';
@@ -177,11 +177,11 @@ export const testDataSource = (
 
 export function loadDataSources(): ThunkResult<Promise<void>> {
   return async (dispatch) => {
-    dispatch(dataSourcesLoad());
-    let response: DataSourceSettings[] = [];
-    if (contextSrv.hasPermission(AccessControlAction.DataSourcesRead)) {
-      response = await api.getDataSources();
+    if (!contextSrv.hasPermission(AccessControlAction.DataSourcesRead)) {
+      return;
     }
+    dispatch(dataSourcesLoad());
+    const response = await api.getDataSources();
     dispatch(dataSourcesLoaded(response));
   };
 }


### PR DESCRIPTION
**What is this feature?**

Allow users who can create a data source but can't list any of the existing data sources to see the data source create menu.

**Why do we need this feature?**

To allow teams to create and manage their own data sources without being able to see any other data sources.

**Who is this feature for?**

Enterprise and cloud users.

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Related to https://github.com/grafana/identity-access-team/issues/474

**Special notes for your reviewer:**

Note that this PR doesn't fully fix the workflow for users with only data source create access - https://github.com/grafana/identity-access-team/issues/474 needs to be completed as well.