### PR TITLE
mssql: prepare logs-handling for decouple-datasource changes

### DIFF
--- a/pkg/api/datasource/validation.go
+++ b/pkg/api/datasource/validation.go
@@ -69,7 +69,7 @@ func ValidateURL(typeName, urlStr string) (*url.URL, error) {
 	var err error
 	switch strings.ToLower(typeName) {
 	case "mssql":
-		u, err = mssql.ParseURL(urlStr)
+		u, err = mssql.ParseURL(urlStr, logger)
 	default:
 		logger.Debug("Applying default URL parsing for this data source type", "type", typeName, "url", urlStr)
 

--- a/pkg/tsdb/mssql/mssql_test.go
+++ b/pkg/tsdb/mssql/mssql_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/grafana/grafana/pkg/infra/db"
+	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/services/sqlstore/sqlutil"
 	"github.com/grafana/grafana/pkg/setting"
 	"github.com/grafana/grafana/pkg/tsdb/sqleng"
@@ -58,6 +59,9 @@ func TestMSSQL(t *testing.T) {
 		MetricColumnTypes: []string{"VARCHAR", "CHAR", "NVARCHAR", "NCHAR"},
 		RowLimit:          1000000,
 	}
+
+	logger := log.New("mssql.test")
+
 	endpoint, err := sqleng.NewQueryDataHandler(setting.NewCfg(), config, &queryResultTransformer, newMssqlMacroEngine(), logger)
 	require.NoError(t, err)
 
@@ -1336,6 +1340,8 @@ func TestTransformQueryError(t *testing.T) {
 		{err: randomErr, expectedErr: randomErr},
 	}
 
+	logger := log.New("mssql.test")
+
 	for _, tc := range tests {
 		resultErr := transformer.TransformQueryError(logger, tc.err)
 		assert.ErrorIs(t, resultErr, tc.expectedErr)
@@ -1470,9 +1476,12 @@ func TestGenerateConnectionString(t *testing.T) {
 			expConnStr: "server=localhost;database=database;user id=user;password=;",
 		},
 	}
+
+	logger := log.New("mssql.test")
+
 	for _, tc := range testCases {
 		t.Run(tc.desc, func(t *testing.T) {
-			connStr, err := generateConnectionString(tc.dataSource, nil, nil)
+			connStr, err := generateConnectionString(tc.dataSource, nil, nil, logger)
 			require.NoError(t, err)
 			assert.Equal(t, tc.expConnStr, connStr)
 		})


### PR DESCRIPTION
we must not use grafana-core-only functions in the mssql datasource plugin. one problem is logging, it uses `"github.com/grafana/grafana/pkg/infra/log"` . we need to switch to `"github.com/grafana/grafana-plugin-sdk-go/backend/log"` (see https://github.com/grafana/grafana/pull/79143/commits/b9532af244016c69a5dc9fe6ab6de0652e27f057 for a proof-of-concept).

the problem is, with the plugin's current architecture, the converted logger will not initialize correctly. we need to create the logger "later". we do that in this PR, as a preparation for the "real" conversion:
- before: logger is created as a package-level variable
- after: logger is created in `ProvideService`

(similar PRs happened for [mysql](https://github.com/grafana/grafana/pull/79148) and [postgres](https://github.com/grafana/grafana/pull/79147) too)

this change causes no change in behavior, so we're only testing that things did not get worse 😄 

how to test:
- run grafana from main-branch, for example as a docker-image, with log-level-debug
- go to explore-mode, choose the mssql-datasource and run a query. 
- observe that log-lines with `tsdb.mssql` appear (one good example is turning off the database, and then running a query and seeing the query error log message)
- now do the same with this branch
- verify that the log-lines are the same
    - they are also named `tsdb.mssql`
    - for logs, where there is extra info in main-branch version, the extra info is there too in this version
    - verify that they are logfmt-formatted (not json-formatted)