### PR TITLE
IDForwarding: Remove dev mode restriction for feature toggle

### DIFF
--- a/docs/sources/setup-grafana/configure-grafana/feature-toggles/index.md
+++ b/docs/sources/setup-grafana/configure-grafana/feature-toggles/index.md
@@ -140,6 +140,7 @@ Experimental features might be changed or removed without prior notice.
 | `externalCorePlugins`                       | Allow core plugins to be loaded as external                                                                                                                                                                                                                                       |
 | `pluginsAPIMetrics`                         | Sends metrics of public grafana packages usage by plugins                                                                                                                                                                                                                         |
 | `httpSLOLevels`                             | Adds SLO level to http request metrics                                                                                                                                                                                                                                            |
+| `idForwarding`                              | Generate signed id token for identity that can be forwarded to plugins and external services                                                                                                                                                                                      |
 | `panelMonitoring`                           | Enables panel monitoring through logs and measurements                                                                                                                                                                                                                            |
 | `enableNativeHTTPHistogram`                 | Enables native HTTP Histograms                                                                                                                                                                                                                                                    |
 | `formatString`                              | Enable format string transformer                                                                                                                                                                                                                                                  |
@@ -172,12 +173,11 @@ Experimental features might be changed or removed without prior notice.
 
 The following toggles require explicitly setting Grafana's [app mode]({{< relref "../_index.md#app_mode" >}}) to 'development' before you can enable this feature toggle. These features tend to be experimental.
 
-| Feature toggle name                   | Description                                                                                  |
-| ------------------------------------- | -------------------------------------------------------------------------------------------- |
-| `unifiedStorage`                      | SQL-based k8s storage                                                                        |
-| `externalServiceAuth`                 | Starts an OAuth2 authentication provider for external services                               |
-| `grafanaAPIServerEnsureKubectlAccess` | Start an additional https handler and write kubectl options                                  |
-| `idForwarding`                        | Generate signed id token for identity that can be forwarded to plugins and external services |
-| `externalServiceAccounts`             | Automatic service account and token setup for plugins                                        |
-| `panelTitleSearchInV1`                | Enable searching for dashboards using panel title in search v1                               |
-| `ssoSettingsApi`                      | Enables the SSO settings API                                                                 |
+| Feature toggle name                   | Description                                                    |
+| ------------------------------------- | -------------------------------------------------------------- |
+| `unifiedStorage`                      | SQL-based k8s storage                                          |
+| `externalServiceAuth`                 | Starts an OAuth2 authentication provider for external services |
+| `grafanaAPIServerEnsureKubectlAccess` | Start an additional https handler and write kubectl options    |
+| `externalServiceAccounts`             | Automatic service account and token setup for plugins          |
+| `panelTitleSearchInV1`                | Enable searching for dashboards using panel title in search v1 |
+| `ssoSettingsApi`                      | Enables the SSO settings API                                   |

--- a/pkg/services/featuremgmt/registry.go
+++ b/pkg/services/featuremgmt/registry.go
@@ -936,12 +936,11 @@ var (
 			Created:         time.Date(2023, time.September, 22, 12, 0, 0, 0, time.UTC),
 		},
 		{
-			Name:            "idForwarding",
-			Description:     "Generate signed id token for identity that can be forwarded to plugins and external services",
-			Stage:           FeatureStageExperimental,
-			Owner:           identityAccessTeam,
-			RequiresDevMode: true,
-			Created:         time.Date(2023, time.September, 25, 12, 0, 0, 0, time.UTC),
+			Name:        "idForwarding",
+			Description: "Generate signed id token for identity that can be forwarded to plugins and external services",
+			Stage:       FeatureStageExperimental,
+			Owner:       identityAccessTeam,
+			Created:     time.Date(2023, time.September, 25, 12, 0, 0, 0, time.UTC),
 		},
 		{
 			Name:           "cloudWatchWildCardDimensionValues",

--- a/pkg/services/featuremgmt/toggles_gen.csv
+++ b/pkg/services/featuremgmt/toggles_gen.csv
@@ -109,7 +109,7 @@ alertingInsights,GA,@grafana/alerting-squad,2023-09-14,false,false,false,true
 externalCorePlugins,experimental,@grafana/plugins-platform-backend,2023-09-22,false,false,false,false
 pluginsAPIMetrics,experimental,@grafana/plugins-platform-backend,2023-09-21,false,false,false,true
 httpSLOLevels,experimental,@grafana/hosted-grafana-team,2023-09-22,false,false,true,false
-idForwarding,experimental,@grafana/identity-access-team,2023-09-25,true,false,false,false
+idForwarding,experimental,@grafana/identity-access-team,2023-09-25,false,false,false,false
 cloudWatchWildCardDimensionValues,GA,@grafana/aws-datasources,2023-09-27,false,false,false,false
 externalServiceAccounts,experimental,@grafana/identity-access-team,2023-09-28,true,false,false,false
 panelMonitoring,experimental,@grafana/dataviz-squad,2023-10-08,false,false,false,true


### PR DESCRIPTION
**What is this feature?**
We want to start testing id forwarding in our dev environments, to make that easier we need to remove dev mode restriction. Flag is still in experimental stage.

**Which issue(s) does this PR fix?**:

Part of: https://github.com/grafana/identity-access-team/issues/310

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
