### PR TITLE
Alerting: Apply query optimization to eval endpoints

### DIFF
--- a/pkg/services/ngalert/api/api_testing_test.go
+++ b/pkg/services/ngalert/api/api_testing_test.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
+	"github.com/grafana/grafana-plugin-sdk-go/data"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 
@@ -264,6 +265,78 @@ func TestRouteEvalQueries(t *testing.T) {
 			require.Equal(t, http.StatusOK, response.Status())
 
 			evaluator.AssertCalled(t, "EvaluateRaw", mock.Anything, currentTime)
+		})
+	})
+
+	t.Run("when query is optimizable", func(t *testing.T) {
+		rc := &contextmodel.ReqContext{
+			Context: &web.Context{
+				Req: &http.Request{},
+			},
+			SignedInUser: &user.SignedInUser{
+				OrgID: 1,
+			},
+		}
+		t.Run("should return warning notice on optimized queries", func(t *testing.T) {
+			queries := []models.AlertQuery{
+				models.CreatePrometheusQuery("A", "1", 1000, 43200, false, "some-ds"),
+				models.CreatePrometheusQuery("B", "1", 1000, 43200, false, "some-ds"),
+				models.CreatePrometheusQuery("C", "1", 1000, 43200, false, "some-ds"), // Not optimizable.
+				models.CreateReduceExpression("D", "A", "last"),
+				models.CreateReduceExpression("E", "B", "last"),
+			}
+
+			currentTime := time.Now()
+
+			ac := acMock.New().WithPermissions([]ac.Permission{
+				{Action: datasources.ActionQuery, Scope: datasources.ScopeProvider.GetResourceScopeUID(queries[0].DatasourceUID)},
+			})
+
+			ds := &fakes.FakeCacheService{DataSources: []*datasources.DataSource{
+				{UID: queries[0].DatasourceUID},
+			}}
+
+			evaluator := &eval_mocks.ConditionEvaluatorMock{}
+			createEmptyFrameResponse := func(refId string) backend.DataResponse {
+				frame := data.NewFrame("")
+				frame.RefID = refId
+				frame.SetMeta(&data.FrameMeta{})
+				return backend.DataResponse{
+					Frames: []*data.Frame{frame},
+					Error:  nil,
+				}
+			}
+			result := &backend.QueryDataResponse{
+				Responses: map[string]backend.DataResponse{
+					"A": createEmptyFrameResponse("A"),
+					"B": createEmptyFrameResponse("B"),
+					"C": createEmptyFrameResponse("C"),
+				},
+			}
+			evaluator.EXPECT().EvaluateRaw(mock.Anything, mock.Anything).Return(result, nil)
+
+			srv := createTestingApiSrv(t, ds, ac, eval_mocks.NewEvaluatorFactory(evaluator))
+
+			response := srv.RouteEvalQueries(rc, definitions.EvalQueriesPayload{
+				Data: ApiAlertQueriesFromAlertQueries(queries),
+				Now:  currentTime,
+			})
+
+			require.Equal(t, http.StatusOK, response.Status())
+
+			evaluator.AssertCalled(t, "EvaluateRaw", mock.Anything, currentTime)
+
+			require.Equal(t, []data.Notice{{
+				Severity: data.NoticeSeverityWarning,
+				Text:     "Query optimized from Range to Instant type",
+			}}, result.Responses["A"].Frames[0].Meta.Notices)
+
+			require.Equal(t, []data.Notice{{
+				Severity: data.NoticeSeverityWarning,
+				Text:     "Query optimized from Range to Instant type",
+			}}, result.Responses["B"].Frames[0].Meta.Notices)
+
+			require.Equal(t, 0, len(result.Responses["C"].Frames[0].Meta.Notices))
 		})
 	})
 }

--- a/pkg/services/ngalert/api/api_testing_test.go
+++ b/pkg/services/ngalert/api/api_testing_test.go
@@ -7,7 +7,6 @@ import (
 	"time"
 
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
-	"github.com/grafana/grafana-plugin-sdk-go/data"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 
@@ -265,78 +264,6 @@ func TestRouteEvalQueries(t *testing.T) {
 			require.Equal(t, http.StatusOK, response.Status())
 
 			evaluator.AssertCalled(t, "EvaluateRaw", mock.Anything, currentTime)
-		})
-	})
-
-	t.Run("when query is optimizable", func(t *testing.T) {
-		rc := &contextmodel.ReqContext{
-			Context: &web.Context{
-				Req: &http.Request{},
-			},
-			SignedInUser: &user.SignedInUser{
-				OrgID: 1,
-			},
-		}
-		t.Run("should return warning notice on optimized queries", func(t *testing.T) {
-			queries := []models.AlertQuery{
-				models.CreatePrometheusQuery("A", "1", 1000, 43200, false, "some-ds"),
-				models.CreatePrometheusQuery("B", "1", 1000, 43200, false, "some-ds"),
-				models.CreatePrometheusQuery("C", "1", 1000, 43200, false, "some-ds"), // Not optimizable.
-				models.CreateReduceExpression("D", "A", "last"),
-				models.CreateReduceExpression("E", "B", "last"),
-			}
-
-			currentTime := time.Now()
-
-			ac := acMock.New().WithPermissions([]ac.Permission{
-				{Action: datasources.ActionQuery, Scope: datasources.ScopeProvider.GetResourceScopeUID(queries[0].DatasourceUID)},
-			})
-
-			ds := &fakes.FakeCacheService{DataSources: []*datasources.DataSource{
-				{UID: queries[0].DatasourceUID},
-			}}
-
-			evaluator := &eval_mocks.ConditionEvaluatorMock{}
-			createEmptyFrameResponse := func(refId string) backend.DataResponse {
-				frame := data.NewFrame("")
-				frame.RefID = refId
-				frame.SetMeta(&data.FrameMeta{})
-				return backend.DataResponse{
-					Frames: []*data.Frame{frame},
-					Error:  nil,
-				}
-			}
-			result := &backend.QueryDataResponse{
-				Responses: map[string]backend.DataResponse{
-					"A": createEmptyFrameResponse("A"),
-					"B": createEmptyFrameResponse("B"),
-					"C": createEmptyFrameResponse("C"),
-				},
-			}
-			evaluator.EXPECT().EvaluateRaw(mock.Anything, mock.Anything).Return(result, nil)
-
-			srv := createTestingApiSrv(t, ds, ac, eval_mocks.NewEvaluatorFactory(evaluator))
-
-			response := srv.RouteEvalQueries(rc, definitions.EvalQueriesPayload{
-				Data: ApiAlertQueriesFromAlertQueries(queries),
-				Now:  currentTime,
-			})
-
-			require.Equal(t, http.StatusOK, response.Status())
-
-			evaluator.AssertCalled(t, "EvaluateRaw", mock.Anything, currentTime)
-
-			require.Equal(t, []data.Notice{{
-				Severity: data.NoticeSeverityWarning,
-				Text:     "Query optimized from Range to Instant type",
-			}}, result.Responses["A"].Frames[0].Meta.Notices)
-
-			require.Equal(t, []data.Notice{{
-				Severity: data.NoticeSeverityWarning,
-				Text:     "Query optimized from Range to Instant type",
-			}}, result.Responses["B"].Frames[0].Meta.Notices)
-
-			require.Equal(t, 0, len(result.Responses["C"].Frames[0].Meta.Notices))
 		})
 	})
 }

--- a/pkg/services/ngalert/models/testing.go
+++ b/pkg/services/ngalert/models/testing.go
@@ -12,6 +12,7 @@ import (
 	"github.com/grafana/grafana-plugin-sdk-go/data"
 
 	"github.com/grafana/grafana/pkg/expr"
+	"github.com/grafana/grafana/pkg/services/datasources"
 	"github.com/grafana/grafana/pkg/services/folder"
 	"github.com/grafana/grafana/pkg/util"
 )
@@ -445,6 +446,68 @@ func CreateClassicConditionExpression(refID string, inputRefID string, reducer s
                 }
             ]
 		}`, refID, inputRefID, operation, threshold, reducer, expr.DatasourceUID, expr.DatasourceType)),
+	}
+}
+
+func CreateReduceExpression(refID string, inputRefID string, reducer string) AlertQuery {
+	return AlertQuery{
+		RefID:         refID,
+		QueryType:     expr.DatasourceType,
+		DatasourceUID: expr.DatasourceUID,
+		Model: json.RawMessage(fmt.Sprintf(`
+		{
+			"refId": "%[1]s",
+            "hide": false,
+            "type": "reduce",
+			"expression": "%[2]s",
+			"reducer": "%[3]s",
+            "datasource": {
+                "uid": "%[4]s",
+                "type": "%[5]s"
+            }
+		}`, refID, inputRefID, reducer, expr.DatasourceUID, expr.DatasourceType)),
+	}
+}
+
+func CreatePrometheusQuery(refID string, expr string, intervalMs int64, maxDataPoints int64, isInstant bool, datasourceUID string) AlertQuery {
+	return AlertQuery{
+		RefID:         refID,
+		QueryType:     "",
+		DatasourceUID: datasourceUID,
+		Model: json.RawMessage(fmt.Sprintf(`
+		{
+			"refId": "%[1]s",
+			"expr": "%[2]s",
+            "intervalMs": %[3]d,
+            "maxDataPoints": %[4]d,
+			"exemplar": false,
+			"instant": %[5]t,
+			"range": %[6]t,
+            "datasource": {
+                "uid": "%[7]s",
+                "type": "%[8]s"
+            }
+		}`, refID, expr, intervalMs, maxDataPoints, isInstant, !isInstant, datasourceUID, datasources.DS_PROMETHEUS)),
+	}
+}
+
+func CreateLokiQuery(refID string, expr string, intervalMs int64, maxDataPoints int64, queryType string, datasourceUID string) AlertQuery {
+	return AlertQuery{
+		RefID:         refID,
+		QueryType:     queryType,
+		DatasourceUID: datasourceUID,
+		Model: json.RawMessage(fmt.Sprintf(`
+		{
+			"refId": "%[1]s",
+			"expr": "%[2]s",
+            "intervalMs": %[3]d,
+            "maxDataPoints": %[4]d,
+			"queryType": "%[5]s",
+            "datasource": {
+                "uid": "%[6]s",
+                "type": "%[7]s"
+            }
+		}`, refID, expr, intervalMs, maxDataPoints, queryType, datasourceUID, datasources.DS_LOKI)),
 	}
 }
 

--- a/pkg/services/ngalert/store/range_to_instant.go
+++ b/pkg/services/ngalert/store/range_to_instant.go
@@ -14,6 +14,21 @@ const (
 	grafanaCloudUsage = "grafanacloud-usage"
 )
 
+// OptimizeAlertQueries was added to mitigate the high load that could be created by loki range queries.
+// In previous versions of Grafana, Loki datasources would default to range queries
+// instead of instant queries, sometimes creating unnecessary load. This is only
+// done for Grafana Cloud.
+func OptimizeAlertQueries(queries []models.AlertQuery) ([]Optimization, error) {
+	if optimizations, migratable := canBeInstant(queries); migratable {
+		err := migrateToInstant(queries, optimizations)
+		if err != nil {
+			return nil, err
+		}
+		return optimizations, nil
+	}
+	return nil, nil
+}
+
 // DSType can be used to check the datasource type if it's set in the model.
 type dsType struct {
 	DS struct {
@@ -22,7 +37,9 @@ type dsType struct {
 	Range bool `json:"range"`
 }
 
-type optimization struct {
+type Optimization struct {
+	// RefID of the query that can be optimized
+	RefID string
 	// Index of the query that can be optimized
 	i int
 	// Type of the query that ca be optimized (loki,prometheus)
@@ -31,19 +48,19 @@ type optimization struct {
 
 // canBeInstant checks if any of the query nodes that are loki or prometheus range queries can be migrated to instant queries.
 // If any are migratable, those indices are returned.
-func canBeInstant(r *models.AlertRule) ([]optimization, bool) {
-	if len(r.Data) < 2 {
+func canBeInstant(queries []models.AlertQuery) ([]Optimization, bool) {
+	if len(queries) < 2 {
 		return nil, false
 	}
 	var (
-		optimizableIndices []optimization
+		optimizableIndices []Optimization
 		canBeOptimized     = false
 	)
 	// Loop over query nodes to find all range queries.
-	for i := range r.Data {
+	for i := range queries {
 		var t dsType
 		// We can ignore the error here, the query just won't be optimized.
-		_ = json.Unmarshal(r.Data[i].Model, &t)
+		_ = json.Unmarshal(queries[i].Model, &t)
 
 		switch t.DS.Type {
 		case datasources.DS_PROMETHEUS:
@@ -51,13 +68,13 @@ func canBeInstant(r *models.AlertRule) ([]optimization, bool) {
 				continue
 			}
 		case datasources.DS_LOKI:
-			if r.Data[i].QueryType != "range" {
+			if queries[i].QueryType != "range" {
 				continue
 			}
 		default:
 			// The default datasource is not saved as datasource, this is why we need to check for the datasource name.
 			// Here we check the well-known grafana cloud datasources.
-			if r.Data[i].DatasourceUID != grafanaCloudProm && r.Data[i].DatasourceUID != grafanaCloudUsage {
+			if queries[i].DatasourceUID != grafanaCloudProm && queries[i].DatasourceUID != grafanaCloudUsage {
 				continue
 			}
 			if !t.Range {
@@ -68,17 +85,17 @@ func canBeInstant(r *models.AlertRule) ([]optimization, bool) {
 
 		var validReducers bool
 		// Loop over all query nodes to find the reduce node.
-		for ii := range r.Data {
+		for ii := range queries {
 			// Second query part should be and expression.
-			if !expr.IsDataSource(r.Data[ii].DatasourceUID) {
+			if !expr.IsDataSource(queries[ii].DatasourceUID) {
 				continue
 			}
 			exprRaw := make(map[string]any)
-			if err := json.Unmarshal(r.Data[ii].Model, &exprRaw); err != nil {
+			if err := json.Unmarshal(queries[ii].Model, &exprRaw); err != nil {
 				continue
 			}
 			// Second query part should use first query part as expression.
-			if ref, ok := exprRaw["expression"].(string); !ok || ref != r.Data[i].RefID {
+			if ref, ok := exprRaw["expression"].(string); !ok || ref != queries[i].RefID {
 				continue
 			}
 			// Second query part should be "last()"
@@ -91,9 +108,10 @@ func canBeInstant(r *models.AlertRule) ([]optimization, bool) {
 		// If we found a reduce node that uses last, we can add the query to the optimizations.
 		if validReducers {
 			canBeOptimized = true
-			optimizableIndices = append(optimizableIndices, optimization{
-				i: i,
-				t: t.DS.Type,
+			optimizableIndices = append(optimizableIndices, Optimization{
+				RefID: queries[i].RefID,
+				i:     i,
+				t:     t.DS.Type,
 			})
 		}
 	}
@@ -101,10 +119,10 @@ func canBeInstant(r *models.AlertRule) ([]optimization, bool) {
 }
 
 // migrateToInstant will move the provided indices from a range-query to an instant query.
-func migrateToInstant(r *models.AlertRule, optimizations []optimization) error {
+func migrateToInstant(queries []models.AlertQuery, optimizations []Optimization) error {
 	for _, opti := range optimizations {
 		modelRaw := make(map[string]any)
-		if err := json.Unmarshal(r.Data[opti.i].Model, &modelRaw); err != nil {
+		if err := json.Unmarshal(queries[opti.i].Model, &modelRaw); err != nil {
 			return err
 		}
 		switch opti.t {
@@ -115,15 +133,15 @@ func migrateToInstant(r *models.AlertRule, optimizations []optimization) error {
 			if err != nil {
 				return err
 			}
-			r.Data[opti.i].Model = model
+			queries[opti.i].Model = model
 		case datasources.DS_LOKI:
 			modelRaw["queryType"] = "instant"
 			model, err := json.Marshal(modelRaw)
 			if err != nil {
 				return err
 			}
-			r.Data[opti.i].Model = model
-			r.Data[opti.i].QueryType = "instant"
+			queries[opti.i].Model = model
+			queries[opti.i].QueryType = "instant"
 		default:
 			return fmt.Errorf("optimization for datasource of type %s not possible", opti.t)
 		}


### PR DESCRIPTION
**What is this feature?**

Previously, query optimization was only applied to alert queries when scheduled and not when ran through `api/v1/eval` or `/api/v1/rule/test/grafana`. This PR fixes that by adding it to both of these endpoints.

**Why do we need this feature?**

This could lead to discrepancies between alert rule preview and scheduled alert results.

**Who is this feature for?**

Alerting users.

**Special notes for your reviewer:**

Preview before fix:
![Screenshot from 2023-11-22 16-05-01](https://github.com/grafana/grafana/assets/8484471/82b2a40d-c971-4648-8286-09e0c9234f98)

Resulting alert before & after fix (no change as we're just fixing the preview endpoints), note the alert is `NoData` but the preview is `Firing`:
![Screenshot from 2023-11-22 16-06-20](https://github.com/grafana/grafana/assets/8484471/55aa7339-3f32-4a51-b4e4-86899b8b53d4)

Preview after fix:
![2023-11-22_16-08](https://github.com/grafana/grafana/assets/8484471/96a502d3-e613-47cb-8b05-b0dfd17bee88)

