### PR TITLE
Add feature toggle config to grafana-data

### DIFF
--- a/.betterer.results
+++ b/.betterer.results
@@ -1,5 +1,5 @@
 // BETTERER RESULTS V2.
-//
+// 
 // If this file contains merge conflicts, use `betterer merge` to automatically resolve them:
 // https://phenomnomnominal.github.io/betterer/docs/results-file/#merge
 //
@@ -244,10 +244,6 @@ exports[`better eslint`] = {
     ],
     "packages/grafana-data/src/transformations/transformers/reduce.ts:5381": [
       [0, 0, 0, "Unexpected any. Specify a different type.", "0"],
-      [0, 0, 0, "Unexpected any. Specify a different type.", "1"]
-    ],
-    "packages/grafana-data/src/transformations/transformers/utils.ts:5381": [
-      [0, 0, 0, "Do not use any type assertions.", "0"],
       [0, 0, 0, "Unexpected any. Specify a different type.", "1"]
     ],
     "packages/grafana-data/src/types/OptionsUIRegistryBuilder.ts:5381": [

--- a/packages/grafana-data/src/config.ts
+++ b/packages/grafana-data/src/config.ts
@@ -1,0 +1,11 @@
+import { FeatureToggles } from './types';
+
+let featureToggles: FeatureToggles;
+
+export function setFeatureToggles(newFeatureToggles: FeatureToggles) {
+  featureToggles = newFeatureToggles;
+}
+
+export function getFeatureToggles() {
+  return featureToggles;
+}

--- a/packages/grafana-data/src/config.ts
+++ b/packages/grafana-data/src/config.ts
@@ -7,5 +7,5 @@ export function setFeatureToggles(newFeatureToggles: FeatureToggles) {
 }
 
 export function getFeatureToggles() {
-  return featureToggles;
+  return featureToggles || {};
 }

--- a/packages/grafana-data/src/transformations/matchers/nameMatcher.test.ts
+++ b/packages/grafana-data/src/transformations/matchers/nameMatcher.test.ts
@@ -1,3 +1,4 @@
+import { setFeatureToggles } from '../../config';
 import { toDataFrame } from '../../dataframe/processDataFrame';
 import { FieldType, DataFrame } from '../../types';
 import { getFieldMatcher } from '../matchers';
@@ -5,15 +6,7 @@ import { getFieldMatcher } from '../matchers';
 import { FieldMatcherID } from './ids';
 import { ByNamesMatcherMode } from './nameMatcher';
 
-// mock the default window.grafanaBootData settings
-// eslint-disable-next-line
-(window as any).grafanaBootData = {
-  settings: {
-    featureToggles: {
-      dataplaneFrontendFallback: true,
-    },
-  },
-};
+setFeatureToggles({ dataplaneFrontendFallback: true });
 
 describe('Field Name by Regexp Matcher', () => {
   it('Match all with wildcard regex', () => {

--- a/packages/grafana-data/src/transformations/matchers/nameMatcher.test.ts
+++ b/packages/grafana-data/src/transformations/matchers/nameMatcher.test.ts
@@ -6,7 +6,12 @@ import { getFieldMatcher } from '../matchers';
 import { FieldMatcherID } from './ids';
 import { ByNamesMatcherMode } from './nameMatcher';
 
-setFeatureToggles({ dataplaneFrontendFallback: true });
+beforeAll(() => {
+  setFeatureToggles({ dataplaneFrontendFallback: true });
+});
+afterAll(() => {
+  setFeatureToggles({ dataplaneFrontendFallback: false });
+});
 
 describe('Field Name by Regexp Matcher', () => {
   it('Match all with wildcard regex', () => {

--- a/packages/grafana-data/src/transformations/matchers/nameMatcher.ts
+++ b/packages/grafana-data/src/transformations/matchers/nameMatcher.ts
@@ -1,3 +1,4 @@
+import { getFeatureToggles } from '../../config';
 import { getFieldDisplayName } from '../../field/fieldState';
 import { stringToJsRegex } from '../../text/string';
 import { DataFrame, Field, FieldType, TIME_SERIES_VALUE_FIELD_NAME } from '../../types/dataFrame';
@@ -110,7 +111,7 @@ export function fieldNameFallback(fields: Set<string>) {
   // grafana-data does not have access to runtime so we are accessing the window object
   // to get access to the feature toggle
   // eslint-disable-next-line
-  const useMatcherFallback = (window as any)?.grafanaBootData?.settings?.featureToggles?.dataplaneFrontendFallback;
+  const useMatcherFallback = getFeatureToggles().dataplaneFrontendFallback;
   if (useMatcherFallback) {
     if (fields.has(TIME_SERIES_VALUE_FIELD_NAME)) {
       fallback = (field: Field, frame: DataFrame) => {

--- a/packages/grafana-data/src/transformations/transformers/filterByValue.test.ts
+++ b/packages/grafana-data/src/transformations/transformers/filterByValue.test.ts
@@ -1,3 +1,4 @@
+import { setFeatureToggles } from '../../config';
 import { toDataFrame } from '../../dataframe/processDataFrame';
 import { DataTransformerConfig, FieldType, MatcherConfig } from '../../types';
 import { mockTransformationsRegistry } from '../../utils/tests/mockTransformationsRegistry';
@@ -12,18 +13,6 @@ import {
   FilterByValueType,
 } from './filterByValue';
 import { DataTransformerID } from './ids';
-
-let transformationSupport = false;
-
-jest.mock('./utils', () => {
-  const actual = jest.requireActual('./utils');
-  return {
-    ...actual,
-    transformationsVariableSupport: () => {
-      return transformationSupport;
-    },
-  };
-});
 
 const seriesAWithSingleField = toDataFrame({
   name: 'A',
@@ -40,6 +29,7 @@ describe('FilterByValue transformer', () => {
   });
 
   it('should exclude values', async () => {
+    setFeatureToggles({ dataplaneFrontendFallback: true });
     const lower: MatcherConfig<BasicValueMatcherOptions<number>> = {
       id: ValueMatcherID.lower,
       options: { value: 6 },
@@ -122,7 +112,7 @@ describe('FilterByValue transformer', () => {
   });
 
   it('should interpolate dashboard variables', async () => {
-    transformationSupport = true;
+    setFeatureToggles({ transformationsVariableSupport: true });
 
     const lower: MatcherConfig<BasicValueMatcherOptions<string | number>> = {
       id: ValueMatcherID.lower,
@@ -164,7 +154,7 @@ describe('FilterByValue transformer', () => {
         },
       ]);
     });
-    transformationSupport = false;
+    setFeatureToggles({ transformationsVariableSupport: false });
   });
 
   it('should not interpolate dashboard variables when feature toggle is off', async () => {

--- a/packages/grafana-data/src/transformations/transformers/groupingToMatrix.test.ts
+++ b/packages/grafana-data/src/transformations/transformers/groupingToMatrix.test.ts
@@ -1,3 +1,4 @@
+import { setFeatureToggles } from '../../config';
 import { toDataFrame } from '../../dataframe';
 import { DataTransformerConfig, FieldType, Field, SpecialValue } from '../../types';
 import { mockTransformationsRegistry } from '../../utils/tests/mockTransformationsRegistry';
@@ -8,6 +9,7 @@ import { DataTransformerID } from './ids';
 
 describe('Grouping to Matrix', () => {
   beforeAll(() => {
+    setFeatureToggles({ dataplaneFrontendFallback: false });
     mockTransformationsRegistry([groupingToMatrixTransformer]);
   });
 

--- a/packages/grafana-data/src/transformations/transformers/groupingToMatrix.test.ts
+++ b/packages/grafana-data/src/transformations/transformers/groupingToMatrix.test.ts
@@ -9,7 +9,6 @@ import { DataTransformerID } from './ids';
 
 describe('Grouping to Matrix', () => {
   beforeAll(() => {
-    setFeatureToggles({ dataplaneFrontendFallback: false });
     mockTransformationsRegistry([groupingToMatrixTransformer]);
   });
 

--- a/packages/grafana-data/src/transformations/transformers/groupingToMatrix.ts
+++ b/packages/grafana-data/src/transformations/transformers/groupingToMatrix.ts
@@ -1,5 +1,6 @@
 import { map } from 'rxjs/operators';
 
+import { getFeatureToggles } from '../../config';
 import { getFieldDisplayName } from '../../field/fieldState';
 import {
   DataFrame,
@@ -25,11 +26,6 @@ const DEFAULT_COLUMN_FIELD = 'Time';
 const DEFAULT_ROW_FIELD = 'Time';
 const DEFAULT_VALUE_FIELD = 'Value';
 const DEFAULT_EMPTY_VALUE = SpecialValue.Empty;
-
-// grafana-data does not have access to runtime so we are accessing the window object
-// to get access to the feature toggle
-// eslint-disable-next-line
-const supportDataplaneFallback = (window as any)?.grafanaBootData?.settings?.featureToggles?.dataplaneFrontendFallback;
 
 export const groupingToMatrixTransformer: DataTransformerInfo<GroupingToMatrixTransformerOptions> = {
   id: DataTransformerID.groupingToMatrix,
@@ -123,7 +119,7 @@ export const groupingToMatrixTransformer: DataTransformerInfo<GroupingToMatrixTr
           // the column name based on value fields that are numbers
           // this prevents columns that should be named 1000190
           // from becoming named {__name__: 'metricName'}
-          if (supportDataplaneFallback && typeof columnName === 'number') {
+          if (getFeatureToggles().dataplaneFrontendFallback && typeof columnName === 'number') {
             valueField.config = { ...valueField.config, displayNameFromDS: undefined };
           }
 
@@ -161,7 +157,7 @@ function findKeyField(frame: DataFrame, matchTitle: string): Field | null {
 
     // support for dataplane contract with Prometheus and change in location of field name
     let matches: boolean;
-    if (supportDataplaneFallback) {
+    if (getFeatureToggles().dataplaneFrontendFallback) {
       const matcher = fieldMatchers.get(FieldMatcherID.byName).get(matchTitle);
       matches = matcher(field, frame, [frame]);
     } else {

--- a/packages/grafana-data/src/transformations/transformers/utils.ts
+++ b/packages/grafana-data/src/transformations/transformers/utils.ts
@@ -1,3 +1,6 @@
+import { getFeatureToggles } from '../../config';
+
 export const transformationsVariableSupport = () => {
-  return (window as any)?.grafanaBootData?.settings?.featureToggles?.transformationsVariableSupport;
+  console.log(getFeatureToggles().transformationsVariableSupport);
+  return getFeatureToggles().transformationsVariableSupport;
 };

--- a/packages/grafana-data/src/transformations/transformers/utils.ts
+++ b/packages/grafana-data/src/transformations/transformers/utils.ts
@@ -1,6 +1,5 @@
 import { getFeatureToggles } from '../../config';
 
 export const transformationsVariableSupport = () => {
-  console.log(getFeatureToggles().transformationsVariableSupport);
   return getFeatureToggles().transformationsVariableSupport;
 };

--- a/packages/grafana-runtime/src/config.ts
+++ b/packages/grafana-runtime/src/config.ts
@@ -18,6 +18,7 @@ import {
   getThemeById,
   AngularMeta,
 } from '@grafana/data';
+import { setFeatureToggles } from '@grafana/data/src/config';
 
 export interface AzureSettings {
   cloud?: string;
@@ -264,3 +265,5 @@ options.bootData = bootData;
  * @public
  */
 export const config = new GrafanaBootConfig(options);
+
+setFeatureToggles(config.featureToggles);


### PR DESCRIPTION
**What is this feature?**

Makes feature toggles accessible from grafana-data

**Why do we need this feature?**

We're currently accessing feature toggles in a round about way through the window object, this is an attempt to reduce the hackyness.