### PR TITLE
Alerting: Prevent inhibition rules in Grafana Alertmanager

### DIFF
--- a/pkg/services/ngalert/notifier/alertmanager_config.go
+++ b/pkg/services/ngalert/notifier/alertmanager_config.go
@@ -156,6 +156,13 @@ func (moa *MultiOrgAlertmanager) gettableUserConfigFromAMConfigString(ctx contex
 }
 
 func (moa *MultiOrgAlertmanager) ApplyAlertmanagerConfiguration(ctx context.Context, org int64, config definitions.PostableUserConfig) error {
+	// We cannot add this validation to PostableUserConfig as that struct is used for both
+	// Grafana Alertmanager (where inhibition rules are not supported) and External Alertmanagers
+	// (including Mimir) where inhibition rules are supported.
+	if len(config.AlertmanagerConfig.InhibitRules) > 0 {
+		return errors.New("inhibition rules are not supported")
+	}
+
 	// Get the last known working configuration
 	_, err := moa.configStore.GetLatestAlertmanagerConfiguration(ctx, org)
 	if err != nil {

--- a/pkg/tests/api/alerting/api_admin_configuration_test.go
+++ b/pkg/tests/api/alerting/api_admin_configuration_test.go
@@ -10,11 +10,13 @@ import (
 	"testing"
 	"time"
 
-	"github.com/grafana/grafana/pkg/expr"
+	"github.com/prometheus/alertmanager/config"
+	"github.com/prometheus/alertmanager/pkg/labels"
 	"github.com/prometheus/common/model"
 	"github.com/stretchr/testify/require"
 
 	"github.com/grafana/grafana/pkg/components/simplejson"
+	"github.com/grafana/grafana/pkg/expr"
 	"github.com/grafana/grafana/pkg/services/datasources"
 	apimodels "github.com/grafana/grafana/pkg/services/ngalert/api/tooling/definitions"
 	ngmodels "github.com/grafana/grafana/pkg/services/ngalert/models"
@@ -351,4 +353,50 @@ func TestIntegrationAdminConfiguration_SendingToExternalAlertmanagers(t *testing
 			return len(alertmanagers.Data.Active) == 0
 		}, 16*time.Second, 8*time.Second) // the sync interval is 2s so after 8s all alertmanagers (if any) most probably are started
 	}
+}
+
+func TestIntegrationAdminConfiguration_CannotCreateInhibitionRules(t *testing.T) {
+	testinfra.SQLiteIntegrationTest(t)
+	dir, path := testinfra.CreateGrafDir(t, testinfra.GrafanaOpts{
+		DisableLegacyAlerting: true,
+		EnableUnifiedAlerting: true,
+		AppModeProduction:     true,
+	})
+	grafanaListedAddr, store := testinfra.StartGrafana(t, dir, path)
+	createUser(t, store, user.CreateUserCommand{
+		DefaultOrgRole: string(org.RoleAdmin),
+		Password:       "admin",
+		Login:          "admin",
+	})
+	client := newAlertingApiClient(grafanaListedAddr, "admin", "admin")
+
+	cfg := apimodels.PostableUserConfig{
+		AlertmanagerConfig: apimodels.PostableApiAlertingConfig{
+			Config: apimodels.Config{
+				Route: &apimodels.Route{
+					Receiver: "test",
+				},
+				InhibitRules: []config.InhibitRule{{
+					SourceMatchers: config.Matchers{{
+						Type:  labels.MatchEqual,
+						Name:  "foo",
+						Value: "bar",
+					}},
+					TargetMatchers: config.Matchers{{
+						Type:  labels.MatchEqual,
+						Name:  "bar",
+						Value: "baz",
+					}},
+				}},
+			},
+			Receivers: []*apimodels.PostableApiReceiver{{
+				Receiver: config.Receiver{
+					Name: "test",
+				},
+			}},
+		},
+	}
+	ok, err := client.PostConfiguration(t, cfg)
+	require.False(t, ok)
+	require.EqualError(t, err, "inhibition rules are not supported")
 }

--- a/pkg/tests/api/alerting/testing.go
+++ b/pkg/tests/api/alerting/testing.go
@@ -3,6 +3,7 @@ package alerting
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -339,6 +340,39 @@ func (a apiClient) UpdateAlertRuleOrgQuota(t *testing.T, orgID int64, limit int6
 		_ = resp.Body.Close()
 	}()
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
+}
+
+func (a apiClient) PostConfiguration(t *testing.T, c apimodels.PostableUserConfig) (bool, error) {
+	t.Helper()
+
+	b, err := json.Marshal(c)
+	require.NoError(t, err)
+
+	u := fmt.Sprintf("%s/api/alertmanager/grafana/config/api/v1/alerts", a.url)
+	req, err := http.NewRequest(http.MethodPost, u, bytes.NewReader(b))
+	require.NoError(t, err)
+	req.Header.Set("Content-Type", "application/json")
+	client := &http.Client{}
+	resp, err := client.Do(req)
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+
+	defer func() {
+		_ = resp.Body.Close()
+	}()
+	b, err = io.ReadAll(resp.Body)
+	require.NoError(t, err)
+
+	data := struct {
+		Message string `json:"message"`
+	}{}
+	require.NoError(t, json.Unmarshal(b, &data))
+
+	if resp.StatusCode == http.StatusAccepted {
+		return true, nil
+	}
+
+	return false, errors.New(data.Message)
 }
 
 func (a apiClient) PostRulesGroupWithStatus(t *testing.T, folder string, group *apimodels.PostableRuleGroupConfig) (apimodels.UpdateRuleGroupResponse, int, string) {


### PR DESCRIPTION
**What is this feature?**

This commit prevents saving configurations containing inhibition rules in Grafana Alertmanager. It does not reject inhibition rules when using external Alertmanagers, such as Mimir. This meant the validation had to be put in the MultiOrgAlertmanager instead of in the validation of PostableUserConfig. We can remove this when inhibition rules are supported in Grafana Managed Alerts.

Here is a screenshot showing it being rejected in Grafana Alertmanager:

<img width="1177" alt="Screenshot 2024-02-01 at 12 41 55 PM" src="https://github.com/grafana/grafana/assets/85952834/5474aafa-cfef-42fc-a6a3-4e77d7b7b4d9">

And accepted in Grafana Cloud Alertmanager:

<img width="1182" alt="Screenshot 2024-02-01 at 12 42 51 PM" src="https://github.com/grafana/grafana/assets/85952834/cfcf4d46-44ae-47dc-a61d-6d136b407b06">

**Why do we need this feature?**

Inhibition rules are not supported in Grafana Managed Alerts.

**Who is this feature for?**

[Add information on what kind of user the feature is for.]

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle.
- [x] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
