### PR TITLE
Chore: Fix plugins manager process data race in pkg/plugins/manager/process

### DIFF
--- a/pkg/plugins/log/fake.go
+++ b/pkg/plugins/log/fake.go
@@ -23,19 +23,19 @@ func (f *TestLogger) New(_ ...any) Logger {
 }
 
 func (f *TestLogger) Info(msg string, ctx ...any) {
-	f.InfoLogs.Set(msg, ctx)
+	f.InfoLogs.Call(msg, ctx)
 }
 
 func (f *TestLogger) Warn(msg string, ctx ...any) {
-	f.WarnLogs.Set(msg, ctx)
+	f.WarnLogs.Call(msg, ctx)
 }
 
 func (f *TestLogger) Debug(msg string, ctx ...any) {
-	f.DebugLogs.Set(msg, ctx)
+	f.DebugLogs.Call(msg, ctx)
 }
 
 func (f *TestLogger) Error(msg string, ctx ...any) {
-	f.ErrorLogs.Set(msg, ctx)
+	f.ErrorLogs.Call(msg, ctx)
 }
 
 func (f *TestLogger) FromContext(_ context.Context) Logger {
@@ -50,7 +50,7 @@ type Logs struct {
 	mu sync.Mutex
 }
 
-func (l *Logs) Set(msg string, ctx ...any) {
+func (l *Logs) Call(msg string, ctx ...any) {
 	l.mu.Lock()
 	defer l.mu.Unlock()
 	l.Calls++

--- a/pkg/plugins/log/fake.go
+++ b/pkg/plugins/log/fake.go
@@ -43,7 +43,7 @@ func (f *TestLogger) FromContext(_ context.Context) Logger {
 }
 
 type Logs struct {
-	Calls   uint64
+	Calls   int
 	Message string
 	Ctx     []any
 

--- a/pkg/plugins/manager/process/process_test.go
+++ b/pkg/plugins/manager/process/process_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"sync"
 	"testing"
-	"time"
 
 	"github.com/stretchr/testify/require"
 
@@ -15,7 +14,11 @@ import (
 )
 
 func TestProcessManager_Start(t *testing.T) {
+	t.Parallel()
+
 	t.Run("Plugin state determines process start", func(t *testing.T) {
+		t.Parallel()
+
 		tcs := []struct {
 			name               string
 			managed            bool
@@ -52,14 +55,20 @@ func TestProcessManager_Start(t *testing.T) {
 			},
 		}
 		for _, tc := range tcs {
+			// create a local copy of "tc" to allow concurrent access within tests to the different items of testCases,
+			// otherwise it would be like a moving pointer while tests run in parallel
+			tc := tc
+
 			t.Run(tc.name, func(t *testing.T) {
+				t.Parallel()
+
 				bp := fakes.NewFakeBackendPlugin(tc.managed)
 				p := createPlugin(t, bp, func(plugin *plugins.Plugin) {
 					plugin.Backend = tc.backend
 					plugin.SignatureError = tc.signatureError
 				})
 
-				m := &Service{}
+				m := ProvideService()
 				err := m.Start(context.Background(), p)
 				require.NoError(t, err)
 				require.Equal(t, tc.expectedStartCount, bp.StartCount)
@@ -74,18 +83,15 @@ func TestProcessManager_Start(t *testing.T) {
 	})
 
 	t.Run("Won't stop the plugin if the context is cancelled", func(t *testing.T) {
+		t.Parallel()
+
 		bp := fakes.NewFakeBackendPlugin(true)
 		p := createPlugin(t, bp, func(plugin *plugins.Plugin) {
 			plugin.Backend = true
 		})
 
-		tickerDuration := keepPluginAliveTickerDuration
-		keepPluginAliveTickerDuration = 1 * time.Millisecond
-		defer func() {
-			keepPluginAliveTickerDuration = tickerDuration
-		}()
-
-		m := &Service{}
+		m := ProvideService()
+		m.keepPluginAliveTickerDuration = 1
 		ctx := context.Background()
 		ctx, cancel := context.WithCancel(ctx)
 		err := m.Start(ctx, p)
@@ -100,7 +106,11 @@ func TestProcessManager_Start(t *testing.T) {
 }
 
 func TestProcessManager_Stop(t *testing.T) {
+	t.Parallel()
+
 	t.Run("Can stop a running plugin", func(t *testing.T) {
+		t.Parallel()
+
 		pluginID := "test-datasource"
 
 		bp := fakes.NewFakeBackendPlugin(true)
@@ -109,7 +119,7 @@ func TestProcessManager_Stop(t *testing.T) {
 			plugin.Backend = true
 		})
 
-		m := &Service{}
+		m := ProvideService()
 		err := m.Stop(context.Background(), p)
 		require.NoError(t, err)
 
@@ -120,18 +130,21 @@ func TestProcessManager_Stop(t *testing.T) {
 }
 
 func TestProcessManager_ManagedBackendPluginLifecycle(t *testing.T) {
-	bp := fakes.NewFakeBackendPlugin(true)
-	p := createPlugin(t, bp, func(plugin *plugins.Plugin) {
-		plugin.Backend = true
-	})
-
-	m := &Service{}
-
-	err := m.Start(context.Background(), p)
-	require.NoError(t, err)
-	require.Equal(t, 1, bp.StartCount)
+	t.Parallel()
 
 	t.Run("When plugin process is killed, the process is restarted", func(t *testing.T) {
+		t.Parallel()
+		bp := fakes.NewFakeBackendPlugin(true)
+		p := createPlugin(t, bp, func(plugin *plugins.Plugin) {
+			plugin.Backend = true
+		})
+
+		m := ProvideService()
+
+		err := m.Start(context.Background(), p)
+		require.NoError(t, err)
+		require.Equal(t, 1, bp.StartCount)
+
 		var wgKill sync.WaitGroup
 		wgKill.Add(1)
 		go func() {


### PR DESCRIPTION
**What is this feature?**

Fix a data race in tests and enable running all tests in parallel in `pkg/plugins/manager/process`.

**Why do we need this feature?**

To allow tests to run in parallel and enable the general use of -race for the grafana repo so we can automatically catch new data races introduced more easily.

**Who is this feature for?**

Everyone.

**Which issue(s) does this PR fix?**:

None.

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [x] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
