### PR TITLE
Hackathon: log options + log controls

### DIFF
--- a/public/app/features/logsApp/Logs/Logs.tsx
+++ b/public/app/features/logsApp/Logs/Logs.tsx
@@ -36,9 +36,11 @@ import { config, getDataSourceSrv, reportInteraction } from '@grafana/runtime';
 import { DataQuery } from '@grafana/schema';
 import {
   Button,
+  Dropdown,
   FeatureBadge,
   Icon,
   LinkButton,
+  Menu,
   PanelChrome,
   RadioButtonGroup,
   Themeable2,
@@ -765,33 +767,23 @@ class UnthemedLogs extends PureComponent<Props, State> {
         >
           <div className={styles.stickyNavigation}>
             <div className={styles.logsOptions}>
-                <Button
-                  size="md"
-                  variant="secondary"
-                  onClick={() => this.setState({ showLogsOptions: !this.state.showLogsOptions })}
-                 >
-                  <Icon name="sliders-v-alt" size="md" />
-                  Logs settings
-                </Button>
-                {this.state.showLogsOptions && (
-                  <LogsOptions
-                    styles={styles}
-                    showTime={showTime}
-                    showLabels={showLabels}
-                    wrapLogMessage={wrapLogMessage}
-                    prettifyLogMessage={prettifyLogMessage}
-                    isFlipping={isFlipping}
-                    dedupStrategy={dedupStrategy}
-                    exploreId={exploreId}
-                    logsSortOrder={logsSortOrder}
-                    onChangeTime={this.onChangeTime}
-                    onChangeLabels={this.onChangeLabels}
-                    onChangeWrapLogMessage={this.onChangeWrapLogMessage}
-                    onChangePrettifyLogMessage={this.onChangePrettifyLogMessage}
-                    onChangeDedup={this.onChangeDedup}
-                    onChangeLogsSortOrder={this.onChangeLogsSortOrder}
-                  />
-                )}
+                <LogsOptions
+                  styles={styles}
+                  showTime={showTime}
+                  showLabels={showLabels}
+                  wrapLogMessage={wrapLogMessage}
+                  prettifyLogMessage={prettifyLogMessage}
+                  isFlipping={isFlipping}
+                  dedupStrategy={dedupStrategy}
+                  exploreId={exploreId}
+                  logsSortOrder={logsSortOrder}
+                  onChangeTime={this.onChangeTime}
+                  onChangeLabels={this.onChangeLabels}
+                  onChangeWrapLogMessage={this.onChangeWrapLogMessage}
+                  onChangePrettifyLogMessage={this.onChangePrettifyLogMessage}
+                  onChangeDedup={this.onChangeDedup}
+                  onChangeLogsSortOrder={this.onChangeLogsSortOrder}
+                />
                 {config.featureToggles.logsExploreTableVisualisation && (
                   <div className={styles.visualisationType}>
                     <RadioButtonGroup
@@ -952,6 +944,17 @@ export const Logs = withTheme2(UnthemedLogs);
 
 const getStyles = (theme: GrafanaTheme2, wrapLogMessage: boolean, tableHeight: number) => {
   return {
+    logOptionsMenu: css({
+      position: 'relative',
+      left: theme.spacing(2),
+      backgroundColor: theme.colors.background.secondary,
+      padding: theme.spacing(1),
+      paddingLeft: theme.spacing(0.5),
+    }),
+    logOptionMenuItem: css({
+      display: 'flex',
+      justifyContent: 'space-between',
+    }),
     logsOptions: css({
       marginBottom: theme.spacing(2),
       display: 'flex',
@@ -983,9 +986,6 @@ const getStyles = (theme: GrafanaTheme2, wrapLogMessage: boolean, tableHeight: n
       '& > label': {
         marginRight: '0',
       },
-    }),
-    horizontalInlineSwitch: css({
-      padding: `0 ${theme.spacing(1)} 0 0`,
     }),
     radioButtons: css({
       margin: '0',

--- a/public/app/features/logsApp/Logs/Logs.tsx
+++ b/public/app/features/logsApp/Logs/Logs.tsx
@@ -68,6 +68,7 @@ import { LogsOptions } from './LogsOptions';
 import { getLogsTableHeight, LogsTableWrap } from './LogsTableWrap';
 import { LogsVolumePanelList } from './LogsVolumePanelList';
 import { SETTINGS_KEYS } from './utils/logs';
+import { LogsOrder } from './LogsOrder';
 
 interface Props extends Themeable2 {
   width: number;
@@ -773,38 +774,41 @@ class UnthemedLogs extends PureComponent<Props, State> {
                   showLabels={showLabels}
                   wrapLogMessage={wrapLogMessage}
                   prettifyLogMessage={prettifyLogMessage}
-                  isFlipping={isFlipping}
-                  dedupStrategy={dedupStrategy}
                   exploreId={exploreId}
-                  logsSortOrder={logsSortOrder}
                   onChangeTime={this.onChangeTime}
                   onChangeLabels={this.onChangeLabels}
                   onChangeWrapLogMessage={this.onChangeWrapLogMessage}
                   onChangePrettifyLogMessage={this.onChangePrettifyLogMessage}
-                  onChangeDedup={this.onChangeDedup}
-                  onChangeLogsSortOrder={this.onChangeLogsSortOrder}
                 />
-                {config.featureToggles.logsExploreTableVisualisation && (
-                  <div className={styles.visualisationType}>
-                    <RadioButtonGroup
-                      options={[
-                        {
-                          label: 'Logs',
-                          value: 'logs',
-                          description: 'Show results in logs visualisation',
-                        },
-                        {
-                          label: 'Table',
-                          value: 'table',
-                          description: 'Show results in table visualisation',
-                        },
-                      ]}
-                      size="md"
-                      value={this.state.visualisationType}
-                      onChange={this.onChangeVisualisation}
-                    />
-                  </div>
-                )}
+                <div className={styles.optionToggles}>
+                  {config.featureToggles.logsExploreTableVisualisation && (
+                    <div className={styles.visualisationType}>
+                      <RadioButtonGroup
+                        options={[
+                          {
+                            label: 'List',
+                            value: 'logs',
+                            description: 'Show results in logs visualisation',
+                          },
+                          {
+                            label: 'Table',
+                            value: 'table',
+                            description: 'Show results in table visualisation',
+                          },
+                        ]}
+                        size="md"
+                        value={this.state.visualisationType}
+                        onChange={this.onChangeVisualisation}
+                      />
+                    </div>
+                  )}
+                  <LogsOrder
+                    logsSortOrder={logsSortOrder}
+                    isFlipping={isFlipping}
+                    onChangeLogsSortOrder={this.onChangeLogsSortOrder}
+                    styles={styles}
+                  />
+                </div>
               </div>
             <div ref={this.topLogsRef} />
           </div>
@@ -944,6 +948,9 @@ export const Logs = withTheme2(UnthemedLogs);
 
 const getStyles = (theme: GrafanaTheme2, wrapLogMessage: boolean, tableHeight: number) => {
   return {
+    optionToggles: css({
+      display: 'flex', 
+    }),
     logOptionsMenu: css({
       position: 'relative',
       left: theme.spacing(2),

--- a/public/app/features/logsApp/Logs/Logs.tsx
+++ b/public/app/features/logsApp/Logs/Logs.tsx
@@ -758,23 +758,6 @@ class UnthemedLogs extends PureComponent<Props, State> {
           }
         </PanelChrome>
         <PanelChrome
-          titleItems={[
-            config.featureToggles.logsExploreTableVisualisation
-              ? this.state.visualisationType === 'logs'
-                ? null
-                : [
-                    <PanelChrome.TitleItem title="Experimental" key="A">
-                      <FeatureBadge
-                        featureState={FeatureState.beta}
-                        tooltip="Table view is experimental and may change in future versions"
-                      />
-                    </PanelChrome.TitleItem>,
-                    <PanelChrome.TitleItem title="Feedback" key="B">
-                      <LogsFeedback feedbackUrl="https://forms.gle/5YyKdRQJ5hzq4c289" />
-                    </PanelChrome.TitleItem>,
-                  ]
-              : null,
-          ]}
           title={`Logs${
             this.state.hiddenLogLevels.length > 0 ? ` (filtered based on selected ${this.state.groupByLabel})` : ''
           }`}
@@ -782,7 +765,6 @@ class UnthemedLogs extends PureComponent<Props, State> {
         >
           <div className={styles.stickyNavigation}>
             <div className={styles.logsOptions}>
-              {this.state.visualisationType !== 'table' && (
                 <Button
                   size="md"
                   variant="secondary"
@@ -791,7 +773,6 @@ class UnthemedLogs extends PureComponent<Props, State> {
                   <Icon name="sliders-v-alt" size="md" />
                   Logs settings
                 </Button>
-                )}
                 {this.state.showLogsOptions && (
                   <LogsOptions
                     styles={styles}

--- a/public/app/features/logsApp/Logs/LogsOptions.tsx
+++ b/public/app/features/logsApp/Logs/LogsOptions.tsx
@@ -1,37 +1,18 @@
-import { capitalize } from "lodash";
 import React from "react";
 
-import { LogsDedupDescription } from "@grafana/data";
-import { LogsDedupStrategy, LogsSortOrder } from "@grafana/schema";
-import { Button, Dropdown, Icon, InlineField, InlineFieldRow, InlineSwitch, RadioButtonGroup } from "@grafana/ui";
+import { Button, Dropdown, Icon, InlineField, InlineSwitch } from "@grafana/ui";
 
-// we need to define the order of these explicitly
-const DEDUP_OPTIONS = [
-  LogsDedupStrategy.none,
-  LogsDedupStrategy.exact,
-  LogsDedupStrategy.numbers,
-  LogsDedupStrategy.signature,
-];
-
-/**
- * Placeholder component for Log Details to clean up the UI and prepare for that.
- */
 interface Props {
   styles: Record<string, string>;
   showTime: boolean;
   showLabels: boolean;
   wrapLogMessage: boolean;
   prettifyLogMessage: boolean;
-  isFlipping: boolean;
-  dedupStrategy: LogsDedupStrategy;
   exploreId: string;
-  logsSortOrder: LogsSortOrder;
   onChangeTime(event: React.ChangeEvent<HTMLInputElement>): void;
   onChangeLabels(event: React.ChangeEvent<HTMLInputElement>): void;
   onChangeWrapLogMessage(event: React.ChangeEvent<HTMLInputElement>): void;
   onChangePrettifyLogMessage(event: React.ChangeEvent<HTMLInputElement>): void;
-  onChangeDedup(dedupStrategy: LogsDedupStrategy): void;
-  onChangeLogsSortOrder(): void;
 }
 
 export const LogsOptions = ({
@@ -45,11 +26,6 @@ export const LogsOptions = ({
   onChangeWrapLogMessage,
   onChangePrettifyLogMessage,
   prettifyLogMessage,
-  dedupStrategy,
-  onChangeDedup,
-  isFlipping,
-  logsSortOrder,
-  onChangeLogsSortOrder
 }: Props) => {
   const menu = (
     <div className={styles.logOptionsMenu}>

--- a/public/app/features/logsApp/Logs/LogsOptions.tsx
+++ b/public/app/features/logsApp/Logs/LogsOptions.tsx
@@ -1,9 +1,9 @@
+import { capitalize } from "lodash";
 import React from "react";
 
-import { LogsDedupStrategy, LogsSortOrder } from "@grafana/schema";
-import { InlineField, InlineFieldRow, InlineSwitch, RadioButtonGroup } from "@grafana/ui";
-import { capitalize } from "lodash";
 import { LogsDedupDescription } from "@grafana/data";
+import { LogsDedupStrategy, LogsSortOrder } from "@grafana/schema";
+import { Button, Dropdown, Icon, InlineField, InlineFieldRow, InlineSwitch, RadioButtonGroup } from "@grafana/ui";
 
 // we need to define the order of these explicitly
 const DEDUP_OPTIONS = [
@@ -51,81 +51,51 @@ export const LogsOptions = ({
   logsSortOrder,
   onChangeLogsSortOrder
 }: Props) => {
-  return (
-    <div className={styles.logOptions}>
-      <InlineFieldRow>
-        <InlineField label="Time" className={styles.horizontalInlineLabel} transparent>
-          <InlineSwitch
-            value={showTime}
-            onChange={onChangeTime}
-            className={styles.horizontalInlineSwitch}
-            transparent
-            id={`show-time_${exploreId}`}
-          />
-        </InlineField>
-        <InlineField label="Unique labels" className={styles.horizontalInlineLabel} transparent>
-          <InlineSwitch
-            value={showLabels}
-            onChange={onChangeLabels}
-            className={styles.horizontalInlineSwitch}
-            transparent
-            id={`unique-labels_${exploreId}`}
-          />
-        </InlineField>
-        <InlineField label="Wrap lines" className={styles.horizontalInlineLabel} transparent>
-          <InlineSwitch
-            value={wrapLogMessage}
-            onChange={onChangeWrapLogMessage}
-            className={styles.horizontalInlineSwitch}
-            transparent
-            id={`wrap-lines_${exploreId}`}
-          />
-        </InlineField>
-        <InlineField label="Prettify JSON" className={styles.horizontalInlineLabel} transparent>
-          <InlineSwitch
-            value={prettifyLogMessage}
-            onChange={onChangePrettifyLogMessage}
-            className={styles.horizontalInlineSwitch}
-            transparent
-            id={`prettify_${exploreId}`}
-          />
-        </InlineField>
-        <InlineField label="Deduplication" className={styles.horizontalInlineLabel} transparent>
-          <RadioButtonGroup
-            options={DEDUP_OPTIONS.map((dedupType) => ({
-              label: capitalize(dedupType),
-              value: dedupType,
-              description: LogsDedupDescription[dedupType],
-            }))}
-            value={dedupStrategy}
-            onChange={onChangeDedup}
-            className={styles.radioButtons}
-          />
-        </InlineField>
-      </InlineFieldRow>
-
-      <div>
-        <InlineField label="Display results" className={styles.horizontalInlineLabel} transparent>
-          <RadioButtonGroup
-            disabled={isFlipping}
-            options={[
-              {
-                label: 'Newest first',
-                value: LogsSortOrder.Descending,
-                description: 'Show results newest to oldest',
-              },
-              {
-                label: 'Oldest first',
-                value: LogsSortOrder.Ascending,
-                description: 'Show results oldest to newest',
-              },
-            ]}
-            value={logsSortOrder}
-            onChange={onChangeLogsSortOrder}
-            className={styles.radioButtons}
-          />
-        </InlineField>
-      </div>
+  const menu = (
+    <div className={styles.logOptionsMenu}>
+      <InlineField label="Time" className={styles.logOptionMenuItem}>
+        <InlineSwitch
+          value={showTime}
+          onChange={onChangeTime}
+          transparent
+          id={`show-time_${exploreId}`}
+        />
+      </InlineField>
+      <InlineField label="Unique labels" className={styles.logOptionMenuItem}>
+        <InlineSwitch
+          value={showLabels}
+          onChange={onChangeLabels}
+          transparent
+          id={`unique-labels_${exploreId}`}
+        />
+      </InlineField>
+      <InlineField label="Wrap lines" className={styles.logOptionMenuItem}>
+        <InlineSwitch
+          value={wrapLogMessage}
+          onChange={onChangeWrapLogMessage}
+          transparent
+          id={`wrap-lines_${exploreId}`}
+        />
+      </InlineField>
+      <InlineField label="Prettify JSON" className={styles.logOptionMenuItem}>
+        <InlineSwitch
+          value={prettifyLogMessage}
+          onChange={onChangePrettifyLogMessage}
+          transparent
+          id={`prettify_${exploreId}`}
+        />
+      </InlineField>
     </div>
+  );
+  return (
+    <Dropdown overlay={menu}>
+    <Button
+      size="md"
+      variant="secondary"
+    >
+      <Icon name="sliders-v-alt" size="md" />
+      Logs settings
+    </Button>
+  </Dropdown>
   );
 };

--- a/public/app/features/logsApp/Logs/LogsOptions.tsx
+++ b/public/app/features/logsApp/Logs/LogsOptions.tsx
@@ -1,0 +1,131 @@
+import React from "react";
+
+import { LogsDedupStrategy, LogsSortOrder } from "@grafana/schema";
+import { InlineField, InlineFieldRow, InlineSwitch, RadioButtonGroup } from "@grafana/ui";
+import { capitalize } from "lodash";
+import { LogsDedupDescription } from "@grafana/data";
+
+// we need to define the order of these explicitly
+const DEDUP_OPTIONS = [
+  LogsDedupStrategy.none,
+  LogsDedupStrategy.exact,
+  LogsDedupStrategy.numbers,
+  LogsDedupStrategy.signature,
+];
+
+/**
+ * Placeholder component for Log Details to clean up the UI and prepare for that.
+ */
+interface Props {
+  styles: Record<string, string>;
+  showTime: boolean;
+  showLabels: boolean;
+  wrapLogMessage: boolean;
+  prettifyLogMessage: boolean;
+  isFlipping: boolean;
+  dedupStrategy: LogsDedupStrategy;
+  exploreId: string;
+  logsSortOrder: LogsSortOrder;
+  onChangeTime(event: React.ChangeEvent<HTMLInputElement>): void;
+  onChangeLabels(event: React.ChangeEvent<HTMLInputElement>): void;
+  onChangeWrapLogMessage(event: React.ChangeEvent<HTMLInputElement>): void;
+  onChangePrettifyLogMessage(event: React.ChangeEvent<HTMLInputElement>): void;
+  onChangeDedup(dedupStrategy: LogsDedupStrategy): void;
+  onChangeLogsSortOrder(): void;
+}
+
+export const LogsOptions = ({
+  styles,
+  showTime,
+  onChangeTime,
+  exploreId,
+  showLabels,
+  onChangeLabels,
+  wrapLogMessage,
+  onChangeWrapLogMessage,
+  onChangePrettifyLogMessage,
+  prettifyLogMessage,
+  dedupStrategy,
+  onChangeDedup,
+  isFlipping,
+  logsSortOrder,
+  onChangeLogsSortOrder
+}: Props) => {
+  return (
+    <div className={styles.logOptions}>
+      <InlineFieldRow>
+        <InlineField label="Time" className={styles.horizontalInlineLabel} transparent>
+          <InlineSwitch
+            value={showTime}
+            onChange={onChangeTime}
+            className={styles.horizontalInlineSwitch}
+            transparent
+            id={`show-time_${exploreId}`}
+          />
+        </InlineField>
+        <InlineField label="Unique labels" className={styles.horizontalInlineLabel} transparent>
+          <InlineSwitch
+            value={showLabels}
+            onChange={onChangeLabels}
+            className={styles.horizontalInlineSwitch}
+            transparent
+            id={`unique-labels_${exploreId}`}
+          />
+        </InlineField>
+        <InlineField label="Wrap lines" className={styles.horizontalInlineLabel} transparent>
+          <InlineSwitch
+            value={wrapLogMessage}
+            onChange={onChangeWrapLogMessage}
+            className={styles.horizontalInlineSwitch}
+            transparent
+            id={`wrap-lines_${exploreId}`}
+          />
+        </InlineField>
+        <InlineField label="Prettify JSON" className={styles.horizontalInlineLabel} transparent>
+          <InlineSwitch
+            value={prettifyLogMessage}
+            onChange={onChangePrettifyLogMessage}
+            className={styles.horizontalInlineSwitch}
+            transparent
+            id={`prettify_${exploreId}`}
+          />
+        </InlineField>
+        <InlineField label="Deduplication" className={styles.horizontalInlineLabel} transparent>
+          <RadioButtonGroup
+            options={DEDUP_OPTIONS.map((dedupType) => ({
+              label: capitalize(dedupType),
+              value: dedupType,
+              description: LogsDedupDescription[dedupType],
+            }))}
+            value={dedupStrategy}
+            onChange={onChangeDedup}
+            className={styles.radioButtons}
+          />
+        </InlineField>
+      </InlineFieldRow>
+
+      <div>
+        <InlineField label="Display results" className={styles.horizontalInlineLabel} transparent>
+          <RadioButtonGroup
+            disabled={isFlipping}
+            options={[
+              {
+                label: 'Newest first',
+                value: LogsSortOrder.Descending,
+                description: 'Show results newest to oldest',
+              },
+              {
+                label: 'Oldest first',
+                value: LogsSortOrder.Ascending,
+                description: 'Show results oldest to newest',
+              },
+            ]}
+            value={logsSortOrder}
+            onChange={onChangeLogsSortOrder}
+            className={styles.radioButtons}
+          />
+        </InlineField>
+      </div>
+    </div>
+  );
+};

--- a/public/app/features/logsApp/Logs/LogsOrder.tsx
+++ b/public/app/features/logsApp/Logs/LogsOrder.tsx
@@ -1,0 +1,43 @@
+import React from 'react';
+
+import { LogsSortOrder } from '@grafana/schema';
+import { Icon, InlineField, RadioButtonGroup } from '@grafana/ui';
+
+interface Props {
+  logsSortOrder: LogsSortOrder;
+  onChangeLogsSortOrder(): void;
+  isFlipping: boolean;
+  styles: Record<string, string>;
+}
+
+export const LogsOrder = ({
+  logsSortOrder,
+  onChangeLogsSortOrder,
+  isFlipping,
+  styles
+}: Props) => {
+  return (
+    <div>
+      <InlineField className={styles.logOptionMenuItem}>
+        <RadioButtonGroup
+          disabled={isFlipping}
+          options={[
+            {
+              label: '↑',
+              value: LogsSortOrder.Descending,
+              description: 'Show results newest to oldest',
+            },
+            {
+              label: '↓',
+              value: LogsSortOrder.Ascending,
+              description: 'Show results oldest to newest',
+            },
+          ]}
+          value={logsSortOrder}
+          onChange={onChangeLogsSortOrder}
+          className={styles.radioButtons}
+        />
+      </InlineField>
+    </div>
+  );
+};


### PR DESCRIPTION
Completely refactored the log options:

- Created a log options component with a dropdown (currently not clickable for some dom reason, will fix in a follow up)
- Refactored List / Table picker to new design
- Refactored sort order to new deseign

![imagen](https://github.com/grafana/grafana/assets/1069378/efa7a30c-febc-45bf-8a38-9d46dc05c159)
