### PR TITLE
intervalv2: use duration-formatting logic from plugin-sdk-go

### DIFF
--- a/pkg/tsdb/intervalv2/intervalv2.go
+++ b/pkg/tsdb/intervalv2/intervalv2.go
@@ -1,7 +1,6 @@
 package intervalv2
 
 import (
-	"fmt"
 	"regexp"
 	"strings"
 	"time"
@@ -13,8 +12,6 @@ import (
 var (
 	DefaultRes         int64 = 1500
 	defaultMinInterval       = time.Millisecond * 1
-	year                     = time.Hour * 24 * 365
-	day                      = time.Hour * 24
 )
 
 type Interval struct {
@@ -129,31 +126,7 @@ func ParseIntervalStringToTimeDuration(interval string) (time.Duration, error) {
 
 // FormatDuration converts a duration into the kbn format e.g. 1m 2h or 3d
 func FormatDuration(inter time.Duration) string {
-	if inter >= year {
-		return fmt.Sprintf("%dy", inter/year)
-	}
-
-	if inter >= day {
-		return fmt.Sprintf("%dd", inter/day)
-	}
-
-	if inter >= time.Hour {
-		return fmt.Sprintf("%dh", inter/time.Hour)
-	}
-
-	if inter >= time.Minute {
-		return fmt.Sprintf("%dm", inter/time.Minute)
-	}
-
-	if inter >= time.Second {
-		return fmt.Sprintf("%ds", inter/time.Second)
-	}
-
-	if inter >= time.Millisecond {
-		return fmt.Sprintf("%dms", inter/time.Millisecond)
-	}
-
-	return "1ms"
+	return gtime.FormatInterval(inter)
 }
 
 //nolint:gocyclo


### PR DESCRIPTION
in https://github.com/grafana/grafana-plugin-sdk-go/pull/880 we added `intervalv2.FormatDuration` to `grafan-plugin-sdk-go` with the name `FormatInterval`.

this pull request adjusts the original to just call the plugin-sdk-version, so that we do not have the function duplicated in two repositories.

(NOTE: later we can of course completely remove `intervalv2.FormatDuration`, but it's used also in multiple datasource plugins, so the PR would become much larger, so i think it's best to do that later, maybe plugin-by-plugin)