### PR TITLE
Prometheus: Azure scopes from Grafana Azure SDK

### DIFF
--- a/pkg/tsdb/prometheus/azureauth/azure.go
+++ b/pkg/tsdb/prometheus/azureauth/azure.go
@@ -80,15 +80,18 @@ func getPrometheusScopes(settings *azsettings.AzureSettings, credentials azcrede
 	}
 
 	// Get scopes for the given cloud
-	resourceIdStr, ok := cloudSettings.Properties["prometheusResourceId"]
+	resourceIdS, ok := cloudSettings.Properties["prometheusResourceId"]
 	if !ok {
 		err := fmt.Errorf("the Azure cloud '%s' doesn't have configuration for Prometheus", azureCloud)
 		return nil, err
 	}
+	return audienceToScopes(resourceIdS)
+}
 
-	resourceId, err := url.Parse(resourceIdStr)
+func audienceToScopes(audience string) ([]string, error) {
+	resourceId, err := url.Parse(audience)
 	if err != nil || resourceId.Scheme == "" || resourceId.Host == "" {
-		err = fmt.Errorf("endpoint resource ID (audience) '%s' invalid", resourceIdStr)
+		err = fmt.Errorf("endpoint resource ID (audience) '%s' invalid", audience)
 		return nil, err
 	}
 

--- a/pkg/tsdb/prometheus/azureauth/azure.go
+++ b/pkg/tsdb/prometheus/azureauth/azure.go
@@ -15,14 +15,6 @@ import (
 	"github.com/grafana/grafana/pkg/tsdb/prometheus/utils"
 )
 
-var (
-	azurePrometheusScopes = map[string][]string{
-		azsettings.AzurePublic:       {"https://prometheus.monitor.azure.com/.default"},
-		azsettings.AzureChina:        {"https://prometheus.monitor.azure.cn/.default"},
-		azsettings.AzureUSGovernment: {"https://prometheus.monitor.azure.us/.default"},
-	}
-)
-
 func ConfigureAzureAuthentication(settings backend.DataSourceInstanceSettings, azureSettings *azsettings.AzureSettings, clientOpts *sdkhttpclient.Options) error {
 	jsonData, err := utils.GetJsonData(settings)
 	if err != nil {
@@ -82,11 +74,25 @@ func getPrometheusScopes(settings *azsettings.AzureSettings, credentials azcrede
 		return nil, err
 	}
 
-	// Get scopes for the given cloud
-	if scopes, ok := azurePrometheusScopes[azureCloud]; !ok {
-		err := fmt.Errorf("the Azure cloud '%s' not supported by Prometheus datasource", azureCloud)
+	cloudSettings, err := settings.GetCloud(azureCloud)
+	if err != nil {
 		return nil, err
-	} else {
-		return scopes, nil
 	}
+
+	// Get scopes for the given cloud
+	resourceIdStr, ok := cloudSettings.Properties["prometheusResourceId"]
+	if !ok {
+		err := fmt.Errorf("the Azure cloud '%s' doesn't have configuration for Prometheus", azureCloud)
+		return nil, err
+	}
+
+	resourceId, err := url.Parse(resourceIdStr)
+	if err != nil || resourceId.Scheme == "" || resourceId.Host == "" {
+		err = fmt.Errorf("endpoint resource ID (audience) '%s' invalid", resourceIdStr)
+		return nil, err
+	}
+
+	resourceId.Path = path.Join(resourceId.Path, ".default")
+	scopes := []string{resourceId.String()}
+	return scopes, nil
 }


### PR DESCRIPTION
**What is this feature?**

New release of [grafana/grafana-azure-sdk-go](https://github.com/grafana/grafana-azure-sdk-go) introduced cloud-specific settings which can be used instead of keeping the settings inside of the datasource itself.

**Why do we need this feature?**

Refactoring to use the new API of Grafana Azure SDK.

**Which issue(s) does this PR fix?**:

Related #61124

**Special notes for your reviewer:**

No changes to the end user.

Please check that:
- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.

Mirror of #82023 for CI