### PR TITLE
InfluxDB: Check the value type before casting it to the string

### DIFF
--- a/pkg/tsdb/influxdb/influxql/buffered/response_parser.go
+++ b/pkg/tsdb/influxdb/influxql/buffered/response_parser.go
@@ -241,6 +241,12 @@ func transformRowsForTimeSeries(rows []models.Row, query models.Query) data.Fram
 
 		if !hasTimeCol {
 			newFrame := newFrameWithoutTimeField(row, query)
+			if len(frames) == 0 {
+				newFrame.Meta = &data.FrameMeta{
+					ExecutedQueryString:    query.RawQuery,
+					PreferredVisualization: util.GetVisType(query.ResultFormat),
+				}
+			}
 			frames = append(frames, newFrame)
 		} else {
 			for colIndex, column := range row.Columns {
@@ -342,12 +348,5 @@ func newFrameWithoutTimeField(row models.Row, query models.Query) *data.Frame {
 
 	field := data.NewField("Value", nil, values)
 	frame := data.NewFrame(row.Name, field)
-	frame.Meta = &data.FrameMeta{
-		ExecutedQueryString:    query.RawQuery,
-		PreferredVisualization: util.TableVisType,
-	}
-	if query.ResultFormat == "logs" {
-		frame.Meta.PreferredVisualization = util.LogsVisType
-	}
 	return frame
 }

--- a/pkg/tsdb/influxdb/influxql/buffered/response_parser.go
+++ b/pkg/tsdb/influxdb/influxql/buffered/response_parser.go
@@ -328,6 +328,11 @@ func newFrameWithoutTimeField(row models.Row, query models.Query) *data.Frame {
 			if len(valuePair) >= 2 {
 				values = append(values, util.ParseString(valuePair[1]))
 			}
+		} else if strings.Contains(strings.ToLower(query.RawQuery), strings.ToLower("SHOW DIAGNOSTICS")) {
+			// https://docs.influxdata.com/platform/monitoring/influxdata-platform/tools/show-diagnostics/
+			for _, vp := range valuePair {
+				values = append(values, util.ParseString(vp))
+			}
 		} else {
 			if len(valuePair) >= 1 {
 				values = append(values, util.ParseString(valuePair[0]))

--- a/pkg/tsdb/influxdb/influxql/buffered/response_parser.go
+++ b/pkg/tsdb/influxdb/influxql/buffered/response_parser.go
@@ -339,7 +339,10 @@ func newFrameWithoutTimeField(row models.Row, query models.Query) *data.Frame {
 	frame := data.NewFrame(row.Name, field)
 	frame.Meta = &data.FrameMeta{
 		ExecutedQueryString:    query.RawQuery,
-		PreferredVisualization: util.GetVisType(query.ResultFormat),
+		PreferredVisualization: util.TableVisType,
+	}
+	if query.ResultFormat == "logs" {
+		frame.Meta.PreferredVisualization = util.LogsVisType
 	}
 	return frame
 }

--- a/pkg/tsdb/influxdb/influxql/buffered/response_parser.go
+++ b/pkg/tsdb/influxdb/influxql/buffered/response_parser.go
@@ -326,11 +326,11 @@ func newFrameWithoutTimeField(row models.Row, query models.Query) *data.Frame {
 	for _, valuePair := range row.Values {
 		if strings.Contains(strings.ToLower(query.RawQuery), strings.ToLower("SHOW TAG VALUES")) {
 			if len(valuePair) >= 2 {
-				values = append(values, util.ToPtr(valuePair[1].(string)))
+				values = append(values, util.ParseString(valuePair[1]))
 			}
 		} else {
 			if len(valuePair) >= 1 {
-				values = append(values, util.ToPtr(valuePair[0].(string)))
+				values = append(values, util.ParseString(valuePair[0]))
 			}
 		}
 	}

--- a/pkg/tsdb/influxdb/influxql/util/util.go
+++ b/pkg/tsdb/influxdb/influxql/util/util.go
@@ -140,9 +140,9 @@ func ParseNumber(value any) *float64 {
 }
 
 func ParseString(value any) *string {
-	switch value.(type) {
+	switch val := value.(type) {
 	case string:
-		return ToPtr(value.(string))
+		return ToPtr(val)
 	default:
 		return ToPtr(fmt.Sprintf("%v", value))
 	}

--- a/pkg/tsdb/influxdb/influxql/util/util.go
+++ b/pkg/tsdb/influxdb/influxql/util/util.go
@@ -139,6 +139,15 @@ func ParseNumber(value any) *float64 {
 	return &fvalue
 }
 
+func ParseString(value any) *string {
+	switch value.(type) {
+	case string:
+		return ToPtr(value.(string))
+	default:
+		return ToPtr(fmt.Sprintf("%v", value))
+	}
+}
+
 func GetVisType(resFormat string) data.VisType {
 	switch resFormat {
 	case "table":

--- a/pkg/tsdb/influxdb/influxql/util/util_test.go
+++ b/pkg/tsdb/influxdb/influxql/util/util_test.go
@@ -1,0 +1,23 @@
+package util
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseString(t *testing.T) {
+	t.Run("parse bool value to string", func(t *testing.T) {
+		val := true
+		expected := ToPtr("true")
+		result := ParseString(val)
+		require.Equal(t, expected, result)
+	})
+
+	t.Run("parse number value to string", func(t *testing.T) {
+		val := 123
+		expected := ToPtr("123")
+		result := ParseString(val)
+		require.Equal(t, expected, result)
+	})
+}


### PR DESCRIPTION
**What is this feature?**

We assume all the values returned from influxdb will be `string`. But there are cases that could be otherwise. For instance when we run `SHOW DIAGNOSTICS` it returns a lot of information. https://docs.influxdata.com/platform/monitoring/influxdata-platform/tools/show-diagnostics/
The data we received may contain Integer or Boolean values. Casting those values to string causes panics. 
With this PR we are checking the types and handling the conversion properly. 

**Why do we need this feature?**

For better type conversion

**Who is this feature for?**

InfluxDB InfluxQL language users

**Which issue(s) does this PR fix?**:
Fixes https://github.com/grafana/grafana/issues/79849

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
