### PR TITLE
Elasticsearch: Fix resource calls for paths that include `:`

### DIFF
--- a/pkg/tsdb/elasticsearch/elasticsearch.go
+++ b/pkg/tsdb/elasticsearch/elasticsearch.go
@@ -194,7 +194,6 @@ func (s *Service) CallResource(ctx context.Context, req *backend.CallResourceReq
 	// - /_mapping for fetching index mapping, e.g. requests going to `index/_mapping`
 	// - _msearch for executing getTerms queries
 	// - _mapping for fetching "root" index mappings
-	// If adding a path with raw query params, ensure that params are correctly added, as this is not supported at the moment, as not needed.
 	if req.Path != "" && !strings.HasSuffix(req.Path, "/_mapping") && req.Path != "_msearch" && req.Path != "_mapping" {
 		logger.Error("Invalid resource path", "path", req.Path)
 		return fmt.Errorf("invalid resource URL: %s", req.Path)

--- a/pkg/tsdb/elasticsearch/elasticsearch.go
+++ b/pkg/tsdb/elasticsearch/elasticsearch.go
@@ -194,6 +194,7 @@ func (s *Service) CallResource(ctx context.Context, req *backend.CallResourceReq
 	// - /_mapping for fetching index mapping, e.g. requests going to `index/_mapping`
 	// - _msearch for executing getTerms queries
 	// - _mapping for fetching "root" index mappings
+	// If adding a path with raw query params, ensure that params are correctly added, as this is not supported at the moment, as not needed.
 	if req.Path != "" && !strings.HasSuffix(req.Path, "/_mapping") && req.Path != "_msearch" && req.Path != "_mapping" {
 		logger.Error("Invalid resource path", "path", req.Path)
 		return fmt.Errorf("invalid resource URL: %s", req.Path)

--- a/pkg/tsdb/elasticsearch/elasticsearch.go
+++ b/pkg/tsdb/elasticsearch/elasticsearch.go
@@ -205,13 +205,11 @@ func (s *Service) CallResource(ctx context.Context, req *backend.CallResourceReq
 		return err
 	}
 
-	esUrl, err := url.Parse(ds.URL)
+	esUrl, err := createElasticsearchURL(req, ds)
 	if err != nil {
-		logger.Error("Failed to parse data source URL", "error", err, "url", ds.URL)
-		return err
+		logger.Error("Failed to create request url", "error", err, "url", ds.URL, "path", req.Path)
 	}
 
-	esUrl.Path = path.Join(esUrl.Path, req.Path)
 	request, err := http.NewRequestWithContext(ctx, req.Method, esUrl.String(), bytes.NewBuffer(req.Body))
 	if err != nil {
 		logger.Error("Failed to create request", "error", err, "url", esUrl.String())
@@ -260,4 +258,14 @@ func (s *Service) CallResource(ctx context.Context, req *backend.CallResourceReq
 		Headers: responseHeaders,
 		Body:    body,
 	})
+}
+
+func createElasticsearchURL(req *backend.CallResourceRequest, ds *es.DatasourceInfo) (*url.URL, error) {
+	esUrl, err := url.Parse(ds.URL)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse data source URL: %s, error: %w", ds.URL, err)
+	}
+
+	esUrl.Path = path.Join(esUrl.Path, req.Path)
+	return esUrl, nil
 }

--- a/pkg/tsdb/elasticsearch/elasticsearch.go
+++ b/pkg/tsdb/elasticsearch/elasticsearch.go
@@ -211,15 +211,7 @@ func (s *Service) CallResource(ctx context.Context, req *backend.CallResourceReq
 		return err
 	}
 
-	resourcePath, err := url.Parse(req.Path)
-	if err != nil {
-		logger.Error("Failed to parse data source path", "error", err, "url", req.Path)
-		return err
-	}
-
-	// We take the path and the query-string only
-	esUrl.RawQuery = resourcePath.RawQuery
-	esUrl.Path = path.Join(esUrl.Path, resourcePath.Path)
+	esUrl.Path = path.Join(esUrl.Path, req.Path)
 	request, err := http.NewRequestWithContext(ctx, req.Method, esUrl.String(), bytes.NewBuffer(req.Body))
 	if err != nil {
 		logger.Error("Failed to create request", "error", err, "url", esUrl.String())

--- a/pkg/tsdb/elasticsearch/elasticsearch_test.go
+++ b/pkg/tsdb/elasticsearch/elasticsearch_test.go
@@ -89,6 +89,8 @@ func TestCreateElasticsearchURL(t *testing.T) {
 		{name: "with abc/_mapping path and valid url", settings: es.DatasourceInfo{URL: "http://localhost:9200"}, req: backend.CallResourceRequest{Path: "abc/_mapping"}, expected: "http://localhost:9200/abc/_mapping"},
 		{name: "with /abc/_mapping path and valid url", settings: es.DatasourceInfo{URL: "http://localhost:9200"}, req: backend.CallResourceRequest{Path: "abc/_mapping"}, expected: "http://localhost:9200/abc/_mapping"},
 		{name: "with /abc/_mapping path and valid url", settings: es.DatasourceInfo{URL: "http://localhost:9200/"}, req: backend.CallResourceRequest{Path: "abc/_mapping"}, expected: "http://localhost:9200/abc/_mapping"},
+		// This is to support mappings to cross cluster search that includes ":"
+		{name: "with path including :", settings: es.DatasourceInfo{URL: "http://localhost:9200/"}, req: backend.CallResourceRequest{Path: "ab:c/_mapping"}, expected: "http://localhost:9200/ab:c/_mapping"},
 	}
 
 	for _, test := range tt {


### PR DESCRIPTION
This PR follows up on https://github.com/grafana/grafana/pull/79746 and removes redundant logic that was using `url.Parse` to parse `req.Path`. Consequently, it also fixes the issue https://github.com/grafana/grafana/issues/79745 where `url.Parse` throws error when parsing path with `:`. Moreover it adds tests and does a small refactor to make testing of these (and future) changes easier. 

To test, do a sanity check that resource calls work:

See field options:
<img width="1481" alt="image" src="https://github.com/grafana/grafana/assets/30407135/70961f37-77a7-4baf-b356-05698090bf7c">

Adhoc filters working:
<img width="1003" alt="image" src="https://github.com/grafana/grafana/assets/30407135/f3d90c07-5622-444c-8877-9b3e7b2f1e00">

Test data source working:
<img width="1492" alt="image" src="https://github.com/grafana/grafana/assets/30407135/5d73bf62-e5cf-403b-b19c-840537bb176f">

Fixes: https://github.com/grafana/grafana/pull/82327