### PR TITLE
Special alerts for NoData and Error

### DIFF
--- a/docs/sources/alerting/manage-notifications/view-state-health.md
+++ b/docs/sources/alerting/manage-notifications/view-state-health.md
@@ -77,6 +77,10 @@ When evaluation of an alerting rule produces state `NoData` or `Error`, Grafana 
 | **alertname**      | Either `DatasourceNoData` or `DatasourceError` depending on the state. |
 | **datasource_uid** | The UID of the data source that caused the state.                      |
 
+{{% admonition type="note" %}}
+You will need to set the No Data and Error Handling to `No Data` or `Error` in the alert rule as per this doc: https://grafana.com/docs/grafana/latest/alerting/alerting-rules/create-grafana-managed-rule/#configure-no-data-and-error-handling in order to generate the additional labels. 
+{{% /admonition %}}
+
 You can handle these alerts the same way as regular alerts by adding a silence, route to a contact point, and so on.
 
 ## State history view

--- a/docs/sources/alerting/manage-notifications/view-state-health.md
+++ b/docs/sources/alerting/manage-notifications/view-state-health.md
@@ -78,7 +78,7 @@ When evaluation of an alerting rule produces state `NoData` or `Error`, Grafana 
 | **datasource_uid** | The UID of the data source that caused the state.                      |
 
 {{% admonition type="note" %}}
-You will need to set the No Data and Error Handling to `No Data` or `Error` in the alert rule as per this doc: https://grafana.com/docs/grafana/latest/alerting/alerting-rules/create-grafana-managed-rule/#configure-no-data-and-error-handling in order to generate the additional labels. 
+You will need to set the No Data and Error Handling to `No Data` or `Error` in the alert rule as per this doc: https://grafana.com/docs/grafana/latest/alerting/alerting-rules/create-grafana-managed-rule/#configure-no-data-and-error-handling in order to generate the additional labels.
 {{% /admonition %}}
 
 You can handle these alerts the same way as regular alerts by adding a silence, route to a contact point, and so on.


### PR DESCRIPTION
To avoid confusion why there is no additional label added when setting `Alerting` or `OK` in the No Data and Error handling

<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

[Add a brief description of what the feature or update does.]

**Why do we need this feature?**

[Add a description of the problem the feature is trying to solve.]

**Who is this feature for?**

[Add information on what kind of user the feature is for.]

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
