### PR TITLE
ngalert openapi: Fix mutetimings definitions

### DIFF
--- a/pkg/services/ngalert/api/compat.go
+++ b/pkg/services/ngalert/api/compat.go
@@ -363,8 +363,8 @@ func MuteTimeIntervalExportFromMuteTiming(orgID int64, m definitions.MuteTimeInt
 }
 
 // Converts definitions.MuteTimeIntervalExport to definitions.MuteTimeIntervalExportHcl using JSON marshalling. Returns error if structure could not be marshalled\unmarshalled
-func MuteTimingIntervalToMuteTimeIntervalHclExport(m definitions.MuteTimeIntervalExport) (definitions.MuteTimeIntervalExportHcl, error) {
-	result := definitions.MuteTimeIntervalExportHcl{}
+func MuteTimingIntervalToMuteTimeIntervalHclExport(m definitions.MuteTimeIntervalExport) (definitions.MuteTimeIntervalModel, error) {
+	result := definitions.MuteTimeIntervalModel{}
 	j := jsoniter.ConfigCompatibleWithStandardLibrary
 	mdata, err := j.Marshal(m)
 	if err != nil {

--- a/pkg/services/ngalert/api/tooling/Makefile
+++ b/pkg/services/ngalert/api/tooling/Makefile
@@ -58,6 +58,7 @@ fix:
 	sed $(SED_INPLACE) -e 's/apimodels\.\[\]PostableAlert/apimodels.PostableAlerts/' $(GENERATED_GO_MATCHERS)
 	sed $(SED_INPLACE) -e 's/apimodels\.\[\]UpdateDashboardACLCommand/apimodels.Permissions/' $(GENERATED_GO_MATCHERS)
 	sed $(SED_INPLACE) -e 's/apimodels\.\[\]PostableApiReceiver/apimodels.TestReceiversConfigParams/' $(GENERATED_GO_MATCHERS)
+	sed $(SED_INPLACE) -e 's/apimodels\.MuteTimeIntervalApiModel/apimodels.MuteTimeInterval/' $(GENERATED_GO_MATCHERS)
 	goimports -w -v $(GENERATED_GO_MATCHERS)
 
 clean:

--- a/pkg/services/ngalert/api/tooling/api.json
+++ b/pkg/services/ngalert/api/tooling/api.json
@@ -2058,6 +2058,24 @@
    "title": "MuteTimeInterval represents a named set of time intervals for which a route should be muted.",
    "type": "object"
   },
+  "MuteTimeIntervalAPIModel": {
+   "description": "MuteTimeIntervalAPIModel is a serialized representation of the MuteTimeInterval struct, as returned by the API",
+   "properties": {
+    "name": {
+     "type": "string"
+    },
+    "provenance": {
+     "$ref": "#/definitions/Provenance"
+    },
+    "time_intervals": {
+     "items": {
+      "$ref": "#/definitions/TimeIntervalModel"
+     },
+     "type": "array"
+    }
+   },
+   "type": "object"
+  },
   "MuteTimeIntervalExport": {
    "properties": {
     "name": {
@@ -2076,9 +2094,24 @@
    },
    "type": "object"
   },
-  "MuteTimings": {
+  "MuteTimeIntervalModel": {
+   "description": "MuteTimeIntervalModel is a serialized representation of the MuteTimeInterval struct",
+   "properties": {
+    "name": {
+     "type": "string"
+    },
+    "time_intervals": {
+     "items": {
+      "$ref": "#/definitions/TimeIntervalModel"
+     },
+     "type": "array"
+    }
+   },
+   "type": "object"
+  },
+  "MuteTimingsAPIModel": {
    "items": {
-    "$ref": "#/definitions/MuteTimeInterval"
+    "$ref": "#/definitions/MuteTimeIntervalAPIModel"
    },
    "type": "array"
   },
@@ -4149,6 +4182,45 @@
    },
    "type": "object"
   },
+  "TimeIntervalModel": {
+   "description": "TimeIntervalModel is a serialized representation of the timeinterval.TimeInterval struct",
+   "properties": {
+    "days_of_month": {
+     "items": {
+      "type": "string"
+     },
+     "type": "array"
+    },
+    "location": {
+     "type": "string"
+    },
+    "months": {
+     "items": {
+      "type": "string"
+     },
+     "type": "array"
+    },
+    "times": {
+     "items": {
+      "$ref": "#/definitions/TimeRangeModel"
+     },
+     "type": "array"
+    },
+    "weekdays": {
+     "items": {
+      "type": "string"
+     },
+     "type": "array"
+    },
+    "years": {
+     "items": {
+      "type": "string"
+     },
+     "type": "array"
+    }
+   },
+   "type": "object"
+  },
   "TimeRange": {
    "description": "Redefining this to avoid an import cycle",
    "properties": {
@@ -4158,6 +4230,18 @@
     },
     "to": {
      "format": "date-time",
+     "type": "string"
+    }
+   },
+   "type": "object"
+  },
+  "TimeRangeModel": {
+   "description": "TimeRangeModel is a serialize representation of the timeinterval.TimeRange struct",
+   "properties": {
+    "end_time": {
+     "type": "string"
+    },
+    "start_time": {
      "type": "string"
     }
    },
@@ -4405,6 +4489,7 @@
    "type": "object"
   },
   "alertGroup": {
+   "description": "AlertGroup alert group",
    "properties": {
     "alerts": {
      "description": "alerts",
@@ -4595,6 +4680,7 @@
    "type": "array"
   },
   "gettableSilence": {
+   "description": "GettableSilence gettable silence",
    "properties": {
     "comment": {
      "description": "comment",
@@ -4793,6 +4879,7 @@
    "type": "array"
   },
   "postableSilence": {
+   "description": "PostableSilence postable silence",
    "properties": {
     "comment": {
      "description": "comment",
@@ -5537,9 +5624,9 @@
     "operationId": "RouteGetMuteTimings",
     "responses": {
      "200": {
-      "description": "MuteTimings",
+      "description": "MuteTimingsAPIModel",
       "schema": {
-       "$ref": "#/definitions/MuteTimings"
+       "$ref": "#/definitions/MuteTimingsAPIModel"
       }
      }
     },
@@ -5558,7 +5645,7 @@
       "in": "body",
       "name": "Body",
       "schema": {
-       "$ref": "#/definitions/MuteTimeInterval"
+       "$ref": "#/definitions/MuteTimeIntervalAPIModel"
       }
      },
      {
@@ -5569,9 +5656,9 @@
     ],
     "responses": {
      "201": {
-      "description": "MuteTimeInterval",
+      "description": "MuteTimeIntervalAPIModel",
       "schema": {
-       "$ref": "#/definitions/MuteTimeInterval"
+       "$ref": "#/definitions/MuteTimeIntervalAPIModel"
       }
      },
      "400": {
@@ -5661,9 +5748,9 @@
     ],
     "responses": {
      "200": {
-      "description": "MuteTimeInterval",
+      "description": "MuteTimeIntervalAPIModel",
       "schema": {
-       "$ref": "#/definitions/MuteTimeInterval"
+       "$ref": "#/definitions/MuteTimeIntervalAPIModel"
       }
      },
      "404": {
@@ -5692,7 +5779,7 @@
       "in": "body",
       "name": "Body",
       "schema": {
-       "$ref": "#/definitions/MuteTimeInterval"
+       "$ref": "#/definitions/MuteTimeIntervalAPIModel"
       }
      },
      {
@@ -5703,9 +5790,9 @@
     ],
     "responses": {
      "200": {
-      "description": "MuteTimeInterval",
+      "description": "MuteTimeIntervalAPIModel",
       "schema": {
-       "$ref": "#/definitions/MuteTimeInterval"
+       "$ref": "#/definitions/MuteTimeIntervalAPIModel"
       }
      },
      "400": {

--- a/pkg/services/ngalert/api/tooling/definitions/provisioning_mute_timings.go
+++ b/pkg/services/ngalert/api/tooling/definitions/provisioning_mute_timings.go
@@ -9,7 +9,7 @@ import (
 // Get all the mute timings.
 //
 //     Responses:
-//       200: MuteTimings
+//       200: MuteTimingsAPIModel
 
 // swagger:route GET /api/v1/provisioning/mute-timings/export provisioning stable RouteExportMuteTimings
 //
@@ -24,7 +24,7 @@ import (
 // Get a mute timing.
 //
 //     Responses:
-//       200: MuteTimeInterval
+//       200: MuteTimeIntervalAPIModel
 //       404: description: Not found.
 
 // swagger:route GET /api/v1/provisioning/mute-timings/{name}/export provisioning stable RouteExportMuteTiming
@@ -43,7 +43,7 @@ import (
 //     - application/json
 //
 //     Responses:
-//       201: MuteTimeInterval
+//       201: MuteTimeIntervalAPIModel
 //       400: ValidationError
 
 // swagger:route PUT /api/v1/provisioning/mute-timings/{name} provisioning stable RoutePutMuteTiming
@@ -54,7 +54,7 @@ import (
 //     - application/json
 //
 //     Responses:
-//       200: MuteTimeInterval
+//       200: MuteTimeIntervalAPIModel
 //       400: ValidationError
 
 // swagger:route DELETE /api/v1/provisioning/mute-timings/{name} provisioning stable RouteDeleteMuteTiming
@@ -64,9 +64,6 @@ import (
 //     Responses:
 //       204: description: The mute timing was deleted successfully.
 
-// swagger:route
-
-// swagger:model
 type MuteTimings []MuteTimeInterval
 
 // swagger:parameters RouteGetTemplate RouteGetMuteTiming RoutePutMuteTiming stable RouteDeleteMuteTiming RouteExportMuteTiming
@@ -79,7 +76,7 @@ type RouteGetMuteTimingParam struct {
 // swagger:parameters RoutePostMuteTiming RoutePutMuteTiming
 type MuteTimingPayload struct {
 	// in:body
-	Body MuteTimeInterval
+	Body MuteTimeIntervalAPIModel
 }
 
 // swagger:parameters RoutePostMuteTiming RoutePutMuteTiming
@@ -88,7 +85,6 @@ type MuteTimingHeaders struct {
 	XDisableProvenance string `json:"X-Disable-Provenance"`
 }
 
-// swagger:model
 type MuteTimeInterval struct {
 	config.MuteTimeInterval `json:",inline" yaml:",inline"`
 	Provenance              Provenance `json:"provenance,omitempty"`
@@ -107,24 +103,34 @@ type MuteTimeIntervalExport struct {
 	config.MuteTimeInterval `json:",inline" yaml:",inline"`
 }
 
-// MuteTimeIntervalExportHcl is a representation of the MuteTimeInterval in HCL
-type MuteTimeIntervalExportHcl struct {
-	Name          string                  `json:"name" hcl:"name"`
-	TimeIntervals []TimeIntervalExportHcl `json:"time_intervals" hcl:"intervals,block"`
+// MuteTimeIntervalAPIModel is a serialized representation of the MuteTimeInterval struct, as returned by the API
+// swagger:model
+type MuteTimeIntervalAPIModel struct {
+	MuteTimeIntervalModel
+	Provenance Provenance `json:"provenance,omitempty"` // TODO: This is never populated on GETs
 }
 
-// TimeIntervalExportHcl is a representation of the timeinterval.TimeInterval in HCL
-type TimeIntervalExportHcl struct {
-	Times       []TimeRangeExportHcl `json:"times,omitempty" hcl:"times,block"`
-	Weekdays    *[]string            `json:"weekdays,omitempty" hcl:"weekdays"`
-	DaysOfMonth *[]string            `json:"days_of_month,omitempty" hcl:"days_of_month"`
-	Months      *[]string            `json:"months,omitempty" hcl:"months"`
-	Years       *[]string            `json:"years,omitempty" hcl:"years"`
-	Location    *string              `json:"location,omitempty" hcl:"location"`
+// swagger:model
+type MuteTimingsAPIModel []MuteTimeIntervalAPIModel
+
+// MuteTimeIntervalModel is a serialized representation of the MuteTimeInterval struct
+type MuteTimeIntervalModel struct {
+	Name          string              `json:"name" hcl:"name"`
+	TimeIntervals []TimeIntervalModel `json:"time_intervals" hcl:"intervals,block"`
 }
 
-// TimeRangeExportHcl is a representation of the timeinterval.TimeRange in HCL
-type TimeRangeExportHcl struct {
+// TimeIntervalModel is a serialized representation of the timeinterval.TimeInterval struct
+type TimeIntervalModel struct {
+	Times       []TimeRangeModel `json:"times,omitempty" hcl:"times,block"`
+	Weekdays    *[]string        `json:"weekdays,omitempty" hcl:"weekdays"`
+	DaysOfMonth *[]string        `json:"days_of_month,omitempty" hcl:"days_of_month"`
+	Months      *[]string        `json:"months,omitempty" hcl:"months"`
+	Years       *[]string        `json:"years,omitempty" hcl:"years"`
+	Location    *string          `json:"location,omitempty" hcl:"location"`
+}
+
+// TimeRangeModel is a serialize representation of the timeinterval.TimeRange struct
+type TimeRangeModel struct {
 	StartMinute string `json:"start_time" hcl:"start"`
 	EndMinute   string `json:"end_time" hcl:"end"`
 }

--- a/pkg/services/ngalert/api/tooling/post.json
+++ b/pkg/services/ngalert/api/tooling/post.json
@@ -2058,6 +2058,24 @@
    "title": "MuteTimeInterval represents a named set of time intervals for which a route should be muted.",
    "type": "object"
   },
+  "MuteTimeIntervalAPIModel": {
+   "description": "MuteTimeIntervalAPIModel is a serialized representation of the MuteTimeInterval struct, as returned by the API",
+   "properties": {
+    "name": {
+     "type": "string"
+    },
+    "provenance": {
+     "$ref": "#/definitions/Provenance"
+    },
+    "time_intervals": {
+     "items": {
+      "$ref": "#/definitions/TimeIntervalModel"
+     },
+     "type": "array"
+    }
+   },
+   "type": "object"
+  },
   "MuteTimeIntervalExport": {
    "properties": {
     "name": {
@@ -2076,9 +2094,24 @@
    },
    "type": "object"
   },
-  "MuteTimings": {
+  "MuteTimeIntervalModel": {
+   "description": "MuteTimeIntervalModel is a serialized representation of the MuteTimeInterval struct",
+   "properties": {
+    "name": {
+     "type": "string"
+    },
+    "time_intervals": {
+     "items": {
+      "$ref": "#/definitions/TimeIntervalModel"
+     },
+     "type": "array"
+    }
+   },
+   "type": "object"
+  },
+  "MuteTimingsAPIModel": {
    "items": {
-    "$ref": "#/definitions/MuteTimeInterval"
+    "$ref": "#/definitions/MuteTimeIntervalAPIModel"
    },
    "type": "array"
   },
@@ -4149,6 +4182,45 @@
    },
    "type": "object"
   },
+  "TimeIntervalModel": {
+   "description": "TimeIntervalModel is a serialized representation of the timeinterval.TimeInterval struct",
+   "properties": {
+    "days_of_month": {
+     "items": {
+      "type": "string"
+     },
+     "type": "array"
+    },
+    "location": {
+     "type": "string"
+    },
+    "months": {
+     "items": {
+      "type": "string"
+     },
+     "type": "array"
+    },
+    "times": {
+     "items": {
+      "$ref": "#/definitions/TimeRangeModel"
+     },
+     "type": "array"
+    },
+    "weekdays": {
+     "items": {
+      "type": "string"
+     },
+     "type": "array"
+    },
+    "years": {
+     "items": {
+      "type": "string"
+     },
+     "type": "array"
+    }
+   },
+   "type": "object"
+  },
   "TimeRange": {
    "description": "Redefining this to avoid an import cycle",
    "properties": {
@@ -4158,6 +4230,18 @@
     },
     "to": {
      "format": "date-time",
+     "type": "string"
+    }
+   },
+   "type": "object"
+  },
+  "TimeRangeModel": {
+   "description": "TimeRangeModel is a serialize representation of the timeinterval.TimeRange struct",
+   "properties": {
+    "end_time": {
+     "type": "string"
+    },
+    "start_time": {
      "type": "string"
     }
    },
@@ -4405,7 +4489,6 @@
    "type": "object"
   },
   "alertGroup": {
-   "description": "AlertGroup alert group",
    "properties": {
     "alerts": {
      "description": "alerts",
@@ -4534,7 +4617,6 @@
    "type": "object"
   },
   "gettableAlert": {
-   "description": "GettableAlert gettable alert",
    "properties": {
     "annotations": {
      "$ref": "#/definitions/labelSet"
@@ -4590,6 +4672,7 @@
    "type": "object"
   },
   "gettableAlerts": {
+   "description": "GettableAlerts gettable alerts",
    "items": {
     "$ref": "#/definitions/gettableAlert"
    },
@@ -4652,7 +4735,6 @@
    "type": "array"
   },
   "integration": {
-   "description": "Integration integration",
    "properties": {
     "lastNotifyAttempt": {
      "description": "A timestamp indicating the last attempt to deliver a notification regardless of the outcome.\nFormat: date-time",
@@ -4796,6 +4878,7 @@
    "type": "array"
   },
   "postableSilence": {
+   "description": "PostableSilence postable silence",
    "properties": {
     "comment": {
      "description": "comment",
@@ -7520,9 +7603,9 @@
     "operationId": "RouteGetMuteTimings",
     "responses": {
      "200": {
-      "description": "MuteTimings",
+      "description": "MuteTimingsAPIModel",
       "schema": {
-       "$ref": "#/definitions/MuteTimings"
+       "$ref": "#/definitions/MuteTimingsAPIModel"
       }
      }
     },
@@ -7541,7 +7624,7 @@
       "in": "body",
       "name": "Body",
       "schema": {
-       "$ref": "#/definitions/MuteTimeInterval"
+       "$ref": "#/definitions/MuteTimeIntervalAPIModel"
       }
      },
      {
@@ -7552,9 +7635,9 @@
     ],
     "responses": {
      "201": {
-      "description": "MuteTimeInterval",
+      "description": "MuteTimeIntervalAPIModel",
       "schema": {
-       "$ref": "#/definitions/MuteTimeInterval"
+       "$ref": "#/definitions/MuteTimeIntervalAPIModel"
       }
      },
      "400": {
@@ -7644,9 +7727,9 @@
     ],
     "responses": {
      "200": {
-      "description": "MuteTimeInterval",
+      "description": "MuteTimeIntervalAPIModel",
       "schema": {
-       "$ref": "#/definitions/MuteTimeInterval"
+       "$ref": "#/definitions/MuteTimeIntervalAPIModel"
       }
      },
      "404": {
@@ -7675,7 +7758,7 @@
       "in": "body",
       "name": "Body",
       "schema": {
-       "$ref": "#/definitions/MuteTimeInterval"
+       "$ref": "#/definitions/MuteTimeIntervalAPIModel"
       }
      },
      {
@@ -7686,9 +7769,9 @@
     ],
     "responses": {
      "200": {
-      "description": "MuteTimeInterval",
+      "description": "MuteTimeIntervalAPIModel",
       "schema": {
-       "$ref": "#/definitions/MuteTimeInterval"
+       "$ref": "#/definitions/MuteTimeIntervalAPIModel"
       }
      },
      "400": {

--- a/pkg/services/ngalert/api/tooling/spec.json
+++ b/pkg/services/ngalert/api/tooling/spec.json
@@ -2604,9 +2604,9 @@
         "operationId": "RouteGetMuteTimings",
         "responses": {
           "200": {
-            "description": "MuteTimings",
+            "description": "MuteTimingsAPIModel",
             "schema": {
-              "$ref": "#/definitions/MuteTimings"
+              "$ref": "#/definitions/MuteTimingsAPIModel"
             }
           }
         }
@@ -2626,7 +2626,7 @@
             "name": "Body",
             "in": "body",
             "schema": {
-              "$ref": "#/definitions/MuteTimeInterval"
+              "$ref": "#/definitions/MuteTimeIntervalAPIModel"
             }
           },
           {
@@ -2637,9 +2637,9 @@
         ],
         "responses": {
           "201": {
-            "description": "MuteTimeInterval",
+            "description": "MuteTimeIntervalAPIModel",
             "schema": {
-              "$ref": "#/definitions/MuteTimeInterval"
+              "$ref": "#/definitions/MuteTimeIntervalAPIModel"
             }
           },
           "400": {
@@ -2710,9 +2710,9 @@
         ],
         "responses": {
           "200": {
-            "description": "MuteTimeInterval",
+            "description": "MuteTimeIntervalAPIModel",
             "schema": {
-              "$ref": "#/definitions/MuteTimeInterval"
+              "$ref": "#/definitions/MuteTimeIntervalAPIModel"
             }
           },
           "404": {
@@ -2742,7 +2742,7 @@
             "name": "Body",
             "in": "body",
             "schema": {
-              "$ref": "#/definitions/MuteTimeInterval"
+              "$ref": "#/definitions/MuteTimeIntervalAPIModel"
             }
           },
           {
@@ -2753,9 +2753,9 @@
         ],
         "responses": {
           "200": {
-            "description": "MuteTimeInterval",
+            "description": "MuteTimeIntervalAPIModel",
             "schema": {
-              "$ref": "#/definitions/MuteTimeInterval"
+              "$ref": "#/definitions/MuteTimeIntervalAPIModel"
             }
           },
           "400": {
@@ -5466,6 +5466,24 @@
         }
       }
     },
+    "MuteTimeIntervalAPIModel": {
+      "description": "MuteTimeIntervalAPIModel is a serialized representation of the MuteTimeInterval struct, as returned by the API",
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "provenance": {
+          "$ref": "#/definitions/Provenance"
+        },
+        "time_intervals": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/TimeIntervalModel"
+          }
+        }
+      }
+    },
     "MuteTimeIntervalExport": {
       "type": "object",
       "properties": {
@@ -5484,10 +5502,25 @@
         }
       }
     },
-    "MuteTimings": {
+    "MuteTimeIntervalModel": {
+      "description": "MuteTimeIntervalModel is a serialized representation of the MuteTimeInterval struct",
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "time_intervals": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/TimeIntervalModel"
+          }
+        }
+      }
+    },
+    "MuteTimingsAPIModel": {
       "type": "array",
       "items": {
-        "$ref": "#/definitions/MuteTimeInterval"
+        "$ref": "#/definitions/MuteTimeIntervalAPIModel"
       }
     },
     "NamespaceConfigResponse": {
@@ -7557,6 +7590,45 @@
         }
       }
     },
+    "TimeIntervalModel": {
+      "description": "TimeIntervalModel is a serialized representation of the timeinterval.TimeInterval struct",
+      "type": "object",
+      "properties": {
+        "days_of_month": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "location": {
+          "type": "string"
+        },
+        "months": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "times": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/TimeRangeModel"
+          }
+        },
+        "weekdays": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "years": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
     "TimeRange": {
       "description": "Redefining this to avoid an import cycle",
       "type": "object",
@@ -7568,6 +7640,18 @@
         "to": {
           "type": "string",
           "format": "date-time"
+        }
+      }
+    },
+    "TimeRangeModel": {
+      "description": "TimeRangeModel is a serialize representation of the timeinterval.TimeRange struct",
+      "type": "object",
+      "properties": {
+        "end_time": {
+          "type": "string"
+        },
+        "start_time": {
+          "type": "string"
         }
       }
     },
@@ -7813,7 +7897,6 @@
       }
     },
     "alertGroup": {
-      "description": "AlertGroup alert group",
       "type": "object",
       "required": [
         "alerts",
@@ -7944,7 +8027,6 @@
       }
     },
     "gettableAlert": {
-      "description": "GettableAlert gettable alert",
       "type": "object",
       "required": [
         "labels",
@@ -8001,6 +8083,7 @@
       "$ref": "#/definitions/gettableAlert"
     },
     "gettableAlerts": {
+      "description": "GettableAlerts gettable alerts",
       "type": "array",
       "items": {
         "$ref": "#/definitions/gettableAlert"
@@ -8066,7 +8149,6 @@
       "$ref": "#/definitions/gettableSilences"
     },
     "integration": {
-      "description": "Integration integration",
       "type": "object",
       "required": [
         "name",
@@ -8211,6 +8293,7 @@
       }
     },
     "postableSilence": {
+      "description": "PostableSilence postable silence",
       "type": "object",
       "required": [
         "comment",

--- a/public/api-merged.json
+++ b/public/api-merged.json
@@ -3392,9 +3392,9 @@
         "operationId": "RouteGetMuteTimings",
         "responses": {
           "200": {
-            "description": "MuteTimings",
+            "description": "MuteTimingsAPIModel",
             "schema": {
-              "$ref": "#/definitions/MuteTimings"
+              "$ref": "#/definitions/MuteTimingsAPIModel"
             }
           }
         }
@@ -3413,7 +3413,7 @@
             "name": "Body",
             "in": "body",
             "schema": {
-              "$ref": "#/definitions/MuteTimeInterval"
+              "$ref": "#/definitions/MuteTimeIntervalAPIModel"
             }
           },
           {
@@ -3424,9 +3424,9 @@
         ],
         "responses": {
           "201": {
-            "description": "MuteTimeInterval",
+            "description": "MuteTimeIntervalAPIModel",
             "schema": {
-              "$ref": "#/definitions/MuteTimeInterval"
+              "$ref": "#/definitions/MuteTimeIntervalAPIModel"
             }
           },
           "400": {
@@ -3495,9 +3495,9 @@
         ],
         "responses": {
           "200": {
-            "description": "MuteTimeInterval",
+            "description": "MuteTimeIntervalAPIModel",
             "schema": {
-              "$ref": "#/definitions/MuteTimeInterval"
+              "$ref": "#/definitions/MuteTimeIntervalAPIModel"
             }
           },
           "404": {
@@ -3526,7 +3526,7 @@
             "name": "Body",
             "in": "body",
             "schema": {
-              "$ref": "#/definitions/MuteTimeInterval"
+              "$ref": "#/definitions/MuteTimeIntervalAPIModel"
             }
           },
           {
@@ -3537,9 +3537,9 @@
         ],
         "responses": {
           "200": {
-            "description": "MuteTimeInterval",
+            "description": "MuteTimeIntervalAPIModel",
             "schema": {
-              "$ref": "#/definitions/MuteTimeInterval"
+              "$ref": "#/definitions/MuteTimeIntervalAPIModel"
             }
           },
           "400": {
@@ -16380,6 +16380,24 @@
         }
       }
     },
+    "MuteTimeIntervalAPIModel": {
+      "description": "MuteTimeIntervalAPIModel is a serialized representation of the MuteTimeInterval struct, as returned by the API",
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "provenance": {
+          "$ref": "#/definitions/Provenance"
+        },
+        "time_intervals": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/TimeIntervalModel"
+          }
+        }
+      }
+    },
     "MuteTimeIntervalExport": {
       "type": "object",
       "properties": {
@@ -16398,10 +16416,25 @@
         }
       }
     },
-    "MuteTimings": {
+    "MuteTimeIntervalModel": {
+      "description": "MuteTimeIntervalModel is a serialized representation of the MuteTimeInterval struct",
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "time_intervals": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/TimeIntervalModel"
+          }
+        }
+      }
+    },
+    "MuteTimingsAPIModel": {
       "type": "array",
       "items": {
-        "$ref": "#/definitions/MuteTimeInterval"
+        "$ref": "#/definitions/MuteTimeIntervalAPIModel"
       }
     },
     "Name": {
@@ -20311,6 +20344,45 @@
         }
       }
     },
+    "TimeIntervalModel": {
+      "description": "TimeIntervalModel is a serialized representation of the timeinterval.TimeInterval struct",
+      "type": "object",
+      "properties": {
+        "days_of_month": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "location": {
+          "type": "string"
+        },
+        "months": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "times": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/TimeRangeModel"
+          }
+        },
+        "weekdays": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "years": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
     "TimeRange": {
       "description": "Redefining this to avoid an import cycle",
       "type": "object",
@@ -20322,6 +20394,18 @@
         "to": {
           "type": "string",
           "format": "date-time"
+        }
+      }
+    },
+    "TimeRangeModel": {
+      "description": "TimeRangeModel is a serialize representation of the timeinterval.TimeRange struct",
+      "type": "object",
+      "properties": {
+        "end_time": {
+          "type": "string"
+        },
+        "start_time": {
+          "type": "string"
         }
       }
     },
@@ -21364,6 +21448,7 @@
       }
     },
     "alertGroup": {
+      "description": "AlertGroup alert group",
       "type": "object",
       "required": [
         "alerts",
@@ -21582,6 +21667,7 @@
       }
     },
     "gettableSilence": {
+      "description": "GettableSilence gettable silence",
       "type": "object",
       "required": [
         "comment",
@@ -21780,6 +21866,7 @@
       }
     },
     "postableSilence": {
+      "description": "PostableSilence postable silence",
       "type": "object",
       "required": [
         "comment",

--- a/public/openapi3.json
+++ b/public/openapi3.json
@@ -6917,6 +6917,24 @@
         "title": "MuteTimeInterval represents a named set of time intervals for which a route should be muted.",
         "type": "object"
       },
+      "MuteTimeIntervalAPIModel": {
+        "description": "MuteTimeIntervalAPIModel is a serialized representation of the MuteTimeInterval struct, as returned by the API",
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "provenance": {
+            "$ref": "#/components/schemas/Provenance"
+          },
+          "time_intervals": {
+            "items": {
+              "$ref": "#/components/schemas/TimeIntervalModel"
+            },
+            "type": "array"
+          }
+        },
+        "type": "object"
+      },
       "MuteTimeIntervalExport": {
         "properties": {
           "name": {
@@ -6935,9 +6953,24 @@
         },
         "type": "object"
       },
-      "MuteTimings": {
+      "MuteTimeIntervalModel": {
+        "description": "MuteTimeIntervalModel is a serialized representation of the MuteTimeInterval struct",
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "time_intervals": {
+            "items": {
+              "$ref": "#/components/schemas/TimeIntervalModel"
+            },
+            "type": "array"
+          }
+        },
+        "type": "object"
+      },
+      "MuteTimingsAPIModel": {
         "items": {
-          "$ref": "#/components/schemas/MuteTimeInterval"
+          "$ref": "#/components/schemas/MuteTimeIntervalAPIModel"
         },
         "type": "array"
       },
@@ -10846,6 +10879,45 @@
         },
         "type": "object"
       },
+      "TimeIntervalModel": {
+        "description": "TimeIntervalModel is a serialized representation of the timeinterval.TimeInterval struct",
+        "properties": {
+          "days_of_month": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "location": {
+            "type": "string"
+          },
+          "months": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "times": {
+            "items": {
+              "$ref": "#/components/schemas/TimeRangeModel"
+            },
+            "type": "array"
+          },
+          "weekdays": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "years": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          }
+        },
+        "type": "object"
+      },
       "TimeRange": {
         "description": "Redefining this to avoid an import cycle",
         "properties": {
@@ -10855,6 +10927,18 @@
           },
           "to": {
             "format": "date-time",
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "TimeRangeModel": {
+        "description": "TimeRangeModel is a serialize representation of the timeinterval.TimeRange struct",
+        "properties": {
+          "end_time": {
+            "type": "string"
+          },
+          "start_time": {
             "type": "string"
           }
         },
@@ -11899,6 +11983,7 @@
         "type": "object"
       },
       "alertGroup": {
+        "description": "AlertGroup alert group",
         "properties": {
           "alerts": {
             "description": "alerts",
@@ -12117,6 +12202,7 @@
         "type": "array"
       },
       "gettableSilence": {
+        "description": "GettableSilence gettable silence",
         "properties": {
           "comment": {
             "description": "comment",
@@ -12315,6 +12401,7 @@
         "type": "array"
       },
       "postableSilence": {
+        "description": "PostableSilence postable silence",
         "properties": {
           "comment": {
             "description": "comment",
@@ -16327,11 +16414,11 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/MuteTimings"
+                  "$ref": "#/components/schemas/MuteTimingsAPIModel"
                 }
               }
             },
-            "description": "MuteTimings"
+            "description": "MuteTimingsAPIModel"
           }
         },
         "summary": "Get all the mute timings.",
@@ -16354,7 +16441,7 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/MuteTimeInterval"
+                "$ref": "#/components/schemas/MuteTimeIntervalAPIModel"
               }
             }
           },
@@ -16365,11 +16452,11 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/MuteTimeInterval"
+                  "$ref": "#/components/schemas/MuteTimeIntervalAPIModel"
                 }
               }
             },
-            "description": "MuteTimeInterval"
+            "description": "MuteTimeIntervalAPIModel"
           },
           "400": {
             "content": {
@@ -16481,11 +16568,11 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/MuteTimeInterval"
+                  "$ref": "#/components/schemas/MuteTimeIntervalAPIModel"
                 }
               }
             },
-            "description": "MuteTimeInterval"
+            "description": "MuteTimeIntervalAPIModel"
           },
           "404": {
             "description": " Not found."
@@ -16520,7 +16607,7 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/MuteTimeInterval"
+                "$ref": "#/components/schemas/MuteTimeIntervalAPIModel"
               }
             }
           },
@@ -16531,11 +16618,11 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/MuteTimeInterval"
+                  "$ref": "#/components/schemas/MuteTimeIntervalAPIModel"
                 }
               }
             },
-            "description": "MuteTimeInterval"
+            "description": "MuteTimeIntervalAPIModel"
           },
           "400": {
             "content": {


### PR DESCRIPTION
Similar as in https://github.com/grafana/grafana/pull/79225, the models being exported are different from the golang structs, with the conversion being done during the marshalling process 

To make the openapi spec work, we can use the same structs as what's used in the HCL/YAML exports
