### PR TITLE
ServiceAccounts: Add `GetServiceAccountByID` function

### DIFF
--- a/pkg/services/serviceaccounts/database/store_test.go
+++ b/pkg/services/serviceaccounts/database/store_test.go
@@ -72,7 +72,7 @@ func TestStore_CreateServiceAccount(t *testing.T) {
 		assert.Equal(t, string(serviceAccountRole), retrieved.Role)
 		assert.True(t, retrieved.IsDisabled)
 
-		retrievedId, err := store.RetrieveServiceAccountIdByName(context.Background(), serviceAccountOrgId, serviceAccountName)
+		retrievedId, err := store.GetServiceAccountID(context.Background(), &serviceaccounts.GetIDCmd{Name: serviceAccountName, OrgID: serviceAccountOrgId})
 		require.NoError(t, err)
 		assert.Equal(t, saDTO.Id, retrievedId)
 	})
@@ -106,7 +106,7 @@ func TestStore_CreateServiceAccountRoleNone(t *testing.T) {
 	assert.Equal(t, serviceAccountOrgId, retrieved.OrgId)
 	assert.Equal(t, string(serviceAccountRole), retrieved.Role)
 
-	retrievedId, err := store.RetrieveServiceAccountIdByName(context.Background(), serviceAccountOrgId, serviceAccountName)
+	retrievedId, err := store.GetServiceAccountID(context.Background(), &serviceaccounts.GetIDCmd{Name: serviceAccountName, OrgID: serviceAccountOrgId})
 	require.NoError(t, err)
 	assert.Equal(t, saDTO.Id, retrievedId)
 	assert.Equal(t, saDTO.Role, string(org.RoleNone))

--- a/pkg/services/serviceaccounts/manager/service.go
+++ b/pkg/services/serviceaccounts/manager/service.go
@@ -157,6 +157,16 @@ func (sa *ServiceAccountsService) RetrieveServiceAccount(ctx context.Context, or
 	return sa.store.RetrieveServiceAccount(ctx, orgID, serviceAccountID)
 }
 
+func (sa *ServiceAccountsService) GetServiceAccountID(ctx context.Context, cmd *serviceaccounts.GetIDCmd) (int64, error) {
+	if err := validOrgID(cmd.OrgID); err != nil {
+		return 0, err
+	}
+	if cmd.Login == "" && cmd.Name == "" {
+		return 0, errors.New("login or name is required")
+	}
+	return sa.store.GetServiceAccountID(ctx, cmd)
+}
+
 func (sa *ServiceAccountsService) RetrieveServiceAccountIdByName(ctx context.Context, orgID int64, name string) (int64, error) {
 	if err := validOrgID(orgID); err != nil {
 		return 0, err
@@ -164,7 +174,7 @@ func (sa *ServiceAccountsService) RetrieveServiceAccountIdByName(ctx context.Con
 	if name == "" {
 		return 0, errors.New("name is required")
 	}
-	return sa.store.RetrieveServiceAccountIdByName(ctx, orgID, name)
+	return sa.store.GetServiceAccountID(ctx, &serviceaccounts.GetIDCmd{Name: name, OrgID: orgID})
 }
 
 func (sa *ServiceAccountsService) DeleteServiceAccount(ctx context.Context, orgID, serviceAccountID int64) error {

--- a/pkg/services/serviceaccounts/manager/service_test.go
+++ b/pkg/services/serviceaccounts/manager/service_test.go
@@ -36,8 +36,8 @@ func (f *FakeServiceAccountStore) RetrieveServiceAccount(ctx context.Context, or
 	return f.ExpectedServiceAccountProfileDTO, f.ExpectedError
 }
 
-// RetrieveServiceAccountIdByName is a fake retrieving a service account id by name.
-func (f *FakeServiceAccountStore) RetrieveServiceAccountIdByName(ctx context.Context, orgID int64, name string) (int64, error) {
+// GetServiceAccountID is a fake retrieving a service account id by name.
+func (f *FakeServiceAccountStore) GetServiceAccountID(ctx context.Context, cmd *serviceaccounts.GetIDCmd) (int64, error) {
 	return f.ExpectedServiceAccountID.Id, f.ExpectedError
 }
 

--- a/pkg/services/serviceaccounts/manager/store.go
+++ b/pkg/services/serviceaccounts/manager/store.go
@@ -13,12 +13,12 @@ type store interface {
 	DeleteServiceAccount(ctx context.Context, orgID, serviceAccountID int64) error
 	DeleteServiceAccountToken(ctx context.Context, orgID, serviceAccountID, tokenID int64) error
 	EnableServiceAccount(ctx context.Context, orgID, serviceAccountID int64, enable bool) error
+	GetServiceAccountID(ctx context.Context, cmd *serviceaccounts.GetIDCmd) (int64, error)
 	GetUsageMetrics(ctx context.Context) (*serviceaccounts.Stats, error)
 	ListTokens(ctx context.Context, query *serviceaccounts.GetSATokensQuery) ([]apikey.APIKey, error)
 	MigrateApiKey(ctx context.Context, orgID int64, keyId int64) error
 	MigrateApiKeysToServiceAccounts(ctx context.Context, orgID int64) (*serviceaccounts.MigrationResult, error)
 	RetrieveServiceAccount(ctx context.Context, orgID, serviceAccountID int64) (*serviceaccounts.ServiceAccountProfileDTO, error)
-	RetrieveServiceAccountIdByName(ctx context.Context, orgID int64, name string) (int64, error)
 	RevokeServiceAccountToken(ctx context.Context, orgId, serviceAccountId, tokenId int64) error
 	SearchOrgServiceAccounts(ctx context.Context, query *serviceaccounts.SearchOrgServiceAccountsQuery) (*serviceaccounts.SearchOrgServiceAccountsResult, error)
 	UpdateServiceAccount(ctx context.Context, orgID, serviceAccountID int64,

--- a/pkg/services/serviceaccounts/models.go
+++ b/pkg/services/serviceaccounts/models.go
@@ -108,6 +108,12 @@ type AddServiceAccountTokenCommand struct {
 	SecondsToLive int64  `json:"secondsToLive"`
 }
 
+type GetIDCmd struct {
+	Name  string
+	Login string
+	OrgID int64
+}
+
 type SearchOrgServiceAccountsQuery struct {
 	OrgID        int64
 	Query        string

--- a/pkg/services/serviceaccounts/models.go
+++ b/pkg/services/serviceaccounts/models.go
@@ -109,8 +109,8 @@ type AddServiceAccountTokenCommand struct {
 }
 
 type GetIDCmd struct {
-	Name  string
 	Login string
+	Name  string
 	OrgID int64
 }
 

--- a/pkg/services/serviceaccounts/proxy/service.go
+++ b/pkg/services/serviceaccounts/proxy/service.go
@@ -119,6 +119,10 @@ func (s *ServiceAccountsProxy) EnableServiceAccount(ctx context.Context, orgID i
 	return s.proxiedService.EnableServiceAccount(ctx, orgID, serviceAccountID, enable)
 }
 
+func (s *ServiceAccountsProxy) GetServiceAccountID(ctx context.Context, cmd *serviceaccounts.GetIDCmd) (int64, error) {
+	return s.proxiedService.GetServiceAccountID(ctx, cmd)
+}
+
 func (s *ServiceAccountsProxy) ListTokens(ctx context.Context, query *serviceaccounts.GetSATokensQuery) ([]apikey.APIKey, error) {
 	return s.proxiedService.ListTokens(ctx, query)
 }

--- a/pkg/services/serviceaccounts/serviceaccounts.go
+++ b/pkg/services/serviceaccounts/serviceaccounts.go
@@ -18,6 +18,9 @@ type Service interface {
 	CreateServiceAccount(ctx context.Context, orgID int64, saForm *CreateServiceAccountForm) (*ServiceAccountDTO, error)
 	DeleteServiceAccount(ctx context.Context, orgID, serviceAccountID int64) error
 	RetrieveServiceAccount(ctx context.Context, orgID, serviceAccountID int64) (*ServiceAccountProfileDTO, error)
+	GetServiceAccountID(ctx context.Context, cmd *GetIDCmd) (int64, error)
+	// deprecated: use GetServiceAccountID instead
+	// FIXME: Remove this method and use GetServiceAccountID instead
 	RetrieveServiceAccountIdByName(ctx context.Context, orgID int64, name string) (int64, error)
 	SearchOrgServiceAccounts(ctx context.Context, query *SearchOrgServiceAccountsQuery) (*SearchOrgServiceAccountsResult, error)
 	EnableServiceAccount(ctx context.Context, orgID, serviceAccountID int64, enable bool) error

--- a/pkg/services/serviceaccounts/tests/fakes.go
+++ b/pkg/services/serviceaccounts/tests/fakes.go
@@ -37,6 +37,10 @@ func (f *FakeServiceAccountService) EnableServiceAccount(ctx context.Context, or
 	return f.ExpectedErr
 }
 
+func (f *FakeServiceAccountService) GetServiceAccountID(ctx context.Context, cmd *serviceaccounts.GetIDCmd) (int64, error) {
+	return f.ExpectedServiceAccountID, f.ExpectedErr
+}
+
 func (f *FakeServiceAccountService) RetrieveServiceAccount(ctx context.Context, orgID, id int64) (*serviceaccounts.ServiceAccountProfileDTO, error) {
 	return f.ExpectedServiceAccountProfile, f.ExpectedErr
 }

--- a/pkg/services/serviceaccounts/tests/mocks.go
+++ b/pkg/services/serviceaccounts/tests/mocks.go
@@ -111,6 +111,30 @@ func (_m *MockServiceAccountService) EnableServiceAccount(ctx context.Context, o
 	return r0
 }
 
+// RetrieveServiceAccountIdByName provides a mock function with given fields: ctx, orgID, name
+func (_m *MockServiceAccountService) GetServiceAccountID(ctx context.Context, cmd *serviceaccounts.GetIDCmd) (int64, error) {
+	ret := _m.Called(ctx, cmd)
+
+	var r0 int64
+	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context, *serviceaccounts.GetIDCmd) (int64, error)); ok {
+		return rf(ctx, cmd)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context, *serviceaccounts.GetIDCmd) int64); ok {
+		r0 = rf(ctx, cmd)
+	} else {
+		r0 = ret.Get(0).(int64)
+	}
+
+	if rf, ok := ret.Get(1).(func(context.Context, *serviceaccounts.GetIDCmd) error); ok {
+		r1 = rf(ctx, cmd)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
 // ListTokens provides a mock function with given fields: ctx, query
 func (_m *MockServiceAccountService) ListTokens(ctx context.Context, query *serviceaccounts.GetSATokensQuery) ([]apikey.APIKey, error) {
 	ret := _m.Called(ctx, query)


### PR DESCRIPTION
**What is this feature?**

This PR adds a new function to the serviceaccounts service to be able to get a service account by ID or name.

**Why do we need this feature?**

[Add a description of the problem the feature is trying to solve.]

**Who is this feature for?**

[Add information on what kind of user the feature is for.]

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
