### PR TITLE
Alerting: Use mute_time_intervals as field name in dto ,for simplified routing

### DIFF
--- a/public/app/features/alerting/unified/utils/rule-form.test.ts
+++ b/public/app/features/alerting/unified/utils/rule-form.test.ts
@@ -130,7 +130,7 @@ describe('getContactPointsFromDTO', () => {
       ],
       notification_settings: {
         receiver: 'receiver',
-        mute_timings: ['mute_timing'],
+        mute_time_intervals: ['mute_timing'],
         group_by: ['group_by'],
         group_wait: 'group_wait',
         group_interval: 'group_interval',
@@ -199,7 +199,7 @@ describe('getNotificationSettingsForDTO', () => {
     const result = getNotificationSettingsForDTO(manualRouting, contactPoints);
     expect(result).toEqual({
       receiver: 'receiver',
-      mute_timings: ['mute_timing'],
+      mute_time_intervals: ['mute_timing'],
       group_by: ['group_by'],
       group_wait: 'group_wait',
       group_interval: 'group_interval',

--- a/public/app/features/alerting/unified/utils/rule-form.ts
+++ b/public/app/features/alerting/unified/utils/rule-form.ts
@@ -147,7 +147,7 @@ export function getNotificationSettingsForDTO(
   if (contactPoints?.grafana?.selectedContactPoint && manualRouting) {
     return {
       receiver: contactPoints?.grafana?.selectedContactPoint,
-      mute_timings: contactPoints?.grafana?.muteTimeIntervals,
+      mute_time_intervals: contactPoints?.grafana?.muteTimeIntervals,
       group_by: contactPoints?.grafana?.overrideGrouping ? contactPoints?.grafana?.groupBy : undefined,
       group_wait:
         contactPoints?.grafana?.overrideTimings && contactPoints?.grafana?.groupWaitValue
@@ -197,7 +197,7 @@ export function getContactPointsFromDTO(ga: GrafanaRuleDefinition): AlertManager
   const contactPoint: ContactPoint | undefined = ga.notification_settings
     ? {
         selectedContactPoint: ga.notification_settings.receiver,
-        muteTimeIntervals: ga.notification_settings.mute_timings ?? [],
+        muteTimeIntervals: ga.notification_settings.mute_time_intervals ?? [],
         overrideGrouping:
           Array.isArray(ga.notification_settings.group_by) && ga.notification_settings.group_by.length > 0,
         overrideTimings: [
@@ -247,24 +247,6 @@ export function rulerRuleToFormValues(ruleWithLocation: RuleWithLocation): RuleF
 
         contactPoints: routingSettings,
         manualRouting: Boolean(routingSettings),
-        // next line is for testing
-        // manualRouting: true,
-        // contactPoints: {
-        //   grafana: {
-        //       selectedContactPoint: "contact_point_5",
-        //       muteTimeIntervals: [
-        //           "mute timing 1"
-        //       ],
-        //       overrideGrouping: true,
-        //       overrideTimings: true,
-        //       "groupBy": [
-        //           "..."
-        //       ],
-        //       groupWaitValue: "35s",
-        //       groupIntervalValue: "6m",
-        //       repeatIntervalValue: "5h"
-        //   }
-        // }
       };
     } else {
       throw new Error('Unexpected type of rule for grafana rules source');

--- a/public/app/types/unified-alerting-dto.ts
+++ b/public/app/types/unified-alerting-dto.ts
@@ -203,7 +203,7 @@ export interface GrafanaNotificationSettings {
   group_wait?: string;
   group_interval?: string;
   repeat_interval?: string;
-  mute_timings?: string[];
+  mute_time_intervals?: string[];
 }
 export interface PostableGrafanaRuleDefinition {
   uid?: string;


### PR DESCRIPTION
**What is this feature?**

This PR updates the field name for mute timings following the model in this [PR](https://github.com/grafana/grafana/pull/81011)

**Who is this feature for?**

All users.


Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
