### PR TITLE
sql: simplify interval handling

### DIFF
--- a/pkg/tsdb/intervalv2/intervalv2.go
+++ b/pkg/tsdb/intervalv2/intervalv2.go
@@ -67,7 +67,7 @@ func (ic *intervalCalculator) Calculate(timerange backend.TimeRange, minInterval
 		return Interval{Text: FormatDuration(minInterval), Value: minInterval}
 	}
 
-	rounded := roundInterval(calculatedInterval)
+	rounded := RoundInterval(calculatedInterval)
 
 	return Interval{Text: FormatDuration(rounded), Value: rounded}
 }
@@ -77,7 +77,7 @@ func (ic *intervalCalculator) CalculateSafeInterval(timerange backend.TimeRange,
 	from := timerange.From.UnixNano()
 	safeInterval := time.Duration((to - from) / safeRes)
 
-	rounded := roundInterval(safeInterval)
+	rounded := RoundInterval(safeInterval)
 	return Interval{Text: FormatDuration(rounded), Value: rounded}
 }
 
@@ -157,7 +157,7 @@ func FormatDuration(inter time.Duration) string {
 }
 
 //nolint:gocyclo
-func roundInterval(interval time.Duration) time.Duration {
+func RoundInterval(interval time.Duration) time.Duration {
 	switch {
 	// 0.01s
 	case interval <= 10*time.Millisecond:

--- a/pkg/tsdb/intervalv2/intervalv2_test.go
+++ b/pkg/tsdb/intervalv2/intervalv2_test.go
@@ -78,7 +78,7 @@ func TestRoundInterval(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			assert.Equal(t, tc.expected, roundInterval(tc.interval))
+			assert.Equal(t, tc.expected, RoundInterval(tc.interval))
 		})
 	}
 }


### PR DESCRIPTION
as part of decoupling datasources, we try to reduce our dependency on core-grafana imports.
this PR replaces the calls to `intervalv2.getintervalfrom` & `intervalv2.calculate` with simpler code, that accomplishes the same.

this makes the change very backward-compatible, but on the other hand, in theory, a datasource plugin should be able to rely on the received `DataQuery.Interval` value (other datasources like `loki` or `influxdb` do that). for an alternative that does that see https://github.com/grafana/grafana/pull/78517

(NOTE: we neeeded to make `intervalv2.roundInterval` public)