### PR TITLE
Transformations: Fix bug where having NaN in the input to regression analysis transformation causes all predictions to be NaN

### DIFF
--- a/public/app/features/transformers/regression/regression.test.ts
+++ b/public/app/features/transformers/regression/regression.test.ts
@@ -152,6 +152,34 @@ describe('Regression transformation', () => {
     expect(result[1].fields[0].values[8]).toBeCloseTo(3.55, 1);
     expect(result[1].fields[0].values[9]).toBe(4);
   });
+
+  it('should filter NaNs', () => {
+    const source = [
+      toDataFrame({
+        name: 'data',
+        refId: 'A',
+        fields: [
+          { name: 'y', type: FieldType.number, values: [0, 1, 2, 3, NaN] },
+          { name: 'x', type: FieldType.number, values: [0, 1, 2, 3, 4] },
+        ],
+      }),
+    ];
+
+    const config: RegressionTransformerOptions = {
+      modelType: ModelType.linear,
+      predictionCount: 5,
+      xFieldName: 'x',
+      yFieldName: 'y',
+    };
+
+    const result = RegressionTransformer.transformer(config, {} as DataTransformContext)(source);
+
+    expect(result[1].fields[1].values[0]).toBe(0);
+    expect(result[1].fields[1].values[1]).toBe(1);
+    expect(result[1].fields[1].values[2]).toBe(2);
+    expect(result[1].fields[1].values[3]).toBe(3);
+    expect(result[1].fields[1].values[4]).toBe(4);
+  });
 });
 
 function toEquableDataFrame(source: DataFrame): DataFrame {

--- a/public/app/features/transformers/regression/regression.ts
+++ b/public/app/features/transformers/regression/regression.ts
@@ -84,7 +84,7 @@ export const RegressionTransformer: SynchronousDataTransformerInfo<RegressionTra
       const xValues = [];
 
       for (let i = 0; i < xField.values.length; i++) {
-        if (yField.values[i] !== null) {
+        if (yField.values[i] !== null && !isNaN(yField.values[i])) {
           xValues.push(xField.values[i] - normalizationSubtrahend);
           yValues.push(yField.values[i]);
         }


### PR DESCRIPTION
**What is this feature?**

This fixes a bug where having NaN in the input to regression analysis transformation causes all predictions to be NaN.

**Which issue(s) does this PR fix?**:

Fixes: #79736