### PR TITLE
Rendering: Fix streaming panels always reaching timeout

### DIFF
--- a/public/app/features/dashboard/dashgrid/PanelStateWrapper.tsx
+++ b/public/app/features/dashboard/dashgrid/PanelStateWrapper.tsx
@@ -460,7 +460,12 @@ export class PanelStateWrapper extends PureComponent<Props, State> {
   };
 
   shouldSignalRenderingCompleted(loadingState: LoadingState, pluginMeta: PanelPluginMeta) {
-    return loadingState === LoadingState.Done || loadingState === LoadingState.Error || pluginMeta.skipDataQuery;
+    return (
+      loadingState === LoadingState.Done ||
+      loadingState === LoadingState.Streaming ||
+      loadingState === LoadingState.Error ||
+      pluginMeta.skipDataQuery
+    );
   }
 
   skipFirstRender(loadingState: LoadingState) {


### PR DESCRIPTION
**What is this feature? Why do we need it?**
Currently, when trying to render streaming panels, the rendering request always times out because the function `renderingCompleted` is never called. This fixes this behavior.

**Who is this feature for?**
Users using the rendering features along with streaming panels.

**Special notes for your reviewer:**
This fixes the timeout issue but I wonder if this is the right fix, when the panel is in the `Streaming` state does it mean initial data is loaded? 