### PR TITLE
Cloudwatch: Move getNextRefIdChar util from app/core/utils to @grafana/data

### DIFF
--- a/packages/grafana-data/src/index.ts
+++ b/packages/grafana-data/src/index.ts
@@ -16,6 +16,7 @@ export * from './events';
 export * from './themes';
 export * from './monaco';
 export * from './geo/layer';
+export * from './query';
 export {
   type ValueMatcherOptions,
   type BasicValueMatcherOptions,

--- a/packages/grafana-data/src/query/index.ts
+++ b/packages/grafana-data/src/query/index.ts
@@ -1,0 +1,1 @@
+export * from './refId';

--- a/packages/grafana-data/src/query/refId.test.ts
+++ b/packages/grafana-data/src/query/refId.test.ts
@@ -1,6 +1,6 @@
 import { DataQuery } from '@grafana/schema';
 
-import { getNextRefIdChar } from '.';
+import { getNextRefId } from '.';
 
 export interface TestQuery extends DataQuery {
   name?: string;
@@ -18,18 +18,18 @@ const singleExtendedDataQuery: DataQuery[] = dataQueryHelper('ABCDEFGHIJKLMNOPQR
 
 describe('Get next refId char', () => {
   it('should return next char', () => {
-    expect(getNextRefIdChar(singleDataQuery)).toEqual('F');
+    expect(getNextRefId(singleDataQuery)).toEqual('F');
   });
 
   it('should get first char', () => {
-    expect(getNextRefIdChar([])).toEqual('A');
+    expect(getNextRefId([])).toEqual('A');
   });
 
   it('should get the first available character if a query has been deleted out of order', () => {
-    expect(getNextRefIdChar(outOfOrderDataQuery)).toEqual('C');
+    expect(getNextRefId(outOfOrderDataQuery)).toEqual('C');
   });
 
   it('should append a new char and start from AA when Z is reached', () => {
-    expect(getNextRefIdChar(singleExtendedDataQuery)).toEqual('AA');
+    expect(getNextRefId(singleExtendedDataQuery)).toEqual('AA');
   });
 });

--- a/packages/grafana-data/src/query/refId.test.ts
+++ b/packages/grafana-data/src/query/refId.test.ts
@@ -1,0 +1,35 @@
+import { DataQuery } from '@grafana/schema';
+
+import { getNextRefIdChar } from '.';
+
+export interface TestQuery extends DataQuery {
+  name?: string;
+}
+
+function dataQueryHelper(ids: string[]): DataQuery[] {
+  return ids.map((letter) => {
+    return { refId: letter };
+  });
+}
+
+const singleDataQuery: DataQuery[] = dataQueryHelper('ABCDE'.split(''));
+const outOfOrderDataQuery: DataQuery[] = dataQueryHelper('ABD'.split(''));
+const singleExtendedDataQuery: DataQuery[] = dataQueryHelper('ABCDEFGHIJKLMNOPQRSTUVWXYZ'.split(''));
+
+describe('Get next refId char', () => {
+  it('should return next char', () => {
+    expect(getNextRefIdChar(singleDataQuery)).toEqual('F');
+  });
+
+  it('should get first char', () => {
+    expect(getNextRefIdChar([])).toEqual('A');
+  });
+
+  it('should get the first available character if a query has been deleted out of order', () => {
+    expect(getNextRefIdChar(outOfOrderDataQuery)).toEqual('C');
+  });
+
+  it('should append a new char and start from AA when Z is reached', () => {
+    expect(getNextRefIdChar(singleExtendedDataQuery)).toEqual('AA');
+  });
+});

--- a/packages/grafana-data/src/query/refId.ts
+++ b/packages/grafana-data/src/query/refId.ts
@@ -1,6 +1,9 @@
 import { DataQuery } from '@grafana/schema';
 
-export const getNextRefIdChar = (queries: DataQuery[]): string => {
+/**
+ * Finds the next available refId for a query
+ */
+export const getNextRefId = (queries: DataQuery[]): string => {
   for (let num = 0; ; num++) {
     const refId = getRefId(num);
     if (!queries.some((query) => query.refId === refId)) {

--- a/packages/grafana-data/src/query/refId.ts
+++ b/packages/grafana-data/src/query/refId.ts
@@ -1,0 +1,20 @@
+import { DataQuery } from '@grafana/schema';
+
+export const getNextRefIdChar = (queries: DataQuery[]): string => {
+  for (let num = 0; ; num++) {
+    const refId = getRefId(num);
+    if (!queries.some((query) => query.refId === refId)) {
+      return refId;
+    }
+  }
+};
+
+function getRefId(num: number): string {
+  const letters = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ';
+
+  if (num < letters.length) {
+    return letters[num];
+  } else {
+    return getRefId(Math.floor(num / letters.length) - 1) + letters[num % letters.length];
+  }
+}

--- a/public/app/core/utils/query.ts
+++ b/public/app/core/utils/query.ts
@@ -1,6 +1,6 @@
 import { DataQuery, DataSourceRef } from '@grafana/data';
 
-// Legacy. Import from packages/grafana-data
+// @deprecated use the `getNextRefId` function from grafana/data instead
 export const getNextRefIdChar = (queries: DataQuery[]): string => {
   for (let num = 0; ; num++) {
     const refId = getRefId(num);

--- a/public/app/core/utils/query.ts
+++ b/public/app/core/utils/query.ts
@@ -1,5 +1,6 @@
 import { DataQuery, DataSourceRef } from '@grafana/data';
 
+// Legacy. Import from packages/grafana-data
 export const getNextRefIdChar = (queries: DataQuery[]): string => {
   for (let num = 0; ; num++) {
     const refId = getRefId(num);

--- a/public/app/plugins/datasource/cloudwatch/migrations/dashboardMigrations.ts
+++ b/public/app/plugins/datasource/cloudwatch/migrations/dashboardMigrations.ts
@@ -2,7 +2,8 @@
 // Migrations applied by the DashboardMigrator are performed before the plugin is loaded.
 // DashboardMigrator migrations are tied to a certain minimum version of a dashboard which means they will only be ran once.
 
-import { DataQuery, AnnotationQuery, getNextRefIdChar } from '@grafana/data';
+import { AnnotationQuery, getNextRefId } from '@grafana/data';
+import { DataQuery } from '@grafana/schema';
 
 import { CloudWatchMetricsQuery, LegacyAnnotationQuery, MetricQueryType, MetricEditorMode } from '../types';
 
@@ -19,7 +20,7 @@ export function migrateMultipleStatsMetricsQuery(
     }
   }
   for (const newTarget of newQueries) {
-    newTarget.refId = getNextRefIdChar(panelQueries);
+    newTarget.refId = getNextRefId(panelQueries);
     delete newTarget.statistics;
     panelQueries.push(newTarget);
   }

--- a/public/app/plugins/datasource/cloudwatch/migrations/dashboardMigrations.ts
+++ b/public/app/plugins/datasource/cloudwatch/migrations/dashboardMigrations.ts
@@ -2,8 +2,7 @@
 // Migrations applied by the DashboardMigrator are performed before the plugin is loaded.
 // DashboardMigrator migrations are tied to a certain minimum version of a dashboard which means they will only be ran once.
 
-import { DataQuery, AnnotationQuery } from '@grafana/data';
-import { getNextRefIdChar } from 'app/core/utils/query';
+import { DataQuery, AnnotationQuery, getNextRefIdChar } from '@grafana/data';
 
 import { CloudWatchMetricsQuery, LegacyAnnotationQuery, MetricQueryType, MetricEditorMode } from '../types';
 


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

Move getNextRefIdChar util from app/core/utils to @grafana/data

**Why do we need this feature?**

Part of https://github.com/grafana/grafana/issues/78778
As we didn't have an equivalent export from grafana/data and multiple plugins use this function from app/core, added a new util in grafana/data

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
