### PR TITLE
Alerting: Use mimir:r274-1780c50 in CI

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -809,7 +809,7 @@ services:
   - name: mysql80
     path: /var/lib/mysql
 - commands:
-  - /bin/mimir -target=backend
+  - /bin/mimir -target=backend -alertmanager.grafana-alertmanager-compatibility-enabled
   environment: {}
   image: grafana/mimir:r274-1780c50
   name: mimir_backend
@@ -1256,7 +1256,7 @@ services:
   - name: mysql80
     path: /var/lib/mysql
 - commands:
-  - /bin/mimir -target=backend
+  - /bin/mimir -target=backend -alertmanager.grafana-alertmanager-compatibility-enabled
   environment: {}
   image: grafana/mimir:r274-1780c50
   name: mimir_backend
@@ -2192,7 +2192,7 @@ services:
   - name: mysql80
     path: /var/lib/mysql
 - commands:
-  - /bin/mimir -target=backend
+  - /bin/mimir -target=backend -alertmanager.grafana-alertmanager-compatibility-enabled
   environment: {}
   image: grafana/mimir:r274-1780c50
   name: mimir_backend
@@ -3983,7 +3983,7 @@ services:
   - name: mysql80
     path: /var/lib/mysql
 - commands:
-  - /bin/mimir -target=backend
+  - /bin/mimir -target=backend -alertmanager.grafana-alertmanager-compatibility-enabled
   environment: {}
   image: grafana/mimir:r274-1780c50
   name: mimir_backend
@@ -4779,6 +4779,6 @@ kind: secret
 name: gcr_credentials
 ---
 kind: signature
-hmac: 818573a7d485db86c43840ae339fc4e7611f3d186ba9d2232b3648bb8fce3c9d
+hmac: e3ab1ec1c6d9e85f235c0d662808509453e3efa9431da4de420098d1f4e536cc
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -811,7 +811,7 @@ services:
 - commands:
   - /bin/mimir -target=backend
   environment: {}
-  image: us.gcr.io/kubernetes-dev/mimir:gotjosh-state-config-grafana-663a0ae78
+  image: grafana/mimir:r274-1780c50
   name: mimir_backend
 - environment: {}
   image: redis:6.2.11-alpine
@@ -1258,7 +1258,7 @@ services:
 - commands:
   - /bin/mimir -target=backend
   environment: {}
-  image: us.gcr.io/kubernetes-dev/mimir:gotjosh-state-config-grafana-663a0ae78
+  image: grafana/mimir:r274-1780c50
   name: mimir_backend
 - environment: {}
   image: redis:6.2.11-alpine
@@ -2194,7 +2194,7 @@ services:
 - commands:
   - /bin/mimir -target=backend
   environment: {}
-  image: us.gcr.io/kubernetes-dev/mimir:gotjosh-state-config-grafana-663a0ae78
+  image: grafana/mimir:r274-1780c50
   name: mimir_backend
 - environment: {}
   image: redis:6.2.11-alpine
@@ -3985,7 +3985,7 @@ services:
 - commands:
   - /bin/mimir -target=backend
   environment: {}
-  image: us.gcr.io/kubernetes-dev/mimir:gotjosh-state-config-grafana-663a0ae78
+  image: grafana/mimir:r274-1780c50
   name: mimir_backend
 - environment: {}
   image: redis:6.2.11-alpine
@@ -4501,7 +4501,7 @@ steps:
   - trivy --exit-code 0 --severity UNKNOWN,LOW,MEDIUM plugins/slack
   - trivy --exit-code 0 --severity UNKNOWN,LOW,MEDIUM python:3.8
   - trivy --exit-code 0 --severity UNKNOWN,LOW,MEDIUM postgres:12.3-alpine
-  - trivy --exit-code 0 --severity UNKNOWN,LOW,MEDIUM us.gcr.io/kubernetes-dev/mimir:gotjosh-state-config-grafana-663a0ae78
+  - trivy --exit-code 0 --severity UNKNOWN,LOW,MEDIUM grafana/mimir:r274-1780c50
   - trivy --exit-code 0 --severity UNKNOWN,LOW,MEDIUM mysql:5.7.39
   - trivy --exit-code 0 --severity UNKNOWN,LOW,MEDIUM mysql:8.0.32
   - trivy --exit-code 0 --severity UNKNOWN,LOW,MEDIUM redis:6.2.11-alpine
@@ -4535,7 +4535,7 @@ steps:
   - trivy --exit-code 1 --severity HIGH,CRITICAL plugins/slack
   - trivy --exit-code 1 --severity HIGH,CRITICAL python:3.8
   - trivy --exit-code 1 --severity HIGH,CRITICAL postgres:12.3-alpine
-  - trivy --exit-code 1 --severity HIGH,CRITICAL us.gcr.io/kubernetes-dev/mimir:gotjosh-state-config-grafana-663a0ae78
+  - trivy --exit-code 1 --severity HIGH,CRITICAL grafana/mimir:r274-1780c50
   - trivy --exit-code 1 --severity HIGH,CRITICAL mysql:5.7.39
   - trivy --exit-code 1 --severity HIGH,CRITICAL mysql:8.0.32
   - trivy --exit-code 1 --severity HIGH,CRITICAL redis:6.2.11-alpine
@@ -4779,6 +4779,6 @@ kind: secret
 name: gcr_credentials
 ---
 kind: signature
-hmac: c960d3059e4cb4c852b4b51ce07867d9ea1ab42cb0f30f5775e9889dba71dff3
+hmac: 818573a7d485db86c43840ae339fc4e7611f3d186ba9d2232b3648bb8fce3c9d
 
 ...

--- a/devenv/docker/blocks/mimir_backend/docker-compose.yaml
+++ b/devenv/docker/blocks/mimir_backend/docker-compose.yaml
@@ -1,8 +1,9 @@
   mimir_backend:
-    image: grafana/mimir
+    image: grafana/mimir:r274-1780c50
     container_name: mimir_backend
     command:
       - -target=backend
+      - -alertmanager.grafana-alertmanager-compatibility-enabled
   nginx:
     environment:
       - NGINX_ENVSUBST_OUTPUT_DIR=/etc/nginx

--- a/scripts/drone/services/services.star
+++ b/scripts/drone/services/services.star
@@ -57,7 +57,7 @@ def integration_test_services():
             "name": "mimir_backend",
             "image": images["mimir"],
             "environment": {},
-            "commands": ["/bin/mimir -target=backend"],
+            "commands": ["/bin/mimir -target=backend -alertmanager.grafana-alertmanager-compatibility-enabled"],
         },
         {
             "name": "redis",

--- a/scripts/drone/utils/images.star
+++ b/scripts/drone/utils/images.star
@@ -21,7 +21,7 @@ images = {
     "plugins_slack": "plugins/slack",
     "python": "python:3.8",
     "postgres_alpine": "postgres:12.3-alpine",
-    "mimir": "us.gcr.io/kubernetes-dev/mimir:gotjosh-state-config-grafana-663a0ae78",
+    "mimir": "grafana/mimir:r274-1780c50",
     "mysql5": "mysql:5.7.39",
     "mysql8": "mysql:8.0.32",
     "redis_alpine": "redis:6.2.11-alpine",


### PR DESCRIPTION
This PR replaces the private Mimir image we are using in our CI for `mimir:r274-1780c50` to unblock external PRs from being merged. This release has the changes we need to test the Cloud AM migration, there's no reason to use a private image anymore.