### PR TITLE
Send empty http response when body is nil

### DIFF
--- a/pkg/api/response/response.go
+++ b/pkg/api/response/response.go
@@ -311,6 +311,8 @@ func Respond(status int, body any) *NormalResponse {
 		b = t
 	case string:
 		b = []byte(t)
+	case nil:
+		break
 	default:
 		var err error
 		if b, err = json.Marshal(body); err != nil {

--- a/pkg/api/response/response_test.go
+++ b/pkg/api/response/response_test.go
@@ -125,3 +125,49 @@ func TestErrors(t *testing.T) {
 		)
 	}
 }
+
+func TestRespond(t *testing.T) {
+	testCases := []struct {
+		name     string
+		status   int
+		body     any
+		expected []byte
+	}{
+		{
+			name:     "with body of type []byte",
+			status:   200,
+			body:     []byte("message body"),
+			expected: []byte("message body"),
+		},
+		{
+			name:     "with body of type string",
+			status:   400,
+			body:     "message body",
+			expected: []byte("message body"),
+		},
+		{
+			name:     "with nil body",
+			status:   204,
+			body:     nil,
+			expected: nil,
+		},
+		{
+			name:   "with body of type struct",
+			status: 200,
+			body: struct {
+				Name  string
+				Value int
+			}{"name", 1},
+			expected: []byte(`{"Name":"name","Value":1}`),
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			resp := Respond(tc.status, tc.body)
+
+			require.Equal(t, tc.status, resp.status)
+			require.Equal(t, tc.expected, resp.body.Bytes())
+		})
+	}
+}

--- a/pkg/services/publicdashboards/api/api_test.go
+++ b/pkg/services/publicdashboards/api/api_test.go
@@ -269,10 +269,7 @@ func TestAPIDeletePublicDashboard(t *testing.T) {
 			assert.Equal(t, test.ExpectedHttpResponse, response.Code)
 
 			if test.ExpectedHttpResponse == http.StatusOK {
-				var jsonResp any
-				err := json.Unmarshal(response.Body.Bytes(), &jsonResp)
-				require.NoError(t, err)
-				assert.Equal(t, jsonResp, nil)
+				assert.Equal(t, []byte(nil), response.Body.Bytes())
 			}
 
 			if !test.ShouldCallService {


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

This was causing an error generated by the http package when responding with a status code that doesn't use a response body (for example, 204 No Content). 

**Why do we need this feature?**

With this fix we can send empty http responses to the client: `return response.Respond(http.StatusNoContent, nil)`.

**Who is this feature for?**

[Add information on what kind of user the feature is for.]

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
