### PR TITLE
Alerting: Add note to the docs that GMA rules are evaluated concurrently

### DIFF
--- a/docs/sources/alerting/alerting-rules/create-grafana-managed-rule.md
+++ b/docs/sources/alerting/alerting-rules/create-grafana-managed-rule.md
@@ -92,7 +92,7 @@ To do this, you need to make sure that your alert rule is in the right evaluatio
 
    If you are creating a new evaluation group, specify the interval for the group.
 
-   All rules within the same group are evaluated sequentially over the same time interval.
+   All rules within the same group are evaluated concurrently over the same time interval.
 
 1. Enter a pending period.
 

--- a/docs/sources/alerting/fundamentals/alert-rules/organising-alerts.md
+++ b/docs/sources/alerting/fundamentals/alert-rules/organising-alerts.md
@@ -29,6 +29,8 @@ A namespace contains one or more groups. The rules within a group are run sequen
 
 ### Groups
 
-The rules within a group are run sequentially at a regular interval, meaning no rules will be evaluated at the same time and in order of appearance.. The default interval is one (1) minute. You can rename Grafana Mimir or Loki rule namespaces and groups, and edit group evaluation intervals.
+The rules within a group are run sequentially at a regular interval, meaning no rules will be evaluated at the same time and in order of appearance. The default interval is one (1) minute. You can rename Grafana Mimir or Loki rule namespaces and groups, and edit group evaluation intervals.
 
 > **Note** If you want rules to be evaluated concurrently and with different intervals, consider storing them in different groups.
+
+> **Note** Grafana managed alert rules are evaluated concurrently instead of sequentially.

--- a/public/app/features/alerting/unified/components/rule-editor/FolderAndGroup.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/FolderAndGroup.tsx
@@ -206,7 +206,7 @@ export function FolderAndGroup({
           <Field
             label="Evaluation group"
             data-testid="group-picker"
-            description="Rules within the same group are evaluated sequentially over the same time interval."
+            description="Rules within the same group are evaluated concurrently over the same time interval."
             className={styles.formInput}
             error={errors.group?.message}
             invalid={!!errors.group?.message}


### PR DESCRIPTION
**What is this feature?**

Update our docs and in-app documentation to clarify that Grafana managed alert rules are evaluated concurrently instead of sequentially.