### PR TITLE
Alerting: Fix state sync errors counter increment

### DIFF
--- a/pkg/services/ngalert/remote/alertmanager.go
+++ b/pkg/services/ngalert/remote/alertmanager.go
@@ -205,7 +205,7 @@ func (am *Alertmanager) CompareAndSendState(ctx context.Context) error {
 	if am.shouldSendState(ctx, state) {
 		am.metrics.StateSyncsTotal.Inc()
 		if err := am.mimirClient.CreateGrafanaAlertmanagerState(ctx, state); err != nil {
-			am.metrics.ConfigSyncErrorsTotal.Inc()
+			am.metrics.StateSyncErrorsTotal.Inc()
 			return err
 		}
 		am.metrics.LastStateSync.SetToCurrentTime()


### PR DESCRIPTION
We're incrementing the wrong counter when failing a state sync attempt.