### PR TITLE
Authn: Only resolve org id once

### DIFF
--- a/pkg/services/authn/authnimpl/service.go
+++ b/pkg/services/authn/authnimpl/service.go
@@ -191,6 +191,8 @@ func (s *Service) Authenticate(ctx context.Context, r *authn.Request) (*authn.Id
 	ctx, span := s.tracer.Start(ctx, "authn.Authenticate")
 	defer span.End()
 
+	r.OrgID = orgIDFromRequest(r)
+
 	var authErr error
 	for _, item := range s.clientQueue.items {
 		if item.v.Test(ctx, r) {
@@ -223,7 +225,6 @@ func (s *Service) Authenticate(ctx context.Context, r *authn.Request) (*authn.Id
 }
 
 func (s *Service) authenticate(ctx context.Context, c authn.Client, r *authn.Request) (*authn.Identity, error) {
-	r.OrgID = orgIDFromRequest(r)
 	identity, err := c.Authenticate(ctx, r)
 	if err != nil {
 		s.errorLogFunc(ctx, err)("Failed to authenticate request", "client", c.Name(), "error", err)
@@ -267,6 +268,8 @@ func (s *Service) Login(ctx context.Context, client string, r *authn.Request) (i
 		attribute.String(attributeKeyClient, client),
 	))
 	defer span.End()
+
+	r.OrgID = orgIDFromRequest(r)
 
 	defer func() {
 		for _, hook := range s.postLoginHooks.items {


### PR DESCRIPTION
**What is this feature?**
I noticed that we resolve org id for every client we try to authenticate with. The value is always resolved to the same so we can just do it once.

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
