### PR TITLE
Lock when cleaning-up external services

### DIFF
--- a/pkg/services/extsvcauth/registry/service_test.go
+++ b/pkg/services/extsvcauth/registry/service_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/grafana/grafana/pkg/infra/log"
+	"github.com/grafana/grafana/pkg/infra/serverlock"
 	"github.com/grafana/grafana/pkg/services/extsvcauth"
 	"github.com/grafana/grafana/pkg/services/extsvcauth/tests"
 	"github.com/grafana/grafana/pkg/services/featuremgmt"
@@ -18,6 +19,14 @@ type TestEnv struct {
 	saReg    *tests.ExternalServiceRegistryMock
 }
 
+// Never lock in tests
+type fakeServerLock struct{}
+
+func (f *fakeServerLock) LockExecuteAndReleaseWithRetries(ctx context.Context, actionName string, timeConfig serverlock.LockTimeConfig, fn func(ctx context.Context), retryOpts ...serverlock.RetryOpt) error {
+	fn(ctx)
+	return nil
+}
+
 func setupTestEnv(t *testing.T) *TestEnv {
 	env := TestEnv{}
 	env.oauthReg = tests.NewExternalServiceRegistryMock(t)
@@ -28,6 +37,7 @@ func setupTestEnv(t *testing.T) *TestEnv {
 		oauthReg:        env.oauthReg,
 		saReg:           env.saReg,
 		extSvcProviders: map[string]extsvcauth.AuthProvider{},
+		serverLock:      &fakeServerLock{},
 	}
 	return &env
 }


### PR DESCRIPTION
Follow up of https://github.com/grafana/grafana/pull/78425

Wraps clean-up of external service accounts in a lock to avoid data races on HA setups.
