### PR TITLE
CloudWatch: Fetch Dimension keys correctly from Dimension Picker

### DIFF
--- a/public/app/plugins/datasource/cloudwatch/components/VariableQueryEditor/VariableQueryEditor.test.tsx
+++ b/public/app/plugins/datasource/cloudwatch/components/VariableQueryEditor/VariableQueryEditor.test.tsx
@@ -149,8 +149,10 @@ describe('VariableEditor', () => {
         // change filter key
         const keySelect = screen.getByRole('combobox', { name: 'Dimensions filter key' });
         // confirms getDimensionKeys was called with filter and that the element uses keysForDimensionFilter
-        await select(keySelect, 'v4', {
-          container: document.body,
+        await waitFor(() => {
+          select(keySelect, 'v4', {
+            container: document.body,
+          });
         });
         expect(ds.datasource.resources.getDimensionKeys).toHaveBeenCalledWith({
           namespace: 'z2',
@@ -158,14 +160,16 @@ describe('VariableEditor', () => {
           metricName: 'i3',
           dimensionFilters: undefined,
         });
-        expect(onChange).toHaveBeenCalledWith({
-          ...defaultQuery,
-          queryType: VariableQueryType.DimensionValues,
-          namespace: 'z2',
-          region: 'a1',
-          metricName: 'i3',
-          dimensionKey: 's4',
-          dimensionFilters: { v4: undefined },
+        await waitFor(() => {
+          expect(onChange).toHaveBeenCalledWith({
+            ...defaultQuery,
+            queryType: VariableQueryType.DimensionValues,
+            namespace: 'z2',
+            region: 'a1',
+            metricName: 'i3',
+            dimensionKey: 's4',
+            dimensionFilters: { v4: undefined },
+          });
         });
 
         // set filter value

--- a/public/app/plugins/datasource/cloudwatch/components/VariableQueryEditor/VariableQueryEditor.test.tsx
+++ b/public/app/plugins/datasource/cloudwatch/components/VariableQueryEditor/VariableQueryEditor.test.tsx
@@ -149,10 +149,8 @@ describe('VariableEditor', () => {
         // change filter key
         const keySelect = screen.getByRole('combobox', { name: 'Dimensions filter key' });
         // confirms getDimensionKeys was called with filter and that the element uses keysForDimensionFilter
-        await waitFor(() => {
-          select(keySelect, 'v4', {
-            container: document.body,
-          });
+        select(keySelect, 'v4', {
+          container: document.body,
         });
         expect(ds.datasource.resources.getDimensionKeys).toHaveBeenCalledWith({
           namespace: 'z2',

--- a/public/app/plugins/datasource/cloudwatch/components/VariableQueryEditor/VariableQueryEditor.tsx
+++ b/public/app/plugins/datasource/cloudwatch/components/VariableQueryEditor/VariableQueryEditor.tsx
@@ -37,12 +37,11 @@ const queryTypes: Array<{ value: string; label: string }> = [
 export const VariableQueryEditor = ({ query, datasource, onChange }: Props) => {
   const parsedQuery = migrateVariableQuery(query);
 
-  const { region, namespace, metricName, dimensionKey, dimensionFilters } = parsedQuery;
+  const { region, namespace, metricName, dimensionKey } = parsedQuery;
   const [regions, regionIsLoading] = useRegions(datasource);
   const namespaces = useNamespaces(datasource);
   const metrics = useMetrics(datasource, { region, namespace });
   const dimensionKeys = useDimensionKeys(datasource, { region, namespace, metricName });
-  const keysForDimensionFilter = useDimensionKeys(datasource, { region, namespace, metricName, dimensionFilters });
   const accountState = useAccountOptions(datasource.resources, query.region);
 
   const newFormStylingEnabled = config.featureToggles.awsDatasourcesNewFormStyling;
@@ -188,7 +187,6 @@ export const VariableQueryEditor = ({ query, datasource, onChange }: Props) => {
                 onChange={(dimensions) => {
                   onChange({ ...parsedQuery, dimensionFilters: dimensions });
                 }}
-                dimensionKeys={keysForDimensionFilter}
                 disableExpressions={true}
                 datasource={datasource}
               />
@@ -205,7 +203,6 @@ export const VariableQueryEditor = ({ query, datasource, onChange }: Props) => {
                 onChange={(dimensions) => {
                   onChange({ ...parsedQuery, dimensionFilters: dimensions });
                 }}
-                dimensionKeys={keysForDimensionFilter}
                 disableExpressions={true}
                 datasource={datasource}
               />

--- a/public/app/plugins/datasource/cloudwatch/components/shared/Dimensions/Dimensions.test.tsx
+++ b/public/app/plugins/datasource/cloudwatch/components/shared/Dimensions/Dimensions.test.tsx
@@ -46,7 +46,7 @@ describe('Dimensions', () => {
       await act(async () => {
         render(<Dimensions {...props} metricStat={props.query} />);
       });
-      const filterItems = screen.queryAllByTestId('cloudwatch-dimensions-filter-item');
+      const filterItems = screen.getAllByTestId('cloudwatch-dimensions-filter-item');
       expect(filterItems.length).toBe(2);
 
       expect(within(filterItems[0]).getByText('InstanceId')).toBeInTheDocument();

--- a/public/app/plugins/datasource/cloudwatch/components/shared/Dimensions/Dimensions.test.tsx
+++ b/public/app/plugins/datasource/cloudwatch/components/shared/Dimensions/Dimensions.test.tsx
@@ -43,7 +43,7 @@ describe('Dimensions', () => {
         InstanceId: '*',
         InstanceGroup: 'Group1',
       };
-      render(<Dimensions {...props} metricStat={props.query} dimensionKeys={[]} />);
+      render(<Dimensions {...props} metricStat={props.query} />);
       const filterItems = screen.getAllByTestId('cloudwatch-dimensions-filter-item');
       expect(filterItems.length).toBe(2);
 
@@ -61,7 +61,7 @@ describe('Dimensions', () => {
         InstanceId: ['*'],
         InstanceGroup: ['Group1'],
       };
-      render(<Dimensions {...props} metricStat={props.query} dimensionKeys={[]} />);
+      render(<Dimensions {...props} metricStat={props.query} />);
       const filterItems = screen.getAllByTestId('cloudwatch-dimensions-filter-item');
       expect(filterItems.length).toBe(2);
 
@@ -77,7 +77,7 @@ describe('Dimensions', () => {
     it('it should add the new item but not call onChange', async () => {
       props.query.dimensions = {};
       const onChange = jest.fn();
-      render(<Dimensions {...props} metricStat={props.query} onChange={onChange} dimensionKeys={[]} />);
+      render(<Dimensions {...props} metricStat={props.query} onChange={onChange} />);
 
       await userEvent.click(screen.getByLabelText('Add'));
       expect(screen.getByTestId('cloudwatch-dimensions-filter-item')).toBeInTheDocument();
@@ -89,9 +89,7 @@ describe('Dimensions', () => {
     it('it should add the new item but not call onChange', async () => {
       props.query.dimensions = {};
       const onChange = jest.fn();
-      const { container } = render(
-        <Dimensions {...props} metricStat={props.query} onChange={onChange} dimensionKeys={[]} />
-      );
+      const { container } = render(<Dimensions {...props} metricStat={props.query} onChange={onChange} />);
 
       await userEvent.click(screen.getByLabelText('Add'));
       const filterItemElement = screen.getByTestId('cloudwatch-dimensions-filter-item');
@@ -109,9 +107,7 @@ describe('Dimensions', () => {
     it('it should add the new item and trigger onChange', async () => {
       props.query.dimensions = {};
       const onChange = jest.fn();
-      const { container } = render(
-        <Dimensions {...props} metricStat={props.query} onChange={onChange} dimensionKeys={[]} />
-      );
+      const { container } = render(<Dimensions {...props} metricStat={props.query} onChange={onChange} />);
 
       const label = await screen.findByLabelText('Add');
       await userEvent.click(label);
@@ -128,11 +124,8 @@ describe('Dimensions', () => {
       expect(valueElement).toBeInTheDocument();
       await userEvent.type(valueElement!, 'my-value');
       fireEvent.keyDown(valueElement!, { keyCode: 13 });
-      expect(onChange).not.toHaveBeenCalledWith({
-        ...props.query,
-        dimensions: {
-          'my-key': 'my-value',
-        },
+      expect(onChange).toHaveBeenCalledWith({
+        'my-key': 'my-value',
       });
     });
   });

--- a/public/app/plugins/datasource/cloudwatch/components/shared/Dimensions/Dimensions.test.tsx
+++ b/public/app/plugins/datasource/cloudwatch/components/shared/Dimensions/Dimensions.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen, within } from '@testing-library/react';
+import { act, fireEvent, render, screen, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import React from 'react';
 
@@ -43,8 +43,10 @@ describe('Dimensions', () => {
         InstanceId: '*',
         InstanceGroup: 'Group1',
       };
-      render(<Dimensions {...props} metricStat={props.query} />);
-      const filterItems = screen.getAllByTestId('cloudwatch-dimensions-filter-item');
+      await act(async () => {
+        render(<Dimensions {...props} metricStat={props.query} />);
+      });
+      const filterItems = screen.queryAllByTestId('cloudwatch-dimensions-filter-item');
       expect(filterItems.length).toBe(2);
 
       expect(within(filterItems[0]).getByText('InstanceId')).toBeInTheDocument();
@@ -61,7 +63,9 @@ describe('Dimensions', () => {
         InstanceId: ['*'],
         InstanceGroup: ['Group1'],
       };
-      render(<Dimensions {...props} metricStat={props.query} />);
+      await act(async () => {
+        render(<Dimensions {...props} metricStat={props.query} />);
+      });
       const filterItems = screen.getAllByTestId('cloudwatch-dimensions-filter-item');
       expect(filterItems.length).toBe(2);
 

--- a/public/app/plugins/datasource/cloudwatch/components/shared/Dimensions/Dimensions.test.tsx
+++ b/public/app/plugins/datasource/cloudwatch/components/shared/Dimensions/Dimensions.test.tsx
@@ -1,4 +1,4 @@
-import { act, fireEvent, render, screen, within } from '@testing-library/react';
+import { fireEvent, render, screen, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import React from 'react';
 
@@ -43,10 +43,8 @@ describe('Dimensions', () => {
         InstanceId: '*',
         InstanceGroup: 'Group1',
       };
-      await act(async () => {
-        render(<Dimensions {...props} metricStat={props.query} />);
-      });
-      const filterItems = screen.getAllByTestId('cloudwatch-dimensions-filter-item');
+      render(<Dimensions {...props} metricStat={props.query} />);
+      const filterItems = await screen.findAllByTestId('cloudwatch-dimensions-filter-item');
       expect(filterItems.length).toBe(2);
 
       expect(within(filterItems[0]).getByText('InstanceId')).toBeInTheDocument();
@@ -63,10 +61,8 @@ describe('Dimensions', () => {
         InstanceId: ['*'],
         InstanceGroup: ['Group1'],
       };
-      await act(async () => {
-        render(<Dimensions {...props} metricStat={props.query} />);
-      });
-      const filterItems = screen.getAllByTestId('cloudwatch-dimensions-filter-item');
+      render(<Dimensions {...props} metricStat={props.query} />);
+      const filterItems = await screen.findAllByTestId('cloudwatch-dimensions-filter-item');
       expect(filterItems.length).toBe(2);
 
       expect(within(filterItems[0]).getByText('InstanceId')).toBeInTheDocument();

--- a/public/app/plugins/datasource/cloudwatch/components/shared/Dimensions/Dimensions.tsx
+++ b/public/app/plugins/datasource/cloudwatch/components/shared/Dimensions/Dimensions.tsx
@@ -1,7 +1,6 @@
 import { isEqual } from 'lodash';
 import React, { useMemo, useState } from 'react';
 
-import { SelectableValue } from '@grafana/data';
 import { EditorList } from '@grafana/experimental';
 
 import { CloudWatchDatasource } from '../../../datasource';
@@ -13,7 +12,6 @@ export interface Props {
   metricStat: MetricStat;
   onChange: (dimensions: DimensionsType) => void;
   datasource: CloudWatchDatasource;
-  dimensionKeys: Array<SelectableValue<string>>;
   disableExpressions: boolean;
 }
 
@@ -62,7 +60,7 @@ const filterConditionsToDimensions = (filters: DimensionFilterCondition[]) => {
   }, {});
 };
 
-export const Dimensions = ({ metricStat, datasource, dimensionKeys, disableExpressions, onChange }: Props) => {
+export const Dimensions = ({ metricStat, datasource, disableExpressions, onChange }: Props) => {
   const dimensionFilters = useMemo(() => dimensionsToFilterConditions(metricStat.dimensions), [metricStat.dimensions]);
   const [items, setItems] = useState<DimensionFilterCondition[]>(dimensionFilters);
   const onDimensionsChange = (newItems: Array<Partial<DimensionFilterCondition>>) => {
@@ -80,17 +78,12 @@ export const Dimensions = ({ metricStat, datasource, dimensionKeys, disableExpre
     <EditorList
       items={items}
       onChange={onDimensionsChange}
-      renderItem={makeRenderFilter(datasource, metricStat, dimensionKeys, disableExpressions)}
+      renderItem={makeRenderFilter(datasource, metricStat, disableExpressions)}
     />
   );
 };
 
-function makeRenderFilter(
-  datasource: CloudWatchDatasource,
-  metricStat: MetricStat,
-  dimensionKeys: Array<SelectableValue<string>>,
-  disableExpressions: boolean
-) {
+function makeRenderFilter(datasource: CloudWatchDatasource, metricStat: MetricStat, disableExpressions: boolean) {
   function renderFilter(
     item: DimensionFilterCondition,
     onChange: (item: DimensionFilterCondition) => void,
@@ -103,7 +96,6 @@ function makeRenderFilter(
         datasource={datasource}
         metricStat={metricStat}
         disableExpressions={disableExpressions}
-        dimensionKeys={dimensionKeys}
         onDelete={onDelete}
       />
     );

--- a/public/app/plugins/datasource/cloudwatch/components/shared/Dimensions/FilterItem.test.tsx
+++ b/public/app/plugins/datasource/cloudwatch/components/shared/Dimensions/FilterItem.test.tsx
@@ -1,0 +1,53 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import React from 'react';
+
+import { setupMockedDataSource } from '../../../__mocks__/CloudWatchDataSource';
+import { CloudWatchMetricsQuery } from '../../../types';
+
+import { FilterItem } from './FilterItem';
+
+const ds = setupMockedDataSource({
+  variables: [],
+});
+
+const q: CloudWatchMetricsQuery = {
+  id: '',
+  region: 'us-east-2',
+  namespace: '',
+  period: '',
+  alias: '',
+  metricName: '',
+  dimensions: { foo: 'bar', abc: 'xyz' },
+  matchExact: true,
+  statistic: '',
+  expression: '',
+  refId: '',
+};
+
+describe('Dimensions', () => {
+  it('should call getDimensionKeys without the current key', async () => {
+    const getDimensionKeys = jest.fn().mockResolvedValue([]);
+    ds.datasource.resources.getDimensionKeys = getDimensionKeys;
+    const currFilter = { key: 'foo', value: 'bar' };
+
+    render(
+      <FilterItem
+        metricStat={q}
+        datasource={ds.datasource}
+        filter={currFilter}
+        disableExpressions={true}
+        onChange={jest.fn()}
+        onDelete={jest.fn()}
+      />
+    );
+    await userEvent.click(screen.getByLabelText('Dimensions filter key'));
+    expect(getDimensionKeys).toHaveBeenCalledWith({
+      namespace: q.namespace,
+      region: q.region,
+      metricName: q.metricName,
+      accountId: q.accountId,
+      dimensionFilters: { abc: ['xyz'] },
+    });
+  });
+});

--- a/public/app/plugins/datasource/cloudwatch/components/shared/Dimensions/FilterItem.tsx
+++ b/public/app/plugins/datasource/cloudwatch/components/shared/Dimensions/FilterItem.tsx
@@ -7,6 +7,7 @@ import { AccessoryButton, InputGroup } from '@grafana/experimental';
 import { Select, useStyles2 } from '@grafana/ui';
 
 import { CloudWatchDatasource } from '../../../datasource';
+import { useDimensionKeys } from '../../../hooks';
 import { Dimensions, MetricStat } from '../../../types';
 import { appendTemplateVariables } from '../../../utils/utils';
 
@@ -16,7 +17,6 @@ export interface Props {
   metricStat: MetricStat;
   datasource: CloudWatchDatasource;
   filter: DimensionFilterCondition;
-  dimensionKeys: Array<SelectableValue<string>>;
   disableExpressions: boolean;
   onChange: (value: DimensionFilterCondition) => void;
   onDelete: () => void;
@@ -32,19 +32,16 @@ const excludeCurrentKey = (dimensions: Dimensions, currentKey: string | undefine
     return acc;
   }, {});
 
-export const FilterItem = ({
-  filter,
-  metricStat: { region, namespace, metricName, dimensions, accountId },
-  datasource,
-  dimensionKeys,
-  disableExpressions,
-  onChange,
-  onDelete,
-}: Props) => {
+export const FilterItem = ({ filter, metricStat, datasource, disableExpressions, onChange, onDelete }: Props) => {
+  const { region, namespace, metricName, dimensions, accountId } = metricStat;
   const dimensionsExcludingCurrentKey = useMemo(
     () => excludeCurrentKey(dimensions ?? {}, filter.key),
     [dimensions, filter]
   );
+  const dimensionKeys = useDimensionKeys(datasource, {
+    ...metricStat,
+    dimensionFilters: dimensionsExcludingCurrentKey,
+  });
 
   const loadDimensionValues = async () => {
     if (!filter.key) {

--- a/public/app/plugins/datasource/cloudwatch/components/shared/MetricStatEditor/MetricStatEditor.tsx
+++ b/public/app/plugins/datasource/cloudwatch/components/shared/MetricStatEditor/MetricStatEditor.tsx
@@ -6,7 +6,7 @@ import { config } from '@grafana/runtime';
 import { Select } from '@grafana/ui';
 
 import { CloudWatchDatasource } from '../../../datasource';
-import { useAccountOptions, useDimensionKeys, useMetrics, useNamespaces } from '../../../hooks';
+import { useAccountOptions, useMetrics, useNamespaces } from '../../../hooks';
 import { standardStatistics } from '../../../standardStatistics';
 import { MetricStat } from '../../../types';
 import { appendTemplateVariables, toOption } from '../../../utils/utils';
@@ -35,7 +35,6 @@ export const MetricStatEditor = ({
 }: React.PropsWithChildren<Props>) => {
   const namespaces = useNamespaces(datasource);
   const metrics = useMetrics(datasource, metricStat);
-  const dimensionKeys = useDimensionKeys(datasource, { ...metricStat, dimensionFilters: metricStat.dimensions });
   const accountState = useAccountOptions(datasource.resources, metricStat.region);
 
   useEffect(() => {
@@ -139,7 +138,6 @@ export const MetricStatEditor = ({
           <Dimensions
             metricStat={metricStat}
             onChange={(dimensions) => onChange({ ...metricStat, dimensions })}
-            dimensionKeys={dimensionKeys}
             disableExpressions={disableExpressions}
             datasource={datasource}
           />


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

Makes it so that we get the dimension key options without the key that we are currently changing. Otherwise, the user needs to delete and re-create the dimension to pick a new key.

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #77828

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
