### PR TITLE
Alerting: Add migration for matchers to object matchers

### DIFF
--- a/pkg/services/ngalert/api/api_alertmanager.go
+++ b/pkg/services/ngalert/api/api_alertmanager.go
@@ -272,6 +272,11 @@ func (srv AlertmanagerSrv) RoutePostAlertingConfig(c *contextmodel.ReqContext, b
 			return ErrResp(http.StatusBadRequest, err, "")
 		}
 	}
+	// Change all matchers into object matchers. The purpose of this is to get all Grafana
+	// configurations using object matchers so we can turn on UTF-8 strict mode as there will
+	// be no users using matchers.
+	body.AsObjectMatchers()
+
 	err = srv.mam.ApplyAlertmanagerConfiguration(c.Req.Context(), c.SignedInUser.GetOrgID(), body)
 	if err == nil {
 		return response.JSON(http.StatusAccepted, util.DynMap{"message": "configuration created"})

--- a/pkg/services/ngalert/provisioning/notification_policies.go
+++ b/pkg/services/ngalert/provisioning/notification_policies.go
@@ -84,6 +84,8 @@ func (nps *NotificationPolicyService) UpdatePolicyTree(ctx context.Context, orgI
 		return fmt.Errorf("%w: %s", ErrValidation, err.Error())
 	}
 
+	tree.AsObjectMatchers()
+
 	revision.cfg.AlertmanagerConfig.Config.Route = &tree
 
 	return nps.xact.InTransaction(ctx, func(ctx context.Context) error {

--- a/pkg/services/sqlstore/migrations/migrations.go
+++ b/pkg/services/sqlstore/migrations/migrations.go
@@ -117,6 +117,7 @@ func (oss *OSSMigrations) AddMigration(mg *Migrator) {
 	}
 
 	addKVStoreMySQLValueTypeLongTextMigration(mg)
+	ualert.AddMigrateToObjectMatchersMigration(mg)
 }
 
 func addStarMigrations(mg *Migrator) {

--- a/pkg/services/sqlstore/migrations/ualert/ualert.go
+++ b/pkg/services/sqlstore/migrations/ualert/ualert.go
@@ -290,7 +290,7 @@ func (m *migrateToObjectMatchers) Exec(sess *xorm.Session, mg *migrator.Migrator
 			return fmt.Errorf("failed to marshal configuration for org %d: %w", row.OrgID, err)
 		}
 		row.AlertmanagerConfiguration = string(b)
-		if _, err = sess.Table(&ngmodels.AlertConfiguration{}).Update(row); err != nil {
+		if _, err = sess.Table(&ngmodels.AlertConfiguration{}).ID(row.ID).Update(row); err != nil {
 			return fmt.Errorf("failed to update configuration for org %d: %w", row.OrgID, err)
 		}
 		mg.Logger.Debug("Saved updated configuration", "org", row.OrgID)

--- a/pkg/tests/api/alerting/api_notification_channel_test.go
+++ b/pkg/tests/api/alerting/api_notification_channel_test.go
@@ -1414,9 +1414,7 @@ const alertmanagerConfig = `
           "group_by": [
             "alertname"
           ],
-          "matchers": [
-            "alertname=\"EmailAlert\""
-          ]
+          "object_matchers": [["alertname", "=", "EmailAlert"]]
         },
         {
           "receiver": "slack_recv1",
@@ -1424,9 +1422,7 @@ const alertmanagerConfig = `
           "group_by": [
             "alertname"
           ],
-          "matchers": [
-            "alertname=\"SlackAlert1\""
-          ]
+          "object_matchers": [["alertname", "=", "SlackAlert1"]]
         },
         {
           "receiver": "slack_recv2",
@@ -1434,9 +1430,7 @@ const alertmanagerConfig = `
           "group_by": [
             "alertname"
           ],
-          "matchers": [
-            "alertname=\"SlackAlert2\""
-          ]
+          "object_matchers": [["alertname", "=", "SlackAlert2"]]
         },
 		{
 		  "receiver": "slack_failed_recv",
@@ -1444,9 +1438,7 @@ const alertmanagerConfig = `
 		  "group_by": [
 			"alertname"
 		  ],
-		  "matchers": [
-			"alertname=\"SlackFailedAlert\""
-		  ]
+		  "object_matchers": [["alertname", "=", "SlackFailedAlert"]]
 		},
 		{
 		  "receiver": "slack_inactive_recv",
@@ -1454,9 +1446,7 @@ const alertmanagerConfig = `
 		  "group_by": [
 			"alertname"
 		  ],
-		  "matchers": [
-			"alertname=\"Inactive\""
-		  ]
+		  "object_matchers": [["alertname", "=", "Inactive"]]
 		},
         {
           "receiver": "pagerduty_recv",
@@ -1464,9 +1454,7 @@ const alertmanagerConfig = `
           "group_by": [
             "alertname"
           ],
-          "matchers": [
-            "alertname=\"PagerdutyAlert\""
-          ]
+          "object_matchers": [["alertname", "=", "PagerdutyAlert"]]
         },
         {
           "receiver": "dingding_recv",
@@ -1474,9 +1462,7 @@ const alertmanagerConfig = `
           "group_by": [
             "alertname"
           ],
-          "matchers": [
-            "alertname=\"DingDingAlert\""
-          ]
+          "object_matchers": [["alertname", "=", "DingDingAlert"]]
         },
         {
           "receiver": "discord_recv",
@@ -1484,9 +1470,7 @@ const alertmanagerConfig = `
           "group_by": [
             "alertname"
           ],
-          "matchers": [
-            "alertname=\"DiscordAlert\""
-          ]
+          "object_matchers": [["alertname", "=", "DiscordAlert"]]
         },
         {
           "receiver": "sensugo_recv",
@@ -1494,9 +1478,7 @@ const alertmanagerConfig = `
           "group_by": [
             "alertname"
           ],
-          "matchers": [
-            "alertname=\"SensuGoAlert\""
-          ]
+          "object_matchers": [["alertname", "=", "SensuGoAlert"]]
         },
         {
           "receiver": "pushover_recv",
@@ -1504,9 +1486,7 @@ const alertmanagerConfig = `
           "group_by": [
             "alertname"
           ],
-          "matchers": [
-            "alertname=\"PushoverAlert\""
-          ]
+          "object_matchers": [["alertname", "=", "PushoverAlert"]]
         },
         {
           "receiver": "googlechat_recv",
@@ -1514,9 +1494,7 @@ const alertmanagerConfig = `
           "group_by": [
             "alertname"
           ],
-          "matchers": [
-            "alertname=\"GoogleChatAlert\""
-          ]
+          "object_matchers": [["alertname", "=", "GoogleChatAlert"]]
         },
         {
           "receiver": "kafka_recv",
@@ -1524,9 +1502,7 @@ const alertmanagerConfig = `
           "group_by": [
             "alertname"
           ],
-          "matchers": [
-            "alertname=\"KafkaAlert\""
-          ]
+          "object_matchers": [["alertname", "=", "KafkaAlert"]]
         },
         {
           "receiver": "line_recv",
@@ -1534,9 +1510,7 @@ const alertmanagerConfig = `
           "group_by": [
             "alertname"
           ],
-          "matchers": [
-            "alertname=\"LineAlert\""
-          ]
+          "object_matchers": [["alertname", "=", "LineAlert"]]
         },
         {
           "receiver": "threema_recv",
@@ -1544,9 +1518,7 @@ const alertmanagerConfig = `
           "group_by": [
             "alertname"
           ],
-          "matchers": [
-            "alertname=\"ThreemaAlert\""
-          ]
+          "object_matchers": [["alertname", "=", "ThreemaAlert"]]
         },
         {
           "receiver": "opsgenie_recv",
@@ -1554,9 +1526,7 @@ const alertmanagerConfig = `
           "group_by": [
             "alertname"
           ],
-          "matchers": [
-            "alertname=\"OpsGenieAlert\""
-          ]
+          "object_matchers": [["alertname", "=", "OpsGenieAlert"]]
         },
         {
           "receiver": "alertmanager_recv",
@@ -1564,9 +1534,7 @@ const alertmanagerConfig = `
           "group_by": [
             "alertname"
           ],
-          "matchers": [
-            "alertname=\"AlertmanagerAlert\""
-          ]
+          "object_matchers": [["alertname", "=", "AlertmanagerAlert"]]
         },
         {
           "receiver": "victorops_recv",
@@ -1574,9 +1542,7 @@ const alertmanagerConfig = `
           "group_by": [
             "alertname"
           ],
-          "matchers": [
-            "alertname=\"VictorOpsAlert\""
-          ]
+          "object_matchers": [["alertname", "=", "VictorOpsAlert"]]
         },
         {
           "receiver": "teams_recv",
@@ -1584,9 +1550,7 @@ const alertmanagerConfig = `
           "group_by": [
             "alertname"
           ],
-          "matchers": [
-            "alertname=\"TeamsAlert\""
-          ]
+          "object_matchers": [["alertname", "=", "TeamsAlert"]]
         },
         {
           "receiver": "webhook_recv",
@@ -1594,9 +1558,7 @@ const alertmanagerConfig = `
           "group_by": [
             "alertname"
           ],
-          "matchers": [
-            "alertname=\"WebhookAlert\""
-          ]
+          "object_matchers": [["alertname", "=", "WebhookAlert"]]
         },
         {
           "receiver": "telegram_recv",
@@ -1604,9 +1566,7 @@ const alertmanagerConfig = `
           "group_by": [
             "alertname"
           ],
-          "matchers": [
-            "alertname=\"TelegramAlert\""
-          ]
+          "object_matchers": [["alertname", "=", "TelegramAlert"]]
 		}
       ]
     },
@@ -1932,9 +1892,7 @@ var expAlertmanagerConfigFromAPI = `
           "group_by": [
             "alertname"
           ],
-          "matchers": [
-            "alertname=\"EmailAlert\""
-          ]
+          "object_matchers": [["alertname", "=", "EmailAlert"]]
         },
         {
           "receiver": "slack_recv1",
@@ -1942,9 +1900,7 @@ var expAlertmanagerConfigFromAPI = `
           "group_by": [
             "alertname"
           ],
-          "matchers": [
-            "alertname=\"SlackAlert1\""
-          ]
+          "object_matchers": [["alertname", "=", "SlackAlert1"]]
         },
         {
           "receiver": "slack_recv2",
@@ -1952,9 +1908,7 @@ var expAlertmanagerConfigFromAPI = `
           "group_by": [
             "alertname"
           ],
-          "matchers": [
-            "alertname=\"SlackAlert2\""
-          ]
+          "object_matchers": [["alertname", "=", "SlackAlert2"]]
         },
 		{
           "receiver": "slack_failed_recv",
@@ -1962,9 +1916,7 @@ var expAlertmanagerConfigFromAPI = `
           "group_by": [
             "alertname"
           ],
-          "matchers": [
-            "alertname=\"SlackFailedAlert\""
-          ]
+          "object_matchers": [["alertname", "=", "SlackFailedAlert"]]
         },
    		{
           "receiver": "slack_inactive_recv",
@@ -1972,18 +1924,14 @@ var expAlertmanagerConfigFromAPI = `
           "group_by": [
             "alertname"
           ],
-          "matchers": [
-            "alertname=\"Inactive\""
-          ]
+          "object_matchers": [["alertname", "=", "Inactive"]]
         },     {
           "receiver": "pagerduty_recv",
           "group_wait": "0s",
           "group_by": [
             "alertname"
           ],
-          "matchers": [
-            "alertname=\"PagerdutyAlert\""
-          ]
+          "object_matchers": [["alertname", "=", "PagerdutyAlert"]]
         },
         {
           "receiver": "dingding_recv",
@@ -1991,9 +1939,7 @@ var expAlertmanagerConfigFromAPI = `
           "group_by": [
             "alertname"
           ],
-          "matchers": [
-            "alertname=\"DingDingAlert\""
-          ]
+          "object_matchers": [["alertname", "=", "DingDingAlert"]]
         },
         {
           "receiver": "discord_recv",
@@ -2001,9 +1947,7 @@ var expAlertmanagerConfigFromAPI = `
           "group_by": [
             "alertname"
           ],
-          "matchers": [
-            "alertname=\"DiscordAlert\""
-          ]
+          "object_matchers": [["alertname", "=", "DiscordAlert"]]
         },
         {
           "receiver": "sensugo_recv",
@@ -2011,9 +1955,7 @@ var expAlertmanagerConfigFromAPI = `
           "group_by": [
             "alertname"
           ],
-          "matchers": [
-            "alertname=\"SensuGoAlert\""
-          ]
+          "object_matchers": [["alertname", "=", "SensuGoAlert"]]
         },
         {
           "receiver": "pushover_recv",
@@ -2021,9 +1963,7 @@ var expAlertmanagerConfigFromAPI = `
           "group_by": [
             "alertname"
           ],
-          "matchers": [
-            "alertname=\"PushoverAlert\""
-          ]
+          "object_matchers": [["alertname", "=", "PushoverAlert"]]
         },
         {
           "receiver": "googlechat_recv",
@@ -2031,9 +1971,7 @@ var expAlertmanagerConfigFromAPI = `
           "group_by": [
             "alertname"
           ],
-          "matchers": [
-            "alertname=\"GoogleChatAlert\""
-          ]
+          "object_matchers": [["alertname", "=", "GoogleChatAlert"]]
         },
         {
           "receiver": "kafka_recv",
@@ -2041,9 +1979,7 @@ var expAlertmanagerConfigFromAPI = `
           "group_by": [
             "alertname"
           ],
-          "matchers": [
-            "alertname=\"KafkaAlert\""
-          ]
+          "object_matchers": [["alertname", "=", "KafkaAlert"]]
         },
         {
           "receiver": "line_recv",
@@ -2051,9 +1987,7 @@ var expAlertmanagerConfigFromAPI = `
           "group_by": [
             "alertname"
           ],
-          "matchers": [
-            "alertname=\"LineAlert\""
-          ]
+          "object_matchers": [["alertname", "=", "LineAlert"]]
         },
         {
           "receiver": "threema_recv",
@@ -2061,9 +1995,7 @@ var expAlertmanagerConfigFromAPI = `
           "group_by": [
             "alertname"
           ],
-          "matchers": [
-            "alertname=\"ThreemaAlert\""
-          ]
+          "object_matchers": [["alertname", "=", "ThreemaAlert"]]
         },
         {
           "receiver": "opsgenie_recv",
@@ -2071,9 +2003,7 @@ var expAlertmanagerConfigFromAPI = `
           "group_by": [
             "alertname"
           ],
-          "matchers": [
-            "alertname=\"OpsGenieAlert\""
-          ]
+          "object_matchers": [["alertname", "=", "OpsGenieAlert"]]
         },
         {
           "receiver": "alertmanager_recv",
@@ -2081,9 +2011,7 @@ var expAlertmanagerConfigFromAPI = `
           "group_by": [
             "alertname"
           ],
-          "matchers": [
-            "alertname=\"AlertmanagerAlert\""
-          ]
+          "object_matchers": [["alertname", "=", "AlertmanagerAlert"]]
         },
         {
           "receiver": "victorops_recv",
@@ -2091,9 +2019,7 @@ var expAlertmanagerConfigFromAPI = `
           "group_by": [
             "alertname"
           ],
-          "matchers": [
-            "alertname=\"VictorOpsAlert\""
-          ]
+          "object_matchers": [["alertname", "=", "VictorOpsAlert"]]
         },
         {
           "receiver": "teams_recv",
@@ -2101,9 +2027,7 @@ var expAlertmanagerConfigFromAPI = `
           "group_by": [
             "alertname"
           ],
-          "matchers": [
-            "alertname=\"TeamsAlert\""
-          ]
+          "object_matchers": [["alertname", "=", "TeamsAlert"]]
         },
         {
           "receiver": "webhook_recv",
@@ -2111,9 +2035,7 @@ var expAlertmanagerConfigFromAPI = `
           "group_by": [
             "alertname"
           ],
-          "matchers": [
-            "alertname=\"WebhookAlert\""
-          ]
+          "object_matchers": [["alertname", "=", "WebhookAlert"]]
         },
         {
           "receiver": "telegram_recv",
@@ -2121,9 +2043,7 @@ var expAlertmanagerConfigFromAPI = `
           "group_by": [
             "alertname"
           ],
-          "matchers": [
-            "alertname=\"TelegramAlert\""
-          ]
+          "object_matchers": [["alertname", "=", "TelegramAlert"]]
 		}
       ]
     },


### PR DESCRIPTION
**What is this feature?**

This pull request adds a migration to translate all occurrences of `matchers` into `object_matchers` in the configuration files for all organizations using Grafana Managed Alerts. It also updates the API and Provisioning API to prevent future changes to the configuration file from using `matchers`, instead translating them to `object_matchers` at runtime.

**Why do we need this feature?**

The purpose of this change is to make it easier to upgrade Grafana to UTF-8 strict mode - a mode in Prometheus Alertmanager that uses the new `matchers/parse` parser for parsing label matchers that does not fallback to the old `pkg/labels` parser.

The reason this change will make the upgrade easier is as it will prevent users from using the `matchers` field in the Alertmanager configuration file, and as `object_matchers` are stored in a structured format, removing the use of `matchers` will mean no configurations that needs to be migrated before UTF-8 strict mode can be enabled.

**Who is this feature for?**

In Grafana Cloud, there are about 2,600 occurrences of `matchers` across 500 customers being used in Grafana Managed Alerts (about 5.5% of all configurations). Just 50 of these customers have more than 10 `matchers`. Please ask for me a link to the dashboard.

It is unclear how some users are using `matchers` as the Grafana UI uses `object_matchers`. It could be that users have provisioned their Alertmanager configuration from a file on disk instead of via the Grafana UI.

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle.
- [x] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
