### PR TITLE
Alerting: Retry readiness check to the remote Alertmanager on 5xx status code responses

### DIFF
--- a/pkg/services/ngalert/remote/client/alertmanager.go
+++ b/pkg/services/ngalert/remote/client/alertmanager.go
@@ -107,7 +107,7 @@ func (am *Alertmanager) IsReadyWithBackoff(ctx context.Context) (bool, error) {
 			}
 
 			if status != http.StatusOK {
-				if status/400 == 1 {
+				if status >= 400 && status < 500 {
 					am.logger.Debug("Ready check failed with non-retriable status code", "attempt", attempts, "status", status)
 					return false, fmt.Errorf("ready check failed with non-retriable status code %d", status)
 				}


### PR DESCRIPTION
We're not retrying the readiness check on 5xx status code responses, this PR fixes that.