### PR TITLE
datatrails: fix: improve performance of related metrics sort

### DIFF
--- a/public/app/features/trails/MetricSelectScene.tsx
+++ b/public/app/features/trails/MetricSelectScene.tsx
@@ -1,5 +1,4 @@
 import { css } from '@emotion/css';
-import leven from 'leven';
 import { debounce } from 'lodash';
 import React, { useCallback } from 'react';
 
@@ -29,6 +28,7 @@ import { MetricCategoryCascader } from './MetricCategory/MetricCategoryCascader'
 import { MetricScene } from './MetricScene';
 import { SelectMetricAction } from './SelectMetricAction';
 import { hideEmptyPreviews } from './hideEmptyPreviews';
+import { sortRelatedMetrics } from './relatedMetrics';
 import { getVariablesWithMetricConstant, trailDS, VAR_DATASOURCE, VAR_FILTERS_EXPR, VAR_METRIC_NAMES } from './shared';
 import { getColorByIndex, getTrailFor } from './utils';
 
@@ -429,22 +429,6 @@ function getCardPanelFor(metric: string) {
     .setHeaderActions(new SelectMetricAction({ metric, title: 'Select' }))
     .setOption('content', '')
     .build();
-}
-
-// Computes the Levenshtein distance between two strings, twice, once for the first half and once for the whole string.
-function sortRelatedMetrics(metricList: string[], metric: string) {
-  return metricList.sort((aValue, bValue) => {
-    const aSplit = aValue.split('_');
-    const aHalf = aSplit.slice(0, aSplit.length / 2).join('_');
-
-    const bSplit = bValue.split('_');
-    const bHalf = bSplit.slice(0, bSplit.length / 2).join('_');
-
-    return (
-      (leven(aHalf, metric!) || 0 + (leven(aValue, metric!) || 0)) -
-      (leven(bHalf, metric!) || 0 + (leven(bValue, metric!) || 0))
-    );
-  });
 }
 
 function getStyles(theme: GrafanaTheme2) {

--- a/public/app/features/trails/relatedMetrics.ts
+++ b/public/app/features/trails/relatedMetrics.ts
@@ -1,0 +1,42 @@
+import leven from 'leven';
+
+export function sortRelatedMetrics(metricList: string[], metric: string) {
+  return metricList.sort((aValue, bValue) => {
+    const a = getLevenDistances(aValue, metric);
+    const b = getLevenDistances(bValue, metric);
+
+    return a.halfLeven + a.wholeLeven - (b.halfLeven + b.wholeLeven);
+  });
+}
+
+type LevenDistances = { halfLeven: number; wholeLeven: number };
+type TargetToLevenDistances = Map<string, LevenDistances>;
+
+const metricToTargetLevenDistances = new Map<string, TargetToLevenDistances>();
+
+// Provides the Levenshtein distance between a metric to be sorted
+// and a targetMetric compared to which all other metrics are being sorted
+// There are two distances: once for the first half and once for the whole string.
+// This operation is not expected to be symmetric; order of parameters matters
+// since only `metric` is split.
+function getLevenDistances(metric: string, targetMetric: string) {
+  let targetToDistances: TargetToLevenDistances | undefined = metricToTargetLevenDistances.get(metric);
+  if (!targetToDistances) {
+    targetToDistances = new Map<string, LevenDistances>();
+    metricToTargetLevenDistances.set(metric, targetToDistances);
+  }
+
+  let distances: LevenDistances | undefined = targetToDistances.get(targetMetric);
+  if (!distances) {
+    const metricSplit = metric.split('_');
+    const metricHalf = metricSplit.slice(0, metricSplit.length / 2).join('_');
+
+    const halfLeven = leven(metricHalf, targetMetric!) || 0;
+    const wholeLeven = leven(metric, targetMetric!) || 0;
+
+    distances = { halfLeven, wholeLeven };
+    targetToDistances.set(targetMetric, distances);
+  }
+
+  return distances;
+}


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

This improves the performance of the related metrics sort by dynamically caching partial computations repeated for each comparison (2x faster, roughly).

The end result is that the first sort is twice as fast as the straightforward version, and each subsequent sort is significantly faster (<20x faster, roughly).

This makes stepping between data trail history steps, a more UI-responsive experience.

The cache is global, since the comparisons are solely between metric names -- they will still be valid even if the set of metric names changes.

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
