### PR TITLE
Auth: fix swagger response for get SSO settings endpoint

### DIFF
--- a/pkg/services/ssosettings/api/api.go
+++ b/pkg/services/ssosettings/api/api.go
@@ -117,7 +117,7 @@ func (api *Api) getAuthorizedList(ctx context.Context, identity identity.Request
 // You need to have a permission with action `settings:read` with scope `settings:auth.<provider>:*`.
 //
 // Responses:
-// 200: okResponse
+// 200: getSSOSettingsResponse
 // 400: badRequestError
 // 401: unauthorisedError
 // 403: forbiddenError
@@ -234,4 +234,10 @@ type RemoveProviderSettingsParams struct {
 	// in:path
 	// required:true
 	Provider string `json:"key"`
+}
+
+// swagger:response getSSOSettingsResponse
+type GetSSOSettingsResponse struct {
+	// in: body
+	Body models.SSOSettings `json:"body"`
 }

--- a/public/api-merged.json
+++ b/public/api-merged.json
@@ -11401,7 +11401,7 @@
         ],
         "responses": {
           "200": {
-            "$ref": "#/responses/okResponse"
+            "$ref": "#/responses/getSSOSettingsResponse"
           },
           "400": {
             "$ref": "#/responses/badRequestError"
@@ -22929,6 +22929,12 @@
       "description": "(empty)",
       "schema": {
         "$ref": "#/definitions/RoleDTO"
+      }
+    },
+    "getSSOSettingsResponse": {
+      "description": "(empty)",
+      "schema": {
+        "$ref": "#/definitions/SSOSettings"
       }
     },
     "getSharingOptionsResponse": {

--- a/public/openapi3.json
+++ b/public/openapi3.json
@@ -1169,6 +1169,16 @@
         },
         "description": "(empty)"
       },
+      "getSSOSettingsResponse": {
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/SSOSettings"
+            }
+          }
+        },
+        "description": "(empty)"
+      },
       "getSharingOptionsResponse": {
         "content": {
           "application/json": {
@@ -25087,7 +25097,7 @@
         ],
         "responses": {
           "200": {
-            "$ref": "#/components/responses/okResponse"
+            "$ref": "#/components/responses/getSSOSettingsResponse"
           },
           "400": {
             "$ref": "#/components/responses/badRequestError"


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

Fix the swagger response type for SSO Settings GET endpoint.

**Why do we need this feature?**

For using the `getProviderSettings` method in the terraform provider.

**Who is this feature for?**

[Add information on what kind of user the feature is for.]

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
