### PR TITLE
PanelQueryRunner: Fix loading state

### DIFF
--- a/public/app/features/query/state/PanelQueryRunner.ts
+++ b/public/app/features/query/state/PanelQueryRunner.ts
@@ -342,6 +342,7 @@ export class PanelQueryRunner {
         if (last != null) {
           let sameSeries = compareArrayValues(last.series ?? [], next.series ?? [], (a, b) => a === b);
           let sameAnnotations = compareArrayValues(last.annotations ?? [], next.annotations ?? [], (a, b) => a === b);
+          let sameState = last.state === next.state;
 
           if (sameSeries) {
             next.series = last.series;
@@ -351,7 +352,7 @@ export class PanelQueryRunner {
             next.annotations = last.annotations;
           }
 
-          if (sameSeries && sameAnnotations) {
+          if (sameSeries && sameAnnotations && sameState) {
             return;
           }
         }


### PR DESCRIPTION
https://github.com/grafana/grafana/pull/79257/ made some changes to optimize updates from PanelQueryRunner but missed comparing loading state property. 

