### PR TITLE
Add test for `TemporaryAlert`

### DIFF
--- a/packages/grafana-o11y-ds-frontend/src/TemporaryAlert.test.tsx
+++ b/packages/grafana-o11y-ds-frontend/src/TemporaryAlert.test.tsx
@@ -4,15 +4,15 @@ import React from 'react';
 import { TemporaryAlert } from './TemporaryAlert';
 
 describe('TemporaryAlert', () => {
-  it('full life cycle', async () => {
-    render(<TemporaryAlert severity="error" text="" />);
+  it('full component life cycle', async () => {
+    render(<TemporaryAlert duration={1000} severity="error" text="" />);
     expect(screen.queryByTestId('data-testid Alert error')).not.toBeInTheDocument();
 
-    render(<TemporaryAlert severity="error" text="error message" />);
+    render(<TemporaryAlert duration={1000} severity="error" text="error message" />);
     expect(screen.queryByTestId('data-testid Alert error')).toBeInTheDocument();
     expect(screen.getByText('error message')).toBeInTheDocument();
 
-    await act(() => new Promise((_) => setTimeout(_, 7500)));
+    await act(() => new Promise((_) => setTimeout(_, 1000)));
     expect(screen.queryByTestId('data-testid Alert error')).not.toBeInTheDocument();
     expect(screen.queryByText('error message')).not.toBeInTheDocument();
   });

--- a/packages/grafana-o11y-ds-frontend/src/TemporaryAlert.test.tsx
+++ b/packages/grafana-o11y-ds-frontend/src/TemporaryAlert.test.tsx
@@ -8,12 +8,12 @@ describe('TemporaryAlert', () => {
     render(<TemporaryAlert duration={1000} severity="error" text="" />);
     expect(screen.queryByTestId('data-testid Alert error')).not.toBeInTheDocument();
 
-    render(<TemporaryAlert duration={1000} severity="error" text="error message" />);
+    render(<TemporaryAlert duration={1000} severity="error" text="Error message" />);
     expect(screen.queryByTestId('data-testid Alert error')).toBeInTheDocument();
-    expect(screen.getByText('error message')).toBeInTheDocument();
+    expect(screen.getByText('Error message')).toBeInTheDocument();
 
     await act(() => new Promise((_) => setTimeout(_, 1000)));
     expect(screen.queryByTestId('data-testid Alert error')).not.toBeInTheDocument();
-    expect(screen.queryByText('error message')).not.toBeInTheDocument();
+    expect(screen.queryByText('Error message')).not.toBeInTheDocument();
   });
 });

--- a/packages/grafana-o11y-ds-frontend/src/TemporaryAlert.test.tsx
+++ b/packages/grafana-o11y-ds-frontend/src/TemporaryAlert.test.tsx
@@ -18,7 +18,7 @@ describe('TemporaryAlert', () => {
     expect(screen.queryByTestId('data-testid Alert error')).not.toBeInTheDocument();
 
     render(<TemporaryAlert severity="error" text="Error message" />);
-    expect(screen.queryByTestId('data-testid Alert error')).toBeInTheDocument();
+    expect(screen.getByTestId('data-testid Alert error')).toBeInTheDocument();
     expect(screen.getByText('Error message')).toBeInTheDocument();
 
     act(() => jest.runAllTimers());

--- a/packages/grafana-o11y-ds-frontend/src/TemporaryAlert.test.tsx
+++ b/packages/grafana-o11y-ds-frontend/src/TemporaryAlert.test.tsx
@@ -4,15 +4,24 @@ import React from 'react';
 import { TemporaryAlert } from './TemporaryAlert';
 
 describe('TemporaryAlert', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.runOnlyPendingTimers();
+    jest.useRealTimers();
+  });
+
   it('full component life cycle', async () => {
-    render(<TemporaryAlert duration={1000} severity="error" text="" />);
+    render(<TemporaryAlert severity="error" text="" />);
     expect(screen.queryByTestId('data-testid Alert error')).not.toBeInTheDocument();
 
-    render(<TemporaryAlert duration={1000} severity="error" text="Error message" />);
+    render(<TemporaryAlert severity="error" text="Error message" />);
     expect(screen.queryByTestId('data-testid Alert error')).toBeInTheDocument();
     expect(screen.getByText('Error message')).toBeInTheDocument();
 
-    await act(() => new Promise((_) => setTimeout(_, 1000)));
+    act(() => jest.runAllTimers());
     expect(screen.queryByTestId('data-testid Alert error')).not.toBeInTheDocument();
     expect(screen.queryByText('Error message')).not.toBeInTheDocument();
   });

--- a/packages/grafana-o11y-ds-frontend/src/TemporaryAlert.test.tsx
+++ b/packages/grafana-o11y-ds-frontend/src/TemporaryAlert.test.tsx
@@ -1,0 +1,19 @@
+import { act, render, screen } from '@testing-library/react';
+import React from 'react';
+
+import { TemporaryAlert } from './TemporaryAlert';
+
+describe('TemporaryAlert', () => {
+  it('full life cycle', async () => {
+    render(<TemporaryAlert severity="error" text="" />);
+    expect(screen.queryByTestId('data-testid Alert error')).not.toBeInTheDocument();
+
+    render(<TemporaryAlert severity="error" text="error message" />);
+    expect(screen.queryByTestId('data-testid Alert error')).toBeInTheDocument();
+    expect(screen.getByText('error message')).toBeInTheDocument();
+
+    await act(() => new Promise((_) => setTimeout(_, 7500)));
+    expect(screen.queryByTestId('data-testid Alert error')).not.toBeInTheDocument();
+    expect(screen.queryByText('error message')).not.toBeInTheDocument();
+  });
+});

--- a/packages/grafana-o11y-ds-frontend/src/TemporaryAlert.tsx
+++ b/packages/grafana-o11y-ds-frontend/src/TemporaryAlert.tsx
@@ -28,8 +28,6 @@ const timeoutMap = {
 };
 
 type AlertProps = {
-  // Custom duration of the alert. If not provided a default duration, dependent on the severity, is used
-  duration?: number;
   // Severity of the alert. Controls the style of the alert (e.g., background color)
   severity: AlertVariant;
   // Displayed message. If set to empty string, the alert is not displayed
@@ -55,10 +53,10 @@ export const TemporaryAlert = (props: AlertProps) => {
 
       const timer = setTimeout(() => {
         setVisible(false);
-      }, props.duration || timeoutMap[props.severity]);
+      }, timeoutMap[props.severity]);
       setTimer(timer);
     }
-  }, [props.duration, props.severity, props.text]);
+  }, [props.severity, props.text]);
 
   return <>{visible && <Alert className={style} elevated={true} title={props.text} severity={props.severity} />}</>;
 };

--- a/packages/grafana-o11y-ds-frontend/src/TemporaryAlert.tsx
+++ b/packages/grafana-o11y-ds-frontend/src/TemporaryAlert.tsx
@@ -27,7 +27,7 @@ const timeoutMap = {
   ['warning']: AlertTimeout.Warning,
 };
 
-export const TemporaryAlert = (props: { severity: AlertVariant; text: string }) => {
+export const TemporaryAlert = (props: { duration?: number; severity: AlertVariant; text: string }) => {
   const style = getStyle(useTheme2());
   const [visible, setVisible] = useState(false);
   const [timer, setTimer] = useState<NodeJS.Timeout>();
@@ -46,10 +46,10 @@ export const TemporaryAlert = (props: { severity: AlertVariant; text: string }) 
 
       const timer = setTimeout(() => {
         setVisible(false);
-      }, timeoutMap[props.severity]);
+      }, props.duration || timeoutMap[props.severity]);
       setTimer(timer);
     }
-  }, [props.severity, props.text]);
+  }, [props.duration, props.severity, props.text]);
 
   return <>{visible && <Alert className={style} elevated={true} title={props.text} severity={props.severity} />}</>;
 };

--- a/packages/grafana-o11y-ds-frontend/src/TemporaryAlert.tsx
+++ b/packages/grafana-o11y-ds-frontend/src/TemporaryAlert.tsx
@@ -27,7 +27,16 @@ const timeoutMap = {
   ['warning']: AlertTimeout.Warning,
 };
 
-export const TemporaryAlert = (props: { duration?: number; severity: AlertVariant; text: string }) => {
+type AlertProps = {
+  // Custom duration of the alert. If not provided a default duration, dependent on the severity, is used
+  duration?: number;
+  // Severity of the alert. Controls the style of the alert (e.g., background color)
+  severity: AlertVariant;
+  // Displayed message. If set to empty string, the alert is not displayed
+  text: string;
+};
+
+export const TemporaryAlert = (props: AlertProps) => {
   const style = getStyle(useTheme2());
   const [visible, setVisible] = useState(false);
   const [timer, setTimer] = useState<NodeJS.Timeout>();


### PR DESCRIPTION
Add a test to cover `TemporaryAlert`. Let me know if we prefer to break it into smaller tests or if we prefer a different approach in testing it (e.g., trying to mock the timeout duration instead of passing a custom value).