### PR TITLE
Docs: add missing alt text (1/3)

### DIFF
--- a/docs/sources/dashboards/assess-dashboard-usage/index.md
+++ b/docs/sources/dashboards/assess-dashboard-usage/index.md
@@ -51,14 +51,14 @@ For every dashboard and data source, you can access usage information.
 
 To see dashboard usage information, click the dashboard insights icon in the header.
 
-{{< figure src="/media/docs/grafana/dashboards/screenshot-dashboard-insights.png" max-width="400px" class="docs-image--no-shadow" >}}
+{{< figure src="/media/docs/grafana/dashboards/screenshot-dashboard-insights.png" max-width="400px" class="docs-image--no-shadow" alt="Dashboard insights icon" >}}
 
 Dashboard insights show the following information:
 
 - **Stats:** The number of daily queries and errors for the past 30 days.
 - **Users & activity:** The daily view count for the last 30 days; last activities on the dashboard and recent users (with a limit of 20).
 
-{{< figure src="/static/img/docs/enterprise/dashboard_insights_stats.png" max-width="400px" class="docs-image--no-shadow" >}}{{< figure src="/static/img/docs/enterprise/dashboard_insights_users.png" max-width="400px" class="docs-image--no-shadow" >}}
+{{< figure src="/static/img/docs/enterprise/dashboard_insights_stats.png" max-width="400px" class="docs-image--no-shadow" alt="Stats tab" >}}{{< figure src="/static/img/docs/enterprise/dashboard_insights_users.png" max-width="400px" class="docs-image--no-shadow" alt="Users and activity tab" >}}
 
 {{% admonition type="note" %}}
 
@@ -81,7 +81,7 @@ To find data source insights:
 1. Click a data source.
 1. Click the **Insights** tab.
 
-{{< figure src="/media/docs/grafana/dashboards/screenshot-data-source-insights-9.5.png" max-width="650px" class="docs-image--no-shadow" >}}
+{{< figure src="/media/docs/grafana/dashboards/screenshot-data-source-insights-9.5.png" max-width="650px" class="docs-image--no-shadow" alt="Insights tab for a data source" >}}
 
 ## Presence indicator
 
@@ -89,7 +89,7 @@ When you are signed in and looking at a dashboard, you can know who is looking a
 
 When there are more active users on a dashboard than can fit within the presence indicator, click the **+X** icon. Doing so opens [dashboard insights](#dashboard-and-data-source-insights), which contains more details about recent user activity.
 
-{{< figure src="/static/img/docs/enterprise/presence_indicators.png" max-width="400px" class="docs-image--no-shadow" >}}
+{{< figure src="/static/img/docs/enterprise/presence_indicators.png" max-width="400px" class="docs-image--no-shadow" alt="Presence indicator icons" >}}
 
 To change _recent_ to something other than the past 10 minutes, edit the [configuration][] file:
 
@@ -123,7 +123,7 @@ You can sort the dashboards by:
 - Views total
 - Views 30 days (most and least)
 
-{{< figure src="/media/docs/grafana/dashboards/screenshot-dashboard-sort-9.5.png" max-width="650px" class="docs-image--no-shadow" >}}
+{{< figure src="/media/docs/grafana/dashboards/screenshot-dashboard-sort-9.5.png" max-width="650px" class="docs-image--no-shadow" alt="Open list of dashboard sort options" >}}
 
 ## Visualize usage insights data
 

--- a/docs/sources/dashboards/build-dashboards/annotate-visualizations/index.md
+++ b/docs/sources/dashboards/build-dashboards/annotate-visualizations/index.md
@@ -21,7 +21,7 @@ weight: 600
 
 Annotations provide a way to mark points on a visualization with rich events. They are visualized as vertical lines and icons on all graph panels. When you hover over an annotation, you can get event description and event tags. The text field can include links to other systems with more detail.
 
-{{< figure src="/static/img/docs/v46/annotations.png" max-width="800px" >}}
+{{< figure src="/static/img/docs/v46/annotations.png" max-width="800px" alt="Annotated visualization with annotation context menu open" >}}
 
 You can annotate visualizations in three ways:
 
@@ -148,21 +148,21 @@ Grafana v8.1 and later versions also support typeahead of existing tags, provide
 
 For example, create an annotation query name `outages` and specify a tag `outage`. This query will show all annotations (from any dashboard or via API) with the `outage` tag. If multiple tags are defined in an annotation query, then Grafana will only show annotations matching all the tags. To modify the behavior, enable `Match any`, and Grafana will show annotations that contain any one of the tags you provided.
 
-{{< figure src="/media/docs/grafana/dashboards/screenshot-annotations-typeahead-support-10.0.png" max-width="600px" >}}
+{{< figure src="/media/docs/grafana/dashboards/screenshot-annotations-typeahead-support-10.0.png" max-width="600px" alt="Annotation query options" >}}
 
 You can also use template variables in the tag query. This means if you have a dashboard showing stats for different services and a template variable that dictates which services to show, you can use the same template variable in your annotation query to only show annotations for those services.
 
-{{< figure src="/media/docs/grafana/dashboards/screenshot-annotation-tag-filter-variable-10.0.png" max-width="600px" >}}
+{{< figure src="/media/docs/grafana/dashboards/screenshot-annotation-tag-filter-variable-10.0.png" max-width="600px" alt="Annotation query options with a template variable query tag" >}}
 
 ### Add time regions
 
 When adding or editing an annotation, you can define a repeating time region by setting **Query type** to **Time regions**. Then, define the **From** and **To** sections with the preferred days of the week and time. You also have the option to change the timezone, which is set to the dashboard's timezone, by default.
 
-{{< figure src="/media/docs/grafana/dashboards/screenshot-annotation-timeregions-10-v2.png" max-width="600px" caption="Time regions business hours" >}}
+{{< figure src="/media/docs/grafana/dashboards/screenshot-annotation-timeregions-10-v2.png" max-width="600px" alt="Time regions options set to business hours" >}}
 
 The above configuration will produce the following result in the Time series panel:
 
-{{< figure src="/media/docs/grafana/screenshot-grafana-10-0-timeseries-time-regions.png" max-width="600px" caption="Time series time regions business hours" >}}
+{{< figure src="/media/docs/grafana/screenshot-grafana-10-0-timeseries-time-regions.png" max-width="600px" alt="Time series visualization with time regions business hours" >}}
 
 {{% docs/reference %}}
 [Annotations API]: "/docs/grafana/ -> /docs/grafana/<GRAFANA VERSION>/developers/http_api/annotations"

--- a/docs/sources/dashboards/build-dashboards/manage-dashboard-links/index.md
+++ b/docs/sources/dashboards/build-dashboards/manage-dashboard-links/index.md
@@ -119,7 +119,7 @@ Each panel can have its own set of links that are shown in the upper left of the
 
 Click the icon next to the panel title to see available panel links.
 
-{{< figure src="/media/docs/grafana/screenshot-panel-links.png" width="200px" >}}
+{{< figure src="/media/docs/grafana/screenshot-panel-links.png" width="200px" alt="List of panel links displayed" >}}
 
 ### Add a panel link
 

--- a/docs/sources/dashboards/build-dashboards/manage-library-panels/index.md
+++ b/docs/sources/dashboards/build-dashboards/manage-library-panels/index.md
@@ -30,7 +30,7 @@ When you create a library panel, the panel on the source dashboard is converted 
 
 1. Open a panel in edit mode.
 1. In the panel display options, click the down arrow option to bring changes to the visualization.
-   {{< figure src="/media/docs/grafana/panels-visualizations/screenshot-create-lib-panel-from-edit-9-5.png" class="docs-image--no-shadow" max-width= "800px" >}}
+   {{< figure src="/media/docs/grafana/panels-visualizations/screenshot-create-lib-panel-from-edit-9-5.png" class="docs-image--no-shadow" max-width= "800px" alt="Library panels tab of the panel editor pane" >}}
 1. Click **Library panels**, and then click **+ Create library panel** to open the create dialog.
 1. In **Library panel name**, enter the name.
 1. In **Save in folder**, select the folder to save the library panel.
@@ -41,7 +41,7 @@ Once created, you can modify the library panel using any dashboard on which it a
 
 You can also create a library panel directly from the edit menu of any panel.
 
-{{< figure src="/media/docs/grafana/panels-visualizations/screenshot-create-from-more-9-5.png" class="docs-image--no-shadow" max-width= "900px" >}}
+{{< figure src="/media/docs/grafana/panels-visualizations/screenshot-create-from-more-9-5.png" class="docs-image--no-shadow" max-width= "900px" alt="Create library panel option in the panel menu" >}}
 
 ## Add a library panel to a dashboard
 
@@ -77,7 +77,7 @@ You can view a list of available library panels and search for a library panel.
 1. Click **Library panels**.
 
    You can see a list of previously defined library panels.
-   {{< figure src="/media/docs/grafana/panels-visualizations/screenshot-library-panel-list-9-5.png" class="docs-image--no-shadow" max-width= "900px" >}}
+   {{< figure src="/media/docs/grafana/panels-visualizations/screenshot-library-panel-list-9-5.png" class="docs-image--no-shadow" max-width= "900px" alt="Library panels page with list of library panels" >}}
 
 1. Search for a specific library panel if you know its name.
 

--- a/docs/sources/dashboards/create-reports/index.md
+++ b/docs/sources/dashboards/create-reports/index.md
@@ -26,10 +26,6 @@ Reporting enables you to automatically generate PDFs from any of your dashboards
 > If you have [Role-based access control][] enabled, for some actions you would need to have relevant permissions.
 > Refer to specific guides to understand what permissions are required.
 
-<!--
-{{< figure src="/static/img/docs/enterprise/reports_list_8.1.png" max-width="500px" >}}
--->
-
 Any changes you make to a dashboard used in a report are reflected the next time the report is sent. For example, if you change the time range in the dashboard, then the time range in the report also changes, unless you've configured a custom time range.
 
 For information about recent improvements to the reporting UI, refer to [Grafana reporting: How we improved the UX in Grafana](https://grafana.com/blog/2022/06/29/grafana-reporting-how-we-improved-the-ux-in-grafana/).
@@ -121,12 +117,12 @@ If the time zone is set differently between your Grafana server and its remote i
 
 > We're actively developing new report layout options. [Contact us](https://grafana.com/contact?about=grafana-enterprise&topic=design-process&value=reporting) to get involved in the design process.
 
-| Layout | Orientation | Support | Description                                                                                               | Preview                                                                                                                                               |
-| ------ | ----------- | ------- | --------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Simple | Portrait    | v6.4+   | Generates an A4 page in portrait mode with three panels per page.                                         | {{< figure src="/static/img/docs/enterprise/reports_portrait_preview.png" max-width="500px" max-height="500px" class="docs-image--no-shadow" >}}      |
-| Simple | Landscape   | v6.7+   | Generates an A4 page in landscape mode with a single panel per page.                                      | {{< figure src="/static/img/docs/enterprise/reports_landscape_preview.png" max-width="500px" class="docs-image--no-shadow" >}}                        |
-| Grid   | Portrait    | v7.2+   | Generates an A4 page in portrait mode with panels arranged in the same way as at the original dashboard.  | {{< figure src="/static/img/docs/enterprise/reports_grid_portrait_preview.png" max-width="500px" max-height="500px" class="docs-image--no-shadow" >}} |
-| Grid   | Landscape   | v7.2+   | Generates an A4 page in landscape mode with panels arranged in the same way as in the original dashboard. | {{< figure src="/static/img/docs/enterprise/reports_grid_landscape_preview.png" max-width="500px" class="docs-image--no-shadow" >}}                   |
+| Layout | Orientation | Support | Description                                                                                               | Preview                                                                                                                                                                             |
+| ------ | ----------- | ------- | --------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Simple | Portrait    | v6.4+   | Generates an A4 page in portrait mode with three panels per page.                                         | {{< figure src="/static/img/docs/enterprise/reports_portrait_preview.png" max-width="500px" max-height="500px" class="docs-image--no-shadow" alt="Simple layout in portrait" >}}    |
+| Simple | Landscape   | v6.7+   | Generates an A4 page in landscape mode with a single panel per page.                                      | {{< figure src="/static/img/docs/enterprise/reports_landscape_preview.png" max-width="500px" class="docs-image--no-shadow" alt="Simple layout in landscape" >}}                     |
+| Grid   | Portrait    | v7.2+   | Generates an A4 page in portrait mode with panels arranged in the same way as at the original dashboard.  | {{< figure src="/static/img/docs/enterprise/reports_grid_portrait_preview.png" max-width="500px" max-height="500px" class="docs-image--no-shadow" alt="Grid layout in portrait" >}} |
+| Grid   | Landscape   | v7.2+   | Generates an A4 page in landscape mode with panels arranged in the same way as in the original dashboard. | {{< figure src="/static/img/docs/enterprise/reports_grid_landscape_preview.png" max-width="500px" class="docs-image--no-shadow" alt="Grid layout in landscape" >}}                  |
 
 ### CSV export
 

--- a/docs/sources/dashboards/manage-dashboards/index.md
+++ b/docs/sources/dashboards/manage-dashboards/index.md
@@ -131,16 +131,13 @@ A template variable of the type `Constant` is automatically hidden in the dashbo
    - Paste a [Grafana.com](https://grafana.com) dashboard URL
    - Paste dashboard JSON text directly into the text area
 
-<!--{{< figure src="/static/img/docs/v70/import_step2_grafana.com.png"  max-width="700px" >}}
--->
-
 The import process enables you to change the name of the dashboard, pick the data source you want the dashboard to use, and specify any metric prefixes (if the dashboard uses any).
 
 ### Discover dashboards on grafana.com
 
 Find dashboards for common server applications at [Grafana.com/dashboards](https://grafana.com/dashboards).
 
-{{< figure src="/media/docs/grafana/dashboards/screenshot-gcom-dashboards.png" >}}
+{{< figure src="/media/docs/grafana/dashboards/screenshot-gcom-dashboards.png" alt="Preconfigured dashboards on grafana.com">}}
 
 ## Set up generative AI features for dashboards
 
@@ -185,11 +182,11 @@ In the picture below we've enabled:
 - Points and 3-point radius to highlight where data points are actually present.
 - **Connect null values\* is set to **Always\*\*.
 
-{{< figure src="/static/img/docs/troubleshooting/grafana_null_connected.png" max-width="1200px" >}}
+{{< figure src="/static/img/docs/troubleshooting/grafana_null_connected.png" max-width="1200px" alt="Graph with null values connected" >}}
 
 In this graph, we set graph to show bars instead of lines and set the **No value** under **Standard options** to **0**. There is a very big difference in the visuals.
 
-{{< figure src="/static/img/docs/troubleshooting/grafana_null_zero.png" max-width="1200px" >}}
+{{< figure src="/static/img/docs/troubleshooting/grafana_null_zero.png" max-width="1200px" alt="Graph with null values not connected" >}}
 
 ### More examples
 

--- a/docs/sources/dashboards/use-dashboards/index.md
+++ b/docs/sources/dashboards/use-dashboards/index.md
@@ -32,7 +32,7 @@ The dashboard user interface provides a number of features that you can use to c
 
 The following image and descriptions highlight all dashboard features.
 
-{{< figure src="/media/docs/grafana/dashboards/screenshot-dashboard-annotated-9-5-0.png" width="700px" >}}
+{{< figure src="/media/docs/grafana/dashboards/screenshot-dashboard-annotated-9-5-0.png" width="700px" alt="An annotated image of a dashboard" >}}
 
 - (1) **Grafana home**: Click **Home** in the breadcrumb to be redirected to the home page configured in the Grafana instance.
 - (2) **Dashboard title**: When you click the dashboard title, you can search for dashboards contained in the current folder.

--- a/docs/sources/dashboards/variables/_index.md
+++ b/docs/sources/dashboards/variables/_index.md
@@ -24,7 +24,8 @@ the value, using the dropdown at the top of the dashboard, your panel's metric q
 Variables allow you to create more interactive and dynamic dashboards. Instead of hard-coding things like server, application,
 and sensor names in your metric queries, you can use variables in their place. Variables are displayed as dropdown lists at the top of
 the dashboard. These dropdowns make it easy to change the data being displayed in your dashboard.
-{{< figure src="/static/img/docs/v50/variables_dashboard.png" >}}
+
+{{< figure src="/static/img/docs/v50/variables_dashboard.png" alt="Variable drop-down open and two values selected" >}}
 
 These can be especially useful for administrators who want to allow Grafana viewers to quickly adjust visualizations but do not want to give them full editing permissions. Grafana Viewers can use variables.
 

--- a/docs/sources/panels-visualizations/configure-data-links/index.md
+++ b/docs/sources/panels-visualizations/configure-data-links/index.md
@@ -109,7 +109,7 @@ You can use variables in data links to send people to a detailed dashboard with 
 
 When creating or updating a data link, press Cmd+Space or Ctrl+Space on your keyboard to open the typeahead suggestions to more easily add variables to your URL.
 
-{{< figure src="/static/img/docs/data_link_typeahead.png"  max-width= "800px" >}}
+{{< figure src="/static/img/docs/data_link_typeahead.png"  max-width= "800px" alt="Drop-down list with variable suggestions open from the URL field" >}}
 
 ### Add a data link
 

--- a/docs/sources/panels-visualizations/configure-panel-options/index.md
+++ b/docs/sources/panels-visualizations/configure-panel-options/index.md
@@ -71,7 +71,7 @@ Add a title and description to a panel to share with users any important informa
 
    You can use [variables you have defined][] in the **Title** and **Description** field, but not [global variables][].
 
-   ![](/static/img/docs/panels/panel-options-8-0.png)
+   ![Panel editor pane with Panel options section expanded](/static/img/docs/panels/panel-options-8-0.png)
 
 ## View a panel JSON model
 

--- a/docs/sources/panels-visualizations/query-transform-data/_index.md
+++ b/docs/sources/panels-visualizations/query-transform-data/_index.md
@@ -41,7 +41,7 @@ Grafana supports up to 26 queries per panel.
 
 ### Query editors
 
-{{< figure src="/static/img/docs/queries/influxdb-query-editor-7-2.png" class="docs-image--no-shadow" max-width="1000px" caption="The InfluxDB query editor" >}}
+{{< figure src="/static/img/docs/queries/influxdb-query-editor-7-2.png" class="docs-image--no-shadow" max-width="1000px" alt="The InfluxDB query editor" >}}
 
 Each data source's **query editor** provides a customized user interface that helps you write queries that take advantage of its unique capabilities.
 
@@ -123,20 +123,20 @@ Each query row contains a query editor and is identified with a letter (A, B, C,
 
 You can:
 
-|                                                                    Icon                                                                     | Description                                                                                                                                                                                                                                     |
-| :-----------------------------------------------------------------------------------------------------------------------------------------: | :---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-|  {{< figure src="/static/img/docs/queries/query-editor-help-7-4.png" class="docs-image--no-shadow" max-width="30px" max-height="30px" >}}   | Toggles query editor help. If supported by the data source, click this icon to display information on how to use the query editor or provide quick access to common queries.                                                                    |
-| {{< figure src="/static/img/docs/queries/duplicate-query-icon-7-0.png" class="docs-image--no-shadow" max-width="30px" max-height="30px" >}} | Copies a query. Duplicating queries is useful when working with multiple complex queries that are similar and you want to either experiment with different variants or do minor alterations.                                                    |
-|   {{< figure src="/static/img/docs/queries/hide-query-icon-7-0.png" class="docs-image--no-shadow" max-width="30px" max-height="30px" >}}    | Hides a query. Grafana does not send hidden queries to the data source.                                                                                                                                                                         |
-|  {{< figure src="/static/img/docs/queries/remove-query-icon-7-0.png" class="docs-image--no-shadow" max-width="30px" max-height="30px" >}}   | Removes a query. Removing a query permanently deletes it, but sometimes you can recover deleted queries by reverting to previously saved versions of the panel.                                                                                 |
-|   {{< figure src="/static/img/docs/queries/query-drag-icon-7-2.png" class="docs-image--no-shadow" max-width="30px" max-height="30px" >}}    | Reorders queries. Change the order of queries by clicking and holding the drag icon, then drag queries where desired. The order of results reflects the order of the queries, so you can often adjust your visual results based on query order. |
+|                                                                               Icon                                                                               | Description                                                                                                                                                                                                                                     |
+| :--------------------------------------------------------------------------------------------------------------------------------------------------------------: | :---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+|     {{< figure src="/static/img/docs/queries/query-editor-help-7-4.png" class="docs-image--no-shadow" max-width="30px" max-height="30px" alt="Help icon" >}}     | Toggles query editor help. If supported by the data source, click this icon to display information on how to use the query editor or provide quick access to common queries.                                                                    |
+| {{< figure src="/static/img/docs/queries/duplicate-query-icon-7-0.png" class="docs-image--no-shadow" max-width="30px" max-height="30px" alt="Duplicate icon" >}} | Copies a query. Duplicating queries is useful when working with multiple complex queries that are similar and you want to either experiment with different variants or do minor alterations.                                                    |
+|      {{< figure src="/static/img/docs/queries/hide-query-icon-7-0.png" class="docs-image--no-shadow" max-width="30px" max-height="30px" alt="Hide icon" >}}      | Hides a query. Grafana does not send hidden queries to the data source.                                                                                                                                                                         |
+|    {{< figure src="/static/img/docs/queries/remove-query-icon-7-0.png" class="docs-image--no-shadow" max-width="30px" max-height="30px" alt="Remove icon">}}     | Removes a query. Removing a query permanently deletes it, but sometimes you can recover deleted queries by reverting to previously saved versions of the panel.                                                                                 |
+|      {{< figure src="/static/img/docs/queries/query-drag-icon-7-2.png" class="docs-image--no-shadow" max-width="30px" max-height="30px" alt="Drag icon" >}}      | Reorders queries. Change the order of queries by clicking and holding the drag icon, then drag queries where desired. The order of results reflects the order of the queries, so you can often adjust your visual results based on query order. |
 
 ## Query options
 
 Click **Query options** next to the data source selector to see settings for the selected data source.
 Changes you make here affect only queries made in this panel.
 
-{{< figure src="/static/img/docs/queries/data-source-options-7-0.png" class="docs-image--no-shadow" max-width="1000px" >}}
+{{< figure src="/static/img/docs/queries/data-source-options-7-0.png" class="docs-image--no-shadow" max-width="1000px" alt="Data source query options" >}}
 
 Grafana sets defaults that are shown in dark gray text.
 Changes are displayed in white text.

--- a/docs/sources/panels-visualizations/visualizations/_index.md
+++ b/docs/sources/panels-visualizations/visualizations/_index.md
@@ -75,11 +75,11 @@ A [stat][] shows one large stat value with an optional graph sparkline. You can 
 
 If you want to present a value as it relates to a min and max value you have two options. First a standard radial [gauge][] shown below.
 
-{{< figure src="/static/img/docs/v66/gauge_panel_cover.png" max-width="700px" >}}
+{{< figure src="/static/img/docs/v66/gauge_panel_cover.png" max-width="700px" alt="A gauge visualization" >}}
 
 Secondly Grafana also has a horizontal or vertical [bar gauge][] with three different distinct display modes.
 
-{{< figure src="/static/img/docs/v66/bar_gauge_lcd.png" max-width="700px" >}}
+{{< figure src="/static/img/docs/v66/bar_gauge_lcd.png" max-width="700px" alt="A bar gauge visualization" >}}
 
 ### Table
 

--- a/docs/sources/panels-visualizations/visualizations/alert-list/index.md
+++ b/docs/sources/panels-visualizations/visualizations/alert-list/index.md
@@ -23,7 +23,7 @@ weight: 100
 
 Use alert lists to display your alerts. You can configure the list to show the current state. You can read more about alerts in [Grafana Alerting overview][].
 
-{{< figure src="/static/img/docs/alert-list-panel/alert-list-panel.png" max-width="850px" >}}
+{{< figure src="/static/img/docs/alert-list-panel/alert-list-panel.png" max-width="850px" alt="An alert list visualization" >}}
 
 Customize your visualization using the following settings.
 

--- a/docs/sources/panels-visualizations/visualizations/dashboard-list/index.md
+++ b/docs/sources/panels-visualizations/visualizations/dashboard-list/index.md
@@ -23,7 +23,7 @@ weight: 100
 
 Dashboard lists allow you to display dynamic links to other dashboards. The list can be configured to use starred dashboards, recently viewed dashboards, a search query, and dashboard tags.
 
-{{< figure src="/static/img/docs/v45/dashboard-list-panels.png" max-width="850px">}}
+{{< figure src="/static/img/docs/v45/dashboard-list-panels.png" max-width="850px" alt="A dashboard list visualization" >}}
 
 On each dashboard load, this panel queries the dashboard list, always providing the most up-to-date results.
 

--- a/docs/sources/panels-visualizations/visualizations/gauge/index.md
+++ b/docs/sources/panels-visualizations/visualizations/gauge/index.md
@@ -21,7 +21,7 @@ weight: 100
 
 Gauges are single-value visualizations that can repeat a gauge for every series, column or row.
 
-{{< figure src="/static/img/docs/v66/gauge_panel_cover.png" max-width="1025px" >}}
+{{< figure src="/static/img/docs/v66/gauge_panel_cover.png" max-width="1025px" alt="A gauge visualization">}}
 
 ## Value options
 

--- a/docs/sources/panels-visualizations/visualizations/heatmap/index.md
+++ b/docs/sources/panels-visualizations/visualizations/heatmap/index.md
@@ -21,7 +21,7 @@ weight: 100
 
 Heatmaps allow you to view histograms over time. For more information about histograms, refer to [Introduction to histograms and heatmaps][].
 
-![Screenshot of a heatmap](/static/img/docs/v43/heatmap_panel_cover.jpg)
+![A heatmap visualization](/static/img/docs/v43/heatmap_panel_cover.jpg)
 
 ## Calculate from data
 

--- a/docs/sources/panels-visualizations/visualizations/heatmap/index.md
+++ b/docs/sources/panels-visualizations/visualizations/heatmap/index.md
@@ -21,7 +21,7 @@ weight: 100
 
 Heatmaps allow you to view histograms over time. For more information about histograms, refer to [Introduction to histograms and heatmaps][].
 
-![](/static/img/docs/v43/heatmap_panel_cover.jpg)
+![Screenshot of a heatmap](/static/img/docs/v43/heatmap_panel_cover.jpg)
 
 ## Calculate from data
 

--- a/docs/sources/shared/visualizations/disconnect-values.md
+++ b/docs/sources/shared/visualizations/disconnect-values.md
@@ -6,7 +6,7 @@ title: Disconnect values
 
 Choose whether to set a threshold above which values in the data should be disconnected.
 
-{{< figure src="/media/docs/grafana/screenshot-grafana-10-1-disconnect-values.png" max-width="750px" >}}
+{{< figure src="/media/docs/grafana/screenshot-grafana-10-1-disconnect-values.png" max-width="750px" alt="Disconnect values options" >}}
 
 - **Never:** Time series data points in the the data are never disconnected.
 - **Threshold:** Specify a threshold above which values in the data are disconnected. This can be useful when desired values in the data are of a known size and/or within a known range, and values outside this range should no longer be connected.

--- a/docs/sources/whatsnew/whats-new-in-v10-2.md
+++ b/docs/sources/whatsnew/whats-new-in-v10-2.md
@@ -327,7 +327,7 @@ The **Add field from calculation** transformation has been updated.
 - **Floor (floor)** - Returns the largest integer less than or equal to a given expression.
 - **Ceiling (ceil)** - Returns the smallest integer greater than or equal to a given expression.
 
-{{< figure src="/media/docs/grafana/transformations/unary-operation.png" >}}
+{{< figure src="/media/docs/grafana/transformations/unary-operation.png" alt="Unary operation options" >}}
 
 Also, **Row index** can now show the index as a percentage.
 

--- a/docs/sources/whatsnew/whats-new-in-v7-2.md
+++ b/docs/sources/whatsnew/whats-new-in-v7-2.md
@@ -132,7 +132,7 @@ A new layout option is available when rendering reports: the grid layout. With t
 
 The grid layout is also available for the [Export dashboard as PDF]({{< relref "../dashboards/share-dashboards-panels#export-dashboard-as-pdf" >}}) feature.
 
-{{< figure src="/static/img/docs/enterprise/reports_grid_landscape_preview.png" max-width="500px" class="docs-image--no-shadow" >}}
+{{< figure src="/static/img/docs/enterprise/reports_grid_landscape_preview.png" max-width="500px" class="docs-image--no-shadow" alt="Report in grid layout" >}}
 
 ### Report time range
 

--- a/docs/sources/whatsnew/whats-new-in-v7-4.md
+++ b/docs/sources/whatsnew/whats-new-in-v7-4.md
@@ -169,7 +169,7 @@ Many thanks to [mtanda](https://github.com/mtanda) this contribution!
 
 Google Cloud Monitoring data source ships with pre-configured dashboards for some of the most popular GCP services. These curated dashboards are based on similar dashboards in the GCP dashboard samples repository. In this release, we have expanded the set of pre-configured dashboards.
 
-{{< figure src="/static/img/docs/google-cloud-monitoring/curated-dashboards-7-4.png" max-width= "650px" >}}
+{{< figure src="/static/img/docs/google-cloud-monitoring/curated-dashboards-7-4.png" max-width= "650px" alt="Google Cloud Monitoring pre-configured dashboards" >}}
 
 If you want to customize a dashboard, we recommend that you save it under a different name. Otherwise the dashboard will be overwritten when a new version of the dashboard is released.
 


### PR DESCRIPTION
Adds missing alt text for several images in the following areas:

- Dashboards
- Panels and visualizations
- What's new
