### PR TITLE
Alerting: Add rule ID and title to alert state history Loki entry

### DIFF
--- a/pkg/services/ngalert/state/historian/loki.go
+++ b/pkg/services/ngalert/state/historian/loki.go
@@ -255,6 +255,8 @@ func statesToStream(rule history_model.RuleMeta, states []state.StateTransition,
 			DashboardUID:   rule.DashboardUID,
 			PanelID:        rule.PanelID,
 			Fingerprint:    labelFingerprint(sanitizedLabels),
+			RuleTitle:      rule.Title,
+			RuleID:         rule.ID,
 			RuleUID:        rule.UID,
 			InstanceLabels: sanitizedLabels,
 		}
@@ -300,6 +302,8 @@ type lokiEntry struct {
 	DashboardUID  string           `json:"dashboardUID"`
 	PanelID       int64            `json:"panelID"`
 	Fingerprint   string           `json:"fingerprint"`
+	RuleTitle     string           `json:"ruleTitle"`
+	RuleID        int64            `json:"ruleID"`
 	RuleUID       string           `json:"ruleUID"`
 	// InstanceLabels is exactly the set of labels associated with the alert instance in Alertmanager.
 	// These should not be conflated with labels associated with log streams.

--- a/pkg/services/ngalert/state/historian/loki_test.go
+++ b/pkg/services/ngalert/state/historian/loki_test.go
@@ -89,7 +89,7 @@ func TestRemoteLokiBackend(t *testing.T) {
 			require.NotContains(t, res.Stream, "__private__")
 		})
 
-		t.Run("includes ruleTitle in log line", func(t *testing.T) {
+		t.Run("includes rule data in log line", func(t *testing.T) {
 			rule := createTestRule()
 			l := log.NewNopLogger()
 			states := singleFromNormal(&state.State{
@@ -98,36 +98,10 @@ func TestRemoteLokiBackend(t *testing.T) {
 			})
 
 			res := statesToStream(rule, states, nil, l)
-
 			entry := requireSingleEntry(t, res)
+
 			require.Equal(t, rule.Title, entry.RuleTitle)
-		})
-
-		t.Run("includes ruleID in log line", func(t *testing.T) {
-			rule := createTestRule()
-			l := log.NewNopLogger()
-			states := singleFromNormal(&state.State{
-				State:  eval.Alerting,
-				Labels: data.Labels{"a": "b"},
-			})
-
-			res := statesToStream(rule, states, nil, l)
-
-			entry := requireSingleEntry(t, res)
 			require.Equal(t, rule.ID, entry.RuleID)
-		})
-
-		t.Run("includes ruleUID in log line", func(t *testing.T) {
-			rule := createTestRule()
-			l := log.NewNopLogger()
-			states := singleFromNormal(&state.State{
-				State:  eval.Alerting,
-				Labels: data.Labels{"a": "b"},
-			})
-
-			res := statesToStream(rule, states, nil, l)
-
-			entry := requireSingleEntry(t, res)
 			require.Equal(t, rule.UID, entry.RuleUID)
 		})
 

--- a/pkg/services/ngalert/state/historian/loki_test.go
+++ b/pkg/services/ngalert/state/historian/loki_test.go
@@ -89,6 +89,34 @@ func TestRemoteLokiBackend(t *testing.T) {
 			require.NotContains(t, res.Stream, "__private__")
 		})
 
+		t.Run("includes ruleTitle in log line", func(t *testing.T) {
+			rule := createTestRule()
+			l := log.NewNopLogger()
+			states := singleFromNormal(&state.State{
+				State:  eval.Alerting,
+				Labels: data.Labels{"a": "b"},
+			})
+
+			res := statesToStream(rule, states, nil, l)
+
+			entry := requireSingleEntry(t, res)
+			require.Equal(t, rule.Title, entry.RuleTitle)
+		})
+
+		t.Run("includes ruleID in log line", func(t *testing.T) {
+			rule := createTestRule()
+			l := log.NewNopLogger()
+			states := singleFromNormal(&state.State{
+				State:  eval.Alerting,
+				Labels: data.Labels{"a": "b"},
+			})
+
+			res := statesToStream(rule, states, nil, l)
+
+			entry := requireSingleEntry(t, res)
+			require.Equal(t, rule.ID, entry.RuleID)
+		})
+
 		t.Run("includes ruleUID in log line", func(t *testing.T) {
 			rule := createTestRule()
 			l := log.NewNopLogger()
@@ -525,11 +553,13 @@ func singleFromNormal(st *state.State) []state.StateTransition {
 func createTestRule() history_model.RuleMeta {
 	return history_model.RuleMeta{
 		OrgID:        1,
+		ID:           123,
 		UID:          "rule-uid",
 		Group:        "my-group",
 		NamespaceUID: "my-folder",
 		DashboardUID: "dash-uid",
 		PanelID:      123,
+		Title:        "my-title",
 	}
 }
 


### PR DESCRIPTION
**What is this feature?**

Adds extra fields to alert state history Loki log lines

**Why do we need this feature?**

Makes debugging easier, and helps enable #78156

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
