### PR TITLE
Alerting: Fix max data points placeholder rendering decimals

### DIFF
--- a/public/app/features/alerting/unified/components/rule-editor/QueryWrapper.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/QueryWrapper.tsx
@@ -213,7 +213,7 @@ export function MaxDataPointsOption({
       <Input
         type="number"
         width={10}
-        placeholder={DEFAULT_MAX_DATA_POINTS.toLocaleString()}
+        placeholder={DEFAULT_MAX_DATA_POINTS.toString()}
         spellCheck={false}
         onBlur={onMaxDataPointsBlur}
         defaultValue={value}


### PR DESCRIPTION
**What is this feature?**

This PR fixes max-datapoints rendering decimals in the placeholder.


Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
