### PR TITLE
[v9.5.x] Auth: id response header

### DIFF
--- a/conf/defaults.ini
+++ b/conf/defaults.ini
@@ -534,6 +534,17 @@ azure_auth_enabled = false
 # Use email lookup in addition to the unique ID provided by the IdP
 oauth_allow_insecure_email_lookup = false
 
+# Set to true to include id of identity as a response header
+id_response_header_enabled = false
+
+# Prefix used for the id response header, X-Grafana-Identity-Id
+id_response_header_prefix = X-Grafana
+
+# List of identity namespaces to add id response headers for, separated by space.
+# Available namespaces are user, api-key and service-account.
+# The header value will encode the namespace ("user:<id>", "api-key:<id>", "service-account:<id>")
+id_response_header_namespaces = user api-key service-account
+
 #################################### Anonymous Auth ######################
 [auth.anonymous]
 # enable anonymous access

--- a/conf/sample.ini
+++ b/conf/sample.ini
@@ -523,6 +523,17 @@
 # Use email lookup in addition to the unique ID provided by the IdP
 ;oauth_allow_insecure_email_lookup = false
 
+# Set to true to include id of identity as a response header
+;id_response_header_enabled = false
+
+# Prefix used for the id response header, X-Grafana-Identity-Id
+;id_response_header_prefix = X-Grafana
+
+# List of identity namespaces to add id response headers for, separated by space.
+# Available namespaces are user, api-key and service-account.
+# The header value will encode the namespace ("user:<id>", "api-key:<id>", "service-account:<id>")
+;id_response_header_namespaces = user api-key service-account
+
 #################################### Anonymous Auth ######################
 [auth.anonymous]
 # enable anonymous access

--- a/pkg/services/contexthandler/contexthandler.go
+++ b/pkg/services/contexthandler/contexthandler.go
@@ -239,6 +239,11 @@ func (h *ContextHandler) Middleware(next http.Handler) http.Handler {
 			}
 		}
 
+		if h.Cfg.IDResponseHeaderEnabled && reqContext.SignedInUser != nil {
+			namespace, id := getNamespaceAndID(reqContext.SignedInUser)
+			reqContext.Resp.Before(h.addIDHeaderEndOfRequestFunc(namespace, id))
+		}
+
 		next.ServeHTTP(w, r)
 	})
 }
@@ -571,6 +576,42 @@ func (h *ContextHandler) initContextWithToken(reqContext *contextmodel.ReqContex
 	reqContext.Resp.Before(h.rotateEndOfRequestFunc(reqContext))
 
 	return true
+}
+
+// TODO(kalleep): Refactor to user identity.Requester interface and methods after we have backported this
+func getNamespaceAndID(user *user.SignedInUser) (string, string) {
+	var namespace, id string
+	if user.UserID > 0 && user.IsServiceAccount {
+		id = strconv.Itoa(int(user.UserID))
+		namespace = "service-account"
+	} else if user.UserID > 0 {
+		id = strconv.Itoa(int(user.UserID))
+		namespace = "user"
+	} else if user.ApiKeyID > 0 {
+		id = strconv.Itoa(int(user.ApiKeyID))
+		namespace = "api-key"
+	}
+
+	return namespace, id
+}
+
+func (h *ContextHandler) addIDHeaderEndOfRequestFunc(namespace, id string) web.BeforeFunc {
+	return func(w web.ResponseWriter) {
+		if w.Written() {
+			return
+		}
+
+		if namespace == "" || id == "" {
+			return
+		}
+
+		if _, ok := h.Cfg.IDResponseHeaderNamespaces[namespace]; !ok {
+			return
+		}
+
+		headerName := fmt.Sprintf("%s-Identity-Id", h.Cfg.IDResponseHeaderPrefix)
+		w.Header().Add(headerName, fmt.Sprintf("%s:%s", namespace, id))
+	}
 }
 
 func (h *ContextHandler) deleteInvalidCookieEndOfRequestFunc(reqContext *contextmodel.ReqContext) web.BeforeFunc {

--- a/pkg/setting/setting.go
+++ b/pkg/setting/setting.go
@@ -270,6 +270,9 @@ type Cfg struct {
 	AdminEmail                   string
 	DisableSyncLock              bool
 	DisableLoginForm             bool
+	IDResponseHeaderEnabled      bool
+	IDResponseHeaderPrefix       string
+	IDResponseHeaderNamespaces   map[string]struct{}
 
 	// AWS Plugin Auth
 	AWSAllowedAuthProviders []string
@@ -1491,6 +1494,17 @@ func readAuthSettings(iniFile *ini.File, cfg *Cfg) (err error) {
 	// Azure Auth
 	AzureAuthEnabled = auth.Key("azure_auth_enabled").MustBool(false)
 	cfg.AzureAuthEnabled = AzureAuthEnabled
+
+	// ID response header
+	cfg.IDResponseHeaderEnabled = auth.Key("id_response_header_enabled").MustBool(false)
+	cfg.IDResponseHeaderPrefix = auth.Key("id_response_header_prefix").MustString("X-Grafana-")
+
+	idHeaderNamespaces := util.SplitString(auth.Key("id_response_header_namespaces").MustString(""))
+	cfg.IDResponseHeaderNamespaces = make(map[string]struct{}, len(idHeaderNamespaces))
+	for _, namespace := range idHeaderNamespaces {
+		cfg.IDResponseHeaderNamespaces[namespace] = struct{}{}
+	}
+
 	readAuthAzureADSettings(cfg)
 
 	// Google Auth


### PR DESCRIPTION
Backport 21f94c5b783b51a2cab61937d32a92bab572a45c from #77871

---

**What is this feature?**
Add config options and functionality to include the id of the identity making a request to all response headers.
I decided make the implementation a little more generic than what the issue describes.
I also intentionally only used fields / functions I know exist on 9.5.x because we want to backport this feature.

The response header will use the specified prefix, with default values it would be `X-Grafana-Identitity-Id` and the value will be use the namespace and id of identitiy (`user:<id>`, `api-key:<id>` or `service-account:<id>`

**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/identity-access-team/issues/394

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
