### PR TITLE
datatrails: improve width responsiveness for breakdown label selector

### DIFF
--- a/public/app/features/trails/ActionTabs/BreakdownScene.tsx
+++ b/public/app/features/trails/ActionTabs/BreakdownScene.tsx
@@ -19,11 +19,12 @@ import {
   SceneQueryRunner,
   VariableDependencyConfig,
 } from '@grafana/scenes';
-import { Button, Field, Select, RadioButtonGroup, useStyles2 } from '@grafana/ui';
+import { Button, Field, useStyles2 } from '@grafana/ui';
 import { ALL_VARIABLE_VALUE } from 'app/features/variables/constants';
 
 import { getAutoQueriesForMetric } from '../AutomaticMetricQueries/AutoQueryEngine';
 import { AutoQueryDef } from '../AutomaticMetricQueries/types';
+import { BreakdownLabelSelector } from '../BreakdownLabelSelector';
 import { MetricScene } from '../MetricScene';
 import { trailDS, VAR_FILTERS, VAR_GROUP_BY, VAR_GROUP_BY_EXP } from '../shared';
 import { getColorByIndex } from '../utils';
@@ -129,25 +130,16 @@ export class BreakdownScene extends SceneObjectBase<BreakdownSceneState> {
     const { labels, body, loading, value } = model.useState();
     const styles = useStyles2(getStyles);
 
-    const useHorizontalLabelSelector = labels.length <= 6;
-
     return (
       <div className={styles.container}>
         {loading && <div>Loading...</div>}
         <div className={styles.controls}>
           {!loading && (
-            <Field label="By label">
-              {useHorizontalLabelSelector ? (
-                <RadioButtonGroup options={labels} value={value} onChange={model.onChange} />
-              ) : (
-                <Select
-                  options={labels}
-                  value={value}
-                  onChange={(selected) => model.onChange(selected.value)}
-                  className={styles.select}
-                />
-              )}
-            </Field>
+            <div className={styles.controlsLeft}>
+              <Field label="By label">
+                <BreakdownLabelSelector options={labels} value={value} onChange={model.onChange} />
+              </Field>
+            </div>
           )}
           {body instanceof LayoutSwitcher && (
             <div className={styles.controlsRight}>
@@ -174,10 +166,6 @@ function getStyles(theme: GrafanaTheme2) {
       display: 'flex',
       paddingTop: theme.spacing(0),
     }),
-    tabHeading: css({
-      paddingRight: theme.spacing(2),
-      fontWeight: theme.typography.fontWeightMedium,
-    }),
     controls: css({
       flexGrow: 0,
       display: 'flex',
@@ -185,12 +173,16 @@ function getStyles(theme: GrafanaTheme2) {
       gap: theme.spacing(2),
     }),
     controlsRight: css({
-      flexGrow: 1,
+      flexGrow: 0,
       display: 'flex',
       justifyContent: 'flex-end',
     }),
-    select: css({
-      minWidth: theme.spacing(16),
+    controlsLeft: css({
+      display: 'flex',
+      justifyContent: 'flex-left',
+      justifyItems: 'left',
+      width: '100%',
+      flexDirection: 'column',
     }),
   };
 }

--- a/public/app/features/trails/BreakdownLabelSelector.tsx
+++ b/public/app/features/trails/BreakdownLabelSelector.tsx
@@ -1,0 +1,70 @@
+import { css } from '@emotion/css';
+import { useResizeObserver } from '@react-aria/utils';
+import React, { useEffect, useRef, useState } from 'react';
+
+import { GrafanaTheme2, SelectableValue } from '@grafana/data';
+import { Select, RadioButtonGroup, useStyles2, useTheme2 } from '@grafana/ui';
+
+type Props = {
+  options: Array<SelectableValue<string>>;
+  value?: string;
+  onChange: (label: string | undefined) => void;
+};
+
+export function BreakdownLabelSelector({ options, value, onChange }: Props) {
+  const styles = useStyles2(getStyles);
+  const theme = useTheme2();
+
+  const [labelSelectorRequiredWidth, setLabelSelectorRequiredWidth] = useState<number>(0);
+  const [availableWidth, setAvailableWidth] = useState<number>(0);
+
+  const useHorizontalLabelSelector = availableWidth > labelSelectorRequiredWidth;
+
+  const controlsContainer = useRef<HTMLDivElement>(null);
+
+  useResizeObserver({
+    ref: controlsContainer,
+    onResize: () => {
+      const element = controlsContainer.current;
+      if (element) {
+        setAvailableWidth(element.clientWidth);
+      }
+    },
+  });
+
+  useEffect(() => {
+    const canvas = document.createElement('canvas');
+    const context = canvas.getContext('2d');
+
+    if (!context) {
+      return;
+    }
+
+    const { fontSize, fontFamily } = theme.typography;
+    context.font = `${fontSize}px ${fontFamily.split(',')}`;
+
+    const text = options.map((option) => option.label || option.value || '').join(' ');
+    const textWidth = Math.ceil(context.measureText(text).width);
+
+    const additionalWidthPerItem = 32;
+    setLabelSelectorRequiredWidth(textWidth + additionalWidthPerItem * options.length);
+  }, [options, theme]);
+
+  return (
+    <div ref={controlsContainer}>
+      {useHorizontalLabelSelector ? (
+        <RadioButtonGroup {...{ options, value, onChange }} />
+      ) : (
+        <Select {...{ options, value }} onChange={(selected) => onChange(selected.value)} className={styles.select} />
+      )}
+    </div>
+  );
+}
+
+function getStyles(theme: GrafanaTheme2) {
+  return {
+    select: css({
+      maxWidth: theme.spacing(16),
+    }),
+  };
+}

--- a/public/app/features/trails/BreakdownLabelSelector.tsx
+++ b/public/app/features/trails/BreakdownLabelSelector.tsx
@@ -3,7 +3,7 @@ import { useResizeObserver } from '@react-aria/utils';
 import React, { useEffect, useRef, useState } from 'react';
 
 import { GrafanaTheme2, SelectableValue } from '@grafana/data';
-import { Select, RadioButtonGroup, useStyles2, useTheme2 } from '@grafana/ui';
+import { Select, RadioButtonGroup, useStyles2, useTheme2, measureText } from '@grafana/ui';
 
 type Props = {
   options: Array<SelectableValue<string>>;
@@ -33,19 +33,9 @@ export function BreakdownLabelSelector({ options, value, onChange }: Props) {
   });
 
   useEffect(() => {
-    const canvas = document.createElement('canvas');
-    const context = canvas.getContext('2d');
-
-    if (!context) {
-      return;
-    }
-
-    const { fontSize, fontFamily } = theme.typography;
-    context.font = `${fontSize}px ${fontFamily.split(',')}`;
-
+    const { fontSize } = theme.typography;
     const text = options.map((option) => option.label || option.value || '').join(' ');
-    const textWidth = Math.ceil(context.measureText(text).width);
-
+    const textWidth = measureText(text, fontSize).width;
     const additionalWidthPerItem = 32;
     setLabelSelectorRequiredWidth(textWidth + additionalWidthPerItem * options.length);
   }, [options, theme]);


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->


**Which issue(s) does this PR fix?**:

Resolves this comment:
- https://github.com/grafana/grafana/pull/81427#pullrequestreview-1851258364

[responsive label selector.webm](https://github.com/grafana/grafana/assets/38694490/de47d1a0-efed-45a0-b502-eb0501841545)



Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
