### PR TITLE
Remove mandatory backport checks

### DIFF
--- a/.github/pr-checks.json
+++ b/.github/pr-checks.json
@@ -7,25 +7,6 @@
     "failure": "Milestone not set"
   },
   {
-    "type": "check-label",
-    "title": "Backport Check",
-    "labels": {
-      "exists": "Backport enabled",
-      "notExists": "Backport decision needed",
-      "matches": [
-        "backport v*"
-      ]
-    },
-    "skip": {
-      "message": "Backport skipped",
-      "matches": [
-        "backport",
-        "no-backport"
-      ]
-    },
-    "targetUrl": "https://github.com/grafana/grafana/blob/main/contribute/merge-pull-request.md#should-the-pull-request-be-backported"
-  },
-  {
     "type": "check-changelog",
     "title": "Changelog Check",
     "labels": {

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -11,7 +11,7 @@
   ],
   "includePaths": ["package.json", "packages/**", "public/app/plugins/**"],
   "ignorePaths": ["emails/**", "plugins-bundled/**", "**/mocks/**", "packages/grafana-e2e/**"],
-  "labels": ["area/frontend", "dependencies", "no-backport", "no-changelog"],
+  "labels": ["area/frontend", "dependencies", "no-changelog"],
   "postUpdateOptions": ["yarnDedupeHighest"],
   "packageRules": [
     {

--- a/.github/workflows/alerting-swagger-gen.yml
+++ b/.github/workflows/alerting-swagger-gen.yml
@@ -31,7 +31,7 @@ jobs:
             Please review and merge.
           branch: update-alerting-swagger-spec
           delete-branch: true
-          labels: 'area/alerting,type/docs,no-backport,no-changelog'
+          labels: 'area/alerting,type/docs,no-changelog'
           team-reviewers: 'grafana/alerting-backend-product'
           draft: false
 

--- a/contribute/merge-pull-request.md
+++ b/contribute/merge-pull-request.md
@@ -115,18 +115,12 @@ In case the pull request introduces a breaking change you should document this. 
 <Breaking change description>
 ```
 
-### Should the pull request be backported?
+### Backporting
 
 Backporting is the process of copying the pull request into the version branch of one or multiple previous releases.
-This should only be done for _critical bug fixes_ and involves the intervention of a Grafana Labs employee.
-To make this decision explicit, there is a **Backport Check** that is re-evaluated automatically by adding/removing labels on the pull request.
+This is a rare exception, should only be done for _critical bug fixes_, and involves the intervention of a Grafana Labs employee.
 
-#### Backport
-
-If your pull request fixes a critical bug and needs to go into one or several existing release branches it should be backported.
-
-For a pull request to be backported, please add it to "Critical Bug Release" form so that the delivery team is aware that a release for a previous version needs to be made.
-Once approved, the backporting process will continue from there.
+If your pull request fixes a critical bug and needs to be backported, add it to the "Critical Bug Release" form so the team can approve the backport and know that a release needs to be made. Specify the correct `backport vx.x` labels for the releases the fix needs to be backported to. Once approved, the backporting process will continue from there.
 
 #### Required labels
 

--- a/contribute/merge-pull-request.md
+++ b/contribute/merge-pull-request.md
@@ -121,19 +121,12 @@ Backporting is the process of copying the pull request into the version branch o
 This should only be done for _critical bug fixes_ and involves the intervention of a Grafana Labs employee.
 To make this decision explicit, there is a **Backport Check** that is re-evaluated automatically by adding/removing labels on the pull request.
 
-#### No backport
-
-If you don't want to backport you need to add a label named **no-backport** to the pull request.
-
-This should be the default!
-
 #### Backport
 
 If your pull request fixes a critical bug and needs to go into one or several existing release branches it should be backported.
 
 For a pull request to be backported, please add it to "Critical Bug Release" form so that the delivery team is aware that a release for a previous version needs to be made.
 Once approved, the backporting process will continue from there.
-In the meantime, set the `no-backport` label.
 
 #### Required labels
 

--- a/crowdin.yml
+++ b/crowdin.yml
@@ -6,4 +6,3 @@ pull_request_title: 'I18n: Crowdin sync'
 pull_request_labels:
   - area/internationalization
   - no-changelog
-  - no-backport


### PR DESCRIPTION
Removes the mandatory backport label from PRs.

Now that backports are the rare exception, requiring developers no manually flag that they're not doing an exceptional thing makes less sense. 

Also removes the label from a few automations that added it to PRs