### PR TITLE
Loki: Fix processing of all lines labels in getParserAndLabelKeys

### DIFF
--- a/public/app/plugins/datasource/loki/responseUtils.test.ts
+++ b/public/app/plugins/datasource/loki/responseUtils.test.ts
@@ -66,6 +66,34 @@ const frameWithTypes: DataFrame = {
   ],
 };
 
+const frameWithMultipleLabels: DataFrame = {
+  length: 1,
+  fields: [
+    {
+      name: 'Time',
+      config: {},
+      type: FieldType.time,
+      values: [1, 2, 3],
+    },
+    {
+      name: 'labels',
+      config: {},
+      type: FieldType.other,
+      values: [
+        { level: 'info', foo: 'bar' },
+        { level: 'info', foo: 'baz', new: 'yes' },
+        { level: 'error', foo: 'baz' },
+      ],
+    },
+    {
+      name: 'Line',
+      config: {},
+      type: FieldType.string,
+      values: ['line1', 'line2', 'line3'],
+    },
+  ],
+};
+
 describe('dataFrameHasParsingError', () => {
   it('handles frame with parsing error', () => {
     const input = cloneDeep(frame);
@@ -136,6 +164,11 @@ describe('extractLabelKeysFromDataFrame', () => {
   it('extracts label keys', () => {
     const input = cloneDeep(frame);
     expect(extractLabelKeysFromDataFrame(input)).toEqual(['level']);
+  });
+
+  it('extracts label keys from all logs', () => {
+    const input = cloneDeep(frameWithMultipleLabels);
+    expect(extractLabelKeysFromDataFrame(input)).toEqual(['level', 'foo', 'new']);
   });
 
   it('extracts indexed label keys', () => {

--- a/public/app/plugins/datasource/loki/responseUtils.ts
+++ b/public/app/plugins/datasource/loki/responseUtils.ts
@@ -63,7 +63,7 @@ export function extractLabelKeysFromDataFrame(frame: DataFrame, type: LabelType 
     return [];
   }
 
-  // If we have label types and we have type filter, we can return only label keys that match type
+  // If we have label types, we can return only label keys that match type
   let labelsSet = new Set<string>();
   for (let i = 0; i < labelsArray.length; i++) {
     const labels = labelsArray[i];

--- a/public/app/plugins/datasource/loki/responseUtils.ts
+++ b/public/app/plugins/datasource/loki/responseUtils.ts
@@ -54,28 +54,26 @@ export function extractLabelKeysFromDataFrame(frame: DataFrame, type: LabelType 
     return [];
   }
 
-  // If we have label types and we have type filter, we can return only label keys that match type
-  if (labelTypeArray?.length && type) {
-    let labelsSet = new Set<string>();
-    for (let i = 0; i < labelsArray.length; i++) {
-      const labels = labelsArray[i];
-      const labelsType = labelTypeArray[i];
-
-      const allLabelKeys = Object.keys(labels).filter((key) => labelsType[key] === type);
-      labelsSet = new Set([...labelsSet, ...allLabelKeys]);
+  // if there are no label types and type is LabelType.Indexed return all label keys
+  if (!labelTypeArray?.length) {
+    if (type === LabelType.Indexed) {
+      const { keys: labelKeys } = processLabels(labelsArray);
+      return labelKeys;
     }
-
-    return Array.from(labelsSet);
-  }
-
-  // If we don't have label types and we expect non-indexed labels, we return empty array
-  if (!labelTypeArray?.length && type !== LabelType.Indexed) {
     return [];
   }
 
-  // Otherwise return all label keys
-  const { keys: labelKeys } = processLabels(labelsArray);
-  return labelKeys;
+  // If we have label types and we have type filter, we can return only label keys that match type
+  let labelsSet = new Set<string>();
+  for (let i = 0; i < labelsArray.length; i++) {
+    const labels = labelsArray[i];
+    const labelsType = labelTypeArray[i];
+
+    const allLabelKeys = Object.keys(labels).filter((key) => labelsType[key] === type);
+    labelsSet = new Set([...labelsSet, ...allLabelKeys]);
+  }
+
+  return Array.from(labelsSet);
 }
 
 export function extractUnwrapLabelKeysFromDataFrame(frame: DataFrame): string[] {


### PR DESCRIPTION
Fix processing of all lines in `extractLabelKeysFromDataFrame` that is used in `getParserAndLabelKeys`. 

Until now, we processed labels only from the first `labels` data frame field,  but this PR fixes it and we are going to process all labels from all fields. I have also added tests for this. 