### PR TITLE
DashboardScene: Panel edit toolbar actions

### DIFF
--- a/public/app/features/dashboard-scene/panel-edit/PanelEditor.test.ts
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditor.test.ts
@@ -1,5 +1,5 @@
 import { PanelPlugin, PanelPluginMeta, PluginType } from '@grafana/data';
-import { SceneFlexItem, SplitLayout, VizPanel } from '@grafana/scenes';
+import { SceneFlexItem, SceneGridItem, SceneGridLayout, SplitLayout, VizPanel } from '@grafana/scenes';
 
 import { DashboardScene } from '../scene/DashboardScene';
 import { activateFullSceneTree } from '../utils/test-utils';
@@ -26,6 +26,37 @@ jest.mock('@grafana/runtime', () => ({
 }));
 
 describe('PanelEditor', () => {
+  describe('When closing editor', () => {
+    it('should apply changes automatically', () => {
+      pluginToLoad = getTestPanelPlugin({ id: 'text', skipDataQuery: true });
+
+      const panel = new VizPanel({
+        key: 'panel-1',
+        pluginId: 'text',
+      });
+
+      const editScene = buildPanelEditScene(panel);
+      const gridItem = new SceneGridItem({ body: panel });
+      const scene = new DashboardScene({
+        editPanel: editScene,
+        isEditing: true,
+        body: new SceneGridLayout({
+          children: [gridItem],
+        }),
+      });
+
+      const deactive = activateFullSceneTree(scene);
+
+      const vizManager = editScene.state.panelRef.resolve();
+      vizManager.state.panel.setState({ title: 'changed title' });
+
+      deactive();
+
+      const updatedPanel = gridItem.state.body as VizPanel;
+      expect(updatedPanel?.state.title).toBe('changed title');
+    });
+  });
+
   describe('PanelDataPane', () => {
     it('should not exist if panel is skipDataQuery', () => {
       pluginToLoad = getTestPanelPlugin({ id: 'text', skipDataQuery: true });
@@ -44,7 +75,7 @@ describe('PanelEditor', () => {
       expect(((editScene.state.body as SplitLayout).state.primary as SplitLayout).state.secondary).toBeUndefined();
     });
 
-    it('should  exist if panel is supporting querying', () => {
+    it('should exist if panel is supporting querying', () => {
       pluginToLoad = getTestPanelPlugin({ id: 'timeseries' });
 
       const panel = new VizPanel({

--- a/public/app/features/dashboard-scene/panel-edit/PanelEditor.test.ts
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditor.test.ts
@@ -45,12 +45,12 @@ describe('PanelEditor', () => {
         }),
       });
 
-      const deactive = activateFullSceneTree(scene);
+      const deactivate = activateFullSceneTree(scene);
 
       const vizManager = editScene.state.panelRef.resolve();
       vizManager.state.panel.setState({ title: 'changed title' });
 
-      deactive();
+      deactivate();
 
       const updatedPanel = gridItem.state.body as VizPanel;
       expect(updatedPanel?.state.title).toBe('changed title');

--- a/public/app/features/dashboard-scene/panel-edit/PanelEditorRenderer.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditorRenderer.tsx
@@ -3,10 +3,9 @@ import React from 'react';
 
 import { GrafanaTheme2 } from '@grafana/data';
 import { SceneComponentProps } from '@grafana/scenes';
-import { Button, useStyles2 } from '@grafana/ui';
-import { AppChromeUpdate } from 'app/core/components/AppChrome/AppChromeUpdate';
-import { NavToolbarSeparator } from 'app/core/components/AppChrome/NavToolbar/NavToolbarSeparator';
+import { useStyles2 } from '@grafana/ui';
 
+import { NavToolbarActions } from '../scene/NavToolbarActions';
 import { getDashboardSceneFor } from '../utils/utils';
 
 import { PanelEditor } from './PanelEditor';
@@ -19,7 +18,7 @@ export function PanelEditorRenderer({ model }: SceneComponentProps<PanelEditor>)
 
   return (
     <>
-      <AppChromeUpdate actions={getToolbarActions(model)} />
+      <NavToolbarActions dashboard={dashboard} />
       <div className={styles.canvasContent}>
         {controls && (
           <div className={styles.controls}>
@@ -32,29 +31,6 @@ export function PanelEditorRenderer({ model }: SceneComponentProps<PanelEditor>)
           <body.Component model={body} />
         </div>
       </div>
-    </>
-  );
-}
-
-function getToolbarActions(editor: PanelEditor) {
-  return (
-    <>
-      <NavToolbarSeparator leftActionsSeparator key="separator" />
-
-      <Button
-        onClick={editor.onDiscard}
-        tooltip=""
-        key="panel-edit-discard"
-        variant="destructive"
-        fill="outline"
-        size="sm"
-      >
-        Discard
-      </Button>
-
-      <Button onClick={editor.onApply} tooltip="" key="panel-edit-apply" variant="primary" size="sm">
-        Apply
-      </Button>
     </>
   );
 }

--- a/public/app/features/dashboard-scene/saving/getSaveDashboardChange.test.ts
+++ b/public/app/features/dashboard-scene/saving/getSaveDashboardChange.test.ts
@@ -1,7 +1,9 @@
 import { MultiValueVariable, sceneGraph } from '@grafana/scenes';
 
+import { buildPanelEditScene } from '../panel-edit/PanelEditor';
 import { transformSaveModelToScene } from '../serialization/transformSaveModelToScene';
 import { transformSceneToSaveModel } from '../serialization/transformSceneToSaveModel';
+import { findVizPanelByKey } from '../utils/utils';
 
 import { getSaveDashboardChange } from './getSaveDashboardChange';
 
@@ -59,15 +61,43 @@ describe('getSaveDashboardChange', () => {
     expect(result.hasChanges).toBe(true);
     expect(result.diffCount).toBe(2);
   });
+
+  describe('Saving from panel edit', () => {
+    it('Should commit panel edit changes', () => {
+      const dashboard = setup();
+      const panel = findVizPanelByKey(dashboard, 'panel-1')!;
+      const editScene = buildPanelEditScene(panel);
+
+      dashboard.onEnterEditMode();
+      dashboard.setState({ editPanel: editScene });
+
+      const vizManager = editScene.state.panelRef.resolve();
+      vizManager.state.panel.setState({ title: 'changed title' });
+
+      const result = getSaveDashboardChange(dashboard, false, true);
+      const panelSaveModel = result.changedSaveModel.panels![0];
+      expect(panelSaveModel.title).toBe('changed title');
+    });
+  });
 });
 
-function setup() {
+interface ScenarioOptions {
+  fromPanelEdit?: boolean;
+}
+
+function setup(options: ScenarioOptions = {}) {
   const dashboard = transformSaveModelToScene({
     dashboard: {
       title: 'hello',
       uid: 'my-uid',
       schemaVersion: 30,
-      panels: [],
+      panels: [
+        {
+          id: 1,
+          title: 'Panel 1',
+          type: 'text',
+        },
+      ],
       version: 10,
       templating: {
         list: [

--- a/public/app/features/dashboard-scene/saving/getSaveDashboardChange.ts
+++ b/public/app/features/dashboard-scene/saving/getSaveDashboardChange.ts
@@ -15,6 +15,11 @@ export function getSaveDashboardChange(
   saveVariables?: boolean
 ): DashboardChangeInfo {
   const initialSaveModel = dashboard.getInitialSaveModel()!;
+
+  if (dashboard.state.editPanel) {
+    dashboard.state.editPanel.commitChanges();
+  }
+
   const changedSaveModel = transformSceneToSaveModel(dashboard);
   const hasTimeChanged = getHasTimeChanged(changedSaveModel, initialSaveModel);
 


### PR DESCRIPTION
* [x] Back to dashboard action
* [x] Discard panel changes action (should only be shown when panel edit is in dirty state but we can add that later when new change tracker changes are merged)
* [x] Save dashboard 
* [x] Make save drawer take uncommitted panel edit changes into account
* [x] Automatically apply changes when leaving panel edit except when explicitly user clicks discard changes 

Minor problematic bit
* If you open save drawer from panel edit it will commit changes to have them be taken into account in the diff, so it makes it so you can no longer discard them if you cancel/leave the save drawer without saving. I think it's ok for now as fixing it so that we undo the commit when you leave is a bit messy / complicated. And we have the opposite problem in main/old architecture where you can discard a saved change. 

the current dirty checking is not working in panel edit but not touching that as that is being worked on in separate PR