### PR TITLE
Icons: support docker icon

### DIFF
--- a/packages/grafana-data/src/types/icon.ts
+++ b/packages/grafana-data/src/types/icon.ts
@@ -83,6 +83,7 @@ export const availableIconsIndex = {
   dashboard: true,
   database: true,
   'dice-three': true,
+  docker: true,
   'document-info': true,
   'download-alt': true,
   draggabledots: true,


### PR DESCRIPTION
**What is this feature?**

Adds `docker` to the available icons index. The `docker` icon seems to already exist, but shows a console warning when using it. If there's a reason why this isn't currently included in this index we can close this pr.

**Why do we need this feature?**

The docker icon will be useful for the app plugin the Security team is developing.

**Who is this feature for?**

Anyone who wishes to use the docker icon in an app plugin.

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
