### PR TITLE
RBAC: Update fixed annotation roles

### DIFF
--- a/pkg/api/accesscontrol.go
+++ b/pkg/api/accesscontrol.go
@@ -358,6 +358,8 @@ func (hs *HTTPServer) declareFixedRoles() error {
 				Group:       "Annotations",
 				Permissions: []ac.Permission{
 					{Action: ac.ActionAnnotationsRead, Scope: ac.ScopeAnnotationsTypeOrganization},
+					// Can remove the following permission when we remove the FlagAnnotationPermissionUpdate
+					{Action: ac.ActionAnnotationsRead, Scope: ac.ScopeAnnotationsTypeDashboard},
 				},
 			},
 			Grants: []string{string(org.RoleViewer)},
@@ -372,8 +374,12 @@ func (hs *HTTPServer) declareFixedRoles() error {
 				Group:       "Annotations",
 				Permissions: []ac.Permission{
 					{Action: ac.ActionAnnotationsCreate, Scope: ac.ScopeAnnotationsTypeOrganization},
+					// Can remove the permissions scoped to ScopeAnnotationsTypeDashboard when we remove the FlagAnnotationPermissionUpdate
+					{Action: ac.ActionAnnotationsCreate, Scope: ac.ScopeAnnotationsTypeDashboard},
 					{Action: ac.ActionAnnotationsDelete, Scope: ac.ScopeAnnotationsTypeOrganization},
+					{Action: ac.ActionAnnotationsDelete, Scope: ac.ScopeAnnotationsTypeDashboard},
 					{Action: ac.ActionAnnotationsWrite, Scope: ac.ScopeAnnotationsTypeOrganization},
+					{Action: ac.ActionAnnotationsWrite, Scope: ac.ScopeAnnotationsTypeDashboard},
 				},
 			},
 			Grants: []string{string(org.RoleEditor)},


### PR DESCRIPTION
**What is this feature?**

Updating the fixed annotation roles to reflect annotation permission changes.

This is what basic roles should grant by default:

|                                   | Viewer | Editor | Admin |
|-----------------------------------|--------|--------|-------|
| View all organization annotations | v      | v      | v     |
| Edit all organization annotations | -      | v      | v     |
| View all dashboard annotations    | -      | -      | v     |
| Edit all dashboard annotations    | -      | -      | v     |

Note that viewers and editors will gain access to view/edit dashboard annotations through dashboard managed permissions (when they get assigned View or Edit access to a dashboard through the UI).

**Why do we need this feature?**

Decoupling annotation permissions from dashboard permissions.

**Who is this feature for?**

RBAC users.

**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/identity-access-team/issues/494

**Special notes for your reviewer:**

I've tried to keep breaking changes to minimum, but because of that names of some of the fixed roles don't fully represent the role. For instance `fixed:annotations:writer` will only allow updating organization annotations. My reason for keeping the names the same is to ensure that users that have been assigned the previous `fixed:annotations:write` role manually can still update organization annotations after the feature toggle is enabled (however, they shouldn't be able to update all dashboard annotations - only the annotations for dashboards that they can edit, and these permissions will be assigned through a migration).

Let me know if you think that the name inconsistency is too big of an issue, and I'll think about alternatives (a migration?).