### PR TITLE
Loki: Remove dependency in test files on selectOptionInTest

### DIFF
--- a/public/app/plugins/datasource/loki/components/LokiContextUi.test.tsx
+++ b/public/app/plugins/datasource/loki/components/LokiContextUi.test.tsx
@@ -137,7 +137,7 @@ describe('LokiContextUi', () => {
       expect(props.logContextProvider.getInitContextFilters).toHaveBeenCalled();
     });
     const selects = await screen.findAllByRole('combobox');
-    await waitFor(() => select(selects[0], 'label1="value1"', { container: document.body }));
+    await select(selects[0], 'label1="value1"', { container: document.body });
   });
 
   it('finds label3 as a parsed label', async () => {
@@ -147,7 +147,7 @@ describe('LokiContextUi', () => {
       expect(props.logContextProvider.getInitContextFilters).toHaveBeenCalled();
     });
     const selects = await screen.findAllByRole('combobox');
-    await waitFor(() => select(selects[1], 'label3="value3"', { container: document.body }));
+    await select(selects[1], 'label3="value3"', { container: document.body });
   });
 
   it('calls updateFilter when selecting a label', async () => {
@@ -158,7 +158,7 @@ describe('LokiContextUi', () => {
       expect(props.logContextProvider.getInitContextFilters).toHaveBeenCalled();
       expect(screen.getAllByRole('combobox')).toHaveLength(2);
     });
-    await waitFor(() => select(screen.getAllByRole('combobox')[1], 'label3="value3"', { container: document.body }));
+    await select(screen.getAllByRole('combobox')[1], 'label3="value3"', { container: document.body });
     act(() => {
       jest.runAllTimers();
     });

--- a/public/app/plugins/datasource/loki/components/LokiContextUi.test.tsx
+++ b/public/app/plugins/datasource/loki/components/LokiContextUi.test.tsx
@@ -1,7 +1,7 @@
 import { act, render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import React from 'react';
-import { selectOptionInTest } from 'test/helpers/selectOptionInTest';
+import { select } from 'react-select-event';
 
 import { LogRowModel, dateTime } from '@grafana/data';
 
@@ -136,8 +136,8 @@ describe('LokiContextUi', () => {
     await waitFor(() => {
       expect(props.logContextProvider.getInitContextFilters).toHaveBeenCalled();
     });
-    const select = await screen.findAllByRole('combobox');
-    await selectOptionInTest(select[0], 'label1="value1"');
+    const selects = await screen.findAllByRole('combobox');
+    await waitFor(() => select(selects[0], 'label1="value1"', { container: document.body }));
   });
 
   it('finds label3 as a parsed label', async () => {
@@ -146,8 +146,8 @@ describe('LokiContextUi', () => {
     await waitFor(() => {
       expect(props.logContextProvider.getInitContextFilters).toHaveBeenCalled();
     });
-    const select = await screen.findAllByRole('combobox');
-    await selectOptionInTest(select[1], 'label3="value3"');
+    const selects = await screen.findAllByRole('combobox');
+    await waitFor(() => select(selects[1], 'label3="value3"', { container: document.body }));
   });
 
   it('calls updateFilter when selecting a label', async () => {
@@ -158,7 +158,7 @@ describe('LokiContextUi', () => {
       expect(props.logContextProvider.getInitContextFilters).toHaveBeenCalled();
       expect(screen.getAllByRole('combobox')).toHaveLength(2);
     });
-    await selectOptionInTest(screen.getAllByRole('combobox')[1], 'label3="value3"');
+    await waitFor(() => select(screen.getAllByRole('combobox')[1], 'label3="value3"', { container: document.body }));
     act(() => {
       jest.runAllTimers();
     });

--- a/public/app/plugins/datasource/loki/components/VariableQueryEditor.test.tsx
+++ b/public/app/plugins/datasource/loki/components/VariableQueryEditor.test.tsx
@@ -34,7 +34,7 @@ describe('LokiVariableQueryEditor', () => {
     render(<LokiVariableQueryEditor {...props} onChange={onChange} />);
 
     expect(onChange).not.toHaveBeenCalled();
-    await waitFor(() => select(screen.getByLabelText('Query type'), 'Label names', { container: document.body }));
+    await select(screen.getByLabelText('Query type'), 'Label names', { container: document.body });
 
     expect(onChange).toHaveBeenCalledWith({
       type: LokiVariableQueryType.LabelNames,
@@ -51,7 +51,7 @@ describe('LokiVariableQueryEditor', () => {
     expect(onChange).not.toHaveBeenCalled();
 
     await waitFor(() => select(screen.getByLabelText('Query type'), 'Label values', { container: document.body }));
-    await waitFor(() => select(screen.getByLabelText('Label'), 'luna', { container: document.body }));
+    await select(screen.getByLabelText('Label'), 'luna', { container: document.body });
     await userEvent.type(screen.getByLabelText('Stream selector'), 'stream');
 
     await waitFor(() => expect(screen.getByDisplayValue('stream')).toBeInTheDocument());
@@ -120,7 +120,7 @@ describe('LokiVariableQueryEditor', () => {
   test('Label options are not lost when selecting one', async () => {
     const { rerender } = render(<LokiVariableQueryEditor {...props} onChange={() => {}} />);
     await waitFor(() => select(screen.getByLabelText('Query type'), 'Label values', { container: document.body }));
-    await waitFor(() => select(screen.getByLabelText('Label'), 'luna', { container: document.body }));
+    await select(screen.getByLabelText('Label'), 'luna', { container: document.body });
 
     const updatedQuery = {
       refId: 'test',
@@ -129,8 +129,8 @@ describe('LokiVariableQueryEditor', () => {
     };
     rerender(<LokiVariableQueryEditor {...props} query={updatedQuery} onChange={() => {}} />);
 
-    await waitFor(() => select(screen.getByLabelText('Label'), 'moon', { container: document.body }));
-    await waitFor(() => select(screen.getByLabelText('Label'), 'luna', { container: document.body }));
+    await select(screen.getByLabelText('Label'), 'moon', { container: document.body });
+    await select(screen.getByLabelText('Label'), 'luna', { container: document.body });
     await screen.findByText('luna');
   });
 });

--- a/public/app/plugins/datasource/loki/components/VariableQueryEditor.test.tsx
+++ b/public/app/plugins/datasource/loki/components/VariableQueryEditor.test.tsx
@@ -1,7 +1,7 @@
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import React from 'react';
-import { selectOptionInTest } from 'test/helpers/selectOptionInTest';
+import { select } from 'react-select-event';
 
 import { TemplateSrv } from '@grafana/runtime';
 
@@ -34,8 +34,7 @@ describe('LokiVariableQueryEditor', () => {
     render(<LokiVariableQueryEditor {...props} onChange={onChange} />);
 
     expect(onChange).not.toHaveBeenCalled();
-
-    await selectOptionInTest(screen.getByLabelText('Query type'), 'Label names');
+    await waitFor(() => select(screen.getByLabelText('Query type'), 'Label names', { container: document.body }));
 
     expect(onChange).toHaveBeenCalledWith({
       type: LokiVariableQueryType.LabelNames,
@@ -51,8 +50,8 @@ describe('LokiVariableQueryEditor', () => {
 
     expect(onChange).not.toHaveBeenCalled();
 
-    await selectOptionInTest(screen.getByLabelText('Query type'), 'Label values');
-    await selectOptionInTest(screen.getByLabelText('Label'), 'luna');
+    await waitFor(() => select(screen.getByLabelText('Query type'), 'Label values', { container: document.body }));
+    await waitFor(() => select(screen.getByLabelText('Label'), 'luna', { container: document.body }));
     await userEvent.type(screen.getByLabelText('Stream selector'), 'stream');
 
     await waitFor(() => expect(screen.getByDisplayValue('stream')).toBeInTheDocument());
@@ -72,8 +71,8 @@ describe('LokiVariableQueryEditor', () => {
     render(<LokiVariableQueryEditor {...props} onChange={onChange} />);
 
     expect(onChange).not.toHaveBeenCalled();
+    await waitFor(() => select(screen.getByLabelText('Query type'), 'Label values', { container: document.body }));
 
-    await selectOptionInTest(screen.getByLabelText('Query type'), 'Label values');
     await userEvent.type(screen.getByLabelText('Label'), 'sol{enter}');
     await userEvent.type(screen.getByLabelText('Stream selector'), 'stream');
 
@@ -120,9 +119,8 @@ describe('LokiVariableQueryEditor', () => {
 
   test('Label options are not lost when selecting one', async () => {
     const { rerender } = render(<LokiVariableQueryEditor {...props} onChange={() => {}} />);
-
-    await selectOptionInTest(screen.getByLabelText('Query type'), 'Label values');
-    await selectOptionInTest(screen.getByLabelText('Label'), 'luna');
+    await waitFor(() => select(screen.getByLabelText('Query type'), 'Label values', { container: document.body }));
+    await waitFor(() => select(screen.getByLabelText('Label'), 'luna', { container: document.body }));
 
     const updatedQuery = {
       refId: 'test',
@@ -131,8 +129,8 @@ describe('LokiVariableQueryEditor', () => {
     };
     rerender(<LokiVariableQueryEditor {...props} query={updatedQuery} onChange={() => {}} />);
 
-    await selectOptionInTest(screen.getByLabelText('Label'), 'moon');
-    await selectOptionInTest(screen.getByLabelText('Label'), 'luna');
+    await waitFor(() => select(screen.getByLabelText('Label'), 'moon', { container: document.body }));
+    await waitFor(() => select(screen.getByLabelText('Label'), 'luna', { container: document.body }));
     await screen.findByText('luna');
   });
 });

--- a/public/app/plugins/datasource/loki/components/monaco-query-field/monaco-completion-provider/completions.test.ts
+++ b/public/app/plugins/datasource/loki/components/monaco-query-field/monaco-completion-provider/completions.test.ts
@@ -1,5 +1,5 @@
 import { dateTime } from '@grafana/data';
-import { Monaco, monacoTypes } from '@grafana/ui/src';
+import { Monaco, monacoTypes } from '@grafana/ui';
 
 import LokiLanguageProvider from '../../../LanguageProvider';
 import { createLokiDatasource } from '../../../__mocks__/datasource';


### PR DESCRIPTION
Part of https://github.com/grafana/grafana/issues/72631

Smaller PR that removes dependency on `import { selectOptionInTest } from 'test/helpers/selectOptionInTest';` which is a small wrapper over `select` from `import { select } from 'react-select-event';` . 

Additionally, I have updated import  `import { Monaco, monacoTypes } from '@grafana/ui/src';` => `import { Monaco, monacoTypes } from '@grafana/ui';`