### PR TITLE
Loki: Fix missing timerange in query builder values request

### DIFF
--- a/public/app/plugins/datasource/loki/querybuilder/components/LokiQueryBuilder.test.tsx
+++ b/public/app/plugins/datasource/loki/querybuilder/components/LokiQueryBuilder.test.tsx
@@ -57,6 +57,26 @@ describe('LokiQueryBuilder', () => {
     await waitFor(() => expect(screen.getByText('job')).toBeInTheDocument());
   });
 
+  it('does refetch label values with the correct timerange', async () => {
+    const props = createDefaultProps();
+    props.datasource.getDataSamples = jest.fn().mockResolvedValue([]);
+    props.datasource.languageProvider.fetchSeriesLabels = jest
+      .fn()
+      .mockReturnValue({ job: ['a'], instance: ['b'], baz: ['bar'] });
+
+    render(<LokiQueryBuilder {...props} query={defaultQuery} />);
+    await userEvent.click(screen.getByLabelText('Add'));
+    const labels = screen.getByText(/Label filters/);
+    const selects = getAllByRole(getSelectParent(labels)!, 'combobox');
+    await userEvent.click(selects[3]);
+    await waitFor(() => expect(screen.getByText('job')).toBeInTheDocument());
+    await userEvent.click(screen.getByText('job'));
+    await userEvent.click(selects[5]);
+    expect(props.datasource.languageProvider.fetchSeriesLabels).toHaveBeenNthCalledWith(2, '{baz="bar"}', {
+      timeRange: mockTimeRange,
+    });
+  });
+
   it('does not show already existing label names as option in label filter', async () => {
     const props = createDefaultProps();
     props.datasource.getDataSamples = jest.fn().mockResolvedValue([]);

--- a/public/app/plugins/datasource/loki/querybuilder/components/LokiQueryBuilder.tsx
+++ b/public/app/plugins/datasource/loki/querybuilder/components/LokiQueryBuilder.tsx
@@ -78,7 +78,7 @@ export const LokiQueryBuilder = React.memo<Props>(
         values = await datasource.languageProvider.fetchLabelValues(forLabel.label, { timeRange });
       } else {
         const expr = lokiQueryModeller.renderLabels(labelsToConsider);
-        const result = await datasource.languageProvider.fetchSeriesLabels(expr);
+        const result = await datasource.languageProvider.fetchSeriesLabels(expr, { timeRange });
         values = result[datasource.interpolateString(forLabel.label)];
       }
 


### PR DESCRIPTION
**What is this feature?**

We recently added `timeRange` values to Loki's language provider but missed to add it to one function call. That resulted in label values that were only fetch for the default time range, which is 6hours. If users selected a larger duration, values but have been missed.
