### PR TITLE
updated grafana docker video timestamp

### DIFF
--- a/docs/sources/setup-grafana/installation/docker/index.md
+++ b/docs/sources/setup-grafana/installation/docker/index.md
@@ -15,7 +15,7 @@ weight: 400
 
 This topic guides you through installing Grafana via the official Docker images. Specifically, it covers running Grafana via the Docker command line interface (CLI) and docker-compose.
 
-{{< youtube id="FlDfcMbSLXs" >}}
+{{< youtube id="FlDfcMbSLXs" start="703">}}
 
 Grafana Docker images come in two editions:
 


### PR DESCRIPTION
Fixes #

Update the documentation page:

https://grafana.com/docs/grafana/latest/setup-grafana/installation/docker/

Added the time when the actual demo starts.




**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [x] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
