### PR TITLE
Alerting: Fix missing pagination param in the oncall request

### DIFF
--- a/public/app/features/alerting/unified/api/onCallApi.ts
+++ b/public/app/features/alerting/unified/api/onCallApi.ts
@@ -42,7 +42,11 @@ export const onCallApi = alertingApi.injectEndpoints({
         url: getProxyApiUrl('/api/internal/v1/alert_receive_channels/'),
         // legacy_grafana_alerting is necessary for OnCall.
         // We do NOT need to differentiate between these two on our side
-        params: { filters: true, integration: [GRAFANA_ONCALL_INTEGRATION_TYPE, 'legacy_grafana_alerting'] },
+        params: {
+          filters: true,
+          integration: [GRAFANA_ONCALL_INTEGRATION_TYPE, 'legacy_grafana_alerting'],
+          skip_pagination: true,
+        },
         showErrorAlert: false,
       }),
       transformResponse: (response: AlertReceiveChannelsResult) => {


### PR DESCRIPTION
**Why do we need this feature?**
This PR adds a missing parameter which disables pagination on the OnCall integrations endpoint


Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
