### PR TITLE
DashboardScene: Fixes wrapping panel time override

### DIFF
--- a/public/app/features/dashboard-scene/scene/PanelTimeRange.tsx
+++ b/public/app/features/dashboard-scene/scene/PanelTimeRange.tsx
@@ -104,6 +104,7 @@ const getStyles = (theme: GrafanaTheme2) => {
     timeshift: css({
       color: theme.colors.text.link,
       gap: theme.spacing(0.5),
+      whiteSpace: 'nowrap',
     }),
   };
 };


### PR DESCRIPTION
Part of scene dashboards bug bash.

Fixes the wrapping test found in panel time overrides. 