### PR TITLE
Docs: fix broken link

### DIFF
--- a/docs/sources/whatsnew/whats-new-in-v10-2.md
+++ b/docs/sources/whatsnew/whats-new-in-v10-2.md
@@ -100,7 +100,7 @@ You can now use generative AI to assist you in your Grafana dashboards. So far g
 - **Generate panel and dashboard titles and descriptions** - You can now generate a title and description for your panel or dashboard based on the data you've added to it. This is useful when you want to quickly visualize your data and don't want to spend time coming up with a title or description.
 - **Generate dashboard save changes summary** - You can now generate a summary of the changes you've made to a dashboard when you save it. This is great for effortlessly tracking the history of a dashboard.
 
-To enable these features, you must first enable the `dashgpt` [feature toggle](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/setup-grafana/configure-grafana/feature-toggles/#experimental-feature-toggles). Then install and configure Grafana's LLM app plugin. For more information, refer to the [Grafana LLM app plugin documentation](https://grafana.com/docs/grafana-cloud/alerting-and-irm/machine-learning/llm-plugin/).
+To enable these features, you must first enable the `dashgpt` [feature toggle](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/setup-grafana/configure-grafana/feature-toggles/#experimental-feature-toggles). Then install and configure Grafana's LLM app plugin. For more information, refer to the [Grafana LLM app plugin documentation](https://grafana.com/docs/grafana-cloud/alerting-and-irm/machine-learning/configure/llm-plugin/).
 
 When enabled, look for the **✨ Auto generate** option next to the **Title** and **Description** fields in your panels and dashboards, or when you press the **Save** button.
 


### PR DESCRIPTION
Fix broken link to page that was moved.

Error report: January 18, 2024
Error source page: `/docs/grafana/latest/whatsnew/whats-new-in-v10-2/`
Latest was v10.2 on January 18th, therefore, backporting to v10.2 and v10.3
