### PR TITLE
Chore: Log error from App loading in console and faro

### DIFF
--- a/public/app/features/plugins/components/AppRootPage.test.tsx
+++ b/public/app/features/plugins/components/AppRootPage.test.tsx
@@ -105,7 +105,9 @@ describe('AppRootPage', () => {
   it("should show a not found page if the plugin settings can't load", async () => {
     getPluginSettingsMock.mockRejectedValue(new Error('Unknown Plugin'));
     // Renders once for the first time
-    await renderUnderRouter();
+    await act(async () => {
+      await renderUnderRouter();
+    });
     expect(await screen.findByText('App not found')).toBeVisible();
   });
 

--- a/public/app/features/plugins/components/AppRootPage.test.tsx
+++ b/public/app/features/plugins/components/AppRootPage.test.tsx
@@ -103,6 +103,7 @@ describe('AppRootPage', () => {
   });
 
   it("should show a not found page if the plugin settings can't load", async () => {
+    jest.spyOn(console, 'error').mockImplementation();
     getPluginSettingsMock.mockRejectedValue(new Error('Unknown Plugin'));
     // Renders once for the first time
     await act(async () => {

--- a/public/app/features/plugins/components/AppRootPage.tsx
+++ b/public/app/features/plugins/components/AppRootPage.tsx
@@ -13,7 +13,7 @@ import {
   PluginType,
   PluginContextProvider,
 } from '@grafana/data';
-import { config, locationSearchToObject } from '@grafana/runtime';
+import { config, locationSearchToObject, logError } from '@grafana/runtime';
 import { Alert } from '@grafana/ui';
 import { Page } from 'app/core/components/Page/Page';
 import PageLoader from 'app/core/components/PageLoader/PageLoader';
@@ -21,6 +21,7 @@ import { EntityNotFound } from 'app/core/components/PageNotFound/EntityNotFound'
 import { useGrafana } from 'app/core/context/GrafanaContext';
 import { appEvents, contextSrv } from 'app/core/core';
 import { getNotFoundNav, getWarningNav, getExceptionNav } from 'app/core/navigation/errorModels';
+import { getMessageFromError } from 'app/core/utils/errors';
 
 import { getPluginSettings } from '../pluginSettings';
 import { importAppPlugin } from '../plugin_loader';
@@ -191,6 +192,9 @@ async function loadAppPlugin(pluginId: string, dispatch: React.Dispatch<AnyActio
         pluginNav: process.env.NODE_ENV === 'development' ? getExceptionNav(err) : getNotFoundNav(),
       })
     );
+    const error = err instanceof Error ? err : new Error(getMessageFromError(err));
+    logError(error);
+    console.error(error);
   }
 }
 


### PR DESCRIPTION
**What is this feature?**

It makes sure any error generated inside the [AppRootPage](https://github.com/grafana/grafana/blob/8bf5cdcf0c57151a6022f51a48077dda0c57eb8a/public/app/features/plugins/components/AppRootPage.tsx#L185-L194) is not silently ignored but instead shown in the browser console and logged

**Why do we need this feature?**

To have diagnostic data about apps not loading in grafana instances

**Who is this feature for?**

Users of grafana apps

**Which issue(s) does this PR fix?**:

Closes https://github.com/grafana/grafana/issues/79761

**Special notes for your reviewer:**

Please check that:

- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
