### PR TITLE
Pyroscope: Fix stale value for query in query editor

### DIFF
--- a/public/app/plugins/datasource/grafana-pyroscope-datasource/QueryEditor/QueryEditor.tsx
+++ b/public/app/plugins/datasource/grafana-pyroscope-datasource/QueryEditor/QueryEditor.tsx
@@ -1,6 +1,6 @@
 import deepEqual from 'fast-deep-equal';
 import { debounce } from 'lodash';
-import React, { MutableRefObject, useCallback, useEffect, useRef, useState } from 'react';
+import React, { useCallback, useEffect, useRef, useState } from 'react';
 
 import { CoreApp, QueryEditorProps, TimeRange } from '@grafana/data';
 import { LoadingPlaceholder } from '@grafana/ui';
@@ -27,12 +27,7 @@ export function QueryEditor(props: Props) {
     onRunQuery();
   }
 
-  // Need to reference the query as otherwise when the label selector is changed, only the initial value
-  // of the query is passed into the LabelsEditor (onChange) which renders the CodeEditor for monaco.
-  // The above needs to have a ref to the query so it can get the latest value.
-  const queryRef = useRef(query);
-  queryRef.current = query;
-  const onLabelSelectorChange = useLabelSelector(queryRef, onChange);
+  const onLabelSelectorChange = useLabelSelector(query, onChange);
 
   const profileTypes = useProfileTypes(datasource, range);
   const { labels, getLabelValues } = useLabels(range, datasource, query);
@@ -166,7 +161,13 @@ function useLabels(range: TimeRange | undefined, datasource: PyroscopeDataSource
   return { labels, getLabelValues };
 }
 
-function useLabelSelector(queryRef: MutableRefObject<Query>, onChange: (value: Query) => void) {
+function useLabelSelector(query: Query, onChange: (value: Query) => void) {
+  // Need to reference the query as otherwise when the label selector is changed, only the initial value
+  // of the query is passed into the LabelsEditor (onChange) which renders the CodeEditor for monaco.
+  // The above needs to have a ref to the query so it can get the latest value.
+  const queryRef = useRef(query);
+  queryRef.current = query;
+
   const onChangeDebounced = debounce((value: string) => {
     if (onChange) {
       onChange({ ...queryRef.current, labelSelector: value });


### PR DESCRIPTION
**What is this feature?**

Fixes issue with stale query value in Pyroscope query editor.

**Why do we need this feature?**

We need to reference the query as otherwise when it's passed into useLabels, only the initial value of the query is passed into the LabelsEditor (onChange) which renders the CodeEditor for Monaco. The above needs to have a ref to the query so it can get the latest value.

**Who is this feature for?**

Tempo users/

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes https://github.com/grafana/grafana/issues/80502
Fixes https://github.com/grafana/grafana/issues/80765

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
