### PR TITLE
Alerting: upgrade preview enable folder alert tab and dashboard alert panel

### DIFF
--- a/public/app/features/alerting/Upgrade.tsx
+++ b/public/app/features/alerting/Upgrade.tsx
@@ -42,7 +42,7 @@ import { DynamicTable, DynamicTableColumnProps, DynamicTableItemProps } from './
 import { DynamicTableWithGuidelines } from './unified/components/DynamicTableWithGuidelines';
 import { Matchers } from './unified/components/notification-policies/Matchers';
 import { ActionIcon } from './unified/components/rules/ActionIcon';
-import { createContactPointLink, makeDashboardLink, makeFolderLink } from './unified/utils/misc';
+import { createContactPointLink, makeDashboardLink, makeFolderAlertsLink } from './unified/utils/misc';
 import { createUrl } from './unified/utils/url';
 
 export const UpgradePage = () => {
@@ -1011,7 +1011,7 @@ const useAlertColumns = (): Array<DynamicTableColumnProps<DashboardUpgrade>> => 
                 rel="noreferrer"
                 target="_blank"
                 className={styles.textLink}
-                href={makeFolderLink(dashUpgrade.folderUid)}
+                href={makeFolderAlertsLink(dashUpgrade.folderUid, dashUpgrade.folderName)}
               >
                 {dashUpgrade.folderName}
               </Link>
@@ -1075,7 +1075,7 @@ const useAlertColumns = (): Array<DynamicTableColumnProps<DashboardUpgrade>> => 
                   rel="noreferrer"
                   target="_blank"
                   className={styles.textLink}
-                  href={makeFolderLink(migratedFolderUid)}
+                  href={makeFolderAlertsLink(migratedFolderUid, dashUpgrade.newFolderName)}
                 >
                   {dashUpgrade.newFolderName}
                 </Link>

--- a/public/app/features/alerting/unified/initAlerting.tsx
+++ b/public/app/features/alerting/unified/initAlerting.tsx
@@ -10,7 +10,7 @@ const AlertRulesToolbarButton = React.lazy(
 
 export function initAlerting() {
   addCustomRightAction({
-    show: () => config.unifiedAlertingEnabled,
+    show: () => config.unifiedAlertingEnabled || (config.featureToggles.alertingPreviewUpgrade ?? false),
     component: ({ dashboard }) => (
       <React.Suspense fallback={null} key="alert-rules-button">
         {dashboard && <AlertRulesToolbarButton dashboardUid={dashboard.uid} />}

--- a/public/app/features/alerting/unified/utils/misc.ts
+++ b/public/app/features/alerting/unified/utils/misc.ts
@@ -145,6 +145,10 @@ export function makeFolderLink(folderUID: string): string {
   return createUrl(`/dashboards/f/${folderUID}`);
 }
 
+export function makeFolderAlertsLink(folderUID: string, title: string): string {
+  return createUrl(`/dashboards/f/${folderUID}/${title}/alerting`);
+}
+
 export function makeFolderSettingsLink(folder: FolderDTO): string {
   return createUrl(`/dashboards/f/${folder.uid}/${folder.title}/settings`);
 }

--- a/public/app/features/folders/state/navModel.ts
+++ b/public/app/features/folders/state/navModel.ts
@@ -45,7 +45,10 @@ export function buildNavModel(folder: FolderDTO, parents = folder.parents): NavM
     url: `${folder.url}/library-panels`,
   });
 
-  if (contextSrv.hasPermission(AccessControlAction.AlertingRuleRead) && config.unifiedAlertingEnabled) {
+  if (
+    contextSrv.hasPermission(AccessControlAction.AlertingRuleRead) &&
+    (config.unifiedAlertingEnabled || config.featureToggles.alertingPreviewUpgrade)
+  ) {
     model.children!.push({
       active: false,
       icon: 'bell',


### PR DESCRIPTION
**What is this feature?**

Enable the folder alert tab and the dashboard alert panel when migrating using the preview method.

**Why do we need this feature?**

The folder alert tab and dashboard alert panel are available when using UA and do not interfere with legacy alerting. They also offer a convenient means to view upgraded alert rules per folder and dashboard outside of the `alerting update` page.

**Who is this feature for?**

Users upgrading from legacy alerting to Grafana Alerting.

**Special notes for your reviewer:**

![Screenshot from 2024-02-06 12-11-11](https://github.com/grafana/grafana/assets/8484471/b9494459-9c89-4f03-a23e-b4846537eb8f)

![Screenshot from 2024-02-06 12-10-48](https://github.com/grafana/grafana/assets/8484471/92809ee6-e941-40d5-b295-9f496504f2f9)
