### PR TITLE
CloudWatch: Correctly quote metric names with special characters

### DIFF
--- a/public/app/plugins/datasource/cloudwatch/language/cloudwatch-sql/SQLGenerator.test.ts
+++ b/public/app/plugins/datasource/cloudwatch/language/cloudwatch-sql/SQLGenerator.test.ts
@@ -62,6 +62,13 @@ describe('SQLGenerator', () => {
         `SELECT COUNT("Bytes-Per-Second") FROM SCHEMA("AWS/EC2")`
       );
     });
+
+    it('should wrap in double quotes if metric name starts with a number ', () => {
+      const select = createFunctionWithParameter('COUNT', ['4xxErrorRate']);
+      expect(new SQLGenerator().expressionToSqlQuery({ ...baseQuery, select })).toEqual(
+        `SELECT COUNT("4xxErrorRate") FROM SCHEMA("AWS/EC2")`
+      );
+    });
   });
 
   describe('from', () => {

--- a/public/app/plugins/datasource/cloudwatch/language/cloudwatch-sql/SQLGenerator.ts
+++ b/public/app/plugins/datasource/cloudwatch/language/cloudwatch-sql/SQLGenerator.ts
@@ -146,10 +146,11 @@ export default class SQLGenerator {
   }
 
   private formatValue(label: string): string {
-    const specialCharacters = /[/\s\.-]/; // slash, space, dot or dash
+    const specialCharacters = /[/\s\.%-]/; // slash, space, dot, percent, or dash
+    const startsWithNumber = /^\d/;
 
     const interpolated = this.templateSrv.replace(label, {}, 'raw');
-    if (specialCharacters.test(interpolated)) {
+    if (specialCharacters.test(interpolated) || startsWithNumber.test(interpolated)) {
       return `"${label}"`;
     }
 


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->
**Why do we need this feature?**

Updates the cloudwatch metric query builder to put quotes around metrics that contain the `%` character or start with a number

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #73868 

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
