### PR TITLE
Alerting: Add GetFullState method to FileStore

### DIFF
--- a/pkg/services/ngalert/ngalert.go
+++ b/pkg/services/ngalert/ngalert.go
@@ -177,7 +177,9 @@ func (ng *AlertNG) init() error {
 	if ng.Cfg.UnifiedAlerting.RemoteAlertmanager.Enable {
 		override := notifier.WithAlertmanagerOverride(func(ctx context.Context, orgID int64) (notifier.Alertmanager, error) {
 			externalAMCfg := remote.AlertmanagerConfig{}
-			return remote.NewAlertmanager(externalAMCfg, orgID, ng.KVStore)
+			// We won't be handling files on disk, we can pass an empty string as workingDirPath.
+			stateStore := notifier.NewFileStore(orgID, ng.KVStore, "")
+			return remote.NewAlertmanager(externalAMCfg, orgID, stateStore)
 		})
 
 		overrides = append(overrides, override)

--- a/pkg/services/ngalert/ngalert.go
+++ b/pkg/services/ngalert/ngalert.go
@@ -177,8 +177,7 @@ func (ng *AlertNG) init() error {
 	if ng.Cfg.UnifiedAlerting.RemoteAlertmanager.Enable {
 		override := notifier.WithAlertmanagerOverride(func(ctx context.Context, orgID int64) (notifier.Alertmanager, error) {
 			externalAMCfg := remote.AlertmanagerConfig{}
-			fstore := notifier.NewFileStore(orgID, ng.KVStore, "")
-			return remote.NewAlertmanager(externalAMCfg, orgID, fstore)
+			return remote.NewAlertmanager(externalAMCfg, orgID, ng.KVStore)
 		})
 
 		overrides = append(overrides, override)

--- a/pkg/services/ngalert/ngalert.go
+++ b/pkg/services/ngalert/ngalert.go
@@ -177,7 +177,8 @@ func (ng *AlertNG) init() error {
 	if ng.Cfg.UnifiedAlerting.RemoteAlertmanager.Enable {
 		override := notifier.WithAlertmanagerOverride(func(ctx context.Context, orgID int64) (notifier.Alertmanager, error) {
 			externalAMCfg := remote.AlertmanagerConfig{}
-			return remote.NewAlertmanager(externalAMCfg, orgID)
+			fstore := notifier.NewFileStore(orgID, ng.KVStore, "")
+			return remote.NewAlertmanager(externalAMCfg, orgID, fstore)
 		})
 
 		overrides = append(overrides, override)

--- a/pkg/services/ngalert/notifier/file_store.go
+++ b/pkg/services/ngalert/notifier/file_store.go
@@ -63,37 +63,36 @@ func (fileStore *FileStore) FilepathFor(ctx context.Context, filename string) (s
 	return fileStore.pathFor(filename), err
 }
 
-// GetFullState returns a base64-encoded string containing the Alertmanager's silences and nflog.
-func (fileStore *FileStore) GetFullState(ctx context.Context) (string, error) {
+// GetFullState receives a list of keys, looks for the corresponding values in the kvstore,
+// and returns a base64-encoded protobuf message containing those key-value pairs.
+// That base64-encoded string represents the Alertmanager's internal state.
+func (fileStore *FileStore) GetFullState(ctx context.Context, filenames ...string) (string, error) {
 	all, err := fileStore.kv.GetAll(ctx)
 	if err != nil {
 		return "", err
 	}
 
-	silences, ok := all[fileStore.orgID]["silences"]
+	keys, ok := all[fileStore.orgID]
 	if !ok {
-		fileStore.logger.Warn("No silences found in kvstore", "org", fileStore.orgID)
-	}
-	notifications, ok := all[fileStore.orgID]["notifications"]
-	if !ok {
-		fileStore.logger.Warn("No nflog found in kvstore", "org", fileStore.orgID)
+		return "", fmt.Errorf("no values for org %d", fileStore.orgID)
 	}
 
-	// Decode base64-encoded values and add them as protobuf parts.
-	s, err := decode(silences)
-	if err != nil {
-		return "", fmt.Errorf("error decoding silences: %w", err)
-	}
-	n, err := decode(notifications)
-	if err != nil {
-		return "", fmt.Errorf("error decoding nflog: %w", err)
+	var parts []clusterpb.Part
+	for _, f := range filenames {
+		v, ok := keys[f]
+		if !ok {
+			return "", fmt.Errorf("no value found for key %q", f)
+		}
+
+		b, err := decode(v)
+		if err != nil {
+			return "", fmt.Errorf("error decoding value for key %q", f)
+		}
+		parts = append(parts, clusterpb.Part{Key: f, Data: b})
 	}
 
 	fs := clusterpb.FullState{
-		Parts: []clusterpb.Part{
-			{Key: "silences", Data: s},
-			{Key: "notifications", Data: n},
-		},
+		Parts: parts,
 	}
 	b, err := fs.Marshal()
 	if err != nil {

--- a/pkg/services/ngalert/remote/alertmanager.go
+++ b/pkg/services/ngalert/remote/alertmanager.go
@@ -28,7 +28,7 @@ import (
 const readyPath = "/-/ready"
 
 type stateStore interface {
-	GetFullState(ctx context.Context) (string, error)
+	GetFullState(ctx context.Context, keys ...string) (string, error)
 }
 
 type Alertmanager struct {

--- a/pkg/services/ngalert/remote/alertmanager.go
+++ b/pkg/services/ngalert/remote/alertmanager.go
@@ -26,6 +26,10 @@ import (
 
 const readyPath = "/-/ready"
 
+type stateStore interface {
+	GetFullState(ctx context.Context) (string, error)
+}
+
 type Alertmanager struct {
 	log      log.Logger
 	orgID    int64
@@ -37,6 +41,7 @@ type Alertmanager struct {
 	httpClient  *http.Client
 	ready       bool
 	sender      *sender.ExternalAlertmanager
+	stateStore  stateStore
 }
 
 type AlertmanagerConfig struct {
@@ -45,7 +50,7 @@ type AlertmanagerConfig struct {
 	BasicAuthPassword string
 }
 
-func NewAlertmanager(cfg AlertmanagerConfig, orgID int64) (*Alertmanager, error) {
+func NewAlertmanager(cfg AlertmanagerConfig, orgID int64, stateStore stateStore) (*Alertmanager, error) {
 	client := http.Client{
 		Transport: &mimirClient.MimirAuthRoundTripper{
 			TenantID: cfg.TenantID,
@@ -100,6 +105,7 @@ func NewAlertmanager(cfg AlertmanagerConfig, orgID int64) (*Alertmanager, error)
 		amClient:    amclient.New(transport, nil),
 		httpClient:  &client,
 		sender:      s,
+		stateStore:  stateStore,
 		orgID:       orgID,
 		tenantID:    cfg.TenantID,
 		url:         cfg.URL,

--- a/pkg/services/ngalert/remote/alertmanager_test.go
+++ b/pkg/services/ngalert/remote/alertmanager_test.go
@@ -63,7 +63,7 @@ func TestNewAlertmanager(t *testing.T) {
 				TenantID:          test.tenantID,
 				BasicAuthPassword: test.password,
 			}
-			am, err := NewAlertmanager(cfg, test.orgID)
+			am, err := NewAlertmanager(cfg, test.orgID, nil)
 			if test.expErr != "" {
 				require.EqualError(tt, err, test.expErr)
 				return
@@ -93,7 +93,7 @@ func TestApplyConfig(t *testing.T) {
 	cfg := AlertmanagerConfig{
 		URL: server.URL,
 	}
-	am, err := NewAlertmanager(cfg, 1)
+	am, err := NewAlertmanager(cfg, 1, nil)
 	require.NoError(t, err)
 
 	config := &ngmodels.AlertConfiguration{}
@@ -144,7 +144,7 @@ func TestIntegrationRemoteAlertmanagerApplyConfigOnlyUploadsOnce(t *testing.T) {
 	}
 
 	ctx := context.Background()
-	am, err := NewAlertmanager(cfg, 1)
+	am, err := NewAlertmanager(cfg, 1, nil)
 	require.NoError(t, err)
 
 	// We should have no configuration at first.
@@ -214,7 +214,7 @@ func TestIntegrationRemoteAlertmanagerSilences(t *testing.T) {
 		TenantID:          tenantID,
 		BasicAuthPassword: password,
 	}
-	am, err := NewAlertmanager(cfg, 1)
+	am, err := NewAlertmanager(cfg, 1, nil)
 	require.NoError(t, err)
 
 	// We should have no silences at first.
@@ -293,7 +293,7 @@ func TestIntegrationRemoteAlertmanagerAlerts(t *testing.T) {
 		TenantID:          tenantID,
 		BasicAuthPassword: password,
 	}
-	am, err := NewAlertmanager(cfg, 1)
+	am, err := NewAlertmanager(cfg, 1, nil)
 	require.NoError(t, err)
 
 	// Wait until the Alertmanager is ready to send alerts.
@@ -355,7 +355,7 @@ func TestIntegrationRemoteAlertmanagerReceivers(t *testing.T) {
 		BasicAuthPassword: password,
 	}
 
-	am, err := NewAlertmanager(cfg, 1)
+	am, err := NewAlertmanager(cfg, 1, nil)
 	require.NoError(t, err)
 
 	// We should start with the default config.

--- a/pkg/services/ngalert/tests/fakes/kvstore.go
+++ b/pkg/services/ngalert/tests/fakes/kvstore.go
@@ -98,5 +98,25 @@ func (fkv *FakeKVStore) Keys(ctx context.Context, orgID int64, namespace string,
 }
 
 func (fkv *FakeKVStore) GetAll(ctx context.Context, orgId int64, namespace string) (map[int64]map[string]string, error) {
-	return nil, nil
+	fkv.Mtx.Lock()
+	defer fkv.Mtx.Unlock()
+
+	all := map[int64]map[string]string{
+		orgId: make(map[string]string),
+	}
+
+	org, ok := fkv.Store[orgId]
+	if !ok {
+		return nil, nil
+	}
+
+	values, ok := org[namespace]
+	if !ok {
+		return all, nil
+	}
+
+	for k, v := range values {
+		all[orgId][k] = v
+	}
+	return all, nil
 }


### PR DESCRIPTION
This PR adds a method to query the Alertmanager's internal state to the `FileStore`. The remote Alertmanager struct can fetch the state and send it to the remote Alertmanager using this method.