### PR TITLE
Loki Logs volume: Added a query splitting loading indicator to the Logs Volume graph

### DIFF
--- a/public/app/features/explore/Logs/LogsVolumePanel.test.tsx
+++ b/public/app/features/explore/Logs/LogsVolumePanel.test.tsx
@@ -25,6 +25,7 @@ function renderPanel(logsVolumeData: DataQueryResponse) {
       onHiddenSeriesChanged={() => null}
       eventBus={new EventBusSrv()}
       allLogsVolumeMaximum={20}
+      annotations={[]}
     />
   );
 }

--- a/public/app/features/explore/Logs/LogsVolumePanel.tsx
+++ b/public/app/features/explore/Logs/LogsVolumePanel.tsx
@@ -10,6 +10,7 @@ import {
   TimeZone,
   EventBus,
   GrafanaTheme2,
+  DataFrame,
 } from '@grafana/data';
 import { Icon, Tooltip, TooltipDisplayMode, useStyles2, useTheme2 } from '@grafana/ui';
 
@@ -27,6 +28,7 @@ type Props = {
   onLoadLogsVolume: () => void;
   onHiddenSeriesChanged: (hiddenSeries: string[]) => void;
   eventBus: EventBus;
+  annotations: DataFrame[];
 };
 
 export function LogsVolumePanel(props: Props) {
@@ -80,6 +82,7 @@ export function LogsVolumePanel(props: Props) {
         anchorToZero
         yAxisMaximum={allLogsVolumeMaximum}
         eventBus={props.eventBus}
+        annotations={props.annotations}
       />
       {extraInfoComponent && <div className={styles.extraInfoContainer}>{extraInfoComponent}</div>}
     </div>

--- a/public/app/features/explore/Logs/LogsVolumePanelList.tsx
+++ b/public/app/features/explore/Logs/LogsVolumePanelList.tsx
@@ -6,6 +6,7 @@ import {
   AbsoluteTimeRange,
   DataFrame,
   DataQueryResponse,
+  DataTopic,
   EventBus,
   GrafanaTheme2,
   LoadingState,
@@ -49,9 +50,12 @@ export const LogsVolumePanelList = ({
     logVolumes,
     maximumValue: allLogsVolumeMaximumValue,
     maximumRange: allLogsVolumeMaximumRange,
+    annotations,
   } = useMemo(() => {
     let maximumValue = -Infinity;
-    const sorted = sortBy(logsVolumeData?.data || [], 'meta.custom.datasourceName');
+    const data = logsVolumeData?.data.filter((frame: DataFrame) => frame.meta?.dataTopic !== DataTopic.Annotations);
+    const annotations = logsVolumeData?.data.filter((frame: DataFrame) => frame.meta?.dataTopic === DataTopic.Annotations);
+    const sorted = sortBy(data || [], 'meta.custom.datasourceName');
     const grouped = groupBy(sorted, 'meta.custom.datasourceName');
     const logVolumes = mapValues(grouped, (value) => {
       const mergedData = mergeLogsVolumeDataFrames(value);
@@ -63,6 +67,7 @@ export const LogsVolumePanelList = ({
       maximumValue,
       maximumRange,
       logVolumes,
+      annotations,
     };
   }, [logsVolumeData]);
 
@@ -127,6 +132,7 @@ export const LogsVolumePanelList = ({
             // TODO: Support filtering level from multiple log levels
             onHiddenSeriesChanged={numberOfLogVolumes > 1 ? () => {} : onHiddenSeriesChanged}
             eventBus={eventBus}
+            annotations={annotations}
           />
         );
       })}

--- a/public/app/features/explore/Logs/LogsVolumePanelList.tsx
+++ b/public/app/features/explore/Logs/LogsVolumePanelList.tsx
@@ -54,7 +54,8 @@ export const LogsVolumePanelList = ({
   } = useMemo(() => {
     let maximumValue = -Infinity;
     const data = logsVolumeData?.data.filter((frame: DataFrame) => frame.meta?.dataTopic !== DataTopic.Annotations);
-    const annotations = logsVolumeData?.data.filter((frame: DataFrame) => frame.meta?.dataTopic === DataTopic.Annotations) || [];
+    const annotations =
+      logsVolumeData?.data.filter((frame: DataFrame) => frame.meta?.dataTopic === DataTopic.Annotations) || [];
     const sorted = sortBy(data || [], 'meta.custom.datasourceName');
     const grouped = groupBy(sorted, 'meta.custom.datasourceName');
     const logVolumes = mapValues(grouped, (value) => {

--- a/public/app/features/explore/Logs/LogsVolumePanelList.tsx
+++ b/public/app/features/explore/Logs/LogsVolumePanelList.tsx
@@ -54,7 +54,7 @@ export const LogsVolumePanelList = ({
   } = useMemo(() => {
     let maximumValue = -Infinity;
     const data = logsVolumeData?.data.filter((frame: DataFrame) => frame.meta?.dataTopic !== DataTopic.Annotations);
-    const annotations = logsVolumeData?.data.filter((frame: DataFrame) => frame.meta?.dataTopic === DataTopic.Annotations);
+    const annotations = logsVolumeData?.data.filter((frame: DataFrame) => frame.meta?.dataTopic === DataTopic.Annotations) || [];
     const sorted = sortBy(data || [], 'meta.custom.datasourceName');
     const grouped = groupBy(sorted, 'meta.custom.datasourceName');
     const logVolumes = mapValues(grouped, (value) => {

--- a/public/app/features/logs/logsModel.test.ts
+++ b/public/app/features/logs/logsModel.test.ts
@@ -1,10 +1,12 @@
 import { Observable } from 'rxjs';
 
 import {
+  arrayToDataFrame,
   DataFrame,
   DataQuery,
   DataQueryRequest,
   DataQueryResponse,
+  DataTopic,
   dateTimeParse,
   FieldType,
   LoadingState,
@@ -1282,6 +1284,33 @@ describe('logs volume', () => {
     ]);
   }
 
+  function setupLogsVolumeWithAnnotations() {
+    const resultAFrame1 = createFrame({ app: 'app01' }, [100, 200, 300], [5, 5, 5], 'A');
+    const loadingFrame = arrayToDataFrame([
+      {
+        time: 100,
+        timeEnd: 200,
+        isRegion: true,
+        color: 'rgba(120, 120, 120, 0.1)',
+      },
+    ]);
+    loadingFrame.name = 'annotation';
+    loadingFrame.meta = {
+      dataTopic: DataTopic.Annotations,
+    };
+
+    datasource = new MockObservableDataSourceApi('loki', [
+      {
+        state: LoadingState.Streaming,
+        data: [resultAFrame1, loadingFrame],
+      },
+      {
+        state: LoadingState.Done,
+        data: [resultAFrame1],
+      },
+    ]);
+  }
+
   function setupErrorResponse() {
     datasource = new MockObservableDataSourceApi('loki', [], undefined, 'Error message');
   }
@@ -1363,6 +1392,55 @@ describe('logs volume', () => {
       ]);
     });
   });
+
+  it('handles annotations in responses', async () => {
+    setup(setupLogsVolumeWithAnnotations);
+
+    const logVolumeCustomMeta: LogsVolumeCustomMetaData = {
+      sourceQuery: { refId: 'A', target: 'volume query 1' } as DataQuery,
+      datasourceName: 'loki',
+      logsVolumeType: LogsVolumeType.FullRange,
+      absoluteRange: {
+        from: FROM.valueOf(),
+        to: TO.valueOf(),
+      },
+    };
+
+    await expect(volumeProvider).toEmitValuesWith((received) => {
+      expect(received).toContainEqual({ state: LoadingState.Loading, error: undefined, data: [] });
+      expect(received).toContainEqual({
+        state: LoadingState.Streaming,
+        error: undefined,
+        data: [
+          expect.objectContaining({
+            fields: expect.anything(),
+            meta: {
+              custom: logVolumeCustomMeta,
+            },
+          }),
+          expect.objectContaining({
+            fields: expect.anything(),
+            meta: {
+              dataTopic: DataTopic.Annotations,
+            },
+            name: "annotation"
+          }),
+        ],
+      });
+      expect(received).toContainEqual({
+        state: LoadingState.Done,
+        error: undefined,
+        data: [
+          expect.objectContaining({
+            fields: expect.anything(),
+            meta: {
+              custom: logVolumeCustomMeta,
+            },
+          }),
+        ],
+      });
+    });
+  })
 });
 
 describe('logs sample', () => {

--- a/public/app/features/logs/logsModel.test.ts
+++ b/public/app/features/logs/logsModel.test.ts
@@ -1423,7 +1423,7 @@ describe('logs volume', () => {
             meta: {
               dataTopic: DataTopic.Annotations,
             },
-            name: "annotation"
+            name: 'annotation',
           }),
         ],
       });
@@ -1440,7 +1440,7 @@ describe('logs volume', () => {
         ],
       });
     });
-  })
+  });
 });
 
 describe('logs sample', () => {

--- a/public/app/features/logs/logsModel.ts
+++ b/public/app/features/logs/logsModel.ts
@@ -10,6 +10,7 @@ import {
   DataQueryResponse,
   DataSourceApi,
   DataSourceJsonData,
+  DataTopic,
   dateTimeFormat,
   dateTimeFormatTimeAgo,
   DateTimeInput,
@@ -658,6 +659,9 @@ export function queryLogsVolume<TQuery extends DataQuery, TOptions extends DataS
         } else {
           const framesByRefId = groupBy(dataQueryResponse.data, 'refId');
           logsVolumeData = dataQueryResponse.data.map((dataFrame) => {
+            if (dataFrame.meta?.dataTopic === DataTopic.Annotations) {
+              return dataFrame;
+            }
             let sourceRefId = dataFrame.refId || '';
             if (sourceRefId.startsWith('log-volume-')) {
               sourceRefId = sourceRefId.substr('log-volume-'.length);

--- a/public/app/features/logs/logsModel.ts
+++ b/public/app/features/logs/logsModel.ts
@@ -659,6 +659,7 @@ export function queryLogsVolume<TQuery extends DataQuery, TOptions extends DataS
         } else {
           const framesByRefId = groupBy(dataQueryResponse.data, 'refId');
           logsVolumeData = dataQueryResponse.data.map((dataFrame) => {
+            // Separate possible annotations from data frames
             if (dataFrame.meta?.dataTopic === DataTopic.Annotations) {
               return dataFrame;
             }

--- a/public/app/features/logs/utils.ts
+++ b/public/app/features/logs/utils.ts
@@ -169,10 +169,6 @@ export const getLogsVolumeMaximumRange = (dataFrames: DataFrame[]) => {
   let widestRange = { from: Infinity, to: -Infinity };
 
   dataFrames.forEach((dataFrame: DataFrame) => {
-    // Exclude annotations.
-    if (dataFrame.meta?.dataTopic === DataTopic.Annotations) {
-      return;
-    }
     const meta = dataFrame.meta?.custom || {};
     if (meta.absoluteRange?.from && meta.absoluteRange?.to) {
       widestRange = {

--- a/public/app/features/logs/utils.ts
+++ b/public/app/features/logs/utils.ts
@@ -13,7 +13,6 @@ import {
   MutableDataFrame,
   QueryResultMeta,
   LogsVolumeType,
-  DataTopic,
 } from '@grafana/data';
 
 import { getDataframeFields } from './components/logParser';

--- a/public/app/features/logs/utils.ts
+++ b/public/app/features/logs/utils.ts
@@ -13,6 +13,7 @@ import {
   MutableDataFrame,
   QueryResultMeta,
   LogsVolumeType,
+  DataTopic,
 } from '@grafana/data';
 
 import { getDataframeFields } from './components/logParser';
@@ -168,6 +169,10 @@ export const getLogsVolumeMaximumRange = (dataFrames: DataFrame[]) => {
   let widestRange = { from: Infinity, to: -Infinity };
 
   dataFrames.forEach((dataFrame: DataFrame) => {
+    // Exclude annotations.
+    if (dataFrame.meta?.dataTopic === DataTopic.Annotations) {
+      return;
+    }
     const meta = dataFrame.meta?.custom || {};
     if (meta.absoluteRange?.from && meta.absoluteRange?.to) {
       widestRange = {

--- a/public/app/plugins/datasource/loki/querySplitting.ts
+++ b/public/app/plugins/datasource/loki/querySplitting.ts
@@ -150,17 +150,18 @@ export function runSplitGroupedQueries(datasource: LokiDatasource, requests: Lok
   return response;
 }
 
+export const LOADING_FRAME_NAME = 'loki-splitting-progress';
+
 function updateLoadingFrame(
   response: DataQueryResponse,
   request: DataQueryRequest<LokiQuery>,
   partition: TimeRange[],
   requestN: number
 ): DataQueryResponse {
-  if (isLogsQuery(request.targets[0].expr) || isLogsVolumeRequest(request)) {
+  if (isLogsQuery(request.targets[0].expr)) {
     return response;
   }
-  const loadingFrameName = 'loki-splitting-progress';
-  response.data = response.data.filter((frame) => frame.name !== loadingFrameName);
+  response.data = response.data.filter((frame) => frame.name !== LOADING_FRAME_NAME);
 
   if (requestN <= 1) {
     return response;
@@ -174,7 +175,7 @@ function updateLoadingFrame(
       color: 'rgba(120, 120, 120, 0.1)',
     },
   ]);
-  loadingFrame.name = loadingFrameName;
+  loadingFrame.name = LOADING_FRAME_NAME;
   loadingFrame.meta = {
     dataTopic: DataTopic.Annotations,
   };
@@ -182,10 +183,6 @@ function updateLoadingFrame(
   response.data.push(loadingFrame);
 
   return response;
-}
-
-function isLogsVolumeRequest(request: DataQueryRequest<LokiQuery>): boolean {
-  return request.targets.some((target) => target.refId.startsWith('log-volume'));
 }
 
 function getNextRequestPointers(requests: LokiGroupedRequest[], requestGroup: number, requestN: number) {


### PR DESCRIPTION
Since the original implementation of query splitting we wanted to display a loading indicator for the paritioned log volume query, but time pressure and some bugs led to postpone it.

In a recent user interview we noticed how confusing it can be to see partial data in the logs volume graph, without a clue to wether it finished loading or not. Hence, we're adding support to the loading frame.

![2023-12-19 12 54 56](https://github.com/grafana/grafana/assets/1069378/f0ce2ad0-6fcc-4a1e-ad84-aec414b23d39)

**Why do we need this feature?**

Feature completion of query splitting.
Less paper cuts, less confusion, more transparency to users.

**Who is this feature for?**

Loki users.

**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/grafana/issues/77645

**Special notes for your reviewer:**

Please check that:
- Works as expected with single, multiple, mixed queries.
- It doesn't break anything unexpected.
