### PR TITLE
Gdev: Fix breaking gdev testdata datasource

### DIFF
--- a/public/app/plugins/datasource/grafana-testdata-datasource/package.json
+++ b/public/app/plugins/datasource/grafana-testdata-datasource/package.json
@@ -11,6 +11,7 @@
     "@grafana/schema": "10.3.0-pre",
     "@grafana/ui": "10.3.0-pre",
     "lodash": "4.17.21",
+    "micro-memoize": "^4.1.2",
     "react": "18.2.0",
     "react-use": "17.4.0",
     "rxjs": "7.8.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2932,6 +2932,7 @@ __metadata:
     "@types/react": "npm:18.2.15"
     "@types/testing-library__jest-dom": "npm:5.14.8"
     lodash: "npm:4.17.21"
+    micro-memoize: "npm:^4.1.2"
     react: "npm:18.2.0"
     react-use: "npm:17.4.0"
     rxjs: "npm:7.8.1"


### PR DESCRIPTION
When I pulled latest `main` my grafana-testdata-datasource plugin broke with an error about missing a dependency. Adding the missing dependency to the package.json seems to have fixed the issue.

I'm not sure what caused this to break. After doing some digging while investigating a fix I came across https://github.com/grafana/grafana/pull/75833 which might have changed the way dependencies are passed / handled in some way (cc @andresmgot)

<img width="1497" alt="Screenshot 2024-01-03 at 6 56 14 PM" src="https://github.com/grafana/grafana/assets/22381771/a048d1f4-312e-47e2-bcea-55101f43351f">
