### PR TITLE
I18n: Export only approved translations

### DIFF
--- a/.github/workflows/i18n-crowdin-download.yml
+++ b/.github/workflows/i18n-crowdin-download.yml
@@ -25,6 +25,7 @@ jobs:
           upload_translations: false
           download_sources: false
           download_translations: true
+          export_only_approved: true
           localization_branch_name: i18n_crowdin_translations
           create_pull_request: true
           pull_request_title: 'I18n: Download translations from Crowdin'


### PR DESCRIPTION
**What is this feature?**
Make sure only approved translations can be exported from Crowdin

**Which issue(s) does this PR fix?**:
Relates to https://github.com/grafana/grafana/pull/81571

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
