### PR TITLE
Chore: Deprecate GetFolderByID

### DIFF
--- a/pkg/services/folder/folderimpl/dashboard_folder_store.go
+++ b/pkg/services/folder/folderimpl/dashboard_folder_store.go
@@ -43,6 +43,7 @@ func (d *DashboardFolderStoreImpl) GetFolderByTitle(ctx context.Context, orgID i
 	return dashboards.FromDashboard(&dashboard), err
 }
 
+// Deprecated: use GetFolderByUID instead
 func (d *DashboardFolderStoreImpl) GetFolderByID(ctx context.Context, orgID int64, id int64) (*folder.Folder, error) {
 	// nolint:staticcheck
 	dashboard := dashboards.Dashboard{OrgID: orgID, FolderID: 0, ID: id}

--- a/pkg/services/folder/folderimpl/folder.go
+++ b/pkg/services/folder/folderimpl/folder.go
@@ -406,6 +406,7 @@ func (s *Service) GetParents(ctx context.Context, q folder.GetParentsQuery) ([]*
 	return s.store.GetParents(ctx, q)
 }
 
+// Deprecated: use getFolderByUID instead
 func (s *Service) getFolderByID(ctx context.Context, id int64, orgID int64) (*folder.Folder, error) {
 	if id == 0 {
 		return &folder.GeneralFolder, nil

--- a/pkg/services/folder/foldertest/folder_store_mock.go
+++ b/pkg/services/folder/foldertest/folder_store_mock.go
@@ -14,6 +14,7 @@ type FakeFolderStore struct {
 	mock.Mock
 }
 
+// Deprecated: use GetFolderByUID instead
 // GetFolderByID provides a mock function with given fields: ctx, orgID, id
 func (_m *FakeFolderStore) GetFolderByID(ctx context.Context, orgID int64, id int64) (*folder.Folder, error) {
 	ret := _m.Called(ctx, orgID, id)

--- a/pkg/services/folder/service.go
+++ b/pkg/services/folder/service.go
@@ -36,6 +36,7 @@ type FolderStore interface {
 	GetFolderByTitle(ctx context.Context, orgID int64, title string) (*Folder, error)
 	// GetFolderByUID retrieves a folder by its UID
 	GetFolderByUID(ctx context.Context, orgID int64, uid string) (*Folder, error)
+	// Deprecated: use GetFolderByUID instead
 	// GetFolderByID retrieves a folder by its ID
 	GetFolderByID(ctx context.Context, orgID int64, id int64) (*Folder, error)
 	// GetFolders returns all folders for the given orgID and UIDs.


### PR DESCRIPTION
Add deprecation comments to `GetFolderByID` and `getFolderByID`

Ref https://github.com/grafana/grafana/issues/80315