### PR TITLE
Alerting: Fix using required groupBy options validation in simplified routing settings

### DIFF
--- a/public/app/features/alerting/unified/components/rule-editor/alert-rule-form/simplifiedRouting/route-settings/RouteSettings.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/alert-rule-form/simplifiedRouting/route-settings/RouteSettings.tsx
@@ -62,7 +62,7 @@ export const RoutingSettings = ({ alertManager }: RoutingSettingsProps) => {
         <Field
           label="Group by"
           description="Group alerts when you receive a notification based on labels. If empty it will be inherited from the default notification policy."
-          {...register(`contactPoints.${alertManager}.groupBy`, { required: true })}
+          {...register(`contactPoints.${alertManager}.groupBy`)}
           invalid={!!errors.contactPoints?.[alertManager]?.groupBy}
           className={styles.optionalContent}
         >


### PR DESCRIPTION

**What is this feature?**

This PR fix validation for groupBy not been shown correctly in routing settings section when using simplified routing.
Using `{required: true}` was wrong as we are using the `rules` in `InputControl` for this validation.

After the change:

<img width="1067" alt="Screenshot 2024-01-18 at 08 45 27" src="https://github.com/grafana/grafana/assets/33540275/e1e3e1a1-7144-4c84-8a9f-de990df7ff50">

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
