### PR TITLE
Alerting: adds execErrState to the alerting file provisioning example as it is missing

### DIFF
--- a/docs/sources/alerting/set-up/provision-alerting-resources/file-provisioning/index.md
+++ b/docs/sources/alerting/set-up/provision-alerting-resources/file-provisioning/index.md
@@ -108,6 +108,7 @@ groups:
         # <string> the state the alert rule will have when the query execution
         #          failed - possible values: "Error", "Alerting", "OK"
         #          default = Alerting
+        execErrState: Alerting
         # <duration, required> for how long should the alert fire before alerting
         for: 60s
         # <map<string, string>> a map of strings to pass around any data


### PR DESCRIPTION
**What is this feature?**

Adds the execErrState to the alerting file provisioning example as it is missing there.

**Why do we need this feature?**

This bugfix is needed to have a complete and comprehensive documentation of the alerting file provisioning. I do not know a different location where the execErrState is documented.

**Who is this feature for?**

For everybody who is trying to understand alerting file provisioning.

**Which issue(s) does this PR fix?**:

I did not raise an issue for that, but directly filed a prull request.

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
