### PR TITLE
Tempo: Fix regression caused by #79938

### DIFF
--- a/public/app/plugins/datasource/tempo/resultTransformer.ts
+++ b/public/app/plugins/datasource/tempo/resultTransformer.ts
@@ -734,11 +734,36 @@ export function createTableFrameFromTraceQlQuery(
 }
 
 export function createTableFrameFromTraceQlQueryAsSpans(
-  data: TraceSearchMetadata[],
+  data: TraceSearchMetadata[] | undefined,
   instanceSettings: DataSourceInstanceSettings
 ): DataFrame[] {
   const spanDynamicAttrs: Record<string, FieldDTO> = {};
   let hasNameAttribute = false;
+
+  data?.forEach((trace) =>
+    getSpanSets(trace).forEach((ss) => {
+      ss.attributes?.forEach((attr) => {
+        spanDynamicAttrs[attr.key] = {
+          name: attr.key,
+          type: FieldType.string,
+          config: { displayNameFromDS: attr.key },
+        };
+      });
+      ss.spans.forEach((span) => {
+        if (span.name) {
+          hasNameAttribute = true;
+        }
+        span.attributes?.forEach((attr) => {
+          spanDynamicAttrs[attr.key] = {
+            name: attr.key,
+            type: FieldType.string,
+            config: { displayNameFromDS: attr.key },
+          };
+        });
+      });
+    })
+  );
+
   const frame = new MutableDataFrame({
     name: 'Spans',
     refId: 'traces',
@@ -830,40 +855,9 @@ export function createTableFrameFromTraceQlQueryAsSpans(
     },
   });
 
-  // According to the parameter type, `data` should never be undefined of null, but the old code had
-  // entries such as `!data` or `data?`, so we keep this check just for safety
-  if (data === undefined || data === null) {
-    console.error(`Unexpected ${data} value for \`data\``);
+  if (!data || !data.length) {
     return [frame];
   }
-
-  if (!data.length) {
-    return [frame];
-  }
-
-  data.forEach((trace) =>
-    getSpanSets(trace).forEach((ss) => {
-      ss.attributes?.forEach((attr) => {
-        spanDynamicAttrs[attr.key] = {
-          name: attr.key,
-          type: FieldType.string,
-          config: { displayNameFromDS: attr.key },
-        };
-      });
-      ss.spans.forEach((span) => {
-        if (span.name) {
-          hasNameAttribute = true;
-        }
-        span.attributes?.forEach((attr) => {
-          spanDynamicAttrs[attr.key] = {
-            name: attr.key,
-            type: FieldType.string,
-            config: { displayNameFromDS: attr.key },
-          };
-        });
-      });
-    })
-  );
 
   data
     // Show the most recent traces


### PR DESCRIPTION
#79938 erroneously change the execution flow when `data` is set. This PR fixes it by reverting to the previous flow.

Some tests to prevent the same regression will be added soon.

Credits to @aocenas for the troubleshooting.

Fixes https://github.com/grafana/grafana/issues/80426
