### PR TITLE
VizTooltips: Remove default width/height values

### DIFF
--- a/packages/grafana-ui/src/components/uPlot/plugins/TooltipPlugin2.tsx
+++ b/packages/grafana-ui/src/components/uPlot/plugins/TooltipPlugin2.tsx
@@ -11,8 +11,8 @@ import { UPlotConfigBuilder } from '../config/UPlotConfigBuilder';
 
 import { CloseButton } from './CloseButton';
 
-export const DEFAULT_TOOLTIP_WIDTH = 'none';
-export const DEFAULT_TOOLTIP_HEIGHT = 'none';
+export const DEFAULT_TOOLTIP_WIDTH = undefined;
+export const DEFAULT_TOOLTIP_HEIGHT = undefined;
 export const TOOLTIP_OFFSET = 10;
 
 // todo: barchart? histogram?
@@ -45,8 +45,8 @@ interface TooltipPlugin2Props {
     viaSync: boolean
   ) => React.ReactNode;
 
-  maxWidth?: number | string;
-  maxHeight?: number | string;
+  maxWidth?: number;
+  maxHeight?: number;
 }
 
 interface TooltipContainerState {
@@ -115,7 +115,7 @@ export const TooltipPlugin2 = ({
 
   const sizeRef = useRef<TooltipContainerSize>();
 
-  maxWidth = isPinned ? 'none' : maxWidth ?? DEFAULT_TOOLTIP_WIDTH;
+  maxWidth = isPinned ? DEFAULT_TOOLTIP_WIDTH : maxWidth ?? DEFAULT_TOOLTIP_WIDTH;
   maxHeight ??= DEFAULT_TOOLTIP_HEIGHT;
   const styles = useStyles2(getStyles, maxWidth, maxHeight);
 
@@ -529,7 +529,7 @@ export const TooltipPlugin2 = ({
   return null;
 };
 
-const getStyles = (theme: GrafanaTheme2, maxWidth: number | string, maxHeight: number | string) => ({
+const getStyles = (theme: GrafanaTheme2, maxWidth?: number, maxHeight?: number) => ({
   tooltipWrapper: css({
     top: 0,
     left: 0,
@@ -541,8 +541,8 @@ const getStyles = (theme: GrafanaTheme2, maxWidth: number | string, maxHeight: n
     border: `1px solid ${theme.colors.border.weak}`,
     boxShadow: theme.shadows.z2,
     userSelect: 'text',
-    maxWidth: maxWidth,
-    maxHeight: maxHeight,
+    maxWidth: maxWidth ?? 'none',
+    maxHeight: maxHeight ?? 'none',
     overflowY: 'auto',
   }),
   pinned: css({

--- a/packages/grafana-ui/src/components/uPlot/plugins/TooltipPlugin2.tsx
+++ b/packages/grafana-ui/src/components/uPlot/plugins/TooltipPlugin2.tsx
@@ -11,8 +11,8 @@ import { UPlotConfigBuilder } from '../config/UPlotConfigBuilder';
 
 import { CloseButton } from './CloseButton';
 
-export const DEFAULT_TOOLTIP_WIDTH = 300;
-export const DEFAULT_TOOLTIP_HEIGHT = 600;
+export const DEFAULT_TOOLTIP_WIDTH = 'none';
+export const DEFAULT_TOOLTIP_HEIGHT = 'none';
 export const TOOLTIP_OFFSET = 10;
 
 // todo: barchart? histogram?
@@ -46,7 +46,7 @@ interface TooltipPlugin2Props {
   ) => React.ReactNode;
 
   maxWidth?: number | string;
-  maxHeight?: number;
+  maxHeight?: number | string;
 }
 
 interface TooltipContainerState {
@@ -529,7 +529,7 @@ export const TooltipPlugin2 = ({
   return null;
 };
 
-const getStyles = (theme: GrafanaTheme2, maxWidth: number | string, maxHeight: number) => ({
+const getStyles = (theme: GrafanaTheme2, maxWidth: number | string, maxHeight: number | string) => ({
   tooltipWrapper: css({
     top: 0,
     left: 0,

--- a/packages/grafana-ui/src/options/builder/tooltip.tsx
+++ b/packages/grafana-ui/src/options/builder/tooltip.tsx
@@ -50,7 +50,6 @@ export function addTooltipOptions<T extends OptionsWithTooltip>(
       category,
       settings: {
         integer: true,
-        placeholder: '300',
       },
     })
     .addNumberInput({
@@ -59,7 +58,6 @@ export function addTooltipOptions<T extends OptionsWithTooltip>(
       category,
       settings: {
         integer: true,
-        placeholder: '600',
       },
     });
 }

--- a/public/app/plugins/panel/candlestick/CandlestickPanel.tsx
+++ b/public/app/plugins/panel/candlestick/CandlestickPanel.tsx
@@ -22,6 +22,7 @@ import { ContextMenuPlugin } from '../timeseries/plugins/ContextMenuPlugin';
 import { ExemplarsPlugin } from '../timeseries/plugins/ExemplarsPlugin';
 import { OutsideRangePlugin } from '../timeseries/plugins/OutsideRangePlugin';
 import { ThresholdControlsPlugin } from '../timeseries/plugins/ThresholdControlsPlugin';
+import { isTooltipScrollable } from '../timeseries/utils';
 
 import { prepareCandlestickFields } from './fields';
 import { Options, defaultCandlestickColors, VizDisplayMode } from './types';
@@ -298,9 +299,7 @@ export const CandlestickPanel = ({
                       mode={options.tooltip.mode}
                       isPinned={isPinned}
                       annotate={enableAnnotationCreation ? annotate : undefined}
-                      scrollable={
-                        options.tooltip.mode === TooltipDisplayMode.Multi && options.tooltip.maxHeight !== undefined
-                      }
+                      scrollable={isTooltipScrollable(options.tooltip)}
                     />
                   );
                 }}

--- a/public/app/plugins/panel/candlestick/CandlestickPanel.tsx
+++ b/public/app/plugins/panel/candlestick/CandlestickPanel.tsx
@@ -298,6 +298,9 @@ export const CandlestickPanel = ({
                       mode={options.tooltip.mode}
                       isPinned={isPinned}
                       annotate={enableAnnotationCreation ? annotate : undefined}
+                      scrollable={
+                        options.tooltip.mode === TooltipDisplayMode.Multi && options.tooltip.maxHeight !== undefined
+                      }
                     />
                   );
                 }}

--- a/public/app/plugins/panel/heatmap/module.tsx
+++ b/public/app/plugins/panel/heatmap/module.tsx
@@ -428,7 +428,6 @@ export const plugin = new PanelPlugin<Options, GraphFieldConfig>(HeatmapPanel)
       category,
       settings: {
         integer: true,
-        placeholder: '300',
       },
     });
 
@@ -438,7 +437,6 @@ export const plugin = new PanelPlugin<Options, GraphFieldConfig>(HeatmapPanel)
       category,
       settings: {
         integer: true,
-        placeholder: '600',
       },
     });
 

--- a/public/app/plugins/panel/timeseries/TimeSeriesPanel.tsx
+++ b/public/app/plugins/panel/timeseries/TimeSeriesPanel.tsx
@@ -18,7 +18,7 @@ import { ExemplarsPlugin, getVisibleLabels } from './plugins/ExemplarsPlugin';
 import { OutsideRangePlugin } from './plugins/OutsideRangePlugin';
 import { ThresholdControlsPlugin } from './plugins/ThresholdControlsPlugin';
 import { getPrepareTimeseriesSuggestion } from './suggestions';
-import { getTimezones, prepareGraphableFields, regenerateLinksSupplier } from './utils';
+import { getTimezones, isTooltipScrollable, prepareGraphableFields, regenerateLinksSupplier } from './utils';
 
 interface TimeSeriesPanelProps extends PanelProps<Options> {}
 
@@ -142,9 +142,7 @@ export const TimeSeriesPanel = ({
                           sortOrder={options.tooltip.sort}
                           isPinned={isPinned}
                           annotate={enableAnnotationCreation ? annotate : undefined}
-                          scrollable={
-                            options.tooltip.mode === TooltipDisplayMode.Multi && options.tooltip.maxHeight !== undefined
-                          }
+                          scrollable={isTooltipScrollable(options.tooltip)}
                         />
                       );
                     }}

--- a/public/app/plugins/panel/timeseries/TimeSeriesPanel.tsx
+++ b/public/app/plugins/panel/timeseries/TimeSeriesPanel.tsx
@@ -142,6 +142,9 @@ export const TimeSeriesPanel = ({
                           sortOrder={options.tooltip.sort}
                           isPinned={isPinned}
                           annotate={enableAnnotationCreation ? annotate : undefined}
+                          scrollable={
+                            options.tooltip.mode === TooltipDisplayMode.Multi && options.tooltip.maxHeight !== undefined
+                          }
                         />
                       );
                     }}

--- a/public/app/plugins/panel/timeseries/TimeSeriesTooltip.tsx
+++ b/public/app/plugins/panel/timeseries/TimeSeriesTooltip.tsx
@@ -37,6 +37,7 @@ interface TimeSeriesTooltipProps {
   sortOrder?: SortOrder;
 
   isPinned: boolean;
+  scrollable?: boolean;
 
   annotate?: () => void;
 }
@@ -48,6 +49,7 @@ export const TimeSeriesTooltip = ({
   seriesIdx,
   mode = TooltipDisplayMode.Single,
   sortOrder = SortOrder.None,
+  scrollable = false,
   isPinned,
   annotate,
 }: TimeSeriesTooltipProps) => {
@@ -156,11 +158,7 @@ export const TimeSeriesTooltip = ({
     <div>
       <div className={styles.wrapper}>
         <VizTooltipHeader headerLabel={getHeaderLabel()} isPinned={isPinned} />
-        <VizTooltipContent
-          contentLabelValue={getContentLabelValue()}
-          isPinned={isPinned}
-          scrollable={mode === TooltipDisplayMode.Multi}
-        />
+        <VizTooltipContent contentLabelValue={getContentLabelValue()} isPinned={isPinned} scrollable={scrollable} />
         {isPinned && <VizTooltipFooter dataLinks={links} annotate={annotate} />}
       </div>
     </div>

--- a/public/app/plugins/panel/timeseries/utils.ts
+++ b/public/app/plugins/panel/timeseries/utils.ts
@@ -14,7 +14,7 @@ import {
 import { convertFieldType } from '@grafana/data/src/transformations/transformers/convertFieldType';
 import { applyNullInsertThreshold } from '@grafana/data/src/transformations/transformers/nulls/nullInsertThreshold';
 import { nullToValue } from '@grafana/data/src/transformations/transformers/nulls/nullToValue';
-import { GraphFieldConfig, LineInterpolation } from '@grafana/schema';
+import { GraphFieldConfig, LineInterpolation, TooltipDisplayMode, VizTooltipOptions } from '@grafana/schema';
 import { buildScaleKey } from '@grafana/ui/src/components/uPlot/internal';
 
 type ScaleKey = string;
@@ -310,3 +310,7 @@ export function regenerateLinksSupplier(
 
   return alignedDataFrame;
 }
+
+export const isTooltipScrollable = (tooltipOptions: VizTooltipOptions) => {
+  return tooltipOptions.mode === TooltipDisplayMode.Multi && tooltipOptions.maxHeight !== undefined;
+};

--- a/public/app/plugins/panel/timeseries/utils.ts
+++ b/public/app/plugins/panel/timeseries/utils.ts
@@ -312,5 +312,5 @@ export function regenerateLinksSupplier(
 }
 
 export const isTooltipScrollable = (tooltipOptions: VizTooltipOptions) => {
-  return tooltipOptions.mode === TooltipDisplayMode.Multi && tooltipOptions.maxHeight !== undefined;
+  return tooltipOptions.mode === TooltipDisplayMode.Multi && tooltipOptions.maxHeight != null;
 };

--- a/public/app/plugins/panel/trend/TrendPanel.tsx
+++ b/public/app/plugins/panel/trend/TrendPanel.tsx
@@ -142,6 +142,9 @@ export const TrendPanel = ({
                           mode={options.tooltip.mode}
                           sortOrder={options.tooltip.sort}
                           isPinned={isPinned}
+                          scrollable={
+                            options.tooltip.mode === TooltipDisplayMode.Multi && options.tooltip.maxHeight !== undefined
+                          }
                         />
                       );
                     }}

--- a/public/app/plugins/panel/trend/TrendPanel.tsx
+++ b/public/app/plugins/panel/trend/TrendPanel.tsx
@@ -11,7 +11,7 @@ import { TimeSeries } from 'app/core/components/TimeSeries/TimeSeries';
 import { findFieldIndex } from 'app/features/dimensions';
 
 import { TimeSeriesTooltip } from '../timeseries/TimeSeriesTooltip';
-import { prepareGraphableFields, regenerateLinksSupplier } from '../timeseries/utils';
+import { isTooltipScrollable, prepareGraphableFields, regenerateLinksSupplier } from '../timeseries/utils';
 
 import { Options } from './panelcfg.gen';
 
@@ -142,9 +142,7 @@ export const TrendPanel = ({
                           mode={options.tooltip.mode}
                           sortOrder={options.tooltip.sort}
                           isPinned={isPinned}
-                          scrollable={
-                            options.tooltip.mode === TooltipDisplayMode.Multi && options.tooltip.maxHeight !== undefined
-                          }
+                          scrollable={isTooltipScrollable(options.tooltip)}
                         />
                       );
                     }}


### PR DESCRIPTION
This PR removes the default values for `maxWidth` and `maxHeight`.
Exemplars handling in a follow up PR.


Fixes #81622





Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
