### PR TITLE
Provisioning: sync samples

### DIFF
--- a/conf/provisioning/access-control/sample.yaml
+++ b/conf/provisioning/access-control/sample.yaml
@@ -19,9 +19,9 @@
 #       # <string, required> action allowed.
 #       - action: 'users:read'
 #         #<string> scope it applies to.
-#         scope: 'users:*'
+#         scope: 'global.users:*'
 #       - action: 'users:write'
-#         scope: 'users:*'
+#         scope: 'global.users:*'
 #       - action: 'users:create'
 #   - name: 'custom:global:users:reader'
 #     # <bool> overwrite org id and creates a global role.
@@ -42,9 +42,9 @@
 #     # <list> list of the permissions to add/remove on top of the copied ones.
 #     permissions:
 #       - action: 'users:read'
-#         scope: 'users:*'
+#         scope: 'global.users:*'
 #       - action: 'users:write'
-#         scope: 'users:*'
+#         scope: 'global.users:*'
 #         # <string> state of the permission. Defaults to 'present'. If 'absent', the permission will be removed.
 #         state: absent
 

--- a/conf/provisioning/access-control/sample.yaml
+++ b/conf/provisioning/access-control/sample.yaml
@@ -1,5 +1,5 @@
 # ---
-# # config file version
+# Configuration file version
 # apiVersion: 2
 
 # # <list> list of roles to insert/update/delete
@@ -19,9 +19,9 @@
 #       # <string, required> action allowed.
 #       - action: 'users:read'
 #         #<string> scope it applies to.
-#         scope: 'global.users:*'
+#         scope: 'users:*'
 #       - action: 'users:write'
-#         scope: 'global.users:*'
+#         scope: 'users:*'
 #       - action: 'users:create'
 #   - name: 'custom:global:users:reader'
 #     # <bool> overwrite org id and creates a global role.
@@ -42,9 +42,9 @@
 #     # <list> list of the permissions to add/remove on top of the copied ones.
 #     permissions:
 #       - action: 'users:read'
-#         scope: 'global.users:*'
+#         scope: 'users:*'
 #       - action: 'users:write'
-#         scope: 'global.users:*'
+#         scope: 'users:*'
 #         # <string> state of the permission. Defaults to 'present'. If 'absent', the permission will be removed.
 #         state: absent
 

--- a/conf/provisioning/alerting/sample.yaml
+++ b/conf/provisioning/alerting/sample.yaml
@@ -1,124 +1,132 @@
-# # config file version
+# Configuration file version
 apiVersion: 1
 
 # # List of rule groups to import or update
 # groups:
-#     # <int> organization ID, default = 1
+#   # <int> organization ID, default = 1
 #   - orgId: 1
 #     # <string, required> name of the rule group
 #     name: my_rule_group
 #     # <string, required> name of the folder the rule group will be stored in
 #     folder: my_first_folder
-#     # <duration, required> interval of the rule group evaluation
+#     # <duration, required> interval that the rule group should evaluated at
 #     interval: 60s
 #     # <list, required> list of rules that are part of the rule group
 #     rules:
 #       # <string, required> unique identifier for the rule. Should not exceed 40 symbols. Only letters, numbers, - (hyphen), and _ (underscore) allowed.
-#     - uid: my_id_1
-#       # <string, required> title of the rule, will be displayed in the UI
-#       title: my_first_rule
-#       # <string, required> query used for the condition
-#       condition: A
-#       # <list, required> list of query objects that should be executed on each
-#       #                  evaluation - should be obtained via the API
-#       data:
-#       - refId: A
-#         datasourceUid: "__expr__"
-#         model:
-#           conditions:
-#           - evaluator:
-#               params:
-#               - 3
-#               type: gt
-#             operator:
-#               type: and
-#             query:
-#               params:
-#               - A
-#             reducer:
-#               type: last
-#             type: query
-#           datasource:
-#             type: __expr__
-#             uid: "__expr__"
-#           expression: 1==0
-#           intervalMs: 1000
-#           maxDataPoints: 43200
-#           refId: A
-#           type: math
-#       # <string> UID of a dashboard that the alert rule should be linked to
-#       dashboardUid: my_dashboard
-#       # <int> ID of the panel that the alert rule should be linked to
-#       panelId: 123
-#       # <string> state of the alert rule when no data is returned
-#       #          possible values: "NoData", "Alerting", "OK", default = NoData
-#       noDataState: Alerting
-#       # <string> state of the alert rule when the query execution
-#       #          fails - possible values: "Error", "Alerting", "OK"
-#       #          default = Alerting
-#       executionErrorState: Alerting
-#       # <duration, required> how long the alert condition should be breached before Firing. Before this time has elapsed, the alert is considered to be Pending
-#       for: 60s
-#       # <map<string, string>> map of strings to attach arbitrary custom data
-#       annotations:
-#         some_key: some_value
-#       # <map<string, string> map of strings to filter and
-#       #                      route alerts
-#       labels:
-#         team: sre_team_1
-#       isPaused: false
+#       - uid: my_id_1
+#         # <string, required> title of the rule that will be displayed in the UI
+#         title: my_first_rule
+#         # <string, required> which query should be used for the condition
+#         condition: A
+#         # <list, required> list of query objects that should be executed on each
+#         #                  evaluation - should be obtained through the API
+#         data:
+#           - refId: A
+#             datasourceUid: '__expr__'
+#             model:
+#               conditions:
+#                 - evaluator:
+#                     params:
+#                       - 3
+#                     type: gt
+#                   operator:
+#                     type: and
+#                   query:
+#                     params:
+#                       - A
+#                   reducer:
+#                     type: last
+#                   type: query
+#               datasource:
+#                 type: __expr__
+#                 uid: '__expr__'
+#               expression: 1==0
+#               intervalMs: 1000
+#               maxDataPoints: 43200
+#               refId: A
+#               type: math
+#         # <string> UID of a dashboard that the alert rule should be linked to
+#         dashboardUid: my_dashboard
+#         # <int> ID of the panel that the alert rule should be linked to
+#         panelId: 123
+#         # <string> the state the alert rule will have when no data is returned
+#         #          possible values: "NoData", "Alerting", "OK", default = NoData
+#         noDataState: Alerting
+#         # <string> the state the alert rule will have when the query execution
+#         #          failed - possible values: "Error", "Alerting", "OK"
+#         #          default = Alerting
+#         execErrState: Alerting
+#         # <duration, required> for how long should the alert fire before alerting
+#         for: 60s
+#         # <map<string, string>> a map of strings to pass around any data
+#         annotations:
+#           some_key: some_value
+#         # <map<string, string> a map of strings that can be used to filter and
+#         #                      route alerts
+#         labels:
+#           team: sre_team_1
 
 # # List of alert rule UIDs that should be deleted
 # deleteRules:
-#    # <int> organization ID, default = 1
-#  - orgId: 1
-#    # <string, required> unique identifier for the rule
-#    uid: my_id_1
+#   # <int> organization ID, default = 1
+#   - orgId: 1
+#     # <string, required> unique identifier for the rule
+#     uid: my_id_1
 
 # # List of contact points to import or update
 # contactPoints:
-#     # <int> organization ID, default = 1
+#   # <int> organization ID, default = 1
 #   - orgId: 1
 #     # <string, required> name of the contact point
 #     name: cp_1
 #     receivers:
 #       # <string, required> unique identifier for the receiver. Should not exceed 40 symbols. Only letters, numbers, - (hyphen), and _ (underscore) allowed.
-#     - uid: first_uid
-#       # <string, required> type of the receiver
-#       type: prometheus-alertmanager
-#       # <object, required> settings for the specific receiver type
-#       settings:
-#         url: http://test:9000
+#       - uid: first_uid
+#         # <string, required> type of the receiver
+#         type: prometheus-alertmanager
+#         # <bool, optional> Disable the additional [Incident Resolved] follow-up alert, default = false
+#         disableResolveMessage: false
+#         # <object, required> settings for the specific receiver type
+#         settings:
+#           url: http://test:9000
 
 # # List of receivers that should be deleted
 # deleteContactPoints:
-# - orgId: 1
-#   uid: first_uid
-
-# # List of notification policies to import or update
-# policies:
-#     # <int> organization ID, default = 1
+#   # <int> organization ID, default = 1
 #   - orgId: 1
-#     # <string> name of the receiver that should be used for this route
+#     # <string, required> unique identifier for the receiver
+#     uid: first_uid
+
+# # List of notification policies
+# policies:
+#   # <int> organization ID, default = 1
+#   - orgId: 1
+#     # <string> name of the contact point that should be used for this route
 #     receiver: grafana-default-email
-#     # <list<string>> The labels by which incoming alerts are grouped together. For example,
+#     # <list> The labels by which incoming alerts are grouped together. For example,
 #     #        multiple alerts coming in for cluster=A and alertname=LatencyHigh would
 #     #        be batched into a single group.
 #     #
-#     #        To aggregate by all possible labels, use the special value '...' as
+#     #        To aggregate by all possible labels use the special value '...' as
 #     #        the sole label name, for example:
 #     #        group_by: ['...']
 #     #        This effectively disables aggregation entirely, passing through all
 #     #        alerts as-is. This is unlikely to be what you want, unless you have
 #     #        a very low alert volume or your upstream notification system performs
 #     #        its own grouping.
-#     group_by:
-#     - grafana_folder
-#     - alertname
-#     # <list> a list of matchers that an alert has to fulfill to match the node
+#     group_by: ['...']
+#     # <list> a list of prometheus-like matchers that an alert rule has to fulfill to match the node (allowed chars
+#     #        [a-zA-Z_:])
 #     matchers:
-#     - alertname = Watchdog
-#     - severity =~ "warning|critical"
+#       - alertname = Watchdog
+#       - service_id_X = serviceX
+#       - severity =~ "warning|critical"
+#     # <list> a list of grafana-like matchers that an alert rule has to fulfill to match the node
+#     object_matchers:
+#       - ['alertname', '=', 'CPUUsage']
+#       - ['service_id-X', '=', 'serviceX']
+#       - ['severity', '=~', 'warning|critical']
 #     # <list> Times when the route should be muted. These must match the name of a
 #     #        mute time interval.
 #     #        Additionally, the root node cannot have any mute times.
@@ -126,7 +134,7 @@ apiVersion: 1
 #     #        otherwise acts normally (including ending the route-matching process
 #     #        if the `continue` option is not set)
 #     mute_time_intervals:
-#     - abc
+#       - abc
 #     # <duration> How long to initially wait to send a notification for a group
 #     #            of alerts. Allows to collect more initial alerts for the same group.
 #     #            (Usually ~0s to few minutes), default = 30s
@@ -138,51 +146,55 @@ apiVersion: 1
 #     # <duration>  How long to wait before sending a notification again if it has already
 #     #             been sent successfully for an alert. (Usually ~3h or more), default = 4h
 #     repeat_interval: 4h
-#     # <list> Zero or more child routes
-#     routes:
-#     ...
+#     # <list> Zero or more child policies. The schema is the same as the root policy.
+#     # routes:
+#     #   # Another recursively nested policy...
+#     #   - receiver: another-receiver
+#     #     matchers:
+#     #       - ...
+#     #     ...
 
 # # List of orgIds that should be reset to the default policy
 # resetPolicies:
-# - 1
+#   - 1
 
 # # List of templates to import or update
 # templates:
-#     # <int> organization ID, default = 1
-#   - orgID: 1
+#   # <int> organization ID, default = 1
+#   - orgId: 1
 #     # <string, required> name of the template, must be unique
 #     name: my_first_template
 #     # <string, required> content of the the template
-#     template: Alerting with a custome text template
+#     template: Alerting with a custom text template
 
-# # List of templates that should be deleted
+# # List of alert rule UIDs that should be deleted
 # deleteTemplates:
-#    # <int> organization ID, default = 1
-#  - orgId: 1
-#    # <string, required> name of the template, must be unique
-#    name: my_first_template
-
+#   # <int> organization ID, default = 1
+#   - orgId: 1
+#     # <string, required> name of the template, must be unique
+#     name: my_first_template
 
 # # List of mute time intervals to import or update
 # muteTimes:
 #   # <int> organization ID, default = 1
-# - orgId: 1
-#   # <string, required> name of the mute time interval, must be unique
-#   name: mti_1
-#   # <list> time intervals that should trigger the muting
-#            refer to https://prometheus.io/docs/alerting/latest/configuration/#time_interval-0
-#   time_intervals:
-#    - times:
-#      - start_time: '06:00'
-#        end_time: '23:59'
-#      weekdays: ['monday:wednesday','saturday', 'sunday']
-#      months: ['1:3', 'may:august', 'december']
-#      years: ['2020:2022', '2030']
-#      days_of_month: ['1:5', '-3:-1']
+#   - orgId: 1
+#     # <string, required> name of the mute time interval, must be unique
+#     name: mti_1
+#     # <list> time intervals that should trigger the muting
+#     #        refer to https://prometheus.io/docs/alerting/latest/configuration/#time_interval-0
+#     time_intervals:
+#       - times:
+#           - start_time: '06:00'
+#             end_time: '23:59'
+#         location: 'UTC'
+#         weekdays: ['monday:wednesday', 'saturday', 'sunday']
+#         months: ['1:3', 'may:august', 'december']
+#         years: ['2020:2022', '2030']
+#         days_of_month: ['1:5', '-3:-1']
 
 # # List of mute time intervals that should be deleted
 # deleteMuteTimes:
 #   # <int> organization ID, default = 1
-# - orgId: 1
-#   # <string, required> name of the mute time interval, must be unique
-#   name: mti_1
+#   - orgId: 1
+#     # <string, required> name of the mute time interval, must be unique
+#     name: mti_1

--- a/conf/provisioning/dashboards/sample.yaml
+++ b/conf/provisioning/dashboards/sample.yaml
@@ -1,11 +1,25 @@
-# # config file version
+# Configuration file version
 apiVersion: 1
 
-#providers:
-# - name: 'default'
-#   orgId: 1
-#   folder: ''
-#   folderUid: ''
-#   type: file
-#   options:
-#     path: /var/lib/grafana/dashboards
+# providers:
+#   # <string> an unique provider name. Required
+#   - name: 'a unique provider name'
+#     # <int> Org id. Default to 1
+#     orgId: 1
+#     # <string> name of the dashboard folder.
+#     folder: ''
+#     # <string> folder UID. will be automatically generated if not specified
+#     folderUid: ''
+#     # <string> provider type. Default to 'file'
+#     type: file
+#     # <bool> disable dashboard deletion
+#     disableDeletion: false
+#     # <int> how often Grafana will scan for changed dashboards
+#     updateIntervalSeconds: 10
+#     # <bool> allow updating provisioned dashboards from the UI
+#     allowUiUpdates: false
+#     options:
+#       # <string, required> path to dashboard files on disk. Required when using the 'file' type
+#       path: /var/lib/grafana/dashboards
+#       # <bool> use folder names from filesystem to create folders in Grafana
+#       foldersFromFilesStructure: true

--- a/conf/provisioning/notifiers/sample.yaml
+++ b/conf/provisioning/notifiers/sample.yaml
@@ -1,25 +1,36 @@
-# # config file version
+# Configuration file version
 apiVersion: 1
 
 # notifiers:
-#   - name: default-slack-temp
+#   - name: notification-channel-1
 #     type: slack
+#     uid: notifier1
+#     # either
+#     org_id: 2
+#     # or
 #     org_name: Main Org.
 #     is_default: true
-#     uid: notifier1
+#     send_reminder: true
+#     frequency: 1h
+#     disable_resolve_message: false
+#     # See `Supported Settings` section for settings supported for each
+#     # alert notification type.
 #     settings:
-#       recipient: "XXX"
-#       token: "xoxb"
+#       recipient: 'XXX'
 #       uploadImage: true
+#       token: 'xoxb' # legacy setting since Grafana v7.2 (stored non-encrypted)
+#       url: https://slack.com # legacy setting since Grafana v7.2 (stored non-encrypted)
+#     # Secure settings that will be encrypted in the database (supported since Grafana v7.2). See `Supported Settings` section for secure settings supported for each notifier.
+#     secure_settings:
+#       token: 'xoxb'
 #       url: https://slack.com
-#   - name: default-email
-#     type: email
-#     org_id: 1
-#     uid: notifier2
-#     is_default: false  
-#     settings:
-#       addresses: example11111@example.com
+
 # delete_notifiers:
-#   - name: default-slack-temp
-#     org_name: Main Org.
+#   - name: notification-channel-1
 #     uid: notifier1
+#     # either
+#     org_id: 2
+#     # or
+#     org_name: Main Org.
+#   - name: notification-channel-2
+#     # default org_id: 1

--- a/conf/provisioning/plugins/sample.yaml
+++ b/conf/provisioning/plugins/sample.yaml
@@ -1,11 +1,20 @@
-# # config file version
+# Configuration file version
 apiVersion: 1
 
 # apps:
-#   - type: grafana-example-app
-#     org_name: Main Org.
-#     disabled: true
+#   # <string> the type of app, plugin identifier. Required
 #   - type: raintank-worldping-app
+#     # <int> Org ID. Default to 1, unless org_name is specified
 #     org_id: 1
+#     # <string> Org name. Overrides org_id unless org_id not specified
+#     org_name: Main Org.
+#     # <bool> disable the app. Default to false.
+#     disabled: false
+#     # <map> fields that will be converted to json and stored in jsonData. Custom per app.
 #     jsonData:
-#       apiKey: "API KEY"
+#       # key/value pairs of string to object
+#       key: value
+#     # <map> fields that will be converted to json, encrypted and stored in secureJsonData. Custom per app.
+#     secureJsonData:
+#       # key/value pairs of string to string
+#       key: value

--- a/docs/sources/administration/provisioning/index.md
+++ b/docs/sources/administration/provisioning/index.md
@@ -290,6 +290,7 @@ The plugins must already be installed on the Grafana instance.
 ### Example plugin configuration file
 
 ```yaml
+# Configuration file version
 apiVersion: 1
 
 apps:
@@ -318,6 +319,7 @@ You can manage dashboards in Grafana by adding one or more YAML config files in 
 The dashboard provider config file looks somewhat like this:
 
 ```yaml
+# Configuration file version
 apiVersion: 1
 
 providers:
@@ -464,6 +466,9 @@ By default, exporting a dashboard as JSON will use a sequential identifier to re
 ### Example Alert Notification Channels Config File
 
 ```yaml
+# Configuration file version
+apiVersion: 1
+
 notifiers:
   - name: notification-channel-1
     type: slack

--- a/docs/sources/administration/roles-and-permissions/access-control/rbac-grafana-provisioning/index.md
+++ b/docs/sources/administration/roles-and-permissions/access-control/rbac-grafana-provisioning/index.md
@@ -59,7 +59,7 @@ The following example shows a complete YAML configuration file that:
 
 ```yaml
 ---
-# config file version
+# Configuration file version
 apiVersion: 2
 
 # <list> list of roles to insert/update/delete

--- a/docs/sources/administration/roles-and-permissions/access-control/rbac-grafana-provisioning/index.md
+++ b/docs/sources/administration/roles-and-permissions/access-control/rbac-grafana-provisioning/index.md
@@ -79,9 +79,9 @@ roles:
       # <string, required> action allowed.
       - action: 'users:read'
         #<string> scope it applies to.
-        scope: 'users:*'
+        scope: 'global.users:*'
       - action: 'users:write'
-        scope: 'users:*'
+        scope: 'global.users:*'
       - action: 'users:create'
   - name: 'custom:global:users:reader'
     # <bool> overwrite org id and creates a global role.
@@ -102,9 +102,9 @@ roles:
     # <list> list of the permissions to add/remove on top of the copied ones.
     permissions:
       - action: 'users:read'
-        scope: 'users:*'
+        scope: 'global.users:*'
       - action: 'users:write'
-        scope: 'users:*'
+        scope: 'global.users:*'
         # <string> state of the permission. Defaults to 'present'. If 'absent', the permission will be removed.
         state: absent
 

--- a/docs/sources/alerting/set-up/provision-alerting-resources/file-provisioning/index.md
+++ b/docs/sources/alerting/set-up/provision-alerting-resources/file-provisioning/index.md
@@ -50,7 +50,7 @@ Create or delete alert rules in your Grafana instance(s).
 Here is an example of a configuration file for creating alert rules.
 
 ```yaml
-# config file version
+# Configuration file version
 apiVersion: 1
 
 # List of rule groups to import or update
@@ -123,7 +123,7 @@ groups:
 Here is an example of a configuration file for deleting alert rules.
 
 ```yaml
-# config file version
+# Configuration file version
 apiVersion: 1
 
 # List of alert rule UIDs that should be deleted
@@ -149,7 +149,7 @@ Create or delete contact points in your Grafana instance(s).
 Here is an example of a configuration file for creating contact points.
 
 ```yaml
-# config file version
+# Configuration file version
 apiVersion: 1
 
 # List of contact points to import or update
@@ -173,7 +173,7 @@ contactPoints:
 Here is an example of a configuration file for deleting contact points.
 
 ```yaml
-# config file version
+# Configuration file version
 apiVersion: 1
 
 # List of receivers that should be deleted
@@ -510,7 +510,7 @@ Create or reset the notification policy tree in your Grafana instance(s).
 Here is an example of a configuration file for creating notification policies.
 
 ```yaml
-# config file version
+# Configuration file version
 apiVersion: 1
 
 # List of notification policies
@@ -573,7 +573,7 @@ policies:
 Here is an example of a configuration file for resetting the policy tree back to its default value:
 
 ```yaml
-# config file version
+# Configuration file version
 apiVersion: 1
 
 # List of orgIds that should be reset to the default policy
@@ -600,7 +600,7 @@ Create or delete templates in your Grafana instance(s).
 Here is an example of a configuration file for creating templates.
 
 ```yaml
-# config file version
+# Configuration file version
 apiVersion: 1
 
 # List of templates to import or update
@@ -616,7 +616,7 @@ templates:
 Here is an example of a configuration file for deleting templates.
 
 ```yaml
-# config file version
+# Configuration file version
 apiVersion: 1
 
 # List of alert rule UIDs that should be deleted
@@ -640,7 +640,7 @@ Create or delete mute timings in your Grafana instance(s).
 Here is an example of a configuration file for creating mute timings.
 
 ```yaml
-# config file version
+# Configuration file version
 apiVersion: 1
 
 # List of mute time intervals to import or update
@@ -665,7 +665,7 @@ muteTimes:
 Here is an example of a configuration file for deleting mute timings.
 
 ```yaml
-# config file version
+# Configuration file version
 apiVersion: 1
 
 # List of mute time intervals that should be deleted


### PR DESCRIPTION
**What is this feature?**

Some provisioning examples are outdated, sync them with the docs.
Follow up to #80894.

These were the files used for syncing:
- `conf/provisioning/access-control/sample.yaml`: `docs/sources/administration/roles-and-permissions/access-control/rbac-grafana-provisioning`
- `conf/provisioning/alerting/sample.yaml`: `docs/sources/alerting/set-up/provision-alerting-resources/file-provisioning/index.md`
- `conf/provisioning/dashboards/sample.yaml`: `docs/sources/administration/provisioning/index.md`
- `conf/provisioning/notifiers/sample.yaml`: `docs/sources/administration/provisioning/index.md`
- `conf/provisioning/plugins/sample.yaml`: `docs/sources/administration/provisioning/index.md`

Furthermore, I tried to fix some inconsistencies in the provisioning docs examples (but I can revert the commit if this should not be part of this commit)

**Why do we need this feature?**

...

**Who is this feature for?**
...

**Which issue(s) does this PR fix?**:
...

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
