### PR TITLE
Alerting: defaults for simplified routing

### DIFF
--- a/public/app/features/alerting/unified/components/rule-editor/alert-rule-form/AlertRuleForm.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/alert-rule-form/AlertRuleForm.tsx
@@ -1,11 +1,11 @@
 import { css } from '@emotion/css';
 import React, { useEffect, useMemo, useState } from 'react';
-import { FormProvider, SubmitErrorHandler, useForm, UseFormWatch } from 'react-hook-form';
+import { FormProvider, SubmitErrorHandler, UseFormWatch, useForm } from 'react-hook-form';
 import { Link, useParams } from 'react-router-dom';
 
 import { GrafanaTheme2 } from '@grafana/data';
 import { config } from '@grafana/runtime';
-import { Button, ConfirmModal, CustomScrollbar, HorizontalGroup, Spinner, useStyles2, Stack } from '@grafana/ui';
+import { Button, ConfirmModal, CustomScrollbar, HorizontalGroup, Spinner, Stack, useStyles2 } from '@grafana/ui';
 import { AppChromeUpdate } from 'app/core/components/AppChrome/AppChromeUpdate';
 import { useAppNotification } from 'app/core/copy/appNotification';
 import { contextSrv } from 'app/core/core';
@@ -14,17 +14,18 @@ import { useQueryParams } from 'app/core/hooks/useQueryParams';
 import { useDispatch } from 'app/types';
 import { RuleWithLocation } from 'app/types/unified-alerting';
 
-import { logInfo, LogMessages, trackNewAlerRuleFormError } from '../../../Analytics';
+import { LogMessages, logInfo, trackNewAlerRuleFormError } from '../../../Analytics';
 import { useUnifiedAlertingSelector } from '../../../hooks/useUnifiedAlertingSelector';
 import { deleteRuleAction, saveRuleFormAction } from '../../../state/actions';
 import { RuleFormType, RuleFormValues } from '../../../types/rule-form';
 import { initialAsyncRequestState } from '../../../utils/redux';
 import {
+  MANUAL_ROUTING_KEY,
+  MINUTE,
   formValuesFromExistingRule,
   getDefaultFormValues,
   getDefaultQueries,
   ignoreHiddenQueries,
-  MINUTE,
   normalizeDefaultAnnotations,
 } from '../../../utils/rule-form';
 import * as ruleId from '../../../utils/rule-id';
@@ -107,6 +108,12 @@ export const AlertRuleForm = ({ existing, prefill }: Props) => {
     if (conditionErrorMsg !== '') {
       notifyApp.error(conditionErrorMsg);
       return;
+    }
+    // if this rule is using manual routing, we save this option in local storage
+    if (values.manualRouting) {
+      localStorage.setItem(MANUAL_ROUTING_KEY, 'true');
+    } else {
+      localStorage.removeItem(MANUAL_ROUTING_KEY);
     }
 
     dispatch(

--- a/public/app/features/alerting/unified/components/rule-editor/alert-rule-form/AlertRuleForm.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/alert-rule-form/AlertRuleForm.tsx
@@ -109,11 +109,13 @@ export const AlertRuleForm = ({ existing, prefill }: Props) => {
       notifyApp.error(conditionErrorMsg);
       return;
     }
-    // if this rule is using manual routing, we save this option in local storage
-    if (values.manualRouting) {
-      localStorage.setItem(MANUAL_ROUTING_KEY, 'true');
-    } else {
-      localStorage.setItem(MANUAL_ROUTING_KEY, 'false');
+    // when creating a new rule, we save the manual routing setting in local storage
+    if (!existing) {
+      if (values.manualRouting) {
+        localStorage.setItem(MANUAL_ROUTING_KEY, 'true');
+      } else {
+        localStorage.setItem(MANUAL_ROUTING_KEY, 'false');
+      }
     }
 
     dispatch(

--- a/public/app/features/alerting/unified/components/rule-editor/alert-rule-form/AlertRuleForm.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/alert-rule-form/AlertRuleForm.tsx
@@ -113,7 +113,7 @@ export const AlertRuleForm = ({ existing, prefill }: Props) => {
     if (values.manualRouting) {
       localStorage.setItem(MANUAL_ROUTING_KEY, 'true');
     } else {
-      localStorage.removeItem(MANUAL_ROUTING_KEY);
+      localStorage.setItem(MANUAL_ROUTING_KEY, 'false');
     }
 
     dispatch(

--- a/public/app/features/alerting/unified/components/rule-editor/alert-rule-form/simplifiedRouting/AlertManagerRouting.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/alert-rule-form/simplifiedRouting/AlertManagerRouting.tsx
@@ -1,8 +1,10 @@
 import { css } from '@emotion/css';
 import React, { useState } from 'react';
+import { useFormContext } from 'react-hook-form';
 
 import { GrafanaTheme2 } from '@grafana/data';
 import { Alert, CollapsableSection, LoadingPlaceholder, Stack, useStyles2 } from '@grafana/ui';
+import { RuleFormValues } from 'app/features/alerting/unified/types/rule-form';
 import { AlertManagerDataSource } from 'app/features/alerting/unified/utils/datasource';
 
 import { ContactPointReceiverSummary } from '../../../contact-points/ContactPoints';
@@ -30,6 +32,12 @@ export function AlertManagerManualRouting({ alertManager }: AlertManagerManualRo
   const onSelectContactPoint = (contactPoint?: ContactPointWithMetadata) => {
     setSelectedContactPointWithMetadata(contactPoint);
   };
+
+  const { watch } = useFormContext<RuleFormValues>();
+  const hasRouteSettings =
+    watch(`contactPoints.${alertManagerName}.overrideGrouping`) ||
+    watch(`contactPoints.${alertManagerName}.overrideTimings`) ||
+    watch(`contactPoints.${alertManagerName}.muteTimeIntervals`)?.length > 0;
 
   const options = contactPoints.map((receiver) => {
     const integrations = receiver?.grafana_managed_receiver_configs;
@@ -69,7 +77,7 @@ export function AlertManagerManualRouting({ alertManager }: AlertManagerManualRo
       <div className={styles.routingSection}>
         <CollapsableSection
           label="Muting, grouping and timings (optional)"
-          isOpen={false}
+          isOpen={hasRouteSettings}
           className={styles.collapsableSection}
         >
           <Stack direction="column" gap={1}>

--- a/public/app/features/alerting/unified/utils/rule-form.test.ts
+++ b/public/app/features/alerting/unified/utils/rule-form.test.ts
@@ -1,3 +1,4 @@
+import { config } from '@grafana/runtime';
 import { PromQuery } from 'app/plugins/datasource/prometheus/types';
 import { GrafanaAlertStateDecision, GrafanaRuleDefinition, RulerAlertingRuleDTO } from 'app/types/unified-alerting-dto';
 
@@ -5,11 +6,13 @@ import { AlertManagerManualRouting, RuleFormType, RuleFormValues } from '../type
 
 import { GRAFANA_RULES_SOURCE_NAME } from './datasource';
 import {
+  MANUAL_ROUTING_KEY,
   alertingRulerRuleToRuleForm,
   formValuesToRulerGrafanaRuleDTO,
   formValuesToRulerRuleDTO,
   getContactPointsFromDTO,
   getDefaultFormValues,
+  getDefautManualRouting,
   getNotificationSettingsForDTO,
 } from './rule-form';
 
@@ -205,5 +208,35 @@ describe('getNotificationSettingsForDTO', () => {
       group_interval: 'group_interval',
       repeat_interval: 'repeat_interval',
     });
+  });
+});
+
+describe('getDefautManualRouting', () => {
+  afterEach(() => {
+    window.localStorage.clear();
+  });
+
+  it('returns false if the feature toggle is not enabled', () => {
+    config.featureToggles.alertingSimplifiedRouting = false;
+    expect(getDefautManualRouting()).toBe(false);
+  });
+
+  it('returns true if the feature toggle is enabled and localStorage is not set', () => {
+    config.featureToggles.alertingSimplifiedRouting = true;
+    expect(getDefautManualRouting()).toBe(true);
+  });
+
+  it('returns false if the feature toggle is enabled and localStorage is set to "false"', () => {
+    config.featureToggles.alertingSimplifiedRouting = true;
+    localStorage.setItem(MANUAL_ROUTING_KEY, 'false');
+    expect(getDefautManualRouting()).toBe(false);
+  });
+
+  it('returns true if the feature toggle is enabled and localStorage is set to any value other than "false"', () => {
+    config.featureToggles.alertingSimplifiedRouting = true;
+    localStorage.setItem(MANUAL_ROUTING_KEY, 'true');
+    expect(getDefautManualRouting()).toBe(true);
+    localStorage.removeItem(MANUAL_ROUTING_KEY);
+    expect(getDefautManualRouting()).toBe(true);
   });
 });

--- a/public/app/features/alerting/unified/utils/rule-form.ts
+++ b/public/app/features/alerting/unified/utils/rule-form.ts
@@ -11,7 +11,7 @@ import {
   ScopedVars,
   TimeRange,
 } from '@grafana/data';
-import { getDataSourceSrv } from '@grafana/runtime';
+import { config, getDataSourceSrv } from '@grafana/runtime';
 import { ExpressionDatasourceRef } from '@grafana/runtime/src/utils/DataSourceWithBackend';
 import { DataSourceJsonData } from '@grafana/schema';
 import { getNextRefIdChar } from 'app/core/utils/query';
@@ -48,6 +48,8 @@ export type PromOrLokiQuery = PromQuery | LokiQuery;
 
 export const MINUTE = '1m';
 
+export const MANUAL_ROUTING_KEY = 'grafana.alerting.manualRouting';
+
 export const getDefaultFormValues = (): RuleFormValues => {
   const { canCreateGrafanaRules, canCreateCloudRules } = getRulesAccess();
 
@@ -69,7 +71,7 @@ export const getDefaultFormValues = (): RuleFormValues => {
     execErrState: GrafanaAlertStateDecision.Error,
     evaluateFor: '5m',
     evaluateEvery: MINUTE,
-    manualRouting: false, // let's decide this later
+    manualRouting: getDefautManualRouting(), // we default to true if the feature toggle is enabled and the user hasn't set local storage to false
     contactPoints: {},
     overrideGrouping: false,
     overrideTimings: false,
@@ -81,6 +83,18 @@ export const getDefaultFormValues = (): RuleFormValues => {
     forTime: 1,
     forTimeUnit: 'm',
   });
+};
+
+export const getDefautManualRouting = () => {
+  // first check if feature toggle for simplified routing is enabled
+  const simplifiedRoutingToggleEnabled = config.featureToggles.alertingSimplifiedRouting ?? false;
+  if (!simplifiedRoutingToggleEnabled) {
+    return false;
+  }
+  //then, check in local storage if the user has enabled simplified routing
+  // if it's not set, we'll default to true
+  const manualRouting = localStorage.getItem(MANUAL_ROUTING_KEY);
+  return manualRouting !== 'false';
 };
 
 export function formValuesToRulerRuleDTO(values: RuleFormValues): RulerRuleDTO {


### PR DESCRIPTION
**What is this feature?**

This PR adds default values for two different items in simplified routing.

- **manual routing**: defaults to true, if FF is enabled and localStorage item `grafana.alerting.manualRouting` is different than `'false'`. => only used when creating an alert rule
- **routing settings expandable** section is expanded by default if the alert rule has some fields set in this field. 
=> only used when loading an existing alert rule.

**Why do we need this feature?**

We want to take in account past user preferences in order to give the best user experience.

**Who is this feature for?**

All users.


Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
