### PR TITLE
Loki: Added support for "or" statements in line filters

### DIFF
--- a/package.json
+++ b/package.json
@@ -250,7 +250,7 @@
     "@grafana/faro-web-sdk": "1.2.1",
     "@grafana/flamegraph": "workspace:*",
     "@grafana/google-sdk": "0.1.1",
-    "@grafana/lezer-logql": "0.2.1",
+    "@grafana/lezer-logql": "0.2.2",
     "@grafana/lezer-traceql": "0.0.11",
     "@grafana/monaco-logql": "^0.0.7",
     "@grafana/runtime": "workspace:*",

--- a/public/app/plugins/datasource/loki/backendResultTransformer.ts
+++ b/public/app/plugins/datasource/loki/backendResultTransformer.ts
@@ -2,7 +2,7 @@ import { DataQueryResponse, DataFrame, isDataFrame, FieldType, QueryResultMeta, 
 
 import { getDerivedFields } from './getDerivedFields';
 import { makeTableFrames } from './makeTableFrames';
-import { formatQuery, getHighlighterExpressionsFromQuery } from './queryUtils';
+import { getHighlighterExpressionsFromQuery } from './queryUtils';
 import { dataFrameHasLokiError } from './responseUtils';
 import { DerivedFieldConfig, LokiQuery, LokiQueryType } from './types';
 
@@ -39,7 +39,7 @@ function processStreamFrame(
   const meta: QueryResultMeta = {
     preferredVisualisationType: 'logs',
     limit: query?.maxLines,
-    searchWords: query !== undefined ? getHighlighterExpressionsFromQuery(formatQuery(query.expr)) : undefined,
+    searchWords: query !== undefined ? getHighlighterExpressionsFromQuery(query.expr) : undefined,
     custom,
   };
 

--- a/public/app/plugins/datasource/loki/queryUtils.test.ts
+++ b/public/app/plugins/datasource/loki/queryUtils.test.ts
@@ -125,6 +125,10 @@ describe('getHighlighterExpressionsFromQuery', () => {
   it.each(['|=', '|~'])('returns multiple expressions when using or statements', (op: string) => {
     expect(getHighlighterExpressionsFromQuery(`{app="frontend"} ${op} "line" or "text"`)).toEqual(['line', 'text']);
   });
+
+  it.each(['|=', '|~'])('returns multiple expressions when using or statements and ip filters', (op: string) => {
+    expect(getHighlighterExpressionsFromQuery(`{app="frontend"} ${op} "line" or ip("10.0.0.1")`)).toEqual(['line']);
+  });
 });
 
 describe('getNormalizedLokiQuery', () => {

--- a/public/app/plugins/datasource/loki/queryUtils.test.ts
+++ b/public/app/plugins/datasource/loki/queryUtils.test.ts
@@ -121,6 +121,10 @@ describe('getHighlighterExpressionsFromQuery', () => {
   `('should correctly identify the type of quote used in the term', ({ input, expected }) => {
     expect(getHighlighterExpressionsFromQuery(`{foo="bar"} |= ${input}`)).toEqual([expected]);
   });
+
+  it.each(['|=', '|~'])('returns multiple expressions when using or statements', (op: string) => {
+    expect(getHighlighterExpressionsFromQuery(`{app="frontend"} ${op} "line" or "text"`)).toEqual(['line', 'text']);
+  });
 });
 
 describe('getNormalizedLokiQuery', () => {

--- a/public/app/plugins/datasource/loki/queryUtils.ts
+++ b/public/app/plugins/datasource/loki/queryUtils.ts
@@ -22,6 +22,7 @@ import {
   Logfmt,
   Json,
   OrFilter,
+  FilterOp,
 } from '@grafana/lezer-logql';
 import { reportInteraction } from '@grafana/runtime';
 import { DataQuery } from '@grafana/schema';
@@ -85,7 +86,7 @@ export function getStringsFromLineFilter(filter: SyntaxNode): SyntaxNode[] {
   let node: SyntaxNode | null = filter;
   do {
     const string = node.getChild(String);
-    if (string) {
+    if (string && !node.getChild(FilterOp)) {
       nodes.push(string);
     }
     node = node.getChild(OrFilter);

--- a/public/app/plugins/datasource/loki/queryUtils.ts
+++ b/public/app/plugins/datasource/loki/queryUtils.ts
@@ -21,6 +21,7 @@ import {
   formatLokiQuery,
   Logfmt,
   Json,
+  OrFilter,
 } from '@grafana/lezer-logql';
 import { reportInteraction } from '@grafana/runtime';
 import { DataQuery } from '@grafana/schema';
@@ -32,53 +33,65 @@ import { LokiDatasource } from './datasource';
 import { getStreamSelectorPositions, NodePosition } from './modifyQuery';
 import { LokiQuery, LokiQueryType } from './types';
 
-export function formatQuery(selector: string | undefined): string {
-  return `${selector || ''}`.trim();
-}
-
 /**
  * Returns search terms from a LogQL query.
  * E.g., `{} |= foo |=bar != baz` returns `['foo', 'bar']`.
  */
-export function getHighlighterExpressionsFromQuery(input: string): string[] {
+export function getHighlighterExpressionsFromQuery(input = ''): string[] {
   const results = [];
 
   const filters = getNodesFromQuery(input, [LineFilter]);
 
-  for (let filter of filters) {
+  for (const filter of filters) {
     const pipeExact = filter.getChild(Filter)?.getChild(PipeExact);
     const pipeMatch = filter.getChild(Filter)?.getChild(PipeMatch);
-    const string = filter.getChild(String);
+    const strings = getStringsFromLineFilter(filter);
 
-    if ((!pipeExact && !pipeMatch) || !string) {
+    if ((!pipeExact && !pipeMatch) || !strings.length) {
       continue;
     }
 
-    const filterTerm = input.substring(string.from, string.to).trim();
-    const backtickedTerm = filterTerm[0] === '`';
-    const unwrappedFilterTerm = filterTerm.substring(1, filterTerm.length - 1);
+    for (const string of strings) {
+      const filterTerm = input.substring(string.from, string.to).trim();
+      const backtickedTerm = filterTerm[0] === '`';
+      const unwrappedFilterTerm = filterTerm.substring(1, filterTerm.length - 1);
 
-    if (!unwrappedFilterTerm) {
-      continue;
-    }
+      if (!unwrappedFilterTerm) {
+        continue;
+      }
 
-    let resultTerm = '';
+      let resultTerm = '';
 
-    // Only filter expressions with |~ operator are treated as regular expressions
-    if (pipeMatch) {
-      // When using backticks, Loki doesn't require to escape special characters and we can just push regular expression to highlights array
-      // When using quotes, we have extra backslash escaping and we need to replace \\ with \
-      resultTerm = backtickedTerm ? unwrappedFilterTerm : unwrappedFilterTerm.replace(/\\\\/g, '\\');
-    } else {
-      // We need to escape this string so it is not matched as regular expression
-      resultTerm = escapeRegExp(unwrappedFilterTerm);
-    }
+      // Only filter expressions with |~ operator are treated as regular expressions
+      if (pipeMatch) {
+        // When using backticks, Loki doesn't require to escape special characters and we can just push regular expression to highlights array
+        // When using quotes, we have extra backslash escaping and we need to replace \\ with \
+        resultTerm = backtickedTerm ? unwrappedFilterTerm : unwrappedFilterTerm.replace(/\\\\/g, '\\');
+      } else {
+        // We need to escape this string so it is not matched as regular expression
+        resultTerm = escapeRegExp(unwrappedFilterTerm);
+      }
 
-    if (resultTerm) {
-      results.push(resultTerm);
+      if (resultTerm) {
+        results.push(resultTerm);
+      }
     }
   }
   return results;
+}
+
+export function getStringsFromLineFilter(filter: SyntaxNode): SyntaxNode[] {
+  const nodes: SyntaxNode[] = [];
+  let node: SyntaxNode | null = filter;
+  do {
+    const string = node.getChild(String);
+    if (string) {
+      nodes.push(string);
+    }
+    node = node.getChild(OrFilter);
+  } while (node != null);
+
+  return nodes;
 }
 
 export function getNormalizedLokiQuery(query: LokiQuery): LokiQuery {

--- a/public/app/plugins/datasource/loki/querybuilder/operationUtils.ts
+++ b/public/app/plugins/datasource/loki/querybuilder/operationUtils.ts
@@ -296,9 +296,9 @@ export function addNestedQueryHandler(def: QueryBuilderOperationDef, query: Loki
 export function getLineFilterRenderer(operation: string, caseInsensitive?: boolean) {
   return function lineFilterRenderer(model: QueryBuilderOperation, def: QueryBuilderOperationDef, innerExpr: string) {
     if (caseInsensitive) {
-      return `${innerExpr} ${operation} \`(?i)${model.params[0]}\``;
+      return `${innerExpr} ${operation} \`(?i)${model.params.join('\` or \`(?i)')}\``;
     }
-    return `${innerExpr} ${operation} \`${model.params[0]}\``;
+    return `${innerExpr} ${operation} \`${model.params.join('\` or \`')}\``;
   };
 }
 

--- a/public/app/plugins/datasource/loki/querybuilder/operationUtils.ts
+++ b/public/app/plugins/datasource/loki/querybuilder/operationUtils.ts
@@ -296,9 +296,9 @@ export function addNestedQueryHandler(def: QueryBuilderOperationDef, query: Loki
 export function getLineFilterRenderer(operation: string, caseInsensitive?: boolean) {
   return function lineFilterRenderer(model: QueryBuilderOperation, def: QueryBuilderOperationDef, innerExpr: string) {
     if (caseInsensitive) {
-      return `${innerExpr} ${operation} \`(?i)${model.params.join('\` or \`(?i)')}\``;
+      return `${innerExpr} ${operation} \`(?i)${model.params.join('` or `(?i)')}\``;
     }
-    return `${innerExpr} ${operation} \`${model.params.join('\` or \`')}\``;
+    return `${innerExpr} ${operation} \`${model.params.join('` or `')}\``;
   };
 }
 

--- a/public/app/plugins/datasource/loki/querybuilder/operations.ts
+++ b/public/app/plugins/datasource/loki/querybuilder/operations.ts
@@ -262,7 +262,7 @@ Example: \`\`error_level=\`level\` \`\`
       orderRank: LokiOperationOrder.LineFilters,
       renderer: getLineFilterRenderer('|='),
       addOperationHandler: addLokiOperation,
-      explainHandler: (op) => `Return log lines that contain string \`${op.params?.join('\`, or \`')}\`.`,
+      explainHandler: (op) => `Return log lines that contain string \`${op.params?.join('`, or `')}\`.`,
     },
     {
       id: LokiOperationId.LineContainsNot,
@@ -285,7 +285,7 @@ Example: \`\`error_level=\`level\` \`\`
       orderRank: LokiOperationOrder.LineFilters,
       renderer: getLineFilterRenderer('!='),
       addOperationHandler: addLokiOperation,
-      explainHandler: (op) => `Return log lines that does not contain string \`${op.params?.join('\`, or \`')}\`.`,
+      explainHandler: (op) => `Return log lines that does not contain string \`${op.params?.join('`, or `')}\`.`,
     },
     {
       id: LokiOperationId.LineContainsCaseInsensitive,
@@ -308,7 +308,7 @@ Example: \`\`error_level=\`level\` \`\`
       orderRank: LokiOperationOrder.LineFilters,
       renderer: getLineFilterRenderer('|~', true),
       addOperationHandler: addLokiOperation,
-      explainHandler: (op) => `Return log lines that match regex \`(?i)${op.params?.join('\`, or \`(?i)')}\`.`,
+      explainHandler: (op) => `Return log lines that match regex \`(?i)${op.params?.join('`, or `(?i)')}\`.`,
     },
     {
       id: LokiOperationId.LineContainsNotCaseInsensitive,
@@ -331,7 +331,7 @@ Example: \`\`error_level=\`level\` \`\`
       orderRank: LokiOperationOrder.LineFilters,
       renderer: getLineFilterRenderer('!~', true),
       addOperationHandler: addLokiOperation,
-      explainHandler: (op) => `Return log lines that does not match regex \`(?i)${op.params?.join('\`, or \`(?i)')}\`.`,
+      explainHandler: (op) => `Return log lines that does not match regex \`(?i)${op.params?.join('`, or `(?i)')}\`.`,
     },
     {
       id: LokiOperationId.LineMatchesRegex,
@@ -354,7 +354,7 @@ Example: \`\`error_level=\`level\` \`\`
       orderRank: LokiOperationOrder.LineFilters,
       renderer: getLineFilterRenderer('|~'),
       addOperationHandler: addLokiOperation,
-      explainHandler: (op) => `Return log lines that match a \`RE2\` regex pattern. \`${op.params?.join('\`, or \`')}\`.`,
+      explainHandler: (op) => `Return log lines that match a \`RE2\` regex pattern. \`${op.params?.join('`, or `')}\`.`,
     },
     {
       id: LokiOperationId.LineMatchesRegexNot,
@@ -377,7 +377,8 @@ Example: \`\`error_level=\`level\` \`\`
       orderRank: LokiOperationOrder.LineFilters,
       renderer: getLineFilterRenderer('!~'),
       addOperationHandler: addLokiOperation,
-      explainHandler: (op) => `Return log lines that doesn't match a \`RE2\` regex pattern. \`${op.params?.join('\`, or \`')}\`.`,
+      explainHandler: (op) =>
+        `Return log lines that doesn't match a \`RE2\` regex pattern. \`${op.params?.join('`, or `')}\`.`,
     },
     {
       id: LokiOperationId.LineFilterIpMatches,

--- a/public/app/plugins/datasource/loki/querybuilder/operations.ts
+++ b/public/app/plugins/datasource/loki/querybuilder/operations.ts
@@ -246,9 +246,10 @@ Example: \`\`error_level=\`level\` \`\`
       name: 'Line contains',
       params: [
         {
-          name: 'String',
+          name: '',
           type: 'string',
           hideName: true,
+          restParam: true,
           placeholder: 'Text to find',
           description: 'Find log lines that contains this text',
           minWidth: 20,
@@ -261,16 +262,17 @@ Example: \`\`error_level=\`level\` \`\`
       orderRank: LokiOperationOrder.LineFilters,
       renderer: getLineFilterRenderer('|='),
       addOperationHandler: addLokiOperation,
-      explainHandler: (op) => `Return log lines that contain string \`${op.params[0]}\`.`,
+      explainHandler: (op) => `Return log lines that contain string \`${op.params?.join('\`, or \`')}\`.`,
     },
     {
       id: LokiOperationId.LineContainsNot,
       name: 'Line does not contain',
       params: [
         {
-          name: 'String',
+          name: '',
           type: 'string',
           hideName: true,
+          restParam: true,
           placeholder: 'Text to exclude',
           description: 'Find log lines that does not contain this text',
           minWidth: 26,
@@ -283,16 +285,17 @@ Example: \`\`error_level=\`level\` \`\`
       orderRank: LokiOperationOrder.LineFilters,
       renderer: getLineFilterRenderer('!='),
       addOperationHandler: addLokiOperation,
-      explainHandler: (op) => `Return log lines that does not contain string \`${op.params[0]}\`.`,
+      explainHandler: (op) => `Return log lines that does not contain string \`${op.params?.join('\`, or \`')}\`.`,
     },
     {
       id: LokiOperationId.LineContainsCaseInsensitive,
       name: 'Line contains case insensitive',
       params: [
         {
-          name: 'String',
+          name: '',
           type: 'string',
           hideName: true,
+          restParam: true,
           placeholder: 'Text to find',
           description: 'Find log lines that contains this text',
           minWidth: 33,
@@ -305,16 +308,17 @@ Example: \`\`error_level=\`level\` \`\`
       orderRank: LokiOperationOrder.LineFilters,
       renderer: getLineFilterRenderer('|~', true),
       addOperationHandler: addLokiOperation,
-      explainHandler: (op) => `Return log lines that match regex \`(?i)${op.params[0]}\`.`,
+      explainHandler: (op) => `Return log lines that match regex \`(?i)${op.params?.join('\`, or \`(?i)')}\`.`,
     },
     {
       id: LokiOperationId.LineContainsNotCaseInsensitive,
       name: 'Line does not contain case insensitive',
       params: [
         {
-          name: 'String',
+          name: '',
           type: 'string',
           hideName: true,
+          restParam: true,
           placeholder: 'Text to exclude',
           description: 'Find log lines that does not contain this text',
           minWidth: 40,
@@ -327,16 +331,17 @@ Example: \`\`error_level=\`level\` \`\`
       orderRank: LokiOperationOrder.LineFilters,
       renderer: getLineFilterRenderer('!~', true),
       addOperationHandler: addLokiOperation,
-      explainHandler: (op) => `Return log lines that does not match regex \`(?i)${op.params[0]}\`.`,
+      explainHandler: (op) => `Return log lines that does not match regex \`(?i)${op.params?.join('\`, or \`(?i)')}\`.`,
     },
     {
       id: LokiOperationId.LineMatchesRegex,
       name: 'Line contains regex match',
       params: [
         {
-          name: 'Regex',
+          name: '',
           type: 'string',
           hideName: true,
+          restParam: true,
           placeholder: 'Pattern to match',
           description: 'Find log lines that match this regex pattern',
           minWidth: 30,
@@ -349,16 +354,17 @@ Example: \`\`error_level=\`level\` \`\`
       orderRank: LokiOperationOrder.LineFilters,
       renderer: getLineFilterRenderer('|~'),
       addOperationHandler: addLokiOperation,
-      explainHandler: (op) => `Return log lines that match a \`RE2\` regex pattern. \`${op.params[0]}\`.`,
+      explainHandler: (op) => `Return log lines that match a \`RE2\` regex pattern. \`${op.params?.join('\`, or \`')}\`.`,
     },
     {
       id: LokiOperationId.LineMatchesRegexNot,
       name: 'Line does not match regex',
       params: [
         {
-          name: 'Regex',
+          name: '',
           type: 'string',
           hideName: true,
+          restParam: true,
           placeholder: 'Pattern to exclude',
           description: 'Find log lines that does not match this regex pattern',
           minWidth: 30,
@@ -371,7 +377,7 @@ Example: \`\`error_level=\`level\` \`\`
       orderRank: LokiOperationOrder.LineFilters,
       renderer: getLineFilterRenderer('!~'),
       addOperationHandler: addLokiOperation,
-      explainHandler: (op) => `Return log lines that doesn't match a \`RE2\` regex pattern. \`${op.params[0]}\`.`,
+      explainHandler: (op) => `Return log lines that doesn't match a \`RE2\` regex pattern. \`${op.params?.join('\`, or \`')}\`.`,
     },
     {
       id: LokiOperationId.LineFilterIpMatches,

--- a/public/app/plugins/datasource/loki/querybuilder/parsing.test.ts
+++ b/public/app/plugins/datasource/loki/querybuilder/parsing.test.ts
@@ -171,6 +171,26 @@ describe('buildVisualQueryFromString', () => {
     );
   });
 
+  it.each([
+    ['|=', LokiOperationId.LineContains],
+    ['!=', LokiOperationId.LineContainsNot],
+    ['|~', LokiOperationId.LineMatchesRegex],
+    ['!~', LokiOperationId.LineMatchesRegexNot],
+  ])('parses query with line filter and `or` statements', (op: string, id: LokiOperationId) => {
+    expect(buildVisualQueryFromString(`{app="frontend"} ${op} "line" or "text"`)).toEqual(
+      noErrors({
+        labels: [
+          {
+            op: '=',
+            value: 'frontend',
+            label: 'app',
+          },
+        ],
+        operations: [{ id, params: ['line', 'text'] }],
+      })
+    );
+  });
+
   it('parses query with line filters and escaped characters', () => {
     expect(buildVisualQueryFromString('{app="frontend"} |= "\\\\line"')).toEqual(
       noErrors({

--- a/public/app/plugins/datasource/loki/querybuilder/parsing.ts
+++ b/public/app/plugins/datasource/loki/querybuilder/parsing.ts
@@ -287,10 +287,8 @@ function getLineFilter(expr: string, node: SyntaxNode): GetOperationResult {
 
   const params = [filterExpr];
   let orFilter = node.getChild(OrFilter);
-  while(orFilter) {
-    params.push(
-      handleQuotes(getString(expr, orFilter.getChild(String)))
-    );
+  while (orFilter) {
+    params.push(handleQuotes(getString(expr, orFilter.getChild(String))));
     orFilter = orFilter.getChild(OrFilter);
   }
 

--- a/public/app/plugins/datasource/loki/querybuilder/parsing.ts
+++ b/public/app/plugins/datasource/loki/querybuilder/parsing.ts
@@ -51,6 +51,7 @@ import {
   Without,
   BinOpModifier,
   OnOrIgnoringModifier,
+  OrFilter,
 } from '@grafana/lezer-logql';
 
 import {
@@ -275,7 +276,6 @@ function getLineFilter(expr: string, node: SyntaxNode): GetOperationResult {
   const filter = getString(expr, node.getChild(Filter));
   const filterExpr = handleQuotes(getString(expr, node.getChild(String)));
   const ipLineFilter = node.getChild(FilterOp)?.getChild(Ip);
-
   if (ipLineFilter) {
     return {
       operation: {
@@ -284,6 +284,16 @@ function getLineFilter(expr: string, node: SyntaxNode): GetOperationResult {
       },
     };
   }
+
+  const params = [filterExpr];
+  let orFilter = node.getChild(OrFilter);
+  while(orFilter) {
+    params.push(
+      handleQuotes(getString(expr, orFilter.getChild(String)))
+    );
+    orFilter = orFilter.getChild(OrFilter);
+  }
+
   const mapFilter: Record<string, LokiOperationId> = {
     '|=': LokiOperationId.LineContains,
     '!=': LokiOperationId.LineContainsNot,
@@ -294,7 +304,7 @@ function getLineFilter(expr: string, node: SyntaxNode): GetOperationResult {
   return {
     operation: {
       id: mapFilter[filter],
-      params: [filterExpr],
+      params,
     },
   };
 }

--- a/public/app/plugins/datasource/prometheus/querybuilder/shared/OperationEditor.tsx
+++ b/public/app/plugins/datasource/prometheus/querybuilder/shared/OperationEditor.tsx
@@ -218,7 +218,7 @@ function renderAddRestParamButton(
       <Button
         size="sm"
         icon="plus"
-        title={`Add ${paramDef.name}`}
+        title={`Add ${paramDef.name}`.trimEnd()}
         variant="secondary"
         onClick={onAddRestParam}
         data-testid={`operations.${operationIndex}.add-rest-param`}

--- a/yarn.lock
+++ b/yarn.lock
@@ -3215,12 +3215,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@grafana/lezer-logql@npm:0.2.1":
-  version: 0.2.1
-  resolution: "@grafana/lezer-logql@npm:0.2.1"
+"@grafana/lezer-logql@npm:0.2.2":
+  version: 0.2.2
+  resolution: "@grafana/lezer-logql@npm:0.2.2"
   peerDependencies:
     "@lezer/lr": ^1.0.0
-  checksum: e3669e8e1b41eb87547756fb592681aec9d728397b7bb0ccd4cdb875632fabd3469321b6565da814f5700dece28918a1770313da2364a5bc6e3745ef96d10461
+  checksum: 4a2aa48c67a75a246a13e62854470aa36f15087e212b81cdba5fa1ac913a1bdd47da374fa47576c7db670a7333af460aff95465c61ed3cd48a77df6b918d812c
   languageName: node
   linkType: hard
 
@@ -17310,7 +17310,7 @@ __metadata:
     "@grafana/faro-web-sdk": "npm:1.2.1"
     "@grafana/flamegraph": "workspace:*"
     "@grafana/google-sdk": "npm:0.1.1"
-    "@grafana/lezer-logql": "npm:0.2.1"
+    "@grafana/lezer-logql": "npm:0.2.2"
     "@grafana/lezer-traceql": "npm:0.0.11"
     "@grafana/monaco-logql": "npm:^0.0.7"
     "@grafana/runtime": "workspace:*"


### PR DESCRIPTION
Adding support for "or" statements in line filters to builder and code.

> [!IMPORTANT]  
> This feature requires Loki 3+

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes https://github.com/grafana/grafana/issues/74071

**Special notes for your reviewer:**

Please check that:
- Validation
- Query builder
- Query editor to query builder transitions

![Line contains ci](https://github.com/grafana/grafana/assets/1069378/4d9596b2-06e8-4dcf-b5b3-e89b2bad35ab)
![Line does not contain regex](https://github.com/grafana/grafana/assets/1069378/a6c155e0-bb4f-42df-aaa5-e991fb6ecd3d)
![Line does not contain](https://github.com/grafana/grafana/assets/1069378/91dc47ce-af3d-4b1b-8e9a-2a8efc49393e)
![Line does not contain ci](https://github.com/grafana/grafana/assets/1069378/88037064-234b-41d4-8195-7bbee7ab191b)
![Line contains](https://github.com/grafana/grafana/assets/1069378/8bcd7bc9-5297-4ca1-ba4b-af0110976207)
![Line contains regex](https://github.com/grafana/grafana/assets/1069378/16a4aa52-d493-4a6d-940a-36c3a3a14277)
