### PR TITLE
Update _index.md

### DIFF
--- a/docs/sources/datasources/elasticsearch/_index.md
+++ b/docs/sources/datasources/elasticsearch/_index.md
@@ -34,7 +34,6 @@ The following will help you get started working with Elasticsearch and Grafana:
 
 This data source supports these versions of Elasticsearch:
 
-- v7.16+
 - v8.x
 
 Our maintenance policy for Elasticsearch data source is aligned with the [Elastic Product End of Life Dates](https://www.elastic.co/support/eol) and we ensure proper functionality for supported versions. If you are using an Elasticsearch with version that is past its end-of-life (EOL), you can still execute queries, but you will receive a notification in the query builder indicating that the version of Elasticsearch you are using is no longer supported. It's important to note that in such cases, we do not guarantee the correctness of the functionality, and we will not be addressing any related issues.


### PR DESCRIPTION
Elasticsearch 7.6 is no longer supported and is EOL. Per our maintenance policy, we are no longer supporting 7.6 in the Elasticsearch datasource and will send users a notification that they are no longer supported.

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
