### PR TITLE
Alerting: Fix auth for Nginx in Mimir Backend block (devenv)

### DIFF
--- a/devenv/docker/blocks/mimir_backend/nginx/nginx.conf.template
+++ b/devenv/docker/blocks/mimir_backend/nginx/nginx.conf.template
@@ -5,9 +5,15 @@ events {}
 http {
   resolver 127.0.0.11 ipv6=off;  
 
+  # Use basic auth user in `X-Scope-OrgID` if the header is not already set.
+  map $http_x_scope_orgid $add_x_scope_orgid {
+    default $http_x_scope_orgid;
+    "" $remote_user;
+  }
+
   server {
     listen 8080;
-    proxy_set_header X-Scope-OrgID $http_x_scope_orgid;
+    proxy_set_header X-Scope-OrgID $add_x_scope_orgid;
 
     location / {
       auth_basic "Mimir Backend";


### PR DESCRIPTION
### Description

This PR fixes a bug in the Nginx layer in our Mimir Backend block.

We currently need to set both basic auth and the `X-Scope-OrgID` header. Injecting the header if it's not present is actually the proxy's responsibility.

This PR adds a map to our Nginx configuration. If the `X-Scope-OrgID` header is not present, Nginx uses the basic auth username to add the header before forwarding the request to Mimir.

### How to test it

1. Spin up the `mimir_backend` block from our `main` branch.
2. Send a request using the predefined basic auth credentials (`test:test`), you'll get back a 401 status code error and "no org id".

```bash
> curl http://localhost:8080/alertmanager/-/ready -u "test:test"
> no org id
```

3. Check out to this branch.
4. Do the same request, there should be no error.

```bash
> curl http://localhost:8080/alertmanager/-/ready -u "test:test"
> OK%
```
