### PR TITLE
Popover menu: refactor event tracking

### DIFF
--- a/public/app/features/logs/components/PopoverMenu.tsx
+++ b/public/app/features/logs/components/PopoverMenu.tsx
@@ -56,7 +56,7 @@ export const PopoverMenu = ({
           onClick={() => {
             copyText(selection, containerRef);
             close();
-            track('copy_selection_clicked', selection.length, row.datasourceType);
+            track('copy', selection.length, row.datasourceType);
           }}
         />
         {onClickFilterValue && (
@@ -65,7 +65,7 @@ export const PopoverMenu = ({
             onClick={() => {
               onClickFilterValue(selection, row.dataFrame.refId);
               close();
-              track('line_filter_clicked', selection.length, row.datasourceType);
+              track('line_contains', selection.length, row.datasourceType);
             }}
           />
         )}
@@ -75,7 +75,7 @@ export const PopoverMenu = ({
             onClick={() => {
               onClickFilterOutValue(selection, row.dataFrame.refId);
               close();
-              track('line_filter_out_clicked', selection.length, row.datasourceType);
+              track('line_does_not_contain', selection.length, row.datasourceType);
             }}
           />
         )}
@@ -84,8 +84,9 @@ export const PopoverMenu = ({
   );
 };
 
-function track(event: string, selectionLength: number, dataSourceType: string | undefined) {
-  reportInteraction(`grafana_explore_logs_${event}`, {
+function track(action: string, selectionLength: number, dataSourceType: string | undefined) {
+  reportInteraction(`grafana_explore_logs_popover_menu`, {
+    action,
     selection_length: selectionLength,
     ds_type: dataSourceType || 'unknown',
   });


### PR DESCRIPTION
While adding a dashboard for these metrics, I realized that the structure was incorrect. We're now grouping all events inside `grafana_explore_logs_popover_menu`, and distinguishing the user interaction by the `action` attribute.

**Which issue(s) does this PR fix?**:

Part of https://github.com/grafana/grafana/issues/76129

**Special notes for your reviewer:**

Nothing in particular.