### PR TITLE
Transformers: Do not add transformation info to output frames

### DIFF
--- a/packages/grafana-data/src/transformations/transformDataFrame.ts
+++ b/packages/grafana-data/src/transformations/transformDataFrame.ts
@@ -60,12 +60,6 @@ const postProcessTransform =
           if (!series.meta) {
             series.meta = {};
           }
-
-          if (!series.meta.transformations) {
-            series.meta.transformations = [info.id];
-          } else {
-            series.meta.transformations = [...series.meta.transformations, info.id];
-          }
         }
 
         // Add back the filtered out frames

--- a/packages/grafana-data/src/transformations/transformDataFrame.ts
+++ b/packages/grafana-data/src/transformations/transformDataFrame.ts
@@ -55,13 +55,6 @@ const postProcessTransform =
           return after;
         }
 
-        // Add a key to the metadata if the data changed
-        for (const series of after) {
-          if (!series.meta) {
-            series.meta = {};
-          }
-        }
-
         // Add back the filtered out frames
         if (matcher) {
           // keep the frame order the same

--- a/packages/grafana-data/src/transformations/transformers/ensureColumns.test.ts
+++ b/packages/grafana-data/src/transformations/transformers/ensureColumns.test.ts
@@ -109,11 +109,6 @@ describe('ensureColumns transformer', () => {
             },
           ],
           "length": 2,
-          "meta": {
-            "transformations": [
-              "ensureColumns",
-            ],
-          },
         }
       `);
     });

--- a/packages/grafana-data/src/types/data.ts
+++ b/packages/grafana-data/src/types/data.ts
@@ -54,9 +54,6 @@ export interface QueryResultMeta {
   /** Meta Notices */
   notices?: QueryResultMetaNotice[];
 
-  /** Used to track transformation ids that where part of the processing */
-  transformations?: string[];
-
   /** Currently used to show results in Explore only in preferred visualisation option */
   preferredVisualisationType?: PreferredVisualisationType;
 

--- a/public/app/features/transformers/extractFields/extractFields.test.ts
+++ b/public/app/features/transformers/extractFields/extractFields.test.ts
@@ -313,9 +313,6 @@ describe('Fields from JSON', () => {
         },
       ],
       length: 2,
-      meta: {
-        transformations: ['sortBy'],
-      },
     };
 
     const frames = extractFieldsTransformer.transformer(extractConfig, ctx)([testDataFrame]);

--- a/public/app/plugins/panel/state-timeline/StateTimelinePanel.tsx
+++ b/public/app/plugins/panel/state-timeline/StateTimelinePanel.tsx
@@ -109,10 +109,7 @@ export const StateTimelinePanel = ({
        * Render nothing in this case to prevent error.
        * See https://github.com/grafana/support-escalations/issues/932
        */
-      if (
-        (!alignedData.meta?.transformations?.length && alignedData.fields.length - 1 !== valueFieldsCount) ||
-        !alignedData.fields[seriesIdx]
-      ) {
+      if (alignedData.fields.length - 1 !== valueFieldsCount || !alignedData.fields[seriesIdx]) {
         return null;
       }
 

--- a/public/app/plugins/panel/state-timeline/StateTimelineTooltip2.tsx
+++ b/public/app/plugins/panel/state-timeline/StateTimelineTooltip2.tsx
@@ -68,10 +68,7 @@ export const StateTimelineTooltip2 = ({
    * Render nothing in this case to prevent error.
    * See https://github.com/grafana/support-escalations/issues/932
    */
-  if (
-    (!alignedData.meta?.transformations?.length && alignedData.fields.length - 1 !== valueFieldsCount) ||
-    !alignedData.fields[seriesIdx]
-  ) {
+  if (alignedData.fields.length - 1 !== valueFieldsCount || !alignedData.fields[seriesIdx]) {
     return null;
   }
 

--- a/public/app/plugins/panel/status-history/StatusHistoryPanel.tsx
+++ b/public/app/plugins/panel/status-history/StatusHistoryPanel.tsx
@@ -108,10 +108,7 @@ export const StatusHistoryPanel = ({
        * Render nothing in this case to prevent error.
        * See https://github.com/grafana/support-escalations/issues/932
        */
-      if (
-        (!alignedData.meta?.transformations?.length && alignedData.fields.length - 1 !== valueFieldsCount) ||
-        !alignedData.fields[seriesIdx]
-      ) {
+      if (alignedData.fields.length - 1 !== valueFieldsCount || !alignedData.fields[seriesIdx]) {
         return null;
       }
 


### PR DESCRIPTION
Long ago we added the fact that a transformer runs to the output metadata -- it is not really used anywhere and sometimes grows large (not sure why)

Since not used/useful, lets just remove it.