### PR TITLE
Prometheus: Fix sending time parameter for query result template variable request

### DIFF
--- a/public/app/plugins/datasource/prometheus/metric_find_query.test.ts
+++ b/public/app/plugins/datasource/prometheus/metric_find_query.test.ts
@@ -6,6 +6,7 @@ import { FetchResponse, TemplateSrv } from '@grafana/runtime';
 import { backendSrv } from 'app/core/services/backend_srv'; // will use the version in __mocks__
 
 import { PrometheusDatasource } from './datasource';
+import { getPrometheusTime } from './language_utils';
 import PrometheusMetricFindQuery from './metric_find_query';
 import { PromApplication, PromOptions } from './types';
 
@@ -250,6 +251,37 @@ describe('PrometheusMetricFindQuery', () => {
       expect(fetchMock).toHaveBeenCalledWith({
         method: 'GET',
         url: `/api/datasources/uid/ABCDEF/resources/api/v1/query?query=metric`,
+        headers: {},
+        hideFromInspector: true,
+        showErrorAlert: false,
+      });
+    });
+
+    it('query_result(metric) should pass time parameter to datasource.metric_find_query', async () => {
+      const query = setupMetricFindQuery({
+        query: 'query_result(metric)',
+        response: {
+          data: {
+            resultType: 'vector',
+            result: [
+              {
+                metric: { __name__: 'metric', job: 'testjob' },
+                value: [1443454528.0, '3846'],
+              },
+            ],
+          },
+        },
+      });
+      const results = await query.process(raw);
+
+      const expectedTime = getPrometheusTime(raw.to, true);
+
+      expect(results).toHaveLength(1);
+      expect(results[0].text).toBe('metric{job="testjob"} 3846 1443454528000');
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+      expect(fetchMock).toHaveBeenCalledWith({
+        method: 'GET',
+        url: `/api/datasources/uid/ABCDEF/resources/api/v1/query?query=metric&time=${expectedTime}`,
         headers: {},
         hideFromInspector: true,
         showErrorAlert: false,

--- a/public/app/plugins/datasource/prometheus/metric_find_query.test.ts
+++ b/public/app/plugins/datasource/prometheus/metric_find_query.test.ts
@@ -250,7 +250,7 @@ describe('PrometheusMetricFindQuery', () => {
       expect(fetchMock).toHaveBeenCalledTimes(1);
       expect(fetchMock).toHaveBeenCalledWith({
         method: 'GET',
-        url: `/api/datasources/uid/ABCDEF/resources/api/v1/query?query=metric`,
+        url: `/api/datasources/uid/ABCDEF/resources/api/v1/query?query=metric&time=${raw.to.unix()}`,
         headers: {},
         hideFromInspector: true,
         showErrorAlert: false,
@@ -304,7 +304,7 @@ describe('PrometheusMetricFindQuery', () => {
       expect(fetchMock).toHaveBeenCalledTimes(1);
       expect(fetchMock).toHaveBeenCalledWith({
         method: 'GET',
-        url: `/api/datasources/uid/ABCDEF/resources/api/v1/query?query=1%2B1`,
+        url: `/api/datasources/uid/ABCDEF/resources/api/v1/query?query=1%2B1&time=${raw.to.unix()}`,
         headers: {},
         hideFromInspector: true,
         showErrorAlert: false,

--- a/public/app/plugins/datasource/prometheus/metric_find_query.ts
+++ b/public/app/plugins/datasource/prometheus/metric_find_query.ts
@@ -139,6 +139,7 @@ export default class PrometheusMetricFindQuery {
     const url = '/api/v1/query';
     const params = {
       query,
+      time: getPrometheusTime(this.range.to, true).toString(),
     };
     return this.datasource.metadataRequest(url, params).then((result: any) => {
       switch (result.data.data.resultType) {


### PR DESCRIPTION
**What is this feature?**

The sending time parameter was accidentally removed in this PR https://github.com/grafana/grafana/pull/77316
This PR is fixing it. 

You can test the fix by

- set a time range in the past like from 12 December 2023 12:00:00 to 13 December 2023 12:00:00
- create a Prometheus template variable with "Query result type"
- see the time parameter is not being sent
- With the version before [this PR](https://github.com/grafana/grafana/pull/77316) we send the end timestamp always

