### PR TITLE
VariableEditorForm: Fix multi-value variable runtime error

### DIFF
--- a/public/app/features/dashboard-scene/settings/variables/VariableEditorForm.tsx
+++ b/public/app/features/dashboard-scene/settings/variables/VariableEditorForm.tsx
@@ -84,7 +84,7 @@ export function VariableEditorForm({ variable, onTypeChange, onGoBack, onDiscard
 
         {EditorToRender && <EditorToRender variable={variable} />}
 
-        {hasVariableOptions(variable) && <VariableValuesPreview options={variable.options} />}
+        {hasVariableOptions(variable) && <VariableValuesPreview options={variable.state.options} />}
 
         <div style={{ marginTop: '16px' }}>
           <HorizontalGroup spacing="md" height="inherit">

--- a/public/app/features/dashboard-scene/settings/variables/utils.ts
+++ b/public/app/features/dashboard-scene/settings/variables/utils.ts
@@ -8,7 +8,7 @@ import {
   QueryVariable,
   AdHocFilterSet,
   SceneVariable,
-  VariableValueOption,
+  MultiValueVariable,
 } from '@grafana/scenes';
 import { VariableType } from '@grafana/schema';
 
@@ -117,8 +117,6 @@ export function getVariableScene(type: EditableVariableType, initialState: Commo
   }
 }
 
-export function hasVariableOptions(
-  variable: SceneVariable
-): variable is SceneVariable & { options: VariableValueOption[] } {
+export function hasVariableOptions(variable: SceneVariable): variable is MultiValueVariable {
   return 'options' in variable.state;
 }


### PR DESCRIPTION
Fixes an issue that I discovered after https://github.com/grafana/grafana/pull/80172 got merged. The problem was navigating to a multi-value variable edit view that caused a runtime error trying to access options which are part of the variable state.