### PR TITLE
Chore: removing folderId from plugindashboard service

### DIFF
--- a/pkg/services/plugindashboards/plugindashboards.go
+++ b/pkg/services/plugindashboards/plugindashboards.go
@@ -8,16 +8,14 @@ import (
 
 // PluginDashboard plugin dashboard model..
 type PluginDashboard struct {
-	UID         string `json:"uid"`
-	PluginId    string `json:"pluginId"`
-	Title       string `json:"title"`
-	Imported    bool   `json:"imported"`
-	ImportedUri string `json:"importedUri"`
-	ImportedUrl string `json:"importedUrl"`
-	Slug        string `json:"slug"`
-	DashboardId int64  `json:"dashboardId"`
-	// Deprecated: use FolderUID instead
-	FolderId         int64  `json:"folderId"`
+	UID              string `json:"uid"`
+	PluginId         string `json:"pluginId"`
+	Title            string `json:"title"`
+	Imported         bool   `json:"imported"`
+	ImportedUri      string `json:"importedUri"`
+	ImportedUrl      string `json:"importedUrl"`
+	Slug             string `json:"slug"`
+	DashboardId      int64  `json:"dashboardId"`
 	ImportedRevision int64  `json:"importedRevision"`
 	Revision         int64  `json:"revision"`
 	Description      string `json:"description"`

--- a/public/app/features/datasources/components/DashboardsTable.test.tsx
+++ b/public/app/features/datasources/components/DashboardsTable.test.tsx
@@ -24,8 +24,7 @@ describe('DashboardsTable', () => {
   beforeEach(() => {
     mockDashboard = {
       dashboardId: 0,
-      description: '',
-      folderId: 0,
+      description: '',      
       imported: false,
       importedRevision: 0,
       importedUri: '',

--- a/public/app/features/datasources/components/DashboardsTable.test.tsx
+++ b/public/app/features/datasources/components/DashboardsTable.test.tsx
@@ -24,7 +24,7 @@ describe('DashboardsTable', () => {
   beforeEach(() => {
     mockDashboard = {
       dashboardId: 0,
-      description: '',      
+      description: '',
       imported: false,
       importedRevision: 0,
       importedUri: '',

--- a/public/app/types/plugins.ts
+++ b/public/app/types/plugins.ts
@@ -2,8 +2,7 @@ import { PanelPlugin, PluginError, PluginMeta } from '@grafana/data';
 
 export interface PluginDashboard {
   dashboardId: number;
-  description: string;
-  folderId: number;
+  description: string;  
   imported: boolean;
   importedRevision: number;
   importedUri: string;

--- a/public/app/types/plugins.ts
+++ b/public/app/types/plugins.ts
@@ -2,7 +2,7 @@ import { PanelPlugin, PluginError, PluginMeta } from '@grafana/data';
 
 export interface PluginDashboard {
   dashboardId: number;
-  description: string;  
+  description: string;
   imported: boolean;
   importedRevision: number;
   importedUri: string;


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**
Since the `folderId` is not really used and we do not support providing `folderUid` for dashboard imports for plugins - removing this field completely.

**Why do we need this feature?**
It's part of a larger cleanup tracked via #80315

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #80564 

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
