### PR TITLE
CloudWatch: remove usage of TimeSrv

### DIFF
--- a/public/app/plugins/datasource/cloudwatch/__mocks__/CloudWatchDataSource.ts
+++ b/public/app/plugins/datasource/cloudwatch/__mocks__/CloudWatchDataSource.ts
@@ -9,7 +9,6 @@ import {
   VariableHide,
 } from '@grafana/data';
 import { getBackendSrv, setBackendSrv, DataSourceWithBackend } from '@grafana/runtime';
-import { getTimeSrv } from 'app/features/dashboard/services/TimeSrv';
 import { TemplateSrv } from 'app/features/templating/template_srv';
 import { initialCustomVariableModelState } from 'app/features/variables/custom/reducer';
 
@@ -80,8 +79,7 @@ export function setupMockedDataSource({
     }
   }
 
-  const timeSrv = getTimeSrv();
-  const datasource = new CloudWatchDatasource(customInstanceSettings, templateService, timeSrv);
+  const datasource = new CloudWatchDatasource(customInstanceSettings, templateService);
   datasource.getVariables = () => ['test'];
   datasource.resources.getNamespaces = jest.fn().mockResolvedValue([]);
   datasource.resources.getRegions = jest.fn().mockResolvedValue([]);
@@ -96,7 +94,7 @@ export function setupMockedDataSource({
     get: getMock,
   });
 
-  return { datasource, fetchMock, queryMock, templateService, timeSrv };
+  return { datasource, fetchMock, queryMock, templateService };
 }
 
 export const metricVariable: CustomVariableModel = {

--- a/public/app/plugins/datasource/cloudwatch/__mocks__/LogsQueryRunner.ts
+++ b/public/app/plugins/datasource/cloudwatch/__mocks__/LogsQueryRunner.ts
@@ -2,7 +2,6 @@ import { of } from 'rxjs';
 
 import { CustomVariableModel, DataFrame, DataSourceInstanceSettings } from '@grafana/data';
 import { BackendDataSourceResponse, toDataQueryResponse } from '@grafana/runtime';
-import { getTimeSrv, TimeSrv } from 'app/features/dashboard/services/TimeSrv';
 import { TemplateSrv } from 'app/features/templating/template_srv';
 
 import { CloudWatchLogsQueryRunner } from '../query-runner/CloudWatchLogsQueryRunner';
@@ -17,13 +16,11 @@ export function setupMockedLogsQueryRunner({
   variables,
   mockGetVariableName = true,
   settings = CloudWatchSettings,
-  timeSrv = getTimeSrv(),
 }: {
   data?: BackendDataSourceResponse;
   variables?: CustomVariableModel[];
   mockGetVariableName?: boolean;
   settings?: DataSourceInstanceSettings<CloudWatchJsonData>;
-  timeSrv?: TimeSrv;
 } = {}) {
   let templateService = new TemplateSrv();
   if (variables) {
@@ -34,7 +31,7 @@ export function setupMockedLogsQueryRunner({
   }
 
   const queryMock = jest.fn().mockReturnValue(of(toDataQueryResponse({ data })));
-  const runner = new CloudWatchLogsQueryRunner(settings, templateService, timeSrv, queryMock);
+  const runner = new CloudWatchLogsQueryRunner(settings, templateService, queryMock);
 
   return { runner, queryMock, templateService };
 }

--- a/public/app/plugins/datasource/cloudwatch/__mocks__/ResourcesAPI.ts
+++ b/public/app/plugins/datasource/cloudwatch/__mocks__/ResourcesAPI.ts
@@ -1,5 +1,4 @@
 import { getBackendSrv, setBackendSrv } from '@grafana/runtime';
-import { getTimeSrv } from 'app/features/dashboard/services/TimeSrv';
 import { TemplateSrv } from 'app/features/templating/template_srv';
 import { CustomVariableModel } from 'app/features/variables/types';
 
@@ -19,7 +18,6 @@ export function setupMockedResourcesAPI({
 } = {}) {
   let templateService = variables ? setupMockedTemplateService(variables) : new TemplateSrv();
 
-  const timeSrv = getTimeSrv();
   const api = new ResourcesAPI(CloudWatchSettings, templateService);
   let resourceRequestMock = getMock ? getMock : jest.fn().mockReturnValue(response);
   setBackendSrv({
@@ -27,5 +25,5 @@ export function setupMockedResourcesAPI({
     get: resourceRequestMock,
   });
 
-  return { api, resourceRequestMock, templateService, timeSrv };
+  return { api, resourceRequestMock, templateService };
 }

--- a/public/app/plugins/datasource/cloudwatch/__mocks__/logsTestContext.ts
+++ b/public/app/plugins/datasource/cloudwatch/__mocks__/logsTestContext.ts
@@ -25,7 +25,7 @@ export function setupForLogs() {
     return toDataQueryResponse({ data: { results: { a: { refId: 'a', frames: [dataFrameToJSON(frame)] } } } });
   }
 
-  const { datasource, queryMock, timeSrv } = setupMockedDataSource();
+  const { datasource, queryMock } = setupMockedDataSource();
 
   const startQueryFrame: DataFrame = createDataFrame({ fields: [{ name: 'queryId', values: ['queryid'] }] });
   queryMock.mockReturnValueOnce(of(envelope(startQueryFrame)));
@@ -89,5 +89,5 @@ export function setupForLogs() {
     },
   });
 
-  return { datasource, queryMock, timeSrv };
+  return { datasource, queryMock };
 }

--- a/public/app/plugins/datasource/cloudwatch/components/QueryEditor/MetricsQueryEditor/MetricsQueryEditor.test.tsx
+++ b/public/app/plugins/datasource/cloudwatch/components/QueryEditor/MetricsQueryEditor/MetricsQueryEditor.test.tsx
@@ -4,7 +4,6 @@ import selectEvent from 'react-select-event';
 
 import { DataSourceInstanceSettings } from '@grafana/data';
 import * as ui from '@grafana/ui';
-import { TimeSrv } from 'app/features/dashboard/services/TimeSrv';
 import { TemplateSrv } from 'app/features/templating/template_srv';
 
 import { CustomVariableModel, initialVariableModelState } from '../../../../../../features/variables/types';
@@ -44,7 +43,7 @@ const setup = () => {
   };
   templateSrv.init([variable]);
 
-  const datasource = new CloudWatchDatasource(instanceSettings, templateSrv, {} as TimeSrv);
+  const datasource = new CloudWatchDatasource(instanceSettings, templateSrv);
   datasource.metricFindQuery = async () => [{ value: 'test', label: 'test', text: 'test' }];
   datasource.resources.getNamespaces = jest.fn().mockResolvedValue([]);
   datasource.resources.getMetrics = jest.fn().mockResolvedValue([]);

--- a/public/app/plugins/datasource/cloudwatch/datasource.test.ts
+++ b/public/app/plugins/datasource/cloudwatch/datasource.test.ts
@@ -252,7 +252,7 @@ describe('datasource', () => {
       expect(emits[0].data[0].fields.find((f: Field) => f.name === '@message').config.links).toMatchObject([
         {
           title: 'View in CloudWatch console',
-          url: "https://us-west-1.console.aws.amazon.com/cloudwatch/home?region=us-west-1#logs-insights:queryDetail=~(end~'2017-01-01T01*3a00*3a00.000Z~start~'2016-12-31T15*3a00*3a00.000Z~timeType~'ABSOLUTE~tz~'UTC~editorString~'some*20query~isLiveTail~false~source~(~'test))",
+          url: "https://us-west-1.console.aws.amazon.com/cloudwatch/home?region=us-west-1#logs-insights:queryDetail=~(end~'2016-12-31T16*3a00*3a00.000Z~start~'2016-12-31T15*3a00*3a00.000Z~timeType~'ABSOLUTE~tz~'UTC~editorString~'some*20query~isLiveTail~false~source~(~'test))",
         },
       ]);
     });

--- a/public/app/plugins/datasource/cloudwatch/datasource.test.ts
+++ b/public/app/plugins/datasource/cloudwatch/datasource.test.ts
@@ -1,7 +1,7 @@
 import { lastValueFrom } from 'rxjs';
 import { toArray } from 'rxjs/operators';
 
-import { CoreApp, dateTime, Field } from '@grafana/data';
+import { CoreApp, Field } from '@grafana/data';
 
 import {
   CloudWatchSettings,
@@ -212,19 +212,7 @@ describe('datasource', () => {
     });
 
     it('should add links to log queries', async () => {
-      const { datasource, timeSrv } = setupForLogs();
-      timeSrv.timeRange = () => {
-        const time = dateTime('2021-01-01T01:00:00Z');
-        const range = {
-          from: time.subtract(6, 'hour'),
-          to: time,
-        };
-
-        return {
-          ...range,
-          raw: range,
-        };
-      };
+      const { datasource } = setupForLogs();
 
       const observable = datasource.query({
         targets: [
@@ -264,7 +252,7 @@ describe('datasource', () => {
       expect(emits[0].data[0].fields.find((f: Field) => f.name === '@message').config.links).toMatchObject([
         {
           title: 'View in CloudWatch console',
-          url: "https://us-west-1.console.aws.amazon.com/cloudwatch/home?region=us-west-1#logs-insights:queryDetail=~(end~'2020-12-31T19*3a00*3a00.000Z~start~'2020-12-31T19*3a00*3a00.000Z~timeType~'ABSOLUTE~tz~'UTC~editorString~'some*20query~isLiveTail~false~source~(~'test))",
+          url: "https://us-west-1.console.aws.amazon.com/cloudwatch/home?region=us-west-1#logs-insights:queryDetail=~(end~'2017-01-01T01*3a00*3a00.000Z~start~'2016-12-31T15*3a00*3a00.000Z~timeType~'ABSOLUTE~tz~'UTC~editorString~'some*20query~isLiveTail~false~source~(~'test))",
         },
       ]);
     });

--- a/public/app/plugins/datasource/cloudwatch/datasource.ts
+++ b/public/app/plugins/datasource/cloudwatch/datasource.ts
@@ -14,7 +14,6 @@ import {
   ScopedVars,
 } from '@grafana/data';
 import { DataSourceWithBackend } from '@grafana/runtime';
-import { getTimeSrv, TimeSrv } from 'app/features/dashboard/services/TimeSrv';
 import { getTemplateSrv, TemplateSrv } from 'app/features/templating/template_srv';
 
 import { CloudWatchAnnotationSupport } from './annotationSupport';
@@ -61,8 +60,7 @@ export class CloudWatchDatasource
 
   constructor(
     private instanceSettings: DataSourceInstanceSettings<CloudWatchJsonData>,
-    readonly templateSrv: TemplateSrv = getTemplateSrv(),
-    timeSrv: TimeSrv = getTimeSrv()
+    readonly templateSrv: TemplateSrv = getTemplateSrv()
   ) {
     super(instanceSettings);
     this.defaultRegion = instanceSettings.jsonData.defaultRegion;
@@ -72,12 +70,7 @@ export class CloudWatchDatasource
     this.metricMathCompletionItemProvider = new MetricMathCompletionItemProvider(this.resources, this.templateSrv);
     this.metricsQueryRunner = new CloudWatchMetricsQueryRunner(instanceSettings, templateSrv, super.query.bind(this));
     this.logsCompletionItemProviderFunc = LogsCompletionItemProviderFunc(this.resources, this.templateSrv);
-    this.logsQueryRunner = new CloudWatchLogsQueryRunner(
-      instanceSettings,
-      templateSrv,
-      timeSrv,
-      super.query.bind(this)
-    );
+    this.logsQueryRunner = new CloudWatchLogsQueryRunner(instanceSettings, templateSrv, super.query.bind(this));
     this.annotationQueryRunner = new CloudWatchAnnotationQueryRunner(
       instanceSettings,
       templateSrv,

--- a/public/app/plugins/datasource/cloudwatch/query-runner/CloudWatchLogsQueryRunner.ts
+++ b/public/app/plugins/datasource/cloudwatch/query-runner/CloudWatchLogsQueryRunner.ts
@@ -28,10 +28,10 @@ import {
   LogRowContextOptions,
   LogRowContextQueryDirection,
   LogRowModel,
+  getDefaultTimeRange,
   rangeUtil,
 } from '@grafana/data';
 import { config, FetchError } from '@grafana/runtime';
-import { TimeSrv } from 'app/features/dashboard/services/TimeSrv';
 import { TemplateSrv } from 'app/features/templating/template_srv';
 
 import {
@@ -64,7 +64,6 @@ export class CloudWatchLogsQueryRunner extends CloudWatchRequest {
   constructor(
     instanceSettings: DataSourceInstanceSettings<CloudWatchJsonData>,
     templateSrv: TemplateSrv,
-    private readonly timeSrv: TimeSrv,
     queryFn: (request: DataQueryRequest<CloudWatchQuery>) => Observable<DataQueryResponse>
   ) {
     super(instanceSettings, templateSrv, queryFn);
@@ -186,7 +185,6 @@ export class CloudWatchLogsQueryRunner extends CloudWatchRequest {
             await addDataLinksToLogsResponse(
               dataQueryResponse,
               options,
-              this.timeSrv.timeRange(),
               this.replaceVariableAndDisplayWarningIfMulti.bind(this),
               this.expandVariableToArray.bind(this),
               this.getActualRegion.bind(this),
@@ -312,7 +310,7 @@ export class CloudWatchLogsQueryRunner extends CloudWatchRequest {
     queryParams: CloudWatchLogsRequest[],
     options?: DataQueryRequest<CloudWatchQuery>
   ): Observable<DataFrame[]> {
-    const range = options?.range || this.timeSrv.timeRange();
+    const range = options?.range || getDefaultTimeRange();
 
     const requestParams: DataQueryRequest<CloudWatchLogsQuery> = {
       ...options,

--- a/public/app/plugins/datasource/cloudwatch/utils/datalinks.test.ts
+++ b/public/app/plugins/datasource/cloudwatch/utils/datalinks.test.ts
@@ -40,6 +40,7 @@ describe('addDataLinksToLogsResponse', () => {
           region: 'us-east-1',
         },
       ],
+      range: { ...time, raw: time },
     } as DataQueryRequest<CloudWatchQuery>;
 
     setDataSourceSrv({
@@ -53,7 +54,6 @@ describe('addDataLinksToLogsResponse', () => {
     await addDataLinksToLogsResponse(
       mockResponse,
       mockOptions,
-      { ...time, raw: time },
       (s) => s ?? '',
       (v) => [v] ?? [],
       (r) => r,
@@ -125,12 +125,12 @@ describe('addDataLinksToLogsResponse', () => {
           region: 'us-east-1',
         } as CloudWatchQuery,
       ],
+      range: { ...time, raw: time },
     } as DataQueryRequest<CloudWatchQuery>;
 
     await addDataLinksToLogsResponse(
       mockResponse,
       mockOptions,
-      { ...time, raw: time },
       (s) => s ?? '',
       (v) => [v] ?? [],
       (r) => r
@@ -182,12 +182,12 @@ describe('addDataLinksToLogsResponse', () => {
           region: 'us-east-1',
         } as CloudWatchQuery,
       ],
+      range: { ...time, raw: time },
     } as DataQueryRequest<CloudWatchQuery>;
 
     await addDataLinksToLogsResponse(
       mockResponse,
       mockOptions,
-      { ...time, raw: time },
       (s) => s ?? '',
       (v) => [v] ?? [],
       (r) => r

--- a/public/app/plugins/datasource/cloudwatch/utils/datalinks.ts
+++ b/public/app/plugins/datasource/cloudwatch/utils/datalinks.ts
@@ -14,7 +14,6 @@ type ReplaceFn = (
 export async function addDataLinksToLogsResponse(
   response: DataQueryResponse,
   request: DataQueryRequest<CloudWatchQuery>,
-  range: TimeRange,
   replaceFn: ReplaceFn,
   getVariableValueFn: (value: string, scopedVars: ScopedVars) => string[],
   getRegion: (region: string) => string,
@@ -37,7 +36,9 @@ export async function addDataLinksToLogsResponse(
       } else {
         // Right now we add generic link to open the query in xray console to every field so it shows in the logs row
         // details. Unfortunately this also creates link for all values inside table which look weird.
-        field.config.links = [createAwsConsoleLink(curTarget, range, interpolatedRegion, replace, getVariableValue)];
+        field.config.links = [
+          createAwsConsoleLink(curTarget, request.range, interpolatedRegion, replace, getVariableValue),
+        ];
       }
     }
   }


### PR DESCRIPTION
Part of decoupling Cloudwatch from core.

Fixes #79114

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
