### PR TITLE
refactor: use golang.org/x/oauth2 pkce option

### DIFF
--- a/pkg/services/authn/clients/oauth_test.go
+++ b/pkg/services/authn/clients/oauth_test.go
@@ -268,7 +268,7 @@ func TestOAuth_RedirectURL(t *testing.T) {
 		{
 			desc:              "should generate redirect url with pkce if configured",
 			oauthCfg:          &social.OAuthInfo{UsePKCE: true},
-			numCallOptions:    2,
+			numCallOptions:    1,
 			authCodeUrlCalled: true,
 		},
 	}
@@ -402,6 +402,12 @@ func TestOAuth_Logout(t *testing.T) {
 			assert.True(t, invalidateTokenCalled)
 		})
 	}
+}
+
+func TestGenPKCECodeVerifier(t *testing.T) {
+	verifier, err := genPKCECodeVerifier()
+	assert.NoError(t, err)
+	assert.Len(t, verifier, 128)
 }
 
 type mockConnector struct {


### PR DESCRIPTION
**What is this feature?**

- Refactors the oath client to use [new x/oauth2 option](https://pkg.go.dev/golang.org/x/oauth2?tab=versions).
  - use [oauth2.S256ChallengeOption](https://pkg.go.dev/golang.org/x/oauth2#S256ChallengeOption)
  - use [oauth2.VerifierOption](https://pkg.go.dev/golang.org/x/oauth2#VerifierOption)
  - Add unit tests, Verify that the length of the verifier is as specified

**Why do we need this feature?**

- More clearly expresses PKCE specifications

**Who is this feature for?**

- for contributors.

**Which issue(s) does this PR fix?**:

- Fixes #80510

**Special notes for your reviewer:**

- Of the new PKCE options, only [oauth2.GenerateVerifier](https://pkg.go.dev/golang.org/x/oauth2#GenerateVerifier) is not used
  - When generation fails, it panics. This is different from the current behavior.
  - oauth2.GenerateVerifier generates 43-length verifier. current implementation generates 128 length.

- suggested labels:
  - https://github.com/grafana/grafana/labels/area%2Fauth
  - https://github.com/grafana/grafana/labels/area%2Fauth%2Foauth
  - https://github.com/grafana/grafana/labels/no-backport
  - https://github.com/grafana/grafana/labels/no-changelog

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
