### PR TITLE
Loki: Move `convertToWebSocketUrl` from Explore to Loki

### DIFF
--- a/public/app/core/utils/explore.ts
+++ b/public/app/core/utils/explore.ts
@@ -28,8 +28,6 @@ import store from 'app/core/store';
 import { ExpressionDatasourceUID } from 'app/features/expressions/types';
 import { QueryOptions, QueryTransaction } from 'app/types/explore';
 
-import { config } from '../config';
-
 import { getNextRefIdChar } from './query';
 
 export const DEFAULT_UI_STATE = {

--- a/public/app/core/utils/explore.ts
+++ b/public/app/core/utils/explore.ts
@@ -329,15 +329,6 @@ export const getTimeRange = (timeZone: TimeZone, rawRange: RawTimeRange, fiscalY
 export const refreshIntervalToSortOrder = (refreshInterval?: string) =>
   RefreshPicker.isLive(refreshInterval) ? LogsSortOrder.Ascending : LogsSortOrder.Descending;
 
-export const convertToWebSocketUrl = (url: string) => {
-  const protocol = window.location.protocol === 'https:' ? 'wss://' : 'ws://';
-  let backend = `${protocol}${window.location.host}${config.appSubUrl}`;
-  if (backend.endsWith('/')) {
-    backend = backend.slice(0, -1);
-  }
-  return `${backend}${url}`;
-};
-
 export const stopQueryState = (querySubscription: Unsubscribable | undefined) => {
   if (querySubscription) {
     querySubscription.unsubscribe();

--- a/public/app/plugins/datasource/loki/datasource.ts
+++ b/public/app/plugins/datasource/loki/datasource.ts
@@ -41,7 +41,6 @@ import {
 import { Duration } from '@grafana/lezer-logql';
 import { BackendSrvRequest, config, DataSourceWithBackend, getTemplateSrv, TemplateSrv } from '@grafana/runtime';
 import { DataQuery } from '@grafana/schema';
-import { convertToWebSocketUrl } from 'app/core/utils/explore';
 import { getTimeSrv, TimeSrv } from 'app/features/dashboard/services/TimeSrv';
 
 import { queryLogsSample, queryLogsVolume } from '../../../features/logs/logsModel';
@@ -83,7 +82,7 @@ import {
   isQueryWithError,
   requestSupportsSplitting,
 } from './queryUtils';
-import { doLokiChannelStream } from './streaming';
+import { convertToWebSocketUrl, doLokiChannelStream } from './streaming';
 import { trackQuery } from './tracking';
 import {
   LokiOptions,

--- a/public/app/plugins/datasource/loki/streaming.test.ts
+++ b/public/app/plugins/datasource/loki/streaming.test.ts
@@ -20,7 +20,7 @@ describe('convertToWebSocketUrl', () => {
     window.location = location;
   });
   it('should convert HTTP URL to WebSocket URL', () => {
-    window.location.protocol = 'http';
+    window.location.protocol = 'http:';
     window.location.host = 'example.com';
 
     const httpUrl = '/api/ds/proxy/1/api/v1/tail/loki?query=a';
@@ -32,11 +32,11 @@ describe('convertToWebSocketUrl', () => {
   });
 
   it('should convert HTTPS URL to WebSocket URL', () => {
-    window.location.protocol = 'https';
+    window.location.protocol = 'https:';
     window.location.host = 'example.com';
 
     const httpsUrl = '/api/ds/proxy/1/api/v1/tail/loki?query=a';
-    const expectedWebSocketUrl = 'ws://example.com/grafana/api/ds/proxy/1/api/v1/tail/loki?query=a';
+    const expectedWebSocketUrl = 'wss://example.com/grafana/api/ds/proxy/1/api/v1/tail/loki?query=a';
 
     const result = convertToWebSocketUrl(httpsUrl);
 

--- a/public/app/plugins/datasource/loki/streaming.test.ts
+++ b/public/app/plugins/datasource/loki/streaming.test.ts
@@ -1,0 +1,45 @@
+import { convertToWebSocketUrl } from './streaming';
+
+jest.mock('@grafana/runtime', () => ({
+  ...jest.requireActual('@grafana/runtime'),
+  config: {
+    appSubUrl: '/grafana',
+  },
+}));
+
+describe('convertToWebSocketUrl', () => {
+  const { location } = window;
+
+  beforeEach(() => {
+    // @ts-ignore
+    delete window.location;
+    window.location = {} as Location;
+  });
+
+  afterEach(() => {
+    window.location = location;
+  });
+  it('should convert HTTP URL to WebSocket URL', () => {
+    window.location.protocol = 'http';
+    window.location.host = 'example.com';
+
+    const httpUrl = '/api/ds/proxy/1/api/v1/tail/loki?query=a';
+    const expectedWebSocketUrl = 'ws://example.com/grafana/api/ds/proxy/1/api/v1/tail/loki?query=a';
+
+    const result = convertToWebSocketUrl(httpUrl);
+
+    expect(result).toBe(expectedWebSocketUrl);
+  });
+
+  it('should convert HTTPS URL to WebSocket URL', () => {
+    window.location.protocol = 'https';
+    window.location.host = 'example.com';
+
+    const httpsUrl = '/api/ds/proxy/1/api/v1/tail/loki?query=a';
+    const expectedWebSocketUrl = 'ws://example.com/grafana/api/ds/proxy/1/api/v1/tail/loki?query=a';
+
+    const result = convertToWebSocketUrl(httpsUrl);
+
+    expect(result).toBe(expectedWebSocketUrl);
+  });
+});

--- a/public/app/plugins/datasource/loki/streaming.ts
+++ b/public/app/plugins/datasource/loki/streaming.ts
@@ -8,7 +8,7 @@ import {
   LoadingState,
   StreamingDataFrame,
 } from '@grafana/data';
-import { getGrafanaLiveSrv } from '@grafana/runtime';
+import { getGrafanaLiveSrv, config } from '@grafana/runtime';
 
 import { LokiDatasource } from './datasource';
 import { LokiQuery } from './types';
@@ -86,3 +86,12 @@ export function doLokiChannelStream(
     })
   );
 }
+
+export const convertToWebSocketUrl = (url: string) => {
+  const protocol = window.location.protocol === 'https:' ? 'wss://' : 'ws://';
+  let backend = `${protocol}${window.location.host}${config.appSubUrl}`;
+  if (backend.endsWith('/')) {
+    backend = backend.slice(0, -1);
+  }
+  return `${backend}${url}`;
+};


### PR DESCRIPTION
Part of https://github.com/grafana/grafana/issues/72631

`convertToWebSocketUrl` was a util function in Explore, but the only place where we used it is in Loki data source. Therefore this PR moves it from Explore to Loki. 

<img width="1315" alt="image" src="https://github.com/grafana/grafana/assets/30407135/b4caff87-16aa-4714-bdf9-4f8b7bc5aa42">
