### PR TITLE
IDForwarding: Always forward id tokens to plugins

### DIFF
--- a/pkg/api/pluginproxy/ds_proxy.go
+++ b/pkg/api/pluginproxy/ds_proxy.go
@@ -19,7 +19,6 @@ import (
 	glog "github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/infra/tracing"
 	"github.com/grafana/grafana/pkg/plugins"
-	"github.com/grafana/grafana/pkg/services/auth"
 	contextmodel "github.com/grafana/grafana/pkg/services/contexthandler/model"
 	"github.com/grafana/grafana/pkg/services/datasources"
 	"github.com/grafana/grafana/pkg/services/featuremgmt"
@@ -270,7 +269,7 @@ func (proxy *DataSourceProxy) director(req *http.Request) {
 		}
 	}
 
-	if proxy.features.IsEnabled(req.Context(), featuremgmt.FlagIdForwarding) && auth.IsIDForwardingEnabledForDataSource(proxy.ds) {
+	if proxy.features.IsEnabled(req.Context(), featuremgmt.FlagIdForwarding) {
 		proxyutil.ApplyForwardIDHeader(req, proxy.ctx.SignedInUser)
 	}
 }

--- a/pkg/services/auth/id.go
+++ b/pkg/services/auth/id.go
@@ -21,5 +21,3 @@ type IDClaims struct {
 	jwt.Claims
 	AuthenticatedBy string `json:"authenticatedBy,omitempty"`
 }
-
-const settingsKey = "forwardGrafanaIdToken"

--- a/pkg/services/auth/id.go
+++ b/pkg/services/auth/id.go
@@ -6,7 +6,6 @@ import (
 	"github.com/go-jose/go-jose/v3/jwt"
 
 	"github.com/grafana/grafana/pkg/services/auth/identity"
-	"github.com/grafana/grafana/pkg/services/datasources"
 )
 
 type IDService interface {
@@ -24,7 +23,3 @@ type IDClaims struct {
 }
 
 const settingsKey = "forwardGrafanaIdToken"
-
-func IsIDForwardingEnabledForDataSource(ds *datasources.DataSource) bool {
-	return ds.JsonData != nil && ds.JsonData.Get(settingsKey).MustBool()
-}

--- a/pkg/services/pluginsintegration/clientmiddleware/forward_id_middleware.go
+++ b/pkg/services/pluginsintegration/clientmiddleware/forward_id_middleware.go
@@ -5,11 +5,8 @@ import (
 
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
 
-	"github.com/grafana/grafana/pkg/components/simplejson"
 	"github.com/grafana/grafana/pkg/plugins"
-	"github.com/grafana/grafana/pkg/services/auth"
 	"github.com/grafana/grafana/pkg/services/contexthandler"
-	"github.com/grafana/grafana/pkg/services/datasources"
 )
 
 const forwardIDHeaderName = "X-Grafana-Id"
@@ -33,15 +30,6 @@ func (m *ForwardIDMiddleware) applyToken(ctx context.Context, pCtx backend.Plugi
 	reqCtx := contexthandler.FromContext(ctx)
 	// if request not for a datasource or no HTTP request context skip middleware
 	if req == nil || reqCtx == nil || reqCtx.SignedInUser == nil || pCtx.DataSourceInstanceSettings == nil {
-		return nil
-	}
-
-	jsonDataBytes, err := simplejson.NewJson(pCtx.DataSourceInstanceSettings.JSONData)
-	if err != nil {
-		return err
-	}
-
-	if !auth.IsIDForwardingEnabledForDataSource(&datasources.DataSource{JsonData: jsonDataBytes}) {
 		return nil
 	}
 


### PR DESCRIPTION
**What is this feature?**
After some discussion in https://github.com/grafana/grafana/pull/80840 we decided we should always forward id token headers to plugins.

This is still protected by feature toggle

**Which issue(s) does this PR fix?**:


Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
