### PR TITLE
ServerLock: Allow use of remote cache as server lock

### DIFF
--- a/conf/defaults.ini
+++ b/conf/defaults.ini
@@ -186,7 +186,7 @@ encryption =
 [server_lock]
 # Either "database", "remote_cache", default is "database", remote cache is
 # only usable when cache is enabled and type is not set to database
-type = database
+driver = database
 
 #################################### Data proxy ###########################
 [dataproxy]

--- a/conf/defaults.ini
+++ b/conf/defaults.ini
@@ -183,6 +183,11 @@ prefix =
 # This enables encryption of values stored in the remote cache
 encryption =
 
+[server_lock]
+# Either "database", "remote_cache", default is "database", remote cache is
+# only usable when cache is enabled and type is not set to database
+type = database
+
 #################################### Data proxy ###########################
 [dataproxy]
 
@@ -592,7 +597,7 @@ org_role = Viewer
 hide_version = false
 
 # number of devices in total
-device_limit = 
+device_limit =
 
 #################################### GitHub Auth #########################
 [auth.github]

--- a/conf/sample.ini
+++ b/conf/sample.ini
@@ -193,7 +193,7 @@
 [server_lock]
 # Either "database", "remote_cache", default is "database", remote cache is
 # only usable when cache is enabled and type is not set to database
-; type = database
+; driver = database
 
 #################################### Data proxy ###########################
 [dataproxy]

--- a/conf/sample.ini
+++ b/conf/sample.ini
@@ -190,6 +190,11 @@
 # This enables encryption of values stored in the remote cache
 ;encryption =
 
+[server_lock]
+# Either "database", "remote_cache", default is "database", remote cache is
+# only usable when cache is enabled and type is not set to database
+; type = database
+
 #################################### Data proxy ###########################
 [dataproxy]
 
@@ -1620,4 +1625,3 @@
 [public_dashboards]
 # Set to false to disable public dashboards
 ;enabled = true
-

--- a/pkg/infra/remotecache/memcached_storage_integration_test.go
+++ b/pkg/infra/remotecache/memcached_storage_integration_test.go
@@ -18,7 +18,7 @@ func TestIntegrationMemcachedCacheStorage(t *testing.T) {
 	}
 
 	opts := &setting.RemoteCacheOptions{Name: memcachedCacheType, ConnStr: u}
-	client := createTestClient(t, opts, nil)
+	client := CreateTestClient(t, opts, nil)
 	runTestsForClient(t, client)
 	runCountTestsForClient(t, opts, nil)
 }

--- a/pkg/infra/remotecache/redis_storage_integration_test.go
+++ b/pkg/infra/remotecache/redis_storage_integration_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/go-redis/redis/v8"
+
 	"github.com/grafana/grafana/pkg/setting"
 )
 
@@ -35,7 +36,7 @@ func TestIntegrationRedisCacheStorage(t *testing.T) {
 	}
 
 	opts := &setting.RemoteCacheOptions{Name: redisCacheType, ConnStr: b.String()}
-	client := createTestClient(t, opts, nil)
+	client := CreateTestClient(t, opts, nil)
 	runTestsForClient(t, client)
 	runCountTestsForClient(t, opts, nil)
 }

--- a/pkg/infra/remotecache/remotecache.go
+++ b/pkg/infra/remotecache/remotecache.go
@@ -6,7 +6,6 @@ import (
 	"time"
 
 	"github.com/grafana/grafana/pkg/infra/db"
-	"github.com/grafana/grafana/pkg/infra/usagestats"
 	"github.com/grafana/grafana/pkg/registry"
 	"github.com/grafana/grafana/pkg/services/secrets"
 	"github.com/grafana/grafana/pkg/setting"
@@ -26,7 +25,7 @@ const (
 	ServiceName = "RemoteCache"
 )
 
-func ProvideService(cfg *setting.Cfg, sqlStore db.DB, usageStats usagestats.Service,
+func ProvideService(cfg *setting.Cfg, sqlStore db.DB,
 	secretsService secrets.Service) (*RemoteCache, error) {
 	client, err := createClient(cfg.RemoteCacheOptions, sqlStore, secretsService)
 	if err != nil {
@@ -38,12 +37,10 @@ func ProvideService(cfg *setting.Cfg, sqlStore db.DB, usageStats usagestats.Serv
 		client:   client,
 	}
 
-	usageStats.RegisterMetricsFunc(s.getUsageStats)
-
 	return s, nil
 }
 
-func (ds *RemoteCache) getUsageStats(ctx context.Context) (map[string]any, error) {
+func (ds *RemoteCache) GetUsageStats(ctx context.Context) map[string]any {
 	stats := map[string]any{}
 	stats["stats.remote_cache."+ds.Cfg.RemoteCacheOptions.Name+".count"] = 1
 	encryptVal := 0
@@ -53,7 +50,7 @@ func (ds *RemoteCache) getUsageStats(ctx context.Context) (map[string]any, error
 
 	stats["stats.remote_cache.encrypt_enabled.count"] = encryptVal
 
-	return stats, nil
+	return stats
 }
 
 // CacheStorage allows the caller to set, get and delete items in the cache.

--- a/pkg/infra/remotecache/remotecache_test.go
+++ b/pkg/infra/remotecache/remotecache_test.go
@@ -97,7 +97,7 @@ func canNotFetchExpiredItems(t *testing.T, client CacheStorage) {
 	// should not be able to read that value since its expired
 	_, err = client.Get(context.Background(), "key1")
 	// redis client returns redis.Nil error when key does not exist.
-	assert.Error(t, err)
+	assert.ErrorIs(t, err, ErrCacheItemNotFound)
 }
 
 func TestCollectUsageStats(t *testing.T) {

--- a/pkg/infra/remotecache/remotecache_test.go
+++ b/pkg/infra/remotecache/remotecache_test.go
@@ -10,21 +10,8 @@ import (
 
 	"github.com/grafana/grafana/pkg/infra/db"
 	"github.com/grafana/grafana/pkg/services/secrets"
-	"github.com/grafana/grafana/pkg/services/secrets/fakes"
 	"github.com/grafana/grafana/pkg/setting"
 )
-
-func createTestClient(t *testing.T, opts *setting.RemoteCacheOptions, sqlstore db.DB) CacheStorage {
-	t.Helper()
-
-	cfg := &setting.Cfg{
-		RemoteCacheOptions: opts,
-	}
-	dc, err := ProvideService(cfg, sqlstore, fakes.NewFakeSecretsService())
-	require.Nil(t, err, "Failed to init client for test")
-
-	return dc
-}
 
 func TestCachedBasedOnConfig(t *testing.T) {
 	cfg := setting.NewCfg()
@@ -33,7 +20,7 @@ func TestCachedBasedOnConfig(t *testing.T) {
 	})
 	require.Nil(t, err, "Failed to load config")
 
-	client := createTestClient(t, cfg.RemoteCacheOptions, db.InitTestDB(t))
+	client := CreateTestClient(t, cfg.RemoteCacheOptions, db.InitTestDB(t))
 	runTestsForClient(t, client)
 	runCountTestsForClient(t, cfg.RemoteCacheOptions, db.InitTestDB(t))
 }
@@ -49,7 +36,7 @@ func runTestsForClient(t *testing.T, client CacheStorage) {
 }
 
 func runCountTestsForClient(t *testing.T, opts *setting.RemoteCacheOptions, sqlstore db.DB) {
-	client := createTestClient(t, opts, sqlstore)
+	client := CreateTestClient(t, opts, sqlstore)
 	expectError := false
 	if opts.Name == memcachedCacheType {
 		expectError = true

--- a/pkg/infra/remotecache/remotecache_test.go
+++ b/pkg/infra/remotecache/remotecache_test.go
@@ -9,7 +9,6 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/grafana/grafana/pkg/infra/db"
-	"github.com/grafana/grafana/pkg/infra/usagestats"
 	"github.com/grafana/grafana/pkg/services/secrets"
 	"github.com/grafana/grafana/pkg/services/secrets/fakes"
 	"github.com/grafana/grafana/pkg/setting"
@@ -21,7 +20,7 @@ func createTestClient(t *testing.T, opts *setting.RemoteCacheOptions, sqlstore d
 	cfg := &setting.Cfg{
 		RemoteCacheOptions: opts,
 	}
-	dc, err := ProvideService(cfg, sqlstore, &usagestats.UsageStatsMock{}, fakes.NewFakeSecretsService())
+	dc, err := ProvideService(cfg, sqlstore, fakes.NewFakeSecretsService())
 	require.Nil(t, err, "Failed to init client for test")
 
 	return dc
@@ -126,8 +125,7 @@ func TestCollectUsageStats(t *testing.T) {
 		Cfg: cfg,
 	}
 
-	stats, err := remoteCache.getUsageStats(context.Background())
-	require.NoError(t, err)
+	stats := remoteCache.GetUsageStats(context.Background())
 
 	assert.EqualValues(t, wantMap, stats)
 }

--- a/pkg/infra/remotecache/test_utils.go
+++ b/pkg/infra/remotecache/test_utils.go
@@ -2,7 +2,18 @@ package remotecache
 
 import (
 	"context"
+	"fmt"
+	"os"
+	"strings"
+	"testing"
 	"time"
+
+	"github.com/go-redis/redis/v8"
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/grafana/pkg/infra/db"
+	"github.com/grafana/grafana/pkg/services/secrets/fakes"
+	"github.com/grafana/grafana/pkg/setting"
 )
 
 type FakeCacheStorage struct {
@@ -35,5 +46,49 @@ func (fcs FakeCacheStorage) Count(_ context.Context, prefix string) (int64, erro
 func NewFakeCacheStorage() FakeCacheStorage {
 	return FakeCacheStorage{
 		Storage: map[string][]byte{},
+	}
+}
+
+func CreateTestClient(t *testing.T, opts *setting.RemoteCacheOptions, sqlstore db.DB) CacheStorage {
+	t.Helper()
+
+	cfg := &setting.Cfg{
+		RemoteCacheOptions: opts,
+	}
+	dc, err := ProvideService(cfg, sqlstore, fakes.NewFakeSecretsService())
+	require.Nil(t, err, "Failed to init client for test")
+
+	return dc
+}
+
+func CreateTestRedisCacheStorage(t *testing.T) *RemoteCache {
+	t.Helper()
+
+	u, ok := os.LookupEnv("REDIS_URL")
+	if !ok || u == "" {
+		t.Skip("No redis URL supplied")
+	}
+
+	addr := u
+	db := 0
+	parsed, err := redis.ParseURL(u)
+	if err == nil {
+		addr = parsed.Addr
+		db = parsed.DB
+	}
+
+	b := strings.Builder{}
+	b.WriteString(fmt.Sprintf("addr=%s", addr))
+	if db != 0 {
+		b.WriteString(fmt.Sprintf(",db=%d", db))
+	}
+
+	opts := &setting.RemoteCacheOptions{Name: setting.RedisCacheType,
+		ConnStr: b.String(), Prefix: t.Name()}
+	client := CreateTestClient(t, opts, nil)
+	return &RemoteCache{
+		SQLStore: nil,
+		Cfg:      setting.NewCfg(),
+		client:   client,
 	}
 }

--- a/pkg/infra/remotecache/testing.go
+++ b/pkg/infra/remotecache/testing.go
@@ -6,7 +6,6 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/grafana/grafana/pkg/infra/db"
-	"github.com/grafana/grafana/pkg/infra/usagestats"
 	"github.com/grafana/grafana/pkg/services/secrets/fakes"
 	"github.com/grafana/grafana/pkg/setting"
 )
@@ -24,7 +23,7 @@ func NewFakeStore(t *testing.T) *RemoteCache {
 
 	dc, err := ProvideService(&setting.Cfg{
 		RemoteCacheOptions: opts,
-	}, sqlStore, &usagestats.UsageStatsMock{}, fakes.NewFakeSecretsService())
+	}, sqlStore, fakes.NewFakeSecretsService())
 	require.NoError(t, err, "Failed to init remote cache for test")
 
 	return dc

--- a/pkg/infra/serverlock/db.go
+++ b/pkg/infra/serverlock/db.go
@@ -98,19 +98,18 @@ func (sl *serverLockDB) AcquireForRelease(ctx context.Context, actionName string
 			result := lockRows[0]
 			if isLockWithinInterval(result, maxInterval) {
 				return &ServerLockExistsError{actionName: actionName}
-			} else {
-				// lock has timeouted, so we update the timestamp
-				result.LastExecution = time.Now().Unix()
-				cond := &serverLock{OperationUID: actionName}
-				affected, err := dbSession.Update(result, cond)
-				if err != nil {
-					return err
-				}
-				if affected != 1 {
-					ctxLogger.Error("Expected rows affected to be 1 if there was no error", "actionName", actionName, "rowsAffected", affected)
-				}
-				return nil
 			}
+			// lock has timeouted, so we update the timestamp
+			result.LastExecution = time.Now().Unix()
+			cond := &serverLock{OperationUID: actionName}
+			affected, err := dbSession.Update(result, cond)
+			if err != nil {
+				return err
+			}
+			if affected != 1 {
+				ctxLogger.Error("Expected rows affected to be 1 if there was no error", "actionName", actionName, "rowsAffected", affected)
+			}
+			return nil
 		} else {
 			// lock not found, creating it
 			lockRow := &serverLock{
@@ -130,6 +129,7 @@ func (sl *serverLockDB) AcquireForRelease(ctx context.Context, actionName string
 		}
 		return nil
 	})
+
 	return err
 }
 

--- a/pkg/infra/serverlock/db.go
+++ b/pkg/infra/serverlock/db.go
@@ -1,0 +1,157 @@
+package serverlock
+
+import (
+	"context"
+	"time"
+
+	"github.com/grafana/grafana/pkg/infra/db"
+	"github.com/grafana/grafana/pkg/infra/log"
+	"github.com/grafana/grafana/pkg/infra/tracing"
+)
+
+type serverLockDB struct {
+	SQLStore db.DB
+	tracer   tracing.Tracer
+	log      log.Logger
+}
+
+func (sl *serverLockDB) AcquireLock(ctx context.Context, serverLock *serverLock) (bool, error) {
+	ctx, span := sl.tracer.Start(ctx, "ServerLockService.acquireLock")
+	defer span.End()
+	var result bool
+
+	err := sl.SQLStore.WithDbSession(ctx, func(dbSession *db.Session) error {
+		newVersion := serverLock.Version + 1
+		sql := `UPDATE server_lock SET
+			version = ?,
+			last_execution = ?
+		WHERE
+			id = ? AND version = ?`
+
+		res, err := dbSession.Exec(sql, newVersion, time.Now().Unix(), serverLock.Id, serverLock.Version)
+		if err != nil {
+			return err
+		}
+
+		affected, err := res.RowsAffected()
+		result = affected == 1
+
+		return err
+	})
+
+	return result, err
+}
+
+func (sl *serverLockDB) GetOrCreate(ctx context.Context, actionName string) (*serverLock, error) {
+	ctx, span := sl.tracer.Start(ctx, "ServerLockService.getOrCreate")
+	defer span.End()
+
+	var result *serverLock
+
+	err := sl.SQLStore.WithTransactionalDbSession(ctx, func(dbSession *db.Session) error {
+		lockRows := []*serverLock{}
+		err := dbSession.Where("operation_uid = ?", actionName).Find(&lockRows)
+		if err != nil {
+			return err
+		}
+
+		if len(lockRows) > 0 {
+			result = lockRows[0]
+			return nil
+		}
+
+		lockRow := &serverLock{
+			OperationUID:  actionName,
+			LastExecution: 0,
+		}
+
+		_, err = dbSession.Insert(lockRow)
+		if err != nil {
+			return err
+		}
+
+		result = lockRow
+		return nil
+	})
+
+	return result, err
+}
+
+// acquireForRelease will check if the lock is already on the database, if it is, will check with maxInterval if it is
+// timeouted. Returns nil error if the lock was acquired correctly
+func (sl *serverLockDB) AcquireForRelease(ctx context.Context, actionName string, maxInterval time.Duration) error {
+	ctx, span := sl.tracer.Start(ctx, "ServerLockService.acquireForRelease")
+	defer span.End()
+
+	// getting the lock - as the action name has a Unique constraint, this will fail if the lock is already on the database
+	err := sl.SQLStore.WithTransactionalDbSession(ctx, func(dbSession *db.Session) error {
+		// we need to find if the lock is in the database
+		lockRows := []*serverLock{}
+		err := dbSession.Where("operation_uid = ?", actionName).Find(&lockRows)
+		if err != nil {
+			return err
+		}
+
+		ctxLogger := sl.log.FromContext(ctx)
+
+		if len(lockRows) > 0 {
+			result := lockRows[0]
+			if isLockWithinInterval(result, maxInterval) {
+				return &ServerLockExistsError{actionName: actionName}
+			} else {
+				// lock has timeouted, so we update the timestamp
+				result.LastExecution = time.Now().Unix()
+				cond := &serverLock{OperationUID: actionName}
+				affected, err := dbSession.Update(result, cond)
+				if err != nil {
+					return err
+				}
+				if affected != 1 {
+					ctxLogger.Error("Expected rows affected to be 1 if there was no error", "actionName", actionName, "rowsAffected", affected)
+				}
+				return nil
+			}
+		} else {
+			// lock not found, creating it
+			lockRow := &serverLock{
+				OperationUID:  actionName,
+				LastExecution: time.Now().Unix(),
+			}
+
+			affected, err := dbSession.Insert(lockRow)
+			if err != nil {
+				return err
+			}
+
+			if affected != 1 {
+				// this means that there was no error but there is something not working correctly
+				ctxLogger.Error("Expected rows affected to be 1 if there was no error", "actionName", actionName, "rowsAffected", affected)
+			}
+		}
+		return nil
+	})
+	return err
+}
+
+// releaseLock will delete the row at the database. This is only intended to be used within the scope of LockExecuteAndRelease
+// method, but not as to manually release a Lock
+func (sl *serverLockDB) ReleaseLock(ctx context.Context, actionName string) error {
+	ctx, span := sl.tracer.Start(ctx, "ServerLockService.releaseLock")
+	defer span.End()
+
+	err := sl.SQLStore.WithDbSession(ctx, func(dbSession *db.Session) error {
+		sql := `DELETE FROM server_lock WHERE operation_uid=? `
+
+		res, err := dbSession.Exec(sql, actionName)
+		if err != nil {
+			return err
+		}
+		affected, err := res.RowsAffected()
+		if affected != 1 {
+			sl.log.FromContext(ctx).Debug("Error releasing lock", "actionName", actionName, "rowsAffected", affected)
+		}
+		return err
+	})
+
+	return err
+}

--- a/pkg/infra/serverlock/db_test.go
+++ b/pkg/infra/serverlock/db_test.go
@@ -1,0 +1,99 @@
+package serverlock
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/grafana/pkg/infra/db"
+	"github.com/grafana/grafana/pkg/infra/log"
+	"github.com/grafana/grafana/pkg/infra/tracing"
+)
+
+func createTestableServerLockDB(t *testing.T) *serverLockDB {
+	t.Helper()
+
+	store := db.InitTestDB(t)
+
+	return &serverLockDB{
+		SQLStore: store,
+		tracer:   tracing.InitializeTracerForTest(),
+		log:      log.New("test-logger"),
+	}
+}
+
+func TestLockAndRelease(t *testing.T) {
+	operationUID := "test-operation-release"
+
+	t.Run("create lock and then release it", func(t *testing.T) {
+		sl := createTestableServerLockDB(t)
+		duration := time.Hour * 5
+
+		err := sl.AcquireForRelease(context.Background(), operationUID, duration)
+		require.NoError(t, err)
+
+		err = sl.ReleaseLock(context.Background(), operationUID)
+		require.NoError(t, err)
+
+		// and now we can acquire it again
+		err2 := sl.AcquireForRelease(context.Background(), operationUID, duration)
+		require.NoError(t, err2)
+
+		err = sl.ReleaseLock(context.Background(), operationUID)
+		require.NoError(t, err)
+	})
+
+	t.Run("try to acquire a lock which is already locked, get error", func(t *testing.T) {
+		sl := createTestableServerLockDB(t)
+		duration := time.Hour * 5
+
+		err := sl.AcquireForRelease(context.Background(), operationUID, duration)
+		require.NoError(t, err)
+
+		err2 := sl.AcquireForRelease(context.Background(), operationUID, duration)
+		require.Error(t, err2, "We should expect an error when trying to get the second lock")
+		require.Equal(t, "there is already a lock for this actionName: "+operationUID, err2.Error())
+
+		err3 := sl.ReleaseLock(context.Background(), operationUID)
+		require.NoError(t, err3)
+	})
+
+	t.Run("lock already exists but is timeouted", func(t *testing.T) {
+		sl := createTestableServerLockDB(t)
+		pastLastExec := time.Now().Add(-time.Hour).Unix()
+		lock := serverLock{
+			OperationUID:  operationUID,
+			LastExecution: pastLastExec,
+		}
+
+		// inserting a row with lock in the past
+		err := sl.SQLStore.WithTransactionalDbSession(context.Background(), func(sess *db.Session) error {
+			affectedRows, err := sess.Insert(&lock)
+			require.NoError(t, err)
+			require.Equal(t, int64(1), affectedRows)
+			require.Equal(t, int64(1), lock.Id)
+			return nil
+		})
+		require.NoError(t, err)
+		duration := time.Minute * 5
+
+		err = sl.AcquireForRelease(context.Background(), operationUID, duration)
+		require.NoError(t, err)
+
+		//validate that the lock LastExecution was updated (at least different from the original)
+		err = sl.SQLStore.WithTransactionalDbSession(context.Background(), func(sess *db.Session) error {
+			lockRows := []*serverLock{}
+			err := sess.Where("operation_uid = ?", operationUID).Find(&lockRows)
+			require.NoError(t, err)
+			require.Equal(t, 1, len(lockRows))
+			require.NotEqual(t, pastLastExec, lockRows[0].LastExecution)
+			return nil
+		})
+		require.NoError(t, err)
+
+		err3 := sl.ReleaseLock(context.Background(), operationUID)
+		require.NoError(t, err3)
+	})
+}

--- a/pkg/infra/serverlock/model.go
+++ b/pkg/infra/serverlock/model.go
@@ -2,8 +2,8 @@ package serverlock
 
 type serverLock struct {
 	// nolint:stylecheck
-	Id            int64
-	OperationUID  string `xorm:"operation_uid"`
-	LastExecution int64
-	Version       int64
+	Id            int64  `json:"-"`
+	OperationUID  string `xorm:"operation_uid" json:"operation_uid"`
+	LastExecution int64  `json:"last_execution" xorm:"last_execution"`
+	Version       int64  `json:"-"`
 }

--- a/pkg/infra/serverlock/remote_cache.go
+++ b/pkg/infra/serverlock/remote_cache.go
@@ -28,6 +28,7 @@ func (sl *serverLockRemoteCache) AcquireLock(ctx context.Context, serverLock *se
 
 	lockKey := prefixedLockKey(serverLock.OperationUID)
 
+	serverLock.LastExecution = time.Now().Unix()
 	// Convert serverLock to byte array
 	serverLockBytes, err := json.Marshal(serverLock)
 	if err != nil {

--- a/pkg/infra/serverlock/remote_cache.go
+++ b/pkg/infra/serverlock/remote_cache.go
@@ -1,0 +1,132 @@
+package serverlock
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"time"
+
+	"github.com/grafana/grafana/pkg/infra/log"
+	"github.com/grafana/grafana/pkg/infra/remotecache"
+	"github.com/grafana/grafana/pkg/infra/tracing"
+)
+
+const (
+	lockPrefix  = "server_lock:"
+	lockTimeout = 24 * time.Hour * 30
+)
+
+type serverLockRemoteCache struct {
+	remoteCache *remotecache.RemoteCache
+	tracer      tracing.Tracer
+	log         log.Logger
+}
+
+func (sl *serverLockRemoteCache) AcquireLock(ctx context.Context, serverLock *serverLock) (bool, error) {
+	ctx, span := sl.tracer.Start(ctx, "serverLockRemoteCache.acquireLock")
+	defer span.End()
+
+	lockKey := prefixedLockKey(serverLock.OperationUID)
+
+	// Convert serverLock to byte array
+	serverLockBytes, err := json.Marshal(serverLock)
+	if err != nil {
+		return false, err
+	}
+
+	err = sl.remoteCache.Set(ctx, lockKey, serverLockBytes, lockTimeout)
+	if err != nil {
+		return false, err
+	}
+
+	return true, nil
+}
+
+func (sl *serverLockRemoteCache) AcquireForRelease(ctx context.Context, actionName string, maxInterval time.Duration) error {
+	ctx, span := sl.tracer.Start(ctx, "serverLockRemoteCache.AcquireForRelease")
+	defer span.End()
+
+	lockKey := prefixedLockKey(actionName)
+
+	// Check if the lock is already acquired
+	val, err := sl.remoteCache.Get(ctx, lockKey)
+	if err != nil {
+		// If the lock is not found, acquire it
+		if errors.Is(err, remotecache.ErrCacheItemNotFound) {
+			serverLock := &serverLock{
+				OperationUID:  actionName,
+				Version:       0,
+				LastExecution: time.Now().Unix(),
+			}
+			_, err := sl.AcquireLock(ctx, serverLock)
+			return err
+		}
+		// If there is another error, return it
+		return err
+	}
+
+	// If the lock is found, check if it is within the maxInterval
+	serverLock := &serverLock{}
+	if err := json.Unmarshal(val, serverLock); err != nil {
+		return err
+	}
+
+	if isLockWithinInterval(serverLock, maxInterval) {
+		return &ServerLockExistsError{actionName: actionName}
+	}
+
+	// If the lock is timeouted, acquire it
+	_, err = sl.AcquireLock(ctx, serverLock)
+	return err
+}
+
+func (sl *serverLockRemoteCache) GetOrCreate(ctx context.Context, actionName string) (*serverLock, error) {
+	ctx, span := sl.tracer.Start(ctx, "serverLockRemoteCache.getOrCreate")
+	defer span.End()
+
+	lockKey := prefixedLockKey(actionName)
+
+	// Check if the lock is already acquired
+	val, err := sl.remoteCache.Get(ctx, lockKey)
+	if err != nil {
+		// If the lock is not found, acquire it
+		if errors.Is(err, remotecache.ErrCacheItemNotFound) {
+			serverLock := &serverLock{
+				OperationUID:  actionName,
+				Version:       0,
+				LastExecution: time.Now().Unix(),
+			}
+			_, err := sl.AcquireLock(ctx, serverLock)
+			if err != nil {
+				return nil, err
+			}
+			return serverLock, nil
+		}
+		// If there is another error, return it
+		return nil, err
+	}
+
+	serverLock := &serverLock{}
+	if err := json.Unmarshal(val, serverLock); err != nil {
+		return nil, err
+	}
+
+	return serverLock, err
+}
+
+// releaseLock will delete the row at the database. This is only intended to be used within the scope of LockExecuteAndRelease
+// method, but not as to manually release a Lock
+func (sl *serverLockRemoteCache) ReleaseLock(ctx context.Context, actionName string) error {
+	ctx, span := sl.tracer.Start(ctx, "serverLockRemoteCache.releaseLock")
+	defer span.End()
+
+	lockKey := prefixedLockKey(actionName)
+
+	err := sl.remoteCache.Delete(ctx, lockKey)
+	return err
+}
+
+func prefixedLockKey(actionName string) string {
+	lockKey := lockPrefix + actionName
+	return lockKey
+}

--- a/pkg/infra/serverlock/remote_cache_integration_test.go
+++ b/pkg/infra/serverlock/remote_cache_integration_test.go
@@ -84,7 +84,7 @@ func TestIntegrationRedisCacheStorage(t *testing.T) {
 		require.NoError(t, err)
 
 		require.Equal(t, operationUID, got.OperationUID)
-		require.True(t, got.LastExecution > pastLastExec)
+		require.True(t, got.LastExecution > pastLastExec, "%v should be greater than %v", got, pastLastExec)
 
 		err3 := sl.ReleaseLock(context.Background(), operationUID)
 		require.NoError(t, err3)

--- a/pkg/infra/serverlock/remote_cache_integration_test.go
+++ b/pkg/infra/serverlock/remote_cache_integration_test.go
@@ -1,0 +1,101 @@
+package serverlock
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/grafana/pkg/infra/log"
+	"github.com/grafana/grafana/pkg/infra/remotecache"
+	"github.com/grafana/grafana/pkg/infra/tracing"
+)
+
+func TestIntegrationRedisCacheStorage(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
+
+	operationUID := "test-operation-release"
+
+	t.Run("create lock and then release it", func(t *testing.T) {
+		remoteCache := remotecache.CreateTestRedisCacheStorage(t)
+		sl := createTestRedisServerLock(remoteCache)
+		duration := time.Hour * 5
+
+		err := sl.AcquireForRelease(context.Background(), operationUID, duration)
+		require.NoError(t, err)
+
+		err = sl.ReleaseLock(context.Background(), operationUID)
+		require.NoError(t, err)
+
+		// and now we can acquire it again
+		err2 := sl.AcquireForRelease(context.Background(), operationUID, duration)
+		require.NoError(t, err2)
+
+		err = sl.ReleaseLock(context.Background(), operationUID)
+		require.NoError(t, err)
+	})
+
+	t.Run("try to acquire a lock which is already locked, get error", func(t *testing.T) {
+		remoteCache := remotecache.CreateTestRedisCacheStorage(t)
+		sl := createTestRedisServerLock(remoteCache)
+		duration := time.Hour * 5
+
+		err := sl.AcquireForRelease(context.Background(), operationUID, duration)
+		require.NoError(t, err)
+
+		err2 := sl.AcquireForRelease(context.Background(), operationUID, duration)
+		require.Error(t, err2, "We should expect an error when trying to get the second lock")
+		require.Equal(t, "there is already a lock for this actionName: "+operationUID, err2.Error())
+
+		err3 := sl.ReleaseLock(context.Background(), operationUID)
+		require.NoError(t, err3)
+	})
+
+	t.Run("lock already exists but is timeouted", func(t *testing.T) {
+		remoteCache := remotecache.CreateTestRedisCacheStorage(t)
+		sl := createTestRedisServerLock(remoteCache)
+		pastLastExec := time.Now().Add(-time.Hour).Unix()
+		lock := serverLock{
+			OperationUID:  operationUID,
+			LastExecution: pastLastExec,
+		}
+
+		marshalled, err := json.Marshal(lock)
+		require.NoError(t, err)
+
+		err = remoteCache.Set(context.Background(), prefixedLockKey(operationUID), marshalled, time.Hour*24)
+		require.NoError(t, err)
+
+		require.NoError(t, err)
+		duration := time.Minute * 5
+
+		err = sl.AcquireForRelease(context.Background(), operationUID, duration)
+		require.NoError(t, err)
+
+		val, err := remoteCache.Get(context.Background(), prefixedLockKey(operationUID))
+		require.NoError(t, err)
+
+		got := serverLock{}
+		err = json.Unmarshal(val, &got)
+		require.NoError(t, err)
+
+		require.Equal(t, operationUID, got.OperationUID)
+		require.True(t, got.LastExecution > pastLastExec)
+
+		err3 := sl.ReleaseLock(context.Background(), operationUID)
+		require.NoError(t, err3)
+	})
+}
+
+func createTestRedisServerLock(remoteCache *remotecache.RemoteCache) *serverLockRemoteCache {
+	sl := &serverLockRemoteCache{
+		remoteCache: remoteCache,
+		tracer:      tracing.InitializeTracerForTest(),
+		log:         log.New("test-logger"),
+	}
+	return sl
+}

--- a/pkg/infra/serverlock/remote_cache_serverlock.go
+++ b/pkg/infra/serverlock/remote_cache_serverlock.go
@@ -1,0 +1,1 @@
+package serverlock

--- a/pkg/infra/serverlock/remote_cache_serverlock.go
+++ b/pkg/infra/serverlock/remote_cache_serverlock.go
@@ -1,1 +1,0 @@
-package serverlock

--- a/pkg/infra/serverlock/serverlock.go
+++ b/pkg/infra/serverlock/serverlock.go
@@ -25,7 +25,7 @@ type locker interface {
 func ProvideService(sqlStore db.DB, tracer tracing.Tracer, cfg *setting.Cfg, remoteCache *remotecache.RemoteCache) *ServerLockService {
 	logger := log.New("infra.lockservice")
 
-	if cfg != nil && cfg.ServerLock.Driver == setting.DatabaseLockType {
+	if cfg != nil && cfg.ServerLock.Driver == setting.RemoteCacheLockType {
 		if remoteCache != nil && cfg.RemoteCacheOptions != nil && cfg.RemoteCacheOptions.Name != setting.DatabaseCacheType {
 			logger.Debug("Server lock configured with remote cache")
 			return &ServerLockService{

--- a/pkg/infra/serverlock/serverlock.go
+++ b/pkg/infra/serverlock/serverlock.go
@@ -28,7 +28,15 @@ func ProvideService(sqlStore db.DB, tracer tracing.Tracer, cfg *setting.Cfg, rem
 	if cfg != nil && cfg.ServerLock.Driver == setting.DatabaseLockType {
 		if remoteCache != nil && cfg.RemoteCacheOptions != nil && cfg.RemoteCacheOptions.Name != setting.DatabaseCacheType {
 			logger.Debug("Server lock configured with remote cache")
-			// return NewRemoteCacheServerLockService(remoteCache, tracer)
+			return &ServerLockService{
+				tracer: tracer,
+				log:    logger,
+				locker: &serverLockRemoteCache{
+					remoteCache: remoteCache,
+					tracer:      tracer,
+					log:         logger,
+				},
+			}
 		}
 
 		logger.Warn("Remote cache is not configured with non database type, using database lock")

--- a/pkg/infra/serverlock/serverlock.go
+++ b/pkg/infra/serverlock/serverlock.go
@@ -10,10 +10,12 @@ import (
 
 	"github.com/grafana/grafana/pkg/infra/db"
 	"github.com/grafana/grafana/pkg/infra/log"
+	"github.com/grafana/grafana/pkg/infra/remotecache"
 	"github.com/grafana/grafana/pkg/infra/tracing"
+	"github.com/grafana/grafana/pkg/setting"
 )
 
-func ProvideService(sqlStore db.DB, tracer tracing.Tracer) *ServerLockService {
+func ProvideService(sqlStore db.DB, tracer tracing.Tracer, cfg *setting.Cfg, remoteCache *remotecache.RemoteCache) *ServerLockService {
 	return &ServerLockService{
 		SQLStore: sqlStore,
 		tracer:   tracer,

--- a/pkg/infra/serverlock/serverlock_integration_test.go
+++ b/pkg/infra/serverlock/serverlock_integration_test.go
@@ -86,7 +86,7 @@ func TestIntegrationServerLock_LockExecuteAndReleaseWithRetries(t *testing.T) {
 
 	// Acquire lock so that when `LockExecuteAndReleaseWithRetries` runs, it is forced
 	// to retry
-	err := sl.acquireForRelease(ctx, actionName, lockTimeConfig.MaxInterval)
+	err := sl.locker.AcquireForRelease(ctx, actionName, lockTimeConfig.MaxInterval)
 	require.NoError(t, err)
 
 	wgRetries := sync.WaitGroup{}
@@ -115,7 +115,7 @@ func TestIntegrationServerLock_LockExecuteAndReleaseWithRetries(t *testing.T) {
 
 	// Wait to release the lock until `LockExecuteAndReleaseWithRetries` has retried `expectedRetries` times.
 	wgRetries.Wait()
-	err = sl.releaseLock(ctx, actionName)
+	err = sl.locker.ReleaseLock(ctx, actionName)
 	require.NoError(t, err)
 	wgRelease.Done()
 

--- a/pkg/infra/serverlock/serverlock_test.go
+++ b/pkg/infra/serverlock/serverlock_test.go
@@ -3,7 +3,6 @@ package serverlock
 import (
 	"context"
 	"testing"
-	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -19,9 +18,13 @@ func createTestableServerLock(t *testing.T) *ServerLockService {
 	store := db.InitTestDB(t)
 
 	return &ServerLockService{
-		SQLStore: store,
-		tracer:   tracing.InitializeTracerForTest(),
-		log:      log.New("test-logger"),
+		locker: &serverLockDB{
+			SQLStore: store,
+			tracer:   tracing.InitializeTracerForTest(),
+			log:      log.New("test-logger"),
+		},
+		tracer: tracing.InitializeTracerForTest(),
+		log:    log.New("test-logger"),
 	}
 }
 
@@ -29,7 +32,7 @@ func TestServerLock(t *testing.T) {
 	sl := createTestableServerLock(t)
 	operationUID := "test-operation"
 
-	first, err := sl.getOrCreate(context.Background(), operationUID)
+	first, err := sl.locker.GetOrCreate(context.Background(), operationUID)
 	require.NoError(t, err)
 
 	t.Run("trying to create three new row locks", func(t *testing.T) {
@@ -37,7 +40,7 @@ func TestServerLock(t *testing.T) {
 		var latest *serverLock
 
 		for i := 0; i < 3; i++ {
-			latest, err = sl.getOrCreate(context.Background(), operationUID)
+			latest, err = sl.locker.GetOrCreate(context.Background(), operationUID)
 			require.NoError(t, err)
 			assert.Equal(t, operationUID, first.OperationUID)
 			assert.Equal(t, int64(1), first.Id)
@@ -50,86 +53,12 @@ func TestServerLock(t *testing.T) {
 	})
 
 	t.Run("create lock on first row", func(t *testing.T) {
-		gotLock, err := sl.acquireLock(context.Background(), first)
+		gotLock, err := sl.locker.AcquireLock(context.Background(), first)
 		require.NoError(t, err)
 		assert.True(t, gotLock)
 
-		gotLock, err = sl.acquireLock(context.Background(), first)
+		gotLock, err = sl.locker.AcquireLock(context.Background(), first)
 		require.NoError(t, err)
 		assert.False(t, gotLock)
-	})
-}
-
-func TestLockAndRelease(t *testing.T) {
-	operationUID := "test-operation-release"
-
-	t.Run("create lock and then release it", func(t *testing.T) {
-		sl := createTestableServerLock(t)
-		duration := time.Hour * 5
-
-		err := sl.acquireForRelease(context.Background(), operationUID, duration)
-		require.NoError(t, err)
-
-		err = sl.releaseLock(context.Background(), operationUID)
-		require.NoError(t, err)
-
-		// and now we can acquire it again
-		err2 := sl.acquireForRelease(context.Background(), operationUID, duration)
-		require.NoError(t, err2)
-
-		err = sl.releaseLock(context.Background(), operationUID)
-		require.NoError(t, err)
-	})
-
-	t.Run("try to acquire a lock which is already locked, get error", func(t *testing.T) {
-		sl := createTestableServerLock(t)
-		duration := time.Hour * 5
-
-		err := sl.acquireForRelease(context.Background(), operationUID, duration)
-		require.NoError(t, err)
-
-		err2 := sl.acquireForRelease(context.Background(), operationUID, duration)
-		require.Error(t, err2, "We should expect an error when trying to get the second lock")
-		require.Equal(t, "there is already a lock for this actionName: "+operationUID, err2.Error())
-
-		err3 := sl.releaseLock(context.Background(), operationUID)
-		require.NoError(t, err3)
-	})
-
-	t.Run("lock already exists but is timeouted", func(t *testing.T) {
-		sl := createTestableServerLock(t)
-		pastLastExec := time.Now().Add(-time.Hour).Unix()
-		lock := serverLock{
-			OperationUID:  operationUID,
-			LastExecution: pastLastExec,
-		}
-
-		// inserting a row with lock in the past
-		err := sl.SQLStore.WithTransactionalDbSession(context.Background(), func(sess *db.Session) error {
-			affectedRows, err := sess.Insert(&lock)
-			require.NoError(t, err)
-			require.Equal(t, int64(1), affectedRows)
-			require.Equal(t, int64(1), lock.Id)
-			return nil
-		})
-		require.NoError(t, err)
-		duration := time.Minute * 5
-
-		err = sl.acquireForRelease(context.Background(), operationUID, duration)
-		require.NoError(t, err)
-
-		//validate that the lock LastExecution was updated (at least different from the original)
-		err = sl.SQLStore.WithTransactionalDbSession(context.Background(), func(sess *db.Session) error {
-			lockRows := []*serverLock{}
-			err := sess.Where("operation_uid = ?", operationUID).Find(&lockRows)
-			require.NoError(t, err)
-			require.Equal(t, 1, len(lockRows))
-			require.NotEqual(t, pastLastExec, lockRows[0].LastExecution)
-			return nil
-		})
-		require.NoError(t, err)
-
-		err3 := sl.releaseLock(context.Background(), operationUID)
-		require.NoError(t, err3)
 	})
 }

--- a/pkg/registry/usagestatssvcs/usage_stats_providers_registry.go
+++ b/pkg/registry/usagestatssvcs/usage_stats_providers_registry.go
@@ -1,18 +1,27 @@
 package usagestatssvcs
 
 import (
+	"github.com/grafana/grafana/pkg/infra/remotecache"
 	"github.com/grafana/grafana/pkg/registry"
 	"github.com/grafana/grafana/pkg/services/accesscontrol"
+	encrypt "github.com/grafana/grafana/pkg/services/encryption/service"
+	secrets "github.com/grafana/grafana/pkg/services/secrets/manager"
 	"github.com/grafana/grafana/pkg/services/user"
 )
 
 func ProvideUsageStatsProvidersRegistry(
 	accesscontrol accesscontrol.Service,
 	user user.Service,
+	remoteCache *remotecache.RemoteCache,
+	encryptionService *encrypt.Service,
+	secretsService *secrets.SecretsService,
 ) *UsageStatsProvidersRegistry {
 	return NewUsageStatsProvidersRegistry(
 		accesscontrol,
 		user,
+		remoteCache,
+		encryptionService,
+		secretsService,
 	)
 }
 

--- a/pkg/services/alerting/engine_integration_test.go
+++ b/pkg/services/alerting/engine_integration_test.go
@@ -31,7 +31,7 @@ func TestIntegrationEngineTimeouts(t *testing.T) {
 	usValidatorMock := &validator.FakeUsageStatsValidator{}
 
 	encProvider := encryptionprovider.ProvideEncryptionProvider()
-	encService, err := encryptionservice.ProvideEncryptionService(encProvider, usMock, setting.NewCfg())
+	encService, err := encryptionservice.ProvideEncryptionService(encProvider, setting.NewCfg())
 	require.NoError(t, err)
 
 	tracer := tracing.InitializeTracerForTest()

--- a/pkg/services/alerting/engine_test.go
+++ b/pkg/services/alerting/engine_test.go
@@ -122,7 +122,7 @@ func TestEngineProcessJob(t *testing.T) {
 	usValidatorMock := &validator.FakeUsageStatsValidator{}
 
 	encProvider := encryptionprovider.ProvideEncryptionProvider()
-	encService, err := encryptionservice.ProvideEncryptionService(encProvider, usMock, setting.NewCfg())
+	encService, err := encryptionservice.ProvideEncryptionService(encProvider, setting.NewCfg())
 	require.NoError(t, err)
 	tracer := tracing.InitializeTracerForTest()
 

--- a/pkg/services/alerting/service_test.go
+++ b/pkg/services/alerting/service_test.go
@@ -12,7 +12,6 @@ import (
 	"github.com/grafana/grafana/pkg/infra/db"
 	"github.com/grafana/grafana/pkg/infra/localcache"
 	"github.com/grafana/grafana/pkg/infra/log"
-	"github.com/grafana/grafana/pkg/infra/usagestats"
 	"github.com/grafana/grafana/pkg/services/alerting/models"
 	encryptionprovider "github.com/grafana/grafana/pkg/services/encryption/provider"
 	encryptionservice "github.com/grafana/grafana/pkg/services/encryption/service"
@@ -30,10 +29,8 @@ func TestService(t *testing.T) {
 	nType := "test"
 	registerTestNotifier(nType)
 
-	usMock := &usagestats.UsageStatsMock{T: t}
-
 	encProvider := encryptionprovider.ProvideEncryptionProvider()
-	encService, err := encryptionservice.ProvideEncryptionService(encProvider, usMock, setting.NewCfg())
+	encService, err := encryptionservice.ProvideEncryptionService(encProvider, setting.NewCfg())
 	require.NoError(t, err)
 
 	s := ProvideService(sqlStore.db, encService, nil)

--- a/pkg/services/encryption/service/helpers.go
+++ b/pkg/services/encryption/service/helpers.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/grafana/grafana/pkg/infra/usagestats"
 	encryptionprovider "github.com/grafana/grafana/pkg/services/encryption/provider"
 	"github.com/grafana/grafana/pkg/setting"
 )
@@ -13,11 +12,10 @@ import (
 func SetupTestService(tb testing.TB) *Service {
 	tb.Helper()
 
-	usMock := &usagestats.UsageStatsMock{T: tb}
 	provider := encryptionprovider.ProvideEncryptionProvider()
 	settings := setting.NewCfg()
 
-	service, err := ProvideEncryptionService(provider, usMock, settings)
+	service, err := ProvideEncryptionService(provider, settings)
 	require.NoError(tb, err)
 
 	return service

--- a/pkg/services/encryption/service/service_test.go
+++ b/pkg/services/encryption/service/service_test.go
@@ -7,7 +7,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/grafana/grafana/pkg/infra/usagestats"
 	"github.com/grafana/grafana/pkg/services/encryption"
 	"github.com/grafana/grafana/pkg/services/encryption/provider"
 	"github.com/grafana/grafana/pkg/setting"
@@ -17,10 +16,9 @@ func Test_Service(t *testing.T) {
 	ctx := context.Background()
 
 	encProvider := provider.Provider{}
-	usageStats := &usagestats.UsageStatsMock{}
 	settings := setting.NewCfg()
 
-	svc, err := ProvideEncryptionService(encProvider, usageStats, settings)
+	svc, err := ProvideEncryptionService(encProvider, settings)
 	require.NoError(t, err)
 
 	t.Run("decrypt empty payload should return error", func(t *testing.T) {
@@ -76,10 +74,9 @@ func Test_Service(t *testing.T) {
 
 func Test_Service_MissingProvider(t *testing.T) {
 	encProvider := fakeProvider{}
-	usageStats := &usagestats.UsageStatsMock{}
 	settings := setting.NewCfg()
 
-	service, err := ProvideEncryptionService(encProvider, usageStats, settings)
+	service, err := ProvideEncryptionService(encProvider, settings)
 	assert.Nil(t, service)
 	assert.Error(t, err)
 }

--- a/pkg/services/ngalert/migration/testing.go
+++ b/pkg/services/ngalert/migration/testing.go
@@ -19,7 +19,7 @@ func NewTestMigrationService(t *testing.T, sqlStore *sqlstore.SQLStore, cfg *set
 		cfg = setting.NewCfg()
 	}
 	return &migrationService{
-		lock:              serverlock.ProvideService(sqlStore, tracing.InitializeTracerForTest()),
+		lock:              serverlock.ProvideService(sqlStore, tracing.InitializeTracerForTest(), nil, nil),
 		log:               &logtest.Fake{},
 		cfg:               cfg,
 		store:             sqlStore,

--- a/pkg/services/secrets/manager/helpers.go
+++ b/pkg/services/secrets/manager/helpers.go
@@ -6,7 +6,6 @@ import (
 	"github.com/stretchr/testify/require"
 	"gopkg.in/ini.v1"
 
-	"github.com/grafana/grafana/pkg/infra/usagestats"
 	encryptionprovider "github.com/grafana/grafana/pkg/services/encryption/provider"
 	encryptionservice "github.com/grafana/grafana/pkg/services/encryption/service"
 	"github.com/grafana/grafana/pkg/services/featuremgmt"
@@ -41,9 +40,8 @@ func setupTestService(tb testing.TB, store secrets.Store, features *featuremgmt.
 	cfg := &setting.Cfg{Raw: raw}
 
 	encProvider := encryptionprovider.Provider{}
-	usageStats := &usagestats.UsageStatsMock{}
 
-	encryption, err := encryptionservice.ProvideEncryptionService(encProvider, usageStats, cfg)
+	encryption, err := encryptionservice.ProvideEncryptionService(encProvider, cfg)
 	require.NoError(tb, err)
 
 	secretsService, err := ProvideSecretsService(
@@ -52,7 +50,6 @@ func setupTestService(tb testing.TB, store secrets.Store, features *featuremgmt.
 		encryption,
 		cfg,
 		features,
-		&usagestats.UsageStatsMock{T: tb},
 	)
 	require.NoError(tb, err)
 

--- a/pkg/services/secrets/manager/manager.go
+++ b/pkg/services/secrets/manager/manager.go
@@ -15,7 +15,6 @@ import (
 	"golang.org/x/sync/errgroup"
 
 	"github.com/grafana/grafana/pkg/infra/log"
-	"github.com/grafana/grafana/pkg/infra/usagestats"
 	"github.com/grafana/grafana/pkg/services/encryption"
 	"github.com/grafana/grafana/pkg/services/featuremgmt"
 	"github.com/grafana/grafana/pkg/services/kmsproviders"
@@ -35,11 +34,10 @@ var (
 )
 
 type SecretsService struct {
-	store      secrets.Store
-	enc        encryption.Internal
-	cfg        *setting.Cfg
-	features   featuremgmt.FeatureToggles
-	usageStats usagestats.Service
+	store    secrets.Store
+	enc      encryption.Internal
+	cfg      *setting.Cfg
+	features featuremgmt.FeatureToggles
 
 	mtx          sync.Mutex
 	dataKeyCache *dataKeyCache

--- a/pkg/services/secrets/manager/manager_test.go
+++ b/pkg/services/secrets/manager/manager_test.go
@@ -74,12 +74,11 @@ func TestSecretsService_EnvelopeEncryption(t *testing.T) {
 	})
 
 	t.Run("usage stats should be registered", func(t *testing.T) {
-		reports, err := svc.usageStats.GetUsageReport(context.Background())
-		require.NoError(t, err)
+		reports := svc.GetUsageStats(context.Background())
 
-		assert.Equal(t, 1, reports.Metrics["stats.encryption.envelope_encryption_enabled.count"])
-		assert.Equal(t, 1, reports.Metrics["stats.encryption.current_provider.secretKey.count"])
-		assert.Equal(t, 1, reports.Metrics["stats.encryption.providers.secretKey.count"])
+		assert.Equal(t, 1, reports["stats.encryption.envelope_encryption_enabled.count"])
+		assert.Equal(t, 1, reports["stats.encryption.current_provider.secretKey.count"])
+		assert.Equal(t, 1, reports["stats.encryption.providers.secretKey.count"])
 	})
 }
 

--- a/pkg/services/secrets/manager/manager_test.go
+++ b/pkg/services/secrets/manager/manager_test.go
@@ -11,7 +11,6 @@ import (
 	"gopkg.in/ini.v1"
 
 	"github.com/grafana/grafana/pkg/infra/db"
-	"github.com/grafana/grafana/pkg/infra/usagestats"
 	encryptionprovider "github.com/grafana/grafana/pkg/services/encryption/provider"
 	encryptionservice "github.com/grafana/grafana/pkg/services/encryption/service"
 	"github.com/grafana/grafana/pkg/services/featuremgmt"
@@ -185,9 +184,8 @@ func TestSecretsService_UseCurrentProvider(t *testing.T) {
 		cfg := &setting.Cfg{Raw: raw}
 
 		encProvider := encryptionprovider.Provider{}
-		usageStats := &usagestats.UsageStatsMock{}
 
-		encryptionService, err := encryptionservice.ProvideEncryptionService(encProvider, usageStats, cfg)
+		encryptionService, err := encryptionservice.ProvideEncryptionService(encProvider, cfg)
 		require.NoError(t, err)
 
 		features := featuremgmt.WithFeatures()
@@ -201,7 +199,6 @@ func TestSecretsService_UseCurrentProvider(t *testing.T) {
 			encryptionService,
 			cfg,
 			features,
-			&usagestats.UsageStatsMock{T: t},
 		)
 		require.NoError(t, err)
 
@@ -219,7 +216,6 @@ func TestSecretsService_UseCurrentProvider(t *testing.T) {
 			encryptionService,
 			cfg,
 			features,
-			&usagestats.UsageStatsMock{T: t},
 		)
 		require.NoError(t, err)
 

--- a/pkg/setting/setting_infra.go
+++ b/pkg/setting/setting_infra.go
@@ -1,0 +1,43 @@
+package setting
+
+import "gopkg.in/ini.v1"
+
+type RemoteCacheOptions struct {
+	Name       string
+	ConnStr    string
+	Prefix     string
+	Encryption bool
+}
+
+type ServerLockSettings struct {
+	Driver string
+}
+
+const (
+	DatabaseCacheType  = "database"
+	RedisCacheType     = "redis"
+	MemcachedCacheType = "memcached"
+
+	DatabaseLockType    = "database"
+	RemoteCacheLockType = "remote_cache"
+)
+
+func readRemoteCacheSettings(iniFile *ini.File) *RemoteCacheOptions {
+	s := &RemoteCacheOptions{}
+	cacheServer := iniFile.Section("remote_cache")
+	s.Name = cacheServer.Key("type").In(DatabaseCacheType, []string{DatabaseCacheType, RedisCacheType, MemcachedCacheType})
+	s.ConnStr = valueAsString(cacheServer, "connstr", "")
+	s.Prefix = valueAsString(cacheServer, "prefix", "")
+	s.Encryption = cacheServer.Key("encryption").MustBool(false)
+
+	return s
+}
+
+func readServerLockSettings(iniFile *ini.File) ServerLockSettings {
+	s := ServerLockSettings{}
+	serverLock := iniFile.Section("server_lock")
+	s.Driver = valueAsString(serverLock, "driver", "memory")
+	serverLock.Key("driver").In(DatabaseLockType, []string{DatabaseLockType, RemoteCacheLockType})
+
+	return s
+}

--- a/pkg/setting/setting_infra.go
+++ b/pkg/setting/setting_infra.go
@@ -36,8 +36,7 @@ func readRemoteCacheSettings(iniFile *ini.File) *RemoteCacheOptions {
 func readServerLockSettings(iniFile *ini.File) ServerLockSettings {
 	s := ServerLockSettings{}
 	serverLock := iniFile.Section("server_lock")
-	s.Driver = valueAsString(serverLock, "driver", "memory")
-	serverLock.Key("driver").In(DatabaseLockType, []string{DatabaseLockType, RemoteCacheLockType})
+	s.Driver = serverLock.Key("driver").In(DatabaseLockType, []string{DatabaseLockType, RemoteCacheLockType})
 
 	return s
 }


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

Allow use of remote cache as server lock.

- Avoid spamming DB with lock checks on boot
- Make use of remote_cache
- Allow use of `watch` in the future to avoid pinging for lock availability 

**Why do we need this feature?**

[Add a description of the problem the feature is trying to solve.]

**Who is this feature for?**

[Add information on what kind of user the feature is for.]

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Functional changes are in remote cache serverlock and the provides.

The rest is mostly moving files and fixing circular dependencies

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
