### PR TITLE
Docs: Added data source requirement for built-in annotation query

### DIFF
--- a/docs/sources/dashboards/build-dashboards/annotate-visualizations/index.md
+++ b/docs/sources/dashboards/build-dashboards/annotate-visualizations/index.md
@@ -119,7 +119,7 @@ To add a new annotation query to a dashboard, take the following steps:
 
 After you add an annotation, they will still be visible. This is due to the built-in annotation query that exists on all dashboards. This annotation query will fetch all annotation events that originate from the current dashboard, which are stored in Grafana, and show them on the panel where they were created. This includes alert state history annotations.
 
-The built-in annotation query requires the special `-- Grafana --` data source to function, and the data source selection shouldn't be changed. 
+By default, the built-in annotation query uses the `-- Grafana --` special data source, and manual annotations are only supported using this data source. You can use another data source in the built-in annotation query, but you'll only be able to create automated annotations using the query editor for that data source.
 
 To add annotations directly to the dashboard, this query must be enabled.
 

--- a/docs/sources/dashboards/build-dashboards/annotate-visualizations/index.md
+++ b/docs/sources/dashboards/build-dashboards/annotate-visualizations/index.md
@@ -119,7 +119,7 @@ To add a new annotation query to a dashboard, take the following steps:
 
 After you add an annotation, they will still be visible. This is due to the built-in annotation query that exists on all dashboards. This annotation query will fetch all annotation events that originate from the current dashboard, which are stored in Grafana, and show them on the panel where they were created. This includes alert state history annotations.
 
-The built-in annotation query requires the special `-- Grafana --` data source to function, and the data source for the query shouldn't be changed. 
+The built-in annotation query requires the special `-- Grafana --` data source to function, and the data source selection shouldn't be changed. 
 
 To add annotations directly to the dashboard, this query must be enabled.
 

--- a/docs/sources/dashboards/build-dashboards/annotate-visualizations/index.md
+++ b/docs/sources/dashboards/build-dashboards/annotate-visualizations/index.md
@@ -119,6 +119,8 @@ To add a new annotation query to a dashboard, take the following steps:
 
 After you add an annotation, they will still be visible. This is due to the built-in annotation query that exists on all dashboards. This annotation query will fetch all annotation events that originate from the current dashboard, which are stored in Grafana, and show them on the panel where they were created. This includes alert state history annotations.
 
+The built-in annotation query requires the special `-- Grafana --` data source to function, and the data source for the query shouldn't be changed. 
+
 To add annotations directly to the dashboard, this query must be enabled.
 
 To confirm if the built-in query is enabled, take the following steps:


### PR DESCRIPTION
Clarifies that the built-in annotation query can only use the Grafana data source.