### PR TITLE
Add versions tab in dashboard settings

### DIFF
--- a/public/app/features/dashboard-scene/settings/VersionsEditView.tsx
+++ b/public/app/features/dashboard-scene/settings/VersionsEditView.tsx
@@ -1,0 +1,36 @@
+import React from 'react';
+
+import { PageLayoutType } from '@grafana/data';
+import { SceneComponentProps, SceneObjectBase } from '@grafana/scenes';
+import { Page } from 'app/core/components/Page/Page';
+
+import { DashboardScene } from '../scene/DashboardScene';
+import { getDashboardSceneFor } from '../utils/utils';
+
+import { DashboardEditView, DashboardEditViewState, useDashboardEditPageNav } from './utils';
+
+export interface VersionsEditViewState extends DashboardEditViewState {}
+
+export class VersionsEditView extends SceneObjectBase<VersionsEditViewState> implements DashboardEditView {
+  public static Component = VersionsEditorSettingsListView;
+
+  public getUrlKey(): string {
+    return 'versions';
+  }
+
+  public getDashboard(): DashboardScene {
+    return getDashboardSceneFor(this);
+  }
+}
+
+function VersionsEditorSettingsListView({ model }: SceneComponentProps<VersionsEditView>) {
+  const dashboard = model.getDashboard();
+
+  const { navModel, pageNav } = useDashboardEditPageNav(dashboard, model.getUrlKey());
+
+  return (
+    <Page navModel={navModel} pageNav={pageNav} layout={PageLayoutType.Standard}>
+      <div>TODO</div>
+    </Page>
+  );
+}

--- a/public/app/features/dashboard-scene/settings/utils.ts
+++ b/public/app/features/dashboard-scene/settings/utils.ts
@@ -12,6 +12,7 @@ import { AnnotationsEditView } from './AnnotationsEditView';
 import { DashboardLinksEditView } from './DashboardLinksEditView';
 import { GeneralSettingsEditView } from './GeneralSettingsEditView';
 import { VariablesEditView } from './VariablesEditView';
+import { VersionsEditView } from './VersionsEditView';
 
 export interface DashboardEditViewState extends SceneObjectState {}
 
@@ -54,6 +55,11 @@ export function useDashboardEditPageNav(dashboard: DashboardScene, currentEditVi
         url: locationUtil.getUrlForPartial(location, { editview: 'links', editIndex: null }),
         active: currentEditView === 'links',
       },
+      {
+        text: t('dashboard-settings.versions.title', 'Versions'),
+        url: locationUtil.getUrlForPartial(location, { editview: 'versions', editIndex: null }),
+        active: currentEditView === 'versions',
+      },
     ],
     parentItem: dashboardPageNav,
   };
@@ -69,6 +75,8 @@ export function createDashboardEditViewFor(editview: string): DashboardEditView 
       return new VariablesEditView({});
     case 'links':
       return new DashboardLinksEditView({});
+    case 'versions':
+      return new VersionsEditView({});
     case 'settings':
     default:
       return new GeneralSettingsEditView({});


### PR DESCRIPTION
Covers the first part - "One can navigate to Dashboard Settings/Versions tab" - of versions settings page migration https://github.com/grafana/grafana/issues/80058