### PR TITLE
RBAC: Add metric to count search user permissions cache hits

### DIFF
--- a/pkg/infra/metrics/metrics.go
+++ b/pkg/infra/metrics/metrics.go
@@ -108,6 +108,9 @@ var (
 	// MAccessPermissionsCacheUsage is a metric counter for cache usage
 	MAccessPermissionsCacheUsage *prometheus.CounterVec
 
+	// MAccessSearchUserPermissionsCacheUsage is a metric counter for cache usage
+	MAccessSearchUserPermissionsCacheUsage *prometheus.CounterVec
+
 	// MPublicDashboardRequestCount is a metric counter for public dashboards requests
 	MPublicDashboardRequestCount prometheus.Counter
 
@@ -648,6 +651,12 @@ func init() {
 		Namespace: ExporterName,
 	}, []string{"status"}, map[string][]string{"status": accesscontrol.CacheUsageStatuses})
 
+	MAccessSearchUserPermissionsCacheUsage = metricutil.NewCounterVecStartingAtZero(prometheus.CounterOpts{
+		Name:      "access_search_user_permissions_cache_usage",
+		Help:      "access control search user permissions cache hit/miss",
+		Namespace: ExporterName,
+	}, []string{"status"}, map[string][]string{"status": accesscontrol.CacheUsageStatuses})
+
 	StatsTotalLibraryPanels = prometheus.NewGauge(prometheus.GaugeOpts{
 		Name:      "stat_totals_library_panels",
 		Help:      "total amount of library panels in the database",
@@ -768,6 +777,7 @@ func initMetricVars(reg prometheus.Registerer) {
 		MAccessSearchPermissionsSummary,
 		MAccessEvaluationCount,
 		MAccessPermissionsCacheUsage,
+		MAccessSearchUserPermissionsCacheUsage,
 		MAlertingActiveAlerts,
 		MStatTotalDashboards,
 		MStatTotalFolders,

--- a/pkg/services/accesscontrol/acimpl/service.go
+++ b/pkg/services/accesscontrol/acimpl/service.go
@@ -407,8 +407,11 @@ func (s *Service) searchUserPermissionsFromCache(orgID int64, searchOptions acce
 	key := permissionCacheKey(tempUser)
 	permissions, ok := s.cache.Get((key))
 	if !ok {
+		metrics.MAccessSearchUserPermissionsCacheUsage.WithLabelValues(accesscontrol.CacheMiss).Inc()
 		return nil, false
 	}
+
+	metrics.MAccessSearchUserPermissionsCacheUsage.WithLabelValues(accesscontrol.CacheHit).Inc()
 
 	s.log.Debug("Using cached permissions", "key", key)
 	filteredPermissions := make([]accesscontrol.Permission, 0)


### PR DESCRIPTION
**What is this feature?**

This PR adds a new metric to count the amount of times the user permissions cache is actually used by search user permissions.

**Why do we need this feature?**

I'm adding this metric to help us decide if we want to cache search results in their own cache.

**Who is this feature for?**

[Add information on what kind of user the feature is for.]

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
