### PR TITLE
Opentsdb: Add variables to select when interacting with the metric select

### DIFF
--- a/public/app/plugins/datasource/opentsdb/components/MetricSection.test.tsx
+++ b/public/app/plugins/datasource/opentsdb/components/MetricSection.test.tsx
@@ -16,8 +16,16 @@ const setup = (propOverrides?: Object) => {
     aggregator: 'avg',
     alias: 'alias',
   };
+
+  const varQuery: OpenTsdbQuery = {
+    metric: '$variable',
+    refId: 'A',
+    aggregator: 'avg',
+    alias: 'alias',
+  };
+
   const props: MetricSectionProps = {
-    query,
+    query: !propOverrides ? query : varQuery,
     onChange: onChange,
     onRunQuery: onRunQuery,
     suggestMetrics: suggestMetrics,
@@ -41,6 +49,11 @@ describe('MetricSection', () => {
     it('should render metrics select', () => {
       setup();
       expect(screen.getByText('cpu')).toBeInTheDocument();
+    });
+
+    it('should display variables in the metrics select', () => {
+      setup({ variables: true });
+      expect(screen.getByText('$variable')).toBeInTheDocument();
     });
   });
 

--- a/public/app/plugins/datasource/opentsdb/components/OpenTsdbQueryEditor.tsx
+++ b/public/app/plugins/datasource/opentsdb/components/OpenTsdbQueryEditor.tsx
@@ -93,12 +93,21 @@ export function OpenTsdbQueryEditor({
   }
 
   function getTextValues(metrics: Array<{ text: string }>) {
-    return metrics.map((value: { text: string }) => {
+    const variables = datasource.getVariables().map((value) => {
+      return {
+        value: textUtil.escapeHtml(value),
+        description: value,
+      };
+    });
+
+    const values = metrics.map((value: { text: string }) => {
       return {
         value: textUtil.escapeHtml(value.text),
         description: value.text,
       };
     });
+
+    return variables.concat(values);
   }
 
   return (

--- a/public/app/plugins/datasource/opentsdb/datasource.ts
+++ b/public/app/plugins/datasource/opentsdb/datasource.ts
@@ -550,6 +550,10 @@ export default class OpenTsDatasource extends DataSourceApi<OpenTsdbQuery, OpenT
     });
   }
 
+  getVariables(): string[] {
+    return this.templateSrv.getVariables().map((v) => `$${v.name}`);
+  }
+
   mapMetricsToTargets(metrics: any, options: any, tsdbVersion: number) {
     let interpolatedTagValue, arrTagV;
     return _map(metrics, (metricData) => {


### PR DESCRIPTION
Fixes https://github.com/grafana/grafana/issues/26111

Add variables to metric select in the opentsdb editor.

To test, set up an opentsdb data source. Type the autocomplete in the metric select, see that variables are available.

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
