### PR TITLE
sql: remove pkg/util dependency

### DIFF
--- a/pkg/tsdb/grafana-postgresql-datasource/proxy.go
+++ b/pkg/tsdb/grafana-postgresql-datasource/proxy.go
@@ -2,14 +2,15 @@ package postgres
 
 import (
 	"context"
+	"crypto/md5"
 	"database/sql"
 	"database/sql/driver"
+	"fmt"
 	"net"
 	"slices"
 	"time"
 
 	sdkproxy "github.com/grafana/grafana-plugin-sdk-go/backend/proxy"
-	"github.com/grafana/grafana/pkg/util"
 	"github.com/lib/pq"
 	"golang.org/x/net/proxy"
 )
@@ -18,10 +19,7 @@ import (
 // route connections through the secure socks proxy
 func createPostgresProxyDriver(cnnstr string, opts *sdkproxy.Options) (string, error) {
 	// create a unique driver per connection string
-	hash, err := util.Md5SumString(cnnstr)
-	if err != nil {
-		return "", err
-	}
+	hash := fmt.Sprintf("%x", md5.Sum([]byte(cnnstr)))
 	driverName := "postgres-proxy-" + hash
 
 	// only register the driver once

--- a/pkg/tsdb/mssql/proxy.go
+++ b/pkg/tsdb/mssql/proxy.go
@@ -2,14 +2,15 @@ package mssql
 
 import (
 	"context"
+	"crypto/md5"
 	"database/sql"
 	"database/sql/driver"
 	"errors"
+	"fmt"
 	"net"
 	"slices"
 
 	sdkproxy "github.com/grafana/grafana-plugin-sdk-go/backend/proxy"
-	"github.com/grafana/grafana/pkg/util"
 	mssql "github.com/microsoft/go-mssqldb"
 	"golang.org/x/net/proxy"
 )
@@ -18,10 +19,7 @@ import (
 // route connections through the secure socks proxy
 func createMSSQLProxyDriver(cnnstr string, hostName string, opts *sdkproxy.Options) (string, error) {
 	// create a unique driver per connection string
-	hash, err := util.Md5SumString(cnnstr)
-	if err != nil {
-		return "", err
-	}
+	hash := fmt.Sprintf("%x", md5.Sum([]byte(cnnstr)))
 	driverName := "mssql-proxy-" + hash
 
 	// only register the driver once

--- a/pkg/tsdb/mysql/proxy.go
+++ b/pkg/tsdb/mysql/proxy.go
@@ -2,11 +2,12 @@ package mysql
 
 import (
 	"context"
+	"crypto/md5"
+	"fmt"
 	"net"
 
 	"github.com/go-sql-driver/mysql"
 	sdkproxy "github.com/grafana/grafana-plugin-sdk-go/backend/proxy"
-	"github.com/grafana/grafana/pkg/util"
 	"golang.org/x/net/proxy"
 )
 
@@ -21,10 +22,7 @@ func registerProxyDialerContext(protocol, cnnstr string, opts *sdkproxy.Options)
 
 	// the dialer context can be updated everytime the datasource is updated
 	// have a unique network per connection string
-	hash, err := util.Md5SumString(cnnstr)
-	if err != nil {
-		return "", err
-	}
+	hash := fmt.Sprintf("%x", md5.Sum([]byte(cnnstr)))
 	network := "proxy-" + hash
 	mysql.RegisterDialContext(network, dialer.DialContext)
 


### PR DESCRIPTION
(fixes https://github.com/grafana/grafana/issues/77726)

in the sql code we currently import `pkg/util/md5` to calculate the md5-checksum of a string. this is a core grafana function, not exported, so we should not use it.

the replacement is an inline md5-calculation.

(NOTE: technically this should be a separate PR, but i have decided to merge this into the no-xorm-branch, because testing the proxy-stuff is complicated, so better to do it one time than two times).

NOTE: alternatively, we could create our own string-to-md5 utility function somewhere in `pkg/tsdb/sqleng`, just tell me if you prefer that approach.
