### PR TITLE
Logs Popover Menu: close menu on right click

### DIFF
--- a/public/app/features/logs/components/LogRows.tsx
+++ b/public/app/features/logs/components/LogRows.tsx
@@ -121,6 +121,7 @@ class UnThemedLogRows extends PureComponent<Props, State> {
       selectedRow: row,
     });
     document.addEventListener('click', this.handleDeselection);
+    document.addEventListener('contextmenu', this.handleDeselection);
     return true;
   };
 
@@ -138,6 +139,7 @@ class UnThemedLogRows extends PureComponent<Props, State> {
 
   closePopoverMenu = () => {
     document.removeEventListener('click', this.handleDeselection);
+    document.removeEventListener('contextmenu', this.handleDeselection);
     this.setState({
       selection: '',
       popoverMenuCoordinates: { x: 0, y: 0 },
@@ -160,6 +162,7 @@ class UnThemedLogRows extends PureComponent<Props, State> {
 
   componentWillUnmount() {
     document.removeEventListener('click', this.handleDeselection);
+    document.removeEventListener('contextmenu', this.handleDeselection);
     if (this.renderAllTimer) {
       clearTimeout(this.renderAllTimer);
     }


### PR DESCRIPTION
If the user wants to use the native context menu (by keyboard or right-click), we now close the popover menu so it doesn't interfere.

**Which issue(s) does this PR fix?**:

Part of https://github.com/grafana/grafana/issues/76129

**Special notes for your reviewer:**

When an action triggers the display of the popover menu, right-clicking should close it.