### PR TITLE
DashNav: add missing key

### DIFF
--- a/public/app/features/dashboard/components/DashNav/DashNav.tsx
+++ b/public/app/features/dashboard/components/DashNav/DashNav.tsx
@@ -188,7 +188,13 @@ export const DashNav = React.memo<Props>((props) => {
     if (dashboard.meta.publicDashboardEnabled) {
       // TODO: This will be replaced with the new badge component. Color is required but gets override by css
       buttons.push(
-        <Badge color="blue" text="Public" key="button-badge" className={publicBadgeStyle} data-testid={selectors.publicDashboardTag} />
+        <Badge
+          color="blue"
+          text="Public"
+          key="public-dashboard-button-badge"
+          className={publicBadgeStyle}
+          data-testid={selectors.publicDashboardTag}
+        />
       );
     }
 

--- a/public/app/features/dashboard/components/DashNav/DashNav.tsx
+++ b/public/app/features/dashboard/components/DashNav/DashNav.tsx
@@ -188,7 +188,7 @@ export const DashNav = React.memo<Props>((props) => {
     if (dashboard.meta.publicDashboardEnabled) {
       // TODO: This will be replaced with the new badge component. Color is required but gets override by css
       buttons.push(
-        <Badge color="blue" text="Public" className={publicBadgeStyle} data-testid={selectors.publicDashboardTag} />
+        <Badge color="blue" text="Public" key="button-badge" className={publicBadgeStyle} data-testid={selectors.publicDashboardTag} />
       );
     }
 


### PR DESCRIPTION
Addressing a missing key in DashNav.

![missing key](https://github.com/grafana/grafana/assets/1069378/332204ed-583b-41a9-ad16-273de2211b4f)

Feel free to close if there's another PR containing this fix.