### PR TITLE
CloudWatch: remove imports from logtest

### DIFF
--- a/pkg/tsdb/cloudwatch/get_dimension_values_for_wildcards_test.go
+++ b/pkg/tsdb/cloudwatch/get_dimension_values_for_wildcards_test.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/aws/aws-sdk-go/service/cloudwatch"
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
-	"github.com/grafana/grafana/pkg/infra/log/logtest"
+	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/tsdb/cloudwatch/mocks"
 	"github.com/grafana/grafana/pkg/tsdb/cloudwatch/models"
 	"github.com/grafana/grafana/pkg/tsdb/cloudwatch/utils"
@@ -16,7 +16,7 @@ import (
 )
 
 func TestGetDimensionValuesForWildcards(t *testing.T) {
-	logger := &logtest.Fake{}
+	testLogger := log.NewNopLogger()
 	executor := &cloudWatchExecutor{}
 	ctx := context.Background()
 	pluginCtx := backend.PluginContext{
@@ -28,7 +28,7 @@ func TestGetDimensionValuesForWildcards(t *testing.T) {
 		query := getBaseQuery()
 		query.MetricName = "Test_MetricName1"
 		query.Dimensions = map[string][]string{"Test_DimensionName1": {"Value1"}}
-		queries, err := executor.getDimensionValuesForWildcards(ctx, pluginCtx, "us-east-1", nil, []*models.CloudWatchQuery{query}, tagValueCache, logger)
+		queries, err := executor.getDimensionValuesForWildcards(ctx, pluginCtx, "us-east-1", nil, []*models.CloudWatchQuery{query}, tagValueCache, testLogger)
 		assert.Nil(t, err)
 		assert.Len(t, queries, 1)
 		assert.NotNil(t, queries[0].Dimensions["Test_DimensionName1"], 1)
@@ -39,7 +39,7 @@ func TestGetDimensionValuesForWildcards(t *testing.T) {
 		query := getBaseQuery()
 		query.MetricName = "Test_MetricName1"
 		query.Dimensions = map[string][]string{"Test_DimensionName1": {"*"}}
-		queries, err := executor.getDimensionValuesForWildcards(ctx, pluginCtx, "us-east-1", nil, []*models.CloudWatchQuery{query}, tagValueCache, logger)
+		queries, err := executor.getDimensionValuesForWildcards(ctx, pluginCtx, "us-east-1", nil, []*models.CloudWatchQuery{query}, tagValueCache, testLogger)
 		assert.Nil(t, err)
 		assert.Len(t, queries, 1)
 		assert.NotNil(t, queries[0].Dimensions["Test_DimensionName1"])
@@ -58,7 +58,7 @@ func TestGetDimensionValuesForWildcards(t *testing.T) {
 			{MetricName: utils.Pointer("Test_MetricName4"), Dimensions: []*cloudwatch.Dimension{{Name: utils.Pointer("Test_DimensionName1"), Value: utils.Pointer("Value2")}}},
 		}}
 		api.On("ListMetricsPagesWithContext").Return(nil)
-		queries, err := executor.getDimensionValuesForWildcards(ctx, pluginCtx, "us-east-1", api, []*models.CloudWatchQuery{query}, tagValueCache, logger)
+		queries, err := executor.getDimensionValuesForWildcards(ctx, pluginCtx, "us-east-1", api, []*models.CloudWatchQuery{query}, tagValueCache, testLogger)
 		assert.Nil(t, err)
 		assert.Len(t, queries, 1)
 		assert.Equal(t, map[string][]string{"Test_DimensionName1": {"Value1", "Value2", "Value3", "Value4"}}, queries[0].Dimensions)
@@ -74,13 +74,13 @@ func TestGetDimensionValuesForWildcards(t *testing.T) {
 			{MetricName: utils.Pointer("Test_MetricName"), Dimensions: []*cloudwatch.Dimension{{Name: utils.Pointer("Test_DimensionName"), Value: utils.Pointer("Value")}}},
 		}}
 		api.On("ListMetricsPagesWithContext").Return(nil)
-		_, err := executor.getDimensionValuesForWildcards(ctx, pluginCtx, "us-east-1", api, []*models.CloudWatchQuery{query}, tagValueCache, logger)
+		_, err := executor.getDimensionValuesForWildcards(ctx, pluginCtx, "us-east-1", api, []*models.CloudWatchQuery{query}, tagValueCache, testLogger)
 		assert.Nil(t, err)
 		// make sure the original query wasn't altered
 		assert.Equal(t, map[string][]string{"Test_DimensionName": {"*"}}, query.Dimensions)
 
 		//setting the api to nil confirms that it's using the cached value
-		queries, err := executor.getDimensionValuesForWildcards(ctx, pluginCtx, "us-east-1", nil, []*models.CloudWatchQuery{query}, tagValueCache, logger)
+		queries, err := executor.getDimensionValuesForWildcards(ctx, pluginCtx, "us-east-1", nil, []*models.CloudWatchQuery{query}, tagValueCache, testLogger)
 		assert.Nil(t, err)
 		assert.Len(t, queries, 1)
 		assert.Equal(t, map[string][]string{"Test_DimensionName": {"Value"}}, queries[0].Dimensions)
@@ -94,7 +94,7 @@ func TestGetDimensionValuesForWildcards(t *testing.T) {
 		query.MatchExact = false
 		api := &mocks.MetricsAPI{Metrics: []*cloudwatch.Metric{}}
 		api.On("ListMetricsPagesWithContext").Return(nil)
-		queries, err := executor.getDimensionValuesForWildcards(ctx, pluginCtx, "us-east-1", api, []*models.CloudWatchQuery{query}, tagValueCache, logger)
+		queries, err := executor.getDimensionValuesForWildcards(ctx, pluginCtx, "us-east-1", api, []*models.CloudWatchQuery{query}, tagValueCache, testLogger)
 		assert.Nil(t, err)
 		assert.Len(t, queries, 1)
 		// assert that the values was set to an empty array
@@ -105,7 +105,7 @@ func TestGetDimensionValuesForWildcards(t *testing.T) {
 			{MetricName: utils.Pointer("Test_MetricName"), Dimensions: []*cloudwatch.Dimension{{Name: utils.Pointer("Test_DimensionName2"), Value: utils.Pointer("Value")}}},
 		}
 		api.On("ListMetricsPagesWithContext").Return(nil)
-		queries, err = executor.getDimensionValuesForWildcards(ctx, pluginCtx, "us-east-1", api, []*models.CloudWatchQuery{query}, tagValueCache, logger)
+		queries, err = executor.getDimensionValuesForWildcards(ctx, pluginCtx, "us-east-1", api, []*models.CloudWatchQuery{query}, tagValueCache, testLogger)
 		assert.Nil(t, err)
 		assert.Len(t, queries, 1)
 		assert.Equal(t, map[string][]string{"Test_DimensionName2": {"Value"}}, queries[0].Dimensions)

--- a/pkg/tsdb/cloudwatch/get_metric_query_batches_test.go
+++ b/pkg/tsdb/cloudwatch/get_metric_query_batches_test.go
@@ -3,13 +3,13 @@ package cloudwatch
 import (
 	"testing"
 
-	"github.com/grafana/grafana/pkg/infra/log/logtest"
+	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/tsdb/cloudwatch/models"
 	"github.com/stretchr/testify/assert"
 )
 
 func TestGetMetricQueryBatches(t *testing.T) {
-	logger := &logtest.Fake{}
+	testLogger := log.NewNopLogger()
 	insight1 := models.CloudWatchQuery{
 		MetricQueryType: models.MetricQueryTypeQuery,
 		Id:              "i1",
@@ -86,7 +86,7 @@ func TestGetMetricQueryBatches(t *testing.T) {
 			&m88_ref_m98,
 		}
 
-		result := getMetricQueryBatches(batch, logger)
+		result := getMetricQueryBatches(batch, testLogger)
 		assert.Len(t, result, 3)
 		assert.ElementsMatch(t, []*models.CloudWatchQuery{&insight1}, result[0])
 		assert.ElementsMatch(t, []*models.CloudWatchQuery{&insight2}, result[1])
@@ -102,7 +102,7 @@ func TestGetMetricQueryBatches(t *testing.T) {
 			&m4_ref_s1,
 		}
 
-		result := getMetricQueryBatches(batch, logger)
+		result := getMetricQueryBatches(batch, testLogger)
 		assert.Len(t, result, 1)
 		assert.Equal(t, batch, result[0])
 	})
@@ -113,7 +113,7 @@ func TestGetMetricQueryBatches(t *testing.T) {
 			&metricStat,
 		}
 
-		result := getMetricQueryBatches(batch, logger)
+		result := getMetricQueryBatches(batch, testLogger)
 		assert.Len(t, result, 1)
 		assert.ElementsMatch(t, batch, result[0])
 	})
@@ -125,7 +125,7 @@ func TestGetMetricQueryBatches(t *testing.T) {
 			&insight2,
 		}
 
-		result := getMetricQueryBatches(batch, logger)
+		result := getMetricQueryBatches(batch, testLogger)
 		assert.Len(t, result, 3)
 		assert.ElementsMatch(t, []*models.CloudWatchQuery{&insight1}, result[0])
 		assert.ElementsMatch(t, []*models.CloudWatchQuery{&metricStat}, result[1])
@@ -142,7 +142,7 @@ func TestGetMetricQueryBatches(t *testing.T) {
 			&m4_ref_s1,
 		}
 
-		result := getMetricQueryBatches(batch, logger)
+		result := getMetricQueryBatches(batch, testLogger)
 		assert.Len(t, result, 1)
 		assert.ElementsMatch(t, batch, result[0])
 	})
@@ -157,7 +157,7 @@ func TestGetMetricQueryBatches(t *testing.T) {
 			&m4_ref_s1,
 		}
 
-		result := getMetricQueryBatches(batch, logger)
+		result := getMetricQueryBatches(batch, testLogger)
 		assert.Len(t, result, 3)
 		assert.ElementsMatch(t, []*models.CloudWatchQuery{&insight2}, result[0])
 		assert.ElementsMatch(t, []*models.CloudWatchQuery{&insight1, &m1_ref_i1, &m2_ref_i1, &m3_ref_m1_m2}, result[1])
@@ -172,7 +172,7 @@ func TestGetMetricQueryBatches(t *testing.T) {
 			&m4_ref_i1_i3,
 		}
 
-		result := getMetricQueryBatches(batch, logger)
+		result := getMetricQueryBatches(batch, testLogger)
 		assert.Len(t, result, 3)
 		assert.ElementsMatch(t, []*models.CloudWatchQuery{&insight2}, result[0])
 		assert.ElementsMatch(t, []*models.CloudWatchQuery{&insight1, &m1_ref_i1}, result[1])

--- a/pkg/tsdb/cloudwatch/models/cloudwatch_query_test.go
+++ b/pkg/tsdb/cloudwatch/models/cloudwatch_query_test.go
@@ -10,15 +10,15 @@ import (
 	"github.com/grafana/kindsys"
 
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
+	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/tsdb/cloudwatch/kinds/dataquery"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/grafana/grafana/pkg/infra/log/logtest"
 	"github.com/grafana/grafana/pkg/tsdb/cloudwatch/utils"
 )
 
-var logger = &logtest.Fake{}
+var logger = log.NewNopLogger()
 
 func TestCloudWatchQuery(t *testing.T) {
 	t.Run("Deeplink", func(t *testing.T) {

--- a/pkg/tsdb/cloudwatch/routes/dimension_keys_test.go
+++ b/pkg/tsdb/cloudwatch/routes/dimension_keys_test.go
@@ -9,18 +9,18 @@ import (
 	"testing"
 
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
+	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/tsdb/cloudwatch/models/resources"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 
-	"github.com/grafana/grafana/pkg/infra/log/logtest"
 	"github.com/grafana/grafana/pkg/tsdb/cloudwatch/mocks"
 	"github.com/grafana/grafana/pkg/tsdb/cloudwatch/models"
 	"github.com/grafana/grafana/pkg/tsdb/cloudwatch/services"
 )
 
-var logger = &logtest.Fake{}
+var logger = log.NewNopLogger()
 
 func Test_DimensionKeys_Route(t *testing.T) {
 	t.Run("calls FilterDimensionKeysRequest when a StandardDimensionKeysRequest is passed", func(t *testing.T) {


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

Replace `logtest.Fake{}` in tests with calls to `log.NewNopLogger()`.

**Why do we need this feature?**

We need to remove the dependency on `grafana/pkg/infra/log/logtest` to decouple CloudWatch

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #80900

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
