### PR TITLE
Provisioning: Sync provisioned folders between dashboard and folder tables

### DIFF
--- a/pkg/services/folder/folderimpl/folder.go
+++ b/pkg/services/folder/folderimpl/folder.go
@@ -128,7 +128,7 @@ func (s *Service) Get(ctx context.Context, cmd *folder.GetFolderQuery) (*folder.
 		return nil, dashboards.ErrFolderAccessDenied
 	}
 
-	if !s.features.IsEnabled(ctx, featuremgmt.FlagNestedFolders) {
+	if !s.features.IsEnabled(ctx, featuremgmt.FlagNestedFolders) && !cmd.ForceFoldersWrite {
 		return dashFolder, nil
 	}
 
@@ -440,15 +440,27 @@ func (s *Service) Create(ctx context.Context, cmd *folder.CreateFolderCommand) (
 	}
 
 	saveDashboardCmd, err := s.buildSaveDashboardCommand(ctx, dto)
-	if err != nil {
+	ignoreDuplicateInsert := errors.Is(err, dashboards.ErrDashboardWithSameNameInFolderExists) && cmd.IgnoreDuplicateRowErr
+	if err != nil && !ignoreDuplicateInsert {
 		return nil, toFolderError(err)
 	}
 
 	var nestedFolder *folder.Folder
 	var dash *dashboards.Dashboard
 	err = s.db.InTransaction(ctx, func(ctx context.Context) error {
-		if dash, err = s.dashboardStore.SaveDashboard(ctx, *saveDashboardCmd); err != nil {
-			return toFolderError(err)
+		if !ignoreDuplicateInsert {
+			if dash, err = s.dashboardStore.SaveDashboard(ctx, *saveDashboardCmd); err != nil {
+				return toFolderError(err)
+			}
+
+		} else {
+			dashQuery := &dashboards.GetDashboardQuery{
+				Title: &dashFolder.Title,
+				OrgID: cmd.OrgID,
+			}
+			if dash, err = s.dashboardStore.GetDashboard(ctx, dashQuery); err != nil {
+				return toFolderError(err)
+			}
 		}
 
 		cmd = &folder.CreateFolderCommand{

--- a/pkg/services/folder/folderimpl/folder.go
+++ b/pkg/services/folder/folderimpl/folder.go
@@ -441,7 +441,7 @@ func (s *Service) Create(ctx context.Context, cmd *folder.CreateFolderCommand) (
 	}
 
 	saveDashboardCmd, err := s.buildSaveDashboardCommand(ctx, dto, cmd.IgnoreDuplicateRowErr)
-	ignoreDuplicateInsert := cmd.IgnoreDuplicateRowErr
+	ignoreDuplicateInsert := errors.Is(err, dashboards.ErrDashboardWithSameNameInFolderExists) && cmd.IgnoreDuplicateRowErr
 	if err != nil && !ignoreDuplicateInsert {
 		return nil, toFolderError(err)
 	}

--- a/pkg/services/folder/model.go
+++ b/pkg/services/folder/model.go
@@ -93,7 +93,8 @@ type CreateFolderCommand struct {
 	Description string `json:"description"`
 	ParentUID   string `json:"parentUid"`
 
-	SignedInUser identity.Requester `json:"-"`
+	SignedInUser          identity.Requester `json:"-"`
+	IgnoreDuplicateRowErr bool               `json:"-"`
 }
 
 // UpdateFolderCommand captures the information required by the folder service
@@ -146,7 +147,8 @@ type GetFolderQuery struct {
 	Title *string
 	OrgID int64
 
-	SignedInUser identity.Requester `json:"-"`
+	ForceFoldersWrite bool               `json:"-"`
+	SignedInUser      identity.Requester `json:"-"`
 }
 
 // GetParentsQuery captures the information required by the folder service to

--- a/pkg/services/provisioning/alerting/rules_provisioner.go
+++ b/pkg/services/provisioning/alerting/rules_provisioner.go
@@ -109,9 +109,10 @@ func (prov *defaultAlertRuleProvisioner) getOrCreateFolderUID(
 	// dashboard folder not found. create one.
 	if errors.Is(err, dashboards.ErrDashboardNotFound) {
 		createCmd := &folder.CreateFolderCommand{
-			OrgID: orgID,
-			UID:   util.GenerateShortUID(),
-			Title: folderName,
+			OrgID:                 orgID,
+			UID:                   util.GenerateShortUID(),
+			Title:                 folderName,
+			IgnoreDuplicateRowErr: true,
 		}
 		dbDash, err := prov.dashboardProvService.SaveFolderForProvisionedDashboards(ctx, createCmd)
 		if err != nil {

--- a/pkg/services/provisioning/dashboards/file_reader.go
+++ b/pkg/services/provisioning/dashboards/file_reader.go
@@ -16,6 +16,7 @@ import (
 	"github.com/grafana/grafana/pkg/services/accesscontrol"
 	"github.com/grafana/grafana/pkg/services/dashboards"
 	"github.com/grafana/grafana/pkg/services/folder"
+	"github.com/grafana/grafana/pkg/services/org"
 	"github.com/grafana/grafana/pkg/services/provisioning/utils"
 	"github.com/grafana/grafana/pkg/util"
 )
@@ -324,28 +325,54 @@ func (fr *FileReader) getOrCreateFolder(ctx context.Context, cfg *config, servic
 		return 0, "", ErrFolderNameMissing
 	}
 
-	cmd := &dashboards.GetDashboardQuery{
-		Title:    &folderName,
-		FolderID: util.Pointer(int64(0)), // nolint:staticcheck
-		OrgID:    cfg.OrgID,
+	q := folder.GetFolderQuery{
+		SignedInUser: accesscontrol.BackgroundUser(
+			"dashboard_provisioning",
+			cfg.OrgID,
+			org.RoleAdmin,
+			[]accesscontrol.Permission{
+				{Action: dashboards.ActionFoldersRead, Scope: dashboards.ScopeFoldersAll},
+			}),
+		Title:             &folderName,
+		OrgID:             cfg.OrgID,
+		ForceFoldersWrite: true,
 	}
-	result, err := fr.dashboardStore.GetDashboard(ctx, cmd)
+	result, err := fr.folderService.Get(ctx, &q)
 
-	if err != nil && !errors.Is(err, dashboards.ErrDashboardNotFound) {
+	isNotFound := errors.Is(err, dashboards.ErrDashboardNotFound) || errors.Is(err, folder.ErrFolderNotFound)
+	if err != nil && !isNotFound {
 		return 0, "", err
 	}
 
 	// dashboard folder not found. create one.
-	if errors.Is(err, dashboards.ErrDashboardNotFound) {
+	if isNotFound {
 		// set dashboard folderUid if given
 		if cfg.FolderUID == accesscontrol.GeneralFolderUID {
 			return 0, "", dashboards.ErrFolderInvalidUID
 		}
 
+		dashQuery := &dashboards.GetDashboardQuery{
+			Title:    &folderName,
+			FolderID: util.Pointer(int64(0)), // nolint:staticcheck
+			OrgID:    cfg.OrgID,
+		}
+
+		dash, err := fr.dashboardStore.GetDashboard(ctx, dashQuery)
+		if err != nil && !errors.Is(err, dashboards.ErrDashboardNotFound) {
+			return 0, "", err
+		}
+
+		// if a folder is not found in folder tbl, but found in dashboard tbl,
+		// we create a missing folder entry and set its UID to the dashboard's UID
+		if err == nil {
+			cfg.FolderUID = dash.FolderUID
+		}
+
 		createCmd := &folder.CreateFolderCommand{
-			OrgID: cfg.OrgID,
-			UID:   cfg.FolderUID,
-			Title: folderName,
+			OrgID:                 cfg.OrgID,
+			UID:                   cfg.FolderUID,
+			Title:                 folderName,
+			IgnoreDuplicateRowErr: true,
 		}
 
 		f, err := service.SaveFolderForProvisionedDashboards(ctx, createCmd)
@@ -354,10 +381,6 @@ func (fr *FileReader) getOrCreateFolder(ctx context.Context, cfg *config, servic
 		}
 		// nolint:staticcheck
 		return f.ID, f.UID, nil
-	}
-
-	if !result.IsFolder {
-		return 0, "", fmt.Errorf("got invalid response. expected folder, found dashboard")
 	}
 
 	return result.ID, result.UID, nil

--- a/pkg/services/provisioning/dashboards/file_reader.go
+++ b/pkg/services/provisioning/dashboards/file_reader.go
@@ -383,6 +383,7 @@ func (fr *FileReader) getOrCreateFolder(ctx context.Context, cfg *config, servic
 		return f.ID, f.UID, nil
 	}
 
+	// nolint:staticcheck
 	return result.ID, result.UID, nil
 }
 

--- a/pkg/services/provisioning/dashboards/file_reader.go
+++ b/pkg/services/provisioning/dashboards/file_reader.go
@@ -339,7 +339,7 @@ func (fr *FileReader) getOrCreateFolder(ctx context.Context, cfg *config, servic
 	}
 	result, err := fr.folderService.Get(ctx, &q)
 
-	isNotFound := errors.Is(err, dashboards.ErrDashboardNotFound) || errors.Is(err, folder.ErrFolderNotFound)
+	isNotFound := errors.Is(err, dashboards.ErrFolderNotFound) || errors.Is(err, folder.ErrFolderNotFound)
 	if err != nil && !isNotFound {
 		return 0, "", err
 	}
@@ -365,7 +365,7 @@ func (fr *FileReader) getOrCreateFolder(ctx context.Context, cfg *config, servic
 		// if a folder is not found in folder tbl, but found in dashboard tbl,
 		// we create a missing folder entry and set its UID to the dashboard's UID
 		if err == nil {
-			cfg.FolderUID = dash.FolderUID
+			cfg.FolderUID = dash.UID
 		}
 
 		createCmd := &folder.CreateFolderCommand{

--- a/pkg/services/provisioning/dashboards/validator_test.go
+++ b/pkg/services/provisioning/dashboards/validator_test.go
@@ -2,6 +2,7 @@ package dashboards
 
 import (
 	"context"
+	"github.com/grafana/grafana/pkg/services/folder/foldertest"
 	"sort"
 	"testing"
 
@@ -20,6 +21,7 @@ const (
 
 func TestDuplicatesValidator(t *testing.T) {
 	fakeService := &dashboards.FakeDashboardProvisioning{}
+	fakeFolderServiceWithNoFolders := &foldertest.FakeService{ExpectedFolder: nil, ExpectedError: dashboards.ErrDashboardNotFound}
 	defer fakeService.AssertExpectations(t)
 
 	cfg := &config{
@@ -35,7 +37,7 @@ func TestDuplicatesValidator(t *testing.T) {
 		const folderName = "duplicates-validator-folder"
 
 		fakeStore := &fakeDashboardStore{}
-		r, err := NewDashboardFileReader(cfg, logger, nil, fakeStore, nil)
+		r, err := NewDashboardFileReader(cfg, logger, nil, fakeStore, fakeFolderServiceWithNoFolders)
 		require.NoError(t, err)
 		fakeService.On("SaveFolderForProvisionedDashboards", mock.Anything, mock.Anything).Return(&folder.Folder{}, nil).Times(6)
 		fakeService.On("GetProvisionedDashboardData", mock.Anything, mock.AnythingOfType("string")).Return([]*dashboards.DashboardProvisioning{}, nil).Times(4)
@@ -54,11 +56,11 @@ func TestDuplicatesValidator(t *testing.T) {
 			Options: map[string]any{"path": dashboardContainingUID},
 		}
 
-		reader1, err := NewDashboardFileReader(cfg1, logger, nil, fakeStore, nil)
+		reader1, err := NewDashboardFileReader(cfg1, logger, nil, fakeStore, fakeFolderServiceWithNoFolders)
 		reader1.dashboardProvisioningService = fakeService
 		require.NoError(t, err)
 
-		reader2, err := NewDashboardFileReader(cfg2, logger, nil, fakeStore, nil)
+		reader2, err := NewDashboardFileReader(cfg2, logger, nil, fakeStore, fakeFolderServiceWithNoFolders)
 		reader2.dashboardProvisioningService = fakeService
 		require.NoError(t, err)
 
@@ -91,7 +93,7 @@ func TestDuplicatesValidator(t *testing.T) {
 		const folderName = "duplicates-validator-folder"
 
 		fakeStore := &fakeDashboardStore{}
-		r, err := NewDashboardFileReader(cfg, logger, nil, fakeStore, nil)
+		r, err := NewDashboardFileReader(cfg, logger, nil, fakeStore, fakeFolderServiceWithNoFolders)
 		require.NoError(t, err)
 		_, folderUID, err := r.getOrCreateFolder(context.Background(), cfg, fakeService, folderName)
 		require.NoError(t, err)
@@ -107,11 +109,11 @@ func TestDuplicatesValidator(t *testing.T) {
 			Options: map[string]any{"path": dashboardContainingUID},
 		}
 
-		reader1, err := NewDashboardFileReader(cfg1, logger, nil, fakeStore, nil)
+		reader1, err := NewDashboardFileReader(cfg1, logger, nil, fakeStore, fakeFolderServiceWithNoFolders)
 		reader1.dashboardProvisioningService = fakeService
 		require.NoError(t, err)
 
-		reader2, err := NewDashboardFileReader(cfg2, logger, nil, fakeStore, nil)
+		reader2, err := NewDashboardFileReader(cfg2, logger, nil, fakeStore, fakeFolderServiceWithNoFolders)
 		reader2.dashboardProvisioningService = fakeService
 		require.NoError(t, err)
 
@@ -168,15 +170,15 @@ func TestDuplicatesValidator(t *testing.T) {
 			Name: "third", Type: "file", OrgID: 2, Folder: "duplicates-validator-folder",
 			Options: map[string]any{"path": twoDashboardsWithUID},
 		}
-		reader1, err := NewDashboardFileReader(cfg1, logger, nil, fakeStore, nil)
+		reader1, err := NewDashboardFileReader(cfg1, logger, nil, fakeStore, fakeFolderServiceWithNoFolders)
 		reader1.dashboardProvisioningService = fakeService
 		require.NoError(t, err)
 
-		reader2, err := NewDashboardFileReader(cfg2, logger, nil, fakeStore, nil)
+		reader2, err := NewDashboardFileReader(cfg2, logger, nil, fakeStore, fakeFolderServiceWithNoFolders)
 		reader2.dashboardProvisioningService = fakeService
 		require.NoError(t, err)
 
-		reader3, err := NewDashboardFileReader(cfg3, logger, nil, fakeStore, nil)
+		reader3, err := NewDashboardFileReader(cfg3, logger, nil, fakeStore, fakeFolderServiceWithNoFolders)
 		reader3.dashboardProvisioningService = fakeService
 		require.NoError(t, err)
 
@@ -193,7 +195,7 @@ func TestDuplicatesValidator(t *testing.T) {
 
 		duplicates := duplicateValidator.getDuplicates()
 
-		r, err := NewDashboardFileReader(cfg, logger, nil, fakeStore, nil)
+		r, err := NewDashboardFileReader(cfg, logger, nil, fakeStore, fakeFolderServiceWithNoFolders)
 		require.NoError(t, err)
 		_, folderUID, err := r.getOrCreateFolder(context.Background(), cfg, fakeService, cfg1.Folder)
 		require.NoError(t, err)
@@ -210,7 +212,7 @@ func TestDuplicatesValidator(t *testing.T) {
 		sort.Strings(titleUsageReaders)
 		require.Equal(t, []string{"first"}, titleUsageReaders)
 
-		r, err = NewDashboardFileReader(cfg3, logger, nil, fakeStore, nil)
+		r, err = NewDashboardFileReader(cfg3, logger, nil, fakeStore, fakeFolderServiceWithNoFolders)
 		require.NoError(t, err)
 		_, folderUID, err = r.getOrCreateFolder(context.Background(), cfg3, fakeService, cfg3.Folder)
 		require.NoError(t, err)

--- a/pkg/services/provisioning/dashboards/validator_test.go
+++ b/pkg/services/provisioning/dashboards/validator_test.go
@@ -2,7 +2,6 @@ package dashboards
 
 import (
 	"context"
-	"github.com/grafana/grafana/pkg/services/folder/foldertest"
 	"sort"
 	"testing"
 
@@ -12,6 +11,7 @@ import (
 	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/services/dashboards"
 	"github.com/grafana/grafana/pkg/services/folder"
+	"github.com/grafana/grafana/pkg/services/folder/foldertest"
 )
 
 const (


### PR DESCRIPTION
A follow-up PR to this one https://github.com/grafana/grafana/pull/80140

Fixing an issue where folders, during provisioning, were only inserted into the `dashboard` table and not into the `folder` table. This PR ensures that both tables stay in sync by inserting provisioned folders into the `folder` table.

How to test these changes:

1. Checkout commit that does not have recently made provisioning fixes - `git checkout ee7daeb2a73ba05ed82e33085b6800da2793bd10`
2. Disable `nestedFolders` feature toggle
3. Create provisioning config, for example:
```
apiVersion: 1  

providers:  
  - name: 'gdev dashboards'  
    orgId: 1  
    folder: 'gdev-dashboards'  
    folderUid: ''  
    type: file  
    disableDeletion: false  
    updateIntervalSeconds: 20  
    allowUiUpdates: false  
    options:  
      path: devenv/dev-dashboards  
      foldersFromFilesStructure: true
```
5. Run grafana `make run`
6. Check that the folders have been stored in the `dashboard` table, but they are missing in the `folder` table
7. Switch to the fix branch `git checkout sync-provisioned-folders` and run grafana `make run`
8. Make sure that provisioned folders have been finally stored in both - `dashboard` and `folder` tables
9. Repeat the above steps with `nestedFolders` feature toggle enabled