### PR TITLE
SharedQueryDataProvider: Support __interval[_ms] macro

### DIFF
--- a/package.json
+++ b/package.json
@@ -255,7 +255,7 @@
     "@grafana/lezer-traceql": "0.0.11",
     "@grafana/monaco-logql": "^0.0.7",
     "@grafana/runtime": "workspace:*",
-    "@grafana/scenes": "portal:/Users/dominik/Projects/grafana-scenes/packages/scenes",
+    "@grafana/scenes": "1.25.0",
     "@grafana/schema": "workspace:*",
     "@grafana/ui": "workspace:*",
     "@kusto/monaco-kusto": "^7.4.0",

--- a/package.json
+++ b/package.json
@@ -255,7 +255,7 @@
     "@grafana/lezer-traceql": "0.0.11",
     "@grafana/monaco-logql": "^0.0.7",
     "@grafana/runtime": "workspace:*",
-    "@grafana/scenes": "^1.24.6",
+    "@grafana/scenes": "portal:/Users/dominik/Projects/grafana-scenes/packages/scenes",
     "@grafana/schema": "workspace:*",
     "@grafana/ui": "workspace:*",
     "@kusto/monaco-kusto": "^7.4.0",

--- a/public/app/features/dashboard-scene/scene/ShareQueryDataProvider.ts
+++ b/public/app/features/dashboard-scene/scene/ShareQueryDataProvider.ts
@@ -120,6 +120,13 @@ export class ShareQueryDataProvider extends SceneObjectBase<ShareQueryDataProvid
     }
     return false;
   }
+
+  public getInterval() {
+    if (this._sourceProvider && this._sourceProvider.getInterval) {
+      return this._sourceProvider.getInterval();
+    }
+    return { interval: '1s', intervalMs: 1000 };
+  }
 }
 
 export function findObjectInScene(scene: SceneObject, check: (scene: SceneObject) => boolean): SceneObject | null {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3302,9 +3302,9 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@grafana/scenes@portal:/Users/dominik/Projects/grafana-scenes/packages/scenes::locator=grafana%40workspace%3A.":
-  version: 0.0.0-use.local
-  resolution: "@grafana/scenes@portal:/Users/dominik/Projects/grafana-scenes/packages/scenes::locator=grafana%40workspace%3A."
+"@grafana/scenes@npm:1.25.0":
+  version: 1.25.0
+  resolution: "@grafana/scenes@npm:1.25.0"
   dependencies:
     "@grafana/e2e-selectors": "npm:10.0.2"
     react-grid-layout: "npm:1.3.4"
@@ -3316,8 +3316,9 @@ __metadata:
     "@grafana/runtime": 10.0.3
     "@grafana/schema": 10.0.3
     "@grafana/ui": 10.0.3
+  checksum: 665d3625aa0af2fdf0b2b02f2b650277d2ff6f531357b0419dab2eab5fb73601787389d5886450bd95e6388f6c89cee9c8db33970f549d309709838675912f64
   languageName: node
-  linkType: soft
+  linkType: hard
 
 "@grafana/schema@npm:10.3.0-pre, @grafana/schema@workspace:*, @grafana/schema@workspace:packages/grafana-schema":
   version: 0.0.0-use.local
@@ -17313,7 +17314,7 @@ __metadata:
     "@grafana/lezer-traceql": "npm:0.0.11"
     "@grafana/monaco-logql": "npm:^0.0.7"
     "@grafana/runtime": "workspace:*"
-    "@grafana/scenes": "portal:/Users/dominik/Projects/grafana-scenes/packages/scenes"
+    "@grafana/scenes": "npm:1.25.0"
     "@grafana/schema": "workspace:*"
     "@grafana/tsconfig": "npm:^1.3.0-rc1"
     "@grafana/ui": "workspace:*"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3302,9 +3302,9 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@grafana/scenes@npm:^1.24.6":
-  version: 1.24.6
-  resolution: "@grafana/scenes@npm:1.24.6"
+"@grafana/scenes@portal:/Users/dominik/Projects/grafana-scenes/packages/scenes::locator=grafana%40workspace%3A.":
+  version: 0.0.0-use.local
+  resolution: "@grafana/scenes@portal:/Users/dominik/Projects/grafana-scenes/packages/scenes::locator=grafana%40workspace%3A."
   dependencies:
     "@grafana/e2e-selectors": "npm:10.0.2"
     react-grid-layout: "npm:1.3.4"
@@ -3316,9 +3316,8 @@ __metadata:
     "@grafana/runtime": 10.0.3
     "@grafana/schema": 10.0.3
     "@grafana/ui": 10.0.3
-  checksum: 71df3f23f2a9083643ff2344960c01bcd87e7ff8c0802c8074e11d2b1acc9b99c0a6a3239c75db47b2507493beb83374dca4e02787b486d45f4dcbd5400a4055
   languageName: node
-  linkType: hard
+  linkType: soft
 
 "@grafana/schema@npm:10.3.0-pre, @grafana/schema@workspace:*, @grafana/schema@workspace:packages/grafana-schema":
   version: 0.0.0-use.local
@@ -17314,7 +17313,7 @@ __metadata:
     "@grafana/lezer-traceql": "npm:0.0.11"
     "@grafana/monaco-logql": "npm:^0.0.7"
     "@grafana/runtime": "workspace:*"
-    "@grafana/scenes": "npm:^1.24.6"
+    "@grafana/scenes": "portal:/Users/dominik/Projects/grafana-scenes/packages/scenes"
     "@grafana/schema": "workspace:*"
     "@grafana/tsconfig": "npm:^1.3.0-rc1"
     "@grafana/ui": "workspace:*"


### PR DESCRIPTION
This PR allows `$__interval[_ms]` variable interpolation in panels using Dashboard query. This is NOT possible in the old architecture.

Ref scenes PR https://github.com/grafana/scenes/pull/487