### PR TITLE
datatrails: debounce search and prefix filter

### DIFF
--- a/public/app/features/trails/MetricSelectScene.tsx
+++ b/public/app/features/trails/MetricSelectScene.tsx
@@ -1,5 +1,6 @@
 import { css } from '@emotion/css';
 import leven from 'leven';
+import { debounce } from 'lodash';
 import React, { useCallback } from 'react';
 
 import { GrafanaTheme2, VariableRefresh } from '@grafana/data';
@@ -288,18 +289,26 @@ export class MetricSelectScene extends SceneObjectBase<MetricSelectSceneState> {
     }
   };
 
-  public onSearchChange = (evt: React.SyntheticEvent<HTMLInputElement>) => {
+  public onSearchQueryChange = (evt: React.SyntheticEvent<HTMLInputElement>) => {
     this.setState({ searchQuery: evt.currentTarget.value });
+    this.searchQueryChangedDebounced();
+  };
+
+  private searchQueryChangedDebounced = debounce(() => {
     this.updateMetrics(); // Need to repeat entire pipeline
     this.buildLayout();
-  };
+  }, 500);
 
   public onPrefixFilterChange = (prefixFilter: string | undefined) => {
     this.setState({ prefixFilter });
+    this.prefixFilterChangedDebounced();
+  };
+
+  private prefixFilterChangedDebounced = debounce(() => {
     this.applyMetricPrefixFilter();
     this.updateMetrics(false); // Only needed to applyMetricPrefixFilter
     this.buildLayout();
-  };
+  }, 1000);
 
   public onTogglePreviews = () => {
     this.setState({ showPreviews: !this.state.showPreviews });
@@ -339,7 +348,7 @@ export class MetricSelectScene extends SceneObjectBase<MetricSelectSceneState> {
               placeholder="Search metrics"
               prefix={<Icon name={'search'} />}
               value={searchQuery}
-              onChange={model.onSearchChange}
+              onChange={model.onSearchQueryChange}
               disabled={disableSearch}
             />
           </Field>


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

- Use debouncing for metric name search and filters

**Special notes for your reviewer:**

- [ ] Discuss the timing for debouncing for both the text input and the prefix selection / browsing

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
