### PR TITLE
Datasources: Add concurrency number to the settings

### DIFF
--- a/conf/defaults.ini
+++ b/conf/defaults.ini
@@ -429,6 +429,11 @@ default_home_dashboard_path =
 # Upper limit of data sources that Grafana will return. This limit is a temporary configuration and it will be deprecated when pagination will be introduced on the list data sources API.
 datasource_limit = 5000
 
+# Number of queries to be executed concurrently. Only for the datasource supports concurrency.
+# For now only Loki and InfluxDB (with influxql) are supporting concurrency behind the feature flags.
+# Check datasource documentations for enabling concurrency.
+concurrent_query_count = 10
+
 
 ################################### SQL Data Sources #####################
 [sql_datasources]

--- a/pkg/setting/setting.go
+++ b/pkg/setting/setting.go
@@ -345,6 +345,8 @@ type Cfg struct {
 
 	// Data sources
 	DataSourceLimit int
+	// Number of queries to be executed concurrently. Only for the datasource supports concurrency.
+	ConcurrentQueryCount int
 
 	// SQL Data sources
 	SqlDatasourceMaxOpenConnsDefault    int
@@ -1933,6 +1935,7 @@ func (cfg *Cfg) GetContentDeliveryURL(prefix string) (string, error) {
 func (cfg *Cfg) readDataSourcesSettings() {
 	datasources := cfg.Raw.Section("datasources")
 	cfg.DataSourceLimit = datasources.Key("datasource_limit").MustInt(5000)
+	cfg.ConcurrentQueryCount = datasources.Key("concurrent_query_count").MustInt(10)
 }
 
 func (cfg *Cfg) readSqlDataSourceSettings() {


### PR DESCRIPTION
**What is this feature?**

Currently, only Loki (soon InfluxDB for `influxql`) is supporting concurrent query execution. Concurrency allows us to execute queries in parallel. 

> This ensures that the total execution time of multiple queries is only the longest query rather than the sum of all the query times.

Currently, data sources that use concurrency have a hard-coded concurrent query limit. This must be configurable. 

Loki concurrency: https://github.com/grafana/grafana/pull/74064
InfluxDB concurrency: https://github.com/grafana/grafana/pull/81209

**Why do we need this feature?**

To be able to execute and return responses faster for the requests that have many queries.

**Who is this feature for?**

For the users that need to run multiple queries in one panel. 
⚠️ Concurrency support is on the data source level. Concurrency must be supported by data sources.
Please refer data source documentation for more information

**Special notes for your reviewer:**
This setting option is not being used anywhere yet. After having this in place Loki and InfluxDB will start using this. 

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
