### PR TITLE
sql: use interval-formatting from the sdk

### DIFF
--- a/pkg/tsdb/sqleng/sql_engine.go
+++ b/pkg/tsdb/sqleng/sql_engine.go
@@ -18,9 +18,9 @@ import (
 	"github.com/grafana/grafana-plugin-sdk-go/data"
 	"github.com/grafana/grafana-plugin-sdk-go/data/sqlutil"
 
+	"github.com/grafana/grafana-plugin-sdk-go/backend/gtime"
 	"github.com/grafana/grafana-plugin-sdk-go/backend/log"
 	"github.com/grafana/grafana/pkg/setting"
-	"github.com/grafana/grafana/pkg/tsdb/intervalv2"
 	"github.com/grafana/grafana/pkg/util/errutil"
 )
 
@@ -372,7 +372,7 @@ var Interpolate = func(query backend.DataQuery, timeRange backend.TimeRange, tim
 	interval := query.Interval
 
 	sql = strings.ReplaceAll(sql, "$__interval_ms", strconv.FormatInt(interval.Milliseconds(), 10))
-	sql = strings.ReplaceAll(sql, "$__interval", intervalv2.FormatDuration(interval))
+	sql = strings.ReplaceAll(sql, "$__interval", gtime.FormatInterval(interval))
 	sql = strings.ReplaceAll(sql, "$__unixEpochFrom()", fmt.Sprintf("%d", timeRange.From.UTC().Unix()))
 	sql = strings.ReplaceAll(sql, "$__unixEpochTo()", fmt.Sprintf("%d", timeRange.To.UTC().Unix()))
 


### PR DESCRIPTION
in https://github.com/grafana/grafana-plugin-sdk-go/pull/880 we added `intervalv2.FormatDuration` to `grafan-plugin-sdk-go` with the name `FormatInterval`.

this PR switches the sql codebase to use that.

how to test:
- (you need to be able to see the sql queries that were received by your database)
- start creating a new alert-rule, make it an sql query that contains `$__interval`... you can do something simple like `SELECT 42; -- $__interval`
- verify in the database access logs that `$__interval` was correctly replaced with the real value

(fixes https://github.com/grafana/grafana/issues/77723 )