### PR TITLE
sql: make sure queries do not have fill-params

### DIFF
--- a/pkg/tsdb/sqleng/sql_engine.go
+++ b/pkg/tsdb/sqleng/sql_engine.go
@@ -175,6 +175,13 @@ func (e *DataSourceHandler) QueryData(ctx context.Context, req *backend.QueryDat
 		if err != nil {
 			return nil, fmt.Errorf("error unmarshal query json: %w", err)
 		}
+
+		// the fill-params are only stored inside this function, during query-interpolation. we do not support
+		// sending them in "from the outside"
+		if queryjson.Fill || queryjson.FillInterval != 0.0 || queryjson.FillMode != "" || queryjson.FillValue != 0.0 {
+			return nil, fmt.Errorf("query fill-parameters not supported")
+		}
+
 		if queryjson.RawSql == "" {
 			continue
 		}


### PR DESCRIPTION
in the go-code, we consider the following query-json-fields: https://github.com/grafana/grafana/blob/4cf50595991ebce68d8683fd0dceef3420017a10/pkg/tsdb/sqleng/sql_engine.go#L98-L105  : 
- `RawSQL` .. the sql query
- `Format` ... can be `table` or `timeSeries`
- `Fill`, `FillInterval`, `FillMode`, `FillValue` ... these are the focus of this PR 😄 

the `Fill*` -params are not coming from the "outside". during the processing of the request:
- if the sql-query contains certain macros, for example `$__timeGroup(dateColumn,'5m', previous)`, then these values will be set into those query-params. ( `fill=true, fillinterval=5m, fillmode=previous` )
- then the query is executed, and when the response is received, it will be adjusted based on these `Fill*`values.

so the only reason these 4 `Fill*` are in the query-json is to use it as a temporary storage.

i think we should move these out from there, because it is very confusing to have values here that are not in the user-interface... but... in theory, someone may call the sql-datasources using the Grafana API, and set these values 😿 . i do not think we support this use-case, but to be sure, i propose we do the change in this PR, we validate the request, and reject it if it contains such values. later we can rewrite the code so that these values are stored somewhere else.

WDYT?