### PR TITLE
Grafana UI: Add code variant to Text component

### DIFF
--- a/packages/grafana-data/src/themes/createTypography.ts
+++ b/packages/grafana-data/src/themes/createTypography.ts
@@ -114,6 +114,7 @@ export function createTypography(colors: ThemeColors, typographyInput: ThemeTypo
     h6: buildVariant(fontWeightMedium, 14, 22, 0.15),
     body: buildVariant(fontWeightRegular, fontSize, 22, 0.15),
     bodySmall: buildVariant(fontWeightRegular, 12, 18, 0.15),
+    code: { ...buildVariant(fontWeightRegular, 14, 16, 0.15), fontFamily: fontFamilyMonospace },
   };
 
   const size = {
@@ -152,4 +153,5 @@ export interface ThemeTypographyVariantTypes {
   h6: ThemeTypographyVariant;
   body: ThemeTypographyVariant;
   bodySmall: ThemeTypographyVariant;
+  code: ThemeTypographyVariant;
 }

--- a/packages/grafana-ui/src/components/Link/TextLink.story.tsx
+++ b/packages/grafana-ui/src/components/Link/TextLink.story.tsx
@@ -18,7 +18,10 @@ const meta: Meta = {
     controls: { exclude: ['href', 'external'] },
   },
   argTypes: {
-    variant: { control: 'select', options: ['h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'body', 'bodySmall', undefined] },
+    variant: {
+      control: 'select',
+      options: ['h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'body', 'bodySmall', undefined],
+    },
     weight: {
       control: 'select',
       options: ['bold', 'medium', 'light', 'regular', undefined],

--- a/packages/grafana-ui/src/components/Link/TextLink.tsx
+++ b/packages/grafana-ui/src/components/Link/TextLink.tsx
@@ -19,8 +19,8 @@ interface TextLinkProps extends Omit<AnchorHTMLAttributes<HTMLAnchorElement>, 't
   external?: boolean;
   /** True when the link will be displayed inline with surrounding text, false if it will be displayed as a block. Depending on this prop correspondant default styles will be applied */
   inline?: boolean;
-  /** The default variant is 'body'. To fit another styles set the correspondent variant as it is necessary also to adjust the icon size */
-  variant?: keyof ThemeTypographyVariantTypes;
+  /** The default variant is 'body'. To fit another styles set the correspondent variant as it is necessary also to adjust the icon size. `code` is excluded, as it is not fit for links. */
+  variant?: keyof Omit<ThemeTypographyVariantTypes, 'code'>;
   /** Override the default weight for the used variant */
   weight?: 'light' | 'regular' | 'medium' | 'bold';
   /** Set the icon to be shown. An external link will show the 'external-link-alt' icon as default.*/
@@ -29,7 +29,7 @@ interface TextLinkProps extends Omit<AnchorHTMLAttributes<HTMLAnchorElement>, 't
 }
 
 const svgSizes: {
-  [key in keyof ThemeTypographyVariantTypes]: IconSize;
+  [key in keyof Omit<ThemeTypographyVariantTypes, 'code'>]: IconSize;
 } = {
   h1: 'xl',
   h2: 'xl',

--- a/packages/grafana-ui/src/components/Link/TextLink.tsx
+++ b/packages/grafana-ui/src/components/Link/TextLink.tsx
@@ -10,6 +10,8 @@ import { customWeight } from '../Text/utils';
 
 import { Link } from './Link';
 
+type TextLinkVariants = keyof Omit<ThemeTypographyVariantTypes, 'code'>;
+
 interface TextLinkProps extends Omit<AnchorHTMLAttributes<HTMLAnchorElement>, 'target' | 'rel'> {
   /** url to which redirect the user, external or internal */
   href: string;
@@ -20,7 +22,7 @@ interface TextLinkProps extends Omit<AnchorHTMLAttributes<HTMLAnchorElement>, 't
   /** True when the link will be displayed inline with surrounding text, false if it will be displayed as a block. Depending on this prop correspondant default styles will be applied */
   inline?: boolean;
   /** The default variant is 'body'. To fit another styles set the correspondent variant as it is necessary also to adjust the icon size. `code` is excluded, as it is not fit for links. */
-  variant?: keyof Omit<ThemeTypographyVariantTypes, 'code'>;
+  variant?: TextLinkVariants;
   /** Override the default weight for the used variant */
   weight?: 'light' | 'regular' | 'medium' | 'bold';
   /** Set the icon to be shown. An external link will show the 'external-link-alt' icon as default.*/
@@ -29,7 +31,7 @@ interface TextLinkProps extends Omit<AnchorHTMLAttributes<HTMLAnchorElement>, 't
 }
 
 const svgSizes: {
-  [key in keyof Omit<ThemeTypographyVariantTypes, 'code'>]: IconSize;
+  [key in TextLinkVariants]: IconSize;
 } = {
   h1: 'xl',
   h2: 'xl',

--- a/packages/grafana-ui/src/components/Text/Text.mdx
+++ b/packages/grafana-ui/src/components/Text/Text.mdx
@@ -47,6 +47,7 @@ In this documentation you can find:
 
 - Do not use the `element` prop because of its appearance, use it to organize the structure of the page.
 - Do not use color for emphasis as colors are related to states such as `error`, `success`, `disabled` and so on.
+- Do not use the `code` variant for anything other than code snippets.
 
   <br />
   <br />

--- a/packages/grafana-ui/src/components/Text/Text.story.tsx
+++ b/packages/grafana-ui/src/components/Text/Text.story.tsx
@@ -16,7 +16,10 @@ const meta: Meta = {
     },
   },
   argTypes: {
-    variant: { control: 'select', options: ['h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'body', 'bodySmall', undefined] },
+    variant: {
+      control: 'select',
+      options: ['h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'body', 'bodySmall', 'code', undefined],
+    },
     weight: {
       control: 'select',
       options: ['bold', 'medium', 'light', 'regular', undefined],


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

Adds a monospaced code variant to make it available in the `Text` component. `code` is used as it aligns somewhat with the design tokens.

![image](https://github.com/grafana/grafana/assets/1438972/0f23a07a-7728-44cd-8515-2a7c56696e3f)


**Why do we need this feature?**

Sometimes we need to use a monospaced font.

**Who is this feature for?**

Developers


**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
