### PR TITLE
Azure Monitor: Fix multi-resource bug "Missing required region params, requested QueryParams: api-version:2017-12-01-preview..."

### DIFF
--- a/public/app/plugins/datasource/azuremonitor/azure_monitor/url_builder.test.ts
+++ b/public/app/plugins/datasource/azuremonitor/azure_monitor/url_builder.test.ts
@@ -184,7 +184,7 @@ describe('AzureMonitorUrlBuilder', () => {
         },
         templateSrv,
         true,
-        "region"
+        'region'
       );
       expect(url).toBe(
         'baseUrl/subscriptions/sub/resource-uri/resource/providers/microsoft.insights/metricdefinitions?api-version=apiVersion&region=region'

--- a/public/app/plugins/datasource/azuremonitor/azure_monitor/url_builder.test.ts
+++ b/public/app/plugins/datasource/azuremonitor/azure_monitor/url_builder.test.ts
@@ -174,6 +174,22 @@ describe('AzureMonitorUrlBuilder', () => {
         '/subscriptions/sub/resource-uri/resource/providers/microsoft.insights/metricdefinitions?api-version=2017-05-01-preview&metricnamespace=custom%2Fnamespace'
       );
     });
+
+    it('adds a region with multiple resources', () => {
+      const url = UrlBuilder.buildAzureMonitorGetMetricNamesUrl(
+        'baseUrl',
+        'apiVersion',
+        {
+          resourceUri: '/subscriptions/sub/resource-uri/resource',
+        },
+        templateSrv,
+        true,
+        "region"
+      );
+      expect(url).toBe(
+        'baseUrl/subscriptions/sub/resource-uri/resource/providers/microsoft.insights/metricdefinitions?api-version=apiVersion&region=region'
+      );
+    });
   });
 
   describe('Legacy query object', () => {

--- a/public/app/plugins/datasource/azuremonitor/azure_monitor/url_builder.ts
+++ b/public/app/plugins/datasource/azuremonitor/azure_monitor/url_builder.ts
@@ -104,10 +104,10 @@ export default class UrlBuilder {
 
     if (multipleResources && !customNamespace && metricNamespace) {
       url += `&metricnamespace=${encodeURIComponent(metricNamespace)}`;
+    }
 
-      if (region) {
-        url += `&region=${region}`;
-      }
+    if (region && multipleResources) {
+      url += `&region=${region}`;
     }
 
     return url;


### PR DESCRIPTION
Resource group was not added to the query when multiple resources were selected. I removed the check when building the resource uri. This fixes https://github.com/grafana/support-escalations/issues/8761 

Old:
![image](https://github.com/grafana/grafana/assets/5140848/91d6115a-9096-436b-9653-7b8d23d50555)

Now:
![image](https://github.com/grafana/grafana/assets/5140848/10c08c7b-c476-48f6-b1c4-0192c92fc024)

This did not seem to affect any of the other queries I tested. This check was originally added with https://github.com/grafana/grafana/pull/70864 VM instances with "Inbound Flows" still works as expected.
@asimpson Let me know if you know of something unexpected that this change will cause. 