### PR TITLE
Remote Alertmanager(refactor): Only parse the URL once

### DIFF
--- a/pkg/services/ngalert/remote/alertmanager.go
+++ b/pkg/services/ngalert/remote/alertmanager.go
@@ -55,24 +55,24 @@ func NewAlertmanager(cfg AlertmanagerConfig, orgID int64) (*Alertmanager, error)
 	}
 
 	if cfg.URL == "" {
-		return nil, fmt.Errorf("empty URL for tenant %s", cfg.TenantID)
+		return nil, fmt.Errorf("empty remote Alertmanager URL for tenant '%s'", cfg.TenantID)
+	}
+
+	u, err := url.Parse(cfg.URL)
+	if err != nil {
+		return nil, fmt.Errorf("unable to parse remote Alertmanager URL: %w", err)
 	}
 
 	logger := log.New("ngalert.remote.alertmanager")
 
 	mcCfg := &mimirClient.Config{
-		Address:  cfg.URL,
+		URL:      u,
 		TenantID: cfg.TenantID,
 		Password: cfg.BasicAuthPassword,
 		Logger:   logger,
 	}
 
 	mc, err := mimirClient.New(mcCfg)
-	if err != nil {
-		return nil, err
-	}
-
-	u, err := url.Parse(cfg.URL)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/services/ngalert/remote/alertmanager_test.go
+++ b/pkg/services/ngalert/remote/alertmanager_test.go
@@ -3,7 +3,6 @@ package remote
 import (
 	"context"
 	"crypto/md5"
-	"errors"
 	"fmt"
 	"math/rand"
 	"net/http"
@@ -38,7 +37,15 @@ func TestNewAlertmanager(t *testing.T) {
 			tenantID: "1234",
 			password: "test",
 			orgID:    1,
-			expErr:   "empty URL for tenant 1234",
+			expErr:   "empty remote Alertmanager URL for tenant '1234'",
+		},
+		{
+			name:     "invalid URL",
+			url:      "asdasd%sasdsd",
+			tenantID: "1234",
+			password: "test",
+			orgID:    1,
+			expErr:   "unable to parse remote Alertmanager URL: parse \"asdasd%sasdsd\": invalid URL escape \"%sa\"",
 		},
 		{
 			name:     "valid parameters",
@@ -392,37 +399,5 @@ func genAlert(active bool, labels map[string]string) amv2.PostableAlert {
 			GeneratorURL: "http://localhost:8080",
 			Labels:       labels,
 		},
-	}
-}
-
-func TestNewAlertmanager1(t *testing.T) {
-	orgID := int64(1)
-	tc := []struct {
-		name        string
-		cfg         AlertmanagerConfig
-		expectedErr error
-	}{
-		{
-			name:        "when no tenant ID is given - it fails",
-			expectedErr: errors.New("empty remote Alertmanager URL for tenant ''"),
-		},
-		{
-			name:        "when no URL is given - it fails",
-			cfg:         AlertmanagerConfig{TenantID: "user"},
-			expectedErr: errors.New("empty remote Alertmanager URL for tenant 'user'"),
-		},
-		{
-			name:        "when no valid URL is given - it fails",
-			cfg:         AlertmanagerConfig{TenantID: "user", URL: "asdasd%sasdsd"},
-			expectedErr: errors.New("unable to parse remote Alertmanager URL: parse \"asdasd%sasdsd\": invalid URL escape \"%sa\""),
-		},
-	}
-
-	for _, tt := range tc {
-		t.Run(tt.name, func(t *testing.T) {
-			_, err := NewAlertmanager(tt.cfg, orgID)
-
-			require.EqualError(t, tt.expectedErr, err.Error())
-		})
 	}
 }

--- a/pkg/services/ngalert/remote/client/mimir.go
+++ b/pkg/services/ngalert/remote/client/mimir.go
@@ -32,7 +32,7 @@ type Mimir struct {
 }
 
 type Config struct {
-	Address  string
+	URL      *url.URL
 	TenantID string
 	Password string
 
@@ -61,11 +61,6 @@ func (e *errorResponse) Error() string {
 }
 
 func New(cfg *Config) (*Mimir, error) {
-	endpoint, err := url.Parse(cfg.Address)
-	if err != nil {
-		return nil, err
-	}
-
 	rt := &MimirAuthRoundTripper{
 		TenantID: cfg.TenantID,
 		Password: cfg.Password,
@@ -77,7 +72,7 @@ func New(cfg *Config) (*Mimir, error) {
 	}
 
 	return &Mimir{
-		endpoint: endpoint,
+		endpoint: cfg.URL,
 		client:   c,
 		logger:   cfg.Logger,
 	}, nil


### PR DESCRIPTION
Exactly what it says in the tin.