### PR TITLE
TimeSeries: Fix stacking opacity accumulation on exit from PanelEdit

### DIFF
--- a/packages/grafana-ui/src/components/uPlot/config/UPlotConfigBuilder.test.ts
+++ b/packages/grafana-ui/src/components/uPlot/config/UPlotConfigBuilder.test.ts
@@ -379,8 +379,6 @@ describe('UPlotConfigBuilder', () => {
       max: 100,
     });
 
-    expect(builder.getConfig().scales!['scale-y']!.auto).toEqual(false);
-
     builder.addScale({
       isTime: false,
       scaleKey: 'scale-y2',
@@ -391,6 +389,7 @@ describe('UPlotConfigBuilder', () => {
       softMin: -50,
     });
 
+    expect(builder.getConfig().scales!['scale-y']!.auto).toEqual(false);
     expect(builder.getConfig().scales!['scale-y2']!.auto).toEqual(true);
   });
 

--- a/packages/grafana-ui/src/components/uPlot/config/UPlotConfigBuilder.ts
+++ b/packages/grafana-ui/src/components/uPlot/config/UPlotConfigBuilder.ts
@@ -58,6 +58,8 @@ export class UPlotConfigBuilder {
   private tooltipInterpolator: PlotTooltipInterpolator | undefined = undefined;
   private padding?: Padding = undefined;
 
+  private cachedConfig?: PlotConfig;
+
   prepData: PrepData | undefined = undefined;
 
   constructor(timeZone: TimeZone = DefaultTimeZone) {
@@ -190,6 +192,10 @@ export class UPlotConfigBuilder {
   }
 
   getConfig() {
+    if (this.cachedConfig) {
+      return this.cachedConfig;
+    }
+
     const config: PlotConfig = {
       ...DEFAULT_PLOT_CONFIG,
       mode: this.mode,
@@ -244,17 +250,17 @@ export class UPlotConfigBuilder {
       config.padding = this.padding;
     }
 
-    if (this.stackingGroups.length) {
-      this.stackingGroups.forEach((group) => {
-        getStackingBands(group).forEach((band) => {
-          this.addBand(band);
-        });
+    this.stackingGroups.forEach((group) => {
+      getStackingBands(group).forEach((band) => {
+        this.addBand(band);
       });
-    }
+    });
 
     if (this.bands.length) {
       config.bands = this.bands;
     }
+
+    this.cachedConfig = config;
 
     return config;
   }


### PR DESCRIPTION
**problem:** when exiting PaneEdit without having made any changes (either via Discard or browser back button), all panels with stacking progressively increase in opacity. it is reproducible here: https://play.grafana.org/d/timeseries-stacking2/timeseries-and-barchart-stacking?orgId=1

https://github.com/grafana/grafana/assets/43234/6190df4a-ae54-4111-9c44-4d69c59612d3

**cause:** when calling `builder.getConfig()`, we implicitly add uPlot bands for the stacked series. this builder is not meant to be re-used, and is expected to be discarded after getConfig() has done its job. for some reason (still unknown), this builder is getting reused to re-build up the config when exiting PanelEdit, so these stacking bands end up getting added multiple times, which causes them to render multiple times and increase opacity.

**solution:** since these builders are one-shot things, we cache the getConfig() output and return from cache in future.