### PR TITLE
Storage: Support grafana.app/folder field selector & label selectors

### DIFF
--- a/pkg/apis/types.go
+++ b/pkg/apis/types.go
@@ -49,6 +49,14 @@ func (info *ResourceInfo) GroupResource() schema.GroupResource {
 	}
 }
 
+func (info *ResourceInfo) GroupVersionKind() schema.GroupVersionKind {
+	return schema.GroupVersionKind{
+		Group:   info.group,
+		Version: info.version,
+		Kind:    info.kind,
+	}
+}
+
 func (info *ResourceInfo) SingularGroupResource() schema.GroupResource {
 	return schema.GroupResource{
 		Group:    info.group,

--- a/pkg/registry/apis/playlist/register.go
+++ b/pkg/registry/apis/playlist/register.go
@@ -2,6 +2,7 @@ package playlist
 
 import (
 	"fmt"
+	"strings"
 	"time"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -66,6 +67,28 @@ func (b *PlaylistAPIBuilder) InstallSchema(scheme *runtime.Scheme) error {
 		Group:   b.gv.Group,
 		Version: runtime.APIVersionInternal,
 	})
+
+	gvk := playlist.PlaylistResourceInfo.GroupVersionKind()
+
+	// Add playlist thing
+	scheme.AddFieldLabelConversionFunc(gvk,
+		runtime.FieldLabelConversionFunc(
+			func(label, value string) (string, string, error) {
+				if strings.HasPrefix(label, "grafana.app/") {
+					return label, value, nil
+				}
+
+				switch label {
+				case "metadata.name":
+					return label, value, nil
+				case "metadata.namespace":
+					return label, value, nil
+				default:
+					return "", "", fmt.Errorf("%q is not a known field selector: only %q, %q", label, "metadata.name", "metadata.namespace")
+				}
+			},
+		),
+	)
 
 	// If multiple versions exist, then register conversions from zz_generated.conversion.go
 	// if err := playlist.RegisterConversions(scheme); err != nil {

--- a/pkg/registry/apis/playlist/register.go
+++ b/pkg/registry/apis/playlist/register.go
@@ -71,7 +71,7 @@ func (b *PlaylistAPIBuilder) InstallSchema(scheme *runtime.Scheme) error {
 	gvk := playlist.PlaylistResourceInfo.GroupVersionKind()
 
 	// Add playlist thing
-	scheme.AddFieldLabelConversionFunc(gvk,
+	_ = scheme.AddFieldLabelConversionFunc(gvk,
 		runtime.FieldLabelConversionFunc(
 			func(label, value string) (string, string, error) {
 				if strings.HasPrefix(label, "grafana.app/") {

--- a/pkg/services/grafana-apiserver/storage/entity/storage.go
+++ b/pkg/services/grafana-apiserver/storage/entity/storage.go
@@ -18,6 +18,7 @@ import (
 	"k8s.io/apimachinery/pkg/conversion"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/selection"
 	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/apiserver/pkg/endpoints/request"
 	"k8s.io/apiserver/pkg/storage"
@@ -218,14 +219,53 @@ func (s *Storage) GetList(ctx context.Context, key string, opts storage.ListOpti
 		return err
 	}
 
-	rsp, err := s.store.List(ctx, &entityStore.EntityListRequest{
+	req := &entityStore.EntityListRequest{
 		Key:           []string{key},
 		WithBody:      true,
 		WithStatus:    true,
 		NextPageToken: opts.Predicate.Continue,
 		Limit:         opts.Predicate.Limit,
+		Labels:        map[string]string{},
 		// TODO push label/field matching down to storage
+	}
+
+	// translate "equals" label selectors to storage label conditions
+	requirements, selectable := opts.Predicate.Label.Requirements()
+	if !selectable {
+		return apierrors.NewBadRequest("label selector is not selectable")
+	}
+
+	for _, r := range requirements {
+		if r.Operator() == selection.Equals {
+			req.Labels[r.Key()] = r.Values().List()[0]
+		}
+	}
+
+	// translate grafana.app/folder field selector to folder condition
+	fields := opts.Predicate.Field.Requirements()
+	for _, f := range fields {
+		if f.Field == "grafana.app/folder" {
+			if f.Operator != selection.Equals {
+				return apierrors.NewBadRequest("grafana.app/folder field selector only supports equality")
+			}
+
+			// select items in the spcified folder
+			req.Folder = f.Value
+		}
+	}
+
+	// use Transform function to remove grafana.app/folder field selector
+	opts.Predicate.Field, err = opts.Predicate.Field.Transform(func(field, value string) (string, string, error) {
+		if field == "grafana.app/folder" {
+			return "", "", nil
+		}
+		return field, value, nil
 	})
+	if err != nil {
+		return err
+	}
+
+	rsp, err := s.store.List(ctx, req)
 	if err != nil {
 		return apierrors.NewInternalError(err)
 	}
@@ -314,6 +354,15 @@ func (s *Storage) guaranteedUpdate(
 		return err
 	}
 
+	accessor, err := meta.Accessor(destination)
+	if err != nil {
+		return err
+	}
+	previousVersion, _ := strconv.ParseInt(accessor.GetResourceVersion(), 10, 64)
+	if preconditions != nil && preconditions.ResourceVersion != nil {
+		previousVersion, _ = strconv.ParseInt(*preconditions.ResourceVersion, 10, 64)
+	}
+
 	res := &storage.ResponseMeta{}
 	updatedObj, _, err := tryUpdate(destination, *res)
 	if err != nil {
@@ -331,11 +380,6 @@ func (s *Storage) guaranteedUpdate(
 	e, err := resourceToEntity(key, updatedObj, requestInfo, s.codec)
 	if err != nil {
 		return err
-	}
-
-	previousVersion := int64(0)
-	if preconditions != nil && preconditions.ResourceVersion != nil {
-		previousVersion, _ = strconv.ParseInt(*preconditions.ResourceVersion, 10, 64)
 	}
 
 	req := &entityStore.UpdateEntityRequest{

--- a/pkg/services/store/entity/key.go
+++ b/pkg/services/store/entity/key.go
@@ -42,7 +42,7 @@ func ParseKey(key string) (*Key, error) {
 }
 
 func (k *Key) String() string {
-	s := k.Group + "/" + k.Resource + "/" + k.Namespace
+	s := "/" + k.Group + "/" + k.Resource + "/" + k.Namespace
 	if len(k.Name) > 0 {
 		s += "/" + k.Name
 		if len(k.Subresource) > 0 {


### PR DESCRIPTION
This PR adds support for filtering objects by folder using the field selector `grafana.app/folder` as well as filtering objects by label values.

It also fixes a bug in Key where String() didn't include the leading slash.