### PR TITLE
AuthZ: Improve team ID fetching for signedInUser

### DIFF
--- a/pkg/services/team/model.go
+++ b/pkg/services/team/model.go
@@ -79,7 +79,7 @@ type GetTeamByIDQuery struct {
 // FilterIgnoreUser is used in a get / search teams query when the caller does not want to filter teams by user ID / membership
 const FilterIgnoreUser int64 = 0
 
-type GetTeamIDsByUserIDQuery struct {
+type GetTeamIDsByUserQuery struct {
 	OrgID  int64
 	UserID int64 `json:"userId"`
 }

--- a/pkg/services/team/model.go
+++ b/pkg/services/team/model.go
@@ -79,6 +79,11 @@ type GetTeamByIDQuery struct {
 // FilterIgnoreUser is used in a get / search teams query when the caller does not want to filter teams by user ID / membership
 const FilterIgnoreUser int64 = 0
 
+type GetTeamIDsByUserIDQuery struct {
+	OrgID  int64
+	UserID int64 `json:"userId"`
+}
+
 type GetTeamsByUserQuery struct {
 	OrgID        int64
 	UserID       int64 `json:"userId"`

--- a/pkg/services/team/team.go
+++ b/pkg/services/team/team.go
@@ -13,6 +13,7 @@ type Service interface {
 	SearchTeams(ctx context.Context, query *SearchTeamsQuery) (SearchTeamQueryResult, error)
 	GetTeamByID(ctx context.Context, query *GetTeamByIDQuery) (*TeamDTO, error)
 	GetTeamsByUser(ctx context.Context, query *GetTeamsByUserQuery) ([]*TeamDTO, error)
+	GetIDsByUser(ctx context.Context, query *GetTeamIDsByUserIDQuery) ([]int64, error)
 	AddTeamMember(userID, orgID, teamID int64, isExternal bool, permission dashboards.PermissionType) error
 	UpdateTeamMember(ctx context.Context, cmd *UpdateTeamMemberCommand) error
 	IsTeamMember(orgId int64, teamId int64, userId int64) (bool, error)

--- a/pkg/services/team/team.go
+++ b/pkg/services/team/team.go
@@ -13,7 +13,7 @@ type Service interface {
 	SearchTeams(ctx context.Context, query *SearchTeamsQuery) (SearchTeamQueryResult, error)
 	GetTeamByID(ctx context.Context, query *GetTeamByIDQuery) (*TeamDTO, error)
 	GetTeamsByUser(ctx context.Context, query *GetTeamsByUserQuery) ([]*TeamDTO, error)
-	GetIDsByUser(ctx context.Context, query *GetTeamIDsByUserIDQuery) ([]int64, error)
+	GetTeamIDsByUser(ctx context.Context, query *GetTeamIDsByUserQuery) ([]int64, error)
 	AddTeamMember(userID, orgID, teamID int64, isExternal bool, permission dashboards.PermissionType) error
 	UpdateTeamMember(ctx context.Context, cmd *UpdateTeamMemberCommand) error
 	IsTeamMember(orgId int64, teamId int64, userId int64) (bool, error)

--- a/pkg/services/team/teamimpl/store.go
+++ b/pkg/services/team/teamimpl/store.go
@@ -341,11 +341,9 @@ func (ss *xormStore) GetByUser(ctx context.Context, query *team.GetTeamsByUserQu
 func (ss *xormStore) GetIDsByUser(ctx context.Context, query *team.GetTeamIDsByUserQuery) ([]int64, error) {
 	queryResult := make([]int64, 0)
 	err := ss.db.WithDbSession(ctx, func(sess *db.Session) error {
-		var params []any
-		params = append(params, query.UserID, query.OrgID)
 		return sess.SQL(`SELECT tm.team_id
 FROM team_member as tm
-WHERE tm.user_id=? AND tm.org_id=?;`, params...).Find(&queryResult)
+WHERE tm.user_id=? AND tm.org_id=?;`, query.UserID, query.OrgID).Find(&queryResult)
 	})
 
 	if err != nil {

--- a/pkg/services/team/teamimpl/store.go
+++ b/pkg/services/team/teamimpl/store.go
@@ -337,18 +337,19 @@ func (ss *xormStore) GetByUser(ctx context.Context, query *team.GetTeamsByUserQu
 	return queryResult, nil
 }
 
-// GetIDsByUser is used by the Guardian when checking a users' permissions
+// GetIDsByUser returns a list of team IDs for the given user
 func (ss *xormStore) GetIDsByUser(ctx context.Context, query *team.GetTeamIDsByUserQuery) ([]int64, error) {
 	queryResult := make([]int64, 0)
+
 	err := ss.db.WithDbSession(ctx, func(sess *db.Session) error {
 		return sess.SQL(`SELECT tm.team_id
 FROM team_member as tm
 WHERE tm.user_id=? AND tm.org_id=?;`, query.UserID, query.OrgID).Find(&queryResult)
 	})
-
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to get team IDs by user: %w", err)
 	}
+
 	return queryResult, nil
 }
 

--- a/pkg/services/team/teamimpl/store.go
+++ b/pkg/services/team/teamimpl/store.go
@@ -23,7 +23,7 @@ type store interface {
 	Search(ctx context.Context, query *team.SearchTeamsQuery) (team.SearchTeamQueryResult, error)
 	GetByID(ctx context.Context, query *team.GetTeamByIDQuery) (*team.TeamDTO, error)
 	GetByUser(ctx context.Context, query *team.GetTeamsByUserQuery) ([]*team.TeamDTO, error)
-	GetIDsByUser(ctx context.Context, query *team.GetTeamIDsByUserIDQuery) ([]int64, error)
+	GetIDsByUser(ctx context.Context, query *team.GetTeamIDsByUserQuery) ([]int64, error)
 	RemoveUsersMemberships(ctx context.Context, userID int64) error
 	AddMember(userID, orgID, teamID int64, isExternal bool, permission dashboards.PermissionType) error
 	UpdateMember(ctx context.Context, cmd *team.UpdateTeamMemberCommand) error
@@ -338,7 +338,7 @@ func (ss *xormStore) GetByUser(ctx context.Context, query *team.GetTeamsByUserQu
 }
 
 // GetIDsByUser is used by the Guardian when checking a users' permissions
-func (ss *xormStore) GetIDsByUser(ctx context.Context, query *team.GetTeamIDsByUserIDQuery) ([]int64, error) {
+func (ss *xormStore) GetIDsByUser(ctx context.Context, query *team.GetTeamIDsByUserQuery) ([]int64, error) {
 	queryResult := make([]int64, 0)
 	err := ss.db.WithDbSession(ctx, func(sess *db.Session) error {
 		var params []any

--- a/pkg/services/team/teamimpl/store.go
+++ b/pkg/services/team/teamimpl/store.go
@@ -342,14 +342,10 @@ func (ss *xormStore) GetIDsByUser(ctx context.Context, query *team.GetTeamIDsByU
 	queryResult := make([]int64, 0)
 	err := ss.db.WithDbSession(ctx, func(sess *db.Session) error {
 		var params []any
-		params = append(params, query.UserID, query.OrgID, query.OrgID)
-		return sess.SQL(`SELECT t.id
-FROM team as t
-INNER JOIN team_member as tm ON t.id = tm.team_id
-WHERE
-tm.user_id=?
-AND tm.org_id=?
-AND t.org_id=?;`, params...).Find(&queryResult)
+		params = append(params, query.UserID, query.OrgID)
+		return sess.SQL(`SELECT tm.team_id
+FROM team_member as tm
+WHERE tm.user_id=? AND tm.org_id=?;`, params...).Find(&queryResult)
 	})
 
 	if err != nil {

--- a/pkg/services/team/teamimpl/store_test.go
+++ b/pkg/services/team/teamimpl/store_test.go
@@ -126,8 +126,8 @@ func TestIntegrationTeamCommandsAndQueries(t *testing.T) {
 				require.Equal(t, team1.OrgID, testOrgID)
 				require.EqualValues(t, team1.MemberCount, 2)
 
-				getIDsQuery := &team.GetTeamIDsByUserIDQuery{OrgID: testOrgID, UserID: userIds[0]}
-				getIDResult, err := teamSvc.GetIDsByUser(context.Background(), getIDsQuery)
+				getIDsQuery := &team.GetTeamIDsByUserQuery{OrgID: testOrgID, UserID: userIds[0]}
+				getIDResult, err := teamSvc.GetTeamIDsByUser(context.Background(), getIDsQuery)
 				require.NoError(t, err)
 
 				require.Equal(t, len(getIDResult), 1)

--- a/pkg/services/team/teamimpl/store_test.go
+++ b/pkg/services/team/teamimpl/store_test.go
@@ -125,6 +125,13 @@ func TestIntegrationTeamCommandsAndQueries(t *testing.T) {
 				require.Equal(t, team1.Email, "test1@test.com")
 				require.Equal(t, team1.OrgID, testOrgID)
 				require.EqualValues(t, team1.MemberCount, 2)
+
+				getIDsQuery := &team.GetTeamIDsByUserIDQuery{OrgID: testOrgID, UserID: userIds[0]}
+				getIDResult, err := teamSvc.GetIDsByUser(context.Background(), getIDsQuery)
+				require.NoError(t, err)
+
+				require.Equal(t, len(getIDResult), 1)
+				require.Equal(t, getIDResult[0], team1.ID)
 			})
 
 			t.Run("Should return latest auth module for users when getting team members", func(t *testing.T) {

--- a/pkg/services/team/teamimpl/team.go
+++ b/pkg/services/team/teamimpl/team.go
@@ -41,7 +41,7 @@ func (s *Service) GetTeamsByUser(ctx context.Context, query *team.GetTeamsByUser
 	return s.store.GetByUser(ctx, query)
 }
 
-func (s *Service) GetIDsByUser(ctx context.Context, query *team.GetTeamIDsByUserIDQuery) ([]int64, error) {
+func (s *Service) GetTeamIDsByUser(ctx context.Context, query *team.GetTeamIDsByUserQuery) ([]int64, error) {
 	return s.store.GetIDsByUser(ctx, query)
 }
 

--- a/pkg/services/team/teamimpl/team.go
+++ b/pkg/services/team/teamimpl/team.go
@@ -41,6 +41,10 @@ func (s *Service) GetTeamsByUser(ctx context.Context, query *team.GetTeamsByUser
 	return s.store.GetByUser(ctx, query)
 }
 
+func (s *Service) GetIDsByUser(ctx context.Context, query *team.GetTeamIDsByUserIDQuery) ([]int64, error) {
+	return s.store.GetIDsByUser(ctx, query)
+}
+
 func (s *Service) AddTeamMember(userID, orgID, teamID int64, isExternal bool, permission dashboards.PermissionType) error {
 	return s.store.AddMember(userID, orgID, teamID, isExternal, permission)
 }

--- a/pkg/services/team/teamtest/team.go
+++ b/pkg/services/team/teamtest/team.go
@@ -76,7 +76,7 @@ func (s *FakeService) GetTeamMembers(ctx context.Context, query *team.GetTeamMem
 func (s *FakeService) RegisterDelete(query string) {
 }
 
-func (s *FakeService) GetIDsByUser(ctx context.Context, query *team.GetTeamIDsByUserIDQuery) ([]int64, error) {
+func (s *FakeService) GetTeamIDsByUser(ctx context.Context, query *team.GetTeamIDsByUserQuery) ([]int64, error) {
 	result := make([]int64, 0)
 	for _, team := range s.ExpectedTeamsByUser {
 		result = append(result, team.ID)

--- a/pkg/services/team/teamtest/team.go
+++ b/pkg/services/team/teamtest/team.go
@@ -75,3 +75,12 @@ func (s *FakeService) GetTeamMembers(ctx context.Context, query *team.GetTeamMem
 
 func (s *FakeService) RegisterDelete(query string) {
 }
+
+func (s *FakeService) GetIDsByUser(ctx context.Context, query *team.GetTeamIDsByUserIDQuery) ([]int64, error) {
+	result := make([]int64, 0)
+	for _, team := range s.ExpectedTeamsByUser {
+		result = append(result, team.ID)
+	}
+
+	return result, s.ExpectedError
+}

--- a/pkg/services/user/userimpl/user.go
+++ b/pkg/services/user/userimpl/user.go
@@ -312,11 +312,11 @@ func (s *Service) GetSignedInUser(ctx context.Context, query *user.GetSignedInUs
 		return nil, err
 	}
 
-	getTeamsByUserQuery := &team.GetTeamIDsByUserIDQuery{
+	getTeamsByUserQuery := &team.GetTeamIDsByUserQuery{
 		OrgID:  signedInUser.OrgID,
 		UserID: signedInUser.UserID,
 	}
-	signedInUser.Teams, err = s.teamService.GetIDsByUser(ctx, getTeamsByUserQuery)
+	signedInUser.Teams, err = s.teamService.GetTeamIDsByUser(ctx, getTeamsByUserQuery)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/services/user/userimpl/user.go
+++ b/pkg/services/user/userimpl/user.go
@@ -312,29 +312,15 @@ func (s *Service) GetSignedInUser(ctx context.Context, query *user.GetSignedInUs
 		return nil, err
 	}
 
-	// tempUser is used to retrieve the teams for the signed in user for internal use.
-	tempUser := &user.SignedInUser{
-		OrgID: signedInUser.OrgID,
-		Permissions: map[int64]map[string][]string{
-			signedInUser.OrgID: {
-				ac.ActionTeamsRead: {ac.ScopeTeamsAll},
-			},
-		},
+	getTeamsByUserQuery := &team.GetTeamIDsByUserIDQuery{
+		OrgID:  signedInUser.OrgID,
+		UserID: signedInUser.UserID,
 	}
-	getTeamsByUserQuery := &team.GetTeamsByUserQuery{
-		OrgID:        signedInUser.OrgID,
-		UserID:       signedInUser.UserID,
-		SignedInUser: tempUser,
-	}
-	getTeamsByUserQueryResult, err := s.teamService.GetTeamsByUser(ctx, getTeamsByUserQuery)
+	signedInUser.Teams, err = s.teamService.GetIDsByUser(ctx, getTeamsByUserQuery)
 	if err != nil {
 		return nil, err
 	}
 
-	signedInUser.Teams = make([]int64, len(getTeamsByUserQueryResult))
-	for i, t := range getTeamsByUserQueryResult {
-		signedInUser.Teams[i] = t.ID
-	}
 	return signedInUser, err
 }
 


### PR DESCRIPTION
**What is this feature?**

First step of https://github.com/grafana/identity-access-team/issues/473

Avoid fetching so much team info and instead retrieve only the user's team IDs

**Why do we need this feature?**

[Add a description of the problem the feature is trying to solve.]

**Who is this feature for?**

[Add information on what kind of user the feature is for.]

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
