### PR TITLE
InfluxDB: Update SQL language url specification

### DIFF
--- a/pkg/tsdb/influxdb/fsql/flightsql_test.go
+++ b/pkg/tsdb/influxdb/fsql/flightsql_test.go
@@ -11,76 +11,123 @@ import (
 	"github.com/apache/arrow/go/v13/arrow/flight/flightsql/example"
 	"github.com/apache/arrow/go/v13/arrow/memory"
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
 
 	"github.com/grafana/grafana/pkg/tsdb/influxdb/models"
 )
 
-func TestIntegration_QueryData(t *testing.T) {
+func runMockServer() (flight.Server, error) {
 	db, err := example.CreateDB()
-	require.NoError(t, err)
+	if err != nil {
+		return nil, err
+	}
 	defer func(db *sql.DB) {
-		err := db.Close()
-		assert.NoError(t, err)
+		/*err := */ db.Close()
+		// require.NoError(t, err)
 	}(db)
 
 	sqliteServer, err := example.NewSQLiteFlightSQLServer(db)
-	require.NoError(t, err)
+	// require.NoError(t, err)
+	if err != nil {
+		return nil, err
+	}
 	sqliteServer.Alloc = memory.NewCheckedAllocator(memory.DefaultAllocator)
 	server := flight.NewServerWithMiddleware(nil)
 	server.RegisterFlightService(flightsql.NewFlightServer(sqliteServer))
 	err = server.Init("localhost:12345")
-	require.NoError(t, err)
+	// require.NoError(t, err)
+	if err != nil {
+		return nil, err
+	}
+	return server, nil
+}
+
+// Define the suite, and absorb the built-in basic suite
+// functionality from testify - including a T() method which
+// returns the current testing context
+type FSQLTestSuite struct {
+	suite.Suite
+	db     *sql.DB
+	server flight.Server
+}
+
+func (suite *FSQLTestSuite) SetupTest() {
+	db, err := example.CreateDB()
+	require.NoError(suite.T(), err)
+
+	sqliteServer, err := example.NewSQLiteFlightSQLServer(db)
+	require.NoError(suite.T(), err)
+	sqliteServer.Alloc = memory.NewCheckedAllocator(memory.DefaultAllocator)
+	server := flight.NewServerWithMiddleware(nil)
+	server.RegisterFlightService(flightsql.NewFlightServer(sqliteServer))
+	err = server.Init("localhost:12345")
+	require.NoError(suite.T(), err)
 	go func() {
 		err := server.Serve()
-		assert.NoError(t, err)
+		require.NoError(suite.T(), err)
 	}()
-	defer server.Shutdown()
+	suite.db = db
+	suite.server = server
+}
 
-	resp, err := Query(
-		context.Background(),
-		&models.DatasourceInfo{
-			HTTPClient: nil,
-			Token:      "secret",
-			URL:        "http://localhost:12345",
-			DbName:     "influxdb",
-			Version:    "test",
-			HTTPMode:   "proxy",
-			Metadata: []map[string]string{
-				{
-					"bucket": "bucket",
+func (suite *FSQLTestSuite) AfterTest(suiteName, testName string) {
+	err := suite.db.Close()
+	require.NoError(suite.T(), err)
+	suite.server.Shutdown()
+}
+
+func TestFSQLTestSuite(t *testing.T) {
+	suite.Run(t, new(FSQLTestSuite))
+}
+
+func (suite *FSQLTestSuite) TestIntegration_QueryData() {
+	suite.Run("should run simple query data", func() {
+		resp, err := Query(
+			context.Background(),
+			&models.DatasourceInfo{
+				HTTPClient: nil,
+				Token:      "secret",
+				URL:        "http://localhost:12345",
+				DbName:     "influxdb",
+				Version:    "test",
+				HTTPMode:   "proxy",
+				Metadata: []map[string]string{
+					{
+						"bucket": "bucket",
+					},
+				},
+				SecureGrpc: false,
+			},
+			backend.QueryDataRequest{
+				Queries: []backend.DataQuery{
+					{
+						RefID: "A",
+						JSON:  mustQueryJSON(suite.T(), "A", "select * from intTable"),
+					},
+					{
+						RefID: "B",
+						JSON:  mustQueryJSON(suite.T(), "B", "select 1"),
+					},
 				},
 			},
-			SecureGrpc: false,
-		},
-		backend.QueryDataRequest{
-			Queries: []backend.DataQuery{
-				{
-					RefID: "A",
-					JSON:  mustQueryJSON(t, "A", "select * from intTable"),
-				},
-				{
-					RefID: "B",
-					JSON:  mustQueryJSON(t, "B", "select 1"),
-				},
-			},
-		},
-	)
-	require.NoError(t, err)
-	require.Len(t, resp.Responses, 2)
+		)
 
-	respA := resp.Responses["A"]
-	require.NoError(t, respA.Error)
-	frame := respA.Frames[0]
+		require.NoError(suite.T(), err)
+		require.Len(suite.T(), resp.Responses, 2)
 
-	require.Equal(t, "id", frame.Fields[0].Name)
-	require.Equal(t, "keyName", frame.Fields[1].Name)
-	require.Equal(t, "value", frame.Fields[2].Name)
-	require.Equal(t, "foreignId", frame.Fields[3].Name)
-	for _, f := range frame.Fields {
-		assert.Equal(t, 4, f.Len())
-	}
+		respA := resp.Responses["A"]
+		require.NoError(suite.T(), respA.Error)
+		frame := respA.Frames[0]
+
+		require.Equal(suite.T(), "id", frame.Fields[0].Name)
+		require.Equal(suite.T(), "keyName", frame.Fields[1].Name)
+		require.Equal(suite.T(), "value", frame.Fields[2].Name)
+		require.Equal(suite.T(), "foreignId", frame.Fields[3].Name)
+		for _, f := range frame.Fields {
+			require.Equal(suite.T(), 4, f.Len())
+		}
+	})
 }
 
 func mustQueryJSON(t *testing.T, refID, sql string) []byte {

--- a/pkg/tsdb/influxdb/fsql/flightsql_test.go
+++ b/pkg/tsdb/influxdb/fsql/flightsql_test.go
@@ -17,32 +17,6 @@ import (
 	"github.com/grafana/grafana/pkg/tsdb/influxdb/models"
 )
 
-func runMockServer() (flight.Server, error) {
-	db, err := example.CreateDB()
-	if err != nil {
-		return nil, err
-	}
-	defer func(db *sql.DB) {
-		/*err := */ db.Close()
-		// require.NoError(t, err)
-	}(db)
-
-	sqliteServer, err := example.NewSQLiteFlightSQLServer(db)
-	// require.NoError(t, err)
-	if err != nil {
-		return nil, err
-	}
-	sqliteServer.Alloc = memory.NewCheckedAllocator(memory.DefaultAllocator)
-	server := flight.NewServerWithMiddleware(nil)
-	server.RegisterFlightService(flightsql.NewFlightServer(sqliteServer))
-	err = server.Init("localhost:12345")
-	// require.NoError(t, err)
-	if err != nil {
-		return nil, err
-	}
-	return server, nil
-}
-
 type FSQLTestSuite struct {
 	suite.Suite
 	db     *sql.DB

--- a/pkg/tsdb/influxdb/fsql/flightsql_test.go
+++ b/pkg/tsdb/influxdb/fsql/flightsql_test.go
@@ -43,9 +43,6 @@ func runMockServer() (flight.Server, error) {
 	return server, nil
 }
 
-// Define the suite, and absorb the built-in basic suite
-// functionality from testify - including a T() method which
-// returns the current testing context
 type FSQLTestSuite struct {
 	suite.Suite
 	db     *sql.DB

--- a/pkg/tsdb/influxdb/fsql/fsql.go
+++ b/pkg/tsdb/influxdb/fsql/fsql.go
@@ -3,9 +3,7 @@ package fsql
 import (
 	"context"
 	"fmt"
-	"net"
 	"net/url"
-	"strings"
 
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
 	"google.golang.org/grpc/metadata"
@@ -94,11 +92,10 @@ func runnerFromDataSource(dsInfo *models.DatasourceInfo) (*runner, error) {
 		return nil, fmt.Errorf("bad URL : %s", err)
 	}
 
-	host, port, err := net.SplitHostPort(u.Host)
-	if err != nil {
-		return nil, fmt.Errorf("bad URL : %s", err)
+	addr := u.Host
+	if u.Port() == "" {
+		addr += ":443"
 	}
-	addr := strings.Join([]string{host, port}, ":")
 
 	md := metadata.MD{}
 	for _, m := range dsInfo.Metadata {


### PR DESCRIPTION
**What is this feature?**

In the first iteration, the port information (which must be `443`) was crucial. But it is not anymore. This PR ensures that the backend will accept the URLs with or without port. 
See example below

```
// Valid
https://my-influxdb-server:443

// Also valid
https://my-influxdb-server
```

**Who is this feature for?**

Influxdb SQL users


**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
