### PR TITLE
Users: OSS not using Orgs for users table showing

### DIFF
--- a/public/app/features/admin/Users/UsersTable.tsx
+++ b/public/app/features/admin/Users/UsersTable.tsx
@@ -1,4 +1,5 @@
 import React, { useMemo } from 'react';
+import { UseTableRowProps } from 'react-table';
 
 import {
   Avatar,
@@ -38,6 +39,7 @@ export const UsersTable = ({
   fetchData,
 }: UsersTableProps) => {
   const showLicensedRole = useMemo(() => users.some((user) => user.licensedRole), [users]);
+  const showBelongsTo = useMemo(() => users.some((user) => user.orgs), [users]);
   const columns: Array<Column<UserDTO>> = useMemo(
     () => [
       {
@@ -63,23 +65,27 @@ export const UsersTable = ({
         cell: ({ cell: { value } }: Cell<'name'>) => value,
         sortType: 'string',
       },
-      {
-        id: 'orgs',
-        header: 'Belongs to',
-        cell: ({ cell: { value, row } }: Cell<'orgs'>) => {
-          return (
-            <Stack alignItems={'center'}>
-              <OrgUnits units={value} icon={'building'} />
-              {row.original.isAdmin && (
-                <Tooltip placement="top" content="Grafana Admin">
-                  <Icon name="shield" />
-                </Tooltip>
-              )}
-            </Stack>
-          );
-        },
-        sortType: (a, b) => (a.original.orgs?.length || 0) - (b.original.orgs?.length || 0),
-      },
+      ...(showBelongsTo
+        ? [
+            {
+              id: 'orgs',
+              header: 'Belongs to',
+              cell: ({ cell: { value, row } }: Cell<'orgs'>) => {
+                return (
+                  <Stack alignItems={'center'}>
+                    <OrgUnits units={value} icon={'building'} />
+                    {row.original.isAdmin && (
+                      <Tooltip placement="top" content="Grafana Admin">
+                        <Icon name="shield" />
+                      </Tooltip>
+                    )}
+                  </Stack>
+                );
+              },
+              sortType: (a: UseTableRowProps<UserDTO>, b: UseTableRowProps<UserDTO>) => (a.original.orgs?.length || 0) - (b.original.orgs?.length || 0),
+            },
+          ]
+        : []),
       ...(showLicensedRole
         ? [
             {
@@ -140,7 +146,7 @@ export const UsersTable = ({
         },
       },
     ],
-    [showLicensedRole]
+    [showLicensedRole, showBelongsTo]
   );
   return (
     <Stack direction={'column'} gap={2}>

--- a/public/app/features/admin/Users/UsersTable.tsx
+++ b/public/app/features/admin/Users/UsersTable.tsx
@@ -82,7 +82,8 @@ export const UsersTable = ({
                   </Stack>
                 );
               },
-              sortType: (a: UseTableRowProps<UserDTO>, b: UseTableRowProps<UserDTO>) => (a.original.orgs?.length || 0) - (b.original.orgs?.length || 0),
+              sortType: (a: UseTableRowProps<UserDTO>, b: UseTableRowProps<UserDTO>) =>
+                (a.original.orgs?.length || 0) - (b.original.orgs?.length || 0),
             },
           ]
         : []),


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**
Remove the column "Belongs to" for OSS users

The org sorting returns 400 error not able to sort about orgs because there is none.

https://github.com/grafana/identity-access-team/assets/7727602/fe82b069-881e-4aea-8f43-b4c6e99d8e05

**Why do we need this feature?**
As a user I am not able to sort the users in OSS as we are not popluating the interactive table with orgs.

Options for solving this issue

**Remove "Belongs to" for OSS**
- this would remove the error and also remove a unnecessary column

**Introduce Org lookups in OSS to align with enterprise**
- this would involve another inner join on the search query for OSS, much like we have with enterprise

**Remove the sorting of this column in OSS**