### PR TITLE
Loki: Fix `timeRange` missing in variable requests

### DIFF
--- a/public/app/plugins/datasource/loki/LokiVariableSupport.test.ts
+++ b/public/app/plugins/datasource/loki/LokiVariableSupport.test.ts
@@ -1,12 +1,18 @@
+import { firstValueFrom } from 'rxjs';
+
+import { dateTime, getDefaultTimeRange } from '@grafana/data';
+
 import { LokiVariableSupport } from './LokiVariableSupport';
+import { LokiDatasource } from './datasource';
 import { createLokiDatasource, createMetadataRequest } from './mocks';
 import { LokiVariableQueryType } from './types';
 
 describe('LokiVariableSupport', () => {
   let lokiVariableSupport: LokiVariableSupport;
+  let datasource: LokiDatasource;
 
   beforeEach(() => {
-    const datasource = createLokiDatasource();
+    datasource = createLokiDatasource();
     jest
       .spyOn(datasource, 'metadataRequest')
       .mockImplementation(
@@ -21,7 +27,11 @@ describe('LokiVariableSupport', () => {
 
   it('should return label names for Loki', async () => {
     // label_names()
-    const response = await lokiVariableSupport.execute({ refId: 'test', type: LokiVariableQueryType.LabelNames }, {});
+    const response = await lokiVariableSupport.execute(
+      { refId: 'test', type: LokiVariableQueryType.LabelNames },
+      {},
+      getDefaultTimeRange()
+    );
 
     expect(response).toEqual([{ text: 'label1' }, { text: 'label2' }]);
   });
@@ -34,7 +44,8 @@ describe('LokiVariableSupport', () => {
         type: LokiVariableQueryType.LabelValues,
         label: 'label1',
       },
-      {}
+      {},
+      getDefaultTimeRange()
     );
 
     expect(response).toEqual([{ text: 'value1' }, { text: 'value2' }]);
@@ -49,9 +60,54 @@ describe('LokiVariableSupport', () => {
         stream: '{label1="value1", label2="value2"}',
         label: 'label5',
       },
-      {}
+      {},
+      getDefaultTimeRange()
     );
 
     expect(response).toEqual([{ text: 'value5' }]);
+  });
+
+  it('should call `metricFindQuery` with the correct parameters', async () => {
+    // label_values({label1="value1", label2="value2"},label5)
+    const spy = jest.spyOn(datasource, 'metricFindQuery');
+    const range = getDefaultTimeRange();
+    const scopedVars = { foo: { value: 'bar' } };
+    range.from = dateTime(new Date('2020-01-01T00:00:00Z'));
+    range.to = dateTime(new Date('2020-01-01T01:00:00Z'));
+    await firstValueFrom(
+      lokiVariableSupport.query({
+        targets: [
+          {
+            refId: 'test',
+            type: LokiVariableQueryType.LabelValues,
+            stream: '{label1="value1", label2="value2"}',
+            label: 'label5',
+          },
+        ],
+        range,
+        scopedVars,
+        requestId: 'test',
+        interval: '1m',
+        intervalMs: 60000,
+        timezone: 'utc',
+        app: 'explore',
+        startTime: 0,
+      })
+    );
+
+    expect(spy).toHaveBeenCalledWith(
+      {
+        refId: 'test',
+        type: LokiVariableQueryType.LabelValues,
+        stream: '{label1="value1", label2="value2"}',
+        label: 'label5',
+      },
+      {
+        range,
+        scopedVars,
+      }
+    );
+
+    spy.mockRestore();
   });
 });

--- a/public/app/plugins/datasource/loki/LokiVariableSupport.ts
+++ b/public/app/plugins/datasource/loki/LokiVariableSupport.ts
@@ -1,7 +1,7 @@
 import { from, Observable } from 'rxjs';
 import { map } from 'rxjs/operators';
 
-import { CustomVariableSupport, DataQueryRequest, MetricFindValue, ScopedVars } from '@grafana/data';
+import { CustomVariableSupport, DataQueryRequest, MetricFindValue, ScopedVars, TimeRange } from '@grafana/data';
 
 import { LokiVariableQueryEditor } from './components/VariableQueryEditor';
 import { LokiDatasource } from './datasource';
@@ -14,12 +14,12 @@ export class LokiVariableSupport extends CustomVariableSupport<LokiDatasource, L
     super();
   }
 
-  async execute(query: LokiVariableQuery, scopedVars: ScopedVars) {
-    return this.datasource.metricFindQuery(query, { scopedVars });
+  async execute(query: LokiVariableQuery, scopedVars: ScopedVars, range: TimeRange) {
+    return this.datasource.metricFindQuery(query, { scopedVars, range });
   }
 
   query(request: DataQueryRequest<LokiVariableQuery>): Observable<{ data: MetricFindValue[] }> {
-    const result = this.execute(request.targets[0], request.scopedVars);
+    const result = this.execute(request.targets[0], request.scopedVars, request.range);
 
     return from(result).pipe(map((data) => ({ data })));
   }


### PR DESCRIPTION
**What is this feature?**

The `timeRange` property was missing in variable requests for Loki. This PR adds the necessary parameter and tests.

**Special notes for your reviewer:**

1. Add a Loki query variable to a dashboard.
2. Make sure requests contain the correct timerange and not the default `6h` timerange.
