### PR TITLE
Chore: Fix path resolution for the release os Azure Monitor

### DIFF
--- a/.github/workflows/core-plugins-build-and-release.yml
+++ b/.github/workflows/core-plugins-build-and-release.yml
@@ -87,7 +87,7 @@ jobs:
         id: check_backend
         shell: bash
         run: |
-          if [ -d ./pkg/tsdb/${{ inputs.plugin_id }} ]; then
+          if egrep -qr --include=main.go 'datasource.Manage\("${{ inputs.plugin_id }}"' pkg/tsdb; then
             echo "has_backend=true" >> $GITHUB_OUTPUT
           else
             echo "has_backend=false" >> $GITHUB_OUTPUT
@@ -198,6 +198,8 @@ jobs:
           gsutil -m cp -r ci/packages/*darwin* gs://${{ env.GCP_BUCKET }}/${{ inputs.plugin_id }}/release/${VERSION}/darwin
           gsutil -m cp -r ci/packages/*any* gs://${{ env.GCP_BUCKET }}/${{ inputs.plugin_id }}/release/${VERSION}/any
       - name: Publish new plugin version on grafana.com
+        # TODO: This assumes that there are packages for all platforms
+        # which is not true for frontend only plugins
         working-directory: ${{ steps.get_dir.outputs.dir }}
         env:
           GCOM_TOKEN: ${{ env.PLUGINS_GCOM_TOKEN }}


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

Fixes #81000

The workflow wrongly assumes there is not a backend for Azure since the directory `pkg/tsdb/grafana-azure-monitor-datasource` does not exist (it's called `pkg/tsdb/azuremonitor`).
