### PR TITLE
Transformations: Add (base field name) to Join transformer

### DIFF
--- a/public/app/features/transformers/editors/JoinByFieldTransformerEditor.tsx
+++ b/public/app/features/transformers/editors/JoinByFieldTransformerEditor.tsx
@@ -11,9 +11,9 @@ import {
 import { JoinByFieldOptions, JoinMode } from '@grafana/data/src/transformations/transformers/joinByField';
 import { getTemplateSrv } from '@grafana/runtime';
 import { Select, InlineFieldRow, InlineField } from '@grafana/ui';
+import { useFieldDisplayNames, useSelectOptions } from '@grafana/ui/src/components/MatchersUI/utils';
 
 import { getTransformationContent } from '../docs/getTransformationContent';
-import { useAllFieldNamesFromDataFrames } from '../utils';
 
 const modes = [
   {
@@ -32,7 +32,9 @@ const modes = [
 ];
 
 export function SeriesToFieldsTransformerEditor({ input, options, onChange }: TransformerUIProps<JoinByFieldOptions>) {
-  const fieldNames = useAllFieldNamesFromDataFrames(input).map((item: string) => ({ label: item, value: item }));
+  const names = useFieldDisplayNames(input);
+  const fieldNames = useSelectOptions(names);
+
   const variables = getTemplateSrv()
     .getVariables()
     .map((v) => {


### PR DESCRIPTION
this allows people to use the Trend panel (which currently requires a single frame) after using Partition by values which creates multiple frames.

<details><summary>loss-by-steps.json</summary>

```json
{
  "annotations": {
    "list": [
      {
        "builtIn": 1,
        "datasource": {
          "type": "grafana",
          "uid": "-- Grafana --"
        },
        "enable": true,
        "hide": true,
        "iconColor": "rgba(0, 211, 255, 1)",
        "name": "Annotations & Alerts",
        "type": "dashboard"
      }
    ]
  },
  "editable": true,
  "fiscalYearStartMonth": 0,
  "graphTooltip": 0,
  "id": 859,
  "links": [],
  "liveNow": false,
  "panels": [
    {
      "datasource": {
        "type": "grafana-testdata-datasource",
        "uid": "PD8C576611E62080A"
      },
      "description": "",
      "fieldConfig": {
        "defaults": {
          "color": {
            "mode": "palette-classic"
          },
          "custom": {
            "axisBorderShow": false,
            "axisCenteredZero": false,
            "axisColorMode": "text",
            "axisLabel": "",
            "axisPlacement": "auto",
            "barAlignment": 0,
            "drawStyle": "line",
            "fillOpacity": 0,
            "gradientMode": "none",
            "hideFrom": {
              "legend": false,
              "tooltip": false,
              "viz": false
            },
            "insertNulls": false,
            "lineInterpolation": "linear",
            "lineWidth": 1,
            "pointSize": 5,
            "scaleDistribution": {
              "type": "linear"
            },
            "showPoints": "auto",
            "spanNulls": false,
            "stacking": {
              "group": "A",
              "mode": "none"
            },
            "thresholdsStyle": {
              "mode": "off"
            }
          },
          "mappings": [],
          "thresholds": {
            "mode": "absolute",
            "steps": [
              {
                "color": "green",
                "value": null
              },
              {
                "color": "red",
                "value": 80
              }
            ]
          }
        },
        "overrides": []
      },
      "gridPos": {
        "h": 13,
        "w": 15,
        "x": 0,
        "y": 0
      },
      "id": 2,
      "options": {
        "legend": {
          "calcs": [],
          "displayMode": "list",
          "placement": "bottom",
          "showLegend": true
        },
        "tooltip": {
          "mode": "single",
          "sort": "none"
        }
      },
      "pluginVersion": "10.3.0-64082",
      "targets": [
        {
          "datasource": {
            "type": "grafana-testdata-datasource",
            "uid": "PD8C576611E62080A"
          },
          "rawFrameContent": "[\n  {\n    \"schema\": {\n      \"refId\": \"A\",\n      \"meta\": {\n        \"custom\": {\n          \"frameType\": \"LabeledTimeValues\",\n          \"lokiQueryStatKey\": \"Summary: total bytes processed\"\n        },\n        \"executedQueryString\": \"Expr: {project=\\\"with_counter\\\"} | json | unpack\",\n        \"limit\": 1000,\n        \"preferredVisualisationType\": \"logs\",\n        \"searchWords\": [],\n        \"stats\": [\n          {\n            \"displayName\": \"Summary: bytes processed per second\",\n            \"unit\": \"Bps\",\n            \"value\": 156588\n          },\n          {\n            \"displayName\": \"Summary: lines processed per second\",\n            \"value\": 1282\n          },\n          {\n            \"displayName\": \"Summary: total bytes processed\",\n            \"unit\": \"decbytes\",\n            \"value\": 5859\n          },\n          {\n            \"displayName\": \"Summary: total lines processed\",\n            \"value\": 48\n          },\n          {\n            \"displayName\": \"Summary: exec time\",\n            \"unit\": \"s\",\n            \"value\": 0.037417\n          },\n          {\n            \"displayName\": \"Ingester: total reached\",\n            \"value\": 270\n          },\n          {\n            \"displayName\": \"Ingester: total chunks matched\",\n            \"value\": 0\n          },\n          {\n            \"displayName\": \"Ingester: total batches\",\n            \"value\": 180\n          },\n          {\n            \"displayName\": \"Ingester: total lines sent\",\n            \"value\": 0\n          },\n          {\n            \"displayName\": \"Ingester: head chunk bytes\",\n            \"unit\": \"decbytes\",\n            \"value\": 0\n          },\n          {\n            \"displayName\": \"Ingester: head chunk lines\",\n            \"value\": 0\n          },\n          {\n            \"displayName\": \"Ingester: decompressed bytes\",\n            \"unit\": \"decbytes\",\n            \"value\": 0\n          },\n          {\n            \"displayName\": \"Ingester: decompressed lines\",\n            \"value\": 0\n          },\n          {\n            \"displayName\": \"Ingester: compressed bytes\",\n            \"unit\": \"decbytes\",\n            \"value\": 0\n          },\n          {\n            \"displayName\": \"Ingester: total duplicates\",\n            \"value\": 0\n          }\n        ],\n        \"typeVersion\": [\n          0,\n          0\n        ],\n        \"transformations\": [\n          \"extractFields\",\n          \"convertFieldType\",\n          \"partitionByValues\",\n          \"partitionByValues\",\n          \"partitionByValues\",\n          \"partitionByValues\",\n          \"partitionByValues\",\n          \"partitionByValues\"\n        ]\n      },\n      \"fields\": [\n        {\n          \"config\": {},\n          \"name\": \"labels\",\n          \"type\": \"other\",\n          \"typeInfo\": {\n            \"frame\": \"json.RawMessage\"\n          }\n        },\n        {\n          \"config\": {},\n          \"name\": \"Time\",\n          \"type\": \"time\",\n          \"typeInfo\": {\n            \"frame\": \"time.Time\"\n          }\n        },\n        {\n          \"config\": {},\n          \"name\": \"Line\",\n          \"type\": \"string\",\n          \"typeInfo\": {\n            \"frame\": \"string\"\n          }\n        },\n        {\n          \"config\": {},\n          \"name\": \"tsNs\",\n          \"type\": \"string\",\n          \"typeInfo\": {\n            \"frame\": \"string\"\n          }\n        },\n        {\n          \"config\": {},\n          \"name\": \"id\",\n          \"type\": \"string\",\n          \"typeInfo\": {\n            \"frame\": \"string\"\n          }\n        },\n        {\n          \"config\": {\n            \"links\": [\n              {\n                \"internal\": {\n                  \"datasourceName\": \"grafanacloud-hackathon202312montage-traces\",\n                  \"datasourceUid\": \"grafanacloud-traces\",\n                  \"query\": {\n                    \"query\": \"${__value.raw}\",\n                    \"queryType\": \"traceql\"\n                  }\n                },\n                \"title\": \"\",\n                \"url\": \"\"\n              }\n            ]\n          },\n          \"name\": \"traceID\",\n          \"type\": \"string\"\n        }\n      ]\n    },\n    \"data\": {\n      \"values\": [\n        [\n          {\n            \"acc_\": \"0.9155599456033213\",\n            \"batch_size\": \"32\",\n            \"counter\": \"6\",\n            \"learning_rate\": \"0.01\",\n            \"logger\": \"mandl\",\n            \"loss\": \"0.10245595613323495\",\n            \"optimizer\": \"adam\",\n            \"project\": \"with_counter\",\n            \"run\": \"3\",\n            \"severity\": \"info\"\n          },\n          {\n            \"acc_\": \"0.9097065627281077\",\n            \"batch_size\": \"32\",\n            \"counter\": \"4\",\n            \"learning_rate\": \"0.01\",\n            \"logger\": \"mandl\",\n            \"loss\": \"0.1532706030753554\",\n            \"optimizer\": \"adam\",\n            \"project\": \"with_counter\",\n            \"run\": \"3\",\n            \"severity\": \"info\"\n          },\n          {\n            \"acc_\": \"0.9047419553379855\",\n            \"batch_size\": \"32\",\n            \"counter\": \"5\",\n            \"learning_rate\": \"0.01\",\n            \"logger\": \"mandl\",\n            \"loss\": \"0.05245811618572973\",\n            \"optimizer\": \"adam\",\n            \"project\": \"with_counter\",\n            \"run\": \"3\",\n            \"severity\": \"info\"\n          },\n          {\n            \"acc_\": \"0.8874248475675268\",\n            \"batch_size\": \"32\",\n            \"counter\": \"5\",\n            \"learning_rate\": \"0.01\",\n            \"logger\": \"mandl\",\n            \"loss\": \"0.17828075772529656\",\n            \"optimizer\": \"adam\",\n            \"project\": \"with_counter\",\n            \"run\": \"4\",\n            \"severity\": \"info\"\n          },\n          {\n            \"acc_\": \"0.8865198621448641\",\n            \"batch_size\": \"32\",\n            \"counter\": \"7\",\n            \"learning_rate\": \"0.01\",\n            \"logger\": \"mandl\",\n            \"loss\": \"0.027895722206651617\",\n            \"optimizer\": \"adam\",\n            \"project\": \"with_counter\",\n            \"run\": \"3\",\n            \"severity\": \"info\"\n          },\n          {\n            \"acc_\": \"0.8739628028724391\",\n            \"batch_size\": \"32\",\n            \"counter\": \"6\",\n            \"learning_rate\": \"0.01\",\n            \"logger\": \"mandl\",\n            \"loss\": \"0.08975119991377326\",\n            \"optimizer\": \"adam\",\n            \"project\": \"with_counter\",\n            \"run\": \"2\",\n            \"severity\": \"info\"\n          },\n          {\n            \"acc_\": \"0.8651892476685286\",\n            \"batch_size\": \"32\",\n            \"counter\": \"3\",\n            \"learning_rate\": \"0.01\",\n            \"logger\": \"mandl\",\n            \"loss\": \"0.20282652048043368\",\n            \"optimizer\": \"adam\",\n            \"project\": \"with_counter\",\n            \"run\": \"3\",\n            \"severity\": \"info\"\n          },\n          {\n            \"acc_\": \"0.8639308309522367\",\n            \"batch_size\": \"32\",\n            \"counter\": \"7\",\n            \"learning_rate\": \"0.01\",\n            \"logger\": \"mandl\",\n            \"loss\": \"0.13643147553189303\",\n            \"optimizer\": \"adam\",\n            \"project\": \"with_counter\",\n            \"run\": \"4\",\n            \"severity\": \"info\"\n          },\n          {\n            \"acc_\": \"0.8634164766213455\",\n            \"batch_size\": \"32\",\n            \"counter\": \"7\",\n            \"learning_rate\": \"0.01\",\n            \"logger\": \"mandl\",\n            \"loss\": \"0.09220808751793727\",\n            \"optimizer\": \"adam\",\n            \"project\": \"with_counter\",\n            \"run\": \"1\",\n            \"severity\": \"info\"\n          },\n          {\n            \"acc_\": \"0.857960019414961\",\n            \"batch_size\": \"32\",\n            \"counter\": \"6\",\n            \"learning_rate\": \"0.01\",\n            \"logger\": \"mandl\",\n            \"loss\": \"0.1816547179168026\",\n            \"optimizer\": \"adam\",\n            \"project\": \"with_counter\",\n            \"run\": \"5\",\n            \"severity\": \"info\"\n          },\n          {\n            \"acc_\": \"0.8436017386604135\",\n            \"batch_size\": \"32\",\n            \"counter\": \"7\",\n            \"learning_rate\": \"0.01\",\n            \"logger\": \"mandl\",\n            \"loss\": \"0.20359193703033246\",\n            \"optimizer\": \"adam\",\n            \"project\": \"with_counter\",\n            \"run\": \"5\",\n            \"severity\": \"info\"\n          },\n          {\n            \"acc_\": \"0.8427674406528638\",\n            \"batch_size\": \"32\",\n            \"counter\": \"4\",\n            \"learning_rate\": \"0.01\",\n            \"logger\": \"mandl\",\n            \"loss\": \"0.25503354706489023\",\n            \"optimizer\": \"adam\",\n            \"project\": \"with_counter\",\n            \"run\": \"1\",\n            \"severity\": \"info\"\n          },\n          {\n            \"acc_\": \"0.8359526575369163\",\n            \"batch_size\": \"32\",\n            \"counter\": \"3\",\n            \"learning_rate\": \"0.01\",\n            \"logger\": \"mandl\",\n            \"loss\": \"0.32150621127819246\",\n            \"optimizer\": \"adam\",\n            \"project\": \"with_counter\",\n            \"run\": \"5\",\n            \"severity\": \"info\"\n          },\n          {\n            \"acc_\": \"0.834116963907194\",\n            \"batch_size\": \"32\",\n            \"counter\": \"7\",\n            \"learning_rate\": \"0.01\",\n            \"logger\": \"mandl\",\n            \"loss\": \"0.13600250524792895\",\n            \"optimizer\": \"adam\",\n            \"project\": \"with_counter\",\n            \"run\": \"2\",\n            \"severity\": \"info\"\n          },\n          {\n            \"acc_\": \"0.8338295995010134\",\n            \"batch_size\": \"32\",\n            \"counter\": \"5\",\n            \"learning_rate\": \"0.01\",\n            \"logger\": \"mandl\",\n            \"loss\": \"0.2494388887177475\",\n            \"optimizer\": \"adam\",\n            \"project\": \"with_counter\",\n            \"run\": \"6\",\n            \"severity\": \"info\",\n            \"test_acc\": \"0.9338295995010134\",\n            \"test_loss\": \"0.1494388887177475\",\n            \"val_acc\": \"0.6338295995010135\",\n            \"val_loss\": \"0.04943888871774749\"\n          },\n          {\n            \"acc_\": \"0.8244677826158627\",\n            \"batch_size\": \"32\",\n            \"counter\": \"5\",\n            \"learning_rate\": \"0.01\",\n            \"logger\": \"mandl\",\n            \"loss\": \"0.11203306310875542\",\n            \"optimizer\": \"adam\",\n            \"project\": \"with_counter\",\n            \"run\": \"2\",\n            \"severity\": \"info\"\n          },\n          {\n            \"acc_\": \"0.8237069417864736\",\n            \"batch_size\": \"32\",\n            \"counter\": \"4\",\n            \"learning_rate\": \"0.01\",\n            \"logger\": \"mandl\",\n            \"loss\": \"0.21513458035043637\",\n            \"optimizer\": \"adam\",\n            \"project\": \"with_counter\",\n            \"run\": \"5\",\n            \"severity\": \"info\"\n          },\n          {\n            \"acc_\": \"0.8181927925853246\",\n            \"batch_size\": \"32\",\n            \"counter\": \"6\",\n            \"learning_rate\": \"0.01\",\n            \"logger\": \"mandl\",\n            \"loss\": \"0.08207342626255047\",\n            \"optimizer\": \"adam\",\n            \"project\": \"with_counter\",\n            \"run\": \"1\",\n            \"severity\": \"info\"\n          },\n          {\n            \"acc_\": \"0.8118856013761496\",\n            \"batch_size\": \"32\",\n            \"counter\": \"2\",\n            \"learning_rate\": \"0.01\",\n            \"logger\": \"mandl\",\n            \"loss\": \"0.38643990830498154\",\n            \"optimizer\": \"adam\",\n            \"project\": \"with_counter\",\n            \"run\": \"4\",\n            \"severity\": \"info\"\n          },\n          {\n            \"acc_\": \"0.8056802393082074\",\n            \"batch_size\": \"32\",\n            \"counter\": \"6\",\n            \"learning_rate\": \"0.01\",\n            \"logger\": \"mandl\",\n            \"loss\": \"0.1994764753488268\",\n            \"optimizer\": \"adam\",\n            \"project\": \"with_counter\",\n            \"run\": \"4\",\n            \"severity\": \"info\"\n          },\n          {\n            \"acc_\": \"0.8056635991720746\",\n            \"batch_size\": \"32\",\n            \"counter\": \"4\",\n            \"learning_rate\": \"0.01\",\n            \"logger\": \"mandl\",\n            \"loss\": \"0.1778881927566374\",\n            \"optimizer\": \"adam\",\n            \"project\": \"with_counter\",\n            \"run\": \"4\",\n            \"severity\": \"info\"\n          },\n          {\n            \"acc_\": \"0.8044316635781\",\n            \"batch_size\": \"32\",\n            \"counter\": \"5\",\n            \"learning_rate\": \"0.01\",\n            \"logger\": \"mandl\",\n            \"loss\": \"0.11060466779347133\",\n            \"optimizer\": \"adam\",\n            \"project\": \"with_counter\",\n            \"run\": \"1\",\n            \"severity\": \"info\"\n          },\n          {\n            \"acc_\": \"0.7954130385173886\",\n            \"batch_size\": \"32\",\n            \"counter\": \"4\",\n            \"learning_rate\": \"0.01\",\n            \"logger\": \"mandl\",\n            \"loss\": \"0.20128893672180637\",\n            \"optimizer\": \"adam\",\n            \"project\": \"with_counter\",\n            \"run\": \"2\",\n            \"severity\": \"info\"\n          },\n          {\n            \"acc_\": \"0.7909732859317975\",\n            \"batch_size\": \"32\",\n            \"counter\": \"6\",\n            \"learning_rate\": \"0.01\",\n            \"logger\": \"mandl\",\n            \"loss\": \"0.23366053844146556\",\n            \"optimizer\": \"adam\",\n            \"project\": \"with_counter\",\n            \"run\": \"6\",\n            \"severity\": \"info\",\n            \"test_acc\": \"0.8909732859317975\",\n            \"test_loss\": \"0.13366053844146555\",\n            \"val_acc\": \"0.5909732859317975\",\n            \"val_loss\": \"0.03366053844146555\"\n          },\n          {\n            \"acc_\": \"0.787367190583361\",\n            \"batch_size\": \"32\",\n            \"counter\": \"3\",\n            \"learning_rate\": \"0.01\",\n            \"logger\": \"mandl\",\n            \"loss\": \"0.303498121134643\",\n            \"optimizer\": \"adam\",\n            \"project\": \"with_counter\",\n            \"run\": \"1\",\n            \"severity\": \"info\"\n          },\n          {\n            \"acc_\": \"0.7851427066479056\",\n            \"batch_size\": \"32\",\n            \"counter\": \"5\",\n            \"learning_rate\": \"0.01\",\n            \"logger\": \"mandl\",\n            \"loss\": \"0.12900504580760153\",\n            \"optimizer\": \"adam\",\n            \"project\": \"with_counter\",\n            \"run\": \"5\",\n            \"severity\": \"info\"\n          },\n          {\n            \"acc_\": \"0.7846898981419941\",\n            \"batch_size\": \"32\",\n            \"counter\": \"2\",\n            \"learning_rate\": \"0.01\",\n            \"logger\": \"mandl\",\n            \"loss\": \"0.18203471245269406\",\n            \"optimizer\": \"adam\",\n            \"project\": \"with_counter\",\n            \"run\": \"3\",\n            \"severity\": \"info\"\n          },\n          {\n            \"acc_\": \"0.7792423678706757\",\n            \"batch_size\": \"32\",\n            \"counter\": \"7\",\n            \"learning_rate\": \"0.01\",\n            \"logger\": \"mandl\",\n            \"loss\": \"0.19444616593030503\",\n            \"optimizer\": \"adam\",\n            \"project\": \"with_counter\",\n            \"run\": \"6\",\n            \"severity\": \"info\",\n            \"test_acc\": \"0.8792423678706757\",\n            \"test_loss\": \"0.09444616593030503\",\n            \"val_acc\": \"0.5792423678706757\",\n            \"val_loss\": \"-0.0055538340696949795\"\n          },\n          {\n            \"acc_\": \"0.7784840662822918\",\n            \"batch_size\": \"32\",\n            \"counter\": \"3\",\n            \"learning_rate\": \"0.01\",\n            \"logger\": \"mandl\",\n            \"loss\": \"0.22253686125804334\",\n            \"optimizer\": \"adam\",\n            \"project\": \"with_counter\",\n            \"run\": \"4\",\n            \"severity\": \"info\"\n          },\n          {\n            \"acc_\": \"0.760011896010686\",\n            \"batch_size\": \"32\",\n            \"counter\": \"2\",\n            \"learning_rate\": \"0.01\",\n            \"logger\": \"mandl\",\n            \"loss\": \"0.3304234612776939\",\n            \"optimizer\": \"adam\",\n            \"project\": \"with_counter\",\n            \"run\": \"2\",\n            \"severity\": \"info\"\n          },\n          {\n            \"acc_\": \"0.739994178607413\",\n            \"batch_size\": \"32\",\n            \"counter\": \"3\",\n            \"learning_rate\": \"0.01\",\n            \"logger\": \"mandl\",\n            \"loss\": \"0.22105099370592185\",\n            \"optimizer\": \"adam\",\n            \"project\": \"with_counter\",\n            \"run\": \"2\",\n            \"severity\": \"info\"\n          },\n          {\n            \"acc_\": \"0.6971723114158472\",\n            \"batch_size\": \"32\",\n            \"counter\": \"4\",\n            \"learning_rate\": \"0.01\",\n            \"logger\": \"mandl\",\n            \"loss\": \"0.2629368431737353\",\n            \"optimizer\": \"adam\",\n            \"project\": \"with_counter\",\n            \"run\": \"6\",\n            \"severity\": \"info\",\n            \"test_acc\": \"0.7971723114158472\",\n            \"test_loss\": \"0.16293684317373527\",\n            \"val_acc\": \"0.4971723114158472\",\n            \"val_loss\": \"0.06293684317373527\"\n          },\n          {\n            \"acc_\": \"0.6732179166558548\",\n            \"batch_size\": \"32\",\n            \"counter\": \"1\",\n            \"learning_rate\": \"0.01\",\n            \"logger\": \"mandl\",\n            \"loss\": \"0.3736408330080728\",\n            \"optimizer\": \"adam\",\n            \"project\": \"with_counter\",\n            \"run\": \"5\",\n            \"severity\": \"info\"\n          },\n          {\n            \"acc_\": \"0.6583534878658401\",\n            \"batch_size\": \"32\",\n            \"counter\": \"2\",\n            \"learning_rate\": \"0.01\",\n            \"logger\": \"mandl\",\n            \"loss\": \"0.33565466456439685\",\n            \"optimizer\": \"adam\",\n            \"project\": \"with_counter\",\n            \"run\": \"6\",\n            \"severity\": \"info\",\n            \"test_acc\": \"0.7583534878658401\",\n            \"test_loss\": \"0.23565466456439685\",\n            \"val_acc\": \"0.4583534878658401\",\n            \"val_loss\": \"0.13565466456439684\"\n          },\n          {\n            \"acc_\": \"0.6468896026554001\",\n            \"batch_size\": \"32\",\n            \"counter\": \"3\",\n            \"learning_rate\": \"0.01\",\n            \"logger\": \"mandl\",\n            \"loss\": \"0.3011198590947211\",\n            \"optimizer\": \"adam\",\n            \"project\": \"with_counter\",\n            \"run\": \"6\",\n            \"severity\": \"info\",\n            \"test_acc\": \"0.7468896026554\",\n            \"test_loss\": \"0.2011198590947211\",\n            \"val_acc\": \"0.44688960265540006\",\n            \"val_loss\": \"0.1011198590947211\"\n          },\n          {\n            \"acc_\": \"0.6368294048199735\",\n            \"batch_size\": \"32\",\n            \"counter\": \"2\",\n            \"learning_rate\": \"0.01\",\n            \"logger\": \"mandl\",\n            \"loss\": \"0.2652646794930176\",\n            \"optimizer\": \"adam\",\n            \"project\": \"with_counter\",\n            \"run\": \"1\",\n            \"severity\": \"info\"\n          },\n          {\n            \"acc_\": \"0.6212628092181023\",\n            \"batch_size\": \"32\",\n            \"counter\": \"1\",\n            \"learning_rate\": \"0.01\",\n            \"logger\": \"mandl\",\n            \"loss\": \"0.4333155341738092\",\n            \"optimizer\": \"adam\",\n            \"project\": \"with_counter\",\n            \"run\": \"1\",\n            \"severity\": \"info\"\n          },\n          {\n            \"acc_\": \"0.6014162060717676\",\n            \"batch_size\": \"32\",\n            \"counter\": \"0\",\n            \"learning_rate\": \"0.01\",\n            \"logger\": \"mandl\",\n            \"loss\": \"0.6561612539016246\",\n            \"optimizer\": \"adam\",\n            \"project\": \"with_counter\",\n            \"run\": \"5\",\n            \"severity\": \"info\"\n          },\n          {\n            \"acc_\": \"0.6001024573437596\",\n            \"batch_size\": \"32\",\n            \"counter\": \"2\",\n            \"learning_rate\": \"0.01\",\n            \"logger\": \"mandl\",\n            \"loss\": \"0.37934182535554584\",\n            \"optimizer\": \"adam\",\n            \"project\": \"with_counter\",\n            \"run\": \"5\",\n            \"severity\": \"info\"\n          },\n          {\n            \"acc_\": \"0.563317152222432\",\n            \"batch_size\": \"32\",\n            \"counter\": \"1\",\n            \"learning_rate\": \"0.01\",\n            \"logger\": \"mandl\",\n            \"loss\": \"0.22544633728117994\",\n            \"optimizer\": \"adam\",\n            \"project\": \"with_counter\",\n            \"run\": \"3\",\n            \"severity\": \"info\"\n          },\n          {\n            \"acc_\": \"0.5412845295637901\",\n            \"batch_size\": \"32\",\n            \"counter\": \"1\",\n            \"learning_rate\": \"0.01\",\n            \"logger\": \"mandl\",\n            \"loss\": \"0.3501649329211311\",\n            \"optimizer\": \"adam\",\n            \"project\": \"with_counter\",\n            \"run\": \"2\",\n            \"severity\": \"info\"\n          },\n          {\n            \"acc_\": \"0.5291427827105375\",\n            \"batch_size\": \"32\",\n            \"counter\": \"1\",\n            \"learning_rate\": \"0.01\",\n            \"logger\": \"mandl\",\n            \"loss\": \"0.5188924640735668\",\n            \"optimizer\": \"adam\",\n            \"project\": \"with_counter\",\n            \"run\": \"6\",\n            \"severity\": \"info\",\n            \"test_acc\": \"0.6291427827105375\",\n            \"test_loss\": \"0.41889246407356684\",\n            \"val_acc\": \"0.3291427827105375\",\n            \"val_loss\": \"0.3188924640735668\"\n          },\n          {\n            \"acc_\": \"0.5228279778415722\",\n            \"batch_size\": \"32\",\n            \"counter\": \"0\",\n            \"learning_rate\": \"0.01\",\n            \"logger\": \"mandl\",\n            \"loss\": \"0.5498702384250214\",\n            \"optimizer\": \"adam\",\n            \"project\": \"with_counter\",\n            \"run\": \"1\",\n            \"severity\": \"info\"\n          },\n          {\n            \"acc_\": \"0.45191640067191496\",\n            \"batch_size\": \"32\",\n            \"counter\": \"1\",\n            \"learning_rate\": \"0.01\",\n            \"logger\": \"mandl\",\n            \"loss\": \"0.4925432491826788\",\n            \"optimizer\": \"adam\",\n            \"project\": \"with_counter\",\n            \"run\": \"4\",\n            \"severity\": \"info\"\n          },\n          {\n            \"acc_\": \"0.43358754464147253\",\n            \"batch_size\": \"32\",\n            \"counter\": \"0\",\n            \"learning_rate\": \"0.01\",\n            \"logger\": \"mandl\",\n            \"loss\": \"0.7321570685615264\",\n            \"optimizer\": \"adam\",\n            \"project\": \"with_counter\",\n            \"run\": \"4\",\n            \"severity\": \"info\"\n          },\n          {\n            \"acc_\": \"0.3865729768035964\",\n            \"batch_size\": \"32\",\n            \"counter\": \"0\",\n            \"learning_rate\": \"0.01\",\n            \"logger\": \"mandl\",\n            \"loss\": \"0.43870533791333544\",\n            \"optimizer\": \"adam\",\n            \"project\": \"with_counter\",\n            \"run\": \"2\",\n            \"severity\": \"info\"\n          },\n          {\n            \"acc_\": \"0.37604164546972113\",\n            \"batch_size\": \"32\",\n            \"counter\": \"0\",\n            \"learning_rate\": \"0.01\",\n            \"logger\": \"mandl\",\n            \"loss\": \"0.6141653359011556\",\n            \"optimizer\": \"adam\",\n            \"project\": \"with_counter\",\n            \"run\": \"6\",\n            \"severity\": \"info\",\n            \"test_acc\": \"0.47604164546972116\",\n            \"test_loss\": \"0.5141653359011557\",\n            \"val_acc\": \"0.17604164546972112\",\n            \"val_loss\": \"0.4141653359011556\"\n          },\n          {\n            \"acc_\": \"0.2778744540658636\",\n            \"batch_size\": \"32\",\n            \"counter\": \"0\",\n            \"learning_rate\": \"0.01\",\n            \"logger\": \"mandl\",\n            \"loss\": \"0.4446477544771138\",\n            \"optimizer\": \"adam\",\n            \"project\": \"with_counter\",\n            \"run\": \"3\",\n            \"severity\": \"info\"\n          }\n        ],\n        [\n          1701886426190,\n          1701886426043,\n          1701886426120,\n          1701886429957,\n          1701886426272,\n          1701886422517,\n          1701886425960,\n          1701886430111,\n          1701886418013,\n          1701886433356,\n          1701886433441,\n          1701886417792,\n          1701886433131,\n          1701886422615,\n          1701886452600,\n          1701886422436,\n          1701886433212,\n          1701886417936,\n          1701886429751,\n          1701886430027,\n          1701886429888,\n          1701886417865,\n          1701886422367,\n          1701886452675,\n          1701886417706,\n          1701886433287,\n          1701886425891,\n          1701886452825,\n          1701886429817,\n          1701886422225,\n          1701886422296,\n          1701886452515,\n          1701886432973,\n          1701886452342,\n          1701886452418,\n          1701886417640,\n          1701886417563,\n          1701886432587,\n          1701886433050,\n          1701886425808,\n          1701886422151,\n          1701886452256,\n          1701886417278,\n          1701886429668,\n          1701886429335,\n          1701886421848,\n          1701886451933,\n          1701886425438\n        ],\n        [\n          \"{\\\"acc:\\\": 0.9155599456033213, \\\"loss\\\": 0.10245595613323495, \\\"counter\\\": 6}\",\n          \"{\\\"acc:\\\": 0.9097065627281077, \\\"loss\\\": 0.1532706030753554, \\\"counter\\\": 4}\",\n          \"{\\\"acc:\\\": 0.9047419553379855, \\\"loss\\\": 0.05245811618572973, \\\"counter\\\": 5}\",\n          \"{\\\"acc:\\\": 0.8874248475675268, \\\"loss\\\": 0.17828075772529656, \\\"counter\\\": 5}\",\n          \"{\\\"acc:\\\": 0.8865198621448641, \\\"loss\\\": 0.027895722206651617, \\\"counter\\\": 7}\",\n          \"{\\\"acc:\\\": 0.8739628028724391, \\\"loss\\\": 0.08975119991377326, \\\"counter\\\": 6}\",\n          \"{\\\"acc:\\\": 0.8651892476685286, \\\"loss\\\": 0.20282652048043368, \\\"counter\\\": 3}\",\n          \"{\\\"acc:\\\": 0.8639308309522367, \\\"loss\\\": 0.13643147553189303, \\\"counter\\\": 7}\",\n          \"{\\\"acc:\\\": 0.8634164766213455, \\\"loss\\\": 0.09220808751793727, \\\"counter\\\": 7}\",\n          \"{\\\"acc:\\\": 0.857960019414961, \\\"loss\\\": 0.1816547179168026, \\\"counter\\\": 6}\",\n          \"{\\\"acc:\\\": 0.8436017386604135, \\\"loss\\\": 0.20359193703033246, \\\"counter\\\": 7}\",\n          \"{\\\"acc:\\\": 0.8427674406528638, \\\"loss\\\": 0.25503354706489023, \\\"counter\\\": 4}\",\n          \"{\\\"acc:\\\": 0.8359526575369163, \\\"loss\\\": 0.32150621127819246, \\\"counter\\\": 3}\",\n          \"{\\\"acc:\\\": 0.834116963907194, \\\"loss\\\": 0.13600250524792895, \\\"counter\\\": 7}\",\n          \"{\\\"acc:\\\": 0.8338295995010134, \\\"loss\\\": 0.2494388887177475, \\\"test_acc\\\": 0.9338295995010134, \\\"test_loss\\\": 0.1494388887177475, \\\"val_loss\\\": 0.04943888871774749, \\\"val_acc\\\": 0.6338295995010135, \\\"counter\\\": 5}\",\n          \"{\\\"acc:\\\": 0.8244677826158627, \\\"loss\\\": 0.11203306310875542, \\\"counter\\\": 5}\",\n          \"{\\\"acc:\\\": 0.8237069417864736, \\\"loss\\\": 0.21513458035043637, \\\"counter\\\": 4}\",\n          \"{\\\"acc:\\\": 0.8181927925853246, \\\"loss\\\": 0.08207342626255047, \\\"counter\\\": 6}\",\n          \"{\\\"acc:\\\": 0.8118856013761496, \\\"loss\\\": 0.38643990830498154, \\\"counter\\\": 2}\",\n          \"{\\\"acc:\\\": 0.8056802393082074, \\\"loss\\\": 0.1994764753488268, \\\"counter\\\": 6}\",\n          \"{\\\"acc:\\\": 0.8056635991720746, \\\"loss\\\": 0.1778881927566374, \\\"counter\\\": 4}\",\n          \"{\\\"acc:\\\": 0.8044316635781, \\\"loss\\\": 0.11060466779347133, \\\"counter\\\": 5}\",\n          \"{\\\"acc:\\\": 0.7954130385173886, \\\"loss\\\": 0.20128893672180637, \\\"counter\\\": 4}\",\n          \"{\\\"acc:\\\": 0.7909732859317975, \\\"loss\\\": 0.23366053844146556, \\\"test_acc\\\": 0.8909732859317975, \\\"test_loss\\\": 0.13366053844146555, \\\"val_loss\\\": 0.03366053844146555, \\\"val_acc\\\": 0.5909732859317975, \\\"counter\\\": 6}\",\n          \"{\\\"acc:\\\": 0.787367190583361, \\\"loss\\\": 0.303498121134643, \\\"counter\\\": 3}\",\n          \"{\\\"acc:\\\": 0.7851427066479056, \\\"loss\\\": 0.12900504580760153, \\\"counter\\\": 5}\",\n          \"{\\\"acc:\\\": 0.7846898981419941, \\\"loss\\\": 0.18203471245269406, \\\"counter\\\": 2}\",\n          \"{\\\"acc:\\\": 0.7792423678706757, \\\"loss\\\": 0.19444616593030503, \\\"test_acc\\\": 0.8792423678706757, \\\"test_loss\\\": 0.09444616593030503, \\\"val_loss\\\": -0.0055538340696949795, \\\"val_acc\\\": 0.5792423678706757, \\\"counter\\\": 7}\",\n          \"{\\\"acc:\\\": 0.7784840662822918, \\\"loss\\\": 0.22253686125804334, \\\"counter\\\": 3}\",\n          \"{\\\"acc:\\\": 0.760011896010686, \\\"loss\\\": 0.3304234612776939, \\\"counter\\\": 2}\",\n          \"{\\\"acc:\\\": 0.739994178607413, \\\"loss\\\": 0.22105099370592185, \\\"counter\\\": 3}\",\n          \"{\\\"acc:\\\": 0.6971723114158472, \\\"loss\\\": 0.2629368431737353, \\\"test_acc\\\": 0.7971723114158472, \\\"test_loss\\\": 0.16293684317373527, \\\"val_loss\\\": 0.06293684317373527, \\\"val_acc\\\": 0.4971723114158472, \\\"counter\\\": 4}\",\n          \"{\\\"acc:\\\": 0.6732179166558548, \\\"loss\\\": 0.3736408330080728, \\\"counter\\\": 1}\",\n          \"{\\\"acc:\\\": 0.6583534878658401, \\\"loss\\\": 0.33565466456439685, \\\"test_acc\\\": 0.7583534878658401, \\\"test_loss\\\": 0.23565466456439685, \\\"val_loss\\\": 0.13565466456439684, \\\"val_acc\\\": 0.4583534878658401, \\\"counter\\\": 2}\",\n          \"{\\\"acc:\\\": 0.6468896026554001, \\\"loss\\\": 0.3011198590947211, \\\"test_acc\\\": 0.7468896026554, \\\"test_loss\\\": 0.2011198590947211, \\\"val_loss\\\": 0.1011198590947211, \\\"val_acc\\\": 0.44688960265540006, \\\"counter\\\": 3}\",\n          \"{\\\"acc:\\\": 0.6368294048199735, \\\"loss\\\": 0.2652646794930176, \\\"counter\\\": 2}\",\n          \"{\\\"acc:\\\": 0.6212628092181023, \\\"loss\\\": 0.4333155341738092, \\\"counter\\\": 1}\",\n          \"{\\\"acc:\\\": 0.6014162060717676, \\\"loss\\\": 0.6561612539016246, \\\"counter\\\": 0}\",\n          \"{\\\"acc:\\\": 0.6001024573437596, \\\"loss\\\": 0.37934182535554584, \\\"counter\\\": 2}\",\n          \"{\\\"acc:\\\": 0.563317152222432, \\\"loss\\\": 0.22544633728117994, \\\"counter\\\": 1}\",\n          \"{\\\"acc:\\\": 0.5412845295637901, \\\"loss\\\": 0.3501649329211311, \\\"counter\\\": 1}\",\n          \"{\\\"acc:\\\": 0.5291427827105375, \\\"loss\\\": 0.5188924640735668, \\\"test_acc\\\": 0.6291427827105375, \\\"test_loss\\\": 0.41889246407356684, \\\"val_loss\\\": 0.3188924640735668, \\\"val_acc\\\": 0.3291427827105375, \\\"counter\\\": 1}\",\n          \"{\\\"acc:\\\": 0.5228279778415722, \\\"loss\\\": 0.5498702384250214, \\\"counter\\\": 0}\",\n          \"{\\\"acc:\\\": 0.45191640067191496, \\\"loss\\\": 0.4925432491826788, \\\"counter\\\": 1}\",\n          \"{\\\"acc:\\\": 0.43358754464147253, \\\"loss\\\": 0.7321570685615264, \\\"counter\\\": 0}\",\n          \"{\\\"acc:\\\": 0.3865729768035964, \\\"loss\\\": 0.43870533791333544, \\\"counter\\\": 0}\",\n          \"{\\\"acc:\\\": 0.37604164546972113, \\\"loss\\\": 0.6141653359011556, \\\"test_acc\\\": 0.47604164546972116, \\\"test_loss\\\": 0.5141653359011557, \\\"val_loss\\\": 0.4141653359011556, \\\"val_acc\\\": 0.17604164546972112, \\\"counter\\\": 0}\",\n          \"{\\\"acc:\\\": 0.2778744540658636, \\\"loss\\\": 0.4446477544771138, \\\"counter\\\": 0}\"\n        ],\n        [\n          \"1701886426190526720\",\n          \"1701886426043169024\",\n          \"1701886426120764672\",\n          \"1701886429957740288\",\n          \"1701886426272765440\",\n          \"1701886422517869824\",\n          \"1701886425960483840\",\n          \"1701886430111410944\",\n          \"1701886418013104384\",\n          \"1701886433356441600\",\n          \"1701886433441300736\",\n          \"1701886417792913152\",\n          \"1701886433131112192\",\n          \"1701886422615630080\",\n          \"1701886452600480256\",\n          \"1701886422436583680\",\n          \"1701886433212467968\",\n          \"1701886417936455424\",\n          \"1701886429751312128\",\n          \"1701886430027418112\",\n          \"1701886429888678144\",\n          \"1701886417865863424\",\n          \"1701886422367184640\",\n          \"1701886452675688704\",\n          \"1701886417706505728\",\n          \"1701886433287753216\",\n          \"1701886425891415296\",\n          \"1701886452825912320\",\n          \"1701886429817841152\",\n          \"1701886422225473280\",\n          \"1701886422296144896\",\n          \"1701886452515034368\",\n          \"1701886432973714688\",\n          \"1701886452342554880\",\n          \"1701886452418623232\",\n          \"1701886417640431872\",\n          \"1701886417563679744\",\n          \"1701886432587480576\",\n          \"1701886433050946816\",\n          \"1701886425808807168\",\n          \"1701886422151316736\",\n          \"1701886452256521728\",\n          \"1701886417278991616\",\n          \"1701886429668728320\",\n          \"1701886429335290368\",\n          \"1701886421848463104\",\n          \"1701886451933467648\",\n          \"1701886425438646016\"\n        ],\n        [\n          \"1701886426190526720_10c6be09\",\n          \"1701886426043169024_5c57e48b\",\n          \"1701886426120764672_5601f5ab\",\n          \"1701886429957740288_26d32e58\",\n          \"1701886426272765440_5f1afef7\",\n          \"1701886422517869824_705041fc\",\n          \"1701886425960483840_ae1b0b8f\",\n          \"1701886430111410944_774090e0\",\n          \"1701886418013104384_bad10c09\",\n          \"1701886433356441600_6b241b8d\",\n          \"1701886433441300736_97c5bcfd\",\n          \"1701886417792913152_c8dd31f3\",\n          \"1701886433131112192_675fc061\",\n          \"1701886422615630080_a571c482\",\n          \"1701886452600480256_dfa9234c\",\n          \"1701886422436583680_95224fa2\",\n          \"1701886433212467968_8d1c8443\",\n          \"1701886417936455424_b35ee153\",\n          \"1701886429751312128_9058ee0e\",\n          \"1701886430027418112_6c08e8ac\",\n          \"1701886429888678144_7a67e7ee\",\n          \"1701886417865863424_30a156d3\",\n          \"1701886422367184640_d7e334a0\",\n          \"1701886452675688704_46657872\",\n          \"1701886417706505728_395ed5cb\",\n          \"1701886433287753216_657df795\",\n          \"1701886425891415296_d84802b1\",\n          \"1701886452825912320_4171c140\",\n          \"1701886429817841152_796e0fdc\",\n          \"1701886422225473280_ca03e81e\",\n          \"1701886422296144896_e88208b8\",\n          \"1701886452515034368_3395cf12\",\n          \"1701886432973714688_cfa27535\",\n          \"1701886452342554880_c22ab334\",\n          \"1701886452418623232_a8884da\",\n          \"1701886417640431872_5a2d35c7\",\n          \"1701886417563679744_44752267\",\n          \"1701886432587480576_736046d7\",\n          \"1701886433050946816_9ec5b2cb\",\n          \"1701886425808807168_2482b233\",\n          \"1701886422151316736_734fc46c\",\n          \"1701886452256521728_c22989ac\",\n          \"1701886417278991616_88abbc69\",\n          \"1701886429668728320_c9a59d98\",\n          \"1701886429335290368_e28a2564\",\n          \"1701886421848463104_b2d03d38\",\n          \"1701886451933467648_9ea23eaa\",\n          \"1701886425438646016_69c8dc6b\"\n        ],\n        [\n          null,\n          null,\n          null,\n          null,\n          null,\n          null,\n          null,\n          null,\n          null,\n          null,\n          null,\n          null,\n          null,\n          null,\n          null,\n          null,\n          null,\n          null,\n          null,\n          null,\n          null,\n          null,\n          null,\n          null,\n          null,\n          null,\n          null,\n          null,\n          null,\n          null,\n          null,\n          null,\n          null,\n          null,\n          null,\n          null,\n          null,\n          null,\n          null,\n          null,\n          null,\n          null,\n          null,\n          null,\n          null,\n          null,\n          null,\n          null\n        ]\n      ],\n      \"nanos\": [\n        null,\n        [\n          526720,\n          169024,\n          764672,\n          740288,\n          765440,\n          869824,\n          483840,\n          410944,\n          104384,\n          441600,\n          300736,\n          913152,\n          112192,\n          630080,\n          480256,\n          583680,\n          467968,\n          455424,\n          312128,\n          418112,\n          678144,\n          863424,\n          184640,\n          688704,\n          505728,\n          753216,\n          415296,\n          912320,\n          841152,\n          473280,\n          144896,\n          34368,\n          714688,\n          554880,\n          623232,\n          431872,\n          679744,\n          480576,\n          946816,\n          807168,\n          316736,\n          521728,\n          991616,\n          728320,\n          290368,\n          463104,\n          467648,\n          646016\n        ],\n        null,\n        null,\n        null,\n        null\n      ]\n    }\n  }\n]",
          "refId": "A",
          "scenarioId": "raw_frame"
        }
      ],
      "title": "Reproduced with embedded data",
      "transformations": [
        {
          "id": "extractFields",
          "options": {
            "format": "auto",
            "keepTime": false,
            "replace": true,
            "source": "labels"
          }
        },
        {
          "id": "convertFieldType",
          "options": {
            "conversions": [
              {
                "destinationType": "number",
                "targetField": "acc_"
              },
              {
                "destinationType": "number",
                "targetField": "loss"
              },
              {
                "destinationType": "number",
                "targetField": "counter"
              }
            ],
            "fields": {}
          }
        },
        {
          "id": "partitionByValues",
          "options": {
            "fields": [
              "run"
            ]
          }
        },
        {
          "id": "joinByField",
          "options": {
            "byField": "counter",
            "mode": "outer"
          }
        }
      ],
      "type": "trend"
    }
  ],
  "refresh": "",
  "schemaVersion": 39,
  "tags": [
    "debug",
    "debug-xychart"
  ],
  "templating": {
    "list": []
  },
  "time": {
    "from": "2023-12-06T17:54:58.919Z",
    "to": "2023-12-06T20:54:58.919Z"
  },
  "timepicker": {},
  "timezone": "",
  "title": "Debug: Lost (By steps) // 2023-12-06 14:54:58",
  "uid": "dcd59e68-1c7e-4588-aeb3-96b271b5c1f3",
  "version": 6,
  "weekStart": ""
}
```
</details>

![image](https://github.com/grafana/grafana/assets/43234/0c31a25a-6151-43e6-b18b-63a91af88979)
