### PR TITLE
Alerting: Fix remote Alertmanager integration tests (CI/Makefile)

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -975,7 +975,7 @@ steps:
 - commands:
   - apk add --update build-base
   - go clean -testcache
-  - go test -run TestIntegrationRemoteAlertmanager -covermode=atomic -timeout=2m ./pkg/services/ngalert/remote/...
+  - go test -run TestIntegrationRemoteAlertmanager -covermode=atomic -timeout=2m ./pkg/services/ngalert/...
   depends_on:
   - wire-install
   - wait-for-remote-alertmanager
@@ -2326,7 +2326,7 @@ steps:
 - commands:
   - apk add --update build-base
   - go clean -testcache
-  - go test -run TestIntegrationRemoteAlertmanager -covermode=atomic -timeout=2m ./pkg/services/ngalert/remote/...
+  - go test -run TestIntegrationRemoteAlertmanager -covermode=atomic -timeout=2m ./pkg/services/ngalert/...
   depends_on:
   - wire-install
   - wait-for-remote-alertmanager
@@ -3989,7 +3989,7 @@ steps:
 - commands:
   - apk add --update build-base
   - go clean -testcache
-  - go test -run TestIntegrationRemoteAlertmanager -covermode=atomic -timeout=2m ./pkg/services/ngalert/remote/...
+  - go test -run TestIntegrationRemoteAlertmanager -covermode=atomic -timeout=2m ./pkg/services/ngalert/...
   depends_on:
   - wire-install
   - wait-for-remote-alertmanager
@@ -4685,6 +4685,6 @@ kind: secret
 name: gcr_credentials
 ---
 kind: signature
-hmac: 17c2cbd392c7dbc9d931d2ffce8c51a742ad2b4cb55cd6b9196a07c566568979
+hmac: 64302d9316abab775d7ec1132f26ea4f1829558fa0bfd85812597182c1abe61a
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -975,7 +975,7 @@ steps:
 - commands:
   - apk add --update build-base
   - go clean -testcache
-  - go test -run TestIntegrationRemoteAlertmanager -covermode=atomic -timeout=2m ./pkg/services/ngalert/notifier/...
+  - go test -run TestIntegrationRemoteAlertmanager -covermode=atomic -timeout=2m ./pkg/services/ngalert/remote/...
   depends_on:
   - wire-install
   - wait-for-remote-alertmanager
@@ -2326,7 +2326,7 @@ steps:
 - commands:
   - apk add --update build-base
   - go clean -testcache
-  - go test -run TestIntegrationRemoteAlertmanager -covermode=atomic -timeout=2m ./pkg/services/ngalert/notifier/...
+  - go test -run TestIntegrationRemoteAlertmanager -covermode=atomic -timeout=2m ./pkg/services/ngalert/remote/...
   depends_on:
   - wire-install
   - wait-for-remote-alertmanager
@@ -3989,7 +3989,7 @@ steps:
 - commands:
   - apk add --update build-base
   - go clean -testcache
-  - go test -run TestIntegrationRemoteAlertmanager -covermode=atomic -timeout=2m ./pkg/services/ngalert/notifier/...
+  - go test -run TestIntegrationRemoteAlertmanager -covermode=atomic -timeout=2m ./pkg/services/ngalert/remote/...
   depends_on:
   - wire-install
   - wait-for-remote-alertmanager
@@ -4685,6 +4685,6 @@ kind: secret
 name: gcr_credentials
 ---
 kind: signature
-hmac: e5f8ac3263b36e17d1b6c0b4ec7f9658babff30065f4742d3b570a918e1f680d
+hmac: 17c2cbd392c7dbc9d931d2ffce8c51a742ad2b4cb55cd6b9196a07c566568979
 
 ...

--- a/Makefile
+++ b/Makefile
@@ -185,7 +185,7 @@ test-go-integration-alertmanager: ## Run integration tests for the remote alertm
 	@echo "test remote alertmanager integration tests"
 	$(GO) clean -testcache
 	AM_URL=http://localhost:8080 AM_TENANT_ID=test AM_PASSWORD=test \
-	$(GO) test -count=1 -run "^TestIntegrationRemoteAlertmanager" -covermode=atomic -timeout=5m ./pkg/services/ngalert/remote/...
+	$(GO) test -count=1 -run "^TestIntegrationRemoteAlertmanager" -covermode=atomic -timeout=5m ./pkg/services/ngalert/...
 
 .PHONY: test-go-integration-postgres
 test-go-integration-postgres: devenv-postgres ## Run integration tests for postgres backend with flags.

--- a/Makefile
+++ b/Makefile
@@ -185,7 +185,7 @@ test-go-integration-alertmanager: ## Run integration tests for the remote alertm
 	@echo "test remote alertmanager integration tests"
 	$(GO) clean -testcache
 	AM_URL=http://localhost:8080 AM_TENANT_ID=test AM_PASSWORD=test \
-	$(GO) test -count=1 -run "^TestIntegrationRemoteAlertmanager" -covermode=atomic -timeout=5m ./pkg/services/ngalert/notifier/...
+	$(GO) test -count=1 -run "^TestIntegrationRemoteAlertmanager" -covermode=atomic -timeout=5m ./pkg/services/ngalert/remote/...
 
 .PHONY: test-go-integration-postgres
 test-go-integration-postgres: devenv-postgres ## Run integration tests for postgres backend with flags.

--- a/scripts/drone/steps/lib.star
+++ b/scripts/drone/steps/lib.star
@@ -966,7 +966,7 @@ def redis_integration_tests_steps():
 def remote_alertmanager_integration_tests_steps():
     cmds = [
         "go clean -testcache",
-        "go test -run TestIntegrationRemoteAlertmanager -covermode=atomic -timeout=2m ./pkg/services/ngalert/remote/...",
+        "go test -run TestIntegrationRemoteAlertmanager -covermode=atomic -timeout=2m ./pkg/services/ngalert/...",
     ]
 
     environment = {

--- a/scripts/drone/steps/lib.star
+++ b/scripts/drone/steps/lib.star
@@ -966,7 +966,7 @@ def redis_integration_tests_steps():
 def remote_alertmanager_integration_tests_steps():
     cmds = [
         "go clean -testcache",
-        "go test -run TestIntegrationRemoteAlertmanager -covermode=atomic -timeout=2m ./pkg/services/ngalert/notifier/...",
+        "go test -run TestIntegrationRemoteAlertmanager -covermode=atomic -timeout=2m ./pkg/services/ngalert/remote/...",
     ]
 
     environment = {


### PR DESCRIPTION
We're trying to run integration tests for the remote Alertmanager in the `/pkg/services/ngalert/notifier` directory. There's none, we've moved the code to `/pkg/services/ngalert/remote`.

This affects both our Makefile and our CI:

```bash
./pkg/services/ngalert/notifier/...
?   	github.com/grafana/grafana/pkg/services/ngalert/notifier/alertmanager_mock	[no test files]
?   	github.com/grafana/grafana/pkg/services/ngalert/notifier/channels_config	[no test files]
ok  	github.com/grafana/grafana/pkg/services/ngalert/notifier	0.233s	coverage: 0.0% of statements [no tests to run]
```