### PR TITLE
Automatically assign Pyroscope label

### DIFF
--- a/.github/pr-commands.json
+++ b/.github/pr-commands.json
@@ -149,6 +149,12 @@
   },
   {
     "type": "changedfiles",
+    "matches": [ "public/app/plugins/datasource/grafana-pyroscope-datasource/**/*", "pkg/tsdb/grafana-pyroscope-datasource/**/*"],
+    "action": "updateLabel",
+    "addLabel": "datasource/grafana-pyroscope"
+  },
+  {
+    "type": "changedfiles",
     "matches": [ "public/app/plugins/datasource/grafana-postgresql-datasource/**/*", "pkg/tsdb/grafana-postgresql-datasource/**/*"],
     "action": "updateLabel",
     "addLabel": "datasource/Postgres"


### PR DESCRIPTION
Update automation rules to assign label `datasource/grafana-pyroscope` when files related to Pyroscope are modified in a PR.