### PR TITLE
PeakQ (WIP): Store reference back to template

### DIFF
--- a/pkg/apis/peakq/v0alpha1/types.go
+++ b/pkg/apis/peakq/v0alpha1/types.go
@@ -130,6 +130,9 @@ type QueryTemplateList struct {
 type RenderedQuery struct {
 	metav1.TypeMeta `json:",inline"`
 
+	// The name of the stored query template used to render the targets
+	TemplateName string `json:"templateName,omitempty"`
+
 	// +listType=atomic
 	Targets []Target `json:"targets,omitempty"`
 }

--- a/pkg/apis/peakq/v0alpha1/zz_generated.openapi.go
+++ b/pkg/apis/peakq/v0alpha1/zz_generated.openapi.go
@@ -228,6 +228,13 @@ func schema_pkg_apis_peakq_v0alpha1_RenderedQuery(ref common.ReferenceCallback) 
 							Format:      "",
 						},
 					},
+					"templateName": {
+						SchemaProps: spec.SchemaProps{
+							Description: "The name of the stored query template used to render the targets",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
 					"targets": {
 						VendorExtensible: spec.VendorExtensible{
 							Extensions: spec.Extensions{

--- a/pkg/registry/apis/peakq/render.go
+++ b/pkg/registry/apis/peakq/render.go
@@ -55,7 +55,7 @@ func (r *renderREST) Connect(ctx context.Context, name string, opts runtime.Obje
 			responder.Error(err)
 			return
 		}
-		rq, err := Render(template.Spec, input)
+		rq, err := Render(template.Spec, input, template.Name)
 		if err != nil {
 			responder.Error(fmt.Errorf("failed to render: %w", err))
 			return
@@ -79,7 +79,7 @@ func renderPOSTHandler(w http.ResponseWriter, req *http.Request) {
 		w.WriteHeader(500)
 		return
 	}
-	results, err := Render(qT.Spec, input)
+	results, err := Render(qT.Spec, input, "")
 	if err != nil {
 		_, _ = w.Write([]byte("ERROR: " + err.Error()))
 		w.WriteHeader(500)
@@ -146,7 +146,7 @@ func getReplacementMap(qt peakq.QueryTemplateSpec) map[int]map[string][]replacem
 	return byTargetPath
 }
 
-func Render(qt peakq.QueryTemplateSpec, selectedValues map[string][]string) (*peakq.RenderedQuery, error) {
+func Render(qt peakq.QueryTemplateSpec, selectedValues map[string][]string, name string) (*peakq.RenderedQuery, error) {
 	targets := qt.DeepCopy().Targets
 
 	rawTargetObjects := make([]*ajson.Node, len(qt.Targets))
@@ -207,6 +207,7 @@ func Render(qt peakq.QueryTemplateSpec, selectedValues map[string][]string) (*pe
 	}
 
 	return &peakq.RenderedQuery{
-		Targets: targets,
+		TemplateName: name,
+		Targets:      targets,
 	}, nil
 }

--- a/pkg/registry/apis/peakq/render_examples_test.go
+++ b/pkg/registry/apis/peakq/render_examples_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func TestRender(t *testing.T) {
-	rT, err := Render(basicTemplateSpec, map[string][]string{"metricName": {"up"}})
+	rT, err := Render(basicTemplateSpec, map[string][]string{"metricName": {"up"}}, "")
 	require.NoError(t, err)
 	require.Equal(t,
 		basicTemplateRenderedTargets[0].Properties.AdditionalProperties()["expr"],

--- a/pkg/registry/apis/peakq/render_test.go
+++ b/pkg/registry/apis/peakq/render_test.go
@@ -67,7 +67,7 @@ var nestedFieldRenderedTargets = []peakq.Target{
 }
 
 func TestNestedFieldRender(t *testing.T) {
-	rT, err := Render(nestedFieldRender, map[string][]string{"metricName": {"up"}})
+	rT, err := Render(nestedFieldRender, map[string][]string{"metricName": {"up"}}, "")
 	require.NoError(t, err)
 	require.Equal(t,
 		nestedFieldRenderedTargets,
@@ -166,7 +166,7 @@ func TestMultiVarTemplate(t *testing.T) {
 	rT, err := Render(multiVarTemplate, map[string][]string{
 		"metricName":    {"up"},
 		"anotherMetric": {"sloths_do_like_a_good_nap"},
-	})
+	}, "")
 	require.NoError(t, err)
 	require.Equal(t,
 		multiVarRenderedTargets,
@@ -205,7 +205,7 @@ func TestRenderWithRune(t *testing.T) {
 		"name": {"🦥"},
 	}
 
-	rq, err := Render(qt, selectedValues)
+	rq, err := Render(qt, selectedValues, "")
 	require.NoError(t, err)
 
 	require.Equal(t, "🐦 🦥!", rq.Targets[0].Properties.AdditionalProperties()["message"])


### PR DESCRIPTION
**What is this feature?**

PeakQ - so rendered targets for a stored target have a reference back to the template.


**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
