### PR TITLE
Data-trails: prevent creating new metrics node when clicking on historical metric node

### DIFF
--- a/public/app/features/trails/DataTrail.test.tsx
+++ b/public/app/features/trails/DataTrail.test.tsx
@@ -36,6 +36,10 @@ describe('DataTrail', () => {
       expect(trail.state.topScene).toBeInstanceOf(MetricSelectScene);
     });
 
+    it('Should set stepIndex to 0', () => {
+      expect(trail.state.stepIndex).toBe(0);
+    });
+
     describe('And metric is selected', () => {
       beforeEach(() => {
         trail.publishEvent(new MetricSelectedEvent('metric_bucket'));
@@ -53,6 +57,10 @@ describe('DataTrail', () => {
       it('should add history step', () => {
         expect(trail.state.history.state.steps[1].type).toBe('metric');
       });
+
+      it('Should set stepIndex to 1', () => {
+        expect(trail.state.stepIndex).toBe(1);
+      });
     });
 
     describe('When going back to history step', () => {
@@ -64,8 +72,11 @@ describe('DataTrail', () => {
 
       it('Should restore state and url', () => {
         expect(trail.state.metric).toBe('first_metric');
-        expect(trail.state.stepIndex).toBe(1);
         expect(locationService.getSearchObject().metric).toBe('first_metric');
+      });
+
+      it('Should set stepIndex to 1', () => {
+        expect(trail.state.stepIndex).toBe(1);
       });
 
       it('Should not create another history step', () => {

--- a/public/app/features/trails/DataTrail.test.tsx
+++ b/public/app/features/trails/DataTrail.test.tsx
@@ -1,0 +1,81 @@
+import { locationService, setDataSourceSrv } from '@grafana/runtime';
+import { getUrlSyncManager } from '@grafana/scenes';
+
+import { MockDataSourceSrv, mockDataSource } from '../alerting/unified/mocks';
+import { DataSourceType } from '../alerting/unified/utils/datasource';
+import { activateFullSceneTree } from '../dashboard-scene/utils/test-utils';
+
+import { DataTrail } from './DataTrail';
+import { MetricScene } from './MetricScene';
+import { MetricSelectScene } from './MetricSelectScene';
+import { MetricSelectedEvent } from './shared';
+
+describe('DataTrail', () => {
+  beforeAll(() => {
+    setDataSourceSrv(
+      new MockDataSourceSrv({
+        prom: mockDataSource({
+          name: 'Prometheus',
+          type: DataSourceType.Prometheus,
+        }),
+      })
+    );
+  });
+
+  describe('Given starting trail with url sync and no url state', () => {
+    let trail: DataTrail;
+
+    beforeEach(() => {
+      trail = new DataTrail({});
+      locationService.push('/');
+      getUrlSyncManager().initSync(trail);
+      activateFullSceneTree(trail);
+    });
+
+    it('Should default to metric select scene', () => {
+      expect(trail.state.topScene).toBeInstanceOf(MetricSelectScene);
+    });
+
+    describe('And metric is selected', () => {
+      beforeEach(() => {
+        trail.publishEvent(new MetricSelectedEvent('metric_bucket'));
+      });
+
+      it('should switch scene to MetricScene', () => {
+        expect(trail.state.metric).toBe('metric_bucket');
+        expect(trail.state.topScene).toBeInstanceOf(MetricScene);
+      });
+
+      it('should sync state with url', () => {
+        expect(locationService.getSearchObject().metric).toBe('metric_bucket');
+      });
+
+      it('should add history step', () => {
+        expect(trail.state.history.state.steps[1].type).toBe('metric');
+      });
+    });
+
+    describe('When going back to history step', () => {
+      beforeEach(() => {
+        trail.publishEvent(new MetricSelectedEvent('first_metric'));
+        trail.publishEvent(new MetricSelectedEvent('second_metric'));
+        trail.goBackToStep(trail.state.history.state.steps[1]);
+      });
+
+      it('Should restore state and url', () => {
+        expect(trail.state.metric).toBe('first_metric');
+        expect(trail.state.inHistory).toBe(true);
+        expect(locationService.getSearchObject().metric).toBe('first_metric');
+      });
+
+      it('Should not create another history step', () => {
+        expect(trail.state.history.state.steps.length).toBe(3);
+      });
+
+      it('But selecting a new metric should create another history step', () => {
+        trail.publishEvent(new MetricSelectedEvent('third_metric'));
+        expect(trail.state.history.state.steps.length).toBe(4);
+      });
+    });
+  });
+});

--- a/public/app/features/trails/DataTrail.test.tsx
+++ b/public/app/features/trails/DataTrail.test.tsx
@@ -64,7 +64,7 @@ describe('DataTrail', () => {
 
       it('Should restore state and url', () => {
         expect(trail.state.metric).toBe('first_metric');
-        expect(trail.state.inHistory).toBe(true);
+        expect(trail.state.stepIndex).toBe(1);
         expect(locationService.getSearchObject().metric).toBe('first_metric');
       });
 

--- a/public/app/features/trails/DataTrail.tsx
+++ b/public/app/features/trails/DataTrail.tsx
@@ -43,8 +43,8 @@ export interface DataTrailState extends SceneObjectState {
   // Synced with url
   metric?: string;
 
-  // Indicates that the new state is actually an historical state
-  inHistory?: boolean;
+  // Indicates which step in the data trail this is
+  stepIndex: number;
 }
 
 export class DataTrail extends SceneObjectBase<DataTrailState> {
@@ -62,18 +62,11 @@ export class DataTrail extends SceneObjectBase<DataTrailState> {
       ],
       history: state.history ?? new DataTrailHistory({}),
       settings: state.settings ?? new DataTrailSettings({}),
+      stepIndex: state.stepIndex ?? 0,
       ...state,
     });
 
     this.addActivationHandler(this._onActivate.bind(this));
-  }
-
-  public setState(state: Partial<DataTrailState>) {
-    super.setState({ ...state, inHistory: false });
-  }
-
-  private setStateFromHistory(state: Partial<DataTrailState>) {
-    super.setState({ ...state, inHistory: true });
   }
 
   public _onActivate() {
@@ -100,7 +93,7 @@ export class DataTrail extends SceneObjectBase<DataTrailState> {
       step.trailState.metric = undefined;
     }
 
-    this.setStateFromHistory(step.trailState);
+    this.setState(step.trailState);
 
     if (!this.state.embedded) {
       locationService.replace(getUrlForTrail(this));

--- a/public/app/features/trails/DataTrail.tsx
+++ b/public/app/features/trails/DataTrail.tsx
@@ -42,6 +42,9 @@ export interface DataTrailState extends SceneObjectState {
 
   // Synced with url
   metric?: string;
+
+  // Indicates that the new state is actually an historical state
+  inHistory?: boolean;
 }
 
 export class DataTrail extends SceneObjectBase<DataTrailState> {
@@ -89,7 +92,7 @@ export class DataTrail extends SceneObjectBase<DataTrailState> {
       step.trailState.metric = undefined;
     }
 
-    this.setState(step.trailState);
+    this.setState({ ...step.trailState, inHistory: true });
 
     if (!this.state.embedded) {
       locationService.replace(getUrlForTrail(this));

--- a/public/app/features/trails/DataTrail.tsx
+++ b/public/app/features/trails/DataTrail.tsx
@@ -68,6 +68,14 @@ export class DataTrail extends SceneObjectBase<DataTrailState> {
     this.addActivationHandler(this._onActivate.bind(this));
   }
 
+  public setState(state: Partial<DataTrailState>) {
+    super.setState({ ...state, inHistory: false });
+  }
+
+  private setStateFromHistory(state: Partial<DataTrailState>) {
+    super.setState({ ...state, inHistory: true });
+  }
+
   public _onActivate() {
     if (!this.state.topScene) {
       this.setState({ topScene: getTopSceneFor(this.state.metric) });
@@ -92,7 +100,7 @@ export class DataTrail extends SceneObjectBase<DataTrailState> {
       step.trailState.metric = undefined;
     }
 
-    this.setState({ ...step.trailState, inHistory: true });
+    this.setStateFromHistory(step.trailState);
 
     if (!this.state.embedded) {
       locationService.replace(getUrlForTrail(this));

--- a/public/app/features/trails/DataTrailsHistory.tsx
+++ b/public/app/features/trails/DataTrailsHistory.tsx
@@ -50,7 +50,11 @@ export class DataTrailHistory extends SceneObjectBase<DataTrailsHistoryState> {
           this.state.steps[0].trailState = sceneUtils.cloneSceneObjectState(oldState, { history: this });
         }
 
-        if (newState.metric && !newState.inHistory) {
+        // Check if new and old state are at the same step index
+        // Then we know this isn't a history transition
+        const isMovingThroughHistory = newState.stepIndex !== oldState.stepIndex;
+
+        if (newState.metric && !isMovingThroughHistory) {
           this.addTrailStep(trail, 'metric');
         }
       }
@@ -70,6 +74,10 @@ export class DataTrailHistory extends SceneObjectBase<DataTrailsHistoryState> {
   }
 
   public addTrailStep(trail: DataTrail, type: TrailStepType) {
+    const stepIndex = this.state.steps.length;
+    // Update the trail's current step state.  It is being given a step index.
+    trail.setState({ ...trail.state, stepIndex });
+
     this.setState({
       steps: [
         ...this.state.steps,

--- a/public/app/features/trails/DataTrailsHistory.tsx
+++ b/public/app/features/trails/DataTrailsHistory.tsx
@@ -50,7 +50,7 @@ export class DataTrailHistory extends SceneObjectBase<DataTrailsHistoryState> {
           this.state.steps[0].trailState = sceneUtils.cloneSceneObjectState(oldState, { history: this });
         }
 
-        if (newState.metric) {
+        if (newState.metric && !newState.inHistory) {
           this.addTrailStep(trail, 'metric');
         }
       }


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

In data trails, allows a user to navigate between historical changes in metrics without mistakenly creating a new node on each change.

When updating the state after clicking on a history node, it indicates through the state object that the current trail state is based on history, and not a new change. The state listener that would normally add a new metric node checks this history flag and acts accordingly.

**Why do we need this feature?**

Making a new node was not intended behavior. It should simply revert to the historical state.

**Who is this feature for?**

Users of data trails.

**Which issue(s) does this PR fix?**:


<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

- Fixes #78184

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
