### PR TITLE
Tempo: Fix cache in TraceQL editor

### DIFF
--- a/public/app/plugins/datasource/tempo/traceql/autocomplete.ts
+++ b/public/app/plugins/datasource/tempo/traceql/autocomplete.ts
@@ -282,12 +282,13 @@ export class CompletionProvider implements monacoTypes.languages.CompletionItemP
 
   private async getTagValues(tagName: string, query: string): Promise<Array<SelectableValue<string>>> {
     let tagValues: Array<SelectableValue<string>>;
+    const cacheKey = `${tagName}:${query}`;
 
-    if (this.cachedValues.hasOwnProperty(tagName)) {
-      tagValues = this.cachedValues[tagName];
+    if (this.cachedValues.hasOwnProperty(cacheKey)) {
+      tagValues = this.cachedValues[cacheKey];
     } else {
       tagValues = await this.languageProvider.getOptionsV2(tagName, query);
-      this.cachedValues[tagName] = tagValues;
+      this.cachedValues[cacheKey] = tagValues;
     }
     return tagValues;
   }


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

Fixes the cache of the TraceQL editor as reported in the issue of #77380 .

**Why do we need this feature?**

To get the full functionality of the improved autocomplete API from Tempo.

**Who is this feature for?**

Users of the Tempo datasource.

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #77380 

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
