### PR TITLE
Alerting: Refactor AlertQuery to remove redundant internal state modelProps 

### DIFF
--- a/pkg/services/ngalert/api/api_prometheus.go
+++ b/pkg/services/ngalert/api/api_prometheus.go
@@ -434,7 +434,13 @@ func ruleToQuery(logger log.Logger, rule *ngmodels.AlertRule) string {
 	var queries []string
 
 	for _, q := range rule.Data {
-		q, err := q.GetQuery()
+		modelProps, err := q.CalculateModel()
+		if err != nil {
+			logger.Debug("Failed to parse a query model", "error", err)
+			queryErr = err
+			break
+		}
+		expr, err := modelProps.GetQuery()
 		if err != nil {
 			// If we can't find the query simply omit it, and try the rest.
 			// Even single query alerts would have 2 `AlertQuery`, one for the query and one for the condition.
@@ -448,7 +454,7 @@ func ruleToQuery(logger log.Logger, rule *ngmodels.AlertRule) string {
 			break
 		}
 
-		queries = append(queries, q)
+		queries = append(queries, expr)
 	}
 
 	// If we were able to extract at least one query without failure use it.

--- a/pkg/services/ngalert/eval/eval.go
+++ b/pkg/services/ngalert/eval/eval.go
@@ -45,6 +45,7 @@ type ConditionEvaluator interface {
 
 type expressionService interface {
 	ExecutePipeline(ctx context.Context, now time.Time, pipeline expr.DataPipeline) (*backend.QueryDataResponse, error)
+	BuildPipeline(req *expr.Request) (expr.DataPipeline, error)
 }
 
 type conditionEvaluator struct {
@@ -89,14 +90,14 @@ func (r *conditionEvaluator) Evaluate(ctx context.Context, now time.Time) (Resul
 type evaluatorImpl struct {
 	evaluationTimeout time.Duration
 	dataSourceCache   datasources.CacheService
-	expressionService *expr.Service
+	expressionService expressionService
 	pluginsStore      pluginstore.Store
 }
 
 func NewEvaluatorFactory(
 	cfg setting.UnifiedAlertingSettings,
 	datasourceCache datasources.CacheService,
-	expressionService *expr.Service,
+	expressionService expressionService,
 	pluginsStore pluginstore.Store,
 ) EvaluatorFactory {
 	return &evaluatorImpl{

--- a/pkg/services/ngalert/eval/eval_bench_test.go
+++ b/pkg/services/ngalert/eval/eval_bench_test.go
@@ -18,7 +18,7 @@ func BenchmarkEvaluate(b *testing.B) {
 	seedDataResponse(&dataResp, 10000)
 	var evaluator ConditionEvaluator = &conditionEvaluator{
 		expressionService: &fakeExpressionService{
-			hook: func(ctx context.Context, now time.Time, pipeline expr.DataPipeline) (*backend.QueryDataResponse, error) {
+			executeHook: func(ctx context.Context, now time.Time, pipeline expr.DataPipeline) (*backend.QueryDataResponse, error) {
 				return &dataResp, nil
 			},
 		},

--- a/pkg/services/ngalert/eval/eval_test.go
+++ b/pkg/services/ngalert/eval/eval_test.go
@@ -2,6 +2,7 @@ package eval
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"math/rand"
 	"testing"
@@ -697,8 +698,12 @@ func TestCreate(t *testing.T) {
 
 			// Set expected raw json to be the same as the model.
 			for i, query := range testCase.condition.Data {
-				model, err := query.GetModel()
+				cm, err := query.CalculateModel()
 				require.NoError(t, err)
+
+				model, err := json.Marshal(cm)
+				require.NoError(t, err)
+
 				testCase.expRequest.Queries[i].JSON = model
 			}
 

--- a/pkg/services/ngalert/models/alert_query.go
+++ b/pkg/services/ngalert/models/alert_query.go
@@ -9,8 +9,8 @@ import (
 	"github.com/grafana/grafana/pkg/expr"
 )
 
-const defaultMaxDataPoints float64 = 43200 // 12 hours at 1sec interval
-const defaultIntervalMS float64 = 1000
+const defaultMaxDataPoints int64 = 43200 // 12 hours at 1sec interval
+const defaultIntervalMS int64 = 1000
 
 const (
 	maxDataPointsKey = "maxDataPoints"
@@ -99,194 +99,124 @@ type AlertQuery struct {
 	DatasourceUID string `json:"datasourceUid"`
 
 	// JSON is the raw JSON query and includes the above properties as well as custom properties.
+	// This should not be used directly when maxDataPoints or intervalMs is needed as they might need to be calculated.
+	// Instead, use CalculateModel() to get the CalculatedModel.
 	Model json.RawMessage `json:"model"`
-
-	modelProps map[string]any
 }
 
 func (aq *AlertQuery) String() string {
 	return fmt.Sprintf("refID: %s, queryType: %s, datasourceUID: %s", aq.RefID, aq.QueryType, aq.DatasourceUID)
 }
 
-func (aq *AlertQuery) setModelProps() error {
-	aq.modelProps = make(map[string]any)
-	err := json.Unmarshal(aq.Model, &aq.modelProps)
-	if err != nil {
-		return fmt.Errorf("failed to unmarshal query model: %w", err)
-	}
-
-	return nil
-}
-
 // IsExpression returns true if the alert query is an expression.
-func (aq *AlertQuery) IsExpression() (bool, error) {
-	return expr.NodeTypeFromDatasourceUID(aq.DatasourceUID) == expr.TypeCMDNode, nil
+func (aq *AlertQuery) IsExpression() bool {
+	return expr.NodeTypeFromDatasourceUID(aq.DatasourceUID) == expr.TypeCMDNode
 }
 
-// setMaxDatapoints sets the model maxDataPoints if it's missing or invalid
-func (aq *AlertQuery) setMaxDatapoints() error {
-	if aq.modelProps == nil {
-		err := aq.setModelProps()
-		if err != nil {
-			return err
-		}
+func (aq *AlertQuery) CalculateModel() (CalculatedModel, error) {
+	return fromRawModel(aq.Model)
+}
+
+// PreSave sets query's properties.
+// It should be called before being saved.
+func (aq *AlertQuery) PreSave() error {
+	cm, err := aq.CalculateModel()
+	if err != nil {
+		return err
 	}
-	i, ok := aq.modelProps[maxDataPointsKey] // GEL requires maxDataPoints inside the query JSON
-	if !ok {
-		aq.modelProps[maxDataPointsKey] = defaultMaxDataPoints
+
+	if queryType, err := cm.GetQueryType(); err != nil {
+		return fmt.Errorf("failed to set query type to query model: %w", err)
+	} else if queryType != "" {
+		aq.QueryType = queryType
 	}
-	maxDataPoints, ok := i.(float64)
-	if !ok || maxDataPoints == 0 {
-		aq.modelProps[maxDataPointsKey] = defaultMaxDataPoints
+
+	model, err := json.Marshal(cm)
+	if err != nil {
+		return fmt.Errorf("failed to marshal query model: %w", err)
+	}
+	aq.Model = model
+
+	return nil
+}
+
+func (aq *AlertQuery) Validate() error {
+	if ok := aq.IsExpression() || aq.RelativeTimeRange.isValid(); !ok {
+		return fmt.Errorf("invalid relative time range: %+v", aq.RelativeTimeRange)
 	}
 	return nil
 }
 
-func (aq *AlertQuery) GetMaxDatapoints() (int64, error) {
-	err := aq.setMaxDatapoints()
+type CalculatedModel map[string]any
+
+func fromRawModel(model json.RawMessage) (CalculatedModel, error) {
+	cm := make(CalculatedModel)
+	err := json.Unmarshal(model, &cm)
 	if err != nil {
-		return 0, err
+		return nil, fmt.Errorf("failed to unmarshal query model: %w", err)
 	}
 
-	maxDataPoints, ok := aq.modelProps[maxDataPointsKey].(float64)
-	if !ok {
-		return 0, fmt.Errorf("failed to cast maxDataPoints to float64: %v", aq.modelProps[maxDataPointsKey])
+	// GEL requires intervalMs and maxDataPoints inside the query JSON
+	maxDataPoints, err := cm.GetMaxDataPoints()
+	if err != nil || maxDataPoints <= 0 {
+		cm[maxDataPointsKey] = defaultMaxDataPoints
 	}
-	return int64(maxDataPoints), nil
+
+	interval, err := cm.GetIntervalDuration()
+	if err != nil || interval <= 0 {
+		cm[intervalMSKey] = defaultIntervalMS
+	}
+
+	return cm, nil
 }
 
-// setIntervalMS sets the model IntervalMs if it's missing or invalid
-func (aq *AlertQuery) setIntervalMS() error {
-	if aq.modelProps == nil {
-		err := aq.setModelProps()
-		if err != nil {
-			return err
-		}
-	}
-	i, ok := aq.modelProps[intervalMSKey] // GEL requires intervalMs inside the query JSON
+func (cm CalculatedModel) GetQueryType() (string, error) {
+	i, ok := cm[queryTypeKey]
 	if !ok {
-		aq.modelProps[intervalMSKey] = defaultIntervalMS
-	}
-	intervalMs, ok := i.(float64)
-	if !ok || intervalMs == 0 {
-		aq.modelProps[intervalMSKey] = defaultIntervalMS
-	}
-	return nil
-}
-
-func (aq *AlertQuery) getIntervalMS() (int64, error) {
-	err := aq.setIntervalMS()
-	if err != nil {
-		return 0, err
+		return "", nil
 	}
 
-	intervalMs, ok := aq.modelProps[intervalMSKey].(float64)
+	queryType, ok := i.(string)
 	if !ok {
-		return 0, fmt.Errorf("failed to cast intervalMs to float64: %v", aq.modelProps[intervalMSKey])
+		return "", fmt.Errorf("failed to get queryType from query model: %v", cm[queryTypeKey])
 	}
-	return int64(intervalMs), nil
-}
-
-func (aq *AlertQuery) GetIntervalDuration() (time.Duration, error) {
-	err := aq.setIntervalMS()
-	if err != nil {
-		return 0, err
-	}
-
-	intervalMs, ok := aq.modelProps[intervalMSKey].(float64)
-	if !ok {
-		return 0, fmt.Errorf("failed to cast intervalMs to float64: %v", aq.modelProps[intervalMSKey])
-	}
-	return time.Duration(intervalMs) * time.Millisecond, nil
-}
-
-// GetDatasource returns the query datasource identifier.
-func (aq *AlertQuery) GetDatasource() (string, error) {
-	return aq.DatasourceUID, nil
+	return queryType, nil
 }
 
 // GetQuery returns the query defined by `expr` within the model.
 // Returns an ErrNoQuery if it is unable to find the query.
 // Returns an error if it is not able to cast the query to a string.
-func (aq *AlertQuery) GetQuery() (string, error) {
-	if aq.modelProps == nil {
-		err := aq.setModelProps()
-		if err != nil {
-			return "", err
-		}
-	}
-	query, ok := aq.modelProps[exprKey]
+func (cm CalculatedModel) GetQuery() (string, error) {
+	query, ok := cm[exprKey]
 	if !ok {
 		return "", ErrNoQuery
 	}
 
 	q, ok := query.(string)
 	if !ok {
-		return "", fmt.Errorf("failed to cast query to string: %v", aq.modelProps[exprKey])
+		return "", fmt.Errorf("failed to cast query to string: %v", cm[exprKey])
 	}
 	return q, nil
 }
 
-func (aq *AlertQuery) GetModel() ([]byte, error) {
-	err := aq.setMaxDatapoints()
-	if err != nil {
-		return nil, err
+func (cm CalculatedModel) GetMaxDataPoints() (int64, error) {
+	switch maxDataPoints := cm[maxDataPointsKey].(type) {
+	case int64:
+		return maxDataPoints, nil
+	case float64: // Default type for JSON numbers.
+		return int64(maxDataPoints), nil
+	default:
+		return 0, fmt.Errorf("failed to cast maxDataPoints: %v", cm[maxDataPointsKey])
 	}
-
-	err = aq.setIntervalMS()
-	if err != nil {
-		return nil, err
-	}
-
-	model, err := json.Marshal(aq.modelProps)
-	if err != nil {
-		return nil, fmt.Errorf("unable to marshal query model: %w", err)
-	}
-	return model, nil
 }
 
-func (aq *AlertQuery) setQueryType() error {
-	if aq.modelProps == nil {
-		err := aq.setModelProps()
-		if err != nil {
-			return err
-		}
+func (cm CalculatedModel) GetIntervalDuration() (time.Duration, error) {
+	switch intervalMs := cm[intervalMSKey].(type) {
+	case int64:
+		return time.Duration(intervalMs) * time.Millisecond, nil
+	case float64: // Default type for JSON numbers.
+		return time.Duration(intervalMs) * time.Millisecond, nil
+	default:
+		return 0, fmt.Errorf("failed to cast intervalMs: %v", cm[intervalMSKey])
 	}
-	i, ok := aq.modelProps[queryTypeKey]
-	if !ok {
-		return nil
-	}
-
-	queryType, ok := i.(string)
-	if !ok {
-		return fmt.Errorf("failed to get queryType from query model: %v", i)
-	}
-
-	aq.QueryType = queryType
-	return nil
-}
-
-// PreSave sets query's properties.
-// It should be called before being saved.
-func (aq *AlertQuery) PreSave() error {
-	if err := aq.setQueryType(); err != nil {
-		return fmt.Errorf("failed to set query type to query model: %w", err)
-	}
-
-	// override model
-	model, err := aq.GetModel()
-	if err != nil {
-		return err
-	}
-	aq.Model = model
-
-	isExpression, err := aq.IsExpression()
-	if err != nil {
-		return err
-	}
-
-	if ok := isExpression || aq.RelativeTimeRange.isValid(); !ok {
-		return fmt.Errorf("invalid relative time range: %+v", aq.RelativeTimeRange)
-	}
-	return nil
 }

--- a/pkg/services/ngalert/models/alert_query.go
+++ b/pkg/services/ngalert/models/alert_query.go
@@ -12,6 +12,13 @@ import (
 const defaultMaxDataPoints float64 = 43200 // 12 hours at 1sec interval
 const defaultIntervalMS float64 = 1000
 
+const (
+	maxDataPointsKey = "maxDataPoints"
+	intervalMSKey    = "intervalMs"
+	exprKey          = "expr"
+	queryTypeKey     = "queryType"
+)
+
 var ErrNoQuery = errors.New("no `expr` property in the query model")
 
 // Duration is a type used for marshalling durations.
@@ -124,13 +131,13 @@ func (aq *AlertQuery) setMaxDatapoints() error {
 			return err
 		}
 	}
-	i, ok := aq.modelProps["maxDataPoints"] // GEL requires maxDataPoints inside the query JSON
+	i, ok := aq.modelProps[maxDataPointsKey] // GEL requires maxDataPoints inside the query JSON
 	if !ok {
-		aq.modelProps["maxDataPoints"] = defaultMaxDataPoints
+		aq.modelProps[maxDataPointsKey] = defaultMaxDataPoints
 	}
 	maxDataPoints, ok := i.(float64)
 	if !ok || maxDataPoints == 0 {
-		aq.modelProps["maxDataPoints"] = defaultMaxDataPoints
+		aq.modelProps[maxDataPointsKey] = defaultMaxDataPoints
 	}
 	return nil
 }
@@ -141,9 +148,9 @@ func (aq *AlertQuery) GetMaxDatapoints() (int64, error) {
 		return 0, err
 	}
 
-	maxDataPoints, ok := aq.modelProps["maxDataPoints"].(float64)
+	maxDataPoints, ok := aq.modelProps[maxDataPointsKey].(float64)
 	if !ok {
-		return 0, fmt.Errorf("failed to cast maxDataPoints to float64: %v", aq.modelProps["maxDataPoints"])
+		return 0, fmt.Errorf("failed to cast maxDataPoints to float64: %v", aq.modelProps[maxDataPointsKey])
 	}
 	return int64(maxDataPoints), nil
 }
@@ -156,13 +163,13 @@ func (aq *AlertQuery) setIntervalMS() error {
 			return err
 		}
 	}
-	i, ok := aq.modelProps["intervalMs"] // GEL requires intervalMs inside the query JSON
+	i, ok := aq.modelProps[intervalMSKey] // GEL requires intervalMs inside the query JSON
 	if !ok {
-		aq.modelProps["intervalMs"] = defaultIntervalMS
+		aq.modelProps[intervalMSKey] = defaultIntervalMS
 	}
 	intervalMs, ok := i.(float64)
 	if !ok || intervalMs == 0 {
-		aq.modelProps["intervalMs"] = defaultIntervalMS
+		aq.modelProps[intervalMSKey] = defaultIntervalMS
 	}
 	return nil
 }
@@ -173,9 +180,9 @@ func (aq *AlertQuery) getIntervalMS() (int64, error) {
 		return 0, err
 	}
 
-	intervalMs, ok := aq.modelProps["intervalMs"].(float64)
+	intervalMs, ok := aq.modelProps[intervalMSKey].(float64)
 	if !ok {
-		return 0, fmt.Errorf("failed to cast intervalMs to float64: %v", aq.modelProps["intervalMs"])
+		return 0, fmt.Errorf("failed to cast intervalMs to float64: %v", aq.modelProps[intervalMSKey])
 	}
 	return int64(intervalMs), nil
 }
@@ -186,9 +193,9 @@ func (aq *AlertQuery) GetIntervalDuration() (time.Duration, error) {
 		return 0, err
 	}
 
-	intervalMs, ok := aq.modelProps["intervalMs"].(float64)
+	intervalMs, ok := aq.modelProps[intervalMSKey].(float64)
 	if !ok {
-		return 0, fmt.Errorf("failed to cast intervalMs to float64: %v", aq.modelProps["intervalMs"])
+		return 0, fmt.Errorf("failed to cast intervalMs to float64: %v", aq.modelProps[intervalMSKey])
 	}
 	return time.Duration(intervalMs) * time.Millisecond, nil
 }
@@ -208,14 +215,14 @@ func (aq *AlertQuery) GetQuery() (string, error) {
 			return "", err
 		}
 	}
-	query, ok := aq.modelProps["expr"]
+	query, ok := aq.modelProps[exprKey]
 	if !ok {
 		return "", ErrNoQuery
 	}
 
 	q, ok := query.(string)
 	if !ok {
-		return "", fmt.Errorf("failed to cast query to string: %v", aq.modelProps["expr"])
+		return "", fmt.Errorf("failed to cast query to string: %v", aq.modelProps[exprKey])
 	}
 	return q, nil
 }
@@ -245,7 +252,7 @@ func (aq *AlertQuery) setQueryType() error {
 			return err
 		}
 	}
-	i, ok := aq.modelProps["queryType"]
+	i, ok := aq.modelProps[queryTypeKey]
 	if !ok {
 		return nil
 	}

--- a/pkg/services/ngalert/models/alert_rule_test.go
+++ b/pkg/services/ngalert/models/alert_rule_test.go
@@ -610,28 +610,9 @@ func TestDiff(t *testing.T) {
 			},
 			DatasourceUID: util.GenerateShortUID(),
 			Model:         json.RawMessage(`{ "test": "data"}`),
-			modelProps: map[string]any{
-				"test": 1,
-			},
 		}
 
 		rule1.Data = []AlertQuery{query1}
-
-		t.Run("should ignore modelProps", func(t *testing.T) {
-			query2 := query1
-			query2.modelProps = map[string]any{
-				"some": "other value",
-			}
-			rule2.Data = []AlertQuery{query2}
-
-			diff := rule1.Diff(rule2)
-
-			assert.Nil(t, diff)
-
-			if t.Failed() {
-				t.Logf("rule1: %#v, rule2: %#v\ndiff: %v", rule1, rule2, diff)
-			}
-		})
 
 		t.Run("should detect changes inside the query", func(t *testing.T) {
 			query2 := query1


### PR DESCRIPTION
**What is this feature?**

NOTE: This is a refactor only. No functionality should change here.

This PR:
- Improves testing around `AlertQuery`, `intervalMs`, and `maxDataPoints`: https://github.com/grafana/grafana/commit/8611cafea88633fb2fb7134bfb457780e799565e
- Removes the `AlertQuery` unexported field `modelProps`: https://github.com/grafana/grafana/commit/c56f2c0d261ed638fbcf52f5b1e35e965d542726

**Why do we need this feature?**

This is the foundation for calculating `intervalMs` when not present in the model and not persisting default `intervalMs` and `maxDataPoints`.

The existence of two states where the model is stored, `Model` and `modelProps`, made it unclear which contained the correct values for your use-case at a glance. Upcoming changes to `intervalMs` and `maxDataPoints` handling will benefit from a clear delineation between "the model stored in the database" and "the calculated model we use when executing the query", so instead of storing the state twice there's now a method to retrieve the calculated model.

This calculated model currently only adds the default values for `maxDataPoints` and `intervalMs` so we don't change any functionality, but a [followup PR](https://github.com/grafana/grafana/pull/79051) will have it calculate the `intervalMs` if missing.

**Who is this feature for?**

Developers.