### PR TITLE
Decouple: Make eslint rules stricter and don't allow import of anything from public

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -127,8 +127,8 @@
             "zones": [
               {
                 "target": "./public/app/plugins",
-                "from": "./public/app",
-                "except": ["./plugins"],
+                "from": "./public",
+                "except": ["./app/plugins"],
                 "message": "Core plugins are not allowed to depend on Grafana core packages"
               }
             ]

--- a/public/app/plugins/datasource/cloud-monitoring/components/Aggregation.test.tsx
+++ b/public/app/plugins/datasource/cloud-monitoring/components/Aggregation.test.tsx
@@ -2,7 +2,6 @@ import { render, screen } from '@testing-library/react';
 import React from 'react';
 import { openMenu } from 'react-select-event';
 
-import { TemplateSrvStub } from '../../../../../test/specs/helpers';
 import { MetricKind, ValueTypes } from '../types/query';
 import { MetricDescriptor } from '../types/types';
 
@@ -10,8 +9,6 @@ import { Aggregation, Props } from './Aggregation';
 
 const props: Props = {
   onChange: () => {},
-  // @ts-ignore
-  templateSrv: new TemplateSrvStub(),
   metricDescriptor: {
     valueType: '',
     metricKind: '',
@@ -19,6 +16,7 @@ const props: Props = {
   crossSeriesReducer: '',
   groupBys: [],
   templateVariableOptions: [],
+  refId: 'A',
 };
 
 describe('Aggregation', () => {


### PR DESCRIPTION
While working on decoupling, I noticed that previous eslint rules didn't catch my imports from `public/test/...`. In this PR, I am proposing to make rules stricter and I am fixing 1 case in `Aggregations.test.tsx` where we were importing from `public/test/...`. 