### PR TITLE
Chore: Levitate to ignore private packages for compatibility comparison

### DIFF
--- a/scripts/check-breaking-changes.sh
+++ b/scripts/check-breaking-changes.sh
@@ -21,6 +21,11 @@ while IFS=" " read -r -a package; do
     continue
   fi
 
+  # Skip packages that are marked as private in their package.json (private: true)
+  if [[ $(jq -r '.private' "./packages/$PACKAGE_PATH/package.json") == "true" ]]; then
+    continue
+  fi
+
   # Extract the npm package tarballs into separate directories e.g. ./base/@grafana-data.tgz -> ./base/grafana-data/
   mkdir "$PREV"
   tar -xf "./base/@$PACKAGE_PATH.tgz" --strip-components=1 -C "$PREV"


### PR DESCRIPTION
**What is this feature?**

Makes sure levitate skips compatibility checks for packages with private: true

**Why do we need this feature?**

To prevent levitate creating false positives on private packages

**Who is this feature for?**

All developers of grafana  

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
