### PR TITLE
K8s: StackIDs can be single digits

### DIFF
--- a/pkg/services/apiserver/endpoints/request/namespace.go
+++ b/pkg/services/apiserver/endpoints/request/namespace.go
@@ -68,7 +68,7 @@ func ParseNamespace(ns string) (NamespaceInfo, error) {
 
 	if strings.HasPrefix(ns, "stack-") {
 		info.StackID = ns[6:]
-		if len(info.StackID) < 2 {
+		if len(info.StackID) < 1 {
 			return info, fmt.Errorf("invalid stack id")
 		}
 		info.OrgID = 1

--- a/pkg/services/apiserver/endpoints/request/namespace_test.go
+++ b/pkg/services/apiserver/endpoints/request/namespace_test.go
@@ -94,11 +94,11 @@ func TestParseNamespace(t *testing.T) {
 		},
 		{
 			name:      "invalid stack id (too short)",
-			namespace: "stack-1",
+			namespace: "stack-",
 			expectErr: true,
 			expected: request.NamespaceInfo{
 				OrgID:   -1,
-				StackID: "1",
+				StackID: "",
 			},
 		},
 		{


### PR DESCRIPTION
**What is this feature?**

This PR allows stackIDs as specified in the k8s namespace to be in the single digits
