### PR TITLE
Infinite scroll: share loader with log context + small fixes

### DIFF
--- a/.betterer.results
+++ b/.betterer.results
@@ -3691,6 +3691,9 @@ exports[`better eslint`] = {
       [0, 0, 0, "Do not use any type assertions.", "3"],
       [0, 0, 0, "Do not use any type assertions.", "4"]
     ],
+    "public/app/features/logs/components/LoadingIndicator.tsx:5381": [
+      [0, 0, 0, "Styles should be written using objects.", "0"]
+    ],
     "public/app/features/logs/components/LogDetailsRow.tsx:5381": [
       [0, 0, 0, "Styles should be written using objects.", "0"],
       [0, 0, 0, "Styles should be written using objects.", "1"],
@@ -3762,9 +3765,6 @@ exports[`better eslint`] = {
       [0, 0, 0, "Styles should be written using objects.", "33"],
       [0, 0, 0, "Styles should be written using objects.", "34"],
       [0, 0, 0, "Styles should be written using objects.", "35"]
-    ],
-    "public/app/features/logs/components/log-context/LoadingIndicator.tsx:5381": [
-      [0, 0, 0, "Styles should be written using objects.", "0"]
     ],
     "public/app/features/logs/components/log-context/LogRowContextModal.tsx:5381": [
       [0, 0, 0, "Styles should be written using objects.", "0"],

--- a/public/app/features/explore/Logs/Logs.tsx
+++ b/public/app/features/explore/Logs/Logs.tsx
@@ -727,7 +727,12 @@ class UnthemedLogs extends PureComponent<Props, State> {
                 </InlineFieldRow>
 
                 <div>
-                  <InlineField label="Display results" className={styles.horizontalInlineLabel} transparent disabled={isFlipping || loading}>
+                  <InlineField
+                    label="Display results"
+                    className={styles.horizontalInlineLabel}
+                    transparent
+                    disabled={isFlipping || loading}
+                  >
                     <RadioButtonGroup
                       options={[
                         {

--- a/public/app/features/explore/Logs/Logs.tsx
+++ b/public/app/features/explore/Logs/Logs.tsx
@@ -727,9 +727,8 @@ class UnthemedLogs extends PureComponent<Props, State> {
                 </InlineFieldRow>
 
                 <div>
-                  <InlineField label="Display results" className={styles.horizontalInlineLabel} transparent>
+                  <InlineField label="Display results" className={styles.horizontalInlineLabel} transparent disabled={isFlipping || loading}>
                     <RadioButtonGroup
-                      disabled={isFlipping || loading}
                       options={[
                         {
                           label: 'Newest first',

--- a/public/app/features/explore/Logs/Logs.tsx
+++ b/public/app/features/explore/Logs/Logs.tsx
@@ -729,7 +729,7 @@ class UnthemedLogs extends PureComponent<Props, State> {
                 <div>
                   <InlineField label="Display results" className={styles.horizontalInlineLabel} transparent>
                     <RadioButtonGroup
-                      disabled={isFlipping}
+                      disabled={isFlipping || loading}
                       options={[
                         {
                           label: 'Newest first',

--- a/public/app/features/explore/state/query.ts
+++ b/public/app/features/explore/state/query.ts
@@ -760,7 +760,8 @@ export const runLoadMoreLogsQueries = createAsyncThunk<void, RunLoadMoreLogsQuer
       mergeMap(([data, correlations]) => {
         // For query splitting, otherwise duplicates results
         if (data.state !== LoadingState.Done) {
-          return of(queryResponse);
+          // While loading, return the previous response and override state, otherwise it's set to Done
+          return of({ ...queryResponse, state: LoadingState.Loading });
         }
         return decorateData(
           combinePanelData(queryResponse, data),

--- a/public/app/features/logs/components/InfiniteScroll.tsx
+++ b/public/app/features/logs/components/InfiniteScroll.tsx
@@ -32,7 +32,7 @@ export const InfiniteScroll = ({
   const [lowerOutOfRange, setLowerOutOfRange] = useState(false);
   const [upperLoading, setUpperLoading] = useState(false);
   const [lowerLoading, setLowerLoading] = useState(false);
-  const [lastScroll, setLastScroll] = useState(scrollElement?.scrollTop || 0);
+  const lastScroll = useRef<number>(scrollElement?.scrollTop || 0);
 
   useEffect(() => {
     setUpperOutOfRange(false);
@@ -56,8 +56,8 @@ export const InfiniteScroll = ({
         return;
       }
       event.stopImmediatePropagation();
-      setLastScroll(scrollElement.scrollTop);
-      const scrollDirection = shouldLoadMore(event, scrollElement, lastScroll);
+      lastScroll.current = scrollElement.scrollTop;
+      const scrollDirection = shouldLoadMore(event, scrollElement, lastScroll.current);
       if (scrollDirection === ScrollDirection.NoScroll) {
         return;
       } else if (scrollDirection === ScrollDirection.Top) {
@@ -110,7 +110,7 @@ export const InfiniteScroll = ({
       scrollElement.removeEventListener('scroll', handleScroll);
       scrollElement.removeEventListener('wheel', handleScroll);
     };
-  }, [lastScroll, loadMoreLogs, loading, range, rows, scrollElement, sortOrder, timeZone]);
+  }, [loadMoreLogs, loading, range, rows, scrollElement, sortOrder, timeZone]);
 
   // We allow "now" to move when using relative time, so we hide the message so it doesn't flash.
   const hideTopMessage = sortOrder === LogsSortOrder.Descending && isRelativeTime(range.raw.to);

--- a/public/app/features/logs/components/InfiniteScroll.tsx
+++ b/public/app/features/logs/components/InfiniteScroll.tsx
@@ -57,8 +57,8 @@ export const InfiniteScroll = ({
         return;
       }
       event.stopImmediatePropagation();
-      lastScroll.current = scrollElement.scrollTop;
       const scrollDirection = shouldLoadMore(event, scrollElement, lastScroll.current);
+      lastScroll.current = scrollElement.scrollTop;
       if (scrollDirection === ScrollDirection.NoScroll) {
         return;
       } else if (scrollDirection === ScrollDirection.Top) {

--- a/public/app/features/logs/components/InfiniteScroll.tsx
+++ b/public/app/features/logs/components/InfiniteScroll.tsx
@@ -5,7 +5,6 @@ import { AbsoluteTimeRange, LogRowModel, TimeRange } from '@grafana/data';
 import { convertRawToRange, isRelativeTime, isRelativeTimeRange } from '@grafana/data/src/datetime/rangeutil';
 import { reportInteraction } from '@grafana/runtime';
 import { LogsSortOrder, TimeZone } from '@grafana/schema';
-import { Spinner } from '@grafana/ui';
 
 import { LoadingIndicator } from './LoadingIndicator';
 
@@ -54,7 +53,7 @@ export const InfiniteScroll = ({
     }
 
     function handleScroll(event: Event | WheelEvent) {
-      if (!scrollElement || !loadMoreLogs || !rows.length || loading || upperLoading || lowerLoading) {
+      if (!scrollElement || !loadMoreLogs || !rows.length || loading) {
         return;
       }
       event.stopImmediatePropagation();
@@ -112,7 +111,7 @@ export const InfiniteScroll = ({
       scrollElement.removeEventListener('scroll', handleScroll);
       scrollElement.removeEventListener('wheel', handleScroll);
     };
-  }, [loadMoreLogs, loading, lowerLoading, range, rows, scrollElement, sortOrder, timeZone, upperLoading]);
+  }, [loadMoreLogs, loading, range, rows, scrollElement, sortOrder, timeZone]);
 
   // We allow "now" to move when using relative time, so we hide the message so it doesn't flash.
   const hideTopMessage = sortOrder === LogsSortOrder.Descending && isRelativeTime(range.raw.to);

--- a/public/app/features/logs/components/LoadingIndicator.tsx
+++ b/public/app/features/logs/components/LoadingIndicator.tsx
@@ -5,9 +5,6 @@ import { Spinner } from '@grafana/ui';
 
 // ideally we'd use `@grafana/ui/LoadingPlaceholder`, but that
 // one has a large margin-bottom.
-
-export type Place = 'above' | 'below';
-
 type Props = {
   adjective?: string;
 };

--- a/public/app/features/logs/components/LoadingIndicator.tsx
+++ b/public/app/features/logs/components/LoadingIndicator.tsx
@@ -3,17 +3,17 @@ import React from 'react';
 
 import { Spinner } from '@grafana/ui';
 
-import { Place } from './types';
-
 // ideally we'd use `@grafana/ui/LoadingPlaceholder`, but that
 // one has a large margin-bottom.
 
+export type Place = 'above' | 'below';
+
 type Props = {
-  place: Place;
+  adjective?: string;
 };
 
-export const LoadingIndicator = ({ place }: Props) => {
-  const text = place === 'above' ? 'Loading newer logs...' : 'Loading older logs...';
+export const LoadingIndicator = ({ adjective = 'newer' }: Props) => {
+  const text = `Loading ${adjective} logs...`;
   return (
     <div className={loadingIndicatorStyles}>
       <div>

--- a/public/app/features/logs/components/log-context/LogRowContextModal.tsx
+++ b/public/app/features/logs/components/log-context/LogRowContextModal.tsx
@@ -26,11 +26,10 @@ import { useDispatch } from 'app/types';
 
 import { dataFrameToLogsModel } from '../../logsModel';
 import { sortLogRows } from '../../utils';
+import { LoadingIndicator } from '../LoadingIndicator';
 import { LogRows } from '../LogRows';
 
-import { LoadingIndicator } from './LoadingIndicator';
 import { LogContextButtons } from './LogContextButtons';
-import { Place } from './types';
 
 const getStyles = (theme: GrafanaTheme2) => {
   return {
@@ -143,6 +142,7 @@ type Section = {
   loadingState: LoadingState;
   rows: LogRowModel[];
 };
+type Place = 'above' | 'below';
 type Context = Record<Place, Section>;
 
 const makeEmptyContext = (): Context => ({
@@ -518,7 +518,7 @@ export const LogRowContextModal: React.FunctionComponent<LogRowContextModalProps
               <td className={styles.loadingCell}>
                 {loadingStateAbove !== LoadingState.Done && loadingStateAbove !== LoadingState.Error && (
                   <div ref={aboveLoadingElement}>
-                    <LoadingIndicator place="above" />
+                    <LoadingIndicator adjective="newer" />
                   </div>
                 )}
                 {loadingStateAbove === LoadingState.Error && <div>Error loading log more logs.</div>}
@@ -587,7 +587,7 @@ export const LogRowContextModal: React.FunctionComponent<LogRowContextModalProps
               <td className={styles.loadingCell}>
                 {loadingStateBelow !== LoadingState.Done && loadingStateBelow !== LoadingState.Error && (
                   <div ref={belowLoadingElement}>
-                    <LoadingIndicator place="below" />
+                    <LoadingIndicator adjective="older" />
                   </div>
                 )}
                 {loadingStateBelow === LoadingState.Error && <div>Error loading log more logs.</div>}

--- a/public/app/features/logs/components/log-context/types.ts
+++ b/public/app/features/logs/components/log-context/types.ts
@@ -1,1 +1,0 @@
-export type Place = 'above' | 'below';


### PR DESCRIPTION
Adjustments:
- Share loading message with Logs Context. Not only to use the same component, but to make it clear through words what is happening (Loading newer/older logs).

Refactors:
- Moved `LoadingIndicator` out of `/log-context` to `/components`.
- Small prop/type refactor.

Fixes:
- Keep `lastScroll` in a ref, out of state. Using state was causing unnecessary re-renders.
- State: override to `loading` when returning the previous response for query splitting, otherwise it set `loading` to `false`, allowing new scrolling requests.
- Disable changing order of logs while loading.
  ![2024-01-23 13 52 35](https://github.com/grafana/grafana/assets/1069378/2263c1c7-5e8b-43c0-8b55-a9a8b3b4207c)

**What is this feature?**

Addressing feedback on Infinite Scrolling.

**Which issue(s) does this PR fix?**:

Part of https://github.com/grafana/grafana/issues/71728