### PR TITLE
Loki: Fix nil pointer in api.go

### DIFF
--- a/pkg/tsdb/loki/api.go
+++ b/pkg/tsdb/loki/api.go
@@ -213,7 +213,7 @@ func (api *LokiAPI) DataQuery(ctx context.Context, query lokiQuery, responseOpts
 
 	if res.Error != nil {
 		span.RecordError(res.Error)
-		span.SetStatus(codes.Error, err.Error())
+		span.SetStatus(codes.Error, res.Error.Error())
 		instrumentation.UpdatePluginParsingResponseDurationSeconds(ctx, time.Since(start), "error")
 		api.log.Error("Error parsing response from loki", "error", res.Error, "metricDataplane", responseOpts.metricDataplane, "duration", time.Since(start), "stage", stageParseResponse)
 		return nil, res.Error


### PR DESCRIPTION
**What is this feature?**

Fixes wrongly accessing `err` instead of `res.Error` in api response handling.