### PR TITLE
Plugins: Only set plugin sub path config when Grafana is actually serving from sub path

### DIFF
--- a/pkg/services/pluginsintegration/config/config.go
+++ b/pkg/services/pluginsintegration/config/config.go
@@ -27,6 +27,12 @@ func ProvideConfig(settingProvider setting.Provider, grafanaCfg *setting.Cfg, fe
 		return nil, fmt.Errorf("new opentelemetry cfg: %w", err)
 	}
 
+	// We only want to set the appSubURL if we are actually serving requests from a sub path
+	var appSubURL string
+	if grafanaCfg.ServeFromSubPath {
+		appSubURL = grafanaCfg.AppSubURL
+	}
+
 	return pCfg.NewCfg(
 		settingProvider.KeyValue("", "app_mode").MustBool(grafanaCfg.Env == setting.Dev),
 		grafanaCfg.PluginsPath,
@@ -41,7 +47,7 @@ func ProvideConfig(settingProvider setting.Provider, grafanaCfg *setting.Cfg, fe
 		grafanaCfg.PluginLogBackendRequests,
 		grafanaCfg.PluginsCDNURLTemplate,
 		grafanaCfg.AppURL,
-		grafanaCfg.AppSubURL,
+		appSubURL,
 		tracingCfg,
 		features,
 		grafanaCfg.AngularSupportEnabled,


### PR DESCRIPTION
**What is this feature?**

Makes sure we only set the sub path of plugin asset links (base URL, module URL, images, etc.) when Grafana is serving requests from a sub path (which is based on [this config](https://grafana.com/docs/grafana/latest/setup-grafana/configure-grafana/#serve_from_sub_path))

**Why do we need this feature?**

Fixes a bug with instances where Grafana requests are served from a sub path.

**Who is this feature for?**

Plugins Platform.

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes https://github.com/grafana/grafana/issues/76180

<!--
**Special notes for your reviewer:**
-->

Please check that:
- [X] It works as expected from a user's perspective.
- [X] If this is a pre-GA feature, it is behind a feature toggle.
- [X] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
