### PR TITLE
Fetch and render dashboard versions

### DIFF
--- a/public/app/features/dashboard-scene/settings/VersionsEditView.test.tsx
+++ b/public/app/features/dashboard-scene/settings/VersionsEditView.test.tsx
@@ -1,0 +1,113 @@
+import { SceneGridItem, SceneGridLayout, SceneTimeRange } from '@grafana/scenes';
+import { historySrv } from 'app/features/dashboard/components/VersionHistory/HistorySrv';
+
+import { DashboardScene } from '../scene/DashboardScene';
+import { activateFullSceneTree } from '../utils/test-utils';
+
+import { VERSIONS_FETCH_LIMIT, VersionsEditView } from './VersionsEditView';
+
+jest.mock('app/features/dashboard/components/VersionHistory/HistorySrv');
+
+describe('VersionsEditView', () => {
+  describe('Dashboard Versions state', () => {
+    let dashboard: DashboardScene;
+    let versionsView: VersionsEditView;
+
+    beforeEach(async () => {
+      // @ts-ignore
+      historySrv.getHistoryList.mockResolvedValue(getVersions());
+
+      const result = await buildTestScene();
+      dashboard = result.dashboard;
+      versionsView = result.versionsView;
+    });
+
+    it('should return the correct urlKey', () => {
+      expect(versionsView.getUrlKey()).toBe('versions');
+    });
+
+    it('should return the dashboard', () => {
+      expect(versionsView.getDashboard()).toBe(dashboard);
+    });
+
+    it('should return the decorated list of versions', () => {
+      const versions = versionsView.state.versions;
+
+      expect(versions).toHaveLength(2);
+      expect(versions[0].createdDateString).toBe('2017-02-22 20:43:01');
+      expect(versions[0].ageString).toBe('7 years ago');
+      expect(versions[1].createdDateString).toBe('2017-02-22 20:43:01');
+      expect(versions[1].ageString).toBe('7 years ago');
+    });
+
+    it('should bump the start threshold when fetching more versions', async () => {
+      expect(versionsView.start).toBe(VERSIONS_FETCH_LIMIT);
+
+      versionsView.fetchVersions(true);
+      await new Promise(process.nextTick);
+
+      expect(versionsView.start).toBe(VERSIONS_FETCH_LIMIT * 2);
+    });
+  });
+});
+
+function getVersions() {
+  return [
+    {
+      id: 4,
+      dashboardId: 1,
+      dashboardUID: '_U4zObQMz',
+      parentVersion: 3,
+      restoredFrom: 0,
+      version: 4,
+      created: '2017-02-22T17:43:01-08:00',
+      createdBy: 'admin',
+      message: '',
+    },
+    {
+      id: 3,
+      dashboardId: 1,
+      dashboardUID: '_U4zObQMz',
+      parentVersion: 1,
+      restoredFrom: 1,
+      version: 3,
+      created: '2017-02-22T17:43:01-08:00',
+      createdBy: 'admin',
+      message: '',
+    },
+  ];
+}
+
+async function buildTestScene() {
+  const versionsView = new VersionsEditView({ versions: [] });
+  const dashboard = new DashboardScene({
+    $timeRange: new SceneTimeRange({}),
+    title: 'hello',
+    uid: 'dash-1',
+    meta: {
+      canEdit: true,
+    },
+    body: new SceneGridLayout({
+      children: [
+        new SceneGridItem({
+          key: 'griditem-1',
+          x: 0,
+          y: 0,
+          width: 10,
+          height: 12,
+          body: undefined,
+        }),
+      ],
+    }),
+    editview: versionsView,
+  });
+
+  activateFullSceneTree(dashboard);
+
+  await new Promise((r) => setTimeout(r, 1));
+
+  dashboard.onEnterEditMode();
+  versionsView.activate();
+
+  return { dashboard, versionsView };
+}

--- a/public/app/features/dashboard-scene/settings/VersionsEditView.tsx
+++ b/public/app/features/dashboard-scene/settings/VersionsEditView.tsx
@@ -1,0 +1,36 @@
+import React from 'react';
+
+import { PageLayoutType } from '@grafana/data';
+import { SceneComponentProps, SceneObjectBase } from '@grafana/scenes';
+import { Page } from 'app/core/components/Page/Page';
+
+import { DashboardScene } from '../scene/DashboardScene';
+import { getDashboardSceneFor } from '../utils/utils';
+
+import { DashboardEditView, DashboardEditViewState, useDashboardEditPageNav } from './utils';
+
+export interface VersionsEditViewState extends DashboardEditViewState {}
+
+export class VersionsEditView extends SceneObjectBase<VersionsEditViewState> implements DashboardEditView {
+  public static Component = VersionsEditorSettingsListView;
+
+  public getUrlKey(): string {
+    return 'versions';
+  }
+
+  public getDashboard(): DashboardScene {
+    return getDashboardSceneFor(this);
+  }
+}
+
+function VersionsEditorSettingsListView({ model }: SceneComponentProps<VersionsEditView>) {
+  const dashboard = model.getDashboard();
+
+  const { navModel, pageNav } = useDashboardEditPageNav(dashboard, model.getUrlKey());
+
+  return (
+    <Page navModel={navModel} pageNav={pageNav} layout={PageLayoutType.Standard}>
+      <div>TODO</div>
+    </Page>
+  );
+}

--- a/public/app/features/dashboard-scene/settings/VersionsEditView.tsx
+++ b/public/app/features/dashboard-scene/settings/VersionsEditView.tsx
@@ -1,36 +1,125 @@
 import React from 'react';
 
-import { PageLayoutType } from '@grafana/data';
-import { SceneComponentProps, SceneObjectBase } from '@grafana/scenes';
+import { PageLayoutType, dateTimeFormat, dateTimeFormatTimeAgo } from '@grafana/data';
+import { SceneComponentProps, SceneObjectBase, sceneGraph } from '@grafana/scenes';
 import { Page } from 'app/core/components/Page/Page';
+import {
+  DecoratedRevisionModel,
+  VersionsHistorySpinner,
+} from 'app/features/dashboard/components/DashboardSettings/VersionsSettings';
+import { RevisionsModel, VersionHistoryTable, historySrv } from 'app/features/dashboard/components/VersionHistory';
 
 import { DashboardScene } from '../scene/DashboardScene';
 import { getDashboardSceneFor } from '../utils/utils';
 
 import { DashboardEditView, DashboardEditViewState, useDashboardEditPageNav } from './utils';
 
-export interface VersionsEditViewState extends DashboardEditViewState {}
+export const VERSIONS_FETCH_LIMIT = 10;
+
+export interface VersionsEditViewState extends DashboardEditViewState {
+  versions: DecoratedRevisionModel[];
+  isLoading?: boolean;
+  isAppending?: boolean;
+}
 
 export class VersionsEditView extends SceneObjectBase<VersionsEditViewState> implements DashboardEditView {
   public static Component = VersionsEditorSettingsListView;
+  private _limit: number = VERSIONS_FETCH_LIMIT;
+  private _start = 0;
+
+  constructor(state: VersionsEditViewState) {
+    super({
+      ...state,
+      versions: [],
+      isLoading: true,
+      isAppending: true,
+    });
+
+    this.addActivationHandler(() => {
+      this.fetchVersions();
+    });
+  }
+
+  private get _dashboard(): DashboardScene {
+    return getDashboardSceneFor(this);
+  }
+
+  public get limit(): number {
+    return this._limit;
+  }
+
+  public get start(): number {
+    return this._start;
+  }
 
   public getUrlKey(): string {
     return 'versions';
   }
 
   public getDashboard(): DashboardScene {
-    return getDashboardSceneFor(this);
+    return this._dashboard;
+  }
+
+  public getTimeRange() {
+    return sceneGraph.getTimeRange(this._dashboard);
+  }
+
+  public fetchVersions(append = false): void {
+    const uid = this._dashboard.state.uid;
+
+    if (!uid) {
+      return;
+    }
+
+    this.setState({ isAppending: append });
+
+    historySrv
+      .getHistoryList(uid, { limit: this._limit, start: this._start })
+      .then((result) => {
+        this.setState({
+          isLoading: false,
+          versions: [...(this.state.versions ?? []), ...this.decorateVersions(result)],
+        });
+        this._start += this._limit;
+      })
+      .catch((err) => console.log(err))
+      .finally(() => this.setState({ isAppending: false }));
+  }
+
+  private decorateVersions(versions: RevisionsModel[]): DecoratedRevisionModel[] {
+    const timeZone = this.getTimeRange().getTimeZone();
+
+    return versions.map((version) => {
+      return {
+        ...version,
+        createdDateString: dateTimeFormat(version.created, { timeZone: timeZone }),
+        ageString: dateTimeFormatTimeAgo(version.created, { timeZone: timeZone }),
+        checked: false,
+      };
+    });
   }
 }
 
 function VersionsEditorSettingsListView({ model }: SceneComponentProps<VersionsEditView>) {
   const dashboard = model.getDashboard();
-
+  const { versions, isLoading, isAppending } = model.useState();
   const { navModel, pageNav } = useDashboardEditPageNav(dashboard, model.getUrlKey());
+  const canCompare = versions.filter((version) => version.checked).length === 2;
 
   return (
     <Page navModel={navModel} pageNav={pageNav} layout={PageLayoutType.Standard}>
-      <div>TODO</div>
+      {isLoading ? (
+        <VersionsHistorySpinner msg="Fetching history list&hellip;" />
+      ) : (
+        <VersionHistoryTable
+          versions={versions}
+          onCheck={(x, y) => {
+            console.log('todo');
+          }}
+          canCompare={canCompare}
+        />
+      )}
+      {isAppending && <VersionsHistorySpinner msg="Fetching more entries&hellip;" />}
     </Page>
   );
 }

--- a/public/app/features/dashboard-scene/settings/utils.ts
+++ b/public/app/features/dashboard-scene/settings/utils.ts
@@ -12,6 +12,7 @@ import { AnnotationsEditView } from './AnnotationsEditView';
 import { DashboardLinksEditView } from './DashboardLinksEditView';
 import { GeneralSettingsEditView } from './GeneralSettingsEditView';
 import { VariablesEditView } from './VariablesEditView';
+import { VersionsEditView } from './VersionsEditView';
 
 export interface DashboardEditViewState extends SceneObjectState {}
 
@@ -54,6 +55,11 @@ export function useDashboardEditPageNav(dashboard: DashboardScene, currentEditVi
         url: locationUtil.getUrlForPartial(location, { editview: 'links', editIndex: null }),
         active: currentEditView === 'links',
       },
+      {
+        text: t('dashboard-settings.versions.title', 'Versions'),
+        url: locationUtil.getUrlForPartial(location, { editview: 'versions', editIndex: null }),
+        active: currentEditView === 'versions',
+      },
     ],
     parentItem: dashboardPageNav,
   };
@@ -69,6 +75,8 @@ export function createDashboardEditViewFor(editview: string): DashboardEditView 
       return new VariablesEditView({});
     case 'links':
       return new DashboardLinksEditView({});
+    case 'versions':
+      return new VersionsEditView({});
     case 'settings':
     default:
       return new GeneralSettingsEditView({});

--- a/public/app/features/dashboard-scene/settings/utils.ts
+++ b/public/app/features/dashboard-scene/settings/utils.ts
@@ -76,7 +76,7 @@ export function createDashboardEditViewFor(editview: string): DashboardEditView 
     case 'links':
       return new DashboardLinksEditView({});
     case 'versions':
-      return new VersionsEditView({});
+      return new VersionsEditView({ versions: [] });
     case 'settings':
     default:
       return new GeneralSettingsEditView({});

--- a/public/app/features/dashboard/components/DashboardSettings/VersionsSettings.tsx
+++ b/public/app/features/dashboard/components/DashboardSettings/VersionsSettings.tsx
@@ -63,7 +63,7 @@ export class VersionsSettings extends PureComponent<Props, State> {
   getVersions = (append = false) => {
     this.setState({ isAppending: append });
     historySrv
-      .getHistoryList(this.props.dashboard, { limit: this.limit, start: this.start })
+      .getHistoryList(this.props.dashboard.uid, { limit: this.limit, start: this.start })
       .then((res) => {
         this.setState({
           isLoading: false,
@@ -186,7 +186,7 @@ export class VersionsSettings extends PureComponent<Props, State> {
   }
 }
 
-const VersionsHistorySpinner = ({ msg }: { msg: string }) => (
+export const VersionsHistorySpinner = ({ msg }: { msg: string }) => (
   <HorizontalGroup>
     <Spinner />
     <em>{msg}</em>

--- a/public/app/features/dashboard/components/VersionHistory/HistorySrv.test.ts
+++ b/public/app/features/dashboard/components/VersionHistory/HistorySrv.test.ts
@@ -1,4 +1,3 @@
-import { DashboardModel } from '../../state/DashboardModel';
 import { createDashboardModelFixture } from '../../state/__fixtures__/dashboardFixtures';
 
 import { HistorySrv } from './HistorySrv';
@@ -39,19 +38,19 @@ describe('historySrv', () => {
       getMock.mockImplementation(() => Promise.resolve(versionsResponse));
       historySrv = new HistorySrv();
 
-      return historySrv.getHistoryList(dash, historyListOpts).then((versions) => {
+      return historySrv.getHistoryList(dash.uid, historyListOpts).then((versions) => {
         expect(versions).toEqual(versionsResponse);
       });
     });
 
     it('should return an empty array when not given an id', () => {
-      return historySrv.getHistoryList(emptyDash, historyListOpts).then((versions) => {
+      return historySrv.getHistoryList(emptyDash.uid, historyListOpts).then((versions) => {
         expect(versions).toEqual([]);
       });
     });
 
-    it('should return an empty array when not given a dashboard', () => {
-      return historySrv.getHistoryList(null as unknown as DashboardModel, historyListOpts).then((versions) => {
+    it('should return an empty array when not given a dashboard id', () => {
+      return historySrv.getHistoryList(null as unknown as string, historyListOpts).then((versions) => {
         expect(versions).toEqual([]);
       });
     });

--- a/public/app/features/dashboard/components/VersionHistory/HistorySrv.ts
+++ b/public/app/features/dashboard/components/VersionHistory/HistorySrv.ts
@@ -27,9 +27,12 @@ export interface DiffTarget {
 }
 
 export class HistorySrv {
-  getHistoryList(dashboard: DashboardModel, options: HistoryListOpts) {
-    const uid = dashboard && dashboard.uid ? dashboard.uid : void 0;
-    return uid ? getBackendSrv().get(`api/dashboards/uid/${uid}/versions`, options) : Promise.resolve([]);
+  getHistoryList(dashboardUID: string, options: HistoryListOpts) {
+    if (typeof dashboardUID !== 'string') {
+      return Promise.resolve([]);
+    }
+
+    return getBackendSrv().get(`api/dashboards/uid/${dashboardUID}/versions`, options);
   }
 
   getDashboardVersion(uid: string, version: number) {


### PR DESCRIPTION
Covers the second part - "A list of dashboard versions is fetched and rendered" - of versions settings page migration https://github.com/grafana/grafana/issues/80058