### PR TITLE
Update rasp pi install tutorial, correct APT install steps

### DIFF
--- a/docs/sources/tutorials/install-grafana-on-raspberry-pi/index.md
+++ b/docs/sources/tutorials/install-grafana-on-raspberry-pi/index.md
@@ -51,7 +51,7 @@ Follow the directions on the website to download and install the imager.
 
 #### Install Raspberry Pi OS
 
-Now it is time to install Raspberry Pi OS.
+Now it's time to install Raspberry Pi OS.
 
 1. Insert the SD card into your regular computer from which you plan to install Raspberry Pi OS.
 1. Run the Raspberry Pi Imager that you downloaded and installed.
@@ -69,7 +69,7 @@ While you _could_ fire up the Raspberry Pi now, we don't yet have any way of acc
 
 1. **(Optional)** Create a file called `wpa_supplicant.conf` in the boot directory:
 
-   ```
+   ```bash
    ctrl_interface=/var/run/wpa_supplicant
    update_config=1
    country=<Insert 2 letter ISO 3166-1 country code here>
@@ -89,13 +89,16 @@ All the necessary files are now on the SD card. Let's start up the Raspberry Pi.
 #### Connect remotely via SSH
 
 1. Open up your terminal and enter the following command:
-   ```
+
+   ```bash
    ssh pi@<ip address>
    ```
+
 1. SSH warns you that the authenticity of the host can't be established. Type "yes" to continue connecting.
 1. When asked for a password, enter the default password: `raspberry`.
 1. Once you're logged in, change the default password:
-   ```
+
+   ```bash
    passwd
    ```
 
@@ -107,18 +110,19 @@ Now that you've got the Raspberry Pi up and running, the next step is to install
 
 1. Add the APT key used to authenticate packages:
 
-   ```
-   wget -q -O - https://packages.grafana.com/gpg.key | sudo apt-key add -
+   ```bash
+   wget -q -O - https://apt.grafana.com/gpg.key | gpg --dearmor | sudo tee /etc/apt/keyrings/grafana.gpg > /dev/null
    ```
 
 1. Add the Grafana APT repository:
 
-   ```
-   echo "deb https://packages.grafana.com/oss/deb stable main" | sudo tee -a /etc/apt/sources.list.d/grafana.list
+   ```bash
+   echo "deb [signed-by=/etc/apt/keyrings/grafana.gpg] https://apt.grafana.com stable main" | sudo tee /etc/apt/sources.list.d/grafana.list
    ```
 
 1. Install Grafana:
-   ```
+
+   ```bash
    sudo apt-get update
    sudo apt-get install -y grafana
    ```
@@ -127,13 +131,13 @@ Grafana is now installed, but not yet running. To make sure Grafana starts up ev
 
 1. Enable the Grafana server:
 
-   ```
+   ```bash
    sudo /bin/systemctl enable grafana-server
    ```
 
 1. Start the Grafana server:
 
-   ```
+   ```bash
    sudo /bin/systemctl start grafana-server
    ```
 
@@ -143,7 +147,7 @@ Grafana is now installed, but not yet running. To make sure Grafana starts up ev
 1. Log in to Grafana with the default username `admin`, and the default password `admin`.
 1. Change the password for the admin user when asked.
 
-Congratulations! Grafana is now running on your Raspberry Pi. If the Raspberry Pi is ever restarted or turned off, Grafana will start up whenever the machine regains power.
+Congratulations, Grafana is now running on your Raspberry Pi. If the Raspberry Pi is ever restarted or turned off, Grafana will start up whenever the machine regains power.
 
 ## Summary
 

--- a/docs/sources/tutorials/install-grafana-on-raspberry-pi/index.md
+++ b/docs/sources/tutorials/install-grafana-on-raspberry-pi/index.md
@@ -111,6 +111,7 @@ Now that you've got the Raspberry Pi up and running, the next step is to install
 1. Add the APT key used to authenticate packages:
 
    ```bash
+   sudo mkdir -p /etc/apt/keyrings/
    wget -q -O - https://apt.grafana.com/gpg.key | gpg --dearmor | sudo tee /etc/apt/keyrings/grafana.gpg > /dev/null
    ```
 


### PR DESCRIPTION
This PR fixes the last open task in Issue https://github.com/grafana/grafana/issues/72687 

* Correct APT installation steps for installing Grafana on Debian based Linux distros.
* Some minor cleanup is inscluded - adding bash to codefence

**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/grafana/issues/72687

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
