### PR TITLE
[v10.2.x] Auth: Use cfg.Raw in OAuthStrategy for loading settings

### DIFF
--- a/pkg/services/ssosettings/strategies/oauth_strategy.go
+++ b/pkg/services/ssosettings/strategies/oauth_strategy.go
@@ -56,7 +56,7 @@ func (s *OAuthStrategy) loadAllSettings() {
 }
 
 func (s *OAuthStrategy) loadSettingsForProvider(provider string) *social.OAuthInfo {
-	section := s.cfg.SectionWithEnvOverrides("auth." + provider)
+	section := s.cfg.Raw.Section("auth." + provider)
 
 	result := &social.OAuthInfo{
 		AllowAssignGrafanaAdmin: section.Key("allow_assign_grafana_admin").MustBool(false),

--- a/pkg/services/ssosettings/strategies/oauth_strategy_test.go
+++ b/pkg/services/ssosettings/strategies/oauth_strategy_test.go
@@ -97,22 +97,7 @@ var (
 	}
 )
 
-func TestGetProviderConfig_EnvVarsOnly(t *testing.T) {
-	setupEnvVars(t)
-
-	cfg := setting.NewCfg()
-	strategy := NewOAuthStrategy(cfg)
-
-	result, err := strategy.GetProviderConfig(context.Background(), "generic_oauth")
-	require.NoError(t, err)
-
-	oauthInfo, ok := result.(*social.OAuthInfo)
-	require.True(t, ok)
-
-	require.Equal(t, expectedOAuthInfo, oauthInfo)
-}
-
-func TestGetProviderConfig_IniFileOnly(t *testing.T) {
+func TestGetProviderConfig(t *testing.T) {
 	iniFile, err := ini.Load([]byte(iniContent))
 	require.NoError(t, err)
 
@@ -128,69 +113,4 @@ func TestGetProviderConfig_IniFileOnly(t *testing.T) {
 	require.True(t, ok)
 
 	require.Equal(t, expectedOAuthInfo, oauthInfo)
-}
-
-func TestGetProviderConfig_EnvVarsOverrideIniFileSettings(t *testing.T) {
-	t.Setenv("GF_AUTH_GENERIC_OAUTH_ENABLED", "false")
-	t.Setenv("GF_AUTH_GENERIC_OAUTH_SKIP_ORG_ROLE_SYNC", "false")
-
-	iniFile, err := ini.Load([]byte(iniContent))
-	require.NoError(t, err)
-
-	cfg := setting.NewCfg()
-	cfg.Raw = iniFile
-
-	strategy := NewOAuthStrategy(cfg)
-
-	result, err := strategy.GetProviderConfig(context.Background(), "generic_oauth")
-	require.NoError(t, err)
-
-	oauthInfo, ok := result.(*social.OAuthInfo)
-	require.True(t, ok)
-
-	expectedOAuthInfoWithOverrides := *expectedOAuthInfo
-	expectedOAuthInfoWithOverrides.Enabled = false
-	expectedOAuthInfoWithOverrides.SkipOrgRoleSync = false
-
-	require.Equal(t, expectedOAuthInfoWithOverrides, *oauthInfo)
-}
-
-func setupEnvVars(t *testing.T) {
-	t.Setenv("GF_AUTH_GENERIC_OAUTH_NAME", "OAuth")
-	t.Setenv("GF_AUTH_GENERIC_OAUTH_ICON", "signin")
-	t.Setenv("GF_AUTH_GENERIC_OAUTH_ENABLED", "true")
-	t.Setenv("GF_AUTH_GENERIC_OAUTH_ALLOW_SIGN_UP", "false")
-	t.Setenv("GF_AUTH_GENERIC_OAUTH_AUTO_LOGIN", "true")
-	t.Setenv("GF_AUTH_GENERIC_OAUTH_CLIENT_ID", "test_client_id")
-	t.Setenv("GF_AUTH_GENERIC_OAUTH_CLIENT_SECRET", "test_client_secret")
-	t.Setenv("GF_AUTH_GENERIC_OAUTH_SCOPES", `["openid", "profile", "email"]`)
-	t.Setenv("GF_AUTH_GENERIC_OAUTH_EMPTY_SCOPES", "")
-	t.Setenv("GF_AUTH_GENERIC_OAUTH_EMAIL_ATTRIBUTE_NAME", "email:primary")
-	t.Setenv("GF_AUTH_GENERIC_OAUTH_EMAIL_ATTRIBUTE_PATH", "email")
-	t.Setenv("GF_AUTH_GENERIC_OAUTH_ROLE_ATTRIBUTE_PATH", "role")
-	t.Setenv("GF_AUTH_GENERIC_OAUTH_ROLE_ATTRIBUTE_STRICT", "true")
-	t.Setenv("GF_AUTH_GENERIC_OAUTH_GROUPS_ATTRIBUTE_PATH", "groups")
-	t.Setenv("GF_AUTH_GENERIC_OAUTH_TEAM_IDS_ATTRIBUTE_PATH", "team_ids")
-	t.Setenv("GF_AUTH_GENERIC_OAUTH_AUTH_URL", "test_auth_url")
-	t.Setenv("GF_AUTH_GENERIC_OAUTH_TOKEN_URL", "test_token_url")
-	t.Setenv("GF_AUTH_GENERIC_OAUTH_API_URL", "test_api_url")
-	t.Setenv("GF_AUTH_GENERIC_OAUTH_TEAMS_URL", "test_teams_url")
-	t.Setenv("GF_AUTH_GENERIC_OAUTH_ALLOWED_DOMAINS", "domain1.com")
-	t.Setenv("GF_AUTH_GENERIC_OAUTH_ALLOWED_GROUPS", "")
-	t.Setenv("GF_AUTH_GENERIC_OAUTH_TLS_SKIP_VERIFY_INSECURE", "true")
-	t.Setenv("GF_AUTH_GENERIC_OAUTH_TLS_CLIENT_CERT", "")
-	t.Setenv("GF_AUTH_GENERIC_OAUTH_TLS_CLIENT_KEY", "")
-	t.Setenv("GF_AUTH_GENERIC_OAUTH_TLS_CLIENT_CA", "")
-	t.Setenv("GF_AUTH_GENERIC_OAUTH_USE_PKCE", "false")
-	t.Setenv("GF_AUTH_GENERIC_OAUTH_AUTH_STYLE", "inheader")
-	t.Setenv("GF_AUTH_GENERIC_OAUTH_ALLOW_ASSIGN_GRAFANA_ADMIN", "true")
-	t.Setenv("GF_AUTH_GENERIC_OAUTH_SKIP_ORG_ROLE_SYNC", "true")
-	t.Setenv("GF_AUTH_GENERIC_OAUTH_USE_REFRESH_TOKEN", "true")
-	t.Setenv("GF_AUTH_GENERIC_OAUTH_HOSTED_DOMAIN", "test_hosted_domain")
-	t.Setenv("GF_AUTH_GENERIC_OAUTH_ALLOWED_ORGANIZATIONS", "org1, org2")
-	t.Setenv("GF_AUTH_GENERIC_OAUTH_ID_TOKEN_ATTRIBUTE_NAME", "id_token")
-	t.Setenv("GF_AUTH_GENERIC_OAUTH_LOGIN_ATTRIBUTE_PATH", "login")
-	t.Setenv("GF_AUTH_GENERIC_OAUTH_NAME_ATTRIBUTE_PATH", "name")
-	t.Setenv("GF_AUTH_GENERIC_OAUTH_TEAM_IDS", "first, second")
-	t.Setenv("GF_AUTH_GENERIC_OAUTH_SIGNOUT_REDIRECT_URL", "test_signout_redirect_url")
 }

--- a/pkg/setting/setting_test.go
+++ b/pkg/setting/setting_test.go
@@ -75,6 +75,19 @@ func TestLoadingSettings(t *testing.T) {
 		require.Equal(t, filepath.Join(cfg.DataPath, "log"), cfg.LogsPath)
 	})
 
+	t.Run("Should be able to expand parameter from environment variables", func(t *testing.T) {
+		t.Setenv("DEFAULT_IDP_URL", "grafana.com")
+		t.Setenv("GF_AUTH_GENERIC_OAUTH_AUTH_URL", "${DEFAULT_IDP_URL}/auth")
+
+		cfg := NewCfg()
+		err := cfg.Load(CommandLineArgs{HomePath: "../../"})
+		require.Nil(t, err)
+
+		genericOAuthSection, err := cfg.Raw.GetSection("auth.generic_oauth")
+		require.NoError(t, err)
+		require.Equal(t, "grafana.com/auth", genericOAuthSection.Key("auth_url").Value())
+	})
+
 	t.Run("Should replace password when defined in environment", func(t *testing.T) {
 		t.Setenv("GF_SECURITY_ADMIN_PASSWORD", "supersecret")
 


### PR DESCRIPTION
Backport eae6adf0029328bcd3a9ce9fec29932c5511459c from #80136

---

**What is this feature?**

Use `cfg.Raw.Section` instead of `cfg.SectionWithEnvOverrides` in the OAuthStrategy for loading SSO settings from ini/env variables.

**Why do we need this feature?**

1. `DynamicSection` (returned by `SectionWithEnvOverrides`) doesn't support parameter expansion
2. Settings service handles config overrides (by command-line or by environment variable) and it handles parameter expansion (everything will be in the `cfg.Raw` variable)
3. OAuthStrategy loads the configuration once, during the startup anyway so this change won't affect that behaviour

**Who is this feature for?**


**Which issue(s) does this PR fix?**:

Fixes #

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
