### PR TITLE
Docs: fix broken Cloud docs link 

### DIFF
--- a/docs/sources/dashboards/assess-dashboard-usage/index.md
+++ b/docs/sources/dashboards/assess-dashboard-usage/index.md
@@ -60,11 +60,7 @@ Dashboard insights show the following information:
 
 {{< figure src="/static/img/docs/enterprise/dashboard_insights_stats.png" max-width="400px" class="docs-image--no-shadow" alt="Stats tab" >}}{{< figure src="/static/img/docs/enterprise/dashboard_insights_users.png" max-width="400px" class="docs-image--no-shadow" alt="Users and activity tab" >}}
 
-{{% admonition type="note" %}}
-
 If public dashboards are [enabled][], you'll also see a **Public dashboards** tab in your analytics.
-
-{{% /admonition %}}
 
 ### Data source insights
 

--- a/docs/sources/dashboards/assess-dashboard-usage/index.md
+++ b/docs/sources/dashboards/assess-dashboard-usage/index.md
@@ -62,7 +62,7 @@ Dashboard insights show the following information:
 
 {{% admonition type="note" %}}
 
-If public dashboards are [enabled]({{< relref "../../setup-grafana/configure-grafana/#public_dashboards" >}}), you'll also see a **Public dashboards** tab in your analytics.
+If public dashboards are [enabled][], you'll also see a **Public dashboards** tab in your analytics.
 
 {{% /admonition %}}
 
@@ -146,4 +146,7 @@ You can click the previous links to download the respective dashboard JSON, then
 
 [Grafana Enterprise]: "/docs/grafana/ -> /docs/grafana/<GRAFANA VERSION>/introduction/grafana-enterprise"
 [Grafana Enterprise]: "/docs/grafana-cloud/ -> /docs/grafana/<GRAFANA VERSION>/introduction/grafana-enterprise"
+
+[enabled]: "/docs/grafana/ -> /docs/grafana/<GRAFANA VERSION>/setup-grafana/configure-grafana#public_dashboards"
+[enabled]: "/docs/grafana-cloud/ -> /docs/grafana/<GRAFANA VERSION>/setup-grafana/configure-grafana#public_dashboards"
 {{% /docs/reference %}}


### PR DESCRIPTION
_Assess dashboard usage_ page is mounted in Grafana and Grafana Cloud docs so `docs-reference` style linking must be used on this page to support linking from both doc sets. This PR replaces the `relref` style link with a `docs-reference` style link. 

Also, the link text was taken out of an admonition since `docs-reference` style links inside `admonition` shortcodes don't work.