### PR TITLE
Elasticsearch: Fix showing of logs when `__source` is log message field

### DIFF
--- a/pkg/tsdb/elasticsearch/response_parser.go
+++ b/pkg/tsdb/elasticsearch/response_parser.go
@@ -136,8 +136,14 @@ func processLogsResponse(res *es.SearchResponse, target *Query, configuredFields
 
 	for hitIdx, hit := range res.Hits.Hits {
 		var flattened map[string]interface{}
+		var sourceString string
 		if hit["_source"] != nil {
 			flattened = flatten(hit["_source"].(map[string]interface{}), 10)
+			sourceMarshalled, err := json.Marshal(flattened)
+			if err != nil {
+				return err
+			}
+			sourceString = string(sourceMarshalled)
 		}
 
 		doc := map[string]interface{}{
@@ -146,7 +152,8 @@ func processLogsResponse(res *es.SearchResponse, target *Query, configuredFields
 			"_index":    hit["_index"],
 			"sort":      hit["sort"],
 			"highlight": hit["highlight"],
-			"_source":   flattened,
+			// In case of logs query we want to have the raw source as a string field so it can be visualized in logs panel
+			"_source": sourceString,
 		}
 
 		for k, v := range flattened {

--- a/pkg/tsdb/elasticsearch/response_parser_test.go
+++ b/pkg/tsdb/elasticsearch/response_parser_test.go
@@ -129,7 +129,7 @@ func TestProcessLogsResponse(t *testing.T) {
 			require.Equal(t, data.FieldTypeNullableFloat64, logsFieldMap["number"].Type())
 
 			require.Contains(t, logsFieldMap, "_source")
-			require.Equal(t, data.FieldTypeNullableJSON, logsFieldMap["_source"].Type())
+			require.Equal(t, data.FieldTypeNullableString, logsFieldMap["_source"].Type())
 
 			requireStringAt(t, "fdsfs", logsFieldMap["_id"], 0)
 			requireStringAt(t, "kdospaidopa", logsFieldMap["_id"], 1)
@@ -138,10 +138,8 @@ func TestProcessLogsResponse(t *testing.T) {
 			requireStringAt(t, "mock-index", logsFieldMap["_index"], 0)
 			requireStringAt(t, "mock-index", logsFieldMap["_index"], 1)
 
-			actualJson1, err := json.Marshal(logsFieldMap["_source"].At(0).(*json.RawMessage))
-			require.NoError(t, err)
-			actualJson2, err := json.Marshal(logsFieldMap["_source"].At(1).(*json.RawMessage))
-			require.NoError(t, err)
+			actualJson1 := logsFieldMap["_source"].At(0).(*string)
+			actualJson2 := logsFieldMap["_source"].At(1).(*string)
 
 			expectedJson1 := `
 					{
@@ -165,8 +163,8 @@ func TestProcessLogsResponse(t *testing.T) {
 						"fields.lvl": "info"
 					}`
 
-			require.JSONEq(t, expectedJson1, string(actualJson1))
-			require.JSONEq(t, expectedJson2, string(actualJson2))
+			require.JSONEq(t, expectedJson1, *actualJson1)
+			require.JSONEq(t, expectedJson2, *actualJson2)
 		})
 
 		t.Run("creates correct level field", func(t *testing.T) {

--- a/pkg/tsdb/elasticsearch/testdata_response/logs.a.golden.jsonc
+++ b/pkg/tsdb/elasticsearch/testdata_response/logs.a.golden.jsonc
@@ -19,7 +19,7 @@
 //  +-----------------------------------+---------------------------+----------------------+-----------------+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+--------------------------+-----------------+------------------+--------------------+--------------------------------------------------------------------------------------------------------------------------------+--------------------------------------+---------------+-----------------+-----------------+-----------------------------------------+------------------------------------+---------------------------------------------------------------------------------+--------------------------+
 //  | Name: testtime                    | Name: line                | Name: _id            | Name: _index    | Name: _source                                                                                                                                                                                                                                                                                                                                 | Name: _type              | Name: abc       | Name: counter    | Name: float        | Name: highlight                                                                                                                | Name: id                             | Name: is_true | Name: label     | Name: level     | Name: location                          | Name: nested_field.internal.nested | Name: shapes                                                                    | Name: sort               |
 //  | Labels:                           | Labels:                   | Labels:              | Labels:         | Labels:                                                                                                                                                                                                                                                                                                                                       | Labels:                  | Labels:         | Labels:          | Labels:            | Labels:                                                                                                                        | Labels:                              | Labels:       | Labels:         | Labels:         | Labels:                                 | Labels:                            | Labels:                                                                         | Labels:                  |
-//  | Type: []*time.Time                | Type: []*string           | Type: []*string      | Type: []*string | Type: []*json.RawMessage                                                                                                                                                                                                                                                                                                                      | Type: []*json.RawMessage | Type: []*string | Type: []*float64 | Type: []*float64   | Type: []*json.RawMessage                                                                                                       | Type: []*string                      | Type: []*bool | Type: []*string | Type: []*string | Type: []*string                         | Type: []*string                    | Type: []*json.RawMessage                                                        | Type: []*json.RawMessage |
+//  | Type: []*time.Time                | Type: []*string           | Type: []*string      | Type: []*string | Type: []*string                                                                                                                                                                                                                                                                                                                               | Type: []*json.RawMessage | Type: []*string | Type: []*float64 | Type: []*float64   | Type: []*json.RawMessage                                                                                                       | Type: []*string                      | Type: []*bool | Type: []*string | Type: []*string | Type: []*string                         | Type: []*string                    | Type: []*json.RawMessage                                                        | Type: []*json.RawMessage |
 //  +-----------------------------------+---------------------------+----------------------+-----------------+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+--------------------------+-----------------+------------------+--------------------+--------------------------------------------------------------------------------------------------------------------------------+--------------------------------------+---------------+-----------------+-----------------+-----------------------------------------+------------------------------------+---------------------------------------------------------------------------------+--------------------------+
 //  | 2023-02-09 14:40:01.475 +0000 UTC | log text  [106619125]     | g2aeNoYB7vaC3bq-ezfK | logs-2023.02.09 | {"abc":null,"counter":81,"float":10.911972180833306,"is_true":true,"label":"val3","line":"log text  [106619125]","location":"-42.73465234425797, -14.097854057104112","lvl":"info","nested_field.internal.nested":"value1","shapes":[{"type":"triangle"},{"type":"triangle"},{"type":"triangle"},{"type":"square"}],"testtime":"09/02/2023"}  | null                     | null            | 81               | 10.911972180833306 | {"duplicated":["@HIGHLIGHT@hello@/HIGHLIGHT@"],"line":["@HIGHLIGHT@hello@/HIGHLIGHT@, i am a @HIGHLIGHT@message@/HIGHLIGHT@"]} | logs-2023.02.09#g2aeNoYB7vaC3bq-ezfK | true          | val3            | info            | -42.73465234425797, -14.097854057104112 | value1                             | [{"type":"triangle"},{"type":"triangle"},{"type":"triangle"},{"type":"square"}] | [1675953601475,4]        |
 //  | 2023-02-09 14:40:00.513 +0000 UTC | log text with [781660944] | gmaeNoYB7vaC3bq-eDcN | logs-2023.02.09 | {"abc":null,"counter":80,"float":62.94120607636795,"is_true":false,"label":"val3","line":"log text with [781660944]","location":"42.07571917624318, 15.95725088484611","lvl":"error","nested_field.internal.nested":"value2","shapes":[{"type":"triangle"},{"type":"square"}],"testtime":"09/02/2023"}                                        | null                     | null            | 80               | 62.94120607636795  | {"duplicated":["@HIGHLIGHT@hello@/HIGHLIGHT@"],"line":["@HIGHLIGHT@hello@/HIGHLIGHT@, i am a @HIGHLIGHT@message@/HIGHLIGHT@"]} | logs-2023.02.09#gmaeNoYB7vaC3bq-eDcN | false         | val3            | error           | 42.07571917624318, 15.95725088484611    | value2                             | [{"type":"triangle"},{"type":"square"}]                                         | [1675953600513,7]        |
@@ -96,9 +96,9 @@
           },
           {
             "name": "_source",
-            "type": "other",
+            "type": "string",
             "typeInfo": {
-              "frame": "json.RawMessage",
+              "frame": "string",
               "nullable": true
             },
             "config": {
@@ -281,124 +281,11 @@
             "logs-2023.02.09"
           ],
           [
-            {
-              "abc": null,
-              "counter": 81,
-              "float": 10.911972180833306,
-              "is_true": true,
-              "label": "val3",
-              "line": "log text  [106619125]",
-              "location": "-42.73465234425797, -14.097854057104112",
-              "lvl": "info",
-              "nested_field.internal.nested": "value1",
-              "shapes": [
-                {
-                  "type": "triangle"
-                },
-                {
-                  "type": "triangle"
-                },
-                {
-                  "type": "triangle"
-                },
-                {
-                  "type": "square"
-                }
-              ],
-              "testtime": "09/02/2023"
-            },
-            {
-              "abc": null,
-              "counter": 80,
-              "float": 62.94120607636795,
-              "is_true": false,
-              "label": "val3",
-              "line": "log text with [781660944]",
-              "location": "42.07571917624318, 15.95725088484611",
-              "lvl": "error",
-              "nested_field.internal.nested": "value2",
-              "shapes": [
-                {
-                  "type": "triangle"
-                },
-                {
-                  "type": "square"
-                }
-              ],
-              "testtime": "09/02/2023"
-            },
-            {
-              "abc": "def",
-              "counter": 79,
-              "float": 53.323706427230455,
-              "is_true": true,
-              "label": "val1",
-              "line": "log text  [894867430]",
-              "location": "-38.27341566189766, -23.66739642570781",
-              "lvl": "info",
-              "nested_field.internal.nested": "value3",
-              "shapes": [
-                {
-                  "type": "triangle"
-                },
-                {
-                  "type": "square"
-                }
-              ],
-              "testtime": "09/02/2023"
-            },
-            {
-              "abc": "def",
-              "counter": 78,
-              "float": 82.72012623471589,
-              "is_true": false,
-              "label": "val1",
-              "line": "log text  [478598889]",
-              "location": "12.373240290451287, 43.265493464362024",
-              "lvl": "info",
-              "nested_field.internal.nested": "value4",
-              "shapes": [
-                {
-                  "type": "triangle"
-                },
-                {
-                  "type": "triangle"
-                },
-                {
-                  "type": "triangle"
-                },
-                {
-                  "type": "square"
-                }
-              ],
-              "testtime": "09/02/2023"
-            },
-            {
-              "abc": "def",
-              "counter": 77,
-              "float": 35.05784443331803,
-              "is_true": false,
-              "label": "val3",
-              "line": "log text  [526995818]",
-              "location": "-31.524344042228194, -32.11254790120572",
-              "lvl": "info",
-              "nested_field.internal.nested": "value5",
-              "shapes": [
-                {
-                  "type": "triangle"
-                },
-                {
-                  "type": "triangle"
-                },
-                {
-                  "type": "triangle"
-                },
-                {
-                  "type": "square"
-                }
-              ],
-              "testtime": "09/02/2023"
-            }
+            "{\"abc\":null,\"counter\":81,\"float\":10.911972180833306,\"is_true\":true,\"label\":\"val3\",\"line\":\"log text  [106619125]\",\"location\":\"-42.73465234425797, -14.097854057104112\",\"lvl\":\"info\",\"nested_field.internal.nested\":\"value1\",\"shapes\":[{\"type\":\"triangle\"},{\"type\":\"triangle\"},{\"type\":\"triangle\"},{\"type\":\"square\"}],\"testtime\":\"09/02/2023\"}",
+            "{\"abc\":null,\"counter\":80,\"float\":62.94120607636795,\"is_true\":false,\"label\":\"val3\",\"line\":\"log text with [781660944]\",\"location\":\"42.07571917624318, 15.95725088484611\",\"lvl\":\"error\",\"nested_field.internal.nested\":\"value2\",\"shapes\":[{\"type\":\"triangle\"},{\"type\":\"square\"}],\"testtime\":\"09/02/2023\"}",
+            "{\"abc\":\"def\",\"counter\":79,\"float\":53.323706427230455,\"is_true\":true,\"label\":\"val1\",\"line\":\"log text  [894867430]\",\"location\":\"-38.27341566189766, -23.66739642570781\",\"lvl\":\"info\",\"nested_field.internal.nested\":\"value3\",\"shapes\":[{\"type\":\"triangle\"},{\"type\":\"square\"}],\"testtime\":\"09/02/2023\"}",
+            "{\"abc\":\"def\",\"counter\":78,\"float\":82.72012623471589,\"is_true\":false,\"label\":\"val1\",\"line\":\"log text  [478598889]\",\"location\":\"12.373240290451287, 43.265493464362024\",\"lvl\":\"info\",\"nested_field.internal.nested\":\"value4\",\"shapes\":[{\"type\":\"triangle\"},{\"type\":\"triangle\"},{\"type\":\"triangle\"},{\"type\":\"square\"}],\"testtime\":\"09/02/2023\"}",
+            "{\"abc\":\"def\",\"counter\":77,\"float\":35.05784443331803,\"is_true\":false,\"label\":\"val3\",\"line\":\"log text  [526995818]\",\"location\":\"-31.524344042228194, -32.11254790120572\",\"lvl\":\"info\",\"nested_field.internal.nested\":\"value5\",\"shapes\":[{\"type\":\"triangle\"},{\"type\":\"triangle\"},{\"type\":\"triangle\"},{\"type\":\"square\"}],\"testtime\":\"09/02/2023\"}"
           ],
           [
             null,


### PR DESCRIPTION
The Logs panel currently presents the first string data frame field as the log message. However, when the Elasticsearch response undergoes processing through the backend, we set the `_source` field to the type of `*json.RawMessage` which is on frontend represented as `other`. Consequently, it is skipped, and the subsequent field is displayed as the log message.

This PR addresses the problem by ensuring that for log queries, the `__source` is set as the string results, resolving the issue.

Fixed: 
<img width="929" alt="image" src="https://github.com/grafana/grafana/assets/30407135/45e2f7dc-7e6b-4704-9df6-9a838786e75b">
<img width="1498" alt="image" src="https://github.com/grafana/grafana/assets/30407135/a83f42a4-7b46-4e0b-bc77-6cc204354ec5">

Current main:
<img width="1504" alt="image" src="https://github.com/grafana/grafana/assets/30407135/9eede7e2-7cec-40e9-9358-05fd6e60a06f">

Related to: https://github.com/grafana/grafana/issues/78790

To test:
1. Run make devenv sources=elastic
1. Create Elasticsearch data source and set log message field to `__source`
1. Go to Explore and ensure that log message is from `__source` field
