### PR TITLE
Cloudwatch: remove dependency on app/core/config

### DIFF
--- a/public/app/plugins/datasource/cloudwatch/components/ConfigEditor/ConfigEditor.tsx
+++ b/public/app/plugins/datasource/cloudwatch/components/ConfigEditor/ConfigEditor.tsx
@@ -11,10 +11,9 @@ import {
   DataSourceTestFailed,
 } from '@grafana/data';
 import { ConfigSection } from '@grafana/experimental';
-import { getAppEvents, usePluginInteractionReporter } from '@grafana/runtime';
+import { getAppEvents, usePluginInteractionReporter, config } from '@grafana/runtime';
 import { Input, InlineField, FieldProps, SecureSocksProxySettings, Field, Divider } from '@grafana/ui';
 import { notifyApp } from 'app/core/actions';
-import { config } from 'app/core/config';
 import { createWarningNotification } from 'app/core/copy/appNotification';
 import { getDatasourceSrv } from 'app/features/plugins/datasource_srv';
 import { store } from 'app/store/store';


### PR DESCRIPTION
**What is this feature?**

No user-facing changes, just a code refactor to remove a dependencies on core grafana from the Cloudwatch Datasource.

**Why do we need this feature?**

We are working to remove dependencies on core grafana so that the Cloudwatch plugin could be released/run separately from core grafana.

**Who is this feature for?**

grafana devs


**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/grafana/issues/80150

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
