### PR TITLE
K8s: Update OpenAPI post processing structures

### DIFF
--- a/pkg/registry/apis/example/register.go
+++ b/pkg/registry/apis/example/register.go
@@ -103,7 +103,7 @@ func (b *TestingAPIBuilder) GetAPIRoutes() *grafanaapiserver.APIRoutes {
 	return &grafanaapiserver.APIRoutes{
 		Root: []grafanaapiserver.APIRouteHandler{
 			{
-				Path: "/aaa",
+				Path: "aaa",
 				Spec: &spec3.PathProps{
 					Summary:     "an example at the root level",
 					Description: "longer description here?",
@@ -144,7 +144,7 @@ func (b *TestingAPIBuilder) GetAPIRoutes() *grafanaapiserver.APIRoutes {
 				},
 			},
 			{
-				Path: "/bbb",
+				Path: "bbb",
 				Spec: &spec3.PathProps{
 					Summary:     "an example at the root level",
 					Description: "longer description here?",
@@ -165,7 +165,7 @@ func (b *TestingAPIBuilder) GetAPIRoutes() *grafanaapiserver.APIRoutes {
 		},
 		Namespace: []grafanaapiserver.APIRouteHandler{
 			{
-				Path: "/ccc",
+				Path: "ccc",
 				Spec: &spec3.PathProps{
 					Summary:     "an example at the root level",
 					Description: "longer description here?",

--- a/pkg/services/grafana-apiserver/request_handler.go
+++ b/pkg/services/grafana-apiserver/request_handler.go
@@ -8,6 +8,8 @@ import (
 	restclient "k8s.io/client-go/rest"
 	"k8s.io/kube-openapi/pkg/spec3"
 	"k8s.io/kube-openapi/pkg/validation/spec"
+
+	"github.com/grafana/grafana/pkg/setting"
 )
 
 type requestHandler struct {
@@ -132,8 +134,8 @@ func GetOpenAPIPostProcessor(builders []APIGroupBuilder) func(*spec3.OpenAPI) (*
 					Version: s.Version,
 					Info: &spec.Info{
 						InfoProps: spec.InfoProps{
-							Title:   gv.Group,
-							Version: gv.Version,
+							Title:   gv.String(),
+							Version: setting.BuildVersion,
 						},
 					},
 					Components:   s.Components,
@@ -153,7 +155,7 @@ func GetOpenAPIPostProcessor(builders []APIGroupBuilder) func(*spec3.OpenAPI) (*
 				}
 
 				for _, route := range routes.Namespace {
-					copy.Paths.Paths[prefix+"/namespaces/{namespace}"+route.Path] = &spec3.Path{
+					copy.Paths.Paths[prefix+"namespaces/{namespace}/"+route.Path] = &spec3.Path{
 						PathProps: *route.Spec,
 					}
 				}

--- a/pkg/services/grafana-apiserver/service.go
+++ b/pkg/services/grafana-apiserver/service.go
@@ -339,7 +339,7 @@ func (s *service) start(ctx context.Context) error {
 		// Call DefaultBuildHandlerChain on the main entrypoint http.Handler
 		// See https://github.com/kubernetes/apiserver/blob/v0.28.0/pkg/server/config.go#L906
 		// DefaultBuildHandlerChain provides many things, notably CORS, HSTS, cache-control, authz and latency tracking
-		requestHandler, err := getAPIHandler(
+		requestHandler, err := GetAPIHandler(
 			delegateHandler,
 			c.LoopbackClientConfig,
 			builders)


### PR DESCRIPTION
When we [bumped k8s to v0.29.0](https://github.com/grafana/grafana/pull/79492), the paths registered in the callback now have a trailing slash.  This broken our custom path support.  This PR updates the slash behavior so it works again.  The api once again looks like:

<img width="1440" alt="image" src="https://github.com/grafana/grafana/assets/705951/8ee74f16-448d-41fd-b7a6-d7bcfa5449ee">
