### PR TITLE
Loki query builder: force click in e2e test

### DIFF
--- a/e2e/various-suite/loki-query-builder.spec.ts
+++ b/e2e/various-suite/loki-query-builder.spec.ts
@@ -43,6 +43,8 @@ describe('Loki query builder', () => {
       req.reply({ status: 'success', data: ['instance1', 'instance2'] });
     }).as('valuesRequest');
 
+    });
+
     // Go to Explore and choose Loki data source
     e2e.pages.Explore.visit();
     e2e.components.DataSourcePicker.container().should('be.visible').click();
@@ -68,22 +70,21 @@ describe('Loki query builder', () => {
     // Add labels to remove error
     e2e.components.QueryBuilder.labelSelect().should('be.visible').click();
     // wait until labels are loaded and set on the component before starting to type
+    e2e.components.QueryBuilder.labelSelect().children('div').children('input').type('i');
     cy.wait('@labelsRequest');
-    e2e.components.QueryBuilder.labelSelect().children('div').children('input').type('instance{enter}');
-    e2e.components.QueryBuilder.valueSelect().should('be.visible').click();
-    cy.wait('@valuesRequest');
-    e2e.components.QueryBuilder.valueSelect()
-      .children('div')
-      .children('input')
-      .type('instance1{enter}')
-      .type('instance2{enter}');
-    cy.contains(MISSING_LABEL_FILTER_ERROR_MESSAGE).should('not.exist');
+    e2e.components.QueryBuilder.labelSelect().children('div').children('input').type('nstance{enter}');
     e2e.components.QueryBuilder.matchOperatorSelect()
       .should('be.visible')
       .click({ force: true })
       .children('div')
       .children('input')
       .type('=~{enter}', { force: true });
+    e2e.components.QueryBuilder.valueSelect().should('be.visible').click();
+    e2e.components.QueryBuilder.valueSelect().children('div').children('input').type('instance1{enter}');
+    cy.wait('@valuesRequest');
+    e2e.components.QueryBuilder.valueSelect().children('div').children('input').type('instance2{enter}');
+
+    cy.contains(MISSING_LABEL_FILTER_ERROR_MESSAGE).should('not.exist');
     cy.contains(finalQuery).should('be.visible');
 
     // Change to code editor

--- a/e2e/various-suite/loki-query-builder.spec.ts
+++ b/e2e/various-suite/loki-query-builder.spec.ts
@@ -72,7 +72,7 @@ describe('Loki query builder', () => {
     e2e.components.QueryBuilder.labelSelect().children('div').children('input').type('instance{enter}');
     e2e.components.QueryBuilder.matchOperatorSelect()
       .should('be.visible')
-      .click()
+      .click({ force: true })
       .children('div')
       .children('input')
       .type('=~{enter}', { force: true });

--- a/e2e/various-suite/loki-query-builder.spec.ts
+++ b/e2e/various-suite/loki-query-builder.spec.ts
@@ -70,12 +70,6 @@ describe('Loki query builder', () => {
     // wait until labels are loaded and set on the component before starting to type
     cy.wait('@labelsRequest');
     e2e.components.QueryBuilder.labelSelect().children('div').children('input').type('instance{enter}');
-    e2e.components.QueryBuilder.matchOperatorSelect()
-      .should('be.visible')
-      .click({ force: true })
-      .children('div')
-      .children('input')
-      .type('=~{enter}', { force: true });
     e2e.components.QueryBuilder.valueSelect().should('be.visible').click();
     cy.wait('@valuesRequest');
     e2e.components.QueryBuilder.valueSelect()
@@ -84,6 +78,12 @@ describe('Loki query builder', () => {
       .type('instance1{enter}')
       .type('instance2{enter}');
     cy.contains(MISSING_LABEL_FILTER_ERROR_MESSAGE).should('not.exist');
+    e2e.components.QueryBuilder.matchOperatorSelect()
+      .should('be.visible')
+      .click({ force: true })
+      .children('div')
+      .children('input')
+      .type('=~{enter}', { force: true });
     cy.contains(finalQuery).should('be.visible');
 
     // Change to code editor

--- a/e2e/various-suite/loki-query-builder.spec.ts
+++ b/e2e/various-suite/loki-query-builder.spec.ts
@@ -43,6 +43,8 @@ describe('Loki query builder', () => {
       req.reply({ status: 'success', data: ['instance1', 'instance2'] });
     }).as('valuesRequest');
 
+    cy.intercept(/index\/stats/, (req) => {
+      req.reply({ streams: 2, chunks: 2660, bytes: 2721792, entries: 14408 });
     });
 
     // Go to Explore and choose Loki data source


### PR DESCRIPTION
Related with https://drone.grafana.net/grafana/grafana/159485/5/16 where:

```
<div data-testid="data-testid Select match operator" class="css-1q0c0d5-grafana-select-value-container">...</div>
is being covered by another element:
<div class="css-1kfdb0e"></div>
```

Changes:
- Force the click because of a random overlap with the sibling select with :focused state
- Reordered the sequence of waits so the selects wait for labels and values
- Added a missing mock for /index/stats which was failing with 500 and could have unwanted side effects