### PR TITLE
mysql/postgres: vendor in unit-test helper function

### DIFF
--- a/pkg/tsdb/grafana-postgresql-datasource/postgres_test.go
+++ b/pkg/tsdb/grafana-postgresql-datasource/postgres_test.go
@@ -15,7 +15,6 @@ import (
 	"github.com/stretchr/testify/require"
 	"xorm.io/xorm"
 
-	"github.com/grafana/grafana/pkg/services/sqlstore/sqlutil"
 	"github.com/grafana/grafana/pkg/setting"
 	"github.com/grafana/grafana/pkg/tsdb/sqleng"
 
@@ -1394,9 +1393,8 @@ func TestIntegrationPostgres(t *testing.T) {
 }
 
 func InitPostgresTestDB(t *testing.T) *xorm.Engine {
-	testDB := sqlutil.PostgresTestDB()
-	x, err := xorm.NewEngine(testDB.DriverName, strings.Replace(testDB.ConnStr, "dbname=grafanatest",
-		"dbname=grafanadstest", 1))
+	connStr := postgresTestDBConnString()
+	x, err := xorm.NewEngine("postgres", connStr)
 	require.NoError(t, err, "Failed to init postgres DB")
 
 	x.DatabaseTZ = time.UTC
@@ -1434,4 +1432,17 @@ func isTestDbPostgres() bool {
 	}
 
 	return false
+}
+
+func postgresTestDBConnString() string {
+	host := os.Getenv("POSTGRES_HOST")
+	if host == "" {
+		host = "localhost"
+	}
+	port := os.Getenv("POSTGRES_PORT")
+	if port == "" {
+		port = "5432"
+	}
+	return fmt.Sprintf("user=grafanatest password=grafanatest host=%s port=%s dbname=grafanadstest sslmode=disable",
+		host, port)
 }

--- a/pkg/tsdb/mysql/mysql_test.go
+++ b/pkg/tsdb/mysql/mysql_test.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"math/rand"
 	"os"
-	"strings"
 	"testing"
 	"time"
 
@@ -14,7 +13,6 @@ import (
 	"github.com/stretchr/testify/require"
 	"xorm.io/xorm"
 
-	"github.com/grafana/grafana/pkg/services/sqlstore/sqlutil"
 	"github.com/grafana/grafana/pkg/setting"
 	"github.com/grafana/grafana/pkg/tsdb/sqleng"
 )
@@ -1294,9 +1292,8 @@ func TestIntegrationMySQL(t *testing.T) {
 }
 
 func InitMySQLTestDB(t *testing.T) *xorm.Engine {
-	testDB := sqlutil.MySQLTestDB()
-	x, err := xorm.NewEngine(testDB.DriverName, strings.Replace(testDB.ConnStr, "/grafana_tests",
-		"/grafana_ds_tests", 1)+"&parseTime=true&loc=UTC")
+	connStr := mySQLTestDBConnStr()
+	x, err := xorm.NewEngine("mysql", connStr)
 	if err != nil {
 		t.Fatalf("Failed to init mysql db %v", err)
 	}
@@ -1328,4 +1325,16 @@ func isTestDbMySQL() bool {
 	}
 
 	return false
+}
+
+func mySQLTestDBConnStr() string {
+	host := os.Getenv("MYSQL_HOST")
+	if host == "" {
+		host = "localhost"
+	}
+	port := os.Getenv("MYSQL_PORT")
+	if port == "" {
+		port = "3306"
+	}
+	return fmt.Sprintf("grafana:password@tcp(%s:%s)/grafana_ds_tests?collation=utf8mb4_unicode_ci&sql_mode='ANSI_QUOTES'&parseTime=true&loc=UTC", host, port)
 }


### PR DESCRIPTION
(fixes https://github.com/grafana/grafana/issues/77729)

the mysql & postgres unit tests used non-exported core-grafana utility functions: `/pkg/services/sqlstore/sqlutil.MySQLTestDB/PostgresTestDB`

https://github.com/grafana/grafana/blob/6f658f5aae652b64a2ff77ba302268c4b404941f/pkg/services/sqlstore/sqlutil/sqlutil.go#L22-L53

here we just copy them into the unit test files.

i simplified the code a little, did the following changes:
- postgres:
    - original function returned both the database-name and connection-string, we do know the database-name, so the function only returns the connection-string
    - in the previous version we took the connection-string from the helper-function, and replaced the `dbname` with a new value. in this version, the utility function returns the already-replaced string
- mysql:
    - all the things that postgres does
    - in the previous versions we append the string `"&parseTime=true&loc=UTC"` to the returned connection string. i adjusted the code to already return the appended version
        - the `&parseTime=true` part was two times in the string, so i adjusted it to only be there one time

how to test:
- run the db tests:
    - mysql
        - `make devenv sources=mysql_tests`
        - `GRAFANA_TEST_DB=mysql go test -v  ./pkg/tsdb/mysql`
    - postgres
        - `make devenv sources=postgres_tests`
        - `GRAFANA_TEST_DB=postgres go test -v  ./pkg/tsdb/grafana-postgresql-datasource`