### PR TITLE
Table: Cell inspector auto-detecting JSON

### DIFF
--- a/packages/grafana-ui/src/components/Table/TableCellInspectModal.tsx
+++ b/packages/grafana-ui/src/components/Table/TableCellInspectModal.tsx
@@ -14,12 +14,16 @@ interface TableCellInspectModalProps {
 export function TableCellInspectModal({ value, onDismiss, mode }: TableCellInspectModalProps) {
   let displayValue = value;
   if (isString(value)) {
-    try {
-      value = JSON.parse(value);
-      mode = 'code';
-    } catch {
+    if (value[0] === '{' || value[0] === '[' || mode === 'code') {
+      try {
+        value = JSON.parse(value);
+        mode = 'code';
+      } catch {
+        mode = 'text';
+      } // ignore errors
+    } else {
       mode = 'text';
-    } // ignore errors
+    }
   } else {
     displayValue = JSON.stringify(value, null, ' ');
   }

--- a/packages/grafana-ui/src/components/Table/TableCellInspectModal.tsx
+++ b/packages/grafana-ui/src/components/Table/TableCellInspectModal.tsx
@@ -16,7 +16,10 @@ export function TableCellInspectModal({ value, onDismiss, mode }: TableCellInspe
   if (isString(value)) {
     try {
       value = JSON.parse(value);
-    } catch {} // ignore errors
+      mode = 'code';
+    } catch {
+      mode = 'text';
+    } // ignore errors
   } else {
     displayValue = JSON.stringify(value, null, ' ');
   }

--- a/packages/grafana-ui/src/components/Table/TableCellInspectModal.tsx
+++ b/packages/grafana-ui/src/components/Table/TableCellInspectModal.tsx
@@ -14,6 +14,7 @@ interface TableCellInspectModalProps {
 export function TableCellInspectModal({ value, onDismiss, mode }: TableCellInspectModalProps) {
   let displayValue = value;
   if (isString(value)) {
+    // Exclude numeric strings like '123' from being displayed in code/JSON mode
     if (value[0] === '{' || value[0] === '[' || mode === 'code') {
       try {
         value = JSON.parse(value);

--- a/packages/grafana-ui/src/components/Table/TableCellInspectModal.tsx
+++ b/packages/grafana-ui/src/components/Table/TableCellInspectModal.tsx
@@ -14,8 +14,9 @@ interface TableCellInspectModalProps {
 export function TableCellInspectModal({ value, onDismiss, mode }: TableCellInspectModalProps) {
   let displayValue = value;
   if (isString(value)) {
+    const trimmedValue = value.trim();
     // Exclude numeric strings like '123' from being displayed in code/JSON mode
-    if (value[0] === '{' || value[0] === '[' || mode === 'code') {
+    if (trimmedValue[0] === '{' || trimmedValue[0] === '[' || mode === 'code') {
       try {
         value = JSON.parse(value);
         mode = 'code';


### PR DESCRIPTION
**What is this feature?**

Automatically setting the inspect type to json if the value can be parsed as JSON. This will automatically show the JSON/code view when the user clicks on the inspect icon within a table cell.

<img width="345" alt="image" src="https://github.com/grafana/grafana/assets/109082771/9b52438a-ca4f-413c-9212-6302abc73d15">

<img width="754" alt="image" src="https://github.com/grafana/grafana/assets/109082771/1943d071-d151-4cdf-8bff-7a28c436e244">



**Why do we need this feature?**
It's hard to read JSON without any formatting.
https://github.com/grafana/grafana/issues/79589

**Who is this feature for?**
Table users, specifically logs table in explore.

**Which issue(s) does this PR fix?**:
Fixes https://github.com/grafana/grafana/issues/79589

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
