### PR TITLE
RBAC: Reject plugin registrations without a name

### DIFF
--- a/pkg/services/accesscontrol/errors.go
+++ b/pkg/services/accesscontrol/errors.go
@@ -21,6 +21,16 @@ func (e *ErrorInvalidRole) Error() string {
 	return "role is invalid"
 }
 
+type ErrorRoleNameMissing struct{}
+
+func (e *ErrorRoleNameMissing) Error() string {
+	return fmt.Sprintf("role has been defined without a name")
+}
+
+func (e *ErrorRoleNameMissing) Unwrap() error {
+	return &ErrorInvalidRole{}
+}
+
 type ErrorRolePrefixMissing struct {
 	Role     string
 	Prefixes []string

--- a/pkg/services/accesscontrol/errors.go
+++ b/pkg/services/accesscontrol/errors.go
@@ -24,7 +24,7 @@ func (e *ErrorInvalidRole) Error() string {
 type ErrorRoleNameMissing struct{}
 
 func (e *ErrorRoleNameMissing) Error() string {
-	return fmt.Sprintf("role has been defined without a name")
+	return "role has been defined without a name"
 }
 
 func (e *ErrorRoleNameMissing) Unwrap() error {

--- a/pkg/services/accesscontrol/pluginutils/utils.go
+++ b/pkg/services/accesscontrol/pluginutils/utils.go
@@ -34,6 +34,9 @@ func ValidatePluginRole(pluginID string, role ac.RoleDTO) error {
 	if pluginID == "" {
 		return ac.ErrPluginIDRequired
 	}
+	if role.DisplayName == "" {
+		return &ac.ErrorRoleNameMissing{}
+	}
 	if !strings.HasPrefix(role.Name, ac.PluginRolePrefix+pluginID+":") {
 		return &ac.ErrorRolePrefixMissing{Role: role.Name, Prefixes: []string{ac.PluginRolePrefix + pluginID + ":"}}
 	}

--- a/pkg/services/accesscontrol/pluginutils/utils_test.go
+++ b/pkg/services/accesscontrol/pluginutils/utils_test.go
@@ -86,33 +86,40 @@ func TestValidatePluginRole(t *testing.T) {
 		wantErr  error
 	}{
 		{
+			name:     "empty display name",
+			pluginID: "test-app",
+			role:     ac.RoleDTO{DisplayName: ""},
+			wantErr:  &ac.ErrorInvalidRole{},
+		},
+		{
 			name:     "empty",
 			pluginID: "",
-			role:     ac.RoleDTO{Name: "plugins::"},
+			role:     ac.RoleDTO{Name: "plugins::reader", DisplayName: "Reader"},
 			wantErr:  ac.ErrPluginIDRequired,
 		},
 		{
 			name:     "invalid name",
 			pluginID: "test-app",
-			role:     ac.RoleDTO{Name: "test-app:reader"},
+			role:     ac.RoleDTO{Name: "test-app:reader", DisplayName: "Reader"},
 			wantErr:  &ac.ErrorInvalidRole{},
 		},
 		{
 			name:     "invalid id in name",
 			pluginID: "test-app",
-			role:     ac.RoleDTO{Name: "plugins:test-app2:reader"},
+			role:     ac.RoleDTO{Name: "plugins:test-app2:reader", DisplayName: "Reader"},
 			wantErr:  &ac.ErrorInvalidRole{},
 		},
 		{
 			name:     "valid name",
 			pluginID: "test-app",
-			role:     ac.RoleDTO{Name: "plugins:test-app:reader"},
+			role:     ac.RoleDTO{Name: "plugins:test-app:reader", DisplayName: "Reader"},
 		},
 		{
 			name:     "invalid permission",
 			pluginID: "test-app",
 			role: ac.RoleDTO{
 				Name:        "plugins:test-app:reader",
+				DisplayName: "Reader",
 				Permissions: []ac.Permission{{Action: "invalidtest-app:read"}},
 			},
 			wantErr: &ac.ErrorInvalidRole{},
@@ -121,7 +128,8 @@ func TestValidatePluginRole(t *testing.T) {
 			name:     "valid permissions",
 			pluginID: "test-app",
 			role: ac.RoleDTO{
-				Name: "plugins:test-app:reader",
+				Name:        "plugins:test-app:reader",
+				DisplayName: "Reader",
 				Permissions: []ac.Permission{
 					{Action: "plugins.app:access", Scope: "plugins:id:test-app"},
 					{Action: "test-app:read"},
@@ -133,7 +141,8 @@ func TestValidatePluginRole(t *testing.T) {
 			name:     "invalid permission targets other plugin",
 			pluginID: "test-app",
 			role: ac.RoleDTO{
-				Name: "plugins:test-app:reader",
+				Name:        "plugins:test-app:reader",
+				DisplayName: "Reader",
 				Permissions: []ac.Permission{
 					{Action: "plugins.app:access", Scope: "plugins:id:other-app"},
 				},


### PR DESCRIPTION
**What is this feature?**

I noticed while writing [the docs](https://github.com/grafana/plugin-tools/pull/709/) that you could technically register a role without any definition:
```json
{
  "roles": [{}]
}
```
To prevent that, I'm adding as a requirement that the registration's name (hence the role's `DisplayName`) must be defined. 

**Why do we need this feature?**

[Add a description of the problem the feature is trying to solve.]

**Who is this feature for?**

[Add information on what kind of user the feature is for.]

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
