### PR TITLE
Loki: Replace pre-calculated $__interval values for backend interpolation 

### DIFF
--- a/public/app/plugins/datasource/loki/datasource.ts
+++ b/public/app/plugins/datasource/loki/datasource.ts
@@ -1085,10 +1085,21 @@ export class LokiDatasource
 
     const exprWithAdHoc = this.addAdHocFilters(target.expr, adhocFilters);
 
+    const variables = {
+      ...rest,
+
+      // pass through for backend interpolation. Need to be in scopedVars for Scenes though
+      __interval: {
+        value: '$__interval',
+      },
+      __interval_ms: {
+        value: '$__interval_ms',
+      },
+    };
     return {
       ...target,
       legendFormat: this.templateSrv.replace(target.legendFormat, rest),
-      expr: this.templateSrv.replace(exprWithAdHoc, rest, this.interpolateQueryExpr),
+      expr: this.templateSrv.replace(exprWithAdHoc, variables, this.interpolateQueryExpr),
     };
   }
 


### PR DESCRIPTION
Sister PR to https://github.com/grafana/grafana/pull/79645.

Need to have `$__interval` and `$__interval_ms` in `scopedVars` for Scenes to no-op interpolate them instead of using `TimeMacro`  and in some cases resolving to empty string.

Related: https://github.com/grafana/scenes/issues/507