### PR TITLE
Update pr-codeql-analysis-go.yml to use token

### DIFF
--- a/.github/workflows/pr-codeql-analysis-go.yml
+++ b/.github/workflows/pr-codeql-analysis-go.yml
@@ -16,12 +16,21 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+    - name: "Generate token"
+      id: generate_token
+      continue-on-error: true
+      uses: tibdex/github-app-token@3beb63f4bd073e61482598c45c71c1019b59b73a
+      with:
+        app_id: ${{ secrets.GRAFANA_DELIVERY_BOT_APP_ID }}
+        private_key: ${{ secrets.GRAFANA_DELIVERY_BOT_APP_PEM }}
+
     - name: Checkout repository
       uses: actions/checkout@v4
       with:
         # We must fetch at least the immediate parents so that if this is
         # a pull request then we can checkout the head.
         fetch-depth: 2
+        token: ${{ steps.generate_token.outputs.token }}
 
     - name: Set go version
       uses: actions/setup-go@v4


### PR DESCRIPTION
Updating .github/workflows/pr-codeql-analysis-go.yml to use GH token to work in private security mirror