### PR TITLE
Chore: Remove gf-form in DashboardLinks

### DIFF
--- a/.betterer.results
+++ b/.betterer.results
@@ -7194,9 +7194,6 @@ exports[`no gf-form usage`] = {
       [0, 0, 0, "gf-form usage has been deprecated. Use a component from @grafana/ui or custom CSS instead.", "5381"],
       [0, 0, 0, "gf-form usage has been deprecated. Use a component from @grafana/ui or custom CSS instead.", "5381"]
     ],
-    "public/app/features/dashboard/components/SubMenu/DashboardLinks.tsx:5381": [
-      [0, 0, 0, "gf-form usage has been deprecated. Use a component from @grafana/ui or custom CSS instead.", "5381"]
-    ],
     "public/app/features/dashboard/components/SubMenu/SubMenuItems.tsx:5381": [
       [0, 0, 0, "gf-form usage has been deprecated. Use a component from @grafana/ui or custom CSS instead.", "5381"]
     ],

--- a/public/app/features/dashboard/components/SubMenu/DashboardLinks.tsx
+++ b/public/app/features/dashboard/components/SubMenu/DashboardLinks.tsx
@@ -55,7 +55,7 @@ export const DashboardLinks = ({ dashboard, links }: Props) => {
         );
 
         return (
-          <div key={key} className="gf-form" data-testid={selectors.components.DashboardLinks.container}>
+          <div key={key} data-testid={selectors.components.DashboardLinks.container}>
             {link.tooltip ? <Tooltip content={linkInfo.tooltip}>{linkElement}</Tooltip> : linkElement}
           </div>
         );


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

Removes a gf-form occurrence for the external dashboard link. This remove a 4px bottom padding, which displaces the entire submenu, hence causes inconsistency depending on if you have an external link or not.
**with gf-form**
![image](https://github.com/grafana/grafana/assets/1438972/7ebbecff-5529-4ec2-b754-78828eb1426f)

**no gf-form**
![image](https://github.com/grafana/grafana/assets/1438972/e94863af-fa2f-4b4f-ba02-65f9e94d4283)

**without external dashboard link**
![image](https://github.com/grafana/grafana/assets/1438972/2a6f8f83-bf6a-4cee-a244-3560d8a41c34)



**Why do we need this feature?**

Refer to #65513


