### PR TITLE
BrowseDashboards: Refactor state to prevent sharing with nested folder picker

### DIFF
--- a/public/app/core/components/NestedFolderPicker/utils.ts
+++ b/public/app/core/components/NestedFolderPicker/utils.ts
@@ -1,0 +1,1 @@
+export const EXCLUDED_KINDS = ['empty-folder' as const, 'dashboard' as const];

--- a/public/app/features/browse-dashboards/BrowseDashboardsPage.tsx
+++ b/public/app/features/browse-dashboards/BrowseDashboardsPage.tsx
@@ -12,6 +12,7 @@ import { useDispatch } from 'app/types';
 import { buildNavModel, getDashboardsTabID } from '../folders/state/navModel';
 import { useSearchStateManager } from '../search/state/SearchStateManager';
 import { getSearchPlaceholder } from '../search/tempI18nPhrases';
+import { DashboardViewItemKind } from '../search/types';
 
 import { skipToken, useGetFolderQuery, useSaveFolderMutation } from './api/browseDashboardsAPI';
 import { BrowseActions } from './components/BrowseActions/BrowseActions';
@@ -27,6 +28,8 @@ export interface BrowseDashboardsPageRouteParams {
   uid?: string;
   slug?: string;
 }
+
+const EXCLUDED_KINDS: DashboardViewItemKind[] = [];
 
 export interface Props extends GrafanaRouteComponentProps<BrowseDashboardsPageRouteParams> {}
 
@@ -48,6 +51,7 @@ const BrowseDashboardsPage = memo(({ match }: Props) => {
       setAllSelection({
         isSelected: false,
         folderUID: undefined,
+        excludeKinds: EXCLUDED_KINDS,
       })
     );
   }, [dispatch, folderUID, stateManager]);

--- a/public/app/features/browse-dashboards/components/NameCell.tsx
+++ b/public/app/features/browse-dashboards/components/NameCell.tsx
@@ -1,5 +1,5 @@
 import { css } from '@emotion/css';
-import React from 'react';
+import React, { useMemo } from 'react';
 import Skeleton from 'react-loading-skeleton';
 
 import { GrafanaTheme2 } from '@grafana/data';
@@ -10,7 +10,8 @@ import { t } from 'app/core/internationalization';
 import { getIconForItem } from 'app/features/search/service/utils';
 
 import { Indent } from '../../../core/components/Indent/Indent';
-import { useChildrenByParentUIDState } from '../state';
+import { useChildrenCollectionsState } from '../state';
+import { getChildrenStateKey } from '../state/utils';
 import { DashboardsTreeCellProps } from '../types';
 
 import { makeRowID } from './utils';
@@ -25,8 +26,13 @@ type NameCellProps = DashboardsTreeCellProps & {
 export function NameCell({ row: { original: data }, onFolderClick, treeID }: NameCellProps) {
   const styles = useStyles2(getStyles);
   const { item, level, isOpen } = data;
-  const childrenByParentUID = useChildrenByParentUIDState();
-  const isLoading = isOpen && !childrenByParentUID[item.uid];
+  const childrenCollections = useChildrenCollectionsState();
+
+  const isLoading = useMemo(() => {
+    const stateKey = getChildrenStateKey({ parentUID: item.uid });
+    return isOpen && !childrenCollections[stateKey];
+  }, [item.uid, isOpen, childrenCollections]);
+
   const iconName = getIconForItem(data.item, isOpen);
 
   if (item.kind === 'ui') {

--- a/public/app/features/browse-dashboards/state/actions.ts
+++ b/public/app/features/browse-dashboards/state/actions.ts
@@ -5,7 +5,7 @@ import { createAsyncThunk } from 'app/types';
 import { listDashboards, listFolders, PAGE_SIZE } from '../api/services';
 import { DashboardViewItemWithUIItems, UIDashboardViewItem } from '../types';
 
-import { findItem } from './utils';
+import { findItem, getChildrenStateKey } from './utils';
 
 interface FetchNextChildrenPageArgs {
   parentUID: string | undefined;
@@ -38,12 +38,12 @@ export const refreshParents = createAsyncThunk(
   'browseDashboards/refreshParents',
   async (uids: string[], { getState, dispatch }) => {
     const { browseDashboards } = getState();
-    const { rootItems, childrenByParentUID } = browseDashboards;
+    const { children } = browseDashboards;
     const parentsToRefresh = new Set<string | undefined>();
 
     for (const uid of uids) {
       // find the parent folder uid
-      const item = findItem(rootItems?.items ?? [], childrenByParentUID, uid);
+      const item = findItem(children, uid);
       parentsToRefresh.add(item?.parentUID);
     }
 
@@ -100,7 +100,9 @@ export const fetchNextChildrenPage = createAsyncThunk(
     const uid = parentUID === GENERAL_FOLDER_UID ? undefined : parentUID;
 
     const state = thunkAPI.getState().browseDashboards;
-    const collection = uid ? state.childrenByParentUID[uid] : state.rootItems;
+
+    const stateKey = getChildrenStateKey({ parentUID: uid, excludeKinds });
+    const collection = state.children[stateKey];
 
     let page = 1;
     let fetchKind: DashboardViewItemKind | undefined = undefined;

--- a/public/app/features/browse-dashboards/state/slice.ts
+++ b/public/app/features/browse-dashboards/state/slice.ts
@@ -8,8 +8,11 @@ import * as allReducers from './reducers';
 const { fetchNextChildrenPageFulfilled, refetchChildrenFulfilled, ...baseReducers } = allReducers;
 
 const initialState: BrowseDashboardsState = {
-  rootItems: undefined,
-  childrenByParentUID: {},
+  children: {},
+
+  // rootItems: undefined, // deprecated, moving to children
+  // childrenByParentUID: {}, // deprecated, moving to children
+
   openFolders: {},
   selectedItems: {
     dashboard: {},

--- a/public/app/features/browse-dashboards/state/utils.ts
+++ b/public/app/features/browse-dashboards/state/utils.ts
@@ -3,18 +3,12 @@ import { DashboardViewItem } from 'app/features/search/types';
 import { BrowseDashboardsState } from '../types';
 
 export function findItem(
-  rootItems: DashboardViewItem[],
-  childrenByUID: BrowseDashboardsState['childrenByParentUID'],
+  childrenCollection: BrowseDashboardsState['children'],
   uid: string
 ): DashboardViewItem | undefined {
-  for (const item of rootItems) {
-    if (item.uid === uid) {
-      return item;
-    }
-  }
+  for (const key in childrenCollection) {
+    const children = childrenCollection[key];
 
-  for (const parentUID in childrenByUID) {
-    const children = childrenByUID[parentUID];
     if (!children) {
       continue;
     }
@@ -41,5 +35,17 @@ export function getPaginationPlaceholders(amount: number, parentUID: string | un
         uid: `${parentUID}-pagination-${index}`,
       },
     };
+  });
+}
+
+type KeyableArgs = {
+  parentUID: string | undefined;
+  excludeKinds?: string[];
+};
+
+export function getChildrenStateKey({ parentUID, excludeKinds }: KeyableArgs) {
+  return JSON.stringify({
+    parentUID: parentUID ?? '$$special_uid_for_grafana_root_folder', // JOSH TODO: we probably don't need to set a root folder uid, and just rely on it being undefined
+    excludeKinds: excludeKinds ?? [],
   });
 }

--- a/public/app/features/browse-dashboards/types.ts
+++ b/public/app/features/browse-dashboards/types.ts
@@ -19,8 +19,8 @@ export type DashboardViewItemCollection = {
 };
 
 export interface BrowseDashboardsState {
-  rootItems: DashboardViewItemCollection | undefined;
-  childrenByParentUID: Record<string, DashboardViewItemCollection | undefined>;
+  children: Record<string, DashboardViewItemCollection | undefined>;
+
   selectedItems: DashboardTreeSelection;
 
   // Only folders can ever be open or closed, so no need to seperate this by kind


### PR DESCRIPTION
start of a refactor of the browse dashboards state to allow children to be partitioned by more arbitary properties.

currently there's a bug where if you have a small number of dashboards and folders, and you load the nested folder picker _before_ the browse dashboards view, the browse dashboards view won't show dashboards at the root.

this is because the folder picker and browse dashboards share state, but the folder picker only loads folders, and in that state we say "right, this folder has fully loaded".

this PR starts an approach where instead children are keyed by the arguments that went into fetching them, so the nested folder picker has its own set of state.

![image](https://github.com/grafana/grafana/assets/46142/aa351b24-d4a7-4cc3-9f1e-d377fac2fe08)


part of https://github.com/grafana/grafana/issues/81941