### PR TITLE
UI: Hide additional separator when time picker is hidden

### DIFF
--- a/public/app/features/dashboard/components/DashNav/DashNav.tsx
+++ b/public/app/features/dashboard/components/DashNav/DashNav.tsx
@@ -251,7 +251,7 @@ export const DashNav = React.memo<Props>((props) => {
   };
 
   const renderRightActions = () => {
-    const { dashboard, onAddPanel, isFullscreen, kioskMode } = props;
+    const { dashboard, onAddPanel, isFullscreen, kioskMode, hideTimePicker } = props;
     const { canSave, canEdit, showSettings, canShare } = dashboard.meta;
     const { snapshot } = dashboard;
     const snapshotUrl = snapshot && snapshot.originalUrl;
@@ -335,7 +335,10 @@ export const DashNav = React.memo<Props>((props) => {
       buttons.push(<ShareButton key="button-share" dashboard={dashboard} />);
     }
 
-    buttons.push(<NavToolbarSeparator key="toolbar-separator" />);
+    // if the timepicker is hidden, we don't need to add this separator
+    if (!hideTimePicker) {
+      buttons.push(<NavToolbarSeparator key="toolbar-separator" />);
+    }
 
     buttons.push(renderTimeControls());
 


### PR DESCRIPTION
**What is this feature?**
With this [PR](https://github.com/grafana/grafana/issues/77298) we introduced an additional `NavToolbarSeparator`, which results in a duplicated Separator when the time picker is hidden.

Before (near the Share button there are two Separators)
![Screenshot 2024-01-08 at 15 12 56](https://github.com/grafana/grafana/assets/20256983/b79fa946-2a81-499c-80a0-828e745e24b0)

After
![Screenshot 2024-01-08 at 15 14 58](https://github.com/grafana/grafana/assets/20256983/de478e0a-779c-4355-98de-0bd34c8ed756)

**Special notes for your reviewer:**
Test: there is a toggle in the dashboard settings to hide the time picker.

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
