### PR TITLE
Alerting: Increase size of kvstore value type for MySQL to LONGTEXT

### DIFF
--- a/pkg/services/sqlstore/migrations/kv_store_mig.go
+++ b/pkg/services/sqlstore/migrations/kv_store_mig.go
@@ -25,3 +25,10 @@ func addKVStoreMigrations(mg *Migrator) {
 
 	mg.AddMigration("add index kv_store.org_id-namespace-key", NewAddIndexMigration(kvStoreV1, kvStoreV1.Indices[0]))
 }
+
+// addKVStoreValueTypeLongTextMigration adds a migration to change the column type of kv_store.value to LONGTEXT for
+// MySQL to be more inline size-wise with PSQL (TEXT) and SQLite.
+func addKVStoreValueTypeLongTextMigration(mg *Migrator) {
+	mg.AddMigration("alter kv_store.value to longtext", NewRawSQLMigration("").
+		Mysql("ALTER TABLE kv_store MODIFY value LONGTEXT NOT NULL;"))
+}

--- a/pkg/services/sqlstore/migrations/kv_store_mig.go
+++ b/pkg/services/sqlstore/migrations/kv_store_mig.go
@@ -26,9 +26,9 @@ func addKVStoreMigrations(mg *Migrator) {
 	mg.AddMigration("add index kv_store.org_id-namespace-key", NewAddIndexMigration(kvStoreV1, kvStoreV1.Indices[0]))
 }
 
-// addKVStoreValueTypeLongTextMigration adds a migration to change the column type of kv_store.value to LONGTEXT for
+// addKVStoreMySQLValueTypeLongTextMigration adds a migration to change the column type of kv_store.value to LONGTEXT for
 // MySQL to be more inline size-wise with PSQL (TEXT) and SQLite.
-func addKVStoreValueTypeLongTextMigration(mg *Migrator) {
+func addKVStoreMySQLValueTypeLongTextMigration(mg *Migrator) {
 	mg.AddMigration("alter kv_store.value to longtext", NewRawSQLMigration("").
 		Mysql("ALTER TABLE kv_store MODIFY value LONGTEXT NOT NULL;"))
 }

--- a/pkg/services/sqlstore/migrations/migrations.go
+++ b/pkg/services/sqlstore/migrations/migrations.go
@@ -113,6 +113,8 @@ func (*OSSMigrations) AddMigration(mg *Migrator) {
 	ssosettings.AddMigration(mg)
 
 	ualert.CreateOrgMigratedKVStoreEntries(mg)
+
+	addKVStoreValueTypeLongTextMigration(mg)
 }
 
 func addStarMigrations(mg *Migrator) {

--- a/pkg/services/sqlstore/migrations/migrations.go
+++ b/pkg/services/sqlstore/migrations/migrations.go
@@ -114,7 +114,7 @@ func (*OSSMigrations) AddMigration(mg *Migrator) {
 
 	ualert.CreateOrgMigratedKVStoreEntries(mg)
 
-	addKVStoreValueTypeLongTextMigration(mg)
+	addKVStoreMySQLValueTypeLongTextMigration(mg)
 }
 
 func addStarMigrations(mg *Migrator) {


### PR DESCRIPTION

**What is this feature?**

This PR changes the type for kvstore `value` column from `MEDIUMTEXT` to `LONGTEXT`.

**Why do we need this feature?**

Alertmanager uses the kvstore to persist its notification log and the current column limit for MySQL (16.7mb) puts the maximum entries at a level that is potentially achievable for heavy alerting users (~40-80k entries).

In comparison, the current type for PSQL (TEXT) is effectively unlimited and I believe SQLIte defaults to 2gb which is also plenty of leeway.

**Who is this feature for?**

Grafana-managed alerting users with high alert loads.

**Which issue(s) does this PR fix?**:

Reports of errors such as:

```
... msg="unable to create Alertmanager for org" error="error decoding file 'notifications': illegal base64 data at input byte 16777212"
```

**Special notes for your reviewer:**

The nflog is a set of [protobuf messages](https://github.com/prometheus/alertmanager/blob/main/nflog/nflogpb/nflog.proto#L25) that contains some metadata (group key, receiver, group hash) and a list of uint64 hashes for all firing and resolved alert that were in the most recent notification.

Size-wise:
- The size of each entry scales with the cardinality of the firing alert group with some overhead for the metadata. ~M*8 bytes + ~160 bytes (but could be much higher)
- The number of entries scales linearly with the total unique notifications log entries in the past 5 days. Essentially one per (receiver, aggregation group) tuple. N * M

Given `MEDIUMTEXT` has a max size of 16.7 mb and a small entry is ~200-400 bytes, we can estimate the upper bound nflog entries on MySQL at about ~40k-80k.
