### PR TITLE
Tempo: Improve UX of the query editors status select

### DIFF
--- a/public/app/plugins/datasource/tempo/SearchTraceQLEditor/SearchField.tsx
+++ b/public/app/plugins/datasource/tempo/SearchTraceQLEditor/SearchField.tsx
@@ -33,6 +33,8 @@ interface Props {
   hideTag?: boolean;
   hideValue?: boolean;
   query: string;
+  isMulti?: boolean;
+  allowCustomValue?: boolean;
 }
 const SearchField = ({
   filter,
@@ -45,6 +47,8 @@ const SearchField = ({
   hideTag,
   hideValue,
   query,
+  isMulti = true,
+  allowCustomValue = true,
 }: Props) => {
   const styles = useStyles2(getStyles);
   const scopedTag = useMemo(() => filterScopedTag(filter), [filter]);
@@ -195,10 +199,10 @@ const SearchField = ({
             }
           }}
           placeholder="Select value"
-          isClearable={false}
+          isClearable={true}
           aria-label={`select ${filter.id} value`}
-          allowCustomValue={true}
-          isMulti
+          allowCustomValue={allowCustomValue}
+          isMulti={isMulti}
           allowCreateWhileLoading
         />
       )}

--- a/public/app/plugins/datasource/tempo/SearchTraceQLEditor/TraceQLSearch.tsx
+++ b/public/app/plugins/datasource/tempo/SearchTraceQLEditor/TraceQLSearch.tsx
@@ -151,6 +151,8 @@ const TraceQLSearch = ({ datasource, query, onChange, onClearResults, app }: Pro
               hideScope={true}
               hideTag={true}
               query={traceQlQuery}
+              isMulti={false}
+              allowCustomValue={false}
             />
           </InlineSearchField>
           <InlineSearchField


### PR DESCRIPTION
**What is this feature?**

Improves UX of the query editors status select.

**Why do we need this feature?**

Creates a simpler UX by reducing the amount of possibly invalid values a user can mistakingly choose for the status part of their query. This PR removes the possibility for a user to type a status which could essentially be typed incorrectly and since there are only (usually) 3 values to choose from in the dropdown this is not an issue. The inverse however of typing an invalid valid and seeing red errors etc leads to a poor user experience. 

Secondly, the PR disallows the adding of more than one status as that will also result in an invalid query.

**Who is this feature for?**

Tempo users.