### PR TITLE
UX: Remove spacing in duration row in the Tempo query editor (search tab)

### DIFF
--- a/public/app/plugins/datasource/tempo/SearchTraceQLEditor/TraceQLSearch.tsx
+++ b/public/app/plugins/datasource/tempo/SearchTraceQLEditor/TraceQLSearch.tsx
@@ -157,7 +157,7 @@ const TraceQLSearch = ({ datasource, query, onChange, onClearResults, app }: Pro
             label={'Duration'}
             tooltip="The trace or span duration, i.e. end - start time of the trace/span. Accepted units are ns, ms, s, m, h"
           >
-            <HorizontalGroup spacing={'sm'}>
+            <HorizontalGroup spacing={'none'}>
               <Select
                 options={[
                   { label: 'span', value: 'span' },


### PR DESCRIPTION
**What is this feature?**

Removes spacing in duration row in the Tempo query editor (search tab).

**Why do we need this feature?**

Small UX enhancement.

Before
![Screenshot 2024-01-11 at 14 48 15](https://github.com/grafana/grafana/assets/90795735/f071f3f3-60aa-46e1-bce7-75821dc80b92)

After
![Screenshot 2024-01-11 at 14 47 23](https://github.com/grafana/grafana/assets/90795735/24bd776f-1ac3-4b2b-95d3-08a94a8e5550)

**Who is this feature for?**

Tempo users.

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
