### PR TITLE
Infinite scroll: update deduplication method and only run log queries when scrolling

### DIFF
--- a/public/app/features/explore/state/query.ts
+++ b/public/app/features/explore/state/query.ts
@@ -725,7 +725,8 @@ export const runLoadMoreLogsQueries = createAsyncThunk<void, RunLoadMoreLogsQuer
     let newQuerySource: Observable<ExplorePanelData>;
 
     const logQueries = queryResponse.logsResult?.queries || [];
-    const queries = logQueries.map((query: DataQuery) => ({
+    const logRefIds = queryResponse.logsFrames.map(frame => frame.refId);
+    const queries = logQueries.filter(query => logRefIds.includes(query.refId)).map((query: DataQuery) => ({
       ...query,
       datasource: query.datasource || datasourceInstance?.getRef(),
       refId: `${infiniteScrollRefId}${query.refId}`,

--- a/public/app/features/explore/state/query.ts
+++ b/public/app/features/explore/state/query.ts
@@ -725,12 +725,14 @@ export const runLoadMoreLogsQueries = createAsyncThunk<void, RunLoadMoreLogsQuer
     let newQuerySource: Observable<ExplorePanelData>;
 
     const logQueries = queryResponse.logsResult?.queries || [];
-    const logRefIds = queryResponse.logsFrames.map(frame => frame.refId);
-    const queries = logQueries.filter(query => logRefIds.includes(query.refId)).map((query: DataQuery) => ({
-      ...query,
-      datasource: query.datasource || datasourceInstance?.getRef(),
-      refId: `${infiniteScrollRefId}${query.refId}`,
-    }));
+    const logRefIds = queryResponse.logsFrames.map((frame) => frame.refId);
+    const queries = logQueries
+      .filter((query) => logRefIds.includes(query.refId))
+      .map((query: DataQuery) => ({
+        ...query,
+        datasource: query.datasource || datasourceInstance?.getRef(),
+        refId: `${infiniteScrollRefId}${query.refId}`,
+      }));
 
     if (!hasNonEmptyQuery(queries) || !datasourceInstance) {
       return;

--- a/public/app/features/explore/state/query.ts
+++ b/public/app/features/explore/state/query.ts
@@ -724,9 +724,9 @@ export const runLoadMoreLogsQueries = createAsyncThunk<void, RunLoadMoreLogsQuer
 
     let newQuerySource: Observable<ExplorePanelData>;
 
-    const logQueries = queryResponse.logsResult?.queries || [];
+    const queries = queryResponse.logsResult?.queries || [];
     const logRefIds = queryResponse.logsFrames.map((frame) => frame.refId);
-    const queries = logQueries
+    const logQueries = queries
       .filter((query) => logRefIds.includes(query.refId))
       .map((query: DataQuery) => ({
         ...query,
@@ -734,7 +734,7 @@ export const runLoadMoreLogsQueries = createAsyncThunk<void, RunLoadMoreLogsQuer
         refId: `${infiniteScrollRefId}${query.refId}`,
       }));
 
-    if (!hasNonEmptyQuery(queries) || !datasourceInstance) {
+    if (!hasNonEmptyQuery(logQueries) || !datasourceInstance) {
       return;
     }
 
@@ -752,7 +752,7 @@ export const runLoadMoreLogsQueries = createAsyncThunk<void, RunLoadMoreLogsQuer
       },
       getFiscalYearStartMonth(getState().user)
     );
-    const transaction = buildQueryTransaction(exploreId, queries, queryOptions, range, false, timeZone, scopedVars);
+    const transaction = buildQueryTransaction(exploreId, logQueries, queryOptions, range, false, timeZone, scopedVars);
 
     dispatch(changeLoadingStateAction({ exploreId, loadingState: LoadingState.Loading }));
 
@@ -767,7 +767,7 @@ export const runLoadMoreLogsQueries = createAsyncThunk<void, RunLoadMoreLogsQuer
           queryResponse,
           absoluteRange,
           undefined,
-          queries,
+          logQueries,
           correlations,
           showCorrelationEditorLinks,
           defaultCorrelationEditorDatasource

--- a/public/app/features/logs/logsModel.ts
+++ b/public/app/features/logs/logsModel.ts
@@ -46,7 +46,7 @@ import { ansicolor, colors } from '@grafana/ui';
 import { getThemeColor } from 'app/core/utils/colors';
 
 import { LogsFrame, parseLogsFrame } from './logsFrame';
-import { findMatchingRow, getLogLevel, getLogLevelFromKey, sortInAscendingOrder } from './utils';
+import { createLogRowsMap, getLogLevel, getLogLevelFromKey, sortInAscendingOrder } from './utils';
 
 export const LIMIT_LABEL = 'Line limit';
 export const COMMON_LABELS = 'Common labels';
@@ -415,6 +415,7 @@ export function logSeriesToLogsModel(
   let rows: LogRowModel[] = [];
   let hasUniqueLabels = false;
 
+  const findMatchingRow = createLogRowsMap();
   for (const info of allSeries) {
     const { logsFrame, rawFrame: series, frameLabels } = info;
     const { timeField, timeNanosecondField, bodyField: stringField, severityField: logLevelField, idField } = logsFrame;
@@ -478,7 +479,7 @@ export function logSeriesToLogsModel(
         row.rowId = idField.values[j];
       }
 
-      if (filterDuplicateRows && findMatchingRow(row, rows)) {
+      if (filterDuplicateRows && findMatchingRow(row)) {
         continue;
       }
 

--- a/public/app/features/logs/utils.ts
+++ b/public/app/features/logs/utils.ts
@@ -298,13 +298,14 @@ export function targetIsElement(target: EventTarget | null): target is Element {
   return target instanceof Element;
 }
 
-export function findMatchingRow(target: LogRowModel, rows: LogRowModel[]) {
-  return rows.find((row) => {
-    if (target.dataFrame.refId !== row.dataFrame.refId) {
-      return false;
+export function createLogRowsMap() {
+  const logRowsSet = new Set();
+  return function (target: LogRowModel): boolean {
+    let id = `${target.dataFrame.refId}_${target.rowId ? target.rowId : `${target.timeEpochNs}_${target.entry}`}`;
+    if (logRowsSet.has(id)) {
+      return true;
     }
-    const sameId = target.rowId && row.rowId && target.rowId === row.rowId;
-    const sameSignature = row.entry === target.entry && row.timeEpochNs === target.timeEpochNs;
-    return sameId || sameSignature;
-  });
+    logRowsSet.add(id);
+    return false;
+  };
 }


### PR DESCRIPTION
**Performance change**
We don't need to store a reference to each log row, and using a map is faster than doing an array lookup, so this PR updates the implementation to an optimized one.

**Infinite scrolling queries**
I realized that we were running all log queries, including those for metrics. I updated the implementation to grab the refIds from log frames and use them to filter queries.

**What is this feature?**

Performance optimization.

**Why do we need this feature?**

Performance.

**Which issue(s) does this PR fix?**:

Part of https://github.com/grafana/grafana/issues/71728