### PR TITLE
[WIP] Geomap: Support icon value mapping

### DIFF
--- a/public/app/plugins/panel/geomap/editor/StyleEditor.tsx
+++ b/public/app/plugins/panel/geomap/editor/StyleEditor.tsx
@@ -231,7 +231,7 @@ export const StyleEditor = (props: Props) => {
                     folderName: ResourceFolderName.Marker,
                     placeholderText: hasTextLabel ? 'Select a symbol' : 'Select a symbol or add a text label',
                     placeholderValue: defaultStyleConfig.symbol.fixed,
-                    showSourceRadio: false,
+                    showSourceRadio: true,
                     maxFiles,
                   },
                 } as StandardEditorsRegistryItem

--- a/public/app/plugins/panel/geomap/module.tsx
+++ b/public/app/plugins/panel/geomap/module.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { PanelPlugin } from '@grafana/data';
+import { FieldConfigProperty, PanelPlugin } from '@grafana/data';
 import { config } from '@grafana/runtime';
 import { commonOptionsBuilder } from '@grafana/ui';
 
@@ -18,6 +18,13 @@ export const plugin = new PanelPlugin<Options>(GeomapPanel)
   .useFieldConfig({
     useCustomConfig: (builder) => {
       commonOptionsBuilder.addHideFrom(builder);
+    },
+    standardOptions: {
+      [FieldConfigProperty.Mappings]: {
+        settings: {
+          icon: true,
+        },
+      },
     },
   })
   .setPanelOptions((builder, context) => {


### PR DESCRIPTION
Was inspired by [a recent doc update PR](https://github.com/grafana/grafana/pull/81668/files#r1473553049) for value mappings to take a stab at supporting icon value mapping in geomap.

Didn't get too far but it seems like it should be viable provided we process symbol in similar way as we do in canvas. At a high level I'm wondering if this even makes sense to do in the first place 😬 

Geomap
<img width="1184" alt="Screenshot 2024-01-31 at 5 42 31 PM" src="https://github.com/grafana/grafana/assets/22381771/04845329-fc2e-462f-86ba-42518dd98f51">
<img width="599" alt="Screenshot 2024-01-31 at 5 42 39 PM" src="https://github.com/grafana/grafana/assets/22381771/cdf56fb2-6508-46fd-9e8e-bec06336413e">


Canvas

<img width="1480" alt="Screenshot 2024-01-31 at 5 50 56 PM" src="https://github.com/grafana/grafana/assets/22381771/97311b2a-d6b7-4206-b6d6-d5537fb74030">

[Icon value mappings in geomap_-1706752281559.json](https://github.com/grafana/grafana/files/14119260/Icon.value.mappings.in.geomap_-1706752281559.json)


