### PR TITLE
NestedFolderPicker: Debounce search correctly

### DIFF
--- a/public/app/core/components/NestedFolderPicker/NestedFolderPicker.tsx
+++ b/public/app/core/components/NestedFolderPicker/NestedFolderPicker.tsx
@@ -85,6 +85,10 @@ export function NestedFolderPicker({
   const lastSearchTimestamp = useRef<number>(0);
 
   useEffect(() => {
+    if (!search) {
+      setSearchResults(null);
+      return;
+    }
     const timestamp = Date.now();
     setIsFetchingSearchResults(true);
     debouncedSearch(search).then((queryResponse) => {

--- a/public/app/core/components/NestedFolderPicker/NestedFolderPicker.tsx
+++ b/public/app/core/components/NestedFolderPicker/NestedFolderPicker.tsx
@@ -1,7 +1,7 @@
 import { css } from '@emotion/css';
 import { autoUpdate, flip, useClick, useDismiss, useFloating, useInteractions } from '@floating-ui/react';
-import React, { useCallback, useId, useMemo, useState } from 'react';
-import { useAsync } from 'react-use';
+import debounce from 'debounce-promise';
+import React, { useCallback, useEffect, useId, useMemo, useRef, useState } from 'react';
 
 import { GrafanaTheme2 } from '@grafana/data';
 import { config } from '@grafana/runtime';
@@ -19,7 +19,7 @@ import {
 } from 'app/features/browse-dashboards/state';
 import { getPaginationPlaceholders } from 'app/features/browse-dashboards/state/utils';
 import { DashboardViewItemCollection } from 'app/features/browse-dashboards/types';
-import { getGrafanaSearcher } from 'app/features/search/service';
+import { QueryResponse, getGrafanaSearcher } from 'app/features/search/service';
 import { queryResultToViewItem } from 'app/features/search/service/utils';
 import { DashboardViewItem } from 'app/features/search/types';
 import { useDispatch, useSelector } from 'app/types/store';
@@ -47,6 +47,19 @@ export interface NestedFolderPickerProps {
 
 const EXCLUDED_KINDS = ['empty-folder' as const, 'dashboard' as const];
 
+const debouncedSearch = debounce(getSearchResults, 300);
+
+async function getSearchResults(searchQuery: string) {
+  const queryResponse = await getGrafanaSearcher().search({
+    query: searchQuery,
+    kind: ['folder'],
+    limit: 100,
+  });
+
+  const items = queryResponse.view.map((v) => queryResultToViewItem(v, queryResponse.view));
+  return { ...queryResponse, items };
+}
+
 export function NestedFolderPicker({
   value,
   invalid,
@@ -62,26 +75,30 @@ export function NestedFolderPicker({
   const nestedFoldersEnabled = Boolean(config.featureToggles.nestedFolders);
 
   const [search, setSearch] = useState('');
+  const [searchResults, setSearchResults] = useState<(QueryResponse & { items: DashboardViewItem[] }) | null>(null);
+  const [isFetchingSearchResults, setIsFetchingSearchResults] = useState(false);
   const [autoFocusButton, setAutoFocusButton] = useState(false);
   const [overlayOpen, setOverlayOpen] = useState(false);
   const [folderOpenState, setFolderOpenState] = useState<Record<string, boolean>>({});
   const overlayId = useId();
   const [error] = useState<Error | undefined>(undefined); // TODO: error not populated anymore
+  const lastSearchTimestamp = useRef<number>(0);
 
-  const searchState = useAsync(async () => {
-    if (!search) {
-      return undefined;
-    }
-    const searcher = getGrafanaSearcher();
-    const queryResponse = await searcher.search({
-      query: search,
-      kind: ['folder'],
-      limit: 100,
+  useEffect(() => {
+    const timestamp = Date.now();
+    setIsFetchingSearchResults(true);
+    debouncedSearch(search).then((queryResponse) => {
+      // Only keep the results if it's was issued after the most recently resolved search.
+      // This prevents results showing out of order if first request is slower than later ones.
+      // We don't need to worry about clearing the isFetching state either - if there's a later
+      // request in progress, this will clear it for us
+      if (timestamp > lastSearchTimestamp.current) {
+        const items = queryResponse.view.map((v) => queryResultToViewItem(v, queryResponse.view));
+        setSearchResults({ ...queryResponse, items });
+        setIsFetchingSearchResults(false);
+        lastSearchTimestamp.current = timestamp;
+      }
     });
-
-    const items = queryResponse.view.map((v) => queryResultToViewItem(v, queryResponse.view));
-
-    return { ...queryResponse, items };
   }, [search]);
 
   const rootCollection = useSelector(rootItemsSelector);
@@ -152,9 +169,7 @@ export function NestedFolderPicker({
   );
 
   const flatTree = useMemo(() => {
-    const searchResults = search && searchState.value;
-
-    if (searchResults) {
+    if (search && searchResults) {
       const searchCollection: DashboardViewItemCollection = {
         isFullyLoaded: true, //searchResults.items.length === searchResults.totalRows,
         lastKindHasMoreItems: false, // TODO: paginate search
@@ -203,7 +218,7 @@ export function NestedFolderPicker({
     }
 
     return flatTree;
-  }, [search, searchState.value, rootCollection, childrenCollections, folderOpenState, excludeUIDs, showRootFolder]);
+  }, [search, searchResults, rootCollection, childrenCollections, folderOpenState, excludeUIDs, showRootFolder]);
 
   const isItemLoaded = useCallback(
     (itemIndex: number) => {
@@ -219,7 +234,7 @@ export function NestedFolderPicker({
     [flatTree]
   );
 
-  const isLoading = rootStatus === 'pending' || searchState.loading;
+  const isLoading = rootStatus === 'pending' || isFetchingSearchResults;
 
   const { focusedItemIndex, handleKeyDown } = useTreeInteractions({
     tree: flatTree,
@@ -311,7 +326,7 @@ export function NestedFolderPicker({
               onFolderExpand={handleFolderExpand}
               onFolderSelect={handleFolderSelect}
               idPrefix={overlayId}
-              foldersAreOpenable={nestedFoldersEnabled && !(search && searchState.value)}
+              foldersAreOpenable={nestedFoldersEnabled && !(search && searchResults)}
               isItemLoaded={isItemLoaded}
               requestLoadMore={handleLoadMore}
             />


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

- debounces the `NestedFolderPicker` search
- includes logic to prevent earlier slower requests overwriting later request

**Why do we need this feature?**

- to prevent `NestedFolderPicker` hammering the search api 🔨 

**Who is this feature for?**

- everyone!

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes https://github.com/grafana/grafana/issues/80462

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
