### PR TITLE
Logs: Fix toggleable filters to be applied for specified query

### DIFF
--- a/public/app/features/logs/logsModel.test.ts
+++ b/public/app/features/logs/logsModel.test.ts
@@ -1636,6 +1636,7 @@ const mockLogRow = {
       },
       { name: 'labels', type: FieldType.other, values: [{ app: 'app01' }, { app: 'app02' }] },
     ],
+    refId: 'Z',
   }),
   rowIndex: 0,
 } as unknown as LogRowModel;
@@ -1673,5 +1674,10 @@ describe('logRowToDataFrame', () => {
     const result = logRowToSingleRowDataFrame({ ...mockLogRow, rowIndex: invalidRowIndex });
 
     expect(result).toBe(null);
+  });
+
+  it('should use refId from original DataFrame', () => {
+    const result = logRowToSingleRowDataFrame(mockLogRow);
+    expect(result?.refId).toBe(mockLogRow.dataFrame.refId);
   });
 });

--- a/public/app/features/logs/logsModel.ts
+++ b/public/app/features/logs/logsModel.ts
@@ -844,6 +844,7 @@ export function logRowToSingleRowDataFrame(logRow: LogRowModel): DataFrame | nul
   // create a new data frame containing only the single row from `logRow`
   const frame = createDataFrame({
     fields: originFrame.fields.map((field) => ({ ...field, values: [field.values[logRow.rowIndex]] })),
+    refId: originFrame.refId,
   });
 
   return frame;


### PR DESCRIPTION
This PR fixes applying of toggleable filters for specified query, as it is written in tooltip. 

https://github.com/grafana/grafana/assets/30407135/3653e8f8-749a-4f2b-8d7d-bedeb1f0a556

This is probably related to this change in https://github.com/grafana/grafana/pull/78595/ where we expected `refId`, but it is not passed anymore. 
<img width="1442" alt="image" src="https://github.com/grafana/grafana/assets/30407135/eeca11d6-db27-426c-958d-e55817bff1ed">
