### PR TITLE
Alerting: Add metrics for remote secondary mode to the forked AM

### DIFF
--- a/pkg/services/ngalert/metrics/ngalert.go
+++ b/pkg/services/ngalert/metrics/ngalert.go
@@ -25,22 +25,24 @@ type NGAlert struct {
 	// Registerer is used by subcomponents which register their own metrics.
 	Registerer prometheus.Registerer
 
-	schedulerMetrics            *Scheduler
-	stateMetrics                *State
-	multiOrgAlertmanagerMetrics *MultiOrgAlertmanager
-	apiMetrics                  *API
-	historianMetrics            *Historian
+	schedulerMetrics               *Scheduler
+	stateMetrics                   *State
+	multiOrgAlertmanagerMetrics    *MultiOrgAlertmanager
+	apiMetrics                     *API
+	historianMetrics               *Historian
+	remoteSecondaryForkedAMMetrics *RemoteSecondaryForkedAlertmanager
 }
 
 // NewNGAlert manages the metrics of all the alerting components.
 func NewNGAlert(r prometheus.Registerer) *NGAlert {
 	return &NGAlert{
-		Registerer:                  r,
-		schedulerMetrics:            NewSchedulerMetrics(r),
-		stateMetrics:                NewStateMetrics(r),
-		multiOrgAlertmanagerMetrics: NewMultiOrgAlertmanagerMetrics(r),
-		apiMetrics:                  NewAPIMetrics(r),
-		historianMetrics:            NewHistorianMetrics(r, Subsystem),
+		Registerer:                     r,
+		schedulerMetrics:               NewSchedulerMetrics(r),
+		stateMetrics:                   NewStateMetrics(r),
+		multiOrgAlertmanagerMetrics:    NewMultiOrgAlertmanagerMetrics(r),
+		apiMetrics:                     NewAPIMetrics(r),
+		historianMetrics:               NewHistorianMetrics(r, Subsystem),
+		remoteSecondaryForkedAMMetrics: NewRemoteSecondaryForkedAlertmanagerMetrics(r, Subsystem),
 	}
 }
 
@@ -62,4 +64,8 @@ func (ng *NGAlert) GetMultiOrgAlertmanagerMetrics() *MultiOrgAlertmanager {
 
 func (ng *NGAlert) GetHistorianMetrics() *Historian {
 	return ng.historianMetrics
+}
+
+func (ng *NGAlert) GetRemoteSecondaryForkedAMMetrics() *RemoteSecondaryForkedAlertmanager {
+	return ng.remoteSecondaryForkedAMMetrics
 }

--- a/pkg/services/ngalert/metrics/remote_secondary_forked_alertmanager.go
+++ b/pkg/services/ngalert/metrics/remote_secondary_forked_alertmanager.go
@@ -1,0 +1,35 @@
+package metrics
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+)
+
+type RemoteSecondaryForkedAlertmanager struct {
+	SyncsTotal                    *prometheus.CounterVec
+	ConfigurationSyncsFailedTotal *prometheus.CounterVec
+	StateSyncsFailedTotal         *prometheus.CounterVec
+}
+
+func NewRemoteSecondaryForkedAlertmanagerMetrics(r prometheus.Registerer, subsystem string) *RemoteSecondaryForkedAlertmanager {
+	return &RemoteSecondaryForkedAlertmanager{
+		SyncsTotal: promauto.With(r).NewCounterVec(prometheus.CounterOpts{
+			Namespace: Namespace,
+			Subsystem: subsystem,
+			Name:      "remote_secondary_forked_alertmanager_syncs_total",
+			Help:      "The total number of configuration + state sync attempts between the internal and the remote Alertmanager.",
+		}, []string{"org"}),
+		ConfigurationSyncsFailedTotal: promauto.With(r).NewCounterVec(prometheus.CounterOpts{
+			Namespace: Namespace,
+			Subsystem: subsystem,
+			Name:      "remote_secondary_forked_alertmanager_configuration_syncs_failed_total",
+			Help:      "The total number of failed attempts to sync configuration between Alertmanagers.",
+		}, []string{"org"}),
+		StateSyncsFailedTotal: promauto.With(r).NewCounterVec(prometheus.CounterOpts{
+			Namespace: Namespace,
+			Subsystem: subsystem,
+			Name:      "remote_secondary_forked_alertmanager_state_syncs_failed_total",
+			Help:      "The total number of failed attempts to sync state between Alertmanagers.",
+		}, []string{"org"}),
+	}
+}

--- a/pkg/services/ngalert/ngalert.go
+++ b/pkg/services/ngalert/ngalert.go
@@ -204,6 +204,7 @@ func (ng *AlertNG) init() error {
 					// Use both Alertmanager implementations in the forked Alertmanager.
 					cfg := remote.RemoteSecondaryConfig{
 						Logger:       log.New("ngalert.forked-alertmanager.remote-secondary"),
+						Metrics:      ng.Metrics.GetRemoteSecondaryForkedAMMetrics(),
 						OrgID:        orgID,
 						Store:        ng.store,
 						SyncInterval: ng.Cfg.UnifiedAlerting.RemoteAlertmanager.SyncInterval,

--- a/pkg/services/ngalert/remote/forked_alertmanager_test.go
+++ b/pkg/services/ngalert/remote/forked_alertmanager_test.go
@@ -8,10 +8,12 @@ import (
 
 	"github.com/grafana/grafana/pkg/infra/log"
 	apimodels "github.com/grafana/grafana/pkg/services/ngalert/api/tooling/definitions"
+	"github.com/grafana/grafana/pkg/services/ngalert/metrics"
 	"github.com/grafana/grafana/pkg/services/ngalert/models"
 	"github.com/grafana/grafana/pkg/services/ngalert/notifier"
 	"github.com/grafana/grafana/pkg/services/ngalert/notifier/alertmanager_mock"
 	remote_alertmanager_mock "github.com/grafana/grafana/pkg/services/ngalert/remote/mock"
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 )
@@ -621,6 +623,7 @@ func genTestAlertmanagersWithSyncInterval(t *testing.T, mode int, syncInterval t
 			SyncInterval: syncInterval,
 			OrgID:        1,
 			Store:        notifier.NewFakeConfigStore(t, configs),
+			Metrics:      metrics.NewRemoteSecondaryForkedAlertmanagerMetrics(prometheus.NewRegistry(), metrics.Subsystem),
 		}
 		forked, err := NewRemoteSecondaryForkedAlertmanager(cfg, internal, remote)
 		require.NoError(t, err)


### PR DESCRIPTION
This PR adds metrics around configuration and state sync attempts (total, failed).