### PR TITLE
Infinite scroll: implementation clean up

### DIFF
--- a/public/app/features/logs/components/InfiniteScroll.test.tsx
+++ b/public/app/features/logs/components/InfiniteScroll.test.tsx
@@ -3,6 +3,7 @@ import React, { useEffect, useRef, useState } from 'react';
 
 import { LogRowModel, dateTimeForTimeZone } from '@grafana/data';
 import { convertRawToRange } from '@grafana/data/src/datetime/rangeutil';
+import { config } from '@grafana/runtime';
 import { LogsSortOrder } from '@grafana/schema';
 
 import { InfiniteScroll, Props, SCROLLING_THRESHOLD } from './InfiniteScroll';
@@ -56,9 +57,9 @@ function setup(loadMoreMock: () => void, startPosition: number, rows: LogRowMode
   function scrollTo(position: number) {
     element.scrollTop = position;
 
-      act(() => {
-        events['scroll'](new Event('scroll'));
-      });
+    act(() => {
+      events['scroll'](new Event('scroll'));
+    });
   }
   function wheel(deltaY: number) {
     act(() => {
@@ -81,6 +82,13 @@ function setup(loadMoreMock: () => void, startPosition: number, rows: LogRowMode
 
   return { element, events, scrollTo, wheel };
 }
+
+beforeAll(() => {
+  config.featureToggles.logsInfiniteScrolling = true;
+});
+afterAll(() => {
+  config.featureToggles.logsInfiniteScrolling = false;
+});
 
 describe('InfiniteScroll', () => {
   test('Wraps components without adding DOM elements', async () => {
@@ -121,7 +129,7 @@ describe('InfiniteScroll', () => {
         const { scrollTo } = setup(loadMoreMock, startPosition, rows, order);
 
         expect(await screen.findByTestId('contents')).toBeInTheDocument();
-        
+
         scrollTo(endPosition);
 
         expect(loadMoreMock).toHaveBeenCalled();
@@ -168,7 +176,7 @@ describe('InfiniteScroll', () => {
         const { scrollTo } = setup(loadMoreMock, startPosition, rows, order);
 
         expect(await screen.findByTestId('contents')).toBeInTheDocument();
-        
+
         scrollTo(endPosition);
 
         expect(loadMoreMock).toHaveBeenCalledWith({
@@ -185,7 +193,7 @@ describe('InfiniteScroll', () => {
         const { scrollTo } = setup(loadMoreMock, startPosition, rows, order);
 
         expect(await screen.findByTestId('contents')).toBeInTheDocument();
-        
+
         scrollTo(endPosition);
 
         expect(loadMoreMock).toHaveBeenCalledWith({
@@ -207,7 +215,7 @@ describe('InfiniteScroll', () => {
             const { scrollTo } = setup(loadMoreMock, startPosition, rows, order);
 
             expect(await screen.findByTestId('contents')).toBeInTheDocument();
-            
+
             scrollTo(endPosition);
 
             expect(loadMoreMock).not.toHaveBeenCalled();
@@ -230,7 +238,7 @@ describe('InfiniteScroll', () => {
             const { scrollTo } = setup(loadMoreMock, startPosition, rows, order);
 
             expect(await screen.findByTestId('contents')).toBeInTheDocument();
-            
+
             scrollTo(endPosition);
 
             expect(loadMoreMock).not.toHaveBeenCalled();

--- a/public/app/features/logs/components/InfiniteScroll.test.tsx
+++ b/public/app/features/logs/components/InfiniteScroll.test.tsx
@@ -124,17 +124,26 @@ describe('InfiniteScroll', () => {
       test.each([
         ['top', 10, 0],
         ['bottom', 50, 60],
-      ])('Requests more logs when scrolling %s', async (_: string, startPosition: number, endPosition: number) => {
-        const loadMoreMock = jest.fn();
-        const { scrollTo } = setup(loadMoreMock, startPosition, rows, order);
+      ])(
+        'Requests more logs when scrolling %s',
+        async (direction: string, startPosition: number, endPosition: number) => {
+          const loadMoreMock = jest.fn();
+          const { scrollTo, element } = setup(loadMoreMock, startPosition, rows, order);
 
-        expect(await screen.findByTestId('contents')).toBeInTheDocument();
+          expect(await screen.findByTestId('contents')).toBeInTheDocument();
 
-        scrollTo(endPosition);
+          scrollTo(endPosition);
 
-        expect(loadMoreMock).toHaveBeenCalled();
-        expect(await screen.findByTestId('Spinner')).toBeInTheDocument();
-      });
+          expect(loadMoreMock).toHaveBeenCalled();
+          expect(await screen.findByTestId('Spinner')).toBeInTheDocument();
+          if (direction === 'bottom') {
+            // Bottom loader visibility trick
+            expect(element.scrollTo).toHaveBeenCalled();
+          } else {
+            expect(element.scrollTo).not.toHaveBeenCalled();
+          }
+        }
+      );
 
       test.each([
         ['up', -5, 0],
@@ -273,6 +282,7 @@ function getMockElement(scrollTop: number) {
     scrollHeight: 100,
     clientHeight: 40,
     scrollTop,
+    scrollTo: jest.fn(),
   };
 
   return { element, events };

--- a/public/app/features/logs/components/InfiniteScroll.tsx
+++ b/public/app/features/logs/components/InfiniteScroll.tsx
@@ -210,16 +210,16 @@ function canScrollTop(
   currentRange: TimeRange,
   timeZone: TimeZone,
   sortOrder: LogsSortOrder
-): AbsoluteTimeRange | false {
+): AbsoluteTimeRange | undefined {
   if (sortOrder === LogsSortOrder.Descending) {
     // When requesting new logs, update the current range if using relative time ranges.
     currentRange = updateCurrentRange(currentRange, timeZone);
     const canScroll = currentRange.to.valueOf() - visibleRange.to > SCROLLING_THRESHOLD;
-    return canScroll ? getNextRange(visibleRange, currentRange, timeZone) : false;
+    return canScroll ? getNextRange(visibleRange, currentRange, timeZone) : undefined;
   }
 
   const canScroll = Math.abs(currentRange.from.valueOf() - visibleRange.from) > SCROLLING_THRESHOLD;
-  return canScroll ? getPrevRange(visibleRange, currentRange) : false;
+  return canScroll ? getPrevRange(visibleRange, currentRange) : undefined;
 }
 
 function canScrollBottom(
@@ -227,15 +227,15 @@ function canScrollBottom(
   currentRange: TimeRange,
   timeZone: TimeZone,
   sortOrder: LogsSortOrder
-): AbsoluteTimeRange | false {
+): AbsoluteTimeRange | undefined {
   if (sortOrder === LogsSortOrder.Descending) {
     const canScroll = Math.abs(currentRange.from.valueOf() - visibleRange.from) > SCROLLING_THRESHOLD;
-    return canScroll ? getPrevRange(visibleRange, currentRange) : false;
+    return canScroll ? getPrevRange(visibleRange, currentRange) : undefined;
   }
   // When requesting new logs, update the current range if using relative time ranges.
   currentRange = updateCurrentRange(currentRange, timeZone);
   const canScroll = currentRange.to.valueOf() - visibleRange.to > SCROLLING_THRESHOLD;
-  return canScroll ? getNextRange(visibleRange, currentRange, timeZone) : false;
+  return canScroll ? getNextRange(visibleRange, currentRange, timeZone) : undefined;
 }
 
 // Given a TimeRange, returns a new instance if using relative time, or else the same.

--- a/public/app/features/logs/components/InfiniteScroll.tsx
+++ b/public/app/features/logs/components/InfiniteScroll.tsx
@@ -33,13 +33,16 @@ export const InfiniteScroll = ({
   const [lowerOutOfRange, setLowerOutOfRange] = useState(false);
   const [upperLoading, setUpperLoading] = useState(false);
   const [lowerLoading, setLowerLoading] = useState(false);
+  const rowsRef = useRef<LogRowModel[]>(rows);
   const lastScroll = useRef<number>(scrollElement?.scrollTop || 0);
 
+  // Reset messages when range/order/rows change
   useEffect(() => {
     setUpperOutOfRange(false);
     setLowerOutOfRange(false);
   }, [range, rows, sortOrder]);
 
+  // Reset loading messages when loading stops
   useEffect(() => {
     if (!loading) {
       setUpperLoading(false);
@@ -47,12 +50,24 @@ export const InfiniteScroll = ({
     }
   }, [loading]);
 
+  // Ensure bottom loader visibility
   useEffect(() => {
     if (lowerLoading && scrollElement) {
-      // Ensure bottom loader visibility
       scrollElement.scrollTo(0, scrollElement.scrollHeight - scrollElement.clientHeight);
     }
   }, [lowerLoading, scrollElement]);
+
+  // Request came back with no new past rows
+  useEffect(() => {
+    if (rows !== rowsRef.current && rows.length === rowsRef.current.length && (upperLoading || lowerLoading)) {
+      if (sortOrder === LogsSortOrder.Descending && lowerLoading) {
+        setLowerOutOfRange(true);
+      } else if (sortOrder === LogsSortOrder.Ascending && upperLoading) {
+        setUpperOutOfRange(true);
+      }
+    }
+    rowsRef.current = rows;
+  }, [lowerLoading, rows, sortOrder, upperLoading]);
 
   useEffect(() => {
     if (!scrollElement || !loadMoreLogs) {

--- a/public/app/features/logs/components/InfiniteScroll.tsx
+++ b/public/app/features/logs/components/InfiniteScroll.tsx
@@ -69,15 +69,12 @@ export const InfiniteScroll = ({
     }
 
     function scrollTop() {
-      if (!canScrollTop(getVisibleRange(rows), range, timeZone, sortOrder)) {
+      const newRange = canScrollTop(getVisibleRange(rows), range, timeZone, sortOrder);
+      if (!newRange) {
         setUpperOutOfRange(true);
         return;
       }
       setUpperOutOfRange(false);
-      const newRange =
-        sortOrder === LogsSortOrder.Descending
-          ? getNextRange(getVisibleRange(rows), range, timeZone)
-          : getPrevRange(getVisibleRange(rows), range);
       loadMoreLogs?.(newRange);
       setUpperLoading(true);
       reportInteraction('grafana_logs_infinite_scrolling', {
@@ -87,15 +84,12 @@ export const InfiniteScroll = ({
     }
 
     function scrollBottom() {
-      if (!canScrollBottom(getVisibleRange(rows), range, timeZone, sortOrder)) {
+      const newRange = canScrollBottom(getVisibleRange(rows), range, timeZone, sortOrder);
+      if (!newRange) {
         setLowerOutOfRange(true);
         return;
       }
       setLowerOutOfRange(false);
-      const newRange =
-        sortOrder === LogsSortOrder.Descending
-          ? getPrevRange(getVisibleRange(rows), range)
-          : getNextRange(getVisibleRange(rows), range, timeZone);
       loadMoreLogs?.(newRange);
       setLowerLoading(true);
       reportInteraction('grafana_logs_infinite_scrolling', {
@@ -160,9 +154,8 @@ function shouldLoadMore(event: Event | WheelEvent, element: HTMLDivElement, last
     scrollDirection === ScrollDirection.Top
       ? element.scrollTop
       : element.scrollHeight - element.scrollTop - element.clientHeight;
-  const coef = 1;
 
-  return diff <= coef ? scrollDirection : ScrollDirection.NoScroll;
+  return diff <= 1 ? scrollDirection : ScrollDirection.NoScroll;
 }
 
 function getVisibleRange(rows: LogRowModel[]) {
@@ -195,13 +188,16 @@ function canScrollTop(
   currentRange: TimeRange,
   timeZone: TimeZone,
   sortOrder: LogsSortOrder
-) {
+): AbsoluteTimeRange | false {
   if (sortOrder === LogsSortOrder.Descending) {
     // When requesting new logs, update the current range if using relative time ranges.
     currentRange = updateCurrentRange(currentRange, timeZone);
-    return currentRange.to.valueOf() - visibleRange.to > SCROLLING_THRESHOLD;
+    const canScroll = currentRange.to.valueOf() - visibleRange.to > SCROLLING_THRESHOLD;
+    return canScroll ? getNextRange(visibleRange, currentRange, timeZone) : false;
   }
-  return Math.abs(currentRange.from.valueOf() - visibleRange.from) > SCROLLING_THRESHOLD;
+
+  const canScroll = Math.abs(currentRange.from.valueOf() - visibleRange.from) > SCROLLING_THRESHOLD;
+  return canScroll ? getPrevRange(visibleRange, currentRange) : false;
 }
 
 function canScrollBottom(
@@ -209,13 +205,15 @@ function canScrollBottom(
   currentRange: TimeRange,
   timeZone: TimeZone,
   sortOrder: LogsSortOrder
-) {
+): AbsoluteTimeRange | false {
   if (sortOrder === LogsSortOrder.Descending) {
-    return Math.abs(currentRange.from.valueOf() - visibleRange.from) > SCROLLING_THRESHOLD;
+    const canScroll = Math.abs(currentRange.from.valueOf() - visibleRange.from) > SCROLLING_THRESHOLD;
+    return canScroll ? getPrevRange(visibleRange, currentRange) : false;
   }
   // When requesting new logs, update the current range if using relative time ranges.
   currentRange = updateCurrentRange(currentRange, timeZone);
-  return currentRange.to.valueOf() - visibleRange.to > SCROLLING_THRESHOLD;
+  const canScroll = currentRange.to.valueOf() - visibleRange.to > SCROLLING_THRESHOLD;
+  return canScroll ? getNextRange(visibleRange, currentRange, timeZone) : false;
 }
 
 // Given a TimeRange, returns a new instance if using relative time, or else the same.

--- a/public/app/features/logs/components/InfiniteScroll.tsx
+++ b/public/app/features/logs/components/InfiniteScroll.tsx
@@ -3,7 +3,7 @@ import React, { ReactNode, useEffect, useRef, useState } from 'react';
 
 import { AbsoluteTimeRange, LogRowModel, TimeRange } from '@grafana/data';
 import { convertRawToRange, isRelativeTime, isRelativeTimeRange } from '@grafana/data/src/datetime/rangeutil';
-import { reportInteraction } from '@grafana/runtime';
+import { config, reportInteraction } from '@grafana/runtime';
 import { LogsSortOrder, TimeZone } from '@grafana/schema';
 
 import { LoadingIndicator } from './LoadingIndicator';
@@ -53,7 +53,7 @@ export const InfiniteScroll = ({
     }
 
     function handleScroll(event: Event | WheelEvent) {
-      if (!scrollElement || !loadMoreLogs || !rows.length || loading) {
+      if (!scrollElement || !loadMoreLogs || !rows.length || loading || !config.featureToggles.logsInfiniteScrolling) {
         return;
       }
       event.stopImmediatePropagation();

--- a/public/app/features/logs/components/InfiniteScroll.tsx
+++ b/public/app/features/logs/components/InfiniteScroll.tsx
@@ -48,6 +48,12 @@ export const InfiniteScroll = ({
   }, [loading]);
 
   useEffect(() => {
+    if (lowerLoading && scrollElement) {
+      scrollElement.scrollTo(0, scrollElement.scrollHeight - scrollElement.clientHeight);
+    }
+  }, [lowerLoading, scrollElement]);
+
+  useEffect(() => {
     if (!scrollElement || !loadMoreLogs) {
       return;
     }

--- a/public/app/features/logs/components/InfiniteScroll.tsx
+++ b/public/app/features/logs/components/InfiniteScroll.tsx
@@ -49,6 +49,7 @@ export const InfiniteScroll = ({
 
   useEffect(() => {
     if (lowerLoading && scrollElement) {
+      // Ensure bottom loader visibility
       scrollElement.scrollTo(0, scrollElement.scrollHeight - scrollElement.clientHeight);
     }
   }, [lowerLoading, scrollElement]);


### PR DESCRIPTION
Since we will proabably not need https://github.com/grafana/grafana/pull/81156, I'm bringing here some minor enhancements that I made in that PR.

- Reordered test
- Cleaned up scroll component
- Internally disable by feature flag
- Improved visibility of the lower loader
- **Ensure End of range message is displayed when older logs return no result**

**Which issue(s) does this PR fix?**:

Part of https://github.com/grafana/grafana/issues/71728
