### PR TITLE
Infinite scroll: exclude visible range from new requests

### DIFF
--- a/public/app/features/explore/state/query.ts
+++ b/public/app/features/explore/state/query.ts
@@ -751,10 +751,13 @@ export const runLoadMoreLogsQueries = createAsyncThunk<void, RunLoadMoreLogsQuer
     dispatch(changeLoadingStateAction({ exploreId, loadingState: LoadingState.Loading }));
 
     newQuerySource = combineLatest([runRequest(datasourceInstance, transaction.request), correlations$]).pipe(
-      mergeMap(([data, correlations]) =>
-        decorateData(
-          // Query splitting, otherwise duplicates results
-          data.state === LoadingState.Done ? mergeDataSeries(queryResponse, data) : data,
+      mergeMap(([data, correlations]) => {
+        // For query splitting, otherwise duplicates results
+        if (data.state !== LoadingState.Done) {
+          return of(queryResponse);
+        }
+        return decorateData(
+          mergeDataSeries(queryResponse, data),
           queryResponse,
           absoluteRange,
           undefined,
@@ -763,7 +766,7 @@ export const runLoadMoreLogsQueries = createAsyncThunk<void, RunLoadMoreLogsQuer
           showCorrelationEditorLinks,
           defaultCorrelationEditorDatasource
         )
-      )
+      })
     );
 
     newQuerySource.subscribe({

--- a/public/app/features/explore/state/query.ts
+++ b/public/app/features/explore/state/query.ts
@@ -38,6 +38,7 @@ import {
 } from 'app/core/utils/explore';
 import { getShiftedTimeRange } from 'app/core/utils/timePicker';
 import { getCorrelationsBySourceUIDs } from 'app/features/correlations/utils';
+import { combinePanelData } from 'app/features/logs/response';
 import { getFiscalYearStartMonth, getTimeZone } from 'app/features/profile/state/selectors';
 import { MIXED_DATASOURCE_NAME } from 'app/plugins/datasource/mixed/MixedDataSource';
 import {
@@ -55,7 +56,7 @@ import { notifyApp } from '../../../core/actions';
 import { createErrorNotification } from '../../../core/copy/appNotification';
 import { runRequest } from '../../query/state/runRequest';
 import { visualisationTypeKey } from '../Logs/utils/logs';
-import { decorateData, mergeDataSeries } from '../utils/decorators';
+import { decorateData } from '../utils/decorators';
 import {
   getSupplementaryQueryProvider,
   storeSupplementaryQueryEnabled,
@@ -758,7 +759,7 @@ export const runLoadMoreLogsQueries = createAsyncThunk<void, RunLoadMoreLogsQuer
           return of(queryResponse);
         }
         return decorateData(
-          mergeDataSeries(queryResponse, data),
+          combinePanelData(queryResponse, data),
           queryResponse,
           absoluteRange,
           undefined,

--- a/public/app/features/explore/state/query.ts
+++ b/public/app/features/explore/state/query.ts
@@ -38,6 +38,7 @@ import {
 } from 'app/core/utils/explore';
 import { getShiftedTimeRange } from 'app/core/utils/timePicker';
 import { getCorrelationsBySourceUIDs } from 'app/features/correlations/utils';
+import { infiniteScrollRefId } from 'app/features/logs/logsModel';
 import { combinePanelData } from 'app/features/logs/response';
 import { getFiscalYearStartMonth, getTimeZone } from 'app/features/profile/state/selectors';
 import { MIXED_DATASOURCE_NAME } from 'app/plugins/datasource/mixed/MixedDataSource';
@@ -727,7 +728,7 @@ export const runLoadMoreLogsQueries = createAsyncThunk<void, RunLoadMoreLogsQuer
     const queries = logQueries.map((query: DataQuery) => ({
       ...query,
       datasource: query.datasource || datasourceInstance?.getRef(),
-      refId: `infinite-scroll-${query.refId}`
+      refId: `${infiniteScrollRefId}${query.refId}`
     }));
 
     if (!hasNonEmptyQuery(queries) || !datasourceInstance) {

--- a/public/app/features/explore/state/query.ts
+++ b/public/app/features/explore/state/query.ts
@@ -728,7 +728,7 @@ export const runLoadMoreLogsQueries = createAsyncThunk<void, RunLoadMoreLogsQuer
     const queries = logQueries.map((query: DataQuery) => ({
       ...query,
       datasource: query.datasource || datasourceInstance?.getRef(),
-      refId: `${infiniteScrollRefId}${query.refId}`
+      refId: `${infiniteScrollRefId}${query.refId}`,
     }));
 
     if (!hasNonEmptyQuery(queries) || !datasourceInstance) {
@@ -768,7 +768,7 @@ export const runLoadMoreLogsQueries = createAsyncThunk<void, RunLoadMoreLogsQuer
           correlations,
           showCorrelationEditorLinks,
           defaultCorrelationEditorDatasource
-        )
+        );
       })
     );
 

--- a/public/app/features/explore/state/query.ts
+++ b/public/app/features/explore/state/query.ts
@@ -726,6 +726,7 @@ export const runLoadMoreLogsQueries = createAsyncThunk<void, RunLoadMoreLogsQuer
     const queries = logQueries.map((query: DataQuery) => ({
       ...query,
       datasource: query.datasource || datasourceInstance?.getRef(),
+      refId: `infinite-scroll-${query.refId}`
     }));
 
     if (!hasNonEmptyQuery(queries) || !datasourceInstance) {

--- a/public/app/features/explore/utils/decorators.ts
+++ b/public/app/features/explore/utils/decorators.ts
@@ -16,7 +16,6 @@ import {
 } from '@grafana/data';
 import { config } from '@grafana/runtime';
 import { DataQuery } from '@grafana/schema';
-import { combineResponses } from 'app/features/logs/response';
 
 import { refreshIntervalToSortOrder } from '../../../core/utils/explore';
 import { ExplorePanelData } from '../../../types';
@@ -310,11 +309,6 @@ export function decorateData(
     mergeMap(decorateWithRawPrometheusResult),
     mergeMap(decorateWithTableResult)
   );
-}
-
-export function mergeDataSeries(currentData: PanelData, newData: PanelData): PanelData {
-  const series = combineResponses({ data: currentData.series }, { data: newData.series }).data;
-  return { ...currentData, series };
 }
 
 /**

--- a/public/app/features/explore/utils/decorators.ts
+++ b/public/app/features/explore/utils/decorators.ts
@@ -313,8 +313,8 @@ export function decorateData(
 }
 
 export function mergeDataSeries(currentData: PanelData, newData: PanelData): PanelData {
-  currentData.series = combineResponses({ data: currentData.series }, { data: newData.series }).data;
-  return currentData;
+  const series = combineResponses({ data: currentData.series }, { data: newData.series }).data;
+  return { ...currentData, series };
 }
 
 /**

--- a/public/app/features/logs/components/InfiniteScroll.test.tsx
+++ b/public/app/features/logs/components/InfiniteScroll.test.tsx
@@ -152,7 +152,47 @@ describe('InfiniteScroll', () => {
         expect(screen.queryByTestId('Spinner')).not.toBeInTheDocument();
       });
 
-      describe('With absolute range', () => {
+      test('Requests newer logs from the most recent timestamp without including it', async () => {
+        const startPosition = order === LogsSortOrder.Descending ? 10 : 90; // Scroll top
+        const endPosition = order === LogsSortOrder.Descending ? 0 : 100; // Scroll bottom
+
+        const loadMoreMock = jest.fn();
+        const { element, events } = setup(loadMoreMock, startPosition);
+
+        expect(await screen.findByTestId('contents')).toBeInTheDocument();
+        element.scrollTop = endPosition;
+
+        act(() => {
+          events['scroll'](new Event('scroll'));
+        });
+
+        expect(loadMoreMock).toHaveBeenCalledWith({
+          from: rows[rows.length - 1].timeEpochMs + 1,
+          to: absoluteRange.to,
+        });
+      });
+
+      test('Requests older logs from the oldest timestamp without including it', async () => {
+        const startPosition = order === LogsSortOrder.Ascending ? 10 : 90; // Scroll top
+        const endPosition = order === LogsSortOrder.Ascending ? 0 : 100; // Scroll bottom
+
+        const loadMoreMock = jest.fn();
+        const { element, events } = setup(loadMoreMock, startPosition);
+
+        expect(await screen.findByTestId('contents')).toBeInTheDocument();
+        element.scrollTop = endPosition;
+
+        act(() => {
+          events['scroll'](new Event('scroll'));
+        });
+
+        expect(loadMoreMock).toHaveBeenCalledWith({
+          from: absoluteRange.from,
+          to: rows[0].timeEpochMs - 1,
+        });
+      });
+
+      describe('With absolute range matching visible range', () => {
         function setup(loadMoreMock: () => void, startPosition: number, rows: LogRowModel[]) {
           const { element, events } = getMockElement(startPosition);
           render(
@@ -175,6 +215,7 @@ describe('InfiniteScroll', () => {
         ])(
           'It does not request more when scrolling %s',
           async (_: string, startPosition: number, endPosition: number) => {
+            // Visible range matches the current range
             const rows = createLogRows(absoluteRange.from, absoluteRange.to);
             const loadMoreMock = jest.fn();
             const { element, events } = setup(loadMoreMock, startPosition, rows);
@@ -188,11 +229,12 @@ describe('InfiniteScroll', () => {
 
             expect(loadMoreMock).not.toHaveBeenCalled();
             expect(screen.queryByTestId('Spinner')).not.toBeInTheDocument();
+            expect(await screen.findByTestId('end-of-range')).toBeInTheDocument();
           }
         );
       });
 
-      describe('With relative range', () => {
+      describe('With relative range matching visible range', () => {
         function setup(loadMoreMock: () => void, startPosition: number, rows: LogRowModel[]) {
           const { element, events } = getMockElement(startPosition);
           render(
@@ -215,6 +257,7 @@ describe('InfiniteScroll', () => {
         ])(
           'It does not request more when scrolling %s',
           async (_: string, startPosition: number, endPosition: number) => {
+            // Visible range matches the current range
             const rows = createLogRows(absoluteRange.from, absoluteRange.to);
             const loadMoreMock = jest.fn();
             const { element, events } = setup(loadMoreMock, startPosition, rows);
@@ -228,6 +271,7 @@ describe('InfiniteScroll', () => {
 
             expect(loadMoreMock).not.toHaveBeenCalled();
             expect(screen.queryByTestId('Spinner')).not.toBeInTheDocument();
+            expect(await screen.findByTestId('end-of-range')).toBeInTheDocument();
           }
         );
       });

--- a/public/app/features/logs/components/InfiniteScroll.test.tsx
+++ b/public/app/features/logs/components/InfiniteScroll.test.tsx
@@ -152,7 +152,7 @@ describe('InfiniteScroll', () => {
         expect(screen.queryByTestId('Spinner')).not.toBeInTheDocument();
       });
 
-      test('Requests newer logs from the most recent timestamp without including it', async () => {
+      test('Requests newer logs from the most recent timestamp', async () => {
         const startPosition = order === LogsSortOrder.Descending ? 10 : 90; // Scroll top
         const endPosition = order === LogsSortOrder.Descending ? 0 : 100; // Scroll bottom
 
@@ -167,12 +167,12 @@ describe('InfiniteScroll', () => {
         });
 
         expect(loadMoreMock).toHaveBeenCalledWith({
-          from: rows[rows.length - 1].timeEpochMs + 1,
+          from: rows[rows.length - 1].timeEpochMs,
           to: absoluteRange.to,
         });
       });
 
-      test('Requests older logs from the oldest timestamp without including it', async () => {
+      test('Requests older logs from the oldest timestamp', async () => {
         const startPosition = order === LogsSortOrder.Ascending ? 10 : 90; // Scroll top
         const endPosition = order === LogsSortOrder.Ascending ? 0 : 100; // Scroll bottom
 
@@ -188,7 +188,7 @@ describe('InfiniteScroll', () => {
 
         expect(loadMoreMock).toHaveBeenCalledWith({
           from: absoluteRange.from,
-          to: rows[0].timeEpochMs - 1,
+          to: rows[0].timeEpochMs,
         });
       });
 

--- a/public/app/features/logs/components/InfiniteScroll.tsx
+++ b/public/app/features/logs/components/InfiniteScroll.tsx
@@ -128,15 +128,15 @@ export const InfiniteScroll = ({
 };
 
 const styles = {
-  limitReached: css({
+  messageContainer: css({
     textAlign: 'center',
     padding: 0.25,
   }),
 };
 
-const outOfRangeMessage = <div className={styles.limitReached}>End of the selected time range.</div>;
+const outOfRangeMessage = <div className={styles.messageContainer} data-testid="end-of-range">End of the selected time range.</div>;
 const loadingMessage = (
-  <div className={styles.limitReached}>
+  <div className={styles.messageContainer}>
     <Spinner />
   </div>
 );
@@ -178,13 +178,15 @@ function getVisibleRange(rows: LogRowModel[]) {
 }
 
 function getPrevRange(visibleRange: AbsoluteTimeRange, currentRange: TimeRange) {
-  return { from: currentRange.from.valueOf(), to: visibleRange.from };
+  // Until the oldest log line, but without including it
+  return { from: currentRange.from.valueOf(), to: visibleRange.from - 1 };
 }
 
 function getNextRange(visibleRange: AbsoluteTimeRange, currentRange: TimeRange, timeZone: TimeZone) {
   // When requesting new logs, update the current range if using relative time ranges.
   currentRange = updateCurrentRange(currentRange, timeZone);
-  return { from: visibleRange.to, to: currentRange.to.valueOf() };
+  // From the most recent log line, but without including it
+  return { from: visibleRange.to + 1, to: currentRange.to.valueOf() };
 }
 
 export const SCROLLING_THRESHOLD = 1e3;

--- a/public/app/features/logs/components/InfiniteScroll.tsx
+++ b/public/app/features/logs/components/InfiniteScroll.tsx
@@ -178,15 +178,13 @@ function getVisibleRange(rows: LogRowModel[]) {
 }
 
 function getPrevRange(visibleRange: AbsoluteTimeRange, currentRange: TimeRange) {
-  // Until the oldest log line, but without including it
-  return { from: currentRange.from.valueOf(), to: visibleRange.from - 1 };
+  return { from: currentRange.from.valueOf(), to: visibleRange.from };
 }
 
 function getNextRange(visibleRange: AbsoluteTimeRange, currentRange: TimeRange, timeZone: TimeZone) {
   // When requesting new logs, update the current range if using relative time ranges.
   currentRange = updateCurrentRange(currentRange, timeZone);
-  // From the most recent log line, but without including it
-  return { from: visibleRange.to + 1, to: currentRange.to.valueOf() };
+  return { from: visibleRange.to, to: currentRange.to.valueOf() };
 }
 
 export const SCROLLING_THRESHOLD = 1e3;

--- a/public/app/features/logs/components/InfiniteScroll.tsx
+++ b/public/app/features/logs/components/InfiniteScroll.tsx
@@ -134,7 +134,11 @@ const styles = {
   }),
 };
 
-const outOfRangeMessage = <div className={styles.messageContainer} data-testid="end-of-range">End of the selected time range.</div>;
+const outOfRangeMessage = (
+  <div className={styles.messageContainer} data-testid="end-of-range">
+    End of the selected time range.
+  </div>
+);
 const loadingMessage = (
   <div className={styles.messageContainer}>
     <Spinner />

--- a/public/app/features/logs/logsModel.test.ts
+++ b/public/app/features/logs/logsModel.test.ts
@@ -30,12 +30,14 @@ import {
   dedupLogRows,
   filterLogLevels,
   getSeriesProperties,
+  infiniteScrollRefId,
   LIMIT_LABEL,
   logRowToSingleRowDataFrame,
   logSeriesToLogsModel,
   queryLogsSample,
   queryLogsVolume,
 } from './logsModel';
+import { getMockFrames } from 'app/plugins/datasource/loki/__mocks__/frames';
 
 const FROM = dateTimeParse('2021-06-17 00:00:00', { timeZone: 'utc' });
 const TO = dateTimeParse('2021-06-17 00:00:00', { timeZone: 'utc' });
@@ -231,7 +233,7 @@ const emptyLogsModel = {
 
 describe('dataFrameToLogsModel', () => {
   it('given empty series should return empty logs model', () => {
-    expect(dataFrameToLogsModel([] as DataFrame[], 0)).toMatchObject(emptyLogsModel);
+    expect(dataFrameToLogsModel([], 0)).toMatchObject(emptyLogsModel);
   });
 
   it('given series without correct series name should return empty logs model', () => {
@@ -1015,6 +1017,51 @@ describe('dataFrameToLogsModel', () => {
     ];
     const logsModel = dataFrameToLogsModel(series, 1);
     expect(logsModel.rows[0].uid).toBe('A_0');
+  });
+
+  describe('infinite scrolling', () => {
+    let frameA: DataFrame, frameB: DataFrame;
+    beforeEach(() => {
+      const { logFrameA, logFrameB } = getMockFrames();
+      logFrameA.refId = `${infiniteScrollRefId}-A`;
+      logFrameA.fields[0].values = [1, 1];
+      logFrameA.fields[1].values = ['line', 'line'];
+      logFrameA.fields[3].values = ['3000000', '3000000'];
+      logFrameA.fields[4].values = ['id', 'id'];
+      logFrameB.refId = `${infiniteScrollRefId}-B`;
+      logFrameB.fields[0].values = [2, 2];
+      logFrameB.fields[1].values = ['line 2', 'line 2'];
+      logFrameB.fields[3].values = ['4000000', '4000000'];
+      logFrameB.fields[4].values = ['id2', 'id2'];
+      frameA = logFrameA;
+      frameB = logFrameB;
+    });
+
+    it('deduplicates repeated log frames when invoked from infinite scrolling results', () => {
+      const logsModel = dataFrameToLogsModel([frameA, frameB], 1, { from: 1556270591353, to: 1556289770991 }, [
+        { refId: `${infiniteScrollRefId}-A` },
+        { refId: `${infiniteScrollRefId}-B` },
+      ]);
+
+      expect(logsModel.rows).toHaveLength(2);
+      expect(logsModel.rows[0].entry).toBe(frameA.fields[1].values[0]);
+      expect(logsModel.rows[1].entry).toBe(frameB.fields[1].values[0]);
+    });
+
+    it('does not remove repeated log frames when invoked from other contexts', () => {
+      frameA.refId = 'A';
+      frameB.refId = 'B';
+      const logsModel = dataFrameToLogsModel([frameA, frameB], 1, { from: 1556270591353, to: 1556289770991 }, [
+        { refId: 'A' },
+        { refId: 'B' },
+      ]);
+
+      expect(logsModel.rows).toHaveLength(4);
+      expect(logsModel.rows[0].entry).toBe(frameA.fields[1].values[0]);
+      expect(logsModel.rows[1].entry).toBe(frameA.fields[1].values[1]);
+      expect(logsModel.rows[2].entry).toBe(frameB.fields[1].values[0]);
+      expect(logsModel.rows[3].entry).toBe(frameB.fields[1].values[1]);
+    });
   });
 });
 

--- a/public/app/features/logs/logsModel.test.ts
+++ b/public/app/features/logs/logsModel.test.ts
@@ -21,6 +21,7 @@ import {
   toDataFrame,
 } from '@grafana/data';
 import { config } from '@grafana/runtime';
+import { getMockFrames } from 'app/plugins/datasource/loki/__mocks__/frames';
 
 import { MockObservableDataSourceApi } from '../../../test/mocks/datasource_srv';
 
@@ -37,7 +38,6 @@ import {
   queryLogsSample,
   queryLogsVolume,
 } from './logsModel';
-import { getMockFrames } from 'app/plugins/datasource/loki/__mocks__/frames';
 
 const FROM = dateTimeParse('2021-06-17 00:00:00', { timeZone: 'utc' });
 const TO = dateTimeParse('2021-06-17 00:00:00', { timeZone: 'utc' });

--- a/public/app/features/logs/logsModel.ts
+++ b/public/app/features/logs/logsModel.ts
@@ -375,7 +375,6 @@ export function logSeriesToLogsModel(logSeries: DataFrame[], queries: DataQuery[
     return undefined;
   }
   const allLabels: Labels[][] = [];
-  
 
   // Find the fields we care about and collect all labels
   let allSeries: LogInfo[] = [];

--- a/public/app/features/logs/logsModel.ts
+++ b/public/app/features/logs/logsModel.ts
@@ -46,7 +46,7 @@ import { ansicolor, colors } from '@grafana/ui';
 import { getThemeColor } from 'app/core/utils/colors';
 
 import { LogsFrame, parseLogsFrame } from './logsFrame';
-import { getLogLevel, getLogLevelFromKey, sortInAscendingOrder } from './utils';
+import { filterDuplicates, getLogLevel, getLogLevelFromKey, sortInAscendingOrder } from './utils';
 
 export const LIMIT_LABEL = 'Line limit';
 export const COMMON_LABELS = 'Common labels';
@@ -387,7 +387,7 @@ export function logSeriesToLogsModel(logSeries: DataFrame[], queries: DataQuery[
   const flatAllLabels = allLabels.flat();
   const commonLabels = flatAllLabels.length > 0 ? findCommonLabels(flatAllLabels) : {};
 
-  const rows: LogRowModel[] = [];
+  let rows: LogRowModel[] = [];
   let hasUniqueLabels = false;
 
   for (const info of allSeries) {
@@ -455,6 +455,11 @@ export function logSeriesToLogsModel(logSeries: DataFrame[], queries: DataQuery[
 
       rows.push(row);
     }
+  }
+
+  // Until nanosecond precision for requests is supported, we need to filter possible duplicates
+  if (config.featureToggles.logsInfiniteScrolling) {
+    rows = filterDuplicates(rows);
   }
 
   // Meta data to display in status

--- a/public/app/features/logs/logsModel.ts
+++ b/public/app/features/logs/logsModel.ts
@@ -474,7 +474,6 @@ export function logSeriesToLogsModel(logSeries: DataFrame[], queries: DataQuery[
       }
 
       if (filterDuplicateRows && findMatchingRow(row, rows)) {
-        console.log(`skipping`, row)
         continue;
       }
 

--- a/public/app/features/logs/logsModel.ts
+++ b/public/app/features/logs/logsModel.ts
@@ -202,6 +202,8 @@ function isLogsData(series: DataFrame) {
   return series.fields.some((f) => f.type === FieldType.time) && series.fields.some((f) => f.type === FieldType.string);
 }
 
+export const infiniteScrollRefId = 'infinite-scroll-';
+
 /**
  * Convert dataFrame into LogsModel which consists of creating separate array of log rows and metrics series. Metrics
  * series can be either already included in the dataFrame or will be computed from the log rows.
@@ -223,7 +225,7 @@ export function dataFrameToLogsModel(
       infiniteScrollingResults = true;
       return {
         ...query,
-        refId: query.refId.replace('infinite-scroll-', ''),
+        refId: query.refId.replace(infiniteScrollRefId, ''),
       }
     }
     return query;
@@ -231,7 +233,7 @@ export function dataFrameToLogsModel(
   if (infiniteScrollingResults) {
     dataFrame = dataFrame.map(frame => ({
       ...frame,
-      refId: frame.refId?.replace('infinite-scroll-', '')
+      refId: frame.refId?.replace(infiniteScrollRefId, '')
     }));
   }
 

--- a/public/app/features/logs/logsModel.ts
+++ b/public/app/features/logs/logsModel.ts
@@ -220,20 +220,20 @@ export function dataFrameToLogsModel(
 ): LogsModel {
   // Until nanosecond precision for requests is supported, we need to account for possible duplicate rows.
   let infiniteScrollingResults = false;
-  queries = queries?.map(query => {
-    if (query.refId.includes('infinite-scroll')) {
+  queries = queries?.map((query) => {
+    if (query.refId.includes(infiniteScrollRefId)) {
       infiniteScrollingResults = true;
       return {
         ...query,
         refId: query.refId.replace(infiniteScrollRefId, ''),
-      }
+      };
     }
     return query;
   });
   if (infiniteScrollingResults) {
-    dataFrame = dataFrame.map(frame => ({
+    dataFrame = dataFrame.map((frame) => ({
       ...frame,
-      refId: frame.refId?.replace(infiniteScrollRefId, '')
+      refId: frame.refId?.replace(infiniteScrollRefId, ''),
     }));
   }
 
@@ -372,7 +372,11 @@ function parseTime(
  * Converts dataFrames into LogsModel. This involves merging them into one list, sorting them and computing metadata
  * like common labels.
  */
-export function logSeriesToLogsModel(logSeries: DataFrame[], queries: DataQuery[] = [], filterDuplicateRows = false): LogsModel | undefined {
+export function logSeriesToLogsModel(
+  logSeries: DataFrame[],
+  queries: DataQuery[] = [],
+  filterDuplicateRows = false
+): LogsModel | undefined {
   if (logSeries.length === 0) {
     return undefined;
   }

--- a/public/app/features/logs/response.ts
+++ b/public/app/features/logs/response.ts
@@ -5,9 +5,15 @@ import {
   DataQueryResponseData,
   Field,
   FieldType,
+  PanelData,
   QueryResultMetaStat,
   shallowCompare,
 } from '@grafana/data';
+
+export function combinePanelData(currentData: PanelData, newData: PanelData): PanelData {
+  const series = combineResponses({ data: currentData.series }, { data: newData.series }).data;
+  return { ...currentData, series };
+}
 
 export function combineResponses(currentResult: DataQueryResponse | null, newResult: DataQueryResponse) {
   if (!currentResult) {

--- a/public/app/features/logs/utils.test.ts
+++ b/public/app/features/logs/utils.test.ts
@@ -512,7 +512,7 @@ describe('findMatchingRow', () => {
     }
   });
 
-  it('matches rows by rowId', () => {
+  it('matches rows by entry and nanosecond time', () => {
     const { logFrameA, logFrameB } = getMockFrames();
     const logsModel = setup([logFrameA, logFrameB]);
     const rows = logsModel?.rows || [];

--- a/public/app/features/logs/utils.test.ts
+++ b/public/app/features/logs/utils.test.ts
@@ -9,12 +9,14 @@ import {
   MutableDataFrame,
   DataFrame,
 } from '@grafana/data';
+import { getMockFrames } from 'app/plugins/datasource/loki/__mocks__/frames';
 
 import {
   calculateLogsLabelStats,
   calculateStats,
   checkLogsError,
   escapeUnescapedString,
+  findMatchingRow,
   getLogLevel,
   getLogLevelFromKey,
   getLogsVolumeMaximumRange,
@@ -22,6 +24,7 @@ import {
   mergeLogsVolumeDataFrames,
   sortLogsResult,
 } from './utils';
+import { logSeriesToLogsModel } from './logsModel';
 
 describe('getLoglevel()', () => {
   it('returns no log level on empty line', () => {
@@ -477,5 +480,46 @@ describe('escapeUnescapedString', () => {
   });
   it('escapes unescaped strings', () => {
     expect(escapeUnescapedString(`\\r\\n|\\n|\\t|\\r`)).toBe(`\n|\n|\t|\n`);
+  });
+});
+
+describe('findMatchingRow', () => {
+  function setup(frames: DataFrame[]) {
+    return logSeriesToLogsModel(frames);
+  }
+
+  it('ignores rows from different queries', () => {
+    const { logFrameA, logFrameB } = getMockFrames();
+    logFrameA.refId = 'A';
+    logFrameB.refId = 'B';
+    const logsModel = setup([logFrameA, logFrameB]);
+    const rows = logsModel?.rows || [];
+    
+    for (const row of rows) {
+      const targetRow = { ...row, dataFrame: { ...logFrameA, refId: 'Z' }};
+      expect(findMatchingRow(targetRow, rows)).toBe(undefined);
+    }
+  });
+
+  it('matches rows by rowId', () => {
+    const { logFrameA, logFrameB } = getMockFrames();
+    const logsModel = setup([logFrameA, logFrameB]);
+    const rows = logsModel?.rows || [];
+    
+    for (const row of rows) {
+      const targetRow = { ...row, entry: `${Math.random()}`, timeEpochNs: `${Math.ceil(Math.random() * 1000000)}` };
+      expect(findMatchingRow(targetRow, rows)).toBeDefined();
+    }
+  });
+
+  it('matches rows by rowId', () => {
+    const { logFrameA, logFrameB } = getMockFrames();
+    const logsModel = setup([logFrameA, logFrameB]);
+    const rows = logsModel?.rows || [];
+    
+    for (const row of rows) {
+      const targetRow = { ...row, rowId: undefined };
+      expect(findMatchingRow(targetRow, rows)).toBeDefined();
+    }
   });
 });

--- a/public/app/features/logs/utils.test.ts
+++ b/public/app/features/logs/utils.test.ts
@@ -494,9 +494,9 @@ describe('findMatchingRow', () => {
     logFrameB.refId = 'B';
     const logsModel = setup([logFrameA, logFrameB]);
     const rows = logsModel?.rows || [];
-    
+
     for (const row of rows) {
-      const targetRow = { ...row, dataFrame: { ...logFrameA, refId: 'Z' }};
+      const targetRow = { ...row, dataFrame: { ...logFrameA, refId: 'Z' } };
       expect(findMatchingRow(targetRow, rows)).toBe(undefined);
     }
   });
@@ -505,7 +505,7 @@ describe('findMatchingRow', () => {
     const { logFrameA, logFrameB } = getMockFrames();
     const logsModel = setup([logFrameA, logFrameB]);
     const rows = logsModel?.rows || [];
-    
+
     for (const row of rows) {
       const targetRow = { ...row, entry: `${Math.random()}`, timeEpochNs: `${Math.ceil(Math.random() * 1000000)}` };
       expect(findMatchingRow(targetRow, rows)).toBeDefined();
@@ -516,7 +516,7 @@ describe('findMatchingRow', () => {
     const { logFrameA, logFrameB } = getMockFrames();
     const logsModel = setup([logFrameA, logFrameB]);
     const rows = logsModel?.rows || [];
-    
+
     for (const row of rows) {
       const targetRow = { ...row, rowId: undefined };
       expect(findMatchingRow(targetRow, rows)).toBeDefined();

--- a/public/app/features/logs/utils.test.ts
+++ b/public/app/features/logs/utils.test.ts
@@ -11,6 +11,7 @@ import {
 } from '@grafana/data';
 import { getMockFrames } from 'app/plugins/datasource/loki/__mocks__/frames';
 
+import { logSeriesToLogsModel } from './logsModel';
 import {
   calculateLogsLabelStats,
   calculateStats,
@@ -24,7 +25,6 @@ import {
   mergeLogsVolumeDataFrames,
   sortLogsResult,
 } from './utils';
-import { logSeriesToLogsModel } from './logsModel';
 
 describe('getLoglevel()', () => {
   it('returns no log level on empty line', () => {

--- a/public/app/features/logs/utils.ts
+++ b/public/app/features/logs/utils.ts
@@ -299,14 +299,12 @@ export function targetIsElement(target: EventTarget | null): target is Element {
 }
 
 export function findMatchingRow(target: LogRowModel, rows: LogRowModel[]) {
-  return rows.find(
-    (row) => {
-      if (target.dataFrame.refId !== row.dataFrame.refId) {
-        return false;
-      } 
-      const sameId = (target.rowId && row.rowId && target.rowId === row.rowId);
-      const sameSignature = row.entry === target.entry && row.timeEpochNs === target.timeEpochNs;
-      return sameId || sameSignature;
-     }
-  );
+  return rows.find((row) => {
+    if (target.dataFrame.refId !== row.dataFrame.refId) {
+      return false;
+    }
+    const sameId = target.rowId && row.rowId && target.rowId === row.rowId;
+    const sameSignature = row.entry === target.entry && row.timeEpochNs === target.timeEpochNs;
+    return sameId || sameSignature;
+  });
 }

--- a/public/app/features/logs/utils.ts
+++ b/public/app/features/logs/utils.ts
@@ -297,3 +297,14 @@ export const copyText = async (text: string, buttonRef: React.MutableRefObject<E
 export function targetIsElement(target: EventTarget | null): target is Element {
   return target instanceof Element;
 }
+
+export function filterDuplicates(rows: LogRowModel[]) {
+  return rows.filter((currentRow, i) => {
+    return rows.findIndex(
+      (row, j) =>
+        i < j &&
+        currentRow.dataFrame.refId === row.dataFrame.refId &&
+        row.entry === currentRow.entry && row.timeEpochNs === currentRow.timeEpochNs
+    ) < 0
+  });
+}

--- a/public/app/features/logs/utils.ts
+++ b/public/app/features/logs/utils.ts
@@ -298,13 +298,15 @@ export function targetIsElement(target: EventTarget | null): target is Element {
   return target instanceof Element;
 }
 
-export function filterDuplicates(rows: LogRowModel[]) {
-  return rows.filter((currentRow, i) => {
-    return rows.findIndex(
-      (row, j) =>
-        i < j &&
-        currentRow.dataFrame.refId === row.dataFrame.refId &&
-        row.entry === currentRow.entry && row.timeEpochNs === currentRow.timeEpochNs
-    ) < 0
-  });
+export function findMatchingRow(target: LogRowModel, rows: LogRowModel[]) {
+  return rows.find(
+    (row) => {
+      if (target.dataFrame.refId !== row.dataFrame.refId) {
+        return false;
+      } 
+      const sameId = (target.rowId && row.rowId && target.rowId === row.rowId);
+      const sameSignature = row.entry === target.entry && row.timeEpochNs === target.timeEpochNs;
+      return sameId || sameSignature;
+     }
+  );
 }


### PR DESCRIPTION
Because we don't have nanosecond support for requests, we were using the visible range (oldest to newest log line) to generate infinite scrolling requests, which had the possible effect of displaying duplicated log lines.

Since we cannot skip 1 ms (by adding or substracting from the interval) because we could potentially omit multiple log lines, the proposed solution is to:
- Identify infinite scrolling requests (by changing the refId)
- Filtering duplicate results when parsing results

**Why do we need this feature?**

Fixes duplicated results on scrolling.

**Which issue(s) does this PR fix?**:

Part of https://github.com/grafana/grafana/issues/71728

**Special notes for your reviewer:**

Steps to repro:
1. 
- Add a log query with at least one line filter
- Change sorting method to newest first
- Quickly scroll top to get new logs
- **Expected result** no duplicated log lines

2.
- Add a log query with at least one line filter
- Change sorting method to oldest first
- Quickly scroll bottom to get new logs
- **Expected result** no duplicated log lines

Before:

https://github.com/grafana/grafana/assets/1069378/09d1075d-49de-4a55-ba5e-67f328101642

After:

https://github.com/grafana/grafana/assets/1069378/1e919848-bfef-4dfb-914d-98e8b3d497cb

