### PR TITLE
data-trails: hightlight current node and its ancestry

### DIFF
--- a/public/app/features/trails/DataTrail.test.tsx
+++ b/public/app/features/trails/DataTrail.test.tsx
@@ -40,6 +40,14 @@ describe('DataTrail', () => {
       expect(trail.state.stepIndex).toBe(0);
     });
 
+    it('Should set parentIndex to -1', () => {
+      expect(trail.state.parentIndex).toBe(-1);
+    });
+
+    it('Should set history currentStep to 0', () => {
+      expect(trail.state.history.state.currentStep).toBe(0);
+    });
+
     describe('And metric is selected', () => {
       beforeEach(() => {
         trail.publishEvent(new MetricSelectedEvent('metric_bucket'));
@@ -61,9 +69,17 @@ describe('DataTrail', () => {
       it('Should set stepIndex to 1', () => {
         expect(trail.state.stepIndex).toBe(1);
       });
+
+      it('Should set history currentStep to 1', () => {
+        expect(trail.state.history.state.currentStep).toBe(1);
+      });
+
+      it('Should set parentIndex to 0', () => {
+        expect(trail.state.parentIndex).toBe(0);
+      });
     });
 
-    describe('When going back to history step', () => {
+    describe('When going back to history step 1', () => {
       beforeEach(() => {
         trail.publishEvent(new MetricSelectedEvent('first_metric'));
         trail.publishEvent(new MetricSelectedEvent('second_metric'));
@@ -79,13 +95,34 @@ describe('DataTrail', () => {
         expect(trail.state.stepIndex).toBe(1);
       });
 
+      it('Should set history currentStep to 1', () => {
+        expect(trail.state.history.state.currentStep).toBe(1);
+      });
+
       it('Should not create another history step', () => {
         expect(trail.state.history.state.steps.length).toBe(3);
       });
 
-      it('But selecting a new metric should create another history step', () => {
-        trail.publishEvent(new MetricSelectedEvent('third_metric'));
-        expect(trail.state.history.state.steps.length).toBe(4);
+      describe('But then selecting a new metric', () => {
+        beforeEach(() => {
+          trail.publishEvent(new MetricSelectedEvent('third_metric'));
+        });
+
+        it('Should create another history step', () => {
+          expect(trail.state.history.state.steps.length).toBe(4);
+        });
+
+        it('Should set stepIndex to 3', () => {
+          expect(trail.state.stepIndex).toBe(3);
+        });
+
+        it('Should set history currentStep to 1', () => {
+          expect(trail.state.history.state.currentStep).toBe(3);
+        });
+
+        it('Should set parentIndex to 1', () => {
+          expect(trail.state.parentIndex).toBe(1);
+        });
       });
     });
   });

--- a/public/app/features/trails/DataTrail.tsx
+++ b/public/app/features/trails/DataTrail.tsx
@@ -45,6 +45,7 @@ export interface DataTrailState extends SceneObjectState {
 
   // Indicates which step in the data trail this is
   stepIndex: number;
+  parentIndex: number; // If there is no parent, this will be -1
 }
 
 export class DataTrail extends SceneObjectBase<DataTrailState> {
@@ -63,6 +64,7 @@ export class DataTrail extends SceneObjectBase<DataTrailState> {
       history: state.history ?? new DataTrailHistory({}),
       settings: state.settings ?? new DataTrailSettings({}),
       stepIndex: state.stepIndex ?? 0,
+      parentIndex: state.parentIndex ?? -1,
       ...state,
     });
 

--- a/public/app/features/trails/DataTrailsHistory.tsx
+++ b/public/app/features/trails/DataTrailsHistory.tsx
@@ -139,29 +139,29 @@ export class DataTrailHistory extends SceneObjectBase<DataTrailsHistoryState> {
     return (
       <div className={styles.container}>
         <div className={styles.heading}>Trail</div>
-        <div className={styles.container}>
-          {steps.map((step, index) => (
-            <Tooltip content={() => model.renderStepTooltip(step)} key={index}>
-              <button
-                className={cx(
-                  // Base for all steps
-                  styles.step,
-                  // Specifics per step type
-                  styles.stepTypes[step.type],
-                  // To highlight selected step
-                  model.state.currentStep === index ? styles.stepSelected : '',
-                  // To alter the look of steps with distant non-directly preceding parent
-                  alternatePredecessorStyle.get(index) ?? '',
-                  // To remove direct link for steps that don't have a direct parent
-                  index !== step.trailState.parentIndex + 1 ? styles.stepHasIndirectParent : '',
-                  // To darken steps that aren't the current step's ancesters
-                  !ancestry.has(index) ? styles.stepIsNotAncestorOfCurrent : ''
-                )}
-                onClick={() => trail.goBackToStep(step)}
-              ></button>
-            </Tooltip>
-          ))}
-        </div>
+        {steps.map((step, index) => (
+          <Tooltip content={() => model.renderStepTooltip(step)} key={index}>
+            <button
+              className={cx(
+                // Base for all steps
+                styles.step,
+                // Specifics per step type
+                styles.stepTypes[step.type],
+                // To highlight selected step
+                model.state.currentStep === index ? styles.stepSelected : '',
+                // To alter the look of steps with distant non-directly preceding parent
+                alternatePredecessorStyle.get(index) ?? '',
+                // To remove direct link for steps that don't have a direct parent
+                index !== step.trailState.parentIndex + 1 ? styles.stepOmitsDirectLeftLink : '',
+                // To remove the direct parent link on the start node as well
+                index === 0 ? styles.stepOmitsDirectLeftLink : '',
+                // To darken steps that aren't the current step's ancesters
+                !ancestry.has(index) ? styles.stepIsNotAncestorOfCurrent : ''
+              )}
+              onClick={() => trail.goBackToStep(step)}
+            ></button>
+          </Tooltip>
+        ))}
       </div>
     );
   };
@@ -207,11 +207,6 @@ function getStyles(theme: GrafanaTheme2) {
         background: theme.colors.primary.border,
         pointerEvents: 'none',
       },
-      '&:first-child': {
-        '&:before': {
-          display: 'none',
-        },
-      },
     }),
     stepSelected: css({
       '&:after': {
@@ -227,7 +222,7 @@ function getStyles(theme: GrafanaTheme2) {
         boxShadow: `0px 0px 0px 2px inset ${theme.colors.background.canvas}`,
       },
     }),
-    stepHasIndirectParent: css({
+    stepOmitsDirectLeftLink: css({
       '&:before': {
         background: 'none',
       },

--- a/public/app/features/trails/DataTrailsHistory.tsx
+++ b/public/app/features/trails/DataTrailsHistory.tsx
@@ -152,6 +152,8 @@ export class DataTrailHistory extends SceneObjectBase<DataTrailsHistoryState> {
                   model.state.currentStep === index ? styles.stepSelected : '',
                   // To alter the look of steps with distant non-directly preceding parent
                   alternatePredecessorStyle.get(index) ?? '',
+                  // To remove direct link for steps that don't have a direct parent
+                  index !== step.trailState.parentIndex + 1 ? styles.stepHasIndirectParent : '',
                   // To darken steps that aren't the current step's ancesters
                   !ancestry.has(index) ? styles.stepIsNotAncestorOfCurrent : ''
                 )}
@@ -223,6 +225,11 @@ function getStyles(theme: GrafanaTheme2) {
         left: -4,
         top: -4,
         boxShadow: `0px 0px 0px 2px inset ${theme.colors.background.canvas}`,
+      },
+    }),
+    stepHasIndirectParent: css({
+      '&:before': {
+        background: 'none',
       },
     }),
     stepIsNotAncestorOfCurrent: css({

--- a/public/app/features/trails/DataTrailsHistory.tsx
+++ b/public/app/features/trails/DataTrailsHistory.tsx
@@ -1,5 +1,5 @@
 import { css, cx } from '@emotion/css';
-import React from 'react';
+import React, { useMemo } from 'react';
 
 import { GrafanaTheme2 } from '@grafana/data';
 import {
@@ -18,6 +18,7 @@ import { VAR_FILTERS } from './shared';
 import { getTrailFor } from './utils';
 
 export interface DataTrailsHistoryState extends SceneObjectState {
+  currentStep: number;
   steps: DataTrailHistoryStep[];
 }
 
@@ -31,7 +32,7 @@ export type TrailStepType = 'filters' | 'time' | 'metric' | 'start';
 
 export class DataTrailHistory extends SceneObjectBase<DataTrailsHistoryState> {
   public constructor(state: Partial<DataTrailsHistoryState>) {
-    super({ steps: state.steps ?? [] });
+    super({ steps: state.steps ?? [], currentStep: state.currentStep ?? 0 });
 
     this.addActivationHandler(this._onActivate.bind(this));
   }
@@ -44,17 +45,26 @@ export class DataTrailHistory extends SceneObjectBase<DataTrailsHistoryState> {
     }
 
     trail.subscribeToState((newState, oldState) => {
+      // Check if new and old state are at the same step index
+      // Then we know this is a history transition
+      const isMovingThroughHistory = newState.stepIndex !== oldState.stepIndex;
+
+      if (isMovingThroughHistory) {
+        this.setState({
+          ...this.state,
+          currentStep: newState.stepIndex,
+        });
+
+        return;
+      }
+
       if (newState.metric !== oldState.metric) {
         if (this.state.steps.length === 1) {
           // For the first step we want to update the starting state so that it contains data
           this.state.steps[0].trailState = sceneUtils.cloneSceneObjectState(oldState, { history: this });
         }
 
-        // Check if new and old state are at the same step index
-        // Then we know this isn't a history transition
-        const isMovingThroughHistory = newState.stepIndex !== oldState.stepIndex;
-
-        if (newState.metric && !isMovingThroughHistory) {
+        if (newState.metric) {
           this.addTrailStep(trail, 'metric');
         }
       }
@@ -74,11 +84,13 @@ export class DataTrailHistory extends SceneObjectBase<DataTrailsHistoryState> {
   }
 
   public addTrailStep(trail: DataTrail, type: TrailStepType) {
+    // Update the trail's new current step state, and note its parent step.
     const stepIndex = this.state.steps.length;
-    // Update the trail's current step state.  It is being given a step index.
-    trail.setState({ ...trail.state, stepIndex });
+    const parentIndex = type === 'start' ? -1 : trail.state.stepIndex;
+    trail.setState({ ...trail.state, stepIndex, parentIndex });
 
     this.setState({
+      currentStep: stepIndex,
       steps: [
         ...this.state.steps,
         {
@@ -100,9 +112,29 @@ export class DataTrailHistory extends SceneObjectBase<DataTrailsHistoryState> {
   }
 
   public static Component = ({ model }: SceneComponentProps<DataTrailHistory>) => {
-    const { steps } = model.useState();
+    const { steps, currentStep } = model.useState();
     const styles = useStyles2(getStyles);
     const trail = getTrailFor(model);
+
+    const { ancestry, alternatePredecessorStyle } = useMemo(() => {
+      const ancestry = new Set<number>();
+      let cursor = currentStep;
+      while (cursor >= 0) {
+        ancestry.add(cursor);
+        cursor = steps[cursor].trailState.parentIndex;
+      }
+
+      const alternatePredecessorStyle = new Map<number, string>();
+
+      ancestry.forEach((index) => {
+        const parent = steps[index].trailState.parentIndex;
+        if (parent + 1 !== index) {
+          alternatePredecessorStyle.set(index, createAlternatePredecessorStyle(index, parent));
+        }
+      });
+
+      return { ancestry, alternatePredecessorStyle };
+    }, [currentStep, steps]);
 
     return (
       <div className={styles.container}>
@@ -111,7 +143,18 @@ export class DataTrailHistory extends SceneObjectBase<DataTrailsHistoryState> {
           {steps.map((step, index) => (
             <Tooltip content={() => model.renderStepTooltip(step)} key={index}>
               <button
-                className={cx(styles.step, styles.stepTypes[step.type])}
+                className={cx(
+                  // Base for all steps
+                  styles.step,
+                  // Specifics per step type
+                  styles.stepTypes[step.type],
+                  // To highlight selected step
+                  model.state.currentStep === index ? styles.stepSelected : '',
+                  // To alter the look of steps with distant non-directly preceding parent
+                  alternatePredecessorStyle.get(index) ?? '',
+                  // To darken steps that aren't the current step's ancesters
+                  !ancestry.has(index) ? styles.stepIsNotAncestorOfCurrent : ''
+                )}
                 onClick={() => trail.goBackToStep(step)}
               ></button>
             </Tooltip>
@@ -146,7 +189,11 @@ function getStyles(theme: GrafanaTheme2) {
       background: theme.colors.primary.main,
       position: 'relative',
       '&:hover': {
-        transform: 'scale(1.1)',
+        opacity: 1,
+      },
+      '&:hover:before': {
+        // We only want the node to hover, not its connection to its parent
+        opacity: 0.7,
       },
       '&:before': {
         content: '""',
@@ -156,6 +203,7 @@ function getStyles(theme: GrafanaTheme2) {
         left: -10,
         top: 3,
         background: theme.colors.primary.border,
+        pointerEvents: 'none',
       },
       '&:first-child': {
         '&:before': {
@@ -163,31 +211,65 @@ function getStyles(theme: GrafanaTheme2) {
         },
       },
     }),
+    stepSelected: css({
+      '&:after': {
+        content: '""',
+        borderStyle: `solid`,
+        borderWidth: 2,
+        borderRadius: '50%',
+        position: 'absolute',
+        width: 16,
+        height: 16,
+        left: -4,
+        top: -4,
+        boxShadow: `0px 0px 0px 2px inset ${theme.colors.background.canvas}`,
+      },
+    }),
+    stepIsNotAncestorOfCurrent: css({
+      opacity: 0.2,
+      '&:hover:before': {
+        opacity: 0.2,
+      },
+    }),
     stepTypes: {
-      start: css({
-        background: visTheme.getColorByName('green'),
-        '&:before': {
-          background: visTheme.getColorByName('green'),
-        },
-      }),
-      filters: css({
-        background: visTheme.getColorByName('purple'),
-        '&:before': {
-          background: visTheme.getColorByName('purple'),
-        },
-      }),
-      metric: css({
-        background: visTheme.getColorByName('orange'),
-        '&:before': {
-          background: visTheme.getColorByName('orange'),
-        },
-      }),
-      time: css({
-        background: theme.colors.primary.main,
-        '&:before': {
-          background: theme.colors.primary.main,
-        },
-      }),
+      start: generateStepTypeStyle(visTheme.getColorByName('green')),
+      filters: generateStepTypeStyle(visTheme.getColorByName('purple')),
+      metric: generateStepTypeStyle(visTheme.getColorByName('orange')),
+      time: generateStepTypeStyle(theme.colors.primary.main),
     },
   };
+}
+
+function generateStepTypeStyle(color: string) {
+  return css({
+    background: color,
+    '&:before': {
+      background: color,
+      borderColor: color,
+    },
+    '&:after': {
+      borderColor: color,
+    },
+  });
+}
+
+function createAlternatePredecessorStyle(index: number, parent: number) {
+  const difference = index - parent;
+
+  const NODE_DISTANCE = 18;
+  const distanceToParent = difference * NODE_DISTANCE;
+
+  return css({
+    '&:before': {
+      content: '""',
+      width: distanceToParent + 2,
+      height: 10,
+      borderStyle: 'solid',
+      borderWidth: 2,
+      borderBottom: 'none',
+      top: -10,
+      left: 3 - distanceToParent,
+      background: 'none',
+    },
+  });
 }

--- a/public/app/features/trails/DataTrailsHistory.tsx
+++ b/public/app/features/trails/DataTrailsHistory.tsx
@@ -107,14 +107,16 @@ export class DataTrailHistory extends SceneObjectBase<DataTrailsHistoryState> {
     return (
       <div className={styles.container}>
         <div className={styles.heading}>Trail</div>
-        {steps.map((step, index) => (
-          <Tooltip content={() => model.renderStepTooltip(step)} key={index}>
-            <button
-              className={cx(styles.step, styles.stepTypes[step.type])}
-              onClick={() => trail.goBackToStep(step)}
-            ></button>
-          </Tooltip>
-        ))}
+        <div className={styles.container}>
+          {steps.map((step, index) => (
+            <Tooltip content={() => model.renderStepTooltip(step)} key={index}>
+              <button
+                className={cx(styles.step, styles.stepTypes[step.type])}
+                onClick={() => trail.goBackToStep(step)}
+              ></button>
+            </Tooltip>
+          ))}
+        </div>
       </div>
     );
   };
@@ -146,17 +148,17 @@ function getStyles(theme: GrafanaTheme2) {
       '&:hover': {
         transform: 'scale(1.1)',
       },
-      '&:after': {
+      '&:before': {
         content: '""',
         position: 'absolute',
         width: 10,
         height: 2,
-        left: 8,
+        left: -10,
         top: 3,
         background: theme.colors.primary.border,
       },
-      '&:last-child': {
-        '&:after': {
+      '&:first-child': {
+        '&:before': {
           display: 'none',
         },
       },
@@ -164,25 +166,25 @@ function getStyles(theme: GrafanaTheme2) {
     stepTypes: {
       start: css({
         background: visTheme.getColorByName('green'),
-        '&:after': {
+        '&:before': {
           background: visTheme.getColorByName('green'),
         },
       }),
       filters: css({
         background: visTheme.getColorByName('purple'),
-        '&:after': {
+        '&:before': {
           background: visTheme.getColorByName('purple'),
         },
       }),
       metric: css({
         background: visTheme.getColorByName('orange'),
-        '&:after': {
+        '&:before': {
           background: visTheme.getColorByName('orange'),
         },
       }),
       time: css({
         background: theme.colors.primary.main,
-        '&:after': {
+        '&:before': {
           background: theme.colors.primary.main,
         },
       }),


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

- To clarify which node is currently selected, we encircle it.
  ![image](https://github.com/grafana/grafana/assets/38694490/2a3f3bd1-5f84-40a1-bb7a-c7e6d9043d9a)
- To clarify the steps that led to that node, we gray out nodes that are not on the parent chain, thus highlighting the path of predecessors along with the current selection
  - When rendering a child node and its parent isn't the immediate preceding index (immediately to its left):
    - If that child node is not on the highlighted path, we do not show a left connecting line for that node
      ![image](https://github.com/grafana/grafana/assets/38694490/884e5985-9795-4c58-b231-9a43416752e8)
    - If that child node IS on the highlighted path, we show a 'leap' path that connects up, and to the left, and back down to its parent
      ![image](https://github.com/grafana/grafana/assets/38694490/920756be-f8ca-421c-bfd1-5e875c160071)
- Previously, the color of the connecting line matched the parent node, now it is the reverse:
  - Before 
    ![image](https://github.com/grafana/grafana/assets/38694490/43ff5b0d-9b91-432e-9fb0-11441f1866b4)
  - Now 
    ![image](https://github.com/grafana/grafana/assets/38694490/b3a66aa8-5c84-49d3-a719-fb9724057bb4)



https://github.com/grafana/grafana/assets/38694490/96201bb0-ce19-4754-a707-6a2df3c38548




**Why do we need this feature?**

To clarify the current selection, and the path that led us to it.

**Who is this feature for?**

Users of data trails

**Which issue(s) does this PR fix?**:

N/A



**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
