### PR TITLE
UserAuth: clean-up auth entries on update

### DIFF
--- a/pkg/services/login/authinfoservice/database/database.go
+++ b/pkg/services/login/authinfoservice/database/database.go
@@ -165,6 +165,7 @@ func (s *AuthInfoStore) UpdateAuthInfoDate(ctx context.Context, authInfo *login.
 	}
 	return s.sqlStore.WithTransactionalDbSession(ctx, func(sess *db.Session) error {
 		_, err := sess.Cols("created").Update(authInfo, cond)
+
 		return err
 	})
 }
@@ -208,8 +209,33 @@ func (s *AuthInfoStore) UpdateAuthInfo(ctx context.Context, cmd *login.UpdateAut
 
 	return s.sqlStore.WithTransactionalDbSession(ctx, func(sess *db.Session) error {
 		upd, err := sess.MustCols("o_auth_expiry").Where("user_id = ? AND auth_module = ?", cmd.UserId, cmd.AuthModule).Update(authUser)
-		s.logger.Debug("Updated user_auth", "user_id", cmd.UserId,
-			"auth_id", cmd.AuthId, "auth_module", cmd.AuthModule, "rows", upd)
+
+		s.logger.Debug("Updated user_auth", "user_id", cmd.UserId, "auth_id", cmd.AuthId, "auth_module", cmd.AuthModule, "rows", upd)
+
+		if upd > 1 {
+			// there are some cases with duplicated entries, especially before we used a
+
+			var id int64
+			ok, err := sess.SQL(
+				"SELECT id FROM user_auth WHERE user_id = ? AND auth_module = ? AND auth_id = ?",
+				cmd.UserId, cmd.AuthModule, cmd.AuthId,
+			).Get(&id)
+
+			if err != nil {
+				return err
+			}
+
+			if !ok {
+				return nil
+			}
+
+			_, err = sess.Exec(
+				"DELETE FROM user_auth WHERE user_id = ? AND auth_module = ? AND auth_id = ? AND id != ?",
+				cmd.UserId, cmd.AuthModule, cmd.AuthId, id,
+			)
+			return err
+		}
+
 		return err
 	})
 }

--- a/pkg/services/login/authinfoservice/database/database.go
+++ b/pkg/services/login/authinfoservice/database/database.go
@@ -212,6 +212,7 @@ func (s *AuthInfoStore) UpdateAuthInfo(ctx context.Context, cmd *login.UpdateAut
 
 		s.logger.Debug("Updated user_auth", "user_id", cmd.UserId, "auth_id", cmd.AuthId, "auth_module", cmd.AuthModule, "rows", upd)
 
+		# Clean up duplicated entries
 		if upd > 1 {
 			var id int64
 			ok, err := sess.SQL(

--- a/pkg/services/login/authinfoservice/database/database.go
+++ b/pkg/services/login/authinfoservice/database/database.go
@@ -212,7 +212,7 @@ func (s *AuthInfoStore) UpdateAuthInfo(ctx context.Context, cmd *login.UpdateAut
 
 		s.logger.Debug("Updated user_auth", "user_id", cmd.UserId, "auth_id", cmd.AuthId, "auth_module", cmd.AuthModule, "rows", upd)
 
-		# Clean up duplicated entries
+		// Clean up duplicated entries
 		if upd > 1 {
 			var id int64
 			ok, err := sess.SQL(

--- a/pkg/services/login/authinfoservice/database/database.go
+++ b/pkg/services/login/authinfoservice/database/database.go
@@ -213,8 +213,6 @@ func (s *AuthInfoStore) UpdateAuthInfo(ctx context.Context, cmd *login.UpdateAut
 		s.logger.Debug("Updated user_auth", "user_id", cmd.UserId, "auth_id", cmd.AuthId, "auth_module", cmd.AuthModule, "rows", upd)
 
 		if upd > 1 {
-			// there are some cases with duplicated entries, especially before we used a
-
 			var id int64
 			ok, err := sess.SQL(
 				"SELECT id FROM user_auth WHERE user_id = ? AND auth_module = ? AND auth_id = ?",

--- a/pkg/services/login/authinfoservice/database/database_test.go
+++ b/pkg/services/login/authinfoservice/database/database_test.go
@@ -1,0 +1,64 @@
+package database
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"golang.org/x/oauth2"
+
+	"github.com/grafana/grafana/pkg/infra/db"
+	"github.com/grafana/grafana/pkg/services/login"
+	secretstest "github.com/grafana/grafana/pkg/services/secrets/fakes"
+)
+
+func TestIntegrationAuthInfoStore(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
+
+	sql := db.InitTestDB(t)
+
+	store := ProvideAuthInfoStore(sql, secretstest.NewFakeSecretsService(), nil)
+
+	t.Run("should remove duplicates on update", func(t *testing.T) {
+		setCmd := &login.SetAuthInfoCommand{
+			AuthModule: login.GenericOAuthModule,
+			AuthId:     "1",
+			UserId:     1,
+			OAuthToken: &oauth2.Token{},
+		}
+
+		require.NoError(t, store.SetAuthInfo(context.Background(), setCmd))
+		require.NoError(t, store.SetAuthInfo(context.Background(), setCmd))
+
+		count := countEntries(t, sql, setCmd.AuthModule, setCmd.AuthId, setCmd.UserId)
+		require.Equal(t, 2, count)
+
+		err := store.UpdateAuthInfo(context.Background(), &login.UpdateAuthInfoCommand{
+			AuthModule: setCmd.AuthModule,
+			AuthId:     setCmd.AuthId,
+			UserId:     setCmd.UserId,
+			OAuthToken: &oauth2.Token{},
+		})
+		require.NoError(t, err)
+
+		count = countEntries(t, sql, setCmd.AuthModule, setCmd.AuthId, setCmd.UserId)
+		require.Equal(t, 1, count)
+	})
+}
+
+func countEntries(t *testing.T, sql db.DB, authModule, authID string, userID int64) int {
+	var result int
+
+	err := sql.WithDbSession(context.Background(), func(sess *db.Session) error {
+		_, err := sess.SQL(
+			"SELECT COUNT(*) FROM user_auth WHERE auth_module = ? AND auth_id = ? AND user_id = ?",
+			authModule, authID, userID,
+		).Get(&result)
+		return err
+	})
+
+	require.NoError(t, err)
+	return result
+}


### PR DESCRIPTION
**What is this feature?**
Because of how generic oauth has worked in the past, before https://github.com/grafana/grafana/pull/65902, we can have several copies of a `user_auth` entry for generic oauth. If we notice that we have updated more than one row we can remove all rows except one for the combination of  `user_id`, `auth_module` and `auth_id`

**Which issue(s) does this PR fix?**:

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
