### PR TITLE
VizTooltip: Scrollable content for long lists

### DIFF
--- a/packages/grafana-ui/src/components/VizTooltip/VizTooltipContent.tsx
+++ b/packages/grafana-ui/src/components/VizTooltip/VizTooltipContent.tsx
@@ -1,5 +1,5 @@
 import { css } from '@emotion/css';
-import React, { ReactElement } from 'react';
+import React, { CSSProperties, ReactElement } from 'react';
 
 import { GrafanaTheme2 } from '@grafana/data';
 
@@ -11,14 +11,22 @@ import { LabelValue } from './types';
 interface Props {
   contentLabelValue: LabelValue[];
   customContent?: ReactElement[];
+  scrollable?: boolean;
   isPinned: boolean;
 }
 
-export const VizTooltipContent = ({ contentLabelValue, customContent, isPinned }: Props) => {
+export const VizTooltipContent = ({ contentLabelValue, customContent, isPinned, scrollable = false }: Props) => {
   const styles = useStyles2(getStyles);
 
+  const scrollableStyle: CSSProperties = scrollable
+    ? {
+        maxHeight: 400,
+        overflowY: 'auto',
+      }
+    : {};
+
   return (
-    <div className={styles.wrapper}>
+    <div className={styles.wrapper} style={scrollableStyle}>
       <div>
         {contentLabelValue.map((labelValue, i) => {
           const { label, value, color, colorIndicator, colorPlacement, isActive } = labelValue;

--- a/public/app/plugins/panel/timeseries/TimeSeriesTooltip.tsx
+++ b/public/app/plugins/panel/timeseries/TimeSeriesTooltip.tsx
@@ -61,21 +61,21 @@ export const TimeSeriesTooltip = ({
 
   const xFieldFmt = xField.display || getDisplayProcessor({ field: xField, theme });
   let xVal = xFieldFmt(xField!.values[dataIdxs[0]!]).text;
+  const dataIdx = dataIdxs[seriesIdx!]!;
+
   let links: Array<LinkModel<Field>> = [];
   let contentLabelValue: LabelValue[] = [];
 
-  // Single mode
-  if (mode === TooltipDisplayMode.Single || isPinned) {
-    const field = seriesFrame.fields[seriesIdx!];
-    if (!field) {
-      return null;
-    }
+  const field = seriesFrame.fields[seriesIdx!];
+  if (!field) {
+    return null;
+  }
 
-    const dataIdx = dataIdxs[seriesIdx!]!;
+  // Single mode
+  if (mode === TooltipDisplayMode.Single) {
     xVal = xFieldFmt(xField!.values[dataIdx]).text;
     const fieldFmt = field.display || getDisplayProcessor({ field, theme });
     const display = fieldFmt(field.values[dataIdx]);
-    links = getDataLinks(field, dataIdx);
 
     contentLabelValue = [
       {
@@ -88,7 +88,7 @@ export const TimeSeriesTooltip = ({
     ];
   }
 
-  if (mode === TooltipDisplayMode.Multi && !isPinned) {
+  if (mode === TooltipDisplayMode.Multi) {
     const fields = seriesFrame.fields;
     const sortIdx: unknown[] = [];
 
@@ -133,6 +133,8 @@ export const TimeSeriesTooltip = ({
     }
   }
 
+  links = getDataLinks(field, dataIdx);
+
   const getHeaderLabel = (): LabelValue => {
     return {
       label: xField.type === FieldType.time ? '' : getFieldDisplayName(xField, seriesFrame, frames),
@@ -148,7 +150,11 @@ export const TimeSeriesTooltip = ({
     <div>
       <div className={styles.wrapper}>
         <VizTooltipHeader headerLabel={getHeaderLabel()} isPinned={isPinned} />
-        <VizTooltipContent contentLabelValue={getContentLabelValue()} isPinned={isPinned} />
+        <VizTooltipContent
+          contentLabelValue={getContentLabelValue()}
+          isPinned={isPinned}
+          scrollable={mode === TooltipDisplayMode.Multi}
+        />
         {isPinned && <VizTooltipFooter dataLinks={links} annotate={annotate} />}
       </div>
     </div>

--- a/public/app/plugins/panel/timeseries/TimeSeriesTooltip.tsx
+++ b/public/app/plugins/panel/timeseries/TimeSeriesTooltip.tsx
@@ -61,21 +61,23 @@ export const TimeSeriesTooltip = ({
 
   const xFieldFmt = xField.display || getDisplayProcessor({ field: xField, theme });
   let xVal = xFieldFmt(xField!.values[dataIdxs[0]!]).text;
-  const dataIdx = dataIdxs[seriesIdx!]!;
 
   let links: Array<LinkModel<Field>> = [];
   let contentLabelValue: LabelValue[] = [];
 
-  const field = seriesFrame.fields[seriesIdx!];
-  if (!field) {
-    return null;
-  }
-
   // Single mode
   if (mode === TooltipDisplayMode.Single) {
+    const field = seriesFrame.fields[seriesIdx!];
+    if (!field) {
+      return null;
+    }
+
+    const dataIdx = dataIdxs[seriesIdx!]!;
     xVal = xFieldFmt(xField!.values[dataIdx]).text;
     const fieldFmt = field.display || getDisplayProcessor({ field, theme });
     const display = fieldFmt(field.values[dataIdx]);
+
+    links = getDataLinks(field, dataIdx);
 
     contentLabelValue = [
       {
@@ -131,9 +133,13 @@ export const TimeSeriesTooltip = ({
         });
       }
     }
-  }
 
-  links = getDataLinks(field, dataIdx);
+    if (seriesIdx) {
+      const field = seriesFrame.fields[seriesIdx];
+      const dataIdx = dataIdxs[seriesIdx]!;
+      links = getDataLinks(field, dataIdx);
+    }
+  }
 
   const getHeaderLabel = (): LabelValue => {
     return {

--- a/public/app/plugins/panel/timeseries/TimeSeriesTooltip.tsx
+++ b/public/app/plugins/panel/timeseries/TimeSeriesTooltip.tsx
@@ -134,7 +134,7 @@ export const TimeSeriesTooltip = ({
       }
     }
 
-    if (seriesIdx) {
+    if (seriesIdx != null) {
       const field = seriesFrame.fields[seriesIdx];
       const dataIdx = dataIdxs[seriesIdx]!;
       links = getDataLinks(field, dataIdx);


### PR DESCRIPTION
The PR makes the content scrollable for long list in Timeseries, Candlestick and Trend panels.


https://github.com/grafana/grafana/assets/88068998/72632a82-b240-4ed3-9974-b3afd27c7b18


Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
