### PR TITLE
Tempo: Fix NaN value using fallback

### DIFF
--- a/public/app/plugins/datasource/tempo/traceql/TempoQueryBuilderOptions.tsx
+++ b/public/app/plugins/datasource/tempo/traceql/TempoQueryBuilderOptions.tsx
@@ -13,6 +13,19 @@ interface Props {
   query: Partial<TempoQuery> & TempoQuery;
 }
 
+/**
+ * Parse a string value to integer. If the conversion fails, for example because we are prosessing an empty value for
+ * a field, return a fallback (default) value.
+ *
+ * @param val the value to be parsed to an integer
+ * @param fallback the fallback value
+ * @returns the converted value or the fallback value if the conversion fails
+ */
+const parseIntWithFallback = (val: string, fallback: number) => {
+  const parsed = parseInt(val, 10);
+  return isNaN(parsed) ? fallback : parsed;
+};
+
 export const TempoQueryBuilderOptions = React.memo<Props>(({ onChange, query }) => {
   if (!query.hasOwnProperty('limit')) {
     query.limit = DEFAULT_LIMIT;
@@ -23,10 +36,10 @@ export const TempoQueryBuilderOptions = React.memo<Props>(({ onChange, query }) 
   }
 
   const onLimitChange = (e: React.FormEvent<HTMLInputElement>) => {
-    onChange({ ...query, limit: parseInt(e.currentTarget.value, 10) });
+    onChange({ ...query, limit: parseIntWithFallback(e.currentTarget.value, DEFAULT_LIMIT) });
   };
   const onSpssChange = (e: React.FormEvent<HTMLInputElement>) => {
-    onChange({ ...query, spss: parseInt(e.currentTarget.value, 10) });
+    onChange({ ...query, spss: parseIntWithFallback(e.currentTarget.value, DEFAULT_SPSS) });
   };
   const onTableTypeChange = (val: SearchTableType) => {
     onChange({ ...query, tableType: val });


### PR DESCRIPTION
Fixes https://github.com/grafana/grafana/issues/79891

When option input fields are left empty, thus showing the `auto` placeholder (see image), `NaN` is currently returned. This PR fixes that.
<img width="186" alt="image" src="https://github.com/grafana/grafana/assets/135109076/91b5d6ec-6dbd-4967-9928-b50698ba9da9">
