### PR TITLE
Tempo: Fix read-only access error

### DIFF
--- a/public/app/core/components/TraceToMetrics/TraceToMetricsSettings.tsx
+++ b/public/app/core/components/TraceToMetrics/TraceToMetricsSettings.tsx
@@ -156,11 +156,15 @@ export function TraceToMetricsSettings({ options, onOptionsChange }: Props) {
               allowFullScreen
               value={query.query}
               onChange={(e) => {
-                let newQueries = options.jsonData.tracesToMetrics?.queries.slice() ?? [];
-                newQueries[i].query = e.currentTarget.value;
+                const updatedQueries = (options.jsonData.tracesToMetrics?.queries ?? []).map((q, index) => {
+                  if (index === i) {
+                    return { ...q, query: e.currentTarget.value };
+                  }
+                  return q;
+                });
                 updateDatasourcePluginJsonDataOption({ onOptionsChange, options }, 'tracesToMetrics', {
                   ...options.jsonData.tracesToMetrics,
-                  queries: newQueries,
+                  queries: updatedQueries,
                 });
               }}
             />

--- a/public/app/core/components/TraceToMetrics/TraceToMetricsSettings.tsx
+++ b/public/app/core/components/TraceToMetrics/TraceToMetricsSettings.tsx
@@ -158,10 +158,7 @@ export function TraceToMetricsSettings({ options, onOptionsChange }: Props) {
               onChange={(e) => {
                 const updatedQueries = (options.jsonData.tracesToMetrics?.queries ?? []).map(
                   (traceToMetricQuery, index) => {
-                    if (index === i) {
-                      return { ...traceToMetricQuery, query: e.currentTarget.value };
-                    }
-                    return traceToMetricQuery;
+                    return index === i ? { ...traceToMetricQuery, query: e.currentTarget.value } : traceToMetricQuery;
                   }
                 );
                 updateDatasourcePluginJsonDataOption({ onOptionsChange, options }, 'tracesToMetrics', {

--- a/public/app/core/components/TraceToMetrics/TraceToMetricsSettings.tsx
+++ b/public/app/core/components/TraceToMetrics/TraceToMetricsSettings.tsx
@@ -156,12 +156,14 @@ export function TraceToMetricsSettings({ options, onOptionsChange }: Props) {
               allowFullScreen
               value={query.query}
               onChange={(e) => {
-                const updatedQueries = (options.jsonData.tracesToMetrics?.queries ?? []).map((q, index) => {
-                  if (index === i) {
-                    return { ...q, query: e.currentTarget.value };
+                const updatedQueries = (options.jsonData.tracesToMetrics?.queries ?? []).map(
+                  (traceToMetricQuery, index) => {
+                    if (index === i) {
+                      return { ...traceToMetricQuery, query: e.currentTarget.value };
+                    }
+                    return traceToMetricQuery;
                   }
-                  return q;
-                });
+                );
                 updateDatasourcePluginJsonDataOption({ onOptionsChange, options }, 'tracesToMetrics', {
                   ...options.jsonData.tracesToMetrics,
                   queries: updatedQueries,


### PR DESCRIPTION
In some environment, trying to update `newQueries[i].query` causes the following error in some environments:
```
TypeError: Cannot assign to read only property 'query' of object '#<Object>'
```
This PR changes the code to directly create updated `TraceToMetricQuery` objects instead of changing the `query` property later.