### PR TITLE
Auth: Re-add `authenticatedBy` property

### DIFF
--- a/pkg/services/authn/authnimpl/sync/user_sync.go
+++ b/pkg/services/authn/authnimpl/sync/user_sync.go
@@ -407,4 +407,5 @@ func syncSignedInUserToIdentity(usr *user.SignedInUser, identity *authn.Identity
 	identity.LastSeenAt = usr.LastSeenAt
 	identity.IsDisabled = usr.IsDisabled
 	identity.IsGrafanaAdmin = &usr.IsGrafanaAdmin
+	identity.AuthenticatedBy = usr.AuthenticatedBy
 }

--- a/pkg/services/pluginsintegration/adapters/adapters.go
+++ b/pkg/services/pluginsintegration/adapters/adapters.go
@@ -50,9 +50,10 @@ func BackendUserFromSignedInUser(requester identity.Requester) *backend.User {
 		return nil
 	}
 	return &backend.User{
-		Login: requester.GetLogin(),
-		Name:  requester.GetDisplayName(),
-		Email: requester.GetEmail(),
-		Role:  string(requester.GetOrgRole()),
+		Login:           requester.GetLogin(),
+		Name:            requester.GetDisplayName(),
+		Email:           requester.GetEmail(),
+		Role:            string(requester.GetOrgRole()),
+		AuthenticatedBy: requester.GetAuthenticatedBy(),
 	}
 }

--- a/pkg/services/user/identity.go
+++ b/pkg/services/user/identity.go
@@ -16,9 +16,9 @@ type SignedInUser struct {
 	Login            string
 	Name             string
 	Email            string
-	AuthenticatedBy  string
-	ApiKeyID         int64 `xorm:"api_key_id"`
-	IsServiceAccount bool  `xorm:"is_service_account"`
+	AuthenticatedBy  string `xorm:"authenticated_by"`
+	ApiKeyID         int64  `xorm:"api_key_id"`
+	IsServiceAccount bool   `xorm:"is_service_account"`
 	IsGrafanaAdmin   bool
 	IsAnonymous      bool
 	IsDisabled       bool

--- a/pkg/services/user/userimpl/store.go
+++ b/pkg/services/user/userimpl/store.go
@@ -403,8 +403,10 @@ func (ss *sqlStore) GetSignedInUser(ctx context.Context, query *user.GetSignedIn
 		org.name              as org_name,
 		org_user.role         as org_role,
 		org.id                as org_id,
-		u.is_service_account  as is_service_account
+		u.is_service_account  as is_service_account,
+		user_auth.auth_module as authenticated_by
 		FROM ` + ss.dialect.Quote("user") + ` as u
+		LEFT OUTER JOIN user_auth on user_auth.user_id = u.id
 		LEFT OUTER JOIN org_user on org_user.org_id = ` + orgId + ` and org_user.user_id = u.id
 		LEFT OUTER JOIN org on org.id = org_user.org_id `
 


### PR DESCRIPTION
Re-adding a property removed in #68327 that will allow the backend to determine what auth-provider the currently signed-in user is authenticated with.

Depends on grafana/grafana-plugin-sdk-go#853. This build will fail until that PR is merged and the dependency is bumped.