### PR TITLE
Authn: ensure Grafana Admin are Admin in all Orgs

### DIFF
--- a/pkg/services/authn/authnimpl/service.go
+++ b/pkg/services/authn/authnimpl/service.go
@@ -156,6 +156,7 @@ func ProvideService(
 	orgUserSyncService := sync.ProvideOrgSync(userService, orgService, accessControlService)
 	s.RegisterPostAuthHook(userSyncService.SyncUserHook, 10)
 	s.RegisterPostAuthHook(userSyncService.EnableUserHook, 20)
+	s.RegisterPostAuthHook(orgUserSyncService.GrafanaAdminOrgRolesHook, 29)
 	s.RegisterPostAuthHook(orgUserSyncService.SyncOrgRolesHook, 30)
 	s.RegisterPostAuthHook(userSyncService.SyncLastSeenHook, 120)
 

--- a/pkg/services/authn/authnimpl/sync/org_sync.go
+++ b/pkg/services/authn/authnimpl/sync/org_sync.go
@@ -24,6 +24,20 @@ type OrgSync struct {
 	log log.Logger
 }
 
+func (s *OrgSync) GrafanaAdminOrgRolesHook(ctx context.Context, id *authn.Identity, _ *authn.Request) error {
+	if id.IsGrafanaAdmin == nil || !*id.IsGrafanaAdmin {
+		return nil
+	}
+	orgDTOs, err := s.orgService.Search(ctx, &org.SearchOrgsQuery{})
+	if err != nil {
+		return err
+	}
+	for _, orgDTO := range orgDTOs {
+		id.OrgRoles[orgDTO.ID] = org.RoleAdmin
+	}
+	return nil
+}
+
 func (s *OrgSync) SyncOrgRolesHook(ctx context.Context, id *authn.Identity, _ *authn.Request) error {
 	if !id.ClientParams.SyncOrgRoles {
 		return nil


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

Before this PR, GrafanaAdmins were not Admin in Orgs.

NB: This is a behavior change. Maybe some users depend on the previous behavior.

**Why do we need this feature?**

This is particularly useful when `role_attribute_path` config (for Oauth or others) returns GrafanaAdmin.

**Who is this feature for?**

Users with multiple orgs

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #78582

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
