### PR TITLE
Alerting: Fix panic when creating a new Alertmanager returns an error

### DIFF
--- a/pkg/services/ngalert/notifier/multiorg_alertmanager.go
+++ b/pkg/services/ngalert/notifier/multiorg_alertmanager.go
@@ -269,6 +269,7 @@ func (moa *MultiOrgAlertmanager) SyncAlertmanagersForOrgs(ctx context.Context, o
 			am, err := moa.factory(ctx, orgID)
 			if err != nil {
 				moa.logger.Error("Unable to create Alertmanager for org", "org", orgID, "error", err)
+				continue
 			}
 			moa.alertmanagers[orgID] = am
 			alertmanager = am


### PR DESCRIPTION
In Grafana we sync Alertmanagers for each org periodically by calling `SyncAlertmanagersForOrgs()`. During this call, we check that each org has an Alertmanager assigned. If we can't find an Alertmanager for a given org, we create a new one and assign it to it, storing it in a map of `orgID -> Alertmanager`

We're currently storing the returned `Alertmanager` value and assigning it to the org even when the operation for creating an alertmanager returns an error, resulting in panics when trying to call methods on that nil pointer. This PR fixes this bug by skipping to the next org in case of error.