### PR TITLE
Alerting: Improve notification policies view performance

### DIFF
--- a/public/app/features/alerting/unified/NotificationPolicies.tsx
+++ b/public/app/features/alerting/unified/NotificationPolicies.tsx
@@ -275,6 +275,12 @@ type RouteFilters = {
 
 export const findRoutesMatchingFilters = (rootRoute: RouteWithID, filters: RouteFilters): RouteWithID[] => {
   const { contactPointFilter, labelMatchersFilter = [] } = filters;
+  const hasFilter = contactPointFilter || labelMatchersFilter.length > 0;
+
+  // if filters are empty we short-circuit this function
+  if (!hasFilter) {
+    return [];
+  }
 
   let matchedRoutes: RouteWithID[][] = [];
 

--- a/public/app/features/alerting/unified/utils/notification-policies.test.ts
+++ b/public/app/features/alerting/unified/utils/notification-policies.test.ts
@@ -1,6 +1,7 @@
 import { MatcherOperator, Route, RouteWithID } from 'app/plugins/datasource/alertmanager/types';
 
 import {
+  InhertitableProperties,
   computeInheritedTree,
   findMatchingRoutes,
   getInheritedProperties,
@@ -202,6 +203,18 @@ describe('getInheritedProperties()', () => {
 
       const childInherited = getInheritedProperties(parent, child);
       expect(childInherited).toHaveProperty('group_by', ['label']);
+    });
+
+    // This scenario is technically impossible unless we have a bug in our code.
+    // A route cannot both specify a receiver and inherit it from its parent at the same time.
+    it('should inherit from parent instead of grandparent', () => {
+      const parent: Route = { receiver: 'parent' };
+      const parentInherited: InhertitableProperties = { receiver: 'grandparent', group_by: ['foo'] };
+      const child: Route = {};
+
+      const childInherited = getInheritedProperties(parent, child, parentInherited);
+      expect(childInherited).toHaveProperty('receiver', 'parent');
+      expect(childInherited.group_by).toEqual(['foo']);
     });
   });
 

--- a/public/app/features/alerting/unified/utils/notification-policies.ts
+++ b/public/app/features/alerting/unified/utils/notification-policies.ts
@@ -160,8 +160,8 @@ function getInheritedProperties(
   childRoute: Route,
   propertiesParentInherited?: Partial<InhertitableProperties>
 ) {
-  const propsFromParent = pick(parentRoute, INHERITABLE_KEYS);
-  const inheritableProperties: InhertitableProperties = merge({}, propsFromParent, propertiesParentInherited);
+  const propsFromParent: InhertitableProperties = pick(parentRoute, INHERITABLE_KEYS);
+  const inheritableProperties: InhertitableProperties = merge({}, propertiesParentInherited, propsFromParent);
 
   // TODO how to solve this TypeScript mystery?
   const inherited = reduce(

--- a/public/app/features/alerting/unified/utils/notification-policies.ts
+++ b/public/app/features/alerting/unified/utils/notification-policies.ts
@@ -160,9 +160,8 @@ function getInheritedProperties(
   childRoute: Route,
   propertiesParentInherited?: Partial<InhertitableProperties>
 ) {
-  const fullParentProperties = merge({}, parentRoute, propertiesParentInherited);
-
-  const inheritableProperties: InhertitableProperties = pick(fullParentProperties, INHERITABLE_KEYS);
+  const propsFromParent = pick(parentRoute, INHERITABLE_KEYS);
+  const inheritableProperties: InhertitableProperties = merge({}, propsFromParent, propertiesParentInherited);
 
   // TODO how to solve this TypeScript mystery?
   const inherited = reduce(


### PR DESCRIPTION
**What is this feature?**

This PR includes two optimisations to improve the performance of the notification policies view.

Firstly, it avoids an expensive search operation (which computes the full inherited tree, traversing it entirely) when no filters are selected.

Secondly it avoids an expensive merge operation to compute inherited properties.

These are functions that have taken up a large chunk of compute time when inspecting the CPU flame graph, especially with larger trees.

**Special notes for your reviewer:**

I'd love to get a very thorough review on the changes in the logic of `getInheritedProperties()` – even though the test suite passes we might be missing something here by not merging the inherited properties of the parent's parent into the parent?