### PR TITLE
Alerting: Fix the "Run queries" button to preview queries

### DIFF
--- a/public/app/features/alerting/unified/components/rule-editor/query-and-alert-condition/QueryAndExpressionsStep.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/query-and-alert-condition/QueryAndExpressionsStep.tsx
@@ -446,7 +446,7 @@ export const QueryAndExpressionsStep = ({ editingExistingRule, onDataChange }: P
           <QueryEditor
             queries={dataQueries}
             expressions={expressionQueries}
-            onRunQueries={runQueriesPreview}
+            onRunQueries={() => runQueriesPreview()}
             onChangeQueries={onChangeQueries}
             onDuplicateQuery={onDuplicateQuery}
             panelData={queryPreviewData}


### PR DESCRIPTION
**What is this feature?**

Fixes the "Run queries" button when previewing a new query.

**Why do we need this feature?**

The button was broken after  https://github.com/grafana/grafana/pull/79032

**Who is this feature for?**

All users

![2023-12-07 18 11 14](https://github.com/grafana/grafana/assets/6271380/76ede93f-4964-42be-9b99-dbba996efec4)
