### PR TITLE
Plugins: Change Postgresql Datasource plugin to issue simpler meta queries for QuestDB

### DIFF
--- a/public/app/plugins/datasource/grafana-postgresql-datasource/configuration/ConfigurationEditor.tsx
+++ b/public/app/plugins/datasource/grafana-postgresql-datasource/configuration/ConfigurationEditor.tsx
@@ -83,6 +83,10 @@ export const PostgresConfigEditor = (props: DataSourcePluginOptionsEditorProps<P
     updateDatasourcePluginJsonDataOption(props, 'timescaledb', event.currentTarget.checked);
   };
 
+  const onQuestDBChanged = (event: SyntheticEvent<HTMLInputElement>) => {
+    updateDatasourcePluginJsonDataOption(props, 'questdb', event.currentTarget.checked);
+  };
+
   const onDSOptionChanged = (property: keyof PostgresOptions) => {
     return (event: SyntheticEvent<HTMLInputElement>) => {
       onOptionsChange({ ...options, ...{ [property]: event.currentTarget.value } });
@@ -397,6 +401,27 @@ export const PostgresConfigEditor = (props: DataSourcePluginOptionsEditorProps<P
             }
           >
             <Switch value={jsonData.timescaledb || false} onChange={onTimeScaleDBChanged} width={WIDTH_LONG} />
+          </Field>
+          <Field
+            label={
+              <Label>
+                <Stack gap={0.5}>
+                  <span>QuestDB</span>
+                  <Tooltip
+                    content={
+                      <span>
+                        QuestDB is a time-series database supporting PostgreSQL wire protocol. If enabled, Grafana will
+                        use QuestDb specific functions.
+                      </span>
+                    }
+                  >
+                    <Icon name="info-circle" size="sm" />
+                  </Tooltip>
+                </Stack>
+              </Label>
+            }
+          >
+            <Switch value={jsonData.questdb || false} onChange={onQuestDBChanged} width={WIDTH_LONG} />
           </Field>
         </ConfigSubSection>
 

--- a/public/app/plugins/datasource/grafana-postgresql-datasource/configuration/useAutoDetectFeatures.ts
+++ b/public/app/plugins/datasource/grafana-postgresql-datasource/configuration/useAutoDetectFeatures.ts
@@ -43,6 +43,13 @@ export function useAutoDetectFeatures({ props, setVersionOptions }: Options) {
           const version = await datasource.getVersion();
           const versionNumber = parseInt(version, 10);
 
+          if (!options.jsonData.questdb) {
+            const questdbVersion = await datasource.getQuestDBVersion();
+            if (questdbVersion) {
+              updateDatasourcePluginJsonDataOption({ options, onOptionsChange }, 'questdb', true);
+            }
+          }
+
           // timescaledb is only available for 9.6+
           if (versionNumber >= 906 && !options.jsonData.timescaledb) {
             const timescaledbVersion = await datasource.getTimescaleDBVersion();

--- a/public/app/plugins/datasource/grafana-postgresql-datasource/postgresMetaQuery.ts
+++ b/public/app/plugins/datasource/grafana-postgresql-datasource/postgresMetaQuery.ts
@@ -6,8 +6,16 @@ export function getTimescaleDBVersion() {
   return "SELECT extversion FROM pg_extension WHERE extname = 'timescaledb'";
 }
 
-export function showTables() {
-  return `select quote_ident(table_name) as "table" from information_schema.tables
+export function getQuestDBVersion() {
+  return "SELECT extversion FROM pg_extension WHERE extname = 'questdb'";
+}
+
+export function showTables(isQuestDB: boolean) {
+  if (isQuestDB) {
+    return `select quote_ident(table_name) as "table"
+            from information_schema.tables`;
+  } else {
+    return `select quote_ident(table_name) as "table" from information_schema.tables
     where quote_ident(table_schema) not in ('information_schema',
                              'pg_catalog',
                              '_timescaledb_cache',
@@ -17,12 +25,20 @@ export function showTables() {
                              'timescaledb_information',
                              'timescaledb_experimental')
       and ${buildSchemaConstraint()}`;
+  }
 }
 
-export function getSchema(table?: string) {
-  return `select quote_ident(column_name) as "column", data_type as "type"
+export function getSchema(isQuestDB: boolean, table?: string) {
+  if (isQuestDB) {
+    // duplicated to prevent accidental changes breaking compatibility
+    return `select quote_ident(column_name) as "column", data_type as "type"
     from information_schema.columns
     where quote_ident(table_name) = '${table}'`;
+  } else {
+    return `select quote_ident(column_name) as "column", data_type as "type"
+    from information_schema.columns
+    where quote_ident(table_name) = '${table}'`;
+  }
 }
 
 function buildSchemaConstraint() {

--- a/public/app/plugins/datasource/grafana-postgresql-datasource/types.ts
+++ b/public/app/plugins/datasource/grafana-postgresql-datasource/types.ts
@@ -19,6 +19,7 @@ export interface PostgresOptions extends SQLOptions {
   sslKeyFile?: string;
   postgresVersion?: number;
   timescaledb?: boolean;
+  questdb?: boolean;
   enableSecureSocksProxy?: boolean;
 }
 


### PR DESCRIPTION
**What is this feature?**

This PR changes PostgreSQL datasource plugin to issue simpler metadata queries that are compatible with QuestDB and thus fix list of tables and columns and autocomplete in Query Builder.

**Why do we need this feature?**

PostgreSQL plugin uses complex sql that isn't entirely supported  (and required )  by  QuestDB yet. 

**Who is this feature for?**

This change is meant for users creating dashboards with QuestDB. 

**Which issue(s) does this PR fix?**:

There's no issue yet . Should I create one and link here ? 