### PR TITLE
Chore: Remove Form usage from alerting config components

### DIFF
--- a/public/app/features/alerting/components/BasicSettings.tsx
+++ b/public/app/features/alerting/components/BasicSettings.tsx
@@ -1,7 +1,8 @@
 import React from 'react';
+import { Controller } from 'react-hook-form';
 
 import { SelectableValue } from '@grafana/data';
-import { Field, Input, InputControl, Select } from '@grafana/ui';
+import { Field, Input, Select } from '@grafana/ui';
 
 import { NotificationChannelSecureFields, NotificationChannelType } from '../../../types';
 
@@ -31,7 +32,7 @@ export const BasicSettings = ({
         <Input {...register('name', { required: 'Name is required' })} />
       </Field>
       <Field label="Type">
-        <InputControl
+        <Controller
           name="type"
           render={({ field: { ref, ...field } }) => <Select {...field} options={channels} />}
           control={control}

--- a/public/app/features/alerting/components/OptionElement.tsx
+++ b/public/app/features/alerting/components/OptionElement.tsx
@@ -1,10 +1,11 @@
 import React from 'react';
+import { Controller, UseFormReturn } from 'react-hook-form';
 
-import { FormAPI, Input, InputControl, Select, TextArea } from '@grafana/ui';
+import { Input, Select, TextArea } from '@grafana/ui';
 
 import { NotificationChannelOption } from '../../../types';
 
-interface Props extends Pick<FormAPI<any>, 'register' | 'control'> {
+interface Props extends Pick<UseFormReturn<any>, 'register' | 'control'> {
   option: NotificationChannelOption;
   invalid?: boolean;
 }
@@ -27,7 +28,7 @@ export const OptionElement = ({ control, option, register, invalid }: Props) => 
 
     case 'select':
       return (
-        <InputControl
+        <Controller
           control={control}
           name={`${modelValue}`}
           render={({ field: { ref, ...field } }) => (

--- a/public/app/features/alerting/unified/components/admin/ConfigEditor.tsx
+++ b/public/app/features/alerting/unified/components/admin/ConfigEditor.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
+import { useForm } from 'react-hook-form';
 
-import { Button, CodeEditor, ConfirmModal, Field, Form, HorizontalGroup } from '@grafana/ui';
+import { Button, CodeEditor, ConfirmModal, Field, Stack } from '@grafana/ui';
 
 import { GRAFANA_RULES_SOURCE_NAME } from '../../utils/datasource';
 
@@ -29,77 +30,77 @@ export const ConfigEditor = ({
   onConfirmReset,
   onDismiss,
 }: ConfigEditorProps) => {
+  const {
+    handleSubmit,
+    formState: { errors },
+    setValue,
+    register,
+  } = useForm({ defaultValues });
+
+  register('configJSON', {
+    required: { value: true, message: 'Required' },
+    validate: (value: string) => {
+      try {
+        JSON.parse(value);
+        return true;
+      } catch (e) {
+        return e instanceof Error ? e.message : 'JSON is invalid';
+      }
+    },
+  });
   return (
-    <Form defaultValues={defaultValues} onSubmit={onSubmit} key={defaultValues.configJSON}>
-      {({ errors, setValue, register }) => {
-        register('configJSON', {
-          required: { value: true, message: 'Required' },
-          validate: (value: string) => {
-            try {
-              JSON.parse(value);
-              return true;
-            } catch (e) {
-              return e instanceof Error ? e.message : 'JSON is invalid';
-            }
-          },
-        });
+    <form onSubmit={handleSubmit(onSubmit)} key={defaultValues.configJSON}>
+      <Field
+        disabled={loading}
+        label="Configuration"
+        invalid={!!errors.configJSON}
+        error={errors.configJSON?.message}
+        data-testid={readOnly ? 'readonly-config' : 'config'}
+      >
+        <CodeEditor
+          language="json"
+          width="100%"
+          height={500}
+          showLineNumbers={true}
+          value={defaultValues.configJSON}
+          showMiniMap={false}
+          onSave={(value) => {
+            setValue('configJSON', value);
+          }}
+          onBlur={(value) => {
+            setValue('configJSON', value);
+          }}
+          readOnly={readOnly}
+        />
+      </Field>
 
-        return (
-          <>
-            <Field
-              disabled={loading}
-              label="Configuration"
-              invalid={!!errors.configJSON}
-              error={errors.configJSON?.message}
-              data-testid={readOnly ? 'readonly-config' : 'config'}
-            >
-              <CodeEditor
-                language="json"
-                width="100%"
-                height={500}
-                showLineNumbers={true}
-                value={defaultValues.configJSON}
-                showMiniMap={false}
-                onSave={(value) => {
-                  setValue('configJSON', value);
-                }}
-                onBlur={(value) => {
-                  setValue('configJSON', value);
-                }}
-                readOnly={readOnly}
-              />
-            </Field>
+      {!readOnly && (
+        <Stack gap={1}>
+          <Button type="submit" variant="primary" disabled={loading}>
+            Save configuration
+          </Button>
+          {onReset && (
+            <Button type="button" disabled={loading} variant="destructive" onClick={onReset}>
+              Reset configuration
+            </Button>
+          )}
+        </Stack>
+      )}
 
-            {!readOnly && (
-              <HorizontalGroup>
-                <Button type="submit" variant="primary" disabled={loading}>
-                  Save configuration
-                </Button>
-                {onReset && (
-                  <Button type="button" disabled={loading} variant="destructive" onClick={onReset}>
-                    Reset configuration
-                  </Button>
-                )}
-              </HorizontalGroup>
-            )}
-
-            {Boolean(showConfirmDeleteAMConfig) && onConfirmReset && onDismiss && (
-              <ConfirmModal
-                isOpen={true}
-                title="Reset Alertmanager configuration"
-                body={`Are you sure you want to reset configuration ${
-                  alertManagerSourceName === GRAFANA_RULES_SOURCE_NAME
-                    ? 'for the Grafana Alertmanager'
-                    : `for "${alertManagerSourceName}"`
-                }? Contact points and notification policies will be reset to their defaults.`}
-                confirmText="Yes, reset configuration"
-                onConfirm={onConfirmReset}
-                onDismiss={onDismiss}
-              />
-            )}
-          </>
-        );
-      }}
-    </Form>
+      {Boolean(showConfirmDeleteAMConfig) && onConfirmReset && onDismiss && (
+        <ConfirmModal
+          isOpen={true}
+          title="Reset Alertmanager configuration"
+          body={`Are you sure you want to reset configuration ${
+            alertManagerSourceName === GRAFANA_RULES_SOURCE_NAME
+              ? 'for the Grafana Alertmanager'
+              : `for "${alertManagerSourceName}"`
+          }? Contact points and notification policies will be reset to their defaults.`}
+          confirmText="Yes, reset configuration"
+          onConfirm={onConfirmReset}
+          onDismiss={onDismiss}
+        />
+      )}
+    </form>
   );
 };


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

Removes Form and other deprecated grafana/ui components from  
- public/app/features/alerting/components/BasicSettings.tsx
- public/app/features/alerting/components/OptionElement.tsx
- public/app/features/alerting/unified/components/admin/ConfigEditor.tsx

**Why do we need this feature?**

Part of https://github.com/grafana/grafana/issues/81226.


