### PR TITLE
chore: fix failing windows tests by enabling cgo

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -3775,6 +3775,8 @@ steps:
   name: wire-install
 - commands:
   - go test -tags requires_buildifer -short -covermode=atomic -timeout=5m ./pkg/...
+  environment:
+    CGO_ENABLED: 1
   depends_on:
   - wire-install
   image: golang:1.21.5-windowsservercore-1809


### PR DESCRIPTION
This (hopefully) fixes the backend tests failing on windows because sqlite3 requires CGO_ENABLED=1


sqlite3 issue: https://github.com/mattn/go-sqlite3/issues/327
example broken windows test: https://drone.grafana.net/grafana/grafana/151178/1/4


This test only runs on `promote` - how can I test this?  