### PR TITLE
LibraryPanels: Fix issue with repeated library panels

### DIFF
--- a/public/app/features/panel/state/actions.ts
+++ b/public/app/features/panel/state/actions.ts
@@ -147,15 +147,16 @@ export function loadLibraryPanelAndUpdate(panel: PanelModel): ThunkResult<void> 
     try {
       const libPanel = await getLibraryPanel(uid, true);
       panel.initLibraryPanel(libPanel);
-      await dispatch(initPanelState(panel));
-      const dashboard = getStore().dashboard.getModel();
 
+      const dashboard = getStore().dashboard.getModel();
       if (panel.repeat && dashboard) {
         const panelIndex = dashboard.panels.findIndex((p) => p.id === panel.id);
         dashboard.repeatPanel(panel, panelIndex);
         dashboard.sortPanelsByGridPos();
         dashboard.events.publish(new DashboardPanelsChangedEvent());
       }
+
+      await dispatch(initPanelState(panel));
     } catch (ex) {
       console.log('ERROR: ', ex);
       dispatch(


### PR DESCRIPTION
Fixes an issue where a library panel being repeated by a template variable would briefly use the `All` value for the first repeat instance.
