### PR TITLE
Loki: Fix import of escapeLabelValueInExactSelector to be from Loki

### DIFF
--- a/public/app/plugins/datasource/loki/components/monaco-query-field/monaco-completion-provider/CompletionDataProvider.test.ts
+++ b/public/app/plugins/datasource/loki/components/monaco-query-field/monaco-completion-provider/CompletionDataProvider.test.ts
@@ -182,4 +182,11 @@ describe('CompletionDataProvider', () => {
   test('Returns the expected series labels', async () => {
     expect(await completionProvider.getSeriesLabels([])).toEqual(seriesLabels);
   });
+
+  test('Escapes regex characters when building stream selector in getSeriesLabels', async () => {
+    completionProvider.getSeriesLabels([{ name: 'job', op: '=', value: '"a\\b\n' }]);
+    expect(languageProvider.fetchSeriesLabels).toHaveBeenCalledWith('{job="\\"a\\\\b\\n"}', {
+      timeRange: mockTimeRange,
+    });
+  });
 });

--- a/public/app/plugins/datasource/loki/components/monaco-query-field/monaco-completion-provider/CompletionDataProvider.test.ts
+++ b/public/app/plugins/datasource/loki/components/monaco-query-field/monaco-completion-provider/CompletionDataProvider.test.ts
@@ -183,7 +183,7 @@ describe('CompletionDataProvider', () => {
     expect(await completionProvider.getSeriesLabels([])).toEqual(seriesLabels);
   });
 
-  test('Escapes regex characters when building stream selector in getSeriesLabels', async () => {
+  test('Escapes correct characters when building stream selector in getSeriesLabels', async () => {
     completionProvider.getSeriesLabels([{ name: 'job', op: '=', value: '"a\\b\n' }]);
     expect(languageProvider.fetchSeriesLabels).toHaveBeenCalledWith('{job="\\"a\\\\b\\n"}', {
       timeRange: mockTimeRange,

--- a/public/app/plugins/datasource/loki/components/monaco-query-field/monaco-completion-provider/CompletionDataProvider.ts
+++ b/public/app/plugins/datasource/loki/components/monaco-query-field/monaco-completion-provider/CompletionDataProvider.ts
@@ -1,9 +1,9 @@
 import { chain } from 'lodash';
 
 import { HistoryItem, TimeRange } from '@grafana/data';
-import { escapeLabelValueInExactSelector } from 'app/plugins/datasource/prometheus/language_utils';
 
 import LanguageProvider from '../../../LanguageProvider';
+import { escapeLabelValueInExactSelector } from '../../../languageUtils';
 import { ParserAndLabelKeysResult, LokiQuery } from '../../../types';
 
 import { Label } from './situation';


### PR DESCRIPTION
Part of https://github.com/grafana/grafana/issues/72631

Fixes import of `escapeLabelValueInExactSelector` function to be from Loki and not Prometheus. Additionally adds test. 