### PR TITLE
Licensing: Redact license when overriden by env variable

### DIFF
--- a/pkg/setting/setting.go
+++ b/pkg/setting/setting.go
@@ -587,6 +587,7 @@ func RedactedValue(key, value string) string {
 		"ENCRYPTION_KEY",
 		"VAULT_TOKEN",
 		"CLIENT_SECRET",
+		"ENTERPRISE_LICENSE",
 	} {
 		if match, err := regexp.MatchString(pattern, uppercased); match && err == nil {
 			return RedactedPassword

--- a/pkg/setting/setting_test.go
+++ b/pkg/setting/setting_test.go
@@ -831,6 +831,12 @@ func TestRedactedValue(t *testing.T) {
 			expected: RedactedPassword,
 		},
 		{
+			desc:     "license key with non-empty value",
+			key:      "GF_ENTERPRISE_LICENSE_TEXT",
+			value:    "some_license_key_test",
+			expected: RedactedPassword,
+		},
+		{
 			desc:     "sensitive key with empty value",
 			key:      "private_key_path",
 			value:    "",


### PR DESCRIPTION
**What is this feature?**
Adds Grafana License env variable as one of the redacted variables in the logs
Tested locally and logs are shown as expected. 

Please check that:
- [x] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle.
- [x] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
