### PR TITLE
Alerting docs: rename provisioning files

### DIFF
--- a/docs/sources/alerting/set-up/provision-alerting-resources/_index.md
+++ b/docs/sources/alerting/set-up/provision-alerting-resources/_index.md
@@ -2,7 +2,7 @@
 aliases:
   - ../provision-alerting-resources/
 canonical: https://grafana.com/docs/grafana/latest/alerting/set-up/provision-alerting-resources/
-description: Provision alerting resources
+description: Import and export alerting resources
 keywords:
   - grafana
   - alerting
@@ -14,23 +14,23 @@ labels:
     - cloud
     - enterprise
     - oss
-title: Provision Grafana Alerting resources
+title: Import and export Grafana Alerting resources
 weight: 300
 ---
 
-# Provision Grafana Alerting resources
+# Import and export Grafana Alerting resources
 
-Alerting infrastructure is often complex, with many pieces of the pipeline that often live in different places. Scaling this across multiple teams and organizations is an especially challenging task. Grafana Alerting provisioning makes this process easier by enabling you to create, manage, and maintain your alerting data in a way that best suits your organization.
+Alerting infrastructure is often complex, with many pieces of the pipeline that often live in different places. Scaling this across multiple teams and organizations is an especially challenging task. Importing and exporting (or provisioning) your alerting resources in Grafana Alerting makes this process easier by enabling you to create, manage, and maintain your alerting data in a way that best suits your organization.
 
-Provisioning for Grafana Alerting supports alert rules, contact points, notification policies, mute timings, and templates.
+You can import alert rules, contact points, notification policies, mute timings, and templates.
 
-You cannot edit provisioned alerting resources in the Grafana UI in the same way as unprovisioned alerting resources. You can only edit provisioned contact points, notification policies, templates, and mute timings in the source where they were created. For example, if you provision your alerting resources using files from disk, you cannot edit the data in Terraform or from within Grafana.
+You cannot edit imported alerting resources in the Grafana UI in the same way as alerting resources that were not imported. You can only edit imported contact points, notification policies, templates, and mute timings in the source where they were created. For example, if you manage your alerting resources using files from disk, you cannot edit the data in Terraform or from within Grafana.
 
-To modify provisioned alert rules, you can use the **Modify export** feature to edit and then export.
+To modify imported alert rules, you can use the **Modify export** feature to edit and then export.
 
-Choose from the options below to provision your Grafana Alerting resources.
+Choose from the options below to import your Grafana Alerting resources.
 
-1. Use file provisioning to provision your Grafana Alerting resources, such as alert rules and contact points, through files on disk.
+1. Use file provisioning to manage your Grafana Alerting resources, such as alert rules and contact points, through files on disk.
 
    {{% admonition type="note" %}}
    File provisioning is not available in Grafana Cloud instances.

--- a/docs/sources/alerting/set-up/provision-alerting-resources/file-provisioning/index.md
+++ b/docs/sources/alerting/set-up/provision-alerting-resources/file-provisioning/index.md
@@ -14,13 +14,13 @@ labels:
     - cloud
     - enterprise
     - oss
-title: Create and manage alerting resources using file provisioning
+title: Use file provisioning to manage alerting resources
 weight: 100
 ---
 
-## Create and manage alerting resources using file provisioning
+## Use file provisioning to manage alerting resources
 
-Provision your alerting resources using files from disk. When you start Grafana, the data from these files is created in your Grafana system. Grafana adds any new resources you created, updates any that you changed, and deletes old ones.
+Manage your alerting resources using files from disk. When you start Grafana, the data from these files is created in your Grafana system. Grafana adds any new resources you created, updates any that you changed, and deletes old ones.
 
 Arrange your files in a directory in a way that best suits your use case. For example, you can choose a team-based layout where every team has its own file, you can have one big file for all your teams; or you can have one file per resource type.
 
@@ -28,9 +28,9 @@ Details on how to set up the files and which fields are required for each object
 
 **Note:**
 
-Provisioning takes place during the initial set up of your Grafana system, but you can re-run it at any time using the [Grafana Admin API][reload-provisioning-configurations].
+Importing takes place during the initial set up of your Grafana system, but you can re-run it at any time using the [Grafana Admin API][reload-provisioning-configurations].
 
-### Provision alert rules
+### Import alert rules
 
 Create or delete alert rules in your Grafana instance(s).
 
@@ -41,11 +41,11 @@ Create or delete alert rules in your Grafana instance(s).
    Example configuration files can be found below.
 
 1. Ensure that your files are in the right directory on the node running the Grafana server, so that they deploy alongside your Grafana instance(s).
-1. Delete the alert rules in Grafana that will be provisioned.
+1. Delete the alert rules in Grafana that are going to be imported.
 
    **Note:**
 
-   If you do not delete the alert rule, it will clash with the provisioned alert rule once uploaded.
+   If you do not delete the alert rule, it will clash with the imported alert rule once uploaded.
 
 Here is an example of a configuration file for creating alert rules.
 
@@ -134,7 +134,7 @@ deleteRules:
     uid: my_id_1
 ```
 
-### Provision contact points
+### Import contact points
 
 Create or delete contact points in your Grafana instance(s).
 
@@ -495,7 +495,7 @@ settings:
     {{ template "default.title" . }}
 ```
 
-### Provision notification policies
+### Import notification policies
 
 Create or reset the notification policy tree in your Grafana instance(s).
 
@@ -587,7 +587,7 @@ In Grafana, the entire notification policy tree is considered a single, large re
 
 Since the policy tree is a single resource, applying it will overwrite a policy tree created through any other means.
 
-### Provision templates
+### Import templates
 
 Create or delete templates in your Grafana instance(s).
 
@@ -627,7 +627,7 @@ deleteTemplates:
     name: my_first_template
 ```
 
-### Provision mute timings
+### Import mute timings
 
 Create or delete mute timings in your Grafana instance(s).
 

--- a/docs/sources/alerting/set-up/provision-alerting-resources/terraform-provisioning/index.md
+++ b/docs/sources/alerting/set-up/provision-alerting-resources/terraform-provisioning/index.md
@@ -13,11 +13,11 @@ labels:
   products:
     - enterprise
     - oss
-title: Create and manage alerting resources using Terraform
+title: Use Terraform to manage alerting resources
 weight: 200
 ---
 
-# Create and manage alerting resources using Terraform
+# Use Terraform to manage alerting resources
 
 Use Terraform’s Grafana Provider to manage your alerting resources and provision them into your Grafana system. Terraform provider support for Grafana Alerting makes it easy to create, manage, and maintain your entire Grafana Alerting stack as code.
 

--- a/docs/sources/alerting/set-up/provision-alerting-resources/view-provisioned-resources/index.md
+++ b/docs/sources/alerting/set-up/provision-alerting-resources/view-provisioned-resources/index.md
@@ -13,12 +13,12 @@ labels:
     - cloud
     - enterprise
     - oss
-menuTitle: Manage provisioned resources in Grafana
-title: Manage provisioned alerting resources in Grafana
+menuTitle: Manage provisioned alerting resources
+title: Manage provisioned alerting resources
 weight: 300
 ---
 
-# Manage provisioned alerting resources in Grafana
+# Manage provisioned alerting resources
 
 Verify that your alerting resources were created in Grafana, as well as edit or export your provisioned alerting resources.
 


### PR DESCRIPTION
updates provisioning file naming to make it less confusing for users and easier to find in search