### PR TITLE
docs: Reword shortened link expiration explainer

### DIFF
--- a/docs/sources/explore/_index.md
+++ b/docs/sources/explore/_index.md
@@ -133,4 +133,6 @@ The `from` and `to` also accept relative ranges defined in [Time units and relat
 Available in Grafana 7.3 and later versions.
 {{% /admonition %}}
 
-The Share shortened link capability allows you to create smaller and simpler URLs of the format /goto/:uid instead of using longer URLs with query parameters. To create a shortened link to the executed query, click the **Share** option in the Explore toolbar. A shortened link that is never used will automatically get deleted after seven (7) days.
+The Share shortened link capability allows you to create smaller and simpler URLs of the format /goto/:uid instead of using longer URLs with query parameters. To create a shortened link to the executed query, click the **Share** option in the Explore toolbar.
+
+A shortened link will automatically get deleted after seven (7) days from its creation if it's never used. If a link is used at least once, it won't ever get deleted.


### PR DESCRIPTION
Rewords the shortlink explainer in Explore docs to make it clearer when links gets deleted.