### PR TITLE
Chore: Ensure BuildVersion is set when using CDN

### DIFF
--- a/pkg/api/index.go
+++ b/pkg/api/index.go
@@ -99,6 +99,10 @@ func (hs *HTTPServer) setIndexViewData(c *contextmodel.ReqContext) (*dtos.IndexV
 
 	hasAccess := ac.HasAccess(hs.AccessControl, c)
 	hasEditPerm := hasAccess(ac.EvalAny(ac.EvalPermission(dashboards.ActionDashboardsCreate), ac.EvalPermission(dashboards.ActionFoldersCreate)))
+	cdnURL, err := hs.Cfg.GetContentDeliveryURL(hs.License.ContentDeliveryPrefix())
+	if err != nil {
+		return nil, err
+	}
 
 	data := dtos.IndexViewData{
 		User: &dtos.CurrentUser{
@@ -144,7 +148,7 @@ func (hs *HTTPServer) setIndexViewData(c *contextmodel.ReqContext) (*dtos.IndexV
 		AppTitle:                            "Grafana",
 		NavTree:                             navTree,
 		Nonce:                               c.RequestNonce,
-		ContentDeliveryURL:                  hs.Cfg.GetContentDeliveryURL(hs.License.ContentDeliveryPrefix()),
+		ContentDeliveryURL:                  cdnURL,
 		LoadingLogo:                         "public/img/grafana_icon.svg",
 		IsDevelopmentEnv:                    hs.Cfg.Env == setting.Dev,
 		Assets:                              assets,

--- a/pkg/setting/setting.go
+++ b/pkg/setting/setting.go
@@ -1996,9 +1996,8 @@ func (cfg *Cfg) GetContentDeliveryURL(prefix string) (string, error) {
 		return "", errors.New("BuildVersion is not set")
 	}
 	url := *cfg.CDNRootURL
-	preReleaseFolder := ""
 
-	url.Path = path.Join(url.Path, prefix, preReleaseFolder, cfg.BuildVersion)
+	url.Path = path.Join(url.Path, prefix, cfg.BuildVersion)
 	return url.String() + "/", nil
 }
 

--- a/pkg/setting/setting.go
+++ b/pkg/setting/setting.go
@@ -1988,16 +1988,18 @@ func (cfg *Cfg) readServerSettings(iniFile *ini.File) error {
 }
 
 // GetContentDeliveryURL returns full content delivery URL with /<edition>/<version> added to URL
-func (cfg *Cfg) GetContentDeliveryURL(prefix string) string {
-	if cfg.CDNRootURL != nil {
-		url := *cfg.CDNRootURL
-		preReleaseFolder := ""
-
-		url.Path = path.Join(url.Path, prefix, preReleaseFolder, cfg.BuildVersion)
-		return url.String() + "/"
+func (cfg *Cfg) GetContentDeliveryURL(prefix string) (string, error) {
+	if cfg.CDNRootURL == nil {
+		return "", nil
 	}
+	if cfg.BuildVersion == "" {
+		return "", errors.New("BuildVersion is not set")
+	}
+	url := *cfg.CDNRootURL
+	preReleaseFolder := ""
 
-	return ""
+	url.Path = path.Join(url.Path, prefix, preReleaseFolder, cfg.BuildVersion)
+	return url.String() + "/", nil
 }
 
 func (cfg *Cfg) readDataSourcesSettings() {

--- a/pkg/setting/setting_test.go
+++ b/pkg/setting/setting_test.go
@@ -384,19 +384,33 @@ func TestAuthDurationSettings(t *testing.T) {
 }
 
 func TestGetCDNPath(t *testing.T) {
-	var err error
-	cfg := NewCfg()
-	cfg.BuildVersion = "v7.5.0-11124"
-	cfg.CDNRootURL, err = url.Parse("http://cdn.grafana.com")
-	require.NoError(t, err)
+	t.Run("should return CDN url as expected", func(t *testing.T) {
+		var (
+			err    error
+			actual string
+		)
+		cfg := NewCfg()
+		cfg.BuildVersion = "v7.5.0-11124"
+		cfg.CDNRootURL, err = url.Parse("http://cdn.grafana.com")
+		require.NoError(t, err)
 
-	require.Equal(t, "http://cdn.grafana.com/grafana-oss/v7.5.0-11124/", cfg.GetContentDeliveryURL("grafana-oss"))
-	require.Equal(t, "http://cdn.grafana.com/grafana/v7.5.0-11124/", cfg.GetContentDeliveryURL("grafana"))
-}
+		actual, err = cfg.GetContentDeliveryURL("grafana-oss")
+		require.NoError(t, err)
+		require.Equal(t, "http://cdn.grafana.com/grafana-oss/v7.5.0-11124/", actual)
+		actual, err = cfg.GetContentDeliveryURL("grafana")
+		require.NoError(t, err)
+		require.Equal(t, "http://cdn.grafana.com/grafana/v7.5.0-11124/", actual)
+	})
 
-func TestGetContentDeliveryURLWhenNoCDNRootURLIsSet(t *testing.T) {
-	cfg := NewCfg()
-	require.Equal(t, "", cfg.GetContentDeliveryURL("grafana-oss"))
+	t.Run("should error if BuildVersion  is not set", func(t *testing.T) {
+		var err error
+		cfg := NewCfg()
+		cfg.CDNRootURL, err = url.Parse("http://cdn.grafana.com")
+		require.NoError(t, err)
+
+		_, err = cfg.GetContentDeliveryURL("grafana")
+		require.Error(t, err)
+	})
 }
 
 func TestGetCDNPathWithPreReleaseVersionAndSubPath(t *testing.T) {
@@ -405,8 +419,12 @@ func TestGetCDNPathWithPreReleaseVersionAndSubPath(t *testing.T) {
 	cfg.BuildVersion = "v7.5.0-11124pre"
 	cfg.CDNRootURL, err = url.Parse("http://cdn.grafana.com/sub")
 	require.NoError(t, err)
-	require.Equal(t, "http://cdn.grafana.com/sub/grafana-oss/v7.5.0-11124pre/", cfg.GetContentDeliveryURL("grafana-oss"))
-	require.Equal(t, "http://cdn.grafana.com/sub/grafana/v7.5.0-11124pre/", cfg.GetContentDeliveryURL("grafana"))
+	actual, err := cfg.GetContentDeliveryURL("grafana-oss")
+	require.NoError(t, err)
+	require.Equal(t, "http://cdn.grafana.com/sub/grafana-oss/v7.5.0-11124pre/", actual)
+	actual, err = cfg.GetContentDeliveryURL("grafana")
+	require.NoError(t, err)
+	require.Equal(t, "http://cdn.grafana.com/sub/grafana/v7.5.0-11124pre/", actual)
 }
 
 // Adding a case for this in case we switch to proper semver version strings
@@ -416,8 +434,12 @@ func TestGetCDNPathWithAlphaVersion(t *testing.T) {
 	cfg.BuildVersion = "v7.5.0-alpha.11124"
 	cfg.CDNRootURL, err = url.Parse("http://cdn.grafana.com")
 	require.NoError(t, err)
-	require.Equal(t, "http://cdn.grafana.com/grafana-oss/v7.5.0-alpha.11124/", cfg.GetContentDeliveryURL("grafana-oss"))
-	require.Equal(t, "http://cdn.grafana.com/grafana/v7.5.0-alpha.11124/", cfg.GetContentDeliveryURL("grafana"))
+	actual, err := cfg.GetContentDeliveryURL("grafana-oss")
+	require.NoError(t, err)
+	require.Equal(t, "http://cdn.grafana.com/grafana-oss/v7.5.0-alpha.11124/", actual)
+	actual, err = cfg.GetContentDeliveryURL("grafana")
+	require.NoError(t, err)
+	require.Equal(t, "http://cdn.grafana.com/grafana/v7.5.0-alpha.11124/", actual)
 }
 
 func TestAlertingEnabled(t *testing.T) {


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

Adds a check to ensure `BuildVersion` is set when using a CDN for assets.

**Why do we need this feature?**

Hopefully this will help make it easier to catch this issue in the future.

**Who is this feature for?**

[Add information on what kind of user the feature is for.]

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
