### PR TITLE
VizTooltips: Add wrapper shadow

### DIFF
--- a/packages/grafana-ui/src/components/uPlot/plugins/TooltipPlugin2.tsx
+++ b/packages/grafana-ui/src/components/uPlot/plugins/TooltipPlugin2.tsx
@@ -1,4 +1,4 @@
-import { css } from '@emotion/css';
+import { css, cx } from '@emotion/css';
 import React, { useLayoutEffect, useRef, useReducer, CSSProperties } from 'react';
 import { createPortal } from 'react-dom';
 import uPlot from 'uplot';
@@ -425,7 +425,7 @@ export const TooltipPlugin2 = ({ config, hoverMode, render, clientZoom = false, 
 
   if (plot && isHovering) {
     return createPortal(
-      <div className={styles.tooltipWrapper} style={style} ref={domRef}>
+      <div className={cx(styles.tooltipWrapper, isPinned && styles.pinned)} style={style} ref={domRef}>
         {isPinned && <CloseButton onClick={dismiss} />}
         {contents}
       </div>,
@@ -446,7 +446,10 @@ const getStyles = (theme: GrafanaTheme2) => ({
     position: 'absolute',
     background: theme.colors.background.primary,
     border: `1px solid ${theme.colors.border.weak}`,
-    boxShadow: `0 4px 8px ${theme.colors.background.primary}`,
+    boxShadow: theme.shadows.z2,
     userSelect: 'text',
+  }),
+  pinned: css({
+    boxShadow: theme.shadows.z3,
   }),
 });


### PR DESCRIPTION
Added shadow to the new tooltips wrapper.

Hover:
![tooltip_hover](https://github.com/grafana/grafana/assets/88068998/4735a3de-2d76-4c7a-8ba8-b09d3f3eee09)


Pinned:
![tooltip_pinned](https://github.com/grafana/grafana/assets/88068998/03c988e7-7c6d-45f3-ba75-8da47e9fb8bc)



Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
