### PR TITLE
Logs: Hide filters for derived fields in table viz

### DIFF
--- a/public/app/features/explore/Logs/LogsTable.tsx
+++ b/public/app/features/explore/Logs/LogsTable.tsx
@@ -176,7 +176,9 @@ const isFieldFilterable = (field: Field, logsFrame?: LogsFrame | undefined) => {
   if (logsFrame.timeField.name === field.name) {
     return false;
   }
-  // @todo not currently excluding derived fields from filtering
+  if (field.config.links?.length) {
+    return false;
+  }
 
   return true;
 };


### PR DESCRIPTION
**What is this feature?**

This PR hides the filter buttons from derived fields in the logs table in Explore.
