### PR TITLE
VizTooltips: Disable tooltips on scenes

### DIFF
--- a/public/app/plugins/panel/candlestick/CandlestickPanel.tsx
+++ b/public/app/plugins/panel/candlestick/CandlestickPanel.tsx
@@ -234,7 +234,9 @@ export const CandlestickPanel = ({
 
   const enableAnnotationCreation = Boolean(canAddAnnotations && canAddAnnotations());
   const showNewVizTooltips =
-    config.featureToggles.newVizTooltips && (sync == null || sync() === DashboardCursorSync.Off);
+    config.featureToggles.newVizTooltips &&
+    !config.featureToggles.scenes &&
+    (sync == null || sync() === DashboardCursorSync.Off);
 
   return (
     <TimeSeries

--- a/public/app/plugins/panel/heatmap/HeatmapPanel.tsx
+++ b/public/app/plugins/panel/heatmap/HeatmapPanel.tsx
@@ -160,7 +160,9 @@ export const HeatmapPanel = ({
   const dataRef = useRef(info);
   dataRef.current = info;
   const showNewVizTooltips =
-    config.featureToggles.newVizTooltips && (sync == null || sync() === DashboardCursorSync.Off);
+    config.featureToggles.newVizTooltips &&
+    !config.featureToggles.scenes &&
+    (sync == null || sync() === DashboardCursorSync.Off);
 
   const builder = useMemo(() => {
     const scaleConfig: ScaleDistributionConfig = dataRef.current?.heatmap?.fields[1].config?.custom?.scaleDistribution;

--- a/public/app/plugins/panel/state-timeline/StateTimelinePanel.tsx
+++ b/public/app/plugins/panel/state-timeline/StateTimelinePanel.tsx
@@ -167,7 +167,9 @@ export const StateTimelinePanel = ({
   }
   const enableAnnotationCreation = Boolean(canAddAnnotations && canAddAnnotations());
   const showNewVizTooltips =
-    config.featureToggles.newVizTooltips && (sync == null || sync() === DashboardCursorSync.Off);
+    config.featureToggles.newVizTooltips &&
+    !config.featureToggles.scenes &&
+    (sync == null || sync() === DashboardCursorSync.Off);
 
   return (
     <TimelineChart

--- a/public/app/plugins/panel/status-history/StatusHistoryPanel.tsx
+++ b/public/app/plugins/panel/status-history/StatusHistoryPanel.tsx
@@ -196,7 +196,9 @@ export const StatusHistoryPanel = ({
   }
 
   const showNewVizTooltips =
-    config.featureToggles.newVizTooltips && (sync == null || sync() === DashboardCursorSync.Off);
+    config.featureToggles.newVizTooltips &&
+    !config.featureToggles.scenes &&
+    (sync == null || sync() === DashboardCursorSync.Off);
 
   return (
     <TimelineChart

--- a/public/app/plugins/panel/timeseries/TimeSeriesPanel.tsx
+++ b/public/app/plugins/panel/timeseries/TimeSeriesPanel.tsx
@@ -52,7 +52,9 @@ export const TimeSeriesPanel = ({
 
   const enableAnnotationCreation = Boolean(canAddAnnotations && canAddAnnotations());
   const showNewVizTooltips =
-    config.featureToggles.newVizTooltips && (sync == null || sync() === DashboardCursorSync.Off);
+    config.featureToggles.newVizTooltips &&
+    !config.featureToggles.scenes &&
+    (sync == null || sync() === DashboardCursorSync.Off);
   // temp range set for adding new annotation set by TooltipPlugin2, consumed by AnnotationPlugin2
   const [newAnnotationRange, setNewAnnotationRange] = useState<TimeRange2 | null>(null);
 

--- a/public/app/plugins/panel/trend/TrendPanel.tsx
+++ b/public/app/plugins/panel/trend/TrendPanel.tsx
@@ -26,7 +26,7 @@ export const TrendPanel = ({
   replaceVariables,
   id,
 }: PanelProps<Options>) => {
-  const showNewVizTooltips = Boolean(config.featureToggles.newVizTooltips);
+  const showNewVizTooltips = config.featureToggles.newVizTooltips && !config.featureToggles.scenes;
 
   const { dataLinkPostProcessor } = usePanelContext();
   // Need to fallback to first number field if no xField is set in options otherwise panel crashes 😬

--- a/public/app/plugins/panel/xychart/XYChartPanel.tsx
+++ b/public/app/plugins/panel/xychart/XYChartPanel.tsx
@@ -44,7 +44,7 @@ export const XYChartPanel = (props: Props) => {
   const [facets, setFacets] = useState<FacetedData | undefined>();
   const [hover, setHover] = useState<ScatterHoverEvent | undefined>();
   const [shouldDisplayCloseButton, setShouldDisplayCloseButton] = useState<boolean>(false);
-  const showNewVizTooltips = Boolean(config.featureToggles.newVizTooltips);
+  const showNewVizTooltips = config.featureToggles.newVizTooltips && !config.featureToggles.scenes;
 
   const isToolTipOpen = useRef<boolean>(false);
   const oldOptions = usePrevious(props.options);


### PR DESCRIPTION
Updated display check for new tooltips for when `scenes` FF is enabled.

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
