### PR TITLE
Rendering: Fix plugin initialization

### DIFF
--- a/pkg/services/rendering/rendering.go
+++ b/pkg/services/rendering/rendering.go
@@ -38,6 +38,7 @@ type RenderingService struct {
 	version           string
 	versionMutex      sync.RWMutex
 	capabilities      []Capability
+	pluginAvailable   bool
 
 	perRequestRenderKeyProvider renderKeyProvider
 	Cfg                         *setting.Cfg
@@ -108,6 +109,8 @@ func ProvideService(cfg *setting.Cfg, features *featuremgmt.FeatureManager, remo
 		}
 	}
 
+	_, exists := rm.Renderer(context.Background())
+
 	s := &RenderingService{
 		perRequestRenderKeyProvider: renderKeyProvider,
 		capabilities: []Capability{
@@ -131,6 +134,7 @@ func ProvideService(cfg *setting.Cfg, features *featuremgmt.FeatureManager, remo
 		log:                   logger,
 		domain:                domain,
 		sanitizeURL:           sanitizeURL,
+		pluginAvailable:       exists,
 	}
 
 	gob.Register(&RenderUser{})
@@ -200,17 +204,12 @@ func (rs *RenderingService) Run(ctx context.Context) error {
 	return nil
 }
 
-func (rs *RenderingService) pluginAvailable(ctx context.Context) bool {
-	_, exists := rs.RendererPluginManager.Renderer(ctx)
-	return exists
-}
-
 func (rs *RenderingService) remoteAvailable() bool {
 	return rs.Cfg.RendererUrl != ""
 }
 
 func (rs *RenderingService) IsAvailable(ctx context.Context) bool {
-	return rs.remoteAvailable() || rs.pluginAvailable(ctx)
+	return rs.remoteAvailable() || rs.pluginAvailable
 }
 
 func (rs *RenderingService) Version() string {


### PR DESCRIPTION
**What is this feature?**
Moves the first renderer plugin initialization from the `Run` function to the `ProvideService` one and stores the plugin availability info as a boolean instead of trying to access the `Renderer` every time.

**Why do we need this feature?**
This is a follow-up on https://github.com/grafana/grafana/pull/77854. After this refactor, there was a conflict between the rendering and the reporting (Enterprise) services to access the renderer to check if it was available causing intermittent failures for one or the other service.

**Special notes for your reviewer:**
To reproduce the issue and test this fix, you should have the Enterprise extension files and a valid Enterprise license. 