### PR TITLE
QueryVariable: Always run queries with dashboard time range

### DIFF
--- a/public/app/features/variables/query/VariableQueryRunner.ts
+++ b/public/app/features/variables/query/VariableQueryRunner.ts
@@ -7,7 +7,6 @@ import {
   DataQuery,
   DataQueryRequest,
   DataSourceApi,
-  getDefaultTimeRange,
   LoadingState,
   PanelData,
   ScopedVars,
@@ -19,7 +18,7 @@ import { getTimeSrv } from '../../dashboard/services/TimeSrv';
 import { runRequest } from '../../query/state/runRequest';
 import { getLastKey, getVariable } from '../state/selectors';
 import { KeyedVariableIdentifier } from '../state/types';
-import { QueryVariableModel, VariableRefresh } from '../types';
+import { QueryVariableModel } from '../types';
 import { getTemplatedRegex } from '../utils';
 
 import { toMetricFindValuesOperator, updateOptionsState, validateVariableSelection } from './operators';
@@ -175,10 +174,7 @@ export class VariableQueryRunner {
     const searchFilterScope = { searchFilter: { text: searchFilter, value: searchFilter } };
     const searchFilterAsVars = searchFilter ? searchFilterScope : {};
     const scopedVars = { ...searchFilterAsVars, ...variableAsVars } as ScopedVars;
-    const range =
-      variable.refresh === VariableRefresh.onTimeRangeChanged
-        ? this.dependencies.getTimeSrv().timeRange()
-        : getDefaultTimeRange();
+    const range = this.dependencies.getTimeSrv().timeRange();
 
     const request: DataQueryRequest = {
       app: CoreApp.Dashboard,


### PR DESCRIPTION
Talking with @torkelo and @itsmylife we decided to always run variable queries with dashboard time range, regardless of the refresh config. Otherwise, the variable query may produce results that are not in line with the data displayed in a dashboard.

Corresponding scenes PR: https://github.com/grafana/scenes/pull/490