### PR TITLE
Chore: Force transitive resolution of debug

### DIFF
--- a/package.json
+++ b/package.json
@@ -413,6 +413,8 @@
     "ngtemplate-loader/loader-utils": "^2.0.0",
     "semver@~7.0.0": "7.5.4",
     "semver@7.3.4": "7.5.4",
+    "debug@npm:^0.7.2": "2.6.9",
+    "debug@npm:^0.7.4": "2.6.9",
     "slate-dev-environment@^0.2.2": "patch:slate-dev-environment@npm:0.2.5#.yarn/patches/slate-dev-environment-npm-0.2.5-9aeb7da7b5.patch",
     "react-split-pane@0.1.92": "patch:react-split-pane@npm:0.1.92#.yarn/patches/react-split-pane-npm-0.1.92-93dbf51dff.patch",
     "@storybook/blocks@7.4.5": "patch:@storybook/blocks@npm%3A7.4.5#./.yarn/patches/@storybook-blocks-npm-7.4.5-5a2374564a.patch",

--- a/yarn.lock
+++ b/yarn.lock
@@ -14388,13 +14388,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"debug@npm:^0.7.2, debug@npm:^0.7.4":
-  version: 0.7.4
-  resolution: "debug@npm:0.7.4"
-  checksum: 10/5646bf2bb349381e1363f1107513270f29092df1a1a7c0f331b23867867c517da5acbd31f828101bef61969fe558b81f044288624dbadaccb2c088329450a74f
-  languageName: node
-  linkType: hard
-
 "debug@npm:^3.1.0, debug@npm:^3.2.7":
   version: 3.2.7
   resolution: "debug@npm:3.2.7"


### PR DESCRIPTION
debug 0.7.4 is used in dependency trees

```
rudder-sdk-js@npm:2.48.1 (via npm:2.48.1)
└─ @segment/localstorage-retry@npm:1.3.0 (via npm:1.3.0)
   └─ debug@npm:0.7.4 [ebcb6] (via npm:^0.7.4 [ebcb6])
```

and

```
@grafana/e2e@workspace:packages/grafana-e2e
└─ blink-diff@npm:1.0.13 (via npm:1.0.13)
   └─ preceptor-core@npm:0.10.1 (via npm:~0.10.0)
      └─ log4js@npm:1.1.1 (via npm:1.1.1)
         └─ streamroller@npm:0.4.1 (via npm:^0.4.0)
            └─ debug@npm:0.7.4 [ebcb6] (via npm:^0.7.4 [ebcb6])
```

which are not getting updates. This forces resolution to a non-vulnerable version.

Note that this will change usage in the packages from 0.7.4 to 2.6.9 which is, on paper a big breaking-changes jump. I reviewed usage in `@segment/localstorage-retry` and `streamroller` and I believe it should still be compatible. Usage through streamroller / @grafana/e2e is in e2e tests anyway, so would not affect grafana running.
 
Fixes https://github.com/grafana/grafana/issues/81898