### PR TITLE
[v10.2.x] Set TEMPO_VERSION as "latest" across all pages

### DIFF
--- a/docs/sources/_index.md
+++ b/docs/sources/_index.md
@@ -13,6 +13,8 @@ labels:
     - enterprise
     - oss
 title: Grafana documentation
+cascade:
+  TEMPO_VERSION: latest
 ---
 
 # Grafana documentation


### PR DESCRIPTION
Backport 58725db9d43a09f5ebaa6ff9266f329dea4f34f5 from #78822

---

All links to Tempo should go to the latest version of Tempo documentation.

Older versions might want to set that to different values and this single variable can be changed to set that.

Signed-off-by: Jack Baldry <jack.baldry@grafana.com>
