### PR TITLE
Chore: Fix levitate workflow to not post a comment when there's no breaking change

### DIFF
--- a/.github/workflows/detect-breaking-changes-levitate.yml
+++ b/.github/workflows/detect-breaking-changes-levitate.yml
@@ -223,6 +223,7 @@ jobs:
 
         # Comment on the PR
         - name: Comment on PR
+          if: steps.levitate-run.outputs.exit_code == 1
           uses: marocchino/sticky-pull-request-comment@v2
           with:
             header: levitate-breaking-change-comment


### PR DESCRIPTION
**What is this feature?**

Fixes an issue in the levitate detect breaking changes workflow so it doesn't post an empty breaking change message and delete it immediately after.

**Why do we need this feature?**

Reduce noise in PRs

**Who is this feature for?**

All grafana developers

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:

- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
