### PR TITLE
Alerting docs: changes wrong label on configure alert state history doc

### DIFF
--- a/docs/sources/alerting/set-up/configure-alert-state-history/index.md
+++ b/docs/sources/alerting/set-up/configure-alert-state-history/index.md
@@ -9,7 +9,7 @@ keywords:
   - alert state history
 labels:
   products:
-    - cloud
+    - oss
 title: Configure Alert State History
 weight: 600
 ---


### PR DESCRIPTION
updates label - was wrongly labelled cloud in oss docs