### PR TITLE
Alerting: Fix support check for export with modifications

### DIFF
--- a/public/app/features/alerting/unified/hooks/__snapshots__/useAbilities.test.tsx.snap
+++ b/public/app/features/alerting/unified/hooks/__snapshots__/useAbilities.test.tsx.snap
@@ -1,5 +1,71 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`AlertRule abilities should report no permissions while we are loading data for cloud rule 1`] = `
+{
+  "delete-alert-rule": [
+    false,
+    false,
+  ],
+  "duplicate-alert-rule": [
+    false,
+    false,
+  ],
+  "explore-alert-rule": [
+    true,
+    false,
+  ],
+  "modify-export-rule": [
+    false,
+    false,
+  ],
+  "silence-alert-rule": [
+    false,
+    false,
+  ],
+  "update-alert-rule": [
+    false,
+    false,
+  ],
+  "view-alert-rule": [
+    true,
+    false,
+  ],
+}
+`;
+
+exports[`AlertRule abilities should report that all actions are supported for a Grafana Managed alert rule 1`] = `
+{
+  "delete-alert-rule": [
+    true,
+    false,
+  ],
+  "duplicate-alert-rule": [
+    true,
+    false,
+  ],
+  "explore-alert-rule": [
+    true,
+    false,
+  ],
+  "modify-export-rule": [
+    true,
+    false,
+  ],
+  "silence-alert-rule": [
+    true,
+    false,
+  ],
+  "update-alert-rule": [
+    true,
+    false,
+  ],
+  "view-alert-rule": [
+    true,
+    false,
+  ],
+}
+`;
+
 exports[`alertmanager abilities should report Create / Update / Delete actions aren't supported for external vanilla alertmanager 1`] = `
 {
   "create-contact-point": [

--- a/public/app/features/alerting/unified/hooks/useAbilities.test.tsx
+++ b/public/app/features/alerting/unified/hooks/useAbilities.test.tsx
@@ -7,7 +7,7 @@ import { TestProvider } from 'test/helpers/TestProvider';
 import { AlertManagerDataSourceJsonData, AlertManagerImplementation } from 'app/plugins/datasource/alertmanager/types';
 import { AccessControlAction } from 'app/types';
 
-import { getGrafanaRule, grantUserPermissions, mockDataSource } from '../mocks';
+import { getCloudRule, getGrafanaRule, grantUserPermissions, mockDataSource } from '../mocks';
 import { AlertmanagerProvider } from '../state/AlertmanagerContext';
 import { setupDataSources } from '../testSetup/datasources';
 import { DataSourceType, GRAFANA_RULES_SOURCE_NAME } from '../utils/datasource';
@@ -136,7 +136,7 @@ describe('alertmanager abilities', () => {
   });
 });
 
-describe('rule permissions', () => {
+describe('AlertRule abilities', () => {
   it('should report that all actions are supported for a Grafana Managed alert rule', async () => {
     const rule = getGrafanaRule();
 
@@ -149,9 +149,21 @@ describe('rule permissions', () => {
         expect(supported).toBe(true);
       }
     });
+
+    expect(abilities.result.current).toMatchSnapshot();
   });
 
-  it('should report the correct set of supported actions for an external rule with ruler API', async () => {});
+  it('should report no permissions while we are loading data for cloud rule', async () => {
+    const rule = getCloudRule();
+
+    const abilities = renderHook(() => useAllAlertRuleAbilities(rule), { wrapper: TestProvider });
+
+    await waitFor(() => {
+      expect(abilities.result.current).not.toBeUndefined();
+    });
+
+    expect(abilities.result.current).toMatchSnapshot();
+  });
 
   it('should not allow certain actions for provisioned rules', () => {});
 

--- a/public/app/features/alerting/unified/hooks/useAbilities.ts
+++ b/public/app/features/alerting/unified/hooks/useAbilities.ts
@@ -151,7 +151,6 @@ export function useAllAlertRuleAbilities(rule: CombinedRule): Abilities<AlertRul
   // if a rule is either provisioned or a federated rule, we don't allow it to be removed or edited
   const immutableRule = isProvisioned || isFederated;
 
-  // TODO refactor this hook maybe
   const {
     isEditable,
     isRemovable,

--- a/public/app/features/alerting/unified/hooks/useAbilities.ts
+++ b/public/app/features/alerting/unified/hooks/useAbilities.ts
@@ -146,6 +146,7 @@ export function useAllAlertRuleAbilities(rule: CombinedRule): Abilities<AlertRul
 
   const isProvisioned = isGrafanaRulerRule(rule.rulerRule) && Boolean(rule.rulerRule.grafana_alert.provenance);
   const isFederated = isFederatedRuleGroup(rule.group);
+  const isGrafanaManagedAlertRule = isGrafanaRulerRule(rule.rulerRule);
 
   // if a rule is either provisioned or a federated rule, we don't allow it to be removed or edited
   const immutableRule = isProvisioned || isFederated;
@@ -173,7 +174,7 @@ export function useAllAlertRuleAbilities(rule: CombinedRule): Abilities<AlertRul
     [AlertRuleAction.Delete]: [MaybeSupportedUnlessImmutable, isRemovable ?? false],
     [AlertRuleAction.Explore]: toAbility(AlwaysSupported, AccessControlAction.DataSourcesExplore),
     [AlertRuleAction.Silence]: canSilence,
-    [AlertRuleAction.ModifyExport]: [MaybeSupported, exportAllowed],
+    [AlertRuleAction.ModifyExport]: [isGrafanaManagedAlertRule, exportAllowed],
   };
 
   return abilities;


### PR DESCRIPTION
**What is this feature?**

Fixes a small regression where we were checking for ruler API support for exporting with modifications instead of only supporting it for Grafana manager alert rules.
