### PR TITLE
Loki: Remove `parsed_query` from tracking in favor of `obfuscated_query`

### DIFF
--- a/public/app/plugins/datasource/loki/datasource.test.ts
+++ b/public/app/plugins/datasource/loki/datasource.test.ts
@@ -209,7 +209,7 @@ describe('LokiDatasource', () => {
         expect.objectContaining({
           query_type: 'logs',
           line_limit: 80,
-          parsed_query: parseToNodeNamesArray('{a="b"}').join(','),
+          obfuscated_query: '{Identifier=String}',
         })
       );
     });
@@ -226,7 +226,7 @@ describe('LokiDatasource', () => {
         expect.objectContaining({
           query_type: 'logs',
           line_limit: 80,
-          parsed_query: parseToNodeNamesArray('{a="b"}').join(','),
+          obfuscated_query: '{Identifier=String}',
         })
       );
     });

--- a/public/app/plugins/datasource/loki/datasource.test.ts
+++ b/public/app/plugins/datasource/loki/datasource.test.ts
@@ -35,7 +35,6 @@ import { createLokiDatasource } from './__mocks__/datasource';
 import { createMetadataRequest } from './__mocks__/metadataRequest';
 import { LokiDatasource, REF_ID_DATA_SAMPLES } from './datasource';
 import { runSplitQuery } from './querySplitting';
-import { parseToNodeNamesArray } from './queryUtils';
 import { LokiOptions, LokiQuery, LokiQueryType, LokiVariableQueryType, SupportingQueryType } from './types';
 
 jest.mock('@grafana/runtime', () => {

--- a/public/app/plugins/datasource/loki/tracking.test.ts
+++ b/public/app/plugins/datasource/loki/tracking.test.ts
@@ -157,7 +157,6 @@ test('Tracks grouped queries', () => {
     legend: undefined,
     line_limit: 10,
     obfuscated_query: '{Identifier=String}',
-
     query_type: 'logs',
     query_vector_type: undefined,
     resolution: 1,

--- a/public/app/plugins/datasource/loki/tracking.test.ts
+++ b/public/app/plugins/datasource/loki/tracking.test.ts
@@ -79,8 +79,6 @@ test('Tracks queries', () => {
     legend: undefined,
     line_limit: undefined,
     obfuscated_query: 'count_over_time({Identifier=String}[1m])',
-    parsed_query:
-      'LogQL,Expr,MetricExpr,RangeAggregationExpr,RangeOp,CountOverTime,LogRangeExpr,Selector,Matchers,Matcher,Identifier,Eq,String,Range,Duration',
     query_type: 'metric',
     query_vector_type: undefined,
     resolution: 1,
@@ -107,8 +105,6 @@ test('Tracks predefined operations', () => {
     legend: undefined,
     line_limit: undefined,
     obfuscated_query: 'count_over_time({Identifier=String}[1m])',
-    parsed_query:
-      'LogQL,Expr,MetricExpr,RangeAggregationExpr,RangeOp,CountOverTime,LogRangeExpr,Selector,Matchers,Matcher,Identifier,Eq,String,Range,Duration',
     query_type: 'metric',
     query_vector_type: undefined,
     resolution: 1,
@@ -135,8 +131,6 @@ test('Tracks grouped queries', () => {
     legend: undefined,
     line_limit: undefined,
     obfuscated_query: 'count_over_time({Identifier=String}[1m])',
-    parsed_query:
-      'LogQL,Expr,MetricExpr,RangeAggregationExpr,RangeOp,CountOverTime,LogRangeExpr,Selector,Matchers,Matcher,Identifier,Eq,String,Range,Duration',
     query_type: 'metric',
     query_vector_type: undefined,
     resolution: 1,
@@ -163,7 +157,7 @@ test('Tracks grouped queries', () => {
     legend: undefined,
     line_limit: 10,
     obfuscated_query: '{Identifier=String}',
-    parsed_query: 'LogQL,Expr,LogExpr,Selector,Matchers,Matcher,Identifier,Eq,String',
+
     query_type: 'logs',
     query_vector_type: undefined,
     resolution: 1,

--- a/public/app/plugins/datasource/loki/tracking.ts
+++ b/public/app/plugins/datasource/loki/tracking.ts
@@ -10,7 +10,7 @@ import {
   REF_ID_STARTER_LOG_VOLUME,
 } from './datasource';
 import pluginJson from './plugin.json';
-import { getNormalizedLokiQuery, isLogsQuery, obfuscate, parseToNodeNamesArray } from './queryUtils';
+import { getNormalizedLokiQuery, isLogsQuery, obfuscate } from './queryUtils';
 import { variableRegex } from './querybuilder/parsingUtils';
 import { LokiGroupedRequest, LokiQuery, LokiQueryType } from './types';
 

--- a/public/app/plugins/datasource/loki/tracking.ts
+++ b/public/app/plugins/datasource/loki/tracking.ts
@@ -177,7 +177,6 @@ export function trackQuery(
       has_error: response.error !== undefined,
       legend: query.legendFormat,
       line_limit: query.maxLines,
-      parsed_query: parseToNodeNamesArray(query.expr).join(','),
       obfuscated_query: obfuscate(query.expr),
       query_type: isLogsQuery(query.expr) ? 'logs' : 'metric',
       query_vector_type: query.queryType,


### PR DESCRIPTION
**What is this feature?**

The parsed query isn't really needed anymore since we've got the "better" `obfuscated_query` property. Removing `parsed_query` to save some bytes and 💵 