### PR TITLE
Auth: Add `AuthenticatedBy` value to Grafana ID token

### DIFF
--- a/packages/grafana-data/src/types/datasource.ts
+++ b/packages/grafana-data/src/types/datasource.ts
@@ -620,6 +620,7 @@ export interface DataSourceJsonData {
   manageAlerts?: boolean;
   alertmanagerUid?: string;
   disableGrafanaCache?: boolean;
+  forwardGrafanaIdToken?: boolean;
 }
 
 /**

--- a/pkg/services/auth/id.go
+++ b/pkg/services/auth/id.go
@@ -20,6 +20,7 @@ type IDSigner interface {
 
 type IDClaims struct {
 	jwt.Claims
+	AuthenticatedBy string
 }
 
 const settingsKey = "forwardGrafanaIdToken"

--- a/pkg/services/auth/idimpl/service.go
+++ b/pkg/services/auth/idimpl/service.go
@@ -77,6 +77,7 @@ func (s *Service) SignIdentity(ctx context.Context, id identity.Requester) (stri
 				Expiry:   jwt.NewNumericDate(now.Add(tokenTTL)),
 				IssuedAt: jwt.NewNumericDate(now),
 			},
+			AuthenticatedBy: id.GetAuthenticatedBy(),
 		})
 
 		if err != nil {

--- a/pkg/services/auth/idimpl/signer.go
+++ b/pkg/services/auth/idimpl/signer.go
@@ -37,7 +37,7 @@ func (s *LocalSigner) SignIDToken(ctx context.Context, claims *auth.IDClaims) (s
 		return "", err
 	}
 
-	builder := jwt.Signed(signer).Claims(claims.Claims)
+	builder := jwt.Signed(signer).Claims(claims)
 
 	token, err := builder.CompactSerialize()
 	if err != nil {

--- a/pkg/services/authn/authnimpl/sync/user_sync.go
+++ b/pkg/services/authn/authnimpl/sync/user_sync.go
@@ -407,4 +407,5 @@ func syncSignedInUserToIdentity(usr *user.SignedInUser, identity *authn.Identity
 	identity.LastSeenAt = usr.LastSeenAt
 	identity.IsDisabled = usr.IsDisabled
 	identity.IsGrafanaAdmin = &usr.IsGrafanaAdmin
+	identity.AuthenticatedBy = usr.AuthenticatedBy
 }

--- a/pkg/services/user/userimpl/store.go
+++ b/pkg/services/user/userimpl/store.go
@@ -403,8 +403,10 @@ func (ss *sqlStore) GetSignedInUser(ctx context.Context, query *user.GetSignedIn
 		org.name              as org_name,
 		org_user.role         as org_role,
 		org.id                as org_id,
-		u.is_service_account  as is_service_account
+		u.is_service_account  as is_service_account,
+		user_auth.auth_module as authenticated_by
 		FROM ` + ss.dialect.Quote("user") + ` as u
+		LEFT OUTER JOIN user_auth on user_auth.user_id = u.id
 		LEFT OUTER JOIN org_user on org_user.org_id = ` + orgId + ` and org_user.user_id = u.id
 		LEFT OUTER JOIN org on org.id = org_user.org_id `
 


### PR DESCRIPTION
Choosing this PR over #80401 

- Add `forwardGrafanaIdToken` to data source JSON data
- Add `AuthenticatedBy` claim
- Re-add `AuthenticatedBy` to db query (not sure on this and if we are using it the query needs to be updated to retrieve the latest value)
