### PR TITLE
Parca: Decouple backend

### DIFF
--- a/pkg/tsdb/parca/plugin.go
+++ b/pkg/tsdb/parca/plugin.go
@@ -7,9 +7,9 @@ import (
 	v1alpha1 "buf.build/gen/go/parca-dev/parca/protocolbuffers/go/parca/query/v1alpha1"
 	"github.com/bufbuild/connect-go"
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
+	"github.com/grafana/grafana-plugin-sdk-go/backend/httpclient"
 	"github.com/grafana/grafana-plugin-sdk-go/backend/instancemgmt"
 	"github.com/grafana/grafana-plugin-sdk-go/backend/tracing"
-	"github.com/grafana/grafana/pkg/infra/httpclient"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/trace"
 )
@@ -35,7 +35,7 @@ type ParcaDatasource struct {
 }
 
 // NewParcaDatasource creates a new datasource instance.
-func NewParcaDatasource(ctx context.Context, httpClientProvider httpclient.Provider, settings backend.DataSourceInstanceSettings) (instancemgmt.Instance, error) {
+func NewParcaDatasource(ctx context.Context, httpClientProvider *httpclient.Provider, settings backend.DataSourceInstanceSettings) (instancemgmt.Instance, error) {
 	ctxLogger := logger.FromContext(ctx)
 	opt, err := settings.HTTPClientOptions(ctx)
 	if err != nil {

--- a/pkg/tsdb/parca/service.go
+++ b/pkg/tsdb/parca/service.go
@@ -8,9 +8,9 @@ import (
 
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
 	"github.com/grafana/grafana-plugin-sdk-go/backend/datasource"
+	"github.com/grafana/grafana-plugin-sdk-go/backend/httpclient"
 	"github.com/grafana/grafana-plugin-sdk-go/backend/instancemgmt"
-	"github.com/grafana/grafana/pkg/infra/httpclient"
-	"github.com/grafana/grafana/pkg/infra/log"
+	"github.com/grafana/grafana-plugin-sdk-go/backend/log"
 )
 
 // Make sure ParcaDatasource implements required interfaces. This is important to do
@@ -33,7 +33,7 @@ type Service struct {
 	logger log.Logger
 }
 
-var logger = log.New("tsdb.parca")
+var logger = backend.NewLoggerWith("logger", "tsdb.parca")
 
 // Return the file, line, and (full-path) function name of the caller
 func getRunContext() (string, int, string) {
@@ -63,14 +63,14 @@ func (s *Service) getInstance(ctx context.Context, pluginCtx backend.PluginConte
 	return in, nil
 }
 
-func ProvideService(httpClientProvider httpclient.Provider) *Service {
+func ProvideService(httpClientProvider *httpclient.Provider) *Service {
 	return &Service{
 		im:     datasource.NewInstanceManager(newInstanceSettings(httpClientProvider)),
 		logger: logger,
 	}
 }
 
-func newInstanceSettings(httpClientProvider httpclient.Provider) datasource.InstanceFactoryFunc {
+func newInstanceSettings(httpClientProvider *httpclient.Provider) datasource.InstanceFactoryFunc {
 	return func(ctx context.Context, settings backend.DataSourceInstanceSettings) (instancemgmt.Instance, error) {
 		return NewParcaDatasource(ctx, httpClientProvider, settings)
 	}


### PR DESCRIPTION
As part of the decoupling of the Parca data source from Grafana core, we replace imports of `grafana/pkg` in the backend with `grafana-plugin-sdk-go`.