### PR TITLE
Alerting: Add SaveAndApply methods to the forked Alertmanager (remote secondary)

### DIFF
--- a/pkg/services/ngalert/remote/remote_secondary_forked_alertmanager.go
+++ b/pkg/services/ngalert/remote/remote_secondary_forked_alertmanager.go
@@ -24,15 +24,13 @@ func (fam *RemoteSecondaryForkedAlertmanager) ApplyConfig(ctx context.Context, c
 	return nil
 }
 
+// SaveAndApplyConfig is only called on the internal Alertmanager when running in remote secondary mode.
 func (fam *RemoteSecondaryForkedAlertmanager) SaveAndApplyConfig(ctx context.Context, config *apimodels.PostableUserConfig) error {
-	// We only need to call this method on the internal Alertmanager.
-	// Configuration is synced on an interval.
 	return fam.internal.SaveAndApplyConfig(ctx, config)
 }
 
+// SaveAndApplyDefaultConfig is only called on the internal Alertmanager when running in remote secondary mode.
 func (fam *RemoteSecondaryForkedAlertmanager) SaveAndApplyDefaultConfig(ctx context.Context) error {
-	// We only need to call this on the internal Alertmanager.
-	// Configuration is synced on an interval.
 	return fam.internal.SaveAndApplyDefaultConfig(ctx)
 }
 

--- a/pkg/services/ngalert/remote/remote_secondary_forked_alertmanager.go
+++ b/pkg/services/ngalert/remote/remote_secondary_forked_alertmanager.go
@@ -25,11 +25,15 @@ func (fam *RemoteSecondaryForkedAlertmanager) ApplyConfig(ctx context.Context, c
 }
 
 func (fam *RemoteSecondaryForkedAlertmanager) SaveAndApplyConfig(ctx context.Context, config *apimodels.PostableUserConfig) error {
-	return nil
+	// We only need to call this method on the internal Alertmanager.
+	// Configuration is synced on an interval.
+	return fam.internal.SaveAndApplyConfig(ctx, config)
 }
 
 func (fam *RemoteSecondaryForkedAlertmanager) SaveAndApplyDefaultConfig(ctx context.Context) error {
-	return nil
+	// We only need to call this on the internal Alertmanager.
+	// Configuration is synced on an interval.
+	return fam.internal.SaveAndApplyDefaultConfig(ctx)
 }
 
 func (fam *RemoteSecondaryForkedAlertmanager) GetStatus() apimodels.GettableStatus {


### PR DESCRIPTION
This PR adds `SaveAndApplyConfig()` and `SaveAndApplyDefaultConfig()` to the forked Alertmanager struct in remote secondary mode.