### PR TITLE
Chore: uPlot v1.6.29

### DIFF
--- a/package.json
+++ b/package.json
@@ -397,7 +397,7 @@
     "tinycolor2": "1.6.0",
     "tslib": "2.6.2",
     "tween-functions": "^1.2.0",
-    "uplot": "1.6.28",
+    "uplot": "1.6.29",
     "uuid": "9.0.1",
     "vendor": "link:./public/vendor",
     "visjs-network": "4.25.0",

--- a/packages/grafana-data/package.json
+++ b/packages/grafana-data/package.json
@@ -58,7 +58,7 @@
     "string-hash": "^1.1.3",
     "tinycolor2": "1.6.0",
     "tslib": "2.6.2",
-    "uplot": "1.6.28",
+    "uplot": "1.6.29",
     "xss": "^1.0.14"
   },
   "devDependencies": {

--- a/packages/grafana-ui/package.json
+++ b/packages/grafana-ui/package.json
@@ -106,7 +106,7 @@
     "slate-react": "0.22.10",
     "tinycolor2": "1.6.0",
     "tslib": "2.6.2",
-    "uplot": "1.6.28",
+    "uplot": "1.6.29",
     "uuid": "9.0.1"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3231,7 +3231,7 @@ __metadata:
     tinycolor2: "npm:1.6.0"
     tslib: "npm:2.6.2"
     typescript: "npm:5.3.3"
-    uplot: "npm:1.6.28"
+    uplot: "npm:1.6.29"
     xss: "npm:^1.0.14"
   peerDependencies:
     react: ^17.0.0 || ^18.0.0
@@ -3819,7 +3819,7 @@ __metadata:
     tinycolor2: "npm:1.6.0"
     tslib: "npm:2.6.2"
     typescript: "npm:5.3.3"
-    uplot: "npm:1.6.28"
+    uplot: "npm:1.6.29"
     uuid: "npm:9.0.1"
     webpack: "npm:5.90.0"
   peerDependencies:
@@ -17622,7 +17622,7 @@ __metadata:
     tslib: "npm:2.6.2"
     tween-functions: "npm:^1.2.0"
     typescript: "npm:5.3.3"
-    uplot: "npm:1.6.28"
+    uplot: "npm:1.6.29"
     uuid: "npm:9.0.1"
     vendor: "link:./public/vendor"
     visjs-network: "npm:4.25.0"
@@ -29575,10 +29575,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"uplot@npm:1.6.28":
-  version: 1.6.28
-  resolution: "uplot@npm:1.6.28"
-  checksum: 6771289c45f2b8e8ad5d56abd8c92e7f5687244d75265f80957af857c2034b7b5e3128122262e5a546da2fc4437b600e56a058523eff1435b5bf6728ddc19612
+"uplot@npm:1.6.29":
+  version: 1.6.29
+  resolution: "uplot@npm:1.6.29"
+  checksum: 0cda54a89cbe7f1ff5eb4a3e75bafa145a6af79e534cef6e8e4a1ace042b18a63ea56b25407d87fc7f073711ebb947a59de8068aa3576bc86b2514f1d058c187
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
https://github.com/leeoniya/uPlot/releases/tag/1.6.29

- improvements to dense bar rendering and bar gaps (for future Histogram work https://github.com/grafana/grafana/issues/80317)
- fix for https://github.com/grafana/support-escalations/issues/8922 (log axis would insist on 1 min, 10 max when those values were not reached/exceeded by data)
- improvements to hook fire order needed for `newVizTooltips` (https://github.com/grafana/grafana/pull/81442)
- simplified interface for hover proximity for https://github.com/grafana/grafana/pull/81421
- more explicit op batching control for future core integration changes (https://github.com/leeoniya/uplot-react)
- various other bug fixes