### PR TITLE
Annotations: Prevent creating on unsaved dashboard

### DIFF
--- a/public/app/plugins/panel/candlestick/CandlestickPanel.tsx
+++ b/public/app/plugins/panel/candlestick/CandlestickPanel.tsx
@@ -320,7 +320,7 @@ export const CandlestickPanel = ({
                 annotations={data.annotations ?? []}
                 config={uplotConfig}
                 timeZone={timeZone}
-                newRange={newAnnotationRange}
+                newRange={enableAnnotationCreation ? newAnnotationRange : null}
                 setNewRange={setNewAnnotationRange}
               />
             ) : (

--- a/public/app/plugins/panel/candlestick/CandlestickPanel.tsx
+++ b/public/app/plugins/panel/candlestick/CandlestickPanel.tsx
@@ -299,8 +299,8 @@ export const CandlestickPanel = ({
                     />
                   );
                 }}
-                maxWidth={options.tooltip.maxWidth}
-                maxHeight={options.tooltip.maxHeight}
+                maxWidth={options.tooltip?.maxWidth}
+                maxHeight={options.tooltip?.maxHeight}
               />
             ) : (
               <>

--- a/public/app/plugins/panel/heatmap/HeatmapPanel.tsx
+++ b/public/app/plugins/panel/heatmap/HeatmapPanel.tsx
@@ -286,7 +286,7 @@ export const HeatmapPanel = ({
                   annotations={data.annotations ?? []}
                   config={builder}
                   timeZone={timeZone}
-                  newRange={newAnnotationRange}
+                  newRange={enableAnnotationCreation ? newAnnotationRange : null}
                   setNewRange={setNewAnnotationRange}
                   canvasRegionRendering={false}
                 />

--- a/public/app/plugins/panel/state-timeline/StateTimelinePanel.tsx
+++ b/public/app/plugins/panel/state-timeline/StateTimelinePanel.tsx
@@ -249,7 +249,7 @@ export const StateTimelinePanel = ({
                   annotations={data.annotations ?? []}
                   config={builder}
                   timeZone={timeZone}
-                  newRange={newAnnotationRange}
+                  newRange={enableAnnotationCreation ? newAnnotationRange : null}
                   setNewRange={setNewAnnotationRange}
                   canvasRegionRendering={false}
                 />

--- a/public/app/plugins/panel/status-history/StatusHistoryPanel.tsx
+++ b/public/app/plugins/panel/status-history/StatusHistoryPanel.tsx
@@ -275,7 +275,7 @@ export const StatusHistoryPanel = ({
                   annotations={data.annotations ?? []}
                   config={builder}
                   timeZone={timeZone}
-                  newRange={newAnnotationRange}
+                  newRange={enableAnnotationCreation ? newAnnotationRange : null}
                   setNewRange={setNewAnnotationRange}
                   canvasRegionRendering={false}
                 />

--- a/public/app/plugins/panel/timeseries/TimeSeriesPanel.tsx
+++ b/public/app/plugins/panel/timeseries/TimeSeriesPanel.tsx
@@ -170,7 +170,7 @@ export const TimeSeriesPanel = ({
                 annotations={data.annotations ?? []}
                 config={uplotConfig}
                 timeZone={timeZone}
-                newRange={newAnnotationRange}
+                newRange={enableAnnotationCreation ? newAnnotationRange : null}
                 setNewRange={setNewAnnotationRange}
               />
             ) : (


### PR DESCRIPTION
https://github.com/grafana/grafana/assets/88068998/d4e22c88-5850-464f-b23b-1d498ea08d64

- Prevents creating annotations before saving the dashboard
- Temporary fix for Candlestick tooltip


Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
