### PR TITLE
Loading screen: Ensure bounce animation isn't blocked by main thread

### DIFF
--- a/public/views/index-template.html
+++ b/public/views/index-template.html
@@ -120,26 +120,21 @@
         0% {
           transform: scaleX(1.3) scaleY(0.8);
           animation-timing-function: cubic-bezier(0.3, 0, 0.1, 1);
-          transform-origin: bottom center;
         }
         15% {
           transform: scaleX(0.75) scaleY(1.25);
           animation-timing-function: cubic-bezier(0, 0, 0.7, 0.75);
-          transform-origin: bottom center;
         }
         55% {
           transform: scaleX(1.05) scaleY(0.95);
           animation-timing-function: cubic-bezier(0.9, 0, 1, 1);
-          transform-origin: top center;
         }
         95% {
           transform: scaleX(0.75) scaleY(1.25);
           animation-timing-function: cubic-bezier(0, 0, 0, 1);
-          transform-origin: bottom center;
         }
         100% {
           transform: scaleX(1.3) scaleY(0.8);
-          transform-origin: bottom center;
           animation-timing-function: cubic-bezier(0, 0, 0.7, 1);
         }
       }


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

ok this is really minor but it's been annoying me... the bouncing grafana logo animation stutters in chrome (not in firefox or safari) when all the javascript loads in. for some reason, chrome doesn't delegate the animation to the compositor thread and therefore it gets blocked by activity on the main thread. removing the `transform-origin` properties seem to allow chrome to correctly put it on the compositor thread with (from what i can see) negligible impact to the animation itself

# before

https://github.com/grafana/grafana/assets/20999846/c9a34d68-abc5-4458-a5db-1207f4179343

# after

https://github.com/grafana/grafana/assets/20999846/d0107865-1719-4bbd-afa6-d80415754d97

**Why do we need this feature?**

- smooth animation

**Who is this feature for?**

- everyone!

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
