### PR TITLE
I18n: Fix path for Crowdin upload 

### DIFF
--- a/.github/workflows/i18n-crowdin-download.yml
+++ b/.github/workflows/i18n-crowdin-download.yml
@@ -45,6 +45,8 @@ jobs:
           pull_request_base_branch_name: 'main'
           base_url: 'https://grafana.api.crowdin.com'
           config: 'crowdin.yml'
+          source: 'public/locales/en-US/grafana.json'
+          translation: 'public/locales/%locale%/%original_file_name%'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           CROWDIN_PROJECT_ID: ${{ secrets.CROWDIN_PROJECT_ID }}

--- a/.github/workflows/i18n-crowdin-upload.yml
+++ b/.github/workflows/i18n-crowdin-upload.yml
@@ -1,6 +1,7 @@
 name: Crowdin Upload Action
 
 on:
+  workflow_dispatch:
   push:
     paths:
       - 'public/locales/en-US/grafana.json'
@@ -19,11 +20,14 @@ jobs:
         uses: crowdin/github-action@v1
         with:
           upload_sources: true
+          upload_sources_args: '--dest=public/locales/en-US/grafana.json'
           upload_translations: false
           download_translations: false
           create_pull_request: false
           base_url: 'https://grafana.api.crowdin.com'
           config: 'crowdin.yml'
+          source: 'public/locales/en-US/grafana.json'
+          translation: 'public/locales/%locale%/%original_file_name%'
         env:
           CROWDIN_PROJECT_ID: ${{ secrets.CROWDIN_PROJECT_ID }}
           CROWDIN_PERSONAL_TOKEN: ${{ secrets.CROWDIN_PERSONAL_TOKEN }}

--- a/crowdin.yml
+++ b/crowdin.yml
@@ -1,7 +1,5 @@
 files:
-  - source: /public/locales/en-US/grafana.json
-    translation: /public/locales/%locale%/%original_file_name%
-    type: i18next_json
+  - type: i18next_json
 # The following are pulled from env variables
 project_id_env: CROWDIN_PROJECT_ID
 api_token_env: CROWDIN_PERSONAL_TOKEN


### PR DESCRIPTION
**What is this feature?**
When uploading the source for translations via `.github/workflows/i18n-crowdin-upload.yml` the file was created in the root directory in Crowdin although we have a file hierarchy.

**Why do we need this feature?**
This update to the mentioned GH action fixes the destination of the uploaded file.

**Who is this feature for?**
Everyone working on our i18n.

**Which issue(s) does this PR fix?**:
Relates to #81571

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
