### PR TITLE
Chore: webpack alias react and grafana-runtime to share singletons

### DIFF
--- a/scripts/webpack/webpack.common.js
+++ b/scripts/webpack/webpack.common.js
@@ -22,9 +22,11 @@ module.exports = {
       // some of data source plugins use global Prism object to add the language definition
       // we want to have same Prism object in core and in grafana/ui
       prismjs: require.resolve('prismjs'),
+
       // some sub-dependencies use a different version of @emotion/react and generate warnings
       // in the browser about @emotion/react loaded twice. We want to only load it once
       '@emotion/react': require.resolve('@emotion/react'),
+
       // due to our webpack configuration not understanding package.json `exports`
       // correctly we must alias this package to the correct file
       // the alternative to this alias is to copy-paste the file into our
@@ -32,6 +34,14 @@ module.exports = {
       '@locker/near-membrane-dom/custom-devtools-formatter': require.resolve(
         '@locker/near-membrane-dom/custom-devtools-formatter.js'
       ),
+
+      // Ensure that all dependencies share the same copy of react.
+      // Mainly linking in packages for local development.
+      react: require.resolve('react'),
+
+      // All dependencies also need to share the same copy of the singletons inside @grafana/runtime.
+      // Mainly linking in packages for local development.
+      '@grafana/runtime': path.resolve(__dirname, '../../packages/grafana-runtime'),
     },
     modules: [
       // default value

--- a/scripts/webpack/webpack.common.js
+++ b/scripts/webpack/webpack.common.js
@@ -22,11 +22,9 @@ module.exports = {
       // some of data source plugins use global Prism object to add the language definition
       // we want to have same Prism object in core and in grafana/ui
       prismjs: require.resolve('prismjs'),
-
       // some sub-dependencies use a different version of @emotion/react and generate warnings
       // in the browser about @emotion/react loaded twice. We want to only load it once
       '@emotion/react': require.resolve('@emotion/react'),
-
       // due to our webpack configuration not understanding package.json `exports`
       // correctly we must alias this package to the correct file
       // the alternative to this alias is to copy-paste the file into our

--- a/scripts/webpack/webpack.common.js
+++ b/scripts/webpack/webpack.common.js
@@ -34,14 +34,6 @@ module.exports = {
       '@locker/near-membrane-dom/custom-devtools-formatter': require.resolve(
         '@locker/near-membrane-dom/custom-devtools-formatter.js'
       ),
-
-      // Ensure that all dependencies share the same copy of react.
-      // Mainly linking in packages for local development.
-      react: require.resolve('react'),
-
-      // All dependencies also need to share the same copy of the singletons inside @grafana/runtime.
-      // Mainly linking in packages for local development.
-      '@grafana/runtime': path.resolve(__dirname, '../../packages/grafana-runtime'),
     },
     modules: [
       // default value

--- a/scripts/webpack/webpack.dev.js
+++ b/scripts/webpack/webpack.dev.js
@@ -35,6 +35,18 @@ module.exports = (env = {}) => {
       ignored: /node_modules/,
     },
 
+    resolve: {
+      alias: {
+        // Packages linked for development need react to be resolved from the same location
+        react: require.resolve('react'),
+
+        // Also Grafana packages need to be resolved from the same location so they share
+        // the same singletons
+        '@grafana/runtime': path.resolve(__dirname, '../../packages/grafana-runtime'),
+        '@grafana/data': path.resolve(__dirname, '../../packages/grafana-data'),
+      },
+    },
+
     module: {
       // Note: order is bottom-to-top and/or right-to-left
       rules: [


### PR DESCRIPTION
Fixes issues introduced after switching back to node_modules with linking the @grafana/scenes package to grafana for local development.

My understanding of the issue:

 - Previously the `portal:` protocol was used with yarn to link @grafana/scenes into the grafana repo for development. 
   - With pnp, the dependencies (react, @grafana/runtime, etc) of the portaled @grafana/scenes package are resolved as normal, and are linked to the same resolutions in the grafana project
   - The node-modules linker does not resolve dependencies 'like normal' for portalled packages for ["security reasons"](https://yarnpkg.com/advanced/error-codes#yn0071---nm_cant_install_external_soft_link), so incompatible ranages on dependencies cause errors preventing install
 - So instead the solution is to use the `link:` protocol and run `yarn install` inside the linked package (@grafana/scenes).
 - However this introduces a new problem where seperate copies of react and @grafana/runtime are installed inside the @grafana/runtime folder, which webpack will resolve to for @grafana/scenes imports, and react and @grafana/runtime rely on all dependencies sharing the same 'copy' of the library to share singletons.
 - The solution, as icky as it is, is to use webpack's aliases to resolve any imports of react and @grafana/runtime to the same copy in the root project.

**Q:** Should the webpack.common.js config be extended (applying this change to the production build as well?), or should this be contained to dev.

I think that resolving all imports to the same react is pretty important and should always happen, and so there's little risk of breaking things in the production build. I think we could actually introduce subtle bugs by having these resolve differently in dev vs prod builds.