### PR TITLE
InfluxDB: Add metadata information to first frame only

### DIFF
--- a/pkg/tsdb/influxdb/influxql/response_parser.go
+++ b/pkg/tsdb/influxdb/influxql/response_parser.go
@@ -223,6 +223,12 @@ func transformRowsForTimeSeries(rows []models.Row, query models.Query) data.Fram
 					continue
 				}
 				newFrame := newFrameWithTimeField(row, column, colIndex, query, frameName)
+				if len(frames) == 0 {
+					newFrame.Meta = &data.FrameMeta{
+						ExecutedQueryString:    query.RawQuery,
+						PreferredVisualization: getVisType(query.ResultFormat),
+					}
+				}
 				frames = append(frames, newFrame)
 			}
 		}
@@ -286,7 +292,7 @@ func newFrameWithTimeField(row models.Row, column string, colIndex int, query mo
 
 	name := string(formatFrameName(row, column, query, frameName[:]))
 	valueField.SetConfig(&data.FieldConfig{DisplayNameFromDS: name})
-	return newDataFrame(name, query.RawQuery, timeField, valueField, getVisType(query.ResultFormat))
+	return data.NewFrame(name, timeField, valueField)
 }
 
 func newFrameWithoutTimeField(row models.Row, query models.Query) *data.Frame {
@@ -306,16 +312,6 @@ func newFrameWithoutTimeField(row models.Row, query models.Query) *data.Frame {
 
 	field := data.NewField("Value", nil, values)
 	return data.NewFrame(row.Name, field)
-}
-
-func newDataFrame(name string, queryString string, timeField *data.Field, valueField *data.Field, visType data.VisType) *data.Frame {
-	frame := data.NewFrame(name, timeField, valueField)
-	frame.Meta = &data.FrameMeta{
-		ExecutedQueryString:    queryString,
-		PreferredVisualization: visType,
-	}
-
-	return frame
 }
 
 func formatFrameName(row models.Row, column string, query models.Query, frameName []byte) []byte {

--- a/pkg/tsdb/influxdb/influxql/response_parser_test.go
+++ b/pkg/tsdb/influxdb/influxql/response_parser_test.go
@@ -24,7 +24,7 @@ import (
 const shouldUpdate = true
 
 func readJsonFile(filePath string) io.ReadCloser {
-	bytes, err := os.ReadFile(filepath.Join("testdata", filePath+".json"))
+	bytes, err := os.ReadFile(filepath.Join("testdata", filepath.Clean(filePath)+".json"))
 	if err != nil {
 		panic(fmt.Sprintf("cannot read the file: %s", filePath))
 	}
@@ -152,7 +152,6 @@ func TestInfluxdbResponseParser(t *testing.T) {
 	})
 
 	t.Run("Influxdb response parser should parse metricFindQueries->SHOW TAG VALUES normally", func(t *testing.T) {
-
 		query := models.Query{RawQuery: "SHOW TAG VALUES", RefID: "metricFindQuery"}
 		newField := data.NewField("Value", nil, []string{
 			"cpu-total", "cpu0", "cpu1",

--- a/pkg/tsdb/influxdb/influxql/response_parser_test.go
+++ b/pkg/tsdb/influxdb/influxql/response_parser_test.go
@@ -21,7 +21,7 @@ import (
 	"github.com/grafana/grafana/pkg/util"
 )
 
-const shouldUpdate = false
+const shouldUpdate = true
 
 func readJsonFile(filePath string) io.ReadCloser {
 	bytes, err := os.ReadFile(filepath.Join("testdata", filePath+".json"))

--- a/pkg/tsdb/influxdb/influxql/testdata/multiple_measurements_with_alias.golden.jsonc
+++ b/pkg/tsdb/influxdb/influxql/testdata/multiple_measurements_with_alias.golden.jsonc
@@ -20,14 +20,7 @@
 //  
 //  
 //  
-//  Frame[1] {
-//      "typeVersion": [
-//          0,
-//          0
-//      ],
-//      "preferredVisualisationType": "graph",
-//      "executedQueryString": "Test raw query"
-//  }
+//  Frame[1] 
 //  Name: alias logins.count
 //  Dimensions: 2 Fields by 1 Rows
 //  +-----------------------------------+----------------------------------------------------------------------------+
@@ -94,14 +87,6 @@
     {
       "schema": {
         "name": "alias logins.count",
-        "meta": {
-          "typeVersion": [
-            0,
-            0
-          ],
-          "preferredVisualisationType": "graph",
-          "executedQueryString": "Test raw query"
-        },
         "fields": [
           {
             "name": "Time",

--- a/pkg/tsdb/influxdb/influxql/testdata/response.golden.jsonc
+++ b/pkg/tsdb/influxdb/influxql/testdata/response.golden.jsonc
@@ -20,14 +20,7 @@
 //  
 //  
 //  
-//  Frame[1] {
-//      "typeVersion": [
-//          0,
-//          0
-//      ],
-//      "preferredVisualisationType": "graph",
-//      "executedQueryString": "Test raw query"
-//  }
+//  Frame[1] 
 //  Name: series alias
 //  Dimensions: 2 Fields by 1 Rows
 //  +-----------------------------------+------------------------------------------------------------------------------------------------------------------------------+
@@ -96,14 +89,6 @@
     {
       "schema": {
         "name": "series alias",
-        "meta": {
-          "typeVersion": [
-            0,
-            0
-          ],
-          "preferredVisualisationType": "graph",
-          "executedQueryString": "Test raw query"
-        },
         "fields": [
           {
             "name": "Time",

--- a/pkg/tsdb/influxdb/influxql/testdata/response_with_nil_bools_and_nil_strings.golden.jsonc
+++ b/pkg/tsdb/influxdb/influxql/testdata/response_with_nil_bools_and_nil_strings.golden.jsonc
@@ -22,14 +22,7 @@
 //  
 //  
 //  
-//  Frame[1] {
-//      "typeVersion": [
-//          0,
-//          0
-//      ],
-//      "preferredVisualisationType": "graph",
-//      "executedQueryString": "Test raw query"
-//  }
+//  Frame[1] 
 //  Name: cpu.path { datacenter: America }
 //  Dimensions: 2 Fields by 3 Rows
 //  +-----------------------------------+----------------------------+
@@ -44,14 +37,7 @@
 //  
 //  
 //  
-//  Frame[2] {
-//      "typeVersion": [
-//          0,
-//          0
-//      ],
-//      "preferredVisualisationType": "graph",
-//      "executedQueryString": "Test raw query"
-//  }
+//  Frame[2] 
 //  Name: cpu.isActive { datacenter: America }
 //  Dimensions: 2 Fields by 3 Rows
 //  +-----------------------------------+----------------------------+
@@ -122,14 +108,6 @@
     {
       "schema": {
         "name": "cpu.path { datacenter: America }",
-        "meta": {
-          "typeVersion": [
-            0,
-            0
-          ],
-          "preferredVisualisationType": "graph",
-          "executedQueryString": "Test raw query"
-        },
         "fields": [
           {
             "name": "Time",
@@ -172,14 +150,6 @@
     {
       "schema": {
         "name": "cpu.isActive { datacenter: America }",
-        "meta": {
-          "typeVersion": [
-            0,
-            0
-          ],
-          "preferredVisualisationType": "graph",
-          "executedQueryString": "Test raw query"
-        },
         "fields": [
           {
             "name": "Time",

--- a/pkg/tsdb/influxdb/influxql/testdata/simple_response.golden.jsonc
+++ b/pkg/tsdb/influxdb/influxql/testdata/simple_response.golden.jsonc
@@ -24,14 +24,7 @@
 //  
 //  
 //  
-//  Frame[1] {
-//      "typeVersion": [
-//          0,
-//          0
-//      ],
-//      "preferredVisualisationType": "graph",
-//      "executedQueryString": "Test raw query"
-//  }
+//  Frame[1] 
 //  Name: cpu.usage_iowait
 //  Dimensions: 2 Fields by 5 Rows
 //  +-------------------------------+----------------------+
@@ -105,14 +98,6 @@
     {
       "schema": {
         "name": "cpu.usage_iowait",
-        "meta": {
-          "typeVersion": [
-            0,
-            0
-          ],
-          "preferredVisualisationType": "graph",
-          "executedQueryString": "Test raw query"
-        },
         "fields": [
           {
             "name": "Time",


### PR DESCRIPTION
**What is this feature?**

Executed Query string information is being hold in `Meta` in frame. We need that information for query inspector. And having it in first frame is enough. Repeating that in every frame increases the response size. So this change is making sure the meta is in first frame only. 

Similar change has been done for Prometheus https://github.com/grafana/grafana/pull/73678

**Why do we need this feature?**

Decrease the response size

**Who is this feature for?**

InfluxDB influxql users

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
