### PR TITLE
Chore: Fix some Explore deprecations

### DIFF
--- a/public/app/features/explore/ExploreQueryInspector.tsx
+++ b/public/app/features/explore/ExploreQueryInspector.tsx
@@ -1,9 +1,9 @@
 import React, { useEffect } from 'react';
 import { connect, ConnectedProps } from 'react-redux';
 
-import { CoreApp, LoadingState, TimeZone } from '@grafana/data';
+import { CoreApp, LoadingState } from '@grafana/data';
 import { reportInteraction } from '@grafana/runtime/src';
-import { defaultTimeZone } from '@grafana/schema';
+import { defaultTimeZone, TimeZone } from '@grafana/schema';
 import { TabbedContainer, TabConfig } from '@grafana/ui';
 import { ExploreDrawer } from 'app/features/explore/ExploreDrawer';
 import { InspectDataTab } from 'app/features/inspector/InspectDataTab';

--- a/public/app/features/explore/ExploreTimeControls.tsx
+++ b/public/app/features/explore/ExploreTimeControls.tsx
@@ -1,7 +1,8 @@
 import React, { Component } from 'react';
 
-import { TimeRange, TimeZone, RawTimeRange, dateTimeForTimeZone, dateMath } from '@grafana/data';
+import { TimeRange, RawTimeRange, dateTimeForTimeZone, dateMath } from '@grafana/data';
 import { reportInteraction } from '@grafana/runtime';
+import { TimeZone } from '@grafana/schema';
 import { TimePickerWithHistory } from 'app/core/components/TimePicker/TimePickerWithHistory';
 import { getShiftedTimeRange, getZoomedTimeRange } from 'app/core/utils/timePicker';
 

--- a/public/app/features/explore/Graph/ExploreGraph.tsx
+++ b/public/app/features/explore/Graph/ExploreGraph.tsx
@@ -13,7 +13,6 @@ import {
   getFrameDisplayName,
   LoadingState,
   SplitOpen,
-  TimeZone,
   ThresholdsConfig,
   DashboardCursorSync,
   EventBus,
@@ -25,6 +24,7 @@ import {
   TooltipDisplayMode,
   SortOrder,
   GraphThresholdsStyleConfig,
+  TimeZone,
 } from '@grafana/schema';
 import { PanelContext, PanelContextProvider, SeriesVisibilityChangeMode, useTheme2 } from '@grafana/ui';
 import { GraphFieldConfig } from 'app/plugins/panel/graph/types';

--- a/public/app/features/explore/Logs/LiveLogs.tsx
+++ b/public/app/features/explore/Logs/LiveLogs.tsx
@@ -2,7 +2,8 @@ import { css, cx } from '@emotion/css';
 import React, { PureComponent } from 'react';
 import tinycolor from 'tinycolor2';
 
-import { LogRowModel, TimeZone, dateTimeFormat, GrafanaTheme2, LogsSortOrder } from '@grafana/data';
+import { LogRowModel, dateTimeFormat, GrafanaTheme2, LogsSortOrder } from '@grafana/data';
+import { TimeZone } from '@grafana/schema';
 import { Button, Themeable2, withTheme2 } from '@grafana/ui';
 
 import { LogMessageAnsi } from '../../logs/components/LogMessageAnsi';

--- a/public/app/features/explore/Logs/Logs.test.tsx
+++ b/public/app/features/explore/Logs/Logs.test.tsx
@@ -10,9 +10,9 @@ import {
   LoadingState,
   LogLevel,
   LogRowModel,
-  MutableDataFrame,
   standardTransformersRegistry,
   toUtc,
+  createDataFrame,
 } from '@grafana/data';
 import { organizeFieldsTransformer } from '@grafana/data/src/transformations/transformers/organize';
 import { config } from '@grafana/runtime';
@@ -513,7 +513,7 @@ const makeLog = (overrides: Partial<LogRowModel>): LogRowModel => {
     uid,
     entryFieldIndex: 0,
     rowIndex: 0,
-    dataFrame: new MutableDataFrame(),
+    dataFrame: createDataFrame({ fields: [] }),
     logLevel: LogLevel.debug,
     entry,
     hasAnsi: false,

--- a/public/app/features/explore/Logs/Logs.tsx
+++ b/public/app/features/explore/Logs/Logs.tsx
@@ -30,11 +30,10 @@ import {
   serializeStateToUrlParam,
   SplitOpen,
   TimeRange,
-  TimeZone,
   urlUtil,
 } from '@grafana/data';
 import { config, reportInteraction } from '@grafana/runtime';
-import { DataQuery } from '@grafana/schema';
+import { DataQuery, TimeZone } from '@grafana/schema';
 import {
   Button,
   FeatureBadge,

--- a/public/app/features/explore/Logs/LogsNavigation.tsx
+++ b/public/app/features/explore/Logs/LogsNavigation.tsx
@@ -2,9 +2,9 @@ import { css } from '@emotion/css';
 import { isEqual } from 'lodash';
 import React, { memo, useCallback, useEffect, useRef, useState } from 'react';
 
-import { AbsoluteTimeRange, GrafanaTheme2, LogsSortOrder, TimeZone } from '@grafana/data';
+import { AbsoluteTimeRange, GrafanaTheme2, LogsSortOrder } from '@grafana/data';
 import { reportInteraction } from '@grafana/runtime';
-import { DataQuery } from '@grafana/schema';
+import { DataQuery, TimeZone } from '@grafana/schema';
 import { Button, Icon, Spinner, useTheme2 } from '@grafana/ui';
 import { TOP_BAR_LEVEL_HEIGHT } from 'app/core/components/AppChrome/types';
 

--- a/public/app/features/explore/Logs/LogsNavigationPages.tsx
+++ b/public/app/features/explore/Logs/LogsNavigationPages.tsx
@@ -1,7 +1,8 @@
 import { css, cx } from '@emotion/css';
 import React from 'react';
 
-import { dateTimeFormat, systemDateFormats, TimeZone, GrafanaTheme2 } from '@grafana/data';
+import { dateTimeFormat, systemDateFormats, GrafanaTheme2 } from '@grafana/data';
+import { TimeZone } from '@grafana/schema';
 import { CustomScrollbar, Spinner, useTheme2, clearButtonStyles } from '@grafana/ui';
 
 import { LogsPage } from './LogsNavigation';

--- a/public/app/features/explore/Logs/LogsVolumePanel.tsx
+++ b/public/app/features/explore/Logs/LogsVolumePanel.tsx
@@ -7,11 +7,11 @@ import {
   DataQueryResponse,
   LoadingState,
   SplitOpen,
-  TimeZone,
   EventBus,
   GrafanaTheme2,
   DataFrame,
 } from '@grafana/data';
+import { TimeZone } from '@grafana/schema';
 import { Icon, Tooltip, TooltipDisplayMode, useStyles2, useTheme2 } from '@grafana/ui';
 
 import { getLogsVolumeDataSourceInfo, isLogsVolumeLimited } from '../../logs/utils';

--- a/public/app/features/explore/RawPrometheus/RawPrometheusContainer.tsx
+++ b/public/app/features/explore/RawPrometheus/RawPrometheusContainer.tsx
@@ -2,8 +2,9 @@ import { css } from '@emotion/css';
 import React, { PureComponent } from 'react';
 import { connect, ConnectedProps } from 'react-redux';
 
-import { applyFieldOverrides, DataFrame, SelectableValue, SplitOpen, TimeZone } from '@grafana/data';
+import { applyFieldOverrides, DataFrame, SelectableValue, SplitOpen } from '@grafana/data';
 import { getTemplateSrv, reportInteraction } from '@grafana/runtime';
+import { TimeZone } from '@grafana/schema';
 import { RadioButtonGroup, Table, AdHocFilterItem, PanelChrome } from '@grafana/ui';
 import { config } from 'app/core/config';
 import { PANEL_BORDER } from 'app/core/constants';

--- a/public/app/features/explore/Table/TableContainer.tsx
+++ b/public/app/features/explore/Table/TableContainer.tsx
@@ -2,8 +2,9 @@ import { css } from '@emotion/css';
 import React, { PureComponent } from 'react';
 import { connect, ConnectedProps } from 'react-redux';
 
-import { applyFieldOverrides, TimeZone, SplitOpen, DataFrame, LoadingState, FieldType } from '@grafana/data';
+import { applyFieldOverrides, SplitOpen, DataFrame, LoadingState, FieldType } from '@grafana/data';
 import { getTemplateSrv } from '@grafana/runtime';
+import { TimeZone } from '@grafana/schema';
 import { Table, AdHocFilterItem, PanelChrome, withTheme2, Themeable2 } from '@grafana/ui';
 import { config } from 'app/core/config';
 import { t } from 'app/core/internationalization';

--- a/public/app/features/explore/TraceView/TraceViewContainer.tsx
+++ b/public/app/features/explore/TraceView/TraceViewContainer.tsx
@@ -1,7 +1,7 @@
 import React, { useMemo } from 'react';
 
 import { DataFrame, SplitOpen } from '@grafana/data';
-import { PanelChrome } from '@grafana/ui/src/components/PanelChrome/PanelChrome';
+import { PanelChrome } from '@grafana/ui';
 import { StoreState, useSelector } from 'app/types';
 
 import { TraceView } from './TraceView';

--- a/public/app/features/explore/TraceView/components/TraceTimelineViewer/SpanDetail/index.tsx
+++ b/public/app/features/explore/TraceView/components/TraceTimelineViewer/SpanDetail/index.tsx
@@ -17,8 +17,9 @@ import { SpanStatusCode } from '@opentelemetry/api';
 import cx from 'classnames';
 import React from 'react';
 
-import { DataFrame, dateTimeFormat, GrafanaTheme2, IconName, LinkModel, TimeZone } from '@grafana/data';
+import { DataFrame, dateTimeFormat, GrafanaTheme2, IconName, LinkModel } from '@grafana/data';
 import { config, locationService, reportInteraction } from '@grafana/runtime';
+import { TimeZone } from '@grafana/schema';
 import { DataLinkButton, Icon, TextArea, useStyles2 } from '@grafana/ui';
 import { TraceToProfilesOptions } from 'app/core/components/TraceToProfiles/TraceToProfilesSettings';
 import { RelatedProfilesTitle } from 'app/plugins/datasource/tempo/resultTransformer';

--- a/public/app/features/explore/TraceView/components/TraceTimelineViewer/SpanDetailRow.tsx
+++ b/public/app/features/explore/TraceView/components/TraceTimelineViewer/SpanDetailRow.tsx
@@ -16,7 +16,8 @@ import { css } from '@emotion/css';
 import classNames from 'classnames';
 import React from 'react';
 
-import { GrafanaTheme2, LinkModel, TimeZone } from '@grafana/data';
+import { GrafanaTheme2, LinkModel } from '@grafana/data';
+import { TimeZone } from '@grafana/schema';
 import { Button, clearButtonStyles, stylesFactory, withTheme2 } from '@grafana/ui';
 import { TraceToProfilesOptions } from 'app/core/components/TraceToProfiles/TraceToProfilesSettings';
 

--- a/public/app/features/explore/TraceView/components/TraceTimelineViewer/VirtualizedTraceView.tsx
+++ b/public/app/features/explore/TraceView/components/TraceTimelineViewer/VirtualizedTraceView.tsx
@@ -18,8 +18,9 @@ import memoizeOne from 'memoize-one';
 import * as React from 'react';
 import { RefObject } from 'react';
 
-import { GrafanaTheme2, LinkModel, TimeZone } from '@grafana/data';
+import { GrafanaTheme2, LinkModel } from '@grafana/data';
 import { config, reportInteraction } from '@grafana/runtime';
+import { TimeZone } from '@grafana/schema';
 import { stylesFactory, withTheme2, ToolbarButton } from '@grafana/ui';
 import { TraceToProfilesOptions } from 'app/core/components/TraceToProfiles/TraceToProfilesSettings';
 

--- a/public/app/features/explore/TraceView/components/TraceTimelineViewer/index.tsx
+++ b/public/app/features/explore/TraceView/components/TraceTimelineViewer/index.tsx
@@ -15,8 +15,9 @@
 import { css } from '@emotion/css';
 import React, { RefObject } from 'react';
 
-import { GrafanaTheme2, LinkModel, TimeZone } from '@grafana/data';
+import { GrafanaTheme2, LinkModel } from '@grafana/data';
 import { config, reportInteraction } from '@grafana/runtime';
+import { TimeZone } from '@grafana/schema';
 import { stylesFactory, withTheme2 } from '@grafana/ui';
 import { TraceToProfilesOptions } from 'app/core/components/TraceToProfiles/TraceToProfilesSettings';
 

--- a/public/app/features/explore/__mocks__/makeLogs.ts
+++ b/public/app/features/explore/__mocks__/makeLogs.ts
@@ -1,4 +1,4 @@
-import { MutableDataFrame, LogLevel, LogRowModel, LogsSortOrder } from '@grafana/data';
+import { createDataFrame, LogLevel, LogRowModel, LogsSortOrder } from '@grafana/data';
 import { sortLogRows } from 'app/features/logs/utils';
 export const makeLogs = (numberOfLogsToCreate: number, overrides?: Partial<LogRowModel>): LogRowModel[] => {
   const array: LogRowModel[] = [];
@@ -12,7 +12,7 @@ export const makeLogs = (numberOfLogsToCreate: number, overrides?: Partial<LogRo
       uid: uuid,
       entryFieldIndex: 0,
       rowIndex: 0,
-      dataFrame: new MutableDataFrame(),
+      dataFrame: createDataFrame({ fields: [] }),
       logLevel: LogLevel.debug,
       entry,
       hasAnsi: false,

--- a/public/app/features/explore/spec/helper/query.ts
+++ b/public/app/features/explore/spec/helper/query.ts
@@ -1,9 +1,9 @@
 import { from, Observable } from 'rxjs';
 
-import { ArrayDataFrame, DataQueryResponse, FieldType } from '@grafana/data';
+import { arrayToDataFrame, DataQueryResponse, FieldType } from '@grafana/data';
 
 export function makeLogsQueryResponse(marker = ''): Observable<DataQueryResponse> {
-  const df = new ArrayDataFrame([{ ts: Date.now(), line: `custom log line ${marker}` }]);
+  const df = arrayToDataFrame([{ ts: Date.now(), line: `custom log line ${marker}` }]);
   df.meta = {
     preferredVisualisationType: 'logs',
   };
@@ -12,7 +12,7 @@ export function makeLogsQueryResponse(marker = ''): Observable<DataQueryResponse
 }
 
 export function makeMetricsQueryResponse(): Observable<DataQueryResponse> {
-  const df = new ArrayDataFrame([{ ts: Date.now(), val: 1 }]);
+  const df = arrayToDataFrame([{ ts: Date.now(), val: 1 }]);
   df.fields[0].type = FieldType.time;
   return from([{ data: [df] }]);
 }

--- a/public/app/features/explore/spec/queryHistory.test.tsx
+++ b/public/app/features/explore/spec/queryHistory.test.tsx
@@ -1,7 +1,8 @@
 import React from 'react';
 
-import { DataQuery, EventBusSrv, serializeStateToUrlParam } from '@grafana/data';
+import { EventBusSrv, serializeStateToUrlParam } from '@grafana/data';
 import { config } from '@grafana/runtime';
+import { DataQuery } from '@grafana/schema';
 
 import { silenceConsoleOutput } from '../../../../test/core/utils/silenceConsoleOutput';
 

--- a/public/app/features/explore/state/helpers.ts
+++ b/public/app/features/explore/state/helpers.ts
@@ -1,4 +1,5 @@
-import { DefaultTimeZone, TimeRange, toUtc, SupplementaryQueryType } from '@grafana/data';
+import { TimeRange, toUtc, SupplementaryQueryType } from '@grafana/data';
+import { defaultTimeZone } from '@grafana/schema';
 
 export const createDefaultInitialState = () => {
   const t = toUtc();
@@ -14,7 +15,7 @@ export const createDefaultInitialState = () => {
   const defaultInitialState = {
     user: {
       orgId: '1',
-      timeZone: DefaultTimeZone,
+      timeZone: defaultTimeZone,
     },
     explore: {
       panes: {


### PR DESCRIPTION
Fixes some deprecations in Explore:

- import `TimeZone` from `@grafana/schema` instead of `@grafana/data`
- use `createDataFrame({ fields: [] })` instead of `new MutableDataFrame()`
(this is technically different, but it was only used in tests, and they pass correctly)
- import `PanelChrome` from '@grafana/ui' instead of the full path in `public/app/features/explore/TraceView/TraceViewContainer.tsx`
- use `arrayToDataFrame` instead of `new ArrayDataFrame`
- import `DataQuery` from `@grafana/schema` instead of `@grafana/data`
- use `defaultTimeZone` from '@grafana/schema' instead of `DefaultTimeZone` from `@grafana/data`

there are some other deprecations that i didn't touch as they are a bit more involved:
- the `TraceView` component largely uses `stylesFactory` from `@grafana/ui` which was deprecated in favor of `stylesCreator` (cc @grafana/observability-traces-and-profiling )
- `getFieldLinksForExplore`