### PR TITLE
Alerting: Update text, link and aria-label in contact points link for simplified routing.

### DIFF
--- a/public/app/features/alerting/unified/components/rule-editor/alert-rule-form/simplifiedRouting/AlertManagerRouting.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/alert-rule-form/simplifiedRouting/AlertManagerRouting.tsx
@@ -2,7 +2,7 @@ import { css } from '@emotion/css';
 import React, { useState } from 'react';
 
 import { GrafanaTheme2 } from '@grafana/data';
-import { Alert, CollapsableSection, Icon, Link, LoadingPlaceholder, Stack, Text, useStyles2 } from '@grafana/ui';
+import { Alert, CollapsableSection, LoadingPlaceholder, Stack, TextLink, useStyles2 } from '@grafana/ui';
 import { AlertManagerDataSource } from 'app/features/alerting/unified/utils/datasource';
 import { createUrl } from 'app/features/alerting/unified/utils/url';
 
@@ -50,7 +50,9 @@ export function AlertManagerManualRouting({ alertManager }: AlertManagerManualRo
           contactPoints={contactPoints}
           onSelectContactPoint={setSelectedContactPointWithMetadata}
         />
-        <LinkToContactPoints />
+        <div className={styles.contactPointsInfo}>
+          <LinkToContactPoints />
+        </div>
       </Stack>
       {selectedContactPointWithMetadata?.grafana_managed_receiver_configs && (
         <ContactPointDetails receivers={selectedContactPointWithMetadata.grafana_managed_receiver_configs} />
@@ -73,13 +75,9 @@ export function AlertManagerManualRouting({ alertManager }: AlertManagerManualRo
 function LinkToContactPoints() {
   const hrefToContactPoints = '/alerting/notifications';
   return (
-    <Link target="_blank" href={createUrl(hrefToContactPoints)} rel="noopener" aria-label="View alert rule">
-      <Stack direction="row" gap={1} alignItems="center" justifyContent="center">
-        <Text color="secondary">To browse contact points and create new ones, go to</Text>
-        <Text color="link">Contact points</Text>
-        <Icon name={'external-link-alt'} size="sm" color="link" />
-      </Stack>
-    </Link>
+    <TextLink external href={createUrl(hrefToContactPoints)} aria-label="View or create contact points">
+      View or create contact points
+    </TextLink>
   );
 }
 
@@ -116,5 +114,13 @@ const getStyles = (theme: GrafanaTheme2) => ({
     borderRadius: theme.shape.radius.default,
     padding: `${theme.spacing(1)} ${theme.spacing(2)}`,
     marginTop: theme.spacing(2),
+  }),
+  contactPointsInfo: css({
+    display: 'flex',
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'center',
+    gap: theme.spacing(1),
+    marginTop: theme.spacing(1),
   }),
 });


### PR DESCRIPTION
**What is this feature?**

This PR add updates the link to contact points view :

- Use TextLink for it and simplify the text.
- fix wrong aria-label
- fix alignment

**Special notes for your reviewer:**

**Before the change:**

<img width="910" alt="Screenshot 2024-01-22 at 08 59 25" src="https://github.com/grafana/grafana/assets/33540275/1354bb51-c5aa-4534-80b3-2ed5850b48fb">

**After the change:**

<img width="800" alt="Screenshot 2024-01-22 at 09 00 03" src="https://github.com/grafana/grafana/assets/33540275/2f519601-eb0c-44a7-b9b5-5347f897f298">


Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
