### PR TITLE
Chore: Avoid NPE with annotations query

### DIFF
--- a/public/app/plugins/datasource/grafana/datasource.ts
+++ b/public/app/plugins/datasource/grafana/datasource.ts
@@ -216,7 +216,7 @@ export class GrafanaDatasource extends DataSourceWithBackend<GrafanaQuery> {
 
     if (target.type === GrafanaAnnotationType.Dashboard) {
       // if no dashboard id yet return
-      if (!options.dashboard.uid) {
+      if (!options.dashboard?.uid) {
         return Promise.resolve({ data: [] });
       }
       // filter by dashboard id


### PR DESCRIPTION
In the ephemeral instances, it seems pretty easy to hit errors that cause errors

<img width="963" alt="image" src="https://github.com/grafana/grafana/assets/705951/1244f265-5fd9-4a05-9aad-d3b0b0f8d9ac">
