### PR TITLE
remove bot/close feature request automation in light of new feature r…

### DIFF
--- a/.github/bot.md
+++ b/.github/bot.md
@@ -12,7 +12,6 @@ Label commands:
 * Add label `bot/question` the the bot will close with standard question message and add label `type/question`
 * Add label `bot/duplicate` the the bot will close with standard duplicate message and add label `type/duplicate`
 * Add label `bot/needs more info` for bot to request more info (or use comment command mentioned above)
-* Add label `bot/close feature request` for bot to close a feature request with standard message and adds label `not implemented`
 * Add label `bot/no new info` for bot to close an issue where we asked for more info but has not received any updates in at least 14 days.
 
 ## Metrics

--- a/.github/commands.json
+++ b/.github/commands.json
@@ -46,13 +46,6 @@
   },
   {
     "type":"label",
-    "name":"bot/close feature request",
-    "action":"close",
-    "addLabel":"not implemented",
-    "comment":"This feature request has been open for a long time with few received upvotes or comments, so we are closing it. We're trying to limit open GitHub issues in order to better track planned work and features.  \r\n\r\nThis doesn't mean that we'll never ever implement it or that we will never accept a PR for it. A closed issue can still attract upvotes and act as a ticket to track feature demand\/interest. \r\n\r\nThank You to you for taking the time to create this issue!"
-  },
-  {
-    "type":"label",
     "name":"area/plugins-catalog",
     "action":"addToProject",
     "addToProject":{


### PR DESCRIPTION
per @usmangt 

We also have a label bot/close feature request which auto close the issue. Here is an [example](https://github.com/grafana/grafana/issues/79576)

This was based on the old criteria. If possible, can you please update it to do the following:

* Remove the old label "not implemented"
* Rename the label  bot/close feature request to bot/feature request
* Add the right label i.e. type/feature-request
* Do not close the issue
* Edit the current message template to something e.g. Thanks for opening this issue. This sounds like a feature request.

We will forward this to our Engineers so that they can have a look and might be able to tell more details about it.
The advantage is that we can tell the user with a template msg that hey we got it and its a feature request and you have to wait. As currently we only select the right label type/feature-request but to acknowledge the user, have to write manually