### PR TITLE
Transformations: Add featureToggles to DataTransformContext to remove use of window.grafanBootData from grafana-data

### DIFF
--- a/.betterer.results
+++ b/.betterer.results
@@ -1,5 +1,5 @@
 // BETTERER RESULTS V2.
-//
+// 
 // If this file contains merge conflicts, use `betterer merge` to automatically resolve them:
 // https://phenomnomnominal.github.io/betterer/docs/results-file/#merge
 //
@@ -244,10 +244,6 @@ exports[`better eslint`] = {
     ],
     "packages/grafana-data/src/transformations/transformers/reduce.ts:5381": [
       [0, 0, 0, "Unexpected any. Specify a different type.", "0"],
-      [0, 0, 0, "Unexpected any. Specify a different type.", "1"]
-    ],
-    "packages/grafana-data/src/transformations/transformers/utils.ts:5381": [
-      [0, 0, 0, "Do not use any type assertions.", "0"],
       [0, 0, 0, "Unexpected any. Specify a different type.", "1"]
     ],
     "packages/grafana-data/src/types/OptionsUIRegistryBuilder.ts:5381": [

--- a/packages/grafana-data/src/transformations/transformers/filterByValue.test.ts
+++ b/packages/grafana-data/src/transformations/transformers/filterByValue.test.ts
@@ -13,18 +13,6 @@ import {
 } from './filterByValue';
 import { DataTransformerID } from './ids';
 
-let transformationSupport = false;
-
-jest.mock('./utils', () => {
-  const actual = jest.requireActual('./utils');
-  return {
-    ...actual,
-    transformationsVariableSupport: () => {
-      return transformationSupport;
-    },
-  };
-});
-
 const seriesAWithSingleField = toDataFrame({
   name: 'A',
   length: 7,
@@ -122,8 +110,6 @@ describe('FilterByValue transformer', () => {
   });
 
   it('should interpolate dashboard variables', async () => {
-    transformationSupport = true;
-
     const lower: MatcherConfig<BasicValueMatcherOptions<string | number>> = {
       id: ValueMatcherID.lower,
       options: { value: 'thiswillinterpolateto6' },
@@ -143,7 +129,7 @@ describe('FilterByValue transformer', () => {
       },
     };
 
-    const ctxmock = { interpolate: jest.fn(() => '6') };
+    const ctxmock = { interpolate: jest.fn(() => '6'), featureToggles: { transformationsVariableSupport: true } };
 
     await expect(transformDataFrame([cfg], [seriesAWithSingleField], ctxmock)).toEmitValuesWith((received) => {
       const processed = received[0];
@@ -164,7 +150,6 @@ describe('FilterByValue transformer', () => {
         },
       ]);
     });
-    transformationSupport = false;
   });
 
   it('should not interpolate dashboard variables when feature toggle is off', async () => {

--- a/packages/grafana-data/src/transformations/transformers/filterByValue.ts
+++ b/packages/grafana-data/src/transformations/transformers/filterByValue.ts
@@ -8,7 +8,6 @@ import { ValueMatcherID } from '../matchers/ids';
 
 import { DataTransformerID } from './ids';
 import { noopTransformer } from './noop';
-import { transformationsVariableSupport } from './utils';
 
 export enum FilterByValueType {
   exclude = 'exclude',
@@ -52,7 +51,7 @@ export const filterByValueTransformer: DataTransformerInfo<FilterByValueTransfor
 
     const interpolatedFilters: FilterByValueFilter[] = [];
 
-    if (transformationsVariableSupport()) {
+    if (ctx.featureToggles?.transformationsVariableSupport) {
       interpolatedFilters.push(
         ...filters.map((filter) => {
           if (filter.config.id === ValueMatcherID.between) {
@@ -102,7 +101,7 @@ export const filterByValueTransformer: DataTransformerInfo<FilterByValueTransfor
           const fieldIndexByName = groupFieldIndexByName(frame, data);
 
           let matchers;
-          if (transformationsVariableSupport()) {
+          if (ctx.featureToggles?.transformationsVariableSupport) {
             matchers = createFilterValueMatchers(interpolatedFilters, fieldIndexByName);
           } else {
             matchers = createFilterValueMatchers(filters, fieldIndexByName);

--- a/packages/grafana-data/src/transformations/transformers/histogram.ts
+++ b/packages/grafana-data/src/transformations/transformers/histogram.ts
@@ -8,7 +8,6 @@ import { roundDecimals } from '../../utils';
 
 import { DataTransformerID } from './ids';
 import { AlignedData, join } from './joinDataFrames';
-import { transformationsVariableSupport } from './utils';
 
 /**
  * @internal
@@ -101,7 +100,7 @@ export const histogramTransformer: SynchronousDataTransformerInfo<HistogramTrans
       bucketOffset: number | undefined = undefined;
 
     if (options.bucketSize) {
-      if (transformationsVariableSupport()) {
+      if (ctx.featureToggles?.transformationsVariableSupport) {
         options.bucketSize = ctx.interpolate(options.bucketSize.toString());
       }
       if (typeof options.bucketSize === 'string') {
@@ -116,7 +115,7 @@ export const histogramTransformer: SynchronousDataTransformerInfo<HistogramTrans
     }
 
     if (options.bucketOffset) {
-      if (transformationsVariableSupport()) {
+      if (ctx.featureToggles?.transformationsVariableSupport) {
         options.bucketOffset = ctx.interpolate(options.bucketOffset.toString());
       }
       if (typeof options.bucketOffset === 'string') {

--- a/packages/grafana-data/src/transformations/transformers/limit.ts
+++ b/packages/grafana-data/src/transformations/transformers/limit.ts
@@ -3,7 +3,6 @@ import { map } from 'rxjs/operators';
 import { DataTransformerInfo } from '../../types';
 
 import { DataTransformerID } from './ids';
-import { transformationsVariableSupport } from './utils';
 
 export interface LimitTransformerOptions {
   limitField?: number | string;
@@ -25,7 +24,7 @@ export const limitTransformer: DataTransformerInfo<LimitTransformerOptions> = {
         let limit = DEFAULT_LIMIT_FIELD;
         if (options.limitField !== undefined) {
           if (typeof options.limitField === 'string') {
-            if (transformationsVariableSupport()) {
+            if (ctx.featureToggles?.transformationsVariableSupport) {
               limit = parseInt(ctx.interpolate(options.limitField), 10);
             } else {
               limit = parseInt(options.limitField, 10);

--- a/packages/grafana-data/src/transformations/transformers/sortBy.ts
+++ b/packages/grafana-data/src/transformations/transformers/sortBy.ts
@@ -6,7 +6,6 @@ import { DataFrame } from '../../types';
 import { DataTransformContext, DataTransformerInfo } from '../../types/transformations';
 
 import { DataTransformerID } from './ids';
-import { transformationsVariableSupport } from './utils';
 
 export interface SortByField {
   field: string;
@@ -59,7 +58,7 @@ function attachFieldIndex(frame: DataFrame, sort: SortByField[], ctx: DataTransf
       // null or undefined
       return s;
     }
-    if (transformationsVariableSupport()) {
+    if (ctx.featureToggles?.transformationsVariableSupport) {
       return {
         ...s,
         index: frame.fields.findIndex((f) => ctx.interpolate(s.field) === getFieldDisplayName(f, frame)),

--- a/packages/grafana-data/src/transformations/transformers/utils.ts
+++ b/packages/grafana-data/src/transformations/transformers/utils.ts
@@ -1,3 +1,0 @@
-export const transformationsVariableSupport = () => {
-  return (window as any)?.grafanaBootData?.settings?.featureToggles?.transformationsVariableSupport;
-};

--- a/packages/grafana-data/src/types/transformations.ts
+++ b/packages/grafana-data/src/types/transformations.ts
@@ -5,6 +5,7 @@ import { MatcherConfig, DataTransformerConfig } from '@grafana/schema';
 import { RegistryItemWithOptions } from '../utils/Registry';
 
 import { DataFrame, Field } from './dataFrame';
+import { FeatureToggles } from './featureToggles.gen';
 import { InterpolateFunction } from './panel';
 
 /** deprecated, use it from schema */
@@ -15,6 +16,7 @@ export type { MatcherConfig };
  */
 export interface DataTransformContext {
   interpolate: InterpolateFunction;
+  featureToggles?: FeatureToggles;
 }
 
 /**

--- a/public/app/features/query/state/PanelQueryRunner.ts
+++ b/public/app/features/query/state/PanelQueryRunner.ts
@@ -29,7 +29,7 @@ import {
   ApplyFieldOverrideOptions,
   StreamingDataFrame,
 } from '@grafana/data';
-import { toDataQueryError } from '@grafana/runtime';
+import { config, toDataQueryError } from '@grafana/runtime';
 import { ExpressionDatasourceRef } from '@grafana/runtime/src/utils/DataSourceWithBackend';
 import { isStreamingDataFrame } from 'app/features/live/data/utils';
 import { getDatasourceSrv } from 'app/features/plugins/datasource_srv';
@@ -44,7 +44,7 @@ import { runRequest } from './runRequest';
 
 export interface QueryRunnerOptions<
   TQuery extends DataQuery = DataQuery,
-  TOptions extends DataSourceJsonData = DataSourceJsonData,
+  TOptions extends DataSourceJsonData = DataSourceJsonData
 > {
   datasource: DataSourceRef | DataSourceApi<TQuery, TOptions> | null;
   queries: TQuery[];
@@ -219,6 +219,7 @@ export class PanelQueryRunner {
 
     const ctx: DataTransformContext = {
       interpolate: (v: string) => this.templateSrv.replace(v, data?.request?.scopedVars),
+      featureToggles: config.featureToggles,
     };
 
     return transformDataFrame(transformations, data.series, ctx).pipe(


### PR DESCRIPTION
**What is this feature?**

Adds featureToggles to the DataTransformContext object passed to transformations.

**Why do we need this feature?**

Since grafana-data doesn't have access to runtime transformations in grafana-data have relied on getting the feature toggles from `window.grafanaBootData `. Passing the feature toggles to the transformations remove the need for this code smell.