### PR TITLE
feat(alerting): add async state persister

### DIFF
--- a/pkg/services/ngalert/state/cache.go
+++ b/pkg/services/ngalert/state/cache.go
@@ -330,6 +330,36 @@ func (c *cache) removeByRuleUID(orgID int64, uid string) []*State {
 	return states
 }
 
+// asInstances returns the whole content of the cache as a slice of AlertInstance.
+func (c *cache) asInstances(skipNormalState bool) []ngModels.AlertInstance {
+	var states []ngModels.AlertInstance
+	c.mtxStates.RLock()
+	defer c.mtxStates.RUnlock()
+	for _, orgStates := range c.states {
+		for _, v1 := range orgStates {
+			for _, v2 := range v1.states {
+				if skipNormalState && IsNormalStateWithNoReason(v2) {
+					continue
+				}
+				key, err := v2.GetAlertInstanceKey()
+				if err != nil {
+					continue
+				}
+				states = append(states, ngModels.AlertInstance{
+					AlertInstanceKey:  key,
+					Labels:            ngModels.InstanceLabels(v2.Labels),
+					CurrentState:      ngModels.InstanceStateType(v2.State.String()),
+					CurrentReason:     v2.StateReason,
+					LastEvalTime:      v2.LastEvaluationTime,
+					CurrentStateSince: v2.StartsAt,
+					CurrentStateEnd:   v2.EndsAt,
+				})
+			}
+		}
+	}
+	return states
+}
+
 // if duplicate labels exist, keep the value from the first set
 func mergeLabels(a, b data.Labels) data.Labels {
 	newLbs := make(data.Labels, len(a)+len(b))

--- a/pkg/services/ngalert/state/cache.go
+++ b/pkg/services/ngalert/state/cache.go
@@ -353,6 +353,7 @@ func (c *cache) asInstances(skipNormalState bool) []ngModels.AlertInstance {
 					LastEvalTime:      v2.LastEvaluationTime,
 					CurrentStateSince: v2.StartsAt,
 					CurrentStateEnd:   v2.EndsAt,
+					ResultFingerprint: v2.ResultFingerprint.String(),
 				})
 			}
 		}

--- a/pkg/services/ngalert/state/persist.go
+++ b/pkg/services/ngalert/state/persist.go
@@ -14,6 +14,7 @@ type InstanceStore interface {
 	SaveAlertInstance(ctx context.Context, instance models.AlertInstance) error
 	DeleteAlertInstances(ctx context.Context, keys ...models.AlertInstanceKey) error
 	DeleteAlertInstancesByRule(ctx context.Context, key models.AlertRuleKey) error
+	FullSync(ctx context.Context, instances []models.AlertInstance) error
 }
 
 // RuleReader represents the ability to fetch alert rules.

--- a/pkg/services/ngalert/state/persister_async.go
+++ b/pkg/services/ngalert/state/persister_async.go
@@ -1,0 +1,62 @@
+package state
+
+import (
+	"context"
+	"time"
+
+	"github.com/benbjohnson/clock"
+	"go.opentelemetry.io/otel/trace"
+
+	"github.com/grafana/grafana/pkg/infra/log"
+)
+
+type AsyncStatePersister struct {
+	log log.Logger
+	// doNotSaveNormalState controls whether eval.Normal state is persisted to the database and returned by get methods.
+	doNotSaveNormalState bool
+	store                InstanceStore
+}
+
+func NewAsyncStatePersisiter(log log.Logger, cfg ManagerCfg) StatePersister {
+	return &AsyncStatePersister{
+		log:                  log,
+		store:                cfg.InstanceStore,
+		doNotSaveNormalState: cfg.DoNotSaveNormalState,
+	}
+}
+
+func (a *AsyncStatePersister) Async(ctx context.Context, ticker *clock.Ticker, cache *cache) {
+infLoop:
+	for {
+		select {
+		case <-ticker.C:
+			if err := a.fullSync(ctx, cache); err != nil {
+				a.log.Error("Failed to do a full state sync to database", "err", err)
+			}
+		case <-ctx.Done():
+			a.log.Info("Stopping state sync...")
+			if err := a.fullSync(context.Background(), cache); err != nil {
+				a.log.Error("Failed to do a full state sync to database", "err", err)
+			}
+			ticker.Stop()
+			break infLoop
+		}
+	}
+	a.log.Info("State sync shut down")
+}
+
+func (a *AsyncStatePersister) fullSync(ctx context.Context, cache *cache) error {
+	startTime := time.Now()
+	a.log.Info("Full state sync start")
+	instances := cache.asInstances(a.doNotSaveNormalState)
+	if err := a.store.FullSync(ctx, instances); err != nil {
+		a.log.Error("Full state sync failed", "duration", time.Since(startTime), "instances", len(instances))
+		return err
+	}
+	a.log.Info("Full state sync done", "duration", time.Since(startTime), "instances", len(instances))
+	return nil
+}
+
+func (a *AsyncStatePersister) Sync(_ context.Context, _ trace.Span, _, _ []StateTransition) {
+	a.log.Debug("Sync: No-Op")
+}

--- a/pkg/services/ngalert/state/persister_async_test.go
+++ b/pkg/services/ngalert/state/persister_async_test.go
@@ -1,0 +1,81 @@
+package state
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/benbjohnson/clock"
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/grafana/pkg/infra/log"
+	"github.com/grafana/grafana/pkg/services/ngalert/eval"
+)
+
+func TestAsyncStatePersister_Async(t *testing.T) {
+	t.Run("It should save on tick", func(t *testing.T) {
+		mockClock := clock.NewMock()
+		store := &FakeInstanceStore{}
+		logger := log.New("async.test")
+
+		persister := NewAsyncStatePersisiter(logger, ManagerCfg{
+			InstanceStore: store,
+		})
+
+		ctx, cancel := context.WithCancel(context.Background())
+
+		defer func() {
+			cancel()
+		}()
+
+		ticker := mockClock.Ticker(1 * time.Second)
+
+		cache := newCache()
+
+		go persister.Async(ctx, ticker, cache)
+
+		cache.set(&State{
+			OrgID:        1,
+			State:        eval.Alerting,
+			AlertRuleUID: "1",
+		})
+		// Let one tick pass
+		mockClock.Add(1 * time.Second)
+
+		// Check if the state was saved
+		require.Eventually(t, func() bool {
+			return len(store.RecordedOps) == 1
+		}, time.Second*5, time.Second)
+	})
+	t.Run("It should save on context done", func(t *testing.T) {
+		mockClock := clock.NewMock()
+		store := &FakeInstanceStore{}
+		logger := log.New("async.test")
+
+		persister := NewAsyncStatePersisiter(logger, ManagerCfg{
+			InstanceStore: store,
+		})
+
+		ctx, cancel := context.WithCancel(context.Background())
+
+		ticker := mockClock.Ticker(1 * time.Second)
+
+		cache := newCache()
+
+		go persister.Async(ctx, ticker, cache)
+
+		cache.set(&State{
+			OrgID:        1,
+			State:        eval.Alerting,
+			AlertRuleUID: "1",
+		})
+
+		// Now we cancel the context
+		cancel()
+
+		// Check if the context cancellation was handled correctly
+		require.Eventually(t, func() bool {
+			return len(store.RecordedOps) == 1
+		}, time.Second*5, time.Second)
+	})
+}

--- a/pkg/services/ngalert/state/persister_async_test.go
+++ b/pkg/services/ngalert/state/persister_async_test.go
@@ -18,7 +18,7 @@ func TestAsyncStatePersister_Async(t *testing.T) {
 		store := &FakeInstanceStore{}
 		logger := log.New("async.test")
 
-		persister := NewAsyncStatePersisiter(logger, ManagerCfg{
+		persister := NewAsyncStatePersister(logger, ManagerCfg{
 			InstanceStore: store,
 		})
 
@@ -52,7 +52,7 @@ func TestAsyncStatePersister_Async(t *testing.T) {
 		store := &FakeInstanceStore{}
 		logger := log.New("async.test")
 
-		persister := NewAsyncStatePersisiter(logger, ManagerCfg{
+		persister := NewAsyncStatePersister(logger, ManagerCfg{
 			InstanceStore: store,
 		})
 

--- a/pkg/services/ngalert/state/testing.go
+++ b/pkg/services/ngalert/state/testing.go
@@ -53,6 +53,16 @@ func (f *FakeInstanceStore) DeleteAlertInstancesByRule(ctx context.Context, key 
 	return nil
 }
 
+func (f *FakeInstanceStore) FullSync(ctx context.Context, instances []models.AlertInstance) error {
+	f.mtx.Lock()
+	defer f.mtx.Unlock()
+	f.RecordedOps = []any{}
+	for _, instance := range instances {
+		f.RecordedOps = append(f.RecordedOps, instance)
+	}
+	return nil
+}
+
 type FakeRuleReader struct{}
 
 func (f *FakeRuleReader) ListAlertRules(_ context.Context, q *models.ListAlertRulesQuery) (models.RulesGroup, error) {

--- a/pkg/services/ngalert/store/instance_database.go
+++ b/pkg/services/ngalert/store/instance_database.go
@@ -9,6 +9,7 @@ import (
 	"github.com/grafana/grafana/pkg/infra/db"
 	"github.com/grafana/grafana/pkg/services/featuremgmt"
 	"github.com/grafana/grafana/pkg/services/ngalert/models"
+	"github.com/grafana/grafana/pkg/services/sqlstore"
 )
 
 // ListAlertInstances is a handler for retrieving alert instances within specific organisation
@@ -195,5 +196,41 @@ func (st DBstore) DeleteAlertInstancesByRule(ctx context.Context, key models.Ale
 	return st.SQLStore.WithTransactionalDbSession(ctx, func(sess *db.Session) error {
 		_, err := sess.Exec("DELETE FROM alert_instance WHERE rule_org_id = ? AND rule_uid = ?", key.OrgID, key.UID)
 		return err
+	})
+}
+
+func (st DBstore) FullSync(ctx context.Context, instances []models.AlertInstance) error {
+	if len(instances) == 0 {
+		return nil
+	}
+	return st.SQLStore.WithTransactionalDbSession(ctx, func(sess *sqlstore.DBSession) error {
+		// First we delete all records from the table
+		if _, err := sess.Exec("DELETE FROM alert_instance"); err != nil {
+			return fmt.Errorf("failed to delete alert_instance table: %w", err)
+		}
+		for _, alertInstance := range instances {
+			if err := models.ValidateAlertInstance(alertInstance); err != nil {
+				st.Logger.Warn("Failed to validate alert instance, skipping", "err", err, "rule_uid", alertInstance.RuleUID)
+				continue
+			}
+			labelTupleJSON, err := alertInstance.Labels.StringKey()
+			if err != nil {
+				st.Logger.Warn("Failed to generate alert instance labels key, skipping", "err", err, "rule_uid", alertInstance.RuleUID)
+				continue
+			}
+
+			_, err = sess.Exec("INSERT INTO alert_instance (rule_org_id, rule_uid, labels, labels_hash, current_state, current_reason, current_state_since, current_state_end, last_eval_time) VALUES (?,?,?,?,?,?,?,?,?)",
+				alertInstance.RuleOrgID, alertInstance.RuleUID, labelTupleJSON, alertInstance.LabelsHash, alertInstance.CurrentState, alertInstance.CurrentReason, alertInstance.CurrentStateSince.Unix(), alertInstance.CurrentStateEnd.Unix(), alertInstance.LastEvalTime.Unix())
+			if err != nil {
+				if rbErr := sess.Rollback(); rbErr != nil {
+					st.Logger.Error("Failed to roll back on full sync", "err", rbErr)
+				}
+				return fmt.Errorf("failed to insert into alert_instance table: %w", err)
+			}
+		}
+		if err := sess.Commit(); err != nil {
+			return fmt.Errorf("failed to commit alert_instance table: %w", err)
+		}
+		return nil
 	})
 }

--- a/pkg/services/ngalert/store/instance_database.go
+++ b/pkg/services/ngalert/store/instance_database.go
@@ -222,9 +222,6 @@ func (st DBstore) FullSync(ctx context.Context, instances []models.AlertInstance
 			_, err = sess.Exec("INSERT INTO alert_instance (rule_org_id, rule_uid, labels, labels_hash, current_state, current_reason, current_state_since, current_state_end, last_eval_time) VALUES (?,?,?,?,?,?,?,?,?)",
 				alertInstance.RuleOrgID, alertInstance.RuleUID, labelTupleJSON, alertInstance.LabelsHash, alertInstance.CurrentState, alertInstance.CurrentReason, alertInstance.CurrentStateSince.Unix(), alertInstance.CurrentStateEnd.Unix(), alertInstance.LastEvalTime.Unix())
 			if err != nil {
-				if rbErr := sess.Rollback(); rbErr != nil {
-					st.Logger.Error("Failed to roll back on full sync", "err", rbErr)
-				}
 				return fmt.Errorf("failed to insert into alert_instance table: %w", err)
 			}
 		}


### PR DESCRIPTION
The second part of #80384, adds the async implementation of this interface. This PR is not enabling anything and just adds the implementation and tests.