### PR TITLE
Table: Automatically detect JSON

### DIFF
--- a/packages/grafana-ui/src/components/Table/DefaultCell.tsx
+++ b/packages/grafana-ui/src/components/Table/DefaultCell.tsx
@@ -55,7 +55,10 @@ export const DefaultCell = (props: TableCellProps) => {
   if (isStringValue) {
     let justifyContent = cellProps.style?.justifyContent;
     const str = value.toString();
-    if (str.startsWith('{') && str.endsWith('}') && isStringJSON(str)) {
+    if (
+      ((str.startsWith('{') && str.endsWith('}')) || (str.startsWith('[') && str.startsWith(']'))) &&
+      isStringJSON(str)
+    ) {
       return JSONViewCell(props);
     }
 

--- a/packages/grafana-ui/src/components/Table/DefaultCell.tsx
+++ b/packages/grafana-ui/src/components/Table/DefaultCell.tsx
@@ -11,6 +11,7 @@ import { clearLinkButtonStyles } from '../Button';
 import { DataLinksContextMenu } from '../DataLinks/DataLinksContextMenu';
 
 import { CellActions } from './CellActions';
+import { JSONViewCell } from './JSONViewCell';
 import { TableStyles } from './styles';
 import { TableCellProps, CustomCellRendererProps, TableCellOptions } from './types';
 import { getCellOptions } from './utils';
@@ -53,6 +54,10 @@ export const DefaultCell = (props: TableCellProps) => {
 
   if (isStringValue) {
     let justifyContent = cellProps.style?.justifyContent;
+    const str = value.toString();
+    if (str.startsWith('{') && str.endsWith('}') && isStringJSON(str)) {
+      return JSONViewCell(props);
+    }
 
     if (justifyContent === 'flex-end') {
       cellProps.style = { ...cellProps.style, textAlign: 'right' };
@@ -144,4 +149,13 @@ function getLinkStyle(tableStyles: TableStyles, cellOptions: TableCellOptions, t
   }
 
   return cx(tableStyles.cellLinkForColoredCell, targetClassName);
+}
+
+export function isStringJSON(str: string): boolean {
+  let parsed;
+  try {
+    parsed = JSON.parse(str);
+  } catch (error) {}
+  // The JSON view should only be used if the parsed value is an object
+  return typeof parsed === 'object';
 }

--- a/packages/grafana-ui/src/components/Table/DefaultCell.tsx
+++ b/packages/grafana-ui/src/components/Table/DefaultCell.tsx
@@ -59,7 +59,7 @@ export const DefaultCell = (props: TableCellProps) => {
       ((str.startsWith('{') && str.endsWith('}')) || (str.startsWith('[') && str.startsWith(']'))) &&
       isStringJSON(str)
     ) {
-      return JSONViewCell(props);
+      return JSONViewCell({ ...props, isJson: true });
     }
 
     if (justifyContent === 'flex-end') {

--- a/packages/grafana-ui/src/components/Table/JSONViewCell.tsx
+++ b/packages/grafana-ui/src/components/Table/JSONViewCell.tsx
@@ -21,12 +21,14 @@ export function JSONViewCell(props: TableCellProps): JSX.Element {
   let value = cell.value;
   let displayValue = value;
 
-  if (isString(value)) {
-    try {
-      value = JSON.parse(value);
-    } catch {} // ignore errors
-  } else {
-    displayValue = JSON.stringify(value, null, ' ');
+  if (!props.isJson) {
+    if (isString(value)) {
+      try {
+        JSON.parse(value);
+      } catch {} // ignore errors
+    } else {
+      displayValue = JSON.stringify(value, null, ' ');
+    }
   }
 
   const hasLinks = Boolean(getCellLinks(field, row)?.length);

--- a/packages/grafana-ui/src/components/Table/types.ts
+++ b/packages/grafana-ui/src/components/Table/types.ts
@@ -44,6 +44,7 @@ export interface TableCellProps extends CellProps<any> {
   onCellFilterAdded?: TableFilterActionCallback;
   innerWidth: number;
   frame: DataFrame;
+  isJson: boolean; // the field has already been parsed as JSON
 }
 
 export type CellComponent = FC<TableCellProps>;


### PR DESCRIPTION
**What is this feature?**

More generic solution to https://github.com/grafana/grafana/pull/79724, but riskier

**Why do we need this feature?**
<img width="768" alt="image" src="https://github.com/grafana/grafana/assets/109082771/9bf6141f-7877-467c-9b99-3c2f7594b794">

Currently the logic is very simple, each table cell string value checks to see if the string is wrapped by `{}`, or `[]` and then attempts to parse the JSON.

**Why do we need this feature?**
Users should be able to better work with JSON within a table.

**Who is this feature for?**
Users of logs table

**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/grafana/issues/79589

**Special notes for your reviewer:**
Thanks to @ryantxu for the idea!

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
