### PR TITLE
Auth: Remove oAuthProviders from Social service

### DIFF
--- a/pkg/login/social/support_bundle.go
+++ b/pkg/login/social/support_bundle.go
@@ -13,19 +13,19 @@ import (
 )
 
 func (ss *SocialService) registerSupportBundleCollectors(bundleRegistry supportbundles.Service) {
-	for name := range ss.oAuthProvider {
+	for name := range ss.socialMap {
 		bundleRegistry.RegisterSupportItemCollector(supportbundles.Collector{
 			UID:               "oauth-" + name,
 			DisplayName:       "OAuth " + strings.Title(strings.ReplaceAll(name, "_", " ")),
 			Description:       "OAuth configuration and healthchecks for " + name,
 			IncludedByDefault: false,
 			Default:           false,
-			Fn:                ss.supportBundleCollectorFn(name, ss.socialMap[name], ss.oAuthProvider[name]),
+			Fn:                ss.supportBundleCollectorFn(name, ss.socialMap[name]),
 		})
 	}
 }
 
-func (ss *SocialService) supportBundleCollectorFn(name string, sc SocialConnector, oinfo *OAuthInfo) func(context.Context) (*supportbundles.SupportItem, error) {
+func (ss *SocialService) supportBundleCollectorFn(name string, sc SocialConnector) func(context.Context) (*supportbundles.SupportItem, error) {
 	return func(ctx context.Context) (*supportbundles.SupportItem, error) {
 		bWriter := bytes.NewBuffer(nil)
 
@@ -36,6 +36,8 @@ func (ss *SocialService) supportBundleCollectorFn(name string, sc SocialConnecto
 		if _, err := bWriter.WriteString("## Parsed Configuration\n\n"); err != nil {
 			return nil, err
 		}
+
+		oinfo := sc.GetOAuthInfo()
 
 		bWriter.WriteString("```toml\n")
 		errM := toml.NewEncoder(bWriter).Encode(oinfo)

--- a/pkg/login/social/support_bundle.go
+++ b/pkg/login/social/support_bundle.go
@@ -13,14 +13,15 @@ import (
 )
 
 func (ss *SocialService) registerSupportBundleCollectors(bundleRegistry supportbundles.Service) {
-	for name := range ss.socialMap {
+	for name, connector := range ss.socialMap {
 		bundleRegistry.RegisterSupportItemCollector(supportbundles.Collector{
 			UID:               "oauth-" + name,
 			DisplayName:       "OAuth " + strings.Title(strings.ReplaceAll(name, "_", " ")),
 			Description:       "OAuth configuration and healthchecks for " + name,
 			IncludedByDefault: false,
 			Default:           false,
-			Fn:                ss.supportBundleCollectorFn(name, ss.socialMap[name]),
+			EnabledFn:         func() bool { return connector.GetOAuthInfo().Enabled },
+			Fn:                ss.supportBundleCollectorFn(name, connector),
 		})
 	}
 }

--- a/pkg/services/supportbundles/interface.go
+++ b/pkg/services/supportbundles/interface.go
@@ -46,6 +46,8 @@ type Collector struct {
 	Default bool `json:"default"`
 	// Fn is the function that collects the support item.
 	Fn CollectorFunc `json:"-"`
+	// EnabledFn is a function that determines if the collector is enabled. If nil, the collector is always enabled.
+	EnabledFn func() bool `json:"-"`
 }
 
 type Service interface {

--- a/pkg/services/supportbundles/supportbundlesimpl/service_bundle.go
+++ b/pkg/services/supportbundles/supportbundlesimpl/service_bundle.go
@@ -74,9 +74,15 @@ func (s *Service) bundle(ctx context.Context, collectors []string, uid string) (
 	files := map[string][]byte{}
 
 	for _, collector := range s.bundleRegistry.Collectors() {
-		if !lookup[collector.UID] && !collector.IncludedByDefault {
+		collectorEnabled := true
+		if collector.EnabledFn != nil {
+			collectorEnabled = collector.EnabledFn()
+		}
+
+		if !(lookup[collector.UID] || collector.IncludedByDefault) || !collectorEnabled {
 			continue
 		}
+
 		item, err := collector.Fn(ctx)
 		if err != nil {
 			s.log.Warn("Failed to collect support bundle item", "error", err, "collector", collector.UID)

--- a/pkg/services/supportbundles/supportbundlesimpl/service_bundle_test.go
+++ b/pkg/services/supportbundles/supportbundlesimpl/service_bundle_test.go
@@ -38,12 +38,16 @@ func TestService_bundleCreate(t *testing.T) {
 	cfg := setting.NewCfg()
 
 	collector := basicCollector(cfg)
+	disabledCollector := settingsCollector(setting.ProvideProvider(cfg))
+	disabledCollector.EnabledFn = func() bool { return false }
+
 	s.bundleRegistry.RegisterSupportItemCollector(collector)
+	s.bundleRegistry.RegisterSupportItemCollector(disabledCollector)
 
 	createdBundle, err := s.store.Create(context.Background(), &user.SignedInUser{UserID: 1, Login: "bob"})
 	require.NoError(t, err)
 
-	s.startBundleWork(context.Background(), []string{collector.UID}, createdBundle.UID)
+	s.startBundleWork(context.Background(), []string{collector.UID, disabledCollector.UID}, createdBundle.UID)
 
 	bundle, err := s.get(context.Background(), createdBundle.UID)
 	require.NoError(t, err)


### PR DESCRIPTION
**What is this feature?**
Removes `oAuthProvider map[string]*OAuthInfo` from the SocialService struct, because the OAuthInfo is accessible through the `SocialConnector.GetOAuthInfo()` function. (Each connector stores its own OAuthInfo)

**Why do we need this feature?**
Required for the SSO settings service/api changes.

**Who is this feature for?**


**Which issue(s) does this PR fix?**:

Fixes #

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
