### PR TITLE
Plugins: Service identifier

### DIFF
--- a/pkg/api/datasources.go
+++ b/pkg/api/datasources.go
@@ -922,7 +922,7 @@ func (hs *HTTPServer) CheckDatasourceHealth(c *contextmodel.ReqContext) response
 }
 
 func (hs *HTTPServer) checkDatasourceHealth(c *contextmodel.ReqContext, ds *datasources.DataSource) response.Response {
-	pCtx, err := hs.pluginContextProvider.GetWithDataSource(c.Req.Context(), ds.Type, c.SignedInUser, ds)
+	pCtx, err := hs.pluginContextProvider.GetWithDataSource(c.Req.Context(), ds.Type, c.SignedInUser, ds, "health-check")
 	if err != nil {
 		return response.ErrOrFallback(http.StatusInternalServerError, "Unable to get plugin context", err)
 	}

--- a/pkg/api/metrics.go
+++ b/pkg/api/metrics.go
@@ -54,7 +54,7 @@ func (hs *HTTPServer) QueryMetricsV2(c *contextmodel.ReqContext) response.Respon
 		return response.Error(http.StatusBadRequest, "bad request data", err)
 	}
 
-	resp, err := hs.queryDataService.QueryData(c.Req.Context(), c.SignedInUser, c.SkipDSCache, reqDTO)
+	resp, err := hs.queryDataService.QueryData(c.Req.Context(), c.SignedInUser, c.SkipDSCache, reqDTO, "query")
 	if err != nil {
 		return hs.handleQueryMetricsError(err)
 	}

--- a/pkg/api/plugin_resource.go
+++ b/pkg/api/plugin_resource.go
@@ -27,7 +27,7 @@ func (hs *HTTPServer) CallResource(c *contextmodel.ReqContext) {
 }
 
 func (hs *HTTPServer) callPluginResource(c *contextmodel.ReqContext, pluginID string) {
-	pCtx, err := hs.pluginContextProvider.Get(c.Req.Context(), pluginID, c.SignedInUser, c.SignedInUser.GetOrgID())
+	pCtx, err := hs.pluginContextProvider.Get(c.Req.Context(), pluginID, c.SignedInUser, c.SignedInUser.GetOrgID(), "resource")
 	if err != nil {
 		if errors.Is(err, plugins.ErrPluginNotRegistered) {
 			c.JsonApiErr(404, "Plugin not found", nil)
@@ -52,7 +52,7 @@ func (hs *HTTPServer) callPluginResource(c *contextmodel.ReqContext, pluginID st
 }
 
 func (hs *HTTPServer) callPluginResourceWithDataSource(c *contextmodel.ReqContext, pluginID string, ds *datasources.DataSource) {
-	pCtx, err := hs.pluginContextProvider.GetWithDataSource(c.Req.Context(), pluginID, c.SignedInUser, ds)
+	pCtx, err := hs.pluginContextProvider.GetWithDataSource(c.Req.Context(), pluginID, c.SignedInUser, ds, "resource")
 	if err != nil {
 		if errors.Is(err, plugins.ErrPluginNotRegistered) {
 			c.JsonApiErr(404, "Plugin not found", nil)

--- a/pkg/api/plugins.go
+++ b/pkg/api/plugins.go
@@ -400,7 +400,7 @@ func (hs *HTTPServer) redirectCDNPluginAsset(c *contextmodel.ReqContext, plugin 
 // /api/plugins/:pluginId/health
 func (hs *HTTPServer) CheckHealth(c *contextmodel.ReqContext) response.Response {
 	pluginID := web.Params(c.Req)[":pluginId"]
-	pCtx, err := hs.pluginContextProvider.Get(c.Req.Context(), pluginID, c.SignedInUser, c.SignedInUser.GetOrgID())
+	pCtx, err := hs.pluginContextProvider.Get(c.Req.Context(), pluginID, c.SignedInUser, c.SignedInUser.GetOrgID(), "health-check")
 	if err != nil {
 		return response.ErrOrFallback(http.StatusInternalServerError, "Failed to get plugin settings", err)
 	}

--- a/pkg/expr/ml.go
+++ b/pkg/expr/ml.go
@@ -62,7 +62,7 @@ func (m *MLNode) Execute(ctx context.Context, now time.Time, _ mathexp.Vars, s *
 	timeRange := m.TimeRange.AbsoluteTime(now)
 
 	// get the plugin configuration that will be used by client (auth, host, etc)
-	pCtx, err := s.pCtxProvider.Get(ctx, mlPluginID, m.request.User, m.request.OrgId)
+	pCtx, err := s.pCtxProvider.Get(ctx, mlPluginID, m.request.User, m.request.OrgId, "expr")
 	if err != nil {
 		if errors.Is(err, plugins.ErrPluginNotRegistered) {
 			return result, errMLPluginDoesNotExist

--- a/pkg/expr/nodes.go
+++ b/pkg/expr/nodes.go
@@ -223,7 +223,7 @@ func executeDSNodesGrouped(ctx context.Context, now time.Time, vars mathexp.Vars
 			ctx, span := s.tracer.Start(ctx, "SSE.ExecuteDatasourceQuery")
 			defer span.End()
 			firstNode := nodeGroup[0]
-			pCtx, err := s.pCtxProvider.GetWithDataSource(ctx, firstNode.datasource.Type, firstNode.request.User, firstNode.datasource)
+			pCtx, err := s.pCtxProvider.GetWithDataSource(ctx, firstNode.datasource.Type, firstNode.request.User, firstNode.datasource, "expr")
 			if err != nil {
 				for _, dn := range nodeGroup {
 					vars[dn.refID] = mathexp.Results{Error: datasources.ErrDataSourceNotFound}
@@ -309,7 +309,7 @@ func (dn *DSNode) Execute(ctx context.Context, now time.Time, _ mathexp.Vars, s 
 	ctx, span := s.tracer.Start(ctx, "SSE.ExecuteDatasourceQuery")
 	defer span.End()
 
-	pCtx, err := s.pCtxProvider.GetWithDataSource(ctx, dn.datasource.Type, dn.request.User, dn.datasource)
+	pCtx, err := s.pCtxProvider.GetWithDataSource(ctx, dn.datasource.Type, dn.request.User, dn.datasource, "expr")
 	if err != nil {
 		return mathexp.Results{}, err
 	}

--- a/pkg/expr/service.go
+++ b/pkg/expr/service.go
@@ -68,8 +68,8 @@ type Service struct {
 }
 
 type pluginContextProvider interface {
-	Get(ctx context.Context, pluginID string, user identity.Requester, orgID int64) (backend.PluginContext, error)
-	GetWithDataSource(ctx context.Context, pluginID string, user identity.Requester, ds *datasources.DataSource) (backend.PluginContext, error)
+	Get(ctx context.Context, pluginID string, user identity.Requester, orgID int64, service string) (backend.PluginContext, error)
+	GetWithDataSource(ctx context.Context, pluginID string, user identity.Requester, ds *datasources.DataSource, service string) (backend.PluginContext, error)
 }
 
 func ProvideService(cfg *setting.Cfg, pluginClient plugins.Client, pCtxProvider *plugincontext.Provider,

--- a/pkg/expr/testing.go
+++ b/pkg/expr/testing.go
@@ -20,7 +20,7 @@ type fakePluginContextProvider struct {
 
 var _ pluginContextProvider = &fakePluginContextProvider{}
 
-func (f *fakePluginContextProvider) Get(_ context.Context, pluginID string, user identity.Requester, orgID int64) (backend.PluginContext, error) {
+func (f *fakePluginContextProvider) Get(_ context.Context, pluginID string, user identity.Requester, orgID int64, service string) (backend.PluginContext, error) {
 	f.recordings = append(f.recordings, struct {
 		method string
 		params []any
@@ -42,10 +42,11 @@ func (f *fakePluginContextProvider) Get(_ context.Context, pluginID string, user
 		User:                       u,
 		AppInstanceSettings:        f.result[pluginID],
 		DataSourceInstanceSettings: nil,
+		FromService:                service,
 	}, nil
 }
 
-func (f *fakePluginContextProvider) GetWithDataSource(ctx context.Context, pluginID string, user identity.Requester, ds *datasources.DataSource) (backend.PluginContext, error) {
+func (f *fakePluginContextProvider) GetWithDataSource(ctx context.Context, pluginID string, user identity.Requester, ds *datasources.DataSource, service string) (backend.PluginContext, error) {
 	f.recordings = append(f.recordings, struct {
 		method string
 		params []any
@@ -59,7 +60,7 @@ func (f *fakePluginContextProvider) GetWithDataSource(ctx context.Context, plugi
 	if user != nil {
 		orgId = user.GetOrgID()
 	}
-	r, err := f.Get(ctx, pluginID, user, orgId)
+	r, err := f.Get(ctx, pluginID, user, orgId, service)
 	if ds != nil {
 		r.DataSourceInstanceSettings = &backend.DataSourceInstanceSettings{
 			ID:   ds.ID,

--- a/pkg/services/live/live.go
+++ b/pkg/services/live/live.go
@@ -577,7 +577,7 @@ func (g *GrafanaLive) handleOnRPC(client *centrifuge.Client, e centrifuge.RPCEve
 	if err != nil {
 		return centrifuge.RPCReply{}, centrifuge.ErrorBadRequest
 	}
-	resp, err := g.queryDataService.QueryData(client.Context(), user, false, req)
+	resp, err := g.queryDataService.QueryData(client.Context(), user, false, req, "query")
 	if err != nil {
 		logger.Error("Error query data", "user", client.UserID(), "client", client.ID(), "method", e.Method, "error", err)
 		if errors.Is(err, datasources.ErrDataSourceAccessDenied) {

--- a/pkg/services/live/liveplugin/plugin.go
+++ b/pkg/services/live/liveplugin/plugin.go
@@ -74,12 +74,12 @@ func NewContextGetter(pluginContextProvider *plugincontext.Provider, dataSourceC
 
 func (g *ContextGetter) GetPluginContext(ctx context.Context, user identity.Requester, pluginID string, datasourceUID string, skipCache bool) (backend.PluginContext, error) {
 	if datasourceUID == "" {
-		return g.pluginContextProvider.Get(ctx, pluginID, user, user.GetOrgID())
+		return g.pluginContextProvider.Get(ctx, pluginID, user, user.GetOrgID(), "live-plugin")
 	}
 
 	ds, err := g.dataSourceCache.GetDatasourceByUID(ctx, datasourceUID, user, skipCache)
 	if err != nil {
 		return backend.PluginContext{}, fmt.Errorf("%v: %w", "Failed to get datasource", err)
 	}
-	return g.pluginContextProvider.GetWithDataSource(ctx, pluginID, user, ds)
+	return g.pluginContextProvider.GetWithDataSource(ctx, pluginID, user, ds, "live-plugin")
 }

--- a/pkg/services/pluginsintegration/plugincontext/plugincontext.go
+++ b/pkg/services/pluginsintegration/plugincontext/plugincontext.go
@@ -60,7 +60,7 @@ type Provider struct {
 // This is intended to be used for app plugin requests.
 // PluginContext.AppInstanceSettings will be resolved and appended to the returned context.
 // Note: identity.Requester can be nil.
-func (p *Provider) Get(ctx context.Context, pluginID string, user identity.Requester, orgID int64) (backend.PluginContext, error) {
+func (p *Provider) Get(ctx context.Context, pluginID string, user identity.Requester, orgID int64, service string) (backend.PluginContext, error) {
 	plugin, exists := p.pluginStore.Plugin(ctx, pluginID)
 	if !exists {
 		return backend.PluginContext{}, plugins.ErrPluginNotRegistered
@@ -69,6 +69,7 @@ func (p *Provider) Get(ctx context.Context, pluginID string, user identity.Reque
 	pCtx := backend.PluginContext{
 		PluginID:      plugin.ID,
 		PluginVersion: plugin.Info.Version,
+		FromService:   service,
 	}
 	if user != nil && !user.IsNil() {
 		pCtx.OrgID = user.GetOrgID()
@@ -99,7 +100,7 @@ func (p *Provider) Get(ctx context.Context, pluginID string, user identity.Reque
 // This is intended to be used for datasource plugin requests.
 // PluginContext.DataSourceInstanceSettings will be resolved and appended to the returned context.
 // Note: identity.Requester can be nil.
-func (p *Provider) GetWithDataSource(ctx context.Context, pluginID string, user identity.Requester, ds *datasources.DataSource) (backend.PluginContext, error) {
+func (p *Provider) GetWithDataSource(ctx context.Context, pluginID string, user identity.Requester, ds *datasources.DataSource, service string) (backend.PluginContext, error) {
 	plugin, exists := p.pluginStore.Plugin(ctx, pluginID)
 	if !exists {
 		return backend.PluginContext{}, plugins.ErrPluginNotRegistered
@@ -108,6 +109,7 @@ func (p *Provider) GetWithDataSource(ctx context.Context, pluginID string, user 
 	pCtx := backend.PluginContext{
 		PluginID:      plugin.ID,
 		PluginVersion: plugin.Info.Version,
+		FromService:   service,
 	}
 	if user != nil && !user.IsNil() {
 		pCtx.OrgID = user.GetOrgID()

--- a/pkg/services/pluginsintegration/plugincontext/plugincontext_test.go
+++ b/pkg/services/pluginsintegration/plugincontext/plugincontext_test.go
@@ -56,10 +56,11 @@ func TestGet(t *testing.T) {
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Run("Get", func(t *testing.T) {
-				pCtx, err := pcp.Get(context.Background(), tc.input, identity, identity.OrgID)
+				pCtx, err := pcp.Get(context.Background(), tc.input, identity, identity.OrgID, "test")
 				require.NoError(t, err)
 				require.Equal(t, pluginID, pCtx.PluginID)
 				require.NotNil(t, pCtx.GrafanaConfig)
+				require.Equal(t, "test", pCtx.FromService)
 			})
 
 			t.Run("GetWithDataSource", func(t *testing.T) {
@@ -69,10 +70,11 @@ func TestGet(t *testing.T) {
 					Name:     "test",
 					Type:     pluginID,
 					JsonData: simplejson.New(),
-				})
+				}, "test")
 				require.NoError(t, err)
 				require.Equal(t, pluginID, pCtx.PluginID)
 				require.NotNil(t, pCtx.GrafanaConfig)
+				require.Equal(t, "test", pCtx.FromService)
 			})
 		})
 	}

--- a/pkg/services/publicdashboards/service/query.go
+++ b/pkg/services/publicdashboards/service/query.go
@@ -139,7 +139,7 @@ func (pd *PublicDashboardServiceImpl) GetQueryDataResponse(ctx context.Context, 
 	}
 
 	anonymousUser := buildAnonymousUser(ctx, dashboard)
-	res, err := pd.QueryDataService.QueryData(ctx, anonymousUser, skipDSCache, metricReq)
+	res, err := pd.QueryDataService.QueryData(ctx, anonymousUser, skipDSCache, metricReq, "publicdashboards")
 
 	reqDatasources := metricReq.GetUniqueDatasourceTypes()
 	if err != nil {

--- a/pkg/services/query/query_service_mock.go
+++ b/pkg/services/query/query_service_mock.go
@@ -20,7 +20,7 @@ type FakeQueryService struct {
 }
 
 // QueryData provides a mock function with given fields: ctx, _a1, skipDSCache, reqDTO
-func (_m *FakeQueryService) QueryData(ctx context.Context, _a1 identity.Requester, skipDSCache bool, reqDTO dtos.MetricRequest) (*backend.QueryDataResponse, error) {
+func (_m *FakeQueryService) QueryData(ctx context.Context, _a1 identity.Requester, skipDSCache bool, reqDTO dtos.MetricRequest, service string) (*backend.QueryDataResponse, error) {
 	ret := _m.Called(ctx, _a1, skipDSCache, reqDTO)
 
 	var r0 *backend.QueryDataResponse

--- a/pkg/services/query/query_test.go
+++ b/pkg/services/query/query_test.go
@@ -307,7 +307,7 @@ func TestQueryDataMultipleSources(t *testing.T) {
 		}
 		ctx := ctxkey.Set(context.Background(), reqCtx)
 
-		_, err = tc.queryService.QueryData(ctx, tc.signedInUser, true, reqDTO)
+		_, err = tc.queryService.QueryData(ctx, tc.signedInUser, true, reqDTO, "query")
 		require.NoError(t, err)
 
 		// response headers should be merged
@@ -360,7 +360,7 @@ func TestQueryDataMultipleSources(t *testing.T) {
 		}
 
 		// without query parameter
-		_, err = tc.queryService.QueryData(context.Background(), tc.signedInUser, true, reqDTO)
+		_, err = tc.queryService.QueryData(context.Background(), tc.signedInUser, true, reqDTO, "query")
 		require.NoError(t, err)
 
 		httpreq, err := http.NewRequest(http.MethodPost, "http://localhost/ds/query?expression=true", bytes.NewReader([]byte{}))
@@ -377,7 +377,7 @@ func TestQueryDataMultipleSources(t *testing.T) {
 		httpreq.Header.Add("X-Datasource-Uid", "gIEkMvIVz")
 
 		// with query parameter
-		_, err = tc.queryService.QueryData(httpreq.Context(), tc.signedInUser, true, reqDTO)
+		_, err = tc.queryService.QueryData(httpreq.Context(), tc.signedInUser, true, reqDTO, "query")
 		require.NoError(t, err)
 	})
 
@@ -413,7 +413,7 @@ func TestQueryDataMultipleSources(t *testing.T) {
 			Debug:   false,
 		}
 
-		res, err := tc.queryService.QueryData(context.Background(), tc.signedInUser, true, reqDTO)
+		res, err := tc.queryService.QueryData(context.Background(), tc.signedInUser, true, reqDTO, "query")
 
 		require.NoError(t, err)
 		require.Error(t, res.Responses["B"].Error)
@@ -442,7 +442,7 @@ func TestQueryDataMultipleSources(t *testing.T) {
 			Debug:   false,
 		}
 
-		_, err = tc.queryService.QueryData(context.Background(), tc.signedInUser, true, reqDTO)
+		_, err = tc.queryService.QueryData(context.Background(), tc.signedInUser, true, reqDTO, "query")
 
 		require.NoError(t, err)
 	})

--- a/pkg/tsdb/legacydata/service/service.go
+++ b/pkg/tsdb/legacydata/service/service.go
@@ -74,7 +74,7 @@ func (h *Service) generateRequest(ctx context.Context, ds *datasources.DataSourc
 		query.Headers = make(map[string]string)
 	}
 
-	pCtx, err := h.pCtxProvider.GetWithDataSource(ctx, ds.Type, query.User, ds)
+	pCtx, err := h.pCtxProvider.GetWithDataSource(ctx, ds.Type, query.User, ds, "legacydata")
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Adds a `service` field to various functions that end up either querying or making resource calls against data sources/plugins. This field will be used to allow plugins to identify the origin of a request that is made to them.

At the moment this applies to:
- Queries (explore/dashboards although we can't tell the difference between the two atm)
- Resource calls (explore/dashboards/alerting although we can't tell the difference atm)
- Check health calls
- Public dashboards (identified as `publicdashboards`)
- Anything using the `expr` backend service (identified as `expr` - not sure if this is just alerting or not)

Not sure what the `legacy` service is actually used for but I added it there to avoid any issues.

Ideally, we'd like to be able to distinguish the calling apps in the frontend as well for completeness. Additionally, we can't do this for backend rendering atm as far as I can tell but that'd also be useful.

See [this](https://raintank-corp.slack.com/archives/C03E2AQKU2W/p1704716276022269) thread for more information.

Dependant on grafana/grafana-plugin-sdk-go#874