### PR TITLE
Alerting: Small cleanup to remove mute timing as inheritable property

### DIFF
--- a/public/app/features/alerting/unified/components/notification-policies/Policy.tsx
+++ b/public/app/features/alerting/unified/components/notification-policies/Policy.tsx
@@ -589,8 +589,6 @@ const routePropertyToLabel = (key: keyof InhertitableProperties | string): strin
       return 'Group interval';
     case 'group_wait':
       return 'Group wait';
-    case 'mute_time_intervals':
-      return 'Mute timings';
     case 'repeat_interval':
       return 'Repeat interval';
     default:

--- a/public/app/features/alerting/unified/utils/notification-policies.ts
+++ b/public/app/features/alerting/unified/utils/notification-policies.ts
@@ -18,14 +18,8 @@ interface LabelMatchResult {
   matcher: ObjectMatcher | null;
 }
 
-export const INHERITABLE_PROPERTIES = [
-  'receiver',
-  'group_by',
-  'group_wait',
-  'group_interval',
-  'repeat_interval',
-] as const;
-export type InheritableKeys = typeof INHERITABLE_PROPERTIES;
+export const INHERITABLE_KEYS = ['receiver', 'group_by', 'group_wait', 'group_interval', 'repeat_interval'] as const;
+export type InheritableKeys = typeof INHERITABLE_KEYS;
 export type InhertitableProperties = Pick<Route, InheritableKeys[number]>;
 
 type LabelsMatch = Map<Label, LabelMatchResult>;
@@ -168,7 +162,7 @@ function getInheritedProperties(
 ) {
   const fullParentProperties = merge({}, parentRoute, propertiesParentInherited);
 
-  const inheritableProperties: InhertitableProperties = pick(fullParentProperties, INHERITABLE_PROPERTIES);
+  const inheritableProperties: InhertitableProperties = pick(fullParentProperties, INHERITABLE_KEYS);
 
   // TODO how to solve this TypeScript mystery?
   const inherited = reduce(

--- a/public/app/features/alerting/unified/utils/notification-policies.ts
+++ b/public/app/features/alerting/unified/utils/notification-policies.ts
@@ -18,6 +18,16 @@ interface LabelMatchResult {
   matcher: ObjectMatcher | null;
 }
 
+export const INHERITABLE_PROPERTIES = [
+  'receiver',
+  'group_by',
+  'group_wait',
+  'group_interval',
+  'repeat_interval',
+] as const;
+export type InheritableKeys = typeof INHERITABLE_PROPERTIES;
+export type InhertitableProperties = Pick<Route, InheritableKeys[number]>;
+
 type LabelsMatch = Map<Label, LabelMatchResult>;
 
 interface MatchingResult {
@@ -150,11 +160,6 @@ function findMatchingAlertGroups(
   }, matchingGroups);
 }
 
-export type InhertitableProperties = Pick<
-  Route,
-  'receiver' | 'group_by' | 'group_wait' | 'group_interval' | 'repeat_interval'
->;
-
 // inherited properties are config properties that exist on the parent route (or its inherited properties) but not on the child route
 function getInheritedProperties(
   parentRoute: Route,
@@ -163,13 +168,7 @@ function getInheritedProperties(
 ) {
   const fullParentProperties = merge({}, parentRoute, propertiesParentInherited);
 
-  const inheritableProperties: InhertitableProperties = pick(fullParentProperties, [
-    'receiver',
-    'group_by',
-    'group_wait',
-    'group_interval',
-    'repeat_interval',
-  ]);
+  const inheritableProperties: InhertitableProperties = pick(fullParentProperties, INHERITABLE_PROPERTIES);
 
   // TODO how to solve this TypeScript mystery?
   const inherited = reduce(

--- a/public/app/features/alerting/unified/utils/notification-policies.ts
+++ b/public/app/features/alerting/unified/utils/notification-policies.ts
@@ -152,7 +152,7 @@ function findMatchingAlertGroups(
 
 export type InhertitableProperties = Pick<
   Route,
-  'receiver' | 'group_by' | 'group_wait' | 'group_interval' | 'repeat_interval' | 'mute_time_intervals'
+  'receiver' | 'group_by' | 'group_wait' | 'group_interval' | 'repeat_interval'
 >;
 
 // inherited properties are config properties that exist on the parent route (or its inherited properties) but not on the child route


### PR DESCRIPTION
Small cleanup related to https://github.com/grafana/grafana/pull/79295 to remove some typing information and unreachable code.