### PR TITLE
DashboardScene: Fixes focus panel z-index issue

### DIFF
--- a/public/app/features/dashboard-scene/scene/DashboardSceneRenderer.tsx
+++ b/public/app/features/dashboard-scene/scene/DashboardSceneRenderer.tsx
@@ -75,7 +75,7 @@ function getStyles(theme: GrafanaTheme2) {
       position: 'sticky',
       top: 0,
       background: theme.colors.background.canvas,
-      zIndex: 1,
+      zIndex: theme.zIndex.navbarFixed,
       padding: theme.spacing(2, 0),
     }),
   };


### PR DESCRIPTION
Part of scene bug bash. 

Fixes issue when hovering over a grid item while having scrolled down, the pinned controls bar was being covered by the panel being hovered over. 