### PR TITLE
Alerting: Fix MuteTiming Get API to return provenance status

### DIFF
--- a/pkg/tests/api/alerting/api_provisioning_test.go
+++ b/pkg/tests/api/alerting/api_provisioning_test.go
@@ -457,12 +457,12 @@ func TestMuteTimings(t *testing.T) {
 		mt, status, body := apiClient.GetMuteTimingByNameWithStatus(t, emptyMuteTiming.Name)
 		requireStatusCode(t, http.StatusOK, status, body)
 		require.Equal(t, emptyMuteTiming.MuteTimeInterval, mt.MuteTimeInterval)
-		require.EqualValues(t, "", mt.Provenance) // TODO this is a bug
+		require.EqualValues(t, models.ProvenanceAPI, mt.Provenance)
 
 		mt, status, body = apiClient.GetMuteTimingByNameWithStatus(t, anotherMuteTiming.Name)
 		requireStatusCode(t, http.StatusOK, status, body)
 		require.Equal(t, anotherMuteTiming.MuteTimeInterval, mt.MuteTimeInterval)
-		require.EqualValues(t, "", mt.Provenance) // TODO this is a bug
+		require.EqualValues(t, models.ProvenanceAPI, mt.Provenance)
 	})
 
 	t.Run("should return NotFound if mute timing does not exist", func(t *testing.T) {
@@ -480,10 +480,10 @@ func TestMuteTimings(t *testing.T) {
 		})
 
 		require.Equal(t, emptyMuteTiming.MuteTimeInterval, mt[0].MuteTimeInterval)
-		require.EqualValues(t, "", mt[0].Provenance) // TODO this is a bug
+		require.EqualValues(t, models.ProvenanceAPI, mt[0].Provenance)
 
 		require.Equal(t, anotherMuteTiming.MuteTimeInterval, mt[1].MuteTimeInterval)
-		require.EqualValues(t, "", mt[1].Provenance) // TODO this is a bug
+		require.EqualValues(t, models.ProvenanceAPI, mt[1].Provenance)
 	})
 
 	t.Run("should get BadRequest if creates a new mute timing with the same name", func(t *testing.T) {


### PR DESCRIPTION
**What is this feature?**
This PR fixes get all and get by name mute timing API methods to return the provenance status that is declared in their model

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
