### PR TITLE
Annotation Service: Add DashboardUID in annotations table

### DIFF
--- a/pkg/api/annotations.go
+++ b/pkg/api/annotations.go
@@ -147,15 +147,16 @@ func (hs *HTTPServer) PostAnnotation(c *contextmodel.ReqContext) response.Respon
 	}
 
 	item := annotations.Item{
-		OrgID:       c.SignedInUser.GetOrgID(),
-		UserID:      userID,
-		DashboardID: cmd.DashboardId,
-		PanelID:     cmd.PanelId,
-		Epoch:       cmd.Time,
-		EpochEnd:    cmd.TimeEnd,
-		Text:        cmd.Text,
-		Data:        cmd.Data,
-		Tags:        cmd.Tags,
+		OrgID:        c.SignedInUser.GetOrgID(),
+		UserID:       userID,
+		DashboardID:  cmd.DashboardId,
+		DashboardUID: cmd.DashboardId, // to deprecate dashboarID
+		PanelID:      cmd.PanelId,
+		Epoch:        cmd.Time,
+		EpochEnd:     cmd.TimeEnd,
+		Text:         cmd.Text,
+		Data:         cmd.Data,
+		Tags:         cmd.Tags,
 	}
 
 	if err := hs.annotationsRepo.Save(c.Req.Context(), &item); err != nil {
@@ -439,9 +440,10 @@ func (hs *HTTPServer) MassDeleteAnnotations(c *contextmodel.ReqContext) response
 	} else {
 		dashboardId = cmd.DashboardId
 		deleteParams = &annotations.DeleteParams{
-			OrgID:       c.SignedInUser.GetOrgID(),
-			DashboardID: cmd.DashboardId,
-			PanelID:     cmd.PanelId,
+			OrgID:        c.SignedInUser.GetOrgID(),
+			DashboardID:  cmd.DashboardId,
+			DashboardUID: cmd.DashboardId, // to deplrecate dashboard ID
+			PanelID:      cmd.PanelId,
 		}
 	}
 

--- a/pkg/services/annotations/annotationsimpl/xorm_store.go
+++ b/pkg/services/annotations/annotationsimpl/xorm_store.go
@@ -426,6 +426,16 @@ func (r *xormRepositoryImpl) Delete(ctx context.Context, params *annotations.Del
 				return err
 			}
 
+			// part of deprecating dashboardID in favour dashboardUID
+			if _, err := sess.Exec(annoTagSQL, params.DashboardUID, params.PanelID, params.OrgID); err != nil {
+				return err
+			}
+
+			if _, err := sess.Exec(sql, params.DashboardID, params.PanelID, params.OrgID); err != nil {
+				return err
+			}
+
+			// part of deprecating dashboardID in favour dashboardUID
 			if _, err := sess.Exec(sql, params.DashboardID, params.PanelID, params.OrgID); err != nil {
 				return err
 			}

--- a/pkg/services/annotations/models.go
+++ b/pkg/services/annotations/models.go
@@ -12,7 +12,7 @@ type ItemQuery struct {
 	UserID       int64    `json:"userId"`
 	AlertID      int64    `json:"alertId"`
 	DashboardID  int64    `json:"dashboardId"`
-	DashboardUID string   `json:"dashboardUID"`
+	DashboardUID string   `json:"dashboardUID"` // to depprecate dashboardID
 	PanelID      int64    `json:"panelId"`
 	AnnotationID int64    `json:"annotationId"`
 	Tags         []string `json:"tags"`
@@ -70,28 +70,30 @@ type GetAnnotationTagsResponse struct {
 }
 
 type DeleteParams struct {
-	OrgID       int64
-	ID          int64
-	DashboardID int64
-	PanelID     int64
+	OrgID        int64
+	ID           int64
+	DashboardID  int64
+	DashboardUID int64 // to depprecate dashboardID
+	PanelID      int64
 }
 
 type Item struct {
-	ID          int64            `json:"id" xorm:"pk autoincr 'id'"`
-	OrgID       int64            `json:"orgId" xorm:"org_id"`
-	UserID      int64            `json:"userId" xorm:"user_id"`
-	DashboardID int64            `json:"dashboardId" xorm:"dashboard_id"`
-	PanelID     int64            `json:"panelId" xorm:"panel_id"`
-	Text        string           `json:"text"`
-	AlertID     int64            `json:"alertId" xorm:"alert_id"`
-	PrevState   string           `json:"prevState"`
-	NewState    string           `json:"newState"`
-	Epoch       int64            `json:"epoch"`
-	EpochEnd    int64            `json:"epochEnd"`
-	Created     int64            `json:"created"`
-	Updated     int64            `json:"updated"`
-	Tags        []string         `json:"tags"`
-	Data        *simplejson.Json `json:"data"`
+	ID           int64            `json:"id" xorm:"pk autoincr 'id'"`
+	OrgID        int64            `json:"orgId" xorm:"org_id"`
+	UserID       int64            `json:"userId" xorm:"user_id"`
+	DashboardID  int64            `json:"dashboardId" xorm:"dashboard_id"`
+	DashboardUID int64            `json:"dashboardUID" xorm:"dashboard_uid"` // to depprecate dashboardID
+	PanelID      int64            `json:"panelId" xorm:"panel_id"`
+	Text         string           `json:"text"`
+	AlertID      int64            `json:"alertId" xorm:"alert_id"`
+	PrevState    string           `json:"prevState"`
+	NewState     string           `json:"newState"`
+	Epoch        int64            `json:"epoch"`
+	EpochEnd     int64            `json:"epochEnd"`
+	Created      int64            `json:"created"`
+	Updated      int64            `json:"updated"`
+	Tags         []string         `json:"tags"`
+	Data         *simplejson.Json `json:"data"`
 
 	// needed until we remove it from db
 	Type  string

--- a/pkg/services/annotations/models.go
+++ b/pkg/services/annotations/models.go
@@ -12,7 +12,7 @@ type ItemQuery struct {
 	UserID       int64    `json:"userId"`
 	AlertID      int64    `json:"alertId"`
 	DashboardID  int64    `json:"dashboardId"`
-	DashboardUID string   `json:"dashboardUID"` // to depprecate dashboardID
+	DashboardUID string   `json:"dashboardUID"`
 	PanelID      int64    `json:"panelId"`
 	AnnotationID int64    `json:"annotationId"`
 	Tags         []string `json:"tags"`


### PR DESCRIPTION
Part of #78345

This is to add Dashboard UID wherever Dashboard ID is used for Annotation Service and eventually deprecate dashboard ID.

