### PR TITLE
Docs: Add HAProxy rewrite information considering `serve_from_sub_path` setting

### DIFF
--- a/docs/sources/tutorials/run-grafana-behind-a-proxy/index.md
+++ b/docs/sources/tutorials/run-grafana-behind-a-proxy/index.md
@@ -38,7 +38,7 @@ You can also serve Grafana behind a _sub path_, such as `http://example.com/graf
 
 To serve Grafana behind a sub path:
 
-- Include the sub path at the end of the `root_url`.
+1. Include the sub path at the end of the `root_url`.
 - Set `serve_from_sub_path` to `true`, **OR** let proxy rewrite the path for you (see proxy config examples bellow).
 
 ```bash

--- a/docs/sources/tutorials/run-grafana-behind-a-proxy/index.md
+++ b/docs/sources/tutorials/run-grafana-behind-a-proxy/index.md
@@ -152,7 +152,7 @@ backend grafana_backend
   server grafana localhost:3000
 ```
 
-If your Grafana configuration doen't set `server.serve_from_sub_path` to `true`, then you must add a rewrite rule to the `backend grafana_backend` block:
+If your Grafana configuration doesn't set `server.serve_from_sub_path` to `true`, then you must add a rewrite rule to the `backend grafana_backend` block:
 
 ```diff
 backend grafana_backend

--- a/docs/sources/tutorials/run-grafana-behind-a-proxy/index.md
+++ b/docs/sources/tutorials/run-grafana-behind-a-proxy/index.md
@@ -39,7 +39,7 @@ You can also serve Grafana behind a _sub path_, such as `http://example.com/graf
 To serve Grafana behind a sub path:
 
 1. Include the sub path at the end of the `root_url`.
-- Set `serve_from_sub_path` to `true`, **OR** let proxy rewrite the path for you (see proxy config examples bellow).
+1. Set `serve_from_sub_path` to `true`. Or, let proxy rewrite the path for you (refer to examples bellow).
 
 ```bash
 [server]

--- a/docs/sources/tutorials/run-grafana-behind-a-proxy/index.md
+++ b/docs/sources/tutorials/run-grafana-behind-a-proxy/index.md
@@ -152,7 +152,7 @@ backend grafana_backend
   server grafana localhost:3000
 ```
 
-If your Grafana configuration does not set `server.serve_from_sub_path` to `true` then you need to add a rewrite rule to `backend grafana_backend` block:
+If your Grafana configuration doen't set `server.serve_from_sub_path` to `true`, then you must add a rewrite rule to the `backend grafana_backend` block:
 
 ```diff
 backend grafana_backend

--- a/docs/sources/tutorials/run-grafana-behind-a-proxy/index.md
+++ b/docs/sources/tutorials/run-grafana-behind-a-proxy/index.md
@@ -39,7 +39,7 @@ You can also serve Grafana behind a _sub path_, such as `http://example.com/graf
 To serve Grafana behind a sub path:
 
 1. Include the sub path at the end of the `root_url`.
-1. Set `serve_from_sub_path` to `true`. Or, let proxy rewrite the path for you (refer to examples bellow).
+1. Set `serve_from_sub_path` to `true`. Or, let proxy rewrite the path for you (refer to examples below).
 
 ```bash
 [server]

--- a/docs/sources/tutorials/run-grafana-behind-a-proxy/index.md
+++ b/docs/sources/tutorials/run-grafana-behind-a-proxy/index.md
@@ -39,7 +39,7 @@ You can also serve Grafana behind a _sub path_, such as `http://example.com/graf
 To serve Grafana behind a sub path:
 
 - Include the sub path at the end of the `root_url`.
-- Set `serve_from_sub_path` to `true`.
+- Set `serve_from_sub_path` to `true`, **OR** let proxy rewrite the path for you (see proxy config examples bellow).
 
 ```bash
 [server]
@@ -149,11 +149,18 @@ frontend http-in
   use_backend grafana_backend if { path /grafana } or { path_beg /grafana/ }
 
 backend grafana_backend
-  # Requires haproxy >= 1.6
-  http-request set-path %[path,regsub(^/grafana/?,/)]
+  server grafana localhost:3000
+```
 
-  # Works for haproxy < 1.6
-  # reqrep ^([^\ ]*\ /)grafana[/]?(.*) \1\2
+If your Grafana configuration does not set `server.serve_from_sub_path` to `true` then you need to add a rewrite rule to `backend grafana_backend` block:
+
+```diff
+backend grafana_backend
++  # Requires haproxy >= 1.6
++  http-request set-path %[path,regsub(^/grafana/?,/)]
+
++  # Works for haproxy < 1.6
++  # reqrep ^([^\ ]*\ /)grafana[/]?(.*) \1\2
 
   server grafana localhost:3000
 ```


### PR DESCRIPTION
**What is this feature?**

Updates HAProxy docs

**Why do we need this feature?**

When investigating why bumping SystemJs broke rendering plugin integration I realised I have to use `serve_from_sub_path` set to `true` which requires having no rewrite in proxy server.

**Who is this feature for?**

HAProxy users

**Which issue(s) does this PR fix?**:

Related to https://github.com/grafana/grafana/issues/76180

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
