### PR TITLE
Loki: Derived fields unit test flake

### DIFF
--- a/public/app/plugins/datasource/loki/configuration/DerivedFields.test.tsx
+++ b/public/app/plugins/datasource/loki/configuration/DerivedFields.test.tsx
@@ -35,7 +35,8 @@ describe('DerivedFields', () => {
     const onChange = jest.fn();
     render(<DerivedFields onChange={onChange} />);
 
-    userEvent.click(screen.getByText('Add'));
+    const addButton = await screen.findByText('Add');
+    userEvent.click(addButton);
 
     await waitFor(() => expect(onChange).toHaveBeenCalledTimes(1));
   });
@@ -63,12 +64,13 @@ describe('DerivedFields', () => {
     ];
     render(<DerivedFields onChange={jest.fn()} fields={repeatedFields} />);
 
-    userEvent.click(screen.getAllByPlaceholderText('Field name')[0]);
+    const inputs = await screen.findAllByPlaceholderText('Field name');
+    userEvent.click(inputs[0]);
 
     expect(await screen.findAllByText('The name is already in use')).toHaveLength(2);
   });
 
-  it('does not validate empty names as repeated', () => {
+  it('does not validate empty names as repeated', async () => {
     const repeatedFields = [
       {
         matcherRegex: '',
@@ -81,7 +83,8 @@ describe('DerivedFields', () => {
     ];
     render(<DerivedFields onChange={jest.fn()} fields={repeatedFields} />);
 
-    userEvent.click(screen.getAllByPlaceholderText('Field name')[0]);
+    const inputs = await screen.findAllByPlaceholderText('Field name');
+    userEvent.click(inputs[0]);
 
     expect(screen.queryByText('The name is already in use')).not.toBeInTheDocument();
   });


### PR DESCRIPTION
@leeoniya caught one of our tests flaking in drone
https://drone.grafana.net/grafana/grafana/152382/1/6

And I believe that you can avoid this by using async [findBy](https://testing-library.com/docs/dom-testing-library/api-async/#findby-queries)* instead of getBy* when grabbing elements that the test interacts with.