### PR TITLE
Alerting: Introduce a Mimir client as part of the Remote Alertmanager

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -802,7 +802,7 @@ services:
 - commands:
   - /bin/mimir -target=backend
   environment: {}
-  image: grafana/mimir:latest
+  image: us.gcr.io/kubernetes-dev/mimir:gotjosh-state-config-grafana-663a0ae78
   name: mimir_backend
 - environment: {}
   image: redis:6.2.11-alpine
@@ -1246,7 +1246,7 @@ services:
 - commands:
   - /bin/mimir -target=backend
   environment: {}
-  image: grafana/mimir:latest
+  image: us.gcr.io/kubernetes-dev/mimir:gotjosh-state-config-grafana-663a0ae78
   name: mimir_backend
 - environment: {}
   image: redis:6.2.11-alpine
@@ -2174,7 +2174,7 @@ services:
 - commands:
   - /bin/mimir -target=backend
   environment: {}
-  image: grafana/mimir:latest
+  image: us.gcr.io/kubernetes-dev/mimir:gotjosh-state-config-grafana-663a0ae78
   name: mimir_backend
 - environment: {}
   image: redis:6.2.11-alpine
@@ -3844,7 +3844,7 @@ services:
 - commands:
   - /bin/mimir -target=backend
   environment: {}
-  image: grafana/mimir:latest
+  image: us.gcr.io/kubernetes-dev/mimir:gotjosh-state-config-grafana-663a0ae78
   name: mimir_backend
 - environment: {}
   image: redis:6.2.11-alpine
@@ -4413,7 +4413,7 @@ steps:
   - trivy --exit-code 0 --severity UNKNOWN,LOW,MEDIUM plugins/slack
   - trivy --exit-code 0 --severity UNKNOWN,LOW,MEDIUM python:3.8
   - trivy --exit-code 0 --severity UNKNOWN,LOW,MEDIUM postgres:12.3-alpine
-  - trivy --exit-code 0 --severity UNKNOWN,LOW,MEDIUM grafana/mimir:latest
+  - trivy --exit-code 0 --severity UNKNOWN,LOW,MEDIUM us.gcr.io/kubernetes-dev/mimir:gotjosh-state-config-grafana-663a0ae78
   - trivy --exit-code 0 --severity UNKNOWN,LOW,MEDIUM mysql:5.7.39
   - trivy --exit-code 0 --severity UNKNOWN,LOW,MEDIUM mysql:8.0.32
   - trivy --exit-code 0 --severity UNKNOWN,LOW,MEDIUM redis:6.2.11-alpine
@@ -4447,7 +4447,7 @@ steps:
   - trivy --exit-code 1 --severity HIGH,CRITICAL plugins/slack
   - trivy --exit-code 1 --severity HIGH,CRITICAL python:3.8
   - trivy --exit-code 1 --severity HIGH,CRITICAL postgres:12.3-alpine
-  - trivy --exit-code 1 --severity HIGH,CRITICAL grafana/mimir:latest
+  - trivy --exit-code 1 --severity HIGH,CRITICAL us.gcr.io/kubernetes-dev/mimir:gotjosh-state-config-grafana-663a0ae78
   - trivy --exit-code 1 --severity HIGH,CRITICAL mysql:5.7.39
   - trivy --exit-code 1 --severity HIGH,CRITICAL mysql:8.0.32
   - trivy --exit-code 1 --severity HIGH,CRITICAL redis:6.2.11-alpine
@@ -4685,6 +4685,6 @@ kind: secret
 name: gcr_credentials
 ---
 kind: signature
-hmac: 64302d9316abab775d7ec1132f26ea4f1829558fa0bfd85812597182c1abe61a
+hmac: d9813a22ff4c27f10390121d7df90ed3359381c2f28bf2cd64b8fa6af167664a
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -980,7 +980,6 @@ steps:
   - wire-install
   - wait-for-remote-alertmanager
   environment:
-    AM_PASSWORD: test
     AM_TENANT_ID: test
     AM_URL: http://mimir_backend:8080
   image: golang:1.21.3-alpine
@@ -2331,7 +2330,6 @@ steps:
   - wire-install
   - wait-for-remote-alertmanager
   environment:
-    AM_PASSWORD: test
     AM_TENANT_ID: test
     AM_URL: http://mimir_backend:8080
   image: golang:1.21.3-alpine
@@ -3994,7 +3992,6 @@ steps:
   - wire-install
   - wait-for-remote-alertmanager
   environment:
-    AM_PASSWORD: test
     AM_TENANT_ID: test
     AM_URL: http://mimir_backend:8080
   image: golang:1.21.3-alpine
@@ -4685,6 +4682,6 @@ kind: secret
 name: gcr_credentials
 ---
 kind: signature
-hmac: d9813a22ff4c27f10390121d7df90ed3359381c2f28bf2cd64b8fa6af167664a
+hmac: 0e9f67184e414d3afbda81c86dfa58b3c2cf7c1a668be5313c851ff5f42de44d
 
 ...

--- a/Makefile
+++ b/Makefile
@@ -184,7 +184,7 @@ test-go-integration: ## Run integration tests for backend with flags.
 test-go-integration-alertmanager: ## Run integration tests for the remote alertmanager (config taken from the mimir_backend block).
 	@echo "test remote alertmanager integration tests"
 	$(GO) clean -testcache
-	AM_URL=http://localhost:8080 AM_TENANT_ID=test AM_PASSWORD=test \
+	AM_URL=http://localhost:8080 AM_TENANT_ID=test \
 	$(GO) test -count=1 -run "^TestIntegrationRemoteAlertmanager" -covermode=atomic -timeout=5m ./pkg/services/ngalert/...
 
 .PHONY: test-go-integration-postgres

--- a/pkg/services/ngalert/remote/alertmanager.go
+++ b/pkg/services/ngalert/remote/alertmanager.go
@@ -88,7 +88,7 @@ func NewAlertmanager(cfg AlertmanagerConfig, orgID int64) (*Alertmanager, error)
 	s.Run()
 
 	err = s.ApplyConfig(orgID, 0, []sender.ExternalAMcfg{{
-		URL: cfg.URL,
+		URL: cfg.URL + "/alertmanager",
 	}})
 	if err != nil {
 		return nil, err

--- a/pkg/services/ngalert/remote/alertmanager.go
+++ b/pkg/services/ngalert/remote/alertmanager.go
@@ -33,7 +33,7 @@ type Alertmanager struct {
 	url      string
 
 	amClient    *amclient.AlertmanagerAPI
-	mimirClient *mimirClient.Mimir
+	mimirClient mimirClient.MimirClient
 	httpClient  *http.Client
 	ready       bool
 	sender      *sender.ExternalAlertmanager
@@ -337,7 +337,7 @@ func (am *Alertmanager) TestTemplate(ctx context.Context, c apimodels.TestTempla
 }
 
 // StopAndWait is called when the grafana server is instructed to shut down or an org is deleted.
-// In the context of a "remote Alertmanager" is a good heuristic for Grafana is about to shut down or we no longer need you.
+// In the context of a "remote Alertmanager" it is a good heuristic for Grafana is about to shut down or we no longer need you.
 func (am *Alertmanager) StopAndWait() {
 	am.sender.Stop()
 

--- a/pkg/services/ngalert/remote/alertmanager.go
+++ b/pkg/services/ngalert/remote/alertmanager.go
@@ -361,8 +361,6 @@ func (am *Alertmanager) compareRemoteConfig(ctx context.Context, config *models.
 	}
 
 	return md5.Sum([]byte(rc.GrafanaAlertmanagerConfig)) == md5.Sum([]byte(config.AlertmanagerConfiguration))
-
-	return false
 }
 
 // compareRemoteState gets the remote Alertmanager state and compares it to the existing state.
@@ -375,6 +373,4 @@ func (am *Alertmanager) compareRemoteState(ctx context.Context, state string) bo
 	}
 
 	return rs.State == state
-
-	return false
 }

--- a/pkg/services/ngalert/remote/alertmanager.go
+++ b/pkg/services/ngalert/remote/alertmanager.go
@@ -121,7 +121,6 @@ func (am *Alertmanager) ApplyConfig(ctx context.Context, config *models.AlertCon
 	am.log.Debug("start readiness check for remote Alertmanager", "url", am.url)
 	err := am.checkReadiness(ctx)
 	if err != nil {
-		// TODO: Should we be returning nil here?
 		am.log.Error("unable to pass the readiness check", "err", err)
 		return err
 	}
@@ -130,7 +129,6 @@ func (am *Alertmanager) ApplyConfig(ctx context.Context, config *models.AlertCon
 	am.log.Debug("start configuration upload to remote Alertmanager", "url", am.url)
 	ok := am.compareRemoteConfig(ctx, config)
 	if !ok {
-		// TODO: We probably need to parse the config anyways.
 		err = am.mimirClient.CreateGrafanaAlertmanagerConfig(ctx, config.AlertmanagerConfiguration, config.ConfigurationHash, config.ID, config.CreatedAt, config.Default)
 		if err != nil {
 			am.log.Error("unable to upload the configuration to the remote Alertmanager", "err", err)

--- a/pkg/services/ngalert/remote/alertmanager.go
+++ b/pkg/services/ngalert/remote/alertmanager.go
@@ -108,7 +108,7 @@ func NewAlertmanager(cfg AlertmanagerConfig, orgID int64) (*Alertmanager, error)
 
 // ApplyConfig is called everytime we've determined we need to apply a configuration to the Alertmanager,
 // including the first time the Alertmanager is started. In the context of a "remote Alertmanager" it's as good of a heuristic,
-// for "a function that gets called when the Alertmanager starts. As a result we do two things:
+// for "a function that gets called when the Alertmanager starts". As a result we do two things:
 // 1. Execute a readiness check to make sure the remote Alertmanager we're about to communicate with is up and ready.
 // 2. Upload the configuration and state we currently hold.
 func (am *Alertmanager) ApplyConfig(ctx context.Context, config *models.AlertConfiguration) error {

--- a/pkg/services/ngalert/remote/alertmanager_test.go
+++ b/pkg/services/ngalert/remote/alertmanager_test.go
@@ -19,9 +19,6 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// Valid config for Cloud AM, no `grafana_managed_receievers` field.
-const upstreamConfig = `{"template_files": {}, "alertmanager_config": "{\"global\": {\"smtp_from\": \"test@test.com\"}, \"route\": {\"receiver\": \"discord\"}, \"receivers\": [{\"name\": \"discord\", \"discord_configs\": [{\"webhook_url\": \"http://localhost:1234\"}]}]}"}`
-
 // Valid Grafana Alertmanager configuration.
 const testGrafanaConfig = `{"template_files":{},"alertmanager_config":{"route":{"receiver":"grafana-default-email","group_by":["grafana_folder","alertname"]},"templates":null,"receivers":[{"name":"grafana-default-email","grafana_managed_receiver_configs":[{"uid":"","name":"some other name","type":"email","disableResolveMessage":false,"settings":{"addresses":"\u003cexample@email.com\u003e"},"secureSettings":null}]}]}}`
 

--- a/pkg/services/ngalert/remote/alertmanager_test.go
+++ b/pkg/services/ngalert/remote/alertmanager_test.go
@@ -151,7 +151,7 @@ func TestIntegrationRemoteAlertmanagerApplyConfigOnlyUploadsOnce(t *testing.T) {
 	{
 		require.NoError(t, am.ApplyConfig(ctx, fakeConfig))
 
-		// First, we need to verify that passed the readiness check.
+		// First, we need to verify that the readiness check passes.
 		require.True(t, am.Ready())
 
 		// Next, we need to verify that Mimir received the configuration.
@@ -166,7 +166,7 @@ func TestIntegrationRemoteAlertmanagerApplyConfigOnlyUploadsOnce(t *testing.T) {
 		// TODO: Check that the state was uploaded.
 	}
 
-	// Calling `ApplyConfig` aagain with a changed configuration yields no effect.
+	// Calling `ApplyConfig` again with a changed configuration yields no effect.
 	{
 		fakeConfig.ID = 30000000000000000
 		require.NoError(t, am.ApplyConfig(ctx, fakeConfig))

--- a/pkg/services/ngalert/remote/alertmanager_test.go
+++ b/pkg/services/ngalert/remote/alertmanager_test.go
@@ -2,13 +2,18 @@ package remote
 
 import (
 	"context"
+	"encoding/json"
 	"math/rand"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"testing"
 	"time"
 
 	"github.com/go-openapi/strfmt"
 	apimodels "github.com/grafana/grafana/pkg/services/ngalert/api/tooling/definitions"
+	ngmodels "github.com/grafana/grafana/pkg/services/ngalert/models"
+	"github.com/grafana/grafana/pkg/services/ngalert/notifier"
 	"github.com/grafana/grafana/pkg/util"
 	amv2 "github.com/prometheus/alertmanager/api/v2/models"
 	"github.com/stretchr/testify/require"
@@ -16,6 +21,9 @@ import (
 
 // Valid config for Cloud AM, no `grafana_managed_receievers` field.
 const upstreamConfig = `{"template_files": {}, "alertmanager_config": "{\"global\": {\"smtp_from\": \"test@test.com\"}, \"route\": {\"receiver\": \"discord\"}, \"receivers\": [{\"name\": \"discord\", \"discord_configs\": [{\"webhook_url\": \"http://localhost:1234\"}]}]}"}`
+
+// Valid Grafana Alertmanager configuration.
+const testGrafanaConfig = `{"template_files":{},"alertmanager_config":{"route":{"receiver":"grafana-default-email","group_by":["grafana_folder","alertname"]},"templates":null,"receivers":[{"name":"grafana-default-email","grafana_managed_receiver_configs":[{"uid":"","name":"some other name","type":"email","disableResolveMessage":false,"settings":{"addresses":"\u003cexample@email.com\u003e"},"secureSettings":null}]}]}}`
 
 func TestNewAlertmanager(t *testing.T) {
 	tests := []struct {
@@ -50,7 +58,7 @@ func TestNewAlertmanager(t *testing.T) {
 				TenantID:          test.tenantID,
 				BasicAuthPassword: test.password,
 			}
-			am, err := NewAlertmanager(cfg, test.orgID)
+			am, err := NewAlertmanager(cfg, test.orgID, nil)
 			if test.expErr != "" {
 				require.EqualError(tt, err, test.expErr)
 				return
@@ -64,6 +72,111 @@ func TestNewAlertmanager(t *testing.T) {
 			require.NotNil(tt, am.httpClient)
 		})
 	}
+}
+
+func TestApplyConfig(t *testing.T) {
+	errorHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	})
+	okHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+
+	// ApplyConfig performs a readiness check at startup.
+	// A non-200 response should result in an error.
+	server := httptest.NewServer(errorHandler)
+	cfg := AlertmanagerConfig{
+		URL: server.URL,
+	}
+	am, err := NewAlertmanager(cfg, 1, nil)
+	require.NoError(t, err)
+
+	ctx := context.Background()
+	require.Error(t, am.ApplyConfig(ctx, nil))
+	require.False(t, am.Ready())
+
+	// A 200 status code response should make the check succeed.
+	server.Config.Handler = okHandler
+	require.NoError(t, am.ApplyConfig(ctx, nil))
+	require.True(t, am.Ready())
+
+	// If we already got a 200 status code response, we shouldn't make the HTTP request again.
+	server.Config.Handler = errorHandler
+	require.NoError(t, am.ApplyConfig(ctx, nil))
+	require.True(t, am.Ready())
+}
+
+func TestIntegrationRemoteAlertmanagerConfiguration(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
+
+	amURL, ok := os.LookupEnv("AM_URL")
+	if !ok {
+		t.Skip("No Alertmanager URL provided")
+	}
+	tenantID := os.Getenv("AM_TENANT_ID")
+	password := os.Getenv("AM_PASSWORD")
+
+	// ApplyConfig performs a readiness check.
+	cfg := AlertmanagerConfig{
+		URL:               amURL + "/alertmanager",
+		TenantID:          tenantID,
+		BasicAuthPassword: password,
+		ConfigEndpoint:    "/api/v1/grafana/config",
+	}
+	store := notifier.NewFakeConfigStore(t, make(map[int64]*ngmodels.AlertConfiguration))
+	am, err := NewAlertmanager(cfg, 1, store)
+	require.NoError(t, err)
+
+	// We should have no configuration at first.
+	ctx := context.Background()
+	_, err = am.getConfig(ctx)
+	require.Error(t, err)
+	require.Equal(t, "config not found", err.Error())
+
+	// ApplyConfig performs a readiness check.
+	require.NoError(t, am.ApplyConfig(ctx, nil))
+
+	// SaveAndApplyConfig should send the configuration to the remote Alertmanager and store it locally.
+	config, err := notifier.Load([]byte(testGrafanaConfig))
+	require.NoError(t, err)
+	require.NoError(t, am.SaveAndApplyConfig(ctx, config))
+
+	// Retrieving the config should succeed, the configurations should be the same.
+	config, err = am.getConfig(ctx)
+	require.NoError(t, err)
+
+	b, err := json.Marshal(config)
+	require.NoError(t, err)
+	require.JSONEq(t, testGrafanaConfig, string(b))
+
+	savedConfig, err := store.GetLatestAlertmanagerConfiguration(ctx, &ngmodels.GetLatestAlertmanagerConfigurationQuery{
+		OrgID: 1,
+	})
+	require.NoError(t, err)
+	require.Equal(t, testGrafanaConfig, savedConfig.AlertmanagerConfiguration)
+
+	// SaveAndApplyDefaultConfig should pull the configuration from the remote Alertmanager and save it locally.
+	// Let's save an empty config to the store.
+	require.NoError(t, store.SaveAlertmanagerConfiguration(ctx, &ngmodels.SaveAlertmanagerConfigurationCmd{
+		OrgID: 1,
+	}))
+
+	// Check that the previous config is not returned.
+	savedConfig, err = store.GetLatestAlertmanagerConfiguration(ctx, &ngmodels.GetLatestAlertmanagerConfigurationQuery{
+		OrgID: 1,
+	})
+	require.NoError(t, err)
+	require.NotEqual(t, testGrafanaConfig, savedConfig.AlertmanagerConfiguration)
+
+	// Call SavenAndApplyDefaultConfig and check the configuration in the store.
+	require.NoError(t, am.SaveAndApplyDefaultConfig(ctx))
+	savedConfig, err = store.GetLatestAlertmanagerConfiguration(ctx, &ngmodels.GetLatestAlertmanagerConfigurationQuery{
+		OrgID: 1,
+	})
+	require.NoError(t, err)
+	require.Equal(t, testGrafanaConfig, savedConfig.AlertmanagerConfiguration)
 }
 
 func TestIntegrationRemoteAlertmanagerSilences(t *testing.T) {
@@ -83,7 +196,7 @@ func TestIntegrationRemoteAlertmanagerSilences(t *testing.T) {
 		TenantID:          tenantID,
 		BasicAuthPassword: password,
 	}
-	am, err := NewAlertmanager(cfg, 1)
+	am, err := NewAlertmanager(cfg, 1, nil)
 	require.NoError(t, err)
 
 	// We should have no silences at first.
@@ -162,7 +275,7 @@ func TestIntegrationRemoteAlertmanagerAlerts(t *testing.T) {
 		TenantID:          tenantID,
 		BasicAuthPassword: password,
 	}
-	am, err := NewAlertmanager(cfg, 1)
+	am, err := NewAlertmanager(cfg, 1, nil)
 	require.NoError(t, err)
 
 	// Wait until the Alertmanager is ready to send alerts.
@@ -224,7 +337,7 @@ func TestIntegrationRemoteAlertmanagerReceivers(t *testing.T) {
 		BasicAuthPassword: password,
 	}
 
-	am, err := NewAlertmanager(cfg, 1)
+	am, err := NewAlertmanager(cfg, 1, nil)
 	require.NoError(t, err)
 
 	// We should start with the default config.
@@ -233,7 +346,9 @@ func TestIntegrationRemoteAlertmanagerReceivers(t *testing.T) {
 	require.Equal(t, "empty-receiver", *rcvs[0].Name)
 
 	// After changing the configuration, we should have a new `discord` receiver.
-	require.NoError(t, am.postConfig(context.Background(), upstreamConfig))
+	remoteCfg, err := notifier.Load([]byte(upstreamConfig))
+	require.NoError(t, err)
+	require.NoError(t, am.postConfig(context.Background(), remoteCfg))
 	require.Eventually(t, func() bool {
 		rcvs, err = am.GetReceivers(context.Background())
 		require.NoError(t, err)

--- a/pkg/services/ngalert/remote/alertmanager_test.go
+++ b/pkg/services/ngalert/remote/alertmanager_test.go
@@ -136,7 +136,6 @@ func TestIntegrationRemoteAlertmanagerApplyConfigOnlyUploadsOnce(t *testing.T) {
 	}
 
 	ctx := context.Background()
-	// store := notifier.NewFakeConfigStore(t, make(map[int64]*ngmodels.AlertConfiguration))
 	am, err := NewAlertmanager(cfg, 1)
 	require.NoError(t, err)
 

--- a/pkg/services/ngalert/remote/alertmanager_test.go
+++ b/pkg/services/ngalert/remote/alertmanager_test.go
@@ -143,7 +143,7 @@ func TestIntegrationRemoteAlertmanagerApplyConfigOnlyUploadsOnce(t *testing.T) {
 	{
 		_, err = am.mimirClient.GetGrafanaAlertmanagerConfig(ctx)
 		require.Error(t, err)
-		require.Equal(t, "error response from the Mimir API: alertmanager storage object not found", err.Error())
+		require.Equal(t, "Error response from the Mimir API: alertmanager storage object not found", err.Error())
 	}
 
 	// Using `ApplyConfig` as a heuristic of a function that gets called when the Alertmanager starts

--- a/pkg/services/ngalert/remote/alertmanager_test.go
+++ b/pkg/services/ngalert/remote/alertmanager_test.go
@@ -88,18 +88,19 @@ func TestApplyConfig(t *testing.T) {
 	am, err := NewAlertmanager(cfg, 1)
 	require.NoError(t, err)
 
+	config := &ngmodels.AlertConfiguration{}
 	ctx := context.Background()
-	require.Error(t, am.ApplyConfig(ctx, nil))
+	require.Error(t, am.ApplyConfig(ctx, config))
 	require.False(t, am.Ready())
 
 	// A 200 status code response should make the check succeed.
 	server.Config.Handler = okHandler
-	require.NoError(t, am.ApplyConfig(ctx, nil))
+	require.NoError(t, am.ApplyConfig(ctx, config))
 	require.True(t, am.Ready())
 
 	// If we already got a 200 status code response, we shouldn't make the HTTP request again.
 	server.Config.Handler = errorHandler
-	require.NoError(t, am.ApplyConfig(ctx, nil))
+	require.NoError(t, am.ApplyConfig(ctx, config))
 	require.True(t, am.Ready())
 }
 

--- a/pkg/services/ngalert/remote/alertmanager_test.go
+++ b/pkg/services/ngalert/remote/alertmanager_test.go
@@ -203,7 +203,7 @@ func TestIntegrationRemoteAlertmanagerSilences(t *testing.T) {
 	password := os.Getenv("AM_PASSWORD")
 
 	cfg := AlertmanagerConfig{
-		URL:               amURL + "/alertmanager",
+		URL:               amURL,
 		TenantID:          tenantID,
 		BasicAuthPassword: password,
 	}
@@ -282,7 +282,7 @@ func TestIntegrationRemoteAlertmanagerAlerts(t *testing.T) {
 	password := os.Getenv("AM_PASSWORD")
 
 	cfg := AlertmanagerConfig{
-		URL:               amURL + "/alertmanager",
+		URL:               amURL,
 		TenantID:          tenantID,
 		BasicAuthPassword: password,
 	}
@@ -343,7 +343,7 @@ func TestIntegrationRemoteAlertmanagerReceivers(t *testing.T) {
 	password := os.Getenv("AM_PASSWORD")
 
 	cfg := AlertmanagerConfig{
-		URL:               amURL + "/alertmanager",
+		URL:               amURL,
 		TenantID:          tenantID,
 		BasicAuthPassword: password,
 	}

--- a/pkg/services/ngalert/remote/client/alertmanager_configuration.go
+++ b/pkg/services/ngalert/remote/client/alertmanager_configuration.go
@@ -12,7 +12,6 @@ const (
 	grafanaAlertmanagerConfigPath = "/api/v1/grafana/config"
 )
 
-// TODO: successresponse should only be private.
 type UserGrafanaConfig struct {
 	ID                        int64  `json:"id"`
 	GrafanaAlertmanagerConfig string `json:"configuration"`

--- a/pkg/services/ngalert/remote/client/alertmanager_configuration.go
+++ b/pkg/services/ngalert/remote/client/alertmanager_configuration.go
@@ -27,7 +27,7 @@ func (mc *Mimir) GetGrafanaAlertmanagerConfig(ctx context.Context) (*UserGrafana
 	}
 	// nolint:bodyclose
 	// closed within `do`
-	_, err := mc.do(ctx, grafanaAlertmanagerConfigPath, http.MethodGet, nil, -1, &response)
+	_, err := mc.do(ctx, grafanaAlertmanagerConfigPath, http.MethodGet, nil, &response)
 	if err != nil {
 		return nil, err
 	}
@@ -51,9 +51,9 @@ func (mc *Mimir) CreateGrafanaAlertmanagerConfig(ctx context.Context, c, hash st
 		return err
 	}
 
-	return mc.doOK(ctx, grafanaAlertmanagerConfigPath, http.MethodPost, bytes.NewBuffer(payload), int64(len(payload)))
+	return mc.doOK(ctx, grafanaAlertmanagerConfigPath, http.MethodPost, bytes.NewBuffer(payload))
 }
 
 func (mc *Mimir) DeleteGrafanaAlertmanagerConfig(ctx context.Context) error {
-	return mc.doOK(ctx, grafanaAlertmanagerConfigPath, http.MethodDelete, nil, -1)
+	return mc.doOK(ctx, grafanaAlertmanagerConfigPath, http.MethodDelete, nil)
 }

--- a/pkg/services/ngalert/remote/client/alertmanager_configuration.go
+++ b/pkg/services/ngalert/remote/client/alertmanager_configuration.go
@@ -1,0 +1,49 @@
+package client
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+)
+
+const (
+	grafanaAlertmanagerConfigPath = "/grafana/config"
+)
+
+type UserGrafanaConfig struct {
+	TemplateFiles             map[string]string `json:"template_files"`
+	GrafanaAlertmanagerConfig string            `json:"grafana_alertmanager_config"`
+}
+
+func (mc *Mimir) GetGrafanaAlertmanagerConfig(ctx context.Context) (*UserGrafanaConfig, error) {
+	var config UserGrafanaConfig
+	err := mc.do(ctx, grafanaAlertmanagerConfigPath, http.MethodGet, nil, -1, &config)
+	if err != nil {
+		return nil, err
+	}
+
+	return &config, nil
+}
+
+func (mc *Mimir) CreateGrafanaAlertmanagerConfig(ctx context.Context, cfg string, templates map[string]string) error {
+	payload, err := json.Marshal(&UserGrafanaConfig{
+		GrafanaAlertmanagerConfig: cfg,
+		TemplateFiles:             templates,
+	})
+
+	if err != nil {
+		return err
+	}
+
+	err = mc.do(ctx, grafanaAlertmanagerConfigPath, http.MethodPost, bytes.NewBuffer(payload), int64(len(payload)), nil)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (mc *Mimir) DeleteGrafanaAlertmanagerConfig() {
+
+}

--- a/pkg/services/ngalert/remote/client/alertmanager_state.go
+++ b/pkg/services/ngalert/remote/client/alertmanager_state.go
@@ -1,0 +1,1 @@
+package client

--- a/pkg/services/ngalert/remote/client/alertmanager_state.go
+++ b/pkg/services/ngalert/remote/client/alertmanager_state.go
@@ -1,1 +1,49 @@
 package client
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+)
+
+const (
+	grafanaAlertmanagerStatePath = "/grafana/state"
+)
+
+type UserGrafanaState struct {
+	successResponse
+	State string `json:"state"`
+}
+
+func (mc *Mimir) GetGrafanaAlertmanagerState(ctx context.Context) (*UserGrafanaState, error) {
+	var state UserGrafanaState
+	// nolint:bodyclose
+	// closed within `do`
+	_, err := mc.do(ctx, grafanaAlertmanagerStatePath, http.MethodGet, nil, -1, &state)
+	if err != nil {
+		return nil, err
+	}
+
+	if state.Status != "success" {
+		return nil, fmt.Errorf("returned non-success `status` from the MimirAPI: %s", state.Status)
+	}
+
+	return &state, nil
+}
+
+func (mc *Mimir) CreateGrafanaAlertmanagerState(ctx context.Context, state string) error {
+	payload, err := json.Marshal(&UserGrafanaState{
+		State: state,
+	})
+	if err != nil {
+		return err
+	}
+
+	return mc.doOK(ctx, grafanaAlertmanagerStatePath, http.MethodPost, bytes.NewBuffer(payload), int64(len(payload)))
+}
+
+func (mc *Mimir) DeleteGrafanaAlertmanagerState(ctx context.Context) error {
+	return mc.doOK(ctx, grafanaAlertmanagerStatePath, http.MethodDelete, nil, -1)
+}

--- a/pkg/services/ngalert/remote/client/alertmanager_state.go
+++ b/pkg/services/ngalert/remote/client/alertmanager_state.go
@@ -13,7 +13,6 @@ const (
 )
 
 type UserGrafanaState struct {
-	successResponse
 	State string `json:"state"`
 }
 

--- a/pkg/services/ngalert/remote/client/alertmanager_state.go
+++ b/pkg/services/ngalert/remote/client/alertmanager_state.go
@@ -18,19 +18,22 @@ type UserGrafanaState struct {
 }
 
 func (mc *Mimir) GetGrafanaAlertmanagerState(ctx context.Context) (*UserGrafanaState, error) {
-	var state UserGrafanaState
+	gs := &UserGrafanaState{}
+	response := successResponse{
+		Data: gs,
+	}
 	// nolint:bodyclose
 	// closed within `do`
-	_, err := mc.do(ctx, grafanaAlertmanagerStatePath, http.MethodGet, nil, -1, &state)
+	_, err := mc.do(ctx, grafanaAlertmanagerStatePath, http.MethodGet, nil, -1, &response)
 	if err != nil {
 		return nil, err
 	}
 
-	if state.Status != "success" {
-		return nil, fmt.Errorf("returned non-success `status` from the MimirAPI: %s", state.Status)
+	if response.Status != "success" {
+		return nil, fmt.Errorf("returned non-success `status` from the MimirAPI: %s", response.Status)
 	}
 
-	return &state, nil
+	return gs, nil
 }
 
 func (mc *Mimir) CreateGrafanaAlertmanagerState(ctx context.Context, state string) error {

--- a/pkg/services/ngalert/remote/client/alertmanager_state.go
+++ b/pkg/services/ngalert/remote/client/alertmanager_state.go
@@ -23,7 +23,7 @@ func (mc *Mimir) GetGrafanaAlertmanagerState(ctx context.Context) (*UserGrafanaS
 	}
 	// nolint:bodyclose
 	// closed within `do`
-	_, err := mc.do(ctx, grafanaAlertmanagerStatePath, http.MethodGet, nil, -1, &response)
+	_, err := mc.do(ctx, grafanaAlertmanagerStatePath, http.MethodGet, nil, &response)
 	if err != nil {
 		return nil, err
 	}
@@ -43,9 +43,9 @@ func (mc *Mimir) CreateGrafanaAlertmanagerState(ctx context.Context, state strin
 		return err
 	}
 
-	return mc.doOK(ctx, grafanaAlertmanagerStatePath, http.MethodPost, bytes.NewBuffer(payload), int64(len(payload)))
+	return mc.doOK(ctx, grafanaAlertmanagerStatePath, http.MethodPost, bytes.NewBuffer(payload))
 }
 
 func (mc *Mimir) DeleteGrafanaAlertmanagerState(ctx context.Context) error {
-	return mc.doOK(ctx, grafanaAlertmanagerStatePath, http.MethodDelete, nil, -1)
+	return mc.doOK(ctx, grafanaAlertmanagerStatePath, http.MethodDelete, nil)
 }

--- a/pkg/services/ngalert/remote/client/mimir.go
+++ b/pkg/services/ngalert/remote/client/mimir.go
@@ -1,0 +1,118 @@
+package client
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"path"
+
+	"github.com/grafana/grafana/pkg/infra/log"
+)
+
+// Client contains all the methods to query the migration critical endpoints of Mimir instance, it's an interface to allow multiple implementations.
+type Client interface {
+	GetGrafanaAlertmanagerConfiguration()
+	SetGrafanaAlertmanagerConfiguration()
+	DeleteGrafanaAlertmanagerConfiguration()
+
+	GetGrafanaAlertmanagerState()
+	SetGrafanaAlertmanagerState()
+	DeleteGrafanaAlertmanagerState()
+}
+
+type Mimir struct {
+	endpoint *url.URL
+	client   http.Client
+	logger   log.Logger
+}
+
+type Config struct {
+	Address string
+	Logger  log.Logger
+}
+
+type successResponse struct {
+	Status string `json:"status"`
+	Data   any    `json:"data"`
+}
+
+type errorResponse struct {
+	Status string `json:"status"`
+	Error  string `json:"error"`
+}
+
+func New(cfg *Config) (*Mimir, error) {
+	endpoint, err := url.Parse(cfg.Address)
+	if err != nil {
+		return nil, err
+	}
+
+	c := http.Client{}
+
+	return &Mimir{
+		endpoint: endpoint,
+		client:   c,
+		logger:   cfg.Logger,
+	}, nil
+
+}
+
+func (mc *Mimir) do(ctx context.Context, p, method string, payload io.Reader, contentLength int64, out any) error {
+	pathURL, err := url.Parse(p)
+	if err != nil {
+		return nil
+	}
+
+	endpoint := *mc.endpoint
+	endpoint.Path = path.Join(endpoint.Path, pathURL.Path)
+
+	r, err := http.NewRequestWithContext(ctx, method, endpoint.String(), payload)
+	if err != nil {
+		return nil
+	}
+
+	if contentLength > 0 {
+		r.ContentLength = contentLength
+	}
+
+	logger := mc.logger.New("url", r.URL.String(), "method", r.Method)
+
+	resp, err := mc.client.Do(r)
+	if err != nil {
+		logger.Debug("unable to fulfill request to the Mimir API", "err", err)
+		return nil
+	}
+
+	if resp.StatusCode/100 != 2 {
+		errResponse := &errorResponse{}
+		if jsonErr := json.NewDecoder(resp.Body).Decode(errResponse); jsonErr != nil {
+			logger.Error("unable to decode JSON error response", "err", jsonErr)
+			return nil
+		}
+
+		return nil
+	}
+
+	sr := successResponse{
+		Data: out,
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&sr); err != nil {
+		logger.Error("unable to decode JSON success response", "err", err)
+		return nil
+	}
+
+	switch sr.Status {
+	case "success":
+		out = sr.Data
+		return nil
+	case "error":
+		logger.Error("received a 2xx status code but no success response")
+	default:
+		return fmt.Errorf("received a 2xx status code but no success or error status: %s", sr.Status)
+	}
+
+	return nil
+}

--- a/pkg/services/ngalert/remote/client/mimir.go
+++ b/pkg/services/ngalert/remote/client/mimir.go
@@ -127,8 +127,8 @@ func (mc *Mimir) do(ctx context.Context, p, method string, payload io.Reader, co
 	}
 
 	if resp.StatusCode/100 != 2 {
-		var errResponse errorResponse
-		jsonErr := json.Unmarshal(body, &errResponse)
+		errResponse := &errorResponse{}
+		jsonErr := json.Unmarshal(body, errResponse)
 
 		if jsonErr == nil && errResponse.Error() != "" {
 			msg := "error response from the Mimir API"

--- a/pkg/services/ngalert/remote/client/mimir.go
+++ b/pkg/services/ngalert/remote/client/mimir.go
@@ -83,9 +83,9 @@ func New(cfg *Config) (*Mimir, error) {
 	}, nil
 }
 
-// do executes an HTTP requests against the specified path and method using the specified payload.
+// do execute an HTTP requests against the specified path and method using the specified payload.
 // It returns the HTTP response.
-func (mc *Mimir) do(ctx context.Context, p, method string, payload io.Reader, contentLength int64, out any) (*http.Response, error) {
+func (mc *Mimir) do(ctx context.Context, p, method string, payload io.Reader, out any) (*http.Response, error) {
 	pathURL, err := url.Parse(p)
 	if err != nil {
 		return nil, err
@@ -101,10 +101,6 @@ func (mc *Mimir) do(ctx context.Context, p, method string, payload io.Reader, co
 
 	r.Header.Set("Accept", "application/json")
 	r.Header.Set("Content-Type", "application/json")
-
-	if contentLength > 0 {
-		r.ContentLength = contentLength
-	}
 
 	resp, err := mc.client.Do(r)
 	if err != nil {
@@ -160,9 +156,9 @@ func (mc *Mimir) do(ctx context.Context, p, method string, payload io.Reader, co
 	return resp, nil
 }
 
-func (mc *Mimir) doOK(ctx context.Context, p, method string, payload io.Reader, contentLength int64) error {
+func (mc *Mimir) doOK(ctx context.Context, p, method string, payload io.Reader) error {
 	var sr successResponse
-	resp, err := mc.do(ctx, p, method, payload, contentLength, &sr)
+	resp, err := mc.do(ctx, p, method, payload, &sr)
 	if err != nil {
 		return err
 	}

--- a/pkg/services/ngalert/remote/client/mimir.go
+++ b/pkg/services/ngalert/remote/client/mimir.go
@@ -122,8 +122,8 @@ func (mc *Mimir) do(ctx context.Context, p, method string, payload io.Reader, co
 	ct := resp.Header.Get("Content-Type")
 	if !strings.HasPrefix(ct, "application/json") {
 		msg := "response content-type is not application/json"
-		logger.Error(msg, "err", err)
-		return nil, fmt.Errorf("%s: %w", msg, err)
+		logger.Error(msg, "content-type", ct)
+		return nil, fmt.Errorf("%s: %s", msg, ct)
 	}
 
 	if out == nil {
@@ -144,7 +144,7 @@ func (mc *Mimir) do(ctx context.Context, p, method string, payload io.Reader, co
 		if jsonErr == nil && errResponse.Error() != "" {
 			msg := "error response from the Mimir API"
 			logger.Error(msg, "err", errResponse)
-			return nil, fmt.Errorf("%s: %w", msg, &errResponse)
+			return nil, fmt.Errorf("%s: %w", msg, errResponse)
 		}
 
 		msg := "failed to decode non-2xx JSON response"
@@ -152,7 +152,7 @@ func (mc *Mimir) do(ctx context.Context, p, method string, payload io.Reader, co
 		return nil, fmt.Errorf("%s: %w", msg, jsonErr)
 	}
 
-	if err = json.Unmarshal(body, &out); err != nil {
+	if err = json.Unmarshal(body, out); err != nil {
 		msg := "failed to decode 2xx JSON response"
 		logger.Error(msg, "err", err)
 		return nil, fmt.Errorf("%s: %w", msg, err)
@@ -163,7 +163,7 @@ func (mc *Mimir) do(ctx context.Context, p, method string, payload io.Reader, co
 
 func (mc *Mimir) doOK(ctx context.Context, p, method string, payload io.Reader, contentLength int64) error {
 	var sr successResponse
-	resp, err := mc.do(ctx, p, method, payload, contentLength, sr)
+	resp, err := mc.do(ctx, p, method, payload, contentLength, &sr)
 	if err != nil {
 		return err
 	}

--- a/pkg/services/ngalert/remote/client/mimir.go
+++ b/pkg/services/ngalert/remote/client/mimir.go
@@ -83,7 +83,8 @@ func New(cfg *Config) (*Mimir, error) {
 	}, nil
 }
 
-// do execute an HTTP requests against the specified path and method using the specified payload. It returns the HTTP response.
+// do executes an HTTP requests against the specified path and method using the specified payload.
+// It returns the HTTP response.
 func (mc *Mimir) do(ctx context.Context, p, method string, payload io.Reader, contentLength int64, out any) (*http.Response, error) {
 	pathURL, err := url.Parse(p)
 	if err != nil {

--- a/pkg/services/ngalert/remote/client/mimir.go
+++ b/pkg/services/ngalert/remote/client/mimir.go
@@ -101,7 +101,11 @@ func (mc *Mimir) do(ctx context.Context, p, method string, payload io.Reader, co
 		logger.Error(msg, "err", err)
 		return nil, fmt.Errorf("%s: %w", msg, err)
 	}
-	defer resp.Body.Close() // go:nolint
+	defer func() {
+		if err := resp.Body.Close(); err != nil {
+			logger.Error("error closing HTTP body", "err", err)
+		}
+	}()
 
 	logger = logger.New("status", resp.StatusCode)
 	ct := resp.Header.Get("Content-Type")
@@ -152,7 +156,11 @@ func (mc *Mimir) doOK(ctx context.Context, p, method string, payload io.Reader, 
 	if err != nil {
 		return err
 	}
-	defer resp.Body.Close()
+	defer func() {
+		if err := resp.Body.Close(); err != nil {
+			mc.logger.Error("error closing HTTP body", "err", err)
+		}
+	}()
 
 	switch sr.Status {
 	case "success":

--- a/pkg/services/ngalert/remote/client/mimir_auth_round_tripper.go
+++ b/pkg/services/ngalert/remote/client/mimir_auth_round_tripper.go
@@ -1,0 +1,28 @@
+package client
+
+import (
+	"net/http"
+)
+
+const mimirTenantHeader = "X-Scope-OrgID"
+
+type MimirAuthRoundTripper struct {
+	TenantID string
+	Password string
+	Next     http.RoundTripper
+}
+
+// RoundTrip implements the http.RoundTripper interface
+// It adds an `X-Scope-OrgID` header with the TenantID if only provided with a tenantID or sets HTTP Basic Authentication if both
+// a tenantID and a password are provided.
+func (r *MimirAuthRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	if r.TenantID != "" && r.Password == "" {
+		req.Header.Set(mimirTenantHeader, r.TenantID)
+	}
+
+	if r.TenantID != "" && r.Password != "" {
+		req.SetBasicAuth(r.TenantID, r.Password)
+	}
+
+	return r.Next.RoundTrip(req)
+}

--- a/scripts/drone/steps/lib.star
+++ b/scripts/drone/steps/lib.star
@@ -971,7 +971,6 @@ def remote_alertmanager_integration_tests_steps():
 
     environment = {
         "AM_TENANT_ID": "test",
-        "AM_PASSWORD": "test",
         "AM_URL": "http://mimir_backend:8080",
     }
 

--- a/scripts/drone/utils/images.star
+++ b/scripts/drone/utils/images.star
@@ -20,7 +20,7 @@ images = {
     "plugins_slack": "plugins/slack",
     "python": "python:3.8",
     "postgres_alpine": "postgres:12.3-alpine",
-    "mimir": "grafana/mimir:latest",
+    "mimir": "us.gcr.io/kubernetes-dev/mimir:gotjosh-state-config-grafana-663a0ae78",
     "mysql5": "mysql:5.7.39",
     "mysql8": "mysql:8.0.32",
     "redis_alpine": "redis:6.2.11-alpine",


### PR DESCRIPTION
There's a lot going on as part of this PR but I'll attempt to describe the thinking behind it -

This is our first attempt at making Grafana communicate use Mimir as a backend - it uses a new set of APIs that we've developed on the Mimir side to upload the grafana configuration and alertmanager state so that it can then be ported over.

Codewise, we've introduced a couple of things:

1. A client to isolate in its own package all the communication that happens with Mimir
2. A few changes to the `remote/alertmanager` to include uploading the configuration and state when it starts
3. A few refactors that align a bit better with the design approach that we're thinking
4. An integration tests again these newly developed APIs using a custom image

This code is likely to change an evolve but given both @santihernandezc and I are working on it in parallel we'd like to get something merged and continue to refine from there - so consider all of this experimental.