### PR TITLE
I18n: Add crowdin PRs to project board

### DIFF
--- a/.github/workflows/i18n-crowdin-download.yml
+++ b/.github/workflows/i18n-crowdin-download.yml
@@ -19,25 +19,26 @@ jobs:
           ref: ${{ github.head_ref }}
 
       - name: Download sources
+        id: crowdin-download
         uses: crowdin/github-action@v1
         with:
           upload_sources: false
           upload_translations: false
           download_sources: false
           download_translations: true
-          export_only_approved: true
-          localization_branch_name: i18n_crowdin_translations
+          localization_branch_name: l10n_crowdin_translations
           create_pull_request: true
           pull_request_title: 'I18n: Download translations from Crowdin'
           pull_request_body:  |
             :robot: Automatic download of translations from Crowdin.
 
             Steps for merging:
-              1. A quick sanity check of the changes and approve. Things to look out for:
+              1. Wait for the **New Crowdin translations by GitHub Action** commit that may be required for CI to pass.
+              2. A quick sanity check of the changes and approve. Things to look out for:
                 - No changes in the English file. The source of truth is in the main branch, NOT in Crowdin.
                 - Translations maybe be removed if the English phrase was removed, but there should not be many of these
                 - Anything else that looks 'funky'. Ask if you're not sure.
-              2. Approve & (Auto-)merge. :tada:
+              3. Approve & (Auto-)merge. :tada:
 
             If there's a conflict, close the pull request and **delete the branch**. A GH action will recreate the pull request.
             Remember, the longer this pull request is open, the more likely it is that it'll get conflicts.
@@ -54,3 +55,38 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           CROWDIN_PROJECT_ID: ${{ secrets.CROWDIN_PROJECT_ID }}
           CROWDIN_PERSONAL_TOKEN: ${{ secrets.CROWDIN_PERSONAL_TOKEN }}
+
+      - name: Generate token
+        if: steps.crowdin-download.outputs.pull_request_url
+        id: generate_token
+        uses: tibdex/github-app-token@b62528385c34dbc9f38e5f4225ac829252d1ea92
+        with:
+          app_id: ${{ secrets.GRAFANA_PR_AUTOMATION_APP_ID }}
+          private_key: ${{ secrets.GRAFANA_PR_AUTOMATION_APP_PEM }}
+
+      - name: Get pull request ID
+        if: steps.crowdin-download.outputs.pull_request_url
+        shell: bash
+        run: |
+          echo "PR_NUMBER=$(echo '$PULL_REQUEST_URL' | awk -F / '{print $7}')" >> "$GITHUB_ENV"
+        env:
+          PULL_REQUEST_URL: ${{ steps.crowdin-download.outputs.pull_request_url }}
+
+      - name: Add to project board
+        uses: octokit/graphql-action@v2.x
+        if: steps.crowdin-download.outputs.pull_request_url
+        with:
+          query: |
+            mutation addPullRequestToProject($projectid: ID!, $prid: ID!){
+              addProjectV2ItemById(input: {projectId: $projectid, contentId: $prid}) {
+                item {
+                  id
+                }
+              }
+            }
+          variables: |
+            projectid: 78
+            prid: ${{ env.PR_NUMBER }}
+        env:
+          GITHUB_TOKEN: ${{ steps.generate_token.outputs.token }}
+


### PR DESCRIPTION
Updates the i18n-crowdin-download action to:
 - get an appropriately scoped github token from the grafana-pr-automations app
 - use the octokit/graphql-action action to manually call github api to add the crowdin PR to the frontend platform project board