### PR TITLE
Elasticsearch: Apply ad-hoc filters to annotation queries

### DIFF
--- a/public/app/plugins/datasource/elasticsearch/datasource.test.ts
+++ b/public/app/plugins/datasource/elasticsearch/datasource.test.ts
@@ -1588,6 +1588,9 @@ describe('ElasticDatasource using backend', () => {
 
         const annotations = await ds.annotationQuery({
           annotation: {},
+          dashboard: {
+            getVariables: () => []
+          },
           range: timeRange,
         });
 
@@ -1618,6 +1621,9 @@ describe('ElasticDatasource using backend', () => {
             query: 'abc',
             tagsField: '@test_tags',
             textField: 'text',
+          },
+          dashboard: {
+            getVariables: () => []
           },
           range: timeRange,
         });
@@ -1657,6 +1663,9 @@ describe('ElasticDatasource using backend', () => {
             tagsField: '@test_tags',
             textField: 'text',
           },
+          dashboard: {
+            getVariables: () => []
+          },
           range: {
             from: dateTime(1683291160012),
             to: dateTime(1683291460012),
@@ -1685,6 +1694,9 @@ describe('ElasticDatasource using backend', () => {
 
         await ds.annotationQuery({
           annotation: {},
+          dashboard: {
+            getVariables: () => []
+          },
           range: {
             from: dateTime(1683291160012),
             to: dateTime(1683291460012),

--- a/public/app/plugins/datasource/elasticsearch/datasource.test.ts
+++ b/public/app/plugins/datasource/elasticsearch/datasource.test.ts
@@ -1707,6 +1707,61 @@ describe('ElasticDatasource using backend', () => {
           '{"search_type":"query_then_fetch","ignore_unavailable":true,"index":"[test-]YYYY.MM.DD"}\n{"query":{"bool":{"filter":[{"bool":{"should":[{"range":{"@timestamp":{"from":1683291160012,"to":1683291460012,"format":"epoch_millis"}}}],"minimum_should_match":1}}]}},"size":10000}\n'
         );
       });
+
+      it('should process annotation request using dashboard adhoc variables', async () => {
+        const { ds } = getTestContext();
+        const postResourceRequestMock = jest.spyOn(ds, 'postResourceRequest').mockResolvedValue({
+          responses: [
+            {
+              hits: {
+                hits: [
+                  { _source: { '@test_time': 1, '@test_tags': 'foo', text: 'abc' } },
+                  { _source: { '@test_time': 3, '@test_tags': 'bar', text: 'def' } },
+                ],
+              },
+            },
+          ],
+        });
+
+        await ds.annotationQuery({
+          annotation: {
+            timeField: '@test_time',
+            timeEndField: '@time_end_field',
+            name: 'foo',
+            query: 'abc',
+            tagsField: '@test_tags',
+            textField: 'text',
+            datasource: {
+              type: 'elasticsearch',
+              uid: 'gdev-elasticsearch'
+            }
+          },
+          dashboard: {
+            getVariables: () => [{
+              type: 'adhoc',
+              datasource: {
+                type: 'elasticsearch',
+                uid: 'gdev-elasticsearch'
+              },
+              filters: [
+                {
+                  key: 'abc_key',
+                  operator: '=',
+                  value: 'abc_value'
+                }
+              ]
+            }]
+          },
+          range: {
+            from: dateTime(1683291160012),
+            to: dateTime(1683291460012),
+          },
+        });
+        expect(postResourceRequestMock).toHaveBeenCalledWith(
+          '_msearch',
+          '{"search_type":"query_then_fetch","ignore_unavailable":true,"index":"[test-]YYYY.MM.DD"}\n{"query":{"bool":{"filter":[{"bool":{"should":[{"range":{"@test_time":{"from":1683291160012,"to":1683291460012,"format":"epoch_millis"}}},{"range":{"@time_end_field":{"from":1683291160012,"to":1683291460012,"format":"epoch_millis"}}}],"minimum_should_match":1}},{"query_string":{"query":"abc AND abc_key:\\"abc_value\\""}}]}},"size":10000}\n'
+        );
+      });
     });
   });
 

--- a/public/app/plugins/datasource/elasticsearch/datasource.test.ts
+++ b/public/app/plugins/datasource/elasticsearch/datasource.test.ts
@@ -1589,7 +1589,7 @@ describe('ElasticDatasource using backend', () => {
         const annotations = await ds.annotationQuery({
           annotation: {},
           dashboard: {
-            getVariables: () => []
+            getVariables: () => [],
           },
           range: timeRange,
         });
@@ -1623,7 +1623,7 @@ describe('ElasticDatasource using backend', () => {
             textField: 'text',
           },
           dashboard: {
-            getVariables: () => []
+            getVariables: () => [],
           },
           range: timeRange,
         });
@@ -1664,7 +1664,7 @@ describe('ElasticDatasource using backend', () => {
             textField: 'text',
           },
           dashboard: {
-            getVariables: () => []
+            getVariables: () => [],
           },
           range: {
             from: dateTime(1683291160012),
@@ -1695,7 +1695,7 @@ describe('ElasticDatasource using backend', () => {
         await ds.annotationQuery({
           annotation: {},
           dashboard: {
-            getVariables: () => []
+            getVariables: () => [],
           },
           range: {
             from: dateTime(1683291160012),
@@ -1733,24 +1733,26 @@ describe('ElasticDatasource using backend', () => {
             textField: 'text',
             datasource: {
               type: 'elasticsearch',
-              uid: 'gdev-elasticsearch'
-            }
+              uid: 'gdev-elasticsearch',
+            },
           },
           dashboard: {
-            getVariables: () => [{
-              type: 'adhoc',
-              datasource: {
-                type: 'elasticsearch',
-                uid: 'gdev-elasticsearch'
+            getVariables: () => [
+              {
+                type: 'adhoc',
+                datasource: {
+                  type: 'elasticsearch',
+                  uid: 'gdev-elasticsearch',
+                },
+                filters: [
+                  {
+                    key: 'abc_key',
+                    operator: '=',
+                    value: 'abc_value',
+                  },
+                ],
               },
-              filters: [
-                {
-                  key: 'abc_key',
-                  operator: '=',
-                  value: 'abc_value'
-                }
-              ]
-            }]
+            ],
           },
           range: {
             from: dateTime(1683291160012),

--- a/public/app/plugins/datasource/elasticsearch/datasource.ts
+++ b/public/app/plugins/datasource/elasticsearch/datasource.ts
@@ -262,16 +262,20 @@ export class ElasticDatasource
     );
   }
 
-  private prepareAnnotationRequest(options: { annotation: ElasticsearchAnnotationQuery; dashboard: DashboardModel, range: TimeRange }) {
+  private prepareAnnotationRequest(options: {
+    annotation: ElasticsearchAnnotationQuery;
+    dashboard: DashboardModel;
+    range: TimeRange;
+  }) {
     const annotation = options.annotation;
     const timeField = annotation.timeField || '@timestamp';
     const timeEndField = annotation.timeEndField || null;
     const dashboard = options.dashboard;
 
     // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
-    const adhocVariables = dashboard.getVariables().filter(v => v.type === "adhoc") as AdHocVariableModel[];
-    const annotationRelatedVariables = adhocVariables.filter(v => v.datasource?.uid === annotation.datasource.uid);
-    const filters = annotationRelatedVariables.map(v => v.filters).flat();
+    const adhocVariables = dashboard.getVariables().filter((v) => v.type === 'adhoc') as AdHocVariableModel[];
+    const annotationRelatedVariables = adhocVariables.filter((v) => v.datasource?.uid === annotation.datasource.uid);
+    const filters = annotationRelatedVariables.map((v) => v.filters).flat();
 
     // the `target.query` is the "new" location for the query.
     // normally we would write this code as
@@ -304,7 +308,6 @@ export class ElasticDatasource
     }
 
     const queryInterpolated = this.interpolateLuceneQuery(queryString);
-
     const finalQuery = this.addAdHocFilters(queryInterpolated, filters);
 
     const query: {

--- a/public/app/plugins/datasource/elasticsearch/datasource.ts
+++ b/public/app/plugins/datasource/elasticsearch/datasource.ts
@@ -305,10 +305,7 @@ export class ElasticDatasource
 
     const queryInterpolated = this.interpolateLuceneQuery(queryString);
 
-    let finalQuery = queryInterpolated;
-    filters.forEach(filter => {
-      finalQuery = addAddHocFilter(finalQuery, filter);
-    })
+    const finalQuery = this.addAdHocFilters(queryInterpolated, filters);
 
     const query: {
       bool: { filter: Array<Record<string, Record<string, string | number | Array<{ range: RangeMap }>>>> };

--- a/public/app/plugins/datasource/elasticsearch/datasource.ts
+++ b/public/app/plugins/datasource/elasticsearch/datasource.ts
@@ -268,6 +268,7 @@ export class ElasticDatasource
     const timeEndField = annotation.timeEndField || null;
     const dashboard = options.dashboard;
 
+    // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
     const adhocVariables = dashboard.getVariables().filter(v => v.type === "adhoc") as AdHocVariableModel[];
     const annotationRelatedVariables = adhocVariables.filter(v => v.datasource?.uid === annotation.datasource.uid);
     const filters = annotationRelatedVariables.map(v => v.filters).flat();

--- a/public/app/plugins/datasource/elasticsearch/datasource.ts
+++ b/public/app/plugins/datasource/elasticsearch/datasource.ts
@@ -306,7 +306,7 @@ export class ElasticDatasource
 
     let finalQuery = queryInterpolated;
     filters.forEach(filter => {
-      finalQuery = addAddHocFilter(finalQuery, filter)
+      finalQuery = addAddHocFilter(finalQuery, filter);
     })
 
     const query: {

--- a/public/app/plugins/datasource/elasticsearch/types.ts
+++ b/public/app/plugins/datasource/elasticsearch/types.ts
@@ -1,4 +1,5 @@
 import { DataSourceJsonData } from '@grafana/data';
+import {DataSourceRef} from '@grafana/schema'
 
 import {
   BucketAggregationType,
@@ -131,6 +132,7 @@ export interface ElasticsearchAnnotationQuery {
   titleField?: string;
   timeEndField?: string;
   query?: string;
+  datasource: DataSourceRef;
   tagsField?: string;
   textField?: string;
   // @deprecated index is deprecated and will be removed in the future

--- a/public/app/plugins/datasource/elasticsearch/types.ts
+++ b/public/app/plugins/datasource/elasticsearch/types.ts
@@ -1,5 +1,5 @@
 import { DataSourceJsonData } from '@grafana/data';
-import {DataSourceRef} from '@grafana/schema'
+import { DataSourceRef } from '@grafana/schema';
 
 import {
   BucketAggregationType,


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

Currently the annotation query is not filtered by Ad-Hoc filters in Elasticsearch. This PR adds the Ad-Hoc filters to the annotation query.

**Why do we need this feature?**

Annotation queries are not affected by ad-hoc filters: Grafana still shows annotations that do not match the filter.

**Who is this feature for?**

This feature is for users that are using Annotations from an Elasticsearch datasource and want to filter them.

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #9599 

**Special notes for your reviewer:**

Steps to test it:
- Create an annotation using the `gdev-elasticsearch` datasource
- Create an ad-hoc variable using the `gdev-elasticsearch` datasource
- In the dashboard, set a filter in the ad-hoc variable that you created 
  - The annotations should be filtered too

Please check that:
- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
