### PR TITLE
Log rows: add re-renders test cases

### DIFF
--- a/public/app/features/logs/components/LogRows.test.tsx
+++ b/public/app/features/logs/components/LogRows.test.tsx
@@ -7,7 +7,6 @@ import { CoreApp, LogRowModel, LogsDedupStrategy, LogsSortOrder } from '@grafana
 
 import { LogRows, PREVIEW_LIMIT } from './LogRows';
 import { createLogRow } from './__mocks__/logRow';
-import * as styles from './getLogRowStyles';
 
 jest.mock('@grafana/runtime', () => ({
   ...jest.requireActual('@grafana/runtime'),
@@ -204,78 +203,6 @@ describe('LogRows', () => {
     expect(screen.queryAllByRole('row').at(0)).toHaveTextContent('log message 3');
     expect(screen.queryAllByRole('row').at(1)).toHaveTextContent('log message 2');
     expect(screen.queryAllByRole('row').at(2)).toHaveTextContent('log message 1');
-  });
-
-  describe('Performance regressions', () => {
-    beforeEach(() => {
-      jest.spyOn(styles, 'getLogRowStyles');
-    });
-    it.only('does not rerender without changes', async () => {
-      const rows: LogRowModel[] = [createLogRow({ uid: '1' })];
-      const { rerender } = render(
-        <LogRows
-          logRows={rows}
-          dedupStrategy={LogsDedupStrategy.none}
-          showLabels={false}
-          showTime={false}
-          wrapLogMessage={true}
-          prettifyLogMessage={true}
-          timeZone={'utc'}
-          enableLogDetails={true}
-        />
-      );
-  
-      expect(await screen.findByRole('row')).toBeInTheDocument();
-      
-      rerender(<LogRows
-        logRows={rows}
-        dedupStrategy={LogsDedupStrategy.none}
-        showLabels={false}
-        showTime={false}
-        wrapLogMessage={true}
-        prettifyLogMessage={true}
-        timeZone={'utc'}
-        enableLogDetails={true}
-      />);
-  
-      expect(await screen.findByRole('row')).toBeInTheDocument();
-      expect(styles.getLogRowStyles).toHaveBeenCalledTimes(2);
-    });
-
-    it('rerenders when prop changes', async () => {
-      const rows: LogRowModel[] = [createLogRow({ uid: '1' })];
-      const { rerender } = render(
-        <LogRows
-          logRows={rows}
-          dedupStrategy={LogsDedupStrategy.none}
-          showLabels={false}
-          showTime={false}
-          wrapLogMessage={true}
-          prettifyLogMessage={true}
-          timeZone={'utc'}
-          enableLogDetails={true}
-          // new array every render
-          displayedFields={[]}
-        />
-      );
-  
-      expect(await screen.findByRole('row')).toBeInTheDocument();
-      
-      rerender(<LogRows
-        logRows={rows}
-        dedupStrategy={LogsDedupStrategy.none}
-        showLabels={false}
-        showTime={false}
-        wrapLogMessage={true}
-        prettifyLogMessage={true}
-        timeZone={'utc'}
-        enableLogDetails={true}
-        displayedFields={[]}
-      />);
-  
-      expect(await screen.findByRole('row')).toBeInTheDocument();
-      expect(jest.mocked(styles.getLogRowStyles).mock.calls.length).toBeGreaterThan(2);
-    });
   });
 });
 

--- a/public/app/plugins/panel/logs/LogsPanel.test.tsx
+++ b/public/app/plugins/panel/logs/LogsPanel.test.tsx
@@ -278,6 +278,9 @@ describe('LogsPanel', () => {
     ];
 
     beforeEach(() => {
+      /**
+       * For the lack of a better option, we spy on getLogRowStyles calls to count re-renders.
+       */
       jest.spyOn(styles, 'getLogRowStyles');
       jest.mocked(styles.getLogRowStyles).mockClear();
     });

--- a/public/app/plugins/panel/logs/LogsPanel.test.tsx
+++ b/public/app/plugins/panel/logs/LogsPanel.test.tsx
@@ -3,7 +3,16 @@ import userEvent from '@testing-library/user-event';
 import React, { ComponentProps } from 'react';
 import { DatasourceSrvMock, MockDataSourceApi } from 'test/mocks/datasource_srv';
 
-import { LoadingState, createDataFrame, FieldType, LogsSortOrder, CoreApp, getDefaultTimeRange, LogsDedupStrategy, EventBusSrv } from '@grafana/data';
+import {
+  LoadingState,
+  createDataFrame,
+  FieldType,
+  LogsSortOrder,
+  CoreApp,
+  getDefaultTimeRange,
+  LogsDedupStrategy,
+  EventBusSrv,
+} from '@grafana/data';
 import * as styles from 'app/features/logs/components/getLogRowStyles';
 import { LogRowContextModal } from 'app/features/logs/components/log-context/LogRowContextModal';
 
@@ -294,7 +303,7 @@ describe('LogsPanel', () => {
 
       expect(await screen.findByRole('row')).toBeInTheDocument();
 
-      rerender(<LogsPanel {...props} />)
+      rerender(<LogsPanel {...props} />);
 
       expect(await screen.findByRole('row')).toBeInTheDocument();
       expect(styles.getLogRowStyles).toHaveBeenCalledTimes(3);
@@ -309,7 +318,7 @@ describe('LogsPanel', () => {
 
       expect(await screen.findByRole('row')).toBeInTheDocument();
 
-      rerender(<LogsPanel {...props} data={{...props.data, series: [...series]}} />)
+      rerender(<LogsPanel {...props} data={{ ...props.data, series: [...series] }} />);
 
       expect(await screen.findByRole('row')).toBeInTheDocument();
       expect(jest.mocked(styles.getLogRowStyles).mock.calls.length).toBeGreaterThan(3);
@@ -337,7 +346,7 @@ const setup = (propsOverrides?: {}) => {
       series: [],
       state: LoadingState.Done,
       timeRange: getDefaultTimeRange(),
-    },    
+    },
     timeZone: 'utc',
     timeRange: getDefaultTimeRange(),
     options: {


### PR DESCRIPTION
Related with https://github.com/grafana/grafana/issues/60687, we made several performance improvements to log rows to improve performance under certain scenarios. One of these have been to memoize callbacks that are passed down the component tree as props.

To prevent performance regressions in the future, these test cases might prevent regressions in the future.

`getLogRowStyles` has been chosen to spy on because it's a function that gets called on every render: https://github.com/grafana/grafana/blob/main/public/app/features/logs/components/LogRows.tsx#L189

**What is this feature?**

Performance regression test.

**Which issue(s) does this PR fix?**:

Part of https://github.com/grafana/grafana/issues/60687,

**Special notes for your reviewer:**

What do you think of this approach?