### PR TITLE
Chore: Add dashboard retrieval by FolderUID

### DIFF
--- a/pkg/services/dashboards/database/database.go
+++ b/pkg/services/dashboards/database/database.go
@@ -813,7 +813,7 @@ func (d *dashboardStore) GetDashboard(ctx context.Context, query *dashboards.Get
 	var queryResult *dashboards.Dashboard
 	err := d.store.WithDbSession(ctx, func(sess *db.Session) error {
 		// nolint:staticcheck
-		if query.ID == 0 && len(query.UID) == 0 && (query.Title == nil || query.FolderID == nil) {
+		if query.ID == 0 && len(query.UID) == 0 && (query.Title == nil || (query.FolderID == nil && query.FolderUID == "")) {
 			return dashboards.ErrDashboardIdentifierNotSet
 		}
 
@@ -823,15 +823,18 @@ func (d *dashboardStore) GetDashboard(ctx context.Context, query *dashboards.Get
 			dashboard.Title = *query.Title
 			mustCols = append(mustCols, "title")
 		}
-		// nolint:staticcheck
-		if query.FolderID != nil {
+
+		if query.FolderUID != "" {
+			dashboard.FolderUID = query.FolderUID
+			mustCols = append(mustCols, "folder_uid")
+			// nolint:staticcheck
+		} else if query.FolderID != nil {
 			// nolint:staticcheck
 			dashboard.FolderID = *query.FolderID
 			mustCols = append(mustCols, "folder_id")
 		}
 
 		has, err := sess.MustCols(mustCols...).Get(&dashboard)
-
 		if err != nil {
 			return err
 		} else if !has {

--- a/pkg/services/dashboards/database/database.go
+++ b/pkg/services/dashboards/database/database.go
@@ -827,8 +827,7 @@ func (d *dashboardStore) GetDashboard(ctx context.Context, query *dashboards.Get
 		if query.FolderUID != "" {
 			dashboard.FolderUID = query.FolderUID
 			mustCols = append(mustCols, "folder_uid")
-			// nolint:staticcheck
-		} else if query.FolderID != nil {
+		} else if query.FolderID != nil { // nolint:staticcheck
 			// nolint:staticcheck
 			dashboard.FolderID = *query.FolderID
 			mustCols = append(mustCols, "folder_id")

--- a/pkg/services/dashboards/database/database_test.go
+++ b/pkg/services/dashboards/database/database_test.go
@@ -108,6 +108,23 @@ func TestIntegrationDashboardDataAccess(t *testing.T) {
 		require.False(t, queryResult.IsFolder)
 	})
 
+	t.Run("Should be able to get dashboard by title and folderUID", func(t *testing.T) {
+		setup()
+		query := dashboards.GetDashboardQuery{
+			Title:     util.Pointer("test dash 23"),
+			FolderUID: savedFolder.UID,
+			OrgID:     1,
+		}
+		queryResult, err := dashboardStore.GetDashboard(context.Background(), &query)
+		require.NoError(t, err)
+
+		require.Equal(t, queryResult.Title, "test dash 23")
+		require.Equal(t, queryResult.Slug, "test-dash-23")
+		require.Equal(t, queryResult.ID, savedDash.ID)
+		require.Equal(t, queryResult.UID, savedDash.UID)
+		require.False(t, queryResult.IsFolder)
+	})
+
 	t.Run("Should not be able to get dashboard by title alone", func(t *testing.T) {
 		setup()
 		query := dashboards.GetDashboardQuery{

--- a/pkg/services/dashboards/models.go
+++ b/pkg/services/dashboards/models.go
@@ -301,8 +301,9 @@ type GetDashboardQuery struct {
 	UID   string
 	Title *string
 	// Deprecated: use FolderUID instead
-	FolderID *int64
-	OrgID    int64
+	FolderID  *int64
+	FolderUID string
+	OrgID     int64
 }
 
 type DashboardTagCloudItem struct {


### PR DESCRIPTION
Related to https://github.com/grafana/grafana/issues/78757

Allows to get a dashboard by FolderUID that eventually should replace FolderID.