### PR TITLE
Plugins: Add fallback for retrieval of data source service

### DIFF
--- a/packages/grafana-runtime/src/components/DataSourcePicker.tsx
+++ b/packages/grafana-runtime/src/components/DataSourcePicker.tsx
@@ -12,7 +12,7 @@ import {
 import { selectors } from '@grafana/e2e-selectors';
 import { ActionMeta, HorizontalGroup, PluginSignatureBadge, Select } from '@grafana/ui';
 
-import { getDataSourceSrv } from '../services/dataSourceSrv';
+import { DataSourceSrv, getDataSourceSrv } from '../services/dataSourceSrv';
 
 import { ExpressionDatasourceRef } from './../utils/DataSourceWithBackend';
 
@@ -49,6 +49,7 @@ export interface DataSourcePickerProps {
   invalid?: boolean;
   disabled?: boolean;
   isLoading?: boolean;
+  dataSourceSrv?: DataSourceSrv;
 }
 
 /**
@@ -83,7 +84,7 @@ export class DataSourcePicker extends PureComponent<DataSourcePickerProps, DataS
 
   componentDidMount() {
     const { current } = this.props;
-    const dsSettings = this.dataSourceSrv.getInstanceSettings(current);
+    const dsSettings = this.getDataSourceService().getInstanceSettings(current);
     if (!dsSettings) {
       this.setState({ error: 'Could not find data source ' + current });
     }
@@ -95,7 +96,7 @@ export class DataSourcePicker extends PureComponent<DataSourcePickerProps, DataS
       return;
     }
 
-    const dsSettings = this.dataSourceSrv.getInstanceSettings(item.value);
+    const dsSettings = this.getDataSourceService().getInstanceSettings(item.value);
 
     if (dsSettings) {
       this.props.onChange(dsSettings);
@@ -109,7 +110,7 @@ export class DataSourcePicker extends PureComponent<DataSourcePickerProps, DataS
       return;
     }
 
-    const ds = this.dataSourceSrv.getInstanceSettings(current);
+    const ds = this.getDataSourceService().getInstanceSettings(current);
 
     if (ds) {
       return {
@@ -135,11 +136,15 @@ export class DataSourcePicker extends PureComponent<DataSourcePickerProps, DataS
     };
   }
 
+  getDataSourceService() {
+    return this.dataSourceSrv || this.props.dataSourceSrv || getDataSourceSrv();
+  }
+
   getDataSourceOptions() {
     const { alerting, tracing, metrics, mixed, dashboard, variables, annotations, pluginId, type, filter, logs } =
       this.props;
 
-    const options = this.dataSourceSrv
+    const options = this.getDataSourceService()
       .getList({
         alerting,
         tracing,


### PR DESCRIPTION
When using `DataSourcePicker` in standalone plugins (such as the ones for data sources), it seems there are some issues in retrieving the data source service (`dataSourceSrv`). In particular, `this.dataSourceSrv` is sometimes `undefined`, and even calling `getDataSourceSrv` after the component has been mounted seems to return `undefined`. This could be due to the fact that `DataSourceSrv` is a singleton, so there might be scope issues. This PR proposes a workaround for that.

Note that:
- In Grafana core, `DataSourcePicker` is [marked as deprecated](https://github.com/grafana/grafana/blob/5fd77afb143bf4bde85f1b651cc5530dee80cbf6/public/app/features/datasources/components/picker/DataSourcePicker.tsx#L3C1-L6), so we can consider this a temporary workaround, but solutions that actually better deal with `DataSourceSrv` are welcome.
- We avoid using a getter in case some code actually accesses `dataSourceSrv` directly, thus potentially introducing a breaking change

