### PR TITLE
postgres: better error handling

### DIFF
--- a/pkg/tsdb/grafana-postgresql-datasource/postgres.go
+++ b/pkg/tsdb/grafana-postgresql-datasource/postgres.go
@@ -105,7 +105,8 @@ func (s *Service) newInstanceSettings(cfg *setting.Cfg) datasource.InstanceFacto
 		if sdkproxy.New(proxyOpts).SecureSocksProxyEnabled() {
 			driverName, err = createPostgresProxyDriver(cnnstr, proxyOpts)
 			if err != nil {
-				return "", nil
+				logger.Error("postgres proxy creation failed", "error", err)
+				return nil, fmt.Errorf("postgres proxy creation failed")
 			}
 		}
 


### PR DESCRIPTION
the code does not handle a certain error situation (invalid socks config) well:
- instead of an error object, it returns `nil`, signalizing `no error`
- instead of `nil` for the value-object, it returns empty-string

we correct it.

how to test:
- adjust your grafana config to have this (NOTE: you do not need to setup a socks proxy, we are testing the failure-case here):
```yaml
[secure_socks_datasource_proxy]
enabled = true
proxy_address = localhost:5555
allow_insecure = true
```
- go to the datasource config page, enable `Secure Socks Proxy`, press `[Save & Test]`
- in the logs you will see `postgres proxy creation failed` with some additional info
- the message in the browser will be that health check failed


in the main-branch this scenario produces an `internal server error`
