### PR TITLE
Docs: making docs clearer on subpath

### DIFF
--- a/docs/sources/tutorials/run-grafana-behind-a-proxy/index.md
+++ b/docs/sources/tutorials/run-grafana-behind-a-proxy/index.md
@@ -34,23 +34,9 @@ domain = example.com
 
 - Restart Grafana for the new changes to take effect.
 
-You can also serve Grafana behind a _sub path_, such as `http://example.com/grafana`.
+## Configure Reverse Proxy
 
-To serve Grafana behind a sub path:
-
-1. Include the sub path at the end of the `root_url`.
-1. Set `serve_from_sub_path` to `true`. Or, let proxy rewrite the path for you (refer to examples below).
-
-```bash
-[server]
-domain = example.com
-root_url = %(protocol)s://%(domain)s:%(http_port)s/grafana/
-serve_from_sub_path = true
-```
-
-Next, you need to configure your reverse proxy.
-
-## Configure NGINX
+### Configure NGINX
 
 [NGINX](https://www.nginx.com) is a high performance load balancer, web server, and reverse proxy.
 
@@ -129,7 +115,7 @@ server {
 }
 ```
 
-If your Grafana configuration does not set `serve_from_sub_path` to true then you need to add a rewrite rule to each location block:
+Add a rewrite rule to each location block:
 
 ```
  rewrite  ^/grafana/(.*)  /$1 break;
@@ -139,7 +125,7 @@ If your Grafana configuration does not set `serve_from_sub_path` to true then yo
 If Grafana is being served from behind a NGINX proxy with TLS termination enabled, then the `root_url` should be set accordingly. For example, if Grafana is being served from `https://example.com/grafana` then the `root_url` should be set to `https://example.com/grafana/` or `https://%(domain)s/grafana/` (and the corresponding `domain` should be set to `example.com`) in the `server` section of the Grafana configuration file. The `protocol` setting should be set to `http`, because the TLS handshake is being handled by NGINX.
 {{% /admonition %}}
 
-## Configure HAProxy
+### Configure HAProxy
 
 To configure HAProxy to serve Grafana under a _sub path_:
 
@@ -150,22 +136,15 @@ frontend http-in
 
 backend grafana_backend
   server grafana localhost:3000
-```
-
-If your Grafana configuration doesn't set `server.serve_from_sub_path` to `true`, then you must add a rewrite rule to the `backend grafana_backend` block:
-
-```diff
-backend grafana_backend
-+  # Requires haproxy >= 1.6
-+  http-request set-path %[path,regsub(^/grafana/?,/)]
-
-+  # Works for haproxy < 1.6
-+  # reqrep ^([^\ ]*\ /)grafana[/]?(.*) \1\2
+  # Requires haproxy >= 1.6
+  http-request set-path %[path,regsub(^/grafana/?,/)]
+  # Works for haproxy < 1.6
+  # reqrep ^([^\ ]*\ /)grafana[/]?(.*) \1\2
 
   server grafana localhost:3000
 ```
 
-## Configure IIS
+### Configure IIS
 
 > IIS requires that the URL Rewrite module is installed.
 
@@ -192,7 +171,7 @@ This is the rewrite rule that is generated in the `web.config`:
 
 See the [tutorial on IIS URL Rewrites](/tutorials/iis/) for more in-depth instructions.
 
-## Configure Traefik
+### Configure Traefik
 
 [Traefik](https://traefik.io/traefik/) Cloud Native Reverse Proxy / Load Balancer / Edge Router
 
@@ -240,6 +219,17 @@ http:
           - url: http://192.168.30.10:3000
 ```
 
-## Summary
+## Alternative for serving Grafana under a sub path
+**Warning:** You only need this, if you do not handle the sub path serving via your reverse proxy configuration.
 
-In this tutorial you learned how to run Grafana behind a reverse proxy.
+If you don't want or can not use the reverse proxy to handle serving Grafana from a _sub path_, you can set the config variable `server_from_sub_path` to `true`
+
+1. Include the sub path at the end of the `root_url`.
+2. Set `serve_from_sub_path` to `true`
+
+```bash
+[server]
+domain = example.com
+root_url = %(protocol)s://%(domain)s:%(http_port)s/grafana/
+serve_from_sub_path = true
+```

--- a/docs/sources/tutorials/run-grafana-behind-a-proxy/index.md
+++ b/docs/sources/tutorials/run-grafana-behind-a-proxy/index.md
@@ -34,7 +34,7 @@ domain = example.com
 
 - Restart Grafana for the new changes to take effect.
 
-## Configure Reverse Proxy
+## Configure reverse proxy
 
 ### Configure NGINX
 

--- a/docs/sources/tutorials/run-grafana-behind-a-proxy/index.md
+++ b/docs/sources/tutorials/run-grafana-behind-a-proxy/index.md
@@ -222,7 +222,7 @@ http:
 ## Alternative for serving Grafana under a sub path
 **Warning:** You only need this if you don't handle the sub path serving via your reverse proxy configuration.
 
-If you don't want or can not use the reverse proxy to handle serving Grafana from a _sub path_, you can set the config variable `server_from_sub_path` to `true`
+If you don't want or can't use the reverse proxy to handle serving Grafana from a _sub path_, you can set the config variable `server_from_sub_path` to `true`.
 
 1. Include the sub path at the end of the `root_url`.
 2. Set `serve_from_sub_path` to `true`:

--- a/docs/sources/tutorials/run-grafana-behind-a-proxy/index.md
+++ b/docs/sources/tutorials/run-grafana-behind-a-proxy/index.md
@@ -220,7 +220,8 @@ http:
 ```
 
 ## Alternative for serving Grafana under a sub path
-**Warning:** You only need this if you don't handle the sub path serving via your reverse proxy configuration.
+
+**Warning:** You only need this, if you do not handle the sub path serving via your reverse proxy configuration.
 
 If you don't want or can't use the reverse proxy to handle serving Grafana from a _sub path_, you can set the config variable `server_from_sub_path` to `true`.
 

--- a/docs/sources/tutorials/run-grafana-behind-a-proxy/index.md
+++ b/docs/sources/tutorials/run-grafana-behind-a-proxy/index.md
@@ -220,7 +220,7 @@ http:
 ```
 
 ## Alternative for serving Grafana under a sub path
-**Warning:** You only need this, if you do not handle the sub path serving via your reverse proxy configuration.
+**Warning:** You only need this if you don't handle the sub path serving via your reverse proxy configuration.
 
 If you don't want or can not use the reverse proxy to handle serving Grafana from a _sub path_, you can set the config variable `server_from_sub_path` to `true`
 

--- a/docs/sources/tutorials/run-grafana-behind-a-proxy/index.md
+++ b/docs/sources/tutorials/run-grafana-behind-a-proxy/index.md
@@ -225,7 +225,7 @@ http:
 If you don't want or can not use the reverse proxy to handle serving Grafana from a _sub path_, you can set the config variable `server_from_sub_path` to `true`
 
 1. Include the sub path at the end of the `root_url`.
-2. Set `serve_from_sub_path` to `true`
+2. Set `serve_from_sub_path` to `true`:
 
 ```bash
 [server]


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

Following up on https://github.com/grafana/grafana/pull/81658


**Why do we need this feature?**
This tutorial has been a source of confusion and multiple issues in the past, trying to make it clear that it's either - handle the sub path in the proxy OR set the `service_from_sub_path` to `true`. Most get confused and do both.

**Who is this feature for?**
Grafana Administrators in the wild
 
**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->


