### PR TITLE
data-trails: ability to (de)serialize parents and current index

### DIFF
--- a/public/app/features/trails/DataTrail.test.tsx
+++ b/public/app/features/trails/DataTrail.test.tsx
@@ -36,16 +36,12 @@ describe('DataTrail', () => {
       expect(trail.state.topScene).toBeInstanceOf(MetricSelectScene);
     });
 
-    it('Should set stepIndex to 0', () => {
-      expect(trail.state.stepIndex).toBe(0);
-    });
-
-    it('Should set parentIndex to -1', () => {
-      expect(trail.state.parentIndex).toBe(-1);
-    });
-
-    it('Should set history currentStep to 0', () => {
+    it('Should set history current step to 0', () => {
       expect(trail.state.history.state.currentStep).toBe(0);
+    });
+
+    it('Should set history step 0 parentIndex to -1', () => {
+      expect(trail.state.history.state.steps[0].parentIndex).toBe(-1);
     });
 
     describe('And metric is selected', () => {
@@ -66,16 +62,16 @@ describe('DataTrail', () => {
         expect(trail.state.history.state.steps[1].type).toBe('metric');
       });
 
-      it('Should set stepIndex to 1', () => {
-        expect(trail.state.stepIndex).toBe(1);
+      it('Should set history current step to 1', () => {
+        expect(trail.state.history.state.currentStep).toBe(1);
       });
 
       it('Should set history currentStep to 1', () => {
         expect(trail.state.history.state.currentStep).toBe(1);
       });
 
-      it('Should set parentIndex to 0', () => {
-        expect(trail.state.parentIndex).toBe(0);
+      it('Should set history step 1 parentIndex to 0', () => {
+        expect(trail.state.history.state.steps[1].parentIndex).toBe(0);
       });
     });
 
@@ -83,16 +79,12 @@ describe('DataTrail', () => {
       beforeEach(() => {
         trail.publishEvent(new MetricSelectedEvent('first_metric'));
         trail.publishEvent(new MetricSelectedEvent('second_metric'));
-        trail.goBackToStep(trail.state.history.state.steps[1]);
+        trail.state.history.goBackToStep(1);
       });
 
       it('Should restore state and url', () => {
         expect(trail.state.metric).toBe('first_metric');
         expect(locationService.getSearchObject().metric).toBe('first_metric');
-      });
-
-      it('Should set stepIndex to 1', () => {
-        expect(trail.state.stepIndex).toBe(1);
       });
 
       it('Should set history currentStep to 1', () => {
@@ -112,16 +104,12 @@ describe('DataTrail', () => {
           expect(trail.state.history.state.steps.length).toBe(4);
         });
 
-        it('Should set stepIndex to 3', () => {
-          expect(trail.state.stepIndex).toBe(3);
-        });
-
-        it('Should set history currentStep to 1', () => {
+        it('Should set history current step to 3', () => {
           expect(trail.state.history.state.currentStep).toBe(3);
         });
 
-        it('Should set parentIndex to 1', () => {
-          expect(trail.state.parentIndex).toBe(1);
+        it('Should set history step 3 parent index to 1', () => {
+          expect(trail.state.history.state.steps[3].parentIndex).toBe(1);
         });
       });
     });

--- a/public/app/features/trails/DataTrail.tsx
+++ b/public/app/features/trails/DataTrail.tsx
@@ -43,10 +43,6 @@ export interface DataTrailState extends SceneObjectState {
 
   // Synced with url
   metric?: string;
-
-  // Indicates which step in the data trail this is
-  stepIndex: number;
-  parentIndex: number; // If there is no parent, this will be -1
 }
 
 export class DataTrail extends SceneObjectBase<DataTrailState> {
@@ -64,8 +60,6 @@ export class DataTrail extends SceneObjectBase<DataTrailState> {
       ],
       history: state.history ?? new DataTrailHistory({}),
       settings: state.settings ?? new DataTrailSettings({}),
-      stepIndex: state.stepIndex ?? 0,
-      parentIndex: state.parentIndex ?? -1,
       ...state,
     });
 
@@ -80,6 +74,29 @@ export class DataTrail extends SceneObjectBase<DataTrailState> {
     // Some scene elements publish this
     this.subscribeToEvent(MetricSelectedEvent, this._handleMetricSelectedEvent.bind(this));
 
+    // Pay attention to changes in history (i.e., changing the step)
+    this.state.history.subscribeToState((newState, oldState) => {
+      const oldNumberOfSteps = oldState.steps.length;
+      const newNumberOfSteps = newState.steps.length;
+
+      const newStepWasAppended = newNumberOfSteps > oldNumberOfSteps;
+
+      if (newStepWasAppended) {
+        // Do nothing because the state is already up to date -- it created a new step!
+        return;
+      }
+
+      if (oldState.currentStep === newState.currentStep) {
+        // The same step was clicked on -- no need to change anything.
+        return;
+      }
+
+      // History changed because a different node was selected
+      const step = newState.steps[newState.currentStep];
+
+      this.goBackToStep(step);
+    });
+
     return () => {
       if (!this.state.embedded) {
         getUrlSyncManager().cleanUp(this);
@@ -88,7 +105,7 @@ export class DataTrail extends SceneObjectBase<DataTrailState> {
     };
   }
 
-  public goBackToStep(step: DataTrailHistoryStep) {
+  private goBackToStep(step: DataTrailHistoryStep) {
     if (!this.state.embedded) {
       getUrlSyncManager().cleanUp(this);
     }

--- a/public/app/features/trails/TrailStore/TrailStore.ts
+++ b/public/app/features/trails/TrailStore/TrailStore.ts
@@ -13,7 +13,9 @@ export interface SerializedTrail {
     urlValues: SceneObjectUrlValues;
     type: TrailStepType;
     description: string;
+    parentIndex: number;
   }>;
+  currentStep: number;
 }
 
 export class TrailStore {
@@ -55,8 +57,14 @@ export class TrailStore {
 
     t.history.map((step) => {
       this._loadFromUrl(trail, step.urlValues);
+      const parentIndex = step.parentIndex ?? trail.state.history.state.steps.length - 1;
+      // Set the parent of the next trail step by setting the current step in history.
+      trail.state.history.setState({ currentStep: parentIndex });
       trail.state.history.addTrailStep(trail, step.type);
     });
+
+    const currentStep = t.currentStep ?? trail.state.history.state.steps.length - 1;
+    trail.state.history.setState({ currentStep });
 
     return trail;
   }
@@ -68,10 +76,12 @@ export class TrailStore {
         urlValues: getUrlSyncManager().getUrlState(stepTrail),
         type: step.type,
         description: step.description,
+        parentIndex: step.parentIndex,
       };
     });
     return {
       history,
+      currentStep: trail.state.history.state.currentStep,
     };
   }
 


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

There was an issue with serializing and deserializing some of the new capabilities added to data trails.

This PR resolves those issues.

**What is this feature?**

- refactored data trails state so that the history stores parent relations and current index, not the actual trailState.

- Since I was in the area, rounded indirect parent links
  ![image](https://github.com/grafana/grafana/assets/38694490/83fcdc74-f722-4503-9014-218fba6cdf91)

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
