### PR TITLE
Auth: Add SSO settings usage stats

### DIFF
--- a/pkg/login/social/socialimpl/service_test.go
+++ b/pkg/login/social/socialimpl/service_test.go
@@ -73,7 +73,7 @@ func TestSocialService_ProvideService(t *testing.T) {
 	accessControl := acimpl.ProvideAccessControl(cfg)
 	sqlStore := db.InitTestDB(t)
 
-	ssoSettingsSvc := ssosettingsimpl.ProvideService(cfg, sqlStore, accessControl, routing.NewRouteRegister(), featuremgmt.WithFeatures(), secrets)
+	ssoSettingsSvc := ssosettingsimpl.ProvideService(cfg, sqlStore, accessControl, routing.NewRouteRegister(), featuremgmt.WithFeatures(), secrets, &usagestats.UsageStatsMock{})
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/pkg/registry/backgroundsvcs/background_services.go
+++ b/pkg/registry/backgroundsvcs/background_services.go
@@ -59,7 +59,7 @@ func ProvideBackgroundServiceRegistry(
 	keyRetriever *dynamic.KeyRetriever, dynamicAngularDetectorsProvider *angulardetectorsprovider.Dynamic,
 	grafanaAPIServer grafanaapiserver.Service,
 	anon *anonimpl.AnonDeviceService,
-	ssoSettings *ssosettingsimpl.SSOSettingsService,
+	ssoSettings *ssosettingsimpl.Service,
 	// Need to make sure these are initialized, is there a better place to put them?
 	_ dashboardsnapshots.Service, _ *alerting.AlertNotificationService,
 	_ serviceaccounts.Service, _ *guardian.Provider,

--- a/pkg/server/wire.go
+++ b/pkg/server/wire.go
@@ -380,7 +380,7 @@ var wireBasicSet = wire.NewSet(
 	signingkeysimpl.ProvideEmbeddedSigningKeysService,
 	wire.Bind(new(signingkeys.Service), new(*signingkeysimpl.Service)),
 	ssoSettingsImpl.ProvideService,
-	wire.Bind(new(ssosettings.Service), new(*ssoSettingsImpl.SSOSettingsService)),
+	wire.Bind(new(ssosettings.Service), new(*ssoSettingsImpl.Service)),
 	idimpl.ProvideService,
 	wire.Bind(new(auth.IDService), new(*idimpl.Service)),
 	cloudmigrations.ProvideService,

--- a/pkg/services/ssosettings/ssosettingsimpl/service_test.go
+++ b/pkg/services/ssosettings/ssosettingsimpl/service_test.go
@@ -24,7 +24,7 @@ import (
 	"github.com/grafana/grafana/pkg/setting"
 )
 
-func TestSSOSettingsService_GetForProvider(t *testing.T) {
+func TestService_GetForProvider(t *testing.T) {
 	testCases := []struct {
 		name    string
 		setup   func(env testEnv)
@@ -205,7 +205,7 @@ func TestSSOSettingsService_GetForProvider(t *testing.T) {
 	}
 }
 
-func TestSSOSettingsService_GetForProviderWithRedactedSecrets(t *testing.T) {
+func TestService_GetForProviderWithRedactedSecrets(t *testing.T) {
 	testCases := []struct {
 		name    string
 		setup   func(env testEnv)
@@ -304,7 +304,7 @@ func TestSSOSettingsService_GetForProviderWithRedactedSecrets(t *testing.T) {
 	}
 }
 
-func TestSSOSettingsService_List(t *testing.T) {
+func TestService_List(t *testing.T) {
 	testCases := []struct {
 		name    string
 		setup   func(env testEnv)
@@ -447,7 +447,7 @@ func TestSSOSettingsService_List(t *testing.T) {
 	}
 }
 
-func TestSSOSettingsService_ListWithRedactedSecrets(t *testing.T) {
+func TestService_ListWithRedactedSecrets(t *testing.T) {
 	testCases := []struct {
 		name    string
 		setup   func(env testEnv)
@@ -741,7 +741,7 @@ func TestSSOSettingsService_ListWithRedactedSecrets(t *testing.T) {
 	}
 }
 
-func TestSSOSettingsService_Upsert(t *testing.T) {
+func TestService_Upsert(t *testing.T) {
 	t.Run("successfully upsert SSO settings", func(t *testing.T) {
 		env := setupTestEnv(t)
 
@@ -1003,7 +1003,7 @@ func TestSSOSettingsService_Upsert(t *testing.T) {
 	})
 }
 
-func TestSSOSettingsService_Delete(t *testing.T) {
+func TestService_Delete(t *testing.T) {
 	t.Run("successfully delete SSO settings", func(t *testing.T) {
 		env := setupTestEnv(t)
 
@@ -1048,7 +1048,7 @@ func TestSSOSettingsService_Delete(t *testing.T) {
 	})
 }
 
-func TestSSOSettingsService_DoReload(t *testing.T) {
+func TestService_DoReload(t *testing.T) {
 	t.Run("successfully reload settings", func(t *testing.T) {
 		env := setupTestEnv(t)
 
@@ -1101,7 +1101,7 @@ func TestSSOSettingsService_DoReload(t *testing.T) {
 	})
 }
 
-func TestSSOSettingsService_decryptSecrets(t *testing.T) {
+func TestService_decryptSecrets(t *testing.T) {
 	testCases := []struct {
 		name     string
 		setup    func(env testEnv)
@@ -1216,7 +1216,7 @@ func setupTestEnv(t *testing.T) testEnv {
 		},
 	}
 
-	svc := &SSOSettingsService{
+	svc := &Service{
 		logger:       log.NewNopLogger(),
 		cfg:          cfg,
 		store:        store,
@@ -1239,7 +1239,7 @@ func setupTestEnv(t *testing.T) testEnv {
 
 type testEnv struct {
 	cfg              *setting.Cfg
-	service          *SSOSettingsService
+	service          *Service
 	store            *ssosettingstests.FakeStore
 	ac               accesscontrol.AccessControl
 	fallbackStrategy *ssosettingstests.FakeFallbackStrategy

--- a/pkg/services/ssosettings/ssosettingsimpl/usage_stats.go
+++ b/pkg/services/ssosettings/ssosettingsimpl/usage_stats.go
@@ -1,0 +1,30 @@
+package ssosettingsimpl
+
+import (
+	"context"
+
+	"github.com/grafana/grafana/pkg/services/ssosettings/models"
+)
+
+func (s *SSOSettingsService) getUsageStats(ctx context.Context) (map[string]any, error) {
+	m := map[string]any{}
+
+	settings, err := s.store.List(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	configuredInDbCounter := 0
+	for _, setting := range settings {
+		if setting.Source == models.DB {
+			configuredInDbCounter++
+			m["stats.sso."+setting.Provider+".config.database.count"] = 1
+		} else {
+			m["stats.sso."+setting.Provider+".config.database.count"] = 0
+		}
+	}
+
+	m["stats.sso.configured_in_db.count"] = configuredInDbCounter
+
+	return m, nil
+}

--- a/pkg/services/ssosettings/ssosettingsimpl/usage_stats.go
+++ b/pkg/services/ssosettings/ssosettingsimpl/usage_stats.go
@@ -6,7 +6,7 @@ import (
 	"github.com/grafana/grafana/pkg/services/ssosettings/models"
 )
 
-func (s *SSOSettingsService) getUsageStats(ctx context.Context) (map[string]any, error) {
+func (s *Service) getUsageStats(ctx context.Context) (map[string]any, error) {
 	m := map[string]any{}
 
 	settings, err := s.store.List(ctx)
@@ -16,12 +16,12 @@ func (s *SSOSettingsService) getUsageStats(ctx context.Context) (map[string]any,
 
 	configuredInDbCounter := 0
 	for _, setting := range settings {
+		enabledValue := 0
 		if setting.Source == models.DB {
 			configuredInDbCounter++
-			m["stats.sso."+setting.Provider+".config.database.count"] = 1
-		} else {
-			m["stats.sso."+setting.Provider+".config.database.count"] = 0
+			enabledValue = 1
 		}
+		m["stats.sso."+setting.Provider+".config.database.count"] = enabledValue
 	}
 
 	m["stats.sso.configured_in_db.count"] = configuredInDbCounter

--- a/pkg/services/ssosettings/ssosettingsimpl/usage_stats_test.go
+++ b/pkg/services/ssosettings/ssosettingsimpl/usage_stats_test.go
@@ -1,1 +1,68 @@
 package ssosettingsimpl
+
+import (
+	"context"
+	"testing"
+
+	"github.com/grafana/grafana/pkg/infra/log"
+	"github.com/grafana/grafana/pkg/services/ssosettings/models"
+	"github.com/grafana/grafana/pkg/services/ssosettings/ssosettingstests"
+	"github.com/grafana/grafana/pkg/setting"
+	"github.com/stretchr/testify/require"
+)
+
+func TestService_getUsageStats(t *testing.T) {
+	fakeStore := &ssosettingstests.FakeStore{
+		ExpectedSSOSettings: []*models.SSOSettings{
+			{
+				Provider: "google",
+				Source:   models.DB,
+			},
+			{
+				Provider: "github",
+				Source:   models.System,
+			},
+			{
+				Provider: "grafana_com",
+				Source:   models.System,
+			},
+			{
+				Provider: "generic_oauth",
+				Source:   models.DB,
+			},
+			{
+				Provider: "okta",
+				Source:   models.DB,
+			},
+			{
+				Provider: "azuread",
+				Source:   models.DB,
+			},
+			{
+				Provider: "gitlab",
+				Source:   models.DB,
+			},
+		},
+	}
+	svc := &Service{
+		logger: log.New("test"),
+		store:  fakeStore,
+		cfg:    &setting.Cfg{},
+	}
+
+	actual, err := svc.getUsageStats(context.Background())
+	require.NoError(t, err)
+
+	expected := map[string]any{
+		"stats.sso.configured_in_db.count":              5,
+		"stats.sso.azuread.config.database.count":       1,
+		"stats.sso.gitlab.config.database.count":        1,
+		"stats.sso.google.config.database.count":        1,
+		"stats.sso.okta.config.database.count":          1,
+		"stats.sso.generic_oauth.config.database.count": 1,
+		"stats.sso.grafana_com.config.database.count":   0,
+		"stats.sso.github.config.database.count":        0,
+	}
+
+	require.EqualValues(t, expected, actual)
+}

--- a/pkg/services/ssosettings/ssosettingsimpl/usage_stats_test.go
+++ b/pkg/services/ssosettings/ssosettingsimpl/usage_stats_test.go
@@ -1,0 +1,1 @@
+package ssosettingsimpl

--- a/public/app/features/auth-config/ProviderConfigForm.tsx
+++ b/public/app/features/auth-config/ProviderConfigForm.tsx
@@ -31,7 +31,7 @@ export const ProviderConfigForm = ({ config, provider, isLoading }: ProviderConf
     setValue,
     unregister,
     formState: { errors, dirtyFields, isSubmitted },
-  } = useForm({ defaultValues: dataToDTO(config), reValidateMode: 'onSubmit' });
+  } = useForm({ defaultValues: dataToDTO(config), mode: 'onChange', reValidateMode: 'onChange' });
   const [isSaving, setIsSaving] = useState(false);
   const providerFields = fields[provider];
   const [submitError, setSubmitError] = useState(false);

--- a/public/app/features/auth-config/ProviderConfigForm.tsx
+++ b/public/app/features/auth-config/ProviderConfigForm.tsx
@@ -31,7 +31,7 @@ export const ProviderConfigForm = ({ config, provider, isLoading }: ProviderConf
     setValue,
     unregister,
     formState: { errors, dirtyFields, isSubmitted },
-  } = useForm({ defaultValues: dataToDTO(config), mode: 'onChange', reValidateMode: 'onChange' });
+  } = useForm({ defaultValues: dataToDTO(config), reValidateMode: 'onSubmit' });
   const [isSaving, setIsSaving] = useState(false);
   const providerFields = fields[provider];
   const [submitError, setSubmitError] = useState(false);


### PR DESCRIPTION
**What is this feature?**
- Add the usage stats to SSO settings service.
- Rename SSOSettingService to Service.

**Why do we need this feature?**

**Who is this feature for?**

**Which issue(s) does this PR fix?**:

Fixes #

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
