### PR TITLE
Make: Add `make gen-go` to initcmds in .bra

### DIFF
--- a/.bra.toml
+++ b/.bra.toml
@@ -1,7 +1,7 @@
 [run]
 init_cmds = [
-  ["GO_BUILD_DEV=1", "make", "build-go"],
   ["GO_BUILD_DEV=1", "make", "gen-go"],
+  ["GO_BUILD_DEV=1", "make", "build-go"],
   ["make", "gen-jsonnet"],
   ["./bin/grafana", "server", "-packaging=dev", "cfg:app_mode=development"]
 ]
@@ -17,8 +17,8 @@ watch_exts = [".go", ".ini", ".toml", ".template.html"]
 ignore_files = [".*_gen.go"]
 build_delay = 1500
 cmds = [
+  ["GO_BUILD_DEV=1", "make", "gen-go"],
   ["GO_BUILD_DEV=1", "make", "build-go"],
   ["make", "gen-jsonnet"],
-  ["GO_BUILD_DEV=1", "make", "gen-go"],
   ["./bin/grafana", "server", "-packaging=dev", "cfg:app_mode=development"]
 ]

--- a/.bra.toml
+++ b/.bra.toml
@@ -1,6 +1,7 @@
 [run]
 init_cmds = [
   ["GO_BUILD_DEV=1", "make", "build-go"],
+  ["GO_BUILD_DEV=1", "make", "gen-go"],
   ["make", "gen-jsonnet"],
   ["./bin/grafana", "server", "-packaging=dev", "cfg:app_mode=development"]
 ]
@@ -18,5 +19,6 @@ build_delay = 1500
 cmds = [
   ["GO_BUILD_DEV=1", "make", "build-go"],
   ["make", "gen-jsonnet"],
+  ["GO_BUILD_DEV=1", "make", "gen-go"],
   ["./bin/grafana", "server", "-packaging=dev", "cfg:app_mode=development"]
 ]


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**
This adds `make gen-go` to the init_cmds and cmds arrays in .bra.toml so it's run automatically every **time**

The `make run` get's stuck at times where `make gen-go` has not been run and we are depending on generated go files.

I have not tested this and the performance hit on start up enough.

tests

M1 Macbook

```sh
make run (for migrations to run once)
```
At least 3 times per configuration
```sh
time make run
```

- roughly 29 seconds when not having `make gen-go` to `make run`
- roughly 39 seconds when adding the `make gen-go` to `make run`

So it would add 30% more startup time for `make run`