### PR TITLE
Dashboard-Scenes: JSON Model and Version tabs don't hide edit mode on refresh

### DIFF
--- a/public/app/features/dashboard-scene/settings/JsonModelEditView.tsx
+++ b/public/app/features/dashboard-scene/settings/JsonModelEditView.tsx
@@ -10,6 +10,7 @@ import { getPrettyJSON } from 'app/features/inspector/utils/utils';
 import { DashboardDTO } from 'app/types';
 
 import { DashboardScene } from '../scene/DashboardScene';
+import { NavToolbarActions } from '../scene/NavToolbarActions';
 import { transformSaveModelToScene } from '../serialization/transformSaveModelToScene';
 import { transformSceneToSaveModel } from '../serialization/transformSceneToSaveModel';
 import { getDashboardSceneFor } from '../utils/utils';
@@ -69,6 +70,7 @@ export class JsonModelEditView extends SceneObjectBase<JsonModelEditViewState> i
 
     return (
       <Page navModel={navModel} pageNav={pageNav} layout={PageLayoutType.Standard}>
+        <NavToolbarActions dashboard={dashboard} />
         <div className={styles.wrapper}>
           <Trans i18nKey="dashboard-settings.json-editor.subtitle">
             The JSON model below is the data structure that defines the dashboard. This includes dashboard settings,

--- a/public/app/features/dashboard-scene/settings/VersionsEditView.tsx
+++ b/public/app/features/dashboard-scene/settings/VersionsEditView.tsx
@@ -6,6 +6,7 @@ import { HorizontalGroup, Spinner } from '@grafana/ui';
 import { Page } from 'app/core/components/Page/Page';
 
 import { DashboardScene } from '../scene/DashboardScene';
+import { NavToolbarActions } from '../scene/NavToolbarActions';
 import { getDashboardSceneFor } from '../utils/utils';
 
 import { DashboardEditView, DashboardEditViewState, useDashboardEditPageNav } from './utils';
@@ -188,32 +189,30 @@ function VersionsEditorSettingsListView({ model }: SceneComponentProps<VersionsE
   const hasMore = model.versions.length >= model.limit;
   const isLastPage = model.versions.find((rev) => rev.version === 1);
 
-  if (viewMode === 'compare') {
-    return (
-      <Page navModel={navModel} pageNav={pageNav} layout={PageLayoutType.Standard}>
-        <VersionHistoryHeader
-          onClick={model.reset}
-          baseVersion={baseInfo?.version}
-          newVersion={newInfo?.version}
-          isNewLatest={isNewLatest}
-        />
-        {isLoading ? (
-          <VersionsHistorySpinner msg="Fetching changes&hellip;" />
-        ) : (
-          <VersionHistoryComparison
-            newInfo={newInfo!}
-            baseInfo={baseInfo!}
-            isNewLatest={isNewLatest!}
-            diffData={model.diffData}
-            onRestore={dashboard.onRestore}
-          />
-        )}
-      </Page>
+  const viewModeCompare = (
+    <VersionHistoryHeader
+      onClick={model.reset}
+      baseVersion={baseInfo?.version}
+      newVersion={newInfo?.version}
+      isNewLatest={isNewLatest}
+    />
+  );
+  {
+    isLoading ? (
+      <VersionsHistorySpinner msg="Fetching changes&hellip;" />
+    ) : (
+      <VersionHistoryComparison
+        newInfo={newInfo!}
+        baseInfo={baseInfo!}
+        isNewLatest={isNewLatest!}
+        diffData={model.diffData}
+        onRestore={dashboard.onRestore}
+      />
     );
   }
 
-  return (
-    <Page navModel={navModel} pageNav={pageNav} layout={PageLayoutType.Standard}>
+  const viewModeList = (
+    <>
       {isLoading ? (
         <VersionsHistorySpinner msg="Fetching history list&hellip;" />
       ) : (
@@ -234,6 +233,13 @@ function VersionsEditorSettingsListView({ model }: SceneComponentProps<VersionsE
           isLastPage={!!isLastPage}
         />
       )}
+    </>
+  );
+
+  return (
+    <Page navModel={navModel} pageNav={pageNav} layout={PageLayoutType.Standard}>
+      <NavToolbarActions dashboard={dashboard} />
+      {viewMode === 'compare' ? viewModeCompare : viewModeList}
     </Page>
   );
 }

--- a/public/app/features/dashboard-scene/settings/VersionsEditView.tsx
+++ b/public/app/features/dashboard-scene/settings/VersionsEditView.tsx
@@ -190,26 +190,28 @@ function VersionsEditorSettingsListView({ model }: SceneComponentProps<VersionsE
   const isLastPage = model.versions.find((rev) => rev.version === 1);
 
   const viewModeCompare = (
-    <VersionHistoryHeader
-      onClick={model.reset}
-      baseVersion={baseInfo?.version}
-      newVersion={newInfo?.version}
-      isNewLatest={isNewLatest}
-    />
-  );
-  {
-    isLoading ? (
-      <VersionsHistorySpinner msg="Fetching changes&hellip;" />
-    ) : (
-      <VersionHistoryComparison
-        newInfo={newInfo!}
-        baseInfo={baseInfo!}
-        isNewLatest={isNewLatest!}
-        diffData={model.diffData}
-        onRestore={dashboard.onRestore}
+    <>
+      <VersionHistoryHeader
+        onClick={model.reset}
+        baseVersion={baseInfo?.version}
+        newVersion={newInfo?.version}
+        isNewLatest={isNewLatest}
       />
-    );
-  }
+      {
+        isLoading ? (
+          <VersionsHistorySpinner msg="Fetching changes&hellip;" />
+        ) : (
+          <VersionHistoryComparison
+            newInfo={newInfo!}
+            baseInfo={baseInfo!}
+            isNewLatest={isNewLatest!}
+            diffData={model.diffData}
+            onRestore={dashboard.onRestore}
+          />
+        )
+      }
+    </>
+  );
 
   const viewModeList = (
     <>

--- a/public/app/features/dashboard-scene/settings/VersionsEditView.tsx
+++ b/public/app/features/dashboard-scene/settings/VersionsEditView.tsx
@@ -197,19 +197,17 @@ function VersionsEditorSettingsListView({ model }: SceneComponentProps<VersionsE
         newVersion={newInfo?.version}
         isNewLatest={isNewLatest}
       />
-      {
-        isLoading ? (
-          <VersionsHistorySpinner msg="Fetching changes&hellip;" />
-        ) : (
-          <VersionHistoryComparison
-            newInfo={newInfo!}
-            baseInfo={baseInfo!}
-            isNewLatest={isNewLatest!}
-            diffData={model.diffData}
-            onRestore={dashboard.onRestore}
-          />
-        )
-      }
+      {isLoading ? (
+        <VersionsHistorySpinner msg="Fetching changes&hellip;" />
+      ) : (
+        <VersionHistoryComparison
+          newInfo={newInfo!}
+          baseInfo={baseInfo!}
+          isNewLatest={isNewLatest!}
+          diffData={model.diffData}
+          onRestore={dashboard.onRestore}
+        />
+      )}
     </>
   );
 


### PR DESCRIPTION
Fixed the issue where refreshing JSON Edit settings or Version tabs dashboard hides the edit mode buttons. 

Also refactored the Versions tab to wrap the whole logic under Page and NavToolbarActions to avoid repeating these components for each case.

Fixes #81218 

Please check that:
- [ ] It works as expected from a user's perspective.

