### PR TITLE
RBAC: correctly fetch nested folder metadata

### DIFF
--- a/pkg/api/folder.go
+++ b/pkg/api/folder.go
@@ -431,8 +431,7 @@ func (hs *HTTPServer) getFolderACMetadata(c *contextmodel.ReqContext, f *folder.
 	}
 
 	allMetadata := hs.getMultiAccessControlMetadata(c, dashboards.ScopeFoldersPrefix, folderIDs)
-	metadata := allMetadata[f.UID]
-
+	metadata := map[string]bool{}
 	// Flatten metadata - if any parent has a permission, the child folder inherits it
 	for _, md := range allMetadata {
 		for action := range md {


### PR DESCRIPTION
**What is this feature?**

Fix the code to avoid a panic when fetching metadata for a folder which a user can see (due to inherited permissions) but on which the user doesn't have direct permissions.

Panic from the current logs:
```
ERROR[11-24|17:13:07] Request Completed                        logger=context userId=4 orgId=2 uname=N method=GET path=/api/folders/ac217b20-b1c2-420f-88a1-96833937d88c status=500 remote_addr=[::1] time_ms=20 duration=20.587791ms size=7635 referer=http://localhost:3000/dashboards/f/ac217b20-b1c2-420f-88a1-96833937d88c/ handler=/api/folders/:uid/
ERROR[11-24|17:14:05] Request error                            logger=context userId=4 orgId=2 uname=N error="assignment to entry in nil map" stack="/usr/local/go/src/runtime/map_faststr.go:205 (0x10259467f)\n\tmapassign_faststr: panic(plainError(\"assignment to entry in nil map\"))\n/.../grafana/pkg/api/folder.go:439 (0x105b4f977)\n\t(*HTTPServer).getFolderACMetadata: metadata[action] = true ....
```
