### PR TITLE
AccessControl: Add safety valve truncation for long user defined scopes 

### DIFF
--- a/pkg/services/accesscontrol/migrator/migrator.go
+++ b/pkg/services/accesscontrol/migrator/migrator.go
@@ -11,8 +11,9 @@ import (
 	"github.com/grafana/grafana/pkg/services/sqlstore/session"
 )
 
-var (
+const (
 	batchSize = 1000
+	maxLen    = 40
 )
 
 func MigrateScopeSplit(db db.DB, log log.Logger) error {
@@ -48,6 +49,12 @@ func MigrateScopeSplit(db db.DB, log log.Logger) error {
 		// Prepare batch of updated permissions
 		for i := start; i < end; i++ {
 			kind, attribute, identifier := permissions[i].SplitScope()
+
+			// Trim to max length to avoid bootloop.
+			// too long scopes will be truncated and the permission will become invalid.
+			kind = trimToMaxLen(kind, maxLen)
+			attribute = trimToMaxLen(attribute, maxLen)
+			identifier = trimToMaxLen(identifier, maxLen)
 
 			delQuery += "?,"
 			delArgs = append(delArgs, permissions[i].ID)
@@ -108,4 +115,11 @@ func batch(count, batchSize int, eachFn func(start, end int) error) error {
 	}
 
 	return nil
+}
+
+func trimToMaxLen(s string, maxLen int) string {
+	if len(s) > maxLen {
+		return s[:maxLen]
+	}
+	return s
 }

--- a/pkg/services/accesscontrol/migrator/migrator.go
+++ b/pkg/services/accesscontrol/migrator/migrator.go
@@ -11,9 +11,12 @@ import (
 	"github.com/grafana/grafana/pkg/services/sqlstore/session"
 )
 
-const (
+var (
 	batchSize = 1000
-	maxLen    = 40
+)
+
+const (
+	maxLen = 40
 )
 
 func MigrateScopeSplit(db db.DB, log log.Logger) error {

--- a/pkg/services/accesscontrol/migrator/migrator_test.go
+++ b/pkg/services/accesscontrol/migrator/migrator_test.go
@@ -77,7 +77,6 @@ func TestIntegrationMigrateScopeSplitTruncation(t *testing.T) {
 			assert.Equal(t, strings.Repeat("a", 40), permissions[i].Kind)
 			assert.Equal(t, strings.Repeat("b", 40), permissions[i].Attribute)
 			assert.Equal(t, strings.Repeat("c", 40), permissions[i].Identifier)
-
 		}
 	}
 }

--- a/pkg/services/accesscontrol/migrator/migrator_test.go
+++ b/pkg/services/accesscontrol/migrator/migrator_test.go
@@ -49,7 +49,7 @@ func TestIntegrationMigrateScopeSplitTruncation(t *testing.T) {
 	require.NoError(t, batchInsertPermissions(3*batchSize, sqlStore), "could not insert permissions")
 
 	// Insert a permission with a scope longer than 240 characters
-	longScope := strings.Repeat("a", 100) + ":" + strings.Repeat("b", 100) + ":" + strings.Repeat("c", 100)
+	longScope := strings.Repeat("a", 60) + ":" + strings.Repeat("b", 60) + ":" + strings.Repeat("c", 60)
 	permission := ac.Permission{
 		RoleID:  1,
 		Action:  "action",

--- a/pkg/services/accesscontrol/migrator/migrator_test.go
+++ b/pkg/services/accesscontrol/migrator/migrator_test.go
@@ -3,14 +3,17 @@ package migrator
 import (
 	"context"
 	"fmt"
+	"strings"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/grafana/grafana/pkg/infra/db"
 	"github.com/grafana/grafana/pkg/infra/log"
 	ac "github.com/grafana/grafana/pkg/services/accesscontrol"
 	"github.com/grafana/grafana/pkg/services/sqlstore"
-	"github.com/stretchr/testify/require"
 )
 
 func batchInsertPermissions(cnt int, sqlStore db.DB) error {
@@ -35,27 +38,46 @@ func batchInsertPermissions(cnt int, sqlStore db.DB) error {
 	})
 }
 
-func TestMigrateScopeSplit(t *testing.T) {
+// TestIntegrationMigrateScopeSplit tests the scope split migration
+// also tests the scope split truncation logic
+func TestIntegrationMigrateScopeSplitTruncation(t *testing.T) {
 	sqlStore := db.InitTestDB(t)
 	logger := log.New("accesscontrol.migrator.test")
 
+	batchSize = 20
 	// Populate permissions
 	require.NoError(t, batchInsertPermissions(3*batchSize, sqlStore), "could not insert permissions")
+
+	// Insert a permission with a scope longer than 240 characters
+	longScope := strings.Repeat("a", 100) + ":" + strings.Repeat("b", 100) + ":" + strings.Repeat("c", 100)
+	permission := ac.Permission{
+		RoleID:  1,
+		Action:  "action",
+		Scope:   longScope,
+		Created: time.Now(),
+		Updated: time.Now(),
+	}
+	require.NoError(t, sqlStore.WithDbSession(context.Background(), func(sess *db.Session) error {
+		_, err := sess.Insert(permission)
+		return err
+	}), "could not insert permission with long scope")
 
 	// Migrate
 	require.NoError(t, MigrateScopeSplit(sqlStore, logger))
 
 	// Check migration result
-	permissions := make([]ac.Permission, 0, 3*batchSize)
+	permissions := make([]ac.Permission, 0, 3*batchSize+1)
 	errFind := sqlStore.WithDbSession(context.Background(), func(sess *sqlstore.DBSession) error {
 		return sess.Find(&permissions)
 	})
 	require.NoError(t, errFind, "could not find permissions in store")
 
 	for i := range permissions {
-		require.Equal(t, fmt.Sprintf("resource:uid:%v", i+1), permissions[i].Scope, "scope should have been preserved")
-		require.Equal(t, "resource", permissions[i].Kind)
-		require.Equal(t, "uid", permissions[i].Attribute)
-		require.Equal(t, fmt.Sprintf("%v", i+1), permissions[i].Identifier)
+		if permissions[i].Scope == longScope {
+			assert.Equal(t, strings.Repeat("a", 40), permissions[i].Kind)
+			assert.Equal(t, strings.Repeat("b", 40), permissions[i].Attribute)
+			assert.Equal(t, strings.Repeat("c", 40), permissions[i].Identifier)
+
+		}
 	}
 }


### PR DESCRIPTION
**What is this feature?**

Tweak migration to cut down user invalid scopes

**Why do we need this feature?**

Users break migration with undefined behavior

**Who is this feature for?**

[Add information on what kind of user the feature is for.]

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
