### PR TITLE
Chore: Fix data race within tests and enable a few parallel tests

### DIFF
--- a/pkg/services/ssosettings/ssosettingsimpl/service.go
+++ b/pkg/services/ssosettings/ssosettingsimpl/service.go
@@ -196,7 +196,7 @@ func (s *Service) Upsert(ctx context.Context, settings *models.SSOSettings) erro
 		return err
 	}
 
-	// make a copy of current setings for reload operation and apply overrides
+	// make a copy of current settings for reload operation and apply overrides
 	reloadSettings := *settings
 	reloadSettings.Settings = overrideMaps(storedSettings.Settings, settings.Settings, secrets)
 

--- a/pkg/services/ssosettings/ssosettingsimpl/service.go
+++ b/pkg/services/ssosettings/ssosettingsimpl/service.go
@@ -165,42 +165,50 @@ func (s *Service) ListWithRedactedSecrets(ctx context.Context) ([]*models.SSOSet
 }
 
 func (s *Service) Upsert(ctx context.Context, settings *models.SSOSettings) error {
+	_, err := s.upsertAndReloadBg(ctx, settings)
+	return err
+}
+
+// upsertAndReloadBg implements Upsert but returning a second value which is a done channel that is closed when an
+// internal reload operation is completed. This is used to allow consistently testing that the implementation eventually
+// performs all the expected operations in a consistent manner.
+func (s *Service) upsertAndReloadBg(ctx context.Context, settings *models.SSOSettings) (<-chan struct{}, error) {
 	if !s.isProviderConfigurable(settings.Provider) {
-		return ssosettings.ErrNotConfigurable
+		return nil, ssosettings.ErrNotConfigurable
 	}
 
 	social, ok := s.reloadables[settings.Provider]
 	if !ok {
-		return ssosettings.ErrInvalidProvider.Errorf("provider %s not found in reloadables", settings.Provider)
+		return nil, ssosettings.ErrInvalidProvider.Errorf("provider %s not found in reloadables", settings.Provider)
 	}
 
 	err := social.Validate(ctx, *settings)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	storedSettings, err := s.GetForProvider(ctx, settings.Provider)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	secrets := collectSecrets(settings, storedSettings)
 
 	settings.Settings, err = s.encryptSecrets(ctx, settings.Settings, storedSettings.Settings)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	err = s.store.Upsert(ctx, settings)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	settings.Settings = overrideMaps(storedSettings.Settings, settings.Settings, secrets)
 
-	go s.reload(social, settings.Provider, *settings)
+	doneReloading := s.reloadBg(social, settings.Provider, *settings)
 
-	return nil
+	return doneReloading, nil
 }
 
 func (s *Service) Patch(ctx context.Context, provider string, data map[string]any) error {
@@ -208,29 +216,48 @@ func (s *Service) Patch(ctx context.Context, provider string, data map[string]an
 }
 
 func (s *Service) Delete(ctx context.Context, provider string) error {
+	_, err := s.deleteAndReloadBg(ctx, provider)
+	return err
+}
+
+// deleteAndReloadBg implements Delete but returning a second value which is a done channel that is closed when an
+// internal reload operation is completed. This is used to allow consistently testing that the implementation eventually
+// performs all the expected operations in a consistent manner.
+func (s *Service) deleteAndReloadBg(ctx context.Context, provider string) (<-chan struct{}, error) {
 	if !s.isProviderConfigurable(provider) {
-		return ssosettings.ErrNotConfigurable
+		return nil, ssosettings.ErrNotConfigurable
 	}
 
 	social, ok := s.reloadables[provider]
 	if !ok {
-		return ssosettings.ErrInvalidProvider.Errorf("provider %s not found in reloadables", provider)
+		return nil, ssosettings.ErrInvalidProvider.Errorf("provider %s not found in reloadables", provider)
 	}
 
 	err := s.store.Delete(ctx, provider)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	currentSettings, err := s.GetForProvider(ctx, provider)
 	if err != nil {
 		s.logger.Error("failed to get current settings, skipping reload", "provider", provider, "error", err)
-		return nil
+		return nil, nil
 	}
 
-	go s.reload(social, provider, *currentSettings)
+	doneReloading := s.reloadBg(social, provider, *currentSettings)
 
-	return nil
+	return doneReloading, nil
+}
+
+// reloadBg calls reload in a new goroutine and returns a done channel that is closed when the reload operation is
+// completed.
+func (s *Service) reloadBg(reloadable ssosettings.Reloadable, provider string, currentSettings models.SSOSettings) (done <-chan struct{}) {
+	doneChan := make(chan struct{})
+	go func() {
+		s.reload(reloadable, provider, currentSettings)
+		close(doneChan)
+	}()
+	return doneChan
 }
 
 func (s *Service) reload(reloadable ssosettings.Reloadable, provider string, currentSettings models.SSOSettings) {

--- a/pkg/services/ssosettings/ssosettingsimpl/service.go
+++ b/pkg/services/ssosettings/ssosettingsimpl/service.go
@@ -196,9 +196,11 @@ func (s *Service) Upsert(ctx context.Context, settings *models.SSOSettings) erro
 		return err
 	}
 
-	settings.Settings = overrideMaps(storedSettings.Settings, settings.Settings, secrets)
+	// make a copy of current setings for reload operation and apply overrides
+	reloadSettings := *settings
+	reloadSettings.Settings = overrideMaps(storedSettings.Settings, settings.Settings, secrets)
 
-	go s.reload(social, settings.Provider, *settings)
+	go s.reload(social, settings.Provider, reloadSettings)
 
 	return nil
 }

--- a/pkg/services/ssosettings/ssosettingsimpl/service_test.go
+++ b/pkg/services/ssosettings/ssosettingsimpl/service_test.go
@@ -187,6 +187,10 @@ func TestService_GetForProvider(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
+		// create a local copy of "tc" to allow concurrent access within tests to the different items of testCases,
+		// otherwise it would be like a moving pointer while tests run in parallel
+		tc := tc
+
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -292,6 +296,10 @@ func TestService_GetForProviderWithRedactedSecrets(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
+		// create a local copy of "tc" to allow concurrent access within tests to the different items of testCases,
+		// otherwise it would be like a moving pointer while tests run in parallel
+		tc := tc
+
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -439,6 +447,10 @@ func TestService_List(t *testing.T) {
 		},
 	}
 	for _, tc := range testCases {
+		// create a local copy of "tc" to allow concurrent access within tests to the different items of testCases,
+		// otherwise it would be like a moving pointer while tests run in parallel
+		tc := tc
+
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -737,6 +749,10 @@ func TestService_ListWithRedactedSecrets(t *testing.T) {
 		},
 	}
 	for _, tc := range testCases {
+		// create a local copy of "tc" to allow concurrent access within tests to the different items of testCases,
+		// otherwise it would be like a moving pointer while tests run in parallel
+		tc := tc
+
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -1294,6 +1310,10 @@ func TestService_decryptSecrets(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
+		// create a local copy of "tc" to allow concurrent access within tests to the different items of testCases,
+		// otherwise it would be like a moving pointer while tests run in parallel
+		tc := tc
+
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 


### PR DESCRIPTION
**What is this feature?**

Fix a few data races in tests and enable running all tests in parallel in `pkg/services/ssosettings/ssosettingsimpl`.

**Why do we need this feature?**

To allow tests to run in parallel and enable the general use of `-race` for the grafana repo so we can automatically catch new data races introduced more easily.

**Who is this feature for?**

Everyone

**Which issue(s) does this PR fix?**:

None

**Special notes for your reviewer:**

Check that:
- [x] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle.
- [x] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
