### PR TITLE
Tempo: Add span, trace vars to trace to metrics interpolation

### DIFF
--- a/public/app/features/explore/TraceView/createSpanLink.tsx
+++ b/public/app/features/explore/TraceView/createSpanLink.tsx
@@ -16,7 +16,6 @@ import {
 } from '@grafana/data';
 import {
   TraceToProfilesOptions,
-  TraceToMetricQuery,
   TraceToMetricsOptions,
   TraceToLogsOptionsV2,
   TraceToLogsTag,

--- a/public/app/features/explore/TraceView/createSpanLink.tsx
+++ b/public/app/features/explore/TraceView/createSpanLink.tsx
@@ -257,9 +257,9 @@ function legacyCreateSpanLinkFactory(
     // Get metrics links
     if (metricsDataSourceSettings && traceToMetricsOptions?.queries) {
       for (const query of traceToMetricsOptions.queries) {
-        const expr = !query.query
-          ? `histogram_quantile(0.5, sum(rate(traces_spanmetrics_latency_bucket{service="${span.process.serviceName}"}[5m])) by (le))`
-          : query.query;
+        const expr =
+          query.query ||
+          `histogram_quantile(0.5, sum(rate(traces_spanmetrics_latency_bucket{service="${span.process.serviceName}"}[5m])) by (le))`;
         const dataLink: DataLink<PromQuery> = {
           title: metricsDataSourceSettings.name,
           url: '',

--- a/public/app/features/explore/TraceView/createSpanLink.tsx
+++ b/public/app/features/explore/TraceView/createSpanLink.tsx
@@ -258,7 +258,9 @@ function legacyCreateSpanLinkFactory(
     // Get metrics links
     if (metricsDataSourceSettings && traceToMetricsOptions?.queries) {
       for (const query of traceToMetricsOptions.queries) {
-        const expr = buildMetricsQuery(query, traceToMetricsOptions?.tags || [], span);
+        const expr = !query.query
+          ? `histogram_quantile(0.5, sum(rate(traces_spanmetrics_latency_bucket{service="${span.process.serviceName}"}[5m])) by (le))`
+          : query.query;
         const dataLink: DataLink<PromQuery> = {
           title: metricsDataSourceSettings.name,
           url: '',
@@ -272,10 +274,23 @@ function legacyCreateSpanLinkFactory(
           },
         };
 
+        const tagsToUse =
+          traceToMetricsOptions.tags && traceToMetricsOptions.tags.length > 0
+            ? traceToMetricsOptions.tags
+            : defaultKeys;
+
+        scopedVars = {
+          ...scopedVars,
+          __tags: {
+            text: 'Tags',
+            value: getFormattedTags(span, tagsToUse),
+          },
+        };
+
         const link = mapInternalLinkToExplore({
           link: dataLink,
           internalLink: dataLink.internal!,
-          scopedVars: {},
+          scopedVars,
           range: getTimeRangeFromSpan(span, {
             startMs: traceToMetricsOptions.spanStartTimeShift
               ? rangeUtil.intervalToMs(traceToMetricsOptions.spanStartTimeShift)
@@ -566,34 +581,6 @@ function getTimeRangeFromSpan(
       to,
     },
   };
-}
-
-// Interpolates span attributes into trace to metric query, or returns default query
-function buildMetricsQuery(
-  query: TraceToMetricQuery,
-  tags: Array<{ key: string; value?: string }> = [],
-  span: TraceSpan
-): string {
-  if (!query.query) {
-    return `histogram_quantile(0.5, sum(rate(traces_spanmetrics_latency_bucket{service="${span.process.serviceName}"}[5m])) by (le))`;
-  }
-
-  let expr = query.query;
-  if (tags.length && expr.indexOf('$__tags') !== -1) {
-    const spanTags = [...span.process.tags, ...span.tags];
-    const labels = tags.reduce<string[]>((acc, tag) => {
-      const tagValue = spanTags.find((t) => t.key === tag.key)?.value;
-      if (tagValue) {
-        acc.push(`${tag.value ? tag.value : tag.key}="${tagValue}"`);
-      }
-      return acc;
-    }, []);
-
-    const labelsQuery = labels?.join(', ');
-    expr = expr.replace(/\$__tags/g, labelsQuery);
-  }
-
-  return expr;
 }
 
 /**


### PR DESCRIPTION
**What is this feature?**

Adds span, trace vars to trace to metrics interpolation.

**Why do we need this feature?**

More variables that can be used in trace to metrics interpolation.

**Who is this feature for?**

Tempo users.

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes https://github.com/grafana/grafana/issues/60961

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
