### PR TITLE
Remove deprecated FolderID from api tests

### DIFF
--- a/pkg/api/dashboard_test.go
+++ b/pkg/api/dashboard_test.go
@@ -377,14 +377,12 @@ func TestDashboardAPIEndpoint(t *testing.T) {
 	t.Run("Given two dashboards with the same title in different folders", func(t *testing.T) {
 		dashOne := dashboards.NewDashboard("dash")
 		dashOne.ID = 2
-		// nolint:staticcheck
-		dashOne.FolderID = 1
+		dashOne.FolderUID = "folderUID"
 		dashOne.HasACL = false
 
 		dashTwo := dashboards.NewDashboard("dash")
 		dashTwo.ID = 4
-		// nolint:staticcheck
-		dashTwo.FolderID = 3
+		dashTwo.FolderUID = "folderUID2"
 		dashTwo.HasACL = false
 	})
 
@@ -404,19 +402,16 @@ func TestDashboardAPIEndpoint(t *testing.T) {
 					"title": "Dash",
 				}),
 				Overwrite: true,
-				FolderID:  folderID, // nolint:staticcheck
 				FolderUID: folderUID,
 				IsFolder:  false,
 				Message:   "msg",
 			}
 
 			dashboardService := dashboards.NewFakeDashboardService(t)
-			// nolint:staticcheck
 			dashboardService.On("SaveDashboard", mock.Anything, mock.AnythingOfType("*dashboards.SaveDashboardDTO"), mock.AnythingOfType("bool")).
-				Return(&dashboards.Dashboard{ID: dashID, UID: "uid", Title: "Dash", Slug: "dash", Version: 2, FolderUID: folderUID, FolderID: folderID}, nil)
-			// nolint:staticcheck
+				Return(&dashboards.Dashboard{ID: dashID, UID: "uid", Title: "Dash", Slug: "dash", Version: 2, FolderUID: folderUID}, nil)
 			mockFolderService := &foldertest.FakeService{
-				ExpectedFolder: &folder.Folder{ID: 1, UID: folderUID, Title: "Folder"},
+				ExpectedFolder: &folder.Folder{UID: folderUID, Title: "Folder"},
 			}
 
 			postDashboardScenario(t, "When calling POST on", "/api/dashboards", "/api/dashboards", cmd, dashboardService, mockFolderService, func(sc *scenarioContext) {
@@ -451,9 +446,8 @@ func TestDashboardAPIEndpoint(t *testing.T) {
 			dashboardService.On("SaveDashboard", mock.Anything, mock.AnythingOfType("*dashboards.SaveDashboardDTO"), mock.AnythingOfType("bool")).
 				Return(&dashboards.Dashboard{ID: dashID, UID: "uid", Title: "Dash", Slug: "dash", Version: 2}, nil)
 
-			// nolint:staticcheck
 			mockFolder := &foldertest.FakeService{
-				ExpectedFolder: &folder.Folder{ID: 1, UID: "folderUID", Title: "Folder"},
+				ExpectedFolder: &folder.Folder{UID: "folderUID", Title: "Folder"},
 			}
 
 			postDashboardScenario(t, "When calling POST on", "/api/dashboards", "/api/dashboards", cmd, dashboardService, mockFolder, func(sc *scenarioContext) {
@@ -567,11 +561,8 @@ func TestDashboardAPIEndpoint(t *testing.T) {
 	})
 
 	t.Run("Given dashboard in folder being restored should restore to folder", func(t *testing.T) {
-		const folderID int64 = 1
 		fakeDash := dashboards.NewDashboard("Child dash")
 		fakeDash.ID = 2
-		// nolint:staticcheck
-		fakeDash.FolderID = folderID
 		fakeDash.HasACL = false
 
 		dashboardService := dashboards.NewFakeDashboardService(t)
@@ -703,9 +694,6 @@ func TestDashboardAPIEndpoint(t *testing.T) {
 
 func TestDashboardVersionsAPIEndpoint(t *testing.T) {
 	fakeDash := dashboards.NewDashboard("Child dash")
-	fakeDash.ID = 1
-	// nolint:staticcheck
-	fakeDash.FolderID = 1
 
 	fakeDashboardVersionService := dashvertest.NewDashboardVersionServiceFake()
 	dashboardService := dashboards.NewFakeDashboardService(t)

--- a/pkg/api/dashboard_test.go
+++ b/pkg/api/dashboard_test.go
@@ -391,7 +391,6 @@ func TestDashboardAPIEndpoint(t *testing.T) {
 		defer dashboardStore.AssertExpectations(t)
 		// This tests that a valid request returns correct response
 		t.Run("Given a correct request for creating a dashboard", func(t *testing.T) {
-			const folderID int64 = 3
 			folderUID := "Folder"
 			const dashID int64 = 2
 

--- a/pkg/api/folder_bench_test.go
+++ b/pkg/api/folder_bench_test.go
@@ -343,20 +343,20 @@ func setupDB(b testing.TB) benchScenario {
 			str := fmt.Sprintf("dashboard_%d_%d", i, j)
 			dashID := generateID(IDs)
 			dashs = append(dashs, &dashboards.Dashboard{
-				ID:       dashID,
-				OrgID:    signedInUser.OrgID,
-				IsFolder: false,
-				UID:      str,
-				FolderID: f0.ID, // nolint:staticcheck
-				Slug:     str,
-				Title:    str,
-				Data:     simplejson.New(),
-				Created:  now,
-				Updated:  now,
+				ID:        dashID,
+				OrgID:     signedInUser.OrgID,
+				IsFolder:  false,
+				UID:       str,
+				FolderUID: f0.UID,
+				Slug:      str,
+				Title:     str,
+				Data:      simplejson.New(),
+				Created:   now,
+				Updated:   now,
 			})
 
 			dashTags = append(dashTags, &dashboardTag{
-				DashboardId: dashID,
+				DashboardID: dashID,
 				Term:        fmt.Sprintf("tag%d", j),
 			})
 		}
@@ -370,20 +370,20 @@ func setupDB(b testing.TB) benchScenario {
 				str := fmt.Sprintf("dashboard_%d_%d_%d", i, j, k)
 				dashID := generateID(IDs)
 				dashs = append(dashs, &dashboards.Dashboard{
-					ID:       dashID,
-					OrgID:    signedInUser.OrgID,
-					IsFolder: false,
-					UID:      str,
-					FolderID: f1.ID, // nolint:staticcheck
-					Slug:     str,
-					Title:    str,
-					Data:     simplejson.New(),
-					Created:  now,
-					Updated:  now,
+					ID:        dashID,
+					OrgID:     signedInUser.OrgID,
+					IsFolder:  false,
+					UID:       str,
+					FolderUID: f1.UID,
+					Slug:      str,
+					Title:     str,
+					Data:      simplejson.New(),
+					Created:   now,
+					Updated:   now,
 				})
 
 				dashTags = append(dashTags, &dashboardTag{
-					DashboardId: dashID,
+					DashboardID: dashID,
 					Term:        fmt.Sprintf("tag%d", k),
 				})
 			}
@@ -397,20 +397,20 @@ func setupDB(b testing.TB) benchScenario {
 					str := fmt.Sprintf("dashboard_%d_%d_%d_%d", i, j, k, l)
 					dashID := generateID(IDs)
 					dashs = append(dashs, &dashboards.Dashboard{
-						ID:       dashID,
-						OrgID:    signedInUser.OrgID,
-						IsFolder: false,
-						UID:      str,
-						FolderID: f2.ID, // nolint:staticcheck
-						Slug:     str,
-						Title:    str,
-						Data:     simplejson.New(),
-						Created:  now,
-						Updated:  now,
+						ID:        dashID,
+						OrgID:     signedInUser.OrgID,
+						IsFolder:  false,
+						UID:       str,
+						FolderUID: f2.UID,
+						Slug:      str,
+						Title:     str,
+						Data:      simplejson.New(),
+						Created:   now,
+						Updated:   now,
 					})
 
 					dashTags = append(dashTags, &dashboardTag{
-						DashboardId: dashID,
+						DashboardID: dashID,
 						Term:        fmt.Sprintf("tag%d", l),
 					})
 				}
@@ -507,7 +507,7 @@ func setupServer(b testing.TB, sc benchScenario, features *featuremgmt.FeatureMa
 }
 
 type f struct {
-	ID          int64   `xorm:"pk autoincr 'id'"`
+	// ID          int64   `xorm:"pk autoincr 'id'"`
 	OrgID       int64   `xorm:"org_id"`
 	UID         string  `xorm:"uid"`
 	ParentUID   *string `xorm:"parent_uid"`
@@ -524,8 +524,8 @@ func (f *f) TableName() string {
 
 // SQL bean helper to save tags
 type dashboardTag struct {
-	Id          int64
-	DashboardId int64
+	ID          int64
+	DashboardID int64
 	Term        string
 }
 
@@ -533,10 +533,10 @@ func addFolder(orgID int64, id int64, uid string, parentUID *string) (*f, *dashb
 	now := time.Now()
 	title := uid
 	f := &f{
-		OrgID:     orgID,
-		UID:       uid,
-		Title:     title,
-		ID:        id,
+		OrgID: orgID,
+		UID:   uid,
+		Title: title,
+		// ID:        id,
 		Created:   now,
 		Updated:   now,
 		ParentUID: parentUID,

--- a/pkg/api/folder_permission_test.go
+++ b/pkg/api/folder_permission_test.go
@@ -30,8 +30,7 @@ func TestHTTPServer_GetFolderPermissionList(t *testing.T) {
 
 	t.Run("should be able to list acl with correct permission", func(t *testing.T) {
 		server := SetupAPITestServer(t, func(hs *HTTPServer) {
-			// nolint:staticcheck
-			hs.folderService = &foldertest.FakeService{ExpectedFolder: &folder.Folder{ID: 1, UID: "1"}}
+			hs.folderService = &foldertest.FakeService{ExpectedFolder: &folder.Folder{UID: "1"}}
 			hs.folderPermissionsService = &actest.FakePermissionsService{
 				ExpectedPermissions: []accesscontrol.ResourcePermission{},
 			}
@@ -51,8 +50,7 @@ func TestHTTPServer_GetFolderPermissionList(t *testing.T) {
 			cfg := setting.NewCfg()
 			cfg.HiddenUsers = map[string]struct{}{"hidden": {}}
 			hs.Cfg = cfg
-			// nolint:staticcheck
-			hs.folderService = &foldertest.FakeService{ExpectedFolder: &folder.Folder{ID: 1, UID: "1"}}
+			hs.folderService = &foldertest.FakeService{ExpectedFolder: &folder.Folder{UID: "1"}}
 
 			hs.folderPermissionsService = &actest.FakePermissionsService{
 				ExpectedPermissions: []accesscontrol.ResourcePermission{
@@ -90,8 +88,7 @@ func TestHTTPServer_UpdateFolderPermissions(t *testing.T) {
 
 	t.Run("should be able to update acl with correct permissions", func(t *testing.T) {
 		server := SetupAPITestServer(t, func(hs *HTTPServer) {
-			// nolint:staticcheck
-			hs.folderService = &foldertest.FakeService{ExpectedFolder: &folder.Folder{ID: 1, UID: "1"}}
+			hs.folderService = &foldertest.FakeService{ExpectedFolder: &folder.Folder{UID: "1"}}
 			hs.folderPermissionsService = &actest.FakePermissionsService{}
 		})
 
@@ -107,8 +104,7 @@ func TestHTTPServer_UpdateFolderPermissions(t *testing.T) {
 
 	t.Run("should not be able to specify team and user in same acl", func(t *testing.T) {
 		server := SetupAPITestServer(t, func(hs *HTTPServer) {
-			// nolint:staticcheck
-			hs.folderService = &foldertest.FakeService{ExpectedFolder: &folder.Folder{ID: 1, UID: "1"}}
+			hs.folderService = &foldertest.FakeService{ExpectedFolder: &folder.Folder{UID: "1"}}
 			hs.folderPermissionsService = &actest.FakePermissionsService{}
 		})
 
@@ -124,8 +120,7 @@ func TestHTTPServer_UpdateFolderPermissions(t *testing.T) {
 
 	t.Run("should not be able to specify team and role in same acl", func(t *testing.T) {
 		server := SetupAPITestServer(t, func(hs *HTTPServer) {
-			// nolint:staticcheck
-			hs.folderService = &foldertest.FakeService{ExpectedFolder: &folder.Folder{ID: 1, UID: "1"}}
+			hs.folderService = &foldertest.FakeService{ExpectedFolder: &folder.Folder{UID: "1"}}
 			hs.folderPermissionsService = &actest.FakePermissionsService{}
 		})
 
@@ -141,8 +136,7 @@ func TestHTTPServer_UpdateFolderPermissions(t *testing.T) {
 
 	t.Run("should not be able to specify user and role in same acl", func(t *testing.T) {
 		server := SetupAPITestServer(t, func(hs *HTTPServer) {
-			// nolint:staticcheck
-			hs.folderService = &foldertest.FakeService{ExpectedFolder: &folder.Folder{ID: 1, UID: "1"}}
+			hs.folderService = &foldertest.FakeService{ExpectedFolder: &folder.Folder{UID: "1"}}
 			hs.folderPermissionsService = &actest.FakePermissionsService{}
 		})
 

--- a/pkg/api/folder_test.go
+++ b/pkg/api/folder_test.go
@@ -47,7 +47,7 @@ func TestFoldersCreateAPIEndpoint(t *testing.T) {
 			description:    "folder creation succeeds given the correct request for creating a folder",
 			input:          folderWithoutParentInput,
 			expectedCode:   http.StatusOK,
-			expectedFolder: &folder.Folder{ID: 1, UID: "uid", Title: "Folder"}, // nolint:staticcheck
+			expectedFolder: &folder.Folder{UID: "uid", Title: "Folder"},
 			permissions:    []accesscontrol.Permission{{Action: dashboards.ActionFoldersCreate}},
 		},
 		{
@@ -167,7 +167,7 @@ func TestFoldersUpdateAPIEndpoint(t *testing.T) {
 		{
 			description:    "folder updating succeeds given the correct request and permissions to update a folder",
 			expectedCode:   http.StatusOK,
-			expectedFolder: &folder.Folder{ID: 1, UID: "uid", Title: "Folder upd"}, // nolint:staticcheck
+			expectedFolder: &folder.Folder{UID: "uid", Title: "Folder upd"},
 			permissions:    []accesscontrol.Permission{{Action: dashboards.ActionFoldersWrite, Scope: dashboards.ScopeFoldersAll}},
 		},
 		{
@@ -417,7 +417,6 @@ func TestFolderMoveAPIEndpoint(t *testing.T) {
 func TestFolderGetAPIEndpoint(t *testing.T) {
 	folderService := &foldertest.FakeService{
 		ExpectedFolder: &folder.Folder{
-			ID:    1, // nolint:staticcheck
 			UID:   "uid",
 			Title: "uid title",
 		},


### PR DESCRIPTION
Deprecating FolderIDs for tests in api pkg. 

Related to #78757