### PR TITLE
Outside time-range plugin: Fix condition causing "Zoom to data" message to show with data present

### DIFF
--- a/public/app/plugins/panel/timeseries/plugins/OutsideRangePlugin.tsx
+++ b/public/app/plugins/panel/timeseries/plugins/OutsideRangePlugin.tsx
@@ -43,10 +43,10 @@ export const OutsideRangePlugin = ({ config, onChangeTimeRange }: ThresholdContr
   let j = timevalues.length - 1;
 
   // Increment i until we get the last non-null value
-  for (; i < timevalues.length && timevalues[i] == null; i++) {}
+  for (; i < (timevalues.length - 1) && timevalues[i] == null; i++) {}
 
   // Decrement j until we get the first non-null-value
-  for (; j >= i && timevalues[j] == null; j--) {}
+  for (; j > i && timevalues[j] == null; j--) {}
 
   // Grab the first and last time values
   const last = timevalues[i];

--- a/public/app/plugins/panel/timeseries/plugins/OutsideRangePlugin.tsx
+++ b/public/app/plugins/panel/timeseries/plugins/OutsideRangePlugin.tsx
@@ -46,7 +46,7 @@ export const OutsideRangePlugin = ({ config, onChangeTimeRange }: ThresholdContr
   for (; i < timevalues.length && timevalues[i] == null; i++) {}
 
   // Decrement j until we get the first non-null-value
-  for (; j >= 0 && timevalues[j] == null; j--) {}
+  for (; j >= i && timevalues[j] == null; j--) {}
 
   // Grab the first and last time values
   const last = timevalues[i];

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -1022,6 +1022,10 @@
     "starred-dashboard": "Dashboard starred",
     "unstarred-dashboard": "Dashboard unstarred"
   },
+  "outside-range": {
+    "data": "Data outside of time range",
+    "zoom": "Zoom to data"
+  },
   "panel": {
     "header-menu": {
       "copy": "Copy",


### PR DESCRIPTION
It was brought to our attention that the outside time range plugin will sometimes show even in the presence of data being present. This PR:

- Fixes the issue with a condition in which if there is some time laying outside of one end of the time range then it will fail, causing the message to display erroneously 
- Does slight refactors for clarity and conciseness along with adding comments to add further information around conditions of display
- Adds translations to the displayed messages

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
