### PR TITLE
Service account: Update last used timestamp when token is used

### DIFF
--- a/pkg/services/authn/clients/api_key_test.go
+++ b/pkg/services/authn/clients/api_key_test.go
@@ -201,6 +201,112 @@ func TestAPIKey_Test(t *testing.T) {
 	}
 }
 
+func TestAPIKey_GetAPIKeyIDFromIdentity(t *testing.T) {
+	type TestCase struct {
+		desc             string
+		expectedKey      *apikey.APIKey
+		expectedIdentity *authn.Identity
+		expectedError    error
+		expectedKeyID    int64
+		expectedExists   bool
+	}
+
+	tests := []TestCase{
+		{
+			desc: "should return API Key ID for valid token that is connected to service account",
+			expectedKey: &apikey.APIKey{
+				ID:               1,
+				OrgID:            1,
+				Key:              hash,
+				ServiceAccountId: intPtr(1),
+			},
+			expectedIdentity: &authn.Identity{
+				ID:              "service-account:1",
+				OrgID:           1,
+				Name:            "test",
+				AuthenticatedBy: login.APIKeyAuthModule,
+			},
+			expectedKeyID:  1,
+			expectedExists: true,
+		},
+		{
+			desc: "should return API Key ID for valid token for API key",
+			expectedKey: &apikey.APIKey{
+				ID:    2,
+				OrgID: 1,
+				Key:   hash,
+			},
+			expectedIdentity: &authn.Identity{
+				ID:              "api-key:2",
+				OrgID:           1,
+				Name:            "test",
+				AuthenticatedBy: login.APIKeyAuthModule,
+			},
+			expectedKeyID:  2,
+			expectedExists: true,
+		},
+		{
+			desc: "should not return any ID when the request is not made by API key or service account",
+			expectedKey: &apikey.APIKey{
+				ID:    2,
+				OrgID: 1,
+				Key:   hash,
+			},
+			expectedIdentity: &authn.Identity{
+				ID:              "user:2",
+				OrgID:           1,
+				Name:            "test",
+				AuthenticatedBy: login.APIKeyAuthModule,
+			},
+			expectedKeyID:  -1,
+			expectedExists: false,
+		},
+		{
+			desc: "should not return any ID when the can't fetch API Key",
+			expectedKey: &apikey.APIKey{
+				ID:    1,
+				OrgID: 1,
+				Key:   hash,
+			},
+			expectedIdentity: &authn.Identity{
+				ID:              "service-account:2",
+				OrgID:           1,
+				Name:            "test",
+				AuthenticatedBy: login.APIKeyAuthModule,
+			},
+			expectedError:  fmt.Errorf("invalid token"),
+			expectedKeyID:  -1,
+			expectedExists: false,
+		},
+	}
+
+	req := &authn.Request{HTTPRequest: &http.Request{
+		Header: map[string][]string{
+			"Authorization": {"Bearer " + secret},
+		},
+	}}
+
+	signedInUser := &user.SignedInUser{
+		UserID: 1,
+		OrgID:  1,
+		Name:   "test",
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			c := ProvideAPIKey(&apikeytest.Service{
+				ExpectedError:  tt.expectedError,
+				ExpectedAPIKey: tt.expectedKey,
+			}, &usertest.FakeUserService{
+				ExpectedSignedInUser: signedInUser,
+			})
+			id, exists := c.getAPIKeyID(context.Background(), tt.expectedIdentity, req)
+			assert.Equal(t, tt.expectedExists, exists)
+			assert.Equal(t, tt.expectedKeyID, id)
+		})
+	}
+}
+
 func intPtr(n int64) *int64 {
 	return &n
 }


### PR DESCRIPTION
## Context

When authenticating using legacy API Key or service account token, there is a hook which is being called after valid authentication. The hook is supposed to update the last used timestamp of a given token.

With the latest changes (introduction of auth broker), we are relying on the namespace from the resolved identity to parse the ID assigned to the identity. 

The service account namespace was ignored and not processed, resulting to not updating the service account token last used timestamp.

## Fix

The fix consists of two parts:

1. Adding namespace check for service accounts (self explanatory)
2. Ensuring that the right token is updated (see further details below)

Service account tokens are persisted in the `api_key` table. When the request is made by using API key, the parsed ID is the API Key ID which is being correctly used to update the last used timestamp. However, when the request is done by using service account token, the parsed ID from the namespace is actually the service account ID.

Since there are multiple tokens per service account, we can't use that ID to update correct token, thus we need to fetch the API Key ID to identify the token correctly.

**Which issue(s) does this PR fix?**:

Fixes # https://github.com/grafana/grafana/

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
