### PR TITLE
Docs: Fix for i386 Error in Main Stable and Beta Versions

### DIFF
--- a/docs/sources/setup-grafana/installation/debian/index.md
+++ b/docs/sources/setup-grafana/installation/debian/index.md
@@ -55,13 +55,21 @@ Complete the following steps to install Grafana from the APT repository:
 1. To add a repository for stable releases, run the following command:
 
    ```bash
+   for system having 32 bit architecture
    echo "deb [signed-by=/etc/apt/keyrings/grafana.gpg] https://apt.grafana.com stable main" | sudo tee -a /etc/apt/sources.list.d/grafana.list
+
+   for system having 64 bit architecture
+   echo "deb [arch=amd64 signed-by=/etc/apt/keyrings/grafana.gpg] https://apt.grafana.com stable main" | sudo tee -a /etc/apt/sources.list.d/grafana.list
    ```
 
 1. To add a repository for beta releases, run the following command:
 
    ```bash
+   for system having 32 bit architecture
    echo "deb [signed-by=/etc/apt/keyrings/grafana.gpg] https://apt.grafana.com beta main" | sudo tee -a /etc/apt/sources.list.d/grafana.list
+   
+   for system having 64 bit architecture
+   echo "deb [arch=amd64 signed-by=/etc/apt/keyrings/grafana.gpg] https://apt.grafana.com beta main" | sudo tee -a /etc/apt/sources.list.d/grafana.list
    ```
 
 1. Run the following command to update the list of available packages:


### PR DESCRIPTION
**What is this feature?**

This feature is a fix for the `i386` error that occurs during the download process of the main stable and beta versions of the project. The fix involves modifications to the basic command from line 56 to line 63 in the source code.

**Why do we need this feature?**

We need this feature to prevent the `i386` error that currently disrupts the download process. By resolving this issue, we can ensure a smoother and more reliable download experience for all users.

**Who is this feature for?**

This feature is for all users who are downloading the main stable and beta versions of the project. It will be particularly beneficial for those who have encountered the `i386` error.

**Which issue(s) does this PR fix?:**

Fixes the `i386` error during the download process.

**Special notes for your reviewer:**

The modifications to resolve this issue have been successfully tested on both the main stable and beta versions of the project. I recommend reviewing these changes for potential integration into the main project. I look forward to your feedback.

Best,
Siddharth D