### PR TITLE
Docs: adds info on location for mute timings

### DIFF
--- a/docs/sources/alerting/alerting-rules/create-grafana-managed-rule.md
+++ b/docs/sources/alerting/alerting-rules/create-grafana-managed-rule.md
@@ -30,6 +30,9 @@ Multiple alert instances can be created as a result of one alert rule (also know
 
 Grafana managed alert rules can only be edited or deleted by users with Edit permissions for the folder storing the rules.
 
+If you delete an alerting resource created in the UI, you can no longer retrieve it.
+To make a backup of your configuration and to be able to restore deleted alerting resources, create your alerting resources using file provisioning, Terraform, or the Alerting API.
+
 Watch this video to learn more about creating alert rules: {{< vimeo 720001934 >}}
 
 In the following sections, we’ll guide you through the process of creating your Grafana-managed alert rules.

--- a/docs/sources/alerting/alerting-rules/create-mimir-loki-managed-rule.md
+++ b/docs/sources/alerting/alerting-rules/create-mimir-loki-managed-rule.md
@@ -28,6 +28,9 @@ Create alert rules for an external Grafana Mimir or Loki instance that has ruler
 
 Alert rules for an external Grafana Mimir or Loki instance can be edited or deleted by users with Editor or Admin roles.
 
+If you delete an alerting resource created in the UI, you can no longer retrieve it.
+To make a backup of your configuration and to be able to restore deleted alerting resources, create your alerting resources using file provisioning, Terraform, or the Alerting API.
+
 ## Before you begin
 
 - Verify that you have write permission to the Prometheus or Loki data source. Otherwise, you will not be able to create or update Grafana Mimir managed alert rules.

--- a/docs/sources/alerting/manage-notifications/mute-timings.md
+++ b/docs/sources/alerting/manage-notifications/mute-timings.md
@@ -67,7 +67,7 @@ Supported time interval options are:
 - Months: The months of the year in either numerical or the full calendar month. For example: `1, may:august`.
 - Years: The year or years for the interval. For example: `2021:2024`.
 
-All fields are lists, and at least one list element must be satisfied to match the field. Fields also support ranges using `:` (ex: `monday:thursday`).
+All fields are lists; to match the field, at least one list element must be satisfied. Fields also support ranges using `:` (e.g., `monday:thursday`).
 
 If a field is left blank, any moment of time will match the field. For an instant of time to match a complete time interval, all fields must match. A mute timing can contain multiple time intervals.
 

--- a/docs/sources/alerting/manage-notifications/mute-timings.md
+++ b/docs/sources/alerting/manage-notifications/mute-timings.md
@@ -56,7 +56,7 @@ The following table highlights the key differences between mute timings and sile
 
 ## Time intervals
 
-A time interval is a specific duration when alerts are suppressed from firing. The duration typically consists of a specific time range along with days of a week, month, or year.
+A time interval is a specific duration during which alerts are suppressed. The duration typically consists of a specific time range and the days of the week, month, or year.
 
 Supported time interval options are:
 

--- a/docs/sources/alerting/manage-notifications/mute-timings.md
+++ b/docs/sources/alerting/manage-notifications/mute-timings.md
@@ -67,7 +67,7 @@ Supported time interval options are:
 - Months: The months of the year in either numerical or the full calendar month. For example: `1, may:august`.
 - Years: The year or years for the interval. For example: `2021:2024`.
 
- All fields are lists, and at least one list element must be satisfied to match the field. Fields also support ranges using `:` (ex: `monday:thursday`).
+All fields are lists, and at least one list element must be satisfied to match the field. Fields also support ranges using `:` (ex: `monday:thursday`).
 
 If a field is left blank, any moment of time will match the field. For an instant of time to match a complete time interval, all fields must match. A mute timing can contain multiple time intervals.
 

--- a/docs/sources/alerting/manage-notifications/mute-timings.md
+++ b/docs/sources/alerting/manage-notifications/mute-timings.md
@@ -56,17 +56,18 @@ The following table highlights the key differences between mute timings and sile
 
 ## Time intervals
 
-A time interval is a definition for a moment in time. If an alert fires during this interval it will be suppressed. All fields are lists, and at least one list element must be satisfied to match the field. Fields also support ranges using `:` (ex: `monday:thursday`). The fields available for a time interval are: mute timing can contain multiple time intervals. A time interval is a specific duration when alerts are suppressed from firing. The duration typically consists of a specific time range along with days of a week, month, or year.
-
-    All properties for the time interval are lists, and at least one list element must be satisfied to match the field. The fields support ranges using `:` (ex: `monday:thursday`). If you leave a field blank, it will match with any moment of time.
+A time interval is a specific duration when alerts are suppressed from firing. The duration typically consists of a specific time range along with days of a week, month, or year.
 
 Supported time interval options are:
 
 - Time range: The time inclusive of the start and exclusive of the end time (in UTC if no location has been selected, otherwise local time).
+- Location: Depending on the location you select, the time range is displayed in local time.
 - Days of the week: The day or range of days of the week. Example: `monday:thursday`.
 - Days of the month: The date 1-31 of a month. Negative values can also be used to represent days that begin at the end of the month. For example: `-1` for the last day of the month.
 - Months: The months of the year in either numerical or the full calendar month. For example: `1, may:august`.
 - Years: The year or years for the interval. For example: `2021:2024`.
+
+ All fields are lists, and at least one list element must be satisfied to match the field. Fields also support ranges using `:` (ex: `monday:thursday`).
 
 If a field is left blank, any moment of time will match the field. For an instant of time to match a complete time interval, all fields must match. A mute timing can contain multiple time intervals.
 


### PR DESCRIPTION
support for locations was missing in the docs - added it in to address https://github.com/grafana/support-escalations/issues/8313
