### PR TITLE
Alerting: Decouple quota configuration logic from API interfaces and add tests

### DIFF
--- a/pkg/services/ngalert/api/api.go
+++ b/pkg/services/ngalert/api/api.go
@@ -148,34 +148,3 @@ func (api *API) RegisterAPIEndpoints(m *metrics.API) {
 		hist:   api.Historian,
 	}), m)
 }
-
-func (api *API) Usage(ctx context.Context, scopeParams *quota.ScopeParameters) (*quota.Map, error) {
-	u := &quota.Map{}
-
-	var orgID int64 = 0
-	if scopeParams != nil {
-		orgID = scopeParams.OrgID
-	}
-
-	if orgUsage, err := api.RuleStore.Count(ctx, orgID); err != nil {
-		return u, err
-	} else {
-		tag, err := quota.NewTag(models.QuotaTargetSrv, models.QuotaTarget, quota.OrgScope)
-		if err != nil {
-			return u, err
-		}
-		u.Set(tag, orgUsage)
-	}
-
-	if globalUsage, err := api.RuleStore.Count(ctx, 0); err != nil {
-		return u, err
-	} else {
-		tag, err := quota.NewTag(models.QuotaTargetSrv, models.QuotaTarget, quota.GlobalScope)
-		if err != nil {
-			return u, err
-		}
-		u.Set(tag, globalUsage)
-	}
-
-	return u, nil
-}

--- a/pkg/services/ngalert/api/limits.go
+++ b/pkg/services/ngalert/api/limits.go
@@ -5,7 +5,21 @@ import (
 
 	"github.com/grafana/grafana/pkg/services/ngalert/models"
 	"github.com/grafana/grafana/pkg/services/quota"
+	"github.com/grafana/grafana/pkg/setting"
 )
+
+func RegisterQuotas(cfg *setting.Cfg, qs quota.Service, rules RuleStore) error {
+	defaultLimits, err := readQuotaConfig(cfg)
+	if err != nil {
+		return err
+	}
+
+	return qs.RegisterQuotaReporter(&quota.NewUsageReporter{
+		TargetSrv:     models.QuotaTargetSrv,
+		DefaultLimits: defaultLimits,
+		Reporter:      UsageReporter(rules),
+	})
+}
 
 func UsageReporter(store RuleStore) quota.UsageReporterFunc {
 	return func(ctx context.Context, scopeParams *quota.ScopeParameters) (*quota.Map, error) {
@@ -38,4 +52,33 @@ func UsageReporter(store RuleStore) quota.UsageReporterFunc {
 
 		return u, nil
 	}
+}
+
+func readQuotaConfig(cfg *setting.Cfg) (*quota.Map, error) {
+	limits := &quota.Map{}
+
+	if cfg == nil {
+		return limits, nil
+	}
+
+	var alertOrgQuota int64
+	var alertGlobalQuota int64
+
+	if cfg.UnifiedAlerting.IsEnabled() {
+		alertOrgQuota = cfg.Quota.Org.AlertRule
+		alertGlobalQuota = cfg.Quota.Global.AlertRule
+	}
+
+	globalQuotaTag, err := quota.NewTag(models.QuotaTargetSrv, models.QuotaTarget, quota.GlobalScope)
+	if err != nil {
+		return limits, err
+	}
+	orgQuotaTag, err := quota.NewTag(models.QuotaTargetSrv, models.QuotaTarget, quota.OrgScope)
+	if err != nil {
+		return limits, err
+	}
+
+	limits.Set(globalQuotaTag, alertGlobalQuota)
+	limits.Set(orgQuotaTag, alertOrgQuota)
+	return limits, nil
 }

--- a/pkg/services/ngalert/api/limits.go
+++ b/pkg/services/ngalert/api/limits.go
@@ -1,0 +1,41 @@
+package api
+
+import (
+	"context"
+
+	"github.com/grafana/grafana/pkg/services/ngalert/models"
+	"github.com/grafana/grafana/pkg/services/quota"
+)
+
+func UsageReporter(store RuleStore) quota.UsageReporterFunc {
+	return func(ctx context.Context, scopeParams *quota.ScopeParameters) (*quota.Map, error) {
+		u := &quota.Map{}
+
+		var orgID int64 = 0
+		if scopeParams != nil {
+			orgID = scopeParams.OrgID
+		}
+
+		if orgUsage, err := store.Count(ctx, orgID); err != nil {
+			return u, err
+		} else {
+			tag, err := quota.NewTag(models.QuotaTargetSrv, models.QuotaTarget, quota.OrgScope)
+			if err != nil {
+				return u, err
+			}
+			u.Set(tag, orgUsage)
+		}
+
+		if globalUsage, err := store.Count(ctx, 0); err != nil {
+			return u, err
+		} else {
+			tag, err := quota.NewTag(models.QuotaTargetSrv, models.QuotaTarget, quota.GlobalScope)
+			if err != nil {
+				return u, err
+			}
+			u.Set(tag, globalUsage)
+		}
+
+		return u, nil
+	}
+}

--- a/pkg/services/ngalert/api/persist.go
+++ b/pkg/services/ngalert/api/persist.go
@@ -24,6 +24,4 @@ type RuleStore interface {
 
 	// IncreaseVersionForAllRulesInNamespace Increases version for all rules that have specified namespace. Returns all rules that belong to the namespace
 	IncreaseVersionForAllRulesInNamespace(ctx context.Context, orgID int64, namespaceUID string) ([]ngmodels.AlertRuleKeyWithVersionAndPauseStatus, error)
-
-	Count(ctx context.Context, orgID int64) (int64, error)
 }

--- a/pkg/services/ngalert/limits.go
+++ b/pkg/services/ngalert/limits.go
@@ -1,4 +1,4 @@
-package api
+package ngalert
 
 import (
 	"context"

--- a/pkg/services/ngalert/limits_test.go
+++ b/pkg/services/ngalert/limits_test.go
@@ -1,0 +1,114 @@
+package ngalert
+
+import (
+	"context"
+	"testing"
+
+	"github.com/grafana/grafana/pkg/services/ngalert/models"
+	"github.com/grafana/grafana/pkg/services/quota"
+	"github.com/grafana/grafana/pkg/setting"
+	"github.com/stretchr/testify/require"
+)
+
+func TestUsageReporter(t *testing.T) {
+
+	t.Run("reports org usage", func(t *testing.T) {
+		rules := newFakeUsageReader(map[int64]int64{1: 10, 2: 20})
+		params := quota.ScopeParameters{
+			OrgID: 1,
+		}
+
+		res, err := UsageReporter(rules)(context.Background(), &params)
+
+		require.NoError(t, err)
+		rulesOrg, _ := quota.NewTag(models.QuotaTargetSrv, models.QuotaTarget, quota.OrgScope)
+		val, ok := res.Get(rulesOrg)
+		require.True(t, ok, "reporter did not report on org 1 rules usage")
+		require.Equal(t, int64(10), val)
+	})
+
+	t.Run("reports global usage", func(t *testing.T) {
+		rules := newFakeUsageReader(map[int64]int64{1: 10, 2: 20})
+		params := quota.ScopeParameters{
+			OrgID: 1,
+		}
+
+		res, err := UsageReporter(rules)(context.Background(), &params)
+
+		require.NoError(t, err)
+		rulesGlobal, _ := quota.NewTag(models.QuotaTargetSrv, models.QuotaTarget, quota.GlobalScope)
+		val, ok := res.Get(rulesGlobal)
+		require.True(t, ok, "reporter did not report on global rules usage")
+		require.Equal(t, int64(30), val)
+	})
+
+	t.Run("reports global usage if scope params are nil", func(t *testing.T) {
+		rules := newFakeUsageReader(map[int64]int64{1: 10, 2: 20})
+
+		res, err := UsageReporter(rules)(context.Background(), nil)
+
+		require.NoError(t, err)
+		rulesGlobal, _ := quota.NewTag(models.QuotaTargetSrv, models.QuotaTarget, quota.GlobalScope)
+		val, ok := res.Get(rulesGlobal)
+		require.True(t, ok, "reporter did not report on global rules usage")
+		require.Equal(t, int64(30), val)
+	})
+}
+
+func TestReadQuotaConfig(t *testing.T) {
+	cfg := &setting.Cfg{
+		Quota: setting.QuotaSettings{
+			Org: setting.OrgQuota{
+				AlertRule: 30,
+			},
+			Global: setting.GlobalQuota{
+				AlertRule: 50,
+			},
+		},
+	}
+
+	t.Run("registers per-org rule quota from config", func(t *testing.T) {
+		res, err := readQuotaConfig(cfg)
+
+		require.NoError(t, err)
+		rulesOrg, _ := quota.NewTag(models.QuotaTargetSrv, models.QuotaTarget, quota.OrgScope)
+		val, ok := res.Get(rulesOrg)
+		require.True(t, ok, "did not configure per-org rules quota")
+		require.Equal(t, int64(30), val)
+	})
+
+	t.Run("registers global rule quota from config", func(t *testing.T) {
+		res, err := readQuotaConfig(cfg)
+
+		require.NoError(t, err)
+		rulesGlobal, _ := quota.NewTag(models.QuotaTargetSrv, models.QuotaTarget, quota.GlobalScope)
+		val, ok := res.Get(rulesGlobal)
+		require.True(t, ok, "did not configure global rules quota")
+		require.Equal(t, int64(50), val)
+	})
+}
+
+type fakeUsageReader struct {
+	usage map[int64]int64 // orgID -> count
+}
+
+func newFakeUsageReader(usage map[int64]int64) fakeUsageReader {
+	return fakeUsageReader{
+		usage: usage,
+	}
+}
+
+func (f fakeUsageReader) Count(_ context.Context, orgID int64) (int64, error) {
+	if orgID == 0 {
+		total := int64(0)
+		for _, count := range f.usage {
+			total += count
+		}
+		return total, nil
+	}
+
+	if c, ok := f.usage[orgID]; ok {
+		return c, nil
+	}
+	return 0, nil
+}

--- a/pkg/services/ngalert/limits_test.go
+++ b/pkg/services/ngalert/limits_test.go
@@ -11,7 +11,6 @@ import (
 )
 
 func TestUsageReporter(t *testing.T) {
-
 	t.Run("reports org usage", func(t *testing.T) {
 		rules := newFakeUsageReader(map[int64]int64{1: 10, 2: 20})
 		params := quota.ScopeParameters{

--- a/pkg/services/ngalert/ngalert.go
+++ b/pkg/services/ngalert/ngalert.go
@@ -304,7 +304,7 @@ func (ng *AlertNG) init() error {
 	}
 	ng.api.RegisterAPIEndpoints(ng.Metrics.GetAPIMetrics())
 
-	if err := api.RegisterQuotas(ng.Cfg, ng.QuotaService, ng.api.RuleStore); err != nil {
+	if err := api.RegisterQuotas(ng.Cfg, ng.QuotaService, ng.store); err != nil {
 		return err
 	}
 

--- a/pkg/services/ngalert/ngalert.go
+++ b/pkg/services/ngalert/ngalert.go
@@ -312,7 +312,7 @@ func (ng *AlertNG) init() error {
 	if err := ng.QuotaService.RegisterQuotaReporter(&quota.NewUsageReporter{
 		TargetSrv:     models.QuotaTargetSrv,
 		DefaultLimits: defaultLimits,
-		Reporter:      ng.api.Usage,
+		Reporter:      api.UsageReporter(ng.api.RuleStore),
 	}); err != nil {
 		return err
 	}

--- a/pkg/services/ngalert/ngalert.go
+++ b/pkg/services/ngalert/ngalert.go
@@ -304,16 +304,7 @@ func (ng *AlertNG) init() error {
 	}
 	ng.api.RegisterAPIEndpoints(ng.Metrics.GetAPIMetrics())
 
-	defaultLimits, err := readQuotaConfig(ng.Cfg)
-	if err != nil {
-		return err
-	}
-
-	if err := ng.QuotaService.RegisterQuotaReporter(&quota.NewUsageReporter{
-		TargetSrv:     models.QuotaTargetSrv,
-		DefaultLimits: defaultLimits,
-		Reporter:      api.UsageReporter(ng.api.RuleStore),
-	}); err != nil {
+	if err := api.RegisterQuotas(ng.Cfg, ng.QuotaService, ng.api.RuleStore); err != nil {
 		return err
 	}
 
@@ -382,35 +373,6 @@ func (ng *AlertNG) IsDisabled() bool {
 // is invoked after all other middleware is invoked (authentication, instrumentation).
 func (ng *AlertNG) GetHooks() *api.Hooks {
 	return ng.api.Hooks
-}
-
-func readQuotaConfig(cfg *setting.Cfg) (*quota.Map, error) {
-	limits := &quota.Map{}
-
-	if cfg == nil {
-		return limits, nil
-	}
-
-	var alertOrgQuota int64
-	var alertGlobalQuota int64
-
-	if cfg.UnifiedAlerting.IsEnabled() {
-		alertOrgQuota = cfg.Quota.Org.AlertRule
-		alertGlobalQuota = cfg.Quota.Global.AlertRule
-	}
-
-	globalQuotaTag, err := quota.NewTag(models.QuotaTargetSrv, models.QuotaTarget, quota.GlobalScope)
-	if err != nil {
-		return limits, err
-	}
-	orgQuotaTag, err := quota.NewTag(models.QuotaTargetSrv, models.QuotaTarget, quota.OrgScope)
-	if err != nil {
-		return limits, err
-	}
-
-	limits.Set(globalQuotaTag, alertGlobalQuota)
-	limits.Set(orgQuotaTag, alertOrgQuota)
-	return limits, nil
 }
 
 type Historian interface {

--- a/pkg/services/ngalert/ngalert.go
+++ b/pkg/services/ngalert/ngalert.go
@@ -304,7 +304,7 @@ func (ng *AlertNG) init() error {
 	}
 	ng.api.RegisterAPIEndpoints(ng.Metrics.GetAPIMetrics())
 
-	if err := api.RegisterQuotas(ng.Cfg, ng.QuotaService, ng.store); err != nil {
+	if err := RegisterQuotas(ng.Cfg, ng.QuotaService, ng.store); err != nil {
 		return err
 	}
 

--- a/pkg/services/ngalert/tests/fakes/rules.go
+++ b/pkg/services/ngalert/tests/fakes/rules.go
@@ -344,10 +344,6 @@ func (f *RuleStore) IncreaseVersionForAllRulesInNamespace(_ context.Context, org
 	return result, nil
 }
 
-func (f *RuleStore) Count(ctx context.Context, orgID int64) (int64, error) {
-	return 0, nil
-}
-
 func (f *RuleStore) CountInFolder(ctx context.Context, orgID int64, folderUID string, u identity.Requester) (int64, error) {
 	return 0, nil
 }


### PR DESCRIPTION
**What is this feature?**

The logic to report usage on quotas was part of the API package, so it depended on the API-layer rule stores and brings along a lot of baggage. This PR puts all the quota configuration in one place, and introduces a newer, smaller interface for it. 

**Why do we need this feature?**

This reduces coupling, makes the quota code more testable, and making it easier to add future database queries for quota usage to the store without affecting the API layer.

Now that it's easier to test with a tiny fake, this PR also adds tests.

**Which issue(s) does this PR fix?**:

n/a

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle.
- [x] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
