### PR TITLE
Chore: Remove folderID from dashboardIdentity tests

### DIFF
--- a/pkg/services/provisioning/dashboards/file_reader.go
+++ b/pkg/services/provisioning/dashboards/file_reader.go
@@ -484,9 +484,10 @@ type provisioningMetadata struct {
 }
 
 type dashboardIdentity struct {
-	// Deprecated: use FolderUID instead
-	folderID int64
-	title    string
+	// Deprecated: use folderUID instead
+	folderID  int64
+	folderUID string
+	title     string
 }
 
 func (d *dashboardIdentity) Exists() bool {

--- a/pkg/services/provisioning/dashboards/validator_test.go
+++ b/pkg/services/provisioning/dashboards/validator_test.go
@@ -39,11 +39,10 @@ func TestDuplicatesValidator(t *testing.T) {
 		fakeService.On("SaveFolderForProvisionedDashboards", mock.Anything, mock.Anything).Return(&dashboards.Dashboard{}, nil).Times(6)
 		fakeService.On("GetProvisionedDashboardData", mock.Anything, mock.AnythingOfType("string")).Return([]*dashboards.DashboardProvisioning{}, nil).Times(4)
 		fakeService.On("SaveProvisionedDashboard", mock.Anything, mock.Anything, mock.Anything).Return(&dashboards.Dashboard{}, nil).Times(5)
-		folderID, _, err := r.getOrCreateFolder(context.Background(), cfg, fakeService, folderName)
+		_, folderUID, err := r.getOrCreateFolder(context.Background(), cfg, fakeService, folderName)
 		require.NoError(t, err)
 
-		// nolint:staticcheck
-		identity := dashboardIdentity{folderID: folderID, title: "Grafana"}
+		identity := dashboardIdentity{folderUID: folderUID, title: "Grafana"}
 
 		cfg1 := &config{
 			Name: "first", Type: "file", OrgID: 1, Folder: folderName,
@@ -93,11 +92,10 @@ func TestDuplicatesValidator(t *testing.T) {
 		fakeStore := &fakeDashboardStore{}
 		r, err := NewDashboardFileReader(cfg, logger, nil, fakeStore)
 		require.NoError(t, err)
-		folderID, _, err := r.getOrCreateFolder(context.Background(), cfg, fakeService, folderName)
+		_, folderUID, err := r.getOrCreateFolder(context.Background(), cfg, fakeService, folderName)
 		require.NoError(t, err)
 
-		// nolint:staticcheck
-		identity := dashboardIdentity{folderID: folderID, title: "Grafana"}
+		identity := dashboardIdentity{folderUID: folderUID, title: "Grafana"}
 
 		cfg1 := &config{
 			Name: "first", Type: "file", OrgID: 1, Folder: folderName,
@@ -196,11 +194,10 @@ func TestDuplicatesValidator(t *testing.T) {
 
 		r, err := NewDashboardFileReader(cfg, logger, nil, fakeStore)
 		require.NoError(t, err)
-		folderID, _, err := r.getOrCreateFolder(context.Background(), cfg, fakeService, cfg1.Folder)
+		_, folderUID, err := r.getOrCreateFolder(context.Background(), cfg, fakeService, cfg1.Folder)
 		require.NoError(t, err)
 
-		// nolint:staticcheck
-		identity := dashboardIdentity{folderID: folderID, title: "Grafana"}
+		identity := dashboardIdentity{folderUID: folderUID, title: "Grafana"}
 
 		require.Equal(t, uint8(2), duplicates[1].UIDs["Z-phNqGmz"].Sum)
 		uidUsageReaders := keysToSlice(duplicates[1].UIDs["Z-phNqGmz"].InvolvedReaders)
@@ -214,11 +211,10 @@ func TestDuplicatesValidator(t *testing.T) {
 
 		r, err = NewDashboardFileReader(cfg3, logger, nil, fakeStore)
 		require.NoError(t, err)
-		folderID, _, err = r.getOrCreateFolder(context.Background(), cfg3, fakeService, cfg3.Folder)
+		_, folderUID, err = r.getOrCreateFolder(context.Background(), cfg3, fakeService, cfg3.Folder)
 		require.NoError(t, err)
 
-		// nolint:staticcheck
-		identity = dashboardIdentity{folderID: folderID, title: "Grafana"}
+		identity = dashboardIdentity{folderUID: folderUID, title: "Grafana"}
 
 		require.Equal(t, uint8(2), duplicates[2].UIDs["Z-phNqGmz"].Sum)
 		uidUsageReaders = keysToSlice(duplicates[2].UIDs["Z-phNqGmz"].InvolvedReaders)


### PR DESCRIPTION
Delete `folderID` from `dashboardIdentity`'s tests

Additional changes:

- Add `folderUID` field to `dashboardIdentity`

Main issue https://github.com/grafana/grafana/issues/78757
Related deprecation PR https://github.com/grafana/grafana/pull/77650