### PR TITLE
Transformations: Fix regression transformation adding predictions after last x point of data

### DIFF
--- a/public/app/features/transformers/regression/regression.test.ts
+++ b/public/app/features/transformers/regression/regression.test.ts
@@ -123,6 +123,35 @@ describe('Regression transformation', () => {
     expect(result[1].fields[1].values[4]).toBeCloseTo(1.2, 1);
     expect(result[1].fields[1].values[5]).toBeCloseTo(-0.1, 1);
   });
+
+  it('should have the last x point be equal to the last x point of the data', () => {
+    const source = [
+      toDataFrame({
+        name: 'data',
+        refId: 'A',
+        fields: [
+          { name: 'time', type: FieldType.time, values: [0, 1, 2, 3, 4] },
+          { name: 'value', type: FieldType.number, values: [1, 1, 1, 1, 1] },
+        ],
+      }),
+    ];
+
+    const config: RegressionTransformerOptions = {
+      modelType: ModelType.polynomial,
+      degree: 2,
+      predictionCount: 10,
+      xFieldName: 'time',
+      yFieldName: 'value',
+    };
+
+    const result = RegressionTransformer.transformer(config, {} as DataTransformContext)(source);
+
+    expect(result[1].fields[0].values[0]).toBe(0);
+    expect(result[1].fields[0].values[1]).toBeCloseTo(0.44, 1);
+    expect(result[1].fields[0].values[4]).toBeCloseTo(1.76, 1);
+    expect(result[1].fields[0].values[8]).toBeCloseTo(3.55, 1);
+    expect(result[1].fields[0].values[9]).toBe(4);
+  });
 });
 
 function toEquableDataFrame(source: DataFrame): DataFrame {

--- a/public/app/features/transformers/regression/regression.ts
+++ b/public/app/features/transformers/regression/regression.ts
@@ -72,7 +72,7 @@ export const RegressionTransformer: SynchronousDataTransformerInfo<RegressionTra
         }
       }
 
-      const resolution = (xMax - xMin + 1) / predictionCount;
+      const resolution = (xMax - xMin) / (predictionCount - 1);
 
       // These are the X values for which we should predict Y
       const predictionPoints = [...[...Array(predictionCount - 1).keys()].map((_, i) => i * resolution + xMin), xMax];


### PR DESCRIPTION
**What is this feature?**

Before:
The transformation is predicting points where X is larger than the largest X in the data
![image](https://github.com/grafana/grafana/assets/468940/a3a97b95-d4ef-49e7-8d1d-d85094424ca8)

After:
The last predicted X is the last X in the data.
![regressionfixafter](https://github.com/grafana/grafana/assets/468940/df8cbec9-28b0-47a9-8fd5-be0a6c8cbab4)
