### PR TITLE
DashboardScene: Fixes issue with variables without current property

### DIFF
--- a/public/app/features/dashboard-scene/serialization/transformSaveModelToScene.test.ts
+++ b/public/app/features/dashboard-scene/serialization/transformSaveModelToScene.test.ts
@@ -679,6 +679,7 @@ describe('transformSaveModelToScene', () => {
         error: null,
         description: null,
       };
+
       const migrated = createSceneVariableFromVariableModel(variable);
       const { key, ...rest } = migrated.state;
       expect(rest).toEqual({
@@ -696,6 +697,7 @@ describe('transformSaveModelToScene', () => {
         value: '1m',
       });
     });
+
     it.each(['textbox', 'system'])('should throw for unsupported (yet) variables', (type) => {
       const variable = {
         name: 'query0',
@@ -703,6 +705,42 @@ describe('transformSaveModelToScene', () => {
       };
 
       expect(() => createSceneVariableFromVariableModel(variable as TypedVariableModel)).toThrow();
+    });
+
+    it('should handle variable without current', () => {
+      // @ts-expect-error
+      const variable: TypedVariableModel = {
+        id: 'query1',
+        name: 'query1',
+        type: 'datasource',
+        global: false,
+        regex: '/^gdev/',
+        options: [],
+        query: 'prometheus',
+        multi: true,
+        includeAll: true,
+        refresh: 1,
+        allValue: 'Custom all',
+      };
+
+      const migrated = createSceneVariableFromVariableModel(variable);
+      const { key, ...rest } = migrated.state;
+
+      expect(migrated).toBeInstanceOf(DataSourceVariable);
+      expect(rest).toEqual({
+        allValue: 'Custom all',
+        defaultToAll: true,
+        includeAll: true,
+        label: undefined,
+        name: 'query1',
+        options: [],
+        pluginId: 'prometheus',
+        regex: '/^gdev/',
+        text: '',
+        type: 'datasource',
+        value: '',
+        isMulti: true,
+      });
     });
   });
 

--- a/public/app/features/dashboard-scene/serialization/transformSaveModelToScene.ts
+++ b/public/app/features/dashboard-scene/serialization/transformSaveModelToScene.ts
@@ -274,8 +274,8 @@ export function createSceneVariableFromVariableModel(variable: TypedVariableMode
   if (variable.type === 'custom') {
     return new CustomVariable({
       ...commonProperties,
-      value: variable.current.value,
-      text: variable.current.text,
+      value: variable.current?.value ?? '',
+      text: variable.current?.text ?? '',
       description: variable.description,
       query: variable.query,
       isMulti: variable.multi,
@@ -288,8 +288,8 @@ export function createSceneVariableFromVariableModel(variable: TypedVariableMode
   } else if (variable.type === 'query') {
     return new QueryVariable({
       ...commonProperties,
-      value: variable.current.value,
-      text: variable.current.text,
+      value: variable.current?.value ?? '',
+      text: variable.current?.text ?? '',
       description: variable.description,
       query: variable.query,
       datasource: variable.datasource,
@@ -306,8 +306,8 @@ export function createSceneVariableFromVariableModel(variable: TypedVariableMode
   } else if (variable.type === 'datasource') {
     return new DataSourceVariable({
       ...commonProperties,
-      value: variable.current.value,
-      text: variable.current.text,
+      value: variable.current?.value ?? '',
+      text: variable.current?.text ?? '',
       description: variable.description,
       regex: variable.regex,
       pluginId: variable.query,


### PR DESCRIPTION
Fixes issue found on this dashboard: https://ops.grafana-ops.net/d/d2e206e1-f72b-448c-83d8-657831c2ea6d/overview?orgId=1&refresh=1m&from=now-3h&to=now where the persisted model is missing a current property. 

This is perfectly valid according to the schema, sadly createSceneVariableFromVariableModel  is using TypedVariableModel which is not correct, that is the old runtime variable model and not the persisted schema model.

That is too big a project to fix in this PR so this only adds a unit test and fixes the bug. 
