### PR TITLE
chore: use our custom windows container for windows tests

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -3775,6 +3775,8 @@ steps:
   name: wire-install
 - commands:
   - go test -tags requires_buildifer -short -covermode=atomic -timeout=5m ./pkg/...
+  environment:
+    CGO_ENABLED: 1
   depends_on:
   - wire-install
   image: golang:1.21.5-windowsservercore-1809

--- a/.drone.yml
+++ b/.drone.yml
@@ -3779,7 +3779,7 @@ steps:
     CGO_ENABLED: 1
   depends_on:
   - wire-install
-  image: golang:1.21.5-windowsservercore-1809
+  image: grafana/ci-wix:0.1.1
   name: test-backend
 trigger:
   event:

--- a/.drone.yml
+++ b/.drone.yml
@@ -3775,10 +3775,10 @@ steps:
   name: wire-install
 - commands:
   - go test -tags requires_buildifer -short -covermode=atomic -timeout=5m ./pkg/...
-  environment:
-    CGO_ENABLED: 1
   depends_on:
   - wire-install
+  environment:
+    CGO_ENBABLED: 1
   image: grafana/ci-wix:0.1.1
   name: test-backend
 trigger:
@@ -4631,6 +4631,6 @@ kind: secret
 name: gcr_credentials
 ---
 kind: signature
-hmac: df80b5092eb1332e4cd0ea83df7011790bf745788f7f38a0571cd044319e07af
+hmac: 168b77f596eb556089649cbdaeb564fa9d54869a573446820fa220523b30c89d
 
 ...

--- a/scripts/drone/steps/lib_windows.star
+++ b/scripts/drone/steps/lib_windows.star
@@ -151,7 +151,8 @@ def test_backend_step_windows():
     # otherwise it creates an import cycle.
     return {
         "name": "test-backend",
-        "image": windows_images["go"],
+        "image": windows_images["wix"],
+        "environment": {"CGO_ENBABLED": 1},
         "depends_on": [
             "wire-install",
         ],


### PR DESCRIPTION
The sqlite package requires CGO enabled to compile, which isn't in the windows server docker image we were using. Grafana already has a [docker image](https://hub.docker.com/r/grafana/ci-wix) for this purpose, so let's try that next. We might need to update the image first - ours is 3 years old - but there's already [drone task](https://github.com/grafana/grafana/blob/main/.drone.yml#L4024) if we need to build a new image more frequently.


I only made this change in the step that runs `go test`, as that's the only place compilation is failing.