### PR TITLE
Explore: Hide support button

### DIFF
--- a/public/app/features/inspector/InspectJSONTab.tsx
+++ b/public/app/features/inspector/InspectJSONTab.tsx
@@ -131,7 +131,7 @@ export function InspectJSONTab({ panel, dashboard, data, onClose }: Props) {
             Apply
           </Button>
         )}
-        {show === ShowContent.DataFrames && (
+        {show === ShowContent.DataFrames && dashboard !== undefined && (
           <Button className={styles.toolbarItem} onClick={onShowHelpWizard}>
             Support
           </Button>


### PR DESCRIPTION
**What is this feature?**

Adding an easy way for users to get support in their dashboards was added in #54678 . Unfortunately, the tab where the support button was added is shared with explore, which does not have that feature. This hides the button if dashboard information is not present, as the support button is only relevant for dashboards.

**Which issue(s) does this PR fix?**:

Fixes #78707

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
