### PR TITLE
Grafana Build: fix release process not publishing latest storybook

### DIFF
--- a/pkg/build/cmd/publishstorybook.go
+++ b/pkg/build/cmd/publishstorybook.go
@@ -39,7 +39,7 @@ func PublishStorybookAction(c *cli.Context) error {
 		return err
 	}
 
-	if latest, err := isLatest(cfg); err != nil && latest {
+	if latest, err := isLatest(cfg); err == nil && latest {
 		log.Printf("Copying storybooks to latest...")
 		if err := gcs.CopyRemoteDir(c.Context, gcs.Bucket(cfg.srcBucket), fmt.Sprintf("artifacts/storybook/v%s", cfg.tag), bucket, "latest"); err != nil {
 			return err


### PR DESCRIPTION
**Which issue(s) does this PR fix?**:
https://github.com/grafana/grafana-release/issues/877

"the storybook at [/latest](https://developers.grafana.com/ui/latest/index.html) is very out of date. despite 10.3.0 just being released, this is a version from at least <10.1.0. compare to [/canary](https://developers.grafana.com/ui/canary/index.html)"