### PR TITLE
Infinite scroll: Allow users to reach top/bottom of the log list before triggering scroll

### DIFF
--- a/public/app/features/logs/components/InfiniteScroll.test.tsx
+++ b/public/app/features/logs/components/InfiniteScroll.test.tsx
@@ -17,7 +17,7 @@ jest.mock('lodash', () => ({
     }
     debounced.cancel = jest.fn();
     return debounced;
-  }
+  },
 }));
 
 const defaultTz = 'browser';
@@ -240,7 +240,7 @@ describe('InfiniteScroll', () => {
             const { simulateScrollTo } = setup(loadMoreMock, rows, order, startPosition);
 
             expect(await screen.findByTestId('contents')).toBeInTheDocument();
-            
+
             simulateScrollTo(endPosition);
 
             expect(loadMoreMock).not.toHaveBeenCalled();
@@ -263,7 +263,7 @@ describe('InfiniteScroll', () => {
             const { simulateScrollTo } = setup(loadMoreMock, rows, order, startPosition);
 
             expect(await screen.findByTestId('contents')).toBeInTheDocument();
-            
+
             simulateScrollTo(endPosition);
 
             expect(loadMoreMock).not.toHaveBeenCalled();

--- a/public/app/features/logs/components/InfiniteScroll.test.tsx
+++ b/public/app/features/logs/components/InfiniteScroll.test.tsx
@@ -134,7 +134,7 @@ describe('InfiniteScroll', () => {
 `);
   });
 
-  describe.each([LogsSortOrder.Descending])( //, LogsSortOrder.Ascending])(
+  describe.each([LogsSortOrder.Descending, LogsSortOrder.Ascending])(
     'When the sort order is %s',
     (order: LogsSortOrder) => {
       let rows: LogRowModel[];

--- a/public/app/features/logs/components/InfiniteScroll.tsx
+++ b/public/app/features/logs/components/InfiniteScroll.tsx
@@ -3,7 +3,7 @@ import React, { ReactNode, useEffect, useRef, useState } from 'react';
 
 import { AbsoluteTimeRange, LogRowModel, TimeRange } from '@grafana/data';
 import { convertRawToRange, isRelativeTime, isRelativeTimeRange } from '@grafana/data/src/datetime/rangeutil';
-import { reportInteraction } from '@grafana/runtime';
+import { config, reportInteraction } from '@grafana/runtime';
 import { LogsSortOrder, TimeZone } from '@grafana/schema';
 
 import { LoadingIndicator } from './LoadingIndicator';
@@ -48,7 +48,7 @@ export const InfiniteScroll = ({
   }, [loading]);
 
   useEffect(() => {
-    if (!scrollElement || !loadMoreLogs) {
+    if (!scrollElement || !loadMoreLogs || !config.featureToggles.logsInfiniteScrolling) {
       return;
     }
 

--- a/public/app/features/logs/components/InfiniteScroll.tsx
+++ b/public/app/features/logs/components/InfiniteScroll.tsx
@@ -57,6 +57,12 @@ export const InfiniteScroll = ({
   }, [loading]);
 
   useEffect(() => {
+    if (lowerLoading && scrollElement) {
+      scrollElement.scrollTo(0, scrollElement.scrollHeight - scrollElement.clientHeight);
+    }
+  }, [lowerLoading, scrollElement]);
+
+  useEffect(() => {
     if (!scrollElement || !loadMoreLogs || !config.featureToggles.logsInfiniteScrolling) {
       return;
     }

--- a/public/app/features/logs/components/InfiniteScroll.tsx
+++ b/public/app/features/logs/components/InfiniteScroll.tsx
@@ -36,10 +36,13 @@ export const InfiniteScroll = ({
   const [lowerLoading, setLowerLoading] = useState(false);
   const lastScroll = useRef<number>(scrollElement?.scrollTop || 0);
   const [onEdge, setOnEdge] = useState(true);
-  const debouncedOnEdge = useMemo(() => debounce(() => { 
-    setOnEdge(true);
-    console.log('bouncy bouncy') 
-  }, 300), []);
+  const debouncedOnEdge = useMemo(
+    () =>
+      debounce(() => {
+        setOnEdge(true);
+      }, 300),
+    []
+  );
 
   useEffect(() => {
     setUpperOutOfRange(false);
@@ -65,7 +68,10 @@ export const InfiniteScroll = ({
       event.stopImmediatePropagation();
 
       // Give the user a chance to reach the top or bottom before triggering infinite scrolling requests
-      const onScrollingEdge = isOnEdge(lastScroll.current, scrollElement, onEdge, debouncedOnEdge, () => { setOnEdge(false); debouncedOnEdge.cancel(); });
+      const onScrollingEdge = isOnEdge(lastScroll.current, scrollElement, onEdge, debouncedOnEdge, () => {
+        setOnEdge(false);
+        debouncedOnEdge.cancel();
+      });
       if (!onScrollingEdge) {
         lastScroll.current = scrollElement.scrollTop;
         return;
@@ -238,10 +244,20 @@ function updateCurrentRange(timeRange: TimeRange, timeZone: TimeZone) {
   return isRelativeTimeRange(timeRange.raw) ? convertRawToRange(timeRange.raw, timeZone) : timeRange;
 }
 
-function isOnEdge(lastScroll: number, scrollElement: HTMLDivElement, currentlyOnEdge: boolean, onEdgeCallback: () => void, notOnEdgeCallback: () => void) {
+function isOnEdge(
+  lastScroll: number,
+  scrollElement: HTMLDivElement,
+  currentlyOnEdge: boolean,
+  onEdgeCallback: () => void,
+  notOnEdgeCallback: () => void
+) {
   const scrollHeight = scrollElement.scrollHeight - scrollElement.clientHeight;
   // Sometimes, when the scroll reaches the end, it can be 1 less the scroll height, hence `Math.abs(scrollHeight - scrollElement.scrollTop) <= 1`
-  if (lastScroll === scrollElement.scrollTop && (scrollElement.scrollTop === 0 || Math.abs(scrollHeight - scrollElement.scrollTop) <= 1)) {
+  console.log(currentlyOnEdge);
+  if (
+    lastScroll === scrollElement.scrollTop &&
+    (scrollElement.scrollTop === 0 || Math.abs(scrollHeight - scrollElement.scrollTop) <= 1)
+  ) {
     if (currentlyOnEdge) {
       return true;
     }

--- a/public/app/features/logs/components/InfiniteScroll.tsx
+++ b/public/app/features/logs/components/InfiniteScroll.tsx
@@ -258,8 +258,8 @@ function isOnEdge(
   const scrollHeight = scrollElement.scrollHeight - scrollElement.clientHeight;
   // Sometimes, when the scroll reaches the end, it can be 1 less the scroll height, hence `Math.abs(scrollHeight - scrollElement.scrollTop) <= 1`
   if (
-    lastScroll === scrollElement.scrollTop &&
-    (scrollElement.scrollTop === 0 || Math.abs(scrollHeight - scrollElement.scrollTop) <= 1)
+    scrollElement.scrollTop === 0 ||
+    (lastScroll === scrollElement.scrollTop && Math.abs(scrollHeight - scrollElement.scrollTop) <= 1)
   ) {
     if (currentlyOnEdge) {
       return true;

--- a/public/app/features/logs/components/InfiniteScroll.tsx
+++ b/public/app/features/logs/components/InfiniteScroll.tsx
@@ -35,7 +35,7 @@ export const InfiniteScroll = ({
   const [upperLoading, setUpperLoading] = useState(false);
   const [lowerLoading, setLowerLoading] = useState(false);
   const lastScroll = useRef<number>(scrollElement?.scrollTop || 0);
-  const [onEdge, setOnEdge] = useState(true);
+  const [onEdge, setOnEdge] = useState(scrollElement?.scrollTop === 0 ? true : false);
   const debouncedOnEdge = useMemo(
     () =>
       debounce(() => {


### PR DESCRIPTION
Addressing recent feedback, with these changes we allow users to reach the top or bottom of the log list, before an scrolling event triggers a new request.

The reason is that triggering a new requests when the users are in the process of scrolling is potentially confusing and disrupting. By debouncing and waiting a few milliseconds, we allow the user to stay in the desired state, and trigger a new request only if they scroll in the right direction.

Additional changes: code clean up for enhanced readability.

Part of https://github.com/grafana/grafana/issues/71728

**Special notes for your reviewer:**

Please give this a try and let me know how it feels. I recommend to simmulate different network conditions for an experience closer to the real world.

Demo:

https://github.com/grafana/grafana/assets/1069378/3d8bdcf0-6118-4ea0-87f1-c104734befd6

