### PR TITLE
InfluxDB SQL: Don't show dataset dropdown

### DIFF
--- a/public/app/features/plugins/sql/components/DatasetSelector.tsx
+++ b/public/app/features/plugins/sql/components/DatasetSelector.tsx
@@ -4,7 +4,7 @@ import { useAsync } from 'react-use';
 import { SelectableValue } from '@grafana/data';
 import { Select } from '@grafana/ui';
 
-import { DB, ResourceSelectorProps, toOption } from '../types';
+import { DB, ResourceSelectorProps, SQLDialect, toOption } from '../types';
 
 import { isSqlDatasourceDatabaseSelectionFeatureFlagEnabled } from './QueryEditorFeatureFlag.utils';
 
@@ -12,17 +12,11 @@ export interface DatasetSelectorProps extends ResourceSelectorProps {
   db: DB;
   dataset: string | undefined;
   preconfiguredDataset: string;
-  isPostgresInstance: boolean | undefined;
+  dialect: SQLDialect;
   onChange: (v: SelectableValue) => void;
 }
 
-export const DatasetSelector = ({
-  dataset,
-  db,
-  isPostgresInstance,
-  onChange,
-  preconfiguredDataset,
-}: DatasetSelectorProps) => {
+export const DatasetSelector = ({ dataset, db, dialect, onChange, preconfiguredDataset }: DatasetSelectorProps) => {
   /* 
     The behavior of this component - for MSSQL and MySQL datasources - is based on whether the user chose to create a datasource
     with or without a default database (preconfiguredDataset). If the user configured a default database, this selector
@@ -31,7 +25,7 @@ export const DatasetSelector = ({
   */
   // `hasPreconfigCondition` is true if either 1) the sql datasource has a preconfigured default database,
   // OR if 2) the datasource is Postgres. In either case the only option available to the user is the preconfigured database.
-  const hasPreconfigCondition = !!preconfiguredDataset || isPostgresInstance;
+  const hasPreconfigCondition = !!preconfiguredDataset || dialect === 'postgres';
 
   const state = useAsync(async () => {
     if (isSqlDatasourceDatabaseSelectionFeatureFlagEnabled()) {

--- a/public/app/features/plugins/sql/components/QueryEditor.tsx
+++ b/public/app/features/plugins/sql/components/QueryEditor.tsx
@@ -14,7 +14,7 @@ import { RawEditor } from './query-editor-raw/RawEditor';
 import { VisualEditor } from './visual-query-builder/VisualEditor';
 
 interface SqlQueryEditorProps extends QueryEditorProps<SqlDatasource, SQLQuery, SQLOptions> {
-  queryHeaderProps?: Pick<QueryHeaderProps, 'isPostgresInstance'>;
+  queryHeaderProps?: Pick<QueryHeaderProps, 'isPostgresInstance' | 'isFsqlInstance'>;
 }
 
 export function SqlQueryEditor({
@@ -30,6 +30,7 @@ export function SqlQueryEditor({
 
   const { preconfiguredDatabase } = datasource;
   const isPostgresInstance = !!queryHeaderProps?.isPostgresInstance;
+  const isFsqlInstance = !!queryHeaderProps?.isFsqlInstance;
   const { loading, error } = useAsync(async () => {
     return () => {
       if (datasource.getDB(datasource.id).init !== undefined) {
@@ -98,6 +99,7 @@ export function SqlQueryEditor({
         query={queryWithDefaults}
         isQueryRunnable={isQueryRunnable}
         isPostgresInstance={isPostgresInstance}
+        isFsqlInstance={isFsqlInstance}
       />
 
       <Space v={0.5} />

--- a/public/app/features/plugins/sql/components/QueryEditor.tsx
+++ b/public/app/features/plugins/sql/components/QueryEditor.tsx
@@ -14,7 +14,7 @@ import { RawEditor } from './query-editor-raw/RawEditor';
 import { VisualEditor } from './visual-query-builder/VisualEditor';
 
 interface SqlQueryEditorProps extends QueryEditorProps<SqlDatasource, SQLQuery, SQLOptions> {
-  queryHeaderProps?: Pick<QueryHeaderProps, 'isPostgresInstance' | 'isFsqlInstance'>;
+  queryHeaderProps?: Pick<QueryHeaderProps, 'dialect'>;
 }
 
 export function SqlQueryEditor({
@@ -29,8 +29,7 @@ export function SqlQueryEditor({
   const db = datasource.getDB();
 
   const { preconfiguredDatabase } = datasource;
-  const isPostgresInstance = !!queryHeaderProps?.isPostgresInstance;
-  const isFsqlInstance = !!queryHeaderProps?.isFsqlInstance;
+  const dialect = queryHeaderProps?.dialect ?? 'other';
   const { loading, error } = useAsync(async () => {
     return () => {
       if (datasource.getDB(datasource.id).init !== undefined) {
@@ -98,8 +97,7 @@ export function SqlQueryEditor({
         queryRowFilter={queryRowFilter}
         query={queryWithDefaults}
         isQueryRunnable={isQueryRunnable}
-        isPostgresInstance={isPostgresInstance}
-        isFsqlInstance={isFsqlInstance}
+        dialect={dialect}
       />
 
       <Space v={0.5} />

--- a/public/app/features/plugins/sql/components/QueryHeader.tsx
+++ b/public/app/features/plugins/sql/components/QueryHeader.tsx
@@ -18,6 +18,7 @@ import { TableSelector } from './TableSelector';
 export interface QueryHeaderProps {
   db: DB;
   isPostgresInstance?: boolean;
+  isFsqlInstance?: boolean;
   isQueryRunnable: boolean;
   onChange: (query: SQLQuery) => void;
   onQueryRowChange: (queryRowFilter: QueryRowFilter) => void;
@@ -35,6 +36,7 @@ const editorModes = [
 export function QueryHeader({
   db,
   isPostgresInstance,
+  isFsqlInstance,
   isQueryRunnable,
   onChange,
   onQueryRowChange,
@@ -108,6 +110,9 @@ export function QueryHeader({
   };
 
   const datasetDropdownIsAvailable = () => {
+    if (isFsqlInstance) {
+      return false;
+    }
     // If the feature flag is DISABLED, && the datasource is Postgres (`isPostgresInstance`),
     // we want to hide the dropdown - as per previous behavior.
     if (!isSqlDatasourceDatabaseSelectionFeatureFlagEnabled() && isPostgresInstance) {

--- a/public/app/features/plugins/sql/components/QueryHeader.tsx
+++ b/public/app/features/plugins/sql/components/QueryHeader.tsx
@@ -8,7 +8,7 @@ import { reportInteraction } from '@grafana/runtime';
 import { Button, InlineSwitch, RadioButtonGroup, Tooltip } from '@grafana/ui';
 
 import { QueryWithDefaults } from '../defaults';
-import { SQLQuery, QueryFormat, QueryRowFilter, QUERY_FORMAT_OPTIONS, DB } from '../types';
+import { SQLQuery, QueryFormat, QueryRowFilter, QUERY_FORMAT_OPTIONS, DB, SQLDialect } from '../types';
 
 import { ConfirmModal } from './ConfirmModal';
 import { DatasetSelector } from './DatasetSelector';
@@ -17,8 +17,7 @@ import { TableSelector } from './TableSelector';
 
 export interface QueryHeaderProps {
   db: DB;
-  isPostgresInstance?: boolean;
-  isFsqlInstance?: boolean;
+  dialect: SQLDialect;
   isQueryRunnable: boolean;
   onChange: (query: SQLQuery) => void;
   onQueryRowChange: (queryRowFilter: QueryRowFilter) => void;
@@ -35,8 +34,7 @@ const editorModes = [
 
 export function QueryHeader({
   db,
-  isPostgresInstance,
-  isFsqlInstance,
+  dialect,
   isQueryRunnable,
   onChange,
   onQueryRowChange,
@@ -110,12 +108,12 @@ export function QueryHeader({
   };
 
   const datasetDropdownIsAvailable = () => {
-    if (isFsqlInstance) {
+    if (dialect === 'influx') {
       return false;
     }
-    // If the feature flag is DISABLED, && the datasource is Postgres (`isPostgresInstance`),
+    // If the feature flag is DISABLED, && the datasource is Postgres (`dialect = 'postgres`),
     // we want to hide the dropdown - as per previous behavior.
-    if (!isSqlDatasourceDatabaseSelectionFeatureFlagEnabled() && isPostgresInstance) {
+    if (!isSqlDatasourceDatabaseSelectionFeatureFlagEnabled() && dialect === 'postgres') {
       return false;
     }
 
@@ -295,7 +293,7 @@ export function QueryHeader({
                 <DatasetSelector
                   db={db}
                   dataset={query.dataset}
-                  isPostgresInstance={isPostgresInstance}
+                  dialect={dialect}
                   preconfiguredDataset={preconfiguredDataset}
                   onChange={onDatasetChange}
                 />

--- a/public/app/features/plugins/sql/components/SqlComponents.test.tsx
+++ b/public/app/features/plugins/sql/components/SqlComponents.test.tsx
@@ -30,7 +30,7 @@ describe('DatasetSelector', () => {
   });
 
   it('should not query the database if Postgres instance, and no preconfigured database', async () => {
-    const mockProps = buildMockDatasetSelectorProps({ isPostgresInstance: true });
+    const mockProps = buildMockDatasetSelectorProps({ dialect: 'postgres' });
     render(<DatasetSelector {...mockProps} />);
 
     await waitFor(() => {

--- a/public/app/features/plugins/sql/components/SqlComponents.testHelpers.ts
+++ b/public/app/features/plugins/sql/components/SqlComponents.testHelpers.ts
@@ -76,7 +76,7 @@ export function buildMockDatasetSelectorProps(overrides?: Partial<DatasetSelecto
   return {
     db: buildMockDB(),
     dataset: '',
-    isPostgresInstance: false,
+    dialect: 'other',
     onChange: jest.fn(),
     preconfiguredDataset: '',
     ...overrides,

--- a/public/app/features/plugins/sql/types.ts
+++ b/public/app/features/plugins/sql/types.ts
@@ -168,3 +168,5 @@ export interface MetaDefinition {
   completion?: string;
   kind: CompletionItemKind;
 }
+
+export type SQLDialect = 'postgres' | 'influx' | 'other';

--- a/public/app/plugins/datasource/grafana-postgresql-datasource/PostgresQueryEditor.tsx
+++ b/public/app/plugins/datasource/grafana-postgresql-datasource/PostgresQueryEditor.tsx
@@ -4,9 +4,11 @@ import { QueryEditorProps } from '@grafana/data';
 import { SqlQueryEditor } from 'app/features/plugins/sql/components/QueryEditor';
 import { SQLOptions, SQLQuery } from 'app/features/plugins/sql/types';
 
+import { QueryHeaderProps } from '../../../features/plugins/sql/components/QueryHeader';
+
 import { PostgresDatasource } from './datasource';
 
-const queryHeaderProps = { isPostgresInstance: true };
+const queryHeaderProps: Pick<QueryHeaderProps, 'dialect'> = { dialect: 'postgres' };
 
 export function PostgresQueryEditor(props: QueryEditorProps<PostgresDatasource, SQLQuery, SQLOptions>) {
   return <SqlQueryEditor {...props} queryHeaderProps={queryHeaderProps} />;

--- a/public/app/plugins/datasource/influxdb/components/editor/query/fsql/FSQLEditor.tsx
+++ b/public/app/plugins/datasource/influxdb/components/editor/query/fsql/FSQLEditor.tsx
@@ -61,6 +61,7 @@ class UnthemedSQLQueryEditor extends PureComponent<Props> {
     const defaultQuery = applyQueryDefaults(query);
     return {
       ...defaultQuery,
+      dataset: 'iox',
       sql: {
         ...defaultQuery.sql,
         limit: undefined,

--- a/public/app/plugins/datasource/influxdb/components/editor/query/fsql/FSQLEditor.tsx
+++ b/public/app/plugins/datasource/influxdb/components/editor/query/fsql/FSQLEditor.tsx
@@ -99,7 +99,7 @@ class UnthemedSQLQueryEditor extends PureComponent<Props> {
           query={this.transformQuery(query)}
           onRunQuery={onRunSQLQuery}
           onChange={onSQLChange}
-          queryHeaderProps={{ isFsqlInstance: true }}
+          queryHeaderProps={{ dialect: 'influx' }}
         />
         <div className={cx('gf-form-inline', styles.editorActions)}>
           <LinkButton

--- a/public/app/plugins/datasource/influxdb/components/editor/query/fsql/FSQLEditor.tsx
+++ b/public/app/plugins/datasource/influxdb/components/editor/query/fsql/FSQLEditor.tsx
@@ -98,6 +98,7 @@ class UnthemedSQLQueryEditor extends PureComponent<Props> {
           query={this.transformQuery(query)}
           onRunQuery={onRunSQLQuery}
           onChange={onSQLChange}
+          queryHeaderProps={{ isFsqlInstance: true }}
         />
         <div className={cx('gf-form-inline', styles.editorActions)}>
           <LinkButton

--- a/public/app/plugins/datasource/influxdb/fsql/datasource.flightsql.ts
+++ b/public/app/plugins/datasource/influxdb/fsql/datasource.flightsql.ts
@@ -19,6 +19,7 @@ export class FlightSQLDatasource extends SqlDatasource {
     protected readonly templateSrv: TemplateSrv = getTemplateSrv()
   ) {
     super(instanceSettings);
+    this.preconfiguredDatabase = 'iox';
   }
 
   getQueryModel() {

--- a/public/app/plugins/datasource/influxdb/fsql/datasource.flightsql.ts
+++ b/public/app/plugins/datasource/influxdb/fsql/datasource.flightsql.ts
@@ -6,7 +6,7 @@ import { DB, SQLQuery } from 'app/features/plugins/sql/types';
 import { formatSQL } from 'app/features/plugins/sql/utils/formatSQL';
 
 import { mapFieldsToTypes } from './fields';
-import { buildColumnQuery, buildTableQuery, showDatabases } from './flightsqlMetaQuery';
+import { buildColumnQuery, buildTableQuery } from './flightsqlMetaQuery';
 import { getSqlCompletionProvider } from './sqlCompletionProvider';
 import { quoteLiteral, quoteIdentifierIfNecessary, toRawSql } from './sqlUtil';
 import { FlightSQLOptions } from './types';
@@ -19,7 +19,6 @@ export class FlightSQLDatasource extends SqlDatasource {
     protected readonly templateSrv: TemplateSrv = getTemplateSrv()
   ) {
     super(instanceSettings);
-    this.preconfiguredDatabase = 'iox';
   }
 
   getQueryModel() {
@@ -43,8 +42,7 @@ export class FlightSQLDatasource extends SqlDatasource {
   }
 
   async fetchDatasets(): Promise<string[]> {
-    const datasets = await this.runSql<string[]>(showDatabases(), { refId: 'datasets' });
-    return datasets.map((t) => quoteIdentifierIfNecessary(t[0]));
+    return Promise.resolve(['iox']);
   }
 
   async fetchTables(dataset?: string): Promise<string[]> {


### PR DESCRIPTION
**What is this feature?**

For InfluxDB SQL we don't need dataset dropdown to be shown. The default dataset is `iox`. 

**Who is this feature for?**

InfluxDB SQL users

**Which issue(s) does this PR fix?**:


Fixes https://github.com/grafana/grafana/issues/78552

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
