### PR TITLE
Scenes: Bump to 2.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -245,7 +245,7 @@
     "@grafana/monaco-logql": "^0.0.7",
     "@grafana/o11y-ds-frontend": "workspace:*",
     "@grafana/runtime": "workspace:*",
-    "@grafana/scenes": "^2.1.0",
+    "@grafana/scenes": "^2.2.0",
     "@grafana/schema": "workspace:*",
     "@grafana/sql": "workspace:*",
     "@grafana/ui": "workspace:*",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3636,9 +3636,9 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@grafana/scenes@npm:^2.1.0":
-  version: 2.1.0
-  resolution: "@grafana/scenes@npm:2.1.0"
+"@grafana/scenes@npm:^2.2.0":
+  version: 2.2.0
+  resolution: "@grafana/scenes@npm:2.2.0"
   dependencies:
     "@grafana/e2e-selectors": "npm:10.0.2"
     react-grid-layout: "npm:1.3.4"
@@ -3650,7 +3650,7 @@ __metadata:
     "@grafana/runtime": 10.0.3
     "@grafana/schema": 10.0.3
     "@grafana/ui": 10.0.3
-  checksum: c036793fd172e25a5d2a27ef633401831339a1936967101663602109f292be8205c8bf1fd3482c34445a377633c573110845e3fda0f583067d8bc1dbab106240
+  checksum: eb21724accc1f3cae883bc9bdfa1786e8f62f9482436bf46225ea32b7bbb389b28c497d1766771cb4406ad4b9802fbe6233b34c8800fa264c39b45fea4e8125b
   languageName: node
   linkType: hard
 
@@ -17380,7 +17380,7 @@ __metadata:
     "@grafana/monaco-logql": "npm:^0.0.7"
     "@grafana/o11y-ds-frontend": "workspace:*"
     "@grafana/runtime": "workspace:*"
-    "@grafana/scenes": "npm:^2.1.0"
+    "@grafana/scenes": "npm:^2.2.0"
     "@grafana/schema": "workspace:*"
     "@grafana/sql": "workspace:*"
     "@grafana/tsconfig": "npm:^1.3.0-rc1"


### PR DESCRIPTION
Brings dashboard scene's queries to `getTagKeys` calls. Integrates https://github.com/grafana/grafana/pull/81071 and https://github.com/grafana/scenes/pull/544