### PR TITLE
K8s/WIP: Use connector for non-resource custom APIs

### DIFF
--- a/pkg/registry/apis/example/helloREST.go
+++ b/pkg/registry/apis/example/helloREST.go
@@ -1,0 +1,51 @@
+package example
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apiserver/pkg/registry/rest"
+
+	"github.com/grafana/grafana/pkg/infra/appcontext"
+)
+
+type helloREST struct {
+	txt string
+}
+
+var _ = rest.Connecter(&helloREST{})
+
+func (r *helloREST) New() runtime.Object {
+	return &metav1.Status{}
+}
+
+func (r *helloREST) Destroy() {
+}
+
+func (r *helloREST) ConnectMethods() []string {
+	return []string{"GET"}
+}
+
+func (r *helloREST) NewConnectOptions() (runtime.Object, bool, string) {
+	return nil, false, "" // true means you can use the trailing path as a variable
+}
+
+func (r *helloREST) Connect(ctx context.Context, name string, opts runtime.Object, responder rest.Responder) (http.Handler, error) {
+	user, err := appcontext.User(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+
+		if true {
+			responder.Error(fmt.Errorf("dooh"))
+			return
+		}
+
+		_, _ = w.Write([]byte(fmt.Sprintf("HELLO [%s]: %s", r.txt, user.Login)))
+	}), nil
+}

--- a/pkg/services/grafana-apiserver/common.go
+++ b/pkg/services/grafana-apiserver/common.go
@@ -1,12 +1,11 @@
 package grafanaapiserver
 
 import (
-	"net/http"
-
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/runtime/serializer"
 	"k8s.io/apiserver/pkg/registry/generic"
+	"k8s.io/apiserver/pkg/registry/rest"
 	genericapiserver "k8s.io/apiserver/pkg/server"
 	"k8s.io/kube-openapi/pkg/common"
 	"k8s.io/kube-openapi/pkg/spec3"
@@ -37,9 +36,9 @@ type APIGroupBuilder interface {
 
 // This is used to implement dynamic sub-resources like pods/x/logs
 type APIRouteHandler struct {
-	Path    string           // added to the appropriate level
-	Spec    *spec3.PathProps // Exposed in the open api service discovery
-	Handler http.HandlerFunc // when Level = resource, the resource will be available in context
+	Path      string           // added to the appropriate level
+	Spec      *spec3.PathProps // Exposed in the open api service discovery
+	Connector rest.Connecter   // NOTE this is not passed a name!
 }
 
 // APIRoutes define explicit HTTP handlers in an apiserver


### PR DESCRIPTION
We currently have a method to implement raw responses for non-resource endpoints.

That is great because it allows *anything*, but sucks because you don't have access to any of the standard helper functions to write objects and errors.

This PR explores how we could wrap the non-resource values