### PR TITLE
Azure Monitor: Add Azure Infrastructure Monitoring Dashboard 

### DIFF
--- a/public/app/plugins/datasource/azuremonitor/dashboards/infrastructureMonitoring.json
+++ b/public/app/plugins/datasource/azuremonitor/dashboards/infrastructureMonitoring.json
@@ -1,0 +1,6556 @@
+{
+    "__inputs": [],
+    "__elements": {},
+    "__requires": [
+      {
+        "type": "panel",
+        "id": "bargauge",
+        "name": "Bar gauge",
+        "version": ""
+      },
+      {
+        "type": "grafana",
+        "id": "grafana",
+        "name": "Grafana",
+        "version": "9.5.13"
+      },
+      {
+        "type": "datasource",
+        "id": "grafana-azure-monitor-datasource",
+        "name": "Azure Monitor",
+        "version": "1.0.0"
+      },
+      {
+        "type": "panel",
+        "id": "stat",
+        "name": "Stat",
+        "version": ""
+      },
+      {
+        "type": "panel",
+        "id": "text",
+        "name": "Text",
+        "version": ""
+      }
+    ],
+    "description": "This dashboard displays traffic-light indicators to show the health of your Azure infrastructure resources based on key performance indicators and thresholds defined for each infrastructure resource type.",
+    "editable": true,
+    "id": null,
+    "links": [],
+    "liveNow": true,
+    "panels": [
+      {
+        "gridPos": {
+          "h": 3,
+          "w": 11,
+          "x": 0,
+          "y": 0
+        },
+        "id": 1,
+        "options": {
+          "code": {
+            "language": "plaintext",
+            "showLineNumbers": false,
+            "showMiniMap": false
+          },
+          "content": "<p style=\"font-size:30px;color:rgb(87, 148, 242);\">Azure Infrastructure - Monitoring Dashboard</p>",
+          "mode": "markdown"
+        },
+        "transparent": true,
+        "type": "text"
+      },
+      {
+        "gridPos": {
+          "h": 3,
+          "w": 13,
+          "x": 11,
+          "y": 0
+        },
+        "id": 90,
+        "options": {
+          "code": {
+            "language": "plaintext",
+            "showLineNumbers": false,
+            "showMiniMap": false
+          },
+          "content": "#### Welcome to the Azure Infrastructure Monitoring Dashboard!    Select a data source and subscription to see the current status of your infrastructure resources.  Examine the key performance indicators for your resources by expanding the row for a resource type.",
+          "mode": "markdown"
+        },
+        "transparent": true,
+        "type": "text"
+      },
+      {
+        "datasource": {
+          "type": "grafana-azure-monitor-datasource",
+          "uid": "${ds}"
+        },
+        "description": "",
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "mode": "thresholds"
+            },
+            "links": [],
+            "mappings": [
+              {
+                "options": {
+                  "0": {
+                    "index": 0,
+                    "text": "Healthy"
+                  },
+                  "1": {
+                    "index": 1,
+                    "text": "Warning"
+                  }
+                },
+                "type": "value"
+              },
+              {
+                "options": {
+                  "from": 2,
+                  "result": {
+                    "index": 2,
+                    "text": "Unhealthy"
+                  },
+                  "to": 4
+                },
+                "type": "range"
+              }
+            ],
+            "max": 4,
+            "min": 0,
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "#808080",
+                  "value": null
+                },
+                {
+                  "color": "dark-green",
+                  "value": 0
+                },
+                {
+                  "color": "dark-yellow",
+                  "value": 1
+                },
+                {
+                  "color": "dark-red",
+                  "value": 2
+                }
+              ]
+            }
+          },
+          "overrides": []
+        },
+        "gridPos": {
+          "h": 3,
+          "w": 3,
+          "x": 0,
+          "y": 3
+        },
+        "id": 2,
+        "links": [],
+        "options": {
+          "colorMode": "background_solid",
+          "graphMode": "none",
+          "justifyMode": "auto",
+          "orientation": "auto",
+          "reduceOptions": {
+            "calcs": [
+              "max"
+            ],
+            "fields": "",
+            "values": false
+          },
+          "textMode": "auto"
+        },
+        "targets": [
+          {
+            "azureLogAnalytics": {
+              "query": "let insight_table = InsightsMetrics\r\n| where _ResourceId has '/microsoft.compute/virtualmachines/'\r\n| where Origin == \"vm.azm.ms\"\r\n| where Namespace == \"Processor\" and Name == \"UtilizationPercentage\"\r\n| extend Resource = toupper(tostring(split(_ResourceId,'/')[8]));\r\nAzureMetrics\r\n| where _ResourceId has '/microsoft.compute/virtualmachines/'\r\n| where MetricName in('Percentage CPU', 'Available Memory Bytes', 'VmAvailabilityMetric')\r\n| union kind=outer insight_table\r\n| summarize\r\n  kpi1 = avgif(Average, MetricName == 'Percentage CPU'),\r\n  kpi2 = percentile(Val, 95),\r\n  kpi3 = avgif(Average/1000000000, MetricName == 'Available Memory Bytes'),\r\n  kpi4 = avgif(Average*100, MetricName == 'VmAvailabilityMetric') by _ResourceId, Resource\r\n|extend kpi1 = iff(isnan(kpi1), 0.0, kpi1)\r\n|extend kpi2 = iff(isnan(kpi2), 0.0, kpi2) \r\n|extend kpi3 = iff(isnan(kpi3), 0.0, kpi3) \r\n|extend kpi4 = iff(isnan(kpi4), 0.0, kpi4) \r\n|extend health1 = iff(kpi1>80, 1, 0)\r\n|extend health2 = iff(kpi2>85, 1, 0)\r\n|extend health3 = iff(kpi3<1, 1, 0)\r\n|extend health4 = iff(kpi4<90, 1, 0)\r\n|extend health = health1 + health2 + health3 + health4",
+              "resources": [
+                "/subscriptions/$sub"
+              ]
+            },
+            "datasource": {
+              "type": "grafana-azure-monitor-datasource",
+              "uid": "${ds}"
+            },
+            "queryType": "Azure Log Analytics",
+            "refId": "A",
+            "subscriptions": [
+              "ebb79bc0-aa86-44a7-8111-cabbe0c43993"
+            ]
+          }
+        ],
+        "title": "Virtual Machines",
+        "transformations": [
+          {
+            "id": "organize",
+            "options": {
+              "excludeByName": {
+                "A": false,
+                "Resource": true,
+                "_ResourceId": true,
+                "health1": true,
+                "health2": true,
+                "health3": true,
+                "health4": true,
+                "kpi1": true,
+                "kpi2": true,
+                "kpi3": true,
+                "kpi4": true
+              },
+              "indexByName": {},
+              "renameByName": {
+                "A": " ",
+                "health": " "
+              }
+            }
+          }
+        ],
+        "transparent": true,
+        "type": "stat"
+      },
+      {
+        "datasource": {
+          "type": "grafana-azure-monitor-datasource",
+          "uid": "${ds}"
+        },
+        "description": "",
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "mode": "thresholds"
+            },
+            "links": [],
+            "mappings": [
+              {
+                "options": {
+                  "0": {
+                    "index": 0,
+                    "text": "Healthy"
+                  },
+                  "1": {
+                    "index": 1,
+                    "text": "Warning"
+                  }
+                },
+                "type": "value"
+              },
+              {
+                "options": {
+                  "from": 2,
+                  "result": {
+                    "index": 2,
+                    "text": "Unhealthy"
+                  },
+                  "to": 4
+                },
+                "type": "range"
+              }
+            ],
+            "max": 4,
+            "min": 0,
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "#808080",
+                  "value": null
+                },
+                {
+                  "color": "dark-green",
+                  "value": 0
+                },
+                {
+                  "color": "dark-yellow",
+                  "value": 1
+                },
+                {
+                  "color": "dark-red",
+                  "value": 2
+                }
+              ]
+            }
+          },
+          "overrides": []
+        },
+        "gridPos": {
+          "h": 3,
+          "w": 3,
+          "x": 3,
+          "y": 3
+        },
+        "id": 27,
+        "links": [],
+        "options": {
+          "colorMode": "background_solid",
+          "graphMode": "none",
+          "justifyMode": "auto",
+          "orientation": "auto",
+          "reduceOptions": {
+            "calcs": [
+              "max"
+            ],
+            "fields": "",
+            "values": false
+          },
+          "textMode": "auto"
+        },
+        "targets": [
+          {
+            "azureLogAnalytics": {
+              "query": "let stroage_table = StorageBlobLogs \r\n    | where StatusText != 'Success'\r\n    | extend ErrorCounter = 1\r\n    | extend ResourceName = AccountName\r\n    | extend _ResourceId = trim('/blobservices/default', _ResourceId)\r\n    | extend _ResourceId = trim('/queueservices/default', _ResourceId)\r\n    | extend _ResourceId = trim('/tableservices/default', _ResourceId)\r\n    | extend _ResourceId = trim('/fileservices/default', _ResourceId)\r\n    | project TimeGenerated, ResourceName, StatusText, ErrorCounter, _ResourceId;\r\nAzureMetrics\r\n| where _ResourceId has '/microsoft.storage/'\r\n| where MetricName in('SuccessE2ELatency', 'UsedCapacity', 'Availability')\r\n| extend ResourceName = tostring(split(_ResourceId,'/')[8])\r\n| extend _ResourceId = trim('/blobservices/default', _ResourceId)\r\n| extend _ResourceId = trim('/queueservices/default', _ResourceId)\r\n| extend _ResourceId = trim('/tableservices/default', _ResourceId)\r\n| extend _ResourceId = trim('/fileservices/default', _ResourceId)\r\n| project ResourceName, _ResourceId, MetricName, Average, Total\r\n| union kind=outer stroage_table\r\n| summarize\r\n  kpi1 = avgif(Average, MetricName == 'SuccessE2ELatency'),\r\n  kpi2 = sumif(ErrorCounter, isnotnull(ErrorCounter)),\r\n  kpi3 = avgif(Average, MetricName == 'UsedCapacity'),\r\n  kpi4 = avgif(Average, MetricName == 'Availability') by _ResourceId, ResourceName\r\n|extend kpi1 = iff(isnan(kpi1), 0.0, kpi1)\r\n|extend kpi2 = iff(isnan(toreal(kpi2)), 0.0, toreal(kpi2)) \r\n|extend kpi3 = iff(isnan(kpi3), 0.0, kpi3) \r\n|extend kpi4 = iff(isnan(kpi4), 0.0, kpi4) \r\n|extend health1 = iff(kpi1>5000, 1, 0)\r\n|extend health2 = iff(kpi2>500, 1, 0)\r\n|extend health3 = iff(kpi3>4000000000000000, 1, 0)\r\n|extend health4 = iff(kpi4<90, 1, 0)\r\n|extend health = health1 + health2 + health3 + health4",
+              "resources": [
+                "/subscriptions/$sub"
+              ]
+            },
+            "datasource": {
+              "type": "grafana-azure-monitor-datasource",
+              "uid": "${ds}"
+            },
+            "queryType": "Azure Log Analytics",
+            "refId": "A",
+            "subscriptions": [
+              "ebb79bc0-aa86-44a7-8111-cabbe0c43993"
+            ]
+          }
+        ],
+        "title": "Storage",
+        "transformations": [
+          {
+            "id": "organize",
+            "options": {
+              "excludeByName": {
+                "A": false,
+                "Resource": true,
+                "ResourceName": true,
+                "_ResourceId": true,
+                "health1": true,
+                "health2": true,
+                "health3": true,
+                "health4": true,
+                "kpi1": true,
+                "kpi2": true,
+                "kpi3": true,
+                "kpi4": true
+              },
+              "indexByName": {},
+              "renameByName": {
+                "A": " ",
+                "health": " "
+              }
+            }
+          }
+        ],
+        "transparent": true,
+        "type": "stat"
+      },
+      {
+        "datasource": {
+          "type": "grafana-azure-monitor-datasource",
+          "uid": "${ds}"
+        },
+        "description": "",
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "mode": "thresholds"
+            },
+            "links": [],
+            "mappings": [
+              {
+                "options": {
+                  "0": {
+                    "index": 0,
+                    "text": "Healthy"
+                  },
+                  "1": {
+                    "index": 1,
+                    "text": "Warning"
+                  }
+                },
+                "type": "value"
+              },
+              {
+                "options": {
+                  "from": 2,
+                  "result": {
+                    "index": 2,
+                    "text": "Unhealthy"
+                  },
+                  "to": 3
+                },
+                "type": "range"
+              }
+            ],
+            "max": 3,
+            "min": 0,
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "#808080",
+                  "value": null
+                },
+                {
+                  "color": "dark-green",
+                  "value": 0
+                },
+                {
+                  "color": "dark-yellow",
+                  "value": 1
+                },
+                {
+                  "color": "dark-red",
+                  "value": 2
+                }
+              ]
+            }
+          },
+          "overrides": []
+        },
+        "gridPos": {
+          "h": 3,
+          "w": 3,
+          "x": 6,
+          "y": 3
+        },
+        "id": 36,
+        "links": [],
+        "options": {
+          "colorMode": "background_solid",
+          "graphMode": "none",
+          "justifyMode": "auto",
+          "orientation": "auto",
+          "reduceOptions": {
+            "calcs": [
+              "max"
+            ],
+            "fields": "",
+            "values": false
+          },
+          "textMode": "auto"
+        },
+        "targets": [
+          {
+            "azureLogAnalytics": {
+              "query": "AzureMetrics\r\n| where _ResourceId has '/microsoft.network/loadbalancers/'\r\n| where MetricName in('UsedSnatPorts', 'DipAvailability', 'VipAvailability')\r\n| summarize\r\n  kpi1 = avgif(Average, MetricName == 'UsedSnatPorts'),\r\n  kpi2 = avgif(Average, MetricName == 'DipAvailability'),\r\n  kpi3 = avgif(Average, MetricName == 'VipAvailability') by _ResourceId, Resource\r\n|extend kpi1 = iff(isnan(kpi1), 0.0, kpi1)\r\n|extend kpi2 = iff(isnan(kpi2), 0.0, kpi2) \r\n|extend kpi3 = iff(isnan(kpi3), 0.0, kpi3)  \r\n|extend health1 = iff(kpi1>900, 1, 0)\r\n|extend health2 = iff(kpi2<=50, 1, 0)\r\n|extend health3 = iff(kpi3<50, 1, 0)\r\n|extend health = health1 + health2 + health3",
+              "resources": [
+                "/subscriptions/$sub"
+              ]
+            },
+            "datasource": {
+              "type": "grafana-azure-monitor-datasource",
+              "uid": "${ds}"
+            },
+            "queryType": "Azure Log Analytics",
+            "refId": "A",
+            "subscriptions": [
+              "ebb79bc0-aa86-44a7-8111-cabbe0c43993"
+            ]
+          }
+        ],
+        "title": "Load Balancers",
+        "transformations": [
+          {
+            "id": "organize",
+            "options": {
+              "excludeByName": {
+                "A": false,
+                "Resource": true,
+                "_ResourceId": true,
+                "health1": true,
+                "health2": true,
+                "health3": true,
+                "kpi1": true,
+                "kpi2": true,
+                "kpi3": true
+              },
+              "indexByName": {},
+              "renameByName": {
+                "A": " ",
+                "health": " "
+              }
+            }
+          }
+        ],
+        "transparent": true,
+        "type": "stat"
+      },
+      {
+        "datasource": {
+          "type": "grafana-azure-monitor-datasource",
+          "uid": "${ds}"
+        },
+        "description": "",
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "mode": "thresholds"
+            },
+            "links": [],
+            "mappings": [
+              {
+                "options": {
+                  "0": {
+                    "index": 0,
+                    "text": "Healthy"
+                  },
+                  "1": {
+                    "index": 1,
+                    "text": "Warning"
+                  }
+                },
+                "type": "value"
+              },
+              {
+                "options": {
+                  "from": 2,
+                  "result": {
+                    "index": 2,
+                    "text": "Unhealthy"
+                  },
+                  "to": 3
+                },
+                "type": "range"
+              }
+            ],
+            "max": 3,
+            "min": 0,
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "#808080",
+                  "value": null
+                },
+                {
+                  "color": "dark-green",
+                  "value": 0
+                },
+                {
+                  "color": "dark-yellow",
+                  "value": 1
+                },
+                {
+                  "color": "dark-red",
+                  "value": 2
+                }
+              ]
+            }
+          },
+          "overrides": []
+        },
+        "gridPos": {
+          "h": 3,
+          "w": 3,
+          "x": 9,
+          "y": 3
+        },
+        "id": 41,
+        "links": [],
+        "options": {
+          "colorMode": "background_solid",
+          "graphMode": "none",
+          "justifyMode": "auto",
+          "orientation": "auto",
+          "reduceOptions": {
+            "calcs": [
+              "max"
+            ],
+            "fields": "",
+            "values": false
+          },
+          "textMode": "auto"
+        },
+        "targets": [
+          {
+            "azureLogAnalytics": {
+              "query": "AzureMetrics\r\n| where _ResourceId has '/microsoft.network/applicationgateways/'\r\n| where MetricName in('UnhealthyHostCount', 'FailedRequests', 'HealthyHostCount')\r\n| summarize\r\n  kpi1 = avgif(Average, MetricName == 'UnhealthyHostCount'),\r\n  kpi2 = sumif(Total, MetricName == 'FailedRequests'),\r\n  kpi3 = avgif(Average, MetricName == 'HealthyHostCount') by _ResourceId, Resource\r\n|extend kpi1 = iff(isnan(kpi1), 0.0, kpi1)\r\n|extend kpi2 = iff(isnan(kpi2), 0.0, kpi2) \r\n|extend kpi3 = iff(isnan(kpi3), 0.0, kpi3)  \r\n|extend health1 = iff(kpi1>=1, 1, 0)\r\n|extend health2 = iff(kpi2>10, 1, 0)\r\n|extend health3 = iff(kpi3<=0, 1, 0)\r\n|extend health = health1 + health2 + health3",
+              "resources": [
+                "/subscriptions/$sub"
+              ]
+            },
+            "datasource": {
+              "type": "grafana-azure-monitor-datasource",
+              "uid": "${ds}"
+            },
+            "queryType": "Azure Log Analytics",
+            "refId": "A",
+            "subscriptions": [
+              "ebb79bc0-aa86-44a7-8111-cabbe0c43993"
+            ]
+          }
+        ],
+        "title": "Application Gateways",
+        "transformations": [
+          {
+            "id": "organize",
+            "options": {
+              "excludeByName": {
+                "A": false,
+                "Resource": true,
+                "_ResourceId": true,
+                "health1": true,
+                "health2": true,
+                "health3": true,
+                "kpi1": true,
+                "kpi2": true,
+                "kpi3": true
+              },
+              "indexByName": {},
+              "renameByName": {
+                "A": " ",
+                "health": " "
+              }
+            }
+          }
+        ],
+        "transparent": true,
+        "type": "stat"
+      },
+      {
+        "datasource": {
+          "type": "grafana-azure-monitor-datasource",
+          "uid": "${ds}"
+        },
+        "description": "",
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "mode": "thresholds"
+            },
+            "links": [],
+            "mappings": [
+              {
+                "options": {
+                  "0": {
+                    "index": 0,
+                    "text": "Healthy"
+                  },
+                  "1": {
+                    "index": 1,
+                    "text": "Warning"
+                  }
+                },
+                "type": "value"
+              },
+              {
+                "options": {
+                  "from": 2,
+                  "result": {
+                    "index": 2,
+                    "text": "Unhealthy"
+                  },
+                  "to": 3
+                },
+                "type": "range"
+              }
+            ],
+            "max": 3,
+            "min": 0,
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "#808080",
+                  "value": null
+                },
+                {
+                  "color": "dark-green",
+                  "value": 0
+                },
+                {
+                  "color": "dark-yellow",
+                  "value": 1
+                },
+                {
+                  "color": "dark-red",
+                  "value": 2
+                }
+              ]
+            }
+          },
+          "overrides": []
+        },
+        "gridPos": {
+          "h": 3,
+          "w": 3,
+          "x": 12,
+          "y": 3
+        },
+        "id": 50,
+        "links": [],
+        "options": {
+          "colorMode": "background_solid",
+          "graphMode": "none",
+          "justifyMode": "auto",
+          "orientation": "auto",
+          "reduceOptions": {
+            "calcs": [
+              "max"
+            ],
+            "fields": "",
+            "values": false
+          },
+          "textMode": "auto"
+        },
+        "targets": [
+          {
+            "azureLogAnalytics": {
+              "query": "AzureMetrics\r\n| where _ResourceId has '/microsoft.network/publicipaddresses/'\r\n| where MetricName in('VipAvailability', 'IfUnderDDoSAttack', 'PacketsInDDoS')\r\n| summarize\r\n  kpi1 = avgif(Average, MetricName == 'VipAvailability'),\r\n  kpi2 = avgif(Maximum, MetricName == 'IfUnderDDoSAttack'),\r\n  kpi3 = avgif(Total, MetricName == 'PacketsInDDoS') by _ResourceId, Resource\r\n|extend kpi1 = iff(isnan(kpi1), 0.0, kpi1)\r\n|extend kpi2 = iff(isnan(kpi2), 0.0, kpi2)\r\n|extend kpi3 = iff(isnan(kpi3), 0.0, kpi3)\r\n|extend health1 = iff(kpi1<100, 1, 0)\r\n|extend health2 = iff(kpi2>0, 1, 0)\r\n|extend health3 = iff(kpi3>=1000, 1, 0)\r\n|extend health = health1 + health2 + health3",
+              "resources": [
+                "/subscriptions/$sub"
+              ]
+            },
+            "datasource": {
+              "type": "grafana-azure-monitor-datasource",
+              "uid": "${ds}"
+            },
+            "queryType": "Azure Log Analytics",
+            "refId": "A",
+            "subscriptions": [
+              "ebb79bc0-aa86-44a7-8111-cabbe0c43993"
+            ]
+          }
+        ],
+        "title": "Public IPs",
+        "transformations": [
+          {
+            "id": "organize",
+            "options": {
+              "excludeByName": {
+                "A": false,
+                "Resource": true,
+                "_ResourceId": true,
+                "health1": true,
+                "health2": true,
+                "health3": true,
+                "kpi1": true,
+                "kpi2": true,
+                "kpi3": true
+              },
+              "indexByName": {},
+              "renameByName": {
+                "A": " ",
+                "health": " "
+              }
+            }
+          }
+        ],
+        "transparent": true,
+        "type": "stat"
+      },
+      {
+        "datasource": {
+          "type": "grafana-azure-monitor-datasource",
+          "uid": "${ds}"
+        },
+        "description": "",
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "mode": "thresholds"
+            },
+            "links": [],
+            "mappings": [
+              {
+                "options": {
+                  "0": {
+                    "index": 0,
+                    "text": "Healthy"
+                  },
+                  "1": {
+                    "index": 1,
+                    "text": "Warning"
+                  }
+                },
+                "type": "value"
+              },
+              {
+                "options": {
+                  "from": 2,
+                  "result": {
+                    "index": 2,
+                    "text": "Unhealthy"
+                  },
+                  "to": 3
+                },
+                "type": "range"
+              }
+            ],
+            "max": 3,
+            "min": 0,
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "#808080",
+                  "value": null
+                },
+                {
+                  "color": "dark-green",
+                  "value": 0
+                },
+                {
+                  "color": "dark-yellow",
+                  "value": 1
+                },
+                {
+                  "color": "dark-red",
+                  "value": 2
+                }
+              ]
+            }
+          },
+          "overrides": []
+        },
+        "gridPos": {
+          "h": 3,
+          "w": 3,
+          "x": 15,
+          "y": 3
+        },
+        "id": 54,
+        "links": [],
+        "options": {
+          "colorMode": "background_solid",
+          "graphMode": "none",
+          "justifyMode": "auto",
+          "orientation": "auto",
+          "reduceOptions": {
+            "calcs": [
+              "max"
+            ],
+            "fields": "",
+            "values": false
+          },
+          "textMode": "auto"
+        },
+        "targets": [
+          {
+            "azureLogAnalytics": {
+              "query": "AzureMetrics\r\n| where _ResourceId has '/microsoft.network/virtualnetworks/'\r\n| where MetricName in('IfUnderDDoSAttack', 'PacketsInDDoS', 'PacketsForwardedDDoS')\r\n| summarize\r\n  kpi1 = avgif(Maximum, MetricName == 'IfUnderDDoSAttack'),\r\n  kpi2 = avgif(Maximum, MetricName == 'PacketsInDDoS'),\r\n  kpi3 = avgif(Maximum, MetricName == 'PacketsForwardedDDoS') by _ResourceId, Resource\r\n|extend kpi1 = iff(isnan(kpi1), 0.0, kpi1)\r\n|extend kpi2 = iff(isnan(kpi2), 0.0, kpi2) \r\n|extend kpi3 = iff(isnan(kpi3), 0.0, kpi3)\r\n|extend health1 = iff(kpi1>0, 1, 0)\r\n|extend health2 = iff(kpi2>=1000, 1, 0)\r\n|extend health3 = iff(kpi3>1, 1, 0)\r\n|extend health = health1 + health2 + health3",
+              "resources": [
+                "/subscriptions/$sub"
+              ]
+            },
+            "datasource": {
+              "type": "grafana-azure-monitor-datasource",
+              "uid": "${ds}"
+            },
+            "queryType": "Azure Log Analytics",
+            "refId": "A",
+            "subscriptions": [
+              "ebb79bc0-aa86-44a7-8111-cabbe0c43993"
+            ]
+          }
+        ],
+        "title": "Virtual Networks",
+        "transformations": [
+          {
+            "id": "organize",
+            "options": {
+              "excludeByName": {
+                "A": false,
+                "Resource": true,
+                "_ResourceId": true,
+                "health1": true,
+                "health2": true,
+                "health3": true,
+                "kpi1": true,
+                "kpi2": true,
+                "kpi3": true
+              },
+              "indexByName": {},
+              "renameByName": {
+                "A": " ",
+                "health": " "
+              }
+            }
+          }
+        ],
+        "transparent": true,
+        "type": "stat"
+      },
+      {
+        "datasource": {
+          "type": "grafana-azure-monitor-datasource",
+          "uid": "${ds}"
+        },
+        "description": "",
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "mode": "thresholds"
+            },
+            "links": [],
+            "mappings": [
+              {
+                "options": {
+                  "0": {
+                    "index": 0,
+                    "text": "Healthy"
+                  },
+                  "1": {
+                    "index": 1,
+                    "text": "Warning"
+                  }
+                },
+                "type": "value"
+              },
+              {
+                "options": {
+                  "from": 2,
+                  "result": {
+                    "index": 2,
+                    "text": "Unhealthy"
+                  },
+                  "to": 3
+                },
+                "type": "range"
+              }
+            ],
+            "max": 3,
+            "min": 0,
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "#808080",
+                  "value": null
+                },
+                {
+                  "color": "dark-green",
+                  "value": 0
+                },
+                {
+                  "color": "dark-yellow",
+                  "value": 1
+                },
+                {
+                  "color": "dark-red",
+                  "value": 2
+                }
+              ]
+            }
+          },
+          "overrides": []
+        },
+        "gridPos": {
+          "h": 3,
+          "w": 3,
+          "x": 18,
+          "y": 3
+        },
+        "id": 68,
+        "links": [],
+        "options": {
+          "colorMode": "background_solid",
+          "graphMode": "none",
+          "justifyMode": "auto",
+          "orientation": "auto",
+          "reduceOptions": {
+            "calcs": [
+              "max"
+            ],
+            "fields": "",
+            "values": false
+          },
+          "textMode": "auto"
+        },
+        "targets": [
+          {
+            "azureLogAnalytics": {
+              "query": "AzureMetrics\r\n| where _ResourceId has '/microsoft.network/expressroutecircuits/'\r\n| where MetricName in('BgpAvailability', 'ArpAvailability', 'QosDropBitsInPerSecond', 'QosDropBitsOutPerSecond' )\r\n| summarize\r\n  kpi1 = avgif(Average, MetricName == 'BgpAvailability'),\r\n  kpi2 = avgif(Average, MetricName == 'ArpAvailability'),\r\n  kpi3 = avgif(Average, MetricName == 'QosDropBitsInPerSecond'),\r\n  kpi4 = avgif(Total, MetricName == 'QosDropBitsOutPerSecond') by _ResourceId, Resource\r\n|extend kpi1 = iff(isnan(kpi1), 0.0, kpi1)\r\n|extend kpi2 = iff(isnan(kpi2), 0.0, kpi2) \r\n|extend kpi3 = iff(isnan(kpi3), 0.0, kpi3) \r\n|extend kpi4 = iff(isnan(kpi4), 0.0, kpi4)\r\n|extend health1 = iff(kpi1<90, 1, 0)\r\n|extend health2 = iff(kpi1<90, 1, 0)\r\n|extend health3 = iff(kpi2>100, 1, 0)\r\n|extend health4 = iff(kpi3>100, 1, 0)\r\n|extend health = health1 + health2 + health3 + health4\r\n",
+              "resources": [
+                "/subscriptions/$sub"
+              ]
+            },
+            "datasource": {
+              "type": "grafana-azure-monitor-datasource",
+              "uid": "${ds}"
+            },
+            "queryType": "Azure Log Analytics",
+            "refId": "A",
+            "subscriptions": [
+              "ebb79bc0-aa86-44a7-8111-cabbe0c43993"
+            ]
+          }
+        ],
+        "title": "ExpressRoute Circuits",
+        "transformations": [
+          {
+            "id": "organize",
+            "options": {
+              "excludeByName": {
+                "A": false,
+                "Resource": true,
+                "_ResourceId": true,
+                "health1": true,
+                "health2": true,
+                "health3": true,
+                "kpi1": true,
+                "kpi2": true,
+                "kpi3": true,
+                "kpi4": true
+              },
+              "indexByName": {},
+              "renameByName": {
+                "A": " ",
+                "health": " "
+              }
+            }
+          }
+        ],
+        "transparent": true,
+        "type": "stat"
+      },
+      {
+        "datasource": {
+          "type": "grafana-azure-monitor-datasource",
+          "uid": "${ds}"
+        },
+        "description": "",
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "mode": "thresholds"
+            },
+            "links": [],
+            "mappings": [
+              {
+                "options": {
+                  "0": {
+                    "index": 0,
+                    "text": "Healthy"
+                  },
+                  "1": {
+                    "index": 1,
+                    "text": "Warning"
+                  }
+                },
+                "type": "value"
+              },
+              {
+                "options": {
+                  "from": 2,
+                  "result": {
+                    "index": 2,
+                    "text": "Unhealthy"
+                  },
+                  "to": 4
+                },
+                "type": "range"
+              }
+            ],
+            "max": 4,
+            "min": 0,
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "#808080",
+                  "value": null
+                },
+                {
+                  "color": "dark-green",
+                  "value": 0
+                },
+                {
+                  "color": "dark-yellow",
+                  "value": 1
+                },
+                {
+                  "color": "dark-red",
+                  "value": 2
+                }
+              ]
+            }
+          },
+          "overrides": []
+        },
+        "gridPos": {
+          "h": 3,
+          "w": 3,
+          "x": 0,
+          "y": 6
+        },
+        "id": 26,
+        "links": [],
+        "options": {
+          "colorMode": "background_solid",
+          "graphMode": "none",
+          "justifyMode": "auto",
+          "orientation": "auto",
+          "reduceOptions": {
+            "calcs": [
+              "max"
+            ],
+            "fields": "",
+            "values": false
+          },
+          "textMode": "auto"
+        },
+        "targets": [
+          {
+            "azureLogAnalytics": {
+              "query": "AzureMetrics\r\n| where _ResourceId has '/microsoft.compute/virtualmachinescalesets/'\r\n| where MetricName in('Percentage CPU', 'OS Disk IOPS Consumed Percentage','Available Memory Bytes', 'VmAvailabilityMetric')\r\n| summarize\r\n  kpi1 = avgif(Average, MetricName == 'Percentage CPU'),\r\n  kpi2 = avgif(Average, MetricName == 'OS Disk IOPS Consumed Percentage'),\r\n  kpi3 = avgif(Average/1000000000, MetricName == 'Available Memory Bytes'),\r\n  kpi4 = avgif(Average*100, MetricName == 'VmAvailabilityMetric') by _ResourceId, Resource\r\n|extend kpi1 = iff(isnan(kpi1), 0.0, kpi1)\r\n|extend kpi2 = iff(isnan(kpi2), 0.0, kpi2) \r\n|extend kpi3 = iff(isnan(kpi3), 0.0, kpi3) \r\n|extend kpi4 = iff(isnan(kpi4), 0.0, kpi4)\r\n|extend health1 = iff(kpi1>80, 1, 0)\r\n|extend health2 = iff(kpi2>95, 1, 0)\r\n|extend health3 = iff(kpi3<1, 1, 0)\r\n|extend health4 = iff(kpi4<90, 1, 0)\r\n|extend health = health1 + health2 + health3 + health4",
+              "resources": [
+                "/subscriptions/$sub"
+              ]
+            },
+            "datasource": {
+              "type": "grafana-azure-monitor-datasource",
+              "uid": "${ds}"
+            },
+            "queryType": "Azure Log Analytics",
+            "refId": "A",
+            "subscriptions": [
+              "ebb79bc0-aa86-44a7-8111-cabbe0c43993"
+            ]
+          }
+        ],
+        "title": "Virtual Machine Scale Sets",
+        "transformations": [
+          {
+            "id": "organize",
+            "options": {
+              "excludeByName": {
+                "A": false,
+                "Resource": true,
+                "_ResourceId": true,
+                "health1": true,
+                "health2": true,
+                "health3": true,
+                "health4": true,
+                "kpi1": true,
+                "kpi2": true,
+                "kpi3": true,
+                "kpi4": true
+              },
+              "indexByName": {},
+              "renameByName": {
+                "A": " ",
+                "health": " "
+              }
+            }
+          }
+        ],
+        "transparent": true,
+        "type": "stat"
+      },
+      {
+        "datasource": {
+          "type": "grafana-azure-monitor-datasource",
+          "uid": "${ds}"
+        },
+        "description": "",
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "mode": "thresholds"
+            },
+            "links": [],
+            "mappings": [
+              {
+                "options": {
+                  "0": {
+                    "index": 0,
+                    "text": "Healthy"
+                  },
+                  "1": {
+                    "index": 1,
+                    "text": "Warning"
+                  }
+                },
+                "type": "value"
+              },
+              {
+                "options": {
+                  "from": 2,
+                  "result": {
+                    "index": 2,
+                    "text": "Unhealthy"
+                  },
+                  "to": 3
+                },
+                "type": "range"
+              }
+            ],
+            "max": 3,
+            "min": 0,
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "#808080",
+                  "value": null
+                },
+                {
+                  "color": "dark-green",
+                  "value": 0
+                },
+                {
+                  "color": "dark-yellow",
+                  "value": 1
+                },
+                {
+                  "color": "dark-red",
+                  "value": 2
+                }
+              ]
+            }
+          },
+          "overrides": []
+        },
+        "gridPos": {
+          "h": 3,
+          "w": 3,
+          "x": 3,
+          "y": 6
+        },
+        "id": 28,
+        "links": [],
+        "options": {
+          "colorMode": "background_solid",
+          "graphMode": "none",
+          "justifyMode": "auto",
+          "orientation": "auto",
+          "reduceOptions": {
+            "calcs": [
+              "max"
+            ],
+            "fields": "",
+            "values": false
+          },
+          "textMode": "auto"
+        },
+        "targets": [
+          {
+            "azureLogAnalytics": {
+              "query": "let diagnostic_table = AzureDiagnostics \r\n    | where _ResourceId has '/microsoft.keyvault/vaults/'\r\n    | where ResultSignature !='OK'\r\n    | extend ErrorCounter = 1\r\n    | project TimeGenerated, Resource, ErrorCounter, _ResourceId;\r\nAzureMetrics\r\n| where _ResourceId has '/microsoft.keyvault/vaults/'\r\n| where MetricName in('ServiceApiLatency', 'Availability')\r\n| project Resource, _ResourceId, MetricName, Average, Total\r\n| union kind=outer diagnostic_table\r\n| summarize\r\n  kpi1 = avgif(Average, MetricName == 'ServiceApiLatency'),\r\n  kpi2 = sumif(ErrorCounter, isnotnull(ErrorCounter)),\r\n  kpi3 = avgif(Average*100, MetricName == 'Availability') by _ResourceId, Resource\r\n|extend kpi1 = iff(isnan(kpi1), 0.0, kpi1)\r\n|extend kpi2 = iff(isnan(toreal(kpi2)), 0.0, toreal(kpi2)) \r\n|extend kpi3 = iff(isnan(kpi3), 0.0, kpi3) \r\n|extend health1 = iff(kpi1>1000, 1, 0)\r\n|extend health2 = iff(kpi2>500, 1, 0)\r\n|extend health3 = iff(kpi3<90, 1, 0)\r\n|extend health = health1 + health2 + health3",
+              "resources": [
+                "/subscriptions/$sub"
+              ]
+            },
+            "datasource": {
+              "type": "grafana-azure-monitor-datasource",
+              "uid": "${ds}"
+            },
+            "queryType": "Azure Log Analytics",
+            "refId": "A",
+            "subscriptions": [
+              "ebb79bc0-aa86-44a7-8111-cabbe0c43993"
+            ]
+          }
+        ],
+        "title": "Key Vaults",
+        "transformations": [
+          {
+            "id": "organize",
+            "options": {
+              "excludeByName": {
+                "A": false,
+                "Resource": true,
+                "_ResourceId": true,
+                "health1": true,
+                "health2": true,
+                "health3": true,
+                "kpi1": true,
+                "kpi2": true,
+                "kpi3": true,
+                "kpi4": true
+              },
+              "indexByName": {},
+              "renameByName": {
+                "A": " ",
+                "health": " "
+              }
+            }
+          }
+        ],
+        "transparent": true,
+        "type": "stat"
+      },
+      {
+        "datasource": {
+          "type": "grafana-azure-monitor-datasource",
+          "uid": "${ds}"
+        },
+        "description": "",
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "mode": "thresholds"
+            },
+            "links": [],
+            "mappings": [
+              {
+                "options": {
+                  "0": {
+                    "index": 0,
+                    "text": "Healthy"
+                  },
+                  "1": {
+                    "index": 1,
+                    "text": "Warning"
+                  }
+                },
+                "type": "value"
+              },
+              {
+                "options": {
+                  "from": 2,
+                  "result": {
+                    "index": 2,
+                    "text": "Unhealthy"
+                  },
+                  "to": 3
+                },
+                "type": "range"
+              }
+            ],
+            "max": 3,
+            "min": 0,
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "#808080",
+                  "value": null
+                },
+                {
+                  "color": "dark-green",
+                  "value": 0
+                },
+                {
+                  "color": "dark-yellow",
+                  "value": 1
+                },
+                {
+                  "color": "dark-red",
+                  "value": 2
+                }
+              ]
+            }
+          },
+          "overrides": []
+        },
+        "gridPos": {
+          "h": 3,
+          "w": 3,
+          "x": 6,
+          "y": 6
+        },
+        "id": 46,
+        "links": [],
+        "options": {
+          "colorMode": "background_solid",
+          "graphMode": "none",
+          "justifyMode": "auto",
+          "orientation": "auto",
+          "reduceOptions": {
+            "calcs": [
+              "max"
+            ],
+            "fields": "",
+            "values": false
+          },
+          "textMode": "auto"
+        },
+        "targets": [
+          {
+            "azureLogAnalytics": {
+              "query": "AzureMetrics\r\n| where _ResourceId has '/microsoft.network/trafficmanagerprofiles/'\r\n| where MetricName in('ProbeAgentCurrentEndpointStateByProfileResourceId', 'QpsByEndpoint')\r\n| summarize\r\n  kpi1 = avgif(Maximum, MetricName == 'ProbeAgentCurrentEndpointStateByProfileResourceId'),\r\n  kpi2 = avgif(Total, MetricName == 'QpsByEndpoint') by _ResourceId, Resource\r\n|extend kpi1 = iff(isnan(kpi1), 0.0, kpi1)\r\n|extend kpi2 = iff(isnan(kpi2), 0.0, kpi2) \r\n|extend health1 = iff(kpi1<=0, 1, 0)\r\n|extend health2 = iff(kpi2<=0, 1, 0)\r\n|extend health = health1 + health2",
+              "resources": [
+                "/subscriptions/$sub"
+              ]
+            },
+            "datasource": {
+              "type": "grafana-azure-monitor-datasource",
+              "uid": "${ds}"
+            },
+            "queryType": "Azure Log Analytics",
+            "refId": "A",
+            "subscriptions": [
+              "ebb79bc0-aa86-44a7-8111-cabbe0c43993"
+            ]
+          }
+        ],
+        "title": "Traffic Managers",
+        "transformations": [
+          {
+            "id": "organize",
+            "options": {
+              "excludeByName": {
+                "A": false,
+                "Resource": true,
+                "_ResourceId": true,
+                "health1": true,
+                "health2": true,
+                "health3": true,
+                "kpi1": true,
+                "kpi2": true,
+                "kpi3": true
+              },
+              "indexByName": {},
+              "renameByName": {
+                "A": " ",
+                "health": " "
+              }
+            }
+          }
+        ],
+        "transparent": true,
+        "type": "stat"
+      },
+      {
+        "datasource": {
+          "type": "grafana-azure-monitor-datasource",
+          "uid": "${ds}"
+        },
+        "description": "",
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "mode": "thresholds"
+            },
+            "links": [],
+            "mappings": [
+              {
+                "options": {
+                  "0": {
+                    "index": 0,
+                    "text": "Healthy"
+                  },
+                  "1": {
+                    "index": 1,
+                    "text": "Warning"
+                  }
+                },
+                "type": "value"
+              },
+              {
+                "options": {
+                  "from": 2,
+                  "result": {
+                    "index": 2,
+                    "text": "Unhealthy"
+                  },
+                  "to": 3
+                },
+                "type": "range"
+              }
+            ],
+            "max": 3,
+            "min": 0,
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "#808080",
+                  "value": null
+                },
+                {
+                  "color": "dark-green",
+                  "value": 0
+                },
+                {
+                  "color": "dark-yellow",
+                  "value": 1
+                },
+                {
+                  "color": "dark-red",
+                  "value": 2
+                }
+              ]
+            }
+          },
+          "overrides": []
+        },
+        "gridPos": {
+          "h": 3,
+          "w": 3,
+          "x": 9,
+          "y": 6
+        },
+        "id": 53,
+        "links": [],
+        "options": {
+          "colorMode": "background_solid",
+          "graphMode": "none",
+          "justifyMode": "auto",
+          "orientation": "auto",
+          "reduceOptions": {
+            "calcs": [
+              "max"
+            ],
+            "fields": "",
+            "values": false
+          },
+          "textMode": "auto"
+        },
+        "targets": [
+          {
+            "azureLogAnalytics": {
+              "query": "AzureMetrics\r\n| where _ResourceId has '/microsoft.cdn/profiles/'\r\n| where MetricName in('TotalLatency', 'ByteHitRatio', 'OriginHealthPercentage')\r\n| summarize\r\n  kpi1 = avgif(Average, MetricName == 'TotalLatency'),\r\n  kpi2 = avgif(Average, MetricName == 'ByteHitRatio'),\r\n  kpi3 = avgif(Average, MetricName == 'OriginHealthPercentage') by _ResourceId, Resource\r\n|extend kpi1 = iff(isnan(kpi1), 0.0, kpi1)\r\n|extend kpi2 = iff(isnan(kpi2), 0.0, kpi2) \r\n|extend kpi3 = iff(isnan(kpi3), 0.0, kpi3)\r\n|extend health1 = iff(kpi1>100, 1, 0)\r\n|extend health2 = iff(kpi2<50, 1, 0)\r\n|extend health3 = iff(kpi3<95, 1, 0)\r\n|extend health = health1 + health2 + health3",
+              "resources": [
+                "/subscriptions/$sub"
+              ]
+            },
+            "datasource": {
+              "type": "grafana-azure-monitor-datasource",
+              "uid": "${ds}"
+            },
+            "queryType": "Azure Log Analytics",
+            "refId": "A",
+            "subscriptions": [
+              "ebb79bc0-aa86-44a7-8111-cabbe0c43993"
+            ]
+          }
+        ],
+        "title": "Front Doors",
+        "transformations": [
+          {
+            "id": "organize",
+            "options": {
+              "excludeByName": {
+                "A": false,
+                "Resource": true,
+                "_ResourceId": true,
+                "health1": true,
+                "health2": true,
+                "health3": true,
+                "kpi1": true,
+                "kpi2": true,
+                "kpi3": true
+              },
+              "indexByName": {},
+              "renameByName": {
+                "A": " ",
+                "health": " "
+              }
+            }
+          }
+        ],
+        "transparent": true,
+        "type": "stat"
+      },
+      {
+        "datasource": {
+          "type": "grafana-azure-monitor-datasource",
+          "uid": "${ds}"
+        },
+        "description": "",
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "mode": "thresholds"
+            },
+            "links": [],
+            "mappings": [
+              {
+                "options": {
+                  "0": {
+                    "index": 0,
+                    "text": "Healthy"
+                  },
+                  "1": {
+                    "index": 1,
+                    "text": "Warning"
+                  }
+                },
+                "type": "value"
+              },
+              {
+                "options": {
+                  "from": 2,
+                  "result": {
+                    "index": 2,
+                    "text": "Unhealthy"
+                  },
+                  "to": 3
+                },
+                "type": "range"
+              }
+            ],
+            "max": 3,
+            "min": 0,
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "#808080",
+                  "value": null
+                },
+                {
+                  "color": "dark-green",
+                  "value": 0
+                },
+                {
+                  "color": "dark-yellow",
+                  "value": 1
+                },
+                {
+                  "color": "dark-red",
+                  "value": 2
+                }
+              ]
+            }
+          },
+          "overrides": []
+        },
+        "gridPos": {
+          "h": 3,
+          "w": 3,
+          "x": 12,
+          "y": 6
+        },
+        "id": 59,
+        "links": [],
+        "options": {
+          "colorMode": "background_solid",
+          "graphMode": "none",
+          "justifyMode": "auto",
+          "orientation": "auto",
+          "reduceOptions": {
+            "calcs": [
+              "max"
+            ],
+            "fields": "",
+            "values": false
+          },
+          "textMode": "auto"
+        },
+        "targets": [
+          {
+            "azureLogAnalytics": {
+              "query": "AzureMetrics\r\n| where _ResourceId has '/microsoft.network/azurefirewalls/'\r\n| where MetricName in('FirewallHealth', 'SNATPortUtilization') \r\n| summarize\r\n  kpi1 = avgif(Average, MetricName == 'FirewallHealth'),\r\n  kpi2 = avgif(Average, MetricName == 'SNATPortUtilization') by _ResourceId, Resource\r\n|extend kpi1 = iff(isnan(kpi1), 0.0, kpi1)\r\n|extend kpi2 = iff(isnan(kpi2), 0.0, kpi2)\r\n|extend health1 = iff(kpi1<90, 1, 0)\r\n|extend health2 = iff(kpi2>80, 1, 0)\r\n|extend health = health1 + health2",
+              "resources": [
+                "/subscriptions/$sub"
+              ]
+            },
+            "datasource": {
+              "type": "grafana-azure-monitor-datasource",
+              "uid": "${ds}"
+            },
+            "queryType": "Azure Log Analytics",
+            "refId": "A",
+            "subscriptions": [
+              "ebb79bc0-aa86-44a7-8111-cabbe0c43993"
+            ]
+          }
+        ],
+        "title": "Firewalls",
+        "transformations": [
+          {
+            "id": "organize",
+            "options": {
+              "excludeByName": {
+                "A": false,
+                "Resource": true,
+                "_ResourceId": true,
+                "health1": true,
+                "health2": true,
+                "health3": true,
+                "kpi1": true,
+                "kpi2": true,
+                "kpi3": true
+              },
+              "indexByName": {},
+              "renameByName": {
+                "A": " ",
+                "health": " "
+              }
+            }
+          }
+        ],
+        "transparent": true,
+        "type": "stat"
+      },
+      {
+        "datasource": {
+          "type": "grafana-azure-monitor-datasource",
+          "uid": "${ds}"
+        },
+        "description": "",
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "mode": "thresholds"
+            },
+            "links": [],
+            "mappings": [
+              {
+                "options": {
+                  "0": {
+                    "index": 0,
+                    "text": "Healthy"
+                  },
+                  "1": {
+                    "index": 1,
+                    "text": "Warning"
+                  }
+                },
+                "type": "value"
+              },
+              {
+                "options": {
+                  "from": 2,
+                  "result": {
+                    "index": 2,
+                    "text": "Unhealthy"
+                  },
+                  "to": 3
+                },
+                "type": "range"
+              }
+            ],
+            "max": 3,
+            "min": 0,
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "#808080",
+                  "value": null
+                },
+                {
+                  "color": "dark-green",
+                  "value": 0
+                },
+                {
+                  "color": "dark-yellow",
+                  "value": 1
+                },
+                {
+                  "color": "dark-red",
+                  "value": 2
+                }
+              ]
+            }
+          },
+          "overrides": []
+        },
+        "gridPos": {
+          "h": 3,
+          "w": 3,
+          "x": 15,
+          "y": 6
+        },
+        "id": 57,
+        "links": [],
+        "options": {
+          "colorMode": "background_solid",
+          "graphMode": "none",
+          "justifyMode": "auto",
+          "orientation": "auto",
+          "reduceOptions": {
+            "calcs": [
+              "max"
+            ],
+            "fields": "",
+            "values": false
+          },
+          "textMode": "auto"
+        },
+        "targets": [
+          {
+            "azureLogAnalytics": {
+              "query": "AzureMetrics\r\n| where _ResourceId has '/microsoft.network/virtualnetworkgateways/'\r\n| where MetricName in('TunnelAverageBandwidth', 'AverageBandwidth', 'TunnelIngressBytes' )\r\n| summarize\r\n  kpi1 = avgif(Average, MetricName == 'TunnelAverageBandwidth'),\r\n  kpi2 = avgif(Average, MetricName == 'TunnelEgressBytes'),\r\n  kpi3 = avgif(Total, MetricName == 'TunnelIngressBytes') by _ResourceId, Resource\r\n|extend kpi1 = iff(isnan(kpi1), 0.0, kpi1)\r\n|extend kpi2 = iff(isnan(kpi2), 0.0, kpi2) \r\n|extend kpi3 = iff(isnan(kpi3), 0.0, kpi3)\r\n|extend health1 = iff(kpi1<1, 1, 0)\r\n|extend health2 = iff(kpi2<=1, 1, 0)\r\n|extend health3 = iff(kpi3<=1, 1, 0)\r\n|extend health = health1 + health2 + health3",
+              "resources": [
+                "/subscriptions/$sub"
+              ]
+            },
+            "datasource": {
+              "type": "grafana-azure-monitor-datasource",
+              "uid": "${ds}"
+            },
+            "queryType": "Azure Log Analytics",
+            "refId": "A",
+            "subscriptions": [
+              "ebb79bc0-aa86-44a7-8111-cabbe0c43993"
+            ]
+          }
+        ],
+        "title": "VPN Gateways",
+        "transformations": [
+          {
+            "id": "organize",
+            "options": {
+              "excludeByName": {
+                "A": false,
+                "Resource": true,
+                "_ResourceId": true,
+                "health1": true,
+                "health2": true,
+                "health3": true,
+                "kpi1": true,
+                "kpi2": true,
+                "kpi3": true
+              },
+              "indexByName": {},
+              "renameByName": {
+                "A": " ",
+                "health": " "
+              }
+            }
+          }
+        ],
+        "transparent": true,
+        "type": "stat"
+      },
+      {
+        "datasource": {
+          "type": "grafana-azure-monitor-datasource",
+          "uid": "${ds}"
+        },
+        "description": "",
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "mode": "thresholds"
+            },
+            "links": [],
+            "mappings": [
+              {
+                "options": {
+                  "0": {
+                    "index": 0,
+                    "text": "Healthy"
+                  },
+                  "1": {
+                    "index": 1,
+                    "text": "Warning"
+                  }
+                },
+                "type": "value"
+              },
+              {
+                "options": {
+                  "from": 2,
+                  "result": {
+                    "index": 2,
+                    "text": "Unhealthy"
+                  },
+                  "to": 3
+                },
+                "type": "range"
+              }
+            ],
+            "max": 3,
+            "min": 0,
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "#808080",
+                  "value": null
+                },
+                {
+                  "color": "dark-green",
+                  "value": 0
+                },
+                {
+                  "color": "dark-yellow",
+                  "value": 1
+                },
+                {
+                  "color": "dark-red",
+                  "value": 2
+                }
+              ]
+            }
+          },
+          "overrides": []
+        },
+        "gridPos": {
+          "h": 3,
+          "w": 3,
+          "x": 18,
+          "y": 6
+        },
+        "id": 66,
+        "links": [],
+        "options": {
+          "colorMode": "background_solid",
+          "graphMode": "none",
+          "justifyMode": "auto",
+          "orientation": "auto",
+          "reduceOptions": {
+            "calcs": [
+              "max"
+            ],
+            "fields": "",
+            "values": false
+          },
+          "textMode": "auto"
+        },
+        "targets": [
+          {
+            "azureLogAnalytics": {
+              "query": "AzureMetrics\r\n| where _ResourceId has '/microsoft.network/virtualnetworkgateways/'\r\n| where MetricName in('ExpressRouteGatewayCpuUtilization', 'ExpressRouteGatewayBitsPerSecond', 'ExpressRouteGatewayPacketsPerSecond' )\r\n| summarize\r\n  kpi1 = avgif(Average, MetricName == 'ExpressRouteGatewayCpuUtilization'),\r\n  kpi2 = avgif(Average, MetricName == 'ExpressRouteGatewayBitsPerSecond'),\r\n  kpi3 = avgif(Total, MetricName == 'ExpressRouteGatewayPacketsPerSecond') by _ResourceId, Resource\r\n|extend kpi1 = iff(isnan(kpi1), 0.0, kpi1)\r\n|extend kpi2 = iff(isnan(kpi2), 0.0, kpi2) \r\n|extend kpi3 = iff(isnan(kpi3), 0.0, kpi3)\r\n|extend health1 = iff(kpi1>80, 1, 0)\r\n|extend health2 = iff(kpi2<=1, 1, 0)\r\n|extend health3 = iff(kpi3<=1, 1, 0)\r\n|extend health = health1 + health2 + health3",
+              "resources": [
+                "/subscriptions/$sub"
+              ]
+            },
+            "datasource": {
+              "type": "grafana-azure-monitor-datasource",
+              "uid": "${ds}"
+            },
+            "queryType": "Azure Log Analytics",
+            "refId": "A",
+            "subscriptions": [
+              "ebb79bc0-aa86-44a7-8111-cabbe0c43993"
+            ]
+          }
+        ],
+        "title": "ExpressRoute Gateways",
+        "transformations": [
+          {
+            "id": "organize",
+            "options": {
+              "excludeByName": {
+                "A": false,
+                "Resource": true,
+                "_ResourceId": true,
+                "health1": true,
+                "health2": true,
+                "health3": true,
+                "kpi1": true,
+                "kpi2": true,
+                "kpi3": true
+              },
+              "indexByName": {},
+              "renameByName": {
+                "A": " ",
+                "health": " "
+              }
+            }
+          }
+        ],
+        "transparent": true,
+        "type": "stat"
+      },
+      {
+        "gridPos": {
+          "h": 1,
+          "w": 24,
+          "x": 0,
+          "y": 9
+        },
+        "id": 25,
+        "options": {
+          "code": {
+            "language": "plaintext",
+            "showLineNumbers": false,
+            "showMiniMap": false
+          },
+          "content": "",
+          "mode": "markdown"
+        },
+        "transparent": true,
+        "type": "text"
+      },
+      {
+        "collapsed": true,
+        "gridPos": {
+          "h": 1,
+          "w": 24,
+          "x": 0,
+          "y": 10
+        },
+        "id": 22,
+        "panels": [
+          {
+            "datasource": {
+              "type": "datasource",
+              "uid": "-- Dashboard --"
+            },
+            "fieldConfig": {
+              "defaults": {
+                "color": {
+                  "mode": "thresholds"
+                },
+                "mappings": [],
+                "max": 100,
+                "min": 0,
+                "thresholds": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "#808080",
+                      "value": null
+                    },
+                    {
+                      "color": "dark-green",
+                      "value": 0
+                    },
+                    {
+                      "color": "dark-red",
+                      "value": 80
+                    }
+                  ]
+                }
+              },
+              "overrides": []
+            },
+            "gridPos": {
+              "h": 12,
+              "w": 6,
+              "x": 0,
+              "y": 11
+            },
+            "id": 6,
+            "options": {
+              "displayMode": "basic",
+              "minVizHeight": 10,
+              "minVizWidth": 0,
+              "orientation": "horizontal",
+              "reduceOptions": {
+                "calcs": [
+                  "lastNotNull"
+                ],
+                "fields": "",
+                "values": true
+              },
+              "showUnfilled": true,
+              "valueMode": "color"
+            },
+                "targets": [
+              {
+                "datasource": {
+                  "type": "datasource",
+                  "uid": "-- Dashboard --"
+                },
+                "panelId": 2,
+                "refId": "A"
+              }
+            ],
+            "title": "Virtual Machine CPU Percentage",
+            "transformations": [
+              {
+                "id": "organize",
+                "options": {
+                  "excludeByName": {
+                    "_ResourceId": true,
+                    "health": true,
+                    "health1": true,
+                    "health2": true,
+                    "health3": true,
+                    "health4": true,
+                    "kpi2": true,
+                    "kpi3": true,
+                    "kpi4": true
+                  },
+                  "indexByName": {},
+                  "renameByName": {}
+                }
+              },
+              {
+                "id": "sortBy",
+                "options": {
+                  "fields": {},
+                  "sort": [
+                    {
+                      "desc": true,
+                      "field": "kpi1"
+                    }
+                  ]
+                }
+              }
+            ],
+            "type": "bargauge"
+          },
+          {
+            "datasource": {
+              "type": "datasource",
+              "uid": "-- Dashboard --"
+            },
+            "description": "",
+            "fieldConfig": {
+              "defaults": {
+                "color": {
+                  "mode": "thresholds"
+                },
+                "mappings": [],
+                "max": 100,
+                "min": 0,
+                "thresholds": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "#808080",
+                      "value": null
+                    },
+                    {
+                      "color": "dark-green",
+                      "value": 0
+                    },
+                    {
+                      "color": "dark-red",
+                      "value": 85
+                    }
+                  ]
+                }
+              },
+              "overrides": []
+            },
+            "gridPos": {
+              "h": 12,
+              "w": 6,
+              "x": 6,
+              "y": 11
+            },
+            "id": 92,
+            "options": {
+              "displayMode": "basic",
+              "minVizHeight": 10,
+              "minVizWidth": 0,
+              "orientation": "horizontal",
+              "reduceOptions": {
+                "calcs": [
+                  "lastNotNull"
+                ],
+                "fields": "",
+                "values": true
+              },
+              "showUnfilled": true,
+              "valueMode": "color"
+            },
+                "targets": [
+              {
+                "datasource": {
+                  "type": "datasource",
+                  "uid": "-- Dashboard --"
+                },
+                "panelId": 2,
+                "refId": "A"
+              }
+            ],
+            "title": "Virtual Machine CPU Utilization 95th Percentile",
+            "transformations": [
+              {
+                "id": "organize",
+                "options": {
+                  "excludeByName": {
+                    "TimeGenerated": true,
+                    "_ResourceId": true,
+                    "health": true,
+                    "health1": true,
+                    "health2": true,
+                    "health3": true,
+                    "health4": true,
+                    "kpi1": true,
+                    "kpi2": false,
+                    "kpi3": true,
+                    "kpi4": true
+                  },
+                  "indexByName": {},
+                  "renameByName": {}
+                }
+              },
+              {
+                "id": "sortBy",
+                "options": {
+                  "fields": {},
+                  "sort": [
+                    {
+                      "desc": true,
+                      "field": "kpi2"
+                    }
+                  ]
+                }
+              }
+            ],
+            "type": "bargauge"
+          },
+          {
+            "datasource": {
+              "type": "datasource",
+              "uid": "-- Dashboard --"
+            },
+            "fieldConfig": {
+              "defaults": {
+                "color": {
+                  "mode": "thresholds"
+                },
+                "mappings": [],
+                "max": 15,
+                "min": 0,
+                "thresholds": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "#808080",
+                      "value": null
+                    },
+                    {
+                      "color": "dark-red",
+                      "value": 0
+                    },
+                    {
+                      "color": "dark-green",
+                      "value": 1
+                    }
+                  ]
+                }
+              },
+              "overrides": []
+            },
+            "gridPos": {
+              "h": 12,
+              "w": 6,
+              "x": 12,
+              "y": 11
+            },
+            "id": 7,
+            "options": {
+              "displayMode": "basic",
+              "minVizHeight": 10,
+              "minVizWidth": 0,
+              "orientation": "horizontal",
+              "reduceOptions": {
+                "calcs": [
+                  "lastNotNull"
+                ],
+                "fields": "",
+                "values": true
+              },
+              "showUnfilled": true,
+              "valueMode": "color"
+            },
+                "targets": [
+              {
+                "datasource": {
+                  "type": "datasource",
+                  "uid": "-- Dashboard --"
+                },
+                "panelId": 2,
+                "refId": "A"
+              }
+            ],
+            "title": "Virtual Machine Available Memory GB",
+            "transformations": [
+              {
+                "id": "organize",
+                "options": {
+                  "excludeByName": {
+                    "_ResourceId": true,
+                    "health": true,
+                    "health1": true,
+                    "health2": true,
+                    "health3": true,
+                    "health4": true,
+                    "kpi1": true,
+                    "kpi2": true,
+                    "kpi3": false,
+                    "kpi4": true
+                  },
+                  "indexByName": {},
+                  "renameByName": {}
+                }
+              },
+              {
+                "id": "sortBy",
+                "options": {
+                  "fields": {},
+                  "sort": [
+                    {
+                      "field": "kpi3"
+                    }
+                  ]
+                }
+              }
+            ],
+            "type": "bargauge"
+          },
+          {
+            "datasource": {
+              "type": "datasource",
+              "uid": "-- Dashboard --"
+            },
+            "fieldConfig": {
+              "defaults": {
+                "color": {
+                  "mode": "thresholds"
+                },
+                "mappings": [],
+                "max": 100,
+                "min": 0,
+                "thresholds": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "#808080",
+                      "value": null
+                    },
+                    {
+                      "color": "dark-red",
+                      "value": 0
+                    },
+                    {
+                      "color": "dark-green",
+                      "value": 90
+                    }
+                  ]
+                }
+              },
+              "overrides": []
+            },
+            "gridPos": {
+              "h": 12,
+              "w": 6,
+              "x": 18,
+              "y": 11
+            },
+            "id": 8,
+            "options": {
+              "displayMode": "basic",
+              "minVizHeight": 10,
+              "minVizWidth": 0,
+              "orientation": "horizontal",
+              "reduceOptions": {
+                "calcs": [
+                  "lastNotNull"
+                ],
+                "fields": "",
+                "values": true
+              },
+              "showUnfilled": true,
+              "valueMode": "color"
+            },
+                "targets": [
+              {
+                "datasource": {
+                  "type": "datasource",
+                  "uid": "-- Dashboard --"
+                },
+                "panelId": 2,
+                "refId": "A"
+              }
+            ],
+            "title": "Virtual Machine Availability",
+            "transformations": [
+              {
+                "id": "organize",
+                "options": {
+                  "excludeByName": {
+                    "_ResourceId": true,
+                    "health": true,
+                    "health1": true,
+                    "health2": true,
+                    "health3": true,
+                    "health4": true,
+                    "kpi1": true,
+                    "kpi2": true,
+                    "kpi3": true
+                  },
+                  "indexByName": {},
+                  "renameByName": {}
+                }
+              },
+              {
+                "id": "sortBy",
+                "options": {
+                  "fields": {},
+                  "sort": [
+                    {
+                      "field": "kpi4"
+                    }
+                  ]
+                }
+              }
+            ],
+            "type": "bargauge"
+          }
+        ],
+        "title": "Virtual Machines",
+        "type": "row"
+      },
+      {
+        "collapsed": true,
+        "gridPos": {
+          "h": 1,
+          "w": 24,
+          "x": 0,
+          "y": 11
+        },
+        "id": 21,
+        "panels": [
+          {
+            "datasource": {
+              "type": "datasource",
+              "uid": "-- Dashboard --"
+            },
+            "fieldConfig": {
+              "defaults": {
+                "color": {
+                  "mode": "thresholds"
+                },
+                "mappings": [],
+                "max": 100,
+                "min": 0,
+                "thresholds": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "#808080"
+                    },
+                    {
+                      "color": "dark-green",
+                      "value": 0
+                    },
+                    {
+                      "color": "dark-red",
+                      "value": 80
+                    }
+                  ]
+                }
+              },
+              "overrides": []
+            },
+            "gridPos": {
+              "h": 12,
+              "w": 6,
+              "x": 0,
+              "y": 24
+            },
+            "id": 16,
+            "options": {
+              "displayMode": "basic",
+              "minVizHeight": 10,
+              "minVizWidth": 0,
+              "orientation": "horizontal",
+              "reduceOptions": {
+                "calcs": [
+                  "lastNotNull"
+                ],
+                "fields": "",
+                "values": true
+              },
+              "showUnfilled": true,
+              "valueMode": "color"
+            },
+                "targets": [
+              {
+                "datasource": {
+                  "type": "datasource",
+                  "uid": "-- Dashboard --"
+                },
+                "panelId": 26,
+                "refId": "A"
+              }
+            ],
+            "title": "Virtual Machine Scale Set CPU Percentage",
+            "transformations": [
+              {
+                "id": "organize",
+                "options": {
+                  "excludeByName": {
+                    "_ResourceId": true,
+                    "health": true,
+                    "health1": true,
+                    "health2": true,
+                    "health3": true,
+                    "health4": true,
+                    "kpi1": false,
+                    "kpi2": true,
+                    "kpi3": true,
+                    "kpi4": true
+                  },
+                  "indexByName": {},
+                  "renameByName": {}
+                }
+              },
+              {
+                "id": "sortBy",
+                "options": {
+                  "fields": {},
+                  "sort": [
+                    {
+                      "desc": true,
+                      "field": "kpi1"
+                    }
+                  ]
+                }
+              }
+            ],
+            "type": "bargauge"
+          },
+          {
+            "datasource": {
+              "type": "datasource",
+              "uid": "-- Dashboard --"
+            },
+            "fieldConfig": {
+              "defaults": {
+                "color": {
+                  "mode": "thresholds"
+                },
+                "mappings": [],
+                "max": 100,
+                "min": 0,
+                "thresholds": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "#808080"
+                    },
+                    {
+                      "color": "dark-green",
+                      "value": 0
+                    },
+                    {
+                      "color": "dark-red",
+                      "value": 95
+                    }
+                  ]
+                }
+              },
+              "overrides": []
+            },
+            "gridPos": {
+              "h": 12,
+              "w": 6,
+              "x": 6,
+              "y": 24
+            },
+            "id": 93,
+            "options": {
+              "displayMode": "basic",
+              "minVizHeight": 10,
+              "minVizWidth": 0,
+              "orientation": "horizontal",
+              "reduceOptions": {
+                "calcs": [
+                  "lastNotNull"
+                ],
+                "fields": "",
+                "values": true
+              },
+              "showUnfilled": true,
+              "valueMode": "color"
+            },
+                "targets": [
+              {
+                "datasource": {
+                  "type": "datasource",
+                  "uid": "-- Dashboard --"
+                },
+                "panelId": 26,
+                "refId": "A"
+              }
+            ],
+            "title": "Virtual Machine Scale Set OS Disk IOPS Consumed Percentage",
+            "transformations": [
+              {
+                "id": "organize",
+                "options": {
+                  "excludeByName": {
+                    "_ResourceId": true,
+                    "health": true,
+                    "health1": true,
+                    "health2": true,
+                    "health3": true,
+                    "health4": true,
+                    "kpi1": true,
+                    "kpi2": false,
+                    "kpi3": true,
+                    "kpi4": true
+                  },
+                  "indexByName": {},
+                  "renameByName": {}
+                }
+              },
+              {
+                "id": "sortBy",
+                "options": {
+                  "fields": {},
+                  "sort": [
+                    {
+                      "desc": true,
+                      "field": "kpi2"
+                    }
+                  ]
+                }
+              }
+            ],
+            "type": "bargauge"
+          },
+          {
+            "datasource": {
+              "type": "datasource",
+              "uid": "-- Dashboard --"
+            },
+            "fieldConfig": {
+              "defaults": {
+                "color": {
+                  "mode": "thresholds"
+                },
+                "mappings": [],
+                "max": 15,
+                "min": 0,
+                "thresholds": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "#808080"
+                    },
+                    {
+                      "color": "dark-red",
+                      "value": 0
+                    },
+                    {
+                      "color": "dark-green",
+                      "value": 1
+                    }
+                  ]
+                }
+              },
+              "overrides": []
+            },
+            "gridPos": {
+              "h": 12,
+              "w": 6,
+              "x": 12,
+              "y": 24
+            },
+            "id": 17,
+            "options": {
+              "displayMode": "basic",
+              "minVizHeight": 10,
+              "minVizWidth": 0,
+              "orientation": "horizontal",
+              "reduceOptions": {
+                "calcs": [
+                  "lastNotNull"
+                ],
+                "fields": "",
+                "values": true
+              },
+              "showUnfilled": true,
+              "valueMode": "color"
+            },
+                "targets": [
+              {
+                "datasource": {
+                  "type": "datasource",
+                  "uid": "-- Dashboard --"
+                },
+                "panelId": 26,
+                "refId": "A"
+              }
+            ],
+            "title": "Virtual Machine Scale Set Available Memory GB",
+            "transformations": [
+              {
+                "id": "organize",
+                "options": {
+                  "excludeByName": {
+                    "_ResourceId": true,
+                    "health": true,
+                    "health1": true,
+                    "health2": true,
+                    "health3": true,
+                    "health4": true,
+                    "kpi1": true,
+                    "kpi2": true,
+                    "kpi4": true
+                  },
+                  "indexByName": {},
+                  "renameByName": {}
+                }
+              },
+              {
+                "id": "sortBy",
+                "options": {
+                  "fields": {},
+                  "sort": [
+                    {
+                      "field": "kpi3"
+                    }
+                  ]
+                }
+              }
+            ],
+            "type": "bargauge"
+          },
+          {
+            "datasource": {
+              "type": "datasource",
+              "uid": "-- Dashboard --"
+            },
+            "fieldConfig": {
+              "defaults": {
+                "color": {
+                  "mode": "thresholds"
+                },
+                "mappings": [],
+                "max": 100,
+                "min": 0,
+                "thresholds": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "#808080"
+                    },
+                    {
+                      "color": "dark-red",
+                      "value": 0
+                    },
+                    {
+                      "color": "dark-green",
+                      "value": 90
+                    }
+                  ]
+                }
+              },
+              "overrides": []
+            },
+            "gridPos": {
+              "h": 12,
+              "w": 6,
+              "x": 18,
+              "y": 24
+            },
+            "id": 18,
+            "options": {
+              "displayMode": "basic",
+              "minVizHeight": 10,
+              "minVizWidth": 0,
+              "orientation": "horizontal",
+              "reduceOptions": {
+                "calcs": [
+                  "lastNotNull"
+                ],
+                "fields": "",
+                "values": true
+              },
+              "showUnfilled": true,
+              "valueMode": "color"
+            },
+                "targets": [
+              {
+                "datasource": {
+                  "type": "datasource",
+                  "uid": "-- Dashboard --"
+                },
+                "panelId": 26,
+                "refId": "A"
+              }
+            ],
+            "title": "Virtual Machine Scale Set Availability",
+            "transformations": [
+              {
+                "id": "organize",
+                "options": {
+                  "excludeByName": {
+                    "_ResourceId": true,
+                    "health": true,
+                    "health1": true,
+                    "health2": true,
+                    "health3": true,
+                    "health4": true,
+                    "kpi1": true,
+                    "kpi2": true,
+                    "kpi3": true
+                  },
+                  "indexByName": {},
+                  "renameByName": {}
+                }
+              }
+            ],
+            "type": "bargauge"
+          }
+        ],
+        "title": "Virtual Machine Scale Sets",
+        "type": "row"
+      },
+      {
+        "collapsed": true,
+        "gridPos": {
+          "h": 1,
+          "w": 24,
+          "x": 0,
+          "y": 12
+        },
+        "id": 23,
+        "panels": [
+          {
+            "datasource": {
+              "type": "datasource",
+              "uid": "-- Dashboard --"
+            },
+            "fieldConfig": {
+              "defaults": {
+                "color": {
+                  "mode": "thresholds"
+                },
+                "mappings": [],
+                "max": 5000,
+                "min": 0,
+                "thresholds": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "#808080"
+                    },
+                    {
+                      "color": "dark-green",
+                      "value": 0
+                    },
+                    {
+                      "color": "dark-red",
+                      "value": 5000
+                    }
+                  ]
+                }
+              },
+              "overrides": []
+            },
+            "gridPos": {
+              "h": 12,
+              "w": 6,
+              "x": 0,
+              "y": 13
+            },
+            "id": 29,
+            "options": {
+              "displayMode": "basic",
+              "minVizHeight": 10,
+              "minVizWidth": 0,
+              "orientation": "horizontal",
+              "reduceOptions": {
+                "calcs": [
+                  "lastNotNull"
+                ],
+                "fields": "",
+                "values": true
+              },
+              "showUnfilled": true,
+              "valueMode": "color"
+            },
+                "targets": [
+              {
+                "datasource": {
+                  "type": "datasource",
+                  "uid": "-- Dashboard --"
+                },
+                "panelId": 27,
+                "refId": "A"
+              }
+            ],
+            "title": "Storage Success End to End Latency",
+            "transformations": [
+              {
+                "id": "organize",
+                "options": {
+                  "excludeByName": {
+                    "_ResourceId": true,
+                    "health": true,
+                    "health1": true,
+                    "health2": true,
+                    "health3": true,
+                    "health4": true,
+                    "kpi2": true,
+                    "kpi3": true,
+                    "kpi4": true
+                  },
+                  "indexByName": {},
+                  "renameByName": {}
+                }
+              },
+              {
+                "id": "sortBy",
+                "options": {
+                  "fields": {},
+                  "sort": [
+                    {
+                      "desc": true,
+                      "field": "kpi1"
+                    }
+                  ]
+                }
+              }
+            ],
+            "type": "bargauge"
+          },
+          {
+            "datasource": {
+              "type": "datasource",
+              "uid": "-- Dashboard --"
+            },
+            "fieldConfig": {
+              "defaults": {
+                "color": {
+                  "mode": "thresholds"
+                },
+                "mappings": [],
+                "max": 5000,
+                "min": 0,
+                "thresholds": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "#808080"
+                    },
+                    {
+                      "color": "dark-green",
+                      "value": 0
+                    },
+                    {
+                      "color": "dark-red",
+                      "value": 500
+                    }
+                  ]
+                }
+              },
+              "overrides": []
+            },
+            "gridPos": {
+              "h": 12,
+              "w": 6,
+              "x": 6,
+              "y": 13
+            },
+            "id": 30,
+            "options": {
+              "displayMode": "basic",
+              "minVizHeight": 10,
+              "minVizWidth": 0,
+              "orientation": "horizontal",
+              "reduceOptions": {
+                "calcs": [
+                  "lastNotNull"
+                ],
+                "fields": "",
+                "values": true
+              },
+              "showUnfilled": true,
+              "valueMode": "color"
+            },
+                "targets": [
+              {
+                "datasource": {
+                  "type": "datasource",
+                  "uid": "-- Dashboard --"
+                },
+                "panelId": 27,
+                "refId": "A"
+              }
+            ],
+            "title": "Storage Failing Transactions",
+            "transformations": [
+              {
+                "id": "organize",
+                "options": {
+                  "excludeByName": {
+                    "_ResourceId": true,
+                    "health": true,
+                    "health1": true,
+                    "health2": true,
+                    "health3": true,
+                    "health4": true,
+                    "kpi1": true,
+                    "kpi2": false,
+                    "kpi3": true,
+                    "kpi4": true
+                  },
+                  "indexByName": {},
+                  "renameByName": {}
+                }
+              },
+              {
+                "id": "sortBy",
+                "options": {
+                  "fields": {},
+                  "sort": [
+                    {
+                      "desc": true,
+                      "field": "kpi2"
+                    }
+                  ]
+                }
+              }
+            ],
+            "type": "bargauge"
+          },
+          {
+            "datasource": {
+              "type": "datasource",
+              "uid": "-- Dashboard --"
+            },
+            "fieldConfig": {
+              "defaults": {
+                "color": {
+                  "mode": "thresholds"
+                },
+                "mappings": [],
+                "max": 4000000000000000,
+                "min": 0,
+                "thresholds": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "#808080"
+                    },
+                    {
+                      "color": "dark-green",
+                      "value": 0
+                    },
+                    {
+                      "color": "dark-red",
+                      "value": 4000000000000000
+                    }
+                  ]
+                }
+              },
+              "overrides": []
+            },
+            "gridPos": {
+              "h": 12,
+              "w": 6,
+              "x": 12,
+              "y": 13
+            },
+            "id": 94,
+            "options": {
+              "displayMode": "basic",
+              "minVizHeight": 10,
+              "minVizWidth": 0,
+              "orientation": "horizontal",
+              "reduceOptions": {
+                "calcs": [
+                  "lastNotNull"
+                ],
+                "fields": "",
+                "values": true
+              },
+              "showUnfilled": true,
+              "valueMode": "color"
+            },
+                "targets": [
+              {
+                "datasource": {
+                  "type": "datasource",
+                  "uid": "-- Dashboard --"
+                },
+                "panelId": 27,
+                "refId": "A"
+              }
+            ],
+            "title": "Storage Used Capacity",
+            "transformations": [
+              {
+                "id": "organize",
+                "options": {
+                  "excludeByName": {
+                    "_ResourceId": true,
+                    "health": true,
+                    "health1": true,
+                    "health2": true,
+                    "health3": true,
+                    "health4": true,
+                    "kpi1": true,
+                    "kpi2": true,
+                    "kpi3": false,
+                    "kpi4": true
+                  },
+                  "indexByName": {},
+                  "renameByName": {}
+                }
+              },
+              {
+                "id": "filterByValue",
+                "options": {
+                  "filters": [
+                    {
+                      "config": {
+                        "id": "regex",
+                        "options": {
+                          "value": ".*NaN"
+                        }
+                      },
+                      "fieldName": "kpi3"
+                    }
+                  ],
+                  "match": "any",
+                  "type": "exclude"
+                }
+              },
+              {
+                "id": "sortBy",
+                "options": {
+                  "fields": {},
+                  "sort": [
+                    {
+                      "desc": true,
+                      "field": "kpi3"
+                    }
+                  ]
+                }
+              }
+            ],
+            "type": "bargauge"
+          },
+          {
+            "datasource": {
+              "type": "datasource",
+              "uid": "-- Dashboard --"
+            },
+            "fieldConfig": {
+              "defaults": {
+                "color": {
+                  "mode": "thresholds"
+                },
+                "mappings": [],
+                "max": 100,
+                "min": 0,
+                "thresholds": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "#808080"
+                    },
+                    {
+                      "color": "dark-red",
+                      "value": 0
+                    },
+                    {
+                      "color": "dark-green",
+                      "value": 90
+                    }
+                  ]
+                }
+              },
+              "overrides": []
+            },
+            "gridPos": {
+              "h": 12,
+              "w": 6,
+              "x": 18,
+              "y": 13
+            },
+            "id": 31,
+            "options": {
+              "displayMode": "basic",
+              "minVizHeight": 10,
+              "minVizWidth": 0,
+              "orientation": "horizontal",
+              "reduceOptions": {
+                "calcs": [
+                  "lastNotNull"
+                ],
+                "fields": "",
+                "values": true
+              },
+              "showUnfilled": true,
+              "valueMode": "color"
+            },
+                "targets": [
+              {
+                "datasource": {
+                  "type": "datasource",
+                  "uid": "-- Dashboard --"
+                },
+                "panelId": 27,
+                "refId": "A"
+              }
+            ],
+            "title": "Storage Availability",
+            "transformations": [
+              {
+                "id": "organize",
+                "options": {
+                  "excludeByName": {
+                    "_ResourceId": true,
+                    "health": true,
+                    "health1": true,
+                    "health2": true,
+                    "health3": true,
+                    "health4": true,
+                    "kpi1": true,
+                    "kpi2": true,
+                    "kpi3": true
+                  },
+                  "indexByName": {},
+                  "renameByName": {}
+                }
+              },
+              {
+                "id": "sortBy",
+                "options": {
+                  "fields": {},
+                  "sort": [
+                    {
+                      "desc": false,
+                      "field": "kpi4"
+                    }
+                  ]
+                }
+              }
+            ],
+            "type": "bargauge"
+          }
+        ],
+        "title": "Storage",
+        "type": "row"
+      },
+      {
+        "collapsed": true,
+        "gridPos": {
+          "h": 1,
+          "w": 24,
+          "x": 0,
+          "y": 13
+        },
+        "id": 24,
+        "panels": [
+          {
+            "datasource": {
+              "type": "datasource",
+              "uid": "-- Dashboard --"
+            },
+            "fieldConfig": {
+              "defaults": {
+                "color": {
+                  "mode": "thresholds"
+                },
+                "mappings": [],
+                "max": 2000,
+                "min": 0,
+                "thresholds": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "#808080"
+                    },
+                    {
+                      "color": "dark-green",
+                      "value": 0
+                    },
+                    {
+                      "color": "dark-red",
+                      "value": 1000
+                    }
+                  ]
+                }
+              },
+              "overrides": []
+            },
+            "gridPos": {
+              "h": 12,
+              "w": 6,
+              "x": 0,
+              "y": 50
+            },
+            "id": 32,
+            "options": {
+              "displayMode": "basic",
+              "minVizHeight": 10,
+              "minVizWidth": 0,
+              "orientation": "horizontal",
+              "reduceOptions": {
+                "calcs": [
+                  "lastNotNull"
+                ],
+                "fields": "",
+                "values": true
+              },
+              "showUnfilled": true,
+              "valueMode": "color"
+            },
+                "targets": [
+              {
+                "datasource": {
+                  "type": "datasource",
+                  "uid": "-- Dashboard --"
+                },
+                "panelId": 28,
+                "refId": "A"
+              }
+            ],
+            "title": "Key Vault Service API Latency",
+            "transformations": [
+              {
+                "id": "organize",
+                "options": {
+                  "excludeByName": {
+                    "_ResourceId": true,
+                    "health": true,
+                    "health1": true,
+                    "health2": true,
+                    "health3": true,
+                    "kpi2": true,
+                    "kpi3": true
+                  },
+                  "indexByName": {},
+                  "renameByName": {}
+                }
+              },
+              {
+                "id": "sortBy",
+                "options": {
+                  "fields": {},
+                  "sort": [
+                    {
+                      "desc": true,
+                      "field": "kpi1"
+                    }
+                  ]
+                }
+              }
+            ],
+            "type": "bargauge"
+          },
+          {
+            "datasource": {
+              "type": "datasource",
+              "uid": "-- Dashboard --"
+            },
+            "fieldConfig": {
+              "defaults": {
+                "color": {
+                  "mode": "thresholds"
+                },
+                "mappings": [],
+                "max": 1000,
+                "min": 0,
+                "thresholds": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "#808080"
+                    },
+                    {
+                      "color": "dark-green",
+                      "value": 0
+                    },
+                    {
+                      "color": "dark-red",
+                      "value": 500
+                    }
+                  ]
+                }
+              },
+              "overrides": []
+            },
+            "gridPos": {
+              "h": 12,
+              "w": 6,
+              "x": 6,
+              "y": 50
+            },
+            "id": 33,
+            "options": {
+              "displayMode": "basic",
+              "minVizHeight": 10,
+              "minVizWidth": 0,
+              "orientation": "horizontal",
+              "reduceOptions": {
+                "calcs": [
+                  "lastNotNull"
+                ],
+                "fields": "",
+                "values": true
+              },
+              "showUnfilled": true,
+              "valueMode": "color"
+            },
+                "targets": [
+              {
+                "datasource": {
+                  "type": "datasource",
+                  "uid": "-- Dashboard --"
+                },
+                "panelId": 28,
+                "refId": "A"
+              }
+            ],
+            "title": "Key Vault Failing Transactions",
+            "transformations": [
+              {
+                "id": "organize",
+                "options": {
+                  "excludeByName": {
+                    "_ResourceId": true,
+                    "health": true,
+                    "health1": true,
+                    "health2": true,
+                    "health3": true,
+                    "kpi1": true,
+                    "kpi2": false,
+                    "kpi3": true
+                  },
+                  "indexByName": {},
+                  "renameByName": {}
+                }
+              },
+              {
+                "id": "sortBy",
+                "options": {
+                  "fields": {},
+                  "sort": [
+                    {
+                      "desc": true,
+                      "field": "kpi1"
+                    }
+                  ]
+                }
+              }
+            ],
+            "type": "bargauge"
+          },
+          {
+            "datasource": {
+              "type": "datasource",
+              "uid": "-- Dashboard --"
+            },
+            "fieldConfig": {
+              "defaults": {
+                "color": {
+                  "mode": "thresholds"
+                },
+                "mappings": [],
+                "max": 100,
+                "min": 0,
+                "thresholds": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "#808080"
+                    },
+                    {
+                      "color": "dark-red",
+                      "value": 0
+                    },
+                    {
+                      "color": "dark-green",
+                      "value": 90
+                    }
+                  ]
+                }
+              },
+              "overrides": []
+            },
+            "gridPos": {
+              "h": 12,
+              "w": 6,
+              "x": 12,
+              "y": 50
+            },
+            "id": 51,
+            "options": {
+              "displayMode": "basic",
+              "minVizHeight": 10,
+              "minVizWidth": 0,
+              "orientation": "horizontal",
+              "reduceOptions": {
+                "calcs": [
+                  "lastNotNull"
+                ],
+                "fields": "",
+                "values": true
+              },
+              "showUnfilled": true,
+              "valueMode": "color"
+            },
+                "targets": [
+              {
+                "datasource": {
+                  "type": "datasource",
+                  "uid": "-- Dashboard --"
+                },
+                "panelId": 28,
+                "refId": "A"
+              }
+            ],
+            "title": "Key Vault Availability",
+            "transformations": [
+              {
+                "id": "organize",
+                "options": {
+                  "excludeByName": {
+                    "_ResourceId": true,
+                    "health": true,
+                    "health1": true,
+                    "health2": true,
+                    "health3": true,
+                    "kpi1": true,
+                    "kpi2": true,
+                    "kpi3": false
+                  },
+                  "indexByName": {},
+                  "renameByName": {}
+                }
+              },
+              {
+                "id": "sortBy",
+                "options": {
+                  "fields": {},
+                  "sort": [
+                    {
+                      "desc": false,
+                      "field": "kpi3"
+                    }
+                  ]
+                }
+              }
+            ],
+            "type": "bargauge"
+          }
+        ],
+        "title": "Key Vaults",
+        "type": "row"
+      },
+      {
+        "collapsed": true,
+        "gridPos": {
+          "h": 1,
+          "w": 24,
+          "x": 0,
+          "y": 14
+        },
+        "id": 35,
+        "panels": [
+          {
+            "datasource": {
+              "type": "datasource",
+              "uid": "-- Dashboard --"
+            },
+            "fieldConfig": {
+              "defaults": {
+                "color": {
+                  "mode": "thresholds"
+                },
+                "mappings": [],
+                "max": 5000,
+                "min": 0,
+                "thresholds": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "#808080"
+                    },
+                    {
+                      "color": "dark-green",
+                      "value": 0
+                    },
+                    {
+                      "color": "dark-red",
+                      "value": 900
+                    }
+                  ]
+                }
+              },
+              "overrides": []
+            },
+            "gridPos": {
+              "h": 12,
+              "w": 6,
+              "x": 0,
+              "y": 63
+            },
+            "id": 37,
+            "options": {
+              "displayMode": "basic",
+              "minVizHeight": 10,
+              "minVizWidth": 0,
+              "orientation": "horizontal",
+              "reduceOptions": {
+                "calcs": [
+                  "lastNotNull"
+                ],
+                "fields": "",
+                "values": true
+              },
+              "showUnfilled": true,
+              "valueMode": "color"
+            },
+                "targets": [
+              {
+                "datasource": {
+                  "type": "datasource",
+                  "uid": "-- Dashboard --"
+                },
+                "panelId": 36,
+                "refId": "A"
+              }
+            ],
+            "title": "Load Balancer Used SNAT Ports",
+            "transformations": [
+              {
+                "id": "organize",
+                "options": {
+                  "excludeByName": {
+                    "_ResourceId": true,
+                    "health": true,
+                    "health1": true,
+                    "health2": true,
+                    "health3": true,
+                    "kpi2": true,
+                    "kpi3": true
+                  },
+                  "indexByName": {},
+                  "renameByName": {}
+                }
+              },
+              {
+                "id": "sortBy",
+                "options": {
+                  "fields": {},
+                  "sort": [
+                    {
+                      "desc": true,
+                      "field": "kpi1"
+                    }
+                  ]
+                }
+              }
+            ],
+            "type": "bargauge"
+          },
+          {
+            "datasource": {
+              "type": "datasource",
+              "uid": "-- Dashboard --"
+            },
+            "fieldConfig": {
+              "defaults": {
+                "color": {
+                  "mode": "thresholds"
+                },
+                "mappings": [],
+                "max": 100,
+                "min": 0,
+                "thresholds": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "#808080"
+                    },
+                    {
+                      "color": "dark-red",
+                      "value": 0
+                    },
+                    {
+                      "color": "dark-green",
+                      "value": 51
+                    }
+                  ]
+                }
+              },
+              "overrides": []
+            },
+            "gridPos": {
+              "h": 12,
+              "w": 6,
+              "x": 6,
+              "y": 63
+            },
+            "id": 38,
+            "options": {
+              "displayMode": "basic",
+              "minVizHeight": 10,
+              "minVizWidth": 0,
+              "orientation": "horizontal",
+              "reduceOptions": {
+                "calcs": [
+                  "lastNotNull"
+                ],
+                "fields": "",
+                "values": true
+              },
+              "showUnfilled": true,
+              "valueMode": "color"
+            },
+                "targets": [
+              {
+                "datasource": {
+                  "type": "datasource",
+                  "uid": "-- Dashboard --"
+                },
+                "panelId": 36,
+                "refId": "A"
+              }
+            ],
+            "title": "Load Balancer Health Probe Status",
+            "transformations": [
+              {
+                "id": "organize",
+                "options": {
+                  "excludeByName": {
+                    "_ResourceId": true,
+                    "health": true,
+                    "health1": true,
+                    "health2": true,
+                    "health3": true,
+                    "kpi1": true,
+                    "kpi2": false,
+                    "kpi3": true
+                  },
+                  "indexByName": {},
+                  "renameByName": {}
+                }
+              },
+              {
+                "id": "sortBy",
+                "options": {
+                  "fields": {},
+                  "sort": [
+                    {
+                      "desc": false,
+                      "field": "kpi2"
+                    }
+                  ]
+                }
+              }
+            ],
+            "type": "bargauge"
+          },
+          {
+            "datasource": {
+              "type": "datasource",
+              "uid": "-- Dashboard --"
+            },
+            "fieldConfig": {
+              "defaults": {
+                "color": {
+                  "mode": "thresholds"
+                },
+                "mappings": [],
+                "max": 100,
+                "min": 0,
+                "thresholds": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "#808080"
+                    },
+                    {
+                      "color": "dark-red",
+                      "value": 0
+                    },
+                    {
+                      "color": "dark-green",
+                      "value": 50
+                    }
+                  ]
+                }
+              },
+              "overrides": []
+            },
+            "gridPos": {
+              "h": 12,
+              "w": 6,
+              "x": 12,
+              "y": 63
+            },
+            "id": 39,
+            "options": {
+              "displayMode": "basic",
+              "minVizHeight": 10,
+              "minVizWidth": 0,
+              "orientation": "horizontal",
+              "reduceOptions": {
+                "calcs": [
+                  "lastNotNull"
+                ],
+                "fields": "",
+                "values": true
+              },
+              "showUnfilled": true,
+              "valueMode": "color"
+            },
+                "targets": [
+              {
+                "datasource": {
+                  "type": "datasource",
+                  "uid": "-- Dashboard --"
+                },
+                "panelId": 36,
+                "refId": "A"
+              }
+            ],
+            "title": "Load Balancer Data Path Availability",
+            "transformations": [
+              {
+                "id": "organize",
+                "options": {
+                  "excludeByName": {
+                    "_ResourceId": true,
+                    "health": true,
+                    "health1": true,
+                    "health2": true,
+                    "health3": true,
+                    "kpi1": true,
+                    "kpi2": true,
+                    "kpi3": false
+                  },
+                  "indexByName": {},
+                  "renameByName": {}
+                }
+              },
+              {
+                "id": "sortBy",
+                "options": {
+                  "fields": {},
+                  "sort": [
+                    {
+                      "desc": false,
+                      "field": "kpi3"
+                    }
+                  ]
+                }
+              }
+            ],
+            "type": "bargauge"
+          }
+        ],
+        "title": "Load Balancers",
+        "type": "row"
+      },
+      {
+        "collapsed": true,
+        "gridPos": {
+          "h": 1,
+          "w": 24,
+          "x": 0,
+          "y": 15
+        },
+        "id": 45,
+        "panels": [
+          {
+            "datasource": {
+              "type": "datasource",
+              "uid": "-- Dashboard --"
+            },
+            "fieldConfig": {
+              "defaults": {
+                "color": {
+                  "mode": "thresholds"
+                },
+                "mappings": [],
+                "max": 25,
+                "min": 0,
+                "thresholds": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "#808080"
+                    },
+                    {
+                      "color": "dark-red",
+                      "value": 0
+                    },
+                    {
+                      "color": "dark-green",
+                      "value": 1
+                    }
+                  ]
+                }
+              },
+              "overrides": []
+            },
+            "gridPos": {
+              "h": 12,
+              "w": 6,
+              "x": 0,
+              "y": 16
+            },
+            "id": 47,
+            "options": {
+              "displayMode": "basic",
+              "minVizHeight": 10,
+              "minVizWidth": 0,
+              "orientation": "horizontal",
+              "reduceOptions": {
+                "calcs": [
+                  "lastNotNull"
+                ],
+                "fields": "",
+                "values": true
+              },
+              "showUnfilled": true,
+              "valueMode": "color"
+            },
+                "targets": [
+              {
+                "datasource": {
+                  "type": "datasource",
+                  "uid": "-- Dashboard --"
+                },
+                "panelId": 46,
+                "refId": "A"
+              }
+            ],
+            "title": "Traffic Manager Endpoint Status by Endpoint",
+            "transformations": [
+              {
+                "id": "organize",
+                "options": {
+                  "excludeByName": {
+                    "_ResourceId": true,
+                    "health": true,
+                    "health1": true,
+                    "health2": true,
+                    "health3": true,
+                    "kpi2": true,
+                    "kpi3": true
+                  },
+                  "indexByName": {},
+                  "renameByName": {}
+                }
+              },
+              {
+                "id": "sortBy",
+                "options": {
+                  "fields": {},
+                  "sort": [
+                    {
+                      "desc": false,
+                      "field": "kpi1"
+                    }
+                  ]
+                }
+              }
+            ],
+            "type": "bargauge"
+          },
+          {
+            "datasource": {
+              "type": "datasource",
+              "uid": "-- Dashboard --"
+            },
+            "fieldConfig": {
+              "defaults": {
+                "color": {
+                  "mode": "thresholds"
+                },
+                "mappings": [],
+                "max": 25,
+                "min": 0,
+                "thresholds": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "#808080"
+                    },
+                    {
+                      "color": "dark-red",
+                      "value": 0
+                    },
+                    {
+                      "color": "dark-green",
+                      "value": 1
+                    }
+                  ]
+                }
+              },
+              "overrides": []
+            },
+            "gridPos": {
+              "h": 12,
+              "w": 6,
+              "x": 6,
+              "y": 16
+            },
+            "id": 48,
+            "options": {
+              "displayMode": "basic",
+              "minVizHeight": 10,
+              "minVizWidth": 0,
+              "orientation": "horizontal",
+              "reduceOptions": {
+                "calcs": [
+                  "lastNotNull"
+                ],
+                "fields": "",
+                "values": true
+              },
+              "showUnfilled": true,
+              "valueMode": "color"
+            },
+                "targets": [
+              {
+                "datasource": {
+                  "type": "datasource",
+                  "uid": "-- Dashboard --"
+                },
+                "panelId": 46,
+                "refId": "A"
+              }
+            ],
+            "title": "Traffic Manager Queries by Endpoint Returned",
+            "transformations": [
+              {
+                "id": "organize",
+                "options": {
+                  "excludeByName": {
+                    "_ResourceId": true,
+                    "health": true,
+                    "health1": true,
+                    "health2": true,
+                    "health3": true,
+                    "kpi1": true,
+                    "kpi2": false,
+                    "kpi3": true
+                  },
+                  "indexByName": {},
+                  "renameByName": {}
+                }
+              },
+              {
+                "id": "sortBy",
+                "options": {
+                  "fields": {},
+                  "sort": [
+                    {
+                      "desc": false,
+                      "field": "kpi2"
+                    }
+                  ]
+                }
+              }
+            ],
+            "type": "bargauge"
+          }
+        ],
+        "title": "Traffic Managers",
+        "type": "row"
+      },
+      {
+        "collapsed": true,
+        "gridPos": {
+          "h": 1,
+          "w": 24,
+          "x": 0,
+          "y": 16
+        },
+        "id": 40,
+        "panels": [
+          {
+            "datasource": {
+              "type": "datasource",
+              "uid": "-- Dashboard --"
+            },
+            "fieldConfig": {
+              "defaults": {
+                "color": {
+                  "mode": "thresholds"
+                },
+                "mappings": [],
+                "max": 25,
+                "min": 0,
+                "thresholds": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "#808080"
+                    },
+                    {
+                      "color": "dark-green",
+                      "value": 0
+                    },
+                    {
+                      "color": "dark-red",
+                      "value": 1
+                    }
+                  ]
+                }
+              },
+              "overrides": []
+            },
+            "gridPos": {
+              "h": 12,
+              "w": 6,
+              "x": 0,
+              "y": 89
+            },
+            "id": 42,
+            "options": {
+              "displayMode": "basic",
+              "minVizHeight": 10,
+              "minVizWidth": 0,
+              "orientation": "horizontal",
+              "reduceOptions": {
+                "calcs": [
+                  "lastNotNull"
+                ],
+                "fields": "",
+                "values": true
+              },
+              "showUnfilled": true,
+              "valueMode": "color"
+            },
+                "targets": [
+              {
+                "datasource": {
+                  "type": "datasource",
+                  "uid": "-- Dashboard --"
+                },
+                "panelId": 41,
+                "refId": "A"
+              }
+            ],
+            "title": "Application Gateway Unhealthy Host Count",
+            "transformations": [
+              {
+                "id": "organize",
+                "options": {
+                  "excludeByName": {
+                    "_ResourceId": true,
+                    "health": true,
+                    "health1": true,
+                    "health2": true,
+                    "health3": true,
+                    "kpi2": true,
+                    "kpi3": true
+                  },
+                  "indexByName": {},
+                  "renameByName": {}
+                }
+              },
+              {
+                "id": "sortBy",
+                "options": {
+                  "fields": {},
+                  "sort": [
+                    {
+                      "desc": true,
+                      "field": "kpi1"
+                    }
+                  ]
+                }
+              }
+            ],
+            "type": "bargauge"
+          },
+          {
+            "datasource": {
+              "type": "datasource",
+              "uid": "-- Dashboard --"
+            },
+            "fieldConfig": {
+              "defaults": {
+                "color": {
+                  "mode": "thresholds"
+                },
+                "mappings": [],
+                "max": 500,
+                "min": 0,
+                "thresholds": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "#808080"
+                    },
+                    {
+                      "color": "dark-green",
+                      "value": 0
+                    },
+                    {
+                      "color": "dark-red",
+                      "value": 10
+                    }
+                  ]
+                }
+              },
+              "overrides": []
+            },
+            "gridPos": {
+              "h": 12,
+              "w": 6,
+              "x": 6,
+              "y": 89
+            },
+            "id": 43,
+            "options": {
+              "displayMode": "basic",
+              "minVizHeight": 10,
+              "minVizWidth": 0,
+              "orientation": "horizontal",
+              "reduceOptions": {
+                "calcs": [
+                  "lastNotNull"
+                ],
+                "fields": "",
+                "values": true
+              },
+              "showUnfilled": true,
+              "valueMode": "color"
+            },
+                "targets": [
+              {
+                "datasource": {
+                  "type": "datasource",
+                  "uid": "-- Dashboard --"
+                },
+                "panelId": 41,
+                "refId": "A"
+              }
+            ],
+            "title": "Application Gateway Failed Requests",
+            "transformations": [
+              {
+                "id": "organize",
+                "options": {
+                  "excludeByName": {
+                    "_ResourceId": true,
+                    "health": true,
+                    "health1": true,
+                    "health2": true,
+                    "health3": true,
+                    "kpi1": true,
+                    "kpi2": false,
+                    "kpi3": true
+                  },
+                  "indexByName": {},
+                  "renameByName": {}
+                }
+              },
+              {
+                "id": "sortBy",
+                "options": {
+                  "fields": {},
+                  "sort": [
+                    {
+                      "desc": true,
+                      "field": "kpi2"
+                    }
+                  ]
+                }
+              }
+            ],
+            "type": "bargauge"
+          },
+          {
+            "datasource": {
+              "type": "datasource",
+              "uid": "-- Dashboard --"
+            },
+            "fieldConfig": {
+              "defaults": {
+                "color": {
+                  "mode": "thresholds"
+                },
+                "mappings": [],
+                "max": 25,
+                "min": 0,
+                "thresholds": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "#808080"
+                    },
+                    {
+                      "color": "dark-red",
+                      "value": 0
+                    },
+                    {
+                      "color": "dark-green",
+                      "value": 1
+                    }
+                  ]
+                }
+              },
+              "overrides": []
+            },
+            "gridPos": {
+              "h": 12,
+              "w": 6,
+              "x": 12,
+              "y": 89
+            },
+            "id": 44,
+            "options": {
+              "displayMode": "basic",
+              "minVizHeight": 10,
+              "minVizWidth": 0,
+              "orientation": "horizontal",
+              "reduceOptions": {
+                "calcs": [
+                  "lastNotNull"
+                ],
+                "fields": "",
+                "values": true
+              },
+              "showUnfilled": true,
+              "valueMode": "color"
+            },
+                "targets": [
+              {
+                "datasource": {
+                  "type": "datasource",
+                  "uid": "-- Dashboard --"
+                },
+                "panelId": 41,
+                "refId": "A"
+              }
+            ],
+            "title": "Application Gateway Healthy Host Count",
+            "transformations": [
+              {
+                "id": "organize",
+                "options": {
+                  "excludeByName": {
+                    "_ResourceId": true,
+                    "health": true,
+                    "health1": true,
+                    "health2": true,
+                    "health3": true,
+                    "kpi1": true,
+                    "kpi2": true,
+                    "kpi3": false
+                  },
+                  "indexByName": {},
+                  "renameByName": {}
+                }
+              },
+              {
+                "id": "sortBy",
+                "options": {
+                  "fields": {},
+                  "sort": [
+                    {
+                      "desc": false,
+                      "field": "kpi3"
+                    }
+                  ]
+                }
+              }
+            ],
+            "type": "bargauge"
+          }
+        ],
+        "title": "Application Gateways",
+        "type": "row"
+      },
+      {
+        "collapsed": true,
+        "gridPos": {
+          "h": 1,
+          "w": 24,
+          "x": 0,
+          "y": 17
+        },
+        "id": 52,
+        "panels": [
+          {
+            "datasource": {
+              "type": "datasource",
+              "uid": "-- Dashboard --"
+            },
+            "fieldConfig": {
+              "defaults": {
+                "color": {
+                  "mode": "thresholds"
+                },
+                "mappings": [],
+                "max": 500,
+                "min": 0,
+                "thresholds": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "#808080"
+                    },
+                    {
+                      "color": "dark-green",
+                      "value": 0
+                    },
+                    {
+                      "color": "dark-red",
+                      "value": 100
+                    }
+                  ]
+                }
+              },
+              "overrides": []
+            },
+            "gridPos": {
+              "h": 12,
+              "w": 6,
+              "x": 0,
+              "y": 102
+            },
+            "id": 69,
+            "options": {
+              "displayMode": "basic",
+              "minVizHeight": 10,
+              "minVizWidth": 0,
+              "orientation": "horizontal",
+              "reduceOptions": {
+                "calcs": [
+                  "lastNotNull"
+                ],
+                "fields": "",
+                "values": true
+              },
+              "showUnfilled": true,
+              "valueMode": "color"
+            },
+                "targets": [
+              {
+                "datasource": {
+                  "type": "datasource",
+                  "uid": "-- Dashboard --"
+                },
+                "panelId": 53,
+                "refId": "A"
+              }
+            ],
+            "title": "Front Door Total Latency",
+            "transformations": [
+              {
+                "id": "organize",
+                "options": {
+                  "excludeByName": {
+                    "_ResourceId": true,
+                    "health": true,
+                    "health1": true,
+                    "health2": true,
+                    "health3": true,
+                    "kpi2": true,
+                    "kpi3": true
+                  },
+                  "indexByName": {},
+                  "renameByName": {}
+                }
+              },
+              {
+                "id": "sortBy",
+                "options": {
+                  "fields": {},
+                  "sort": [
+                    {
+                      "desc": true,
+                      "field": "kpi1"
+                    }
+                  ]
+                }
+              }
+            ],
+            "type": "bargauge"
+          },
+          {
+            "datasource": {
+              "type": "datasource",
+              "uid": "-- Dashboard --"
+            },
+            "fieldConfig": {
+              "defaults": {
+                "color": {
+                  "mode": "thresholds"
+                },
+                "mappings": [],
+                "max": 500,
+                "min": 0,
+                "thresholds": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "#808080"
+                    },
+                    {
+                      "color": "dark-red",
+                      "value": 0
+                    },
+                    {
+                      "color": "dark-green",
+                      "value": 50
+                    }
+                  ]
+                }
+              },
+              "overrides": []
+            },
+            "gridPos": {
+              "h": 12,
+              "w": 6,
+              "x": 6,
+              "y": 102
+            },
+            "id": 70,
+            "options": {
+              "displayMode": "basic",
+              "minVizHeight": 10,
+              "minVizWidth": 0,
+              "orientation": "horizontal",
+              "reduceOptions": {
+                "calcs": [
+                  "lastNotNull"
+                ],
+                "fields": "",
+                "values": true
+              },
+              "showUnfilled": true,
+              "valueMode": "color"
+            },
+                "targets": [
+              {
+                "datasource": {
+                  "type": "datasource",
+                  "uid": "-- Dashboard --"
+                },
+                "panelId": 53,
+                "refId": "A"
+              }
+            ],
+            "title": "Front Door Byte Hit Ratio",
+            "transformations": [
+              {
+                "id": "organize",
+                "options": {
+                  "excludeByName": {
+                    "_ResourceId": true,
+                    "health": true,
+                    "health1": true,
+                    "health2": true,
+                    "health3": true,
+                    "kpi2": true,
+                    "kpi3": true
+                  },
+                  "indexByName": {},
+                  "renameByName": {}
+                }
+              },
+              {
+                "id": "sortBy",
+                "options": {
+                  "fields": {},
+                  "sort": [
+                    {
+                      "desc": true,
+                      "field": "kpi1"
+                    }
+                  ]
+                }
+              }
+            ],
+            "type": "bargauge"
+          },
+          {
+            "datasource": {
+              "type": "datasource",
+              "uid": "-- Dashboard --"
+            },
+            "fieldConfig": {
+              "defaults": {
+                "color": {
+                  "mode": "thresholds"
+                },
+                "mappings": [],
+                "max": 100,
+                "min": 0,
+                "thresholds": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "#808080"
+                    },
+                    {
+                      "color": "dark-red",
+                      "value": 0
+                    },
+                    {
+                      "color": "dark-green",
+                      "value": 95
+                    }
+                  ]
+                }
+              },
+              "overrides": []
+            },
+            "gridPos": {
+              "h": 12,
+              "w": 6,
+              "x": 12,
+              "y": 102
+            },
+            "id": 71,
+            "options": {
+              "displayMode": "basic",
+              "minVizHeight": 10,
+              "minVizWidth": 0,
+              "orientation": "horizontal",
+              "reduceOptions": {
+                "calcs": [
+                  "lastNotNull"
+                ],
+                "fields": "",
+                "values": true
+              },
+              "showUnfilled": true,
+              "valueMode": "color"
+            },
+                "targets": [
+              {
+                "datasource": {
+                  "type": "datasource",
+                  "uid": "-- Dashboard --"
+                },
+                "panelId": 53,
+                "refId": "A"
+              }
+            ],
+            "title": "Front Door Origin Health Percentage",
+            "transformations": [
+              {
+                "id": "organize",
+                "options": {
+                  "excludeByName": {
+                    "_ResourceId": true,
+                    "health": true,
+                    "health1": true,
+                    "health2": true,
+                    "health3": true,
+                    "kpi2": true,
+                    "kpi3": true
+                  },
+                  "indexByName": {},
+                  "renameByName": {}
+                }
+              },
+              {
+                "id": "sortBy",
+                "options": {
+                  "fields": {},
+                  "sort": [
+                    {
+                      "desc": false,
+                      "field": "kpi1"
+                    }
+                  ]
+                }
+              }
+            ],
+            "type": "bargauge"
+          }
+        ],
+        "title": "Front Doors",
+        "type": "row"
+      },
+      {
+        "collapsed": true,
+        "gridPos": {
+          "h": 1,
+          "w": 24,
+          "x": 0,
+          "y": 18
+        },
+        "id": 49,
+        "panels": [
+          {
+            "datasource": {
+              "type": "datasource",
+              "uid": "-- Dashboard --"
+            },
+            "fieldConfig": {
+              "defaults": {
+                "color": {
+                  "mode": "thresholds"
+                },
+                "mappings": [],
+                "max": 100,
+                "min": 0,
+                "thresholds": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "#808080"
+                    },
+                    {
+                      "color": "dark-red",
+                      "value": 0
+                    },
+                    {
+                      "color": "dark-green",
+                      "value": 99
+                    }
+                  ]
+                }
+              },
+              "overrides": []
+            },
+            "gridPos": {
+              "h": 12,
+              "w": 6,
+              "x": 0,
+              "y": 115
+            },
+            "id": 72,
+            "options": {
+              "displayMode": "basic",
+              "minVizHeight": 10,
+              "minVizWidth": 0,
+              "orientation": "horizontal",
+              "reduceOptions": {
+                "calcs": [
+                  "lastNotNull"
+                ],
+                "fields": "",
+                "values": true
+              },
+              "showUnfilled": true,
+              "valueMode": "color"
+            },
+                "targets": [
+              {
+                "datasource": {
+                  "type": "datasource",
+                  "uid": "-- Dashboard --"
+                },
+                "panelId": 50,
+                "refId": "A"
+              }
+            ],
+            "title": "Public IP Availability",
+            "transformations": [
+              {
+                "id": "organize",
+                "options": {
+                  "excludeByName": {
+                    "_ResourceId": true,
+                    "health": true,
+                    "health1": true,
+                    "health2": true,
+                    "health3": true,
+                    "kpi1": false,
+                    "kpi2": true,
+                    "kpi3": true
+                  },
+                  "indexByName": {},
+                  "renameByName": {}
+                }
+              },
+              {
+                "id": "sortBy",
+                "options": {
+                  "fields": {},
+                  "sort": [
+                    {
+                      "desc": false,
+                      "field": "kpi1"
+                    }
+                  ]
+                }
+              }
+            ],
+            "type": "bargauge"
+          },
+          {
+            "datasource": {
+              "type": "datasource",
+              "uid": "-- Dashboard --"
+            },
+            "fieldConfig": {
+              "defaults": {
+                "color": {
+                  "mode": "thresholds"
+                },
+                "mappings": [],
+                "max": 1,
+                "min": 0,
+                "thresholds": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "#808080"
+                    },
+                    {
+                      "color": "dark-green",
+                      "value": 0
+                    },
+                    {
+                      "color": "dark-red",
+                      "value": 0.001
+                    }
+                  ]
+                }
+              },
+              "overrides": []
+            },
+            "gridPos": {
+              "h": 12,
+              "w": 6,
+              "x": 6,
+              "y": 115
+            },
+            "id": 95,
+            "options": {
+              "displayMode": "basic",
+              "minVizHeight": 10,
+              "minVizWidth": 0,
+              "orientation": "horizontal",
+              "reduceOptions": {
+                "calcs": [
+                  "lastNotNull"
+                ],
+                "fields": "",
+                "values": true
+              },
+              "showUnfilled": true,
+              "valueMode": "color"
+            },
+                "targets": [
+              {
+                "datasource": {
+                  "type": "datasource",
+                  "uid": "-- Dashboard --"
+                },
+                "panelId": 50,
+                "refId": "A"
+              }
+            ],
+            "title": "Virtual Network Under DDoS Attack",
+            "transformations": [
+              {
+                "id": "organize",
+                "options": {
+                  "excludeByName": {
+                    "_ResourceId": true,
+                    "health": true,
+                    "health1": true,
+                    "health2": true,
+                    "health3": true,
+                    "kpi1": true,
+                    "kpi2": false,
+                    "kpi3": true
+                  },
+                  "indexByName": {},
+                  "renameByName": {}
+                }
+              },
+              {
+                "id": "sortBy",
+                "options": {
+                  "fields": {},
+                  "sort": [
+                    {
+                      "desc": true,
+                      "field": "kpi1"
+                    }
+                  ]
+                }
+              }
+            ],
+            "type": "bargauge"
+          },
+          {
+            "datasource": {
+              "type": "datasource",
+              "uid": "-- Dashboard --"
+            },
+            "fieldConfig": {
+              "defaults": {
+                "color": {
+                  "mode": "thresholds"
+                },
+                "mappings": [],
+                "max": 50000,
+                "min": 0,
+                "thresholds": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "#808080"
+                    },
+                    {
+                      "color": "dark-green",
+                      "value": 0
+                    },
+                    {
+                      "color": "dark-red",
+                      "value": 1000
+                    }
+                  ]
+                }
+              },
+              "overrides": []
+            },
+            "gridPos": {
+              "h": 12,
+              "w": 6,
+              "x": 12,
+              "y": 115
+            },
+            "id": 96,
+            "options": {
+              "displayMode": "basic",
+              "minVizHeight": 10,
+              "minVizWidth": 0,
+              "orientation": "horizontal",
+              "reduceOptions": {
+                "calcs": [
+                  "lastNotNull"
+                ],
+                "fields": "",
+                "values": true
+              },
+              "showUnfilled": true,
+              "valueMode": "color"
+            },
+                "targets": [
+              {
+                "datasource": {
+                  "type": "datasource",
+                  "uid": "-- Dashboard --"
+                },
+                "panelId": 50,
+                "refId": "A"
+              }
+            ],
+            "title": "Virtual Network Inbound Packets DDoS",
+            "transformations": [
+              {
+                "id": "organize",
+                "options": {
+                  "excludeByName": {
+                    "_ResourceId": true,
+                    "health": true,
+                    "health1": true,
+                    "health2": true,
+                    "health3": true,
+                    "kpi1": true,
+                    "kpi2": true,
+                    "kpi3": false
+                  },
+                  "indexByName": {},
+                  "renameByName": {}
+                }
+              },
+              {
+                "id": "sortBy",
+                "options": {
+                  "fields": {},
+                  "sort": [
+                    {
+                      "desc": true,
+                      "field": "kpi1"
+                    }
+                  ]
+                }
+              }
+            ],
+            "type": "bargauge"
+          }
+        ],
+        "title": "Public IPs",
+        "type": "row"
+      },
+      {
+        "collapsed": true,
+        "gridPos": {
+          "h": 1,
+          "w": 24,
+          "x": 0,
+          "y": 19
+        },
+        "id": 58,
+        "panels": [
+          {
+            "datasource": {
+              "type": "datasource",
+              "uid": "-- Dashboard --"
+            },
+            "fieldConfig": {
+              "defaults": {
+                "color": {
+                  "mode": "thresholds"
+                },
+                "mappings": [],
+                "max": 100,
+                "min": 0,
+                "thresholds": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "#808080"
+                    },
+                    {
+                      "color": "dark-red",
+                      "value": 0
+                    },
+                    {
+                      "color": "dark-green",
+                      "value": 90
+                    }
+                  ]
+                }
+              },
+              "overrides": []
+            },
+            "gridPos": {
+              "h": 12,
+              "w": 6,
+              "x": 0,
+              "y": 128
+            },
+            "id": 78,
+            "options": {
+              "displayMode": "basic",
+              "minVizHeight": 10,
+              "minVizWidth": 0,
+              "orientation": "horizontal",
+              "reduceOptions": {
+                "calcs": [
+                  "lastNotNull"
+                ],
+                "fields": "",
+                "values": true
+              },
+              "showUnfilled": true,
+              "valueMode": "color"
+            },
+                "targets": [
+              {
+                "datasource": {
+                  "type": "datasource",
+                  "uid": "-- Dashboard --"
+                },
+                "panelId": 59,
+                "refId": "A"
+              }
+            ],
+            "title": "Firewall Health",
+            "transformations": [
+              {
+                "id": "organize",
+                "options": {
+                  "excludeByName": {
+                    "_ResourceId": true,
+                    "health": true,
+                    "health1": true,
+                    "health2": true,
+                    "health3": true,
+                    "kpi1": false,
+                    "kpi2": true,
+                    "kpi3": true
+                  },
+                  "indexByName": {},
+                  "renameByName": {}
+                }
+              },
+              {
+                "id": "sortBy",
+                "options": {
+                  "fields": {},
+                  "sort": [
+                    {
+                      "desc": false,
+                      "field": "kpi1"
+                    }
+                  ]
+                }
+              }
+            ],
+            "type": "bargauge"
+          },
+          {
+            "datasource": {
+              "type": "datasource",
+              "uid": "-- Dashboard --"
+            },
+            "fieldConfig": {
+              "defaults": {
+                "color": {
+                  "mode": "thresholds"
+                },
+                "mappings": [],
+                "max": 1000,
+                "min": 0,
+                "thresholds": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "#808080"
+                    },
+                    {
+                      "color": "dark-green",
+                      "value": 0
+                    },
+                    {
+                      "color": "dark-red",
+                      "value": 80
+                    }
+                  ]
+                }
+              },
+              "overrides": []
+            },
+            "gridPos": {
+              "h": 12,
+              "w": 6,
+              "x": 6,
+              "y": 128
+            },
+            "id": 79,
+            "options": {
+              "displayMode": "basic",
+              "minVizHeight": 10,
+              "minVizWidth": 0,
+              "orientation": "horizontal",
+              "reduceOptions": {
+                "calcs": [
+                  "lastNotNull"
+                ],
+                "fields": "",
+                "values": true
+              },
+              "showUnfilled": true,
+              "valueMode": "color"
+            },
+                "targets": [
+              {
+                "datasource": {
+                  "type": "datasource",
+                  "uid": "-- Dashboard --"
+                },
+                "panelId": 59,
+                "refId": "A"
+              }
+            ],
+            "title": "Firewall SNAT Port Utilization",
+            "transformations": [
+              {
+                "id": "organize",
+                "options": {
+                  "excludeByName": {
+                    "_ResourceId": true,
+                    "health": true,
+                    "health1": true,
+                    "health2": true,
+                    "health3": true,
+                    "kpi1": true,
+                    "kpi2": false,
+                    "kpi3": true
+                  },
+                  "indexByName": {},
+                  "renameByName": {}
+                }
+              },
+              {
+                "id": "sortBy",
+                "options": {
+                  "fields": {},
+                  "sort": [
+                    {
+                      "desc": true,
+                      "field": "kpi1"
+                    }
+                  ]
+                }
+              }
+            ],
+            "type": "bargauge"
+          }
+        ],
+        "title": "Firewalls",
+        "type": "row"
+      },
+      {
+        "collapsed": true,
+        "gridPos": {
+          "h": 1,
+          "w": 24,
+          "x": 0,
+          "y": 20
+        },
+        "id": 55,
+        "panels": [
+          {
+            "datasource": {
+              "type": "datasource",
+              "uid": "-- Dashboard --"
+            },
+            "fieldConfig": {
+              "defaults": {
+                "color": {
+                  "mode": "thresholds"
+                },
+                "mappings": [],
+                "max": 1,
+                "min": 0,
+                "thresholds": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "#808080"
+                    },
+                    {
+                      "color": "dark-green",
+                      "value": 0
+                    },
+                    {
+                      "color": "dark-red",
+                      "value": 0.001
+                    }
+                  ]
+                }
+              },
+              "overrides": []
+            },
+            "gridPos": {
+              "h": 12,
+              "w": 6,
+              "x": 0,
+              "y": 141
+            },
+            "id": 34,
+            "options": {
+              "displayMode": "basic",
+              "minVizHeight": 10,
+              "minVizWidth": 0,
+              "orientation": "horizontal",
+              "reduceOptions": {
+                "calcs": [
+                  "lastNotNull"
+                ],
+                "fields": "",
+                "values": true
+              },
+              "showUnfilled": true,
+              "valueMode": "color"
+            },
+                "targets": [
+              {
+                "datasource": {
+                  "type": "datasource",
+                  "uid": "-- Dashboard --"
+                },
+                "panelId": 54,
+                "refId": "A"
+              }
+            ],
+            "title": "Virtual Network Under DDoS Attack",
+            "transformations": [
+              {
+                "id": "organize",
+                "options": {
+                  "excludeByName": {
+                    "_ResourceId": true,
+                    "health": true,
+                    "health1": true,
+                    "health2": true,
+                    "health3": true,
+                    "kpi1": false,
+                    "kpi2": true,
+                    "kpi3": true
+                  },
+                  "indexByName": {},
+                  "renameByName": {}
+                }
+              },
+              {
+                "id": "sortBy",
+                "options": {
+                  "fields": {},
+                  "sort": [
+                    {
+                      "desc": true,
+                      "field": "kpi1"
+                    }
+                  ]
+                }
+              }
+            ],
+            "type": "bargauge"
+          },
+          {
+            "datasource": {
+              "type": "datasource",
+              "uid": "-- Dashboard --"
+            },
+            "fieldConfig": {
+              "defaults": {
+                "color": {
+                  "mode": "thresholds"
+                },
+                "mappings": [],
+                "max": 50000,
+                "min": 0,
+                "thresholds": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "#808080"
+                    },
+                    {
+                      "color": "dark-green",
+                      "value": 0
+                    },
+                    {
+                      "color": "dark-red",
+                      "value": 1000
+                    }
+                  ]
+                }
+              },
+              "overrides": []
+            },
+            "gridPos": {
+              "h": 12,
+              "w": 6,
+              "x": 6,
+              "y": 141
+            },
+            "id": 73,
+            "options": {
+              "displayMode": "basic",
+              "minVizHeight": 10,
+              "minVizWidth": 0,
+              "orientation": "horizontal",
+              "reduceOptions": {
+                "calcs": [
+                  "lastNotNull"
+                ],
+                "fields": "",
+                "values": true
+              },
+              "showUnfilled": true,
+              "valueMode": "color"
+            },
+                "targets": [
+              {
+                "datasource": {
+                  "type": "datasource",
+                  "uid": "-- Dashboard --"
+                },
+                "panelId": 54,
+                "refId": "A"
+              }
+            ],
+            "title": "Virtual Network Inbound Packets DDoS",
+            "transformations": [
+              {
+                "id": "organize",
+                "options": {
+                  "excludeByName": {
+                    "_ResourceId": true,
+                    "health": true,
+                    "health1": true,
+                    "health2": true,
+                    "health3": true,
+                    "kpi1": true,
+                    "kpi2": false,
+                    "kpi3": true
+                  },
+                  "indexByName": {},
+                  "renameByName": {}
+                }
+              },
+              {
+                "id": "sortBy",
+                "options": {
+                  "fields": {},
+                  "sort": [
+                    {
+                      "desc": true,
+                      "field": "kpi1"
+                    }
+                  ]
+                }
+              }
+            ],
+            "type": "bargauge"
+          },
+          {
+            "datasource": {
+              "type": "datasource",
+              "uid": "-- Dashboard --"
+            },
+            "fieldConfig": {
+              "defaults": {
+                "color": {
+                  "mode": "thresholds"
+                },
+                "mappings": [],
+                "max": 5000,
+                "min": 0,
+                "thresholds": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "#808080"
+                    },
+                    {
+                      "color": "dark-green",
+                      "value": 0
+                    },
+                    {
+                      "color": "dark-red",
+                      "value": 1
+                    }
+                  ]
+                }
+              },
+              "overrides": []
+            },
+            "gridPos": {
+              "h": 12,
+              "w": 6,
+              "x": 12,
+              "y": 141
+            },
+            "id": 74,
+            "options": {
+              "displayMode": "basic",
+              "minVizHeight": 10,
+              "minVizWidth": 0,
+              "orientation": "horizontal",
+              "reduceOptions": {
+                "calcs": [
+                  "lastNotNull"
+                ],
+                "fields": "",
+                "values": true
+              },
+              "showUnfilled": true,
+              "valueMode": "color"
+            },
+                "targets": [
+              {
+                "datasource": {
+                  "type": "datasource",
+                  "uid": "-- Dashboard --"
+                },
+                "panelId": 54,
+                "refId": "A"
+              }
+            ],
+            "title": "Virtual Network Packets Forwarded DDoS",
+            "transformations": [
+              {
+                "id": "organize",
+                "options": {
+                  "excludeByName": {
+                    "_ResourceId": true,
+                    "health": true,
+                    "health1": true,
+                    "health2": true,
+                    "health3": true,
+                    "kpi1": true,
+                    "kpi2": true,
+                    "kpi3": false
+                  },
+                  "indexByName": {},
+                  "renameByName": {}
+                }
+              },
+              {
+                "id": "sortBy",
+                "options": {
+                  "fields": {},
+                  "sort": [
+                    {
+                      "desc": true,
+                      "field": "kpi1"
+                    }
+                  ]
+                }
+              }
+            ],
+            "type": "bargauge"
+          }
+        ],
+        "title": "Virtual Networks",
+        "type": "row"
+      },
+      {
+        "collapsed": true,
+        "gridPos": {
+          "h": 1,
+          "w": 24,
+          "x": 0,
+          "y": 21
+        },
+        "id": 56,
+        "panels": [
+          {
+            "datasource": {
+              "type": "datasource",
+              "uid": "-- Dashboard --"
+            },
+            "fieldConfig": {
+              "defaults": {
+                "color": {
+                  "mode": "thresholds"
+                },
+                "mappings": [],
+                "max": 100000,
+                "min": 0,
+                "thresholds": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "#808080"
+                    },
+                    {
+                      "color": "dark-red",
+                      "value": 0
+                    },
+                    {
+                      "color": "dark-green",
+                      "value": 1
+                    }
+                  ]
+                }
+              },
+              "overrides": []
+            },
+            "gridPos": {
+              "h": 12,
+              "w": 6,
+              "x": 0,
+              "y": 154
+            },
+            "id": 75,
+            "options": {
+              "displayMode": "basic",
+              "minVizHeight": 10,
+              "minVizWidth": 0,
+              "orientation": "horizontal",
+              "reduceOptions": {
+                "calcs": [
+                  "lastNotNull"
+                ],
+                "fields": "",
+                "values": true
+              },
+              "showUnfilled": true,
+              "valueMode": "color"
+            },
+                "targets": [
+              {
+                "datasource": {
+                  "type": "datasource",
+                  "uid": "-- Dashboard --"
+                },
+                "panelId": 57,
+                "refId": "A"
+              }
+            ],
+            "title": "VPN Gateway Tunnel Bandwidth",
+            "transformations": [
+              {
+                "id": "organize",
+                "options": {
+                  "excludeByName": {
+                    "_ResourceId": true,
+                    "health": true,
+                    "health1": true,
+                    "health2": true,
+                    "health3": true,
+                    "kpi1": false,
+                    "kpi2": true,
+                    "kpi3": false
+                  },
+                  "indexByName": {},
+                  "renameByName": {}
+                }
+              },
+              {
+                "id": "sortBy",
+                "options": {
+                  "fields": {},
+                  "sort": [
+                    {
+                      "desc": false,
+                      "field": "kpi1"
+                    }
+                  ]
+                }
+              }
+            ],
+            "type": "bargauge"
+          },
+          {
+            "datasource": {
+              "type": "datasource",
+              "uid": "-- Dashboard --"
+            },
+            "fieldConfig": {
+              "defaults": {
+                "color": {
+                  "mode": "thresholds"
+                },
+                "mappings": [],
+                "max": 8000000000,
+                "min": 0,
+                "thresholds": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "#808080"
+                    },
+                    {
+                      "color": "dark-red",
+                      "value": 0
+                    },
+                    {
+                      "color": "dark-green",
+                      "value": 2
+                    }
+                  ]
+                }
+              },
+              "overrides": []
+            },
+            "gridPos": {
+              "h": 12,
+              "w": 6,
+              "x": 6,
+              "y": 154
+            },
+            "id": 76,
+            "options": {
+              "displayMode": "basic",
+              "minVizHeight": 10,
+              "minVizWidth": 0,
+              "orientation": "horizontal",
+              "reduceOptions": {
+                "calcs": [
+                  "lastNotNull"
+                ],
+                "fields": "",
+                "values": true
+              },
+              "showUnfilled": true,
+              "valueMode": "color"
+            },
+                "targets": [
+              {
+                "datasource": {
+                  "type": "datasource",
+                  "uid": "-- Dashboard --"
+                },
+                "panelId": 57,
+                "refId": "A"
+              }
+            ],
+            "title": "VPN Gateway Tunnel Egress Bytes",
+            "transformations": [
+              {
+                "id": "organize",
+                "options": {
+                  "excludeByName": {
+                    "_ResourceId": true,
+                    "health": true,
+                    "health1": true,
+                    "health2": true,
+                    "health3": true,
+                    "kpi1": false,
+                    "kpi2": true,
+                    "kpi3": false
+                  },
+                  "indexByName": {},
+                  "renameByName": {}
+                }
+              },
+              {
+                "id": "sortBy",
+                "options": {
+                  "fields": {},
+                  "sort": [
+                    {
+                      "desc": false,
+                      "field": "kpi1"
+                    }
+                  ]
+                }
+              }
+            ],
+            "type": "bargauge"
+          },
+          {
+            "datasource": {
+              "type": "datasource",
+              "uid": "-- Dashboard --"
+            },
+            "fieldConfig": {
+              "defaults": {
+                "color": {
+                  "mode": "thresholds"
+                },
+                "mappings": [],
+                "max": 8000000000,
+                "min": 0,
+                "thresholds": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "#808080"
+                    },
+                    {
+                      "color": "dark-red",
+                      "value": 0
+                    },
+                    {
+                      "color": "dark-green",
+                      "value": 2
+                    }
+                  ]
+                }
+              },
+              "overrides": []
+            },
+            "gridPos": {
+              "h": 12,
+              "w": 6,
+              "x": 12,
+              "y": 154
+            },
+            "id": 77,
+            "options": {
+              "displayMode": "basic",
+              "minVizHeight": 10,
+              "minVizWidth": 0,
+              "orientation": "horizontal",
+              "reduceOptions": {
+                "calcs": [
+                  "lastNotNull"
+                ],
+                "fields": "",
+                "values": true
+              },
+              "showUnfilled": true,
+              "valueMode": "color"
+            },
+                "targets": [
+              {
+                "datasource": {
+                  "type": "datasource",
+                  "uid": "-- Dashboard --"
+                },
+                "panelId": 57,
+                "refId": "A"
+              }
+            ],
+            "title": "VPN Gateway Tunnel Ingress Bytes",
+            "transformations": [
+              {
+                "id": "organize",
+                "options": {
+                  "excludeByName": {
+                    "_ResourceId": true,
+                    "health": true,
+                    "health1": true,
+                    "health2": true,
+                    "health3": true,
+                    "kpi1": false,
+                    "kpi2": true,
+                    "kpi3": false
+                  },
+                  "indexByName": {},
+                  "renameByName": {}
+                }
+              },
+              {
+                "id": "sortBy",
+                "options": {
+                  "fields": {},
+                  "sort": [
+                    {
+                      "desc": false,
+                      "field": "kpi1"
+                    }
+                  ]
+                }
+              }
+            ],
+            "type": "bargauge"
+          }
+        ],
+        "title": "VPN Gateways",
+        "type": "row"
+      },
+      {
+        "collapsed": true,
+        "gridPos": {
+          "h": 1,
+          "w": 24,
+          "x": 0,
+          "y": 22
+        },
+        "id": 67,
+        "panels": [
+          {
+            "datasource": {
+              "type": "datasource",
+              "uid": "-- Dashboard --"
+            },
+            "fieldConfig": {
+              "defaults": {
+                "color": {
+                  "mode": "thresholds"
+                },
+                "mappings": [],
+                "max": 100,
+                "min": 0,
+                "thresholds": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "#808080"
+                    },
+                    {
+                      "color": "dark-red",
+                      "value": 0
+                    },
+                    {
+                      "color": "dark-green",
+                      "value": 90
+                    }
+                  ]
+                }
+              },
+              "overrides": []
+            },
+            "gridPos": {
+              "h": 12,
+              "w": 6,
+              "x": 0,
+              "y": 167
+            },
+            "id": 87,
+            "options": {
+              "displayMode": "basic",
+              "minVizHeight": 10,
+              "minVizWidth": 0,
+              "orientation": "horizontal",
+              "reduceOptions": {
+                "calcs": [
+                  "lastNotNull"
+                ],
+                "fields": "",
+                "values": true
+              },
+              "showUnfilled": true,
+              "valueMode": "color"
+            },
+                "targets": [
+              {
+                "datasource": {
+                  "type": "datasource",
+                  "uid": "-- Dashboard --"
+                },
+                "panelId": 68,
+                "refId": "A"
+              }
+            ],
+            "title": "Express Route Circuit BGP Availability",
+            "transformations": [
+              {
+                "id": "organize",
+                "options": {
+                  "excludeByName": {
+                    "Health": true,
+                    "_ResourceId": true,
+                    "health": true,
+                    "health1": true,
+                    "health2": true,
+                    "health3": true,
+                    "kpi1": false,
+                    "kpi2": true,
+                    "kpi3": true,
+                    "kpi4": true
+                  },
+                  "indexByName": {},
+                  "renameByName": {}
+                }
+              },
+              {
+                "id": "sortBy",
+                "options": {
+                  "fields": {},
+                  "sort": [
+                    {
+                      "desc": true,
+                      "field": "kpi1"
+                    }
+                  ]
+                }
+              }
+            ],
+            "type": "bargauge"
+          },
+          {
+            "datasource": {
+              "type": "datasource",
+              "uid": "-- Dashboard --"
+            },
+            "fieldConfig": {
+              "defaults": {
+                "color": {
+                  "mode": "thresholds"
+                },
+                "mappings": [],
+                "max": 100,
+                "min": 0,
+                "thresholds": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "#808080"
+                    },
+                    {
+                      "color": "dark-red",
+                      "value": 0
+                    },
+                    {
+                      "color": "dark-green",
+                      "value": 90
+                    }
+                  ]
+                }
+              },
+              "overrides": []
+            },
+            "gridPos": {
+              "h": 12,
+              "w": 6,
+              "x": 6,
+              "y": 167
+            },
+            "id": 97,
+            "options": {
+              "displayMode": "basic",
+              "minVizHeight": 10,
+              "minVizWidth": 0,
+              "orientation": "horizontal",
+              "reduceOptions": {
+                "calcs": [
+                  "lastNotNull"
+                ],
+                "fields": "",
+                "values": true
+              },
+              "showUnfilled": true,
+              "valueMode": "color"
+            },
+                "targets": [
+              {
+                "datasource": {
+                  "type": "datasource",
+                  "uid": "-- Dashboard --"
+                },
+                "panelId": 68,
+                "refId": "A"
+              }
+            ],
+            "title": "Express Route Circuit ARP Availability",
+            "transformations": [
+              {
+                "id": "organize",
+                "options": {
+                  "excludeByName": {
+                    "Health": true,
+                    "_ResourceId": true,
+                    "health": true,
+                    "health1": true,
+                    "health2": true,
+                    "health3": true,
+                    "kpi1": true,
+                    "kpi2": false,
+                    "kpi3": true,
+                    "kpi4": true
+                  },
+                  "indexByName": {},
+                  "renameByName": {}
+                }
+              },
+              {
+                "id": "sortBy",
+                "options": {
+                  "fields": {},
+                  "sort": [
+                    {
+                      "desc": true,
+                      "field": "kpi1"
+                    }
+                  ]
+                }
+              }
+            ],
+            "type": "bargauge"
+          },
+          {
+            "datasource": {
+              "type": "datasource",
+              "uid": "-- Dashboard --"
+            },
+            "description": "",
+            "fieldConfig": {
+              "defaults": {
+                "color": {
+                  "mode": "thresholds"
+                },
+                "mappings": [],
+                "max": 10000,
+                "min": 0,
+                "thresholds": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "#808080"
+                    },
+                    {
+                      "color": "dark-green",
+                      "value": 0
+                    },
+                    {
+                      "color": "dark-red",
+                      "value": 100
+                    }
+                  ]
+                }
+              },
+              "overrides": []
+            },
+            "gridPos": {
+              "h": 12,
+              "w": 6,
+              "x": 12,
+              "y": 167
+            },
+            "id": 88,
+            "options": {
+              "displayMode": "basic",
+              "minVizHeight": 10,
+              "minVizWidth": 0,
+              "orientation": "horizontal",
+              "reduceOptions": {
+                "calcs": [
+                  "lastNotNull"
+                ],
+                "fields": "",
+                "values": true
+              },
+              "showUnfilled": true,
+              "valueMode": "color"
+            },
+                "targets": [
+              {
+                "datasource": {
+                  "type": "datasource",
+                  "uid": "-- Dashboard --"
+                },
+                "panelId": 68,
+                "refId": "A"
+              }
+            ],
+            "title": "Express Route QoS Drop Bits In Per Second",
+            "transformations": [
+              {
+                "id": "organize",
+                "options": {
+                  "excludeByName": {
+                    "Health": true,
+                    "_ResourceId": true,
+                    "health": true,
+                    "health1": true,
+                    "health2": true,
+                    "health3": true,
+                    "kpi1": true,
+                    "kpi2": true,
+                    "kpi3": false,
+                    "kpi4": true
+                  },
+                  "indexByName": {},
+                  "renameByName": {}
+                }
+              },
+              {
+                "id": "sortBy",
+                "options": {
+                  "fields": {},
+                  "sort": [
+                    {
+                      "desc": true,
+                      "field": "kpi1"
+                    }
+                  ]
+                }
+              }
+            ],
+            "type": "bargauge"
+          },
+          {
+            "datasource": {
+              "type": "datasource",
+              "uid": "-- Dashboard --"
+            },
+            "description": "",
+            "fieldConfig": {
+              "defaults": {
+                "color": {
+                  "mode": "thresholds"
+                },
+                "mappings": [],
+                "max": 10000,
+                "min": 0,
+                "thresholds": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "#808080"
+                    },
+                    {
+                      "color": "dark-green",
+                      "value": 0
+                    },
+                    {
+                      "color": "dark-red",
+                      "value": 100
+                    }
+                  ]
+                }
+              },
+              "overrides": []
+            },
+            "gridPos": {
+              "h": 12,
+              "w": 6,
+              "x": 18,
+              "y": 167
+            },
+            "id": 89,
+            "options": {
+              "displayMode": "basic",
+              "minVizHeight": 10,
+              "minVizWidth": 0,
+              "orientation": "horizontal",
+              "reduceOptions": {
+                "calcs": [
+                  "lastNotNull"
+                ],
+                "fields": "",
+                "values": true
+              },
+              "showUnfilled": true,
+              "valueMode": "color"
+            },
+                "targets": [
+              {
+                "datasource": {
+                  "type": "datasource",
+                  "uid": "-- Dashboard --"
+                },
+                "panelId": 68,
+                "refId": "A"
+              }
+            ],
+            "title": "Express Route QoS Drop Bits Out Per Second",
+            "transformations": [
+              {
+                "id": "organize",
+                "options": {
+                  "excludeByName": {
+                    "Health": true,
+                    "_ResourceId": true,
+                    "health": true,
+                    "health1": true,
+                    "health2": true,
+                    "health3": true,
+                    "kpi1": true,
+                    "kpi2": true,
+                    "kpi3": true
+                  },
+                  "indexByName": {},
+                  "renameByName": {}
+                }
+              },
+              {
+                "id": "sortBy",
+                "options": {
+                  "fields": {},
+                  "sort": [
+                    {
+                      "desc": true,
+                      "field": "kpi1"
+                    }
+                  ]
+                }
+              }
+            ],
+            "type": "bargauge"
+          }
+        ],
+        "title": "ExpressRoute Circuits",
+        "type": "row"
+      },
+      {
+        "collapsed": true,
+        "gridPos": {
+          "h": 1,
+          "w": 24,
+          "x": 0,
+          "y": 23
+        },
+        "id": 65,
+        "panels": [
+          {
+            "datasource": {
+              "type": "datasource",
+              "uid": "-- Dashboard --"
+            },
+            "fieldConfig": {
+              "defaults": {
+                "color": {
+                  "mode": "thresholds"
+                },
+                "mappings": [],
+                "max": 100,
+                "min": 0,
+                "thresholds": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "#808080"
+                    },
+                    {
+                      "color": "dark-green",
+                      "value": 0
+                    },
+                    {
+                      "color": "dark-red",
+                      "value": 80
+                    }
+                  ]
+                }
+              },
+              "overrides": []
+            },
+            "gridPos": {
+              "h": 12,
+              "w": 6,
+              "x": 0,
+              "y": 180
+            },
+            "id": 84,
+            "options": {
+              "displayMode": "basic",
+              "minVizHeight": 10,
+              "minVizWidth": 0,
+              "orientation": "horizontal",
+              "reduceOptions": {
+                "calcs": [
+                  "lastNotNull"
+                ],
+                "fields": "",
+                "values": true
+              },
+              "showUnfilled": true,
+              "valueMode": "color"
+            },
+                "targets": [
+              {
+                "datasource": {
+                  "type": "datasource",
+                  "uid": "-- Dashboard --"
+                },
+                "panelId": 66,
+                "refId": "A"
+              }
+            ],
+            "title": "Express Route Gateway CPU Utilization",
+            "transformations": [
+              {
+                "id": "organize",
+                "options": {
+                  "excludeByName": {
+                    "_ResourceId": true,
+                    "health": true,
+                    "health1": true,
+                    "health2": true,
+                    "health3": true,
+                    "kpi1": false,
+                    "kpi2": true,
+                    "kpi3": true
+                  },
+                  "indexByName": {},
+                  "renameByName": {}
+                }
+              },
+              {
+                "id": "sortBy",
+                "options": {
+                  "fields": {},
+                  "sort": [
+                    {
+                      "desc": true,
+                      "field": "kpi1"
+                    }
+                  ]
+                }
+              }
+            ],
+            "type": "bargauge"
+          },
+          {
+            "datasource": {
+              "type": "datasource",
+              "uid": "-- Dashboard --"
+            },
+            "fieldConfig": {
+              "defaults": {
+                "color": {
+                  "mode": "thresholds"
+                },
+                "mappings": [],
+                "max": 100000,
+                "min": 0,
+                "thresholds": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "#808080"
+                    },
+                    {
+                      "color": "dark-red",
+                      "value": 0
+                    },
+                    {
+                      "color": "dark-green",
+                      "value": 2
+                    }
+                  ]
+                }
+              },
+              "overrides": []
+            },
+            "gridPos": {
+              "h": 12,
+              "w": 6,
+              "x": 6,
+              "y": 180
+            },
+            "id": 85,
+            "options": {
+              "displayMode": "basic",
+              "minVizHeight": 10,
+              "minVizWidth": 0,
+              "orientation": "horizontal",
+              "reduceOptions": {
+                "calcs": [
+                  "lastNotNull"
+                ],
+                "fields": "",
+                "values": true
+              },
+              "showUnfilled": true,
+              "valueMode": "color"
+            },
+                "targets": [
+              {
+                "datasource": {
+                  "type": "datasource",
+                  "uid": "-- Dashboard --"
+                },
+                "panelId": 66,
+                "refId": "A"
+              }
+            ],
+            "title": "Express Route Gateway Bits Per Second",
+            "transformations": [
+              {
+                "id": "organize",
+                "options": {
+                  "excludeByName": {
+                    "_ResourceId": true,
+                    "health": true,
+                    "health1": true,
+                    "health2": true,
+                    "health3": true,
+                    "kpi1": true,
+                    "kpi2": false,
+                    "kpi3": true
+                  },
+                  "indexByName": {},
+                  "renameByName": {}
+                }
+              },
+              {
+                "id": "sortBy",
+                "options": {
+                  "fields": {},
+                  "sort": [
+                    {
+                      "desc": false,
+                      "field": "kpi2"
+                    }
+                  ]
+                }
+              }
+            ],
+            "type": "bargauge"
+          },
+          {
+            "datasource": {
+              "type": "datasource",
+              "uid": "-- Dashboard --"
+            },
+            "fieldConfig": {
+              "defaults": {
+                "color": {
+                  "mode": "thresholds"
+                },
+                "mappings": [],
+                "max": 100000,
+                "min": 0,
+                "thresholds": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "#808080"
+                    },
+                    {
+                      "color": "dark-red",
+                      "value": 0
+                    },
+                    {
+                      "color": "dark-green",
+                      "value": 2
+                    }
+                  ]
+                }
+              },
+              "overrides": []
+            },
+            "gridPos": {
+              "h": 12,
+              "w": 6,
+              "x": 12,
+              "y": 180
+            },
+            "id": 86,
+            "options": {
+              "displayMode": "basic",
+              "minVizHeight": 10,
+              "minVizWidth": 0,
+              "orientation": "horizontal",
+              "reduceOptions": {
+                "calcs": [
+                  "lastNotNull"
+                ],
+                "fields": "",
+                "values": true
+              },
+              "showUnfilled": true,
+              "valueMode": "color"
+            },
+                "targets": [
+              {
+                "datasource": {
+                  "type": "datasource",
+                  "uid": "-- Dashboard --"
+                },
+                "panelId": 66,
+                "refId": "A"
+              }
+            ],
+            "title": "Express Route Gateway Packets Per Second",
+            "transformations": [
+              {
+                "id": "organize",
+                "options": {
+                  "excludeByName": {
+                    "_ResourceId": true,
+                    "health": true,
+                    "health1": true,
+                    "health2": true,
+                    "health3": true,
+                    "kpi1": true,
+                    "kpi2": true,
+                    "kpi3": false
+                  },
+                  "indexByName": {},
+                  "renameByName": {}
+                }
+              },
+              {
+                "id": "sortBy",
+                "options": {
+                  "fields": {},
+                  "sort": [
+                    {
+                      "desc": false,
+                      "field": "kpi3"
+                    }
+                  ]
+                }
+              }
+            ],
+            "type": "bargauge"
+          }
+        ],
+        "title": "ExpressRoute Gateway",
+        "type": "row"
+      }
+    ],
+    "refresh": "",
+    "schemaVersion": 38,
+    "style": "dark",
+    "tags": [],
+    "templating": {
+      "list": [
+        {
+          "current": {},
+          "hide": 0,
+          "includeAll": false,
+          "label": "Datasource",
+          "multi": false,
+          "name": "ds",
+          "options": [],
+          "query": "grafana-azure-monitor-datasource",
+          "queryValue": "",
+          "refresh": 1,
+          "regex": "",
+          "skipUrlSync": false,
+          "type": "datasource"
+        },
+        {
+          "current": {},
+          "datasource": {
+            "type": "grafana-azure-monitor-datasource",
+            "uid": "${ds}"
+          },
+          "definition": "",
+          "hide": 0,
+          "includeAll": false,
+          "label": "Subscription",
+          "multi": false,
+          "name": "sub",
+          "options": [],
+          "query": {
+            "azureLogAnalytics": {
+              "query": "",
+              "resources": []
+            },
+            "queryType": "Azure Subscriptions",
+            "refId": "A"
+          },
+          "refresh": 1,
+          "regex": "",
+          "skipUrlSync": false,
+          "sort": 5,
+          "type": "query"
+        }
+      ]
+    },
+    "time": {
+      "from": "now-6h",
+      "to": "now"
+    },
+    "timepicker": {},
+    "timezone": "",
+    "title": "Azure / Infrastructure / Infrastructure Monitoring",
+    "uid": "azure-infrastructure-monitoring",
+    "version": 215
+  }

--- a/public/app/plugins/datasource/azuremonitor/plugin.json
+++ b/public/app/plugins/datasource/azuremonitor/plugin.json
@@ -7,6 +7,11 @@
     { "type": "dashboard", "name": "Azure / Alert Consumption", "path": "dashboards/v1Alerts.json" },
     {
       "type": "dashboard",
+      "name": "Azure / Infrastructure / Infrastructure Monitoring",
+      "path": "dashboards/infrastructureMonitoring.json"
+    },
+    {
+      "type": "dashboard",
       "name": "Azure / Azure PostgreSQL / Flexible Server Monitoring",
       "path": "dashboards/postgresFlexibleServer.json"
     },


### PR DESCRIPTION
Adds a dashboard to the Azure Monitor dashboards folder for Infrastructure Monitoring. The dashboard utilizes Azure Monitor metrics and logs to monitor the current health of your infrastructure resources.  It uses a simple traffic-light indicator to indicate whether your Azure infrastructure is in a healthy, warning or unhealthy state. The state of each resource is determined by looking at key performance indicators (KPIs) and whether they have exceeded certain thresholds.

![image](https://github.com/grafana/grafana/assets/77704161/1b09d9cc-2150-4f3c-b8c8-fedfc86ca1bc)

Mirror of #78498 for CI