### PR TITLE
RBAC: Render team, service account and user list when a user can see entities but not roles attached to them

### DIFF
--- a/public/app/features/serviceaccounts/state/actions.ts
+++ b/public/app/features/serviceaccounts/state/actions.ts
@@ -54,7 +54,7 @@ export function fetchServiceAccounts(
           )}&accesscontrol=true`
         );
 
-        if (contextSrv.licensedAccessControlEnabled()) {
+        if (contextSrv.licensedAccessControlEnabled() && contextSrv.hasPermission(AccessControlAction.ActionUserRolesList)) {
           dispatch(rolesFetchBegin());
           const orgId = contextSrv.user.orgId;
           const userIds = result?.serviceAccounts.map((u: ServiceAccountDTO) => u.id);

--- a/public/app/features/serviceaccounts/state/actions.ts
+++ b/public/app/features/serviceaccounts/state/actions.ts
@@ -54,7 +54,10 @@ export function fetchServiceAccounts(
           )}&accesscontrol=true`
         );
 
-        if (contextSrv.licensedAccessControlEnabled() && contextSrv.hasPermission(AccessControlAction.ActionUserRolesList)) {
+        if (
+          contextSrv.licensedAccessControlEnabled() &&
+          contextSrv.hasPermission(AccessControlAction.ActionUserRolesList)
+        ) {
           dispatch(rolesFetchBegin());
           const orgId = contextSrv.user.orgId;
           const userIds = result?.serviceAccounts.map((u: ServiceAccountDTO) => u.id);

--- a/public/app/features/teams/state/actions.ts
+++ b/public/app/features/teams/state/actions.ts
@@ -41,7 +41,10 @@ export function loadTeams(initial = false): ThunkResult<void> {
       noTeams = response.teams.length === 0;
     }
 
-    if (contextSrv.licensedAccessControlEnabled() && contextSrv.hasPermission(AccessControlAction.ActionTeamsRolesList)) {
+    if (
+      contextSrv.licensedAccessControlEnabled() &&
+      contextSrv.hasPermission(AccessControlAction.ActionTeamsRolesList)
+    ) {
       dispatch(rolesFetchBegin());
       const teamIds = response?.teams.map((t: Team) => t.id);
       const roles = await getBackendSrv().post(`/api/access-control/teams/roles/search`, { teamIds });

--- a/public/app/features/teams/state/actions.ts
+++ b/public/app/features/teams/state/actions.ts
@@ -41,7 +41,7 @@ export function loadTeams(initial = false): ThunkResult<void> {
       noTeams = response.teams.length === 0;
     }
 
-    if (contextSrv.licensedAccessControlEnabled()) {
+    if (contextSrv.licensedAccessControlEnabled() && contextSrv.hasPermission(AccessControlAction.ActionTeamsRolesList)) {
       dispatch(rolesFetchBegin());
       const teamIds = response?.teams.map((t: Team) => t.id);
       const roles = await getBackendSrv().post(`/api/access-control/teams/roles/search`, { teamIds });

--- a/public/app/features/users/state/actions.ts
+++ b/public/app/features/users/state/actions.ts
@@ -6,7 +6,7 @@ import { contextSrv } from 'app/core/core';
 import { accessControlQueryParam } from 'app/core/utils/accessControl';
 import { OrgUser } from 'app/types';
 
-import { ThunkResult } from '../../../types';
+import { AccessControlAction, ThunkResult } from '../../../types';
 
 import {
   usersLoaded,
@@ -29,7 +29,7 @@ export function loadUsers(): ThunkResult<void> {
         accessControlQueryParam({ perpage: perPage, page, query: searchQuery, sort })
       );
 
-      if (contextSrv.licensedAccessControlEnabled()) {
+      if (contextSrv.licensedAccessControlEnabled() && contextSrv.hasPermission(AccessControlAction.ActionUserRolesList)) {
         dispatch(rolesFetchBegin());
         const orgId = contextSrv.user.orgId;
         const userIds = users?.orgUsers.map((u: OrgUser) => u.userId);

--- a/public/app/features/users/state/actions.ts
+++ b/public/app/features/users/state/actions.ts
@@ -29,7 +29,10 @@ export function loadUsers(): ThunkResult<void> {
         accessControlQueryParam({ perpage: perPage, page, query: searchQuery, sort })
       );
 
-      if (contextSrv.licensedAccessControlEnabled() && contextSrv.hasPermission(AccessControlAction.ActionUserRolesList)) {
+      if (
+        contextSrv.licensedAccessControlEnabled() &&
+        contextSrv.hasPermission(AccessControlAction.ActionUserRolesList)
+      ) {
         dispatch(rolesFetchBegin());
         const orgId = contextSrv.user.orgId;
         const userIds = users?.orgUsers.map((u: OrgUser) => u.userId);


### PR DESCRIPTION
**What is this feature?**
Fix regression added in https://github.com/grafana/grafana/pull/77297. If a user can list entity but not roles assigned to it we should still render the in the list.

Using a user that can list e.g. service account but not roles assigned to them.

Before:
![2023-12-18-14:54:16](https://github.com/grafana/grafana/assets/23356117/42185052-411e-4422-a5b0-7276aa803c71)

After:
![2023-12-18-14:52:58](https://github.com/grafana/grafana/assets/23356117/d9a9ad34-7de4-41c8-8be4-1955e2f0c33a)

**Which issue(s) does this PR fix?**:
Fixes https://github.com/grafana/identity-access-team/issues/486

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
