### PR TITLE
Transformations: Use the display name of the original y field for the predicted field of the regression analysis transformation.

### DIFF
--- a/public/app/features/transformers/regression/regression.ts
+++ b/public/app/features/transformers/regression/regression.ts
@@ -9,6 +9,7 @@ import {
   FieldType,
   SynchronousDataTransformerInfo,
   fieldMatchers,
+  getFieldDisplayName,
 } from '@grafana/data';
 
 export enum ModelType {
@@ -42,6 +43,7 @@ export const RegressionTransformer: SynchronousDataTransformerInfo<RegressionTra
 
       let xField;
       let yField;
+      let predictFromFrame;
       for (const frame of frames) {
         const fy = frame.fields.find((f) => matchesY(f, frame, frames));
         if (fy) {
@@ -49,6 +51,7 @@ export const RegressionTransformer: SynchronousDataTransformerInfo<RegressionTra
           const fx = frame.fields.find((f) => matchesX(f, frame, frames));
           if (fx) {
             xField = fx;
+            predictFromFrame = frame;
             break;
           } else {
             throw 'X and Y fields must be part of the same frame';
@@ -108,7 +111,7 @@ export const RegressionTransformer: SynchronousDataTransformerInfo<RegressionTra
         fields: [
           { name: xField.name, type: xField.type, values: predictionPoints, config: {} },
           {
-            name: `${yField.name} predicted`,
+            name: `${getFieldDisplayName(yField, predictFromFrame, frames)} predicted`,
             type: yField.type,
             values: predictionPoints.map((x) => result.predict(x - normalizationSubtrahend)),
             config: {},


### PR DESCRIPTION
**What is this feature?**

This sets a better name for the field with the predicted value from the regression analysis transformation

**Why do we need this feature?**

See #81317

**Who is this feature for?**

Users of the regression analysis transformation.

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #81317

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
