### PR TITLE
Chore: Skip flaky dashboard settings test.

### DIFF
--- a/public/app/features/dashboard/components/DashboardSettings/GeneralSettings.test.tsx
+++ b/public/app/features/dashboard/components/DashboardSettings/GeneralSettings.test.tsx
@@ -77,7 +77,7 @@ describe('General Settings', () => {
   });
 
   describe('when timezone is changed', () => {
-    it('should call update function', async () => {
+    it.skip('should call update function', async () => {
       const { props } = setupTestContext({});
       await userEvent.click(screen.getByTestId(selectors.components.TimeZonePicker.containerV2));
       const timeZonePicker = screen.getByTestId(selectors.components.TimeZonePicker.containerV2);


### PR DESCRIPTION
**What is this feature?**

This disables a test that is testing if the update function is called when the timezone changes. The test is flaky and the flakyness can't be reproduced locally.

One of the failing runs: https://drone.grafana.net/grafana/grafana/159653/1/5

**Why do we need this feature?**

Flaky tests = :skull: 