### PR TITLE
k8S: (Chore) Add arg to hack codegen to filter openapi generation

### DIFF
--- a/hack/update-codegen.sh
+++ b/hack/update-codegen.sh
@@ -29,6 +29,9 @@ if [[ "${UPDATE_API_KNOWN_VIOLATIONS:-}" == "true" ]]; then
 fi
 
 for api_pkg in $(ls ./pkg/apis); do
+  if [[ "${1-}" != "" && ${api_pkg} != $1 ]]; then
+    continue
+  fi
   for pkg_version in $(ls ./pkg/apis/${api_pkg}); do
     echo "Generating openapi package for ${api_pkg}, version=${pkg_version} ..."
     grafana::codegen::gen_openapi \


### PR DESCRIPTION
(Only applies to OpenAPI part). This allows an argument to be applied to a single app api endpoind (e.g. playlist), skipping the others.


```
# kbrandt @ kbrandt-ws in ~/go/src/github.com/grafana/grafana on git:peakq x [10:14:46] C:1
$ GODEGEN_PKG=~/go/src/github.com/kubernetes/code-generator GOPATH=~/go ./hack/update-codegen.sh
Generating deepcopy code for 8 targets
Generating defaulter code for 9 targets
Generating openapi package for common, version=v0alpha1 ...
pkg/apis/common/v0alpha1
Generating openapi code for 1 targets
Generating openapi package for dashboard, version=v0alpha1 ...
pkg/apis/dashboard/v0alpha1
Generating openapi code for 1 targets
Generating openapi package for datasource, version=v0alpha1 ...
pkg/apis/datasource/v0alpha1
Generating openapi code for 1 targets
Deleting /home/kbrandt/go/src/github.com/grafana/grafana/pkg/apis/datasource/v0alpha1/zz_generated.openapi_violation_exceptions.list since it is empty
Generating openapi package for example, version=v0alpha1 ...
pkg/apis/example/v0alpha1
Generating openapi code for 1 targets
Generating openapi package for featuretoggle, version=v0alpha1 ...
pkg/apis/featuretoggle/v0alpha1
Generating openapi code for 1 targets
Generating openapi package for folder, version=v0alpha1 ...
pkg/apis/folder/v0alpha1
Generating openapi code for 1 targets
Generating openapi package for peakq, version=v0alpha1 ...
pkg/apis/peakq/v0alpha1
Generating openapi code for 1 targets
Generating openapi package for playlist, version=v0alpha1 ...
pkg/apis/playlist/v0alpha1
Generating openapi code for 1 targets
Generating openapi package for service, version=v0alpha1 ...
pkg/apis/service/v0alpha1
Generating openapi code for 1 targets
Deleting /home/kbrandt/go/src/github.com/grafana/grafana/pkg/apis/service/v0alpha1/zz_generated.openapi_violation_exceptions.list since it is empty
Generating applyconfig code for 1 targets
Generating client code for 1 targets
Generating lister code for 1 targets
Generating informer code for 1 targets

# kbrandt @ kbrandt-ws in ~/go/src/github.com/grafana/grafana on git:peakq x [10:16:54] 
$ GODEGEN_PKG=~/go/src/github.com/kubernetes/code-generator GOPATH=~/go ./hack/update-codegen.sh peakq
Generating deepcopy code for 8 targets
Generating defaulter code for 9 targets
Generating openapi package for peakq, version=v0alpha1 ...
pkg/apis/peakq/v0alpha1
Generating openapi code for 1 targets
Generating applyconfig code for 1 targets
Generating client code for 1 targets
Generating lister code for 1 targets
Generating informer code for 1 targets
```