### PR TITLE
VizTooltip: Make hover proximity bias away from zero

### DIFF
--- a/public/app/core/components/TimeSeries/utils.ts
+++ b/public/app/core/components/TimeSeries/utils.ts
@@ -607,6 +607,10 @@ export const preparePlotConfigBuilder: UPlotConfigPrepFn<{
 
       return hoveredIdx;
     },
+    focus: {
+      bias: 1,
+      prox: 30,
+    }
   };
 
   if (sync && sync() !== DashboardCursorSync.Off && xField.type === FieldType.time) {


### PR DESCRIPTION
see https://github.com/grafana/support-escalations/issues/8491

problem:

![image](https://github.com/grafana/grafana/assets/43234/39adbfc8-c7ce-491c-a6d6-233b01f387ec)

TimeSeries and Trend panels use proximity-based hover for tooltip activation. the proximity is to the actual datapoint, not the the filled region that may or may not exist (such as opacity > 0 line areas, bars, stacked series, and bands). this can be surprising, but is internally very simple, high performance, and consistent. since users can mix and match a vast diversity of options for each series and mix them at-will, it's not really feasible to do anything else as a general case, vs a case when you only have a single, simple rendering style. for example, here's a mixed case where all bets are off:

![image](https://github.com/grafana/grafana/assets/43234/4b6a7f98-31d6-4312-989a-71c9cce38234)

we can improve the filled region case (assuming things are filled to 0) by biasing the proximity test away from zero. this has an improved effect on filled styles, at the expense of making unfilled lines more difficult to proximity-hover:

i'm not sure if this should be merged or not, the new behavior works like this:

https://github.com/grafana/grafana/assets/43234/d7551b5c-2f6c-410c-a75d-d5d84d42db11