### PR TITLE
Explore: Preserve time range when creating a dashboard panel from Explore

### DIFF
--- a/public/app/features/explore/extensions/AddToDashboard/AddToDashboardForm.tsx
+++ b/public/app/features/explore/extensions/AddToDashboard/AddToDashboardForm.tsx
@@ -102,6 +102,8 @@ export function AddToDashboardForm(props: Props): ReactElement {
       queries: exploreItem.queries.length,
     });
 
+    const { from, to } = exploreItem.range.raw;
+
     try {
       await setDashboardInLocalStorage({
         dashboardUid,
@@ -109,6 +111,10 @@ export function AddToDashboardForm(props: Props): ReactElement {
         queries: exploreItem.queries,
         queryResponse: exploreItem.queryResponse,
         panelState: exploreItem?.panelsState,
+        time: {
+          from: typeof from === 'string' ? from : from.toISOString(),
+          to: typeof to === 'string' ? to : to.toISOString(),
+        },
       });
     } catch (error) {
       switch (error) {

--- a/public/app/features/explore/extensions/AddToDashboard/addToDashboard.test.ts
+++ b/public/app/features/explore/extensions/AddToDashboard/addToDashboard.test.ts
@@ -23,11 +23,29 @@ describe('addPanelToDashboard', () => {
       queries: [],
       queryResponse: createEmptyQueryResponse(),
       datasource: { type: 'loki', uid: 'someUid' },
+      time: { from: 'now-1h', to: 'now' },
     });
     expect(spy).toHaveBeenCalledWith(
       expect.objectContaining({
         dashboard: expect.objectContaining({
           panels: expect.arrayContaining([expect.objectContaining({ datasource: { type: 'loki', uid: 'someUid' } })]),
+        }),
+      })
+    );
+  });
+
+  it('Correct time range is used', async () => {
+    await setDashboardInLocalStorage({
+      queries: [],
+      queryResponse: createEmptyQueryResponse(),
+      datasource: { type: 'loki', uid: 'someUid' },
+      time: { from: 'now-10h', to: 'now' },
+    });
+
+    expect(spy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        dashboard: expect.objectContaining({
+          time: expect.objectContaining({ from: 'now-10h', to: 'now' }),
         }),
       })
     );
@@ -39,6 +57,7 @@ describe('addPanelToDashboard', () => {
     await setDashboardInLocalStorage({
       queries,
       queryResponse: createEmptyQueryResponse(),
+      time: { from: 'now-1h', to: 'now' },
     });
     expect(spy).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -68,6 +87,7 @@ describe('addPanelToDashboard', () => {
       queryResponse: createEmptyQueryResponse(),
       dashboardUid: 'someUid',
       datasource: { type: '' },
+      time: { from: 'now-1h', to: 'now' },
     });
 
     expect(spy).toHaveBeenCalledWith(
@@ -95,7 +115,7 @@ describe('addPanelToDashboard', () => {
       ];
 
       it.each(cases)('%s', async (_, queries, queryResponse) => {
-        await setDashboardInLocalStorage({ queries, queryResponse });
+        await setDashboardInLocalStorage({ queries, queryResponse, time: { from: 'now-1h', to: 'now' } });
         expect(spy).toHaveBeenCalledWith(
           expect.objectContaining({
             dashboard: expect.objectContaining({
@@ -127,7 +147,7 @@ describe('addPanelToDashboard', () => {
             [framesType]: [new MutableDataFrame({ refId: 'A', fields: [] })],
           };
 
-          await setDashboardInLocalStorage({ queries, queryResponse });
+          await setDashboardInLocalStorage({ queries, queryResponse, time: { from: 'now-1h', to: 'now' } });
           expect(spy).toHaveBeenCalledWith(
             expect.objectContaining({
               dashboard: expect.objectContaining({
@@ -151,7 +171,7 @@ describe('addPanelToDashboard', () => {
           ],
         };
 
-        await setDashboardInLocalStorage({ queries, queryResponse });
+        await setDashboardInLocalStorage({ queries, queryResponse, time: { from: 'now-1h', to: 'now' } });
         expect(spy).toHaveBeenCalledWith(
           expect.objectContaining({
             dashboard: expect.objectContaining({

--- a/public/app/features/explore/extensions/AddToDashboard/addToDashboard.ts
+++ b/public/app/features/explore/extensions/AddToDashboard/addToDashboard.ts
@@ -1,5 +1,5 @@
 import { DataFrame, ExplorePanelsState } from '@grafana/data';
-import { DataQuery, DataSourceRef } from '@grafana/schema';
+import { Dashboard, DataQuery, DataSourceRef } from '@grafana/schema';
 import { DataTransformerConfig } from '@grafana/schema/dist/esm/raw/dashboard/x/dashboard_types.gen';
 import { backendSrv } from 'app/core/services/backend_srv';
 import {
@@ -19,6 +19,7 @@ interface AddPanelToDashboardOptions {
   datasource?: DataSourceRef;
   dashboardUid?: string;
   panelState?: ExplorePanelsState;
+  time: Dashboard['time'];
 }
 
 function createDashboard(): DashboardDTO {
@@ -92,6 +93,8 @@ export async function setDashboardInLocalStorage(options: AddPanelToDashboardOpt
   }
 
   dto.dashboard.panels = [panel, ...(dto.dashboard.panels ?? [])];
+
+  dto.dashboard.time = options.time;
 
   try {
     setDashboardToFetchFromLocalStorage(dto);

--- a/public/app/features/explore/extensions/AddToDashboard/index.test.tsx
+++ b/public/app/features/explore/extensions/AddToDashboard/index.test.tsx
@@ -24,6 +24,11 @@ const setup = (children: ReactNode, queries: DataQuery[] = [{ refId: 'A' }]) => 
     explore: {
       panes: {
         left: {
+          range: {
+            from: 'now-6h',
+            to: 'now',
+            raw: { from: 'now-6h', to: 'now' },
+          },
           queries,
           queryResponse: createEmptyQueryResponse(),
         },


### PR DESCRIPTION

<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

Preserves Explore's time range when creating a dashboard from explore. This also applies when creating a panel in existing dashboards.

**Why do we need this feature?**

When a user creates a dashboard (or adds a panel to an existing one) from Explore, the default time range (or the existing dashboard saved range) is used instead of the one in Explore. this is confusing because users expect to see roughly the same data. by also opening the dashboard with Explore's time range this confusion is removed, is then up to the users if they want to save the new ime range as the default for the dashboard or not.

**Who is this feature for?**

Dashboard users creating panels from Explore

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #72085

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
