### PR TITLE
DashboardScene: move overlay out from each edit view

### DIFF
--- a/public/app/features/dashboard-scene/scene/DashboardSceneRenderer.tsx
+++ b/public/app/features/dashboard-scene/scene/DashboardSceneRenderer.tsx
@@ -22,7 +22,12 @@ export function DashboardSceneRenderer({ model }: SceneComponentProps<DashboardS
   const navModel = getNavModel(navIndex, 'dashboards/browse');
 
   if (editview) {
-    return <editview.Component model={editview} />;
+    return (
+      <>
+        <editview.Component model={editview} />
+        {overlay && <overlay.Component model={overlay} />}
+      </>
+    );
   }
 
   return (

--- a/public/app/features/dashboard-scene/settings/DashboardLinksEditView.tsx
+++ b/public/app/features/dashboard-scene/settings/DashboardLinksEditView.tsx
@@ -124,7 +124,6 @@ interface EditLinkViewProps {
 function EditLinkView({ pageNav, link, navModel, dashboard, onChange, onGoBack }: EditLinkViewProps) {
   const parentTab = pageNav.children!.find((p) => p.active)!;
   parentTab.parentItem = pageNav;
-  const { overlay } = dashboard.useState();
 
   const editLinkPageNav = {
     text: 'Edit link',
@@ -135,7 +134,6 @@ function EditLinkView({ pageNav, link, navModel, dashboard, onChange, onGoBack }
     <Page navModel={navModel} pageNav={editLinkPageNav} layout={PageLayoutType.Standard}>
       <NavToolbarActions dashboard={dashboard} />
       <DashboardLinkForm link={link!} onUpdate={onChange} onGoBack={onGoBack} />
-      {overlay && <overlay.Component model={overlay} />}
     </Page>
   );
 }

--- a/public/app/features/dashboard-scene/settings/GeneralSettingsEditView.tsx
+++ b/public/app/features/dashboard-scene/settings/GeneralSettingsEditView.tsx
@@ -148,7 +148,7 @@ export class GeneralSettingsEditView
 
   static Component = ({ model }: SceneComponentProps<GeneralSettingsEditView>) => {
     const { navModel, pageNav } = useDashboardEditPageNav(model.getDashboard(), model.getUrlKey());
-    const { title, description, tags, meta, editable, overlay } = model.getDashboard().useState();
+    const { title, description, tags, meta, editable } = model.getDashboard().useState();
     const { sync: graphTooltip } = model.getCursorSync()?.useState() || {};
     const { timeZone, weekStart, UNSAFE_nowDelay: nowDelay } = model.getTimeRange().useState();
     const { intervals } = model.getRefreshPicker()?.useState() || {};
@@ -260,7 +260,6 @@ export class GeneralSettingsEditView
 
           <Box marginTop={3}>{meta.canDelete && <DeleteDashboardButton />}</Box>
         </div>
-        {overlay && <overlay.Component model={overlay} />}
       </Page>
     );
   };


### PR DESCRIPTION

Some edit views where missing the overlay (and without it no save drawer), so feels like this should be outside each editview as all need it. 