### PR TITLE
Alerting: In migration improve deduplication of title and group

### DIFF
--- a/pkg/services/ngalert/migration/alert_rule_test.go
+++ b/pkg/services/ngalert/migration/alert_rule_test.go
@@ -287,7 +287,7 @@ func TestMakeAlertRule(t *testing.T) {
 		}
 	})
 
-	t.Run("truncate rule group if dashboard name + panel id is too long", func(t *testing.T) {
+	t.Run("truncate dashboard name part of rule group if too long", func(t *testing.T) {
 		service := NewTestMigrationService(t, sqlStore, nil)
 		m := service.newOrgMigration(1)
 		da := createTestDashAlert()

--- a/pkg/services/ngalert/migration/alert_rule_test.go
+++ b/pkg/services/ngalert/migration/alert_rule_test.go
@@ -177,10 +177,7 @@ func TestMakeAlertRule(t *testing.T) {
 
 			require.NoError(t, err)
 			require.Len(t, ar.Title, store.AlertDefinitionMaxTitleLength)
-			parts := strings.SplitN(ar.Title, "_", 2)
-			require.Len(t, parts, 2)
-			require.Equal(t, ar.Title, fmt.Sprintf("%s_%d-%d", strings.Repeat("a", store.AlertDefinitionMaxTitleLength-4), da.DashboardID, da.PanelID))
-			require.Equal(t, store.AlertDefinitionMaxTitleLength-1, len(parts[0])+len(parts[1]), "truncated name + underscore + unique identifier should together be DefaultFieldMaxLength")
+			require.Equal(t, ar.Title, fmt.Sprintf("%s #2", strings.Repeat("a", store.AlertDefinitionMaxTitleLength-3)))
 		})
 	})
 

--- a/pkg/services/ngalert/migration/migration_test.go
+++ b/pkg/services/ngalert/migration/migration_test.go
@@ -714,7 +714,7 @@ func TestDashAlertQueryMigration(t *testing.T) {
 			mutator(rule)
 		}
 
-		rule.RuleGroup = fmt.Sprintf("%s - %ds", *rule.DashboardUID, rule.IntervalSeconds)
+		rule.RuleGroup = fmt.Sprintf("%s - 1m", *rule.DashboardUID)
 
 		rule.Annotations["__dashboardUid__"] = *rule.DashboardUID
 		rule.Annotations["__panelId__"] = strconv.FormatInt(*rule.PanelID, 10)

--- a/pkg/services/ngalert/migration/migration_test.go
+++ b/pkg/services/ngalert/migration/migration_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/prometheus/alertmanager/pkg/labels"
 	"github.com/prometheus/common/model"
 	"github.com/stretchr/testify/require"
+
 	"xorm.io/xorm"
 
 	"github.com/grafana/grafana/pkg/components/simplejson"
@@ -713,7 +714,7 @@ func TestDashAlertQueryMigration(t *testing.T) {
 			mutator(rule)
 		}
 
-		rule.RuleGroup = fmt.Sprintf("%s - %d", *rule.DashboardUID, *rule.PanelID)
+		rule.RuleGroup = fmt.Sprintf("%s - %ds", *rule.DashboardUID, rule.IntervalSeconds)
 
 		rule.Annotations["__dashboardUid__"] = *rule.DashboardUID
 		rule.Annotations["__panelId__"] = strconv.FormatInt(*rule.PanelID, 10)

--- a/pkg/services/ngalert/migration/models.go
+++ b/pkg/services/ngalert/migration/models.go
@@ -1,8 +1,6 @@
 package migration
 
 import (
-	"strings"
-
 	pb "github.com/prometheus/alertmanager/silence/silencepb"
 
 	"github.com/grafana/grafana/pkg/infra/log"
@@ -14,7 +12,6 @@ import (
 	"github.com/grafana/grafana/pkg/services/ngalert/store"
 	"github.com/grafana/grafana/pkg/services/secrets"
 	"github.com/grafana/grafana/pkg/setting"
-	"github.com/grafana/grafana/pkg/util"
 )
 
 // OrgMigration is a helper struct for migrating alerts for a single org. It contains state, services, and caches.
@@ -25,10 +22,10 @@ type OrgMigration struct {
 	migrationStore    migrationStore.Store
 	encryptionService secrets.Service
 
-	orgID               int64
-	seenUIDs            Deduplicator
-	silences            []*pb.MeshSilence
-	alertRuleTitleDedup map[string]Deduplicator // Folder -> Deduplicator (Title).
+	orgID                      int64
+	seenUIDs                   *migmodels.Deduplicator
+	silences                   []*pb.MeshSilence
+	titleDeduplicatorForFolder func(folderUID string) *migmodels.Deduplicator
 
 	// Migrated folder for a dashboard based on permissions. Parent Folder ID -> unique dashboard permission -> custom folder.
 	permissionsMap        map[int64]map[permissionHash]*folder.Folder
@@ -41,6 +38,7 @@ type OrgMigration struct {
 
 // newOrgMigration creates a new OrgMigration for the given orgID.
 func (ms *migrationService) newOrgMigration(orgID int64) *OrgMigration {
+	titlededuplicatorPerFolder := make(map[string]*migmodels.Deduplicator)
 	return &OrgMigration{
 		cfg: ms.cfg,
 		log: ms.log.New("orgID", orgID),
@@ -50,9 +48,14 @@ func (ms *migrationService) newOrgMigration(orgID int64) *OrgMigration {
 
 		orgID: orgID,
 		// We deduplicate for case-insensitive matching in MySQL-compatible backend flavours because they use case-insensitive collation.
-		seenUIDs:            Deduplicator{set: make(map[string]struct{}), caseInsensitive: ms.migrationStore.CaseInsensitive()},
-		silences:            make([]*pb.MeshSilence, 0),
-		alertRuleTitleDedup: make(map[string]Deduplicator),
+		seenUIDs: migmodels.NewDeduplicator(ms.store.GetDialect().SupportEngine(), 0),
+		silences: make([]*pb.MeshSilence, 0),
+		titleDeduplicatorForFolder: func(folderUID string) *migmodels.Deduplicator {
+			if _, ok := titlededuplicatorPerFolder[folderUID]; !ok {
+				titlededuplicatorPerFolder[folderUID] = migmodels.NewDeduplicator(ms.store.GetDialect().SupportEngine(), store.AlertDefinitionMaxTitleLength)
+			}
+			return titlededuplicatorPerFolder[folderUID]
+		},
 
 		permissionsMap:        make(map[int64]map[permissionHash]*folder.Folder),
 		folderCache:           make(map[int64]*folder.Folder),
@@ -65,62 +68,7 @@ func (ms *migrationService) newOrgMigration(orgID int64) *OrgMigration {
 	}
 }
 
-func (om *OrgMigration) AlertTitleDeduplicator(folderUID string) Deduplicator {
-	if _, ok := om.alertRuleTitleDedup[folderUID]; !ok {
-		om.alertRuleTitleDedup[folderUID] = Deduplicator{
-			set:             make(map[string]struct{}),
-			caseInsensitive: om.migrationStore.CaseInsensitive(),
-			maxLen:          store.AlertDefinitionMaxTitleLength,
-		}
-	}
-	return om.alertRuleTitleDedup[folderUID]
-}
-
 type AlertPair struct {
 	AlertRule *models.AlertRule
 	DashAlert *migrationStore.DashAlert
-}
-
-// Deduplicator is a wrapper around map[string]struct{} and util.GenerateShortUID() which aims help maintain and generate
-// unique strings (such as uids or titles). if caseInsensitive is true, all uniqueness is determined in a
-// case-insensitive manner. if maxLen is greater than 0, all strings will be truncated to maxLen before being checked in
-// contains and dedup will always return a string of length maxLen or less.
-type Deduplicator struct {
-	set             map[string]struct{}
-	caseInsensitive bool
-	maxLen          int
-}
-
-// contains checks whether the given string has already been seen by this Deduplicator.
-func (s *Deduplicator) contains(u string) bool {
-	dedup := u
-	if s.caseInsensitive {
-		dedup = strings.ToLower(dedup)
-	}
-	if s.maxLen > 0 && len(dedup) > s.maxLen {
-		dedup = dedup[:s.maxLen]
-	}
-	_, seen := s.set[dedup]
-	return seen
-}
-
-// deduplicate returns a unique string based on the given string by appending a uuid to it. Will truncate the given string if
-// the resulting string would be longer than maxLen.
-func (s *Deduplicator) deduplicate(dedup string) string {
-	uid := util.GenerateShortUID()
-	if s.maxLen > 0 && len(dedup)+1+len(uid) > s.maxLen {
-		trunc := s.maxLen - 1 - len(uid)
-		dedup = dedup[:trunc]
-	}
-
-	return dedup + "_" + uid
-}
-
-// add adds the given string to the Deduplicator.
-func (s *Deduplicator) add(uid string) {
-	dedup := uid
-	if s.caseInsensitive {
-		dedup = strings.ToLower(dedup)
-	}
-	s.set[dedup] = struct{}{}
 }

--- a/pkg/services/ngalert/migration/models.go
+++ b/pkg/services/ngalert/migration/models.go
@@ -49,7 +49,7 @@ func (ms *migrationService) newOrgMigration(orgID int64) *OrgMigration {
 		silences: make([]*pb.MeshSilence, 0),
 		titleDeduplicatorForFolder: func(folderUID string) *migmodels.Deduplicator {
 			if _, ok := titlededuplicatorPerFolder[folderUID]; !ok {
-				titlededuplicatorPerFolder[folderUID] = migmodels.NewDeduplicator(ms.store.GetDialect().SupportEngine(), store.AlertDefinitionMaxTitleLength)
+				titlededuplicatorPerFolder[folderUID] = migmodels.NewDeduplicator(ms.migrationStore.CaseInsensitive(), store.AlertDefinitionMaxTitleLength)
 			}
 			return titlededuplicatorPerFolder[folderUID]
 		},

--- a/pkg/services/ngalert/migration/models.go
+++ b/pkg/services/ngalert/migration/models.go
@@ -23,7 +23,6 @@ type OrgMigration struct {
 	encryptionService secrets.Service
 
 	orgID                      int64
-	seenUIDs                   *migmodels.Deduplicator
 	silences                   []*pb.MeshSilence
 	titleDeduplicatorForFolder func(folderUID string) *migmodels.Deduplicator
 
@@ -46,9 +45,7 @@ func (ms *migrationService) newOrgMigration(orgID int64) *OrgMigration {
 		migrationStore:    ms.migrationStore,
 		encryptionService: ms.encryptionService,
 
-		orgID: orgID,
-		// We deduplicate for case-insensitive matching in MySQL-compatible backend flavours because they use case-insensitive collation.
-		seenUIDs: migmodels.NewDeduplicator(ms.store.GetDialect().SupportEngine(), 0),
+		orgID:    orgID,
 		silences: make([]*pb.MeshSilence, 0),
 		titleDeduplicatorForFolder: func(folderUID string) *migmodels.Deduplicator {
 			if _, ok := titlededuplicatorPerFolder[folderUID]; !ok {

--- a/pkg/services/ngalert/migration/models/models.go
+++ b/pkg/services/ngalert/migration/models/models.go
@@ -14,7 +14,7 @@ const MaxIncrementDeduplicationAttempts = 10
 // Deduplicator is a utility for deduplicating strings. It keeps track of the strings it has seen and appends a unique
 // suffix to strings that have already been seen. It can optionally truncate strings before appending the suffix to
 // ensure that the resulting string is not longer than maxLen.
-// This implementation will first try to deduplicate via an auto-incrementing suffix of the form "_2", "_3", etc.
+// This implementation will first try to deduplicate via a sequential index suffix of the form " #2", " #3", etc.
 // If after MaxIncrementDeduplicationAttempts attempts it still cannot find a unique string, it will generate a new
 // unique uid and append that to the string.
 type Deduplicator struct {

--- a/pkg/services/ngalert/migration/models/models.go
+++ b/pkg/services/ngalert/migration/models/models.go
@@ -7,9 +7,9 @@ import (
 	"github.com/grafana/grafana/pkg/util"
 )
 
-// MaxIncrementDeduplicationAttempts is the maximum number of attempts to try to deduplicate a string by appending
-// an incrementing suffix.
-const MaxIncrementDeduplicationAttempts = 10
+// MaxDeduplicationAttempts is the maximum number of attempts to try to deduplicate a string using any
+// individual method, such as sequential index suffixes or uids.
+const MaxDeduplicationAttempts = 10
 
 // Deduplicator is a utility for deduplicating strings. It keeps track of the strings it has seen and appends a unique
 // suffix to strings that have already been seen. It can optionally truncate strings before appending the suffix to
@@ -51,7 +51,7 @@ func (s *Deduplicator) Deduplicate(base string) (string, error) {
 	}
 
 	// Start at 2, so we get a, a_2, a_3, etc.
-	for i := 2 + cnt; i < 2+cnt+MaxIncrementDeduplicationAttempts; i++ {
+	for i := 2 + cnt; i < 2+cnt+MaxDeduplicationAttempts; i++ {
 		dedup := s.appendSuffix(base, fmt.Sprintf(" #%d", i))
 		if _, ok := s.contains(dedup); !ok {
 			s.add(dedup, 0)
@@ -59,9 +59,9 @@ func (s *Deduplicator) Deduplicate(base string) (string, error) {
 		}
 	}
 
-	// None of the simple suffixes worked, so we generate a new uid. We try a few times, just in case but this should
+	// None of the simple suffixes worked, so we generate a new uid. We try a few times, just in case, but this should
 	// almost always create a unique string on the first try.
-	for i := 0; i < 5; i++ {
+	for i := 0; i < MaxDeduplicationAttempts; i++ {
 		dedup := s.appendSuffix(base, fmt.Sprintf("_%s", s.uidGenerator()))
 		if _, ok := s.contains(dedup); !ok {
 			s.add(dedup, 0)

--- a/pkg/services/ngalert/migration/models/models.go
+++ b/pkg/services/ngalert/migration/models/models.go
@@ -1,0 +1,104 @@
+package models
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/grafana/grafana/pkg/util"
+)
+
+// MaxIncrementDeduplicationAttempts is the maximum number of attempts to try to deduplicate a string by appending
+// an incrementing suffix.
+const MaxIncrementDeduplicationAttempts = 10
+
+// Deduplicator is a utility for deduplicating strings. It keeps track of the strings it has seen and appends a unique
+// suffix to strings that have already been seen. It can optionally truncate strings before appending the suffix to
+// ensure that the resulting string is not longer than maxLen.
+// This implementation will first try to deduplicate via an auto-incrementing suffix of the form "_2", "_3", etc.
+// If after MaxIncrementDeduplicationAttempts attempts it still cannot find a unique string, it will generate a new
+// unique uid and append that to the string.
+type Deduplicator struct {
+	set             map[string]int
+	caseInsensitive bool
+	maxLen          int
+	uidGenerator    func() string
+}
+
+// NewDeduplicator creates a new deduplicator.
+// caseInsensitive determines whether the string comparison should be case-insensitive.
+// maxLen determines the maximum length of deduplicated strings. If the deduplicated string would be longer than
+// maxLen, it will be truncated.
+func NewDeduplicator(caseInsensitive bool, maxLen int) *Deduplicator {
+	return &Deduplicator{
+		set:             make(map[string]int),
+		caseInsensitive: caseInsensitive,
+		maxLen:          maxLen,
+		uidGenerator:    util.GenerateShortUID,
+	}
+}
+
+// Deduplicate returns a unique string based on the given base string. If the base string has not already been seen by
+// this deduplicator, it will be returned as-is. If the base string has already been seen, a unique suffix will be
+// appended to the base string to make it unique.
+func (s *Deduplicator) Deduplicate(base string) (string, error) {
+	if s.maxLen > 0 && len(base) > s.maxLen {
+		base = base[:s.maxLen]
+	}
+	cnt, ok := s.contains(base)
+	if !ok {
+		s.add(base, 0)
+		return base, nil
+	}
+
+	// Start at 2, so we get a, a_2, a_3, etc.
+	for i := 2 + cnt; i < 2+cnt+MaxIncrementDeduplicationAttempts; i++ {
+		dedup := s.appendSuffix(base, fmt.Sprintf(" #%d", i))
+		if _, ok := s.contains(dedup); !ok {
+			s.add(dedup, 0)
+			return dedup, nil
+		}
+	}
+
+	// None of the simple suffixes worked, so we generate a new uid. We try a few times, just in case but this should
+	// almost always create a unique string on the first try.
+	for i := 0; i < 5; i++ {
+		dedup := s.appendSuffix(base, fmt.Sprintf("_%s", s.uidGenerator()))
+		if _, ok := s.contains(dedup); !ok {
+			s.add(dedup, 0)
+			return dedup, nil
+		}
+	}
+
+	return "", fmt.Errorf("failed to deduplicate %q", base)
+}
+
+// contains checks whether the given string has already been seen by this deduplicator.
+func (s *Deduplicator) contains(u string) (int, bool) {
+	dedup := u
+	if s.caseInsensitive {
+		dedup = strings.ToLower(dedup)
+	}
+	if s.maxLen > 0 && len(dedup) > s.maxLen {
+		dedup = dedup[:s.maxLen]
+	}
+	cnt, seen := s.set[dedup]
+	return cnt, seen
+}
+
+// appendSuffix appends the given suffix to the given base string. If the resulting string would be longer than maxLen,
+// the base string will be truncated.
+func (s *Deduplicator) appendSuffix(base, suffix string) string {
+	if s.maxLen > 0 && len(base)+len(suffix) > s.maxLen {
+		return base[:s.maxLen-len(suffix)] + suffix
+	}
+	return base + suffix
+}
+
+// add adds the given string to the deduplicator.
+func (s *Deduplicator) add(uid string, cnt int) {
+	dedup := uid
+	if s.caseInsensitive {
+		dedup = strings.ToLower(dedup)
+	}
+	s.set[dedup] = cnt
+}

--- a/pkg/services/ngalert/migration/models/models_test.go
+++ b/pkg/services/ngalert/migration/models/models_test.go
@@ -1,0 +1,149 @@
+package models
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/grafana/pkg/util"
+)
+
+func TestDeduplicator(t *testing.T) {
+	tc := []struct {
+		name            string
+		maxLen          int
+		caseInsensitive bool
+		input           []string
+		expected        []string
+		expectedState   map[string]struct{}
+	}{
+		{
+			name:            "when case insensitive, it deduplicates case-insensitively",
+			caseInsensitive: true,
+			input:           []string{"a", "A", "B", "b", "a", "A", "b", "B"},
+			expected:        []string{"a", "A #2", "B", "b #2", "a #3", "A #4", "b #3", "B #4"},
+		},
+		{
+			name:            "when case sensitive, it deduplicates case-sensitively",
+			caseInsensitive: false,
+			input:           []string{"a", "A", "B", "b", "a", "A", "b", "B"},
+			expected:        []string{"a", "A", "B", "b", "a #2", "A #2", "b #2", "B #2"},
+		},
+		{
+			name:     "when maxLen is 0, it does not truncate",
+			maxLen:   0,
+			input:    []string{strings.Repeat("a", 1000), strings.Repeat("a", 1000)},
+			expected: []string{strings.Repeat("a", 1000), strings.Repeat("a", 1000) + " #2"},
+		},
+		{
+			name:            "when maxLen is > 0, it truncates - caseInsensitive",
+			caseInsensitive: true,
+			maxLen:          10,
+			input:           []string{strings.Repeat("A", 15), strings.Repeat("a", 15), strings.Repeat("A", 15)},
+			expected:        []string{strings.Repeat("A", 10), strings.Repeat("a", 7) + " #2", strings.Repeat("A", 7) + " #3"},
+		},
+		{
+			name:     "when maxLen is > 0, it truncates - caseSensitive",
+			maxLen:   10,
+			input:    []string{strings.Repeat("A", 15), strings.Repeat("a", 15), strings.Repeat("A", 15)},
+			expected: []string{strings.Repeat("A", 10), strings.Repeat("a", 10), strings.Repeat("A", 7) + " #2"},
+		},
+		{
+			name:            "when truncate causes collision, it deduplicates - caseInsensitive",
+			caseInsensitive: true,
+			maxLen:          10,
+			input:           []string{strings.Repeat("A", 15), strings.Repeat("a", 10), strings.Repeat("b", 15), strings.Repeat("B", 10)},
+			expected:        []string{strings.Repeat("A", 10), strings.Repeat("a", 7) + " #2", strings.Repeat("b", 10), strings.Repeat("B", 7) + " #2"},
+		},
+		{
+			name:     "when truncate causes collision, it deduplicates - caseSensitive",
+			maxLen:   10,
+			input:    []string{strings.Repeat("A", 15), strings.Repeat("A", 10)},
+			expected: []string{strings.Repeat("A", 10), strings.Repeat("A", 7) + " #2"},
+		},
+		{
+			name:            "when deduplicate causes collision, it deduplicates - caseInsensitive",
+			caseInsensitive: true,
+			maxLen:          10,
+			input:           []string{"A", "a", "a #2", "b", "B", "B #2"},
+			expected:        []string{"A", "a #2", "a #2 #2", "b", "B #2", "B #2 #2"},
+		},
+		{
+			name:     "when deduplicate causes collision, it deduplicates - caseSensitive",
+			maxLen:   10,
+			input:    []string{"a", "a", "a #2", "b", "b", "b #2"},
+			expected: []string{"a", "a #2", "a #2 #2", "b", "b #2", "b #2 #2"},
+		},
+		{
+			name:            "when deduplicate causes collision, it finds next available increment - caseInsensitive",
+			caseInsensitive: true,
+			maxLen:          10,
+			input:           []string{"a", "A #2", "a #3", "A #4", "a #5", "A #6", "a #7", "A #8", "a #9", "A #10", "a"},
+			expected:        []string{"a", "A #2", "a #3", "A #4", "a #5", "A #6", "a #7", "A #8", "a #9", "A #10", "a #11"},
+		},
+		{
+			name:     "when deduplicate causes collision, it finds next available increment - caseSensitive",
+			maxLen:   10,
+			input:    []string{"a", "a #2", "a #3", "a #4", "a #5", "a #6", "a #7", "a #8", "a #9", "a #10", "a"},
+			expected: []string{"a", "a #2", "a #3", "a #4", "a #5", "a #6", "a #7", "a #8", "a #9", "a #10", "a #11"},
+		},
+		{
+			name:            "when deduplicate causes collision enough times, it deduplicates with uid - caseInsensitive",
+			caseInsensitive: true,
+			maxLen:          10,
+			input:           []string{"a", "A #2", "a #3", "A #4", "a #5", "A #6", "a #7", "A #8", "a #9", "A #10", "a #11", "A"},
+			expected:        []string{"a", "A #2", "a #3", "A #4", "a #5", "A #6", "a #7", "A #8", "a #9", "A #10", "a #11", "A_uid-1"},
+		},
+		{
+			name:     "when deduplicate causes collision enough times, it deduplicates with uid - caseSensitive",
+			maxLen:   10,
+			input:    []string{"a", "a #2", "a #3", "a #4", "a #5", "a #6", "a #7", "a #8", "a #9", "a #10", "a #11", "a"},
+			expected: []string{"a", "a #2", "a #3", "a #4", "a #5", "a #6", "a #7", "a #8", "a #9", "a #10", "a #11", "a_uid-1"},
+		},
+	}
+
+	for _, tt := range tc {
+		t.Run(tt.name, func(t *testing.T) {
+			inc := 0
+			mockUidGenerator := func() string {
+				inc++
+				return fmt.Sprintf("uid-%d", inc)
+			}
+			dedup := Deduplicator{
+				set:             make(map[string]int),
+				caseInsensitive: tt.caseInsensitive,
+				maxLen:          tt.maxLen,
+				uidGenerator:    mockUidGenerator,
+			}
+			out := make([]string, 0, len(tt.input))
+			for _, in := range tt.input {
+				d, err := dedup.Deduplicate(in)
+				require.NoError(t, err)
+				out = append(out, d)
+			}
+			require.Equal(t, tt.expected, out)
+		})
+	}
+}
+
+func Test_shortUIDCaseInsensitiveConflicts(t *testing.T) {
+	s := Deduplicator{
+		set:             make(map[string]int),
+		caseInsensitive: true,
+	}
+
+	// 10000 uids seems to be enough to cause a collision in almost every run if using util.GenerateShortUID directly.
+	for i := 0; i < 10000; i++ {
+		s.add(util.GenerateShortUID(), 0)
+	}
+
+	// check if any are case-insensitive duplicates.
+	deduped := make(map[string]struct{})
+	for k := range s.set {
+		deduped[strings.ToLower(k)] = struct{}{}
+	}
+
+	require.Equal(t, len(s.set), len(deduped))
+}

--- a/pkg/services/ngalert/migration/permissions_test.go
+++ b/pkg/services/ngalert/migration/permissions_test.go
@@ -55,7 +55,7 @@ func TestDashAlertPermissionMigration(t *testing.T) {
 			},
 			NamespaceUID:    namespaceUID,
 			DashboardUID:    &dashboardUID,
-			RuleGroup:       fmt.Sprintf("%s - %ds", dashTitle, 60),
+			RuleGroup:       fmt.Sprintf("%s - 1m", dashTitle),
 			IntervalSeconds: 60,
 			Version:         1,
 			PanelID:         pointer(int64(1)),

--- a/pkg/services/ngalert/migration/permissions_test.go
+++ b/pkg/services/ngalert/migration/permissions_test.go
@@ -40,6 +40,7 @@ func TestDashAlertPermissionMigration(t *testing.T) {
 	}
 
 	genAlert := func(title string, namespaceUID string, dashboardUID string, mutators ...func(*ngModels.AlertRule)) *ngModels.AlertRule {
+		dashTitle := "Dashboard Title " + dashboardUID
 		a := &ngModels.AlertRule{
 			ID:        1,
 			OrgID:     1,
@@ -54,7 +55,7 @@ func TestDashAlertPermissionMigration(t *testing.T) {
 			},
 			NamespaceUID:    namespaceUID,
 			DashboardUID:    &dashboardUID,
-			RuleGroup:       fmt.Sprintf("Dashboard Title %s - %d", dashboardUID, 1),
+			RuleGroup:       fmt.Sprintf("%s - %ds", dashTitle, 60),
 			IntervalSeconds: 60,
 			Version:         1,
 			PanelID:         pointer(int64(1)),
@@ -82,7 +83,6 @@ func TestDashAlertPermissionMigration(t *testing.T) {
 		return func(a *ngModels.AlertRule) {
 			a.PanelID = pointer(id)
 			a.Annotations["__panelId__"] = fmt.Sprintf("%d", id)
-			a.RuleGroup = fmt.Sprintf("Dashboard Title %s - %d", *a.DashboardUID, id)
 		}
 	}
 

--- a/pkg/services/ngalert/migration/store/database.go
+++ b/pkg/services/ngalert/migration/store/database.go
@@ -61,8 +61,6 @@ type Store interface {
 	SetOrgMigrationState(ctx context.Context, orgID int64, summary *migmodels.OrgMigrationState) error
 
 	RevertAllOrgs(ctx context.Context) error
-
-	CaseInsensitive() bool
 }
 
 type migrationStore struct {
@@ -435,8 +433,4 @@ func (ms *migrationStore) SetFolderPermissions(ctx context.Context, orgID int64,
 
 func (ms *migrationStore) MapActions(permission accesscontrol.ResourcePermission) string {
 	return ms.dashboardPermissions.MapActions(permission)
-}
-
-func (ms *migrationStore) CaseInsensitive() bool {
-	return ms.store.GetDialect().SupportEngine()
 }

--- a/pkg/services/ngalert/migration/store/database.go
+++ b/pkg/services/ngalert/migration/store/database.go
@@ -61,6 +61,8 @@ type Store interface {
 	SetOrgMigrationState(ctx context.Context, orgID int64, summary *migmodels.OrgMigrationState) error
 
 	RevertAllOrgs(ctx context.Context) error
+
+	CaseInsensitive() bool
 }
 
 type migrationStore struct {
@@ -433,4 +435,8 @@ func (ms *migrationStore) SetFolderPermissions(ctx context.Context, orgID int64,
 
 func (ms *migrationStore) MapActions(permission accesscontrol.ResourcePermission) string {
 	return ms.dashboardPermissions.MapActions(permission)
+}
+
+func (ms *migrationStore) CaseInsensitive() bool {
+	return ms.store.GetDialect().SupportEngine()
 }

--- a/pkg/services/ngalert/migration/ualert_test.go
+++ b/pkg/services/ngalert/migration/ualert_test.go
@@ -3,7 +3,6 @@ package migration
 import (
 	"encoding/json"
 	"fmt"
-	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -132,26 +131,6 @@ func Test_getAlertFolderNameFromDashboard(t *testing.T) {
 		require.Len(t, name, MaxFolderName)
 		require.Contains(t, name, hash)
 	})
-}
-
-func Test_shortUIDCaseInsensitiveConflicts(t *testing.T) {
-	s := Deduplicator{
-		set:             make(map[string]struct{}),
-		caseInsensitive: true,
-	}
-
-	// 10000 uids seems to be enough to cause a collision in almost every run if using util.GenerateShortUID directly.
-	for i := 0; i < 10000; i++ {
-		s.add(util.GenerateShortUID())
-	}
-
-	// check if any are case-insensitive duplicates.
-	deduped := make(map[string]struct{})
-	for k := range s.set {
-		deduped[strings.ToLower(k)] = struct{}{}
-	}
-
-	require.Equal(t, len(s.set), len(deduped))
 }
 
 func mustRawMessage[T any](s T) apimodels.RawMessage {


### PR DESCRIPTION
**What is this feature?**

 This change improves alert titles generated in the legacy migration that occur when we need to deduplicate titles. Now when duplicate titles are detected we will first attempt to append a sequential index, falling back to a random uid if none are unique within 10 attempts. This should cause shorter and more easily readable deduplicated titles in most cases.

In addition, groups are no longer deduplicated. Instead we set them to a combination of truncated dashboard name and humanized alert frequency. This way, alerts from the same dashboard share a group if they have the same evaluation interval. In the event that truncation causes overlap, it won't be a big issue as all alerts will still be in a group with the correct evaluation interval.

**Who is this feature for?**

Users migrating from legacy alerting to Grafana Alerting (UA)

`alertA` in `panel1` in `dashboard1` in `folder1` - `60s` interval
`alertA` in `panel2` in `dashboard1` in `folder1` - `60s` interval
`alertB` in `panel1` in `dashboard2` in `folder1` - `300s` interval

These would migrate to as follows.

Before this change (example uid):
`alertA`                                                                      in group `dashboard1 - 1` in `folder1`
`alertA_c976a621-4f7a-4963-82c3-0e58e2e5311f` in group `dashboard1 - 2` in `folder1`
`alertB`                                                                      in group `dashboard2 - 1` in `folder1`


After this change:
`alertA`        in group `dashboard1 - 1m` in `folder1`
`alertA #2` in group `dashboard1 - 1m` in `folder1`
`alertB`        in group `dashboard2 - 5m` in `folder1`