### PR TITLE
datatrails: allow multiple search terms to help select metric names

### DIFF
--- a/public/app/features/trails/MetricSelectScene.tsx
+++ b/public/app/features/trails/MetricSelectScene.tsx
@@ -115,7 +115,7 @@ export class MetricSelectScene extends SceneObjectBase<MetricSelectSceneState> {
       return;
     }
 
-    const searchRegex = createSearchRegExp(this.state.searchQuery || '');
+    const searchRegex = createSearchRegExp(this.state.searchQuery);
     const metricNames = variable.state.options;
     const sortedMetricNames =
       trail.state.metric !== undefined ? sortRelatedMetrics(metricNames, trail.state.metric) : metricNames;
@@ -127,7 +127,7 @@ export class MetricSelectScene extends SceneObjectBase<MetricSelectSceneState> {
 
       const metricName = String(metric.value);
 
-      if (!searchRegex || !searchRegex.test(metricName)) {
+      if (searchRegex && !searchRegex.test(metricName)) {
         continue;
       }
 
@@ -324,7 +324,10 @@ function getStyles(theme: GrafanaTheme2) {
 // Consider any sequence of characters not permitted for metric names as a sepratator
 const splitSeparator = /[^a-z0-9_:]+/;
 
-function createSearchRegExp(spaceSeparatedMetricNames: string) {
+function createSearchRegExp(spaceSeparatedMetricNames?: string) {
+  if (!spaceSeparatedMetricNames) {
+    return null;
+  }
   const searchParts = spaceSeparatedMetricNames
     ?.toLowerCase()
     .split(splitSeparator)

--- a/public/app/features/trails/MetricSelectScene.tsx
+++ b/public/app/features/trails/MetricSelectScene.tsx
@@ -115,7 +115,7 @@ export class MetricSelectScene extends SceneObjectBase<MetricSelectSceneState> {
       return;
     }
 
-    const searchRegex = new RegExp(this.state.searchQuery ?? '.*');
+    const searchRegex = createSearchRegExp(this.state.searchQuery || '');
     const metricNames = variable.state.options;
     const sortedMetricNames =
       trail.state.metric !== undefined ? sortRelatedMetrics(metricNames, trail.state.metric) : metricNames;
@@ -126,7 +126,7 @@ export class MetricSelectScene extends SceneObjectBase<MetricSelectSceneState> {
       const metric = sortedMetricNames[index];
 
       const metricName = String(metric.value);
-      if (!metricName.match(searchRegex)) {
+      if (!metricName.toLowerCase().match(searchRegex)) {
         continue;
       }
 
@@ -318,4 +318,16 @@ function getStyles(theme: GrafanaTheme2) {
       marginBottom: theme.spacing(1),
     }),
   };
+}
+
+// Consider any sequence of characters not permitted for metric names as a sepratator
+const splitSeparator = /[^a-z0-9_:]+/;
+
+function createSearchRegExp(spaceSeparatedMetricNames: string) {
+  const searchParts = spaceSeparatedMetricNames
+    ?.toLowerCase()
+    .split(splitSeparator)
+    .filter((part) => part.length > 0);
+  const regex = `(.*${searchParts?.join('.*|.*')}.*)`;
+  return new RegExp(regex);
 }

--- a/public/app/features/trails/MetricSelectScene.tsx
+++ b/public/app/features/trails/MetricSelectScene.tsx
@@ -126,7 +126,8 @@ export class MetricSelectScene extends SceneObjectBase<MetricSelectSceneState> {
       const metric = sortedMetricNames[index];
 
       const metricName = String(metric.value);
-      if (!metricName.toLowerCase().match(searchRegex)) {
+
+      if (!searchRegex || !searchRegex.test(metricName)) {
         continue;
       }
 
@@ -327,7 +328,15 @@ function createSearchRegExp(spaceSeparatedMetricNames: string) {
   const searchParts = spaceSeparatedMetricNames
     ?.toLowerCase()
     .split(splitSeparator)
-    .filter((part) => part.length > 0);
-  const regex = `(.*${searchParts?.join('.*|.*')}.*)`;
-  return new RegExp(regex);
+    .filter((part) => part.length > 0)
+    .map((part) => `(?=(.*${part}.*))`);
+
+  if (searchParts.length === 0) {
+    return null;
+  }
+
+  const regex = searchParts.join('');
+  //  (?=(.*expr1.*))(?=().*expr2.*))...
+  // The ?=(...) lookahead allows us to match these in any order.
+  return new RegExp(regex, 'igy');
 }


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

An improvement to the data trails (explorer -> metrics) metric selector.

The goal was to be similar to the metric selector in the prometheus query editor. 
> the metric search really needs the same behaviour as the Prometheus query editor MetricSelect.  It has a really nice search behavior that enables you to search on multiple fragmens of the metric (and not in order).
> so for a metric like `grafana_http_request_duration_seconds_bucket`, you can search for it with search strings like `htt buck`, or `duration http`

![image](https://github.com/grafana/grafana/assets/38694490/55294c48-eaa5-4d47-9dae-c95bd3e5145c)

![image](https://github.com/grafana/grafana/assets/38694490/3cd5a1bf-0555-4cac-a57c-56666d9b7b68)

![image](https://github.com/grafana/grafana/assets/38694490/1945e2b8-1344-43c9-92d9-474dbe69bdd1)

- whitespace (or non metric name characters) separate search terms
- case insensitive
- each search term must appear at least once in the metric name for it to be included
  - duplicate or overlapping search terms are permissive: e.g., `go go build go build` would include `go_build_info`

E.g., 
`   aler   ` includes ALERTS, ALERTS_FOR_STATE, grafana_alerting_active_configurations, etc.
`prom http` includes: promhttp_metric_handler_requests_in_flight
  but not grafana_http_request_duration_seconds_sum



**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
