### PR TITLE
Alerting: Saved detailed migration state

### DIFF
--- a/pkg/services/ngalert/migration/models/alertmanager.go
+++ b/pkg/services/ngalert/migration/models/alertmanager.go
@@ -1,6 +1,8 @@
 package models
 
 import (
+	"strings"
+
 	"github.com/prometheus/alertmanager/config"
 	"github.com/prometheus/alertmanager/pkg/labels"
 	"github.com/prometheus/common/model"
@@ -11,17 +13,50 @@ import (
 
 // Alertmanager is a helper struct for creating migrated alertmanager configs.
 type Alertmanager struct {
-	Config      *apiModels.PostableUserConfig
-	legacyRoute *apiModels.Route
+	config                *apiModels.PostableUserConfig
+	legacyRoute           *apiModels.Route
+	legacyReceiverToRoute map[string]*apiModels.Route
+	legacyUIDToReceiver   map[string]*apiModels.PostableGrafanaReceiver
 }
 
 // NewAlertmanager creates a new Alertmanager.
 func NewAlertmanager() *Alertmanager {
-	c, r := createBaseConfig()
-	return &Alertmanager{
-		Config:      c,
-		legacyRoute: r,
+	return FromPostableUserConfig(nil)
+}
+
+// FromPostableUserConfig creates an Alertmanager from a PostableUserConfig.
+func FromPostableUserConfig(config *apiModels.PostableUserConfig) *Alertmanager {
+	if config == nil {
+		// No existing amConfig created from a previous migration.
+		config = createBaseConfig()
 	}
+	if config.AlertmanagerConfig.Route == nil {
+		// No existing base route created from a previous migration.
+		config.AlertmanagerConfig.Route = createDefaultRoute()
+	}
+	am := &Alertmanager{
+		config:                config,
+		legacyRoute:           getOrCreateNestedLegacyRoute(config),
+		legacyReceiverToRoute: make(map[string]*apiModels.Route),
+		legacyUIDToReceiver:   config.GetGrafanaReceiverMap(),
+	}
+
+	for _, r := range am.legacyRoute.Routes {
+		am.legacyReceiverToRoute[r.Receiver] = r
+	}
+	return am
+}
+
+// CleanAlertmanager removes the nested legacy route from the base PostableUserConfig if it's empty.
+func CleanAlertmanager(am *Alertmanager) *apiModels.PostableUserConfig {
+	for i, r := range am.config.AlertmanagerConfig.Route.Routes {
+		if isNestedLegacyRoute(r) && len(r.Routes) == 0 {
+			// Remove empty nested route.
+			am.config.AlertmanagerConfig.Route.Routes = append(am.config.AlertmanagerConfig.Route.Routes[:i], am.config.AlertmanagerConfig.Route.Routes[i+1:]...)
+			return am.config
+		}
+	}
+	return am.config
 }
 
 // AddRoute adds a route to the alertmanager config.
@@ -29,6 +64,7 @@ func (am *Alertmanager) AddRoute(route *apiModels.Route) {
 	if route == nil {
 		return
 	}
+	am.legacyReceiverToRoute[route.Receiver] = route
 	am.legacyRoute.Routes = append(am.legacyRoute.Routes, route)
 }
 
@@ -37,7 +73,7 @@ func (am *Alertmanager) AddReceiver(recv *apiModels.PostableGrafanaReceiver) {
 	if recv == nil {
 		return
 	}
-	am.Config.AlertmanagerConfig.Receivers = append(am.Config.AlertmanagerConfig.Receivers, &apiModels.PostableApiReceiver{
+	am.config.AlertmanagerConfig.Receivers = append(am.config.AlertmanagerConfig.Receivers, &apiModels.PostableApiReceiver{
 		Receiver: config.Receiver{
 			Name: recv.Name, // Channel name is unique within an Org.
 		},
@@ -45,12 +81,57 @@ func (am *Alertmanager) AddReceiver(recv *apiModels.PostableGrafanaReceiver) {
 			GrafanaManagedReceivers: []*apiModels.PostableGrafanaReceiver{recv},
 		},
 	})
+	am.legacyUIDToReceiver[recv.UID] = recv
+}
+
+// GetLegacyRoute retrieves the legacy route for a given migrated channel UID.
+func (am *Alertmanager) GetLegacyRoute(recv string) (*apiModels.Route, bool) {
+	route, ok := am.legacyReceiverToRoute[recv]
+	return route, ok
+}
+
+// GetReceiver retrieves the receiver for a given UID.
+func (am *Alertmanager) GetReceiver(uid string) (*apiModels.PostableGrafanaReceiver, bool) {
+	recv, ok := am.legacyUIDToReceiver[uid]
+	return recv, ok
+}
+
+// GetContactLabel retrieves the label used to route for a given UID.
+func (am *Alertmanager) GetContactLabel(uid string) string {
+	if recv, ok := am.GetReceiver(uid); ok {
+		if route, ok := am.GetLegacyRoute(recv.Name); ok {
+			for _, match := range route.ObjectMatchers {
+				if match.Type == labels.MatchEqual && strings.HasPrefix(match.Name, ngmodels.MigratedContactLabelPrefix) {
+					return match.Name
+				}
+			}
+		}
+	}
+	return ""
+}
+
+// getOrCreateNestedLegacyRoute finds or creates the nested route for migrated channels.
+func getOrCreateNestedLegacyRoute(config *apiModels.PostableUserConfig) *apiModels.Route {
+	for _, r := range config.AlertmanagerConfig.Route.Routes {
+		if isNestedLegacyRoute(r) {
+			return r
+		}
+	}
+	nestedLegacyChannelRoute := createNestedLegacyRoute()
+	// Add new nested route as the first of the top-level routes.
+	config.AlertmanagerConfig.Route.Routes = append([]*apiModels.Route{nestedLegacyChannelRoute}, config.AlertmanagerConfig.Route.Routes...)
+	return nestedLegacyChannelRoute
+}
+
+// isNestedLegacyRoute checks whether a route is the nested legacy route for migrated channels.
+func isNestedLegacyRoute(r *apiModels.Route) bool {
+	return len(r.ObjectMatchers) == 1 && r.ObjectMatchers[0].Name == ngmodels.MigratedUseLegacyChannelsLabel
 }
 
 // createBaseConfig creates an alertmanager config with the root-level route, default receiver, and nested route
 // for migrated channels.
-func createBaseConfig() (*apiModels.PostableUserConfig, *apiModels.Route) {
-	defaultRoute, nestedRoute := createDefaultRoute()
+func createBaseConfig() *apiModels.PostableUserConfig {
+	defaultRoute := createDefaultRoute()
 	return &apiModels.PostableUserConfig{
 		AlertmanagerConfig: apiModels.PostableApiAlertingConfig{
 			Receivers: []*apiModels.PostableApiReceiver{
@@ -67,18 +148,18 @@ func createBaseConfig() (*apiModels.PostableUserConfig, *apiModels.Route) {
 				Route: defaultRoute,
 			},
 		},
-	}, nestedRoute
+	}
 }
 
 // createDefaultRoute creates a default root-level route and associated nested route that will contain all the migrated channels.
-func createDefaultRoute() (*apiModels.Route, *apiModels.Route) {
+func createDefaultRoute() *apiModels.Route {
 	nestedRoute := createNestedLegacyRoute()
 	return &apiModels.Route{
 		Receiver:       "autogen-contact-point-default",
 		Routes:         []*apiModels.Route{nestedRoute},
 		GroupByStr:     []string{ngmodels.FolderTitleLabel, model.AlertNameLabel}, // To keep parity with pre-migration notifications.
 		RepeatInterval: nil,
-	}, nestedRoute
+	}
 }
 
 // createNestedLegacyRoute creates a nested route that will contain all the migrated channels.

--- a/pkg/services/ngalert/migration/persist.go
+++ b/pkg/services/ngalert/migration/persist.go
@@ -94,11 +94,13 @@ func createDelta(
 // syncDelta persists the given delta to the state and database.
 func (sync *sync) syncDelta(ctx context.Context, delta StateDelta) (*migrationStore.OrgMigrationState, error) {
 	state := &migrationStore.OrgMigrationState{
-		OrgID:          sync.orgID,
-		CreatedFolders: make([]string, 0),
+		OrgID:              sync.orgID,
+		CreatedFolders:     make([]string, 0),
+		MigratedDashboards: make(map[int64]*migrationStore.DashboardUpgrade, len(delta.DashboardsToAdd)),
+		MigratedChannels:   make(map[int64]*migrationStore.ContactPair, len(delta.ChannelsToAdd)),
 	}
 
-	amConfig, err := sync.handleAlertmanager(ctx, delta)
+	amConfig, err := sync.handleAlertmanager(ctx, state, delta)
 	if err != nil {
 		return nil, err
 	}
@@ -112,7 +114,7 @@ func (sync *sync) syncDelta(ctx context.Context, delta StateDelta) (*migrationSt
 }
 
 // handleAlertmanager persists the given channel delta to the state and database.
-func (sync *sync) handleAlertmanager(ctx context.Context, delta StateDelta) (*migmodels.Alertmanager, error) {
+func (sync *sync) handleAlertmanager(ctx context.Context, state *migrationStore.OrgMigrationState, delta StateDelta) (*migmodels.Alertmanager, error) {
 	amConfig := migmodels.NewAlertmanager()
 
 	if len(delta.ChannelsToAdd) == 0 {
@@ -122,16 +124,19 @@ func (sync *sync) handleAlertmanager(ctx context.Context, delta StateDelta) (*mi
 	for _, pair := range delta.ChannelsToAdd {
 		amConfig.AddReceiver(pair.ContactPoint)
 		amConfig.AddRoute(pair.Route)
+		state.MigratedChannels[pair.Channel.ID] = newContactPair(pair)
 	}
+
+	config := migmodels.CleanAlertmanager(amConfig)
 
 	// Validate the alertmanager configuration produced, this gives a chance to catch bad configuration at migration time.
 	// Validation between legacy and unified alerting can be different (e.g. due to bug fixes) so this would fail the migration in that case.
-	if err := sync.validateAlertmanagerConfig(amConfig.Config); err != nil {
+	if err := sync.validateAlertmanagerConfig(config); err != nil {
 		return nil, fmt.Errorf("validate AlertmanagerConfig: %w", err)
 	}
 
-	sync.log.Info("Writing alertmanager config", "receivers", len(amConfig.Config.AlertmanagerConfig.Receivers), "routes", len(amConfig.Config.AlertmanagerConfig.Route.Routes))
-	if err := sync.migrationStore.SaveAlertmanagerConfiguration(ctx, sync.orgID, amConfig.Config); err != nil {
+	sync.log.Info("Writing alertmanager config", "receivers", len(config.AlertmanagerConfig.Receivers), "routes", len(config.AlertmanagerConfig.Route.Routes))
+	if err := sync.migrationStore.SaveAlertmanagerConfiguration(ctx, sync.orgID, config); err != nil {
 		return nil, fmt.Errorf("write AlertmanagerConfig: %w", err)
 	}
 
@@ -143,8 +148,13 @@ func (sync *sync) handleAddRules(ctx context.Context, state *migrationStore.OrgM
 	pairs := make([]*migmodels.AlertPair, 0)
 	createdFolderUIDs := make(map[string]struct{})
 	for _, duToAdd := range delta.DashboardsToAdd {
+		du := &migrationStore.DashboardUpgrade{
+			DashboardID:    duToAdd.ID,
+			MigratedAlerts: make(map[int64]*migrationStore.AlertPair, len(duToAdd.MigratedAlerts)),
+		}
 		pairsWithRules := make([]*migmodels.AlertPair, 0, len(duToAdd.MigratedAlerts))
 		for _, pair := range duToAdd.MigratedAlerts {
+			du.MigratedAlerts[pair.LegacyRule.PanelID] = newAlertPair(pair)
 			if pair.Rule != nil {
 				pairsWithRules = append(pairsWithRules, pair)
 			}
@@ -156,6 +166,8 @@ func (sync *sync) handleAddRules(ctx context.Context, state *migrationStore.OrgM
 			if err != nil {
 				return err
 			}
+			du.AlertFolderUID = migratedFolder.uid
+			du.Warning = migratedFolder.warning
 
 			// Keep track of folders created by the migration.
 			if _, exists := createdFolderUIDs[migratedFolder.uid]; migratedFolder.created && !exists {
@@ -168,6 +180,7 @@ func (sync *sync) handleAddRules(ctx context.Context, state *migrationStore.OrgM
 				pairs = append(pairs, pair)
 			}
 		}
+		state.MigratedDashboards[du.DashboardID] = du
 	}
 
 	if len(pairs) > 0 {
@@ -182,7 +195,7 @@ func (sync *sync) handleAddRules(ctx context.Context, state *migrationStore.OrgM
 		if err != nil {
 			return fmt.Errorf("deduplicate titles: %w", err)
 		}
-		rules, err := sync.attachContactPointLabels(ctx, pairs, amConfig)
+		rules, err := sync.attachContactPointLabels(ctx, state, pairs, amConfig)
 		if err != nil {
 			return fmt.Errorf("attach contact point labels: %w", err)
 		}
@@ -237,7 +250,7 @@ func (sync *sync) deduplicateTitles(ctx context.Context, pairs []*migmodels.Aler
 }
 
 // attachContactPointLabels attaches contact point labels to the given alert rules.
-func (sync *sync) attachContactPointLabels(ctx context.Context, pairs []*migmodels.AlertPair, amConfig *migmodels.Alertmanager) ([]models.AlertRule, error) {
+func (sync *sync) attachContactPointLabels(ctx context.Context, state *migrationStore.OrgMigrationState, pairs []*migmodels.AlertPair, amConfig *migmodels.Alertmanager) ([]models.AlertRule, error) {
 	rules := make([]models.AlertRule, 0, len(pairs))
 	for _, pair := range pairs {
 		alertChannels, err := sync.extractChannels(ctx, pair.LegacyRule)
@@ -245,10 +258,12 @@ func (sync *sync) attachContactPointLabels(ctx context.Context, pairs []*migmode
 			return nil, fmt.Errorf("extract channel IDs: %w", err)
 		}
 
+		statePair := state.MigratedDashboards[pair.LegacyRule.DashboardID].MigratedAlerts[pair.LegacyRule.PanelID]
+		statePair.ChannelIDs = make([]int64, 0, len(alertChannels))
 		for _, c := range alertChannels {
+			statePair.ChannelIDs = append(statePair.ChannelIDs, c.ID)
 			pair.Rule.Labels[contactLabel(c.Name)] = "true"
 		}
-
 		rules = append(rules, *pair.Rule)
 	}
 	return rules, nil
@@ -315,4 +330,33 @@ func (sync *sync) validateAlertmanagerConfig(config *apiModels.PostableUserConfi
 	}
 
 	return nil
+}
+
+func newContactPair(pair *migmodels.ContactPair) *migrationStore.ContactPair {
+	p := &migrationStore.ContactPair{
+		LegacyID: pair.Channel.ID,
+	}
+	if pair.Error != nil {
+		p.Error = pair.Error.Error()
+	}
+
+	if pair.ContactPoint != nil {
+		p.NewReceiverUID = pair.ContactPoint.UID
+	}
+	return p
+}
+
+func newAlertPair(a *migmodels.AlertPair) *migrationStore.AlertPair {
+	pair := &migrationStore.AlertPair{}
+	if a.Error != nil {
+		pair.Error = a.Error.Error()
+	}
+	if a.LegacyRule != nil {
+		pair.LegacyID = a.LegacyRule.ID
+		pair.PanelID = a.LegacyRule.PanelID
+	}
+	if a.Rule != nil {
+		pair.NewRuleUID = a.Rule.UID
+	}
+	return pair
 }

--- a/pkg/services/ngalert/migration/service_test.go
+++ b/pkg/services/ngalert/migration/service_test.go
@@ -2,13 +2,31 @@ package migration
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
+	"strings"
 	"testing"
 	"time"
 
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	"github.com/prometheus/alertmanager/config"
+	"github.com/prometheus/alertmanager/pkg/labels"
+	"github.com/prometheus/common/model"
 	"github.com/stretchr/testify/require"
 
+	"github.com/grafana/grafana/pkg/components/simplejson"
+	"github.com/grafana/grafana/pkg/infra/log/logtest"
+	"github.com/grafana/grafana/pkg/services/accesscontrol"
+	"github.com/grafana/grafana/pkg/services/dashboards/dashboardaccess"
+	"github.com/grafana/grafana/pkg/services/ngalert/api/tooling/definitions"
+	migmodels "github.com/grafana/grafana/pkg/services/ngalert/migration/models"
 	migrationStore "github.com/grafana/grafana/pkg/services/ngalert/migration/store"
+	"github.com/grafana/grafana/pkg/services/ngalert/store"
+	"github.com/grafana/grafana/pkg/services/org"
+	"github.com/grafana/grafana/pkg/services/sqlstore"
+	"github.com/grafana/grafana/pkg/util"
+
 	"xorm.io/xorm"
 
 	"github.com/grafana/grafana/pkg/infra/db"
@@ -370,4 +388,833 @@ func checkAlertRulesCount(t *testing.T, x *xorm.Engine, orgID int64, count int) 
 	cnt, err := x.Table("alert_rule").Where("org_id=?", orgID).Count()
 	require.NoError(t, err, "table alert_rule error")
 	require.Equal(t, int(cnt), count, "table alert_rule should have no rows")
+}
+
+type testcase struct {
+	name         string
+	orgToMigrate int64
+
+	// Common Inputs
+	folders        []*dashboards.Dashboard
+	dashboards     []*dashboards.Dashboard
+	dashboardPerms map[string][]accesscontrol.SetResourcePermissionCommand
+
+	initialLegacyState legacyState
+	initialUAState     *uaState
+
+	operations []testOp
+}
+type legacyState struct {
+	alerts   []*legacymodels.Alert
+	channels []*legacymodels.AlertNotification
+}
+type uaState struct {
+	alerts   []*models.AlertRule
+	amConfig *definitions.PostableUserConfig
+	migState *migrationStore.OrgMigrationState
+}
+
+type testOp struct {
+	description       string
+	newLegacyState    *legacyState
+	updateLegacyState *legacyState
+	operation         func(ctx context.Context, tt testcase, service *migrationService, x *xorm.Engine) error
+	expectedUAState   *uaState
+	expectedErrors    []string
+}
+
+func TestCommonServicePatterns(t *testing.T) {
+	sh := newServiceHelper(t)
+	f1 := sh.genFolder()
+	f2 := sh.genFolder()
+	generalAlertingFolder := sh.genFolder()
+	generalAlertingFolder.UID = "general-alerting"
+	generalAlertingFolder.Title = "General Alerting"
+	sh.folders[generalAlertingFolder.ID] = generalAlertingFolder
+	sh.foldersByUID[generalAlertingFolder.UID] = generalAlertingFolder
+
+	generalFolder := &dashboards.Dashboard{
+		ID:    0,
+		Title: "General",
+	}
+	sh.folders[generalFolder.ID] = generalFolder
+	sh.foldersByUID[generalFolder.UID] = generalFolder
+
+	d1 := sh.genDash(f1)
+	alerts1 := sh.genAlerts(d1, 10)
+	rules1, pairs1 := sh.genAlertPairs(f1, d1, alerts1)
+
+	d2 := sh.genDash(f1)
+	alerts2 := sh.genAlerts(d2, 10)
+	rules2, pairs2 := sh.genAlertPairs(f1, d2, alerts2)
+
+	d3 := sh.genDash(f2)
+	alerts3 := sh.genAlerts(d3, 10)
+	_, pairs3 := sh.genAlertPairs(f2, d3, alerts3)
+
+	channels1 := sh.genChannels(10)
+
+	modifiedAlerts := func(alerts []*legacymodels.Alert, muts ...func(alert *legacymodels.Alert)) []*legacymodels.Alert {
+		newAlerts := copyAlerts(alerts...)
+		for _, alert := range newAlerts {
+			for _, mut := range muts {
+				mut(alert)
+			}
+		}
+		return newAlerts
+	}
+
+	withName := func(name string) func(alert *legacymodels.Alert) {
+		return func(alert *legacymodels.Alert) {
+			alert.Name = name
+		}
+	}
+
+	withNotifiers := func(alert *legacymodels.Alert) {
+		alert.Settings.Set("notifications", []notificationKey{{ID: alert.ID}})
+	}
+
+	modifiedPairs := func(pairs []*migmodels.AlertPair, muts ...func(alert *migmodels.AlertPair)) []*migmodels.AlertPair {
+		newPairs := copyPairs(pairs...)
+		for _, pair := range newPairs {
+			for _, mut := range muts {
+				mut(pair)
+			}
+		}
+		return newPairs
+	}
+
+	withTitle := func(name string) func(pair *migmodels.AlertPair) {
+		return func(pair *migmodels.AlertPair) {
+			pair.Rule.Title = name
+			pair.LegacyRule.Name = name
+		}
+	}
+
+	withNotifierLabels := func(pair *migmodels.AlertPair) {
+		withNotifiers(pair.LegacyRule)
+		pair.Rule.Labels[contactLabel(fmt.Sprintf("notifiername%d", pair.LegacyRule.ID))] = "true"
+	}
+
+	modifiedRules := func(alerts []*models.AlertRule, muts ...func(alert *models.AlertRule)) []*models.AlertRule {
+		newAlerts := copyRules(alerts...)
+		for _, alert := range newAlerts {
+			for _, mut := range muts {
+				mut(alert)
+			}
+		}
+		return newAlerts
+	}
+
+	withFolder := func(f *dashboards.Dashboard) func(alert *models.AlertRule) {
+		return func(alert *models.AlertRule) {
+			alert.NamespaceUID = f.UID
+		}
+	}
+
+	modifiedState := func(state *uaState, muts ...func(state *uaState)) *uaState {
+		for _, mut := range muts {
+			mut(state)
+		}
+		return state
+	}
+
+	for _, tt := range []testcase{
+		{
+			name:         "Standard org migration",
+			orgToMigrate: 1,
+			folders:      []*dashboards.Dashboard{f1, f2},
+			dashboards:   []*dashboards.Dashboard{d1},
+
+			initialLegacyState: legacyState{
+				alerts:   alerts1,
+				channels: channels1,
+			},
+			operations: []testOp{
+				{
+					description:     "initial migration",
+					operation:       migrateAllOrgsOp,
+					expectedUAState: sh.uaState(t, channels1, pairs1),
+				},
+			},
+		},
+		{
+			name:         "Standard org migration with multiple dashboards",
+			orgToMigrate: 1,
+			folders:      []*dashboards.Dashboard{f1, f2},
+			dashboards:   []*dashboards.Dashboard{d1, d2, d3},
+
+			initialLegacyState: legacyState{
+				alerts: append(append(alerts1, alerts2...), alerts3...),
+			},
+			operations: []testOp{
+				{
+					description:     "initial migration",
+					operation:       migrateAllOrgsOp,
+					expectedUAState: sh.uaState(t, nil, pairs1, pairs2, pairs3),
+				},
+			},
+		},
+		{
+			name:         "alert titles should be deduplicated",
+			orgToMigrate: 1,
+			folders:      []*dashboards.Dashboard{f1},
+			dashboards:   []*dashboards.Dashboard{d1},
+
+			initialLegacyState: legacyState{
+				alerts: modifiedAlerts(alerts1, withName("duplicate name")),
+			},
+			operations: []testOp{
+				{
+					description: "initial migration",
+					operation:   migrateAllOrgsOp,
+					expectedUAState: modifiedState(sh.uaState(t, nil, modifiedPairs(pairs1, withTitle("duplicate name"))), func(state *uaState) {
+						state.alerts[0].Title = "duplicate name"
+						for i := 1; i < len(state.alerts); i++ { // First pair doesn't need to be deduplicated.
+							state.alerts[i].Title = fmt.Sprintf("duplicate name #%d", i+1)
+						}
+					}),
+				},
+			},
+		},
+		{
+			name:         "alert titles should be truncated",
+			orgToMigrate: 1,
+			folders:      []*dashboards.Dashboard{f1},
+			dashboards:   []*dashboards.Dashboard{d1},
+
+			initialLegacyState: legacyState{
+				alerts: modifiedAlerts(alerts1[0:1:1], withName(strings.Repeat("a", store.AlertDefinitionMaxTitleLength+1))),
+			},
+			operations: []testOp{
+				{
+					operation:       migrateAllOrgsOp,
+					expectedUAState: modifiedState(sh.uaState(t, nil, modifiedPairs(pairs1[0:1:1], withTitle(strings.Repeat("a", store.AlertDefinitionMaxTitleLength))))),
+				},
+			},
+		},
+		{
+			name:         "alert titles should be truncated and deduplicated",
+			orgToMigrate: 1,
+			folders:      []*dashboards.Dashboard{f1},
+			dashboards:   []*dashboards.Dashboard{d1},
+
+			initialLegacyState: legacyState{
+				alerts: modifiedAlerts(alerts1, withName(strings.Repeat("a", store.AlertDefinitionMaxTitleLength+1))),
+			},
+			operations: []testOp{
+				{
+					operation: migrateAllOrgsOp,
+					expectedUAState: func() *uaState {
+						pairs := modifiedPairs(pairs1, withTitle(strings.Repeat("a", store.AlertDefinitionMaxTitleLength)))
+						for i := 1; i < len(pairs); i++ { // First pair doesn't need to be deduplicated.
+							suffix := fmt.Sprintf(" #%d", i+1)
+							pairs[i].Rule.Title = fmt.Sprintf("%s%s", pairs[i].Rule.Title[:store.AlertDefinitionMaxTitleLength-len(suffix)], suffix)
+						}
+						state := sh.uaState(t, nil, pairs)
+						return state
+					}(),
+				},
+			},
+		},
+		{
+			name:         "alert dashboard has missing folder, should migrate to new general alerting folder",
+			orgToMigrate: 1,
+			folders:      []*dashboards.Dashboard{f1, generalAlertingFolder},
+			//nolint:staticcheck
+			dashboards: []*dashboards.Dashboard{func(d dashboards.Dashboard) *dashboards.Dashboard { d.FolderID = 99999; return &d }(*d1), d2},
+
+			initialLegacyState: legacyState{
+				alerts: append(alerts1, alerts2...),
+			},
+			operations: []testOp{
+				{
+					operation: migrateAllOrgsOp,
+					expectedUAState: &uaState{
+						alerts: append(modifiedRules(rules1, withFolder(generalAlertingFolder)), rules2...),
+						migState: &migrationStore.OrgMigrationState{
+							OrgID: 1,
+							MigratedDashboards: map[int64]*migrationStore.DashboardUpgrade{
+								d1.ID: sh.dashUpgrade(d1.ID, generalAlertingFolder.UID, pairs1, "dashboard alerts moved to general alerting folder during upgrade: original folder not found"),
+								d2.ID: sh.dashUpgrade(d2.ID, f1.UID, pairs2, ""),
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name:         "alert dashboard in general folder, should migrate to new general alerting folder",
+			orgToMigrate: 1,
+			folders:      []*dashboards.Dashboard{f1, generalAlertingFolder},
+			//nolint:staticcheck
+			dashboards: []*dashboards.Dashboard{func(d dashboards.Dashboard) *dashboards.Dashboard { d.FolderID = 0; return &d }(*d1), d2},
+
+			initialLegacyState: legacyState{
+				alerts: append(alerts1[0:1:1], alerts2[0]),
+			},
+			operations: []testOp{
+				{
+					operation: migrateAllOrgsOp,
+					expectedUAState: &uaState{
+						alerts: append(modifiedRules(rules1[0:1:1], withFolder(generalAlertingFolder)), rules2[0]),
+						migState: &migrationStore.OrgMigrationState{
+							OrgID: 1,
+							MigratedDashboards: map[int64]*migrationStore.DashboardUpgrade{
+								d1.ID: sh.dashUpgrade(d1.ID, generalAlertingFolder.UID, pairs1[0:1:1], "dashboard alerts moved to general alerting folder during upgrade: general folder not supported"),
+								d2.ID: sh.dashUpgrade(d2.ID, f1.UID, pairs2[0:1:1], ""),
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name:         "alert dashboard has custom permissions, should migrate to new folder",
+			orgToMigrate: 1,
+			folders: []*dashboards.Dashboard{
+				f1,
+				func() *dashboards.Dashboard {
+					// The folder name is deterministic, so we can create the expected folder beforehand. This is so we know the uid for expected states.
+					f := createFolder(t, 100, 1, "created-folder-id")
+					f.Title = "folder1 Alerts - 787427ef800a01a544d6bae21970b4d2"
+					return f
+				}(),
+			},
+			dashboards: []*dashboards.Dashboard{d1, d2},
+			dashboardPerms: map[string][]accesscontrol.SetResourcePermissionCommand{
+				d2.UID: {{BuiltinRole: string(org.RoleViewer), Permission: dashboardaccess.PERMISSION_ADMIN.String()}}, // This permission maps to the 787427ef800a01a544d6bae21970b4d2 hash above.
+			},
+			initialLegacyState: legacyState{
+				alerts: append(alerts1, alerts2...),
+			},
+			operations: []testOp{
+				{
+					operation: migrateAllOrgsOp,
+					expectedUAState: &uaState{
+						alerts: append(rules1, modifiedRules(rules2, withFolder(&dashboards.Dashboard{UID: "created-folder-id"}))...),
+						migState: &migrationStore.OrgMigrationState{
+							OrgID: 1,
+							MigratedDashboards: map[int64]*migrationStore.DashboardUpgrade{
+								d1.ID: sh.dashUpgrade(d1.ID, f1.UID, pairs1, ""),
+								d2.ID: sh.dashUpgrade(d2.ID, "created-folder-id", pairs2, "dashboard alerts moved to new folder during upgrade: folder permission changes were needed"),
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name:         "alert labels are correct",
+			orgToMigrate: 1,
+			folders:      []*dashboards.Dashboard{f1, f2},
+			dashboards:   []*dashboards.Dashboard{d1},
+
+			initialLegacyState: legacyState{
+				alerts:   modifiedAlerts(alerts1, withNotifiers),
+				channels: channels1,
+			},
+			operations: []testOp{
+				{
+					description:     "initial migration",
+					operation:       migrateAllOrgsOp,
+					expectedUAState: sh.uaState(t, channels1, modifiedPairs(pairs1, withNotifierLabels)),
+				},
+			},
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			tcRun(t, tt)
+		})
+	}
+}
+
+var migrateAllOrgsOp = func(ctx context.Context, tt testcase, service *migrationService, x *xorm.Engine) error {
+	err := service.migrateAllOrgs(ctx)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func tcRun(t *testing.T, tt testcase) {
+	sqlStore := db.InitTestDB(t)
+	x := sqlStore.GetEngine()
+	store := &store.DBstore{
+		SQLStore: sqlStore,
+		Logger:   &logtest.Fake{},
+		Cfg: setting.UnifiedAlertingSettings{
+			BaseInterval:                  10 * time.Second,
+			DefaultRuleEvaluationInterval: time.Minute,
+		},
+	}
+	service := NewTestMigrationService(t, sqlStore, &setting.Cfg{})
+	defer teardown(t, x, service)
+	setupLegacyAlertsTables(t, x, tt.initialLegacyState.channels, tt.initialLegacyState.alerts, tt.folders, tt.dashboards)
+	if tt.initialUAState == nil {
+		tt.initialUAState = &uaState{}
+	}
+	setupUATables(t, store, tt.orgToMigrate, tt.initialUAState.alerts, tt.initialUAState.amConfig)
+	if tt.initialUAState.migState != nil {
+		require.NoError(t, service.migrationStore.SetOrgMigrationState(context.Background(), tt.orgToMigrate, tt.initialUAState.migState))
+	}
+
+	if tt.dashboardPerms != nil {
+		for uid, perms := range tt.dashboardPerms {
+			_, err := service.migrationStore.SetDashboardPermissions(context.Background(), 1, uid, perms...)
+			require.NoError(t, err)
+		}
+	}
+
+	ctx := context.Background()
+
+	for _, op := range tt.operations {
+		if op.description != "" {
+			t.Logf("Running operation: %s", op.description)
+		}
+		if op.newLegacyState != nil {
+			err := sqlStore.WithDbSession(ctx, func(sess *sqlstore.DBSession) error {
+				if len(op.newLegacyState.channels) > 0 {
+					_, err := sess.Insert(op.newLegacyState.channels)
+					require.NoError(t, err)
+				}
+				if len(op.newLegacyState.alerts) > 0 {
+					_, err := sess.Insert(op.newLegacyState.alerts)
+					require.NoError(t, err)
+				}
+				return nil
+			})
+			require.NoError(t, err)
+		}
+		if op.updateLegacyState != nil {
+			err := sqlStore.WithDbSession(ctx, func(sess *sqlstore.DBSession) error {
+				for _, c := range op.updateLegacyState.channels {
+					_, err := sess.ID(c.ID).Update(c)
+					require.NoError(t, err)
+				}
+				for _, a := range op.updateLegacyState.alerts {
+					_, err := sess.ID(a.ID).Update(a)
+					require.NoError(t, err)
+				}
+				return nil
+			})
+			require.NoError(t, err)
+		}
+
+		if op.operation != nil {
+			err := op.operation(ctx, tt, service, x)
+			if len(op.expectedErrors) > 0 {
+				for _, expErr := range op.expectedErrors {
+					require.ErrorContains(t, err, expErr)
+				}
+				return
+			}
+			require.NoError(t, err)
+		}
+
+		if op.expectedUAState != nil {
+			compareRules(t, x, tt.orgToMigrate, op.expectedUAState.alerts)
+			compareAmConfig(t, x, tt.orgToMigrate, op.expectedUAState.amConfig)
+			compareState(t, x, service, tt.orgToMigrate, op.expectedUAState.migState)
+		}
+	}
+}
+
+func compareRules(t *testing.T, x *xorm.Engine, orgId int64, expectedRules []*models.AlertRule) {
+	if expectedRules == nil {
+		return
+	}
+	rules := make([]*models.AlertRule, 0)
+	err := x.Table("alert_rule").Where("org_id = ?", orgId).Find(&rules)
+	require.NoError(t, err)
+
+	cOpt := []cmp.Option{
+		cmpopts.SortSlices(func(a, b models.AlertRule) bool {
+			return a.Title < b.Title
+		}),
+		cmpopts.IgnoreUnexported(models.AlertRule{}, models.AlertQuery{}),
+		cmpopts.IgnoreFields(models.AlertRule{}, "Updated", "UID", "ID", "Version"),
+		cmpopts.IgnoreMapEntries(func(k string, v string) bool { return k == "rule_uid" }),
+	}
+	if !cmp.Equal(expectedRules, rules, cOpt...) {
+		t.Errorf("Unexpected Rule: %v", cmp.Diff(expectedRules, rules, cOpt...))
+	}
+}
+
+func compareAmConfig(t *testing.T, x *xorm.Engine, orgId int64, expectedConfig *definitions.PostableUserConfig) {
+	if expectedConfig == nil {
+		return
+	}
+	amConfig := getAlertmanagerConfig(t, x, orgId)
+
+	// Order of nested GrafanaManagedReceivers is not guaranteed.
+	cOpt := []cmp.Option{
+		cmpopts.IgnoreUnexported(definitions.PostableApiReceiver{}),
+		cmpopts.IgnoreFields(definitions.PostableGrafanaReceiver{}, "UID", "SecureSettings"),
+		cmpopts.SortSlices(func(a, b *definitions.PostableGrafanaReceiver) bool { return a.Name < b.Name }),
+		cmpopts.SortSlices(func(a, b *definitions.PostableApiReceiver) bool { return a.Name < b.Name }),
+	}
+	if !cmp.Equal(expectedConfig.AlertmanagerConfig.Receivers, amConfig.AlertmanagerConfig.Receivers, cOpt...) {
+		t.Errorf("Unexpected Receivers: %v", cmp.Diff(expectedConfig.AlertmanagerConfig.Receivers, amConfig.AlertmanagerConfig.Receivers, cOpt...))
+	}
+
+	// Order of routes is not guaranteed.
+	cOpt = []cmp.Option{
+		cmpopts.SortSlices(func(a, b *definitions.Route) bool {
+			if a.Receiver != b.Receiver {
+				return a.Receiver < b.Receiver
+			}
+			return a.ObjectMatchers[0].Value < b.ObjectMatchers[0].Value
+		}),
+		cmpopts.IgnoreUnexported(definitions.Route{}, labels.Matcher{}),
+		cmpopts.IgnoreFields(definitions.Route{}, "GroupBy", "GroupByAll"),
+	}
+	if !cmp.Equal(expectedConfig.AlertmanagerConfig.Route, amConfig.AlertmanagerConfig.Route, cOpt...) {
+		t.Errorf("Unexpected Route: %v", cmp.Diff(expectedConfig.AlertmanagerConfig.Route, amConfig.AlertmanagerConfig.Route, cOpt...))
+	}
+}
+
+func compareState(t *testing.T, x *xorm.Engine, service *migrationService, orgId int64, expectedState *migrationStore.OrgMigrationState) {
+	if expectedState == nil {
+		return
+	}
+
+	// Assign real UIDS to expected state for comparison.
+	type ruleUid struct {
+		DashboardID int64  `xorm:"dashboard_id"`
+		PanelID     int64  `xorm:"panel_id"`
+		UID         string `xorm:"uid"`
+	}
+	ruleUids := make([]ruleUid, 0)
+	err := x.SQL("SELECT d.id as dashboard_id, ar.panel_id, ar.uid FROM alert_rule ar INNER JOIN dashboard d ON d.uid = ar.dashboard_uid WHERE ar.org_id = ?", orgId).Find(&ruleUids)
+	require.NoError(t, err)
+	uidMap := make(map[string]string)
+	for _, r := range ruleUids {
+		if du, ok := expectedState.MigratedDashboards[r.DashboardID]; ok {
+			if _, ok := du.MigratedAlerts[r.PanelID]; ok {
+				uidMap[du.MigratedAlerts[r.PanelID].NewRuleUID] = r.UID
+				du.MigratedAlerts[r.PanelID].NewRuleUID = r.UID
+			}
+		}
+	}
+
+	state, err := service.migrationStore.GetOrgMigrationState(context.Background(), orgId)
+	require.NoError(t, err)
+
+	cOpt := []cmp.Option{
+		cmpopts.SortSlices(func(a, b string) bool { return a < b }),
+		cmpopts.EquateEmpty(),
+	}
+	if !cmp.Equal(expectedState, state, cOpt...) {
+		t.Errorf("Unexpected OrgMigrationState: %v", cmp.Diff(expectedState, state, cOpt...))
+	}
+}
+
+// setupUATables inserts data into the UA tables.
+func setupUATables(t *testing.T, store *store.DBstore, orgID int64, rules []*models.AlertRule, amConfig *definitions.PostableUserConfig) {
+	t.Helper()
+	ctx := context.Background()
+
+	rs := make([]models.AlertRule, 0, len(rules))
+	for _, r := range rules {
+		rs = append(rs, *r)
+	}
+
+	if len(rs) > 0 {
+		_, err := store.InsertAlertRules(ctx, rs)
+		require.NoError(t, err)
+	}
+
+	if amConfig != nil {
+		rawAmConfig, err := json.Marshal(amConfig)
+		require.NoError(t, err)
+		cmd := models.SaveAlertmanagerConfigurationCmd{
+			AlertmanagerConfiguration: string(rawAmConfig),
+			ConfigurationVersion:      fmt.Sprintf("v%d", models.AlertConfigurationVersion),
+			Default:                   false,
+			OrgID:                     orgID,
+			LastApplied:               0,
+		}
+		err = store.SaveAlertmanagerConfiguration(ctx, &cmd)
+		require.NoError(t, err)
+	}
+}
+
+func createPostableUserConfig(t *testing.T, channels ...*legacymodels.AlertNotification) *definitions.PostableUserConfig {
+	t.Helper()
+	am := &definitions.PostableUserConfig{
+		AlertmanagerConfig: definitions.PostableApiAlertingConfig{
+			Config: definitions.Config{Route: &definitions.Route{
+				Receiver:   "autogen-contact-point-default",
+				GroupByStr: []string{models.FolderTitleLabel, model.AlertNameLabel},
+				Routes: []*definitions.Route{
+					{
+						ObjectMatchers: definitions.ObjectMatchers{{Type: labels.MatchEqual, Name: models.MigratedUseLegacyChannelsLabel, Value: "true"}},
+						Continue:       true,
+						Routes:         []*definitions.Route{},
+					},
+				},
+			}},
+			Receivers: []*definitions.PostableApiReceiver{
+				{Receiver: config.Receiver{Name: "autogen-contact-point-default"}, PostableGrafanaReceivers: definitions.PostableGrafanaReceivers{}},
+			},
+		},
+	}
+	for _, c := range channels {
+		settings, err := c.Settings.MarshalJSON()
+		require.NoError(t, err)
+		am.AlertmanagerConfig.Receivers = append(am.AlertmanagerConfig.Receivers, &definitions.PostableApiReceiver{Receiver: config.Receiver{Name: c.Name}, PostableGrafanaReceivers: definitions.PostableGrafanaReceivers{GrafanaManagedReceivers: []*definitions.PostableGrafanaReceiver{{UID: c.UID, Name: c.Name, Type: c.Type, Settings: settings}}}})
+		am.AlertmanagerConfig.Route.Routes[0].Routes = append(am.AlertmanagerConfig.Route.Routes[0].Routes, &definitions.Route{Receiver: c.Name, ObjectMatchers: definitions.ObjectMatchers{{Type: labels.MatchEqual, Name: contactLabel(c.Name), Value: "true"}}, Routes: nil, Continue: true, RepeatInterval: durationPointer(DisabledRepeatInterval)})
+	}
+	return am
+}
+
+type serviceHelper struct {
+	t           *testing.T
+	dashIncr    int64
+	alertIncr   int64
+	ruleIncr    int64
+	channelIncr int64
+
+	dashes       map[int64]*dashboards.Dashboard
+	folders      map[int64]*dashboards.Dashboard
+	foldersByUID map[string]*dashboards.Dashboard
+}
+
+func newServiceHelper(t *testing.T) serviceHelper {
+	return serviceHelper{
+		t:           t,
+		dashIncr:    int64(1),
+		alertIncr:   int64(1),
+		ruleIncr:    int64(1),
+		channelIncr: int64(1),
+
+		dashes:       make(map[int64]*dashboards.Dashboard),
+		folders:      make(map[int64]*dashboards.Dashboard),
+		foldersByUID: make(map[string]*dashboards.Dashboard),
+	}
+}
+
+func (h *serviceHelper) genAlerts(d *dashboards.Dashboard, cnt int) []*legacymodels.Alert {
+	d.Title = fmt.Sprintf("dash title%d", h.dashIncr)
+	alerts := make([]*legacymodels.Alert, 0, cnt)
+
+	for i := 0; i < cnt; i++ {
+		a := createAlertWithCond(h.t, 1, int(d.ID), int(h.alertIncr), fmt.Sprintf("alert%d", h.alertIncr), nil,
+			[]dashAlertCondition{createCondition("A", "max", "gt", 42, 1, "5m", "now")})
+		a.ID = h.alertIncr
+
+		alerts = append(alerts, a)
+		h.alertIncr++
+	}
+	h.dashIncr++
+	return alerts
+}
+
+func (h *serviceHelper) genFolder() *dashboards.Dashboard {
+	f := createFolder(h.t, h.dashIncr, 1, fmt.Sprintf("folder%d", h.dashIncr))
+	h.dashIncr++
+	h.folders[f.ID] = f
+	h.foldersByUID[f.UID] = f
+	return f
+}
+
+func (h *serviceHelper) genDash(folder *dashboards.Dashboard) *dashboards.Dashboard {
+	d := createDashboard(h.t, h.dashIncr, 1, fmt.Sprintf("dash%d", h.dashIncr), folder.ID, nil)
+	d.Title = fmt.Sprintf("dash title%d", h.dashIncr)
+
+	h.dashIncr++
+	h.dashes[d.ID] = d
+	return d
+}
+
+func (h *serviceHelper) genChannels(cnt int) []*legacymodels.AlertNotification {
+	channels := make([]*legacymodels.AlertNotification, 0, cnt)
+	for i := 0; i < cnt; i++ {
+		c := createAlertNotification(h.t, int64(1), fmt.Sprintf("notifier%d", h.channelIncr), "email", emailSettings, false)
+		c.Name = fmt.Sprintf("notifiername%d", h.channelIncr)
+		c.ID = h.channelIncr
+		channels = append(channels, c)
+		h.channelIncr++
+	}
+	return channels
+}
+
+func (h *serviceHelper) genAlertPairs(f *dashboards.Dashboard, d *dashboards.Dashboard, alerts []*legacymodels.Alert) ([]*models.AlertRule, []*migmodels.AlertPair) {
+	pairs := make([]*migmodels.AlertPair, 0, len(alerts))
+	rules := make([]*models.AlertRule, 0, len(alerts))
+	for _, a := range alerts {
+		uid := util.GenerateShortUID()
+		r := &models.AlertRule{
+			UID:       uid,
+			ID:        h.ruleIncr,
+			OrgID:     1,
+			Title:     a.Name,
+			Condition: "B",
+			Data: []models.AlertQuery{createAlertQuery("A", "ds1-1", "5m", "now"), createClassicConditionQuery("B", []classicCondition{
+				cond("A", "max", "gt", 42),
+			})},
+			IntervalSeconds: 60,
+			Version:         1,
+			NamespaceUID:    f.UID,
+			DashboardUID:    pointer(d.UID),
+			PanelID:         pointer(a.PanelID),
+			RuleGroup:       fmt.Sprintf("%s - 1m", d.Title),
+			RuleGroupIndex:  1,
+			NoDataState:     models.NoData,
+			ExecErrState:    models.AlertingErrState,
+			For:             60 * time.Second,
+			Annotations: map[string]string{
+				models.MigratedAlertIdAnnotation: fmt.Sprintf("%d", a.ID),
+				models.MigratedMessageAnnotation: "message",
+				models.DashboardUIDAnnotation:    d.UID,
+				models.PanelIDAnnotation:         fmt.Sprintf("%d", a.PanelID),
+			},
+			Labels: map[string]string{
+				models.MigratedUseLegacyChannelsLabel: "true",
+				"rule_uid":                            uid,
+			},
+			IsPaused: false,
+		}
+		for _, v := range extractChannelIds(h.t, a) {
+			id := v.ID
+			if id != 0 {
+				// Relies on the naming pattern.
+				r.Labels[contactLabel(fmt.Sprintf("notifiername%d", id))] = "true"
+			}
+		}
+		rules = append(rules, r)
+		pairs = append(pairs, &migmodels.AlertPair{
+			LegacyRule: a,
+			Rule:       r,
+		})
+		h.ruleIncr++
+	}
+	return rules, pairs
+}
+
+func (h *serviceHelper) dashUpgrade(dashboardID int64, alertFolderUID string, migPairs []*migmodels.AlertPair, warning string) *migrationStore.DashboardUpgrade {
+	return &migrationStore.DashboardUpgrade{
+		DashboardID:    dashboardID,
+		AlertFolderUID: alertFolderUID,
+		MigratedAlerts: func() map[int64]*migrationStore.AlertPair {
+			pairs := make(map[int64]*migrationStore.AlertPair, len(migPairs))
+			for _, p := range migPairs {
+				channelsIds := make([]int64, 0)
+				for _, v := range extractChannelIds(h.t, p.LegacyRule) {
+					channelsIds = append(channelsIds, v.ID)
+				}
+				pair := migrationStore.AlertPair{
+					LegacyID:   p.LegacyRule.ID,
+					PanelID:    p.LegacyRule.PanelID,
+					NewRuleUID: p.Rule.UID,
+					ChannelIDs: channelsIds,
+				}
+				if p.Error != nil {
+					pair.Error = p.Error.Error()
+				}
+				pairs[p.LegacyRule.PanelID] = &pair
+			}
+			return pairs
+		}(),
+		Warning: warning,
+	}
+}
+
+func (h *serviceHelper) contactPairs(c ...*legacymodels.AlertNotification) map[int64]*migrationStore.ContactPair {
+	pairs := make(map[int64]*migrationStore.ContactPair, len(c))
+	for _, ch := range c {
+		pairs[ch.ID] = &migrationStore.ContactPair{
+			LegacyID:       ch.ID,
+			NewReceiverUID: ch.UID,
+			Error:          "",
+		}
+	}
+	return pairs
+}
+
+func (h *serviceHelper) uaState(t *testing.T, channels []*legacymodels.AlertNotification, dashPairs ...[]*migmodels.AlertPair) *uaState {
+	s := &uaState{
+		migState: &migrationStore.OrgMigrationState{
+			OrgID: 1,
+		},
+	}
+
+	if len(channels) > 0 {
+		s.amConfig = createPostableUserConfig(t, channels...)
+		s.migState.MigratedChannels = h.contactPairs(channels...)
+	}
+
+	if len(dashPairs) > 0 {
+		s.migState.MigratedDashboards = map[int64]*migrationStore.DashboardUpgrade{}
+		for _, pairs := range dashPairs {
+			for _, p := range pairs {
+				s.alerts = append(s.alerts, p.Rule)
+			}
+			s.migState.MigratedDashboards[pairs[0].LegacyRule.DashboardID] = h.dashUpgrade(pairs[0].LegacyRule.DashboardID, pairs[0].Rule.NamespaceUID, pairs, "")
+		}
+	}
+
+	return s
+}
+
+func copyMap(m map[string]string) map[string]string {
+	c := make(map[string]string, len(m))
+	for k, v := range m {
+		c[k] = v
+	}
+	return c
+}
+
+func copyAlerts(alerts ...*legacymodels.Alert) []*legacymodels.Alert {
+	copies := make([]*legacymodels.Alert, len(alerts))
+	for i, a := range alerts {
+		c := *a
+		settingsMap := c.Settings.MustMap()
+		c.Settings = simplejson.New()
+		for k, v := range settingsMap {
+			c.Settings.Set(k, v)
+		}
+
+		copies[i] = &c
+	}
+	return copies
+}
+
+func copyRules(rules ...*models.AlertRule) []*models.AlertRule {
+	copies := make([]*models.AlertRule, len(rules))
+	for i, a := range rules {
+		c := *a
+		c.Labels = copyMap(c.Labels)
+		c.Annotations = copyMap(c.Annotations)
+		copies[i] = &c
+	}
+	return copies
+}
+
+func copyPairs(pairs ...*migmodels.AlertPair) []*migmodels.AlertPair {
+	newPairs := make([]*migmodels.AlertPair, len(pairs))
+	for i, pair := range pairs {
+		clr := copyAlerts(pair.LegacyRule)[0]
+		cr := copyRules(pair.Rule)[0]
+		newPairs[i] = &migmodels.AlertPair{
+			LegacyRule: clr,
+			Rule:       cr,
+			Error:      pair.Error,
+		}
+	}
+	return newPairs
+}
+
+func extractChannelIds(t *testing.T, alert *legacymodels.Alert) []notificationKey {
+	b, err := alert.Settings.Get("notifications").ToDB()
+	if err == nil && b != nil {
+		require.NoError(t, err)
+		var nots []notificationKey
+		err = json.Unmarshal(b, &nots)
+		require.NoError(t, err)
+
+		return nots
+	}
+	return nil
 }

--- a/pkg/services/ngalert/migration/store/database.go
+++ b/pkg/services/ngalert/migration/store/database.go
@@ -219,13 +219,25 @@ func (ms *migrationStore) GetOrgMigrationState(ctx context.Context, orgID int64)
 	}
 
 	if !exists {
-		return &OrgMigrationState{OrgID: orgID}, nil
+		return &OrgMigrationState{
+			OrgID:              orgID,
+			MigratedDashboards: make(map[int64]*DashboardUpgrade),
+			MigratedChannels:   make(map[int64]*ContactPair),
+		}, nil
 	}
 
 	var state OrgMigrationState
 	err = json.Unmarshal([]byte(content), &state)
 	if err != nil {
 		return nil, err
+	}
+
+	if state.MigratedChannels == nil {
+		state.MigratedChannels = make(map[int64]*ContactPair)
+	}
+
+	if state.MigratedDashboards == nil {
+		state.MigratedDashboards = make(map[int64]*DashboardUpgrade)
 	}
 
 	return &state, nil

--- a/pkg/services/ngalert/migration/store/state.go
+++ b/pkg/services/ngalert/migration/store/state.go
@@ -1,7 +1,30 @@
 package store
 
-// OrgMigrationState contains basic information about the state of an org migration.
+// OrgMigrationState contains information about the state of an org migration.
 type OrgMigrationState struct {
-	OrgID          int64    `json:"orgId"`
-	CreatedFolders []string `json:"createdFolders"`
+	OrgID              int64                       `json:"orgId"`
+	MigratedDashboards map[int64]*DashboardUpgrade `json:"migratedDashboards"`
+	MigratedChannels   map[int64]*ContactPair      `json:"migratedChannels"`
+	CreatedFolders     []string                    `json:"createdFolders"`
+}
+
+type DashboardUpgrade struct {
+	DashboardID    int64                `json:"dashboardId"`
+	AlertFolderUID string               `json:"alertFolderUid"`
+	MigratedAlerts map[int64]*AlertPair `json:"migratedAlerts"`
+	Warning        string               `json:"warning,omitempty"`
+}
+
+type AlertPair struct {
+	LegacyID   int64   `json:"legacyId"`
+	PanelID    int64   `json:"panelId"`
+	NewRuleUID string  `json:"newRuleUid"`
+	ChannelIDs []int64 `json:"channelIds"`
+	Error      string  `json:"error,omitempty"`
+}
+
+type ContactPair struct {
+	LegacyID       int64  `json:"legacyId"`
+	NewReceiverUID string `json:"newReceiverUid"`
+	Error          string `json:"error,omitempty"`
 }


### PR DESCRIPTION

**What is this feature?**

This is a incremental step toward the migration dry-run. This feature will save a more detailed version of the migration state to the kvstore.

**Why do we need this feature?**

The dry-run will allow partial migrations in a preview environment. To facilitate this we need to store the current state of which legacy resources have been upgraded into which UA resources.

Example state:

```json
{
  "orgId": 1,
  "migratedDashboards": {
    "-42": {
      "dashboardId": -42,
      "alertFolderUid": "",
      "migratedAlerts": {
        "1": {
          "legacyId": 34,
          "panelId": 1,
          "newRuleUid": "",
          "channelIds": null,
          "error": "Dashboard not found"
        },
        "2": {
          "legacyId": 36,
          "panelId": 2,
          "newRuleUid": "",
          "channelIds": null,
          "error": "Dashboard not found"
        },
      },
    },
    "239": {
      "dashboardId": 239,
      "alertFolderUid": "ed47fde7-c556-4082-b994-826057619423",
      "migratedAlerts": {
        "1": {
          "legacyId": 635,
          "panelId": 1,
          "newRuleUid": "e80c27fe-f569-4b53-9038-efe936ec2092",
          "channelIds": []
        }
      },
      "warning": "dashboard alerts moved to general alerting folder during upgrade: original folder not found"
    },
    "246": {
      "dashboardId": 246,
      "alertFolderUid": "b4788e5c-3686-4b97-b0e6-5178ef8d3d54",
      "migratedAlerts": {
        "1": {
          "legacyId": 35,
          "panelId": 1,
          "newRuleUid": "fa0279d4-1ed9-4619-82ec-eadd4d6c68d7",
          "channelIds": []
        },
        "2": {
          "legacyId": 633,
          "panelId": 2,
          "newRuleUid": "eea688da-cd5c-4596-bfee-27bcc81095c0",
          "channelIds": []
        },
      },
      "warning": "dashboard alerts moved to new folder during upgrade: folder permission changes were needed"
    },
    "453": {
      "dashboardId": 453,
      "alertFolderUid": "a1bf10fa-f06e-4e07-b593-e480d2b27bbe",
      "migratedAlerts": {
        "1": {
          "legacyId": 641,
          "panelId": 1,
          "newRuleUid": "f7730cf2-3ea3-49ee-9994-5293d4b460db",
          "channelIds": [34]
        },
        "2": {
          "legacyId": 642,
          "panelId": 2,
          "newRuleUid": "e553ca1d-d654-4355-befb-83c7880ef292",
          "channelIds": [35]
        },
        "3": {
          "legacyId": 643,
          "panelId": 3,
          "newRuleUid": "b894e93c-937f-4e81-9bdd-f63f8e6a0267",
          "channelIds": [33]
        },
        "4": {
          "legacyId": 644,
          "panelId": 4,
          "newRuleUid": "d8424086-aea0-4aaf-8d3c-0b2ac4b946b5",
          "channelIds": [34]
        },
        "5": {
          "legacyId": 645,
          "panelId": 5,
          "newRuleUid": "f3544ada-859d-46ed-b0d8-1608ef9a70b6",
          "channelIds": [35]
        },
      },
    },
  },
  "migratedChannels": {
    "24": {
      "legacyId": 24,
      "newReceiverUid": "pagerduty uid with spaces"
    },
    "29": {
      "legacyId": 29,
      "newReceiverUid": "e808bb2b-42ad-4ff1-b63e-844a9ccad241"
    },
    "33": {
      "legacyId": 33,
      "newReceiverUid": "slack1"
    },
    "34": {
      "legacyId": 34,
      "newReceiverUid": "slack2"
    },
    "35": {
      "legacyId": 35,
      "newReceiverUid": "email1"
    },
  },
  "createdFolders": ["b4788e5c-3686-4b97-b0e6-5178ef8d3d54","a45157ec-2f55-454e-bb58-0e37e3b6641e"]
}
```