### PR TITLE
Chore: Fix rootDir path when compiling core ds

### DIFF
--- a/pkg/tsdb/Magefile.go
+++ b/pkg/tsdb/Magefile.go
@@ -75,11 +75,7 @@ func findRootDir(pluginID string) (string, error) {
 	if pluginDir == "" {
 		return "", nil
 	}
-	absolutePath, err := filepath.Abs(pluginDir)
-	if err != nil {
-		return "", err
-	}
-	return filepath.Dir(absolutePath), nil
+	return filepath.Abs(pluginDir)
 }
 
 func buildPlugin(rootDir, pluginJSONDir string) {


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

Bug introduced in https://github.com/grafana/grafana/pull/81138

The code was doing `.Dir` twice, so it was returning the plugin directory (e.g. `/grafana/pkg/tsdb/azuremonitor`) rather than the path with the `main` function (e.g. `/grafana/pkg/tsdb/azuremonitor/standalone`). `go build` was not failing because it was compiling a valid go package (but not executable).
