### PR TITLE
Chore: Make test environment run SQLite in WAL mode

### DIFF
--- a/pkg/tests/api/alerting/api_admin_configuration_test.go
+++ b/pkg/tests/api/alerting/api_admin_configuration_test.go
@@ -10,9 +10,10 @@ import (
 	"testing"
 	"time"
 
-	"github.com/grafana/grafana/pkg/expr"
 	"github.com/prometheus/common/model"
 	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/grafana/pkg/expr"
 
 	"github.com/grafana/grafana/pkg/components/simplejson"
 	"github.com/grafana/grafana/pkg/services/datasources"
@@ -37,6 +38,7 @@ func TestIntegrationAdminConfiguration_SendingToExternalAlertmanagers(t *testing
 		NGAlertAdminConfigPollInterval: 2 * time.Second,
 		UnifiedAlertingDisabledOrgs:    []int64{disableOrgID}, // disable unified alerting for organisation 3
 		AppModeProduction:              true,
+		EnableLog:                      true,
 	})
 
 	grafanaListedAddr, s := testinfra.StartGrafana(t, dir, path)

--- a/pkg/tests/api/alerting/api_alertmanager_configuration_test.go
+++ b/pkg/tests/api/alerting/api_alertmanager_configuration_test.go
@@ -30,6 +30,7 @@ func TestIntegrationAlertmanagerConfigurationIsTransactional(t *testing.T) {
 		NGAlertAlertmanagerConfigPollInterval: 2 * time.Second,
 		DisableAnonymous:                      true,
 		AppModeProduction:                     true,
+		EnableLog:                             true,
 	})
 
 	grafanaListedAddr, store := testinfra.StartGrafana(t, dir, path)
@@ -148,6 +149,7 @@ func TestIntegrationAlertmanagerConfigurationPersistSecrets(t *testing.T) {
 		EnableUnifiedAlerting: true,
 		DisableAnonymous:      true,
 		AppModeProduction:     true,
+		EnableLog:             true,
 	})
 
 	grafanaListedAddr, store := testinfra.StartGrafana(t, dir, path)

--- a/pkg/tests/api/alerting/api_alertmanager_test.go
+++ b/pkg/tests/api/alerting/api_alertmanager_test.go
@@ -45,6 +45,7 @@ func TestIntegrationAMConfigAccess(t *testing.T) {
 		EnableUnifiedAlerting: true,
 		DisableAnonymous:      true,
 		AppModeProduction:     true,
+		EnableLog:             true,
 	})
 
 	grafanaListedAddr, store := testinfra.StartGrafana(t, dir, path)
@@ -406,6 +407,7 @@ func TestIntegrationAlertAndGroupsQuery(t *testing.T) {
 		EnableUnifiedAlerting: true,
 		DisableAnonymous:      true,
 		AppModeProduction:     true,
+		EnableLog:             true,
 	})
 
 	grafanaListedAddr, store := testinfra.StartGrafana(t, dir, path)
@@ -568,6 +570,7 @@ func TestIntegrationRulerAccess(t *testing.T) {
 		DisableAnonymous:      true,
 		ViewersCanEdit:        true,
 		AppModeProduction:     true,
+		EnableLog:             true,
 	})
 
 	grafanaListedAddr, store := testinfra.StartGrafana(t, dir, path)
@@ -685,6 +688,7 @@ func TestIntegrationDeleteFolderWithRules(t *testing.T) {
 		DisableAnonymous:      true,
 		ViewersCanEdit:        true,
 		AppModeProduction:     true,
+		EnableLog:             true,
 	})
 
 	grafanaListedAddr, store := testinfra.StartGrafana(t, dir, path)
@@ -847,6 +851,7 @@ func TestIntegrationAlertRuleCRUD(t *testing.T) {
 		EnableQuota:           true,
 		DisableAnonymous:      true,
 		AppModeProduction:     true,
+		EnableLog:             true,
 	})
 
 	grafanaListedAddr, store := testinfra.StartGrafana(t, dir, path)
@@ -1852,6 +1857,7 @@ func TestIntegrationAlertmanagerStatus(t *testing.T) {
 		DisableLegacyAlerting: true,
 		EnableUnifiedAlerting: true,
 		AppModeProduction:     true,
+		EnableLog:             true,
 	})
 
 	grafanaListedAddr, _ := testinfra.StartGrafana(t, dir, path)
@@ -1919,6 +1925,7 @@ func TestIntegrationQuota(t *testing.T) {
 		EnableQuota:           true,
 		DisableAnonymous:      true,
 		AppModeProduction:     true,
+		EnableLog:             true,
 	})
 
 	grafanaListedAddr, store := testinfra.StartGrafana(t, dir, path)
@@ -2121,6 +2128,7 @@ func TestIntegrationEval(t *testing.T) {
 		EnableQuota:           true,
 		DisableAnonymous:      true,
 		AppModeProduction:     true,
+		EnableLog:             true,
 	})
 
 	grafanaListedAddr, store := testinfra.StartGrafana(t, dir, path)

--- a/pkg/tests/testinfra/testinfra.go
+++ b/pkg/tests/testinfra/testinfra.go
@@ -345,6 +345,11 @@ func CreateGrafDir(t *testing.T, opts ...GrafanaOpts) (string, string) {
 			require.NoError(t, err)
 			_, err = serverSection.NewKey("router_logging", "true")
 			require.NoError(t, err)
+
+			databaseSection, err := getOrCreateSection("database")
+			require.NoError(t, err)
+			_, err = databaseSection.NewKey("log_queries", "true")
+			require.NoError(t, err)
 		}
 
 		if o.APIServerStorageType != "" {

--- a/pkg/tests/testinfra/testinfra.go
+++ b/pkg/tests/testinfra/testinfra.go
@@ -242,6 +242,11 @@ func CreateGrafDir(t *testing.T, opts ...GrafanaOpts) (string, string) {
 		return section, err
 	}
 
+	dbCfg, err := cfg.NewSection("database")
+	require.NoError(t, err)
+	_, err = dbCfg.NewKey("wal", "true")
+	require.NoError(t, err)
+
 	for _, o := range opts {
 		if o.EnableCSP {
 			securitySect, err := cfg.NewSection("security")


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

Enables SQLite WAL mode in the integration tests.

**Why do we need this feature?**

This helps mitigate the problem with concurrent access to table `server_lock` when Grafana starts. 

**Who is this feature for?**

Unblock CI
