### PR TITLE
CloudWatch: remove DataSourcePicker core import

### DIFF
--- a/public/app/plugins/datasource/cloudwatch/components/ConfigEditor/XrayLinkConfig.tsx
+++ b/public/app/plugins/datasource/cloudwatch/components/ConfigEditor/XrayLinkConfig.tsx
@@ -3,8 +3,8 @@ import React from 'react';
 
 import { GrafanaTheme2, DataSourceInstanceSettings } from '@grafana/data';
 import { ConfigSection } from '@grafana/experimental';
+import { DataSourcePicker } from '@grafana/runtime';
 import { Alert, Field, InlineField, useStyles2 } from '@grafana/ui';
-import { DataSourcePicker } from 'app/features/datasources/components/picker/DataSourcePicker';
 import { getDatasourceSrv } from 'app/features/plugins/datasource_srv';
 
 const getStyles = (theme: GrafanaTheme2) => ({


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

Uses the `DataSourcePicker` from `@grafana/runtime` instead of the one from core Grafana.

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #79321

**Special notes for your reviewer:**

There are 2 `DataSourcePicker` components. 1 lives in core Grafana, and the other in `@grafana/runtime`. The core one falls back to the one in `@grafana/runtime` if the `advancedDataSourcePicker` is not set. However, this feature flag is enabled by default now so we no longer fall back to the `@grafana/runtime` one. This PR will make it so we just use the `@grafana/runtime` one.

**`@grafana/runtime` `DataSourcePicker`**
<img width="722" alt="runtime data source picker" src="https://github.com/grafana/grafana/assets/19530599/1b6ab527-b438-4b16-bd64-622436c25793">

**Core Grafana `DataSourcePicker`**
<img width="722" alt="core data source picker" src="https://github.com/grafana/grafana/assets/19530599/00a2a52e-22b7-40c3-8044-e9491a054956">

**Core Grafana `DataSourcePicker` with advanced picker opened**
<img width="1042" alt="core data source picker advanced" src="https://github.com/grafana/grafana/assets/19530599/1b54e824-d8a7-4592-bfd3-088c2abb58fd">

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
