### PR TITLE
Plugins: Suppress 403 preloading errors

### DIFF
--- a/public/app/features/plugins/pluginSettings.ts
+++ b/public/app/features/plugins/pluginSettings.ts
@@ -13,7 +13,7 @@ export function getPluginSettings(pluginId: string, options?: Partial<BackendSrv
     return Promise.resolve(v);
   }
   return getBackendSrv()
-    .get(`/api/plugins/${pluginId}/settings`, undefined, undefined, options)
+    .get(`/api/plugins/${pluginId}/settings`, undefined, undefined, { ...options, showErrorAlert: false })
     .then((settings) => {
       pluginInfoCache[pluginId] = settings;
       return settings;

--- a/public/app/features/plugins/pluginSettings.ts
+++ b/public/app/features/plugins/pluginSettings.ts
@@ -13,12 +13,18 @@ export function getPluginSettings(pluginId: string, options?: Partial<BackendSrv
     return Promise.resolve(v);
   }
   return getBackendSrv()
-    .get(`/api/plugins/${pluginId}/settings`, undefined, undefined, { ...options, showErrorAlert: false })
+    .get(`/api/plugins/${pluginId}/settings`, undefined, undefined, { ...options })
     .then((settings) => {
       pluginInfoCache[pluginId] = settings;
       return settings;
     })
-    .catch(() => {
+    .catch((e) => {
+      // User does not have access to plugin
+      if (typeof e === 'object' && e !== null && 'status' in e && e.status === 403) {
+        e.isHandled = true;
+        return Promise.reject(e);
+      }
+
       return Promise.reject(new Error('Unknown Plugin'));
     });
 }

--- a/public/app/features/plugins/pluginSettings.ts
+++ b/public/app/features/plugins/pluginSettings.ts
@@ -13,7 +13,7 @@ export function getPluginSettings(pluginId: string, options?: Partial<BackendSrv
     return Promise.resolve(v);
   }
   return getBackendSrv()
-    .get(`/api/plugins/${pluginId}/settings`, undefined, undefined, { ...options })
+    .get(`/api/plugins/${pluginId}/settings`, undefined, undefined, options)
     .then((settings) => {
       pluginInfoCache[pluginId] = settings;
       return settings;


### PR DESCRIPTION
**Related:** https://github.com/grafana/grafana/pull/79082

### The problem

Currently we are pre-loading app plugins if they have `preload: true` set in their plugin.json, mostly in case they would like to register UI extensions. Besides preloading the plugin bundles (which contain the ui-extensions logic) we are also fetching the plugin metadata from the `/api/plugins/<id>/settings` endpoint.

Previously it caused issues that Grafana tried to preload plugins on the login screen or for certain other screens for _anonymous_ users, and then we displayed a "Access Denied" error message. [This PR](https://github.com/grafana/grafana/pull/79082) solved these issues.

An issue we still have is that if any of the basic roles are customised to not have access to app plugins, or to only have access to certain app plugins (by using RBAC), then logged in users can face the same issue (Access Denied). 

**To provide a quick-fix for the problem this PR now silences the `403` errors caused by loading plugins, so they won't be visible in the UI.** Re UI extensions: if there is an error like this, then the extensions simply don't get registered due to bundle not being able to be fetched.

### Long term solution

One of the issues we have is that the user permissions in `window.grafanaBootData.user.permissions` don't reflect the scopes of the roles (it will set `plugins.app:access: true` even if it is only enabled for a certain plugin id), and due to this we cannot yet perform a reliable frontend check.

A longer term solution could be if the `window.grafanaBootData.settings.apps` would only contain app plugins which the user has access to. This would eliminate the need of similar checks on the frontend side.

Another thing that we should consider is adding the app plugin metadata to the `window.grafanaBootData.settings.apps` objects, just like it is done for datasources. It obviously would make the object somewhat larger (needs to be verified), but could simplify the frontend logic (async fetching and caching) in a lot of places.

Pinging @marefr and @gamab for visibility.
 

