### PR TITLE
Set TEMPO_VERSION as "latest" across all pages

### DIFF
--- a/docs/sources/_index.md
+++ b/docs/sources/_index.md
@@ -13,6 +13,8 @@ labels:
   products:
     - enterprise
     - oss
+cascade:
+  TEMPO_VERSION: latest
 title: Grafana open source documentation
 ---
 


### PR DESCRIPTION
All links to Tempo should go to the latest version of Tempo documentation.

Older versions might want to set that to different values and this single variable can be changed to set that.

Signed-off-by: Jack Baldry <jack.baldry@grafana.com>
