### PR TITLE
SQL datasources: Consistent interval handling

### DIFF
--- a/pkg/tsdb/grafana-postgresql-datasource/postgres_test.go
+++ b/pkg/tsdb/grafana-postgresql-datasource/postgres_test.go
@@ -420,7 +420,8 @@ func TestIntegrationPostgres(t *testing.T) {
 							"rawSql": "SELECT $__timeGroup(time, $__interval) AS time, avg(value) as value FROM metric GROUP BY 1 ORDER BY 1",
 							"format": "time_series"
 						}`),
-						RefID: "A",
+						RefID:    "A",
+						Interval: time.Second * 60,
 						TimeRange: backend.TimeRange{
 							From: fromStart,
 							To:   fromStart.Add(30 * time.Minute),

--- a/pkg/tsdb/mssql/mssql_test.go
+++ b/pkg/tsdb/mssql/mssql_test.go
@@ -319,7 +319,8 @@ func TestMSSQL(t *testing.T) {
 							JSON: []byte(`{
 								"rawSql": "SELECT $__timeGroup(time, $__interval) AS time, avg(value) as value FROM metric GROUP BY $__timeGroup(time, $__interval) ORDER BY 1",
 								"format": "time_series"}`),
-							RefID: "A",
+							RefID:    "A",
+							Interval: time.Second * 60,
 							TimeRange: backend.TimeRange{
 								From: fromStart,
 								To:   fromStart.Add(30 * time.Minute),

--- a/pkg/tsdb/mysql/mysql_test.go
+++ b/pkg/tsdb/mysql/mysql_test.go
@@ -330,7 +330,8 @@ func TestIntegrationMySQL(t *testing.T) {
 								"rawSql": "SELECT $__timeGroup(time, $__interval) AS time, avg(value) as value FROM metric GROUP BY 1 ORDER BY 1",
 								"format": "time_series"
 							}`),
-							RefID: "A",
+							RefID:    "A",
+							Interval: time.Second * 60,
 							TimeRange: backend.TimeRange{
 								From: fromStart,
 								To:   fromStart.Add(30 * time.Minute),


### PR DESCRIPTION
the datasource should use the configured&received interval-value. this PR does just that, we take the interval-value we receive and use it. this makes it's behaviour consistent between dashboard and other modes, and also with other grafana datasources

(also solves part of https://github.com/grafana/grafana/issues/77723)