### PR TITLE
Swagger: Rename API Key `AddCommand`

### DIFF
--- a/pkg/services/apikey/model.go
+++ b/pkg/services/apikey/model.go
@@ -32,7 +32,7 @@ type APIKey struct {
 
 func (k APIKey) TableName() string { return "api_key" }
 
-// swagger:model
+// swagger:model AddAPIKeyCommand
 type AddCommand struct {
 	Name             string       `json:"name" binding:"Required"`
 	Role             org.RoleType `json:"role" binding:"Required"`

--- a/public/api-enterprise-spec.json
+++ b/public/api-enterprise-spec.json
@@ -1891,7 +1891,7 @@
         }
       }
     },
-    "AddCommand": {
+    "AddAPIKeyCommand": {
       "type": "object",
       "properties": {
         "name": {
@@ -3528,6 +3528,7 @@
           "format": "int64"
         },
         "folderId": {
+          "description": "Deprecated: use FolderUID instead",
           "type": "integer",
           "format": "int64"
         },
@@ -4340,6 +4341,7 @@
           "type": "boolean"
         },
         "id": {
+          "description": "Deprecated: use Uid instead",
           "type": "integer",
           "format": "int64"
         },

--- a/public/api-merged.json
+++ b/public/api-merged.json
@@ -3420,7 +3420,7 @@
             "in": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/AddCommand"
+              "$ref": "#/definitions/AddAPIKeyCommand"
             }
           }
         ],
@@ -10938,7 +10938,7 @@
         }
       }
     },
-    "AddCommand": {
+    "AddAPIKeyCommand": {
       "type": "object",
       "properties": {
         "name": {

--- a/public/openapi3.json
+++ b/public/openapi3.json
@@ -1977,7 +1977,7 @@
         },
         "type": "object"
       },
-      "AddCommand": {
+      "AddAPIKeyCommand": {
         "properties": {
           "name": {
             "type": "string"
@@ -15818,7 +15818,7 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/AddCommand"
+                "$ref": "#/components/schemas/AddAPIKeyCommand"
               }
             }
           },


### PR DESCRIPTION
As a global definition, `AddAPIKeyCommand` is clearer
