### PR TITLE
sql: support the no-tls option in the socks proxy

### DIFF
--- a/pkg/tsdb/sqleng/proxyutil/proxy_util.go
+++ b/pkg/tsdb/sqleng/proxyutil/proxy_util.go
@@ -13,11 +13,12 @@ func GetSQLProxyOptions(cfg setting.SecureSocksDSProxySettings, dsInfo sqleng.Da
 			Username: dsInfo.UID,
 		},
 		ClientCfg: &sdkproxy.ClientCfg{
-			ClientCert:   cfg.ClientCert,
-			ClientKey:    cfg.ClientKey,
-			ServerName:   cfg.ServerName,
-			RootCA:       cfg.RootCA,
-			ProxyAddress: cfg.ProxyAddress,
+			ClientCert:    cfg.ClientCert,
+			ClientKey:     cfg.ClientKey,
+			ServerName:    cfg.ServerName,
+			RootCA:        cfg.RootCA,
+			ProxyAddress:  cfg.ProxyAddress,
+			AllowInsecure: cfg.AllowInsecure,
 		},
 	}
 	if dsInfo.JsonData.SecureDSProxyUsername != "" {


### PR DESCRIPTION
https://github.com/grafana/grafana/pull/79246 added the `allow_insecure` option to the socks proxy settings, and it works fine for example with `Prometheus`.

but the sql datasources (postgres for example), did not pick up the value of this setting, and keep saying it's `false`, even if i set it to `true`.

the diff here makes it work, but i'm not sure if this is the best way to do it.. WDYT?

(i recommend using `hide whitespace` when looking at the diff.. i only added a new line)

how to test (example):
1. add this to your grafana config:
```
[secure_socks_datasource_proxy]
enabled = true
proxy_address = localhost:5555
allow_insecure = true
```
2. install [microsocks](https://github.com/rofl0r/microsocks) ( for example `brew install microsocks`), and run `microsocks -i 127.0.0.1 -p 5555` . this will make it listen on localhost, port 5555
3. configure your postgres/mysql/mssql db-connection to use the socks proxy. it should work.