### PR TITLE
Stat: Support no value in spark line

### DIFF
--- a/packages/grafana-data/src/transformations/index.ts
+++ b/packages/grafana-data/src/transformations/index.ts
@@ -23,3 +23,4 @@ export { ensureTimeField } from './transformers/convertFieldType';
 
 // Required for Sparklines util to work in @grafana/data, but ideally kept internal
 export { applyNullInsertThreshold } from './transformers/nulls/nullInsertThreshold';
+export { nullToValue } from './transformers/nulls/nullToValue';

--- a/packages/grafana-ui/src/components/BigValue/BigValue.story.tsx
+++ b/packages/grafana-ui/src/components/BigValue/BigValue.story.tsx
@@ -57,6 +57,50 @@ interface StoryProps extends Partial<Props> {
   valueText: string;
 }
 
+export const ApplyNoValue: Story<StoryProps> = ({
+  valueText,
+  title,
+  colorMode,
+  graphMode,
+  height,
+  width,
+  color,
+  textMode,
+  justifyMode,
+}) => {
+  const theme = useTheme2();
+  const sparkline: FieldSparkline = {
+    y: {
+      name: '',
+      values: [1, 2, 3, null, null],
+      type: FieldType.number,
+      state: { range: { min: 1, max: 4, delta: 3 } },
+      config: {
+        noValue: '0',
+      },
+    },
+  };
+
+  return (
+    <BigValue
+      theme={theme}
+      width={width}
+      height={height}
+      colorMode={colorMode}
+      graphMode={graphMode}
+      textMode={textMode}
+      justifyMode={justifyMode}
+      value={{
+        text: valueText,
+        numeric: 5022,
+        color: color,
+        title,
+      }}
+      sparkline={graphMode === BigValueGraphMode.None ? undefined : sparkline}
+    />
+  );
+};
+
 export const Basic: Story<StoryProps> = ({
   valueText,
   title,
@@ -100,6 +144,18 @@ export const Basic: Story<StoryProps> = ({
 };
 
 Basic.args = {
+  valueText: '$5022',
+  title: 'Total Earnings',
+  colorMode: BigValueColorMode.Value,
+  graphMode: BigValueGraphMode.Area,
+  justifyMode: BigValueJustifyMode.Auto,
+  width: 400,
+  height: 300,
+  color: 'red',
+  textMode: BigValueTextMode.Auto,
+};
+
+ApplyNoValue.args = {
   valueText: '$5022',
   title: 'Total Earnings',
   colorMode: BigValueColorMode.Value,

--- a/packages/grafana-ui/src/components/Sparkline/Sparkline.tsx
+++ b/packages/grafana-ui/src/components/Sparkline/Sparkline.tsx
@@ -10,6 +10,7 @@ import {
   FieldSparkline,
   FieldType,
   getFieldColorModeForField,
+  nullToValue,
 } from '@grafana/data';
 import {
   AxisPlacement,
@@ -62,7 +63,8 @@ export class Sparkline extends PureComponent<SparklineProps, State> {
   }
 
   static getDerivedStateFromProps(props: SparklineProps, state: State) {
-    const frame = preparePlotFrame(props.sparkline, props.config);
+    const _frame = preparePlotFrame(props.sparkline, props.config);
+    const frame = nullToValue(_frame);
     if (!frame) {
       return { ...state };
     }
@@ -96,6 +98,12 @@ export class Sparkline extends PureComponent<SparklineProps, State> {
 
   getYRange(field: Field): Range.MinMax {
     let { min, max } = this.state.alignedDataFrame.fields[1].state?.range!;
+    const noValue = +this.state.alignedDataFrame.fields[1].config?.noValue!;
+
+    if (!Number.isNaN(noValue)) {
+      min = Math.min(min!, +noValue);
+      max = Math.max(max!, +noValue);
+    }
 
     if (min === max) {
       if (min === 0) {


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**
[Add a brief description of what the feature or update does.]
1. make stat panel support  no value 
2.  add storybook case for  BigValue component's noValue  case


**Why do we need this feature?**
[Add a description of the problem the feature is trying to solve.]
https://github.com/grafana/grafana/issues/52789

**Who is this feature for?**

[Add information on what kind of user the feature is for.]

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #52789

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
