### PR TITLE
Loki: Add custom datasource success metric

### DIFF
--- a/pkg/tsdb/loki/instrumentation/instrumentation.go
+++ b/pkg/tsdb/loki/instrumentation/instrumentation.go
@@ -55,7 +55,7 @@ func UpdateQueryDataMetrics(err error, errorSource string, dsUrl string, fromAle
 	}
 
 	isCloudLabel := "false"
-	if strings.Contains(dsUrl, "grafana.net") {
+	if strings.Contains(dsUrl, ".grafana.net") {
 		isCloudLabel = "true"
 	}
 

--- a/pkg/tsdb/loki/instrumentation/instrumentation.go
+++ b/pkg/tsdb/loki/instrumentation/instrumentation.go
@@ -2,6 +2,8 @@ package instrumentation
 
 import (
 	"context"
+	"errors"
+	"strings"
 	"time"
 
 	"github.com/grafana/grafana/pkg/infra/tracing"
@@ -16,6 +18,12 @@ var (
 		Help:      "Duration of Loki parsing the response in seconds",
 		Buckets:   []float64{.001, 0.0025, .005, .0075, .01, .02, .03, .04, .05, .075, .1, .25, .5, 1, 5, 10, 25},
 	}, []string{"status", "endpoint"})
+
+	pluginRequestCounter = promauto.NewCounterVec(prometheus.CounterOpts{
+		Namespace: "grafana",
+		Name:      "loki_plugin_request_count",
+		Help:      "The total amount of loki data source requests",
+	}, []string{"status", "endpoint", "status_source", "from_alert", "is_cloud"})
 )
 
 const (
@@ -30,4 +38,26 @@ func UpdatePluginParsingResponseDurationSeconds(ctx context.Context, duration ti
 	} else {
 		histogram.Observe(duration.Seconds())
 	}
+}
+
+func UpdateQueryDataMetrics(err error, errorSource string, dsUrl string, fromAlert bool) {
+	status := "ok"
+	if err != nil {
+		status = "error"
+		if errors.Is(err, context.Canceled) {
+			status = "cancelled"
+		}
+	}
+
+	fromAlertLabel := "false"
+	if fromAlert {
+		fromAlertLabel = "true"
+	}
+
+	isCloudLabel := "false"
+	if strings.Contains(dsUrl, "grafana.net") {
+		isCloudLabel = "true"
+	}
+
+	pluginRequestCounter.WithLabelValues(status, EndpointQueryData, errorSource, fromAlertLabel, isCloudLabel).Inc()
 }


### PR DESCRIPTION
**What is this feature?**

Adds a `loki_plugin_request_count` metric that can be used to track Loki datasource queries and their responses, which different dimensions:
- `from_alert`: used to flag queries from alerting
- `is_cloud`: used to flag queries going to datasources pointing to `.grafana.net`