### PR TITLE
Auth: Fix for the github_oauth parse config error

### DIFF
--- a/pkg/login/social/github_oauth.go
+++ b/pkg/login/social/github_oauth.go
@@ -57,7 +57,7 @@ func NewGitHubProvider(settings map[string]any, cfg *setting.Cfg, features *feat
 		return nil, err
 	}
 
-	teamIds, err := mustInts(util.SplitString(info.Extra[teamIdsKey]))
+	teamIds, err := mustInts(util.SplitString(info.Extra[teamIdsKey]), true)
 	if err != nil {
 		return nil, err
 	}
@@ -329,11 +329,14 @@ func convertToGroupList(t []GithubTeam) []string {
 	return groups
 }
 
-func mustInts(s []string) ([]int, error) {
+func mustInts(s []string, returnEmptyOnError bool) ([]int, error) {
 	result := make([]int, 0, len(s))
 	for _, v := range s {
 		num, err := strconv.Atoi(v)
 		if err != nil {
+			if returnEmptyOnError {
+				return []int{}, nil
+			}
 			return nil, err
 		}
 		result = append(result, num)

--- a/pkg/login/social/github_oauth.go
+++ b/pkg/login/social/github_oauth.go
@@ -57,10 +57,7 @@ func NewGitHubProvider(settings map[string]any, cfg *setting.Cfg, features *feat
 		return nil, err
 	}
 
-	teamIds, err := mustInts(util.SplitString(info.Extra[teamIdsKey]), true)
-	if err != nil {
-		return nil, err
-	}
+	teamIds := mustInts(util.SplitString(info.Extra[teamIdsKey]))
 
 	config := createOAuthConfig(info, cfg, GitHubProviderName)
 	provider := &SocialGithub{
@@ -329,17 +326,15 @@ func convertToGroupList(t []GithubTeam) []string {
 	return groups
 }
 
-func mustInts(s []string, returnEmptyOnError bool) ([]int, error) {
+func mustInts(s []string) []int {
 	result := make([]int, 0, len(s))
 	for _, v := range s {
 		num, err := strconv.Atoi(v)
 		if err != nil {
-			if returnEmptyOnError {
-				return []int{}, nil
-			}
-			return nil, err
+			// TODO: add log here
+			return []int{}
 		}
 		result = append(result, num)
 	}
-	return result, nil
+	return result
 }

--- a/pkg/login/social/github_oauth_test.go
+++ b/pkg/login/social/github_oauth_test.go
@@ -307,6 +307,16 @@ func TestSocialGitHub_InitializeExtraFields(t *testing.T) {
 				allowedOrganizations: []string{},
 			},
 		},
+		{
+			name: "should not error when teamIds are not integers",
+			settings: map[string]any{
+				"team_ids": "abc1234,5678",
+			},
+			want: settingFields{
+				teamIds:              []int{},
+				allowedOrganizations: []string{},
+			},
+		},
 	}
 
 	for _, tc := range testCases {

--- a/pkg/login/social/social.go
+++ b/pkg/login/social/social.go
@@ -123,7 +123,6 @@ func ProvideService(cfg *setting.Cfg,
 		conn, err := ss.createOAuthConnector(name, settingsKVs, cfg, features, cache)
 		if err != nil {
 			ss.log.Error("Failed to create OAuth provider", "error", err, "provider", name)
-			continue
 		}
 
 		ss.socialMap[name] = conn

--- a/pkg/login/social/social.go
+++ b/pkg/login/social/social.go
@@ -123,6 +123,7 @@ func ProvideService(cfg *setting.Cfg,
 		conn, err := ss.createOAuthConnector(name, settingsKVs, cfg, features, cache)
 		if err != nil {
 			ss.log.Error("Failed to create OAuth provider", "error", err, "provider", name)
+			continue
 		}
 
 		ss.socialMap[name] = conn


### PR DESCRIPTION
**What is this feature?**
Reverting the GitHub config parsing to the previous behaviour (skip the `teamIds` parsing when it's misconfigured).

**Why do we need this feature?**

[Add a description of the problem the feature is trying to solve.]

**Who is this feature for?**

[Add information on what kind of user the feature is for.]

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
