### PR TITLE
Alerting: Add metric for inhibition rules

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -59,7 +59,7 @@ require (
 	github.com/google/uuid v1.5.0 // @grafana/backend-platform
 	github.com/google/wire v0.5.0 // @grafana/backend-platform
 	github.com/gorilla/websocket v1.5.0 // @grafana/grafana-app-platform-squad
-	github.com/grafana/alerting v0.0.0-20231221110807-c17ec6241a66 // @grafana/alerting-squad-backend
+	github.com/grafana/alerting v0.0.0-20240123184432-1d58deb6074c // @grafana/alerting-squad-backend
 	github.com/grafana/cuetsy v0.1.11 // @grafana/grafana-as-code
 	github.com/grafana/grafana-aws-sdk v0.19.1 // @grafana/aws-datasources
 	github.com/grafana/grafana-azure-sdk-go v1.11.0 // @grafana/partner-datasources

--- a/go.sum
+++ b/go.sum
@@ -1805,8 +1805,8 @@ github.com/gorilla/websocket v1.5.0 h1:PPwGk2jz7EePpoHN/+ClbZu8SPxiqlu12wZP/3sWm
 github.com/gorilla/websocket v1.5.0/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 github.com/gotestyourself/gotestyourself v1.3.0/go.mod h1:zZKM6oeNM8k+FRljX1mnzVYeS8wiGgQyvST1/GafPbY=
 github.com/gotestyourself/gotestyourself v2.2.0+incompatible/go.mod h1:zZKM6oeNM8k+FRljX1mnzVYeS8wiGgQyvST1/GafPbY=
-github.com/grafana/alerting v0.0.0-20231221110807-c17ec6241a66 h1:qX3Reeg7jiLIgXSvxWJj/r/EngiMdiFev+FIsKpjFiE=
-github.com/grafana/alerting v0.0.0-20231221110807-c17ec6241a66/go.mod h1:lR9bhQrESIeOqKtC4Y+fK4mqtLmJFDffFt9q4cWRa8k=
+github.com/grafana/alerting v0.0.0-20240123184432-1d58deb6074c h1:ka8hxHkrRzNK/IqGCm9Vb7s/4NFwUnECmuVuH3CyzN8=
+github.com/grafana/alerting v0.0.0-20240123184432-1d58deb6074c/go.mod h1:lR9bhQrESIeOqKtC4Y+fK4mqtLmJFDffFt9q4cWRa8k=
 github.com/grafana/codejen v0.0.3 h1:tAWxoTUuhgmEqxJPOLtJoxlPBbMULFwKFOcRsPRPXDw=
 github.com/grafana/codejen v0.0.3/go.mod h1:zmwwM/DRyQB7pfuBjTWII3CWtxcXh8LTwAYGfDfpR6s=
 github.com/grafana/cue v0.0.0-20230926092038-971951014e3f h1:TmYAMnqg3d5KYEAaT6PtTguL2GjLfvr6wnAX8Azw6tQ=

--- a/pkg/services/ngalert/metrics/multi_org_alertmanager.go
+++ b/pkg/services/ngalert/metrics/multi_org_alertmanager.go
@@ -73,10 +73,11 @@ type AlertmanagerAggregatedMetrics struct {
 	registries *metrics.TenantRegistries
 
 	// metrics gather from the in-house "Alertmanager" directly.
-	numReceivedAlerts      *prometheus.Desc
-	numInvalidAlerts       *prometheus.Desc
-	configuredReceivers    *prometheus.Desc
-	configuredIntegrations *prometheus.Desc
+	numReceivedAlerts         *prometheus.Desc
+	numInvalidAlerts          *prometheus.Desc
+	configuredReceivers       *prometheus.Desc
+	configuredIntegrations    *prometheus.Desc
+	configuredInhibitionRules *prometheus.Desc
 
 	// exported metrics, gathered from Alertmanager PipelineBuilder
 	numNotifications                   *prometheus.Desc
@@ -141,6 +142,10 @@ func NewAlertmanagerAggregatedMetrics(registries *metrics.TenantRegistries) *Ale
 			fmt.Sprintf("%s_%s_alertmanager_integrations", Namespace, Subsystem),
 			"Number of configured receivers.",
 			[]string{"org", "type"}, nil),
+		configuredInhibitionRules: prometheus.NewDesc(
+			fmt.Sprintf("%s_%s_alertmanager_inhibition_rules", Namespace, Subsystem),
+			"Number of configured inhibition rules.",
+			[]string{"org"}, nil),
 
 		numNotifications: prometheus.NewDesc(
 			fmt.Sprintf("%s_%s_notifications_total", Namespace, Subsystem),
@@ -270,6 +275,7 @@ func (a *AlertmanagerAggregatedMetrics) Describe(out chan<- *prometheus.Desc) {
 	out <- a.numInvalidAlerts
 	out <- a.configuredReceivers
 	out <- a.configuredIntegrations
+	out <- a.configuredInhibitionRules
 
 	out <- a.numNotifications
 	out <- a.numFailedNotifications
@@ -314,6 +320,7 @@ func (a *AlertmanagerAggregatedMetrics) Collect(out chan<- prometheus.Metric) {
 	data.SendSumOfCountersPerTenant(out, a.numInvalidAlerts, "alertmanager_alerts_invalid_total")
 	data.SendSumOfGaugesPerTenantWithLabels(out, a.configuredReceivers, "grafana_alerting_alertmanager_receivers", "state")
 	data.SendSumOfGaugesPerTenantWithLabels(out, a.configuredIntegrations, "grafana_alerting_alertmanager_integrations", "type")
+	data.SendSumOfGaugesPerTenant(out, a.configuredInhibitionRules, "grafana_alerting_alertmanager_inhibition_rules")
 
 	data.SendSumOfCountersPerTenant(out, a.numNotifications, "alertmanager_notifications_total", metrics.WithLabels("integration"), metrics.WithSkipZeroValueMetrics)
 	data.SendSumOfCountersPerTenant(out, a.numFailedNotifications, "alertmanager_notifications_failed_total", metrics.WithLabels("integration"), metrics.WithSkipZeroValueMetrics)


### PR DESCRIPTION
**What is this feature?**

This commit adds a metric for the number of inhibition rules. It matches the metric added upstream in [#3681](https://github.com/prometheus/alertmanager/pull/3681).

The previous version of `grafana/alerting` was `c17ec62`:

<img width="1322" alt="Screenshot 2024-01-23 at 6 51 57 PM" src="https://github.com/grafana/grafana/assets/85952834/81695ab0-014a-4a06-8fc9-f1a380d2dfd3">


You can find the `grafana/alerting` PR [here](https://github.com/grafana/alerting/pull/153).

**Why do we need this feature?**

Inhibition rules are not supported in Grafana Managed Alerts. However, if some users have set up inhibition rules, it could present additional challenges for the UTF-8 migration work as users could have written incompatible matchers in their configuration file. We want to make sure there are no such configurations before proceeding with UTF-8 strict mode.

**Who is this feature for?**

[Add information on what kind of user the feature is for.]

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle.
- [x] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
