### PR TITLE
Folders: Set FullPath and FullPathUIDs when feature flag is off and query requests

### DIFF
--- a/pkg/services/folder/folderimpl/folder.go
+++ b/pkg/services/folder/folderimpl/folder.go
@@ -148,9 +148,27 @@ func (s *Service) GetFolders(ctx context.Context, q folder.GetFoldersQuery) ([]*
 		}
 	}
 
+	if !s.features.IsEnabled(ctx, featuremgmt.FlagNestedFolders) {
+		qry.WithFullpath = false // do not request full path if nested folders are disabled
+		qry.WithFullpathUIDs = false
+	}
+
 	dashFolders, err := s.store.GetFolders(ctx, qry)
 	if err != nil {
 		return nil, folder.ErrInternal.Errorf("failed to fetch subfolders: %w", err)
+	}
+
+	if !s.features.IsEnabled(ctx, featuremgmt.FlagNestedFolders) {
+		if q.WithFullpathUIDs || q.WithFullpath {
+			for _, f := range dashFolders { // and fix the full path with folder title (unescaped)
+				if q.WithFullpath {
+					f.Fullpath = f.Title
+				}
+				if q.WithFullpathUIDs {
+					f.FullpathUIDs = f.UID
+				}
+			}
+		}
 	}
 
 	return dashFolders, nil

--- a/pkg/services/folder/folderimpl/folder_test.go
+++ b/pkg/services/folder/folderimpl/folder_test.go
@@ -1611,7 +1611,7 @@ func TestIntegrationNestedFolderSharedWithMe(t *testing.T) {
 	})
 }
 
-func TestIntegrationFolderServiceGetFolders(t *testing.T) {
+func TestFolderServiceGetFolders(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping integration test")
 	}

--- a/pkg/services/folder/folderimpl/folder_test.go
+++ b/pkg/services/folder/folderimpl/folder_test.go
@@ -1663,13 +1663,10 @@ func TestFolderServiceGetFolders(t *testing.T) {
 	})
 
 	folders := CreateSubtreeInStore(t, nestedFolderStore, serviceWithFlagOff, 4, "getfolders-ff-off", createCmd)
-	rand.Shuffle(len(folders), func(i, j int) {
-		folders[i], folders[j] = folders[j], folders[i]
-	})
 
 	t.Run("when flag is off", func(t *testing.T) {
 		t.Run("full path should be a title", func(t *testing.T) {
-			f := folders[0]
+			f := folders[rand.Intn(len(folders))]
 			q := folder.GetFoldersQuery{
 				OrgID:            orgID,
 				WithFullpath:     true,


### PR DESCRIPTION
**What is this feature?**
When feature flag `nestedFolders` is off and GetFoldersQuery requests FullPath and\or FullPathUIDs, the Folders service sets the corresponding fields to Title and UID.

**Why do we need this feature?**
When feature flag is disabled but query requests those fields they are returned as empty which can cause unexpected problems in places where FullPath is used instead of the title. 

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
