### PR TITLE
Annotations: Fix axis markers rendering in wrong (stale) positions

### DIFF
--- a/public/app/plugins/panel/timeseries/plugins/AnnotationsPlugin2.tsx
+++ b/public/app/plugins/panel/timeseries/plugins/AnnotationsPlugin2.tsx
@@ -1,5 +1,5 @@
 import { css } from '@emotion/css';
-import React, { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
+import React, { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState, useReducer } from 'react';
 import { createPortal } from 'react-dom';
 import tinycolor from 'tinycolor2';
 import uPlot from 'uplot';
@@ -67,6 +67,8 @@ export const AnnotationsPlugin2 = ({
 
   const styles = useStyles2(getStyles);
   const getColorByName = useTheme2().visualization.getColorByName;
+
+  const [_, forceUpdate] = useReducer((x) => x + 1, 0);
 
   const annos = useMemo(() => {
     let annos = annotations.filter(
@@ -165,6 +167,13 @@ export const AnnotationsPlugin2 = ({
   useEffect(() => {
     if (plot) {
       plot.redraw();
+
+      // this forces a second redraw after uPlot is updated (in the Plot.tsx didUpdate) with new data/scales
+      // and ensures the anno marker positions in the dom are re-rendered in correct places
+      // (this is temp fix until uPlot integrtion is refactored)
+      setTimeout(() => {
+        forceUpdate();
+      }, 0);
     }
   }, [annos, plot]);
 


### PR DESCRIPTION
fixes a bug in `AnnotationsPlugin2` (which is behind `newVizTooltips` flag)

related:

- https://github.com/grafana/support-escalations/issues/9040
- https://github.com/grafana/support-escalations/issues/9105
- https://github.com/grafana/grafana/issues/81846
- https://github.com/grafana/grafana/issues/80588
- https://github.com/grafana/grafana/issues/75747 (maybe)

this work-around will be removed in the near-ish future when we refactor uPlot integration to cooperate better with React's rendering model and effects lifecycle.

<details><summary>anno-redraw-test.json</summary>

```json
{
  "annotations": {
    "list": [
      {
        "builtIn": 1,
        "datasource": {
          "type": "grafana",
          "uid": "-- Grafana --"
        },
        "enable": true,
        "hide": true,
        "iconColor": "rgba(0, 211, 255, 1)",
        "name": "Annotations & Alerts",
        "type": "dashboard"
      }
    ]
  },
  "editable": true,
  "fiscalYearStartMonth": 0,
  "graphTooltip": 0,
  "id": 937,
  "links": [],
  "liveNow": false,
  "panels": [
    {
      "datasource": {
        "type": "grafana-testdata-datasource",
        "uid": "PD8C576611E62080A"
      },
      "fieldConfig": {
        "defaults": {
          "color": {
            "mode": "palette-classic"
          },
          "custom": {
            "axisBorderShow": false,
            "axisCenteredZero": false,
            "axisColorMode": "text",
            "axisLabel": "",
            "axisPlacement": "auto",
            "barAlignment": 0,
            "drawStyle": "line",
            "fillOpacity": 0,
            "gradientMode": "none",
            "hideFrom": {
              "legend": false,
              "tooltip": false,
              "viz": false
            },
            "insertNulls": false,
            "lineInterpolation": "linear",
            "lineWidth": 1,
            "pointSize": 5,
            "scaleDistribution": {
              "type": "linear"
            },
            "showPoints": "auto",
            "spanNulls": false,
            "stacking": {
              "group": "A",
              "mode": "none"
            },
            "thresholdsStyle": {
              "mode": "off"
            }
          },
          "mappings": [],
          "thresholds": {
            "mode": "absolute",
            "steps": [
              {
                "color": "green",
                "value": null
              },
              {
                "color": "red",
                "value": 80
              }
            ]
          }
        },
        "overrides": []
      },
      "gridPos": {
        "h": 15,
        "w": 24,
        "x": 0,
        "y": 0
      },
      "id": 3,
      "maxDataPoints": 20,
      "options": {
        "legend": {
          "calcs": [],
          "displayMode": "list",
          "placement": "bottom",
          "showLegend": true
        },
        "tooltip": {
          "mode": "multi",
          "sort": "none"
        }
      },
      "targets": [
        {
          "datasource": {
            "type": "grafana-testdata-datasource",
            "uid": "PD8C576611E62080A"
          },
          "rawFrameContent": "[\n  {\n    \"schema\": {\n      \"refId\": \"A\",\n      \"meta\": {\n        \"typeVersion\": [\n          0,\n          0\n        ],\n        \"custom\": {\n          \"customStat\": 10\n        }\n      },\n      \"fields\": [\n        {\n          \"name\": \"time\",\n          \"type\": \"time\",\n          \"typeInfo\": {\n            \"frame\": \"time.Time\",\n            \"nullable\": true\n          },\n          \"config\": {\n            \"interval\": 1200000\n          }\n        },\n        {\n          \"name\": \"A-series\",\n          \"type\": \"number\",\n          \"typeInfo\": {\n            \"frame\": \"float64\",\n            \"nullable\": true\n          },\n          \"labels\": {},\n          \"config\": {}\n        }\n      ]\n    },\n    \"data\": {\n      \"values\": [\n        [\n          1707250365321,\n          1707251565321,\n          1707252765321,\n          1707253965321,\n          1707255165321,\n          1707256365321,\n          1707257565321,\n          1707258765321,\n          1707259965321,\n          1707261165321,\n          1707262365321,\n          1707263565321,\n          1707264765321,\n          1707265965321,\n          1707267165321,\n          1707268365321,\n          1707269565321,\n          1707270765321\n        ],\n        [\n          92.79656571947812,\n          92.76197850178745,\n          93.10165065496803,\n          93.26913660382614,\n          93.43946236743908,\n          93.33637076969687,\n          93.10370559258874,\n          93.38352348670988,\n          93.42535907181374,\n          93.06820719917222,\n          93.31956238969546,\n          92.92809366605007,\n          92.76344220508007,\n          92.52791114131088,\n          92.31617207250031,\n          92.02384063644877,\n          92.25522130877535,\n          92.56291825166703\n        ]\n      ]\n    }\n  },\n  {\n    \"schema\": {\n      \"refId\": \"A\",\n      \"meta\": {\n        \"typeVersion\": [\n          0,\n          0\n        ],\n        \"custom\": {\n          \"customStat\": 10\n        }\n      },\n      \"fields\": [\n        {\n          \"name\": \"time\",\n          \"type\": \"time\",\n          \"typeInfo\": {\n            \"frame\": \"time.Time\",\n            \"nullable\": true\n          },\n          \"config\": {\n            \"interval\": 1200000\n          }\n        },\n        {\n          \"name\": \"A-series1\",\n          \"type\": \"number\",\n          \"typeInfo\": {\n            \"frame\": \"float64\",\n            \"nullable\": true\n          },\n          \"labels\": {},\n          \"config\": {}\n        }\n      ]\n    },\n    \"data\": {\n      \"values\": [\n        [\n          1707250365321,\n          1707251565321,\n          1707252765321,\n          1707253965321,\n          1707255165321,\n          1707256365321,\n          1707257565321,\n          1707258765321,\n          1707259965321,\n          1707261165321,\n          1707262365321,\n          1707263565321,\n          1707264765321,\n          1707265965321,\n          1707267165321,\n          1707268365321,\n          1707269565321,\n          1707270765321\n        ],\n        [\n          92.79656571947812,\n          92.89741693062646,\n          92.42655560748541,\n          92.22768080793767,\n          92.31425171752231,\n          92.39719340066296,\n          92.77580929141085,\n          92.36827097440566,\n          92.86336292357439,\n          92.8417721909787,\n          93.1803962177981,\n          93.04868585737472,\n          93.24996250985836,\n          93.50791027907384,\n          93.82888650462313,\n          93.72072889476789,\n          94.0026234417734,\n          94.2247895062772\n        ]\n      ]\n    }\n  },\n  {\n    \"schema\": {\n      \"refId\": \"A\",\n      \"meta\": {\n        \"typeVersion\": [\n          0,\n          0\n        ],\n        \"custom\": {\n          \"customStat\": 10\n        }\n      },\n      \"fields\": [\n        {\n          \"name\": \"time\",\n          \"type\": \"time\",\n          \"typeInfo\": {\n            \"frame\": \"time.Time\",\n            \"nullable\": true\n          },\n          \"config\": {\n            \"interval\": 1200000\n          }\n        },\n        {\n          \"name\": \"A-series2\",\n          \"type\": \"number\",\n          \"typeInfo\": {\n            \"frame\": \"float64\",\n            \"nullable\": true\n          },\n          \"labels\": {},\n          \"config\": {}\n        }\n      ]\n    },\n    \"data\": {\n      \"values\": [\n        [\n          1707250365321,\n          1707251565321,\n          1707252765321,\n          1707253965321,\n          1707255165321,\n          1707256365321,\n          1707257565321,\n          1707258765321,\n          1707259965321,\n          1707261165321,\n          1707262365321,\n          1707263565321,\n          1707264765321,\n          1707265965321,\n          1707267165321,\n          1707268365321,\n          1707269565321,\n          1707270765321\n        ],\n        [\n          92.79656571947812,\n          92.3314320248304,\n          92.0929682232115,\n          92.46380532980335,\n          92.07947724760406,\n          91.98245387061296,\n          92.16848508923482,\n          92.65885289725475,\n          92.9609757647416,\n          93.11590234071664,\n          92.80123960632616,\n          93.05092451184359,\n          93.02151199702848,\n          93.29180454475231,\n          92.87411516053481,\n          93.09569853575115,\n          92.67454304066582,\n          93.11510943259742\n        ]\n      ]\n    }\n  },\n  {\n    \"schema\": {\n      \"refId\": \"A\",\n      \"meta\": {\n        \"typeVersion\": [\n          0,\n          0\n        ],\n        \"custom\": {\n          \"customStat\": 10\n        }\n      },\n      \"fields\": [\n        {\n          \"name\": \"time\",\n          \"type\": \"time\",\n          \"typeInfo\": {\n            \"frame\": \"time.Time\",\n            \"nullable\": true\n          },\n          \"config\": {\n            \"interval\": 1200000\n          }\n        },\n        {\n          \"name\": \"A-series3\",\n          \"type\": \"number\",\n          \"typeInfo\": {\n            \"frame\": \"float64\",\n            \"nullable\": true\n          },\n          \"labels\": {},\n          \"config\": {}\n        }\n      ]\n    },\n    \"data\": {\n      \"values\": [\n        [\n          1707250365321,\n          1707251565321,\n          1707252765321,\n          1707253965321,\n          1707255165321,\n          1707256365321,\n          1707257565321,\n          1707258765321,\n          1707259965321,\n          1707261165321,\n          1707262365321,\n          1707263565321,\n          1707264765321,\n          1707265965321,\n          1707267165321,\n          1707268365321,\n          1707269565321,\n          1707270765321\n        ],\n        [\n          92.79656571947812,\n          92.99907405711559,\n          92.62203274833543,\n          92.70387268156841,\n          92.91249871430652,\n          92.45668283030385,\n          92.5294884090769,\n          92.3380050267922,\n          92.40139624345889,\n          92.4005494723289,\n          92.65035929754346,\n          92.61398099984835,\n          92.83764684476417,\n          92.9668978773754,\n          93.3216354794767,\n          93.78019479775085,\n          93.45711770998678,\n          93.6282516584017\n        ]\n      ]\n    }\n  },\n  {\n    \"schema\": {\n      \"refId\": \"A\",\n      \"meta\": {\n        \"typeVersion\": [\n          0,\n          0\n        ],\n        \"custom\": {\n          \"customStat\": 10\n        }\n      },\n      \"fields\": [\n        {\n          \"name\": \"time\",\n          \"type\": \"time\",\n          \"typeInfo\": {\n            \"frame\": \"time.Time\",\n            \"nullable\": true\n          },\n          \"config\": {\n            \"interval\": 1200000\n          }\n        },\n        {\n          \"name\": \"A-series4\",\n          \"type\": \"number\",\n          \"typeInfo\": {\n            \"frame\": \"float64\",\n            \"nullable\": true\n          },\n          \"labels\": {},\n          \"config\": {}\n        }\n      ]\n    },\n    \"data\": {\n      \"values\": [\n        [\n          1707250365321,\n          1707251565321,\n          1707252765321,\n          1707253965321,\n          1707255165321,\n          1707256365321,\n          1707257565321,\n          1707258765321,\n          1707259965321,\n          1707261165321,\n          1707262365321,\n          1707263565321,\n          1707264765321,\n          1707265965321,\n          1707267165321,\n          1707268365321,\n          1707269565321,\n          1707270765321\n        ],\n        [\n          92.79656571947812,\n          92.72815684223364,\n          92.87512801617214,\n          93.00373613779465,\n          93.40765200704658,\n          93.26308504459467,\n          92.9814677881027,\n          92.99206090009055,\n          92.63321788407497,\n          92.86643112497414,\n          92.77641698830222,\n          92.49950671209099,\n          92.95403002445414,\n          92.60965857623634,\n          92.70070115314435,\n          92.30531912099828,\n          91.95992897426848,\n          92.30938681785464\n        ]\n      ]\n    }\n  },\n  {\n    \"schema\": {\n      \"refId\": \"A\",\n      \"meta\": {\n        \"typeVersion\": [\n          0,\n          0\n        ],\n        \"custom\": {\n          \"customStat\": 10\n        }\n      },\n      \"fields\": [\n        {\n          \"name\": \"time\",\n          \"type\": \"time\",\n          \"typeInfo\": {\n            \"frame\": \"time.Time\",\n            \"nullable\": true\n          },\n          \"config\": {\n            \"interval\": 1200000\n          }\n        },\n        {\n          \"name\": \"A-series5\",\n          \"type\": \"number\",\n          \"typeInfo\": {\n            \"frame\": \"float64\",\n            \"nullable\": true\n          },\n          \"labels\": {},\n          \"config\": {}\n        }\n      ]\n    },\n    \"data\": {\n      \"values\": [\n        [\n          1707250365321,\n          1707251565321,\n          1707252765321,\n          1707253965321,\n          1707255165321,\n          1707256365321,\n          1707257565321,\n          1707258765321,\n          1707259965321,\n          1707261165321,\n          1707262365321,\n          1707263565321,\n          1707264765321,\n          1707265965321,\n          1707267165321,\n          1707268365321,\n          1707269565321,\n          1707270765321\n        ],\n        [\n          92.79656571947812,\n          93.12156086427626,\n          93.55606530664711,\n          93.77353853903406,\n          93.99302828888717,\n          94.00751541985049,\n          94.22010263635246,\n          93.75281058339733,\n          93.88636354351763,\n          94.07783591597988,\n          93.83950578427059,\n          93.77613145392493,\n          94.00620995818949,\n          93.76584262289012,\n          93.96921451742017,\n          94.10130466985939,\n          94.06933257986705,\n          94.35243224605577\n        ]\n      ]\n    }\n  },\n  {\n    \"schema\": {\n      \"refId\": \"A\",\n      \"meta\": {\n        \"typeVersion\": [\n          0,\n          0\n        ],\n        \"custom\": {\n          \"customStat\": 10\n        }\n      },\n      \"fields\": [\n        {\n          \"name\": \"time\",\n          \"type\": \"time\",\n          \"typeInfo\": {\n            \"frame\": \"time.Time\",\n            \"nullable\": true\n          },\n          \"config\": {\n            \"interval\": 1200000\n          }\n        },\n        {\n          \"name\": \"A-series6\",\n          \"type\": \"number\",\n          \"typeInfo\": {\n            \"frame\": \"float64\",\n            \"nullable\": true\n          },\n          \"labels\": {},\n          \"config\": {}\n        }\n      ]\n    },\n    \"data\": {\n      \"values\": [\n        [\n          1707250365321,\n          1707251565321,\n          1707252765321,\n          1707253965321,\n          1707255165321,\n          1707256365321,\n          1707257565321,\n          1707258765321,\n          1707259965321,\n          1707261165321,\n          1707262365321,\n          1707263565321,\n          1707264765321,\n          1707265965321,\n          1707267165321,\n          1707268365321,\n          1707269565321,\n          1707270765321\n        ],\n        [\n          92.79656571947812,\n          92.84432958740402,\n          93.28171326456908,\n          93.16474402853893,\n          92.92761347534959,\n          93.0994393607289,\n          93.05904535658028,\n          92.80565403094654,\n          93.01323433531334,\n          92.61525287732744,\n          92.724737095041,\n          92.39321597247948,\n          92.0749830362049,\n          91.94720190665224,\n          92.19767259661916,\n          92.07630927609011,\n          92.00083856556789,\n          91.97679271558212\n        ]\n      ]\n    }\n  },\n  {\n    \"schema\": {\n      \"refId\": \"A\",\n      \"meta\": {\n        \"typeVersion\": [\n          0,\n          0\n        ],\n        \"custom\": {\n          \"customStat\": 10\n        }\n      },\n      \"fields\": [\n        {\n          \"name\": \"time\",\n          \"type\": \"time\",\n          \"typeInfo\": {\n            \"frame\": \"time.Time\",\n            \"nullable\": true\n          },\n          \"config\": {\n            \"interval\": 1200000\n          }\n        },\n        {\n          \"name\": \"A-series7\",\n          \"type\": \"number\",\n          \"typeInfo\": {\n            \"frame\": \"float64\",\n            \"nullable\": true\n          },\n          \"labels\": {},\n          \"config\": {}\n        }\n      ]\n    },\n    \"data\": {\n      \"values\": [\n        [\n          1707250365321,\n          1707251565321,\n          1707252765321,\n          1707253965321,\n          1707255165321,\n          1707256365321,\n          1707257565321,\n          1707258765321,\n          1707259965321,\n          1707261165321,\n          1707262365321,\n          1707263565321,\n          1707264765321,\n          1707265965321,\n          1707267165321,\n          1707268365321,\n          1707269565321,\n          1707270765321\n        ],\n        [\n          92.79656571947812,\n          92.9572327424628,\n          92.85047883253797,\n          92.96005967293415,\n          93.3054626371252,\n          93.0127125126295,\n          93.42264911402395,\n          92.98018191080045,\n          92.69172283739337,\n          92.84515361353273,\n          92.56142965408394,\n          92.44265300032926,\n          92.78872719582061,\n          93.17546989442211,\n          93.47904445082293,\n          93.4826802403684,\n          93.62386217360255,\n          93.72789291585643\n        ]\n      ]\n    }\n  },\n  {\n    \"schema\": {\n      \"refId\": \"A\",\n      \"meta\": {\n        \"typeVersion\": [\n          0,\n          0\n        ],\n        \"custom\": {\n          \"customStat\": 10\n        }\n      },\n      \"fields\": [\n        {\n          \"name\": \"time\",\n          \"type\": \"time\",\n          \"typeInfo\": {\n            \"frame\": \"time.Time\",\n            \"nullable\": true\n          },\n          \"config\": {\n            \"interval\": 1200000\n          }\n        },\n        {\n          \"name\": \"A-series8\",\n          \"type\": \"number\",\n          \"typeInfo\": {\n            \"frame\": \"float64\",\n            \"nullable\": true\n          },\n          \"labels\": {},\n          \"config\": {}\n        }\n      ]\n    },\n    \"data\": {\n      \"values\": [\n        [\n          1707250365321,\n          1707251565321,\n          1707252765321,\n          1707253965321,\n          1707255165321,\n          1707256365321,\n          1707257565321,\n          1707258765321,\n          1707259965321,\n          1707261165321,\n          1707262365321,\n          1707263565321,\n          1707264765321,\n          1707265965321,\n          1707267165321,\n          1707268365321,\n          1707269565321,\n          1707270765321\n        ],\n        [\n          92.79656571947812,\n          92.37512937854554,\n          92.61394356581054,\n          92.63490631016572,\n          92.90579401563006,\n          92.48349941224917,\n          92.11767744319899,\n          92.34320923938695,\n          92.25777033896439,\n          91.93568091664561,\n          91.46928323937759,\n          91.47105334920839,\n          91.52058217847353,\n          91.1477475017906,\n          90.86532447027065,\n          90.75506936453137,\n          91.22981771303343,\n          90.77564321701522\n        ]\n      ]\n    }\n  },\n  {\n    \"schema\": {\n      \"refId\": \"A\",\n      \"meta\": {\n        \"typeVersion\": [\n          0,\n          0\n        ],\n        \"custom\": {\n          \"customStat\": 10\n        }\n      },\n      \"fields\": [\n        {\n          \"name\": \"time\",\n          \"type\": \"time\",\n          \"typeInfo\": {\n            \"frame\": \"time.Time\",\n            \"nullable\": true\n          },\n          \"config\": {\n            \"interval\": 1200000\n          }\n        },\n        {\n          \"name\": \"A-series9\",\n          \"type\": \"number\",\n          \"typeInfo\": {\n            \"frame\": \"float64\",\n            \"nullable\": true\n          },\n          \"labels\": {},\n          \"config\": {}\n        }\n      ]\n    },\n    \"data\": {\n      \"values\": [\n        [\n          1707250365321,\n          1707251565321,\n          1707252765321,\n          1707253965321,\n          1707255165321,\n          1707256365321,\n          1707257565321,\n          1707258765321,\n          1707259965321,\n          1707261165321,\n          1707262365321,\n          1707263565321,\n          1707264765321,\n          1707265965321,\n          1707267165321,\n          1707268365321,\n          1707269565321,\n          1707270765321\n        ],\n        [\n          92.79656571947812,\n          93.04740464901938,\n          92.98274758903217,\n          92.8701635773328,\n          92.79223588326735,\n          92.99412372246111,\n          93.02108782041383,\n          92.70268069114418,\n          92.8516804247861,\n          92.95613821522957,\n          93.22995143531197,\n          92.73565996326208,\n          92.60166550677192,\n          92.74677246104646,\n          92.56956136105576,\n          93.01222135058842,\n          92.92056514539674,\n          92.94588304394554\n        ]\n      ]\n    }\n  }\n]",
          "refId": "A",
          "scenarioId": "raw_frame"
        }
      ],
      "title": "Panel Title",
      "type": "timeseries"
    },
    {
      "datasource": {
        "type": "grafana-testdata-datasource",
        "uid": "PD8C576611E62080A"
      },
      "fieldConfig": {
        "defaults": {
          "color": {
            "mode": "palette-classic"
          },
          "custom": {
            "axisBorderShow": false,
            "axisCenteredZero": false,
            "axisColorMode": "text",
            "axisLabel": "",
            "axisPlacement": "auto",
            "barAlignment": 0,
            "drawStyle": "line",
            "fillOpacity": 0,
            "gradientMode": "none",
            "hideFrom": {
              "legend": false,
              "tooltip": false,
              "viz": false
            },
            "insertNulls": false,
            "lineInterpolation": "linear",
            "lineWidth": 1,
            "pointSize": 5,
            "scaleDistribution": {
              "type": "linear"
            },
            "showPoints": "auto",
            "spanNulls": false,
            "stacking": {
              "group": "A",
              "mode": "none"
            },
            "thresholdsStyle": {
              "mode": "off"
            }
          },
          "mappings": [],
          "thresholds": {
            "mode": "absolute",
            "steps": [
              {
                "color": "green",
                "value": null
              },
              {
                "color": "red",
                "value": 80
              }
            ]
          }
        },
        "overrides": []
      },
      "gridPos": {
        "h": 14,
        "w": 24,
        "x": 0,
        "y": 15
      },
      "id": 4,
      "maxDataPoints": 20,
      "options": {
        "legend": {
          "calcs": [],
          "displayMode": "list",
          "placement": "bottom",
          "showLegend": true
        },
        "tooltip": {
          "mode": "multi",
          "sort": "none"
        }
      },
      "targets": [
        {
          "datasource": {
            "type": "grafana-testdata-datasource",
            "uid": "PD8C576611E62080A"
          },
          "refId": "A",
          "scenarioId": "csv_metric_values",
          "stringInput": "5,5,5,5,5,5,5,5,"
        },
        {
          "datasource": {
            "type": "grafana-testdata-datasource",
            "uid": "PD8C576611E62080A"
          },
          "refId": "B",
          "scenarioId": "csv_metric_values",
          "stringInput": "10,10,10,10,10,10,10,10,"
        }
      ],
      "title": "Panel Title",
      "type": "timeseries"
    }
  ],
  "schemaVersion": 39,
  "tags": [],
  "templating": {
    "list": []
  },
  "time": {
    "from": "2024-02-06T20:12:45.000Z",
    "to": "2024-02-07T02:12:45.000Z"
  },
  "timepicker": {},
  "timezone": "browser",
  "title": "anno-redraw-test.json",
  "uid": "edbfe3l83zmkga",
  "version": 19,
  "weekStart": ""
}
```
</details>

before the fix (zooming in/out and changing time range, anything that re-issued the anno queries):

https://github.com/grafana/grafana/assets/43234/18c15898-2e3a-4800-a8c8-95a3477f7e6f