### PR TITLE
Auth: Fix flaky tests that are mocking time.Now() from SSO Settings

### DIFF
--- a/pkg/services/ssosettings/database/database.go
+++ b/pkg/services/ssosettings/database/database.go
@@ -17,11 +17,6 @@ type SSOSettingsStore struct {
 	log      log.Logger
 }
 
-var (
-	// timeNow makes it possible to test usage of time
-	timeNow = time.Now
-)
-
 func ProvideStore(sqlStore db.DB) *SSOSettingsStore {
 	return &SSOSettingsStore{
 		sqlStore: sqlStore,
@@ -87,7 +82,7 @@ func (s *SSOSettingsStore) Upsert(ctx context.Context, settings models.SSOSettin
 			return err
 		}
 
-		now := timeNow().UTC()
+		now := time.Now().UTC()
 
 		if found {
 			updated := &models.SSOSettings{
@@ -130,7 +125,7 @@ func (s *SSOSettingsStore) Delete(ctx context.Context, provider string) error {
 			return ssosettings.ErrNotFound
 		}
 
-		existing.Updated = timeNow().UTC()
+		existing.Updated = time.Now().UTC()
 		existing.IsDeleted = true
 
 		_, err = sess.ID(existing.ID).MustCols("updated", "is_deleted").Update(existing)


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

Change SSO database tests to use require.WithinDuration() for time values instead of mocking time.Now().

**Why do we need this feature?**

Fix flaky test.

**Who is this feature for?**

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
