### PR TITLE
Postgres: Fix enabling the socks proxy

### DIFF
--- a/public/app/plugins/datasource/grafana-postgresql-datasource/configuration/ConfigurationEditor.tsx
+++ b/public/app/plugins/datasource/grafana-postgresql-datasource/configuration/ConfigurationEditor.tsx
@@ -403,7 +403,7 @@ export const PostgresConfigEditor = (props: DataSourcePluginOptionsEditorProps<P
         <ConnectionLimits options={options} onOptionsChange={onOptionsChange} />
 
         {config.secureSocksDSProxyEnabled && (
-          <SecureSocksProxySettings options={options} onOptionsChange={() => onOptionsChange(options)} />
+          <SecureSocksProxySettings options={options} onOptionsChange={onOptionsChange} />
         )}
       </ConfigSection>
     </>


### PR DESCRIPTION
currently you cannot enable the socks-proxy-mode in the postgres config UI because of the way the callback is called (we always call it with the original values, not the changed one).

the code has been adjusted, this is how it is done everywher else too, for example mysql:
https://github.com/grafana/grafana/blob/41144209de5043d3e53b178b7f204acc137a8f93/public/app/plugins/datasource/mysql/configuration/ConfigurationEditor.tsx#L235-L237

how to test:
1. add this section to your grafana config file
    - (NOTE: you do not need to setup any proxy thing, this will not work, but it is enough to trigger the UI):
```yaml
[secure_socks_datasource_proxy]
enabled = true
proxy_address = localhost:5555
allow_insecure = true
```

3. in grafana go to the postgres datasource config page, the `Secure Socks Proxy` toggle should  be visible, and you should be able to toggle it to enable it, then save it.
    - NOTE: when you save it, if will return an error, but that's ok. then reload the page, and verify that the setting stays enabled.
5. verify that you can turn it off, save it, and the setting stays disabled.

(NOTE: there are more things that needs fixing, i'm trying to keep these PRs small. more small PRs will follow when this is merged)