### PR TITLE
SSE: Add utility methods for HysteresisCommand 

### DIFF
--- a/pkg/expr/graph.go
+++ b/pkg/expr/graph.go
@@ -292,3 +292,23 @@ func buildGraphEdges(dp *simple.DirectedGraph, registry map[string]Node) error {
 	}
 	return nil
 }
+
+// GetCommandsFromPipeline traverses the pipeline and extracts all CMDNode commands that match the type
+func GetCommandsFromPipeline[T Command](pipeline DataPipeline) []T {
+	var results []T
+	for _, p := range pipeline {
+		if p.NodeType() != TypeCMDNode {
+			continue
+		}
+		switch cmd := p.(type) {
+		case *CMDNode:
+			switch r := cmd.Command.(type) {
+			case T:
+				results = append(results, r)
+			}
+		default:
+			continue
+		}
+	}
+	return results
+}

--- a/pkg/expr/graph_test.go
+++ b/pkg/expr/graph_test.go
@@ -246,6 +246,41 @@ func TestServicebuildPipeLine(t *testing.T) {
 	}
 }
 
+func TestGetCommandsFromPipeline(t *testing.T) {
+	pipeline := DataPipeline{
+		&MLNode{},
+		&DSNode{},
+		&CMDNode{
+			baseNode: baseNode{},
+			CMDType:  0,
+			Command:  &ReduceCommand{},
+		},
+		&CMDNode{
+			baseNode: baseNode{},
+			CMDType:  0,
+			Command:  &ReduceCommand{},
+		},
+		&CMDNode{
+			baseNode: baseNode{},
+			CMDType:  0,
+			Command:  &HysteresisCommand{},
+		},
+	}
+	t.Run("should find command that exists", func(t *testing.T) {
+		cmds := GetCommandsFromPipeline[*HysteresisCommand](pipeline)
+		require.Len(t, cmds, 1)
+		require.Equal(t, pipeline[4].(*CMDNode).Command, cmds[0])
+	})
+	t.Run("should find all commands that exist", func(t *testing.T) {
+		cmds := GetCommandsFromPipeline[*ReduceCommand](pipeline)
+		require.Len(t, cmds, 2)
+	})
+	t.Run("should not find all command that does not exist", func(t *testing.T) {
+		cmds := GetCommandsFromPipeline[*MathCommand](pipeline)
+		require.Len(t, cmds, 0)
+	})
+}
+
 func getRefIDOrder(nodes []Node) []string {
 	ids := make([]string, 0, len(nodes))
 	for _, n := range nodes {

--- a/pkg/expr/hysteresis.go
+++ b/pkg/expr/hysteresis.go
@@ -120,3 +120,17 @@ func FingerprintsFromFrame(frame *data.Frame) (Fingerprints, error) {
 	}
 	return result, nil
 }
+
+// FingerprintsToFrame converts Fingerprints to data.Frame.
+func FingerprintsToFrame(fingerprints Fingerprints) *data.Frame {
+	fp := make([]uint64, 0, len(fingerprints))
+	for fingerprint := range fingerprints {
+		fp = append(fp, uint64(fingerprint))
+	}
+	frame := data.NewFrame("", data.NewField("fingerprints", nil, fp))
+	frame.SetMeta(&data.FrameMeta{
+		Type:        "fingerprints",
+		TypeVersion: data.FrameTypeVersion{1, 0},
+	})
+	return frame
+}

--- a/pkg/expr/hysteresis_test.go
+++ b/pkg/expr/hysteresis_test.go
@@ -186,3 +186,36 @@ func TestLoadedDimensionsFromFrame(t *testing.T) {
 		})
 	}
 }
+
+func TestFingerprintsToFrame(t *testing.T) {
+	testCases := []struct {
+		name          string
+		input         Fingerprints
+		expected      Fingerprints
+		expectedError bool
+	}{
+		{
+			name:     "when empty map",
+			input:    Fingerprints{},
+			expected: Fingerprints{},
+		},
+		{
+			name:     "when nil",
+			input:    nil,
+			expected: Fingerprints{},
+		},
+		{
+			name:     "when has values",
+			input:    Fingerprints{1: {}, 2: {}, 3: {}, 4: {}, 5: {}},
+			expected: Fingerprints{1: {}, 2: {}, 3: {}, 4: {}, 5: {}},
+		},
+	}
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			frame := FingerprintsToFrame(testCase.input)
+			actual, err := FingerprintsFromFrame(frame)
+			require.NoError(t, err)
+			require.EqualValues(t, testCase.expected, actual)
+		})
+	}
+}

--- a/pkg/expr/nodes.go
+++ b/pkg/expr/nodes.go
@@ -3,6 +3,7 @@ package expr
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"strings"
 	"time"
@@ -45,10 +46,10 @@ type rawNode struct {
 	idx int64
 }
 
-func (rn *rawNode) GetCommandType() (c CommandType, err error) {
-	rawType, ok := rn.Query["type"]
+func GetExpressionCommandType(rawQuery map[string]any) (c CommandType, err error) {
+	rawType, ok := rawQuery["type"]
 	if !ok {
-		return c, fmt.Errorf("no expression command type in query for refId %v", rn.RefID)
+		return c, errors.New("no expression command type in query")
 	}
 	typeString, ok := rawType.(string)
 	if !ok {
@@ -97,7 +98,7 @@ func (gn *CMDNode) Execute(ctx context.Context, now time.Time, vars mathexp.Vars
 }
 
 func buildCMDNode(rn *rawNode, toggles featuremgmt.FeatureToggles) (*CMDNode, error) {
-	commandType, err := rn.GetCommandType()
+	commandType, err := GetExpressionCommandType(rn.Query)
 	if err != nil {
 		return nil, fmt.Errorf("invalid command type in expression '%v': %w", rn.RefID, err)
 	}

--- a/pkg/expr/threshold_test.go
+++ b/pkg/expr/threshold_test.go
@@ -3,6 +3,7 @@ package expr
 import (
 	"encoding/json"
 	"fmt"
+	"math"
 	"sort"
 	"testing"
 
@@ -162,7 +163,7 @@ func TestUnmarshalThresholdCommand(t *testing.T) {
 				        ],
 				        "type": "lt"
 				      },
-				      "loadedDimensions": {"schema":{"name":"test","meta":{"type":"fingerprints","typeVersion":[1,0]},"fields":[{"name":"fingerprints","type":"number","typeInfo":{"frame":"uint64"}}]},"data":{"values":[[1,2,3,4,5]]}}
+				      "loadedDimensions": {"schema":{"name":"test","meta":{"type":"fingerprints","typeVersion":[1,0]},"fields":[{"name":"fingerprints","type":"number","typeInfo":{"frame":"uint64"}}]},"data":{"values":[[18446744073709551615,2,3,4,5]]}}
 				    }
 				  ]
 				}`,
@@ -186,7 +187,7 @@ func TestUnmarshalThresholdCommand(t *testing.T) {
 					return actual[i] < actual[j]
 				})
 
-				require.EqualValues(t, []uint64{1, 2, 3, 4, 5}, actual)
+				require.EqualValues(t, []uint64{2, 3, 4, 5, 18446744073709551615}, actual)
 			},
 		},
 	}
@@ -423,7 +424,7 @@ func TestSetLoadedDimensionsToHysteresisCommand(t *testing.T) {
 		{
 			name:           "true type is threshold and a single condition has unloadEvaluator field",
 			input:          json.RawMessage(`{ "type": "threshold", "conditions": [{ "unloadEvaluator" : {}}] }`),
-			expectedResult: json.RawMessage(`{ "type": "threshold", "conditions": [{ "unloadEvaluator" : {}, "loadedDimensions": {"schema":{"meta":{"type":"fingerprints","typeVersion":[1,0]},"fields":[{"name":"fingerprints","type":"number","typeInfo":{"frame":"uint64"}}]},"data":{"values":[[1,2,3]]}}}] }`),
+			expectedResult: json.RawMessage(`{ "type": "threshold", "conditions": [{ "unloadEvaluator" : {}, "loadedDimensions": {"schema":{"meta":{"type":"fingerprints","typeVersion":[1,0]},"fields":[{"name":"fingerprints","type":"number","typeInfo":{"frame":"uint64"}}]},"data":{"values":[[18446744073709551615,2,3]]}}}] }`),
 		},
 	}
 
@@ -431,7 +432,7 @@ func TestSetLoadedDimensionsToHysteresisCommand(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			query := map[string]any{}
 			require.NoError(t, json.Unmarshal(tc.input, &query))
-			err := SetLoadedDimensionsToHysteresisCommand(query, Fingerprints{1: {}, 2: {}, 3: {}})
+			err := SetLoadedDimensionsToHysteresisCommand(query, Fingerprints{math.MaxUint64: {}, 2: {}, 3: {}})
 			if tc.expectedError {
 				require.Error(t, err)
 				return


### PR DESCRIPTION
**What is this feature?**
Changes in this PR are extracted from https://github.com/grafana/grafana/pull/75189. This PR adds some convenience functions to analyze the expression tree and individual expressions.

- The function IsHysteresisExpression allows us to determine whether the raw JSON model describes the hysteresis command.
- The function SetLoadedDimensionsToHysteresisCommand allows us to correctly modify the JSON model with the fingerprints.
- GetCommandsFromPipeline simplifies extracting expressions by type from the tree. It is useful in testing and perhaps lately in analyzing the tree (a possible application is query optimizations in alerting).

**Why do we need this feature?**
To use these functions in https://github.com/grafana/grafana/pull/75189

**Who is this feature for?**
Developers

Please check that:
- [x] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle.
- [x] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
