### PR TITLE
Remove legacy dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -257,7 +257,6 @@
     "@grafana/flamegraph": "workspace:*",
     "@grafana/google-sdk": "0.1.2",
     "@grafana/lezer-logql": "0.2.2",
-    "@grafana/lezer-traceql": "0.0.12",
     "@grafana/monaco-logql": "^0.0.7",
     "@grafana/runtime": "workspace:*",
     "@grafana/scenes": "1.28.6",

--- a/yarn.lock
+++ b/yarn.lock
@@ -17215,7 +17215,6 @@ __metadata:
     "@grafana/flamegraph": "workspace:*"
     "@grafana/google-sdk": "npm:0.1.2"
     "@grafana/lezer-logql": "npm:0.2.2"
-    "@grafana/lezer-traceql": "npm:0.0.12"
     "@grafana/monaco-logql": "npm:^0.0.7"
     "@grafana/runtime": "workspace:*"
     "@grafana/scenes": "npm:1.28.6"


### PR DESCRIPTION
Now that Tempo has its dedicated plugin, there is no more need to have `@grafana/lezer-traceql` as a dependency of Grafana core. This PR removes it.