### PR TITLE
AppChrome: Fixes topnav height 

### DIFF
--- a/public/app/core/components/AppChrome/AppChrome.tsx
+++ b/public/app/core/components/AppChrome/AppChrome.tsx
@@ -118,12 +118,12 @@ const getStyles = (theme: GrafanaTheme2) => {
     content: css({
       display: 'flex',
       flexDirection: 'column',
-      paddingTop: TOP_BAR_LEVEL_HEIGHT * 2,
+      paddingTop: TOP_BAR_LEVEL_HEIGHT * 2 + 1,
       flexGrow: 1,
       height: '100%',
     }),
     contentNoSearchBar: css({
-      paddingTop: TOP_BAR_LEVEL_HEIGHT,
+      paddingTop: TOP_BAR_LEVEL_HEIGHT + 1,
     }),
     contentChromeless: css({
       paddingTop: 0,

--- a/public/app/core/components/AppChrome/AppChrome.tsx
+++ b/public/app/core/components/AppChrome/AppChrome.tsx
@@ -118,12 +118,12 @@ const getStyles = (theme: GrafanaTheme2) => {
     content: css({
       display: 'flex',
       flexDirection: 'column',
-      paddingTop: TOP_BAR_LEVEL_HEIGHT * 2 + 1,
+      paddingTop: TOP_BAR_LEVEL_HEIGHT * 2,
       flexGrow: 1,
       height: '100%',
     }),
     contentNoSearchBar: css({
-      paddingTop: TOP_BAR_LEVEL_HEIGHT + 1,
+      paddingTop: TOP_BAR_LEVEL_HEIGHT,
     }),
     contentChromeless: css({
       paddingTop: 0,
@@ -148,7 +148,6 @@ const getStyles = (theme: GrafanaTheme2) => {
       boxShadow: config.featureToggles.dockedMegaMenu ? undefined : shadow,
       background: theme.colors.background.primary,
       flexDirection: 'column',
-      borderBottom: `1px solid ${theme.colors.border.weak}`,
     }),
     panes: css({
       label: 'page-panes',

--- a/public/app/core/components/AppChrome/NavToolbar/NavToolbar.tsx
+++ b/public/app/core/components/AppChrome/NavToolbar/NavToolbar.tsx
@@ -97,6 +97,7 @@ const getStyles = (theme: GrafanaTheme2) => {
       display: 'flex',
       padding: theme.spacing(0, 1, 0, 2),
       alignItems: 'center',
+      borderBottom: `1px solid ${theme.colors.border.weak}`,
     }),
     menuButton: css({
       display: 'flex',


### PR DESCRIPTION
Noticed that scenes where missing the bottom border for the topnav.
![image](https://github.com/grafana/grafana/assets/10999/082c6880-bd5f-4a75-b57e-89724f2129fd)
 
This is caused by the first element in the scenes canvas is sticky "toolbar" (where variables and time range controls are), this has a z-index above that of the topnav chrome and renders on top of the bottom border. 

The page top padding that pushes the page down below the topnav is 80px, which is the combined height of the two rows of topnav but the border of the topnav was added on the wrapping element for these two 40px rows (so not included), so really adds up to 81px. 

Fix: Move the border to the bottom row of the topnav instead of the wrapping element (this way it's included in the bottom row 40px). After this change the topnav is really 80px . 
