### PR TITLE
Parca: Decouple frontend

### DIFF
--- a/public/app/plugins/datasource/parca/ConfigEditor.tsx
+++ b/public/app/plugins/datasource/parca/ConfigEditor.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
 
 import { DataSourcePluginOptionsEditorProps } from '@grafana/data';
+import { config } from '@grafana/runtime';
 import { DataSourceHttpSettings } from '@grafana/ui';
-import { config } from 'app/core/config';
 
 import { ParcaDataSourceOptions } from './types';
 


### PR DESCRIPTION
As part of the decoupling of the Parca data source from Grafana core, we replace the import from `app/core/config` with `@grafana/runtime`.