### PR TITLE
Alerting: Update provisioning services that handle Alertmanager configuraiton to access config via storage

### DIFF
--- a/pkg/services/ngalert/provisioning/config.go
+++ b/pkg/services/ngalert/provisioning/config.go
@@ -3,15 +3,15 @@ package provisioning
 import (
 	"context"
 	"encoding/json"
-	"fmt"
 
 	"github.com/grafana/grafana/pkg/services/ngalert/api/tooling/definitions"
+	"github.com/grafana/grafana/pkg/services/ngalert/models"
 )
 
 func deserializeAlertmanagerConfig(config []byte) (*definitions.PostableUserConfig, error) {
 	result := definitions.PostableUserConfig{}
 	if err := json.Unmarshal(config, &result); err != nil {
-		return nil, fmt.Errorf("failed to deserialize alertmanager configuration: %w", err)
+		return nil, makeErrBadAlertmanagerConfiguration(err)
 	}
 	return &result, nil
 }
@@ -33,7 +33,7 @@ func getLastConfiguration(ctx context.Context, orgID int64, store AMConfigStore)
 	}
 
 	if alertManagerConfig == nil {
-		return nil, fmt.Errorf("no alertmanager configuration present in this org")
+		return nil, ErrNoAlertmanagerConfiguration.Errorf("")
 	}
 
 	concurrencyToken := alertManagerConfig.ConfigurationHash
@@ -47,4 +47,43 @@ func getLastConfiguration(ctx context.Context, orgID int64, store AMConfigStore)
 		concurrencyToken: concurrencyToken,
 		version:          alertManagerConfig.ConfigurationVersion,
 	}, nil
+}
+
+type alertmanagerConfigStore interface {
+	Get(ctx context.Context, orgID int64) (*cfgRevision, error)
+	Save(ctx context.Context, revision *cfgRevision, orgID int64, afterSave func(ctx context.Context) error) error
+}
+
+type alertmanagerConfigStoreImpl struct {
+	store AMConfigStore
+	xact  TransactionManager
+}
+
+func (a alertmanagerConfigStoreImpl) Get(ctx context.Context, orgID int64) (*cfgRevision, error) {
+	return getLastConfiguration(ctx, orgID, a.store)
+}
+
+func (a alertmanagerConfigStoreImpl) Save(ctx context.Context, revision *cfgRevision, orgID int64, afterSave func(ctx context.Context) error) error {
+	serialized, err := serializeAlertmanagerConfig(*revision.cfg)
+	if err != nil {
+		return err
+	}
+	cmd := models.SaveAlertmanagerConfigurationCmd{
+		AlertmanagerConfiguration: string(serialized),
+		ConfigurationVersion:      revision.version,
+		FetchedConfigurationHash:  revision.concurrencyToken,
+		Default:                   false,
+		OrgID:                     orgID,
+	}
+	return a.xact.InTransaction(ctx, func(ctx context.Context) error {
+		err = PersistConfig(ctx, a.store, &cmd)
+		if err != nil {
+			return err
+		}
+		err = afterSave(ctx)
+		if err != nil {
+			return err
+		}
+		return nil
+	})
 }

--- a/pkg/services/ngalert/provisioning/config.go
+++ b/pkg/services/ngalert/provisioning/config.go
@@ -49,11 +49,6 @@ func getLastConfiguration(ctx context.Context, orgID int64, store AMConfigStore)
 	}, nil
 }
 
-type alertmanagerConfigStore interface {
-	Get(ctx context.Context, orgID int64) (*cfgRevision, error)
-	Save(ctx context.Context, revision *cfgRevision, orgID int64) error
-}
-
 type alertmanagerConfigStoreImpl struct {
 	store AMConfigStore
 }

--- a/pkg/services/ngalert/provisioning/config_test.go
+++ b/pkg/services/ngalert/provisioning/config_test.go
@@ -1,0 +1,176 @@
+package provisioning
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/grafana/pkg/services/ngalert/api/tooling/definitions"
+	"github.com/grafana/grafana/pkg/services/ngalert/models"
+)
+
+func TestAlertmanagerConfigStoreGet(t *testing.T) {
+	orgID := int64(1)
+
+	t.Run("should read the latest config for giving organization", func(t *testing.T) {
+		storeMock := &MockAMConfigStore{}
+		store := &alertmanagerConfigStoreImpl{
+			store: storeMock,
+			xact:  newNopTransactionManager(),
+		}
+
+		expected := models.AlertConfiguration{
+			ID:                        1,
+			AlertmanagerConfiguration: defaultConfig,
+			ConfigurationHash:         "config-hash-123",
+			ConfigurationVersion:      "123",
+			CreatedAt:                 time.Now().Unix(),
+			Default:                   false,
+			OrgID:                     orgID,
+		}
+
+		expectedCfg := definitions.PostableUserConfig{}
+		require.NoError(t, json.Unmarshal([]byte(defaultConfig), &expectedCfg))
+
+		storeMock.EXPECT().GetLatestAlertmanagerConfiguration(mock.Anything, mock.Anything).Return(&expected, nil)
+
+		revision, err := store.Get(context.Background(), orgID)
+		require.NoError(t, err)
+
+		require.Equal(t, expected.ConfigurationVersion, revision.version)
+		require.Equal(t, expected.ConfigurationHash, revision.concurrencyToken)
+		require.Equal(t, expectedCfg, *revision.cfg)
+
+		storeMock.AssertCalled(t, "GetLatestAlertmanagerConfiguration", mock.Anything, orgID)
+	})
+
+	t.Run("propagate errors", func(t *testing.T) {
+		t.Run("when underlying store fails", func(t *testing.T) {
+			storeMock := &MockAMConfigStore{}
+			store := &alertmanagerConfigStoreImpl{
+				store: storeMock,
+				xact:  newNopTransactionManager(),
+			}
+			expectedErr := errors.New("test=err")
+			storeMock.EXPECT().GetLatestAlertmanagerConfiguration(mock.Anything, mock.Anything).Return(nil, expectedErr)
+
+			_, err := store.Get(context.Background(), orgID)
+			require.ErrorIs(t, err, expectedErr)
+		})
+
+		t.Run("return ErrNoAlertmanagerConfiguration config does not exist", func(t *testing.T) {
+			storeMock := &MockAMConfigStore{}
+			store := &alertmanagerConfigStoreImpl{
+				store: storeMock,
+				xact:  newNopTransactionManager(),
+			}
+			storeMock.EXPECT().GetLatestAlertmanagerConfiguration(mock.Anything, mock.Anything).Return(nil, nil)
+
+			_, err := store.Get(context.Background(), orgID)
+			require.Truef(t, ErrNoAlertmanagerConfiguration.Is(err), "expected ErrNoAlertmanagerConfiguration but got %s", err.Error())
+		})
+
+		t.Run("when config cannot be unmarshalled", func(t *testing.T) {
+			storeMock := &MockAMConfigStore{}
+			store := &alertmanagerConfigStoreImpl{
+				store: storeMock,
+				xact:  newNopTransactionManager(),
+			}
+			storeMock.EXPECT().GetLatestAlertmanagerConfiguration(mock.Anything, mock.Anything).Return(&models.AlertConfiguration{
+				AlertmanagerConfiguration: "invalid-json",
+			}, nil)
+
+			_, err := store.Get(context.Background(), orgID)
+			require.Truef(t, ErrBadAlertmanagerConfiguration.Base.Is(err), "expected ErrBadAlertmanagerConfiguration but got %s", err.Error())
+		})
+	})
+}
+
+func TestAlertmanagerConfigStoreSave(t *testing.T) {
+	orgID := int64(1)
+
+	cfg := definitions.PostableUserConfig{}
+	require.NoError(t, json.Unmarshal([]byte(defaultConfig), &cfg))
+	expectedCfg, err := serializeAlertmanagerConfig(cfg)
+	require.NoError(t, err)
+
+	revision := cfgRevision{
+		cfg:              &cfg,
+		concurrencyToken: "config-hash-123",
+		version:          "123",
+	}
+
+	t.Run("should save the config to store", func(t *testing.T) {
+		storeMock := &MockAMConfigStore{}
+		store := &alertmanagerConfigStoreImpl{
+			store: storeMock,
+			xact:  newNopTransactionManager(),
+		}
+
+		storeMock.EXPECT().UpdateAlertmanagerConfiguration(mock.Anything, mock.Anything).RunAndReturn(func(ctx context.Context, cmd *models.SaveAlertmanagerConfigurationCmd) error {
+			assertInTransaction(t, ctx)
+			assert.Equal(t, string(expectedCfg), cmd.AlertmanagerConfiguration)
+			assert.Equal(t, orgID, cmd.OrgID)
+			assert.Equal(t, revision.version, cmd.ConfigurationVersion)
+			assert.Equal(t, false, cmd.Default)
+			assert.Equal(t, revision.concurrencyToken, cmd.FetchedConfigurationHash)
+			return nil
+		})
+
+		afterExecuted := false
+		err := store.Save(context.Background(), &revision, orgID, func(ctx context.Context) error {
+			assertInTransaction(t, ctx)
+			afterExecuted = true
+			return nil
+		})
+		require.NoError(t, err)
+		assert.Truef(t, afterExecuted, "callback was supposed to be executed but it was not")
+
+		storeMock.AssertCalled(t, "UpdateAlertmanagerConfiguration", mock.Anything, mock.Anything)
+	})
+
+	t.Run("propagates errors", func(t *testing.T) {
+		t.Run("when underlying storage returns error", func(t *testing.T) {
+			storeMock := &MockAMConfigStore{}
+			store := &alertmanagerConfigStoreImpl{
+				store: storeMock,
+				xact:  newNopTransactionManager(),
+			}
+
+			expectedErr := errors.New("test-err")
+			storeMock.EXPECT().UpdateAlertmanagerConfiguration(mock.Anything, mock.Anything).Return(expectedErr)
+
+			err := store.Save(context.Background(), &revision, orgID, func(ctx context.Context) error {
+				assert.Fail(t, "callback should not be executed")
+				return nil
+			})
+
+			require.ErrorIs(t, err, expectedErr)
+		})
+
+		t.Run("when callback returns error", func(t *testing.T) {
+			storeMock := &MockAMConfigStore{}
+			store := &alertmanagerConfigStoreImpl{
+				store: storeMock,
+				xact:  newNopTransactionManager(),
+			}
+
+			storeMock.EXPECT().UpdateAlertmanagerConfiguration(mock.Anything, mock.Anything).Return(nil)
+
+			expectedErr := errors.New("test-err")
+			err := store.Save(context.Background(), &revision, orgID, func(ctx context.Context) error {
+				return expectedErr
+			})
+
+			require.ErrorIs(t, err, expectedErr)
+
+			storeMock.AssertCalled(t, "UpdateAlertmanagerConfiguration", mock.Anything, mock.Anything) // assert that the callback executed after this method
+		})
+	})
+}

--- a/pkg/services/ngalert/provisioning/contactpoints_test.go
+++ b/pkg/services/ngalert/provisioning/contactpoints_test.go
@@ -239,14 +239,14 @@ func TestContactPointService(t *testing.T) {
 	t.Run("service respects concurrency token when updating", func(t *testing.T) {
 		sut := createContactPointServiceSut(t, secretsService)
 		newCp := createTestContactPoint()
-		config, err := sut.amStore.GetLatestAlertmanagerConfiguration(context.Background(), 1)
+		config, err := sut.config.store.GetLatestAlertmanagerConfiguration(context.Background(), 1)
 		require.NoError(t, err)
 		expectedConcurrencyToken := config.ConfigurationHash
 
 		_, err = sut.CreateContactPoint(context.Background(), 1, newCp, models.ProvenanceAPI)
 		require.NoError(t, err)
 
-		fake := sut.amStore.(*fakeAMConfigStore)
+		fake := sut.config.store.(*fakeAMConfigStore)
 		intercepted := fake.lastSaveCommand
 		require.Equal(t, expectedConcurrencyToken, intercepted.FetchedConfigurationHash)
 	})
@@ -349,9 +349,8 @@ func createContactPointServiceSut(t *testing.T, secretService secrets.Service) *
 	require.NoError(t, err)
 
 	return &ContactPointService{
-		amStore:           newFakeAMConfigStore(string(raw)),
+		config:            &alertmanagerConfigStoreImpl{store: newFakeAMConfigStore(string(raw)), xact: newNopTransactionManager()},
 		provenanceStore:   NewFakeProvisioningStore(),
-		xact:              newNopTransactionManager(),
 		encryptionService: secretService,
 		log:               log.NewNopLogger(),
 		ac:                actest.FakeAccessControl{},

--- a/pkg/services/ngalert/provisioning/errors.go
+++ b/pkg/services/ngalert/provisioning/errors.go
@@ -3,8 +3,26 @@ package provisioning
 import (
 	"errors"
 	"fmt"
+
+	"github.com/grafana/grafana/pkg/util/errutil"
 )
 
 var ErrValidation = fmt.Errorf("invalid object specification")
 var ErrNotFound = fmt.Errorf("object not found")
 var ErrPermissionDenied = errors.New("permission denied")
+
+var (
+	ErrNoAlertmanagerConfiguration  = errutil.Internal("alerting.notification.configMissing", errutil.WithPublicMessage("No alertmanager configuration present in this organization"))
+	ErrBadAlertmanagerConfiguration = errutil.Internal("alerting.notification.configCorrupted").MustTemplate("Failed to unmarshall the Alertmanager configuration", errutil.WithPublic("Current Alertmanager configuration in the storage is corrupted. Reset the configuration or rollback to the recent valid one."))
+)
+
+func makeErrBadAlertmanagerConfiguration(err error) error {
+	data := errutil.TemplateData{
+		Public: map[string]interface{}{
+			"Error": err.Error(),
+		},
+		Error: err,
+	}
+
+	return ErrBadAlertmanagerConfiguration.Build(data)
+}

--- a/pkg/services/ngalert/provisioning/errors.go
+++ b/pkg/services/ngalert/provisioning/errors.go
@@ -13,7 +13,7 @@ var ErrPermissionDenied = errors.New("permission denied")
 
 var (
 	ErrNoAlertmanagerConfiguration  = errutil.Internal("alerting.notification.configMissing", errutil.WithPublicMessage("No alertmanager configuration present in this organization"))
-	ErrBadAlertmanagerConfiguration = errutil.Internal("alerting.notification.configCorrupted").MustTemplate("Failed to unmarshall the Alertmanager configuration", errutil.WithPublic("Current Alertmanager configuration in the storage is corrupted. Reset the configuration or rollback to the recent valid one."))
+	ErrBadAlertmanagerConfiguration = errutil.Internal("alerting.notification.configCorrupted").MustTemplate("Failed to unmarshal the Alertmanager configuration", errutil.WithPublic("Current Alertmanager configuration in the storage is corrupted. Reset the configuration or rollback to a recent valid one."))
 )
 
 func makeErrBadAlertmanagerConfiguration(err error) error {

--- a/pkg/services/ngalert/provisioning/mute_timings_test.go
+++ b/pkg/services/ngalert/provisioning/mute_timings_test.go
@@ -17,7 +17,7 @@ import (
 func TestMuteTimingService(t *testing.T) {
 	t.Run("service returns timings from config file", func(t *testing.T) {
 		sut := createMuteTimingSvcSut()
-		sut.config.(*MockAMConfigStore).EXPECT().
+		sut.config.store.(*MockAMConfigStore).EXPECT().
 			GetsConfig(models.AlertConfiguration{
 				AlertmanagerConfiguration: configWithMuteTimings,
 			})
@@ -31,7 +31,7 @@ func TestMuteTimingService(t *testing.T) {
 
 	t.Run("service returns empty list when config file contains no mute timings", func(t *testing.T) {
 		sut := createMuteTimingSvcSut()
-		sut.config.(*MockAMConfigStore).EXPECT().
+		sut.config.store.(*MockAMConfigStore).EXPECT().
 			GetsConfig(models.AlertConfiguration{
 				AlertmanagerConfiguration: defaultConfig,
 			})
@@ -45,7 +45,7 @@ func TestMuteTimingService(t *testing.T) {
 	t.Run("service propagates errors", func(t *testing.T) {
 		t.Run("when unable to read config", func(t *testing.T) {
 			sut := createMuteTimingSvcSut()
-			sut.config.(*MockAMConfigStore).EXPECT().
+			sut.config.store.(*MockAMConfigStore).EXPECT().
 				GetLatestAlertmanagerConfiguration(mock.Anything, mock.Anything).
 				Return(nil, fmt.Errorf("failed"))
 
@@ -56,25 +56,25 @@ func TestMuteTimingService(t *testing.T) {
 
 		t.Run("when config is invalid", func(t *testing.T) {
 			sut := createMuteTimingSvcSut()
-			sut.config.(*MockAMConfigStore).EXPECT().
+			sut.config.store.(*MockAMConfigStore).EXPECT().
 				GetsConfig(models.AlertConfiguration{
 					AlertmanagerConfiguration: brokenConfig,
 				})
 
 			_, err := sut.GetMuteTimings(context.Background(), 1)
 
-			require.ErrorContains(t, err, "failed to deserialize")
+			require.Truef(t, ErrBadAlertmanagerConfiguration.Base.Is(err), "expected ErrBadAlertmanagerConfiguration but got %s", err.Error())
 		})
 
 		t.Run("when no AM config in current org", func(t *testing.T) {
 			sut := createMuteTimingSvcSut()
-			sut.config.(*MockAMConfigStore).EXPECT().
+			sut.config.store.(*MockAMConfigStore).EXPECT().
 				GetLatestAlertmanagerConfiguration(mock.Anything, mock.Anything).
 				Return(nil, nil)
 
 			_, err := sut.GetMuteTimings(context.Background(), 1)
 
-			require.ErrorContains(t, err, "no alertmanager configuration")
+			require.Truef(t, ErrNoAlertmanagerConfiguration.Is(err), "expected ErrNoAlertmanagerConfiguration but got %s", err.Error())
 		})
 	})
 
@@ -96,7 +96,7 @@ func TestMuteTimingService(t *testing.T) {
 			t.Run("when unable to read config", func(t *testing.T) {
 				sut := createMuteTimingSvcSut()
 				timing := createMuteTiming()
-				sut.config.(*MockAMConfigStore).EXPECT().
+				sut.config.store.(*MockAMConfigStore).EXPECT().
 					GetLatestAlertmanagerConfiguration(mock.Anything, mock.Anything).
 					Return(nil, fmt.Errorf("failed"))
 
@@ -108,36 +108,36 @@ func TestMuteTimingService(t *testing.T) {
 			t.Run("when config is invalid", func(t *testing.T) {
 				sut := createMuteTimingSvcSut()
 				timing := createMuteTiming()
-				sut.config.(*MockAMConfigStore).EXPECT().
+				sut.config.store.(*MockAMConfigStore).EXPECT().
 					GetsConfig(models.AlertConfiguration{
 						AlertmanagerConfiguration: brokenConfig,
 					})
 
 				_, err := sut.CreateMuteTiming(context.Background(), timing, 1)
 
-				require.ErrorContains(t, err, "failed to deserialize")
+				require.Truef(t, ErrBadAlertmanagerConfiguration.Base.Is(err), "expected ErrBadAlertmanagerConfiguration but got %s", err.Error())
 			})
 
 			t.Run("when no AM config in current org", func(t *testing.T) {
 				sut := createMuteTimingSvcSut()
 				timing := createMuteTiming()
-				sut.config.(*MockAMConfigStore).EXPECT().
+				sut.config.store.(*MockAMConfigStore).EXPECT().
 					GetLatestAlertmanagerConfiguration(mock.Anything, mock.Anything).
 					Return(nil, nil)
 
 				_, err := sut.CreateMuteTiming(context.Background(), timing, 1)
 
-				require.ErrorContains(t, err, "no alertmanager configuration")
+				require.Truef(t, ErrNoAlertmanagerConfiguration.Is(err), "expected ErrNoAlertmanagerConfiguration but got %s", err.Error())
 			})
 
 			t.Run("when provenance fails to save", func(t *testing.T) {
 				sut := createMuteTimingSvcSut()
 				timing := createMuteTiming()
-				sut.config.(*MockAMConfigStore).EXPECT().
+				sut.config.store.(*MockAMConfigStore).EXPECT().
 					GetsConfig(models.AlertConfiguration{
 						AlertmanagerConfiguration: configWithMuteTimings,
 					})
-				sut.config.(*MockAMConfigStore).EXPECT().SaveSucceeds()
+				sut.config.store.(*MockAMConfigStore).EXPECT().SaveSucceeds()
 				sut.prov.(*MockProvisioningStore).EXPECT().
 					SetProvenance(mock.Anything, mock.Anything, mock.Anything, mock.Anything).
 					Return(fmt.Errorf("failed to save provenance"))
@@ -150,11 +150,11 @@ func TestMuteTimingService(t *testing.T) {
 			t.Run("when AM config fails to save", func(t *testing.T) {
 				sut := createMuteTimingSvcSut()
 				timing := createMuteTiming()
-				sut.config.(*MockAMConfigStore).EXPECT().
+				sut.config.store.(*MockAMConfigStore).EXPECT().
 					GetsConfig(models.AlertConfiguration{
 						AlertmanagerConfiguration: configWithMuteTimings,
 					})
-				sut.config.(*MockAMConfigStore).EXPECT().
+				sut.config.store.(*MockAMConfigStore).EXPECT().
 					UpdateAlertmanagerConfiguration(mock.Anything, mock.Anything).
 					Return(fmt.Errorf("failed to save config"))
 				sut.prov.(*MockProvisioningStore).EXPECT().SaveSucceeds()
@@ -184,11 +184,11 @@ func TestMuteTimingService(t *testing.T) {
 			sut := createMuteTimingSvcSut()
 			timing := createMuteTiming()
 			timing.Name = "does not exist"
-			sut.config.(*MockAMConfigStore).EXPECT().
+			sut.config.store.(*MockAMConfigStore).EXPECT().
 				GetsConfig(models.AlertConfiguration{
 					AlertmanagerConfiguration: configWithMuteTimings,
 				})
-			sut.config.(*MockAMConfigStore).EXPECT().SaveSucceeds()
+			sut.config.store.(*MockAMConfigStore).EXPECT().SaveSucceeds()
 			sut.prov.(*MockProvisioningStore).EXPECT().SaveSucceeds()
 
 			updated, err := sut.UpdateMuteTiming(context.Background(), timing, 1)
@@ -202,7 +202,7 @@ func TestMuteTimingService(t *testing.T) {
 				sut := createMuteTimingSvcSut()
 				timing := createMuteTiming()
 				timing.Name = "asdf"
-				sut.config.(*MockAMConfigStore).EXPECT().
+				sut.config.store.(*MockAMConfigStore).EXPECT().
 					GetLatestAlertmanagerConfiguration(mock.Anything, mock.Anything).
 					Return(nil, fmt.Errorf("failed"))
 
@@ -215,38 +215,38 @@ func TestMuteTimingService(t *testing.T) {
 				sut := createMuteTimingSvcSut()
 				timing := createMuteTiming()
 				timing.Name = "asdf"
-				sut.config.(*MockAMConfigStore).EXPECT().
+				sut.config.store.(*MockAMConfigStore).EXPECT().
 					GetsConfig(models.AlertConfiguration{
 						AlertmanagerConfiguration: brokenConfig,
 					})
 
 				_, err := sut.UpdateMuteTiming(context.Background(), timing, 1)
 
-				require.ErrorContains(t, err, "failed to deserialize")
+				require.Truef(t, ErrBadAlertmanagerConfiguration.Base.Is(err), "expected ErrBadAlertmanagerConfiguration but got %s", err.Error())
 			})
 
 			t.Run("when no AM config in current org", func(t *testing.T) {
 				sut := createMuteTimingSvcSut()
 				timing := createMuteTiming()
 				timing.Name = "asdf"
-				sut.config.(*MockAMConfigStore).EXPECT().
+				sut.config.store.(*MockAMConfigStore).EXPECT().
 					GetLatestAlertmanagerConfiguration(mock.Anything, mock.Anything).
 					Return(nil, nil)
 
 				_, err := sut.UpdateMuteTiming(context.Background(), timing, 1)
 
-				require.ErrorContains(t, err, "no alertmanager configuration")
+				require.Truef(t, ErrNoAlertmanagerConfiguration.Is(err), "expected ErrNoAlertmanagerConfiguration but got %s", err.Error())
 			})
 
 			t.Run("when provenance fails to save", func(t *testing.T) {
 				sut := createMuteTimingSvcSut()
 				timing := createMuteTiming()
 				timing.Name = "asdf"
-				sut.config.(*MockAMConfigStore).EXPECT().
+				sut.config.store.(*MockAMConfigStore).EXPECT().
 					GetsConfig(models.AlertConfiguration{
 						AlertmanagerConfiguration: configWithMuteTimings,
 					})
-				sut.config.(*MockAMConfigStore).EXPECT().SaveSucceeds()
+				sut.config.store.(*MockAMConfigStore).EXPECT().SaveSucceeds()
 				sut.prov.(*MockProvisioningStore).EXPECT().
 					SetProvenance(mock.Anything, mock.Anything, mock.Anything, mock.Anything).
 					Return(fmt.Errorf("failed to save provenance"))
@@ -260,11 +260,11 @@ func TestMuteTimingService(t *testing.T) {
 				sut := createMuteTimingSvcSut()
 				timing := createMuteTiming()
 				timing.Name = "asdf"
-				sut.config.(*MockAMConfigStore).EXPECT().
+				sut.config.store.(*MockAMConfigStore).EXPECT().
 					GetsConfig(models.AlertConfiguration{
 						AlertmanagerConfiguration: configWithMuteTimings,
 					})
-				sut.config.(*MockAMConfigStore).EXPECT().
+				sut.config.store.(*MockAMConfigStore).EXPECT().
 					UpdateAlertmanagerConfiguration(mock.Anything, mock.Anything).
 					Return(fmt.Errorf("failed to save config"))
 				sut.prov.(*MockProvisioningStore).EXPECT().SaveSucceeds()
@@ -279,11 +279,11 @@ func TestMuteTimingService(t *testing.T) {
 	t.Run("deleting mute timings", func(t *testing.T) {
 		t.Run("returns nil if timing does not exist", func(t *testing.T) {
 			sut := createMuteTimingSvcSut()
-			sut.config.(*MockAMConfigStore).EXPECT().
+			sut.config.store.(*MockAMConfigStore).EXPECT().
 				GetsConfig(models.AlertConfiguration{
 					AlertmanagerConfiguration: configWithMuteTimings,
 				})
-			sut.config.(*MockAMConfigStore).EXPECT().SaveSucceeds()
+			sut.config.store.(*MockAMConfigStore).EXPECT().SaveSucceeds()
 			sut.prov.(*MockProvisioningStore).EXPECT().SaveSucceeds()
 
 			err := sut.DeleteMuteTiming(context.Background(), "does not exist", 1)
@@ -294,7 +294,7 @@ func TestMuteTimingService(t *testing.T) {
 		t.Run("propagates errors", func(t *testing.T) {
 			t.Run("when unable to read config", func(t *testing.T) {
 				sut := createMuteTimingSvcSut()
-				sut.config.(*MockAMConfigStore).EXPECT().
+				sut.config.store.(*MockAMConfigStore).EXPECT().
 					GetLatestAlertmanagerConfiguration(mock.Anything, mock.Anything).
 					Return(nil, fmt.Errorf("failed"))
 
@@ -305,34 +305,34 @@ func TestMuteTimingService(t *testing.T) {
 
 			t.Run("when config is invalid", func(t *testing.T) {
 				sut := createMuteTimingSvcSut()
-				sut.config.(*MockAMConfigStore).EXPECT().
+				sut.config.store.(*MockAMConfigStore).EXPECT().
 					GetsConfig(models.AlertConfiguration{
 						AlertmanagerConfiguration: brokenConfig,
 					})
 
 				err := sut.DeleteMuteTiming(context.Background(), "asdf", 1)
 
-				require.ErrorContains(t, err, "failed to deserialize")
+				require.Truef(t, ErrBadAlertmanagerConfiguration.Base.Is(err), "expected ErrBadAlertmanagerConfiguration but got %s", err.Error())
 			})
 
 			t.Run("when no AM config in current org", func(t *testing.T) {
 				sut := createMuteTimingSvcSut()
-				sut.config.(*MockAMConfigStore).EXPECT().
+				sut.config.store.(*MockAMConfigStore).EXPECT().
 					GetLatestAlertmanagerConfiguration(mock.Anything, mock.Anything).
 					Return(nil, nil)
 
 				err := sut.DeleteMuteTiming(context.Background(), "asdf", 1)
 
-				require.ErrorContains(t, err, "no alertmanager configuration")
+				require.Truef(t, ErrNoAlertmanagerConfiguration.Is(err), "expected ErrNoAlertmanagerConfiguration but got %s", err.Error())
 			})
 
 			t.Run("when provenance fails to save", func(t *testing.T) {
 				sut := createMuteTimingSvcSut()
-				sut.config.(*MockAMConfigStore).EXPECT().
+				sut.config.store.(*MockAMConfigStore).EXPECT().
 					GetsConfig(models.AlertConfiguration{
 						AlertmanagerConfiguration: configWithMuteTimings,
 					})
-				sut.config.(*MockAMConfigStore).EXPECT().SaveSucceeds()
+				sut.config.store.(*MockAMConfigStore).EXPECT().SaveSucceeds()
 				sut.prov.(*MockProvisioningStore).EXPECT().
 					DeleteProvenance(mock.Anything, mock.Anything, mock.Anything).
 					Return(fmt.Errorf("failed to save provenance"))
@@ -344,11 +344,11 @@ func TestMuteTimingService(t *testing.T) {
 
 			t.Run("when AM config fails to save", func(t *testing.T) {
 				sut := createMuteTimingSvcSut()
-				sut.config.(*MockAMConfigStore).EXPECT().
+				sut.config.store.(*MockAMConfigStore).EXPECT().
 					GetsConfig(models.AlertConfiguration{
 						AlertmanagerConfiguration: configWithMuteTimings,
 					})
-				sut.config.(*MockAMConfigStore).EXPECT().
+				sut.config.store.(*MockAMConfigStore).EXPECT().
 					UpdateAlertmanagerConfiguration(mock.Anything, mock.Anything).
 					Return(fmt.Errorf("failed to save config"))
 				sut.prov.(*MockProvisioningStore).EXPECT().SaveSucceeds()
@@ -360,7 +360,7 @@ func TestMuteTimingService(t *testing.T) {
 
 			t.Run("when mute timing is used in route", func(t *testing.T) {
 				sut := createMuteTimingSvcSut()
-				sut.config.(*MockAMConfigStore).EXPECT().
+				sut.config.store.(*MockAMConfigStore).EXPECT().
 					GetsConfig(models.AlertConfiguration{
 						AlertmanagerConfiguration: configWithMuteTimingsInRoute,
 					})
@@ -375,9 +375,8 @@ func TestMuteTimingService(t *testing.T) {
 
 func createMuteTimingSvcSut() *MuteTimingService {
 	return &MuteTimingService{
-		config: &MockAMConfigStore{},
+		config: &alertmanagerConfigStoreImpl{store: &MockAMConfigStore{}, xact: newNopTransactionManager()},
 		prov:   &MockProvisioningStore{},
-		xact:   newNopTransactionManager(),
 		log:    log.NewNopLogger(),
 	}
 }

--- a/pkg/services/ngalert/provisioning/mute_timings_test.go
+++ b/pkg/services/ngalert/provisioning/mute_timings_test.go
@@ -17,7 +17,7 @@ import (
 func TestMuteTimingService(t *testing.T) {
 	t.Run("service returns timings from config file", func(t *testing.T) {
 		sut := createMuteTimingSvcSut()
-		sut.config.store.(*MockAMConfigStore).EXPECT().
+		sut.configStore.store.(*MockAMConfigStore).EXPECT().
 			GetsConfig(models.AlertConfiguration{
 				AlertmanagerConfiguration: configWithMuteTimings,
 			})
@@ -31,7 +31,7 @@ func TestMuteTimingService(t *testing.T) {
 
 	t.Run("service returns empty list when config file contains no mute timings", func(t *testing.T) {
 		sut := createMuteTimingSvcSut()
-		sut.config.store.(*MockAMConfigStore).EXPECT().
+		sut.configStore.store.(*MockAMConfigStore).EXPECT().
 			GetsConfig(models.AlertConfiguration{
 				AlertmanagerConfiguration: defaultConfig,
 			})
@@ -45,7 +45,7 @@ func TestMuteTimingService(t *testing.T) {
 	t.Run("service propagates errors", func(t *testing.T) {
 		t.Run("when unable to read config", func(t *testing.T) {
 			sut := createMuteTimingSvcSut()
-			sut.config.store.(*MockAMConfigStore).EXPECT().
+			sut.configStore.store.(*MockAMConfigStore).EXPECT().
 				GetLatestAlertmanagerConfiguration(mock.Anything, mock.Anything).
 				Return(nil, fmt.Errorf("failed"))
 
@@ -56,7 +56,7 @@ func TestMuteTimingService(t *testing.T) {
 
 		t.Run("when config is invalid", func(t *testing.T) {
 			sut := createMuteTimingSvcSut()
-			sut.config.store.(*MockAMConfigStore).EXPECT().
+			sut.configStore.store.(*MockAMConfigStore).EXPECT().
 				GetsConfig(models.AlertConfiguration{
 					AlertmanagerConfiguration: brokenConfig,
 				})
@@ -68,7 +68,7 @@ func TestMuteTimingService(t *testing.T) {
 
 		t.Run("when no AM config in current org", func(t *testing.T) {
 			sut := createMuteTimingSvcSut()
-			sut.config.store.(*MockAMConfigStore).EXPECT().
+			sut.configStore.store.(*MockAMConfigStore).EXPECT().
 				GetLatestAlertmanagerConfiguration(mock.Anything, mock.Anything).
 				Return(nil, nil)
 
@@ -96,7 +96,7 @@ func TestMuteTimingService(t *testing.T) {
 			t.Run("when unable to read config", func(t *testing.T) {
 				sut := createMuteTimingSvcSut()
 				timing := createMuteTiming()
-				sut.config.store.(*MockAMConfigStore).EXPECT().
+				sut.configStore.store.(*MockAMConfigStore).EXPECT().
 					GetLatestAlertmanagerConfiguration(mock.Anything, mock.Anything).
 					Return(nil, fmt.Errorf("failed"))
 
@@ -108,7 +108,7 @@ func TestMuteTimingService(t *testing.T) {
 			t.Run("when config is invalid", func(t *testing.T) {
 				sut := createMuteTimingSvcSut()
 				timing := createMuteTiming()
-				sut.config.store.(*MockAMConfigStore).EXPECT().
+				sut.configStore.store.(*MockAMConfigStore).EXPECT().
 					GetsConfig(models.AlertConfiguration{
 						AlertmanagerConfiguration: brokenConfig,
 					})
@@ -121,7 +121,7 @@ func TestMuteTimingService(t *testing.T) {
 			t.Run("when no AM config in current org", func(t *testing.T) {
 				sut := createMuteTimingSvcSut()
 				timing := createMuteTiming()
-				sut.config.store.(*MockAMConfigStore).EXPECT().
+				sut.configStore.store.(*MockAMConfigStore).EXPECT().
 					GetLatestAlertmanagerConfiguration(mock.Anything, mock.Anything).
 					Return(nil, nil)
 
@@ -133,12 +133,12 @@ func TestMuteTimingService(t *testing.T) {
 			t.Run("when provenance fails to save", func(t *testing.T) {
 				sut := createMuteTimingSvcSut()
 				timing := createMuteTiming()
-				sut.config.store.(*MockAMConfigStore).EXPECT().
+				sut.configStore.store.(*MockAMConfigStore).EXPECT().
 					GetsConfig(models.AlertConfiguration{
 						AlertmanagerConfiguration: configWithMuteTimings,
 					})
-				sut.config.store.(*MockAMConfigStore).EXPECT().SaveSucceeds()
-				sut.prov.(*MockProvisioningStore).EXPECT().
+				sut.configStore.store.(*MockAMConfigStore).EXPECT().SaveSucceeds()
+				sut.provenanceStore.(*MockProvisioningStore).EXPECT().
 					SetProvenance(mock.Anything, mock.Anything, mock.Anything, mock.Anything).
 					Return(fmt.Errorf("failed to save provenance"))
 
@@ -150,14 +150,14 @@ func TestMuteTimingService(t *testing.T) {
 			t.Run("when AM config fails to save", func(t *testing.T) {
 				sut := createMuteTimingSvcSut()
 				timing := createMuteTiming()
-				sut.config.store.(*MockAMConfigStore).EXPECT().
+				sut.configStore.store.(*MockAMConfigStore).EXPECT().
 					GetsConfig(models.AlertConfiguration{
 						AlertmanagerConfiguration: configWithMuteTimings,
 					})
-				sut.config.store.(*MockAMConfigStore).EXPECT().
+				sut.configStore.store.(*MockAMConfigStore).EXPECT().
 					UpdateAlertmanagerConfiguration(mock.Anything, mock.Anything).
-					Return(fmt.Errorf("failed to save config"))
-				sut.prov.(*MockProvisioningStore).EXPECT().SaveSucceeds()
+					Return(fmt.Errorf("failed to save configStore"))
+				sut.provenanceStore.(*MockProvisioningStore).EXPECT().SaveSucceeds()
 
 				_, err := sut.CreateMuteTiming(context.Background(), timing, 1)
 
@@ -184,12 +184,12 @@ func TestMuteTimingService(t *testing.T) {
 			sut := createMuteTimingSvcSut()
 			timing := createMuteTiming()
 			timing.Name = "does not exist"
-			sut.config.store.(*MockAMConfigStore).EXPECT().
+			sut.configStore.store.(*MockAMConfigStore).EXPECT().
 				GetsConfig(models.AlertConfiguration{
 					AlertmanagerConfiguration: configWithMuteTimings,
 				})
-			sut.config.store.(*MockAMConfigStore).EXPECT().SaveSucceeds()
-			sut.prov.(*MockProvisioningStore).EXPECT().SaveSucceeds()
+			sut.configStore.store.(*MockAMConfigStore).EXPECT().SaveSucceeds()
+			sut.provenanceStore.(*MockProvisioningStore).EXPECT().SaveSucceeds()
 
 			updated, err := sut.UpdateMuteTiming(context.Background(), timing, 1)
 
@@ -202,7 +202,7 @@ func TestMuteTimingService(t *testing.T) {
 				sut := createMuteTimingSvcSut()
 				timing := createMuteTiming()
 				timing.Name = "asdf"
-				sut.config.store.(*MockAMConfigStore).EXPECT().
+				sut.configStore.store.(*MockAMConfigStore).EXPECT().
 					GetLatestAlertmanagerConfiguration(mock.Anything, mock.Anything).
 					Return(nil, fmt.Errorf("failed"))
 
@@ -215,7 +215,7 @@ func TestMuteTimingService(t *testing.T) {
 				sut := createMuteTimingSvcSut()
 				timing := createMuteTiming()
 				timing.Name = "asdf"
-				sut.config.store.(*MockAMConfigStore).EXPECT().
+				sut.configStore.store.(*MockAMConfigStore).EXPECT().
 					GetsConfig(models.AlertConfiguration{
 						AlertmanagerConfiguration: brokenConfig,
 					})
@@ -229,7 +229,7 @@ func TestMuteTimingService(t *testing.T) {
 				sut := createMuteTimingSvcSut()
 				timing := createMuteTiming()
 				timing.Name = "asdf"
-				sut.config.store.(*MockAMConfigStore).EXPECT().
+				sut.configStore.store.(*MockAMConfigStore).EXPECT().
 					GetLatestAlertmanagerConfiguration(mock.Anything, mock.Anything).
 					Return(nil, nil)
 
@@ -242,12 +242,12 @@ func TestMuteTimingService(t *testing.T) {
 				sut := createMuteTimingSvcSut()
 				timing := createMuteTiming()
 				timing.Name = "asdf"
-				sut.config.store.(*MockAMConfigStore).EXPECT().
+				sut.configStore.store.(*MockAMConfigStore).EXPECT().
 					GetsConfig(models.AlertConfiguration{
 						AlertmanagerConfiguration: configWithMuteTimings,
 					})
-				sut.config.store.(*MockAMConfigStore).EXPECT().SaveSucceeds()
-				sut.prov.(*MockProvisioningStore).EXPECT().
+				sut.configStore.store.(*MockAMConfigStore).EXPECT().SaveSucceeds()
+				sut.provenanceStore.(*MockProvisioningStore).EXPECT().
 					SetProvenance(mock.Anything, mock.Anything, mock.Anything, mock.Anything).
 					Return(fmt.Errorf("failed to save provenance"))
 
@@ -260,14 +260,14 @@ func TestMuteTimingService(t *testing.T) {
 				sut := createMuteTimingSvcSut()
 				timing := createMuteTiming()
 				timing.Name = "asdf"
-				sut.config.store.(*MockAMConfigStore).EXPECT().
+				sut.configStore.store.(*MockAMConfigStore).EXPECT().
 					GetsConfig(models.AlertConfiguration{
 						AlertmanagerConfiguration: configWithMuteTimings,
 					})
-				sut.config.store.(*MockAMConfigStore).EXPECT().
+				sut.configStore.store.(*MockAMConfigStore).EXPECT().
 					UpdateAlertmanagerConfiguration(mock.Anything, mock.Anything).
 					Return(fmt.Errorf("failed to save config"))
-				sut.prov.(*MockProvisioningStore).EXPECT().SaveSucceeds()
+				sut.provenanceStore.(*MockProvisioningStore).EXPECT().SaveSucceeds()
 
 				_, err := sut.UpdateMuteTiming(context.Background(), timing, 1)
 
@@ -279,12 +279,12 @@ func TestMuteTimingService(t *testing.T) {
 	t.Run("deleting mute timings", func(t *testing.T) {
 		t.Run("returns nil if timing does not exist", func(t *testing.T) {
 			sut := createMuteTimingSvcSut()
-			sut.config.store.(*MockAMConfigStore).EXPECT().
+			sut.configStore.store.(*MockAMConfigStore).EXPECT().
 				GetsConfig(models.AlertConfiguration{
 					AlertmanagerConfiguration: configWithMuteTimings,
 				})
-			sut.config.store.(*MockAMConfigStore).EXPECT().SaveSucceeds()
-			sut.prov.(*MockProvisioningStore).EXPECT().SaveSucceeds()
+			sut.configStore.store.(*MockAMConfigStore).EXPECT().SaveSucceeds()
+			sut.provenanceStore.(*MockProvisioningStore).EXPECT().SaveSucceeds()
 
 			err := sut.DeleteMuteTiming(context.Background(), "does not exist", 1)
 
@@ -294,7 +294,7 @@ func TestMuteTimingService(t *testing.T) {
 		t.Run("propagates errors", func(t *testing.T) {
 			t.Run("when unable to read config", func(t *testing.T) {
 				sut := createMuteTimingSvcSut()
-				sut.config.store.(*MockAMConfigStore).EXPECT().
+				sut.configStore.store.(*MockAMConfigStore).EXPECT().
 					GetLatestAlertmanagerConfiguration(mock.Anything, mock.Anything).
 					Return(nil, fmt.Errorf("failed"))
 
@@ -305,7 +305,7 @@ func TestMuteTimingService(t *testing.T) {
 
 			t.Run("when config is invalid", func(t *testing.T) {
 				sut := createMuteTimingSvcSut()
-				sut.config.store.(*MockAMConfigStore).EXPECT().
+				sut.configStore.store.(*MockAMConfigStore).EXPECT().
 					GetsConfig(models.AlertConfiguration{
 						AlertmanagerConfiguration: brokenConfig,
 					})
@@ -317,7 +317,7 @@ func TestMuteTimingService(t *testing.T) {
 
 			t.Run("when no AM config in current org", func(t *testing.T) {
 				sut := createMuteTimingSvcSut()
-				sut.config.store.(*MockAMConfigStore).EXPECT().
+				sut.configStore.store.(*MockAMConfigStore).EXPECT().
 					GetLatestAlertmanagerConfiguration(mock.Anything, mock.Anything).
 					Return(nil, nil)
 
@@ -328,12 +328,12 @@ func TestMuteTimingService(t *testing.T) {
 
 			t.Run("when provenance fails to save", func(t *testing.T) {
 				sut := createMuteTimingSvcSut()
-				sut.config.store.(*MockAMConfigStore).EXPECT().
+				sut.configStore.store.(*MockAMConfigStore).EXPECT().
 					GetsConfig(models.AlertConfiguration{
 						AlertmanagerConfiguration: configWithMuteTimings,
 					})
-				sut.config.store.(*MockAMConfigStore).EXPECT().SaveSucceeds()
-				sut.prov.(*MockProvisioningStore).EXPECT().
+				sut.configStore.store.(*MockAMConfigStore).EXPECT().SaveSucceeds()
+				sut.provenanceStore.(*MockProvisioningStore).EXPECT().
 					DeleteProvenance(mock.Anything, mock.Anything, mock.Anything).
 					Return(fmt.Errorf("failed to save provenance"))
 
@@ -344,14 +344,14 @@ func TestMuteTimingService(t *testing.T) {
 
 			t.Run("when AM config fails to save", func(t *testing.T) {
 				sut := createMuteTimingSvcSut()
-				sut.config.store.(*MockAMConfigStore).EXPECT().
+				sut.configStore.store.(*MockAMConfigStore).EXPECT().
 					GetsConfig(models.AlertConfiguration{
 						AlertmanagerConfiguration: configWithMuteTimings,
 					})
-				sut.config.store.(*MockAMConfigStore).EXPECT().
+				sut.configStore.store.(*MockAMConfigStore).EXPECT().
 					UpdateAlertmanagerConfiguration(mock.Anything, mock.Anything).
 					Return(fmt.Errorf("failed to save config"))
-				sut.prov.(*MockProvisioningStore).EXPECT().SaveSucceeds()
+				sut.provenanceStore.(*MockProvisioningStore).EXPECT().SaveSucceeds()
 
 				err := sut.DeleteMuteTiming(context.Background(), "asdf", 1)
 
@@ -360,7 +360,7 @@ func TestMuteTimingService(t *testing.T) {
 
 			t.Run("when mute timing is used in route", func(t *testing.T) {
 				sut := createMuteTimingSvcSut()
-				sut.config.store.(*MockAMConfigStore).EXPECT().
+				sut.configStore.store.(*MockAMConfigStore).EXPECT().
 					GetsConfig(models.AlertConfiguration{
 						AlertmanagerConfiguration: configWithMuteTimingsInRoute,
 					})
@@ -375,9 +375,10 @@ func TestMuteTimingService(t *testing.T) {
 
 func createMuteTimingSvcSut() *MuteTimingService {
 	return &MuteTimingService{
-		config: &alertmanagerConfigStoreImpl{store: &MockAMConfigStore{}, xact: newNopTransactionManager()},
-		prov:   &MockProvisioningStore{},
-		log:    log.NewNopLogger(),
+		configStore:     &alertmanagerConfigStoreImpl{store: &MockAMConfigStore{}},
+		provenanceStore: &MockProvisioningStore{},
+		xact:            newNopTransactionManager(),
+		log:             log.NewNopLogger(),
 	}
 }
 

--- a/pkg/services/ngalert/provisioning/notification_policies_test.go
+++ b/pkg/services/ngalert/provisioning/notification_policies_test.go
@@ -28,7 +28,7 @@ func TestNotificationPolicyService(t *testing.T) {
 
 	t.Run("error if referenced mute time interval is not existing", func(t *testing.T) {
 		sut := createNotificationPolicyServiceSut()
-		sut.config.store = &MockAMConfigStore{}
+		sut.configStore.store = &MockAMConfigStore{}
 		cfg := createTestAlertingConfig()
 		cfg.AlertmanagerConfig.MuteTimeIntervals = []config.MuteTimeInterval{
 			{
@@ -37,9 +37,9 @@ func TestNotificationPolicyService(t *testing.T) {
 			},
 		}
 		data, _ := serializeAlertmanagerConfig(*cfg)
-		sut.config.store.(*MockAMConfigStore).On("GetLatestAlertmanagerConfiguration", mock.Anything, mock.Anything).
+		sut.configStore.store.(*MockAMConfigStore).On("GetLatestAlertmanagerConfiguration", mock.Anything, mock.Anything).
 			Return(&models.AlertConfiguration{AlertmanagerConfiguration: string(data)}, nil)
-		sut.config.store.(*MockAMConfigStore).EXPECT().
+		sut.configStore.store.(*MockAMConfigStore).EXPECT().
 			UpdateAlertmanagerConfiguration(mock.Anything, mock.Anything).
 			Return(nil)
 		newRoute := createTestRoutingTree()
@@ -54,7 +54,7 @@ func TestNotificationPolicyService(t *testing.T) {
 
 	t.Run("pass if referenced mute time interval is existing", func(t *testing.T) {
 		sut := createNotificationPolicyServiceSut()
-		sut.config.store = &MockAMConfigStore{}
+		sut.configStore.store = &MockAMConfigStore{}
 		cfg := createTestAlertingConfig()
 		cfg.AlertmanagerConfig.MuteTimeIntervals = []config.MuteTimeInterval{
 			{
@@ -63,9 +63,9 @@ func TestNotificationPolicyService(t *testing.T) {
 			},
 		}
 		data, _ := serializeAlertmanagerConfig(*cfg)
-		sut.config.store.(*MockAMConfigStore).On("GetLatestAlertmanagerConfiguration", mock.Anything, mock.Anything).
+		sut.configStore.store.(*MockAMConfigStore).On("GetLatestAlertmanagerConfiguration", mock.Anything, mock.Anything).
 			Return(&models.AlertConfiguration{AlertmanagerConfiguration: string(data)}, nil)
-		sut.config.store.(*MockAMConfigStore).EXPECT().
+		sut.configStore.store.(*MockAMConfigStore).EXPECT().
 			UpdateAlertmanagerConfiguration(mock.Anything, mock.Anything).
 			Return(nil)
 		newRoute := createTestRoutingTree()
@@ -105,12 +105,12 @@ func TestNotificationPolicyService(t *testing.T) {
 
 	t.Run("existing receiver reference will pass", func(t *testing.T) {
 		sut := createNotificationPolicyServiceSut()
-		sut.config.store = &MockAMConfigStore{}
+		sut.configStore.store = &MockAMConfigStore{}
 		cfg := createTestAlertingConfig()
 		data, _ := serializeAlertmanagerConfig(*cfg)
-		sut.config.store.(*MockAMConfigStore).On("GetLatestAlertmanagerConfiguration", mock.Anything, mock.Anything).
+		sut.configStore.store.(*MockAMConfigStore).On("GetLatestAlertmanagerConfiguration", mock.Anything, mock.Anything).
 			Return(&models.AlertConfiguration{AlertmanagerConfiguration: string(data)}, nil)
-		sut.config.store.(*MockAMConfigStore).EXPECT().
+		sut.configStore.store.(*MockAMConfigStore).EXPECT().
 			UpdateAlertmanagerConfiguration(mock.Anything, mock.Anything).
 			Return(nil)
 		newRoute := createTestRoutingTree()
@@ -183,7 +183,7 @@ func TestNotificationPolicyService(t *testing.T) {
 
 	t.Run("deleting route with missing default receiver restores receiver", func(t *testing.T) {
 		sut := createNotificationPolicyServiceSut()
-		sut.config.store = &MockAMConfigStore{}
+		sut.configStore.store = &MockAMConfigStore{}
 		cfg := createTestAlertingConfig()
 		cfg.AlertmanagerConfig.Route = &definitions.Route{
 			Receiver: "a new receiver",
@@ -197,17 +197,17 @@ func TestNotificationPolicyService(t *testing.T) {
 			// No default receiver! Only our custom one.
 		}
 		data, _ := serializeAlertmanagerConfig(*cfg)
-		sut.config.store.(*MockAMConfigStore).On("GetLatestAlertmanagerConfiguration", mock.Anything, mock.Anything).
+		sut.configStore.store.(*MockAMConfigStore).On("GetLatestAlertmanagerConfiguration", mock.Anything, mock.Anything).
 			Return(&models.AlertConfiguration{AlertmanagerConfiguration: string(data)}, nil)
 		var interceptedSave = models.SaveAlertmanagerConfigurationCmd{}
-		sut.config.store.(*MockAMConfigStore).EXPECT().SaveSucceedsIntercept(&interceptedSave)
+		sut.configStore.store.(*MockAMConfigStore).EXPECT().SaveSucceedsIntercept(&interceptedSave)
 
 		tree, err := sut.ResetPolicyTree(context.Background(), 1)
 
 		require.NoError(t, err)
 		require.Equal(t, "grafana-default-email", tree.Receiver)
 		require.NotEmpty(t, interceptedSave.AlertmanagerConfiguration)
-		// Deserializing with no error asserts that the saved config is semantically valid.
+		// Deserializing with no error asserts that the saved configStore is semantically valid.
 		newCfg, err := deserializeAlertmanagerConfig([]byte(interceptedSave.AlertmanagerConfiguration))
 		require.NoError(t, err)
 		require.Len(t, newCfg.AlertmanagerConfig.Receivers, 2)
@@ -216,11 +216,9 @@ func TestNotificationPolicyService(t *testing.T) {
 
 func createNotificationPolicyServiceSut() *NotificationPolicyService {
 	return &NotificationPolicyService{
-		config: &alertmanagerConfigStoreImpl{
-			store: newFakeAMConfigStore(defaultAlertmanagerConfigJSON),
-			xact:  newNopTransactionManager(),
-		},
+		configStore:     &alertmanagerConfigStoreImpl{store: newFakeAMConfigStore(defaultAlertmanagerConfigJSON)},
 		provenanceStore: NewFakeProvisioningStore(),
+		xact:            newNopTransactionManager(),
 		log:             log.NewNopLogger(),
 		settings: setting.UnifiedAlertingSettings{
 			DefaultConfiguration: setting.GetAlertmanagerDefaultConfiguration(),

--- a/pkg/services/ngalert/provisioning/templates.go
+++ b/pkg/services/ngalert/provisioning/templates.go
@@ -10,21 +10,23 @@ import (
 )
 
 type TemplateService struct {
-	config *alertmanagerConfigStoreImpl
-	prov   ProvisioningStore
-	log    log.Logger
+	configStore     *alertmanagerConfigStoreImpl
+	provenanceStore ProvisioningStore
+	xact            TransactionManager
+	log             log.Logger
 }
 
 func NewTemplateService(config AMConfigStore, prov ProvisioningStore, xact TransactionManager, log log.Logger) *TemplateService {
 	return &TemplateService{
-		config: &alertmanagerConfigStoreImpl{store: config, xact: xact},
-		prov:   prov,
-		log:    log,
+		configStore:     &alertmanagerConfigStoreImpl{store: config},
+		provenanceStore: prov,
+		xact:            xact,
+		log:             log,
 	}
 }
 
 func (t *TemplateService) GetTemplates(ctx context.Context, orgID int64) (map[string]string, error) {
-	revision, err := t.config.Get(ctx, orgID)
+	revision, err := t.configStore.Get(ctx, orgID)
 	if err != nil {
 		return nil, err
 	}
@@ -42,7 +44,7 @@ func (t *TemplateService) SetTemplate(ctx context.Context, orgID int64, tmpl def
 		return definitions.NotificationTemplate{}, fmt.Errorf("%w: %s", ErrValidation, err.Error())
 	}
 
-	revision, err := t.config.Get(ctx, orgID)
+	revision, err := t.configStore.Get(ctx, orgID)
 	if err != nil {
 		return definitions.NotificationTemplate{}, err
 	}
@@ -57,8 +59,11 @@ func (t *TemplateService) SetTemplate(ctx context.Context, orgID int64, tmpl def
 	}
 	revision.cfg.AlertmanagerConfig.Templates = tmpls
 
-	err = t.config.Save(ctx, revision, orgID, func(ctx context.Context) error {
-		return t.prov.SetProvenance(ctx, &tmpl, orgID, models.Provenance(tmpl.Provenance))
+	err = t.xact.InTransaction(ctx, func(ctx context.Context) error {
+		if err := t.configStore.Save(ctx, revision, orgID); err != nil {
+			return err
+		}
+		return t.provenanceStore.SetProvenance(ctx, &tmpl, orgID, models.Provenance(tmpl.Provenance))
 	})
 	if err != nil {
 		return definitions.NotificationTemplate{}, err
@@ -68,17 +73,20 @@ func (t *TemplateService) SetTemplate(ctx context.Context, orgID int64, tmpl def
 }
 
 func (t *TemplateService) DeleteTemplate(ctx context.Context, orgID int64, name string) error {
-	revision, err := t.config.Get(ctx, orgID)
+	revision, err := t.configStore.Get(ctx, orgID)
 	if err != nil {
 		return err
 	}
 
 	delete(revision.cfg.TemplateFiles, name)
 
-	return t.config.Save(ctx, revision, orgID, func(ctx context.Context) error {
+	return t.xact.InTransaction(ctx, func(ctx context.Context) error {
+		if err := t.configStore.Save(ctx, revision, orgID); err != nil {
+			return err
+		}
 		tgt := definitions.NotificationTemplate{
 			Name: name,
 		}
-		return t.prov.DeleteProvenance(ctx, &tgt, orgID)
+		return t.provenanceStore.DeleteProvenance(ctx, &tgt, orgID)
 	})
 }

--- a/pkg/services/ngalert/provisioning/templates_test.go
+++ b/pkg/services/ngalert/provisioning/templates_test.go
@@ -17,7 +17,7 @@ import (
 func TestTemplateService(t *testing.T) {
 	t.Run("service returns templates from config file", func(t *testing.T) {
 		sut := createTemplateServiceSut()
-		sut.config.store.(*MockAMConfigStore).EXPECT().
+		sut.configStore.store.(*MockAMConfigStore).EXPECT().
 			GetsConfig(models.AlertConfiguration{
 				AlertmanagerConfiguration: configWithTemplates,
 			})
@@ -30,7 +30,7 @@ func TestTemplateService(t *testing.T) {
 
 	t.Run("service returns empty map when config file contains no templates", func(t *testing.T) {
 		sut := createTemplateServiceSut()
-		sut.config.store.(*MockAMConfigStore).EXPECT().
+		sut.configStore.store.(*MockAMConfigStore).EXPECT().
 			GetsConfig(models.AlertConfiguration{
 				AlertmanagerConfiguration: defaultConfig,
 			})
@@ -44,7 +44,7 @@ func TestTemplateService(t *testing.T) {
 	t.Run("service propagates errors", func(t *testing.T) {
 		t.Run("when unable to read config", func(t *testing.T) {
 			sut := createTemplateServiceSut()
-			sut.config.store.(*MockAMConfigStore).EXPECT().
+			sut.configStore.store.(*MockAMConfigStore).EXPECT().
 				GetLatestAlertmanagerConfiguration(mock.Anything, mock.Anything).
 				Return(nil, fmt.Errorf("failed"))
 
@@ -55,7 +55,7 @@ func TestTemplateService(t *testing.T) {
 
 		t.Run("when config is invalid", func(t *testing.T) {
 			sut := createTemplateServiceSut()
-			sut.config.store.(*MockAMConfigStore).EXPECT().
+			sut.configStore.store.(*MockAMConfigStore).EXPECT().
 				GetsConfig(models.AlertConfiguration{
 					AlertmanagerConfiguration: brokenConfig,
 				})
@@ -67,7 +67,7 @@ func TestTemplateService(t *testing.T) {
 
 		t.Run("when no AM config in current org", func(t *testing.T) {
 			sut := createTemplateServiceSut()
-			sut.config.store.(*MockAMConfigStore).EXPECT().
+			sut.configStore.store.(*MockAMConfigStore).EXPECT().
 				GetLatestAlertmanagerConfiguration(mock.Anything, mock.Anything).
 				Return(nil, nil)
 
@@ -94,7 +94,7 @@ func TestTemplateService(t *testing.T) {
 			t.Run("when unable to read config", func(t *testing.T) {
 				sut := createTemplateServiceSut()
 				tmpl := createNotificationTemplate()
-				sut.config.store.(*MockAMConfigStore).EXPECT().
+				sut.configStore.store.(*MockAMConfigStore).EXPECT().
 					GetLatestAlertmanagerConfiguration(mock.Anything, mock.Anything).
 					Return(nil, fmt.Errorf("failed"))
 
@@ -106,7 +106,7 @@ func TestTemplateService(t *testing.T) {
 			t.Run("when config is invalid", func(t *testing.T) {
 				sut := createTemplateServiceSut()
 				tmpl := createNotificationTemplate()
-				sut.config.store.(*MockAMConfigStore).EXPECT().
+				sut.configStore.store.(*MockAMConfigStore).EXPECT().
 					GetsConfig(models.AlertConfiguration{
 						AlertmanagerConfiguration: brokenConfig,
 					})
@@ -119,7 +119,7 @@ func TestTemplateService(t *testing.T) {
 			t.Run("when no AM config in current org", func(t *testing.T) {
 				sut := createTemplateServiceSut()
 				tmpl := createNotificationTemplate()
-				sut.config.store.(*MockAMConfigStore).EXPECT().
+				sut.configStore.store.(*MockAMConfigStore).EXPECT().
 					GetLatestAlertmanagerConfiguration(mock.Anything, mock.Anything).
 					Return(nil, nil)
 
@@ -131,12 +131,12 @@ func TestTemplateService(t *testing.T) {
 			t.Run("when provenance fails to save", func(t *testing.T) {
 				sut := createTemplateServiceSut()
 				tmpl := createNotificationTemplate()
-				sut.config.store.(*MockAMConfigStore).EXPECT().
+				sut.configStore.store.(*MockAMConfigStore).EXPECT().
 					GetsConfig(models.AlertConfiguration{
 						AlertmanagerConfiguration: configWithTemplates,
 					})
-				sut.config.store.(*MockAMConfigStore).EXPECT().SaveSucceeds()
-				sut.prov.(*MockProvisioningStore).EXPECT().
+				sut.configStore.store.(*MockAMConfigStore).EXPECT().SaveSucceeds()
+				sut.provenanceStore.(*MockProvisioningStore).EXPECT().
 					SetProvenance(mock.Anything, mock.Anything, mock.Anything, mock.Anything).
 					Return(fmt.Errorf("failed to save provenance"))
 
@@ -148,14 +148,14 @@ func TestTemplateService(t *testing.T) {
 			t.Run("when AM config fails to save", func(t *testing.T) {
 				sut := createTemplateServiceSut()
 				tmpl := createNotificationTemplate()
-				sut.config.store.(*MockAMConfigStore).EXPECT().
+				sut.configStore.store.(*MockAMConfigStore).EXPECT().
 					GetsConfig(models.AlertConfiguration{
 						AlertmanagerConfiguration: configWithTemplates,
 					})
-				sut.config.store.(*MockAMConfigStore).EXPECT().
+				sut.configStore.store.(*MockAMConfigStore).EXPECT().
 					UpdateAlertmanagerConfiguration(mock.Anything, mock.Anything).
 					Return(fmt.Errorf("failed to save config"))
-				sut.prov.(*MockProvisioningStore).EXPECT().SaveSucceeds()
+				sut.provenanceStore.(*MockProvisioningStore).EXPECT().SaveSucceeds()
 
 				_, err := sut.SetTemplate(context.Background(), 1, tmpl)
 
@@ -166,12 +166,12 @@ func TestTemplateService(t *testing.T) {
 		t.Run("adds new template to config file on success", func(t *testing.T) {
 			sut := createTemplateServiceSut()
 			tmpl := createNotificationTemplate()
-			sut.config.store.(*MockAMConfigStore).EXPECT().
+			sut.configStore.store.(*MockAMConfigStore).EXPECT().
 				GetsConfig(models.AlertConfiguration{
 					AlertmanagerConfiguration: configWithTemplates,
 				})
-			sut.config.store.(*MockAMConfigStore).EXPECT().SaveSucceeds()
-			sut.prov.(*MockProvisioningStore).EXPECT().SaveSucceeds()
+			sut.configStore.store.(*MockAMConfigStore).EXPECT().SaveSucceeds()
+			sut.provenanceStore.(*MockProvisioningStore).EXPECT().SaveSucceeds()
 
 			_, err := sut.SetTemplate(context.Background(), 1, tmpl)
 
@@ -181,12 +181,12 @@ func TestTemplateService(t *testing.T) {
 		t.Run("succeeds when stitching config file with no templates", func(t *testing.T) {
 			sut := createTemplateServiceSut()
 			tmpl := createNotificationTemplate()
-			sut.config.store.(*MockAMConfigStore).EXPECT().
+			sut.configStore.store.(*MockAMConfigStore).EXPECT().
 				GetsConfig(models.AlertConfiguration{
 					AlertmanagerConfiguration: defaultConfig,
 				})
-			sut.config.store.(*MockAMConfigStore).EXPECT().SaveSucceeds()
-			sut.prov.(*MockProvisioningStore).EXPECT().SaveSucceeds()
+			sut.configStore.store.(*MockAMConfigStore).EXPECT().SaveSucceeds()
+			sut.provenanceStore.(*MockProvisioningStore).EXPECT().SaveSucceeds()
 
 			_, err := sut.SetTemplate(context.Background(), 1, tmpl)
 
@@ -199,12 +199,12 @@ func TestTemplateService(t *testing.T) {
 				Name:     "name",
 				Template: "content",
 			}
-			sut.config.store.(*MockAMConfigStore).EXPECT().
+			sut.configStore.store.(*MockAMConfigStore).EXPECT().
 				GetsConfig(models.AlertConfiguration{
 					AlertmanagerConfiguration: defaultConfig,
 				})
-			sut.config.store.(*MockAMConfigStore).EXPECT().SaveSucceeds()
-			sut.prov.(*MockProvisioningStore).EXPECT().SaveSucceeds()
+			sut.configStore.store.(*MockAMConfigStore).EXPECT().SaveSucceeds()
+			sut.provenanceStore.(*MockProvisioningStore).EXPECT().SaveSucceeds()
 
 			result, _ := sut.SetTemplate(context.Background(), 1, tmpl)
 
@@ -218,12 +218,12 @@ func TestTemplateService(t *testing.T) {
 				Name:     "name",
 				Template: "{{define \"name\"}}content{{end}}",
 			}
-			sut.config.store.(*MockAMConfigStore).EXPECT().
+			sut.configStore.store.(*MockAMConfigStore).EXPECT().
 				GetsConfig(models.AlertConfiguration{
 					AlertmanagerConfiguration: defaultConfig,
 				})
-			sut.config.store.(*MockAMConfigStore).EXPECT().SaveSucceeds()
-			sut.prov.(*MockProvisioningStore).EXPECT().SaveSucceeds()
+			sut.configStore.store.(*MockAMConfigStore).EXPECT().SaveSucceeds()
+			sut.provenanceStore.(*MockProvisioningStore).EXPECT().SaveSucceeds()
 
 			result, _ := sut.SetTemplate(context.Background(), 1, tmpl)
 
@@ -236,12 +236,12 @@ func TestTemplateService(t *testing.T) {
 				Name:     "name",
 				Template: "{{ .MyField }",
 			}
-			sut.config.store.(*MockAMConfigStore).EXPECT().
+			sut.configStore.store.(*MockAMConfigStore).EXPECT().
 				GetsConfig(models.AlertConfiguration{
 					AlertmanagerConfiguration: defaultConfig,
 				})
-			sut.config.store.(*MockAMConfigStore).EXPECT().SaveSucceeds()
-			sut.prov.(*MockProvisioningStore).EXPECT().SaveSucceeds()
+			sut.configStore.store.(*MockAMConfigStore).EXPECT().SaveSucceeds()
+			sut.provenanceStore.(*MockProvisioningStore).EXPECT().SaveSucceeds()
 
 			_, err := sut.SetTemplate(context.Background(), 1, tmpl)
 
@@ -254,12 +254,12 @@ func TestTemplateService(t *testing.T) {
 				Name:     "name",
 				Template: "{{ .NotAField }}",
 			}
-			sut.config.store.(*MockAMConfigStore).EXPECT().
+			sut.configStore.store.(*MockAMConfigStore).EXPECT().
 				GetsConfig(models.AlertConfiguration{
 					AlertmanagerConfiguration: defaultConfig,
 				})
-			sut.config.store.(*MockAMConfigStore).EXPECT().SaveSucceeds()
-			sut.prov.(*MockProvisioningStore).EXPECT().SaveSucceeds()
+			sut.configStore.store.(*MockAMConfigStore).EXPECT().SaveSucceeds()
+			sut.provenanceStore.(*MockProvisioningStore).EXPECT().SaveSucceeds()
 
 			_, err := sut.SetTemplate(context.Background(), 1, tmpl)
 
@@ -271,7 +271,7 @@ func TestTemplateService(t *testing.T) {
 		t.Run("propagates errors", func(t *testing.T) {
 			t.Run("when unable to read config", func(t *testing.T) {
 				sut := createTemplateServiceSut()
-				sut.config.store.(*MockAMConfigStore).EXPECT().
+				sut.configStore.store.(*MockAMConfigStore).EXPECT().
 					GetLatestAlertmanagerConfiguration(mock.Anything, mock.Anything).
 					Return(nil, fmt.Errorf("failed"))
 
@@ -282,7 +282,7 @@ func TestTemplateService(t *testing.T) {
 
 			t.Run("when config is invalid", func(t *testing.T) {
 				sut := createTemplateServiceSut()
-				sut.config.store.(*MockAMConfigStore).EXPECT().
+				sut.configStore.store.(*MockAMConfigStore).EXPECT().
 					GetsConfig(models.AlertConfiguration{
 						AlertmanagerConfiguration: brokenConfig,
 					})
@@ -294,7 +294,7 @@ func TestTemplateService(t *testing.T) {
 
 			t.Run("when no AM config in current org", func(t *testing.T) {
 				sut := createTemplateServiceSut()
-				sut.config.store.(*MockAMConfigStore).EXPECT().
+				sut.configStore.store.(*MockAMConfigStore).EXPECT().
 					GetLatestAlertmanagerConfiguration(mock.Anything, mock.Anything).
 					Return(nil, nil)
 
@@ -305,12 +305,12 @@ func TestTemplateService(t *testing.T) {
 
 			t.Run("when provenance fails to save", func(t *testing.T) {
 				sut := createTemplateServiceSut()
-				sut.config.store.(*MockAMConfigStore).EXPECT().
+				sut.configStore.store.(*MockAMConfigStore).EXPECT().
 					GetsConfig(models.AlertConfiguration{
 						AlertmanagerConfiguration: configWithTemplates,
 					})
-				sut.config.store.(*MockAMConfigStore).EXPECT().SaveSucceeds()
-				sut.prov.(*MockProvisioningStore).EXPECT().
+				sut.configStore.store.(*MockAMConfigStore).EXPECT().SaveSucceeds()
+				sut.provenanceStore.(*MockProvisioningStore).EXPECT().
 					DeleteProvenance(mock.Anything, mock.Anything, mock.Anything).
 					Return(fmt.Errorf("failed to save provenance"))
 
@@ -321,14 +321,14 @@ func TestTemplateService(t *testing.T) {
 
 			t.Run("when AM config fails to save", func(t *testing.T) {
 				sut := createTemplateServiceSut()
-				sut.config.store.(*MockAMConfigStore).EXPECT().
+				sut.configStore.store.(*MockAMConfigStore).EXPECT().
 					GetsConfig(models.AlertConfiguration{
 						AlertmanagerConfiguration: configWithTemplates,
 					})
-				sut.config.store.(*MockAMConfigStore).EXPECT().
+				sut.configStore.store.(*MockAMConfigStore).EXPECT().
 					UpdateAlertmanagerConfiguration(mock.Anything, mock.Anything).
 					Return(fmt.Errorf("failed to save config"))
-				sut.prov.(*MockProvisioningStore).EXPECT().SaveSucceeds()
+				sut.provenanceStore.(*MockProvisioningStore).EXPECT().SaveSucceeds()
 
 				err := sut.DeleteTemplate(context.Background(), 1, "template")
 
@@ -338,12 +338,12 @@ func TestTemplateService(t *testing.T) {
 
 		t.Run("deletes template from config file on success", func(t *testing.T) {
 			sut := createTemplateServiceSut()
-			sut.config.store.(*MockAMConfigStore).EXPECT().
+			sut.configStore.store.(*MockAMConfigStore).EXPECT().
 				GetsConfig(models.AlertConfiguration{
 					AlertmanagerConfiguration: configWithTemplates,
 				})
-			sut.config.store.(*MockAMConfigStore).EXPECT().SaveSucceeds()
-			sut.prov.(*MockProvisioningStore).EXPECT().SaveSucceeds()
+			sut.configStore.store.(*MockAMConfigStore).EXPECT().SaveSucceeds()
+			sut.provenanceStore.(*MockProvisioningStore).EXPECT().SaveSucceeds()
 
 			err := sut.DeleteTemplate(context.Background(), 1, "a")
 
@@ -352,12 +352,12 @@ func TestTemplateService(t *testing.T) {
 
 		t.Run("does not error when deleting templates that do not exist", func(t *testing.T) {
 			sut := createTemplateServiceSut()
-			sut.config.store.(*MockAMConfigStore).EXPECT().
+			sut.configStore.store.(*MockAMConfigStore).EXPECT().
 				GetsConfig(models.AlertConfiguration{
 					AlertmanagerConfiguration: configWithTemplates,
 				})
-			sut.config.store.(*MockAMConfigStore).EXPECT().SaveSucceeds()
-			sut.prov.(*MockProvisioningStore).EXPECT().SaveSucceeds()
+			sut.configStore.store.(*MockAMConfigStore).EXPECT().SaveSucceeds()
+			sut.provenanceStore.(*MockProvisioningStore).EXPECT().SaveSucceeds()
 
 			err := sut.DeleteTemplate(context.Background(), 1, "does not exist")
 
@@ -366,12 +366,12 @@ func TestTemplateService(t *testing.T) {
 
 		t.Run("succeeds when deleting from config file with no template section", func(t *testing.T) {
 			sut := createTemplateServiceSut()
-			sut.config.store.(*MockAMConfigStore).EXPECT().
+			sut.configStore.store.(*MockAMConfigStore).EXPECT().
 				GetsConfig(models.AlertConfiguration{
 					AlertmanagerConfiguration: defaultConfig,
 				})
-			sut.config.store.(*MockAMConfigStore).EXPECT().SaveSucceeds()
-			sut.prov.(*MockProvisioningStore).EXPECT().SaveSucceeds()
+			sut.configStore.store.(*MockAMConfigStore).EXPECT().SaveSucceeds()
+			sut.provenanceStore.(*MockProvisioningStore).EXPECT().SaveSucceeds()
 
 			err := sut.DeleteTemplate(context.Background(), 1, "a")
 
@@ -382,9 +382,10 @@ func TestTemplateService(t *testing.T) {
 
 func createTemplateServiceSut() *TemplateService {
 	return &TemplateService{
-		config: &alertmanagerConfigStoreImpl{store: &MockAMConfigStore{}, xact: newNopTransactionManager()},
-		prov:   &MockProvisioningStore{},
-		log:    log.NewNopLogger(),
+		configStore:     &alertmanagerConfigStoreImpl{store: &MockAMConfigStore{}},
+		provenanceStore: &MockProvisioningStore{},
+		xact:            newNopTransactionManager(),
+		log:             log.NewNopLogger(),
 	}
 }
 

--- a/pkg/services/ngalert/provisioning/testing.go
+++ b/pkg/services/ngalert/provisioning/testing.go
@@ -5,7 +5,9 @@ import (
 	"crypto/md5"
 	"fmt"
 	"strings"
+	"testing"
 
+	"github.com/stretchr/testify/assert"
 	mock "github.com/stretchr/testify/mock"
 
 	"github.com/grafana/grafana/pkg/services/ngalert/models"
@@ -135,6 +137,10 @@ func (f *fakeProvisioningStore) DeleteProvenance(ctx context.Context, o models.P
 	return nil
 }
 
+func assertInTransaction(t *testing.T, ctx context.Context) {
+	assert.Truef(t, ctx.Value(NopTransactionManager{}) != nil, "Expected to be executed in transaction but there is none")
+}
+
 type NopTransactionManager struct{}
 
 func newNopTransactionManager() *NopTransactionManager {
@@ -142,7 +148,7 @@ func newNopTransactionManager() *NopTransactionManager {
 }
 
 func (n *NopTransactionManager) InTransaction(ctx context.Context, work func(ctx context.Context) error) error {
-	return work(ctx)
+	return work(context.WithValue(ctx, NopTransactionManager{}, struct{}{}))
 }
 
 func (m *MockAMConfigStore_Expecter) GetsConfig(ac models.AlertConfiguration) *MockAMConfigStore_Expecter {

--- a/pkg/services/ngalert/provisioning/testing.go
+++ b/pkg/services/ngalert/provisioning/testing.go
@@ -5,9 +5,7 @@ import (
 	"crypto/md5"
 	"fmt"
 	"strings"
-	"testing"
 
-	"github.com/stretchr/testify/assert"
 	mock "github.com/stretchr/testify/mock"
 
 	"github.com/grafana/grafana/pkg/services/ngalert/models"
@@ -137,10 +135,6 @@ func (f *fakeProvisioningStore) DeleteProvenance(ctx context.Context, o models.P
 	return nil
 }
 
-func assertInTransaction(t *testing.T, ctx context.Context) {
-	assert.Truef(t, ctx.Value(NopTransactionManager{}) != nil, "Expected to be executed in transaction but there is none")
-}
-
 type NopTransactionManager struct{}
 
 func newNopTransactionManager() *NopTransactionManager {
@@ -148,7 +142,7 @@ func newNopTransactionManager() *NopTransactionManager {
 }
 
 func (n *NopTransactionManager) InTransaction(ctx context.Context, work func(ctx context.Context) error) error {
-	return work(context.WithValue(ctx, NopTransactionManager{}, struct{}{}))
+	return work(ctx)
 }
 
 func (m *MockAMConfigStore_Expecter) GetsConfig(ac models.AlertConfiguration) *MockAMConfigStore_Expecter {


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**
This PR introduces a new struct that encapsulates logic to read the latest Alertmanager configuration and save it to the database. This logic is duplicated in all methods of services that handle Alertmanager configuration. The new struct is covered by tests to make sure that it works correctly.

Also, some errors produced by the storage, are updated to return errutil.

**Why do we need this feature?**
- this will allow us to avoid duplicated tests in services that assert the common errors produced by replaced logic and remove those tests.
- clean up services' methods to contain only business logic and offload the storage logic into a separate layer.


- this opens an interesting possibility in file provisioning. Currently, provisioning of each resource creates a record in the history table, e.g. if file provisioning creates 100 notification resources, it will do 100 read\write cycles and create 100 records in the history table. We can implement a custom storage that will only read once and then save after all provisioning resources are handled. 

**Who is this feature for?**
Developers

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
