### PR TITLE
fix: data trails auto query use general generator for unconventional metrics

### DIFF
--- a/public/app/features/trails/AutomaticMetricQueries/AutoQueryEngine.test.ts
+++ b/public/app/features/trails/AutomaticMetricQueries/AutoQueryEngine.test.ts
@@ -167,4 +167,20 @@ describe('getAutoQueriesForMetric', () => {
       expect(received).toStrictEqual(expectedVariants);
     });
   });
+
+  describe('Able to handle unconventional metric names', () => {
+    it.each([['PRODUCT_High_Priority_items_', 'avg(...)', 'short', 1]])(
+      'Given metric %p expect %p with unit %p',
+      (metric, expr, unit, queryCount) => {
+        const result = getAutoQueriesForMetric(metric);
+
+        const queryDef = result.main;
+
+        const expected = { expr: expandExpr(expr), unit, queryCount };
+        const actual = { expr: queryDef.queries[0].expr, unit: queryDef.unit, queryCount: queryDef.queries.length };
+
+        expect(actual).toStrictEqual(expected);
+      }
+    );
+  });
 });

--- a/public/app/features/trails/AutomaticMetricQueries/query-generators/index.ts
+++ b/public/app/features/trails/AutomaticMetricQueries/query-generators/index.ts
@@ -7,8 +7,5 @@ const SUFFIX_TO_ALTERNATIVE_GENERATOR: Record<string, MetricQueriesGenerator> = 
 };
 
 export function getQueryGeneratorFor(suffix?: string) {
-  if (!suffix || suffix === '') {
-    return null;
-  }
-  return SUFFIX_TO_ALTERNATIVE_GENERATOR[suffix] || general.generator;
+  return (suffix && SUFFIX_TO_ALTERNATIVE_GENERATOR[suffix]) || general.generator;
 }


### PR DESCRIPTION
Metrics that ended in `_` were failing due to strict checks. These have been loosened due to encountering one in a real environment.


**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
