### PR TITLE
Loki: Fix label not being added to all subexpressions

### DIFF
--- a/public/app/plugins/datasource/loki/modifyQuery.test.ts
+++ b/public/app/plugins/datasource/loki/modifyQuery.test.ts
@@ -98,6 +98,18 @@ describe('addLabelToQuery()', () => {
       '{foo="bar"} | logfmt | forcedLabel=`value`'
     );
   });
+
+  it('should add label as labelFilter to multiple places if label is StructuredMetadata', () => {
+    expect(
+      addLabelToQuery(
+        'rate({foo="bar"} [$__auto]) / rate({foo="bar"} [$__auto])',
+        'forcedLabel',
+        '=',
+        'value',
+        LabelType.StructuredMetadata
+      )
+    ).toEqual('rate({foo="bar"} | forcedLabel=`value` [$__auto]) / rate({foo="bar"} | forcedLabel=`value` [$__auto])');
+  });
 });
 
 describe('addParserToQuery', () => {

--- a/public/app/plugins/datasource/loki/modifyQuery.ts
+++ b/public/app/plugins/datasource/loki/modifyQuery.ts
@@ -171,8 +171,13 @@ export function addLabelToQuery(
 
   const filter = toLabelFilter(key, value, operator);
   if (labelType === LabelType.Parsed || labelType === LabelType.StructuredMetadata) {
-    const positionToAdd = findLastPosition([...streamSelectorPositions, ...labelFilterPositions, ...parserPositions]);
-    return addFilterAsLabelFilter(query, [positionToAdd], filter);
+    const lastPositionsPerExpression = getLastPositionPerExpression(query, [
+      ...streamSelectorPositions,
+      ...labelFilterPositions,
+      ...parserPositions,
+    ]);
+
+    return addFilterAsLabelFilter(query, lastPositionsPerExpression, filter);
   } else if (labelType === LabelType.Indexed) {
     return addFilterToStreamSelector(query, streamSelectorPositions, filter);
   } else {
@@ -183,21 +188,29 @@ export function addLabelToQuery(
     } else {
       // If `labelType` is not set, it indicates a potential metric query (`labelType` is present only in log queries that came from a Loki instance supporting the `categorize-labels` API). In case we are not adding the label to stream selectors we need to find the last position to add in each expression.
       // E.g. in `sum(rate({foo="bar"} | logfmt [$__auto])) / sum(rate({foo="baz"} | logfmt [$__auto]))` we need to add the label at two places.
-      const subExpressions = findLeaves(getNodePositionsFromQuery(query, [Expr]));
-      const parserFilterPositions = [...parserPositions, ...labelFilterPositions];
-
-      // find last position for each subexpression
-      const lastPositionsPerExpression = subExpressions.map((subExpression) => {
-        return findLastPosition(
-          parserFilterPositions.filter((p) => {
-            return subExpression.contains(p);
-          })
-        );
-      });
+      const lastPositionsPerExpression = getLastPositionPerExpression(query, [
+        ...parserPositions,
+        ...labelFilterPositions,
+      ]);
 
       return addFilterAsLabelFilter(query, lastPositionsPerExpression, filter);
     }
   }
+}
+
+function getLastPositionPerExpression(query: string, positions: NodePosition[]): NodePosition[] {
+  const subExpressions = findLeaves(getNodePositionsFromQuery(query, [Expr]));
+  const subPositions = [...positions];
+
+  // find last position for each subexpression
+  const lastPositionsPerExpression = subExpressions.map((subExpression) => {
+    return findLastPosition(
+      subPositions.filter((p) => {
+        return subExpression.contains(p);
+      })
+    );
+  });
+  return lastPositionsPerExpression;
 }
 
 /**


### PR DESCRIPTION
**What is this feature?**

`parsed` and `structured metadata` labels were not properly added to all subexpressions.

**Special notes for your reviewer:**

1. Start Grafana and Loki devenv
2. Do 2 queries in explore: 
  3. A: `sum(rate({place="moon"} [$__auto])) / sum(rate({place="moon"} [$__auto]))`
  4. B: `{place="moon"}`
6. Use the log details of `B` to add label filters.
7. Without this PR they wouldn't be added to all sub expressions.