### PR TITLE
Alerting: Hide error messages for failing HTTP calls to Grafana OnCall

### DIFF
--- a/public/app/features/alerting/unified/api/onCallApi.ts
+++ b/public/app/features/alerting/unified/api/onCallApi.ts
@@ -43,6 +43,7 @@ export const onCallApi = alertingApi.injectEndpoints({
         // legacy_grafana_alerting is necessary for OnCall.
         // We do NOT need to differentiate between these two on our side
         params: { filters: true, integration: [GRAFANA_ONCALL_INTEGRATION_TYPE, 'legacy_grafana_alerting'] },
+        showErrorAlert: false,
       }),
       transformResponse: (response: AlertReceiveChannelsResult) => {
         if (isPaginatedResponse(response)) {
@@ -71,6 +72,7 @@ export const onCallApi = alertingApi.injectEndpoints({
     features: build.query<OnCallFeature[], void>({
       query: () => ({
         url: getProxyApiUrl('/api/internal/v1/features/'),
+        showErrorAlert: false,
       }),
     }),
   }),


### PR DESCRIPTION
**What is this feature?**

This PR will hide error alerts from the OnCall HTTP API when trying to find matching integrations.
Since the plugin bridge will treat these as "not installed" it's unnecessary to inform the user with the failed HTTP response.