### PR TITLE
Logs navigation: derive current page index

### DIFF
--- a/public/app/features/explore/Logs/LogsNavigation.test.tsx
+++ b/public/app/features/explore/Logs/LogsNavigation.test.tsx
@@ -94,7 +94,7 @@ describe('LogsNavigation', () => {
     expect(onChangeTimeMock).toHaveBeenCalledWith({ from: 1637319338000, to: 1637322938000 });
   });
 
-  it.only('should correctly display the active page', async () => {
+  it('should correctly display the active page', async () => {
     const queries: DataQuery[] = [];
     const { rerender } = setup({
       absoluteRange: { from: 1704737384139, to: 1704737684139 },

--- a/public/app/features/explore/Logs/LogsNavigation.test.tsx
+++ b/public/app/features/explore/Logs/LogsNavigation.test.tsx
@@ -3,6 +3,7 @@ import userEvent from '@testing-library/user-event';
 import React, { ComponentProps } from 'react';
 
 import { LogsSortOrder } from '@grafana/data';
+import { DataQuery } from '@grafana/schema';
 
 import LogsNavigation from './LogsNavigation';
 
@@ -91,6 +92,42 @@ describe('LogsNavigation', () => {
     );
     await userEvent.click(screen.getByTestId('olderLogsButton'));
     expect(onChangeTimeMock).toHaveBeenCalledWith({ from: 1637319338000, to: 1637322938000 });
+  });
+
+  it.only('should correctly display the active page', async () => {
+    const queries: DataQuery[] = [];
+    const { rerender } = setup({
+      absoluteRange: { from: 1704737384139, to: 1704737684139 },
+      visibleRange: { from: 1704737384207, to: 1704737683316 },
+      queries,
+      logsSortOrder: LogsSortOrder.Descending,
+    });
+
+    expect(await screen.findByTestId('page1')).toBeInTheDocument();
+    expect(screen.getByTestId('page1').firstChild).toHaveClass('selectedBg');
+
+    expect(screen.queryByTestId('page2')).not.toBeInTheDocument();
+
+    await userEvent.click(screen.getByTestId('olderLogsButton'));
+
+    rerender(
+      <LogsNavigation
+        {...defaultProps}
+        absoluteRange={{ from: 1704737084207, to: 1704737384207 }}
+        visibleRange={{ from: 1704737084627, to: 1704737383765 }}
+        onChangeTime={jest.fn()}
+        logsSortOrder={LogsSortOrder.Descending}
+        queries={queries}
+      />
+    );
+
+    expect(await screen.findByTestId('page1')).toBeInTheDocument();
+    expect(screen.getByTestId('page1').firstChild).not.toHaveClass('selectedBg');
+
+    expect(await screen.findByTestId('page2')).toBeInTheDocument();
+    expect(screen.getByTestId('page2').firstChild).toHaveClass('selectedBg');
+
+    expect(screen.queryByTestId('page3')).not.toBeInTheDocument();
   });
 
   it('should reset the scroll when pagination is clicked', async () => {

--- a/public/app/features/explore/Logs/LogsNavigation.tsx
+++ b/public/app/features/explore/Logs/LogsNavigation.tsx
@@ -49,9 +49,13 @@ function LogsNavigation({
   // e.g. if last 5 min selected, always run 5 min range
   const rangeSpanRef = useRef(0);
 
-  const currentPageIndex = useMemo(() => pages.findIndex((page) => {
-    return page.queryRange.to === absoluteRange.to;
-  }), [absoluteRange.to, pages]);
+  const currentPageIndex = useMemo(
+    () =>
+      pages.findIndex((page) => {
+        return page.queryRange.to === absoluteRange.to;
+      }),
+    [absoluteRange.to, pages]
+  );
 
   const oldestLogsFirst = logsSortOrder === LogsSortOrder.Ascending;
   const onFirstPage = oldestLogsFirst ? currentPageIndex === pages.length - 1 : currentPageIndex === 0;

--- a/public/app/features/explore/Logs/LogsNavigation.tsx
+++ b/public/app/features/explore/Logs/LogsNavigation.tsx
@@ -1,6 +1,6 @@
 import { css } from '@emotion/css';
 import { isEqual } from 'lodash';
-import React, { memo, useCallback, useEffect, useRef, useState } from 'react';
+import React, { memo, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
 import { AbsoluteTimeRange, GrafanaTheme2, LogsSortOrder } from '@grafana/data';
 import { reportInteraction } from '@grafana/runtime';
@@ -41,7 +41,6 @@ function LogsNavigation({
   addResultsToCache,
 }: Props) {
   const [pages, setPages] = useState<LogsPage[]>([]);
-  const [currentPageIndex, setCurrentPageIndex] = useState(0);
 
   // These refs are to determine, if we want to clear up logs navigation when totally new query is run
   const expectedQueriesRef = useRef<DataQuery[]>();
@@ -49,6 +48,10 @@ function LogsNavigation({
   // This ref is to store range span for future queres based on firstly selected time range
   // e.g. if last 5 min selected, always run 5 min range
   const rangeSpanRef = useRef(0);
+
+  const currentPageIndex = useMemo(() => pages.findIndex((page) => {
+    return page.queryRange.to === absoluteRange.to;
+  }), [absoluteRange.to, pages]);
 
   const oldestLogsFirst = logsSortOrder === LogsSortOrder.Ascending;
   const onFirstPage = oldestLogsFirst ? currentPageIndex === pages.length - 1 : currentPageIndex === 0;
@@ -64,7 +67,6 @@ function LogsNavigation({
     if (!isEqual(expectedRangeRef.current, absoluteRange) || !isEqual(expectedQueriesRef.current, queries)) {
       clearCache();
       setPages([newPage]);
-      setCurrentPageIndex(0);
       expectedQueriesRef.current = queries;
       rangeSpanRef.current = absoluteRange.to - absoluteRange.from;
     } else {
@@ -73,14 +75,8 @@ function LogsNavigation({
         newPages = pages.filter((page) => !isEqual(newPage.queryRange, page.queryRange));
         // Sort pages based on logsOrder so they visually align with displayed logs
         newPages = [...newPages, newPage].sort((a, b) => sortPages(a, b, logsSortOrder));
-        // Set new pages
-
         return newPages;
       });
-
-      // Set current page index
-      const index = newPages.findIndex((page) => page.queryRange.to === absoluteRange.to);
-      setCurrentPageIndex(index);
     }
     addResultsToCache();
   }, [visibleRange, absoluteRange, logsSortOrder, queries, clearCache, addResultsToCache]);


### PR DESCRIPTION
Before these changes, we were using a state variable to hold the current displayed page index, which needed to be updated after a change in any of multiple props and internal state. This approach caused running conditions, depending on the current value of the list of pages, but also was not necessary, as it can be easily calculated at render time, instead of requiring async state updates.

**Which issue(s) does this PR fix?**:

Escalation 8919.

**Special notes for your reviewer:**

Please check that the navigation pages are correctly generated, and the current active page is highlighted in the list of pages.
