### PR TITLE
Chore: Remove Folder ID from FindPersistedDashboardsQuery

### DIFF
--- a/pkg/services/dashboards/database/database.go
+++ b/pkg/services/dashboards/database/database.go
@@ -964,11 +964,6 @@ func (d *dashboardStore) FindDashboards(ctx context.Context, query *dashboards.F
 		filters = append(filters, searchstore.TypeFilter{Dialect: d.store.GetDialect(), Type: query.Type})
 	}
 
-	// nolint:staticcheck
-	if len(query.FolderIds) > 0 {
-		filters = append(filters, searchstore.FolderFilter{IDs: query.FolderIds})
-	}
-
 	if len(query.FolderUIDs) > 0 {
 		filters = append(filters, searchstore.FolderUIDFilter{
 			Dialect:              d.store.GetDialect(),

--- a/pkg/services/dashboards/database/database_folder_test.go
+++ b/pkg/services/dashboards/database/database_folder_test.go
@@ -169,7 +169,7 @@ func TestIntegrationDashboardFolderDataAccess(t *testing.T) {
 
 				t.Run("should return dashboards in root and expanded folder", func(t *testing.T) {
 					query := &dashboards.FindPersistedDashboardsQuery{
-						FolderIds: []int64{
+						FolderUIDs: []int64{
 							rootFolderId,
 							folder1.ID,
 						}, // nolint:staticcheck

--- a/pkg/services/dashboards/database/database_test.go
+++ b/pkg/services/dashboards/database/database_test.go
@@ -280,7 +280,7 @@ func TestIntegrationDashboardDataAccess(t *testing.T) {
 
 		query := dashboards.FindPersistedDashboardsQuery{
 			OrgId:        1,
-			FolderIds:    []int64{savedFolder.ID}, // nolint:staticcheck
+			FolderUIDs:   []int64{savedFolder.ID}, // nolint:staticcheck
 			SignedInUser: &user.SignedInUser{},
 		}
 
@@ -438,8 +438,8 @@ func TestIntegrationDashboardDataAccess(t *testing.T) {
 	t.Run("Should be able to find a dashboard folder's children", func(t *testing.T) {
 		setup()
 		query := dashboards.FindPersistedDashboardsQuery{
-			OrgId:     1,
-			FolderIds: []int64{savedFolder.ID}, // nolint:staticcheck
+			OrgId:      1,
+			FolderUIDs: []int64{savedFolder.ID}, // nolint:staticcheck
 			SignedInUser: &user.SignedInUser{
 				OrgID:   1,
 				OrgRole: org.RoleEditor,
@@ -456,8 +456,6 @@ func TestIntegrationDashboardDataAccess(t *testing.T) {
 		hit := hits[0]
 		require.Equal(t, hit.ID, savedDash.ID)
 		require.Equal(t, hit.URL, fmt.Sprintf("/d/%s/%s", savedDash.UID, savedDash.Slug))
-		// nolint:staticcheck
-		require.Equal(t, hit.FolderID, savedFolder.ID)
 		require.Equal(t, hit.FolderUID, savedFolder.UID)
 		require.Equal(t, hit.FolderTitle, savedFolder.Title)
 		require.Equal(t, hit.FolderURL, fmt.Sprintf("/dashboards/f/%s/%s", savedFolder.UID, savedFolder.Slug))
@@ -484,8 +482,7 @@ func TestIntegrationDashboardDataAccess(t *testing.T) {
 		hit := hits[0]
 		require.Equal(t, hit.ID, savedDash.ID)
 		require.Equal(t, hit.URL, fmt.Sprintf("/d/%s/%s", savedDash.UID, savedDash.Slug))
-		// nolint:staticcheck
-		require.Equal(t, hit.FolderID, savedFolder.ID)
+
 		require.Equal(t, hit.FolderUID, savedFolder.UID)
 		require.Equal(t, hit.FolderTitle, savedFolder.Title)
 		require.Equal(t, hit.FolderURL, fmt.Sprintf("/dashboards/f/%s/%s", savedFolder.UID, savedFolder.Slug))
@@ -1053,7 +1050,6 @@ func TestIntegrationFindDashboardsByFolder(t *testing.T) {
 				res, err := dashboardStore.FindDashboards(context.Background(), &dashboards.FindPersistedDashboardsQuery{
 					SignedInUser: user,
 					Type:         tc.typ,
-					FolderIds:    tc.folderIDs, // nolint:staticcheck
 					FolderUIDs:   tc.folderUIDs,
 				})
 				require.NoError(t, err)

--- a/pkg/services/dashboards/models.go
+++ b/pkg/services/dashboards/models.go
@@ -485,14 +485,12 @@ type FindPersistedDashboardsQuery struct {
 	DashboardIds  []int64
 	DashboardUIDs []string
 	Type          string
-	// Deprecated: use FolderUIDs instead
-	FolderIds  []int64
-	FolderUIDs []string
-	Tags       []string
-	Limit      int64
-	Page       int64
-	Permission dashboardaccess.PermissionType
-	Sort       model.SortOption
+	FolderUIDs    []string
+	Tags          []string
+	Limit         int64
+	Page          int64
+	Permission    dashboardaccess.PermissionType
+	Sort          model.SortOption
 
 	Filters []any
 }

--- a/pkg/services/search/service.go
+++ b/pkg/services/search/service.go
@@ -85,7 +85,6 @@ func (s *SearchService) SearchHandler(ctx context.Context, query *Query) (model.
 		DashboardUIDs: query.DashboardUIDs,
 		DashboardIds:  query.DashboardIds,
 		Type:          query.Type,
-		FolderIds:     query.FolderIds, // nolint:staticcheck
 		FolderUIDs:    query.FolderUIDs,
 		Tags:          query.Tags,
 		Limit:         query.Limit,


### PR DESCRIPTION
This is part of the effort to deprecate folder ID #78757

This PR removes folder ID from FindPersistedDashboardsQuery