### PR TITLE
Alerting: Improve 404 and other HTTP request error handling

### DIFF
--- a/public/app/features/alerting/unified/RuleViewer.tsx
+++ b/public/app/features/alerting/unified/RuleViewer.tsx
@@ -1,9 +1,10 @@
 import React from 'react';
 
 import { NavModelItem } from '@grafana/data';
-import { config } from '@grafana/runtime';
+import { config, isFetchError } from '@grafana/runtime';
 import { Alert, withErrorBoundary } from '@grafana/ui';
 import { SafeDynamicImport } from 'app/core/components/DynamicImports/SafeDynamicImport';
+import { EntityNotFound } from 'app/core/components/PageNotFound/EntityNotFound';
 import { GrafanaRouteComponentProps } from 'app/core/navigation/types';
 
 import { AlertingPageWrapper } from './components/AlertingPageWrapper';
@@ -52,7 +53,7 @@ const RuleViewerV2Wrapper = (props: RuleViewerProps) => {
   if (error) {
     return (
       <AlertingPageWrapper pageNav={defaultPageNav} navId="alert-list">
-        <Alert title={'Something went wrong loading the rule'}>{stringifyErrorLike(error)}</Alert>
+        <ErrorMessage error={error} />
       </AlertingPageWrapper>
     );
   }
@@ -75,5 +76,17 @@ const RuleViewerV2Wrapper = (props: RuleViewerProps) => {
 
   return null;
 };
+
+interface ErrorMessageProps {
+  error: unknown;
+}
+
+function ErrorMessage({ error }: ErrorMessageProps) {
+  if (isFetchError(error) && error.status === 404) {
+    return <EntityNotFound entity="Rule" />;
+  }
+
+  return <Alert title={'Something went wrong loading the rule'}>{stringifyErrorLike(error)}</Alert>;
+}
 
 export default withErrorBoundary(RuleViewer, { style: 'page' });

--- a/public/app/features/alerting/unified/utils/misc.ts
+++ b/public/app/features/alerting/unified/utils/misc.ts
@@ -2,7 +2,7 @@ import { sortBy } from 'lodash';
 
 import { UrlQueryMap, Labels } from '@grafana/data';
 import { GrafanaEdition } from '@grafana/data/src/types/config';
-import { config } from '@grafana/runtime';
+import { config, isFetchError } from '@grafana/runtime';
 import { DataSourceRef } from '@grafana/schema';
 import { escapePathSeparators } from 'app/features/alerting/unified/utils/rule-id';
 import { alertInstanceKey } from 'app/features/alerting/unified/utils/rules';
@@ -231,5 +231,10 @@ export function isErrorLike(error: unknown): error is Error {
 }
 
 export function stringifyErrorLike(error: unknown): string {
+  const fetchError = isFetchError(error);
+  if (fetchError) {
+    return error.data.message;
+  }
+
   return isErrorLike(error) ? error.message : String(error);
 }


### PR DESCRIPTION
This PR adds some additional error message decoding to the new alert detail view;

1. when the error is a `FetchError` we decode the messsage properly
2. when a 404 is returned we render the `EntityNotFound` component

<img width="1197" alt="image" src="https://github.com/grafana/grafana/assets/868844/b5478eb4-88a7-428c-8a42-2387fc15144d">

Related to #72731