### PR TITLE
Chore: move PrometheusListView specific utils in the correct directory

### DIFF
--- a/public/app/features/explore/PrometheusListView/ItemValues.test.tsx
+++ b/public/app/features/explore/PrometheusListView/ItemValues.test.tsx
@@ -1,10 +1,9 @@
 import { render, screen } from '@testing-library/react';
 import React from 'react';
 
-import { RawPrometheusListItemEmptyValue } from '../utils/getRawPrometheusListItemsFromDataFrame';
-
 import { ItemValues } from './ItemValues';
 import { RawListValue } from './RawListItem';
+import { RawPrometheusListItemEmptyValue } from './utils/getRawPrometheusListItemsFromDataFrame';
 
 const value1 = 'value 1';
 const value2 = 'value 2';

--- a/public/app/features/explore/PrometheusListView/ItemValues.tsx
+++ b/public/app/features/explore/PrometheusListView/ItemValues.tsx
@@ -4,9 +4,8 @@ import React from 'react';
 import { GrafanaTheme2 } from '@grafana/data/';
 import { useStyles2 } from '@grafana/ui/';
 
-import { RawPrometheusListItemEmptyValue } from '../utils/getRawPrometheusListItemsFromDataFrame';
-
 import { rawListItemColumnWidth, rawListPaddingToHoldSpaceForCopyIcon, RawListValue } from './RawListItem';
+import { RawPrometheusListItemEmptyValue } from './utils/getRawPrometheusListItemsFromDataFrame';
 
 const getStyles = (theme: GrafanaTheme2, totalNumberOfValues: number) => ({
   rowWrapper: css`

--- a/public/app/features/explore/PrometheusListView/RawListContainer.tsx
+++ b/public/app/features/explore/PrometheusListView/RawListContainer.tsx
@@ -8,13 +8,12 @@ import { DataFrame, Field as DataFrameField } from '@grafana/data/';
 import { reportInteraction } from '@grafana/runtime/src';
 import { Field, Switch } from '@grafana/ui/';
 
+import { ItemLabels } from './ItemLabels';
+import RawListItem from './RawListItem';
 import {
   getRawPrometheusListItemsFromDataFrame,
   RawPrometheusListItemEmptyValue,
-} from '../utils/getRawPrometheusListItemsFromDataFrame';
-
-import { ItemLabels } from './ItemLabels';
-import RawListItem from './RawListItem';
+} from './utils/getRawPrometheusListItemsFromDataFrame';
 
 export type instantQueryRawVirtualizedListData = { Value: string; __name__: string; [index: string]: string };
 

--- a/public/app/features/explore/PrometheusListView/utils/getRawPrometheusListItemsFromDataFrame.test.ts
+++ b/public/app/features/explore/PrometheusListView/utils/getRawPrometheusListItemsFromDataFrame.test.ts
@@ -1,4 +1,4 @@
-import { DataFrame, FieldType, FormattedValue, toDataFrame } from '@grafana/data/src';
+import { DataFrame, FieldType, FormattedValue, toDataFrame } from '@grafana/data';
 
 import { getRawPrometheusListItemsFromDataFrame } from './getRawPrometheusListItemsFromDataFrame';
 

--- a/public/app/features/explore/PrometheusListView/utils/getRawPrometheusListItemsFromDataFrame.ts
+++ b/public/app/features/explore/PrometheusListView/utils/getRawPrometheusListItemsFromDataFrame.ts
@@ -1,6 +1,6 @@
-import { DataFrame, formattedValueToString } from '@grafana/data/src';
+import { DataFrame, formattedValueToString } from '@grafana/data';
 
-import { instantQueryRawVirtualizedListData } from '../PrometheusListView/RawListContainer';
+import { instantQueryRawVirtualizedListData } from '../RawListContainer';
 
 type instantQueryMetricList = { [index: string]: { [index: string]: instantQueryRawVirtualizedListData } };
 


### PR DESCRIPTION
Move PromListView specific utils into `public/app/features/explore/PrometheusListView/utils` as they are not Explore related.