### PR TITLE
I18n: Add PR to project board

### DIFF
--- a/.github/pr-commands.json
+++ b/.github/pr-commands.json
@@ -192,7 +192,7 @@
     "type": "author",
     "name": "pr/external",
     "notMemberOf": { "org": "grafana" },
-    "ignoreList": ["renovate[bot]","dependabot[bot]","grafana-delivery-bot[bot]","grafanabot","github-actions[bot]"],
+    "ignoreList": ["renovate[bot]","dependabot[bot]","grafana-delivery-bot[bot]","grafanabot"],
     "action": "updateLabel",
     "addLabel": "pr/external"
   },
@@ -454,14 +454,6 @@
     "action": "addToProject",
     "addToProject": {
       "url": "https://github.com/orgs/grafana/projects/56"
-    }
-  },
-  {
-    "type": "changedfiles",
-    "matches": ["public/locales/de-DE/grafana.json", "public/locales/es-ES/grafana.json", "public/locales/fr-FR/grafana.json", "public/locales/zh-Hans/grafana.json"],
-    "action": "addToProject",
-    "addToProject": {
-      "url": "https://github.com/orgs/grafana/projects/78"
     }
   }
 ]

--- a/.github/workflows/i18n-crowdin-download.yml
+++ b/.github/workflows/i18n-crowdin-download.yml
@@ -54,3 +54,9 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           CROWDIN_PROJECT_ID: ${{ secrets.CROWDIN_PROJECT_ID }}
           CROWDIN_PERSONAL_TOKEN: ${{ secrets.CROWDIN_PERSONAL_TOKEN }}
+
+      - name: Add PR to project board
+        uses: actions/add-to-project@RELEASE_VERSION
+        with:
+          project-url: https://github.com/orgs/grafana/projects/78
+          github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
**What is this feature?**
Clean up of failed attempts and implementation of alternative way to add Crowdin PRs to the FE Platform board.

Relates to https://github.com/grafana/grafana/pull/81571

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
