### PR TITLE
Plugins: Fix enable button to appear after installing APP plugin

### DIFF
--- a/public/app/features/plugins/admin/components/GetStartedWithPlugin/GetStartedWithApp.tsx
+++ b/public/app/features/plugins/admin/components/GetStartedWithPlugin/GetStartedWithApp.tsx
@@ -19,9 +19,8 @@ export function GetStartedWithApp({ plugin }: Props): React.ReactElement | null 
   if (!pluginConfig) {
     return null;
   }
-
   // Enforce RBAC
-  if (!contextSrv.hasPermissionInMetadata(AccessControlAction.PluginsWrite, plugin)) {
+  if (!contextSrv.hasPermission(AccessControlAction.PluginsWrite)) {
     return null;
   }
 

--- a/public/app/features/plugins/admin/hooks/usePluginConfig.tsx
+++ b/public/app/features/plugins/admin/hooks/usePluginConfig.tsx
@@ -9,7 +9,7 @@ export const usePluginConfig = (plugin?: CatalogPlugin) => {
       return null;
     }
 
-    if (plugin.isFullyInstalled && !plugin.isDisabled) {
+    if (plugin.isInstalled && !plugin.isDisabled) {
       return loadPlugin(plugin.id);
     }
     return null;


### PR DESCRIPTION
**What is this feature?**
Fix of a bug

**Why do we need this feature?**
After installing App plugin we did not see Enable button. It was appearing only after the refresh. First problem was with new changes introduced after improving plugin installation and isFullyInstalled flag and also roles checking while loading the plugin. Plugin object did not have accessControl property and that is why roles were always wrong

**Which issue(s) does this PR fix?**:
Fixes #78003


