### PR TITLE
RBAC: Fix filter so that check for access on service account is correct

### DIFF
--- a/pkg/services/accesscontrol/resourcepermissions/store.go
+++ b/pkg/services/accesscontrol/resourcepermissions/store.go
@@ -393,14 +393,14 @@ func (s *store) getResourcePermissions(sess *db.Session, orgID int64, query GetR
 			return nil, err
 		}
 
-		filter := "(" + userFilter.Where + " AND NOT u.is_service_account)"
+		filter := "((" + userFilter.Where + " AND NOT u.is_service_account)"
 
 		saFilter, err := accesscontrol.Filter(query.User, "u.id", "serviceaccounts:id:", serviceaccounts.ActionRead)
 		if err != nil {
 			return nil, err
 		}
 
-		filter += " OR (" + saFilter.Where + " AND u.is_service_account)"
+		filter += " OR (" + saFilter.Where + " AND u.is_service_account))"
 
 		userQuery += " AND " + filter
 		args = append(args, userFilter.Args...)


### PR DESCRIPTION
**What is this feature?**
In https://github.com/grafana/grafana/pull/78681 I adjusted the filter to perform correct access check on service account. 

I noticed that if a service account have permission on any folder and a user can read it, it gets rendered on all dashboard and folder permissions list. This is just a cosmetic issue, the service account does not have access to them all.

This is because in the query we have a bunch of `AND` conditions but has a `OR` condition for rbac check on service account. 

Query look something like this:
```
   // other filters here
   AND (<check permission on user> AND NOT u.is_service_account)
   OR (<check permission on service account> AND u.is_service_account)
```

But we need to wrap that last bit in parentheses
```
  // other filters here
   AND ((<check permission on user> AND NOT u.is_service_account)
   OR (<check permission on service account> AND u.is_service_account))
```

**Which issue(s) does this PR fix?**:
Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
