### PR TITLE
BarChart: Show "No data" message for zero-length frames

### DIFF
--- a/public/app/plugins/panel/barchart/utils.test.ts
+++ b/public/app/plugins/panel/barchart/utils.test.ts
@@ -158,8 +158,24 @@ describe('BarChart utils', () => {
   });
 
   describe('prepareGraphableFrames', () => {
-    it('will warn when there is no data in the response', () => {
+    it('will warn when there is no frames in the response', () => {
       const result = prepareBarChartDisplayValues([], createTheme(), { stacking: StackingMode.None } as Options);
+      const warning = assertIsDefined('warn' in result ? result : null);
+
+      expect(warning.warn).toEqual('No data in response');
+    });
+
+    it('will warn when there is no data in the response', () => {
+      const result = prepareBarChartDisplayValues(
+        [
+          {
+            length: 0,
+            fields: [],
+          },
+        ],
+        createTheme(),
+        { stacking: StackingMode.None } as Options
+      );
       const warning = assertIsDefined('warn' in result ? result : null);
 
       expect(warning.warn).toEqual('No data in response');

--- a/public/app/plugins/panel/barchart/utils.ts
+++ b/public/app/plugins/panel/barchart/utils.ts
@@ -375,7 +375,7 @@ export function prepareBarChartDisplayValues(
   theme: GrafanaTheme2,
   options: Options
 ): BarChartDisplayValues | BarChartDisplayWarning {
-  if (!series?.length) {
+  if (!series.length || series.every((fr) => fr.length === 0)) {
     return { warn: 'No data in response' };
   }
 


### PR DESCRIPTION
Fixes https://github.com/grafana/support-escalations/issues/8826

before:

![image](https://github.com/grafana/grafana/assets/43234/102ab6ab-ff00-4442-942a-f05cb56d7fe4)

after:

![image](https://github.com/grafana/grafana/assets/43234/084d6b50-e20b-4a6c-a27a-03b174389666)
