### PR TITLE
[v9.4.x] Alerting: Fixes combination of multiple predicates for rule search

### DIFF
--- a/public/app/features/alerting/unified/hooks/useFilteredRules.test.ts
+++ b/public/app/features/alerting/unified/hooks/useFilteredRules.test.ts
@@ -160,4 +160,38 @@ describe('filterRules', function () {
     expect(filtered[0].groups[0].rules).toHaveLength(1);
     expect(filtered[0].groups[0].rules[0].name).toBe('Memory too low');
   });
+
+  it('should be able to combine multiple predicates with AND', () => {
+    const rules = [
+      mockCombinedRule({
+        name: 'Memory too low',
+        labels: { team: 'operations', region: 'EMEA' },
+        promRule: mockPromAlertingRule({
+          health: RuleHealth.Ok,
+        }),
+      }),
+      mockCombinedRule({
+        name: 'Memory too low',
+        labels: { team: 'operations', region: 'NASA' },
+        promRule: mockPromAlertingRule({
+          health: RuleHealth.Ok,
+        }),
+      }),
+    ];
+
+    const ns = mockCombinedRuleNamespace({
+      groups: [mockCombinedRuleGroup('Resources usage group', rules)],
+    });
+
+    const filtered = filterRules(
+      [ns],
+      getFilter({
+        ruleHealth: RuleHealth.Ok,
+        labels: ['team=operations', 'region=EMEA'],
+      })
+    );
+
+    expect(filtered[0]?.groups[0]?.rules).toHaveLength(1);
+    expect(filtered[0]?.groups[0]?.rules[0]?.name).toBe('Memory too low');
+  });
 });

--- a/public/app/features/alerting/unified/hooks/useFilteredRules.ts
+++ b/public/app/features/alerting/unified/hooks/useFilteredRules.ts
@@ -140,7 +140,7 @@ const reduceGroups = (filterState: RulesFilter) => {
         }
       }
 
-      if ('ruleName' in matchesFilterFor) {
+      if ('ruleName' in matchesFilterFor && filterState.ruleName) {
         const hasMatch = rule.name?.toLocaleLowerCase().includes(filterState.ruleName.toLocaleLowerCase());
         if (hasMatch) {
           matchesFilterFor.ruleName = true;


### PR DESCRIPTION
Backport 7ccdea6f6778eb29ccd92b0bf88f953ab3e90355 from #78910

---

**What is this feature?**

This PR fixes a bug where we were not properly combining / checking for multiple predicates in the alert rule search.

The following search query would not return the correct set of results – it would appear to be using an `OR` instead of an `AND`.

`health:error label:foo=bar`

This would previously return a set of rules that had _either_ the `health: error` property _or_ the `foo=bar` label.

With the fix in this PR it would correctly filter the result set.

**Special notes for your reviewer:**

Includes a regression test for a rather simple combination.
