### PR TITLE
Elasticsearch: Set middlewares from Grafana's `httpClientProvider`

### DIFF
--- a/pkg/tsdb/elasticsearch/elasticsearch.go
+++ b/pkg/tsdb/elasticsearch/elasticsearch.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
 	"github.com/grafana/grafana-plugin-sdk-go/backend/datasource"
+	sdkhttpclient "github.com/grafana/grafana-plugin-sdk-go/backend/httpclient"
 	"github.com/grafana/grafana-plugin-sdk-go/backend/instancemgmt"
 	exphttpclient "github.com/grafana/grafana-plugin-sdk-go/experimental/errorsource/httpclient"
 
@@ -88,6 +89,8 @@ func newInstanceSettings(httpClientProvider httpclient.Provider) datasource.Inst
 			httpCliOpts.SigV4.Service = "es"
 		}
 
+		// set the default middlewars from the httpClientProvider
+		httpCliOpts.Middlewares = httpClientProvider.(*sdkhttpclient.Provider).Opts.Middlewares
 		// enable experimental http client to support errors with source
 		httpCli, err := exphttpclient.New(httpCliOpts)
 		if err != nil {


### PR DESCRIPTION

**What is this feature?**

This PR sets the same middlewares from Grafana's `httpClientProvider` on the new experimental http client. The experimental http client were missing some middlewares, e.g. the one that's handling SigV4 auth.

**Which issue(s) does this PR fix?**:

Fixes #81294
