### PR TITLE
fix(swagger): Add new access control endpoints

### DIFF
--- a/pkg/services/accesscontrol/resourcepermissions/api.go
+++ b/pkg/services/accesscontrol/resourcepermissions/api.go
@@ -63,6 +63,13 @@ type Assignments struct {
 	BuiltInRoles    bool `json:"builtInRoles"`
 }
 
+// swagger:parameters getResourceDescription
+type GetResourceDescriptionParams struct {
+	// in:path
+	// required:true
+	Resource string `json:"resource"`
+}
+
 // swagger:response resourcePermissionsDescription
 type DescriptionResponse struct {
 	// in:body
@@ -75,7 +82,7 @@ type Description struct {
 	Permissions []string    `json:"permissions"`
 }
 
-// swagger:route POST /access-control/:resource/description enterprise,access_control getResourceDescription
+// swagger:route POST /access-control/{resource}/description access_control getResourceDescription
 //
 // Get a description of a resource's access control properties.
 //
@@ -107,10 +114,21 @@ type resourcePermissionDTO struct {
 	Permission       string   `json:"permission"`
 }
 
+// swagger:parameters getResourcePermissions
+type GetResourcePermissionsParams struct {
+	// in:path
+	// required:true
+	Resource string `json:"resource"`
+
+	// in:path
+	// required:true
+	ResourceID string `json:"resourceID"`
+}
+
 // swagger:response getResourcePermissionsResponse
 type getResourcePermissionsResponse []resourcePermissionDTO
 
-// swagger:route POST /access-control/:resource/:resourceID enterprise,access_control getResourcePermissions
+// swagger:route POST /access-control/{resource}/{resourceID} access_control getResourcePermissions
 //
 // Get permissions for a resource.
 //
@@ -172,16 +190,35 @@ type setPermissionsCommand struct {
 	Permissions []accesscontrol.SetResourcePermissionCommand `json:"permissions"`
 }
 
-// swagger:route POST /access-control/:resource/:resourceID/users/:userID enterprise,access_control setResourcePermissionsForUser
+// swagger:parameters setResourcePermissionsForUser
+type SetResourcePermissionsForUserParams struct {
+	// in:path
+	// required:true
+	Resource string `json:"resource"`
+
+	// in:path
+	// required:true
+	ResourceID string `json:"resourceID"`
+
+	// in:path
+	// required:true
+	UserID int64 `json:"userID"`
+
+	// in:body
+	// required:true
+	Body setPermissionCommand
+}
+
+// swagger:route POST /access-control/{resource}/{resourceID}/users/{userID} access_control setResourcePermissionsForUser
 //
 // Set resource permissions for a user.
 //
 // Assigns permissions for a resource by a given type (`:resource`) and `:resourceID` to a user or a service account.
 // Allowed resources are `datasources`, `teams`, `dashboards`, `folders`, and `serviceaccounts`.
-// Refer to the `/access-control/:resource/description` endpoint for allowed Permissions.
+// Refer to the `/access-control/{resource}/description` endpoint for allowed Permissions.
 //
 // Responses:
-// 200: okRespoonse
+// 200: okResponse
 // 400: badRequestError
 // 403: forbiddenError
 // 500: internalServerError
@@ -205,16 +242,35 @@ func (a *api) setUserPermission(c *contextmodel.ReqContext) response.Response {
 	return permissionSetResponse(cmd)
 }
 
-// swagger:route POST /access-control/:resource/:resourceID/teams/:teamID enterprise,access_control setResourcePermissionsForTeam
+// swagger:parameters setResourcePermissionsForTeam
+type SetResourcePermissionsForTeamParams struct {
+	// in:path
+	// required:true
+	Resource string `json:"resource"`
+
+	// in:path
+	// required:true
+	ResourceID string `json:"resourceID"`
+
+	// in:path
+	// required:true
+	TeamID int64 `json:"teamID"`
+
+	// in:body
+	// required:true
+	Body setPermissionCommand
+}
+
+// swagger:route POST /access-control/{resource}/{resourceID}/teams/{teamID} access_control setResourcePermissionsForTeam
 //
 // Set resource permissions for a team.
 //
 // Assigns permissions for a resource by a given type (`:resource`) and `:resourceID` to a team.
 // Allowed resources are `datasources`, `teams`, `dashboards`, `folders`, and `serviceaccounts`.
-// Refer to the `/access-control/:resource/description` endpoint for allowed Permissions.
+// Refer to the `/access-control/{resource}/description` endpoint for allowed Permissions.
 //
 // Responses:
-// 200: okRespoonse
+// 200: okResponse
 // 400: badRequestError
 // 403: forbiddenError
 // 500: internalServerError
@@ -238,16 +294,35 @@ func (a *api) setTeamPermission(c *contextmodel.ReqContext) response.Response {
 	return permissionSetResponse(cmd)
 }
 
-// swagger:route POST /access-control/:resource/:resourceID/builtInRoles/:builtInRole enterprise,access_control setResourcePermissionsForBuiltInRole
+// swagger:parameters setResourcePermissionsForBuiltInRole
+type SetResourcePermissionsForBuiltInRoleParams struct {
+	// in:path
+	// required:true
+	Resource string `json:"resource"`
+
+	// in:path
+	// required:true
+	ResourceID string `json:"resourceID"`
+
+	// in:path
+	// required:true
+	BuiltInRole string `json:"builtInRole"`
+
+	// in:body
+	// required:true
+	Body setPermissionCommand
+}
+
+// swagger:route POST /access-control/{resource}/{resourceID}/builtInRoles/{builtInRole} access_control setResourcePermissionsForBuiltInRole
 //
 // Set resource permissions for a built-in role.
 //
 // Assigns permissions for a resource by a given type (`:resource`) and `:resourceID` to a built-in role.
 // Allowed resources are `datasources`, `teams`, `dashboards`, `folders`, and `serviceaccounts`.
-// Refer to the `/access-control/:resource/description` endpoint for allowed Permissions.
+// Refer to the `/access-control/{resource}/description` endpoint for allowed Permissions.
 //
 // Responses:
-// 200: okRespoonse
+// 200: okResponse
 // 400: badRequestError
 // 403: forbiddenError
 // 500: internalServerError
@@ -268,16 +343,31 @@ func (a *api) setBuiltinRolePermission(c *contextmodel.ReqContext) response.Resp
 	return permissionSetResponse(cmd)
 }
 
-// swagger:route POST /access-control/:resource/:resourceID enterprise,access_control setResourcePermissions
+// swagger:parameters setResourcePermissions
+type SetResourcePermissionsParams struct {
+	// in:path
+	// required:true
+	Resource string `json:"resource"`
+
+	// in:path
+	// required:true
+	ResourceID string `json:"resourceID"`
+
+	// in:body
+	// required:true
+	Body setPermissionsCommand
+}
+
+// swagger:route POST /access-control/{resource}/{resourceID} access_control setResourcePermissions
 //
 // Set resource permissions.
 //
 // Assigns permissions for a resource by a given type (`:resource`) and `:resourceID` to one or many
 // assignment types. Allowed resources are `datasources`, `teams`, `dashboards`, `folders`, and `serviceaccounts`.
-// Refer to the `/access-control/:resource/description` endpoint for allowed Permissions.
+// Refer to the `/access-control/{resource}/description` endpoint for allowed Permissions.
 //
 // Responses:
-// 200: okRespoonse
+// 200: okResponse
 // 400: badRequestError
 // 403: forbiddenError
 // 500: internalServerError

--- a/public/api-enterprise-spec.json
+++ b/public/api-enterprise-spec.json
@@ -318,6 +318,41 @@
         }
       }
     },
+    "/access-control/teams/roles/search": {
+      "post": {
+        "description": "Lists the roles that have been directly assigned to the given teams.\n\nYou need to have a permission with action `teams.roles:read` and scope `teams:id:*`.",
+        "tags": [
+          "access_control",
+          "enterprise"
+        ],
+        "summary": "List roles assigned to multiple teams.",
+        "operationId": "listTeamsRoles",
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/RolesSearchQuery"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/responses/listTeamsRolesResponse"
+          },
+          "400": {
+            "$ref": "#/responses/badRequestError"
+          },
+          "403": {
+            "$ref": "#/responses/forbiddenError"
+          },
+          "500": {
+            "$ref": "#/responses/internalServerError"
+          }
+        }
+      }
+    },
     "/access-control/teams/{teamId}/roles": {
       "get": {
         "description": "You need to have a permission with action `teams.roles:read` and scope `teams:id:\u003cteam ID\u003e`.",
@@ -466,6 +501,41 @@
           },
           "404": {
             "$ref": "#/responses/notFoundError"
+          },
+          "500": {
+            "$ref": "#/responses/internalServerError"
+          }
+        }
+      }
+    },
+    "/access-control/users/roles/search": {
+      "post": {
+        "description": "Lists the roles that have been directly assigned to the given users. The list does not include built-in roles (Viewer, Editor, Admin or Grafana Admin), and it does not include roles that have been inherited from a team.\n\nYou need to have a permission with action `users.roles:read` and scope `users:id:*`.",
+        "tags": [
+          "access_control",
+          "enterprise"
+        ],
+        "summary": "List roles assigned to multiple users.",
+        "operationId": "listUsersRoles",
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/RolesSearchQuery"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/responses/listUsersRolesResponse"
+          },
+          "400": {
+            "$ref": "#/responses/badRequestError"
+          },
+          "403": {
+            "$ref": "#/responses/forbiddenError"
           },
           "500": {
             "$ref": "#/responses/internalServerError"
@@ -1878,6 +1948,10 @@
       "type": "object",
       "properties": {
         "active_admins_and_editors": {
+          "type": "integer",
+          "format": "int64"
+        },
+        "active_anonymous_devices": {
           "type": "integer",
           "format": "int64"
         },
@@ -6402,6 +6476,32 @@
         }
       }
     },
+    "RolesSearchQuery": {
+      "type": "object",
+      "properties": {
+        "includeHidden": {
+          "type": "boolean"
+        },
+        "orgId": {
+          "type": "integer",
+          "format": "int64"
+        },
+        "teamIds": {
+          "type": "array",
+          "items": {
+            "type": "integer",
+            "format": "int64"
+          }
+        },
+        "userIds": {
+          "type": "array",
+          "items": {
+            "type": "integer",
+            "format": "int64"
+          }
+        }
+      }
+    },
     "SSOSettings": {
       "type": "object",
       "properties": {
@@ -6713,6 +6813,25 @@
           "type": "string",
           "format": "date-time",
           "example": "2022-03-21T14:35:33Z"
+        }
+      }
+    },
+    "SetResourcePermissionCommand": {
+      "type": "object",
+      "properties": {
+        "builtInRole": {
+          "type": "string"
+        },
+        "permission": {
+          "type": "string"
+        },
+        "teamId": {
+          "type": "integer",
+          "format": "int64"
+        },
+        "userId": {
+          "type": "integer",
+          "format": "int64"
         }
       }
     },
@@ -7063,6 +7182,10 @@
       "properties": {
         "account": {
           "type": "string"
+        },
+        "anonymousRatio": {
+          "type": "integer",
+          "format": "int64"
         },
         "company": {
           "type": "string"
@@ -8014,6 +8137,25 @@
         },
         "userLogin": {
           "type": "string"
+        }
+      }
+    },
+    "setPermissionCommand": {
+      "type": "object",
+      "properties": {
+        "permission": {
+          "type": "string"
+        }
+      }
+    },
+    "setPermissionsCommand": {
+      "type": "object",
+      "properties": {
+        "permissions": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/SetResourcePermissionCommand"
+          }
         }
       }
     }
@@ -8995,12 +9137,36 @@
         }
       }
     },
+    "listTeamsRolesResponse": {
+      "description": "",
+      "schema": {
+        "type": "object",
+        "additionalProperties": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/RoleDTO"
+          }
+        }
+      }
+    },
     "listTokensResponse": {
       "description": "",
       "schema": {
         "type": "array",
         "items": {
           "$ref": "#/definitions/TokenDTO"
+        }
+      }
+    },
+    "listUsersRolesResponse": {
+      "description": "",
+      "schema": {
+        "type": "object",
+        "additionalProperties": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/RoleDTO"
+          }
         }
       }
     },

--- a/public/api-merged.json
+++ b/public/api-merged.json
@@ -318,6 +318,41 @@
         }
       }
     },
+    "/access-control/teams/roles/search": {
+      "post": {
+        "description": "Lists the roles that have been directly assigned to the given teams.\n\nYou need to have a permission with action `teams.roles:read` and scope `teams:id:*`.",
+        "tags": [
+          "access_control",
+          "enterprise"
+        ],
+        "summary": "List roles assigned to multiple teams.",
+        "operationId": "listTeamsRoles",
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/RolesSearchQuery"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/responses/listTeamsRolesResponse"
+          },
+          "400": {
+            "$ref": "#/responses/badRequestError"
+          },
+          "403": {
+            "$ref": "#/responses/forbiddenError"
+          },
+          "500": {
+            "$ref": "#/responses/internalServerError"
+          }
+        }
+      }
+    },
     "/access-control/teams/{teamId}/roles": {
       "get": {
         "description": "You need to have a permission with action `teams.roles:read` and scope `teams:id:\u003cteam ID\u003e`.",
@@ -466,6 +501,41 @@
           },
           "404": {
             "$ref": "#/responses/notFoundError"
+          },
+          "500": {
+            "$ref": "#/responses/internalServerError"
+          }
+        }
+      }
+    },
+    "/access-control/users/roles/search": {
+      "post": {
+        "description": "Lists the roles that have been directly assigned to the given users. The list does not include built-in roles (Viewer, Editor, Admin or Grafana Admin), and it does not include roles that have been inherited from a team.\n\nYou need to have a permission with action `users.roles:read` and scope `users:id:*`.",
+        "tags": [
+          "access_control",
+          "enterprise"
+        ],
+        "summary": "List roles assigned to multiple users.",
+        "operationId": "listUsersRoles",
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/RolesSearchQuery"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/responses/listUsersRolesResponse"
+          },
+          "400": {
+            "$ref": "#/responses/badRequestError"
+          },
+          "403": {
+            "$ref": "#/responses/forbiddenError"
           },
           "500": {
             "$ref": "#/responses/internalServerError"
@@ -632,6 +702,238 @@
           },
           "404": {
             "$ref": "#/responses/notFoundError"
+          },
+          "500": {
+            "$ref": "#/responses/internalServerError"
+          }
+        }
+      }
+    },
+    "/access-control/{resource}/description": {
+      "post": {
+        "tags": [
+          "access_control"
+        ],
+        "summary": "Get a description of a resource's access control properties.",
+        "operationId": "getResourceDescription",
+        "parameters": [
+          {
+            "type": "string",
+            "name": "resource",
+            "in": "path",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/responses/resourcePermissionsDescription"
+          },
+          "403": {
+            "$ref": "#/responses/forbiddenError"
+          },
+          "500": {
+            "$ref": "#/responses/internalServerError"
+          }
+        }
+      }
+    },
+    "/access-control/{resource}/{resourceID}": {
+      "post": {
+        "description": "Assigns permissions for a resource by a given type (`:resource`) and `:resourceID` to one or many\nassignment types. Allowed resources are `datasources`, `teams`, `dashboards`, `folders`, and `serviceaccounts`.\nRefer to the `/access-control/{resource}/description` endpoint for allowed Permissions.",
+        "tags": [
+          "access_control"
+        ],
+        "summary": "Set resource permissions.",
+        "operationId": "setResourcePermissions",
+        "parameters": [
+          {
+            "type": "string",
+            "name": "resource",
+            "in": "path",
+            "required": true
+          },
+          {
+            "type": "string",
+            "name": "resourceID",
+            "in": "path",
+            "required": true
+          },
+          {
+            "name": "Body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/setPermissionsCommand"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/responses/okResponse"
+          },
+          "400": {
+            "$ref": "#/responses/badRequestError"
+          },
+          "403": {
+            "$ref": "#/responses/forbiddenError"
+          },
+          "500": {
+            "$ref": "#/responses/internalServerError"
+          }
+        }
+      }
+    },
+    "/access-control/{resource}/{resourceID}/builtInRoles/{builtInRole}": {
+      "post": {
+        "description": "Assigns permissions for a resource by a given type (`:resource`) and `:resourceID` to a built-in role.\nAllowed resources are `datasources`, `teams`, `dashboards`, `folders`, and `serviceaccounts`.\nRefer to the `/access-control/{resource}/description` endpoint for allowed Permissions.",
+        "tags": [
+          "access_control"
+        ],
+        "summary": "Set resource permissions for a built-in role.",
+        "operationId": "setResourcePermissionsForBuiltInRole",
+        "parameters": [
+          {
+            "type": "string",
+            "name": "resource",
+            "in": "path",
+            "required": true
+          },
+          {
+            "type": "string",
+            "name": "resourceID",
+            "in": "path",
+            "required": true
+          },
+          {
+            "type": "string",
+            "name": "builtInRole",
+            "in": "path",
+            "required": true
+          },
+          {
+            "name": "Body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/setPermissionCommand"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/responses/okResponse"
+          },
+          "400": {
+            "$ref": "#/responses/badRequestError"
+          },
+          "403": {
+            "$ref": "#/responses/forbiddenError"
+          },
+          "500": {
+            "$ref": "#/responses/internalServerError"
+          }
+        }
+      }
+    },
+    "/access-control/{resource}/{resourceID}/teams/{teamID}": {
+      "post": {
+        "description": "Assigns permissions for a resource by a given type (`:resource`) and `:resourceID` to a team.\nAllowed resources are `datasources`, `teams`, `dashboards`, `folders`, and `serviceaccounts`.\nRefer to the `/access-control/{resource}/description` endpoint for allowed Permissions.",
+        "tags": [
+          "access_control"
+        ],
+        "summary": "Set resource permissions for a team.",
+        "operationId": "setResourcePermissionsForTeam",
+        "parameters": [
+          {
+            "type": "string",
+            "name": "resource",
+            "in": "path",
+            "required": true
+          },
+          {
+            "type": "string",
+            "name": "resourceID",
+            "in": "path",
+            "required": true
+          },
+          {
+            "type": "integer",
+            "format": "int64",
+            "name": "teamID",
+            "in": "path",
+            "required": true
+          },
+          {
+            "name": "Body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/setPermissionCommand"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/responses/okResponse"
+          },
+          "400": {
+            "$ref": "#/responses/badRequestError"
+          },
+          "403": {
+            "$ref": "#/responses/forbiddenError"
+          },
+          "500": {
+            "$ref": "#/responses/internalServerError"
+          }
+        }
+      }
+    },
+    "/access-control/{resource}/{resourceID}/users/{userID}": {
+      "post": {
+        "description": "Assigns permissions for a resource by a given type (`:resource`) and `:resourceID` to a user or a service account.\nAllowed resources are `datasources`, `teams`, `dashboards`, `folders`, and `serviceaccounts`.\nRefer to the `/access-control/{resource}/description` endpoint for allowed Permissions.",
+        "tags": [
+          "access_control"
+        ],
+        "summary": "Set resource permissions for a user.",
+        "operationId": "setResourcePermissionsForUser",
+        "parameters": [
+          {
+            "type": "string",
+            "name": "resource",
+            "in": "path",
+            "required": true
+          },
+          {
+            "type": "string",
+            "name": "resourceID",
+            "in": "path",
+            "required": true
+          },
+          {
+            "type": "integer",
+            "format": "int64",
+            "name": "userID",
+            "in": "path",
+            "required": true
+          },
+          {
+            "name": "Body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/setPermissionCommand"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/responses/okResponse"
+          },
+          "400": {
+            "$ref": "#/responses/badRequestError"
+          },
+          "403": {
+            "$ref": "#/responses/forbiddenError"
           },
           "500": {
             "$ref": "#/responses/internalServerError"
@@ -11126,6 +11428,10 @@
           "type": "integer",
           "format": "int64"
         },
+        "active_anonymous_devices": {
+          "type": "integer",
+          "format": "int64"
+        },
         "active_users": {
           "type": "integer",
           "format": "int64"
@@ -18287,6 +18593,32 @@
         }
       }
     },
+    "RolesSearchQuery": {
+      "type": "object",
+      "properties": {
+        "includeHidden": {
+          "type": "boolean"
+        },
+        "orgId": {
+          "type": "integer",
+          "format": "int64"
+        },
+        "teamIds": {
+          "type": "array",
+          "items": {
+            "type": "integer",
+            "format": "int64"
+          }
+        },
+        "userIds": {
+          "type": "array",
+          "items": {
+            "type": "integer",
+            "format": "int64"
+          }
+        }
+      }
+    },
     "Route": {
       "description": "A Route is a node that contains definitions of how to handle alerts. This is modified\nfrom the upstream alertmanager in that it adds the ObjectMatchers property.",
       "type": "object",
@@ -18926,6 +19258,25 @@
           "type": "string",
           "format": "date-time",
           "example": "2022-03-21T14:35:33Z"
+        }
+      }
+    },
+    "SetResourcePermissionCommand": {
+      "type": "object",
+      "properties": {
+        "builtInRole": {
+          "type": "string"
+        },
+        "permission": {
+          "type": "string"
+        },
+        "teamId": {
+          "type": "integer",
+          "format": "int64"
+        },
+        "userId": {
+          "type": "integer",
+          "format": "int64"
         }
       }
     },
@@ -19754,6 +20105,10 @@
       "properties": {
         "account": {
           "type": "string"
+        },
+        "anonymousRatio": {
+          "type": "integer",
+          "format": "int64"
         },
         "company": {
           "type": "string"
@@ -21342,6 +21697,25 @@
         }
       }
     },
+    "setPermissionCommand": {
+      "type": "object",
+      "properties": {
+        "permission": {
+          "type": "string"
+        }
+      }
+    },
+    "setPermissionsCommand": {
+      "type": "object",
+      "properties": {
+        "permissions": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/SetResourcePermissionCommand"
+          }
+        }
+      }
+    },
     "silence": {
       "description": "Silence silence",
       "type": "object",
@@ -22432,12 +22806,36 @@
         }
       }
     },
+    "listTeamsRolesResponse": {
+      "description": "(empty)",
+      "schema": {
+        "type": "object",
+        "additionalProperties": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/RoleDTO"
+          }
+        }
+      }
+    },
     "listTokensResponse": {
       "description": "(empty)",
       "schema": {
         "type": "array",
         "items": {
           "$ref": "#/definitions/TokenDTO"
+        }
+      }
+    },
+    "listUsersRolesResponse": {
+      "description": "(empty)",
+      "schema": {
+        "type": "object",
+        "additionalProperties": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/RoleDTO"
+          }
         }
       }
     },

--- a/public/openapi3.json
+++ b/public/openapi3.json
@@ -1437,6 +1437,22 @@
         },
         "description": "(empty)"
       },
+      "listTeamsRolesResponse": {
+        "content": {
+          "application/json": {
+            "schema": {
+              "additionalProperties": {
+                "items": {
+                  "$ref": "#/components/schemas/RoleDTO"
+                },
+                "type": "array"
+              },
+              "type": "object"
+            }
+          }
+        },
+        "description": "(empty)"
+      },
       "listTokensResponse": {
         "content": {
           "application/json": {
@@ -1445,6 +1461,22 @@
                 "$ref": "#/components/schemas/TokenDTO"
               },
               "type": "array"
+            }
+          }
+        },
+        "description": "(empty)"
+      },
+      "listUsersRolesResponse": {
+        "content": {
+          "application/json": {
+            "schema": {
+              "additionalProperties": {
+                "items": {
+                  "$ref": "#/components/schemas/RoleDTO"
+                },
+                "type": "array"
+              },
+              "type": "object"
             }
           }
         },
@@ -1994,6 +2026,10 @@
       "ActiveUserStats": {
         "properties": {
           "active_admins_and_editors": {
+            "format": "int64",
+            "type": "integer"
+          },
+          "active_anonymous_devices": {
             "format": "int64",
             "type": "integer"
           },
@@ -9158,6 +9194,32 @@
         },
         "type": "object"
       },
+      "RolesSearchQuery": {
+        "properties": {
+          "includeHidden": {
+            "type": "boolean"
+          },
+          "orgId": {
+            "format": "int64",
+            "type": "integer"
+          },
+          "teamIds": {
+            "items": {
+              "format": "int64",
+              "type": "integer"
+            },
+            "type": "array"
+          },
+          "userIds": {
+            "items": {
+              "format": "int64",
+              "type": "integer"
+            },
+            "type": "array"
+          }
+        },
+        "type": "object"
+      },
       "Route": {
         "description": "A Route is a node that contains definitions of how to handle alerts. This is modified\nfrom the upstream alertmanager in that it adds the ObjectMatchers property.",
         "properties": {
@@ -9795,6 +9857,25 @@
             "example": "2022-03-21T14:35:33Z",
             "format": "date-time",
             "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "SetResourcePermissionCommand": {
+        "properties": {
+          "builtInRole": {
+            "type": "string"
+          },
+          "permission": {
+            "type": "string"
+          },
+          "teamId": {
+            "format": "int64",
+            "type": "integer"
+          },
+          "userId": {
+            "format": "int64",
+            "type": "integer"
           }
         },
         "type": "object"
@@ -10623,6 +10704,10 @@
         "properties": {
           "account": {
             "type": "string"
+          },
+          "anonymousRatio": {
+            "format": "int64",
+            "type": "integer"
           },
           "company": {
             "type": "string"
@@ -12212,6 +12297,25 @@
         },
         "type": "object"
       },
+      "setPermissionCommand": {
+        "properties": {
+          "permission": {
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "setPermissionsCommand": {
+        "properties": {
+          "permissions": {
+            "items": {
+              "$ref": "#/components/schemas/SetResourcePermissionCommand"
+            },
+            "type": "array"
+          }
+        },
+        "type": "object"
+      },
       "silence": {
         "description": "Silence silence",
         "properties": {
@@ -12644,6 +12748,42 @@
         ]
       }
     },
+    "/access-control/teams/roles/search": {
+      "post": {
+        "description": "Lists the roles that have been directly assigned to the given teams.\n\nYou need to have a permission with action `teams.roles:read` and scope `teams:id:*`.",
+        "operationId": "listTeamsRoles",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/RolesSearchQuery"
+              }
+            }
+          },
+          "required": true,
+          "x-originalParamName": "body"
+        },
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/listTeamsRolesResponse"
+          },
+          "400": {
+            "$ref": "#/components/responses/badRequestError"
+          },
+          "403": {
+            "$ref": "#/components/responses/forbiddenError"
+          },
+          "500": {
+            "$ref": "#/components/responses/internalServerError"
+          }
+        },
+        "summary": "List roles assigned to multiple teams.",
+        "tags": [
+          "access_control",
+          "enterprise"
+        ]
+      }
+    },
     "/access-control/teams/{teamId}/roles": {
       "get": {
         "description": "You need to have a permission with action `teams.roles:read` and scope `teams:id:\u003cteam ID\u003e`.",
@@ -12806,6 +12946,42 @@
           }
         },
         "summary": "Remove team role.",
+        "tags": [
+          "access_control",
+          "enterprise"
+        ]
+      }
+    },
+    "/access-control/users/roles/search": {
+      "post": {
+        "description": "Lists the roles that have been directly assigned to the given users. The list does not include built-in roles (Viewer, Editor, Admin or Grafana Admin), and it does not include roles that have been inherited from a team.\n\nYou need to have a permission with action `users.roles:read` and scope `users:id:*`.",
+        "operationId": "listUsersRoles",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/RolesSearchQuery"
+              }
+            }
+          },
+          "required": true,
+          "x-originalParamName": "body"
+        },
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/listUsersRolesResponse"
+          },
+          "400": {
+            "$ref": "#/components/responses/badRequestError"
+          },
+          "403": {
+            "$ref": "#/components/responses/forbiddenError"
+          },
+          "500": {
+            "$ref": "#/components/responses/internalServerError"
+          }
+        },
+        "summary": "List roles assigned to multiple users.",
         "tags": [
           "access_control",
           "enterprise"
@@ -12993,6 +13169,274 @@
         "tags": [
           "access_control",
           "enterprise"
+        ]
+      }
+    },
+    "/access-control/{resource}/description": {
+      "post": {
+        "operationId": "getResourceDescription",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "resource",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/resourcePermissionsDescription"
+          },
+          "403": {
+            "$ref": "#/components/responses/forbiddenError"
+          },
+          "500": {
+            "$ref": "#/components/responses/internalServerError"
+          }
+        },
+        "summary": "Get a description of a resource's access control properties.",
+        "tags": [
+          "access_control"
+        ]
+      }
+    },
+    "/access-control/{resource}/{resourceID}": {
+      "post": {
+        "description": "Assigns permissions for a resource by a given type (`:resource`) and `:resourceID` to one or many\nassignment types. Allowed resources are `datasources`, `teams`, `dashboards`, `folders`, and `serviceaccounts`.\nRefer to the `/access-control/{resource}/description` endpoint for allowed Permissions.",
+        "operationId": "setResourcePermissions",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "resource",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "resourceID",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/setPermissionsCommand"
+              }
+            }
+          },
+          "required": true,
+          "x-originalParamName": "Body"
+        },
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/okResponse"
+          },
+          "400": {
+            "$ref": "#/components/responses/badRequestError"
+          },
+          "403": {
+            "$ref": "#/components/responses/forbiddenError"
+          },
+          "500": {
+            "$ref": "#/components/responses/internalServerError"
+          }
+        },
+        "summary": "Set resource permissions.",
+        "tags": [
+          "access_control"
+        ]
+      }
+    },
+    "/access-control/{resource}/{resourceID}/builtInRoles/{builtInRole}": {
+      "post": {
+        "description": "Assigns permissions for a resource by a given type (`:resource`) and `:resourceID` to a built-in role.\nAllowed resources are `datasources`, `teams`, `dashboards`, `folders`, and `serviceaccounts`.\nRefer to the `/access-control/{resource}/description` endpoint for allowed Permissions.",
+        "operationId": "setResourcePermissionsForBuiltInRole",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "resource",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "resourceID",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "builtInRole",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/setPermissionCommand"
+              }
+            }
+          },
+          "required": true,
+          "x-originalParamName": "Body"
+        },
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/okResponse"
+          },
+          "400": {
+            "$ref": "#/components/responses/badRequestError"
+          },
+          "403": {
+            "$ref": "#/components/responses/forbiddenError"
+          },
+          "500": {
+            "$ref": "#/components/responses/internalServerError"
+          }
+        },
+        "summary": "Set resource permissions for a built-in role.",
+        "tags": [
+          "access_control"
+        ]
+      }
+    },
+    "/access-control/{resource}/{resourceID}/teams/{teamID}": {
+      "post": {
+        "description": "Assigns permissions for a resource by a given type (`:resource`) and `:resourceID` to a team.\nAllowed resources are `datasources`, `teams`, `dashboards`, `folders`, and `serviceaccounts`.\nRefer to the `/access-control/{resource}/description` endpoint for allowed Permissions.",
+        "operationId": "setResourcePermissionsForTeam",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "resource",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "resourceID",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "teamID",
+            "required": true,
+            "schema": {
+              "format": "int64",
+              "type": "integer"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/setPermissionCommand"
+              }
+            }
+          },
+          "required": true,
+          "x-originalParamName": "Body"
+        },
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/okResponse"
+          },
+          "400": {
+            "$ref": "#/components/responses/badRequestError"
+          },
+          "403": {
+            "$ref": "#/components/responses/forbiddenError"
+          },
+          "500": {
+            "$ref": "#/components/responses/internalServerError"
+          }
+        },
+        "summary": "Set resource permissions for a team.",
+        "tags": [
+          "access_control"
+        ]
+      }
+    },
+    "/access-control/{resource}/{resourceID}/users/{userID}": {
+      "post": {
+        "description": "Assigns permissions for a resource by a given type (`:resource`) and `:resourceID` to a user or a service account.\nAllowed resources are `datasources`, `teams`, `dashboards`, `folders`, and `serviceaccounts`.\nRefer to the `/access-control/{resource}/description` endpoint for allowed Permissions.",
+        "operationId": "setResourcePermissionsForUser",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "resource",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "resourceID",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "userID",
+            "required": true,
+            "schema": {
+              "format": "int64",
+              "type": "integer"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/setPermissionCommand"
+              }
+            }
+          },
+          "required": true,
+          "x-originalParamName": "Body"
+        },
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/okResponse"
+          },
+          "400": {
+            "$ref": "#/components/responses/badRequestError"
+          },
+          "403": {
+            "$ref": "#/components/responses/forbiddenError"
+          },
+          "500": {
+            "$ref": "#/components/responses/internalServerError"
+          }
+        },
+        "summary": "Set resource permissions for a user.",
+        "tags": [
+          "access_control"
         ]
       }
     },


### PR DESCRIPTION
There were a few errors that prevented these endpoints (which are the most up-to-date ones) from being present in the openapi spec:
- The `enterprise` tag excluded the endpoints from being generated
- `okRespoonse` typo
- Invalid templating on the parameters
- Missing parameter structs