### PR TITLE
Chore: Make xorm ignore tsvector columns

### DIFF
--- a/pkg/services/sqlstore/migrations/folder_mig.go
+++ b/pkg/services/sqlstore/migrations/folder_mig.go
@@ -35,6 +35,10 @@ func addFolderMigrations(mg *migrator.Migrator) {
 		Type: migrator.UniqueIndex,
 		Cols: []string{"title", "parent_uid", "org_id"},
 	}))
+
+	mg.AddMigration("Test", migrator.NewRawSQLMigration("").Postgres(`
+		CREATE TABLE fts(title TEXT, ts tsvector)
+	`))
 }
 
 func folderv1() migrator.Table {

--- a/pkg/util/xorm/dialect_postgres.go
+++ b/pkg/util/xorm/dialect_postgres.go
@@ -1036,6 +1036,8 @@ WHERE c.relkind = 'r'::char AND c.relname = $1%s AND f.attnum > 0 ORDER BY f.att
 			col.SQLType = core.SQLType{Name: core.Time, DefaultLength: 0, DefaultLength2: 0}
 		case "oid":
 			col.SQLType = core.SQLType{Name: core.BigInt, DefaultLength: 0, DefaultLength2: 0}
+		case "tsvector":
+			continue
 		default:
 			col.SQLType = core.SQLType{Name: strings.ToUpper(dataType), DefaultLength: 0, DefaultLength2: 0}
 		}

--- a/pkg/util/xorm/dialect_postgres.go
+++ b/pkg/util/xorm/dialect_postgres.go
@@ -1037,6 +1037,7 @@ WHERE c.relkind = 'r'::char AND c.relname = $1%s AND f.attnum > 0 ORDER BY f.att
 		case "oid":
 			col.SQLType = core.SQLType{Name: core.BigInt, DefaultLength: 0, DefaultLength2: 0}
 		case "tsvector":
+			// Ignore tsvector columns in PostgreSQL. Xorm does not know how to work with them anyway, but otherwise it would fail on unknown column type.
 			continue
 		default:
 			col.SQLType = core.SQLType{Name: strings.ToUpper(dataType), DefaultLength: 0, DefaultLength2: 0}


### PR DESCRIPTION
This PR tampers with xorm making it ignore FTS columns in PostgreSQL (tsvector column type). FTS types are unknown to xorm anyway, it doesn't know how to map them etc. So it should be safe to ignore such columns when a table info is requested.

Table info on the other hand is needed in Grafana to run intergration tests. We merely need table names for that (and not even column types), but it doesn't seem like Xorm has an API just for that. 🤷 

An alternative would be to treat this column as a BLOB or something and hope nobody would ever use it with xorm helpers. I much prefer hiding the column from xorm completely.