### PR TITLE
Plugins: Include Azure settings as a part of Grafana config sent in plugin requests

### DIFF
--- a/conf/defaults.ini
+++ b/conf/defaults.ini
@@ -907,9 +907,9 @@ user_identity_client_id =
 # By default is the same as used in AAD authentication or can be set to another application (for OBO flow)
 user_identity_client_secret =
 
-# Set the plugins that will receive Azure settings via plugin context
-# By default this will always include all Grafana Labs owned Azure plugins, or those that make use of Azure settings (Azure Monitor, Azure Data Explorer, Prometheus, MSSQL).
-forward_settings_to_plugins =
+# Set the plugins that will receive Azure settings for each request (via plugin context)
+# By default this will include all Grafana Labs owned Azure plugins, or those that make use of Azure settings (Azure Monitor, Azure Data Explorer, Prometheus, MSSQL).
+forward_settings_to_plugins = grafana-azure-monitor-datasource, prometheus, grafana-azure-data-explorer-datasource, mssql
 
 #################################### Role-based Access Control ###########
 [rbac]

--- a/conf/defaults.ini
+++ b/conf/defaults.ini
@@ -907,6 +907,10 @@ user_identity_client_id =
 # By default is the same as used in AAD authentication or can be set to another application (for OBO flow)
 user_identity_client_secret =
 
+# Set the plugins that will receive Azure settings via plugin context
+# By default this will always include all Grafana Labs owned Azure plugins, or those that make use of Azure settings (Azure Monitor, Azure Data Explorer, Prometheus, MSSQL).
+forward_settings_to_plugins =
+
 #################################### Role-based Access Control ###########
 [rbac]
 # If enabled, cache permissions in a in memory cache

--- a/conf/sample.ini
+++ b/conf/sample.ini
@@ -859,6 +859,10 @@
 # By default is the same as used in AAD authentication or can be set to another application (for OBO flow)
 ;user_identity_client_secret =
 
+# Set the plugins that will receive Azure settings via plugin context
+# By default this will always include all Grafana Labs owned Azure plugins, or those that make use of Azure settings (Azure Monitor, Azure Data Explorer, Prometheus, MSSQL).
+;forward_settings_to_plugins =
+
 #################################### Role-based Access Control ###########
 [rbac]
 ;permission_cache = true

--- a/conf/sample.ini
+++ b/conf/sample.ini
@@ -859,9 +859,9 @@
 # By default is the same as used in AAD authentication or can be set to another application (for OBO flow)
 ;user_identity_client_secret =
 
-# Set the plugins that will receive Azure settings via plugin context
-# By default this will always include all Grafana Labs owned Azure plugins, or those that make use of Azure settings (Azure Monitor, Azure Data Explorer, Prometheus, MSSQL).
-;forward_settings_to_plugins =
+# Set the plugins that will receive Azure settings for each request (via plugin context)
+# By default this will include all Grafana Labs owned Azure plugins, or those that make use of Azure settings (Azure Monitor, Azure Data Explorer, Prometheus, MSSQL).
+;forward_settings_to_plugins = grafana-azure-monitor-datasource, prometheus, grafana-azure-data-explorer-datasource, mssql
 
 #################################### Role-based Access Control ###########
 [rbac]

--- a/docs/sources/setup-grafana/configure-grafana/_index.md
+++ b/docs/sources/setup-grafana/configure-grafana/_index.md
@@ -1221,6 +1221,12 @@ Override the AAD application client secret.
 
 By default is the same as used in AAD authentication or can be set to another application (for OBO flow).
 
+### forward_settings_to_plugins
+
+Set any additional plugins that will receive Azure settings via plugin context.
+
+By default this will always include all Grafana Labs owned Azure plugins, or those that make use of Azure settings (Azure Monitor, Azure Data Explorer, Prometheus, MSSQL).
+
 ## [auth.jwt]
 
 Refer to [JWT authentication]({{< relref "../configure-security/configure-authentication/jwt" >}}) for more information.

--- a/docs/sources/setup-grafana/configure-grafana/_index.md
+++ b/docs/sources/setup-grafana/configure-grafana/_index.md
@@ -1223,9 +1223,9 @@ By default is the same as used in AAD authentication or can be set to another ap
 
 ### forward_settings_to_plugins
 
-Set any additional plugins that will receive Azure settings via plugin context.
+Set plugins that will receive Azure settings via plugin context.
 
-By default this will always include all Grafana Labs owned Azure plugins, or those that make use of Azure settings (Azure Monitor, Azure Data Explorer, Prometheus, MSSQL).
+By default this will include all Grafana Labs owned Azure plugins, or those that make use of Azure settings (Azure Monitor, Azure Data Explorer, Prometheus, MSSQL).
 
 ## [auth.jwt]
 

--- a/docs/sources/setup-grafana/configure-grafana/_index.md
+++ b/docs/sources/setup-grafana/configure-grafana/_index.md
@@ -1225,7 +1225,7 @@ By default is the same as used in AAD authentication or can be set to another ap
 
 Set plugins that will receive Azure settings via plugin context.
 
-By default this will include all Grafana Labs owned Azure plugins, or those that make use of Azure settings (Azure Monitor, Azure Data Explorer, Prometheus, MSSQL).
+By default, this will include all Grafana Labs owned Azure plugins or those that use Azure settings (Azure Monitor, Azure Data Explorer, Prometheus, MSSQL).
 
 ## [auth.jwt]
 

--- a/go.mod
+++ b/go.mod
@@ -66,7 +66,7 @@ require (
 	github.com/grafana/alerting v0.0.0-20231101090315-bf12694896a8 // @grafana/alerting-squad-backend
 	github.com/grafana/cuetsy v0.1.11 // @grafana/grafana-as-code
 	github.com/grafana/grafana-aws-sdk v0.19.1 // @grafana/aws-datasources
-	github.com/grafana/grafana-azure-sdk-go v1.9.0 // @grafana/backend-platform
+	github.com/grafana/grafana-azure-sdk-go v1.11.0 // @grafana/backend-platform
 	github.com/grafana/grafana-plugin-sdk-go v0.196.0 // @grafana/plugins-platform-backend
 	github.com/grpc-ecosystem/go-grpc-middleware v1.4.0 // @grafana/backend-platform
 	github.com/hashicorp/go-hclog v1.5.0 // @grafana/plugins-platform-backend
@@ -227,7 +227,7 @@ require (
 
 require (
 	cloud.google.com/go/kms v1.15.2 // @grafana/backend-platform
-	github.com/Azure/azure-sdk-for-go/sdk/azidentity v1.3.0 // @grafana/backend-platform
+	github.com/Azure/azure-sdk-for-go/sdk/azidentity v1.4.0 // @grafana/backend-platform
 	github.com/Azure/azure-sdk-for-go/sdk/keyvault/azkeys v0.9.0 // @grafana/backend-platform
 	github.com/Azure/azure-storage-blob-go v0.15.0 // @grafana/backend-platform
 	github.com/Azure/go-autorest/autorest/adal v0.9.22 // @grafana/backend-platform
@@ -435,9 +435,9 @@ require (
 	cloud.google.com/go/compute v1.23.0 // indirect
 	cloud.google.com/go/iam v1.1.2 // indirect
 	filippo.io/age v1.1.1 // @grafana/grafana-authnz-team
-	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.6.1 // indirect
+	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.8.0 // indirect
 	github.com/Azure/azure-sdk-for-go/sdk/keyvault/internal v0.7.0 // indirect
-	github.com/AzureAD/microsoft-authentication-library-for-go v1.0.0 // indirect
+	github.com/AzureAD/microsoft-authentication-library-for-go v1.1.1 // indirect
 	github.com/Masterminds/sprig/v3 v3.2.2 // @grafana/backend-platform
 	github.com/Microsoft/go-winio v0.6.0 // indirect
 	github.com/ProtonMail/go-crypto v0.0.0-20230828082145-3c4c8a2d2371 // @grafana/plugins-platform-backend
@@ -476,6 +476,7 @@ require (
 )
 
 require (
+	github.com/golang-jwt/jwt/v5 v5.0.0 // indirect
 	github.com/google/gnostic-models v0.6.8 // indirect
 	github.com/matttproud/golang_protobuf_extensions/v2 v2.0.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -560,11 +560,12 @@ github.com/Azure/azure-sdk-for-go v65.0.0+incompatible h1:HzKLt3kIwMm4KeJYTdx9Eb
 github.com/Azure/azure-sdk-for-go v65.0.0+incompatible/go.mod h1:9XXNKU+eRnpl9moKnB4QOLf1HestfXbmab5FXxiDBjc=
 github.com/Azure/azure-sdk-for-go/sdk/azcore v0.19.0/go.mod h1:h6H6c8enJmmocHUbLiiGY6sx7f9i+X3m1CHdd5c6Rdw=
 github.com/Azure/azure-sdk-for-go/sdk/azcore v1.6.0/go.mod h1:bjGvMhVMb+EEm3VRNQawDMUyMMjo+S5ewNjflkep/0Q=
-github.com/Azure/azure-sdk-for-go/sdk/azcore v1.6.1 h1:SEy2xmstIphdPwNBUi7uhvjyjhVKISfwjfOJmuy7kg4=
-github.com/Azure/azure-sdk-for-go/sdk/azcore v1.6.1/go.mod h1:bjGvMhVMb+EEm3VRNQawDMUyMMjo+S5ewNjflkep/0Q=
+github.com/Azure/azure-sdk-for-go/sdk/azcore v1.8.0 h1:9kDVnTz3vbfweTqAUmk/a/pH5pWFCHtvRpHYC0G/dcA=
+github.com/Azure/azure-sdk-for-go/sdk/azcore v1.8.0/go.mod h1:3Ug6Qzto9anB6mGlEdgYMDF5zHQ+wwhEaYR4s17PHMw=
 github.com/Azure/azure-sdk-for-go/sdk/azidentity v0.11.0/go.mod h1:HcM1YX14R7CJcghJGOYCgdezslRSVzqwLf/q+4Y2r/0=
-github.com/Azure/azure-sdk-for-go/sdk/azidentity v1.3.0 h1:vcYCAze6p19qBW7MhZybIsqD8sMV8js0NyQM8JDnVtg=
 github.com/Azure/azure-sdk-for-go/sdk/azidentity v1.3.0/go.mod h1:OQeznEEkTZ9OrhHJoDD8ZDq51FHgXjqtP9z6bEwBq9U=
+github.com/Azure/azure-sdk-for-go/sdk/azidentity v1.4.0 h1:BMAjVKJM0U/CYF27gA0ZMmXGkOcvfFtD0oHVZ1TIPRI=
+github.com/Azure/azure-sdk-for-go/sdk/azidentity v1.4.0/go.mod h1:1fXstnBMas5kzG+S3q8UoJcmyU6nUeunJcMDHcRYHhs=
 github.com/Azure/azure-sdk-for-go/sdk/internal v0.7.0/go.mod h1:yqy467j36fJxcRV2TzfVZ1pCb5vxm4BtZPUdYWe/Xo8=
 github.com/Azure/azure-sdk-for-go/sdk/internal v1.3.0 h1:sXr+ck84g/ZlZUOZiNELInmMgOsuGwdjjVkEIde0OtY=
 github.com/Azure/azure-sdk-for-go/sdk/internal v1.3.0/go.mod h1:okt5dMMTOFjX/aovMlrjvvXoPMBVSPzk9185BT0+eZM=
@@ -612,8 +613,9 @@ github.com/Azure/go-autorest/tracing v0.6.0 h1:TYi4+3m5t6K48TGI9AUdb+IzbnSxvnvUM
 github.com/Azure/go-autorest/tracing v0.6.0/go.mod h1:+vhtPC754Xsa23ID7GlGsrdKBpUA79WCAKPPZVC2DeU=
 github.com/Azure/go-ntlmssp v0.0.0-20220621081337-cb9428e4ac1e h1:NeAW1fUYUEWhft7pkxDf6WoUvEZJ/uOKsvtpjLnn8MU=
 github.com/Azure/go-ntlmssp v0.0.0-20220621081337-cb9428e4ac1e/go.mod h1:chxPXzSsl7ZWRAuOIE23GDNzjWuZquvFlgA8xmpunjU=
-github.com/AzureAD/microsoft-authentication-library-for-go v1.0.0 h1:OBhqkivkhkMqLPymWEppkm7vgPQY2XsHoEkaMQ0AdZY=
 github.com/AzureAD/microsoft-authentication-library-for-go v1.0.0/go.mod h1:kgDmCTgBzIEPFElEF+FK0SdjAor06dRq2Go927dnQ6o=
+github.com/AzureAD/microsoft-authentication-library-for-go v1.1.1 h1:WpB/QDNLpMw72xHJc34BNNykqSOeEJDAWkhf0u12/Jk=
+github.com/AzureAD/microsoft-authentication-library-for-go v1.1.1/go.mod h1:wP83P5OoQ5p6ip3ScPr0BAq0BvuPAvacpEuSzyouqAI=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/BurntSushi/toml v1.3.2 h1:o7IhLm0Msx3BaB+n3Ag7L8EVlByGnpq14C4YWiu/gL8=
 github.com/BurntSushi/toml v1.3.2/go.mod h1:CxXYINrC8qIiEnFrOxCa7Jy5BFHlXnUU2pbicEuybxQ=
@@ -1594,6 +1596,8 @@ github.com/golang-jwt/jwt/v4 v4.4.1/go.mod h1:m21LjoU+eqJr34lmDMbreY2eSTRJ1cv77w
 github.com/golang-jwt/jwt/v4 v4.4.3/go.mod h1:m21LjoU+eqJr34lmDMbreY2eSTRJ1cv77w39/MY0Ch0=
 github.com/golang-jwt/jwt/v4 v4.5.0 h1:7cYmW1XlMY7h7ii7UhUyChSgS5wUJEnm9uZVTGqOWzg=
 github.com/golang-jwt/jwt/v4 v4.5.0/go.mod h1:m21LjoU+eqJr34lmDMbreY2eSTRJ1cv77w39/MY0Ch0=
+github.com/golang-jwt/jwt/v5 v5.0.0 h1:1n1XNM9hk7O9mnQoNBGolZvzebBQ7p93ULHRc28XJUE=
+github.com/golang-jwt/jwt/v5 v5.0.0/go.mod h1:pqrtFR0X4osieyHYxtmOUWsAWrfe1Q5UVIyoH402zdk=
 github.com/golang-migrate/migrate/v4 v4.7.0 h1:gONcHxHApDTKXDyLH/H97gEHmpu1zcnnbAaq2zgrPrs=
 github.com/golang-migrate/migrate/v4 v4.7.0/go.mod h1:Qvut3N4xKWjoH3sokBccML6WyHSnggXm/DvMMnTsQIc=
 github.com/golang-sql/civil v0.0.0-20190719163853-cb61b32ac6fe/go.mod h1:8vg3r2VgvsThLBIFL93Qb5yWzgyZWhEmBwUJWevAkK0=
@@ -1808,8 +1812,8 @@ github.com/grafana/gofpdf v0.0.0-20231002120153-857cc45be447 h1:jxJJ5z0GxqhWFbQU
 github.com/grafana/gofpdf v0.0.0-20231002120153-857cc45be447/go.mod h1:IxsY6mns6Q5sAnWcrptrgUrSglTZJXH/kXr9nbpb/9I=
 github.com/grafana/grafana-aws-sdk v0.19.1 h1:5GBiOv2AgdyjwlgAX+dtgPtXU4FgMTD9rfQUPQseEpQ=
 github.com/grafana/grafana-aws-sdk v0.19.1/go.mod h1:ntq2NDH12Y2Fkbc6fozpF8kYsJM9k6KNr+Xfo5w3/iM=
-github.com/grafana/grafana-azure-sdk-go v1.9.0 h1:4JRwlqgUtPRAQSoiV4DFZDQ3lbNsauHqj9kC6SMR9Ak=
-github.com/grafana/grafana-azure-sdk-go v1.9.0/go.mod h1:1vBa0KOl+/Kcm7V888OyMXDSFncmek14q7XhEkrcSaA=
+github.com/grafana/grafana-azure-sdk-go v1.11.0 h1:nc6MgOZ5fIaxvBfZjYU5rSqB4zaD7rlU8BqnGcXZtWk=
+github.com/grafana/grafana-azure-sdk-go v1.11.0/go.mod h1:5a3FuG2lEsYNop9HDNgTO1bx4ExCgsjvrFhpuqolYAU=
 github.com/grafana/grafana-google-sdk-go v0.1.0 h1:LKGY8z2DSxKjYfr2flZsWgTRTZ6HGQbTqewE3JvRaNA=
 github.com/grafana/grafana-google-sdk-go v0.1.0/go.mod h1:Vo2TKWfDVmNTELBUM+3lkrZvFtBws0qSZdXhQxRdJrE=
 github.com/grafana/grafana-plugin-sdk-go v0.94.0/go.mod h1:3VXz4nCv6wH5SfgB3mlW39s+c+LetqSCjFj7xxPC5+M=

--- a/pkg/plugins/envvars/envvars.go
+++ b/pkg/plugins/envvars/envvars.go
@@ -145,7 +145,7 @@ func (s *Service) GetConfigMap(ctx context.Context, pluginID string, _ *auth.Ext
 		m[proxy.PluginSecureSocksProxyServerName] = s.cfg.ProxySettings.ServerName
 	}
 
-	// Changes here need to be reflected in https://github.com/grafana/grafana-plugin-sdk-go/tree/main/backend/config.go#L152
+	// Changes here need to be reflected in https://github.com/grafana/grafana-azure-sdk-go/tree/main/azsettings/settings.go#L49
 	azureSettings := s.cfg.Azure
 	if azureSettings != nil && slices.Contains[[]string, string](azureSettings.ForwardSettingsPlugins, pluginID) {
 		if azureSettings.Cloud != "" {

--- a/pkg/plugins/envvars/envvars.go
+++ b/pkg/plugins/envvars/envvars.go
@@ -147,8 +147,7 @@ func (s *Service) GetConfigMap(ctx context.Context, pluginID string, _ *auth.Ext
 
 	// Changes here need to be reflected in https://github.com/grafana/grafana-plugin-sdk-go/tree/main/backend/config.go#L152
 	azureSettings := s.cfg.Azure
-	azureDatasources := []string{"grafana-azure-monitor-datasource", "prometheus", "grafana-azure-data-explorer-datasource"}
-	if azureSettings != nil && slices.Contains[[]string, string](azureDatasources, pluginID) {
+	if azureSettings != nil && slices.Contains[[]string, string](azureSettings.ForwardSettingsPlugins, pluginID) {
 		if azureSettings.Cloud != "" {
 			m[azsettings.AzureCloud] = azureSettings.Cloud
 		}

--- a/pkg/plugins/envvars/envvars.go
+++ b/pkg/plugins/envvars/envvars.go
@@ -145,7 +145,7 @@ func (s *Service) GetConfigMap(ctx context.Context, pluginID string, _ *auth.Ext
 		m[proxy.PluginSecureSocksProxyServerName] = s.cfg.ProxySettings.ServerName
 	}
 
-	// Changes here need to be reflected in https://github.com/grafana/grafana-azure-sdk-go/tree/main/azsettings/settings.go#L49
+	// Settings here will be extracted by grafana-azure-sdk-go from the plugin context
 	azureSettings := s.cfg.Azure
 	if azureSettings != nil && slices.Contains[[]string, string](azureSettings.ForwardSettingsPlugins, pluginID) {
 		if azureSettings.Cloud != "" {

--- a/pkg/plugins/envvars/envvars.go
+++ b/pkg/plugins/envvars/envvars.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"slices"
 	"sort"
 	"strconv"
 	"strings"
@@ -98,7 +99,7 @@ func (s *Service) Get(ctx context.Context, p *plugins.Plugin) []string {
 }
 
 // GetConfigMap returns a map of configuration that should be passed in a plugin request.
-func (s *Service) GetConfigMap(ctx context.Context, _ string, _ *auth.ExternalService) map[string]string {
+func (s *Service) GetConfigMap(ctx context.Context, pluginID string, _ *auth.ExternalService) map[string]string {
 	m := make(map[string]string)
 
 	if s.cfg.GrafanaAppURL != "" {
@@ -146,7 +147,8 @@ func (s *Service) GetConfigMap(ctx context.Context, _ string, _ *auth.ExternalSe
 
 	// Changes here need to be reflected in https://github.com/grafana/grafana-plugin-sdk-go/tree/main/backend/config.go#L152
 	azureSettings := s.cfg.Azure
-	if azureSettings != nil {
+	azureDatasources := []string{"grafana-azure-monitor-datasource", "prometheus", "grafana-azure-data-explorer-datasource"}
+	if azureSettings != nil && slices.Contains[[]string, string](azureDatasources, pluginID) {
 		if azureSettings.Cloud != "" {
 			m[azsettings.AzureCloud] = azureSettings.Cloud
 		}

--- a/pkg/plugins/envvars/envvars.go
+++ b/pkg/plugins/envvars/envvars.go
@@ -144,40 +144,56 @@ func (s *Service) GetConfigMap(ctx context.Context, _ string, _ *auth.ExternalSe
 		m[proxy.PluginSecureSocksProxyServerName] = s.cfg.ProxySettings.ServerName
 	}
 
-	// TODO add support via plugin SDK
-	//azureSettings := s.cfg.Azure
-	//if azureSettings != nil {
-	//	if azureSettings.Cloud != "" {
-	//		m[azsettings.AzureCloud] = azureSettings.Cloud
-	//	}
-	//
-	//	if azureSettings.ManagedIdentityEnabled {
-	//		m[azsettings.ManagedIdentityEnabled] = "true"
-	//
-	//		if azureSettings.ManagedIdentityClientId != "" {
-	//			m[azsettings.ManagedIdentityClientID] = azureSettings.ManagedIdentityClientId
-	//		}
-	//	}
-	//
-	//	if azureSettings.UserIdentityEnabled {
-	//		m[azsettings.UserIdentityEnabled] = "true"
-	//
-	//		if azureSettings.UserIdentityTokenEndpoint != nil {
-	//			if azureSettings.UserIdentityTokenEndpoint.TokenUrl != "" {
-	//				m[azsettings.UserIdentityTokenURL] = azureSettings.UserIdentityTokenEndpoint.TokenUrl
-	//			}
-	//			if azureSettings.UserIdentityTokenEndpoint.ClientId != "" {
-	//				m[azsettings.UserIdentityClientID] = azureSettings.UserIdentityTokenEndpoint.ClientId
-	//			}
-	//			if azureSettings.UserIdentityTokenEndpoint.ClientSecret != "" {
-	//				m[azsettings.UserIdentityClientSecret] = azureSettings.UserIdentityTokenEndpoint.ClientSecret
-	//			}
-	//			if azureSettings.UserIdentityTokenEndpoint.UsernameAssertion {
-	//				m[azsettings.UserIdentityAssertion] = "username"
-	//			}
-	//		}
-	//	}
-	//}
+	// Changes here need to be reflected in https://github.com/grafana/grafana-plugin-sdk-go/tree/main/backend/config.go#L152
+	azureSettings := s.cfg.Azure
+	if azureSettings != nil {
+		if azureSettings.Cloud != "" {
+			m[azsettings.AzureCloud] = azureSettings.Cloud
+		}
+
+		if azureSettings.ManagedIdentityEnabled {
+			m[azsettings.ManagedIdentityEnabled] = "true"
+
+			if azureSettings.ManagedIdentityClientId != "" {
+				m[azsettings.ManagedIdentityClientID] = azureSettings.ManagedIdentityClientId
+			}
+		}
+
+		if azureSettings.UserIdentityEnabled {
+			m[azsettings.UserIdentityEnabled] = "true"
+
+			if azureSettings.UserIdentityTokenEndpoint != nil {
+				if azureSettings.UserIdentityTokenEndpoint.TokenUrl != "" {
+					m[azsettings.UserIdentityTokenURL] = azureSettings.UserIdentityTokenEndpoint.TokenUrl
+				}
+				if azureSettings.UserIdentityTokenEndpoint.ClientId != "" {
+					m[azsettings.UserIdentityClientID] = azureSettings.UserIdentityTokenEndpoint.ClientId
+				}
+				if azureSettings.UserIdentityTokenEndpoint.ClientSecret != "" {
+					m[azsettings.UserIdentityClientSecret] = azureSettings.UserIdentityTokenEndpoint.ClientSecret
+				}
+				if azureSettings.UserIdentityTokenEndpoint.UsernameAssertion {
+					m[azsettings.UserIdentityAssertion] = "username"
+				}
+			}
+		}
+
+		if azureSettings.WorkloadIdentityEnabled {
+			m[azsettings.WorkloadIdentityEnabled] = "true"
+
+			if azureSettings.WorkloadIdentitySettings != nil {
+				if azureSettings.WorkloadIdentitySettings.ClientId != "" {
+					m[azsettings.WorkloadIdentityClientID] = azureSettings.WorkloadIdentitySettings.ClientId
+				}
+				if azureSettings.WorkloadIdentitySettings.TenantId != "" {
+					m[azsettings.WorkloadIdentityTenantID] = azureSettings.WorkloadIdentitySettings.TenantId
+				}
+				if azureSettings.WorkloadIdentitySettings.TokenFile != "" {
+					m[azsettings.WorkloadIdentityTokenFile] = azureSettings.WorkloadIdentitySettings.TokenFile
+				}
+			}
+		}
+	}
 
 	// TODO add support via plugin SDK
 	//ps := getPluginSettings(pluginID, s.cfg)

--- a/pkg/plugins/envvars/envvars_test.go
+++ b/pkg/plugins/envvars/envvars_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/grafana/grafana-azure-sdk-go/azsettings"
 	"github.com/grafana/grafana/pkg/plugins"
 	"github.com/grafana/grafana/pkg/plugins/auth"
 	"github.com/grafana/grafana/pkg/plugins/config"
@@ -598,6 +599,45 @@ func TestInitializer_featureToggleEnvVar(t *testing.T) {
 	})
 }
 
+func TestInitalizer_azureEnvVars(t *testing.T) {
+	t.Run("backend datasource with azure settings", func(t *testing.T) {
+		p := &plugins.Plugin{}
+		envVarsProvider := NewProvider(&config.Cfg{
+			Azure: &azsettings.AzureSettings{
+				Cloud:                   azsettings.AzurePublic,
+				ManagedIdentityEnabled:  true,
+				ManagedIdentityClientId: "mock_managed_identity_client_id",
+				WorkloadIdentityEnabled: true,
+				WorkloadIdentitySettings: &azsettings.WorkloadIdentitySettings{
+					TenantId:  "mock_workload_identity_tenant_id",
+					ClientId:  "mock_workload_identity_client_id",
+					TokenFile: "mock_workload_identity_token_file",
+				},
+				UserIdentityEnabled: true,
+				UserIdentityTokenEndpoint: &azsettings.TokenEndpointSettings{
+					TokenUrl:          "mock_user_identity_token_url",
+					ClientId:          "mock_user_identity_client_id",
+					ClientSecret:      "mock_user_identity_client_secret",
+					UsernameAssertion: true,
+				},
+			},
+		}, nil)
+		envVars := envVarsProvider.Get(context.Background(), p)
+		assert.ElementsMatch(t, []string{"GF_VERSION=", "GFAZPL_AZURE_CLOUD=AzureCloud", "GFAZPL_MANAGED_IDENTITY_ENABLED=true",
+			"GFAZPL_MANAGED_IDENTITY_CLIENT_ID=mock_managed_identity_client_id",
+			"GFAZPL_WORKLOAD_IDENTITY_ENABLED=true",
+			"GFAZPL_WORKLOAD_IDENTITY_TENANT_ID=mock_workload_identity_tenant_id",
+			"GFAZPL_WORKLOAD_IDENTITY_CLIENT_ID=mock_workload_identity_client_id",
+			"GFAZPL_WORKLOAD_IDENTITY_TOKEN_FILE=mock_workload_identity_token_file",
+			"GFAZPL_USER_IDENTITY_ENABLED=true",
+			"GFAZPL_USER_IDENTITY_TOKEN_URL=mock_user_identity_token_url",
+			"GFAZPL_USER_IDENTITY_CLIENT_ID=mock_user_identity_client_id",
+			"GFAZPL_USER_IDENTITY_CLIENT_SECRET=mock_user_identity_client_secret",
+			"GFAZPL_USER_IDENTITY_ASSERTION=username",
+		}, envVars)
+	})
+}
+
 func TestService_GetConfigMap(t *testing.T) {
 	tcs := []struct {
 		name     string
@@ -728,5 +768,45 @@ func TestService_GetConfigMap_appURL(t *testing.T) {
 			},
 		}
 		require.Equal(t, map[string]string{"GF_APP_URL": "https://myorg.com/"}, s.GetConfigMap(context.Background(), "", nil))
+	})
+}
+
+func TestService_GetConfigMap_azure(t *testing.T) {
+	t.Run("Uses the azure settings", func(t *testing.T) {
+		s := &Service{
+			cfg: &config.Cfg{
+				Azure: &azsettings.AzureSettings{
+					Cloud:                   azsettings.AzurePublic,
+					ManagedIdentityEnabled:  true,
+					ManagedIdentityClientId: "mock_managed_identity_client_id",
+					WorkloadIdentityEnabled: true,
+					WorkloadIdentitySettings: &azsettings.WorkloadIdentitySettings{
+						TenantId:  "mock_workload_identity_tenant_id",
+						ClientId:  "mock_workload_identity_client_id",
+						TokenFile: "mock_workload_identity_token_file",
+					},
+					UserIdentityEnabled: true,
+					UserIdentityTokenEndpoint: &azsettings.TokenEndpointSettings{
+						TokenUrl:          "mock_user_identity_token_url",
+						ClientId:          "mock_user_identity_client_id",
+						ClientSecret:      "mock_user_identity_client_secret",
+						UsernameAssertion: true,
+					},
+				},
+			},
+		}
+		require.Equal(t, map[string]string{
+			"GFAZPL_AZURE_CLOUD": "AzureCloud", "GFAZPL_MANAGED_IDENTITY_ENABLED": "true",
+			"GFAZPL_MANAGED_IDENTITY_CLIENT_ID":   "mock_managed_identity_client_id",
+			"GFAZPL_WORKLOAD_IDENTITY_ENABLED":    "true",
+			"GFAZPL_WORKLOAD_IDENTITY_TENANT_ID":  "mock_workload_identity_tenant_id",
+			"GFAZPL_WORKLOAD_IDENTITY_CLIENT_ID":  "mock_workload_identity_client_id",
+			"GFAZPL_WORKLOAD_IDENTITY_TOKEN_FILE": "mock_workload_identity_token_file",
+			"GFAZPL_USER_IDENTITY_ENABLED":        "true",
+			"GFAZPL_USER_IDENTITY_TOKEN_URL":      "mock_user_identity_token_url",
+			"GFAZPL_USER_IDENTITY_CLIENT_ID":      "mock_user_identity_client_id",
+			"GFAZPL_USER_IDENTITY_CLIENT_SECRET":  "mock_user_identity_client_secret",
+			"GFAZPL_USER_IDENTITY_ASSERTION":      "username",
+		}, s.GetConfigMap(context.Background(), "", nil))
 	})
 }

--- a/pkg/setting/setting_azure.go
+++ b/pkg/setting/setting_azure.go
@@ -64,9 +64,7 @@ func (cfg *Cfg) readAzureSettings() {
 		azureSettings.UserIdentityTokenEndpoint = tokenEndpointSettings
 	}
 
-	if plugins := util.SplitString(azureSection.Key("forward_settings_to_plugins").String()); len(plugins) > 0 {
-		azureSettings.ForwardSettingsPlugins = plugins
-	}
+	azureSettings.ForwardSettingsPlugins = util.SplitString(azureSection.Key("forward_settings_to_plugins").String())
 
 	cfg.Azure = azureSettings
 }

--- a/pkg/setting/setting_azure.go
+++ b/pkg/setting/setting_azure.go
@@ -63,5 +63,12 @@ func (cfg *Cfg) readAzureSettings() {
 		azureSettings.UserIdentityTokenEndpoint = tokenEndpointSettings
 	}
 
+	azurePlugins := []string{"grafana-azure-monitor-datasource", "prometheus", "grafana-azure-data-explorer-datasource", "mssql"}
+	if plugins := azureSection.Key("forward_settings_to_plugins").Strings(","); len(plugins) > 0 {
+		azureSettings.ForwardSettingsPlugins = append(azurePlugins, plugins...)
+	} else {
+		azureSettings.ForwardSettingsPlugins = azurePlugins
+	}
+
 	cfg.Azure = azureSettings
 }

--- a/pkg/setting/setting_azure.go
+++ b/pkg/setting/setting_azure.go
@@ -2,6 +2,7 @@ package setting
 
 import (
 	"github.com/grafana/grafana-azure-sdk-go/azsettings"
+	"github.com/grafana/grafana/pkg/util"
 )
 
 func (cfg *Cfg) readAzureSettings() {
@@ -63,11 +64,8 @@ func (cfg *Cfg) readAzureSettings() {
 		azureSettings.UserIdentityTokenEndpoint = tokenEndpointSettings
 	}
 
-	azurePlugins := []string{"grafana-azure-monitor-datasource", "prometheus", "grafana-azure-data-explorer-datasource", "mssql"}
-	if plugins := azureSection.Key("forward_settings_to_plugins").Strings(","); len(plugins) > 0 {
-		azureSettings.ForwardSettingsPlugins = append(azurePlugins, plugins...)
-	} else {
-		azureSettings.ForwardSettingsPlugins = azurePlugins
+	if plugins := util.SplitString(azureSection.Key("forward_settings_to_plugins").String()); len(plugins) > 0 {
+		azureSettings.ForwardSettingsPlugins = plugins
 	}
 
 	cfg.Azure = azureSettings

--- a/pkg/setting/setting_azure_test.go
+++ b/pkg/setting/setting_azure_test.go
@@ -245,5 +245,4 @@ func TestAzureSettings(t *testing.T) {
 			})
 		}
 	})
-
 }

--- a/pkg/setting/setting_azure_test.go
+++ b/pkg/setting/setting_azure_test.go
@@ -217,21 +217,15 @@ func TestAzureSettings(t *testing.T) {
 	})
 
 	t.Run("forward settings to plugins", func(t *testing.T) {
-		defaultPlugins := []string{"grafana-azure-monitor-datasource", "prometheus", "grafana-azure-data-explorer-datasource", "mssql"}
 		testCases := []struct {
 			name            string
 			configuredValue string
 			resolvedValue   []string
 		}{
 			{
-				name:            "should be Grafana Labs data sources if not set",
-				configuredValue: "",
-				resolvedValue:   defaultPlugins,
-			},
-			{
-				name:            "should append a user specified plugin if set",
+				name:            "should be set to user plugins if set",
 				configuredValue: "test-datasource",
-				resolvedValue:   append(defaultPlugins, "test-datasource"),
+				resolvedValue:   []string{"test-datasource"},
 			},
 		}
 

--- a/pkg/setting/setting_azure_test.go
+++ b/pkg/setting/setting_azure_test.go
@@ -215,4 +215,41 @@ func TestAzureSettings(t *testing.T) {
 			assert.Empty(t, cfg.Azure.UserIdentityTokenEndpoint.ClientSecret)
 		})
 	})
+
+	t.Run("forward settings to plugins", func(t *testing.T) {
+		defaultPlugins := []string{"grafana-azure-monitor-datasource", "prometheus", "grafana-azure-data-explorer-datasource", "mssql"}
+		testCases := []struct {
+			name            string
+			configuredValue string
+			resolvedValue   []string
+		}{
+			{
+				name:            "should be Grafana Labs data sources if not set",
+				configuredValue: "",
+				resolvedValue:   defaultPlugins,
+			},
+			{
+				name:            "should append a user specified plugin if set",
+				configuredValue: "test-datasource",
+				resolvedValue:   append(defaultPlugins, "test-datasource"),
+			},
+		}
+
+		for _, c := range testCases {
+			t.Run(c.name, func(t *testing.T) {
+				cfg := NewCfg()
+
+				azureSection, err := cfg.Raw.NewSection("azure")
+				require.NoError(t, err)
+				_, err = azureSection.NewKey("forward_settings_to_plugins", c.configuredValue)
+				require.NoError(t, err)
+
+				cfg.readAzureSettings()
+				require.NotNil(t, cfg.Azure)
+
+				assert.Equal(t, c.resolvedValue, cfg.Azure.ForwardSettingsPlugins)
+			})
+		}
+	})
+
 }


### PR DESCRIPTION
Updates the Grafana config sent to plugins to include the Azure settings from the Grafana instance.

Note that these variables will only be included in requests to the following data sources by default:
- Azure Monitor (ID: `grafana-azure-monitor-datasource`)
- Prometheus (ID: `prometheus`)
- Azure Data Explorer (ID:  `grafana-azure-data-explorer-datasource`)
- MSSQL (ID: `mssql`)

These variables can be read from the request context sent to a specified plugin by using the `ReadSettings` or `ReadFromContext` functions from [grafana-azure-sdk-go](https://github.com/grafana/grafana-azure-sdk-go).

The plugins that receive the settings via context can be overridden via the `forward_settings_to_plugins` configuration variable in the `ini` file.