### PR TITLE
Loki: Limit running of samples based on query and time range

### DIFF
--- a/public/app/plugins/datasource/loki/querybuilder/components/LokiQueryBuilder.test.tsx
+++ b/public/app/plugins/datasource/loki/querybuilder/components/LokiQueryBuilder.test.tsx
@@ -3,6 +3,7 @@ import userEvent from '@testing-library/user-event';
 import React from 'react';
 
 import { dateTime } from '@grafana/data';
+import { config } from '@grafana/runtime';
 
 import { createLokiDatasource } from '../../__mocks__/datasource';
 import { LokiOperationId, LokiVisualQuery } from '../types';
@@ -40,6 +41,14 @@ const createDefaultProps = () => {
 };
 
 describe('LokiQueryBuilder', () => {
+  const originalLokiQueryHints = config.featureToggles.lokiQueryHints;
+  beforeEach(() => {
+    config.featureToggles.lokiQueryHints = true;
+  });
+
+  afterEach(() => {
+    config.featureToggles.lokiQueryHints = originalLokiQueryHints;
+  });
   it('tries to load labels when no labels are selected', async () => {
     const props = createDefaultProps();
     props.datasource.getDataSamples = jest.fn().mockResolvedValue([]);
@@ -132,6 +141,95 @@ describe('LokiQueryBuilder', () => {
     render(<LokiQueryBuilder {...props} query={query} />);
     await waitFor(() => {
       expect(screen.queryByText(EXPLAIN_LABEL_FILTER_CONTENT)).not.toBeInTheDocument();
+    });
+  });
+
+  it('re-runs sample query when query changes', async () => {
+    const query = {
+      labels: [{ label: 'foo', op: '=', value: 'bar' }],
+      operations: [{ id: LokiOperationId.LineContains, params: ['error'] }],
+    };
+    const props = createDefaultProps();
+    props.datasource.getDataSamples = jest.fn().mockResolvedValue([]);
+
+    const { rerender } = render(<LokiQueryBuilder {...props} query={query} />);
+    rerender(
+      <LokiQueryBuilder
+        {...props}
+        query={{ ...query, labels: [...query.labels, { label: 'xyz', op: '=', value: 'abc' }] }}
+      />
+    );
+
+    await waitFor(() => {
+      expect(props.datasource.getDataSamples).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  it('does not re-run sample query when query does not change', async () => {
+    const query = {
+      labels: [{ label: 'foo', op: '=', value: 'bar' }],
+      operations: [{ id: LokiOperationId.LineContains, params: ['error'] }],
+    };
+    const props = createDefaultProps();
+    props.datasource.getDataSamples = jest.fn().mockResolvedValue([]);
+
+    const { rerender } = render(<LokiQueryBuilder {...props} query={query} />);
+    rerender(<LokiQueryBuilder {...props} query={query} />);
+
+    await waitFor(() => {
+      expect(props.datasource.getDataSamples).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  it('re-run sample query when time range changes over 5 minutes', async () => {
+    const query = {
+      labels: [{ label: 'foo', op: '=', value: 'bar' }],
+      operations: [{ id: LokiOperationId.LineContains, params: ['error'] }],
+    };
+    const props = createDefaultProps();
+    const updatedFrom = dateTime(props.timeRange.from.valueOf() + 10 * 60 * 1000);
+    const updatedTo = dateTime(props.timeRange.to.valueOf() + 10 * 60 * 1000);
+    const updatedTimeRange = {
+      from: updatedFrom,
+      to: updatedTo,
+      raw: {
+        from: updatedFrom,
+        to: updatedTo,
+      },
+    };
+    props.datasource.getDataSamples = jest.fn().mockResolvedValue([]);
+
+    const { rerender } = render(<LokiQueryBuilder {...props} query={query} />);
+    rerender(<LokiQueryBuilder {...props} query={query} timeRange={updatedTimeRange} />);
+
+    await waitFor(() => {
+      expect(props.datasource.getDataSamples).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  it('does not re-run sample query when time range changes less than 5 minutes', async () => {
+    const query = {
+      labels: [{ label: 'foo', op: '=', value: 'bar' }],
+      operations: [{ id: LokiOperationId.LineContains, params: ['error'] }],
+    };
+    const props = createDefaultProps();
+    const updatedFrom = dateTime(props.timeRange.from.valueOf() + 2 * 60 * 1000);
+    const updatedTo = dateTime(props.timeRange.to.valueOf() + 2 * 60 * 1000);
+    const updatedTimeRange = {
+      from: updatedFrom,
+      to: updatedTo,
+      raw: {
+        from: updatedFrom,
+        to: updatedTo,
+      },
+    };
+    props.datasource.getDataSamples = jest.fn().mockResolvedValue([]);
+
+    const { rerender } = render(<LokiQueryBuilder {...props} query={query} />);
+    rerender(<LokiQueryBuilder {...props} query={query} timeRange={updatedTimeRange} />);
+
+    await waitFor(() => {
+      expect(props.datasource.getDataSamples).toHaveBeenCalledTimes(1);
     });
   });
 });

--- a/public/app/plugins/datasource/loki/querybuilder/components/LokiQueryBuilder.test.tsx
+++ b/public/app/plugins/datasource/loki/querybuilder/components/LokiQueryBuilder.test.tsx
@@ -8,7 +8,7 @@ import { config } from '@grafana/runtime';
 import { createLokiDatasource } from '../../__mocks__/datasource';
 import { LokiOperationId, LokiVisualQuery } from '../types';
 
-import { LokiQueryBuilder } from './LokiQueryBuilder';
+import { LokiQueryBuilder, TIME_SPAN_TO_TRIGGER_SAMPLES } from './LokiQueryBuilder';
 import { EXPLAIN_LABEL_FILTER_CONTENT } from './LokiQueryBuilderExplained';
 
 const MISSING_LABEL_FILTER_ERROR_MESSAGE = 'Select at least 1 label filter (label and value)';
@@ -187,8 +187,8 @@ describe('LokiQueryBuilder', () => {
       operations: [{ id: LokiOperationId.LineContains, params: ['error'] }],
     };
     const props = createDefaultProps();
-    const updatedFrom = dateTime(props.timeRange.from.valueOf() + 10 * 60 * 1000);
-    const updatedTo = dateTime(props.timeRange.to.valueOf() + 10 * 60 * 1000);
+    const updatedFrom = dateTime(props.timeRange.from.valueOf() + TIME_SPAN_TO_TRIGGER_SAMPLES + 1000);
+    const updatedTo = dateTime(props.timeRange.to.valueOf() + TIME_SPAN_TO_TRIGGER_SAMPLES + 1000);
     const updatedTimeRange = {
       from: updatedFrom,
       to: updatedTo,
@@ -213,8 +213,8 @@ describe('LokiQueryBuilder', () => {
       operations: [{ id: LokiOperationId.LineContains, params: ['error'] }],
     };
     const props = createDefaultProps();
-    const updatedFrom = dateTime(props.timeRange.from.valueOf() + 2 * 60 * 1000);
-    const updatedTo = dateTime(props.timeRange.to.valueOf() + 2 * 60 * 1000);
+    const updatedFrom = dateTime(props.timeRange.from.valueOf() + TIME_SPAN_TO_TRIGGER_SAMPLES - 1000);
+    const updatedTo = dateTime(props.timeRange.to.valueOf() + TIME_SPAN_TO_TRIGGER_SAMPLES - 1000);
     const updatedTimeRange = {
       from: updatedFrom,
       to: updatedTo,

--- a/public/app/plugins/datasource/loki/querybuilder/components/LokiQueryBuilder.tsx
+++ b/public/app/plugins/datasource/loki/querybuilder/components/LokiQueryBuilder.tsx
@@ -1,4 +1,6 @@
+import { isEqual } from 'lodash';
 import React, { useEffect, useMemo, useState } from 'react';
+import { usePrevious } from 'react-use';
 
 import { DataSourceApi, getDefaultTimeRange, LoadingState, PanelData, SelectableValue, TimeRange } from '@grafana/data';
 import {
@@ -41,6 +43,8 @@ export const LokiQueryBuilder = React.memo<Props>(
   ({ datasource, query, onChange, onRunQuery, showExplain, timeRange }) => {
     const [sampleData, setSampleData] = useState<PanelData>();
     const [highlightedOp, setHighlightedOp] = useState<QueryBuilderOperation | undefined>(undefined);
+    const prevQuery = usePrevious(query);
+    const prevTimeRange = usePrevious(timeRange);
 
     const onChangeLabels = (labels: QueryBuilderLabelFilter[]) => {
       onChange({ ...query, labels });
@@ -109,10 +113,18 @@ export const LokiQueryBuilder = React.memo<Props>(
         setSampleData(sampleData);
       };
 
-      if (config.featureToggles.lokiQueryHints) {
+      // TIME_SPAN should be changed by at least 5 minutes to trigger a new sample data request
+      const TIME_SPAN = 5 * 60 * 1000;
+      const shouldUpdateChangedTimeRange =
+        prevTimeRange &&
+        timeRange &&
+        (Math.abs(timeRange.to.valueOf() - prevTimeRange.to.valueOf()) > TIME_SPAN ||
+          Math.abs(timeRange.from.valueOf() - prevTimeRange.from.valueOf()) > TIME_SPAN);
+      const shouldUpdateChangedQuery = !isEqual(prevQuery, query);
+      if (config.featureToggles.lokiQueryHints && (shouldUpdateChangedQuery || shouldUpdateChangedTimeRange)) {
         onGetSampleData().catch(console.error);
       }
-    }, [datasource, query, timeRange]);
+    }, [datasource, query, timeRange, prevQuery, prevTimeRange]);
 
     const lang = { grammar: logqlGrammar, name: 'logql' };
     return (

--- a/public/app/plugins/datasource/loki/querybuilder/components/LokiQueryBuilder.tsx
+++ b/public/app/plugins/datasource/loki/querybuilder/components/LokiQueryBuilder.tsx
@@ -31,6 +31,7 @@ import { LokiOperationId, LokiVisualQuery } from '../types';
 import { EXPLAIN_LABEL_FILTER_CONTENT } from './LokiQueryBuilderExplained';
 import { NestedQueryList } from './NestedQueryList';
 
+export const TIME_SPAN_TO_TRIGGER_SAMPLES = 5 * 60 * 1000;
 export interface Props {
   query: LokiVisualQuery;
   datasource: LokiDatasource;
@@ -113,15 +114,13 @@ export const LokiQueryBuilder = React.memo<Props>(
         setSampleData(sampleData);
       };
 
-      // TIME_SPAN should be changed by at least 5 minutes to trigger a new sample data request
-      const TIME_SPAN = 5 * 60 * 1000;
-      const shouldUpdateChangedTimeRange =
+      const updateBasedOnChangedTimeRange =
         prevTimeRange &&
         timeRange &&
-        (Math.abs(timeRange.to.valueOf() - prevTimeRange.to.valueOf()) > TIME_SPAN ||
-          Math.abs(timeRange.from.valueOf() - prevTimeRange.from.valueOf()) > TIME_SPAN);
-      const shouldUpdateChangedQuery = !isEqual(prevQuery, query);
-      if (config.featureToggles.lokiQueryHints && (shouldUpdateChangedQuery || shouldUpdateChangedTimeRange)) {
+        (Math.abs(timeRange.to.valueOf() - prevTimeRange.to.valueOf()) > TIME_SPAN_TO_TRIGGER_SAMPLES ||
+          Math.abs(timeRange.from.valueOf() - prevTimeRange.from.valueOf()) > TIME_SPAN_TO_TRIGGER_SAMPLES);
+      const updateBasedOnChangedQuery = !isEqual(prevQuery, query);
+      if (config.featureToggles.lokiQueryHints && (updateBasedOnChangedTimeRange || updateBasedOnChangedQuery)) {
         onGetSampleData().catch(console.error);
       }
     }, [datasource, query, timeRange, prevQuery, prevTimeRange]);


### PR DESCRIPTION
Currently log samples are run on every time range and query change. Sometimes, samples query is triggered twice because `query` changes and then `time range` value changes by couple of milliseconds. 

After this change, the log samples query will be triggered after:
1. Query changes
OR
2. Time range changes by more than 5 minutes.

I've added test to document this behavior. 