### PR TITLE
I18n: Adjust GH actions workflow

### DIFF
--- a/.github/pr-commands.json
+++ b/.github/pr-commands.json
@@ -192,7 +192,7 @@
     "type": "author",
     "name": "pr/external",
     "notMemberOf": { "org": "grafana" },
-    "ignoreList": ["renovate[bot]","dependabot[bot]","grafana-delivery-bot[bot]","grafanabot"],
+    "ignoreList": ["renovate[bot]","dependabot[bot]","grafana-delivery-bot[bot]","grafanabot","github-actions[bot]"],
     "action": "updateLabel",
     "addLabel": "pr/external"
   },

--- a/.github/workflows/i18n-crowdin-download.yml
+++ b/.github/workflows/i18n-crowdin-download.yml
@@ -47,6 +47,8 @@ jobs:
           config: 'crowdin.yml'
           source: 'public/locales/en-US/grafana.json'
           translation: 'public/locales/%locale%/%original_file_name%'
+          github_user_name: "github-actions[bot]"
+          github_user_email: "41898282+github-actions[bot]@users.noreply.github.com"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           CROWDIN_PROJECT_ID: ${{ secrets.CROWDIN_PROJECT_ID }}


### PR DESCRIPTION
**What is this feature?**
Adds github-actions bot to pr-commands.

**Why do we need this feature?**
github-actions bot should be treated like other bots that create PRs in grafana/grafana. I hope to avoid the CLA-assistant requirements. (see [here](https://github.com/grafana/grafana/pull/81880#issuecomment-1926909548))

**Which issue(s) does this PR fix?**:
Relates to https://github.com/grafana/grafana/pull/81571

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
