### PR TITLE
Annotations: Prevent creating a new range in unsaved dashboards

### DIFF
--- a/public/app/plugins/panel/candlestick/CandlestickPanel.tsx
+++ b/public/app/plugins/panel/candlestick/CandlestickPanel.tsx
@@ -274,7 +274,7 @@ export const CandlestickPanel = ({
                     return null;
                   }
 
-                  if (timeRange2 != null) {
+                  if (enableAnnotationCreation && timeRange2 != null) {
                     setNewAnnotationRange(timeRange2);
                     dismiss();
                     return;
@@ -320,7 +320,7 @@ export const CandlestickPanel = ({
                 annotations={data.annotations ?? []}
                 config={uplotConfig}
                 timeZone={timeZone}
-                newRange={enableAnnotationCreation ? newAnnotationRange : null}
+                newRange={newAnnotationRange}
                 setNewRange={setNewAnnotationRange}
               />
             ) : (

--- a/public/app/plugins/panel/heatmap/HeatmapPanel.tsx
+++ b/public/app/plugins/panel/heatmap/HeatmapPanel.tsx
@@ -248,7 +248,7 @@ export const HeatmapPanel = ({
                         return null;
                       }
 
-                      if (timeRange2 != null) {
+                      if (enableAnnotationCreation && timeRange2 != null) {
                         setNewAnnotationRange(timeRange2);
                         dismiss();
                         return;
@@ -286,7 +286,7 @@ export const HeatmapPanel = ({
                   annotations={data.annotations ?? []}
                   config={builder}
                   timeZone={timeZone}
-                  newRange={enableAnnotationCreation ? newAnnotationRange : null}
+                  newRange={newAnnotationRange}
                   setNewRange={setNewAnnotationRange}
                   canvasRegionRendering={false}
                 />

--- a/public/app/plugins/panel/state-timeline/StateTimelinePanel.tsx
+++ b/public/app/plugins/panel/state-timeline/StateTimelinePanel.tsx
@@ -212,7 +212,7 @@ export const StateTimelinePanel = ({
                         return null;
                       }
 
-                      if (timeRange2 != null) {
+                      if (enableAnnotationCreation && timeRange2 != null) {
                         setNewAnnotationRange(timeRange2);
                         dismiss();
                         return;
@@ -249,7 +249,7 @@ export const StateTimelinePanel = ({
                   annotations={data.annotations ?? []}
                   config={builder}
                   timeZone={timeZone}
-                  newRange={enableAnnotationCreation ? newAnnotationRange : null}
+                  newRange={newAnnotationRange}
                   setNewRange={setNewAnnotationRange}
                   canvasRegionRendering={false}
                 />

--- a/public/app/plugins/panel/status-history/StatusHistoryPanel.tsx
+++ b/public/app/plugins/panel/status-history/StatusHistoryPanel.tsx
@@ -240,7 +240,7 @@ export const StatusHistoryPanel = ({
                         return null;
                       }
 
-                      if (timeRange2 != null) {
+                      if (enableAnnotationCreation && timeRange2 != null) {
                         setNewAnnotationRange(timeRange2);
                         dismiss();
                         return;
@@ -275,7 +275,7 @@ export const StatusHistoryPanel = ({
                   annotations={data.annotations ?? []}
                   config={builder}
                   timeZone={timeZone}
-                  newRange={enableAnnotationCreation ? newAnnotationRange : null}
+                  newRange={newAnnotationRange}
                   setNewRange={setNewAnnotationRange}
                   canvasRegionRendering={false}
                 />

--- a/public/app/plugins/panel/timeseries/TimeSeriesPanel.tsx
+++ b/public/app/plugins/panel/timeseries/TimeSeriesPanel.tsx
@@ -118,7 +118,7 @@ export const TimeSeriesPanel = ({
                         return null;
                       }
 
-                      if (timeRange2 != null) {
+                      if (enableAnnotationCreation && timeRange2 != null) {
                         setNewAnnotationRange(timeRange2);
                         dismiss();
                         return;
@@ -170,7 +170,7 @@ export const TimeSeriesPanel = ({
                 annotations={data.annotations ?? []}
                 config={uplotConfig}
                 timeZone={timeZone}
-                newRange={enableAnnotationCreation ? newAnnotationRange : null}
+                newRange={newAnnotationRange}
                 setNewRange={setNewAnnotationRange}
               />
             ) : (


### PR DESCRIPTION
Prevents creating a new range vs conditionally passing it.
Reverts https://github.com/grafana/grafana/pull/81200



Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
