### PR TITLE
WizarDS: Fix prompts to return accurate content

### DIFF
--- a/public/app/plugins/datasource/prometheus/querybuilder/components/PromQueryEditorSelector.tsx
+++ b/public/app/plugins/datasource/prometheus/querybuilder/components/PromQueryEditorSelector.tsx
@@ -125,7 +125,6 @@ export const PromQueryEditorSelector = React.memo<Props>((props) => {
             // remove all references to the query
             query={{ metric: '', labels: [], operations: [] }}
             closeDrawer={() => setWizarDSDrawerOpen(false)}
-            datasource={props.datasource}
             // add component templates so any DS can use this
             templates={componentTemplates}
           />

--- a/public/app/plugins/datasource/prometheus/querybuilder/components/promQail/QuerySuggestionItem.tsx
+++ b/public/app/plugins/datasource/prometheus/querybuilder/components/promQail/QuerySuggestionItem.tsx
@@ -208,14 +208,13 @@ export function QuerySuggestionItem(props: Props) {
               <div className={styles.textPadding}>This query is trying to answer the question:</div>
               <div className={styles.textPadding}>{explanation}</div>
               <div className={styles.textPadding}>
-                Learn more with this{' '}
                 <a
                   className={styles.doc}
                   href={'https://prometheus.io/docs/prometheus/latest/querying/examples/#query-examples'}
                   target="_blank"
                   rel="noopener noreferrer"
                 >
-                  Prometheus doc
+                  Learn more
                 </a>
               </div>
 

--- a/public/app/plugins/datasource/prometheus/querybuilder/components/wizarDS/SuggestionItem.tsx
+++ b/public/app/plugins/datasource/prometheus/querybuilder/components/wizarDS/SuggestionItem.tsx
@@ -205,14 +205,13 @@ export function SuggestionItem(props: Props) {
             <div className={cx(styles.bodySmall, styles.explainPadding)}>
               <div className={styles.textPadding}>{explanation}</div>
               <div className={styles.textPadding}>
-                Learn more with this{' '}
                 <a
                   className={styles.doc}
-                  href={'https://prometheus.io/docs/prometheus/latest/querying/examples/#query-examples'}
+                  href={suggestion.link}
                   target="_blank"
                   rel="noopener noreferrer"
                 >
-                  Prometheus doc
+                  Learn more
                 </a>
               </div>
 

--- a/public/app/plugins/datasource/prometheus/querybuilder/components/wizarDS/WizarDS.tsx
+++ b/public/app/plugins/datasource/prometheus/querybuilder/components/wizarDS/WizarDS.tsx
@@ -6,7 +6,6 @@ import { GrafanaTheme2 } from '@grafana/data';
 import { Button, Checkbox, Input, Spinner, useTheme2 } from '@grafana/ui';
 import store from 'app/core/store';
 
-import { PrometheusDatasource } from '../../../datasource';
 import { PromVisualQuery } from '../../types';
 
 import { SuggestionContainer } from './SuggestionContainer';
@@ -22,14 +21,13 @@ const { showStartingMessage, indicateCheckbox, addInteraction, updateInteraction
 export type WizarDSProps = {
   query: PromVisualQuery;
   closeDrawer: () => void;
-  datasource: PrometheusDatasource;
   templates: Suggestion[];
 };
 
 const SKIP_STARTING_MESSAGE = 'SKIP_STARTING_MESSAGE';
 
 export const WizarDS = (props: WizarDSProps) => {
-  const { query, closeDrawer, datasource, templates } = props;
+  const { query, closeDrawer, templates } = props;
   const skipStartingMessage = store.getBool(SKIP_STARTING_MESSAGE, false);
 
   const [state, dispatch] = useReducer(stateSlice.reducer, initialState(query, !skipStartingMessage));
@@ -193,7 +191,7 @@ export const WizarDS = (props: WizarDSProps) => {
                         //   promVisualQuery: query,
                         //   doYouKnow: 'no',
                         // });
-                        wizarDSSuggest(dispatch, 0, query, [], datasource, templates);
+                        wizarDSSuggest(dispatch, 0, templates);
                       }}
                     >
                       Just walk me through everything
@@ -288,7 +286,7 @@ export const WizarDS = (props: WizarDSProps) => {
                                     // });
 
                                     dispatch(updateInteraction(payload));
-                                    wizarDSSuggest(dispatch, idx, query, [], datasource, templates, newInteraction);
+                                    wizarDSSuggest(dispatch, idx, templates, newInteraction);
                                   }}
                                 >
                                   Show me everything instead.
@@ -315,7 +313,7 @@ export const WizarDS = (props: WizarDSProps) => {
 
                                     dispatch(updateInteraction(payload));
                                     // add the suggestions in the API call
-                                    wizarDSSuggest(dispatch, idx, query, [], datasource, templates, interaction);
+                                    wizarDSSuggest(dispatch, idx, templates, interaction);
                                   }}
                                 >
                                   Submit
@@ -337,7 +335,7 @@ export const WizarDS = (props: WizarDSProps) => {
                           }}
                           explain={(suggIdx: number) =>
                             interaction.suggestions[suggIdx].explanation === ''
-                              ? wizarDSExplain(dispatch, idx, query, interaction, suggIdx, datasource)
+                              ? wizarDSExplain(dispatch, idx, interaction, suggIdx)
                               : interaction.suggestions[suggIdx].explanation
                           }
                           // onChange={onChange}
@@ -365,7 +363,7 @@ export const WizarDS = (props: WizarDSProps) => {
                       }}
                       explain={(suggIdx: number) =>
                         interaction.suggestions[suggIdx].explanation === ''
-                          ? wizarDSExplain(dispatch, idx, query, interaction, suggIdx, datasource)
+                          ? wizarDSExplain(dispatch, idx, interaction, suggIdx)
                           : interaction.suggestions[suggIdx].explanation
                       }
                       // onChange={onChange}

--- a/public/app/plugins/datasource/prometheus/querybuilder/components/wizarDS/prompts.ts
+++ b/public/app/plugins/datasource/prometheus/querybuilder/components/wizarDS/prompts.ts
@@ -28,12 +28,20 @@ export type SuggestSystemPromptParams = {
 // You are a Grafana expert.
 export function GetComponentSuggestionsSystemPrompt({ templates }: SuggestSystemPromptParams): string {
   return `
-  You are an expert on Grafana.
+  You are an an assistant that answers questions.
 
-  You only respond with JSON like the following.
-  ${templates}
-
-  Return only the JSON above. Do not return any prose.
+  You only know about the following list of components and the information you learn from the links provided.
+  ${templates?.reduce((acc: string, el: Suggestion) => {
+    return (
+      acc +
+      `
+      ${el.order}. Name: ${el.component}
+      ${el.link}
+      \n
+      \n
+    `
+    );
+  }, '')}
 `;
 }
 
@@ -41,12 +49,12 @@ export function GetComponentSuggestionsUserPrompt({ templates, question }: Sugge
   return `
   Here is a user question: "${question}".
   
-  Here is the same JSON list of objects you saw before:
-  ${templates}
+  Scan all the words of the question and think,
+  what are all of the components best match the words in the question? 
   
-  Return exact copies of these JSON objects ${templates} that best match the user question by the attributes 'component' and 'explanation'.
-
-  Each object should have the same values for the keys 'component', 'explanation', 'testid', 'order' and 'link'. Do not hallucinate new attributes or replace values. Do not replace any values in the JSON.
+  Make your best guess and return as many components as you think are correct.
+  
+  Return a list of the names of the components in a CSV list.
 
   Do not return any prose.  
 `;

--- a/public/app/plugins/datasource/prometheus/querybuilder/components/wizarDS/state/helpers.ts
+++ b/public/app/plugins/datasource/prometheus/querybuilder/components/wizarDS/state/helpers.ts
@@ -251,13 +251,15 @@ export async function wizarDSSuggest(
       temperature: 0,
     });
 
-    const componentsArray = JSON.parse(info.choices[0].message.content);
+    const suggestedList = info.choices[0].message.content.split(',').map((item) => item.trim());
+
+    const suggestedComponents = templates.filter((t: Suggestion) => suggestedList.includes(t.component));
 
     const payload = {
       idx,
       interaction: {
         ...interactionToUpdate,
-        suggestions: componentsArray,
+        suggestions: suggestedComponents,
         isLoading: false,
       },
     };

--- a/public/app/plugins/datasource/prometheus/querybuilder/components/wizarDS/state/helpers.ts
+++ b/public/app/plugins/datasource/prometheus/querybuilder/components/wizarDS/state/helpers.ts
@@ -1,14 +1,11 @@
 import { AnyAction } from 'redux';
 
 import { llms } from '@grafana/experimental';
-import { PrometheusDatasource } from 'app/plugins/datasource/prometheus/datasource';
 
-import { PromVisualQuery } from '../../../types';
 import { GetComponentSuggestionsUserPrompt, GetComponentSuggestionsSystemPrompt } from '../prompts';
 import { Interaction, Suggestion, SuggestionType } from '../types';
 
 import { createInteraction, stateSlice } from './state';
-import { getTemplateSuggestions } from './templates';
 
 const OPENAI_MODEL_NAME = 'gpt-3.5-turbo';
 
@@ -40,10 +37,8 @@ export function getExplainMessage(templates?: Suggestion[], question?: string): 
 export async function wizarDSExplain(
   dispatch: React.Dispatch<AnyAction>,
   idx: number,
-  query: PromVisualQuery,
   interaction: Interaction,
   suggIdx: number,
-  datasource: PrometheusDatasource
 ) {
   // const suggestedQuery = interaction.suggestions[suggIdx].component;
 
@@ -218,9 +213,6 @@ export async function wizarDSExplain(
 export async function wizarDSSuggest(
   dispatch: React.Dispatch<AnyAction>,
   idx: number,
-  query: PromVisualQuery,
-  labelNames: string[],
-  datasource: PrometheusDatasource,
   templates: Suggestion[],
   interaction?: Interaction
 ) {
@@ -232,7 +224,7 @@ export async function wizarDSSuggest(
 
   if (!check || interactionToUpdate.suggestionType === SuggestionType.Historical) {
     return new Promise<void>((resolve) => {
-      const suggestions = getTemplateSuggestions();
+      const suggestions = templates;
 
       const payload = {
         idx,

--- a/public/app/plugins/datasource/prometheus/querybuilder/components/wizarDS/state/templates.ts
+++ b/public/app/plugins/datasource/prometheus/querybuilder/components/wizarDS/state/templates.ts
@@ -4,9 +4,12 @@ export const componentTemplates: Suggestion[] = [
   {
     component: 'Kickstart your query',
     explanation: `Click to see a list of operation patterns that help you quickly get started adding multiple operations to your query. These include:
-
+      \n
+      \n
       Rate query starters
+      \n
       Histogram query starters
+      \n
       Binary query starters`,
     testid: 'wizard-prometheus-kickstart-your-query',
     order: 1,
@@ -28,8 +31,24 @@ export const componentTemplates: Suggestion[] = [
   },
   {
     component: 'Operations',
-    explanation:
-      'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.',
+    explanation: `Select the + Operations button to add operations to your query.
+      \n
+      The query editor groups operations into the following sections:
+      \n
+      \n
+      Aggregations - for additional information see Aggregation operators.
+      \n
+      Range functions - for additional information see Functions.
+      \n
+      Functions - for additional information see Functions.
+      \n
+      Binary operations - for additional information see Binary operators.
+      \n
+      Trigonometric - for additional information see Trigonometric functions.
+      \n
+      Time functions - for additional information see Functions.
+      \n
+      All operations have function parameters under the operation header. Click the operator to see a full list of supported functions. Some operations allow you to apply specific labels to functions.`,
     testid: 'wizard-prometheus-operations',
     order: 4,
     link: 'https://grafana.com/docs/grafana/latest/datasources/prometheus/query-editor/#operations',
@@ -37,9 +56,12 @@ export const componentTemplates: Suggestion[] = [
   {
     component: 'Legend',
     explanation: `The Legend setting defines the time series’s name. You can use a predefined or custom format.
-
+      \n
+      \n
       Auto - Displays unique labels. Also displays all overlapping labels if a series has multiple labels.
+      \n
       Verbose - Displays all label names.
+      \n
       Custom - Uses templating to select which labels will be included. For example, {{hostname}} is replaced by the label value for the label hostname. Clear the input and click outside of it to select another mode.`,
     testid: 'wizard-prometheus-legend',
     order: 5,
@@ -55,9 +77,12 @@ export const componentTemplates: Suggestion[] = [
   {
     component: 'Format',
     explanation: `Switch between the following format options:
-
+      \n
+      \n
       Time series - The default time series format. See Time series kind formats for information on time series data frames and how time and value fields are structured.
+      \n
       Table - This works only in a Table panel.
+      \n
       Heatmap - Displays metrics of the Histogram type on a Heatmap panel by converting cumulative histograms to regular ones and sorting the series by the bucket bound.`,
     testid: 'wizard-prometheus-format',
     order: 7,
@@ -66,9 +91,12 @@ export const componentTemplates: Suggestion[] = [
   {
     component: 'Type',
     explanation: `The Type setting sets the query type. These include:
-
+      \n
+      \n
       Both - The default option. Returns results for both a Range query and an Instant query.
+      \n
       Range - Returns a range vector consisting of a set of time series data containing a range of data points over time for each time series. You can choose lines, bars, points, stacked lines or stacked bars
+      \n
       Instant - Returns one data point per query and only the most recent point in the time range provided. The results can be shown in table format or as raw data. To depict instant query results in the time series panel, first add a field override, next add a property to the override named Transform, and finally select Constant from the Transform dropdown.`,
     testid: 'wizard-prometheus-type',
     order: 8,
@@ -77,7 +105,7 @@ export const componentTemplates: Suggestion[] = [
   {
     component: 'Exemplars',
     explanation:
-      'Toggle Exemplars to run a query that includes exemplars in the graph. Exemplars are unique to Prometheus. For more information see Introduction to exemplars. https://grafana.com/docs/grafana/latest/datasources/prometheus/query-editor/#:~:text=Toggle%20Exemplars%20to%20run%20a%20query%20that%20includes%20exemplars%20in%20the%20graph.%20Exemplars%20are%20unique%20to%20Prometheus.%20For%20more%20information%20see%20Introduction%20to%20exemplars.',
+      'Toggle Exemplars to run a query that includes exemplars in the graph. Exemplars are unique to Prometheus.',
     testid: 'wizard-prometheus-exemplars',
     order: 9,
     link: 'https://grafana.com/docs/grafana/latest/datasources/prometheus/query-editor/#exemplars',

--- a/public/app/plugins/datasource/prometheus/querybuilder/components/wizarDS/state/templatesLoki.ts
+++ b/public/app/plugins/datasource/prometheus/querybuilder/components/wizarDS/state/templatesLoki.ts
@@ -1,0 +1,18 @@
+import { Suggestion } from '../types';
+
+export const componentTemplates: Suggestion[] = [
+  {
+    component: 'Kickstart your query',
+    explanation: `Click to see a list of operation patterns that help you quickly get started adding multiple operations to your query. These include:
+      \n
+      \n
+      Rate query starters
+      \n
+      Histogram query starters
+      \n
+      Binary query starters`,
+    testid: 'wizard-prometheus-kickstart-your-query',
+    order: 1,
+    link: 'https://grafana.com/docs/grafana/latest/datasources/prometheus/query-editor/#toolbar-elements',
+  },
+];


### PR DESCRIPTION
1. Update the system and user prompts
2. Map the content response to the template list
3. Fix some of the template info.
4. Apply templates to Loki (need to switch the templates based on the selected data source or something like that)


https://github.com/grafana/grafana/assets/25674746/2fa2572c-b3ec-4ff5-87bd-a2c28bd9c4d1



Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
