### PR TITLE
Alerting: Updates to recording rules

### DIFF
--- a/public/app/features/alerting/unified/components/rule-editor/query-and-alert-condition/QueryAndExpressionsStep.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/query-and-alert-condition/QueryAndExpressionsStep.tsx
@@ -40,6 +40,7 @@ import { errorFromCurrentCondition, errorFromPreviewData, findRenamedDataQueryRe
 
 import { CloudDataSourceSelector } from './CloudDataSourceSelector';
 import { SmartAlertTypeDetector } from './SmartAlertTypeDetector';
+import { DESCRIPTIONS } from './descriptions';
 import {
   addExpressions,
   addNewDataQuery,
@@ -243,6 +244,7 @@ export const QueryAndExpressionsStep = ({ editingExistingRule, onDataChange }: P
         queryType: '',
         relativeTimeRange: getDefaultRelativeTimeRange(),
         expr,
+        instant: true,
         model: {
           refId: 'A',
           hide: false,
@@ -370,23 +372,22 @@ export const QueryAndExpressionsStep = ({ editingExistingRule, onDataChange }: P
     condition,
   ]);
 
+  const { sectionTitle, helpLabel, helpContent, helpLink } = DESCRIPTIONS[type ?? RuleFormType.grafana];
+
   return (
     <RuleEditorSection
       stepNo={2}
-      title={type !== RuleFormType.cloudRecording ? 'Define query and alert condition' : 'Define query'}
+      title={sectionTitle}
       description={
-        <Stack direction="row" gap={0.5} alignItems="baseline">
+        <Stack direction="row" gap={0.5} alignItems="center">
           <Text variant="bodySmall" color="secondary">
-            Define queries and/or expressions and then choose one of them as the alert rule condition. This is the
-            threshold that an alert rule must meet or exceed in order to fire.
+            {helpLabel}
           </Text>
           <NeedHelpInfo
-            contentText={`An alert rule consists of one or more queries and expressions that select the data you want to measure.
-          Define queries and/or expressions and then choose one of them as the alert rule condition. This is the threshold that an alert rule must meet or exceed in order to fire.
-          For more information on queries and expressions, see Query and transform data.`}
-            externalLink={`https://grafana.com/docs/grafana/latest/panels-visualizations/query-transform-data/`}
-            linkText={`Read about query and condition`}
-            title="Define query and alert condition"
+            contentText={helpContent}
+            externalLink={helpLink}
+            linkText={'Read more on our documentation website'}
+            title={helpLabel}
           />
         </Stack>
       }

--- a/public/app/features/alerting/unified/components/rule-editor/query-and-alert-condition/descriptions.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/query-and-alert-condition/descriptions.tsx
@@ -1,0 +1,32 @@
+import { RuleFormType } from '../../../types/rule-form';
+
+type FormDescriptions = {
+  sectionTitle: string;
+  helpLabel: string;
+  helpContent: string;
+  helpLink: string;
+};
+
+export const DESCRIPTIONS: Record<RuleFormType, FormDescriptions> = {
+  [RuleFormType.cloudRecording]: {
+    sectionTitle: 'Define recording rule',
+    helpLabel: 'Define your recording rule',
+    helpContent:
+      'Pre-compute frequently needed or computationally expensive expressions and save their result as a new set of time series.',
+    helpLink: '',
+  },
+  [RuleFormType.grafana]: {
+    sectionTitle: 'Define query and alert condition',
+    helpLabel: 'Define query and alert condition',
+    helpContent:
+      'An alert rule consists of one or more queries and expressions that select the data you want to measure. Define queries and/or expressions and then choose one of them as the alert rule condition. This is the threshold that an alert rule must meet or exceed in order to fire. For more information on queries and expressions, see Query and transform data.',
+    helpLink: 'https://grafana.com/docs/grafana/latest/panels-visualizations/query-transform-data/',
+  },
+  [RuleFormType.cloudAlerting]: {
+    sectionTitle: 'Define query and alert condition',
+    helpLabel: 'Define query and alert condition',
+    helpContent:
+      'An alert rule consists of one or more queries and expressions that select the data you want to measure. Define queries and/or expressions and then choose one of them as the alert rule condition. This is the threshold that an alert rule must meet or exceed in order to fire. For more information on queries and expressions, see Query and transform data.',
+    helpLink: 'https://grafana.com/docs/grafana/latest/panels-visualizations/query-transform-data/',
+  },
+};


### PR DESCRIPTION
**What is this feature?**

This PR makes the following changes;

1. Adds separate in-app documentation for recording rules instead of re-using the ones from alert rules.
2. Set the defaults for new recording rules to display results as "instant".

The query expressions themselves aren't range queries – we only forward the expression to the recording rule but defaulting to "range" would make users confused making them think that a range query is requested for each recording rule evaluation.

**Special notes for your reviewer:**

Please check that:

@brendamuir or @ppcano to review the copy of the descriptions for recording rules :)