### PR TITLE
Auth: Add validation to Generic OAuth API and UI

### DIFF
--- a/pkg/login/social/connectors/azuread_oauth.go
+++ b/pkg/login/social/connectors/azuread_oauth.go
@@ -12,6 +12,7 @@ import (
 
 	jose "github.com/go-jose/go-jose/v3"
 	"github.com/go-jose/go-jose/v3/jwt"
+	"github.com/google/uuid"
 	"golang.org/x/oauth2"
 
 	"github.com/grafana/grafana/pkg/infra/remotecache"
@@ -195,7 +196,12 @@ func (s *SocialAzureAD) Validate(ctx context.Context, settings ssoModels.SSOSett
 		return err
 	}
 
-	// add specific validation rules for AzureAD
+	for _, groupId := range info.AllowedGroups {
+		_, err := uuid.Parse(groupId)
+		if err != nil {
+			return ssosettings.ErrInvalidOAuthConfig("One or more of the Allowed groups are not in the correct format. Allowed groups should be a list of Object Ids.")
+		}
+	}
 
 	return nil
 }

--- a/pkg/login/social/connectors/azuread_oauth_test.go
+++ b/pkg/login/social/connectors/azuread_oauth_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/grafana/grafana/pkg/infra/remotecache"
 	"github.com/grafana/grafana/pkg/login/social"
 	"github.com/grafana/grafana/pkg/services/featuremgmt"
+	"github.com/grafana/grafana/pkg/services/ssosettings"
 	ssoModels "github.com/grafana/grafana/pkg/services/ssosettings/models"
 	"github.com/grafana/grafana/pkg/services/ssosettings/ssosettingstests"
 	"github.com/grafana/grafana/pkg/setting"
@@ -991,18 +992,18 @@ func TestSocialAzureAD_InitializeExtraFields(t *testing.T) {
 
 func TestSocialAzureAD_Validate(t *testing.T) {
 	testCases := []struct {
-		name        string
-		settings    ssoModels.SSOSettings
-		expectError bool
+		name     string
+		settings ssoModels.SSOSettings
+		wantErr  error
 	}{
 		{
 			name: "SSOSettings is valid",
 			settings: ssoModels.SSOSettings{
 				Settings: map[string]any{
-					"client_id": "client-id",
+					"client_id":      "client-id",
+					"allowed_groups": "0bb9c9cc-4945-418f-9b6a-c1d3b81141b0, 6034d328-0e6a-4240-8d03-cb9f2c1f16e4",
 				},
 			},
-			expectError: false,
 		},
 		{
 			name: "fails if settings map contains an invalid field",
@@ -1012,7 +1013,7 @@ func TestSocialAzureAD_Validate(t *testing.T) {
 					"invalid_field": []int{1, 2, 3},
 				},
 			},
-			expectError: true,
+			wantErr: ssosettings.ErrInvalidSettings,
 		},
 		{
 			name: "fails if client id is empty",
@@ -1021,14 +1022,35 @@ func TestSocialAzureAD_Validate(t *testing.T) {
 					"client_id": "",
 				},
 			},
-			expectError: true,
+			wantErr: ssosettings.ErrBaseInvalidOAuthConfig,
 		},
 		{
 			name: "fails if client id does not exist",
 			settings: ssoModels.SSOSettings{
 				Settings: map[string]any{},
 			},
-			expectError: true,
+			wantErr: ssosettings.ErrBaseInvalidOAuthConfig,
+		},
+		{
+			name: "fails if allowed groups are not uuids",
+			settings: ssoModels.SSOSettings{
+				Settings: map[string]any{
+					"client_id":      "client-id",
+					"allowed_groups": "abc, def",
+				},
+			},
+			wantErr: ssosettings.ErrBaseInvalidOAuthConfig,
+		},
+		{
+			name: "fails if both allow assign grafana admin and skip org role sync are enabled",
+			settings: ssoModels.SSOSettings{
+				Settings: map[string]any{
+					"client_id":                  "client-id",
+					"allow_assign_grafana_admin": "true",
+					"skip_org_role_sync":         "true",
+				},
+			},
+			wantErr: ssosettings.ErrBaseInvalidOAuthConfig,
 		},
 	}
 
@@ -1037,11 +1059,12 @@ func TestSocialAzureAD_Validate(t *testing.T) {
 			s := NewAzureADProvider(&social.OAuthInfo{}, &setting.Cfg{}, &ssosettingstests.MockService{}, featuremgmt.WithFeatures(), nil)
 
 			err := s.Validate(context.Background(), tc.settings)
-			if tc.expectError {
-				require.Error(t, err)
-			} else {
-				require.NoError(t, err)
+			if tc.wantErr != nil {
+				require.ErrorIs(t, err, tc.wantErr)
+				return
 			}
+			require.NoError(t, err)
+
 		})
 	}
 }

--- a/pkg/login/social/connectors/azuread_oauth_test.go
+++ b/pkg/login/social/connectors/azuread_oauth_test.go
@@ -1064,7 +1064,6 @@ func TestSocialAzureAD_Validate(t *testing.T) {
 				return
 			}
 			require.NoError(t, err)
-
 		})
 	}
 }

--- a/pkg/login/social/connectors/generic_oauth.go
+++ b/pkg/login/social/connectors/generic_oauth.go
@@ -78,7 +78,15 @@ func (s *SocialGenericOAuth) Validate(ctx context.Context, settings ssoModels.SS
 		return err
 	}
 
-	// add specific validation rules for Generic OAuth
+	if info.Extra[teamIdsKey] != "" && (info.TeamIdsAttributePath == "" || info.TeamsUrl == "") {
+		return ssosettings.ErrOauthValidationError("If Team Ids are configured then Team Ids attribute path and Teams URL must be configured.",
+			map[string]any{"team_ids": info.Extra[teamIdsKey]})
+	}
+
+	if info.AllowedGroups != nil && len(info.AllowedGroups) > 0 && info.GroupsAttributePath == "" {
+		return ssosettings.ErrOauthValidationError("If Allowed groups are configured then Groups attribute path must be configured.",
+			map[string]any{"allowed_groups": info.AllowedGroups})
+	}
 
 	return nil
 }

--- a/pkg/login/social/connectors/generic_oauth.go
+++ b/pkg/login/social/connectors/generic_oauth.go
@@ -79,13 +79,11 @@ func (s *SocialGenericOAuth) Validate(ctx context.Context, settings ssoModels.SS
 	}
 
 	if info.Extra[teamIdsKey] != "" && (info.TeamIdsAttributePath == "" || info.TeamsUrl == "") {
-		return ssosettings.ErrOauthValidationError("If Team Ids are configured then Team Ids attribute path and Teams URL must be configured.",
-			map[string]any{"team_ids": info.Extra[teamIdsKey]})
+		return ssosettings.ErrOauthValidationError("If Team Ids are configured then Team Ids attribute path and Teams URL must be configured.")
 	}
 
 	if info.AllowedGroups != nil && len(info.AllowedGroups) > 0 && info.GroupsAttributePath == "" {
-		return ssosettings.ErrOauthValidationError("If Allowed groups are configured then Groups attribute path must be configured.",
-			map[string]any{"allowed_groups": info.AllowedGroups})
+		return ssosettings.ErrOauthValidationError("If Allowed groups are configured then Groups attribute path must be configured.")
 	}
 
 	return nil

--- a/pkg/login/social/connectors/generic_oauth.go
+++ b/pkg/login/social/connectors/generic_oauth.go
@@ -79,11 +79,11 @@ func (s *SocialGenericOAuth) Validate(ctx context.Context, settings ssoModels.SS
 	}
 
 	if info.Extra[teamIdsKey] != "" && (info.TeamIdsAttributePath == "" || info.TeamsUrl == "") {
-		return ssosettings.ErrOauthValidationError("If Team Ids are configured then Team Ids attribute path and Teams URL must be configured.")
+		return ssosettings.ErrInvalidOAuthConfig("If Team Ids are configured then Team Ids attribute path and Teams URL must be configured.")
 	}
 
 	if info.AllowedGroups != nil && len(info.AllowedGroups) > 0 && info.GroupsAttributePath == "" {
-		return ssosettings.ErrOauthValidationError("If Allowed groups are configured then Groups attribute path must be configured.")
+		return ssosettings.ErrInvalidOAuthConfig("If Allowed groups are configured then Groups attribute path must be configured.")
 	}
 
 	return nil

--- a/pkg/login/social/connectors/github_oauth.go
+++ b/pkg/login/social/connectors/github_oauth.go
@@ -89,8 +89,7 @@ func (s *SocialGithub) Validate(ctx context.Context, settings ssoModels.SSOSetti
 	teamIds := mustInts(teamIdsSplitted)
 
 	if len(teamIdsSplitted) != len(teamIds) {
-		s.log.Warn("Failed to parse team ids. Team ids must be a list of numbers.", "teamIds", teamIdsSplitted)
-		return ssosettings.ErrOauthValidationError("Failed to parse Team IDs. Team Ids must be a list of numbers.", map[string]any{"team_ids": teamIdsSplitted})
+		return ssosettings.ErrOauthValidationError("Failed to parse Team Ids. Team Ids must be a list of numbers.")
 	}
 
 	return nil

--- a/pkg/login/social/connectors/github_oauth.go
+++ b/pkg/login/social/connectors/github_oauth.go
@@ -90,7 +90,7 @@ func (s *SocialGithub) Validate(ctx context.Context, settings ssoModels.SSOSetti
 
 	if len(teamIdsSplitted) != len(teamIds) {
 		s.log.Warn("Failed to parse team ids. Team ids must be a list of numbers.", "teamIds", teamIdsSplitted)
-		return ssosettings.ErrInvalidSettings.Errorf("Failed to parse team ids. Team ids must be a list of numbers.")
+		return ssosettings.ErrOauthValidationError("Failed to parse Team IDs. Team Ids must be a list of numbers.", map[string]any{"team_ids": teamIdsSplitted})
 	}
 
 	return nil

--- a/pkg/login/social/connectors/github_oauth.go
+++ b/pkg/login/social/connectors/github_oauth.go
@@ -89,7 +89,7 @@ func (s *SocialGithub) Validate(ctx context.Context, settings ssoModels.SSOSetti
 	teamIds := mustInts(teamIdsSplitted)
 
 	if len(teamIdsSplitted) != len(teamIds) {
-		return ssosettings.ErrOauthValidationError("Failed to parse Team Ids. Team Ids must be a list of numbers.")
+		return ssosettings.ErrInvalidOAuthConfig("Failed to parse Team Ids. Team Ids must be a list of numbers.")
 	}
 
 	return nil

--- a/pkg/login/social/connectors/github_oauth_test.go
+++ b/pkg/login/social/connectors/github_oauth_test.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/grafana/grafana/pkg/login/social"
 	"github.com/grafana/grafana/pkg/services/featuremgmt"
+	"github.com/grafana/grafana/pkg/services/ssosettings"
 	ssoModels "github.com/grafana/grafana/pkg/services/ssosettings/models"
 	"github.com/grafana/grafana/pkg/services/ssosettings/ssosettingstests"
 	"github.com/grafana/grafana/pkg/setting"
@@ -345,9 +346,9 @@ func TestSocialGitHub_InitializeExtraFields(t *testing.T) {
 
 func TestSocialGitHub_Validate(t *testing.T) {
 	testCases := []struct {
-		name        string
-		settings    ssoModels.SSOSettings
-		expectError bool
+		name     string
+		settings ssoModels.SSOSettings
+		wantErr  error
 	}{
 		{
 			name: "SSOSettings is valid",
@@ -356,7 +357,6 @@ func TestSocialGitHub_Validate(t *testing.T) {
 					"client_id": "client-id",
 				},
 			},
-			expectError: false,
 		},
 		{
 			name: "fails if settings map contains an invalid field",
@@ -366,7 +366,7 @@ func TestSocialGitHub_Validate(t *testing.T) {
 					"invalid_field": []int{1, 2, 3},
 				},
 			},
-			expectError: true,
+			wantErr: ssosettings.ErrInvalidSettings,
 		},
 		{
 			name: "fails if client id is empty",
@@ -375,14 +375,35 @@ func TestSocialGitHub_Validate(t *testing.T) {
 					"client_id": "",
 				},
 			},
-			expectError: true,
+			wantErr: ssosettings.ErrBaseInvalidOAuthConfig,
 		},
 		{
 			name: "fails if client id does not exist",
 			settings: ssoModels.SSOSettings{
 				Settings: map[string]any{},
 			},
-			expectError: true,
+			wantErr: ssosettings.ErrBaseInvalidOAuthConfig,
+		},
+		{
+			name: "fails if team ids are not integers",
+			settings: ssoModels.SSOSettings{
+				Settings: map[string]any{
+					"client_id": "client-id",
+					"team_ids":  "abc1234,5678,def",
+				},
+			},
+			wantErr: ssosettings.ErrBaseInvalidOAuthConfig,
+		},
+		{
+			name: "fails if both allow assign grafana admin and skip org role sync are enabled",
+			settings: ssoModels.SSOSettings{
+				Settings: map[string]any{
+					"client_id":                  "client-id",
+					"allow_assign_grafana_admin": "true",
+					"skip_org_role_sync":         "true",
+				},
+			},
+			wantErr: ssosettings.ErrBaseInvalidOAuthConfig,
 		},
 	}
 
@@ -391,11 +412,11 @@ func TestSocialGitHub_Validate(t *testing.T) {
 			s := NewGitHubProvider(&social.OAuthInfo{}, &setting.Cfg{}, &ssosettingstests.MockService{}, featuremgmt.WithFeatures())
 
 			err := s.Validate(context.Background(), tc.settings)
-			if tc.expectError {
-				require.Error(t, err)
-			} else {
-				require.NoError(t, err)
+			if tc.wantErr != nil {
+				require.ErrorIs(t, err, tc.wantErr)
+				return
 			}
+			require.NoError(t, err)
 		})
 	}
 }

--- a/pkg/login/social/connectors/gitlab_oauth_test.go
+++ b/pkg/login/social/connectors/gitlab_oauth_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/grafana/grafana/pkg/login/social"
 	"github.com/grafana/grafana/pkg/services/featuremgmt"
 	"github.com/grafana/grafana/pkg/services/org"
+	"github.com/grafana/grafana/pkg/services/ssosettings"
 	ssoModels "github.com/grafana/grafana/pkg/services/ssosettings/models"
 	"github.com/grafana/grafana/pkg/services/ssosettings/ssosettingstests"
 	"github.com/grafana/grafana/pkg/setting"
@@ -463,9 +464,9 @@ func TestSocialGitlab_GetGroupsNextPage(t *testing.T) {
 
 func TestSocialGitlab_Validate(t *testing.T) {
 	testCases := []struct {
-		name        string
-		settings    ssoModels.SSOSettings
-		expectError bool
+		name     string
+		settings ssoModels.SSOSettings
+		wantErr  error
 	}{
 		{
 			name: "SSOSettings is valid",
@@ -474,7 +475,6 @@ func TestSocialGitlab_Validate(t *testing.T) {
 					"client_id": "client-id",
 				},
 			},
-			expectError: false,
 		},
 		{
 			name: "fails if settings map contains an invalid field",
@@ -484,7 +484,7 @@ func TestSocialGitlab_Validate(t *testing.T) {
 					"invalid_field": []int{1, 2, 3},
 				},
 			},
-			expectError: true,
+			wantErr: ssosettings.ErrInvalidSettings,
 		},
 		{
 			name: "fails if client id is empty",
@@ -493,14 +493,25 @@ func TestSocialGitlab_Validate(t *testing.T) {
 					"client_id": "",
 				},
 			},
-			expectError: true,
+			wantErr: ssosettings.ErrBaseInvalidOAuthConfig,
 		},
 		{
 			name: "fails if client id does not exist",
 			settings: ssoModels.SSOSettings{
 				Settings: map[string]any{},
 			},
-			expectError: true,
+			wantErr: ssosettings.ErrBaseInvalidOAuthConfig,
+		},
+		{
+			name: "fails if both allow assign grafana admin and skip org role sync are enabled",
+			settings: ssoModels.SSOSettings{
+				Settings: map[string]any{
+					"client_id":                  "client-id",
+					"allow_assign_grafana_admin": "true",
+					"skip_org_role_sync":         "true",
+				},
+			},
+			wantErr: ssosettings.ErrBaseInvalidOAuthConfig,
 		},
 	}
 
@@ -509,11 +520,11 @@ func TestSocialGitlab_Validate(t *testing.T) {
 			s := NewGitLabProvider(&social.OAuthInfo{}, &setting.Cfg{}, &ssosettingstests.MockService{}, featuremgmt.WithFeatures())
 
 			err := s.Validate(context.Background(), tc.settings)
-			if tc.expectError {
-				require.Error(t, err)
-			} else {
-				require.NoError(t, err)
+			if tc.wantErr != nil {
+				require.ErrorIs(t, err, tc.wantErr)
+				return
 			}
+			require.NoError(t, err)
 		})
 	}
 }

--- a/pkg/login/social/connectors/google_oauth_test.go
+++ b/pkg/login/social/connectors/google_oauth_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/grafana/grafana/pkg/login/social"
 	"github.com/grafana/grafana/pkg/models/roletype"
 	"github.com/grafana/grafana/pkg/services/featuremgmt"
+	"github.com/grafana/grafana/pkg/services/ssosettings"
 	ssoModels "github.com/grafana/grafana/pkg/services/ssosettings/models"
 	"github.com/grafana/grafana/pkg/services/ssosettings/ssosettingstests"
 	"github.com/grafana/grafana/pkg/setting"
@@ -668,9 +669,9 @@ func TestSocialGoogle_UserInfo(t *testing.T) {
 
 func TestSocialGoogle_Validate(t *testing.T) {
 	testCases := []struct {
-		name        string
-		settings    ssoModels.SSOSettings
-		expectError bool
+		name     string
+		settings ssoModels.SSOSettings
+		wantErr  error
 	}{
 		{
 			name: "SSOSettings is valid",
@@ -679,7 +680,6 @@ func TestSocialGoogle_Validate(t *testing.T) {
 					"client_id": "client-id",
 				},
 			},
-			expectError: false,
 		},
 		{
 			name: "fails if settings map contains an invalid field",
@@ -689,7 +689,7 @@ func TestSocialGoogle_Validate(t *testing.T) {
 					"invalid_field": []int{1, 2, 3},
 				},
 			},
-			expectError: true,
+			wantErr: ssosettings.ErrInvalidSettings,
 		},
 		{
 			name: "fails if client id is empty",
@@ -698,14 +698,25 @@ func TestSocialGoogle_Validate(t *testing.T) {
 					"client_id": "",
 				},
 			},
-			expectError: true,
+			wantErr: ssosettings.ErrBaseInvalidOAuthConfig,
 		},
 		{
 			name: "fails if client id does not exist",
 			settings: ssoModels.SSOSettings{
 				Settings: map[string]any{},
 			},
-			expectError: true,
+			wantErr: ssosettings.ErrBaseInvalidOAuthConfig,
+		},
+		{
+			name: "fails if both allow assign grafana admin and skip org role sync are enabled",
+			settings: ssoModels.SSOSettings{
+				Settings: map[string]any{
+					"client_id":                  "client-id",
+					"allow_assign_grafana_admin": "true",
+					"skip_org_role_sync":         "true",
+				},
+			},
+			wantErr: ssosettings.ErrBaseInvalidOAuthConfig,
 		},
 	}
 
@@ -714,11 +725,11 @@ func TestSocialGoogle_Validate(t *testing.T) {
 			s := NewGoogleProvider(&social.OAuthInfo{}, &setting.Cfg{}, &ssosettingstests.MockService{}, featuremgmt.WithFeatures())
 
 			err := s.Validate(context.Background(), tc.settings)
-			if tc.expectError {
-				require.Error(t, err)
-			} else {
-				require.NoError(t, err)
+			if tc.wantErr != nil {
+				require.ErrorIs(t, err, tc.wantErr)
+				return
 			}
+			require.NoError(t, err)
 		})
 	}
 }

--- a/pkg/login/social/connectors/okta_oauth_test.go
+++ b/pkg/login/social/connectors/okta_oauth_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/grafana/grafana/pkg/login/social"
 	"github.com/grafana/grafana/pkg/models/roletype"
 	"github.com/grafana/grafana/pkg/services/featuremgmt"
+	"github.com/grafana/grafana/pkg/services/ssosettings"
 	ssoModels "github.com/grafana/grafana/pkg/services/ssosettings/models"
 	"github.com/grafana/grafana/pkg/services/ssosettings/ssosettingstests"
 	"github.com/grafana/grafana/pkg/setting"
@@ -136,9 +137,9 @@ func TestSocialOkta_UserInfo(t *testing.T) {
 
 func TestSocialOkta_Validate(t *testing.T) {
 	testCases := []struct {
-		name        string
-		settings    ssoModels.SSOSettings
-		expectError bool
+		name     string
+		settings ssoModels.SSOSettings
+		wantErr  error
 	}{
 		{
 			name: "SSOSettings is valid",
@@ -147,7 +148,6 @@ func TestSocialOkta_Validate(t *testing.T) {
 					"client_id": "client-id",
 				},
 			},
-			expectError: false,
 		},
 		{
 			name: "fails if settings map contains an invalid field",
@@ -157,7 +157,7 @@ func TestSocialOkta_Validate(t *testing.T) {
 					"invalid_field": []int{1, 2, 3},
 				},
 			},
-			expectError: true,
+			wantErr: ssosettings.ErrInvalidSettings,
 		},
 		{
 			name: "fails if client id is empty",
@@ -166,14 +166,25 @@ func TestSocialOkta_Validate(t *testing.T) {
 					"client_id": "",
 				},
 			},
-			expectError: true,
+			wantErr: ssosettings.ErrBaseInvalidOAuthConfig,
 		},
 		{
 			name: "fails if client id does not exist",
 			settings: ssoModels.SSOSettings{
 				Settings: map[string]any{},
 			},
-			expectError: true,
+			wantErr: ssosettings.ErrBaseInvalidOAuthConfig,
+		},
+		{
+			name: "fails if both allow assign grafana admin and skip org role sync are enabled",
+			settings: ssoModels.SSOSettings{
+				Settings: map[string]any{
+					"client_id":                  "client-id",
+					"allow_assign_grafana_admin": "true",
+					"skip_org_role_sync":         "true",
+				},
+			},
+			wantErr: ssosettings.ErrBaseInvalidOAuthConfig,
 		},
 	}
 
@@ -182,11 +193,11 @@ func TestSocialOkta_Validate(t *testing.T) {
 			s := NewOktaProvider(&social.OAuthInfo{}, &setting.Cfg{}, &ssosettingstests.MockService{}, featuremgmt.WithFeatures())
 
 			err := s.Validate(context.Background(), tc.settings)
-			if tc.expectError {
-				require.Error(t, err)
-			} else {
-				require.NoError(t, err)
+			if tc.wantErr != nil {
+				require.ErrorIs(t, err, tc.wantErr)
+				return
 			}
+			require.NoError(t, err)
 		})
 	}
 }

--- a/pkg/login/social/connectors/social_base.go
+++ b/pkg/login/social/connectors/social_base.go
@@ -222,7 +222,11 @@ func getRoleFromSearch(role string) (org.RoleType, bool) {
 
 func validateInfo(info *social.OAuthInfo) error {
 	if info.ClientId == "" {
-		return ssosettings.ErrOauthValidationError("ClientId is empty", map[string]any{"clientId": ""})
+		return ssosettings.ErrOauthValidationError("ClientId is empty")
+	}
+
+	if info.AllowAssignGrafanaAdmin && info.SkipOrgRoleSync {
+		return ssosettings.ErrOauthValidationError("Allow assign Grafana Admin and Skip org role sync are both set thus Grafana Admin role will not be synced. Consider setting one or the other.")
 	}
 
 	return nil

--- a/pkg/login/social/connectors/social_base.go
+++ b/pkg/login/social/connectors/social_base.go
@@ -222,11 +222,11 @@ func getRoleFromSearch(role string) (org.RoleType, bool) {
 
 func validateInfo(info *social.OAuthInfo) error {
 	if info.ClientId == "" {
-		return ssosettings.ErrOauthValidationError("ClientId is empty")
+		return ssosettings.ErrInvalidOAuthConfig("ClientId is empty")
 	}
 
 	if info.AllowAssignGrafanaAdmin && info.SkipOrgRoleSync {
-		return ssosettings.ErrOauthValidationError("Allow assign Grafana Admin and Skip org role sync are both set thus Grafana Admin role will not be synced. Consider setting one or the other.")
+		return ssosettings.ErrInvalidOAuthConfig("Allow assign Grafana Admin and Skip org role sync are both set thus Grafana Admin role will not be synced. Consider setting one or the other.")
 	}
 
 	return nil

--- a/pkg/login/social/connectors/social_base.go
+++ b/pkg/login/social/connectors/social_base.go
@@ -222,7 +222,7 @@ func getRoleFromSearch(role string) (org.RoleType, bool) {
 
 func validateInfo(info *social.OAuthInfo) error {
 	if info.ClientId == "" {
-		return ssosettings.ErrEmptyClientId.Errorf("clientId is empty")
+		return ssosettings.ErrOauthValidationError("ClientId is empty", map[string]any{"clientId": ""})
 	}
 
 	return nil

--- a/pkg/services/ssosettings/errors.go
+++ b/pkg/services/ssosettings/errors.go
@@ -10,10 +10,10 @@ var (
 
 	ErrNotConfigurable = errNotFoundBase.Errorf("not configurable")
 
-	errInvalidOAuthInfo = errutil.ValidationFailed("sso.invalidOAuthInfo")
+	ErrBaseInvalidOAuthConfig = errutil.ValidationFailed("sso.invalidOauthConfig")
 
-	ErrOauthValidationError = func(msg string) error {
-		base := errInvalidOAuthInfo.Errorf("OAuth settings are invalid")
+	ErrInvalidOAuthConfig = func(msg string) error {
+		base := ErrBaseInvalidOAuthConfig.Errorf("OAuth settings are invalid")
 		base.PublicMessage = msg
 		return base
 	}

--- a/pkg/services/ssosettings/errors.go
+++ b/pkg/services/ssosettings/errors.go
@@ -12,10 +12,9 @@ var (
 
 	errInvalidOAuthInfo = errutil.ValidationFailed("sso.invalidOAuthInfo")
 
-	ErrOauthValidationError = func(msg string, payload map[string]any) error {
+	ErrOauthValidationError = func(msg string) error {
 		base := errInvalidOAuthInfo.Errorf("OAuth settings are invalid")
 		base.PublicMessage = msg
-		base.PublicPayload = payload
 		return base
 	}
 

--- a/pkg/services/ssosettings/errors.go
+++ b/pkg/services/ssosettings/errors.go
@@ -10,6 +10,15 @@ var (
 
 	ErrNotConfigurable = errNotFoundBase.Errorf("not configurable")
 
+	errInvalidOAuthInfo = errutil.ValidationFailed("sso.invalidOAuthInfo")
+
+	ErrOauthValidationError = func(msg string, payload map[string]any) error {
+		base := errInvalidOAuthInfo.Errorf("OAuth settings are invalid")
+		base.PublicMessage = msg
+		base.PublicPayload = payload
+		return base
+	}
+
 	ErrInvalidProvider = errutil.ValidationFailed("sso.invalidProvider", errutil.WithPublicMessage("Provider is invalid"))
 	ErrInvalidSettings = errutil.ValidationFailed("sso.settings", errutil.WithPublicMessage("Settings field is invalid"))
 	ErrEmptyClientId   = errutil.ValidationFailed("sso.emptyClientId", errutil.WithPublicMessage("ClientId cannot be empty"))

--- a/public/app/features/auth-config/FieldRenderer.tsx
+++ b/public/app/features/auth-config/FieldRenderer.tsx
@@ -68,12 +68,7 @@ export const FieldRenderer = ({
     case 'text':
       return (
         <Field {...fieldProps}>
-          <Input
-            {...register(name, { required: !!fieldData.validation?.required })}
-            type={fieldData.type}
-            id={name}
-            autoComplete={'off'}
-          />
+          <Input {...register(name, fieldData.validation)} type={fieldData.type} id={name} autoComplete={'off'} />
         </Field>
       );
     case 'secret':

--- a/public/app/features/auth-config/FieldRenderer.tsx
+++ b/public/app/features/auth-config/FieldRenderer.tsx
@@ -13,6 +13,7 @@ interface FieldRendererProps
   field: SSOSettingsField;
   errors: UseFormReturn['formState']['errors'];
   secretConfigured: boolean;
+  provider: string;
 }
 
 export const FieldRenderer = ({
@@ -24,12 +25,13 @@ export const FieldRenderer = ({
   control,
   unregister,
   secretConfigured,
+  provider,
 }: FieldRendererProps) => {
   const [isSecretConfigured, setIsSecretConfigured] = useState(secretConfigured);
   const isDependantField = typeof field !== 'string';
   const name = isDependantField ? field.name : field;
   const parentValue = isDependantField ? watch(field.dependsOn) : null;
-  const fieldData = fieldMap[name];
+  const fieldData = fieldMap(provider)[name];
   const theme = useTheme2();
   // Unregister a field that depends on a toggle to clear its data
   useEffect(() => {

--- a/public/app/features/auth-config/FieldRenderer.tsx
+++ b/public/app/features/auth-config/FieldRenderer.tsx
@@ -1,8 +1,8 @@
 import { css } from '@emotion/css';
 import React, { useEffect, useState } from 'react';
-import { UseFormReturn } from 'react-hook-form';
+import { UseFormReturn, Controller } from 'react-hook-form';
 
-import { Checkbox, Field, Input, InputControl, SecretInput, Select, Switch, useTheme2 } from '@grafana/ui';
+import { Checkbox, Field, Input, SecretInput, Select, Switch, useTheme2 } from '@grafana/ui';
 
 import { fieldMap } from './fields';
 import { SSOProviderDTO, SSOSettingsField } from './types';
@@ -74,7 +74,7 @@ export const FieldRenderer = ({
     case 'secret':
       return (
         <Field {...fieldProps} htmlFor={name}>
-          <InputControl
+          <Controller
             name={name}
             control={control}
             rules={fieldData.validation}
@@ -103,7 +103,7 @@ export const FieldRenderer = ({
       }
       return (
         <Field {...fieldProps} htmlFor={name}>
-          <InputControl
+          <Controller
             rules={fieldData.validation}
             name={name}
             control={control}

--- a/public/app/features/auth-config/FieldRenderer.tsx
+++ b/public/app/features/auth-config/FieldRenderer.tsx
@@ -97,9 +97,8 @@ export const FieldRenderer = ({
     case 'select':
       const watchOptions = watch(name);
       let options = fieldData.options;
-
       if (!fieldData.options?.length) {
-        options = isSelectableValue(watchOptions) ? watchOptions : [{ label: '', value: '' }];
+        options = isSelectableValue(watchOptions) ? watchOptions : [];
       }
       return (
         <Field {...fieldProps} htmlFor={name}>

--- a/public/app/features/auth-config/ProviderConfigForm.test.tsx
+++ b/public/app/features/auth-config/ProviderConfigForm.test.tsx
@@ -90,16 +90,20 @@ describe('ProviderConfigForm', () => {
     await user.click(screen.getByRole('button', { name: /Save/i }));
 
     await waitFor(() => {
-      expect(putMock).toHaveBeenCalledWith('/api/v1/sso-settings/github', {
-        ...testConfig,
-        settings: {
-          allowedOrganizations: 'test-org1,test-org2',
-          clientId: 'test-client-id',
-          clientSecret: 'test-client-secret',
-          teamIds: '12324',
-          enabled: true,
+      expect(putMock).toHaveBeenCalledWith(
+        '/api/v1/sso-settings/github',
+        {
+          ...testConfig,
+          settings: {
+            allowedOrganizations: 'test-org1,test-org2',
+            clientId: 'test-client-id',
+            clientSecret: 'test-client-secret',
+            teamIds: '12324',
+            enabled: true,
+          },
         },
-      });
+        { showErrorAlert: false }
+      );
     });
   });
 

--- a/public/app/features/auth-config/ProviderConfigForm.tsx
+++ b/public/app/features/auth-config/ProviderConfigForm.tsx
@@ -31,7 +31,7 @@ export const ProviderConfigForm = ({ config, provider, isLoading }: ProviderConf
     setValue,
     unregister,
     formState: { errors, dirtyFields, isSubmitted },
-  } = useForm({ defaultValues: dataToDTO(config), mode: 'onChange', reValidateMode: 'onChange' });
+  } = useForm({ defaultValues: dataToDTO(config), mode: 'onSubmit', reValidateMode: 'onChange' });
   const [isSaving, setIsSaving] = useState(false);
   const providerFields = fields[provider];
   const [submitError, setSubmitError] = useState(false);

--- a/public/app/features/auth-config/ProviderConfigForm.tsx
+++ b/public/app/features/auth-config/ProviderConfigForm.tsx
@@ -133,6 +133,7 @@ export const ProviderConfigForm = ({ config, provider, isLoading }: ProviderConf
                               register={register}
                               watch={watch}
                               unregister={unregister}
+                              provider={provider}
                               secretConfigured={!!config?.settings.clientSecret}
                             />
                           );
@@ -154,6 +155,7 @@ export const ProviderConfigForm = ({ config, provider, isLoading }: ProviderConf
                     register={register}
                     watch={watch}
                     unregister={unregister}
+                    provider={provider}
                     secretConfigured={!!config?.settings.clientSecret}
                   />
                 );

--- a/public/app/features/auth-config/ProviderConfigForm.tsx
+++ b/public/app/features/auth-config/ProviderConfigForm.tsx
@@ -44,11 +44,17 @@ export const ProviderConfigForm = ({ config, provider, isLoading }: ProviderConf
     setSubmitError(false);
     const requestData = dtoToData(data, provider);
     try {
-      await getBackendSrv().put(`/api/v1/sso-settings/${provider}`, {
-        id: config?.id,
-        provider: config?.provider,
-        settings: { ...requestData },
-      });
+      await getBackendSrv().put(
+        `/api/v1/sso-settings/${provider}`,
+        {
+          id: config?.id,
+          provider: config?.provider,
+          settings: { ...requestData },
+        },
+        {
+          showErrorAlert: false,
+        }
+      );
 
       appEvents.publish({
         type: AppEvents.alertSuccess.name,

--- a/public/app/features/auth-config/fields.tsx
+++ b/public/app/features/auth-config/fields.tsx
@@ -4,6 +4,7 @@ import { TextLink } from '@grafana/ui';
 
 import { FieldData, SSOProvider, SSOSettingsField } from './types';
 import { isSelectableValue } from './utils/guards';
+import { Field } from 'react-hook-form';
 
 /** Map providers to their settings */
 export const fields: Record<SSOProvider['provider'], Array<keyof SSOProvider['settings']>> = {
@@ -95,276 +96,305 @@ export const sectionFields: Section = {
 /**
  * List all the fields that can be used in the form
  */
-export const fieldMap: Record<string, FieldData> = {
-  clientId: {
-    label: 'Client Id',
-    type: 'text',
-    description: 'The client ID of your OAuth2 app.',
-    validation: {
-      required: true,
-      message: 'This field is required',
-    },
-  },
-  clientSecret: {
-    label: 'Client Secret',
-    type: 'secret',
-    description: 'The client secret of your OAuth2 app.',
-  },
-  teamIds: {
-    label: 'Team Ids',
-    type: 'select',
-    description:
-      'String list of team IDs. If set, the user must be a member of one of the given teams to log in. \n' +
-      'If you configure team_ids, you must also configure teams_url and team_ids_attribute_path.',
-    multi: true,
-    allowCustomValue: true,
-    options: [],
-    placeholder: 'Enter team IDs and press Enter to add',
-    validation: {
-      validate: (value) => {
-        if (typeof value === 'string') {
-          return isNumeric(value);
-        }
-        if (isSelectableValue(value)) {
-          return value.every((v) => v?.value && isNumeric(v.value));
-        }
-        return true;
+export function fieldMap(provider: string): Record<string, FieldData> {
+  let result: Record<string, FieldData> = {
+    clientId: {
+      label: 'Client Id',
+      type: 'text',
+      description: 'The client ID of your OAuth2 app.',
+      validation: {
+        required: true,
+        message: 'This field is required',
       },
-      message: 'Team ID must be a number.',
     },
-  },
-  allowedOrganizations: {
-    label: 'Allowed Organizations',
-    type: 'select',
-    description:
-      'List of comma- or space-separated organizations. The user should be a member \n' +
-      'of at least one organization to log in.',
-    multi: true,
-    allowCustomValue: true,
-    options: [],
-    placeholder: 'Enter organizations (my-team, myteam...) and press Enter to add',
-  },
-  allowedDomains: {
-    label: 'Allowed Domains',
-    type: 'select',
-    description:
-      'List of comma- or space-separated domains. The user should belong to at least \n' + 'one domain to log in.',
-    multi: true,
-    allowCustomValue: true,
-    options: [],
-  },
-  authUrl: {
-    label: 'Auth Url',
-    type: 'text',
-    description: 'The authorization endpoint of your OAuth2 provider.',
-    validation: {
-      required: false,
+    clientSecret: {
+      label: 'Client Secret',
+      type: 'secret',
+      description: 'The client secret of your OAuth2 app.',
     },
-  },
-  authStyle: {
-    label: 'Auth Style',
-    type: 'select',
-    description: 'It determines how client_id and client_secret are sent to Oauth2 provider. Default is AutoDetect.',
-    multi: false,
-    options: [
-      { value: 'AutoDetect', label: 'AutoDetect' },
-      { value: 'InParams', label: 'InParams' },
-      { value: 'InHeader', label: 'InHeader' },
-    ],
-    defaultValue: 'AutoDetect',
-  },
-  tokenUrl: {
-    label: 'Token Url',
-    type: 'text',
-    description: 'The token endpoint of your OAuth2 provider.',
-    validation: {
-      required: false,
+    teamIds: {
+      label: 'Team Ids',
+      type: 'select',
+      description:
+        'String list of team IDs. If set, the user must be a member of one of the given teams to log in. \n' +
+        'If you configure team_ids, you must also configure teams_url and team_ids_attribute_path.',
+      multi: true,
+      allowCustomValue: true,
+      options: [],
+      placeholder: 'Enter team IDs and press Enter to add',
     },
-  },
-  scopes: {
-    label: 'Scopes',
-    type: 'select',
-    description: 'List of comma- or space-separated OAuth2 scopes.',
-    multi: true,
-    allowCustomValue: true,
-    options: [],
-  },
-  allowedGroups: {
-    label: 'Allowed Groups',
-    type: 'select',
-    description:
-      'List of comma- or space-separated groups. The user should be a member of \n' +
-      'at least one group to log in. If you configure allowed_groups, you must also configure \n' +
-      'groups_attribute_path.',
-    multi: true,
-    allowCustomValue: true,
-    options: [],
-  },
-  apiUrl: {
-    label: 'API Url',
-    type: 'text',
-    description: (
-      <>
-        The user information endpoint of your OAuth2 provider. Information returned by this endpoint must be compatible
-        with{' '}
-        <TextLink href={'https://connect2id.com/products/server/docs/api/userinfo'} external variant={'bodySmall'}>
-          OpenID UserInfo
-        </TextLink>
-        .
-      </>
-    ),
-    validation: {
-      required: false,
+    allowedOrganizations: {
+      label: 'Allowed Organizations',
+      type: 'select',
+      description:
+        'List of comma- or space-separated organizations. The user should be a member \n' +
+        'of at least one organization to log in.',
+      multi: true,
+      allowCustomValue: true,
+      options: [],
+      placeholder: 'Enter organizations (my-team, myteam...) and press Enter to add',
     },
-  },
-  roleAttributePath: {
-    label: 'Role Attribute Path',
-    description: 'JMESPath expression to use for Grafana role lookup.',
-    type: 'text',
-    validation: {
-      required: false,
+    allowedDomains: {
+      label: 'Allowed Domains',
+      type: 'select',
+      description:
+        'List of comma- or space-separated domains. The user should belong to at least \n' + 'one domain to log in.',
+      multi: true,
+      allowCustomValue: true,
+      options: [],
     },
-  },
-  name: {
-    label: 'Display name',
-    description: 'Helpful if you use more than one identity providers or SSO protocols.',
-    type: 'text',
-  },
-  allowSignUp: {
-    label: 'Allow sign up',
-    description: 'If not enabled, only existing Grafana users can log in using OAuth.',
-    type: 'switch',
-  },
-  autoLogin: {
-    label: 'Auto login',
-    description: 'Log in automatically, skipping the login screen.',
-    type: 'switch',
-  },
-  signoutRedirectUrl: {
-    label: 'Sign out redirect URL',
-    description: 'The URL to redirect the user to after signing out from Grafana.',
-    type: 'text',
-    validation: {
-      required: false,
+    authUrl: {
+      label: 'Auth Url',
+      type: 'text',
+      description: 'The authorization endpoint of your OAuth2 provider.',
+      validation: {
+        required: false,
+      },
     },
-  },
-  emailAttributeName: {
-    label: 'Email attribute name',
-    description: 'Name of the key to use for user email lookup within the attributes map of OAuth2 ID token.',
-    type: 'text',
-  },
-  emailAttributePath: {
-    label: 'Email attribute path',
-    description: 'JMESPath expression to use for user email lookup from the user information.',
-    type: 'text',
-  },
-  nameAttributePath: {
-    label: 'Name attribute path',
-    description:
-      'JMESPath expression to use for user name lookup from the user ID token. \n' +
-      'This name will be used as the user’s display name.',
-    type: 'text',
-  },
-  loginAttributePath: {
-    label: 'Login attribute path',
-    description: 'JMESPath expression to use for user login lookup from the user ID token.',
-    type: 'text',
-  },
-  idTokenAttributeName: {
-    label: 'ID token attribute name',
-    description: 'The name of the key used to extract the ID token from the returned OAuth2 token.',
-    type: 'text',
-  },
-  roleAttributeStrict: {
-    label: 'Role attribute strict mode',
-    description: 'If enabled, denies user login if the Grafana role cannot be extracted using Role attribute path.',
-    type: 'switch',
-  },
-  allowAssignGrafanaAdmin: {
-    label: 'Allow assign Grafana admin',
-    description: 'If enabled, it will automatically sync the Grafana server administrator role.',
-    type: 'switch',
-  },
-  skipOrgRoleSync: {
-    label: 'Skip organization role sync',
-    description: 'Prevent synchronizing users’ organization roles from your IdP.',
-    type: 'switch',
-  },
-  defineAllowedGroups: {
-    label: 'Define Allowed Groups',
-    type: 'switch',
-  },
-  defineAllowedTeamsIds: {
-    label: 'Define Allowed Teams Ids',
-    type: 'switch',
-  },
-  usePkce: {
-    label: 'Use Pkce',
-    description: (
-      <>
-        If enabled, Grafana will use{' '}
-        <TextLink external variant={'bodySmall'} href={'https://datatracker.ietf.org/doc/html/rfc7636'}>
-          Proof Key for Code Exchange (PKCE)
-        </TextLink>{' '}
-        with the OAuth2 Authorization Code Grant.
-      </>
-    ),
-    type: 'checkbox',
-  },
-  useRefreshToken: {
-    label: 'Use Refresh Token',
-    description:
-      'If enabled, Grafana will fetch a new access token using the refresh token provided by the OAuth2 provider.',
-    type: 'checkbox',
-  },
-  configureTLS: {
-    label: 'Configure TLS',
-    type: 'switch',
-  },
-  tlsClientCa: {
-    label: 'TLS Client CA',
-    description: 'The path to the trusted certificate authority list.',
-    type: 'text',
-  },
-  tlsClientCert: {
-    label: 'TLS Client Cert',
-    description: 'The path to the certificate',
-    type: 'text',
-  },
-  tlsClientKey: {
-    label: 'TLS Client Key',
-    description: 'The path to the key',
-    type: 'text',
-  },
-  tlsSkipVerifyInsecure: {
-    label: 'TLS Skip Verify',
-    description:
-      'If enabled, the client accepts any certificate presented by the server and any host \n' +
-      'name in that certificate. You should only use this for testing, because this mode leaves \n' +
-      'SSL/TLS susceptible to man-in-the-middle attacks.',
-    type: 'switch',
-  },
-  groupsAttributePath: {
-    label: 'Groups attribute path',
-    description:
-      'JMESPath expression to use for user group lookup. If you configure allowed_groups, \n' +
-      'you must also configure groups_attribute_path.',
-    type: 'text',
-  },
-  teamsUrl: {
-    label: 'Teams URL',
-    description:
-      'The URL used to query for team IDs. If not set, the default value is /teams. \n' +
-      'If you configure teams_url, you must also configure team_ids_attribute_path.',
-    type: 'text',
-  },
-  teamIdsAttributePath: {
-    label: 'Team IDs attribute path',
-    description:
-      'The JMESPath expression to use for Grafana team ID lookup within the results returned by the teams_url endpoint.',
-    type: 'text',
-  },
-};
+    authStyle: {
+      label: 'Auth Style',
+      type: 'select',
+      description: 'It determines how client_id and client_secret are sent to Oauth2 provider. Default is AutoDetect.',
+      multi: false,
+      options: [
+        { value: 'AutoDetect', label: 'AutoDetect' },
+        { value: 'InParams', label: 'InParams' },
+        { value: 'InHeader', label: 'InHeader' },
+      ],
+      defaultValue: 'AutoDetect',
+    },
+    tokenUrl: {
+      label: 'Token Url',
+      type: 'text',
+      description: 'The token endpoint of your OAuth2 provider.',
+      validation: {
+        required: false,
+      },
+    },
+    scopes: {
+      label: 'Scopes',
+      type: 'select',
+      description: 'List of comma- or space-separated OAuth2 scopes.',
+      multi: true,
+      allowCustomValue: true,
+      options: [],
+    },
+    allowedGroups: {
+      label: 'Allowed Groups',
+      type: 'select',
+      description:
+        'List of comma- or space-separated groups. The user should be a member of \n' +
+        'at least one group to log in. If you configure allowed_groups, you must also configure \n' +
+        'groups_attribute_path.',
+      multi: true,
+      allowCustomValue: true,
+      options: [],
+    },
+    apiUrl: {
+      label: 'API Url',
+      type: 'text',
+      description: (
+        <>
+          The user information endpoint of your OAuth2 provider. Information returned by this endpoint must be
+          compatible with{' '}
+          <TextLink href={'https://connect2id.com/products/server/docs/api/userinfo'} external variant={'bodySmall'}>
+            OpenID UserInfo
+          </TextLink>
+          .
+        </>
+      ),
+      validation: {
+        required: false,
+      },
+    },
+    roleAttributePath: {
+      label: 'Role Attribute Path',
+      description: 'JMESPath expression to use for Grafana role lookup.',
+      type: 'text',
+      validation: {
+        required: false,
+      },
+    },
+    name: {
+      label: 'Display name',
+      description: 'Helpful if you use more than one identity providers or SSO protocols.',
+      type: 'text',
+    },
+    allowSignUp: {
+      label: 'Allow sign up',
+      description: 'If not enabled, only existing Grafana users can log in using OAuth.',
+      type: 'switch',
+    },
+    autoLogin: {
+      label: 'Auto login',
+      description: 'Log in automatically, skipping the login screen.',
+      type: 'switch',
+    },
+    signoutRedirectUrl: {
+      label: 'Sign out redirect URL',
+      description: 'The URL to redirect the user to after signing out from Grafana.',
+      type: 'text',
+      validation: {
+        required: false,
+      },
+    },
+    emailAttributeName: {
+      label: 'Email attribute name',
+      description: 'Name of the key to use for user email lookup within the attributes map of OAuth2 ID token.',
+      type: 'text',
+    },
+    emailAttributePath: {
+      label: 'Email attribute path',
+      description: 'JMESPath expression to use for user email lookup from the user information.',
+      type: 'text',
+    },
+    nameAttributePath: {
+      label: 'Name attribute path',
+      description:
+        'JMESPath expression to use for user name lookup from the user ID token. \n' +
+        'This name will be used as the user’s display name.',
+      type: 'text',
+    },
+    loginAttributePath: {
+      label: 'Login attribute path',
+      description: 'JMESPath expression to use for user login lookup from the user ID token.',
+      type: 'text',
+    },
+    idTokenAttributeName: {
+      label: 'ID token attribute name',
+      description: 'The name of the key used to extract the ID token from the returned OAuth2 token.',
+      type: 'text',
+    },
+    roleAttributeStrict: {
+      label: 'Role attribute strict mode',
+      description: 'If enabled, denies user login if the Grafana role cannot be extracted using Role attribute path.',
+      type: 'switch',
+    },
+    allowAssignGrafanaAdmin: {
+      label: 'Allow assign Grafana admin',
+      description: 'If enabled, it will automatically sync the Grafana server administrator role.',
+      type: 'switch',
+    },
+    skipOrgRoleSync: {
+      label: 'Skip organization role sync',
+      description: 'Prevent synchronizing users’ organization roles from your IdP.',
+      type: 'switch',
+    },
+    defineAllowedGroups: {
+      label: 'Define Allowed Groups',
+      type: 'switch',
+    },
+    defineAllowedTeamsIds: {
+      label: 'Define Allowed Teams Ids',
+      type: 'switch',
+    },
+    usePkce: {
+      label: 'Use Pkce',
+      description: (
+        <>
+          If enabled, Grafana will use{' '}
+          <TextLink external variant={'bodySmall'} href={'https://datatracker.ietf.org/doc/html/rfc7636'}>
+            Proof Key for Code Exchange (PKCE)
+          </TextLink>{' '}
+          with the OAuth2 Authorization Code Grant.
+        </>
+      ),
+      type: 'checkbox',
+    },
+    useRefreshToken: {
+      label: 'Use Refresh Token',
+      description:
+        'If enabled, Grafana will fetch a new access token using the refresh token provided by the OAuth2 provider.',
+      type: 'checkbox',
+    },
+    configureTLS: {
+      label: 'Configure TLS',
+      type: 'switch',
+    },
+    tlsClientCa: {
+      label: 'TLS Client CA',
+      description: 'The path to the trusted certificate authority list.',
+      type: 'text',
+    },
+    tlsClientCert: {
+      label: 'TLS Client Cert',
+      description: 'The path to the certificate',
+      type: 'text',
+    },
+    tlsClientKey: {
+      label: 'TLS Client Key',
+      description: 'The path to the key',
+      type: 'text',
+    },
+    tlsSkipVerifyInsecure: {
+      label: 'TLS Skip Verify',
+      description:
+        'If enabled, the client accepts any certificate presented by the server and any host \n' +
+        'name in that certificate. You should only use this for testing, because this mode leaves \n' +
+        'SSL/TLS susceptible to man-in-the-middle attacks.',
+      type: 'switch',
+    },
+    groupsAttributePath: {
+      label: 'Groups attribute path',
+      description:
+        'JMESPath expression to use for user group lookup. If you configure allowed_groups, \n' +
+        'you must also configure groups_attribute_path.',
+      type: 'text',
+    },
+    teamsUrl: {
+      label: 'Teams URL',
+      description:
+        'The URL used to query for team IDs. If not set, the default value is /teams. \n' +
+        'If you configure teams_url, you must also configure team_ids_attribute_path.',
+      type: 'text',
+    },
+    teamIdsAttributePath: {
+      label: 'Team IDs attribute path',
+      description:
+        'The JMESPath expression to use for Grafana team ID lookup within the results returned by the teams_url endpoint.',
+      type: 'text',
+      validation: {
+        validate: (value, formValues) => {
+          if (formValues.teamIds) {
+            return !!value;
+          }
+          return true;
+        },
+        message: 'This field must be set if Team IDs are configured.'
+      }
+    },
+  };
+
+  if (provider === 'github') {
+    result = {
+      ...result,
+      teamIds: {
+        label: 'Team Ids',
+        type: 'select',
+        description:
+          'String list of team IDs. If set, the user must be a member of one of the given teams to log in. \n' +
+          'If you configure team_ids, you must also configure teams_url and team_ids_attribute_path.',
+        multi: true,
+        allowCustomValue: true,
+        options: [],
+        placeholder: 'Enter team IDs and press Enter to add',
+        validation: {
+          validate: (value) => {
+            if (typeof value === 'string') {
+              return isNumeric(value);
+            }
+            if (isSelectableValue(value)) {
+              return value.every((v) => v?.value && isNumeric(v.value));
+            }
+            return true;
+          },
+          message: 'Team ID must be a number.',
+        },
+      },
+    };
+  }
+  return result;
+}
 
 // Check if a string contains only numeric values
 function isNumeric(value: string) {

--- a/public/app/features/auth-config/fields.tsx
+++ b/public/app/features/auth-config/fields.tsx
@@ -100,19 +100,19 @@ export function fieldMap(provider: string): Record<string, FieldData> {
     clientId: {
       label: 'Client Id',
       type: 'text',
-      description: 'The client ID of your OAuth2 app.',
+      description: 'The client Id of your OAuth2 app.',
       validation: {
         required: true,
         message: 'This field is required',
       },
     },
     clientSecret: {
-      label: 'Client Secret',
+      label: 'Client secret',
       type: 'secret',
       description: 'The client secret of your OAuth2 app.',
     },
     allowedOrganizations: {
-      label: 'Allowed Organizations',
+      label: 'Allowed organizations',
       type: 'select',
       description:
         'List of comma- or space-separated organizations. The user should be a member \n' +
@@ -123,7 +123,7 @@ export function fieldMap(provider: string): Record<string, FieldData> {
       placeholder: 'Enter organizations (my-team, myteam...) and press Enter to add',
     },
     allowedDomains: {
-      label: 'Allowed Domains',
+      label: 'Allowed domains',
       type: 'select',
       description:
         'List of comma- or space-separated domains. The user should belong to at least \n' + 'one domain to log in.',
@@ -132,7 +132,7 @@ export function fieldMap(provider: string): Record<string, FieldData> {
       options: [],
     },
     authUrl: {
-      label: 'Auth Url',
+      label: 'Auth URL',
       type: 'text',
       description: 'The authorization endpoint of your OAuth2 provider.',
       validation: {
@@ -140,7 +140,7 @@ export function fieldMap(provider: string): Record<string, FieldData> {
       },
     },
     authStyle: {
-      label: 'Auth Style',
+      label: 'Auth style',
       type: 'select',
       description: 'It determines how client_id and client_secret are sent to Oauth2 provider. Default is AutoDetect.',
       multi: false,
@@ -152,7 +152,7 @@ export function fieldMap(provider: string): Record<string, FieldData> {
       defaultValue: 'AutoDetect',
     },
     tokenUrl: {
-      label: 'Token Url',
+      label: 'Token URL',
       type: 'text',
       description: 'The token endpoint of your OAuth2 provider.',
       validation: {
@@ -168,7 +168,7 @@ export function fieldMap(provider: string): Record<string, FieldData> {
       options: [],
     },
     allowedGroups: {
-      label: 'Allowed Groups',
+      label: 'Allowed groups',
       type: 'select',
       description:
         'List of comma- or space-separated groups. The user should be a member of \n' +
@@ -179,7 +179,7 @@ export function fieldMap(provider: string): Record<string, FieldData> {
       options: [],
     },
     apiUrl: {
-      label: 'API Url',
+      label: 'API URL',
       type: 'text',
       description: (
         <>
@@ -196,7 +196,7 @@ export function fieldMap(provider: string): Record<string, FieldData> {
       },
     },
     roleAttributePath: {
-      label: 'Role Attribute Path',
+      label: 'Role attribute path',
       description: 'JMESPath expression to use for Grafana role lookup.',
       type: 'text',
       validation: {
@@ -269,15 +269,15 @@ export function fieldMap(provider: string): Record<string, FieldData> {
       type: 'switch',
     },
     defineAllowedGroups: {
-      label: 'Define Allowed Groups',
+      label: 'Define allowed groups',
       type: 'switch',
     },
     defineAllowedTeamsIds: {
-      label: 'Define Allowed Teams Ids',
+      label: 'Define allowed teams ids',
       type: 'switch',
     },
     usePkce: {
-      label: 'Use Pkce',
+      label: 'Use PKCE',
       description: (
         <>
           If enabled, Grafana will use{' '}
@@ -290,7 +290,7 @@ export function fieldMap(provider: string): Record<string, FieldData> {
       type: 'checkbox',
     },
     useRefreshToken: {
-      label: 'Use Refresh Token',
+      label: 'Use refresh token',
       description:
         'If enabled, Grafana will fetch a new access token using the refresh token provided by the OAuth2 provider.',
       type: 'checkbox',
@@ -300,22 +300,22 @@ export function fieldMap(provider: string): Record<string, FieldData> {
       type: 'switch',
     },
     tlsClientCa: {
-      label: 'TLS Client CA',
-      description: 'The path to the trusted certificate authority list.',
+      label: 'TLS client ca',
+      description: 'The path to the trusted certificate authority list. Does not applicable on Grafana Cloud.',
       type: 'text',
     },
     tlsClientCert: {
-      label: 'TLS Client Cert',
-      description: 'The path to the certificate',
+      label: 'TLS client cert',
+      description: 'The path to the certificate. Does not applicable on Grafana Cloud.',
       type: 'text',
     },
     tlsClientKey: {
-      label: 'TLS Client Key',
-      description: 'The path to the key',
+      label: 'TLS client key',
+      description: 'The path to the key. Does not applicable on Grafana Cloud.',
       type: 'text',
     },
     tlsSkipVerifyInsecure: {
-      label: 'TLS Skip Verify',
+      label: 'TLS skip verify',
       description:
         'If enabled, the client accepts any certificate presented by the server and any host \n' +
         'name in that certificate. You should only use this for testing, because this mode leaves \n' +
@@ -326,20 +326,14 @@ export function fieldMap(provider: string): Record<string, FieldData> {
       label: 'Groups attribute path',
       description:
         'JMESPath expression to use for user group lookup. If you configure allowed_groups, \n' +
-        'you must also configure groups_attribute_path.',
+        'you must also configure groupsƒ_attribute_path.',
       type: 'text',
     },
     teamsUrl: {
       label: 'Teams URL',
       description:
-        'The URL used to query for team IDs. If not set, the default value is /teams. \n' +
+        'The URL used to query for Team Ids. If not set, the default value is /teams. \n' +
         'If you configure teams_url, you must also configure team_ids_attribute_path.',
-      type: 'text',
-    },
-    teamIdsAttributePath: {
-      label: 'Team IDs attribute path',
-      description:
-        'The JMESPath expression to use for Grafana team ID lookup within the results returned by the teams_url endpoint.',
       type: 'text',
       validation: {
         validate: (value, formValues) => {
@@ -348,19 +342,34 @@ export function fieldMap(provider: string): Record<string, FieldData> {
           }
           return true;
         },
-        message: 'This field must be set if Team IDs are configured.',
+        message: 'This field must be set if Team Ids are configured.',
+      },
+    },
+    teamIdsAttributePath: {
+      label: 'Team Ids attribute path',
+      description:
+        'The JMESPath expression to use for Grafana Team Id lookup within the results returned by the teams_url endpoint.',
+      type: 'text',
+      validation: {
+        validate: (value, formValues) => {
+          if (formValues.teamIds.length) {
+            return !!value;
+          }
+          return true;
+        },
+        message: 'This field must be set if Team Ids are configured.',
       },
     },
     teamIds: {
       label: 'Team Ids',
       type: 'select',
       description:
-        'String list of team IDs. If set, the user must be a member of one of the given teams to log in. \n' +
+        'String list of Team Ids. If set, the user must be a member of one of the given teams to log in. \n' +
         'If you configure team_ids, you must also configure teams_url and team_ids_attribute_path.',
       multi: true,
       allowCustomValue: true,
       options: [],
-      placeholder: 'Enter team IDs and press Enter to add',
+      placeholder: 'Enter Team Ids and press Enter to add',
       validation:
         provider === 'generic_oauth'
           ? undefined
@@ -374,7 +383,7 @@ export function fieldMap(provider: string): Record<string, FieldData> {
                 }
                 return true;
               },
-              message: 'Team ID must be a number.',
+              message: 'Team Ids must be numbers.',
             },
     },
   };

--- a/public/app/features/auth-config/fields.tsx
+++ b/public/app/features/auth-config/fields.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { validate as uuidValidate } from 'uuid';
 
 import { TextLink } from '@grafana/ui';
 
@@ -177,6 +178,21 @@ export function fieldMap(provider: string): Record<string, FieldData> {
       multi: true,
       allowCustomValue: true,
       options: [],
+      validation:
+        provider === 'azuread'
+          ? {
+              validate: (value) => {
+                if (typeof value === 'string') {
+                  return uuidValidate(value);
+                }
+                if (isSelectableValue(value)) {
+                  return value.every((v) => v?.value && uuidValidate(v.value));
+                }
+                return true;
+              },
+              message: 'Allowed groups must be Object Ids.',
+            }
+          : undefined,
     },
     apiUrl: {
       label: 'API URL',
@@ -371,9 +387,8 @@ export function fieldMap(provider: string): Record<string, FieldData> {
       options: [],
       placeholder: 'Enter Team Ids and press Enter to add',
       validation:
-        provider === 'generic_oauth'
-          ? undefined
-          : {
+        provider === 'github'
+          ? {
               validate: (value) => {
                 if (typeof value === 'string') {
                   return isNumeric(value);
@@ -384,7 +399,8 @@ export function fieldMap(provider: string): Record<string, FieldData> {
                 return true;
               },
               message: 'Team Ids must be numbers.',
-            },
+            }
+          : undefined,
     },
   };
 }

--- a/public/app/features/auth-config/utils/data.ts
+++ b/public/app/features/auth-config/utils/data.ts
@@ -93,7 +93,7 @@ export function dtoToData(dto: SSOProviderDTO, provider: string) {
   let current: Partial<SSOProviderDTO> = dto;
 
   if (fields[provider]) {
-    current = includeRequiredKeysOnly(dto, [...fields[provider], 'enabled'])
+    current = includeRequiredKeysOnly(dto, [...fields[provider], 'enabled']);
   }
   const settings = { ...current };
 

--- a/public/app/features/auth-config/utils/data.ts
+++ b/public/app/features/auth-config/utils/data.ts
@@ -58,7 +58,7 @@ export function dataToDTO(data?: SSOProvider): SSOProviderDTO {
   if (!data) {
     return emptySettings;
   }
-  const arrayFields = getArrayFields(fieldMap);
+  const arrayFields = getArrayFields(fieldMap(data.provider));
   const settings = { ...data.settings };
   for (const field of arrayFields) {
     //@ts-expect-error
@@ -89,12 +89,16 @@ const includeRequiredKeysOnly = (
 
 // Convert the DTO to the data format used by the API
 export function dtoToData(dto: SSOProviderDTO, provider: string) {
-  const arrayFields = getArrayFields(fieldMap);
-  const dtoWithRequiredFields = includeRequiredKeysOnly(dto, [...fields[provider], 'enabled']);
-  const settings = { ...dtoWithRequiredFields };
+  const arrayFields = getArrayFields(fieldMap(provider));
+  let current: Partial<SSOProviderDTO> = dto;
+
+  if (fields[provider]) {
+    current = includeRequiredKeysOnly(dto, [...fields[provider], 'enabled'])
+  }
+  const settings = { ...current };
 
   for (const field of arrayFields) {
-    const value = dtoWithRequiredFields[field];
+    const value = current[field];
     if (value) {
       if (isSelectableValue(value)) {
         //@ts-expect-error


### PR DESCRIPTION
**What is this feature?**
This PR..
- Adds validation to the Generic OAuth connector.
- Adds missing validation to the base OAuthInfo validator.
- Improves the validation on the UI.

**Why do we need this feature?**


**Who is this feature for?**

**Which issue(s) does this PR fix?**:

Fixes #

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
