### PR TITLE
Cloudwatch: remove direct import on getDatasourceSrv

### DIFF
--- a/public/app/plugins/datasource/cloudwatch/components/ConfigEditor/ConfigEditor.test.tsx
+++ b/public/app/plugins/datasource/cloudwatch/components/ConfigEditor/ConfigEditor.test.tsx
@@ -15,11 +15,6 @@ import { ConfigEditor, Props } from './ConfigEditor';
 
 const datasource = new CloudWatchDatasource(CloudWatchSettings);
 const loadDataSourceMock = jest.fn();
-jest.mock('app/features/plugins/datasource_srv', () => ({
-  getDatasourceSrv: () => ({
-    loadDatasource: loadDataSourceMock,
-  }),
-}));
 
 jest.mock('./XrayLinkConfig', () => ({
   XrayLinkConfig: () => <></>,
@@ -35,6 +30,9 @@ jest.mock('@grafana/runtime', () => ({
   getBackendSrv: () => ({
     put: putMock,
     get: getMock,
+  }),
+  getDataSourceSrv: () => ({
+    get: loadDataSourceMock,
   }),
   getAppEvents: () => mockAppEvents,
   config: {

--- a/public/app/plugins/datasource/cloudwatch/components/ConfigEditor/ConfigEditor.tsx
+++ b/public/app/plugins/datasource/cloudwatch/components/ConfigEditor/ConfigEditor.tsx
@@ -295,11 +295,13 @@ function useDatasource(props: Props) {
 
   useEffect(() => {
     if (props.options.version) {
-      getDataSourceSrv().get(props.options.name).then((datasource) => {
-        if (datasource instanceof CloudWatchDatasource) {
-          setDatasource(datasource);
-        }
-      });
+      getDataSourceSrv()
+        .get(props.options.name)
+        .then((datasource) => {
+          if (datasource instanceof CloudWatchDatasource) {
+            setDatasource(datasource);
+          }
+        });
     }
   }, [props.options.version, props.options.name]);
 

--- a/public/app/plugins/datasource/cloudwatch/components/ConfigEditor/ConfigEditor.tsx
+++ b/public/app/plugins/datasource/cloudwatch/components/ConfigEditor/ConfigEditor.tsx
@@ -11,11 +11,10 @@ import {
   DataSourceTestFailed,
 } from '@grafana/data';
 import { ConfigSection } from '@grafana/experimental';
-import { getAppEvents, usePluginInteractionReporter, config } from '@grafana/runtime';
+import { getAppEvents, usePluginInteractionReporter, getDataSourceSrv, config } from '@grafana/runtime';
 import { Input, InlineField, FieldProps, SecureSocksProxySettings, Field, Divider } from '@grafana/ui';
 import { notifyApp } from 'app/core/actions';
 import { createWarningNotification } from 'app/core/copy/appNotification';
-import { getDatasourceSrv } from 'app/features/plugins/datasource_srv';
 import { store } from 'app/store/store';
 
 import { CloudWatchDatasource } from '../../datasource';
@@ -296,13 +295,11 @@ function useDatasource(props: Props) {
 
   useEffect(() => {
     if (props.options.version) {
-      getDatasourceSrv()
-        .loadDatasource(props.options.name)
-        .then((datasource) => {
-          if (datasource instanceof CloudWatchDatasource) {
-            setDatasource(datasource);
-          }
-        });
+      getDataSourceSrv().get(props.options.name).then((datasource) => {
+        if (datasource instanceof CloudWatchDatasource) {
+          setDatasource(datasource);
+        }
+      });
     }
   }, [props.options.version, props.options.name]);
 

--- a/public/app/plugins/datasource/cloudwatch/components/ConfigEditor/XrayLinkConfig.tsx
+++ b/public/app/plugins/datasource/cloudwatch/components/ConfigEditor/XrayLinkConfig.tsx
@@ -3,9 +3,8 @@ import React from 'react';
 
 import { GrafanaTheme2, DataSourceInstanceSettings } from '@grafana/data';
 import { ConfigSection } from '@grafana/experimental';
-import { DataSourcePicker } from '@grafana/runtime';
+import { DataSourcePicker, getDataSourceSrv } from '@grafana/runtime';
 import { Alert, Field, InlineField, useStyles2 } from '@grafana/ui';
-import { getDatasourceSrv } from 'app/features/plugins/datasource_srv';
 
 const getStyles = (theme: GrafanaTheme2) => ({
   infoText: css`
@@ -23,7 +22,7 @@ interface Props {
 const xRayDsId = 'grafana-x-ray-datasource';
 
 export function XrayLinkConfig({ newFormStyling, datasourceUid, onChange }: Props) {
-  const hasXrayDatasource = Boolean(getDatasourceSrv().getList({ pluginId: xRayDsId }).length);
+  const hasXrayDatasource = Boolean(getDataSourceSrv().getList({ pluginId: xRayDsId }).length);
 
   const styles = useStyles2(getStyles);
 


### PR DESCRIPTION
**What is this feature?**

No user-facing changes, just a code refactor to remove a dependencies on core grafana from the Cloudwatch Datasource. 

**Why do we need this feature?**

We are working to remove dependencies on core grafana so that the Cloudwatch plugin could be released/run separately from core grafana. 

**Who is this feature for?**

grafana devs

**Which issue(s) does this PR fix?**:

fixes https://github.com/grafana/grafana/issues/80152

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
