### PR TITLE
Documentation: Add minimal doc for using own CA

### DIFF
--- a/docs/sources/setup-grafana/set-up-https.md
+++ b/docs/sources/setup-grafana/set-up-https.md
@@ -224,7 +224,7 @@ To adjust permissions, perform the following steps:
 
 ### Use your own CA
 
-If you want to use your own CA or your organization's and make sure the full chain is advertized by Grafana, make sure your `cert_file` contains your signed certificate followed by the full CA bundle chain (not the opposite way around).
+If you want to use your own CA or your organization's and ensure Grafana advertises the full chain, ensure your `cert_file` contains your signed certificate followed by the full CA bundle chain.
 
 ## Configure Grafana HTTPS and restart Grafana
 

--- a/docs/sources/setup-grafana/set-up-https.md
+++ b/docs/sources/setup-grafana/set-up-https.md
@@ -222,6 +222,10 @@ To adjust permissions, perform the following steps:
    lrwxrwxrwx 1 root grafana    65 Mar 22 14:15 /etc/grafana/grafana.key -> /etc/letsencrypt/live/subdomain.mysite.com/privkey.pem
    ```
 
+### Use your own CA
+
+If you want to use your own CA or your organization's and make sure the full chain is advertized by Grafana, make sure your `cert_file` contains your signed certificate followed by the full CA bundle chain (not the opposite way around).
+
 ## Configure Grafana HTTPS and restart Grafana
 
 In this section you edit the `grafana.ini` file so that it includes the certificate you created. If you need help identifying where to find this file, or what each key means, refer to [Configuration file location]({{< relref "./configure-grafana#configuration-file-location" >}}).


### PR DESCRIPTION
It's not clear how to advertise the CA chain as there doesn't seem to be an option to use a trusted bundle. It seems to be possible (tested with grafana 9) to concatenate the server certificate with the bundle in the same file.