### PR TITLE
DashboardGrid: Resize panels using variable

### DIFF
--- a/packages/grafana-data/src/types/featureToggles.gen.ts
+++ b/packages/grafana-data/src/types/featureToggles.gen.ts
@@ -177,4 +177,5 @@ export interface FeatureToggles {
   ssoSettingsSAML?: boolean;
   usePrometheusFrontendPackage?: boolean;
   oauthRequireSubClaim?: boolean;
+  rowResizeVariable?: boolean;
 }

--- a/pkg/services/featuremgmt/registry.go
+++ b/pkg/services/featuremgmt/registry.go
@@ -1189,6 +1189,14 @@ var (
 			HideFromDocs:      true,
 			HideFromAdminPage: true,
 		},
+		{
+			Name:         "rowResizeVariable",
+			Description:  "Enables use of the `systemDynamicRowSizeVar` variable to resize to a certain amount of panels per row",
+			Stage:        FeatureStageExperimental,
+			FrontendOnly: true,
+			Owner:        grafanaDashboardsSquad,
+			HideFromDocs: true,
+		},
 	}
 )
 

--- a/pkg/services/featuremgmt/toggles_gen.csv
+++ b/pkg/services/featuremgmt/toggles_gen.csv
@@ -158,3 +158,4 @@ scopeFilters,experimental,@grafana/dashboards-squad,false,false,false
 ssoSettingsSAML,experimental,@grafana/identity-access-team,false,false,false
 usePrometheusFrontendPackage,experimental,@grafana/observability-metrics,false,false,true
 oauthRequireSubClaim,experimental,@grafana/identity-access-team,false,false,false
+rowResizeVariable,experimental,@grafana/dashboards-squad,2024-01-17,false,false,false,true

--- a/pkg/services/featuremgmt/toggles_gen.go
+++ b/pkg/services/featuremgmt/toggles_gen.go
@@ -642,4 +642,7 @@ const (
 	// FlagOauthRequireSubClaim
 	// Require that sub claims is present in oauth tokens.
 	FlagOauthRequireSubClaim = "oauthRequireSubClaim"
+	// FlagRowResizeVariable
+	// Enables use of the `systemDynamicRowSizeVar` variable to resize to a certain amount of panels per row
+	FlagRowResizeVariable = "rowResizeVariable"
 )

--- a/public/app/features/dashboard/dashgrid/DashboardGrid.test.tsx
+++ b/public/app/features/dashboard/dashgrid/DashboardGrid.test.tsx
@@ -18,7 +18,7 @@ import { DashboardMeta } from 'app/types';
 import { DashboardModel } from '../state';
 import { createDashboardModelFixture } from '../state/__fixtures__/dashboardFixtures';
 
-import { DashboardGrid, PANEL_FILTER_VARIABLE, ROW_RESIZE_VARIABLE, Props } from './DashboardGrid';
+import { DashboardGrid, PANEL_FILTER_VARIABLE, Props } from './DashboardGrid';
 import { Props as LazyLoaderProps } from './LazyLoader';
 
 jest.mock('@grafana/runtime', () => ({

--- a/public/app/features/dashboard/dashgrid/DashboardGrid.test.tsx
+++ b/public/app/features/dashboard/dashgrid/DashboardGrid.test.tsx
@@ -18,7 +18,7 @@ import { DashboardMeta } from 'app/types';
 import { DashboardModel } from '../state';
 import { createDashboardModelFixture } from '../state/__fixtures__/dashboardFixtures';
 
-import { DashboardGrid, PANEL_FILTER_VARIABLE, Props } from './DashboardGrid';
+import { DashboardGrid, PANEL_FILTER_VARIABLE, ROW_RESIZE_VARIABLE, Props } from './DashboardGrid';
 import { Props as LazyLoaderProps } from './LazyLoader';
 
 jest.mock('@grafana/runtime', () => ({

--- a/public/app/features/dashboard/dashgrid/DashboardGrid.tsx
+++ b/public/app/features/dashboard/dashgrid/DashboardGrid.tsx
@@ -172,6 +172,8 @@ export class DashboardGrid extends PureComponent<Props, State> {
 
     let x = 0;
     let y = 0;
+    let lastPanelHeight = 1;
+
     for (const panel of this.props.dashboard.panels) {
       if (!panel.key) {
         panel.key = `panel-${panel.id}-${Date.now()}`;
@@ -212,11 +214,12 @@ export class DashboardGrid extends PureComponent<Props, State> {
           // row
           if (x !== 0) {
             x = 0;
-            y++;
+            y += lastPanelHeight;
           }
           panelPos.x = x;
           panelPos.y = y;
           y++;
+          lastPanelHeight = 1;
         } else {
           // Skip if this non-row panel doesn't
           // match the title filter
@@ -224,13 +227,15 @@ export class DashboardGrid extends PureComponent<Props, State> {
             continue
           }
 
+          lastPanelHeight = panelPos.h;
+
           panelPos.w = overrideWidth;
           panelPos.x = x;
           panelPos.y = y;
           x += overrideWidth;
           if (x >= GRID_COLUMN_COUNT) {
             x = 0;
-            y++;
+            y += lastPanelHeight;
           }
         }
       }

--- a/public/app/features/dashboard/dashgrid/DashboardGrid.tsx
+++ b/public/app/features/dashboard/dashgrid/DashboardGrid.tsx
@@ -169,6 +169,7 @@ export class DashboardGrid extends PureComponent<Props, State> {
       overrideCols = rowResize;
     }
     let overrideWidth = GRID_COLUMN_COUNT / overrideCols;
+    let overrideHeight = 8; // TODO Replace with variable
 
     let x = 0;
     let y = 0;
@@ -227,12 +228,13 @@ export class DashboardGrid extends PureComponent<Props, State> {
             continue
           }
 
-          lastPanelHeight = panelPos.h;
-
+          panelPos.h = overrideHeight;
           panelPos.w = overrideWidth;
           panelPos.x = x;
           panelPos.y = y;
-          x += overrideWidth;
+
+          x += panelPos.w;
+          lastPanelHeight = panelPos.h;
           if (x >= GRID_COLUMN_COUNT) {
             x = 0;
             y += lastPanelHeight;


### PR DESCRIPTION
**What is this feature?**
A new special variable is added, `systemDynamicRowSizeVar` which accepts the number of panels there should be per row. When the variable changes the dashboard is re-rendered to place said number of panels per row.

**Why do we need this feature?**
Sometimes the situation arises where the user wants to temporarily see two panels per row instead of the default layout they had configured prior.

**Who is this feature for?**
Any user that wishes to try it before the feature flag.

**Which issue(s) does this PR fix?**:
@natellium @thanos-karachalios @mjtalarczyk This PR represents the proposal we spoke about a few weeks ago.

**Special notes for your reviewer:**
I wasn't able to find a way to leverage the test framework to test this feature. This is likely due to lack of knowledge on my part. I'll gladly take any suggestions to formulate viable test cases.

Please check that:
- [X] It works as expected from a user's perspective.
- [X] If this is a pre-GA feature, it is behind a feature toggle.
- [X] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
