### PR TITLE
Playlist: Implement a more efficient List command to support k8s list

### DIFF
--- a/pkg/registry/apis/playlist/legacy_storage.go
+++ b/pkg/registry/apis/playlist/legacy_storage.go
@@ -68,8 +68,8 @@ func (s *legacyStorage) List(ctx context.Context, options *internalversion.ListO
 	}
 
 	list := &playlist.PlaylistList{}
-	for _, v := range res {
-		list.Items = append(list.Items, *convertToK8sResource(&v, s.namespacer))
+	for idx := range res {
+		list.Items = append(list.Items, *convertToK8sResource(&res[idx], s.namespacer))
 	}
 	return list, nil
 }

--- a/pkg/registry/apis/playlist/legacy_storage.go
+++ b/pkg/registry/apis/playlist/legacy_storage.go
@@ -62,31 +62,14 @@ func (s *legacyStorage) List(ctx context.Context, options *internalversion.ListO
 		return nil, err
 	}
 
-	limit := 100
-	if options.Limit > 0 {
-		limit = int(options.Limit)
-	}
-	res, err := s.service.Search(ctx, &playlistsvc.GetPlaylistsQuery{
-		OrgId: orgId,
-		Limit: limit,
-	})
+	res, err := s.service.List(ctx, orgId)
 	if err != nil {
 		return nil, err
 	}
 
 	list := &playlist.PlaylistList{}
 	for _, v := range res {
-		p, err := s.service.Get(ctx, &playlistsvc.GetPlaylistByUidQuery{
-			UID:   v.UID,
-			OrgId: orgId,
-		})
-		if err != nil {
-			return nil, err
-		}
-		list.Items = append(list.Items, *convertToK8sResource(p, s.namespacer))
-	}
-	if len(list.Items) == limit {
-		list.Continue = "<more>" // TODO?
+		list.Items = append(list.Items, *convertToK8sResource(&v, s.namespacer))
 	}
 	return list, nil
 }

--- a/pkg/services/playlist/model.go
+++ b/pkg/services/playlist/model.go
@@ -28,7 +28,7 @@ type Playlist struct {
 type PlaylistDTO struct {
 	// Unique playlist identifier. Generated on creation, either by the
 	// creator of the playlist of by the application.
-	Uid string `json:"uid"`
+	Uid string `json:"uid" db:"uid"`
 
 	// Name of the playlist.
 	Name string `json:"name"`
@@ -40,16 +40,16 @@ type PlaylistDTO struct {
 	Items []PlaylistItemDTO `json:"items,omitempty"`
 
 	// Returned for k8s
-	CreatedAt int64 `json:"-"`
+	CreatedAt int64 `json:"-" db:"created_at"`
 
 	// Returned for k8s
-	UpdatedAt int64 `json:"-"`
+	UpdatedAt int64 `json:"-" db:"updated_at"`
 
 	// Returned for k8s
-	OrgID int64 `json:"-"`
+	OrgID int64 `json:"-" db:"org_id"`
 
 	// Returned for k8s and added as an annotation
-	Id int64 `json:"-"`
+	Id int64 `json:"-" db:"id"`
 }
 
 type PlaylistItemDTO struct {

--- a/pkg/services/playlist/playlist.go
+++ b/pkg/services/playlist/playlist.go
@@ -11,4 +11,7 @@ type Service interface {
 	Get(context.Context, *GetPlaylistByUidQuery) (*PlaylistDTO, error)
 	Search(context.Context, *GetPlaylistsQuery) (Playlists, error)
 	Delete(ctx context.Context, cmd *DeletePlaylistCommand) error
+
+	// This is optimized for the kubernetes list command that returns full bodies in the list
+	List(ctx context.Context, orgId int64) ([]PlaylistDTO, error)
 }

--- a/pkg/services/playlist/playlistimpl/playlist.go
+++ b/pkg/services/playlist/playlistimpl/playlist.go
@@ -90,3 +90,9 @@ func (s *Service) Delete(ctx context.Context, cmd *playlist.DeletePlaylistComman
 	defer span.End()
 	return s.store.Delete(ctx, cmd)
 }
+
+func (s *Service) List(ctx context.Context, orgId int64) ([]playlist.PlaylistDTO, error) {
+	ctx, span := s.tracer.Start(ctx, "playlists.List")
+	defer span.End()
+	return s.store.ListAll(ctx, orgId)
+}

--- a/pkg/services/playlist/playlistimpl/store.go
+++ b/pkg/services/playlist/playlistimpl/store.go
@@ -13,4 +13,7 @@ type store interface {
 	GetItems(context.Context, *playlist.GetPlaylistItemsByUidQuery) ([]playlist.PlaylistItem, error)
 	List(context.Context, *playlist.GetPlaylistsQuery) (playlist.Playlists, error)
 	Update(context.Context, *playlist.UpdatePlaylistCommand) (*playlist.PlaylistDTO, error)
+
+	// This is optimized for the kubernetes list command that returns full bodies in the list
+	ListAll(ctx context.Context, orgId int64) ([]playlist.PlaylistDTO, error)
 }

--- a/pkg/services/playlist/playlistimpl/store_test.go
+++ b/pkg/services/playlist/playlistimpl/store_test.go
@@ -2,6 +2,8 @@ package playlistimpl
 
 import (
 	"context"
+	"encoding/json"
+	"fmt"
 	"testing"
 	"time"
 
@@ -136,6 +138,53 @@ func testIntegrationPlaylistDataAccess(t *testing.T, fn getStore) {
 			res, err := playlistStore.List(context.Background(), &qr)
 			require.NoError(t, err)
 			require.Equal(t, 2, len(res))
+		})
+
+		t.Run("With FullList support", func(t *testing.T) {
+			res, err := playlistStore.ListAll(context.Background(), 1)
+			require.NoError(t, err)
+
+			for id := range res {
+				res[id].Uid = fmt.Sprintf("ROW:%d", id)
+			}
+
+			jj, err := json.MarshalIndent(res, "", "  ")
+			require.NoError(t, err)
+			// fmt.Printf("OUT:%s\n", string(jj))
+
+			// Each row has a full payload
+			require.JSONEq(t, `[
+				{
+				  "uid": "ROW:0",
+				  "name": "NICE office",
+				  "interval": "10m",
+				  "items": [
+					{
+					  "type": "dashboard_by_tag",
+					  "value": "graphite"
+					},
+					{
+					  "type": "dashboard_by_id",
+					  "value": "3"
+					}
+				  ]
+				},
+				{
+				  "uid": "ROW:1",
+				  "name": "NYC office",
+				  "interval": "10m",
+				  "items": [
+					{
+					  "type": "dashboard_by_tag",
+					  "value": "graphite"
+					},
+					{
+					  "type": "dashboard_by_id",
+					  "value": "3"
+					}
+				  ]
+				}
+			  ]`, string(jj))
 		})
 	})
 

--- a/pkg/services/playlist/playlistimpl/xorm_store.go
+++ b/pkg/services/playlist/playlistimpl/xorm_store.go
@@ -223,25 +223,6 @@ func (s *sqlStore) ListAll(ctx context.Context, orgId int64) ([]playlist.Playlis
 		})
 		playlists[idx].Items = items
 	}
-
-	// err := s.db.WithDbSession(ctx, func(dbSess *db.Session) error {
-	// 	sess := dbSess.Limit(1000) // MAX?
-	// 	sess.Where("org_id = ?", orgId)
-	// 	err := sess.Find(&playlists)
-	// 	return err
-	// })
-	// if err != nil {
-	// 	return nil, err
-	// }
-
-	// playlistItems := make([]playlist.PlaylistItem, 0)
-	// err = s.db.WithDbSession(ctx, func(dbSess *db.Session) error {
-	// 	sess := dbSess.Limit(5000) // items
-	// 	sess.Where("org_id = ?", orgId)
-	// 	err := sess.Find(&playlistItems)
-	// 	return err
-	// })
-
 	return playlists, err
 }
 

--- a/pkg/services/playlist/playlistimpl/xorm_store.go
+++ b/pkg/services/playlist/playlistimpl/xorm_store.go
@@ -2,6 +2,7 @@ package playlistimpl
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	"github.com/grafana/grafana/pkg/infra/db"
@@ -177,6 +178,70 @@ func (s *sqlStore) List(ctx context.Context, query *playlist.GetPlaylistsQuery) 
 
 		return err
 	})
+	return playlists, err
+}
+
+func (s *sqlStore) ListAll(ctx context.Context, orgId int64) ([]playlist.PlaylistDTO, error) {
+	db := s.db.GetSqlxSession() // OK because dates are numbers!
+
+	playlists := []playlist.PlaylistDTO{}
+	err := db.Select(ctx, &playlists, "SELECT * FROM playlist WHERE org_id=? ORDER BY created_at asc", orgId)
+	if err != nil {
+		return nil, err
+	}
+
+	// Create a map that links playlist id to the playlist array index
+	lookup := map[int64]int{}
+	for i, v := range playlists {
+		lookup[v.Id] = i
+	}
+
+	var playlistId int64
+	var itemType string
+	var itemValue string
+
+	rows, err := db.Query(ctx, `SELECT playlist.id,playlist_item.type,playlist_item.value
+		FROM playlist_item 
+		JOIN playlist ON playlist_item.playlist_id = playlist.id
+		WHERE playlist.org_id = ?
+		ORDER BY playlist_id asc, `+s.db.Quote("order")+` asc`, orgId)
+	if err != nil {
+		return nil, err
+	}
+	for rows.Next() {
+		err = rows.Scan(&playlistId, &itemType, &itemValue)
+		if err != nil {
+			return nil, err
+		}
+		idx, ok := lookup[playlistId]
+		if !ok {
+			return nil, fmt.Errorf("could not find playlist by id")
+		}
+		items := append(playlists[idx].Items, playlist.PlaylistItemDTO{
+			Type:  itemType,
+			Value: itemValue,
+		})
+		playlists[idx].Items = items
+	}
+
+	// err := s.db.WithDbSession(ctx, func(dbSess *db.Session) error {
+	// 	sess := dbSess.Limit(1000) // MAX?
+	// 	sess.Where("org_id = ?", orgId)
+	// 	err := sess.Find(&playlists)
+	// 	return err
+	// })
+	// if err != nil {
+	// 	return nil, err
+	// }
+
+	// playlistItems := make([]playlist.PlaylistItem, 0)
+	// err = s.db.WithDbSession(ctx, func(dbSess *db.Session) error {
+	// 	sess := dbSess.Limit(5000) // items
+	// 	sess.Where("org_id = ?", orgId)
+	// 	err := sess.Find(&playlistItems)
+	// 	return err
+	// })
+
 	return playlists, err
 }
 


### PR DESCRIPTION
Currently we implement playlists using the sql commands as they have existed forever.  The semantics for "List" do not match because k8s needs to return full payloads for each item.  We made that work by querying each item in the list.

This PR adds a new query optimized to return everythign needed for k8s List.

It replaces the 1+(2*n) queries with two queries, and should help reduce k6 testing issues 😛 

This adds a new SQL based test, but existing tests will exercise its correctness also