### PR TITLE
Plugins: Fix loading modules that only export a default

### DIFF
--- a/public/app/features/plugins/plugin_loader.ts
+++ b/public/app/features/plugins/plugin_loader.ts
@@ -30,7 +30,7 @@ const systemJSPrototype: SystemJSWithLoaderHooks = SystemJS.constructor.prototyp
 systemJSPrototype.shouldFetch = () => true;
 
 const originalImport = systemJSPrototype.import;
-
+// Hook Systemjs import to support plugins that only have a default export.
 systemJSPrototype.import = function (...args: Parameters<typeof originalImport>) {
   return originalImport.apply(this, args).then((module) => {
     if (module && module.__useDefault) {

--- a/public/app/features/plugins/plugin_loader.ts
+++ b/public/app/features/plugins/plugin_loader.ts
@@ -78,15 +78,8 @@ export async function importPluginModule({
   let attempts = 0;
   // While the module's default export is a promise, wait for it to resolve.
   // Do we need to recurse here? It seems unlikely that a module would return a promise that resolves to another promise.
-  while (
-    !('plugin' in mod) &&
-    'default' in mod &&
-    typeof mod.default === 'object' &&
-    'then' in mod.default &&
-    typeof mod.default.then === 'function' &&
-    attempts < 5
-  ) {
-    mod = await mod.default;
+  while (!('plugin' in mod) && 'default' in mod && attempts < 5) {
+    mod = Promise.resolve(mod.default);
     attempts++;
   }
   return mod;


### PR DESCRIPTION
**What is this feature?**

This PR fixes the loading of modules whose default exports resolve to promises, such as plugins which bundle WebAssembly dependencies using webpack's `asyncWebAssembly` experiment.

**Why do we need this feature?**

Prior to this commit we expected the default export of a plugin module to be an object with a `plugin` field.

This is the case for the vast majority of plugins, but if a plugin uses webpack's `asyncWebAssembly` feature then the default export will actually be a promise which resolves to such an object.

This commit checks the result of the SystemJS import to make sure it has a `plugin` field. If not, and if the `default` field looks like a Promise, it recursively attempts to resolve the Promise until the object looks like a plugin.

I think this may have broken with the SystemJS upgrade (#70068) because it used to work without this change in Grafana 10.1, but it's difficult to say for sure.

**Who is this feature for?**

Plugin developers who want to make use of WASM dependencies in their plugins.

**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/grafana-plugins-platform-team/issues/64

**Special notes for your reviewer:**

I know we've chatted on Slack about this, figured I'd make this PR since it contains a fix that's working for me! Feel free to close if there's a better solution though.

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
