### PR TITLE
allow using {{ .URL }} inside "routes" section in plugin.json

### DIFF
--- a/pkg/api/pluginproxy/ds_auth_provider.go
+++ b/pkg/api/pluginproxy/ds_auth_provider.go
@@ -24,7 +24,7 @@ type DSInfo struct {
 func ApplyRoute(ctx context.Context, req *http.Request, proxyPath string, route *plugins.Route,
 	ds DSInfo, cfg *setting.Cfg) {
 	proxyPath = strings.TrimPrefix(proxyPath, route.Path)
-
+	req.URL.Path = proxyPath
 	data := templateData{
 		JsonData:       ds.JSONData,
 		SecureJsonData: ds.DecryptedSecureJSONData,

--- a/pkg/api/pluginproxy/ds_auth_provider.go
+++ b/pkg/api/pluginproxy/ds_auth_provider.go
@@ -24,7 +24,6 @@ type DSInfo struct {
 func ApplyRoute(ctx context.Context, req *http.Request, proxyPath string, route *plugins.Route,
 	ds DSInfo, cfg *setting.Cfg) {
 	proxyPath = strings.TrimPrefix(proxyPath, route.Path)
-	req.URL.Path = proxyPath
 	data := templateData{
 		JsonData:       ds.JSONData,
 		SecureJsonData: ds.DecryptedSecureJSONData,
@@ -49,6 +48,9 @@ func ApplyRoute(ctx context.Context, req *http.Request, proxyPath string, route 
 		req.URL.Host = routeURL.Host
 		req.Host = routeURL.Host
 		req.URL.Path = util.JoinURLFragments(routeURL.Path, proxyPath)
+	} else {
+		// fix https://github.com/grafana/grafana/issues/80856 when we skip URL then /{{route.Path}} shall be deleted to avoid error from HTTP severs which not allow dynamic HTTP handlers
+		req.URL.Path = proxyPath
 	}
 
 	if err := addQueryString(req, route, data); err != nil {

--- a/pkg/api/pluginproxy/ds_auth_provider.go
+++ b/pkg/api/pluginproxy/ds_auth_provider.go
@@ -16,6 +16,7 @@ import (
 type DSInfo struct {
 	ID                      int64
 	Updated                 time.Time
+	URL                     string
 	JSONData                map[string]any
 	DecryptedSecureJSONData map[string]string
 }
@@ -25,6 +26,7 @@ func ApplyRoute(ctx context.Context, req *http.Request, proxyPath string, route 
 	ds DSInfo, cfg *setting.Cfg) {
 	proxyPath = strings.TrimPrefix(proxyPath, route.Path)
 	data := templateData{
+		URL:            ds.URL,
 		JsonData:       ds.JSONData,
 		SecureJsonData: ds.DecryptedSecureJSONData,
 	}
@@ -48,9 +50,6 @@ func ApplyRoute(ctx context.Context, req *http.Request, proxyPath string, route 
 		req.URL.Host = routeURL.Host
 		req.Host = routeURL.Host
 		req.URL.Path = util.JoinURLFragments(routeURL.Path, proxyPath)
-	} else {
-		// If the route URL is empty, we still need to update the request path with the proxy one.
-		req.URL.Path = proxyPath
 	}
 
 	if err := addQueryString(req, route, data); err != nil {

--- a/pkg/api/pluginproxy/ds_auth_provider.go
+++ b/pkg/api/pluginproxy/ds_auth_provider.go
@@ -49,7 +49,7 @@ func ApplyRoute(ctx context.Context, req *http.Request, proxyPath string, route 
 		req.Host = routeURL.Host
 		req.URL.Path = util.JoinURLFragments(routeURL.Path, proxyPath)
 	} else {
-		// fix https://github.com/grafana/grafana/issues/80856 when we skip URL then /{{route.Path}} shall be deleted to avoid error from HTTP severs which not allow dynamic HTTP handlers
+		// If the route URL is empty, we still need to update the request path with the proxy one.
 		req.URL.Path = proxyPath
 	}
 

--- a/pkg/api/pluginproxy/ds_proxy.go
+++ b/pkg/api/pluginproxy/ds_proxy.go
@@ -252,6 +252,7 @@ func (proxy *DataSourceProxy) director(req *http.Request) {
 
 		ApplyRoute(req.Context(), req, proxy.proxyPath, proxy.matchedRoute, DSInfo{
 			ID:                      proxy.ds.ID,
+			URL:                     proxy.ds.URL,
 			Updated:                 proxy.ds.Updated,
 			JSONData:                jsonData,
 			DecryptedSecureJSONData: decryptedValues,

--- a/pkg/api/pluginproxy/ds_proxy_test.go
+++ b/pkg/api/pluginproxy/ds_proxy_test.go
@@ -158,6 +158,36 @@ func TestDataSourceProxy_routeRule(t *testing.T) {
 			assert.Equal(t, "http://localhost/asd", req.URL.String())
 		})
 
+		t.Run("When matching route path and has setting url", func(t *testing.T) {
+			ctx, req := setUp()
+			proxy, err := setupDSProxyTest(t, ctx, ds, routes, "api/common/some/method")
+			require.NoError(t, err)
+			proxy.matchedRoute = &plugins.Route{
+				Path: "api/common",
+				URL:  "{{.URL}}",
+				Headers: []plugins.Header{
+					{Name: "x-header", Content: "my secret {{.SecureJsonData.key}}"},
+				},
+				URLParams: []plugins.URLParam{
+					{Name: "{{.JsonData.queryParam}}", Content: "{{.SecureJsonData.key}}"},
+				},
+			}
+
+			dsInfo := DSInfo{
+				ID:       ds.ID,
+				Updated:  ds.Updated,
+				JSONData: jd,
+				DecryptedSecureJSONData: map[string]string{
+					"key": "123",
+				},
+				URL: "https://dynamic.grafana.com",
+			}
+			ApplyRoute(proxy.ctx.Req.Context(), req, proxy.proxyPath, proxy.matchedRoute, dsInfo, proxy.cfg)
+
+			assert.Equal(t, "https://dynamic.grafana.com/some/method?apiKey=123", req.URL.String())
+			assert.Equal(t, "my secret 123", req.Header.Get("x-header"))
+		})
+
 		t.Run("When matching route path and has dynamic body", func(t *testing.T) {
 			ctx, req := setUp()
 			proxy, err := setupDSProxyTest(t, ctx, ds, routes, "api/body")

--- a/pkg/api/pluginproxy/pluginproxy.go
+++ b/pkg/api/pluginproxy/pluginproxy.go
@@ -218,6 +218,7 @@ func (proxy PluginProxy) logRequest() {
 }
 
 type templateData struct {
+	URL            string
 	JsonData       map[string]any
 	SecureJsonData map[string]string
 }


### PR DESCRIPTION
**What is this feature?**
Detail description is  https://github.com/grafana/grafana/issues/80856

**Why do we need this feature?**

Looks like current implementation contains bug

**Who is this feature for?**

For plugin developers which can't store all settings into `jsonData`
and try to use standard `@grafana/ui` `DataSourceHttpSettings` component

For plugin developers when data source destination server doesn't allow additional `path` in proxyfied request URL.


**Which issue(s) does this PR fix?**:

Fixes #80856 

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
