### PR TITLE
Field color: Filter out editor options that have excludeFromPicker=true

### DIFF
--- a/public/app/core/components/OptionsUI/fieldColor.test.tsx
+++ b/public/app/core/components/OptionsUI/fieldColor.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, fireEvent } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import React from 'react';
 

--- a/public/app/core/components/OptionsUI/fieldColor.test.tsx
+++ b/public/app/core/components/OptionsUI/fieldColor.test.tsx
@@ -42,12 +42,10 @@ describe('fieldColor', () => {
         onChange={() => {}}
         id="test"
         data-testid="test"
-        context={{} as any}
+        context={{ data: [] }}
         item={testRegistryItems[0]}
       />
     );
-    expect(screen.getByRole('combobox')).toBeInTheDocument();
-    fireEvent.focus(screen.getByRole('combobox'));
     await userEvent.type(screen.getByRole('combobox'), '{arrowdown}');
     expect(screen.getByText(/^Foo/i)).toBeInTheDocument();
     expect(screen.getByText(/^Bar/i)).toBeInTheDocument();

--- a/public/app/core/components/OptionsUI/fieldColor.test.tsx
+++ b/public/app/core/components/OptionsUI/fieldColor.test.tsx
@@ -1,0 +1,56 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import React from 'react';
+
+import { FieldColorEditor } from './fieldColor';
+
+const testRegistryItems = [
+  {
+    id: 'foo',
+    name: 'Foo',
+    description: 'This option will appear in the picker',
+    getCalculator: () => 'red',
+  },
+  {
+    id: 'bar',
+    name: 'Bar',
+    description: 'This option will also appear in the picker',
+    getCalculator: () => 'green',
+  },
+  {
+    id: 'baz',
+    name: 'Baz',
+    description: 'This option will not appear in the picker',
+    getCalculator: () => 'blue',
+    excludeFromPicker: true,
+  },
+];
+
+jest.mock('@grafana/data', () => {
+  const actualData = jest.requireActual('@grafana/data');
+  return {
+    ...actualData,
+    fieldColorModeRegistry: new actualData.Registry(() => testRegistryItems),
+  };
+});
+
+describe('fieldColor', () => {
+  it('filters out registry options with excludeFromPicker=true', async () => {
+    render(
+      <FieldColorEditor
+        value={undefined}
+        onChange={() => {}}
+        id="test"
+        data-testid="test"
+        context={{} as any}
+        item={testRegistryItems[0]}
+      />
+    );
+    expect(screen.getByRole('combobox')).toBeInTheDocument();
+    fireEvent.focus(screen.getByRole('combobox'));
+    await userEvent.type(screen.getByRole('combobox'), '{arrowdown}');
+    expect(screen.getByText(/^Foo/i)).toBeInTheDocument();
+    expect(screen.getByText(/^Bar/i)).toBeInTheDocument();
+    expect(screen.queryByText(/^Baz/i)).not.toBeInTheDocument();
+  });
+});

--- a/public/app/core/components/OptionsUI/fieldColor.tsx
+++ b/public/app/core/components/OptionsUI/fieldColor.tsx
@@ -28,20 +28,22 @@ export const FieldColorEditor = ({ value, onChange, item, id }: Props) => {
     ? fieldColorModeRegistry.list()
     : fieldColorModeRegistry.list().filter((m) => !m.isByValue);
 
-  const options = availableOptions.map((mode) => {
-    let suffix = mode.isByValue ? ' (by value)' : '';
+  const options = availableOptions
+    .filter((mode) => !mode.excludeFromPicker)
+    .map((mode) => {
+      let suffix = mode.isByValue ? ' (by value)' : '';
 
-    return {
-      value: mode.id,
-      label: `${mode.name}${suffix}`,
-      description: mode.description,
-      isContinuous: mode.isContinuous,
-      isByValue: mode.isByValue,
-      component() {
-        return <FieldColorModeViz mode={mode} theme={theme} />;
-      },
-    };
-  });
+      return {
+        value: mode.id,
+        label: `${mode.name}${suffix}`,
+        description: mode.description,
+        isContinuous: mode.isContinuous,
+        isByValue: mode.isByValue,
+        component() {
+          return <FieldColorModeViz mode={mode} theme={theme} />;
+        },
+      };
+    });
 
   const onModeChange = (newMode: SelectableValue<string>) => {
     onChange({


### PR DESCRIPTION
**What is this feature?**

It updates field color picker to exclude modes with `excludeFromPicker` property set to `true`. 

**Why do we need this feature?**

We want to add custom color mode for app o11y plugin panels, but don't want it to show up in regular dashboards. Noticed that registery items have a property to exclude them from pickers, but it isn't respected by field color picker.