### PR TITLE
Loki: Implement error source

### DIFF
--- a/pkg/tsdb/loki/api.go
+++ b/pkg/tsdb/loki/api.go
@@ -11,14 +11,15 @@ import (
 	"net/url"
 	"path"
 	"strconv"
+	"syscall"
 	"time"
 
-	"github.com/grafana/grafana-plugin-sdk-go/data"
 	jsoniter "github.com/json-iterator/go"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
 	"go.opentelemetry.io/otel/trace"
 
+	"github.com/grafana/grafana-plugin-sdk-go/backend"
 	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/infra/tracing"
 	"github.com/grafana/grafana/pkg/tsdb/loki/instrumentation"
@@ -160,7 +161,7 @@ func readLokiError(body io.ReadCloser) error {
 	return makeLokiError(bytes)
 }
 
-func (api *LokiAPI) DataQuery(ctx context.Context, query lokiQuery, responseOpts ResponseOpts) (data.Frames, error) {
+func (api *LokiAPI) DataQuery(ctx context.Context, query lokiQuery, responseOpts ResponseOpts) (*backend.DataResponse, error) {
 	req, err := makeDataRequest(ctx, api.url, query, api.requestStructuredMetadata)
 	if err != nil {
 		return nil, err
@@ -181,7 +182,13 @@ func (api *LokiAPI) DataQuery(ctx context.Context, query lokiQuery, responseOpts
 			lp = append(lp, "statusCode", resp.StatusCode)
 		}
 		api.log.Error("Error received from Loki", lp...)
-		return nil, err
+		res := backend.DataResponse{
+			Error: err,
+		}
+		if errors.Is(err, syscall.ECONNREFUSED) {
+			res.ErrorSource = backend.ErrorSourceDownstream
+		}
+		return &res, nil
 	}
 
 	defer func() {
@@ -194,9 +201,13 @@ func (api *LokiAPI) DataQuery(ctx context.Context, query lokiQuery, responseOpts
 	lp = append(lp, queryAttrs...)
 	if resp.StatusCode/100 != 2 {
 		err := readLokiError(resp.Body)
+		res := backend.DataResponse{
+			Error:       err,
+			ErrorSource: backend.ErrorSourceFromHTTPStatus(resp.StatusCode),
+		}
 		lp = append(lp, "status", "error", "error", err)
 		api.log.Error("Error received from Loki", lp...)
-		return nil, err
+		return &res, nil
 	} else {
 		lp = append(lp, "status", "ok")
 		api.log.Info("Response received from loki", lp...)
@@ -221,7 +232,7 @@ func (api *LokiAPI) DataQuery(ctx context.Context, query lokiQuery, responseOpts
 	instrumentation.UpdatePluginParsingResponseDurationSeconds(ctx, time.Since(start), "ok")
 	api.log.Info("Response parsed from loki", "duration", time.Since(start), "metricDataplane", responseOpts.metricDataplane, "framesLength", len(res.Frames), "stage", stageParseResponse)
 
-	return res.Frames, nil
+	return &res, nil
 }
 
 func makeRawRequest(ctx context.Context, lokiDsUrl string, resourcePath string) (*http.Request, error) {

--- a/pkg/tsdb/loki/framing_test.go
+++ b/pkg/tsdb/loki/framing_test.go
@@ -63,13 +63,9 @@ func TestSuccessResponse(t *testing.T) {
 		bytes, err := os.ReadFile(responseFileName)
 		require.NoError(t, err)
 
-		frames, err := runQuery(context.Background(), makeMockedAPI(http.StatusOK, "application/json", bytes, nil, false), &query, responseOpts, log.New("test"))
+		dr, err := runQuery(context.Background(), makeMockedAPI(http.StatusOK, "application/json", bytes, nil, false), &query, responseOpts, log.New("test"))
 		require.NoError(t, err)
 
-		dr := &backend.DataResponse{
-			Frames: frames,
-			Error:  err,
-		}
 		experimental.CheckGoldenJSONResponse(t, folder, goldenFileName, dr, false)
 	}
 
@@ -128,11 +124,57 @@ func TestErrorResponse(t *testing.T) {
 
 	for _, test := range tt {
 		t.Run(test.name, func(t *testing.T) {
-			frames, err := runQuery(context.Background(), makeMockedAPI(400, test.contentType, test.body, nil, false), &lokiQuery{QueryType: QueryTypeRange, Direction: DirectionBackward}, ResponseOpts{}, log.New("test"))
+			dr, err := runQuery(context.Background(), makeMockedAPI(400, test.contentType, test.body, nil, false), &lokiQuery{QueryType: QueryTypeRange, Direction: DirectionBackward}, ResponseOpts{}, log.New("test"))
+			require.NoError(t, err)
+			require.Len(t, dr.Frames, 0)
+			require.Equal(t, dr.Error.Error(), test.errorMessage)
+			require.Equal(t, dr.ErrorSource, backend.ErrorSourceDownstream)
+		})
+	}
+}
 
-			require.Len(t, frames, 0)
-			require.Error(t, err)
-			require.EqualError(t, err, test.errorMessage)
+func TestErrorsFromResponseCodes(t *testing.T) {
+	tt := []struct {
+		name        string
+		statusCode  int
+		errorSource backend.ErrorSource
+	}{
+		{
+			name:        "parse response with status code 400 into correct error",
+			statusCode:  400,
+			errorSource: backend.ErrorSourceDownstream,
+		},
+		{
+			name:        "parse response with status code 406 into correct error",
+			statusCode:  406,
+			errorSource: backend.ErrorSourcePlugin,
+		},
+		{
+			name:        "parse response with status code 413 into correct error",
+			statusCode:  413,
+			errorSource: backend.ErrorSourcePlugin,
+		},
+		{
+			name:        "parse response with status code 500 into correct error",
+			statusCode:  500,
+			errorSource: backend.ErrorSourceDownstream,
+		},
+		{
+			name:        "parse response with status code 501 into correct error",
+			statusCode:  501,
+			errorSource: backend.ErrorSourcePlugin,
+		},
+	}
+
+	errorString := "parse error at line 1, col 8: something is wrong"
+	contentType := "application/json; charset=UTF-8"
+
+	for _, test := range tt {
+		t.Run(test.name, func(t *testing.T) {
+			dr, _ := runQuery(context.Background(), makeMockedAPI(test.statusCode, contentType, []byte(errorString), nil, false), &lokiQuery{QueryType: QueryTypeRange, Direction: DirectionBackward}, ResponseOpts{}, log.New("test"))
+			require.Len(t, dr.Frames, 0)
+			require.Equal(t, dr.Error.Error(), errorString)
+			require.Equal(t, dr.ErrorSource, test.errorSource)
 		})
 	}
 }


### PR DESCRIPTION
This pull request introduces an error source for the Loki data source. Initially, we attempted to implement it through the error source middleware, but encountered issues, resulting in the removal of valuable error messages from Loki, such as details about incorrect query syntax. As a result, this modification was rolled back in https://github.com/grafana/grafana/pull/78006.

To address this, we have employed a comparable or identical logic to the error source middleware, which can be found at https://github.com/grafana/grafana-plugin-sdk-go/blob/main/experimental/errorsource/error_source_middleware.go. This logic has been directly implemented in Loki.

To test this PR:

1. Before running Loki, attempt to query a non-running Loki instance. You should encounter an error similar to `Get "http://localhost:3100/loki/api/v1/query_range?direction=backward&end=1704719281458000000&limit=1000&query=%7Bage%3D%22new%22%7D+blabla&start=1704697681458000000&step=10000ms": dial tcp 127.0.0.1:3100: connect: connection refused`.
<img width="1888" alt="image" src="https://github.com/grafana/grafana/assets/30407135/ebadb792-22e2-4699-8870-c2349293948c">

2. Run Loki using `make devenv sources=loki` and verify that with the correct query `{age="new}`, you receive results.

3. Write an invalid query `{age="new} blabla` and observe that you can see an error similar to `parse error at line 1, col 13: syntax error: unexpected IDENTIFIER`.

<img width="1913" alt="image" src="https://github.com/grafana/grafana/assets/30407135/bb59a41d-082c-4edc-835c-c1750c4f613b">
