### PR TITLE
Use specified time range, default to class value

### DIFF
--- a/public/app/plugins/datasource/prometheus/datasource.ts
+++ b/public/app/plugins/datasource/prometheus/datasource.ts
@@ -706,10 +706,12 @@ export class PrometheusDatasource
     const expr = promQueryModeller.renderLabels(labelFilters);
 
     if (this.hasLabelsMatchAPISupport()) {
-      return (await this.languageProvider.fetchSeriesValuesWithMatch(options.key, expr)).map((v) => ({
-        value: v,
-        text: v,
-      }));
+      return (await this.languageProvider.fetchSeriesValuesWithMatch(options.key, expr, options.timeRange)).map(
+        (v) => ({
+          value: v,
+          text: v,
+        })
+      );
     }
 
     const params = this.getTimeRangeParams(options.timeRange ?? getDefaultTimeRange());

--- a/public/app/plugins/datasource/prometheus/language_provider.ts
+++ b/public/app/plugins/datasource/prometheus/language_provider.ts
@@ -239,11 +239,16 @@ export default class PromQlLanguageProvider extends LanguageProvider {
    * Fetches all values for a label, with optional match[]
    * @param name
    * @param match
+   * @param timeRange
    */
-  fetchSeriesValuesWithMatch = async (name: string, match?: string): Promise<string[]> => {
+  fetchSeriesValuesWithMatch = async (
+    name: string,
+    match?: string,
+    timeRange: TimeRange = this.timeRange
+  ): Promise<string[]> => {
     const interpolatedName = name ? this.datasource.interpolateString(name) : null;
     const interpolatedMatch = match ? this.datasource.interpolateString(match) : null;
-    const range = this.datasource.getAdjustedInterval(this.timeRange);
+    const range = this.datasource.getAdjustedInterval(timeRange);
     const urlParams = {
       ...range,
       ...(interpolatedMatch && { 'match[]': interpolatedMatch }),


### PR DESCRIPTION
**What is this feature?**

Use specified time range when fetching label values.

**Why do we need this feature?**

We're currently ignoring the time range passed through the options object when `hasLabelsMatchAPISupport` is true. When it's false, we are using it.

**Who is this feature for?**

- Users of the ad-hoc filters feature

**Which issue(s) does this PR fix?**:

- When fetching label values, we're not taking into account the current time range, we're using the default one.

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
