### PR TITLE
DataFrame: Add optional unique id definition

### DIFF
--- a/packages/grafana-data/src/dataframe/index.ts
+++ b/packages/grafana-data/src/dataframe/index.ts
@@ -13,5 +13,6 @@ export {
   isTimeSeriesFrame,
   isTimeSeriesFrames,
   isTimeSeriesField,
+  getRowUniqueId,
 } from './utils';
 export { StreamingDataFrame, StreamingFrameAction, type StreamingFrameOptions, closestIdx } from './StreamingDataFrame';

--- a/packages/grafana-data/src/dataframe/utils.ts
+++ b/packages/grafana-data/src/dataframe/utils.ts
@@ -88,7 +88,7 @@ export function hasTimeField(data: DataFrame): boolean {
 }
 
 /**
- * Get row id based on the meta.keyBy attribute.
+ * Get row id based on the meta.uniqueRowIdFields attribute.
  * @param dataFrame
  * @param rowIndex
  */

--- a/packages/grafana-data/src/dataframe/utils.ts
+++ b/packages/grafana-data/src/dataframe/utils.ts
@@ -93,8 +93,8 @@ export function hasTimeField(data: DataFrame): boolean {
  * @param rowIndex
  */
 export function getRowUniqueId(dataFrame: DataFrame, rowIndex: number) {
-  if (dataFrame.meta?.uniqueId === undefined) {
+  if (dataFrame.meta?.uniqueRowIdFields === undefined) {
     return undefined;
   }
-  return dataFrame.meta.uniqueId.map((fieldIndex) => dataFrame.fields[fieldIndex].values[rowIndex]).join('-');
+  return dataFrame.meta.uniqueRowIdFields.map((fieldIndex) => dataFrame.fields[fieldIndex].values[rowIndex]).join('-');
 }

--- a/packages/grafana-data/src/dataframe/utils.ts
+++ b/packages/grafana-data/src/dataframe/utils.ts
@@ -86,3 +86,15 @@ export function anySeriesWithTimeField(data: DataFrame[]) {
 export function hasTimeField(data: DataFrame): boolean {
   return data.fields.some((field) => field.type === FieldType.time);
 }
+
+/**
+ * Get row id based on the meta.keyBy attribute.
+ * @param dataFrame
+ * @param rowIndex
+ */
+export function getRowUniqueId(dataFrame: DataFrame, rowIndex: number) {
+  if (dataFrame.meta?.uniqueId === undefined) {
+    return undefined;
+  }
+  return dataFrame.meta.uniqueId.map((fieldIndex) => dataFrame.fields[fieldIndex].values[rowIndex]).join('-');
+}

--- a/packages/grafana-data/src/types/data.ts
+++ b/packages/grafana-data/src/types/data.ts
@@ -110,9 +110,11 @@ export interface QueryResultMeta {
 
   /**
    * Array of field indices which values create a unique id for each row. Ideally this should be globally unique ID
-   * but that isn't guarantied.
+   * but that isn't guarantied. Should help with keeping track and deduplicating rows in visualizations, especially
+   * with streaming data with frequent updates.
+   * Example: TraceID in Tempo, table name + primary key in SQL
    */
-  uniqueId?: number[];
+  uniqueRowIdFields?: number[];
 }
 
 export interface QueryResultMetaStat extends FieldConfig {

--- a/packages/grafana-data/src/types/data.ts
+++ b/packages/grafana-data/src/types/data.ts
@@ -109,7 +109,8 @@ export interface QueryResultMeta {
   instant?: boolean;
 
   /**
-   * Array of field indices which values create a unique id for each row.
+   * Array of field indices which values create a unique id for each row. Ideally this should be globally unique ID
+   * but that isn't guarantied.
    */
   uniqueId?: number[];
 }

--- a/packages/grafana-data/src/types/data.ts
+++ b/packages/grafana-data/src/types/data.ts
@@ -33,6 +33,7 @@ export const preferredVisualizationTypes = [
 export type PreferredVisualisationType = (typeof preferredVisualizationTypes)[number];
 
 /**
+ * Should be kept in sync with https://github.com/grafana/grafana-plugin-sdk-go/blob/main/data/frame_meta.go
  * @public
  */
 export interface QueryResultMeta {

--- a/packages/grafana-data/src/types/data.ts
+++ b/packages/grafana-data/src/types/data.ts
@@ -107,6 +107,11 @@ export interface QueryResultMeta {
   limit?: number; // used by log models and loki
   json?: boolean; // used to keep track of old json doc values
   instant?: boolean;
+
+  /**
+   * Array of field indices which values create a unique id for each row.
+   */
+  uniqueId?: number[];
 }
 
 export interface QueryResultMetaStat extends FieldConfig {


### PR DESCRIPTION
Adds a definition for row unique id. This can be useful when it's needed to track rows between data changes for example in streaming responses.

The uniqueId definition is typed as number[] and means an array of indexes of fields in which composite values should be unique. This allows for a simple, single field uniqueId or a uniqueId from multiple values.

Ideally, the uniqueId should be globally unique but it's probably not feasible for all usecases. At the same time the usecases for this at this point aren't that critical that non global uniqueId would create significant issues. 

For example current main usecase for this is https://github.com/grafana/grafana/pull/80031 which fixes the handling of expanded rows across data changes. In case of non global uniqueId this could create an issue where querying different dataset with the same uniqueId could persist expanded rows even though the rows aren't the same thing.