### PR TITLE
Loki/Elasticsearch: prevent errors in onDashboardLoadedHandler

### DIFF
--- a/public/app/plugins/datasource/elasticsearch/tracking.test.ts
+++ b/public/app/plugins/datasource/elasticsearch/tracking.test.ts
@@ -1,0 +1,64 @@
+
+import { DashboardLoadedEvent } from '@grafana/data';
+import { reportInteraction } from '@grafana/runtime';
+
+import pluginJson from './plugin.json';
+import { onDashboardLoadedHandler } from './tracking';
+import { ElasticsearchQuery } from './types';
+
+jest.mock('@grafana/runtime', () => ({
+  ...jest.requireActual('@grafana/runtime'),
+  reportInteraction: jest.fn(),
+}));
+
+const targets: ElasticsearchQuery[] = [
+  {
+    refId: 'test',
+    alias: '$varAlias',
+    bucketAggs: [],
+    metrics: [],
+    query: 'test',
+  },
+];
+
+afterAll(() => {
+  jest.clearAllMocks();
+});
+
+describe('onDashboardLoadedHandler', () => {
+  beforeEach(() => {
+    jest.mocked(reportInteraction).mockClear();
+    jest.spyOn(console, 'error');
+  });
+  test('Reports dashboard loaded interactions', () => {
+    const event = new DashboardLoadedEvent({
+      dashboardId: 'test',
+      orgId: 1,
+      userId: 2,
+      grafanaVersion: '11',
+      queries: {
+        [pluginJson.id]: targets,
+      },
+    });
+    onDashboardLoadedHandler(event);
+
+    expect(reportInteraction).toHaveBeenCalled();
+    expect(console.error).not.toHaveBeenCalled();
+  });
+
+  test('Does not report or fails when the dashboard id has no queries', () => {
+    const event = new DashboardLoadedEvent({
+      dashboardId: 'test',
+      orgId: 1,
+      userId: 2,
+      grafanaVersion: '11',
+      queries: {
+        'not elasticsearch': targets,
+      },
+    });
+    onDashboardLoadedHandler(event);
+
+    expect(reportInteraction).not.toHaveBeenCalled();
+    expect(console.error).not.toHaveBeenCalled();
+  });
+});

--- a/public/app/plugins/datasource/elasticsearch/tracking.test.ts
+++ b/public/app/plugins/datasource/elasticsearch/tracking.test.ts
@@ -1,4 +1,3 @@
-
 import { DashboardLoadedEvent } from '@grafana/data';
 import { reportInteraction } from '@grafana/runtime';
 

--- a/public/app/plugins/datasource/elasticsearch/tracking.ts
+++ b/public/app/plugins/datasource/elasticsearch/tracking.ts
@@ -41,7 +41,7 @@ export const onDashboardLoadedHandler = ({
 }: DashboardLoadedEvent<ElasticsearchQuery>) => {
   try {
     // We only want to track visible ElasticSearch queries
-    const elasticsearchQueries = queries[pluginJson.id].filter((query) => !query.hide);
+    const elasticsearchQueries = queries[pluginJson.id]?.filter((query) => !query.hide);
     if (!elasticsearchQueries?.length) {
       return;
     }

--- a/public/app/plugins/datasource/loki/tracking.test.ts
+++ b/public/app/plugins/datasource/loki/tracking.test.ts
@@ -1,13 +1,15 @@
 import { getQueryOptions } from 'test/helpers/getQueryOptions';
 
-import { dateTime } from '@grafana/data';
+import { DashboardLoadedEvent, dateTime } from '@grafana/data';
 import { reportInteraction } from '@grafana/runtime';
 
 import { QueryEditorMode } from '../prometheus/querybuilder/shared/types';
 
+import pluginJson from './plugin.json';
 import { partitionTimeRange } from './querySplitting';
-import { trackGroupedQueries, trackQuery } from './tracking';
+import { onDashboardLoadedHandler, trackGroupedQueries, trackQuery } from './tracking';
 import { LokiGroupedRequest, LokiQuery } from './types';
+
 
 jest.mock('@grafana/runtime', () => ({
   ...jest.requireActual('@grafana/runtime'),
@@ -63,6 +65,7 @@ beforeAll(() => {
 });
 afterAll(() => {
   jest.useRealTimers();
+  jest.clearAllMocks();
 });
 beforeEach(() => {
   jest.mocked(reportInteraction).mockClear();
@@ -180,5 +183,43 @@ test('Tracks grouped queries', () => {
     time_range_to: '2023-02-10T06:00:00.000Z',
     time_taken: 0,
     predefined_operations_applied: 'n/a',
+  });
+});
+
+describe('onDashboardLoadedHandler', () => {
+  beforeEach(() => {
+    jest.mocked(reportInteraction).mockClear();
+    jest.spyOn(console, 'error');
+  });
+  test('Reports dashboard loaded interactions', () => {
+    const event = new DashboardLoadedEvent({
+      dashboardId: 'test',
+      orgId: 1,
+      userId: 2,
+      grafanaVersion: '11',
+      queries: {
+        [pluginJson.id]: originalRequest.targets,
+      },
+    });
+    onDashboardLoadedHandler(event);
+
+    expect(reportInteraction).toHaveBeenCalled();
+    expect(console.error).not.toHaveBeenCalled();
+  });
+
+  test('Does not report or fails when the dashboard id has no queries', () => {
+    const event = new DashboardLoadedEvent({
+      dashboardId: 'test',
+      orgId: 1,
+      userId: 2,
+      grafanaVersion: '11',
+      queries: {
+        'not loki': originalRequest.targets,
+      },
+    });
+    onDashboardLoadedHandler(event);
+
+    expect(reportInteraction).not.toHaveBeenCalled();
+    expect(console.error).not.toHaveBeenCalled();
   });
 });

--- a/public/app/plugins/datasource/loki/tracking.test.ts
+++ b/public/app/plugins/datasource/loki/tracking.test.ts
@@ -10,7 +10,6 @@ import { partitionTimeRange } from './querySplitting';
 import { onDashboardLoadedHandler, trackGroupedQueries, trackQuery } from './tracking';
 import { LokiGroupedRequest, LokiQuery } from './types';
 
-
 jest.mock('@grafana/runtime', () => ({
   ...jest.requireActual('@grafana/runtime'),
   reportInteraction: jest.fn(),

--- a/public/app/plugins/datasource/loki/tracking.ts
+++ b/public/app/plugins/datasource/loki/tracking.ts
@@ -63,8 +63,8 @@ export const onDashboardLoadedHandler = ({
   try {
     // We only want to track visible Loki queries
     const lokiQueries = queries[pluginJson.id]
-      .filter((query) => !query.hide)
-      .map((query) => getNormalizedLokiQuery(query));
+      ?.filter((query) => !query.hide)
+      ?.map((query) => getNormalizedLokiQuery(query));
 
     if (!lokiQueries?.length) {
       return;


### PR DESCRIPTION
While working on infinite scrolling on dashboards, I noticed errors in the console when loading dashboards, in particular in Loki and Elastic dashboards.

The source of the errors is that `queries[pluginJson.id]` is undefined.

![loki](https://github.com/grafana/grafana/assets/1069378/a4c9ff13-b8cd-484d-bd91-93dc4df9694a)

![elastic](https://github.com/grafana/grafana/assets/1069378/f345f226-a449-4f99-bea6-edd49821dc45)

**What is this feature?**

- Better handling of possibly undefined objects.
- Addition of missing coverage.

**Why do we need this feature?**

Even within the `try/catch`, there's no guarantee that mishandling of possibly undefined variables could cause other bugs or unexpected behaviors.

We are also documenting through tests that this function needs to handle possibly undefined queries, which would ease refactoring of this code. For example, if the try/catch is removed for whatever reason, these tests should prevent that code to reach production.

**Special notes for your reviewer:**

The only way to reproduce these errors is to load Grafana in an new session/incognito tab, browse dashboards, and see the erros in the console.