### PR TITLE
Plugins: Auto fix backend executable path for running system

### DIFF
--- a/pkg/plugins/plugins.go
+++ b/pkg/plugins/plugins.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"io/fs"
 	"path"
+	"path/filepath"
 	"runtime"
 	"strings"
 	"sync"
@@ -406,7 +407,7 @@ func (p *Plugin) executablePath(f string) string {
 	if os == "windows" {
 		extension = ".exe"
 	}
-	return path.Join(p.FS.Base(), fmt.Sprintf("%s_%s_%s%s", f, os, strings.ToLower(arch), extension))
+	return path.Join(p.FS.Base(), fmt.Sprintf("%s_%s_%s%s", filepath.FromSlash(f), os, strings.ToLower(arch), extension))
 }
 
 type PluginClient interface {


### PR DESCRIPTION
**What is this feature?**

Though it was never officially encouraged or supported, backend plugins can specify a relative route to their executable via their `plugin.json`. For example, Zabbix does it here https://github.com/grafana/grafana-zabbix/blob/main/src/datasource/plugin.json#L9.

If we do want to choose to support this (please see note below), [filepath.FromSlash](https://pkg.go.dev/path/filepath#FromSlash) should give us what we need.

**Why do we need this feature?**

If we do not attempt to auto correct this, it means that plugin backends that are specified as a path will only be found/started if run on a system that is compatible with the file path style specified in the plugin.json. For example in [the Zabbix case](https://github.com/grafana/grafana-zabbix/blob/main/src/datasource/plugin.json#L9), this will not work on Windows. 

**Who is this feature for?**

Plugin developers who have their backend binary paths specified at a relative path.

<!--
**Which issue(s) does this PR fix?**:



- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"



Fixes #
-->

**Special notes for your reviewer:**

**NOTE**: We can also chose to not to support this and instead communicate with any existing plugins to correct their paths to include only a executable _name_, **and not a path** (relative or otherwise).


Please check that:
- [X] It works as expected from a user's perspective.
- [X] If this is a pre-GA feature, it is behind a feature toggle.
- [X] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
