### PR TITLE
Explore: Set default time range to now-1h

### DIFF
--- a/public/app/features/explore/hooks/useStateSync/migrators/v0.ts
+++ b/public/app/features/explore/hooks/useStateSync/migrators/v0.ts
@@ -20,8 +20,8 @@ export const v0Migrator: MigrationHandler<never, ExploreURLV0> = {
             datasource: null,
             queries: [],
             range: {
-              from: 'now-6h',
-              to: 'now',
+              from: DEFAULT_RANGE.from,
+              to: DEFAULT_RANGE.to,
             },
           },
           schemaVersion: 0,

--- a/public/app/features/explore/state/utils.ts
+++ b/public/app/features/explore/state/utils.ts
@@ -32,7 +32,7 @@ import { getDatasourceSrv } from '../../plugins/datasource_srv';
 import { loadSupplementaryQueries } from '../utils/supplementaryQueries';
 
 export const DEFAULT_RANGE = {
-  from: 'now-6h',
+  from: 'now-1h',
   to: 'now',
 };
 


### PR DESCRIPTION
Fixes #79777

The default time range for Explore was set to `now-1h` in [here](https://github.com/grafana/grafana/pull/18212). [Migration PR](https://github.com/grafana/grafana/pull/69692) changed the behavior to `now-6h`. The current PR is to revert back to the previous behavior.

References:

One of the reasons this happened is since [this change](https://github.com/grafana/grafana/pull/28819) we had 2 inconsistent default ranges in 2 places overriding each other in runtime. After some refactoring the longer now-6h started to be applied on top of the previous one.