### PR TITLE
Loki: Fix values variable with unexisting label and stream selector

### DIFF
--- a/public/app/plugins/datasource/loki/datasource.test.ts
+++ b/public/app/plugins/datasource/loki/datasource.test.ts
@@ -484,6 +484,21 @@ describe('LokiDatasource', () => {
       return { ds };
     };
 
+    it('should return empty array if /series returns empty', async () => {
+      const ds = createLokiDatasource(templateSrvStub);
+      const spy = jest.spyOn(ds.languageProvider, 'fetchSeriesLabels').mockResolvedValue({});
+
+      const result = await ds.metricFindQuery({
+        refId: 'test',
+        type: LokiVariableQueryType.LabelValues,
+        stream: '{label1="value1"}',
+        label: 'label2',
+      });
+
+      expect(result).toEqual([]);
+      spy.mockClear();
+    });
+
     it('should return label names for Loki', async () => {
       const { ds } = getTestContext();
 

--- a/public/app/plugins/datasource/loki/datasource.ts
+++ b/public/app/plugins/datasource/loki/datasource.ts
@@ -685,6 +685,9 @@ export class LokiDatasource
     // If we have stream selector, use /series endpoint
     if (query.stream) {
       const result = await this.languageProvider.fetchSeriesLabels(query.stream, { timeRange });
+      if (!result[query.label]) {
+        return [];
+      }
       return result[query.label].map((value: string) => ({ text: value }));
     }
 


### PR DESCRIPTION
**What is this feature?**

Fixes a bug with dashboard variables where an additional stream selector is configured and the datasource returns an empty result set. In that case the object accessed by `result[query.label]` would lead to `undefined`, which subsequently would make the `.map` call fail.

