### PR TITLE
DashboardScenePageStateManager: Do not initialise dashboard meta after fetch

### DIFF
--- a/public/app/features/dashboard-scene/scene/DashboardSceneUrlSync.ts
+++ b/public/app/features/dashboard-scene/scene/DashboardSceneUrlSync.ts
@@ -34,10 +34,10 @@ export class DashboardSceneUrlSync implements SceneObjectUrlSyncHandler {
   }
 
   updateFromUrl(values: SceneObjectUrlValues): void {
-    const { inspectPanelKey, viewPanelScene, meta, isEditing, editPanel } = this._scene.state;
+    const { inspectPanelKey, viewPanelScene, isEditing, editPanel } = this._scene.state;
     const update: Partial<DashboardSceneState> = {};
 
-    if (typeof values.editview === 'string' && meta.canEdit) {
+    if (typeof values.editview === 'string' && this._scene.canEditDashboard()) {
       update.editview = createDashboardEditViewFor(values.editview);
 
       // If we are not in editing (for example after full page reload)

--- a/public/app/features/dashboard/containers/DashboardPageProxy.tsx
+++ b/public/app/features/dashboard/containers/DashboardPageProxy.tsx
@@ -49,7 +49,11 @@ function DashboardPageProxy(props: DashboardPageProxyProps) {
     return null;
   }
 
-  if (dashboard.value && !dashboard.value.meta.canEdit && isScenesSupportedRoute) {
+  if (
+    dashboard.value &&
+    !(dashboard.value.meta.canEdit || dashboard.value.meta.canMakeEditable) &&
+    isScenesSupportedRoute
+  ) {
     return <DashboardScenePage {...props} />;
   } else {
     return <DashboardPage {...props} />;


### PR DESCRIPTION
Fixes https://github.com/grafana/grafana/issues/80454

The problem was that the DashboardScenePageStateManager used for fetching the dashboard also initialised runtime dashboard meta that's use to indicate whether or not the dashboard has certain features enabled. But this metadata is also initialised by the DashboardModel that we still use in both old and the new architecture. This caused the already initialised meta to be re-initialised which caused incorrect statre of dashbaord metadata.

This PR removes the meta initialisation from the DashboardScenePageStateManager. The dashbaords cache now stores raw dashboard API responses, and the runtime metadata is only initialised via the DashbaordModel:
- in initDashoard thunk in the old architecture
- in transformSaveModelToScene in the new architecture