### PR TITLE
Plugins: Only set non-existing headers for core plugin requests

### DIFF
--- a/pkg/services/pluginsintegration/clientmiddleware/httpclient_middleware.go
+++ b/pkg/services/pluginsintegration/clientmiddleware/httpclient_middleware.go
@@ -50,7 +50,10 @@ func (m *HTTPClientMiddleware) applyHeaders(ctx context.Context, pReq any) conte
 
 			if h, ok := pReq.(backend.ForwardHTTPHeaders); ok {
 				for k, v := range h.GetHTTPHeaders() {
-					req.Header[k] = v
+					// Only set a header if it is not already set.
+					if req.Header.Get(k) == "" {
+						req.Header[k] = v
+					}
 				}
 			}
 

--- a/pkg/services/pluginsintegration/clientmiddleware/httpclient_middleware_test.go
+++ b/pkg/services/pluginsintegration/clientmiddleware/httpclient_middleware_test.go
@@ -263,14 +263,12 @@ func TestHTTPClientMiddleware(t *testing.T) {
 				require.Equal(t, forwardPluginRequestHTTPHeaders, middlewares[0].(httpclient.MiddlewareName).MiddlewareName())
 
 				reqClone := req.Clone(req.Context())
-				// Create a header on the request as if it had been set by some other logic e.g. preceding middleware
-				reqClone.Header.Set(backend.OAuthIdentityTokenHeaderName, "bearer test-token")
 				res, err := middlewares[0].CreateMiddleware(httpclient.Options{}, finalRoundTripper).RoundTrip(reqClone)
 				require.NoError(t, err)
 				require.NoError(t, res.Body.Close())
 				require.Len(t, reqClone.Header, 5)
 				require.Equal(t, "true", reqClone.Header.Get(ngalertmodels.FromAlertHeaderName))
-				require.Equal(t, "bearer test-token", reqClone.Header.Get(backend.OAuthIdentityTokenHeaderName))
+				require.Equal(t, "bearer token", reqClone.Header.Get(backend.OAuthIdentityTokenHeaderName))
 				require.Equal(t, "id-token", reqClone.Header.Get(backend.OAuthIdentityIDTokenHeaderName))
 				require.Equal(t, "uname", reqClone.Header.Get(proxyutil.UserHeaderName))
 				require.Len(t, reqClone.Cookies(), 3)
@@ -293,12 +291,14 @@ func TestHTTPClientMiddleware(t *testing.T) {
 				require.Equal(t, forwardPluginRequestHTTPHeaders, middlewares[0].(httpclient.MiddlewareName).MiddlewareName())
 
 				reqClone := req.Clone(req.Context())
+				// Create a header on the request as if it had been set by some other logic e.g. preceding middleware
+				reqClone.Header.Set(backend.OAuthIdentityTokenHeaderName, "bearer test-token")
 				res, err := middlewares[0].CreateMiddleware(httpclient.Options{}, finalRoundTripper).RoundTrip(reqClone)
 				require.NoError(t, err)
 				require.NoError(t, res.Body.Close())
 				require.Len(t, reqClone.Header, 5)
 				require.Equal(t, "true", reqClone.Header.Get(ngalertmodels.FromAlertHeaderName))
-				require.Equal(t, "bearer token", reqClone.Header.Get(backend.OAuthIdentityTokenHeaderName))
+				require.Equal(t, "bearer test-token", reqClone.Header.Get(backend.OAuthIdentityTokenHeaderName))
 				require.Equal(t, "id-token", reqClone.Header.Get(backend.OAuthIdentityIDTokenHeaderName))
 				require.Equal(t, "uname", reqClone.Header.Get(proxyutil.UserHeaderName))
 				require.Len(t, reqClone.Cookies(), 3)

--- a/pkg/services/pluginsintegration/clientmiddleware/httpclient_middleware_test.go
+++ b/pkg/services/pluginsintegration/clientmiddleware/httpclient_middleware_test.go
@@ -263,6 +263,36 @@ func TestHTTPClientMiddleware(t *testing.T) {
 				require.Equal(t, forwardPluginRequestHTTPHeaders, middlewares[0].(httpclient.MiddlewareName).MiddlewareName())
 
 				reqClone := req.Clone(req.Context())
+				// Create a header on the request as if it had been set by some other logic e.g. preceding middleware
+				reqClone.Header.Set(backend.OAuthIdentityTokenHeaderName, "bearer test-token")
+				res, err := middlewares[0].CreateMiddleware(httpclient.Options{}, finalRoundTripper).RoundTrip(reqClone)
+				require.NoError(t, err)
+				require.NoError(t, res.Body.Close())
+				require.Len(t, reqClone.Header, 5)
+				require.Equal(t, "true", reqClone.Header.Get(ngalertmodels.FromAlertHeaderName))
+				require.Equal(t, "bearer test-token", reqClone.Header.Get(backend.OAuthIdentityTokenHeaderName))
+				require.Equal(t, "id-token", reqClone.Header.Get(backend.OAuthIdentityIDTokenHeaderName))
+				require.Equal(t, "uname", reqClone.Header.Get(proxyutil.UserHeaderName))
+				require.Len(t, reqClone.Cookies(), 3)
+				require.Equal(t, "cookie1", reqClone.Cookies()[0].Name)
+				require.Equal(t, "cookie2", reqClone.Cookies()[1].Name)
+				require.Equal(t, "cookie3", reqClone.Cookies()[2].Name)
+			})
+
+			t.Run("Should not overwrite an existing header", func(t *testing.T) {
+				_, err = cdt.Decorator.CheckHealth(req.Context(), &backend.CheckHealthRequest{
+					PluginContext: pluginCtx,
+					Headers:       headers,
+				})
+				require.NoError(t, err)
+				require.NotNil(t, cdt.CheckHealthReq)
+				require.Len(t, cdt.CheckHealthReq.Headers, 6)
+
+				middlewares := httpclient.ContextualMiddlewareFromContext(cdt.QueryDataCtx)
+				require.Len(t, middlewares, 1)
+				require.Equal(t, forwardPluginRequestHTTPHeaders, middlewares[0].(httpclient.MiddlewareName).MiddlewareName())
+
+				reqClone := req.Clone(req.Context())
 				res, err := middlewares[0].CreateMiddleware(httpclient.Options{}, finalRoundTripper).RoundTrip(reqClone)
 				require.NoError(t, err)
 				require.NoError(t, res.Body.Close())


### PR DESCRIPTION
Fixes #78629 

When a plugin request has headers that have been set by some logic in the plugin or some other middleware this change prevents the `HTTPClient` middleware from overwriting those headers. This is the same logic as that which already exists in the plugin-sdk.