### PR TITLE
fix: Upgrade ts-node to work with latest typescript

### DIFF
--- a/plugins-bundled/internal/input-datasource/package.json
+++ b/plugins-bundled/internal/input-datasource/package.json
@@ -24,7 +24,7 @@
     "jest-environment-jsdom": "29.3.1",
     "swc-loader": "0.2.3",
     "ts-jest": "29.0.5",
-    "ts-node": "10.9.1",
+    "ts-node": "10.9.2",
     "webpack": "5.76.0"
   },
   "dependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3062,7 +3062,7 @@ __metadata:
     react: "npm:18.2.0"
     swc-loader: "npm:0.2.3"
     ts-jest: "npm:29.0.5"
-    ts-node: "npm:10.9.1"
+    ts-node: "npm:10.9.2"
     tslib: "npm:2.5.0"
     webpack: "npm:5.76.0"
   languageName: unknown
@@ -28915,44 +28915,6 @@ __metadata:
     typescript: "*"
     webpack: "*"
   checksum: d5cd87c1070840e0502ca8f348c385980a159efbe2d2d24cc259a4063b562c9e1c3e38c7b150f8aabeee3097132aca20a60eced335037631cb25e3f3f906ea0c
-  languageName: node
-  linkType: hard
-
-"ts-node@npm:10.9.1":
-  version: 10.9.1
-  resolution: "ts-node@npm:10.9.1"
-  dependencies:
-    "@cspotcode/source-map-support": "npm:^0.8.0"
-    "@tsconfig/node10": "npm:^1.0.7"
-    "@tsconfig/node12": "npm:^1.0.7"
-    "@tsconfig/node14": "npm:^1.0.0"
-    "@tsconfig/node16": "npm:^1.0.2"
-    acorn: "npm:^8.4.1"
-    acorn-walk: "npm:^8.1.1"
-    arg: "npm:^4.1.0"
-    create-require: "npm:^1.1.0"
-    diff: "npm:^4.0.1"
-    make-error: "npm:^1.1.1"
-    v8-compile-cache-lib: "npm:^3.0.1"
-    yn: "npm:3.1.1"
-  peerDependencies:
-    "@swc/core": ">=1.2.50"
-    "@swc/wasm": ">=1.2.50"
-    "@types/node": "*"
-    typescript: ">=2.7"
-  peerDependenciesMeta:
-    "@swc/core":
-      optional: true
-    "@swc/wasm":
-      optional: true
-  bin:
-    ts-node: dist/bin.js
-    ts-node-cwd: dist/bin-cwd.js
-    ts-node-esm: dist/bin-esm.js
-    ts-node-script: dist/bin-script.js
-    ts-node-transpile-only: dist/bin-transpile.js
-    ts-script: dist/bin-script-deprecated.js
-  checksum: bee56d4dc96ccbafc99dfab7b73fbabc62abab2562af53cdea91c874a301b9d11e42bc33c0a032a6ed6d813dbdc9295ec73dde7b73ea4ebde02b0e22006f7e04
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
There is a version incompatibility with ts-node 10.9.1 and TS >= 5.3. [ref](https://github.com/TypeStrong/ts-node/pull/2091)

Since we upgraded to [typescript 5.3.3](https://github.com/grafana/grafana/pull/81096), this causes the build in the `input-datasource` plugin to error. This was only found when trying to run `make build-js` in isolation.