### PR TITLE
Prometheus: Invest in tests and docs for min interval or min step explanation

### DIFF
--- a/docs/sources/datasources/prometheus/query-editor/index.md
+++ b/docs/sources/datasources/prometheus/query-editor/index.md
@@ -74,7 +74,7 @@ The **Legend** setting defines the time series's name. You can use a predefined 
 
 The **Min step** setting defines the lower bounds on the interval between data points.
 For example, set this to `1h` to hint that measurements are taken hourly.
-This setting supports the `$__interval` and `$__rate_interval` macros.
+This setting supports the `$__interval` and `$__rate_interval` macros. Be aware that the query range dates are aligned to the step and this can change the start and end of the range.
 
 ### Format
 

--- a/docs/sources/datasources/prometheus/query-editor/index.md
+++ b/docs/sources/datasources/prometheus/query-editor/index.md
@@ -96,7 +96,7 @@ For more information, refer to the [Time Series Transform option documentation][
 
 {{% admonition type="note" %}}
 Grafana modifies the request dates for queries to align them with the dynamically calculated step.
-This ensures a consistent display of metrics data, but it can result in a small gap of data at the right edge of a graph.
+This ensures a consistent display of metrics data and Prometheus requires this for caching results. But, aligning the range with the step can result in a small gap of data at the right edge of a graph or change the start date of the range. For example, a 15s step aligns the range to Unix time divisible by 15s and a 1w minstep aligns the range to the start of the week on a Thursday.
 {{% /admonition %}}
 
 ### Exemplars

--- a/docs/sources/panels-visualizations/query-transform-data/_index.md
+++ b/docs/sources/panels-visualizations/query-transform-data/_index.md
@@ -160,7 +160,7 @@ Panel data source query options include:
   You can also set this to a higher minimum than the scrape interval to retrieve queries that are more coarse-grained and well-functioning.
 
   {{% admonition type="note" %}}
-  The min interval corresponds to the min step in Prometheus. Changing the Prometheus interval can change the start and end of the query range because Prometheus aligns the range to the interval. See [min step](https://grafana.com/docs/grafana/latest/datasources/prometheus/query-editor/#min-step) for more details.
+  The **Min interval** corresponds to the min step in Prometheus. Changing the Prometheus interval can change the start and end of the query range because Prometheus aligns the range to the interval. Refer to [Min step](https://grafana.com/docs/grafana/latest/datasources/prometheus/query-editor/#min-step) for more details.
   {{% /admonition %}}
 
 - **Interval:** Sets a time span that you can use when aggregating or grouping data points by time.

--- a/docs/sources/panels-visualizations/query-transform-data/_index.md
+++ b/docs/sources/panels-visualizations/query-transform-data/_index.md
@@ -158,6 +158,11 @@ Panel data source query options include:
 - **Min interval:** Sets a minimum limit for the automatically calculated interval, which is typically the minimum scrape interval.
   If a data point is saved every 15 seconds, you don't benefit from having an interval lower than that.
   You can also set this to a higher minimum than the scrape interval to retrieve queries that are more coarse-grained and well-functioning.
+
+  {{% admonition type="note" %}}
+  The min interval corresponds to the min step in Prometheus. Changing the Prometheus interval can change the start and end of the query range because Prometheus aligns the range to the interval. See [min step](https://grafana.com/docs/grafana/latest/datasources/prometheus/query-editor/#min-step) for more details.
+  {{% /admonition %}}
+
 - **Interval:** Sets a time span that you can use when aggregating or grouping data points by time.
 
   Grafana automatically calculates an appropriate interval that you can use as a variable in templated queries.

--- a/pkg/tsdb/prometheus/models/query.go
+++ b/pkg/tsdb/prometheus/models/query.go
@@ -284,6 +284,11 @@ func isVariableInterval(interval string) bool {
 	return false
 }
 
+// This function aligns query range to step and handles the time offset.
+// It rounds start and end down to a multiple of step.
+// Prometheus caching is dependent on the range being aligned with the step.
+// Rounding to the step can significantly change the start and end of the range for larger steps, i.e. a week.
+// In rounding the range to a 1w step the range will always start on a Thursday.
 func AlignTimeRange(t time.Time, step time.Duration, offset int64) time.Time {
 	offsetNano := float64(offset * 1e9)
 	stepNano := float64(step.Nanoseconds())

--- a/pkg/tsdb/prometheus/models/query_test.go
+++ b/pkg/tsdb/prometheus/models/query_test.go
@@ -739,20 +739,40 @@ func queryContext(json string, timeRange backend.TimeRange, queryInterval time.D
 	}
 }
 
+// AlignTimeRange aligns query range to step and handles the time offset.
+// It rounds start and end down to a multiple of step.
+// Prometheus caching is dependent on the range being aligned with the step.
+// Rounding to the step can significantly change the start and end of the range for larger steps, i.e. a week.
+// In rounding the range to a 1w step the range will always start on a Thursday.
 func TestAlignTimeRange(t *testing.T) {
 	type args struct {
 		t      time.Time
 		step   time.Duration
 		offset int64
 	}
+
+	var monday int64 = 1704672000
+	var thursday int64 = 1704326400
+	var one_week_min_step = 604800 * time.Second
+
 	tests := []struct {
 		name string
 		args args
 		want time.Time
 	}{
-		{name: "second step", args: args{t: time.Unix(1664816826, 0), step: 10 * time.Second, offset: 0}, want: time.Unix(1664816820, 0).UTC()},
+		{
+			name: "second step",
+			args: args{t: time.Unix(1664816826, 0), step: 10 * time.Second, offset: 0},
+			want: time.Unix(1664816820, 0).UTC(),
+		},
 		{name: "millisecond step", args: args{t: time.Unix(1664816825, 5*int64(time.Millisecond)), step: 10 * time.Millisecond, offset: 0}, want: time.Unix(1664816825, 0).UTC()},
 		{name: "second step with offset", args: args{t: time.Unix(1664816825, 5*int64(time.Millisecond)), step: 2 * time.Second, offset: -3}, want: time.Unix(1664816825, 0).UTC()},
+		// we may not want this functionality in the future but if we change this we break Prometheus caching.
+		{
+			name: "1w step with range date of Monday that changes the range to a Thursday.",
+			args: args{t: time.Unix(monday, 0), step: one_week_min_step, offset: 0},
+			want: time.Unix(thursday, 0).UTC(),
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
**What is this?**

This is an addition to tests and docs that explains the following behavior in Prometheus and Grafana. 

**Why do we need this?**

For context, the interval or step is the time between sampling points in a query. A query with an interval of 15s will request data results for every 15s within a query range. Also, when a user selects a min interval in the dashboard query options, this is the same as changing the min step in Prometheus. 
Prometheus does something special with the query range with regard to the step or interval. Prometheus aligns the query start and end dates based on the step or the calculated interval. A query that requests data in 60s interval will be rounded to the start of the minute. A query that requests data in 1week interval will be rounded to the beginning of the week which in Unix time is Thursday.

**Problem:** If a user wants to make a query that aggregates weekly but has a range that starts on a Monday, this Prometheus behavior overrides that and the query range starts on a Thursday. This is confusing and has resulted in [questions](https://community.grafana.com/t/why-grafana-weeks-start-on-thursday/37726/10), [articles](https://sigmoid.at/post/2022/11/prometheus_step_alignment/#:~:text=Prometheus%20has%20a%20fixed%20alignment,or%201h%20step%20boundaries%20are.) and an [escalation](https://github.com/grafana/support-escalations/issues/8853).

There is an issue to explore overriding the range alignment [here](https://github.com/grafana/grafana/issues/80005).

**Who is this for?**
Prometheus users who are changing the interval and are seeing an unexpected change to the query range start and end.

I am tagging @grafana/dashboards-squad just because I am adding something Prometheus specific to their docs because the escalation came from the customer using query options expose the the issue. If we don't want to change the query options docs, just let me know and I can remove the Prometheus specific addition.

Please check that:
- [ ] It works as expected from a user's perspective. 
- [ ] If this is a pre-GA feature, it is behind a feature toggle. 
- [x] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
