### PR TITLE
Chore: Fix flaky test

### DIFF
--- a/pkg/tests/api/folders/api_folders_test.go
+++ b/pkg/tests/api/folders/api_folders_test.go
@@ -67,7 +67,7 @@ func TestGetFolders(t *testing.T) {
 	for i := 0; i < numberOfFolders; i++ {
 		respCode := 0
 		folderUID := ""
-		i := 0
+		retries := 0
 		maxRetries := 3
 		err := retryer.Retry(func() (retryer.RetrySignal, error) {
 			resp, err := adminClient.Folders.CreateFolder(&models.CreateFolderCommand{
@@ -75,10 +75,10 @@ func TestGetFolders(t *testing.T) {
 				UID:   fmt.Sprintf("folder-%d", i),
 			})
 			if err != nil {
-				if i == maxRetries {
+				if retries == maxRetries {
 					return retryer.FuncError, err
 				}
-				i++
+				retries++
 				return retryer.FuncFailure, nil
 			}
 			respCode = resp.Code()

--- a/pkg/tests/api/folders/api_folders_test.go
+++ b/pkg/tests/api/folders/api_folders_test.go
@@ -74,7 +74,6 @@ func TestGetFolders(t *testing.T) {
 				Title: fmt.Sprintf("Folder %d", i),
 				UID:   fmt.Sprintf("folder-%d", i),
 			})
-			err = fmt.Errorf("error creating folder: %w", err)
 			if err != nil {
 				if i == maxRetries {
 					return retryer.FuncError, err

--- a/pkg/tests/api/folders/api_folders_test.go
+++ b/pkg/tests/api/folders/api_folders_test.go
@@ -1,13 +1,11 @@
 package folders
 
 import (
-	"context"
 	"fmt"
 	"net/http"
-	"runtime"
 	"testing"
+	"time"
 
-	"github.com/grafana/dskit/concurrency"
 	"github.com/grafana/grafana-openapi-client-go/client/folders"
 	"github.com/grafana/grafana-openapi-client-go/models"
 	"github.com/grafana/grafana/pkg/services/accesscontrol/resourcepermissions"
@@ -17,6 +15,7 @@ import (
 	"github.com/grafana/grafana/pkg/services/user"
 	"github.com/grafana/grafana/pkg/tests"
 	"github.com/grafana/grafana/pkg/tests/testinfra"
+	"github.com/grafana/grafana/pkg/util/retryer"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -64,22 +63,29 @@ func TestGetFolders(t *testing.T) {
 
 	numberOfFolders := 5
 	indexWithoutPermission := 3
-	err := concurrency.ForEachJob(context.Background(), numberOfFolders, runtime.NumCPU(), func(_ context.Context, job int) error {
-		resp, err := adminClient.Folders.CreateFolder(&models.CreateFolderCommand{
-			Title: fmt.Sprintf("Folder %d", job),
-			UID:   fmt.Sprintf("folder-%d", job),
-		})
-		if err != nil {
-			return err
+
+	for i := 0; i < numberOfFolders; i++ {
+		respCode := 0
+		folderUID := ""
+		retryer.Retry(func() (retryer.RetrySignal, error) {
+			resp, err := adminClient.Folders.CreateFolder(&models.CreateFolderCommand{
+				Title: fmt.Sprintf("Folder %d", i),
+				UID:   fmt.Sprintf("folder-%d", i),
+			})
+			if err != nil {
+				return retryer.FuncError, err
+			}
+			respCode = resp.Code()
+			folderUID = resp.Payload.UID
+			return retryer.FuncComplete, nil
+		}, 3, time.Millisecond*time.Duration(10), time.Second)
+
+		require.Equal(t, http.StatusOK, respCode)
+		if i == indexWithoutPermission {
+			tests.RemoveFolderPermission(t, permissionsStore, orgID, org.RoleViewer, folderUID)
+			t.Log("Removed viewer permission from folder", folderUID)
 		}
-		require.Equal(t, http.StatusOK, resp.Code())
-		if job == indexWithoutPermission {
-			tests.RemoveFolderPermission(t, permissionsStore, orgID, org.RoleViewer, resp.Payload.UID)
-			t.Log("Removed viewer permission from folder", resp.Payload.UID)
-		}
-		return nil
-	})
-	require.NoError(t, err)
+	}
 
 	t.Run("Admin can get all folders", func(t *testing.T) {
 		res, err := adminClient.Folders.GetFolders(folders.NewGetFoldersParams())


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

Mitigates flaky folders test that occasionally fails with:

<details><summary>Details</summary>
<p>

```
--- FAIL: TestGetFolders (10.13s)
    testinfra.go:37: Grafana is listening on 127.0.0.1:46125
    api_folders_test.go:78: Removed viewer permission from folder folder-3
    api_folders_test.go:82: 
        	Error Trace:	/drone/src/pkg/tests/api/folders/api_folders_test.go:82
        	Error:      	Received unexpected error:
        	            	[POST /folders][401] createFolderUnauthorized  &{Error: Message:0xc00210f8d0 Status:}
        	Test:       	TestGetFolders
FAIL
coverage: [no statements]
FAIL	github.com/grafana/grafana/pkg/tests/api/folders	10.568s
```


</p>
</details> 

I'm not completely sure why this fails with `401 Unauthorized` but to provide some context:
- the failure happens during test data setup
- the test uses the Go client for creating the test data
- several requests for the creation of the test data happen concurrently
- occasionally they fail with `401 Unauthorized`

To mitigate the problem I have removed concurrency and I have enabled retrying failing requests

**Why do we need this feature?**

[Add a description of the problem the feature is trying to solve.]

**Who is this feature for?**

[Add information on what kind of user the feature is for.]

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
