### PR TITLE
[v10.2.x] Auth: Add anonymous users view and stats

### DIFF
--- a/docs/sources/setup-grafana/configure-grafana/feature-toggles/index.md
+++ b/docs/sources/setup-grafana/configure-grafana/feature-toggles/index.md
@@ -151,6 +151,7 @@ Experimental features might be changed or removed without prior notice.
 | `awsDatasourcesNewFormStyling`              | Applies new form styling for configuration and query editors in AWS plugins                                                                                                                                                                                                       |
 | `cachingOptimizeSerializationMemoryUsage`   | If enabled, the caching backend gradually serializes query responses for the cache, comparing against the configured `[caching]max_value_mb` value as it goes. This can can help prevent Grafana from running out of memory while attempting to cache very large query responses. |
 | `pluginsInstrumentationStatusSource`        | Include a status source label for plugin request metrics and logs                                                                                                                                                                                                                 |
+| `displayAnonymousStats`                     | Enables anonymous stats to be shown in the UI for Grafana                                                                                                                                                                                                                         |
 
 ## Development feature toggles
 

--- a/packages/grafana-data/src/types/featureToggles.gen.ts
+++ b/packages/grafana-data/src/types/featureToggles.gen.ts
@@ -146,4 +146,5 @@ export interface FeatureToggles {
   panelTitleSearchInV1?: boolean;
   pluginsInstrumentationStatusSource?: boolean;
   panelFilterVariable?: boolean;
+  displayAnonymousStats?: boolean;
 }

--- a/packages/grafana-e2e-selectors/src/selectors/pages.ts
+++ b/packages/grafana-e2e-selectors/src/selectors/pages.ts
@@ -307,6 +307,7 @@ export const Pages = {
     tabs: {
       allUsers: 'data-testid all-users-tab',
       orgUsers: 'data-testid org-users-tab',
+      anonUserDevices: 'data-testid anon-user-devices-tab',
       publicDashboardsUsers: 'data-testid public-dashboards-users-tab',
       users: 'data-testid users-tab',
     },

--- a/pkg/api/admin.go
+++ b/pkg/api/admin.go
@@ -3,6 +3,7 @@ package api
 import (
 	"context"
 	"net/http"
+	"time"
 
 	"github.com/grafana/grafana/pkg/api/response"
 	ac "github.com/grafana/grafana/pkg/services/accesscontrol"
@@ -63,6 +64,12 @@ func (hs *HTTPServer) AdminGetStats(c *contextmodel.ReqContext) response.Respons
 	if err != nil {
 		return response.Error(500, "Failed to get admin stats from database", err)
 	}
+	thirtyDays := 30 * 24 * time.Hour
+	devicesCount, err := hs.anonService.CountDevices(c.Req.Context(), time.Now().Add(-thirtyDays), time.Now().Add(time.Minute))
+	if err != nil {
+		return response.Error(500, "Failed to get anon stats from database", err)
+	}
+	adminStats.AnonymousStats.ActiveDevices = devicesCount
 
 	return response.JSON(http.StatusOK, adminStats)
 }

--- a/pkg/api/http_server.go
+++ b/pkg/api/http_server.go
@@ -16,6 +16,8 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 
+	"github.com/grafana/grafana/pkg/services/anonymous"
+
 	"github.com/grafana/grafana/pkg/api/avatar"
 	"github.com/grafana/grafana/pkg/api/routing"
 	httpstatic "github.com/grafana/grafana/pkg/api/static"
@@ -205,6 +207,7 @@ type HTTPServer struct {
 	authnService         authn.Service
 	starApi              *starApi.API
 	promRegister         prometheus.Registerer
+	anonService          anonymous.Service
 }
 
 type ServerOptions struct {
@@ -246,7 +249,7 @@ func ProvideHTTPServer(opts ServerOptions, cfg *setting.Cfg, routeRegister routi
 	accesscontrolService accesscontrol.Service, navTreeService navtree.Service,
 	annotationRepo annotations.Repository, tagService tag.Service, searchv2HTTPService searchV2.SearchHTTPService, oauthTokenService oauthtoken.OAuthTokenService,
 	statsService stats.Service, authnService authn.Service, pluginsCDNService *pluginscdn.Service,
-	starApi *starApi.API, promRegister prometheus.Registerer,
+	starApi *starApi.API, promRegister prometheus.Registerer, anonService anonymous.Service,
 
 ) (*HTTPServer, error) {
 	web.Env = cfg.Env
@@ -348,6 +351,7 @@ func ProvideHTTPServer(opts ServerOptions, cfg *setting.Cfg, routeRegister routi
 		pluginsCDNService:            pluginsCDNService,
 		starApi:                      starApi,
 		promRegister:                 promRegister,
+		anonService:                  anonService,
 	}
 	if hs.Listener != nil {
 		hs.log.Debug("Using provided listener")

--- a/pkg/services/anonymous/anonimpl/anonstore/database.go
+++ b/pkg/services/anonymous/anonimpl/anonstore/database.go
@@ -21,11 +21,11 @@ type AnonDBStore struct {
 
 type Device struct {
 	ID        int64     `json:"-" xorm:"id" db:"id"`
-	DeviceID  string    `json:"device_id" xorm:"device_id" db:"device_id"`
-	ClientIP  string    `json:"client_ip" xorm:"client_ip" db:"client_ip"`
-	UserAgent string    `json:"user_agent" xorm:"user_agent" db:"user_agent"`
-	CreatedAt time.Time `json:"created_at" xorm:"created_at" db:"created_at"`
-	UpdatedAt time.Time `json:"updated_at" xorm:"updated_at" db:"updated_at"`
+	DeviceID  string    `json:"deviceId" xorm:"device_id" db:"device_id"`
+	ClientIP  string    `json:"clientIp" xorm:"client_ip" db:"client_ip"`
+	UserAgent string    `json:"userAgent" xorm:"user_agent" db:"user_agent"`
+	CreatedAt time.Time `json:"createdAt" xorm:"created_at" db:"created_at"`
+	UpdatedAt time.Time `json:"updatedAt" xorm:"updated_at" db:"updated_at"`
 }
 
 func (a *Device) CacheKey() string {

--- a/pkg/services/anonymous/anonimpl/api/api.go
+++ b/pkg/services/anonymous/anonimpl/api/api.go
@@ -1,0 +1,98 @@
+package api
+
+import (
+	"net/http"
+	"time"
+
+	"github.com/grafana/grafana/pkg/api/dtos"
+	"github.com/grafana/grafana/pkg/api/response"
+	"github.com/grafana/grafana/pkg/api/routing"
+	"github.com/grafana/grafana/pkg/infra/log"
+	"github.com/grafana/grafana/pkg/services/accesscontrol"
+	"github.com/grafana/grafana/pkg/services/anonymous/anonimpl/anonstore"
+	contextmodel "github.com/grafana/grafana/pkg/services/contexthandler/model"
+	"github.com/grafana/grafana/pkg/setting"
+	"github.com/grafana/grafana/pkg/util"
+)
+
+const (
+	thirtyDays = 30 * 24 * time.Hour
+)
+
+type deviceDTO struct {
+	anonstore.Device
+	LastSeenAt string `json:"lastSeenAt"`
+	AvatarUrl  string `json:"avatarUrl"`
+}
+
+type AnonDeviceServiceAPI struct {
+	cfg            *setting.Cfg
+	store          anonstore.AnonStore
+	accesscontrol  accesscontrol.AccessControl
+	RouterRegister routing.RouteRegister
+	log            log.Logger
+}
+
+func NewAnonDeviceServiceAPI(
+	cfg *setting.Cfg,
+	anonstore anonstore.AnonStore,
+	accesscontrol accesscontrol.AccessControl,
+	routerRegister routing.RouteRegister,
+) *AnonDeviceServiceAPI {
+	return &AnonDeviceServiceAPI{
+		cfg:            cfg,
+		store:          anonstore,
+		accesscontrol:  accesscontrol,
+		RouterRegister: routerRegister,
+		log:            log.New("anon.api"),
+	}
+}
+
+func (api *AnonDeviceServiceAPI) RegisterAPIEndpoints() {
+	auth := accesscontrol.Middleware(api.accesscontrol)
+	api.RouterRegister.Group("/api/anonymous", func(anonRoutes routing.RouteRegister) {
+		anonRoutes.Get("/devices", auth(accesscontrol.EvalPermission(accesscontrol.ActionUsersRead)), routing.Wrap(api.ListDevices))
+	})
+}
+
+// swagger:route GET /stats devices listDevices
+//
+// # Lists all devices within the last 30 days
+//
+// Produces:
+// - application/json
+//
+// Responses:
+//
+//	200: devicesResponse
+//	401: unauthorisedError
+//	403: forbiddenError
+//	404: notFoundError
+//	500: internalServerError
+func (api *AnonDeviceServiceAPI) ListDevices(c *contextmodel.ReqContext) response.Response {
+	fromTime := time.Now().Add(-thirtyDays)
+	toTime := time.Now()
+
+	devices, err := api.store.ListDevices(c.Req.Context(), &fromTime, &toTime)
+	if err != nil {
+		return response.ErrOrFallback(http.StatusInternalServerError, "Failed to list devices", err)
+	}
+
+	// convert to response format
+	resDevices := make([]*deviceDTO, 0, len(devices))
+	for _, device := range devices {
+		resDevices = append(resDevices, &deviceDTO{
+			Device:     *device,
+			LastSeenAt: util.GetAgeString(device.UpdatedAt),
+			AvatarUrl:  dtos.GetGravatarUrl(device.DeviceID),
+		})
+	}
+
+	return response.JSON(http.StatusOK, resDevices)
+}
+
+// swagger:response devicesResponse
+type DevicesResponse struct {
+	// in:body
+	Body []deviceDTO `json:"body"`
+}

--- a/pkg/services/anonymous/anonimpl/client_test.go
+++ b/pkg/services/anonymous/anonimpl/client_test.go
@@ -49,7 +49,7 @@ func TestAnonymous_Authenticate(t *testing.T) {
 				cfg:               tt.cfg,
 				log:               log.NewNopLogger(),
 				orgService:        &orgtest.FakeOrgService{ExpectedOrg: tt.org, ExpectedError: tt.err},
-				anonDeviceService: &anontest.FakeAnonymousSessionService{},
+				anonDeviceService: anontest.NewFakeService(),
 			}
 
 			identity, err := c.Authenticate(context.Background(), &authn.Request{})

--- a/pkg/services/anonymous/anonimpl/impl.go
+++ b/pkg/services/anonymous/anonimpl/impl.go
@@ -5,13 +5,16 @@ import (
 	"net/http"
 	"time"
 
+	"github.com/grafana/grafana/pkg/api/routing"
 	"github.com/grafana/grafana/pkg/infra/localcache"
 	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/infra/network"
 	"github.com/grafana/grafana/pkg/infra/serverlock"
 	"github.com/grafana/grafana/pkg/infra/usagestats"
+	"github.com/grafana/grafana/pkg/services/accesscontrol"
 	"github.com/grafana/grafana/pkg/services/anonymous"
 	"github.com/grafana/grafana/pkg/services/anonymous/anonimpl/anonstore"
+	"github.com/grafana/grafana/pkg/services/anonymous/anonimpl/api"
 	"github.com/grafana/grafana/pkg/services/authn"
 	"github.com/grafana/grafana/pkg/services/org"
 	"github.com/grafana/grafana/pkg/setting"
@@ -31,7 +34,7 @@ type AnonDeviceService struct {
 
 func ProvideAnonymousDeviceService(usageStats usagestats.Service, authBroker authn.Service,
 	anonStore anonstore.AnonStore, cfg *setting.Cfg, orgService org.Service,
-	serverLockService *serverlock.ServerLockService,
+	serverLockService *serverlock.ServerLockService, accesscontrol accesscontrol.AccessControl, routeRegister routing.RouteRegister,
 ) *AnonDeviceService {
 	a := &AnonDeviceService{
 		log:        log.New("anonymous-session-service"),
@@ -53,6 +56,9 @@ func ProvideAnonymousDeviceService(usageStats usagestats.Service, authBroker aut
 		authBroker.RegisterClient(anonClient)
 		authBroker.RegisterPostLoginHook(a.untagDevice, 100)
 	}
+
+	anonAPI := api.NewAnonDeviceServiceAPI(cfg, anonStore, accesscontrol, routeRegister)
+	anonAPI.RegisterAPIEndpoints()
 
 	return a
 }
@@ -140,6 +146,16 @@ func (a *AnonDeviceService) TagDevice(ctx context.Context, httpReq *http.Request
 	}
 
 	return nil
+}
+
+// ListDevices returns all devices that have been updated between the given times.
+func (a *AnonDeviceService) ListDevices(ctx context.Context, from *time.Time, to *time.Time) ([]*anonstore.Device, error) {
+	return a.anonStore.ListDevices(ctx, from, to)
+}
+
+// CountDevices returns the number of devices that have been updated between the given times.
+func (a *AnonDeviceService) CountDevices(ctx context.Context, from time.Time, to time.Time) (int64, error) {
+	return a.anonStore.CountDevices(ctx, from, to)
 }
 
 func (a *AnonDeviceService) Run(ctx context.Context) error {

--- a/pkg/services/anonymous/anonimpl/impl_test.go
+++ b/pkg/services/anonymous/anonimpl/impl_test.go
@@ -9,8 +9,10 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/grafana/grafana/pkg/api/routing"
 	"github.com/grafana/grafana/pkg/infra/db"
 	"github.com/grafana/grafana/pkg/infra/usagestats"
+	"github.com/grafana/grafana/pkg/services/accesscontrol/actest"
 	"github.com/grafana/grafana/pkg/services/anonymous"
 	"github.com/grafana/grafana/pkg/services/anonymous/anonimpl/anonstore"
 	"github.com/grafana/grafana/pkg/services/authn/authntest"
@@ -113,7 +115,7 @@ func TestIntegrationDeviceService_tag(t *testing.T) {
 			store := db.InitTestDB(t)
 			anonDBStore := anonstore.ProvideAnonDBStore(store)
 			anonService := ProvideAnonymousDeviceService(&usagestats.UsageStatsMock{},
-				&authntest.FakeService{}, anonDBStore, setting.NewCfg(), orgtest.NewOrgServiceFake(), nil)
+				&authntest.FakeService{}, anonDBStore, setting.NewCfg(), orgtest.NewOrgServiceFake(), nil, actest.FakeAccessControl{}, &routing.RouteRegisterImpl{})
 
 			for _, req := range tc.req {
 				err := anonService.TagDevice(context.Background(), req.httpReq, req.kind)
@@ -149,7 +151,7 @@ func TestIntegrationAnonDeviceService_localCacheSafety(t *testing.T) {
 	store := db.InitTestDB(t)
 	anonDBStore := anonstore.ProvideAnonDBStore(store)
 	anonService := ProvideAnonymousDeviceService(&usagestats.UsageStatsMock{},
-		&authntest.FakeService{}, anonDBStore, setting.NewCfg(), orgtest.NewOrgServiceFake(), nil)
+		&authntest.FakeService{}, anonDBStore, setting.NewCfg(), orgtest.NewOrgServiceFake(), nil, actest.FakeAccessControl{}, &routing.RouteRegisterImpl{})
 
 	req := &http.Request{
 		Header: http.Header{

--- a/pkg/services/anonymous/anontest/fake.go
+++ b/pkg/services/anonymous/anontest/fake.go
@@ -3,13 +3,27 @@ package anontest
 import (
 	"context"
 	"net/http"
+	"time"
 
 	"github.com/grafana/grafana/pkg/services/anonymous"
 )
 
+type FakeService struct {
+	ExpectedCountDevices int64
+	ExpectedError        error
+}
+
+func NewFakeService() *FakeService {
+	return &FakeService{}
+}
+
 type FakeAnonymousSessionService struct {
 }
 
-func (f *FakeAnonymousSessionService) TagDevice(ctx context.Context, httpReq *http.Request, kind anonymous.DeviceKind) error {
+func (f *FakeService) TagDevice(ctx context.Context, httpReq *http.Request, kind anonymous.DeviceKind) error {
 	return nil
+}
+
+func (f *FakeService) CountDevices(ctx context.Context, from time.Time, to time.Time) (int64, error) {
+	return f.ExpectedCountDevices, nil
 }

--- a/pkg/services/anonymous/service.go
+++ b/pkg/services/anonymous/service.go
@@ -3,6 +3,7 @@ package anonymous
 import (
 	"context"
 	"net/http"
+	"time"
 )
 
 type DeviceKind string
@@ -13,4 +14,5 @@ const (
 
 type Service interface {
 	TagDevice(context.Context, *http.Request, DeviceKind) error
+	CountDevices(ctx context.Context, from time.Time, to time.Time) (int64, error)
 }

--- a/pkg/services/featuremgmt/registry.go
+++ b/pkg/services/featuremgmt/registry.go
@@ -898,5 +898,12 @@ var (
 			Owner:        grafanaDashboardsSquad,
 			HideFromDocs: true,
 		},
+		{
+			Name:         "displayAnonymousStats",
+			Description:  "Enables anonymous stats to be shown in the UI for Grafana",
+			Stage:        FeatureStageExperimental,
+			FrontendOnly: true,
+			Owner:        grafanaAuthnzSquad,
+		},
 	}
 )

--- a/pkg/services/featuremgmt/toggles_gen.csv
+++ b/pkg/services/featuremgmt/toggles_gen.csv
@@ -127,3 +127,4 @@ cachingOptimizeSerializationMemoryUsage,experimental,@grafana/grafana-operator-e
 panelTitleSearchInV1,experimental,@grafana/backend-platform,true,false,false,false
 pluginsInstrumentationStatusSource,experimental,@grafana/plugins-platform-backend,false,false,false,false
 panelFilterVariable,experimental,@grafana/dashboards-squad,false,false,false,true
+displayAnonymousStats,experimental,@grafana/grafana-authnz-team,false,false,false,true

--- a/pkg/services/featuremgmt/toggles_gen.go
+++ b/pkg/services/featuremgmt/toggles_gen.go
@@ -518,4 +518,8 @@ const (
 	// FlagPanelFilterVariable
 	// Enables use of the `systemPanelFilterVar` variable to filter panels in a dashboard
 	FlagPanelFilterVariable = "panelFilterVariable"
+
+	// FlagDisplayAnonymousStats
+	// Enables anonymous stats to be shown in the UI for Grafana
+	FlagDisplayAnonymousStats = "displayAnonymousStats"
 )

--- a/pkg/services/stats/models.go
+++ b/pkg/services/stats/models.go
@@ -77,6 +77,9 @@ type NotifierUsageStats struct {
 
 type GetAlertNotifierUsageStatsQuery struct{}
 
+type AnonymousStats struct {
+	ActiveDevices int64 `json:"activeDevices"`
+}
 type AdminStats struct {
 	Orgs                int64 `json:"orgs"`
 	Dashboards          int64 `json:"dashboards"`
@@ -101,6 +104,7 @@ type AdminStats struct {
 	DailyActiveViewers  int64 `json:"dailyActiveViewers"`
 	DailyActiveSessions int64 `json:"dailyActiveSessions"`
 	MonthlyActiveUsers  int64 `json:"monthlyActiveUsers"`
+	AnonymousStats
 }
 
 type GetAdminStatsQuery struct{}

--- a/pkg/services/stats/statstest/stats.go
+++ b/pkg/services/stats/statstest/stats.go
@@ -7,6 +7,7 @@ import (
 )
 
 type FakeService struct {
+	ExpectedAdminStats             *stats.AdminStats
 	ExpectedSystemStats            *stats.SystemStats
 	ExpectedDataSourceStats        []*stats.DataSourceStats
 	ExpectedDataSourcesAccessStats []*stats.DataSourceAccessStats
@@ -20,7 +21,7 @@ func NewFakeService() *FakeService {
 }
 
 func (s *FakeService) GetAdminStats(ctx context.Context, query *stats.GetAdminStatsQuery) (*stats.AdminStats, error) {
-	return nil, s.ExpectedError
+	return s.ExpectedAdminStats, s.ExpectedError
 }
 
 func (s *FakeService) GetAlertNotifiersUsageStats(ctx context.Context, query *stats.GetAlertNotifierUsageStatsQuery) ([]*stats.NotifierUsageStats, error) {

--- a/public/api-merged.json
+++ b/public/api-merged.json
@@ -9402,6 +9402,35 @@
         }
       }
     },
+    "/stats": {
+      "get": {
+        "produces": [
+          "application/json"
+        ],
+        "tags": [
+          "devices"
+        ],
+        "summary": "Lists all devices within the last 30 days",
+        "operationId": "listDevices",
+        "responses": {
+          "200": {
+            "$ref": "#/responses/devicesResponse"
+          },
+          "401": {
+            "$ref": "#/responses/unauthorisedError"
+          },
+          "403": {
+            "$ref": "#/responses/forbiddenError"
+          },
+          "404": {
+            "$ref": "#/responses/notFoundError"
+          },
+          "500": {
+            "$ref": "#/responses/internalServerError"
+          }
+        }
+      }
+    },
     "/teams": {
       "post": {
         "tags": [
@@ -11071,6 +11100,10 @@
       "type": "object",
       "properties": {
         "activeAdmins": {
+          "type": "integer",
+          "format": "int64"
+        },
+        "activeDevices": {
           "type": "integer",
           "format": "int64"
         },
@@ -19845,6 +19878,34 @@
         }
       }
     },
+    "deviceDTO": {
+      "type": "object",
+      "properties": {
+        "avatarUrl": {
+          "type": "string"
+        },
+        "clientIp": {
+          "type": "string"
+        },
+        "createdAt": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "deviceId": {
+          "type": "string"
+        },
+        "lastSeenAt": {
+          "type": "string"
+        },
+        "updatedAt": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "userAgent": {
+          "type": "string"
+        }
+      }
+    },
     "gettableAlert": {
       "description": "GettableAlert gettable alert",
       "type": "object",
@@ -20636,6 +20697,15 @@
             "type": "string",
             "example": "My Folder"
           }
+        }
+      }
+    },
+    "devicesResponse": {
+      "description": "(empty)",
+      "schema": {
+        "type": "array",
+        "items": {
+          "$ref": "#/definitions/deviceDTO"
         }
       }
     },

--- a/public/app/core/services/backend_srv.ts
+++ b/public/app/core/services/backend_srv.ts
@@ -16,7 +16,6 @@ import {
 import { v4 as uuidv4 } from 'uuid';
 
 import { AppEvents, DataQueryErrorType } from '@grafana/data';
-import { GrafanaEdition } from '@grafana/data/src/types/config';
 import { BackendSrv as BackendService, BackendSrvRequest, config, FetchError, FetchResponse } from '@grafana/runtime';
 import appEvents from 'app/core/app_events';
 import { getConfig } from 'app/core/config';
@@ -94,10 +93,6 @@ export class BackendSrv implements BackendService {
   }
 
   private async initGrafanaDeviceID() {
-    if (config.buildInfo?.edition === GrafanaEdition.OpenSource) {
-      return;
-    }
-
     try {
       const fp = await FingerprintJS.load();
       const result = await fp.get();
@@ -161,8 +156,7 @@ export class BackendSrv implements BackendService {
       }
     }
 
-    // Add device id header if not OSS build
-    if (config.buildInfo?.edition !== GrafanaEdition.OpenSource && this.deviceID) {
+    if (!!this.deviceID) {
       options.headers = options.headers ?? {};
       options.headers['X-Grafana-Device-Id'] = `${this.deviceID}`;
     }

--- a/public/app/features/admin/ServerStats.test.tsx
+++ b/public/app/features/admin/ServerStats.test.tsx
@@ -1,6 +1,8 @@
 import { render, screen } from '@testing-library/react';
 import React from 'react';
 
+import config from 'app/core/config';
+
 import { ServerStats } from './ServerStats';
 import { ServerStat } from './state/apis';
 
@@ -10,6 +12,7 @@ const stats: ServerStat = {
   activeSessions: 1,
   activeUsers: 1,
   activeViewers: 0,
+  activeDevices: 1,
   admins: 1,
   alerts: 5,
   dashboards: 1599,
@@ -45,5 +48,13 @@ describe('ServerStats', () => {
     expect(screen.getByRole('link', { name: 'Manage data sources' })).toBeInTheDocument();
     expect(screen.getByRole('link', { name: 'Alerts' })).toBeInTheDocument();
     expect(screen.getByRole('link', { name: 'Manage users' })).toBeInTheDocument();
+  });
+
+  it('Should render page with anonymous stats', async () => {
+    config.featureToggles.displayAnonymousStats = true;
+    render(<ServerStats />);
+    expect(await screen.findByRole('heading', { name: /instance statistics/i })).toBeInTheDocument();
+    expect(screen.getByText('Active anonymous devices in last 30 days')).toBeInTheDocument();
+    expect(screen.getByText('Active anonymous users in last 30 days')).toBeInTheDocument();
   });
 });

--- a/public/app/features/admin/ServerStats.tsx
+++ b/public/app/features/admin/ServerStats.tsx
@@ -2,6 +2,7 @@ import { css } from '@emotion/css';
 import React, { useEffect, useState } from 'react';
 
 import { GrafanaTheme2 } from '@grafana/data';
+import { config } from '@grafana/runtime';
 import { CardContainer, LinkButton, useStyles2 } from '@grafana/ui';
 import { AccessControlAction } from 'app/types';
 
@@ -80,6 +81,12 @@ export const ServerStats = () => {
               { name: 'Organisations', value: stats.orgs },
               { name: 'Users total', value: stats.users },
               { name: 'Active users in last 30 days', value: stats.activeUsers },
+              ...(config.featureToggles.displayAnonymousStats && stats.activeDevices
+                ? [
+                    { name: 'Active anonymous devices in last 30 days', value: stats.activeDevices },
+                    { name: 'Active anonymous users in last 30 days', value: Math.floor(stats.activeDevices / 3) },
+                  ]
+                : []),
               { name: 'Active sessions', value: stats.activeSessions },
             ]}
             footer={

--- a/public/app/features/admin/UserListAnonymousPage.tsx
+++ b/public/app/features/admin/UserListAnonymousPage.tsx
@@ -1,0 +1,47 @@
+import React, { useEffect } from 'react';
+import { connect, ConnectedProps } from 'react-redux';
+
+import { Page } from 'app/core/components/Page/Page';
+
+import { StoreState } from '../../types';
+
+import { AnonUsersDevicesTable } from './Users/AnonUsersTable';
+import { fetchUsersAnonymousDevices } from './state/actions';
+
+const mapDispatchToProps = {
+  fetchUsersAnonymousDevices,
+};
+
+const mapStateToProps = (state: StoreState) => ({
+  devices: state.userListAnonymousDevices.devices,
+});
+
+const connector = connect(mapStateToProps, mapDispatchToProps);
+
+interface OwnProps {}
+
+type Props = OwnProps & ConnectedProps<typeof connector>;
+
+const UserListAnonymousDevicesPageUnConnected = ({ devices, fetchUsersAnonymousDevices }: Props) => {
+  useEffect(() => {
+    fetchUsersAnonymousDevices();
+  }, [fetchUsersAnonymousDevices]);
+
+  return (
+    <Page.Contents>
+      <AnonUsersDevicesTable devices={devices} />
+    </Page.Contents>
+  );
+};
+
+export const UserListAnonymousDevicesPageContent = connector(UserListAnonymousDevicesPageUnConnected);
+
+export function UserListAnonymousDevicesPage() {
+  return (
+    <Page navId="anonymous-users">
+      <UserListAnonymousDevicesPageContent />
+    </Page>
+  );
+}
+
+export default UserListAnonymousDevicesPage;

--- a/public/app/features/admin/UserListPage.tsx
+++ b/public/app/features/admin/UserListPage.tsx
@@ -12,12 +12,14 @@ import { AccessControlAction } from '../../types';
 import { UsersListPageContent } from '../users/UsersListPage';
 
 import { UserListAdminPageContent } from './UserListAdminPage';
+import { UserListAnonymousDevicesPageContent } from './UserListAnonymousPage';
 import { UserListPublicDashboardPage } from './UserListPublicDashboardPage/UserListPublicDashboardPage';
 
 enum TabView {
   ADMIN = 'admin',
   ORG = 'org',
   PUBLIC_DASHBOARDS = 'public-dashboards',
+  ANON = 'anon',
 }
 
 const selectors = e2eSelectors.pages.UserListPage;
@@ -35,6 +37,7 @@ const TAB_PAGE_MAP: Record<TabView, React.ReactElement> = {
   [TabView.ADMIN]: <UserListAdminPageContent />,
   [TabView.ORG]: <UsersListPageContent />,
   [TabView.PUBLIC_DASHBOARDS]: <UserListPublicDashboardPage />,
+  [TabView.ANON]: <UserListAnonymousDevicesPageContent />,
 };
 
 export default function UserListPage() {
@@ -74,6 +77,14 @@ export default function UserListPage() {
             onChangeTab={() => setView(TabView.ORG)}
             data-testid={selectors.tabs.orgUsers}
           />
+          {config.featureToggles.displayAnonymousStats && (
+            <Tab
+              label="Anonymous devices"
+              active={view === TabView.ANON}
+              onChangeTab={() => setView(TabView.ANON)}
+              data-testid={selectors.tabs.anonUserDevices}
+            />
+          )}
           {hasEmailSharingEnabled && <PublicDashboardsTab view={view} setView={setView} />}
         </TabsBar>
       ) : (

--- a/public/app/features/admin/Users/AnonUsersTable.tsx
+++ b/public/app/features/admin/Users/AnonUsersTable.tsx
@@ -1,0 +1,82 @@
+import React, { useMemo } from 'react';
+
+import { Avatar, CellProps, Column, InteractiveTable, Stack, Badge, Tooltip } from '@grafana/ui';
+import { UserAnonymousDeviceDTO } from 'app/types';
+
+type Cell<T extends keyof UserAnonymousDeviceDTO = keyof UserAnonymousDeviceDTO> = CellProps<
+  UserAnonymousDeviceDTO,
+  UserAnonymousDeviceDTO[T]
+>;
+
+// A helper function to parse the user agent string and extract parts
+const parseUserAgent = (userAgent: string) => {
+  return {
+    browser: userAgent.split(' ')[0],
+    computer: userAgent.split(' ')[1],
+  };
+};
+
+// A helper function to truncate each part of the user agent
+const truncatePart = (part: string, maxLength: number) => {
+  return part.length > maxLength ? part.substring(0, maxLength) + '...' : part;
+};
+
+interface UserAgentCellProps {
+  value: string;
+}
+
+const UserAgentCell = ({ value }: UserAgentCellProps) => {
+  const parts = parseUserAgent(value);
+  return (
+    <Tooltip theme="info-alt" content={value} placement="top-end" interactive={true}>
+      <span>
+        {truncatePart(parts.browser, 10)}
+        {truncatePart(parts.computer, 10)}
+      </span>
+    </Tooltip>
+  );
+};
+
+interface AnonUsersTableProps {
+  devices: UserAnonymousDeviceDTO[];
+}
+
+export const AnonUsersDevicesTable = ({ devices }: AnonUsersTableProps) => {
+  const columns: Array<Column<UserAnonymousDeviceDTO>> = useMemo(
+    () => [
+      {
+        id: 'avatarUrl',
+        header: '',
+        cell: ({ cell: { value } }: Cell<'avatarUrl'>) => value && <Avatar src={value} alt={'User avatar'} />,
+      },
+      {
+        id: 'login',
+        header: 'Login',
+        cell: ({ cell: { value } }: Cell<'login'>) => 'Anonymous',
+      },
+      {
+        id: 'userAgent',
+        header: 'User Agent',
+        cell: ({ cell: { value } }: Cell<'userAgent'>) => <UserAgentCell value={value} />,
+        sortType: 'string',
+      },
+      {
+        id: 'lastSeenAt',
+        header: 'Last active',
+        cell: ({ cell: { value } }: Cell<'lastSeenAt'>) => value,
+        sortType: (a, b) => new Date(a.original.updatedAt).getTime() - new Date(b.original.updatedAt).getTime(),
+      },
+      {
+        id: 'clientIp',
+        header: 'Origin IP (address)',
+        cell: ({ cell: { value } }: Cell<'clientIp'>) => value && <Badge text={value} color="orange" />,
+      },
+    ],
+    []
+  );
+  return (
+    <Stack direction={'column'} gap={2}>
+      <InteractiveTable columns={columns} data={devices} getRowId={(user) => user.deviceId} />
+    </Stack>
+  );
+};

--- a/public/app/features/admin/Users/AnonUsersTable.tsx
+++ b/public/app/features/admin/Users/AnonUsersTable.tsx
@@ -1,6 +1,7 @@
 import React, { useMemo } from 'react';
 
-import { Avatar, CellProps, Column, InteractiveTable, Stack, Badge, Tooltip } from '@grafana/ui';
+import { Stack } from '@grafana/experimental';
+import { Avatar, CellProps, Column, InteractiveTable, Badge, Tooltip } from '@grafana/ui';
 import { UserAnonymousDeviceDTO } from 'app/types';
 
 type Cell<T extends keyof UserAnonymousDeviceDTO = keyof UserAnonymousDeviceDTO> = CellProps<

--- a/public/app/features/admin/state/actions.ts
+++ b/public/app/features/admin/state/actions.ts
@@ -28,6 +28,7 @@ import {
   usersFetchBegin,
   usersFetchEnd,
   sortChanged,
+  usersAnonymousDevicesFetched,
 } from './reducers';
 // UserAdminPage
 
@@ -331,6 +332,21 @@ export function changeSort({ sortBy }: FetchDataArgs<UserDTO>): ThunkResult<void
       dispatch(usersFetchBegin());
       dispatch(sortChanged(sort));
       dispatch(fetchUsers());
+    }
+  };
+}
+
+// UserListAnonymousPage
+
+export function fetchUsersAnonymousDevices(): ThunkResult<void> {
+  return async (dispatch, getState) => {
+    try {
+      let url = `/api/anonymous/devices`;
+      const result = await getBackendSrv().get(url);
+      dispatch(usersAnonymousDevicesFetched({ devices: result }));
+    } catch (error) {
+      usersFetchEnd();
+      console.error(error);
     }
   };
 }

--- a/public/app/features/admin/state/apis.tsx
+++ b/public/app/features/admin/state/apis.tsx
@@ -1,6 +1,10 @@
 import { getBackendSrv } from '@grafana/runtime';
 
-export interface ServerStat {
+interface AnonServerStat {
+  activeDevices?: number;
+}
+
+export interface ServerStat extends AnonServerStat {
   activeAdmins: number;
   activeEditors: number;
   activeSessions: number;

--- a/public/app/features/admin/state/reducers.ts
+++ b/public/app/features/admin/state/reducers.ts
@@ -13,6 +13,8 @@ import {
   UserSession,
   UserListAdminState,
   UserFilter,
+  UserListAnonymousDevicesState,
+  UserAnonymousDeviceDTO,
 } from 'app/types';
 
 const initialLdapState: LdapState = {
@@ -201,8 +203,37 @@ export const { usersFetched, usersFetchBegin, usersFetchEnd, queryChanged, pageC
   userListAdminSlice.actions;
 export const userListAdminReducer = userListAdminSlice.reducer;
 
+// UserListAnonymousPage
+
+const initialUserListAnonymousDevicesState: UserListAnonymousDevicesState = {
+  devices: [],
+};
+
+interface UsersAnonymousDevicesFetched {
+  devices: UserAnonymousDeviceDTO[];
+}
+
+export const userListAnonymousDevicesSlice = createSlice({
+  name: 'userListAnonymousDevices',
+  initialState: initialUserListAnonymousDevicesState,
+  reducers: {
+    usersAnonymousDevicesFetched: (state, action: PayloadAction<UsersAnonymousDevicesFetched>) => {
+      const { devices } = action.payload;
+      return {
+        ...state,
+        devices,
+        isLoading: false,
+      };
+    },
+  },
+});
+
+export const { usersAnonymousDevicesFetched } = userListAnonymousDevicesSlice.actions;
+export const userListAnonymousDevicesReducer = userListAnonymousDevicesSlice.reducer;
+
 export default {
   ldap: ldapReducer,
   userAdmin: userAdminReducer,
   userListAdmin: userListAdminReducer,
+  userListAnonymousDevices: userListAnonymousDevicesReducer,
 };

--- a/public/app/types/user.ts
+++ b/public/app/types/user.ts
@@ -131,3 +131,17 @@ export interface UserListAdminState {
   isLoading: boolean;
   sort?: string;
 }
+
+export interface UserAnonymousDeviceDTO {
+  login?: string;
+  clientIp: string;
+  deviceId: string;
+  userAgent: string;
+  updatedAt: string;
+  lastSeenAt: string;
+  avatarUrl?: string;
+}
+
+export interface UserListAnonymousDevicesState {
+  devices: UserAnonymousDeviceDTO[];
+}

--- a/public/openapi3.json
+++ b/public/openapi3.json
@@ -505,6 +505,19 @@
         },
         "description": "(empty)"
       },
+      "devicesResponse": {
+        "content": {
+          "application/json": {
+            "schema": {
+              "items": {
+                "$ref": "#/components/schemas/deviceDTO"
+              },
+              "type": "array"
+            }
+          }
+        },
+        "description": "(empty)"
+      },
       "folderResponse": {
         "content": {
           "application/json": {
@@ -2097,6 +2110,10 @@
       "AdminStats": {
         "properties": {
           "activeAdmins": {
+            "format": "int64",
+            "type": "integer"
+          },
+          "activeDevices": {
             "format": "int64",
             "type": "integer"
           },
@@ -10868,6 +10885,34 @@
         "required": [
           "status"
         ],
+        "type": "object"
+      },
+      "deviceDTO": {
+        "properties": {
+          "avatarUrl": {
+            "type": "string"
+          },
+          "clientIp": {
+            "type": "string"
+          },
+          "createdAt": {
+            "format": "date-time",
+            "type": "string"
+          },
+          "deviceId": {
+            "type": "string"
+          },
+          "lastSeenAt": {
+            "type": "string"
+          },
+          "updatedAt": {
+            "format": "date-time",
+            "type": "string"
+          },
+          "userAgent": {
+            "type": "string"
+          }
+        },
         "type": "object"
       },
       "gettableAlert": {
@@ -21517,6 +21562,32 @@
         "summary": "Get Snapshot by Key.",
         "tags": [
           "snapshots"
+        ]
+      }
+    },
+    "/stats": {
+      "get": {
+        "operationId": "listDevices",
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/devicesResponse"
+          },
+          "401": {
+            "$ref": "#/components/responses/unauthorisedError"
+          },
+          "403": {
+            "$ref": "#/components/responses/forbiddenError"
+          },
+          "404": {
+            "$ref": "#/components/responses/notFoundError"
+          },
+          "500": {
+            "$ref": "#/components/responses/internalServerError"
+          }
+        },
+        "summary": "Lists all devices within the last 30 days",
+        "tags": [
+          "devices"
         ]
       }
     },


### PR DESCRIPTION
Backport 59bdff0280d52ca5d8918157d7697b9279b25501 from #78685

---

<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

- anonymous users users page
- add feature toggle `displayAnonymousStats `
- remove check for enterprise for `X-Grafana-Device-Id` header in request
- add anonusers/device count to stats


**Why do we need this feature?**
We want to surface the anonymous users to our users as well as show a count of them in the stats page.


**Special notes for your reviewer:**
![image](https://github.com/grafana/grafana/assets/7727602/759f2134-2013-46c0-beb7-ffba4151ef63)
![image](https://github.com/grafana/grafana/assets/7727602/e5ab8ba5-61db-41be-985e-82ee90b9d625)



Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
