### PR TITLE
Timeseries Panel: Only prepare frames when data is loaded

### DIFF
--- a/public/app/plugins/panel/timeseries/TimeSeriesPanel.tsx
+++ b/public/app/plugins/panel/timeseries/TimeSeriesPanel.tsx
@@ -1,6 +1,6 @@
 import React, { useMemo } from 'react';
 
-import { PanelProps, DataFrameType } from '@grafana/data';
+import { PanelProps, DataFrameType, LoadingState } from '@grafana/data';
 import { PanelDataErrorView } from '@grafana/runtime';
 import { TooltipDisplayMode } from '@grafana/schema';
 import { KeyboardPlugin, TooltipPlugin, TooltipPlugin2, usePanelContext, ZoomPlugin } from '@grafana/ui';
@@ -35,8 +35,9 @@ export const TimeSeriesPanel = ({
 }: TimeSeriesPanelProps) => {
   const { sync, canAddAnnotations, onThresholdsChange, canEditThresholds, showThresholds, dataLinkPostProcessor } =
     usePanelContext();
-
-  const frames = useMemo(() => prepareGraphableFields(data.series, config.theme2, timeRange), [data.series, timeRange]);
+  const frames = useMemo(() => {
+    return prepareGraphableFields(data.state === LoadingState.Done ? data.series : [], config.theme2, timeRange);
+  }, [data.state, data.series, timeRange]);
   const timezones = useMemo(() => getTimezones(options.timezone, timeZone), [options.timezone, timeZone]);
   const suggestions = useMemo(() => {
     if (frames?.length && frames.every((df) => df.meta?.type === DataFrameType.TimeSeriesLong)) {


### PR DESCRIPTION
**What is this feature?**

This fixes a bug where the timeseries panel would attempt to load null frames in with a previous panel render's interval, even if the previous interval was very small compared to the new date range. 

To fill out the null data, there is a while loop that adds in frames at the given interval from the last data point to the end of the date range https://github.com/grafana/grafana/blob/main/packages/grafana-data/src/transformations/transformers/nulls/nullInsertThreshold.ts#L155

If you render a frame with an extremely small date range, like a few seconds between the to and from date, Grafana will calculate the interval and have it go to the lowest possible value of 1ms https://github.com/grafana/grafana/blob/main/packages/grafana-data/src/datetime/rangeutil.ts#L283

In the case of a 4 second range window, a 1ms interval makes sense.

If you then change the date range to a broader time (like previous 6 hours), it will attempt to re-render the frame with the 1ms interval instead of the interval that should be calculated for the new date range. That means many, many null data frames will attempt to be created and it will hang at the while loop.

The null insert threshold logic is ran as a part of `prepareGraphableFields` - if we wait for the frames to be fully loaded, it will only run this function after the new, valid interval is calculated.

**Why do we need this feature?**
 
To fix a bug.

**Which issue(s) does this PR fix?**:

Fixes #79476

**Special notes for your reviewer:**
There are specific replication steps available at the bug linked to this ticket. Generally though, you need a functional metric function in loki with a lot of data. Zoom in/alter the time picker to have a 4 second window. Copy this link, and travel to your grafana instance so the 1ms interval is cached. Then change your time range to be wider, like an hour or so, if you want to see the lag without crashing your browser.

Another step I used file testing is to console.log out the number of iterations the while loop will take based on the data it gets. I placed a `console.log('iterations', (refFieldPseudoMax - prevValue) / threshold);` just outside the while loop linked above. 

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
