### PR TITLE
Loki: Fix language provider's `start` method won't fetch labels with changed timerange

### DIFF
--- a/public/app/plugins/datasource/loki/LanguageProvider.test.ts
+++ b/public/app/plugins/datasource/loki/LanguageProvider.test.ts
@@ -32,19 +32,50 @@ const mockTimeRange = {
     to: dateTime(1546380000000),
   },
 };
+
+const defaultTimeRange = {
+  from: dateTime(0),
+  to: dateTime(1),
+  raw: {
+    from: dateTime(0),
+    to: dateTime(1),
+  },
+};
 jest.mock('@grafana/data', () => ({
   ...jest.requireActual('@grafana/data'),
-  getDefaultTimeRange: jest.fn().mockReturnValue({
-    from: 0,
-    to: 1,
-    raw: {
-      from: 0,
-      to: 1,
-    },
-  }),
+  getDefaultTimeRange: jest.fn().mockImplementation(() => defaultTimeRange),
 }));
 
 describe('Language completion provider', () => {
+  describe('start', () => {
+    const datasource = setup({ testkey: ['label1_val1', 'label1_val2'], label2: [] });
+
+    it('should fetch labels on initial start', async () => {
+      const languageProvider = new LanguageProvider(datasource);
+      const fetchSpy = jest.spyOn(languageProvider, 'fetchLabels').mockResolvedValue([]);
+      await languageProvider.start();
+      expect(fetchSpy).toHaveBeenCalled();
+    });
+
+    it('should not again fetch labels on second start', async () => {
+      const languageProvider = new LanguageProvider(datasource);
+      const fetchSpy = jest.spyOn(languageProvider, 'fetchLabels').mockResolvedValue([]);
+      await languageProvider.start();
+      expect(fetchSpy).toHaveBeenCalledTimes(1);
+      await languageProvider.start();
+      expect(fetchSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it('should again fetch labels on second start with different timerange', async () => {
+      const languageProvider = new LanguageProvider(datasource);
+      const fetchSpy = jest.spyOn(languageProvider, 'fetchLabels').mockResolvedValue([]);
+      await languageProvider.start();
+      expect(fetchSpy).toHaveBeenCalledTimes(1);
+      await languageProvider.start(mockTimeRange);
+      expect(fetchSpy).toHaveBeenCalledTimes(2);
+    });
+  });
+
   describe('fetchSeries', () => {
     it('should use match[] parameter', () => {
       const datasource = setup({}, { '{foo="bar"}': [{ label1: 'label_val1' }] });
@@ -407,11 +438,7 @@ describe('Query imports', () => {
           maxLines: DEFAULT_MAX_LINES_SAMPLE,
           refId: 'data-samples',
         },
-        // mocked default time range
-        expect.objectContaining({
-          from: 0,
-          to: 1,
-        })
+        defaultTimeRange
       );
     });
 
@@ -432,11 +459,7 @@ describe('Query imports', () => {
           maxLines: 5,
           refId: 'data-samples',
         },
-        // mocked default time range
-        expect.objectContaining({
-          from: 0,
-          to: 1,
-        })
+        defaultTimeRange
       );
     });
 

--- a/public/app/plugins/datasource/loki/LanguageProvider.ts
+++ b/public/app/plugins/datasource/loki/LanguageProvider.ts
@@ -18,6 +18,7 @@ const NS_IN_MS = 1000000;
 export default class LokiLanguageProvider extends LanguageProvider {
   labelKeys: string[];
   started = false;
+  startedTimeRange?: TimeRange;
   datasource: LokiDatasource;
 
   /**
@@ -52,7 +53,13 @@ export default class LokiLanguageProvider extends LanguageProvider {
    */
   start = (timeRange?: TimeRange) => {
     const range = timeRange ?? this.getDefaultTimeRange();
-    if (!this.startTask) {
+    // refetch labels if either there's not already a start task or the time range has changed
+    if (
+      !this.startTask ||
+      this.startedTimeRange?.from.isSame(range.from) === false ||
+      this.startedTimeRange?.to.isSame(range.to) === false
+    ) {
+      this.startedTimeRange = range;
       this.startTask = this.fetchLabels({ timeRange: range }).then(() => {
         this.started = true;
         return [];


### PR DESCRIPTION
**What is this feature?**

The LanguageProvider in the Loki datasource only fetches new labels in the `start` method if there's not a `startTask`. With https://github.com/grafana/grafana/pull/78450 the `start` method now also accepts a `timeRange` parameter. This PR fixes a bug where the `start` method should also fetch new labels if the given `timeRange` parameter changed.