### PR TITLE
Alerting: Update docs after moving action buttons im the alert list, and move t…

### DIFF
--- a/docs/sources/alerting/alerting-rules/create-mimir-loki-managed-recording-rule.md
+++ b/docs/sources/alerting/alerting-rules/create-mimir-loki-managed-recording-rule.md
@@ -48,7 +48,7 @@ To create recording rules, follow these steps.
 
 1. Click **Alerts & IRM** -> **Alerting** ->
    **Alert rules**.
-1. Click the **More** dropdown and then **New recording rule**.
+1. Click **New recording rule**.
 
 1. Set rule name.
 

--- a/docs/sources/alerting/manage-notifications/view-alert-rules.md
+++ b/docs/sources/alerting/manage-notifications/view-alert-rules.md
@@ -52,7 +52,7 @@ From the Alert list page, you can also make copies of alert rules to help you re
 
 Click the **Export rule group** icon next to each alert rule group to export to YAML, JSON, or Terraform.
 
-Click **More** -> **Export all Grafana-managed rules** to export all Grafana-managed alert rules to YAML, JSON, or Terraform.
+Click **Export rules** to export all Grafana-managed alert rules to YAML, JSON, or Terraform.
 
 Click **More** -> **Modify export** next to each individual alert rule within a group to edit provisioned alert rules and export a modified version.
 

--- a/docs/sources/alerting/set-up/provision-alerting-resources/view-provisioned-resources/index.md
+++ b/docs/sources/alerting/set-up/provision-alerting-resources/view-provisioned-resources/index.md
@@ -39,7 +39,7 @@ Export your alerting resources, such as alert rules, contact points, and notific
 To export provisioned alerting resources from the Grafana UI, complete the following steps.
 
 1. Click **Alerts & IRM** -> **Alert rules**.
-1. To export all Grafana-managed rules, click **More v** -> **Export all Grafana-managed rules**.
+1. To export all Grafana-managed rules, click **Export rules**.
 1. To export a folder, change the **View as** to **List**.
 1. Select the folder you want to export and click the **Export rules folder** icon.
 1. To export a group, change the **View as** to **Grouped**.

--- a/public/app/features/alerting/unified/components/rules/CloudRules.tsx
+++ b/public/app/features/alerting/unified/components/rules/CloudRules.tsx
@@ -56,16 +56,16 @@ export const CloudRules = ({ namespaces, expandAll }: Props) => {
       <div className={styles.sectionHeader}>
         <div className={styles.headerRow}>
           <h5>Mimir / Cortex / Loki</h5>
+          {dataSourcesLoading.length ? (
+            <LoadingPlaceholder
+              className={styles.loader}
+              text={`Loading rules from ${dataSourcesLoading.length} ${pluralize('source', dataSourcesLoading.length)}`}
+            />
+          ) : (
+            <div />
+          )}
           <CreateRecordingRuleButton />
         </div>
-        {dataSourcesLoading.length ? (
-          <LoadingPlaceholder
-            className={styles.loader}
-            text={`Loading rules from ${dataSourcesLoading.length} ${pluralize('source', dataSourcesLoading.length)}`}
-          />
-        ) : (
-          <div />
-        )}
       </div>
 
       {pageItems.map(({ group, namespace }) => {

--- a/public/app/features/alerting/unified/components/rules/GrafanaRules.tsx
+++ b/public/app/features/alerting/unified/components/rules/GrafanaRules.tsx
@@ -59,6 +59,7 @@ export const GrafanaRules = ({ namespaces, expandAll }: Props) => {
       <div className={styles.sectionHeader}>
         <div className={styles.headerRow}>
           <h5>Grafana</h5>
+          {loading ? <LoadingPlaceholder className={styles.loader} text="Loading..." /> : <div />}
           {hasGrafanaAlerts && canExportRules && (
             <Button
               aria-label="export all grafana rules"
@@ -72,7 +73,6 @@ export const GrafanaRules = ({ namespaces, expandAll }: Props) => {
             </Button>
           )}
         </div>
-        {loading ? <LoadingPlaceholder className={styles.loader} text="Loading..." /> : <div />}
       </div>
 
       {pageItems.map(({ group, namespace }) => (


### PR DESCRIPTION
**What is this feature?**

This PR updates the docs after moving some action buttons in the alert list view.
It also moves some loading spinners that were in the wrong place.

In the new alert list view, the action buttons have been moved:

<img width="1491" alt="Screenshot 2024-01-26 at 14 59 27" src="https://github.com/grafana/grafana/assets/33540275/d5f0d238-30b2-4b59-912e-3232b9c6c1f7">

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
