### PR TITLE
Data trails: Avoid setting state in MetricScene component

### DIFF
--- a/public/app/features/trails/ActionTabs/AddToFiltersGraphAction.tsx
+++ b/public/app/features/trails/ActionTabs/AddToFiltersGraphAction.tsx
@@ -10,8 +10,6 @@ import {
 } from '@grafana/scenes';
 import { Button } from '@grafana/ui';
 
-import { getMetricSceneFor } from '../utils';
-
 export interface AddToFiltersGraphActionState extends SceneObjectState {
   frame: DataFrame;
 }
@@ -27,10 +25,6 @@ export class AddToFiltersGraphAction extends SceneObjectBase<AddToFiltersGraphAc
     if (Object.keys(labels).length !== 1) {
       return;
     }
-
-    // close action view
-    const metricScene = getMetricSceneFor(this);
-    metricScene.setActionView(undefined);
 
     const labelName = Object.keys(labels)[0];
 

--- a/public/app/features/trails/DataTrail.tsx
+++ b/public/app/features/trails/DataTrail.tsx
@@ -205,7 +205,7 @@ function getVariableSet(initialDS?: string, metric?: string, initialFilters?: Ad
         pluginId: metric === LOGS_METRIC ? 'loki' : 'prometheus',
       }),
       AdHocFiltersVariable.create({
-        name: 'filters',
+        name: VAR_FILTERS,
         datasource: trailDS,
         layout: 'vertical',
         filters: initialFilters ?? [],

--- a/public/app/features/trails/MetricScene.tsx
+++ b/public/app/features/trails/MetricScene.tsx
@@ -51,6 +51,14 @@ export class MetricScene extends SceneObjectBase<MetricSceneState> {
       body: state.body ?? buildGraphScene(state.metric),
       ...state,
     });
+
+    this.addActivationHandler(this._onActivate.bind(this));
+  }
+
+  private _onActivate() {
+    if (this.state.actionView === undefined) {
+      this.setActionView('overview');
+    }
   }
 
   getUrlState() {
@@ -118,10 +126,6 @@ export class MetricActionBar extends SceneObjectBase<MetricActionBarState> {
       getTrailStore().addBookmark(trail);
       setBookmarked(!isBookmarked);
     };
-
-    if (!actionView) {
-      metricScene.setActionView('overview');
-    }
 
     return (
       <Box paddingY={1}>


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

React doesn't allow setting state in the render path so this PR moves the code to select the default tab in a MetricScene to an activation handler.

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
