### PR TITLE
Alerting: Validate configuration for the remote Alertmanager struct

### DIFF
--- a/pkg/services/ngalert/ngalert.go
+++ b/pkg/services/ngalert/ngalert.go
@@ -179,7 +179,7 @@ func (ng *AlertNG) init() error {
 			externalAMCfg := remote.AlertmanagerConfig{}
 			// We won't be handling files on disk, we can pass an empty string as workingDirPath.
 			stateStore := notifier.NewFileStore(orgID, ng.KVStore, "")
-			return remote.NewAlertmanager(externalAMCfg, orgID, stateStore)
+			return remote.NewAlertmanager(externalAMCfg, stateStore)
 		})
 
 		overrides = append(overrides, override)

--- a/pkg/services/ngalert/remote/alertmanager_test.go
+++ b/pkg/services/ngalert/remote/alertmanager_test.go
@@ -138,6 +138,7 @@ func TestIntegrationRemoteAlertmanagerApplyConfigOnlyUploadsOnce(t *testing.T) {
 
 	// ApplyConfig performs a readiness check.
 	cfg := AlertmanagerConfig{
+		OrgID:             1,
 		URL:               amURL,
 		TenantID:          tenantID,
 		BasicAuthPassword: password,
@@ -253,6 +254,7 @@ func TestIntegrationRemoteAlertmanagerSilences(t *testing.T) {
 	password := os.Getenv("AM_PASSWORD")
 
 	cfg := AlertmanagerConfig{
+		OrgID:             1,
 		URL:               amURL,
 		TenantID:          tenantID,
 		BasicAuthPassword: password,
@@ -332,6 +334,7 @@ func TestIntegrationRemoteAlertmanagerAlerts(t *testing.T) {
 	password := os.Getenv("AM_PASSWORD")
 
 	cfg := AlertmanagerConfig{
+		OrgID:             1,
 		URL:               amURL,
 		TenantID:          tenantID,
 		BasicAuthPassword: password,
@@ -396,6 +399,7 @@ func TestIntegrationRemoteAlertmanagerReceivers(t *testing.T) {
 	password := os.Getenv("AM_PASSWORD")
 
 	cfg := AlertmanagerConfig{
+		OrgID:             1,
 		URL:               amURL,
 		TenantID:          tenantID,
 		BasicAuthPassword: password,

--- a/pkg/services/ngalert/remote/alertmanager_test.go
+++ b/pkg/services/ngalert/remote/alertmanager_test.go
@@ -95,8 +95,9 @@ func TestApplyConfig(t *testing.T) {
 	// A non-200 response should result in an error.
 	server := httptest.NewServer(errorHandler)
 	cfg := AlertmanagerConfig{
-		OrgID: 1,
-		URL:   server.URL,
+		OrgID:    1,
+		TenantID: "test",
+		URL:      server.URL,
 	}
 
 	ctx := context.Background()


### PR DESCRIPTION
This PR adds a `Validate()` method to the remote Alertmanager configuration. The OrgID is moved to that config struct too.