### PR TITLE
[v10.3.x] RBAC: Annotation permission migration

### DIFF
--- a/pkg/api/accesscontrol.go
+++ b/pkg/api/accesscontrol.go
@@ -606,7 +606,7 @@ func (hs *HTTPServer) declareFixedRoles() error {
 				Group:       "Annotations",
 				Permissions: []ac.Permission{
 					{Action: ac.ActionAnnotationsRead, Scope: ac.ScopeAnnotationsTypeOrganization},
-					{Action: ac.ActionAnnotationsRead, Scope: dashboards.ScopeDashboardsAll},
+					{Action: ac.ActionAnnotationsRead, Scope: dashboards.ScopeFoldersAll},
 				},
 			},
 			Grants: []string{string(org.RoleAdmin)},
@@ -620,11 +620,11 @@ func (hs *HTTPServer) declareFixedRoles() error {
 				Group:       "Annotations",
 				Permissions: []ac.Permission{
 					{Action: ac.ActionAnnotationsCreate, Scope: ac.ScopeAnnotationsTypeOrganization},
-					{Action: ac.ActionAnnotationsCreate, Scope: dashboards.ScopeDashboardsAll},
+					{Action: ac.ActionAnnotationsCreate, Scope: dashboards.ScopeFoldersAll},
 					{Action: ac.ActionAnnotationsDelete, Scope: ac.ScopeAnnotationsTypeOrganization},
-					{Action: ac.ActionAnnotationsDelete, Scope: dashboards.ScopeDashboardsAll},
+					{Action: ac.ActionAnnotationsDelete, Scope: dashboards.ScopeFoldersAll},
 					{Action: ac.ActionAnnotationsWrite, Scope: ac.ScopeAnnotationsTypeOrganization},
-					{Action: ac.ActionAnnotationsWrite, Scope: dashboards.ScopeDashboardsAll},
+					{Action: ac.ActionAnnotationsWrite, Scope: dashboards.ScopeFoldersAll},
 				},
 			},
 			Grants: []string{string(org.RoleAdmin)},

--- a/pkg/services/accesscontrol/ossaccesscontrol/permissions_services.go
+++ b/pkg/services/accesscontrol/ossaccesscontrol/permissions_services.go
@@ -116,6 +116,27 @@ var DashboardViewActions = []string{dashboards.ActionDashboardsRead}
 var DashboardEditActions = append(DashboardViewActions, []string{dashboards.ActionDashboardsWrite, dashboards.ActionDashboardsDelete}...)
 var DashboardAdminActions = append(DashboardEditActions, []string{dashboards.ActionDashboardsPermissionsRead, dashboards.ActionDashboardsPermissionsWrite}...)
 
+func getDashboardViewActions(features featuremgmt.FeatureToggles) []string {
+	if features.IsEnabled(context.Background(), featuremgmt.FlagAnnotationPermissionUpdate) {
+		return append(DashboardViewActions, accesscontrol.ActionAnnotationsRead)
+	}
+	return DashboardViewActions
+}
+
+func getDashboardEditActions(features featuremgmt.FeatureToggles) []string {
+	if features.IsEnabled(context.Background(), featuremgmt.FlagAnnotationPermissionUpdate) {
+		return append(DashboardEditActions, []string{accesscontrol.ActionAnnotationsRead, accesscontrol.ActionAnnotationsWrite, accesscontrol.ActionAnnotationsDelete, accesscontrol.ActionAnnotationsCreate}...)
+	}
+	return DashboardEditActions
+}
+
+func getDashboardAdminActions(features featuremgmt.FeatureToggles) []string {
+	if features.IsEnabled(context.Background(), featuremgmt.FlagAnnotationPermissionUpdate) {
+		return append(DashboardAdminActions, []string{accesscontrol.ActionAnnotationsRead, accesscontrol.ActionAnnotationsWrite, accesscontrol.ActionAnnotationsDelete, accesscontrol.ActionAnnotationsCreate}...)
+	}
+	return DashboardAdminActions
+}
+
 func ProvideDashboardPermissions(
 	features featuremgmt.FeatureToggles, router routing.RouteRegister, sql db.DB, ac accesscontrol.AccessControl,
 	license licensing.Licensing, dashboardStore dashboards.Store, folderService folder.Service, service accesscontrol.Service,
@@ -174,9 +195,9 @@ func ProvideDashboardPermissions(
 			ServiceAccounts: true,
 		},
 		PermissionsToActions: map[string][]string{
-			"View":  DashboardViewActions,
-			"Edit":  DashboardEditActions,
-			"Admin": DashboardAdminActions,
+			"View":  getDashboardViewActions(features),
+			"Edit":  getDashboardEditActions(features),
+			"Admin": getDashboardAdminActions(features),
 		},
 		ReaderRoleName: "Dashboard permission reader",
 		WriterRoleName: "Dashboard permission writer",
@@ -239,9 +260,9 @@ func ProvideFolderPermissions(
 			ServiceAccounts: true,
 		},
 		PermissionsToActions: map[string][]string{
-			"View":  append(DashboardViewActions, FolderViewActions...),
-			"Edit":  append(DashboardEditActions, FolderEditActions...),
-			"Admin": append(DashboardAdminActions, FolderAdminActions...),
+			"View":  append(getDashboardViewActions(features), FolderViewActions...),
+			"Edit":  append(getDashboardEditActions(features), FolderEditActions...),
+			"Admin": append(getDashboardAdminActions(features), FolderAdminActions...),
 		},
 		ReaderRoleName: "Folder permission reader",
 		WriterRoleName: "Folder permission writer",

--- a/pkg/services/sqlstore/migrations/accesscontrol/test/ac_test.go
+++ b/pkg/services/sqlstore/migrations/accesscontrol/test/ac_test.go
@@ -262,6 +262,9 @@ func setupTestDB(t *testing.T) *xorm.Engine {
 	mg := migrator.NewMigrator(x, &setting.Cfg{
 		Logger: log.New("acmigration.test"),
 		Raw:    ini.Empty(),
+		IsFeatureToggleEnabled: func(key string) bool {
+			return true
+		},
 	})
 	migrations := &migrations.OSSMigrations{}
 	migrations.AddMigration(mg)

--- a/pkg/services/sqlstore/migrations/accesscontrol/test/dashbord_permission_migrator_test.go
+++ b/pkg/services/sqlstore/migrations/accesscontrol/test/dashbord_permission_migrator_test.go
@@ -1,0 +1,335 @@
+package test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/grafana/pkg/infra/log"
+	"github.com/grafana/grafana/pkg/services/accesscontrol"
+	"github.com/grafana/grafana/pkg/services/dashboards"
+	acmig "github.com/grafana/grafana/pkg/services/sqlstore/migrations/accesscontrol"
+	"github.com/grafana/grafana/pkg/services/sqlstore/migrator"
+	"github.com/grafana/grafana/pkg/setting"
+)
+
+type testCase struct {
+	desc          string
+	putRolePerms  map[int64]map[string][]rawPermission
+	wantRolePerms map[int64]map[string][]rawPermission
+}
+
+func testCases() []testCase {
+	allAnnotationPermissions := []rawPermission{
+		{Action: accesscontrol.ActionAnnotationsRead, Scope: accesscontrol.ScopeAnnotationsTypeDashboard},
+		{Action: accesscontrol.ActionAnnotationsCreate, Scope: accesscontrol.ScopeAnnotationsTypeDashboard},
+		{Action: accesscontrol.ActionAnnotationsDelete, Scope: accesscontrol.ScopeAnnotationsTypeDashboard},
+		{Action: accesscontrol.ActionAnnotationsWrite, Scope: accesscontrol.ScopeAnnotationsTypeDashboard},
+	}
+
+	onlyOrgAnnotations := []rawPermission{
+		{Action: accesscontrol.ActionAnnotationsRead, Scope: accesscontrol.ScopeAnnotationsTypeOrganization},
+		{Action: accesscontrol.ActionAnnotationsCreate, Scope: accesscontrol.ScopeAnnotationsTypeOrganization},
+		{Action: accesscontrol.ActionAnnotationsDelete, Scope: accesscontrol.ScopeAnnotationsTypeOrganization},
+		{Action: accesscontrol.ActionAnnotationsWrite, Scope: accesscontrol.ScopeAnnotationsTypeOrganization},
+	}
+
+	wildcardAnnotationPermissions := []rawPermission{
+		{Action: accesscontrol.ActionAnnotationsRead, Scope: "*"},
+		{Action: accesscontrol.ActionAnnotationsCreate, Scope: "annotations:*"},
+		{Action: accesscontrol.ActionAnnotationsDelete, Scope: "annotations:type:*"},
+		{Action: accesscontrol.ActionAnnotationsWrite, Scope: accesscontrol.ScopeAnnotationsAll},
+	}
+
+	return []testCase{
+		{
+			desc:          "empty permissions lead to empty permissions",
+			putRolePerms:  map[int64]map[string][]rawPermission{},
+			wantRolePerms: map[int64]map[string][]rawPermission{},
+		},
+		{
+			desc: "adds new permissions for instances without basic roles (should only be OSS instances)",
+			putRolePerms: map[int64]map[string][]rawPermission{
+				1: {
+					"managed:users:1:permissions": {{Action: dashboards.ActionDashboardsRead, Scope: "dashboards:uid:test"}},
+				},
+			},
+			wantRolePerms: map[int64]map[string][]rawPermission{
+				1: {
+					"managed:users:1:permissions": {
+						{Action: dashboards.ActionDashboardsRead, Scope: "dashboards:uid:test"},
+						{Action: accesscontrol.ActionAnnotationsRead, Scope: "dashboards:uid:test"},
+					},
+				},
+			},
+		},
+		{
+			desc: "doesn't add any new permissions if has default annotation permissions on basic roles but no dashboard or folder permissions",
+			putRolePerms: map[int64]map[string][]rawPermission{
+				1: {
+					"basic:viewer": allAnnotationPermissions,
+					"basic:editor": allAnnotationPermissions,
+					"basic:admin":  allAnnotationPermissions,
+				},
+			},
+			wantRolePerms: map[int64]map[string][]rawPermission{
+				1: {
+					"basic:viewer": allAnnotationPermissions,
+					"basic:editor": allAnnotationPermissions,
+					"basic:admin":  allAnnotationPermissions,
+				},
+			},
+		},
+		{
+			desc: "adds new permissions if has default annotation permissions on basic roles and dashboard read permissions",
+			putRolePerms: map[int64]map[string][]rawPermission{
+				1: {
+					"basic:viewer":                allAnnotationPermissions,
+					"basic:editor":                allAnnotationPermissions,
+					"basic:admin":                 allAnnotationPermissions,
+					"managed:users:1:permissions": {{Action: dashboards.ActionDashboardsRead, Scope: "dashboards:uid:test"}},
+				},
+			},
+			wantRolePerms: map[int64]map[string][]rawPermission{
+				1: {
+					"basic:viewer": allAnnotationPermissions,
+					"basic:editor": allAnnotationPermissions,
+					"basic:admin":  allAnnotationPermissions,
+					"managed:users:1:permissions": {
+						{Action: dashboards.ActionDashboardsRead, Scope: "dashboards:uid:test"},
+						{Action: accesscontrol.ActionAnnotationsRead, Scope: "dashboards:uid:test"},
+					},
+				},
+			},
+		},
+		{
+			desc: "adds new permissions if has default annotation permissions on basic roles and dashboard write permissions",
+			putRolePerms: map[int64]map[string][]rawPermission{
+				1: {
+					"basic:viewer": allAnnotationPermissions,
+					"basic:editor": allAnnotationPermissions,
+					"basic:admin":  allAnnotationPermissions,
+					"managed:users:1:permissions": {
+						{Action: dashboards.ActionDashboardsWrite, Scope: "dashboards:uid:test"},
+						{Action: dashboards.ActionDashboardsRead, Scope: "dashboards:uid:test"},
+					},
+				},
+			},
+			wantRolePerms: map[int64]map[string][]rawPermission{
+				1: {
+					"basic:viewer": allAnnotationPermissions,
+					"basic:editor": allAnnotationPermissions,
+					"basic:admin":  allAnnotationPermissions,
+					"managed:users:1:permissions": {
+						{Action: dashboards.ActionDashboardsWrite, Scope: "dashboards:uid:test"},
+						{Action: dashboards.ActionDashboardsRead, Scope: "dashboards:uid:test"},
+						{Action: accesscontrol.ActionAnnotationsRead, Scope: "dashboards:uid:test"},
+						{Action: accesscontrol.ActionAnnotationsWrite, Scope: "dashboards:uid:test"},
+						{Action: accesscontrol.ActionAnnotationsDelete, Scope: "dashboards:uid:test"},
+						{Action: accesscontrol.ActionAnnotationsCreate, Scope: "dashboards:uid:test"},
+					},
+				},
+			},
+		},
+		{
+			desc: "adds new permissions if has default annotation permissions on basic roles and folder read permissions",
+			putRolePerms: map[int64]map[string][]rawPermission{
+				1: {
+					"basic:viewer":                allAnnotationPermissions,
+					"basic:editor":                allAnnotationPermissions,
+					"basic:admin":                 allAnnotationPermissions,
+					"managed:users:1:permissions": {{Action: dashboards.ActionDashboardsRead, Scope: "folders:uid:test"}},
+				},
+			},
+			wantRolePerms: map[int64]map[string][]rawPermission{
+				1: {
+					"basic:viewer": allAnnotationPermissions,
+					"basic:editor": allAnnotationPermissions,
+					"basic:admin":  allAnnotationPermissions,
+					"managed:users:1:permissions": {
+						{Action: dashboards.ActionDashboardsRead, Scope: "folders:uid:test"},
+						{Action: accesscontrol.ActionAnnotationsRead, Scope: "folders:uid:test"},
+					},
+				},
+			},
+		},
+		{
+			desc: "adds new permissions if has default annotation permissions on basic roles and folder write permissions",
+			putRolePerms: map[int64]map[string][]rawPermission{
+				1: {
+					"basic:viewer": allAnnotationPermissions,
+					"basic:editor": allAnnotationPermissions,
+					"basic:admin":  allAnnotationPermissions,
+					"managed:users:1:permissions": {
+						{Action: dashboards.ActionDashboardsWrite, Scope: "folders:uid:test"},
+						{Action: dashboards.ActionDashboardsRead, Scope: "folders:uid:test"},
+					},
+				},
+			},
+			wantRolePerms: map[int64]map[string][]rawPermission{
+				1: {
+					"basic:viewer": allAnnotationPermissions,
+					"basic:editor": allAnnotationPermissions,
+					"basic:admin":  allAnnotationPermissions,
+					"managed:users:1:permissions": {
+						{Action: dashboards.ActionDashboardsWrite, Scope: "folders:uid:test"},
+						{Action: dashboards.ActionDashboardsRead, Scope: "folders:uid:test"},
+						{Action: accesscontrol.ActionAnnotationsRead, Scope: "folders:uid:test"},
+						{Action: accesscontrol.ActionAnnotationsWrite, Scope: "folders:uid:test"},
+						{Action: accesscontrol.ActionAnnotationsDelete, Scope: "folders:uid:test"},
+						{Action: accesscontrol.ActionAnnotationsCreate, Scope: "folders:uid:test"},
+					},
+				},
+			},
+		},
+		{
+			desc: "adds new permissions to several managed roles if has default annotation permissions on basic roles and dashboard read permissions",
+			putRolePerms: map[int64]map[string][]rawPermission{
+				1: {
+					"basic:viewer":                allAnnotationPermissions,
+					"basic:editor":                allAnnotationPermissions,
+					"basic:admin":                 allAnnotationPermissions,
+					"managed:users:1:permissions": {{Action: dashboards.ActionDashboardsRead, Scope: "dashboards:uid:test"}},
+					"managed:teams:1:permissions": {{Action: dashboards.ActionDashboardsRead, Scope: "dashboards:uid:test2"}},
+				},
+			},
+			wantRolePerms: map[int64]map[string][]rawPermission{
+				1: {
+					"basic:viewer": allAnnotationPermissions,
+					"basic:editor": allAnnotationPermissions,
+					"basic:admin":  allAnnotationPermissions,
+					"managed:users:1:permissions": {
+						{Action: dashboards.ActionDashboardsRead, Scope: "dashboards:uid:test"},
+						{Action: accesscontrol.ActionAnnotationsRead, Scope: "dashboards:uid:test"},
+					},
+					"managed:teams:1:permissions": {
+						{Action: dashboards.ActionDashboardsRead, Scope: "dashboards:uid:test2"},
+						{Action: accesscontrol.ActionAnnotationsRead, Scope: "dashboards:uid:test2"},
+					},
+				},
+			},
+		},
+		{
+			desc: "doesn't add any new permissions if annotation permissions are missing from the basic roles",
+			putRolePerms: map[int64]map[string][]rawPermission{
+				1: {
+					"basic:editor": allAnnotationPermissions,
+					"basic:admin":  allAnnotationPermissions,
+					"managed:users:1:permissions": {
+						{Action: dashboards.ActionDashboardsWrite, Scope: "dashboards:uid:test"},
+						{Action: dashboards.ActionDashboardsRead, Scope: "dashboards:uid:test"},
+					},
+				},
+			},
+			wantRolePerms: map[int64]map[string][]rawPermission{
+				1: {
+					"basic:editor": allAnnotationPermissions,
+					"basic:admin":  allAnnotationPermissions,
+				},
+			},
+		},
+		{
+			desc: "doesn't add any new permissions if annotation permissions from the basic roles don't have the dashboard scope",
+			putRolePerms: map[int64]map[string][]rawPermission{
+				1: {
+					"basic:viewer": onlyOrgAnnotations,
+					"basic:editor": allAnnotationPermissions,
+					"basic:admin":  allAnnotationPermissions,
+					"managed:users:1:permissions": {
+						{Action: dashboards.ActionDashboardsWrite, Scope: "dashboards:uid:test"},
+						{Action: dashboards.ActionDashboardsRead, Scope: "dashboards:uid:test"},
+					},
+				},
+			},
+			wantRolePerms: map[int64]map[string][]rawPermission{
+				1: {
+					"basic:viewer": onlyOrgAnnotations,
+					"basic:editor": allAnnotationPermissions,
+					"basic:admin":  allAnnotationPermissions,
+				},
+			},
+		},
+		{
+			desc: "adds new permissions if has default annotation permissions with different wildcard scopes",
+			putRolePerms: map[int64]map[string][]rawPermission{
+				1: {
+					"basic:viewer":                wildcardAnnotationPermissions,
+					"basic:editor":                wildcardAnnotationPermissions,
+					"basic:admin":                 wildcardAnnotationPermissions,
+					"managed:users:1:permissions": {{Action: dashboards.ActionDashboardsRead, Scope: "dashboards:uid:test"}},
+				},
+			},
+			wantRolePerms: map[int64]map[string][]rawPermission{
+				1: {
+					"basic:viewer": wildcardAnnotationPermissions,
+					"basic:editor": wildcardAnnotationPermissions,
+					"basic:admin":  wildcardAnnotationPermissions,
+					"managed:users:1:permissions": {
+						{Action: dashboards.ActionDashboardsRead, Scope: "dashboards:uid:test"},
+						{Action: accesscontrol.ActionAnnotationsRead, Scope: "dashboards:uid:test"},
+					},
+				},
+			},
+		},
+	}
+}
+
+func TestAnnotationActionMigration(t *testing.T) {
+	// Run initial migration to have a working DB
+	x := setupTestDB(t)
+
+	for _, tc := range testCases() {
+		t.Run(tc.desc, func(t *testing.T) {
+			// Remove migration
+			_, errDeleteMig := x.Exec(`DELETE FROM migration_log WHERE migration_id LIKE ?`, acmig.ManagedDashboardAnnotationActionsMigratorID)
+			require.NoError(t, errDeleteMig)
+			_, errDeletePerm := x.Exec(`DELETE FROM permission`)
+			require.NoError(t, errDeletePerm)
+			_, errDeleteRole := x.Exec(`DELETE FROM role`)
+			require.NoError(t, errDeleteRole)
+
+			// Test running the migrations twice to make sure they don't conflict
+			for i := 0; i < 2; i++ {
+				if i == 0 {
+					// put permissions
+					putTestPermissions(t, x, tc.putRolePerms)
+				}
+
+				// Run accesscontrol migration (permissions insertion should not have conflicted)
+				acmigrator := migrator.NewMigrator(x, &setting.Cfg{Logger: log.New("acmigration.test")})
+				acmig.AddManagedDashboardAnnotationActionsMigration(acmigrator)
+
+				errRunningMig := acmigrator.Start(false, 0)
+				require.NoError(t, errRunningMig)
+
+				// verify got == want
+				for orgID, roles := range tc.wantRolePerms {
+					for roleName := range roles {
+						// Check managed roles exist
+						role := accesscontrol.Role{}
+						hasRole, errRoleSearch := x.Table("role").Where("org_id = ? AND name = ?", orgID, roleName).Get(&role)
+
+						require.NoError(t, errRoleSearch)
+						require.True(t, hasRole, "expected role to exist", "orgID", orgID, "role", roleName)
+
+						// Check permissions associated with each role
+						perms := []accesscontrol.Permission{}
+						count, errManagedPermsSearch := x.Table("permission").Where("role_id = ?", role.ID).FindAndCount(&perms)
+
+						require.NoError(t, errManagedPermsSearch)
+						require.Equal(t, int64(len(tc.wantRolePerms[orgID][roleName])), count, "expected role to be tied to permissions", "orgID", orgID, "role", roleName)
+
+						gotRawPerms := convertToRawPermissions(perms)
+						require.ElementsMatch(t, gotRawPerms, tc.wantRolePerms[orgID][roleName], "expected role to have permissions", "orgID", orgID, "role", roleName)
+
+						// Check assignment of the roles
+						br := accesscontrol.BuiltinRole{}
+						has, errAssignmentSearch := x.Table("builtin_role").Where("role_id = ? AND role = ? AND org_id = ?", role.ID, acmig.ParseRoleFromName(roleName), orgID).Get(&br)
+						require.NoError(t, errAssignmentSearch)
+						require.True(t, has, "expected assignment of role to builtin role", "orgID", orgID, "role", roleName)
+					}
+				}
+			}
+		})
+	}
+}

--- a/pkg/services/sqlstore/migrations/accesscontrol/test/managed_permission_migrator_test.go
+++ b/pkg/services/sqlstore/migrations/accesscontrol/test/managed_permission_migrator_test.go
@@ -2,7 +2,6 @@ package test
 
 import (
 	"fmt"
-	"strconv"
 	"strings"
 	"testing"
 
@@ -256,7 +255,10 @@ func TestManagedPermissionsMigrationRunTwice(t *testing.T) {
 func putTestPermissions(t *testing.T, x *xorm.Engine, rolePerms map[int64]map[string][]rawPermission) {
 	for orgID, roles := range rolePerms {
 		for roleName, perms := range roles {
-			uid := strconv.FormatInt(orgID, 10) + strings.ReplaceAll(roleName, ":", "_")
+			uid := strings.ReplaceAll(roleName, ":", "_")
+			if !strings.HasPrefix(roleName, "basic") {
+				uid = fmt.Sprintf("%d_%s", orgID, uid)
+			}
 			role := accesscontrol.Role{
 				OrgID:   orgID,
 				Version: 1,

--- a/pkg/services/sqlstore/migrations/migrations.go
+++ b/pkg/services/sqlstore/migrations/migrations.go
@@ -113,6 +113,15 @@ func (*OSSMigrations) AddMigration(mg *Migrator) {
 	ssosettings.AddMigration(mg)
 
 	ualert.CreateOrgMigratedKVStoreEntries(mg)
+
+	// https://github.com/grafana/identity-access-team/issues/546: tracks removal of the feature toggle from the annotation permission migration
+	// nolint:staticcheck
+	if mg.Cfg != nil && mg.Cfg.IsFeatureToggleEnabled != nil {
+		// nolint:staticcheck
+		if mg.Cfg.IsFeatureToggleEnabled(featuremgmt.FlagAnnotationPermissionUpdate) {
+			accesscontrol.AddManagedDashboardAnnotationActionsMigration(mg)
+		}
+	}
 }
 
 func addStarMigrations(mg *Migrator) {


### PR DESCRIPTION
Backport 048d1e7c861c419c7b2522429b654cc17a9c903b from #78899

---

**What is this feature?**

This PR: 
* adds annotation permissions to dashboard and folder managed permissions;
* adds migrations for annotation permissions.

The migrations are described in more detail [here](https://docs.google.com/document/d/1MG6mu-ycLhdW2lv0KVJmqBl_c3ox0CQ-lzuNHv3ulvQ/edit#heading=h.v4s92i509ph1).

**Why do we need this feature?**

To decouple annotation permissions from dashboard permissions.

**Who is this feature for?**

RBAC users

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes https://github.com/grafana/identity-access-team/issues/495
Fixes https://github.com/grafana/identity-access-team/issues/481

**Special notes for your reviewer:**

Some things to consider:
* currently this migration will run every time an instance is restarted - this is to avoid breaking permissions in upgrade -> downgrade -> upgrade scenario. However, I do worry that this might slow the start up down for large instances or cause performance issues for HG instances if many of them are restarted at the same time;
* currently we don't migrate permissions assigned through custom roles. I opted for not doing it, as this might cause confusion for users who use provisioning. But we could add migrations for custom roles if preferred.
