### PR TITLE
Alerting: Swap order between Annotations and Labels step in the alert rule form.

### DIFF
--- a/public/app/features/alerting/unified/components/rule-editor/AnnotationHeaderField.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/AnnotationHeaderField.tsx
@@ -38,8 +38,10 @@ const AnnotationHeaderField = ({
               switch (annotationField.key) {
                 case Annotation.dashboardUID:
                   label = 'Dashboard and panel';
+                  break;
                 case Annotation.panelID:
                   label = '';
+                  break;
                 default:
                   label = annotationLabels[annotation] && annotationLabels[annotation] + ' (optional)';
               }

--- a/public/app/features/alerting/unified/components/rule-editor/AnnotationsStep.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/AnnotationsStep.tsx
@@ -95,11 +95,11 @@ const AnnotationsStep = () => {
     return (
       <Stack direction="row" gap={0.5} alignItems="baseline">
         <Text variant="bodySmall" color="secondary">
-          Add annotations to provide more context in your alert notifications.
+          Add more context in your notification messages.
         </Text>
         <NeedHelpInfo
-          contentText={`Annotations add metadata to provide more information on the alert in your alert notifications.
-          For example, add a Summary annotation to tell you which value caused the alert to fire or which server it happened on.
+          contentText={`Annotations add metadata to provide more information on the alert in your alert notification messages. 
+          For example, add a Summary annotation to tell you which value caused the alert to fire or which server it happened on. 
           Annotations can contain a combination of text and template code.`}
           externalLink={docsLink}
           linkText={`Read about annotations`}
@@ -110,7 +110,7 @@ const AnnotationsStep = () => {
   }
 
   return (
-    <RuleEditorSection stepNo={4} title="Add annotations" description={getAnnotationsSectionDescription()} fullWidth>
+    <RuleEditorSection stepNo={5} title="Add annotations" description={getAnnotationsSectionDescription()} fullWidth>
       <Stack direction="column" gap={1}>
         {fields.map((annotationField, index: number) => {
           const isUrl = annotations[index]?.key?.toLocaleLowerCase().endsWith('url');

--- a/public/app/features/alerting/unified/components/rule-editor/NotificationsStep.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/NotificationsStep.tsx
@@ -37,8 +37,8 @@ export const NotificationsStep = ({ alertUid }: NotificationsStepProps) => {
 
   return (
     <RuleEditorSection
-      stepNo={type === RuleFormType.cloudRecording ? 4 : 5}
-      title={type === RuleFormType.cloudRecording ? 'Add labels' : 'Labels and notifications'}
+      stepNo={4}
+      title={type === RuleFormType.cloudRecording ? 'Add labels' : 'Configure labels and notifications'}
       description={
         <Stack direction="row" gap={0.5} alignItems="baseline">
           {type === RuleFormType.cloudRecording ? (
@@ -59,7 +59,7 @@ export const NotificationsStep = ({ alertUid }: NotificationsStepProps) => {
       <LabelsField dataSourceName={dataSourceName} />
       {shouldAllowSimplifiedRouting && (
         <div className={styles.configureNotifications}>
-          <Text element="h5">Configure notifications</Text>
+          <Text element="h5">Notifications</Text>
           <Text variant="bodySmall" color="secondary">
             Select who should receive a notification when an alert rule fires.
           </Text>

--- a/public/app/features/alerting/unified/components/rule-editor/alert-rule-form/AlertRuleForm.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/alert-rule-form/AlertRuleForm.tsx
@@ -240,10 +240,10 @@ export const AlertRuleForm = ({ existing, prefill }: Props) => {
                   {type === RuleFormType.cloudRecording && <RecordingRulesNameSpaceAndGroupStep />}
 
                   {/* Step 4 & 5 */}
-                  {/* Annotations only for cloud and Grafana */}
-                  {type !== RuleFormType.cloudRecording && <AnnotationsStep />}
                   {/* Notifications step*/}
                   <NotificationsStep alertUid={uidFromParams} />
+                  {/* Annotations only for cloud and Grafana */}
+                  {type !== RuleFormType.cloudRecording && <AnnotationsStep />}
                 </>
               )}
             </Stack>

--- a/public/app/features/alerting/unified/components/rule-editor/alert-rule-form/ModifyExportRuleForm.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/alert-rule-form/ModifyExportRuleForm.tsx
@@ -97,10 +97,10 @@ export function ModifyExportRuleForm({ ruleForm, alertUid }: ModifyExportRuleFor
                 />
 
                 {/* Step 4 & 5 */}
-                {/* Annotations only for cloud and Grafana */}
-                <AnnotationsStep />
                 {/* Notifications step*/}
                 <NotificationsStep alertUid={alertUid} />
+                {/* Annotations only for cloud and Grafana */}
+                <AnnotationsStep />
               </Stack>
             </CustomScrollbar>
           </div>

--- a/public/app/features/alerting/unified/components/rule-editor/notificaton-preview/NotificationPreview.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/notificaton-preview/NotificationPreview.tsx
@@ -71,7 +71,7 @@ export const NotificationPreview = ({
     <Stack direction="column">
       <div className={styles.routePreviewHeaderRow}>
         <div className={styles.previewHeader}>
-          <Text element="h4">Alert instance routing preview</Text>
+          <Text element="h5">Alert instance routing preview</Text>
           {isLoading && previewUninitialized && (
             <Text color="secondary" variant="bodySmall">
               Loading...
@@ -124,6 +124,7 @@ const getStyles = (theme: GrafanaTheme2) => ({
     flex-direction: row;
     justify-content: space-between;
     align-items: flex-start;
+    margin-top: ${theme.spacing(1)};
   `,
   collapseLabel: css`
     flex: 1;


### PR DESCRIPTION
**What is this feature?**

This PR change the order in steps in the alert rule form and updates some texts. (Same change is done in the Modfiy export form)
This PR also fix data source and panel label not being correct.

**_Before the change we had:_**
4. Add annotations 
5. Labels and notifications

**_After the change:_**
4. Configure labels and notifications
5. Add annotations

**Why do we need this feature?**

We need to provide the best user experience, and with this change we think users can go through the steps in a more logical way.

**Who is this feature for?**

All users.

**Special notes for your reviewer:**

<img width="1191" alt="Screenshot 2024-01-23 at 13 37 21" src="https://github.com/grafana/grafana/assets/33540275/c6a557a3-28f6-4f65-a4cb-53776a4cf336">

**_Recording rules are not affected:_**

<img width="1111" alt="Screenshot 2024-01-23 at 13 00 09" src="https://github.com/grafana/grafana/assets/33540275/78c7b386-db62-4382-b39b-9608b4375061">

**_Before the data source and panel label fix:_**

<img width="583" alt="Screenshot 2024-01-23 at 15 34 43" src="https://github.com/grafana/grafana/assets/33540275/e807187a-53f9-4250-9ea1-fb776d78243c">


**_After the data source and panel label fix:_**

<img width="504" alt="Screenshot 2024-01-23 at 15 34 09" src="https://github.com/grafana/grafana/assets/33540275/f754ac53-82d7-4236-9d67-63a63baccd30">

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
