### PR TITLE
Strip out auth token from shared URL when sharing a dashboard

### DIFF
--- a/public/app/features/dashboard/components/ShareModal/utils.test.ts
+++ b/public/app/features/dashboard/components/ShareModal/utils.test.ts
@@ -29,6 +29,7 @@ describe('buildParams', () => {
     ${'var=%2B1&var=a+value+with+spaces&var=true'} | ${false}            | ${'current'}  | ${{ id: 3 }} | ${'var=%2B1&var=a+value+with+spaces&var=true&orgId=2&viewPanel=3'}
     ${'var=%2B1&var=a+value+with+spaces&var=true'} | ${false}            | ${'light'}    | ${undefined} | ${'var=%2B1&var=a+value+with+spaces&var=true&orgId=2&theme=light'}
     ${'var=%2B1&var=a+value+with+spaces&var=true'} | ${false}            | ${'light'}    | ${{ id: 3 }} | ${'var=%2B1&var=a+value+with+spaces&var=true&orgId=2&theme=light&viewPanel=3'}
+    ${'auth_token=1234'}                           | ${true}             | ${'current'}  | ${undefined} | ${'from=1000&to=2000&orgId=2'}
   `(
     "when called with search: '$search' and useCurrentTimeRange: '$useCurrentTimeRange' and selectedTheme: '$selectedTheme' and panel: '$panel'then result should be '$expected'",
     ({ search, useCurrentTimeRange, selectedTheme, panel, expected }) => {

--- a/public/app/features/dashboard/components/ShareModal/utils.ts
+++ b/public/app/features/dashboard/components/ShareModal/utils.ts
@@ -49,6 +49,9 @@ export function buildParams({
     searchParams.set('viewPanel', String(panel.id));
   }
 
+  // Token is unique to the authenticated identity and should not be shared with the URL,
+  // so we are stripping it from the query params as a safety measure.
+  searchParams.delete('auth_token');
   return searchParams;
 }
 


### PR DESCRIPTION
**What is this feature?**

When using [JWT authentication](https://grafana.com/docs/grafana/latest/setup-grafana/configure-security/configure-authentication/jwt/#configure-jwt-authentication) it is possible to navigate straight to Grafana by adding JWT token to the URL. 

This token is unique to the authenticated user and should not be shared publicly.  

When sharing a dashboard (by URL, or iframe embedding) the URL we built contains the `auth_token` parameter and it is very easy to not know or notice that the parameter should be removed before sharing the link with others. 

The PR strips out the auth_token from the param list before building a URL.

**Why do we need this feature?**

Leaving the token in the shared URL is a security risk.

Here are screenshots of we have now

<img width="816" alt="Screenshot 2023-12-08 at 10 15 50" src="https://github.com/grafana/grafana/assets/1861190/8c58932d-e747-4f79-a2fd-082e085d1769">

<img width="860" alt="Screenshot 2023-12-08 at 10 15 43" src="https://github.com/grafana/grafana/assets/1861190/17ff8981-e5a0-4f5f-a3e0-df34b3225ec8">

Here is what we have after fix

<img width="799" alt="Screenshot 2023-12-08 at 10 14 14" src="https://github.com/grafana/grafana/assets/1861190/12fa403f-f0d4-4252-9d46-a659a9354bb2">

<img width="802" alt="Screenshot 2023-12-08 at 10 14 19" src="https://github.com/grafana/grafana/assets/1861190/bae942cb-e9fb-411a-b302-8ca86542a42f">


**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/grafana/issues/78189

**Special notes for your reviewer:**

I have decided to strip the token from `buildParams` as this will ensure that it won't be anywhere when building a URL. At the moment, I can't see any scenario where we want token to be in the URL, however if in the future this function is used for other purposes, it might be misleading. That said, the function is scoped to the share modal component, so hopefully this won't be an issue.

Please check that:
- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
