### PR TITLE
Divider: Add option to show and hide line

### DIFF
--- a/packages/grafana-ui/src/components/Divider/Divider.story.tsx
+++ b/packages/grafana-ui/src/components/Divider/Divider.story.tsx
@@ -14,11 +14,11 @@ const meta: Meta<typeof Divider> = {
   },
 };
 
-export const Basic: StoryFn<typeof Divider> = ({ direction, spacing }) => {
+export const Basic: StoryFn<typeof Divider> = ({ direction, spacing, showLine }) => {
   return (
     <div style={{ display: direction === 'vertical' ? 'flex' : 'block', flexDirection: 'row', height: '50px' }}>
       <div>My text here</div>
-      <Divider direction={direction} spacing={spacing} />
+      <Divider direction={direction} spacing={spacing} showLine={showLine} />
       <div>My text here</div>
     </div>
   );

--- a/packages/grafana-ui/src/components/Divider/Divider.test.tsx
+++ b/packages/grafana-ui/src/components/Divider/Divider.test.tsx
@@ -1,0 +1,31 @@
+import { screen } from '@testing-library/dom';
+import { render } from '@testing-library/react';
+import React from 'react';
+
+import { Divider } from './Divider';
+
+describe('Divider', () => {
+  it('should render horizontal divider', () => {
+    render(<Divider direction="horizontal" />);
+    expect(screen.getByTestId('horizontal-divider')).toBeInTheDocument();
+  });
+
+  it('should render vertical divider', () => {
+    render(<Divider direction="vertical" />);
+    expect(screen.getByTestId('vertical-divider')).toBeInTheDocument();
+  });
+
+  it('should render divider with line by default', () => {
+    render(<Divider />);
+    const divider = screen.getByTestId('horizontal-divider');
+    expect(divider).toBeInTheDocument();
+    expect(divider).toHaveStyle('border-top: 1px solid rgba(204, 204, 220, 0.12)');
+  });
+
+  it('should render divider without line if specified', () => {
+    render(<Divider showLine={false} />);
+    const divider = screen.getByTestId('horizontal-divider');
+    expect(divider).toBeInTheDocument();
+    expect(divider).toHaveStyle('border-top: none');
+  });
+});

--- a/packages/grafana-ui/src/components/Divider/Divider.tsx
+++ b/packages/grafana-ui/src/components/Divider/Divider.tsx
@@ -8,29 +8,30 @@ import { useStyles2 } from '../../themes';
 interface DividerProps {
   direction?: 'vertical' | 'horizontal';
   spacing?: ThemeSpacingTokens;
+  showLine?: boolean;
 }
 
-export const Divider = ({ direction = 'horizontal', spacing = 2 }: DividerProps) => {
-  const styles = useStyles2(getStyles, spacing);
+export const Divider = ({ direction = 'horizontal', spacing = 2, showLine = true }: DividerProps) => {
+  const styles = useStyles2(getStyles, spacing, showLine);
 
   if (direction === 'vertical') {
-    return <div className={styles.verticalDivider}></div>;
+    return <div className={styles.verticalDivider} data-testid="vertical-divider"></div>;
   } else {
-    return <hr className={styles.horizontalDivider} />;
+    return <hr className={styles.horizontalDivider} data-testid="horizontal-divider" />;
   }
 };
 
 Divider.displayName = 'Divider';
 
-const getStyles = (theme: GrafanaTheme2, spacing: ThemeSpacingTokens) => {
+const getStyles = (theme: GrafanaTheme2, spacing: ThemeSpacingTokens, showLine: boolean) => {
   return {
     horizontalDivider: css({
-      borderTop: `1px solid ${theme.colors.border.weak}`,
+      borderTop: showLine ? `1px solid ${theme.colors.border.weak}` : 'none',
       margin: theme.spacing(spacing, 0),
       width: '100%',
     }),
     verticalDivider: css({
-      borderRight: `1px solid ${theme.colors.border.weak}`,
+      borderRight: showLine ? `1px solid ${theme.colors.border.weak}` : 'none',
       margin: theme.spacing(0, spacing),
       height: '100%',
     }),


### PR DESCRIPTION
In this PR, we are adding a `showLine` prop to a `Divider` component to let developers specify, if they want to see divider with line or not. We are doing it so we can remove a component, that is similar/same as `Divider`, but let's developers remove line https://github.com/grafana/grafana/blob/main/public/app/core/components/Divider.tsx. This is useful for example in Config pages, where we want to divide different section, but some of them we don't want to divide with line. 

See example of code where some dividers use lines and some don't:

<img width="1479" alt="image" src="https://github.com/grafana/grafana/assets/30407135/a89e074b-b9c1-41ea-ab3d-16adbfc05c93">

 If this PR is accepted, we will be able to remove this similar component and reuse `Divider` from `@grafana/ui`. 

I have added tests and update story for `Divider`

<img width="1266" alt="image" src="https://github.com/grafana/grafana/assets/30407135/990b6fa9-ee2e-4a3e-9b35-f5afb908f48a">
<img width="1268" alt="image" src="https://github.com/grafana/grafana/assets/30407135/00529ca9-a19a-4ac0-b566-c642626b0fd0">
