### PR TITLE
Plugins: Add Grafana config to app plugin context

### DIFF
--- a/pkg/api/plugin_resource_test.go
+++ b/pkg/api/plugin_resource_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/grafana/grafana/pkg/infra/tracing"
 	"github.com/grafana/grafana/pkg/plugins"
 	"github.com/grafana/grafana/pkg/plugins/backendplugin/coreplugin"
+	"github.com/grafana/grafana/pkg/plugins/config"
 	pluginClient "github.com/grafana/grafana/pkg/plugins/manager/client"
 	"github.com/grafana/grafana/pkg/plugins/manager/fakes"
 	"github.com/grafana/grafana/pkg/services/accesscontrol"
@@ -47,6 +48,7 @@ func TestCallResource(t *testing.T) {
 	cfg := setting.NewCfg()
 	cfg.StaticRootPath = staticRootPath
 	cfg.Azure = &azsettings.AzureSettings{}
+	pCfg := config.Cfg{}
 
 	coreRegistry := coreplugin.ProvideCoreRegistry(tracing.InitializeTracerForTest(), nil, &cloudwatch.CloudWatchService{}, nil, nil, nil, nil,
 		nil, nil, nil, nil, testdatasource.ProvideService(), nil, nil, nil, nil, nil, nil)
@@ -54,7 +56,7 @@ func TestCallResource(t *testing.T) {
 	textCtx := pluginsintegration.CreateIntegrationTestCtx(t, cfg, coreRegistry)
 
 	pcp := plugincontext.ProvideService(cfg, localcache.ProvideService(), textCtx.PluginStore, &datasources.FakeDataSourceService{},
-		pluginSettings.ProvideService(db.InitTestDB(t), fakeSecrets.NewFakeSecretsService()), nil, nil)
+		pluginSettings.ProvideService(db.InitTestDB(t), fakeSecrets.NewFakeSecretsService()), nil, &pCfg)
 
 	srv := SetupAPITestServer(t, func(hs *HTTPServer) {
 		hs.Cfg = cfg

--- a/pkg/services/pluginsintegration/plugincontext/plugincontext.go
+++ b/pkg/services/pluginsintegration/plugincontext/plugincontext.go
@@ -80,6 +80,9 @@ func (p *Provider) Get(ctx context.Context, pluginID string, user identity.Reque
 		pCtx.AppInstanceSettings = appSettings
 	}
 
+	settings := p.pluginEnvVars.GetConfigMap(ctx, pluginID, plugin.ExternalService)
+	pCtx.GrafanaConfig = backend.NewGrafanaCfg(settings)
+
 	ua, err := useragent.New(p.cfg.BuildVersion, runtime.GOOS, runtime.GOARCH)
 	if err != nil {
 		p.logger.Warn("Could not create user agent", "error", err)

--- a/pkg/services/pluginsintegration/plugincontext/plugincontext_test.go
+++ b/pkg/services/pluginsintegration/plugincontext/plugincontext_test.go
@@ -59,6 +59,7 @@ func TestGet(t *testing.T) {
 				pCtx, err := pcp.Get(context.Background(), tc.input, identity, identity.OrgID)
 				require.NoError(t, err)
 				require.Equal(t, pluginID, pCtx.PluginID)
+				require.NotNil(t, pCtx.GrafanaConfig)
 			})
 
 			t.Run("GetWithDataSource", func(t *testing.T) {
@@ -71,6 +72,7 @@ func TestGet(t *testing.T) {
 				})
 				require.NoError(t, err)
 				require.Equal(t, pluginID, pCtx.PluginID)
+				require.NotNil(t, pCtx.GrafanaConfig)
 			})
 		})
 	}


### PR DESCRIPTION
This was already being passed down for datasource plugins, but not
for apps.
