### PR TITLE
sql: improve sqleng-api, leave sql.DB creation to the plugins

### DIFF
--- a/pkg/tsdb/grafana-postgresql-datasource/postgres_test.go
+++ b/pkg/tsdb/grafana-postgresql-datasource/postgres_test.go
@@ -184,17 +184,10 @@ func TestIntegrationPostgres(t *testing.T) {
 		t.Skip()
 	}
 
-	x := InitPostgresTestDB(t)
-
-	origDB := sqleng.NewDB
 	origInterpolate := sqleng.Interpolate
 	t.Cleanup(func() {
-		sqleng.NewDB = origDB
 		sqleng.Interpolate = origInterpolate
 	})
-	sqleng.NewDB = func(d, c string) (*sql.DB, error) {
-		return x, nil
-	}
 	sqleng.Interpolate = func(query backend.DataQuery, timeRange backend.TimeRange, timeInterval string, sql string) (string, error) {
 		return sql, nil
 	}
@@ -216,8 +209,6 @@ func TestIntegrationPostgres(t *testing.T) {
 	}
 
 	config := sqleng.DataPluginConfiguration{
-		DriverName:        "postgres",
-		ConnectionString:  "",
 		DSInfo:            dsInfo,
 		MetricColumnTypes: []string{"UNKNOWN", "TEXT", "VARCHAR", "CHAR"},
 		RowLimit:          1000000,
@@ -226,12 +217,14 @@ func TestIntegrationPostgres(t *testing.T) {
 	queryResultTransformer := postgresQueryResultTransformer{}
 
 	logger := backend.NewLoggerWith("logger", "postgres.test")
-	exe, err := sqleng.NewQueryDataHandler(cfg, config, &queryResultTransformer, newPostgresMacroEngine(dsInfo.JsonData.Timescaledb),
+
+	db := InitPostgresTestDB(t, jsonData)
+
+	exe, err := sqleng.NewQueryDataHandler(cfg, db, config, &queryResultTransformer, newPostgresMacroEngine(dsInfo.JsonData.Timescaledb),
 		logger)
 
 	require.NoError(t, err)
 
-	db := x
 	fromStart := time.Date(2018, 3, 15, 13, 0, 0, 0, time.UTC).In(time.Local)
 
 	t.Run("Given a table with different native data types", func(t *testing.T) {
@@ -1282,8 +1275,6 @@ func TestIntegrationPostgres(t *testing.T) {
 		t.Run("When row limit set to 1", func(t *testing.T) {
 			dsInfo := sqleng.DataSourceInfo{}
 			config := sqleng.DataPluginConfiguration{
-				DriverName:        "postgres",
-				ConnectionString:  "",
 				DSInfo:            dsInfo,
 				MetricColumnTypes: []string{"UNKNOWN", "TEXT", "VARCHAR", "CHAR"},
 				RowLimit:          1,
@@ -1291,7 +1282,7 @@ func TestIntegrationPostgres(t *testing.T) {
 
 			queryResultTransformer := postgresQueryResultTransformer{}
 
-			handler, err := sqleng.NewQueryDataHandler(setting.NewCfg(), config, &queryResultTransformer, newPostgresMacroEngine(false), logger)
+			handler, err := sqleng.NewQueryDataHandler(setting.NewCfg(), db, config, &queryResultTransformer, newPostgresMacroEngine(false), logger)
 			require.NoError(t, err)
 
 			t.Run("When doing a table query that returns 2 rows should limit the result to 1 row", func(t *testing.T) {
@@ -1392,11 +1383,15 @@ func TestIntegrationPostgres(t *testing.T) {
 	})
 }
 
-func InitPostgresTestDB(t *testing.T) *sql.DB {
+func InitPostgresTestDB(t *testing.T, jsonData sqleng.JsonData) *sql.DB {
 	connStr := postgresTestDBConnString()
-	x, err := sql.Open("postgres", connStr)
+	db, err := sql.Open("postgres", connStr)
 	require.NoError(t, err, "Failed to init postgres DB")
-	return x
+
+	db.SetMaxOpenConns(jsonData.MaxOpenConns)
+	db.SetMaxIdleConns(jsonData.MaxIdleConns)
+	db.SetConnMaxLifetime(time.Duration(jsonData.ConnMaxLifetime) * time.Second)
+	return db
 }
 
 func genTimeRangeByInterval(from time.Time, duration time.Duration, interval time.Duration) []time.Time {

--- a/pkg/tsdb/mssql/mssql.go
+++ b/pkg/tsdb/mssql/mssql.go
@@ -2,6 +2,7 @@ package mssql
 
 import (
 	"context"
+	"database/sql"
 	"encoding/json"
 	"fmt"
 	"net/url"
@@ -9,6 +10,7 @@ import (
 	"regexp"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/grafana/grafana-azure-sdk-go/azcredentials"
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
@@ -125,8 +127,6 @@ func newInstanceSettings(cfg *setting.Cfg, logger log.Logger) datasource.Instanc
 		}
 
 		config := sqleng.DataPluginConfiguration{
-			DriverName:        driverName,
-			ConnectionString:  cnnstr,
 			DSInfo:            dsInfo,
 			MetricColumnTypes: []string{"VARCHAR", "CHAR", "NVARCHAR", "NCHAR"},
 			RowLimit:          cfg.DataProxyRowLimit,
@@ -136,7 +136,16 @@ func newInstanceSettings(cfg *setting.Cfg, logger log.Logger) datasource.Instanc
 			userError: cfg.UserFacingDefaultError,
 		}
 
-		return sqleng.NewQueryDataHandler(cfg, config, &queryResultTransformer, newMssqlMacroEngine(), logger)
+		db, err := sql.Open(driverName, cnnstr)
+		if err != nil {
+			return nil, err
+		}
+
+		db.SetMaxOpenConns(config.DSInfo.JsonData.MaxOpenConns)
+		db.SetMaxIdleConns(config.DSInfo.JsonData.MaxIdleConns)
+		db.SetConnMaxLifetime(time.Duration(config.DSInfo.JsonData.ConnMaxLifetime) * time.Second)
+
+		return sqleng.NewQueryDataHandler(cfg, db, config, &queryResultTransformer, newMssqlMacroEngine(), logger)
 	}
 }
 

--- a/pkg/tsdb/mssql/mssql_test.go
+++ b/pkg/tsdb/mssql/mssql_test.go
@@ -39,21 +39,9 @@ func TestMSSQL(t *testing.T) {
 		t.Skip()
 	}
 
-	x := initMSSQLTestDB(t)
-	origDB := sqleng.NewDB
-	t.Cleanup(func() {
-		sqleng.NewDB = origDB
-	})
-
-	sqleng.NewDB = func(d, c string) (*sql.DB, error) {
-		return x, nil
-	}
-
 	queryResultTransformer := mssqlQueryResultTransformer{}
 	dsInfo := sqleng.DataSourceInfo{}
 	config := sqleng.DataPluginConfiguration{
-		DriverName:        "mssql",
-		ConnectionString:  "",
 		DSInfo:            dsInfo,
 		MetricColumnTypes: []string{"VARCHAR", "CHAR", "NVARCHAR", "NCHAR"},
 		RowLimit:          1000000,
@@ -61,10 +49,10 @@ func TestMSSQL(t *testing.T) {
 
 	logger := backend.NewLoggerWith("logger", "mssql.test")
 
-	endpoint, err := sqleng.NewQueryDataHandler(setting.NewCfg(), config, &queryResultTransformer, newMssqlMacroEngine(), logger)
-	require.NoError(t, err)
+	db := initMSSQLTestDB(t, config.DSInfo.JsonData)
 
-	db := x
+	endpoint, err := sqleng.NewQueryDataHandler(setting.NewCfg(), db, config, &queryResultTransformer, newMssqlMacroEngine(), logger)
+	require.NoError(t, err)
 
 	fromStart := time.Date(2018, 3, 15, 13, 0, 0, 0, time.UTC).In(time.Local)
 
@@ -811,13 +799,11 @@ func TestMSSQL(t *testing.T) {
 				queryResultTransformer := mssqlQueryResultTransformer{}
 				dsInfo := sqleng.DataSourceInfo{}
 				config := sqleng.DataPluginConfiguration{
-					DriverName:        "mssql",
-					ConnectionString:  "",
 					DSInfo:            dsInfo,
 					MetricColumnTypes: []string{"VARCHAR", "CHAR", "NVARCHAR", "NCHAR"},
 					RowLimit:          1000000,
 				}
-				endpoint, err := sqleng.NewQueryDataHandler(setting.NewCfg(), config, &queryResultTransformer, newMssqlMacroEngine(), logger)
+				endpoint, err := sqleng.NewQueryDataHandler(setting.NewCfg(), db, config, &queryResultTransformer, newMssqlMacroEngine(), logger)
 				require.NoError(t, err)
 				query := &backend.QueryDataRequest{
 					Queries: []backend.DataQuery{
@@ -1216,14 +1202,12 @@ func TestMSSQL(t *testing.T) {
 			queryResultTransformer := mssqlQueryResultTransformer{}
 			dsInfo := sqleng.DataSourceInfo{}
 			config := sqleng.DataPluginConfiguration{
-				DriverName:        "mssql",
-				ConnectionString:  "",
 				DSInfo:            dsInfo,
 				MetricColumnTypes: []string{"VARCHAR", "CHAR", "NVARCHAR", "NCHAR"},
 				RowLimit:          1,
 			}
 
-			handler, err := sqleng.NewQueryDataHandler(setting.NewCfg(), config, &queryResultTransformer, newMssqlMacroEngine(), logger)
+			handler, err := sqleng.NewQueryDataHandler(setting.NewCfg(), db, config, &queryResultTransformer, newMssqlMacroEngine(), logger)
 			require.NoError(t, err)
 
 			t.Run("When doing a table query that returns 2 rows should limit the result to 1 row", func(t *testing.T) {
@@ -1487,15 +1471,19 @@ func TestGenerateConnectionString(t *testing.T) {
 	}
 }
 
-func initMSSQLTestDB(t *testing.T) *sql.DB {
+func initMSSQLTestDB(t *testing.T, jsonData sqleng.JsonData) *sql.DB {
 	t.Helper()
 
 	testDB := sqlutil.MSSQLTestDB()
-	x, err := sql.Open(testDB.DriverName, strings.Replace(testDB.ConnStr, "localhost",
+	db, err := sql.Open(testDB.DriverName, strings.Replace(testDB.ConnStr, "localhost",
 		serverIP, 1))
 	require.NoError(t, err)
 
-	return x
+	db.SetMaxOpenConns(jsonData.MaxOpenConns)
+	db.SetMaxIdleConns(jsonData.MaxIdleConns)
+	db.SetConnMaxLifetime(time.Duration(jsonData.ConnMaxLifetime) * time.Second)
+
+	return db
 }
 
 func genTimeRangeByInterval(from time.Time, duration time.Duration, interval time.Duration) []time.Time {

--- a/pkg/tsdb/mysql/mysql_test.go
+++ b/pkg/tsdb/mysql/mysql_test.go
@@ -37,18 +37,10 @@ func TestIntegrationMySQL(t *testing.T) {
 		t.Skip()
 	}
 
-	x := InitMySQLTestDB(t)
-
-	origDB := sqleng.NewDB
 	origInterpolate := sqleng.Interpolate
 	t.Cleanup(func() {
-		sqleng.NewDB = origDB
 		sqleng.Interpolate = origInterpolate
 	})
-
-	sqleng.NewDB = func(d, c string) (*sql.DB, error) {
-		return x, nil
-	}
 
 	sqleng.Interpolate = func(query backend.DataQuery, timeRange backend.TimeRange, timeInterval string, sql string) (string, error) {
 		return sql, nil
@@ -63,8 +55,6 @@ func TestIntegrationMySQL(t *testing.T) {
 	}
 
 	config := sqleng.DataPluginConfiguration{
-		DriverName:        "mysql",
-		ConnectionString:  "",
 		DSInfo:            dsInfo,
 		TimeColumnNames:   []string{"time", "time_sec"},
 		MetricColumnTypes: []string{"CHAR", "VARCHAR", "TINYTEXT", "TEXT", "MEDIUMTEXT", "LONGTEXT"},
@@ -74,11 +64,13 @@ func TestIntegrationMySQL(t *testing.T) {
 	rowTransformer := mysqlQueryResultTransformer{}
 
 	logger := backend.NewLoggerWith("logger", "mysql.test")
-	exe, err := sqleng.NewQueryDataHandler(setting.NewCfg(), config, &rowTransformer, newMysqlMacroEngine(logger, setting.NewCfg()), logger)
+
+	db := InitMySQLTestDB(t, config.DSInfo.JsonData)
+
+	exe, err := sqleng.NewQueryDataHandler(setting.NewCfg(), db, config, &rowTransformer, newMysqlMacroEngine(logger, setting.NewCfg()), logger)
 
 	require.NoError(t, err)
 
-	db := x
 	fromStart := time.Date(2018, 3, 15, 13, 0, 0, 0, time.UTC)
 
 	t.Run("Given a table with different native data types", func(t *testing.T) {
@@ -1178,8 +1170,6 @@ func TestIntegrationMySQL(t *testing.T) {
 		t.Run("When row limit set to 1", func(t *testing.T) {
 			dsInfo := sqleng.DataSourceInfo{}
 			config := sqleng.DataPluginConfiguration{
-				DriverName:        "mysql",
-				ConnectionString:  "",
 				DSInfo:            dsInfo,
 				TimeColumnNames:   []string{"time", "time_sec"},
 				MetricColumnTypes: []string{"CHAR", "VARCHAR", "TINYTEXT", "TEXT", "MEDIUMTEXT", "LONGTEXT"},
@@ -1188,7 +1178,7 @@ func TestIntegrationMySQL(t *testing.T) {
 
 			queryResultTransformer := mysqlQueryResultTransformer{}
 
-			handler, err := sqleng.NewQueryDataHandler(setting.NewCfg(), config, &queryResultTransformer, newMysqlMacroEngine(logger, setting.NewCfg()), logger)
+			handler, err := sqleng.NewQueryDataHandler(setting.NewCfg(), db, config, &queryResultTransformer, newMysqlMacroEngine(logger, setting.NewCfg()), logger)
 			require.NoError(t, err)
 
 			t.Run("When doing a table query that returns 2 rows should limit the result to 1 row", func(t *testing.T) {
@@ -1290,14 +1280,18 @@ func TestIntegrationMySQL(t *testing.T) {
 	})
 }
 
-func InitMySQLTestDB(t *testing.T) *sql.DB {
+func InitMySQLTestDB(t *testing.T, jsonData sqleng.JsonData) *sql.DB {
 	connStr := mySQLTestDBConnStr()
-	x, err := sql.Open("mysql", connStr)
+	db, err := sql.Open("mysql", connStr)
 	if err != nil {
 		t.Fatalf("Failed to init mysql db %v", err)
 	}
 
-	return x
+	db.SetMaxOpenConns(jsonData.MaxOpenConns)
+	db.SetMaxIdleConns(jsonData.MaxIdleConns)
+	db.SetConnMaxLifetime(time.Duration(jsonData.ConnMaxLifetime) * time.Second)
+
+	return db
 }
 
 func genTimeRangeByInterval(from time.Time, duration time.Duration, interval time.Duration) []time.Time {


### PR DESCRIPTION
for the postgres datasource plugin, we have to switch the postgres-go-module to a different one (we go from `lib/pq` to `pgx`) ( see https://github.com/grafana/grafana/issues/79671) . there are some complications related to the proxy-code. so to make this easier, a minor refactoring is needed:

before:
- `sqleng` receives two strings, the database-driver-name (for example `mssql`), and the connection-string. `sqleng` then calls `sql.Open(driverName,connString)`, receives a `sql.DB` struct, and uses it.

after:
- the datasource-plugin itself (for example the mssql-plugin) calls `sql.Open` receives a `sql.DB` struct, and gives it to `sqleng`. the plugin can also do it in any other way they want, as long as they are able to create a `sql.DB` somehow.

why do we do this:
- main motivation is above, we need more flexibility in the the datasource-plugin with regard to the  creation of the `sql.DB` structure (this will allow us to do this (draft-pr):  https://github.com/grafana/grafana/pull/79398/commits/e04d6cab2b61091365e368dc5baf2ac17428a7af )
- this approach is very close to what https://github.com/grafana/sqlds does

(there will be a separate postgres-only PR after this one, that does the proxy-changes, using the API created here.)