### PR TITLE
Loki: Fix derived fields with undefined `matcherType`

### DIFF
--- a/public/app/plugins/datasource/loki/getDerivedFields.test.ts
+++ b/public/app/plugins/datasource/loki/getDerivedFields.test.ts
@@ -154,4 +154,41 @@ describe('getDerivedFields', () => {
     const trace4 = newFields.find((f) => f.name === 'trace4Name');
     expect(trace4!.values).toEqual([null, null, null, null]);
   });
+
+  it('adds links to fields with no `matcherType`', () => {
+    const df = createDataFrame({ fields: [{ name: 'line', values: ['nothing', 'trace1=1234', 'trace2=foo'] }] });
+    const newFields = getDerivedFields(df, [
+      {
+        matcherRegex: 'trace1=(\\w+)',
+        name: 'trace1',
+        url: 'http://localhost/${__value.raw}',
+      },
+    ]);
+    expect(newFields.length).toBe(1);
+    const trace1 = newFields.find((f) => f.name === 'trace1');
+    expect(trace1!.values).toEqual([null, '1234', null]);
+    expect(trace1!.config.links![0]).toEqual({
+      url: 'http://localhost/${__value.raw}',
+      title: '',
+    });
+  });
+
+  it('adds links to fields with `matcherType=regex`', () => {
+    const df = createDataFrame({ fields: [{ name: 'line', values: ['nothing', 'trace1=1234', 'trace2=foo'] }] });
+    const newFields = getDerivedFields(df, [
+      {
+        matcherRegex: 'trace1=(\\w+)',
+        matcherType: 'regex',
+        name: 'trace1',
+        url: 'http://localhost/${__value.raw}',
+      },
+    ]);
+    expect(newFields.length).toBe(1);
+    const trace1 = newFields.find((f) => f.name === 'trace1');
+    expect(trace1!.values).toEqual([null, '1234', null]);
+    expect(trace1!.config.links![0]).toEqual({
+      url: 'http://localhost/${__value.raw}',
+      title: '',
+    });
+  });
 });

--- a/public/app/plugins/datasource/loki/getDerivedFields.ts
+++ b/public/app/plugins/datasource/loki/getDerivedFields.ts
@@ -41,7 +41,10 @@ export function getDerivedFields(dataFrame: DataFrame, derivedFieldConfigs: Deri
           }
         }
         field.values.push(null);
-      } else if (derivedFieldsGrouped[field.name][0].matcherType === 'regex') {
+      } else if (
+        derivedFieldsGrouped[field.name][0].matcherType === 'regex' ||
+        derivedFieldsGrouped[field.name][0].matcherType === undefined
+      ) {
         // `matcherRegex` will actually be used as a RegExp here
         const line = lineField.values[i];
         const logMatch = line.match(derivedFieldsGrouped[field.name][0].matcherRegex);


### PR DESCRIPTION
**What is this feature?**

Followup from #78464. An undefined `matcherType` should be treated as a `regex` matcher.
