### PR TITLE
Variables: Remove alpha flag from variable support API

### DIFF
--- a/packages/grafana-data/src/types/variables.ts
+++ b/packages/grafana-data/src/types/variables.ts
@@ -14,8 +14,6 @@ import { DataQuery } from './query';
 
 /**
  * Enum with the different variable support types
- *
- * @alpha -- experimental
  */
 export enum VariableSupportType {
   Legacy = 'legacy',
@@ -26,8 +24,6 @@ export enum VariableSupportType {
 
 /**
  * Base class for VariableSupport classes
- *
- * @alpha -- experimental
  */
 export abstract class VariableSupportBase<
   DSType extends DataSourceApi<TQuery, TOptions>,
@@ -44,8 +40,6 @@ export abstract class VariableSupportBase<
 
 /**
  * Extend this class in a data source plugin to use the standard query editor for Query variables
- *
- * @alpha -- experimental
  */
 export abstract class StandardVariableSupport<
   DSType extends DataSourceApi<TQuery, TOptions>,
@@ -62,8 +56,6 @@ export abstract class StandardVariableSupport<
 
 /**
  * Extend this class in a data source plugin to use a customized query editor for Query variables
- *
- * @alpha -- experimental
  */
 export abstract class CustomVariableSupport<
   DSType extends DataSourceApi<TQuery, TOptions>,
@@ -89,8 +81,6 @@ export abstract class CustomVariableSupport<
 
 /**
  * Extend this class in a data source plugin to use the query editor in the data source plugin for Query variables
- *
- * @alpha -- experimental
  */
 export abstract class DataSourceVariableSupport<
   DSType extends DataSourceApi<TQuery, TOptions>,
@@ -104,8 +94,6 @@ export abstract class DataSourceVariableSupport<
 
 /**
  * Defines the standard DatQuery used by data source plugins that implement StandardVariableSupport
- *
- * @alpha -- experimental
  */
 export interface StandardVariableQuery extends DataQuery {
   query: string;


### PR DESCRIPTION

**What is this feature?**

Removes the `@alpha` flag from the variable support api. 

**Why do we need this feature?**

The variable support API was introduced in 2020 and it's used across many data sources, so it should be considered stable by now. 

**Who is this feature for?**

Datasource plugin developers. 

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Wonder if we should also remove the [setVariableQueryEditor](https://github.com/grafana/grafana/blob/main/packages/grafana-data/src/types/datasource.ts#L101-L107) method? It's been marked as deprecated since 2020. 

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
