### PR TITLE
Chore: make `baseDir` absolute in grafana-plugin-config

### DIFF
--- a/packages/grafana-plugin-configs/webpack.config.ts
+++ b/packages/grafana-plugin-configs/webpack.config.ts
@@ -90,7 +90,7 @@ const config = async (env: Record<string, unknown>): Promise<Configuration> => {
             loader: require.resolve('swc-loader'),
             options: {
               jsc: {
-                baseUrl: '.',
+                baseUrl: path.resolve(__dirname),
                 target: 'es2015',
                 loose: false,
                 parser: {


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

- basically applies the same fix as in https://github.com/grafana/plugin-tools/pull/424

**Why do we need this feature?**

- i think probably an automated bump to _something_ (swc?) has caused 5 packages to now fail to build in main:
> base_dir(`.`) must be absolute. Please ensure that `jsc.baseUrl` is specified correctly. This cannot be deduced by SWC itself because SWC is a transpiler and it does not try to resolve project details. In other words, SWC does not know which directory should be used as a base directory. It can be deduced if `.swcrc` is used, but if not, there are many candidates. e.g. the directory containing `package.json`, or the current working directory. Because of that, the caller (typically the developer of the JavaScript package) should specify it.

For 5 datasources:

> [1]  >  Lerna (powered by Nx)   Running target build for 5 projects failed
[1] 
[1]    Failed tasks:
[1]    
[1]    - @grafana-plugins/grafana-azure-monitor-datasource:build
[1]    - @grafana-plugins/grafana-pyroscope-datasource:build
[1]    - @grafana-plugins/parca:build
[1]    - @grafana-plugins/grafana-testdata-datasource:build
[1]    - @grafana-plugins/tempo:build

**Who is this feature for?**

- grafana devs

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
