### PR TITLE
Pyroscope: Add query range to ProfileTypes API call

### DIFF
--- a/pkg/tsdb/grafana-pyroscope-datasource/pyroscopeClient.go
+++ b/pkg/tsdb/grafana-pyroscope-datasource/pyroscopeClient.go
@@ -70,10 +70,13 @@ func NewPyroscopeClient(httpClient *http.Client, url string) *PyroscopeClient {
 	}
 }
 
-func (c *PyroscopeClient) ProfileTypes(ctx context.Context) ([]*ProfileType, error) {
+func (c *PyroscopeClient) ProfileTypes(ctx context.Context, start int64, end int64) ([]*ProfileType, error) {
 	ctx, span := tracing.DefaultTracer().Start(ctx, "datasource.pyroscope.ProfileTypes")
 	defer span.End()
-	res, err := c.connectClient.ProfileTypes(ctx, connect.NewRequest(&querierv1.ProfileTypesRequest{}))
+	res, err := c.connectClient.ProfileTypes(ctx, connect.NewRequest(&querierv1.ProfileTypesRequest{
+		Start: start,
+		End:   end,
+	}))
 	if err != nil {
 		logger.Error("Received error from client", "error", err, "function", logEntrypoint())
 		span.RecordError(err)

--- a/pkg/tsdb/grafana-pyroscope-datasource/query_test.go
+++ b/pkg/tsdb/grafana-pyroscope-datasource/query_test.go
@@ -275,7 +275,7 @@ type FakeClient struct {
 	Args []any
 }
 
-func (f *FakeClient) ProfileTypes(ctx context.Context) ([]*ProfileType, error) {
+func (f *FakeClient) ProfileTypes(ctx context.Context, start int64, end int64) ([]*ProfileType, error) {
 	return []*ProfileType{
 		{
 			ID:    "type:1",

--- a/public/app/core/components/TraceToProfiles/TraceToProfilesSettings.tsx
+++ b/public/app/core/components/TraceToProfiles/TraceToProfilesSettings.tsx
@@ -55,7 +55,9 @@ export function TraceToProfilesSettings({ options, onOptionsChange }: Props) {
       supportedDataSourceTypes.includes(dataSource.type) &&
       dataSource.uid === options.jsonData.tracesToProfiles?.datasourceUid
     ) {
-      dataSource.getProfileTypes().then((profileTypes) => {
+      const end = Date.now();
+      const start = end - 24 * 60 * 60 * 1000; // 1 day ago
+      dataSource.getProfileTypes(start, end).then((profileTypes) => {
         setProfileTypes(profileTypes);
       });
     } else {

--- a/public/app/plugins/datasource/grafana-pyroscope-datasource/QueryEditor/ProfileTypesCascader.tsx
+++ b/public/app/plugins/datasource/grafana-pyroscope-datasource/QueryEditor/ProfileTypesCascader.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useMemo, useState } from 'react';
 
+import { TimeRange } from '@grafana/data';
 import { Cascader, CascaderOption } from '@grafana/ui';
 
 import { PyroscopeDataSource } from '../datasource';
@@ -70,16 +71,22 @@ function useCascaderOptions(profileTypes?: ProfileTypeMessage[]): CascaderOption
  * This is exported and not used directly in the ProfileTypesCascader component because in some case we need to know
  * the profileTypes before rendering the cascader.
  * @param datasource
+ * @param range
  */
-export function useProfileTypes(datasource: PyroscopeDataSource) {
+export function useProfileTypes(datasource: PyroscopeDataSource, range?: TimeRange) {
   const [profileTypes, setProfileTypes] = useState<ProfileTypeMessage[]>();
+
+  const impreciseRange = {
+    to: Math.ceil((range?.to.valueOf() || 0) / 60000) * 60000,
+    from: Math.floor((range?.from.valueOf() || 0) / 60000) * 60000,
+  };
 
   useEffect(() => {
     (async () => {
-      const profileTypes = await datasource.getProfileTypes();
+      const profileTypes = await datasource.getProfileTypes(impreciseRange.from.valueOf(), impreciseRange.to.valueOf());
       setProfileTypes(profileTypes);
     })();
-  }, [datasource]);
+  }, [datasource, impreciseRange.from, impreciseRange.to]);
 
   return profileTypes;
 }

--- a/public/app/plugins/datasource/grafana-pyroscope-datasource/QueryEditor/QueryEditor.tsx
+++ b/public/app/plugins/datasource/grafana-pyroscope-datasource/QueryEditor/QueryEditor.tsx
@@ -27,7 +27,7 @@ export function QueryEditor(props: Props) {
     onRunQuery();
   }
 
-  const profileTypes = useProfileTypes(datasource);
+  const profileTypes = useProfileTypes(datasource, range);
   const { labels, getLabelValues, onLabelSelectorChange } = useLabels(range, datasource, query, onChange);
   useNormalizeQuery(query, profileTypes, onChange, app);
 

--- a/public/app/plugins/datasource/grafana-pyroscope-datasource/VariableQueryEditor.tsx
+++ b/public/app/plugins/datasource/grafana-pyroscope-datasource/VariableQueryEditor.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from 'react';
 
-import { QueryEditorProps, SelectableValue } from '@grafana/data';
+import { QueryEditorProps, SelectableValue, TimeRange } from '@grafana/data';
 import { InlineField, InlineFieldRow, LoadingPlaceholder, Select } from '@grafana/ui';
 
 import { ProfileTypesCascader, useProfileTypes } from './QueryEditor/ProfileTypesCascader';
@@ -58,6 +58,7 @@ export function VariableQueryEditor(props: QueryEditorProps<PyroscopeDataSource,
       {(props.query.type === 'labelValue' || props.query.type === 'label') && (
         <ProfileTypeRow
           datasource={props.datasource}
+          range={props.range}
           initialValue={props.query.profileTypeId}
           onChange={(val) => {
             // To make TS happy
@@ -131,8 +132,9 @@ function ProfileTypeRow(props: {
   datasource: PyroscopeDataSource;
   onChange: (val: string) => void;
   initialValue?: string;
+  range?: TimeRange;
 }) {
-  const profileTypes = useProfileTypes(props.datasource);
+  const profileTypes = useProfileTypes(props.datasource, props.range);
   return (
     <InlineFieldRow>
       <InlineField

--- a/public/app/plugins/datasource/grafana-pyroscope-datasource/VariableSupport.ts
+++ b/public/app/plugins/datasource/grafana-pyroscope-datasource/VariableSupport.ts
@@ -9,7 +9,7 @@ import { PyroscopeDataSource } from './datasource';
 import { ProfileTypeMessage, VariableQuery } from './types';
 
 export interface DataAPI {
-  getProfileTypes(): Promise<ProfileTypeMessage[]>;
+  getProfileTypes(start: number, end: number): Promise<ProfileTypeMessage[]>;
   getLabelNames(query: string, start: number, end: number): Promise<string[]>;
   getLabelValues(query: string, label: string, start: number, end: number): Promise<string[]>;
 }
@@ -26,7 +26,9 @@ export class VariableSupport extends CustomVariableSupport<PyroscopeDataSource> 
 
   query(request: DataQueryRequest<VariableQuery>): Observable<DataQueryResponse> {
     if (request.targets[0].type === 'profileType') {
-      return from(this.dataAPI.getProfileTypes()).pipe(
+      return from(
+        this.dataAPI.getProfileTypes(this.timeSrv.timeRange().from.valueOf(), this.timeSrv.timeRange().to.valueOf())
+      ).pipe(
         map((values) => {
           return { data: values.map<MetricFindValue>((v) => ({ text: v.label, value: v.id })) };
         })

--- a/public/app/plugins/datasource/grafana-pyroscope-datasource/datasource.ts
+++ b/public/app/plugins/datasource/grafana-pyroscope-datasource/datasource.ts
@@ -48,8 +48,11 @@ export class PyroscopeDataSource extends DataSourceWithBackend<Query, PyroscopeD
     });
   }
 
-  async getProfileTypes(): Promise<ProfileTypeMessage[]> {
-    return await this.getResource('profileTypes');
+  async getProfileTypes(start: number, end: number): Promise<ProfileTypeMessage[]> {
+    return await this.getResource('profileTypes', {
+      start,
+      end,
+    });
   }
 
   async getLabelNames(query: string, start: number, end: number): Promise<string[]> {


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

This change makes the Pyroscope user experience more consistent by making sure the query interval is included in requests to fetch available profile types.

**Why do we need this feature?**

The feature solves 2 problems:
1. The user sees an accurate list of available profile types
2. The Pyroscope backend (querier) can improve the query execution knowing the interval

**Who is this feature for?**

Users of the Pyroscope datasource in Grafana.

**Special notes for your reviewer:**

See https://github.com/grafana/pyroscope/pull/2852 for a related Pyroscope change

Please check that:
- [x] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle.
- [x] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
