### PR TITLE
sql: removed dependency on test-db-check

### DIFF
--- a/pkg/tsdb/grafana-postgresql-datasource/postgres_test.go
+++ b/pkg/tsdb/grafana-postgresql-datasource/postgres_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"math/rand"
+	"os"
 	"strings"
 	"testing"
 	"time"
@@ -14,7 +15,6 @@ import (
 	"github.com/stretchr/testify/require"
 	"xorm.io/xorm"
 
-	"github.com/grafana/grafana/pkg/infra/db"
 	"github.com/grafana/grafana/pkg/services/sqlstore/sqlutil"
 	"github.com/grafana/grafana/pkg/setting"
 	"github.com/grafana/grafana/pkg/tsdb/sqleng"
@@ -180,7 +180,7 @@ func TestIntegrationPostgres(t *testing.T) {
 	// change to true to run the PostgreSQL tests
 	const runPostgresTests = false
 
-	if !(db.IsTestDbPostgres() || runPostgresTests) {
+	if !(isTestDbPostgres() || runPostgresTests) {
 		t.Skip()
 	}
 
@@ -1426,4 +1426,12 @@ type tlsTestManager struct {
 
 func (m *tlsTestManager) getTLSSettings(dsInfo sqleng.DataSourceInfo) (tlsSettings, error) {
 	return m.settings, nil
+}
+
+func isTestDbPostgres() bool {
+	if db, present := os.LookupEnv("GRAFANA_TEST_DB"); present {
+		return db == "postgres"
+	}
+
+	return false
 }

--- a/pkg/tsdb/mysql/mysql_test.go
+++ b/pkg/tsdb/mysql/mysql_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"math/rand"
+	"os"
 	"strings"
 	"testing"
 	"time"
@@ -13,7 +14,6 @@ import (
 	"github.com/stretchr/testify/require"
 	"xorm.io/xorm"
 
-	"github.com/grafana/grafana/pkg/infra/db"
 	"github.com/grafana/grafana/pkg/services/sqlstore/sqlutil"
 	"github.com/grafana/grafana/pkg/setting"
 	"github.com/grafana/grafana/pkg/tsdb/sqleng"
@@ -35,7 +35,7 @@ func TestIntegrationMySQL(t *testing.T) {
 	runMySQLTests := false
 	// runMySqlTests := true
 
-	if !(db.IsTestDbMySQL() || runMySQLTests) {
+	if !(isTestDbMySQL() || runMySQLTests) {
 		t.Skip()
 	}
 
@@ -1320,4 +1320,12 @@ func genTimeRangeByInterval(from time.Time, duration time.Duration, interval tim
 	}
 
 	return timeRange
+}
+
+func isTestDbMySQL() bool {
+	if db, present := os.LookupEnv("GRAFANA_TEST_DB"); present {
+		return db == "mysql"
+	}
+
+	return false
 }


### PR DESCRIPTION
(fixes https://github.com/grafana/grafana/issues/77728)

the sql test files were using two functions from `/pkg/infra/db`:
- `IsTestDBMySQL` https://github.com/grafana/grafana/blob/529271d7a81b140556185cb122f3862753413268/pkg/infra/db/db.go#L66-L72
- `IsTestDBPostgres` https://github.com/grafana/grafana/blob/529271d7a81b140556185cb122f3862753413268/pkg/infra/db/db.go#L74-L80

i simply copied them to the place where they were used.

how to test:
- run the db tests:
    - mysql
        - `make devenv sources=mysql_tests`
        - `GRAFANA_TEST_DB=mysql go test -v  ./pkg/tsdb/mysql`
    - postgres
        - `make devenv sources=postgres_tests`
        - `GRAFANA_TEST_DB=postgres go test -v  ./pkg/tsdb/grafana-postgresql-datasource`