### PR TITLE
Alerting: Document that remote.alertmanager.url should not have any suffixes

### DIFF
--- a/conf/defaults.ini
+++ b/conf/defaults.ini
@@ -1264,11 +1264,12 @@ clean_upgrade = false
 enabled = false
 
 # URL of the remote Alertmanager that will replace the internal one.
+# This URL should be the root path, Grafana will automatically append an "/alertmanager" suffix for certain HTTP calls.
 # Required if `enabled` is set to `true`.
 url =
 
 # Tenant ID to use in requests to the Alertmanager.
-# It will also be used for the basic auth username.
+# It will also be used for the basic auth username if a password is configured.
 tenant =
 
 # Optional password for basic authentication.


### PR DESCRIPTION
This PR adds a comment to the `.ini` file for the `[remote.alertmanager][url]` configuration option saying that Grafana will append an `/alertmanager` suffix to any configured URL.

Freebie: explicitly saying that the tenantID will be used for basic auth only if there's a password.