### PR TITLE
Alerting: Calculate intervalMs when not provided, no longer persist defaults

### DIFF
--- a/pkg/services/ngalert/migration/permissions_test.go
+++ b/pkg/services/ngalert/migration/permissions_test.go
@@ -51,7 +51,7 @@ func TestDashAlertPermissionMigration(t *testing.T) {
 				{
 					RefID:         "A",
 					DatasourceUID: "__expr__",
-					Model:         json.RawMessage(`{"conditions":[],"intervalMs":1000,"maxDataPoints":43200,"refId":"A","type":"classic_conditions"}`),
+					Model:         json.RawMessage(`{"conditions":[],"refId":"A","type":"classic_conditions"}`),
 				},
 			},
 			NamespaceUID:    namespaceUID,
@@ -747,6 +747,12 @@ func TestDashAlertPermissionMigration(t *testing.T) {
 						cmpopts.IgnoreUnexported(ngModels.AlertRule{}, ngModels.AlertQuery{}),
 						cmpopts.IgnoreFields(ngModels.AlertRule{}, "ID", "Updated", "UID"),
 						cmpopts.IgnoreFields(dashboards.Dashboard{}, "ID", "Created", "Updated", "Data", "Slug"),
+						cmp.Transformer("AlertQuery.Model", func(in json.RawMessage) (out map[string]any) {
+							if err := json.Unmarshal(in, &out); err != nil {
+								panic(err)
+							}
+							return out
+						}),
 					}
 					if !cmp.Equal(tt.expected, actual, cOpt...) {
 						t.Errorf("Unexpected Rule: %v", cmp.Diff(tt.expected, actual, cOpt...))

--- a/pkg/services/ngalert/models/alert_query.go
+++ b/pkg/services/ngalert/models/alert_query.go
@@ -132,12 +132,6 @@ func (aq *AlertQuery) PreSave() error {
 		aq.QueryType = queryType
 	}
 
-	model, err := json.Marshal(cm)
-	if err != nil {
-		return fmt.Errorf("failed to marshal query model: %w", err)
-	}
-	aq.Model = model
-
 	return nil
 }
 

--- a/pkg/services/ngalert/models/alert_query_test.go
+++ b/pkg/services/ngalert/models/alert_query_test.go
@@ -134,6 +134,58 @@ func TestAlertQuery(t *testing.T) {
 			expectedMaxPoints:    defaultMaxDataPoints,
 			expectedIntervalMS:   defaultIntervalMS,
 		},
+		{
+			desc: "given a query with short time range and no intervalMs",
+			alertQuery: AlertQuery{
+				RefID: "A",
+				Model: json.RawMessage(`{
+					"queryType": "metricQuery",
+					"extraParam": "some text"
+				}`),
+				RelativeTimeRange: RelativeTimeRange{
+					From: Duration(time.Duration(5) * time.Minute),
+					To:   Duration(0),
+				},
+			},
+			expectedIsExpression: false,
+			expectedMaxPoints:    defaultMaxDataPoints,
+			expectedIntervalMS:   defaultIntervalMS,
+		},
+		{
+			desc: "given a query with long time range and no intervalMs",
+			alertQuery: AlertQuery{
+				RefID: "A",
+				Model: json.RawMessage(`{
+					"queryType": "metricQuery",
+					"extraParam": "some text"
+				}`),
+				RelativeTimeRange: RelativeTimeRange{
+					From: Duration(time.Duration(24) * time.Hour),
+					To:   Duration(0),
+				},
+			},
+			expectedIsExpression: false,
+			expectedMaxPoints:    defaultMaxDataPoints,
+			expectedIntervalMS:   2000,
+		},
+		{
+			desc: "given a query with long time range, custom maxDataPoints, and no intervalMs",
+			alertQuery: AlertQuery{
+				RefID: "A",
+				Model: json.RawMessage(`{
+					"queryType": "metricQuery",
+					"maxDataPoints": 24,
+					"extraParam": "some text"
+				}`),
+				RelativeTimeRange: RelativeTimeRange{
+					From: Duration(time.Duration(24) * time.Hour),
+					To:   Duration(0),
+				},
+			},
+			expectedIsExpression: false,
+			expectedMaxPoints:    24,
+			expectedIntervalMS:   (time.Duration(1) * time.Hour).Milliseconds(),
+		},
 	}
 
 	for _, tc := range testCases {

--- a/pkg/services/ngalert/store/alert_rule_test.go
+++ b/pkg/services/ngalert/store/alert_rule_test.go
@@ -569,7 +569,7 @@ func TestIntegrationInsertAlertRules(t *testing.T) {
 		}
 	})
 
-	t.Run("rules without maxDataPoints and intervalMs persist defaults to model and database", func(t *testing.T) {
+	t.Run("rules without maxDataPoints and intervalMs don't persist defaults to model and database", func(t *testing.T) {
 		sqlStore := db.InitTestDB(t)
 		cfg := setting.NewCfg()
 		cfg.UnifiedAlerting.BaseInterval = 1 * time.Second
@@ -603,15 +603,6 @@ func TestIntegrationInsertAlertRules(t *testing.T) {
 			OrgID: 1,
 		})
 		require.NoError(t, err)
-
-		// Add the default maxDataPoints and intervalMs to the expected rules.
-		for _, rule := range rules {
-			for i, q := range rule.Data {
-				models.WithDefaultMaxDataPoints()(&q)
-				models.WithDefaultIntervalMs()(&q)
-				rule.Data[i] = q
-			}
-		}
 
 		cOpt := []cmp.Option{
 			cmpopts.SortSlices(func(a, b *models.AlertRule) bool {


### PR DESCRIPTION
**What is this feature?**

This feature changes how we determine the `intervalMs` for alert queries when one is not provided. 

Previously, if an `intervalMs` was not provided we would use the default value of `1s` and leave it up to datasource plugins to re-calculate the interval if they deemed it unsafe or unnecessarily short.

Now, if an `intervalMs` is not provided we calculate it in a similar fashion to how it's calculate by dashboard panels:

```max[(to-from)/maxDataPoints, minInterval]```, where `minInterval` is `1s`

In addition, we no longer save the default values for `maxDataPoints` (43200) and `intervalMs` (1000) to the database. This is more necessary now that an empty `intervalMs` has semantic meaning and also more correct as we should only be storing values directly set by the user.

**Why do we need this feature?**

This should reduce discrepancies between dashboard panels/explore and alert queries as well as provide more reasonable default interval values for queries that don't decide to override them.

**Who is this feature for?**

Alerting users.

**Which issue(s) does this PR fix?**:

Fixes #74852

**Special notes for your reviewer:**

This PR is meant to be targeted in its scope. Future changes could improve further by:

- Reducing the default `maxDataPoints` (43200) or increasing the default `minInterval` (1s) to more reasonable values.
- Adding a db migration to remove `maxDataPoints` and `intervalMs` from alert queries when they are both set to the default value.

TODO:
- (in a separate PR) Rename frontend form field from `min interval` to `interval`, as it's currently incorrect.
- Merge base https://github.com/grafana/grafana/pull/79049

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
