### PR TITLE
Loki Log Context: Always show label filters with at least one parsed label

### DIFF
--- a/public/app/plugins/datasource/loki/LogContextProvider.test.ts
+++ b/public/app/plugins/datasource/loki/LogContextProvider.test.ts
@@ -57,7 +57,7 @@ describe('LogContextProvider', () => {
   describe('getLogRowContext', () => {
     it('should call getInitContextFilters if no cachedContextFilters', async () => {
       logContextProvider.getInitContextFilters = jest.fn().mockResolvedValue({
-        contextFilters: [{ value: 'baz', enabled: true, fromParser: false, label: 'bar' }],
+        contextFilters: [{ value: 'baz', enabled: true, nonIndexed: false, label: 'bar' }],
         preservedFiltersApplied: false,
       });
 
@@ -89,7 +89,7 @@ describe('LogContextProvider', () => {
     it('should not call getInitContextFilters if cachedContextFilters', async () => {
       logContextProvider.getInitContextFilters = jest
         .fn()
-        .mockResolvedValue([{ value: 'baz', enabled: true, fromParser: false, label: 'bar' }]);
+        .mockResolvedValue([{ value: 'baz', enabled: true, nonIndexed: false, label: 'bar' }]);
 
       logContextProvider.cachedContextFilters = [
         { value: 'baz', enabled: true, nonIndexed: false, label: 'bar' },
@@ -107,7 +107,7 @@ describe('LogContextProvider', () => {
   describe('getLogRowContextQuery', () => {
     it('should call getInitContextFilters if no cachedContextFilters', async () => {
       logContextProvider.getInitContextFilters = jest.fn().mockResolvedValue({
-        contextFilters: [{ value: 'baz', enabled: true, fromParser: false, label: 'bar' }],
+        contextFilters: [{ value: 'baz', enabled: true, nonIndexed: false, label: 'bar' }],
         preservedFiltersApplied: false,
       });
 
@@ -121,7 +121,7 @@ describe('LogContextProvider', () => {
 
     it('should also call getInitContextFilters if cacheFilters is not set', async () => {
       logContextProvider.getInitContextFilters = jest.fn().mockResolvedValue({
-        contextFilters: [{ value: 'baz', enabled: true, fromParser: false, label: 'bar' }],
+        contextFilters: [{ value: 'baz', enabled: true, nonIndexed: false, label: 'bar' }],
         preservedFiltersApplied: false,
       });
       logContextProvider.cachedContextFilters = [
@@ -229,7 +229,7 @@ describe('LogContextProvider', () => {
         }
       );
 
-      expect(contextQuery.query.expr).toEqual(`{bar="baz"}`);
+      expect(contextQuery.query.expr).toEqual(`{bar="baz"} | foo=\`uniqueParsedLabel\``);
     });
 
     it('should not apply line_format if flag is not set by default', async () => {
@@ -401,9 +401,9 @@ describe('LogContextProvider', () => {
       it('should correctly create contextFilters', async () => {
         const result = await logContextProvider.getInitContextFilters(defaultLogRow.labels, queryWithoutParser);
         expect(result.contextFilters).toEqual([
-          { enabled: true, fromParser: false, label: 'bar', value: 'baz' },
-          { enabled: false, fromParser: true, label: 'foo', value: 'uniqueParsedLabel' },
-          { enabled: true, fromParser: false, label: 'xyz', value: 'abc' },
+          { enabled: true, nonIndexed: false, label: 'bar', value: 'baz' },
+          { enabled: false, nonIndexed: true, label: 'foo', value: 'uniqueParsedLabel' },
+          { enabled: true, nonIndexed: false, label: 'xyz', value: 'abc' },
         ]);
         expect(result.preservedFiltersApplied).toBe(false);
       });
@@ -444,9 +444,9 @@ describe('LogContextProvider', () => {
       it('should correctly create contextFilters', async () => {
         const result = await logContextProvider.getInitContextFilters(defaultLogRow.labels, queryWithParser);
         expect(result.contextFilters).toEqual([
-          { enabled: true, fromParser: false, label: 'bar', value: 'baz' },
-          { enabled: false, fromParser: true, label: 'foo', value: 'uniqueParsedLabel' },
-          { enabled: true, fromParser: false, label: 'xyz', value: 'abc' },
+          { enabled: true, nonIndexed: false, label: 'bar', value: 'baz' },
+          { enabled: false, nonIndexed: true, label: 'foo', value: 'uniqueParsedLabel' },
+          { enabled: true, nonIndexed: false, label: 'xyz', value: 'abc' },
         ]);
         expect(result.preservedFiltersApplied).toBe(false);
       });
@@ -479,9 +479,9 @@ describe('LogContextProvider', () => {
         );
         const result = await logContextProvider.getInitContextFilters(defaultLogRow.labels, queryWithParser);
         expect(result.contextFilters).toEqual([
-          { enabled: false, fromParser: false, label: 'bar', value: 'baz' }, // disabled real label
-          { enabled: true, fromParser: true, label: 'foo', value: 'uniqueParsedLabel' }, // enabled parsed label
-          { enabled: true, fromParser: false, label: 'xyz', value: 'abc' },
+          { enabled: false, nonIndexed: false, label: 'bar', value: 'baz' }, // disabled real label
+          { enabled: true, nonIndexed: true, label: 'foo', value: 'uniqueParsedLabel' }, // enabled parsed label
+          { enabled: true, nonIndexed: false, label: 'xyz', value: 'abc' },
         ]);
         expect(result.preservedFiltersApplied).toBe(true);
       });
@@ -496,9 +496,9 @@ describe('LogContextProvider', () => {
         );
         const result = await logContextProvider.getInitContextFilters(defaultLogRow.labels, queryWithParser);
         expect(result.contextFilters).toEqual([
-          { enabled: true, fromParser: false, label: 'bar', value: 'baz' }, // enabled real label
-          { enabled: false, fromParser: true, label: 'foo', value: 'uniqueParsedLabel' },
-          { enabled: true, fromParser: false, label: 'xyz', value: 'abc' }, // enabled real label
+          { enabled: true, nonIndexed: false, label: 'bar', value: 'baz' }, // enabled real label
+          { enabled: false, nonIndexed: true, label: 'foo', value: 'uniqueParsedLabel' },
+          { enabled: true, nonIndexed: false, label: 'xyz', value: 'abc' }, // enabled real label
         ]);
         expect(result.preservedFiltersApplied).toBe(false);
       });
@@ -513,9 +513,9 @@ describe('LogContextProvider', () => {
         );
         const result = await logContextProvider.getInitContextFilters(defaultLogRow.labels, queryWithParser);
         expect(result.contextFilters).toEqual([
-          { enabled: false, fromParser: false, label: 'bar', value: 'baz' },
-          { enabled: true, fromParser: true, label: 'foo', value: 'uniqueParsedLabel' },
-          { enabled: true, fromParser: false, label: 'xyz', value: 'abc' },
+          { enabled: false, nonIndexed: false, label: 'bar', value: 'baz' },
+          { enabled: true, nonIndexed: true, label: 'foo', value: 'uniqueParsedLabel' },
+          { enabled: true, nonIndexed: false, label: 'xyz', value: 'abc' },
         ]);
         expect(result.preservedFiltersApplied).toBe(true);
       });

--- a/public/app/plugins/datasource/loki/LogContextProvider.test.ts
+++ b/public/app/plugins/datasource/loki/LogContextProvider.test.ts
@@ -158,7 +158,7 @@ describe('LogContextProvider', () => {
         expect(result.query.expr).toEqual('{}');
       });
 
-      it('should not apply parsed labels', async () => {
+      it('should apply parsed label as structured metadata', async () => {
         logContextProvider.cachedContextFilters = [
           { value: 'baz', enabled: true, fromParser: false, label: 'bar' },
           { value: 'abc', enabled: true, fromParser: false, label: 'xyz' },
@@ -171,7 +171,7 @@ describe('LogContextProvider', () => {
           query
         );
 
-        expect(contextQuery.query.expr).toEqual('{bar="baz",xyz="abc"}');
+        expect(contextQuery.query.expr).toEqual('{bar="baz",xyz="abc"} | foo=`uniqueParsedLabel`');
       });
     });
 

--- a/public/app/plugins/datasource/loki/LogContextProvider.test.ts
+++ b/public/app/plugins/datasource/loki/LogContextProvider.test.ts
@@ -92,8 +92,8 @@ describe('LogContextProvider', () => {
         .mockResolvedValue([{ value: 'baz', enabled: true, fromParser: false, label: 'bar' }]);
 
       logContextProvider.cachedContextFilters = [
-        { value: 'baz', enabled: true, fromParser: false, label: 'bar' },
-        { value: 'abc', enabled: true, fromParser: false, label: 'xyz' },
+        { value: 'baz', enabled: true, nonIndexed: false, label: 'bar' },
+        { value: 'abc', enabled: true, nonIndexed: false, label: 'xyz' },
       ];
       await logContextProvider.getLogRowContext(defaultLogRow, {
         limit: 10,
@@ -125,8 +125,8 @@ describe('LogContextProvider', () => {
         preservedFiltersApplied: false,
       });
       logContextProvider.cachedContextFilters = [
-        { value: 'baz', enabled: true, fromParser: false, label: 'bar' },
-        { value: 'abc', enabled: true, fromParser: false, label: 'xyz' },
+        { value: 'baz', enabled: true, nonIndexed: false, label: 'bar' },
+        { value: 'abc', enabled: true, nonIndexed: false, label: 'xyz' },
       ];
       await logContextProvider.getLogRowContextQuery(
         defaultLogRow,
@@ -160,9 +160,9 @@ describe('LogContextProvider', () => {
 
       it('should apply parsed label as structured metadata', async () => {
         logContextProvider.cachedContextFilters = [
-          { value: 'baz', enabled: true, fromParser: false, label: 'bar' },
-          { value: 'abc', enabled: true, fromParser: false, label: 'xyz' },
-          { value: 'uniqueParsedLabel', enabled: true, fromParser: true, label: 'foo' },
+          { value: 'baz', enabled: true, nonIndexed: false, label: 'bar' },
+          { value: 'abc', enabled: true, nonIndexed: false, label: 'xyz' },
+          { value: 'uniqueParsedLabel', enabled: true, nonIndexed: true, label: 'foo' },
         ];
         const contextQuery = await logContextProvider.prepareLogRowContextQueryTarget(
           defaultLogRow,
@@ -178,8 +178,8 @@ describe('LogContextProvider', () => {
     describe('query with parser', () => {
       it('should apply parser', async () => {
         logContextProvider.cachedContextFilters = [
-          { value: 'baz', enabled: true, fromParser: false, label: 'bar' },
-          { value: 'abc', enabled: true, fromParser: false, label: 'xyz' },
+          { value: 'baz', enabled: true, nonIndexed: false, label: 'bar' },
+          { value: 'abc', enabled: true, nonIndexed: false, label: 'xyz' },
         ];
         const contextQuery = await logContextProvider.prepareLogRowContextQueryTarget(
           defaultLogRow,
@@ -196,9 +196,9 @@ describe('LogContextProvider', () => {
 
       it('should apply parser and parsed labels', async () => {
         logContextProvider.cachedContextFilters = [
-          { value: 'baz', enabled: true, fromParser: false, label: 'bar' },
-          { value: 'abc', enabled: true, fromParser: false, label: 'xyz' },
-          { value: 'uniqueParsedLabel', enabled: true, fromParser: true, label: 'foo' },
+          { value: 'baz', enabled: true, nonIndexed: false, label: 'bar' },
+          { value: 'abc', enabled: true, nonIndexed: false, label: 'xyz' },
+          { value: 'uniqueParsedLabel', enabled: true, nonIndexed: true, label: 'foo' },
         ];
         const contextQuery = await logContextProvider.prepareLogRowContextQueryTarget(
           defaultLogRow,
@@ -216,8 +216,8 @@ describe('LogContextProvider', () => {
 
     it('should not apply parser and parsed labels if more parsers in original query', async () => {
       logContextProvider.cachedContextFilters = [
-        { value: 'baz', enabled: true, fromParser: false, label: 'bar' },
-        { value: 'uniqueParsedLabel', enabled: true, fromParser: true, label: 'foo' },
+        { value: 'baz', enabled: true, nonIndexed: false, label: 'bar' },
+        { value: 'uniqueParsedLabel', enabled: true, nonIndexed: true, label: 'foo' },
       ];
       const contextQuery = await logContextProvider.prepareLogRowContextQueryTarget(
         defaultLogRow,
@@ -233,7 +233,7 @@ describe('LogContextProvider', () => {
     });
 
     it('should not apply line_format if flag is not set by default', async () => {
-      logContextProvider.cachedContextFilters = [{ value: 'baz', enabled: true, fromParser: false, label: 'bar' }];
+      logContextProvider.cachedContextFilters = [{ value: 'baz', enabled: true, nonIndexed: false, label: 'bar' }];
       const contextQuery = await logContextProvider.prepareLogRowContextQueryTarget(
         defaultLogRow,
         10,
@@ -249,7 +249,7 @@ describe('LogContextProvider', () => {
 
     it('should not apply line_format if flag is not set', async () => {
       window.localStorage.setItem(SHOULD_INCLUDE_PIPELINE_OPERATIONS, 'false');
-      logContextProvider.cachedContextFilters = [{ value: 'baz', enabled: true, fromParser: false, label: 'bar' }];
+      logContextProvider.cachedContextFilters = [{ value: 'baz', enabled: true, nonIndexed: false, label: 'bar' }];
       const contextQuery = await logContextProvider.prepareLogRowContextQueryTarget(
         defaultLogRow,
         10,
@@ -265,7 +265,7 @@ describe('LogContextProvider', () => {
 
     it('should apply line_format if flag is set', async () => {
       window.localStorage.setItem(SHOULD_INCLUDE_PIPELINE_OPERATIONS, 'true');
-      logContextProvider.cachedContextFilters = [{ value: 'baz', enabled: true, fromParser: false, label: 'bar' }];
+      logContextProvider.cachedContextFilters = [{ value: 'baz', enabled: true, nonIndexed: false, label: 'bar' }];
       const contextQuery = await logContextProvider.prepareLogRowContextQueryTarget(
         defaultLogRow,
         10,
@@ -281,7 +281,7 @@ describe('LogContextProvider', () => {
 
     it('should not apply line filters if flag is set', async () => {
       window.localStorage.setItem(SHOULD_INCLUDE_PIPELINE_OPERATIONS, 'true');
-      logContextProvider.cachedContextFilters = [{ value: 'baz', enabled: true, fromParser: false, label: 'bar' }];
+      logContextProvider.cachedContextFilters = [{ value: 'baz', enabled: true, nonIndexed: false, label: 'bar' }];
       let contextQuery = await logContextProvider.prepareLogRowContextQueryTarget(
         defaultLogRow,
         10,
@@ -333,7 +333,7 @@ describe('LogContextProvider', () => {
 
     it('should not apply line filters if nested between two operations', async () => {
       window.localStorage.setItem(SHOULD_INCLUDE_PIPELINE_OPERATIONS, 'true');
-      logContextProvider.cachedContextFilters = [{ value: 'baz', enabled: true, fromParser: false, label: 'bar' }];
+      logContextProvider.cachedContextFilters = [{ value: 'baz', enabled: true, nonIndexed: false, label: 'bar' }];
       const contextQuery = await logContextProvider.prepareLogRowContextQueryTarget(
         defaultLogRow,
         10,
@@ -349,7 +349,7 @@ describe('LogContextProvider', () => {
 
     it('should not apply label filters', async () => {
       window.localStorage.setItem(SHOULD_INCLUDE_PIPELINE_OPERATIONS, 'true');
-      logContextProvider.cachedContextFilters = [{ value: 'baz', enabled: true, fromParser: false, label: 'bar' }];
+      logContextProvider.cachedContextFilters = [{ value: 'baz', enabled: true, nonIndexed: false, label: 'bar' }];
       const contextQuery = await logContextProvider.prepareLogRowContextQueryTarget(
         defaultLogRow,
         10,
@@ -365,7 +365,7 @@ describe('LogContextProvider', () => {
 
     it('should not apply additional parsers', async () => {
       window.localStorage.setItem(SHOULD_INCLUDE_PIPELINE_OPERATIONS, 'true');
-      logContextProvider.cachedContextFilters = [{ value: 'baz', enabled: true, fromParser: false, label: 'bar' }];
+      logContextProvider.cachedContextFilters = [{ value: 'baz', enabled: true, nonIndexed: false, label: 'bar' }];
       const contextQuery = await logContextProvider.prepareLogRowContextQueryTarget(
         defaultLogRow,
         10,

--- a/public/app/plugins/datasource/loki/LogContextProvider.ts
+++ b/public/app/plugins/datasource/loki/LogContextProvider.ts
@@ -29,7 +29,7 @@ import {
   isQueryWithParser,
 } from './queryUtils';
 import { sortDataFrameByTime, SortDirection } from './sortDataFrame';
-import { ContextFilter, LokiQuery, LokiQueryDirection, LokiQueryType } from './types';
+import { ContextFilter, LabelType, LokiQuery, LokiQueryDirection, LokiQueryType } from './types';
 
 export const LOKI_LOG_CONTEXT_PRESERVED_LABELS = 'lokiLogContextPreservedLabels';
 export const SHOULD_INCLUDE_PIPELINE_OPERATIONS = 'lokiLogContextShouldIncludePipelineOperations';
@@ -246,6 +246,14 @@ export class LogContextProvider {
           if (parsedLabel.enabled) {
             expr = addLabelToQuery(expr, parsedLabel.label, '=', parsedLabel.value);
           }
+        }
+      }
+    } else if (query && isQueryWithParser(query.expr).parserCount === 0) {
+      // this case handles labels added from structured metadata, because the label is `fromParser` but the query does not contain a parser
+      const parsedLabels = contextFilters.filter((filter) => filter.fromParser && filter.enabled);
+      for (const parsedLabel of parsedLabels) {
+        if (parsedLabel.enabled) {
+          expr = addLabelToQuery(expr, parsedLabel.label, '=', parsedLabel.value, LabelType.StructuredMetadata);
         }
       }
     }

--- a/public/app/plugins/datasource/loki/LogContextProvider.ts
+++ b/public/app/plugins/datasource/loki/LogContextProvider.ts
@@ -237,23 +237,26 @@ export class LogContextProvider {
 
     // We need to have original query to get parser and include parsed labels
     // We only add parser and parsed labels if there is only one parser in query
-    if (query && isQueryWithParser(query.expr).parserCount === 1) {
-      const parser = getParserFromQuery(query.expr);
-      if (parser) {
-        expr = addParserToQuery(expr, parser);
-        const parsedLabels = contextFilters.filter((filter) => filter.nonIndexed && filter.enabled);
-        for (const parsedLabel of parsedLabels) {
-          if (parsedLabel.enabled) {
-            expr = addLabelToQuery(expr, parsedLabel.label, '=', parsedLabel.value);
-          }
+    if (query) {
+      let hasParser = false;
+      if (isQueryWithParser(query.expr).parserCount === 1) {
+        hasParser = true;
+        const parser = getParserFromQuery(query.expr);
+        if (parser) {
+          expr = addParserToQuery(expr, parser);
         }
       }
-    } else if (query && isQueryWithParser(query.expr).parserCount === 0) {
-      // this case handles labels added from structured metadata, because the label is `fromParser` but the query does not contain a parser
+
       const parsedLabels = contextFilters.filter((filter) => filter.nonIndexed && filter.enabled);
       for (const parsedLabel of parsedLabels) {
         if (parsedLabel.enabled) {
-          expr = addLabelToQuery(expr, parsedLabel.label, '=', parsedLabel.value, LabelType.StructuredMetadata);
+          expr = addLabelToQuery(
+            expr,
+            parsedLabel.label,
+            '=',
+            parsedLabel.value,
+            hasParser ? LabelType.Parsed : LabelType.StructuredMetadata
+          );
         }
       }
     }

--- a/public/app/plugins/datasource/loki/LogContextProvider.ts
+++ b/public/app/plugins/datasource/loki/LogContextProvider.ts
@@ -247,8 +247,8 @@ export class LogContextProvider {
         }
       }
 
-      const parsedLabels = contextFilters.filter((filter) => filter.nonIndexed && filter.enabled);
-      for (const parsedLabel of parsedLabels) {
+      const nonIndexedLabels = contextFilters.filter((filter) => filter.nonIndexed && filter.enabled);
+      for (const parsedLabel of nonIndexedLabels) {
         if (parsedLabel.enabled) {
           expr = addLabelToQuery(
             expr,
@@ -379,9 +379,7 @@ export class LogContextProvider {
         return { ...contextFilter };
       });
 
-      const isAtLeastOneRealLabelEnabled = newContextFilters.some(
-        ({ enabled, nonIndexed: fromParser }) => enabled && !fromParser
-      );
+      const isAtLeastOneRealLabelEnabled = newContextFilters.some(({ enabled, nonIndexed }) => enabled && !nonIndexed);
       if (!isAtLeastOneRealLabelEnabled) {
         // If we end up with no real labels enabled, we need to reset the init filters
         return { contextFilters, preservedFiltersApplied };

--- a/public/app/plugins/datasource/loki/components/LokiContextUi.test.tsx
+++ b/public/app/plugins/datasource/loki/components/LokiContextUi.test.tsx
@@ -43,8 +43,8 @@ const mockLogContextProvider = {
   getInitContextFilters: jest.fn().mockImplementation(() =>
     Promise.resolve({
       contextFilters: [
-        { value: 'value1', enabled: true, fromParser: false, label: 'label1' },
-        { value: 'value3', enabled: false, fromParser: true, label: 'label3' },
+        { value: 'value1', enabled: true, nonIndexed: false, label: 'label1' },
+        { value: 'value3', enabled: false, nonIndexed: true, label: 'label3' },
       ],
       preservedFiltersApplied: false,
     })
@@ -339,8 +339,8 @@ describe('LokiContextUi', () => {
         getInitContextFilters: jest.fn().mockImplementation(() =>
           Promise.resolve({
             contextFilters: [
-              { value: 'value1', enabled: true, fromParser: false, label: 'label1' },
-              { value: 'value3', enabled: false, fromParser: true, label: 'label3' },
+              { value: 'value1', enabled: true, nonIndexed: false, label: 'label1' },
+              { value: 'value3', enabled: false, nonIndexed: true, label: 'label3' },
             ],
             preservedFiltersApplied: true,
           })

--- a/public/app/plugins/datasource/loki/components/LokiContextUi.tsx
+++ b/public/app/plugins/datasource/loki/components/LokiContextUi.tsx
@@ -253,7 +253,7 @@ export function LokiContextUi(props: LokiContextUiProps) {
   }, []);
 
   // If there's any "parsedLabel", that also includes structured metadata, we show the parsed labels input
-  const showParsedLabels = parsedLabels.length > 0;
+  const showNonIndexedLabels = parsedLabels.length > 0;
 
   let queryExpr = logContextProvider.prepareExpression(
     contextFilters.filter(({ enabled }) => enabled),
@@ -366,7 +366,7 @@ export function LokiContextUi(props: LokiContextUiProps) {
               );
             }}
           />
-          {showParsedLabels && (
+          {showNonIndexedLabels && (
             <>
               <Label
                 className={styles.label}

--- a/public/app/plugins/datasource/loki/components/LokiContextUi.tsx
+++ b/public/app/plugins/datasource/loki/components/LokiContextUi.tsx
@@ -28,7 +28,6 @@ import {
   SHOULD_INCLUDE_PIPELINE_OPERATIONS,
 } from '../LogContextProvider';
 import { escapeLabelValueInSelector } from '../languageUtils';
-import { isQueryWithParser } from '../queryUtils';
 import { lokiGrammar } from '../syntax';
 import { ContextFilter, LokiQuery } from '../types';
 
@@ -253,8 +252,8 @@ export function LokiContextUi(props: LokiContextUiProps) {
     };
   }, []);
 
-  // Currently we support adding of parser and showing parsed labels only if there is 1 parser
-  const showParsedLabels = origQuery && isQueryWithParser(origQuery.expr).parserCount === 1 && parsedLabels.length > 0;
+  // If there's any "parsedLabel", that also includes structured metadata, we show the parsed labels input
+  const showParsedLabels = parsedLabels.length > 0;
 
   let queryExpr = logContextProvider.prepareExpression(
     contextFilters.filter(({ enabled }) => enabled),

--- a/public/app/plugins/datasource/loki/components/LokiContextUi.tsx
+++ b/public/app/plugins/datasource/loki/components/LokiContextUi.tsx
@@ -132,7 +132,7 @@ export function LokiContextUi(props: LokiContextUiProps) {
 
   const isInitialState = useMemo(() => {
     // Initial query has all regular labels enabled and all parsed labels disabled
-    if (initialized && contextFilters.some((filter) => filter.fromParser === filter.enabled)) {
+    if (initialized && contextFilters.some((filter) => filter.nonIndexed === filter.enabled)) {
       return false;
     }
 
@@ -155,7 +155,7 @@ export function LokiContextUi(props: LokiContextUiProps) {
       return;
     }
 
-    if (contextFilters.filter(({ enabled, fromParser }) => enabled && !fromParser).length === 0) {
+    if (contextFilters.filter(({ enabled, nonIndexed: fromParser }) => enabled && !fromParser).length === 0) {
       setContextFilters(previousContextFilters.current);
       return;
     }
@@ -175,7 +175,7 @@ export function LokiContextUi(props: LokiContextUiProps) {
         selectedExtractedLabels: [],
       };
 
-      contextFilters.forEach(({ enabled, fromParser, label }) => {
+      contextFilters.forEach(({ enabled, nonIndexed: fromParser, label }) => {
         // We only want to store real labels that were removed from the initial query
         if (!enabled && !fromParser) {
           preservedLabels.removedLabels.push(label);
@@ -239,10 +239,10 @@ export function LokiContextUi(props: LokiContextUiProps) {
     };
   }, [row.uid]);
 
-  const realLabels = contextFilters.filter(({ fromParser }) => !fromParser);
+  const realLabels = contextFilters.filter(({ nonIndexed: fromParser }) => !fromParser);
   const realLabelsEnabled = realLabels.filter(({ enabled }) => enabled);
 
-  const parsedLabels = contextFilters.filter(({ fromParser }) => fromParser);
+  const parsedLabels = contextFilters.filter(({ nonIndexed: fromParser }) => fromParser);
   const parsedLabelsEnabled = parsedLabels.filter(({ enabled }) => enabled);
 
   const contextFilterToSelectFilter = useCallback((contextFilter: ContextFilter): SelectableValue<string> => {
@@ -284,7 +284,7 @@ export function LokiContextUi(props: LokiContextUiProps) {
                 return contextFilters.map((contextFilter) => ({
                   ...contextFilter,
                   // For revert to initial query we need to enable all labels and disable all parsed labels
-                  enabled: !contextFilter.fromParser,
+                  enabled: !contextFilter.nonIndexed,
                 }));
               });
               // We are removing the preserved labels from local storage so we can preselect the labels in the UI
@@ -357,7 +357,7 @@ export function LokiContextUi(props: LokiContextUiProps) {
               }
               return setContextFilters(
                 contextFilters.map((filter) => {
-                  if (filter.fromParser) {
+                  if (filter.nonIndexed) {
                     return filter;
                   }
                   filter.enabled = keys.some((key) => key.value === filter.label);
@@ -399,7 +399,7 @@ export function LokiContextUi(props: LokiContextUiProps) {
                   }
                   setContextFilters(
                     contextFilters.map((filter) => {
-                      if (!filter.fromParser) {
+                      if (!filter.nonIndexed) {
                         return filter;
                       }
                       filter.enabled = keys.some((key) => key.value === filter.label);

--- a/public/app/plugins/datasource/loki/components/LokiContextUi.tsx
+++ b/public/app/plugins/datasource/loki/components/LokiContextUi.tsx
@@ -155,7 +155,7 @@ export function LokiContextUi(props: LokiContextUiProps) {
       return;
     }
 
-    if (contextFilters.filter(({ enabled, nonIndexed: fromParser }) => enabled && !fromParser).length === 0) {
+    if (contextFilters.filter(({ enabled, nonIndexed }) => enabled && !nonIndexed).length === 0) {
       setContextFilters(previousContextFilters.current);
       return;
     }
@@ -175,13 +175,13 @@ export function LokiContextUi(props: LokiContextUiProps) {
         selectedExtractedLabels: [],
       };
 
-      contextFilters.forEach(({ enabled, nonIndexed: fromParser, label }) => {
+      contextFilters.forEach(({ enabled, nonIndexed, label }) => {
         // We only want to store real labels that were removed from the initial query
-        if (!enabled && !fromParser) {
+        if (!enabled && !nonIndexed) {
           preservedLabels.removedLabels.push(label);
         }
         // Or extracted labels that were added to the initial query
-        if (enabled && fromParser) {
+        if (enabled && nonIndexed) {
           preservedLabels.selectedExtractedLabels.push(label);
         }
       });
@@ -239,10 +239,10 @@ export function LokiContextUi(props: LokiContextUiProps) {
     };
   }, [row.uid]);
 
-  const realLabels = contextFilters.filter(({ nonIndexed: fromParser }) => !fromParser);
+  const realLabels = contextFilters.filter(({ nonIndexed }) => !nonIndexed);
   const realLabelsEnabled = realLabels.filter(({ enabled }) => enabled);
 
-  const parsedLabels = contextFilters.filter(({ nonIndexed: fromParser }) => fromParser);
+  const parsedLabels = contextFilters.filter(({ nonIndexed }) => nonIndexed);
   const parsedLabelsEnabled = parsedLabels.filter(({ enabled }) => enabled);
 
   const contextFilterToSelectFilter = useCallback((contextFilter: ContextFilter): SelectableValue<string> => {
@@ -252,7 +252,7 @@ export function LokiContextUi(props: LokiContextUiProps) {
     };
   }, []);
 
-  // If there's any "parsedLabel", that also includes structured metadata, we show the parsed labels input
+  // If there's any nonIndexed labels, that includes structured metadata and parsed labels, we show the nonIndexed labels input
   const showNonIndexedLabels = parsedLabels.length > 0;
 
   let queryExpr = logContextProvider.prepareExpression(

--- a/public/app/plugins/datasource/loki/types.ts
+++ b/public/app/plugins/datasource/loki/types.ts
@@ -87,8 +87,7 @@ export interface ContextFilter {
   enabled: boolean;
   label: string;
   value: string;
-  fromParser: boolean;
-  description?: string;
+  nonIndexed: boolean;
 }
 
 export interface ParserAndLabelKeysResult {


### PR DESCRIPTION
**What is this feature?**
Removes a check if a query contains a parser and only rely on the `parsedLabels` field to determine if the second search input box is present.

![image](https://github.com/grafana/grafana/assets/8092184/aeca3267-487f-4a76-bef7-2a8708387a6c)
