### PR TITLE
Tempo: Move query ref to TraceQLEditor

### DIFF
--- a/public/app/plugins/datasource/tempo/traceql/QueryEditor.tsx
+++ b/public/app/plugins/datasource/tempo/traceql/QueryEditor.tsx
@@ -1,6 +1,6 @@
 import { css } from '@emotion/css';
 import { defaults } from 'lodash';
-import React, { useRef, useState } from 'react';
+import React, { useState } from 'react';
 
 import { QueryEditorProps } from '@grafana/data';
 import { config, reportInteraction } from '@grafana/runtime';
@@ -26,16 +26,6 @@ export function QueryEditor(props: Props) {
     const genQuery = generateQueryFromFilters(query.filters || []);
     return genQuery === query.query || genQuery === '{}';
   });
-
-  // The Monaco Editor uses the first version of props.onChange in handleOnMount i.e. always has the initial
-  // value of query because underlying Monaco editor is passed `query` below in the onEditorChange callback.
-  // handleOnMount is called only once when the editor is mounted and does not get updates to query.
-  // So we need useRef to get the latest version of query in the onEditorChange callback.
-  const queryRef = useRef(query);
-  queryRef.current = query;
-  const onEditorChange = (value: string) => {
-    props.onChange({ ...queryRef.current, query: value });
-  };
 
   return (
     <>
@@ -75,8 +65,8 @@ export function QueryEditor(props: Props) {
       )}
       <TraceQLEditor
         placeholder="Enter a TraceQL query or trace ID (run with Shift+Enter)"
-        value={query.query || ''}
-        onChange={onEditorChange}
+        query={query}
+        onChange={props.onChange}
         datasource={props.datasource}
         onRunQuery={props.onRunQuery}
       />


### PR DESCRIPTION
**What is this feature?**

Moves query ref to TraceQLEditor.

**Why do we need this feature?**

If anyone uses the TraceQLEditor component they will also have the fix.

**Who is this feature for?**

Tempo users.