### PR TITLE
[PoC] Storage: Update dualwriter

### DIFF
--- a/pkg/services/grafana-apiserver/rest/dualwriter.go
+++ b/pkg/services/grafana-apiserver/rest/dualwriter.go
@@ -84,14 +84,22 @@ func (d *DualWriter) Create(ctx context.Context, obj runtime.Object, createValid
 			return nil, err
 		}
 
-		accessor, err := meta.Accessor(created)
+		accessorC, err := meta.Accessor(created)
 		if err != nil {
 			return created, err
 		}
-		accessor.SetResourceVersion("")
-		accessor.SetUID("")
 
-		rsp, err := d.Storage.Create(ctx, created, createValidation, options)
+		accessorO, err := meta.Accessor(obj)
+		if err != nil {
+			return created, err
+		}
+
+		accessorO.SetName(accessorC.GetName())
+		accessorO.SetCreationTimestamp(accessorC.GetCreationTimestamp())
+		// #TODO figure out what other properties need to be set and how to get/set them properties
+		// based on that decide where it's better to pass "obj" or "created" to the next Create call
+
+		rsp, err := d.Storage.Create(ctx, obj, createValidation, options)
 		if err != nil {
 			d.log.Error("unable to create object in duplicate storage", "error", err)
 		}


### PR DESCRIPTION
To support work on this design doc: https://github.com/grafana/grafana-backend-platform-squad/issues/42

--------
TODO

I need to verify if this PoC changes the behavior when `generateName` is set
How I tested updating k8s fields:
* Run `kubectl --kubeconfig=./grafana.kubeconfig apply -f playlist-generate.yaml` (also can use patch instead)
* Also have to set the metadata.name in the yaml file
* And not include the generateName field in the yaml file

Before the code changes in the PoC, it seems that the `name` value was always the one set in legacy storage, even if `generateName` is set. This is no longer the case. However, this seems more in line with the expected behavior.

- [ ] figure out if behavior is correct when `generateName` is set 
- [ ] figure out which other properties need to be set in the object/object info we send to US. In particular ensure that all fields in legacy storage are also included in US.
- [ ] figure out how to set them and if the current approach makes that easy
- [ ] update the doc comment for dualwriter

