### PR TITLE
RBAC: Remove redundant search endpoint

### DIFF
--- a/pkg/services/accesscontrol/api/api.go
+++ b/pkg/services/accesscontrol/api/api.go
@@ -11,7 +11,6 @@ import (
 	ac "github.com/grafana/grafana/pkg/services/accesscontrol"
 	contextmodel "github.com/grafana/grafana/pkg/services/contexthandler/model"
 	"github.com/grafana/grafana/pkg/services/featuremgmt"
-	"github.com/grafana/grafana/pkg/web"
 )
 
 func NewAccessControlAPI(router routing.RouteRegister, accesscontrol ac.AccessControl, service ac.Service,
@@ -38,9 +37,7 @@ func (api *AccessControlAPI) RegisterAPIEndpoints() {
 		rr.Get("/user/actions", middleware.ReqSignedIn, routing.Wrap(api.getUserActions))
 		rr.Get("/user/permissions", middleware.ReqSignedIn, routing.Wrap(api.getUserPermissions))
 		if api.features.IsEnabledGlobally(featuremgmt.FlagAccessControlOnCall) {
-			userIDScope := ac.Scope("users", "id", ac.Parameter(":userID"))
 			rr.Get("/users/permissions/search", authorize(ac.EvalPermission(ac.ActionUsersPermissionsRead)), routing.Wrap(api.searchUsersPermissions))
-			rr.Get("/user/:userID/permissions/search", authorize(ac.EvalPermission(ac.ActionUsersPermissionsRead, userIDScope)), routing.Wrap(api.searchUserPermissions))
 		}
 	}, requestmeta.SetOwner(requestmeta.TeamAuth))
 }
@@ -51,7 +48,7 @@ func (api *AccessControlAPI) getUserActions(c *contextmodel.ReqContext) response
 	permissions, err := api.Service.GetUserPermissions(c.Req.Context(),
 		c.SignedInUser, ac.Options{ReloadCache: reloadCache})
 	if err != nil {
-		response.JSON(http.StatusInternalServerError, err)
+		return response.JSON(http.StatusInternalServerError, err)
 	}
 
 	return response.JSON(http.StatusOK, ac.BuildPermissionsMap(permissions))
@@ -63,7 +60,7 @@ func (api *AccessControlAPI) getUserPermissions(c *contextmodel.ReqContext) resp
 	permissions, err := api.Service.GetUserPermissions(c.Req.Context(),
 		c.SignedInUser, ac.Options{ReloadCache: reloadCache})
 	if err != nil {
-		response.JSON(http.StatusInternalServerError, err)
+		return response.JSON(http.StatusInternalServerError, err)
 	}
 
 	return response.JSON(http.StatusOK, ac.GroupScopesByAction(permissions))
@@ -108,32 +105,4 @@ func (api *AccessControlAPI) searchUsersPermissions(c *contextmodel.ReqContext) 
 	}
 
 	return response.JSON(http.StatusOK, permsByAction)
-}
-
-// GET /api/access-control/user/:userID/permissions/search
-func (api *AccessControlAPI) searchUserPermissions(c *contextmodel.ReqContext) response.Response {
-	userIDString := web.Params(c.Req)[":userID"]
-	userID, err := strconv.ParseInt(userIDString, 10, 64)
-	if err != nil {
-		return response.Error(http.StatusBadRequest, "user ID is invalid", err)
-	}
-
-	searchOptions := ac.SearchOptions{
-		ActionPrefix: c.Query("actionPrefix"),
-		Action:       c.Query("action"),
-		Scope:        c.Query("scope"),
-		UserID:       userID,
-	}
-	// Validate inputs
-	if (searchOptions.ActionPrefix != "") == (searchOptions.Action != "") {
-		return response.JSON(http.StatusBadRequest, "provide one of 'action' or 'actionPrefix'")
-	}
-
-	permissions, err := api.Service.SearchUserPermissions(c.Req.Context(),
-		c.SignedInUser.GetOrgID(), searchOptions)
-	if err != nil {
-		response.Error(http.StatusInternalServerError, "could not search user permissions", err)
-	}
-
-	return response.JSON(http.StatusOK, ac.Reduce(permissions))
 }


### PR DESCRIPTION
**What is this feature?**

With https://github.com/grafana/grafana/pull/81137 we added the userID and userLogin filters to the permissions search endpoint making the user specific endpoint redundant. This PR removes it before it is used by anyone. 

**Why do we need this feature?**

[Add a description of the problem the feature is trying to solve.]

**Who is this feature for?**

[Add information on what kind of user the feature is for.]

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
