### PR TITLE
Chore: Improve typing for onPanelConfigChange

### DIFF
--- a/public/app/features/dashboard/components/PanelEditor/getPanelFrameOptions.tsx
+++ b/public/app/features/dashboard/components/PanelEditor/getPanelFrameOptions.tsx
@@ -125,7 +125,7 @@ export function getPanelFrameCategory(props: OptionPaneRenderProps): OptionsPane
                 <RepeatRowSelect
                   id="repeat-by-variable-select"
                   repeat={panel.repeat}
-                  onChange={(value?: string | null) => {
+                  onChange={(value?: string) => {
                     onPanelConfigChange('repeat', value);
                   }}
                 />

--- a/public/app/features/dashboard/components/PanelEditor/types.ts
+++ b/public/app/features/dashboard/components/PanelEditor/types.ts
@@ -56,7 +56,7 @@ export interface OptionPaneRenderProps {
   data?: PanelData;
   dashboard: DashboardModel;
   instanceState: unknown;
-  onPanelConfigChange: (configKey: keyof PanelModel, value: unknown) => void;
+  onPanelConfigChange: <T extends keyof PanelModel>(configKey: T, value: PanelModel[T]) => void;
   onPanelOptionsChanged: (options: PanelModel['options']) => void;
   onFieldConfigsChange: (config: FieldConfigSource) => void;
 }

--- a/public/app/features/dashboard/components/RepeatRowSelect/RepeatRowSelect.tsx
+++ b/public/app/features/dashboard/components/RepeatRowSelect/RepeatRowSelect.tsx
@@ -8,8 +8,8 @@ import { getLastKey, getVariablesByKey } from '../../../variables/state/selector
 
 export interface Props {
   id?: string;
-  repeat?: string | null;
-  onChange: (name: string | null) => void;
+  repeat?: string;
+  onChange: (name?: string) => void;
 }
 
 export const RepeatRowSelect = ({ repeat, onChange, id }: Props) => {

--- a/public/app/features/dashboard/components/RowOptions/RowOptionsButton.tsx
+++ b/public/app/features/dashboard/components/RowOptions/RowOptionsButton.tsx
@@ -7,7 +7,7 @@ import { RowOptionsModal } from './RowOptionsModal';
 
 export interface RowOptionsButtonProps {
   title: string;
-  repeat?: string | null;
+  repeat?: string;
   onUpdate: OnRowOptionsUpdate;
   warning?: React.ReactNode;
 }

--- a/public/app/features/dashboard/components/RowOptions/RowOptionsForm.tsx
+++ b/public/app/features/dashboard/components/RowOptions/RowOptionsForm.tsx
@@ -9,15 +9,15 @@ export type OnRowOptionsUpdate = (title: string, repeat?: string | null) => void
 
 export interface Props {
   title: string;
-  repeat?: string | null;
+  repeat?: string;
   onUpdate: OnRowOptionsUpdate;
   onCancel: () => void;
   warning?: React.ReactNode;
 }
 
 export const RowOptionsForm = ({ repeat, title, warning, onUpdate, onCancel }: Props) => {
-  const [newRepeat, setNewRepeat] = useState<string | null | undefined>(repeat);
-  const onChangeRepeat = useCallback((name?: string | null) => setNewRepeat(name), [setNewRepeat]);
+  const [newRepeat, setNewRepeat] = useState<string | undefined>(repeat);
+  const onChangeRepeat = useCallback((name?: string) => setNewRepeat(name), [setNewRepeat]);
 
   return (
     <Form

--- a/public/app/features/dashboard/components/RowOptions/RowOptionsModal.tsx
+++ b/public/app/features/dashboard/components/RowOptions/RowOptionsModal.tsx
@@ -7,7 +7,7 @@ import { OnRowOptionsUpdate, RowOptionsForm } from './RowOptionsForm';
 
 export interface RowOptionsModalProps {
   title: string;
-  repeat?: string | null;
+  repeat?: string;
   warning?: React.ReactNode;
   onDismiss: () => void;
   onUpdate: OnRowOptionsUpdate;


### PR DESCRIPTION
Changes type of `onPanelConfigChange` so the type of `value` is the appropriate type for the `configKey`.
Also removes some instances of `null` where `undefined` is fine.