### PR TITLE
Transformations: Fill array with `undefined` to prevent mismatching length

### DIFF
--- a/public/app/features/transformers/extractFields/extractFields.test.ts
+++ b/public/app/features/transformers/extractFields/extractFields.test.ts
@@ -1,5 +1,14 @@
-import { DataFrame, Field, FieldType } from '@grafana/data';
+import {
+  DataFrame,
+  DataTransformerConfig,
+  DataTransformerID,
+  Field,
+  FieldType,
+  transformDataFrame,
+} from '@grafana/data';
 import { toDataFrame } from '@grafana/data/src/dataframe/processDataFrame';
+import { SortByTransformerOptions, sortByTransformer } from '@grafana/data/src/transformations/transformers/sortBy';
+import { mockTransformationsRegistry } from '@grafana/data/src/utils/tests/mockTransformationsRegistry';
 
 import { extractFieldsTransformer } from './extractFields';
 import { ExtractFieldsOptions, FieldExtractorID } from './types';
@@ -235,10 +244,21 @@ describe('Fields from JSON', () => {
   });
 
   it('works with different value sizes', async () => {
-    const cfg: ExtractFieldsOptions = {
+    const extractConfig: ExtractFieldsOptions = {
       source: 'line',
       replace: false,
     };
+    const sortConfig: DataTransformerConfig<SortByTransformerOptions> = {
+      id: DataTransformerID.sortBy,
+      options: {
+        sort: [
+          {
+            field: 'time',
+          },
+        ],
+      },
+    };
+    mockTransformationsRegistry([sortByTransformer]);
     const ctx = { interpolate: (v: string) => v };
 
     const testDataFrame: DataFrame = {
@@ -249,9 +269,7 @@ describe('Fields from JSON', () => {
       length: 2,
     };
 
-    const frames = extractFieldsTransformer.transformer(cfg, ctx)([testDataFrame]);
-    expect(frames.length).toEqual(1);
-    expect(frames[0]).toEqual({
+    const expected = {
       fields: [
         {
           config: {},
@@ -266,24 +284,78 @@ describe('Fields from JSON', () => {
         {
           config: {},
           name: 'line',
+          state: {
+            displayName: 'line',
+            multipleFrames: false,
+          },
           type: 'other',
           values: ['{"foo":"bar"}', '{"baz":"bar"}'],
         },
         {
           name: 'foo',
+          state: {
+            displayName: 'foo',
+            multipleFrames: false,
+          },
           values: ['bar', undefined],
           type: 'string',
           config: {},
         },
         {
           name: 'baz',
+          state: {
+            displayName: 'baz',
+            multipleFrames: false,
+          },
           values: [undefined, 'bar'],
           type: 'string',
           config: {},
         },
       ],
       length: 2,
+      meta: {
+        transformations: ['sortBy'],
+      },
+    };
+
+    const frames = extractFieldsTransformer.transformer(extractConfig, ctx)([testDataFrame]);
+
+    await expect(transformDataFrame([sortConfig], frames)).toEmitValuesWith((received) => {
+      expect(received[0][0].fields[2]).toMatchInlineSnapshot(`
+        {
+          "config": {},
+          "name": "foo",
+          "state": {
+            "displayName": "foo",
+            "multipleFrames": false,
+          },
+          "type": "string",
+          "values": [
+            "bar",
+            undefined,
+          ],
+        }
+      `);
+
+      expect(received[0][0].fields[3]).toMatchInlineSnapshot(`
+        {
+          "config": {},
+          "name": "baz",
+          "state": {
+            "displayName": "baz",
+            "multipleFrames": false,
+          },
+          "type": "string",
+          "values": [
+            undefined,
+            "bar",
+          ],
+        }
+      `);
     });
+
+    expect(frames.length).toEqual(1);
+    expect(frames[0]).toEqual(expected);
   });
 });
 

--- a/public/app/features/transformers/extractFields/extractFields.test.ts
+++ b/public/app/features/transformers/extractFields/extractFields.test.ts
@@ -233,6 +233,58 @@ describe('Fields from JSON', () => {
       length: 2,
     });
   });
+
+  it('works with different value sizes', async () => {
+    const cfg: ExtractFieldsOptions = {
+      source: 'line',
+      replace: false,
+    };
+    const ctx = { interpolate: (v: string) => v };
+
+    const testDataFrame: DataFrame = {
+      fields: [
+        { config: {}, name: 'Time', type: FieldType.time, values: [1, 2] },
+        { config: {}, name: 'line', type: FieldType.other, values: ['{"foo":"bar"}', '{"baz":"bar"}'] },
+      ],
+      length: 2,
+    };
+
+    const frames = extractFieldsTransformer.transformer(cfg, ctx)([testDataFrame]);
+    expect(frames.length).toEqual(1);
+    expect(frames[0]).toEqual({
+      fields: [
+        {
+          config: {},
+          name: 'Time',
+          type: 'time',
+          values: [1, 2],
+          state: {
+            displayName: 'Time',
+            multipleFrames: false,
+          },
+        },
+        {
+          config: {},
+          name: 'line',
+          type: 'other',
+          values: ['{"foo":"bar"}', '{"baz":"bar"}'],
+        },
+        {
+          name: 'foo',
+          values: ['bar', undefined],
+          type: 'string',
+          config: {},
+        },
+        {
+          name: 'baz',
+          values: [undefined, 'bar'],
+          type: 'string',
+          config: {},
+        },
+      ],
+      length: 2,
+    });
+  });
 });
 
 const testFieldTime: Field = {

--- a/public/app/features/transformers/extractFields/extractFields.ts
+++ b/public/app/features/transformers/extractFields/extractFields.ts
@@ -86,7 +86,7 @@ export function addExtractedFields(frame: DataFrame, options: ExtractFieldsOptio
     for (const [key, val] of Object.entries(obj)) {
       let buffer = values.get(key);
       if (buffer == null) {
-        buffer = new Array(count);
+        buffer = new Array(count).fill(undefined);
         values.set(key, buffer);
         names.push(key);
       }


### PR DESCRIPTION
**What is this feature?**

We recently added a table visualisation for logs in Explore. Data frames are sorted with the [`sortDataFrame` method](https://github.com/grafana/grafana/blob/main/packages/grafana-data/src/dataframe/processDataFrame.ts#L441). That  method maps values based on their index. We also use an `extractFields` transformation before we sort the data frame. 

This can be seen in action here: https://ops.grafana-ops.net/goto/M46f7-NIR?orgId=1

The `b` column should show a value, but unfortunately is not. 

What we do here is the following:
1. We extract the `labels` field with a `JSON` type.
2. The `extractFields` transformation sets the length of the new field's `values` array to the total length of the data frame, in this case `3`.
3. Since `b` is only present in one row, only 1 value will be pushed into the new field's `values` array. This leaves the array with a length of 3, but only 1 item present:
![image](https://github.com/grafana/grafana/assets/8092184/f74d4448-be90-4dc5-b6a9-88a44239a677)
4. This will cause issues for the `sortDataFrame` method and lead to an empty array.

This PR just fills every extracted field with `undefined` values, in order to guarantee the correct length of a field. However, I think, jest is handling those arrays with mismatched length a bit differently than the browser is. That leads to the point, that the fest will also work without the `fill(undefined)` call.