### PR TITLE
Loki: Add to `.eslintrc` list to restrict imports from core

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -111,7 +111,9 @@
         "public/app/plugins/datasource/parca/*.{ts,tsx}",
         "public/app/plugins/datasource/parca/**/*.{ts,tsx}",
         "public/app/plugins/datasource/tempo/*.{ts,tsx}",
-        "public/app/plugins/datasource/tempo/**/*.{ts,tsx}"
+        "public/app/plugins/datasource/tempo/**/*.{ts,tsx}",
+        "public/app/plugins/datasource/loki/*.{ts,tsx}",
+        "public/app/plugins/datasource/loki/**/*.{ts,tsx}"
       ],
       "settings": {
         "import/resolver": {


### PR DESCRIPTION
Part of https://github.com/grafana/grafana/issues/72631
Last step of removing frontend dependencies on core - adding Loki to `.eslintrc`. 