### PR TITLE
RBAC: Fix authorize in org

### DIFF
--- a/pkg/services/accesscontrol/middleware.go
+++ b/pkg/services/accesscontrol/middleware.go
@@ -260,23 +260,31 @@ func makeTmpUser(ctx context.Context, service Service, cache userCache,
 			tmpUser.OrgName = queryResult.OrgName
 			tmpUser.OrgRole = queryResult.OrgRole
 
-			if teamService != nil {
-				teamIDs, err := teamService.GetTeamIDsByUser(ctx, &team.GetTeamIDsByUserQuery{OrgID: targetOrgID, UserID: tmpUser.UserID})
-				if err != nil {
-					return nil, err
+			// Only fetch the team membership is the user is a member of the organization
+			if queryResult.OrgID == targetOrgID {
+				if teamService != nil {
+					teamIDs, err := teamService.GetTeamIDsByUser(ctx, &team.GetTeamIDsByUserQuery{OrgID: targetOrgID, UserID: tmpUser.UserID})
+					if err != nil {
+						return nil, err
+					}
+					tmpUser.Teams = teamIDs
 				}
-				tmpUser.Teams = teamIDs
 			}
 		}
 	}
 
-	if tmpUser.Permissions[targetOrgID] == nil || len(tmpUser.Permissions[targetOrgID]) == 0 {
+	// If the user is not a member of the organization, evaluation must happen based on global permissions.
+	evaluationOrg := targetOrgID
+	if tmpUser.OrgID == NoOrgID {
+		evaluationOrg = GlobalOrgID
+	}
+	if tmpUser.Permissions[evaluationOrg] == nil || len(tmpUser.Permissions[evaluationOrg]) == 0 {
 		permissions, err := service.GetUserPermissions(ctx, tmpUser, Options{})
 		if err != nil {
 			return nil, err
 		}
 
-		tmpUser.Permissions[targetOrgID] = GroupScopesByAction(permissions)
+		tmpUser.Permissions[evaluationOrg] = GroupScopesByAction(permissions)
 	}
 
 	return tmpUser, nil

--- a/pkg/services/accesscontrol/models.go
+++ b/pkg/services/accesscontrol/models.go
@@ -330,6 +330,7 @@ func (cmd *SaveExternalServiceRoleCommand) Validate() error {
 
 const (
 	GlobalOrgID      = 0
+	NoOrgID          = int64(-1)
 	GeneralFolderUID = "general"
 	RoleGrafanaAdmin = "Grafana Admin"
 

--- a/pkg/services/authn/identity.go
+++ b/pkg/services/authn/identity.go
@@ -31,6 +31,8 @@ const (
 
 const (
 	AnonymousNamespaceID = NamespaceAnonymous + ":0"
+	GlobalOrgID          = int64(0)
+	NoOrgID              = int64(-1)
 )
 
 var _ identity.Requester = (*Identity)(nil)
@@ -157,11 +159,17 @@ func (i *Identity) GetPermissions() map[string][]string {
 		return make(map[string][]string)
 	}
 
-	if i.Permissions[i.GetOrgID()] == nil {
+	// If the identity is not logged in an organization use global permissions.
+	orgID := i.GetOrgID()
+	if orgID == NoOrgID {
+		orgID = GlobalOrgID
+	}
+
+	if i.Permissions[orgID] == nil {
 		return make(map[string][]string)
 	}
 
-	return i.Permissions[i.GetOrgID()]
+	return i.Permissions[orgID]
 }
 
 func (i *Identity) GetTeams() []int64 {

--- a/pkg/services/user/identity.go
+++ b/pkg/services/user/identity.go
@@ -8,6 +8,11 @@ import (
 	"github.com/grafana/grafana/pkg/services/auth/identity"
 )
 
+const (
+	GlobalOrgID = int64(0)
+	NoOrgID     = int64(-1)
+)
+
 type SignedInUser struct {
 	UserID           int64 `xorm:"user_id"`
 	OrgID            int64 `xorm:"org_id"`
@@ -152,11 +157,17 @@ func (u *SignedInUser) GetPermissions() map[string][]string {
 		return make(map[string][]string)
 	}
 
-	if u.Permissions[u.GetOrgID()] == nil {
+	// If the identity is not logged in an organization use global permissions.
+	orgID := u.OrgID
+	if orgID == NoOrgID {
+		orgID = GlobalOrgID
+	}
+
+	if u.Permissions[orgID] == nil {
 		return make(map[string][]string)
 	}
 
-	return u.Permissions[u.GetOrgID()]
+	return u.Permissions[orgID]
 }
 
 // DEPRECATED: GetTeams returns the teams the entity is a member of


### PR DESCRIPTION
**What is this feature?**

This feature makes Grafana access-control check for global permissions when a user is not signed in any org.

**Why do we need this feature?**

Server Admins cannot use the [/api/orgs/:orgID/](https://github.com/grafana/grafana/blob/5ab75410e93a5f2b553151f9009b9c3d036c1a83/pkg/api/api.go#L348-L361) for organizations they are not members of. For example, they cannot add themselves to other organizations.

**Who is this feature for?**

[Add information on what kind of user the feature is for.]

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
