### PR TITLE
Chore: First step towards a github action that regularly notifies about feature toggle cleanup

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -678,6 +678,7 @@ embed.go @grafana/grafana-as-code
 /.github/workflows/core-plugins-build-and-release.yml @grafana/plugins-platform-frontend @grafana/plugins-platform-backend
 /.github/workflows/i18n-crowdin-fix-files.yml @grafana/grafana-frontend-platform
 /.github/workflows/feature-toggle-cleanup.yml @tolzhabayev
+/.github/workflows/scripts/feature-toggle-cleanup/feature-toggle-cleanup.js @tolzhabayev
 
 # Generated files not requiring owner approval
 /packages/grafana-data/src/types/featureToggles.gen.ts @grafanabot

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -677,6 +677,7 @@ embed.go @grafana/grafana-as-code
 /.github/workflows/create-security-patch-from-security-mirror.yml @grafana/grafana-release-guild
 /.github/workflows/core-plugins-build-and-release.yml @grafana/plugins-platform-frontend @grafana/plugins-platform-backend
 /.github/workflows/i18n-crowdin-fix-files.yml @grafana/grafana-frontend-platform
+/.github/workflows/feature-toggle-cleanup.yml @tolzhabayev
 
 # Generated files not requiring owner approval
 /packages/grafana-data/src/types/featureToggles.gen.ts @grafanabot

--- a/.github/workflows/feature-toggle-cleanup.yml
+++ b/.github/workflows/feature-toggle-cleanup.yml
@@ -6,8 +6,9 @@ on:
       # * is a special character in YAML so you have to quote this string
       - cron:  '30 10 * * *'
 jobs:
-    fetch:
+    feature-toggle-cleanup:
         runs-on: ubuntu-latest    
+        if: github.repository == 'grafana/grafana'
         steps:
             - name: Check out the code
               uses: actions/checkout@v3

--- a/.github/workflows/feature-toggle-cleanup.yml
+++ b/.github/workflows/feature-toggle-cleanup.yml
@@ -1,0 +1,25 @@
+name: Feature Toggle Cleanup
+
+on:
+    repository_dispatch:
+        types: feature-toggle-cleanup
+
+jobs:
+    fetch:
+        runs-on: ubuntu-latest    
+        steps:
+            - name: Check out the code
+              uses: actions/checkout@v3
+            - uses: actions/setup-node@v4
+              with:
+                node-version: "20.x"
+            - run: npm install csv-parse
+            - name: Parse CVS file to see which Feature Toggles should be notified about
+              id: parse-csv-file
+              uses: actions/github-script@v7
+              env:
+                    FEATURE_TOGGLES_CSV_FILE_PATH: "pkg/services/featuremgmt/toggles_gen.csv"
+              with:
+                    script: |
+                        const { default: printStuff } = await import('${{ github.workspace }}/.github/workflows/scripts/feature-toggle-cleanup/feature-toggle-cleanup.js')                        
+                        await script({github, context, core})

--- a/.github/workflows/feature-toggle-cleanup.yml
+++ b/.github/workflows/feature-toggle-cleanup.yml
@@ -1,8 +1,7 @@
 name: Feature Toggle Cleanup
 
 on:
-    repository_dispatch:
-        types: feature-toggle-cleanup
+  workflow_dispatch:    
 
 jobs:
     fetch:

--- a/.github/workflows/feature-toggle-cleanup.yml
+++ b/.github/workflows/feature-toggle-cleanup.yml
@@ -7,7 +7,8 @@ on:
       - cron:  '30 10 * * *'
 jobs:
     feature-toggle-cleanup:
-        runs-on: ubuntu-latest    
+        runs-on: ubuntu-latest
+        # This check is here to prevent this workflow from running on forks.    
         if: github.repository == 'grafana/grafana'
         steps:
             - name: Check out the code

--- a/.github/workflows/feature-toggle-cleanup.yml
+++ b/.github/workflows/feature-toggle-cleanup.yml
@@ -1,8 +1,10 @@
 name: Feature Toggle Cleanup
 
 on:
-  workflow_dispatch:    
-
+  workflow_dispatch:
+  schedule:
+      # * is a special character in YAML so you have to quote this string
+      - cron:  '30 10 * * *'
 jobs:
     fetch:
         runs-on: ubuntu-latest    
@@ -20,5 +22,5 @@ jobs:
                     FEATURE_TOGGLES_CSV_FILE_PATH: "pkg/services/featuremgmt/toggles_gen.csv"
               with:
                     script: |
-                        const { default: printStuff } = await import('${{ github.workspace }}/.github/workflows/scripts/feature-toggle-cleanup/feature-toggle-cleanup.js')                        
-                        await script({github, context, core})
+                        const { default: cleanupFeatureFlags } = await import('${{ github.workspace }}/.github/workflows/scripts/feature-toggle-cleanup/feature-toggle-cleanup.mjs')                        
+                        await cleanupFeatureFlags({github, context, core})

--- a/.github/workflows/scripts/feature-toggle-cleanup/feature-toggle-cleanup.js
+++ b/.github/workflows/scripts/feature-toggle-cleanup/feature-toggle-cleanup.js
@@ -1,0 +1,5 @@
+import { parse } from 'csv-parse/sync';
+
+export default function printStuff() {
+	console.log("stuff")
+}

--- a/.github/workflows/scripts/feature-toggle-cleanup/feature-toggle-cleanup.js
+++ b/.github/workflows/scripts/feature-toggle-cleanup/feature-toggle-cleanup.js
@@ -1,5 +1,38 @@
 import { parse } from 'csv-parse/sync';
+import fs from 'fs';
 
-export default function printStuff() {
-	console.log("stuff")
+/***
+ * Feauture Flag Structure example
+ *  Name: 'disableEnvelopeEncryption',
+    Stage: 'GA',
+    Owner: '@grafana/grafana-as-code',
+    Created: '2022-05-24',
+    requiresDevMode: 'false',
+    RequiresLicense: 'false',
+    RequiresRestart: 'false',
+    FrontendOnly: 'false'
+ * 
+ */
+
+
+export default function cleanupFeatureFlags() {
+	const today = new Date();
+	const sixMonthAgo = today.setMonth(today.getMonth() - 6);
+	const inputFileContents = fs.readFileSync(process.env.FEATURE_TOGGLES_CSV_FILE_PATH);
+	const parsedFeatureFlags = parse(inputFileContents, {
+		columns: true,
+		skip_empty_lines: true,
+		cast: true,
+		cast_date: true,
+	  });
+
+	// Here we can have the custom logic of how to handle what type of feature flag - e.g. GA can be treated differently than experimental and so on.
+	for (const flag of parsedFeatureFlags) {
+		if (flag.Created < sixMonthAgo) {
+			console.log(`The flag ${flag.Name} was created more than 6 months ago. It should be checked.`);
+			console.log(flag);
+		}
+	}
+	
+
 }

--- a/.github/workflows/scripts/feature-toggle-cleanup/package.json
+++ b/.github/workflows/scripts/feature-toggle-cleanup/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "feature-toggle-cleanup",
+  "version": "1.0.0",
+  "description": "",
+  "type:": "module",
+  "main": "feature-toggle-cleanup.js",
+  "author": "",
+  "license": "ISC"
+}

--- a/.github/workflows/scripts/feature-toggle-cleanup/package.json
+++ b/.github/workflows/scripts/feature-toggle-cleanup/package.json
@@ -1,9 +1,0 @@
-{
-  "name": "feature-toggle-cleanup",
-  "version": "1.0.0",
-  "description": "",
-  "type:": "module",
-  "main": "feature-toggle-cleanup.js",
-  "author": "",
-  "license": "ISC"
-}


### PR DESCRIPTION
This is the first stepping stone towards TTL for feature toggles https://github.com/grafana/grafana-enterprise/issues/4731

We can merge this one safely as it currently not do much but logging. Merging would helps us iterate further via separate branches and either add real notifications via slack / email or creation of cleanup issues for the corresponding squad.