### PR TITLE
Transformations: Focus search input on drawer open

### DIFF
--- a/public/app/features/dashboard/components/TransformationsEditor/TransformationPickerNg.tsx
+++ b/public/app/features/dashboard/components/TransformationsEditor/TransformationPickerNg.tsx
@@ -1,5 +1,5 @@
 import { cx, css } from '@emotion/css';
-import React, { FormEventHandler, KeyboardEventHandler, ReactNode } from 'react';
+import React, { FormEventHandler, KeyboardEventHandler, ReactNode, useCallback } from 'react';
 
 import {
   DataFrame,
@@ -43,7 +43,6 @@ interface TransformationPickerNgProps {
 export function TransformationPickerNg(props: TransformationPickerNgProps) {
   const styles = useStyles2(getTransformationPickerStyles);
   const {
-    noTransforms,
     suffix,
     setState,
     xforms,
@@ -56,6 +55,12 @@ export function TransformationPickerNg(props: TransformationPickerNgProps) {
     data,
   } = props;
 
+  // Use a callback ref to call "click" on the search input
+  // This will focus it when it's opened
+  const searchInputRef = useCallback((input: HTMLInputElement) => {
+    input?.click();
+  }, [])
+
   return (
     <Drawer size="md" onClose={() => setState({ showPicker: false })} title="Add another transformation">
       <div className={styles.searchWrapper}>
@@ -63,11 +68,11 @@ export function TransformationPickerNg(props: TransformationPickerNgProps) {
           data-testid={selectors.components.Transforms.searchInput}
           className={styles.searchInput}
           value={search ?? ''}
-          autoFocus={!noTransforms}
           placeholder="Search for transformation"
           onChange={onSearchChange}
           onKeyDown={onSearchKeyDown}
           suffix={suffix}
+          ref={searchInputRef}
         />
         <div className={styles.showImages}>
           <span className={styles.illustationSwitchLabel}>Show images</span>{' '}

--- a/public/app/features/dashboard/components/TransformationsEditor/TransformationPickerNg.tsx
+++ b/public/app/features/dashboard/components/TransformationsEditor/TransformationPickerNg.tsx
@@ -59,7 +59,7 @@ export function TransformationPickerNg(props: TransformationPickerNgProps) {
   // This will focus it when it's opened
   const searchInputRef = useCallback((input: HTMLInputElement) => {
     input?.click();
-  }, [])
+  }, []);
 
   return (
     <Drawer size="md" onClose={() => setState({ showPicker: false })} title="Add another transformation">


### PR DESCRIPTION
**What is this feature?**

When adding transformations there is a search box which can be used to filter transformations. Currently this isn't focused when the drawer is opened causing an extra click. While auto-focusing on fields is generally not considered the best for accessibility when the drawer is open this field in the only text field which can be interacted with. In this case that seems like a reasonable trade-off.

**Why do we need this feature?**

It streamlines the addition of new transformations.

**Who is this feature for?**

Users of transformations.

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
