### PR TITLE
Chore: Update OpenAPI generation README to include bingo instructions

### DIFF
--- a/pkg/api/README.md
+++ b/pkg/api/README.md
@@ -80,3 +80,7 @@ make swagger-clean && make openapi3-gen
 They can observe its output into the `public/api-merged.json` and `public/openapi3.json` files.
 
 Finally, they can browser and try out both the OpenAPI v2 and v3 via the Swagger UI editor (served by the grafana server) by navigating to `/swagger`.
+
+If there are any issues generating the specifications (e.g., diff containing unrelated changes to your PR or unusually large diff), please run the following two commands to ensure your Swagger version is up to date, then re-run the make commands.
+- `go install github.com/bwplotka/bingo@latest`
+- `bingo get swagger`

--- a/pkg/api/README.md
+++ b/pkg/api/README.md
@@ -73,7 +73,6 @@ type UpdateServiceAccountResponse struct {
 Developers can re-create the OpenAPI v2 and v3 specifications using the following command:
 
 ```bash
-
 make swagger-clean && make openapi3-gen
 ```
 


### PR DESCRIPTION
Added instructions to README about installing `bingo` and updating `swagger` through `bingo`

This is the current solution to some people getting an unusually large diff or a diff containing changes unrelated to their PR after running the spec generation make commands (`make swagger-clean && make openapi3-gen`)