### PR TITLE
Alerting: Fix URL timestamp conversion in historian API in annotation mode

### DIFF
--- a/pkg/services/ngalert/state/historian/annotation.go
+++ b/pkg/services/ngalert/state/historian/annotation.go
@@ -111,8 +111,8 @@ func (h *AnnotationBackend) Query(ctx context.Context, query ngmodels.HistoryQue
 	q := annotations.ItemQuery{
 		AlertID:      rule.ID,
 		OrgID:        query.OrgID,
-		From:         query.From.Unix(),
-		To:           query.To.Unix(),
+		From:         query.From.UnixMilli(),
+		To:           query.To.UnixMilli(),
 		SignedInUser: query.SignedInUser,
 	}
 	items, err := h.store.Find(ctx, &q)


### PR DESCRIPTION
**What is this feature?**

The annotation backend uses a typeless representation of time in its item queries, and so does not enforce the precision level.

History API queries in annotation mode were adding unix timestamps here, where the constructed SQL uses unix millisecond timestamps. Fix the bug, and convert accordingly.

**Which issue(s) does this PR fix?**:

n/a

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle.
- [x] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
