### PR TITLE
ErrUtil: Add a function to both set the error and the public message

### DIFF
--- a/pkg/util/errutil/errors.go
+++ b/pkg/util/errutil/errors.go
@@ -234,6 +234,24 @@ func (b Base) Errorf(format string, args ...any) Error {
 	}
 }
 
+// PublicErrorf creates a new [Error] with Reason and MessageID from [Base],
+// PublicMessage will be populated using the rules of [fmt.Sprintf],
+// Message and Underlying will be populated using the rules of [fmt.Errorf].
+func (b Base) PublicErrorf(format string, args ...any) Error {
+	err := fmt.Errorf(format, args...)
+	public := fmt.Sprintf(format, args...)
+
+	return Error{
+		Reason:        b.reason,
+		LogMessage:    err.Error(),
+		PublicMessage: public,
+		MessageID:     b.messageID,
+		Underlying:    errors.Unwrap(err),
+		LogLevel:      b.logLevel,
+		Source:        b.source,
+	}
+}
+
 // Error makes Base implement the error type. Relying on this is
 // discouraged, as the Error type can carry additional information
 // that's valuable when debugging.


### PR DESCRIPTION
**What is this feature?**

I noticed that it's not easy to have a customizable public message with the `errutil` package.

This PR is a proposal to add a function to make both the public message and the underlying error message customizable following the fmt rules.

Usage example:
```go
var ErrCorePluginBase = errutil.NewBase(errutil.StatusForbidden, "plugin.forbiddenCorePluginInstall")

func ErrCorePlugin(pluginID string) error {
	return ErrCorePluginBase.PublicErrorf("plugin %s is a core plugin and cannot be installed separately", pluginID)
}

// test an error:
if errors.Is(t, err, ErrCorePluginBase) {
  svc.log.Debug("User is trying to install a code plugin", "error", err)
}
```

**Why do we need this feature?**

[Add a description of the problem the feature is trying to solve.]

**Who is this feature for?**

[Add information on what kind of user the feature is for.]

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
