### PR TITLE
Stat: Fix inconsistent center padding

### DIFF
--- a/packages/grafana-ui/src/components/BigValue/BigValue.tsx
+++ b/packages/grafana-ui/src/components/BigValue/BigValue.tsx
@@ -1,7 +1,7 @@
 import { cx } from '@emotion/css';
 import React, { PureComponent } from 'react';
 
-import { DisplayValue, DisplayValueAlignmentFactors, FieldSparkline, VizOrientation } from '@grafana/data';
+import { DisplayValue, DisplayValueAlignmentFactors, FieldSparkline } from '@grafana/data';
 import { VizTextDisplayOptions } from '@grafana/schema';
 
 import { Themeable2 } from '../../types';

--- a/packages/grafana-ui/src/components/BigValue/BigValue.tsx
+++ b/packages/grafana-ui/src/components/BigValue/BigValue.tsx
@@ -66,8 +66,6 @@ export interface Props extends Themeable2 {
   textMode?: BigValueTextMode;
   /** If true disables the tooltip */
   hasLinks?: boolean;
-  /** The orientation of the parent container */
-  parentOrientation?: VizOrientation;
 
   /**
    * If part of a series of stat panes, this is the total number.

--- a/packages/grafana-ui/src/components/BigValue/BigValueLayout.tsx
+++ b/packages/grafana-ui/src/components/BigValue/BigValueLayout.tsx
@@ -63,10 +63,6 @@ export abstract class BigValueLayout {
       lineHeight: LINE_HEIGHT,
     };
 
-    if (this.props.parentOrientation === VizOrientation.Horizontal && this.justifyCenter) {
-      styles.paddingRight = '0.75ch';
-    }
-
     if (
       this.props.colorMode === BigValueColorMode.Background ||
       this.props.colorMode === BigValueColorMode.BackgroundSolid
@@ -115,6 +111,7 @@ export abstract class BigValueLayout {
       styles.alignItems = 'center';
       styles.justifyContent = 'center';
       styles.flexGrow = 1;
+      styles.gap = '0.75ch';
     }
 
     return styles;

--- a/packages/grafana-ui/src/components/BigValue/BigValueLayout.tsx
+++ b/packages/grafana-ui/src/components/BigValue/BigValueLayout.tsx
@@ -1,7 +1,7 @@
 import React, { CSSProperties } from 'react';
 import tinycolor from 'tinycolor2';
 
-import { formattedValueToString, DisplayValue, FieldConfig, FieldType, VizOrientation } from '@grafana/data';
+import { formattedValueToString, DisplayValue, FieldConfig, FieldType } from '@grafana/data';
 import { GraphDrawStyle, GraphFieldConfig } from '@grafana/schema';
 
 import { getTextColorForAlphaBackground } from '../../utils';

--- a/public/app/plugins/panel/stat/StatPanel.tsx
+++ b/public/app/plugins/panel/stat/StatPanel.tsx
@@ -24,7 +24,7 @@ export class StatPanel extends PureComponent<PanelProps<Options>> {
     menuProps: DataLinksContextMenuApi
   ): JSX.Element => {
     const { timeRange, options } = this.props;
-    const { value, alignmentFactors, width, height, count, orientation } = valueProps;
+    const { value, alignmentFactors, width, height, count } = valueProps;
     const { openMenu, targetClassName } = menuProps;
     let sparkline = value.sparkline;
     if (sparkline) {
@@ -41,7 +41,6 @@ export class StatPanel extends PureComponent<PanelProps<Options>> {
         justifyMode={options.justifyMode}
         textMode={this.getTextMode()}
         alignmentFactors={alignmentFactors}
-        parentOrientation={orientation}
         text={options.text}
         width={width}
         height={height}


### PR DESCRIPTION
I was reviewing https://github.com/grafana/grafana/pull/78250 and got very confused with the parentOrientation property, and why BigValue would care about the parent orientation. 

And found this change https://github.com/grafana/grafana/pull/55299 that introduced it and got even more confused. Seems to only add some center padding when parent orientation is hard set to horizontal. And to really fix this problem (of adding spacing between title and value when text align is centered requires no knowledge of the parent VizRepeater orientation) 

Image showing bugged padding (only working when horizontal orientation is hard set)
![image](https://github.com/grafana/grafana/assets/10999/489485f9-730f-4f7f-99ce-8f2701a1822e)

The fix requires no knowledge of parent orientation 