### PR TITLE
Prometheus: Only use the series endpoint in the metrics browser

### DIFF
--- a/public/app/plugins/datasource/prometheus/components/PrometheusMetricsBrowser.test.tsx
+++ b/public/app/plugins/datasource/prometheus/components/PrometheusMetricsBrowser.test.tsx
@@ -114,7 +114,13 @@ describe('PrometheusMetricsBrowser', () => {
         }
         return [];
       },
-      fetchLabelsWithMatch: (selector: string) => {
+      // This must always call the series endpoint 
+      // until we refactor all of the metrics browser
+      // to never use the series endpoint.
+      // The metrics browser expects both label names and label values.
+      // The labels endpoint with match does not supply label values 
+      // and so using it breaks the metrics browser.
+      fetchSeriesLabels: (selector: string) => {
         switch (selector) {
           case '{label1="value1-1"}':
             return { label1: ['value1-1'], label2: ['value2-1'], label3: ['value3-1'] };

--- a/public/app/plugins/datasource/prometheus/components/PrometheusMetricsBrowser.test.tsx
+++ b/public/app/plugins/datasource/prometheus/components/PrometheusMetricsBrowser.test.tsx
@@ -114,11 +114,11 @@ describe('PrometheusMetricsBrowser', () => {
         }
         return [];
       },
-      // This must always call the series endpoint 
+      // This must always call the series endpoint
       // until we refactor all of the metrics browser
       // to never use the series endpoint.
       // The metrics browser expects both label names and label values.
-      // The labels endpoint with match does not supply label values 
+      // The labels endpoint with match does not supply label values
       // and so using it breaks the metrics browser.
       fetchSeriesLabels: (selector: string) => {
         switch (selector) {

--- a/public/app/plugins/datasource/prometheus/components/PrometheusMetricsBrowser.tsx
+++ b/public/app/plugins/datasource/prometheus/components/PrometheusMetricsBrowser.tsx
@@ -415,7 +415,7 @@ export class UnthemedPrometheusMetricsBrowser extends React.Component<BrowserPro
       this.updateLabelState(lastFacetted, { loading: true }, `Facetting labels for ${selector}`);
     }
     try {
-      const possibleLabels = await languageProvider.fetchLabelsWithMatch(selector, true);
+      const possibleLabels = await languageProvider.fetchSeriesLabels(selector, true);
       // If selector changed, clear loading state and discard result by returning early
       if (selector !== buildSelector(this.state.labels)) {
         if (lastFacetted) {


### PR DESCRIPTION
What is this bug fix?


https://github.com/grafana/grafana/assets/25674746/25c00a8f-4d1e-40a5-a025-98984226d9f2



https://github.com/grafana/grafana/pull/80774 introduced a bug in the metrics browser by refactoring all calls to the labels endpoint to use 'api/v1/labels' if match is supported or 'api/v1/series' if not. The metrics browser only supports the series endpoint. 

We have a plan to remove the series endpoint from the metrics browser but do not currently have the resources to refactor it in our squad. Therefore, we are making this bug fix by using the series endpoint again.

**Special notes for your reviewer:**
Before this fix, the metrics browser would not work if the Prometheus version supported labels match. With this fix it should work. Test this out by using a Prom data source that has match support, like Mimir instance, change the type and version in the Prometheus Grafana DS config page. Then use the metrics browser and search for a metric and see that labels are fetched.
Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
