### PR TITLE
Explore: Add e2e selector to panels

### DIFF
--- a/public/app/features/explore/ContentOutline/ContentOutlineItem.tsx
+++ b/public/app/features/explore/ContentOutline/ContentOutlineItem.tsx
@@ -1,5 +1,7 @@
 import React, { useEffect, useRef, ReactNode } from 'react';
 
+import { selectors } from '@grafana/e2e-selectors';
+
 import { useContentOutlineContext } from './ContentOutlineContext';
 
 export interface ContentOutlineItemBaseProps {
@@ -25,7 +27,7 @@ export function ContentOutlineItem({ title, icon, children, className }: Content
   }, [title, icon, register, unregister]);
 
   return (
-    <div className={className} ref={ref}>
+    <div className={className} ref={ref} data-testid={selectors.components.Panels.Panel.title(title)}>
       {children}
     </div>
   );


### PR DESCRIPTION
**What is this feature?**

I'm working on a [package](https://github.com/grafana/plugin-tools/tree/main/packages/plugin-e2e) that enables testing Grafana plugins across multiple versions of Grafana. While working on this, it's been hard providing a good experience within Explore as the e2e-selectors for the panels keep changing from one Grafana version to another. 

This PR adds a `data-testid` selector to the panel wrapper in Explore. For some of the panels, this means the same data-testid will be rendered twice but on different levels. But that is fine - data-testid doesn't have to be unique - we just need a consistent way of locating an element in e2e tests.

**Who is this feature for?**

Plugin authors

**Which issue(s) does this PR fix?**:


<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #https://github.com/grafana/plugin-tools/issues/728
Part of https://github.com/grafana/grafana/issues/77484

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
