### PR TITLE
Variable: Inform users of the error details when Grafana is unable to retrieve the variable values from an SQL data source.

### DIFF
--- a/packages/grafana-sql/src/datasource/SqlDatasource.ts
+++ b/packages/grafana-sql/src/datasource/SqlDatasource.ts
@@ -28,8 +28,8 @@ import {
   toDataQueryResponse,
   TemplateSrv,
   reportInteraction,
+  getAppEvents,
 } from '@grafana/runtime';
-import appEvents from 'app/core/app_events';
 
 import { ResponseParser } from '../ResponseParser';
 import { SqlQueryEditor } from '../components/QueryEditor';
@@ -216,7 +216,7 @@ export abstract class SqlDatasource extends DataSourceWithBackend<SQLQuery, SQLO
     } catch (error) {
       let response = error as FetchResponse<BackendDataSourceResponse>;
       // Publish the error info to notify users
-      appEvents.publish({
+      getAppEvents().publish({
         type: AppEvents.alertError.name,
         payload: [`Fail to load values of the variable ${refId}`, response.data.results?.[refId]?.error],
       });

--- a/packages/grafana-sql/src/datasource/SqlDatasource.ts
+++ b/packages/grafana-sql/src/datasource/SqlDatasource.ts
@@ -213,7 +213,7 @@ export abstract class SqlDatasource extends DataSourceWithBackend<SQLQuery, SQLO
       response = await this.runMetaQuery(interpolatedQuery, range);
     } catch (error) {
       console.error(error);
-      throw new Error(`error when executing the sql query`);
+      throw new Error("error when executing the sql query");
     }
     return this.getResponseParser().transformMetricFindResponse(response);
   }

--- a/packages/grafana-sql/src/datasource/SqlDatasource.ts
+++ b/packages/grafana-sql/src/datasource/SqlDatasource.ts
@@ -16,7 +16,6 @@ import {
   LegacyMetricFindQueryOptions,
   VariableWithMultiSupport,
   TimeRange,
-  AppEvents,
 } from '@grafana/data';
 import { EditorMode } from '@grafana/experimental';
 import {
@@ -28,7 +27,6 @@ import {
   toDataQueryResponse,
   TemplateSrv,
   reportInteraction,
-  getAppEvents,
 } from '@grafana/runtime';
 
 import { ResponseParser } from '../ResponseParser';
@@ -210,18 +208,14 @@ export abstract class SqlDatasource extends DataSourceWithBackend<SQLQuery, SQLO
       format: QueryFormat.Table,
     };
 
+    let response;
     try {
-      const response = await this.runMetaQuery(interpolatedQuery, range);
-      return this.getResponseParser().transformMetricFindResponse(response);
+      response = await this.runMetaQuery(interpolatedQuery, range);
     } catch (error) {
-      let response = error as FetchResponse<BackendDataSourceResponse>;
-      // Publish the error info to notify users
-      getAppEvents().publish({
-        type: AppEvents.alertError.name,
-        payload: [`Fail to load values of the variable ${refId}`, response.data.results?.[refId]?.error],
-      });
-      throw error;
+      console.error(error);
+      throw new Error(`error when executing the sql query`);
     }
+    return this.getResponseParser().transformMetricFindResponse(response);
   }
 
   // NOTE: this always runs with the `@grafana/data/getDefaultTimeRange` time range

--- a/packages/grafana-sql/src/datasource/SqlDatasource.ts
+++ b/packages/grafana-sql/src/datasource/SqlDatasource.ts
@@ -213,7 +213,7 @@ export abstract class SqlDatasource extends DataSourceWithBackend<SQLQuery, SQLO
       response = await this.runMetaQuery(interpolatedQuery, range);
     } catch (error) {
       console.error(error);
-      throw new Error("error when executing the sql query");
+      throw new Error('error when executing the sql query');
     }
     return this.getResponseParser().transformMetricFindResponse(response);
   }

--- a/packages/grafana-sql/src/datasource/SqlDatasource.ts
+++ b/packages/grafana-sql/src/datasource/SqlDatasource.ts
@@ -210,17 +210,17 @@ export abstract class SqlDatasource extends DataSourceWithBackend<SQLQuery, SQLO
       format: QueryFormat.Table,
     };
 
-    try{
+    try {
       const response = await this.runMetaQuery(interpolatedQuery, range);
       return this.getResponseParser().transformMetricFindResponse(response);
-    }catch (error){
-      let response  = error as FetchResponse<BackendDataSourceResponse>
+    } catch (error) {
+      let response = error as FetchResponse<BackendDataSourceResponse>;
       // Publish the error info to notify users
       appEvents.publish({
         type: AppEvents.alertError.name,
         payload: [`Fail to load values of the variable ${refId}`, response.data.results?.[refId]?.error],
       });
-      throw error
+      throw error;
     }
   }
 


### PR DESCRIPTION
**What is this feature?**

Inform users of the error details when Grafana is unable to retrieve the variable values from an SQL data source.

**Why do we need this feature?**

While using the MySQL data source to fetch variable values, I found that no notifications were generated even in the presence of syntax errors. Simultaneously, the list of variable values was displayed as empty, which could potentially mislead users. This absence of error notifications significantly hampers users' ability to identify and rectify the issue.

It is evident that we need to provide clear error information to users, enabling them to take corrective actions based on the specific error details. So I added the notification below:

In the Variable editing page:
![303540140-5fe46a61-0e90-4cb3-bf4b-ebc5fec1fc9c](https://github.com/grafana/grafana/assets/49775184/69f28347-d523-4ea5-b372-df84a53f6c46)

In the dashboard page:
![303542217-1fb14ef5-c1e5-4be3-a428-64c06129ba0e](https://github.com/grafana/grafana/assets/49775184/d4aaca25-2f8b-47f7-aceb-d4261d3ece9c)

**Who is this feature for?**

users who uses Variable with MySQL data source

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
