### PR TITLE
ReturnToPrevious: Add interaction reporting

### DIFF
--- a/public/app/core/components/AppChrome/AppChrome.tsx
+++ b/public/app/core/components/AppChrome/AppChrome.tsx
@@ -58,9 +58,10 @@ export function AppChrome({ children }: Props) {
   const shouldShowReturnToPrevious =
     config.featureToggles.returnToPrevious && state.returnToPrevious && url !== state.returnToPrevious.href;
 
+  // Clear returnToPrevious when the page is manually navigated to
   useEffect(() => {
     if (state.returnToPrevious && url === state.returnToPrevious.href) {
-      chrome.clearReturnToPrevious();
+      chrome.clearReturnToPrevious('auto_dismissed');
     }
     // We only want to pay attention when the location changes
     // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/public/app/core/components/AppChrome/AppChromeService.tsx
+++ b/public/app/core/components/AppChrome/AppChromeService.tsx
@@ -103,7 +103,7 @@ export class AppChromeService {
   public clearReturnToPrevious = (interactionAction: 'clicked' | 'dismissed' | 'auto_dismissed') => {
     const existingRtp = this.state.getValue().returnToPrevious;
     if (existingRtp) {
-      reportInteraction('grafana_return_to_previous_button_dissmissed', {
+      reportInteraction('grafana_return_to_previous_button_dismissed', {
         action: interactionAction,
         page: existingRtp.href,
       });

--- a/public/app/core/components/AppChrome/AppChromeService.tsx
+++ b/public/app/core/components/AppChrome/AppChromeService.tsx
@@ -90,11 +90,25 @@ export class AppChromeService {
   }
 
   public setReturnToPrevious = (returnToPrevious: ReturnToPreviousProps) => {
+    const previousPage = this.state.getValue().returnToPrevious;
+    reportInteraction('grafana_return_to_previous_button_created', {
+      page: returnToPrevious.href,
+      previousPage: previousPage?.href,
+    });
+
     this.update({ returnToPrevious });
     window.sessionStorage.setItem('returnToPrevious', JSON.stringify(returnToPrevious));
   };
 
-  public clearReturnToPrevious = () => {
+  public clearReturnToPrevious = (interactionAction: 'clicked' | 'dismissed' | 'auto_dismissed') => {
+    const existingRtp = this.state.getValue().returnToPrevious;
+    if (existingRtp) {
+      reportInteraction('grafana_return_to_previous_button_dissmissed', {
+        action: interactionAction,
+        page: existingRtp.href,
+      });
+    }
+
     this.update({ returnToPrevious: undefined });
     window.sessionStorage.removeItem('returnToPrevious');
   };

--- a/public/app/core/components/AppChrome/ReturnToPrevious/ReturnToPrevious.tsx
+++ b/public/app/core/components/AppChrome/ReturnToPrevious/ReturnToPrevious.tsx
@@ -24,7 +24,7 @@ export const ReturnToPrevious = ({ href, title }: ReturnToPreviousProps) => {
   }, [href, chrome]);
 
   const handleOnDismiss = useCallback(() => {
-    reportInteraction('grafana_return_to_previous_button_dissmissed', { action: 'dismissed', page: href });
+    reportInteraction('grafana_return_to_previous_button_dismissed', { action: 'dismissed', page: href });
     chrome.clearReturnToPrevious('dismissed');
   }, [href, chrome]);
 

--- a/public/app/core/components/AppChrome/ReturnToPrevious/ReturnToPrevious.tsx
+++ b/public/app/core/components/AppChrome/ReturnToPrevious/ReturnToPrevious.tsx
@@ -1,8 +1,8 @@
 import { css } from '@emotion/css';
-import React from 'react';
+import React, { useCallback } from 'react';
 
 import { GrafanaTheme2 } from '@grafana/data';
-import { locationService } from '@grafana/runtime';
+import { locationService, reportInteraction } from '@grafana/runtime';
 import { useStyles2 } from '@grafana/ui';
 import { useGrafana } from 'app/core/context/GrafanaContext';
 import { t } from 'app/core/internationalization';
@@ -17,13 +17,16 @@ export interface ReturnToPreviousProps {
 export const ReturnToPrevious = ({ href, title }: ReturnToPreviousProps) => {
   const styles = useStyles2(getStyles);
   const { chrome } = useGrafana();
-  const handleOnClick = () => {
+
+  const handleOnClick = useCallback(() => {
     locationService.push(href);
-    chrome.clearReturnToPrevious();
-  };
-  const handleOnDismiss = () => {
-    chrome.clearReturnToPrevious();
-  };
+    chrome.clearReturnToPrevious('clicked');
+  }, [href, chrome]);
+
+  const handleOnDismiss = useCallback(() => {
+    reportInteraction('grafana_return_to_previous_button_dissmissed', { action: 'dismissed', page: href });
+    chrome.clearReturnToPrevious('dismissed');
+  }, [href, chrome]);
 
   return (
     <div className={styles.returnToPrevious}>


### PR DESCRIPTION
Fixes https://github.com/grafana/grafana/issues/80872

Adds two events:
 - `grafana_return_to_previous_button_created` is triggered when a new return-to-previous is set.
    - `page` property with the href
    - `previousPage` property with the previous href, if set. You can use this to determine if a new rtp was dropped when there's already an existing one
 - `grafana_return_to_previous_button_dissmissed` is triggered when the button is removed
    - `action` property, valid values `'clicked' | 'dismissed' | 'auto_dismissed'` to determine _why_ it was removed
    - `page` property with the href