### PR TITLE
Build: Update plugin IDs list in build and release process

### DIFF
--- a/.github/workflows/core-plugins-build-and-release.yml
+++ b/.github/workflows/core-plugins-build-and-release.yml
@@ -6,6 +6,7 @@ on:
         required: true
         type: choice
         options:
+          - grafana-azure-monitor-datasource
           - grafana-testdata-datasource
           - parca
 

--- a/.github/workflows/core-plugins-build-and-release.yml
+++ b/.github/workflows/core-plugins-build-and-release.yml
@@ -7,6 +7,7 @@ on:
         type: choice
         options:
           - grafana-testdata-datasource
+          - parca
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}-${{ inputs.plugin_id }}


### PR DESCRIPTION
Add Parca and Azure Monitor to the build and release process for core plugins. The changes to externalize them (create the standalone plugins) have already been merged on `main`, but this step was left out. 