### PR TITLE
Alerting: add telegram api url config

### DIFF
--- a/pkg/services/alerting/notifiers/telegram.go
+++ b/pkg/services/alerting/notifiers/telegram.go
@@ -17,9 +17,6 @@ import (
 
 const (
 	captionLengthLimit = 1024
-)
-
-var (
 	defaultTelegramAPIURL = "https://api.telegram.org/"
 )
 
@@ -218,7 +215,7 @@ func (tn *TelegramNotifier) generateTelegramCmd(message string, messageField str
 
 	apiUrlPattern := tn.APIURL + "bot%s/%s"
 
-	tn.log.Info("Sending telegram notification", "chat_id", tn.ChatID, "bot_token", tn.BotToken, "apiAction", apiAction)
+	tn.log.Info("Sending telegram notification", "chat_id", tn.ChatID, "bot_token", tn.BotToken, "apiAction", apiAction, "apiUrl", tn.APIURL)
 	url := fmt.Sprintf(apiUrlPattern, tn.BotToken, apiAction)
 
 	cmd := &notifications.SendWebhookSync{

--- a/pkg/services/alerting/notifiers/telegram_test.go
+++ b/pkg/services/alerting/notifiers/telegram_test.go
@@ -33,6 +33,20 @@ func TestTelegramNotifier(t *testing.T) {
 			require.Error(t, err)
 		})
 
+		t.Run("Empty APIURL should set default APIURL", func(t *testing.T) {
+			json := `{ }`
+
+			settingsJSON, _ := simplejson.NewJson([]byte(json))
+			model := &models.AlertNotification{
+				Name:     "telegram_testing",
+				Type:     "telegram",
+				Settings: settingsJSON,
+			}
+
+			telegramNotifier, err := NewTelegramNotifier(setting.NewCfg(), model, encryptionService.GetDecryptedValue, nil)
+			require.Equal(t, "https://api.telegram.org/", telegramNotifier.APIURL)
+		})
+
 		t.Run("settings should trigger incident", func(t *testing.T) {
 			json := `
 				{


### PR DESCRIPTION
**What is this feature?**

A config for custom api url for telegram added.

**Why do we need this feature?**

Resolving Issue: https://github.com/grafana/grafana/issues/81534
**Who is this feature for?**

User who use telegram notifier and use local bot api deployments or proxied domain for accessing telegram.
**Which issue(s) does this PR fix?**:

Fixes #81534

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
