### PR TITLE
Nested Folders: Move SharedWithMe to the top of the folders list

### DIFF
--- a/pkg/services/folder/folderimpl/folder.go
+++ b/pkg/services/folder/folderimpl/folder.go
@@ -263,7 +263,7 @@ func (s *Service) getRootFolders(ctx context.Context, q *folder.GetChildrenQuery
 
 	// add "shared with me" folder on the 1st page
 	if (q.Page == 0 || q.Page == 1) && len(q.FolderUIDs) != 0 {
-		children = append(children, &folder.SharedWithMeFolder)
+		children = append([]*folder.Folder{&folder.SharedWithMeFolder}, children...)
 	}
 
 	return children, nil

--- a/pkg/tests/api/folders/api_folders_test.go
+++ b/pkg/tests/api/folders/api_folders_test.go
@@ -128,7 +128,7 @@ func TestGetFolders(t *testing.T) {
 		for i := range res.Payload {
 			actualFolders = append(actualFolders, res.Payload[i].UID)
 		}
-		assert.Equal(t, []string{"folder-0", "folder-1", "folder-2", "folder-3", "folder-4", folder.SharedWithMeFolderUID}, actualFolders)
+		assert.Equal(t, []string{folder.SharedWithMeFolderUID, "folder-0", "folder-1", "folder-2", "folder-3", "folder-4"}, actualFolders)
 	})
 
 	t.Run("Pagination works as expect for editor", func(t *testing.T) {
@@ -140,7 +140,7 @@ func TestGetFolders(t *testing.T) {
 		for i := range res.Payload {
 			actualFolders = append(actualFolders, res.Payload[i].UID)
 		}
-		assert.Equal(t, []string{"folder-0", "folder-1", folder.SharedWithMeFolderUID}, actualFolders)
+		assert.Equal(t, []string{folder.SharedWithMeFolderUID, "folder-0", "folder-1"}, actualFolders)
 
 		page = int64(2)
 		res, err = editorClient.Folders.GetFolders(folders.NewGetFoldersParams().WithLimit(&limit).WithPage(&page))
@@ -168,7 +168,7 @@ func TestGetFolders(t *testing.T) {
 		for i := range res.Payload {
 			actualFolders = append(actualFolders, res.Payload[i].UID)
 		}
-		assert.Equal(t, []string{"folder-0", "folder-1", "folder-2", "folder-4", folder.SharedWithMeFolderUID}, actualFolders)
+		assert.Equal(t, []string{folder.SharedWithMeFolderUID, "folder-0", "folder-1", "folder-2", "folder-4"}, actualFolders)
 	})
 
 	t.Run("Pagination works as expect for viewer", func(t *testing.T) {
@@ -180,7 +180,7 @@ func TestGetFolders(t *testing.T) {
 		for i := range res.Payload {
 			actualFolders = append(actualFolders, res.Payload[i].UID)
 		}
-		assert.Equal(t, []string{"folder-0", "folder-1", folder.SharedWithMeFolderUID}, actualFolders)
+		assert.Equal(t, []string{folder.SharedWithMeFolderUID, "folder-0", "folder-1"}, actualFolders)
 
 		page = int64(2)
 		res, err = viewerClient.Folders.GetFolders(folders.NewGetFoldersParams().WithLimit(&limit).WithPage(&page))


### PR DESCRIPTION
**Who is this feature for?**

Users of Grafana instances with nested folders feature toggle enabled.

**Which issue(s) does this PR fix?**:

Moving "Shared With Me" to the top of the list is mentioned in this issue https://github.com/grafana/grafana/issues/78752

<img width="500" alt="Screenshot 2023-12-27 at 15 50 58" src="https://github.com/grafana/grafana/assets/10127682/287d0ca2-1d49-4997-a741-b2a9bbfe1155">
