### PR TITLE
Stat: Add Percent Change Option (refactor and color exploration) 

### DIFF
--- a/packages/grafana-ui/src/components/BigValue/BigValue.tsx
+++ b/packages/grafana-ui/src/components/BigValue/BigValue.tsx
@@ -86,7 +86,7 @@ export class BigValue extends PureComponent<Props> {
   };
 
   render() {
-    const { onClick, className, hasLinks, theme, textMode } = this.props;
+    const { onClick, className, hasLinks, theme } = this.props;
     const layout = buildLayout(this.props);
     const panelStyles = layout.getPanelStyles();
     const valueAndTitleContainerStyles = layout.getValueAndTitleContainerStyles();
@@ -94,7 +94,7 @@ export class BigValue extends PureComponent<Props> {
     const titleStyles = layout.getTitleStyles();
     const textValues = layout.textValues;
     const percentChange = this.props.value.percentChange;
-    const percentChangeStyles = layout.getValueStyles(true);
+    const showPercentChange = percentChange != null && !Number.isNaN(percentChange);
 
     // When there is an outer data link this tooltip will override the outer native tooltip
     const tooltip = hasLinks ? undefined : textValues.tooltip;
@@ -105,14 +105,9 @@ export class BigValue extends PureComponent<Props> {
           <div style={valueAndTitleContainerStyles}>
             {textValues.title && <div style={titleStyles}>{textValues.title}</div>}
             <FormattedValueDisplay value={textValues} style={valueStyles} />
-            <PercentChange
-              percentChange={percentChange}
-              percentChangeStyles={percentChangeStyles}
-              valueAndTitleContainerFlexDirection={valueAndTitleContainerStyles.flexDirection}
-              panelStyles={panelStyles}
-              valueFontSize={layout.valueFontSize}
-              textMode={textMode}
-            />
+            {showPercentChange && (
+              <PercentChange percentChange={percentChange} styles={layout.getPercentChangeStyles(percentChange)} />
+            )}
           </div>
           {layout.renderChart()}
         </div>

--- a/packages/grafana-ui/src/components/BigValue/BigValueLayout.tsx
+++ b/packages/grafana-ui/src/components/BigValue/BigValueLayout.tsx
@@ -74,11 +74,8 @@ export abstract class BigValueLayout {
   }
 
   getValueStyles(percentChange?: boolean): CSSProperties {
-    const valueFontSize = this.valueFontSize;
-    const fontSize = percentChange ? valueFontSize / 2 : valueFontSize;
-
     const styles: CSSProperties = {
-      fontSize: fontSize,
+      fontSize: this.valueFontSize,
       fontWeight: VALUE_FONT_WEIGHT,
       lineHeight: LINE_HEIGHT,
       position: 'relative',
@@ -103,6 +100,43 @@ export abstract class BigValueLayout {
     }
 
     return styles;
+  }
+
+  getPercentChangeStyles(percentChange: number): PercentChangeStyles {
+    const valueContainerStyles = this.getValueAndTitleContainerStyles();
+    const percentFontSize = Math.max(this.valueFontSize / 2.5, 12);
+
+    const containerStyles: CSSProperties = {
+      fontSize: percentFontSize,
+      fontWeight: VALUE_FONT_WEIGHT,
+      lineHeight: LINE_HEIGHT,
+      position: 'relative',
+      display: 'flex',
+      alignItems: 'center',
+      gap: Math.max(percentFontSize / 3, 4),
+      zIndex: 1,
+      color:
+        percentChange > 0
+          ? this.props.theme.visualization.getColorByName('green')
+          : this.props.theme.visualization.getColorByName('red'),
+    };
+
+    if (this.justifyCenter) {
+      containerStyles.textAlign = 'center';
+    }
+
+    if (valueContainerStyles.flexDirection === 'column') {
+      containerStyles.marginTop = -(percentFontSize / 4);
+    }
+
+    switch (this.props.colorMode) {
+      case BigValueColorMode.Background:
+      case BigValueColorMode.BackgroundSolid:
+        containerStyles.color = getTextColorForAlphaBackground(this.valueColor, this.props.theme.isDark);
+        break;
+    }
+
+    return { containerStyles, iconSize: Math.max(this.valueFontSize / 3, 10) };
   }
 
   getValueAndTitleContainerStyles() {
@@ -527,4 +561,9 @@ function getTextValues(props: Props): BigValueTextValues {
         valueToAlignTo,
       };
   }
+}
+
+export interface PercentChangeStyles {
+  containerStyles: CSSProperties;
+  iconSize: number;
 }

--- a/packages/grafana-ui/src/components/BigValue/BigValueLayout.tsx
+++ b/packages/grafana-ui/src/components/BigValue/BigValueLayout.tsx
@@ -1,7 +1,7 @@
 import React, { CSSProperties } from 'react';
 import tinycolor from 'tinycolor2';
 
-import { formattedValueToString, DisplayValue, FieldConfig, FieldType } from '@grafana/data';
+import { formattedValueToString, DisplayValue, FieldConfig, FieldType, colorManipulator } from '@grafana/data';
 import { GraphDrawStyle, GraphFieldConfig } from '@grafana/schema';
 
 import { getTextColorForAlphaBackground } from '../../utils';
@@ -105,6 +105,10 @@ export abstract class BigValueLayout {
   getPercentChangeStyles(percentChange: number): PercentChangeStyles {
     const valueContainerStyles = this.getValueAndTitleContainerStyles();
     const percentFontSize = Math.max(this.valueFontSize / 2.5, 12);
+    const color =
+      percentChange > 0
+        ? this.props.theme.visualization.getColorByName('green')
+        : this.props.theme.visualization.getColorByName('red');
 
     const containerStyles: CSSProperties = {
       fontSize: percentFontSize,
@@ -115,24 +119,37 @@ export abstract class BigValueLayout {
       alignItems: 'center',
       gap: Math.max(percentFontSize / 3, 4),
       zIndex: 1,
-      color:
-        percentChange > 0
-          ? this.props.theme.visualization.getColorByName('green')
-          : this.props.theme.visualization.getColorByName('red'),
+      color,
     };
 
     if (this.justifyCenter) {
       containerStyles.textAlign = 'center';
     }
 
-    if (valueContainerStyles.flexDirection === 'column') {
+    if (valueContainerStyles.flexDirection === 'column' && percentFontSize > 12) {
       containerStyles.marginTop = -(percentFontSize / 4);
+    }
+
+    // This layout mode needs more work
+    if (valueContainerStyles.flexDirection === 'row') {
+      containerStyles.alignItems = 'unset';
     }
 
     switch (this.props.colorMode) {
       case BigValueColorMode.Background:
       case BigValueColorMode.BackgroundSolid:
         containerStyles.color = getTextColorForAlphaBackground(this.valueColor, this.props.theme.isDark);
+
+        // Tried switching color based on contrast but was created too inconsistent results
+
+        //const contrast = colorManipulator.getContrastRatio(color, this.valueColor);
+        //if (contrast < 1.4) {
+        //  containerStyles.color = getTextColorForAlphaBackground(this.valueColor, this.props.theme.isDark);
+        //const shadowDim = Math.max(percentFontSize / 13, 1);
+        //containerStyles.textShadow = `${shadowDim}px ${shadowDim}px ${shadowDim}px black`;
+        // }
+        // console.log('contrast', contrast);
+
         break;
     }
 

--- a/packages/grafana-ui/src/components/BigValue/BigValueLayout.tsx
+++ b/packages/grafana-ui/src/components/BigValue/BigValueLayout.tsx
@@ -130,7 +130,7 @@ export abstract class BigValueLayout {
       containerStyles.marginTop = -(percentFontSize / 4);
     }
 
-    // This layout mode needs more work
+    // TODO: This layout mode needs more work (especially for horizontal layout)
     if (valueContainerStyles.flexDirection === 'row') {
       containerStyles.alignItems = 'unset';
     }
@@ -139,17 +139,6 @@ export abstract class BigValueLayout {
       case BigValueColorMode.Background:
       case BigValueColorMode.BackgroundSolid:
         containerStyles.color = getTextColorForAlphaBackground(this.valueColor, this.props.theme.isDark);
-
-        // Tried switching color based on contrast but was created too inconsistent results
-
-        //const contrast = colorManipulator.getContrastRatio(color, this.valueColor);
-        //if (contrast < 1.4) {
-        //  containerStyles.color = getTextColorForAlphaBackground(this.valueColor, this.props.theme.isDark);
-        //const shadowDim = Math.max(percentFontSize / 13, 1);
-        //containerStyles.textShadow = `${shadowDim}px ${shadowDim}px ${shadowDim}px black`;
-        // }
-        // console.log('contrast', contrast);
-
         break;
     }
 

--- a/packages/grafana-ui/src/components/BigValue/BigValueLayout.tsx
+++ b/packages/grafana-ui/src/components/BigValue/BigValueLayout.tsx
@@ -73,7 +73,7 @@ export abstract class BigValueLayout {
     return styles;
   }
 
-  getValueStyles(percentChange?: boolean): CSSProperties {
+  getValueStyles(): CSSProperties {
     const styles: CSSProperties = {
       fontSize: this.valueFontSize,
       fontWeight: VALUE_FONT_WEIGHT,

--- a/packages/grafana-ui/src/components/BigValue/PercentChange.tsx
+++ b/packages/grafana-ui/src/components/BigValue/PercentChange.tsx
@@ -15,21 +15,10 @@ export const PercentChange = ({ percentChange, styles }: Props) => {
   const percentChangeIcon =
     percentChange && (percentChange > 0 ? 'arrow-up' : percentChange < 0 ? 'arrow-down' : undefined);
 
-  // Add text shadow to percent change to make it more readable when background does not contrast well
-  //const shadowDim = metricHeight / 60;
-  //const shadowString = `${shadowDim}px ${shadowDim}px ${shadowDim}px black`;
-  //percentChangeStyles.textShadow = shadowString;
-
   return (
     <div style={styles.containerStyles}>
       {percentChangeIcon && (
-        <Icon
-          name={percentChangeIcon}
-          height={styles.iconSize}
-          width={styles.iconSize}
-          viewBox="6 6 12 12"
-          //filter={`drop-shadow(${shadowString})`}
-        />
+        <Icon name={percentChangeIcon} height={styles.iconSize} width={styles.iconSize} viewBox="6 6 12 12" />
       )}
       {percentChangeString}
     </div>

--- a/packages/grafana-ui/src/components/BigValue/PercentChange.tsx
+++ b/packages/grafana-ui/src/components/BigValue/PercentChange.tsx
@@ -1,70 +1,37 @@
 import React from 'react';
 
-import { BigValueTextMode } from '@grafana/schema';
-
 import { Icon } from '../Icon/Icon';
-import { HorizontalGroup } from '../Layout/Layout';
+
+import { PercentChangeStyles } from './BigValueLayout';
 
 export interface Props {
-  percentChange: number | undefined;
-  percentChangeStyles: React.CSSProperties;
-  panelStyles: React.CSSProperties;
-  valueAndTitleContainerFlexDirection: string | undefined;
-  valueFontSize: number;
-  textMode: BigValueTextMode | undefined;
+  percentChange: number;
+  styles: PercentChangeStyles;
 }
 
-export const PercentChange = ({
-  percentChange,
-  percentChangeStyles,
-  panelStyles,
-  valueAndTitleContainerFlexDirection,
-  valueFontSize,
-  textMode,
-}: Props) => {
+export const PercentChange = ({ percentChange, styles }: Props) => {
   const percentChangeString =
     percentChange?.toLocaleString(undefined, { style: 'percent', maximumSignificantDigits: 3 }) ?? '';
   const percentChangeIcon =
     percentChange && (percentChange > 0 ? 'arrow-up' : percentChange < 0 ? 'arrow-down' : undefined);
 
-  const metricHeight = valueFontSize;
-  const metricAlignment = panelStyles.flexDirection === 'row' ? 'center' : 'flex-start';
-  const iconDim = metricHeight / 2;
-
-  const percentChangeNaN = Number.isNaN(percentChange) || percentChange === undefined;
-  const showPercentChange = !percentChangeNaN && textMode !== BigValueTextMode.None;
-
-  if (showPercentChange && valueAndTitleContainerFlexDirection === 'column') {
-    percentChangeStyles.marginTop = -iconDim / 4;
-  }
-
-  if (percentChange && percentChange > 0) {
-    percentChangeStyles.color = '#73bf68';
-  } else if (percentChange && percentChange < 0) {
-    percentChangeStyles.color = '#f2485c';
-  }
-
   // Add text shadow to percent change to make it more readable when background does not contrast well
-  const shadowDim = metricHeight / 40;
-  const shadowString = `${shadowDim}px ${shadowDim}px ${shadowDim}px black`;
-  percentChangeStyles.textShadow = shadowString;
+  //const shadowDim = metricHeight / 60;
+  //const shadowString = `${shadowDim}px ${shadowDim}px ${shadowDim}px black`;
+  //percentChangeStyles.textShadow = shadowString;
 
   return (
-    showPercentChange && (
-      <div style={percentChangeStyles}>
-        <HorizontalGroup height={metricHeight} align={metricAlignment}>
-          {percentChangeIcon && (
-            <Icon
-              name={percentChangeIcon}
-              height={iconDim}
-              width={iconDim}
-              viewBox="6 6 12 12"
-              filter={`drop-shadow(${shadowString})`}
-            />
-          )}
-          {percentChangeString}
-        </HorizontalGroup>
-      </div>
-    )
+    <div style={styles.containerStyles}>
+      {percentChangeIcon && (
+        <Icon
+          name={percentChangeIcon}
+          height={styles.iconSize}
+          width={styles.iconSize}
+          viewBox="6 6 12 12"
+          //filter={`drop-shadow(${shadowString})`}
+        />
+      )}
+      {percentChangeString}
+    </div>
   );
 };


### PR DESCRIPTION
base: https://github.com/grafana/grafana/pull/78250 

I wanted to explore the coloring / shadow of the percent change and test a few things but ended up refactoring it a bit to help simplify the logic a bit (and have it less spread between the layout class and the PercentChange component). 

Did not really like the shadow that much (looks so inconsistent that only the percent change have shadow), think both need shadow if we are to add that. 

* Tried to make the coloring of the value be dependent on the background color option 
* Tried to calc contrast and have that control if we switch color (or enable shadow) 

Opted to disable the color for now when the background is colored and use the same white (or back) text that depends on the background color for percent change. Not ideal... but tricky. 

Other changes
* I do not think we textmode should control the percent change option, we should always show percent change if that is enabled. Text mode only controls value and text. Unnecessary to have it also control the percent change as this already has an option. And makes it possible to have panels with only value + percent change or only name + percent change, or only percent change etc (the test dashboard needs to be updated has a few panels that have percent change enabled that do not make sense).

Think the refactor is nice, but the color/shadow control might need more work. And I think the horizontal layout needs more work/rehink. The way it currently works it breaks the size / spacing calculation for the name and value:

![image](https://github.com/grafana/grafana/assets/10999/534228df-cb7f-4759-8c87-57e33db780df)
