### PR TITLE
Correlations: Move links to row

### DIFF
--- a/packages/grafana-data/src/types/logs.ts
+++ b/packages/grafana-data/src/types/logs.ts
@@ -4,6 +4,7 @@ import { DataQuery } from '@grafana/schema';
 
 import { KeyValue, Labels } from './data';
 import { DataFrame } from './dataFrame';
+import { DataLink } from './dataLink';
 import { DataQueryRequest, DataQueryResponse, QueryFixAction, QueryFixType } from './datasource';
 import { AbsoluteTimeRange } from './time';
 export { LogsDedupStrategy, LogsSortOrder } from '@grafana/schema';
@@ -81,6 +82,9 @@ export interface LogRowModel {
   uid: string;
   uniqueLabels?: Labels;
   datasourceType?: string;
+
+  //interpolated links for this row - this should also record the field if we want to use this for log details as well
+  links?: DataLink[];
 }
 
 export interface LogsModel {

--- a/public/app/features/explore/Logs/Logs.tsx
+++ b/public/app/features/explore/Logs/Logs.tsx
@@ -48,6 +48,7 @@ import {
 } from '@grafana/ui';
 import store from 'app/core/store';
 import { createAndCopyShortLink } from 'app/core/utils/shortLinks';
+import { attachLinks } from 'app/features/logs/utils';
 import { dispatch, getState } from 'app/store/store';
 
 import { ExploreItemState } from '../../../types';
@@ -492,6 +493,10 @@ class UnthemedLogs extends PureComponent<Props, State> {
     return filterLogLevels(logRows, new Set(hiddenLogLevels));
   });
 
+  attachedLinks = memoizeOne((logRows: LogRowModel[], getFieldLinks) => {
+    return attachLinks(logRows, getFieldLinks);
+  });
+
   createNavigationRange = memoizeOne((logRows: LogRowModel[]): { from: number; to: number } | undefined => {
     if (!logRows || logRows.length === 0) {
       return undefined;
@@ -573,6 +578,8 @@ class UnthemedLogs extends PureComponent<Props, State> {
     const navigationRange = this.createNavigationRange(logRows);
 
     const scanText = scanRange ? `Scanning ${rangeUtil.describeTimeRange(scanRange)}` : 'Scanning...';
+
+    this.attachedLinks(logRows, getFieldLinks);
 
     return (
       <>

--- a/public/app/features/logs/components/LogRowMenuCell.tsx
+++ b/public/app/features/logs/components/LogRowMenuCell.tsx
@@ -1,6 +1,6 @@
 import React, { FocusEvent, SyntheticEvent, useCallback, useState } from 'react';
 
-import { LogRowModel } from '@grafana/data';
+import { DataLinkClickEvent, LogRowModel } from '@grafana/data';
 import { ClipboardButton, Dropdown, IconButton, Menu } from '@grafana/ui';
 
 import { LogRowStyles } from './getLogRowStyles';
@@ -16,7 +16,7 @@ interface Props {
   pinned?: boolean;
   styles: LogRowStyles;
   mouseIsOver: boolean;
-  onBlur: () => void;
+  onBlur?: () => void;
 }
 
 export const LogRowMenuCell = React.memo(
@@ -63,21 +63,26 @@ export const LogRowMenuCell = React.memo(
       .map((field) => {
         const wat = field.config
           .links!.map((link) => {
-            return link.url ? { title: link.title, url: link.url } : undefined;
+            return link.url ? { title: link.title, url: link.url, onClick: link.onClick } : undefined;
           })
-          .filter((v): v is { title: string; url: string } => v !== undefined);
+          .filter(
+            (v): v is { title: string; url: string; onClick: ((event: DataLinkClickEvent<any>) => void) | undefined } =>
+              v !== undefined
+          );
         return wat;
       })
       .flat();
 
     const MenuActions = (
       <Menu>
-        {links.map((link) => (
+        {links.map((link, i) => (
           <Menu.Item
-            key={link.title}
+            key={`link-menu-${i}`}
             label={link.title}
-            onClick={() => {
-              window.location.href = link.url;
+            onClick={(e) => {
+              if (link.onClick) {
+                link.onClick(e as any);
+              }
             }}
           />
         ))}

--- a/public/app/features/logs/components/LogRowMenuCell.tsx
+++ b/public/app/features/logs/components/LogRowMenuCell.tsx
@@ -1,7 +1,7 @@
-import React, { FocusEvent, SyntheticEvent, useCallback } from 'react';
+import React, { FocusEvent, SyntheticEvent, useCallback, useState } from 'react';
 
 import { LogRowModel } from '@grafana/data';
-import { ClipboardButton, IconButton } from '@grafana/ui';
+import { ClipboardButton, Dropdown, IconButton, Menu } from '@grafana/ui';
 
 import { LogRowStyles } from './getLogRowStyles';
 
@@ -57,6 +57,33 @@ export const LogRowMenuCell = React.memo(
       [onBlur]
     );
     const getLogText = useCallback(() => logText, [logText]);
+    const [isLinkMenuOpen, setIsLinkMenuOpen] = useState(false);
+
+    const links = row.dataFrame.fields
+      .map((field) => {
+        const wat = field.config
+          .links!.map((link) => {
+            return link.url ? { title: link.title, url: link.url } : undefined;
+          })
+          .filter((v): v is { title: string; url: string } => v !== undefined);
+        return wat;
+      })
+      .flat();
+
+    const MenuActions = (
+      <Menu>
+        {links.map((link) => (
+          <Menu.Item
+            key={link.title}
+            label={link.title}
+            onClick={() => {
+              window.location.href = link.url;
+            }}
+          />
+        ))}
+      </Menu>
+    );
+
     return (
       // We keep this click listener here to prevent the row from being selected when clicking on the menu.
       // eslint-disable-next-line jsx-a11y/click-events-have-key-events, jsx-a11y/no-static-element-interactions
@@ -131,6 +158,19 @@ export const LogRowMenuCell = React.memo(
                 onClick={() => onPermalinkClick(row)}
                 tabIndex={0}
               />
+            )}
+            {links.length > 0 && (
+              <Dropdown overlay={MenuActions} placement="bottom-end" onVisibleChange={setIsLinkMenuOpen}>
+                <IconButton
+                  tooltip="Open links"
+                  aria-label="Open links"
+                  tooltipPlacement="top"
+                  size="md"
+                  name="link"
+                  onClick={() => setIsLinkMenuOpen(!isLinkMenuOpen)}
+                  tabIndex={0}
+                />
+              </Dropdown>
             )}
           </>
         )}

--- a/public/app/features/logs/components/LogRowMenuCell.tsx
+++ b/public/app/features/logs/components/LogRowMenuCell.tsx
@@ -59,19 +59,17 @@ export const LogRowMenuCell = React.memo(
     const getLogText = useCallback(() => logText, [logText]);
     const [isLinkMenuOpen, setIsLinkMenuOpen] = useState(false);
 
-    const links = row.dataFrame.fields
-      .map((field) => {
-        const wat = field.config
-          .links!.map((link) => {
+    const links = row.links
+      ? row.links
+          .map((link) => {
             return link.url ? { title: link.title, url: link.url, onClick: link.onClick } : undefined;
           })
           .filter(
             (v): v is { title: string; url: string; onClick: ((event: DataLinkClickEvent<any>) => void) | undefined } =>
               v !== undefined
-          );
-        return wat;
-      })
-      .flat();
+          )
+          .flat()
+      : [];
 
     const MenuActions = (
       <Menu>

--- a/public/app/features/logs/components/LogRowMessage.tsx
+++ b/public/app/features/logs/components/LogRowMessage.tsx
@@ -80,7 +80,7 @@ export const LogRowMessage = React.memo((props: Props) => {
   } = props;
   const { hasAnsi, raw } = row;
   const restructuredEntry = useMemo(() => restructureLog(raw, prettifyLogMessage), [raw, prettifyLogMessage]);
-  const shouldShowMenu = true; //useMemo(() => mouseIsOver || pinned, [mouseIsOver, pinned]);
+  const shouldShowMenu = useMemo(() => mouseIsOver || pinned, [mouseIsOver, pinned]);
   return (
     <>
       {
@@ -106,8 +106,7 @@ export const LogRowMessage = React.memo((props: Props) => {
             onUnpinLine={onUnpinLine}
             pinned={pinned}
             styles={styles}
-            mouseIsOver={true}
-            onBlur={onBlur}
+            mouseIsOver={mouseIsOver}
           />
         )}
       </td>

--- a/public/app/features/logs/components/LogRowMessage.tsx
+++ b/public/app/features/logs/components/LogRowMessage.tsx
@@ -80,7 +80,7 @@ export const LogRowMessage = React.memo((props: Props) => {
   } = props;
   const { hasAnsi, raw } = row;
   const restructuredEntry = useMemo(() => restructureLog(raw, prettifyLogMessage), [raw, prettifyLogMessage]);
-  const shouldShowMenu = useMemo(() => mouseIsOver || pinned, [mouseIsOver, pinned]);
+  const shouldShowMenu = true; //useMemo(() => mouseIsOver || pinned, [mouseIsOver, pinned]);
   return (
     <>
       {
@@ -106,7 +106,7 @@ export const LogRowMessage = React.memo((props: Props) => {
             onUnpinLine={onUnpinLine}
             pinned={pinned}
             styles={styles}
-            mouseIsOver={mouseIsOver}
+            mouseIsOver={true}
             onBlur={onBlur}
           />
         )}

--- a/public/app/features/logs/utils.ts
+++ b/public/app/features/logs/utils.ts
@@ -13,7 +13,6 @@ import {
   MutableDataFrame,
   QueryResultMeta,
   LogsVolumeType,
-  DataLink,
   Field,
   LinkModel,
 } from '@grafana/data';
@@ -146,9 +145,6 @@ export const attachLinks = (
     if (row !== undefined) {
       rowWithLinks.dataFrameWithLinks.forEach((generatedLinkDF) => {
         const rowField = row.dataFrame.fields[generatedLinkDF.fieldIndex];
-        if (rowField.config.links === undefined) {
-          rowField.config.links = [];
-        }
         if (generatedLinkDF.links && generatedLinkDF.links.length > 0) {
           if (rowField.config.links) {
             // if links already exist, merge generated links list with existing links, matching by origin data
@@ -158,18 +154,25 @@ export const attachLinks = (
                   (rowConfigLink) => JSON.stringify(rowConfigLink) === JSON.stringify(originLink)
                 );
                 if (rowLinkIndex !== undefined && rowLinkIndex !== -1) {
-                  const url = rowField.config.links![rowLinkIndex].url;
-                  const onClick = rowField.config.links![rowLinkIndex].onClick;
+                  let constructedLink = { ...rowField.config.links![rowLinkIndex] };
+                  const url = constructedLink.url;
+                  const onClick = constructedLink.onClick;
                   if (url === undefined || url === '') {
-                    rowField.config.links![rowLinkIndex].url = generatedLink.href;
+                    //rowField.config.links![rowLinkIndex].url = generatedLink.href;
+                    constructedLink.url = generatedLink.href;
                   }
                   if (onClick === undefined) {
-                    rowField.config.links![rowLinkIndex].onClick = generatedLink.onClick;
+                    //rowField.config.links![rowLinkIndex].onClick = generatedLink.onClick;
+                    constructedLink.onClick = generatedLink.onClick;
                   }
+                  if (row.links === undefined) {
+                    row.links = [];
+                  }
+                  row.links?.push(constructedLink);
                 }
               });
             });
-          } else {
+          } /*else {
             rowField.config.links = generatedLinkDF.links.map((linkFieldLink) => {
               const newDL: DataLink = {
                 title: linkFieldLink.title,
@@ -179,7 +182,7 @@ export const attachLinks = (
               };
               return newDL;
             });
-          }
+          } */
         }
       });
     }


### PR DESCRIPTION
WIP: This is a POC of a open question and my mini-hackathon project

**What is this feature?**

Correlations is a feature that lets you add data links from any datasource to any other datasource within Explore. In the logs visualization, datalinks are displayed when the log line is expanded, showing the log details. This can be inconvenient for users who want easier access to their logs' correlations.

This adds a new field onto log rows for interpolated links. The dataframe keeps link data, but it's before interpolation, meaning it is more like a template for the datalink. The actual interpolated link requires knowing the row values, and if we are to pre-process all of these, we should add it to the log row.

![Screenshot 2023-12-06 at 3 12 13 PM](https://github.com/grafana/grafana/assets/1533128/cdd76065-f1b5-4866-805d-5b151fef6fd3)
![Screenshot 2023-12-06 at 3 12 19 PM](https://github.com/grafana/grafana/assets/1533128/f14eefb1-72a4-435e-9dc9-1563b3c38906)


**Special notes for your reviewer:**
This is the outcome of a mini-hackathon. I want to get feedback from product, the log team, and run some performance tests before we move forward with this idea.

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
