### PR TITLE
`accesscontrol` swagger: Add `global` field to `RoleDTO` type

### DIFF
--- a/pkg/services/accesscontrol/models.go
+++ b/pkg/services/accesscontrol/models.go
@@ -50,18 +50,20 @@ func (r *Role) IsBasic() bool {
 	return strings.HasPrefix(r.Name, BasicRolePrefix) || strings.HasPrefix(r.UID, BasicRoleUIDPrefix)
 }
 
-func (r Role) MarshalJSON() ([]byte, error) {
-	type Alias Role
-
-	return json.Marshal(&struct {
-		Alias
-		Global bool `json:"global" xorm:"-"`
-	}{
-		Alias:  (Alias)(r),
-		Global: r.Global(),
-	})
+type RoleStatic struct {
+	Role
+	Global bool `json:"global" xorm:"-"`
 }
 
+func (r Role) MarshalJSON() ([]byte, error) {
+	static := RoleStatic{
+		Role:   r,
+		Global: r.Global(),
+	}
+	return json.Marshal(&static)
+}
+
+// swagger:ignore
 type RoleDTO struct {
 	Version     int64        `json:"version"`
 	UID         string       `xorm:"uid" json:"uid"`
@@ -135,16 +137,18 @@ func (r *RoleDTO) IsExternalService() bool {
 	return strings.HasPrefix(r.Name, ExternalServiceRolePrefix) || strings.HasPrefix(r.UID, ExternalServiceRoleUIDPrefix)
 }
 
-func (r RoleDTO) MarshalJSON() ([]byte, error) {
-	type Alias RoleDTO
+// swagger:model RoleDTO
+type RoleDTOStatic struct {
+	RoleDTO
+	Global bool `json:"global" xorm:"-"`
+}
 
-	return json.Marshal(&struct {
-		Alias
-		Global bool `json:"global" xorm:"-"`
-	}{
-		Alias:  (Alias)(r),
-		Global: r.Global(),
-	})
+func (r RoleDTO) MarshalJSON() ([]byte, error) {
+	static := RoleDTOStatic{
+		RoleDTO: r,
+		Global:  r.Global(),
+	}
+	return json.Marshal(&static)
 }
 
 type TeamRole struct {

--- a/pkg/services/accesscontrol/models.go
+++ b/pkg/services/accesscontrol/models.go
@@ -50,17 +50,16 @@ func (r *Role) IsBasic() bool {
 	return strings.HasPrefix(r.Name, BasicRolePrefix) || strings.HasPrefix(r.UID, BasicRoleUIDPrefix)
 }
 
-type RoleStatic struct {
-	Role
-	Global bool `json:"global" xorm:"-"`
-}
-
 func (r Role) MarshalJSON() ([]byte, error) {
-	static := RoleStatic{
-		Role:   r,
+	type Alias Role
+
+	return json.Marshal(&struct {
+		Alias
+		Global bool `json:"global" xorm:"-"`
+	}{
+		Alias:  (Alias)(r),
 		Global: r.Global(),
-	}
-	return json.Marshal(&static)
+	})
 }
 
 // swagger:ignore
@@ -144,11 +143,15 @@ type RoleDTOStatic struct {
 }
 
 func (r RoleDTO) MarshalJSON() ([]byte, error) {
-	static := RoleDTOStatic{
-		RoleDTO: r,
-		Global:  r.Global(),
-	}
-	return json.Marshal(&static)
+	type Alias RoleDTO
+
+	return json.Marshal(&struct {
+		Alias
+		Global bool `json:"global" xorm:"-"`
+	}{
+		Alias:  (Alias)(r),
+		Global: r.Global(),
+	})
 }
 
 type TeamRole struct {

--- a/public/api-enterprise-spec.json
+++ b/public/api-enterprise-spec.json
@@ -4214,7 +4214,11 @@
           "type": "boolean"
         },
         "id": {
-          "description": "Deprecated: use Uid instead",
+          "description": "Deprecated: use UID instead",
+          "type": "integer",
+          "format": "int64"
+        },
+        "orgId": {
           "type": "integer",
           "format": "int64"
         },
@@ -6332,6 +6336,9 @@
         },
         "displayName": {
           "type": "string"
+        },
+        "global": {
+          "type": "boolean"
         },
         "group": {
           "type": "string"

--- a/public/api-merged.json
+++ b/public/api-merged.json
@@ -18033,6 +18033,9 @@
         "displayName": {
           "type": "string"
         },
+        "global": {
+          "type": "boolean"
+        },
         "group": {
           "type": "string"
         },

--- a/public/openapi3.json
+++ b/public/openapi3.json
@@ -9049,6 +9049,9 @@
           "displayName": {
             "type": "string"
           },
+          "global": {
+            "type": "boolean"
+          },
           "group": {
             "type": "string"
           },


### PR DESCRIPTION
The field is currently added in the MarshalJSON function so it isn't reflected in the spec 

This PR sets the "static" version of the RoleDTO, that has the global field, as the swagger model
