### PR TITLE
Tempo: Remove type assertion

### DIFF
--- a/.betterer.results
+++ b/.betterer.results
@@ -5715,9 +5715,6 @@ exports[`better eslint`] = {
       [0, 0, 0, "Do not use any type assertions.", "0"],
       [0, 0, 0, "Do not use any type assertions.", "1"]
     ],
-    "public/app/plugins/datasource/tempo/configuration/TraceQLSearchSettings.tsx:5381": [
-      [0, 0, 0, "Do not use any type assertions.", "0"]
-    ],
     "public/app/plugins/datasource/tempo/datasource.test.ts:5381": [
       [0, 0, 0, "Unexpected any. Specify a different type.", "0"],
       [0, 0, 0, "Unexpected any. Specify a different type.", "1"],

--- a/public/app/plugins/datasource/tempo/SearchTraceQLEditor/SearchField.tsx
+++ b/public/app/plugins/datasource/tempo/SearchTraceQLEditor/SearchField.tsx
@@ -3,7 +3,7 @@ import { uniq } from 'lodash';
 import React, { useState, useEffect, useMemo } from 'react';
 import useAsync from 'react-use/lib/useAsync';
 
-import { SelectableValue } from '@grafana/data';
+import { DataSourceApi, SelectableValue } from '@grafana/data';
 import { AccessoryButton } from '@grafana/experimental';
 import { FetchError, getTemplateSrv, isFetchError } from '@grafana/runtime';
 import { Select, HorizontalGroup, useStyles2 } from '@grafana/ui';
@@ -12,7 +12,6 @@ import { notifyApp } from '../_importedDependencies/actions/appNotification';
 import { createErrorNotification } from '../_importedDependencies/core/appNotification';
 import { dispatch } from '../_importedDependencies/store';
 import { TraceqlFilter, TraceqlSearchScope } from '../dataquery.gen';
-import { TempoDatasource } from '../datasource';
 import { operators as allOperators, stringOperators, numberOperators, keywordOperators } from '../traceql/traceql';
 
 import { filterScopedTag, operatorSelectableValue } from './utils';
@@ -25,7 +24,7 @@ const getStyles = () => ({
 
 interface Props {
   filter: TraceqlFilter;
-  datasource: TempoDatasource;
+  datasource: DataSourceApi;
   updateFilter: (f: TraceqlFilter) => void;
   deleteFilter?: (f: TraceqlFilter) => void;
   setError: (error: FetchError) => void;
@@ -81,7 +80,12 @@ const SearchField = ({
   ]);
 
   // Add selected option if it doesn't exist in the current list of options
-  if (filter.value && !Array.isArray(filter.value) && options && !options.find((o) => o.value === filter.value)) {
+  if (
+    filter.value &&
+    !Array.isArray(filter.value) &&
+    options &&
+    !options.find((o: { value: string | string[] | undefined }) => o.value === filter.value)
+  ) {
     options.push({ label: filter.value.toString(), value: filter.value.toString(), type: filter.valueType });
   }
 
@@ -109,7 +113,7 @@ const SearchField = ({
     .map((t) => ({ label: t, value: t }));
 
   // If all values have type string or int/float use a focused list of operators instead of all operators
-  const optionsOfFirstType = options?.filter((o) => o.type === options[0]?.type);
+  const optionsOfFirstType = options?.filter((o: SelectableValue) => o.type === options[0]?.type);
   const uniqueOptionType = options?.length === optionsOfFirstType?.length ? options?.[0]?.type : undefined;
   let operatorList = allOperators;
   switch (uniqueOptionType) {

--- a/public/app/plugins/datasource/tempo/SearchTraceQLEditor/TagsInput.tsx
+++ b/public/app/plugins/datasource/tempo/SearchTraceQLEditor/TagsInput.tsx
@@ -2,12 +2,12 @@ import { css } from '@emotion/css';
 import React, { useCallback, useEffect } from 'react';
 import { v4 as uuidv4 } from 'uuid';
 
+import { DataSourceApi } from '@grafana/data';
 import { AccessoryButton } from '@grafana/experimental';
 import { FetchError } from '@grafana/runtime';
 import { useStyles2 } from '@grafana/ui';
 
 import { TraceqlFilter, TraceqlSearchScope } from '../dataquery.gen';
-import { TempoDatasource } from '../datasource';
 
 import SearchField from './SearchField';
 import { getFilteredTags } from './utils';
@@ -29,7 +29,7 @@ interface Props {
   updateFilter: (f: TraceqlFilter) => void;
   deleteFilter: (f: TraceqlFilter) => void;
   filters: TraceqlFilter[];
-  datasource: TempoDatasource;
+  datasource: DataSourceApi;
   setError: (error: FetchError) => void;
   staticTags: Array<string | undefined>;
   isTagsLoading: boolean;

--- a/public/app/plugins/datasource/tempo/configuration/TraceQLSearchSettings.tsx
+++ b/public/app/plugins/datasource/tempo/configuration/TraceQLSearchSettings.tsx
@@ -5,7 +5,6 @@ import { DataSourcePluginOptionsEditorProps, updateDatasourcePluginJsonDataOptio
 import { getDataSourceSrv } from '@grafana/runtime';
 import { InlineField, InlineFieldRow, InlineSwitch, useStyles2 } from '@grafana/ui';
 
-import { TempoDatasource } from '../datasource';
 import { TempoJsonData } from '../types';
 
 import { getStyles } from './QuerySettings';
@@ -17,7 +16,7 @@ export function TraceQLSearchSettings({ options, onOptionsChange }: Props) {
   const styles = useStyles2(getStyles);
   const dataSourceSrv = getDataSourceSrv();
   const fetchDatasource = async () => {
-    return (await dataSourceSrv.get({ type: options.type, uid: options.uid })) as TempoDatasource;
+    return await dataSourceSrv.get({ type: options.type, uid: options.uid });
   };
 
   const { value: datasource } = useAsync(fetchDatasource, [dataSourceSrv, options]);

--- a/public/app/plugins/datasource/tempo/configuration/TraceQLSearchTags.tsx
+++ b/public/app/plugins/datasource/tempo/configuration/TraceQLSearchTags.tsx
@@ -1,18 +1,17 @@
 import React, { useCallback, useEffect } from 'react';
 import useAsync from 'react-use/lib/useAsync';
 
-import { DataSourcePluginOptionsEditorProps, updateDatasourcePluginJsonDataOption } from '@grafana/data';
+import { DataSourceApi, DataSourcePluginOptionsEditorProps, updateDatasourcePluginJsonDataOption } from '@grafana/data';
 import { Alert } from '@grafana/ui';
 
 import TagsInput from '../SearchTraceQLEditor/TagsInput';
 import { replaceAt } from '../SearchTraceQLEditor/utils';
 import { TraceqlFilter, TraceqlSearchScope } from '../dataquery.gen';
-import { TempoDatasource } from '../datasource';
 import { TempoJsonData } from '../types';
 import { getErrorMessage } from '../utils';
 
 interface Props extends DataSourcePluginOptionsEditorProps<TempoJsonData> {
-  datasource?: TempoDatasource;
+  datasource?: DataSourceApi;
 }
 
 export function TraceQLSearchTags({ options, onOptionsChange, datasource }: Props) {


### PR DESCRIPTION
Remove the `as TempoDatasource` type assertion in `TraceQLSearchSettings.tsx` and replace the `TempoDatasource` type with the correct one wherever necessary. These changes don't cause to any other type error so far, meaning that the type assertion seems to be useless at the moment, so I propose to do them.