### PR TITLE
Update products labels for KMS instructions

### DIFF
--- a/docs/sources/setup-grafana/configure-security/configure-database-encryption/encrypt-secrets-using-aws-kms/index.md
+++ b/docs/sources/setup-grafana/configure-security/configure-database-encryption/encrypt-secrets-using-aws-kms/index.md
@@ -5,7 +5,6 @@ description: Learn how to use AWS KMS to encrypt secrets in the Grafana database
 labels:
   products:
     - enterprise
-    - oss
 title: Encrypt database secrets using AWS KMS
 weight: 300
 ---


### PR DESCRIPTION
AWS KMS secret encryption is not available in Grafana OSS, updating product labels to reflect this.
