### PR TITLE
Alerting: Check whether the internal Alertmanager is ready in remote secondary mode

### DIFF
--- a/pkg/services/ngalert/remote/forked_alertmanager_test.go
+++ b/pkg/services/ngalert/remote/forked_alertmanager_test.go
@@ -282,21 +282,12 @@ func TestForkedAlertmanager_ModeRemoteSecondary(t *testing.T) {
 	})
 
 	t.Run("Ready", func(tt *testing.T) {
-		// Ready should be called on both Alertmanagers
-		internal, remote, forked := genTestAlertmanagers(tt, modeRemoteSecondary)
+		// Ready should be called only on the internal Alertmanager.
+		internal, _, forked := genTestAlertmanagers(tt, modeRemoteSecondary)
 		internal.EXPECT().Ready().Return(true).Once()
-		remote.EXPECT().Ready().Return(true).Once()
 		require.True(tt, forked.Ready())
 
-		// If one of the two Alertmanagers is not ready, it returns false.
-		internal, remote, forked = genTestAlertmanagers(tt, modeRemoteSecondary)
 		internal.EXPECT().Ready().Return(false).Maybe()
-		remote.EXPECT().Ready().Return(true).Maybe()
-		require.False(tt, forked.Ready())
-
-		internal, remote, forked = genTestAlertmanagers(tt, modeRemoteSecondary)
-		internal.EXPECT().Ready().Return(true).Maybe()
-		remote.EXPECT().Ready().Return(false).Maybe()
 		require.False(tt, forked.Ready())
 	})
 }

--- a/pkg/services/ngalert/remote/remote_secondary_forked_alertmanager.go
+++ b/pkg/services/ngalert/remote/remote_secondary_forked_alertmanager.go
@@ -98,9 +98,6 @@ func (fam *RemoteSecondaryForkedAlertmanager) StopAndWait() {
 }
 
 func (fam *RemoteSecondaryForkedAlertmanager) Ready() bool {
-	// Both Alertmanagers must be ready.
-	if ready := fam.remote.Ready(); !ready {
-		return false
-	}
+	// We only care about the internal Alertmanager being ready.
 	return fam.internal.Ready()
 }


### PR DESCRIPTION
We're currently checking both Alertmanagers in remote secondary mode when `Ready()` is called, which causes the method to return `false` in cases where the internal Alertmanager is ready but the remote one is not. This could result in missed alerts.

We only care about the internal Alertmanager being ready when we're in _remote secondary_ mode.