### PR TITLE
Alerting: Stop retries on 4xx status code responses (remote Alertmanager readiness check)

### DIFF
--- a/pkg/services/ngalert/remote/client/alertmanager.go
+++ b/pkg/services/ngalert/remote/client/alertmanager.go
@@ -107,6 +107,10 @@ func (am *Alertmanager) IsReadyWithBackoff(ctx context.Context) (bool, error) {
 			}
 
 			if status != http.StatusOK {
+				if status/400 == 1 {
+					am.logger.Debug("Ready check failed with non-retriable status code", "attempt", attempts, "status", status)
+					return false, fmt.Errorf("ready check failed with non-retriable status code %d", status)
+				}
 				am.logger.Debug("Ready check failed, status code is not 200", "attempt", attempts, "status", status, "err", err)
 				continue
 			}


### PR DESCRIPTION
The readiness check for the remote Alertmanager sends HTTP requests to the `/-/ready` endpoint on a 100ms interval with a 10s timeout. This makes sense for transient errors, but in the case of authentication errors, we could save ~99 HTTP requests by returning after the first `4xx` status code error.

This PR stops retries on the readiness check for the remote Alertmanager when encountering a `4xx` status code response.