### PR TITLE
Alerting: Fix reusing last url in tab when reopening a new tab in rule detail a…

### DIFF
--- a/public/app/features/alerting/unified/components/rules/RuleDetailsActionButtons.tsx
+++ b/public/app/features/alerting/unified/components/rules/RuleDetailsActionButtons.tsx
@@ -110,7 +110,7 @@ export const RuleDetailsActionButtons = ({ rule, rulesSource, isViewMode }: Prop
         key="explore"
         variant="primary"
         icon="chart-line"
-        target="__blank"
+        target="_blank"
         href={createExploreLink(rulesSource, rule.query)}
       >
         See graph
@@ -124,7 +124,7 @@ export const RuleDetailsActionButtons = ({ rule, rulesSource, isViewMode }: Prop
         key="runbook"
         variant="primary"
         icon="book"
-        target="__blank"
+        target="_blank"
         href={textUtil.sanitizeUrl(rule.annotations[Annotation.runbookURL])}
       >
         View runbook
@@ -140,7 +140,7 @@ export const RuleDetailsActionButtons = ({ rule, rulesSource, isViewMode }: Prop
           key="dashboard"
           variant="primary"
           icon="apps"
-          target="__blank"
+          target="_blank"
           href={`d/${encodeURIComponent(dashboardUID)}`}
         >
           Go to dashboard
@@ -154,7 +154,7 @@ export const RuleDetailsActionButtons = ({ rule, rulesSource, isViewMode }: Prop
             key="panel"
             variant="primary"
             icon="apps"
-            target="__blank"
+            target="_blank"
             href={`d/${encodeURIComponent(dashboardUID)}?viewPanel=${encodeURIComponent(panelId)}`}
           >
             Go to panel
@@ -170,7 +170,7 @@ export const RuleDetailsActionButtons = ({ rule, rulesSource, isViewMode }: Prop
         size="sm"
         key="silence"
         icon="bell-slash"
-        target="__blank"
+        target="_blank"
         href={makeRuleBasedSilenceLink(alertmanagerSourceName, rule)}
       >
         Silence


### PR DESCRIPTION
**What is this feature?**

This PR fixes some buttons reusing the last url in the tab recently opened instead of opening the url assigned to these `hrefs`
In particular this happened when accessing the alerting list page on an instance and clicking:

- See Graph
- Go to dashboard
- Go to panel 
- Silence

The problem was we were using `__blank` instead of `_blank` , so the new tab was reusing this existing `__blank` named tab instead of opening a new one (as `_blank` option does).

**Who is this feature for?**

All users.

**Special notes for your reviewer:**

Before the fix:

https://github.com/grafana/grafana/assets/33540275/692bd530-791f-4b35-bb1c-59e8f4d94089

After the fix:

https://github.com/grafana/grafana/assets/33540275/877d1c1b-7785-41f1-b838-a82874dd3e51



Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
