### PR TITLE
Fix output of breaking change check

### DIFF
--- a/.github/workflows/detect-breaking-changes-levitate.yml
+++ b/.github/workflows/detect-breaking-changes-levitate.yml
@@ -229,7 +229,7 @@ jobs:
             header: levitate-breaking-change-comment
             number: ${{ github.event.pull_request.number }}
             message: |
-              ⚠️ &nbsp;&nbsp;**Possible breaking changes (md version)*** &nbsp;&nbsp ⚠️
+              ⚠️ &nbsp;&nbsp;**Possible breaking changes (md version)**&nbsp;&nbsp; ⚠️
 
               ${{ steps.levitate-markdown.outputs.levitate_markdown }}
 


### PR DESCRIPTION
Minor fix on the output of the check for breaking changes. Current header output:
<img width="417" alt="Screenshot 2024-01-18 at 13 32 11" src="https://github.com/grafana/grafana/assets/135109076/f1057811-1802-439a-9cff-c5a8b77308f5">
