### PR TITLE
Alerting: Fix inconsistent AM raw config when applied via sync vs API

### DIFF
--- a/pkg/services/ngalert/notifier/status.go
+++ b/pkg/services/ngalert/notifier/status.go
@@ -8,15 +8,15 @@ import (
 
 // TODO: We no longer do apimodels at this layer, move it to the API.
 func (am *alertmanager) GetStatus() apimodels.GettableStatus {
-	config := &apimodels.PostableUserConfig{}
-	status := am.Base.GetStatus()
+	config := &apimodels.PostableApiAlertingConfig{}
+	status := am.Base.GetStatus() // TODO: This should return a GettableStatus, for now it returns PostableApiAlertingConfig.
 	if status == nil {
-		return *apimodels.NewGettableStatus(&config.AlertmanagerConfig)
+		return *apimodels.NewGettableStatus(config)
 	}
 
 	if err := json.Unmarshal(status, config); err != nil {
 		am.logger.Error("Unable to unmarshall alertmanager config", "Err", err)
 	}
 
-	return *apimodels.NewGettableStatus(&config.AlertmanagerConfig)
+	return *apimodels.NewGettableStatus(config)
 }


### PR DESCRIPTION
**What is this feature?**

AM config applied via API would use the `PostableUserConfig` as the AM raw config and also the hash used to decide when the AM config has changed. However, when applied via the periodic sync the `PostableApiAlertingConfig` would be used instead.

This changes makes all means of applying the AM config use `PostableApiAlertingConfig`.

**Why do we need this feature?**

This issue causes:
- Inconsistent hash comparisons when modifying the AM causing redundant applies.
- `GetStatus` (`api/alertmanager/grafana/api/v2/status`) assumed the raw config was `PostableUserConfig` causing the endpoint to return correctly after a new config is applied via API and then nothing once the periodic sync runs.

**Who is this feature for?**

UA users.

**Special notes for your reviewer:**

Technically, the upstream `GrafanaAlertamanger` `GetStatus` shouldn't be returning `PostableUserConfig` or `PostableApiAlertingConfig`, but instead `GettableStatus`. However, this issue required changes elsewhere and is out of scope.