### PR TITLE
Fix incorrect quotes in crowdin-download github action

### DIFF
--- a/.github/workflows/i18n-crowdin-download.yml
+++ b/.github/workflows/i18n-crowdin-download.yml
@@ -26,19 +26,19 @@ jobs:
           upload_translations: false
           download_sources: false
           download_translations: true
-          localization_branch_name: l10n_crowdin_translations
+          export_only_approved: true
+          localization_branch_name: i18n_crowdin_translations
           create_pull_request: true
           pull_request_title: 'I18n: Download translations from Crowdin'
           pull_request_body:  |
             :robot: Automatic download of translations from Crowdin.
 
             Steps for merging:
-              1. Wait for the **New Crowdin translations by GitHub Action** commit that may be required for CI to pass.
-              2. A quick sanity check of the changes and approve. Things to look out for:
+              1. A quick sanity check of the changes and approve. Things to look out for:
                 - No changes in the English file. The source of truth is in the main branch, NOT in Crowdin.
                 - Translations maybe be removed if the English phrase was removed, but there should not be many of these
                 - Anything else that looks 'funky'. Ask if you're not sure.
-              3. Approve & (Auto-)merge. :tada:
+              2. Approve & (Auto-)merge. :tada:
 
             If there's a conflict, close the pull request and **delete the branch**. A GH action will recreate the pull request.
             Remember, the longer this pull request is open, the more likely it is that it'll get conflicts.
@@ -49,6 +49,7 @@ jobs:
           config: 'crowdin.yml'
           source: 'public/locales/en-US/grafana.json'
           translation: 'public/locales/%locale%/%original_file_name%'
+          # Magic details of the github-actions bot user, to pass CLA checks
           github_user_name: "github-actions[bot]"
           github_user_email: "41898282+github-actions[bot]@users.noreply.github.com"
         env:
@@ -68,7 +69,7 @@ jobs:
         if: steps.crowdin-download.outputs.pull_request_url
         shell: bash
         run: |
-          echo "PR_NUMBER=$(echo '$PULL_REQUEST_URL' | awk -F / '{print $7}')" >> "$GITHUB_ENV"
+          echo "PR_NUMBER=$(echo "$PULL_REQUEST_URL" | awk -F / '{print $7}')" >> "$GITHUB_ENV"
         env:
           PULL_REQUEST_URL: ${{ steps.crowdin-download.outputs.pull_request_url }}
 


### PR DESCRIPTION
Follow up from https://github.com/grafana/grafana/pull/82059

 - Fixes the incorrect copy-paste from the actions test repo that didn't have some of the latest changes to the action
 - Fixes quotes in the bash script to get the PR number from PR URL