### PR TITLE
Storage: raise errors when timestamps cannot be parsed

### DIFF
--- a/pkg/kinds/general.go
+++ b/pkg/kinds/general.go
@@ -171,15 +171,12 @@ func (m *GrafanaResourceMetadata) GetOriginInfo() (*ResourceOriginInfo, error) {
 		return nil, nil
 	}
 	t, err := m.GetOriginTimestamp()
-	if err != nil {
-		return nil, err
-	}
 	return &ResourceOriginInfo{
 		Name:      v,
 		Path:      m.GetOriginPath(),
 		Key:       m.GetOriginKey(),
 		Timestamp: t,
-	}, nil
+	}, err
 }
 
 func (m *GrafanaResourceMetadata) GetOriginName() string {
@@ -360,15 +357,12 @@ func (m *grafanaResourceMetaAccessor) GetOriginInfo() (*ResourceOriginInfo, erro
 		return nil, nil
 	}
 	t, err := m.GetOriginTimestamp()
-	if err != nil {
-		return nil, err
-	}
 	return &ResourceOriginInfo{
 		Name:      v,
 		Path:      m.GetOriginPath(),
 		Key:       m.GetOriginKey(),
 		Timestamp: t,
-	}, nil
+	}, err
 }
 
 func (m *grafanaResourceMetaAccessor) GetOriginName() string {

--- a/pkg/registry/apis/playlist/conversions.go
+++ b/pkg/registry/apis/playlist/conversions.go
@@ -123,7 +123,7 @@ func getLegacyID(item *unstructured.Unstructured) int64 {
 	meta := kinds.GrafanaResourceMetadata{
 		Annotations: item.GetAnnotations(),
 	}
-	info := meta.GetOriginInfo()
+	info, _ := meta.GetOriginInfo()
 	if info != nil && info.Name == "SQL" {
 		i, err := strconv.ParseInt(info.Key, 10, 64)
 		if err == nil {

--- a/pkg/services/grafana-apiserver/storage/entity/utils.go
+++ b/pkg/services/grafana-apiserver/storage/entity/utils.go
@@ -126,11 +126,19 @@ func resourceToEntity(key string, res runtime.Object, requestInfo *request.Reque
 		Labels: metaAccessor.GetLabels(),
 	}
 
-	if t := grafanaAccessor.GetUpdatedTimestamp(); t != nil {
+	t, err := grafanaAccessor.GetUpdatedTimestamp()
+	if err != nil {
+		return nil, err
+	}
+	if t != nil {
 		rsp.UpdatedAt = t.UnixMilli()
 	}
 
-	if t := grafanaAccessor.GetOriginTimestamp(); t != nil {
+	t, err = grafanaAccessor.GetOriginTimestamp()
+	if err != nil {
+		return nil, err
+	}
+	if t != nil {
 		rsp.Origin.Time = t.UnixMilli()
 	}
 


### PR DESCRIPTION
This PR updates our meta accessors so that we can raise errors when the updated or origin timestamps cannot be parsed.