### PR TITLE
Heatmap: Fix null options migration

### DIFF
--- a/public/app/plugins/panel/heatmap/migrations.test.ts
+++ b/public/app/plugins/panel/heatmap/migrations.test.ts
@@ -1,6 +1,6 @@
 import { PanelModel, FieldConfigSource } from '@grafana/data';
 
-import { heatmapChangedHandler } from './migrations';
+import { heatmapChangedHandler, heatmapMigrationHandler } from './migrations';
 
 describe('Heatmap Migrations', () => {
   let prevFieldConfig: FieldConfigSource;
@@ -85,6 +85,63 @@ describe('Heatmap Migrations', () => {
             "min": 7,
             "reverse": false,
             "unit": "short",
+          },
+        },
+      }
+    `);
+  });
+
+  it('Null Options', () => {
+    const panel = {} as PanelModel;
+    panel.options = null;
+    panel.options = heatmapMigrationHandler(panel);
+    expect(panel).toMatchInlineSnapshot(`
+      {
+        "fieldConfig": {
+          "defaults": {},
+          "overrides": [],
+        },
+        "options": {
+          "calculate": true,
+          "calculation": {},
+          "cellGap": 2,
+          "cellRadius": undefined,
+          "cellValues": {
+            "decimals": undefined,
+          },
+          "color": {
+            "exponent": 0.5,
+            "fill": undefined,
+            "max": undefined,
+            "min": undefined,
+            "mode": "scheme",
+            "reverse": false,
+            "scale": "exponential",
+            "scheme": "Oranges",
+            "steps": 128,
+          },
+          "exemplars": {
+            "color": "rgba(255,0,255,0.7)",
+          },
+          "legend": {
+            "show": false,
+          },
+          "rowsFrame": {
+            "layout": "auto",
+          },
+          "showValue": "never",
+          "tooltip": {
+            "show": false,
+            "yHistogram": false,
+          },
+          "yAxis": {
+            "axisPlacement": "left",
+            "axisWidth": undefined,
+            "decimals": undefined,
+            "max": undefined,
+            "min": undefined,
+            "reverse": false,
+            "unit": undefined,
           },
         },
       }

--- a/public/app/plugins/panel/heatmap/migrations.ts
+++ b/public/app/plugins/panel/heatmap/migrations.ts
@@ -14,7 +14,7 @@ import { Options, defaultOptions, HeatmapColorMode } from './types';
 /** Called when the version number changes */
 export const heatmapMigrationHandler = (panel: PanelModel): Partial<Options> => {
   // Migrating from angular
-  if (Object.keys(panel.options).length === 0) {
+  if (panel.options === null || Object.keys(panel.options).length === 0) {
     return heatmapChangedHandler(panel, 'heatmap', { angular: panel }, panel.fieldConfig);
   }
   return panel.options;

--- a/public/app/plugins/panel/heatmap/migrations.ts
+++ b/public/app/plugins/panel/heatmap/migrations.ts
@@ -14,7 +14,7 @@ import { Options, defaultOptions, HeatmapColorMode } from './types';
 /** Called when the version number changes */
 export const heatmapMigrationHandler = (panel: PanelModel): Partial<Options> => {
   // Migrating from angular
-  if (panel.options === null || Object.keys(panel.options).length === 0) {
+  if (Object.keys(panel.options ?? {}).length === 0) {
     return heatmapChangedHandler(panel, 'heatmap', { angular: panel }, panel.fieldConfig);
   }
   return panel.options;


### PR DESCRIPTION
Some dashboard generation libraries, such as grafanalib, may produce heatmaps with a null 'options' attribute. This condition triggers a panic during migration, resulting in a blank heatmap panel.

This commit addresses the issue by returning default options if a panel has a null 'options'.

---

Exception stack (grafana v9.2.4)
```
Uncaught (in promise) TypeError: Cannot convert undefined or null to object
    at Function.keys (<anonymous>)
    at z.onPanelMigration (migrations.ts:15:14)
    at x.pluginLoaded (PanelModel.ts:421:31)
    at actions.ts:34:13
```

Blank heatmap
![image](https://github.com/grafana/grafana/assets/2150711/114cbd18-0727-4d94-989b-f0dba6456a39)


<details><summary>Panel JSON</summary>
<p>

```json
{
  "cacheTimeout": null,
  "cards": {
    "cardPadding": null,
    "cardRound": null
  },
  "color": {
    "cardColor": "#b4ff00",
    "colorScale": "sqrt",
    "colorScheme": "interpolateSpectral",
    "exponent": 0.5,
    "max": null,
    "min": null,
    "mode": "spectrum"
  },
  "dataFormat": "tsbuckets",
  "datasource": "${DS_TEST-CLUSTER}",
  "description": "The time consumed for peer processes to be ready in Raft",
  "editable": true,
  "error": false,
  "fieldConfig": {
    "defaults": {
      "thresholds": {
        "mode": "absolute",
        "steps": []
      }
    }
  },
  "gridPos": {
    "h": 7,
    "w": 12,
    "x": 0,
    "y": 0
  },
  "heatmap": {},
  "height": null,
  "hideTimeOverride": false,
  "hideZeroBuckets": true,
  "highlightCards": true,
  "id": 111,
  "interval": null,
  "legend": {
    "show": false
  },
  "links": [],
  "maxDataPoints": 512,
  "maxPerRow": null,
  "minSpan": null,
  "options": null,
  "repeat": null,
  "repeatDirection": null,
  "reverseYBuckets": false,
  "span": null,
  "targets": [
    {
      "datasource": "${DS_TEST-CLUSTER}",
      "expr": "sum(rate(\n    tikv_raftstore_raft_process_duration_secs_bucket\n    {k8s_cluster=\"$k8s_cluster\",tidb_cluster=\"$tidb_cluster\",instance=~\"$instance\",type=\"ready\"}\n    [$__rate_interval]\n)) by (le) ",
      "format": "heatmap",
      "hide": false,
      "instant": false,
      "interval": "",
      "intervalFactor": 1,
      "legendFormat": "{{le}}",
      "metric": "",
      "query": "sum(rate(\n    tikv_raftstore_raft_process_duration_secs_bucket\n    {k8s_cluster=\"$k8s_cluster\",tidb_cluster=\"$tidb_cluster\",instance=~\"$instance\",type=\"ready\"}\n    [$__rate_interval]\n)) by (le) ",
      "refId": "",
      "step": 10,
      "target": ""
    }
  ],
  "timeFrom": null,
  "timeShift": null,
  "title": "Process ready duration",
  "tooltip": {
    "msResolution": true,
    "shared": true,
    "showHistogram": true,
    "sort": 0,
    "value_type": "individual"
  },
  "transformations": [],
  "transparent": false,
  "type": "heatmap",
  "xAxis": {
    "mode": "time",
    "name": null,
    "show": true,
    "values": []
  },
  "xBucketNumber": null,
  "xBucketSize": null,
  "yAxis": {
    "decimals": 1,
    "format": "s",
    "label": null,
    "logBase": 1,
    "max": null,
    "min": null,
    "show": true
  },
  "yBucketBound": "upper",
  "yBucketNumber": null,
  "yBucketSize": null
}
```

</p>
</details> 

<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

