### PR TITLE
RBAC: prioritise directly applied permissions over inherited permissions

### DIFF
--- a/public/app/core/components/AccessControl/PermissionList.tsx
+++ b/public/app/core/components/AccessControl/PermissionList.tsx
@@ -27,6 +27,12 @@ export const PermissionList = ({ title, items, compareKey, permissionLevels, can
 
       if (item.actions.length > keep[key].actions.length) {
         keep[key] = item;
+        continue;
+      }
+
+      // If the same permission has been inherited and applied directly, keep the one that is applied directly
+      if (item.actions.length === keep[key].actions.length && !item.isInherited) {
+        keep[key] = item;
       }
     }
     return Object.keys(keep).map((k) => keep[k]);


### PR DESCRIPTION
**What is this feature?**

If a permission of the same level for a folder/dashboard has been both applied directly and inherited from the parent, display it as a directly applied permission and not an inherited permission.

https://github.com/grafana/grafana/assets/9482349/9c228e44-c97f-4c82-984b-510537de9030

**Why do we need this feature?**

To hopefully make it clearer which permission will stay after a folder/dashboard gets moved.

**Who is this feature for?**

Anyone who uses folder/dashboard permissions

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes https://github.com/grafana/grafana/issues/80156

**Special notes for your reviewer:**

Note that this will not fix the case of the child resource having a lower permission applied to it directly than the permission that has been inherited from a parent resource. In this case we will still only display the inherited higher level permission. But this should not be a common scenario.
