### PR TITLE
DashboardScene: Add time picker keybindings

### DIFF
--- a/packages/grafana-data/src/datetime/rangeutil.test.ts
+++ b/packages/grafana-data/src/datetime/rangeutil.test.ts
@@ -1,8 +1,8 @@
 import { RawTimeRange, TimeRange } from '../types/time';
 
-import { timeRangeToRelative } from './rangeutil';
+import { timeRangeToRelative, zoomOutTimeRange } from './rangeutil';
 
-import { dateTime, rangeUtil } from './index';
+import { dateTime, rangeUtil, toUtc } from './index';
 
 describe('Range Utils', () => {
   // These tests probably wrap the dateTimeParser tests to some extent
@@ -273,6 +273,34 @@ describe('Range Utils', () => {
 
       expect(relativeTimeRange.from).toEqual(1209600);
       expect(relativeTimeRange.to).toEqual(604800);
+    });
+  });
+
+  describe('zoomOutTimeRange', () => {
+    it('calculates zoomed time range correctly', () => {
+      // 07:48:27 on Dec 17 - 07:48:27 on Dec 18
+      const from = dateTime('2023-12-17T07:48:27.433Z');
+      const to = dateTime('2023-12-18T07:48:27.433Z');
+
+      const timeRange = {
+        from,
+        to,
+        raw: { from, to },
+      };
+      // zoom out by 2
+      const zoomedTimeRange = zoomOutTimeRange(timeRange, 2);
+
+      // 19:48:27 on Dec 16 - 19:48:27 on Dec 18
+      const zoomedFrom = dateTime('2023-12-16T19:48:27.433Z').valueOf();
+      const zoomedTo = dateTime('2023-12-18T19:48:27.433Z').valueOf();
+      expect(zoomedTimeRange).toEqual({
+        from: toUtc(zoomedFrom),
+        to: toUtc(zoomedTo),
+        raw: {
+          from: toUtc(zoomedFrom),
+          to: toUtc(zoomedTo),
+        },
+      });
     });
   });
 });

--- a/packages/grafana-data/src/datetime/rangeutil.test.ts
+++ b/packages/grafana-data/src/datetime/rangeutil.test.ts
@@ -1,8 +1,8 @@
 import { RawTimeRange, TimeRange } from '../types/time';
 
-import { timeRangeToRelative, zoomOutTimeRange } from './rangeutil';
+import { timeRangeToRelative } from './rangeutil';
 
-import { dateTime, rangeUtil, toUtc } from './index';
+import { dateTime, rangeUtil } from './index';
 
 describe('Range Utils', () => {
   // These tests probably wrap the dateTimeParser tests to some extent
@@ -273,34 +273,6 @@ describe('Range Utils', () => {
 
       expect(relativeTimeRange.from).toEqual(1209600);
       expect(relativeTimeRange.to).toEqual(604800);
-    });
-  });
-
-  describe('zoomOutTimeRange', () => {
-    it('calculates zoomed time range correctly', () => {
-      // 07:48:27 on Dec 17 - 07:48:27 on Dec 18
-      const from = dateTime('2023-12-17T07:48:27.433Z');
-      const to = dateTime('2023-12-18T07:48:27.433Z');
-
-      const timeRange = {
-        from,
-        to,
-        raw: { from, to },
-      };
-      // zoom out by 2
-      const zoomedTimeRange = zoomOutTimeRange(timeRange, 2);
-
-      // 19:48:27 on Dec 16 - 19:48:27 on Dec 18
-      const zoomedFrom = dateTime('2023-12-16T19:48:27.433Z').valueOf();
-      const zoomedTo = dateTime('2023-12-18T19:48:27.433Z').valueOf();
-      expect(zoomedTimeRange).toEqual({
-        from: toUtc(zoomedFrom),
-        to: toUtc(zoomedTo),
-        raw: {
-          from: toUtc(zoomedFrom),
-          to: toUtc(zoomedTo),
-        },
-      });
     });
   });
 });

--- a/packages/grafana-data/src/datetime/rangeutil.ts
+++ b/packages/grafana-data/src/datetime/rangeutil.ts
@@ -214,7 +214,7 @@ export const convertRawToRange = (
   return { from, to, raw: { from, to } };
 };
 
-function isRelativeTime(v: DateTime | string) {
+export function isRelativeTime(v: DateTime | string) {
   if (typeof v === 'string') {
     return v.indexOf('now') >= 0;
   }

--- a/packages/grafana-data/src/datetime/rangeutil.ts
+++ b/packages/grafana-data/src/datetime/rangeutil.ts
@@ -4,7 +4,7 @@ import { RawTimeRange, TimeRange, TimeZone, IntervalValues, RelativeTimeRange, T
 
 import * as dateMath from './datemath';
 import { timeZoneAbbrevation, dateTimeFormat, dateTimeFormatTimeAgo } from './formatter';
-import { isDateTime, DateTime, dateTime, toUtc } from './moment_wrapper';
+import { isDateTime, DateTime, dateTime } from './moment_wrapper';
 import { dateTimeParse } from './parser';
 
 const spans: { [key: string]: { display: string; section?: number } } = {
@@ -468,16 +468,4 @@ export function relativeToTimeRange(relativeTimeRange: RelativeTimeRange, now: D
     to,
     raw: { from, to },
   };
-}
-
-export function zoomOutTimeRange(timeRange: TimeRange, factor: number): TimeRange {
-  const timespan = timeRange.to.valueOf() - timeRange.from.valueOf();
-  const center = timeRange.to.valueOf() - timespan / 2;
-  // If the timepsan is 0, zooming out would do nothing, so we force a zoom out to 30s
-  const newTimespan = timespan === 0 ? 30000 : timespan * factor;
-
-  const to = center + newTimespan / 2;
-  const from = center - newTimespan / 2;
-
-  return { from: toUtc(from), to: toUtc(to), raw: { from: toUtc(from), to: toUtc(to) } };
 }

--- a/packages/grafana-data/src/datetime/rangeutil.ts
+++ b/packages/grafana-data/src/datetime/rangeutil.ts
@@ -4,7 +4,7 @@ import { RawTimeRange, TimeRange, TimeZone, IntervalValues, RelativeTimeRange, T
 
 import * as dateMath from './datemath';
 import { timeZoneAbbrevation, dateTimeFormat, dateTimeFormatTimeAgo } from './formatter';
-import { isDateTime, DateTime, dateTime } from './moment_wrapper';
+import { isDateTime, DateTime, dateTime, toUtc } from './moment_wrapper';
 import { dateTimeParse } from './parser';
 
 const spans: { [key: string]: { display: string; section?: number } } = {
@@ -468,4 +468,16 @@ export function relativeToTimeRange(relativeTimeRange: RelativeTimeRange, now: D
     to,
     raw: { from, to },
   };
+}
+
+export function zoomOutTimeRange(timeRange: TimeRange, factor: number): TimeRange {
+  const timespan = timeRange.to.valueOf() - timeRange.from.valueOf();
+  const center = timeRange.to.valueOf() - timespan / 2;
+  // If the timepsan is 0, zooming out would do nothing, so we force a zoom out to 30s
+  const newTimespan = timespan === 0 ? 30000 : timespan * factor;
+
+  const to = center + newTimespan / 2;
+  const from = center - newTimespan / 2;
+
+  return { from: toUtc(from), to: toUtc(to), raw: { from: toUtc(from), to: toUtc(to) } };
 }

--- a/packages/grafana-ui/src/components/DateTimePickers/TimeRangePicker.tsx
+++ b/packages/grafana-ui/src/components/DateTimePickers/TimeRangePicker.tsx
@@ -5,7 +5,6 @@ import { useOverlay } from '@react-aria/overlays';
 import React, { memo, createRef, useState, useEffect } from 'react';
 
 import {
-  isDateTime,
   rangeUtil,
   GrafanaTheme2,
   dateTimeFormat,
@@ -294,6 +293,3 @@ const getLabelStyles = (theme: GrafanaTheme2) => {
     }),
   };
 };
-function isRelativeTime(from: string | import('@grafana/data').DateTime) {
-  throw new Error('Function not implemented.');
-}

--- a/packages/grafana-ui/src/components/DateTimePickers/TimeRangePicker.tsx
+++ b/packages/grafana-ui/src/components/DateTimePickers/TimeRangePicker.tsx
@@ -108,7 +108,8 @@ export function TimeRangePicker(props: TimeRangePickerProps) {
 
   const styles = useStyles2(getStyles);
   const { modalBackdrop } = useStyles2(getModalStyles);
-  const hasAbsolute = isDateTime(value.raw.from) || isDateTime(value.raw.to);
+  const hasAbsolute = !rangeUtil.isRelativeTime(value.raw.from) || !rangeUtil.isRelativeTime(value.raw.to);
+
   const variant = isSynced ? 'active' : isOnCanvas ? 'canvas' : 'default';
 
   const currentTimeRange = formattedRange(value, timeZone);
@@ -293,3 +294,6 @@ const getLabelStyles = (theme: GrafanaTheme2) => {
     }),
   };
 };
+function isRelativeTime(from: string | import('@grafana/data').DateTime) {
+  throw new Error('Function not implemented.');
+}

--- a/public/app/features/dashboard-scene/scene/keyboardShortcuts.ts
+++ b/public/app/features/dashboard-scene/scene/keyboardShortcuts.ts
@@ -1,3 +1,4 @@
+import { rangeUtil } from '@grafana/data';
 import { locationService } from '@grafana/runtime';
 import { sceneGraph, VizPanel } from '@grafana/scenes';
 import { OptionsWithLegend } from '@grafana/schema';
@@ -79,6 +80,20 @@ export function setupKeyboardShortcuts(scene: DashboardScene) {
     onTrigger: () => sceneGraph.getTimeRange(scene).onRefresh(),
   });
 
+  // Zoom out
+  keybindings.addBinding({
+    key: 't z',
+    onTrigger: () => {
+      handleZoomOut(scene);
+    },
+  });
+  keybindings.addBinding({
+    key: 'ctrl+z',
+    onTrigger: () => {
+      handleZoomOut(scene);
+    },
+  });
+
   // Dashboard settings
   keybindings.addBinding({
     key: 'd s',
@@ -127,4 +142,10 @@ export function toggleVizPanelLegend(vizPanel: VizPanel) {
 
 function hasLegendOptions(optionsWithLegend: unknown): optionsWithLegend is OptionsWithLegend {
   return optionsWithLegend != null && typeof optionsWithLegend === 'object' && 'legend' in optionsWithLegend;
+}
+
+function handleZoomOut(scene: DashboardScene) {
+  const timeRange = sceneGraph.getTimeRange(scene);
+  const zoomedTimeRange = rangeUtil.zoomOutTimeRange(timeRange.state.value, 2);
+  timeRange.onTimeRangeChange(zoomedTimeRange);
 }

--- a/public/app/features/dashboard-scene/scene/keyboardShortcuts.ts
+++ b/public/app/features/dashboard-scene/scene/keyboardShortcuts.ts
@@ -1,17 +1,14 @@
-import { rangeUtil } from '@grafana/data';
 import { locationService } from '@grafana/runtime';
-import { sceneGraph, SceneTimePicker, VizPanel } from '@grafana/scenes';
+import { sceneGraph, VizPanel } from '@grafana/scenes';
 import { OptionsWithLegend } from '@grafana/schema';
 import { KeybindingSet } from 'app/core/services/KeybindingSet';
 
 import { ShareModal } from '../sharing/ShareModal';
+import { dashboardSceneGraph } from '../utils/dashboardSceneGraph';
 import { getDashboardUrl, getInspectUrl, getViewPanelUrl, tryGetExploreUrlForPanel } from '../utils/urlBuilders';
 import { getPanelIdForVizPanel } from '../utils/utils';
 
 import { DashboardScene } from './DashboardScene';
-import { DashboardControls } from './DashboardControls';
-import { time } from 'console';
-import { dashboardSceneGraph } from '../utils/dashboardSceneGraph';
 
 export function setupKeyboardShortcuts(scene: DashboardScene) {
   const keybindings = new KeybindingSet();

--- a/public/app/features/dashboard-scene/scene/keyboardShortcuts.ts
+++ b/public/app/features/dashboard-scene/scene/keyboardShortcuts.ts
@@ -1,6 +1,6 @@
 import { rangeUtil } from '@grafana/data';
 import { locationService } from '@grafana/runtime';
-import { sceneGraph, VizPanel } from '@grafana/scenes';
+import { sceneGraph, SceneTimePicker, VizPanel } from '@grafana/scenes';
 import { OptionsWithLegend } from '@grafana/schema';
 import { KeybindingSet } from 'app/core/services/KeybindingSet';
 
@@ -9,6 +9,9 @@ import { getDashboardUrl, getInspectUrl, getViewPanelUrl, tryGetExploreUrlForPan
 import { getPanelIdForVizPanel } from '../utils/utils';
 
 import { DashboardScene } from './DashboardScene';
+import { DashboardControls } from './DashboardControls';
+import { time } from 'console';
+import { dashboardSceneGraph } from '../utils/dashboardSceneGraph';
 
 export function setupKeyboardShortcuts(scene: DashboardScene) {
   const keybindings = new KeybindingSet();
@@ -94,6 +97,20 @@ export function setupKeyboardShortcuts(scene: DashboardScene) {
     },
   });
 
+  keybindings.addBinding({
+    key: 't left',
+    onTrigger: () => {
+      handleTimeRangeShift(scene, 'left');
+    },
+  });
+
+  keybindings.addBinding({
+    key: 't right',
+    onTrigger: () => {
+      handleTimeRangeShift(scene, 'right');
+    },
+  });
+
   // Dashboard settings
   keybindings.addBinding({
     key: 'd s',
@@ -145,7 +162,21 @@ function hasLegendOptions(optionsWithLegend: unknown): optionsWithLegend is Opti
 }
 
 function handleZoomOut(scene: DashboardScene) {
-  const timeRange = sceneGraph.getTimeRange(scene);
-  const zoomedTimeRange = rangeUtil.zoomOutTimeRange(timeRange.state.value, 2);
-  timeRange.onTimeRangeChange(zoomedTimeRange);
+  const timePicker = dashboardSceneGraph.getTimePicker(scene);
+  timePicker?.onZoom();
+}
+
+function handleTimeRangeShift(scene: DashboardScene, direction: 'left' | 'right') {
+  const timePicker = dashboardSceneGraph.getTimePicker(scene);
+
+  if (!timePicker) {
+    return;
+  }
+
+  if (direction === 'left') {
+    timePicker.onMoveBackward();
+  }
+  if (direction === 'right') {
+    timePicker.onMoveForward();
+  }
 }

--- a/public/app/features/dashboard-scene/utils/dashboardSceneGraph.test.ts
+++ b/public/app/features/dashboard-scene/utils/dashboardSceneGraph.test.ts
@@ -1,0 +1,39 @@
+import { DashboardDataDTO } from 'app/types';
+
+import dashboard_to_load from '../serialization/testfiles/dashboard_to_load1.json';
+import { transformSaveModelToScene } from '../serialization/transformSaveModelToScene';
+
+import { dashboardSceneGraph } from './dashboardSceneGraph';
+
+describe('dashboardSceneGraph', () => {
+  describe('getTimePicker', () => {
+    it('should return null if no time picker', () => {
+      const dashboard: DashboardDataDTO = {
+        ...(dashboard_to_load as unknown as DashboardDataDTO),
+        timepicker: {
+          hidden: true,
+          collapse: false,
+          refresh_intervals: [],
+          time_options: [],
+        },
+      };
+
+      const scene = transformSaveModelToScene({
+        dashboard: dashboard as unknown as DashboardDataDTO,
+        meta: {},
+      });
+
+      const timePicker = dashboardSceneGraph.getTimePicker(scene);
+      expect(timePicker).toBeNull();
+    });
+
+    it('should return time picker', () => {
+      const scene = transformSaveModelToScene({
+        dashboard: dashboard_to_load as unknown as DashboardDataDTO,
+        meta: {},
+      });
+      const timePicker = dashboardSceneGraph.getTimePicker(scene);
+      expect(timePicker).not.toBeNull();
+    });
+  });
+});

--- a/public/app/features/dashboard-scene/utils/dashboardSceneGraph.ts
+++ b/public/app/features/dashboard-scene/utils/dashboardSceneGraph.ts
@@ -1,0 +1,22 @@
+import { SceneTimePicker } from '@grafana/scenes';
+
+import { DashboardControls } from '../scene/DashboardControls';
+import { DashboardScene } from '../scene/DashboardScene';
+
+function getTimePicker(scene: DashboardScene) {
+  const controls = scene.state.controls;
+
+  if (controls && controls[0] instanceof DashboardControls) {
+    const dashboardControls = controls[0];
+    const timePicker = dashboardControls.state.timeControls.find((c) => c instanceof SceneTimePicker);
+    if (timePicker && timePicker instanceof SceneTimePicker) {
+      return timePicker;
+    }
+  }
+
+  return null;
+}
+
+export const dashboardSceneGraph = {
+  getTimePicker,
+};


### PR DESCRIPTION
This adds 
- a keybinding (ctrl+z, t z) to allow time range zoom out in dashboard scene.
- a keybinding (t left, tright) for navigating time range back and forth

~Additionally, it adds a zoom function [that's currently implemented in scenes](https://github.com/grafana/scenes/blob/main/packages/scenes/src/components/SceneTimePicker.tsx#L74) to grafana/data `rangeUtil` so that it can be reused.~

It adds `dashboardSceneGraph` utility that will allow us to traverse the specific DashboardScene hierarchy. For now I've just added `getTimePicker` and respective tests. 
