### PR TITLE
SQL AI Query Builder

### DIFF
--- a/package.json
+++ b/package.json
@@ -432,7 +432,8 @@
     "react-split-pane@0.1.92": "patch:react-split-pane@npm:0.1.92#.yarn/patches/react-split-pane-npm-0.1.92-93dbf51dff.patch",
     "@storybook/blocks@7.4.5": "patch:@storybook/blocks@npm%3A7.4.5#./.yarn/patches/@storybook-blocks-npm-7.4.5-5a2374564a.patch",
     "history@4.10.1": "patch:history@npm%3A4.10.1#./.yarn/patches/history-npm-4.10.1-ee217563ae.patch",
-    "history@^4.9.0": "patch:history@npm%3A4.10.1#./.yarn/patches/history-npm-4.10.1-ee217563ae.patch"
+    "history@^4.9.0": "patch:history@npm%3A4.10.1#./.yarn/patches/history-npm-4.10.1-ee217563ae.patch",
+    "@grafana/experimental": "file:<link-to-local-experimental>"
   },
   "workspaces": {
     "packages": [

--- a/public/app/features/plugins/sql/components/QueryEditor.tsx
+++ b/public/app/features/plugins/sql/components/QueryEditor.tsx
@@ -10,6 +10,7 @@ import { SQLQuery, QueryRowFilter, SQLOptions } from '../types';
 import { haveColumns } from '../utils/sql.utils';
 
 import { QueryHeader, QueryHeaderProps } from './QueryHeader';
+import { AIEditor } from './ai-query-builder/AIEditor';
 import { RawEditor } from './query-editor-raw/RawEditor';
 import { VisualEditor } from './visual-query-builder/VisualEditor';
 
@@ -102,7 +103,7 @@ export function SqlQueryEditor({
 
       <Space v={0.5} />
 
-      {queryWithDefaults.editorMode !== EditorMode.Code && (
+      {queryWithDefaults.editorMode === EditorMode.Builder && (
         <VisualEditor
           db={db}
           query={queryWithDefaults}
@@ -123,6 +124,10 @@ export function SqlQueryEditor({
           onValidate={setIsQueryRunnable}
           range={range}
         />
+      )}
+
+      {queryWithDefaults.editorMode === EditorMode.AI && (
+        <AIEditor datasource={datasource} db={db} query={queryWithDefaults} onChange={onQueryChange} />
       )}
     </>
   );

--- a/public/app/features/plugins/sql/components/QueryHeader.tsx
+++ b/public/app/features/plugins/sql/components/QueryHeader.tsx
@@ -30,6 +30,7 @@ export interface QueryHeaderProps {
 const editorModes = [
   { label: 'Builder', value: EditorMode.Builder },
   { label: 'Code', value: EditorMode.Code },
+  { label: 'AI', value: EditorMode.AI },
 ];
 
 export function QueryHeader({
@@ -57,7 +58,7 @@ export function QueryHeader({
         });
       }
 
-      if (editorMode === EditorMode.Code) {
+      if (editorMode === EditorMode.Code && newEditorMode === EditorMode.Builder) {
         setShowConfirm(true);
         return;
       }

--- a/public/app/features/plugins/sql/components/ai-query-builder/AIEditor.tsx
+++ b/public/app/features/plugins/sql/components/ai-query-builder/AIEditor.tsx
@@ -1,0 +1,166 @@
+/* eslint-disable react-hooks/exhaustive-deps */
+
+/*
+ESLINT (useEffect bypass):
+i only want to update the query when the response changes.
+eslint doesn't like this, and wants me to add "onChange" and "query" to the dependency array.\this causes an infinite loop, so i'm disabling it.
+*/
+
+import { css } from '@emotion/css';
+import React, { useEffect, useState } from 'react';
+import { useCopyToClipboard } from 'react-use';
+
+import { GrafanaTheme2 } from '@grafana/data';
+import { EditorField, EditorRow, EditorRows } from '@grafana/experimental';
+import { Button, CodeEditor, Field, Icon, MultiSelect, Stack, TextArea, useStyles2 } from '@grafana/ui';
+import { MonacoOptionsWithGrafanaDefaults } from '@grafana/ui/src/components/Monaco/types';
+
+import { SqlDatasource } from '../../datasource/SqlDatasource';
+import { DB, SQLQuery } from '../../types';
+
+import { requestAI } from './helpers';
+
+interface AIEditorProps {
+  datasource: SqlDatasource;
+  db: DB;
+  query: SQLQuery;
+  onChange: (q: SQLQuery, processQuery: boolean) => void;
+}
+
+export const AIEditor = ({ datasource, db, query, onChange }: AIEditorProps) => {
+  const styles = useStyles2(getStyles);
+  const btnRef = React.useRef<HTMLButtonElement>(null);
+
+  const [tables, setTables] = useState<any[]>([]);
+  const [prompt, setPrompt] = useState<string>('');
+  const [selectedTables, setSelectedTables] = useState<any[]>([]);
+  const [showCopySuccess, setShowCopySuccess] = useState<boolean>(false);
+  const [showErrorMessage, setShowErrorMessage] = useState<boolean>(false);
+  const [response, setResponse] = useState<string>('');
+  const [_, copyToClipboard] = useCopyToClipboard();
+
+  const onMakeRequest = async () => {
+    if (!prompt || !selectedTables.length) {
+      setShowErrorMessage(true);
+      return;
+    }
+
+    const response = await requestAI(datasource.meta.name, db, prompt, selectedTables);
+    setResponse(response);
+  };
+
+  const onCopyResponse = () => {
+    copyToClipboard(response);
+    setShowCopySuccess(true);
+    setTimeout(() => {
+      setShowCopySuccess(false);
+    }, 2500);
+  };
+
+  useEffect(() => {
+    (async () => {
+      setTables(await transformTables(db));
+    })();
+  }, [db]);
+
+  useEffect(() => {
+    if (prompt && selectedTables.length) {
+      setShowErrorMessage(false);
+    }
+  }, [prompt, selectedTables]);
+
+  useEffect(() => {
+    onChange({ ...query, rawQuery: true, rawSql: response }, false);
+  }, [response]);
+
+  return (
+    <EditorRows>
+      <EditorRow>
+        <Stack gap={1.5} direction="column">
+          <EditorField label="Prompt" width={100} required>
+            <TextArea
+              value={prompt}
+              onChange={(e) => setPrompt(e.currentTarget.value)}
+              placeholder="Retrieve all data points with a value greater than 50"
+            />
+          </EditorField>
+          <EditorField label="Select tables" width={100} required>
+            <MultiSelect options={tables} onChange={(e) => setSelectedTables(e)} />
+          </EditorField>
+          <Stack gap={1} direction="row">
+            <Button size="sm" variant="primary" onClick={onMakeRequest}>
+              Ask AI
+            </Button>
+            <Button
+              ref={btnRef}
+              size="sm"
+              variant="secondary"
+              onClick={onCopyResponse}
+              disabled={!response}
+              tooltip={'Copy the AI generated query to clipboard'}
+            >
+              Copy to clipboard
+            </Button>
+            {showCopySuccess && (
+              <p className={styles.success}>
+                <Icon name="check" /> Response has been copied to clipboard.
+              </p>
+            )}
+            {showErrorMessage && (
+              <p className={styles.error}>
+                Submitting a request requires both a prompt and the selection of at least one table.
+              </p>
+            )}
+          </Stack>
+        </Stack>
+      </EditorRow>
+
+      <EditorRow>
+        <Field label={'AI generated query'} className={styles.preview}>
+          <CodeEditor
+            readOnly={true}
+            language="sql"
+            height={150}
+            value={response || ''}
+            monacoOptions={getMonacoOptions()}
+          />
+        </Field>
+      </EditorRow>
+    </EditorRows>
+  );
+};
+
+const transformTables = async (db: DB) => {
+  const tables = await db.tables();
+  return tables.map((table) => {
+    return { label: table, value: table };
+  });
+};
+
+const getMonacoOptions = (): MonacoOptionsWithGrafanaDefaults => {
+  return {
+    scrollbar: { vertical: 'hidden' },
+    scrollBeyondLastLine: false,
+    minimap: { enabled: false },
+  };
+};
+
+const getStyles = (theme: GrafanaTheme2) => {
+  return {
+    preview: css`
+      flex-grow: 1;
+    `,
+    success: css`
+      margin: 0px;
+      align-self: center;
+      color: ${theme.colors.success.text};
+      font-size: ${theme.typography.size.sm};
+    `,
+    error: css`
+      margin: 0px;
+      align-self: center;
+      color: ${theme.colors.error.text};
+      font-size: ${theme.typography.size.sm};
+    `,
+  };
+};

--- a/public/app/features/plugins/sql/components/ai-query-builder/helpers.ts
+++ b/public/app/features/plugins/sql/components/ai-query-builder/helpers.ts
@@ -1,0 +1,47 @@
+import { llms } from '@grafana/experimental';
+
+import { DB, SQLQuery } from '../../types';
+
+export async function requestAI(datasource: string, db: DB, prompt: string, selectedTables: any[]) {
+  const tables = [];
+
+  for (const item of selectedTables) {
+    const columns = await db.fields({ table: item.value } as SQLQuery);
+    tables.push({ tableName: item.value, columns: columns });
+  }
+
+  const response = await llms.openai.chatCompletions({
+    model: 'gpt-3.5-turbo',
+    messages: [{ role: 'system', content: getSystemPrompt(datasource, prompt, JSON.stringify(tables)) }],
+    temperature: 0,
+  });
+
+  return response.choices[0].message.content;
+}
+
+export function getSystemPrompt(datasource: string, prompt: string, tables: string) {
+  return `You are an SQL expert assistant.
+You will be given a prompt along with table and column names.
+You are to take the prompt and return a suggested query based on all provided data.
+Show only the suggested SQL Query.
+
+The users prompt is
+\`\`\`
+${prompt}
+\`\`\`
+
+The database tables and columns are as follows
+\`\`\`
+${tables}
+\`\`\`
+
+Rules:
+- You should only response with a single "valid" SQL statement.
+- All queries should end with a semi-colon.
+- The database used is ${datasource}, Make sure to use the correct syntax.
+- Do NOT invent table or column names, you must use only the data provided.
+- The year date is ${new Date()} make sure to keep this in mind when writing any queries that use dates.
+
+Answer:
+\`\`\``;
+}


### PR DESCRIPTION
**how to setup and test this feature:**
1. install the [grafana llm](https://grafana.com/grafana/plugins/grafana-llm-app/) plugin.
2. set your openai api credentials in the llm plugin.
3. go to the postgres datasource and you should see a new `AI` editormode.

---

**IMPORTANT:**
**due to the use of some exported types from grafana-experimental you will need to make a small change in that repo and link that to grafana.**

- inside of **grafana-experimental/src/sql-editor/types.ts** add this property `AI = 'ai'` to the `EditorMode` enum.
- build your modified version of grafana-experimental.
- back in grafana/grafana update the resolution in **package.json** to point at your local build of grafana-experimental.
- it is essential to run **yarn install** after updating the resolution path.
```
REPLACE:
"@grafana/experimental": "file:<link-to-local-experimental>"

TO SOMETHING LIKE:
"@grafana/experimental": "file:../../grafana-experimental"
```
---

<img width="2302" alt="Screenshot 2023-12-11 at 11 51 51" src="https://github.com/grafana/grafana/assets/34524710/ca96c1ce-c8d1-4ab6-a432-8f9516ccfa70">
