### PR TITLE
Docs: Improves date format in alerting sample

### DIFF
--- a/docs/sources/alerting/fundamentals/alert-rules/rule-evaluation/_index.md
+++ b/docs/sources/alerting/fundamentals/alert-rules/rule-evaluation/_index.md
@@ -42,16 +42,15 @@ Imagine you have an alert rule evaluation interval set at every 30 seconds and t
 
 Evaluation will occur as follows:
 
-[00:30] First evaluation - condition not met.
+`11:00:30` First evaluation - condition not met.
 
-[01:00] Second evaluation - condition breached.
-Pending counter starts. **Alert starts pending.**
+`11:01:00` Second evaluation - condition breached. Pending counter starts. **Alert starts pending.**
 
-[01:30] Third evaluation - condition breached. Pending counter = 30s. **Pending state.**
+`11:01:30` Third evaluation - condition breached. Pending counter = 30s. **Pending state.**
 
-[02:00] Fourth evaluation - condition breached. Pending counter = 60s **Pending state.**
+`11:02:00` Fourth evaluation - condition breached. Pending counter = 60s **Pending state.**
 
-[02:30] Fifth evaluation - condition breached. Pending counter = 90s. **Alert starts firing**
+`11:02:30` Fifth evaluation - condition breached. Pending counter = 90s. **Alert starts firing**
 
 If the alert rule has a condition that needs to be in breach for a certain amount of time before it takes action, then its state changes as follows:
 


### PR DESCRIPTION
By this change given example presents time period and not like timer format.

**What is this feature?**

documentation improvement

**Why do we need this feature?**

to clarify samples presented in documentation

**Who is this feature for?**

users who want to understand how grafana alerts should be implemented

**Which issue(s) does this PR fix?**:


**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
