### PR TITLE
Histogram: Start y-axis at 0, set default color mode to classic palette

### DIFF
--- a/public/app/plugins/panel/histogram/Histogram.tsx
+++ b/public/app/plugins/panel/histogram/Histogram.tsx
@@ -136,6 +136,7 @@ const prepConfig = (frame: DataFrame, theme: GrafanaTheme2) => {
     distribution: ScaleDistribution.Linear,
     orientation: ScaleOrientation.Vertical,
     direction: ScaleDirection.Up,
+    softMin: 0,
   });
 
   const fmt = frame.fields[0].display!;

--- a/public/app/plugins/panel/histogram/module.tsx
+++ b/public/app/plugins/panel/histogram/module.tsx
@@ -54,7 +54,9 @@ export const plugin = new PanelPlugin<Options, FieldConfig>(HistogramPanel)
     standardOptions: {
       [FieldConfigProperty.Color]: {
         settings: {
-          byValueSupport: true,
+          byValueSupport: false,
+          bySeriesSupport: true,
+          preferThresholdsMode: false,
         },
         defaultValue: {
           mode: FieldColorModeId.PaletteClassic,


### PR DESCRIPTION
bars should start at zero. (fixes part of https://github.com/grafana/grafana/issues/81745)

classic palette changes pulled out from `bucketCount` WIP PR: https://github.com/grafana/grafana/pull/80990