### PR TITLE
Prometheus: improved PromQAIL v1 prompt

### DIFF
--- a/public/app/plugins/datasource/prometheus/querybuilder/components/promQail/prompts.ts
+++ b/public/app/plugins/datasource/prometheus/querybuilder/components/promQail/prompts.ts
@@ -67,36 +67,49 @@ export function GetExplainUserPrompt({
     `;
 }
 
+export const SuggestSystemPrompt = `You are a Prometheus Query Language (PromQL) expert assistant inside Grafana.
+When the user asks a question, respond with a valid PromQL query and only the query.
+
+To help you answer the question, you will receive:
+- List of potentially relevant PromQL templates with descriptions, ranked by semantic search score
+- Prometheus metric
+- Metric type
+- Available Prometheus metric labels
+- User question
+
+Policy:
+- Do not invent labels names, you can only use the available labels
+- For rate queries, use the $__rate_interval variable`;
+
 // rewrite with a type
-export type SuggestSystemPromptParams = {
+export type SuggestUserPromptParams = {
   promql: string;
   question: string;
+  metricType: string;
   labels: string;
   templates: string;
 };
 
-export function GetSuggestSystemPrompt({ promql, question, labels, templates }: SuggestSystemPromptParams): string {
+export function GetSuggestUserPrompt({
+  promql,
+  question,
+  metricType,
+  labels,
+  templates,
+}: SuggestUserPromptParams): string {
   if (templates === '') {
     templates = 'No templates provided.';
+  } else {
+    templates = templates.replace(/\n/g, '\n  ');
   }
-  return `You are an PromQL expert assistant. You will be is given a PromQL expression and a user question.
-You are to edit the PromQL expression so that it answers the user question. Show only the edited PromQL.
-
-The initial PromQL query is
-\`\`\`
-${promql}
-\`\`\`
-The user question is: "${question}"
-
-To help you answer the question, here are 2 pieces of information:
-
-1. List of labels to use: ${labels}
-2. Here is a list of possibly relevant PromQL template expressions with descriptions to help target your answer:
-${templates}
-
-Rules:
-- Do not invent labels names, you must use only the labels provided.
-
-Answer:
-\`\`\``;
+  return `Relevant PromQL templates:
+  ${templates}
+  
+  Prometheus metric: ${promql}
+  Metric type: ${metricType}
+  Available Prometheus metric labels: ${labels}
+  User question: ${question}
+  
+  \`\`\`promql
+`;
 }

--- a/public/app/plugins/datasource/prometheus/querybuilder/components/promQail/prompts.ts
+++ b/public/app/plugins/datasource/prometheus/querybuilder/components/promQail/prompts.ts
@@ -110,6 +110,5 @@ export function GetSuggestUserPrompt({
   Available Prometheus metric labels: ${labels}
   User question: ${question}
   
-  \`\`\`promql
-`;
+  \`\`\`promql`;
 }

--- a/public/app/plugins/datasource/prometheus/querybuilder/components/promQail/state/helpers.ts
+++ b/public/app/plugins/datasource/prometheus/querybuilder/components/promQail/state/helpers.ts
@@ -353,9 +353,13 @@ export async function promQailSuggest(
       prompt?: string;
     };
 
+    const allLabels = await datasource.languageProvider.fetchSeriesLabels(query.metric);
+
     let feedTheAI: SuggestionBody = {
       metric: query.metric,
-      labels: promQueryModeller.renderLabels(query.labels),
+      // get all available labels
+      // labels: promQueryModeller.renderLabels(query.labels),
+      labels: Object.keys(allLabels).join(', '),
     };
 
     // @ts-ignore llms types issue

--- a/public/app/plugins/datasource/prometheus/querybuilder/components/promQail/state/helpers.ts
+++ b/public/app/plugins/datasource/prometheus/querybuilder/components/promQail/state/helpers.ts
@@ -353,13 +353,15 @@ export async function promQailSuggest(
       prompt?: string;
     };
 
-    const allLabels = await datasource.languageProvider.fetchSeriesLabels(query.metric);
+    // get all available labels
+    const metricLabels = await datasource.languageProvider.fetchSeriesLabelsMatch(query.metric);
 
     let feedTheAI: SuggestionBody = {
       metric: query.metric,
-      // get all available labels
-      // labels: promQueryModeller.renderLabels(query.labels),
-      labels: Object.keys(allLabels).join(', '),
+      // drop __name__ label because it's not useful
+      labels: Object.keys(metricLabels)
+        .filter((label) => label !== '__name__')
+        .join(','),
     };
 
     // @ts-ignore llms types issue


### PR DESCRIPTION
**What is this feature?**
This PR updates the PromQL query advisor to provide more reliable results based on iterations in the lab:
- Split out system and user prompt, and update prompts to latest iteration
- added `metricType` to user prompt
- Use latest gpt-3.5-turbo-1106 model (will become default next week, on December 11)
- Set temperature to 0.5
- Use all available labels instead of selected label
- tweaked formatting of templates to avoid repetition / save tokens 

**Why do we need this feature?**
The current prompt with gpt-3.5-turbo-1106 always leads to a code-block wrapped query that's can't be used. The updated version avoids it. 