### PR TITLE
Alerting: Add metric counting rule groups per org

### DIFF
--- a/pkg/services/ngalert/metrics/scheduler.go
+++ b/pkg/services/ngalert/metrics/scheduler.go
@@ -21,6 +21,7 @@ type Scheduler struct {
 	ProcessDuration                     *prometheus.HistogramVec
 	SendDuration                        *prometheus.HistogramVec
 	GroupRules                          *prometheus.GaugeVec
+	Groups                              *prometheus.GaugeVec
 	SchedulePeriodicDuration            prometheus.Histogram
 	SchedulableAlertRules               prometheus.Gauge
 	SchedulableAlertRulesHash           prometheus.Gauge
@@ -99,6 +100,15 @@ func NewSchedulerMetrics(r prometheus.Registerer) *Scheduler {
 				Help:      "The number of alert rules that are scheduled, both active and paused.",
 			},
 			[]string{"org", "state"},
+		),
+		Groups: promauto.With(r).NewGaugeVec(
+			prometheus.GaugeOpts{
+				Namespace: Namespace,
+				Subsystem: Subsystem,
+				Name:      "rule_groups",
+				Help:      "The number of alert rule groups",
+			},
+			[]string{"org"},
 		),
 		SchedulePeriodicDuration: promauto.With(r).NewHistogram(
 			prometheus.HistogramOpts{

--- a/pkg/services/ngalert/schedule/schedule.go
+++ b/pkg/services/ngalert/schedule/schedule.go
@@ -204,16 +204,16 @@ type readyToRunItem struct {
 }
 
 func (sch *schedule) updateRulesMetrics(alertRules []*ngmodels.AlertRule) {
-	orgs := make(map[int64]int64, len(alertRules))
-	orgsPaused := make(map[int64]int64, len(alertRules))
+	rulesPerOrg := make(map[int64]int64)
+	orgsPaused := make(map[int64]int64)
 	for _, rule := range alertRules {
-		orgs[rule.OrgID]++
+		rulesPerOrg[rule.OrgID]++
 		if rule.IsPaused {
 			orgsPaused[rule.OrgID]++
 		}
 	}
 
-	for orgID, numRules := range orgs {
+	for orgID, numRules := range rulesPerOrg {
 		numRulesPaused := orgsPaused[orgID]
 		sch.metrics.GroupRules.WithLabelValues(fmt.Sprint(orgID), metrics.AlertRuleActiveLabelValue).Set(float64(numRules - numRulesPaused))
 		sch.metrics.GroupRules.WithLabelValues(fmt.Sprint(orgID), metrics.AlertRulePausedLabelValue).Set(float64(numRulesPaused))

--- a/pkg/services/ngalert/schedule/schedule.go
+++ b/pkg/services/ngalert/schedule/schedule.go
@@ -204,19 +204,32 @@ type readyToRunItem struct {
 }
 
 func (sch *schedule) updateRulesMetrics(alertRules []*ngmodels.AlertRule) {
-	rulesPerOrg := make(map[int64]int64)
-	orgsPaused := make(map[int64]int64)
+	rulesPerOrg := make(map[int64]int64)                // orgID -> count
+	orgsPaused := make(map[int64]int64)                 // orgID -> count
+	groupsPerOrg := make(map[int64]map[string]struct{}) // orgID -> set of groups
 	for _, rule := range alertRules {
 		rulesPerOrg[rule.OrgID]++
+
 		if rule.IsPaused {
 			orgsPaused[rule.OrgID]++
 		}
+
+		orgGroups, ok := groupsPerOrg[rule.OrgID]
+		if !ok {
+			orgGroups = make(map[string]struct{})
+			groupsPerOrg[rule.OrgID] = orgGroups
+		}
+		orgGroups[rule.RuleGroup] = struct{}{}
 	}
 
 	for orgID, numRules := range rulesPerOrg {
 		numRulesPaused := orgsPaused[orgID]
 		sch.metrics.GroupRules.WithLabelValues(fmt.Sprint(orgID), metrics.AlertRuleActiveLabelValue).Set(float64(numRules - numRulesPaused))
 		sch.metrics.GroupRules.WithLabelValues(fmt.Sprint(orgID), metrics.AlertRulePausedLabelValue).Set(float64(numRulesPaused))
+	}
+
+	for orgID, groups := range groupsPerOrg {
+		sch.metrics.Groups.WithLabelValues(fmt.Sprint(orgID)).Set(float64(len(groups)))
 	}
 
 	// While these are the rules that we iterate over, at the moment there's no 100% guarantee that they'll be


### PR DESCRIPTION
**What is this feature?**

Adds a metric, `grafana_alerting_rule_groups`, which tracks rule groups.
The current metrics emitted by the scheduler only track rules.

This will also inform the cardinality impact of adding rule_group as a label, like how Prometheus works.

**Why do we need this feature?**
n/a

**Who is this feature for?**
operators, anyone observing Grafana

**Which issue(s) does this PR fix?**:

n/a

**Special notes for your reviewer:**

Please check that:
- [X] It works as expected from a user's perspective.
- [X] If this is a pre-GA feature, it is behind a feature toggle.
- [X] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
