### PR TITLE
Loki: Use DataSourcePicker from runtime in DerivedField

### DIFF
--- a/public/app/plugins/datasource/loki/configuration/DerivedField.tsx
+++ b/public/app/plugins/datasource/loki/configuration/DerivedField.tsx
@@ -3,8 +3,8 @@ import React, { ChangeEvent, useEffect, useState } from 'react';
 import { usePrevious } from 'react-use';
 
 import { GrafanaTheme2, DataSourceInstanceSettings, VariableSuggestion } from '@grafana/data';
+import { DataSourcePicker } from '@grafana/runtime';
 import { Button, DataLinkInput, Field, Icon, Input, Label, Tooltip, useStyles2, Select, Switch } from '@grafana/ui';
-import { DataSourcePicker } from 'app/features/datasources/components/picker/DataSourcePicker';
 
 import { DerivedFieldConfig } from '../types';
 


### PR DESCRIPTION
Part of https://github.com/grafana/grafana/issues/72631

In this PR we are removing dependency on `DataSourcePicker` from `core` and use `DataSourcePicker` from `@grafana/runtime`. 

There is a slight difference between pickers - the one that is from `core` is more advanced, but as this is used only in `DerivedField` to pick from tracing data sources, advanced picker is not needed.

Before:
<img width="1879" alt="image" src="https://github.com/grafana/grafana/assets/30407135/b54d5949-1f5b-4001-884c-f6b1bcef8b77">


After: 

<img width="1901" alt="image" src="https://github.com/grafana/grafana/assets/30407135/a4b7d8cf-adf2-4931-a1c3-5792f2339f35">
