### PR TITLE
Alerting: Change create/update permissions for silences

### DIFF
--- a/public/app/features/alerting/unified/hooks/__snapshots__/useAbilities.test.tsx.snap
+++ b/public/app/features/alerting/unified/hooks/__snapshots__/useAbilities.test.tsx.snap
@@ -19,7 +19,7 @@ exports[`alertmanager abilities should report Create / Update / Delete actions a
     false,
   ],
   "create-silence": [
-    false,
+    true,
     false,
   ],
   "decrypt-secrets": [
@@ -71,7 +71,7 @@ exports[`alertmanager abilities should report Create / Update / Delete actions a
     false,
   ],
   "update-silence": [
-    false,
+    true,
     false,
   ],
   "view-contact-point": [

--- a/public/app/features/alerting/unified/hooks/useAbilities.ts
+++ b/public/app/features/alerting/unified/hooks/useAbilities.ts
@@ -226,6 +226,7 @@ export function useAllAlertmanagerAbilities(): Abilities<AlertmanagerAction> {
       notificationsPermissions.provisioning.readSecrets
     ),
     // -- silences --
+    // for now, all supported Alertmanager flavors have API endpoints for managing silences
     [AlertmanagerAction.CreateSilence]: toAbility(AlwaysSupported, instancePermissions.create),
     [AlertmanagerAction.ViewSilence]: toAbility(AlwaysSupported, instancePermissions.read),
     [AlertmanagerAction.UpdateSilence]: toAbility(AlwaysSupported, instancePermissions.update),

--- a/public/app/features/alerting/unified/hooks/useAbilities.ts
+++ b/public/app/features/alerting/unified/hooks/useAbilities.ts
@@ -226,9 +226,9 @@ export function useAllAlertmanagerAbilities(): Abilities<AlertmanagerAction> {
       notificationsPermissions.provisioning.readSecrets
     ),
     // -- silences --
-    [AlertmanagerAction.CreateSilence]: toAbility(hasConfigurationAPI, instancePermissions.create),
+    [AlertmanagerAction.CreateSilence]: toAbility(AlwaysSupported, instancePermissions.create),
     [AlertmanagerAction.ViewSilence]: toAbility(AlwaysSupported, instancePermissions.read),
-    [AlertmanagerAction.UpdateSilence]: toAbility(hasConfigurationAPI, instancePermissions.update),
+    [AlertmanagerAction.UpdateSilence]: toAbility(AlwaysSupported, instancePermissions.update),
     // -- mute timtings --
     [AlertmanagerAction.CreateMuteTiming]: toAbility(hasConfigurationAPI, notificationsPermissions.create),
     [AlertmanagerAction.ViewMuteTiming]: toAbility(AlwaysSupported, notificationsPermissions.read),


### PR DESCRIPTION
**What is this feature?**

Changes the required permissions for creating and editing of silences as actually all flavors of Alertmanager support it.

**Why do we need this feature?**

Users were unable to edit silences for Prometheus Alertmanager.

Fixes https://github.com/grafana/grafana/issues/78509