### PR TITLE
Alerting:fix silences removing labels pressing enter 5

### DIFF
--- a/public/app/features/alerting/unified/components/silences/MatchersField.tsx
+++ b/public/app/features/alerting/unified/components/silences/MatchersField.tsx
@@ -81,6 +81,7 @@ const MatchersField = ({ className }: Props) => {
                       tooltip="Remove matcher"
                       name={'trash-alt'}
                       onClick={() => remove(index)}
+                      type="button"
                     >
                       Remove
                     </IconButton>


### PR DESCRIPTION
This backport fixes alert labels being removed when user press enter in duration input in the Silence form.