### PR TITLE
DashboardScene: Fix issue with url sync after saving title change

### DIFF
--- a/public/app/features/dashboard-scene/saving/SaveDashboardAsForm.tsx
+++ b/public/app/features/dashboard-scene/saving/SaveDashboardAsForm.tsx
@@ -10,7 +10,7 @@ import { DashboardScene } from '../scene/DashboardScene';
 
 import { SaveDashboardDrawer } from './SaveDashboardDrawer';
 import { DashboardChangeInfo, NameAlreadyExistsError, SaveButton, isNameExistsError } from './shared';
-import { useDashboardSave } from './useSaveDashboard';
+import { useSaveDashboard } from './useSaveDashboard';
 
 interface SaveDashboardAsFormDTO {
   firstName?: string;
@@ -45,7 +45,7 @@ export function SaveDashboardAsForm({ dashboard, drawer, changeInfo }: Props) {
   const { errors, isValid, defaultValues } = formState;
   const formValues = watch();
 
-  const { state, onSaveDashboard } = useDashboardSave(false);
+  const { state, onSaveDashboard } = useSaveDashboard(false);
 
   const onSave = async (overwrite: boolean) => {
     const data = getValues();

--- a/public/app/features/dashboard-scene/saving/SaveDashboardForm.tsx
+++ b/public/app/features/dashboard-scene/saving/SaveDashboardForm.tsx
@@ -15,7 +15,7 @@ import {
   isPluginDashboardError,
   isVersionMismatchError,
 } from './shared';
-import { useDashboardSave } from './useSaveDashboard';
+import { useSaveDashboard } from './useSaveDashboard';
 
 export interface Props {
   dashboard: DashboardScene;
@@ -26,7 +26,7 @@ export interface Props {
 export function SaveDashboardForm({ dashboard, drawer, changeInfo }: Props) {
   const { changedSaveModel, hasChanges } = changeInfo;
 
-  const { state, onSaveDashboard } = useDashboardSave(false);
+  const { state, onSaveDashboard } = useSaveDashboard(false);
   const [options, setOptions] = useState<SaveDashboardOptions>({
     folderUid: dashboard.state.meta.folderUid,
   });

--- a/public/app/features/dashboard-scene/saving/useSaveDashboard.ts
+++ b/public/app/features/dashboard-scene/saving/useSaveDashboard.ts
@@ -14,7 +14,7 @@ import { DashboardSavedEvent } from 'app/types/events';
 import { updateDashboardUidLastUsedDatasource } from '../../dashboard/utils/dashboard';
 import { DashboardScene } from '../scene/DashboardScene';
 
-export function useDashboardSave(isCopy = false) {
+export function useSaveDashboard(isCopy = false) {
   const dispatch = useDispatch();
   const notifyApp = useAppNotification();
   const [saveDashboardRtkQuery] = useSaveDashboardMutation();
@@ -60,7 +60,12 @@ export function useDashboardSave(isCopy = false) {
         const newUrl = locationUtil.stripBaseFromUrl(resultData.url);
 
         if (newUrl !== currentLocation.pathname) {
-          setTimeout(() => locationService.replace({ pathname: newUrl, search: currentLocation.search }));
+          setTimeout(() => {
+            // Because the path changes we need to stop and restart url sync
+            scene.stopUrlSync();
+            locationService.push({ pathname: newUrl, search: currentLocation.search });
+            scene.startUrlSync();
+          });
         }
 
         if (scene.state.meta.isStarred) {


### PR DESCRIPTION
* Changing title causes a new url after save
* Scene url sync ignores location updates for a different path then what it was initialized with (to detect location changes that happen when you move away from a scene)
* To fix I needed to stop and start url sync again. Alt fix would be a UrlSyncManager.updateSceneLocation function 