### PR TITLE
Logs permalink: adjust for infinite scrolling

### DIFF
--- a/public/app/features/explore/Logs/Logs.tsx
+++ b/public/app/features/explore/Logs/Logs.tsx
@@ -447,10 +447,10 @@ class UnthemedLogs extends PureComponent<Props, State> {
     if (!config.featureToggles.logsInfiniteScrolling) {
       return range;
     }
-    
+
     // With infinite scrolling, the time range of the log line can be after the absolute range or beyond the request line limit, so we need to adjust
     // Look for the previous sibling log, and use its timestamp
-    const allLogs = this.props.logRows.filter(logRow => logRow.dataFrame.refId === row.dataFrame.refId);
+    const allLogs = this.props.logRows.filter((logRow) => logRow.dataFrame.refId === row.dataFrame.refId);
     const prevLog = allLogs[allLogs.indexOf(row) - 1];
 
     if (row.timeEpochMs > this.props.absoluteRange.to && !prevLog) {
@@ -459,14 +459,14 @@ class UnthemedLogs extends PureComponent<Props, State> {
       return {
         from: new Date(this.props.absoluteRange.from).toISOString(),
         // Slide 1ms otherwise it's very likely to be omitted in the results
-        to: new Date(row.timeEpochMs+1).toISOString(),
-      }
+        to: new Date(row.timeEpochMs + 1).toISOString(),
+      };
     }
 
     return {
       from: new Date(this.props.absoluteRange.from).toISOString(),
-      to: new Date(prevLog ? prevLog.timeEpochMs : this.props.absoluteRange.to).toISOString()
-    }
+      to: new Date(prevLog ? prevLog.timeEpochMs : this.props.absoluteRange.to).toISOString(),
+    };
   }
 
   onPermalinkClick = async (row: LogRowModel) => {


### PR DESCRIPTION
With infinite scrolling, the time range situation for sharing log lines changed. Before, the current absolute time range + queries + resulted log lines would univocally generate the same results when queried again. With infinite scrolling, the log to share can be:
- Newer than the current absolute range (scrolling into the future)
- Between the results of the current absolute range + queries (current behavior)
- Older than the results of the current absolute time range (scrolling into the past)

With the changes in this PR, the generated interval when sharing a long line will be:
- From: current absolute range from
- To: the log line immediately after the one we want to share, or the current absolute range to

There is only one exception, which happens when you scroll into the future and want to share the first log of the list. In that case 1) we don't have another log line to use as a reference timestamp and 2) we cannot use the current absolute `to` because it's old. For this case, there's no current other workaround than to slide `to` 1 ms to the log line to share.

The main visual change from this to the previous implementation of permalink is that the shared log line will be the first (or last) in the list.

Demo:

https://github.com/grafana/grafana/assets/1069378/a00d5558-db28-4f12-b126-7cccbd213a67

**Which issue(s) does this PR fix?**:

Part of https://github.com/grafana/grafana/issues/71728

**Special notes for your reviewer:**

Please check that it doesn't create any edge case nor breaks the current funcionality.
