### PR TITLE
Pyroscope: Add Span ID to options collapsed info

### DIFF
--- a/public/app/plugins/datasource/grafana-pyroscope-datasource/QueryEditor/QueryOptions.tsx
+++ b/public/app/plugins/datasource/grafana-pyroscope-datasource/QueryEditor/QueryOptions.tsx
@@ -48,6 +48,9 @@ export function QueryOptions({ query, onQueryChange, app, labels }: Props) {
   if (query.groupBy?.length) {
     collapsedInfo.push(`Group by: ${query.groupBy.join(', ')}`);
   }
+  if (query.spanSelector?.length) {
+    collapsedInfo.push(`Span ID: ${query.spanSelector}`);
+  }
   if (query.maxNodes) {
     collapsedInfo.push(`Max nodes: ${query.maxNodes}`);
   }

--- a/public/app/plugins/datasource/grafana-pyroscope-datasource/QueryEditor/QueryOptions.tsx
+++ b/public/app/plugins/datasource/grafana-pyroscope-datasource/QueryEditor/QueryOptions.tsx
@@ -49,7 +49,7 @@ export function QueryOptions({ query, onQueryChange, app, labels }: Props) {
     collapsedInfo.push(`Group by: ${query.groupBy.join(', ')}`);
   }
   if (query.spanSelector?.length) {
-    collapsedInfo.push(`Span ID: ${query.spanSelector}`);
+    collapsedInfo.push(`Span IDs: ${query.spanSelector.join(', ')}`);
   }
   if (query.maxNodes) {
     collapsedInfo.push(`Max nodes: ${query.maxNodes}`);

--- a/public/app/plugins/datasource/grafana-pyroscope-datasource/QueryEditor/QueryOptions.tsx
+++ b/public/app/plugins/datasource/grafana-pyroscope-datasource/QueryEditor/QueryOptions.tsx
@@ -49,7 +49,7 @@ export function QueryOptions({ query, onQueryChange, app, labels }: Props) {
     collapsedInfo.push(`Group by: ${query.groupBy.join(', ')}`);
   }
   if (query.spanSelector?.length) {
-    collapsedInfo.push(`Span IDs: ${query.spanSelector.join(', ')}`);
+    collapsedInfo.push(`Span ID: ${query.spanSelector.join(', ')}`);
   }
   if (query.maxNodes) {
     collapsedInfo.push(`Max nodes: ${query.maxNodes}`);


### PR DESCRIPTION
**What is this feature?**

Adds Span ID to options collapsed info.

**Why do we need this feature?**

So users can see all their options summary.

**Who is this feature for?**

Pyroscope users.

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
