### PR TITLE
AuthProxy: Invalidate previous cached item for user when changes are made to any header

### DIFF
--- a/pkg/services/authn/clients/proxy.go
+++ b/pkg/services/authn/clients/proxy.go
@@ -54,6 +54,7 @@ func ProvideProxy(cfg *setting.Cfg, cache proxyCache, userSrv user.Service, clie
 type proxyCache interface {
 	Get(ctx context.Context, key string) ([]byte, error)
 	Set(ctx context.Context, key string, value []byte, expire time.Duration) error
+	Delete(ctx context.Context, key string) error
 }
 
 type Proxy struct {
@@ -146,13 +147,31 @@ func (c *Proxy) Hook(ctx context.Context, identity *authn.Identity, r *authn.Req
 		c.log.Warn("Failed to cache proxy user", "error", err, "userId", identifier, "err", err)
 		return nil
 	}
+
+	// User's role would not be updated if the cache hit. If requests arrive in the following order:
+	// 1. Name = x; Role = Admin  		# cache missed, new user created and cached with key Name=x;Role=Admin
+	// 2. Name = x; Role = Editor			# cache missed, the user got updated and cached with key Name=x;Role=Editor
+	// 3. Name = x; Role = Admin			# cache hit with key Name=x;Role=Admin, no update, the user stays with Role=Editor
+	// To avoid such a problem, we need to make sure the there is only one cache for a specific user
+	username := getProxyHeader(r, c.cfg.AuthProxyHeaderName, c.cfg.AuthProxyHeadersEncoded)
+	userKey := fmt.Sprintf("%s:%s", proxyCachePrefix, username)
+
+	// invalidate previously cached user id
+	if prevCacheKey, err := c.cache.Get(ctx, userKey); err == nil && len(prevCacheKey) > 0 {
+		if err := c.cache.Delete(ctx, string(prevCacheKey)); err != nil {
+			return err
+		}
+	}
+
 	c.log.FromContext(ctx).Debug("Cache proxy user", "userId", id)
 	bytes := []byte(strconv.FormatInt(id, 10))
-	if err := c.cache.Set(ctx, identity.ClientParams.CacheAuthProxyKey, bytes, time.Duration(c.cfg.AuthProxySyncTTL)*time.Minute); err != nil {
+	duration := time.Duration(c.cfg.AuthProxySyncTTL) * time.Minute
+	if err := c.cache.Set(ctx, identity.ClientParams.CacheAuthProxyKey, bytes, duration); err != nil {
 		c.log.Warn("Failed to cache proxy user", "error", err, "userId", id)
 	}
 
-	return nil
+	// store current cacheKey for the user
+	return c.cache.Set(ctx, userKey, []byte(identity.ClientParams.CacheAuthProxyKey), duration)
 }
 
 func (c *Proxy) isAllowedIP(r *authn.Request) bool {

--- a/pkg/services/authn/clients/proxy.go
+++ b/pkg/services/authn/clients/proxy.go
@@ -149,7 +149,7 @@ func (c *Proxy) Hook(ctx context.Context, identity *authn.Identity, r *authn.Req
 	}
 
 	// User's role would not be updated if the cache hit. If requests arrive in the following order:
-	// 1. Name = x; Role = Admin  		# cache missed, new user created and cached with key Name=x;Role=Admin
+	// 1. Name = x; Role = Admin			# cache missed, new user created and cached with key Name=x;Role=Admin
 	// 2. Name = x; Role = Editor			# cache missed, the user got updated and cached with key Name=x;Role=Editor
 	// 3. Name = x; Role = Admin			# cache hit with key Name=x;Role=Admin, no update, the user stays with Role=Editor
 	// To avoid such a problem, we need to make sure the there is only one cache for a specific user

--- a/pkg/services/authn/clients/proxy.go
+++ b/pkg/services/authn/clients/proxy.go
@@ -152,7 +152,7 @@ func (c *Proxy) Hook(ctx context.Context, identity *authn.Identity, r *authn.Req
 	// 1. Name = x; Role = Admin			# cache missed, new user created and cached with key Name=x;Role=Admin
 	// 2. Name = x; Role = Editor			# cache missed, the user got updated and cached with key Name=x;Role=Editor
 	// 3. Name = x; Role = Admin			# cache hit with key Name=x;Role=Admin, no update, the user stays with Role=Editor
-	// To avoid such a problem we also cache the key used using `prefix:[username]`. 
+	// To avoid such a problem we also cache the key used using `prefix:[username]`.
 	// Then whenever we get a cache miss due to changes in any header we use it to invalidate the previous item.
 	username := getProxyHeader(r, c.cfg.AuthProxyHeaderName, c.cfg.AuthProxyHeadersEncoded)
 	userKey := fmt.Sprintf("%s:%s", proxyCachePrefix, username)

--- a/pkg/services/authn/clients/proxy.go
+++ b/pkg/services/authn/clients/proxy.go
@@ -152,7 +152,8 @@ func (c *Proxy) Hook(ctx context.Context, identity *authn.Identity, r *authn.Req
 	// 1. Name = x; Role = Admin			# cache missed, new user created and cached with key Name=x;Role=Admin
 	// 2. Name = x; Role = Editor			# cache missed, the user got updated and cached with key Name=x;Role=Editor
 	// 3. Name = x; Role = Admin			# cache hit with key Name=x;Role=Admin, no update, the user stays with Role=Editor
-	// To avoid such a problem, we need to make sure the there is only one cache for a specific user
+	// To avoid such a problem we also cache the key used using `prefix:[username]`. 
+	// Then whenever we get a cache miss due to changes in any header we use it to invalidate the previous item.
 	username := getProxyHeader(r, c.cfg.AuthProxyHeaderName, c.cfg.AuthProxyHeadersEncoded)
 	userKey := fmt.Sprintf("%s:%s", proxyCachePrefix, username)
 

--- a/pkg/services/authn/clients/proxy_test.go
+++ b/pkg/services/authn/clients/proxy_test.go
@@ -188,3 +188,7 @@ func (f fakeCache) Get(ctx context.Context, key string) ([]byte, error) {
 func (f fakeCache) Set(ctx context.Context, key string, value []byte, expire time.Duration) error {
 	return f.expectedErr
 }
+
+func (f fakeCache) Delete(ctx context.Context, key string) error {
+	return f.expectedErr
+}

--- a/pkg/services/authn/clients/proxy_test.go
+++ b/pkg/services/authn/clients/proxy_test.go
@@ -227,6 +227,7 @@ func TestProxy_Hook(t *testing.T) {
 				},
 			}
 			err = c.Hook(context.Background(), userIdentity, userReq)
+			assert.NoError(t, err)
 			expectedCache := map[string][]byte{
 				cacheKey: []byte(fmt.Sprintf("%d", userId)),
 				fmt.Sprintf("%s:%s", proxyCachePrefix, "johndoe"): []byte(fmt.Sprintf("users:johndoe-%s", role)),


### PR DESCRIPTION
**What is this feature?**

fix: sign in using auth_proxy with role a -> b -> a would end up with role b


**Why do we need this feature?**

fixing a bug

**Who is this feature for?**

anyone who uses authproxy with role

**Which issue(s) does this PR fix?**:

Fixes #81327

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
