### PR TITLE
[DOC] Remove experimental warning for trace to profiles

### DIFF
--- a/docs/sources/explore/trace-integration.md
+++ b/docs/sources/explore/trace-integration.md
@@ -117,8 +117,6 @@ You can navigate from a span in a trace view directly to metrics relevant for th
 
 ### Trace to profiles
 
-{{< docs/experimental product="Trace to profiles" featureFlag="traceToProfiles" >}}
-
 Using Trace to profiles, you can use Grafana’s ability to correlate different signals by adding the functionality to link between traces and profiles.
 Refer to the [relevant documentation](/docs/grafana/latest/datasources/tempo/configure-tempo-data-source#trace-to-profiles) for configuration instructions.
 

--- a/docs/sources/shared/datasources/tempo-traces-to-profiles.md
+++ b/docs/sources/shared/datasources/tempo-traces-to-profiles.md
@@ -16,8 +16,6 @@ labels:
 
 <!-- # Trace to profiles  -->
 
-{{< docs/experimental product="Trace to profiles" featureFlag="traceToProfiles" >}}
-
 Using Trace to profiles, you can use Grafana’s ability to correlate different signals by adding the functionality to link between traces and profiles.
 
 **Trace to profiles** lets you link your Grafana Pyroscope data source to tracing data.


### PR DESCRIPTION
**What is this feature?**

Removes the experimental warning from the traces to profiles capability in the Tempo data source documentation. 

**Why do we need this feature?**

This feature is no longer experimental. 

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [X] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
