### PR TITLE
Analytics: Fix metanalytics sending 'undefined' to backend

### DIFF
--- a/packages/grafana-runtime/src/analytics/types.ts
+++ b/packages/grafana-runtime/src/analytics/types.ts
@@ -28,7 +28,7 @@ export interface DataRequestInfo extends Partial<DashboardInfo> {
   datasourceId: number;
   datasourceUid: string;
   datasourceType: string;
-  panelId?: number;
+  panelId: number;
   panelName?: string;
   duration: number;
   error?: string;

--- a/packages/grafana-runtime/src/analytics/types.ts
+++ b/packages/grafana-runtime/src/analytics/types.ts
@@ -28,7 +28,7 @@ export interface DataRequestInfo extends Partial<DashboardInfo> {
   datasourceId: number;
   datasourceUid: string;
   datasourceType: string;
-  panelId: number;
+  panelId?: number;
   panelName?: string;
   duration: number;
   error?: string;

--- a/public/app/features/query/state/queryAnalytics.ts
+++ b/public/app/features/query/state/queryAnalytics.ts
@@ -28,6 +28,7 @@ export function emitDataRequestEvent(datasource: DataSourceApi) {
       datasourceUid: datasource.uid,
       datasourceType: datasource.type,
       dataSize: 0,
+      panelId: 0,
       duration: data.request.endTime! - data.request.startTime,
     };
 
@@ -60,7 +61,9 @@ export function emitDataRequestEvent(datasource: DataSourceApi) {
 
     eventData.totalQueries = Object.keys(queryCacheStatus).length;
     eventData.cachedQueries = Object.values(queryCacheStatus).filter((val) => val === true).length;
-    eventData.panelId = data.request!.panelId;
+    if (typeof data.request?.panelId === 'number') {
+      eventData.panelId = data.request.panelId;
+    }
 
     const dashboard = getDashboardSrv().getCurrent();
     if (dashboard) {

--- a/public/app/features/query/state/queryAnalytics.ts
+++ b/public/app/features/query/state/queryAnalytics.ts
@@ -61,7 +61,7 @@ export function emitDataRequestEvent(datasource: DataSourceApi) {
 
     eventData.totalQueries = Object.keys(queryCacheStatus).length;
     eventData.cachedQueries = Object.values(queryCacheStatus).filter((val) => val === true).length;
-    if (Number.isInteger(data.request?.panelId)) {
+    if (data.request && Number.isInteger(data.request.panelId)) {
       eventData.panelId = data.request.panelId;
     }
 

--- a/public/app/features/query/state/queryAnalytics.ts
+++ b/public/app/features/query/state/queryAnalytics.ts
@@ -61,7 +61,7 @@ export function emitDataRequestEvent(datasource: DataSourceApi) {
 
     eventData.totalQueries = Object.keys(queryCacheStatus).length;
     eventData.cachedQueries = Object.values(queryCacheStatus).filter((val) => val === true).length;
-    if (typeof data.request?.panelId === 'number') {
+    if (Number.isInteger(data.request?.panelId)) {
       eventData.panelId = data.request.panelId;
     }
 


### PR DESCRIPTION

**What is this feature?**

Fix metanalytics sending 'undefined' to backend

For some reason the request panelId can come as the literal string "undefined".

The backend can only take in numbers. 