### PR TITLE
Docs: add/update frontmatter descriptions for Dashboards pages

### DIFF
--- a/docs/sources/dashboards/_index.md
+++ b/docs/sources/dashboards/_index.md
@@ -8,6 +8,7 @@ labels:
     - oss
 title: Dashboards
 weight: 70
+description: Create and manage dashboards
 ---
 
 # Dashboards

--- a/docs/sources/dashboards/build-dashboards/_index.md
+++ b/docs/sources/dashboards/build-dashboards/_index.md
@@ -13,6 +13,7 @@ labels:
     - oss
 menuTitle: Build dashboards
 title: Build dashboards
+description: Build dashboards including managing settings, links, and version history
 weight: 2
 ---
 

--- a/docs/sources/dashboards/build-dashboards/annotate-visualizations/index.md
+++ b/docs/sources/dashboards/build-dashboards/annotate-visualizations/index.md
@@ -15,6 +15,7 @@ labels:
 menuTitle: Annotate visualizations
 title: Annotate visualizations
 weight: 600
+description: Annotate dashboard visualizations to mark points with rich events
 ---
 
 # Annotate visualizations

--- a/docs/sources/dashboards/build-dashboards/best-practices/index.md
+++ b/docs/sources/dashboards/build-dashboards/best-practices/index.md
@@ -6,7 +6,7 @@ aliases:
   - ../../best-practices/common-observability-strategies/
   - ../../best-practices/dashboard-management-maturity-levels/
   - ../../getting-started/strategies/
-description: Best practices for working with Grafana
+description: Learn best practices for building and maintaining Grafana dashboards
 labels:
   products:
     - cloud

--- a/docs/sources/dashboards/build-dashboards/create-dashboard-url-variables/index.md
+++ b/docs/sources/dashboards/build-dashboards/create-dashboard-url-variables/index.md
@@ -14,6 +14,7 @@ labels:
     - enterprise
     - oss
 title: Dashboard URL variables
+description: Use variables in dashboard URLs to add more context to your links
 weight: 250
 ---
 

--- a/docs/sources/dashboards/build-dashboards/create-dashboard/index.md
+++ b/docs/sources/dashboards/build-dashboards/create-dashboard/index.md
@@ -12,6 +12,7 @@ labels:
     - oss
 menuTitle: Create a dashboard
 title: Create a dashboard
+description: Create and edit a dashboard
 weight: 1
 ---
 

--- a/docs/sources/dashboards/build-dashboards/manage-dashboard-links/index.md
+++ b/docs/sources/dashboards/build-dashboards/manage-dashboard-links/index.md
@@ -6,7 +6,7 @@ aliases:
   - ../../linking/linking-overview/
   - ../../panels/working-with-panels/add-link-to-panel/
   - ../manage-dashboard-links/
-description: How to link Grafana dashboards.
+description: Add links to your Grafana dashboards to connect to other dashboards, panels, and websites
 keywords:
   - link
   - dashboard

--- a/docs/sources/dashboards/build-dashboards/manage-library-panels/index.md
+++ b/docs/sources/dashboards/build-dashboards/manage-library-panels/index.md
@@ -15,6 +15,7 @@ labels:
     - oss
 menuTitle: Manage library panels
 title: Manage library panels
+description: Create reusable library panels that you can use in any dashboard
 weight: 300
 ---
 

--- a/docs/sources/dashboards/build-dashboards/manage-version-history/index.md
+++ b/docs/sources/dashboards/build-dashboards/manage-version-history/index.md
@@ -15,6 +15,7 @@ labels:
     - oss
 menutitle: Manage version history
 title: Manage dashboard version history
+description: View and compare previous versions of your dashboard
 weight: 400
 ---
 

--- a/docs/sources/dashboards/build-dashboards/modify-dashboard-settings/index.md
+++ b/docs/sources/dashboards/build-dashboards/modify-dashboard-settings/index.md
@@ -12,6 +12,7 @@ labels:
     - oss
 menuTitle: Modify dashboard settings
 title: Modify dashboard settings
+description: Manage and edit your dashboard settings
 weight: 8
 ---
 

--- a/docs/sources/dashboards/build-dashboards/view-dashboard-json-model/index.md
+++ b/docs/sources/dashboards/build-dashboards/view-dashboard-json-model/index.md
@@ -14,6 +14,7 @@ labels:
     - enterprise
     - oss
 title: JSON model
+description: View your Grafana dashboard JSON object
 weight: 700
 ---
 

--- a/docs/sources/dashboards/create-manage-playlists/index.md
+++ b/docs/sources/dashboards/create-manage-playlists/index.md
@@ -14,6 +14,7 @@ labels:
     - oss
 menuTitle: Manage playlists
 title: Manage playlists
+description: Create and manage dashboard playlists
 weight: 9
 ---
 

--- a/docs/sources/dashboards/create-reports/index.md
+++ b/docs/sources/dashboards/create-reports/index.md
@@ -16,6 +16,7 @@ labels:
     - enterprise
 menuTitle: Reporting
 title: Create and manage reports
+description: Generate and share PDF reports from your Grafana dashboards
 weight: 85
 ---
 

--- a/docs/sources/dashboards/dashboard-public/index.md
+++ b/docs/sources/dashboards/dashboard-public/index.md
@@ -8,7 +8,7 @@ labels:
     - enterprise
     - oss
 title: Public dashboards
-description: Share your Grafana dashboards with anyone using public dashboards
+description: Make your Grafana dashboards public and share them with anyone
 weight: 8
 ---
 

--- a/docs/sources/dashboards/dashboard-public/index.md
+++ b/docs/sources/dashboards/dashboard-public/index.md
@@ -8,6 +8,7 @@ labels:
     - enterprise
     - oss
 title: Public dashboards
+desription: Share your Grafana dashboards with anyone using public dashboards
 weight: 8
 ---
 

--- a/docs/sources/dashboards/dashboard-public/index.md
+++ b/docs/sources/dashboards/dashboard-public/index.md
@@ -8,7 +8,7 @@ labels:
     - enterprise
     - oss
 title: Public dashboards
-desription: Share your Grafana dashboards with anyone using public dashboards
+description: Share your Grafana dashboards with anyone using public dashboards
 weight: 8
 ---
 

--- a/docs/sources/dashboards/manage-dashboards/index.md
+++ b/docs/sources/dashboards/manage-dashboards/index.md
@@ -27,6 +27,7 @@ labels:
     - oss
 menuTitle: Manage dashboards
 title: Manage dashboards
+description: Learn about dashboard folders, generative AI features for dashboards, and troubleshooting
 weight: 8
 ---
 

--- a/docs/sources/dashboards/share-dashboards-panels/index.md
+++ b/docs/sources/dashboards/share-dashboards-panels/index.md
@@ -31,6 +31,7 @@ labels:
     - oss
 menuTitle: Sharing
 title: Share dashboards and panels
+description: Share Grafana dashboards and panels within your organization and publicly
 weight: 85
 ---
 

--- a/docs/sources/dashboards/use-dashboards/index.md
+++ b/docs/sources/dashboards/use-dashboards/index.md
@@ -19,6 +19,7 @@ labels:
     - oss
 menuTitle: Use dashboards
 title: Use dashboards
+description: Learn about the features of a Grafana dashboard
 weight: 1
 ---
 

--- a/docs/sources/dashboards/variables/_index.md
+++ b/docs/sources/dashboards/variables/_index.md
@@ -9,6 +9,7 @@ labels:
     - enterprise
     - oss
 title: Variables
+description: Add variables to metric queries and panel titles to create interactive and dynamic dashboards
 weight: 130
 ---
 

--- a/docs/sources/dashboards/variables/add-template-variables/index.md
+++ b/docs/sources/dashboards/variables/add-template-variables/index.md
@@ -42,6 +42,7 @@ labels:
     - oss
 menuTitle: Manage variables
 title: Add and manage variables
+description: Learn about the types of variables you can add to dashboards and how
 weight: 100
 ---
 

--- a/docs/sources/dashboards/variables/inspect-variable/index.md
+++ b/docs/sources/dashboards/variables/inspect-variable/index.md
@@ -15,6 +15,7 @@ labels:
     - enterprise
     - oss
 title: Inspect variables
+description: Review and manage your dashboard variables
 weight: 200
 ---
 

--- a/docs/sources/dashboards/variables/variable-syntax/index.md
+++ b/docs/sources/dashboards/variables/variable-syntax/index.md
@@ -16,6 +16,7 @@ labels:
     - enterprise
     - oss
 title: Variable syntax
+description: Learn about different types of variable syntax
 weight: 300
 ---
 


### PR DESCRIPTION
Adding concise descriptions for each page in the Dashboards documentation
This PR must be merged by December 15th