### PR TITLE
Loki: Fix `getParserAndLabelKeys` not returning parsed labels

### DIFF
--- a/public/app/plugins/datasource/loki/LanguageProvider.test.ts
+++ b/public/app/plugins/datasource/loki/LanguageProvider.test.ts
@@ -371,6 +371,7 @@ describe('Query imports', () => {
     const extractLogParserFromDataFrameMock = jest.mocked(extractLogParserFromDataFrame);
     const extractedLabelKeys = ['extracted', 'label'];
     const structuredMetadataKeys = ['structured', 'metadata'];
+    const parsedKeys = ['parsed', 'label'];
     const unwrapLabelKeys = ['unwrap', 'labels'];
 
     beforeEach(() => {
@@ -379,8 +380,12 @@ describe('Query imports', () => {
       jest.mocked(extractLabelKeysFromDataFrame).mockImplementation((_, type) => {
         if (type === LabelType.Indexed || !type) {
           return extractedLabelKeys;
-        } else {
+        } else if (type === LabelType.StructuredMetadata) {
           return structuredMetadataKeys;
+        } else if (type === LabelType.Parsed) {
+          return parsedKeys;
+        } else {
+          return [];
         }
       });
       jest.mocked(extractUnwrapLabelKeysFromDataFrame).mockReturnValue(unwrapLabelKeys);
@@ -391,7 +396,7 @@ describe('Query imports', () => {
       extractLogParserFromDataFrameMock.mockReturnValueOnce({ hasLogfmt: false, hasJSON: true, hasPack: false });
 
       expect(await languageProvider.getParserAndLabelKeys('{place="luna"}')).toEqual({
-        extractedLabelKeys,
+        extractedLabelKeys: [...extractedLabelKeys, ...parsedKeys],
         unwrapLabelKeys,
         structuredMetadataKeys,
         hasJSON: true,
@@ -405,7 +410,7 @@ describe('Query imports', () => {
       extractLogParserFromDataFrameMock.mockReturnValueOnce({ hasLogfmt: true, hasJSON: false, hasPack: false });
 
       expect(await languageProvider.getParserAndLabelKeys('{place="luna"}')).toEqual({
-        extractedLabelKeys,
+        extractedLabelKeys: [...extractedLabelKeys, ...parsedKeys],
         unwrapLabelKeys,
         structuredMetadataKeys,
         hasJSON: false,

--- a/public/app/plugins/datasource/loki/LanguageProvider.ts
+++ b/public/app/plugins/datasource/loki/LanguageProvider.ts
@@ -297,7 +297,10 @@ export default class LokiLanguageProvider extends LanguageProvider {
     const { hasLogfmt, hasJSON, hasPack } = extractLogParserFromDataFrame(series[0]);
 
     return {
-      extractedLabelKeys: extractLabelKeysFromDataFrame(series[0]),
+      extractedLabelKeys: [
+        ...extractLabelKeysFromDataFrame(series[0], LabelType.Indexed),
+        ...extractLabelKeysFromDataFrame(series[0], LabelType.Parsed),
+      ],
       structuredMetadataKeys: extractLabelKeysFromDataFrame(series[0], LabelType.StructuredMetadata),
       unwrapLabelKeys: extractUnwrapLabelKeysFromDataFrame(series[0]),
       hasJSON,


### PR DESCRIPTION
**What is this feature?**

The `getParserAndLabelKeys` method of Loki's language provider should return parsed and indexed labels in the `extractedLabelKeys` property. Since https://github.com/grafana/grafana/pull/78584 this now defaulted to only indexed labels.

This PR adds a fix to add parsed labels to the `extractedLabelKeys` property.
