### PR TITLE
Alerting: Fix validation of selected contact point being required in the alert form when simplified routing

### DIFF
--- a/public/app/features/alerting/unified/components/rule-editor/alert-rule-form/simplifiedRouting/contactPoint/ContactPointSelector.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/alert-rule-form/simplifiedRouting/contactPoint/ContactPointSelector.tsx
@@ -16,12 +16,7 @@ export interface ContactPointSelectorProps {
 }
 export function ContactPointSelector({ alertManager, contactPoints, onSelectContactPoint }: ContactPointSelectorProps) {
   const styles = useStyles2(getStyles);
-  const {
-    register,
-    control,
-    formState: { errors },
-    watch,
-  } = useFormContext<RuleFormValues>();
+  const { control, watch } = useFormContext<RuleFormValues>();
 
   const options = contactPoints.map((receiver) => {
     const integrations = receiver?.grafana_managed_receiver_configs;
@@ -39,11 +34,7 @@ export function ContactPointSelector({ alertManager, contactPoints, onSelectCont
 
   return (
     <Stack direction="column">
-      <Field
-        label="Contact point"
-        {...register(`contactPoints.${alertManager}.selectedContactPoint`, { required: true })}
-        invalid={!!errors.contactPoints?.[alertManager]?.selectedContactPoint}
-      >
+      <Field label="Contact point">
         <InputControl
           render={({ field: { onChange, ref, ...field }, fieldState: { error } }) => (
             <>
@@ -65,9 +56,10 @@ export function ContactPointSelector({ alertManager, contactPoints, onSelectCont
                   width={50}
                 />
               </div>
-              {error && <FieldValidationMessage>{'Contact point is required.'}</FieldValidationMessage>}
+              {error && <FieldValidationMessage>{error.message}</FieldValidationMessage>}
             </>
           )}
+          rules={{ required: { value: true, message: 'Contact point is required.' } }}
           control={control}
           name={`contactPoints.${alertManager}.selectedContactPoint`}
         />


### PR DESCRIPTION

**What is this feature?**

This PR fixes contact point selector validation field (required) when using simplified routing.
Before that change the field was showing a validation error (required field) after selecting a contact point.

Feature is still behind a feature toggle.

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
