### PR TITLE
Loki: Fix conditional for derived fields using regex type

### DIFF
--- a/public/app/plugins/datasource/loki/getDerivedFields.test.ts
+++ b/public/app/plugins/datasource/loki/getDerivedFields.test.ts
@@ -26,17 +26,20 @@ describe('getDerivedFields', () => {
     const newFields = getDerivedFields(df, [
       {
         matcherRegex: 'trace1=(\\w+)',
+        matcherType: 'regex',
         name: 'trace1',
         url: 'http://localhost/${__value.raw}',
       },
       {
         matcherRegex: 'trace2=(\\w+)',
+        matcherType: 'regex',
         name: 'trace2',
         url: 'test',
         datasourceUid: 'uid',
       },
       {
         matcherRegex: 'trace2=(\\w+)',
+        matcherType: 'regex',
         name: 'trace2',
         url: 'test',
         datasourceUid: 'uid2',
@@ -44,6 +47,7 @@ describe('getDerivedFields', () => {
       },
       {
         matcherRegex: 'trace=(\\w+)',
+        matcherType: 'regex',
         name: 'tempoTraceId',
         url: 'test',
         datasourceUid: 'tempo-datasource-uid',
@@ -51,6 +55,7 @@ describe('getDerivedFields', () => {
       },
       {
         matcherRegex: 'trace=(\\w+)',
+        matcherType: 'regex',
         name: 'xrayTraceId',
         url: 'test',
         datasourceUid: 'xray-datasource-uid',
@@ -115,6 +120,7 @@ describe('getDerivedFields', () => {
     const newFields = getDerivedFields(df, [
       {
         matcherRegex: 'trace1=(\\w+)',
+        matcherType: 'regex',
         name: 'trace1',
         url: 'http://localhost/${__value.raw}',
       },

--- a/public/app/plugins/datasource/loki/getDerivedFields.ts
+++ b/public/app/plugins/datasource/loki/getDerivedFields.ts
@@ -41,7 +41,7 @@ export function getDerivedFields(dataFrame: DataFrame, derivedFieldConfigs: Deri
           }
         }
         field.values.push(null);
-      } else if (derivedFieldsGrouped[field.name][0].matcherType !== 'regex') {
+      } else if (derivedFieldsGrouped[field.name][0].matcherType === 'regex') {
         // `matcherRegex` will actually be used as a RegExp here
         const line = lineField.values[i];
         const logMatch = line.match(derivedFieldsGrouped[field.name][0].matcherRegex);


### PR DESCRIPTION
In https://github.com/grafana/grafana/commit/53758ad7642e9d3646bbad3698e55774bdf0623c, the condition to check the matcher type for regex derived fields was flipped. Reverting that now, and updating the tests.

**Why do we need this feature?**

Currently breaks derived fields.

**Special notes for your reviewer:**

Test derived fields with regular expressions. For example:

![imagen](https://github.com/grafana/grafana/assets/1069378/b7e740e9-b783-4b04-a93d-a368c8abed13)
