### PR TITLE
Alerting: Show warning when query optimized

### DIFF
--- a/pkg/services/ngalert/api/api_testing.go
+++ b/pkg/services/ngalert/api/api_testing.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/benbjohnson/clock"
 	"github.com/grafana/alerting/models"
+	"github.com/grafana/grafana-plugin-sdk-go/backend"
 	amv2 "github.com/prometheus/alertmanager/api/v2/models"
 
 	"github.com/grafana/grafana-plugin-sdk-go/data"
@@ -163,7 +164,7 @@ func (srv TestingApiSrv) RouteEvalQueries(c *contextmodel.ReqContext, cmd apimod
 		cond.Condition = cond.Data[len(cond.Data)-1].RefID
 	}
 
-	_, err := store.OptimizeAlertQueries(cond.Data)
+	optimizations, err := store.OptimizeAlertQueries(cond.Data)
 	if err != nil {
 		return ErrResp(http.StatusInternalServerError, err, "Failed to optimize query")
 	}
@@ -185,7 +186,22 @@ func (srv TestingApiSrv) RouteEvalQueries(c *contextmodel.ReqContext, cmd apimod
 		return ErrResp(http.StatusInternalServerError, err, "Failed to evaluate queries and expressions")
 	}
 
+	addOptimizedQueryWarnings(evalResults, optimizations)
 	return response.JSONStreaming(http.StatusOK, evalResults)
+}
+
+// addOptimizedQueryWarnings adds warnings to the query results for any queries that were optimized.
+func addOptimizedQueryWarnings(evalResults *backend.QueryDataResponse, optimizations []store.Optimization) {
+	for _, opt := range optimizations {
+		if res, ok := evalResults.Responses[opt.RefID]; ok {
+			if len(res.Frames) > 0 && res.Frames[0].Meta != nil {
+				res.Frames[0].Meta.Notices = append(res.Frames[0].Meta.Notices, data.Notice{
+					Severity: data.NoticeSeverityWarning,
+					Text:     "Query optimized from Range to Instant type", // Currently this is the only optimization we do.
+				})
+			}
+		}
+	}
 }
 
 func (srv TestingApiSrv) BacktestAlertRule(c *contextmodel.ReqContext, cmd apimodels.BacktestConfig) response.Response {

--- a/pkg/services/ngalert/api/api_testing.go
+++ b/pkg/services/ngalert/api/api_testing.go
@@ -194,8 +194,8 @@ func (srv TestingApiSrv) RouteEvalQueries(c *contextmodel.ReqContext, cmd apimod
 func addOptimizedQueryWarnings(evalResults *backend.QueryDataResponse, optimizations []store.Optimization) {
 	for _, opt := range optimizations {
 		if res, ok := evalResults.Responses[opt.RefID]; ok {
-			if len(res.Frames) > 0 && res.Frames[0].Meta != nil {
-				res.Frames[0].Meta.Notices = append(res.Frames[0].Meta.Notices, data.Notice{
+			if len(res.Frames) > 0 {
+				res.Frames[0].AppendNotices(data.Notice{
 					Severity: data.NoticeSeverityWarning,
 					Text:     "Query optimized from Range to Instant type", // Currently this is the only optimization we do.
 				})

--- a/pkg/services/ngalert/api/api_testing.go
+++ b/pkg/services/ngalert/api/api_testing.go
@@ -8,9 +8,10 @@ import (
 	"time"
 
 	"github.com/benbjohnson/clock"
+	amv2 "github.com/prometheus/alertmanager/api/v2/models"
+
 	"github.com/grafana/alerting/models"
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
-	amv2 "github.com/prometheus/alertmanager/api/v2/models"
 
 	"github.com/grafana/grafana-plugin-sdk-go/data"
 
@@ -197,7 +198,8 @@ func addOptimizedQueryWarnings(evalResults *backend.QueryDataResponse, optimizat
 			if len(res.Frames) > 0 {
 				res.Frames[0].AppendNotices(data.Notice{
 					Severity: data.NoticeSeverityWarning,
-					Text:     "Query optimized from Range to Instant type", // Currently this is the only optimization we do.
+					Text: "Query optimized from Range to Instant type; all uses exclusively require the last datapoint. " +
+						"Consider modifying your query to Instant type to ensure accuracy.", // Currently this is the only optimization we do.
 				})
 			}
 		}

--- a/pkg/services/ngalert/api/api_testing_test.go
+++ b/pkg/services/ngalert/api/api_testing_test.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
+	"github.com/grafana/grafana-plugin-sdk-go/data"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 
@@ -264,6 +265,78 @@ func TestRouteEvalQueries(t *testing.T) {
 			require.Equal(t, http.StatusOK, response.Status())
 
 			evaluator.AssertCalled(t, "EvaluateRaw", mock.Anything, currentTime)
+		})
+	})
+
+	t.Run("when query is optimizable", func(t *testing.T) {
+		rc := &contextmodel.ReqContext{
+			Context: &web.Context{
+				Req: &http.Request{},
+			},
+			SignedInUser: &user.SignedInUser{
+				OrgID: 1,
+			},
+		}
+		t.Run("should return warning notice on optimized queries", func(t *testing.T) {
+			queries := []models.AlertQuery{
+				models.CreatePrometheusQuery("A", "1", 1000, 43200, false, "some-ds"),
+				models.CreatePrometheusQuery("B", "1", 1000, 43200, false, "some-ds"),
+				models.CreatePrometheusQuery("C", "1", 1000, 43200, false, "some-ds"), // Not optimizable.
+				models.CreateReduceExpression("D", "A", "last"),
+				models.CreateReduceExpression("E", "B", "last"),
+			}
+
+			currentTime := time.Now()
+
+			ac := acMock.New().WithPermissions([]ac.Permission{
+				{Action: datasources.ActionQuery, Scope: datasources.ScopeProvider.GetResourceScopeUID(queries[0].DatasourceUID)},
+			})
+
+			ds := &fakes.FakeCacheService{DataSources: []*datasources.DataSource{
+				{UID: queries[0].DatasourceUID},
+			}}
+
+			evaluator := &eval_mocks.ConditionEvaluatorMock{}
+			createEmptyFrameResponse := func(refId string) backend.DataResponse {
+				frame := data.NewFrame("")
+				frame.RefID = refId
+				frame.SetMeta(&data.FrameMeta{})
+				return backend.DataResponse{
+					Frames: []*data.Frame{frame},
+					Error:  nil,
+				}
+			}
+			result := &backend.QueryDataResponse{
+				Responses: map[string]backend.DataResponse{
+					"A": createEmptyFrameResponse("A"),
+					"B": createEmptyFrameResponse("B"),
+					"C": createEmptyFrameResponse("C"),
+				},
+			}
+			evaluator.EXPECT().EvaluateRaw(mock.Anything, mock.Anything).Return(result, nil)
+
+			srv := createTestingApiSrv(t, ds, ac, eval_mocks.NewEvaluatorFactory(evaluator))
+
+			response := srv.RouteEvalQueries(rc, definitions.EvalQueriesPayload{
+				Data: ApiAlertQueriesFromAlertQueries(queries),
+				Now:  currentTime,
+			})
+
+			require.Equal(t, http.StatusOK, response.Status())
+
+			evaluator.AssertCalled(t, "EvaluateRaw", mock.Anything, currentTime)
+
+			require.Equal(t, []data.Notice{{
+				Severity: data.NoticeSeverityWarning,
+				Text:     "Query optimized from Range to Instant type",
+			}}, result.Responses["A"].Frames[0].Meta.Notices)
+
+			require.Equal(t, []data.Notice{{
+				Severity: data.NoticeSeverityWarning,
+				Text:     "Query optimized from Range to Instant type",
+			}}, result.Responses["B"].Frames[0].Meta.Notices)
+
+			require.Equal(t, 0, len(result.Responses["C"].Frames[0].Meta.Notices))
 		})
 	})
 }

--- a/pkg/services/ngalert/api/api_testing_test.go
+++ b/pkg/services/ngalert/api/api_testing_test.go
@@ -328,12 +328,12 @@ func TestRouteEvalQueries(t *testing.T) {
 
 			require.Equal(t, []data.Notice{{
 				Severity: data.NoticeSeverityWarning,
-				Text:     "Query optimized from Range to Instant type",
+				Text:     "Query optimized from Range to Instant type; all uses exclusively require the last datapoint. Consider modifying your query to Instant type to ensure accuracy.",
 			}}, result.Responses["A"].Frames[0].Meta.Notices)
 
 			require.Equal(t, []data.Notice{{
 				Severity: data.NoticeSeverityWarning,
-				Text:     "Query optimized from Range to Instant type",
+				Text:     "Query optimized from Range to Instant type; all uses exclusively require the last datapoint. Consider modifying your query to Instant type to ensure accuracy.",
 			}}, result.Responses["B"].Frames[0].Meta.Notices)
 
 			require.Equal(t, 0, len(result.Responses["C"].Frames[0].Meta.Notices))


### PR DESCRIPTION
**What is this feature?**

Attach a warning `Notice` to the `api/v1/eval` query frame result when a query is optimized. This will display like any other warning in frontend when previewing an alert rule.

**Why do we need this feature?**

Let users know when their query has been modified/optimized from Range to Instant. They can then choose to keep it as-is, or modify it themselves to avoid the optimization or change it to Instant themselves.

**Who is this feature for?**

Alerting users.

**Special notes for your reviewer:**

![image](https://github.com/grafana/grafana/assets/8484471/329371c4-dbde-4dd1-a671-ec50df47c5af)