### PR TITLE
Hackathon: allow stats to have a smaller min width

### DIFF
--- a/public/app/features/logs/components/LogLabelStats.tsx
+++ b/public/app/features/logs/components/LogLabelStats.tsx
@@ -25,8 +25,6 @@ const getStyles = stylesFactory((theme: GrafanaTheme2) => {
       background: inherit;
       color: ${theme.colors.text.primary};
       word-break: break-all;
-      width: fit-content;
-      max-width: 100%;
       margin: ${theme.spacing(0.5)} 0;
       padding: ${theme.spacing(1)};
       &:hover {
@@ -95,7 +93,7 @@ class UnThemedLogLabelStats extends PureComponent<Props> {
       <div className={style.logsStats} data-testid="logLabelStats">
         <div className={style.logsStatsTitle}>{label}</div>
         <div className={style.logsStatsBody}>
-          <div style={{ width: '70%' }}>
+          <table style={{ width: '75%' }}>
             {topRows.map((stat) => (
               <LogLabelStatsRow
                 key={stat.value}
@@ -121,8 +119,8 @@ class UnThemedLogLabelStats extends PureComponent<Props> {
                 onClickFilterOutLabel={onClickFilterOutLabel}
               />
             )}
-          </div>
-          <div style={{ width: '30%', marginLeft: '50px', marginTop: '-30px' }}>
+          </table>
+          <div style={{ width: '25%', marginTop: '-30px' }}>
             <PanelRenderer
               pluginId="piechart"
               height={100}

--- a/public/app/features/logs/components/LogLabelStatsRow.tsx
+++ b/public/app/features/logs/components/LogLabelStatsRow.tsx
@@ -76,8 +76,8 @@ export const LogLabelStatsRow = ({
   const percent = `${Math.round(proportion * 100)}%`;
 
   return (
-    <div style={{ display: 'flex' }}>
-      <div style={{ width: '60px', marginTop: '3px' }}>
+    <tr>
+      <td style={{ marginRight: '1.5em', width: '45px' }}>
         <IconButton
           disabled={!shouldFilter}
           size="xs"
@@ -92,23 +92,22 @@ export const LogLabelStatsRow = ({
           aria-label="search-minus"
           onClick={() => onClickFilterOutLabel?.(keyField, value ?? '')}
         />
-      </div>
-      <div
+      </td>
+      <td
         style={{
-          width: '180px',
           textOverflow: 'ellipsis',
           overflow: 'hidden',
           whiteSpace: 'nowrap',
-          marginRight: '20px',
+          marginRight: '1.5em',
         }}
       >
         {value}
-      </div>
-      <div style={{ width: '80px' }}>
+      </td>
+      <td style={{ width: '80px' }}>
         {count}/{total}
-      </div>
-      <div style={{ width: '44px' }}>{percent}</div>
-    </div>
+      </td>
+      <td style={{ width: '40px' }}>{percent}</td>
+    </tr>
   );
 };
 

--- a/public/app/features/logsApp/Logs/Logs.tsx
+++ b/public/app/features/logsApp/Logs/Logs.tsx
@@ -690,7 +690,7 @@ class UnthemedLogs extends PureComponent<Props, State> {
       this.state.hiddenLogLevels.length > 0 ? ` (filtered based on selected ${this.state.groupByLabel})` : ''
     }`;
 
-    const maxPaneSize = this.state.logDetailsRow ? getMaxPaneSize() : window.innerWidth;
+    const maxPaneSize = getMaxPaneSize();
 
     return (
       <>


### PR DESCRIPTION
![Stats](https://github.com/grafana/grafana/assets/1069378/d2921a53-3234-4e98-a831-4238994f45c3)
