### PR TITLE
Alerting: Nilcheck JitterStrategyFrom so it can be used in contexts without feature toggles

### DIFF
--- a/pkg/services/ngalert/schedule/jitter.go
+++ b/pkg/services/ngalert/schedule/jitter.go
@@ -21,6 +21,9 @@ const (
 // JitterStrategyFrom returns the JitterStrategy indicated by the current Grafana feature toggles.
 func JitterStrategyFrom(toggles featuremgmt.FeatureToggles) JitterStrategy {
 	strategy := JitterNever
+	if toggles == nil {
+		return strategy
+	}
 	if toggles.IsEnabledGlobally(featuremgmt.FlagJitterAlertRules) {
 		strategy = JitterByGroup
 	}


### PR DESCRIPTION
**What is this feature?**

This is to make tests easier to write. No need to inject an empty featuretoggles everywhere.

**Why do we need this feature?**

make test setups simpler, make the function less dependent on the setup

**Which issue(s) does this PR fix?**:

n/a

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle.
- [x] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
