### PR TITLE
Allow "Get Help" on read-only panels

### DIFF
--- a/public/app/features/dashboard/utils/getPanelMenu.ts
+++ b/public/app/features/dashboard/utils/getPanelMenu.ts
@@ -310,7 +310,7 @@ export function getPanelMenu(
     }
   }
 
-  if (canEdit && panel.plugin && !panel.plugin.meta.skipDataQuery) {
+  if (panel.plugin && !panel.plugin.meta.skipDataQuery) {
     subMenu.push({
       text: t('panel.header-menu.get-help', 'Get help'),
       onClick: (e: React.MouseEvent) => onInspectPanel(InspectTab.Help),


### PR DESCRIPTION
IMO "Get help" should always be available. Panels can break or show bugs
even when they are on dashboards which are not editable. eg. New data,
new dashboard-variable choices, a new time-range or a new grafana
version can all trigger a bug or regression on a provisioned or
otherwise non-editable dashboard. So we should always offer the
"Get help" option.

See GrafanaLabs internal Slack thread on this topic:
https://raintank-corp.slack.com/archives/C036J5B39/p1705571740247479?thread_ts=1705568891.261309&cid=C036J5B39
