### PR TITLE
ngalert Swagger: Fix mute timings API definitions

### DIFF
--- a/pkg/services/ngalert/api/api_provisioning.go
+++ b/pkg/services/ngalert/api/api_provisioning.go
@@ -50,9 +50,9 @@ type NotificationPolicyService interface {
 }
 
 type MuteTimingService interface {
-	GetMuteTimings(ctx context.Context, orgID int64) ([]definitions.MuteTimeInterval, error)
-	CreateMuteTiming(ctx context.Context, mt definitions.MuteTimeInterval, orgID int64) (*definitions.MuteTimeInterval, error)
-	UpdateMuteTiming(ctx context.Context, mt definitions.MuteTimeInterval, orgID int64) (*definitions.MuteTimeInterval, error)
+	GetMuteTimings(ctx context.Context, orgID int64) ([]definitions.MuteTiming, error)
+	CreateMuteTiming(ctx context.Context, mt definitions.MuteTiming, orgID int64) (*definitions.MuteTiming, error)
+	UpdateMuteTiming(ctx context.Context, mt definitions.MuteTiming, orgID int64) (*definitions.MuteTiming, error)
 	DeleteMuteTiming(ctx context.Context, name string, orgID int64) error
 }
 
@@ -263,7 +263,7 @@ func (srv *ProvisioningSrv) RouteGetMuteTimings(c *contextmodel.ReqContext) resp
 	return response.JSON(http.StatusOK, timings)
 }
 
-func (srv *ProvisioningSrv) RoutePostMuteTiming(c *contextmodel.ReqContext, mt definitions.MuteTimeInterval) response.Response {
+func (srv *ProvisioningSrv) RoutePostMuteTiming(c *contextmodel.ReqContext, mt definitions.MuteTiming) response.Response {
 	mt.Provenance = determineProvenance(c)
 	created, err := srv.muteTimings.CreateMuteTiming(c.Req.Context(), mt, c.SignedInUser.GetOrgID())
 	if err != nil {
@@ -275,7 +275,7 @@ func (srv *ProvisioningSrv) RoutePostMuteTiming(c *contextmodel.ReqContext, mt d
 	return response.JSON(http.StatusCreated, created)
 }
 
-func (srv *ProvisioningSrv) RoutePutMuteTiming(c *contextmodel.ReqContext, mt definitions.MuteTimeInterval, name string) response.Response {
+func (srv *ProvisioningSrv) RoutePutMuteTiming(c *contextmodel.ReqContext, mt definitions.MuteTiming, name string) response.Response {
 	mt.Name = name
 	mt.Provenance = determineProvenance(c)
 	updated, err := srv.muteTimings.UpdateMuteTiming(c.Req.Context(), mt, c.SignedInUser.GetOrgID())

--- a/pkg/services/ngalert/api/api_provisioning_test.go
+++ b/pkg/services/ngalert/api/api_provisioning_test.go
@@ -12,7 +12,6 @@ import (
 
 	prometheus "github.com/prometheus/alertmanager/config"
 	"github.com/prometheus/alertmanager/pkg/labels"
-	"github.com/prometheus/alertmanager/timeinterval"
 	"github.com/prometheus/common/model"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
@@ -228,7 +227,7 @@ func TestProvisioningApi(t *testing.T) {
 		t.Run("are missing, PUT returns 404", func(t *testing.T) {
 			sut := createProvisioningSrvSut(t)
 			rc := createTestRequestCtx()
-			mti := definitions.MuteTimeInterval{}
+			mti := definitions.MuteTiming{}
 
 			response := sut.RoutePutMuteTiming(&rc, mti, "does not exist")
 
@@ -1620,21 +1619,12 @@ func createInvalidContactPoint() definitions.EmbeddedContactPoint {
 	}
 }
 
-func createInvalidMuteTiming() definitions.MuteTimeInterval {
-	return definitions.MuteTimeInterval{
-		MuteTimeInterval: prometheus.MuteTimeInterval{
-			Name: "interval",
-			TimeIntervals: []timeinterval.TimeInterval{
-				{
-					Weekdays: []timeinterval.WeekdayRange{
-						{
-							InclusiveRange: timeinterval.InclusiveRange{
-								Begin: -1,
-								End:   7,
-							},
-						},
-					},
-				},
+func createInvalidMuteTiming() definitions.MuteTiming {
+	return definitions.MuteTiming{
+		Name: "interval",
+		TimeIntervals: []definitions.MuteTimingInterval{
+			{
+				Weekdays: []string{"bad:tuesday"},
 			},
 		},
 	}

--- a/pkg/services/ngalert/api/generated_base_api_provisioning.go
+++ b/pkg/services/ngalert/api/generated_base_api_provisioning.go
@@ -144,7 +144,7 @@ func (f *ProvisioningApiHandler) RoutePostContactpoints(ctx *contextmodel.ReqCon
 }
 func (f *ProvisioningApiHandler) RoutePostMuteTiming(ctx *contextmodel.ReqContext) response.Response {
 	// Parse Request Body
-	conf := apimodels.MuteTimeInterval{}
+	conf := apimodels.MuteTiming{}
 	if err := web.Bind(ctx.Req, &conf); err != nil {
 		return response.Error(http.StatusBadRequest, "bad request data", err)
 	}
@@ -185,7 +185,7 @@ func (f *ProvisioningApiHandler) RoutePutMuteTiming(ctx *contextmodel.ReqContext
 	// Parse Path Parameters
 	nameParam := web.Params(ctx.Req)[":name"]
 	// Parse Request Body
-	conf := apimodels.MuteTimeInterval{}
+	conf := apimodels.MuteTiming{}
 	if err := web.Bind(ctx.Req, &conf); err != nil {
 		return response.Error(http.StatusBadRequest, "bad request data", err)
 	}

--- a/pkg/services/ngalert/api/provisioning.go
+++ b/pkg/services/ngalert/api/provisioning.go
@@ -72,11 +72,11 @@ func (f *ProvisioningApiHandler) handleRouteGetMuteTimings(ctx *contextmodel.Req
 	return f.svc.RouteGetMuteTimings(ctx)
 }
 
-func (f *ProvisioningApiHandler) handleRoutePostMuteTiming(ctx *contextmodel.ReqContext, mt apimodels.MuteTimeInterval) response.Response {
+func (f *ProvisioningApiHandler) handleRoutePostMuteTiming(ctx *contextmodel.ReqContext, mt apimodels.MuteTiming) response.Response {
 	return f.svc.RoutePostMuteTiming(ctx, mt)
 }
 
-func (f *ProvisioningApiHandler) handleRoutePutMuteTiming(ctx *contextmodel.ReqContext, mt apimodels.MuteTimeInterval, name string) response.Response {
+func (f *ProvisioningApiHandler) handleRoutePutMuteTiming(ctx *contextmodel.ReqContext, mt apimodels.MuteTiming, name string) response.Response {
 	return f.svc.RoutePutMuteTiming(ctx, mt, name)
 }
 

--- a/pkg/services/ngalert/api/tooling/api.json
+++ b/pkg/services/ngalert/api/tooling/api.json
@@ -1920,9 +1920,83 @@
    "title": "MuteTimeInterval represents a named set of time intervals for which a route should be muted.",
    "type": "object"
   },
+  "MuteTiming": {
+   "properties": {
+    "name": {
+     "type": "string"
+    },
+    "provenance": {
+     "$ref": "#/definitions/Provenance"
+    },
+    "time_intervals": {
+     "items": {
+      "$ref": "#/definitions/MuteTimingInterval"
+     },
+     "type": "array"
+    }
+   },
+   "type": "object"
+  },
+  "MuteTimingInterval": {
+   "properties": {
+    "days_of_month": {
+     "description": "an inclusive range of days of month, e.g. \"1\" or \"5:15\".",
+     "items": {
+      "type": "string"
+     },
+     "type": "array"
+    },
+    "location": {
+     "description": "a location time zone for the time interval in the IANA Time Zone Database format, e.g. \"America/New_York\".",
+     "type": "string"
+    },
+    "months": {
+     "description": "an inclusive range of months, e.g. \"january\" or \"february:april\".",
+     "items": {
+      "type": "string"
+     },
+     "type": "array"
+    },
+    "times": {
+     "description": "an inclusive range of times",
+     "items": {
+      "$ref": "#/definitions/MuteTimingTimeRange"
+     },
+     "type": "array"
+    },
+    "weekdays": {
+     "description": "an inclusive range of weekdays, e.g. \"monday\" or \"tuesday:thursday\".",
+     "items": {
+      "type": "string"
+     },
+     "type": "array"
+    },
+    "years": {
+     "description": "an inclusive range of years, e.g. \"2019\" or \"2020:2022\".",
+     "items": {
+      "type": "string"
+     },
+     "type": "array"
+    }
+   },
+   "type": "object"
+  },
+  "MuteTimingTimeRange": {
+   "properties": {
+    "end_time": {
+     "description": "the end time of the range in the format HH:MM, e.g. \"17:00\".",
+     "type": "string"
+    },
+    "start_time": {
+     "description": "the start time of the range in the format HH:MM, e.g. \"08:00\".",
+     "type": "string"
+    }
+   },
+   "type": "object"
+  },
   "MuteTimings": {
    "items": {
-    "$ref": "#/definitions/MuteTimeInterval"
+    "$ref": "#/definitions/MuteTiming"
    },
    "type": "array"
   },
@@ -3950,17 +4024,18 @@
    "type": "object"
   },
   "TimeRange": {
-   "description": "Redefining this to avoid an import cycle",
+   "description": "For example, 4:00PM to End of the day would Begin at 1020 and End at 1440.",
    "properties": {
-    "from": {
-     "format": "date-time",
-     "type": "string"
+    "EndMinute": {
+     "format": "int64",
+     "type": "integer"
     },
-    "to": {
-     "format": "date-time",
-     "type": "string"
+    "StartMinute": {
+     "format": "int64",
+     "type": "integer"
     }
    },
+   "title": "TimeRange represents a range of minutes within a 1440 minute day, exclusive of the End minute. A day consists of 1440 minutes.",
    "type": "object"
   },
   "URL": {
@@ -4228,7 +4303,6 @@
    "type": "object"
   },
   "alertGroups": {
-   "description": "AlertGroups alert groups",
    "items": {
     "$ref": "#/definitions/alertGroup"
    },
@@ -4333,6 +4407,7 @@
    "type": "object"
   },
   "gettableAlert": {
+   "description": "GettableAlert gettable alert",
    "properties": {
     "annotations": {
      "$ref": "#/definitions/labelSet"
@@ -4444,14 +4519,12 @@
    "type": "object"
   },
   "gettableSilences": {
-   "description": "GettableSilences gettable silences",
    "items": {
     "$ref": "#/definitions/gettableSilence"
    },
    "type": "array"
   },
   "integration": {
-   "description": "Integration integration",
    "properties": {
     "lastNotifyAttempt": {
      "description": "A timestamp indicating the last attempt to deliver a notification regardless of the outcome.\nFormat: date-time",
@@ -4632,7 +4705,6 @@
    "type": "object"
   },
   "receiver": {
-   "description": "Receiver receiver",
    "properties": {
     "active": {
      "description": "active",
@@ -5341,7 +5413,7 @@
       "in": "body",
       "name": "Body",
       "schema": {
-       "$ref": "#/definitions/MuteTimeInterval"
+       "$ref": "#/definitions/MuteTiming"
       }
      }
     ],
@@ -5431,7 +5503,7 @@
       "in": "body",
       "name": "Body",
       "schema": {
-       "$ref": "#/definitions/MuteTimeInterval"
+       "$ref": "#/definitions/MuteTiming"
       }
      }
     ],

--- a/pkg/services/ngalert/api/tooling/definitions/alertmanager_validation.go
+++ b/pkg/services/ngalert/api/tooling/definitions/alertmanager_validation.go
@@ -8,10 +8,8 @@ import (
 	tmpltext "text/template"
 	"time"
 
-	"github.com/prometheus/alertmanager/config"
 	"github.com/prometheus/alertmanager/template"
 	"github.com/prometheus/common/model"
-	"gopkg.in/yaml.v3"
 )
 
 // Validate normalizes a possibly nested Route r, and returns errors if r is invalid.
@@ -143,15 +141,8 @@ func (r *Route) ValidateMuteTimes(muteTimes map[string]struct{}) error {
 }
 
 func (mt *MuteTiming) Validate() error {
-	s, err := yaml.Marshal(mt)
-	if err != nil {
-		return err
-	}
 	// The MuteTiming is a simplified version of the Alertmanager config, so we can reuse the Alertmanager config
 	// validation by unmarshaling into an Alertmanager config.
-	var configMuteTiming config.MuteTimeInterval
-	if err = yaml.Unmarshal(s, &configMuteTiming); err != nil {
-		return err
-	}
-	return nil
+	_, err := mt.ToConfigMuteTimeInterval()
+	return err
 }

--- a/pkg/services/ngalert/api/tooling/definitions/alertmanager_validation.go
+++ b/pkg/services/ngalert/api/tooling/definitions/alertmanager_validation.go
@@ -8,6 +8,7 @@ import (
 	tmpltext "text/template"
 	"time"
 
+	"github.com/prometheus/alertmanager/config"
 	"github.com/prometheus/alertmanager/template"
 	"github.com/prometheus/common/model"
 	"gopkg.in/yaml.v3"
@@ -141,12 +142,15 @@ func (r *Route) ValidateMuteTimes(muteTimes map[string]struct{}) error {
 	return nil
 }
 
-func (mt *MuteTimeInterval) Validate() error {
-	s, err := yaml.Marshal(mt.MuteTimeInterval)
+func (mt *MuteTiming) Validate() error {
+	s, err := yaml.Marshal(mt)
 	if err != nil {
 		return err
 	}
-	if err = yaml.Unmarshal(s, &(mt.MuteTimeInterval)); err != nil {
+	// The MuteTiming is a simplified version of the Alertmanager config, so we can reuse the Alertmanager config
+	// validation by unmarshaling into an Alertmanager config.
+	var configMuteTiming config.MuteTimeInterval
+	if err = yaml.Unmarshal(s, &configMuteTiming); err != nil {
 		return err
 	}
 	return nil

--- a/pkg/services/ngalert/api/tooling/definitions/alertmanager_validation_test.go
+++ b/pkg/services/ngalert/api/tooling/definitions/alertmanager_validation_test.go
@@ -4,8 +4,6 @@ import (
 	"errors"
 	"testing"
 
-	"github.com/prometheus/alertmanager/config"
-	"github.com/prometheus/alertmanager/timeinterval"
 	"github.com/prometheus/common/model"
 	"github.com/stretchr/testify/require"
 )
@@ -259,10 +257,10 @@ func TestValidateRoutes(t *testing.T) {
 	})
 }
 
-func TestValidateMuteTimeInterval(t *testing.T) {
+func TestValidateMuteTiming(t *testing.T) {
 	type testCase struct {
 		desc   string
-		mti    MuteTimeInterval
+		mti    MuteTiming
 		expMsg string
 	}
 
@@ -270,48 +268,43 @@ func TestValidateMuteTimeInterval(t *testing.T) {
 		cases := []testCase{
 			{
 				desc: "nil intervals",
-				mti: MuteTimeInterval{
-					MuteTimeInterval: config.MuteTimeInterval{
-						Name: "interval",
-					},
+				mti: MuteTiming{
+					Name: "interval",
 				},
 			},
 			{
 				desc: "empty intervals",
-				mti: MuteTimeInterval{
-					MuteTimeInterval: config.MuteTimeInterval{
-						Name:          "interval",
-						TimeIntervals: []timeinterval.TimeInterval{},
-					},
+				mti: MuteTiming{
+					Name:          "interval",
+					TimeIntervals: []MuteTimingInterval{},
 				},
 			},
 			{
 				desc: "blank interval",
-				mti: MuteTimeInterval{
-					MuteTimeInterval: config.MuteTimeInterval{
-						Name: "interval",
-						TimeIntervals: []timeinterval.TimeInterval{
-							{},
-						},
+				mti: MuteTiming{
+					Name: "interval",
+					TimeIntervals: []MuteTimingInterval{
+						{},
 					},
 				},
 			},
 			{
-				desc: "simple",
-				mti: MuteTimeInterval{
-					MuteTimeInterval: config.MuteTimeInterval{
-						Name: "interval",
-						TimeIntervals: []timeinterval.TimeInterval{
-							{
-								Weekdays: []timeinterval.WeekdayRange{
-									{
-										InclusiveRange: timeinterval.InclusiveRange{
-											Begin: 1,
-											End:   2,
-										},
-									},
+				desc: "full",
+				mti: MuteTiming{
+					Name: "interval",
+					TimeIntervals: []MuteTimingInterval{
+						{
+							Times: []MuteTimingTimeRange{
+								{
+									StartTime: "00:10",
+									EndTime:   "01:00",
 								},
 							},
+							Weekdays:    []string{"monday:tuesday"},
+							DaysOfMonth: []string{"1:2"},
+							Months:      []string{"january:february"},
+							Years:       []string{"2020:2021"},
+							Location:    "America/New_York",
 						},
 					},
 				},
@@ -331,29 +324,20 @@ func TestValidateMuteTimeInterval(t *testing.T) {
 		cases := []testCase{
 			{
 				desc:   "empty",
-				mti:    MuteTimeInterval{},
+				mti:    MuteTiming{},
 				expMsg: "missing name",
 			},
 			{
-				desc: "empty",
-				mti: MuteTimeInterval{
-					MuteTimeInterval: config.MuteTimeInterval{
-						Name: "interval",
-						TimeIntervals: []timeinterval.TimeInterval{
-							{
-								Weekdays: []timeinterval.WeekdayRange{
-									{
-										InclusiveRange: timeinterval.InclusiveRange{
-											Begin: -1,
-											End:   7,
-										},
-									},
-								},
-							},
+				desc: "bad weekday",
+				mti: MuteTiming{
+					Name: "interval",
+					TimeIntervals: []MuteTimingInterval{
+						{
+							Weekdays: []string{"bad:tuesday"},
 						},
 					},
 				},
-				expMsg: "unable to convert -1 into weekday",
+				expMsg: "bad is not a valid weekday",
 			},
 		}
 

--- a/pkg/services/ngalert/api/tooling/definitions/provisioning_mute_timings.go
+++ b/pkg/services/ngalert/api/tooling/definitions/provisioning_mute_timings.go
@@ -1,5 +1,10 @@
 package definitions
 
+import (
+	"github.com/prometheus/alertmanager/config"
+	"gopkg.in/yaml.v3"
+)
+
 // swagger:route GET /api/v1/provisioning/mute-timings provisioning stable RouteGetMuteTimings
 //
 // Get all the mute timings.
@@ -75,6 +80,33 @@ func (mt *MuteTiming) ResourceType() string {
 
 func (mt *MuteTiming) ResourceID() string {
 	return mt.Name
+}
+
+func (mt *MuteTiming) ToConfigMuteTimeInterval() (config.MuteTimeInterval, error) {
+	s, err := yaml.Marshal(mt)
+	if err != nil {
+		return config.MuteTimeInterval{}, err
+	}
+
+	var configMuteTiming config.MuteTimeInterval
+	if err = yaml.Unmarshal(s, &configMuteTiming); err != nil {
+		return config.MuteTimeInterval{}, err
+	}
+
+	return configMuteTiming, nil
+}
+
+func (mt *MuteTiming) FromConfigMuteTimeInterval(configMuteTiming config.MuteTimeInterval) error {
+	s, err := yaml.Marshal(configMuteTiming)
+	if err != nil {
+		return err
+	}
+
+	if err = yaml.Unmarshal(s, mt); err != nil {
+		return err
+	}
+
+	return nil
 }
 
 // swagger:model

--- a/pkg/services/ngalert/api/tooling/definitions/provisioning_mute_timings.go
+++ b/pkg/services/ngalert/api/tooling/definitions/provisioning_mute_timings.go
@@ -1,9 +1,5 @@
 package definitions
 
-import (
-	"github.com/prometheus/alertmanager/config"
-)
-
 // swagger:route GET /api/v1/provisioning/mute-timings provisioning stable RouteGetMuteTimings
 //
 // Get all the mute timings.
@@ -51,7 +47,7 @@ import (
 // swagger:route
 
 // swagger:model
-type MuteTimings []MuteTimeInterval
+type MuteTimings []MuteTiming
 
 // swagger:parameters RouteGetTemplate RouteGetMuteTiming RoutePutMuteTiming stable RouteDeleteMuteTiming
 type RouteGetMuteTimingParam struct {
@@ -63,19 +59,46 @@ type RouteGetMuteTimingParam struct {
 // swagger:parameters RoutePostMuteTiming RoutePutMuteTiming
 type MuteTimingPayload struct {
 	// in:body
-	Body MuteTimeInterval
+	Body MuteTiming
 }
 
 // swagger:model
-type MuteTimeInterval struct {
-	config.MuteTimeInterval `json:",inline" yaml:",inline"`
-	Provenance              Provenance `json:"provenance,omitempty"`
+type MuteTiming struct {
+	Name          string               `yaml:"name" json:"name"`
+	Provenance    Provenance           `yaml:"provenance,omitempty" json:"provenance,omitempty"`
+	TimeIntervals []MuteTimingInterval `yaml:"time_intervals" json:"time_intervals"`
 }
 
-func (mt *MuteTimeInterval) ResourceType() string {
-	return "muteTimeInterval"
+func (mt *MuteTiming) ResourceType() string {
+	return "muteTiming"
 }
 
-func (mt *MuteTimeInterval) ResourceID() string {
-	return mt.MuteTimeInterval.Name
+func (mt *MuteTiming) ResourceID() string {
+	return mt.Name
+}
+
+// swagger:model
+// MuteTimeInterval represents a time interval during which alerts should be muted.
+type MuteTimingInterval struct {
+	// an inclusive range of times
+	Times []MuteTimingTimeRange `yaml:"times,omitempty" json:"times,omitempty"`
+	// an inclusive range of weekdays, e.g. "monday" or "tuesday:thursday".
+	Weekdays []string `yaml:"weekdays,omitempty" json:"weekdays,omitempty"`
+	// an inclusive range of days of month, e.g. "1" or "5:15".
+	DaysOfMonth []string `yaml:"days_of_month,omitempty" json:"days_of_month,omitempty"`
+	// an inclusive range of months, e.g. "january" or "february:april".
+	Months []string `yaml:"months,omitempty" json:"months,omitempty"`
+	// an inclusive range of years, e.g. "2019" or "2020:2022".
+	Years []string `yaml:"years,omitempty" json:"years,omitempty"`
+	// a location time zone for the time interval in the IANA Time Zone Database format, e.g. "America/New_York".
+	Location string `yaml:"location,omitempty" json:"location,omitempty"`
+}
+
+// swagger:model
+// MuteTimingInterval represents a time range during which alerts should be muted.
+type MuteTimingTimeRange struct {
+	// the start time of the range in the format HH:MM, e.g. "08:00".
+	StartTime string `yaml:"start_time,omitempty" json:"start_time,omitempty"`
+	// the end time of the range in the format HH:MM, e.g. "17:00".
+	EndTime string `yaml:"end_time,omitempty" json:"end_time,omitempty"`
 }

--- a/pkg/services/ngalert/api/tooling/post.json
+++ b/pkg/services/ngalert/api/tooling/post.json
@@ -1920,9 +1920,83 @@
    "title": "MuteTimeInterval represents a named set of time intervals for which a route should be muted.",
    "type": "object"
   },
+  "MuteTiming": {
+   "properties": {
+    "name": {
+     "type": "string"
+    },
+    "provenance": {
+     "$ref": "#/definitions/Provenance"
+    },
+    "time_intervals": {
+     "items": {
+      "$ref": "#/definitions/MuteTimingInterval"
+     },
+     "type": "array"
+    }
+   },
+   "type": "object"
+  },
+  "MuteTimingInterval": {
+   "properties": {
+    "days_of_month": {
+     "description": "an inclusive range of days of month, e.g. \"1\" or \"5:15\".",
+     "items": {
+      "type": "string"
+     },
+     "type": "array"
+    },
+    "location": {
+     "description": "a location time zone for the time interval in the IANA Time Zone Database format, e.g. \"America/New_York\".",
+     "type": "string"
+    },
+    "months": {
+     "description": "an inclusive range of months, e.g. \"january\" or \"february:april\".",
+     "items": {
+      "type": "string"
+     },
+     "type": "array"
+    },
+    "times": {
+     "description": "an inclusive range of times",
+     "items": {
+      "$ref": "#/definitions/MuteTimingTimeRange"
+     },
+     "type": "array"
+    },
+    "weekdays": {
+     "description": "an inclusive range of weekdays, e.g. \"monday\" or \"tuesday:thursday\".",
+     "items": {
+      "type": "string"
+     },
+     "type": "array"
+    },
+    "years": {
+     "description": "an inclusive range of years, e.g. \"2019\" or \"2020:2022\".",
+     "items": {
+      "type": "string"
+     },
+     "type": "array"
+    }
+   },
+   "type": "object"
+  },
+  "MuteTimingTimeRange": {
+   "properties": {
+    "end_time": {
+     "description": "the end time of the range in the format HH:MM, e.g. \"17:00\".",
+     "type": "string"
+    },
+    "start_time": {
+     "description": "the start time of the range in the format HH:MM, e.g. \"08:00\".",
+     "type": "string"
+    }
+   },
+   "type": "object"
+  },
   "MuteTimings": {
    "items": {
-    "$ref": "#/definitions/MuteTimeInterval"
+    "$ref": "#/definitions/MuteTiming"
    },
    "type": "array"
   },
@@ -3950,17 +4024,18 @@
    "type": "object"
   },
   "TimeRange": {
-   "description": "Redefining this to avoid an import cycle",
+   "description": "For example, 4:00PM to End of the day would Begin at 1020 and End at 1440.",
    "properties": {
-    "from": {
-     "format": "date-time",
-     "type": "string"
+    "EndMinute": {
+     "format": "int64",
+     "type": "integer"
     },
-    "to": {
-     "format": "date-time",
-     "type": "string"
+    "StartMinute": {
+     "format": "int64",
+     "type": "integer"
     }
    },
+   "title": "TimeRange represents a range of minutes within a 1440 minute day, exclusive of the End minute. A day consists of 1440 minutes.",
    "type": "object"
   },
   "URL": {
@@ -4228,7 +4303,6 @@
    "type": "object"
   },
   "alertGroups": {
-   "description": "AlertGroups alert groups",
    "items": {
     "$ref": "#/definitions/alertGroup"
    },
@@ -4333,7 +4407,6 @@
    "type": "object"
   },
   "gettableAlert": {
-   "description": "GettableAlert gettable alert",
    "properties": {
     "annotations": {
      "$ref": "#/definitions/labelSet"
@@ -4396,6 +4469,7 @@
    "type": "array"
   },
   "gettableSilence": {
+   "description": "GettableSilence gettable silence",
    "properties": {
     "comment": {
      "description": "comment",
@@ -4444,14 +4518,12 @@
    "type": "object"
   },
   "gettableSilences": {
-   "description": "GettableSilences gettable silences",
    "items": {
     "$ref": "#/definitions/gettableSilence"
    },
    "type": "array"
   },
   "integration": {
-   "description": "Integration integration",
    "properties": {
     "lastNotifyAttempt": {
      "description": "A timestamp indicating the last attempt to deliver a notification regardless of the outcome.\nFormat: date-time",
@@ -7320,7 +7392,7 @@
       "in": "body",
       "name": "Body",
       "schema": {
-       "$ref": "#/definitions/MuteTimeInterval"
+       "$ref": "#/definitions/MuteTiming"
       }
      }
     ],
@@ -7410,7 +7482,7 @@
       "in": "body",
       "name": "Body",
       "schema": {
-       "$ref": "#/definitions/MuteTimeInterval"
+       "$ref": "#/definitions/MuteTiming"
       }
      }
     ],

--- a/pkg/services/ngalert/api/tooling/spec.json
+++ b/pkg/services/ngalert/api/tooling/spec.json
@@ -2606,7 +2606,7 @@
             "name": "Body",
             "in": "body",
             "schema": {
-              "$ref": "#/definitions/MuteTimeInterval"
+              "$ref": "#/definitions/MuteTiming"
             }
           }
         ],
@@ -2677,7 +2677,7 @@
             "name": "Body",
             "in": "body",
             "schema": {
-              "$ref": "#/definitions/MuteTimeInterval"
+              "$ref": "#/definitions/MuteTiming"
             }
           }
         ],
@@ -4986,10 +4986,84 @@
         }
       }
     },
+    "MuteTiming": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "provenance": {
+          "$ref": "#/definitions/Provenance"
+        },
+        "time_intervals": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/MuteTimingInterval"
+          }
+        }
+      }
+    },
+    "MuteTimingInterval": {
+      "type": "object",
+      "properties": {
+        "days_of_month": {
+          "description": "an inclusive range of days of month, e.g. \"1\" or \"5:15\".",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "location": {
+          "description": "a location time zone for the time interval in the IANA Time Zone Database format, e.g. \"America/New_York\".",
+          "type": "string"
+        },
+        "months": {
+          "description": "an inclusive range of months, e.g. \"january\" or \"february:april\".",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "times": {
+          "description": "an inclusive range of times",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/MuteTimingTimeRange"
+          }
+        },
+        "weekdays": {
+          "description": "an inclusive range of weekdays, e.g. \"monday\" or \"tuesday:thursday\".",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "years": {
+          "description": "an inclusive range of years, e.g. \"2019\" or \"2020:2022\".",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "MuteTimingTimeRange": {
+      "type": "object",
+      "properties": {
+        "end_time": {
+          "description": "the end time of the range in the format HH:MM, e.g. \"17:00\".",
+          "type": "string"
+        },
+        "start_time": {
+          "description": "the start time of the range in the format HH:MM, e.g. \"08:00\".",
+          "type": "string"
+        }
+      }
+    },
     "MuteTimings": {
       "type": "array",
       "items": {
-        "$ref": "#/definitions/MuteTimeInterval"
+        "$ref": "#/definitions/MuteTiming"
       }
     },
     "NamespaceConfigResponse": {
@@ -7016,16 +7090,17 @@
       }
     },
     "TimeRange": {
-      "description": "Redefining this to avoid an import cycle",
+      "description": "For example, 4:00PM to End of the day would Begin at 1020 and End at 1440.",
       "type": "object",
+      "title": "TimeRange represents a range of minutes within a 1440 minute day, exclusive of the End minute. A day consists of 1440 minutes.",
       "properties": {
-        "from": {
-          "type": "string",
-          "format": "date-time"
+        "EndMinute": {
+          "type": "integer",
+          "format": "int64"
         },
-        "to": {
-          "type": "string",
-          "format": "date-time"
+        "StartMinute": {
+          "type": "integer",
+          "format": "int64"
         }
       }
     },
@@ -7295,7 +7370,6 @@
       "$ref": "#/definitions/alertGroup"
     },
     "alertGroups": {
-      "description": "AlertGroups alert groups",
       "type": "array",
       "items": {
         "$ref": "#/definitions/alertGroup"
@@ -7401,7 +7475,6 @@
       }
     },
     "gettableAlert": {
-      "description": "GettableAlert gettable alert",
       "type": "object",
       "required": [
         "labels",
@@ -7466,6 +7539,7 @@
       "$ref": "#/definitions/gettableAlerts"
     },
     "gettableSilence": {
+      "description": "GettableSilence gettable silence",
       "type": "object",
       "required": [
         "comment",
@@ -7515,7 +7589,6 @@
       "$ref": "#/definitions/gettableSilence"
     },
     "gettableSilences": {
-      "description": "GettableSilences gettable silences",
       "type": "array",
       "items": {
         "$ref": "#/definitions/gettableSilence"
@@ -7523,7 +7596,6 @@
       "$ref": "#/definitions/gettableSilences"
     },
     "integration": {
-      "description": "Integration integration",
       "type": "object",
       "required": [
         "name",

--- a/pkg/services/ngalert/notifier/alertmanager_config.go
+++ b/pkg/services/ngalert/notifier/alertmanager_config.go
@@ -260,7 +260,7 @@ func (moa *MultiOrgAlertmanager) mergeProvenance(ctx context.Context, config def
 		config.TemplateFileProvenances[key] = definitions.Provenance(provenance)
 	}
 
-	mt := definitions.MuteTimeInterval{}
+	mt := definitions.MuteTiming{}
 	mtProvs, err := moa.ProvStore.GetProvenances(ctx, org, mt.ResourceType())
 	if err != nil {
 		return definitions.GettableUserConfig{}, nil

--- a/pkg/services/ngalert/provisioning/mute_timings_test.go
+++ b/pkg/services/ngalert/provisioning/mute_timings_test.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/prometheus/alertmanager/config"
 	mock "github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 
@@ -81,10 +80,8 @@ func TestMuteTimingService(t *testing.T) {
 	t.Run("creating mute timings", func(t *testing.T) {
 		t.Run("rejects mute timings that fail validation", func(t *testing.T) {
 			sut := createMuteTimingSvcSut()
-			timing := definitions.MuteTimeInterval{
-				MuteTimeInterval: config.MuteTimeInterval{
-					Name: "",
-				},
+			timing := definitions.MuteTiming{
+				Name: "",
 			}
 
 			_, err := sut.CreateMuteTiming(context.Background(), timing, 1)
@@ -169,10 +166,8 @@ func TestMuteTimingService(t *testing.T) {
 	t.Run("updating mute timings", func(t *testing.T) {
 		t.Run("rejects mute timings that fail validation", func(t *testing.T) {
 			sut := createMuteTimingSvcSut()
-			timing := definitions.MuteTimeInterval{
-				MuteTimeInterval: config.MuteTimeInterval{
-					Name: "",
-				},
+			timing := definitions.MuteTiming{
+				Name: "",
 			}
 
 			_, err := sut.UpdateMuteTiming(context.Background(), timing, 1)
@@ -382,11 +377,9 @@ func createMuteTimingSvcSut() *MuteTimingService {
 	}
 }
 
-func createMuteTiming() definitions.MuteTimeInterval {
-	return definitions.MuteTimeInterval{
-		MuteTimeInterval: config.MuteTimeInterval{
-			Name: "interval",
-		},
+func createMuteTiming() definitions.MuteTiming {
+	return definitions.MuteTiming{
+		Name: "interval",
 	}
 }
 

--- a/pkg/services/provisioning/alerting/mute_times_provisioner.go
+++ b/pkg/services/provisioning/alerting/mute_times_provisioner.go
@@ -29,7 +29,7 @@ func NewMuteTimesProvisioner(logger log.Logger,
 
 func (c *defaultMuteTimesProvisioner) Provision(ctx context.Context,
 	files []*AlertingFile) error {
-	cache := map[int64]map[string]definitions.MuteTimeInterval{}
+	cache := map[int64]map[string]definitions.MuteTiming{}
 	for _, file := range files {
 		for _, muteTiming := range file.MuteTimes {
 			if _, exists := cache[muteTiming.OrgID]; !exists {
@@ -37,7 +37,7 @@ func (c *defaultMuteTimesProvisioner) Provision(ctx context.Context,
 				if err != nil {
 					return err
 				}
-				cache[muteTiming.OrgID] = make(map[string]definitions.MuteTimeInterval, len(intervals))
+				cache[muteTiming.OrgID] = make(map[string]definitions.MuteTiming, len(intervals))
 				for _, interval := range intervals {
 					cache[muteTiming.OrgID][interval.Name] = interval
 				}

--- a/pkg/services/provisioning/alerting/mute_times_types.go
+++ b/pkg/services/provisioning/alerting/mute_times_types.go
@@ -9,8 +9,8 @@ import (
 )
 
 type MuteTimeV1 struct {
-	OrgID    values.Int64Value            `json:"orgId" yaml:"orgId"`
-	MuteTime definitions.MuteTimeInterval `json:",inline" yaml:",inline"`
+	OrgID    values.Int64Value      `json:"orgId" yaml:"orgId"`
+	MuteTime definitions.MuteTiming `json:",inline" yaml:",inline"`
 }
 
 func (v1 *MuteTimeV1) mapToModel() MuteTime {
@@ -26,7 +26,7 @@ func (v1 *MuteTimeV1) mapToModel() MuteTime {
 
 type MuteTime struct {
 	OrgID    int64
-	MuteTime definitions.MuteTimeInterval
+	MuteTime definitions.MuteTiming
 }
 
 type DeleteMuteTimeV1 struct {

--- a/public/api-enterprise-spec.json
+++ b/public/api-enterprise-spec.json
@@ -4214,7 +4214,11 @@
           "type": "boolean"
         },
         "id": {
-          "description": "Deprecated: use Uid instead",
+          "description": "Deprecated: use UID instead",
+          "type": "integer",
+          "format": "int64"
+        },
+        "orgId": {
           "type": "integer",
           "format": "int64"
         },

--- a/public/api-merged.json
+++ b/public/api-merged.json
@@ -3059,7 +3059,7 @@
             "name": "Body",
             "in": "body",
             "schema": {
-              "$ref": "#/definitions/MuteTimeInterval"
+              "$ref": "#/definitions/MuteTiming"
             }
           }
         ],
@@ -3128,7 +3128,7 @@
             "name": "Body",
             "in": "body",
             "schema": {
-              "$ref": "#/definitions/MuteTimeInterval"
+              "$ref": "#/definitions/MuteTiming"
             }
           }
         ],
@@ -15691,10 +15691,84 @@
         }
       }
     },
+    "MuteTiming": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "provenance": {
+          "$ref": "#/definitions/Provenance"
+        },
+        "time_intervals": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/MuteTimingInterval"
+          }
+        }
+      }
+    },
+    "MuteTimingInterval": {
+      "type": "object",
+      "properties": {
+        "days_of_month": {
+          "description": "an inclusive range of days of month, e.g. \"1\" or \"5:15\".",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "location": {
+          "description": "a location time zone for the time interval in the IANA Time Zone Database format, e.g. \"America/New_York\".",
+          "type": "string"
+        },
+        "months": {
+          "description": "an inclusive range of months, e.g. \"january\" or \"february:april\".",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "times": {
+          "description": "an inclusive range of times",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/MuteTimingTimeRange"
+          }
+        },
+        "weekdays": {
+          "description": "an inclusive range of weekdays, e.g. \"monday\" or \"tuesday:thursday\".",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "years": {
+          "description": "an inclusive range of years, e.g. \"2019\" or \"2020:2022\".",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "MuteTimingTimeRange": {
+      "type": "object",
+      "properties": {
+        "end_time": {
+          "description": "the end time of the range in the format HH:MM, e.g. \"17:00\".",
+          "type": "string"
+        },
+        "start_time": {
+          "description": "the start time of the range in the format HH:MM, e.g. \"08:00\".",
+          "type": "string"
+        }
+      }
+    },
     "MuteTimings": {
       "type": "array",
       "items": {
-        "$ref": "#/definitions/MuteTimeInterval"
+        "$ref": "#/definitions/MuteTiming"
       }
     },
     "Name": {
@@ -20559,7 +20633,6 @@
       }
     },
     "alertGroups": {
-      "description": "AlertGroups alert groups",
       "type": "array",
       "items": {
         "$ref": "#/definitions/alertGroup"
@@ -20692,6 +20765,7 @@
       }
     },
     "gettableAlert": {
+      "description": "GettableAlert gettable alert",
       "type": "object",
       "required": [
         "labels",
@@ -20803,14 +20877,12 @@
       }
     },
     "gettableSilences": {
-      "description": "GettableSilences gettable silences",
       "type": "array",
       "items": {
         "$ref": "#/definitions/gettableSilence"
       }
     },
     "integration": {
-      "description": "Integration integration",
       "type": "object",
       "required": [
         "name",
@@ -21019,7 +21091,6 @@
       }
     },
     "receiver": {
-      "description": "Receiver receiver",
       "type": "object",
       "required": [
         "active",

--- a/public/openapi3.json
+++ b/public/openapi3.json
@@ -6709,9 +6709,83 @@
         "title": "MuteTimeInterval represents a named set of time intervals for which a route should be muted.",
         "type": "object"
       },
+      "MuteTiming": {
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "provenance": {
+            "$ref": "#/components/schemas/Provenance"
+          },
+          "time_intervals": {
+            "items": {
+              "$ref": "#/components/schemas/MuteTimingInterval"
+            },
+            "type": "array"
+          }
+        },
+        "type": "object"
+      },
+      "MuteTimingInterval": {
+        "properties": {
+          "days_of_month": {
+            "description": "an inclusive range of days of month, e.g. \"1\" or \"5:15\".",
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "location": {
+            "description": "a location time zone for the time interval in the IANA Time Zone Database format, e.g. \"America/New_York\".",
+            "type": "string"
+          },
+          "months": {
+            "description": "an inclusive range of months, e.g. \"january\" or \"february:april\".",
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "times": {
+            "description": "an inclusive range of times",
+            "items": {
+              "$ref": "#/components/schemas/MuteTimingTimeRange"
+            },
+            "type": "array"
+          },
+          "weekdays": {
+            "description": "an inclusive range of weekdays, e.g. \"monday\" or \"tuesday:thursday\".",
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "years": {
+            "description": "an inclusive range of years, e.g. \"2019\" or \"2020:2022\".",
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          }
+        },
+        "type": "object"
+      },
+      "MuteTimingTimeRange": {
+        "properties": {
+          "end_time": {
+            "description": "the end time of the range in the format HH:MM, e.g. \"17:00\".",
+            "type": "string"
+          },
+          "start_time": {
+            "description": "the start time of the range in the format HH:MM, e.g. \"08:00\".",
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
       "MuteTimings": {
         "items": {
-          "$ref": "#/components/schemas/MuteTimeInterval"
+          "$ref": "#/components/schemas/MuteTiming"
         },
         "type": "array"
       },
@@ -11575,7 +11649,6 @@
         "type": "object"
       },
       "alertGroups": {
-        "description": "AlertGroups alert groups",
         "items": {
           "$ref": "#/components/schemas/alertGroup"
         },
@@ -11708,6 +11781,7 @@
         "type": "object"
       },
       "gettableAlert": {
+        "description": "GettableAlert gettable alert",
         "properties": {
           "annotations": {
             "$ref": "#/components/schemas/labelSet"
@@ -11819,14 +11893,12 @@
         "type": "object"
       },
       "gettableSilences": {
-        "description": "GettableSilences gettable silences",
         "items": {
           "$ref": "#/components/schemas/gettableSilence"
         },
         "type": "array"
       },
       "integration": {
-        "description": "Integration integration",
         "properties": {
           "lastNotifyAttempt": {
             "description": "A timestamp indicating the last attempt to deliver a notification regardless of the outcome.\nFormat: date-time",
@@ -12035,7 +12107,6 @@
         "type": "object"
       },
       "receiver": {
-        "description": "Receiver receiver",
         "properties": {
           "active": {
             "description": "active",
@@ -15523,7 +15594,7 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/MuteTimeInterval"
+                "$ref": "#/components/schemas/MuteTiming"
               }
             }
           },
@@ -15631,7 +15702,7 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/MuteTimeInterval"
+                "$ref": "#/components/schemas/MuteTiming"
               }
             }
           },


### PR DESCRIPTION
Currently, the models that we use for the mute timing endpoints are the ones from the `grafana/prometheus-alertmanager` repository (https://github.com/grafana/prometheus-alertmanager/blob/main/config/config.go#L264)

However, these models are not really suitable for Swagger spec generation because they have a lot of logic within the Unmarshal*/Marshal* functions 
All the fields in that config are complex structs but the API accepts strings in fact (as shown in the client here: https://github.com/grafana/grafana-api-golang-client/blob/master/alerting_mute_timing.go)

This PR creates new models specifically for the API definition. The new models are converted to and from the underlying `config.MuteTimeInterval` config and validated as they were before

Schema changes are from:
`make` in `pkg/services/ngalert/api/tooling`
`make swagger-clean && make openapi3-gen` in root