### PR TITLE
Tab: Only make `Tab` an anchor if a `href` is passed

### DIFF
--- a/.betterer.results
+++ b/.betterer.results
@@ -928,6 +928,10 @@ exports[`better eslint`] = {
       [0, 0, 0, "Unexpected any. Specify a different type.", "4"],
       [0, 0, 0, "Unexpected any. Specify a different type.", "5"]
     ],
+    "packages/grafana-ui/src/components/Tabs/Tab.tsx:5381": [
+      [0, 0, 0, "Do not use any type assertions.", "0"],
+      [0, 0, 0, "Do not use any type assertions.", "1"]
+    ],
     "packages/grafana-ui/src/components/Tags/Tag.tsx:5381": [
       [0, 0, 0, "Do not use any type assertions.", "0"]
     ],

--- a/.betterer.results
+++ b/.betterer.results
@@ -928,10 +928,6 @@ exports[`better eslint`] = {
       [0, 0, 0, "Unexpected any. Specify a different type.", "4"],
       [0, 0, 0, "Unexpected any. Specify a different type.", "5"]
     ],
-    "packages/grafana-ui/src/components/Tabs/Tab.tsx:5381": [
-      [0, 0, 0, "Do not use any type assertions.", "0"],
-      [0, 0, 0, "Do not use any type assertions.", "1"]
-    ],
     "packages/grafana-ui/src/components/Tags/Tag.tsx:5381": [
       [0, 0, 0, "Do not use any type assertions.", "0"]
     ],

--- a/packages/grafana-ui/src/components/Tabs/Tab.tsx
+++ b/packages/grafana-ui/src/components/Tabs/Tab.tsx
@@ -72,10 +72,7 @@ export const Tab = React.forwardRef<HTMLElement, TabProps>(
           // don't think we can avoid the type assertion here :(
           ref={ref as React.ForwardedRef<HTMLButtonElement>}
         >
-          {icon && <Icon name={icon} />}
-          {label}
-          {typeof counter === 'number' && <Counter value={counter} />}
-          {Suffix && <Suffix className={tabsStyles.suffix} />}
+          {content()}
         </button>
       </div>
     );

--- a/packages/grafana-ui/src/components/Tabs/Tab.tsx
+++ b/packages/grafana-ui/src/components/Tabs/Tab.tsx
@@ -12,38 +12,37 @@ import { Icon } from '../Icon/Icon';
 
 import { Counter } from './Counter';
 
-interface BaseProps {
+export interface TabProps extends HTMLProps<HTMLElement> {
   label: string;
   active?: boolean;
+  /** When provided, it is possible to use the tab as a hyperlink. Use in cases where the tabs update location. */
+  href?: string;
   icon?: IconName;
   /** A number rendered next to the text. Usually used to display the number of items in a tab's view. */
   counter?: number | null;
   /** Extra content, displayed after the tab label and counter */
   suffix?: NavModelItem['tabSuffix'];
+  onChangeTab?: (event: React.MouseEvent<HTMLElement>) => void;
 }
 
-interface ButtonProps extends BaseProps, Omit<HTMLProps<HTMLButtonElement>, 'label'> {
-  onChangeTab?: (event?: React.MouseEvent<HTMLButtonElement>) => void;
-}
-
-interface LinkProps extends BaseProps, Omit<HTMLProps<HTMLAnchorElement>, 'label'> {
-  /** When provided, it is possible to use the tab as a hyperlink. Use in cases where the tabs update location. */
-  href: string;
-  onChangeTab?: (event?: React.MouseEvent<HTMLAnchorElement>) => void;
-}
-
-export type TabProps = ButtonProps | LinkProps;
-
-export const Tab = React.forwardRef<HTMLButtonElement | HTMLAnchorElement, TabProps>(
+export const Tab = React.forwardRef<HTMLElement, TabProps>(
   ({ label, active, icon, onChangeTab, counter, suffix: Suffix, className, href, ...otherProps }, ref) => {
     const tabsStyles = useStyles2(getStyles);
     const clearStyles = useStyles2(clearButtonStyles);
-    const Element = href ? 'a' : 'button';
     const linkClass = cx(clearStyles, tabsStyles.link, active ? tabsStyles.activeStyle : tabsStyles.notActive);
 
-    return (
+    const content = () => (
+      <>
+        {icon && <Icon name={icon} />}
+        {label}
+        {typeof counter === 'number' && <Counter value={counter} />}
+        {Suffix && <Suffix className={tabsStyles.suffix} />}
+      </>
+    );
+
+    if (href) {
       <div className={tabsStyles.item}>
-        <Element
+        <a
           href={href}
           className={linkClass}
           {...otherProps}
@@ -51,13 +50,32 @@ export const Tab = React.forwardRef<HTMLButtonElement | HTMLAnchorElement, TabPr
           aria-label={otherProps['aria-label'] || selectors.components.Tab.title(label)}
           role="tab"
           aria-selected={active}
-          ref={ref}
+          // don't think we can avoid the type assertion here :(
+          ref={ref as React.ForwardedRef<HTMLAnchorElement>}
+        >
+          {content()}
+        </a>
+      </div>;
+    }
+
+    return (
+      <div className={tabsStyles.item}>
+        <button
+          className={linkClass}
+          {...otherProps}
+          onClick={onChangeTab}
+          aria-label={otherProps['aria-label'] || selectors.components.Tab.title(label)}
+          role="tab"
+          type="button"
+          aria-selected={active}
+          // don't think we can avoid the type assertion here :(
+          ref={ref as React.ForwardedRef<HTMLButtonElement>}
         >
           {icon && <Icon name={icon} />}
           {label}
           {typeof counter === 'number' && <Counter value={counter} />}
           {Suffix && <Suffix className={tabsStyles.suffix} />}
-        </Element>
+        </button>
       </div>
     );
   }

--- a/packages/grafana-ui/src/components/Tabs/Tab.tsx
+++ b/packages/grafana-ui/src/components/Tabs/Tab.tsx
@@ -52,6 +52,7 @@ export const Tab = React.forwardRef<HTMLElement, TabProps>(
           role="tab"
           aria-selected={active}
           // don't think we can avoid the type assertion here :(
+          // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
           ref={ref as React.ForwardedRef<HTMLAnchorElement>}
         >
           {content()}
@@ -70,6 +71,7 @@ export const Tab = React.forwardRef<HTMLElement, TabProps>(
           type="button"
           aria-selected={active}
           // don't think we can avoid the type assertion here :(
+          // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
           ref={ref as React.ForwardedRef<HTMLButtonElement>}
         >
           {content()}

--- a/packages/grafana-ui/src/components/Tabs/Tab.tsx
+++ b/packages/grafana-ui/src/components/Tabs/Tab.tsx
@@ -18,18 +18,17 @@ export interface TabProps extends HTMLProps<HTMLElement> {
   /** When provided, it is possible to use the tab as a hyperlink. Use in cases where the tabs update location. */
   href?: string;
   icon?: IconName;
+  onChangeTab?: (event: React.MouseEvent<HTMLElement>) => void;
   /** A number rendered next to the text. Usually used to display the number of items in a tab's view. */
   counter?: number | null;
   /** Extra content, displayed after the tab label and counter */
   suffix?: NavModelItem['tabSuffix'];
-  onChangeTab?: (event: React.MouseEvent<HTMLElement>) => void;
 }
 
 export const Tab = React.forwardRef<HTMLElement, TabProps>(
   ({ label, active, icon, onChangeTab, counter, suffix: Suffix, className, href, ...otherProps }, ref) => {
     const tabsStyles = useStyles2(getStyles);
     const clearStyles = useStyles2(clearButtonStyles);
-    const linkClass = cx(clearStyles, tabsStyles.link, active ? tabsStyles.activeStyle : tabsStyles.notActive);
 
     const content = () => (
       <>
@@ -39,6 +38,8 @@ export const Tab = React.forwardRef<HTMLElement, TabProps>(
         {Suffix && <Suffix className={tabsStyles.suffix} />}
       </>
     );
+
+    const linkClass = cx(clearStyles, tabsStyles.link, active ? tabsStyles.activeStyle : tabsStyles.notActive);
 
     if (href) {
       <div className={tabsStyles.item}>

--- a/packages/grafana-ui/src/components/Tabs/Tab.tsx
+++ b/packages/grafana-ui/src/components/Tabs/Tab.tsx
@@ -41,35 +41,36 @@ export const Tab = React.forwardRef<HTMLElement, TabProps>(
 
     const linkClass = cx(clearStyles, tabsStyles.link, active ? tabsStyles.activeStyle : tabsStyles.notActive);
 
+    const commonProps = {
+      className: linkClass,
+      ...otherProps,
+      onClick: onChangeTab,
+      'aria-label': otherProps['aria-label'] || selectors.components.Tab.title(label),
+      role: 'tab',
+      'aria-selected': active,
+    };
+
     if (href) {
-      <div className={tabsStyles.item}>
-        <a
-          href={href}
-          className={linkClass}
-          {...otherProps}
-          onClick={onChangeTab}
-          aria-label={otherProps['aria-label'] || selectors.components.Tab.title(label)}
-          role="tab"
-          aria-selected={active}
-          // don't think we can avoid the type assertion here :(
-          // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
-          ref={ref as React.ForwardedRef<HTMLAnchorElement>}
-        >
-          {content()}
-        </a>
-      </div>;
+      return (
+        <div className={tabsStyles.item}>
+          <a
+            {...commonProps}
+            href={href}
+            // don't think we can avoid the type assertion here :(
+            // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+            ref={ref as React.ForwardedRef<HTMLAnchorElement>}
+          >
+            {content()}
+          </a>
+        </div>
+      );
     }
 
     return (
       <div className={tabsStyles.item}>
         <button
-          className={linkClass}
-          {...otherProps}
-          onClick={onChangeTab}
-          aria-label={otherProps['aria-label'] || selectors.components.Tab.title(label)}
-          role="tab"
+          {...commonProps}
           type="button"
-          aria-selected={active}
           // don't think we can avoid the type assertion here :(
           // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
           ref={ref as React.ForwardedRef<HTMLButtonElement>}

--- a/packages/grafana-ui/src/components/Tabs/Tab.tsx
+++ b/packages/grafana-ui/src/components/Tabs/Tab.tsx
@@ -7,42 +7,44 @@ import { selectors } from '@grafana/e2e-selectors';
 import { useStyles2 } from '../../themes';
 import { getFocusStyles } from '../../themes/mixins';
 import { IconName } from '../../types';
+import { clearButtonStyles } from '../Button';
 import { Icon } from '../Icon/Icon';
 
 import { Counter } from './Counter';
 
-export interface TabProps extends HTMLProps<HTMLAnchorElement> {
+interface BaseProps {
   label: string;
   active?: boolean;
-  /** When provided, it is possible to use the tab as a hyperlink. Use in cases where the tabs update location. */
-  href?: string;
   icon?: IconName;
-  onChangeTab?: (event?: React.MouseEvent<HTMLAnchorElement>) => void;
   /** A number rendered next to the text. Usually used to display the number of items in a tab's view. */
   counter?: number | null;
   /** Extra content, displayed after the tab label and counter */
   suffix?: NavModelItem['tabSuffix'];
 }
 
-export const Tab = React.forwardRef<HTMLAnchorElement, TabProps>(
+interface ButtonProps extends BaseProps, Omit<HTMLProps<HTMLButtonElement>, 'label'> {
+  onChangeTab?: (event?: React.MouseEvent<HTMLButtonElement>) => void;
+}
+
+interface LinkProps extends BaseProps, Omit<HTMLProps<HTMLAnchorElement>, 'label'> {
+  /** When provided, it is possible to use the tab as a hyperlink. Use in cases where the tabs update location. */
+  href: string;
+  onChangeTab?: (event?: React.MouseEvent<HTMLAnchorElement>) => void;
+}
+
+export type TabProps = ButtonProps | LinkProps;
+
+export const Tab = React.forwardRef<HTMLButtonElement | HTMLAnchorElement, TabProps>(
   ({ label, active, icon, onChangeTab, counter, suffix: Suffix, className, href, ...otherProps }, ref) => {
     const tabsStyles = useStyles2(getStyles);
-    const content = () => (
-      <>
-        {icon && <Icon name={icon} />}
-        {label}
-        {typeof counter === 'number' && <Counter value={counter} />}
-        {Suffix && <Suffix className={tabsStyles.suffix} />}
-      </>
-    );
-
-    const linkClass = cx(tabsStyles.link, active ? tabsStyles.activeStyle : tabsStyles.notActive);
+    const clearStyles = useStyles2(clearButtonStyles);
+    const Element = href ? 'a' : 'button';
+    const linkClass = cx(clearStyles, tabsStyles.link, active ? tabsStyles.activeStyle : tabsStyles.notActive);
 
     return (
       <div className={tabsStyles.item}>
-        <a
-          // in case there is no href '#' is set in order to maintain a11y
-          href={href ? href : '#'}
+        <Element
+          href={href}
           className={linkClass}
           {...otherProps}
           onClick={onChangeTab}
@@ -51,8 +53,11 @@ export const Tab = React.forwardRef<HTMLAnchorElement, TabProps>(
           aria-selected={active}
           ref={ref}
         >
-          {content()}
-        </a>
+          {icon && <Icon name={icon} />}
+          {label}
+          {typeof counter === 'number' && <Counter value={counter} />}
+          {Suffix && <Suffix className={tabsStyles.suffix} />}
+        </Element>
       </div>
     );
   }
@@ -107,10 +112,6 @@ const getStyles = (theme: GrafanaTheme2) => {
       label: 'activeTabStyle',
       color: theme.colors.text.primary,
       overflow: 'hidden',
-
-      a: {
-        color: theme.colors.text.primary,
-      },
 
       '&::before': {
         backgroundImage: theme.colors.gradients.brandHorizontal,

--- a/packages/grafana-ui/src/components/index.ts
+++ b/packages/grafana-ui/src/components/index.ts
@@ -100,7 +100,7 @@ export {
 } from './Table/types';
 export { TableInputCSV } from './TableInputCSV/TableInputCSV';
 export { TabsBar } from './Tabs/TabsBar';
-export { Tab } from './Tabs/Tab';
+export { Tab, type TabProps } from './Tabs/Tab';
 export { VerticalTab } from './Tabs/VerticalTab';
 export { TabContent } from './Tabs/TabContent';
 export { Counter } from './Tabs/Counter';

--- a/public/app/features/alerting/unified/PanelAlertTab.tsx
+++ b/public/app/features/alerting/unified/PanelAlertTab.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { Tab, TabProps } from '@grafana/ui/src/components/Tabs/Tab';
+import { Tab, TabProps } from '@grafana/ui';
 import { DashboardModel, PanelModel } from 'app/features/dashboard/state';
 
 import { usePanelCombinedRules } from './hooks/usePanelCombinedRules';


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

- render `Tab` as a `<button>` by default, only render as an anchor when an `href` is present

**Why do we need this feature?**

- so we don't always render `<Tab>`s as anchor elements with empty `href`s

**Who is this feature for?**

- everyone!

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
