### PR TITLE
VizLegend: Implement natural sort, simplify, optimize

### DIFF
--- a/.betterer.results
+++ b/.betterer.results
@@ -938,6 +938,12 @@ exports[`better eslint`] = {
     "packages/grafana-ui/src/components/VizLegend/VizLegendListItem.tsx:5381": [
       [0, 0, 0, "Use data-testid for E2E selectors instead of aria-label", "0"]
     ],
+    "packages/grafana-ui/src/components/VizLegend/VizLegendTable.tsx:5381": [
+      [0, 0, 0, "Do not use any type assertions.", "0"],
+      [0, 0, 0, "Do not use any type assertions.", "1"],
+      [0, 0, 0, "Do not use any type assertions.", "2"],
+      [0, 0, 0, "Do not use any type assertions.", "3"]
+    ],
     "packages/grafana-ui/src/components/VizLegend/types.ts:5381": [
       [0, 0, 0, "Unexpected any. Specify a different type.", "0"],
       [0, 0, 0, "Unexpected any. Specify a different type.", "1"]

--- a/packages/grafana-ui/src/components/VizLegend/VizLegendTable.tsx
+++ b/packages/grafana-ui/src/components/VizLegend/VizLegendTable.tsx
@@ -1,8 +1,7 @@
 import { css, cx } from '@emotion/css';
-import { orderBy } from 'lodash';
 import React from 'react';
 
-import { DisplayValue, GrafanaTheme2 } from '@grafana/data';
+import { GrafanaTheme2 } from '@grafana/data';
 
 import { useStyles2 } from '../../themes/ThemeContext';
 import { Icon } from '../Icon/Icon';

--- a/packages/grafana-ui/src/components/VizLegend/VizLegendTable.tsx
+++ b/packages/grafana-ui/src/components/VizLegend/VizLegendTable.tsx
@@ -10,6 +10,8 @@ import { Icon } from '../Icon/Icon';
 import { LegendTableItem } from './VizLegendTableItem';
 import { VizLegendTableProps } from './types';
 
+const nameSortKey = 'Name';
+
 /**
  * @internal
  */
@@ -27,18 +29,16 @@ export const VizLegendTable = <T extends unknown>({
   isSortable,
 }: VizLegendTableProps<T>): JSX.Element => {
   const styles = useStyles2(getStyles);
-  const stats: Record<string, DisplayValue> = {};
-  const nameSortKey = 'Name';
+  const header: Record<string, string> = {};
 
   if (isSortable) {
-    // placeholder displayValue for Name
-    stats[nameSortKey] = { description: 'name', numeric: 0, text: '' };
+    header[nameSortKey] = '';
   }
 
   for (const item of items) {
     if (item.getDisplayValues) {
       for (const displayValue of item.getDisplayValues()) {
-        stats[displayValue.title ?? '?'] = displayValue;
+        header[displayValue.title ?? '?'] = displayValue.description ?? '';
       }
     }
   }
@@ -83,26 +83,23 @@ export const VizLegendTable = <T extends unknown>({
       <thead>
         <tr>
           {!isSortable && <th></th>}
-          {Object.keys(stats).map((columnTitle) => {
-            const displayValue = stats[columnTitle];
-            return (
-              <th
-                title={displayValue.description}
-                key={columnTitle}
-                className={cx(styles.header, onToggleSort && styles.headerSortable, isSortable && styles.nameHeader, {
-                  [styles.withIcon]: sortKey === columnTitle,
-                })}
-                onClick={() => {
-                  if (onToggleSort) {
-                    onToggleSort(columnTitle);
-                  }
-                }}
-              >
-                {columnTitle}
-                {sortKey === columnTitle && <Icon size="xs" name={sortDesc ? 'angle-down' : 'angle-up'} />}
-              </th>
-            );
-          })}
+          {Object.keys(header).map((columnTitle) => (
+            <th
+              title={header[columnTitle]}
+              key={columnTitle}
+              className={cx(styles.header, onToggleSort && styles.headerSortable, isSortable && styles.nameHeader, {
+                [styles.withIcon]: sortKey === columnTitle,
+              })}
+              onClick={() => {
+                if (onToggleSort) {
+                  onToggleSort(columnTitle);
+                }
+              }}
+            >
+              {columnTitle}
+              {sortKey === columnTitle && <Icon size="xs" name={sortDesc ? 'angle-down' : 'angle-up'} />}
+            </th>
+          ))}
         </tr>
       </thead>
       <tbody>{sortedItems.map(itemRenderer!)}</tbody>


### PR DESCRIPTION
alternative approach to https://github.com/grafana/grafana/pull/78494

<details><summary>legend-calcs.json</summary>

```json
{
  "annotations": {
    "list": [
      {
        "builtIn": 1,
        "datasource": {
          "type": "grafana",
          "uid": "-- Grafana --"
        },
        "enable": true,
        "hide": true,
        "iconColor": "rgba(0, 211, 255, 1)",
        "name": "Annotations & Alerts",
        "target": {
          "limit": 100,
          "matchAny": false,
          "tags": [],
          "type": "dashboard"
        },
        "type": "dashboard"
      }
    ]
  },
  "editable": true,
  "fiscalYearStartMonth": 0,
  "graphTooltip": 0,
  "id": 588,
  "links": [],
  "liveNow": false,
  "panels": [
    {
      "datasource": {
        "type": "grafana-testdata-datasource",
        "uid": "PD8C576611E62080A"
      },
      "fieldConfig": {
        "defaults": {
          "color": {
            "mode": "palette-classic"
          },
          "custom": {
            "axisBorderShow": false,
            "axisCenteredZero": false,
            "axisColorMode": "text",
            "axisLabel": "",
            "axisPlacement": "auto",
            "barAlignment": 0,
            "drawStyle": "line",
            "fillOpacity": 0,
            "gradientMode": "none",
            "hideFrom": {
              "legend": false,
              "tooltip": false,
              "viz": false
            },
            "insertNulls": false,
            "lineInterpolation": "linear",
            "lineWidth": 1,
            "pointSize": 5,
            "scaleDistribution": {
              "type": "linear"
            },
            "showPoints": "auto",
            "spanNulls": false,
            "stacking": {
              "group": "A",
              "mode": "none"
            },
            "thresholdsStyle": {
              "mode": "off"
            }
          },
          "mappings": [],
          "thresholds": {
            "mode": "absolute",
            "steps": [
              {
                "color": "green",
                "value": null
              },
              {
                "color": "red",
                "value": 80
              }
            ]
          }
        },
        "overrides": []
      },
      "gridPos": {
        "h": 23,
        "w": 17,
        "x": 0,
        "y": 0
      },
      "id": 2,
      "maxDataPoints": 10,
      "options": {
        "legend": {
          "calcs": [
            "last",
            "first",
            "mean"
          ],
          "displayMode": "table",
          "placement": "right",
          "showLegend": true
        },
        "tooltip": {
          "mode": "single",
          "sort": "none"
        }
      },
      "targets": [
        {
          "datasource": {
            "type": "grafana-testdata-datasource",
            "uid": "PD8C576611E62080A"
          },
          "noise": 1000,
          "refId": "A",
          "scenarioId": "random_walk",
          "seriesCount": 30,
          "spread": 100
        }
      ],
      "title": "Panel Title",
      "type": "timeseries"
    }
  ],
  "refresh": "",
  "revision": 1,
  "schemaVersion": 39,
  "tags": [],
  "templating": {
    "list": []
  },
  "time": {
    "from": "now-6h",
    "to": "now"
  },
  "timepicker": {},
  "timezone": "",
  "title": "legend-calcs",
  "uid": "qXFG4jT4k",
  "version": 5,
  "weekStart": ""
}
```
</details>

may be easiest to review each commit by itself. also hide whitespace changes:

![image](https://github.com/grafana/grafana/assets/43234/f03e3a1d-79d7-4299-8d30-22f32f4c208c)