### PR TITLE
Prometheus: Azure auth update select and input to not use legacy components

### DIFF
--- a/public/app/plugins/datasource/prometheus/configuration/AzureCredentialsForm.tsx
+++ b/public/app/plugins/datasource/prometheus/configuration/AzureCredentialsForm.tsx
@@ -3,9 +3,7 @@ import React, { ChangeEvent, useEffect, useMemo, useReducer, useState } from 're
 
 import { SelectableValue } from '@grafana/data';
 import { config } from '@grafana/runtime';
-import { InlineFormLabel, Button } from '@grafana/ui/src/components';
-import { Input } from '@grafana/ui/src/components/Forms/Legacy/Input/Input';
-import { Select } from '@grafana/ui/src/components/Forms/Legacy/Select/Select';
+import { InlineFormLabel, Button, Select, Input } from '@grafana/ui';
 
 import { AzureAuthType, AzureCredentials, isCredentialsComplete } from './AzureCredentials';
 


### PR DESCRIPTION
Fixes https://github.com/grafana/support-escalations/issues/8067

Updating Select and Input components to use @grafana/ui instead of legacy components which resulted in UI bugs.

Go from this (see the select option is off to the left)

<img width="380" alt="Screenshot 2023-11-28 at 5 12 29 PM" src="https://github.com/grafana/grafana/assets/25674746/b2998295-12a4-4188-852d-0ba47b97b4be">


to this so that is aligned correctly

<img width="469" alt="Screenshot 2023-11-28 at 5 13 08 PM" src="https://github.com/grafana/grafana/assets/25674746/6a7359b4-b249-455b-bc5c-a4341595dbc6">


To test this, these feature toggles need to be enabled locally in your custom.ini file:
```
azure_auth_enabled = true
managed_identity_enabled=true
user_identity_enabled=true
workload_identity_enabled=true
```

or you can pass them in the docker ephemeral instance below like so:
```
GF_AUTH_AZURE_AUTH_ENABLED=true
GF_AZURE_CLOUD=AzureCloud
GF_AZURE_MANAGED_IDENTITY_ENABLED=true
GF_AZURE_USER_IDENTITY_ENABLED=true
GF_AZURE_WORKLOAD_IDENTITY_ENABLED=true
```

Please check that:
- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
