### PR TITLE
Docs: Add JSON Body Schema for creating data source

### DIFF
--- a/docs/sources/developers/http_api/data_source.md
+++ b/docs/sources/developers/http_api/data_source.md
@@ -360,8 +360,8 @@ JSON Body schema:
 - **name** – Name of data source
 - **type** – Type of data source
 - **url** – Url of data source
-- **access** - The access mode for the data source. "proxy" or "direct"
-- **basicAuth** –  Whether basic authentication is enabled for the data source.
+- **access** - The access mode for the data source. "proxy" or "direct". Some data sources are only compatible with proxy.
+- **basicAuth** – Whether basic authentication is enabled for the data source.
 
 **Example Graphite Request with basic auth enabled**:
 

--- a/docs/sources/developers/http_api/data_source.md
+++ b/docs/sources/developers/http_api/data_source.md
@@ -355,6 +355,14 @@ Content-Type: application/json
 By defining `password` and `basicAuthPassword` under `secureJsonData` Grafana encrypts them securely as an encrypted blob in the database. The response then lists the encrypted fields under `secureJsonFields`.
 {{% /admonition %}}
 
+JSON Body schema:
+
+- **name** – Name of data source
+- **type** – Type of data source
+- **url** – Url of data source
+- **access** - The access mode for the data source. "proxy" or "direct"
+- **basicAuth** –  Whether basic authentication is enabled for the data source.
+
 **Example Graphite Request with basic auth enabled**:
 
 ```http

--- a/pkg/services/datasources/models.go
+++ b/pkg/services/datasources/models.go
@@ -44,8 +44,10 @@ type DataSource struct {
 	OrgID   int64 `json:"orgId,omitempty" xorm:"org_id"`
 	Version int   `json:"version,omitempty"`
 
-	Name   string   `json:"name"`
-	Type   string   `json:"type"`
+	Name string `json:"name"`
+	Type string `json:"type"`
+	// Some data sources are incompatible with any setting but proxy (Server).
+	// enum: Proxy,Direct
 	Access DsAccess `json:"access"`
 	URL    string   `json:"url" xorm:"url"`
 	// swagger:ignore

--- a/pkg/services/datasources/models.go
+++ b/pkg/services/datasources/models.go
@@ -37,6 +37,7 @@ const (
 	CustomHeaderValue = "httpHeaderValue"
 )
 
+// enum: Proxy,Direct
 type DsAccess string
 
 type DataSource struct {
@@ -44,10 +45,8 @@ type DataSource struct {
 	OrgID   int64 `json:"orgId,omitempty" xorm:"org_id"`
 	Version int   `json:"version,omitempty"`
 
-	Name string `json:"name"`
-	Type string `json:"type"`
-	// Some data sources are incompatible with any setting but proxy (Server).
-	// enum: Proxy,Direct
+	Name   string   `json:"name"`
+	Type   string   `json:"type"`
 	Access DsAccess `json:"access"`
 	URL    string   `json:"url" xorm:"url"`
 	// swagger:ignore

--- a/public/api-merged.json
+++ b/public/api-merged.json
@@ -13746,6 +13746,7 @@
       }
     },
     "DsAccess": {
+      "description": "enum: Proxy,Direct",
       "type": "string"
     },
     "DsPermissionType": {

--- a/public/openapi3.json
+++ b/public/openapi3.json
@@ -4754,6 +4754,7 @@
         "type": "object"
       },
       "DsAccess": {
+        "description": "enum: Proxy,Direct",
         "type": "string"
       },
       "DsPermissionType": {


### PR DESCRIPTION
**What is this feature?**

Add Json Body Schema for creating data source for clearer instruction.

**Why do we need this feature?**

 Issue [#71699](https://github.com/grafana/grafana/issues/71699) was raised mentioning that values for access field for creating data source was not clearly stated.

**Which issue(s) does this PR fix?**:

Fixes #71699

**How to test this**
Go to 
http://localhost:3002/docs/grafana/latest/developers/http_api/data_source/#create-a-data-source & 
http://localhost:3000/swagger#/datasources/addDataSource
to check for the newly provided info
![image](https://github.com/grafana/grafana/assets/81026263/e8df869e-f90b-4c9d-b37e-0b21490d8be1)
![image](https://github.com/grafana/grafana/assets/81026263/e73f6c49-82db-4ae2-aba3-45ba3d5b6621)

**Special notes for your reviewer:**

Please check that:

- [ ] It works as expected from a user's perspective.
- [ ]  If this is a pre-GA feature, it is behind a feature toggle.
- [ ]  The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.