### PR TITLE
parseSupportingQueryType: add missing case for infinite scroll

### DIFF
--- a/pkg/tsdb/loki/parse_query.go
+++ b/pkg/tsdb/loki/parse_query.go
@@ -112,6 +112,8 @@ func parseSupportingQueryType(jsonPointerValue *string) (SupportingQueryType, er
 			return SupportingQueryLogsSample, nil
 		case "dataSample":
 			return SupportingQueryDataSample, nil
+		case "infiniteScroll":
+			return SupportingQueryInfiniteScroll, nil
 		default:
 			return SupportingQueryNone, fmt.Errorf("invalid supportingQueryType: %s", jsonValue)
 		}


### PR DESCRIPTION
Follow up to https://github.com/grafana/grafana/pull/81089, which had a missing case for `parseSupportingQueryType()`, which is currently breaking infinite scrolling.