### PR TITLE
Chore: Fix Azure Monitor plugin build

### DIFF
--- a/.github/workflows/core-plugins-build-and-release.yml
+++ b/.github/workflows/core-plugins-build-and-release.yml
@@ -1,3 +1,5 @@
+name: Build and release core plugins
+
 on:
   workflow_dispatch:
     inputs:
@@ -61,7 +63,12 @@ jobs:
         shell: bash
         id: get_dir
         run: |
-          dir=$(find public/app/plugins -name ${{ inputs.plugin_id }} -print -quit)
+          dir=$(dirname \
+            $(egrep -lir --include=plugin.json --exclude-dir=dist \
+              '"id": "${{ inputs.plugin_id }}"' \
+              public/app/plugins \
+            ) \
+          )
           echo "dir=${dir}" >> $GITHUB_OUTPUT
       - name: Install frontend dependencies
         shell: bash


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

Fix the command that tries to find the directory for a core plugin. Before, it assumed that the directory name was equal to the plugin ID but that's not the case for Azure Monitor (`grafana-azure-monitor-datasource != azuremonitor`)

