### PR TITLE
Grafana UI: Menu - Add autofocus by default to menu component

### DIFF
--- a/packages/grafana-ui/src/components/Menu/Menu.tsx
+++ b/packages/grafana-ui/src/components/Menu/Menu.tsx
@@ -1,4 +1,5 @@
 import { css, cx } from '@emotion/css';
+import { FocusScope } from '@react-aria/focus';
 import React, { useImperativeHandle, useRef } from 'react';
 
 import { GrafanaTheme2 } from '@grafana/data';
@@ -15,13 +16,14 @@ export interface MenuProps extends React.HTMLAttributes<HTMLDivElement> {
   header?: React.ReactNode;
   children: React.ReactNode;
   ariaLabel?: string;
+  autoFocusMenu?: boolean;
   onOpen?: (focusOnItem: (itemId: number) => void) => void;
   onClose?: () => void;
   onKeyDown?: React.KeyboardEventHandler;
 }
 
 const MenuComp = React.forwardRef<HTMLDivElement, MenuProps>(
-  ({ header, children, ariaLabel, onOpen, onClose, onKeyDown, ...otherProps }, forwardedRef) => {
+  ({ header, children, ariaLabel, onOpen, onClose, onKeyDown, autoFocusMenu = true, ...otherProps }, forwardedRef) => {
     const styles = useStyles2(getStyles);
 
     const localRef = useRef<HTMLDivElement>(null);
@@ -30,27 +32,29 @@ const MenuComp = React.forwardRef<HTMLDivElement, MenuProps>(
     const [handleKeys] = useMenuFocus({ localRef, onOpen, onClose, onKeyDown });
 
     return (
-      <div
-        {...otherProps}
-        tabIndex={-1}
-        ref={localRef}
-        className={styles.wrapper}
-        role="menu"
-        aria-label={ariaLabel}
-        onKeyDown={handleKeys}
-      >
-        {header && (
-          <div
-            className={cx(
-              styles.header,
-              Boolean(children) && React.Children.toArray(children).length > 0 && styles.headerBorder
-            )}
-          >
-            {header}
-          </div>
-        )}
-        {children}
-      </div>
+      <FocusScope autoFocus={autoFocusMenu}>
+        <div
+          {...otherProps}
+          tabIndex={-1}
+          ref={localRef}
+          className={styles.wrapper}
+          role="menu"
+          aria-label={ariaLabel}
+          onKeyDown={handleKeys}
+        >
+          {header && (
+            <div
+              className={cx(
+                styles.header,
+                Boolean(children) && React.Children.toArray(children).length > 0 && styles.headerBorder
+              )}
+            >
+              {header}
+            </div>
+          )}
+          {children}
+        </div>
+      </FocusScope>
     );
   }
 );


### PR DESCRIPTION
## Problem:
Dropdown menus containing async items (specifically, `PanelMenu` from `PanelChrome`) do not trigger autofocus to the container. When we don't have autofocus the logic from the `Menu` component to handle keyboard navigation does not work.

_This issue is coming from rendering panels using scenes, we noticed the keyboard does not work, the tricky part was to understand why it was working in the old architecture  (core grafana) and not using scenes._

<table>
<tr>
 <td> Bug
 <td> Fix
<tr>
 <td> 

![image](https://github.com/grafana/grafana/assets/239999/0fd1b7b4-adfe-4b0e-8a1d-11e57fed78eb)
 
<td> 

![MenuScenesWorking](https://github.com/grafana/grafana/assets/239999/b6d1752b-cf31-4945-a097-187870f3ddc0)

</table>



### So, Why it was not working in dashboards rendered with Scenes?

####  Old Architecture Behavior:

- Panel Rendering: `PanelChrome` renders a menu using `PanelMenu`. This dropdown, when visible, renders a menu provided by `PanelStateWrapper -->PanelHeaderMenu`.
- Menu Interaction: When a user clicks the menu, the dropdown's visibility changes.
- Menu Rendering: then `PanelHeaderMenu` is triggered, initially rendering an empty Menu (`<div tabindex="-1" role="menu"...`).
- Autofocus Triggering: The Autofocus (from React Aria) in the Dropdown is activated, focusing on the role="menu" element.
- Item Availability: Once items become available, PanelHeaderMenu re-renders with items. However, the focus remains on the container with role="menu".

#### New Architecture Behavior:

- Panel Rendering: Similar to the old architecture, `PanelChrome` uses `PanelMenu`. However, this time it's coupled with `VizPanelMenu -> VizPanelMenuRenderer.`
- Menu Interaction: When a user clicks the menu, `VizPanelMenu` get activated,  which in turn calls `panelMenuBehavior.`
- Asynchronous Item Gathering: Items are loaded asynchronously.
- Autofocus Triggering: The Autofocus (from React Aria) in the `Dropdown` activates, but at this point, there are no focusable elements.
- Delayed Menu Rendering: Once items are ready, `VizPanelMenuRenderer` is triggered, rendering the Menu with items. However, the container lacks focus.

In short: The problem is the order of execution, in the case of Scenes, the autofocus from react aria executes right after the `panelMenuBehavior `, but before the `VizPanelMenuRenderer`, this means the container of the menu never gets the focus.

## Proposal:

This PR adds by default autofocus to the `Menu` component, but also offers a possibility to override that prop for cases where autofocus is not desired. 
I'm open to suggestions and welcome any feedback or alternative ideas.
