### PR TITLE
Alerting: Improve performance of TrimResults

### DIFF
--- a/pkg/services/ngalert/state/state.go
+++ b/pkg/services/ngalert/state/state.go
@@ -399,9 +399,7 @@ func (a *State) TrimResults(alertRule *models.AlertRule) {
 	if len(a.Results) < int(numBuckets) {
 		return
 	}
-	newResults := make([]Evaluation, numBuckets)
-	copy(newResults, a.Results[len(a.Results)-int(numBuckets):])
-	a.Results = newResults
+	a.Results = a.Results[len(a.Results)-int(numBuckets):]
 }
 
 func nextEndsTime(interval int64, evaluatedAt time.Time) time.Time {


### PR DESCRIPTION
**What is this feature?**

I've run some benchmarks and found that taking a subslice is much faster than `copy`. The subslice will be copied on the next call to `Append`, but additional copies will be deferred until the backing array needs to be resized a subsequent time. This is in comparison to the current code, which creates a new backing array and copies all data on every call (once `a.Results` has exceeded `numBuckets` for the first time).

**Benchmarks**:

I ran the following benchmark to compare performance of the old function with the new function:

```
BenchmarkTrimResults-8       	200140569	       180.7 ns/op
BenchmarkTrimResultsFast-8   	1000000000	        29.41 ns/op
```

and the same benchmark with allocations:

```
BenchmarkTrimResults-8       	201521774	       179.4 ns/op	     864 B/op       2 allocs/op
BenchmarkTrimResultsFast-8   	1000000000	        29.14 ns/op	     115 B/op       0 allocs/op
```

**Abstract benchmarks**

I ran the following benchmark to compare performance of taking a subslice v.s `copy`:

```go
package main

import (
	"testing"
)

const LogMaxSize = 10;

type AppendLog []int

func (a *AppendLog) Append(i int) {
	if len(*a) >= LogMaxSize {
		*a = (*a)[1:len(*a)]
	}
	*a = append(*a, i)
}

type CopyLog []int

func (c *CopyLog) Append(i int) {
	if len(*c) >= LogMaxSize {
		tmp := make(CopyLog, len(*c)-1)
		copy(tmp, (*c)[1:len(*c)])
		*c = tmp
	}
	*c = append(*c, i)
}

func BenchmarkAppend(b *testing.B) {
	for n := 0; n < b.N; n++ {
		a := make(AppendLog, 0)
		for i := 0; i < 10000; i++ {
			a.Append(i)
		}
	}
}

func BenchmarkCopy(b *testing.B) {
	for n := 0; n < b.N; n++ {
		c := make(CopyLog, 0)
		for i := 0; i < 10000; i++ {
			c.Append(i)
		}
	}
}
```

```
BenchmarkAppend-8   	   23932	     48397 ns/op
BenchmarkCopy-8     	    2660	    442576 ns/op
```

**Who is this feature for?**

[Add information on what kind of user the feature is for.]

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
