### PR TITLE
Table: Adding header row menu icon - PoC/Hack

### DIFF
--- a/packages/grafana-ui/src/components/Table/HeaderRow.tsx
+++ b/packages/grafana-ui/src/components/Table/HeaderRow.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { HeaderGroup, Column } from 'react-table';
 
+import { Field } from '@grafana/data';
 import { selectors } from '@grafana/e2e-selectors';
 
 import { getFieldTypeIcon } from '../../types';
@@ -13,10 +14,11 @@ export interface HeaderRowProps {
   headerGroups: HeaderGroup[];
   showTypeIcons?: boolean;
   tableStyles: TableStyles;
+  headerMenuClick?: (fieldName: string) => void;
 }
 
 export const HeaderRow = (props: HeaderRowProps) => {
-  const { headerGroups, showTypeIcons, tableStyles } = props;
+  const { headerGroups, showTypeIcons, tableStyles, headerMenuClick } = props;
   const e2eSelectorsTable = selectors.components.Panels.Visualization.Table;
 
   return (
@@ -32,7 +34,7 @@ export const HeaderRow = (props: HeaderRowProps) => {
             role="row"
           >
             {headerGroup.headers.map((column: Column, index: number) =>
-              renderHeaderCell(column, tableStyles, showTypeIcons)
+              renderHeaderCell(column, tableStyles, showTypeIcons, headerMenuClick)
             )}
           </div>
         );
@@ -41,9 +43,14 @@ export const HeaderRow = (props: HeaderRowProps) => {
   );
 };
 
-function renderHeaderCell(column: any, tableStyles: TableStyles, showTypeIcons?: boolean) {
+function renderHeaderCell(
+  column: any,
+  tableStyles: TableStyles,
+  showTypeIcons?: boolean,
+  headerMenuClick?: (fieldName: string) => void
+) {
   const headerProps = column.getHeaderProps();
-  const field = column.field ?? null;
+  const field: Field = column.field ?? null;
 
   if (column.canResize) {
     headerProps.style.userSelect = column.isResizing ? 'none' : 'auto'; // disables selecting text while resizing
@@ -74,6 +81,9 @@ function renderHeaderCell(column: any, tableStyles: TableStyles, showTypeIcons?:
       {!column.canSort && column.render('Header')}
       {!column.canSort && column.canFilter && <Filter column={column} tableStyles={tableStyles} field={field} />}
       {column.canResize && <div {...column.getResizerProps()} className={tableStyles.resizeHandle} />}
+      {headerMenuClick && (
+        <Icon onClick={() => headerMenuClick(field?.name)} className={tableStyles.headerMenuIcon} name={'ellipsis-v'} />
+      )}
     </div>
   );
 }

--- a/packages/grafana-ui/src/components/Table/Table.tsx
+++ b/packages/grafana-ui/src/components/Table/Table.tsx
@@ -49,13 +49,14 @@ export const Table = memo((props: Props) => {
     timeRange,
     enableSharedCrosshair = false,
     initialRowIndex = undefined,
+    headerMenuClick = undefined,
   } = props;
 
   const listRef = useRef<VariableSizeList>(null);
   const tableDivRef = useRef<HTMLDivElement>(null);
   const variableSizeListScrollbarRef = useRef<HTMLDivElement>(null);
   const theme = useTheme2();
-  const tableStyles = useTableStyles(theme, cellHeight);
+  const tableStyles = useTableStyles(theme, cellHeight, !!headerMenuClick);
   const headerHeight = noHeader ? 0 : tableStyles.rowHeight;
   const [footerItems, setFooterItems] = useState<FooterItem[] | undefined>(footerValues);
 
@@ -285,7 +286,12 @@ export const Table = memo((props: Props) => {
       <CustomScrollbar hideVerticalTrack={true}>
         <div className={tableStyles.tableContentWrapper(totalColumnsWidth)}>
           {!noHeader && (
-            <HeaderRow headerGroups={headerGroups} showTypeIcons={showTypeIcons} tableStyles={tableStyles} />
+            <HeaderRow
+              headerGroups={headerGroups}
+              showTypeIcons={showTypeIcons}
+              tableStyles={tableStyles}
+              headerMenuClick={headerMenuClick}
+            />
           )}
           {itemCount > 0 ? (
             <div data-testid={selectors.components.Panels.Visualization.Table.body} ref={variableSizeListScrollbarRef}>

--- a/packages/grafana-ui/src/components/Table/styles.ts
+++ b/packages/grafana-ui/src/components/Table/styles.ts
@@ -3,7 +3,7 @@ import { css } from '@emotion/css';
 import { GrafanaTheme2 } from '@grafana/data';
 import { TableCellHeight } from '@grafana/schema';
 
-export function useTableStyles(theme: GrafanaTheme2, cellHeightOption: TableCellHeight) {
+export function useTableStyles(theme: GrafanaTheme2, cellHeightOption: TableCellHeight, tableHeaderMenu: boolean) {
   const borderColor = theme.colors.border.weak;
   const resizerColor = theme.colors.primary.border;
   const cellPadding = 6;
@@ -128,7 +128,7 @@ export function useTableStyles(theme: GrafanaTheme2, cellHeightOption: TableCell
     }),
     headerCell: css({
       height: '100%',
-      padding: `0 ${cellPadding}px`,
+      padding: `0 ${tableHeaderMenu ? cellPadding * 3 : cellPadding}px ${cellPadding}px ${cellPadding}px`,
       overflow: 'hidden',
       whiteSpace: 'nowrap',
       display: 'flex',
@@ -247,6 +247,11 @@ export function useTableStyles(theme: GrafanaTheme2, cellHeightOption: TableCell
     }),
     imageCell: css({
       height: '100%',
+    }),
+    headerMenuIcon: css({
+      position: 'absolute',
+      right: '4px',
+      cursor: 'pointer',
     }),
     resizeHandle: css({
       label: 'resizeHandle',

--- a/packages/grafana-ui/src/components/Table/types.ts
+++ b/packages/grafana-ui/src/components/Table/types.ts
@@ -99,6 +99,7 @@ export interface Props {
   enableSharedCrosshair?: boolean;
   // The index of the field value that the table will initialize scrolled to
   initialRowIndex?: number;
+  headerMenuClick?: (fieldName: string) => void;
 }
 
 /**

--- a/public/app/features/explore/Logs/LogsTable.tsx
+++ b/public/app/features/explore/Logs/LogsTable.tsx
@@ -170,6 +170,9 @@ export function LogsTable(props: Props) {
       onCellFilterAdded={props.onClickFilterLabel && props.onClickFilterOutLabel ? onCellFilterAdded : undefined}
       height={props.height}
       footerOptions={{ show: true, reducer: ['count'], countRows: true }}
+      headerMenuClick={(fieldName) => {
+        console.log('headerMenuClick', fieldName);
+      }}
     />
   );
 }


### PR DESCRIPTION
**What is this feature?**
Adding the ability to add a menu to table headers.

<img width="549" alt="image" src="https://github.com/grafana/grafana/assets/109082771/0fe03bdf-bbc8-43de-a32e-1aee28b7a6a7">

**Why do we need this feature?**
So developers of higher order components can provide more interactive functionality to table.

**Who is this feature for?**
Developers using table viz.

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
