### PR TITLE
fix: datatrails: hide graphs when previews disabled

### DIFF
--- a/public/app/features/trails/MetricSelectScene.tsx
+++ b/public/app/features/trails/MetricSelectScene.tsx
@@ -168,11 +168,11 @@ export class MetricSelectScene extends SceneObjectBase<MetricSelectSceneState> {
     for (let index = 0; index < metricsList.length; index++) {
       const metric = metricsList[index];
 
-      if (metric.itemRef && metric.isPanel) {
-        children.push(metric.itemRef.resolve());
-        continue;
-      }
       if (this.state.showPreviews) {
+        if (metric.itemRef && metric.isPanel) {
+          children.push(metric.itemRef.resolve());
+          continue;
+        }
         const panel = getPreviewPanelFor(metric.name, index);
         metric.itemRef = panel.getRef();
         metric.isPanel = true;


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**Which issue(s) does this PR fix?**:

- fixes #81168 


When the "show previews" toggle is disabled, a flattened graph was showing up for each metric:
![image](https://github.com/grafana/grafana/assets/38694490/e5e8fd36-af2e-40fe-b5cc-0d950e342715)

With this PR, there will be no graph:
![image](https://github.com/grafana/grafana/assets/38694490/44d39bb2-7db5-42dc-adaa-cb4b76c65d72)


<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
