### PR TITLE
DataTrails: Fixes heatmap 

### DIFF
--- a/public/app/features/trails/AutomaticMetricQueries/query-generators/bucket/index.ts
+++ b/public/app/features/trails/AutomaticMetricQueries/query-generators/bucket/index.ts
@@ -68,11 +68,11 @@ function baseQuery(groupings: string[] = []) {
   return `sum by(${sumByList.join(', ')}) (${BASE_QUERY})`;
 }
 
-function heatMapQuery(groupings: string[] = []) {
+function heatMapQuery(groupings: string[] = []): PromQuery {
   return {
     refId: 'A',
     expr: baseQuery(groupings),
-    legendFormat: '{{le}}',
+    format: 'heatmap',
   };
 }
 

--- a/public/app/features/trails/AutomaticMetricQueries/query-generators/bucket/index.ts
+++ b/public/app/features/trails/AutomaticMetricQueries/query-generators/bucket/index.ts
@@ -72,6 +72,7 @@ function heatMapQuery(groupings: string[] = []) {
   return {
     refId: 'A',
     expr: baseQuery(groupings),
+    legendFormat: '{{le}}',
   };
 }
 


### PR DESCRIPTION
https://github.com/grafana/grafana/pull/80170 broke the heatmap, the heatmap query after that change is missing the `format: heatmap`


Before:
<img width="517" alt="Screenshot 2024-01-17 at 10 09 06" src="https://github.com/grafana/grafana/assets/10999/d642c79d-8b51-4476-a75f-4760961c6acb">

After:
<img width="586" alt="Screenshot 2024-01-17 at 10 10 56" src="https://github.com/grafana/grafana/assets/10999/9f857d28-4d3c-4993-96d5-b5f88cf660ea">
