### PR TITLE
Keybindings: Change 'h' to 'mod+h' to open help modal

### DIFF
--- a/.betterer.results
+++ b/.betterer.results
@@ -1296,16 +1296,6 @@ exports[`better eslint`] = {
       [0, 0, 0, "Unexpected any. Specify a different type.", "0"],
       [0, 0, 0, "Do not use any type assertions.", "1"]
     ],
-    "public/app/core/components/help/HelpModal.tsx:5381": [
-      [0, 0, 0, "Styles should be written using objects.", "0"],
-      [0, 0, 0, "Styles should be written using objects.", "1"],
-      [0, 0, 0, "Styles should be written using objects.", "2"],
-      [0, 0, 0, "Styles should be written using objects.", "3"],
-      [0, 0, 0, "Styles should be written using objects.", "4"],
-      [0, 0, 0, "Styles should be written using objects.", "5"],
-      [0, 0, 0, "Styles should be written using objects.", "6"],
-      [0, 0, 0, "Styles should be written using objects.", "7"]
-    ],
     "public/app/core/navigation/types.ts:5381": [
       [0, 0, 0, "Unexpected any. Specify a different type.", "0"]
     ],

--- a/public/app/core/components/help/HelpModal.tsx
+++ b/public/app/core/components/help/HelpModal.tsx
@@ -27,7 +27,7 @@ const getShortcuts = (modKey: string) => {
           description: t('help-modal.shortcuts-description.exit-edit/setting-views', 'Exit edit/setting views'),
         },
         {
-          keys: ['h'],
+          keys: [`${modKey} + h`],
           description: t('help-modal.shortcuts-description.show-all-shortcuts', 'Show all keyboard shortcuts'),
         },
         { keys: ['c', 't'], description: t('help-modal.shortcuts-description.change-theme', 'Change theme') },
@@ -177,60 +177,55 @@ export const HelpModal = ({ onDismiss }: HelpModalProps): JSX.Element => {
 
 function getStyles(theme: GrafanaTheme2) {
   return {
-    titleDescription: css`
-      font-size: ${theme.typography.bodySmall.fontSize};
-      font-weight: ${theme.typography.bodySmall.fontWeight};
-      color: ${theme.colors.text.disabled};
-      padding-bottom: ${theme.spacing(2)};
-    `,
-    categories: css`
-      font-size: ${theme.typography.bodySmall.fontSize};
-      display: flex;
-      flex-flow: row wrap;
-      justify-content: space-between;
-      align-items: flex-start;
-    `,
-    shortcutCategory: css`
-      width: 50%;
-      font-size: ${theme.typography.bodySmall.fontSize};
-    `,
-    shortcutTable: css`
-      margin-bottom: ${theme.spacing(2)};
-    `,
-    shortcutTableCategoryHeader: css`
-      font-weight: normal;
-      font-size: ${theme.typography.h6.fontSize};
-      text-align: left;
-    `,
-    shortcutTableDescription: css`
-      text-align: left;
-      color: ${theme.colors.text.disabled};
-      width: 99%;
-      padding: ${theme.spacing(1, 2)};
-    `,
-    shortcutTableKeys: css`
-      white-space: nowrap;
-      width: 1%;
-      text-align: right;
-      color: ${theme.colors.text.primary};
-    `,
-    shortcutTableKey: css`
-      display: inline-block;
-      text-align: center;
-      margin-right: ${theme.spacing(0.5)};
-      padding: 3px 5px;
-      font:
-        11px Consolas,
-        'Liberation Mono',
-        Menlo,
-        Courier,
-        monospace;
-      line-height: 10px;
-      vertical-align: middle;
-      border: solid 1px ${theme.colors.border.medium};
-      border-radius: ${theme.shape.borderRadius(3)};
-      color: ${theme.colors.text.primary};
-      background-color: ${theme.colors.background.secondary};
-    `,
+    titleDescription: css({
+      fontSize: theme.typography.bodySmall.fontSize,
+      fontWeight: theme.typography.bodySmall.fontWeight,
+      color: theme.colors.text.disabled,
+      paddingBottom: theme.spacing(2),
+    }),
+    categories: css({
+      fontSize: theme.typography.bodySmall.fontSize,
+      display: 'flex',
+      flexFlow: 'row wrap',
+      justifyContent: 'space-between',
+      alignItems: 'flex-start',
+    }),
+    shortcutCategory: css({
+      width: '50%',
+      fontSize: theme.typography.bodySmall.fontSize,
+    }),
+    shortcutTable: css({
+      marginBottom: theme.spacing(2),
+    }),
+    shortcutTableCategoryHeader: css({
+      fontWeight: 'normal',
+      fontSize: theme.typography.h6.fontSize,
+      textAlign: 'left',
+    }),
+    shortcutTableDescription: css({
+      textAlign: 'left',
+      color: theme.colors.text.disabled,
+      width: '99%',
+      padding: theme.spacing(1, 2),
+    }),
+    shortcutTableKeys: css({
+      whiteSpace: 'nowrap',
+      width: '1%',
+      textAlign: 'right',
+      color: theme.colors.text.primary,
+    }),
+    shortcutTableKey: css({
+      display: 'inline-block',
+      textAlign: 'center',
+      marginRight: theme.spacing(0.5),
+      padding: '3px 5px',
+      font: "11px Consolas, 'Liberation Mono', Menlo, Courier, monospace",
+      lineHeight: '10px',
+      verticalAlign: 'middle',
+      border: `solid 1px ${theme.colors.border.medium}`,
+      borderRadius: theme.shape.radius.default,
+      color: theme.colors.text.primary,
+      backgroundColor: theme.colors.background.secondary,
+    }),
   };
 }

--- a/public/app/core/services/keybindingSrv.ts
+++ b/public/app/core/services/keybindingSrv.ts
@@ -40,7 +40,7 @@ export class KeybindingSrv {
 
     // Chromeless pages like login and signup page don't get any global bindings
     if (!route.chromeless) {
-      this.bind(['?', 'h'], this.showHelpModal);
+      this.bind(['?', 'mod+h'], this.showHelpModal);
       this.bind('g h', this.goToHome);
       this.bind('g d', this.goToDashboards);
       this.bind('g e', this.goToExplore);


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**
Updates the help modal to open on `mod+h` instead of just `h`.

Some other cleanup updates:
- Use CSS object for styles
- Use `theme.shape.radius.default` for displaying keys instead of `borderRadius(3)`

**Why do we need this feature?**

WCAG recommendation is that a modifier is needed, as having just a single character may interfere with assistive technologies.

**Who is this feature for?**
Mainly keyboard users


Fixes #74841

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
