### PR TITLE
Explore: Re-enable basic e2e test for Explore

### DIFF
--- a/e2e/various-suite/explore.spec.ts
+++ b/e2e/various-suite/explore.spec.ts
@@ -1,7 +1,6 @@
 import { e2e } from '../utils';
 
-// This seems to be flaky on CI, skipping it for now.
-describe.skip('Explore', () => {
+describe('Explore', () => {
   beforeEach(() => {
     e2e.flows.login(Cypress.env('USERNAME'), Cypress.env('PASSWORD'));
   });
@@ -11,14 +10,6 @@ describe.skip('Explore', () => {
     e2e.pages.Explore.General.container().should('have.length', 1);
     e2e.components.RefreshPicker.runButtonV2().should('have.length', 1);
 
-    // delete query history queries that would be unrelated
-    e2e.components.QueryTab.queryHistoryButton().should('be.visible').click();
-    cy.get('button[title="Delete query"]').each((button) => {
-      button.trigger('click');
-    });
-    cy.get('button[title="Delete query"]').should('not.exist');
-    e2e.components.QueryTab.queryHistoryButton().should('be.visible').click();
-
     e2e.components.DataSource.TestData.QueryTab.scenarioSelectContainer()
       .scrollIntoView()
       .should('be.visible')
@@ -27,17 +18,5 @@ describe.skip('Explore', () => {
       });
 
     cy.contains('CSV Metric Values').scrollIntoView().should('be.visible').click();
-
-    const canvases = cy.get('canvas');
-    canvases.should('have.length', 1);
-
-    // Both queries above should have been run and be shown in the query history
-    e2e.components.QueryTab.queryHistoryButton().should('be.visible').click();
-    e2e.components.QueryHistory.queryText().should('have.length', 1).should('contain', 'csv_metric_values');
-
-    // delete all queries
-    cy.get('button[title="Delete query"]').each((button) => {
-      button.trigger('click');
-    });
   });
 });


### PR DESCRIPTION
This is to re-enable a basic test for Explore to check if editors load fine. I've removed code related to query history testing which proves to be difficult to maintain as there's no clean slate for each test and other tests may cause unexpected failures.

At the same time, a basic test for Explore makes sense. It's a smoke test to check if query editors load fine. 

Probably a good idea to backport it as it may affect a release.

Fixes #80551