### PR TITLE
Stat: Fix data links that refer to fields

### DIFF
--- a/packages/grafana-data/src/field/fieldDisplay.ts
+++ b/packages/grafana-data/src/field/fieldDisplay.ts
@@ -204,6 +204,25 @@ export const getFieldDisplayValues = (options: GetFieldDisplayValuesOptions): Fi
             }
           }
 
+          // If there is only one row in the data frame, then set the
+          // valueRowIndex to that one row. This allows the data macros in
+          // things like links to access other fields from the data frame.
+          //
+          // If there were more rows, it still may be sane to set the row
+          // index, but it may be confusing; the calculation may have
+          // selected a value from a different row or it may have aggregated
+          // the values from multiple rows, so to make just the first row
+          // available would be arbitrary. For now, the users will have to
+          // ensure that the data frame has just one row if they want data
+          // link referencing other fields to work.
+          //
+          // TODO: A more complete solution here would be to allow the
+          // calculation to report a relevant row and use that value. For
+          // example, a common calculation is 'lastNotNull'. It'd be nifty to
+          // know which row the display value corresponds to in that case if
+          // there were potentially many
+          const valueRowIndex = dataFrame.length === 1 ? 0 : undefined;
+
           values.push({
             name: calc,
             field: config,
@@ -215,6 +234,7 @@ export const getFieldDisplayValues = (options: GetFieldDisplayValuesOptions): Fi
               ? () =>
                   fieldLinksSupplier({
                     calculatedValue: displayValue,
+                    valueRowIndex,
                   })
               : () => [],
             hasLinks: hasLinks(field),


### PR DESCRIPTION




**What is this feature?**

Fixes a bug whereby data links in Stat panels (and probably other "reduced" data panels) could not refer to the `${__data.fields}` macros available in other panels.

For these panels, data links which referred to fields did not end up rendering because the rowIndex ended up being undefined. When the row index is undefined, the data macro expansion for fields does not trigger (see [0]).

**Why do we need this feature?**

It's often very nice to link to data that you are not displaying. See the chatter in #60297.

**Who is this feature for?**

Grafana users who like data links.

**Which issue(s) does this PR fix?**:

Fixes #60297

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
    - I tested it manually; I don't have the context on how to write the appropriate test. All the tests passed.
    
[0]: https://github.com/grafana/grafana/blob/878ba96a/public/app/features/templating/dataMacros.ts#L99-L101
