### PR TITLE
Docs: move best practices page

### DIFF
--- a/docs/sources/dashboards/build-dashboards/best-practices/index.md
+++ b/docs/sources/dashboards/build-dashboards/best-practices/index.md
@@ -14,7 +14,7 @@ labels:
     - oss
 menuTitle: Best practices
 title: Grafana dashboard best practices
-weight: 100
+weight: 800
 ---
 
 # Grafana dashboard best practices


### PR DESCRIPTION
This PR changes the weight of the Dashboards best practices page to change its position in the TOC. It does not change it's folder location.

Related to issue #80255 