### PR TITLE
fix: data-trails get data source name for display

### DIFF
--- a/public/app/features/trails/DataTrailCard.tsx
+++ b/public/app/features/trails/DataTrailCard.tsx
@@ -2,6 +2,7 @@ import { css } from '@emotion/css';
 import React from 'react';
 
 import { GrafanaTheme2 } from '@grafana/data';
+import { getDataSourceSrv } from '@grafana/runtime';
 import { AdHocFiltersVariable, sceneGraph } from '@grafana/scenes';
 import { useStyles2, Stack, Tooltip, Button } from '@grafana/ui';
 
@@ -40,7 +41,7 @@ export function DataTrailCard({ trail, onSelect, onDelete }: Props) {
         {dsValue && (
           <Stack direction="column" gap={0.5}>
             <div className={styles.label}>Datasource</div>
-            <div className={styles.value}>{getDataSource(trail)}</div>
+            <div className={styles.value}>{getDataSourceName(dsValue)}</div>
           </Stack>
         )}
         {filters.map((filter, index) => (
@@ -68,6 +69,10 @@ function getMetricName(metric?: string) {
 
 function getDataSource(trail: DataTrail) {
   return sceneGraph.interpolate(trail, VAR_DATASOURCE_EXPR);
+}
+
+function getDataSourceName(dataSourceUid: string) {
+  return getDataSourceSrv().getInstanceSettings(dataSourceUid)?.name || dataSourceUid;
 }
 
 function getStyles(theme: GrafanaTheme2) {


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**Which issue(s) does this PR fix?**:

In data trails the display card (i.e., on the bookmark view, etc) showed the UID for the data source.
![image](https://github.com/grafana/grafana/assets/38694490/71da54a5-57ff-4971-9088-105d40915d19)


Now it shows its name.

![image](https://github.com/grafana/grafana/assets/38694490/fed798d4-6b51-4395-a1e0-873c3c944c27)


**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
