### PR TITLE
FeatureFlags: Move funky setting stuff within the feature manager (not /api)

### DIFF
--- a/hack/README.md
+++ b/hack/README.md
@@ -14,6 +14,8 @@ total 0
 lrwxr-xr-x  1 ryan  staff  37 Oct  5 09:34 grafana -> /Users/ryan/workspace/grafana/grafana
 ```
 
+You can clone k8s [code-generator](https://github.com/kubernetes/code-generator) here and use `CODEGEN_PKG=<CODE-GENERATOR-GIT-ROOT>` when running the `update-codegen.sh` script.
+
 The current workflow (sorry!) is to:
 
 1. update the script to point to the group+version you want

--- a/pkg/api/featuremgmt.go
+++ b/pkg/api/featuremgmt.go
@@ -18,22 +18,20 @@ import (
 )
 
 func (hs *HTTPServer) GetFeatureToggles(ctx *contextmodel.ReqContext) response.Response {
-	cfg := hs.Cfg.FeatureManagement
-	enabledFeatures := hs.Features.GetEnabled(ctx.Req.Context())
-
 	// object being returned
 	dtos := make([]featuremgmt.FeatureToggleDTO, 0)
 
 	// loop through features an add features that should be visible to dtos
 	for _, ft := range hs.featureManager.GetFlags() {
-		if isFeatureHidden(ft, cfg.HiddenToggles) {
+		flag := ft.Name
+		if hs.featureManager.IsHiddenFromAdminPage(flag, false) {
 			continue
 		}
 		dto := featuremgmt.FeatureToggleDTO{
-			Name:        ft.Name,
+			Name:        flag,
 			Description: ft.Description,
-			Enabled:     enabledFeatures[ft.Name],
-			ReadOnly:    !isFeatureWriteable(ft, cfg.ReadOnlyToggles) || !isFeatureEditingAllowed(*hs.Cfg),
+			Enabled:     hs.featureManager.IsEnabled(ctx.Req.Context(), flag),
+			ReadOnly:    !hs.featureManager.IsEditableFromAdminPage(flag),
 		}
 
 		dtos = append(dtos, dto)
@@ -67,7 +65,7 @@ func (hs *HTTPServer) UpdateFeatureToggle(ctx *contextmodel.ReqContext) response
 
 	for _, t := range cmd.FeatureToggles {
 		// make sure flag exists, and only continue if flag is writeable
-		if f, ok := hs.featureManager.LookupFlag(t.Name); ok && isFeatureWriteable(f, hs.Cfg.FeatureManagement.ReadOnlyToggles) {
+		if hs.featureManager.IsEditableFromAdminPage(t.Name) {
 			hs.log.Info("UpdateFeatureToggle: updating toggle", "toggle_name", t.Name, "enabled", t.Enabled, "username", ctx.SignedInUser.Login)
 			payload.FeatureToggles[t.Name] = strconv.FormatBool(t.Enabled)
 		} else {
@@ -90,32 +88,6 @@ func (hs *HTTPServer) UpdateFeatureToggle(ctx *contextmodel.ReqContext) response
 func (hs *HTTPServer) GetFeatureMgmtState(ctx *contextmodel.ReqContext) response.Response {
 	fmState := hs.featureManager.GetState()
 	return response.Respond(http.StatusOK, fmState)
-}
-
-// isFeatureHidden returns whether a toggle should be hidden from the admin page.
-// filters out statuses Unknown, Experimental, and Private Preview
-func isFeatureHidden(flag featuremgmt.FeatureFlag, hideCfg map[string]struct{}) bool {
-	if _, ok := hideCfg[flag.Name]; ok {
-		return true
-	}
-	return flag.Stage == featuremgmt.FeatureStageUnknown || flag.Stage == featuremgmt.FeatureStageExperimental || flag.Stage == featuremgmt.FeatureStagePrivatePreview || flag.HideFromAdminPage
-}
-
-// isFeatureWriteable returns whether a toggle on the admin page can be updated by the user.
-// only allows writing of GA and Deprecated toggles, and excludes the feature toggle admin page toggle
-func isFeatureWriteable(flag featuremgmt.FeatureFlag, readOnlyCfg map[string]struct{}) bool {
-	if _, ok := readOnlyCfg[flag.Name]; ok {
-		return false
-	}
-	if flag.Name == featuremgmt.FlagFeatureToggleAdminPage {
-		return false
-	}
-	return (flag.Stage == featuremgmt.FeatureStageGeneralAvailability || flag.Stage == featuremgmt.FeatureStageDeprecated) && flag.AllowSelfServe
-}
-
-// isFeatureEditingAllowed checks if the backend is properly configured to allow feature toggle changes from the UI
-func isFeatureEditingAllowed(cfg setting.Cfg) bool {
-	return cfg.FeatureManagement.AllowEditing && cfg.FeatureManagement.UpdateWebhook != ""
 }
 
 type UpdatePayload struct {

--- a/pkg/api/featuremgmt_test.go
+++ b/pkg/api/featuremgmt_test.go
@@ -393,9 +393,8 @@ func runGetScenario(
 ) []featuremgmt.FeatureToggleDTO {
 	// Set up server and send request
 	cfg := setting.NewCfg()
-	cfg.FeatureManagement = settings
 
-	fm := featuremgmt.WithFeatureManager(append([]*featuremgmt.FeatureFlag{{
+	fm := featuremgmt.WithFeatureManager(settings, append([]*featuremgmt.FeatureFlag{{
 		Name:  featuremgmt.FlagFeatureToggleAdminPage,
 		Stage: featuremgmt.FeatureStageGeneralAvailability,
 	}}, features...), disabled...)
@@ -460,9 +459,7 @@ func runSetScenario(
 ) *http.Response {
 	// Set up server and send request
 	cfg := setting.NewCfg()
-	cfg.FeatureManagement = settings
-
-	features := featuremgmt.WithFeatureManager(append([]*featuremgmt.FeatureFlag{{
+	features := featuremgmt.WithFeatureManager(settings, append([]*featuremgmt.FeatureFlag{{
 		Name:  featuremgmt.FlagFeatureToggleAdminPage,
 		Stage: featuremgmt.FeatureStageGeneralAvailability,
 	}}, serverFeatures...), disabled...)

--- a/pkg/services/featuremgmt/manager.go
+++ b/pkg/services/featuremgmt/manager.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/services/licensing"
+	"github.com/grafana/grafana/pkg/setting"
 )
 
 var (
@@ -16,15 +17,17 @@ var (
 type FeatureManager struct {
 	isDevMod        bool
 	restartRequired bool
-	allowEditing    bool
-	licensing       licensing.Licensing
-	flags           map[string]*FeatureFlag
-	enabled         map[string]bool // only the "on" values
-	config          string          // path to config file
-	vars            map[string]any
-	startup         map[string]bool   // the explicit values registered at startup
-	warnings        map[string]string // potential warnings about the flag
-	log             log.Logger
+
+	settings setting.FeatureMgmtSettings
+
+	licensing licensing.Licensing
+	flags     map[string]*FeatureFlag
+	enabled   map[string]bool // only the "on" values
+	config    string          // path to config file
+	vars      map[string]any
+	startup   map[string]bool   // the explicit values registered at startup
+	warnings  map[string]string // potential warnings about the flag
+	log       log.Logger
 }
 
 // This will merge the flags with the current configuration
@@ -160,20 +163,64 @@ func (fm *FeatureManager) GetFlags() []FeatureFlag {
 }
 
 func (fm *FeatureManager) GetState() *FeatureManagerState {
-	return &FeatureManagerState{RestartRequired: fm.restartRequired, AllowEditing: fm.allowEditing}
+	return &FeatureManagerState{
+		RestartRequired: fm.restartRequired,
+		AllowEditing:    fm.settings.AllowEditing,
+	}
+}
+
+// isFeatureEditingAllowed checks if the backend is properly configured to allow feature toggle changes from the UI
+func (fm *FeatureManager) IsFeatureEditingAllowed() bool {
+	return fm.settings.AllowEditing && fm.settings.UpdateWebhook != ""
+}
+
+// Flags that can be edited
+func (fm *FeatureManager) IsEditableFromAdminPage(key string) bool {
+	flag, ok := fm.flags[key]
+	if !ok ||
+		!fm.IsFeatureEditingAllowed() ||
+		!flag.AllowSelfServe ||
+		flag.Name == FlagFeatureToggleAdminPage {
+		return false
+	}
+	return flag.Stage == FeatureStageGeneralAvailability ||
+		flag.Stage == FeatureStageDeprecated
+}
+
+// Flags that should not be shown in the UI (regardless of their state)
+func (fm *FeatureManager) IsHiddenFromAdminPage(key string, lenient bool) bool {
+	_, hide := fm.settings.HiddenToggles[key]
+	flag, ok := fm.flags[key]
+	if !ok || flag.HideFromAdminPage || hide {
+		return true // unknown flag (should we show it as a warning!)
+	}
+
+	// Explicitly hidden from configs
+	_, found := fm.settings.HiddenToggles[key]
+	if found {
+		return true
+	}
+	if lenient {
+		return false
+	}
+
+	return flag.Stage == FeatureStageUnknown ||
+		flag.Stage == FeatureStageExperimental ||
+		flag.Stage == FeatureStagePrivatePreview
+}
+
+// Get the flags that were explicitly set on startup
+func (fm *FeatureManager) GetStartupFlags() map[string]bool {
+	return fm.startup
+}
+
+// Perhaps expose the flag warnings
+func (fm *FeatureManager) GetWarning() map[string]string {
+	return fm.warnings
 }
 
 func (fm *FeatureManager) SetRestartRequired() {
 	fm.restartRequired = true
-}
-
-// Check to see if a feature toggle exists by name
-func (fm *FeatureManager) LookupFlag(name string) (FeatureFlag, bool) {
-	f, ok := fm.flags[name]
-	if !ok {
-		return FeatureFlag{}, false
-	}
-	return *f, true
 }
 
 // ############# Test Functions #############
@@ -212,7 +259,7 @@ func WithManager(spec ...any) *FeatureManager {
 // WithFeatureManager is used to define feature toggle manager for testing.
 // It should be used when your test feature toggles require metadata beyond `Name` and `Enabled`.
 // You should provide a feature toggle Name at a minimum.
-func WithFeatureManager(flags []*FeatureFlag, disabled ...string) *FeatureManager {
+func WithFeatureManager(cfg setting.FeatureMgmtSettings, flags []*FeatureFlag, disabled ...string) *FeatureManager {
 	count := len(flags)
 	features := make(map[string]*FeatureFlag, count)
 	enabled := make(map[string]bool, count)
@@ -230,5 +277,11 @@ func WithFeatureManager(flags []*FeatureFlag, disabled ...string) *FeatureManage
 		enabled[f.Name] = !dis[f.Name]
 	}
 
-	return &FeatureManager{enabled: enabled, flags: features, startup: enabled, warnings: map[string]string{}}
+	return &FeatureManager{
+		settings: cfg,
+		enabled:  enabled,
+		flags:    features,
+		startup:  enabled,
+		warnings: map[string]string{},
+	}
 }

--- a/pkg/services/featuremgmt/service.go
+++ b/pkg/services/featuremgmt/service.go
@@ -23,14 +23,14 @@ var (
 
 func ProvideManagerService(cfg *setting.Cfg, licensing licensing.Licensing) (*FeatureManager, error) {
 	mgmt := &FeatureManager{
-		isDevMod:     setting.Env != setting.Prod,
-		licensing:    licensing,
-		flags:        make(map[string]*FeatureFlag, 30),
-		enabled:      make(map[string]bool),
-		startup:      make(map[string]bool),
-		warnings:     make(map[string]string),
-		allowEditing: cfg.FeatureManagement.AllowEditing && cfg.FeatureManagement.UpdateWebhook != "",
-		log:          log.New("featuremgmt"),
+		isDevMod:  setting.Env != setting.Prod,
+		licensing: licensing,
+		flags:     make(map[string]*FeatureFlag, 30),
+		enabled:   make(map[string]bool),
+		startup:   make(map[string]bool),
+		warnings:  make(map[string]string),
+		settings:  cfg.FeatureManagement,
+		log:       log.New("featuremgmt"),
 	}
 
 	// Register the standard flags

--- a/pkg/setting/setting_featuremgmt.go
+++ b/pkg/setting/setting_featuremgmt.go
@@ -4,6 +4,7 @@ import (
 	"github.com/grafana/grafana/pkg/util"
 )
 
+// This configuration is only relevant in hosted grafana and is subject to change without notice
 type FeatureMgmtSettings struct {
 	HiddenToggles      map[string]struct{}
 	ReadOnlyToggles    map[string]struct{}


### PR DESCRIPTION
This moves the config logic that says which flags can be edited into the manager rather than in the api handler.
