### PR TITLE
Wizards split view

### DIFF
--- a/public/app/core/components/AppChrome/AppChrome.tsx
+++ b/public/app/core/components/AppChrome/AppChrome.tsx
@@ -7,6 +7,7 @@ import { useStyles2, LinkButton, useTheme2 } from '@grafana/ui';
 import config from 'app/core/config';
 import { useGrafana } from 'app/core/context/GrafanaContext';
 import { CommandPalette } from 'app/features/commandPalette/CommandPalette';
+import { TutorialProvider } from 'app/features/tutorial/TutorialProvider';
 import { KioskMode } from 'app/types';
 
 import { AppChromeMenu } from './AppChromeMenu';
@@ -101,6 +102,7 @@ export function AppChrome({ children }: Props) {
           <CommandPalette />
         </>
       )}
+      <TutorialProvider />
     </div>
   );
 }

--- a/public/app/core/components/AppChrome/AppChrome.tsx
+++ b/public/app/core/components/AppChrome/AppChrome.tsx
@@ -7,7 +7,6 @@ import { useStyles2, LinkButton, useTheme2 } from '@grafana/ui';
 import config from 'app/core/config';
 import { useGrafana } from 'app/core/context/GrafanaContext';
 import { CommandPalette } from 'app/features/commandPalette/CommandPalette';
-import { TutorialProvider } from 'app/features/tutorial/TutorialProvider';
 import { KioskMode } from 'app/types';
 
 import { AppChromeMenu } from './AppChromeMenu';
@@ -102,7 +101,6 @@ export function AppChrome({ children }: Props) {
           <CommandPalette />
         </>
       )}
-      <TutorialProvider />
     </div>
   );
 }

--- a/public/app/features/explore/ExploreToolbar.tsx
+++ b/public/app/features/explore/ExploreToolbar.tsx
@@ -13,6 +13,7 @@ import {
   ToolbarButton,
   ButtonGroup,
   useStyles2,
+  Button,
 } from '@grafana/ui';
 import { AppChromeUpdate } from 'app/core/components/AppChrome/AppChromeUpdate';
 import { t, Trans } from 'app/core/internationalization';
@@ -62,9 +63,16 @@ interface Props {
   onChangeTime: (range: RawTimeRange, changedByScanner?: boolean) => void;
   onContentOutlineToogle: () => void;
   isContentOutlineOpen: boolean;
+  setOpenTutorial: () => void;
 }
 
-export function ExploreToolbar({ exploreId, onChangeTime, onContentOutlineToogle, isContentOutlineOpen }: Props) {
+export function ExploreToolbar({
+  exploreId,
+  onChangeTime,
+  onContentOutlineToogle,
+  isContentOutlineOpen,
+  setOpenTutorial,
+}: Props) {
   const dispatch = useDispatch();
   const splitted = useSelector(isSplit);
   const styles = useStyles2(getStyles, splitted);
@@ -241,14 +249,19 @@ export function ExploreToolbar({ exploreId, onChangeTime, onContentOutlineToogle
               Outline
             </ToolbarButton>
           ),
-          <DataSourcePicker
-            key={`${exploreId}-ds-picker`}
-            mixed={!isCorrelationsEditorMode}
-            onChange={onChangeDatasource}
-            current={datasourceInstance?.getRef()}
-            hideTextValue={showSmallDataSourcePicker}
-            width={showSmallDataSourcePicker ? 8 : undefined}
-          />,
+          <>
+            <DataSourcePicker
+              key={`${exploreId}-ds-picker`}
+              mixed={!isCorrelationsEditorMode}
+              onChange={onChangeDatasource}
+              current={datasourceInstance?.getRef()}
+              hideTextValue={showSmallDataSourcePicker}
+              width={showSmallDataSourcePicker ? 8 : undefined}
+            />
+            <Button variant="primary" size="sm" onClick={() => setOpenTutorial()} style={{ marginLeft: '10px' }}>
+              Take me on a magical journey
+            </Button>
+          </>,
         ].filter(Boolean)}
         forceShowLeftItems
       >

--- a/public/app/plugins/datasource/prometheus/querybuilder/components/PromQueryEditorSelector.tsx
+++ b/public/app/plugins/datasource/prometheus/querybuilder/components/PromQueryEditorSelector.tsx
@@ -4,8 +4,8 @@ import React, { SyntheticEvent, useCallback, useEffect, useState } from 'react';
 import { CoreApp, LoadingState, SelectableValue } from '@grafana/data';
 import { selectors } from '@grafana/e2e-selectors';
 import { EditorHeader, EditorRows, FlexItem, Space } from '@grafana/experimental';
-import { config, reportInteraction } from '@grafana/runtime';
-import { Button, ConfirmModal, Drawer } from '@grafana/ui';
+import { reportInteraction } from '@grafana/runtime';
+import { Button, ConfirmModal } from '@grafana/ui';
 
 import { PromQueryEditorProps } from '../../components/types';
 import { PromQueryFormat } from '../../dataquery.gen';
@@ -21,8 +21,6 @@ import { changeEditorMode, getQueryWithDefaults } from '../state';
 import { PromQueryBuilderContainer } from './PromQueryBuilderContainer';
 import { PromQueryBuilderOptions } from './PromQueryBuilderOptions';
 import { PromQueryCodeEditor } from './PromQueryCodeEditor';
-import { WizarDS } from './wizarDS/WizarDS';
-import { componentTemplates } from './wizarDS/state/templates';
 
 export const FORMAT_OPTIONS: Array<SelectableValue<PromQueryFormat>> = [
   { label: 'Time series', value: 'time_series' },
@@ -51,7 +49,6 @@ export const PromQueryEditorSelector = React.memo<Props>((props) => {
   const [parseModalOpen, setParseModalOpen] = useState(false);
   const [queryPatternsModalOpen, setQueryPatternsModalOpen] = useState(false);
   const [dataIsStale, setDataIsStale] = useState(false);
-  const [wizarDSDrawerOpen, setWizarDSDrawerOpen] = useState(false);
   const { flag: explain, setFlag: setExplain } = useFlag(promQueryEditorExplainKey);
 
   const query = getQueryWithDefaults(props.query, app, defaultEditor);
@@ -95,8 +92,6 @@ export const PromQueryEditorSelector = React.memo<Props>((props) => {
     setExplain(e.currentTarget.checked);
   };
 
-  const wizarDSToggle = config.featureToggles.wizarDSToggle;
-
   return (
     <>
       <ConfirmModal
@@ -119,18 +114,6 @@ export const PromQueryEditorSelector = React.memo<Props>((props) => {
         onChange={onChange}
         onAddQuery={onAddQuery}
       />
-      {wizarDSToggle && wizarDSDrawerOpen && (
-        <Drawer closeOnMaskClick={false} onClose={() => setWizarDSDrawerOpen(false)}>
-          <WizarDS
-            // remove all references to the query
-            query={{ metric: '', labels: [], operations: [] }}
-            closeDrawer={() => setWizarDSDrawerOpen(false)}
-            datasource={props.datasource}
-            // add component templates so any DS can use this
-            templates={componentTemplates}
-          />
-        </Drawer>
-      )}
       <EditorHeader>
         <Button
           aria-label={selectors.components.QueryBuilder.queryPatterns}
@@ -139,9 +122,6 @@ export const PromQueryEditorSelector = React.memo<Props>((props) => {
           onClick={() => setQueryPatternsModalOpen((prevValue) => !prevValue)}
         >
           Kick start your query
-        </Button>
-        <Button variant="secondary" size="sm" onClick={() => setWizarDSDrawerOpen((prevValue) => !prevValue)}>
-          Take me on a magical journey
         </Button>
         <QueryHeaderSwitch label="Explain" value={explain} onChange={onShowExplainChange} />
         <FlexItem grow={1} />


### PR DESCRIPTION
**What is this feature?**

Uses a split view for the Wizards LLM content.

**Why do we need this feature?**

Now we can view explore and the Wizards LLM content side by side and take users to specific parts of the UI while keeping the split view open.
