### PR TITLE
Add timeout parameter to the example

### DIFF
--- a/docs/sources/datasources/loki/_index.md
+++ b/docs/sources/datasources/loki/_index.md
@@ -60,6 +60,7 @@ datasources:
     access: proxy
     url: http://localhost:3100
     jsonData:
+      timeout: 60
       maxLines: 1000
 ```
 


### PR DESCRIPTION
**What is this feature?**

Adding the http timeout parameter to the example to know where  is needed in the yaml configuration.

**Why do we need this feature?**

There is no place in the docs where the user can identify how to setup the timeout for Loki queries using a yaml datasource

**Who is this feature for?**

For those seting up Loki datasource as yaml files
