### PR TITLE
postgres: refactor code that is called by tests

### DIFF
--- a/pkg/tsdb/grafana-postgresql-datasource/postgres.go
+++ b/pkg/tsdb/grafana-postgresql-datasource/postgres.go
@@ -58,10 +58,6 @@ func (s *Service) QueryData(ctx context.Context, req *backend.QueryDataRequest) 
 }
 
 func newPostgres(cfg *setting.Cfg, dsInfo sqleng.DataSourceInfo, cnnstr string, logger log.Logger) (*sql.DB, *sqleng.DataSourceHandler, error) {
-	if cfg.Env == setting.Dev {
-		logger.Debug("GetEngine", "connection", cnnstr)
-	}
-
 	connector, err := pq.NewConnector(cnnstr)
 	if err != nil {
 		logger.Error("postgres connector creation failed", "error", err)

--- a/pkg/tsdb/grafana-postgresql-datasource/postgres.go
+++ b/pkg/tsdb/grafana-postgresql-datasource/postgres.go
@@ -57,6 +57,54 @@ func (s *Service) QueryData(ctx context.Context, req *backend.QueryDataRequest) 
 	return dsInfo.QueryData(ctx, req)
 }
 
+func newPostgres(cfg *setting.Cfg, dsInfo sqleng.DataSourceInfo, cnnstr string, logger log.Logger) (*sql.DB, *sqleng.DataSourceHandler, error) {
+	if cfg.Env == setting.Dev {
+		logger.Debug("GetEngine", "connection", cnnstr)
+	}
+
+	connector, err := pq.NewConnector(cnnstr)
+	if err != nil {
+		logger.Error("postgres connector creation failed", "error", err)
+		return nil, nil, fmt.Errorf("postgres connector creation failed")
+	}
+
+	// use the proxy-dialer if the secure socks proxy is enabled
+	proxyOpts := proxyutil.GetSQLProxyOptions(cfg.SecureSocksDSProxy, dsInfo)
+	if sdkproxy.New(proxyOpts).SecureSocksProxyEnabled() {
+		dialer, err := newPostgresProxyDialer(proxyOpts)
+		if err != nil {
+			logger.Error("postgres proxy creation failed", "error", err)
+			return nil, nil, fmt.Errorf("postgres proxy creation failed")
+		}
+		// update the postgres dialer with the proxy dialer
+		connector.Dialer(dialer)
+	}
+
+	config := sqleng.DataPluginConfiguration{
+		DSInfo:            dsInfo,
+		MetricColumnTypes: []string{"UNKNOWN", "TEXT", "VARCHAR", "CHAR"},
+		RowLimit:          cfg.DataProxyRowLimit,
+	}
+
+	queryResultTransformer := postgresQueryResultTransformer{}
+
+	db := sql.OpenDB(connector)
+
+	db.SetMaxOpenConns(config.DSInfo.JsonData.MaxOpenConns)
+	db.SetMaxIdleConns(config.DSInfo.JsonData.MaxIdleConns)
+	db.SetConnMaxLifetime(time.Duration(config.DSInfo.JsonData.ConnMaxLifetime) * time.Second)
+
+	handler, err := sqleng.NewQueryDataHandler(cfg, db, config, &queryResultTransformer, newPostgresMacroEngine(dsInfo.JsonData.Timescaledb),
+		logger)
+	if err != nil {
+		logger.Error("Failed connecting to Postgres", "err", err)
+		return nil, nil, err
+	}
+
+	logger.Debug("Successfully connected to Postgres")
+	return db, handler, nil
+}
+
 func (s *Service) newInstanceSettings(cfg *setting.Cfg) datasource.InstanceFactoryFunc {
 	logger := s.logger
 	return func(_ context.Context, settings backend.DataSourceInstanceSettings) (instancemgmt.Instance, error) {
@@ -96,44 +144,8 @@ func (s *Service) newInstanceSettings(cfg *setting.Cfg) datasource.InstanceFacto
 			return nil, err
 		}
 
-		if cfg.Env == setting.Dev {
-			logger.Debug("GetEngine", "connection", cnnstr)
-		}
+		_, handler, err := newPostgres(cfg, dsInfo, cnnstr, logger)
 
-		connector, err := pq.NewConnector(cnnstr)
-		if err != nil {
-			logger.Error("postgres connector creation failed", "error", err)
-			return nil, fmt.Errorf("postgres connector creation failed")
-		}
-
-		// use the proxy-dialer if the secure socks proxy is enabled
-		proxyOpts := proxyutil.GetSQLProxyOptions(cfg.SecureSocksDSProxy, dsInfo)
-		if sdkproxy.New(proxyOpts).SecureSocksProxyEnabled() {
-			dialer, err := newPostgresProxyDialer(proxyOpts)
-			if err != nil {
-				logger.Error("postgres proxy creation failed", "error", err)
-				return nil, fmt.Errorf("postgres proxy creation failed")
-			}
-			// update the postgres dialer with the proxy dialer
-			connector.Dialer(dialer)
-		}
-
-		config := sqleng.DataPluginConfiguration{
-			DSInfo:            dsInfo,
-			MetricColumnTypes: []string{"UNKNOWN", "TEXT", "VARCHAR", "CHAR"},
-			RowLimit:          cfg.DataProxyRowLimit,
-		}
-
-		queryResultTransformer := postgresQueryResultTransformer{}
-
-		db := sql.OpenDB(connector)
-
-		db.SetMaxOpenConns(config.DSInfo.JsonData.MaxOpenConns)
-		db.SetMaxIdleConns(config.DSInfo.JsonData.MaxIdleConns)
-		db.SetConnMaxLifetime(time.Duration(config.DSInfo.JsonData.ConnMaxLifetime) * time.Second)
-
-		handler, err := sqleng.NewQueryDataHandler(cfg, db, config, &queryResultTransformer, newPostgresMacroEngine(dsInfo.JsonData.Timescaledb),
-			logger)
 		if err != nil {
 			logger.Error("Failed connecting to Postgres", "err", err)
 			return nil, err


### PR DESCRIPTION
in our postgres-tests, we repeat a lot of the postgres config.
for example, in the real postgres code, `postgres.go` : 
https://github.com/grafana/grafana/blob/5195e5347e01f57feaf42636ebe8bcf01d595139/pkg/tsdb/grafana-postgresql-datasource/postgres.go#L123

and then in tests:
we define it again in `postgres_test.go`, twice:
https://github.com/grafana/grafana/blob/5195e5347e01f57feaf42636ebe8bcf01d595139/pkg/tsdb/grafana-postgresql-datasource/postgres_test.go#L213
https://github.com/grafana/grafana/blob/5195e5347e01f57feaf42636ebe8bcf01d595139/pkg/tsdb/grafana-postgresql-datasource/postgres_test.go#L1280
and in` postgres_snapshot_test.go` again:
https://github.com/grafana/grafana/blob/5195e5347e01f57feaf42636ebe8bcf01d595139/pkg/tsdb/grafana-postgresql-datasource/postgres_snapshot_test.go#L176

this is not nice, because, for example, imagine in the real `postgres.go` we adjust this value for some reason. our unit-tests will not catch this, because they define it again.

for this reason i refactored the code a bit, in `postgres.go` i created a new function `newPostgres`, that wraps these configs, and then the tests just call `newPostgres`. (it's not the absolutely best solution, but i think it does improve the current situation, and larger improvements would need larger changes 😿 )


how to test:
1. do a basic check if the postgres datasource still works
2. if the CI-job finishes successfully, all is good 👍 