### PR TITLE
Annotations: Split cleanup into separate queries and deletes to avoid deadlocks on MySQL

### DIFF
--- a/pkg/services/annotations/annotationsimpl/cleanup_test.go
+++ b/pkg/services/annotations/annotationsimpl/cleanup_test.go
@@ -15,7 +15,11 @@ import (
 	"github.com/grafana/grafana/pkg/setting"
 )
 
-func TestAnnotationCleanUp(t *testing.T) {
+func TestIntegrationAnnotationCleanUp(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test")
+	}
+
 	fakeSQL := db.InitTestDB(t)
 
 	tests := []struct {
@@ -144,7 +148,11 @@ func TestAnnotationCleanUp(t *testing.T) {
 	}
 }
 
-func TestOldAnnotationsAreDeletedFirst(t *testing.T) {
+func TestIntegrationOldAnnotationsAreDeletedFirst(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test")
+	}
+
 	fakeSQL := db.InitTestDB(t)
 
 	t.Cleanup(func() {

--- a/pkg/services/annotations/annotationsimpl/cleanup_test.go
+++ b/pkg/services/annotations/annotationsimpl/cleanup_test.go
@@ -268,7 +268,6 @@ func createTestAnnotations(t *testing.T, store db.DB, expectedCount int, oldAnno
 
 		newAnnotations = append(newAnnotations, a)
 		newAnnotationTags = append(newAnnotationTags, &annotationTag{AnnotationID: a.ID, TagID: 1}, &annotationTag{AnnotationID: a.ID, TagID: 2})
-
 	}
 
 	err := store.WithDbSession(context.Background(), func(sess *db.Session) error {

--- a/pkg/services/annotations/annotationsimpl/cleanup_test.go
+++ b/pkg/services/annotations/annotationsimpl/cleanup_test.go
@@ -90,7 +90,7 @@ func TestAnnotationCleanUp(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			cfg := setting.NewCfg()
-			cfg.AnnotationCleanupJobBatchSize = 2
+			cfg.AnnotationCleanupJobBatchSize = 1
 			cleaner := ProvideCleanupService(fakeSQL, cfg)
 			affectedAnnotations, affectedAnnotationTags, err := cleaner.Run(context.Background(), test.cfg)
 			require.NoError(t, err)
@@ -145,7 +145,7 @@ func TestOldAnnotationsAreDeletedFirst(t *testing.T) {
 
 		// run the clean up task to keep one annotation.
 		cfg := setting.NewCfg()
-		cfg.AnnotationCleanupJobBatchSize = 2
+		cfg.AnnotationCleanupJobBatchSize = 1
 		cleaner := NewXormStore(cfg, log.New("annotation.test"), fakeSQL, nil)
 		_, err = cleaner.CleanAnnotations(context.Background(), setting.AnnotationCleanupSettings{MaxCount: 1}, alertAnnotationType)
 		require.NoError(t, err)

--- a/pkg/services/annotations/annotationsimpl/cleanup_test.go
+++ b/pkg/services/annotations/annotationsimpl/cleanup_test.go
@@ -90,7 +90,7 @@ func TestAnnotationCleanUp(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			cfg := setting.NewCfg()
-			cfg.AnnotationCleanupJobBatchSize = 1
+			cfg.AnnotationCleanupJobBatchSize = 2
 			cleaner := ProvideCleanupService(fakeSQL, cfg)
 			affectedAnnotations, affectedAnnotationTags, err := cleaner.Run(context.Background(), test.cfg)
 			require.NoError(t, err)
@@ -145,7 +145,7 @@ func TestOldAnnotationsAreDeletedFirst(t *testing.T) {
 
 		// run the clean up task to keep one annotation.
 		cfg := setting.NewCfg()
-		cfg.AnnotationCleanupJobBatchSize = 1
+		cfg.AnnotationCleanupJobBatchSize = 2
 		cleaner := NewXormStore(cfg, log.New("annotation.test"), fakeSQL, nil)
 		_, err = cleaner.CleanAnnotations(context.Background(), setting.AnnotationCleanupSettings{MaxCount: 1}, alertAnnotationType)
 		require.NoError(t, err)

--- a/pkg/services/annotations/annotationsimpl/xorm_store.go
+++ b/pkg/services/annotations/annotationsimpl/xorm_store.go
@@ -567,9 +567,10 @@ func (r *xormRepositoryImpl) CleanOrphanedAnnotationTags(ctx context.Context) (i
 
 func (r *xormRepositoryImpl) fetchIDs(ctx context.Context, table, condition string) ([]int64, error) {
 	sql := fmt.Sprintf(`SELECT id FROM %s`, table)
-	if condition != "" {
-		sql += fmt.Sprintf(` WHERE %s`, condition)
+	if condition == "" {
+		return nil, fmt.Errorf("condition must be supplied; cannot fetch IDs from entire table")
 	}
+	sql += fmt.Sprintf(` WHERE %s`, condition)
 	ids := make([]int64, 0)
 	err := r.db.WithDbSession(ctx, func(session *db.Session) error {
 		return session.SQL(sql).Find(&ids)

--- a/pkg/services/annotations/annotationsimpl/xorm_store.go
+++ b/pkg/services/annotations/annotationsimpl/xorm_store.go
@@ -611,24 +611,6 @@ func asAny(vs []int64) []any {
 	return r
 }
 
-// executeSQLUntilDoneOrCancelled repeatedly executes a SQL statement until it affects no rows, produces an error, or the context is cancelled.
-// It operates in a similar way to untilDoneOrCancelled.
-func (r *xormRepositoryImpl) executeSQLUntilDoneOrCancelled(ctx context.Context, sql string) (int64, error) {
-	return untilDoneOrCancelled(ctx, func() (int64, error) {
-		var affected int64
-		err := r.db.WithDbSession(ctx, func(session *db.Session) error {
-			res, err := session.Exec(sql)
-			if err != nil {
-				return err
-			}
-
-			affected, err = res.RowsAffected()
-			return err
-		})
-		return affected, err
-	})
-}
-
 // untilDoneOrCancelled repeatedly executes batched work until that work is either done (i.e., returns zero affected objects),
 // a batch produces an error, or the provided context is cancelled.
 // The work to be done is given as a callback that returns the number of affected objects for each batch, plus that batch's errors.

--- a/pkg/services/annotations/annotationsimpl/xorm_store.go
+++ b/pkg/services/annotations/annotationsimpl/xorm_store.go
@@ -519,7 +519,7 @@ func (r *xormRepositoryImpl) CleanAnnotations(ctx context.Context, cfg setting.A
 	var totalAffected int64
 	if cfg.MaxAge > 0 {
 		cutoffDate := timeNow().Add(-cfg.MaxAge).UnixNano() / int64(time.Millisecond)
-		// A subquery seems to deadlock with concurrent inserts on MySQL.
+		// Single-statement approaches, specifically ones using sub-queries, seem to deadlock with concurrent inserts on MySQL.
 		// We have a bounded batch size, so work around this by first loading the IDs into memory and allowing any locks to flush.
 		// This may under-delete when concurrent inserts happen, but any such annotations will simply be cleaned on the next cycle.
 		cond := fmt.Sprintf(`%s AND created < %v ORDER BY id DESC %s`, annotationType, cutoffDate, r.db.GetDialect().Limit(r.cfg.AnnotationCleanupJobBatchSize))

--- a/pkg/services/cleanup/cleanup.go
+++ b/pkg/services/cleanup/cleanup.go
@@ -74,7 +74,7 @@ func (j cleanUpJob) String() string {
 func (srv *CleanUpService) Run(ctx context.Context) error {
 	srv.cleanUpTmpFiles(ctx)
 
-	ticker := time.NewTicker(time.Minute * 10)
+	ticker := time.NewTicker(time.Minute * 1)
 	for {
 		select {
 		case <-ticker.C:


### PR DESCRIPTION
**What is this feature?**

Writes to annotations are sometimes rejected on MySQL due to a recurring deadlock with the annotation cleanup job.
Details here: https://github.com/grafana/grafana/issues/64979

**Why do we need this feature?**

The deadlock seems to be a result of the subquery, under normal circumstances a plain insert and delete should not lock, and there are no extended transactions at play.

This PR splits the subquery into a separate SQL statement. These statements do not share a transaction, and therefore allow locks to flush in between.

Unfortunately we could not reduce this to a single DELETE statement, due to the batching - DELETE LIMIT is not supported on all databases without needing to reintroduce the subquery. The IDs loaded into memory are of bounded size due to the batch size configuration.

**Which issue(s) does this PR fix?**:

https://github.com/grafana/grafana/issues/64979

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle.
- [x] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
