### PR TITLE
Datasources: Add wireset for datasource.DataSourceAPIBuilder 

### DIFF
--- a/pkg/cmd/grafana/apiserver/server.go
+++ b/pkg/cmd/grafana/apiserver/server.go
@@ -12,9 +12,9 @@ import (
 	"k8s.io/client-go/tools/clientcmd"
 	netutils "k8s.io/utils/net"
 
-	"github.com/grafana/grafana/pkg/registry/apis/datasource"
 	"github.com/grafana/grafana/pkg/registry/apis/example"
 	"github.com/grafana/grafana/pkg/registry/apis/featuretoggle"
+	"github.com/grafana/grafana/pkg/server"
 	"github.com/grafana/grafana/pkg/services/featuremgmt"
 	grafanaAPIServer "github.com/grafana/grafana/pkg/services/grafana-apiserver"
 	"github.com/grafana/grafana/pkg/services/grafana-apiserver/utils"
@@ -58,7 +58,7 @@ func (o *APIServerOptions) loadAPIGroupBuilders(args []string) error {
 			}
 			o.builders = append(o.builders, featuretoggle.NewFeatureFlagAPIBuilder(features))
 		case "testdata.datasource.grafana.app":
-			ds, err := datasource.NewStandaloneDatasource(g)
+			ds, err := server.InitializeDataSourceAPIServer(g)
 			if err != nil {
 				return err
 			}

--- a/pkg/registry/apis/datasource/standalone.go
+++ b/pkg/registry/apis/datasource/standalone.go
@@ -8,16 +8,13 @@ import (
 
 	common "github.com/grafana/grafana/pkg/apis/common/v0alpha1"
 	"github.com/grafana/grafana/pkg/plugins"
-	"github.com/grafana/grafana/pkg/services/accesscontrol/acimpl"
 	"github.com/grafana/grafana/pkg/setting"
 	testdatasource "github.com/grafana/grafana/pkg/tsdb/grafana-testdata-datasource"
 )
 
-// NewStandaloneDatasource is a helper function to create a new datasource API server for a group.
-// This currently has no dependencies and only works for testdata.  In future iterations
-// this will include here (or elsewhere) versions that can load config from HG api or
-// the remote SQL directly.
-func NewStandaloneDatasource(group string) (*DataSourceAPIBuilder, error) {
+// NewTestDataAPIServer is a helper function to create a new datasource API server for a group.
+// This currently builds its dependencies manually and only works for testdata.
+func NewTestDataAPIServer(group string) (*DataSourceAPIBuilder, error) {
 	pluginID := "grafana-testdata-datasource"
 
 	if group != "testdata.datasource.grafana.app" {
@@ -31,7 +28,7 @@ func NewStandaloneDatasource(group string) (*DataSourceAPIBuilder, error) {
 		return nil, err
 	}
 
-	_, pluginStore, dsService, dsCache, err := apiBuilderServices(cfg, pluginID)
+	accessControl, pluginStore, dsService, dsCache, err := apiBuilderServices(cfg, pluginID)
 	if err != nil {
 		return nil, err
 	}
@@ -49,7 +46,7 @@ func NewStandaloneDatasource(group string) (*DataSourceAPIBuilder, error) {
 		td.JSONData,
 		NewQuerierProvider(testsDataQuerierFactory),
 		&TestDataPluginContextProvider{},
-		acimpl.ProvideAccessControl(cfg),
+		accessControl,
 	)
 }
 

--- a/pkg/server/wire.go
+++ b/pkg/server/wire.go
@@ -35,6 +35,7 @@ import (
 	"github.com/grafana/grafana/pkg/middleware/csrf"
 	"github.com/grafana/grafana/pkg/middleware/loggermw"
 	apiregistry "github.com/grafana/grafana/pkg/registry/apis"
+	"github.com/grafana/grafana/pkg/registry/apis/datasource"
 	"github.com/grafana/grafana/pkg/services/accesscontrol"
 	"github.com/grafana/grafana/pkg/services/accesscontrol/acimpl"
 	"github.com/grafana/grafana/pkg/services/accesscontrol/ossaccesscontrol"
@@ -458,4 +459,9 @@ func InitializeForCLITarget(cfg *setting.Cfg) (ModuleRunner, error) {
 func InitializeModuleServer(cfg *setting.Cfg, opts Options, apiOpts api.ServerOptions) (*ModuleServer, error) {
 	wire.Build(wireExtsModuleServerSet)
 	return &ModuleServer{}, nil
+}
+
+func InitializeDataSourceAPIServer(group string) (*datasource.DataSourceAPIBuilder, error) {
+	wire.Build(wireExtsDataSourceApiServerSet)
+	return &datasource.DataSourceAPIBuilder{}, nil
 }

--- a/pkg/server/wireexts_oss.go
+++ b/pkg/server/wireexts_oss.go
@@ -11,6 +11,7 @@ import (
 	"github.com/grafana/grafana/pkg/plugins"
 	"github.com/grafana/grafana/pkg/plugins/manager"
 	"github.com/grafana/grafana/pkg/registry"
+	"github.com/grafana/grafana/pkg/registry/apis/datasource"
 	"github.com/grafana/grafana/pkg/registry/backgroundsvcs"
 	"github.com/grafana/grafana/pkg/registry/usagestatssvcs"
 	"github.com/grafana/grafana/pkg/services/accesscontrol"
@@ -136,4 +137,8 @@ var wireExtsBaseCLISet = wire.NewSet(
 var wireExtsModuleServerSet = wire.NewSet(
 	NewModule,
 	wireExtsBaseCLISet,
+)
+
+var wireExtsDataSourceApiServerSet = wire.NewSet(
+	datasource.NewTestDataAPIServer,
 )


### PR DESCRIPTION
**What is this feature?**

Adds wireset to build OSS versions of ds API server builder.

**Why do we need this feature?**

Makes it possible to have different implementations across Grafana flavours.

**Who is this feature for?**

Plugins Platform.

**Special notes for your reviewer:**

See associated enterprise work: https://github.com/grafana/grafana-enterprise/pull/6185

Please check that:
- [X] It works as expected from a user's perspective.
- [X] If this is a pre-GA feature, it is behind a feature toggle.
- [X] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
