### PR TITLE
Prometheus: Add VictoriaMetrics as a Prometheus type 

### DIFF
--- a/public/app/plugins/datasource/prometheus/configuration/PromFlavorVersions.ts
+++ b/public/app/plugins/datasource/prometheus/configuration/PromFlavorVersions.ts
@@ -96,4 +96,9 @@ export const PromFlavorVersions: { [index: string]: Array<{ value?: string; labe
     { value: '1.13.0', label: '1.13.x' },
     { value: '1.14.0', label: '> 1.13.x' },
   ],
+  VictoriaMetrics: [
+    { value: undefined, label: 'Please select' },
+    { value: '0.0.0', label: '< 1.31.x' },
+    { value: '1.31.1', label: '> 1.31.x' },
+  ],
 };

--- a/public/app/plugins/datasource/prometheus/configuration/PromSettings.tsx
+++ b/public/app/plugins/datasource/prometheus/configuration/PromSettings.tsx
@@ -46,6 +46,7 @@ const prometheusFlavorSelectItems: PrometheusSelectItemsType = [
   { value: PromApplication.Cortex, label: PromApplication.Cortex },
   { value: PromApplication.Mimir, label: PromApplication.Mimir },
   { value: PromApplication.Thanos, label: PromApplication.Thanos },
+  { value: PromApplication.VictoriaMetrics, label: PromApplication.VictoriaMetrics },
 ];
 
 type Props = Pick<DataSourcePluginOptionsEditorProps<PromOptions>, 'options' | 'onOptionsChange'>;

--- a/public/app/plugins/datasource/prometheus/datasource.ts
+++ b/public/app/plugins/datasource/prometheus/datasource.ts
@@ -183,7 +183,9 @@ export class PrometheusDatasource
       this._isDatasourceVersionGreaterOrEqualTo('1.11.0', PromApplication.Cortex) ||
       // https://github.com/thanos-io/thanos/pull/3566
       //https://github.com/thanos-io/thanos/releases/tag/v0.18.0
-      this._isDatasourceVersionGreaterOrEqualTo('0.18.0', PromApplication.Thanos)
+      this._isDatasourceVersionGreaterOrEqualTo('0.18.0', PromApplication.Thanos) ||
+      // https://github.com/VictoriaMetrics/VictoriaMetrics/releases/tag/v1.31.1
+      this._isDatasourceVersionGreaterOrEqualTo('1.31.1', PromApplication.VictoriaMetrics)
     );
   }
 

--- a/public/app/plugins/datasource/prometheus/types.ts
+++ b/public/app/plugins/datasource/prometheus/types.ts
@@ -33,6 +33,7 @@ export enum PromApplication {
   Mimir = 'Mimir',
   Prometheus = 'Prometheus',
   Thanos = 'Thanos',
+  VictoriaMetrics = 'VictoriaMetrics',
 }
 
 export interface PromOptions extends DataSourceJsonData {


### PR DESCRIPTION
#### Objective
This pull request adds the option to designate VictoriaMetrics as a specific Prometheus data source in Grafana. This enables the use of the `label/values` API, supported by VictoriaMetrics since version [1.31.1](https://github.com/VictoriaMetrics/VictoriaMetrics/releases/tag/v1.31.1).

#### Problem Addressed
When VictoriaMetrics is set as a Prometheus data source in Grafana, the platform's auto-discovery incorrectly identifies it as an older Prometheus version due to the lack of a version number in VictoriaMetrics' `buildinfo` response. This results in Grafana defaulting to the slower `/series` API for `label/values` queries.
See this issue: https://github.com/VictoriaMetrics/VictoriaMetrics/issues/5370

#### Solution
Introduce a selection option for VictoriaMetrics in the Prometheus data source type menu in Grafana.

<img width="400" alt="image" src="https://github.com/grafana/grafana/assets/29711459/49b785a3-4163-43ac-9997-0e47ef475cad">
