### PR TITLE
fix: Faro usage issue

### DIFF
--- a/public/app/core/services/echo/backends/grafana-javascript-agent/GrafanaJavascriptAgentBackend.test.ts
+++ b/public/app/core/services/echo/backends/grafana-javascript-agent/GrafanaJavascriptAgentBackend.test.ts
@@ -45,14 +45,6 @@ describe('GrafanaJavascriptAgentEchoBackend', () => {
 
   it('will set up FetchTransport if customEndpoint is provided', () => {
     // arrange
-    // jest.spyOn(faroWebSdkModule, 'initializeFaro').mockReturnValueOnce({
-    //   ...faroWebSdkModule.faro,
-    //   api: {
-    //     ...faroWebSdkModule.faro.api,
-    //     setUser: jest.fn(),
-    //   },
-    // });
-
     const constructorSpy = jest.spyOn(faroWebSdkModule, 'FetchTransport');
 
     //act

--- a/public/app/core/services/echo/backends/grafana-javascript-agent/GrafanaJavascriptAgentBackend.test.ts
+++ b/public/app/core/services/echo/backends/grafana-javascript-agent/GrafanaJavascriptAgentBackend.test.ts
@@ -102,67 +102,6 @@ describe('GrafanaJavascriptAgentEchoBackend', () => {
     });
   });
 
-  it('will forward events to transports', () => {
-    //arrange
-    const mockedSetUser = jest.fn();
-    const mockedInstrumentationsForConfig: Instrumentation[] = [];
-    const mockedInstrumentations = {
-      add: jest.fn(),
-      instrumentations: mockedInstrumentationsForConfig,
-      remove: jest.fn(),
-    };
-    const mockedInternalLogger = {
-      prefix: 'Faro',
-      debug: jest.fn(),
-      info: jest.fn(),
-      warn: jest.fn(),
-      error: jest.fn(),
-    };
-
-    const mockTransports: BaseTransport[] = [
-      { send: jest.fn() } as unknown as BaseTransport,
-      { send: jest.fn() } as unknown as BaseTransport,
-    ];
-
-    jest.spyOn(faroWebSdkModule, 'initializeFaro').mockReturnValueOnce({
-      ...faroWebSdkModule.faro,
-      api: {
-        ...faroWebSdkModule.faro.api,
-        setUser: mockedSetUser,
-      },
-      config: {
-        ...faroWebSdkModule.faro.config,
-        instrumentations: mockedInstrumentationsForConfig,
-      },
-      instrumentations: mockedInstrumentations,
-      internalLogger: mockedInternalLogger,
-
-      transports: {
-        ...faroWebSdkModule.faro.transports,
-        transports: mockTransports,
-      },
-    });
-
-    const backend = new GrafanaJavascriptAgentBackend({
-      ...options,
-      preventGlobalExposure: true,
-    });
-
-    const event: GrafanaJavascriptAgentEchoEvent = {
-      type: EchoEventType.GrafanaJavascriptAgent,
-      payload: { foo: 'bar' } as unknown as GrafanaJavascriptAgentEchoEvent,
-      meta: {} as unknown as EchoMeta,
-    };
-
-    backend.addEvent(event);
-
-    expect(mockTransports[0].send).toHaveBeenCalledTimes(1);
-    expect(mockTransports[0].send).toHaveBeenCalledWith(event.payload);
-
-    expect(mockTransports[1].send).toHaveBeenCalledTimes(1);
-    expect(mockTransports[1].send).toHaveBeenCalledWith(event.payload);
-  });
-
   //@FIXME - make integration test work
 
   // it('integration test with EchoSrv and  GrafanaJavascriptAgent', async () => {

--- a/public/app/core/services/echo/backends/grafana-javascript-agent/GrafanaJavascriptAgentBackend.test.ts
+++ b/public/app/core/services/echo/backends/grafana-javascript-agent/GrafanaJavascriptAgentBackend.test.ts
@@ -1,6 +1,6 @@
 import { BuildInfo } from '@grafana/data';
 import { GrafanaEdition } from '@grafana/data/src/types/config';
-import { BaseTransport, Instrumentation, InternalLoggerLevel } from '@grafana/faro-core';
+import { BaseTransport, Instrumentation } from '@grafana/faro-core';
 import * as faroWebSdkModule from '@grafana/faro-web-sdk';
 import { FetchTransport, initializeFaro } from '@grafana/faro-web-sdk';
 import { EchoEventType, EchoMeta } from '@grafana/runtime';

--- a/public/app/core/services/echo/backends/grafana-javascript-agent/GrafanaJavascriptAgentBackend.test.ts
+++ b/public/app/core/services/echo/backends/grafana-javascript-agent/GrafanaJavascriptAgentBackend.test.ts
@@ -1,13 +1,11 @@
 import { BuildInfo } from '@grafana/data';
 import { GrafanaEdition } from '@grafana/data/src/types/config';
-import { BaseTransport, Instrumentation } from '@grafana/faro-core';
+import { Instrumentation } from '@grafana/faro-core';
 import * as faroWebSdkModule from '@grafana/faro-web-sdk';
 import { FetchTransport, initializeFaro } from '@grafana/faro-web-sdk';
-import { EchoEventType, EchoMeta } from '@grafana/runtime';
 
 import { EchoSrvTransport } from './EchoSrvTransport';
 import { GrafanaJavascriptAgentBackend, GrafanaJavascriptAgentBackendOptions } from './GrafanaJavascriptAgentBackend';
-import { GrafanaJavascriptAgentEchoEvent } from './types';
 
 describe('GrafanaJavascriptAgentEchoBackend', () => {
   beforeEach(() => {

--- a/public/app/core/services/echo/backends/grafana-javascript-agent/GrafanaJavascriptAgentBackend.test.ts
+++ b/public/app/core/services/echo/backends/grafana-javascript-agent/GrafanaJavascriptAgentBackend.test.ts
@@ -5,6 +5,7 @@ import * as faroWebSdkModule from '@grafana/faro-web-sdk';
 import { FetchTransport, initializeFaro } from '@grafana/faro-web-sdk';
 import { EchoEventType, EchoMeta } from '@grafana/runtime';
 
+import { EchoSrvTransport } from './EchoSrvTransport';
 import { GrafanaJavascriptAgentBackend, GrafanaJavascriptAgentBackendOptions } from './GrafanaJavascriptAgentBackend';
 import { GrafanaJavascriptAgentEchoEvent } from './types';
 
@@ -44,20 +45,24 @@ describe('GrafanaJavascriptAgentEchoBackend', () => {
 
   it('will set up FetchTransport if customEndpoint is provided', () => {
     // arrange
-    jest.spyOn(faroWebSdkModule, 'initializeFaro').mockReturnValueOnce({
-      ...faroWebSdkModule.faro,
-      api: {
-        ...faroWebSdkModule.faro.api,
-        setUser: jest.fn(),
-      },
-    });
+    // jest.spyOn(faroWebSdkModule, 'initializeFaro').mockReturnValueOnce({
+    //   ...faroWebSdkModule.faro,
+    //   api: {
+    //     ...faroWebSdkModule.faro.api,
+    //     setUser: jest.fn(),
+    //   },
+    // });
+
+    const constructorSpy = jest.spyOn(faroWebSdkModule, 'FetchTransport');
 
     //act
-    const backend = new GrafanaJavascriptAgentBackend(options);
+    new GrafanaJavascriptAgentBackend(options);
 
     //assert
-    expect(backend.transports.length).toEqual(1);
-    expect(backend.transports[0]).toBeInstanceOf(FetchTransport);
+    expect(constructorSpy).toHaveBeenCalledTimes(1);
+    expect(faroWebSdkModule.faro.transports.transports.length).toEqual(2);
+    expect(faroWebSdkModule.faro.transports.transports[0]).toBeInstanceOf(EchoSrvTransport);
+    expect(faroWebSdkModule.faro.transports.transports[1]).toBeInstanceOf(FetchTransport);
   });
 
   it('will initialize GrafanaJavascriptAgent and set user', () => {
@@ -76,71 +81,20 @@ describe('GrafanaJavascriptAgentEchoBackend', () => {
       warn: jest.fn(),
       error: jest.fn(),
     };
-    const mockedAgent = () => {
-      return {
-        api: {
-          setUser: mockedSetUser,
-          pushLog: jest.fn(),
-          callOriginalConsoleMethod: jest.fn(),
-          pushError: jest.fn(),
-          pushMeasurement: jest.fn(),
-          pushTraces: jest.fn(),
-          pushEvent: jest.fn(),
-          initOTEL: jest.fn(),
-          getOTEL: jest.fn(),
-          getTraceContext: jest.fn(),
-          changeStacktraceParser: jest.fn(),
-          getStacktraceParser: jest.fn(),
-          isOTELInitialized: jest.fn(),
-          setSession: jest.fn(),
-          getSession: jest.fn(),
-          resetUser: jest.fn(),
-          resetSession: jest.fn(),
-          setView: jest.fn(),
-          getView: jest.fn(),
-        },
-        config: {
-          globalObjectKey: '',
-          preventGlobalExposure: false,
-          transports: [],
-          instrumentations: mockedInstrumentationsForConfig,
-          metas: [],
-          parseStacktrace: jest.fn(),
-          app: jest.fn(),
-          paused: false,
-          dedupe: true,
-          isolate: false,
-          internalLoggerLevel: InternalLoggerLevel.ERROR,
-          unpatchedConsole: { ...console },
-        },
-        metas: {
-          add: jest.fn(),
-          remove: jest.fn(),
-          value: {},
-          addListener: jest.fn(),
-          removeListener: jest.fn(),
-        },
-        transports: {
-          add: jest.fn(),
-          execute: jest.fn(),
-          transports: [],
-          pause: jest.fn(),
-          unpause: jest.fn(),
-          addBeforeSendHooks: jest.fn(),
-          addIgnoreErrorsPatterns: jest.fn(),
-          getBeforeSendHooks: jest.fn(),
-          isPaused: jest.fn(),
-          remove: jest.fn(),
-          removeBeforeSendHooks: jest.fn(),
-        },
-        pause: jest.fn(),
-        unpause: jest.fn(),
-        instrumentations: mockedInstrumentations,
-        internalLogger: mockedInternalLogger,
-        unpatchedConsole: { ...console },
-      };
-    };
-    jest.mocked(initializeFaro).mockImplementation(mockedAgent);
+
+    jest.spyOn(faroWebSdkModule, 'initializeFaro').mockReturnValueOnce({
+      ...faroWebSdkModule.faro,
+      api: {
+        ...faroWebSdkModule.faro.api,
+        setUser: mockedSetUser,
+      },
+      config: {
+        ...faroWebSdkModule.faro.config,
+        instrumentations: mockedInstrumentationsForConfig,
+      },
+      instrumentations: mockedInstrumentations,
+      internalLogger: mockedInternalLogger,
+    });
 
     //act
     new GrafanaJavascriptAgentBackend(options);
@@ -172,93 +126,49 @@ describe('GrafanaJavascriptAgentEchoBackend', () => {
       warn: jest.fn(),
       error: jest.fn(),
     };
-    const mockedAgent = () => {
-      return {
-        api: {
-          setUser: mockedSetUser,
-          pushLog: jest.fn(),
-          callOriginalConsoleMethod: jest.fn(),
-          pushError: jest.fn(),
-          pushMeasurement: jest.fn(),
-          pushTraces: jest.fn(),
-          pushEvent: jest.fn(),
-          initOTEL: jest.fn(),
-          getOTEL: jest.fn(),
-          getTraceContext: jest.fn(),
-          changeStacktraceParser: jest.fn(),
-          getStacktraceParser: jest.fn(),
-          isOTELInitialized: jest.fn(),
-          setSession: jest.fn(),
-          getSession: jest.fn(),
-          resetUser: jest.fn(),
-          resetSession: jest.fn(),
-          setView: jest.fn(),
-          getView: jest.fn(),
-        },
-        config: {
-          globalObjectKey: '',
-          preventGlobalExposure: false,
-          transports: [],
-          instrumentations: mockedInstrumentationsForConfig,
-          metas: [],
-          parseStacktrace: jest.fn(),
-          app: jest.fn(),
-          paused: false,
-          dedupe: true,
-          isolate: false,
-          internalLoggerLevel: InternalLoggerLevel.ERROR,
-          unpatchedConsole: { ...console },
-        },
-        metas: {
-          add: jest.fn(),
-          remove: jest.fn(),
-          value: {},
-          addListener: jest.fn(),
-          removeListener: jest.fn(),
-        },
-        transports: {
-          add: jest.fn(),
-          execute: jest.fn(),
-          transports: [],
-          pause: jest.fn(),
-          unpause: jest.fn(),
-          addBeforeSendHooks: jest.fn(),
-          addIgnoreErrorsPatterns: jest.fn(),
-          getBeforeSendHooks: jest.fn(),
-          isPaused: jest.fn(),
-          remove: jest.fn(),
-          removeBeforeSendHooks: jest.fn(),
-        },
-        pause: jest.fn(),
-        unpause: jest.fn(),
-        instrumentations: mockedInstrumentations,
-        internalLogger: mockedInternalLogger,
-        unpatchedConsole: { ...console },
-      };
-    };
 
-    jest.mocked(initializeFaro).mockImplementation(mockedAgent);
+    const mockTransports: BaseTransport[] = [
+      { send: jest.fn() } as unknown as BaseTransport,
+      { send: jest.fn() } as unknown as BaseTransport,
+    ];
+
+    jest.spyOn(faroWebSdkModule, 'initializeFaro').mockReturnValueOnce({
+      ...faroWebSdkModule.faro,
+      api: {
+        ...faroWebSdkModule.faro.api,
+        setUser: mockedSetUser,
+      },
+      config: {
+        ...faroWebSdkModule.faro.config,
+        instrumentations: mockedInstrumentationsForConfig,
+      },
+      instrumentations: mockedInstrumentations,
+      internalLogger: mockedInternalLogger,
+
+      transports: {
+        ...faroWebSdkModule.faro.transports,
+        transports: mockTransports,
+      },
+    });
+
     const backend = new GrafanaJavascriptAgentBackend({
       ...options,
       preventGlobalExposure: true,
     });
 
-    backend.transports = [
-      /* eslint-disable */
-      { send: jest.fn() } as unknown as BaseTransport,
-      { send: jest.fn() } as unknown as BaseTransport,
-    ];
     const event: GrafanaJavascriptAgentEchoEvent = {
       type: EchoEventType.GrafanaJavascriptAgent,
       payload: { foo: 'bar' } as unknown as GrafanaJavascriptAgentEchoEvent,
       meta: {} as unknown as EchoMeta,
     };
-    /* eslint-enable */
+
     backend.addEvent(event);
-    backend.transports.forEach((transport) => {
-      expect(transport.send).toHaveBeenCalledTimes(1);
-      expect(transport.send).toHaveBeenCalledWith(event.payload);
-    });
+
+    expect(mockTransports[0].send).toHaveBeenCalledTimes(1);
+    expect(mockTransports[0].send).toHaveBeenCalledWith(event.payload);
+
+    expect(mockTransports[1].send).toHaveBeenCalledTimes(1);
+    expect(mockTransports[1].send).toHaveBeenCalledWith(event.payload);
   });
 
   //@FIXME - make integration test work

--- a/public/app/core/services/echo/backends/grafana-javascript-agent/GrafanaJavascriptAgentBackend.ts
+++ b/public/app/core/services/echo/backends/grafana-javascript-agent/GrafanaJavascriptAgentBackend.ts
@@ -70,9 +70,6 @@ export class GrafanaJavascriptAgentBackend
       ],
       sessionTracking: {
         persistent: true,
-        generateSessionId() {
-          return (Math.random() + 1).toString(36).substring(2);
-        },
       },
       batching: {
         sendTimeout: 1000,

--- a/public/app/core/services/echo/backends/grafana-javascript-agent/GrafanaJavascriptAgentBackend.ts
+++ b/public/app/core/services/echo/backends/grafana-javascript-agent/GrafanaJavascriptAgentBackend.ts
@@ -87,12 +87,8 @@ export class GrafanaJavascriptAgentBackend
     }
   }
 
-  addEvent = (e: EchoEvent) => {
-    this.faroInstance.transports.transports
-      // don't call 'EchoSrvTransport' because it already calls addEvent() internally.
-      .filter((t) => t.name !== EchoSrvTransport.name)
-      .forEach((t) => t.send(e.payload));
-  };
+  // noop because the EchoSrvTransport registered in Faro will already broadcast all signals emitted by the Faro API
+  addEvent = (e: EchoEvent) => {};
 
   // backend will log events to stdout, and at least in case of hosted grafana they will be
   // ingested into Loki. Due to Loki limitations logs cannot be backdated,

--- a/public/app/core/services/echo/backends/grafana-javascript-agent/GrafanaJavascriptAgentBackend.ts
+++ b/public/app/core/services/echo/backends/grafana-javascript-agent/GrafanaJavascriptAgentBackend.ts
@@ -29,16 +29,15 @@ export class GrafanaJavascriptAgentBackend
 {
   supportedEvents = [EchoEventType.GrafanaJavascriptAgent];
   private faroInstance;
-  transports: BaseTransport[];
 
   constructor(public options: GrafanaJavascriptAgentBackendOptions) {
     // configure instrumentations.
     const instrumentations: Instrumentation[] = [];
 
-    this.transports = [];
+    const transports: BaseTransport[] = [new EchoSrvTransport()];
 
     if (options.customEndpoint) {
-      this.transports.push(new FetchTransport({ url: options.customEndpoint, apiKey: options.apiKey }));
+      transports.push(new FetchTransport({ url: options.customEndpoint, apiKey: options.apiKey }));
     }
 
     if (options.errorInstrumentalizationEnabled) {
@@ -63,7 +62,7 @@ export class GrafanaJavascriptAgentBackend
         environment: options.buildInfo.env,
       },
       instrumentations,
-      transports: [new EchoSrvTransport()],
+      transports,
       ignoreErrors: [
         'ResizeObserver loop limit exceeded',
         'ResizeObserver loop completed',
@@ -92,7 +91,7 @@ export class GrafanaJavascriptAgentBackend
   }
 
   addEvent = (e: EchoEvent) => {
-    this.transports.forEach((t) => t.send(e.payload));
+    this.faroInstance.transports.transports.forEach((t) => t.send(e.payload));
   };
 
   // backend will log events to stdout, and at least in case of hosted grafana they will be

--- a/public/app/core/services/echo/backends/grafana-javascript-agent/GrafanaJavascriptAgentBackend.ts
+++ b/public/app/core/services/echo/backends/grafana-javascript-agent/GrafanaJavascriptAgentBackend.ts
@@ -88,7 +88,10 @@ export class GrafanaJavascriptAgentBackend
   }
 
   addEvent = (e: EchoEvent) => {
-    this.faroInstance.transports.transports.forEach((t) => t.send(e.payload));
+    this.faroInstance.transports.transports
+      // don't call 'EchoSrvTransport' because it already calls addEvent() internally.
+      .filter((t) => t.name !== EchoSrvTransport.name)
+      .forEach((t) => t.send(e.payload));
   };
 
   // backend will log events to stdout, and at least in case of hosted grafana they will be


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

# What
We discovered Faro that the Grafana Faro instance is crashing.

<img width="602" alt="Screenshot 2024-01-05 at 10 42 13" src="https://github.com/grafana/grafana/assets/47627413/cf63d85d-2054-48a5-9f97-7577acc6ebdd">

This caused by an unintended usage of the Faro `FetchTansport` in the `GrafanaJavascriptAgentBackend` setup.

# Why
Due to the new pricing model Faro now adds a custom `x-faro-session-id` header to each requests it sends to the collector.
It receives the `sessionId` from the `SessionMeta` and attaches it to the `x-faro-session-id` header (`x-faro-session-id: mySessionId`).

<img width="795" alt="Screenshot 2024-01-05 at 10 43 24" src="https://github.com/grafana/grafana/assets/47627413/8a12bcac-6b4b-44e3-81a3-9bce5eb1826d">


## What is the reason for the issue

The `GrafanaJavascriptAgentBackend` instantiates a `new FetchTransport` if it finds a custom endpoint in the config.

```ts
 if (options.customEndpoint) {
      this.transports.push(new FetchTransport({ url: options.customEndpoint, apiKey: options.apiKey }));
    }
```

This `FetchTransport` was never added to the Faro transports property such it was never registered on the Faro instance.

This is a problem because Faro maintains a bunch of runtime data, like the meta objects, which are automatically attached to the `FetchTransport` instance, so it's guaranteed that meta data is always available in the instance.

See this image taken from the browser debugger. You can see that the meta object is empty.
<img width="645" alt="Screenshot 2024-01-05 at 10 31 16" src="https://github.com/grafana/grafana/assets/47627413/6a35fd4f-0de2-4941-8160-81921dce5d5b">

See this image taken from the browser debugger which shows a `FetchTrasnport` registered on Faro. You see the metas object is available.
 
<img width="743" alt="Screenshot 2024-01-05 at 10 41 49" src="https://github.com/grafana/grafana/assets/47627413/3ca2eab7-aa3d-41cd-8bda-683a917f9e21">


## What caused the issue

The `GrafanaJavascriptAgentBackend` provides the `addEvent` function which iterates over the transports array which includes the `FetchTransport` which is **not** under the control of Faro.

```ts  
 addEvent = (e: EchoEvent) => {
    this.transports.forEach((t) => t.send(e.payload));
  };
```

What now happens is that the `send()` function of the transport is called, which wants to receive the session meta, but the metas object is empty, which caused above issue.

## What fixes the issue
If a custom transport  is needed, instantiate it and add register it on the Faro instance so all meta information is automatically updated.

When calling the `addEvent` function receive the registered transports to iterate and call `send()` on each.

```ts
addEvent = (e: EchoEvent) => {
    this.faroInstance.transports.transports
      // don't call 'EchoSrvTransport' because it already calls addEvent() internally.
      .filter((t) => t.name !== EchoSrvTransport.name)
      .forEach((t) => t.send(e.payload));
  };
```  

**Edit (24/05/01)**
Because the registered `EchoSrvTransport` already broadcasts all signals emitted by the Faro API we make this a noop function. Otherwise every signal is sent twice

## Other things done in this PR
* Update tests
* As discussed with @tolzhabayev we remove the custom session-id-generator and use the internal session-id-generator built into Faro


# Result 
Tested locally with the following `conf/custom.ini`

```
[log.frontend]
enabled = true
provider = grafana
custom_endpoint = /log-grafana-javascript-agent
instrumentations_errors_enabled = true
instrumentations_console_enabled = true
instrumentations_webvitals_enabled = true
apiKey = testingCustomApiKey
```

* Issue does not appear anymore
* Metadata is correctly attached to each beacon

https://github.com/grafana/grafana/assets/47627413/973ec026-a0c6-4339-9389-bb04b707697b


Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
