### PR TITLE
Login: convert scheme relative URL to path

### DIFF
--- a/public/app/core/components/AppChrome/TopBar/SignInLink.tsx
+++ b/public/app/core/components/AppChrome/TopBar/SignInLink.tsx
@@ -9,12 +9,12 @@ export function SignInLink() {
   const location = useLocation();
   const styles = useStyles2(getStyles);
   let loginUrl = textUtil.sanitizeUrl(locationUtil.getUrlForPartial(location, { forceLogin: 'true' }));
-  
+
   // Fix for loginUrl starting with "//" which is a scheme relative URL
   if (loginUrl.startsWith('//')) {
     loginUrl = loginUrl.replace(/\/+/g, '/');
   }
-  
+
   return (
     <a className={styles.link} href={loginUrl} target="_self">
       Sign in

--- a/public/app/core/components/AppChrome/TopBar/SignInLink.tsx
+++ b/public/app/core/components/AppChrome/TopBar/SignInLink.tsx
@@ -8,8 +8,13 @@ import { useStyles2 } from '@grafana/ui';
 export function SignInLink() {
   const location = useLocation();
   const styles = useStyles2(getStyles);
-  const loginUrl = textUtil.sanitizeUrl(locationUtil.getUrlForPartial(location, { forceLogin: 'true' }));
-
+  let loginUrl = textUtil.sanitizeUrl(locationUtil.getUrlForPartial(location, { forceLogin: 'true' }));
+  
+  // Fix for loginUrl starting with "//" which is a scheme relative URL
+  if (loginUrl.startsWith('//')) {
+    loginUrl = loginUrl.replace(/\/+/g, '/');
+  }
+  
   return (
     <a className={styles.link} href={loginUrl} target="_self">
       Sign in


### PR DESCRIPTION
Convert a scheme relative "Sign In" URL to a path. 