### PR TITLE
Alerting: Return provenance of notification templates

### DIFF
--- a/pkg/services/ngalert/api/api_provisioning.go
+++ b/pkg/services/ngalert/api/api_provisioning.go
@@ -38,7 +38,7 @@ type ContactPointService interface {
 }
 
 type TemplateService interface {
-	GetTemplates(ctx context.Context, orgID int64) (map[string]string, error)
+	GetTemplates(ctx context.Context, orgID int64) ([]definitions.NotificationTemplate, error)
 	SetTemplate(ctx context.Context, orgID int64, tmpl definitions.NotificationTemplate) (definitions.NotificationTemplate, error)
 	DeleteTemplate(ctx context.Context, orgID int64, name string) error
 }
@@ -201,11 +201,7 @@ func (srv *ProvisioningSrv) RouteGetTemplates(c *contextmodel.ReqContext) respon
 	if err != nil {
 		return ErrResp(http.StatusInternalServerError, err, "")
 	}
-	result := make([]definitions.NotificationTemplate, 0, len(templates))
-	for k, v := range templates {
-		result = append(result, definitions.NotificationTemplate{Name: k, Template: v})
-	}
-	return response.JSON(http.StatusOK, result)
+	return response.JSON(http.StatusOK, templates)
 }
 
 func (srv *ProvisioningSrv) RouteGetTemplate(c *contextmodel.ReqContext, name string) response.Response {
@@ -213,8 +209,10 @@ func (srv *ProvisioningSrv) RouteGetTemplate(c *contextmodel.ReqContext, name st
 	if err != nil {
 		return ErrResp(http.StatusInternalServerError, err, "")
 	}
-	if tmpl, ok := templates[name]; ok {
-		return response.JSON(http.StatusOK, definitions.NotificationTemplate{Name: name, Template: tmpl})
+	for _, tmpl := range templates {
+		if tmpl.Name == name {
+			return response.JSON(http.StatusOK, tmpl)
+		}
 	}
 	return response.Empty(http.StatusNotFound)
 }

--- a/pkg/services/ngalert/provisioning/templates.go
+++ b/pkg/services/ngalert/provisioning/templates.go
@@ -25,17 +25,27 @@ func NewTemplateService(config AMConfigStore, prov ProvisioningStore, xact Trans
 	}
 }
 
-func (t *TemplateService) GetTemplates(ctx context.Context, orgID int64) (map[string]string, error) {
+func (t *TemplateService) GetTemplates(ctx context.Context, orgID int64) ([]definitions.NotificationTemplate, error) {
 	revision, err := t.configStore.Get(ctx, orgID)
 	if err != nil {
 		return nil, err
 	}
 
-	if revision.cfg.TemplateFiles == nil {
-		return map[string]string{}, nil
+	var templates []definitions.NotificationTemplate
+	for name, tmpl := range revision.cfg.TemplateFiles {
+		tmpl := definitions.NotificationTemplate{
+			Name:     name,
+			Template: tmpl,
+		}
+		provenance, err := t.provenanceStore.GetProvenance(ctx, &tmpl, orgID)
+		if err != nil {
+			return nil, err
+		}
+		tmpl.Provenance = definitions.Provenance(provenance)
+		templates = append(templates, tmpl)
 	}
 
-	return revision.cfg.TemplateFiles, nil
+	return templates, nil
 }
 
 func (t *TemplateService) SetTemplate(ctx context.Context, orgID int64, tmpl definitions.NotificationTemplate) (definitions.NotificationTemplate, error) {

--- a/pkg/services/ngalert/provisioning/templates_test.go
+++ b/pkg/services/ngalert/provisioning/templates_test.go
@@ -21,6 +21,7 @@ func TestTemplateService(t *testing.T) {
 			GetsConfig(models.AlertConfiguration{
 				AlertmanagerConfiguration: configWithTemplates,
 			})
+		sut.provenanceStore.(*MockProvisioningStore).EXPECT().GetProvenance(mock.Anything, mock.Anything, mock.Anything).Return(models.ProvenanceAPI, nil)
 
 		result, err := sut.GetTemplates(context.Background(), 1)
 


### PR DESCRIPTION
I noticed that this endpoint, unlike other provisioning endpoints, does not return the provenance in the GET operations (while setting it does work).
This PR should add it to the response by building the `NotificationTemplate` objects in the service, and setting the provenance there, rather than building the object in the API, where the provenance is unavailable
