### PR TITLE
[v10.3.x] Docs: restructure manage dashboards page

### DIFF
--- a/docs/sources/dashboards/build-dashboards/import-dashboards/index.md
+++ b/docs/sources/dashboards/build-dashboards/import-dashboards/index.md
@@ -1,0 +1,60 @@
+---
+aliases:
+  - ../../reference/export_import/ # /docs/grafana/<GRAFANA_VERSION>/reference/export_import/
+  - ../export-import/ # /docs/grafana/<GRAFANA_VERSION>/dashboards/export-import/
+canonical: https://grafana.com/docs/grafana/latest/dashboards/build-dashboards/import-dashboards/
+keywords:
+  - grafana
+  - dashboard
+  - import
+labels:
+  products:
+    - cloud
+    - enterprise
+    - oss
+menuTitle: Import dashboards
+title: Import dashboards
+description: Learn how to import dashboards and about Grafana's preconfigured dashboards
+weight: 5
+---
+
+# Import dashboards
+
+You can import preconfigured dashboards into your Grafana instance or Cloud stack using the UI or the [HTTP API][].
+
+## Import a dashboard
+
+To import a dashboard, follow these steps:
+
+1. Click **Dashboards** in the primary menu.
+1. Click **New** and select **Import** in the drop-down menu.
+1. Perform one of the following steps:
+
+   - Upload a dashboard JSON file.
+   - Paste a [Grafana.com dashboard](#discover-dashboards-on-grafanacom) URL or ID into the field provided.
+   - Paste dashboard JSON text directly into the text area.
+
+1. (Optional) Change the dashboard name, folder, or UID, and specify metric prefixes, if the dashboard uses any.
+1. Select a data source, if required.
+1. Click **Import**.
+1. Save the dashboard.
+
+## Discover dashboards on grafana.com
+
+The [Dashboards page](https://grafana.com/grafana/dashboards/) on grafana.com provides you with dashboards for common server applications. Browse our library of official and community-built dashboards and import them to quickly get up and running.
+
+{{< figure src="/media/docs/grafana/dashboards/screenshot-gcom-dashboards.png" alt="Preconfigured dashboards on grafana.com">}}
+
+You can also add to this library by exporting one of your own dashboards. For more information, refer to [Share dashboards and panels][].
+
+## More examples
+
+Your Grafana Cloud stack comes with several default dashboards in the **Grafana Cloud** folder in **Dashboards**. If you're running your own installation of Grafana, you can find more example dashboards in the `public/dashboards/` directory.
+
+{{% docs/reference %}}
+[HTTP API]: "/docs/grafana/ -> /docs/grafana/<GRAFANA VERSION>/developers/http_api"
+[HTTP API]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/developer-resources/api-reference/http-api"
+
+[Share dashboards and panels]: "/docs/grafana/ -> /docs/grafana/<GRAFANA VERSION>/dashboards/share-dashboards-panels"
+[Share dashboards and panels]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/visualizations/dashboards/share-dashboards-panels"
+{{% /docs/reference %}}

--- a/docs/sources/dashboards/manage-dashboards/index.md
+++ b/docs/sources/dashboards/manage-dashboards/index.md
@@ -3,23 +3,15 @@ aliases:
   - ../features/dashboard/dashboards/
   - ../panels/working-with-panels/organize-dashboard/
   - ../reference/dashboard_folders/
-  - ../reference/export_import/
-  - ../reference/timerange/
-  - ../troubleshooting/troubleshoot-dashboards/
   - dashboard-folders/
   - dashboard-manage/
-  - export-import/
+canonical: https://grafana.com/docs/grafana/latest/dashboards/manage-dashboards/
 keywords:
   - grafana
   - dashboard
   - dashboard folders
   - folder
   - folders
-  - import
-  - export
-  - troubleshoot
-  - time range
-  - scripting
 labels:
   products:
     - cloud
@@ -27,34 +19,31 @@ labels:
     - oss
 menuTitle: Manage dashboards
 title: Manage dashboards
-description: Learn about dashboard folders, generative AI features for dashboards, and troubleshooting
+description: Learn about dashboard management and generative AI features for dashboards
 weight: 8
 ---
 
 # Manage dashboards
 
-This topic includes techniques you can use to manage your Grafana dashboards, including:
+On the **Dashboards** page, you can perform dashboard management tasks such as:
 
-- [Creating and managing dashboard folders](#create-and-manage-dashboard-folders)
-- [Exporting and importing dashboards](#export-and-import-dashboards)
-- [Organizing dashboards](#organize-a-dashboard)
-- [Troubleshooting dashboards](#troubleshoot-dashboards)
+- [Browsing](#browse-dashboards) and [creating](#create-a-dashboard-folder) dashboard folders
+- [Managing folder permissions](#folder-permissions)
+- [Adding generative AI features to dashboards](#set-up-generative-ai-features-for-dashboards)
 
-For more information about creating dashboards, refer to [Add and organize panels](../add-organize-panels).
+For more information about creating dashboards, refer to [Build dashboards][].
 
 ## Browse dashboards
 
 On the **Dashboards** page, you can browse and manage folders and dashboards. This includes the options to:
 
-- Create folders and dashboards
+- Create folders and dashboards.
 - Move dashboards between folders.
 - Delete multiple dashboards and folders.
 - Navigate to a folder.
 - Manage folder permissions. For more information, refer to [Dashboard permissions][].
 
-{{% admonition type="note" %}}
-As of Grafana 10.2, there is no longer a special **General** folder. Dashboards without a folder are now shown at the top level alongside folders.
-{{% /admonition %}}
+The page lists all the dashboards to which you have access, grouped into folders. Dashboards without a folder are displayed at the top level alongside folders.
 
 ## Create a dashboard folder
 
@@ -76,9 +65,9 @@ Alerts can't be placed in folders with slashes (\ /) in the name. If you wish to
 
 **To edit the name of a folder:**
 
-1. Click **Dashboards** in the main menu.
+1. Click **Dashboards** in the primary menu.
 1. Navigate to the folder by selecting it in the list, or searching for it.
-1. Click the pencil icon labelled **Edit title** in the header and update the name of the folder.
+1. Click the **Edit title** icon (pencil) in the header and update the name of the folder.
 
 The new folder name is automatically saved.
 
@@ -88,7 +77,7 @@ You can assign permissions to a folder. Dashboards in the folder inherit any per
 
 **To modify permissions for a folder:**
 
-1. Click **Dashboards** in the main menu.
+1. Click **Dashboards** in the primary menu.
 1. Navigate to the folder by selecting it in the list, or searching for it.
 1. On the folder's page, click **Folder actions** and select **Manage permissions** in the drop-down.
 1. Update the permissions as desired.
@@ -96,49 +85,6 @@ You can assign permissions to a folder. Dashboards in the folder inherit any per
 Changes are saved automatically.
 
 For more information about dashboard permissions, refer to [Dashboard permissions][].
-
-## Export and import dashboards
-
-You can use the Grafana UI or the [HTTP API][] to export and import dashboards.
-
-### Export a dashboard
-
-The dashboard export action creates a Grafana JSON file that contains everything you need, including layout, variables, styles, data sources, queries, and so on, so that you can later import the dashboard.
-
-1. Click **Dashboards** in the main menu.
-1. Open the dashboard you want to export.
-1. Click the **Share** icon in the top navigation bar.
-1. Click **Export**.
-
-   If you're exporting the dashboard to use in another instance, with different data source UIDs, enable the **Export for sharing externally** switch.
-
-1. Click **Save to file**.
-
-Grafana downloads a JSON file to your local machine.
-
-#### Make a dashboard portable
-
-If you want to export a dashboard for others to use, you can add template variables for things like a metric prefix (use a constant variable) and server name.
-
-A template variable of the type `Constant` is automatically hidden in the dashboard, and is also added as a required input when the dashboard is imported.
-
-### Import a dashboard
-
-1. Click **Dashboards** in the left-side menu.
-1. Click **New** and select **Import** in the dropdown menu.
-1. Perform one of the following steps:
-
-   - Upload a dashboard JSON file
-   - Paste a [Grafana.com](https://grafana.com) dashboard URL
-   - Paste dashboard JSON text directly into the text area
-
-The import process enables you to change the name of the dashboard, pick the data source you want the dashboard to use, and specify any metric prefixes (if the dashboard uses any).
-
-### Discover dashboards on grafana.com
-
-Find dashboards for common server applications at [Grafana.com/dashboards](https://grafana.com/dashboards).
-
-{{< figure src="/media/docs/grafana/dashboards/screenshot-gcom-dashboards.png" alt="Preconfigured dashboards on grafana.com">}}
 
 ## Set up generative AI features for dashboards
 
@@ -153,56 +99,13 @@ To access these features, enable the `dashgpt` feature toggle. Then install and 
 
 When enabled, the **✨ Auto generate** option displays next to the **Title** and **Description** fields in your panels and dashboards, or when you press the **Save** button.
 
-## Troubleshoot dashboards
-
-This section provides information to help you solve common dashboard problems.
-
-### Dashboard is slow
-
-- Are you trying to render dozens (or hundreds or thousands) of time-series on a graph? This can cause the browser to lag. Try using functions like `highestMax` (in Graphite) to reduce the returned series.
-- Sometimes the series names can be very large. This causes larger response sizes. Try using `alias` to reduce the size of the returned series names.
-- Are you querying many time-series or for a long range of time? Both of these conditions can cause Grafana or your data source to pull in a lot of data, which may slow it down.
-- It could be high load on your network infrastructure. If the slowness isn't consistent, this may be the problem.
-
-### Dashboard refresh rate issues
-
-By default, Grafana queries your data source every 30 seconds. Setting a low refresh rate on your dashboards puts unnecessary stress on the backend. In many cases, querying this frequently isn't necessary because the data isn't being sent to the system such that changes would be seen.
-
-We recommend the following:
-
-- Only enable auto-refreshing on dashboards, panels, or variables unless if necessary. Users can refresh their browser manually, or you can set the refresh rate for a time period that makes sense (every ten minutes, every hour, and so on).
-- If it's required, then set the refresh rate to once a minute. Users can always refresh the dashboard manually.
-- If your dashboard has a longer time period (such as a week), then you really don't need automated refreshing.
-
-#### Handling or rendering null data is wrong or confusing
-
-Some applications publish data intermittently; for example, they only post a metric when an event occurs. By default, Grafana graphs connect lines between the data points. This can be very deceiving.
-
-In the picture below we've enabled:
-
-- Points and 3-point radius to highlight where data points are actually present.
-- **Connect null values\* is set to **Always\*\*.
-
-{{< figure src="/static/img/docs/troubleshooting/grafana_null_connected.png" max-width="1200px" alt="Graph with null values connected" >}}
-
-In this graph, we set graph to show bars instead of lines and set the **No value** under **Standard options** to **0**. There is a very big difference in the visuals.
-
-{{< figure src="/static/img/docs/troubleshooting/grafana_null_zero.png" max-width="1200px" alt="Graph with null values not connected" >}}
-
-### More examples
-
-You can find more examples in `public/dashboards/` directory of your Grafana installation.
-
 {{% docs/reference %}}
 [Dashboard permissions]: "/docs/grafana/ -> /docs/grafana/<GRAFANA VERSION>/administration/roles-and-permissions#dashboard-permissions"
 [Dashboard permissions]: "/docs/grafana-cloud/ -> /docs/grafana/<GRAFANA VERSION>/administration/roles-and-permissions#dashboard-permissions"
 
-[panels]: "/docs/grafana/ -> /docs/grafana/<GRAFANA VERSION>/panels-visualizations"
-[panels]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/visualizations/panels-visualizations"
+[Grafana LLM plugin documentation]: "/docs/grafana/ -> /docs/grafana-cloud/alerting-and-irm/machine-learning/configure/llm-plugin"
+[Grafana LLM plugin documentation]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/alerting-and-irm/machine-learning/configure/llm-plugin"
 
-[HTTP API]: "/docs/grafana/ -> /docs/grafana/<GRAFANA VERSION>/developers/http_api"
-[HTTP API]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/developer-resources/api-reference/http-api"
-
-[Grafana LLM plugin documentation]: "/docs/grafana/ -> /docs/grafana-cloud/alerting-and-irm/machine-learning/llm-plugin"
-[Grafana LLM plugin documentation]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/alerting-and-irm/machine-learning/llm-plugin"
+[Build dashboards]: "/docs/grafana/ -> /docs/grafana/<GRAFANA VERSION>/dashboards/build-dashboards"
+[Build dashboards]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/visualizations/dashboards/build-dashboards"
 {{% /docs/reference %}}

--- a/docs/sources/dashboards/troubleshoot-dashboards/index.md
+++ b/docs/sources/dashboards/troubleshoot-dashboards/index.md
@@ -1,0 +1,58 @@
+---
+aliases:
+  - ../troubleshooting/troubleshoot-dashboards/
+  - ../reference/timerange/
+canonical: https://grafana.com/docs/grafana/latest/dashboards/troubleshoot-dashboards/
+keywords:
+  - grafana
+  - dashboard
+  - troubleshoot
+  - time range
+labels:
+  products:
+    - cloud
+    - enterprise
+    - oss
+menuTitle: Troubleshoot dashboards
+title: Troubleshoot dashboards
+description: Learn how to troubleshoot common dashboard issues
+weight: 300
+---
+
+# Troubleshoot dashboards
+
+Use the following strategies to help you troubleshoot common dashboard problems.
+
+## Dashboard is slow
+
+- Are you trying to render dozens (or hundreds or thousands) of time series on a graph? This can cause the browser to lag. Try using functions like `highestMax` (in Graphite) to reduce the number of returned series.
+- Sometimes series names can be very large. This causes larger response sizes. Try using `alias` to reduce the size of the returned series names.
+- Are you querying many time series or a long time range? Both of these conditions can cause Grafana or your data source to pull in a lot of data, which may slow the dashboard down. Try reducing one or both of these.
+- There could be high load on your network infrastructure. If the slowness isn't consistent, this may be the problem.
+
+## Dashboard refresh rate issues
+
+By default, Grafana queries your data source every 30 seconds. However, setting a low refresh rate on your dashboards puts unnecessary stress on the backend. In many cases, querying this frequently isn't necessary because the data source isn't sending data often enough for there to be changes every 30 seconds.
+
+We recommend the following:
+
+- Only enable auto-refreshing on dashboards, panels, or variables if necessary. Users can refresh their browser manually.
+- If you require auto-refreshing, then set the refresh rate to a longer time period that makes sense, such as once a minute, every 10 minutes, or every hour.
+- Check the time range of your dashboard. If your dashboard has a longer time range, such as a week, then you really don't need automated refreshing and you should disable it.
+
+## Handling or rendering null data is wrong or confusing
+
+Some applications publish data intermittently; for example, they only post a metric when an event occurs. By default, Grafana graphs connect lines between the data points, but this can be deceptive.
+
+The graph in the following image has:
+
+- Points and 3-point radius enabled to highlight where data points are actually present.
+- **Connect null values** set to **Always**.
+
+{{< figure src="/static/img/docs/troubleshooting/grafana_null_connected.png" max-width="1200px" alt="Graph with null values connected" >}}
+
+The graph in this next image shows bars instead of lines and has the **No value** option under **Standard options** set to **0**.
+
+{{< figure src="/static/img/docs/troubleshooting/grafana_null_zero.png" max-width="1200px" alt="Graph with null values not connected" >}}
+
+As you can see, there's a significant difference in the visualizations.


### PR DESCRIPTION
Backport fb1368d1efa40a971a85bf18596eace132a3e46f from #81311

---

This PR:

- Creates standalone **Troubleshoot dashboards** page
- Creates standalone **Import dashboards** page
- Removes import/export, discover, and troubleshooting content from **Manage dashboards** page
- General copy edits

TO DO

- [x] Clarify **Shared with me** details
- [x] Add canonicals
