### PR TITLE
Alerting: Fix for data source filter on cloud rules.

### DIFF
--- a/public/app/features/alerting/unified/hooks/useFilteredRules.test.ts
+++ b/public/app/features/alerting/unified/hooks/useFilteredRules.test.ts
@@ -2,7 +2,9 @@ import { setDataSourceSrv } from '@grafana/runtime';
 
 import { PromAlertingRuleState } from '../../../../types/unified-alerting-dto';
 import {
+  getCloudRule,
   mockAlertQuery,
+  mockCombinedCloudRuleNamespace,
   mockCombinedRule,
   mockCombinedRuleGroup,
   mockCombinedRuleNamespace,
@@ -154,16 +156,24 @@ describe('filterRules', function () {
           data: [mockAlertQuery({ datasourceUid: dataSources.loki.uid })],
         }),
       }),
+      getCloudRule({ name: 'Cloud' }),
     ];
 
     const ns = mockCombinedRuleNamespace({
       groups: [mockCombinedRuleGroup('Resources usage group', rules)],
     });
+    const cloudNs = mockCombinedCloudRuleNamespace(
+      {
+        groups: [mockCombinedRuleGroup('Resources usage group', rules)],
+      },
+      'Prometheus-ds'
+    );
 
-    const filtered = filterRules([ns], getFilter({ dataSourceNames: ['loki'] }));
+    const filtered = filterRules([ns, cloudNs], getFilter({ dataSourceNames: ['loki', 'Prometheus-ds'] }));
 
-    expect(filtered[0].groups[0].rules).toHaveLength(1);
+    expect(filtered[0].groups[0].rules).toHaveLength(2);
     expect(filtered[0].groups[0].rules[0].name).toBe('Memory too low');
+    expect(filtered[0].groups[0].rules[1].name).toBe('Cloud');
   });
 
   it('should be able to combine multiple predicates with AND', () => {

--- a/public/app/features/alerting/unified/hooks/useFilteredRules.ts
+++ b/public/app/features/alerting/unified/hooks/useFilteredRules.ts
@@ -204,9 +204,13 @@ const reduceGroups = (filterState: RulesFilter) => {
       }
 
       if ('dataSourceNames' in matchesFilterFor) {
-        const doesNotQueryDs = isGrafanaRulerRule(rule.rulerRule) && isQueryingDataSource(rule.rulerRule, filterState);
+        if (isGrafanaRulerRule(rule.rulerRule)) {
+          const doesNotQueryDs = isQueryingDataSource(rule.rulerRule, filterState);
 
-        if (doesNotQueryDs) {
+          if (doesNotQueryDs) {
+            matchesFilterFor.dataSourceNames = true;
+          }
+        } else {
           matchesFilterFor.dataSourceNames = true;
         }
       }

--- a/public/app/features/alerting/unified/mocks.ts
+++ b/public/app/features/alerting/unified/mocks.ts
@@ -15,16 +15,16 @@ import {
   ScopedVars,
   TestDataSourceResponse,
 } from '@grafana/data';
-import { config, DataSourceSrv, GetDataSourceListFilters } from '@grafana/runtime';
+import { DataSourceSrv, GetDataSourceListFilters, config } from '@grafana/runtime';
 import { defaultDashboard } from '@grafana/schema';
 import { contextSrv } from 'app/core/services/context_srv';
 import { DatasourceSrv } from 'app/features/plugins/datasource_srv';
 import {
-  AlertmanagerAlert,
   AlertManagerCortexConfig,
+  AlertState,
+  AlertmanagerAlert,
   AlertmanagerGroup,
   AlertmanagerStatus,
-  AlertState,
   GrafanaManagedReceiverConfig,
   MatcherOperator,
   Silence,
@@ -654,6 +654,17 @@ export function mockCombinedRuleNamespace(namespace: Partial<CombinedRuleNamespa
     name: 'Grafana',
     groups: [],
     rulesSource: 'grafana',
+    ...namespace,
+  };
+}
+export function mockCombinedCloudRuleNamespace(
+  namespace: Partial<CombinedRuleNamespace>,
+  dataSourceName: string
+): CombinedRuleNamespace {
+  return {
+    name: 'Grafana',
+    groups: [],
+    rulesSource: mockDataSource({ name: dataSourceName, uid: 'Prometheus-1' }),
     ...namespace,
   };
 }


### PR DESCRIPTION
**What is this feature?**

This PR fix data source filter not working for cloud rules.
The bug was introduced by this [PR](https://github.com/grafana/grafana/pull/78910)

**Who is this feature for?**

All users.


**Special notes for your reviewer:**

After the fix: 


https://github.com/grafana/grafana/assets/33540275/c43d9c3f-d0ec-4428-9441-cf88f848e4b4



Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
