### PR TITLE
Alerting: Add metric to check for default AM configurations

### DIFF
--- a/pkg/services/ngalert/metrics/alertmanager.go
+++ b/pkg/services/ngalert/metrics/alertmanager.go
@@ -24,6 +24,7 @@ func NewAlertmanagerMetrics(r prometheus.Registerer) *Alertmanager {
 }
 
 type AlertmanagerConfigMetrics struct {
+	ConfigHash     *prometheus.GaugeVec
 	Matchers       prometheus.Gauge
 	MatchRE        prometheus.Gauge
 	Match          prometheus.Gauge
@@ -32,6 +33,10 @@ type AlertmanagerConfigMetrics struct {
 
 func NewAlertmanagerConfigMetrics(r prometheus.Registerer) *AlertmanagerConfigMetrics {
 	m := &AlertmanagerConfigMetrics{
+		ConfigHash: prometheus.NewGaugeVec(prometheus.GaugeOpts{
+			Name: "alertmanager_config_hash",
+			Help: "The hash of the Alertmanager configuration.",
+		}, []string{"org"}),
 		Matchers: prometheus.NewGauge(prometheus.GaugeOpts{
 			Name: "alertmanager_config_matchers",
 			Help: "The total number of matchers",
@@ -50,7 +55,7 @@ func NewAlertmanagerConfigMetrics(r prometheus.Registerer) *AlertmanagerConfigMe
 		}),
 	}
 	if r != nil {
-		r.MustRegister(m.Matchers, m.MatchRE, m.Match, m.ObjectMatchers)
+		r.MustRegister(m.ConfigHash, m.Matchers, m.MatchRE, m.Match, m.ObjectMatchers)
 	}
 	return m
 }

--- a/pkg/services/ngalert/metrics/multi_org_alertmanager.go
+++ b/pkg/services/ngalert/metrics/multi_org_alertmanager.go
@@ -15,9 +15,9 @@ type MultiOrgAlertmanager struct {
 	Registerer prometheus.Registerer
 	registries *metrics.TenantRegistries
 
-	ActiveConfigurations      prometheus.Gauge
-	DiscoveredConfigurations  prometheus.Gauge
-	UsingDefaultConfiguration *prometheus.GaugeVec
+	ActiveConfigurations     prometheus.Gauge
+	ConfigurationHash        *prometheus.GaugeVec
+	DiscoveredConfigurations prometheus.Gauge
 
 	aggregatedMetrics *AlertmanagerAggregatedMetrics
 }
@@ -39,11 +39,11 @@ func NewMultiOrgAlertmanagerMetrics(r prometheus.Registerer) *MultiOrgAlertmanag
 			Name:      "active_configurations",
 			Help:      "The number of active Alertmanager configurations.",
 		}),
-		UsingDefaultConfiguration: promauto.With(r).NewGaugeVec(prometheus.GaugeOpts{
+		ConfigurationHash: promauto.With(r).NewGaugeVec(prometheus.GaugeOpts{
 			Namespace: Namespace,
 			Subsystem: Subsystem,
-			Name:      "using_default_alertmanager_configuration",
-			Help:      "Whether or not an org is using the default configuration for their Alertmanager.",
+			Name:      "configuration_hash",
+			Help:      "Hash for the currently applied Alertmanager configuration for an org.",
 		}, []string{"org"}),
 		aggregatedMetrics: NewAlertmanagerAggregatedMetrics(registries),
 	}

--- a/pkg/services/ngalert/metrics/multi_org_alertmanager.go
+++ b/pkg/services/ngalert/metrics/multi_org_alertmanager.go
@@ -15,8 +15,9 @@ type MultiOrgAlertmanager struct {
 	Registerer prometheus.Registerer
 	registries *metrics.TenantRegistries
 
-	ActiveConfigurations     prometheus.Gauge
-	DiscoveredConfigurations prometheus.Gauge
+	ActiveConfigurations      prometheus.Gauge
+	DiscoveredConfigurations  prometheus.Gauge
+	UsingDefaultConfiguration *prometheus.GaugeVec
 
 	aggregatedMetrics *AlertmanagerAggregatedMetrics
 }
@@ -38,6 +39,12 @@ func NewMultiOrgAlertmanagerMetrics(r prometheus.Registerer) *MultiOrgAlertmanag
 			Name:      "active_configurations",
 			Help:      "The number of active Alertmanager configurations.",
 		}),
+		UsingDefaultConfiguration: promauto.With(r).NewGaugeVec(prometheus.GaugeOpts{
+			Namespace: Namespace,
+			Subsystem: Subsystem,
+			Name:      "using_default_alertmanager_configuration",
+			Help:      "Whether or not an org is using the default configuration for their Alertmanager.",
+		}, []string{"org"}),
 		aggregatedMetrics: NewAlertmanagerAggregatedMetrics(registries),
 	}
 

--- a/pkg/services/ngalert/notifier/alertmanager.go
+++ b/pkg/services/ngalert/notifier/alertmanager.go
@@ -3,6 +3,7 @@ package notifier
 import (
 	"context"
 	"crypto/md5"
+	"encoding/binary"
 	"encoding/json"
 	"fmt"
 	"path/filepath"
@@ -255,6 +256,10 @@ func (am *alertmanager) updateConfigMetrics(cfg *apimodels.PostableUserConfig) {
 	am.ConfigMetrics.MatchRE.Set(float64(amu.MatchRE))
 	am.ConfigMetrics.Match.Set(float64(amu.Match))
 	am.ConfigMetrics.ObjectMatchers.Set(float64(amu.ObjectMatchers))
+
+	am.ConfigMetrics.ConfigHash.
+		WithLabelValues(strconv.FormatInt(am.orgID, 10)).
+		Set(hashAsMetricValue(am.Base.ConfigHash()))
 }
 
 func (am *alertmanager) aggregateRouteMatchers(r *apimodels.Route, amu *AggregateMatchersUsage) {
@@ -421,3 +426,13 @@ func (e AlertValidationError) Error() string {
 type nilLimits struct{}
 
 func (n nilLimits) MaxNumberOfAggregationGroups() int { return 0 }
+
+// This function is taken from upstream, modified to take a [16]byte instead of a []byte.
+// https://github.com/prometheus/alertmanager/blob/30fa9cd44bc91c0d6adcc9985609bb08a09a127b/config/coordinator.go#L149-L156
+func hashAsMetricValue(data [16]byte) float64 {
+	// We only want 48 bits as a float64 only has a 53 bit mantissa.
+	smallSum := data[0:6]
+	bytes := make([]byte, 8)
+	copy(bytes, smallSum)
+	return float64(binary.LittleEndian.Uint64(bytes))
+}

--- a/pkg/services/ngalert/notifier/alertmanager.go
+++ b/pkg/services/ngalert/notifier/alertmanager.go
@@ -320,8 +320,6 @@ func (am *alertmanager) applyConfig(cfg *apimodels.PostableUserConfig, rawConfig
 		return false, nil
 	}
 
-	am.updateConfigMetrics(cfg)
-
 	err = am.Base.ApplyConfig(AlertingConfiguration{
 		rawAlertmanagerConfig:    rawConfig,
 		alertmanagerConfig:       cfg.AlertmanagerConfig,
@@ -332,6 +330,7 @@ func (am *alertmanager) applyConfig(cfg *apimodels.PostableUserConfig, rawConfig
 		return false, err
 	}
 
+	am.updateConfigMetrics(cfg)
 	return true, nil
 }
 

--- a/pkg/services/ngalert/notifier/multiorg_alertmanager.go
+++ b/pkg/services/ngalert/notifier/multiorg_alertmanager.go
@@ -296,6 +296,12 @@ func (moa *MultiOrgAlertmanager) SyncAlertmanagersForOrgs(ctx context.Context, o
 			continue
 		}
 		moa.alertmanagers[orgID] = alertmanager
+
+		if dbConfig.Default {
+			moa.metrics.UsingDefaultConfiguration.WithLabelValues(strconv.FormatInt(orgID, 10)).Set(1)
+			continue
+		}
+		moa.metrics.UsingDefaultConfiguration.WithLabelValues(strconv.FormatInt(orgID, 10)).Set(0)
 	}
 
 	amsToStop := map[int64]Alertmanager{}

--- a/pkg/services/ngalert/notifier/multiorg_alertmanager.go
+++ b/pkg/services/ngalert/notifier/multiorg_alertmanager.go
@@ -2,7 +2,6 @@ package notifier
 
 import (
 	"context"
-	"encoding/binary"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -296,12 +295,6 @@ func (moa *MultiOrgAlertmanager) SyncAlertmanagersForOrgs(ctx context.Context, o
 			moa.logger.Error("Failed to apply Alertmanager config for org", "org", orgID, "id", dbConfig.ID, "error", err)
 			continue
 		}
-
-		// Store the float64 representation of the configuration hash in the gauge.
-		metricHash := hashToFloat64([]byte(dbConfig.ConfigurationHash))
-		moa.metrics.ConfigurationHash.WithLabelValues(strconv.FormatInt(orgID, 10)).Set(metricHash)
-
-		// Map the new Alertmanager to the org.
 		moa.alertmanagers[orgID] = alertmanager
 	}
 
@@ -437,19 +430,3 @@ func (p *NilPeer) AddState(string, alertingCluster.State, prometheus.Registerer)
 type NilChannel struct{}
 
 func (c *NilChannel) Broadcast([]byte) {}
-
-func hashToFloat64(hash []byte) float64 {
-	// binary.LittleEndian.Uint64 expects a slice of 8 bytes.
-	bytes := make([]byte, 8)
-
-	// We only want 6 bytes as a float64 only has a 53 bit mantissa,
-	// we'll pad the rest with 0s.
-	for i := 0; i < 6; i++ {
-		if i == len(hash) { // avoid panics
-			break
-		}
-		bytes[i] = hash[i]
-	}
-
-	return float64(binary.LittleEndian.Uint64(bytes))
-}


### PR DESCRIPTION
This PR adds a gauge to store the float64 representation of an Alertmanager configuration's hash.