### PR TITLE
Alerting: Prevent state badge from wrapping

### DIFF
--- a/public/app/features/alerting/unified/components/rule-viewer/v2/StateBadges.tsx
+++ b/public/app/features/alerting/unified/components/rule-viewer/v2/StateBadges.tsx
@@ -29,7 +29,7 @@ interface StateBadgeProps {
 
 export const StateBadge = ({ state, health }: StateBadgeProps) => {
   let stateLabel: string;
-  let color: 'success' | 'error' | 'warning';
+  let color: BadgeColor;
 
   switch (state) {
     case PromAlertingRuleState.Inactive:
@@ -60,8 +60,11 @@ export const StateBadge = ({ state, health }: StateBadgeProps) => {
   return <Badge color={color} text={stateLabel} />;
 };
 
+// the generic badge component
+type BadgeColor = 'success' | 'error' | 'warning';
+
 interface BadgeProps {
-  color: 'success' | 'error' | 'warning';
+  color: BadgeColor;
   text: NonNullable<ReactNode>;
 }
 

--- a/public/app/features/alerting/unified/components/rule-viewer/v2/StateBadges.tsx
+++ b/public/app/features/alerting/unified/components/rule-viewer/v2/StateBadges.tsx
@@ -19,7 +19,7 @@ export const RecordingBadge = ({ health }: RecordingBadgeProps) => {
   const text = hasError ? 'Recording error' : 'Recording';
 
   return (
-    <Stack direction="row" gap={0.5}>
+    <Stack direction="row" gap={0.5} wrap={'nowrap'} flex={'0 0 auto'}>
       <AlertStateDot color={color} />
       <Text variant="bodySmall" color={color}>
         {text}
@@ -65,7 +65,7 @@ export const StateBadge = ({ state, health }: StateBadgeProps) => {
   }
 
   return (
-    <Stack direction="row" gap={0.5}>
+    <Stack direction="row" gap={0.5} wrap={'nowrap'} flex={'0 0 auto'}>
       <AlertStateDot color={color} />
       <Text variant="bodySmall" color={color}>
         {stateLabel}

--- a/public/app/features/alerting/unified/components/rule-viewer/v2/StateBadges.tsx
+++ b/public/app/features/alerting/unified/components/rule-viewer/v2/StateBadges.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { ReactNode } from 'react';
 
 import { Stack, Text } from '@grafana/ui';
 import { RuleHealth } from 'app/types/unified-alerting';
@@ -18,14 +18,7 @@ export const RecordingBadge = ({ health }: RecordingBadgeProps) => {
   const color = hasError ? 'error' : 'success';
   const text = hasError ? 'Recording error' : 'Recording';
 
-  return (
-    <Stack direction="row" gap={0.5} wrap={'nowrap'} flex={'0 0 auto'}>
-      <AlertStateDot color={color} />
-      <Text variant="bodySmall" color={color}>
-        {text}
-      </Text>
-    </Stack>
-  );
+  return <Badge color={color} text={text} />;
 };
 
 // we're making a distinction here between the "state" of the rule and its "health".
@@ -64,12 +57,21 @@ export const StateBadge = ({ state, health }: StateBadgeProps) => {
     stateLabel = 'No data';
   }
 
+  return <Badge color={color} text={stateLabel} />;
+};
+
+interface BadgeProps {
+  color: 'success' | 'error' | 'warning';
+  text: NonNullable<ReactNode>;
+}
+
+function Badge({ color, text }: BadgeProps) {
   return (
     <Stack direction="row" gap={0.5} wrap={'nowrap'} flex={'0 0 auto'}>
       <AlertStateDot color={color} />
       <Text variant="bodySmall" color={color}>
-        {stateLabel}
+        {text}
       </Text>
     </Stack>
   );
-};
+}


### PR DESCRIPTION
**What is this feature?**

While testing the new alert detail view I've found this small edge-case where the state badge would wrap if the title of the rule overflows.

**Before**
<img width="886" alt="image" src="https://github.com/grafana/grafana/assets/868844/6ad5e34b-38cf-484a-9e55-f6723ebfd9e4">

**After**
<img width="888" alt="image" src="https://github.com/grafana/grafana/assets/868844/f3f497a7-51dc-4112-9eab-a1b1e380bc57">


