### PR TITLE
sql: removed unnecessary error-check

### DIFF
--- a/pkg/tsdb/grafana-postgresql-datasource/postgres_snapshot_test.go
+++ b/pkg/tsdb/grafana-postgresql-datasource/postgres_snapshot_test.go
@@ -139,8 +139,8 @@ func TestIntegrationPostgresSnapshots(t *testing.T) {
 				sqleng.Interpolate = origInterpolate
 			})
 
-			sqleng.Interpolate = func(query backend.DataQuery, timeRange backend.TimeRange, timeInterval string, sql string) (string, error) {
-				return sql, nil
+			sqleng.Interpolate = func(query backend.DataQuery, timeRange backend.TimeRange, timeInterval string, sql string) string {
+				return sql
 			}
 
 			cfg := setting.NewCfg()

--- a/pkg/tsdb/grafana-postgresql-datasource/postgres_test.go
+++ b/pkg/tsdb/grafana-postgresql-datasource/postgres_test.go
@@ -187,8 +187,8 @@ func TestIntegrationPostgres(t *testing.T) {
 	t.Cleanup(func() {
 		sqleng.Interpolate = origInterpolate
 	})
-	sqleng.Interpolate = func(query backend.DataQuery, timeRange backend.TimeRange, timeInterval string, sql string) (string, error) {
-		return sql, nil
+	sqleng.Interpolate = func(query backend.DataQuery, timeRange backend.TimeRange, timeInterval string, sql string) string {
+		return sql
 	}
 
 	cfg := setting.NewCfg()

--- a/pkg/tsdb/mysql/mysql_test.go
+++ b/pkg/tsdb/mysql/mysql_test.go
@@ -42,8 +42,8 @@ func TestIntegrationMySQL(t *testing.T) {
 		sqleng.Interpolate = origInterpolate
 	})
 
-	sqleng.Interpolate = func(query backend.DataQuery, timeRange backend.TimeRange, timeInterval string, sql string) (string, error) {
-		return sql, nil
+	sqleng.Interpolate = func(query backend.DataQuery, timeRange backend.TimeRange, timeInterval string, sql string) string {
+		return sql
 	}
 
 	dsInfo := sqleng.DataSourceInfo{

--- a/pkg/tsdb/sqleng/sql_engine.go
+++ b/pkg/tsdb/sqleng/sql_engine.go
@@ -249,14 +249,10 @@ func (e *DataSourceHandler) executeQuery(query backend.DataQuery, wg *sync.WaitG
 	}
 
 	// global substitutions
-	interpolatedQuery, err := Interpolate(query, timeRange, e.dsInfo.JsonData.TimeInterval, queryJson.RawSql)
-	if err != nil {
-		errAppendDebug("interpolation failed", e.TransformQueryError(logger, err), interpolatedQuery)
-		return
-	}
+	interpolatedQuery := Interpolate(query, timeRange, e.dsInfo.JsonData.TimeInterval, queryJson.RawSql)
 
 	// data source specific substitutions
-	interpolatedQuery, err = e.macroEngine.Interpolate(&query, timeRange, interpolatedQuery)
+	interpolatedQuery, err := e.macroEngine.Interpolate(&query, timeRange, interpolatedQuery)
 	if err != nil {
 		errAppendDebug("interpolation failed", e.TransformQueryError(logger, err), interpolatedQuery)
 		return
@@ -375,7 +371,7 @@ func (e *DataSourceHandler) executeQuery(query backend.DataQuery, wg *sync.WaitG
 }
 
 // Interpolate provides global macros/substitutions for all sql datasources.
-var Interpolate = func(query backend.DataQuery, timeRange backend.TimeRange, timeInterval string, sql string) (string, error) {
+var Interpolate = func(query backend.DataQuery, timeRange backend.TimeRange, timeInterval string, sql string) string {
 	interval := query.Interval
 
 	sql = strings.ReplaceAll(sql, "$__interval_ms", strconv.FormatInt(interval.Milliseconds(), 10))
@@ -383,7 +379,7 @@ var Interpolate = func(query backend.DataQuery, timeRange backend.TimeRange, tim
 	sql = strings.ReplaceAll(sql, "$__unixEpochFrom()", fmt.Sprintf("%d", timeRange.From.UTC().Unix()))
 	sql = strings.ReplaceAll(sql, "$__unixEpochTo()", fmt.Sprintf("%d", timeRange.To.UTC().Unix()))
 
-	return sql, nil
+	return sql
 }
 
 func (e *DataSourceHandler) newProcessCfg(query backend.DataQuery, queryContext context.Context,

--- a/pkg/tsdb/sqleng/sql_engine_test.go
+++ b/pkg/tsdb/sqleng/sql_engine_test.go
@@ -28,22 +28,19 @@ func TestSQLEngine(t *testing.T) {
 
 		t.Run("interpolate 10 minutes $__interval", func(t *testing.T) {
 			query := backend.DataQuery{JSON: []byte("{}"), MaxDataPoints: 1500, Interval: time.Minute * 10}
-			sql, err := Interpolate(query, timeRange, "", text)
-			require.NoError(t, err)
+			sql := Interpolate(query, timeRange, "", text)
 			require.Equal(t, "10m $__timeGroupAlias(time,10m) 600000", sql)
 		})
 
 		t.Run("interpolate 4seconds $__interval", func(t *testing.T) {
 			query := backend.DataQuery{JSON: []byte("{}"), MaxDataPoints: 1500, Interval: time.Second * 4}
-			sql, err := Interpolate(query, timeRange, "", text)
-			require.NoError(t, err)
+			sql := Interpolate(query, timeRange, "", text)
 			require.Equal(t, "4s $__timeGroupAlias(time,4s) 4000", sql)
 		})
 
 		t.Run("interpolate 200 milliseconds $__interval", func(t *testing.T) {
 			query := backend.DataQuery{JSON: []byte("{}"), MaxDataPoints: 1500, Interval: time.Millisecond * 200}
-			sql, err := Interpolate(query, timeRange, "", text)
-			require.NoError(t, err)
+			sql := Interpolate(query, timeRange, "", text)
 			require.Equal(t, "200ms $__timeGroupAlias(time,200ms) 200", sql)
 		})
 	})
@@ -55,14 +52,12 @@ func TestSQLEngine(t *testing.T) {
 		query := backend.DataQuery{JSON: []byte("{}"), MaxDataPoints: 1500, Interval: time.Second * 60}
 
 		t.Run("interpolate __unixEpochFrom function", func(t *testing.T) {
-			sql, err := Interpolate(query, timeRange, "", "select $__unixEpochFrom()")
-			require.NoError(t, err)
+			sql := Interpolate(query, timeRange, "", "select $__unixEpochFrom()")
 			require.Equal(t, fmt.Sprintf("select %d", from.Unix()), sql)
 		})
 
 		t.Run("interpolate __unixEpochTo function", func(t *testing.T) {
-			sql, err := Interpolate(query, timeRange, "", "select $__unixEpochTo()")
-			require.NoError(t, err)
+			sql := Interpolate(query, timeRange, "", "select $__unixEpochTo()")
 			require.Equal(t, fmt.Sprintf("select %d", to.Unix()), sql)
 		})
 	})


### PR DESCRIPTION
the `sqleng.Interpolate` function never returns an error:
https://github.com/grafana/grafana/blob/de4171862c45e30a973f194cd3af68a3dbd58703/pkg/tsdb/sqleng/sql_engine.go#L371-L380

so there's no need to have an error-return-value.

how to test:
- ( you need to be able to see the sql queries as they arrive in the sql database, for example the access log of the database)
- go to alerting, start creating a new alert rule, use the following SQL query: `select 45; -- $__interval $__interval_ms $__unixEpochFrom() $__unixEpochTo()`
- run it, now check the sql-server's access log, verify that all the variables were replace with the right values