### PR TITLE
feat: datatrails: include metric prefix filter

### DIFF
--- a/packages/grafana-ui/src/components/Cascader/Cascader.tsx
+++ b/packages/grafana-ui/src/components/Cascader/Cascader.tsx
@@ -93,7 +93,7 @@ export class Cascader extends PureComponent<CascaderProps, CascaderState> {
     for (const option of options) {
       const cpy = [...optionPath];
       cpy.push(option);
-      if (!option.items) {
+      if (!option.items || option.items.length === 0) {
         selectOptions.push({
           singleLabel: cpy[cpy.length - 1].label,
           label: cpy.map((o) => o.label).join(this.props.separator || DEFAULT_SEPARATOR),
@@ -135,23 +135,27 @@ export class Cascader extends PureComponent<CascaderProps, CascaderState> {
       : this.props.displayAllSelectedLevels
         ? selectedOptions.map((option) => option.label).join(this.props.separator || DEFAULT_SEPARATOR)
         : selectedOptions[selectedOptions.length - 1].label;
-    this.setState({
-      rcValue: value,
+    const state: CascaderState = {
+      rcValue: { value, label: activeLabel },
       focusCascade: true,
       activeLabel,
-    });
-
+      isSearching: false,
+    };
+    this.setState(state);
     this.props.onSelect(selectedOptions[selectedOptions.length - 1].value);
   };
 
   //For select
   onSelect = (obj: SelectableValue<string[]>) => {
     const valueArray = obj.value || [];
-    this.setState({
-      activeLabel: this.props.displayAllSelectedLevels ? obj.label : obj.singleLabel || '',
-      rcValue: valueArray,
+    const activeLabel = this.props.displayAllSelectedLevels ? obj.label : obj.singleLabel || '';
+    const state: CascaderState = {
+      activeLabel: activeLabel,
+      rcValue: { value: valueArray, label: activeLabel },
       isSearching: false,
-    });
+      focusCascade: false,
+    };
+    this.setState(state);
     this.props.onSelect(valueArray[valueArray.length - 1]);
   };
 

--- a/public/app/features/trails/MetricCategory/MetricCategoryCascader.tsx
+++ b/public/app/features/trails/MetricCategory/MetricCategoryCascader.tsx
@@ -1,0 +1,80 @@
+import React, { useMemo, useReducer, useState } from 'react';
+
+import { Cascader, CascaderOption, HorizontalGroup, Button } from '@grafana/ui';
+
+import { useMetricCategories } from './useMetricCategories';
+
+type Props = {
+  metricNames: string[];
+  onSelect: (prefix: string | undefined) => void;
+  disabled?: boolean;
+  initialValue?: string;
+};
+
+export function MetricCategoryCascader({ metricNames, onSelect, disabled, initialValue }: Props) {
+  const categoryTree = useMetricCategories(metricNames);
+  const options = useMemo(() => createCasaderOptions(categoryTree), [categoryTree]);
+
+  const [disableClear, setDisableClear] = useState(initialValue == null);
+
+  // Increments whenever clear is pressed, to reset the Cascader component
+  const [cascaderKey, resetCascader] = useReducer((x) => x + 1, 0);
+
+  const clear = () => {
+    resetCascader();
+    setDisableClear(true);
+    onSelect(undefined);
+  };
+
+  return (
+    <HorizontalGroup>
+      <Cascader
+        key={cascaderKey} // To reset the component to `undefined`
+        displayAllSelectedLevels={true}
+        width={40}
+        separator="_"
+        hideActiveLevelLabel={false}
+        placeholder={'No filter'}
+        allowCustomValue={true} // Allow the user to enter their own prefix
+        onSelect={(prefix) => {
+          setDisableClear(!prefix);
+          onSelect(prefix);
+        }}
+        {...{ options, disabled, initialValue }}
+      />
+      <Button disabled={disableClear} onClick={clear} variant="secondary">
+        Clear
+      </Button>
+    </HorizontalGroup>
+  );
+}
+
+function createCasaderOptions(tree: ReturnType<typeof useMetricCategories>, currentPrefix = '') {
+  const categories = Object.entries(tree.children);
+
+  const options = categories.map(([metricPart, node]) => {
+    let subcategoryEntries = Object.entries(node.children);
+
+    while (subcategoryEntries.length === 1 && !node.isMetric) {
+      // There is only one subcategory, so we will join it with the current metricPart to reduce depth
+      const [subMetricPart, subNode] = subcategoryEntries[0];
+      metricPart = `${metricPart}_${subMetricPart}`;
+      // Extend the metric part name, because there is only one subcategory
+      node = subNode;
+      subcategoryEntries = Object.entries(node.children);
+    }
+
+    const value = currentPrefix + metricPart;
+    const subOptions = createCasaderOptions(node, value + '_');
+
+    const option: CascaderOption = {
+      value: value,
+      label: metricPart,
+      items: subOptions,
+    };
+
+    return option;
+  });
+
+  return options;
+}

--- a/public/app/features/trails/MetricCategory/MetricCategoryCascader.tsx
+++ b/public/app/features/trails/MetricCategory/MetricCategoryCascader.tsx
@@ -35,7 +35,6 @@ export function MetricCategoryCascader({ metricNames, onSelect, disabled, initia
         separator="_"
         hideActiveLevelLabel={false}
         placeholder={'No filter'}
-        allowCustomValue={true} // Allow the user to enter their own prefix
         onSelect={(prefix) => {
           setDisableClear(!prefix);
           onSelect(prefix);

--- a/public/app/features/trails/MetricCategory/useMetricCategories.ts
+++ b/public/app/features/trails/MetricCategory/useMetricCategories.ts
@@ -1,0 +1,43 @@
+import { useMemo } from 'react';
+
+export function useMetricCategories(metrics: string[]) {
+  return useMemo(() => processMetrics(metrics), [metrics]);
+}
+
+interface MetricPartNode {
+  isMetric?: boolean;
+  children: Record<string, MetricPartNode>;
+}
+
+function processMetrics(metrics: string[]) {
+  const categoryTree: MetricPartNode = { children: {} };
+
+  function insertMetric(metric: string) {
+    if (metric.indexOf(':') !== -1) {
+      // Ignore recording rules.
+      return;
+    }
+
+    const metricParts = metric.split('_');
+
+    let cursor = categoryTree;
+    for (const metricPart of metricParts) {
+      let node = cursor.children[metricPart];
+      if (!node) {
+        // Create new node
+        node = {
+          children: {},
+        };
+        // Insert it
+        cursor.children[metricPart] = node;
+      }
+      cursor = node;
+    }
+    // We know this node is a metric because it was for the last metricPart
+    cursor.isMetric = true;
+  }
+
+  metrics.forEach((metric) => insertMetric(metric));
+
+  return categoryTree;
+}

--- a/public/app/features/trails/MetricSelectScene.tsx
+++ b/public/app/features/trails/MetricSelectScene.tsx
@@ -17,12 +17,12 @@ import {
   SceneCSSGridItem,
   SceneObjectRef,
   SceneQueryRunner,
-  VariableValueOption,
 } from '@grafana/scenes';
 import { VariableHide } from '@grafana/schema';
-import { Input, Text, useStyles2, InlineSwitch } from '@grafana/ui';
+import { Input, Text, useStyles2, InlineSwitch, Field, LoadingPlaceholder } from '@grafana/ui';
 
 import { getAutoQueriesForMetric } from './AutomaticMetricQueries/AutoQueryEngine';
+import { MetricCategoryCascader } from './MetricCategory/MetricCategoryCascader';
 import { SelectMetricAction } from './SelectMetricAction';
 import { hideEmptyPreviews } from './hideEmptyPreviews';
 import { getVariablesWithMetricConstant, trailDS, VAR_FILTERS_EXPR, VAR_METRIC_NAMES } from './shared';
@@ -42,6 +42,9 @@ export interface MetricSelectSceneState extends SceneObjectState {
   showHeading?: boolean;
   searchQuery?: string;
   showPreviews?: boolean;
+  prefixFilter?: string;
+  metricsAfterSearch?: string[];
+  metricsAfterFilter?: string[];
 }
 
 const ROW_PREVIEW_HEIGHT = '175px';
@@ -75,7 +78,7 @@ export class MetricSelectScene extends SceneObjectBase<MetricSelectSceneState> {
   });
 
   private onVariableUpdateCompleted(): void {
-    this.updateMetrics();
+    this.updateMetrics(); // Entire pipeline must be performed
     this.buildLayout();
   }
 
@@ -103,33 +106,71 @@ export class MetricSelectScene extends SceneObjectBase<MetricSelectSceneState> {
     });
   }
 
-  private updateMetrics() {
-    const trail = getTrailFor(this);
+  private getAllMetricNames() {
+    // Get the datasource metrics list from the VAR_METRIC_NAMES variable
     const variable = sceneGraph.lookupVariable(VAR_METRIC_NAMES, this);
 
     if (!(variable instanceof QueryVariable)) {
-      return;
+      return null;
     }
 
     if (variable.state.loading) {
+      return null;
+    }
+
+    const metricNames = variable.state.options.map((option) => option.value.toString());
+    return metricNames;
+  }
+
+  private applyMetricSearch() {
+    // This should only occur when the `searchQuery` changes, of if the `metricNames` change
+    const metricNames = this.getAllMetricNames();
+    if (metricNames == null) {
+      return;
+    }
+    const searchRegex = createSearchRegExp(this.state.searchQuery);
+
+    if (!searchRegex) {
+      this.setState({ metricsAfterSearch: metricNames });
+    } else {
+      const metricsAfterSearch = metricNames.filter((metric) => !searchRegex || searchRegex.test(metric));
+      this.setState({ metricsAfterSearch });
+    }
+  }
+
+  private applyMetricPrefixFilter() {
+    const { metricsAfterSearch, prefixFilter } = this.state;
+
+    if (!prefixFilter || !metricsAfterSearch) {
+      this.setState({ metricsAfterFilter: metricsAfterSearch });
+    } else {
+      const metricsAfterFilter = metricsAfterSearch.filter((metric) => metric.startsWith(prefixFilter));
+      this.setState({ metricsAfterFilter });
+    }
+  }
+
+  private updateMetrics(applySearchAndFilter = true) {
+    if (applySearchAndFilter) {
+      // Set to false if these are not required (because they can be assumed to have been suitably called).
+      this.applyMetricSearch();
+      this.applyMetricPrefixFilter();
+    }
+
+    const { metricsAfterFilter } = this.state;
+
+    if (!metricsAfterFilter) {
       return;
     }
 
-    const searchRegex = createSearchRegExp(this.state.searchQuery);
-    const metricNames = variable.state.options;
+    const metricNames = metricsAfterFilter;
+    const trail = getTrailFor(this);
     const sortedMetricNames =
       trail.state.metric !== undefined ? sortRelatedMetrics(metricNames, trail.state.metric) : metricNames;
     const metricsMap: Record<string, MetricPanel> = {};
     const metricsLimit = 120;
 
     for (let index = 0; index < sortedMetricNames.length; index++) {
-      const metric = sortedMetricNames[index];
-
-      const metricName = String(metric.value);
-
-      if (searchRegex && !searchRegex.test(metricName)) {
-        continue;
-      }
+      const metricName = sortedMetricNames[index];
 
       if (Object.keys(metricsMap).length > metricsLimit) {
         break;
@@ -207,7 +248,14 @@ export class MetricSelectScene extends SceneObjectBase<MetricSelectSceneState> {
 
   public onSearchChange = (evt: React.SyntheticEvent<HTMLInputElement>) => {
     this.setState({ searchQuery: evt.currentTarget.value });
-    this.updateMetrics();
+    this.updateMetrics(); // Need to repeat entire pipeline
+    this.buildLayout();
+  };
+
+  public onPrefixFilterChange = (prefixFilter: string | undefined) => {
+    this.setState({ prefixFilter });
+    this.applyMetricPrefixFilter();
+    this.updateMetrics(false); // Only needed to applyMetricPrefixFilter
     this.buildLayout();
   };
 
@@ -217,13 +265,25 @@ export class MetricSelectScene extends SceneObjectBase<MetricSelectSceneState> {
   };
 
   public static Component = ({ model }: SceneComponentProps<MetricSelectScene>) => {
-    const { showHeading, searchQuery, showPreviews, body } = model.useState();
+    const { showHeading, searchQuery, showPreviews, body, metricsAfterSearch, metricsAfterFilter, prefixFilter } =
+      model.useState();
     const { children } = body.useState();
     const styles = useStyles2(getStyles);
 
-    const searchTooStrictWarning = children.length === 0 && searchQuery && (
-      <div className={styles.alternateMessage}>There are no results found. Try adjusting your search or filters.</div>
-    );
+    const notLoaded = metricsAfterSearch === undefined && metricsAfterFilter === undefined && children.length === 0;
+
+    const tooStrict = children.length === 0 && (searchQuery || prefixFilter);
+
+    let status =
+      (notLoaded && <LoadingPlaceholder className={styles.statusMessage} text="Loading..." />) ||
+      (tooStrict && 'There are no results found. Try adjusting your search or filters.');
+
+    const showStatus = status && <div className={styles.statusMessage}>{status}</div>;
+
+    const prefixError =
+      prefixFilter && metricsAfterSearch != null && !metricsAfterFilter?.length
+        ? 'The current prefix filter is not available with the current search terms.'
+        : undefined;
 
     return (
       <div className={styles.container}>
@@ -236,7 +296,17 @@ export class MetricSelectScene extends SceneObjectBase<MetricSelectSceneState> {
           <Input placeholder="Search metrics" value={searchQuery} onChange={model.onSearchChange} />
           <InlineSwitch showLabel={true} label="Show previews" value={showPreviews} onChange={model.onTogglePreviews} />
         </div>
-        {searchTooStrictWarning}
+        <div className={styles.header}>
+          <Field label="Filter by prefix" error={prefixError} invalid={true}>
+            <MetricCategoryCascader
+              metricNames={metricsAfterSearch || []}
+              onSelect={model.onPrefixFilterChange}
+              disabled={metricsAfterSearch == null}
+              initialValue={prefixFilter}
+            />
+          </Field>
+        </div>
+        {showStatus}
         <model.state.body.Component model={model.state.body} />
       </div>
     );
@@ -291,13 +361,11 @@ function getCardPanelFor(metric: string) {
 }
 
 // Computes the Levenshtein distance between two strings, twice, once for the first half and once for the whole string.
-function sortRelatedMetrics(metricList: VariableValueOption[], metric: string) {
-  return metricList.sort((a, b) => {
-    const aValue = String(a.value);
+function sortRelatedMetrics(metricList: string[], metric: string) {
+  return metricList.sort((aValue, bValue) => {
     const aSplit = aValue.split('_');
     const aHalf = aSplit.slice(0, aSplit.length / 2).join('_');
 
-    const bValue = String(b.value);
     const bSplit = bValue.split('_');
     const bHalf = bSplit.slice(0, bSplit.length / 2).join('_');
 
@@ -324,7 +392,7 @@ function getStyles(theme: GrafanaTheme2) {
       gap: theme.spacing(2),
       marginBottom: theme.spacing(1),
     }),
-    alternateMessage: css({
+    statusMessage: css({
       fontStyle: 'italic',
       marginTop: theme.spacing(7),
       textAlign: 'center',

--- a/public/app/features/trails/MetricSelectScene.tsx
+++ b/public/app/features/trails/MetricSelectScene.tsx
@@ -23,6 +23,7 @@ import { Input, Text, useStyles2, InlineSwitch, Field, LoadingPlaceholder } from
 
 import { getAutoQueriesForMetric } from './AutomaticMetricQueries/AutoQueryEngine';
 import { MetricCategoryCascader } from './MetricCategory/MetricCategoryCascader';
+import { MetricScene } from './MetricScene';
 import { SelectMetricAction } from './SelectMetricAction';
 import { hideEmptyPreviews } from './hideEmptyPreviews';
 import { getVariablesWithMetricConstant, trailDS, VAR_FILTERS_EXPR, VAR_METRIC_NAMES } from './shared';
@@ -177,6 +178,14 @@ export class MetricSelectScene extends SceneObjectBase<MetricSelectSceneState> {
       }
 
       metricsMap[metricName] = { name: metricName, index, loaded: false };
+    }
+
+    try {
+      // If there is a current metric, do not present it
+      const currentMetric = sceneGraph.getAncestor(this, MetricScene).state.metric;
+      delete metricsMap[currentMetric];
+    } catch (err) {
+      // There is no current metric
     }
 
     this.previewCache = metricsMap;


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

- Addresses #79597 
- Fixes #81594 
  - https://github.com/grafana/grafana/pull/81316/commits/db8d5056d854f5d077683ef43d0dfacf5f423029

A category tree is derived from all metric names that fit the current metric search criteria, populating a prefix filter Cascader component.

![image](https://github.com/grafana/grafana/assets/38694490/c36b15a9-0322-4301-9b20-fa69543c9678)

This cascader components allows the user to browse through the remaining metrics through the name-based hierarchy, and select a prefix filter to further narrow down the displayed results.

If the search terms are changed to something too restrictive, an error message will appear:
![image](https://github.com/grafana/grafana/assets/38694490/b2c1a17f-0458-42c5-996f-7d1f5eb6ca60)

The Cascader allows text input, which I was not able to disable. By default, it would report "No results" for anything typed in, so I enabled `allowCustomValue`. This gives the user the ability to type in their own custom prefix, even an invalid one. This was preferable to the confusing "No results" outcome.

![image](https://github.com/grafana/grafana/assets/38694490/57fe5658-f2bb-4b69-a4e9-79ba9421a65f)

![image](https://github.com/grafana/grafana/assets/38694490/ab4c3535-6161-4617-8abb-92f83241c704)


**Which issue(s) does this PR fix?**:

- Resolves #79597 

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
