### PR TITLE
Query splitting: add key to merged response

### DIFF
--- a/public/app/plugins/datasource/loki/querySplitting.test.ts
+++ b/public/app/plugins/datasource/loki/querySplitting.test.ts
@@ -1,5 +1,6 @@
 import { of } from 'rxjs';
 import { getQueryOptions } from 'test/helpers/getQueryOptions';
+import { v4 as uuidv4 } from 'uuid';
 
 import { dateTime, LoadingState } from '@grafana/data';
 
@@ -12,6 +13,9 @@ import { trackGroupedQueries } from './tracking';
 import { LokiQuery, LokiQueryType } from './types';
 
 jest.mock('./tracking');
+jest.mock('uuid', () => ({
+  v4: jest.fn().mockReturnValue('uuid'),
+}));
 
 describe('runSplitQuery()', () => {
   let datasource: LokiDatasource;
@@ -36,6 +40,14 @@ describe('runSplitQuery()', () => {
     await expect(runSplitQuery(datasource, request)).toEmitValuesWith(() => {
       // 3 days, 3 chunks, 3 requests.
       expect(datasource.runQuery).toHaveBeenCalledTimes(3);
+    });
+  });
+
+  test('Returns a DataQueryResponse with the expected attributes', async () => {
+    await expect(runSplitQuery(datasource, request)).toEmitValuesWith((response) => {
+      expect(response[0].data).toBeDefined();
+      expect(response[0].state).toBe(LoadingState.Done);
+      expect(response[0].key).toBeDefined();
     });
   });
 
@@ -201,6 +213,7 @@ describe('runSplitQuery()', () => {
           {
             data: [],
             state: LoadingState.Done,
+            key: 'uuid',
           },
           [
             {
@@ -233,6 +246,7 @@ describe('runSplitQuery()', () => {
           {
             data: [],
             state: LoadingState.Done,
+            key: 'uuid',
           },
           [
             {

--- a/public/app/plugins/datasource/loki/querySplitting.test.ts
+++ b/public/app/plugins/datasource/loki/querySplitting.test.ts
@@ -1,6 +1,5 @@
 import { of } from 'rxjs';
 import { getQueryOptions } from 'test/helpers/getQueryOptions';
-import { v4 as uuidv4 } from 'uuid';
 
 import { dateTime, LoadingState } from '@grafana/data';
 

--- a/public/app/plugins/datasource/loki/querySplitting.ts
+++ b/public/app/plugins/datasource/loki/querySplitting.ts
@@ -76,7 +76,7 @@ function adjustTargetsFromResponseState(targets: LokiQuery[], response: DataQuer
     .filter((target) => target.maxLines === undefined || target.maxLines > 0);
 }
 export function runSplitGroupedQueries(datasource: LokiDatasource, requests: LokiGroupedRequest[]) {
-  let mergedResponse: DataQueryResponse = { data: [], state: LoadingState.Streaming };
+  let mergedResponse: DataQueryResponse = { data: [], state: LoadingState.Streaming, key: uuidv4() };
   const totalRequests = Math.max(...requests.map(({ partition }) => partition.length));
   const longestPartition = requests.filter(({ partition }) => partition.length === totalRequests)[0].partition;
 

--- a/public/app/plugins/datasource/loki/querySplitting.ts
+++ b/public/app/plugins/datasource/loki/querySplitting.ts
@@ -76,7 +76,8 @@ function adjustTargetsFromResponseState(targets: LokiQuery[], response: DataQuer
     .filter((target) => target.maxLines === undefined || target.maxLines > 0);
 }
 export function runSplitGroupedQueries(datasource: LokiDatasource, requests: LokiGroupedRequest[]) {
-  let mergedResponse: DataQueryResponse = { data: [], state: LoadingState.Streaming, key: uuidv4() };
+  const responseKey = requests.length ? requests[0].request.queryGroupId : uuidv4();
+  let mergedResponse: DataQueryResponse = { data: [], state: LoadingState.Streaming, key: responseKey };
   const totalRequests = Math.max(...requests.map(({ partition }) => partition.length));
   const longestPartition = requests.filter(({ partition }) => partition.length === totalRequests)[0].partition;
 


### PR DESCRIPTION
This PR updates the merged response emited by Loki query splitting to have a key, as defined in https://github.com/grafana/grafana/blob/main/packages/grafana-data/src/types/datasource.ts#L479

This aims to **patch** a situation that arised in an escalation, when time shift is used in the query options, as: 

![imagen](https://github.com/grafana/grafana/assets/1069378/ecb3cb66-62a5-4337-be9b-8052b0075a02)

The effect of using time shift is to change the time interval to generate requests that will not return data. When data is not present, it "breaks" the current implementation in runRequest, which creates a key to group responses, which ends up generating duplicated series. Quote from my investigation in the escalation:

---
Furthermore: I'm seeing that `processResponsePacket` https://github.com/grafana/grafana/blob/main/public/app/features/query/state/runRequest.ts#L48 receives a response with dataframes refId `C` and `D`, and creates a packet key that is `response.key`, OR the `refId` of the first dataframe, OR `A`.

```javascript
const key = packet.key ?? packet.data?.[0]?.refId ?? 'A';
```

It accumulates the merged response (state = streaming) from Loki in the packet `A` when there's no data in the current month until the first data frame is returned, with the refId `C`. Now it will accumulate the responses in the packets `A` (the default created with no data) and `C` (the first refId with data), causing the 4 time series. That is why it doesn't fail when my first refId is actually the default: `A`.

From the Loki data source, we can patch this by setting a value for the "key" attribute of a `DataQueryResponse`, so that the responses are linked to this "key packet" and not the default `A`, but I'm not sure if this is correct or if it's going to cause other issues/side effects.

https://github.com/grafana/grafana/blob/main/public/app/plugins/datasource/loki/querySplitting.ts#L79

See the video which might help to better understand all this:

https://github.com/grafana/grafana/assets/1069378/4cd7250e-25ff-486a-ba81-45eb2c56dcda

---

I still think that we should adjust the code in runRequest not to create a default `A` key, as it can have unexpected results, as it's shown in this PR.

**Which issue(s) does this PR fix?**:

Escalation 7973

**Special notes for your reviewer:**

Please check that:
- Multi-day loki queries in explore.
- Multi-day loki queries in dashboards.