### PR TITLE
Alerting: Fix GetAlertRulesForScheduling to use folder table and join by org_id

### DIFF
--- a/pkg/services/ngalert/store/alert_rule.go
+++ b/pkg/services/ngalert/store/alert_rule.go
@@ -568,7 +568,7 @@ func (st DBstore) GetAlertRulesForScheduling(ctx context.Context, query *ngmodel
 		if query.PopulateFolders {
 			foldersSql := sess.Table("dashboard").Alias("d").Select("d.uid, d.title").
 				Where("is_folder = ?", st.SQLStore.GetDialect().BooleanStr(true)).
-				And(`EXISTS (SELECT 1 FROM alert_rule a WHERE d.uid = a.namespace_uid)`)
+				And(`EXISTS (SELECT 1 FROM alert_rule a WHERE d.uid = a.namespace_uid AND d.org_id = a.org_id)`)
 			if len(disabledOrgs) > 0 {
 				foldersSql.NotIn("org_id", disabledOrgs)
 			}

--- a/pkg/services/ngalert/store/alert_rule.go
+++ b/pkg/services/ngalert/store/alert_rule.go
@@ -566,9 +566,8 @@ func (st DBstore) GetAlertRulesForScheduling(ctx context.Context, query *ngmodel
 		query.ResultRules = rules
 
 		if query.PopulateFolders {
-			foldersSql := sess.Table("dashboard").Alias("d").Select("d.uid, d.title").
-				Where("is_folder = ?", st.SQLStore.GetDialect().BooleanStr(true)).
-				And(`EXISTS (SELECT 1 FROM alert_rule a WHERE d.uid = a.namespace_uid AND d.org_id = a.org_id)`)
+			foldersSql := sess.Table("folder").Alias("d").Select("d.uid, d.title").
+				Where(`EXISTS (SELECT 1 FROM alert_rule a WHERE d.uid = a.namespace_uid AND d.org_id = a.org_id)`)
 			if len(disabledOrgs) > 0 {
 				foldersSql.NotIn("org_id", disabledOrgs)
 			}

--- a/pkg/services/ngalert/store/alert_rule_test.go
+++ b/pkg/services/ngalert/store/alert_rule_test.go
@@ -342,7 +342,7 @@ func TestIntegration_GetAlertRulesForScheduling(t *testing.T) {
 	createFolder(t, store, rule1.NamespaceUID, rule1.Title, rule1.OrgID)
 	createFolder(t, store, rule2.NamespaceUID, rule2.Title, rule2.OrgID)
 
-	createFolder(t, store, rule2.NamespaceUID, "same UID folder", rand.Int63()) // create a folder with the same UID but in the different org
+	createFolder(t, store, rule2.NamespaceUID, "same UID folder", generator().OrgID) // create a folder with the same UID but in the different org
 
 	tc := []struct {
 		name         string

--- a/pkg/services/ngalert/store/alert_rule_test.go
+++ b/pkg/services/ngalert/store/alert_rule_test.go
@@ -342,6 +342,8 @@ func TestIntegration_GetAlertRulesForScheduling(t *testing.T) {
 	createFolder(t, store, rule1.NamespaceUID, rule1.Title, rule1.OrgID)
 	createFolder(t, store, rule2.NamespaceUID, rule2.Title, rule2.OrgID)
 
+	createFolder(t, store, rule2.NamespaceUID, "same UID folder", rand.Int63()) // create a folder with the same UID but in the different org
+
 	tc := []struct {
 		name         string
 		rules        []string


### PR DESCRIPTION
**What is this feature?**
1. This PR fixes a bug in the method GetAlertRulesForScheduling which happens when two organizations have a folder with different titles but the same UID. The method can return a wrong title. (first commit creates a test for the bug)

2. Changes the method GetAlertRulesForScheduling to query folder table. This will be needed for support of nested folders and for https://github.com/grafana/grafana/pull/74600
