### PR TITLE
Prometheus: Fix $__interval value interpolation when minStep is set

### DIFF
--- a/pkg/tsdb/prometheus/models/query.go
+++ b/pkg/tsdb/prometheus/models/query.go
@@ -254,8 +254,8 @@ func interpolateVariables(
 		rateInterval = calculateRateInterval(queryInterval, requestedMinStep)
 	}
 
-	expr = strings.ReplaceAll(expr, varIntervalMs, strconv.FormatInt(int64(queryInterval/time.Millisecond), 10))
-	expr = strings.ReplaceAll(expr, varInterval, intervalv2.FormatDuration(queryInterval))
+	expr = strings.ReplaceAll(expr, varIntervalMs, strconv.FormatInt(int64(calculatedMinStep/time.Millisecond), 10))
+	expr = strings.ReplaceAll(expr, varInterval, intervalv2.FormatDuration(calculatedMinStep))
 	expr = strings.ReplaceAll(expr, varRangeMs, strconv.FormatInt(rangeMs, 10))
 	expr = strings.ReplaceAll(expr, varRangeS, strconv.FormatInt(rangeSRounded, 10))
 	expr = strings.ReplaceAll(expr, varRange, strconv.FormatInt(rangeSRounded, 10)+"s")
@@ -263,8 +263,8 @@ func interpolateVariables(
 	expr = strings.ReplaceAll(expr, varRateInterval, rateInterval.String())
 
 	// Repetitive code, we should have functionality to unify these
-	expr = strings.ReplaceAll(expr, varIntervalMsAlt, strconv.FormatInt(int64(queryInterval/time.Millisecond), 10))
-	expr = strings.ReplaceAll(expr, varIntervalAlt, intervalv2.FormatDuration(queryInterval))
+	expr = strings.ReplaceAll(expr, varIntervalMsAlt, strconv.FormatInt(int64(calculatedMinStep/time.Millisecond), 10))
+	expr = strings.ReplaceAll(expr, varIntervalAlt, intervalv2.FormatDuration(calculatedMinStep))
 	expr = strings.ReplaceAll(expr, varRangeMsAlt, strconv.FormatInt(rangeMs, 10))
 	expr = strings.ReplaceAll(expr, varRangeSAlt, strconv.FormatInt(rangeSRounded, 10))
 	expr = strings.ReplaceAll(expr, varRangeAlt, strconv.FormatInt(rangeSRounded, 10)+"s")

--- a/pkg/tsdb/prometheus/models/query.go
+++ b/pkg/tsdb/prometheus/models/query.go
@@ -84,7 +84,7 @@ func Parse(query backend.DataQuery, dsScrapeInterval string, intervalCalculator 
 	}
 
 	// Final step value for prometheus
-	calculatedMinStep, err := calculatePrometheusInterval(model.Interval, dsScrapeInterval, model.IntervalMs, model.IntervalFactor, query, intervalCalculator)
+	calculatedStep, err := calculatePrometheusInterval(model.Interval, dsScrapeInterval, model.IntervalMs, model.IntervalFactor, query, intervalCalculator)
 	if err != nil {
 		return nil, err
 	}
@@ -94,7 +94,7 @@ func Parse(query backend.DataQuery, dsScrapeInterval string, intervalCalculator 
 	expr := interpolateVariables(
 		model.Expr,
 		query.Interval,
-		calculatedMinStep,
+		calculatedStep,
 		model.Interval,
 		dsScrapeInterval,
 		timeRange,
@@ -126,7 +126,7 @@ func Parse(query backend.DataQuery, dsScrapeInterval string, intervalCalculator 
 
 	return &Query{
 		Expr:          expr,
-		Step:          calculatedMinStep,
+		Step:          calculatedStep,
 		LegendFormat:  model.LegendFormat,
 		Start:         query.TimeRange.From,
 		End:           query.TimeRange.To,
@@ -226,14 +226,14 @@ func calculateRateInterval(
 // interpolateVariables interpolates built-in variables
 // expr                         PromQL query
 // queryInterval                Requested interval in milliseconds. This value may be overridden by MinStep in query options
-// calculatedMinStep            Calculated final step value. It was calculated in calculatePrometheusInterval
+// calculatedStep               Calculated final step value. It was calculated in calculatePrometheusInterval
 // requestedMinStep             Requested minimum step value. QueryModel.interval
 // dsScrapeInterval             Data source scrape interval in the config
 // timeRange                    Requested time range for query
 func interpolateVariables(
 	expr string,
 	queryInterval time.Duration,
-	calculatedMinStep time.Duration,
+	calculatedStep time.Duration,
 	requestedMinStep string,
 	dsScrapeInterval string,
 	timeRange time.Duration,
@@ -243,10 +243,10 @@ func interpolateVariables(
 
 	var rateInterval time.Duration
 	if requestedMinStep == varRateInterval || requestedMinStep == varRateIntervalAlt {
-		rateInterval = calculatedMinStep
+		rateInterval = calculatedStep
 	} else {
 		if requestedMinStep == varInterval || requestedMinStep == varIntervalAlt {
-			requestedMinStep = calculatedMinStep.String()
+			requestedMinStep = calculatedStep.String()
 		}
 		if requestedMinStep == "" {
 			requestedMinStep = dsScrapeInterval
@@ -254,8 +254,8 @@ func interpolateVariables(
 		rateInterval = calculateRateInterval(queryInterval, requestedMinStep)
 	}
 
-	expr = strings.ReplaceAll(expr, varIntervalMs, strconv.FormatInt(int64(calculatedMinStep/time.Millisecond), 10))
-	expr = strings.ReplaceAll(expr, varInterval, intervalv2.FormatDuration(calculatedMinStep))
+	expr = strings.ReplaceAll(expr, varIntervalMs, strconv.FormatInt(int64(calculatedStep/time.Millisecond), 10))
+	expr = strings.ReplaceAll(expr, varInterval, intervalv2.FormatDuration(calculatedStep))
 	expr = strings.ReplaceAll(expr, varRangeMs, strconv.FormatInt(rangeMs, 10))
 	expr = strings.ReplaceAll(expr, varRangeS, strconv.FormatInt(rangeSRounded, 10))
 	expr = strings.ReplaceAll(expr, varRange, strconv.FormatInt(rangeSRounded, 10)+"s")
@@ -263,8 +263,8 @@ func interpolateVariables(
 	expr = strings.ReplaceAll(expr, varRateInterval, rateInterval.String())
 
 	// Repetitive code, we should have functionality to unify these
-	expr = strings.ReplaceAll(expr, varIntervalMsAlt, strconv.FormatInt(int64(calculatedMinStep/time.Millisecond), 10))
-	expr = strings.ReplaceAll(expr, varIntervalAlt, intervalv2.FormatDuration(calculatedMinStep))
+	expr = strings.ReplaceAll(expr, varIntervalMsAlt, strconv.FormatInt(int64(calculatedStep/time.Millisecond), 10))
+	expr = strings.ReplaceAll(expr, varIntervalAlt, intervalv2.FormatDuration(calculatedStep))
 	expr = strings.ReplaceAll(expr, varRangeMsAlt, strconv.FormatInt(rangeMs, 10))
 	expr = strings.ReplaceAll(expr, varRangeSAlt, strconv.FormatInt(rangeSRounded, 10))
 	expr = strings.ReplaceAll(expr, varRangeAlt, strconv.FormatInt(rangeSRounded, 10)+"s")

--- a/pkg/tsdb/prometheus/models/query_test.go
+++ b/pkg/tsdb/prometheus/models/query_test.go
@@ -147,7 +147,7 @@ func TestParse(t *testing.T) {
 
 		res, err := models.Parse(q, "15s", intervalCalculator, false)
 		require.NoError(t, err)
-		require.Equal(t, "rate(ALERTS{job=\"test\" [1m]})", res.Expr)
+		require.Equal(t, "rate(ALERTS{job=\"test\" [2m]})", res.Expr)
 		require.Equal(t, 120*time.Second, res.Step)
 	})
 
@@ -168,7 +168,7 @@ func TestParse(t *testing.T) {
 
 		res, err := models.Parse(q, "15s", intervalCalculator, false)
 		require.NoError(t, err)
-		require.Equal(t, "rate(ALERTS{job=\"test\" [1m]})", res.Expr)
+		require.Equal(t, "rate(ALERTS{job=\"test\" [2m]})", res.Expr)
 	})
 
 	t.Run("parsing query model with $__interval_ms variable", func(t *testing.T) {
@@ -187,7 +187,7 @@ func TestParse(t *testing.T) {
 
 		res, err := models.Parse(q, "15s", intervalCalculator, false)
 		require.NoError(t, err)
-		require.Equal(t, "rate(ALERTS{job=\"test\" [60000]})", res.Expr)
+		require.Equal(t, "rate(ALERTS{job=\"test\" [120000]})", res.Expr)
 	})
 
 	t.Run("parsing query model with $__interval_ms and $__interval variable", func(t *testing.T) {
@@ -206,7 +206,7 @@ func TestParse(t *testing.T) {
 
 		res, err := models.Parse(q, "15s", intervalCalculator, false)
 		require.NoError(t, err)
-		require.Equal(t, "rate(ALERTS{job=\"test\" [60000]}) + rate(ALERTS{job=\"test\" [1m]})", res.Expr)
+		require.Equal(t, "rate(ALERTS{job=\"test\" [120000]}) + rate(ALERTS{job=\"test\" [2m]})", res.Expr)
 	})
 
 	t.Run("parsing query model with ${__interval_ms} and ${__interval} variable", func(t *testing.T) {
@@ -225,7 +225,7 @@ func TestParse(t *testing.T) {
 
 		res, err := models.Parse(q, "15s", intervalCalculator, false)
 		require.NoError(t, err)
-		require.Equal(t, "rate(ALERTS{job=\"test\" [60000]}) + rate(ALERTS{job=\"test\" [1m]})", res.Expr)
+		require.Equal(t, "rate(ALERTS{job=\"test\" [120000]}) + rate(ALERTS{job=\"test\" [2m]})", res.Expr)
 	})
 
 	t.Run("parsing query model with $__range variable", func(t *testing.T) {


### PR DESCRIPTION
**What is this feature?**

The `Min Step` value in options underneath the Prometheus query is setting an additional lower limit for the step parameter of the Prometheus query and for the `$__interval` and `$__rate_interval` variables.
This was altered wrongly in this PR https://github.com/grafana/grafana/pull/77234
After discussions (see [thread](https://raintank-corp.slack.com/archives/C02UC0KCSF4/p1705577613447989)) this PR is bringing back the correct functionality. 

### How to test?
- Set up a prometheus data source with scrape interval 15s
- Create a dashboard and add a panel with prometheus query 
- Set time range as "Last 6 Hours"
- You should see 15s as Interval in "Query Options" panel
- `rate(process_cpu_seconds_total[$__interval])` run query and check query inspector. `$__interval` should be `15s`
- Set `Min Step` as `30s` and run the query again. See `$__interval` stayed as `15s` where it should be `30s`
- Switch over to this branch and try again.


