### PR TITLE
Anonymous: Fix anonymous access needs anonymousEnabled in config to show in UI

### DIFF
--- a/public/app/features/admin/ServerStats.test.tsx
+++ b/public/app/features/admin/ServerStats.test.tsx
@@ -52,6 +52,7 @@ describe('ServerStats', () => {
 
   it('Should render page with anonymous stats', async () => {
     config.featureToggles.displayAnonymousStats = true;
+    config.anonymousEnabled = true;
     config.anonymousDeviceLimit = 10;
     render(<ServerStats />);
     expect(await screen.findByRole('heading', { name: /instance statistics/i })).toBeInTheDocument();

--- a/public/app/features/admin/ServerStats.tsx
+++ b/public/app/features/admin/ServerStats.tsx
@@ -100,7 +100,7 @@ export const ServerStats = () => {
 };
 
 const getAnonymousStatsContent = (stats: ServerStat | null, config: GrafanaBootConfig) => {
-  if (!config.featureToggles.displayAnonymousStats || !stats?.activeDevices) {
+  if (!config.anonymousEnabled || !config.featureToggles.displayAnonymousStats || !stats?.activeDevices) {
     return [];
   }
   if (!config.anonymousDeviceLimit) {

--- a/public/app/features/admin/UserListPage.tsx
+++ b/public/app/features/admin/UserListPage.tsx
@@ -78,7 +78,7 @@ export default function UserListPage() {
             onChangeTab={() => setView(TabView.ORG)}
             data-testid={selectors.tabs.orgUsers}
           />
-          {config.featureToggles.displayAnonymousStats && (
+          {config.anonymousEnabled && config.featureToggles.displayAnonymousStats && (
             <Tab
               label="Anonymous devices"
               active={view === TabView.ANON}


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**
This shows the UI for anonymous devices if the anonymous access is enabled. If we do not have this inplace, it means we always show the anonymous devices as a default.

```[auth.anonymous]
enabled = false
```
<img width="1042" alt="image" src="https://github.com/grafana/grafana/assets/7727602/c41fdb4f-b887-4eed-9aa5-6da7a84184e4">


```[auth.anonymous]
enabled = true
```
<img width="1043" alt="image" src="https://github.com/grafana/grafana/assets/7727602/3038895f-612d-4384-a664-c7b8129e1b37">
