### PR TITLE
Makefile: Reset `go` depedencies

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,6 +26,12 @@ all: deps build
 deps-go: ## Install backend dependencies.
 	$(GO) run build.go setup
 
+go-reset:
+	rm -rf ./vendor/
+	+$(MAKE) gen-go
+	$(GO) mod tidy
+	$(GO) mod vendor
+
 deps-js: node_modules ## Install frontend dependencies.
 
 deps: deps-js ## Install all dependencies.


### PR DESCRIPTION
Grafana has some auto-generated files (wire) that depend heavily on the current set of vendored dependencies.

I find myself running this set of commands very very often (when switching across multiple major/minor versions, when backporting PRs, after not having pulled for a while) to make sure I'm on a clean slate (and to overall make grafana work).

So I thought it might be a good idea to include a Makefile command for what I run.

Thoughts?

Signed-off-by: gotjosh <josue.abreu@gmail.com>
