### PR TITLE
QueryEditor: Display error even if error field is empty

### DIFF
--- a/public/app/features/query/components/QueryEditorRow.test.tsx
+++ b/public/app/features/query/components/QueryEditorRow.test.tsx
@@ -241,33 +241,33 @@ describe('frame results with warnings', () => {
     const warningsComponent = editorRow.renderWarnings();
     expect(warningsComponent).toBe(null);
   });
-  describe('QueryEditorRow', () => {
-    const props = (errorRefId: string): Props<DataQuery> => ({
-      dataSource: mockDS,
-      query: { refId: 'B' },
-      data: {
-        state: LoadingState.Error,
-        series: [],
-        errors: [{ message: 'Error!!', refId: errorRefId }],
-        timeRange: { from: dateTime(), to: dateTime(), raw: { from: 'now-1d', to: 'now' } },
-      },
-      queries: [{ refId: 'B' }],
-      id: 'test',
-      onAddQuery: jest.fn(),
-      onRunQuery: jest.fn(),
-      onChange: jest.fn(),
-      onRemoveQuery: jest.fn(),
-      index: 0,
-    });
-    it('should display error message in corresponding panel', async () => {
-      render(<QueryEditorRow {...props('B')} />);
-      expect(await screen.findByText('Error!!')).toBeInTheDocument();
-    });
-    it('should not display error message if error.refId doesnt match', async () => {
+});
+describe('QueryEditorRow', () => {
+  const props = (errorRefId: string): Props<DataQuery> => ({
+    dataSource: mockDS,
+    query: { refId: 'B' },
+    data: {
+      state: LoadingState.Error,
+      series: [],
+      errors: [{ message: 'Error!!', refId: errorRefId }],
+      timeRange: { from: dateTime(), to: dateTime(), raw: { from: 'now-1d', to: 'now' } },
+    },
+    queries: [{ refId: 'B' }],
+    id: 'test',
+    onAddQuery: jest.fn(),
+    onRunQuery: jest.fn(),
+    onChange: jest.fn(),
+    onRemoveQuery: jest.fn(),
+    index: 0,
+  });
+  it('should display error message in corresponding panel', async () => {
+    render(<QueryEditorRow {...props('B')} />);
+    expect(await screen.findByText('Error!!')).toBeInTheDocument();
+  });
+  it('should not display error message if error.refId doesnt match', async () => {
+      render(<QueryEditorRow {...props('A')} />);
       await waitFor(() => {
-        render(<QueryEditorRow {...props('A')} />);
-        expect(screen.queryByText('Error!!')).not.toBeInTheDocument();
-      });
+      expect(screen.queryByText('Error!!')).not.toBeInTheDocument();
     });
   });
 });

--- a/public/app/features/query/components/QueryEditorRow.test.tsx
+++ b/public/app/features/query/components/QueryEditorRow.test.tsx
@@ -1,8 +1,31 @@
-import { render, screen } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
+import React, { PropsWithChildren } from 'react';
 
 import { DataQueryRequest, dateTime, LoadingState, PanelData, toDataFrame } from '@grafana/data';
+import { DataQuery } from '@grafana/schema';
+import { mockDataSource } from 'app/features/alerting/unified/mocks';
 
-import { filterPanelDataToQuery, QueryEditorRow } from './QueryEditorRow';
+import { DataSourceType } from '../../alerting/unified/utils/datasource';
+
+import { filterPanelDataToQuery, Props, QueryEditorRow } from './QueryEditorRow';
+
+const mockDS = mockDataSource({
+  name: 'test',
+  type: DataSourceType.Alertmanager,
+});
+jest.mock('@grafana/runtime/src/services/dataSourceSrv', () => {
+  return {
+    getDataSourceSrv: () => ({
+      get: () => Promise.resolve(mockDS),
+      getList: () => {},
+      getInstanceSettings: () => mockDS,
+    }),
+  };
+});
+// Draggable fails to render in tests, so we mock it out
+jest.mock('app/core/components/QueryOperationRow/QueryOperationRow', () => ({
+  QueryOperationRow: (props: PropsWithChildren) => <div>{props.children}</div>,
+}));
 
 function makePretendRequest(requestId: string, subRequests?: DataQueryRequest[]): DataQueryRequest {
   return {
@@ -217,5 +240,34 @@ describe('frame results with warnings', () => {
 
     const warningsComponent = editorRow.renderWarnings();
     expect(warningsComponent).toBe(null);
+  });
+  describe('QueryEditorRow', () => {
+    const props = (errorRefId: string): Props<DataQuery> => ({
+      dataSource: mockDS,
+      query: { refId: 'B' },
+      data: {
+        state: LoadingState.Error,
+        series: [],
+        errors: [{ message: 'Error!!', refId: errorRefId }],
+        timeRange: { from: dateTime(), to: dateTime(), raw: { from: 'now-1d', to: 'now' } },
+      },
+      queries: [{ refId: 'B' }],
+      id: 'test',
+      onAddQuery: jest.fn(),
+      onRunQuery: jest.fn(),
+      onChange: jest.fn(),
+      onRemoveQuery: jest.fn(),
+      index: 0,
+    });
+    it('should display error message in corresponding panel', async () => {
+      render(<QueryEditorRow {...props('B')} />);
+      expect(await screen.findByText('Error!!')).toBeInTheDocument();
+    });
+    it('should not display error message if error.refId doesnt match', async () => {
+      await waitFor(() => {
+        render(<QueryEditorRow {...props('A')} />);
+        expect(screen.queryByText('Error!!')).not.toBeInTheDocument();
+      });
+    });
   });
 });

--- a/public/app/features/query/components/QueryEditorRow.test.tsx
+++ b/public/app/features/query/components/QueryEditorRow.test.tsx
@@ -243,15 +243,10 @@ describe('frame results with warnings', () => {
   });
 });
 describe('QueryEditorRow', () => {
-  const props = (errorRefId: string): Props<DataQuery> => ({
+  const props = (data: PanelData): Props<DataQuery> => ({
     dataSource: mockDS,
     query: { refId: 'B' },
-    data: {
-      state: LoadingState.Error,
-      series: [],
-      errors: [{ message: 'Error!!', refId: errorRefId }],
-      timeRange: { from: dateTime(), to: dateTime(), raw: { from: 'now-1d', to: 'now' } },
-    },
+    data,
     queries: [{ refId: 'B' }],
     id: 'test',
     onAddQuery: jest.fn(),
@@ -261,12 +256,35 @@ describe('QueryEditorRow', () => {
     index: 0,
   });
   it('should display error message in corresponding panel', async () => {
-    render(<QueryEditorRow {...props('B')} />);
+    const data = {
+      state: LoadingState.Error,
+      series: [],
+      errors: [{ message: 'Error!!', refId: 'B' }],
+      timeRange: { from: dateTime(), to: dateTime(), raw: { from: 'now-1d', to: 'now' } },
+    };
+    render(<QueryEditorRow {...props(data)} />);
+    expect(await screen.findByText('Error!!')).toBeInTheDocument();
+  });
+  it('should display error message in corresponding panel if only error field is provided', async () => {
+    const data = {
+      state: LoadingState.Error,
+      series: [],
+      error: { message: 'Error!!', refId: 'B' },
+      errors: [],
+      timeRange: { from: dateTime(), to: dateTime(), raw: { from: 'now-1d', to: 'now' } },
+    };
+    render(<QueryEditorRow {...props(data)} />);
     expect(await screen.findByText('Error!!')).toBeInTheDocument();
   });
   it('should not display error message if error.refId doesnt match', async () => {
-      render(<QueryEditorRow {...props('A')} />);
-      await waitFor(() => {
+    const data = {
+      state: LoadingState.Error,
+      series: [],
+      errors: [{ message: 'Error!!', refId: 'A' }],
+      timeRange: { from: dateTime(), to: dateTime(), raw: { from: 'now-1d', to: 'now' } },
+    };
+    render(<QueryEditorRow {...props(data)} />);
+    await waitFor(() => {
       expect(screen.queryByText('Error!!')).not.toBeInTheDocument();
     });
   });

--- a/public/app/features/query/components/QueryEditorRow.tsx
+++ b/public/app/features/query/components/QueryEditorRow.tsx
@@ -42,7 +42,7 @@ import { RowActionComponents } from './QueryActionComponent';
 import { QueryEditorRowHeader } from './QueryEditorRowHeader';
 import { QueryErrorAlert } from './QueryErrorAlert';
 
-interface Props<TQuery extends DataQuery> {
+export interface Props<TQuery extends DataQuery> {
   data: PanelData;
   query: TQuery;
   queries: TQuery[];
@@ -510,7 +510,8 @@ export class QueryEditorRow<TQuery extends DataQuery> extends PureComponent<Prop
     const { query, index, visualization, collapsable } = this.props;
     const { datasource, showingHelp, data } = this.state;
     const isDisabled = query.hide;
-
+    const error =
+      data?.error && data.error.refId === query.refId ? data.error : data?.errors?.find((e) => e.refId === query.refId);
     const rowClasses = classNames('query-editor-row', {
       'query-editor-row--disabled': isDisabled,
       'gf-form-disabled': isDisabled,
@@ -547,7 +548,7 @@ export class QueryEditorRow<TQuery extends DataQuery> extends PureComponent<Prop
               )}
               {editor}
             </ErrorBoundaryAlert>
-            {data?.error && data.error.refId === query.refId && <QueryErrorAlert error={data.error} />}
+            {error && <QueryErrorAlert error={error} />}
             {visualization}
           </div>
         </QueryOperationRow>


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**
I noticed that errors aren't displayed in the panel when we pass only `errors` field from Cloudwatch. We'd have to pass `error` field as well, even though it's deprecated. This adds the support for only `errors` but keeps it compatible with `error`. 

<img width="500" alt="Screenshot 2024-01-02 at 17 39 47" src="https://github.com/grafana/grafana/assets/16140639/70533a53-7a53-471e-b64a-0fd44ac77427">

[Add a brief description of what the feature or update does.]

**Why do we need this feature?**

[Add a description of the problem the feature is trying to solve.]

**Who is this feature for?**

[Add information on what kind of user the feature is for.]

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
