### PR TITLE
obsolete: PoC: postgres: simpler proxy codebase

### DIFF
--- a/pkg/tsdb/grafana-postgresql-datasource/postgres_test.go
+++ b/pkg/tsdb/grafana-postgresql-datasource/postgres_test.go
@@ -185,17 +185,10 @@ func TestIntegrationPostgres(t *testing.T) {
 		t.Skip()
 	}
 
-	x := InitPostgresTestDB(t)
-
-	origDB := sqleng.NewDB
 	origInterpolate := sqleng.Interpolate
 	t.Cleanup(func() {
-		sqleng.NewDB = origDB
 		sqleng.Interpolate = origInterpolate
 	})
-	sqleng.NewDB = func(d, c string) (*sql.DB, error) {
-		return x, nil
-	}
 	sqleng.Interpolate = func(query backend.DataQuery, timeRange backend.TimeRange, timeInterval string, sql string) (string, error) {
 		return sql, nil
 	}
@@ -217,8 +210,6 @@ func TestIntegrationPostgres(t *testing.T) {
 	}
 
 	config := sqleng.DataPluginConfiguration{
-		DriverName:        "postgres",
-		ConnectionString:  "",
 		DSInfo:            dsInfo,
 		MetricColumnTypes: []string{"UNKNOWN", "TEXT", "VARCHAR", "CHAR"},
 		RowLimit:          1000000,
@@ -227,12 +218,14 @@ func TestIntegrationPostgres(t *testing.T) {
 	queryResultTransformer := postgresQueryResultTransformer{}
 
 	logger := log.New("postgres.test")
-	exe, err := sqleng.NewQueryDataHandler(cfg, config, &queryResultTransformer, newPostgresMacroEngine(dsInfo.JsonData.Timescaledb),
+
+	db := InitPostgresTestDB(t, jsonData)
+
+	exe, err := sqleng.NewQueryDataHandler(cfg, db, config, &queryResultTransformer, newPostgresMacroEngine(dsInfo.JsonData.Timescaledb),
 		logger)
 
 	require.NoError(t, err)
 
-	db := x
 	fromStart := time.Date(2018, 3, 15, 13, 0, 0, 0, time.UTC).In(time.Local)
 
 	t.Run("Given a table with different native data types", func(t *testing.T) {
@@ -1283,8 +1276,6 @@ func TestIntegrationPostgres(t *testing.T) {
 		t.Run("When row limit set to 1", func(t *testing.T) {
 			dsInfo := sqleng.DataSourceInfo{}
 			config := sqleng.DataPluginConfiguration{
-				DriverName:        "postgres",
-				ConnectionString:  "",
 				DSInfo:            dsInfo,
 				MetricColumnTypes: []string{"UNKNOWN", "TEXT", "VARCHAR", "CHAR"},
 				RowLimit:          1,
@@ -1292,7 +1283,7 @@ func TestIntegrationPostgres(t *testing.T) {
 
 			queryResultTransformer := postgresQueryResultTransformer{}
 
-			handler, err := sqleng.NewQueryDataHandler(setting.NewCfg(), config, &queryResultTransformer, newPostgresMacroEngine(false), logger)
+			handler, err := sqleng.NewQueryDataHandler(setting.NewCfg(), db, config, &queryResultTransformer, newPostgresMacroEngine(false), logger)
 			require.NoError(t, err)
 
 			t.Run("When doing a table query that returns 2 rows should limit the result to 1 row", func(t *testing.T) {
@@ -1393,11 +1384,15 @@ func TestIntegrationPostgres(t *testing.T) {
 	})
 }
 
-func InitPostgresTestDB(t *testing.T) *sql.DB {
+func InitPostgresTestDB(t *testing.T, jsonData sqleng.JsonData) *sql.DB {
 	connStr := postgresTestDBConnString()
-	x, err := sql.Open("postgres", connStr)
+	db, err := sql.Open("postgres", connStr)
 	require.NoError(t, err, "Failed to init postgres DB")
-	return x
+
+	db.SetMaxOpenConns(jsonData.MaxOpenConns)
+	db.SetMaxIdleConns(jsonData.MaxIdleConns)
+	db.SetConnMaxLifetime(time.Duration(jsonData.ConnMaxLifetime) * time.Second)
+	return db
 }
 
 func genTimeRangeByInterval(from time.Time, duration time.Duration, interval time.Duration) []time.Time {

--- a/pkg/tsdb/grafana-postgresql-datasource/proxy.go
+++ b/pkg/tsdb/grafana-postgresql-datasource/proxy.go
@@ -2,12 +2,7 @@ package postgres
 
 import (
 	"context"
-	"crypto/md5"
-	"database/sql"
-	"database/sql/driver"
-	"fmt"
 	"net"
-	"slices"
 	"time"
 
 	sdkproxy "github.com/grafana/grafana-plugin-sdk-go/backend/proxy"
@@ -15,51 +10,19 @@ import (
 	"golang.org/x/net/proxy"
 )
 
-// createPostgresProxyDriver creates and registers a new sql driver that uses a postgres connector and updates the dialer to
-// route connections through the secure socks proxy
-func createPostgresProxyDriver(cnnstr string, opts *sdkproxy.Options) (string, error) {
-	// create a unique driver per connection string
-	hash := fmt.Sprintf("%x", md5.Sum([]byte(cnnstr)))
-	driverName := "postgres-proxy-" + hash
-
-	// only register the driver once
-	if !slices.Contains(sql.Drivers(), driverName) {
-		connector, err := pq.NewConnector(cnnstr)
-		if err != nil {
-			return "", err
-		}
-
-		driver, err := newPostgresProxyDriver(connector, opts)
-		if err != nil {
-			return "", err
-		}
-
-		sql.Register(driverName, driver)
-	}
-	return driverName, nil
-}
-
-// postgresProxyDriver is a regular postgres driver with an updated dialer.
-// This is done because there is no way to save a dialer to the postgres driver in xorm
-type postgresProxyDriver struct {
-	c *pq.Connector
-}
-
-var _ driver.DriverContext = (*postgresProxyDriver)(nil)
-
 // newPostgresProxyDriver updates the dialer for a postgres connector with a dialer that proxies connections through the secure socks proxy
 // and returns a new postgres driver to register
-func newPostgresProxyDriver(connector *pq.Connector, opts *sdkproxy.Options) (*postgresProxyDriver, error) {
+func newPostgresProxyDialer(opts *sdkproxy.Options) (pq.Dialer, error) {
 	dialer, err := sdkproxy.New(opts).NewSecureSocksProxyContextDialer()
 	if err != nil {
 		return nil, err
 	}
 
 	// update the postgres dialer with the proxy dialer
-	connector.Dialer(&postgresProxyDialer{d: dialer})
-
-	return &postgresProxyDriver{connector}, nil
+	return &postgresProxyDialer{d: dialer}, nil
 }
+
+var _ pq.Dialer = (&postgresProxyDialer{})
 
 // postgresProxyDialer implements the postgres dialer using a proxy dialer, as their functions differ slightly
 type postgresProxyDialer struct {
@@ -77,14 +40,4 @@ func (p *postgresProxyDialer) DialTimeout(network, address string, timeout time.
 	defer cancel()
 
 	return p.d.(proxy.ContextDialer).DialContext(ctx, network, address)
-}
-
-// OpenConnector returns the normal postgres connector that has the updated dialer context
-func (d *postgresProxyDriver) OpenConnector(name string) (driver.Connector, error) {
-	return d.c, nil
-}
-
-// Open uses the connector with the updated dialer to open a new connection
-func (d *postgresProxyDriver) Open(dsn string) (driver.Conn, error) {
-	return d.c.Connect(context.Background())
 }

--- a/pkg/tsdb/mssql/mssql.go
+++ b/pkg/tsdb/mssql/mssql.go
@@ -2,6 +2,7 @@ package mssql
 
 import (
 	"context"
+	"database/sql"
 	"encoding/json"
 	"fmt"
 	"net/url"
@@ -9,6 +10,7 @@ import (
 	"regexp"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/grafana/grafana-azure-sdk-go/azcredentials"
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
@@ -125,8 +127,6 @@ func newInstanceSettings(cfg *setting.Cfg, logger log.Logger) datasource.Instanc
 		}
 
 		config := sqleng.DataPluginConfiguration{
-			DriverName:        driverName,
-			ConnectionString:  cnnstr,
 			DSInfo:            dsInfo,
 			MetricColumnTypes: []string{"VARCHAR", "CHAR", "NVARCHAR", "NCHAR"},
 			RowLimit:          cfg.DataProxyRowLimit,
@@ -136,7 +136,16 @@ func newInstanceSettings(cfg *setting.Cfg, logger log.Logger) datasource.Instanc
 			userError: cfg.UserFacingDefaultError,
 		}
 
-		return sqleng.NewQueryDataHandler(cfg, config, &queryResultTransformer, newMssqlMacroEngine(), logger)
+		db, err := sql.Open(driverName, cnnstr)
+		if err != nil {
+			return nil, err
+		}
+
+		db.SetMaxOpenConns(config.DSInfo.JsonData.MaxOpenConns)
+		db.SetMaxIdleConns(config.DSInfo.JsonData.MaxIdleConns)
+		db.SetConnMaxLifetime(time.Duration(config.DSInfo.JsonData.ConnMaxLifetime) * time.Second)
+
+		return sqleng.NewQueryDataHandler(cfg, db, config, &queryResultTransformer, newMssqlMacroEngine(), logger)
 	}
 }
 

--- a/pkg/tsdb/mysql/mysql_test.go
+++ b/pkg/tsdb/mysql/mysql_test.go
@@ -38,18 +38,10 @@ func TestIntegrationMySQL(t *testing.T) {
 		t.Skip()
 	}
 
-	x := InitMySQLTestDB(t)
-
-	origDB := sqleng.NewDB
 	origInterpolate := sqleng.Interpolate
 	t.Cleanup(func() {
-		sqleng.NewDB = origDB
 		sqleng.Interpolate = origInterpolate
 	})
-
-	sqleng.NewDB = func(d, c string) (*sql.DB, error) {
-		return x, nil
-	}
 
 	sqleng.Interpolate = func(query backend.DataQuery, timeRange backend.TimeRange, timeInterval string, sql string) (string, error) {
 		return sql, nil
@@ -64,8 +56,6 @@ func TestIntegrationMySQL(t *testing.T) {
 	}
 
 	config := sqleng.DataPluginConfiguration{
-		DriverName:        "mysql",
-		ConnectionString:  "",
 		DSInfo:            dsInfo,
 		TimeColumnNames:   []string{"time", "time_sec"},
 		MetricColumnTypes: []string{"CHAR", "VARCHAR", "TINYTEXT", "TEXT", "MEDIUMTEXT", "LONGTEXT"},
@@ -76,11 +66,12 @@ func TestIntegrationMySQL(t *testing.T) {
 
 	logger := log.New("mysql.test")
 
-	exe, err := sqleng.NewQueryDataHandler(setting.NewCfg(), config, &rowTransformer, newMysqlMacroEngine(logger, setting.NewCfg()), logger)
+	db := InitMySQLTestDB(t, config.DSInfo.JsonData)
+
+	exe, err := sqleng.NewQueryDataHandler(setting.NewCfg(), db, config, &rowTransformer, newMysqlMacroEngine(logger, setting.NewCfg()), logger)
 
 	require.NoError(t, err)
 
-	db := x
 	fromStart := time.Date(2018, 3, 15, 13, 0, 0, 0, time.UTC)
 
 	t.Run("Given a table with different native data types", func(t *testing.T) {
@@ -1180,8 +1171,6 @@ func TestIntegrationMySQL(t *testing.T) {
 		t.Run("When row limit set to 1", func(t *testing.T) {
 			dsInfo := sqleng.DataSourceInfo{}
 			config := sqleng.DataPluginConfiguration{
-				DriverName:        "mysql",
-				ConnectionString:  "",
 				DSInfo:            dsInfo,
 				TimeColumnNames:   []string{"time", "time_sec"},
 				MetricColumnTypes: []string{"CHAR", "VARCHAR", "TINYTEXT", "TEXT", "MEDIUMTEXT", "LONGTEXT"},
@@ -1190,7 +1179,7 @@ func TestIntegrationMySQL(t *testing.T) {
 
 			queryResultTransformer := mysqlQueryResultTransformer{}
 
-			handler, err := sqleng.NewQueryDataHandler(setting.NewCfg(), config, &queryResultTransformer, newMysqlMacroEngine(logger, setting.NewCfg()), logger)
+			handler, err := sqleng.NewQueryDataHandler(setting.NewCfg(), db, config, &queryResultTransformer, newMysqlMacroEngine(logger, setting.NewCfg()), logger)
 			require.NoError(t, err)
 
 			t.Run("When doing a table query that returns 2 rows should limit the result to 1 row", func(t *testing.T) {
@@ -1292,14 +1281,18 @@ func TestIntegrationMySQL(t *testing.T) {
 	})
 }
 
-func InitMySQLTestDB(t *testing.T) *sql.DB {
+func InitMySQLTestDB(t *testing.T, jsonData sqleng.JsonData) *sql.DB {
 	connStr := mySQLTestDBConnStr()
-	x, err := sql.Open("mysql", connStr)
+	db, err := sql.Open("mysql", connStr)
 	if err != nil {
 		t.Fatalf("Failed to init mysql db %v", err)
 	}
 
-	return x
+	db.SetMaxOpenConns(jsonData.MaxOpenConns)
+	db.SetMaxIdleConns(jsonData.MaxIdleConns)
+	db.SetConnMaxLifetime(time.Duration(jsonData.ConnMaxLifetime) * time.Second)
+
+	return db
 }
 
 func genTimeRangeByInterval(from time.Time, duration time.Duration, interval time.Duration) []time.Time {

--- a/pkg/tsdb/sqleng/sql_engine.go
+++ b/pkg/tsdb/sqleng/sql_engine.go
@@ -43,13 +43,6 @@ type SqlQueryResultTransformer interface {
 
 var sqlIntervalCalculator = intervalv2.NewCalculator()
 
-// NewDB is a sql.DB factory, that can be stubbed by tests.
-//
-//nolint:gocritic
-var NewDB = func(driverName string, connectionString string) (*sql.DB, error) {
-	return sql.Open(driverName, connectionString)
-}
-
 type JsonData struct {
 	MaxOpenConns            int    `json:"maxOpenConns"`
 	MaxIdleConns            int    `json:"maxIdleConns"`
@@ -85,9 +78,7 @@ type DataSourceInfo struct {
 }
 
 type DataPluginConfiguration struct {
-	DriverName        string
 	DSInfo            DataSourceInfo
-	ConnectionString  string
 	TimeColumnNames   []string
 	MetricColumnTypes []string
 	RowLimit          int64
@@ -128,13 +119,8 @@ func (e *DataSourceHandler) TransformQueryError(logger log.Logger, err error) er
 	return e.queryResultTransformer.TransformQueryError(logger, err)
 }
 
-func NewQueryDataHandler(cfg *setting.Cfg, config DataPluginConfiguration, queryResultTransformer SqlQueryResultTransformer,
+func NewQueryDataHandler(cfg *setting.Cfg, db *sql.DB, config DataPluginConfiguration, queryResultTransformer SqlQueryResultTransformer,
 	macroEngine SQLMacroEngine, log log.Logger) (*DataSourceHandler, error) {
-	log.Debug("Creating engine...")
-	defer func() {
-		log.Debug("Engine created")
-	}()
-
 	queryDataHandler := DataSourceHandler{
 		queryResultTransformer: queryResultTransformer,
 		macroEngine:            macroEngine,
@@ -152,15 +138,6 @@ func NewQueryDataHandler(cfg *setting.Cfg, config DataPluginConfiguration, query
 	if len(config.MetricColumnTypes) > 0 {
 		queryDataHandler.metricColumnTypes = config.MetricColumnTypes
 	}
-
-	db, err := NewDB(config.DriverName, config.ConnectionString)
-	if err != nil {
-		return nil, err
-	}
-
-	db.SetMaxOpenConns(config.DSInfo.JsonData.MaxOpenConns)
-	db.SetMaxIdleConns(config.DSInfo.JsonData.MaxIdleConns)
-	db.SetConnMaxLifetime(time.Duration(config.DSInfo.JsonData.ConnMaxLifetime) * time.Second)
 
 	queryDataHandler.db = db
 	return &queryDataHandler, nil


### PR DESCRIPTION
(fixes https://github.com/grafana/grafana/issues/79127)

this PR does two things:
- A. adjusts the interface of the shared `sqleng` code
- B. simplifies the postgres-proxy-code (this requires step [A])
---
### step A in more detail:

currently, when an sql datasource plugin communicates the shared `sqleng` codebase, it works like this:

the datasource-plugin tells `sqleng` two things:
- the sql driver name (for example `postgres`)
- the sql connection string

and then `sqleng` calls:
`db, err := sql.Open(driverName, connectionString)`

to be able to customize this more (and make it more similar to https://github.com/grafana/sqlds), we adjust it like this:

- the datasource-plugin somehow creates the `db` instance (usually by calling `sql.Open`, but for example in this PR, for postgres we use `sql.OpenDB`.. this is transparent to the shared code)
- the `sqleng` codebase simply uses the provided `sql.DB` instance
- (i also moved the timeout-setup into the datasource plugins. it felt more correct that it is part of the setup of the `db` instance, i don't think `sqleng` should modify the provided `db` in any way)
---
step B in more detail:
technically, when we use the `proxy`, we want to customize the `dialer`. but, before, this sql codebase used the `xorm` library, this was not possible. we had to build a whole custom database-driver around the custom `dialer`. now it's possible to only create a custom `dialer`, so the proxy-code becomes much simpler.