### PR TITLE
Explore: use numeric ids for panel ids when building query transactions

### DIFF
--- a/.betterer.results
+++ b/.betterer.results
@@ -1188,9 +1188,7 @@ exports[`better eslint`] = {
       [0, 0, 0, "Unexpected any. Specify a different type.", "0"]
     ],
     "public/app/core/utils/explore.ts:5381": [
-      [0, 0, 0, "Do not use any type assertions.", "0"],
-      [0, 0, 0, "Unexpected any. Specify a different type.", "1"],
-      [0, 0, 0, "Unexpected any. Specify a different type.", "2"]
+      [0, 0, 0, "Unexpected any. Specify a different type.", "0"]
     ],
     "public/app/core/utils/fetch.ts:5381": [
       [0, 0, 0, "Do not use any type assertions.", "0"],

--- a/jest.config.js
+++ b/jest.config.js
@@ -12,6 +12,7 @@ const esModules = [
   'internmap',
   'robust-predicates',
   'leven',
+  'nanoid',
 ].join('|');
 
 module.exports = {

--- a/package.json
+++ b/package.json
@@ -356,6 +356,7 @@
     "mousetrap": "1.6.5",
     "mousetrap-global-bind": "1.1.0",
     "moveable": "0.43.1",
+    "nanoid": "^5.0.4",
     "node-forge": "^1.3.1",
     "ol": "7.4.0",
     "ol-ext": "4.0.10",

--- a/public/app/features/explore/hooks/useStateSync/migrators/v1.ts
+++ b/public/app/features/explore/hooks/useStateSync/migrators/v1.ts
@@ -1,5 +1,5 @@
 import { ExploreUrlState } from '@grafana/data';
-import { generateExploreId } from 'app/core/utils/explore';
+import { ID_ALPHABET, generateExploreId } from 'app/core/utils/explore';
 import { DEFAULT_RANGE } from 'app/features/explore/state/utils';
 
 import { hasKey } from '../../utils';
@@ -48,9 +48,21 @@ export const v1Migrator: MigrationHandler<ExploreURLV0, ExploreURLV1> = {
     const panes = Object.entries(rawPanes)
       .map(([key, value]) => [key, applyDefaults(value)] as const)
       .reduce<Record<string, ExploreUrlState>>((acc, [key, value]) => {
+        let newKey = key;
+        // Panes IDs must be 3 characters long and contain at least one letter
+        if (
+          newKey.length !== 3 ||
+          /^\d+$/.test(newKey) ||
+          newKey.split('').some((ch) => {
+            return ID_ALPHABET.indexOf(ch) === -1;
+          })
+        ) {
+          newKey = generateExploreId();
+        }
+
         return {
           ...acc,
-          [key]: value,
+          [newKey]: value,
         };
       }, {});
 

--- a/public/app/features/explore/state/main.ts
+++ b/public/app/features/explore/state/main.ts
@@ -65,7 +65,7 @@ export const clearPanes = createAction('explore/clearPanes');
  */
 export const splitOpen = createAsyncThunk(
   'explore/splitOpen',
-  async (options: SplitOpenOptions | undefined, { getState, dispatch, requestId }) => {
+  async (options: SplitOpenOptions | undefined, { getState, dispatch }) => {
     // we currently support showing only 2 panes in explore, so if this action is dispatched we know it has been dispatched from the "first" pane.
     const originState = Object.values(getState().explore.panes)[0];
 
@@ -80,9 +80,15 @@ export const splitOpen = createAsyncThunk(
 
     const splitRange = options?.range || originState?.range.raw || DEFAULT_RANGE;
 
+    let newPaneId = generateExploreId();
+    // in case we have a duplicate id, generate a new one
+    while (getState().explore.panes[newPaneId]) {
+      newPaneId = generateExploreId();
+    }
+
     await dispatch(
       createNewSplitOpenPane({
-        exploreId: requestId,
+        exploreId: newPaneId,
         datasource: options?.datasourceUid || originState?.datasourceInstance?.getRef(),
         queries: withUniqueRefIds(queries),
         range: splitRange,
@@ -95,9 +101,6 @@ export const splitOpen = createAsyncThunk(
     if (originState?.range) {
       await dispatch(syncTimesAction({ syncedTimes: isEqual(originState.range.raw, splitRange) })); // if time ranges are equal, mark times as synced
     }
-  },
-  {
-    idGenerator: generateExploreId,
   }
 );
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -17276,6 +17276,7 @@ __metadata:
     moveable: "npm:0.43.1"
     msw: "npm:1.3.2"
     mutationobserver-shim: "npm:0.3.7"
+    nanoid: "npm:^5.0.4"
     ngtemplate-loader: "npm:2.1.0"
     node-forge: "npm:^1.3.1"
     node-notifier: "npm:10.0.1"
@@ -21898,6 +21899,15 @@ __metadata:
   bin:
     nanoid: bin/nanoid.cjs
   checksum: 67235c39d1bc05851383dadde5cf77ae1c90c2a1d189e845c7f20f646f0488d875ad5f5226bbba072a88cebbb085a3f784a6673117daf785bdf614a852550362
+  languageName: node
+  linkType: hard
+
+"nanoid@npm:^5.0.4":
+  version: 5.0.4
+  resolution: "nanoid@npm:5.0.4"
+  bin:
+    nanoid: bin/nanoid.js
+  checksum: cf09cca3774f3147100948f7478f75f4c9ee97a4af65c328dd9abbd83b12f8bb35cf9f89a21c330f3b759d667a4cd0140ed84aa5fdd522c61e0d341aeaa7fb6f
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
for context: https://raintank-corp.slack.com/archives/CHKLEJ668/p1702997323296379
makes use of a custom nanoid alphabet (`01234567890abcdefghijklmnopqrstuwxyz`) to generate explore ids, so that any explore id can be parsed as a unique integer when generating panelIds when building transactions.
When navigating to explore from an external URL, if pane ids in the URL are not part of the alphabet, are not 3 chars long or are only numeric, new valid ids are generated.

additionally, prevents Ids duplication when opening split panes

Fixes #70427
Fixes #64515