### PR TITLE
Doc: Custom branding is not applicable to OSS

### DIFF
--- a/docs/sources/setup-grafana/configure-grafana/configure-custom-branding/index.md
+++ b/docs/sources/setup-grafana/configure-grafana/configure-custom-branding/index.md
@@ -6,7 +6,6 @@ description: Change the look of Grafana to match your corporate brand.
 labels:
   products:
     - enterprise
-    - oss
 title: Configure custom branding
 weight: 300
 ---


### PR DESCRIPTION
Custom branding page (https://grafana.com/docs/grafana/latest/setup-grafana/configure-grafana/configure-custom-branding/) has OSS Tag. But where as documentation below is mentioning that it is applicable to only Enterprise. 

This PR is to remove OSS tag .

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
