### PR TITLE
Transformations: Fix regression where disabling single transformation would display "No data"

### DIFF
--- a/e2e/panels-suite/panelEdit_transforms.spec.ts
+++ b/e2e/panels-suite/panelEdit_transforms.spec.ts
@@ -6,12 +6,23 @@ describe('Panel edit tests - transformations', () => {
   });
 
   it('Tests transformations editor', () => {
-    e2e.flows.openDashboard({ uid: '5SdHCadmz', queryParams: { editPanel: 3 } });
+    e2e.flows.openDashboard({ uid: 'TkZXxlNG3', queryParams: { editPanel: 47 } });
 
     e2e.components.Tab.title('Transform data').should('be.visible').click();
     e2e.components.Transforms.addTransformationButton().scrollIntoView().should('be.visible').click();
     e2e.components.TransformTab.newTransform('Reduce').scrollIntoView().should('be.visible').click();
     e2e.components.Transforms.Reduce.calculationsLabel().scrollIntoView().should('be.visible');
     e2e.components.Transforms.Reduce.modeLabel().should('be.visible');
+  });
+
+  it('Tests case where transformations can be disabled and not clear out panel data', () => {
+    e2e.flows.openDashboard({ uid: 'TkZXxlNG3', queryParams: { editPanel: 47 } });
+
+    e2e.components.Tab.title('Transform data').should('be.visible').click();
+    e2e.components.Transforms.addTransformationButton().scrollIntoView().should('be.visible').click();
+    e2e.components.TransformTab.newTransform('Reduce').scrollIntoView().should('be.visible').click();
+    e2e.components.Transforms.disableTransformationButton().should('be.visible').click();
+
+    e2e.components.Panels.Panel.PanelDataErrorMessage().should('not.exist');
   });
 });

--- a/packages/grafana-e2e-selectors/src/selectors/components.ts
+++ b/packages/grafana-e2e-selectors/src/selectors/components.ts
@@ -164,6 +164,7 @@ export const Components = {
         container: 'data-testid hover-header-container',
         dragIcon: 'data-testid drag-icon',
       },
+      PanelDataErrorMessage: 'data-testid Panel data error message',
     },
     Visualization: {
       Graph: {
@@ -306,6 +307,7 @@ export const Components = {
   },
   Transforms: {
     card: (name: string) => `data-testid New transform ${name}`,
+    disableTransformationButton: 'data-testid Disable transformation button',
     Reduce: {
       modeLabel: 'data-testid Transform mode label',
       calculationsLabel: 'data-testid Transform calculations label',

--- a/public/app/core/components/QueryOperationRow/QueryOperationAction.tsx
+++ b/public/app/core/components/QueryOperationRow/QueryOperationAction.tsx
@@ -10,6 +10,7 @@ interface BaseQueryOperationActionProps {
   title: string;
   onClick: (e: React.MouseEvent) => void;
   disabled?: boolean;
+  dataTestId?: string;
 }
 
 function BaseQueryOperationAction(props: QueryOperationActionProps | QueryOperationToggleActionProps) {
@@ -25,6 +26,7 @@ function BaseQueryOperationAction(props: QueryOperationActionProps | QueryOperat
         onClick={props.onClick}
         type="button"
         aria-label={selectors.components.QueryEditorRow.actionButton(props.title)}
+        data-testid={props.dataTestId}
         {...('active' in props && { 'aria-pressed': props.active })}
       />
     </div>

--- a/public/app/features/dashboard/components/TransformationsEditor/TransformationOperationRow.tsx
+++ b/public/app/features/dashboard/components/TransformationsEditor/TransformationOperationRow.tsx
@@ -2,6 +2,7 @@ import React, { useCallback } from 'react';
 import { useToggle } from 'react-use';
 
 import { DataTransformerConfig, TransformerRegistryItem, FrameMatcherID, DataTopic } from '@grafana/data';
+import { selectors } from '@grafana/e2e-selectors';
 import { reportInteraction } from '@grafana/runtime';
 import { ConfirmModal } from '@grafana/ui';
 import {
@@ -120,6 +121,7 @@ export const TransformationOperationRow = ({
           icon={disabled ? 'eye-slash' : 'eye'}
           onClick={instrumentToggleCallback(() => onDisableToggle(index), 'disabled', disabled)}
           active={disabled}
+          dataTestId={selectors.components.Transforms.disableTransformationButton}
         />
         <QueryOperationAction
           title="Remove"

--- a/public/app/features/panel/components/PanelDataErrorView.tsx
+++ b/public/app/features/panel/components/PanelDataErrorView.tsx
@@ -8,6 +8,7 @@ import {
   VisualizationSuggestionsBuilder,
   VisualizationSuggestion,
 } from '@grafana/data';
+import { selectors } from '@grafana/e2e-selectors';
 import { PanelDataErrorViewProps, locationService } from '@grafana/runtime';
 import { usePanelContext, useStyles2 } from '@grafana/ui';
 import { CardButton } from 'app/core/components/CardButton';
@@ -66,7 +67,9 @@ export function PanelDataErrorView(props: PanelDataErrorViewProps) {
 
   return (
     <div className={styles.wrapper}>
-      <div className={styles.message}>{message}</div>
+      <div className={styles.message} data-testid={selectors.components.Panels.Panel.PanelDataErrorMessage}>
+        {message}
+      </div>
       {context.app === CoreApp.PanelEditor && dataSummary.hasData && panel && (
         <div className={styles.actions}>
           {props.suggestions && (

--- a/public/app/features/query/state/PanelQueryRunner.ts
+++ b/public/app/features/query/state/PanelQueryRunner.ts
@@ -219,12 +219,8 @@ export class PanelQueryRunner {
   private applyTransformations(data: PanelData): Observable<PanelData> {
     const transformations = this.dataConfigSource.getTransformations();
 
-    if (
-      // add a check to see if all transformations are disabled and return early if that is the case...
-      // (transformations && transformations.length === 1 && transformations[0].disabled) ||
-      !transformations ||
-      transformations.length === 0
-    ) {
+    const allTransformationsDisabled = transformations && transformations.every((t) => t.disabled);
+    if (allTransformationsDisabled || !transformations || transformations.length === 0) {
       return of(data);
     }
 

--- a/public/app/features/query/state/PanelQueryRunner.ts
+++ b/public/app/features/query/state/PanelQueryRunner.ts
@@ -219,7 +219,12 @@ export class PanelQueryRunner {
   private applyTransformations(data: PanelData): Observable<PanelData> {
     const transformations = this.dataConfigSource.getTransformations();
 
-    if (!transformations || transformations.length === 0) {
+    if (
+      // add a check to see if all transformations are disabled and return early if that is the case...
+      // (transformations && transformations.length === 1 && transformations[0].disabled) ||
+      !transformations ||
+      transformations.length === 0
+    ) {
       return of(data);
     }
 


### PR DESCRIPTION
Fixes a regression where disabling transformation on a panel with a single transformation would cause the panel to display "No data" despite valid query data being available.

Adds basic e2e test to hopefully prevent this regression in the future 😬 (also updates existing transformation test to use a timeseries panel vs graph (note: updating our old tests may be part of the deprecation project))

![Screenshot 2024-01-25 at 4 12 26 PM](https://github.com/grafana/grafana/assets/22381771/f75e8fb7-d00e-46ab-a933-fa0afe4b01ab)

[Repro dashboard.txt](https://github.com/grafana/grafana/files/14058911/debug-Panel.Title-2024-01-25.16_27_39.json.txt)


Fixes https://github.com/grafana/grafana/issues/80503
Fixes https://github.com/grafana/grafana/issues/80947
Fixes https://github.com/grafana/support-escalations/issues/9012