### PR TITLE
datatrails: fix: indicate `__ignore_usage__` for preview queries

### DIFF
--- a/public/app/features/trails/AutomaticMetricQueries/previewPanel.test.ts
+++ b/public/app/features/trails/AutomaticMetricQueries/previewPanel.test.ts
@@ -1,0 +1,31 @@
+import { SceneQueryRunner } from '@grafana/scenes';
+
+import { getPreviewPanelFor } from './previewPanel';
+
+describe('getPreviewPanelFor', () => {
+  describe('includes __ignore_usage__ indicator', () => {
+    function callAndGetExpr(filterCount: number) {
+      const result = getPreviewPanelFor('METRIC', 0, filterCount);
+      const runner = result.state.$data as SceneQueryRunner;
+      expect(runner).toBeInstanceOf(SceneQueryRunner);
+      const query = runner.state.queries[0];
+      const expr = query.expr as string;
+      return expr;
+    }
+
+    test('When there are no filters, replace the ${filters} variable', () => {
+      const expected = "avg(${metric}{__ignore_usage__=''})";
+      const expr = callAndGetExpr(0);
+      expect(expr).toStrictEqual(expected);
+    });
+
+    test('When there are 1 or more filters, append to the ${filters} variable', () => {
+      const expected = "avg(${metric}{${filters},__ignore_usage__=''})";
+
+      for (let i = 1; i < 10; ++i) {
+        const expr = callAndGetExpr(1);
+        expect(expr).toStrictEqual(expected);
+      }
+    });
+  });
+});

--- a/public/app/features/trails/AutomaticMetricQueries/previewPanel.ts
+++ b/public/app/features/trails/AutomaticMetricQueries/previewPanel.ts
@@ -1,0 +1,48 @@
+import { SceneCSSGridItem, SceneQueryRunner, SceneVariableSet } from '@grafana/scenes';
+import { PromQuery } from 'app/plugins/datasource/prometheus/types';
+
+import { SelectMetricAction } from '../SelectMetricAction';
+import { hideEmptyPreviews } from '../hideEmptyPreviews';
+import { getVariablesWithMetricConstant, trailDS } from '../shared';
+import { getColorByIndex } from '../utils';
+
+import { getAutoQueriesForMetric } from './AutoQueryEngine';
+
+export function getPreviewPanelFor(metric: string, index: number, currentFilterCount: number) {
+  const autoQuery = getAutoQueriesForMetric(metric);
+
+  const vizPanel = autoQuery.preview
+    .vizBuilder()
+    .setColor({ mode: 'fixed', fixedColor: getColorByIndex(index) })
+    .setHeaderActions(new SelectMetricAction({ metric, title: 'Select' }))
+    .build();
+
+  const queries = autoQuery.preview.queries.map((query) =>
+    convertPreviewQueriesToIgnoreUsage(query, currentFilterCount)
+  );
+
+  return new SceneCSSGridItem({
+    $variables: new SceneVariableSet({
+      variables: getVariablesWithMetricConstant(metric),
+    }),
+    $behaviors: [hideEmptyPreviews(metric)],
+    $data: new SceneQueryRunner({
+      datasource: trailDS,
+      maxDataPoints: 200,
+      queries,
+    }),
+    body: vizPanel,
+  });
+}
+
+function convertPreviewQueriesToIgnoreUsage(query: PromQuery, currentFilterCount: number) {
+  // If there are filters, we append to the list. Otherwise, we replace the empty list.
+  const replacement = currentFilterCount > 0 ? "${filters},__ignore_usage__=''" : "__ignore_usage__=''";
+
+  const expr = query.expr?.replace('${filters}', replacement);
+
+  return {
+    ...query,
+    expr,
+  };
+}

--- a/public/app/features/trails/MetricSelectScene.tsx
+++ b/public/app/features/trails/MetricSelectScene.tsx
@@ -76,8 +76,6 @@ export class MetricSelectScene extends SceneObjectBase<MetricSelectSceneState> {
     this.addActivationHandler(this._onActivate.bind(this));
   }
 
-  // private justChangedTimeRange = false;
-
   protected _variableDependency = new VariableDependencyConfig(this, {
     variableNames: [VAR_METRIC_NAMES, VAR_DATASOURCE],
     onReferencedVariableValueChanged: (variable: SceneVariable) => {

--- a/public/app/features/trails/utils.ts
+++ b/public/app/features/trails/utils.ts
@@ -1,6 +1,7 @@
 import { urlUtil } from '@grafana/data';
 import { config, getDataSourceSrv } from '@grafana/runtime';
 import {
+  AdHocFiltersVariable,
   getUrlSyncManager,
   sceneGraph,
   SceneObject,
@@ -104,4 +105,12 @@ export type SceneTimeRangeState = SceneObjectState & {
 export function isSceneTimeRangeState(state: SceneObjectState): state is SceneTimeRangeState {
   const keys = Object.keys(state);
   return keys.includes('from') && keys.includes('to');
+}
+
+export function getFilters(scene: SceneObject) {
+  const filters = sceneGraph.lookupVariable('filters', scene);
+  if (filters instanceof AdHocFiltersVariable) {
+    return filters.state.set.state.filters;
+  }
+  return null;
 }

--- a/public/app/features/trails/utils.ts
+++ b/public/app/features/trails/utils.ts
@@ -110,7 +110,7 @@ export function isSceneTimeRangeState(state: SceneObjectState): state is SceneTi
 export function getFilters(scene: SceneObject) {
   const filters = sceneGraph.lookupVariable('filters', scene);
   if (filters instanceof AdHocFiltersVariable) {
-    return filters.state.set.state.filters;
+    return filters.state.filters;
   }
   return null;
 }


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

We want to tell the data source not to record preview queries in usage services (for prometheus data sources that have this capability), since preview queries are generated by datatrails and aren't explicitly selected by the user.
Including `__ignore_usage__=''` as a filter works as a directive to tell services to ignore this when recording usage information.

E.g., 

CHANGES
`avg(${metric}{${filters}}) `
to 
`avg(${metric}{__ignore_usage__=''})`
When there are no filters.

CHANGES
`avg(${metric}{${filters}})`
to 
`avg(${metric}{${filters},__ignore_usage__=''})`
When there are filters.

**Why do we need this feature?**

So that data trails doesn't give false positives when it comes to metric usage.


<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->


**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
