### PR TITLE
mssql: adjust unit test to minimize xorm-usage

### DIFF
--- a/pkg/tsdb/mssql/mssql_test.go
+++ b/pkg/tsdb/mssql/mssql_test.go
@@ -463,7 +463,6 @@ func TestMSSQL(t *testing.T) {
 				m.TimeFloat32, m.TimeFloat32Nullable,
 				m.Measurement, m.ValueOne, m.ValueTwo)
 			require.NoError(t, err)
-
 		}
 
 		t.Run("When doing a metric query using epoch (int64) as time column and value column (int64) should return metric with time in time.Time", func(t *testing.T) {

--- a/pkg/tsdb/mssql/mssql_test.go
+++ b/pkg/tsdb/mssql/mssql_test.go
@@ -63,6 +63,7 @@ func TestMSSQL(t *testing.T) {
 
 	sess := x.NewSession()
 	t.Cleanup(sess.Close)
+	db := sess.DB()
 
 	fromStart := time.Date(2018, 3, 15, 13, 0, 0, 0, time.UTC).In(time.Local)
 
@@ -105,7 +106,7 @@ func TestMSSQL(t *testing.T) {
 					)
 				`
 
-		_, err := sess.Exec(sql)
+		_, err := db.Exec(sql)
 		require.NoError(t, err)
 
 		dt := time.Date(2018, 3, 14, 21, 20, 6, 527e6, time.UTC)
@@ -127,7 +128,7 @@ func TestMSSQL(t *testing.T) {
 					CONVERT(uniqueidentifier, '%s')
 		`, d, d2, d, d, d, d2, uuid)
 
-		_, err = sess.Exec(sql)
+		_, err = db.Exec(sql)
 		require.NoError(t, err)
 
 		t.Run("When doing a table query should map MSSQL column types to Go types", func(t *testing.T) {
@@ -194,7 +195,7 @@ func TestMSSQL(t *testing.T) {
 							)
 						`
 
-		_, err := sess.Exec(sql)
+		_, err := db.Exec(sql)
 		require.NoError(t, err)
 
 		type metric struct {
@@ -220,8 +221,10 @@ func TestMSSQL(t *testing.T) {
 			})
 		}
 
-		_, err = sess.InsertMulti(series)
-		require.NoError(t, err)
+		for _, m := range series {
+			_, err := db.Exec(`INSERT INTO metric ("time", value) VALUES (?, ?)`, m.Time.UTC(), m.Value)
+			require.NoError(t, err)
+		}
 
 		t.Run("When doing a metric query using timeGroup", func(t *testing.T) {
 			query := &backend.QueryDataRequest{
@@ -391,13 +394,17 @@ func TestMSSQL(t *testing.T) {
 			ValueTwo            int64 `xorm:"integer 'valueTwo'"`
 		}
 
-		exists, err := sess.IsTableExist(metric_values{})
+		_, err := db.Exec("DROP TABLE IF EXISTS metric_values")
 		require.NoError(t, err)
-		if exists {
-			err := sess.DropTable(metric_values{})
-			require.NoError(t, err)
-		}
-		err = sess.CreateTable(metric_values{})
+		_, err = db.Exec(`CREATE TABLE metric_values (
+			"time" DATETIME NULL,
+			timeInt64 BIGINT NOT NULL, timeInt64Nullable BIGINT NULL,
+			timeFloat64 FLOAT NOT NULL, timeFloat64Nullable FLOAT NULL,
+			timeInt32 INT NOT NULL, timeInt32Nullable INT NULL,
+			timeFloat32 FLOAT(11) NOT NULL, timeFloat32Nullable FLOAT(11) NULL,
+			measurement VARCHAR(255) NULL, valueOne INTEGER NULL, valueTwo INTEGER NULL
+		);
+		`)
 		require.NoError(t, err)
 
 		rng := rand.New(rand.NewSource(time.Now().Unix()))
@@ -440,8 +447,24 @@ func TestMSSQL(t *testing.T) {
 			series = append(series, &second)
 		}
 
-		_, err = sess.InsertMulti(series)
-		require.NoError(t, err)
+		for _, m := range series {
+			_, err := db.Exec(`INSERT INTO metric_values (
+					"time",
+					timeInt64, timeInt64Nullable,
+					timeFloat64, timeFloat64Nullable,
+					timeInt32, timeInt32Nullable,
+					timeFloat32, timeFloat32Nullable,
+					measurement, valueOne, valueTwo
+				) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+			`, m.Time,
+				m.TimeInt64, m.TimeInt64Nullable,
+				m.TimeFloat64, m.TimeFloat64Nullable,
+				m.TimeInt32, m.TimeInt32Nullable,
+				m.TimeFloat32, m.TimeFloat32Nullable,
+				m.Measurement, m.ValueOne, m.ValueTwo)
+			require.NoError(t, err)
+
+		}
 
 		t.Run("When doing a metric query using epoch (int64) as time column and value column (int64) should return metric with time in time.Time", func(t *testing.T) {
 			query := &backend.QueryDataRequest{
@@ -747,7 +770,7 @@ func TestMSSQL(t *testing.T) {
 									DROP PROCEDURE sp_test_epoch
 							`
 
-			_, err := sess.Exec(sql)
+			_, err := db.Exec(sql)
 			require.NoError(t, err)
 
 			sql = `
@@ -781,7 +804,7 @@ func TestMSSQL(t *testing.T) {
 				END
 			`
 
-			_, err = sess.Exec(sql)
+			_, err = db.Exec(sql)
 			require.NoError(t, err)
 
 			t.Run("When doing a metric query using stored procedure should return correct result", func(t *testing.T) {
@@ -837,7 +860,7 @@ func TestMSSQL(t *testing.T) {
 									DROP PROCEDURE sp_test_datetime
 							`
 
-			_, err := sess.Exec(sql)
+			_, err := db.Exec(sql)
 			require.NoError(t, err)
 
 			sql = `
@@ -871,7 +894,7 @@ func TestMSSQL(t *testing.T) {
 				END
 			`
 
-			_, err = sess.Exec(sql)
+			_, err = db.Exec(sql)
 			require.NoError(t, err)
 
 			t.Run("When doing a metric query using stored procedure should return correct result", func(t *testing.T) {
@@ -924,7 +947,7 @@ func TestMSSQL(t *testing.T) {
 			)
 		`
 
-		_, err := sess.Exec(sql)
+		_, err := db.Exec(sql)
 		require.NoError(t, err)
 
 		type event struct {
@@ -953,7 +976,7 @@ func TestMSSQL(t *testing.T) {
 							VALUES(%d, '%s', '%s')
 						`, e.TimeSec, e.Description, e.Tags)
 
-			_, err = sess.Exec(sql)
+			_, err = db.Exec(sql)
 			require.NoError(t, err)
 		}
 
@@ -1266,18 +1289,10 @@ func TestMSSQL(t *testing.T) {
 	})
 
 	t.Run("Given an empty table", func(t *testing.T) {
-		type emptyObj struct {
-			EmptyKey string
-			EmptyVal int64
-		}
-
-		exists, err := sess.IsTableExist(emptyObj{})
+		_, err := db.Exec("DROP TABLE IF EXISTS empty_obj")
 		require.NoError(t, err)
-		if exists {
-			err := sess.DropTable(emptyObj{})
-			require.NoError(t, err)
-		}
-		err = sess.CreateTable(emptyObj{})
+
+		_, err = db.Exec("CREATE TABLE empty_obj (empty_key VARCHAR(255) NULL, empty_val BIGINT NULL)")
 		require.NoError(t, err)
 
 		t.Run("When no rows are returned, should return an empty frame", func(t *testing.T) {


### PR DESCRIPTION
we are planning to remove the usage of the `xorm` library from the sql datasource plugins (mysql, mssql, postgres), because it's a library provided by core-grafana in this case.. see a proof-of-concept of this at https://github.com/grafana/grafana/pull/77870 .

as you can see, we do not really use `xorm` in the datasource plugins. but, we do use it in the plugin unit tests. so we need to remove it from there too.

this pull request removes the usage of `xorm` from the `mssql` unit test. please note, we cannot completely remove `xorm`  from  `mssql_test.go` yet, because the rest of the datasource plugin still has `xorm` in it. but, we ask `xorm` to give us a "raw" database connection at the beginning, and then only use it. this way, when we do the full migration, we only need to change 2-3 lines of code in this file.

how to test:
1. `make devenv sources=mssql_tests`
    - (note: not the normal `mssql`, it is `mssql_tests` in this case)
    - (note: if you are on an arm-macbook and this refuses to run correctly, try this: https://github.com/microsoft/mssql-docker/issues/668#issuecomment-1412206521)
3. `GRAFANA_TEST_DB=mssql go test -v  ./pkg/tsdb/mssql`

NOTE: if you want to compare the the sql output from the old version, you can add `x.ShowSQL(true)` somewhere in the test-file, and then `xorm` will provide the SQL output in the debug-output.


(this is part of the unit-test "trilogy", the others are https://github.com/grafana/grafana/pull/78064 and https://github.com/grafana/grafana/pull/78537)