### PR TITLE
DashboardScene: Link to explore should take adhoc filters into account

### DIFF
--- a/public/app/features/dashboard-scene/utils/urlBuilders.ts
+++ b/public/app/features/dashboard-scene/utils/urlBuilders.ts
@@ -1,6 +1,6 @@
-import { AdHocVariableFilter, locationUtil, UrlQueryMap, urlUtil } from '@grafana/data';
+import { locationUtil, UrlQueryMap, urlUtil } from '@grafana/data';
 import { config, locationSearchToObject, locationService } from '@grafana/runtime';
-import { sceneGraph, SceneQueryRunner, VizPanel } from '@grafana/scenes';
+import { sceneGraph, VizPanel } from '@grafana/scenes';
 import { contextSrv } from 'app/core/core';
 import { getExploreUrl } from 'app/core/utils/explore';
 

--- a/public/app/features/dashboard-scene/utils/urlBuilders.ts
+++ b/public/app/features/dashboard-scene/utils/urlBuilders.ts
@@ -1,6 +1,6 @@
-import { locationUtil, UrlQueryMap, urlUtil } from '@grafana/data';
+import { AdHocVariableFilter, locationUtil, UrlQueryMap, urlUtil } from '@grafana/data';
 import { config, locationSearchToObject, locationService } from '@grafana/runtime';
-import { sceneGraph, VizPanel } from '@grafana/scenes';
+import { sceneGraph, SceneQueryRunner, VizPanel } from '@grafana/scenes';
 import { contextSrv } from 'app/core/core';
 import { getExploreUrl } from 'app/core/utils/explore';
 
@@ -91,5 +91,6 @@ export function tryGetExploreUrlForPanel(vizPanel: VizPanel): Promise<string | u
     dsRef: queryRunner.state.datasource,
     timeRange: timeRange.state.value,
     scopedVars: { __sceneObject: { value: vizPanel } },
+    adhocFilters: queryRunner.state.data?.request?.filters,
   });
 }


### PR DESCRIPTION
In https://github.com/grafana/grafana/pull/78339 I thought to make this work for scenes I had to add a way for SceneQueryRunner to expose the adhoc filter set it subscribes (to access the filters) but realised that we can just take the filters from the request object attached to PanelData. 

