### PR TITLE
GettingStarted: Put steps in one big carousel

### DIFF
--- a/.betterer.results
+++ b/.betterer.results
@@ -6598,7 +6598,7 @@ exports[`better eslint`] = {
       [0, 0, 0, "Do not use any type assertions.", "0"]
     ],
     "public/app/plugins/panel/gettingstarted/GettingStarted.tsx:5381": [
-      [0, 0, 0, "Styles should be written using objects.", "0"],
+      [0, 0, 0, "Do not use any type assertions.", "0"],
       [0, 0, 0, "Styles should be written using objects.", "1"],
       [0, 0, 0, "Styles should be written using objects.", "2"],
       [0, 0, 0, "Styles should be written using objects.", "3"],
@@ -6616,12 +6616,6 @@ exports[`better eslint`] = {
       [0, 0, 0, "Styles should be written using objects.", "2"],
       [0, 0, 0, "Styles should be written using objects.", "3"],
       [0, 0, 0, "Styles should be written using objects.", "4"]
-    ],
-    "public/app/plugins/panel/gettingstarted/components/Step.tsx:5381": [
-      [0, 0, 0, "Styles should be written using objects.", "0"],
-      [0, 0, 0, "Styles should be written using objects.", "1"],
-      [0, 0, 0, "Styles should be written using objects.", "2"],
-      [0, 0, 0, "Styles should be written using objects.", "3"]
     ],
     "public/app/plugins/panel/gettingstarted/components/TutorialCard.tsx:5381": [
       [0, 0, 0, "Styles should be written using objects.", "0"],

--- a/.betterer.results
+++ b/.betterer.results
@@ -6598,17 +6598,7 @@ exports[`better eslint`] = {
       [0, 0, 0, "Do not use any type assertions.", "0"]
     ],
     "public/app/plugins/panel/gettingstarted/GettingStarted.tsx:5381": [
-      [0, 0, 0, "Do not use any type assertions.", "0"],
-      [0, 0, 0, "Styles should be written using objects.", "1"],
-      [0, 0, 0, "Styles should be written using objects.", "2"],
-      [0, 0, 0, "Styles should be written using objects.", "3"],
-      [0, 0, 0, "Styles should be written using objects.", "4"],
-      [0, 0, 0, "Styles should be written using objects.", "5"],
-      [0, 0, 0, "Styles should be written using objects.", "6"],
-      [0, 0, 0, "Styles should be written using objects.", "7"],
-      [0, 0, 0, "Styles should be written using objects.", "8"],
-      [0, 0, 0, "Styles should be written using objects.", "9"],
-      [0, 0, 0, "Styles should be written using objects.", "10"]
+      [0, 0, 0, "Do not use any type assertions.", "0"]
     ],
     "public/app/plugins/panel/gettingstarted/components/DocsCard.tsx:5381": [
       [0, 0, 0, "Styles should be written using objects.", "0"],

--- a/.betterer.results
+++ b/.betterer.results
@@ -6597,9 +6597,6 @@ exports[`better eslint`] = {
     "public/app/plugins/panel/geomap/utils/tooltip.ts:5381": [
       [0, 0, 0, "Do not use any type assertions.", "0"]
     ],
-    "public/app/plugins/panel/gettingstarted/GettingStarted.tsx:5381": [
-      [0, 0, 0, "Do not use any type assertions.", "0"]
-    ],
     "public/app/plugins/panel/gettingstarted/components/DocsCard.tsx:5381": [
       [0, 0, 0, "Styles should be written using objects.", "0"],
       [0, 0, 0, "Styles should be written using objects.", "1"],

--- a/pkg/api/dashboard.go
+++ b/pkg/api/dashboard.go
@@ -586,7 +586,7 @@ func (hs *HTTPServer) addGettingStartedPanelToHomeDashboard(c *contextmodel.ReqC
 			"x": 0,
 			"y": 3,
 			"w": 24,
-			"h": 9,
+			"h": 10,
 		},
 	})
 

--- a/public/app/plugins/panel/gettingstarted/GettingStarted.tsx
+++ b/public/app/plugins/panel/gettingstarted/GettingStarted.tsx
@@ -171,6 +171,8 @@ function StepCarousel({ steps }: { steps: SetupStep[] }) {
 }
 
 const getStyles = stylesFactory(() => {
+  const DEV_FLAG_DONT_MERGE_SMUSH = window.location.search.includes('smush');
+
   const theme = config.theme2;
   const buttonBase = {
     position: 'absolute',
@@ -209,12 +211,16 @@ const getStyles = stylesFactory(() => {
       scrollSnapType: 'x proximity',
       paddingBottom: theme.spacing(2),
     }),
-    step: css({
-      padding: theme.spacing(2, 2, 0, 2),
-      scrollSnapAlign: 'start',
-      flexShrink: 0,
-      minWidth: '100%',
-    }),
+    step: css(
+      {
+        padding: theme.spacing(2, 2, 0, 2),
+        scrollSnapAlign: 'start',
+      },
+      !DEV_FLAG_DONT_MERGE_SMUSH && {
+        flexShrink: 0,
+        minWidth: '100%',
+      }
+    ),
     header: css`
       label: header;
       margin-bottom: ${theme.spacing(3)};

--- a/public/app/plugins/panel/gettingstarted/GettingStarted.tsx
+++ b/public/app/plugins/panel/gettingstarted/GettingStarted.tsx
@@ -81,7 +81,7 @@ export class GettingStarted extends PureComponent<PanelProps, State> {
         ) : (
           <Carousel page={this.state.currentStep}>
             {steps.map((step, index) => (
-              <Step key={index} step={step} />
+              <Step key={index} step={step} onDismiss={this.dismiss} />
             ))}
           </Carousel>
         )}

--- a/public/app/plugins/panel/gettingstarted/GettingStarted.tsx
+++ b/public/app/plugins/panel/gettingstarted/GettingStarted.tsx
@@ -69,8 +69,6 @@ export class GettingStarted extends PureComponent<PanelProps, State> {
     const { checksDone, steps } = this.state;
     const styles = getStyles();
 
-    // TODO: restore "Remove this panel" link / button
-
     return (
       <div className={styles.container}>
         {!checksDone ? (

--- a/public/app/plugins/panel/gettingstarted/components/Carousel.tsx
+++ b/public/app/plugins/panel/gettingstarted/components/Carousel.tsx
@@ -53,8 +53,8 @@ function useCarousel(page: number) {
   };
 
   const carouselRef = useRef<HTMLDivElement | null>(null);
-  const handleCarouselRef = useCallback((el: HTMLDivElement) => {
-    handleScroll({ currentTarget: el });
+  const handleCarouselRef = useCallback((el: HTMLDivElement | null) => {
+    el && handleScroll({ currentTarget: el });
     carouselRef.current = el;
   }, []);
 

--- a/public/app/plugins/panel/gettingstarted/components/Carousel.tsx
+++ b/public/app/plugins/panel/gettingstarted/components/Carousel.tsx
@@ -1,0 +1,157 @@
+import { css } from '@emotion/css';
+import React, { useCallback, useEffect, useRef } from 'react';
+
+import { GrafanaTheme2 } from '@grafana/data';
+import { IconButton, useStyles2 } from '@grafana/ui';
+
+export function Carousel({ children, page }: { page: number; children: React.ReactNode }) {
+  const styles = useStyles2(getStyles);
+  const [ref, onScroll, scrollBy, scrollProgress] = useCarousel(page);
+
+  return (
+    <div className={styles.carouselWrapper}>
+      <IconButton
+        className={styles.prevButton}
+        variant="secondary"
+        name="angle-left"
+        tooltip="Previous"
+        disabled={scrollProgress === 0}
+        onClick={() => scrollBy(-1)}
+        size="xl"
+      />
+      <IconButton
+        className={styles.nextButton}
+        variant="secondary"
+        name="angle-right"
+        tooltip="Next"
+        disabled={scrollProgress === 1}
+        onClick={() => scrollBy(1)}
+        size="xl"
+      />
+
+      <div className={styles.stepCarousel} ref={ref} onScroll={onScroll}>
+        {React.Children.map(children, (child, index) => (
+          <div key={index} className={styles.step}>
+            {child}
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function useCarousel(page: number) {
+  const [{ scrollWidth, offsetWidth, scrollLeft }, setScrollData] = React.useState({
+    scrollWidth: 0,
+    offsetWidth: 0,
+    scrollLeft: 0,
+  });
+
+  const handleScroll = (ev: { currentTarget: HTMLDivElement }) => {
+    const { scrollWidth, offsetWidth, scrollLeft } = ev.currentTarget;
+    setScrollData({ scrollWidth, offsetWidth, scrollLeft });
+  };
+
+  const carouselRef = useRef<HTMLDivElement | null>(null);
+  const handleCarouselRef = useCallback((el: HTMLDivElement) => {
+    handleScroll({ currentTarget: el });
+    carouselRef.current = el;
+  }, []);
+
+  useEffect(() => {
+    if (carouselRef.current) {
+      carouselRef.current.scrollTo({
+        left: getElementWidth(carouselRef.current) * page,
+        behavior: 'instant',
+      });
+    }
+  }, [page]);
+
+  const scrollBy = useCallback((scrollBy: number) => {
+    carouselRef.current && scrollElement(carouselRef.current, scrollBy);
+  }, []);
+
+  const scrollProgress = scrollLeft / (scrollWidth - offsetWidth);
+
+  return [handleCarouselRef, handleScroll, scrollBy, scrollProgress] as const;
+}
+
+function getElementWidth(el: HTMLElement): number {
+  const baseWidth = el.clientWidth;
+  const computedStyles = window.getComputedStyle(el);
+  const pageWidth =
+    baseWidth - parseFloat(computedStyles.paddingLeft || '0') - parseFloat(computedStyles.paddingRight || '0');
+
+  return pageWidth;
+}
+
+/**
+ * Scrolls an element by a given percentage of its width
+ * @param element Element to scroll
+ * @param scrollBy Percentage of the element's width to scroll. Positive values scroll right, negative values scroll left
+ */
+function scrollElement(element: HTMLElement, scrollBy: number) {
+  const scrollByPx = getElementWidth(element) * scrollBy;
+
+  element.scrollTo({
+    left: element.scrollLeft + scrollByPx,
+    behavior: 'smooth',
+  });
+}
+
+const getStyles = (theme: GrafanaTheme2) => {
+  const nextPrevSpacing = 1;
+  const nextPrevSize = 4; // xl button grid size
+  const nextPrevGutter = nextPrevSize + nextPrevSpacing * 2;
+
+  const buttonBase = {
+    position: 'absolute',
+    top: '50%',
+    transform: 'translateY(-50%)',
+    zIndex: 2,
+
+    ['&:disabled']: {
+      opacity: 0,
+      pointerEvents: 'none',
+    },
+  } as const;
+
+  return {
+    carouselWrapper: css({
+      position: 'relative',
+    }),
+    nextButton: css(buttonBase, {
+      right: theme.spacing(0.5 + nextPrevSpacing),
+    }),
+    prevButton: css(buttonBase, {
+      left: theme.spacing(0.5 + nextPrevSpacing),
+    }),
+    stepCarousel: css({
+      position: 'relative',
+      zIndex: 1,
+      overflowX: 'auto',
+      display: 'flex',
+      flexWrap: 'nowrap',
+      scrollSnapType: 'x proximity',
+      padding: theme.spacing(2, 0),
+    }),
+    step: css({
+      scrollSnapAlign: 'start',
+      flexShrink: 0,
+      paddingLeft: theme.spacing(nextPrevGutter),
+
+      display: 'flex',
+      '& > div': {
+        flex: 1,
+      },
+
+      // Make last step full width so when it scrolls it can snap to the start of the container
+      '&:last-of-type': {
+        minWidth: '100%',
+        // paddingRight: theme.spacing(nextPrevGutter),
+      },
+
+      '&:first-of-type': {},
+    }),
+  };
+};

--- a/public/app/plugins/panel/gettingstarted/components/Step.tsx
+++ b/public/app/plugins/panel/gettingstarted/components/Step.tsx
@@ -31,7 +31,7 @@ export const Step = ({ step }: Props) => {
         <Text>{step.info}</Text>
       </Stack>
 
-      <Stack gap={4} direction="row">
+      <Stack gap={4} direction="row" grow={1}>
         {step.cards.map((card, index) => {
           return <SetupCard key={index} card={card} />;
         })}

--- a/public/app/plugins/panel/gettingstarted/components/Step.tsx
+++ b/public/app/plugins/panel/gettingstarted/components/Step.tsx
@@ -1,10 +1,8 @@
-import { css } from '@emotion/css';
 import React from 'react';
 
-import { GrafanaTheme2 } from '@grafana/data';
-import { useStyles2 } from '@grafana/ui';
+import { Stack, Text } from '@grafana/ui';
 
-import { SetupStep } from '../types';
+import { Card, SetupStep, TutorialCardType } from '../types';
 
 import { DocsCard } from './DocsCard';
 import { TutorialCard } from './TutorialCard';
@@ -13,58 +11,31 @@ interface Props {
   step: SetupStep;
 }
 
+interface SetupCardProps {
+  card: Card | TutorialCardType;
+}
+
+export function SetupCard({ card }: SetupCardProps) {
+  if (card.type === 'tutorial') {
+    return <TutorialCard card={card} />;
+  }
+
+  return <DocsCard card={card} />;
+}
+
 export const Step = ({ step }: Props) => {
-  const styles = useStyles2(getStyles);
-
   return (
-    <div className={styles.setup}>
-      <div className={styles.info}>
-        <h2 className={styles.title}>{step.title}</h2>
-        <p>{step.info}</p>
-      </div>
-      <div className={styles.cards}>
+    <Stack gap={2} direction="column">
+      <Stack direction="column">
+        <Text variant="h4">{step.title}</Text>
+        <Text>{step.info}</Text>
+      </Stack>
+
+      <Stack gap={4} direction="row">
         {step.cards.map((card, index) => {
-          const key = `${card.title}-${index}`;
-          if (card.type === 'tutorial') {
-            return <TutorialCard key={key} card={card} />;
-          }
-          return <DocsCard key={key} card={card} />;
+          return <SetupCard key={index} card={card} />;
         })}
-      </div>
-    </div>
+      </Stack>
+    </Stack>
   );
-};
-
-const getStyles = (theme: GrafanaTheme2) => {
-  return {
-    setup: css`
-      display: flex;
-      width: 95%;
-    `,
-    info: css`
-      width: 172px;
-      margin-right: 5%;
-
-      ${theme.breakpoints.down('xxl')} {
-        margin-right: ${theme.spacing(4)};
-      }
-      ${theme.breakpoints.down('sm')} {
-        display: none;
-      }
-    `,
-    title: css`
-      color: ${theme.v1.palette.blue95};
-    `,
-    cards: css`
-      overflow-x: scroll;
-      overflow-y: hidden;
-      width: 100%;
-      display: flex;
-      justify-content: center;
-
-      ${theme.breakpoints.down('xxl')} {
-        justify-content: flex-start;
-      }
-    `,
-  };
 };

--- a/public/app/plugins/panel/gettingstarted/components/Step.tsx
+++ b/public/app/plugins/panel/gettingstarted/components/Step.tsx
@@ -33,9 +33,11 @@ export const Step = ({ step, onDismiss }: StepProps) => {
           <Text>{step.info}</Text>
         </Stack>
 
-        <Button variant="secondary" fill="text" onClick={onDismiss}>
-          Remove this panel
-        </Button>
+        {step.showRemovePanel && (
+          <Button variant="secondary" fill="text" onClick={onDismiss}>
+            Remove this panel
+          </Button>
+        )}
       </Stack>
 
       <Stack gap={4} direction="row" grow={1}>

--- a/public/app/plugins/panel/gettingstarted/components/Step.tsx
+++ b/public/app/plugins/panel/gettingstarted/components/Step.tsx
@@ -1,14 +1,15 @@
 import React from 'react';
 
-import { Stack, Text } from '@grafana/ui';
+import { Button, Stack, Text } from '@grafana/ui';
 
 import { Card, SetupStep, TutorialCardType } from '../types';
 
 import { DocsCard } from './DocsCard';
 import { TutorialCard } from './TutorialCard';
 
-interface Props {
+interface StepProps {
   step: SetupStep;
+  onDismiss: () => void;
 }
 
 interface SetupCardProps {
@@ -23,12 +24,18 @@ export function SetupCard({ card }: SetupCardProps) {
   return <DocsCard card={card} />;
 }
 
-export const Step = ({ step }: Props) => {
+export const Step = ({ step, onDismiss }: StepProps) => {
   return (
     <Stack gap={2} direction="column">
-      <Stack direction="column">
-        <Text variant="h4">{step.title}</Text>
-        <Text>{step.info}</Text>
+      <Stack justifyContent="space-between">
+        <Stack direction="column">
+          <Text variant="h4">{step.title}</Text>
+          <Text>{step.info}</Text>
+        </Stack>
+
+        <Button variant="secondary" fill="text" onClick={onDismiss}>
+          Remove this panel
+        </Button>
       </Stack>
 
       <Stack gap={4} direction="row" grow={1}>

--- a/public/app/plugins/panel/gettingstarted/components/TutorialCard.tsx
+++ b/public/app/plugins/panel/gettingstarted/components/TutorialCard.tsx
@@ -17,12 +17,14 @@ export const TutorialCard = ({ card }: Props) => {
   const styles = useStyles2(getStyles, card.done);
   const iconStyles = useStyles2(iconStyle, card.done);
 
+  const href = card.href + '?utm_source=grafana_gettingstarted';
+
   return (
     <a
       className={styles.card}
       target="_blank"
       rel="noreferrer"
-      href={`${card.href}?utm_source=grafana_gettingstarted`}
+      href={href}
       onClick={(event: MouseEvent<HTMLAnchorElement>) => handleTutorialClick(event, card)}
     >
       <div className={cardContent}>
@@ -37,7 +39,6 @@ export const TutorialCard = ({ card }: Props) => {
 };
 
 const handleTutorialClick = (event: MouseEvent<HTMLAnchorElement>, card: TutorialCardType) => {
-  event.preventDefault();
   const isSet = store.get(card.key);
   if (!isSet) {
     store.set(card.key, true);

--- a/public/app/plugins/panel/gettingstarted/components/sharedStyles.ts
+++ b/public/app/plugins/panel/gettingstarted/components/sharedStyles.ts
@@ -11,16 +11,11 @@ export const cardStyle = (theme: GrafanaTheme2, complete: boolean) => {
 
   return `
       background-color: ${theme.colors.background.secondary};
-      margin-right: ${theme.spacing(4)};
       border: 1px solid ${theme.colors.border.weak};
       border-bottom-left-radius: ${theme.shape.borderRadius(2)};
       border-bottom-right-radius: ${theme.shape.borderRadius(2)};
       position: relative;
-      max-height: 230px;
 
-      ${theme.breakpoints.down('xxl')} {
-        margin-right: ${theme.spacing(2)};
-      }
       &::before {
         display: block;
         content: ' ';

--- a/public/app/plugins/panel/gettingstarted/steps.ts
+++ b/public/app/plugins/panel/gettingstarted/steps.ts
@@ -17,6 +17,7 @@ export const getSteps = (): SetupStep[] => [
     title: 'Basic',
     info: 'The steps below will guide you to quickly finish setting up your Grafana installation.',
     done: false,
+    showRemovePanel: false,
     cards: [
       {
         type: 'tutorial',
@@ -71,6 +72,7 @@ export const getSteps = (): SetupStep[] => [
     title: 'Advanced',
     info: ' Manage your users and teams and add plugins. These steps are optional',
     done: false,
+    showRemovePanel: true,
     cards: [
       {
         type: 'tutorial',

--- a/public/app/plugins/panel/gettingstarted/types.ts
+++ b/public/app/plugins/panel/gettingstarted/types.ts
@@ -25,4 +25,5 @@ export interface SetupStep {
   info: string;
   cards: Array<Card | TutorialCardType>;
   done: boolean;
+  showRemovePanel: boolean;
 }


### PR DESCRIPTION
Updates the default dashboard Getting Started panel to put all steps in one big scrollable carousel, with little page buttons.

Fixes an issue made more noticable by docked nav where at certain breakpoints the cards are clipped and unable to scroll.

Part of https://github.com/grafana/grafana/issues/78451

https://github.com/grafana/grafana/assets/46142/bc48d993-ac1b-470b-844f-4c1fd23cc382

