### PR TITLE
alerting: Add tests for hooks

### DIFF
--- a/pkg/services/ngalert/api/hooks_test.go
+++ b/pkg/services/ngalert/api/hooks_test.go
@@ -1,0 +1,128 @@
+package api
+
+import (
+	"net/http"
+	"net/url"
+	"testing"
+
+	"github.com/grafana/grafana/pkg/api/response"
+	"github.com/grafana/grafana/pkg/infra/log"
+	contextmodel "github.com/grafana/grafana/pkg/services/contexthandler/model"
+	"github.com/grafana/grafana/pkg/web"
+	"github.com/stretchr/testify/require"
+)
+
+func TestHooks(t *testing.T) {
+	t.Run("Hooks", func(t *testing.T) {
+		t.Run("yields handlers for paths with hooks", func(t *testing.T) {
+			hooks := NewHooks(log.NewNopLogger())
+			invoked := false
+			hook := func(*contextmodel.ReqContext) response.Response { invoked = true; return nil }
+
+			hooks.Set("/some/path", hook)
+			reqURL, _ := url.Parse("http://domain.test/some/path")
+			handler, ok := hooks.Get(reqURL)
+
+			require.True(t, ok, "hooks did not contain a matching hook for path")
+			require.False(t, invoked, "hook was invoked earlier than expected")
+			handler(nil)
+			require.True(t, invoked, "the hook returned by get() was not invoked as expected")
+		})
+
+		t.Run("yields no handlers for paths without hooks", func(t *testing.T) {
+			hooks := NewHooks(log.NewNopLogger())
+			hook := func(*contextmodel.ReqContext) response.Response { return nil }
+
+			hooks.Set("/some/path", hook)
+			reqURL, _ := url.Parse("http://domain.test/does/not/match")
+			handler, ok := hooks.Get(reqURL)
+
+			require.False(t, ok, "hooks returned a hook when we expected it not to")
+			require.Nil(t, handler)
+		})
+
+		t.Run("hooks do not match routes with additional subpaths", func(t *testing.T) {
+			hooks := NewHooks(log.NewNopLogger())
+			hook := func(*contextmodel.ReqContext) response.Response { return nil }
+
+			hooks.Set("/some/path", hook)
+			reqURL, _ := url.Parse("http://domain.test/some/path/with/more")
+			handler, ok := hooks.Get(reqURL)
+
+			require.False(t, ok, "hooks returned a hook when we expected it not to")
+			require.Nil(t, handler)
+		})
+
+		t.Run("hooks match routes with query parameters", func(t *testing.T) {
+			hooks := NewHooks(log.NewNopLogger())
+			invoked := false
+			hook := func(*contextmodel.ReqContext) response.Response { invoked = true; return nil }
+
+			hooks.Set("/some/path", hook)
+			reqURL, _ := url.Parse("http://domain.test/some/path?query=param")
+			handler, ok := hooks.Get(reqURL)
+
+			require.True(t, ok, "hooks did not contain a matching hook for path")
+			require.False(t, invoked, "hook was invoked earlier than expected")
+			handler(nil)
+			require.True(t, invoked, "the hook returned by get() was not invoked as expected")
+		})
+
+		t.Run("hooks do not match routes with path variables", func(t *testing.T) {
+			hooks := NewHooks(log.NewNopLogger())
+			hook := func(*contextmodel.ReqContext) response.Response { return nil }
+
+			hooks.Set("/some/{value}", hook)
+			reqURL, _ := url.Parse("http://domain.test/some/123")
+			handler, ok := hooks.Get(reqURL)
+
+			require.False(t, ok, "hooks returned a hook when we expected it not to")
+			require.Nil(t, handler)
+		})
+	})
+
+	t.Run("Wrap", func(t *testing.T) {
+		t.Run("invokes hooks if one is defined", func(t *testing.T) {
+			defaultInvoked := false
+			defaultHandler := func(*contextmodel.ReqContext) response.Response { defaultInvoked = true; return nil }
+			hookInvoked := false
+			hookHandler := func(*contextmodel.ReqContext) response.Response { hookInvoked = true; return nil }
+			hooks := NewHooks(log.NewNopLogger())
+			hooks.Set("/some/path", hookHandler)
+
+			composed := hooks.Wrap(defaultHandler)
+			req := createReqWithURL("http://domain.test/some/path")
+			composed(req)
+
+			require.True(t, hookInvoked, "hook was expected to be invoked, but it was not")
+			require.False(t, defaultInvoked, "default handler was invoked, but it should not have been")
+		})
+
+		t.Run("does not invoke hooks if path has none defined", func(t *testing.T) {
+			defaultInvoked := false
+			defaultHandler := func(*contextmodel.ReqContext) response.Response { defaultInvoked = true; return nil }
+			hookInvoked := false
+			hookHandler := func(*contextmodel.ReqContext) response.Response { hookInvoked = true; return nil }
+			hooks := NewHooks(log.NewNopLogger())
+			hooks.Set("/some/path", hookHandler)
+
+			composed := hooks.Wrap(defaultHandler)
+			req := createReqWithURL("http://domain.test/does/not/match")
+			composed(req)
+
+			require.False(t, hookInvoked, "hook was invoked, but it should not have been")
+			require.True(t, defaultInvoked, "default handler was expected to be invoked, but it was not")
+		})
+	})
+}
+
+func createReqWithURL(setupURL string) *contextmodel.ReqContext {
+	reqURL, _ := url.Parse(setupURL)
+	return &contextmodel.ReqContext{
+		Context: &web.Context{
+			Req: &http.Request{
+				URL: reqURL,
+			},
+		},
+	}
+}


### PR DESCRIPTION
**What is this feature?**

Adds test coverage for the behavior of ngalert's route hooks.

These tests also serve as developer documentation for its exact behavior. TLDR, it does support query params, it does not support mux-style path variables.

**Why do we need this feature?**

Tests an untested component, that other pieces use to integrate. Breakages will become more obvious.

**Which issue(s) does this PR fix?**:
n/a

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle.
- [x] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
