### PR TITLE
sql: add linting rule for decoupling postgres & mysql

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -96,6 +96,8 @@
     },
     {
       "files": [
+        "public/app/plugins/datasource/grafana-postgresql-datasource/*.{ts,tsx}",
+        "public/app/plugins/datasource/grafana-postgresql-datasource/**/*.{ts,tsx}",
         "public/app/plugins/datasource/grafana-pyroscope-datasource/*.{ts,tsx}",
         "public/app/plugins/datasource/grafana-pyroscope-datasource/**/*.{ts,tsx}",
         "public/app/plugins/datasource/grafana-testdata-datasource/*.{ts,tsx}",
@@ -104,6 +106,8 @@
         "public/app/plugins/datasource/azuremonitor/**/*.{ts,tsx}",
         "public/app/plugins/datasource/cloud-monitoring/*.{ts,tsx}",
         "public/app/plugins/datasource/cloud-monitoring/**/*.{ts,tsx}",
+        "public/app/plugins/datasource/mysql/*.{ts,tsx}",
+        "public/app/plugins/datasource/mysql/**/*.{ts,tsx}",
         "public/app/plugins/datasource/parca/*.{ts,tsx}",
         "public/app/plugins/datasource/parca/**/*.{ts,tsx}",
         "public/app/plugins/datasource/tempo/*.{ts,tsx}",


### PR DESCRIPTION
as part of the decoupling-datasources plugin, it's necessary to add linting rules to make sure plugins do not import from core-grafana.