### PR TITLE
Alerting: Fix receiver inheritance when provisioning a notification policy

### DIFF
--- a/pkg/services/ngalert/provisioning/notification_policies.go
+++ b/pkg/services/ngalert/provisioning/notification_policies.go
@@ -70,6 +70,7 @@ func (nps *NotificationPolicyService) UpdatePolicyTree(ctx context.Context, orgI
 		return err
 	}
 
+	receivers[""] = struct{}{} // Allow empty receiver (inheriting from parent)
 	err = tree.ValidateReceivers(receivers)
 	if err != nil {
 		return fmt.Errorf("%w: %s", ErrValidation, err.Error())

--- a/pkg/services/ngalert/provisioning/notification_policies_test.go
+++ b/pkg/services/ngalert/provisioning/notification_policies_test.go
@@ -92,6 +92,31 @@ func TestNotificationPolicyService(t *testing.T) {
 		require.Equal(t, "slack receiver", updated.Receiver)
 	})
 
+	t.Run("no root receiver will error", func(t *testing.T) {
+		sut := createNotificationPolicyServiceSut()
+
+		newRoute := createTestRoutingTree()
+		newRoute.Receiver = ""
+		newRoute.Routes = append(newRoute.Routes, &definitions.Route{
+			Receiver: "",
+		})
+
+		err := sut.UpdatePolicyTree(context.Background(), 1, newRoute, models.ProvenanceNone)
+		require.EqualError(t, err, "invalid object specification: root route must specify a default receiver")
+	})
+
+	t.Run("allow receiver inheritance", func(t *testing.T) {
+		sut := createNotificationPolicyServiceSut()
+
+		newRoute := createTestRoutingTree()
+		newRoute.Routes = append(newRoute.Routes, &definitions.Route{
+			Receiver: "",
+		})
+
+		err := sut.UpdatePolicyTree(context.Background(), 1, newRoute, models.ProvenanceNone)
+		require.NoError(t, err)
+	})
+
 	t.Run("not existing receiver reference will error", func(t *testing.T) {
 		sut := createNotificationPolicyServiceSut()
 


### PR DESCRIPTION
Terraform Issue: https://github.com/grafana/terraform-provider-grafana/issues/1007 
Nested routes should be allowed to inherit the contact point from the root (or direct parent) route but this fails in the provisioning API (it works in the UI)
