### PR TITLE
Explore: skip flaky e2e test

### DIFF
--- a/e2e/various-suite/explore.spec.ts
+++ b/e2e/various-suite/explore.spec.ts
@@ -1,6 +1,7 @@
 import { e2e } from '../utils';
 
-describe('Explore', () => {
+// This seems to be flaky on CI, skipping it for now.
+describe.skip('Explore', () => {
   beforeEach(() => {
     e2e.flows.login(Cypress.env('USERNAME'), Cypress.env('PASSWORD'));
   });


### PR DESCRIPTION
Skips a flaky e2e test in Explore to unblock other PRs, will create a follow up issue to investigate