### PR TITLE
data sources: more consistent interval/max-data-points

### DIFF
--- a/pkg/tsdb/intervalv2/intervalv2.go
+++ b/pkg/tsdb/intervalv2/intervalv2.go
@@ -67,7 +67,7 @@ func (ic *intervalCalculator) Calculate(timerange backend.TimeRange, minInterval
 		return Interval{Text: FormatDuration(minInterval), Value: minInterval}
 	}
 
-	rounded := roundInterval(calculatedInterval)
+	rounded := RoundInterval(calculatedInterval)
 
 	return Interval{Text: FormatDuration(rounded), Value: rounded}
 }
@@ -77,7 +77,7 @@ func (ic *intervalCalculator) CalculateSafeInterval(timerange backend.TimeRange,
 	from := timerange.From.UnixNano()
 	safeInterval := time.Duration((to - from) / safeRes)
 
-	rounded := roundInterval(safeInterval)
+	rounded := RoundInterval(safeInterval)
 	return Interval{Text: FormatDuration(rounded), Value: rounded}
 }
 
@@ -157,7 +157,7 @@ func FormatDuration(inter time.Duration) string {
 }
 
 //nolint:gocyclo
-func roundInterval(interval time.Duration) time.Duration {
+func RoundInterval(interval time.Duration) time.Duration {
 	switch {
 	// 0.01s
 	case interval <= 10*time.Millisecond:

--- a/pkg/tsdb/intervalv2/intervalv2_test.go
+++ b/pkg/tsdb/intervalv2/intervalv2_test.go
@@ -78,7 +78,7 @@ func TestRoundInterval(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			assert.Equal(t, tc.expected, roundInterval(tc.interval))
+			assert.Equal(t, tc.expected, RoundInterval(tc.interval))
 		})
 	}
 }


### PR DESCRIPTION
work in progress.

(part of https://github.com/grafana/grafana/issues/77723)

unsolved problems:
1. this does not "catch" alerting queries. those build the `backend.DataQuery` at https://github.com/grafana/grafana/blob/cbb607b36f026349fe989d37ff2b0f7055ae6f5b/pkg/expr/nodes.go#L326C63-L326C73 
2. in general... when we round the calculated interval, we round to the nearest nice number, so sometimes the interval-value increases, and sometimes it decreases. the problem is, when it decreases, we'll get an interval-value that creates more points than max-data-points. (this is not a problem specific to the current situation, it has been like this in grafana for some time)
