### PR TITLE
Alerting: Fix group by and timing override fields in simplfied routing section

### DIFF
--- a/public/app/features/alerting/unified/components/rule-editor/alert-rule-form/simplifiedRouting/route-settings/RouteSettings.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/alert-rule-form/simplifiedRouting/route-settings/RouteSettings.tsx
@@ -38,6 +38,7 @@ export const RoutingSettings = ({ alertManager }: RoutingSettingsProps) => {
     control,
     watch,
     register,
+    setValue,
     formState: { errors },
   } = useFormContext<RuleFormValues>();
   const [groupByOptions, setGroupByOptions] = useState(stringsToSelectableValues([]));

--- a/public/app/features/alerting/unified/utils/rule-form.ts
+++ b/public/app/features/alerting/unified/utils/rule-form.ts
@@ -149,11 +149,18 @@ export function getNotificationSettingsForDTO(
       receiver: contactPoints?.grafana?.selectedContactPoint,
       mute_timings: contactPoints?.grafana?.muteTimeIntervals,
       group_by: contactPoints?.grafana?.overrideGrouping ? contactPoints?.grafana?.groupBy : undefined,
-      group_wait: contactPoints?.grafana?.overrideTimings ? contactPoints?.grafana?.groupWaitValue : undefined,
-      group_interval: contactPoints?.grafana?.overrideTimings ? contactPoints?.grafana?.groupIntervalValue : undefined,
-      repeat_interval: contactPoints?.grafana?.overrideTimings
-        ? contactPoints?.grafana?.repeatIntervalValue
-        : undefined,
+      group_wait:
+        contactPoints?.grafana?.overrideTimings && contactPoints?.grafana?.groupWaitValue
+          ? contactPoints?.grafana?.groupWaitValue
+          : undefined,
+      group_interval:
+        contactPoints?.grafana?.overrideTimings && contactPoints?.grafana?.groupIntervalValue
+          ? contactPoints?.grafana?.groupIntervalValue
+          : undefined,
+      repeat_interval:
+        contactPoints?.grafana?.overrideTimings && contactPoints?.grafana?.repeatIntervalValue
+          ? contactPoints?.grafana?.repeatIntervalValue
+          : undefined,
     };
   }
   return undefined;
@@ -191,8 +198,13 @@ export function getContactPointsFromDTO(ga: GrafanaRuleDefinition): AlertManager
     ? {
         selectedContactPoint: ga.notification_settings.receiver,
         muteTimeIntervals: ga.notification_settings.mute_timings ?? [],
-        overrideGrouping: Boolean(ga.notification_settings?.group_by),
-        overrideTimings: Boolean(ga.notification_settings.group_wait),
+        overrideGrouping:
+          Array.isArray(ga.notification_settings.group_by) && ga.notification_settings.group_by.length > 0,
+        overrideTimings: [
+          ga.notification_settings.group_wait,
+          ga.notification_settings.group_interval,
+          ga.notification_settings.repeat_interval,
+        ].some(Boolean),
         groupBy: ga.notification_settings.group_by || [],
         groupWaitValue: ga.notification_settings.group_wait || '',
         groupIntervalValue: ga.notification_settings.group_interval || '',


### PR DESCRIPTION
Fixes the group by custom labels and timings override logic in the simplified routing section of the edit rule page.

Previously:

- Custom labels would fail on first attempt at adding them to the group by.
- Timings fields required all timings to be overridden instead of any of them.

**Special notes for your reviewer:**

Before:

[Peek 2024-01-25 22-03.webm](https://github.com/grafana/grafana/assets/8484471/1cc918fa-d6b7-40c8-9014-8fe173bc5e04)


After:

[Peek 2024-01-25 22-07.webm](https://github.com/grafana/grafana/assets/8484471/4dba1f68-4b2c-452d-b487-b6cacf22a08e)

