### PR TITLE
WizarDS: Connect with Loki

### DIFF
--- a/public/app/plugins/datasource/loki/components/LokiQueryEditor.tsx
+++ b/public/app/plugins/datasource/loki/components/LokiQueryEditor.tsx
@@ -128,7 +128,6 @@ export const LokiQueryEditor = React.memo<LokiQueryEditorProps>((props) => {
             // remove all references to the query
             query={{ metric: '', labels: [], operations: [] }}
             closeDrawer={() => setWizarDSDrawerOpen(false)}
-            datasource={props.datasource}
             // add component templates so any DS can use this
             templates={componentTemplates}
           />

--- a/public/app/plugins/datasource/loki/components/LokiQueryEditor.tsx
+++ b/public/app/plugins/datasource/loki/components/LokiQueryEditor.tsx
@@ -6,11 +6,13 @@ import { CoreApp, LoadingState } from '@grafana/data';
 import { selectors } from '@grafana/e2e-selectors';
 import { EditorHeader, EditorRows, FlexItem, Space, Stack } from '@grafana/experimental';
 import { config, reportInteraction } from '@grafana/runtime';
-import { Button, ConfirmModal } from '@grafana/ui';
+import { Button, ConfirmModal, Drawer } from '@grafana/ui';
 import { QueryEditorModeToggle } from 'app/plugins/datasource/prometheus/querybuilder/shared/QueryEditorModeToggle';
 import { QueryHeaderSwitch } from 'app/plugins/datasource/prometheus/querybuilder/shared/QueryHeaderSwitch';
 import { QueryEditorMode } from 'app/plugins/datasource/prometheus/querybuilder/shared/types';
 
+import { WizarDS } from '../../prometheus/querybuilder/components/wizarDS/WizarDS';
+import { componentTemplates } from '../../prometheus/querybuilder/components/wizarDS/state/templatesLoki';
 import { lokiQueryEditorExplainKey, useFlag } from '../../prometheus/querybuilder/shared/hooks/useFlag';
 import { LabelBrowserModal } from '../querybuilder/components/LabelBrowserModal';
 import { LokiQueryBuilderContainer } from '../querybuilder/components/LokiQueryBuilderContainer';
@@ -36,6 +38,7 @@ export const LokiQueryEditor = React.memo<LokiQueryEditorProps>((props) => {
   const [dataIsStale, setDataIsStale] = useState(false);
   const [labelBrowserVisible, setLabelBrowserVisible] = useState(false);
   const [queryStats, setQueryStats] = useState<QueryStats | null>(null);
+  const [wizarDSDrawerOpen, setWizarDSDrawerOpen] = useState(false);
   const { flag: explain, setFlag: setExplain } = useFlag(lokiQueryEditorExplainKey);
 
   const predefinedOperations = datasource.predefinedOperations;
@@ -115,8 +118,22 @@ export const LokiQueryEditor = React.memo<LokiQueryEditorProps>((props) => {
     }
   }, [datasource, timeRange, previousTimeRange, query, previousQueryExpr, previousQueryType, setQueryStats, id]);
 
+  const wizarDSToggle = config.featureToggles.wizarDSToggle;
+
   return (
     <>
+    {wizarDSToggle && wizarDSDrawerOpen && (
+        <Drawer closeOnMaskClick={false} onClose={() => setWizarDSDrawerOpen(false)}>
+          <WizarDS
+            // remove all references to the query
+            query={{ metric: '', labels: [], operations: [] }}
+            closeDrawer={() => setWizarDSDrawerOpen(false)}
+            datasource={props.datasource}
+            // add component templates so any DS can use this
+            templates={componentTemplates}
+          />
+        </Drawer>
+      )}
       <ConfirmModal
         isOpen={parseModalOpen}
         title="Query parsing"
@@ -167,6 +184,9 @@ export const LokiQueryEditor = React.memo<LokiQueryEditorProps>((props) => {
             }}
           >
             Kick start your query
+          </Button>
+          <Button variant="secondary" size="sm" onClick={() => setWizarDSDrawerOpen((prevValue) => !prevValue)}>
+            Take me on a magical journey
           </Button>
           <Button variant="secondary" size="sm" onClick={onClickLabelBrowserButton} data-testid="label-browser-button">
             Label browser

--- a/public/app/plugins/datasource/prometheus/querybuilder/components/PromQueryEditorSelector.tsx
+++ b/public/app/plugins/datasource/prometheus/querybuilder/components/PromQueryEditorSelector.tsx
@@ -125,7 +125,6 @@ export const PromQueryEditorSelector = React.memo<Props>((props) => {
             // remove all references to the query
             query={{ metric: '', labels: [], operations: [] }}
             closeDrawer={() => setWizarDSDrawerOpen(false)}
-            datasource={props.datasource}
             // add component templates so any DS can use this
             templates={componentTemplates}
           />

--- a/public/app/plugins/datasource/prometheus/querybuilder/components/promQail/QuerySuggestionItem.tsx
+++ b/public/app/plugins/datasource/prometheus/querybuilder/components/promQail/QuerySuggestionItem.tsx
@@ -208,14 +208,13 @@ export function QuerySuggestionItem(props: Props) {
               <div className={styles.textPadding}>This query is trying to answer the question:</div>
               <div className={styles.textPadding}>{explanation}</div>
               <div className={styles.textPadding}>
-                Learn more with this{' '}
                 <a
                   className={styles.doc}
                   href={'https://prometheus.io/docs/prometheus/latest/querying/examples/#query-examples'}
                   target="_blank"
                   rel="noopener noreferrer"
                 >
-                  Prometheus doc
+                  Learn more
                 </a>
               </div>
 

--- a/public/app/plugins/datasource/prometheus/querybuilder/components/wizarDS/SuggestionItem.tsx
+++ b/public/app/plugins/datasource/prometheus/querybuilder/components/wizarDS/SuggestionItem.tsx
@@ -205,14 +205,13 @@ export function SuggestionItem(props: Props) {
             <div className={cx(styles.bodySmall, styles.explainPadding)}>
               <div className={styles.textPadding}>{explanation}</div>
               <div className={styles.textPadding}>
-                Learn more with this{' '}
                 <a
                   className={styles.doc}
-                  href={'https://prometheus.io/docs/prometheus/latest/querying/examples/#query-examples'}
+                  href={suggestion.link}
                   target="_blank"
                   rel="noopener noreferrer"
                 >
-                  Prometheus doc
+                  Learn more
                 </a>
               </div>
 

--- a/public/app/plugins/datasource/prometheus/querybuilder/components/wizarDS/WizarDS.tsx
+++ b/public/app/plugins/datasource/prometheus/querybuilder/components/wizarDS/WizarDS.tsx
@@ -5,6 +5,7 @@ import { GrafanaTheme2 } from '@grafana/data';
 // import { reportInteraction } from '@grafana/runtime';
 import { Button, Checkbox, Input, Spinner, useTheme2 } from '@grafana/ui';
 import store from 'app/core/store';
+import { LokiDatasource } from 'app/plugins/datasource/loki/datasource';
 
 import { PrometheusDatasource } from '../../../datasource';
 import { PromVisualQuery } from '../../types';
@@ -22,7 +23,7 @@ const { showStartingMessage, indicateCheckbox, addInteraction, updateInteraction
 export type WizarDSProps = {
   query: PromVisualQuery;
   closeDrawer: () => void;
-  datasource: PrometheusDatasource;
+  datasource: PrometheusDatasource | LokiDatasource;
   templates: Suggestion[];
 };
 

--- a/public/app/plugins/datasource/prometheus/querybuilder/components/wizarDS/WizarDS.tsx
+++ b/public/app/plugins/datasource/prometheus/querybuilder/components/wizarDS/WizarDS.tsx
@@ -5,9 +5,7 @@ import { GrafanaTheme2 } from '@grafana/data';
 // import { reportInteraction } from '@grafana/runtime';
 import { Button, Checkbox, Input, Spinner, useTheme2 } from '@grafana/ui';
 import store from 'app/core/store';
-import { LokiDatasource } from 'app/plugins/datasource/loki/datasource';
 
-import { PrometheusDatasource } from '../../../datasource';
 import { PromVisualQuery } from '../../types';
 
 import { SuggestionContainer } from './SuggestionContainer';
@@ -23,14 +21,13 @@ const { showStartingMessage, indicateCheckbox, addInteraction, updateInteraction
 export type WizarDSProps = {
   query: PromVisualQuery;
   closeDrawer: () => void;
-  datasource: PrometheusDatasource | LokiDatasource;
   templates: Suggestion[];
 };
 
 const SKIP_STARTING_MESSAGE = 'SKIP_STARTING_MESSAGE';
 
 export const WizarDS = (props: WizarDSProps) => {
-  const { query, closeDrawer, datasource, templates } = props;
+  const { query, closeDrawer, templates } = props;
   const skipStartingMessage = store.getBool(SKIP_STARTING_MESSAGE, false);
 
   const [state, dispatch] = useReducer(stateSlice.reducer, initialState(query, !skipStartingMessage));
@@ -194,7 +191,7 @@ export const WizarDS = (props: WizarDSProps) => {
                         //   promVisualQuery: query,
                         //   doYouKnow: 'no',
                         // });
-                        wizarDSSuggest(dispatch, 0, query, [], datasource, templates);
+                        wizarDSSuggest(dispatch, 0, templates);
                       }}
                     >
                       Just walk me through everything
@@ -289,7 +286,7 @@ export const WizarDS = (props: WizarDSProps) => {
                                     // });
 
                                     dispatch(updateInteraction(payload));
-                                    wizarDSSuggest(dispatch, idx, query, [], datasource, templates, newInteraction);
+                                    wizarDSSuggest(dispatch, idx, templates, newInteraction);
                                   }}
                                 >
                                   Show me everything instead.
@@ -316,7 +313,7 @@ export const WizarDS = (props: WizarDSProps) => {
 
                                     dispatch(updateInteraction(payload));
                                     // add the suggestions in the API call
-                                    wizarDSSuggest(dispatch, idx, query, [], datasource, templates, interaction);
+                                    wizarDSSuggest(dispatch, idx, templates, interaction);
                                   }}
                                 >
                                   Submit
@@ -338,7 +335,7 @@ export const WizarDS = (props: WizarDSProps) => {
                           }}
                           explain={(suggIdx: number) =>
                             interaction.suggestions[suggIdx].explanation === ''
-                              ? wizarDSExplain(dispatch, idx, query, interaction, suggIdx, datasource)
+                              ? wizarDSExplain(dispatch, idx, interaction, suggIdx)
                               : interaction.suggestions[suggIdx].explanation
                           }
                           // onChange={onChange}
@@ -366,7 +363,7 @@ export const WizarDS = (props: WizarDSProps) => {
                       }}
                       explain={(suggIdx: number) =>
                         interaction.suggestions[suggIdx].explanation === ''
-                          ? wizarDSExplain(dispatch, idx, query, interaction, suggIdx, datasource)
+                          ? wizarDSExplain(dispatch, idx, interaction, suggIdx)
                           : interaction.suggestions[suggIdx].explanation
                       }
                       // onChange={onChange}

--- a/public/app/plugins/datasource/prometheus/querybuilder/components/wizarDS/state/helpers.ts
+++ b/public/app/plugins/datasource/prometheus/querybuilder/components/wizarDS/state/helpers.ts
@@ -1,10 +1,7 @@
 import { AnyAction } from 'redux';
 
 import { llms } from '@grafana/experimental';
-import { LokiDatasource } from 'app/plugins/datasource/loki/datasource';
-import { PrometheusDatasource } from 'app/plugins/datasource/prometheus/datasource';
 
-import { PromVisualQuery } from '../../../types';
 import { GetComponentSuggestionsUserPrompt, GetComponentSuggestionsSystemPrompt } from '../prompts';
 import { Interaction, Suggestion, SuggestionType } from '../types';
 
@@ -40,10 +37,8 @@ export function getExplainMessage(templates?: Suggestion[], question?: string): 
 export async function wizarDSExplain(
   dispatch: React.Dispatch<AnyAction>,
   idx: number,
-  query: PromVisualQuery,
   interaction: Interaction,
   suggIdx: number,
-  datasource: PrometheusDatasource | LokiDatasource
 ) {
   // const suggestedQuery = interaction.suggestions[suggIdx].component;
 
@@ -218,9 +213,6 @@ export async function wizarDSExplain(
 export async function wizarDSSuggest(
   dispatch: React.Dispatch<AnyAction>,
   idx: number,
-  query: PromVisualQuery,
-  labelNames: string[],
-  datasource: PrometheusDatasource | LokiDatasource,
   templates: Suggestion[],
   interaction?: Interaction
 ) {

--- a/public/app/plugins/datasource/prometheus/querybuilder/components/wizarDS/state/helpers.ts
+++ b/public/app/plugins/datasource/prometheus/querybuilder/components/wizarDS/state/helpers.ts
@@ -9,7 +9,6 @@ import { GetComponentSuggestionsUserPrompt, GetComponentSuggestionsSystemPrompt 
 import { Interaction, Suggestion, SuggestionType } from '../types';
 
 import { createInteraction, stateSlice } from './state';
-import { getTemplateSuggestions } from './templates';
 
 const OPENAI_MODEL_NAME = 'gpt-3.5-turbo';
 
@@ -233,7 +232,7 @@ export async function wizarDSSuggest(
 
   if (!check || interactionToUpdate.suggestionType === SuggestionType.Historical) {
     return new Promise<void>((resolve) => {
-      const suggestions = getTemplateSuggestions();
+      const suggestions = templates;
 
       const payload = {
         idx,

--- a/public/app/plugins/datasource/prometheus/querybuilder/components/wizarDS/state/helpers.ts
+++ b/public/app/plugins/datasource/prometheus/querybuilder/components/wizarDS/state/helpers.ts
@@ -1,6 +1,7 @@
 import { AnyAction } from 'redux';
 
 import { llms } from '@grafana/experimental';
+import { LokiDatasource } from 'app/plugins/datasource/loki/datasource';
 import { PrometheusDatasource } from 'app/plugins/datasource/prometheus/datasource';
 
 import { PromVisualQuery } from '../../../types';
@@ -43,7 +44,7 @@ export async function wizarDSExplain(
   query: PromVisualQuery,
   interaction: Interaction,
   suggIdx: number,
-  datasource: PrometheusDatasource
+  datasource: PrometheusDatasource | LokiDatasource
 ) {
   // const suggestedQuery = interaction.suggestions[suggIdx].component;
 
@@ -220,7 +221,7 @@ export async function wizarDSSuggest(
   idx: number,
   query: PromVisualQuery,
   labelNames: string[],
-  datasource: PrometheusDatasource,
+  datasource: PrometheusDatasource | LokiDatasource,
   templates: Suggestion[],
   interaction?: Interaction
 ) {

--- a/public/app/plugins/datasource/prometheus/querybuilder/components/wizarDS/state/templatesLoki.ts
+++ b/public/app/plugins/datasource/prometheus/querybuilder/components/wizarDS/state/templatesLoki.ts
@@ -1,0 +1,18 @@
+import { Suggestion } from '../types';
+
+export const componentTemplates: Suggestion[] = [
+  {
+    component: 'Kickstart your query',
+    explanation: `Click to see a list of operation patterns that help you quickly get started adding multiple operations to your query. These include:
+      \n
+      \n
+      Rate query starters
+      \n
+      Histogram query starters
+      \n
+      Binary query starters`,
+    testid: 'wizard-prometheus-kickstart-your-query',
+    order: 1,
+    link: 'https://grafana.com/docs/grafana/latest/datasources/prometheus/query-editor/#toolbar-elements',
+  },
+];


### PR DESCRIPTION
Initial step for adding Loki support for WizarDS:

- Integrated with the editor
- Added the drawer and component
- Added template files for Loki
- Used the passed templates instance for "hardcoded" suggestions

 
![imagen](https://github.com/grafana/grafana/assets/1069378/31927c11-27f3-472d-83d5-d6b66d9d0b84)

