### PR TITLE
Alerting: Fix queries and expressions in rule view details.

### DIFF
--- a/public/app/features/alerting/unified/GrafanaRuleQueryViewer.test.tsx
+++ b/public/app/features/alerting/unified/GrafanaRuleQueryViewer.test.tsx
@@ -1,0 +1,80 @@
+import { render } from '@testing-library/react';
+import { noop } from 'lodash';
+import React from 'react';
+
+import { DataSourceRef } from '@grafana/schema';
+import { AlertQuery } from 'app/types/unified-alerting-dto';
+
+import { GrafanaRuleQueryViewer } from './GrafanaRuleQueryViewer';
+
+describe('GrafanaRuleQueryViewer', () => {
+  it('renders without crashing', () => {
+    const getDataSourceQuery = (refId: string) => {
+      const query: AlertQuery = {
+        refId: refId,
+        datasourceUid: 'abc123',
+        queryType: '',
+        relativeTimeRange: {
+          from: 600,
+          to: 0,
+        },
+        model: {
+          refId: 'A',
+        },
+      };
+      return query;
+    };
+    const queries = [
+      getDataSourceQuery('A'),
+      getDataSourceQuery('B'),
+      getDataSourceQuery('C'),
+      getDataSourceQuery('D'),
+      getDataSourceQuery('E'),
+    ];
+
+    const getExpression = (refId: string, dsRef: DataSourceRef) => {
+      const expr = {
+        refId: refId,
+        datasourceUid: '__expr__',
+        queryType: '',
+        model: {
+          refId: refId,
+          type: 'classic_conditions',
+          datasource: dsRef,
+          conditions: [
+            {
+              type: 'query',
+              evaluator: {
+                params: [3],
+                type: 'gt',
+              },
+              operator: {
+                type: 'and',
+              },
+              query: {
+                params: ['A'],
+              },
+              reducer: {
+                params: [],
+                type: 'last',
+              },
+            },
+          ],
+        },
+      };
+      return expr;
+    };
+
+    const expressions = [
+      getExpression('A', { type: '' }),
+      getExpression('B', { type: '' }),
+      getExpression('C', { type: '' }),
+      getExpression('D', { type: '' }),
+    ];
+    const { getByTestId } = render(
+      <GrafanaRuleQueryViewer queries={[...queries, ...expressions]} condition="A" onTimeRangeChange={noop} />
+    );
+    expect(getByTestId('queries-container')).toHaveStyle('flex-wrap: wrap');
+    expect(getByTestId('expressions-container')).toHaveStyle('flex-wrap: wrap');
+  });
+});

--- a/public/app/features/alerting/unified/GrafanaRuleQueryViewer.tsx
+++ b/public/app/features/alerting/unified/GrafanaRuleQueryViewer.tsx
@@ -51,7 +51,7 @@ export function GrafanaRuleQueryViewer({
   return (
     <Stack gap={2} direction="column">
       <div className={styles.maxWidthContainer}>
-        <Stack gap={2} wrap="wrap">
+        <Stack gap={2} wrap="wrap" data-testid="queries-container">
           {dataQueries.map(({ model, relativeTimeRange, refId, datasourceUid }, index) => {
             const dataSource = dsByUid[datasourceUid];
 
@@ -73,7 +73,7 @@ export function GrafanaRuleQueryViewer({
         </Stack>
       </div>
       <div className={styles.maxWidthContainer}>
-        <Stack gap={1} wrap="wrap">
+        <Stack gap={1} wrap="wrap" data-testid="expressions-container">
           {expressions.map(({ model, refId, datasourceUid }, index) => {
             const dataSource = dsByUid[datasourceUid];
 

--- a/public/app/features/alerting/unified/GrafanaRuleQueryViewer.tsx
+++ b/public/app/features/alerting/unified/GrafanaRuleQueryViewer.tsx
@@ -5,7 +5,7 @@ import React from 'react';
 
 import { DataSourceInstanceSettings, GrafanaTheme2, PanelData, RelativeTimeRange } from '@grafana/data';
 import { config } from '@grafana/runtime';
-import { Badge, useStyles2, Stack } from '@grafana/ui';
+import { Badge, Stack, useStyles2 } from '@grafana/ui';
 import { mapRelativeTimeRangeToOption } from '@grafana/ui/src/components/DateTimePickers/RelativeTimeRangePicker/utils';
 
 import { AlertQuery } from '../../../types/unified-alerting-dto';
@@ -14,8 +14,8 @@ import {
   downsamplingTypes,
   ExpressionQuery,
   ExpressionQueryType,
-  reducerModes,
   ReducerMode,
+  reducerModes,
   reducerTypes,
   thresholdFunctions,
   upsamplingTypes,
@@ -51,7 +51,7 @@ export function GrafanaRuleQueryViewer({
   return (
     <Stack gap={2} direction="column">
       <div className={styles.maxWidthContainer}>
-        <Stack gap={2}>
+        <Stack gap={2} wrap="wrap">
           {dataQueries.map(({ model, relativeTimeRange, refId, datasourceUid }, index) => {
             const dataSource = dsByUid[datasourceUid];
 
@@ -73,7 +73,7 @@ export function GrafanaRuleQueryViewer({
         </Stack>
       </div>
       <div className={styles.maxWidthContainer}>
-        <Stack gap={1}>
+        <Stack gap={1} wrap="wrap">
           {expressions.map(({ model, refId, datasourceUid }, index) => {
             const dataSource = dsByUid[datasourceUid];
 


### PR DESCRIPTION
**What is this feature?**

This PR fixes queries and expressions not being shown in alert view page.

The bug was introduced in this [PR](https://github.com/grafana/grafana/pull/77543), where Stack component from  `@grafana/experimental` in favor of  `@grafana/ui`.

The recent update to the Stack component in `@grafana/ui` defaults to using `nowrap`. Consequently, some Stacks in our current view were automatically switched to nowrap, leading to the observed issue.

**Special notes for your reviewer:**

Before the change: (observe there is no D query)


https://github.com/grafana/grafana/assets/33540275/6da6e8f5-fc73-4519-882f-d2cce8be9dc2

After the change:


https://github.com/grafana/grafana/assets/33540275/5cd54378-9c6c-41b9-b7fe-87dbe643f922


Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
