### PR TITLE
postgres: vendor in the file-exists helper

### DIFF
--- a/pkg/tsdb/grafana-postgresql-datasource/tlsmanager.go
+++ b/pkg/tsdb/grafana-postgresql-datasource/tlsmanager.go
@@ -10,7 +10,6 @@ import (
 	"time"
 
 	"github.com/grafana/grafana-plugin-sdk-go/backend/log"
-	"github.com/grafana/grafana/pkg/infra/fs"
 	"github.com/grafana/grafana/pkg/tsdb/sqleng"
 )
 
@@ -132,7 +131,7 @@ func writeCertFile(logger log.Logger, fileContent string, generatedFilePath stri
 	}
 
 	logger.Debug("Deleting cert file since no content is provided", "path", generatedFilePath)
-	exists, err := fs.Exists(generatedFilePath)
+	exists, err := fileExists(generatedFilePath)
 	if err != nil {
 		return err
 	}
@@ -181,7 +180,7 @@ func (m *tlsManager) writeCertFiles(dsInfo sqleng.DataSourceInfo, tlsconfig *tls
 	}
 
 	// Write certification directory and files
-	exists, err := fs.Exists(workDir)
+	exists, err := fileExists(workDir)
 	if err != nil {
 		return err
 	}
@@ -212,7 +211,7 @@ func validateCertFilePaths(rootCert, clientCert, clientKey string) error {
 		if fpath == "" {
 			continue
 		}
-		exists, err := fs.Exists(fpath)
+		exists, err := fileExists(fpath)
 		if err != nil {
 			return err
 		}
@@ -221,4 +220,17 @@ func validateCertFilePaths(rootCert, clientCert, clientKey string) error {
 		}
 	}
 	return nil
+}
+
+// Exists determines whether a file/directory exists or not.
+func fileExists(fpath string) (bool, error) {
+	_, err := os.Stat(fpath)
+	if err != nil {
+		if !os.IsNotExist(err) {
+			return false, err
+		}
+		return false, nil
+	}
+
+	return true, nil
 }


### PR DESCRIPTION
we must not import from core-grafana, so i vendored in this short helper function.
fixes https://github.com/grafana/grafana/issues/77718

how to test:
1. spin up a postgres database which is configured for tls auth (for example: https://github.com/grafana/oss-big-tent-tools/tree/main/tls-setups/postgres#verify-both-certs )
2. configure grafana to connect to it, use the `tls/ssl method = certificate content` option
3. make sure grafana can connect to the database, and run a query successfully.