### PR TITLE
Authn: Handle logout logic in auth broker

### DIFF
--- a/pkg/api/login.go
+++ b/pkg/api/login.go
@@ -243,70 +243,31 @@ func (hs *HTTPServer) loginUserWithUser(user *user.User, c *contextmodel.ReqCont
 }
 
 func (hs *HTTPServer) Logout(c *contextmodel.ReqContext) {
-	userID, errID := identity.UserIdentifier(c.SignedInUser.GetNamespacedID())
-	if errID != nil {
-		hs.log.Error("failed to retrieve user ID", "error", errID)
-	}
-
-	oauthProviderSignoutRedirectUrl := ""
-	getAuthQuery := loginservice.GetAuthInfoQuery{UserId: userID}
-	authInfo, err := hs.authInfoService.GetAuthInfo(c.Req.Context(), &getAuthQuery)
-	if err == nil {
-		// If SAML is enabled and this is a SAML user use saml logout
-		if hs.samlSingleLogoutEnabled() {
-			if authInfo.AuthModule == loginservice.SAMLAuthModule {
-				c.Redirect(hs.Cfg.AppSubURL + "/logout/saml")
-				return
-			}
+	// FIXME: restructure saml client to implement authn.LogoutClient
+	if hs.samlSingleLogoutEnabled() {
+		id, err := identity.UserIdentifier(c.SignedInUser.GetNamespacedID())
+		if err != nil {
+			hs.log.Error("failed to retrieve user ID", "error", err)
 		}
-		oauthProvider := hs.SocialService.GetOAuthInfoProvider(strings.TrimPrefix(authInfo.AuthModule, "oauth_"))
-		if oauthProvider != nil {
-			oauthProviderSignoutRedirectUrl = oauthProvider.SignoutRedirectUrl
+
+		authInfo, _ := hs.authInfoService.GetAuthInfo(c.Req.Context(), &loginservice.GetAuthInfoQuery{UserId: id})
+		if authInfo != nil && authInfo.AuthModule == loginservice.SAMLAuthModule {
+			c.Redirect(hs.Cfg.AppSubURL + "/logout/saml")
+			return
 		}
 	}
 
-	hs.log.Debug("Logout Redirect url", "auth.SignoutRedirectUrl:", hs.Cfg.SignoutRedirectUrl)
-	hs.log.Debug("Logout Redirect url", "oauth provider redirect url:", oauthProviderSignoutRedirectUrl)
-
-	signOutRedirectUrl := getSignOutRedirectUrl(hs.Cfg.SignoutRedirectUrl, oauthProviderSignoutRedirectUrl)
-
-	hs.log.Debug("Logout Redirect url", "signOurRedirectUrl:", signOutRedirectUrl)
-	idTokenHint := ""
-	oidcLogout := isPostLogoutRedirectConfigured(signOutRedirectUrl)
-
-	// Invalidate the OAuth tokens in case the User logged in with OAuth or the last external AuthEntry is an OAuth one
-	if entry, exists, _ := hs.oauthTokenService.HasOAuthEntry(c.Req.Context(), c.SignedInUser); exists {
-		token := hs.oauthTokenService.GetCurrentOAuthToken(c.Req.Context(), c.SignedInUser)
-		if oidcLogout {
-			if token.Valid() {
-				idTokenHint = token.Extra("id_token").(string)
-			} else {
-				hs.log.Warn("Token is not valid")
-			}
-		}
-
-		if err := hs.oauthTokenService.InvalidateOAuthTokens(c.Req.Context(), entry); err != nil {
-			hs.log.Warn("failed to invalidate oauth tokens for user", "userId", userID, "error", err)
-		}
-	}
-
-	err = hs.AuthTokenService.RevokeToken(c.Req.Context(), c.UserToken, false)
-	if err != nil && !errors.Is(err, auth.ErrUserTokenNotFound) {
-		hs.log.Error("failed to revoke auth token", "error", err)
-	}
-
+	redirect, err := hs.authnService.Logout(c.Req.Context(), c.SignedInUser, c.UserToken)
 	authn.DeleteSessionCookie(c.Resp, hs.Cfg)
 
-	rdUrl := signOutRedirectUrl
-	if rdUrl != "" {
-		if oidcLogout {
-			rdUrl = getPostRedirectUrl(signOutRedirectUrl, idTokenHint)
-		}
-		c.Redirect(rdUrl)
-	} else {
-		hs.log.Info("Successful Logout", "User", c.SignedInUser.GetEmail())
+	if err != nil {
+		hs.log.Error("Failed perform proper logout", "error", err)
 		c.Redirect(hs.Cfg.AppSubURL + "/login")
 	}
+
+	_, id := c.SignedInUser.GetNamespacedID()
+	hs.log.Info("Successful Logout", "userID", id)
+	c.Redirect(redirect.URL)
 }
 
 func (hs *HTTPServer) tryGetEncryptedCookie(ctx *contextmodel.ReqContext, cookieName string) (string, bool) {
@@ -419,48 +380,4 @@ func getFirstPublicErrorMessage(err *errutil.Error) string {
 	}
 
 	return errPublic.Message
-}
-
-func isPostLogoutRedirectConfigured(redirectUrl string) bool {
-	if redirectUrl == "" {
-		return false
-	}
-
-	u, err := url.Parse(redirectUrl)
-	if err != nil {
-		return false
-	}
-
-	q := u.Query()
-	_, ok := q[postLogoutRedirectParam]
-	return ok
-}
-
-func getPostRedirectUrl(rdUrl string, tokenHint string) string {
-	if tokenHint == "" {
-		return rdUrl
-	}
-	if rdUrl == "" {
-		return rdUrl
-	}
-
-	u, err := url.Parse(rdUrl)
-	if err != nil {
-		return rdUrl
-	}
-
-	q := u.Query()
-	q.Set("id_token_hint", tokenHint)
-	u.RawQuery = q.Encode()
-
-	return u.String()
-}
-
-func getSignOutRedirectUrl(gRdUrl string, oauthProviderUrl string) string {
-	if oauthProviderUrl != "" {
-		return oauthProviderUrl
-	} else if gRdUrl != "" {
-		return gRdUrl
-	}
-	return ""
 }

--- a/pkg/api/login.go
+++ b/pkg/api/login.go
@@ -29,8 +29,6 @@ import (
 const (
 	viewIndex            = "index"
 	loginErrorCookieName = "login_error"
-	// #nosec G101 - this is not a hardcoded secret
-	postLogoutRedirectParam = "post_logout_redirect_uri"
 )
 
 var setIndexViewData = (*HTTPServer).setIndexViewData

--- a/pkg/services/authn/authn.go
+++ b/pkg/services/authn/authn.go
@@ -75,7 +75,7 @@ type Service interface {
 	RegisterPostLoginHook(hook PostLoginHookFn, priority uint)
 	// RedirectURL will generate url that we can use to initiate auth flow for supported clients.
 	RedirectURL(ctx context.Context, client string, r *Request) (*Redirect, error)
-	// Logout revokes session token and do additional clean up if client used to authenticate suppoerts it
+	// Logout revokes session token and does additional clean up if client used to authenticate supports it
 	Logout(ctx context.Context, user identity.Requester, sessionToken *usertoken.UserToken) (*Redirect, error)
 	// RegisterClient will register a new authn.Client that can be used for authentication
 	RegisterClient(c Client)

--- a/pkg/services/authn/authn.go
+++ b/pkg/services/authn/authn.go
@@ -11,6 +11,7 @@ import (
 	"github.com/grafana/grafana/pkg/api/response"
 	"github.com/grafana/grafana/pkg/middleware/cookies"
 	"github.com/grafana/grafana/pkg/models/usertoken"
+	"github.com/grafana/grafana/pkg/services/auth/identity"
 	"github.com/grafana/grafana/pkg/services/login"
 	"github.com/grafana/grafana/pkg/setting"
 	"github.com/grafana/grafana/pkg/web"
@@ -74,6 +75,8 @@ type Service interface {
 	RegisterPostLoginHook(hook PostLoginHookFn, priority uint)
 	// RedirectURL will generate url that we can use to initiate auth flow for supported clients.
 	RedirectURL(ctx context.Context, client string, r *Request) (*Redirect, error)
+	// Logout revokes session token and do additonal clean up if client used to authenticate suppoerts it
+	Logout(ctx context.Context, user identity.Requester, sessionToken *usertoken.UserToken) (*Redirect, error)
 	// RegisterClient will register a new authn.Client that can be used for authentication
 	RegisterClient(c Client)
 }
@@ -113,6 +116,14 @@ type HookClient interface {
 type RedirectClient interface {
 	Client
 	RedirectURL(ctx context.Context, r *Request) (*Redirect, error)
+}
+
+// LogoutCLient is and optional interface that auth client can implement.
+// Clients that implements this interface can implement additonal logic
+// that should happen during logout and supports client specific redirect URL.
+type LogoutClient interface {
+	Client
+	Logout(ctx context.Context, user identity.Requester, info *login.UserAuth) (*Redirect, bool)
 }
 
 type PasswordClient interface {

--- a/pkg/services/authn/authn.go
+++ b/pkg/services/authn/authn.go
@@ -75,7 +75,7 @@ type Service interface {
 	RegisterPostLoginHook(hook PostLoginHookFn, priority uint)
 	// RedirectURL will generate url that we can use to initiate auth flow for supported clients.
 	RedirectURL(ctx context.Context, client string, r *Request) (*Redirect, error)
-	// Logout revokes session token and do additonal clean up if client used to authenticate suppoerts it
+	// Logout revokes session token and do additional clean up if client used to authenticate suppoerts it
 	Logout(ctx context.Context, user identity.Requester, sessionToken *usertoken.UserToken) (*Redirect, error)
 	// RegisterClient will register a new authn.Client that can be used for authentication
 	RegisterClient(c Client)
@@ -119,7 +119,7 @@ type RedirectClient interface {
 }
 
 // LogoutCLient is and optional interface that auth client can implement.
-// Clients that implements this interface can implement additonal logic
+// Clients that implements this interface can implement additional logic
 // that should happen during logout and supports client specific redirect URL.
 type LogoutClient interface {
 	Client

--- a/pkg/services/authn/authn.go
+++ b/pkg/services/authn/authn.go
@@ -118,7 +118,7 @@ type RedirectClient interface {
 	RedirectURL(ctx context.Context, r *Request) (*Redirect, error)
 }
 
-// LogoutCLient is and optional interface that auth client can implement.
+// LogoutCLient is an optional interface that auth client can implement.
 // Clients that implements this interface can implement additional logic
 // that should happen during logout and supports client specific redirect URL.
 type LogoutClient interface {

--- a/pkg/services/authn/authnimpl/service.go
+++ b/pkg/services/authn/authnimpl/service.go
@@ -344,6 +344,9 @@ func (s *Service) RedirectURL(ctx context.Context, client string, r *authn.Reque
 }
 
 func (s *Service) Logout(ctx context.Context, user identity.Requester, sessionToken *auth.UserToken) (*authn.Redirect, error) {
+	ctx, span := s.tracer.Start(ctx, "authn.Logout")
+	defer span.End()
+
 	redirect := &authn.Redirect{URL: s.cfg.AppSubURL + "/login"}
 
 	namespace, id := user.GetNamespacedID()

--- a/pkg/services/authn/authnimpl/service.go
+++ b/pkg/services/authn/authnimpl/service.go
@@ -359,9 +359,7 @@ func (s *Service) Logout(ctx context.Context, user identity.Requester, sessionTo
 
 	info, _ := s.authInfoService.GetAuthInfo(ctx, &login.GetAuthInfoQuery{UserId: userID})
 	if info != nil {
-		println(info.AuthModule)
 		client := authn.ClientWithPrefix(strings.TrimPrefix(info.AuthModule, "oauth_"))
-		println(client)
 
 		c, ok := s.clients[client]
 		if !ok {

--- a/pkg/services/authn/authnimpl/service_test.go
+++ b/pkg/services/authn/authnimpl/service_test.go
@@ -13,10 +13,14 @@ import (
 
 	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/infra/tracing"
+	"github.com/grafana/grafana/pkg/models/usertoken"
 	"github.com/grafana/grafana/pkg/services/auth"
 	"github.com/grafana/grafana/pkg/services/auth/authtest"
+	"github.com/grafana/grafana/pkg/services/auth/identity"
 	"github.com/grafana/grafana/pkg/services/authn"
 	"github.com/grafana/grafana/pkg/services/authn/authntest"
+	"github.com/grafana/grafana/pkg/services/login"
+	"github.com/grafana/grafana/pkg/services/login/authinfotest"
 	"github.com/grafana/grafana/pkg/services/user"
 	"github.com/grafana/grafana/pkg/setting"
 )
@@ -295,6 +299,96 @@ func TestService_RedirectURL(t *testing.T) {
 
 			_, err := service.RedirectURL(context.Background(), tt.client, nil)
 			assert.ErrorIs(t, err, tt.expectedErr)
+		})
+	}
+}
+
+func TestService_Logout(t *testing.T) {
+	type TestCase struct {
+		desc string
+
+		identity     *authn.Identity
+		sessionToken *usertoken.UserToken
+		info         *login.UserAuth
+
+		client authn.Client
+
+		expectedErr          error
+		expectedTokenRevoked bool
+		expectedRedirect     *authn.Redirect
+	}
+
+	tests := []TestCase{
+		{
+			desc:             "should redirect to default redirect url when identity is not a user",
+			identity:         &authn.Identity{ID: authn.NamespacedID(authn.NamespaceServiceAccount, 1)},
+			expectedRedirect: &authn.Redirect{URL: "http://localhost:3000/login"},
+		},
+		{
+			desc:                 "should redirect to default redirect url when no external provider was used to authenticate",
+			identity:             &authn.Identity{ID: authn.NamespacedID(authn.NamespaceUser, 1)},
+			expectedRedirect:     &authn.Redirect{URL: "http://localhost:3000/login"},
+			expectedTokenRevoked: true,
+		},
+		{
+			desc:                 "should redirect to default redirect url when client is not found",
+			identity:             &authn.Identity{ID: authn.NamespacedID(authn.NamespaceUser, 1)},
+			info:                 &login.UserAuth{AuthModule: "notFound"},
+			expectedRedirect:     &authn.Redirect{URL: "http://localhost:3000/login"},
+			expectedTokenRevoked: true,
+		},
+		{
+			desc:                 "should redirect to default redirect url when client do not implement logout extension",
+			identity:             &authn.Identity{ID: authn.NamespacedID(authn.NamespaceUser, 1)},
+			info:                 &login.UserAuth{AuthModule: "azuread"},
+			expectedRedirect:     &authn.Redirect{URL: "http://localhost:3000/login"},
+			client:               &authntest.FakeClient{ExpectedName: "auth.client.azuread"},
+			expectedTokenRevoked: true,
+		},
+		{
+			desc:             "should redirect to client specific url",
+			identity:         &authn.Identity{ID: authn.NamespacedID(authn.NamespaceUser, 1)},
+			info:             &login.UserAuth{AuthModule: "azuread"},
+			expectedRedirect: &authn.Redirect{URL: "http://idp.com/logout"},
+			client: &authntest.MockClient{
+				NameFunc: func() string { return "auth.client.azuread" },
+				LogoutFunc: func(ctx context.Context, _ identity.Requester, _ *login.UserAuth) (*authn.Redirect, bool) {
+					return &authn.Redirect{URL: "http://idp.com/logout"}, true
+				},
+			},
+			expectedTokenRevoked: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			var tokenRevoked bool
+
+			s := setupTests(t, func(svc *Service) {
+				if tt.client != nil {
+					svc.RegisterClient(tt.client)
+				}
+				svc.cfg.AppSubURL = "http://localhost:3000"
+				svc.authInfoService = &authinfotest.FakeService{
+					ExpectedUserAuth: tt.info,
+				}
+
+				svc.sessionService = &authtest.FakeUserAuthTokenService{
+					RevokeTokenProvider: func(_ context.Context, sessionToken *auth.UserToken, soft bool) error {
+						tokenRevoked = true
+						assert.EqualValues(t, tt.sessionToken, sessionToken)
+						assert.False(t, soft)
+						return nil
+					},
+				}
+
+			})
+
+			redirect, err := s.Logout(context.Background(), tt.identity, tt.sessionToken)
+
+			assert.ErrorIs(t, err, tt.expectedErr)
+			assert.EqualValues(t, tt.expectedRedirect, redirect)
+			assert.Equal(t, tt.expectedTokenRevoked, tokenRevoked)
 		})
 	}
 }

--- a/pkg/services/authn/authnimpl/service_test.go
+++ b/pkg/services/authn/authnimpl/service_test.go
@@ -381,7 +381,6 @@ func TestService_Logout(t *testing.T) {
 						return nil
 					},
 				}
-
 			})
 
 			redirect, err := s.Logout(context.Background(), tt.identity, tt.sessionToken)

--- a/pkg/services/authn/authntest/fake.go
+++ b/pkg/services/authn/authntest/fake.go
@@ -3,6 +3,8 @@ package authntest
 import (
 	"context"
 
+	"github.com/grafana/grafana/pkg/models/usertoken"
+	"github.com/grafana/grafana/pkg/services/auth/identity"
 	"github.com/grafana/grafana/pkg/services/authn"
 )
 
@@ -64,6 +66,10 @@ func (f *FakeService) RegisterPostLoginHook(hook authn.PostLoginHookFn, priority
 
 func (f *FakeService) RedirectURL(ctx context.Context, client string, r *authn.Request) (*authn.Redirect, error) {
 	return f.ExpectedRedirect, f.ExpectedErr
+}
+
+func (*FakeService) Logout(_ context.Context, _ identity.Requester, _ *usertoken.UserToken) (*authn.Redirect, error) {
+	panic("unimplemented")
 }
 
 func (f *FakeService) RegisterClient(c authn.Client) {}

--- a/pkg/services/authn/authntest/mock.go
+++ b/pkg/services/authn/authntest/mock.go
@@ -6,6 +6,7 @@ import (
 	"github.com/grafana/grafana/pkg/models/usertoken"
 	"github.com/grafana/grafana/pkg/services/auth/identity"
 	"github.com/grafana/grafana/pkg/services/authn"
+	"github.com/grafana/grafana/pkg/services/login"
 )
 
 var _ authn.Service = new(MockService)
@@ -54,6 +55,7 @@ func (m *MockService) SyncIdentity(ctx context.Context, identity *authn.Identity
 }
 
 var _ authn.HookClient = new(MockClient)
+var _ authn.LogoutClient = new(MockClient)
 var _ authn.ContextAwareClient = new(MockClient)
 
 type MockClient struct {
@@ -62,6 +64,7 @@ type MockClient struct {
 	TestFunc         func(ctx context.Context, r *authn.Request) bool
 	PriorityFunc     func() uint
 	HookFunc         func(ctx context.Context, identity *authn.Identity, r *authn.Request) error
+	LogoutFunc       func(ctx context.Context, user identity.Requester, info *login.UserAuth) (*authn.Redirect, bool)
 }
 
 func (m MockClient) Name() string {
@@ -97,6 +100,13 @@ func (m MockClient) Hook(ctx context.Context, identity *authn.Identity, r *authn
 		return m.HookFunc(ctx, identity, r)
 	}
 	return nil
+}
+
+func (m *MockClient) Logout(ctx context.Context, user identity.Requester, info *login.UserAuth) (*authn.Redirect, bool) {
+	if m.LogoutFunc != nil {
+		return m.LogoutFunc(ctx, user, info)
+	}
+	return nil, false
 }
 
 var _ authn.ProxyClient = new(MockProxyClient)

--- a/pkg/services/authn/authntest/mock.go
+++ b/pkg/services/authn/authntest/mock.go
@@ -3,6 +3,8 @@ package authntest
 import (
 	"context"
 
+	"github.com/grafana/grafana/pkg/models/usertoken"
+	"github.com/grafana/grafana/pkg/services/auth/identity"
 	"github.com/grafana/grafana/pkg/services/authn"
 )
 
@@ -37,6 +39,10 @@ func (m *MockService) RegisterPostAuthHook(hook authn.PostAuthHookFn, priority u
 }
 
 func (m *MockService) RegisterPostLoginHook(hook authn.PostLoginHookFn, priority uint) {
+	panic("unimplemented")
+}
+
+func (*MockService) Logout(_ context.Context, _ identity.Requester, _ *usertoken.UserToken) (*authn.Redirect, error) {
 	panic("unimplemented")
 }
 

--- a/pkg/services/authn/clients/oauth.go
+++ b/pkg/services/authn/clients/oauth.go
@@ -225,7 +225,9 @@ func (c *OAuth) Logout(ctx context.Context, user identity.Requester, info *login
 	}
 
 	if isOICDLogout(redirctURL) && token != nil && token.Valid() {
-		redirctURL = withIDTokenHint(redirctURL, token.Extra("id_token").(string))
+		if idToken, ok := token.Extra("id_token").(string); ok {
+			redirctURL = withIDTokenHint(redirctURL, idToken)
+		}
 	}
 
 	return &authn.Redirect{URL: redirctURL}, true

--- a/pkg/services/authn/clients/oauth.go
+++ b/pkg/services/authn/clients/oauth.go
@@ -296,7 +296,6 @@ func withIDTokenHint(redirectURL string, idToken string) string {
 	u.RawQuery = q.Encode()
 
 	return u.String()
-
 }
 
 func isOICDLogout(redirectUrl string) bool {

--- a/pkg/services/authn/clients/oauth.go
+++ b/pkg/services/authn/clients/oauth.go
@@ -9,6 +9,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"net/url"
 	"strings"
 
 	"golang.org/x/oauth2"
@@ -16,8 +17,10 @@ import (
 	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/login/social"
 	"github.com/grafana/grafana/pkg/login/social/connectors"
+	"github.com/grafana/grafana/pkg/services/auth/identity"
 	"github.com/grafana/grafana/pkg/services/authn"
 	"github.com/grafana/grafana/pkg/services/login"
+	"github.com/grafana/grafana/pkg/services/oauthtoken"
 	"github.com/grafana/grafana/pkg/services/org"
 	"github.com/grafana/grafana/pkg/setting"
 	"github.com/grafana/grafana/pkg/util/errutil"
@@ -30,9 +33,10 @@ const (
 	codeChallengeMethodParamName = "code_challenge_method"
 	codeChallengeMethod          = "S256"
 
-	oauthStateQueryName  = "state"
-	oauthStateCookieName = "oauth_state"
-	oauthPKCECookieName  = "oauth_code_verifier"
+	oauthStateQueryName          = "state"
+	oauthStateCookieName         = "oauth_state"
+	oauthPKCECookieName          = "oauth_code_verifier"
+	oauthPostLogoutRedirectParam = "post_logout_redirect_uri"
 )
 
 var (
@@ -54,26 +58,28 @@ func fromSocialErr(err *connectors.SocialError) error {
 	return errutil.Unauthorized("auth.oauth.userinfo.failed", errutil.WithPublicMessage(err.Error())).Errorf("%w", err)
 }
 
+var _ authn.LogoutClient = new(OAuth)
 var _ authn.RedirectClient = new(OAuth)
 
 func ProvideOAuth(
 	name string, cfg *setting.Cfg, oauthCfg *social.OAuthInfo,
-	connector social.SocialConnector, httpClient *http.Client,
+	connector social.SocialConnector, httpClient *http.Client, oauthService oauthtoken.OAuthTokenService,
 ) *OAuth {
 	return &OAuth{
 		name, fmt.Sprintf("oauth_%s", strings.TrimPrefix(name, "auth.client.")),
-		log.New(name), cfg, oauthCfg, connector, httpClient,
+		log.New(name), cfg, oauthCfg, connector, httpClient, oauthService,
 	}
 }
 
 type OAuth struct {
-	name       string
-	moduleName string
-	log        log.Logger
-	cfg        *setting.Cfg
-	oauthCfg   *social.OAuthInfo
-	connector  social.SocialConnector
-	httpClient *http.Client
+	name         string
+	moduleName   string
+	log          log.Logger
+	cfg          *setting.Cfg
+	oauthCfg     *social.OAuthInfo
+	connector    social.SocialConnector
+	httpClient   *http.Client
+	oauthService oauthtoken.OAuthTokenService
 }
 
 func (c *OAuth) Name() string {
@@ -204,6 +210,27 @@ func (c *OAuth) RedirectURL(ctx context.Context, r *authn.Request) (*authn.Redir
 	}, nil
 }
 
+func (c *OAuth) Logout(ctx context.Context, user identity.Requester, info *login.UserAuth) (*authn.Redirect, bool) {
+	token := c.oauthService.GetCurrentOAuthToken(ctx, user)
+
+	if err := c.oauthService.InvalidateOAuthTokens(ctx, info); err != nil {
+		namespace, id := user.GetNamespacedID()
+		c.log.FromContext(ctx).Error("Failed to invalidate tokens", "namespace", namespace, "id", id, "error", err)
+	}
+
+	redirctURL := getOAuthSignoutRedirectURL(c.cfg, c.oauthCfg)
+	if redirctURL == "" {
+		c.log.FromContext(ctx).Debug("No signout redirect url configured")
+		return nil, false
+	}
+
+	if isOICDLogout(redirctURL) && token != nil && token.Valid() {
+		redirctURL = withIDTokenHint(redirctURL, token.Extra("id_token").(string))
+	}
+
+	return &authn.Redirect{URL: redirctURL}, true
+}
+
 // genPKCECode returns a random URL-friendly string and it's base64 URL encoded SHA256 digest.
 func genPKCECode() (string, string, error) {
 	// IETF RFC 7636 specifies that the code verifier should be 43-128
@@ -242,4 +269,45 @@ func genOAuthState(secret, seed string) (string, string, error) {
 func hashOAuthState(state, secret, seed string) string {
 	hashBytes := sha256.Sum256([]byte(state + secret + seed))
 	return hex.EncodeToString(hashBytes[:])
+}
+
+func getOAuthSignoutRedirectURL(cfg *setting.Cfg, oauthCfg *social.OAuthInfo) string {
+	if oauthCfg.SignoutRedirectUrl != "" {
+		return oauthCfg.SignoutRedirectUrl
+	}
+
+	return cfg.SignoutRedirectUrl
+}
+
+func withIDTokenHint(redirectURL string, idToken string) string {
+	if idToken == "" {
+		return redirectURL
+	}
+
+	u, err := url.Parse(redirectURL)
+	if err != nil {
+		return redirectURL
+	}
+
+	q := u.Query()
+	q.Set("id_token_hint", idToken)
+	u.RawQuery = q.Encode()
+
+	return u.String()
+
+}
+
+func isOICDLogout(redirectUrl string) bool {
+	if redirectUrl == "" {
+		return false
+	}
+
+	u, err := url.Parse(redirectUrl)
+	if err != nil {
+		return false
+	}
+
+	q := u.Query()
+	_, ok := q[oauthPostLogoutRedirectParam]
+	return ok
 }

--- a/pkg/services/authn/clients/oauth_test.go
+++ b/pkg/services/authn/clients/oauth_test.go
@@ -351,17 +351,6 @@ func TestOAuth_Logout(t *testing.T) {
 			expectedOK:  true,
 		},
 		{
-			desc: "client specific url should take precedence",
-			cfg: &setting.Cfg{
-				SignoutRedirectUrl: "http://idp.com/logout",
-			},
-			oauthCfg: &social.OAuthInfo{
-				SignoutRedirectUrl: "http://idp-2.com/logout",
-			},
-			expectedURL: "http://idp-2.com/logout",
-			expectedOK:  true,
-		},
-		{
 			desc: "should add id token hint if oicd logout is configured and token is valid",
 			cfg:  &setting.Cfg{},
 			oauthCfg: &social.OAuthInfo{

--- a/pkg/services/authn/clients/oauth_test.go
+++ b/pkg/services/authn/clients/oauth_test.go
@@ -4,7 +4,9 @@ import (
 	"context"
 	"net/http"
 	"net/url"
+	"strings"
 	"testing"
+	"time"
 
 	"golang.org/x/oauth2"
 
@@ -12,8 +14,10 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/grafana/grafana/pkg/login/social"
+	"github.com/grafana/grafana/pkg/services/auth/identity"
 	"github.com/grafana/grafana/pkg/services/authn"
 	"github.com/grafana/grafana/pkg/services/login"
+	"github.com/grafana/grafana/pkg/services/oauthtoken/oauthtokentest"
 	"github.com/grafana/grafana/pkg/services/org"
 	"github.com/grafana/grafana/pkg/setting"
 )
@@ -297,6 +301,119 @@ func TestOAuth_RedirectURL(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestOAuth_Logout(t *testing.T) {
+	type testCase struct {
+		desc     string
+		cfg      *setting.Cfg
+		oauthCfg *social.OAuthInfo
+
+		expectedOK            bool
+		expectedURL           string
+		expectedIDTokenHint   string
+		expectedPostLogoutURI string
+	}
+
+	tests := []testCase{
+		{
+			desc:     "should not return redirect url if not configured for client or globably",
+			cfg:      &setting.Cfg{},
+			oauthCfg: &social.OAuthInfo{},
+		},
+		{
+			desc: "should return redirect url for globably configured redirect url",
+			cfg: &setting.Cfg{
+				SignoutRedirectUrl: "http://idp.com/logout",
+			},
+			oauthCfg:    &social.OAuthInfo{},
+			expectedURL: "http://idp.com/logout",
+			expectedOK:  true,
+		},
+		{
+			desc: "should return redirect url for client configured redirect url",
+			cfg:  &setting.Cfg{},
+			oauthCfg: &social.OAuthInfo{
+				SignoutRedirectUrl: "http://idp.com/logout",
+			},
+			expectedURL: "http://idp.com/logout",
+			expectedOK:  true,
+		},
+		{
+			desc: "client specific url should take precedence",
+			cfg: &setting.Cfg{
+				SignoutRedirectUrl: "http://idp.com/logout",
+			},
+			oauthCfg: &social.OAuthInfo{
+				SignoutRedirectUrl: "http://idp-2.com/logout",
+			},
+			expectedURL: "http://idp-2.com/logout",
+			expectedOK:  true,
+		},
+		{
+			desc: "client specific url should take precedence",
+			cfg: &setting.Cfg{
+				SignoutRedirectUrl: "http://idp.com/logout",
+			},
+			oauthCfg: &social.OAuthInfo{
+				SignoutRedirectUrl: "http://idp-2.com/logout",
+			},
+			expectedURL: "http://idp-2.com/logout",
+			expectedOK:  true,
+		},
+		{
+			desc: "should add id token hint if oicd logout is configured and token is valid",
+			cfg:  &setting.Cfg{},
+			oauthCfg: &social.OAuthInfo{
+				SignoutRedirectUrl: "http://idp.com/logout?post_logout_redirect_uri=http%3A%3A%2F%2Ftest.com%2Flogin",
+			},
+			expectedURL:           "http://idp.com/logout",
+			expectedIDTokenHint:   "id_token_hint=some.id.token",
+			expectedPostLogoutURI: "http%3A%3A%2F%2Ftest.com%2Flogin",
+			expectedOK:            true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			var (
+				getTokenCalled        bool
+				invalidateTokenCalled bool
+			)
+
+			mockService := &oauthtokentest.MockOauthTokenService{
+				GetCurrentOauthTokenFunc: func(_ context.Context, _ identity.Requester) *oauth2.Token {
+					getTokenCalled = true
+					token := &oauth2.Token{
+						AccessToken: "some.access.token",
+						Expiry:      time.Now().Add(10 * time.Minute),
+					}
+					return token.WithExtra(map[string]any{
+						"id_token": "some.id.token",
+					})
+				},
+				InvalidateOAuthTokensFunc: func(_ context.Context, _ *login.UserAuth) error {
+					invalidateTokenCalled = true
+					return nil
+				},
+			}
+
+			c := ProvideOAuth(authn.ClientWithPrefix("azuread"), tt.cfg, tt.oauthCfg, mockConnector{}, nil, mockService)
+
+			redirect, ok := c.Logout(context.Background(), &authn.Identity{}, &login.UserAuth{})
+
+			assert.Equal(t, tt.expectedOK, ok)
+			if tt.expectedOK {
+				assert.True(t, strings.HasPrefix(redirect.URL, tt.expectedURL))
+				assert.Contains(t, redirect.URL, tt.expectedIDTokenHint)
+				assert.Contains(t, redirect.URL, tt.expectedPostLogoutURI)
+			}
+
+			assert.True(t, getTokenCalled)
+			assert.True(t, invalidateTokenCalled)
+		})
+	}
+
 }
 
 type mockConnector struct {

--- a/pkg/services/authn/clients/oauth_test.go
+++ b/pkg/services/authn/clients/oauth_test.go
@@ -413,7 +413,6 @@ func TestOAuth_Logout(t *testing.T) {
 			assert.True(t, invalidateTokenCalled)
 		})
 	}
-
 }
 
 type mockConnector struct {

--- a/pkg/services/authn/clients/oauth_test.go
+++ b/pkg/services/authn/clients/oauth_test.go
@@ -212,7 +212,7 @@ func TestOAuth_Authenticate(t *testing.T) {
 				ExpectedToken:           &oauth2.Token{},
 				ExpectedIsSignupAllowed: true,
 				ExpectedIsEmailAllowed:  tt.isEmailAllowed,
-			}, nil)
+			}, nil, nil)
 			identity, err := c.Authenticate(context.Background(), tt.req)
 			assert.ErrorIs(t, err, tt.expectedErr)
 
@@ -281,7 +281,7 @@ func TestOAuth_RedirectURL(t *testing.T) {
 					require.Len(t, opts, tt.numCallOptions)
 					return ""
 				},
-			}, nil)
+			}, nil, nil)
 
 			redirect, err := c.RedirectURL(context.Background(), nil)
 			assert.ErrorIs(t, err, tt.expectedErr)


### PR DESCRIPTION
**What is this feature?**
The logout handler previously had a bunch of provider specific logic when performing logout. This part was a bit messy and hard to follow. 

I instead added logout functionality to `authn.Service`. The service it self perform all shared logic, revoking session token and generate default redirect url.

Some clients (oauth and saml) can be configured with additional logic that should happen. To support this I added a extensions interface that clients can implement `authn.LogoutClient`. If a client implements this interface it will be called for users that has authenticated with it.

For now it is only implemented for oauth clients. For these we remove access, refresh and id tokens and if configured create a new redirect url with support for [oidc rp initiated logout](https://openid.net/specs/openid-connect-rpinitiated-1_0.html).

Plan is to also fix enterprise saml client to also implement this interface and remove the TODO added here. 

**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/identity-access-team/issues/496

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
