### PR TITLE
Chore: Move folder sync logic into one-shot migration

### DIFF
--- a/pkg/services/sqlstore/migrations/folder_mig.go
+++ b/pkg/services/sqlstore/migrations/folder_mig.go
@@ -35,6 +35,26 @@ func addFolderMigrations(mg *migrator.Migrator) {
 		Type: migrator.UniqueIndex,
 		Cols: []string{"title", "parent_uid", "org_id"},
 	}))
+
+	mg.AddMigration("Sync dashboard and folder table", migrator.NewRawSQLMigration("").
+		Mysql(`
+			INSERT INTO folder (uid, org_id, title, created, updated)
+			SELECT * FROM (SELECT uid, org_id, title, created, updated FROM dashboard WHERE is_folder = 1) AS derived
+			ON DUPLICATE KEY UPDATE title=derived.title, updated=derived.updated
+		`).Postgres(`
+			INSERT INTO folder (uid, org_id, title, created, updated)
+			SELECT uid, org_id, title, created, updated FROM dashboard WHERE is_folder = true
+			ON CONFLICT(uid, org_id) DO UPDATE SET title=excluded.title, updated=excluded.updated
+		`).SQLite(`
+			INSERT INTO folder (uid, org_id, title, created, updated)
+			SELECT uid, org_id, title, created, updated FROM dashboard WHERE is_folder = 1
+			ON CONFLICT DO UPDATE SET title=excluded.title, updated=excluded.updated
+		`))
+
+	mg.AddMigration("Remove ghost folders from the folder table", migrator.NewRawSQLMigration(`
+			DELETE FROM folder WHERE NOT EXISTS
+				(SELECT 1 FROM dashboard WHERE dashboard.uid = folder.uid AND dashboard.org_id = folder.org_id AND dashboard.is_folder = true)
+	`))
 }
 
 func folderv1() migrator.Table {


### PR DESCRIPTION
At a certain point for some users who enabled/disabled NestedFolder feature toggle some data got out of sync. This caused deleted folders to appear again or updated folders to roll back to the previous state. 

As a possible mitigation we've introduced a SQL statement that forcefully sync data in dashboard and folder tables to avoid them drifting apart.

Now since most of the sync code has been moved outside of the feature toggle - we can convert that idempotent data migration (that ran on every start of an instance) into a proper Raw SQL migration to run it once. For most users it should be a no-op.