### PR TITLE
Dev: Add vscode launching configurations for MySQL and PostgreSQL

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -55,6 +55,60 @@
       "mode": "test",
       "program": "${workspaceFolder}/${relativeFileDirname}",
       "showLog": true
+    },
+    {
+      "name": "Run Server with MySQL backend",
+      "type": "go",
+      "request": "launch",
+      "mode": "auto",
+      "program": "${workspaceFolder}/pkg/cmd/grafana/",
+      "env": {
+          "GF_DATABASE_TYPE": "mysql",
+          "GF_DATABASE_HOST": "localhost:3306",
+          "GF_DATABASE_NAME": "grafana",
+          "GF_DATABASE_USER": "grafana",
+          "GF_DATABASE_PASSWORD": "password"
+      },
+      "cwd": "${workspaceFolder}",
+      "args": ["server", "--homepath", "${workspaceFolder}", "--packaging", "dev"]
+    },
+    {
+      "name": "Run Server with Postgres backend",
+      "type": "go",
+      "request": "launch",
+      "mode": "auto",
+      "program": "${workspaceFolder}/pkg/cmd/grafana/",
+      "env": {
+          "GF_DATABASE_TYPE": "postgres",
+          "GF_DATABASE_HOST": "localhost:5432",
+          "GF_DATABASE_NAME": "grafana",
+          "GF_DATABASE_USER": "grafana",
+          "GF_DATABASE_PASSWORD": "password"
+      },
+      "cwd": "${workspaceFolder}",
+      "args": ["server", "--homepath", "${workspaceFolder}", "--packaging", "dev"]
+    }, 
+    {
+      "name": "Debug Go test (MySQL)",
+      "type": "go",
+      "request": "launch",
+      "mode": "test",
+      "env": {
+          "GRAFANA_TEST_DB": "mysql"
+      },
+      "program": "${workspaceFolder}/${relativeFileDirname}",
+      "showLog": true
+    },
+    {
+      "name": "Debug Go test (PostgreSQL)",
+      "type": "go",
+      "request": "launch",
+      "mode": "test",
+      "env": {
+          "GRAFANA_TEST_DB": "postgres"
+      },
+      "program": "${workspaceFolder}/${relativeFileDirname}",
+      "showLog": true
     }
   ]
 }


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

Adds vscode configurations for launching:
- grafana server with MySQL backend: (it assumes the MySQL server is configured as defined [in the respective devenv block](https://github.com/grafana/grafana/blob/main/devenv/docker/blocks/mysql/docker-compose.yaml) and is launched using `make devenv sources=mysql`)
- grafana server with PostgreSQL backend (it assumes the PostgreSQL server is configured as defined [in the respective devenv block](https://github.com/grafana/grafana/blob/main/devenv/docker/blocks/postgres/docker-compose.yaml) and is launched using `make devenv sources=postgres`)
- debug test with MySQL backend  (it assumes the MySQL server is configured as defined [in the respective devenv block](https://github.com/grafana/grafana/blob/main/devenv/docker/blocks/mysql_tests/docker-compose.yaml) and is launched using `make devenv sources=mysql_tests`)
- debug test with MySQL backend  (it assumes the MySQL server is configured as defined [in the respective devenv block](https://github.com/grafana/grafana/blob/main/devenv/docker/blocks/postgres_tests/docker-compose.yaml) and is launched using `make devenv sources=postgres_tests`)

![Screenshot 2024-01-22 at 2 21 15 PM](https://github.com/grafana/grafana/assets/1632407/7d3222f7-2eee-403c-af6d-3f5ea2956849)

**Why do we need this feature?**

[Add a description of the problem the feature is trying to solve.]

**Who is this feature for?**

[Add information on what kind of user the feature is for.]

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
