### PR TITLE
Plugins: Add `forwardGrafanaIdToken` to JSON data type

### DIFF
--- a/packages/grafana-data/src/types/datasource.ts
+++ b/packages/grafana-data/src/types/datasource.ts
@@ -620,6 +620,7 @@ export interface DataSourceJsonData {
   manageAlerts?: boolean;
   alertmanagerUid?: string;
   disableGrafanaCache?: boolean;
+  forwardGrafanaIdToken?: boolean;
 }
 
 /**


### PR DESCRIPTION
Follow up to #80622, adding this property allows plugins to enable the forwarding of the Grafana ID token. This will require the `idForwarding` feature toggle to be enabled to have any effect. The ID token will then be available in the `X-Grafana-Id` header in plugin requests. 