### PR TITLE
AnnotationsPlugin2: Skip exemplar frames

### DIFF
--- a/public/app/plugins/panel/timeseries/plugins/AnnotationsPlugin2.tsx
+++ b/public/app/plugins/panel/timeseries/plugins/AnnotationsPlugin2.tsx
@@ -69,7 +69,7 @@ export const AnnotationsPlugin2 = ({
   const getColorByName = useTheme2().visualization.getColorByName;
 
   const annos = useMemo(() => {
-    let annos = annotations.slice();
+    let annos = annotations.filter((frame) => frame.name !== 'exemplar');
 
     if (newRange) {
       let isRegion = newRange.to > newRange.from;


### PR DESCRIPTION
AnnotationsPlugin2 expects either timestamp or timestamp range (region) annotation frames, so we need to filter out Exemplar frames that cause errors, and are rendered by ExemplarsPlugin.

adding this filter into the plugin itself is a bit meh, but less tedious than adding it to every panel that uses this plugin. we can revisit this in the future.