### PR TITLE
feat(alerting): add state persister interface

### DIFF
--- a/pkg/services/ngalert/api/api_testing.go
+++ b/pkg/services/ngalert/api/api_testing.go
@@ -87,15 +87,15 @@ func (srv TestingApiSrv) RouteTestGrafanaRuleConfig(c *contextmodel.ReqContext, 
 	}
 
 	cfg := state.ManagerCfg{
-		Metrics:                 nil,
-		ExternalURL:             srv.appUrl,
-		InstanceStore:           nil,
-		Images:                  &backtesting.NoopImageService{},
-		Clock:                   clock.New(),
-		Historian:               nil,
-		MaxStateSaveConcurrency: 1,
-		Tracer:                  srv.tracer,
-		Log:                     log.New("ngalert.state.manager"),
+		Metrics:        nil,
+		ExternalURL:    srv.appUrl,
+		InstanceStore:  nil,
+		Images:         &backtesting.NoopImageService{},
+		Clock:          clock.New(),
+		Historian:      nil,
+		Tracer:         srv.tracer,
+		Log:            log.New("ngalert.state.manager"),
+		StatePersister: state.NewNoopPersister(),
 	}
 	manager := state.NewManager(cfg)
 	includeFolder := !srv.cfg.ReservedLabels.IsReservedLabelDisabled(models.FolderTitleLabel)

--- a/pkg/services/ngalert/api/api_testing.go
+++ b/pkg/services/ngalert/api/api_testing.go
@@ -87,17 +87,16 @@ func (srv TestingApiSrv) RouteTestGrafanaRuleConfig(c *contextmodel.ReqContext, 
 	}
 
 	cfg := state.ManagerCfg{
-		Metrics:        nil,
-		ExternalURL:    srv.appUrl,
-		InstanceStore:  nil,
-		Images:         &backtesting.NoopImageService{},
-		Clock:          clock.New(),
-		Historian:      nil,
-		Tracer:         srv.tracer,
-		Log:            log.New("ngalert.state.manager"),
-		StatePersister: state.NewNoopPersister(),
+		Metrics:       nil,
+		ExternalURL:   srv.appUrl,
+		InstanceStore: nil,
+		Images:        &backtesting.NoopImageService{},
+		Clock:         clock.New(),
+		Historian:     nil,
+		Tracer:        srv.tracer,
+		Log:           log.New("ngalert.state.manager"),
 	}
-	manager := state.NewManager(cfg)
+	manager := state.NewManager(cfg, state.NewNoopPersister())
 	includeFolder := !srv.cfg.ReservedLabels.IsReservedLabelDisabled(models.FolderTitleLabel)
 	transitions := manager.ProcessEvalResults(
 		c.Req.Context(),

--- a/pkg/services/ngalert/backtesting/engine.go
+++ b/pkg/services/ngalert/backtesting/engine.go
@@ -49,15 +49,15 @@ func NewEngine(appUrl *url.URL, evalFactory eval.EvaluatorFactory, tracer tracin
 		evalFactory: evalFactory,
 		createStateManager: func() stateManager {
 			cfg := state.ManagerCfg{
-				Metrics:                 nil,
-				ExternalURL:             appUrl,
-				InstanceStore:           nil,
-				Images:                  &NoopImageService{},
-				Clock:                   clock.New(),
-				Historian:               nil,
-				MaxStateSaveConcurrency: 1,
-				Tracer:                  tracer,
-				Log:                     log.New("ngalert.state.manager"),
+				Metrics:        nil,
+				ExternalURL:    appUrl,
+				InstanceStore:  nil,
+				Images:         &NoopImageService{},
+				Clock:          clock.New(),
+				Historian:      nil,
+				Tracer:         tracer,
+				Log:            log.New("ngalert.state.manager"),
+				StatePersister: state.NewNoopPersister(),
 			}
 			return state.NewManager(cfg)
 		},

--- a/pkg/services/ngalert/backtesting/engine.go
+++ b/pkg/services/ngalert/backtesting/engine.go
@@ -49,17 +49,16 @@ func NewEngine(appUrl *url.URL, evalFactory eval.EvaluatorFactory, tracer tracin
 		evalFactory: evalFactory,
 		createStateManager: func() stateManager {
 			cfg := state.ManagerCfg{
-				Metrics:        nil,
-				ExternalURL:    appUrl,
-				InstanceStore:  nil,
-				Images:         &NoopImageService{},
-				Clock:          clock.New(),
-				Historian:      nil,
-				Tracer:         tracer,
-				Log:            log.New("ngalert.state.manager"),
-				StatePersister: state.NewNoopPersister(),
+				Metrics:       nil,
+				ExternalURL:   appUrl,
+				InstanceStore: nil,
+				Images:        &NoopImageService{},
+				Clock:         clock.New(),
+				Historian:     nil,
+				Tracer:        tracer,
+				Log:           log.New("ngalert.state.manager"),
 			}
-			return state.NewManager(cfg)
+			return state.NewManager(cfg, state.NewNoopPersister())
 		},
 	}
 }

--- a/pkg/services/ngalert/ngalert.go
+++ b/pkg/services/ngalert/ngalert.go
@@ -282,9 +282,6 @@ func (ng *AlertNG) init() error {
 	if err != nil {
 		return err
 	}
-	statePersister := state.NewSyncStatePerisiter(log.New("ngalert.state.manager.persist"),
-		ng.store, ng.FeatureToggles.IsEnabledGlobally(featuremgmt.FlagAlertingNoNormalState),
-		ng.Cfg.UnifiedAlerting.MaxStateSaveConcurrency)
 	cfg := state.ManagerCfg{
 		Metrics:                        ng.Metrics.GetStateMetrics(),
 		ExternalURL:                    appUrl,
@@ -294,9 +291,11 @@ func (ng *AlertNG) init() error {
 		Historian:                      history,
 		DoNotSaveNormalState:           ng.FeatureToggles.IsEnabledGlobally(featuremgmt.FlagAlertingNoNormalState),
 		ApplyNoDataAndErrorToAllStates: ng.FeatureToggles.IsEnabledGlobally(featuremgmt.FlagAlertingNoDataErrorExecution),
+		MaxStateSaveConcurrency:        ng.Cfg.UnifiedAlerting.MaxStateSaveConcurrency,
 		Tracer:                         ng.tracer,
 		Log:                            log.New("ngalert.state.manager"),
 	}
+	statePersister := state.NewSyncStatePerisiter(log.New("ngalert.state.manager.persist"), cfg)
 	stateManager := state.NewManager(cfg, statePersister)
 	scheduler := schedule.NewScheduler(schedCfg, stateManager)
 

--- a/pkg/services/ngalert/ngalert.go
+++ b/pkg/services/ngalert/ngalert.go
@@ -282,6 +282,9 @@ func (ng *AlertNG) init() error {
 	if err != nil {
 		return err
 	}
+	statePersister := state.NewSyncStatePerisiter(log.New("ngalert.state.manager.persist"),
+		ng.store, ng.FeatureToggles.IsEnabledGlobally(featuremgmt.FlagAlertingNoNormalState),
+		ng.Cfg.UnifiedAlerting.MaxStateSaveConcurrency)
 	cfg := state.ManagerCfg{
 		Metrics:                        ng.Metrics.GetStateMetrics(),
 		ExternalURL:                    appUrl,
@@ -290,8 +293,8 @@ func (ng *AlertNG) init() error {
 		Clock:                          clk,
 		Historian:                      history,
 		DoNotSaveNormalState:           ng.FeatureToggles.IsEnabledGlobally(featuremgmt.FlagAlertingNoNormalState),
-		MaxStateSaveConcurrency:        ng.Cfg.UnifiedAlerting.MaxStateSaveConcurrency,
 		ApplyNoDataAndErrorToAllStates: ng.FeatureToggles.IsEnabledGlobally(featuremgmt.FlagAlertingNoDataErrorExecution),
+		StatePersister:                 statePersister,
 		Tracer:                         ng.tracer,
 		Log:                            log.New("ngalert.state.manager"),
 	}

--- a/pkg/services/ngalert/ngalert.go
+++ b/pkg/services/ngalert/ngalert.go
@@ -295,7 +295,7 @@ func (ng *AlertNG) init() error {
 		Tracer:                         ng.tracer,
 		Log:                            log.New("ngalert.state.manager"),
 	}
-	statePersister := state.NewSyncStatePerisiter(log.New("ngalert.state.manager.persist"), cfg)
+	statePersister := state.NewSyncStatePersisiter(log.New("ngalert.state.manager.persist"), cfg)
 	stateManager := state.NewManager(cfg, statePersister)
 	scheduler := schedule.NewScheduler(schedCfg, stateManager)
 

--- a/pkg/services/ngalert/ngalert.go
+++ b/pkg/services/ngalert/ngalert.go
@@ -294,11 +294,10 @@ func (ng *AlertNG) init() error {
 		Historian:                      history,
 		DoNotSaveNormalState:           ng.FeatureToggles.IsEnabledGlobally(featuremgmt.FlagAlertingNoNormalState),
 		ApplyNoDataAndErrorToAllStates: ng.FeatureToggles.IsEnabledGlobally(featuremgmt.FlagAlertingNoDataErrorExecution),
-		StatePersister:                 statePersister,
 		Tracer:                         ng.tracer,
 		Log:                            log.New("ngalert.state.manager"),
 	}
-	stateManager := state.NewManager(cfg)
+	stateManager := state.NewManager(cfg, statePersister)
 	scheduler := schedule.NewScheduler(schedCfg, stateManager)
 
 	// if it is required to include folder title to the alerts, we need to subscribe to changes of alert title

--- a/pkg/services/ngalert/schedule/schedule_unit_test.go
+++ b/pkg/services/ngalert/schedule/schedule_unit_test.go
@@ -909,7 +909,7 @@ func setupScheduler(t *testing.T, rs *fakeRulesStore, is *state.FakeInstanceStor
 		Log:                     log.New("ngalert.state.manager"),
 		MaxStateSaveConcurrency: 1,
 	}
-	syncStatePersister := state.NewSyncStatePerisiter(log.New("ngalert.state.manager.perist"), managerCfg)
+	syncStatePersister := state.NewSyncStatePersisiter(log.New("ngalert.state.manager.perist"), managerCfg)
 	st := state.NewManager(managerCfg, syncStatePersister)
 
 	return NewScheduler(schedCfg, st)

--- a/pkg/services/ngalert/schedule/schedule_unit_test.go
+++ b/pkg/services/ngalert/schedule/schedule_unit_test.go
@@ -82,15 +82,15 @@ func TestProcessTicks(t *testing.T) {
 		Log:              log.New("ngalert.scheduler"),
 	}
 	managerCfg := state.ManagerCfg{
-		Metrics:                 testMetrics.GetStateMetrics(),
-		ExternalURL:             nil,
-		InstanceStore:           nil,
-		Images:                  &state.NoopImageService{},
-		Clock:                   mockedClock,
-		Historian:               &state.FakeHistorian{},
-		MaxStateSaveConcurrency: 1,
-		Tracer:                  testTracer,
-		Log:                     log.New("ngalert.state.manager"),
+		Metrics:        testMetrics.GetStateMetrics(),
+		ExternalURL:    nil,
+		InstanceStore:  nil,
+		Images:         &state.NoopImageService{},
+		Clock:          mockedClock,
+		Historian:      &state.FakeHistorian{},
+		StatePersister: state.NewNoopPersister(),
+		Tracer:         testTracer,
+		Log:            log.New("ngalert.state.manager"),
 	}
 	st := state.NewManager(managerCfg)
 
@@ -899,16 +899,17 @@ func setupScheduler(t *testing.T, rs *fakeRulesStore, is *state.FakeInstanceStor
 		Tracer:           testTracer,
 		Log:              log.New("ngalert.scheduler"),
 	}
+	syncStatePersister := state.NewSyncStatePerisiter(log.New("ngalert.state.manager.perist"), is, false, 1)
 	managerCfg := state.ManagerCfg{
-		Metrics:                 m.GetStateMetrics(),
-		ExternalURL:             nil,
-		InstanceStore:           is,
-		Images:                  &state.NoopImageService{},
-		Clock:                   mockedClock,
-		Historian:               &state.FakeHistorian{},
-		MaxStateSaveConcurrency: 1,
-		Tracer:                  testTracer,
-		Log:                     log.New("ngalert.state.manager"),
+		Metrics:        m.GetStateMetrics(),
+		ExternalURL:    nil,
+		InstanceStore:  is,
+		Images:         &state.NoopImageService{},
+		Clock:          mockedClock,
+		Historian:      &state.FakeHistorian{},
+		StatePersister: syncStatePersister,
+		Tracer:         testTracer,
+		Log:            log.New("ngalert.state.manager"),
 	}
 	st := state.NewManager(managerCfg)
 

--- a/pkg/services/ngalert/schedule/schedule_unit_test.go
+++ b/pkg/services/ngalert/schedule/schedule_unit_test.go
@@ -899,16 +899,17 @@ func setupScheduler(t *testing.T, rs *fakeRulesStore, is *state.FakeInstanceStor
 		Log:              log.New("ngalert.scheduler"),
 	}
 	managerCfg := state.ManagerCfg{
-		Metrics:       m.GetStateMetrics(),
-		ExternalURL:   nil,
-		InstanceStore: is,
-		Images:        &state.NoopImageService{},
-		Clock:         mockedClock,
-		Historian:     &state.FakeHistorian{},
-		Tracer:        testTracer,
-		Log:           log.New("ngalert.state.manager"),
+		Metrics:                 m.GetStateMetrics(),
+		ExternalURL:             nil,
+		InstanceStore:           is,
+		Images:                  &state.NoopImageService{},
+		Clock:                   mockedClock,
+		Historian:               &state.FakeHistorian{},
+		Tracer:                  testTracer,
+		Log:                     log.New("ngalert.state.manager"),
+		MaxStateSaveConcurrency: 1,
 	}
-	syncStatePersister := state.NewSyncStatePerisiter(log.New("ngalert.state.manager.perist"), is, false, 1)
+	syncStatePersister := state.NewSyncStatePerisiter(log.New("ngalert.state.manager.perist"), managerCfg)
 	st := state.NewManager(managerCfg, syncStatePersister)
 
 	return NewScheduler(schedCfg, st)

--- a/pkg/services/ngalert/schedule/schedule_unit_test.go
+++ b/pkg/services/ngalert/schedule/schedule_unit_test.go
@@ -82,17 +82,16 @@ func TestProcessTicks(t *testing.T) {
 		Log:              log.New("ngalert.scheduler"),
 	}
 	managerCfg := state.ManagerCfg{
-		Metrics:        testMetrics.GetStateMetrics(),
-		ExternalURL:    nil,
-		InstanceStore:  nil,
-		Images:         &state.NoopImageService{},
-		Clock:          mockedClock,
-		Historian:      &state.FakeHistorian{},
-		StatePersister: state.NewNoopPersister(),
-		Tracer:         testTracer,
-		Log:            log.New("ngalert.state.manager"),
+		Metrics:       testMetrics.GetStateMetrics(),
+		ExternalURL:   nil,
+		InstanceStore: nil,
+		Images:        &state.NoopImageService{},
+		Clock:         mockedClock,
+		Historian:     &state.FakeHistorian{},
+		Tracer:        testTracer,
+		Log:           log.New("ngalert.state.manager"),
 	}
-	st := state.NewManager(managerCfg)
+	st := state.NewManager(managerCfg, state.NewNoopPersister())
 
 	sched := NewScheduler(schedCfg, st)
 
@@ -899,19 +898,18 @@ func setupScheduler(t *testing.T, rs *fakeRulesStore, is *state.FakeInstanceStor
 		Tracer:           testTracer,
 		Log:              log.New("ngalert.scheduler"),
 	}
-	syncStatePersister := state.NewSyncStatePerisiter(log.New("ngalert.state.manager.perist"), is, false, 1)
 	managerCfg := state.ManagerCfg{
-		Metrics:        m.GetStateMetrics(),
-		ExternalURL:    nil,
-		InstanceStore:  is,
-		Images:         &state.NoopImageService{},
-		Clock:          mockedClock,
-		Historian:      &state.FakeHistorian{},
-		StatePersister: syncStatePersister,
-		Tracer:         testTracer,
-		Log:            log.New("ngalert.state.manager"),
+		Metrics:       m.GetStateMetrics(),
+		ExternalURL:   nil,
+		InstanceStore: is,
+		Images:        &state.NoopImageService{},
+		Clock:         mockedClock,
+		Historian:     &state.FakeHistorian{},
+		Tracer:        testTracer,
+		Log:           log.New("ngalert.state.manager"),
 	}
-	st := state.NewManager(managerCfg)
+	syncStatePersister := state.NewSyncStatePerisiter(log.New("ngalert.state.manager.perist"), is, false, 1)
+	st := state.NewManager(managerCfg, syncStatePersister)
 
 	return NewScheduler(schedCfg, st)
 }

--- a/pkg/services/ngalert/state/manager.go
+++ b/pkg/services/ngalert/state/manager.go
@@ -68,13 +68,11 @@ type ManagerCfg struct {
 	// to all states when corresponding execution in the rule definition is set to either `Alerting` or `OK`
 	ApplyNoDataAndErrorToAllStates bool
 
-	StatePersister StatePersister
-
 	Tracer tracing.Tracer
 	Log    log.Logger
 }
 
-func NewManager(cfg ManagerCfg) *Manager {
+func NewManager(cfg ManagerCfg, statePersister StatePersister) *Manager {
 	// Metrics for the cache use a collector, so they need access to the register directly.
 	c := newCache()
 	if cfg.Metrics != nil {
@@ -93,7 +91,7 @@ func NewManager(cfg ManagerCfg) *Manager {
 		externalURL:                    cfg.ExternalURL,
 		doNotSaveNormalState:           cfg.DoNotSaveNormalState,
 		applyNoDataAndErrorToAllStates: cfg.ApplyNoDataAndErrorToAllStates,
-		persister:                      cfg.StatePersister,
+		persister:                      statePersister,
 		tracer:                         cfg.Tracer,
 	}
 

--- a/pkg/services/ngalert/state/manager.go
+++ b/pkg/services/ngalert/state/manager.go
@@ -7,7 +7,6 @@ import (
 	"time"
 
 	"github.com/benbjohnson/clock"
-	"github.com/grafana/dskit/concurrency"
 	"github.com/grafana/grafana-plugin-sdk-go/data"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/trace"
@@ -30,6 +29,11 @@ type AlertInstanceManager interface {
 	GetStatesForRuleUID(orgID int64, alertRuleUID string) []*State
 }
 
+type StatePersister interface {
+	Async(ctx context.Context, ticker *clock.Ticker, cache *cache)
+	Sync(ctx context.Context, span trace.Span, states, staleStates []StateTransition)
+}
+
 type Manager struct {
 	log     log.Logger
 	metrics *metrics.State
@@ -45,8 +49,9 @@ type Manager struct {
 	externalURL   *url.URL
 
 	doNotSaveNormalState           bool
-	maxStateSaveConcurrency        int
 	applyNoDataAndErrorToAllStates bool
+
+	persister StatePersister
 }
 
 type ManagerCfg struct {
@@ -58,12 +63,12 @@ type ManagerCfg struct {
 	Historian     Historian
 	// DoNotSaveNormalState controls whether eval.Normal state is persisted to the database and returned by get methods
 	DoNotSaveNormalState bool
-	// MaxStateSaveConcurrency controls the number of goroutines (per rule) that can save alert state in parallel.
-	MaxStateSaveConcurrency int
 
 	// ApplyNoDataAndErrorToAllStates makes state manager to apply exceptional results (NoData and Error)
 	// to all states when corresponding execution in the rule definition is set to either `Alerting` or `OK`
 	ApplyNoDataAndErrorToAllStates bool
+
+	StatePersister StatePersister
 
 	Tracer tracing.Tracer
 	Log    log.Logger
@@ -87,8 +92,8 @@ func NewManager(cfg ManagerCfg) *Manager {
 		clock:                          cfg.Clock,
 		externalURL:                    cfg.ExternalURL,
 		doNotSaveNormalState:           cfg.DoNotSaveNormalState,
-		maxStateSaveConcurrency:        cfg.MaxStateSaveConcurrency,
 		applyNoDataAndErrorToAllStates: cfg.ApplyNoDataAndErrorToAllStates,
+		persister:                      cfg.StatePersister,
 		tracer:                         cfg.Tracer,
 	}
 
@@ -279,16 +284,7 @@ func (st *Manager) ProcessEvalResults(ctx context.Context, evaluatedAt time.Time
 	))
 
 	staleStates := st.deleteStaleStatesFromCache(ctx, logger, evaluatedAt, alertRule)
-	st.deleteAlertStates(tracingCtx, logger, staleStates)
-
-	if len(staleStates) > 0 {
-		span.AddEvent("deleted stale states", trace.WithAttributes(
-			attribute.Int64("state_transitions", int64(len(staleStates))),
-		))
-	}
-
-	st.saveAlertStates(tracingCtx, logger, states...)
-	span.AddEvent("updated database")
+	st.persister.Sync(tracingCtx, span, states, staleStates)
 
 	allChanges := append(states, staleStates...)
 	if st.historian != nil {
@@ -439,72 +435,6 @@ func (st *Manager) GetStatesForRuleUID(orgID int64, alertRuleUID string) []*Stat
 func (st *Manager) Put(states []*State) {
 	for _, s := range states {
 		st.cache.set(s)
-	}
-}
-
-// TODO: Is the `State` type necessary? Should it embed the instance?
-func (st *Manager) saveAlertStates(ctx context.Context, logger log.Logger, states ...StateTransition) {
-	if st.instanceStore == nil || len(states) == 0 {
-		return
-	}
-
-	saveState := func(ctx context.Context, idx int) error {
-		s := states[idx]
-		// Do not save normal state to database and remove transition to Normal state but keep mapped states
-		if st.doNotSaveNormalState && IsNormalStateWithNoReason(s.State) && !s.Changed() {
-			return nil
-		}
-
-		key, err := s.GetAlertInstanceKey()
-		if err != nil {
-			logger.Error("Failed to create a key for alert state to save it to database. The state will be ignored ", "cacheID", s.CacheID, "error", err, "labels", s.Labels.String())
-			return nil
-		}
-		instance := ngModels.AlertInstance{
-			AlertInstanceKey:  key,
-			Labels:            ngModels.InstanceLabels(s.Labels),
-			CurrentState:      ngModels.InstanceStateType(s.State.State.String()),
-			CurrentReason:     s.StateReason,
-			LastEvalTime:      s.LastEvaluationTime,
-			CurrentStateSince: s.StartsAt,
-			CurrentStateEnd:   s.EndsAt,
-			ResultFingerprint: s.ResultFingerprint.String(),
-		}
-
-		err = st.instanceStore.SaveAlertInstance(ctx, instance)
-		if err != nil {
-			logger.Error("Failed to save alert state", "labels", s.Labels.String(), "state", s.State, "error", err)
-			return nil
-		}
-		return nil
-	}
-
-	start := time.Now()
-	logger.Debug("Saving alert states", "count", len(states), "max_state_save_concurrency", st.maxStateSaveConcurrency)
-	_ = concurrency.ForEachJob(ctx, len(states), st.maxStateSaveConcurrency, saveState)
-	logger.Debug("Saving alert states done", "count", len(states), "max_state_save_concurrency", st.maxStateSaveConcurrency, "duration", time.Since(start))
-}
-
-func (st *Manager) deleteAlertStates(ctx context.Context, logger log.Logger, states []StateTransition) {
-	if st.instanceStore == nil || len(states) == 0 {
-		return
-	}
-
-	logger.Debug("Deleting alert states", "count", len(states))
-	toDelete := make([]ngModels.AlertInstanceKey, 0, len(states))
-
-	for _, s := range states {
-		key, err := s.GetAlertInstanceKey()
-		if err != nil {
-			logger.Error("Failed to delete alert instance with invalid labels", "cacheID", s.CacheID, "error", err)
-			continue
-		}
-		toDelete = append(toDelete, key)
-	}
-
-	err := st.instanceStore.DeleteAlertInstances(ctx, toDelete...)
-	if err != nil {
-		logger.Error("Failed to delete stale states", "error", err)
 	}
 }
 

--- a/pkg/services/ngalert/state/manager.go
+++ b/pkg/services/ngalert/state/manager.go
@@ -63,7 +63,8 @@ type ManagerCfg struct {
 	Historian     Historian
 	// DoNotSaveNormalState controls whether eval.Normal state is persisted to the database and returned by get methods
 	DoNotSaveNormalState bool
-
+	// MaxStateSaveConcurrency controls the number of goroutines (per rule) that can save alert state in parallel.
+	MaxStateSaveConcurrency int
 	// ApplyNoDataAndErrorToAllStates makes state manager to apply exceptional results (NoData and Error)
 	// to all states when corresponding execution in the rule definition is set to either `Alerting` or `OK`
 	ApplyNoDataAndErrorToAllStates bool

--- a/pkg/services/ngalert/state/manager_bench_test.go
+++ b/pkg/services/ngalert/state/manager_bench_test.go
@@ -30,7 +30,7 @@ func BenchmarkProcessEvalResults(b *testing.B) {
 		Tracer:    tracing.InitializeTracerForTest(),
 		Log:       log.New("ngalert.state.manager"),
 	}
-	sut := state.NewManager(cfg)
+	sut := state.NewManager(cfg, state.NewNoopPersister())
 	now := time.Now().UTC()
 	rule := makeBenchRule()
 	results := makeBenchResults(100)

--- a/pkg/services/ngalert/state/manager_bench_test.go
+++ b/pkg/services/ngalert/state/manager_bench_test.go
@@ -26,10 +26,9 @@ func BenchmarkProcessEvalResults(b *testing.B) {
 	store := historian.NewAnnotationStore(&as, nil, metrics)
 	hist := historian.NewAnnotationBackend(store, nil, metrics)
 	cfg := state.ManagerCfg{
-		Historian:               hist,
-		MaxStateSaveConcurrency: 1,
-		Tracer:                  tracing.InitializeTracerForTest(),
-		Log:                     log.New("ngalert.state.manager"),
+		Historian: hist,
+		Tracer:    tracing.InitializeTracerForTest(),
+		Log:       log.New("ngalert.state.manager"),
 	}
 	sut := state.NewManager(cfg)
 	now := time.Now().UTC()

--- a/pkg/services/ngalert/state/manager_private_test.go
+++ b/pkg/services/ngalert/state/manager_private_test.go
@@ -19,13 +19,10 @@ import (
 
 	"github.com/grafana/grafana/pkg/expr"
 	"github.com/grafana/grafana/pkg/infra/log"
-	"github.com/grafana/grafana/pkg/infra/log/logtest"
 	"github.com/grafana/grafana/pkg/infra/tracing"
 	"github.com/grafana/grafana/pkg/services/ngalert/eval"
 	"github.com/grafana/grafana/pkg/services/ngalert/metrics"
 	ngmodels "github.com/grafana/grafana/pkg/services/ngalert/models"
-
-	"github.com/grafana/grafana/pkg/util"
 )
 
 // Not for parallel tests.
@@ -80,84 +77,6 @@ func TestStateIsStale(t *testing.T) {
 			require.Equal(t, tc.expectedResult, stateIsStale(now, tc.lastEvaluation, intervalSeconds))
 		})
 	}
-}
-
-func TestManager_saveAlertStates(t *testing.T) {
-	type stateWithReason struct {
-		State  eval.State
-		Reason string
-	}
-	create := func(s eval.State, r string) stateWithReason {
-		return stateWithReason{
-			State:  s,
-			Reason: r,
-		}
-	}
-	allStates := [...]stateWithReason{
-		create(eval.Normal, ""),
-		create(eval.Normal, eval.NoData.String()),
-		create(eval.Normal, eval.Error.String()),
-		create(eval.Normal, util.GenerateShortUID()),
-		create(eval.Alerting, ""),
-		create(eval.Pending, ""),
-		create(eval.NoData, ""),
-		create(eval.Error, ""),
-	}
-
-	transitionToKey := map[ngmodels.AlertInstanceKey]StateTransition{}
-	transitions := make([]StateTransition, 0)
-	for _, fromState := range allStates {
-		for i, toState := range allStates {
-			tr := StateTransition{
-				State: &State{
-					State:       toState.State,
-					StateReason: toState.Reason,
-					Labels:      ngmodels.GenerateAlertLabels(5, fmt.Sprintf("%d--", i)),
-				},
-				PreviousState:       fromState.State,
-				PreviousStateReason: fromState.Reason,
-			}
-			key, err := tr.GetAlertInstanceKey()
-			require.NoError(t, err)
-			transitionToKey[key] = tr
-			transitions = append(transitions, tr)
-		}
-	}
-
-	t.Run("should save all transitions if doNotSaveNormalState is false", func(t *testing.T) {
-		st := &FakeInstanceStore{}
-		m := Manager{instanceStore: st, doNotSaveNormalState: false, maxStateSaveConcurrency: 1}
-		m.saveAlertStates(context.Background(), &logtest.Fake{}, transitions...)
-
-		savedKeys := map[ngmodels.AlertInstanceKey]ngmodels.AlertInstance{}
-		for _, op := range st.RecordedOps {
-			saved := op.(ngmodels.AlertInstance)
-			savedKeys[saved.AlertInstanceKey] = saved
-		}
-		assert.Len(t, transitionToKey, len(savedKeys))
-
-		for key, tr := range transitionToKey {
-			assert.Containsf(t, savedKeys, key, "state %s (%s) was not saved but should be", tr.State.State, tr.StateReason)
-		}
-	})
-
-	t.Run("should not save Normal->Normal if doNotSaveNormalState is true", func(t *testing.T) {
-		st := &FakeInstanceStore{}
-		m := Manager{instanceStore: st, doNotSaveNormalState: true, maxStateSaveConcurrency: 1}
-		m.saveAlertStates(context.Background(), &logtest.Fake{}, transitions...)
-
-		savedKeys := map[ngmodels.AlertInstanceKey]ngmodels.AlertInstance{}
-		for _, op := range st.RecordedOps {
-			saved := op.(ngmodels.AlertInstance)
-			savedKeys[saved.AlertInstanceKey] = saved
-		}
-		for key, tr := range transitionToKey {
-			if tr.State.State == eval.Normal && tr.StateReason == "" && tr.PreviousState == eval.Normal && tr.PreviousStateReason == "" {
-				continue
-			}
-			assert.Containsf(t, savedKeys, key, "state %s (%s) was not saved but should be", tr.State.State, tr.StateReason)
-		}
-	})
 }
 
 // TestProcessEvalResults_StateTransitions tests how state.Manager's ProcessEvalResults processes results and creates or changes states.
@@ -327,16 +246,18 @@ func TestProcessEvalResults_StateTransitions(t *testing.T) {
 		clk := clock.NewMock()
 
 		testMetrics := metrics.NewNGAlert(prometheus.NewPedanticRegistry()).GetStateMetrics()
+		fakeStore := &FakeInstanceStore{}
+		statePersister := NewSyncStatePerisiter(log.New("ngalert.state.manager.persist"), fakeStore, false, 1)
 		cfg := ManagerCfg{
-			Metrics:                 testMetrics,
-			Tracer:                  tracing.InitializeTracerForTest(),
-			Log:                     log.New("ngalert.state.manager"),
-			ExternalURL:             nil,
-			InstanceStore:           &FakeInstanceStore{},
-			Images:                  &NotAvailableImageService{},
-			Clock:                   clk,
-			Historian:               &FakeHistorian{},
-			MaxStateSaveConcurrency: 1,
+			Metrics:        testMetrics,
+			Tracer:         tracing.InitializeTracerForTest(),
+			Log:            log.New("ngalert.state.manager"),
+			ExternalURL:    nil,
+			InstanceStore:  fakeStore,
+			Images:         &NotAvailableImageService{},
+			Clock:          clk,
+			Historian:      &FakeHistorian{},
+			StatePersister: statePersister,
 
 			ApplyNoDataAndErrorToAllStates: applyNoDataErrorToAllStates,
 		}

--- a/pkg/services/ngalert/state/manager_private_test.go
+++ b/pkg/services/ngalert/state/manager_private_test.go
@@ -247,21 +247,20 @@ func TestProcessEvalResults_StateTransitions(t *testing.T) {
 
 		testMetrics := metrics.NewNGAlert(prometheus.NewPedanticRegistry()).GetStateMetrics()
 		fakeStore := &FakeInstanceStore{}
-		statePersister := NewSyncStatePerisiter(log.New("ngalert.state.manager.persist"), fakeStore, false, 1)
 		cfg := ManagerCfg{
-			Metrics:        testMetrics,
-			Tracer:         tracing.InitializeTracerForTest(),
-			Log:            log.New("ngalert.state.manager"),
-			ExternalURL:    nil,
-			InstanceStore:  fakeStore,
-			Images:         &NotAvailableImageService{},
-			Clock:          clk,
-			Historian:      &FakeHistorian{},
-			StatePersister: statePersister,
+			Metrics:       testMetrics,
+			Tracer:        tracing.InitializeTracerForTest(),
+			Log:           log.New("ngalert.state.manager"),
+			ExternalURL:   nil,
+			InstanceStore: fakeStore,
+			Images:        &NotAvailableImageService{},
+			Clock:         clk,
+			Historian:     &FakeHistorian{},
 
 			ApplyNoDataAndErrorToAllStates: applyNoDataErrorToAllStates,
 		}
-		st := NewManager(cfg)
+		statePersister := NewSyncStatePerisiter(log.New("ngalert.state.manager.persist"), fakeStore, false, 1)
+		st := NewManager(cfg, statePersister)
 
 		tss := make([]time.Time, 0, len(resultsAtTime))
 		for ts, results := range resultsAtTime {

--- a/pkg/services/ngalert/state/manager_private_test.go
+++ b/pkg/services/ngalert/state/manager_private_test.go
@@ -246,21 +246,19 @@ func TestProcessEvalResults_StateTransitions(t *testing.T) {
 		clk := clock.NewMock()
 
 		testMetrics := metrics.NewNGAlert(prometheus.NewPedanticRegistry()).GetStateMetrics()
-		fakeStore := &FakeInstanceStore{}
 		cfg := ManagerCfg{
 			Metrics:       testMetrics,
 			Tracer:        tracing.InitializeTracerForTest(),
 			Log:           log.New("ngalert.state.manager"),
 			ExternalURL:   nil,
-			InstanceStore: fakeStore,
+			InstanceStore: &FakeInstanceStore{},
 			Images:        &NotAvailableImageService{},
 			Clock:         clk,
 			Historian:     &FakeHistorian{},
 
 			ApplyNoDataAndErrorToAllStates: applyNoDataErrorToAllStates,
 		}
-		statePersister := NewSyncStatePerisiter(log.New("ngalert.state.manager.persist"), fakeStore, false, 1)
-		st := NewManager(cfg, statePersister)
+		st := NewManager(cfg, NewNoopPersister())
 
 		tss := make([]time.Time, 0, len(resultsAtTime))
 		for ts, results := range resultsAtTime {

--- a/pkg/services/ngalert/state/manager_test.go
+++ b/pkg/services/ngalert/state/manager_test.go
@@ -1355,16 +1355,17 @@ func TestProcessEvalResults(t *testing.T) {
 		instanceStore := &state.FakeInstanceStore{}
 		clk := clock.New()
 		cfg := state.ManagerCfg{
-			Metrics:       metrics.NewNGAlert(prometheus.NewPedanticRegistry()).GetStateMetrics(),
-			ExternalURL:   nil,
-			InstanceStore: instanceStore,
-			Images:        &state.NotAvailableImageService{},
-			Clock:         clk,
-			Historian:     &state.FakeHistorian{},
-			Tracer:        tracing.InitializeTracerForTest(),
-			Log:           log.New("ngalert.state.manager"),
+			Metrics:                 metrics.NewNGAlert(prometheus.NewPedanticRegistry()).GetStateMetrics(),
+			ExternalURL:             nil,
+			InstanceStore:           instanceStore,
+			Images:                  &state.NotAvailableImageService{},
+			Clock:                   clk,
+			Historian:               &state.FakeHistorian{},
+			Tracer:                  tracing.InitializeTracerForTest(),
+			Log:                     log.New("ngalert.state.manager"),
+			MaxStateSaveConcurrency: 1,
 		}
-		statePersister := state.NewSyncStatePerisiter(log.New("ngalert.state.manager.persist"), instanceStore, false, 1)
+		statePersister := state.NewSyncStatePerisiter(log.New("ngalert.state.manager.persist"), cfg)
 		st := state.NewManager(cfg, statePersister)
 		rule := models.AlertRuleGen()()
 		var results = eval.GenerateResults(rand.Intn(4)+1, eval.ResultGen(eval.WithEvaluatedAt(clk.Now())))

--- a/pkg/services/ngalert/state/manager_test.go
+++ b/pkg/services/ngalert/state/manager_test.go
@@ -1365,7 +1365,7 @@ func TestProcessEvalResults(t *testing.T) {
 			Log:                     log.New("ngalert.state.manager"),
 			MaxStateSaveConcurrency: 1,
 		}
-		statePersister := state.NewSyncStatePerisiter(log.New("ngalert.state.manager.persist"), cfg)
+		statePersister := state.NewSyncStatePersisiter(log.New("ngalert.state.manager.persist"), cfg)
 		st := state.NewManager(cfg, statePersister)
 		rule := models.AlertRuleGen()()
 		var results = eval.GenerateResults(rand.Intn(4)+1, eval.ResultGen(eval.WithEvaluatedAt(clk.Now())))

--- a/pkg/services/ngalert/state/persister_noop.go
+++ b/pkg/services/ngalert/state/persister_noop.go
@@ -1,0 +1,17 @@
+package state
+
+import (
+	"context"
+
+	"github.com/benbjohnson/clock"
+	"go.opentelemetry.io/otel/trace"
+)
+
+type NoopPersister struct{}
+
+func (n *NoopPersister) Async(_ context.Context, _ *clock.Ticker, _ *cache)           {}
+func (n *NoopPersister) Sync(_ context.Context, _ trace.Span, _, _ []StateTransition) {}
+
+func NewNoopPersister() StatePersister {
+	return &NoopPersister{}
+}

--- a/pkg/services/ngalert/state/persister_sync.go
+++ b/pkg/services/ngalert/state/persister_sync.go
@@ -22,7 +22,7 @@ type SyncStatePersister struct {
 	maxStateSaveConcurrency int
 }
 
-func NewSyncStatePerisiter(log log.Logger, cfg ManagerCfg) StatePersister {
+func NewSyncStatePersisiter(log log.Logger, cfg ManagerCfg) StatePersister {
 	return &SyncStatePersister{
 		log:                     log,
 		store:                   cfg.InstanceStore,

--- a/pkg/services/ngalert/state/persister_sync.go
+++ b/pkg/services/ngalert/state/persister_sync.go
@@ -22,12 +22,12 @@ type SyncStatePersister struct {
 	maxStateSaveConcurrency int
 }
 
-func NewSyncStatePerisiter(log log.Logger, store InstanceStore, doNotSaveNormalState bool, maxStateSaveConcurrency int) StatePersister {
+func NewSyncStatePerisiter(log log.Logger, cfg ManagerCfg) StatePersister {
 	return &SyncStatePersister{
 		log:                     log,
-		store:                   store,
-		doNotSaveNormalState:    doNotSaveNormalState,
-		maxStateSaveConcurrency: maxStateSaveConcurrency,
+		store:                   cfg.InstanceStore,
+		doNotSaveNormalState:    cfg.DoNotSaveNormalState,
+		maxStateSaveConcurrency: cfg.MaxStateSaveConcurrency,
 	}
 }
 

--- a/pkg/services/ngalert/state/persister_sync.go
+++ b/pkg/services/ngalert/state/persister_sync.go
@@ -1,0 +1,111 @@
+package state
+
+import (
+	"context"
+	"time"
+
+	"github.com/benbjohnson/clock"
+	"github.com/grafana/dskit/concurrency"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/trace"
+
+	"github.com/grafana/grafana/pkg/infra/log"
+	ngModels "github.com/grafana/grafana/pkg/services/ngalert/models"
+)
+
+type SyncStatePersister struct {
+	log   log.Logger
+	store InstanceStore
+	// doNotSaveNormalState controls whether eval.Normal state is persisted to the database and returned by get methods.
+	doNotSaveNormalState bool
+	// maxStateSaveConcurrency controls the number of goroutines (per rule) that can save alert state in parallel.
+	maxStateSaveConcurrency int
+}
+
+func NewSyncStatePerisiter(log log.Logger, store InstanceStore, doNotSaveNormalState bool, maxStateSaveConcurrency int) StatePersister {
+	return &SyncStatePersister{
+		log:                     log,
+		store:                   store,
+		doNotSaveNormalState:    doNotSaveNormalState,
+		maxStateSaveConcurrency: maxStateSaveConcurrency,
+	}
+}
+
+func (a *SyncStatePersister) Async(_ context.Context, _ *clock.Ticker, _ *cache) {
+	a.log.Debug("Async: No-Op")
+}
+func (a *SyncStatePersister) Sync(ctx context.Context, span trace.Span, states, staleStates []StateTransition) {
+	a.deleteAlertStates(ctx, staleStates)
+	if len(staleStates) > 0 {
+		span.AddEvent("deleted stale states", trace.WithAttributes(
+			attribute.Int64("state_transitions", int64(len(staleStates))),
+		))
+	}
+
+	a.saveAlertStates(ctx, states...)
+	span.AddEvent("updated database")
+}
+
+func (a *SyncStatePersister) deleteAlertStates(ctx context.Context, states []StateTransition) {
+	if a.store == nil || len(states) == 0 {
+		return
+	}
+
+	a.log.Debug("Deleting alert states", "count", len(states))
+	toDelete := make([]ngModels.AlertInstanceKey, 0, len(states))
+
+	for _, s := range states {
+		key, err := s.GetAlertInstanceKey()
+		if err != nil {
+			a.log.Error("Failed to delete alert instance with invalid labels", "cacheID", s.CacheID, "error", err)
+			continue
+		}
+		toDelete = append(toDelete, key)
+	}
+
+	err := a.store.DeleteAlertInstances(ctx, toDelete...)
+	if err != nil {
+		a.log.Error("Failed to delete stale states", "error", err)
+	}
+}
+
+func (a *SyncStatePersister) saveAlertStates(ctx context.Context, states ...StateTransition) {
+	if a.store == nil || len(states) == 0 {
+		return
+	}
+
+	saveState := func(ctx context.Context, idx int) error {
+		s := states[idx]
+		// Do not save normal state to database and remove transition to Normal state but keep mapped states
+		if a.doNotSaveNormalState && IsNormalStateWithNoReason(s.State) && !s.Changed() {
+			return nil
+		}
+
+		key, err := s.GetAlertInstanceKey()
+		if err != nil {
+			a.log.Error("Failed to create a key for alert state to save it to database. The state will be ignored ", "cacheID", s.CacheID, "error", err, "labels", s.Labels.String())
+			return nil
+		}
+		instance := ngModels.AlertInstance{
+			AlertInstanceKey:  key,
+			Labels:            ngModels.InstanceLabels(s.Labels),
+			CurrentState:      ngModels.InstanceStateType(s.State.State.String()),
+			CurrentReason:     s.StateReason,
+			LastEvalTime:      s.LastEvaluationTime,
+			CurrentStateSince: s.StartsAt,
+			CurrentStateEnd:   s.EndsAt,
+		}
+
+		err = a.store.SaveAlertInstance(ctx, instance)
+		if err != nil {
+			a.log.Error("Failed to save alert state", "labels", s.Labels.String(), "state", s.State, "error", err)
+			return nil
+		}
+		return nil
+	}
+
+	start := time.Now()
+	a.log.Debug("Saving alert states", "count", len(states), "max_state_save_concurrency", a.maxStateSaveConcurrency)
+	_ = concurrency.ForEachJob(ctx, len(states), a.maxStateSaveConcurrency, saveState)
+	a.log.Debug("Saving alert states done", "count", len(states), "max_state_save_concurrency", a.maxStateSaveConcurrency, "duration", time.Since(start))
+}

--- a/pkg/services/ngalert/state/persister_sync_test.go
+++ b/pkg/services/ngalert/state/persister_sync_test.go
@@ -1,0 +1,97 @@
+package state
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"k8s.io/component-base/tracing"
+
+	"github.com/grafana/grafana/pkg/infra/log/logtest"
+	"github.com/grafana/grafana/pkg/services/ngalert/eval"
+	ngmodels "github.com/grafana/grafana/pkg/services/ngalert/models"
+	"github.com/grafana/grafana/pkg/util"
+)
+
+func TestSyncPersister_saveAlertStates(t *testing.T) {
+	type stateWithReason struct {
+		State  eval.State
+		Reason string
+	}
+	create := func(s eval.State, r string) stateWithReason {
+		return stateWithReason{
+			State:  s,
+			Reason: r,
+		}
+	}
+	allStates := [...]stateWithReason{
+		create(eval.Normal, ""),
+		create(eval.Normal, eval.NoData.String()),
+		create(eval.Normal, eval.Error.String()),
+		create(eval.Normal, util.GenerateShortUID()),
+		create(eval.Alerting, ""),
+		create(eval.Pending, ""),
+		create(eval.NoData, ""),
+		create(eval.Error, ""),
+	}
+
+	transitionToKey := map[ngmodels.AlertInstanceKey]StateTransition{}
+	transitions := make([]StateTransition, 0)
+	for _, fromState := range allStates {
+		for i, toState := range allStates {
+			tr := StateTransition{
+				State: &State{
+					State:       toState.State,
+					StateReason: toState.Reason,
+					Labels:      ngmodels.GenerateAlertLabels(5, fmt.Sprintf("%d--", i)),
+				},
+				PreviousState:       fromState.State,
+				PreviousStateReason: fromState.Reason,
+			}
+			key, err := tr.GetAlertInstanceKey()
+			require.NoError(t, err)
+			transitionToKey[key] = tr
+			transitions = append(transitions, tr)
+		}
+	}
+
+	t.Run("should save all transitions if doNotSaveNormalState is false", func(t *testing.T) {
+		trace := tracing.NewNoopTracerProvider().Tracer("test")
+		_, span := trace.Start(context.Background(), "")
+		st := &FakeInstanceStore{}
+		syncStatePersister := NewSyncStatePerisiter(&logtest.Fake{}, st, false, 1)
+		syncStatePersister.Sync(context.Background(), span, transitions, nil)
+		savedKeys := map[ngmodels.AlertInstanceKey]ngmodels.AlertInstance{}
+		for _, op := range st.RecordedOps {
+			saved := op.(ngmodels.AlertInstance)
+			savedKeys[saved.AlertInstanceKey] = saved
+		}
+		assert.Len(t, transitionToKey, len(savedKeys))
+
+		for key, tr := range transitionToKey {
+			assert.Containsf(t, savedKeys, key, "state %s (%s) was not saved but should be", tr.State.State, tr.StateReason)
+		}
+	})
+
+	t.Run("should not save Normal->Normal if doNotSaveNormalState is true", func(t *testing.T) {
+		trace := tracing.NewNoopTracerProvider().Tracer("test")
+		_, span := trace.Start(context.Background(), "")
+		st := &FakeInstanceStore{}
+		syncStatePersister := NewSyncStatePerisiter(&logtest.Fake{}, st, false, 1)
+		syncStatePersister.Sync(context.Background(), span, transitions, nil)
+
+		savedKeys := map[ngmodels.AlertInstanceKey]ngmodels.AlertInstance{}
+		for _, op := range st.RecordedOps {
+			saved := op.(ngmodels.AlertInstance)
+			savedKeys[saved.AlertInstanceKey] = saved
+		}
+		for key, tr := range transitionToKey {
+			if tr.State.State == eval.Normal && tr.StateReason == "" && tr.PreviousState == eval.Normal && tr.PreviousStateReason == "" {
+				continue
+			}
+			assert.Containsf(t, savedKeys, key, "state %s (%s) was not saved but should be", tr.State.State, tr.StateReason)
+		}
+	})
+}

--- a/pkg/services/ngalert/state/persister_sync_test.go
+++ b/pkg/services/ngalert/state/persister_sync_test.go
@@ -61,7 +61,10 @@ func TestSyncPersister_saveAlertStates(t *testing.T) {
 		trace := tracing.NewNoopTracerProvider().Tracer("test")
 		_, span := trace.Start(context.Background(), "")
 		st := &FakeInstanceStore{}
-		syncStatePersister := NewSyncStatePerisiter(&logtest.Fake{}, st, false, 1)
+		syncStatePersister := NewSyncStatePerisiter(&logtest.Fake{}, ManagerCfg{
+			InstanceStore:           st,
+			MaxStateSaveConcurrency: 1,
+		})
 		syncStatePersister.Sync(context.Background(), span, transitions, nil)
 		savedKeys := map[ngmodels.AlertInstanceKey]ngmodels.AlertInstance{}
 		for _, op := range st.RecordedOps {
@@ -79,7 +82,10 @@ func TestSyncPersister_saveAlertStates(t *testing.T) {
 		trace := tracing.NewNoopTracerProvider().Tracer("test")
 		_, span := trace.Start(context.Background(), "")
 		st := &FakeInstanceStore{}
-		syncStatePersister := NewSyncStatePerisiter(&logtest.Fake{}, st, false, 1)
+		syncStatePersister := NewSyncStatePerisiter(&logtest.Fake{}, ManagerCfg{
+			InstanceStore:           st,
+			MaxStateSaveConcurrency: 1,
+		})
 		syncStatePersister.Sync(context.Background(), span, transitions, nil)
 
 		savedKeys := map[ngmodels.AlertInstanceKey]ngmodels.AlertInstance{}

--- a/pkg/services/ngalert/state/persister_sync_test.go
+++ b/pkg/services/ngalert/state/persister_sync_test.go
@@ -61,7 +61,7 @@ func TestSyncPersister_saveAlertStates(t *testing.T) {
 		trace := tracing.NewNoopTracerProvider().Tracer("test")
 		_, span := trace.Start(context.Background(), "")
 		st := &FakeInstanceStore{}
-		syncStatePersister := NewSyncStatePerisiter(&logtest.Fake{}, ManagerCfg{
+		syncStatePersister := NewSyncStatePersisiter(&logtest.Fake{}, ManagerCfg{
 			InstanceStore:           st,
 			MaxStateSaveConcurrency: 1,
 		})
@@ -82,7 +82,7 @@ func TestSyncPersister_saveAlertStates(t *testing.T) {
 		trace := tracing.NewNoopTracerProvider().Tracer("test")
 		_, span := trace.Start(context.Background(), "")
 		st := &FakeInstanceStore{}
-		syncStatePersister := NewSyncStatePerisiter(&logtest.Fake{}, ManagerCfg{
+		syncStatePersister := NewSyncStatePersisiter(&logtest.Fake{}, ManagerCfg{
 			InstanceStore:           st,
 			MaxStateSaveConcurrency: 1,
 		})


### PR DESCRIPTION
This PR is a spin-off from https://github.com/grafana/grafana/pull/74998/

It does introduce a new interface that will allow us to switch between sync and async state persistence. In this PR I only introduce the new interface and implement the current behavior using the new interface. So it is a no-op PR logic wise.