### PR TITLE
AuthN: Support HA setups with External Service Account management

### DIFF
--- a/pkg/infra/serverlock/serverlock.go
+++ b/pkg/infra/serverlock/serverlock.go
@@ -220,8 +220,7 @@ func (sl *ServerLockService) LockExecuteAndReleaseWithRetries(ctx context.Contex
 
 	sl.executeFunc(ctx, actionName, fn)
 
-	err := sl.releaseLock(ctx, actionName)
-	if err != nil {
+	if err := sl.releaseLock(ctx, actionName); err != nil {
 		span.RecordError(err)
 		ctxLogger.Error("Failed to release the lock", "error", err)
 	}

--- a/pkg/infra/serverlock/serverlock.go
+++ b/pkg/infra/serverlock/serverlock.go
@@ -201,8 +201,7 @@ func (sl *ServerLockService) LockExecuteAndReleaseWithRetries(ctx context.Contex
 				}
 
 				for _, op := range retryOpts {
-					err := op(lockChecks)
-					if err != nil {
+					if err := op(lockChecks); err != nil {
 						return err
 					}
 				}

--- a/pkg/infra/serverlock/serverlock_integration_test.go
+++ b/pkg/infra/serverlock/serverlock_integration_test.go
@@ -2,6 +2,7 @@ package serverlock
 
 import (
 	"context"
+	"sync"
 	"testing"
 	"time"
 
@@ -19,11 +20,11 @@ func TestIntegrationServerLock_LockAndExecute(t *testing.T) {
 	atInterval := time.Hour
 	ctx := context.Background()
 
-	//this time `fn` should be executed
+	// this time `fn` should be executed
 	require.Nil(t, sl.LockAndExecute(ctx, "test-operation", atInterval, fn))
 	require.Equal(t, 1, counter)
 
-	//this should not execute `fn`
+	// this should not execute `fn`
 	require.Nil(t, sl.LockAndExecute(ctx, "test-operation", atInterval, fn))
 	require.Nil(t, sl.LockAndExecute(ctx, "test-operation", atInterval, fn))
 	require.Equal(t, 1, counter)
@@ -61,4 +62,63 @@ func TestIntegrationServerLock_LockExecuteAndRelease(t *testing.T) {
 	require.NoError(t, err)
 
 	require.Equal(t, 4, counter)
+}
+
+func TestIntegrationServerLock_LockExecuteAndReleaseWithRetries(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
+	sl := createTestableServerLock(t)
+
+	retries := 0
+	expectedRetries := 10
+	funcRuns := 0
+	fn := func(context.Context) {
+		funcRuns++
+	}
+	lockTimeout := time.Hour
+	minWait := 0 * time.Millisecond
+	maxWait := 1 * time.Millisecond
+	ctx := context.Background()
+	actionName := "test-operation"
+
+	// Acquire lock so that when `LockExecuteAndReleaseWithRetries` runs, it is forced
+	// to retry
+	err := sl.acquireForRelease(ctx, actionName, lockTimeout)
+	require.NoError(t, err)
+
+	wgRetries := sync.WaitGroup{}
+	wgRetries.Add(expectedRetries)
+	wgRelease := sync.WaitGroup{}
+	wgRelease.Add(1)
+	wgCompleted := sync.WaitGroup{}
+	wgCompleted.Add(1)
+	onRetryFn := func(int) error {
+		retries++
+		wgRetries.Done()
+		if retries == expectedRetries {
+			// When we reach `expectedRetries`, wait for the lock to be released
+			// to guarantee that next try will succeed
+			wgRelease.Wait()
+		}
+		return nil
+	}
+
+	go func() {
+		err := sl.LockExecuteAndReleaseWithRetries(ctx, actionName, minWait, maxWait, lockTimeout, fn, onRetryFn)
+		require.NoError(t, err)
+		wgCompleted.Done()
+	}()
+
+	// Wait to release the lock until `LockExecuteAndReleaseWithRetries` has retried `expectedRetries` times.
+	wgRetries.Wait()
+	err = sl.releaseLock(ctx, actionName)
+	require.NoError(t, err)
+	wgRelease.Done()
+
+	// `LockExecuteAndReleaseWithRetries` has run completely.
+	// Check that it had to retry because the lock was already taken.
+	wgCompleted.Wait()
+	require.Equal(t, expectedRetries, retries)
+	require.Equal(t, 1, funcRuns)
 }

--- a/pkg/services/extsvcauth/registry/service.go
+++ b/pkg/services/extsvcauth/registry/service.go
@@ -123,11 +123,12 @@ func (r *Registry) RemoveExternalService(ctx context.Context, name string) error
 // associated service account has the correct permissions.
 func (r *Registry) SaveExternalService(ctx context.Context, cmd *extsvcauth.ExternalServiceRegistration) (*extsvcauth.ExternalService, error) {
 	var (
-		errSave error
-		extSvc  *extsvcauth.ExternalService
+		errSave  error
+		extSvc   *extsvcauth.ExternalService
+		lockName = "ext-svc-save-" + cmd.Name
 	)
 
-	err := r.serverLock.LockExecuteAndReleaseWithRetries(ctx, "ext-svc-save-"+cmd.Name, lockTimeConfig, func(ctx context.Context) {
+	err := r.serverLock.LockExecuteAndReleaseWithRetries(ctx, lockName, lockTimeConfig, func(ctx context.Context) {
 		// Record provider in case of removal
 		r.lock.Lock()
 		r.extSvcProviders[slugify.Slugify(cmd.Name)] = cmd.AuthProvider

--- a/pkg/services/extsvcauth/registry/service_test.go
+++ b/pkg/services/extsvcauth/registry/service_test.go
@@ -2,7 +2,6 @@ package registry
 
 import (
 	"context"
-	"sync"
 	"testing"
 
 	"github.com/grafana/grafana/pkg/infra/log"
@@ -29,7 +28,6 @@ func setupTestEnv(t *testing.T) *TestEnv {
 		oauthReg:        env.oauthReg,
 		saReg:           env.saReg,
 		extSvcProviders: map[string]extsvcauth.AuthProvider{},
-		lock:            sync.Mutex{},
 	}
 	return &env
 }


### PR DESCRIPTION
### What
Uses a server lock when saving External Service accounts to avoid data races when multiple instances (in HA mode) boot and try to register the same external services all at once.

### Testing
It can be tested using the HA setup in [devenv/docker/ha_test](https://github.com/grafana/grafana/tree/ca831a30d55f329b98c609bc3fc1ac9e4abfe133/devenv/docker/ha_test). As the [README](https://github.com/grafana/grafana/tree/ca831a30d55f329b98c609bc3fc1ac9e4abfe133/devenv/docker/ha_test#build-grafana-docker-container) states, you'll first need to build a Grafana docker image.

I've added a [test script](https://github.com/grafana/grafana/tree/ca831a30d55f329b98c609bc3fc1ac9e4abfe133/devenv/docker/ha_test/test.sh) on a separate branch. It takes ~1 minute to run and manually sets a lock, initializes Grafana and releases the lock. It outputs the Grafana logs showing that it is waiting to create the ext-svc account until we manually release the lock (thanks @gamab for the idea). To use it, you need to set the `PLUGIN_EXAMPLES_REPO` env var pointing to your local checkout of the `grafana-plugin-examples` repo.

Instead of using the `test.sh` script, but still using the [testing branch](https://github.com/grafana/grafana/tree/xavi/ha-extsvc-auth-test), you can also scale up the number of Grafana instances all at once with `docker-compose up --scale grafana=10 -d` and check the logs to (hopefully) see the instances fighting for the lock. I've had success with this scaling up 10 instances at once. To check the logs of all the instances: `docker-compose logs -t | grep -E 'another instance has the lock|Start execution`.

