### PR TITLE
Alerting: Add support for TTL for pushover for Mimir Alertmanager

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -462,6 +462,7 @@ cypress.config.js @grafana/grafana-frontend-platform
 /public/app/routes/ @grafana/grafana-frontend-platform
 /public/app/store/ @grafana/grafana-frontend-platform
 /public/app/types/ @grafana/grafana-frontend-platform
+/public/app/types/alerting.ts @grafana/alerting-frontend
 /public/dashboards/ @grafana/dashboards-squad
 /public/fonts/ @grafana/alerting-frontend
 /public/gazetteer/ @ryantxu

--- a/docs/sources/alerting/set-up/provision-alerting-resources/file-provisioning/index.md
+++ b/docs/sources/alerting/set-up/provision-alerting-resources/file-provisioning/index.md
@@ -355,6 +355,8 @@ settings:
   retry: '30'
   # <string>
   expire: '120'
+  # <string> a number of seconds that the message will live, before being deleted automatically
+  ttl:
   # <string>
   sound: siren
   # <string>

--- a/docs/sources/alerting/set-up/provision-alerting-resources/file-provisioning/index.md
+++ b/docs/sources/alerting/set-up/provision-alerting-resources/file-provisioning/index.md
@@ -355,7 +355,7 @@ settings:
   retry: '30'
   # <string>
   expire: '120'
-  # <string> a number of seconds that the message will live, before being deleted automatically
+  # <string> the number of seconds before a message expires and is deleted automatically
   ttl:
   # <string>
   sound: siren

--- a/docs/sources/alerting/set-up/provision-alerting-resources/file-provisioning/index.md
+++ b/docs/sources/alerting/set-up/provision-alerting-resources/file-provisioning/index.md
@@ -355,7 +355,7 @@ settings:
   retry: '30'
   # <string>
   expire: '120'
-  # <string> the number of seconds before a message expires and is deleted automatically
+  # <string> the number of seconds before a message expires and is deleted automatically. Examples: 10s, 5m30s, 8h.
   ttl:
   # <string>
   sound: siren

--- a/docs/sources/old-alerting/notifications.md
+++ b/docs/sources/old-alerting/notifications.md
@@ -183,7 +183,7 @@ To set up Pushover, you must provide a user key and an API token. Refer to [What
 | OK priority    | The priority OK notifications are sent; if not set, then OK notifications are sent with the priority set for alerting notifications |
 | Retry          | How often (in seconds) the Pushover servers send the same notification to the user. (minimum 30 seconds)                            |
 | Expire         | How many seconds your notification will continue to be retried for (maximum 86400 seconds)                                          |
-| TTL            | A number of seconds that the message will live, before being deleted automatically                                                  |
+| TTL            | A number of seconds that the message will live, before being deleted automatically. Examples: 10s, 5m30s, 8h.                       |
 | Alerting sound | The sound for alerting notifications                                                                                                |
 | OK sound       | The sound for OK notifications                                                                                                      |
 

--- a/docs/sources/old-alerting/notifications.md
+++ b/docs/sources/old-alerting/notifications.md
@@ -183,6 +183,7 @@ To set up Pushover, you must provide a user key and an API token. Refer to [What
 | OK priority    | The priority OK notifications are sent; if not set, then OK notifications are sent with the priority set for alerting notifications |
 | Retry          | How often (in seconds) the Pushover servers send the same notification to the user. (minimum 30 seconds)                            |
 | Expire         | How many seconds your notification will continue to be retried for (maximum 86400 seconds)                                          |
+| TTL            | A number of seconds that the message will live, before being deleted automatically                                                  |
 | Alerting sound | The sound for alerting notifications                                                                                                |
 | OK sound       | The sound for OK notifications                                                                                                      |
 

--- a/docs/sources/old-alerting/notifications.md
+++ b/docs/sources/old-alerting/notifications.md
@@ -183,7 +183,7 @@ To set up Pushover, you must provide a user key and an API token. Refer to [What
 | OK priority    | The priority OK notifications are sent; if not set, then OK notifications are sent with the priority set for alerting notifications |
 | Retry          | How often (in seconds) the Pushover servers send the same notification to the user. (minimum 30 seconds)                            |
 | Expire         | How many seconds your notification will continue to be retried for (maximum 86400 seconds)                                          |
-| TTL            | A number of seconds that the message will live, before being deleted automatically. Examples: 10s, 5m30s, 8h.                       |
+| TTL            | The number of seconds before a message expires and is deleted automatically. Examples: 10s, 5m30s, 8h.                              |
 | Alerting sound | The sound for alerting notifications                                                                                                |
 | OK sound       | The sound for OK notifications                                                                                                      |
 

--- a/public/app/features/alerting/unified/utils/cloud-alertmanager-notifier-types.ts
+++ b/public/app/features/alerting/unified/utils/cloud-alertmanager-notifier-types.ts
@@ -175,9 +175,16 @@ export const cloudNotifierTypes: Array<NotifierDTO<CloudNotifierType>> = [
           placeholder: '1h',
         }
       ),
-      option('ttl', 'TTL', 'The number of seconds before a message expires and is deleted automatically', {
-        validationRule: '^\\d+$|^$',
-      }),
+      option(
+        'ttl',
+        'TTL',
+        'The number of seconds before a message expires and is deleted automatically. Examples: 10s, 5m30s, 8h.',
+        {
+          // allow 30s, 4m30s, etc
+          validationRule: '^(\\d+[s|m|h])+$|^$',
+          element: 'input',
+        }
+      ),
       httpConfigOption,
     ],
   },

--- a/public/app/features/alerting/unified/utils/cloud-alertmanager-notifier-types.ts
+++ b/public/app/features/alerting/unified/utils/cloud-alertmanager-notifier-types.ts
@@ -175,7 +175,7 @@ export const cloudNotifierTypes: Array<NotifierDTO<CloudNotifierType>> = [
           placeholder: '1h',
         }
       ),
-      option('ttl', 'TTL', 'A number of seconds that the message will live, before being deleted automatically', {
+      option('ttl', 'TTL', 'The number of seconds before a message expires and is deleted automatically', {
         validationRule: '^\\d+$|^$',
       }),
       httpConfigOption,

--- a/public/app/features/alerting/unified/utils/cloud-alertmanager-notifier-types.ts
+++ b/public/app/features/alerting/unified/utils/cloud-alertmanager-notifier-types.ts
@@ -175,6 +175,9 @@ export const cloudNotifierTypes: Array<NotifierDTO<CloudNotifierType>> = [
           placeholder: '1h',
         }
       ),
+      option('ttl', 'TTL', 'A number of seconds that the message will live, before being deleted automatically', {
+        validationRule: '^\\d+$|^$',
+      }),
       httpConfigOption,
     ],
   },

--- a/public/app/types/alerting.ts
+++ b/public/app/types/alerting.ts
@@ -144,7 +144,7 @@ export interface NotificationChannelOption {
   validationRule: string;
   subformOptions?: NotificationChannelOption[];
   dependsOn: string;
-  setValueAs?: (value: string | boolean) => string | number | boolean | null;
+  setValueAs?: (value: string | boolean) => string | number | boolean | null | undefined;
 }
 
 export interface NotificationChannelState {

--- a/public/app/types/alerting.ts
+++ b/public/app/types/alerting.ts
@@ -144,7 +144,7 @@ export interface NotificationChannelOption {
   validationRule: string;
   subformOptions?: NotificationChannelOption[];
   dependsOn: string;
-  setValueAs?: (value: string | boolean) => string | number | boolean | null | undefined;
+  setValueAs?: (value: string | boolean) => string | number | boolean | null;
 }
 
 export interface NotificationChannelState {


### PR DESCRIPTION
**What is this feature?**

This PR adds support for the `ttl` configuration option for `Pushover` when configuring an external Mimir Alertmanager.

This is the front-end counterpart to https://github.com/grafana/mimir/pull/6560

**Who is this feature for?**

Users of Mimir or Cortext Alertmanager.

**Notes for reviewers**

This currently requires an unreleased version of Mimir – but it should be released and deployed by the time Grafana 10.3 lands.