### PR TITLE
Auth: Fix identifying rendering request

### DIFF
--- a/pkg/api/index.go
+++ b/pkg/api/index.go
@@ -221,6 +221,8 @@ func (hs *HTTPServer) getUserAuthenticatedBy(c *contextmodel.ReqContext, userID 
 		return ""
 	}
 
+	// Special case for image renderer. Frontend relies on this information
+	// to render dashboards in a bit different way.
 	if c.IsRenderCall {
 		return login.RenderModule
 	}

--- a/pkg/api/index.go
+++ b/pkg/api/index.go
@@ -221,6 +221,10 @@ func (hs *HTTPServer) getUserAuthenticatedBy(c *contextmodel.ReqContext, userID 
 		return ""
 	}
 
+	if c.IsRenderCall {
+		return login.RenderModule
+	}
+
 	info, err := hs.authInfoService.GetAuthInfo(c.Req.Context(), &login.GetAuthInfoQuery{UserId: userID})
 	// we ignore errors where a user does not have external user auth
 	if err != nil && !errors.Is(err, user.ErrUserNotFound) {


### PR DESCRIPTION
**What is this feature?**

This PR fixes an issue with image renderer after changes introduced in https://github.com/grafana/grafana/pull/80345

**Why do we need this feature?**

Image renderer relies on `AuthenticatedBy` field populated in the boot data. It should be correctly set to "renderer" in case of image renderer call. https://github.com/grafana/grafana/pull/73190

**Who is this feature for?**

[Add information on what kind of user the feature is for.]

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Before:
![Screenshot from 2024-01-18 14-55-13](https://github.com/grafana/grafana/assets/4932851/bd1312b2-b159-473c-b28a-e39b593cb662)

After:
![Screenshot from 2024-01-18 14-57-26](https://github.com/grafana/grafana/assets/4932851/143005d9-758d-40ee-b4fb-6bdd053b1d29)

