### PR TITLE
Canvas: Keep tooltip open until dismissed

### DIFF
--- a/public/app/features/canvas/runtime/element.tsx
+++ b/public/app/features/canvas/runtime/element.tsx
@@ -459,7 +459,7 @@ export class ElementState implements LayerElement {
 
   handleMouseEnter = (event: React.MouseEvent, isSelected: boolean | undefined) => {
     const scene = this.getScene();
-    if (!scene?.isEditingEnabled) {
+    if (!scene?.isEditingEnabled && !scene?.tooltip?.isOpen) {
       this.handleTooltip(event);
     } else if (!isSelected) {
       scene?.connections.handleMouseEnter(event);


### PR DESCRIPTION
This PR fixes the interference between mouse events and tooltip.

https://github.com/grafana/grafana/assets/88068998/52d8dc48-3ad9-4da5-8481-523a10da58c6



Fixes https://github.com/grafana/grafana/issues/70079

**Special notes for your reviewer:**
- Definitely more things that can be improved - positioning, design, etc. (cc @lukasztyrala)

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
