### PR TITLE
Alerting: Replace index role_id, action, scope with action, scope, role_id on permission table

### DIFF
--- a/pkg/services/sqlstore/migrations/accesscontrol/migrations.go
+++ b/pkg/services/sqlstore/migrations/accesscontrol/migrations.go
@@ -186,4 +186,8 @@ func AddMigration(mg *migrator.Migrator) {
 	mg.AddMigration("add permission identifier index", migrator.NewAddIndexMigration(permissionV1, &migrator.Index{
 		Cols: []string{"identifier"},
 	}))
+
+	mg.AddMigration("add permission scope action index", migrator.NewAddIndexMigration(permissionV1, &migrator.Index{
+		Cols: []string{"scope", "action"},
+	}))
 }

--- a/pkg/services/sqlstore/migrations/accesscontrol/migrations.go
+++ b/pkg/services/sqlstore/migrations/accesscontrol/migrations.go
@@ -188,6 +188,12 @@ func AddMigration(mg *migrator.Migrator) {
 	}))
 
 	mg.AddMigration("add permission action scope role_id index", migrator.NewAddIndexMigration(permissionV1, &migrator.Index{
+		Type: migrator.UniqueIndex,
 		Cols: []string{"action", "scope", "role_id"},
+	}))
+
+	mg.AddMigration("remove permission role_id action scope index", migrator.NewDropIndexMigration(permissionV1, &migrator.Index{
+		Type: migrator.UniqueIndex,
+		Cols: []string{"role_id", "action", "scope"},
 	}))
 }

--- a/pkg/services/sqlstore/migrations/accesscontrol/migrations.go
+++ b/pkg/services/sqlstore/migrations/accesscontrol/migrations.go
@@ -187,7 +187,7 @@ func AddMigration(mg *migrator.Migrator) {
 		Cols: []string{"identifier"},
 	}))
 
-	mg.AddMigration("add permission scope action index", migrator.NewAddIndexMigration(permissionV1, &migrator.Index{
-		Cols: []string{"scope", "action"},
+	mg.AddMigration("add permission action scope role_id index", migrator.NewAddIndexMigration(permissionV1, &migrator.Index{
+		Cols: []string{"action", "scope", "role_id"},
 	}))
 }


### PR DESCRIPTION
**What is this feature?**

This feature adds an `[action, scope, role_id]` index to the permission table and removes the existing `[role_id, action, scope]` index.

**Why do we need this feature?**

The existing `[role_id, action, scope]` index has the wrong ordering to be most effectively used in dashboard/folder permission requests.

Given a large mock test instance, the core database query inside dashboard/folder permission requests takes ~30-40ms locally. So, when performed individually they don't have that large of a latency impact. However when done in bulk, such as in the legacy alerting migration, this adds up to some very slow requests.

After the index is added, these same requests take ~3-5ms locally.

On a real-world test instance with the following setup:

Folders: 520
Dashboards with alerts: 2,285
Alerts: 11,967
Permission rows: 100,327

This reduces the migration duration from 2m39s to 18s.

**Who is this feature for?**

Mostly, it's for large legacy alerting installations to improve performance of the legacy alerting upgrade. However to some degree, all users with heavy usage of custom dashboard/folder permissions should see some minimal performance improvements on dashboard/folder permissions requests.. 

**Special notes for your reviewer:**

Example partial database query used in benchmark:

```sql
SELECT p.*,
       r.name AS role_name,
       0 AS user_id,
       '' AS user_login,
       0 AS is_service_account,
       '' AS user_email,
       0 AS team_id,
       '' AS team,
       '' AS team_email,
       br.role AS built_in_role
FROM permission p
    INNER JOIN role r
        ON p.role_id = r.id
    INNER JOIN builtin_role br
        ON r.id = br.role_id
           AND (
                   br.org_id = 0
                   OR br.org_id = 1
               )
WHERE (
          r.org_id = 1
          OR r.org_id = 0
      )
      AND (
              p.scope = '*'
              OR p.scope = 'folders:*'
              OR p.scope = 'folders:uid:*'
              OR p.scope = 'folders:uid:abcdfeg'
          )
      AND p.action IN ( 'folders:write', 'alert.rules:delete', 'library.panels:delete', 'library.panels:read',
                        'alert.rules:read', 'dashboards:create', 'alert.rules:create', 'library.panels:create',
                        'dashboards:delete', 'folders.permissions:read', 'folders.permissions:write', 'folders:read',
                        'dashboards:write', 'folders:delete', 'alert.rules:write', 'library.panels:write',
                        'dashboards.permissions:read', 'dashboards.permissions:write', 'dashboards:read'
                      );
```

EXPLAIN ANALYZE before index:

```
-> Limit: 200 row(s)  (cost=1573.81 rows=200) (actual time=0.318..37.436 rows=45 loops=1)
    -> Nested loop inner join  (cost=1573.81 rows=1017) (actual time=0.317..37.432 rows=45 loops=1)
        -> Nested loop inner join  (cost=6.90 rows=7) (actual time=0.238..0.286 rows=7 loops=1)
            -> Filter: ((br.org_id = 0) or (br.org_id = 1))  (cost=0.95 rows=7) (actual time=0.225..0.239 rows=7 loops=1)
                -> Covering index scan on br using UQE_builtin_role_org_id_role_id_role  (cost=0.95 rows=7) (actual time=0.022..0.030 rows=7 loops=1)
            -> Filter: ((r.org_id = 1) or (r.org_id = 0))  (cost=0.76 rows=1) (actual time=0.006..0.006 rows=1 loops=7)
                -> Single-row index lookup on r using PRIMARY (id=br.role_id)  (cost=0.76 rows=1) (actual time=0.005..0.005 rows=1 loops=7)
        -> Index lookup on p using UQE_permission_role_id_action_scope (role_id=br.role_id), with index condition: (((p.scope = '*') or (p.scope = 'folders:*') or (p.scope = 'folders:uid:*') or (p.scope = 'folders:uid:abcdfeg')) and (p.`action` in ('folders:write','alert.rules:delete','library.panels:delete','library.panels:read','alert.rules:read','dashboards:create','alert.rules:create','library.panels:create','dashboards:delete','folders.permissions:read','folders.permissions:write','folders:read','dashboards:write','folders:delete','alert.rules:write','library.panels:write','dashboards.permissions:read','dashboards.permissions:write','dashboards:read')))  (cost=139.70 rows=145) (actual time=5.303..5.305 rows=6 loops=7)
```
EXPLAIN ANALYZE after index:
```
-> Limit: 200 row(s)  (cost=200.51 rows=110) (actual time=0.115..1.003 rows=45 loops=1)
    -> Nested loop inner join  (cost=200.51 rows=110) (actual time=0.114..0.999 rows=45 loops=1)
        -> Nested loop inner join  (cost=107.01 rows=110) (actual time=0.106..0.919 rows=45 loops=1)
            -> Index range scan on p using IDX_permission_scope_action over (scope = '*' AND action = 'alert.rules:create') OR (scope = '*' AND action = 'alert.rules:delete') OR (74 more), with index condition: (((p.scope = '*') or (p.scope = 'folders:*') or (p.scope = 'folders:uid:*') or (p.scope = 'folders:uid:abcdfeg')) and (p.`action` in ('folders:write','alert.rules:delete','library.panels:delete','library.panels:read','alert.rules:read','dashboards:create','alert.rules:create','library.panels:create','dashboards:delete','folders.permissions:read','folders.permissions:write','folders:read','dashboards:write','folders:delete','alert.rules:write','library.panels:write','dashboards.permissions:read','dashboards.permissions:write','dashboards:read')))  (cost=68.51 rows=110) (actual time=0.088..0.699 rows=60 loops=1)
            -> Filter: ((br.org_id = 0) or (br.org_id = 1))  (cost=0.25 rows=1) (actual time=0.003..0.003 rows=1 loops=60)
                -> Index lookup on br using IDX_builtin_role_role_id (role_id=p.role_id)  (cost=0.25 rows=1) (actual time=0.003..0.003 rows=1 loops=60)
        -> Filter: ((r.org_id = 1) or (r.org_id = 0))  (cost=0.75 rows=1) (actual time=0.001..0.002 rows=1 loops=45)
            -> Single-row index lookup on r using PRIMARY (id=p.role_id)  (cost=0.75 rows=1) (actual time=0.001..0.001 rows=1 loops=45)
```
Note the significantly reduced total cost/execution time as well as the more efficient join strategy.