### PR TITLE
Chore: Update grafana-prometheus test types

### DIFF
--- a/.betterer.results
+++ b/.betterer.results
@@ -586,11 +586,6 @@ exports[`better eslint`] = {
     "packages/grafana-prometheus/src/configuration/ExemplarsSettings.tsx:5381": [
       [0, 0, 0, "Styles should be written using objects.", "0"]
     ],
-    "packages/grafana-prometheus/src/datasource.test.ts:5381": [
-      [0, 0, 0, "Unexpected any. Specify a different type.", "0"],
-      [0, 0, 0, "Unexpected any. Specify a different type.", "1"],
-      [0, 0, 0, "Unexpected any. Specify a different type.", "2"]
-    ],
     "packages/grafana-prometheus/src/datasource.ts:5381": [
       [0, 0, 0, "Unexpected any. Specify a different type.", "0"],
       [0, 0, 0, "Unexpected any. Specify a different type.", "1"],
@@ -638,9 +633,6 @@ exports[`better eslint`] = {
       [0, 0, 0, "Unexpected any. Specify a different type.", "0"],
       [0, 0, 0, "Unexpected any. Specify a different type.", "1"],
       [0, 0, 0, "Do not use any type assertions.", "2"]
-    ],
-    "packages/grafana-prometheus/src/metric_find_query.test.ts:5381": [
-      [0, 0, 0, "Unexpected any. Specify a different type.", "0"]
     ],
     "packages/grafana-prometheus/src/metric_find_query.ts:5381": [
       [0, 0, 0, "Unexpected any. Specify a different type.", "0"],
@@ -757,9 +749,6 @@ exports[`better eslint`] = {
       [0, 0, 0, "Unexpected any. Specify a different type.", "0"],
       [0, 0, 0, "Unexpected any. Specify a different type.", "1"],
       [0, 0, 0, "Unexpected any. Specify a different type.", "2"]
-    ],
-    "packages/grafana-prometheus/src/result_transformer.test.ts:5381": [
-      [0, 0, 0, "Unexpected any. Specify a different type.", "0"]
     ],
     "packages/grafana-prometheus/src/types.ts:5381": [
       [0, 0, 0, "Unexpected any. Specify a different type.", "0"],

--- a/packages/grafana-prometheus/src/datasource.test.ts
+++ b/packages/grafana-prometheus/src/datasource.test.ts
@@ -5,9 +5,11 @@ import {
   AnnotationEvent,
   AnnotationQueryRequest,
   CoreApp,
+  CustomVariableModel,
   DataQueryRequest,
   DataSourceInstanceSettings,
   dateTime,
+  LoadingState,
   rangeUtil,
   TimeRange,
   VariableHide,
@@ -461,7 +463,7 @@ describe('PrometheusDatasource', () => {
   });
 
   describe('When interpolating variables', () => {
-    let customVariable: any;
+    let customVariable: CustomVariableModel;
     beforeEach(() => {
       customVariable = {
         id: '',
@@ -474,11 +476,14 @@ describe('PrometheusDatasource', () => {
         current: {},
         name: '',
         type: 'custom',
-        label: null,
+        error: null,
+        rootStateKey: '',
+        state: LoadingState.Done,
+        description: '',
+        label: undefined,
         hide: VariableHide.dontHide,
         skipUrlSync: false,
         index: -1,
-        initLock: null,
       };
     });
 
@@ -490,7 +495,7 @@ describe('PrometheusDatasource', () => {
 
     describe('and value is a number', () => {
       it('should return a number', () => {
-        expect(ds.interpolateQueryExpr(1000 as any, customVariable)).toEqual(1000);
+        expect(ds.interpolateQueryExpr(1000 as unknown as string, customVariable)).toEqual(1000);
       });
     });
 
@@ -861,7 +866,7 @@ describe('PrometheusDatasource2', () => {
     });
 
     describe('region annotations for sectors', () => {
-      const options: any = {
+      const options = {
         annotation: {
           expr: 'ALERTS{alertstate="firing"}',
           tagKeys: 'job',
@@ -872,7 +877,7 @@ describe('PrometheusDatasource2', () => {
           from: time({ seconds: 63 }),
           to: time({ seconds: 900 }),
         },
-      };
+      } as unknown as AnnotationQueryRequest;
 
       async function runAnnotationQuery(data: number[][]) {
         let response = createAnnotationResponse();

--- a/packages/grafana-prometheus/src/metric_find_query.test.ts
+++ b/packages/grafana-prometheus/src/metric_find_query.test.ts
@@ -62,7 +62,15 @@ describe('PrometheusMetricFindQuery', () => {
     );
   });
 
-  const setupMetricFindQuery = (data: any, datasource?: PrometheusDatasource) => {
+  const setupMetricFindQuery = (
+    data: {
+      query: string;
+      response: {
+        data: unknown;
+      };
+    },
+    datasource?: PrometheusDatasource
+  ) => {
     fetchMock.mockImplementation(() => of({ status: 'success', data: data.response } as unknown as FetchResponse));
     return new PrometheusMetricFindQuery(datasource ?? legacyPrometheusDatasource, data.query);
   };

--- a/packages/grafana-prometheus/src/result_transformer.test.ts
+++ b/packages/grafana-prometheus/src/result_transformer.test.ts
@@ -909,7 +909,7 @@ describe('Prometheus Result Transformer', () => {
           },
         ],
       } as unknown as DataQueryRequest<PromQuery>;
-      const testOptions: any = {
+      const testOptions = {
         exemplarTraceIdDestinations: [
           {
             name: 'traceID',


### PR DESCRIPTION
**What is this feature?**

Update test types to stay in sync with the core datasource until we switch its code with the library
Source: https://github.com/grafana/grafana/pull/81812/
