### PR TITLE
Chore: Update node version for bump-version workflow

### DIFF
--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -61,7 +61,7 @@ jobs:
           go-version: '1.20'
       - uses: actions/setup-node@v4
         with:
-          node-version: '16'
+          node-version: '18'
       - name: Install Actions
         run: npm install --production --prefix ./actions
       - name: "Generate token"


### PR DESCRIPTION
Since the `Yarn 4` update, this workflow now requires a minimum Node version of 18