### PR TITLE
enhancement: use SVG icon for cascader expand instead of `>`

### DIFF
--- a/packages/grafana-ui/src/components/ButtonCascader/_ButtonCascader.scss
+++ b/packages/grafana-ui/src/components/ButtonCascader/_ButtonCascader.scss
@@ -127,13 +127,13 @@
         &:after {
           background: $text-color-weak;
           content: '';
-          height: 32px;
+          height: 24px;
           mask: url(../img/icons/unicons/angle-right.svg);
           mask-type: luminance;
           position: absolute;
           right: 0px;
-          top: 0;
-          width: 32px;
+          top: calc((32px - 24px) / 2);
+          width: 24px;
         }
       }
     }

--- a/packages/grafana-ui/src/components/ButtonCascader/_ButtonCascader.scss
+++ b/packages/grafana-ui/src/components/ButtonCascader/_ButtonCascader.scss
@@ -128,7 +128,7 @@
           background: $text-color-weak;
           content: '';
           height: 32px;
-          mask: url(public/img/icons/unicons/angle-right.svg);
+          mask: url(../img/icons/unicons/angle-right.svg);
           mask-type: luminance;
           position: absolute;
           right: 0px;

--- a/packages/grafana-ui/src/components/ButtonCascader/_ButtonCascader.scss
+++ b/packages/grafana-ui/src/components/ButtonCascader/_ButtonCascader.scss
@@ -125,13 +125,15 @@
         position: relative;
 
         &:after {
-          content: '>';
-          font-size: 12px;
-          color: $text-color-weak;
+          background: $text-color-weak;
+          content: '';
+          height: 32px;
+          mask: url(public/img/icons/unicons/angle-right.svg);
+          mask-type: luminance;
           position: absolute;
-          right: 16px;
+          right: 0px;
           top: 0;
-          line-height: 32px;
+          width: 32px;
         }
       }
     }


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**Which issue(s) does this PR fix?**:

It was noted that a text `>` was being used for the cascader expand icon (via css), and it was suggested that we should use the SVG icon instead.

(updated screenshots with reduced 24px size)
![image](https://github.com/grafana/grafana/assets/38694490/41ac9570-a1b9-42c2-bab3-039a6fe4ad0a)

![image](https://github.com/grafana/grafana/assets/38694490/837af269-a1a7-46de-affd-ddb1cc3a9178)



**Special notes for your reviewer:**

Please check that:
- [ ] This method for displaying the icon works correctly for supported browsers
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
