### PR TITLE
Chore: Use maputil functions from grafana-azure-sdk-go

### DIFF
--- a/pkg/tsdb/prometheus/client/transport.go
+++ b/pkg/tsdb/prometheus/client/transport.go
@@ -5,15 +5,16 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/grafana/grafana-azure-sdk-go/util/maputil"
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
 	sdkhttpclient "github.com/grafana/grafana-plugin-sdk-go/backend/httpclient"
 
 	"github.com/grafana/grafana-plugin-sdk-go/backend/log"
+
 	"github.com/grafana/grafana/pkg/setting"
 	"github.com/grafana/grafana/pkg/tsdb/prometheus/azureauth"
 	"github.com/grafana/grafana/pkg/tsdb/prometheus/middleware"
 	"github.com/grafana/grafana/pkg/tsdb/prometheus/utils"
-	"github.com/grafana/grafana/pkg/util/maputil"
 )
 
 // CreateTransportOptions creates options for the http client. Probably should be shared and should not live in the

--- a/pkg/tsdb/prometheus/querydata/request.go
+++ b/pkg/tsdb/prometheus/querydata/request.go
@@ -7,6 +7,7 @@ import (
 	"regexp"
 	"time"
 
+	"github.com/grafana/grafana-azure-sdk-go/util/maputil"
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
 	"github.com/grafana/grafana-plugin-sdk-go/data"
 	"go.opentelemetry.io/otel/attribute"
@@ -20,7 +21,6 @@ import (
 	"github.com/grafana/grafana/pkg/tsdb/prometheus/models"
 	"github.com/grafana/grafana/pkg/tsdb/prometheus/querydata/exemplar"
 	"github.com/grafana/grafana/pkg/tsdb/prometheus/utils"
-	"github.com/grafana/grafana/pkg/util/maputil"
 )
 
 const legendFormatAuto = "__auto"

--- a/pkg/tsdb/prometheus/resource/resource.go
+++ b/pkg/tsdb/prometheus/resource/resource.go
@@ -6,11 +6,12 @@ import (
 	"fmt"
 	"net/http"
 
+	"github.com/grafana/grafana-azure-sdk-go/util/maputil"
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
 	"github.com/grafana/grafana-plugin-sdk-go/backend/log"
+
 	"github.com/grafana/grafana/pkg/tsdb/prometheus/client"
 	"github.com/grafana/grafana/pkg/tsdb/prometheus/utils"
-	"github.com/grafana/grafana/pkg/util/maputil"
 )
 
 type Resource struct {


### PR DESCRIPTION
**What is this feature?**

For the decoupling/externalization I removed `"github.com/grafana/grafana/pkg/util/maputil"` imports and use the same functions from `grafana-azure-sdk-go`. https://github.com/grafana/grafana-azure-sdk-go/blob/main/util/maputil/maputil.go

**Why do we need this feature?**

For decoupling/externalisation

