### PR TITLE
Loki Query Builder: Add parsing support for aggregations with grouping

### DIFF
--- a/public/app/plugins/datasource/loki/querybuilder/parsing.test.ts
+++ b/public/app/plugins/datasource/loki/querybuilder/parsing.test.ts
@@ -673,6 +673,21 @@ describe('buildVisualQueryFromString', () => {
     );
   });
 
+  it('parses quantile queries with grouping', () => {
+    expect(buildVisualQueryFromString(`quantile_over_time(0.99, {app="frontend"} [1m]) by (host1, host2)`)).toEqual(
+      noErrors({
+        labels: [
+          {
+            op: '=',
+            value: 'frontend',
+            label: 'app',
+          },
+        ],
+        operations: [{ id: LokiOperationId.QuantileOverTime, params: ['1m', '0.99', 'host1', 'host2'] }],
+      })
+    );
+  });
+
   it('parses query with line format', () => {
     expect(buildVisualQueryFromString('{app="frontend"} | line_format "abc"')).toEqual(
       noErrors({

--- a/public/app/plugins/datasource/loki/querybuilder/parsing.ts
+++ b/public/app/plugins/datasource/loki/querybuilder/parsing.ts
@@ -501,9 +501,14 @@ function handleRangeAggregation(expr: string, node: SyntaxNode, context: Context
   const params = number !== null && number !== undefined ? [getString(expr, number)] : [];
   const range = logExpr?.getChild(Range);
   const rangeValue = range ? getString(expr, range) : null;
+  const grouping = node.getChild(Grouping);
 
   if (rangeValue) {
     params.unshift(rangeValue.substring(1, rangeValue.length - 1));
+  }
+
+  if (grouping) {
+    params.push(...getAllByType(expr, grouping, Identifier));
   }
 
   const op = {


### PR DESCRIPTION
This PR adds parsing support for aggregations with grouping.

**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/grafana/issues/79194

**Special notes for your reviewer:**

Please check that:
- Queries are correctly parsed.
- Going back and forth between code and builder produces the same query without losing part of it.
