### PR TITLE
Viz: Fix loading bar shifts text

### DIFF
--- a/packages/grafana-ui/src/components/LoadingBar/LoadingBar.tsx
+++ b/packages/grafana-ui/src/components/LoadingBar/LoadingBar.tsx
@@ -1,5 +1,5 @@
 import { css, keyframes } from '@emotion/css';
-import React, { CSSProperties } from 'react';
+import React from 'react';
 
 import { GrafanaTheme2 } from '@grafana/data';
 
@@ -20,14 +20,9 @@ const DEFAULT_ANIMATION_DELAY = 300;
 export function LoadingBar({ width, delay = DEFAULT_ANIMATION_DELAY, ariaLabel = 'Loading bar' }: LoadingBarProps) {
   const durationMs = Math.min(Math.max(Math.round(width * MILLISECONDS_PER_PIXEL), MIN_DURATION_MS), MAX_DURATION_MS);
   const styles = useStyles2(getStyles, delay, durationMs);
-  const containerStyles: CSSProperties = {
-    overflow: 'hidden',
-    position: 'relative',
-    height: 1,
-  };
 
   return (
-    <div style={containerStyles}>
+    <div className={styles.container}>
       <div aria-label={ariaLabel} className={styles.bar} />
     </div>
   );
@@ -45,6 +40,11 @@ const getStyles = (_theme: GrafanaTheme2, delay: number, duration: number) => {
   });
 
   return {
+    container: css({
+      overflow: 'hidden',
+      position: 'relative',
+      height: 1,
+    }),
     bar: css({
       width: BAR_WIDTH + '%',
       height: 1,

--- a/packages/grafana-ui/src/components/LoadingBar/LoadingBar.tsx
+++ b/packages/grafana-ui/src/components/LoadingBar/LoadingBar.tsx
@@ -16,13 +16,14 @@ const MILLISECONDS_PER_PIXEL = 2.4;
 const MIN_DURATION_MS = 500;
 const MAX_DURATION_MS = 4000;
 const DEFAULT_ANIMATION_DELAY = 300;
-const MAX_TRANSLATE_X = (100 / BAR_WIDTH) * 100;
 
 export function LoadingBar({ width, delay = DEFAULT_ANIMATION_DELAY, ariaLabel = 'Loading bar' }: LoadingBarProps) {
   const durationMs = Math.min(Math.max(Math.round(width * MILLISECONDS_PER_PIXEL), MIN_DURATION_MS), MAX_DURATION_MS);
   const styles = useStyles2(getStyles, delay, durationMs);
   const containerStyles: CSSProperties = {
     overflow: 'hidden',
+    position: 'relative',
+    height: 1,
   };
 
   return (
@@ -35,11 +36,11 @@ export function LoadingBar({ width, delay = DEFAULT_ANIMATION_DELAY, ariaLabel =
 const getStyles = (_theme: GrafanaTheme2, delay: number, duration: number) => {
   const animation = keyframes({
     '0%': {
-      transform: 'translateX(-100%)',
+      left: `-${BAR_WIDTH}%`,
     },
     // this gives us a delay between iterations
     '85%, 100%': {
-      transform: `translateX(${MAX_TRANSLATE_X}%)`,
+      left: '100%',
     },
   });
 
@@ -48,14 +49,14 @@ const getStyles = (_theme: GrafanaTheme2, delay: number, duration: number) => {
       width: BAR_WIDTH + '%',
       height: 1,
       background: 'linear-gradient(90deg, rgba(110, 159, 255, 0) 0%, #6E9FFF 80.75%, rgba(110, 159, 255, 0) 100%)',
-      transform: 'translateX(-100%)',
+      left: `-${BAR_WIDTH}%`,
+      position: 'absolute',
       animationName: animation,
       // an initial delay to prevent the loader from showing if the response is faster than the delay
       animationDelay: `${delay}ms`,
       animationDuration: `${duration}ms`,
       animationTimingFunction: 'linear',
       animationIterationCount: 'infinite',
-      willChange: 'transform',
     }),
   };
 };


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

Fixes an issue when loading bar renders it shifts text.

Notice the red text above the bar graph as it's the most noticeable in the gif below.
Before:
![before-fix-loading-bar-text-blur](https://github.com/grafana/grafana/assets/39485579/84840cb9-ca7b-4a95-92d7-a3cc346d44dc)

After:
![fix-loading-bar-text-blur](https://github.com/grafana/grafana/assets/39485579/f4d4092c-a199-4bb2-8c69-cfd3db9b61d0)

**Why do we need this feature?**

Stops the shifting of text.
The shifting of text almost looks blurry, which makes it harder to read.

**Who is this feature for?**

Most would probably not notice, as it's pretty obscure and only seems to happen on Chromium based browsers.
It happens for any panel with some colored text (usually red-ish).

The main group would be those who use https://github.com/gapitio/gapit-htmlgraphics-panel, as it's very visible on SVG text elements.

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #82214

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
