### PR TITLE
sql: use logging functionality from plugin-sdk

### DIFF
--- a/pkg/tsdb/grafana-postgresql-datasource/postgres.go
+++ b/pkg/tsdb/grafana-postgresql-datasource/postgres.go
@@ -15,14 +15,14 @@ import (
 	"github.com/grafana/grafana-plugin-sdk-go/data"
 	"github.com/grafana/grafana-plugin-sdk-go/data/sqlutil"
 
-	"github.com/grafana/grafana/pkg/infra/log"
+	"github.com/grafana/grafana-plugin-sdk-go/backend/log"
 	"github.com/grafana/grafana/pkg/setting"
 	"github.com/grafana/grafana/pkg/tsdb/sqleng"
 	"github.com/grafana/grafana/pkg/tsdb/sqleng/proxyutil"
 )
 
 func ProvideService(cfg *setting.Cfg) *Service {
-	logger := log.New("tsdb.postgres")
+	logger := backend.NewLoggerWith("logger", "tsdb.postgres")
 	s := &Service{
 		tlsManager: newTLSManager(logger, cfg.DataPath),
 		logger:     logger,

--- a/pkg/tsdb/grafana-postgresql-datasource/postgres_test.go
+++ b/pkg/tsdb/grafana-postgresql-datasource/postgres_test.go
@@ -15,7 +15,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/setting"
 	"github.com/grafana/grafana/pkg/tsdb/sqleng"
 
@@ -141,7 +140,7 @@ func TestIntegrationGenerateConnectionString(t *testing.T) {
 		t.Run(tt.desc, func(t *testing.T) {
 			svc := Service{
 				tlsManager: &tlsTestManager{settings: tt.tlsSettings},
-				logger:     log.New("tsdb.postgres"),
+				logger:     backend.NewLoggerWith("logger", "tsdb.postgres"),
 			}
 
 			ds := sqleng.DataSourceInfo{
@@ -226,7 +225,7 @@ func TestIntegrationPostgres(t *testing.T) {
 
 	queryResultTransformer := postgresQueryResultTransformer{}
 
-	logger := log.New("postgres.test")
+	logger := backend.NewLoggerWith("logger", "postgres.test")
 	exe, err := sqleng.NewQueryDataHandler(cfg, config, &queryResultTransformer, newPostgresMacroEngine(dsInfo.JsonData.Timescaledb),
 		logger)
 

--- a/pkg/tsdb/grafana-postgresql-datasource/tlsmanager.go
+++ b/pkg/tsdb/grafana-postgresql-datasource/tlsmanager.go
@@ -9,8 +9,8 @@ import (
 	"sync"
 	"time"
 
+	"github.com/grafana/grafana-plugin-sdk-go/backend/log"
 	"github.com/grafana/grafana/pkg/infra/fs"
-	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/tsdb/sqleng"
 )
 

--- a/pkg/tsdb/grafana-postgresql-datasource/tlsmanager_test.go
+++ b/pkg/tsdb/grafana-postgresql-datasource/tlsmanager_test.go
@@ -9,7 +9,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/grafana/grafana/pkg/infra/log"
+	"github.com/grafana/grafana-plugin-sdk-go/backend"
+	"github.com/grafana/grafana-plugin-sdk-go/backend/log"
 	"github.com/grafana/grafana/pkg/setting"
 	"github.com/grafana/grafana/pkg/tsdb/sqleng"
 	"github.com/stretchr/testify/assert"
@@ -25,7 +26,7 @@ func TestDataSourceCacheManager(t *testing.T) {
 	cfg := setting.NewCfg()
 	cfg.DataPath = t.TempDir()
 	mng := tlsManager{
-		logger:          log.New("tsdb.postgres"),
+		logger:          backend.NewLoggerWith("logger", "tsdb.postgres"),
 		dsCacheInstance: datasourceCacheManager{locker: newLocker()},
 		dataPath:        cfg.DataPath,
 	}
@@ -242,7 +243,7 @@ func TestGetTLSSettings(t *testing.T) {
 			var settings tlsSettings
 			var err error
 			mng := tlsManager{
-				logger:          log.New("tsdb.postgres"),
+				logger:          backend.NewLoggerWith("logger", "tsdb.postgres"),
 				dsCacheInstance: datasourceCacheManager{locker: newLocker()},
 				dataPath:        cfg.DataPath,
 			}

--- a/pkg/tsdb/mssql/mssql.go
+++ b/pkg/tsdb/mssql/mssql.go
@@ -20,7 +20,7 @@ import (
 	mssql "github.com/microsoft/go-mssqldb"
 	_ "github.com/microsoft/go-mssqldb/azuread"
 
-	"github.com/grafana/grafana/pkg/infra/log"
+	"github.com/grafana/grafana-plugin-sdk-go/backend/log"
 	"github.com/grafana/grafana/pkg/setting"
 	"github.com/grafana/grafana/pkg/tsdb/mssql/utils"
 	"github.com/grafana/grafana/pkg/tsdb/sqleng"
@@ -40,7 +40,7 @@ const (
 )
 
 func ProvideService(cfg *setting.Cfg) *Service {
-	logger := log.New("tsdb.mssql")
+	logger := backend.NewLoggerWith("logger", "tsdb.mssql")
 	return &Service{
 		im:     datasource.NewInstanceManager(newInstanceSettings(cfg, logger)),
 		logger: logger,
@@ -140,8 +140,16 @@ func newInstanceSettings(cfg *setting.Cfg, logger log.Logger) datasource.Instanc
 	}
 }
 
+// ParseURL is called also from pkg/api/datasource/validation.go,
+// which uses a different logging interface,
+// so we have a special minimal interface that is fulfilled by
+// both places.
+type DebugOnlyLogger interface {
+	Debug(msg string, args ...interface{})
+}
+
 // ParseURL tries to parse an MSSQL URL string into a URL object.
-func ParseURL(u string, logger log.Logger) (*url.URL, error) {
+func ParseURL(u string, logger DebugOnlyLogger) (*url.URL, error) {
 	logger.Debug("Parsing MSSQL URL", "url", u)
 
 	// Recognize ODBC connection strings like host\instance:1234

--- a/pkg/tsdb/mssql/mssql_test.go
+++ b/pkg/tsdb/mssql/mssql_test.go
@@ -15,7 +15,6 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/grafana/grafana/pkg/infra/db"
-	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/services/sqlstore/sqlutil"
 	"github.com/grafana/grafana/pkg/setting"
 	"github.com/grafana/grafana/pkg/tsdb/sqleng"
@@ -60,7 +59,7 @@ func TestMSSQL(t *testing.T) {
 		RowLimit:          1000000,
 	}
 
-	logger := log.New("mssql.test")
+	logger := backend.NewLoggerWith("logger", "mssql.test")
 
 	endpoint, err := sqleng.NewQueryDataHandler(setting.NewCfg(), config, &queryResultTransformer, newMssqlMacroEngine(), logger)
 	require.NoError(t, err)
@@ -1340,7 +1339,7 @@ func TestTransformQueryError(t *testing.T) {
 		{err: randomErr, expectedErr: randomErr},
 	}
 
-	logger := log.New("mssql.test")
+	logger := backend.NewLoggerWith("logger", "mssql.test")
 
 	for _, tc := range tests {
 		resultErr := transformer.TransformQueryError(logger, tc.err)
@@ -1477,7 +1476,7 @@ func TestGenerateConnectionString(t *testing.T) {
 		},
 	}
 
-	logger := log.New("mssql.test")
+	logger := backend.NewLoggerWith("logger", "mssql.test")
 
 	for _, tc := range testCases {
 		t.Run(tc.desc, func(t *testing.T) {

--- a/pkg/tsdb/mysql/macros.go
+++ b/pkg/tsdb/mysql/macros.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
 	"github.com/grafana/grafana-plugin-sdk-go/backend/gtime"
-	"github.com/grafana/grafana/pkg/infra/log"
+	"github.com/grafana/grafana-plugin-sdk-go/backend/log"
 	"github.com/grafana/grafana/pkg/setting"
 	"github.com/grafana/grafana/pkg/tsdb/sqleng"
 )

--- a/pkg/tsdb/mysql/macros_test.go
+++ b/pkg/tsdb/mysql/macros_test.go
@@ -7,7 +7,6 @@ import (
 	"time"
 
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
-	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/setting"
 
 	"github.com/stretchr/testify/require"
@@ -15,7 +14,7 @@ import (
 
 func TestMacroEngine(t *testing.T) {
 	engine := &mySQLMacroEngine{
-		logger:    log.New("test"),
+		logger:    backend.NewLoggerWith("logger", "test"),
 		userError: "inspect Grafana server log for details",
 	}
 	query := &backend.DataQuery{}
@@ -195,7 +194,7 @@ func TestMacroEngine(t *testing.T) {
 }
 
 func TestMacroEngineConcurrency(t *testing.T) {
-	engine := newMysqlMacroEngine(log.New("test"), setting.NewCfg())
+	engine := newMysqlMacroEngine(backend.NewLoggerWith("logger", "test"), setting.NewCfg())
 	query1 := backend.DataQuery{
 		JSON: []byte{},
 	}

--- a/pkg/tsdb/mysql/mysql.go
+++ b/pkg/tsdb/mysql/mysql.go
@@ -21,8 +21,8 @@ import (
 	"github.com/grafana/grafana-plugin-sdk-go/data"
 	"github.com/grafana/grafana-plugin-sdk-go/data/sqlutil"
 
+	"github.com/grafana/grafana-plugin-sdk-go/backend/log"
 	"github.com/grafana/grafana/pkg/infra/httpclient"
-	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/setting"
 	"github.com/grafana/grafana/pkg/tsdb/sqleng"
 	"github.com/grafana/grafana/pkg/tsdb/sqleng/proxyutil"
@@ -45,7 +45,7 @@ func characterEscape(s string, escapeChar string) string {
 }
 
 func ProvideService(cfg *setting.Cfg, httpClientProvider httpclient.Provider) *Service {
-	logger := log.New("tsdb.mysql")
+	logger := backend.NewLoggerWith("logger", "tsdb.mysql")
 	return &Service{
 		im:     datasource.NewInstanceManager(newInstanceSettings(cfg, logger)),
 		logger: logger,

--- a/pkg/tsdb/mysql/mysql_test.go
+++ b/pkg/tsdb/mysql/mysql_test.go
@@ -13,7 +13,6 @@ import (
 	"github.com/grafana/grafana-plugin-sdk-go/data"
 	"github.com/stretchr/testify/require"
 
-	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/setting"
 	"github.com/grafana/grafana/pkg/tsdb/sqleng"
 )
@@ -74,8 +73,7 @@ func TestIntegrationMySQL(t *testing.T) {
 
 	rowTransformer := mysqlQueryResultTransformer{}
 
-	logger := log.New("mysql.test")
-
+	logger := backend.NewLoggerWith("logger", "mysql.test")
 	exe, err := sqleng.NewQueryDataHandler(setting.NewCfg(), config, &rowTransformer, newMysqlMacroEngine(logger, setting.NewCfg()), logger)
 
 	require.NoError(t, err)

--- a/pkg/tsdb/sqleng/sql_engine.go
+++ b/pkg/tsdb/sqleng/sql_engine.go
@@ -17,7 +17,8 @@ import (
 	"github.com/grafana/grafana-plugin-sdk-go/data"
 	"github.com/grafana/grafana-plugin-sdk-go/data/sqlutil"
 
-	"github.com/grafana/grafana/pkg/infra/log"
+	"github.com/grafana/grafana-plugin-sdk-go/backend/log"
+	corelog "github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/setting"
 	"github.com/grafana/grafana/pkg/tsdb/intervalv2"
 	"github.com/grafana/grafana/pkg/util/errutil"
@@ -231,7 +232,7 @@ func (e *DataSourceHandler) executeQuery(query backend.DataQuery, wg *sync.WaitG
 
 	defer func() {
 		if r := recover(); r != nil {
-			logger.Error("ExecuteQuery panic", "error", r, "stack", log.Stack(1))
+			logger.Error("ExecuteQuery panic", "error", r, "stack", corelog.Stack(1))
 			if theErr, ok := r.(error); ok {
 				queryResult.dataResponse.Error = theErr
 			} else if theErrString, ok := r.(string); ok {

--- a/pkg/tsdb/sqleng/sql_engine_test.go
+++ b/pkg/tsdb/sqleng/sql_engine_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/grafana/grafana/pkg/infra/log"
+	"github.com/grafana/grafana-plugin-sdk-go/backend/log"
 	"github.com/grafana/grafana/pkg/tsdb/sqleng/util"
 )
 
@@ -397,14 +397,14 @@ func TestSQLEngine(t *testing.T) {
 			expectedErr                           error
 			expectQueryResultTransformerWasCalled bool
 		}{
-			{err: &net.OpError{Op: "Dial"}, expectedErr: ErrConnectionFailed, expectQueryResultTransformerWasCalled: false},
+			{err: &net.OpError{Op: "Dial", Err: fmt.Errorf("inner-error")}, expectedErr: ErrConnectionFailed, expectQueryResultTransformerWasCalled: false},
 			{err: randomErr, expectedErr: randomErr, expectQueryResultTransformerWasCalled: true},
 		}
 
 		for _, tc := range tests {
 			transformer := &testQueryResultTransformer{}
 			dp := DataSourceHandler{
-				log:                    log.New("test"),
+				log:                    backend.NewLoggerWith("logger", "test"),
 				queryResultTransformer: transformer,
 			}
 			resultErr := dp.TransformQueryError(dp.log, tc.err)


### PR DESCRIPTION
(solvers most of https://github.com/grafana/grafana/issues/77721)

to decouple the sql core datasources from core grafana, they should not import things from core grafana (and use plugin-sdk-go instead)

this PR adjusts the logging imports.

NOTE: we do not handle one import ( [log.Stack](https://github.com/grafana/grafana/blob/096a3b148f6137a77faed0f6b251d596854542c8/pkg/infra/log/log.go#L343-L347) ), we'll handle that in a separate PR

NOTE2: the mssql datasource's `ParseURL` function is called both from the datasource, but also called from `pkg/api/datasource/validation.go`, both places use different logger types, so i defined a minimal logger-interface (only debug-method), that is enough for that function, which is fulfilled by both caller places.


how to test:
- run grafana from main-branch, for example as a docker-image, with log-level-debug
- go to explore-mode, choose the chosen sql datasource and run a query. 
- observe that log-lines with `tsdb.mssql` (or `tsdb.mysq` or `tsdb.postgres`)  appear (one good example is turning off the database, and then running a query and seeing the query error log message)
- now do the same with this branch
- verify that the log-lines are the same
    - the logger-name is the same
    - for logs, where there is extra info in main-branch version, the extra info is there too in this version
    - verify that they are logfmt-formatted (not json-formatted)