### PR TITLE
Loki: strip out backticks in query editor line filter

### DIFF
--- a/public/app/plugins/datasource/loki/querybuilder/operationUtils.test.ts
+++ b/public/app/plugins/datasource/loki/querybuilder/operationUtils.test.ts
@@ -142,6 +142,10 @@ describe('getLineFilterRenderer', () => {
     id: '__line_contains_case_insensitive',
     params: ['ERrOR'],
   };
+  const MOCK_MODEL_BACKTICKS = {
+    id: '__line_contains',
+    params: ['`error`'],
+  };
 
   const MOCK_DEF = undefined as unknown as QueryBuilderOperationDef;
 
@@ -155,6 +159,11 @@ describe('getLineFilterRenderer', () => {
   it('lineFilterRenderer returns the correct query for line contains', () => {
     const lineFilterRenderer = getLineFilterRenderer('!~');
     expect(lineFilterRenderer(MOCK_MODEL, MOCK_DEF, MOCK_INNER_EXPR)).toBe('{job="grafana"} !~ `error`');
+  });
+
+  it('lineFilterRenderer returns the correct query for line contains, containing backticks', () => {
+    const lineFilterRenderer = getLineFilterRenderer('!~');
+    expect(lineFilterRenderer(MOCK_MODEL_BACKTICKS, MOCK_DEF, MOCK_INNER_EXPR)).toBe('{job="grafana"} !~ `error`');
   });
 
   it('lineFilterRenderer returns the correct query for line contains case insensitive', () => {

--- a/public/app/plugins/datasource/loki/querybuilder/operationUtils.test.ts
+++ b/public/app/plugins/datasource/loki/querybuilder/operationUtils.test.ts
@@ -163,7 +163,7 @@ describe('getLineFilterRenderer', () => {
 
   it('lineFilterRenderer returns the correct query for line contains, containing backticks', () => {
     const lineFilterRenderer = getLineFilterRenderer('!~');
-    expect(lineFilterRenderer(MOCK_MODEL_BACKTICKS, MOCK_DEF, MOCK_INNER_EXPR)).toBe('{job="grafana"} !~ `error`');
+    expect(lineFilterRenderer(MOCK_MODEL_BACKTICKS, MOCK_DEF, MOCK_INNER_EXPR)).toBe('{job="grafana"} !~ "`error`"');
   });
 
   it('lineFilterRenderer returns the correct query for line contains case insensitive', () => {

--- a/public/app/plugins/datasource/loki/querybuilder/operationUtils.ts
+++ b/public/app/plugins/datasource/loki/querybuilder/operationUtils.ts
@@ -296,7 +296,6 @@ export function addNestedQueryHandler(def: QueryBuilderOperationDef, query: Loki
 
 export function getLineFilterRenderer(operation: string, caseInsensitive?: boolean) {
   return function lineFilterRenderer(model: QueryBuilderOperation, def: QueryBuilderOperationDef, innerExpr: string) {
-    // Strip out backticks within the string as backticks are used to wrap each param in the output
     const hasBackticks = model.params.some((param) => typeof param === 'string' && param.includes('`'));
     const delimiter = hasBackticks ? '"' : '`';
     let params;

--- a/public/app/plugins/datasource/loki/querybuilder/operationUtils.ts
+++ b/public/app/plugins/datasource/loki/querybuilder/operationUtils.ts
@@ -299,7 +299,7 @@ export function getLineFilterRenderer(operation: string, caseInsensitive?: boole
     const params =
       model.params?.map((param) => {
         if (typeof param === 'string' && param.includes('`')) {
-          return `${param.replaceAll('`', '')}`;
+          return param.replaceAll('`', '');
         }
         return param;
       }) ?? [];

--- a/public/app/plugins/datasource/loki/querybuilder/operationUtils.ts
+++ b/public/app/plugins/datasource/loki/querybuilder/operationUtils.ts
@@ -295,10 +295,23 @@ export function addNestedQueryHandler(def: QueryBuilderOperationDef, query: Loki
 
 export function getLineFilterRenderer(operation: string, caseInsensitive?: boolean) {
   return function lineFilterRenderer(model: QueryBuilderOperation, def: QueryBuilderOperationDef, innerExpr: string) {
+    console.log('model', model);
+    console.log('operation', operation);
+    console.log('final string', `${innerExpr} ${operation} \`${model.params.join('` or `')}\``);
+
+    // Strip out backticks
+    const params =
+      model.params?.map((param) => {
+        if (typeof param === 'string' && param.includes('`')) {
+          return `${param.replaceAll('`', '')}`;
+        }
+        return param;
+      }) ?? [];
+
     if (caseInsensitive) {
-      return `${innerExpr} ${operation} \`(?i)${model.params.join('` or `(?i)')}\``;
+      return `${innerExpr} ${operation} \`(?i)${params.join('` or `(?i)')}\``;
     }
-    return `${innerExpr} ${operation} \`${model.params.join('` or `')}\``;
+    return `${innerExpr} ${operation} \`${params.join('` or `')}\``;
   };
 }
 

--- a/public/app/plugins/datasource/loki/querybuilder/operationUtils.ts
+++ b/public/app/plugins/datasource/loki/querybuilder/operationUtils.ts
@@ -295,11 +295,7 @@ export function addNestedQueryHandler(def: QueryBuilderOperationDef, query: Loki
 
 export function getLineFilterRenderer(operation: string, caseInsensitive?: boolean) {
   return function lineFilterRenderer(model: QueryBuilderOperation, def: QueryBuilderOperationDef, innerExpr: string) {
-    console.log('model', model);
-    console.log('operation', operation);
-    console.log('final string', `${innerExpr} ${operation} \`${model.params.join('` or `')}\``);
-
-    // Strip out backticks
+    // Strip out backticks within the string as backticks are used to wrap each param in the output
     const params =
       model.params?.map((param) => {
         if (typeof param === 'string' && param.includes('`')) {


### PR DESCRIPTION
**What is this feature?**
Stripping out backticks in line filter values

<img width="567" alt="image" src="https://github.com/grafana/grafana/assets/109082771/1e581b96-f3f5-4c71-835e-bc8f89ed87cf">


**Why do we need this feature?**
Some users may copy or paste values that have backticks into the query builder, and this will cause the query to be improperly formatted, and execution will break. In other words, this simplifies usage of the UI.

**Who is this feature for?**
Loki query builder users.

**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/grafana/issues/78100

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
