### PR TITLE
RBAC: GrafanaAdmin users are admins of the Global Organization

### DIFF
--- a/pkg/services/accesscontrol/accesscontrol.go
+++ b/pkg/services/accesscontrol/accesscontrol.go
@@ -365,6 +365,10 @@ func GetOrgRoles(user identity.Requester) []string {
 	roles := []string{string(user.GetOrgRole())}
 
 	if user.GetIsGrafanaAdmin() {
+		if user.GetOrgID() == GlobalOrgID {
+			// A server admin is the admin of the global organization
+			return []string{RoleGrafanaAdmin, string(org.RoleAdmin)}
+		}
 		roles = append(roles, RoleGrafanaAdmin)
 	}
 


### PR DESCRIPTION
**What is this feature?**

When performing an accesscontrol check in the global organization, a server admin should inherit permissions from the admin role.

That allows Grafana Admins to:
* modify global roles and make global assignments (since they have the roles permissions globally).
* install plugins without warnings (since they have the plugin service accounts permissions globally)

**Why do we need this feature?**

[Add a description of the problem the feature is trying to solve.]

**Who is this feature for?**

[Add information on what kind of user the feature is for.]

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
