### PR TITLE
Prometheus: Replace pre-calculated $__interval values for backend interpolation

### DIFF
--- a/public/app/plugins/datasource/prometheus/datasource.ts
+++ b/public/app/plugins/datasource/prometheus/datasource.ts
@@ -883,9 +883,14 @@ export class PrometheusDatasource
   applyTemplateVariables(target: PromQuery, scopedVars: ScopedVars, filters?: AdHocVariableFilter[]) {
     const variables = cloneDeep(scopedVars);
 
-    // We want to interpolate these variables on backend
-    delete variables.__interval;
-    delete variables.__interval_ms;
+    // We want to interpolate these variables on backend.
+    // The pre-calculated values are replaced withe the variable strings.
+    variables.__interval = {
+      value: '$__interval',
+    };
+    variables.__interval_ms = {
+      value: '$__interval_ms',
+    };
 
     // interpolate expression
     const expr = this.templateSrv.replace(target.expr, variables, this.interpolateQueryExpr);


### PR DESCRIPTION
When working on Scenes migration I have noticed an interpolation issue with Prometheus data source and `$__interval[_ms]` variables. 

In the old architecture the interpolation of those variables happens using the `scopedVars`. But for prometheus ds those scoped vars were removed so that in the interpolation pipeline the interval var was not replaced in the query. 

In the scenes arch this ain't possible as the `$__interval[_ms]` variable interpolation no longer depends on scoped vars but rather the [`IntervalMacro`](https://github.com/grafana/scenes/pull/487).

In order to provide feature parity I'm proposing this change in which the scoped interval variables are not removed from the scopedVars object, but instead their value is set to the identity value. 

For testing this PR just run any dashboard with Prometheus query including `$__interval` variable using Scenes.
