### PR TITLE
Chore: Don't show hint for recorded queries

### DIFF
--- a/public/app/plugins/datasource/prometheus/query_hints.test.ts
+++ b/public/app/plugins/datasource/prometheus/query_hints.test.ts
@@ -171,4 +171,22 @@ describe('getQueryHints()', () => {
       },
     });
   });
+
+  it('should not return rate hint for a recorded query', () => {
+    const seriesCount = SUM_HINT_THRESHOLD_COUNT;
+    const series = Array.from({ length: seriesCount }, (_) => ({
+      datapoints: [
+        [0, 0],
+        [0, 0],
+      ],
+    }));
+    let hints = getQueryHints('node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate', series);
+    expect(hints!.length).toBe(0);
+
+    hints = getQueryHints('node_namespace_pod_container:container_cpu_usage_seconds_total', series);
+    expect(hints!.length).toBe(0);
+
+    hints = getQueryHints('container_cpu_usage_seconds_total:irate_total', series);
+    expect(hints!.length).toBe(0);
+  });
 });

--- a/public/app/plugins/datasource/prometheus/query_hints.ts
+++ b/public/app/plugins/datasource/prometheus/query_hints.ts
@@ -32,7 +32,7 @@ export function getQueryHints(query: string, series?: any[], datasource?: Promet
   // Check for need of rate()
   if (query.indexOf('rate(') === -1 && query.indexOf('increase(') === -1) {
     // Use metric metadata for exact types
-    const nameMatch = query.match(/\b(\w+_(total|sum|count))\b/);
+    const nameMatch = query.match(/\b((?<!:)\w+_(total|sum|count)(?!:))\b/);
     let counterNameMetric = nameMatch ? nameMatch[1] : '';
     const metricsMetadata = datasource?.languageProvider?.metricsMetadata;
     let certain = false;


### PR DESCRIPTION
**What is this feature?**

When using a recorded query, the editor displays a "use rate()" hint if the recorded query has `count`, `total`,or `sum` keywords in it despite the query is not a counter. 

In this PR we are checking if the match has `:` in the end or beginning. If there is a match then we skip that metric and show no `rate` hint for that.

**Why do we need this feature?**

For not showing the wrong hint.

**Who is this feature for?**

Prometheus users who have recorded queries

### How to test it?
- Have a recorded query that has `count`, `total` or `sum` at the end and run it 
  - See an example https://raintank-corp.slack.com/archives/C02UC0KCSF4/p1699874722596259
- Query editor will display a hint suggesting using `rate()`
- Switch to this branch and run it again

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
