### PR TITLE
Chore: Start language provider only once in prometheus variable editor

### DIFF
--- a/public/app/plugins/datasource/prometheus/components/VariableQueryEditor.tsx
+++ b/public/app/plugins/datasource/prometheus/components/VariableQueryEditor.tsx
@@ -61,7 +61,8 @@ export const PromVariableQueryEditor = ({ onChange, query, datasource, range }: 
 
   useEffect(() => {
     datasource.languageProvider.start(range);
-  }, [datasource.languageProvider, range]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   useEffect(() => {
     if (!query) {


### PR DESCRIPTION
**What is this feature?**

Every change (even keystrokes) on the variable editor (name update, label update, description) causes a re-renders the whole editor. In the Prometheus template variable editor we call `languageProvider.start` method in `useEffect`. Each re-render triggers it. This PR is a workaround that we call `languageProvider.start` only once. 

**Why do we need this feature?**

To make less network calls on while we are creating/updating our template variables

**Who is this feature for?**

Prometheus users

### How to test
- create a Prometheus dashboard
- add a template variable
- open network tab on browser inspector
- change the name and see every keystroke causes 3 calls
- switch to this branch
- try again 