### PR TITLE
fix(alerting): add a proper compare func for location in mute timings

### DIFF
--- a/pkg/services/ngalert/api/api_alertmanager_guards_test.go
+++ b/pkg/services/ngalert/api/api_alertmanager_guards_test.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"testing"
+	"time"
 
 	amConfig "github.com/prometheus/alertmanager/config"
 	"github.com/prometheus/alertmanager/pkg/labels"
@@ -563,6 +564,7 @@ func defaultInterval(t *testing.T) []timeinterval.TimeInterval {
 	t.Helper()
 	return []timeinterval.TimeInterval{
 		{
+			Location: &timeinterval.Location{Location: time.Local},
 			Years: []timeinterval.YearRange{
 				{
 					InclusiveRange: timeinterval.InclusiveRange{


### PR DESCRIPTION
This PR adds a compare function for `*time.Location`. This struct from the std time package has no public fields, so cmp errors out not knowing how to compare it. 

In the past, this wasn't a problem as creating a mute timing with a location wasn't possible and the field was always nil -- but we added this functionality last year in the frontend. 

The test cases were also updated to have a location.

fixes #82150 and #81792