### PR TITLE
Auth: Reload OAuth provider after deletion of the current settings 

### DIFF
--- a/pkg/login/social/socialimpl/service_test.go
+++ b/pkg/login/social/socialimpl/service_test.go
@@ -73,7 +73,7 @@ func TestSocialService_ProvideService(t *testing.T) {
 	accessControl := acimpl.ProvideAccessControl(cfg)
 	sqlStore := db.InitTestDB(t)
 
-	ssoSettingsSvc := ssosettingsimpl.ProvideService(cfg, sqlStore, accessControl, routing.NewRouteRegister(), featuremgmt.WithFeatures(), secrets, &usagestats.UsageStatsMock{})
+	ssoSettingsSvc := ssosettingsimpl.ProvideService(cfg, sqlStore, accessControl, routing.NewRouteRegister(), featuremgmt.WithFeatures(), secrets, &usagestats.UsageStatsMock{}, nil)
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/pkg/services/ssosettings/ssosettingsimpl/metrics.go
+++ b/pkg/services/ssosettings/ssosettingsimpl/metrics.go
@@ -1,0 +1,31 @@
+package ssosettingsimpl
+
+import "github.com/prometheus/client_golang/prometheus"
+
+const (
+	metricsNamespace = "grafana"
+	metricsSubSystem = "ssosettings"
+)
+
+type metrics struct {
+	reloadFailures *prometheus.CounterVec
+}
+
+func newMetrics(reg prometheus.Registerer) *metrics {
+	m := &metrics{
+		reloadFailures: prometheus.NewCounterVec(prometheus.CounterOpts{
+			Namespace: metricsNamespace,
+			Subsystem: metricsSubSystem,
+			Name:      "setting_reload_failures_total",
+			Help:      "Number of SSO Setting reload failures.",
+		}, []string{"provider"}),
+	}
+
+	if reg != nil {
+		reg.MustRegister(
+			m.reloadFailures,
+		)
+	}
+
+	return m
+}

--- a/pkg/services/ssosettings/ssosettingsimpl/service.go
+++ b/pkg/services/ssosettings/ssosettingsimpl/service.go
@@ -224,7 +224,8 @@ func (s *Service) Delete(ctx context.Context, provider string) error {
 
 	currentSettings, err := s.GetForProvider(ctx, provider)
 	if err != nil {
-		return err
+		s.logger.Error("failed to get current settings, skipping reload", "provider", provider, "error", err)
+		return nil
 	}
 
 	go s.reload(social, provider, *currentSettings)

--- a/pkg/services/ssosettings/ssosettingsimpl/service_test.go
+++ b/pkg/services/ssosettings/ssosettingsimpl/service_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 
@@ -1251,6 +1252,7 @@ func setupTestEnv(t *testing.T) testEnv {
 		ac:           accessControl,
 		fbStrategies: []ssosettings.FallbackStrategy{fallbackStrategy},
 		reloadables:  reloadables,
+		metrics:      newMetrics(prometheus.NewRegistry()),
 		secrets:      secrets,
 	}
 


### PR DESCRIPTION
**What is this feature?**
Reloads the provider configuration from the system after the setting from the DB was removed.

**Why do we need this feature?**


**Who is this feature for?**


**Which issue(s) does this PR fix?**:

Fixes #

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
