### PR TITLE
Alerting: Filter insights panels (grafanacloud-usage ds) by instance_id

### DIFF
--- a/public/app/features/alerting/unified/home/Insights.tsx
+++ b/public/app/features/alerting/unified/home/Insights.tsx
@@ -17,6 +17,7 @@ import {
   VariableValueSelectors,
 } from '@grafana/scenes';
 
+import { config } from '../../../../core/config';
 import { SectionFooter } from '../insights/SectionFooter';
 import { SectionSubheader } from '../insights/SectionSubheader';
 import { getGrafanaInstancesByStateScene } from '../insights/grafana/AlertsByStateScene';
@@ -94,6 +95,10 @@ export function overrideToFixedColor(key: keyof typeof SERIES_COLORS) {
 export const PANEL_STYLES = { minHeight: 300 };
 
 const THIS_WEEK_TIME_RANGE = new SceneTimeRange({ from: 'now-1w', to: 'now' });
+
+const namespace = config.bootData.settings.namespace;
+
+export const INSTANCE_ID = namespace.includes('stack-') ? namespace.replace('stack-', '') : undefined;
 
 export function getInsightsScenes() {
   const dataSourceSrv = getDataSourceSrv();

--- a/public/app/features/alerting/unified/insights/grafana/AlertsByStateScene.tsx
+++ b/public/app/features/alerting/unified/insights/grafana/AlertsByStateScene.tsx
@@ -3,16 +3,20 @@ import React from 'react';
 import { PanelBuilders, SceneDataTransformer, SceneFlexItem, SceneQueryRunner } from '@grafana/scenes';
 import { DataSourceRef, GraphDrawStyle, TooltipDisplayMode } from '@grafana/schema';
 
-import { overrideToFixedColor, PANEL_STYLES } from '../../home/Insights';
+import { INSTANCE_ID, overrideToFixedColor, PANEL_STYLES } from '../../home/Insights';
 import { InsightsRatingModal } from '../RatingModal';
 
 export function getGrafanaInstancesByStateScene(datasource: DataSourceRef, panelTitle: string) {
+  const expr = INSTANCE_ID
+    ? `sum by(state) (grafanacloud_grafana_instance_alerting_alerts{id="${INSTANCE_ID}"})`
+    : 'sum by (state) (grafanacloud_grafana_instance_alerting_alerts)';
+
   const query = new SceneQueryRunner({
     datasource,
     queries: [
       {
         refId: 'A',
-        expr: 'sum by (state) (grafanacloud_grafana_instance_alerting_alerts)',
+        expr,
         range: true,
         legendFormat: '{{state}}',
       },

--- a/public/app/features/alerting/unified/insights/grafana/EvalSuccessVsFailuresScene.tsx
+++ b/public/app/features/alerting/unified/insights/grafana/EvalSuccessVsFailuresScene.tsx
@@ -3,22 +3,30 @@ import React from 'react';
 import { PanelBuilders, SceneFlexItem, SceneQueryRunner } from '@grafana/scenes';
 import { DataSourceRef, GraphDrawStyle, TooltipDisplayMode } from '@grafana/schema';
 
-import { overrideToFixedColor, PANEL_STYLES } from '../../home/Insights';
+import { INSTANCE_ID, overrideToFixedColor, PANEL_STYLES } from '../../home/Insights';
 import { InsightsRatingModal } from '../RatingModal';
 
 export function getGrafanaEvalSuccessVsFailuresScene(datasource: DataSourceRef, panelTitle: string) {
+  const exprA = INSTANCE_ID
+    ? `sum(grafanacloud_grafana_instance_alerting_rule_evaluations_total:rate5m{id="${INSTANCE_ID}"}) - sum(grafanacloud_grafana_instance_alerting_rule_evaluation_failures_total:rate5m{id="${INSTANCE_ID}"})`
+    : `sum(grafanacloud_grafana_instance_alerting_rule_evaluations_total:rate5m) - sum(grafanacloud_grafana_instance_alerting_rule_evaluation_failures_total:rate5m)`;
+
+  const exprB = INSTANCE_ID
+    ? `sum(grafanacloud_grafana_instance_alerting_rule_evaluation_failures_total:rate5m{id="${INSTANCE_ID}"})`
+    : `sum(grafanacloud_grafana_instance_alerting_rule_evaluation_failures_total:rate5m)`;
+
   const query = new SceneQueryRunner({
     datasource,
     queries: [
       {
         refId: 'A',
-        expr: 'sum(grafanacloud_grafana_instance_alerting_rule_evaluations_total:rate5m) - sum(grafanacloud_grafana_instance_alerting_rule_evaluation_failures_total:rate5m)',
+        exprA,
         range: true,
         legendFormat: 'success',
       },
       {
         refId: 'B',
-        expr: 'sum(grafanacloud_grafana_instance_alerting_rule_evaluation_failures_total:rate5m)',
+        exprB,
         range: true,
         legendFormat: 'failed',
       },

--- a/public/app/features/alerting/unified/insights/grafana/Firing.tsx
+++ b/public/app/features/alerting/unified/insights/grafana/Firing.tsx
@@ -4,17 +4,21 @@ import { ThresholdsMode } from '@grafana/data';
 import { PanelBuilders, SceneFlexItem, SceneQueryRunner } from '@grafana/scenes';
 import { DataSourceRef } from '@grafana/schema';
 
-import { PANEL_STYLES } from '../../home/Insights';
+import { INSTANCE_ID, PANEL_STYLES } from '../../home/Insights';
 import { InsightsRatingModal } from '../RatingModal';
 
 export function getFiringGrafanaAlertsScene(datasource: DataSourceRef, panelTitle: string) {
+  const expr = INSTANCE_ID
+    ? `sum by (state) (grafanacloud_grafana_instance_alerting_rule_group_rules{state="active", id="${INSTANCE_ID}"})`
+    : `sum by (state) (grafanacloud_grafana_instance_alerting_rule_group_rules{state="active"})`;
+
   const query = new SceneQueryRunner({
     datasource,
     queries: [
       {
         refId: 'A',
         instant: true,
-        expr: 'sum by (state) (grafanacloud_grafana_instance_alerting_rule_group_rules{state="active"})',
+        expr,
       },
     ],
   });

--- a/public/app/features/alerting/unified/insights/grafana/InstanceStatusScene.tsx
+++ b/public/app/features/alerting/unified/insights/grafana/InstanceStatusScene.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 import { PanelBuilders, SceneFlexItem, SceneQueryRunner } from '@grafana/scenes';
 import { DataSourceRef } from '@grafana/schema';
 
-import { overrideToFixedColor } from '../../home/Insights';
+import { INSTANCE_ID, overrideToFixedColor } from '../../home/Insights';
 import { InsightsRatingModal } from '../RatingModal';
 export function getInstanceStatByStatusScene(
   datasource: DataSourceRef,
@@ -11,13 +11,17 @@ export function getInstanceStatByStatusScene(
   panelDescription: string,
   status: 'alerting' | 'pending' | 'nodata' | 'normal' | 'error'
 ) {
+  const expr = INSTANCE_ID
+    ? `sum by (state) (grafanacloud_grafana_instance_alerting_alerts{state="${status}", id="${INSTANCE_ID}"}})`
+    : `sum by (state) (grafanacloud_grafana_instance_alerting_alerts{state="${status}"})`;
+
   const query = new SceneQueryRunner({
     datasource,
     queries: [
       {
         refId: 'A',
         instant: true,
-        expr: `sum by (state) (grafanacloud_grafana_instance_alerting_alerts{state="${status}"})`,
+        expr,
         legendFormat: '{{state}}',
       },
     ],

--- a/public/app/features/alerting/unified/insights/grafana/InstanceStatusScene.tsx
+++ b/public/app/features/alerting/unified/insights/grafana/InstanceStatusScene.tsx
@@ -12,7 +12,7 @@ export function getInstanceStatByStatusScene(
   status: 'alerting' | 'pending' | 'nodata' | 'normal' | 'error'
 ) {
   const expr = INSTANCE_ID
-    ? `sum by (state) (grafanacloud_grafana_instance_alerting_alerts{state="${status}", id="${INSTANCE_ID}"}})`
+    ? `sum by (state) (grafanacloud_grafana_instance_alerting_alerts{state="${status}", id="${INSTANCE_ID}"})`
     : `sum by (state) (grafanacloud_grafana_instance_alerting_alerts{state="${status}"})`;
 
   const query = new SceneQueryRunner({

--- a/public/app/features/alerting/unified/insights/grafana/MissedIterationsScene.tsx
+++ b/public/app/features/alerting/unified/insights/grafana/MissedIterationsScene.tsx
@@ -11,16 +11,17 @@ import {
 } from '@grafana/scenes';
 import { DataSourceRef, GraphDrawStyle, TooltipDisplayMode } from '@grafana/schema';
 
-import { PANEL_STYLES } from '../../home/Insights';
+import { INSTANCE_ID, PANEL_STYLES } from '../../home/Insights';
 import { InsightsRatingModal } from '../RatingModal';
 
 export function getGrafanaMissedIterationsScene(datasource: DataSourceRef, panelTitle: string) {
+  const expr = `sum by(rule_group) (grafanacloud_instance_rule_group_iterations_missed_total:rate5m{id="${INSTANCE_ID}"})`;
   const query = new SceneQueryRunner({
     datasource,
     queries: [
       {
         refId: 'A',
-        expr: 'sum by (rule_group) (grafanacloud_instance_rule_group_iterations_missed_total:rate5m)',
+        expr,
         range: true,
         legendFormat: '{{rule_group}}',
       },

--- a/public/app/features/alerting/unified/insights/grafana/MostFiredInstancesTable.tsx
+++ b/public/app/features/alerting/unified/insights/grafana/MostFiredInstancesTable.tsx
@@ -13,17 +13,21 @@ import {
 import { DataSourceRef } from '@grafana/schema';
 import { Link, useStyles2 } from '@grafana/ui';
 
-import { PANEL_STYLES } from '../../home/Insights';
+import { INSTANCE_ID, PANEL_STYLES } from '../../home/Insights';
 import { createUrl } from '../../utils/url';
 import { InsightsRatingModal } from '../RatingModal';
 
 export function getMostFiredInstancesScene(datasource: DataSourceRef, panelTitle: string) {
+  const expr = INSTANCE_ID
+    ? `'topk(10, sum by(labels_alertname, ruleUID) (count_over_time({from="state-history", instance_id="${INSTANCE_ID}"} | json | current = 'Alerting' [1w])))`
+    : 'topk(10, sum by(labels_alertname, ruleUID) (count_over_time({from="state-history"} | json | current = `Alerting` [1w])))';
+
   const query = new SceneQueryRunner({
     datasource,
     queries: [
       {
         refId: 'A',
-        expr: 'topk(10, sum by(labels_alertname, ruleUID) (count_over_time({from="state-history"} | json | current = `Alerting` [1w])))',
+        expr,
         instant: true,
       },
     ],

--- a/public/app/features/alerting/unified/insights/grafana/MostFiredInstancesTable.tsx
+++ b/public/app/features/alerting/unified/insights/grafana/MostFiredInstancesTable.tsx
@@ -13,21 +13,17 @@ import {
 import { DataSourceRef } from '@grafana/schema';
 import { Link, useStyles2 } from '@grafana/ui';
 
-import { INSTANCE_ID, PANEL_STYLES } from '../../home/Insights';
+import { PANEL_STYLES } from '../../home/Insights';
 import { createUrl } from '../../utils/url';
 import { InsightsRatingModal } from '../RatingModal';
 
 export function getMostFiredInstancesScene(datasource: DataSourceRef, panelTitle: string) {
-  const expr = INSTANCE_ID
-    ? `'topk(10, sum by(labels_alertname, ruleUID) (count_over_time({from="state-history", instance_id="${INSTANCE_ID}"} | json | current = 'Alerting' [1w])))`
-    : 'topk(10, sum by(labels_alertname, ruleUID) (count_over_time({from="state-history"} | json | current = `Alerting` [1w])))';
-
   const query = new SceneQueryRunner({
     datasource,
     queries: [
       {
         refId: 'A',
-        expr,
+        expr: 'topk(10, sum by(labels_alertname, ruleUID) (count_over_time({from="state-history"} | json | current = `Alerting` [1w])))',
         instant: true,
       },
     ],

--- a/public/app/features/alerting/unified/insights/grafana/Paused.tsx
+++ b/public/app/features/alerting/unified/insights/grafana/Paused.tsx
@@ -4,17 +4,21 @@ import { ThresholdsMode } from '@grafana/data';
 import { PanelBuilders, SceneFlexItem, SceneQueryRunner } from '@grafana/scenes';
 import { DataSourceRef } from '@grafana/schema';
 
-import { PANEL_STYLES } from '../../home/Insights';
+import { INSTANCE_ID, PANEL_STYLES } from '../../home/Insights';
 import { InsightsRatingModal } from '../RatingModal';
 
 export function getPausedGrafanaAlertsScene(datasource: DataSourceRef, panelTitle: string) {
+  const expr = INSTANCE_ID
+    ? `sum by (state) (grafanacloud_grafana_instance_alerting_rule_group_rules{state="paused", id="${INSTANCE_ID}"})`
+    : `sum by (state) (grafanacloud_grafana_instance_alerting_rule_group_rules{state="paused"})`;
+
   const query = new SceneQueryRunner({
     datasource,
     queries: [
       {
         refId: 'A',
         instant: true,
-        expr: 'sum by (state) (grafanacloud_grafana_instance_alerting_rule_group_rules{state="paused"})',
+        expr,
       },
     ],
   });

--- a/public/app/features/alerting/unified/insights/grafana/RulesByEvaluation.tsx
+++ b/public/app/features/alerting/unified/insights/grafana/RulesByEvaluation.tsx
@@ -3,16 +3,20 @@ import React from 'react';
 import { PanelBuilders, SceneFlexItem, SceneQueryRunner } from '@grafana/scenes';
 import { DataSourceRef, GraphDrawStyle, TooltipDisplayMode } from '@grafana/schema';
 
-import { overrideToFixedColor, PANEL_STYLES } from '../../home/Insights';
+import { INSTANCE_ID, overrideToFixedColor, PANEL_STYLES } from '../../home/Insights';
 import { InsightsRatingModal } from '../RatingModal';
 
 export function getGrafanaRulesByEvaluationScene(datasource: DataSourceRef, panelTitle: string) {
+  const expr = INSTANCE_ID
+    ? `sum by (state) (grafanacloud_grafana_instance_alerting_rule_group_rules{id="${INSTANCE_ID}"})`
+    : `sum by (state) (grafanacloud_grafana_instance_alerting_rule_group_rules)`;
+
   const query = new SceneQueryRunner({
     datasource,
     queries: [
       {
         refId: 'A',
-        expr: 'sum by (state) (grafanacloud_grafana_instance_alerting_rule_group_rules)',
+        expr,
         range: true,
         legendFormat: '{{state}} evaluation',
       },

--- a/public/app/features/alerting/unified/insights/grafana/RulesByEvaluationPercentage.tsx
+++ b/public/app/features/alerting/unified/insights/grafana/RulesByEvaluationPercentage.tsx
@@ -3,16 +3,20 @@ import React from 'react';
 import { PanelBuilders, SceneFlexItem, SceneQueryRunner } from '@grafana/scenes';
 import { DataSourceRef, GraphDrawStyle, TooltipDisplayMode } from '@grafana/schema';
 
-import { overrideToFixedColor, PANEL_STYLES } from '../../home/Insights';
+import { INSTANCE_ID, overrideToFixedColor, PANEL_STYLES } from '../../home/Insights';
 import { InsightsRatingModal } from '../RatingModal';
 
 export function getGrafanaRulesByEvaluationPercentageScene(datasource: DataSourceRef, panelTitle: string) {
+  const expr = INSTANCE_ID
+    ? `sum by (state) (grafanacloud_grafana_instance_alerting_rule_group_rules{id="${INSTANCE_ID}"}) / ignoring(state) group_left sum(grafanacloud_grafana_instance_alerting_rule_group_rules{id="${INSTANCE_ID}"})`
+    : `sum by (state) (grafanacloud_grafana_instance_alerting_rule_group_rules) / ignoring(state) group_left sum(grafanacloud_grafana_instance_alerting_rule_group_rules)`;
+
   const query = new SceneQueryRunner({
     datasource,
     queries: [
       {
         refId: 'A',
-        expr: 'sum by (state) (grafanacloud_grafana_instance_alerting_rule_group_rules) / ignoring(state) group_left sum(grafanacloud_grafana_instance_alerting_rule_group_rules)',
+        expr,
         range: true,
         legendFormat: '{{state}} evaluation',
       },

--- a/public/app/features/alerting/unified/insights/grafana/alertmanager/AlertsByState.tsx
+++ b/public/app/features/alerting/unified/insights/grafana/alertmanager/AlertsByState.tsx
@@ -3,16 +3,20 @@ import React from 'react';
 import { PanelBuilders, SceneFlexItem, SceneQueryRunner } from '@grafana/scenes';
 import { DataSourceRef, GraphDrawStyle, TooltipDisplayMode } from '@grafana/schema';
 
-import { overrideToFixedColor, PANEL_STYLES } from '../../../home/Insights';
+import { INSTANCE_ID, overrideToFixedColor, PANEL_STYLES } from '../../../home/Insights';
 import { InsightsRatingModal } from '../../RatingModal';
 
 export function getAlertsByStateScene(datasource: DataSourceRef, panelTitle: string) {
+  const expr = INSTANCE_ID
+    ? `sum by (state) (grafanacloud_grafana_instance_alerting_alertmanager_alerts{id="${INSTANCE_ID}"})`
+    : `sum by (state) (grafanacloud_grafana_instance_alerting_alertmanager_alerts)`;
+
   const query = new SceneQueryRunner({
     datasource,
     queries: [
       {
         refId: 'A',
-        expr: 'sum by (state) (grafanacloud_grafana_instance_alerting_alertmanager_alerts)',
+        expr,
         range: true,
         legendFormat: '{{state}}',
       },

--- a/public/app/features/alerting/unified/insights/grafana/alertmanager/SilencesByStateScene.tsx
+++ b/public/app/features/alerting/unified/insights/grafana/alertmanager/SilencesByStateScene.tsx
@@ -3,16 +3,20 @@ import React from 'react';
 import { PanelBuilders, SceneFlexItem, SceneQueryRunner } from '@grafana/scenes';
 import { DataSourceRef, GraphDrawStyle, TooltipDisplayMode } from '@grafana/schema';
 
-import { PANEL_STYLES } from '../../../home/Insights';
+import { INSTANCE_ID, PANEL_STYLES } from '../../../home/Insights';
 import { InsightsRatingModal } from '../../RatingModal';
 
 export function getGrafanaAlertmanagerSilencesScene(datasource: DataSourceRef, panelTitle: string) {
+  const expr = INSTANCE_ID
+    ? `sum by (state) (grafanacloud_grafana_instance_alerting_silences{id="${INSTANCE_ID}"})`
+    : `sum by (state) (grafanacloud_grafana_instance_alerting_silences)`;
+
   const query = new SceneQueryRunner({
     datasource,
     queries: [
       {
         refId: 'A',
-        expr: 'sum by (state) (grafanacloud_grafana_instance_alerting_silences)',
+        expr,
         range: true,
         legendFormat: '{{state}}',
       },

--- a/public/app/features/alerting/unified/insights/mimir/AlertsByState.tsx
+++ b/public/app/features/alerting/unified/insights/mimir/AlertsByState.tsx
@@ -3,16 +3,20 @@ import React from 'react';
 import { PanelBuilders, SceneFlexItem, SceneQueryRunner } from '@grafana/scenes';
 import { DataSourceRef, GraphDrawStyle, TooltipDisplayMode } from '@grafana/schema';
 
-import { overrideToFixedColor, PANEL_STYLES } from '../../home/Insights';
+import { INSTANCE_ID, overrideToFixedColor, PANEL_STYLES } from '../../home/Insights';
 import { InsightsRatingModal } from '../RatingModal';
 
 export function getAlertsByStateScene(datasource: DataSourceRef, panelTitle: string) {
+  const expr = INSTANCE_ID
+    ? `sum by (state) (grafanacloud_instance_alertmanager_alerts{id="${INSTANCE_ID}"})`
+    : `sum by (state) (grafanacloud_instance_alertmanager_alerts)`;
+
   const query = new SceneQueryRunner({
     datasource,
     queries: [
       {
         refId: 'A',
-        expr: 'sum by (state) (grafanacloud_instance_alertmanager_alerts)',
+        expr,
         range: true,
         legendFormat: '{{state}}',
       },

--- a/public/app/features/alerting/unified/insights/mimir/InvalidConfig.tsx
+++ b/public/app/features/alerting/unified/insights/mimir/InvalidConfig.tsx
@@ -3,16 +3,20 @@ import React from 'react';
 import { PanelBuilders, SceneFlexItem, SceneQueryRunner } from '@grafana/scenes';
 import { BigValueGraphMode, DataSourceRef } from '@grafana/schema';
 
-import { PANEL_STYLES } from '../../home/Insights';
+import { INSTANCE_ID, PANEL_STYLES } from '../../home/Insights';
 import { InsightsRatingModal } from '../RatingModal';
 
 export function getInvalidConfigScene(datasource: DataSourceRef, panelTitle: string) {
+  const expr = INSTANCE_ID
+    ? `sum by (cluster)(grafanacloud_instance_alertmanager_invalid_config{id="${INSTANCE_ID}"})`
+    : `sum by (cluster)(grafanacloud_instance_alertmanager_invalid_config)`;
+
   const query = new SceneQueryRunner({
     datasource,
     queries: [
       {
         refId: 'A',
-        expr: 'sum by (cluster)(grafanacloud_instance_alertmanager_invalid_config)',
+        expr,
         range: true,
         legendFormat: '{{cluster}}',
       },

--- a/public/app/features/alerting/unified/insights/mimir/Notifications.tsx
+++ b/public/app/features/alerting/unified/insights/mimir/Notifications.tsx
@@ -3,22 +3,30 @@ import React from 'react';
 import { PanelBuilders, SceneFlexItem, SceneQueryRunner } from '@grafana/scenes';
 import { DataSourceRef, GraphDrawStyle, TooltipDisplayMode } from '@grafana/schema';
 
-import { overrideToFixedColor, PANEL_STYLES } from '../../home/Insights';
+import { INSTANCE_ID, overrideToFixedColor, PANEL_STYLES } from '../../home/Insights';
 import { InsightsRatingModal } from '../RatingModal';
 
 export function getNotificationsScene(datasource: DataSourceRef, panelTitle: string) {
+  const exprA = INSTANCE_ID
+    ? `sum by(cluster)(grafanacloud_instance_alertmanager_notifications_per_second{id="${INSTANCE_ID}"}) - sum by (cluster)(grafanacloud_instance_alertmanager_notifications_failed_per_second{id="${INSTANCE_ID}"})`
+    : `sum by(cluster)(grafanacloud_instance_alertmanager_notifications_per_second) - sum by (cluster)(grafanacloud_instance_alertmanager_notifications_failed_per_second)`;
+
+  const exprB = INSTANCE_ID
+    ? `sum by(cluster)(grafanacloud_instance_alertmanager_notifications_failed_per_second{id="${INSTANCE_ID}"})`
+    : `sum by(cluster)(grafanacloud_instance_alertmanager_notifications_failed_per_second)`;
+
   const query = new SceneQueryRunner({
     datasource,
     queries: [
       {
         refId: 'A',
-        expr: 'sum by(cluster)(grafanacloud_instance_alertmanager_notifications_per_second) - sum by (cluster)(grafanacloud_instance_alertmanager_notifications_failed_per_second)',
+        exprA,
         range: true,
         legendFormat: 'success',
       },
       {
         refId: 'B',
-        expr: 'sum by(cluster)(grafanacloud_instance_alertmanager_notifications_failed_per_second)',
+        exprB,
         range: true,
         legendFormat: 'failed',
       },

--- a/public/app/features/alerting/unified/insights/mimir/Silences.tsx
+++ b/public/app/features/alerting/unified/insights/mimir/Silences.tsx
@@ -3,16 +3,20 @@ import React from 'react';
 import { PanelBuilders, SceneFlexItem, SceneQueryRunner } from '@grafana/scenes';
 import { DataSourceRef, GraphDrawStyle, TooltipDisplayMode } from '@grafana/schema';
 
-import { PANEL_STYLES } from '../../home/Insights';
+import { INSTANCE_ID, PANEL_STYLES } from '../../home/Insights';
 import { InsightsRatingModal } from '../RatingModal';
 
 export function getSilencesScene(datasource: DataSourceRef, panelTitle: string) {
+  const expr = INSTANCE_ID
+    ? `sum by (state) (grafanacloud_instance_alertmanager_silences{id="${INSTANCE_ID}"})`
+    : `sum by (state) (grafanacloud_instance_alertmanager_silences)`;
+
   const query = new SceneQueryRunner({
     datasource,
     queries: [
       {
         refId: 'A',
-        expr: 'sum by (state) (grafanacloud_instance_alertmanager_silences)',
+        expr,
         range: true,
         legendFormat: '{{state}}',
       },

--- a/public/app/features/alerting/unified/insights/mimir/perGroup/RuleGroupEvaluationDurationIntervalRatioScene.tsx
+++ b/public/app/features/alerting/unified/insights/mimir/perGroup/RuleGroupEvaluationDurationIntervalRatioScene.tsx
@@ -3,16 +3,20 @@ import React from 'react';
 import { PanelBuilders, SceneFlexItem, SceneQueryRunner } from '@grafana/scenes';
 import { DataSourceRef, GraphDrawStyle, ThresholdsMode, TooltipDisplayMode } from '@grafana/schema';
 
-import { PANEL_STYLES } from '../../../home/Insights';
+import { INSTANCE_ID, PANEL_STYLES } from '../../../home/Insights';
 import { InsightsRatingModal } from '../../RatingModal';
 
 export function getRuleGroupEvaluationDurationIntervalRatioScene(datasource: DataSourceRef, panelTitle: string) {
+  const expr = INSTANCE_ID
+    ? `grafanacloud_instance_rule_group_last_duration_seconds{rule_group="$rule_group", id="${INSTANCE_ID}} / grafanacloud_instance_rule_group_interval_seconds{rule_group="$rule_group", id="${INSTANCE_ID}}`
+    : `grafanacloud_instance_rule_group_last_duration_seconds{rule_group="$rule_group"} / grafanacloud_instance_rule_group_interval_seconds{rule_group="$rule_group"}`;
+
   const query = new SceneQueryRunner({
     datasource,
     queries: [
       {
         refId: 'A',
-        expr: `grafanacloud_instance_rule_group_last_duration_seconds{rule_group="$rule_group"} / grafanacloud_instance_rule_group_interval_seconds{rule_group="$rule_group"}`,
+        expr,
         range: true,
         legendFormat: 'duration / interval',
       },

--- a/public/app/features/alerting/unified/insights/mimir/perGroup/RuleGroupEvaluationDurationIntervalRatioScene.tsx
+++ b/public/app/features/alerting/unified/insights/mimir/perGroup/RuleGroupEvaluationDurationIntervalRatioScene.tsx
@@ -8,7 +8,7 @@ import { InsightsRatingModal } from '../../RatingModal';
 
 export function getRuleGroupEvaluationDurationIntervalRatioScene(datasource: DataSourceRef, panelTitle: string) {
   const expr = INSTANCE_ID
-    ? `grafanacloud_instance_rule_group_last_duration_seconds{rule_group="$rule_group", id="${INSTANCE_ID}} / grafanacloud_instance_rule_group_interval_seconds{rule_group="$rule_group", id="${INSTANCE_ID}}`
+    ? `grafanacloud_instance_rule_group_last_duration_seconds{rule_group="$rule_group", id="${INSTANCE_ID}"} / grafanacloud_instance_rule_group_interval_seconds{rule_group="$rule_group", id="${INSTANCE_ID}"}`
     : `grafanacloud_instance_rule_group_last_duration_seconds{rule_group="$rule_group"} / grafanacloud_instance_rule_group_interval_seconds{rule_group="$rule_group"}`;
 
   const query = new SceneQueryRunner({

--- a/public/app/features/alerting/unified/insights/mimir/perGroup/RuleGroupEvaluationDurationScene.tsx
+++ b/public/app/features/alerting/unified/insights/mimir/perGroup/RuleGroupEvaluationDurationScene.tsx
@@ -8,7 +8,7 @@ import { InsightsRatingModal } from '../../RatingModal';
 
 export function getRuleGroupEvaluationDurationScene(datasource: DataSourceRef, panelTitle: string) {
   const expr = INSTANCE_ID
-    ? `grafanacloud_instance_rule_group_last_duration_seconds{rule_group="$rule_group", id="${INSTANCE_ID}}`
+    ? `grafanacloud_instance_rule_group_last_duration_seconds{rule_group="$rule_group", id="${INSTANCE_ID}"}`
     : `grafanacloud_instance_rule_group_last_duration_seconds{rule_group="$rule_group"}`;
 
   const query = new SceneQueryRunner({

--- a/public/app/features/alerting/unified/insights/mimir/perGroup/RuleGroupEvaluationDurationScene.tsx
+++ b/public/app/features/alerting/unified/insights/mimir/perGroup/RuleGroupEvaluationDurationScene.tsx
@@ -3,16 +3,20 @@ import React from 'react';
 import { PanelBuilders, SceneFlexItem, SceneQueryRunner } from '@grafana/scenes';
 import { DataSourceRef, GraphDrawStyle, TooltipDisplayMode } from '@grafana/schema';
 
-import { PANEL_STYLES } from '../../../home/Insights';
+import { INSTANCE_ID, PANEL_STYLES } from '../../../home/Insights';
 import { InsightsRatingModal } from '../../RatingModal';
 
 export function getRuleGroupEvaluationDurationScene(datasource: DataSourceRef, panelTitle: string) {
+  const expr = INSTANCE_ID
+    ? `grafanacloud_instance_rule_group_last_duration_seconds{rule_group="$rule_group", id="${INSTANCE_ID}}`
+    : `grafanacloud_instance_rule_group_last_duration_seconds{rule_group="$rule_group"}`;
+
   const query = new SceneQueryRunner({
     datasource,
     queries: [
       {
         refId: 'A',
-        expr: `grafanacloud_instance_rule_group_last_duration_seconds{rule_group="$rule_group"}`,
+        expr,
         range: true,
         legendFormat: '{{rule_group}}',
       },

--- a/public/app/features/alerting/unified/insights/mimir/perGroup/RuleGroupEvaluationsScene.tsx
+++ b/public/app/features/alerting/unified/insights/mimir/perGroup/RuleGroupEvaluationsScene.tsx
@@ -3,22 +3,30 @@ import React from 'react';
 import { PanelBuilders, SceneFlexItem, SceneQueryRunner } from '@grafana/scenes';
 import { DataSourceRef, GraphDrawStyle, TooltipDisplayMode } from '@grafana/schema';
 
-import { overrideToFixedColor, PANEL_STYLES } from '../../../home/Insights';
+import { INSTANCE_ID, overrideToFixedColor, PANEL_STYLES } from '../../../home/Insights';
 import { InsightsRatingModal } from '../../RatingModal';
 
 export function getRuleGroupEvaluationsScene(datasource: DataSourceRef, panelTitle: string) {
+  const exprA = INSTANCE_ID
+    ? `grafanacloud_instance_rule_evaluations_total:rate5m{rule_group="$rule_group", id="${INSTANCE_ID}} - grafanacloud_instance_rule_evaluation_failures_total:rate5m{rule_group=~"$rule_group", id="${INSTANCE_ID}}`
+    : `grafanacloud_instance_rule_evaluations_total:rate5m{rule_group="$rule_group"} - grafanacloud_instance_rule_evaluation_failures_total:rate5m{rule_group=~"$rule_group"}`;
+
+  const exprB = INSTANCE_ID
+    ? `grafanacloud_instance_rule_evaluation_failures_total:rate5m{rule_group=~"$rule_group", id="${INSTANCE_ID}}`
+    : `grafanacloud_instance_rule_evaluation_failures_total:rate5m{rule_group=~"$rule_group"}`;
+
   const query = new SceneQueryRunner({
     datasource,
     queries: [
       {
         refId: 'A',
-        expr: `grafanacloud_instance_rule_evaluations_total:rate5m{rule_group="$rule_group"} - grafanacloud_instance_rule_evaluation_failures_total:rate5m{rule_group=~"$rule_group"}`,
+        exprA,
         range: true,
         legendFormat: 'success',
       },
       {
         refId: 'B',
-        expr: `grafanacloud_instance_rule_evaluation_failures_total:rate5m{rule_group=~"$rule_group"}`,
+        exprB,
         range: true,
         legendFormat: 'failed',
       },

--- a/public/app/features/alerting/unified/insights/mimir/perGroup/RuleGroupIntervalScene.tsx
+++ b/public/app/features/alerting/unified/insights/mimir/perGroup/RuleGroupIntervalScene.tsx
@@ -3,16 +3,20 @@ import React from 'react';
 import { PanelBuilders, SceneFlexItem, SceneQueryRunner } from '@grafana/scenes';
 import { BigValueGraphMode, DataSourceRef } from '@grafana/schema';
 
-import { PANEL_STYLES } from '../../../home/Insights';
+import { INSTANCE_ID, PANEL_STYLES } from '../../../home/Insights';
 import { InsightsRatingModal } from '../../RatingModal';
 
 export function getRuleGroupIntervalScene(datasource: DataSourceRef, panelTitle: string) {
+  const expr = INSTANCE_ID
+    ? `grafanacloud_instance_rule_group_interval_seconds{rule_group="$rule_group", id="${INSTANCE_ID}}`
+    : `grafanacloud_instance_rule_group_interval_seconds{rule_group="$rule_group"}`;
+
   const query = new SceneQueryRunner({
     datasource,
     queries: [
       {
         refId: 'A',
-        expr: `grafanacloud_instance_rule_group_interval_seconds{rule_group="$rule_group"}`,
+        expr,
         range: true,
         legendFormat: 'interval',
       },

--- a/public/app/features/alerting/unified/insights/mimir/perGroup/RuleGroupIntervalScene.tsx
+++ b/public/app/features/alerting/unified/insights/mimir/perGroup/RuleGroupIntervalScene.tsx
@@ -8,7 +8,7 @@ import { InsightsRatingModal } from '../../RatingModal';
 
 export function getRuleGroupIntervalScene(datasource: DataSourceRef, panelTitle: string) {
   const expr = INSTANCE_ID
-    ? `grafanacloud_instance_rule_group_interval_seconds{rule_group="$rule_group", id="${INSTANCE_ID}}`
+    ? `grafanacloud_instance_rule_group_interval_seconds{rule_group="$rule_group", id="${INSTANCE_ID}"}`
     : `grafanacloud_instance_rule_group_interval_seconds{rule_group="$rule_group"}`;
 
   const query = new SceneQueryRunner({

--- a/public/app/features/alerting/unified/insights/mimir/perGroup/RulesPerGroupScene.tsx
+++ b/public/app/features/alerting/unified/insights/mimir/perGroup/RulesPerGroupScene.tsx
@@ -8,7 +8,7 @@ import { InsightsRatingModal } from '../../RatingModal';
 
 export function getRulesPerGroupScene(datasource: DataSourceRef, panelTitle: string) {
   const expr = INSTANCE_ID
-    ? `sum(grafanacloud_instance_rule_group_rules{rule_group="$rule_group", id="${INSTANCE_ID}})`
+    ? `sum(grafanacloud_instance_rule_group_rules{rule_group="$rule_group", id="${INSTANCE_ID}"})`
     : `sum(grafanacloud_instance_rule_group_rules{rule_group="$rule_group"})`;
 
   const query = new SceneQueryRunner({

--- a/public/app/features/alerting/unified/insights/mimir/perGroup/RulesPerGroupScene.tsx
+++ b/public/app/features/alerting/unified/insights/mimir/perGroup/RulesPerGroupScene.tsx
@@ -3,16 +3,20 @@ import React from 'react';
 import { PanelBuilders, SceneFlexItem, SceneQueryRunner } from '@grafana/scenes';
 import { BigValueGraphMode, DataSourceRef } from '@grafana/schema';
 
-import { PANEL_STYLES } from '../../../home/Insights';
+import { INSTANCE_ID, PANEL_STYLES } from '../../../home/Insights';
 import { InsightsRatingModal } from '../../RatingModal';
 
 export function getRulesPerGroupScene(datasource: DataSourceRef, panelTitle: string) {
+  const expr = INSTANCE_ID
+    ? `sum(grafanacloud_instance_rule_group_rules{rule_group="$rule_group", id="${INSTANCE_ID}})`
+    : `sum(grafanacloud_instance_rule_group_rules{rule_group="$rule_group"})`;
+
   const query = new SceneQueryRunner({
     datasource,
     queries: [
       {
         refId: 'A',
-        expr: `sum(grafanacloud_instance_rule_group_rules{rule_group="$rule_group"})`,
+        expr,
         range: true,
         legendFormat: 'number of rules',
       },

--- a/public/app/features/alerting/unified/insights/mimir/rules/EvalSuccessVsFailuresScene.tsx
+++ b/public/app/features/alerting/unified/insights/mimir/rules/EvalSuccessVsFailuresScene.tsx
@@ -3,22 +3,30 @@ import React from 'react';
 import { PanelBuilders, SceneFlexItem, SceneQueryRunner } from '@grafana/scenes';
 import { DataSourceRef, GraphDrawStyle, TooltipDisplayMode } from '@grafana/schema';
 
-import { overrideToFixedColor, PANEL_STYLES } from '../../../home/Insights';
+import { INSTANCE_ID, overrideToFixedColor, PANEL_STYLES } from '../../../home/Insights';
 import { InsightsRatingModal } from '../../RatingModal';
 
 export function getEvalSuccessVsFailuresScene(datasource: DataSourceRef, panelTitle: string) {
+  const exprA = INSTANCE_ID
+    ? `sum(grafanacloud_instance_rule_evaluations_total:rate5m{id="${INSTANCE_ID}) - sum(grafanacloud_instance_rule_evaluation_failures_total:rate5m{id="${INSTANCE_ID})`
+    : `sum(grafanacloud_instance_rule_evaluations_total:rate5m) - sum(grafanacloud_instance_rule_evaluation_failures_total:rate5m)`;
+
+  const exprB = INSTANCE_ID
+    ? `sum(grafanacloud_instance_rule_evaluation_failures_total:rate5m{id="${INSTANCE_ID})`
+    : `sum(grafanacloud_instance_rule_evaluation_failures_total:rate5m)`;
+
   const query = new SceneQueryRunner({
     datasource,
     queries: [
       {
         refId: 'A',
-        expr: 'sum(grafanacloud_instance_rule_evaluations_total:rate5m) - sum(grafanacloud_instance_rule_evaluation_failures_total:rate5m)',
+        exprA,
         range: true,
         legendFormat: 'success',
       },
       {
         refId: 'B',
-        expr: 'sum(grafanacloud_instance_rule_evaluation_failures_total:rate5m)',
+        exprB,
         range: true,
         legendFormat: 'failed',
       },

--- a/public/app/features/alerting/unified/insights/mimir/rules/MissedIterationsScene.tsx
+++ b/public/app/features/alerting/unified/insights/mimir/rules/MissedIterationsScene.tsx
@@ -8,7 +8,7 @@ import { InsightsRatingModal } from '../../RatingModal';
 
 export function getMissedIterationsScene(datasource: DataSourceRef, panelTitle: string) {
   const expr = INSTANCE_ID
-    ? `sum(grafanacloud_instance_rule_group_iterations_missed_total:rate5m{id="${INSTANCE_ID})`
+    ? `sum(grafanacloud_instance_rule_group_iterations_missed_total:rate5m{id="${INSTANCE_ID}"})`
     : `sum(grafanacloud_instance_rule_group_iterations_missed_total:rate5m)`;
 
   const query = new SceneQueryRunner({

--- a/public/app/features/alerting/unified/insights/mimir/rules/MissedIterationsScene.tsx
+++ b/public/app/features/alerting/unified/insights/mimir/rules/MissedIterationsScene.tsx
@@ -3,16 +3,20 @@ import React from 'react';
 import { PanelBuilders, SceneFlexItem, SceneQueryRunner } from '@grafana/scenes';
 import { DataSourceRef, GraphDrawStyle, TooltipDisplayMode } from '@grafana/schema';
 
-import { overrideToFixedColor, PANEL_STYLES } from '../../../home/Insights';
+import { INSTANCE_ID, overrideToFixedColor, PANEL_STYLES } from '../../../home/Insights';
 import { InsightsRatingModal } from '../../RatingModal';
 
 export function getMissedIterationsScene(datasource: DataSourceRef, panelTitle: string) {
+  const expr = INSTANCE_ID
+    ? `sum(grafanacloud_instance_rule_group_iterations_missed_total:rate5m{id="${INSTANCE_ID})`
+    : `sum(grafanacloud_instance_rule_group_iterations_missed_total:rate5m)`;
+
   const query = new SceneQueryRunner({
     datasource,
     queries: [
       {
         refId: 'A',
-        expr: 'sum(grafanacloud_instance_rule_group_iterations_missed_total:rate5m)',
+        expr,
         range: true,
         legendFormat: 'missed',
       },


### PR DESCRIPTION
**What is this feature?**

Filters data from `grafanacloud-usage` datasource shown in Alerting Insights to only consider the current instance.

**Why do we need this feature?**

Queries run against the `grafanacloud-usage` datasource are returning data for all the stacks of the organization instead of the current instance. Users can get confused by this as they will see unrelated data and don't understand where it comes from. Instead, we should filter the data we show by the current instance id.

**Who is this feature for?**

All cloud users.

**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/support-escalations/issues/8462
