### PR TITLE
fix: datatrails verify different time range before creating new history node

### DIFF
--- a/public/app/features/trails/DataTrailsHistory.tsx
+++ b/public/app/features/trails/DataTrailsHistory.tsx
@@ -15,7 +15,7 @@ import { useStyles2, Tooltip, Stack } from '@grafana/ui';
 
 import { DataTrail, DataTrailState } from './DataTrail';
 import { VAR_FILTERS } from './shared';
-import { getTrailFor } from './utils';
+import { getTrailFor, isSceneTimeRangeState } from './utils';
 
 export interface DataTrailsHistoryState extends SceneObjectState {
   currentStep: number;
@@ -68,6 +68,14 @@ export class DataTrailHistory extends SceneObjectBase<DataTrailsHistoryState> {
 
     trail.subscribeToEvent(SceneObjectStateChangedEvent, (evt) => {
       if (evt.payload.changedObject instanceof SceneTimeRange) {
+        const { prevState, newState } = evt.payload;
+
+        if (isSceneTimeRangeState(prevState) && isSceneTimeRangeState(newState)) {
+          if (prevState.from === newState.from && prevState.to === newState.to) {
+            return;
+          }
+        }
+
         this.addTrailStep(trail, 'time');
       }
     });

--- a/public/app/features/trails/utils.ts
+++ b/public/app/features/trails/utils.ts
@@ -1,6 +1,13 @@
 import { urlUtil } from '@grafana/data';
 import { config, getDataSourceSrv } from '@grafana/runtime';
-import { getUrlSyncManager, sceneGraph, SceneObject, SceneObjectUrlValues, SceneTimeRange } from '@grafana/scenes';
+import {
+  getUrlSyncManager,
+  sceneGraph,
+  SceneObject,
+  SceneObjectState,
+  SceneObjectUrlValues,
+  SceneTimeRange,
+} from '@grafana/scenes';
 
 import { getDatasourceSrv } from '../plugins/datasource_srv';
 
@@ -88,4 +95,13 @@ export function getDatasourceForNewTrail(): string | undefined {
 export function getColorByIndex(index: number) {
   const visTheme = config.theme2.visualization;
   return visTheme.getColorByName(visTheme.palette[index % 8]);
+}
+
+export type SceneTimeRangeState = SceneObjectState & {
+  from: string;
+  to: string;
+};
+export function isSceneTimeRangeState(state: SceneObjectState): state is SceneTimeRangeState {
+  const keys = Object.keys(state);
+  return keys.includes('from') && keys.includes('to');
 }


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->
**Which issue(s) does this PR fix?**:

In data trails, whenever the user hit refresh, or if the scene had the interval refresh active, a new "time" change history node was appended on each refresh.
This PR checks to make sure that the raw from and to entries is actually different before deciding to append a new node.

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
