### PR TITLE
Auth: Remove unnecessary field from Generic OAuth UI

### DIFF
--- a/public/app/features/auth-config/ProviderConfigForm.test.tsx
+++ b/public/app/features/auth-config/ProviderConfigForm.test.tsx
@@ -113,7 +113,7 @@ describe('ProviderConfigForm', () => {
         { showErrorAlert: false }
       );
 
-      expect(reportInteractionMock).toHaveBeenCalledWith('grafana_authentication_ssosettings_updated', {
+      expect(reportInteractionMock).toHaveBeenCalledWith('grafana_authentication_ssosettings_saved', {
         provider: 'github',
         enabled: true,
       });

--- a/public/app/features/auth-config/ProviderConfigForm.tsx
+++ b/public/app/features/auth-config/ProviderConfigForm.tsx
@@ -56,7 +56,7 @@ export const ProviderConfigForm = ({ config, provider, isLoading }: ProviderConf
         }
       );
 
-      reportInteraction('grafana_authentication_ssosettings_updated', {
+      reportInteraction('grafana_authentication_ssosettings_saved', {
         provider,
         enabled: requestData.enabled,
       });

--- a/public/app/features/auth-config/fields.tsx
+++ b/public/app/features/auth-config/fields.tsx
@@ -88,7 +88,7 @@ export const sectionFields: Section = {
     {
       name: 'TLS',
       id: 'tls',
-      fields: ['configureTLS', 'tlsSkipVerifyInsecure', 'tlsClientCert', 'tlsClientKey', 'tlsClientCa'],
+      fields: ['tlsSkipVerifyInsecure', 'tlsClientCert', 'tlsClientKey', 'tlsClientCa'],
     },
   ],
 };
@@ -310,10 +310,6 @@ export function fieldMap(provider: string): Record<string, FieldData> {
       description:
         'If enabled, Grafana will fetch a new access token using the refresh token provided by the OAuth2 provider.',
       type: 'checkbox',
-    },
-    configureTLS: {
-      label: 'Configure TLS',
-      type: 'switch',
     },
     tlsClientCa: {
       label: 'TLS client ca',


### PR DESCRIPTION
**What is this feature?**
- This PR removes the unnecessary `configure tls` field from the UI.
- Changes an interaction event key

**Why do we need this feature?**

**Who is this feature for?**


**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
