### PR TITLE
I18n: Add crowdin PRs to project board

### DIFF
--- a/.github/pr-commands.json
+++ b/.github/pr-commands.json
@@ -192,7 +192,7 @@
     "type": "author",
     "name": "pr/external",
     "notMemberOf": { "org": "grafana" },
-    "ignoreList": ["renovate[bot]","dependabot[bot]","grafana-delivery-bot[bot]","grafanabot","github-actions[bot]"],
+    "ignoreList": ["renovate[bot]","dependabot[bot]","grafana-delivery-bot[bot]","grafanabot"],
     "action": "updateLabel",
     "addLabel": "pr/external"
   },
@@ -454,14 +454,6 @@
     "action": "addToProject",
     "addToProject": {
       "url": "https://github.com/orgs/grafana/projects/56"
-    }
-  },
-  {
-    "type": "changedfiles",
-    "matches": ["public/locales/de-DE/grafana.json", "public/locales/es-ES/grafana.json", "public/locales/fr-FR/grafana.json", "public/locales/zh-Hans/grafana.json"],
-    "action": "addToProject",
-    "addToProject": {
-      "url": "https://github.com/orgs/grafana/projects/78"
     }
   }
 ]

--- a/.github/workflows/i18n-crowdin-download.yml
+++ b/.github/workflows/i18n-crowdin-download.yml
@@ -19,6 +19,7 @@ jobs:
           ref: ${{ github.head_ref }}
 
       - name: Download sources
+        id: crowdin-download
         uses: crowdin/github-action@v1
         with:
           upload_sources: false
@@ -48,9 +49,67 @@ jobs:
           config: 'crowdin.yml'
           source: 'public/locales/en-US/grafana.json'
           translation: 'public/locales/%locale%/%original_file_name%'
+          # Magic details of the github-actions bot user, to pass CLA checks
           github_user_name: "github-actions[bot]"
           github_user_email: "41898282+github-actions[bot]@users.noreply.github.com"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           CROWDIN_PROJECT_ID: ${{ secrets.CROWDIN_PROJECT_ID }}
           CROWDIN_PERSONAL_TOKEN: ${{ secrets.CROWDIN_PERSONAL_TOKEN }}
+
+      - name: Generate token
+        if: steps.crowdin-download.outputs.pull_request_url
+        id: generate_token
+        uses: tibdex/github-app-token@b62528385c34dbc9f38e5f4225ac829252d1ea92
+        with:
+          app_id: ${{ secrets.GRAFANA_PR_AUTOMATION_APP_ID }}
+          private_key: ${{ secrets.GRAFANA_PR_AUTOMATION_APP_PEM }}
+
+      - name: Get pull request ID
+        if: steps.crowdin-download.outputs.pull_request_url
+        shell: bash
+        # Crowdin action returns us the URL of the pull request, but we need an ID for the GraphQL API
+        # that looks like 'PR_kwDOAOaWjc5mP_GU'
+        run: |
+          pr_id=$(gh pr view ${{ steps.crowdin-download.outputs.pull_request_url }} --json id -q .id)
+          echo "PULL_REQUEST_ID=$pr_id" >> "$GITHUB_ENV"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Get project board ID
+        uses: octokit/graphql-action@v2.x
+        id: get-project-id
+        if: steps.crowdin-download.outputs.pull_request_url
+        with:
+          # Frontend Platform project - https://github.com/orgs/grafana/projects/78
+          org: grafana
+          project_number: 78
+          query: |
+            query getProjectId($org: String!, $project_number: Int!){
+              organization(login: $org) {
+                projectV2(number: $project_number) {
+                  title
+                  id
+                }
+              }
+            }
+        env:
+          GITHUB_TOKEN: ${{ steps.generate_token.outputs.token }}
+
+      - name: Add to project board
+        uses: octokit/graphql-action@v2.x
+        if: steps.crowdin-download.outputs.pull_request_url
+        with:
+          projectid: ${{ fromJson(steps.get-project-id.outputs.data).organization.projectV2.id }}
+          prid: ${{ env.PULL_REQUEST_ID }}
+          query: |
+            mutation addPullRequestToProject($projectid: ID!, $prid: ID!){
+              addProjectV2ItemById(input: {projectId: $projectid, contentId: $prid}) {
+                item {
+                  id
+                }
+              }
+            }
+
+        env:
+          GITHUB_TOKEN: ${{ steps.generate_token.outputs.token }}

--- a/.github/workflows/i18n-crowdin-download.yml
+++ b/.github/workflows/i18n-crowdin-download.yml
@@ -19,7 +19,6 @@ jobs:
           ref: ${{ github.head_ref }}
 
       - name: Download sources
-        id: crowdin-download
         uses: crowdin/github-action@v1
         with:
           upload_sources: false
@@ -49,69 +48,9 @@ jobs:
           config: 'crowdin.yml'
           source: 'public/locales/en-US/grafana.json'
           translation: 'public/locales/%locale%/%original_file_name%'
-          # Magic details of the github-actions bot user, to pass CLA checks
           github_user_name: "github-actions[bot]"
           github_user_email: "41898282+github-actions[bot]@users.noreply.github.com"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           CROWDIN_PROJECT_ID: ${{ secrets.CROWDIN_PROJECT_ID }}
           CROWDIN_PERSONAL_TOKEN: ${{ secrets.CROWDIN_PERSONAL_TOKEN }}
-
-      # App is not available in test repo
-      - name: Generate token
-        if: steps.crowdin-download.outputs.pull_request_url
-        id: generate_token
-        uses: tibdex/github-app-token@b62528385c34dbc9f38e5f4225ac829252d1ea92
-        with:
-          app_id: ${{ secrets.GRAFANA_PR_AUTOMATION_APP_ID }}
-          private_key: ${{ secrets.GRAFANA_PR_AUTOMATION_APP_PEM }}
-
-      - name: Get pull request ID
-        if: steps.crowdin-download.outputs.pull_request_url
-        shell: bash
-        # Crowdin action returns us the URL of the pull request, but we need an ID for the GraphQL API
-        # that looks like 'PR_kwDOAOaWjc5mP_GU'
-        run: |
-          pr_id=$(gh pr view ${{ steps.crowdin-download.outputs.pull_request_url }} --json id -q .id)
-          echo "PULL_REQUEST_ID=$pr_id" >> "$GITHUB_ENV"
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Get project board ID
-        uses: octokit/graphql-action@v2.x
-        id: get-project-id
-        if: steps.crowdin-download.outputs.pull_request_url
-        with:
-          # Frontend Platform project - https://github.com/orgs/grafana/projects/78
-          org: grafana
-          project_number: 78
-          query: |
-            query getProjectId($org: String!, $project_number: Int!){
-              organization(login: $org) {
-                projectV2(number: $project_number) {
-                  title
-                  id
-                }
-              }
-            }
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Add to project board
-        uses: octokit/graphql-action@v2.x
-        if: steps.crowdin-download.outputs.pull_request_url
-        with:
-          query: |
-            mutation addPullRequestToProject($projectid: ID!, $prid: ID!){
-              addProjectV2ItemById(input: {projectId: $projectid, contentId: $prid}) {
-                item {
-                  id
-                }
-              }
-            }
-          variables: |
-            projectid: ${{ fromJson(steps.get-project-id.outputs.data).organization.projectV2.id }}
-            prid: ${{ env.PULL_REQUEST_ID }}
-        env:
-          GITHUB_TOKEN: ${{ steps.generate_token.outputs.token }}
-


### PR DESCRIPTION
Finally! I think this is all that's needed to properly add the crowdin PRs to our project board.

In summary:
 - use the tibdex/github-app-token / grafana-pr-automation app to get a GITHUB_TOKEN with scopes to read/write to the org-level project board
 - use the gh cli to convert the PR URL output from crowdin action to the PR ID (that looks like 'PR_kwDOAOaWjc5mP_GU')
 - use octokit/graphql-action to convert the project board number to an ID, similar to above
 - finally, use octokit/graphql-action to add the PR to the project
 
Additionally there is a clean up in `.github/pr-commands.json` from som other idea that didn't work out.