### PR TITLE
Alerting: GA alertingPreviewUpgrade and enable by default

### DIFF
--- a/docs/sources/alerting/set-up/migrating-alerts/_index.md
+++ b/docs/sources/alerting/set-up/migrating-alerts/_index.md
@@ -37,8 +37,8 @@ When upgrading with either method, your legacy dashboard alerts and notification
 | **Stakeholder Involvement** | ☑️ Collaboration and review of adjusted alerts                                      | ❌ Review only available after upgrade               |
 | **Provisioning Support**    | ☑️ Configure new as-code before upgrading, simultaneous provisioning                | ❌ No built-in provisioning support                  |
 | **Simplicity**              | ❌ May take longer to complete                                                      | ☑️ Fast, one-step process                            |
-| **Technical Requirements**  | Feature flag enabled, Grafana v10.3.0+                                              | Grafana v9.0.0+                                      |
 | **Suited for:**             | ☑️ Complex setups, risk-averse environments, collaborative teams, heavy as-code use | ☑️ Simple setups, testing environments, large fleets |
+| **Version**                 | Grafana v10.3.0+                                                                    | Grafana v9.0.0+                                      |
 
 ## Upgrade with Preview (Recommended)
 
@@ -46,7 +46,7 @@ When upgrading with either method, your legacy dashboard alerts and notification
 
 - Grafana `v10.3.0 or later`.
 - Grafana administrator access.
-- Enable `alertingPreviewUpgrade` [feature toggle]({{< relref "../../../setup-grafana/configure-grafana/feature-toggles" >}}).
+- Enable `alertingPreviewUpgrade` [feature toggle]({{< relref "../../../setup-grafana/configure-grafana/feature-toggles" >}}) (enabled by default in v10.4.0 or later).
 
 ### Suited for
 

--- a/docs/sources/setup-grafana/configure-grafana/feature-toggles/index.md
+++ b/docs/sources/setup-grafana/configure-grafana/feature-toggles/index.md
@@ -53,6 +53,7 @@ Some features are enabled by default. You can disable these feature by setting t
 | `logRowsPopoverMenu`                 | Enable filtering menu displayed when text of a log line is selected                                                                                                                                                          | Yes                |
 | `displayAnonymousStats`              | Enables anonymous stats to be shown in the UI for Grafana                                                                                                                                                                    | Yes                |
 | `lokiQueryHints`                     | Enables query hints for Loki                                                                                                                                                                                                 | Yes                |
+| `alertingPreviewUpgrade`             | Show Unified Alerting preview and upgrade page in legacy alerting                                                                                                                                                            | Yes                |
 | `alertingQueryOptimization`          | Optimizes eligible queries in order to reduce load on datasources                                                                                                                                                            |                    |
 | `jitterAlertRules`                   | Distributes alert rule evaluations more evenly over time, by rule group                                                                                                                                                      |                    |
 
@@ -86,7 +87,6 @@ Some features are enabled by default. You can disable these feature by setting t
 | `pdfTables`                            | Enables generating table data as PDF in reporting                                                                                                                                            |
 | `canvasPanelPanZoom`                   | Allow pan and zoom in canvas panel                                                                                                                                                           |
 | `regressionTransformation`             | Enables regression analysis transformation                                                                                                                                                   |
-| `alertingPreviewUpgrade`               | Show Unified Alerting preview and upgrade page in legacy alerting                                                                                                                            |
 | `groupToNestedTableTransformation`     | Enables the group to nested table transformation                                                                                                                                             |
 
 ## Experimental feature toggles

--- a/pkg/services/featuremgmt/registry.go
+++ b/pkg/services/featuremgmt/registry.go
@@ -1217,10 +1217,11 @@ var (
 			Name:            "alertingPreviewUpgrade",
 			Description:     "Show Unified Alerting preview and upgrade page in legacy alerting",
 			FrontendOnly:    false,
-			Stage:           FeatureStagePublicPreview,
+			Stage:           FeatureStageGeneralAvailability,
 			Owner:           grafanaAlertingSquad,
 			RequiresRestart: true,
 			Created:         time.Date(2024, time.January, 3, 12, 0, 0, 0, time.UTC),
+			Expression:      "true", // enabled by default
 		},
 		{
 			Name:            "enablePluginsTracingByDefault",

--- a/pkg/services/featuremgmt/toggles_gen.csv
+++ b/pkg/services/featuremgmt/toggles_gen.csv
@@ -143,7 +143,7 @@ regressionTransformation,preview,@grafana/grafana-bi-squad,2023-11-24,false,fals
 displayAnonymousStats,GA,@grafana/identity-access-team,2023-11-29,false,false,true
 lokiQueryHints,GA,@grafana/observability-logs,2023-12-18,false,false,true
 kubernetesFeatureToggles,experimental,@grafana/grafana-operator-experience-squad,2023-12-22,false,false,true
-alertingPreviewUpgrade,preview,@grafana/alerting-squad,2024-01-03,false,true,false
+alertingPreviewUpgrade,GA,@grafana/alerting-squad,2024-01-03,false,true,false
 enablePluginsTracingByDefault,experimental,@grafana/plugins-platform-backend,2024-01-09,false,true,false
 cloudRBACRoles,experimental,@grafana/identity-access-team,2024-01-10,false,true,false
 alertingQueryOptimization,GA,@grafana/alerting-squad,2024-01-10,false,false,false


### PR DESCRIPTION
**What is this feature?**

Brings the feature flag `alertingPreviewUpgrade` to GA and enables it by default.

**Why do we need this feature?**

In 10.4.0, the `Alerting (legacy) -> Alerting upgrade` page will show automatically for Admins, prompting them to start (thinking about) upgrading. This is the last minor version before v11 where legacy alerting will go away and upgrading on your own terms will be possible.

**Who is this feature for?**

Users on legacy alerting.

Please check that:
- [x] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle.
- [x] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
