### PR TITLE
Usagestats: Add stat group for alert rule groups

### DIFF
--- a/pkg/infra/metrics/metrics.go
+++ b/pkg/infra/metrics/metrics.go
@@ -185,6 +185,9 @@ var (
 	// StatsTotalAlertRules is a metric of total number of alert rules stored in Grafana.
 	StatsTotalAlertRules prometheus.Gauge
 
+	// StatsTotalRuleGroups is a metric of total number of alert rule groups stored in Grafana.
+	StatsTotalRuleGroups prometheus.Gauge
+
 	// StatsTotalDashboardVersions is a metric of total number of dashboard versions stored in Grafana.
 	StatsTotalDashboardVersions prometheus.Gauge
 
@@ -554,6 +557,12 @@ func init() {
 		Namespace: ExporterName,
 	})
 
+	StatsTotalRuleGroups = prometheus.NewGauge(prometheus.GaugeOpts{
+		Name:      "stat_totals_rule_groups",
+		Help:      "total amount of alert rule groups in the database",
+		Namespace: ExporterName,
+	})
+
 	MAccessPermissionsSummary = prometheus.NewHistogram(prometheus.HistogramOpts{
 		Name:    "access_permissions_duration",
 		Help:    "Histogram for the runtime of permissions check function.",
@@ -708,6 +717,7 @@ func initMetricVars() {
 		StatsTotalDashboardVersions,
 		StatsTotalAnnotations,
 		StatsTotalAlertRules,
+		StatsTotalRuleGroups,
 		MAccessEvaluationCount,
 		StatsTotalLibraryPanels,
 		StatsTotalLibraryVariables,

--- a/pkg/infra/usagestats/statscollector/service.go
+++ b/pkg/infra/usagestats/statscollector/service.go
@@ -164,6 +164,7 @@ func (s *Service) collectSystemStats(ctx context.Context) (map[string]any, error
 	m["stats.dashboard_versions.count"] = statsResult.DashboardVersions
 	m["stats.annotations.count"] = statsResult.Annotations
 	m["stats.alert_rules.count"] = statsResult.AlertRules
+	m["stats.rule_groups.count"] = statsResult.RuleGroups
 	m["stats.library_panels.count"] = statsResult.LibraryPanels
 	m["stats.library_variables.count"] = statsResult.LibraryVariables
 	m["stats.dashboards_viewers_can_edit.count"] = statsResult.DashboardsViewersCanEdit
@@ -328,6 +329,7 @@ func (s *Service) updateTotalStats(ctx context.Context) bool {
 	metrics.StatsTotalDashboardVersions.Set(float64(statsResult.DashboardVersions))
 	metrics.StatsTotalAnnotations.Set(float64(statsResult.Annotations))
 	metrics.StatsTotalAlertRules.Set(float64(statsResult.AlertRules))
+	metrics.StatsTotalRuleGroups.Set(float64(statsResult.RuleGroups))
 	metrics.StatsTotalLibraryPanels.Set(float64(statsResult.LibraryPanels))
 	metrics.StatsTotalLibraryVariables.Set(float64(statsResult.LibraryVariables))
 

--- a/pkg/services/stats/models.go
+++ b/pkg/services/stats/models.go
@@ -26,6 +26,7 @@ type SystemStats struct {
 	DashboardVersions         int64
 	Annotations               int64
 	AlertRules                int64
+	RuleGroups                int64
 	LibraryPanels             int64
 	LibraryVariables          int64
 	DashboardsViewersCanEdit  int64

--- a/pkg/services/stats/statsimpl/stats.go
+++ b/pkg/services/stats/statsimpl/stats.go
@@ -129,7 +129,7 @@ func (ss *sqlStatsService) GetSystemStats(ctx context.Context, query *stats.GetS
 		sb.Write(`(SELECT COUNT(*) FROM ` + dialect.Quote("dashboard_public") + `) AS public_dashboards,`)
 		sb.Write(`(SELECT MIN(timestamp) FROM ` + dialect.Quote("migration_log") + `) AS database_created_time,`)
 		if ss.IsUnifiedAlertingEnabled() {
-			sb.Write(`(SELECT COUNT(DISTINCT rule_group) FROM ` + dialect.Quote("alert_rule") + `) AS rule_groups,`)
+			sb.Write(`(SELECT COUNT(DISTINCT (` + dialect.Quote("rule_group") + `)) FROM ` + dialect.Quote("alert_rule") + `) AS rule_groups,`)
 		}
 
 		sb.Write(ss.roleCounterSQL(ctx))

--- a/pkg/services/stats/statsimpl/stats.go
+++ b/pkg/services/stats/statsimpl/stats.go
@@ -128,6 +128,9 @@ func (ss *sqlStatsService) GetSystemStats(ctx context.Context, query *stats.GetS
 		sb.Write(`(SELECT COUNT(*) FROM ` + dialect.Quote("data_keys") + `WHERE active = true) AS active_data_keys,`)
 		sb.Write(`(SELECT COUNT(*) FROM ` + dialect.Quote("dashboard_public") + `) AS public_dashboards,`)
 		sb.Write(`(SELECT MIN(timestamp) FROM ` + dialect.Quote("migration_log") + `) AS database_created_time,`)
+		if ss.IsUnifiedAlertingEnabled() {
+			sb.Write(`(SELECT COUNT(DISTINCT rule_group) FROM ` + dialect.Quote("alert_rule") + `) AS rule_groups,`)
+		}
 
 		sb.Write(ss.roleCounterSQL(ctx))
 


### PR DESCRIPTION
**What is this feature?**

Adds statistics for total number of rule groups, in addition to alert rules.

Only collected if unified alerting is enabled, as legacy alerting did not have this concept.

**Why do we need this feature?**

Allows administrators to track the number of rule groups in addition to plain rules.

**Which issue(s) does this PR fix?**:

n/a

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle.
- [x] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
