### PR TITLE
UI: Fix tab href race condition

### DIFF
--- a/packages/grafana-ui/src/components/Tabs/Tab.tsx
+++ b/packages/grafana-ui/src/components/Tabs/Tab.tsx
@@ -39,6 +39,14 @@ export const Tab = React.forwardRef<HTMLAnchorElement, TabProps>(
 
     const linkClass = cx(tabsStyles.link, active ? tabsStyles.activeStyle : tabsStyles.notActive);
 
+    // wraps the onClick handler with "event.preventDefault" – prevents a rare race condition between navigating to the "href" and "onClick" handler
+    const onClickHandler = onChangeTab
+      ? (event: React.MouseEvent<HTMLAnchorElement, MouseEvent>) => {
+          event.preventDefault();
+          onChangeTab(event);
+        }
+      : () => {};
+
     return (
       <div className={tabsStyles.item}>
         <a
@@ -46,7 +54,7 @@ export const Tab = React.forwardRef<HTMLAnchorElement, TabProps>(
           href={href ? href : '#'}
           className={linkClass}
           {...otherProps}
-          onClick={onChangeTab}
+          onClick={onClickHandler}
           aria-label={otherProps['aria-label'] || selectors.components.Tab.title(label)}
           role="tab"
           aria-selected={active}

--- a/packages/grafana-ui/src/components/Tabs/Tabs.story.tsx
+++ b/packages/grafana-ui/src/components/Tabs/Tabs.story.tsx
@@ -51,6 +51,14 @@ export const Simple: Story = () => {
   );
 };
 
+export const withHref: Story = () => (
+  <DashboardStoryCanvas>
+    <TabsBar>
+      <Tab label={'to Google'} active={false} href="https://google.com/" />
+    </TabsBar>
+  </DashboardStoryCanvas>
+);
+
 export const Counter: Story<CounterProps> = (args) => {
   return <TabCounter {...args} />;
 };


### PR DESCRIPTION
**What is this feature?**

~So this one is tough to reproduce but I have been able to under certain conditions.~

~The easiest way to reproduce is to go to the panel edit view and switch between tabs really fast.~

The easiest way to reproduce this issue is to click the "counter" of the alert tab specifically.

<img width="442" alt="image" src="https://github.com/grafana/grafana/assets/868844/bcb371c6-f173-428d-9616-8444a40e8a28">

~This sometimes triggers a race condition of sorts where the `onChangeTab` isn't called (or is called) and the user is redirected to `/#` instead.~

This triggers a special condition in the `interceptLinkClicks` when the element we just clicked has been removed from the DOM – it no longer has a `parentElement`.

It will never find a parent anchor tag as per this piece of code
https://github.com/grafana/grafana/blob/4247696402213e749f1ce63eac230b732d6acfe2/public/app/core/navigation/patch/interceptLinkClicks.ts#L46-L55

This in turn makes it not jump into this code branch

https://github.com/grafana/grafana/blob/4247696402213e749f1ce63eac230b732d6acfe2/public/app/core/navigation/patch/interceptLinkClicks.ts#L6-L13

Which results in `event.preventDefault()` to not be called for our click, navigating the user to `/#`.

**Special notes for your reviewer:**

I've added a Story for rendering a tab with an `href` so I could validate the fix doesn't introduce any regressions.

~For now this fix is only targeting `v9.4.x` since I haven't had time to validate this for newer versions of Grafana.~

This bug also exists in every other version of Grafana.

Please check that:
- [x] It works as expected from a user's perspective.
