### PR TITLE
Core: Suggestion of how we could improve the scoped event bus

### DIFF
--- a/packages/grafana-data/src/events/EventBus.ts
+++ b/packages/grafana-data/src/events/EventBus.ts
@@ -158,7 +158,7 @@ class ScopedEventBus implements EventBus {
   }
 }
 
-type PublishEventFilter = (scope: string[], event: BusEvent) => 'parent' | 'local';
+type PublishEventFilter = (scope: string[], event: BusEvent) => 'parent' | 'local' | 'none';
 type SubscribeEventFilter = (scope: string[], event: BusEvent) => boolean;
 type ScopedEvent = BusEvent & {
   path: Readonly<string[]>;
@@ -196,6 +196,8 @@ class ScopedEventBus2 implements EventBus {
     switch (channel) {
       case 'parent':
         return this.parent.publish(event);
+      case 'none':
+        return;
       default:
         return this.local.publish(event);
     }

--- a/packages/grafana-data/src/events/EventBus.ts
+++ b/packages/grafana-data/src/events/EventBus.ts
@@ -48,6 +48,8 @@ export class EventBusSrv implements EventBus, LegacyEmitter {
     });
   }
 
+  // Should be changed so the filter contains publish/subscribe filters.
+  // It should also return a EventBus and not the ScopedEventBus.
   newScopedBus(key: string, filter?: EventFilterOptions): ScopedEventBus {
     return new ScopedEventBus([key], this, filter);
   }


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

This is a suggestion of how we can improve the current scoped event bus to also support some of the use case we would like to provide to plugin developers.

I have added the following capabilities:

- When you create your scoped event bus you can provide two kinds of filters.
   - Subscription filter that will control which events that can be consumed via the event bus.
   - Publish filter that will control which events that can be published and also in what scope.
- The filters are not provided as enums but rather functions. So the consumer of the event bus can either use any of the pre-baked functions or write their own filter function.
- If you removeAllListeners from a scoped event bus it will only clear the subscriptions to that event bus and not all subscriptions to the global event bus.

**Why do we need this feature?**

We would like to expose a scoped event bus to plugins that have limited capabilities. The plugin should be able to publish events internal to the plugin but we would probably want to limit which events the plugin can publish to the global scope. 

The same goes for which events the plugin author can subscribe to. They should not be able to listen to other plugins events or some of the core events in Grafana that might contain sensitive information.

**Who is this feature for?**

Plugin developers

**Special notes for your reviewer:**

This is just a draft PR opened to get early feedback on a suggested solution. Let me know if I should add a couple of tests to provide examples on how it is supposed to be used.

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
