### PR TITLE
docs: add grafana video to install grafana page

### DIFF
--- a/docs/sources/setup-grafana/installation/mac/index.md
+++ b/docs/sources/setup-grafana/installation/mac/index.md
@@ -61,6 +61,10 @@ To install Grafana on macOS using the standalone binaries, complete the followin
    ./bin/grafana server
    ```
 
+Alternatively, watch the Grafana for Beginners video below:
+
+{{< youtube id="T51Qa7eE3W8" >}}
+
 ## Next steps
 
 - [Start the Grafana server]({{< relref "../../start-restart-grafana" >}})


### PR DESCRIPTION
**What is this feature?**

Update docs to include the Grafana for beginner video on installing Grafana on macOS.

**Why do we need this feature?**

[Add a description of the problem the feature is trying to solve.]

**Who is this feature for?**

[Add information on what kind of user the feature is for.]

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
