### PR TITLE
Alerting: Fix Graphite subqueries

### DIFF
--- a/public/app/features/alerting/unified/components/rule-editor/QueryWrapper.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/QueryWrapper.tsx
@@ -136,6 +136,9 @@ export const QueryWrapper = ({
   }
 
   const showVizualisation = data.state !== LoadingState.NotStarted;
+  // ⚠️ the query editors want the entire array of queries passed as "DataQuery" NOT "AlertQuery"
+  // TypeScript isn't complaining here because the interfaces just happen to be compatible
+  const editorQueries = cloneDeep(queries.map((query) => query.model));
 
   return (
     <Stack direction="column" gap={0.5}>
@@ -155,7 +158,7 @@ export const QueryWrapper = ({
           onRemoveQuery={onRemoveQuery}
           onAddQuery={() => onDuplicateQuery(cloneDeep(query))}
           onRunQuery={onRunQueries}
-          queries={queries}
+          queries={editorQueries}
           renderHeaderExtras={() => <HeaderExtras query={query} index={index} error={error} />}
           app={CoreApp.UnifiedAlerting}
           hideDisableQuery={true}

--- a/public/app/plugins/datasource/graphite/state/context.tsx
+++ b/public/app/plugins/datasource/graphite/state/context.tsx
@@ -76,7 +76,7 @@ export const GraphiteQueryEditorContext = ({
     () => {
       if (needsRefresh && state) {
         setNeedsRefresh(false);
-        onChange({ ...query, target: state.target.target });
+        onChange({ ...query, target: state.target.target, targetFull: state.target.targetFull });
         onRunQuery();
       }
     },
@@ -92,8 +92,8 @@ export const GraphiteQueryEditorContext = ({
         datasource: datasource,
         range: range,
         templateSrv: getTemplateSrv(),
-        // list of queries is passed only when the editor is in Dashboards. This is to allow interpolation
-        // of sub-queries which are stored in "targetFull" property used by alerting in the backend.
+        // list of queries is passed only when the editor is in Dashboards or Alerting. This is to allow interpolation
+        // of sub-queries which are stored in "targetFull" property. This is used by alerting in the backend.
         queries: queries || [],
         refresh: () => {
           // do not run onChange/onRunQuery straight away to ensure the internal state gets updated first

--- a/public/app/plugins/datasource/graphite/types.ts
+++ b/public/app/plugins/datasource/graphite/types.ts
@@ -14,6 +14,7 @@ export interface GraphiteQuery extends DataQuery {
   queryType?: string;
   textEditor?: boolean;
   target?: string;
+  targetFull?: string;
   tags?: string[];
   fromAnnotations?: boolean;
 }


### PR DESCRIPTION
**What is this feature?**

This PR contains 2 notable changes to make Graphite subqueries work within alerting.

1. Alerting was passing an incorrect array of queries, TypeScript was not complaining here because the interface of `AlertQuery` is compatible with `DataQuery` (they both have `refId: string`) even though these are very different data structures.
2. The Alerting editor will track the state of its queries by listening to the `onChange` handler and writing the updates to its own state with a reducer. This PR adds the `targetFull` property to it so it can be recorded in the backend and used for rule evaluation.

**Special notes for your reviewer:**

I wasn't quite sure about the changes made to the Graphite editor and currently am a bit perplexed about why this does work for the panel editor. 

I'd love to get some feedback if I'm on the wrong track here and if we need a different approach.