### PR TITLE
postgres: refactor logs-handling

### DIFF
--- a/pkg/tsdb/grafana-postgresql-datasource/postgres_test.go
+++ b/pkg/tsdb/grafana-postgresql-datasource/postgres_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/setting"
 	"github.com/grafana/grafana/pkg/tsdb/sqleng"
 
@@ -140,6 +141,7 @@ func TestIntegrationGenerateConnectionString(t *testing.T) {
 		t.Run(tt.desc, func(t *testing.T) {
 			svc := Service{
 				tlsManager: &tlsTestManager{settings: tt.tlsSettings},
+				logger:     log.New("tsdb.postgres"),
 			}
 
 			ds := sqleng.DataSourceInfo{
@@ -224,6 +226,7 @@ func TestIntegrationPostgres(t *testing.T) {
 
 	queryResultTransformer := postgresQueryResultTransformer{}
 
+	logger := log.New("postgres.test")
 	exe, err := sqleng.NewQueryDataHandler(cfg, config, &queryResultTransformer, newPostgresMacroEngine(dsInfo.JsonData.Timescaledb),
 		logger)
 


### PR DESCRIPTION
we adjust the logger-creation process in postgres. this is needed for a future step, where we switch from `pkg/infra/log` to `grafana-plugin-sdk-go/backend/log` ( https://github.com/grafana/grafana/issues/77721 )

previously it was simply a package-level variable. this will not work well with the planned switch to `plugin-sdk-go`, so we instantiate it on `ProvideService` instead.


how to test:
- run grafana from main-branch, for example as a docker-image, with log-level-debug
- go to explore-mode, choose the postgres-datasource and run a query. 
- observe that log-lines with `tsdb.postgres` appear
- now do the same with this branch
- verify that the log-lines are the same
    - they are also named `tsdb.postgres`
    - for logs, where there is extra info in main-branch version, the extra info is there too in this version
    - verify that they are logfmt-formatted (not json-formatted)