### PR TITLE
Alerting: Fix UI inheriting mute timings from parent when calculating the polic…

### DIFF
--- a/public/app/features/alerting/unified/components/notification-policies/Policy.test.tsx
+++ b/public/app/features/alerting/unified/components/notification-policies/Policy.test.tsx
@@ -134,7 +134,7 @@ describe('Policy', () => {
     expect(within(secondPolicy).getByTestId('label-matchers')).toHaveTextContent(/^region \= EMEA$/);
     expect(within(secondPolicy).queryByTestId('continue-matching')).not.toBeInTheDocument();
     expect(within(secondPolicy).queryByTestId('mute-timings')).not.toBeInTheDocument();
-    expect(within(secondPolicy).getByTestId('inherited-properties')).toHaveTextContent('Inherited4 properties');
+    expect(within(secondPolicy).getByTestId('inherited-properties')).toHaveTextContent('Inherited3 properties');
 
     // third custom policy should be correct
     const thirdPolicy = customPolicies[2];

--- a/public/app/features/alerting/unified/utils/notification-policies.test.ts
+++ b/public/app/features/alerting/unified/utils/notification-policies.test.ts
@@ -1,11 +1,11 @@
 import { MatcherOperator, Route, RouteWithID } from 'app/plugins/datasource/alertmanager/types';
 
 import {
-  findMatchingRoutes,
-  normalizeRoute,
-  getInheritedProperties,
   computeInheritedTree,
+  findMatchingRoutes,
+  getInheritedProperties,
   matchLabels,
+  normalizeRoute,
 } from './notification-policies';
 
 import 'core-js/stable/structured-clone';
@@ -293,6 +293,21 @@ describe('getInheritedProperties()', () => {
       expect(childInherited).toHaveProperty('group_wait', '1m');
       expect(childInherited).toHaveProperty('group_interval', '2m');
     });
+  });
+  it('should not inherit mute timings from parent route', () => {
+    const parent: Route = {
+      receiver: 'PARENT',
+      group_by: ['parentLabel'],
+      mute_time_intervals: ['Mon-Fri 09:00-17:00'],
+    };
+
+    const child: Route = {
+      receiver: 'CHILD',
+      group_by: ['childLabel'],
+    };
+
+    const childInherited = getInheritedProperties(parent, child);
+    expect(childInherited).not.toHaveProperty('mute_time_intervals');
   });
 });
 

--- a/public/app/features/alerting/unified/utils/notification-policies.ts
+++ b/public/app/features/alerting/unified/utils/notification-policies.ts
@@ -169,7 +169,6 @@ function getInheritedProperties(
     'group_wait',
     'group_interval',
     'repeat_interval',
-    'mute_time_intervals',
   ]);
 
   // TODO how to solve this TypeScript mystery?


### PR DESCRIPTION

**What is this feature?**

The UI incorrectly assumes that mute timings are inherited from the parent in the notification policy tree. The current behavior in Prometheus is that routes do not inherit mute timings, despite existing issues related to this in the Prometheus GitHub repository. This discrepancy arises due to unclear documentation on this specific case.

From Prometheus documentation:

> A route block defines a node in a routing tree and its children. Its optional configuration parameters are inherited from its parent node if not set.

However, the reality is that mute timings are not applied in this inheritance.

⚠️ I think we should be alert to potential changes in this behavior considering that there are several open issues regarding this matter.

This PR fixes this wrong inheritance in the UI.

**Why do we need this feature?**

UI should be consistent with the Prometheus current behaviour.

**Who is this feature for?**

All users.


**Special notes for your reviewer:**

Before:

<img width="934" alt="Screenshot 2023-12-11 at 09 19 30" src="https://github.com/grafana/grafana/assets/33540275/6435806c-7402-443e-8189-e15dd03e3821">

After:


<img width="845" alt="Screenshot 2023-12-11 at 09 19 41" src="https://github.com/grafana/grafana/assets/33540275/1a9f443d-f843-4b96-a301-1f68aa9fa5bf">


Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
