### PR TITLE
IDForwading: cache based on expires in

### DIFF
--- a/pkg/services/auth/idimpl/service.go
+++ b/pkg/services/auth/idimpl/service.go
@@ -25,7 +25,7 @@ import (
 const (
 	cachePrefix = "id-token"
 	tokenTTL    = 10 * time.Minute
-	cacheLeeway  = 30 * time.Second
+	cacheLeeway = 30 * time.Second
 )
 
 var _ auth.IDService = (*Service)(nil)
@@ -116,7 +116,7 @@ func (s *Service) SignIdentity(ctx context.Context, id identity.Requester) (stri
 		}
 
 		expires := time.Until(extracted.Expiry.Time())
-		if err := s.cache.Set(ctx, cacheKey, []byte(token), expires-cacheLeway); err != nil {
+		if err := s.cache.Set(ctx, cacheKey, []byte(token), expires-cacheLeeway); err != nil {
 			s.logger.FromContext(ctx).Error("Failed to add id token to cache", "error", err)
 		}
 

--- a/pkg/services/auth/idimpl/service.go
+++ b/pkg/services/auth/idimpl/service.go
@@ -24,7 +24,7 @@ import (
 
 const (
 	cachePrefix = "id-token"
-	tokenTTL    = 1 * time.Hour
+	tokenTTL    = 10 * time.Minute
 	cacheLeway  = 30 * time.Second
 )
 

--- a/pkg/services/auth/idimpl/service.go
+++ b/pkg/services/auth/idimpl/service.go
@@ -25,7 +25,7 @@ import (
 const (
 	cachePrefix = "id-token"
 	tokenTTL    = 10 * time.Minute
-	cacheLeway  = 30 * time.Second
+	cacheLeeway  = 30 * time.Second
 )
 
 var _ auth.IDService = (*Service)(nil)

--- a/pkg/services/auth/idimpl/service_test.go
+++ b/pkg/services/auth/idimpl/service_test.go
@@ -56,11 +56,11 @@ func TestService_SignIdentity(t *testing.T) {
 		SignIDTokenFn: func(_ context.Context, claims *auth.IDClaims) (string, error) {
 			key := []byte("key")
 			s, err := jose.NewSigner(jose.SigningKey{Algorithm: jose.HS256, Key: key}, nil)
+			require.NoError(t, err)
 
 			token, err := jwt.Signed(s).Claims(claims).CompactSerialize()
-			if err != nil {
-				return "", err
-			}
+			require.NoError(t, err)
+
 			return token, nil
 		},
 	}


### PR DESCRIPTION
**What is this feature?**
When using external signer we are not in control of expires is. So we need to set ttl for a token based on when it expires.

**Which issue(s) does this PR fix?**:
Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
