### PR TITLE
Runtime: Add property for disabling caching

### DIFF
--- a/packages/grafana-data/src/types/datasource.ts
+++ b/packages/grafana-data/src/types/datasource.ts
@@ -619,7 +619,7 @@ export interface DataSourceJsonData {
   profile?: string;
   manageAlerts?: boolean;
   alertmanagerUid?: string;
-  disableGrafanaCache?: boolean
+  disableGrafanaCache?: boolean;
 }
 
 /**

--- a/packages/grafana-data/src/types/datasource.ts
+++ b/packages/grafana-data/src/types/datasource.ts
@@ -619,6 +619,7 @@ export interface DataSourceJsonData {
   profile?: string;
   manageAlerts?: boolean;
   alertmanagerUid?: string;
+  disableGrafanaCache?: boolean
 }
 
 /**


### PR DESCRIPTION
As a part of implementing user-based authentication, it is necessary to disable caching for security reasons. Caching should be disabled at a data source level based on the configuration of the data source.

In order to support this, an additional property has been added to the data source JSON data that will indicate to the caching service whether or not a data source instance supports caching.

Part of grafana/grafana-enterprise-mirror-shared-microsoft#170

Fixes #85634 