### PR TITLE
Alerting: Allow copying error messages from query badges

### DIFF
--- a/packages/grafana-ui/src/components/Badge/Badge.tsx
+++ b/packages/grafana-ui/src/components/Badge/Badge.tsx
@@ -18,25 +18,28 @@ export interface BadgeProps extends HTMLAttributes<HTMLDivElement> {
   color: BadgeColor;
   icon?: IconName;
   tooltip?: string;
+  interactive?: boolean;
 }
 
-const BadgeComponent = React.memo<BadgeProps>(({ icon, color, text, tooltip, className, ...otherProps }) => {
-  const styles = useStyles2(getStyles, color);
-  const badge = (
-    <div className={cx(styles.wrapper, className)} {...otherProps}>
-      {icon && <Icon name={icon} size="sm" />}
-      {text}
-    </div>
-  );
+const BadgeComponent = React.memo<BadgeProps>(
+  ({ icon, color, text, tooltip, interactive, className, ...otherProps }) => {
+    const styles = useStyles2(getStyles, color);
+    const badge = (
+      <div className={cx(styles.wrapper, className)} {...otherProps}>
+        {icon && <Icon name={icon} size="sm" />}
+        {text}
+      </div>
+    );
 
-  return tooltip ? (
-    <Tooltip content={tooltip} placement="auto">
-      {badge}
-    </Tooltip>
-  ) : (
-    badge
-  );
-});
+    return tooltip ? (
+      <Tooltip content={tooltip} placement="auto" interactive={interactive}>
+        {badge}
+      </Tooltip>
+    ) : (
+      badge
+    );
+  }
+);
 BadgeComponent.displayName = 'Badge';
 
 const BadgeSkeleton: SkeletonComponent = ({ rootProps }) => {

--- a/packages/grafana-ui/src/components/Badge/Badge.tsx
+++ b/packages/grafana-ui/src/components/Badge/Badge.tsx
@@ -18,28 +18,25 @@ export interface BadgeProps extends HTMLAttributes<HTMLDivElement> {
   color: BadgeColor;
   icon?: IconName;
   tooltip?: string;
-  interactive?: boolean;
 }
 
-const BadgeComponent = React.memo<BadgeProps>(
-  ({ icon, color, text, tooltip, interactive, className, ...otherProps }) => {
-    const styles = useStyles2(getStyles, color);
-    const badge = (
-      <div className={cx(styles.wrapper, className)} {...otherProps}>
-        {icon && <Icon name={icon} size="sm" />}
-        {text}
-      </div>
-    );
+const BadgeComponent = React.memo<BadgeProps>(({ icon, color, text, tooltip, className, ...otherProps }) => {
+  const styles = useStyles2(getStyles, color);
+  const badge = (
+    <div className={cx(styles.wrapper, className)} {...otherProps}>
+      {icon && <Icon name={icon} size="sm" />}
+      {text}
+    </div>
+  );
 
-    return tooltip ? (
-      <Tooltip content={tooltip} placement="auto" interactive={interactive}>
-        {badge}
-      </Tooltip>
-    ) : (
-      badge
-    );
-  }
-);
+  return tooltip ? (
+    <Tooltip content={tooltip} placement="auto">
+      {badge}
+    </Tooltip>
+  ) : (
+    badge
+  );
+});
 BadgeComponent.displayName = 'Badge';
 
 const BadgeSkeleton: SkeletonComponent = ({ rootProps }) => {

--- a/public/app/features/alerting/unified/components/expressions/Expression.tsx
+++ b/public/app/features/alerting/unified/components/expressions/Expression.tsx
@@ -4,7 +4,7 @@ import React, { FC, useCallback, useState } from 'react';
 import { useFormContext } from 'react-hook-form';
 
 import { DataFrame, dateTimeFormat, GrafanaTheme2, isTimeSeriesFrames, LoadingState, PanelData } from '@grafana/data';
-import { AutoSizeInput, Button, clearButtonStyles, IconButton, Stack, useStyles2 } from '@grafana/ui';
+import { Alert, AutoSizeInput, Button, clearButtonStyles, IconButton, Stack, useStyles2 } from '@grafana/ui';
 import { ClassicConditions } from 'app/features/expressions/components/ClassicConditions';
 import { Math } from 'app/features/expressions/components/Math';
 import { Reduce } from 'app/features/expressions/components/Reduce';
@@ -136,12 +136,20 @@ export const Expression: FC<ExpressionProps> = ({
           onUpdateRefId={(newRefId) => onUpdateRefId(query.refId, newRefId)}
           onUpdateExpressionType={(type) => onUpdateExpressionType(query.refId, type)}
           onSetCondition={onSetCondition}
-          warning={warning}
-          error={error}
           query={query}
           alertCondition={alertCondition}
         />
         <div className={styles.expression.body}>
+          {error && (
+            <Alert title="Expression failed" severity="error">
+              {error.message}
+            </Alert>
+          )}
+          {warning && (
+            <Alert title="Expression warning" severity="warning">
+              {warning.message}
+            </Alert>
+          )}
           <div className={styles.expression.description}>{selectedExpressionDescription}</div>
           {renderExpressionType(query)}
         </div>
@@ -275,8 +283,6 @@ interface HeaderProps {
   onUpdateRefId: (refId: string) => void;
   onRemoveExpression: () => void;
   onUpdateExpressionType: (type: ExpressionQueryType) => void;
-  warning?: Error;
-  error?: Error;
   onSetCondition: (refId: string) => void;
   query: ExpressionQuery;
   alertCondition: boolean;
@@ -287,11 +293,9 @@ const Header: FC<HeaderProps> = ({
   queryType,
   onUpdateRefId,
   onRemoveExpression,
-  warning,
   onSetCondition,
   alertCondition,
   query,
-  error,
 }) => {
   const styles = useStyles2(getStyles);
   const clearButton = useStyles2(clearButtonStyles);
@@ -335,12 +339,7 @@ const Header: FC<HeaderProps> = ({
           <div>{getExpressionLabel(queryType)}</div>
         </Stack>
         <Spacer />
-        <ExpressionStatusIndicator
-          error={error}
-          warning={warning}
-          onSetCondition={() => onSetCondition(query.refId)}
-          isCondition={alertCondition}
-        />
+        <ExpressionStatusIndicator onSetCondition={() => onSetCondition(query.refId)} isCondition={alertCondition} />
         <IconButton
           name="trash-alt"
           variant="secondary"

--- a/public/app/features/alerting/unified/components/expressions/ExpressionStatusIndicator.test.tsx
+++ b/public/app/features/alerting/unified/components/expressions/ExpressionStatusIndicator.test.tsx
@@ -12,7 +12,7 @@ describe('ExpressionStatusIndicator', () => {
 
   it('should render one element if not condition', () => {
     render(<ExpressionStatusIndicator isCondition={false} />);
-    gitui;
+
     expect(screen.queryByRole('button', { name: 'Alert condition' })).not.toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'Set as alert condition' })).toBeInTheDocument();
   });

--- a/public/app/features/alerting/unified/components/expressions/ExpressionStatusIndicator.test.tsx
+++ b/public/app/features/alerting/unified/components/expressions/ExpressionStatusIndicator.test.tsx
@@ -4,47 +4,15 @@ import React from 'react';
 import { ExpressionStatusIndicator } from './ExpressionStatusIndicator';
 
 describe('ExpressionStatusIndicator', () => {
-  it('should render two elements when error and not condition', () => {
-    render(<ExpressionStatusIndicator isCondition={false} warning={new Error('this is a warning')} />);
-
-    expect(screen.getByText('Warning')).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: 'Set as alert condition' })).toBeInTheDocument();
-  });
-
-  it('should render one element when warning and condition', () => {
-    render(<ExpressionStatusIndicator isCondition warning={new Error('this is a warning')} />);
-
-    expect(screen.getByText('Alert condition')).toBeInTheDocument();
-    expect(screen.queryByRole('button', { name: 'Set as alert condition' })).not.toBeInTheDocument();
-  });
-
-  it('should render two elements when error and not condition', () => {
-    render(<ExpressionStatusIndicator isCondition={false} error={new Error('this is a error')} />);
-
-    expect(screen.getByText('Error')).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: 'Set as alert condition' })).toBeInTheDocument();
-  });
-
-  it('should render one element when error and condition', () => {
-    render(<ExpressionStatusIndicator isCondition error={new Error('this is a error')} />);
-
-    expect(screen.getByText('Alert condition')).toBeInTheDocument();
-    expect(screen.queryByRole('button', { name: 'Set as alert condition' })).not.toBeInTheDocument();
-  });
-
   it('should render one element if condition', () => {
     render(<ExpressionStatusIndicator isCondition />);
 
-    expect(screen.queryByText('Error')).not.toBeInTheDocument();
-    expect(screen.queryByText('Warning')).not.toBeInTheDocument();
     expect(screen.getByText('Alert condition')).toBeInTheDocument();
   });
 
   it('should render one element if not condition', () => {
     render(<ExpressionStatusIndicator isCondition={false} />);
-
-    expect(screen.queryByText('Error')).not.toBeInTheDocument();
-    expect(screen.queryByText('Warning')).not.toBeInTheDocument();
+    gitui;
     expect(screen.queryByRole('button', { name: 'Alert condition' })).not.toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'Set as alert condition' })).toBeInTheDocument();
   });

--- a/public/app/features/alerting/unified/components/expressions/ExpressionStatusIndicator.tsx
+++ b/public/app/features/alerting/unified/components/expressions/ExpressionStatusIndicator.tsx
@@ -17,16 +17,27 @@ export const ExpressionStatusIndicator = ({ error, warning, isCondition, onSetCo
   const elements: JSX.Element[] = [];
 
   if (error && isCondition) {
-    return <Badge color="red" icon="exclamation-circle" text="Alert condition" tooltip={error.message} />;
+    return <Badge color="red" icon="exclamation-circle" text="Alert condition" tooltip={error.message} interactive />;
   } else if (error) {
-    elements.push(<Badge key="error" color="red" icon="exclamation-circle" text="Error" tooltip={error.message} />);
+    elements.push(
+      <Badge key="error" color="red" icon="exclamation-circle" text="Error" tooltip={error.message} interactive />
+    );
   }
 
   if (warning && isCondition) {
-    return <Badge color="orange" icon="exclamation-triangle" text="Alert condition" tooltip={warning.message} />;
+    return (
+      <Badge color="orange" icon="exclamation-triangle" text="Alert condition" tooltip={warning.message} interactive />
+    );
   } else if (warning) {
     elements.push(
-      <Badge key="warning" color="orange" icon="exclamation-triangle" text="Warning" tooltip={warning.message} />
+      <Badge
+        key="warning"
+        color="orange"
+        icon="exclamation-triangle"
+        text="Warning"
+        tooltip={warning.message}
+        interactive
+      />
     );
   }
 

--- a/public/app/features/alerting/unified/components/expressions/ExpressionStatusIndicator.tsx
+++ b/public/app/features/alerting/unified/components/expressions/ExpressionStatusIndicator.tsx
@@ -5,46 +5,17 @@ import { GrafanaTheme2 } from '@grafana/data';
 import { Badge, clearButtonStyles, useStyles2 } from '@grafana/ui';
 
 interface AlertConditionProps {
-  warning?: Error;
-  error?: Error;
   isCondition?: boolean;
   onSetCondition?: () => void;
 }
 
-export const ExpressionStatusIndicator = ({ error, warning, isCondition, onSetCondition }: AlertConditionProps) => {
+export const ExpressionStatusIndicator = ({ isCondition, onSetCondition }: AlertConditionProps) => {
   const styles = useStyles2(getStyles);
 
-  const elements: JSX.Element[] = [];
-
-  if (error && isCondition) {
-    return <Badge color="red" icon="exclamation-circle" text="Alert condition" tooltip={error.message} interactive />;
-  } else if (error) {
-    elements.push(
-      <Badge key="error" color="red" icon="exclamation-circle" text="Error" tooltip={error.message} interactive />
-    );
-  }
-
-  if (warning && isCondition) {
-    return (
-      <Badge color="orange" icon="exclamation-triangle" text="Alert condition" tooltip={warning.message} interactive />
-    );
-  } else if (warning) {
-    elements.push(
-      <Badge
-        key="warning"
-        color="orange"
-        icon="exclamation-triangle"
-        text="Warning"
-        tooltip={warning.message}
-        interactive
-      />
-    );
-  }
-
   if (isCondition) {
-    elements.unshift(<Badge key="condition" color="green" icon="check" text="Alert condition" />);
+    return <Badge key="condition" color="green" icon="check" text="Alert condition" />;
   } else {
-    elements.unshift(
+    return (
       <button
         key="make-condition"
         type="button"
@@ -55,8 +26,6 @@ export const ExpressionStatusIndicator = ({ error, warning, isCondition, onSetCo
       </button>
     );
   }
-
-  return <>{elements}</>;
 };
 
 const getStyles = (theme: GrafanaTheme2) => {

--- a/public/app/features/alerting/unified/components/rule-editor/QueryWrapper.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/QueryWrapper.tsx
@@ -130,11 +130,7 @@ export const QueryWrapper = ({
           onChangeQueryOptions={onChangeQueryOptions}
           index={index}
         />
-        <ExpressionStatusIndicator
-          error={error}
-          onSetCondition={() => onSetCondition(query.refId)}
-          isCondition={isAlertCondition}
-        />
+        <ExpressionStatusIndicator onSetCondition={() => onSetCondition(query.refId)} isCondition={isAlertCondition} />
       </Stack>
     );
   }


### PR DESCRIPTION
**What is this feature?**

This PR uses Tooltip's interactive mode to enable copying errors shown by the Badge component in the query definition section

**Which issue(s) does this PR fix?**:
Fixes #78743 

**Special notes for your reviewer:**
~~The PR adds an `interactive` prop to the Badge component to pass it down to the Tooltip~~

After getting feedback about using tooltips we decided to change our approach
Instead of having the `Error` and `Warning` badges we render errors and warnings directly in the Expression component
Errors in queries are handled by the query editor

![image](https://github.com/grafana/grafana/assets/6293563/0e145f36-a310-44d1-b61e-0d3654762f93)
![image](https://github.com/grafana/grafana/assets/6293563/9a00ade5-3bb2-4a9b-9da8-cfba5b2a7012)



Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
