### PR TITLE
postgres: tls: only use non-empty certificates

### DIFF
--- a/pkg/tsdb/grafana-postgresql-datasource/tlsmanager.go
+++ b/pkg/tsdb/grafana-postgresql-datasource/tlsmanager.go
@@ -200,6 +200,19 @@ func (m *tlsManager) writeCertFiles(dsInfo sqleng.DataSourceInfo, tlsconfig *tls
 		return err
 	}
 
+	// we do not want to point to cert-files that do not exist
+	if tlsRootCert == "" {
+		tlsconfig.RootCertFile = ""
+	}
+
+	if tlsClientCert == "" {
+		tlsconfig.CertFile = ""
+	}
+
+	if tlsClientKey == "" {
+		tlsconfig.CertKeyFile = ""
+	}
+
 	// Update datasource cache
 	m.dsCacheInstance.cache.Store(cacheKey, dsInfo.Updated)
 	return nil

--- a/pkg/tsdb/grafana-postgresql-datasource/tlsmanager_test.go
+++ b/pkg/tsdb/grafana-postgresql-datasource/tlsmanager_test.go
@@ -237,6 +237,45 @@ func TestGetTLSSettings(t *testing.T) {
 				CertKeyFile:         filepath.Join(cfg.DataPath, "tls", "xxxgeneratedTLSCerts", "client.key"),
 			},
 		},
+		{
+			desc:    "Custom TLS mode verify-ca with no client certificates with certificate files content",
+			updated: updatedTime.Add(3 * time.Minute),
+			uid:     "xxx",
+			jsonData: sqleng.JsonData{
+				Mode:                "verify-ca",
+				ConfigurationMethod: "file-content",
+			},
+			secureJSONData: map[string]string{
+				"tlsCACert": "I am CA certification",
+			},
+			tlsSettings: tlsSettings{
+				Mode:                "verify-ca",
+				ConfigurationMethod: "file-content",
+				RootCertFile:        filepath.Join(cfg.DataPath, "tls", "xxxgeneratedTLSCerts", "root.crt"),
+				CertFile:            "",
+				CertKeyFile:         "",
+			},
+		},
+		{
+			desc:    "Custom TLS mode require with client certificates and no root certificate with certificate files content",
+			updated: updatedTime.Add(4 * time.Minute),
+			uid:     "xxx",
+			jsonData: sqleng.JsonData{
+				Mode:                "require",
+				ConfigurationMethod: "file-content",
+			},
+			secureJSONData: map[string]string{
+				"tlsClientCert": "I am client certification",
+				"tlsClientKey":  "I am client key",
+			},
+			tlsSettings: tlsSettings{
+				Mode:                "require",
+				ConfigurationMethod: "file-content",
+				RootCertFile:        "",
+				CertFile:            filepath.Join(cfg.DataPath, "tls", "xxxgeneratedTLSCerts", "client.crt"),
+				CertKeyFile:         filepath.Join(cfg.DataPath, "tls", "xxxgeneratedTLSCerts", "client.key"),
+			},
+		},
 	}
 	for _, tt := range testCases {
 		t.Run(tt.desc, func(t *testing.T) {


### PR DESCRIPTION
### short version
we are planning to replace the go-module we use for postgres. 
when we provide it with the connection-config, we sometimes refer to files that do not exist. the current postgres go-module tolerates this, but the new go-module does not. so we are improving our code to not refer to files that do not exist.

### long version
when using TLS/SSL with postgres, some modes require the use of certificate files. there are 3 possible certificate files:
- server root/ca cert
- client key
- client cert

these can be added either as the path to the file, or you can paste them into text-areas on the config page.

this PR deals only with the "paste into textarea" situation, the file-path case is unchanged.

the postgres go module does not have an easy option for specifying the certificate-file-content. it really prefers to receive the file-path.

for this reason, in the postgres datasource plugin, when you choose to paste the certificates into the textareas, when later the certificate is needed, the plugin will store the certificate on a file on the local disk, and provide the go module with the path to them.

as i wrote above, there are 3 possible certificate files. but you do not have to provide always all of them. 
but, the current plugin-logic, when constructing the connection-string, it will refer always to all 3 files, even to ones that do not exist.

we currently use the `lib/pq` go module. this module does not mind that we are providing it with a connection-string that points to files that do not exist,  it works fine.

but, we are planning to switch to the `pgx` go module. that one returns an error saying it cannot find the mentioned file.

the PR adjusts the code so that we only refer to non-empty files.

i was trying to make the shortest diff possible, there may be a more elegant way to do this.

(long term we'll probably find a way to not have these temporary-files)

### how to test
https://github.com/grafana/oss-big-tent-tools/tree/main/tls-setups/postgres provides test-setups for postgres databases, you can try out the various scenarios where you paste in the certificates into the plugin config page, to make sure they still work.

(part of https://github.com/grafana/grafana/issues/79671)