### PR TITLE
Loki: Use LabelFilters from `@grafana/experimental`

### DIFF
--- a/e2e/various-suite/loki-query-builder.spec.ts
+++ b/e2e/various-suite/loki-query-builder.spec.ts
@@ -66,23 +66,14 @@ describe('Loki query builder', () => {
     cy.contains(MISSING_LABEL_FILTER_ERROR_MESSAGE).should('be.visible');
 
     // Add labels to remove error
-    e2e.components.QueryBuilder.labelSelect().should('be.visible').click();
+    cy.get("[aria-label='Select label']").should('be.visible').click();
     // wait until labels are loaded and set on the component before starting to type
     cy.wait('@labelsRequest');
-    e2e.components.QueryBuilder.labelSelect().children('div').children('input').type('instance{enter}');
-    e2e.components.QueryBuilder.matchOperatorSelect()
-      .should('be.visible')
-      .click()
-      .children('div')
-      .children('input')
-      .type('=~{enter}', { force: true });
-    e2e.components.QueryBuilder.valueSelect().should('be.visible').click();
+    cy.get("[aria-label='Select label']").type('instance{enter}');
+    cy.get("[aria-label='Select match operator'").should('be.visible').click().type('=~{enter}', { force: true });
+    cy.get("[aria-label='Select value'").should('be.visible').click();
     cy.wait('@valuesRequest');
-    e2e.components.QueryBuilder.valueSelect()
-      .children('div')
-      .children('input')
-      .type('instance1{enter}')
-      .type('instance2{enter}');
+    cy.get("[aria-label='Select value'").type('instance1{enter}').type('instance2{enter}');
     cy.contains(MISSING_LABEL_FILTER_ERROR_MESSAGE).should('not.exist');
     cy.contains(finalQuery).should('be.visible');
 

--- a/e2e/various-suite/loki-query-builder.spec.ts
+++ b/e2e/various-suite/loki-query-builder.spec.ts
@@ -70,10 +70,10 @@ describe('Loki query builder', () => {
     // wait until labels are loaded and set on the component before starting to type
     cy.wait('@labelsRequest');
     cy.get("[aria-label='Select label']").type('instance{enter}');
-    cy.get("[aria-label='Select match operator'").should('be.visible').click().type('=~{enter}', { force: true });
-    cy.get("[aria-label='Select value'").should('be.visible').click();
+    cy.get("[aria-label='Select match operator']").should('be.visible').click().type('=~{enter}', { force: true });
+    cy.get("[aria-label='Select value']").should('be.visible').click();
     cy.wait('@valuesRequest');
-    cy.get("[aria-label='Select value'").type('instance1{enter}').type('instance2{enter}');
+    cy.get("[aria-label='Select value']").type('instance1{enter}').type('instance2{enter}');
     cy.contains(MISSING_LABEL_FILTER_ERROR_MESSAGE).should('not.exist');
     cy.contains(finalQuery).should('be.visible');
 

--- a/public/app/plugins/datasource/loki/querybuilder/components/LokiQueryBuilder.tsx
+++ b/public/app/plugins/datasource/loki/querybuilder/components/LokiQueryBuilder.tsx
@@ -3,7 +3,7 @@ import React, { useEffect, useMemo, useState } from 'react';
 import { DataSourceApi, getDefaultTimeRange, LoadingState, PanelData, SelectableValue, TimeRange } from '@grafana/data';
 import {
   EditorRow,
-  // LabelFilters, this is broken in @grafana/experimental so we need to use the one from prometheus
+  LabelFilters,
   OperationExplainedBox,
   OperationList,
   OperationListExplained,
@@ -14,7 +14,6 @@ import {
   QueryBuilderOperation,
 } from '@grafana/experimental';
 import { config } from '@grafana/runtime';
-import { LabelFilters } from 'app/plugins/datasource/prometheus/querybuilder/shared/LabelFilters';
 
 import { testIds } from '../../components/LokiQueryEditor';
 import { LokiDatasource } from '../../datasource';


### PR DESCRIPTION
Fixes https://github.com/grafana/grafana/issues/79929

In this PR we are using fixed `LabelFilters` component that was fixed in https://github.com/grafana/grafana-experimental/pull/109 and released in 1.7.8 which was automatically updated by renovate in https://github.com/grafana/grafana/pull/81370


https://github.com/grafana/grafana/assets/30407135/781f5501-f41e-474a-81f4-e7283b270748

