### PR TITLE
Tracking: Report dash nowDelay and liveNow values

### DIFF
--- a/public/app/features/dashboard/utils/tracking.test.ts
+++ b/public/app/features/dashboard/utils/tracking.test.ts
@@ -25,6 +25,10 @@ describe('trackDashboardLoaded', () => {
           { type: 'query', name: 'Query 2' },
         ],
       },
+      timepicker: {
+        nowDelay: '1m',
+      },
+      liveNow: true,
     };
     const model = getDashboardModel(dashboardJSON);
     const reportInteractionSpy = jest.spyOn(runtime, 'reportInteraction');
@@ -45,6 +49,8 @@ describe('trackDashboardLoaded', () => {
       panel_type_timeseries_count: 1,
       'panel_type_grafana-worldmap-panel_count': 1,
       panel_type_geomap_count: 1,
+      settings_nowdelay: '1m',
+      settings_livenow: true,
     });
   });
 });

--- a/public/app/features/dashboard/utils/tracking.ts
+++ b/public/app/features/dashboard/utils/tracking.ts
@@ -28,6 +28,8 @@ export function trackDashboardLoaded(dashboard: DashboardModel, versionBeforeMig
     panels_count: dashboard.panels.length,
     ...panels,
     ...variables,
+    settings_nowdelay: dashboard.timepicker.nowDelay,
+    settings_livenow: !!dashboard.liveNow,
   });
 }
 


### PR DESCRIPTION
Track the usage of:
* nowDelay: Override the now time by entering a time delay. This option accommodates known delays in data aggregation to avoid null values.
* liveNow: Continuously re-draw panels where the time range references 'now'

Both options are stored in the dashboard schema and we don't have visibility about how many people is using this feature.