### PR TITLE
Loki: strip out invalid options for logs/metrics queries

### DIFF
--- a/public/app/plugins/datasource/loki/datasource.test.ts
+++ b/public/app/plugins/datasource/loki/datasource.test.ts
@@ -181,10 +181,14 @@ describe('LokiDatasource', () => {
 
     it('should ignore log lines for metric query', async () => {
       const query = getQueryOptions<LokiQuery>({
-        targets: [{ expr: 'rate({bar="baz", job="foo"} |= "bar" [5m])', refId: 'A', maxLines: 0 }],
+        targets: [{ expr: 'rate({bar="baz", job="foo"} |= "bar" [5m])', refId: 'A', maxLines: 0, step: '1m' }],
         app: CoreApp.Dashboard,
       });
-      await runTest(undefined, '40', undefined, undefined, query);
+      const { response, spy } = await runTest(100, '40', undefined, undefined, query);
+      await expect(response).toEmitValuesWith(() => {
+        expect(spy.mock.calls[0][0].maxLines).toBe(undefined);
+        expect(spy.mock.calls[0][0].step).toBe('1m');
+      });
     });
 
     it('should ignore step for logs query', async () => {

--- a/public/app/plugins/datasource/loki/datasource.ts
+++ b/public/app/plugins/datasource/loki/datasource.ts
@@ -208,7 +208,7 @@ export class LokiDatasource
       return undefined;
     }
 
-    const normalizedQuery = getNormalizedLokiQuery(query);
+    const normalizedQuery = getNormalizedLokiQuery(query, query.maxLines ?? this.maxLines);
     const expr = removeCommentsFromQuery(normalizedQuery.expr);
     let isQuerySuitable = false;
 
@@ -293,10 +293,7 @@ export class LokiDatasource
    * @returns An Observable of DataQueryResponse containing the query results.
    */
   query(request: DataQueryRequest<LokiQuery>): Observable<DataQueryResponse> {
-    const queries = request.targets
-      .map(getNormalizedLokiQuery) // used to "fix" the deprecated `.queryType` prop
-      .map((q) => ({ ...q, maxLines: q.maxLines ?? this.maxLines }))
-      .map(removeInvalidOptions);
+    const queries = request.targets.map((q) => getNormalizedLokiQuery(q, q.maxLines ?? this.maxLines)); // used to "fix" the deprecated `.queryType` prop
 
     const fixedRequest: DataQueryRequest<LokiQuery> = {
       ...request,

--- a/public/app/plugins/datasource/loki/datasource.ts
+++ b/public/app/plugins/datasource/loki/datasource.ts
@@ -84,6 +84,7 @@ import {
   getStreamSelectorsFromQuery,
   isLogsQuery,
   isQueryWithError,
+  removeInvalidOptions,
   requestSupportsSplitting,
 } from './queryUtils';
 import { convertToWebSocketUrl, doLokiChannelStream } from './streaming';
@@ -294,7 +295,8 @@ export class LokiDatasource
   query(request: DataQueryRequest<LokiQuery>): Observable<DataQueryResponse> {
     const queries = request.targets
       .map(getNormalizedLokiQuery) // used to "fix" the deprecated `.queryType` prop
-      .map((q) => ({ ...q, maxLines: q.maxLines ?? this.maxLines }));
+      .map((q) => ({ ...q, maxLines: q.maxLines ?? this.maxLines }))
+      .map(removeInvalidOptions);
 
     const fixedRequest: DataQueryRequest<LokiQuery> = {
       ...request,

--- a/public/app/plugins/datasource/loki/queryUtils.test.ts
+++ b/public/app/plugins/datasource/loki/queryUtils.test.ts
@@ -134,20 +134,20 @@ describe('getHighlighterExpressionsFromQuery', () => {
 describe('getNormalizedLokiQuery', () => {
   it('removes deprecated instant property', () => {
     const input: LokiQuery = { refId: 'A', expr: 'test1', instant: true };
-    const output = getNormalizedLokiQuery(input);
-    expect(output).toStrictEqual({ refId: 'A', expr: 'test1', queryType: LokiQueryType.Instant });
+    const output = getNormalizedLokiQuery(input, 100);
+    expect(output).toStrictEqual({ refId: 'A', expr: 'test1', queryType: LokiQueryType.Instant, maxLines: 100 });
   });
 
   it('removes deprecated range property', () => {
     const input: LokiQuery = { refId: 'A', expr: 'test1', range: true };
     const output = getNormalizedLokiQuery(input);
-    expect(output).toStrictEqual({ refId: 'A', expr: 'test1', queryType: LokiQueryType.Range });
+    expect(output).toStrictEqual({ refId: 'A', expr: 'test1', queryType: LokiQueryType.Range, maxLines: undefined });
   });
 
   it('removes deprecated range and instant properties if query with queryType', () => {
     const input: LokiQuery = { refId: 'A', expr: 'test1', range: true, instant: false, queryType: LokiQueryType.Range };
     const output = getNormalizedLokiQuery(input);
-    expect(output).toStrictEqual({ refId: 'A', expr: 'test1', queryType: LokiQueryType.Range });
+    expect(output).toStrictEqual({ refId: 'A', expr: 'test1', queryType: LokiQueryType.Range, maxLines: undefined });
   });
 });
 describe('getLokiQueryType', () => {

--- a/public/app/plugins/datasource/loki/queryUtils.ts
+++ b/public/app/plugins/datasource/loki/queryUtils.ts
@@ -95,11 +95,11 @@ export function getStringsFromLineFilter(filter: SyntaxNode): SyntaxNode[] {
   return nodes;
 }
 
-export function getNormalizedLokiQuery(query: LokiQuery): LokiQuery {
+export function getNormalizedLokiQuery(query: LokiQuery, maxLinesOverride?: number): LokiQuery {
   const queryType = getLokiQueryType(query);
   // instant and range are deprecated, we want to remove them
-  const { instant, range, ...rest } = query;
-  return { ...rest, queryType };
+  const { instant, range, maxLines, ...rest } = query;
+  return removeInvalidOptions({ ...rest, queryType, maxLines: maxLinesOverride ?? query.maxLines });
 }
 
 export function getLokiQueryType(query: LokiQuery): LokiQueryType {

--- a/public/app/plugins/datasource/loki/queryUtils.ts
+++ b/public/app/plugins/datasource/loki/queryUtils.ts
@@ -208,6 +208,24 @@ export function isLogsQuery(query: string): boolean {
   return !isQueryWithNode(query, MetricExpr);
 }
 
+/**
+ * Some logs options are not applicable to metric queries and vice versa.
+ * We need to remove them from the query before the request is sent.
+ * @param query LokiQuery
+ */
+export function removeInvalidOptions(query: LokiQuery): LokiQuery {
+  const isLogQuery = isLogsQuery(query.expr);
+  const { maxLines, step, ...rest } = query;
+
+  // If metric query, add step, remove maxLines
+  if (!isLogQuery) {
+    return { step, ...rest };
+  }
+
+  // If logs query, add maxLines, remove step
+  return { maxLines, ...rest };
+}
+
 export function isQueryWithParser(query: string): { queryWithParser: boolean; parserCount: number } {
   const nodes = getNodesFromQuery(query, [LabelParser, JsonExpressionParser, Logfmt]);
   const parserCount = nodes.length;


### PR DESCRIPTION
**What is this feature?**
Fix for bug introduced when log query options are being evaluated against metric queries.

**Why do we need this feature?**
Users cannot change maxLines after they have written a metric query, since this field is not visible to users, they have the expectation that it will not impact the results of their query. The UX should reflect this assumption.

**Who is this feature for?**
Loki users

**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/grafana/issues/78096

**Special notes for your reviewer:**
We might want to make this change as well on the backend?

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
