### PR TITLE
[v10.1.x] Alerting: Fix deleting rules in a folder with matching UID in another organization

### DIFF
--- a/pkg/api/apierrors/folder.go
+++ b/pkg/api/apierrors/folder.go
@@ -18,8 +18,7 @@ func ToFolderErrorResponse(err error) response.Response {
 	if errors.Is(err, dashboards.ErrFolderTitleEmpty) ||
 		errors.Is(err, dashboards.ErrDashboardTypeMismatch) ||
 		errors.Is(err, dashboards.ErrDashboardInvalidUid) ||
-		errors.Is(err, dashboards.ErrDashboardUidTooLong) ||
-		errors.Is(err, dashboards.ErrFolderContainsAlertRules) {
+		errors.Is(err, dashboards.ErrDashboardUidTooLong) {
 		return response.Error(400, err.Error(), nil)
 	}
 

--- a/pkg/services/dashboards/database/database.go
+++ b/pkg/services/dashboards/database/database.go
@@ -721,10 +721,6 @@ func (d *dashboardStore) deleteDashboard(cmd *dashboards.DeleteDashboardCommand,
 		if err != nil {
 			return err
 		}
-
-		if err := deleteFolderAlertRules(sess, dashboard, cmd.ForceDeleteFolderRules); err != nil {
-			return err
-		}
 	} else {
 		if err := d.deleteResourcePermissions(sess, dashboard.OrgID, ac.GetResourceScopeUID("dashboards", dashboard.UID)); err != nil {
 			return err
@@ -811,33 +807,6 @@ func (d *dashboardStore) deleteChildrenDashboardAssociations(sess *db.Session, d
 
 		for _, sql := range childrenDeletes {
 			_, err := sess.Exec(sql, dashboard.OrgID, dashboard.ID)
-			if err != nil {
-				return err
-			}
-		}
-	}
-	return nil
-}
-
-func deleteFolderAlertRules(sess *db.Session, dashboard dashboards.Dashboard, forceDeleteFolderAlertRules bool) error {
-	var existingRuleID int64
-	exists, err := sess.Table("alert_rule").Where("namespace_uid = (SELECT uid FROM dashboard WHERE id = ?)", dashboard.ID).Cols("id").Get(&existingRuleID)
-	if err != nil {
-		return err
-	}
-	if exists {
-		if !forceDeleteFolderAlertRules {
-			return fmt.Errorf("folder cannot be deleted: %w", dashboards.ErrFolderContainsAlertRules)
-		}
-
-		// Delete all rules under this folder.
-		deleteNGAlertsByFolder := []string{
-			"DELETE FROM alert_rule WHERE namespace_uid = (SELECT uid FROM dashboard WHERE id = ?)",
-			"DELETE FROM alert_rule_version WHERE rule_namespace_uid = (SELECT uid FROM dashboard WHERE id = ?)",
-		}
-
-		for _, sql := range deleteNGAlertsByFolder {
-			_, err := sess.Exec(sql, dashboard.ID)
 			if err != nil {
 				return err
 			}

--- a/pkg/services/dashboards/database/database_test.go
+++ b/pkg/services/dashboards/database/database_test.go
@@ -3,7 +3,6 @@ package database
 import (
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"testing"
 	"time"
@@ -251,45 +250,6 @@ func TestIntegrationDashboardDataAccess(t *testing.T) {
 
 		deleteCmd := &dashboards.DeleteDashboardCommand{ID: emptyFolder.ID}
 		err := dashboardStore.DeleteDashboard(context.Background(), deleteCmd)
-		require.NoError(t, err)
-	})
-
-	t.Run("Should be not able to delete a dashboard if force delete rules is disabled", func(t *testing.T) {
-		setup()
-		deleteCmd := &dashboards.DeleteDashboardCommand{ID: savedFolder.ID, ForceDeleteFolderRules: false}
-		err := dashboardStore.DeleteDashboard(context.Background(), deleteCmd)
-		require.True(t, errors.Is(err, dashboards.ErrFolderContainsAlertRules))
-	})
-
-	t.Run("Should be able to delete a dashboard folder and its children if force delete rules is enabled", func(t *testing.T) {
-		setup()
-		deleteCmd := &dashboards.DeleteDashboardCommand{ID: savedFolder.ID, ForceDeleteFolderRules: true}
-		err := dashboardStore.DeleteDashboard(context.Background(), deleteCmd)
-		require.NoError(t, err)
-
-		query := dashboards.FindPersistedDashboardsQuery{
-			OrgId:        1,
-			FolderIds:    []int64{savedFolder.ID},
-			SignedInUser: &user.SignedInUser{},
-		}
-
-		res, err := dashboardStore.FindDashboards(context.Background(), &query)
-		require.NoError(t, err)
-		require.Equal(t, len(res), 0)
-
-		err = sqlStore.WithDbSession(context.Background(), func(sess *db.Session) error {
-			var existingRuleID int64
-			exists, err := sess.Table("alert_rule").Where("namespace_uid = (SELECT uid FROM dashboard WHERE id = ?)", savedFolder.ID).Cols("id").Get(&existingRuleID)
-			require.NoError(t, err)
-			require.False(t, exists)
-
-			var existingRuleVersionID int64
-			exists, err = sess.Table("alert_rule_version").Where("rule_namespace_uid = (SELECT uid FROM dashboard WHERE id = ?)", savedFolder.ID).Cols("id").Get(&existingRuleVersionID)
-			require.NoError(t, err)
-			require.False(t, exists)
-
-			return nil
-		})
 		require.NoError(t, err)
 	})
 

--- a/pkg/services/dashboards/errors.go
+++ b/pkg/services/dashboards/errors.go
@@ -117,14 +117,13 @@ var (
 		Status:     "not-found",
 	}
 
-	ErrFolderNotFound           = errors.New("folder not found")
-	ErrFolderVersionMismatch    = errors.New("the folder has been changed by someone else")
-	ErrFolderTitleEmpty         = errors.New("folder title cannot be empty")
-	ErrFolderWithSameUIDExists  = errors.New("a folder/dashboard with the same uid already exists")
-	ErrFolderInvalidUID         = errors.New("invalid uid for folder provided")
-	ErrFolderSameNameExists     = errors.New("a folder or dashboard in the general folder with the same name already exists")
-	ErrFolderAccessDenied       = errors.New("access denied to folder")
-	ErrFolderContainsAlertRules = errors.New("folder contains alert rules")
+	ErrFolderNotFound          = errors.New("folder not found")
+	ErrFolderVersionMismatch   = errors.New("the folder has been changed by someone else")
+	ErrFolderTitleEmpty        = errors.New("folder title cannot be empty")
+	ErrFolderWithSameUIDExists = errors.New("a folder/dashboard with the same uid already exists")
+	ErrFolderInvalidUID        = errors.New("invalid uid for folder provided")
+	ErrFolderSameNameExists    = errors.New("a folder or dashboard in the general folder with the same name already exists")
+	ErrFolderAccessDenied      = errors.New("access denied to folder")
 )
 
 // DashboardErr represents a dashboard error.

--- a/pkg/services/dashboards/service/dashboard_service_test.go
+++ b/pkg/services/dashboards/service/dashboard_service_test.go
@@ -206,7 +206,7 @@ func TestDashboardService(t *testing.T) {
 
 		t.Run("Given non provisioned dashboard", func(t *testing.T) {
 			t.Run("DeleteProvisionedDashboard should delete the dashboard", func(t *testing.T) {
-				args := &dashboards.DeleteDashboardCommand{OrgID: 1, ID: 1, ForceDeleteFolderRules: false}
+				args := &dashboards.DeleteDashboardCommand{OrgID: 1, ID: 1}
 				fakeStore.On("DeleteDashboard", mock.Anything, args).Return(nil).Once()
 				err := service.DeleteProvisionedDashboard(context.Background(), 1, 1)
 				require.NoError(t, err)

--- a/pkg/services/folder/folderimpl/folder.go
+++ b/pkg/services/folder/folderimpl/folder.go
@@ -512,6 +512,19 @@ func (s *Service) Delete(ctx context.Context, cmd *folder.DeleteFolderCommand) e
 				if err := s.deleteChildrenInFolder(ctx, dashFolder.OrgID, dashFolder.UID, cmd.SignedInUser); err != nil {
 					return err
 				}
+			} else {
+				alertRuleSrv, ok := s.registry[entity.StandardKindAlertRule]
+				if !ok {
+					return folder.ErrInternal.Errorf("no alert rule service found in registry")
+				}
+				alertRulesInFolder, err := alertRuleSrv.CountInFolder(ctx, dashFolder.OrgID, dashFolder.UID, cmd.SignedInUser)
+				if err != nil {
+					s.log.Error("failed to count alert rules in folder", "error", err)
+					return err
+				}
+				if alertRulesInFolder > 0 {
+					return folder.ErrFolderNotEmpty.Errorf("folder contains %d alert rules", alertRulesInFolder)
+				}
 			}
 
 			err = s.legacyDelete(ctx, cmd, dashFolder)

--- a/pkg/services/folder/folderimpl/folder.go
+++ b/pkg/services/folder/folderimpl/folder.go
@@ -502,8 +502,8 @@ func (s *Service) Delete(ctx context.Context, cmd *folder.DeleteFolderCommand) e
 			result = append(result, subfolders...)
 		}
 
-		for _, folder := range result {
-			dashFolder, err := s.dashboardFolderStore.GetFolderByUID(ctx, cmd.OrgID, folder)
+		for _, f := range result {
+			dashFolder, err := s.dashboardFolderStore.GetFolderByUID(ctx, cmd.OrgID, f)
 			if err != nil {
 				return err
 			}

--- a/pkg/services/folder/model.go
+++ b/pkg/services/folder/model.go
@@ -16,6 +16,7 @@ var ErrDatabaseError = errutil.NewBase(errutil.StatusInternal, "folder.database-
 var ErrInternal = errutil.NewBase(errutil.StatusInternal, "folder.internal")
 var ErrCircularReference = errutil.NewBase(errutil.StatusBadRequest, "folder.circular-reference", errutil.WithPublicMessage("Circular reference detected"))
 var ErrTargetRegistrySrvConflict = errutil.NewBase(errutil.StatusInternal, "folder.target-registry-srv-conflict")
+var ErrFolderNotEmpty = errutil.NewBase(errutil.StatusBadRequest, "folder.not-empty", errutil.WithPublicMessage("Folder cannot be deleted: folder is not empty"))
 
 const (
 	GeneralFolderUID     = "general"

--- a/pkg/services/ngalert/store/alert_rule.go
+++ b/pkg/services/ngalert/store/alert_rule.go
@@ -9,6 +9,7 @@ import (
 	"github.com/google/uuid"
 
 	"github.com/grafana/grafana/pkg/infra/db"
+	"github.com/grafana/grafana/pkg/services/accesscontrol"
 	"github.com/grafana/grafana/pkg/services/dashboards"
 	"github.com/grafana/grafana/pkg/services/featuremgmt"
 	"github.com/grafana/grafana/pkg/services/folder"
@@ -587,6 +588,17 @@ func (st DBstore) GetAlertRulesForScheduling(ctx context.Context, query *ngmodel
 
 // DeleteInFolder deletes the rules contained in a given folder along with their associated data.
 func (st DBstore) DeleteInFolder(ctx context.Context, orgID int64, folderUID string, user *user.SignedInUser) error {
+	evaluator := accesscontrol.EvalPermission(accesscontrol.ActionAlertingRuleDelete, dashboards.ScopeFoldersProvider.GetResourceScopeName(folderUID))
+	canSave, err := st.AccessControl.Evaluate(ctx, user, evaluator)
+	if err != nil {
+		st.Logger.Error("Failed to evaluate access control", "error", err)
+		return err
+	}
+	if !canSave {
+		st.Logger.Error("user is not allowed to delete alert rules in folder", "folder", folderUID, "user")
+		return dashboards.ErrFolderAccessDenied
+	}
+
 	rules, err := st.ListAlertRules(ctx, &ngmodels.ListAlertRulesQuery{
 		OrgID:         orgID,
 		NamespaceUIDs: []string{folderUID},

--- a/pkg/services/ngalert/store/alert_rule_test.go
+++ b/pkg/services/ngalert/store/alert_rule_test.go
@@ -12,6 +12,8 @@ import (
 	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/infra/log/logtest"
 	"github.com/grafana/grafana/pkg/infra/tracing"
+	"github.com/grafana/grafana/pkg/services/accesscontrol"
+	"github.com/grafana/grafana/pkg/services/dashboards"
 	"github.com/grafana/grafana/pkg/services/featuremgmt"
 	"github.com/grafana/grafana/pkg/services/folder"
 	"github.com/grafana/grafana/pkg/services/folder/folderimpl"
@@ -24,6 +26,7 @@ import (
 	"golang.org/x/exp/rand"
 
 	"github.com/grafana/grafana/pkg/infra/db"
+	acmock "github.com/grafana/grafana/pkg/services/accesscontrol/mock"
 	"github.com/grafana/grafana/pkg/services/ngalert/models"
 	"github.com/grafana/grafana/pkg/setting"
 	"github.com/grafana/grafana/pkg/util"
@@ -474,12 +477,23 @@ func TestIntegration_DeleteInFolder(t *testing.T) {
 	}
 	rule := createRule(t, store, nil)
 
-	err := store.DeleteInFolder(context.Background(), rule.OrgID, rule.NamespaceUID, nil)
-	require.NoError(t, err)
+	t.Run("should not be able to delete folder without permissions to delete rules", func(t *testing.T) {
+		store.AccessControl = acmock.New()
+		err := store.DeleteInFolder(context.Background(), rule.OrgID, rule.NamespaceUID, &user.SignedInUser{})
+		require.ErrorIs(t, err, dashboards.ErrFolderAccessDenied)
+	})
 
-	c, err := store.CountInFolder(context.Background(), rule.OrgID, rule.NamespaceUID, nil)
-	require.NoError(t, err)
-	require.Equal(t, int64(0), c)
+	t.Run("should be able to delete folder with permissions to delete rules", func(t *testing.T) {
+		store.AccessControl = acmock.New().WithPermissions([]accesscontrol.Permission{
+			{Action: accesscontrol.ActionAlertingRuleDelete, Scope: dashboards.ScopeFoldersAll},
+		})
+		err := store.DeleteInFolder(context.Background(), rule.OrgID, rule.NamespaceUID, &user.SignedInUser{})
+		require.NoError(t, err)
+
+		c, err := store.CountInFolder(context.Background(), rule.OrgID, rule.NamespaceUID, &user.SignedInUser{})
+		require.NoError(t, err)
+		require.Equal(t, int64(0), c)
+	})
 }
 
 func createRule(t *testing.T, store *DBstore, generate func() *models.AlertRule) *models.AlertRule {

--- a/pkg/tests/api/alerting/api_alertmanager_test.go
+++ b/pkg/tests/api/alerting/api_alertmanager_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/grafana/grafana/pkg/expr"
+	"github.com/grafana/grafana/pkg/util/errutil"
 
 	apimodels "github.com/grafana/grafana/pkg/services/ngalert/api/tooling/definitions"
 	ngmodels "github.com/grafana/grafana/pkg/services/ngalert/models"
@@ -799,7 +800,10 @@ func TestIntegrationDeleteFolderWithRules(t *testing.T) {
 		b, err := io.ReadAll(resp.Body)
 		require.NoError(t, err)
 		require.Equal(t, http.StatusBadRequest, resp.StatusCode)
-		require.JSONEq(t, `{"message":"folder cannot be deleted: folder contains alert rules"}`, string(b))
+		var errutilErr errutil.PublicError
+		err = json.Unmarshal(b, &errutilErr)
+		require.NoError(t, err)
+		assert.Equal(t, "Folder cannot be deleted: folder is not empty", errutilErr.Message)
 	}
 
 	// Next, the editor can delete the folder if forceDeleteRules is true.


### PR DESCRIPTION
Backport 6d4625ad52b2e2ad3b2b88e394f69e8fde83c04b from #78258

---

<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

The [deleteFolderAlertRules()](https://github.com/grafana/grafana/blob/9452a6fcf77e871c6073c1dcbe73a286d86c3f24/pkg/services/dashboards/database/database.go#L796) function that is declared inside dashboard service has become obsolete since #67259 (alert rules get deleted [here](https://github.com/grafana/grafana/blob/e2755e5178c073a94052c68cbce2fdf609fa37cc/pkg/services/folder/folderimpl/folder.go#L506) using [DeleteInFolder()](https://github.com/grafana/grafana/blob/9cb303c3f701169e8651267744a4b5fe1695a066/pkg/services/ngalert/store/alert_rule.go#L591)) but it was still got called.
Unfortunately, this function doesn't take into account the `org_id`. As a result:
- trying to delete a folder without alerts with matching folder UID in another organization (with alerts) wrongly fails with `folder cannot be deleted: folder contains alert rules`
- deleting a folder  using `forceDeleteRules=true` would wrongly delete alert rules with matching folder (namespace_uid) UID in another organization (with alerts)

**Why do we need this feature?**

It fixes the above issues by removing the obsolete call.
 
**Who is this feature for?**

[Add information on what kind of user the feature is for.]

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.