### PR TITLE
Plugins: Only preload plugins if user is authenticated

### DIFF
--- a/public/app/app.ts
+++ b/public/app/app.ts
@@ -196,20 +196,22 @@ export class GrafanaApp {
       const modalManager = new ModalManager();
       modalManager.init();
 
-      // Preload selected app plugins
-      const preloadResults = await preloadPlugins(config.apps);
+      if (contextSrv.isSignedIn) {
+        // Preload selected app plugins
+        const preloadResults = await preloadPlugins(config.apps);
 
-      // Create extension registry out of preloaded plugins and core extensions
-      const extensionRegistry = createPluginExtensionRegistry([
-        { pluginId: 'grafana', extensionConfigs: getCoreExtensionConfigurations() },
-        ...preloadResults,
-      ]);
+        // Create extension registry out of preloaded plugins and core extensions
+        const extensionRegistry = createPluginExtensionRegistry([
+          { pluginId: 'grafana', extensionConfigs: getCoreExtensionConfigurations() },
+          ...preloadResults,
+        ]);
 
-      // Expose the getPluginExtension function via grafana-runtime
-      const pluginExtensionGetter: GetPluginExtensions = (options) =>
-        getPluginExtensions({ ...options, registry: extensionRegistry });
+        // Expose the getPluginExtension function via grafana-runtime
+        const pluginExtensionGetter: GetPluginExtensions = (options) =>
+          getPluginExtensions({ ...options, registry: extensionRegistry });
 
-      setPluginExtensionGetter(pluginExtensionGetter);
+        setPluginExtensionGetter(pluginExtensionGetter);
+      }
 
       // initialize chrome service
       const queryParams = locationService.getSearchObject();

--- a/public/app/app.ts
+++ b/public/app/app.ts
@@ -80,7 +80,7 @@ import { createPluginExtensionRegistry } from './features/plugins/extensions/cre
 import { getCoreExtensionConfigurations } from './features/plugins/extensions/getCoreExtensionConfigurations';
 import { getPluginExtensions } from './features/plugins/extensions/getPluginExtensions';
 import { importPanelPlugin, syncGetPanelPlugin } from './features/plugins/importPanelPlugin';
-import { preloadPlugins } from './features/plugins/pluginPreloader';
+import { PluginPreloadResult, preloadPlugins } from './features/plugins/pluginPreloader';
 import { QueryRunner } from './features/query/state/QueryRunner';
 import { runRequest } from './features/query/state/runRequest';
 import { initWindowRuntime } from './features/runtime/init';
@@ -196,22 +196,24 @@ export class GrafanaApp {
       const modalManager = new ModalManager();
       modalManager.init();
 
+      let preloadResults: PluginPreloadResult[] = [];
+
       if (contextSrv.isSignedIn) {
         // Preload selected app plugins
-        const preloadResults = await preloadPlugins(config.apps);
-
-        // Create extension registry out of preloaded plugins and core extensions
-        const extensionRegistry = createPluginExtensionRegistry([
-          { pluginId: 'grafana', extensionConfigs: getCoreExtensionConfigurations() },
-          ...preloadResults,
-        ]);
-
-        // Expose the getPluginExtension function via grafana-runtime
-        const pluginExtensionGetter: GetPluginExtensions = (options) =>
-          getPluginExtensions({ ...options, registry: extensionRegistry });
-
-        setPluginExtensionGetter(pluginExtensionGetter);
+        preloadResults = await preloadPlugins(config.apps);
       }
+
+      // Create extension registry out of preloaded plugins and core extensions
+      const extensionRegistry = createPluginExtensionRegistry([
+        { pluginId: 'grafana', extensionConfigs: getCoreExtensionConfigurations() },
+        ...preloadResults,
+      ]);
+
+      // Expose the getPluginExtension function via grafana-runtime
+      const pluginExtensionGetter: GetPluginExtensions = (options) =>
+        getPluginExtensions({ ...options, registry: extensionRegistry });
+
+      setPluginExtensionGetter(pluginExtensionGetter);
 
       // initialize chrome service
       const queryParams = locationService.getSearchObject();


### PR DESCRIPTION
**What is this feature?**

Skips preloading of plugins if user is not authenticated.

**Why do we need this feature?**

Otherwise the login page shows an unauthorized message alert when trying to fetch `/api/plugins/:pluginId/settings`. 

**Who is this feature for?**

End users

**Which issue(s) does this PR fix?**:

Fixes #75941

**Special notes for your reviewer:**
- :heavy_check_mark: Tested with [app-with-extensions](https://github.com/grafana/grafana-plugin-examples/tree/main/examples/app-with-extensions) and it works as expected.
- :heavy_check_mark: Tested with public dashboards and they don't render panel menu so that's fine
- :heavy_check_mark: Tested with dashboard snapshot and it now works without crashing after my latest push.
- Anything else to take into consideration?
- Another alternative could be to catch the `FetchError` and set `isHandled = true` which basically would not trigger the unauthorized message alert to be shown. Outcome would be the same though, no preloaded plugins if not authenticated.

Please check that:
- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
