### PR TITLE
Alerting: Support for `condition` field in /api/v1/eval

### DIFF
--- a/pkg/services/ngalert/api/api_testing.go
+++ b/pkg/services/ngalert/api/api_testing.go
@@ -156,11 +156,8 @@ func (srv TestingApiSrv) RouteEvalQueries(c *contextmodel.ReqContext, cmd apimod
 	}
 
 	cond := ngmodels.Condition{
-		Condition: "",
+		Condition: cmd.Condition,
 		Data:      queries,
-	}
-	if len(cmd.Data) > 0 {
-		cond.Condition = cmd.Data[0].RefID
 	}
 
 	_, err := store.OptimizeAlertQueries(cond.Data)

--- a/pkg/services/ngalert/api/api_testing.go
+++ b/pkg/services/ngalert/api/api_testing.go
@@ -159,6 +159,9 @@ func (srv TestingApiSrv) RouteEvalQueries(c *contextmodel.ReqContext, cmd apimod
 		Condition: cmd.Condition,
 		Data:      queries,
 	}
+	if cond.Condition == "" && len(cond.Data) > 0 {
+		cond.Condition = cond.Data[len(cond.Data)-1].RefID
+	}
 
 	_, err := store.OptimizeAlertQueries(cond.Data)
 	if err != nil {

--- a/pkg/services/ngalert/api/tooling/definitions/testing.go
+++ b/pkg/services/ngalert/api/tooling/definitions/testing.go
@@ -128,8 +128,9 @@ type EvalQueriesRequest struct {
 
 // swagger:model
 type EvalQueriesPayload struct {
-	Data []AlertQuery `json:"data"`
-	Now  time.Time    `json:"now"`
+	Condition string       `json:"condition"`
+	Data      []AlertQuery `json:"data"`
+	Now       time.Time    `json:"now"`
 }
 
 func (p *TestRulePayload) UnmarshalJSON(b []byte) error {

--- a/pkg/tests/api/alerting/api_alertmanager_test.go
+++ b/pkg/tests/api/alerting/api_alertmanager_test.go
@@ -2164,6 +2164,7 @@ func TestIntegrationEval(t *testing.T) {
 							}
 						}
 					],
+				"condition": "A",
 				"now": "2021-04-11T14:38:14Z"
 			}
 			`,
@@ -2221,6 +2222,7 @@ func TestIntegrationEval(t *testing.T) {
 							}
 						}
 					],
+				"condition": "A",
 				"now": "2021-04-11T14:38:14Z"
 			}
 			`,
@@ -2276,6 +2278,7 @@ func TestIntegrationEval(t *testing.T) {
 							}
 						}
 					],
+				"condition": "A",
 				"now": "2021-04-11T14:38:14Z"
 			}
 			`,
@@ -2291,6 +2294,33 @@ func TestIntegrationEval(t *testing.T) {
 					return "user is not authorized to access one or many data sources"
 				}
 				return "Failed to build evaluator for queries and expressions: failed to build query 'A': data source not found"
+			},
+		},
+		{
+			desc: "condition is empty",
+			payload: `
+			{
+				"data": [
+						{
+							"refId": "A",
+							"relativeTimeRange": {
+								"from": 18000,
+								"to": 10800
+							},
+							"datasourceUid": "unknown",
+							"model": {
+							}
+						}
+					],
+				"now": "2021-04-11T14:38:14Z"
+			}
+			`,
+			expectedResponse: func() string { return "" },
+			expectedStatusCode: func() int {
+				return http.StatusBadRequest
+			},
+			expectedMessage: func() string {
+				return "Failed to build evaluator for queries and expressions: condition must not be empty"
 			},
 		},
 	}

--- a/pkg/tests/api/alerting/api_alertmanager_test.go
+++ b/pkg/tests/api/alerting/api_alertmanager_test.go
@@ -2307,8 +2307,10 @@ func TestIntegrationEval(t *testing.T) {
 								"from": 18000,
 								"to": 10800
 							},
-							"datasourceUid": "unknown",
+							"datasourceUid": "__expr__",
 							"model": {
+								"type":"math",
+								"expression":"1 > 2"
 							}
 						}
 					],

--- a/pkg/tests/api/alerting/api_alertmanager_test.go
+++ b/pkg/tests/api/alerting/api_alertmanager_test.go
@@ -2317,12 +2317,40 @@ func TestIntegrationEval(t *testing.T) {
 				"now": "2021-04-11T14:38:14Z"
 			}
 			`,
-			expectedResponse: func() string { return "" },
-			expectedStatusCode: func() int {
-				return http.StatusBadRequest
-			},
-			expectedMessage: func() string {
-				return "Failed to build evaluator for queries and expressions: condition must not be empty"
+			expectedStatusCode: func() int { return http.StatusOK },
+			expectedMessage:    func() string { return "" },
+			expectedResponse: func() string {
+				return `{
+				"results": {
+				  "A": {
+					"status": 200,
+					"frames": [
+					  {
+						"schema": {
+						  "refId": "A",
+						  "fields": [
+							{
+							  "name": "A",
+							  "type": "number",
+							  "typeInfo": {
+								"frame": "float64",
+								"nullable": true
+							  }
+							}
+						  ]
+						},
+						"data": {
+						  "values": [
+							[
+							  0
+							]
+						  ]
+						}
+					  }
+					]
+				  }
+				}
+			}`
 			},
 		},
 	}

--- a/public/app/features/alerting/unified/components/rule-editor/query-and-alert-condition/QueryAndExpressionsStep.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/query-and-alert-condition/QueryAndExpressionsStep.tsx
@@ -92,15 +92,18 @@ export const QueryAndExpressionsStep = ({ editingExistingRule, onDataChange }: P
 
   const rulesSourcesWithRuler = useRulesSourcesWithRuler();
 
-  const runQueriesPreview = useCallback(() => {
-    if (isCloudAlertRuleType) {
-      // we will skip preview for cloud rules, these do not have any time series preview
-      // Grafana Managed rules and recording rules do
-      return;
-    }
+  const runQueriesPreview = useCallback(
+    (condition?: string) => {
+      if (isCloudAlertRuleType) {
+        // we will skip preview for cloud rules, these do not have any time series preview
+        // Grafana Managed rules and recording rules do
+        return;
+      }
 
-    runQueries(getValues('queries'));
-  }, [isCloudAlertRuleType, runQueries, getValues]);
+      runQueries(getValues('queries'), condition || (getValues('condition') ?? ''));
+    },
+    [isCloudAlertRuleType, runQueries, getValues]
+  );
 
   // whenever we update the queries we have to update the form too
   useEffect(() => {
@@ -149,7 +152,7 @@ export const QueryAndExpressionsStep = ({ editingExistingRule, onDataChange }: P
         return;
       }
 
-      runQueriesPreview(); //we need to run the queries to know if the condition is valid
+      runQueriesPreview(refId); //we need to run the queries to know if the condition is valid
 
       setValue('condition', refId);
     },
@@ -504,7 +507,7 @@ export const QueryAndExpressionsStep = ({ editingExistingRule, onDataChange }: P
               </Button>
             )}
             {!isPreviewLoading && (
-              <Button icon="sync" type="button" onClick={runQueriesPreview} disabled={emptyQueries}>
+              <Button icon="sync" type="button" onClick={() => runQueriesPreview()} disabled={emptyQueries}>
                 Preview
               </Button>
             )}

--- a/public/app/features/alerting/unified/components/rule-editor/query-and-alert-condition/useAlertQueryRunner.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/query-and-alert-condition/useAlertQueryRunner.tsx
@@ -30,8 +30,8 @@ export function useAlertQueryRunner() {
     runner.current.cancel();
   }, []);
 
-  const runQueries = useCallback((queriesToPreview: AlertQuery[]) => {
-    runner.current.run(queriesToPreview);
+  const runQueries = useCallback((queriesToPreview: AlertQuery[], condition: string) => {
+    runner.current.run(queriesToPreview, condition);
   }, []);
 
   const isPreviewLoading = useMemo(() => {

--- a/public/app/features/alerting/unified/components/rule-viewer/RuleViewer.v1.tsx
+++ b/public/app/features/alerting/unified/components/rule-viewer/RuleViewer.v1.tsx
@@ -78,10 +78,13 @@ export function RuleViewer({ match }: RuleViewerProps) {
         ...q,
         relativeTimeRange: evaluationTimeRanges[q.refId] ?? q.relativeTimeRange,
       }));
-
-      runner.run(evalCustomizedQueries);
+      let condition;
+      if (rule && isGrafanaRulerRule(rule.rulerRule)) {
+        condition = rule.rulerRule.grafana_alert.condition;
+      }
+      runner.run(evalCustomizedQueries, condition ?? 'A');
     }
-  }, [queries, evaluationTimeRanges, runner, allDataSourcesAvailable]);
+  }, [queries, evaluationTimeRanges, runner, allDataSourcesAvailable, rule]);
 
   useEffect(() => {
     const alertQueries = alertRuleToQueries(rule);

--- a/public/app/features/alerting/unified/state/AlertingQueryRunner.test.ts
+++ b/public/app/features/alerting/unified/state/AlertingQueryRunner.test.ts
@@ -6,14 +6,14 @@ import { createFetchResponse } from 'test/helpers/createFetchResponse';
 import {
   DataFrame,
   DataFrameJSON,
+  DataSourceInstanceSettings,
   Field,
   FieldType,
-  getDefaultRelativeTimeRange,
   LoadingState,
+  getDefaultRelativeTimeRange,
   rangeUtil,
-  DataSourceInstanceSettings,
 } from '@grafana/data';
-import { DataSourceSrv, FetchResponse, DataSourceWithBackend } from '@grafana/runtime';
+import { DataSourceSrv, DataSourceWithBackend, FetchResponse } from '@grafana/runtime';
 import { DataQuery } from '@grafana/schema';
 import { BackendSrv } from 'app/core/services/backend_srv';
 import { AlertDataQuery, AlertQuery } from 'app/types/unified-alerting-dto';
@@ -37,7 +37,7 @@ describe('AlertingQueryRunner', () => {
     );
 
     const data = runner.get();
-    runner.run([createQuery('A'), createQuery('B')]);
+    runner.run([createQuery('A'), createQuery('B')], 'B');
 
     await expect(data.pipe(take(1))).toEmitValuesWith((values) => {
       const [data] = values;
@@ -94,7 +94,7 @@ describe('AlertingQueryRunner', () => {
     );
 
     const data = runner.get();
-    runner.run([createQuery('A'), createQuery('B')]);
+    runner.run([createQuery('A'), createQuery('B')], 'B');
 
     await expect(data.pipe(take(1))).toEmitValuesWith((values) => {
       const [data] = values;
@@ -126,7 +126,7 @@ describe('AlertingQueryRunner', () => {
     );
 
     const data = runner.get();
-    runner.run([createQuery('A'), createQuery('B')]);
+    runner.run([createQuery('A'), createQuery('B')], 'B');
 
     await expect(data.pipe(take(2))).toEmitValuesWith((values) => {
       const [loading, data] = values;
@@ -181,7 +181,7 @@ describe('AlertingQueryRunner', () => {
     );
 
     const data = runner.get();
-    runner.run([createQuery('A'), createQuery('B')]);
+    runner.run([createQuery('A'), createQuery('B')], 'B');
 
     await expect(data.pipe(take(1))).toEmitValuesWith((values) => {
       const [data] = values;
@@ -203,7 +203,7 @@ describe('AlertingQueryRunner', () => {
     );
 
     const data = runner.get();
-    runner.run([createQuery('A'), createQuery('B')]);
+    runner.run([createQuery('A'), createQuery('B')], 'B');
 
     await expect(data.pipe(take(1))).toEmitValuesWith((values) => {
       const [data] = values;
@@ -231,15 +231,18 @@ describe('AlertingQueryRunner', () => {
     );
 
     const data = runner.get();
-    runner.run([
-      createQuery('A', {
-        model: {
-          refId: 'A',
-          hide: true,
-        },
-      }),
-      createQuery('B'),
-    ]);
+    runner.run(
+      [
+        createQuery('A', {
+          model: {
+            refId: 'A',
+            hide: true,
+          },
+        }),
+        createQuery('B'),
+      ],
+      'B'
+    );
 
     await expect(data.pipe(take(1))).toEmitValuesWith((values) => {
       const [loading, _data] = values;

--- a/public/app/features/alerting/unified/state/AlertingQueryRunner.ts
+++ b/public/app/features/alerting/unified/state/AlertingQueryRunner.ts
@@ -9,12 +9,12 @@ import {
   getDefaultTimeRange,
   LoadingState,
   PanelData,
+  preProcessPanelData,
   rangeUtil,
   TimeRange,
   withLoadingIndicator,
-  preProcessPanelData,
 } from '@grafana/data';
-import { FetchResponse, getDataSourceSrv, toDataQueryError, DataSourceWithBackend } from '@grafana/runtime';
+import { DataSourceWithBackend, FetchResponse, getDataSourceSrv, toDataQueryError } from '@grafana/runtime';
 import { BackendSrv, getBackendSrv } from 'app/core/services/backend_srv';
 import { isExpressionQuery } from 'app/features/expressions/guards';
 import { cancelNetworkRequestsOnUnsubscribe } from 'app/features/query/state/processing/canceler';
@@ -49,7 +49,7 @@ export class AlertingQueryRunner {
     return this.subject.asObservable();
   }
 
-  async run(queries: AlertQuery[]) {
+  async run(queries: AlertQuery[], condition: string) {
     const empty = initialState(queries, LoadingState.Done);
     const queriesToExclude: string[] = [];
 
@@ -79,7 +79,7 @@ export class AlertingQueryRunner {
       return this.subject.next(empty);
     }
 
-    this.subscription = runRequest(this.backendSrv, queriesToRun).subscribe({
+    this.subscription = runRequest(this.backendSrv, queriesToRun, condition).subscribe({
       next: (dataPerQuery) => {
         const nextResult = applyChange(dataPerQuery, (refId, data) => {
           const previous = this.lastResult[refId];
@@ -131,10 +131,14 @@ export class AlertingQueryRunner {
   }
 }
 
-const runRequest = (backendSrv: BackendSrv, queries: AlertQuery[]): Observable<Record<string, PanelData>> => {
+const runRequest = (
+  backendSrv: BackendSrv,
+  queries: AlertQuery[],
+  condition: string
+): Observable<Record<string, PanelData>> => {
   const initial = initialState(queries, LoadingState.Loading);
   const request = {
-    data: { data: queries },
+    data: { data: queries, condition },
     url: '/api/v1/eval',
     method: 'POST',
     requestId: uuidv4(),


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**
This PR updates the model of the struct EvalQueriesPayload that describes the payload model of the `POST /api/v1/eval`, which is used for the preview of Alert rule evaluation.

**Why do we need this feature?**
Currently, it does not do anything but since  https://github.com/grafana/grafana/pull/75189  it will be mandatory in query validation.

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
