### PR TITLE
Fix issue registering dashboard summary resource

### DIFF
--- a/pkg/registry/apis/dashboard/register.go
+++ b/pkg/registry/apis/dashboard/register.go
@@ -180,9 +180,9 @@ func (b *DashboardsAPIBuilder) GetAPIGroupInfo(
 	}
 
 	// Summary
-	resourceInfo = v0alpha1.DashboardSummaryResourceInfo
-	storage[resourceInfo.StoragePath()] = &summaryStorage{
-		resource:       resourceInfo,
+	resourceInfo2 := v0alpha1.DashboardSummaryResourceInfo
+	storage[resourceInfo2.StoragePath()] = &summaryStorage{
+		resource:       resourceInfo2,
 		access:         b.access,
 		tableConverter: store.TableConvertor,
 	}


### PR DESCRIPTION
Fixes the startup error:
```
Failed to build open api spec for root: duplicate Operation ID listDashboardGrafanaAppV0alpha1NamespacedDashboardSummary for path /apis/dashboard.grafana.app/v0alpha1/namespaces/{namespace}/dashboards and /apis/dashboard.grafana.app/v0alpha1/namespaces/{namespace}/summary
```