### PR TITLE
Alerting: Log a warning if inhibition rules

### DIFF
--- a/pkg/services/ngalert/notifier/alertmanager.go
+++ b/pkg/services/ngalert/notifier/alertmanager.go
@@ -331,6 +331,13 @@ func (am *alertmanager) applyConfig(cfg *apimodels.PostableUserConfig, rawConfig
 	}
 
 	am.updateConfigMetrics(cfg)
+
+	// TODO(grobinson): Remove this once we've added metrics to Prometheus Alertmanager
+	inhibitRules := cfg.AlertmanagerConfig.InhibitRules
+	if len(inhibitRules) > 0 {
+		am.logger.Warn("Inhibition rules are not supported", "count", len(inhibitRules))
+	}
+
 	return true, nil
 }
 


### PR DESCRIPTION
**What is this feature?**

This commit logs a warning if inhibition rules are present in the configuration for Grafana Managed Alerts. These are not supported. If some users have set up inhibition rules, it could present additional challenges for the UTF-8 migration work as users could have written incompatible matchers in their configuration file. We want to make sure there are no such configurations before proceeding with UTF-8 strict mode.

Example:

```
WARN [01-23|15:32:43] Inhibition rules are not supported       logger=ngalert.notifier.alertmanager org=1 count=1
```

**Why do we need this feature?**

There are no metrics for this in the Alertmanager. I will add them, but I also want to get this data as fast as possible. This is what I'm proposing to achieve that. Once I've added them to the Alertmanager, I also need to update our fork, update `github.com/grafana/alerting`, and then also update Grafana, including fixing breaking changes. We will do that, but I want to defer that for when we add UTF-8 strict mode to Grafana.

**Who is this feature for?**

[Add information on what kind of user the feature is for.]

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
