### PR TITLE
Login: Remove input placeholders

### DIFF
--- a/conf/defaults.ini
+++ b/conf/defaults.ini
@@ -463,9 +463,11 @@ auto_assign_org_role = Viewer
 # Require email validation before sign up completes
 verify_email_enabled = false
 
-# Background text for the user field on the login page
-login_hint = email or username
-password_hint = password
+# Placeholder text for the user field on the login page
+login_hint =
+
+# Placeholder text for the password field on the login page
+password_hint =
 
 # Default UI theme ("dark" or "light" or "system")
 default_theme = dark


### PR DESCRIPTION
What if we just just got rid of the login form placeholder text 👉👈 

![image](https://github.com/grafana/grafana/assets/46142/695d3e24-8dca-412e-bab7-5a6599e33056)

It's not really super helpful to just repeat the label text, and there's not useful examples we could give for "email or username" or "password" that aren't even more confusing.