### PR TITLE
Postgres: Handle single quotes in table names in the query editor

### DIFF
--- a/public/app/plugins/datasource/grafana-postgresql-datasource/datasource.ts
+++ b/public/app/plugins/datasource/grafana-postgresql-datasource/datasource.ts
@@ -67,7 +67,12 @@ export class PostgresDatasource extends SqlDatasource {
   }
 
   async fetchFields(query: SQLQuery): Promise<SQLSelectableValue[]> {
-    const schema = await this.runSql<{ column: string; type: string }>(getSchema(query.table), { refId: 'columns' });
+    const { table } = query;
+    if (table === undefined) {
+      // if no table-name, we are not able to query for fields
+      return [];
+    }
+    const schema = await this.runSql<{ column: string; type: string }>(getSchema(table), { refId: 'columns' });
     const result: SQLSelectableValue[] = [];
     for (let i = 0; i < schema.length; i++) {
       const column = schema.fields.column.values[i];

--- a/public/app/plugins/datasource/grafana-postgresql-datasource/postgresMetaQuery.test.ts
+++ b/public/app/plugins/datasource/grafana-postgresql-datasource/postgresMetaQuery.test.ts
@@ -1,0 +1,14 @@
+import { getSchema } from './postgresMetaQuery';
+
+describe('postgredsMetaQuery.getSchema', () => {
+  it('should handle table-names with single quote', () => {
+    // testing multi-line with single-quote, double-quote, backtick
+    const tableName = `'a''bcd'efg'h'  "a""b" ` + '`x``y`z' + `\n a'b''c`;
+    const escapedName = `''a''''bcd''efg''h''  "a""b" ` + '`x``y`z' + `\n a''b''''c`;
+
+    const schemaQuery = getSchema(tableName);
+
+    expect(schemaQuery.includes(escapedName)).toBeTruthy();
+    expect(schemaQuery.includes(tableName)).toBeFalsy();
+  });
+});

--- a/public/app/plugins/datasource/grafana-postgresql-datasource/postgresMetaQuery.ts
+++ b/public/app/plugins/datasource/grafana-postgresql-datasource/postgresMetaQuery.ts
@@ -19,10 +19,15 @@ export function showTables() {
       and ${buildSchemaConstraint()}`;
 }
 
-export function getSchema(table?: string) {
+export function getSchema(table: string) {
+  // we will put table-name between single-quotes, so we need to escape single-quotes
+  // in the table-name
+  const tableNamePart = "'" + table.replace(/'/g, "''") + "'";
+
   return `select quote_ident(column_name) as "column", data_type as "type"
     from information_schema.columns
-    where quote_ident(table_name) = '${table}'`;
+    where quote_ident(table_name) = ${tableNamePart};
+    `;
 }
 
 function buildSchemaConstraint() {


### PR DESCRIPTION
in the query editor, you can choose from a list of tables, and then from a list of columns in the chosen table.
this does not work when the table-name contains a single quote ( `'`). this PR fixes this.

the logic goes like this:
1. we call `postgresMetaQuery.showTables()` to get a list of table-names. we use `quote_ident(table_name)` here, to receive table-names that are escaped to be used as identifiers.
2. we call `getSchema(table)` with a table-name we got from [1]. the problem here is that we use the table-name as a string, not as an identifier. when writing a string in single-quotes, you have to escape the single-quotes by doubling them ( https://www.postgresql.org/docs/current/sql-syntax-lexical.html#SQL-SYNTAX-STRINGS ). so using a regular expression, we replace every `'` with `''` (two single quotes).
    (NOTE: there is a postgres function `quote_literal` that does the escaping for the used-in-string use-case, but for us this is not suitable, because then we cannot use the table-name as an identifier, in other places. in theory we could ask the database in step [1], to return both versions of the table-names (both `quote_ident` and `quote_literal`), but that would require a larger rework of the codebase. currently the codebase assumes we receive an array-of-strings)

the PR does one additional thing:
- the table-name we receive in `getSchema()` can be `string` or `undefined`. if it is `undefined`, we are not able to do anything, so i made sure the function only receives a `string`. 

how to test:
- create a table whose name contains a single-quote
- open the postgres query editor
- choose this table
- verify that you can list it's columns in the `columns` row.