### PR TITLE
Alerting: Display "Show all" button for cloud rules

### DIFF
--- a/public/app/features/alerting/unified/hooks/useCombinedRuleNamespaces.ts
+++ b/public/app/features/alerting/unified/hooks/useCombinedRuleNamespaces.ts
@@ -279,7 +279,7 @@ export function calculateRuleTotals(rule: Pick<AlertingRule, 'alerts' | 'totals'
     pending: result[AlertInstanceTotalState.Pending],
     inactive: result[AlertInstanceTotalState.Normal],
     nodata: result[AlertInstanceTotalState.NoData],
-    error: result[AlertInstanceTotalState.Error] + result['err'] || undefined, // Prometheus uses "err" instead of "error"
+    error: result[AlertInstanceTotalState.Error] || result['err'] || undefined, // Prometheus uses "err" instead of "error"
   };
 }
 

--- a/public/app/features/alerting/unified/hooks/useCombinedRuleNamespaces.ts
+++ b/public/app/features/alerting/unified/hooks/useCombinedRuleNamespaces.ts
@@ -275,11 +275,11 @@ export function calculateRuleTotals(rule: Pick<AlertingRule, 'alerts' | 'totals'
   }
 
   return {
-    alerting: result[AlertInstanceTotalState.Alerting],
+    alerting: result[AlertInstanceTotalState.Alerting] || result['firing'],
     pending: result[AlertInstanceTotalState.Pending],
     inactive: result[AlertInstanceTotalState.Normal],
     nodata: result[AlertInstanceTotalState.NoData],
-    error: result[AlertInstanceTotalState.Error] + result['err'], // Prometheus uses "err" instead of "error"
+    error: result[AlertInstanceTotalState.Error] + result['err'] || undefined, // Prometheus uses "err" instead of "error"
   };
 }
 


### PR DESCRIPTION
**What is this feature?**

Displays "Show all alert instances" button for cloud rules.

**Why do we need this feature?**

This button was only showing for Grafana rules but all of them were being limited to 15 which caused confusion among users.

**Who is this feature for?**

All users.

**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/support-escalations/issues/8648

![2023-12-14 10 13 46](https://github.com/grafana/grafana/assets/6271380/2c940af8-d587-43c5-bbd9-7840149e6438)
(note: in the recording I locally modified the limit to 0 to test the fix)