### PR TITLE
Alerting: Use only the alert condition query as the graph threshold

### DIFF
--- a/public/app/features/alerting/unified/GrafanaRuleQueryViewer.tsx
+++ b/public/app/features/alerting/unified/GrafanaRuleQueryViewer.tsx
@@ -46,7 +46,7 @@ export function GrafanaRuleQueryViewer({
   const expressions = queries.filter((q) => isExpressionQuery(q.model));
   const styles = useStyles2(getExpressionViewerStyles);
 
-  const thresholds = getThresholdsForQueries(queries);
+  const thresholds = getThresholdsForQueries(queries, condition);
 
   return (
     <Stack gap={2} direction="column">

--- a/public/app/features/alerting/unified/components/rule-editor/QueryRows.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/QueryRows.tsx
@@ -144,8 +144,8 @@ export class QueryRows extends PureComponent<Props> {
   };
 
   render() {
-    const { queries, expressions } = this.props;
-    const thresholdByRefId = getThresholdsForQueries([...queries, ...expressions]);
+    const { queries, expressions, condition } = this.props;
+    const thresholdByRefId = getThresholdsForQueries([...queries, ...expressions], condition);
 
     return (
       <DragDropContext onDragEnd={this.onDragEnd}>

--- a/public/app/features/alerting/unified/components/rule-editor/util.test.ts
+++ b/public/app/features/alerting/unified/components/rule-editor/util.test.ts
@@ -245,12 +245,12 @@ describe('checkForPathSeparator', () => {
 
 describe('getThresholdsForQueries', () => {
   it('should work for threshold condition', () => {
-    const queries = createThresholdExample('gt');
-    expect(getThresholdsForQueries(queries)).toMatchSnapshot();
+    const [queries, condition] = createThresholdExample('gt');
+    expect(getThresholdsForQueries(queries, condition)).toMatchSnapshot();
   });
 
   it('should work for classic_condition', () => {
-    const [dataQuery] = createThresholdExample('gt');
+    const [[dataQuery]] = createThresholdExample('gt');
 
     const classicCondition = {
       refId: 'B',
@@ -282,7 +282,7 @@ describe('getThresholdsForQueries', () => {
       },
     };
 
-    const thresholdsClassic = getThresholdsForQueries([dataQuery, classicCondition]);
+    const thresholdsClassic = getThresholdsForQueries([dataQuery, classicCondition], classicCondition.refId);
     expect(thresholdsClassic).toMatchSnapshot();
   });
 
@@ -331,30 +331,32 @@ describe('getThresholdsForQueries', () => {
     };
 
     expect(() => {
-      const thresholds = getThresholdsForQueries([dataQuery, classicCondition]);
+      const thresholds = getThresholdsForQueries([dataQuery, classicCondition], classicCondition.refId);
       expect(thresholds).toStrictEqual({});
     }).not.toThrowError();
   });
 
   it('should work for within_range', () => {
-    const queries = createThresholdExample('within_range');
-    const thresholds = getThresholdsForQueries(queries);
+    const [queries, condition] = createThresholdExample('within_range');
+    const thresholds = getThresholdsForQueries(queries, condition);
     expect(thresholds).toMatchSnapshot();
   });
 
   it('should work for lt and gt', () => {
-    expect(getThresholdsForQueries(createThresholdExample('gt'))).toMatchSnapshot();
-    expect(getThresholdsForQueries(createThresholdExample('lt'))).toMatchSnapshot();
+    const [gtQueries, qtCondition] = createThresholdExample('gt');
+    const [ltQueries, ltCondition] = createThresholdExample('lt');
+    expect(getThresholdsForQueries(gtQueries, qtCondition)).toMatchSnapshot();
+    expect(getThresholdsForQueries(ltQueries, ltCondition)).toMatchSnapshot();
   });
 
   it('should work for outside_range', () => {
-    const queries = createThresholdExample('outside_range');
-    const thresholds = getThresholdsForQueries(queries);
+    const [queries, condition] = createThresholdExample('outside_range');
+    const thresholds = getThresholdsForQueries(queries, condition);
     expect(thresholds).toMatchSnapshot();
   });
 });
 
-function createThresholdExample(thresholdType: string): AlertQuery[] {
+function createThresholdExample(thresholdType: string): [AlertQuery[], string] {
   const dataQuery: AlertQuery = {
     refId: 'A',
     datasourceUid: 'abc123',
@@ -403,7 +405,7 @@ function createThresholdExample(thresholdType: string): AlertQuery[] {
     },
   };
 
-  return [dataQuery, reduceExpression, thresholdExpression];
+  return [[dataQuery, reduceExpression, thresholdExpression], thresholdExpression.refId];
 }
 
 describe('findRenamedReferences', () => {

--- a/public/app/features/alerting/unified/components/rule-editor/util.ts
+++ b/public/app/features/alerting/unified/components/rule-editor/util.ts
@@ -144,9 +144,13 @@ export type ThresholdDefinitions = Record<string, ThresholdDefinition>;
 /**
  * This function will retrieve threshold definitions for the given array of data and expression queries.
  */
-export function getThresholdsForQueries(queries: AlertQuery[]) {
+export function getThresholdsForQueries(queries: AlertQuery[], condition: string | null) {
   const thresholds: ThresholdDefinitions = {};
   const SUPPORTED_EXPRESSION_TYPES = [ExpressionQueryType.threshold, ExpressionQueryType.classic];
+
+  if (!condition) {
+    return thresholds;
+  }
 
   for (const query of queries) {
     if (!isExpressionQuery(query.model)) {
@@ -159,6 +163,10 @@ export function getThresholdsForQueries(queries: AlertQuery[]) {
     }
 
     if (!Array.isArray(query.model.conditions)) {
+      continue;
+    }
+
+    if (query.model.refId !== condition) {
       continue;
     }
 


### PR DESCRIPTION
**What is this feature?**
This PR fixes a rare scenario where an alert rule has multiple Threshold or Classic condition expressions defined. 
Previously the graph rendered thresholds for all defined expressions. 
After the change only the expression marked as the alert condition will be displayed on the graph.

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
