### PR TITLE
AuthN: Check API Key is not trying to access another organization

### DIFF
--- a/pkg/services/authn/clients/api_key.go
+++ b/pkg/services/authn/clients/api_key.go
@@ -63,7 +63,9 @@ func (s *APIKey) Authenticate(ctx context.Context, r *authn.Request) (*authn.Ide
 		return nil, errAPIKeyRevoked.Errorf("Api key is revoked")
 	}
 
-	if r.OrgID != 0 && apiKey.OrgID != r.OrgID {
+	if r.OrgID == 0 {
+		r.OrgID = apiKey.OrgID
+	} else if r.OrgID != apiKey.OrgID {
 		return nil, errAPIKeyInvalidOrg.Errorf("API does not belong in Organization %v", r.OrgID)
 	}
 

--- a/pkg/services/authn/clients/api_key.go
+++ b/pkg/services/authn/clients/api_key.go
@@ -19,9 +19,10 @@ import (
 )
 
 var (
-	errAPIKeyInvalid = errutil.Unauthorized("api-key.invalid", errutil.WithPublicMessage("Invalid API key"))
-	errAPIKeyExpired = errutil.Unauthorized("api-key.expired", errutil.WithPublicMessage("Expired API key"))
-	errAPIKeyRevoked = errutil.Unauthorized("api-key.revoked", errutil.WithPublicMessage("Revoked API key"))
+	errAPIKeyInvalid    = errutil.Unauthorized("api-key.invalid", errutil.WithPublicMessage("Invalid API key"))
+	errAPIKeyExpired    = errutil.Unauthorized("api-key.expired", errutil.WithPublicMessage("Expired API key"))
+	errAPIKeyRevoked    = errutil.Unauthorized("api-key.revoked", errutil.WithPublicMessage("Revoked API key"))
+	errAPIKeyInvalidOrg = errutil.Unauthorized("api-key.invalid-organization", errutil.WithPublicMessage("API key does not belong to the requested organization"))
 )
 
 var _ authn.HookClient = new(APIKey)
@@ -60,6 +61,10 @@ func (s *APIKey) Authenticate(ctx context.Context, r *authn.Request) (*authn.Ide
 
 	if apiKey.IsRevoked != nil && *apiKey.IsRevoked {
 		return nil, errAPIKeyRevoked.Errorf("Api key is revoked")
+	}
+
+	if r.OrgID != 0 && apiKey.OrgID != r.OrgID {
+		return nil, errAPIKeyInvalidOrg.Errorf("API does not belong in Organization %v", r.OrgID)
 	}
 
 	// if the api key don't belong to a service account construct the identity and return it

--- a/pkg/services/authn/clients/api_key.go
+++ b/pkg/services/authn/clients/api_key.go
@@ -19,10 +19,10 @@ import (
 )
 
 var (
-	errAPIKeyInvalid    = errutil.Unauthorized("api-key.invalid", errutil.WithPublicMessage("Invalid API key"))
-	errAPIKeyExpired    = errutil.Unauthorized("api-key.expired", errutil.WithPublicMessage("Expired API key"))
-	errAPIKeyRevoked    = errutil.Unauthorized("api-key.revoked", errutil.WithPublicMessage("Revoked API key"))
-	errAPIKeyInvalidOrg = errutil.Unauthorized("api-key.invalid-organization", errutil.WithPublicMessage("API key does not belong to the requested organization"))
+	errAPIKeyInvalid     = errutil.Unauthorized("api-key.invalid", errutil.WithPublicMessage("Invalid API key"))
+	errAPIKeyExpired     = errutil.Unauthorized("api-key.expired", errutil.WithPublicMessage("Expired API key"))
+	errAPIKeyRevoked     = errutil.Unauthorized("api-key.revoked", errutil.WithPublicMessage("Revoked API key"))
+	errAPIKeyOrgMismatch = errutil.Unauthorized("api-key.organization-mismatch", errutil.WithPublicMessage("API key does not belong to the requested organization"))
 )
 
 var _ authn.HookClient = new(APIKey)
@@ -66,7 +66,7 @@ func (s *APIKey) Authenticate(ctx context.Context, r *authn.Request) (*authn.Ide
 	if r.OrgID == 0 {
 		r.OrgID = apiKey.OrgID
 	} else if r.OrgID != apiKey.OrgID {
-		return nil, errAPIKeyInvalidOrg.Errorf("API does not belong in Organization %v", r.OrgID)
+		return nil, errAPIKeyOrgMismatch.Errorf("API does not belong in Organization %v", r.OrgID)
 	}
 
 	// if the api key don't belong to a service account construct the identity and return it

--- a/pkg/services/authn/clients/api_key_test.go
+++ b/pkg/services/authn/clients/api_key_test.go
@@ -134,10 +134,12 @@ func TestAPIKey_Authenticate(t *testing.T) {
 			if tt.expectedErr != nil {
 				assert.Nil(t, identity)
 				assert.ErrorIs(t, err, tt.expectedErr)
+				return
 			} else {
 				assert.NoError(t, err)
 				assert.EqualValues(t, *tt.expectedIdentity, *identity)
 			}
+			assert.Equal(t, tt.req.OrgID, tt.expectedIdentity.OrgID, "the request organization should match the identity's one")
 		})
 	}
 }

--- a/pkg/services/authn/clients/api_key_test.go
+++ b/pkg/services/authn/clients/api_key_test.go
@@ -135,10 +135,10 @@ func TestAPIKey_Authenticate(t *testing.T) {
 				assert.Nil(t, identity)
 				assert.ErrorIs(t, err, tt.expectedErr)
 				return
-			} else {
-				assert.NoError(t, err)
-				assert.EqualValues(t, *tt.expectedIdentity, *identity)
 			}
+
+			assert.NoError(t, err)
+			assert.EqualValues(t, *tt.expectedIdentity, *identity)
 			assert.Equal(t, tt.req.OrgID, tt.expectedIdentity.OrgID, "the request organization should match the identity's one")
 		})
 	}

--- a/pkg/services/authn/clients/api_key_test.go
+++ b/pkg/services/authn/clients/api_key_test.go
@@ -118,7 +118,7 @@ func TestAPIKey_Authenticate(t *testing.T) {
 				Key:              hash,
 				ServiceAccountId: intPtr(1),
 			},
-			expectedErr: errAPIKeyInvalidOrg,
+			expectedErr: errAPIKeyOrgMismatch,
 		},
 	}
 

--- a/pkg/services/authn/clients/api_key_test.go
+++ b/pkg/services/authn/clients/api_key_test.go
@@ -109,6 +109,17 @@ func TestAPIKey_Authenticate(t *testing.T) {
 			},
 			expectedErr: errAPIKeyRevoked,
 		},
+		{
+			desc: "should fail for api key in another organization",
+			req:  &authn.Request{OrgID: 1, HTTPRequest: &http.Request{Header: map[string][]string{"Authorization": {"Bearer " + secret}}}},
+			expectedKey: &apikey.APIKey{
+				ID:               1,
+				OrgID:            2,
+				Key:              hash,
+				ServiceAccountId: intPtr(1),
+			},
+			expectedErr: errAPIKeyInvalidOrg,
+		},
 	}
 
 	for _, tt := range tests {

--- a/public/app/core/services/context_srv.ts
+++ b/public/app/core/services/context_srv.ts
@@ -92,9 +92,6 @@ export class ContextSrv {
     this.hasEditPermissionInFolders = this.user.hasEditPermissionInFolders;
     this.minRefreshInterval = config.minRefreshInterval;
 
-    console.log('authenticated by', this.user.authenticatedBy);
-    console.log('user', this.user);
-
     this.scheduleTokenRotationJob();
   }
 

--- a/public/app/core/services/context_srv.ts
+++ b/public/app/core/services/context_srv.ts
@@ -92,6 +92,9 @@ export class ContextSrv {
     this.hasEditPermissionInFolders = this.user.hasEditPermissionInFolders;
     this.minRefreshInterval = config.minRefreshInterval;
 
+    console.log('authenticated by', this.user.authenticatedBy);
+    console.log('user', this.user);
+
     this.scheduleTokenRotationJob();
   }
 


### PR DESCRIPTION
**What is this feature?**

This PR rejects an APIKey connection if the user specified an other organization than the APIKey's one.
This is just future proofing in the eventuality a hook uses the request `OrgID` to add things the `Identity`.

```bash
curl  -X GET -H "Authorization: Bearer <token>" http://localhost:3000/api/org/users?targetOrgId=3 
```

**Why do we need this feature?**

[Add a description of the problem the feature is trying to solve.]

**Who is this feature for?**

[Add information on what kind of user the feature is for.]

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
