### PR TITLE
Alerting: Fix migration edge-case race condition for silences

### DIFF
--- a/pkg/services/ngalert/migration/service.go
+++ b/pkg/services/ngalert/migration/service.go
@@ -65,8 +65,7 @@ func ProvideService(
 		migrationStore:    migrationStore,
 		encryptionService: encryptionService,
 		silences: &silenceHandler{
-			dataPath:          cfg.DataPath,
-			createSilenceFile: openReplace,
+			persistSilences: migrationStore.SetSilences,
 		},
 	}, nil
 }
@@ -493,7 +492,7 @@ func (ms *migrationService) migrateAllOrgs(ctx context.Context) error {
 			return err
 		}
 
-		err = ms.silences.createSilences(o.ID, om.log)
+		err = ms.silences.createSilences(ctx, o.ID, om.log)
 		if err != nil {
 			return fmt.Errorf("create silences for org %d: %w", o.ID, err)
 		}


### PR DESCRIPTION
**What is this feature?**

This change opts to bypass the unnecessary step of writing the silences to disk during the migration and instead write them directly to the kvstore. 

**Why do we need this feature?**

If the db already has an entry in the kvstore for the silences of an alertmanager before the migration has taken place, then it's possible that the active alertmanager will overwrite the silence file created by the migration before it has a chance to load it into memory.

This should not happen normally but is possible in edge-cases.

The change avoids the race condition entirely and is more correct as we treat the database as the  source of truth for AM state.

**Special notes for your reviewer:**

Can reproduce by adding an empty silence entry to the kvstore before migrating alerts that would normally create silences (such as alerts with NoData/Error set to keep_state).
