### PR TITLE
`@grafana/data`: Add `serializeParams`

### DIFF
--- a/.betterer.results
+++ b/.betterer.results
@@ -6503,14 +6503,11 @@ exports[`better eslint`] = {
       [0, 0, 0, "Unexpected any. Specify a different type.", "2"],
       [0, 0, 0, "Do not use any type assertions.", "3"],
       [0, 0, 0, "Do not use any type assertions.", "4"],
-      [0, 0, 0, "Do not use any type assertions.", "5"],
-      [0, 0, 0, "Unexpected any. Specify a different type.", "6"],
-      [0, 0, 0, "Do not use any type assertions.", "7"],
-      [0, 0, 0, "Do not use any type assertions.", "8"],
-      [0, 0, 0, "Do not use any type assertions.", "9"],
-      [0, 0, 0, "Unexpected any. Specify a different type.", "10"],
-      [0, 0, 0, "Unexpected any. Specify a different type.", "11"],
-      [0, 0, 0, "Unexpected any. Specify a different type.", "12"]
+      [0, 0, 0, "Unexpected any. Specify a different type.", "5"],
+      [0, 0, 0, "Do not use any type assertions.", "6"],
+      [0, 0, 0, "Unexpected any. Specify a different type.", "7"],
+      [0, 0, 0, "Unexpected any. Specify a different type.", "8"],
+      [0, 0, 0, "Unexpected any. Specify a different type.", "9"]
     ],
     "public/app/plugins/datasource/tempo/language_provider.ts:5381": [
       [0, 0, 0, "Unexpected any. Specify a different type.", "0"]

--- a/.betterer.results
+++ b/.betterer.results
@@ -6503,13 +6503,14 @@ exports[`better eslint`] = {
       [0, 0, 0, "Unexpected any. Specify a different type.", "2"],
       [0, 0, 0, "Do not use any type assertions.", "3"],
       [0, 0, 0, "Do not use any type assertions.", "4"],
-      [0, 0, 0, "Unexpected any. Specify a different type.", "5"],
-      [0, 0, 0, "Do not use any type assertions.", "6"],
+      [0, 0, 0, "Do not use any type assertions.", "5"],
+      [0, 0, 0, "Unexpected any. Specify a different type.", "6"],
       [0, 0, 0, "Do not use any type assertions.", "7"],
       [0, 0, 0, "Do not use any type assertions.", "8"],
-      [0, 0, 0, "Unexpected any. Specify a different type.", "9"],
+      [0, 0, 0, "Do not use any type assertions.", "9"],
       [0, 0, 0, "Unexpected any. Specify a different type.", "10"],
-      [0, 0, 0, "Unexpected any. Specify a different type.", "11"]
+      [0, 0, 0, "Unexpected any. Specify a different type.", "11"],
+      [0, 0, 0, "Unexpected any. Specify a different type.", "12"]
     ],
     "public/app/plugins/datasource/tempo/language_provider.ts:5381": [
       [0, 0, 0, "Unexpected any. Specify a different type.", "0"]

--- a/.betterer.results
+++ b/.betterer.results
@@ -1558,8 +1558,7 @@ exports[`better eslint`] = {
       [0, 0, 0, "Do not use any type assertions.", "6"],
       [0, 0, 0, "Unexpected any. Specify a different type.", "7"],
       [0, 0, 0, "Do not use any type assertions.", "8"],
-      [0, 0, 0, "Unexpected any. Specify a different type.", "9"],
-      [0, 0, 0, "Unexpected any. Specify a different type.", "10"]
+      [0, 0, 0, "Unexpected any. Specify a different type.", "9"]
     ],
     "public/app/core/utils/flatten.ts:5381": [
       [0, 0, 0, "Unexpected any. Specify a different type.", "0"]

--- a/.betterer.results
+++ b/.betterer.results
@@ -1558,7 +1558,8 @@ exports[`better eslint`] = {
       [0, 0, 0, "Do not use any type assertions.", "6"],
       [0, 0, 0, "Unexpected any. Specify a different type.", "7"],
       [0, 0, 0, "Do not use any type assertions.", "8"],
-      [0, 0, 0, "Unexpected any. Specify a different type.", "9"]
+      [0, 0, 0, "Unexpected any. Specify a different type.", "9"],
+      [0, 0, 0, "Unexpected any. Specify a different type.", "10"]
     ],
     "public/app/core/utils/flatten.ts:5381": [
       [0, 0, 0, "Unexpected any. Specify a different type.", "0"]

--- a/packages/grafana-data/src/utils/url.test.ts
+++ b/packages/grafana-data/src/utils/url.test.ts
@@ -33,6 +33,36 @@ describe('toUrlParams', () => {
     });
     expect(url).toBe('datasource=testDs%5B%21%27%28%29%2A%5D');
   });
+  it('should encode object properties as url parameters', () => {
+    const params = urlUtil.serializeParams({
+      server: 'backend-01',
+      hasSpace: 'has space',
+      many: ['1', '2', '3'],
+      true: true,
+      number: 20,
+      isNull: null,
+      isUndefined: undefined,
+      oneMore: false,
+    });
+    expect(params).toBe(
+      'server=backend-01&hasSpace=has%20space&many=1&many=2&many=3&true&number=20&isNull=&isUndefined=&oneMore=false'
+    );
+  });
+
+  it('should not encode special character the same way as angular js', () => {
+    const params = urlUtil.serializeParams({
+      server: ':@',
+    });
+    expect(params).not.toBe('server=:@');
+  });
+
+  it('should keep booleans', () => {
+    const url = urlUtil.serializeParams({
+      bool1: true,
+      bool2: false,
+    });
+    expect(url).toBe('bool1&bool2=false');
+  });
 });
 
 describe('parseKeyValue', () => {

--- a/packages/grafana-data/src/utils/url.ts
+++ b/packages/grafana-data/src/utils/url.ts
@@ -103,7 +103,7 @@ function toUrlParams(a: any, encodeAsAngularJS = true) {
 }
 
 /**
- * Converts an object into a URL-encoded query string.
+ * Converts params into a URL-encoded query string.
  *
  * @param params data to serialize
  * @returns A URL-encoded string representing the provided data.

--- a/packages/grafana-data/src/utils/url.ts
+++ b/packages/grafana-data/src/utils/url.ts
@@ -198,6 +198,7 @@ export const urlUtil = {
   appendQueryToUrl,
   getUrlSearchParams,
   parseKeyValue,
+  serializeParams,
 };
 
 /**
@@ -236,3 +237,21 @@ export const toURLRange = (range: RawTimeRange): URLRange => {
     to,
   };
 };
+
+/**
+ * Converts an object into a URL-encoded query string.
+ *
+ * @param params data to serialize
+ * @returns A URL-encoded string representing the provided data.
+ */
+function serializeParams(params: Record<string, string | number | boolean | Array<string | number | boolean>>): string {
+  return Object.keys(params)
+    .map((key) => {
+      const value = params[key];
+      if (Array.isArray(value)) {
+        return value.map((arrayValue) => `${encodeURIComponent(key)}=${encodeURIComponent(arrayValue)}`).join('&');
+      }
+      return `${encodeURIComponent(key)}=${encodeURIComponent(value)}`;
+    })
+    .join('&');
+}

--- a/public/app/core/utils/fetch.ts
+++ b/public/app/core/utils/fetch.ts
@@ -1,6 +1,6 @@
 import { omitBy } from 'lodash';
 
-import { deprecationWarning, urlUtil } from '@grafana/data';
+import { deprecationWarning } from '@grafana/data';
 import { BackendSrvRequest } from '@grafana/runtime';
 
 export const parseInitFromOptions = (options: BackendSrvRequest): RequestInit => {
@@ -130,9 +130,21 @@ export async function parseResponseBody<T>(
   return textData as any;
 }
 
+function serializeParams(data: Record<string, any>): string {
+  return Object.keys(data)
+    .map((key) => {
+      const value = data[key];
+      if (Array.isArray(value)) {
+        return value.map((arrayValue) => `${encodeURIComponent(key)}=${encodeURIComponent(arrayValue)}`).join('&');
+      }
+      return `${encodeURIComponent(key)}=${encodeURIComponent(value)}`;
+    })
+    .join('&');
+}
+
 export const parseUrlFromOptions = (options: BackendSrvRequest): string => {
   const cleanParams = omitBy(options.params, (v) => v === undefined || (v && v.length === 0));
-  const serializedParams = urlUtil.serializeParams(cleanParams);
+  const serializedParams = serializeParams(cleanParams);
   return options.params && serializedParams.length ? `${options.url}?${serializedParams}` : options.url;
 };
 

--- a/public/app/core/utils/fetch.ts
+++ b/public/app/core/utils/fetch.ts
@@ -1,6 +1,6 @@
 import { omitBy } from 'lodash';
 
-import { deprecationWarning } from '@grafana/data';
+import { deprecationWarning, urlUtil } from '@grafana/data';
 import { BackendSrvRequest } from '@grafana/runtime';
 
 export const parseInitFromOptions = (options: BackendSrvRequest): RequestInit => {
@@ -130,21 +130,9 @@ export async function parseResponseBody<T>(
   return textData as any;
 }
 
-export function serializeParams(data: Record<string, any>): string {
-  return Object.keys(data)
-    .map((key) => {
-      const value = data[key];
-      if (Array.isArray(value)) {
-        return value.map((arrayValue) => `${encodeURIComponent(key)}=${encodeURIComponent(arrayValue)}`).join('&');
-      }
-      return `${encodeURIComponent(key)}=${encodeURIComponent(value)}`;
-    })
-    .join('&');
-}
-
 export const parseUrlFromOptions = (options: BackendSrvRequest): string => {
   const cleanParams = omitBy(options.params, (v) => v === undefined || (v && v.length === 0));
-  const serializedParams = serializeParams(cleanParams);
+  const serializedParams = urlUtil.serializeParams(cleanParams);
   return options.params && serializedParams.length ? `${options.url}?${serializedParams}` : options.url;
 };
 

--- a/public/app/plugins/datasource/jaeger/datasource.ts
+++ b/public/app/plugins/datasource/jaeger/datasource.ts
@@ -13,10 +13,10 @@ import {
   FieldType,
   MutableDataFrame,
   ScopedVars,
+  urlUtil,
 } from '@grafana/data';
 import { BackendSrvRequest, getBackendSrv, getTemplateSrv, TemplateSrv } from '@grafana/runtime';
 import { NodeGraphOptions } from 'app/core/components/NodeGraphSettings';
-import { serializeParams } from 'app/core/utils/fetch';
 import { getTimeSrv, TimeSrv } from 'app/features/dashboard/services/TimeSrv';
 import { SpanBarOptions } from 'app/features/explore/TraceView/components';
 
@@ -47,7 +47,7 @@ export class JaegerDatasource extends DataSourceApi<JaegerQuery, JaegerJsonData>
     this.traceIdTimeParams = instanceSettings.jsonData.traceIdTimeParams;
   }
 
-  async metadataRequest(url: string, params?: Record<string, unknown>) {
+  async metadataRequest(url: string, params?: Record<string, string | number | boolean>) {
     const res = await lastValueFrom(this._request(url, params, { hideFromInspector: true }));
     return res.data.data;
   }
@@ -232,10 +232,10 @@ export class JaegerDatasource extends DataSourceApi<JaegerQuery, JaegerJsonData>
 
   private _request(
     apiUrl: string,
-    data?: Record<string, unknown>,
+    data?: Record<string, string | number | boolean>,
     options?: Partial<BackendSrvRequest>
   ): Observable<Record<string, any>> {
-    const params = data ? serializeParams(data) : '';
+    const params = data ? urlUtil.serializeParams(data) : '';
     const url = `${this.instanceSettings.url}${apiUrl}${params.length ? `?${params}` : ''}`;
     const req = {
       ...options,

--- a/public/app/plugins/datasource/jaeger/datasource.ts
+++ b/public/app/plugins/datasource/jaeger/datasource.ts
@@ -47,7 +47,7 @@ export class JaegerDatasource extends DataSourceApi<JaegerQuery, JaegerJsonData>
     this.traceIdTimeParams = instanceSettings.jsonData.traceIdTimeParams;
   }
 
-  async metadataRequest(url: string, params?: Record<string, string | number | boolean>) {
+  async metadataRequest(url: string, params?: Record<string, unknown>) {
     const res = await lastValueFrom(this._request(url, params, { hideFromInspector: true }));
     return res.data.data;
   }
@@ -232,7 +232,7 @@ export class JaegerDatasource extends DataSourceApi<JaegerQuery, JaegerJsonData>
 
   private _request(
     apiUrl: string,
-    data?: Record<string, string | number | boolean>,
+    data?: Record<string, unknown>,
     options?: Partial<BackendSrvRequest>
   ): Observable<Record<string, any>> {
     const params = data ? urlUtil.serializeParams(data) : '';

--- a/public/app/plugins/datasource/loki/datasource.ts
+++ b/public/app/plugins/datasource/loki/datasource.ts
@@ -36,6 +36,7 @@ import {
   renderLegendFormat,
   LegacyMetricFindQueryOptions,
   AdHocVariableFilter,
+  urlUtil,
 } from '@grafana/data';
 import { Duration } from '@grafana/lezer-logql';
 import { BackendSrvRequest, config, DataSourceWithBackend, getTemplateSrv, TemplateSrv } from '@grafana/runtime';
@@ -43,7 +44,6 @@ import { DataQuery } from '@grafana/schema';
 import { convertToWebSocketUrl } from 'app/core/utils/explore';
 import { getTimeSrv, TimeSrv } from 'app/features/dashboard/services/TimeSrv';
 
-import { serializeParams } from '../../../core/utils/fetch';
 import { queryLogsSample, queryLogsVolume } from '../../../features/logs/logsModel';
 import { getLogLevelFromKey } from '../../../features/logs/utils';
 import { replaceVariables, returnVariables } from '../prometheus/querybuilder/shared/parsingUtils';
@@ -384,7 +384,7 @@ export class LokiDatasource
   private createLiveTarget(target: LokiQuery, maxDataPoints: number): LokiLiveTarget {
     const query = target.expr;
     const baseUrl = this.instanceSettings.url;
-    const params = serializeParams({ query });
+    const params = urlUtil.serializeParams({ query });
 
     return {
       query,

--- a/public/app/plugins/datasource/tempo/datasource.ts
+++ b/public/app/plugins/datasource/tempo/datasource.ts
@@ -319,6 +319,7 @@ export class TempoDatasource extends DataSourceWithBackend<TempoQuery, TempoJson
         // Params can't have undefined values that are possible in SearchQueryParams
         const params: Record<string, string | number> = {};
         for (const key in searchQuery) {
+          // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
           const value = searchQuery[key as keyof SearchQueryParams];
           if (value !== undefined) {
             params[key] = value;
@@ -732,7 +733,9 @@ export class TempoDatasource extends DataSourceWithBackend<TempoQuery, TempoJson
     if (query.queryType === 'nativeSearch') {
       let result = [];
       for (const key of ['serviceName', 'spanName', 'search', 'minDuration', 'maxDuration', 'limit']) {
+        // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
         if (query.hasOwnProperty(key) && query[key as keyof TempoQuery]) {
+          // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
           result.push(`${startCase(key)}: ${query[key as keyof TempoQuery]}`);
         }
       }

--- a/public/app/plugins/datasource/tempo/datasource.ts
+++ b/public/app/plugins/datasource/tempo/datasource.ts
@@ -316,7 +316,7 @@ export class TempoDatasource extends DataSourceWithBackend<TempoQuery, TempoJson
         const timeRange = { startTime: options.range.from.unix(), endTime: options.range.to.unix() };
         const query = this.applyVariables(targets.nativeSearch[0], options.scopedVars);
         const searchQuery = this.buildSearchQuery(query, timeRange);
-        // Params can't have undefined values
+        // Params can't have undefined values that are possible in SearchQueryParams
         const params: Record<string, string | number> = {};
         for (const key in searchQuery) {
           const value = searchQuery[key];

--- a/public/app/plugins/datasource/tempo/datasource.ts
+++ b/public/app/plugins/datasource/tempo/datasource.ts
@@ -316,18 +316,8 @@ export class TempoDatasource extends DataSourceWithBackend<TempoQuery, TempoJson
         const timeRange = { startTime: options.range.from.unix(), endTime: options.range.to.unix() };
         const query = this.applyVariables(targets.nativeSearch[0], options.scopedVars);
         const searchQuery = this.buildSearchQuery(query, timeRange);
-        // Params can't have undefined values that are possible in SearchQueryParams
-        const params: Record<string, string | number> = {};
-        for (const key in searchQuery) {
-          // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
-          const value = searchQuery[key as keyof SearchQueryParams];
-          if (value !== undefined) {
-            params[key] = value;
-          }
-        }
-
         subQueries.push(
-          this._request('/api/search', params).pipe(
+          this._request('/api/search', searchQuery).pipe(
             map((response) => {
               return {
                 data: [createTableFrameFromSearch(response.data.traces, this.instanceSettings)],
@@ -698,7 +688,7 @@ export class TempoDatasource extends DataSourceWithBackend<TempoQuery, TempoJson
 
   private _request(
     apiUrl: string,
-    data?: Record<string, string | number>,
+    data?: unknown,
     options?: Partial<BackendSrvRequest>
   ): Observable<Record<string, any>> {
     const params = data ? urlUtil.serializeParams(data) : '';

--- a/public/app/plugins/datasource/tempo/datasource.ts
+++ b/public/app/plugins/datasource/tempo/datasource.ts
@@ -319,7 +319,7 @@ export class TempoDatasource extends DataSourceWithBackend<TempoQuery, TempoJson
         // Params can't have undefined values that are possible in SearchQueryParams
         const params: Record<string, string | number> = {};
         for (const key in searchQuery) {
-          const value = searchQuery[key];
+          const value = searchQuery[key as keyof SearchQueryParams];
           if (value !== undefined) {
             params[key] = value;
           }

--- a/public/app/plugins/datasource/tempo/types.ts
+++ b/public/app/plugins/datasource/tempo/types.ts
@@ -7,7 +7,6 @@ import { LokiQuery } from '../loki/types';
 import { TempoQuery as TempoBase, TempoQueryType, TraceqlFilter } from './dataquery.gen';
 
 export interface SearchQueryParams {
-  [key: string]: string | number | undefined;
   minDuration?: string;
   maxDuration?: string;
   limit?: number;

--- a/public/app/plugins/datasource/tempo/types.ts
+++ b/public/app/plugins/datasource/tempo/types.ts
@@ -7,6 +7,7 @@ import { LokiQuery } from '../loki/types';
 import { TempoQuery as TempoBase, TempoQueryType, TraceqlFilter } from './dataquery.gen';
 
 export interface SearchQueryParams {
+  [key: string]: string | number | undefined;
   minDuration?: string;
   maxDuration?: string;
   limit?: number;

--- a/public/app/plugins/datasource/zipkin/datasource.ts
+++ b/public/app/plugins/datasource/zipkin/datasource.ts
@@ -10,12 +10,11 @@ import {
   FieldType,
   createDataFrame,
   ScopedVars,
+  urlUtil,
 } from '@grafana/data';
 import { BackendSrvRequest, FetchResponse, getBackendSrv, getTemplateSrv, TemplateSrv } from '@grafana/runtime';
 import { NodeGraphOptions } from 'app/core/components/NodeGraphSettings';
 import { SpanBarOptions } from 'app/features/explore/TraceView/components';
-
-import { serializeParams } from '../../../core/utils/fetch';
 
 import { apiPrefix } from './constants';
 import { ZipkinQuery, ZipkinSpan } from './types';
@@ -104,7 +103,7 @@ export class ZipkinDatasource extends DataSourceApi<ZipkinQuery, ZipkinJsonData>
     data?: any,
     options?: Partial<BackendSrvRequest>
   ): Observable<FetchResponse<T>> {
-    const params = data ? serializeParams(data) : '';
+    const params = data ? urlUtil.serializeParams(data) : '';
     const url = `${this.instanceSettings.url}${apiUrl}${params.length ? `?${params}` : ''}`;
     const req = {
       ...options,


### PR DESCRIPTION
Part of https://github.com/grafana/grafana/issues/72631
While working on https://github.com/grafana/grafana/issues/72631 I wanted to remove `serializeParams` import from `app/core` and I noticed that there are couple of data sources that use it. Therefore I have decided to move it to `@grafana/data` under `urlUtil` and use is in all data sources from there. 