### PR TITLE
Plugins: Disable add new data source for incomplete install

### DIFF
--- a/public/app/features/plugins/admin/components/GetStartedWithPlugin/GetStartedWithDataSource.tsx
+++ b/public/app/features/plugins/admin/components/GetStartedWithPlugin/GetStartedWithDataSource.tsx
@@ -4,6 +4,7 @@ import { DataSourcePluginMeta } from '@grafana/data';
 import { Button } from '@grafana/ui';
 import { useDataSourcesRoutes, addDataSource } from 'app/features/datasources/state';
 import { useDispatch } from 'app/types';
+import config from 'app/core/config';
 
 import { isDataSourceEditor } from '../../permissions';
 import { CatalogPlugin } from '../../types';
@@ -29,7 +30,7 @@ export function GetStartedWithDataSource({ plugin }: Props): React.ReactElement 
   }
 
   return (
-    <Button variant="primary" onClick={onAddDataSource}>
+    <Button variant="primary" onClick={onAddDataSource} disabled={config.featureToggles.managedPluginsInstall && !plugin.isFullyInstalled}>
       Add new data source
     </Button>
   );

--- a/public/app/features/plugins/admin/components/GetStartedWithPlugin/GetStartedWithDataSource.tsx
+++ b/public/app/features/plugins/admin/components/GetStartedWithPlugin/GetStartedWithDataSource.tsx
@@ -1,10 +1,11 @@
 import React, { useCallback } from 'react';
 
 import { DataSourcePluginMeta } from '@grafana/data';
+import { config } from '@grafana/runtime';
 import { Button } from '@grafana/ui';
+import configCore from 'app/core/config';
 import { useDataSourcesRoutes, addDataSource } from 'app/features/datasources/state';
 import { useDispatch } from 'app/types';
-import config from 'app/core/config';
 
 import { isDataSourceEditor } from '../../permissions';
 import { CatalogPlugin } from '../../types';
@@ -30,7 +31,15 @@ export function GetStartedWithDataSource({ plugin }: Props): React.ReactElement 
   }
 
   return (
-    <Button variant="primary" onClick={onAddDataSource} disabled={config.featureToggles.managedPluginsInstall && !plugin.isFullyInstalled}>
+    <Button
+      variant="primary"
+      onClick={onAddDataSource}
+      disabled={
+        configCore.featureToggles.managedPluginsInstall &&
+        config.pluginAdminExternalManageEnabled &&
+        !plugin.isFullyInstalled
+      }
+    >
       Add new data source
     </Button>
   );

--- a/public/app/features/plugins/admin/components/GetStartedWithPlugin/GetStartedWithDataSource.tsx
+++ b/public/app/features/plugins/admin/components/GetStartedWithPlugin/GetStartedWithDataSource.tsx
@@ -30,14 +30,18 @@ export function GetStartedWithDataSource({ plugin }: Props): React.ReactElement 
     return null;
   }
 
+  const disabledButton =
+    configCore.featureToggles.managedPluginsInstall &&
+    config.pluginAdminExternalManageEnabled &&
+    !plugin.isFullyInstalled;
+
   return (
     <Button
       variant="primary"
       onClick={onAddDataSource}
-      disabled={
-        configCore.featureToggles.managedPluginsInstall &&
-        config.pluginAdminExternalManageEnabled &&
-        !plugin.isFullyInstalled
+      disabled={disabledButton}
+      title={
+        disabledButton ? "The plugin isn't usable yet, it may take some time to complete the installation." : undefined
       }
     >
       Add new data source


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

Disable "Add new data source" button when plugin installation isn't completed and show tooltip

**Why do we need this feature?**

This would prevent wrong grafana behavior for incomplete plugin installation.

**Who is this feature for?**

Catalog users

**Special notes for your reviewer:**

![disabled-button](https://github.com/grafana/grafana/assets/5558280/e617ac4d-847a-4bce-991b-bac7687fc288)


Please check that:
- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
