### PR TITLE
Alerting: Use real context on secret encryption

### DIFF
--- a/pkg/services/ngalert/migration/channel_test.go
+++ b/pkg/services/ngalert/migration/channel_test.go
@@ -269,7 +269,7 @@ func TestCreateReceivers(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			service := NewTestMigrationService(t, sqlStore, nil)
 			m := service.newOrgMigration(1)
-			recvMap, recvs, err := m.createReceivers(tt.allChannels)
+			recvMap, recvs, err := m.createReceivers(context.Background(), tt.allChannels)
 			if tt.expErr != nil {
 				require.Error(t, err)
 				require.EqualError(t, err, tt.expErr.Error())
@@ -385,7 +385,7 @@ func TestMigrateNotificationChannelSecureSettings(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			service := NewTestMigrationService(t, sqlStore, nil)
 			m := service.newOrgMigration(1)
-			recv, err := m.createNotifier(tt.channel)
+			recv, err := m.createNotifier(context.Background(), tt.channel)
 			if tt.expErr != nil {
 				require.Error(t, err)
 				require.EqualError(t, err, tt.expErr.Error())
@@ -419,7 +419,7 @@ func TestMigrateNotificationChannelSecureSettings(t *testing.T) {
 							channel.SecureSettings[key] = []byte(legacyEncryptFn("secure " + key))
 						}
 					})
-					recv, err := m.createNotifier(channel)
+					recv, err := m.createNotifier(context.Background(), channel)
 					require.NoError(t, err)
 
 					require.Equal(t, nType, recv.Type)
@@ -454,7 +454,7 @@ func TestMigrateNotificationChannelSecureSettings(t *testing.T) {
 							channel.Settings.Set(key, "secure "+key)
 						}
 					})
-					recv, err := m.createNotifier(channel)
+					recv, err := m.createNotifier(context.Background(), channel)
 					require.NoError(t, err)
 
 					require.Equal(t, nType, recv.Type)
@@ -547,7 +547,7 @@ func TestCreateDefaultRouteAndReceiver(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			service := NewTestMigrationService(t, sqlStore, nil)
 			m := service.newOrgMigration(1)
-			recv, route, err := m.createDefaultRouteAndReceiver(tt.defaultChannels)
+			recv, route, err := m.createDefaultRouteAndReceiver(context.Background(), tt.defaultChannels)
 			if tt.expErr != nil {
 				require.Error(t, err)
 				require.EqualError(t, err, tt.expErr.Error())

--- a/pkg/services/ngalert/migration/ualert.go
+++ b/pkg/services/ngalert/migration/ualert.go
@@ -68,7 +68,7 @@ func (om *OrgMigration) migrateOrgChannels(ctx context.Context, pairs []*AlertPa
 		return nil, fmt.Errorf("load notification channels: %w", err)
 	}
 
-	amConfig, err := om.migrateChannels(channels, pairs)
+	amConfig, err := om.migrateChannels(ctx, channels, pairs)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/services/ngalert/migration/ualert_test.go
+++ b/pkg/services/ngalert/migration/ualert_test.go
@@ -1,6 +1,7 @@
 package migration
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"testing"
@@ -66,7 +67,7 @@ func Test_validateAlertmanagerConfig(t *testing.T) {
 
 			config := configFromReceivers(t, tt.receivers)
 			require.NoError(t, encryptSecureSettings(config, mg)) // make sure we encrypt the settings
-			err := mg.validateAlertmanagerConfig(config)
+			err := mg.validateAlertmanagerConfig(context.Background(), config)
 			if tt.err != nil {
 				require.Error(t, err)
 				require.EqualError(t, err, tt.err.Error())
@@ -92,7 +93,7 @@ func configFromReceivers(t *testing.T, receivers []*apimodels.PostableGrafanaRec
 func encryptSecureSettings(c *apimodels.PostableUserConfig, m *OrgMigration) error {
 	for _, r := range c.AlertmanagerConfig.Receivers {
 		for _, gr := range r.GrafanaManagedReceivers {
-			err := m.encryptSecureSettings(gr.SecureSettings)
+			err := m.encryptSecureSettings(context.Background(), gr.SecureSettings)
 			if err != nil {
 				return err
 			}

--- a/pkg/services/ngalert/provisioning/contactpoints.go
+++ b/pkg/services/ngalert/provisioning/contactpoints.go
@@ -9,8 +9,9 @@ import (
 	"sort"
 	"strings"
 
-	alertingNotify "github.com/grafana/alerting/notify"
 	"github.com/prometheus/alertmanager/config"
+
+	alertingNotify "github.com/grafana/alerting/notify"
 
 	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/services/accesscontrol"
@@ -146,7 +147,7 @@ func (ecp *ContactPointService) CreateContactPoint(ctx context.Context, orgID in
 	}
 
 	for k, v := range extractedSecrets {
-		encryptedValue, err := ecp.encryptValue(v)
+		encryptedValue, err := ecp.encryptValue(ctx, v)
 		if err != nil {
 			return apimodels.EmbeddedContactPoint{}, err
 		}
@@ -272,7 +273,7 @@ func (ecp *ContactPointService) UpdateContactPoint(ctx context.Context, orgID in
 		return err
 	}
 	for k, v := range extractedSecrets {
-		encryptedValue, err := ecp.encryptValue(v)
+		encryptedValue, err := ecp.encryptValue(ctx, v)
 		if err != nil {
 			return err
 		}
@@ -415,8 +416,8 @@ func (ecp *ContactPointService) decryptValueOrRedacted(decrypt bool, integration
 	}
 }
 
-func (ecp *ContactPointService) encryptValue(value string) (string, error) {
-	encryptedData, err := ecp.encryptionService.Encrypt(context.Background(), []byte(value), secrets.WithoutScope())
+func (ecp *ContactPointService) encryptValue(ctx context.Context, value string) (string, error) {
+	encryptedData, err := ecp.encryptionService.Encrypt(ctx, []byte(value), secrets.WithoutScope())
 	if err != nil {
 		return "", fmt.Errorf("failed to encrypt secure settings: %w", err)
 	}

--- a/pkg/services/secrets/secrets.go
+++ b/pkg/services/secrets/secrets.go
@@ -10,15 +10,9 @@ import (
 // Service is an envelope encryption service in charge of encrypting/decrypting secrets.
 // It is a replacement for encryption.Service
 type Service interface {
-	// Encrypt MUST NOT be used within database transactions, it may cause database locks.
-	// For those specific use cases where the encryption operation cannot be moved outside
-	// the database transaction, look at database-specific methods present at the specific
-	// implementation present at manager.SecretsService.
 	Encrypt(ctx context.Context, payload []byte, opt EncryptionOptions) ([]byte, error)
 	Decrypt(ctx context.Context, payload []byte) ([]byte, error)
 
-	// EncryptJsonData MUST NOT be used within database transactions.
-	// Look at Encrypt method comment for further details.
 	EncryptJsonData(ctx context.Context, kv map[string]string, opt EncryptionOptions) (map[string][]byte, error)
 	DecryptJsonData(ctx context.Context, sjd map[string][]byte) (map[string]string, error)
 


### PR DESCRIPTION
**What is this feature?**

Uses the real context in place of the background when calling `Encrypt` from within a transaction.

**Why do we need this feature?**

Warning against using `Encrypt` within a transaction seems to no longer be true since https://github.com/grafana/grafana/pull/60664. In that case, we should be using the real context so that transactionality assumptions are correct.

**Who is this feature for?**

No one in particular, though it might reduce some niche database locked errors in write-contentious sqlite installations.

**Special notes for your reviewer:**

Going to keep this in draft until I get confirmation that https://github.com/grafana/grafana/pull/60664 removed the need for the warning.

There's one more place in the code that uses background for `Encrypt`: https://github.com/grafana/grafana/blob/1eb19befaa312de3faea65342fcd57a7e4c1a570/pkg/services/login/authinfoimpl/store.go#L248-L249

The change is simple but I'll leave it to auth team to implement/test if this PR gets approved.