### PR TITLE
Alerting: During legacy migration reduce the number of created silences

### DIFF
--- a/pkg/services/ngalert/migration/alert_rule.go
+++ b/pkg/services/ngalert/migration/alert_rule.go
@@ -94,14 +94,7 @@ func (om *OrgMigration) migrateAlert(ctx context.Context, l log.Logger, alert *l
 		ExecErrState:    transExecErr(l, parsedSettings.ExecutionErrorState),
 	}
 
-	if parsedSettings.ExecutionErrorState == "keep_state" {
-		om.rulesWithErrorSilenceLabels++
-		ar.Labels[ngmodels.MigratedSilenceLabelErrorKeepState] = "true"
-	}
-	if parsedSettings.NoDataState == "keep_state" {
-		om.rulesWithNoDataSilenceLabels++
-		ar.Labels[ngmodels.MigratedSilenceLabelNodataKeepState] = "true"
-	}
+	om.silences.handleSilenceLabels(ar, parsedSettings)
 
 	// We do some validation and pre-save operations early in order to track these errors as part of the migration state.
 	if err := ar.ValidateAlertRule(om.cfg.UnifiedAlerting); err != nil {

--- a/pkg/services/ngalert/migration/alert_rule.go
+++ b/pkg/services/ngalert/migration/alert_rule.go
@@ -94,20 +94,15 @@ func (om *OrgMigration) migrateAlert(ctx context.Context, l log.Logger, alert *l
 		ExecErrState:    transExecErr(l, parsedSettings.ExecutionErrorState),
 	}
 
-	// Label for routing and silences.
-	n, v := getLabelForSilenceMatching(ar.UID)
-	ar.Labels[n] = v
-
-	if parsedSettings.ExecutionErrorState == string(legacymodels.ExecutionErrorKeepState) {
-		if err := om.addErrorSilence(ar); err != nil {
-			om.log.Error("Alert migration error: failed to create silence for Error", "rule_name", ar.Title, "err", err)
-		}
+	if parsedSettings.ExecutionErrorState == "keep_state" {
+		om.rulesWithErrorSilenceLabels++
+		n, v := getLabelForErrorSilenceMatching()
+		ar.Labels[n] = v
 	}
-
-	if parsedSettings.NoDataState == string(legacymodels.NoDataKeepState) {
-		if err := om.addNoDataSilence(ar); err != nil {
-			om.log.Error("Alert migration error: failed to create silence for NoData", "rule_name", ar.Title, "err", err)
-		}
+	if parsedSettings.NoDataState == "keep_state" {
+		om.rulesWithNoDataSilenceLabels++
+		n, v := getLabelForNoDataSilenceMatching()
+		ar.Labels[n] = v
 	}
 
 	// We do some validation and pre-save operations early in order to track these errors as part of the migration state.

--- a/pkg/services/ngalert/migration/alert_rule.go
+++ b/pkg/services/ngalert/migration/alert_rule.go
@@ -96,13 +96,11 @@ func (om *OrgMigration) migrateAlert(ctx context.Context, l log.Logger, alert *l
 
 	if parsedSettings.ExecutionErrorState == "keep_state" {
 		om.rulesWithErrorSilenceLabels++
-		n, v := getLabelForErrorSilenceMatching()
-		ar.Labels[n] = v
+		ar.Labels[ngmodels.MigratedSilenceLabelErrorKeepState] = "true"
 	}
 	if parsedSettings.NoDataState == "keep_state" {
 		om.rulesWithNoDataSilenceLabels++
-		n, v := getLabelForNoDataSilenceMatching()
-		ar.Labels[n] = v
+		ar.Labels[ngmodels.MigratedSilenceLabelNodataKeepState] = "true"
 	}
 
 	// We do some validation and pre-save operations early in order to track these errors as part of the migration state.

--- a/pkg/services/ngalert/migration/alert_rule_test.go
+++ b/pkg/services/ngalert/migration/alert_rule_test.go
@@ -275,8 +275,7 @@ func TestMakeAlertRule(t *testing.T) {
 		ar, err := m.migrateAlert(context.Background(), &logtest.Fake{}, da, &dashboard)
 		require.NoError(t, err)
 
-		n, v := getLabelForErrorSilenceMatching()
-		require.Equal(t, ar.Labels[n], v)
+		require.Equal(t, ar.Labels[models.MigratedSilenceLabelErrorKeepState], "true")
 	})
 
 	t.Run("keep last state nodata dash alert is silenced", func(t *testing.T) {
@@ -288,8 +287,7 @@ func TestMakeAlertRule(t *testing.T) {
 		ar, err := m.migrateAlert(context.Background(), &logtest.Fake{}, da, &dashboard)
 		require.NoError(t, err)
 
-		n, v := getLabelForNoDataSilenceMatching()
-		require.Equal(t, ar.Labels[n], v)
+		require.Equal(t, ar.Labels[models.MigratedSilenceLabelNodataKeepState], "true")
 	})
 }
 

--- a/pkg/services/ngalert/migration/alert_rule_test.go
+++ b/pkg/services/ngalert/migration/alert_rule_test.go
@@ -265,6 +265,32 @@ func TestMakeAlertRule(t *testing.T) {
 		suffix := fmt.Sprintf(" - %ds", ar.IntervalSeconds)
 		require.Equal(t, fmt.Sprintf("%s%s", strings.Repeat("a", store.AlertRuleMaxRuleGroupNameLength-len(suffix)), suffix), ar.RuleGroup)
 	})
+
+	t.Run("keep last state error dash alert is silenced", func(t *testing.T) {
+		service := NewTestMigrationService(t, sqlStore, nil)
+		m := service.newOrgMigration(1)
+		da := createTestDashAlert()
+		da.Settings.Set("executionErrorState", "keep_state")
+
+		ar, err := m.migrateAlert(context.Background(), &logtest.Fake{}, da, &dashboard)
+		require.NoError(t, err)
+
+		n, v := getLabelForErrorSilenceMatching()
+		require.Equal(t, ar.Labels[n], v)
+	})
+
+	t.Run("keep last state nodata dash alert is silenced", func(t *testing.T) {
+		service := NewTestMigrationService(t, sqlStore, nil)
+		m := service.newOrgMigration(1)
+		da := createTestDashAlert()
+		da.Settings.Set("noDataState", "keep_state")
+
+		ar, err := m.migrateAlert(context.Background(), &logtest.Fake{}, da, &dashboard)
+		require.NoError(t, err)
+
+		n, v := getLabelForNoDataSilenceMatching()
+		require.Equal(t, ar.Labels[n], v)
+	})
 }
 
 func createTestDashAlert() *legacymodels.Alert {

--- a/pkg/services/ngalert/migration/migration_test.go
+++ b/pkg/services/ngalert/migration/migration_test.go
@@ -550,7 +550,6 @@ func TestDashAlertMigration(t *testing.T) {
 			expectedRulesMap := expected[orgId]
 			require.Len(t, rules, len(expectedRulesMap))
 			for _, r := range rules {
-				delete(r.Labels, "rule_uid") // Not checking this here.
 				exp := expectedRulesMap[r.Title].Labels
 				require.Lenf(t, r.Labels, len(exp), "rule doesn't have correct number of labels: %s", r.Title)
 				for l := range r.Labels {
@@ -657,7 +656,6 @@ func TestDashAlertMigration(t *testing.T) {
 			expectedRulesMap := expected[orgId]
 			require.Len(t, rules, len(expectedRulesMap))
 			for _, r := range rules {
-				delete(r.Labels, "rule_uid") // Not checking this here.
 				exp := expectedRulesMap[r.Title].Labels
 				require.Lenf(t, r.Labels, len(exp), "rule doesn't have correct number of labels: %s", r.Title)
 				for l := range r.Labels {
@@ -707,7 +705,6 @@ func TestDashAlertMigration(t *testing.T) {
 			expectedRulesMap := expected[orgId]
 			require.Len(t, rules, len(expectedRulesMap))
 			for _, r := range rules {
-				delete(r.Labels, "rule_uid") // Not checking this here.
 				exp := expectedRulesMap[*r.PanelID]
 				require.Equal(t, exp, r.Title)
 			}
@@ -743,7 +740,6 @@ func TestDashAlertMigration(t *testing.T) {
 			expectedRulesMap := expected[orgId]
 			require.Len(t, rules, len(expectedRulesMap))
 			for _, r := range rules {
-				delete(r.Labels, "rule_uid") // Not checking this here.
 				exp := expectedRulesMap[*r.PanelID]
 				require.Equal(t, exp, r.Title)
 			}
@@ -1217,8 +1213,6 @@ func TestDashAlertQueryMigration(t *testing.T) {
 
 				for _, r := range rules {
 					// Remove generated fields.
-					require.NotEqual(t, r.Labels["rule_uid"], "")
-					delete(r.Labels, "rule_uid")
 					require.NotEqual(t, r.Annotations[ngModels.MigratedAlertIdAnnotation], "")
 					delete(r.Annotations, ngModels.MigratedAlertIdAnnotation)
 

--- a/pkg/services/ngalert/migration/models.go
+++ b/pkg/services/ngalert/migration/models.go
@@ -21,9 +21,7 @@ type OrgMigration struct {
 
 	orgID int64
 
-	// Silences
-	rulesWithErrorSilenceLabels  int
-	rulesWithNoDataSilenceLabels int
+	silences *silenceHandler
 }
 
 // newOrgMigration creates a new OrgMigration for the given orgID.
@@ -34,6 +32,7 @@ func (ms *migrationService) newOrgMigration(orgID int64) *OrgMigration {
 
 		migrationStore:    ms.migrationStore,
 		encryptionService: ms.encryptionService,
+		silences:          ms.silences,
 
 		orgID: orgID,
 	}

--- a/pkg/services/ngalert/migration/models.go
+++ b/pkg/services/ngalert/migration/models.go
@@ -4,8 +4,6 @@ import (
 	"context"
 	"errors"
 
-	pb "github.com/prometheus/alertmanager/silence/silencepb"
-
 	"github.com/grafana/grafana/pkg/infra/log"
 	legacymodels "github.com/grafana/grafana/pkg/services/alerting/models"
 	migrationStore "github.com/grafana/grafana/pkg/services/ngalert/migration/store"
@@ -21,8 +19,11 @@ type OrgMigration struct {
 	migrationStore    migrationStore.Store
 	encryptionService secrets.Service
 
-	orgID    int64
-	silences []*pb.MeshSilence
+	orgID int64
+
+	// Silences
+	rulesWithErrorSilenceLabels  int
+	rulesWithNoDataSilenceLabels int
 }
 
 // newOrgMigration creates a new OrgMigration for the given orgID.
@@ -34,8 +35,7 @@ func (ms *migrationService) newOrgMigration(orgID int64) *OrgMigration {
 		migrationStore:    ms.migrationStore,
 		encryptionService: ms.encryptionService,
 
-		orgID:    orgID,
-		silences: make([]*pb.MeshSilence, 0),
+		orgID: orgID,
 	}
 }
 

--- a/pkg/services/ngalert/migration/permissions_test.go
+++ b/pkg/services/ngalert/migration/permissions_test.go
@@ -683,8 +683,6 @@ func TestDashAlertPermissionMigration(t *testing.T) {
 					actual := make([]expectedAlertMigration, 0, len(rules))
 					for i, r := range rules {
 						// Remove generated fields.
-						require.NotEqual(t, r.Labels["rule_uid"], "")
-						delete(r.Labels, "rule_uid")
 						require.NotEqual(t, r.Annotations[ngModels.MigratedAlertIdAnnotation], "")
 						delete(r.Annotations, ngModels.MigratedAlertIdAnnotation)
 

--- a/pkg/services/ngalert/migration/service.go
+++ b/pkg/services/ngalert/migration/service.go
@@ -65,6 +65,7 @@ func ProvideService(
 		migrationStore:    migrationStore,
 		encryptionService: encryptionService,
 		silences: &silenceHandler{
+			dataPath:          cfg.DataPath,
 			createSilenceFile: openReplace,
 		},
 	}, nil

--- a/pkg/services/ngalert/migration/service_test.go
+++ b/pkg/services/ngalert/migration/service_test.go
@@ -1617,7 +1617,6 @@ func compareRules(t *testing.T, x *xorm.Engine, orgId int64, expectedRules []*mo
 		}),
 		cmpopts.IgnoreUnexported(models.AlertRule{}, models.AlertQuery{}),
 		cmpopts.IgnoreFields(models.AlertRule{}, "Updated", "UID", "ID", "Version"),
-		cmpopts.IgnoreMapEntries(func(k string, v string) bool { return k == "rule_uid" }),
 	}
 	if !cmp.Equal(expectedRules, rules, cOpt...) {
 		t.Errorf("Unexpected Rule: %v", cmp.Diff(expectedRules, rules, cOpt...))
@@ -1708,7 +1707,6 @@ func compareState(t *testing.T, x *xorm.Engine, service *migrationService, orgId
 			cmpopts.SortSlices(func(a, b *definitions.DashboardUpgrade) bool { return a.DashboardID < b.DashboardID }),
 			cmpopts.SortSlices(func(a, b *definitions.AlertPair) bool { return a.LegacyAlert.ID < b.LegacyAlert.ID }),
 			cmpopts.SortSlices(func(a, b *definitions.ContactPair) bool { return a.LegacyChannel.ID < b.LegacyChannel.ID }),
-			cmpopts.IgnoreMapEntries(func(k string, v string) bool { return k == "rule_uid" }),
 			cmpopts.IgnoreUnexported(labels.Matcher{}),
 			cmpopts.EquateEmpty(),
 		}
@@ -1880,7 +1878,6 @@ func (h *serviceHelper) genAlertPairs(f *dashboards.Dashboard, d *dashboards.Das
 			},
 			Labels: map[string]string{
 				models.MigratedUseLegacyChannelsLabel: "true",
-				"rule_uid":                            uid,
 			},
 			IsPaused: false,
 		}

--- a/pkg/services/ngalert/migration/silences.go
+++ b/pkg/services/ngalert/migration/silences.go
@@ -2,7 +2,6 @@ package migration
 
 import (
 	"bytes"
-	"errors"
 	"fmt"
 	"io"
 	"math/rand"
@@ -11,88 +10,73 @@ import (
 	"strconv"
 	"time"
 
-	"github.com/google/uuid"
 	"github.com/matttproud/golang_protobuf_extensions/pbutil"
 	pb "github.com/prometheus/alertmanager/silence/silencepb"
 	"github.com/prometheus/common/model"
 
 	"github.com/grafana/grafana/pkg/services/ngalert/models"
+	ngstate "github.com/grafana/grafana/pkg/services/ngalert/state"
+	"github.com/grafana/grafana/pkg/util"
 )
 
-const (
-	// Should be the same as 'NoDataAlertName' in pkg/services/schedule/compat.go.
-	NoDataAlertName = "DatasourceNoData"
+// TimeNow makes it possible to test usage of time
+var TimeNow = time.Now
 
-	ErrorAlertName = "DatasourceError"
-)
-
-// addErrorSilence adds a silence for the given rule to the orgMigration if the ExecutionErrorState was set to keep_state.
-func (om *OrgMigration) addErrorSilence(rule *models.AlertRule) error {
-	uid, err := uuid.NewRandom()
-	if err != nil {
-		return errors.New("create uuid for silence")
-	}
-
-	s := &pb.MeshSilence{
+// errorSilence creates a silence that matches DatasourceError alerts for rules which have a label attached when ExecutionErrorState was set to keep_state.
+func errorSilence() *pb.MeshSilence {
+	n, v := getLabelForErrorSilenceMatching()
+	return &pb.MeshSilence{
 		Silence: &pb.Silence{
-			Id: uid.String(),
+			Id: util.GenerateShortUID(),
 			Matchers: []*pb.Matcher{
 				{
 					Type:    pb.Matcher_EQUAL,
 					Name:    model.AlertNameLabel,
-					Pattern: ErrorAlertName,
+					Pattern: ngstate.ErrorAlertName,
 				},
 				{
 					Type:    pb.Matcher_EQUAL,
-					Name:    "rule_uid",
-					Pattern: rule.UID,
+					Name:    n,
+					Pattern: v,
 				},
 			},
-			StartsAt:  time.Now(),
-			EndsAt:    time.Now().AddDate(1, 0, 0), // 1 year
+			StartsAt:  TimeNow(),
+			EndsAt:    TimeNow().AddDate(1, 0, 0), // 1 year
 			CreatedBy: "Grafana Migration",
-			Comment:   fmt.Sprintf("Created during migration to unified alerting to silence Error state for alert rule ID '%s' and Title '%s' because the option 'Keep Last State' was selected for Error state", rule.UID, rule.Title),
+			Comment:   "Created during migration to unified alerting to silence Error state when the option 'Keep Last State' was selected for Error state",
 		},
-		ExpiresAt: time.Now().AddDate(1, 0, 0), // 1 year
+		ExpiresAt: TimeNow().AddDate(1, 0, 0), // 1 year
 	}
-	om.silences = append(om.silences, s)
-	return nil
 }
 
-// addNoDataSilence adds a silence for the given rule to the orgMigration if the NoDataState was set to keep_state.
-func (om *OrgMigration) addNoDataSilence(rule *models.AlertRule) error {
-	uid, err := uuid.NewRandom()
-	if err != nil {
-		return errors.New("create uuid for silence")
-	}
-
-	s := &pb.MeshSilence{
+// noDataSilence creates a silence that matches DatasourceNoData alerts for rules which have a label attached when NoDataState was set to keep_state.
+func noDataSilence() *pb.MeshSilence {
+	n, v := getLabelForNoDataSilenceMatching()
+	return &pb.MeshSilence{
 		Silence: &pb.Silence{
-			Id: uid.String(),
+			Id: util.GenerateShortUID(),
 			Matchers: []*pb.Matcher{
 				{
 					Type:    pb.Matcher_EQUAL,
 					Name:    model.AlertNameLabel,
-					Pattern: NoDataAlertName,
+					Pattern: ngstate.NoDataAlertName,
 				},
 				{
 					Type:    pb.Matcher_EQUAL,
-					Name:    "rule_uid",
-					Pattern: rule.UID,
+					Name:    n,
+					Pattern: v,
 				},
 			},
-			StartsAt:  time.Now(),
-			EndsAt:    time.Now().AddDate(1, 0, 0), // 1 year.
+			StartsAt:  TimeNow(),
+			EndsAt:    TimeNow().AddDate(1, 0, 0), // 1 year.
 			CreatedBy: "Grafana Migration",
-			Comment:   fmt.Sprintf("Created during migration to unified alerting to silence NoData state for alert rule ID '%s' and Title '%s' because the option 'Keep Last State' was selected for NoData state", rule.UID, rule.Title),
+			Comment:   "Created during migration to unified alerting to silence NoData state when the option 'Keep Last State' was selected for NoData state",
 		},
-		ExpiresAt: time.Now().AddDate(1, 0, 0), // 1 year.
+		ExpiresAt: TimeNow().AddDate(1, 0, 0), // 1 year.
 	}
-	om.silences = append(om.silences, s)
-	return nil
 }
 
-func writeSilencesFile(dataPath string, orgID int64, silences []*pb.MeshSilence) error {
+func (ms *migrationService) writeSilencesFile(orgId int64, silences []*pb.MeshSilence) error {
 	var buf bytes.Buffer
 	for _, e := range silences {
 		if _, err := pbutil.WriteDelimited(&buf, e); err != nil {
@@ -100,7 +84,7 @@ func writeSilencesFile(dataPath string, orgID int64, silences []*pb.MeshSilence)
 		}
 	}
 
-	f, err := openReplace(silencesFileNameForOrg(dataPath, orgID))
+	f, err := ms.silenceFile(silencesFileNameForOrg(ms.cfg.DataPath, orgId))
 	if err != nil {
 		return err
 	}
@@ -133,7 +117,7 @@ func (f *replaceFile) Close() error {
 }
 
 // openReplace opens a new temporary file that is moved to filename on closing.
-func openReplace(filename string) (*replaceFile, error) {
+func openReplace(filename string) (io.WriteCloser, error) {
 	tmpFilename := fmt.Sprintf("%s.%x", filename, uint64(rand.Int63()))
 
 	if err := os.MkdirAll(filepath.Dir(tmpFilename), os.ModePerm); err != nil {
@@ -153,6 +137,12 @@ func openReplace(filename string) (*replaceFile, error) {
 	return rf, nil
 }
 
-func getLabelForSilenceMatching(ruleUID string) (string, string) {
-	return "rule_uid", ruleUID
+// getLabelForErrorSilenceMatching returns the key, value for a label that will match a silence rule intended for legacy alerts with error state = keep_state.
+func getLabelForErrorSilenceMatching() (string, string) {
+	return models.MigratedSilenceLabelPrefix + "error_keep_state__", "true"
+}
+
+// getLabelForNoDataSilenceMatching returns the key, value for a label that will match a silence rule intended for legacy alerts with nodata state = keep_state.
+func getLabelForNoDataSilenceMatching() (string, string) {
+	return models.MigratedSilenceLabelPrefix + "nodata_keep_state__", "true"
 }

--- a/pkg/services/ngalert/migration/silences.go
+++ b/pkg/services/ngalert/migration/silences.go
@@ -24,7 +24,6 @@ var TimeNow = time.Now
 
 // errorSilence creates a silence that matches DatasourceError alerts for rules which have a label attached when ExecutionErrorState was set to keep_state.
 func errorSilence() *pb.MeshSilence {
-	n, v := getLabelForErrorSilenceMatching()
 	return &pb.MeshSilence{
 		Silence: &pb.Silence{
 			Id: util.GenerateShortUID(),
@@ -36,8 +35,8 @@ func errorSilence() *pb.MeshSilence {
 				},
 				{
 					Type:    pb.Matcher_EQUAL,
-					Name:    n,
-					Pattern: v,
+					Name:    models.MigratedSilenceLabelErrorKeepState,
+					Pattern: "true",
 				},
 			},
 			StartsAt:  TimeNow(),
@@ -51,7 +50,6 @@ func errorSilence() *pb.MeshSilence {
 
 // noDataSilence creates a silence that matches DatasourceNoData alerts for rules which have a label attached when NoDataState was set to keep_state.
 func noDataSilence() *pb.MeshSilence {
-	n, v := getLabelForNoDataSilenceMatching()
 	return &pb.MeshSilence{
 		Silence: &pb.Silence{
 			Id: util.GenerateShortUID(),
@@ -63,8 +61,8 @@ func noDataSilence() *pb.MeshSilence {
 				},
 				{
 					Type:    pb.Matcher_EQUAL,
-					Name:    n,
-					Pattern: v,
+					Name:    models.MigratedSilenceLabelNodataKeepState,
+					Pattern: "true",
 				},
 			},
 			StartsAt:  TimeNow(),
@@ -135,14 +133,4 @@ func openReplace(filename string) (io.WriteCloser, error) {
 		filename: filename,
 	}
 	return rf, nil
-}
-
-// getLabelForErrorSilenceMatching returns the key, value for a label that will match a silence rule intended for legacy alerts with error state = keep_state.
-func getLabelForErrorSilenceMatching() (string, string) {
-	return models.MigratedSilenceLabelPrefix + "error_keep_state__", "true"
-}
-
-// getLabelForNoDataSilenceMatching returns the key, value for a label that will match a silence rule intended for legacy alerts with nodata state = keep_state.
-func getLabelForNoDataSilenceMatching() (string, string) {
-	return models.MigratedSilenceLabelPrefix + "nodata_keep_state__", "true"
 }

--- a/pkg/services/ngalert/migration/silences_test.go
+++ b/pkg/services/ngalert/migration/silences_test.go
@@ -1,0 +1,148 @@
+package migration
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	"github.com/matttproud/golang_protobuf_extensions/pbutil"
+	pb "github.com/prometheus/alertmanager/silence/silencepb"
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/grafana/pkg/infra/db"
+	legacymodels "github.com/grafana/grafana/pkg/services/alerting/models"
+)
+
+func TestSilences(t *testing.T) {
+	t.Run("when some alerts have executionErrorState, create and write silence", func(t *testing.T) {
+		withSetting := func(alert *legacymodels.Alert, key, val string) *legacymodels.Alert {
+			alert.Settings.Set(key, val)
+			return alert
+		}
+
+		now = time.Now()
+		TimeNow = func() time.Time {
+			return now
+		}
+
+		o := createOrg(t, 1)
+		folder1 := createFolder(t, 1, o.ID, "folder-1")
+		dash1 := createDashboard(t, 3, o.ID, "dash1", folder1.ID, nil)
+
+		silenceTests := []struct {
+			name             string
+			alerts           []*legacymodels.Alert
+			expectedSilences []*pb.MeshSilence
+		}{
+			{
+				name:             "single alert with executionErrorState",
+				alerts:           []*legacymodels.Alert{withSetting(createAlert(t, int(o.ID), int(dash1.ID), 1, "alert-1", []string{}), "executionErrorState", "keep_state")},
+				expectedSilences: []*pb.MeshSilence{errorSilence()},
+			},
+			{
+				name:             "single alert with noDataState",
+				alerts:           []*legacymodels.Alert{withSetting(createAlert(t, int(o.ID), int(dash1.ID), 1, "alert-1", []string{}), "noDataState", "keep_state")},
+				expectedSilences: []*pb.MeshSilence{noDataSilence()},
+			},
+			{
+				name: "multiple alerts with both executionErrorState and noDataState",
+				alerts: []*legacymodels.Alert{
+					withSetting(createAlert(t, int(o.ID), int(dash1.ID), 1, "alert-1", []string{}), "executionErrorState", "keep_state"),
+					withSetting(createAlert(t, int(o.ID), int(dash1.ID), 2, "alert-2", []string{}), "noDataState", "keep_state"),
+				},
+				expectedSilences: []*pb.MeshSilence{errorSilence(), noDataSilence()},
+			},
+			{
+				name: "no alerts with keep_state, no silences",
+				alerts: []*legacymodels.Alert{
+					createAlert(t, int(o.ID), int(dash1.ID), 1, "alert-1", []string{}),
+					createAlert(t, int(o.ID), int(dash1.ID), 2, "alert-2", []string{}),
+				},
+				expectedSilences: []*pb.MeshSilence{},
+			},
+		}
+
+		for _, test := range silenceTests {
+			t.Run(test.name, func(t *testing.T) {
+				sqlStore := db.InitTestDB(t)
+				x := sqlStore.GetEngine()
+
+				_, err := x.Insert(o, folder1, dash1)
+				require.NoError(t, err)
+
+				_, err = x.Insert(test.alerts)
+				require.NoError(t, err)
+
+				service := NewTestMigrationService(t, sqlStore, nil)
+
+				sb := stringsBuilderCloser{
+					Builder: &strings.Builder{},
+				}
+				silenceFileAsString := func(filename string) (io.WriteCloser, error) {
+					return sb, nil
+				}
+				service.silenceFile = silenceFileAsString
+
+				require.NoError(t, service.migrateAllOrgs(context.Background()))
+
+				st, err := decodeState(strings.NewReader(sb.String()))
+				require.NoError(t, err)
+				require.Len(t, st, len(test.expectedSilences))
+
+				silences := make([]*pb.MeshSilence, 0, len(st))
+				for _, s := range st {
+					silences = append(silences, s)
+				}
+
+				cOpt := []cmp.Option{
+					cmpopts.SortSlices(func(a, b *pb.MeshSilence) bool { return a.Silence.Comment < b.Silence.Comment }),
+					cmpopts.IgnoreUnexported(pb.MeshSilence{}),
+					cmpopts.IgnoreFields(pb.Silence{}, "Id"),
+				}
+				if !cmp.Equal(silences, test.expectedSilences, cOpt...) {
+					t.Errorf("Unexpected Silence: %v", cmp.Diff(silences, test.expectedSilences, cOpt...))
+				}
+			})
+		}
+	})
+}
+
+type stringsBuilderCloser struct {
+	*strings.Builder
+}
+
+func (s stringsBuilderCloser) Close() error {
+	return nil
+}
+
+// state copied from prometheus-alertmanager/silence/silence.go.
+type state map[string]*pb.MeshSilence
+
+// decodeState copied from prometheus-alertmanager/silence/silence.go.
+func decodeState(r io.Reader) (state, error) {
+	st := state{}
+	for {
+		var s pb.MeshSilence
+		_, err := pbutil.ReadDelimited(r, &s)
+		if err == nil {
+			if s.Silence == nil {
+				return nil, ErrInvalidState
+			}
+			st[s.Silence.Id] = &s
+			continue
+		}
+		//nolint:errorlint
+		if err == io.EOF {
+			break
+		}
+		return nil, err
+	}
+	return st, nil
+}
+
+var ErrInvalidState = fmt.Errorf("invalid state")

--- a/pkg/services/ngalert/migration/silences_test.go
+++ b/pkg/services/ngalert/migration/silences_test.go
@@ -86,7 +86,7 @@ func TestSilences(t *testing.T) {
 				silenceFileAsString := func(filename string) (io.WriteCloser, error) {
 					return sb, nil
 				}
-				service.silenceFile = silenceFileAsString
+				service.silences.createSilenceFile = silenceFileAsString
 
 				require.NoError(t, service.migrateAllOrgs(context.Background()))
 

--- a/pkg/services/ngalert/migration/testing.go
+++ b/pkg/services/ngalert/migration/testing.go
@@ -4,7 +4,8 @@ import (
 	"context"
 	"testing"
 
-	"github.com/grafana/grafana/pkg/infra/log/logtest"
+	"github.com/stretchr/testify/require"
+
 	"github.com/grafana/grafana/pkg/infra/serverlock"
 	"github.com/grafana/grafana/pkg/infra/tracing"
 	apimodels "github.com/grafana/grafana/pkg/services/ngalert/api/tooling/definitions"
@@ -19,15 +20,16 @@ func NewTestMigrationService(t *testing.T, sqlStore *sqlstore.SQLStore, cfg *set
 	if cfg == nil {
 		cfg = setting.NewCfg()
 	}
-	return &migrationService{
-		lock:              serverlock.ProvideService(sqlStore, tracing.InitializeTracerForTest()),
-		log:               &logtest.Fake{},
-		cfg:               cfg,
-		store:             sqlStore,
-		migrationStore:    migrationStore.NewTestMigrationStore(t, sqlStore, cfg),
-		encryptionService: fake_secrets.NewFakeSecretsService(),
-		silences:          &silenceHandler{},
-	}
+
+	svc, err := ProvideService(
+		serverlock.ProvideService(sqlStore, tracing.InitializeTracerForTest()),
+		cfg,
+		sqlStore,
+		migrationStore.NewTestMigrationStore(t, sqlStore, cfg),
+		fake_secrets.NewFakeSecretsService(),
+	)
+	require.NoError(t, err)
+	return svc.(*migrationService)
 }
 
 func NewFakeMigrationService(t testing.TB) *fakeMigrationService {

--- a/pkg/services/ngalert/migration/testing.go
+++ b/pkg/services/ngalert/migration/testing.go
@@ -26,6 +26,7 @@ func NewTestMigrationService(t *testing.T, sqlStore *sqlstore.SQLStore, cfg *set
 		store:             sqlStore,
 		migrationStore:    migrationStore.NewTestMigrationStore(t, sqlStore, cfg),
 		encryptionService: fake_secrets.NewFakeSecretsService(),
+		silences:          &silenceHandler{},
 	}
 }
 

--- a/pkg/services/ngalert/models/alert_rule.go
+++ b/pkg/services/ngalert/models/alert_rule.go
@@ -112,6 +112,8 @@ const (
 	MigratedUseLegacyChannelsLabel = MigratedLabelPrefix + "use_channels__"
 	// MigratedContactLabelPrefix is created during legacy migration to route a migrated alert rule to a specific migrated channel.
 	MigratedContactLabelPrefix = MigratedLabelPrefix + "c_"
+	// MigratedSilenceLabelPrefix is created during legacy migration to ensure a migrated alert rule is silenced.
+	MigratedSilenceLabelPrefix = MigratedLabelPrefix + "silence_"
 	// MigratedAlertIdAnnotation is created during legacy migration to store the ID of the migrated legacy alert rule.
 	MigratedAlertIdAnnotation = "__alertId__"
 	// MigratedMessageAnnotation is created during legacy migration to store the migrated alert message.

--- a/pkg/services/ngalert/models/alert_rule.go
+++ b/pkg/services/ngalert/models/alert_rule.go
@@ -112,8 +112,10 @@ const (
 	MigratedUseLegacyChannelsLabel = MigratedLabelPrefix + "use_channels__"
 	// MigratedContactLabelPrefix is created during legacy migration to route a migrated alert rule to a specific migrated channel.
 	MigratedContactLabelPrefix = MigratedLabelPrefix + "c_"
-	// MigratedSilenceLabelPrefix is created during legacy migration to ensure a migrated alert rule is silenced.
-	MigratedSilenceLabelPrefix = MigratedLabelPrefix + "silence_"
+	// MigratedSilenceLabelErrorKeepState is a label that will match a silence rule intended for legacy alerts with error state = keep_state.
+	MigratedSilenceLabelErrorKeepState = MigratedLabelPrefix + "silence_error_keep_state__"
+	// MigratedSilenceLabelNodataKeepState is a label that will match a silence rule intended for legacy alerts with nodata state = keep_state.
+	MigratedSilenceLabelNodataKeepState = MigratedLabelPrefix + "silence_nodata_keep_state__"
 	// MigratedAlertIdAnnotation is created during legacy migration to store the ID of the migrated legacy alert rule.
 	MigratedAlertIdAnnotation = "__alertId__"
 	// MigratedMessageAnnotation is created during legacy migration to store the migrated alert message.


### PR DESCRIPTION
During legacy migration every migrated rule was given a label `rule_uid=<uid>`. This was used to silence `DatasourceError`/`DatasourceNoData` alerts for migrated rules that had either `ExecutionErrorState`/`NoDataState` set to `keep_state`, respectively.

This could potentially create a large amount of silences and a high cardinality label. Both of these scenarios have poor outcomes for CPU load and latency in unified alerting.

Instead, this change creates one label per `ExecutionErrorState`/`NoDataState` when they are set to `keep_state` as well as two silence rules, if rules with said labels were created during migration. These silence rules are:

- `__legacy_silence_error_keep_state__ = true`
- `__legacy_silence_nodata_keep_state__ = true`

 This will drastically reduce the number of created silence rules in most cases
 as well as not create the potentially high cardinality label `rule_uid`.

**Who is this feature for?**

Users migrating from legacy alerting.

**Special notes for your reviewer:**

This is a forward port of https://github.com/grafana/grafana/pull/77642, modified to fit with the new migration structure and better tested. Note the change in label names to fit with the new prefix from https://github.com/grafana/grafana/pull/76527.

Depends on https://github.com/grafana/grafana/pull/76527, so should wait for that to be merged.

![image](https://github.com/grafana/grafana/assets/8484471/d53f5714-682c-4b3a-8a9b-6c9797aaf970)

![image](https://github.com/grafana/grafana/assets/8484471/033ccd5a-c1dc-42ad-aa7d-83b88f0e4c18)


Please check that:
- [x] It works as expected from a user's perspective.
