### PR TITLE
BrowseDashboards: Fix alerts folder view cards not stacking correctly

### DIFF
--- a/public/app/features/alerting/unified/AlertsFolderView.tsx
+++ b/public/app/features/alerting/unified/AlertsFolderView.tsx
@@ -86,7 +86,7 @@ export const AlertsFolderView = ({ folder }: Props) => {
           />
         </Stack>
 
-        <Stack gap={1}>
+        <Stack direction="column" gap={1}>
           {pageItems.map((currentRule) => (
             <Card
               key={currentRule.name}


### PR DESCRIPTION
Fixes a regression introduced in https://github.com/grafana/grafana/pull/77543 with the Alerts Folder View (the one in Browse Dashboards) where the cards would stack horizontally across the screen, instead of vertically in a list.