### PR TITLE
Timeseries to table transformation: Fix misaligned table field values if some frames are missing a label

### DIFF
--- a/public/app/features/transformers/timeSeriesTable/timeSeriesTableTransformer.test.ts
+++ b/public/app/features/transformers/timeSeriesTable/timeSeriesTableTransformer.test.ts
@@ -216,6 +216,22 @@ describe('timeSeriesTableTransformer', () => {
     expect(results[0].fields[0].values[0].fields[0].values[0]).toBe(10);
     expect(results[0].fields[0].values[0].fields[1].values[0]).toBe(2);
   });
+
+  it('Will correctly fill in gaps in labels', () => {
+    const series = [
+      getTimeSeries('A', { instance: 'A', pod: 'AA' }),
+      getTimeSeries('A', { instance: 'B' }),
+      getTimeSeries('A', { instance: 'C', pod: 'CC' }),
+    ];
+
+    const results = timeSeriesToTableTransform({}, series);
+    expect(results).toHaveLength(1);
+    const result = results[0];
+    expect(result.refId).toBe('A');
+    expect(result.fields).toHaveLength(3);
+    expect(result.fields[0].values).toEqual(['A', 'B', 'C']);
+    expect(result.fields[1].values).toEqual(['AA', '', 'CC']);
+  });
 });
 
 function assertFieldsEqual(field1: Field, field2: Field) {

--- a/public/app/features/transformers/timeSeriesTable/timeSeriesTableTransformer.ts
+++ b/public/app/features/transformers/timeSeriesTable/timeSeriesTableTransformer.ts
@@ -164,7 +164,7 @@ export function timeSeriesToTableTransform(options: TimeSeriesTableTransformerOp
             }
           });
         }
-      })
+      });
     });
 
     for (let i = 0; i < framesForRef.length; i++) {
@@ -222,7 +222,7 @@ export function timeSeriesToTableTransform(options: TimeSeriesTableTransformerOp
         // Because we iterate each frame
         labelNames.forEach((labelName) => {
           refId2labelz[refId][labelName].values.push(field.labels?.[labelName] ?? '');
-        })
+        });
       }
     }
   }

--- a/public/app/features/transformers/timeSeriesTable/timeSeriesTableTransformer.ts
+++ b/public/app/features/transformers/timeSeriesTable/timeSeriesTableTransformer.ts
@@ -143,6 +143,30 @@ export function timeSeriesToTableTransform(options: TimeSeriesTableTransformerOp
     // Intialize object for this refId
     refId2trends[refId] = {};
 
+    // Initialize labels object for this refId
+    refId2labelz[refId] = {};
+
+    // Collect all existing label names across frames
+    // so we can fill in nulls for frames that don't
+    // have a particular label
+    const labelNames: string[] = [];
+
+    framesForRef.forEach((frame) => {
+      frame.fields.forEach((field) => {
+        if (field.type !== FieldType.number) {
+          return;
+        }
+        if (field.labels) {
+          Object.keys(field.labels).forEach((labelName) => {
+            if (!labelNames.includes(labelName)) {
+              refId2labelz[refId][labelName] = newField(labelName, FieldType.string);
+              labelNames.push(labelName);
+            }
+          });
+        }
+      })
+    });
+
     for (let i = 0; i < framesForRef.length; i++) {
       const frame = framesForRef[i];
 
@@ -196,19 +220,9 @@ export function timeSeriesToTableTransform(options: TimeSeriesTableTransformerOp
 
         // If there are labels add them to the appropriate fields
         // Because we iterate each frame
-        if (field.labels !== undefined) {
-          for (const [labelKey, labelValue] of Object.entries(field.labels)) {
-            if (refId2labelz[refId] === undefined) {
-              refId2labelz[refId] = {};
-            }
-
-            if (refId2labelz[refId][labelKey] === undefined) {
-              refId2labelz[refId][labelKey] = newField(labelKey, FieldType.string);
-            }
-
-            refId2labelz[refId][labelKey].values.push(labelValue);
-          }
-        }
+        labelNames.forEach((labelName) => {
+          refId2labelz[refId][labelName].values.push(field.labels?.[labelName] ?? '');
+        })
       }
     }
   }


### PR DESCRIPTION
Hey!

Found a bug with converting frame labels to fields in time series table transform.

When coverting time series frames to a "table" frame,  a field is created for each label and filled with label value from each frame. However if some frame in the middle is missing a particular label, transform would just skipt it and not add an empty value. Thus field values would become misaligned with other fields.

For example if all frames have `name` label but only some frames have `namespace` label, in the resulting table namespaces would become misattributed to wrong names.  Names coming from frames with missing namespace would get attributed namespace from the next frame that has one.

It's probably best to look at the added test to quickly grok the issue :) 



