### PR TITLE
Logs navigation: fix multiple incorrect calls to addResultsFromCache

### DIFF
--- a/public/app/features/explore/Logs/LogsContainer.tsx
+++ b/public/app/features/explore/Logs/LogsContainer.tsx
@@ -275,7 +275,6 @@ class LogsContainer extends PureComponent<LogsContainerProps, LogsContainerState
       splitOpenFn,
       isLive,
       exploreId,
-      clearCache,
       logsVolume,
       scrollElement,
     } = this.props;

--- a/public/app/features/explore/Logs/LogsContainer.tsx
+++ b/public/app/features/explore/Logs/LogsContainer.tsx
@@ -244,6 +244,14 @@ class LogsContainer extends PureComponent<LogsContainerProps, LogsContainerState
     );
   };
 
+  addResultsToCache = () => {
+    this.props.addResultsToCache(this.props.exploreId);
+  }
+
+  clearCache = () => {
+    this.props.clearCache(this.props.exploreId);
+  }
+
   render() {
     const {
       loading,
@@ -267,7 +275,6 @@ class LogsContainer extends PureComponent<LogsContainerProps, LogsContainerState
       splitOpenFn,
       isLive,
       exploreId,
-      addResultsToCache,
       clearCache,
       logsVolume,
       scrollElement,
@@ -330,8 +337,8 @@ class LogsContainer extends PureComponent<LogsContainerProps, LogsContainerState
             getRowContextQuery={this.getLogRowContextQuery}
             getLogRowContextUi={this.getLogRowContextUi}
             getFieldLinks={this.getFieldLinks}
-            addResultsToCache={() => addResultsToCache(exploreId)}
-            clearCache={() => clearCache(exploreId)}
+            addResultsToCache={this.addResultsToCache}
+            clearCache={this.clearCache}
             eventBus={this.props.eventBus}
             panelState={this.props.panelState}
             logsFrames={this.props.logsFrames}

--- a/public/app/features/explore/Logs/LogsContainer.tsx
+++ b/public/app/features/explore/Logs/LogsContainer.tsx
@@ -246,11 +246,11 @@ class LogsContainer extends PureComponent<LogsContainerProps, LogsContainerState
 
   addResultsToCache = () => {
     this.props.addResultsToCache(this.props.exploreId);
-  }
+  };
 
   clearCache = () => {
     this.props.clearCache(this.props.exploreId);
-  }
+  };
 
   render() {
     const {

--- a/public/app/features/explore/Logs/LogsNavigation.test.tsx
+++ b/public/app/features/explore/Logs/LogsNavigation.test.tsx
@@ -138,4 +138,31 @@ describe('LogsNavigation', () => {
     await userEvent.click(screen.getByTestId('olderLogsButton'));
     expect(scrollToTopLogsMock).toHaveBeenCalled();
   });
+
+  it('should not trigger actions while loading', async () => {
+    const scrollToTopLogs = jest.fn();
+    const changeTimeMock = jest.fn();
+    setup({ scrollToTopLogs, onChangeTime: changeTimeMock, loading: true });
+
+    expect(scrollToTopLogs).not.toHaveBeenCalled();
+    expect(changeTimeMock).not.toHaveBeenCalled();
+    await userEvent.click(screen.getByTestId('olderLogsButton'));
+    await userEvent.click(screen.getByTestId('newerLogsButton'));
+    expect(scrollToTopLogs).not.toHaveBeenCalled();
+    expect(changeTimeMock).not.toHaveBeenCalled();
+  });
+
+  it('should not add results to cache unless pagination is used', async () => {
+    const addResultsToCache = jest.fn();
+    setup({ addResultsToCache });
+
+    expect(addResultsToCache).not.toHaveBeenCalled();
+    expect(screen.getByTestId('olderLogsButton')).not.toBeDisabled();
+    expect(screen.getByTestId('newerLogsButton')).toBeDisabled();
+
+    await userEvent.click(screen.getByTestId('olderLogsButton'));
+    await userEvent.click(screen.getByTestId('newerLogsButton'));
+
+    expect(addResultsToCache).toHaveBeenCalledTimes(1);
+  });
 });

--- a/public/app/features/explore/Logs/LogsNavigation.tsx
+++ b/public/app/features/explore/Logs/LogsNavigation.tsx
@@ -82,21 +82,15 @@ function LogsNavigation({
         return newPages;
       });
     }
-    addResultsToCache();
   }, [visibleRange, absoluteRange, logsSortOrder, queries, clearCache, addResultsToCache]);
-
-  useEffect(() => {
-    clearCache();
-    // We can't enforce the eslint rule here because we only want to run when component is mounted.
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
 
   const changeTime = useCallback(
     ({ from, to }: AbsoluteTimeRange) => {
+      addResultsToCache();
       expectedRangeRef.current = { from, to };
       onChangeTime({ from, to });
     },
-    [onChangeTime]
+    [onChangeTime, addResultsToCache]
   );
 
   const sortPages = (a: LogsPage, b: LogsPage, logsSortOrder?: LogsSortOrder | null) => {
@@ -173,10 +167,10 @@ function LogsNavigation({
         pageType: 'page',
         pageNumber,
       });
-      !loading && changeTime({ from: page.queryRange.from, to: page.queryRange.to });
+      changeTime({ from: page.queryRange.from, to: page.queryRange.to });
       scrollToTopLogs();
     },
-    [changeTime, loading, scrollToTopLogs]
+    [changeTime, scrollToTopLogs]
   );
 
   return (

--- a/public/app/features/explore/Logs/LogsNavigationPages.tsx
+++ b/public/app/features/explore/Logs/LogsNavigationPages.tsx
@@ -49,6 +49,7 @@ export function LogsNavigationPages({ pages, currentPageIndex, oldestLogsFirst, 
               onClick={() => {
                 onClick(page, index + 1);
               }}
+              disabled={loading}
             >
               <div className={cx(styles.line, { selectedBg: currentPageIndex === index })} />
               <div className={cx(styles.time, { selectedText: currentPageIndex === index })}>


### PR DESCRIPTION
I've been recently working with this component and perceiving some unexpected behaviors from the main `useEffect`, caused by a lot of logic attached to the referential integrity of the dependency array. That means that any change to the dependencies, independent of user interactions with the Logs Navigation component, trigger its internal logic and, in the case of this PR, calls to store results in the cache.

For example, a recent escalation was also a caused by this implementation: https://github.com/grafana/grafana/pull/80167

Finally, [a comment in another PR](https://github.com/grafana/grafana/pull/76348#pullrequestreview-1809519708) surfaced that any action changing, for example, a change in the current time interval, would cause `LogsNavigation` to invoke cache-related functions, as can be seen in the following video:

https://github.com/grafana/grafana/assets/1069378/e3c027c7-3494-4482-972c-8980d04a1055

In this PR we're cleaning up the effects used by this component, moving the `addResultsFromCache()` out of the effect and into the callback for navigation changes, and adding consistency to the navigation buttons, so they are all disabled while loading.

**Special notes for your reviewer:**

Please check that:
- Navigation works as expected
- Cache used by the navigation pages works as expected
- Newer uncached results are fetched from the backend