### PR TITLE
Loki: Remove getQueryOptions as not needed in tests

### DIFF
--- a/public/app/plugins/datasource/loki/datasource.test.ts
+++ b/public/app/plugins/datasource/loki/datasource.test.ts
@@ -122,6 +122,17 @@ const mockTimeRange = {
   raw: { from: dateTime(0), to: dateTime(1) },
 };
 
+const baseRequestOptions = {
+  requestId: '',
+  interval: '',
+  intervalMs: 1,
+  range: mockTimeRange,
+  scopedVars: {},
+  timezone: '',
+  app: '',
+  startTime: 1,
+};
+
 interface AdHocFilter {
   condition: string;
   key: string;
@@ -160,10 +171,11 @@ describe('LokiDatasource', () => {
       // and applyTemplateVariables is a convenient place to do that.
       const spy = jest.spyOn(ds, 'applyTemplateVariables');
 
-      const options = {
+      const options: DataQueryRequest<LokiQuery> = {
+        ...baseRequestOptions,
         targets: [{ expr: '{a="b"}', refId: 'B', maxLines: queryMaxLines }],
         app: app ?? CoreApp.Dashboard,
-      } as DataQueryRequest<LokiQuery>;
+      };
 
       const fetchMock = jest.fn().mockReturnValue(of({ data: testLogsResponse }));
       setBackendSrv({ ...origBackendSrv, fetch: fetchMock });
@@ -1239,40 +1251,40 @@ describe('LokiDatasource', () => {
     });
 
     it('creates provider for logs query', () => {
-      const options = {
+      const options: DataQueryRequest<LokiQuery> = {
+        ...baseRequestOptions,
         targets: [{ expr: '{label="value"}', refId: 'A', queryType: LokiQueryType.Range }],
-        range: { from: dateTime(), to: dateTime() },
-        scopedVars: {},
-      } as DataQueryRequest<LokiQuery>;
+      };
 
       expect(ds.getDataProvider(SupplementaryQueryType.LogsVolume, options)).toBeDefined();
     });
 
     it('does not create provider for metrics query', () => {
-      const options = {
+      const options: DataQueryRequest<LokiQuery> = {
+        ...baseRequestOptions,
         targets: [{ expr: 'rate({label="value"}[1m])', refId: 'A' }],
-      } as DataQueryRequest<LokiQuery>;
+      };
 
       expect(ds.getDataProvider(SupplementaryQueryType.LogsVolume, options)).not.toBeDefined();
     });
 
     it('creates provider if at least one query is a logs query', () => {
-      const options = {
-        range: { from: dateTime(), to: dateTime() },
-        scopedVars: {},
+      const options: DataQueryRequest<LokiQuery> = {
+        ...baseRequestOptions,
         targets: [
           { expr: 'rate({label="value"}[1m])', queryType: LokiQueryType.Range, refId: 'A' },
           { expr: '{label="value"}', queryType: LokiQueryType.Range, refId: 'B' },
         ],
-      } as DataQueryRequest<LokiQuery>;
+      };
 
       expect(ds.getDataProvider(SupplementaryQueryType.LogsVolume, options)).toBeDefined();
     });
 
     it('does not create provider if there is only an instant logs query', () => {
-      const options = {
+      const options: DataQueryRequest<LokiQuery> = {
+        ...baseRequestOptions,
         targets: [{ expr: '{label="value"', refId: 'A', queryType: LokiQueryType.Instant }],
-      } as DataQueryRequest<LokiQuery>;
+      };
 
       expect(ds.getDataProvider(SupplementaryQueryType.LogsVolume, options)).not.toBeDefined();
     });
@@ -1285,28 +1297,31 @@ describe('LokiDatasource', () => {
     });
 
     it('creates provider for metrics query', () => {
-      const options = {
+      const options: DataQueryRequest<LokiQuery> = {
+        ...baseRequestOptions,
         targets: [{ expr: 'rate({label="value"}[5m])', refId: 'A' }],
-      } as DataQueryRequest<LokiQuery>;
+      };
 
       expect(ds.getDataProvider(SupplementaryQueryType.LogsSample, options)).toBeDefined();
     });
 
     it('does not create provider for log query', () => {
-      const options = {
+      const options: DataQueryRequest<LokiQuery> = {
+        ...baseRequestOptions,
         targets: [{ expr: '{label="value"}', refId: 'A' }],
-      } as DataQueryRequest<LokiQuery>;
+      };
 
       expect(ds.getDataProvider(SupplementaryQueryType.LogsSample, options)).not.toBeDefined();
     });
 
     it('creates provider if at least one query is a metric query', () => {
-      const options = {
+      const options: DataQueryRequest<LokiQuery> = {
+        ...baseRequestOptions,
         targets: [
           { expr: 'rate({label="value"}[1m])', refId: 'A' },
           { expr: '{label="value"}', refId: 'B' },
         ],
-      } as DataQueryRequest<LokiQuery>;
+      };
 
       expect(ds.getDataProvider(SupplementaryQueryType.LogsSample, options)).toBeDefined();
     });
@@ -1555,10 +1570,11 @@ describe('LokiDatasource', () => {
       ],
     ])('supports query splitting when the requirements are met', async (targets: LokiQuery[]) => {
       const ds = createLokiDatasource(templateSrvStub);
-      const query = {
+      const query: DataQueryRequest<LokiQuery> = {
+        ...baseRequestOptions,
         targets,
         app: CoreApp.Dashboard,
-      } as DataQueryRequest<LokiQuery>;
+      };
 
       await expect(ds.query(query)).toEmitValuesWith(() => {
         expect(runSplitQuery).toHaveBeenCalled();

--- a/public/app/plugins/datasource/loki/getDerivedFields.test.ts
+++ b/public/app/plugins/datasource/loki/getDerivedFields.test.ts
@@ -3,7 +3,6 @@ import { createDataFrame } from '@grafana/data';
 import { getDerivedFields } from './getDerivedFields';
 
 jest.mock('@grafana/runtime', () => ({
-  // @ts-ignore
   ...jest.requireActual('@grafana/runtime'),
   getDataSourceSrv: () => {
     return {


### PR DESCRIPTION
Part of https://github.com/grafana/grafana/issues/72631

Removes `getQueryOptions` core dependency in tests as not needed and 1 not needed `// ts-ignore`. 