### PR TITLE
Alerting: Fix contact point selector in simplified routing

### DIFF
--- a/public/app/features/alerting/unified/components/rule-editor/alert-rule-form/simplifiedRouting/contactPoint/ContactPointSelector.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/alert-rule-form/simplifiedRouting/contactPoint/ContactPointSelector.tsx
@@ -1,8 +1,11 @@
 import { css, cx } from '@emotion/css';
+import { BaseQueryFn, QueryDefinition } from '@reduxjs/toolkit/dist/query';
+import { QueryActionCreatorResult } from '@reduxjs/toolkit/dist/query/core/buildInitiate';
 import React, { useCallback, useEffect, useState } from 'react';
 import { useFormContext } from 'react-hook-form';
 
 import { GrafanaTheme2, SelectableValue } from '@grafana/data';
+import { BackendSrvRequest } from '@grafana/runtime';
 import {
   ActionMeta,
   Field,
@@ -16,6 +19,7 @@ import {
 } from '@grafana/ui';
 import { RuleFormValues } from 'app/features/alerting/unified/types/rule-form';
 import { createUrl } from 'app/features/alerting/unified/utils/url';
+import { AlertManagerCortexConfig } from 'app/plugins/datasource/alertmanager/types';
 
 import { ContactPointWithMetadata } from '../../../../contact-points/utils';
 
@@ -27,7 +31,19 @@ export interface ContactPointSelectorProps {
     description: React.JSX.Element;
   }>;
   onSelectContactPoint: (contactPoint?: ContactPointWithMetadata) => void;
-  refetchReceivers: () => Promise<unknown>;
+  refetchReceivers: () => QueryActionCreatorResult<
+    QueryDefinition<
+      string,
+      BaseQueryFn<BackendSrvRequest>,
+      | 'AlertmanagerChoice'
+      | 'AlertmanagerConfiguration'
+      | 'OnCallIntegrations'
+      | 'OrgMigrationState'
+      | 'DataSourceSettings',
+      AlertManagerCortexConfig,
+      'alertingApi'
+    >
+  >;
 }
 
 export function ContactPointSelector({


### PR DESCRIPTION
**What is this feature?**

This PR fixes contact point selector in simplified routing not showing options after adding this [commit](https://github.com/grafana/grafana/pull/81621/commits/8ef7119f023bfabae520124925be5e33bd6310d5)

**Why do we need this feature?**

All users


Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
