### PR TITLE
OptionsPicker: Use fuzzy search and improve ranking of matches

### DIFF
--- a/package.json
+++ b/package.json
@@ -260,7 +260,7 @@
     "@grafana/schema": "workspace:*",
     "@grafana/ui": "workspace:*",
     "@kusto/monaco-kusto": "^7.4.0",
-    "@leeoniya/ufuzzy": "1.0.12",
+    "@leeoniya/ufuzzy": "1.0.13",
     "@lezer/common": "1.0.2",
     "@lezer/highlight": "1.1.3",
     "@lezer/lr": "1.3.3",

--- a/package.json
+++ b/package.json
@@ -260,7 +260,7 @@
     "@grafana/schema": "workspace:*",
     "@grafana/ui": "workspace:*",
     "@kusto/monaco-kusto": "^7.4.0",
-    "@leeoniya/ufuzzy": "1.0.8",
+    "@leeoniya/ufuzzy": "1.0.12",
     "@lezer/common": "1.0.2",
     "@lezer/highlight": "1.1.3",
     "@lezer/lr": "1.3.3",

--- a/packages/grafana-flamegraph/package.json
+++ b/packages/grafana-flamegraph/package.json
@@ -46,7 +46,7 @@
     "@emotion/css": "11.11.2",
     "@grafana/data": "10.3.0-pre",
     "@grafana/ui": "10.3.0-pre",
-    "@leeoniya/ufuzzy": "1.0.12",
+    "@leeoniya/ufuzzy": "1.0.13",
     "d3": "^7.8.5",
     "lodash": "4.17.21",
     "react": "18.2.0",

--- a/packages/grafana-flamegraph/package.json
+++ b/packages/grafana-flamegraph/package.json
@@ -46,7 +46,7 @@
     "@emotion/css": "11.11.2",
     "@grafana/data": "10.3.0-pre",
     "@grafana/ui": "10.3.0-pre",
-    "@leeoniya/ufuzzy": "1.0.8",
+    "@leeoniya/ufuzzy": "1.0.12",
     "d3": "^7.8.5",
     "lodash": "4.17.21",
     "react": "18.2.0",

--- a/packages/grafana-ui/package.json
+++ b/packages/grafana-ui/package.json
@@ -53,7 +53,7 @@
     "@grafana/e2e-selectors": "10.3.0-pre",
     "@grafana/faro-web-sdk": "1.2.1",
     "@grafana/schema": "10.3.0-pre",
-    "@leeoniya/ufuzzy": "1.0.12",
+    "@leeoniya/ufuzzy": "1.0.13",
     "@monaco-editor/react": "4.6.0",
     "@popperjs/core": "2.11.8",
     "@react-aria/button": "3.8.0",

--- a/packages/grafana-ui/package.json
+++ b/packages/grafana-ui/package.json
@@ -53,7 +53,7 @@
     "@grafana/e2e-selectors": "10.3.0-pre",
     "@grafana/faro-web-sdk": "1.2.1",
     "@grafana/schema": "10.3.0-pre",
-    "@leeoniya/ufuzzy": "1.0.8",
+    "@leeoniya/ufuzzy": "1.0.12",
     "@monaco-editor/react": "4.6.0",
     "@popperjs/core": "2.11.8",
     "@react-aria/button": "3.8.0",

--- a/public/app/features/commandPalette/useMatches.ts
+++ b/public/app/features/commandPalette/useMatches.ts
@@ -210,9 +210,9 @@ function useInternalMatches(filtered: ActionImpl[], search: string): Match[] {
     } else {
       const termCount = ufuzzy.split(throttledSearch).length;
       const infoThresh = Infinity;
-      const oooSearch = termCount < 5;
+      const oooLimit = termCount < 5 ? 4 : 0;
 
-      const [, info, order] = ufuzzy.search(haystack, throttledSearch, oooSearch, infoThresh);
+      const [, info, order] = ufuzzy.search(haystack, throttledSearch, oooLimit, infoThresh);
 
       if (info && order) {
         for (let orderIndex = 0; orderIndex < order.length; orderIndex++) {

--- a/public/app/features/explore/Logs/utils/uFuzzy.ts
+++ b/public/app/features/explore/Logs/utils/uFuzzy.ts
@@ -10,7 +10,7 @@ const uf = new uFuzzy({
 });
 
 export function fuzzySearch(haystack: string[], query: string, dispatcher: (data: string[][]) => void) {
-  const [idxs, info, order] = uf.search(haystack, query, false, 1e5);
+  const [idxs, info, order] = uf.search(haystack, query, 0, 1e5);
 
   let haystackOrder: string[] = [];
   let matchesSet: Set<string> = new Set();

--- a/public/app/features/search/service/frontend.ts
+++ b/public/app/features/search/service/frontend.ts
@@ -116,7 +116,7 @@ class FullResultCache {
     // eslint-disable-next-line
     const values = allFields.map((v) => [] as any[]); // empty value for each field
 
-    let [idxs, info, order] = this.ufuzzy.search(haystack, query, true);
+    let [idxs, info, order] = this.ufuzzy.search(haystack, query, 5);
 
     for (let c = 0; c < allFields.length; c++) {
       let src = allFields[c].values;

--- a/public/app/features/variables/pickers/OptionsPicker/reducer.test.ts
+++ b/public/app/features/variables/pickers/OptionsPicker/reducer.test.ts
@@ -774,6 +774,39 @@ describe('optionsPickerReducer', () => {
     });
   });
 
+  describe('when similar data for updateOptionsAndFilter', () => {
+    it('should properly rank by match quality', () => {
+      const searchQuery = 'C';
+
+      const options: VariableOption[] = 'A AA AB AC BC C CD'.split(' ').map((v) => ({
+        selected: false,
+        text: v,
+        value: v,
+      }));
+
+      const expect: VariableOption[] = 'C CD AC BC'.split(' ').map((v) => ({
+        selected: false,
+        text: v,
+        value: v,
+      }));
+
+      const { initialState } = getVariableTestContext({
+        queryValue: searchQuery,
+      });
+
+      reducerTester<OptionsPickerState>()
+        .givenReducer(optionsPickerReducer, cloneDeep(initialState))
+        .whenActionIsDispatched(updateOptionsAndFilter(options))
+        .thenStateShouldEqual({
+          ...cloneDeep(initialState),
+          options: expect,
+          selectedValues: [],
+          queryValue: 'C',
+          highlightIndex: 0,
+        });
+    });
+  });
+
   describe('when large data for updateOptionsFromSearch is dispatched and variable has searchFilter', () => {
     it('then state should be correct', () => {
       const searchQuery = '__searchFilter';

--- a/public/app/features/variables/pickers/OptionsPicker/reducer.test.ts
+++ b/public/app/features/variables/pickers/OptionsPicker/reducer.test.ts
@@ -761,12 +761,19 @@ describe('optionsPickerReducer', () => {
         queryValue: searchQuery,
       });
 
+      const expectedFuzzy = [
+        11256, 10256, 11056, 11156, 11206, 11216, 11226, 11236, 11246, 1125, 11250, 11251, 11252, 11253, 11254, 11255,
+        11257, 11258, 11259, 1126, 11260, 11261, 11262, 11263, 11264, 11265, 11266, 11267, 11268, 11269, 11276, 11286,
+        11296, 11356, 11456, 11526, 11556, 1156, 11560, 11561, 11562, 11563, 11564, 11565, 11566, 11567, 11568, 11569,
+        11656, 11756, 11856, 11956, 12156, 12256, 1256, 11125, 11126,
+      ].map((index) => ({ text: `option:${index}`, value: `option:${index}`, selected: false }));
+
       reducerTester<OptionsPickerState>()
         .givenReducer(optionsPickerReducer, cloneDeep(initialState))
         .whenActionIsDispatched(updateOptionsAndFilter(options))
         .thenStateShouldEqual({
           ...cloneDeep(initialState),
-          options: [{ text: 'option:11256', value: 'option:11256', selected: false }],
+          options: expectedFuzzy,
           selectedValues: [],
           queryValue: 'option:11256',
           highlightIndex: 0,

--- a/public/app/features/variables/pickers/OptionsPicker/reducer.test.ts
+++ b/public/app/features/variables/pickers/OptionsPicker/reducer.test.ts
@@ -761,19 +761,12 @@ describe('optionsPickerReducer', () => {
         queryValue: searchQuery,
       });
 
-      const expectedFuzzy = [
-        11256, 10256, 11056, 11156, 11206, 11216, 11226, 11236, 11246, 1125, 11250, 11251, 11252, 11253, 11254, 11255,
-        11257, 11258, 11259, 1126, 11260, 11261, 11262, 11263, 11264, 11265, 11266, 11267, 11268, 11269, 11276, 11286,
-        11296, 11356, 11456, 11526, 11556, 1156, 11560, 11561, 11562, 11563, 11564, 11565, 11566, 11567, 11568, 11569,
-        11656, 11756, 11856, 11956, 12156, 12256, 1256, 11125, 11126,
-      ].map((index) => ({ text: `option:${index}`, value: `option:${index}`, selected: false }));
-
       reducerTester<OptionsPickerState>()
         .givenReducer(optionsPickerReducer, cloneDeep(initialState))
         .whenActionIsDispatched(updateOptionsAndFilter(options))
         .thenStateShouldEqual({
           ...cloneDeep(initialState),
-          options: expectedFuzzy,
+          options: [{ text: 'option:11256', value: 'option:11256', selected: false }],
           selectedValues: [],
           queryValue: 'option:11256',
           highlightIndex: 0,

--- a/public/app/features/variables/pickers/OptionsPicker/reducer.ts
+++ b/public/app/features/variables/pickers/OptionsPicker/reducer.ts
@@ -1,5 +1,6 @@
+import uFuzzy from '@leeoniya/ufuzzy';
 import { createSlice, PayloadAction } from '@reduxjs/toolkit';
-import { cloneDeep, isString, trimStart } from 'lodash';
+import { cloneDeep, isString } from 'lodash';
 
 import { containsSearchFilter } from '@grafana/data';
 
@@ -33,6 +34,14 @@ export const initialOptionPickerState: OptionsPickerState = {
 };
 
 export const OPTIONS_LIMIT = 1000;
+
+const ufuzzy = new uFuzzy({
+  intraMode: 1,
+  intraIns: 1,
+  intraSub: 1,
+  intraTrn: 1,
+  intraDel: 1,
+});
 
 const optionsToRecord = (options: VariableOption[]): Record<string, VariableOption> => {
   if (!Array.isArray(options)) {
@@ -237,14 +246,28 @@ const optionsPickerSlice = createSlice({
       return state;
     },
     updateOptionsAndFilter: (state, action: PayloadAction<VariableOption[]>): OptionsPickerState => {
-      const searchQuery = trimStart((state.queryValue ?? '').toLowerCase());
+      const needle = state.queryValue;
 
-      state.options = action.payload.filter((option) => {
-        const optionsText = option.text ?? '';
-        const text = Array.isArray(optionsText) ? optionsText.toString() : optionsText;
-        return text.toLowerCase().indexOf(searchQuery) !== -1;
-      });
+      // with current API, not seeing a way to cache this on state using action.payload's uniqueness
+      // since it's recreated and includes selected state on each item :(
+      const haystack = action.payload.map(({ text }) => (Array.isArray(text) ? text.toString() : text));
 
+      const [idxs, info, order] = ufuzzy.search(haystack, needle, true);
+
+      let opts: VariableOption[];
+
+      if (info && order) {
+        opts = order.map((idx) => action.payload[info.idx[idx]]);
+      } else if (idxs) {
+        opts = idxs.map((idx) => action.payload[idx]);
+      } else {
+        opts = action.payload;
+      }
+
+      // always sort $__all to the top, even if exact match exists?
+      opts.sort((a, b) => (a.value === '$__all' ? -1 : 0) - (b.value === '$__all' ? -1 : 0));
+
+      state.options = opts;
       state.highlightIndex = 0;
 
       return applyStateChanges(state, updateDefaultSelection, updateOptions);

--- a/public/app/features/variables/pickers/OptionsPicker/reducer.ts
+++ b/public/app/features/variables/pickers/OptionsPicker/reducer.ts
@@ -252,7 +252,7 @@ const optionsPickerSlice = createSlice({
       // since it's recreated and includes selected state on each item :(
       const haystack = action.payload.map(({ text }) => (Array.isArray(text) ? text.toString() : text));
 
-      const [idxs, info, order] = ufuzzy.search(haystack, needle, true);
+      const [idxs, info, order] = ufuzzy.search(haystack, needle, 5);
 
       let opts: VariableOption[];
 

--- a/public/app/plugins/datasource/prometheus/querybuilder/components/metrics-modal/uFuzzy.ts
+++ b/public/app/plugins/datasource/prometheus/querybuilder/components/metrics-modal/uFuzzy.ts
@@ -10,7 +10,7 @@ const uf = new uFuzzy({
 });
 
 export function fuzzySearch(haystack: string[], query: string, dispatcher: (data: string[][]) => void) {
-  const [idxs, info, order] = uf.search(haystack, query, false, 1e5);
+  const [idxs, info, order] = uf.search(haystack, query, 0, 1e5);
 
   let haystackOrder: string[] = [];
   let matchesSet: Set<string> = new Set();

--- a/yarn.lock
+++ b/yarn.lock
@@ -3169,7 +3169,7 @@ __metadata:
     "@grafana/data": "npm:10.3.0-pre"
     "@grafana/tsconfig": "npm:^1.2.0-rc1"
     "@grafana/ui": "npm:10.3.0-pre"
-    "@leeoniya/ufuzzy": "npm:1.0.8"
+    "@leeoniya/ufuzzy": "npm:1.0.12"
     "@rollup/plugin-node-resolve": "npm:15.2.3"
     "@testing-library/jest-dom": "npm:^6.1.2"
     "@testing-library/react": "npm:14.0.0"
@@ -3366,7 +3366,7 @@ __metadata:
     "@grafana/faro-web-sdk": "npm:1.2.1"
     "@grafana/schema": "npm:10.3.0-pre"
     "@grafana/tsconfig": "npm:^1.2.0-rc1"
-    "@leeoniya/ufuzzy": "npm:1.0.8"
+    "@leeoniya/ufuzzy": "npm:1.0.12"
     "@monaco-editor/react": "npm:4.6.0"
     "@popperjs/core": "npm:2.11.8"
     "@react-aria/button": "npm:3.8.0"
@@ -4177,10 +4177,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@leeoniya/ufuzzy@npm:1.0.8":
-  version: 1.0.8
-  resolution: "@leeoniya/ufuzzy@npm:1.0.8"
-  checksum: b5068593022e322e395e7cb2c134b4b040375165d0953d3f40f8dcd4bb84fe56c39c08ee0dede056b4b8ed1060d39f5bf6c821dab4ae271e8e5befc81c33d7c6
+"@leeoniya/ufuzzy@npm:1.0.12":
+  version: 1.0.12
+  resolution: "@leeoniya/ufuzzy@npm:1.0.12"
+  checksum: c3ccb75a8ac83e0914045cd5a3c9a10b6e90b45e91403c17b3cef99199d3de5d40158306aeb9100464910c3f874b6da05810c8f36d4f05e63765ef55c6fd2f02
   languageName: node
   linkType: hard
 
@@ -17337,7 +17337,7 @@ __metadata:
     "@grafana/tsconfig": "npm:^1.3.0-rc1"
     "@grafana/ui": "workspace:*"
     "@kusto/monaco-kusto": "npm:^7.4.0"
-    "@leeoniya/ufuzzy": "npm:1.0.8"
+    "@leeoniya/ufuzzy": "npm:1.0.12"
     "@lezer/common": "npm:1.0.2"
     "@lezer/highlight": "npm:1.1.3"
     "@lezer/lr": "npm:1.3.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3169,7 +3169,7 @@ __metadata:
     "@grafana/data": "npm:10.3.0-pre"
     "@grafana/tsconfig": "npm:^1.2.0-rc1"
     "@grafana/ui": "npm:10.3.0-pre"
-    "@leeoniya/ufuzzy": "npm:1.0.12"
+    "@leeoniya/ufuzzy": "npm:1.0.13"
     "@rollup/plugin-node-resolve": "npm:15.2.3"
     "@testing-library/jest-dom": "npm:^6.1.2"
     "@testing-library/react": "npm:14.0.0"
@@ -3366,7 +3366,7 @@ __metadata:
     "@grafana/faro-web-sdk": "npm:1.2.1"
     "@grafana/schema": "npm:10.3.0-pre"
     "@grafana/tsconfig": "npm:^1.2.0-rc1"
-    "@leeoniya/ufuzzy": "npm:1.0.12"
+    "@leeoniya/ufuzzy": "npm:1.0.13"
     "@monaco-editor/react": "npm:4.6.0"
     "@popperjs/core": "npm:2.11.8"
     "@react-aria/button": "npm:3.8.0"
@@ -4177,10 +4177,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@leeoniya/ufuzzy@npm:1.0.12":
-  version: 1.0.12
-  resolution: "@leeoniya/ufuzzy@npm:1.0.12"
-  checksum: c3ccb75a8ac83e0914045cd5a3c9a10b6e90b45e91403c17b3cef99199d3de5d40158306aeb9100464910c3f874b6da05810c8f36d4f05e63765ef55c6fd2f02
+"@leeoniya/ufuzzy@npm:1.0.13":
+  version: 1.0.13
+  resolution: "@leeoniya/ufuzzy@npm:1.0.13"
+  checksum: 2222357f136764674e84d1b85ae2b4436840a270f75598c902e528ccfbc3d91b638f9e3b6d16e115e98eaffa4bcd9c71db909b126cf4ac3102fa14339d16cf4b
   languageName: node
   linkType: hard
 
@@ -17337,7 +17337,7 @@ __metadata:
     "@grafana/tsconfig": "npm:^1.3.0-rc1"
     "@grafana/ui": "workspace:*"
     "@kusto/monaco-kusto": "npm:^7.4.0"
-    "@leeoniya/ufuzzy": "npm:1.0.12"
+    "@leeoniya/ufuzzy": "npm:1.0.13"
     "@lezer/common": "npm:1.0.2"
     "@lezer/highlight": "npm:1.1.3"
     "@lezer/lr": "npm:1.3.3"


### PR DESCRIPTION
Fixes #70629

this improves the filtering experience of template variables by allowing single-char typos and ranking exact and prefix matches higher than other substring matches. the previous strategy simply returned filtered results in original order, which is not great, especially with large filtered result lists where the exact "C" match below could be result 100 and not visible without a lot of scrolling.

<details><summary>ufuzzy-tpl-vars.json</summary>

```json
{
  "annotations": {
    "list": [
      {
        "builtIn": 1,
        "datasource": {
          "type": "grafana",
          "uid": "-- Grafana --"
        },
        "enable": true,
        "hide": true,
        "iconColor": "rgba(0, 211, 255, 1)",
        "name": "Annotations & Alerts",
        "type": "dashboard"
      }
    ]
  },
  "editable": true,
  "fiscalYearStartMonth": 0,
  "graphTooltip": 0,
  "id": 893,
  "links": [],
  "liveNow": false,
  "panels": [
    {
      "datasource": {
        "type": "grafana-testdata-datasource",
        "uid": "PD8C576611E62080A"
      },
      "fieldConfig": {
        "defaults": {
          "color": {
            "mode": "palette-classic"
          },
          "custom": {
            "axisBorderShow": false,
            "axisCenteredZero": false,
            "axisColorMode": "text",
            "axisLabel": "",
            "axisPlacement": "auto",
            "barAlignment": 0,
            "drawStyle": "line",
            "fillOpacity": 0,
            "gradientMode": "none",
            "hideFrom": {
              "legend": false,
              "tooltip": false,
              "viz": false
            },
            "insertNulls": false,
            "lineInterpolation": "linear",
            "lineWidth": 1,
            "pointSize": 5,
            "scaleDistribution": {
              "type": "linear"
            },
            "showPoints": "auto",
            "spanNulls": false,
            "stacking": {
              "group": "A",
              "mode": "none"
            },
            "thresholdsStyle": {
              "mode": "off"
            }
          },
          "mappings": [],
          "thresholds": {
            "mode": "absolute",
            "steps": [
              {
                "color": "green",
                "value": null
              },
              {
                "color": "red",
                "value": 80
              }
            ]
          }
        },
        "overrides": []
      },
      "gridPos": {
        "h": 8,
        "w": 12,
        "x": 0,
        "y": 0
      },
      "id": 1,
      "options": {
        "legend": {
          "calcs": [],
          "displayMode": "list",
          "placement": "bottom",
          "showLegend": true
        },
        "tooltip": {
          "mode": "single",
          "sort": "none"
        }
      },
      "targets": [
        {
          "datasource": {
            "type": "grafana-testdata-datasource",
            "uid": "PD8C576611E62080A"
          },
          "refId": "A",
          "scenarioId": "random_walk",
          "seriesCount": 1
        }
      ],
      "title": "Panel Title",
      "type": "timeseries"
    }
  ],
  "refresh": "",
  "schemaVersion": 39,
  "tags": [],
  "templating": {
    "list": [
      {
        "current": {
          "selected": false,
          "text": "A",
          "value": "A"
        },
        "hide": 0,
        "includeAll": false,
        "multi": false,
        "name": "query0",
        "options": [
          {
            "selected": true,
            "text": "A",
            "value": "A"
          },
          {
            "selected": false,
            "text": "AA",
            "value": "AA"
          },
          {
            "selected": false,
            "text": "AB",
            "value": "AB"
          },
          {
            "selected": false,
            "text": "AC",
            "value": "AC"
          },
          {
            "selected": false,
            "text": "BC",
            "value": "BC"
          },
          {
            "selected": false,
            "text": "C",
            "value": "C"
          },
          {
            "selected": false,
            "text": "CD",
            "value": "CD"
          }
        ],
        "query": "A, AA, AB, AC, BC, C, CD",
        "skipUrlSync": false,
        "type": "custom"
      }
    ]
  },
  "time": {
    "from": "now-6h",
    "to": "now"
  },
  "timepicker": {},
  "timezone": "",
  "title": "ufuzzy-tpl-vars",
  "uid": "bfaf9476-1a11-48cb-b63e-81aa49a28dfe",
  "version": 2,
  "weekStart": ""
}
```
</details>


before:

https://github.com/grafana/grafana/assets/43234/a86d73d2-57ea-45d9-850e-78524dc82be8

after:

https://github.com/grafana/grafana/assets/43234/20029db1-1c9d-4b03-8bea-9b2d3276b47b

---

**NOTE:** this does _not_ currently modify the behavior of [adhoc variables picker](https://github.com/grafana/grafana/tree/main/public/app/features/variables/adhoc/picker), which has much different internals and UI:

![image](https://github.com/grafana/grafana/assets/43234/388e9326-4134-4aba-9287-f9eb0af5a2e7)