### PR TITLE
Alerting: Disable export all rules button when no GMA rules

### DIFF
--- a/public/app/features/alerting/unified/MoreActionsRuleButtons.tsx
+++ b/public/app/features/alerting/unified/MoreActionsRuleButtons.tsx
@@ -10,9 +10,11 @@ import { logInfo, LogMessages } from './Analytics';
 import { GrafanaRulesExporter } from './components/export/GrafanaRulesExporter';
 import { AlertingAction, useAlertingAbility } from './hooks/useAbilities';
 
-interface Props {}
+interface Props {
+  enableExport?: boolean;
+}
 
-export function MoreActionsRuleButtons({}: Props) {
+export function MoreActionsRuleButtons({ enableExport }: Props) {
   const [createRuleSupported, createRuleAllowed] = useAlertingAbility(AlertingAction.CreateAlertRule);
   const [createCloudRuleSupported, createCloudRuleAllowed] = useAlertingAbility(AlertingAction.CreateExternalAlertRule);
   const [exportRulesSupported, exportRulesAllowed] = useAlertingAbility(AlertingAction.ExportGrafanaManagedRules);
@@ -40,7 +42,13 @@ export function MoreActionsRuleButtons({}: Props) {
 
   if (canExportRules) {
     menuItems.push(
-      <MenuItem label="Export all Grafana-managed rules" key="export-all-rules" onClick={toggleShowExportDrawer} />
+      <MenuItem
+        label="Export all Grafana-managed rules"
+        key="export-all-rules"
+        onClick={toggleShowExportDrawer}
+        disabled={!enableExport}
+        description={enableExport ? '' : 'No Grafana-managed rules found'}
+      />
     );
   }
 

--- a/public/app/features/alerting/unified/RuleList.tsx
+++ b/public/app/features/alerting/unified/RuleList.tsx
@@ -24,7 +24,7 @@ import { useFilteredRules, useRulesFilter } from './hooks/useFilteredRules';
 import { useUnifiedAlertingSelector } from './hooks/useUnifiedAlertingSelector';
 import { fetchAllPromAndRulerRulesAction } from './state/actions';
 import { RULE_LIST_POLL_INTERVAL_MS } from './utils/constants';
-import { getAllRulesSourceNames } from './utils/datasource';
+import { getAllRulesSourceNames, GRAFANA_RULES_SOURCE_NAME } from './utils/datasource';
 
 const VIEWS = {
   groups: RuleListGroupView,
@@ -77,6 +77,9 @@ const RuleList = withErrorBoundary(
       return noRules && state.dispatched;
     });
 
+    const grafanaRules = useUnifiedAlertingSelector((state) => state.rulerRules[GRAFANA_RULES_SOURCE_NAME]?.result);
+    const hasGrafanaRules = Object.keys(grafanaRules ?? {}).length > 0;
+
     const limitAlerts = hasActiveFilters ? undefined : LIMIT_ALERTS;
     // Trigger data refresh only when the RULE_LIST_POLL_INTERVAL_MS elapsed since the previous load FINISHED
     const [_, fetchRules] = useAsyncFn(async () => {
@@ -126,7 +129,7 @@ const RuleList = withErrorBoundary(
                 <RuleStats namespaces={filteredNamespaces} />
               </div>
               <Stack direction="row" gap={0.5}>
-                <MoreActionsRuleButtons />
+                <MoreActionsRuleButtons enableExport={hasGrafanaRules} />
               </Stack>
             </div>
           </>


### PR DESCRIPTION
**What is this feature?**
This PR disables the export all GMA rules button when there are no Grafana-managed rules present

**Which issue(s) does this PR fix?**:

Fixes #80123

**Special notes for your reviewer:**

**PREVIEW**
![image](https://github.com/grafana/grafana/assets/6293563/26eb1f5c-2bb3-4927-8266-f02e7ffb25a1)


Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
