### PR TITLE
Folders: Add metric for listing subfolders duration

### DIFF
--- a/pkg/services/folder/folderimpl/metrics.go
+++ b/pkg/services/folder/folderimpl/metrics.go
@@ -12,6 +12,7 @@ const (
 
 type foldersMetrics struct {
 	sharedWithMeFetchFoldersRequestsDuration *prometheus.HistogramVec
+	foldersGetChildrenRequestsDuration       *prometheus.HistogramVec
 }
 
 func newFoldersMetrics(r prometheus.Registerer) *foldersMetrics {
@@ -25,6 +26,16 @@ func newFoldersMetrics(r prometheus.Registerer) *foldersMetrics {
 				Subsystem: metricsSubSystem,
 			},
 			[]string{"status"},
+		),
+		foldersGetChildrenRequestsDuration: promauto.With(r).NewHistogramVec(
+			prometheus.HistogramOpts{
+				Name:      "get_children_duration_seconds",
+				Help:      "Duration of listing subfolders in specific folder",
+				Buckets:   []float64{.005, .01, .025, .05, .1, .25, .5, 1, 2.5, 5, 10, 25, 50, 100},
+				Namespace: metricsNamespace,
+				Subsystem: metricsSubSystem,
+			},
+			[]string{"parent"},
 		),
 	}
 }


### PR DESCRIPTION
**What is this feature?**

This PR adds a request duration metric for fetching subfolders. 

**Why do we need this feature?**

We need to measure listing folder times compared to "shared with me" folder. We cannot use HTTP request duration metric since "shared with me" and other folders use the same API endpoint.

**Who is this feature for?**

[Add information on what kind of user the feature is for.]

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
