### PR TITLE
Alerting: Keep track of individual org migration status

### DIFF
--- a/pkg/services/ngalert/migration/migration_test.go
+++ b/pkg/services/ngalert/migration/migration_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/prometheus/alertmanager/pkg/labels"
 	"github.com/prometheus/common/model"
 	"github.com/stretchr/testify/require"
+
 	"xorm.io/xorm"
 
 	"github.com/grafana/grafana/pkg/components/simplejson"
@@ -99,7 +100,7 @@ func TestServiceStart(t *testing.T) {
 			ctx := context.Background()
 			service := NewTestMigrationService(t, sqlStore, tt.config)
 
-			err := service.migrationStore.SetMigrated(ctx, tt.isMigrationRun)
+			err := service.migrationStore.SetMigrated(ctx, anyOrg, tt.isMigrationRun)
 			require.NoError(t, err)
 
 			err = service.Run(ctx)
@@ -109,7 +110,7 @@ func TestServiceStart(t *testing.T) {
 				require.NoError(t, err)
 			}
 
-			migrated, err := service.migrationStore.IsMigrated(ctx)
+			migrated, err := service.migrationStore.IsMigrated(ctx, anyOrg)
 			require.NoError(t, err)
 			require.Equal(t, tt.expected, migrated)
 		})

--- a/pkg/services/ngalert/migration/service.go
+++ b/pkg/services/ngalert/migration/service.go
@@ -83,6 +83,7 @@ func (ms *migrationService) Run(ctx context.Context) error {
 
 				// Revert migration
 				ms.log.Info("Reverting legacy migration")
+				// Note that this will also set the anyOrg migration status to false.
 				err := ms.migrationStore.RevertAllOrgs(ctx)
 				if err != nil {
 					return fmt.Errorf("reverting migration: %w", err)

--- a/pkg/services/ngalert/migration/service.go
+++ b/pkg/services/ngalert/migration/service.go
@@ -16,8 +16,6 @@ import (
 // actionName is the unique row-level lock name for serverlock.ServerLockService.
 const actionName = "alerting migration"
 
-const anyOrg = 0
-
 //nolint:stylecheck
 var ForceMigrationError = fmt.Errorf("Grafana has already been migrated to Unified Alerting. Any alert rules created while using Unified Alerting will be deleted by rolling back. Set force_migration=true in your grafana.ini and restart Grafana to roll back and delete Unified Alerting configuration data.")
 
@@ -52,59 +50,18 @@ func ProvideService(
 	}, nil
 }
 
-// Run starts the migration. This will either migrate from legacy alerting to unified alerting or revert the migration.
-// If the migration status in the kvstore is not set and unified alerting is enabled, the migration will be executed.
-// If the migration status in the kvstore is set and both unified alerting is disabled and ForceMigration is set to true, the migration will be reverted.
+// Run starts the migration to transition between legacy alerting and unified alerting based on the current and desired
+// alerting type as determined by the kvstore and configuration, respectively.
 func (ms *migrationService) Run(ctx context.Context) error {
 	var errMigration error
 	errLock := ms.lock.LockExecuteAndRelease(ctx, actionName, time.Minute*10, func(ctx context.Context) {
 		ms.log.Info("Starting")
 		errMigration = ms.store.InTransaction(ctx, func(ctx context.Context) error {
-			migrated, err := ms.migrationStore.IsMigrated(ctx, anyOrg)
+			currentType, err := ms.migrationStore.GetCurrentAlertingType(ctx)
 			if err != nil {
 				return fmt.Errorf("getting migration status: %w", err)
 			}
-			if migrated == ms.cfg.UnifiedAlerting.IsEnabled() {
-				// Nothing to do.
-				ms.log.Info("No migrations to run")
-				return nil
-			}
-
-			if migrated {
-				// If legacy alerting is also disabled, there is nothing to do
-				if setting.AlertingEnabled != nil && !*setting.AlertingEnabled {
-					return nil
-				}
-
-				// Safeguard to prevent data loss when reverting from UA to LA.
-				if !ms.cfg.ForceMigration {
-					return ForceMigrationError
-				}
-
-				// Revert migration
-				ms.log.Info("Reverting legacy migration")
-				// Note that this will also set the anyOrg migration status to false.
-				err := ms.migrationStore.RevertAllOrgs(ctx)
-				if err != nil {
-					return fmt.Errorf("reverting migration: %w", err)
-				}
-				ms.log.Info("Legacy migration reverted")
-				return nil
-			}
-
-			ms.log.Info("Starting legacy migration")
-			err = ms.migrateAllOrgs(ctx)
-			if err != nil {
-				return fmt.Errorf("executing migration: %w", err)
-			}
-
-			err = ms.migrationStore.SetMigrated(ctx, anyOrg, true)
-			if err != nil {
-				return fmt.Errorf("setting migration status: %w", err)
-			}
-
-			ms.log.Info("Completed legacy migration")
-			return nil
+			return ms.applyTransition(ctx, newTransition(currentType, ms.cfg))
 		})
 	})
 	if errLock != nil {
@@ -114,6 +71,89 @@ func (ms *migrationService) Run(ctx context.Context) error {
 	if errMigration != nil {
 		return fmt.Errorf("migration failed: %w", errMigration)
 	}
+	return nil
+}
+
+// newTransition creates a transition based on the current alerting type and the current configuration.
+func newTransition(currentType migrationStore.AlertingType, cfg *setting.Cfg) transition {
+	desiredType := migrationStore.Legacy
+	if cfg.UnifiedAlerting.IsEnabled() {
+		desiredType = migrationStore.UnifiedAlerting
+	}
+	return transition{
+		CurrentType:      currentType,
+		DesiredType:      desiredType,
+		CleanOnDowngrade: cfg.ForceMigration,
+	}
+}
+
+// transition represents a migration from one alerting type to another.
+type transition struct {
+	CurrentType      migrationStore.AlertingType
+	DesiredType      migrationStore.AlertingType
+	CleanOnDowngrade bool
+}
+
+// isNoChange returns true if the migration is a no-op.
+func (t transition) isNoChange() bool {
+	return t.CurrentType == t.DesiredType
+}
+
+// isUpgrading returns true if the migration is an upgrade from legacy alerting to unified alerting.
+func (t transition) isUpgrading() bool {
+	return t.CurrentType == migrationStore.Legacy && t.DesiredType == migrationStore.UnifiedAlerting
+}
+
+// isDowngrading returns true if the migration is a downgrade from unified alerting to legacy alerting.
+func (t transition) isDowngrading() bool {
+	return t.CurrentType == migrationStore.UnifiedAlerting && t.DesiredType == migrationStore.Legacy
+}
+
+// shouldClean returns true if the migration should delete all unified alerting data.
+func (t transition) shouldClean() bool {
+	return t.isDowngrading() && t.CleanOnDowngrade
+}
+
+// applyTransition applies the transition to the database.
+// If the transition is a no-op, nothing will be done.
+// If the transition is a downgrade and CleanOnDowngrade is true, all unified alerting data will be deleted.
+// If the transition is a downgrade and CleanOnDowngrade is false, an error will be returned.
+// If the transition is an upgrade, all orgs will be migrated.
+func (ms *migrationService) applyTransition(ctx context.Context, t transition) error {
+	l := ms.log.New(
+		"CurrentType", t.CurrentType,
+		"DesiredType", t.DesiredType,
+		"CleanOnDowngrade", t.CleanOnDowngrade,
+	)
+	if t.isNoChange() {
+		l.Info("Migration already complete")
+		return nil
+	}
+
+	// Safeguard to prevent accidental data loss when reverting from UA to LA.
+	if t.isDowngrading() && !ms.cfg.ForceMigration {
+		return ForceMigrationError
+	}
+
+	if t.shouldClean() {
+		l.Info("Cleaning up unified alerting data")
+		if err := ms.migrationStore.RevertAllOrgs(ctx); err != nil {
+			return fmt.Errorf("cleaning up unified alerting data: %w", err)
+		}
+		l.Info("Unified alerting data deleted")
+	}
+
+	if t.isUpgrading() {
+		if err := ms.migrateAllOrgs(ctx); err != nil {
+			return fmt.Errorf("executing migration: %w", err)
+		}
+	}
+
+	if err := ms.migrationStore.SetCurrentAlertingType(ctx, t.DesiredType); err != nil {
+		return fmt.Errorf("setting migration status: %w", err)
+	}
+
+	l.Info("Completed legacy migration")
 	return nil
 }
 

--- a/pkg/services/ngalert/migration/service_test.go
+++ b/pkg/services/ngalert/migration/service_test.go
@@ -2,10 +2,13 @@ package migration
 
 import (
 	"context"
+	"fmt"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/require"
+
+	"xorm.io/xorm"
 
 	"github.com/grafana/grafana/pkg/infra/db"
 	legacymodels "github.com/grafana/grafana/pkg/services/alerting/models"
@@ -44,26 +47,23 @@ func TestServiceRevert(t *testing.T) {
 		// Run migration.
 		ctx := context.Background()
 		cfg := &setting.Cfg{
-			ForceMigration: true,
 			UnifiedAlerting: setting.UnifiedAlertingSettings{
 				Enabled: pointer(true),
 			},
 		}
 		service := NewTestMigrationService(t, sqlStore, cfg)
 
-		err = service.migrationStore.SetMigrated(ctx, false)
+		err = service.migrationStore.SetMigrated(ctx, anyOrg, false)
 		require.NoError(t, err)
 
-		err = service.Run(ctx)
-		require.NoError(t, err)
+		require.NoError(t, service.Run(ctx))
 
 		// Verify migration was run.
-		migrated, err := service.migrationStore.IsMigrated(ctx)
-		require.NoError(t, err)
-		require.Equal(t, true, migrated)
+		checkMigrationStatus(t, ctx, service, anyOrg, true)
+		checkMigrationStatus(t, ctx, service, 1, true)
 
 		// Currently, we fill in some random data for tables that aren't populated during migration.
-		_, err = x.Table("ngalert_configuration").Insert(models.AdminConfiguration{})
+		_, err = x.Table("ngalert_configuration").Insert(models.AdminConfiguration{OrgID: 1})
 		require.NoError(t, err)
 		_, err = x.Table("alert_instance").Insert(models.AlertInstance{
 			AlertInstanceKey: models.AlertInstanceKey{
@@ -79,34 +79,32 @@ func TestServiceRevert(t *testing.T) {
 		require.NoError(t, err)
 
 		// Verify various UA resources exist
-		tables := []string{
-			"alert_rule",
-			"alert_rule_version",
-			"alert_configuration",
-			"ngalert_configuration",
-			"alert_instance",
+		tables := [][2]string{
+			{"alert_rule", "org_id"},
+			{"alert_rule_version", "rule_org_id"},
+			{"alert_configuration", "org_id"},
+			{"ngalert_configuration", "org_id"},
+			{"alert_instance", "rule_org_id"},
 		}
 		for _, table := range tables {
-			count, err := x.Table(table).Count()
-			require.NoError(t, err)
-			require.True(t, count > 0, "table %s should have at least one row", table)
+			count, err := x.Table(table[0]).Where(fmt.Sprintf("%s=?", table[1]), 1).Count()
+			require.NoErrorf(t, err, "table %s error", table[0])
+			require.True(t, count > 0, "table %s should have at least one row", table[0])
 		}
 
 		// Revert migration.
-		service.cfg.UnifiedAlerting.Enabled = pointer(false)
-		err = service.Run(context.Background())
+		err = service.migrationStore.RevertAllOrgs(context.Background())
 		require.NoError(t, err)
 
 		// Verify revert was run.
-		migrated, err = service.migrationStore.IsMigrated(ctx)
-		require.NoError(t, err)
-		require.Equal(t, false, migrated)
+		checkMigrationStatus(t, ctx, service, anyOrg, false)
+		checkMigrationStatus(t, ctx, service, 1, false)
 
 		// Verify various UA resources are gone
 		for _, table := range tables {
-			count, err := x.Table(table).Count()
-			require.NoError(t, err)
-			require.Equal(t, int64(0), count, "table %s should have no rows", table)
+			count, err := x.Table(table[0]).Where(fmt.Sprintf("%s=?", table[1]), 1).Count()
+			require.NoErrorf(t, err, "table %s error", table[0])
+			require.Equal(t, int64(0), count, "table %s should have no rows", table[0])
 		}
 	})
 
@@ -125,23 +123,20 @@ func TestServiceRevert(t *testing.T) {
 		// Run migration.
 		ctx := context.Background()
 		cfg := &setting.Cfg{
-			ForceMigration: true,
 			UnifiedAlerting: setting.UnifiedAlertingSettings{
 				Enabled: pointer(true),
 			},
 		}
 		service := NewTestMigrationService(t, sqlStore, cfg)
 
-		err = service.migrationStore.SetMigrated(ctx, false)
+		err = service.migrationStore.SetMigrated(ctx, anyOrg, false)
 		require.NoError(t, err)
 
-		err = service.Run(ctx)
-		require.NoError(t, err)
+		require.NoError(t, service.Run(ctx))
 
 		// Verify migration was run.
-		migrated, err := service.migrationStore.IsMigrated(ctx)
-		require.NoError(t, err)
-		require.Equal(t, true, migrated)
+		checkMigrationStatus(t, ctx, service, anyOrg, true)
+		checkMigrationStatus(t, ctx, service, 1, true)
 
 		// Verify we created some folders.
 		newDashCount, err := x.Table("dashboard").Count(&dashboards.Dashboard{})
@@ -163,14 +158,12 @@ func TestServiceRevert(t *testing.T) {
 		}
 
 		// Revert migration.
-		service.cfg.UnifiedAlerting.Enabled = pointer(false)
-		err = service.Run(context.Background())
+		err = service.migrationStore.RevertAllOrgs(context.Background())
 		require.NoError(t, err)
 
-		// Verify revert was run.
-		migrated, err = service.migrationStore.IsMigrated(ctx)
-		require.NoError(t, err)
-		require.Equal(t, false, migrated)
+		// Verify revert was run. Should only set migration status for org.
+		checkMigrationStatus(t, ctx, service, anyOrg, false)
+		checkMigrationStatus(t, ctx, service, 1, false)
 
 		// Verify we are back to the original count.
 		newDashCount, err = x.Table("dashboard").Count(&dashboards.Dashboard{})
@@ -210,19 +203,17 @@ func TestServiceRevert(t *testing.T) {
 		}
 		service := NewTestMigrationService(t, sqlStore, cfg)
 
-		err = service.migrationStore.SetMigrated(ctx, false)
+		err = service.migrationStore.SetMigrated(ctx, anyOrg, false)
 		require.NoError(t, err)
 
-		err = service.Run(ctx)
-		require.NoError(t, err)
+		require.NoError(t, service.Run(ctx))
 
 		// Verify migration was run.
-		migrated, err := service.migrationStore.IsMigrated(ctx)
-		require.NoError(t, err)
-		require.Equal(t, true, migrated)
+		checkMigrationStatus(t, ctx, service, anyOrg, true)
+		checkMigrationStatus(t, ctx, service, 1, true)
 
 		// Verify we created some folders.
-		newDashCount, err := x.Table("dashboard").Count(&dashboards.Dashboard{})
+		newDashCount, err := x.Table("dashboard").Count(&dashboards.Dashboard{OrgID: 1})
 		require.NoError(t, err)
 		require.Truef(t, newDashCount > dashCount, "newDashCount: %d should be greater than dashCount: %d", newDashCount, dashCount)
 
@@ -257,17 +248,15 @@ func TestServiceRevert(t *testing.T) {
 		require.NotNil(t, newF)
 
 		// Revert migration.
-		service.cfg.UnifiedAlerting.Enabled = pointer(false)
-		err = service.Run(ctx)
+		err = service.migrationStore.RevertAllOrgs(context.Background())
 		require.NoError(t, err)
 
-		// Verify revert was run.
-		migrated, err = service.migrationStore.IsMigrated(ctx)
-		require.NoError(t, err)
-		require.Equal(t, false, migrated)
+		// Verify revert was run. Should only set migration status for org.
+		checkMigrationStatus(t, ctx, service, anyOrg, false)
+		checkMigrationStatus(t, ctx, service, 1, false)
 
 		// Verify we are back to the original count + 2.
-		newDashCount, err = x.Table("dashboard").Count(&dashboards.Dashboard{})
+		newDashCount, err = x.Table("dashboard").Count(&dashboards.Dashboard{OrgID: 1})
 		require.NoError(t, err)
 		require.Equalf(t, dashCount+2, newDashCount, "newDashCount: %d should be equal to dashCount + 2: %d after revert", newDashCount, dashCount)
 
@@ -289,4 +278,70 @@ func TestServiceRevert(t *testing.T) {
 			require.Nil(t, getDashboard(t, x, 1, uid))
 		}
 	})
+
+	t.Run("ForceMigration story", func(t *testing.T) {
+		sqlStore := db.InitTestDB(t)
+		x := sqlStore.GetEngine()
+
+		setupLegacyAlertsTables(t, x, channels, alerts, folders, dashes)
+
+		ctx := context.Background()
+		cfg := &setting.Cfg{
+			UnifiedAlerting: setting.UnifiedAlertingSettings{
+				Enabled: pointer(true),
+			},
+		}
+		service := NewTestMigrationService(t, sqlStore, cfg)
+		checkMigrationStatus(t, ctx, service, anyOrg, false)
+		checkMigrationStatus(t, ctx, service, 1, false)
+		checkAlertRulesCount(t, x, 1, 0)
+
+		// Enable UA.
+		// First run should migrate org.
+		require.NoError(t, service.Run(ctx))
+		checkMigrationStatus(t, ctx, service, anyOrg, true)
+		checkMigrationStatus(t, ctx, service, 1, true)
+		checkAlertRulesCount(t, x, 1, 1)
+
+		// Disable UA without ForceMigration.
+		// This run should throw an error.
+		service.cfg.UnifiedAlerting.Enabled = pointer(false)
+		require.ErrorContains(t, service.Run(ctx), ForceMigrationError.Error())
+		checkMigrationStatus(t, ctx, service, anyOrg, true)
+		checkMigrationStatus(t, ctx, service, 1, true)
+		checkAlertRulesCount(t, x, 1, 1)
+
+		// Disable UA with force flag.
+		// This run should not revert UA data.
+		service.cfg.UnifiedAlerting.Enabled = pointer(false)
+		service.cfg.ForceMigration = true
+		require.NoError(t, service.Run(ctx))
+		checkMigrationStatus(t, ctx, service, anyOrg, false)
+		checkMigrationStatus(t, ctx, service, 1, false)
+		checkAlertRulesCount(t, x, 1, 0) // Alerts are gone.
+
+		// Add another alert.
+		_, alertErr := x.Insert(createAlert(t, 1, 1, 2, "alert2", []string{"notifier1"}))
+		require.NoError(t, alertErr)
+
+		// Enable UA.
+		// This run should remigrate org, new alert is migrated.
+		service.cfg.UnifiedAlerting.Enabled = pointer(true)
+		require.NoError(t, service.Run(ctx))
+		checkMigrationStatus(t, ctx, service, anyOrg, true)
+		checkMigrationStatus(t, ctx, service, 1, true)
+		checkAlertRulesCount(t, x, 1, 2) // Now we have 2
+	})
+}
+
+func checkMigrationStatus(t *testing.T, ctx context.Context, service *migrationService, orgID int64, expected bool) {
+	migrated, err := service.migrationStore.IsMigrated(ctx, orgID)
+	require.NoError(t, err)
+	require.Equal(t, expected, migrated)
+}
+
+func checkAlertRulesCount(t *testing.T, x *xorm.Engine, orgID int64, count int) {
+	cnt, err := x.Table("alert_rule").Where("org_id=?", orgID).Count()
+	require.NoError(t, err, "table alert_rule error")
+	require.Equal(t, int(cnt), count, "table alert_rule should have no rows")
 }

--- a/pkg/services/ngalert/migration/store/database.go
+++ b/pkg/services/ngalert/migration/store/database.go
@@ -55,8 +55,8 @@ type Store interface {
 	GetFolder(ctx context.Context, cmd *folder.GetFolderQuery) (*folder.Folder, error)
 	CreateFolder(ctx context.Context, cmd *folder.CreateFolderCommand) (*folder.Folder, error)
 
-	IsMigrated(ctx context.Context) (bool, error)
-	SetMigrated(ctx context.Context, migrated bool) error
+	IsMigrated(ctx context.Context, orgID int64) (bool, error)
+	SetMigrated(ctx context.Context, orgID int64, migrated bool) error
 	GetOrgMigrationState(ctx context.Context, orgID int64) (*migmodels.OrgMigrationState, error)
 	SetOrgMigrationState(ctx context.Context, orgID int64, summary *migmodels.OrgMigrationState) error
 
@@ -122,11 +122,9 @@ const migratedKey = "migrated"
 // stateKey is the kvstore key used for the OrgMigrationState.
 const stateKey = "stateKey"
 
-const anyOrg = 0
-
 // IsMigrated returns the migration status from the kvstore.
-func (ms *migrationStore) IsMigrated(ctx context.Context) (bool, error) {
-	kv := kvstore.WithNamespace(ms.kv, anyOrg, KVNamespace)
+func (ms *migrationStore) IsMigrated(ctx context.Context, orgID int64) (bool, error) {
+	kv := kvstore.WithNamespace(ms.kv, orgID, KVNamespace)
 	content, exists, err := kv.Get(ctx, migratedKey)
 	if err != nil {
 		return false, err
@@ -140,8 +138,8 @@ func (ms *migrationStore) IsMigrated(ctx context.Context) (bool, error) {
 }
 
 // SetMigrated sets the migration status in the kvstore.
-func (ms *migrationStore) SetMigrated(ctx context.Context, migrated bool) error {
-	kv := kvstore.WithNamespace(ms.kv, anyOrg, KVNamespace)
+func (ms *migrationStore) SetMigrated(ctx context.Context, orgID int64, migrated bool) error {
+	kv := kvstore.WithNamespace(ms.kv, orgID, KVNamespace)
 	return kv.Set(ctx, migratedKey, strconv.FormatBool(migrated))
 }
 
@@ -226,62 +224,59 @@ var revertPermissions = []accesscontrol.Permission{
 // RevertAllOrgs reverts the migration, deleting all unified alerting resources such as alert rules, alertmanager configurations, and silence files.
 // In addition, it will delete all folders and permissions originally created by this migration, these are stored in the kvstore.
 func (ms *migrationStore) RevertAllOrgs(ctx context.Context) error {
-	return ms.store.WithTransactionalDbSession(ctx, func(sess *db.Session) error {
-		if _, err := sess.Exec("DELETE FROM alert_rule"); err != nil {
-			return err
-		}
-
-		if _, err := sess.Exec("DELETE FROM alert_rule_version"); err != nil {
-			return err
-		}
-
-		orgs, err := ms.GetAllOrgs(ctx)
-		if err != nil {
-			return fmt.Errorf("get orgs: %w", err)
-		}
-		for _, o := range orgs {
-			if err := ms.DeleteMigratedFolders(ctx, o.ID); err != nil {
-				ms.log.Warn("Failed to delete migrated folders", "orgID", o.ID, "err", err)
-				continue
+	return ms.store.InTransaction(ctx, func(ctx context.Context) error {
+		return ms.store.WithDbSession(ctx, func(sess *db.Session) error {
+			if _, err := sess.Exec("DELETE FROM alert_rule"); err != nil {
+				return err
 			}
-		}
 
-		if _, err := sess.Exec("DELETE FROM alert_configuration"); err != nil {
-			return err
-		}
-
-		if _, err := sess.Exec("DELETE FROM ngalert_configuration"); err != nil {
-			return err
-		}
-
-		if _, err := sess.Exec("DELETE FROM alert_instance"); err != nil {
-			return err
-		}
-
-		if _, err := sess.Exec("DELETE FROM kv_store WHERE namespace = ?", notifier.KVNamespace); err != nil {
-			return err
-		}
-
-		if _, err := sess.Exec("DELETE FROM kv_store WHERE namespace = ?", KVNamespace); err != nil {
-			return err
-		}
-
-		files, err := filepath.Glob(filepath.Join(ms.cfg.DataPath, "alerting", "*", "silences"))
-		if err != nil {
-			return err
-		}
-		for _, f := range files {
-			if err := os.Remove(f); err != nil {
-				ms.log.Error("Failed to remove silence file", "file", f, "err", err)
+			if _, err := sess.Exec("DELETE FROM alert_rule_version"); err != nil {
+				return err
 			}
-		}
 
-		err = ms.SetMigrated(ctx, false)
-		if err != nil {
-			return fmt.Errorf("setting migration status: %w", err)
-		}
+			orgs, err := ms.GetAllOrgs(ctx)
+			if err != nil {
+				return fmt.Errorf("get orgs: %w", err)
+			}
+			for _, o := range orgs {
+				if err := ms.DeleteMigratedFolders(ctx, o.ID); err != nil {
+					ms.log.Warn("Failed to delete migrated folders", "orgID", o.ID, "err", err)
+					continue
+				}
+			}
 
-		return nil
+			if _, err := sess.Exec("DELETE FROM alert_configuration"); err != nil {
+				return err
+			}
+
+			if _, err := sess.Exec("DELETE FROM ngalert_configuration"); err != nil {
+				return err
+			}
+
+			if _, err := sess.Exec("DELETE FROM alert_instance"); err != nil {
+				return err
+			}
+
+			if _, err := sess.Exec("DELETE FROM kv_store WHERE namespace = ?", notifier.KVNamespace); err != nil {
+				return err
+			}
+
+			if _, err := sess.Exec("DELETE FROM kv_store WHERE namespace = ?", KVNamespace); err != nil {
+				return err
+			}
+
+			files, err := filepath.Glob(filepath.Join(ms.cfg.DataPath, "alerting", "*", "silences"))
+			if err != nil {
+				return err
+			}
+			for _, f := range files {
+				if err := os.Remove(f); err != nil {
+					ms.log.Error("Failed to remove silence file", "file", f, "err", err)
+				}
+			}
+
+			return nil
+		})
 	})
 }
 

--- a/pkg/services/ngalert/migration/store/database.go
+++ b/pkg/services/ngalert/migration/store/database.go
@@ -222,7 +222,8 @@ var revertPermissions = []accesscontrol.Permission{
 }
 
 // RevertAllOrgs reverts the migration, deleting all unified alerting resources such as alert rules, alertmanager configurations, and silence files.
-// In addition, it will delete all folders and permissions originally created by this migration, these are stored in the kvstore.
+// In addition, it will delete all folders and permissions originally created by this migration, as well as the various migration statuses stored
+// in kvstore, both org-specific and anyOrg.
 func (ms *migrationStore) RevertAllOrgs(ctx context.Context) error {
 	return ms.store.InTransaction(ctx, func(ctx context.Context) error {
 		return ms.store.WithDbSession(ctx, func(sess *db.Session) error {

--- a/pkg/services/sqlstore/migrations/migrations.go
+++ b/pkg/services/sqlstore/migrations/migrations.go
@@ -111,6 +111,8 @@ func (*OSSMigrations) AddMigration(mg *Migrator) {
 	dashboardFolderMigrations.AddDashboardFolderMigrations(mg)
 
 	ssosettings.AddMigration(mg)
+
+	ualert.CreateOrgMigratedKVStoreEntries(mg)
 }
 
 func addStarMigrations(mg *Migrator) {

--- a/pkg/services/sqlstore/migrations/ualert/org_upgrade_state_mig.go
+++ b/pkg/services/sqlstore/migrations/ualert/org_upgrade_state_mig.go
@@ -1,0 +1,74 @@
+package ualert
+
+import (
+	"fmt"
+
+	"xorm.io/xorm"
+
+	"github.com/grafana/grafana/pkg/services/sqlstore/migrator"
+)
+
+// CreateOrgMigratedKVStoreEntries creates kv store entries for each organization if the migration has been run.
+// This is needed now that we've changed the semantics of data loss when upgrading / rolling back. If a user who previously
+// upgraded were to rollback and upgrade again without clean_upgrade, then since they don't have org-level migrated states
+// it will attempt to upgrade their orgs as if they had never upgraded before. This will almost definitely fail with
+// duplicate key errors.
+func CreateOrgMigratedKVStoreEntries(mg *migrator.Migrator) {
+	mg.AddMigration("copy kvstore migration status to each org", &createOrgMigratedKVStoreEntries{})
+}
+
+type createOrgMigratedKVStoreEntries struct {
+	migrator.MigrationBase
+}
+
+func (c createOrgMigratedKVStoreEntries) SQL(migrator.Dialect) string {
+	return codeMigration
+}
+
+func (c createOrgMigratedKVStoreEntries) Exec(sess *xorm.Session, mg *migrator.Migrator) error {
+	var orgs []struct {
+		ID int64 `xorm:"id"`
+	}
+	if err := sess.SQL("select id from org").Find(&orgs); err != nil {
+		return err
+	}
+
+	if len(orgs) == 0 {
+		mg.Logger.Debug("no orgs, nothing to set in kvstore")
+		return nil
+	}
+
+	var anyOrg int64 = 0
+	migrated := kvStoreV1Entry{
+		OrgID:     &anyOrg,
+		Namespace: &KVNamespace,
+		Key:       &migratedKey,
+	}
+	has, err := sess.Table("kv_store").Get(&migrated)
+	if err != nil {
+		return err
+	}
+
+	if !has || migrated.Value != "true" {
+		mg.Logger.Debug("migration has not been run, nothing to set in kvstore")
+		return nil
+	}
+
+	for _, org := range orgs {
+		id := org.ID
+		entry := kvStoreV1Entry{
+			OrgID:     &id,
+			Namespace: &KVNamespace,
+			Key:       &migratedKey,
+			Value:     migrated.Value,
+			Created:   migrated.Created,
+			Updated:   migrated.Updated,
+		}
+		if _, errCreate := sess.Table("kv_store").Insert(&entry); errCreate != nil {
+			mg.Logger.Error("failed to insert org migration status to kvstore", "err", errCreate)
+			return fmt.Errorf("failed to insert org migration status to kvstore: %w", errCreate)
+		}
+	}
+
+	return nil
+}


### PR DESCRIPTION
**What is this feature?**

On migration, currently we save the following value to the kvstore:
|org_id|namespace|key|value|
|------|---------|---|-----|
|0|ngalert.migration|migrated|true|

This PR will:
- Instead save this information per migrated org.
- Change the meaning (and key/value) of the `org_id=0` entry to store the current (previous) config value used by alerting. This is so we can know when to upgrade/downgrade by comparing with the new config value in  `UnifiedAlerting.IsEnabled`.

So, after this change we would have the following entries after migration (given two orgs):

|org_id|namespace|key|value|
|------|---------|---|-----|
|0|ngalert.migration|currentAlertingType|UnifiedAlerting|
|1|ngalert.migration|migrated|true|
|2|ngalert.migration|migrated|true|

If we then downgrade and revert, we'll have:

|org_id|namespace|key|value|
|------|---------|---|-----|
|0|ngalert.migration|currentAlertingType|Legacy|


**Why do we need this feature?**

These extra values are currently unused, but will be necessary for upcoming features. Such as:

- https://github.com/grafana/grafana/pull/78324
- Migration in-app dry-run

**Who is this feature for?**

Developers

**Special notes for your reviewer:**

Adds a sql migration to create the org-specific entries and rename the `org_id=0` entry, if the instance has already been migrated.

Please check that:
- [x] It works as expected from a user's perspective.
