### PR TITLE
Logs Panel: Remove infoThresh parameter from ufuzzy call

### DIFF
--- a/public/app/features/explore/Logs/utils/uFuzzy.ts
+++ b/public/app/features/explore/Logs/utils/uFuzzy.ts
@@ -10,7 +10,7 @@ const uf = new uFuzzy({
 });
 
 export function fuzzySearch(haystack: string[], query: string, dispatcher: (data: string[][]) => void) {
-  const [idxs, info, order] = uf.search(haystack, query, false, 1e5);
+  const [idxs, info, order] = uf.search(haystack, query, false);
 
   let haystackOrder: string[] = [];
   let matchesSet: Set<string> = new Set();


### PR DESCRIPTION
**What is this feature?**
The current settings for ufuzzy are unoptimized for our use-case, we are not utilizing highlighting or using the ufuzzy rank. As such we should be using the default settings, and omit this parameter.

**Why do we need this feature?**
Potential optimization, better adherence to ufuzzy best practices

**Who is this feature for?**
@leeoniya 😆 

Fixes N/A

**Special notes for your reviewer:**
This does not appear to have any noticeable impact on the search results in my testing, but could be noticeable with logs sources that can have many labels like elastic.

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
