### PR TITLE
Settings: Add parameter expansion to DynamicSection.SectionWithEnvOverrides

### DIFF
--- a/pkg/setting/setting.go
+++ b/pkg/setting/setting.go
@@ -1402,6 +1402,14 @@ func (s *DynamicSection) Key(k string) *ini.Key {
 		return key
 	}
 
+	envValue, err := ExpandVar(envValue)
+	if err != nil {
+		s.Logger.Error("got error while expanding %s.%s: %w",
+			s.section.Name(),
+			key.Name(),
+			err)
+	}
+
 	key.SetValue(envValue)
 	s.Logger.Info("Config overridden from Environment variable", "var", fmt.Sprintf("%s=%s", envKey, RedactedValue(envKey, envValue)))
 


### PR DESCRIPTION
**What is this feature?**
Add parameter expansion to `DynamicSection`'s `Key(string)` function (`DynamicSection` is returned by `cfg.SectionWithEnvOverrides()`), because currently it does not support parameter expansion and it has a side effect which updates the key's value (in `cfg.Raw`)  to the value from the environment variable.

**Why do we need this feature?**


**Who is this feature for?**


**Which issue(s) does this PR fix?**:


Fixes #81714

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
