### PR TITLE
Query History: Count using SQL, not post query

### DIFF
--- a/pkg/services/queryhistory/writers.go
+++ b/pkg/services/queryhistory/writers.go
@@ -10,20 +10,20 @@ import (
 
 func writeStarredSQL(query SearchInQueryHistoryQuery, sqlStore db.DB, builder *db.SQLBuilder, isCount bool) {
 	var sql bytes.Buffer
-	if (isCount) {
+	if isCount {
 		sql.WriteString(`COUNT(`)
 	}
-	if (query.OnlyStarred) {
+	if query.OnlyStarred {
 		sql.WriteString(sqlStore.GetDialect().BooleanStr(true))
 	} else {
 		sql.WriteString(`CASE WHEN query_history_star.query_uid IS NULL THEN ` + sqlStore.GetDialect().BooleanStr(false) + ` ELSE ` + sqlStore.GetDialect().BooleanStr(true) + ` END`)
 	}
-	if(isCount) {
+	if isCount {
 		sql.WriteString(`)`)
 	}
 	sql.WriteString(` AS starred FROM query_history `)
 
-	if (query.OnlyStarred) {
+	if query.OnlyStarred {
 		sql.WriteString(`INNER`)
 	} else {
 		sql.WriteString(`LEFT`)

--- a/pkg/services/queryhistory/writers.go
+++ b/pkg/services/queryhistory/writers.go
@@ -8,18 +8,29 @@ import (
 	"github.com/grafana/grafana/pkg/services/user"
 )
 
-func writeStarredSQL(query SearchInQueryHistoryQuery, sqlStore db.DB, builder *db.SQLBuilder) {
-	if query.OnlyStarred {
-		builder.Write(sqlStore.GetDialect().BooleanStr(true) + ` AS starred
-				FROM query_history
-				INNER JOIN query_history_star ON query_history_star.query_uid = query_history.uid 
-				`)
-	} else {
-		builder.Write(` CASE WHEN query_history_star.query_uid IS NULL THEN ` + sqlStore.GetDialect().BooleanStr(false) + ` ELSE ` + sqlStore.GetDialect().BooleanStr(true) + ` END AS starred
-				FROM query_history
-				LEFT JOIN query_history_star ON query_history_star.query_uid = query_history.uid 
-				`)
+func writeStarredSQL(query SearchInQueryHistoryQuery, sqlStore db.DB, builder *db.SQLBuilder, isCount bool) {
+	var sql bytes.Buffer
+	if (isCount) {
+		sql.WriteString(`COUNT(`)
 	}
+	if (query.OnlyStarred) {
+		sql.WriteString(sqlStore.GetDialect().BooleanStr(true))
+	} else {
+		sql.WriteString(`CASE WHEN query_history_star.query_uid IS NULL THEN ` + sqlStore.GetDialect().BooleanStr(false) + ` ELSE ` + sqlStore.GetDialect().BooleanStr(true) + ` END`)
+	}
+	if(isCount) {
+		sql.WriteString(`)`)
+	}
+	sql.WriteString(` AS starred FROM query_history `)
+
+	if (query.OnlyStarred) {
+		sql.WriteString(`INNER`)
+	} else {
+		sql.WriteString(`LEFT`)
+	}
+
+	sql.WriteString(` JOIN query_history_star ON query_history_star.query_uid = query_history.uid `)
+	builder.Write(sql.String())
 }
 
 func writeFiltersSQL(query SearchInQueryHistoryQuery, user *user.SignedInUser, sqlStore db.DB, builder *db.SQLBuilder) {


### PR DESCRIPTION
**What is this feature?**

To get the number of queries returned, the logic would query for all records, but return 1 for each record. In Go, it would then count how many records were returned. SQL has the ability to send a count of number of records returned, so we can use that.

This is to follow through on this comment https://github.com/grafana/grafana/pull/49217#discussion_r878769826

**Why do we need this feature?**

It is slightly more efficient.

**Which issue(s) does this PR fix?**:

Fixes #50306

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
