### PR TITLE
Fix: Use dashboard time range in prometheus variable editor

### DIFF
--- a/public/app/plugins/datasource/prometheus/components/VariableQueryEditor.test.tsx
+++ b/public/app/plugins/datasource/prometheus/components/VariableQueryEditor.test.tsx
@@ -3,6 +3,8 @@ import userEvent from '@testing-library/user-event';
 import React from 'react';
 import { selectOptionInTest } from 'test/helpers/selectOptionInTest';
 
+import { dateTime, TimeRange } from '@grafana/data';
+
 import { PrometheusDatasource } from '../datasource';
 import PrometheusLanguageProvider from '../language_provider';
 import { migrateVariableEditorBackToVariableSupport } from '../migrations/variableMigration';
@@ -367,5 +369,25 @@ describe('PromVariableQueryEditor', () => {
       refId,
       qryType: 5,
     });
+  });
+
+  test('Calls language provider with the time range received in props', async () => {
+    const now = dateTime('2023-09-16T21:26:00Z');
+    const range: TimeRange = {
+      from: dateTime(now).subtract(2, 'days'),
+      to: now,
+      raw: {
+        from: 'now-2d',
+        to: 'now',
+      },
+    };
+    props.range = range;
+
+    const languageProviderStartMock = jest.fn();
+    props.datasource.languageProvider.start = languageProviderStartMock;
+
+    render(<PromVariableQueryEditor {...props} />);
+
+    expect(languageProviderStartMock).toHaveBeenCalledWith(range);
   });
 });

--- a/public/app/plugins/datasource/prometheus/components/VariableQueryEditor.tsx
+++ b/public/app/plugins/datasource/prometheus/components/VariableQueryEditor.tsx
@@ -33,7 +33,7 @@ export type Props = QueryEditorProps<PrometheusDatasource, PromQuery, PromOption
 
 const refId = 'PrometheusVariableQueryEditor-VariableQuery';
 
-export const PromVariableQueryEditor = ({ onChange, query, datasource }: Props) => {
+export const PromVariableQueryEditor = ({ onChange, query, datasource, range }: Props) => {
   // to select the query type, i.e. label_names, label_values, etc.
   const [qryType, setQryType] = useState<number | undefined>(undefined);
   // list of variables for each function
@@ -58,6 +58,10 @@ export const PromVariableQueryEditor = ({ onChange, query, datasource }: Props) 
 
   // label filters have been added as a filter for metrics in label values query type
   const [labelFilters, setLabelFilters] = useState<QueryBuilderLabelFilter[]>([]);
+
+  useEffect(() => {
+    datasource.languageProvider.start(range);
+  }, [datasource.languageProvider, range]);
 
   useEffect(() => {
     if (!query) {


### PR DESCRIPTION
**What is this feature?**

While using a non-default time range on a Prometheus dashboard, variable editor queries always end up being queries with the default time range. This was happening because 'languageProvider` had never received the time range. This PR makes sure `languageProvider` receives the right time range always.

**Why do we need this feature?**

A better variable support in Prometheus

**Who is this feature for?**

Prometheus users

**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/grafana/issues/78947

**Special notes for your reviewer:**

### How to test
- Create a Prometheus dashboard
- Set the time range as a non-default value like the `last 2 days`
- Go to settings and add a new variable
- Select label values type and select the metric
- In the network tab observe that the label query payload
  - `end - start` is 6h which is the default time range
- Switch to this branch and try again
- Observe that the queries have the right time range

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
