### PR TITLE
Supplementary queries: allow plugin decoupling by allowing providers to return a request instance

### DIFF
--- a/.betterer.results
+++ b/.betterer.results
@@ -328,9 +328,6 @@ exports[`better eslint`] = {
       [0, 0, 0, "Do not use any type assertions.", "7"],
       [0, 0, 0, "Do not use any type assertions.", "8"]
     ],
-    "packages/grafana-data/src/types/logs.ts:5381": [
-      [0, 0, 0, "Do not use any type assertions.", "0"]
-    ],
     "packages/grafana-data/src/types/options.ts:5381": [
       [0, 0, 0, "Unexpected any. Specify a different type.", "0"],
       [0, 0, 0, "Unexpected any. Specify a different type.", "1"]

--- a/packages/grafana-data/src/types/logs.ts
+++ b/packages/grafana-data/src/types/logs.ts
@@ -1,5 +1,3 @@
-import { Observable } from 'rxjs';
-
 import { DataQuery } from '@grafana/schema';
 
 import { KeyValue, Labels } from './data';

--- a/packages/grafana-data/src/types/logs.ts
+++ b/packages/grafana-data/src/types/logs.ts
@@ -229,7 +229,7 @@ export interface DataSourceWithSupplementaryQueriesSupport<TQuery extends DataQu
   getDataProvider(
     type: SupplementaryQueryType,
     request: DataQueryRequest<TQuery>
-  ): Observable<DataQueryResponse> | undefined;
+  ): Observable<DataQueryResponse> | DataQueryRequest<TQuery> | undefined;
   /**
    * Returns supplementary query types that data source supports.
    */

--- a/packages/grafana-data/src/types/logs.ts
+++ b/packages/grafana-data/src/types/logs.ts
@@ -229,7 +229,7 @@ export interface DataSourceWithSupplementaryQueriesSupport<TQuery extends DataQu
   getDataProvider(
     type: SupplementaryQueryType,
     request: DataQueryRequest<TQuery>
-  ): Observable<DataQueryResponse> | DataQueryRequest<TQuery> | undefined;
+  ): DataQueryRequest<TQuery> | undefined;
   /**
    * Returns supplementary query types that data source supports.
    */

--- a/packages/grafana-data/src/types/logs.ts
+++ b/packages/grafana-data/src/types/logs.ts
@@ -251,7 +251,7 @@ export interface DataSourceWithSupplementaryQueriesSupport<TQuery extends DataQu
 }
 
 export const hasSupplementaryQuerySupport = <TQuery extends DataQuery>(
-  datasource: DataSourceApi | DataSourceApi & DataSourceWithSupplementaryQueriesSupport<TQuery>,
+  datasource: DataSourceApi | (DataSourceApi & DataSourceWithSupplementaryQueriesSupport<TQuery>),
   type: SupplementaryQueryType
 ): datasource is DataSourceApi & DataSourceWithSupplementaryQueriesSupport<TQuery> => {
   if (!datasource) {

--- a/packages/grafana-data/src/types/logs.ts
+++ b/packages/grafana-data/src/types/logs.ts
@@ -4,7 +4,7 @@ import { DataQuery } from '@grafana/schema';
 
 import { KeyValue, Labels } from './data';
 import { DataFrame } from './dataFrame';
-import { DataQueryRequest, DataQueryResponse, QueryFixAction, QueryFixType } from './datasource';
+import { DataQueryRequest, DataQueryResponse, DataSourceApi, QueryFixAction, QueryFixType } from './datasource';
 import { AbsoluteTimeRange } from './time';
 export { LogsDedupStrategy, LogsSortOrder } from '@grafana/schema';
 
@@ -251,19 +251,18 @@ export interface DataSourceWithSupplementaryQueriesSupport<TQuery extends DataQu
 }
 
 export const hasSupplementaryQuerySupport = <TQuery extends DataQuery>(
-  datasource: unknown,
+  datasource: DataSourceApi | DataSourceApi & DataSourceWithSupplementaryQueriesSupport<TQuery>,
   type: SupplementaryQueryType
-): datasource is DataSourceWithSupplementaryQueriesSupport<TQuery> => {
+): datasource is DataSourceApi & DataSourceWithSupplementaryQueriesSupport<TQuery> => {
   if (!datasource) {
     return false;
   }
 
-  const withSupplementaryQueriesSupport = datasource as DataSourceWithSupplementaryQueriesSupport<TQuery>;
-
   return (
-    withSupplementaryQueriesSupport.getDataProvider !== undefined &&
-    withSupplementaryQueriesSupport.getSupplementaryQuery !== undefined &&
-    withSupplementaryQueriesSupport.getSupportedSupplementaryQueryTypes().includes(type)
+    ('getDataProvider' in datasource || 'getSupplementaryRequest' in datasource) &&
+    'getSupplementaryQuery' in datasource &&
+    'getSupportedSupplementaryQueryTypes' in datasource &&
+    datasource.getSupportedSupplementaryQueryTypes().includes(type)
   );
 };
 

--- a/packages/grafana-data/src/types/logs.ts
+++ b/packages/grafana-data/src/types/logs.ts
@@ -1,3 +1,5 @@
+import { Observable } from 'rxjs';
+
 import { DataQuery } from '@grafana/schema';
 
 import { KeyValue, Labels } from './data';
@@ -223,8 +225,17 @@ export interface DataSourceWithSupplementaryQueriesSupport<TQuery extends DataQu
   /**
    * Returns an observable that will be used to fetch supplementary data based on the provided
    * supplementary query type and original request.
+   * @deprecated Use getSupplementaryQueryRequest() instead
    */
-  getDataProvider(
+  getDataProvider?(
+    type: SupplementaryQueryType,
+    request: DataQueryRequest<TQuery>
+  ): Observable<DataQueryResponse> | undefined;
+  /**
+   * Given a DataQueryRequest returns a new DataQueryRequest to be used to fetch supplementary data.
+   * If provided reqeust is not suitable for a supplementary data request, undefined should be returned.
+   */
+  getSupplementaryRequest?(
     type: SupplementaryQueryType,
     request: DataQueryRequest<TQuery>
   ): DataQueryRequest<TQuery> | undefined;
@@ -234,7 +245,7 @@ export interface DataSourceWithSupplementaryQueriesSupport<TQuery extends DataQu
   getSupportedSupplementaryQueryTypes(): SupplementaryQueryType[];
   /**
    * Returns a supplementary query to be used to fetch supplementary data based on the provided type and original query.
-   * If provided query is not suitable for provided supplementary query type, undefined should be returned.
+   * If the provided query is not suitable for the provided supplementary query type, undefined should be returned.
    */
   getSupplementaryQuery(options: SupplementaryQueryOptions, originalQuery: TQuery): TQuery | undefined;
 }

--- a/packages/grafana-data/src/types/logs.ts
+++ b/packages/grafana-data/src/types/logs.ts
@@ -232,8 +232,8 @@ export interface DataSourceWithSupplementaryQueriesSupport<TQuery extends DataQu
     request: DataQueryRequest<TQuery>
   ): Observable<DataQueryResponse> | undefined;
   /**
-   * Given a DataQueryRequest returns a new DataQueryRequest to be used to fetch supplementary data.
-   * If provided reqeust is not suitable for a supplementary data request, undefined should be returned.
+   * Receives a SupplementaryQueryType and a DataQueryRequest and returns a new DataQueryRequest to fetch supplementary data.
+   * If provided type or request is not suitable for a supplementary data request, returns undefined.
    */
   getSupplementaryRequest?(
     type: SupplementaryQueryType,

--- a/public/app/features/explore/Logs/LogsSamplePanel.tsx
+++ b/public/app/features/explore/Logs/LogsSamplePanel.tsx
@@ -45,6 +45,9 @@ export function LogsSamplePanel(props: Props) {
   };
 
   const OpenInSplitViewButton = () => {
+    if (!datasourceInstance) {
+      return null;
+    }
     if (!hasSupplementaryQuerySupport(datasourceInstance, SupplementaryQueryType.LogsSample)) {
       return null;
     }

--- a/public/app/features/explore/state/query.test.ts
+++ b/public/app/features/explore/state/query.test.ts
@@ -16,6 +16,7 @@ import {
   SupplementaryQueryType,
 } from '@grafana/data';
 import { DataQuery, DataSourceRef } from '@grafana/schema';
+import { queryLogsSample, queryLogsVolume } from 'app/features/logs/logsModel';
 import { createAsyncThunk, ExploreItemState, StoreState, ThunkDispatch } from 'app/types';
 
 import { reducerTester } from '../../../../test/core/redux/reducerTester';
@@ -48,6 +49,8 @@ import {
 } from './query';
 import * as actions from './query';
 import { makeExplorePaneState } from './utils';
+
+jest.mock('app/features/logs/logsModel');
 
 const { testRange, defaultInitialState } = createDefaultInitialState();
 
@@ -866,6 +869,9 @@ describe('reducer', () => {
         } as unknown as Observable<DataQueryResponse>;
       };
 
+      jest.mocked(queryLogsVolume).mockImplementation(() => mockDataProvider());
+      jest.mocked(queryLogsSample).mockImplementation(() => mockDataProvider());
+
       const store: { dispatch: ThunkDispatch; getState: () => StoreState } = configureStore({
         ...defaultInitialState,
         explore: {
@@ -878,8 +884,8 @@ describe('reducer', () => {
                 meta: {
                   id: 'something',
                 },
-                getDataProvider: () => {
-                  return mockDataProvider();
+                getDataProvider: (_: SupplementaryQueryType, request: DataQueryRequest<DataQuery>) => {
+                  return request;
                 },
                 getSupportedSupplementaryQueryTypes: () => [
                   SupplementaryQueryType.LogsVolume,

--- a/public/app/features/explore/utils/supplementaryQueries.test.ts
+++ b/public/app/features/explore/utils/supplementaryQueries.test.ts
@@ -40,10 +40,11 @@ class MockDataSourceWithSupplementaryQuerySupport
   }
 
   query(_: DataQueryRequest): Observable<DataQueryResponse> {
-    const data = this.supplementaryQueriesResults[SupplementaryQueryType.LogsVolume] || this.supplementaryQueriesResults[SupplementaryQueryType.LogsSample] || [];
-    return from([
-      { state: LoadingState.Done, data },
-    ]);
+    const data =
+      this.supplementaryQueriesResults[SupplementaryQueryType.LogsVolume] ||
+      this.supplementaryQueriesResults[SupplementaryQueryType.LogsSample] ||
+      [];
+    return from([{ state: LoadingState.Done, data }]);
   }
 
   getDataProvider(
@@ -146,11 +147,11 @@ const setup = (targetSources: string[], type: SupplementaryQueryType) => {
   const explorePanelDataMock: Observable<ExplorePanelData> = mockExploreDataWithLogs();
 
   const groupedQueries = targetSources.map((source, i) => {
-    const datasource = datasources.find(datasource => datasource.name === source) || datasources[0];
+    const datasource = datasources.find((datasource) => datasource.name === source) || datasources[0];
     return {
       datasource,
       targets: [new MockQuery(`${i}`, 'a', { uid: datasource.name })],
-    }
+    };
   });
 
   return getSupplementaryQueryProvider(groupedQueries, type, requestMock, explorePanelDataMock);
@@ -240,10 +241,7 @@ describe('SupplementaryQueries utils', function () {
 
       describe('All data sources do not support full range logs volume', function () {
         it('Creates single fallback result', async () => {
-          const testProvider = setup(
-            ['no-data-providers', 'no-data-providers-2'],
-            SupplementaryQueryType.LogsVolume
-          );
+          const testProvider = setup(['no-data-providers', 'no-data-providers-2'], SupplementaryQueryType.LogsVolume);
 
           await expect(testProvider).toEmitValuesWith((received) => {
             expect(received).toMatchObject([
@@ -319,10 +317,7 @@ describe('SupplementaryQueries utils', function () {
 
       describe('All data sources do not support full range logs volume', function () {
         it('Does not provide fallback result', async () => {
-          const testProvider = setup(
-            ['no-data-providers', 'no-data-providers-2'],
-            SupplementaryQueryType.LogsSample
-          );
+          const testProvider = setup(['no-data-providers', 'no-data-providers-2'], SupplementaryQueryType.LogsSample);
           await expect(testProvider).toBeUndefined();
         });
       });

--- a/public/app/features/explore/utils/supplementaryQueries.test.ts
+++ b/public/app/features/explore/utils/supplementaryQueries.test.ts
@@ -1,10 +1,9 @@
 import { flatten } from 'lodash';
-import { from, Observable } from 'rxjs';
+import { Observable, from } from 'rxjs';
 
 import {
   DataFrame,
   DataQueryRequest,
-  DataQueryResponse,
   DataSourceApi,
   DataSourceWithSupplementaryQueriesSupport,
   FieldType,
@@ -15,8 +14,8 @@ import {
   SupplementaryQueryType,
   SupplementaryQueryOptions,
   toDataFrame,
+  DataQueryResponse,
 } from '@grafana/data';
-import { getDataSourceSrv } from '@grafana/runtime';
 import { DataQuery } from '@grafana/schema';
 
 import { MockDataSourceApi } from '../../../../test/mocks/datasource_srv';
@@ -40,21 +39,25 @@ class MockDataSourceWithSupplementaryQuerySupport
     return this;
   }
 
+  query(_: DataQueryRequest): Observable<DataQueryResponse> {
+    const data = this.supplementaryQueriesResults[SupplementaryQueryType.LogsVolume] || this.supplementaryQueriesResults[SupplementaryQueryType.LogsSample] || [];
+    return from([
+      { state: LoadingState.Done, data },
+    ]);
+  }
+
   getDataProvider(
     type: SupplementaryQueryType,
     request: DataQueryRequest<DataQuery>
-  ): Observable<DataQueryResponse> | undefined {
+  ): DataQueryRequest<DataQuery> | undefined {
     const data = this.supplementaryQueriesResults[type];
     if (data) {
-      return from([
-        { state: LoadingState.Loading, data: [] },
-        { state: LoadingState.Done, data },
-      ]);
+      return request;
     }
     return undefined;
   }
 
-  getSupplementaryQuery(options: SupplementaryQueryOptions, query: DataQuery): DataQuery | undefined {
+  getSupplementaryQuery(_: SupplementaryQueryOptions, query: DataQuery): DataQuery | undefined {
     return query;
   }
 
@@ -136,38 +139,27 @@ const datasources: DataSourceApi[] = [
   new MockDataSourceApi('no-data-providers-2'),
 ];
 
-jest.mock('@grafana/runtime', () => ({
-  ...jest.requireActual('@grafana/runtime'),
-  getDataSourceSrv: () => {
-    return {
-      get: async ({ uid }: { uid: string }) => datasources.find((ds) => ds.name === uid) || undefined,
-    };
-  },
-}));
-
-const setup = async (targetSources: string[], type: SupplementaryQueryType) => {
+const setup = (targetSources: string[], type: SupplementaryQueryType) => {
   const requestMock = new MockDataQueryRequest({
     targets: targetSources.map((source, i) => new MockQuery(`${i}`, 'a', { uid: source })),
   });
   const explorePanelDataMock: Observable<ExplorePanelData> = mockExploreDataWithLogs();
 
-  const datasources = await Promise.all(
-    targetSources.map(async (source, i) => {
-      const datasource = await getDataSourceSrv().get({ uid: source });
-      return {
-        datasource,
-        targets: [new MockQuery(`${i}`, 'a', { uid: source })],
-      };
-    })
-  );
+  const groupedQueries = targetSources.map((source, i) => {
+    const datasource = datasources.find(datasource => datasource.name === source) || datasources[0];
+    return {
+      datasource,
+      targets: [new MockQuery(`${i}`, 'a', { uid: datasource.name })],
+    }
+  });
 
-  return getSupplementaryQueryProvider(datasources, type, requestMock, explorePanelDataMock);
+  return getSupplementaryQueryProvider(groupedQueries, type, requestMock, explorePanelDataMock);
 };
 
 const assertDataFrom = (type: SupplementaryQueryType, ...datasources: string[]) => {
   return flatten(
     datasources.map((name: string) => {
-      return [{ refId: `1-${type}-${name}` }, { refId: `2-${type}-${name}` }];
+      return createSupplementaryQueryResponse(type, name);
     })
   );
 };
@@ -179,7 +171,7 @@ const assertDataFromLogsResults = () => {
 describe('SupplementaryQueries utils', function () {
   describe('Non-mixed data source', function () {
     it('Returns result from the provider', async () => {
-      const testProvider = await setup(['logs-volume-a'], SupplementaryQueryType.LogsVolume);
+      const testProvider = setup(['logs-volume-a'], SupplementaryQueryType.LogsVolume);
 
       await expect(testProvider).toEmitValuesWith((received) => {
         expect(received).toMatchObject([
@@ -192,7 +184,7 @@ describe('SupplementaryQueries utils', function () {
       });
     });
     it('Uses fallback for logs volume', async () => {
-      const testProvider = await setup(['no-data-providers'], SupplementaryQueryType.LogsVolume);
+      const testProvider = setup(['no-data-providers'], SupplementaryQueryType.LogsVolume);
 
       await expect(testProvider).toEmitValuesWith((received) => {
         expect(received).toMatchObject([
@@ -204,11 +196,11 @@ describe('SupplementaryQueries utils', function () {
       });
     });
     it('Returns undefined for logs sample', async () => {
-      const testProvider = await setup(['no-data-providers'], SupplementaryQueryType.LogsSample);
+      const testProvider = setup(['no-data-providers'], SupplementaryQueryType.LogsSample);
       await expect(testProvider).toBe(undefined);
     });
     it('Creates single fallback result', async () => {
-      const testProvider = await setup(['no-data-providers', 'no-data-providers-2'], SupplementaryQueryType.LogsVolume);
+      const testProvider = setup(['no-data-providers', 'no-data-providers-2'], SupplementaryQueryType.LogsVolume);
 
       await expect(testProvider).toEmitValuesWith((received) => {
         expect(received).toMatchObject([
@@ -229,7 +221,7 @@ describe('SupplementaryQueries utils', function () {
     describe('Logs volume', function () {
       describe('All data sources support full range logs volume', function () {
         it('Merges all data frames into a single response', async () => {
-          const testProvider = await setup(['logs-volume-a', 'logs-volume-b'], SupplementaryQueryType.LogsVolume);
+          const testProvider = setup(['logs-volume-a', 'logs-volume-b'], SupplementaryQueryType.LogsVolume);
           await expect(testProvider).toEmitValuesWith((received) => {
             expect(received).toMatchObject([
               { data: [], state: LoadingState.Loading },
@@ -248,7 +240,7 @@ describe('SupplementaryQueries utils', function () {
 
       describe('All data sources do not support full range logs volume', function () {
         it('Creates single fallback result', async () => {
-          const testProvider = await setup(
+          const testProvider = setup(
             ['no-data-providers', 'no-data-providers-2'],
             SupplementaryQueryType.LogsVolume
           );
@@ -270,7 +262,7 @@ describe('SupplementaryQueries utils', function () {
 
       describe('Some data sources support full range logs volume, while others do not', function () {
         it('Creates merged result containing full range and limited logs volume', async () => {
-          const testProvider = await setup(
+          const testProvider = setup(
             ['logs-volume-a', 'no-data-providers', 'logs-volume-b', 'no-data-providers-2'],
             SupplementaryQueryType.LogsVolume
           );
@@ -308,7 +300,7 @@ describe('SupplementaryQueries utils', function () {
     describe('Logs sample', function () {
       describe('All data sources support logs sample', function () {
         it('Merges all responses into single result', async () => {
-          const testProvider = await setup(['logs-sample-a', 'logs-sample-b'], SupplementaryQueryType.LogsSample);
+          const testProvider = setup(['logs-sample-a', 'logs-sample-b'], SupplementaryQueryType.LogsSample);
           await expect(testProvider).toEmitValuesWith((received) => {
             expect(received).toMatchObject([
               { data: [], state: LoadingState.Loading },
@@ -327,7 +319,7 @@ describe('SupplementaryQueries utils', function () {
 
       describe('All data sources do not support full range logs volume', function () {
         it('Does not provide fallback result', async () => {
-          const testProvider = await setup(
+          const testProvider = setup(
             ['no-data-providers', 'no-data-providers-2'],
             SupplementaryQueryType.LogsSample
           );
@@ -337,7 +329,7 @@ describe('SupplementaryQueries utils', function () {
 
       describe('Some data sources support full range logs volume, while others do not', function () {
         it('Returns results only for data sources supporting logs sample', async () => {
-          const testProvider = await setup(
+          const testProvider = setup(
             ['logs-sample-a', 'no-data-providers', 'logs-sample-b', 'no-data-providers-2'],
             SupplementaryQueryType.LogsSample
           );

--- a/public/app/features/explore/utils/supplementaryQueries.test.ts
+++ b/public/app/features/explore/utils/supplementaryQueries.test.ts
@@ -47,7 +47,7 @@ class MockDataSourceWithSupplementaryQuerySupport
     return from([{ state: LoadingState.Done, data }]);
   }
 
-  getDataProvider(
+  getSupplementaryRequest(
     type: SupplementaryQueryType,
     request: DataQueryRequest<DataQuery>
   ): DataQueryRequest<DataQuery> | undefined {

--- a/public/app/features/explore/utils/supplementaryQueries.ts
+++ b/public/app/features/explore/utils/supplementaryQueries.ts
@@ -1,5 +1,5 @@
 import { cloneDeep, groupBy } from 'lodash';
-import { distinct, Observable, merge, isObservable } from 'rxjs';
+import { distinct, Observable, merge } from 'rxjs';
 import { scan } from 'rxjs/operators';
 
 import {
@@ -131,7 +131,7 @@ export const getSupplementaryQueryProvider = (
 
     if (hasSupplementaryQuerySupport(datasource, type)) {
       const provider = datasource.getDataProvider(type, dsRequest);
-      if (provider === undefined || isObservable(provider)) {
+      if (!provider) {
         return provider;
       }
       return type === SupplementaryQueryType.LogsVolume

--- a/public/app/features/explore/utils/supplementaryQueries.ts
+++ b/public/app/features/explore/utils/supplementaryQueries.ts
@@ -135,7 +135,7 @@ export const getSupplementaryQueryProvider = (
         return provider;
       }
       return type === SupplementaryQueryType.LogsVolume
-        ? queryLogsVolume(datasource, provider)
+        ? queryLogsVolume(datasource, provider, { targets: dsRequest.targets })
         : queryLogsSample(datasource, provider);
     } else {
       return getSupplementaryQueryFallback(type, explorePanelData, targets, datasource.name);

--- a/public/app/features/explore/utils/supplementaryQueries.ts
+++ b/public/app/features/explore/utils/supplementaryQueries.ts
@@ -134,7 +134,9 @@ export const getSupplementaryQueryProvider = (
       if (provider === undefined || isObservable(provider)) {
         return provider;
       }
-      return type === SupplementaryQueryType.LogsVolume ? queryLogsVolume(datasource, provider) : queryLogsSample(datasource, provider);
+      return type === SupplementaryQueryType.LogsVolume
+        ? queryLogsVolume(datasource, provider)
+        : queryLogsSample(datasource, provider);
     } else {
       return getSupplementaryQueryFallback(type, explorePanelData, targets, datasource.name);
     }

--- a/public/app/features/explore/utils/supplementaryQueries.ts
+++ b/public/app/features/explore/utils/supplementaryQueries.ts
@@ -130,13 +130,19 @@ export const getSupplementaryQueryProvider = (
     dsRequest.targets = targets;
 
     if (hasSupplementaryQuerySupport(datasource, type)) {
-      const provider = datasource.getDataProvider(type, dsRequest);
-      if (!provider) {
-        return provider;
+      if (datasource.getDataProvider) {
+        return datasource.getDataProvider(type, dsRequest);
+      } else if (datasource.getSupplementaryRequest) {
+        const provider = datasource.getSupplementaryRequest(type, dsRequest);
+        if (!provider) {
+          return provider;
+        }
+        return type === SupplementaryQueryType.LogsVolume
+          ? queryLogsVolume(datasource, provider, { targets: dsRequest.targets })
+          : queryLogsSample(datasource, provider);
+      } else {
+        return undefined;
       }
-      return type === SupplementaryQueryType.LogsVolume
-        ? queryLogsVolume(datasource, provider, { targets: dsRequest.targets })
-        : queryLogsSample(datasource, provider);
     } else {
       return getSupplementaryQueryFallback(type, explorePanelData, targets, datasource.name);
     }

--- a/public/app/features/explore/utils/supplementaryQueries.ts
+++ b/public/app/features/explore/utils/supplementaryQueries.ts
@@ -133,13 +133,13 @@ export const getSupplementaryQueryProvider = (
       if (datasource.getDataProvider) {
         return datasource.getDataProvider(type, dsRequest);
       } else if (datasource.getSupplementaryRequest) {
-        const provider = datasource.getSupplementaryRequest(type, dsRequest);
+        const request = datasource.getSupplementaryRequest(type, dsRequest);
         if (!provider) {
-          return provider;
+          return undefined;
         }
         return type === SupplementaryQueryType.LogsVolume
-          ? queryLogsVolume(datasource, provider, { targets: dsRequest.targets })
-          : queryLogsSample(datasource, provider);
+          ? queryLogsVolume(datasource, request, { targets: dsRequest.targets })
+          : queryLogsSample(datasource, request);
       } else {
         return undefined;
       }

--- a/public/app/features/explore/utils/supplementaryQueries.ts
+++ b/public/app/features/explore/utils/supplementaryQueries.ts
@@ -134,7 +134,7 @@ export const getSupplementaryQueryProvider = (
         return datasource.getDataProvider(type, dsRequest);
       } else if (datasource.getSupplementaryRequest) {
         const request = datasource.getSupplementaryRequest(type, dsRequest);
-        if (!provider) {
+        if (!request) {
           return undefined;
         }
         return type === SupplementaryQueryType.LogsVolume

--- a/public/app/features/explore/utils/supplementaryQueries_legacy.test.ts
+++ b/public/app/features/explore/utils/supplementaryQueries_legacy.test.ts
@@ -1,0 +1,361 @@
+import { flatten } from 'lodash';
+import { from, Observable } from 'rxjs';
+
+import {
+  DataFrame,
+  DataQueryRequest,
+  DataQueryResponse,
+  DataSourceApi,
+  DataSourceWithSupplementaryQueriesSupport,
+  FieldType,
+  LoadingState,
+  LogLevel,
+  LogsVolumeType,
+  MutableDataFrame,
+  SupplementaryQueryType,
+  SupplementaryQueryOptions,
+  toDataFrame,
+} from '@grafana/data';
+import { getDataSourceSrv } from '@grafana/runtime';
+import { DataQuery } from '@grafana/schema';
+
+import { MockDataSourceApi } from '../../../../test/mocks/datasource_srv';
+import { MockDataQueryRequest, MockQuery } from '../../../../test/mocks/query';
+import { ExplorePanelData } from '../../../types';
+import { mockExplorePanelData } from '../__mocks__/data';
+
+import { getSupplementaryQueryProvider } from './supplementaryQueries';
+
+class MockDataSourceWithSupplementaryQuerySupport
+  extends MockDataSourceApi
+  implements DataSourceWithSupplementaryQueriesSupport<DataQuery>
+{
+  private supplementaryQueriesResults: Record<SupplementaryQueryType, DataFrame[] | undefined> = {
+    [SupplementaryQueryType.LogsVolume]: undefined,
+    [SupplementaryQueryType.LogsSample]: undefined,
+  };
+
+  withSupplementaryQuerySupport(type: SupplementaryQueryType, data: DataFrame[]) {
+    this.supplementaryQueriesResults[type] = data;
+    return this;
+  }
+
+  getDataProvider(
+    type: SupplementaryQueryType,
+    request: DataQueryRequest<DataQuery>
+  ): Observable<DataQueryResponse> | undefined {
+    const data = this.supplementaryQueriesResults[type];
+    if (data) {
+      return from([
+        { state: LoadingState.Loading, data: [] },
+        { state: LoadingState.Done, data },
+      ]);
+    }
+    return undefined;
+  }
+
+  getSupplementaryQuery(options: SupplementaryQueryOptions, query: DataQuery): DataQuery | undefined {
+    return query;
+  }
+
+  getSupportedSupplementaryQueryTypes(): SupplementaryQueryType[] {
+    return Object.values(SupplementaryQueryType).filter((type) => this.supplementaryQueriesResults[type]);
+  }
+}
+
+const createSupplementaryQueryResponse = (type: SupplementaryQueryType, id: string) => {
+  return [
+    toDataFrame({
+      refId: `1-${type}-${id}`,
+      fields: [{ name: 'value', type: FieldType.string, values: [1] }],
+      meta: {
+        custom: {
+          logsVolumeType: LogsVolumeType.FullRange,
+        },
+      },
+    }),
+    toDataFrame({
+      refId: `2-${type}-${id}`,
+      fields: [{ name: 'value', type: FieldType.string, values: [2] }],
+      meta: {
+        custom: {
+          logsVolumeType: LogsVolumeType.FullRange,
+        },
+      },
+    }),
+  ];
+};
+
+const mockRow = (refId: string) => {
+  return {
+    rowIndex: 0,
+    entryFieldIndex: 0,
+    dataFrame: new MutableDataFrame({ refId, fields: [{ name: 'A', values: [] }] }),
+    entry: '',
+    hasAnsi: false,
+    hasUnescapedContent: false,
+    labels: {},
+    logLevel: LogLevel.info,
+    raw: '',
+    timeEpochMs: 0,
+    timeEpochNs: '0',
+    timeFromNow: '',
+    timeLocal: '',
+    timeUtc: '',
+    uid: '1',
+  };
+};
+
+const mockExploreDataWithLogs = () =>
+  mockExplorePanelData({
+    logsResult: {
+      rows: [mockRow('0'), mockRow('1')],
+      visibleRange: { from: 0, to: 1 },
+      bucketSize: 1000,
+    },
+  });
+
+const datasources: DataSourceApi[] = [
+  new MockDataSourceWithSupplementaryQuerySupport('logs-volume-a').withSupplementaryQuerySupport(
+    SupplementaryQueryType.LogsVolume,
+    createSupplementaryQueryResponse(SupplementaryQueryType.LogsVolume, 'logs-volume-a')
+  ),
+  new MockDataSourceWithSupplementaryQuerySupport('logs-volume-b').withSupplementaryQuerySupport(
+    SupplementaryQueryType.LogsVolume,
+    createSupplementaryQueryResponse(SupplementaryQueryType.LogsVolume, 'logs-volume-b')
+  ),
+  new MockDataSourceWithSupplementaryQuerySupport('logs-sample-a').withSupplementaryQuerySupport(
+    SupplementaryQueryType.LogsSample,
+    createSupplementaryQueryResponse(SupplementaryQueryType.LogsSample, 'logs-sample-a')
+  ),
+  new MockDataSourceWithSupplementaryQuerySupport('logs-sample-b').withSupplementaryQuerySupport(
+    SupplementaryQueryType.LogsSample,
+    createSupplementaryQueryResponse(SupplementaryQueryType.LogsSample, 'logs-sample-b')
+  ),
+  new MockDataSourceApi('no-data-providers'),
+  new MockDataSourceApi('no-data-providers-2'),
+];
+
+jest.mock('@grafana/runtime', () => ({
+  ...jest.requireActual('@grafana/runtime'),
+  getDataSourceSrv: () => {
+    return {
+      get: async ({ uid }: { uid: string }) => datasources.find((ds) => ds.name === uid) || undefined,
+    };
+  },
+}));
+
+const setup = async (targetSources: string[], type: SupplementaryQueryType) => {
+  const requestMock = new MockDataQueryRequest({
+    targets: targetSources.map((source, i) => new MockQuery(`${i}`, 'a', { uid: source })),
+  });
+  const explorePanelDataMock: Observable<ExplorePanelData> = mockExploreDataWithLogs();
+
+  const datasources = await Promise.all(
+    targetSources.map(async (source, i) => {
+      const datasource = await getDataSourceSrv().get({ uid: source });
+      return {
+        datasource,
+        targets: [new MockQuery(`${i}`, 'a', { uid: source })],
+      };
+    })
+  );
+
+  return getSupplementaryQueryProvider(datasources, type, requestMock, explorePanelDataMock);
+};
+
+const assertDataFrom = (type: SupplementaryQueryType, ...datasources: string[]) => {
+  return flatten(
+    datasources.map((name: string) => {
+      return [{ refId: `1-${type}-${name}` }, { refId: `2-${type}-${name}` }];
+    })
+  );
+};
+
+const assertDataFromLogsResults = () => {
+  return [{ meta: { custom: { logsVolumeType: LogsVolumeType.Limited } } }];
+};
+
+describe('SupplementaryQueries utils', function () {
+  describe('Non-mixed data source', function () {
+    it('Returns result from the provider', async () => {
+      const testProvider = await setup(['logs-volume-a'], SupplementaryQueryType.LogsVolume);
+
+      await expect(testProvider).toEmitValuesWith((received) => {
+        expect(received).toMatchObject([
+          { data: [], state: LoadingState.Loading },
+          {
+            data: assertDataFrom(SupplementaryQueryType.LogsVolume, 'logs-volume-a'),
+            state: LoadingState.Done,
+          },
+        ]);
+      });
+    });
+    it('Uses fallback for logs volume', async () => {
+      const testProvider = await setup(['no-data-providers'], SupplementaryQueryType.LogsVolume);
+
+      await expect(testProvider).toEmitValuesWith((received) => {
+        expect(received).toMatchObject([
+          {
+            data: assertDataFromLogsResults(),
+            state: LoadingState.Done,
+          },
+        ]);
+      });
+    });
+    it('Returns undefined for logs sample', async () => {
+      const testProvider = await setup(['no-data-providers'], SupplementaryQueryType.LogsSample);
+      await expect(testProvider).toBe(undefined);
+    });
+    it('Creates single fallback result', async () => {
+      const testProvider = await setup(['no-data-providers', 'no-data-providers-2'], SupplementaryQueryType.LogsVolume);
+
+      await expect(testProvider).toEmitValuesWith((received) => {
+        expect(received).toMatchObject([
+          {
+            data: assertDataFromLogsResults(),
+            state: LoadingState.Done,
+          },
+          {
+            data: [...assertDataFromLogsResults(), ...assertDataFromLogsResults()],
+            state: LoadingState.Done,
+          },
+        ]);
+      });
+    });
+  });
+
+  describe('Mixed data source', function () {
+    describe('Logs volume', function () {
+      describe('All data sources support full range logs volume', function () {
+        it('Merges all data frames into a single response', async () => {
+          const testProvider = await setup(['logs-volume-a', 'logs-volume-b'], SupplementaryQueryType.LogsVolume);
+          await expect(testProvider).toEmitValuesWith((received) => {
+            expect(received).toMatchObject([
+              { data: [], state: LoadingState.Loading },
+              {
+                data: assertDataFrom(SupplementaryQueryType.LogsVolume, 'logs-volume-a'),
+                state: LoadingState.Done,
+              },
+              {
+                data: assertDataFrom(SupplementaryQueryType.LogsVolume, 'logs-volume-a', 'logs-volume-b'),
+                state: LoadingState.Done,
+              },
+            ]);
+          });
+        });
+      });
+
+      describe('All data sources do not support full range logs volume', function () {
+        it('Creates single fallback result', async () => {
+          const testProvider = await setup(
+            ['no-data-providers', 'no-data-providers-2'],
+            SupplementaryQueryType.LogsVolume
+          );
+
+          await expect(testProvider).toEmitValuesWith((received) => {
+            expect(received).toMatchObject([
+              {
+                data: assertDataFromLogsResults(),
+                state: LoadingState.Done,
+              },
+              {
+                data: [...assertDataFromLogsResults(), ...assertDataFromLogsResults()],
+                state: LoadingState.Done,
+              },
+            ]);
+          });
+        });
+      });
+
+      describe('Some data sources support full range logs volume, while others do not', function () {
+        it('Creates merged result containing full range and limited logs volume', async () => {
+          const testProvider = await setup(
+            ['logs-volume-a', 'no-data-providers', 'logs-volume-b', 'no-data-providers-2'],
+            SupplementaryQueryType.LogsVolume
+          );
+          await expect(testProvider).toEmitValuesWith((received) => {
+            expect(received).toMatchObject([
+              {
+                data: [],
+                state: LoadingState.Loading,
+              },
+              {
+                data: assertDataFrom(SupplementaryQueryType.LogsVolume, 'logs-volume-a'),
+                state: LoadingState.Done,
+              },
+              {
+                data: [
+                  ...assertDataFrom(SupplementaryQueryType.LogsVolume, 'logs-volume-a'),
+                  ...assertDataFromLogsResults(),
+                ],
+                state: LoadingState.Done,
+              },
+              {
+                data: [
+                  ...assertDataFrom(SupplementaryQueryType.LogsVolume, 'logs-volume-a'),
+                  ...assertDataFromLogsResults(),
+                  ...assertDataFrom(SupplementaryQueryType.LogsVolume, 'logs-volume-b'),
+                ],
+                state: LoadingState.Done,
+              },
+            ]);
+          });
+        });
+      });
+    });
+
+    describe('Logs sample', function () {
+      describe('All data sources support logs sample', function () {
+        it('Merges all responses into single result', async () => {
+          const testProvider = await setup(['logs-sample-a', 'logs-sample-b'], SupplementaryQueryType.LogsSample);
+          await expect(testProvider).toEmitValuesWith((received) => {
+            expect(received).toMatchObject([
+              { data: [], state: LoadingState.Loading },
+              {
+                data: assertDataFrom(SupplementaryQueryType.LogsSample, 'logs-sample-a'),
+                state: LoadingState.Done,
+              },
+              {
+                data: assertDataFrom(SupplementaryQueryType.LogsSample, 'logs-sample-a', 'logs-sample-b'),
+                state: LoadingState.Done,
+              },
+            ]);
+          });
+        });
+      });
+
+      describe('All data sources do not support full range logs volume', function () {
+        it('Does not provide fallback result', async () => {
+          const testProvider = await setup(
+            ['no-data-providers', 'no-data-providers-2'],
+            SupplementaryQueryType.LogsSample
+          );
+          await expect(testProvider).toBeUndefined();
+        });
+      });
+
+      describe('Some data sources support full range logs volume, while others do not', function () {
+        it('Returns results only for data sources supporting logs sample', async () => {
+          const testProvider = await setup(
+            ['logs-sample-a', 'no-data-providers', 'logs-sample-b', 'no-data-providers-2'],
+            SupplementaryQueryType.LogsSample
+          );
+          await expect(testProvider).toEmitValuesWith((received) => {
+            expect(received).toMatchObject([
+              { data: [], state: LoadingState.Loading },
+              {
+                data: assertDataFrom(SupplementaryQueryType.LogsSample, 'logs-sample-a'),
+                state: LoadingState.Done,
+              },
+              {
+                data: assertDataFrom(SupplementaryQueryType.LogsSample, 'logs-sample-a', 'logs-sample-b'),
+                state: LoadingState.Done,
+              },
+            ]);
+          });
+        });
+      });
+    });
+  });
+});

--- a/public/app/features/explore/utils/supplementaryQueries_legacy.test.ts
+++ b/public/app/features/explore/utils/supplementaryQueries_legacy.test.ts
@@ -1,3 +1,7 @@
+/**
+ * Test file to be removed when `getDataProvider` is removed from DataSourceWithSupplementaryQueriesSupport
+ * in packages/grafana-data/src/types/logs.ts
+ */
 import { flatten } from 'lodash';
 import { from, Observable } from 'rxjs';
 

--- a/public/app/features/logs/logsModel.test.ts
+++ b/public/app/features/logs/logsModel.test.ts
@@ -1317,16 +1317,22 @@ describe('logs volume', () => {
         { refId: 'B', target: 'volume query 2' },
       ],
       scopedVars: {},
-    } as unknown as DataQueryRequest<TestDataQuery>;
-    volumeProvider = queryLogsVolume(datasource, request, {
-      extractLevel: (dataFrame: DataFrame) => {
-        return dataFrame.fields[1]!.labels!.level === 'error' ? LogLevel.error : LogLevel.unknown;
-      },
+      requestId: '',
+      interval: '',
+      intervalMs: 0,
       range: {
         from: FROM,
         to: TO,
-        raw: { from: '0', to: '1' },
+        raw: {
+          from: FROM,
+          to: TO,
+        }
       },
+      timezone: '',
+      app: '',
+      startTime: 0,
+    };
+    volumeProvider = queryLogsVolume(datasource, request, {
       targets: request.targets,
     });
   }

--- a/public/app/features/logs/logsModel.test.ts
+++ b/public/app/features/logs/logsModel.test.ts
@@ -1326,7 +1326,7 @@ describe('logs volume', () => {
         raw: {
           from: FROM,
           to: TO,
-        }
+        },
       },
       timezone: '',
       app: '',

--- a/public/app/features/logs/logsModel.ts
+++ b/public/app/features/logs/logsModel.ts
@@ -655,8 +655,8 @@ function defaultExtractLevel(dataFrame: DataFrame): LogLevel {
 }
 
 function getLogLevelFromLabels(labels: Labels): LogLevel {
-  const levelLabel = labels['level'] ?? labels['lvl'] ?? labels['loglevel'] ?? '';
-  return levelLabel ? getLogLevelFromKey(labels[levelLabel]) : LogLevel.unknown;
+  const level = labels['level'] ?? labels['lvl'] ?? labels['loglevel'] ?? '';
+  return level ? getLogLevelFromKey(level) : LogLevel.unknown;
 }
 
 /**

--- a/public/app/features/logs/logsModel.ts
+++ b/public/app/features/logs/logsModel.ts
@@ -640,7 +640,6 @@ const updateLogsVolumeConfig = (
 };
 
 type LogsVolumeQueryOptions<T extends DataQuery> = {
-  extractLevel?: (dataFrame: DataFrame) => LogLevel;
   targets: T[];
 };
 
@@ -667,7 +666,7 @@ export function queryLogsVolume<TQuery extends DataQuery, TOptions extends DataS
 ): Observable<DataQueryResponse> {
   const range = logsVolumeRequest.range;
   const targets = options.targets;
-  const extractLevel = options.extractLevel ? options.extractLevel : defaultExtractLevel;
+  const extractLevel = defaultExtractLevel;
   const timespan = range.to.valueOf() - range.from.valueOf();
   const intervalInfo = getIntervalInfo(logsVolumeRequest.scopedVars, timespan);
 

--- a/public/app/features/logs/logsModel.ts
+++ b/public/app/features/logs/logsModel.ts
@@ -35,7 +35,6 @@ import {
   ScopedVars,
   sortDataFrame,
   textUtil,
-  TimeRange,
   toDataFrame,
   toUtc,
 } from '@grafana/data';
@@ -641,9 +640,8 @@ const updateLogsVolumeConfig = (
 };
 
 type LogsVolumeQueryOptions<T extends DataQuery> = {
-  extractLevel: (dataFrame: DataFrame) => LogLevel;
+  extractLevel?: (dataFrame: DataFrame) => LogLevel;
   targets: T[];
-  range: TimeRange;
 };
 
 function defaultExtractLevel(dataFrame: DataFrame): LogLevel {
@@ -665,11 +663,11 @@ function getLogLevelFromLabels(labels: Labels): LogLevel {
 export function queryLogsVolume<TQuery extends DataQuery, TOptions extends DataSourceJsonData>(
   datasource: DataSourceApi<TQuery, TOptions>,
   logsVolumeRequest: DataQueryRequest<TQuery>,
-  options?: LogsVolumeQueryOptions<TQuery>
+  options: LogsVolumeQueryOptions<TQuery>
 ): Observable<DataQueryResponse> {
-  const range = options ? options.range : logsVolumeRequest.range;
-  const targets = options ? options.targets : logsVolumeRequest.targets;
-  const extractLevel = options ? options.extractLevel : defaultExtractLevel;
+  const range = logsVolumeRequest.range;
+  const targets = options.targets;
+  const extractLevel = options.extractLevel ? options.extractLevel : defaultExtractLevel;
   const timespan = range.to.valueOf() - range.from.valueOf();
   const intervalInfo = getIntervalInfo(logsVolumeRequest.scopedVars, timespan);
 

--- a/public/app/features/logs/utils.ts
+++ b/public/app/features/logs/utils.ts
@@ -44,7 +44,7 @@ export function getLogLevel(line: string): LogLevel {
   return level;
 }
 
-export function getLogLevelFromKey(key: string | number): LogLevel {
+export function getLogLevelFromKey(key: string): LogLevel {
   const level = LogLevel[key.toString().toLowerCase() as keyof typeof LogLevel];
   if (level) {
     return level;

--- a/public/app/features/logs/utils.ts
+++ b/public/app/features/logs/utils.ts
@@ -44,7 +44,7 @@ export function getLogLevel(line: string): LogLevel {
   return level;
 }
 
-export function getLogLevelFromKey(key: string): LogLevel {
+export function getLogLevelFromKey(key: string | number): LogLevel {
   const level = LogLevel[key.toString().toLowerCase() as keyof typeof LogLevel];
   if (level) {
     return level;

--- a/public/app/plugins/datasource/elasticsearch/datasource.test.ts
+++ b/public/app/plugins/datasource/elasticsearch/datasource.test.ts
@@ -1019,7 +1019,7 @@ describe('ElasticDatasource', () => {
         ],
       });
 
-      expect(ds.getLogsSampleDataProvider(request)).not.toBeDefined();
+      expect(ds.getDataProvider(SupplementaryQueryType.LogsSample, request)).not.toBeDefined();
     });
 
     it('returns a logs sample provider given a time series query', () => {
@@ -1032,7 +1032,7 @@ describe('ElasticDatasource', () => {
         ],
       });
 
-      expect(ds.getLogsSampleDataProvider(request)).toBeDefined();
+      expect(ds.getDataProvider(SupplementaryQueryType.LogsSample, request)).toBeDefined();
     });
   });
 });

--- a/public/app/plugins/datasource/elasticsearch/datasource.test.ts
+++ b/public/app/plugins/datasource/elasticsearch/datasource.test.ts
@@ -986,7 +986,7 @@ describe('ElasticDatasource', () => {
         ],
       });
 
-      expect(ds.getDataProvider(SupplementaryQueryType.LogsSample, options)).not.toBeDefined();
+      expect(ds.getSupplementaryRequest(SupplementaryQueryType.LogsSample, options)).not.toBeDefined();
     });
 
     it('does create a logs sample provider for time series query', () => {
@@ -999,7 +999,7 @@ describe('ElasticDatasource', () => {
         ],
       });
 
-      expect(ds.getDataProvider(SupplementaryQueryType.LogsSample, options)).toBeDefined();
+      expect(ds.getSupplementaryRequest(SupplementaryQueryType.LogsSample, options)).toBeDefined();
     });
   });
 
@@ -1019,7 +1019,7 @@ describe('ElasticDatasource', () => {
         ],
       });
 
-      expect(ds.getDataProvider(SupplementaryQueryType.LogsSample, request)).not.toBeDefined();
+      expect(ds.getSupplementaryRequest(SupplementaryQueryType.LogsSample, request)).not.toBeDefined();
     });
 
     it('returns a logs sample provider given a time series query', () => {
@@ -1032,7 +1032,7 @@ describe('ElasticDatasource', () => {
         ],
       });
 
-      expect(ds.getDataProvider(SupplementaryQueryType.LogsSample, request)).toBeDefined();
+      expect(ds.getSupplementaryRequest(SupplementaryQueryType.LogsSample, request)).toBeDefined();
     });
   });
 });

--- a/public/app/plugins/datasource/elasticsearch/datasource.ts
+++ b/public/app/plugins/datasource/elasticsearch/datasource.ts
@@ -631,7 +631,9 @@ export class ElasticDatasource
     }
   }
 
-  private getLogsVolumeDataProvider(request: DataQueryRequest<ElasticsearchQuery>): DataQueryRequest<ElasticsearchQuery> | undefined {
+  private getLogsVolumeDataProvider(
+    request: DataQueryRequest<ElasticsearchQuery>
+  ): DataQueryRequest<ElasticsearchQuery> | undefined {
     const logsVolumeRequest = cloneDeep(request);
     const targets = logsVolumeRequest.targets
       .map((target) => this.getSupplementaryQuery({ type: SupplementaryQueryType.LogsVolume }, target))
@@ -644,7 +646,9 @@ export class ElasticDatasource
     return { ...logsVolumeRequest, targets };
   }
 
-  private getLogsSampleDataProvider(request: DataQueryRequest<ElasticsearchQuery>): DataQueryRequest<ElasticsearchQuery> | undefined {
+  private getLogsSampleDataProvider(
+    request: DataQueryRequest<ElasticsearchQuery>
+  ): DataQueryRequest<ElasticsearchQuery> | undefined {
     const logsSampleRequest = cloneDeep(request);
     const targets = logsSampleRequest.targets;
     const queries = targets.map((query) => {

--- a/public/app/plugins/datasource/elasticsearch/datasource.ts
+++ b/public/app/plugins/datasource/elasticsearch/datasource.ts
@@ -534,7 +534,12 @@ export class ElasticDatasource
     }
   };
 
-  getDataProvider(
+  /**
+   * Implemented for DataSourceWithSupplementaryQueriesSupport.
+   * It generates a DataQueryRequest for a specific supplementary query type.
+   * @returns A DataQueryRequest for the supplementary queries or undefined if not supported.
+   */
+  getSupplementaryRequest(
     type: SupplementaryQueryType,
     request: DataQueryRequest<ElasticsearchQuery>
   ): DataQueryRequest<ElasticsearchQuery> | undefined {

--- a/public/app/plugins/datasource/elasticsearch/datasource.ts
+++ b/public/app/plugins/datasource/elasticsearch/datasource.ts
@@ -538,9 +538,6 @@ export class ElasticDatasource
     type: SupplementaryQueryType,
     request: DataQueryRequest<ElasticsearchQuery>
   ): DataQueryRequest<ElasticsearchQuery> | undefined {
-    if (!this.getSupportedSupplementaryQueryTypes().includes(type)) {
-      return undefined;
-    }
     switch (type) {
       case SupplementaryQueryType.LogsVolume:
         return this.getLogsVolumeDataProvider(request);
@@ -556,10 +553,6 @@ export class ElasticDatasource
   }
 
   getSupplementaryQuery(options: SupplementaryQueryOptions, query: ElasticsearchQuery): ElasticsearchQuery | undefined {
-    if (!this.getSupportedSupplementaryQueryTypes().includes(options.type)) {
-      return undefined;
-    }
-
     let isQuerySuitable = false;
 
     switch (options.type) {

--- a/public/app/plugins/datasource/loki/datasource.test.ts
+++ b/public/app/plugins/datasource/loki/datasource.test.ts
@@ -1255,7 +1255,7 @@ describe('LokiDatasource', () => {
         targets: [{ expr: '{label="value"}', refId: 'A', queryType: LokiQueryType.Range }],
       };
 
-      expect(ds.getDataProvider(SupplementaryQueryType.LogsVolume, options)).toBeDefined();
+      expect(ds.getSupplementaryRequest(SupplementaryQueryType.LogsVolume, options)).toBeDefined();
     });
 
     it('does not create provider for metrics query', () => {
@@ -1264,7 +1264,7 @@ describe('LokiDatasource', () => {
         targets: [{ expr: 'rate({label="value"}[1m])', refId: 'A' }],
       };
 
-      expect(ds.getDataProvider(SupplementaryQueryType.LogsVolume, options)).not.toBeDefined();
+      expect(ds.getSupplementaryRequest(SupplementaryQueryType.LogsVolume, options)).not.toBeDefined();
     });
 
     it('creates provider if at least one query is a logs query', () => {
@@ -1276,7 +1276,7 @@ describe('LokiDatasource', () => {
         ],
       };
 
-      expect(ds.getDataProvider(SupplementaryQueryType.LogsVolume, options)).toBeDefined();
+      expect(ds.getSupplementaryRequest(SupplementaryQueryType.LogsVolume, options)).toBeDefined();
     });
 
     it('does not create provider if there is only an instant logs query', () => {
@@ -1285,7 +1285,7 @@ describe('LokiDatasource', () => {
         targets: [{ expr: '{label="value"', refId: 'A', queryType: LokiQueryType.Instant }],
       };
 
-      expect(ds.getDataProvider(SupplementaryQueryType.LogsVolume, options)).not.toBeDefined();
+      expect(ds.getSupplementaryRequest(SupplementaryQueryType.LogsVolume, options)).not.toBeDefined();
     });
   });
 
@@ -1301,7 +1301,7 @@ describe('LokiDatasource', () => {
         targets: [{ expr: 'rate({label="value"}[5m])', refId: 'A' }],
       };
 
-      expect(ds.getDataProvider(SupplementaryQueryType.LogsSample, options)).toBeDefined();
+      expect(ds.getSupplementaryRequest(SupplementaryQueryType.LogsSample, options)).toBeDefined();
     });
 
     it('does not create provider for log query', () => {
@@ -1310,7 +1310,7 @@ describe('LokiDatasource', () => {
         targets: [{ expr: '{label="value"}', refId: 'A' }],
       };
 
-      expect(ds.getDataProvider(SupplementaryQueryType.LogsSample, options)).not.toBeDefined();
+      expect(ds.getSupplementaryRequest(SupplementaryQueryType.LogsSample, options)).not.toBeDefined();
     });
 
     it('creates provider if at least one query is a metric query', () => {
@@ -1322,7 +1322,7 @@ describe('LokiDatasource', () => {
         ],
       };
 
-      expect(ds.getDataProvider(SupplementaryQueryType.LogsSample, options)).toBeDefined();
+      expect(ds.getSupplementaryRequest(SupplementaryQueryType.LogsSample, options)).toBeDefined();
     });
   });
 

--- a/public/app/plugins/datasource/loki/datasource.ts
+++ b/public/app/plugins/datasource/loki/datasource.ts
@@ -17,11 +17,8 @@ import {
   SupplementaryQueryType,
   DataSourceWithQueryExportSupport,
   DataSourceWithQueryImportSupport,
-  FieldCache,
-  FieldType,
   Labels,
   LoadingState,
-  LogLevel,
   LogRowModel,
   QueryFixAction,
   QueryHint,
@@ -45,9 +42,6 @@ import {
 import { Duration } from '@grafana/lezer-logql';
 import { BackendSrvRequest, config, DataSourceWithBackend, getTemplateSrv, TemplateSrv } from '@grafana/runtime';
 import { DataQuery } from '@grafana/schema';
-
-import { queryLogsSample, queryLogsVolume } from '../../../features/logs/logsModel';
-import { getLogLevelFromKey } from '../../../features/logs/utils';
 
 import LanguageProvider from './LanguageProvider';
 import { LiveStreams, LokiLiveTarget } from './LiveStreams';
@@ -174,7 +168,7 @@ export class LokiDatasource
   getDataProvider(
     type: SupplementaryQueryType,
     request: DataQueryRequest<LokiQuery>
-  ): Observable<DataQueryResponse> | undefined {
+  ): DataQueryRequest<LokiQuery> | undefined {
     if (!this.getSupportedSupplementaryQueryTypes().includes(type)) {
       return undefined;
     }
@@ -255,7 +249,7 @@ export class LokiDatasource
    * Private method used in the `getDataProvider` for DataSourceWithSupplementaryQueriesSupport, specifically for Logs volume queries.
    * @returns An Observable of DataQueryResponse or undefined if no suitable queries are found.
    */
-  private getLogsVolumeDataProvider(request: DataQueryRequest<LokiQuery>): Observable<DataQueryResponse> | undefined {
+  private getLogsVolumeDataProvider(request: DataQueryRequest<LokiQuery>): DataQueryRequest<LokiQuery> | undefined {
     const logsVolumeRequest = cloneDeep(request);
     const targets = logsVolumeRequest.targets
       .map((query) => this.getSupplementaryQuery({ type: SupplementaryQueryType.LogsVolume }, query))
@@ -265,22 +259,14 @@ export class LokiDatasource
       return undefined;
     }
 
-    return queryLogsVolume(
-      this,
-      { ...logsVolumeRequest, targets },
-      {
-        extractLevel,
-        range: request.range,
-        targets: request.targets,
-      }
-    );
+    return { ...logsVolumeRequest, targets };
   }
 
   /**
    * Private method used in the `getDataProvider` for DataSourceWithSupplementaryQueriesSupport, specifically for Logs sample queries.
    * @returns An Observable of DataQueryResponse or undefined if no suitable queries are found.
    */
-  private getLogsSampleDataProvider(request: DataQueryRequest<LokiQuery>): Observable<DataQueryResponse> | undefined {
+  private getLogsSampleDataProvider(request: DataQueryRequest<LokiQuery>): DataQueryRequest<LokiQuery> | undefined {
     const logsSampleRequest = cloneDeep(request);
     const targets = logsSampleRequest.targets
       .map((query) => this.getSupplementaryQuery({ type: SupplementaryQueryType.LogsSample, limit: 100 }, query))
@@ -289,7 +275,7 @@ export class LokiDatasource
     if (!targets.length) {
       return undefined;
     }
-    return queryLogsSample(this, { ...logsSampleRequest, targets });
+    return { ...logsSampleRequest, targets };
   }
 
   /**
@@ -1170,24 +1156,4 @@ export function lokiSpecialRegexEscape(value: any) {
     return lokiRegularEscape(value.replace(/\\/g, '\\\\\\\\').replace(/[$^*{}\[\]+?.()|]/g, '\\\\$&'));
   }
   return value;
-}
-
-function extractLevel(dataFrame: DataFrame): LogLevel {
-  let valueField;
-  try {
-    valueField = new FieldCache(dataFrame).getFirstFieldOfType(FieldType.number);
-  } catch {}
-  return valueField?.labels ? getLogLevelFromLabels(valueField.labels) : LogLevel.unknown;
-}
-
-function getLogLevelFromLabels(labels: Labels): LogLevel {
-  const labelNames = ['level', 'lvl', 'loglevel'];
-  let levelLabel;
-  for (let labelName of labelNames) {
-    if (labelName in labels) {
-      levelLabel = labelName;
-      break;
-    }
-  }
-  return levelLabel ? getLogLevelFromKey(labels[levelLabel]) : LogLevel.unknown;
 }

--- a/public/app/plugins/datasource/loki/datasource.ts
+++ b/public/app/plugins/datasource/loki/datasource.ts
@@ -169,9 +169,6 @@ export class LokiDatasource
     type: SupplementaryQueryType,
     request: DataQueryRequest<LokiQuery>
   ): DataQueryRequest<LokiQuery> | undefined {
-    if (!this.getSupportedSupplementaryQueryTypes().includes(type)) {
-      return undefined;
-    }
     switch (type) {
       case SupplementaryQueryType.LogsVolume:
         return this.getLogsVolumeDataProvider(request);
@@ -197,10 +194,6 @@ export class LokiDatasource
    * @returns A supplemented Loki query or undefined if unsupported.
    */
   getSupplementaryQuery(options: SupplementaryQueryOptions, query: LokiQuery): LokiQuery | undefined {
-    if (!this.getSupportedSupplementaryQueryTypes().includes(options.type)) {
-      return undefined;
-    }
-
     const normalizedQuery = getNormalizedLokiQuery(query);
     let expr = removeCommentsFromQuery(normalizedQuery.expr);
     let isQuerySuitable = false;

--- a/public/app/plugins/datasource/loki/datasource.ts
+++ b/public/app/plugins/datasource/loki/datasource.ts
@@ -162,10 +162,10 @@ export class LokiDatasource
 
   /**
    * Implemented for DataSourceWithSupplementaryQueriesSupport.
-   * It retrieves a data provider for a specific supplementary query type.
-   * @returns An Observable of DataQueryResponse or undefined if the specified query type is not supported.
+   * It generates a DataQueryRequest for a specific supplementary query type.
+   * @returns A DataQueryRequest for the supplementary queries or undefined if not supported.
    */
-  getDataProvider(
+  getSupplementaryRequest(
     type: SupplementaryQueryType,
     request: DataQueryRequest<LokiQuery>
   ): DataQueryRequest<LokiQuery> | undefined {

--- a/public/test/mocks/datasource_srv.ts
+++ b/public/test/mocks/datasource_srv.ts
@@ -49,7 +49,7 @@ export class MockDataSourceApi extends DataSourceApi {
     this.meta = meta || ({} as DataSourcePluginMeta);
   }
 
-  query(request: DataQueryRequest): Promise<DataQueryResponse> {
+  query(request: DataQueryRequest): Promise<DataQueryResponse> | Observable<DataQueryResponse> {
     if (this.error) {
       return Promise.reject(this.error);
     }


### PR DESCRIPTION
Currently, plugins that want to support Logs Volume and/or Logs Sample need to import dependencies from `logsModel`:

![imagen](https://github.com/grafana/grafana/assets/1069378/43271cd5-b33d-40cc-aaf0-bc63ee92aa52)

### Proposed approach

1. Deprecate `getDataProvider(): Observable<DataQueryResponse>`.

By the way this function was designed, it created a dependency between data sources and core, where `queryLogsSample`, `queryLogsVolume` needed to be needlessly imported from core. 

2. Introduce `getSupplementaryRequest(): DataQueryRequest<TQuery>`. 

Observing on the three (Loki, Elasticsearch, ClickHouse) implementations of supplementary queries, it was evident that inversion of control was possible, and `queryLogsSample`, `queryLogsVolume` could be called from core Grafana by just passing a `DataQueryRequest` instance to the data sources and getting another `DataQueryRequest` for the supplementary queries.

Thus, `getSupplementaryRequest` has been introduced to receive and return a `DataQueryRequest` instance.

**Why do we need this feature?**

To allow externalization of Loki and Elasticsearch.

**Which issue(s) does this PR fix?**:

Part of https://github.com/grafana/grafana/issues/72632 and https://github.com/grafana/grafana/issues/72631

# Deprecation notice

For data sources that implement `DataSourceWithSupplementaryQueriesSupport`, `getDataProvider()` has been deprecated in favor of getSupplementaryRequest()`.