### PR TITLE
RBAC: Return the underlying error instead of internal server or bad request for managed permission endpoints

### DIFF
--- a/pkg/services/accesscontrol/resourcepermissions/api.go
+++ b/pkg/services/accesscontrol/resourcepermissions/api.go
@@ -135,13 +135,14 @@ type getResourcePermissionsResponse []resourcePermissionDTO
 // Responses:
 // 200: getResourcePermissionsResponse
 // 403: forbiddenError
+// 404: notFoundError
 // 500: internalServerError
 func (a *api) getPermissions(c *contextmodel.ReqContext) response.Response {
 	resourceID := web.Params(c.Req)[":resourceID"]
 
 	permissions, err := a.service.GetPermissions(c.Req.Context(), c.SignedInUser, resourceID)
 	if err != nil {
-		return response.Error(http.StatusInternalServerError, "failed to get permissions", err)
+		return response.ErrOrFallback(http.StatusInternalServerError, "failed to get permissions", err)
 	}
 
 	if a.service.options.Assignments.BuiltInRoles && !a.service.license.FeatureEnabled("accesscontrol.enforcement") {
@@ -221,6 +222,7 @@ type SetResourcePermissionsForUserParams struct {
 // 200: okResponse
 // 400: badRequestError
 // 403: forbiddenError
+// 404: notFoundError
 // 500: internalServerError
 func (a *api) setUserPermission(c *contextmodel.ReqContext) response.Response {
 	userID, err := strconv.ParseInt(web.Params(c.Req)[":userID"], 10, 64)
@@ -236,7 +238,7 @@ func (a *api) setUserPermission(c *contextmodel.ReqContext) response.Response {
 
 	_, err = a.service.SetUserPermission(c.Req.Context(), c.SignedInUser.GetOrgID(), accesscontrol.User{ID: userID}, resourceID, cmd.Permission)
 	if err != nil {
-		return response.Error(http.StatusBadRequest, "failed to set user permission", err)
+		return response.ErrOrFallback(http.StatusBadRequest, "failed to set user permission", err)
 	}
 
 	return permissionSetResponse(cmd)
@@ -273,6 +275,7 @@ type SetResourcePermissionsForTeamParams struct {
 // 200: okResponse
 // 400: badRequestError
 // 403: forbiddenError
+// 404: notFoundError
 // 500: internalServerError
 func (a *api) setTeamPermission(c *contextmodel.ReqContext) response.Response {
 	teamID, err := strconv.ParseInt(web.Params(c.Req)[":teamID"], 10, 64)
@@ -288,7 +291,7 @@ func (a *api) setTeamPermission(c *contextmodel.ReqContext) response.Response {
 
 	_, err = a.service.SetTeamPermission(c.Req.Context(), c.SignedInUser.GetOrgID(), teamID, resourceID, cmd.Permission)
 	if err != nil {
-		return response.Error(http.StatusBadRequest, "failed to set team permission", err)
+		return response.ErrOrFallback(http.StatusBadRequest, "failed to set team permission", err)
 	}
 
 	return permissionSetResponse(cmd)
@@ -325,6 +328,7 @@ type SetResourcePermissionsForBuiltInRoleParams struct {
 // 200: okResponse
 // 400: badRequestError
 // 403: forbiddenError
+// 404: notFoundError
 // 500: internalServerError
 func (a *api) setBuiltinRolePermission(c *contextmodel.ReqContext) response.Response {
 	builtInRole := web.Params(c.Req)[":builtInRole"]
@@ -337,7 +341,7 @@ func (a *api) setBuiltinRolePermission(c *contextmodel.ReqContext) response.Resp
 
 	_, err := a.service.SetBuiltInRolePermission(c.Req.Context(), c.SignedInUser.GetOrgID(), builtInRole, resourceID, cmd.Permission)
 	if err != nil {
-		return response.Error(http.StatusBadRequest, "failed to set role permission", err)
+		return response.ErrOrFallback(http.StatusBadRequest, "failed to set role permission", err)
 	}
 
 	return permissionSetResponse(cmd)
@@ -370,6 +374,7 @@ type SetResourcePermissionsParams struct {
 // 200: okResponse
 // 400: badRequestError
 // 403: forbiddenError
+// 404: notFoundError
 // 500: internalServerError
 func (a *api) setPermissions(c *contextmodel.ReqContext) response.Response {
 	resourceID := web.Params(c.Req)[":resourceID"]
@@ -381,7 +386,7 @@ func (a *api) setPermissions(c *contextmodel.ReqContext) response.Response {
 
 	_, err := a.service.SetPermissions(c.Req.Context(), c.SignedInUser.GetOrgID(), resourceID, cmd.Permissions...)
 	if err != nil {
-		return response.Error(http.StatusBadRequest, "failed to set permissions", err)
+		return response.ErrOrFallback(http.StatusBadRequest, "failed to set permission", err)
 	}
 
 	return response.Success("Permissions updated")

--- a/pkg/services/dashboards/accesscontrol.go
+++ b/pkg/services/dashboards/accesscontrol.go
@@ -2,6 +2,7 @@ package dashboards
 
 import (
 	"context"
+	"errors"
 	"strings"
 
 	ac "github.com/grafana/grafana/pkg/services/accesscontrol"
@@ -207,6 +208,9 @@ func GetInheritedScopes(ctx context.Context, orgID int64, folderUID string, fold
 	})
 
 	if err != nil {
+		if errors.Is(err, folder.ErrFolderNotFound) {
+			return nil, err
+		}
 		return nil, ac.ErrInternal.Errorf("could not retrieve folder parents: %w", err)
 	}
 

--- a/pkg/services/folder/folderimpl/sqlstore.go
+++ b/pkg/services/folder/folderimpl/sqlstore.go
@@ -231,7 +231,7 @@ func (ss *sqlStore) GetParents(ctx context.Context, q folder.GetParentsQuery) ([
 	if len(folders) < 1 {
 		// the query is expected to return at least the same folder
 		// if it's empty it means that the folder does not exist
-		return nil, folder.ErrFolderNotFound
+		return nil, folder.ErrFolderNotFound.Errorf("folder not found")
 	}
 
 	return util.Reverse(folders[1:]), nil
@@ -294,7 +294,7 @@ func (ss *sqlStore) getParentsMySQL(ctx context.Context, q folder.GetParentsQuer
 			return err
 		}
 		if !ok {
-			return folder.ErrFolderNotFound
+			return folder.ErrFolderNotFound.Errorf("folder not found")
 		}
 		for {
 			f := &folder.Folder{}

--- a/public/api-enterprise-spec.json
+++ b/public/api-enterprise-spec.json
@@ -8994,6 +8994,12 @@
         "$ref": "#/definitions/RoleDTO"
       }
     },
+    "getSSOSettingsResponse": {
+      "description": "",
+      "schema": {
+        "$ref": "#/definitions/SSOSettings"
+      }
+    },
     "getSharingOptionsResponse": {
       "description": "",
       "schema": {
@@ -9169,6 +9175,15 @@
         "type": "array",
         "items": {
           "$ref": "#/definitions/RoleDTO"
+        }
+      }
+    },
+    "listSSOSettingsResponse": {
+      "description": "",
+      "schema": {
+        "type": "array",
+        "items": {
+          "$ref": "#/definitions/SSOSettings"
         }
       }
     },

--- a/public/api-merged.json
+++ b/public/api-merged.json
@@ -765,6 +765,9 @@
           "403": {
             "$ref": "#/responses/forbiddenError"
           },
+          "404": {
+            "$ref": "#/responses/notFoundError"
+          },
           "500": {
             "$ref": "#/responses/internalServerError"
           }
@@ -808,6 +811,9 @@
           },
           "403": {
             "$ref": "#/responses/forbiddenError"
+          },
+          "404": {
+            "$ref": "#/responses/notFoundError"
           },
           "500": {
             "$ref": "#/responses/internalServerError"
@@ -860,6 +866,9 @@
           },
           "403": {
             "$ref": "#/responses/forbiddenError"
+          },
+          "404": {
+            "$ref": "#/responses/notFoundError"
           },
           "500": {
             "$ref": "#/responses/internalServerError"
@@ -914,6 +923,9 @@
           "403": {
             "$ref": "#/responses/forbiddenError"
           },
+          "404": {
+            "$ref": "#/responses/notFoundError"
+          },
           "500": {
             "$ref": "#/responses/internalServerError"
           }
@@ -966,6 +978,9 @@
           },
           "403": {
             "$ref": "#/responses/forbiddenError"
+          },
+          "404": {
+            "$ref": "#/responses/notFoundError"
           },
           "500": {
             "$ref": "#/responses/internalServerError"

--- a/public/openapi3.json
+++ b/public/openapi3.json
@@ -13492,6 +13492,9 @@
           "403": {
             "$ref": "#/components/responses/forbiddenError"
           },
+          "404": {
+            "$ref": "#/components/responses/notFoundError"
+          },
           "500": {
             "$ref": "#/components/responses/internalServerError"
           }
@@ -13542,6 +13545,9 @@
           },
           "403": {
             "$ref": "#/components/responses/forbiddenError"
+          },
+          "404": {
+            "$ref": "#/components/responses/notFoundError"
           },
           "500": {
             "$ref": "#/components/responses/internalServerError"
@@ -13603,6 +13609,9 @@
           },
           "403": {
             "$ref": "#/components/responses/forbiddenError"
+          },
+          "404": {
+            "$ref": "#/components/responses/notFoundError"
           },
           "500": {
             "$ref": "#/components/responses/internalServerError"
@@ -13666,6 +13675,9 @@
           "403": {
             "$ref": "#/components/responses/forbiddenError"
           },
+          "404": {
+            "$ref": "#/components/responses/notFoundError"
+          },
           "500": {
             "$ref": "#/components/responses/internalServerError"
           }
@@ -13727,6 +13739,9 @@
           },
           "403": {
             "$ref": "#/components/responses/forbiddenError"
+          },
+          "404": {
+            "$ref": "#/components/responses/notFoundError"
           },
           "500": {
             "$ref": "#/components/responses/internalServerError"


### PR DESCRIPTION
**What is this feature?**

Change the manage permission endpoints to return the underlying errutil error (if any) instead of 500/400 in all cases.

**Why do we need this feature?**

This makes the returned errors more accurate and informative, and makes it easier for external tooling to work with Grafana's managed permissions. Eg, Terraform processes not found errors differently than internal server errors.

**Who is this feature for?**

Mostly internal/external devs

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
