### PR TITLE
Table Panel: Conditional Formatting POC

### DIFF
--- a/packages/grafana-flamegraph/src/TopTable/FlameGraphTopTableContainer.tsx
+++ b/packages/grafana-flamegraph/src/TopTable/FlameGraphTopTableContainer.tsx
@@ -11,6 +11,7 @@ import {
   GrafanaTheme2,
   MappingType,
 } from '@grafana/data';
+import { TableFormattingOrientation } from '@grafana/schema';
 import {
   IconButton,
   Table,
@@ -222,6 +223,7 @@ function createNumberField(name: string, unit?: string): Field {
     align: 'auto',
     inspect: false,
     cellOptions: { type: TableCellDisplayMode.Auto },
+    formattingOrientation: TableFormattingOrientation.Columns,
   };
 
   return {
@@ -266,6 +268,7 @@ function createActionField(
     inspect: false,
     align: 'auto',
     cellOptions: options,
+    formattingOrientation: TableFormattingOrientation.Columns,
   };
 
   return {

--- a/packages/grafana-schema/src/common/common.gen.ts
+++ b/packages/grafana-schema/src/common/common.gen.ts
@@ -707,6 +707,15 @@ export enum TableCellBackgroundDisplayMode {
 }
 
 /**
+ * When applying conditional formatting to the table determines
+ * whether the formatting is applied either to rows or to columns
+ */
+export enum TableFormattingOrientation {
+  Columns = 'columns',
+  Rows = 'rows',
+}
+
+/**
  * Sort by field state
  */
 export interface TableSortByFieldState {
@@ -922,6 +931,7 @@ export interface TableFieldOptions {
    */
   displayMode?: TableCellDisplayMode;
   filterable?: boolean;
+  formattingOrientation: TableFormattingOrientation.Columns;
   hidden?: boolean; // ?? default is missing or false ??
   /**
    * Hides any header for a column, useful for columns that show some static content or buttons.

--- a/packages/grafana-schema/src/common/table.cue
+++ b/packages/grafana-schema/src/common/table.cue
@@ -11,6 +11,10 @@ TableCellDisplayMode: "auto" | "color-text" | "color-background" | "color-backgr
 // or a gradient.
 TableCellBackgroundDisplayMode: "basic" | "gradient" @cuetsy(kind="enum",memberNames="Basic|Gradient")
 
+// When applying conditional formatting to the table determines
+// whether the formatting is applied either to rows or to columns
+TableFormattingOrientation: "rows" | "columns" @cuetsy(kind="enum", memberNames="Rows|Columns")
+
 // Sort by field state
 TableSortByFieldState: {
 	// Sets the display name of the field to sort by
@@ -89,6 +93,7 @@ TableFieldOptions: {
 	// This field is deprecated in favor of using cellOptions
 	displayMode?: TableCellDisplayMode
 	cellOptions: TableCellOptions
+	formattingOrientation: TableFormattingOrientation & "columns"
 	hidden?:     bool // ?? default is missing or false ??
 	inspect: bool | *false
 	filterable?: bool

--- a/packages/grafana-schema/src/veneer/common.types.ts
+++ b/packages/grafana-schema/src/veneer/common.types.ts
@@ -44,6 +44,7 @@ export const defaultTableFieldOptions: raw.TableFieldOptions = {
   cellOptions: {
     type: raw.TableCellDisplayMode.Auto,
   },
+  formattingOrientation: raw.TableFormattingOrientation.Columns,
 };
 
 /**

--- a/packages/grafana-ui/src/components/Table/RowsList.tsx
+++ b/packages/grafana-ui/src/components/Table/RowsList.tsx
@@ -217,7 +217,7 @@ export const RowsList = (props: RowsListProps) => {
       // TODO: depending on light/dark measure appropriately set 
       // text color as well
       // TODO: may need to handle conversion from Grafana color
-      // code to hex color
+      // code to hex color  
       let rowFormatStyle = null;
       if (colorMap !== undefined && colorMap[index] !== undefined) {
         rowFormatStyle = css({backgroundColor: colorMap[index]});

--- a/packages/grafana-ui/src/components/Table/RowsList.tsx
+++ b/packages/grafana-ui/src/components/Table/RowsList.tsx
@@ -20,10 +20,12 @@ import CustomScrollbar from '../CustomScrollbar/CustomScrollbar';
 import { usePanelContext } from '../PanelChrome';
 
 import { ExpandedRow, getExpandedRowHeight } from './ExpandedRow';
+import { RowToColor } from './Table';
 import { TableCell } from './TableCell';
 import { TableStyles } from './styles';
 import { TableFilterActionCallback } from './types';
 import { calculateAroundPointThreshold, isPointTimeValAroundTableTimeVal } from './utils';
+
 
 interface RowsListProps {
   data: DataFrame;
@@ -44,6 +46,7 @@ interface RowsListProps {
   onCellFilterAdded?: TableFilterActionCallback;
   timeRange?: TimeRange;
   footerPaginationEnabled: boolean;
+  colorMap?: RowToColor;
 }
 
 export const RowsList = (props: RowsListProps) => {
@@ -66,6 +69,7 @@ export const RowsList = (props: RowsListProps) => {
     listHeight,
     listRef,
     enableSharedCrosshair = false,
+    colorMap
   } = props;
 
   const [rowHighlightIndex, setRowHighlightIndex] = useState<number | undefined>(undefined);
@@ -208,6 +212,17 @@ export const RowsList = (props: RowsListProps) => {
 
       const expandedRowStyle = tableState.expanded[row.id] ? css({ '&:hover': { background: 'inherit' } }) : {};
 
+      // If there's a threshold format then
+      // we set the row's background color
+      // TODO: depending on light/dark measure appropriately set 
+      // text color as well
+      // TODO: may need to handle conversion from Grafana color
+      // code to hex color
+      let rowFormatStyle = null;
+      if (colorMap !== undefined && colorMap[index] !== undefined) {
+        rowFormatStyle = css({backgroundColor: colorMap[index]});
+      }
+
       if (rowHighlightIndex !== undefined && row.index === rowHighlightIndex) {
         style = { ...style, backgroundColor: theme.components.table.rowHoverBackground };
       }
@@ -215,7 +230,7 @@ export const RowsList = (props: RowsListProps) => {
       return (
         <div
           {...row.getRowProps({ style })}
-          className={cx(tableStyles.row, expandedRowStyle)}
+          className={cx(tableStyles.row, expandedRowStyle, rowFormatStyle)}
           onMouseEnter={() => onRowHover(index, data)}
           onMouseLeave={onRowLeave}
         >
@@ -259,6 +274,7 @@ export const RowsList = (props: RowsListProps) => {
       theme.components.table.rowHoverBackground,
       timeRange,
       width,
+      colorMap
     ]
   );
 

--- a/packages/grafana-ui/src/components/Table/Table.tsx
+++ b/packages/grafana-ui/src/components/Table/Table.tsx
@@ -79,6 +79,56 @@ export const Table = memo((props: Props) => {
     return EXTENDED_ROW_HEIGHT;
   }, [footerItems]);
 
+  data.fields.map((field) => {
+    const { thresholds } = field.config;
+
+    console.log(thresholds);
+
+    if (thresholds === undefined) {
+      return;
+    }
+
+    // Get threshold configurations for this field
+
+
+    for(let i = 0; i < field.values.length; i++) {
+      const value = field.values[i];
+
+      // If we're not dealing with numbers we
+      // don't need to do anything
+      if (field.type !== FieldType.number) {
+        continue;
+      }
+
+      for (let i = (thresholds.steps.length - 1); i >= 0; i--) {
+
+      }
+      
+      // We have five distinct cases (and assuming)
+      // that the field is numeric
+      // 
+      // 1. Absolute Threshold applied to rows
+      //    In this case we go from highest to lowest
+      //    threshold for each field value and if it 
+      //    matches that threshold we save the color
+      //    for that index and then contine
+      // 2. Absolute threshold applied to columns
+      //    We do the same process as above but stop
+      //    once the threshold has been satisfied
+      //    as it will apply to all values in the column
+      // 3. Percentage threshold for rows
+      //    We do the same as number 1 using the correct
+      //    percentage of the maximum value
+      // 4. Percentage threshold for columns
+      //    The same as number 2 but using the apppropriate
+      //    percentage of the maximum value
+      
+
+      // TODO: Support nested tables
+      
+    }
+  })
+
   // React table data array. This data acts just like a dummy array to let react-table know how many rows exist.
   // The cells use the field to look up values, therefore this is simply a length/size placeholder.
   const memoizedData = useMemo(() => {

--- a/public/app/plugins/panel/table/module.tsx
+++ b/public/app/plugins/panel/table/module.tsx
@@ -93,17 +93,11 @@ export const plugin = new PanelPlugin<Options, FieldConfig>(TablePanel)
           description: 'Enables/disables field filters in table',
           defaultValue: defaultTableFieldOptions.filterable,
         })
-        .addRadio({
-          path: 'formattingOrientation',
-          name: 'Threshold Formatting',
-          description: 'When using thresholds, formatting can be applied to table rows or to table columns',
-          settings: {
-            options: [
-              { label: 'Columns', value: 'columns' },
-              { label: 'Rows', value: 'rows' },
-            ],
-          },
-          defaultValue: defaultTableFieldOptions.formattingOrientation,
+        .addBooleanSwitch({
+          path: 'formatRows',
+          name: 'Format Rows',
+          description: 'If enabled, thresholds will be used to format rows',
+          defaultValue: false,
         })
         .addBooleanSwitch({
           path: 'hidden',

--- a/public/app/plugins/panel/table/module.tsx
+++ b/public/app/plugins/panel/table/module.tsx
@@ -93,6 +93,18 @@ export const plugin = new PanelPlugin<Options, FieldConfig>(TablePanel)
           description: 'Enables/disables field filters in table',
           defaultValue: defaultTableFieldOptions.filterable,
         })
+        .addRadio({
+          path: 'formattingOrientation',
+          name: 'Threshold Formatting',
+          description: 'When using thresholds, formatting can be applied to table rows or to table columns',
+          settings: {
+            options: [
+              { label: 'Columns', value: 'columns' },
+              { label: 'Rows', value: 'rows' },
+            ],
+          },
+          defaultValue: defaultTableFieldOptions.formattingOrientation,
+        })
         .addBooleanSwitch({
           path: 'hidden',
           name: 'Hide in table',


### PR DESCRIPTION
**What is this feature?**

This draft PR implements a first stab at conditional formatting for the table panel. Currently, it uses thresholds to apply colors to rows if a numeric value of a field in that row surpasses a given threshold. At present there are numerous details left to figure out including but not limited to:

- What to do when multiple numeric fields are present
- If it makes sense to apply formatting to both columns and rows, or simply to do so for one or the other
- If this meshes well with field overrides
- Figuring out appropriate text coloring based on theme and applied threshold color
- What to do in the case of nested tables
- How to properly handle percentage thresholds, not just absolute thresholds
- If base thresholds should ever be applied or if an option should be provided for this (currently base threshold is ignored)
- What to do for hovered rows
- Figuring out styling such that this looks good, and is up to the visual standard that Grafana visualizations provide

Here's a short video of this POC in action:

https://github.com/grafana/grafana/assets/199847/d7162a6f-e428-4de6-ad8a-e6f3bdf7c756

**Why do we need this feature?**

Conditional formatting by row is one of the most requested features in Grafana. It's desirable for a wide variety of use cases including observability, monitoring, analytics, business intelligence, and many many (many) more. In addition to being one of the oldest open issues against Grafana, we've had requests for this feature from all quarters.

**Who is this feature for?**

Most if not all of the users of the table panel users in Grafana

**Which issue(s) does this PR fix?**:

Fixes #11418

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
