### PR TITLE
datatrails: fix: propagate unit to breakdown graphs

### DIFF
--- a/public/app/features/trails/ActionTabs/BreakdownScene.tsx
+++ b/public/app/features/trails/ActionTabs/BreakdownScene.tsx
@@ -196,6 +196,7 @@ export function buildAllLayout(options: Array<SelectableValue<string>>, queryDef
     }
 
     const expr = queryDef.queries[0].expr.replace(VAR_GROUP_BY_EXP, String(option.value));
+    const unit = queryDef.unit;
 
     children.push(
       new SceneCSSGridItem({
@@ -215,6 +216,7 @@ export function buildAllLayout(options: Array<SelectableValue<string>>, queryDef
             })
           )
           .setHeaderActions(new SelectLabelAction({ labelName: String(option.value) }))
+          .setUnit(unit)
           .build(),
       })
     );


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

Ensures that the unit specified shows up in the breakdown charts as well.

Before:
![image](https://github.com/grafana/grafana/assets/38694490/c899a1a4-9713-40e9-9774-74539e968e85)

After:
![image](https://github.com/grafana/grafana/assets/38694490/57fd41b6-e23d-4def-a2d6-f95534b7310e)

This makes it easier to see how the charts line up, as the axis widths aren't drastically different.

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
