### PR TITLE
FeatureFlags: fix setting flags to false in startup

### DIFF
--- a/pkg/services/featuremgmt/manager.go
+++ b/pkg/services/featuremgmt/manager.go
@@ -102,7 +102,8 @@ func (fm *FeatureManager) update() {
 		// Update the registry
 		track := 0.0
 
-		if flag.Expression == "true" || (fm.startup[flag.Name]) {
+		startup, ok := fm.startup[flag.Name]
+		if startup || (!ok && flag.Expression == "true") {
 			track = 1
 			enabled[flag.Name] = true
 		}

--- a/pkg/services/featuremgmt/manager_test.go
+++ b/pkg/services/featuremgmt/manager_test.go
@@ -75,4 +75,25 @@ func TestFeatureManager(t *testing.T) {
 		require.Equal(t, "second", flag.Description)
 		require.Equal(t, "http://something", flag.DocsURL)
 	})
+
+	t.Run("check startup false flags", func(t *testing.T) {
+		ft := FeatureManager{
+			flags: map[string]*FeatureFlag{},
+			startup: map[string]bool{
+				"a": true,
+				"b": false, // but default true
+			},
+		}
+		ft.registerFlags(FeatureFlag{
+			Name: "a",
+		}, FeatureFlag{
+			Name:       "b",
+			Expression: "true",
+		}, FeatureFlag{
+			Name: "c",
+		})
+		require.True(t, ft.IsEnabledGlobally("a"))
+		require.False(t, ft.IsEnabledGlobally("b"))
+		require.False(t, ft.IsEnabledGlobally("c"))
+	})
 }


### PR DESCRIPTION
Fix bug introduced in https://github.com/grafana/grafana/pull/79960 that stopped supporting setting flags to false.