### PR TITLE
AnnotationsMarker: Fix non-null assertion operator usage

### DIFF
--- a/public/app/plugins/panel/timeseries/plugins/annotations/AnnotationMarker.tsx
+++ b/public/app/plugins/panel/timeseries/plugins/annotations/AnnotationMarker.tsx
@@ -35,7 +35,7 @@ const POPPER_CONFIG = {
 };
 
 export function AnnotationMarker({ annotation, timeZone, width }: Props) {
-  const { canAddAnnotations, canEditAnnotations, canDeleteAnnotations, ...panelCtx } = usePanelContext();
+  const { canEditAnnotations, canDeleteAnnotations, ...panelCtx } = usePanelContext();
   const commonStyles = useStyles2(getCommonAnnotationStyles);
   const styles = useStyles2(getStyles);
 
@@ -97,11 +97,12 @@ export function AnnotationMarker({ annotation, timeZone, width }: Props) {
         timeFormatter={timeFormatter}
         onEdit={onAnnotationEdit}
         onDelete={onAnnotationDelete}
-        canEdit={canEditAnnotations!(annotation.dashboardUID)}
-        canDelete={canDeleteAnnotations!(annotation.dashboardUID)}
+        canEdit={canEditAnnotations ? canEditAnnotations(annotation.dashboardUID) : false}
+        canDelete={canDeleteAnnotations ? canDeleteAnnotations(annotation.dashboardUID) : false}
       />
     );
   }, [canEditAnnotations, canDeleteAnnotations, onAnnotationDelete, onAnnotationEdit, timeFormatter, annotation]);
+
   const isRegionAnnotation = Boolean(annotation.isRegion) && width > MIN_REGION_ANNOTATION_WIDTH;
 
   let left = `${width / 2}px`;


### PR DESCRIPTION
We got some reports of a bug in scenes caused by this ([internal link](https://raintank-corp.slack.com/archives/C04FRQ2S0AV/p1701895312669979)) 

We should not force anyone to provide panel context that's not required type-wise.