### PR TITLE
FeatureToggles: keep older history

### DIFF
--- a/pkg/services/featuremgmt/toggles_gen.json
+++ b/pkg/services/featuremgmt/toggles_gen.json
@@ -5,686 +5,22 @@
   "items": [
     {
       "metadata": {
-        "name": "lokiExperimentalStreaming",
-        "resourceVersion": "1707755276481",
-        "creationTimestamp": "2024-02-12T16:27:56Z"
+        "name": "disableEnvelopeEncryption",
+        "resourceVersion": "1653393600000",
+        "creationTimestamp": "2022-05-24T12:00:00Z"
       },
       "spec": {
-        "description": "Support new streaming approach for loki (prototype, needs special loki build)",
-        "stage": "experimental",
-        "codeowner": "@grafana/observability-logs"
-      }
-    },
-    {
-      "metadata": {
-        "name": "enablePluginsTracingByDefault",
-        "resourceVersion": "1707755276481",
-        "creationTimestamp": "2024-02-12T16:27:56Z"
-      },
-      "spec": {
-        "description": "Enable plugin tracing for all external plugins",
-        "stage": "experimental",
-        "codeowner": "@grafana/plugins-platform-backend",
-        "requiresRestart": true
-      }
-    },
-    {
-      "metadata": {
-        "name": "sseGroupByDatasource",
-        "resourceVersion": "1707755276481",
-        "creationTimestamp": "2024-02-12T16:27:56Z"
-      },
-      "spec": {
-        "description": "Send query to the same datasource in a single request when using server side expressions. The `cloudWatchBatchQueries` feature toggle should be enabled if this used with CloudWatch.",
-        "stage": "experimental",
-        "codeowner": "@grafana/observability-metrics"
-      }
-    },
-    {
-      "metadata": {
-        "name": "cloudWatchBatchQueries",
-        "resourceVersion": "1707755276481",
-        "creationTimestamp": "2024-02-12T16:27:56Z"
-      },
-      "spec": {
-        "description": "Runs CloudWatch metrics queries as separate batches",
-        "stage": "preview",
-        "codeowner": "@grafana/aws-datasources"
-      }
-    },
-    {
-      "metadata": {
-        "name": "managedPluginsInstall",
-        "resourceVersion": "1707755276481",
-        "creationTimestamp": "2024-02-12T16:27:56Z"
-      },
-      "spec": {
-        "description": "Install managed plugins directly from plugins catalog",
-        "stage": "preview",
-        "codeowner": "@grafana/plugins-platform-backend"
-      }
-    },
-    {
-      "metadata": {
-        "name": "pdfTables",
-        "resourceVersion": "1707755276481",
-        "creationTimestamp": "2024-02-12T16:27:56Z"
-      },
-      "spec": {
-        "description": "Enables generating table data as PDF in reporting",
-        "stage": "preview",
-        "codeowner": "@grafana/sharing-squad"
-      }
-    },
-    {
-      "metadata": {
-        "name": "logsInfiniteScrolling",
-        "resourceVersion": "1707755276481",
-        "creationTimestamp": "2024-02-12T16:27:56Z"
-      },
-      "spec": {
-        "description": "Enables infinite scrolling for the Logs panel in Explore and Dashboards",
-        "stage": "experimental",
-        "codeowner": "@grafana/observability-logs",
-        "frontend": true
-      }
-    },
-    {
-      "metadata": {
-        "name": "enableDatagridEditing",
-        "resourceVersion": "1707755276481",
-        "creationTimestamp": "2024-02-12T16:27:56Z"
-      },
-      "spec": {
-        "description": "Enables the edit functionality in the datagrid panel",
-        "stage": "preview",
-        "codeowner": "@grafana/dataviz-squad",
-        "frontend": true
-      }
-    },
-    {
-      "metadata": {
-        "name": "splitScopes",
-        "resourceVersion": "1707755276481",
-        "creationTimestamp": "2024-02-12T16:27:56Z"
-      },
-      "spec": {
-        "description": "Support faster dashboard and folder search by splitting permission scopes into parts",
-        "stage": "deprecated",
-        "codeowner": "@grafana/identity-access-team",
-        "requiresRestart": true,
-        "hideFromAdminPage": true
-      }
-    },
-    {
-      "metadata": {
-        "name": "permissionsFilterRemoveSubquery",
-        "resourceVersion": "1707755276481",
-        "creationTimestamp": "2024-02-12T16:27:56Z"
-      },
-      "spec": {
-        "description": "Alternative permission filter implementation that does not use subqueries for fetching the dashboard folder",
-        "stage": "experimental",
-        "codeowner": "@grafana/backend-platform"
-      }
-    },
-    {
-      "metadata": {
-        "name": "panelFilterVariable",
-        "resourceVersion": "1707755276481",
-        "creationTimestamp": "2024-02-12T16:27:56Z"
-      },
-      "spec": {
-        "description": "Enables use of the `systemPanelFilterVar` variable to filter panels in a dashboard",
-        "stage": "experimental",
-        "codeowner": "@grafana/dashboards-squad",
-        "frontend": true,
-        "hideFromDocs": true
-      }
-    },
-    {
-      "metadata": {
-        "name": "displayAnonymousStats",
-        "resourceVersion": "1707755276481",
-        "creationTimestamp": "2024-02-12T16:27:56Z"
-      },
-      "spec": {
-        "description": "Enables anonymous stats to be shown in the UI for Grafana",
-        "stage": "GA",
-        "codeowner": "@grafana/identity-access-team",
-        "frontend": true
-      }
-    },
-    {
-      "metadata": {
-        "name": "logRequestsInstrumentedAsUnknown",
-        "resourceVersion": "1707755276481",
-        "creationTimestamp": "2024-02-12T16:27:56Z"
-      },
-      "spec": {
-        "description": "Logs the path for requests that are instrumented as unknown",
-        "stage": "experimental",
-        "codeowner": "@grafana/hosted-grafana-team"
-      }
-    },
-    {
-      "metadata": {
-        "name": "dashboardEmbed",
-        "resourceVersion": "1707755276481",
-        "creationTimestamp": "2024-02-12T16:27:56Z"
-      },
-      "spec": {
-        "description": "Allow embedding dashboard for external use in Code editors",
-        "stage": "experimental",
-        "codeowner": "@grafana/grafana-as-code",
-        "frontend": true
-      }
-    },
-    {
-      "metadata": {
-        "name": "sqlDatasourceDatabaseSelection",
-        "resourceVersion": "1707755276481",
-        "creationTimestamp": "2024-02-12T16:27:56Z"
-      },
-      "spec": {
-        "description": "Enables previous SQL data source dataset dropdown behavior",
-        "stage": "preview",
-        "codeowner": "@grafana/dataviz-squad",
-        "frontend": true,
-        "hideFromAdminPage": true
-      }
-    },
-    {
-      "metadata": {
-        "name": "kubernetesSnapshots",
-        "resourceVersion": "1707755276481",
-        "creationTimestamp": "2024-02-12T16:27:56Z"
-      },
-      "spec": {
-        "description": "Routes snapshot requests from /api to the /apis endpoint",
-        "stage": "experimental",
-        "codeowner": "@grafana/grafana-app-platform-squad",
-        "requiresRestart": true
-      }
-    },
-    {
-      "metadata": {
-        "name": "extractFieldsNameDeduplication",
-        "resourceVersion": "1707755276481",
-        "creationTimestamp": "2024-02-12T16:27:56Z"
-      },
-      "spec": {
-        "description": "Make sure extracted field names are unique in the dataframe",
-        "stage": "experimental",
-        "codeowner": "@grafana/dataviz-squad",
-        "frontend": true
-      }
-    },
-    {
-      "metadata": {
-        "name": "vizAndWidgetSplit",
-        "resourceVersion": "1707755276481",
-        "creationTimestamp": "2024-02-12T16:27:56Z"
-      },
-      "spec": {
-        "description": "Split panels between visualizations and widgets",
-        "stage": "experimental",
-        "codeowner": "@grafana/dashboards-squad",
-        "frontend": true
-      }
-    },
-    {
-      "metadata": {
-        "name": "idForwarding",
-        "resourceVersion": "1707755276481",
-        "creationTimestamp": "2024-02-12T16:27:56Z"
-      },
-      "spec": {
-        "description": "Generate signed id token for identity that can be forwarded to plugins and external services",
-        "stage": "experimental",
-        "codeowner": "@grafana/identity-access-team"
-      }
-    },
-    {
-      "metadata": {
-        "name": "featureHighlights",
-        "resourceVersion": "1707755276481",
-        "creationTimestamp": "2024-02-12T16:27:56Z"
-      },
-      "spec": {
-        "description": "Highlight Grafana Enterprise features",
+        "description": "Disable envelope encryption (emergency only)",
         "stage": "GA",
         "codeowner": "@grafana/grafana-as-code",
-        "allowSelfServe": true
-      }
-    },
-    {
-      "metadata": {
-        "name": "clientTokenRotation",
-        "resourceVersion": "1707755276481",
-        "creationTimestamp": "2024-02-12T16:27:56Z"
-      },
-      "spec": {
-        "description": "Replaces the current in-request token rotation so that the client initiates the rotation",
-        "stage": "GA",
-        "codeowner": "@grafana/identity-access-team"
-      }
-    },
-    {
-      "metadata": {
-        "name": "unifiedRequestLog",
-        "resourceVersion": "1707755276481",
-        "creationTimestamp": "2024-02-12T16:27:56Z"
-      },
-      "spec": {
-        "description": "Writes error logs to the request logger",
-        "stage": "experimental",
-        "codeowner": "@grafana/backend-platform"
-      }
-    },
-    {
-      "metadata": {
-        "name": "kubernetesQueryServiceRewrite",
-        "resourceVersion": "1707755276481",
-        "creationTimestamp": "2024-02-12T16:27:56Z"
-      },
-      "spec": {
-        "description": "Rewrite requests targeting /ds/query to the query service",
-        "stage": "experimental",
-        "codeowner": "@grafana/grafana-app-platform-squad",
-        "requiresDevMode": true,
-        "requiresRestart": true
-      }
-    },
-    {
-      "metadata": {
-        "name": "alertmanagerRemoteOnly",
-        "resourceVersion": "1707755276481",
-        "creationTimestamp": "2024-02-12T16:27:56Z"
-      },
-      "spec": {
-        "description": "Disable the internal Alertmanager and only use the external one defined.",
-        "stage": "experimental",
-        "codeowner": "@grafana/alerting-squad"
-      }
-    },
-    {
-      "metadata": {
-        "name": "alertStateHistoryLokiPrimary",
-        "resourceVersion": "1707755276481",
-        "creationTimestamp": "2024-02-12T16:27:56Z"
-      },
-      "spec": {
-        "description": "Enable a remote Loki instance as the primary source for state history reads.",
-        "stage": "experimental",
-        "codeowner": "@grafana/alerting-squad"
-      }
-    },
-    {
-      "metadata": {
-        "name": "extraThemes",
-        "resourceVersion": "1707755276481",
-        "creationTimestamp": "2024-02-12T16:27:56Z"
-      },
-      "spec": {
-        "description": "Enables extra themes",
-        "stage": "experimental",
-        "codeowner": "@grafana/grafana-frontend-platform",
-        "frontend": true
-      }
-    },
-    {
-      "metadata": {
-        "name": "awsDatasourcesTempCredentials",
-        "resourceVersion": "1707755276481",
-        "creationTimestamp": "2024-02-12T16:27:56Z"
-      },
-      "spec": {
-        "description": "Support temporary security credentials in AWS plugins for Grafana Cloud customers",
-        "stage": "experimental",
-        "codeowner": "@grafana/aws-datasources"
-      }
-    },
-    {
-      "metadata": {
-        "name": "nestedFolders",
-        "resourceVersion": "1707755276481",
-        "creationTimestamp": "2024-02-12T16:27:56Z"
-      },
-      "spec": {
-        "description": "Enable folder nesting",
-        "stage": "preview",
-        "codeowner": "@grafana/backend-platform"
-      }
-    },
-    {
-      "metadata": {
-        "name": "lokiLogsDataplane",
-        "resourceVersion": "1707755276481",
-        "creationTimestamp": "2024-02-12T16:27:56Z"
-      },
-      "spec": {
-        "description": "Changes logs responses from Loki to be compliant with the dataplane specification.",
-        "stage": "experimental",
-        "codeowner": "@grafana/observability-logs"
-      }
-    },
-    {
-      "metadata": {
-        "name": "groupToNestedTableTransformation",
-        "resourceVersion": "1707755276481",
-        "creationTimestamp": "2024-02-12T16:27:56Z"
-      },
-      "spec": {
-        "description": "Enables the group to nested table transformation",
-        "stage": "preview",
-        "codeowner": "@grafana/dataviz-squad",
-        "frontend": true
-      }
-    },
-    {
-      "metadata": {
-        "name": "topnav",
-        "resourceVersion": "1707755276481",
-        "creationTimestamp": "2024-02-12T16:27:56Z"
-      },
-      "spec": {
-        "description": "Enables topnav support in external plugins. The new Grafana navigation cannot be disabled.",
-        "stage": "deprecated",
-        "codeowner": "@grafana/grafana-frontend-platform"
-      }
-    },
-    {
-      "metadata": {
-        "name": "unifiedStorage",
-        "resourceVersion": "1707755276481",
-        "creationTimestamp": "2024-02-12T16:27:56Z"
-      },
-      "spec": {
-        "description": "SQL-based k8s storage",
-        "stage": "experimental",
-        "codeowner": "@grafana/grafana-app-platform-squad",
-        "requiresDevMode": true,
-        "requiresRestart": true
-      }
-    },
-    {
-      "metadata": {
-        "name": "ssoSettingsApi",
-        "resourceVersion": "1707755276481",
-        "creationTimestamp": "2024-02-12T16:27:56Z"
-      },
-      "spec": {
-        "description": "Enables the SSO settings API",
-        "stage": "experimental",
-        "codeowner": "@grafana/identity-access-team"
-      }
-    },
-    {
-      "metadata": {
-        "name": "canvasPanelPanZoom",
-        "resourceVersion": "1707755276481",
-        "creationTimestamp": "2024-02-12T16:27:56Z"
-      },
-      "spec": {
-        "description": "Allow pan and zoom in canvas panel",
-        "stage": "preview",
-        "codeowner": "@grafana/dataviz-squad",
-        "frontend": true
-      }
-    },
-    {
-      "metadata": {
-        "name": "newPDFRendering",
-        "resourceVersion": "1707755276481",
-        "creationTimestamp": "2024-02-12T16:27:56Z"
-      },
-      "spec": {
-        "description": "New implementation for the dashboard to PDF rendering",
-        "stage": "experimental",
-        "codeowner": "@grafana/sharing-squad"
-      }
-    },
-    {
-      "metadata": {
-        "name": "alertingNoDataErrorExecution",
-        "resourceVersion": "1707755276481",
-        "creationTimestamp": "2024-02-12T16:27:56Z"
-      },
-      "spec": {
-        "description": "Changes how Alerting state manager handles execution of NoData/Error",
-        "stage": "GA",
-        "codeowner": "@grafana/alerting-squad",
-        "requiresRestart": true
-      }
-    },
-    {
-      "metadata": {
-        "name": "panelMonitoring",
-        "resourceVersion": "1707755276481",
-        "creationTimestamp": "2024-02-12T16:27:56Z"
-      },
-      "spec": {
-        "description": "Enables panel monitoring through logs and measurements",
-        "stage": "experimental",
-        "codeowner": "@grafana/dataviz-squad",
-        "frontend": true
-      }
-    },
-    {
-      "metadata": {
-        "name": "pluginsInstrumentationStatusSource",
-        "resourceVersion": "1707755276481",
-        "creationTimestamp": "2024-02-12T16:27:56Z"
-      },
-      "spec": {
-        "description": "Include a status source label for plugin request metrics and logs",
-        "stage": "experimental",
-        "codeowner": "@grafana/plugins-platform-backend"
-      }
-    },
-    {
-      "metadata": {
-        "name": "dashboardSceneForViewers",
-        "resourceVersion": "1707755276481",
-        "creationTimestamp": "2024-02-12T16:27:56Z"
-      },
-      "spec": {
-        "description": "Enables dashboard rendering using Scenes for viewer roles",
-        "stage": "experimental",
-        "codeowner": "@grafana/dashboards-squad",
-        "frontend": true
-      }
-    },
-    {
-      "metadata": {
-        "name": "lokiQueryHints",
-        "resourceVersion": "1707755276481",
-        "creationTimestamp": "2024-02-12T16:27:56Z"
-      },
-      "spec": {
-        "description": "Enables query hints for Loki",
-        "stage": "GA",
-        "codeowner": "@grafana/observability-logs",
-        "frontend": true
-      }
-    },
-    {
-      "metadata": {
-        "name": "editPanelCSVDragAndDrop",
-        "resourceVersion": "1707755276481",
-        "creationTimestamp": "2024-02-12T16:27:56Z"
-      },
-      "spec": {
-        "description": "Enables drag and drop for CSV and Excel files",
-        "stage": "experimental",
-        "codeowner": "@grafana/dataviz-squad",
-        "frontend": true
-      }
-    },
-    {
-      "metadata": {
-        "name": "dataplaneFrontendFallback",
-        "resourceVersion": "1707755276481",
-        "creationTimestamp": "2024-02-12T16:27:56Z"
-      },
-      "spec": {
-        "description": "Support dataplane contract field name change for transformations and field name matchers where the name is different",
-        "stage": "GA",
-        "codeowner": "@grafana/observability-metrics",
-        "frontend": true,
-        "allowSelfServe": true
-      }
-    },
-    {
-      "metadata": {
-        "name": "influxdbSqlSupport",
-        "resourceVersion": "1707755276481",
-        "creationTimestamp": "2024-02-12T16:27:56Z"
-      },
-      "spec": {
-        "description": "Enable InfluxDB SQL query language support with new querying UI",
-        "stage": "GA",
-        "codeowner": "@grafana/observability-metrics",
-        "requiresRestart": true,
-        "allowSelfServe": true
-      }
-    },
-    {
-      "metadata": {
-        "name": "frontendSandboxMonitorOnly",
-        "resourceVersion": "1707755276481",
-        "creationTimestamp": "2024-02-12T16:27:56Z"
-      },
-      "spec": {
-        "description": "Enables monitor only in the plugin frontend sandbox (if enabled)",
-        "stage": "experimental",
-        "codeowner": "@grafana/plugins-platform-backend",
-        "frontend": true
-      }
-    },
-    {
-      "metadata": {
-        "name": "exploreScrollableLogsContainer",
-        "resourceVersion": "1707755276481",
-        "creationTimestamp": "2024-02-12T16:27:56Z"
-      },
-      "spec": {
-        "description": "Improves the scrolling behavior of logs in Explore",
-        "stage": "experimental",
-        "codeowner": "@grafana/observability-logs",
-        "frontend": true
-      }
-    },
-    {
-      "metadata": {
-        "name": "externalCorePlugins",
-        "resourceVersion": "1707755276481",
-        "creationTimestamp": "2024-02-12T16:27:56Z"
-      },
-      "spec": {
-        "description": "Allow core plugins to be loaded as external",
-        "stage": "experimental",
-        "codeowner": "@grafana/plugins-platform-backend"
-      }
-    },
-    {
-      "metadata": {
-        "name": "datatrails",
-        "resourceVersion": "1707755276481",
-        "creationTimestamp": "2024-02-12T16:27:56Z"
-      },
-      "spec": {
-        "description": "Enables the new core app datatrails",
-        "stage": "experimental",
-        "codeowner": "@grafana/dashboards-squad",
-        "frontend": true,
-        "hideFromDocs": true
-      }
-    },
-    {
-      "metadata": {
-        "name": "alertingPreviewUpgrade",
-        "resourceVersion": "1707755276481",
-        "creationTimestamp": "2024-02-12T16:27:56Z"
-      },
-      "spec": {
-        "description": "Show Unified Alerting preview and upgrade page in legacy alerting",
-        "stage": "GA",
-        "codeowner": "@grafana/alerting-squad",
-        "requiresRestart": true
-      }
-    },
-    {
-      "metadata": {
-        "name": "exploreContentOutline",
-        "resourceVersion": "1707755276481",
-        "creationTimestamp": "2024-02-12T16:27:56Z"
-      },
-      "spec": {
-        "description": "Content outline sidebar",
-        "stage": "GA",
-        "codeowner": "@grafana/explore-squad",
-        "frontend": true,
-        "allowSelfServe": true
-      }
-    },
-    {
-      "metadata": {
-        "name": "logsContextDatasourceUi",
-        "resourceVersion": "1707755276481",
-        "creationTimestamp": "2024-02-12T16:27:56Z"
-      },
-      "spec": {
-        "description": "Allow datasource to provide custom UI for context view",
-        "stage": "GA",
-        "codeowner": "@grafana/observability-logs",
-        "frontend": true,
-        "allowSelfServe": true
-      }
-    },
-    {
-      "metadata": {
-        "name": "lokiPredefinedOperations",
-        "resourceVersion": "1707755276481",
-        "creationTimestamp": "2024-02-12T16:27:56Z"
-      },
-      "spec": {
-        "description": "Adds predefined query operations to Loki query editor",
-        "stage": "experimental",
-        "codeowner": "@grafana/observability-logs",
-        "frontend": true
-      }
-    },
-    {
-      "metadata": {
-        "name": "lokiRunQueriesInParallel",
-        "resourceVersion": "1707755276481",
-        "creationTimestamp": "2024-02-12T16:27:56Z"
-      },
-      "spec": {
-        "description": "Enables running Loki queries in parallel",
-        "stage": "privatePreview",
-        "codeowner": "@grafana/observability-logs"
-      }
-    },
-    {
-      "metadata": {
-        "name": "promQLScope",
-        "resourceVersion": "1707755276481",
-        "creationTimestamp": "2024-02-12T16:27:56Z"
-      },
-      "spec": {
-        "description": "In-development feature that will allow injection of labels into prometheus queries.",
-        "stage": "experimental",
-        "codeowner": "@grafana/observability-metrics"
+        "hideFromAdminPage": true
       }
     },
     {
       "metadata": {
         "name": "live-service-web-worker",
-        "resourceVersion": "1707755276481",
-        "creationTimestamp": "2024-02-12T16:27:56Z"
+        "resourceVersion": "1636459200000",
+        "creationTimestamp": "2021-11-09T12:00:00Z"
       },
       "spec": {
         "description": "This will use a webworker thread to processes events rather than the main thread",
@@ -695,112 +31,48 @@
     },
     {
       "metadata": {
-        "name": "disableSecretsCompatibility",
-        "resourceVersion": "1707755276481",
-        "creationTimestamp": "2024-02-12T16:27:56Z"
+        "name": "queryOverLive",
+        "resourceVersion": "1641384000000",
+        "creationTimestamp": "2022-01-05T12:00:00Z"
       },
       "spec": {
-        "description": "Disable duplicated secret storage in legacy tables",
+        "description": "Use Grafana Live WebSocket to execute backend queries",
         "stage": "experimental",
-        "codeowner": "@grafana/hosted-grafana-team",
-        "requiresRestart": true
-      }
-    },
-    {
-      "metadata": {
-        "name": "prometheusIncrementalQueryInstrumentation",
-        "resourceVersion": "1707755276481",
-        "creationTimestamp": "2024-02-12T16:27:56Z"
-      },
-      "spec": {
-        "description": "Adds RudderStack events to incremental queries",
-        "stage": "experimental",
-        "codeowner": "@grafana/observability-metrics",
+        "codeowner": "@grafana/grafana-app-platform-squad",
         "frontend": true
       }
     },
     {
       "metadata": {
-        "name": "storage",
-        "resourceVersion": "1707755276481",
-        "creationTimestamp": "2024-02-12T16:27:56Z"
+        "name": "panelTitleSearch",
+        "resourceVersion": "1644926400000",
+        "creationTimestamp": "2022-02-15T12:00:00Z"
       },
       "spec": {
-        "description": "Configurable storage for dashboards, datasources, and resources",
-        "stage": "experimental",
-        "codeowner": "@grafana/grafana-app-platform-squad"
-      }
-    },
-    {
-      "metadata": {
-        "name": "redshiftAsyncQueryDataSupport",
-        "resourceVersion": "1707755276481",
-        "creationTimestamp": "2024-02-12T16:27:56Z"
-      },
-      "spec": {
-        "description": "Enable async query data support for Redshift",
-        "stage": "GA",
-        "codeowner": "@grafana/aws-datasources"
-      }
-    },
-    {
-      "metadata": {
-        "name": "awsDatasourcesNewFormStyling",
-        "resourceVersion": "1707755276481",
-        "creationTimestamp": "2024-02-12T16:27:56Z"
-      },
-      "spec": {
-        "description": "Applies new form styling for configuration and query editors in AWS plugins",
+        "description": "Search for dashboards using panel title",
         "stage": "preview",
-        "codeowner": "@grafana/aws-datasources",
-        "frontend": true
+        "codeowner": "@grafana/grafana-app-platform-squad",
+        "hideFromAdminPage": true
       }
     },
     {
       "metadata": {
-        "name": "libraryPanelRBAC",
-        "resourceVersion": "1707755276481",
-        "creationTimestamp": "2024-02-12T16:27:56Z"
+        "name": "publicDashboards",
+        "resourceVersion": "1649332800000",
+        "creationTimestamp": "2022-04-07T12:00:00Z"
       },
       "spec": {
-        "description": "Enables RBAC support for library panels",
-        "stage": "experimental",
-        "codeowner": "@grafana/dashboards-squad",
-        "requiresRestart": true
-      }
-    },
-    {
-      "metadata": {
-        "name": "flameGraphItemCollapsing",
-        "resourceVersion": "1707755276481",
-        "creationTimestamp": "2024-02-12T16:27:56Z"
-      },
-      "spec": {
-        "description": "Allow collapsing of flame graph items",
-        "stage": "experimental",
-        "codeowner": "@grafana/observability-traces-and-profiling",
-        "frontend": true
-      }
-    },
-    {
-      "metadata": {
-        "name": "alertingDetailsViewV2",
-        "resourceVersion": "1707755276481",
-        "creationTimestamp": "2024-02-12T16:27:56Z"
-      },
-      "spec": {
-        "description": "Enables the preview of the new alert details view",
-        "stage": "experimental",
-        "codeowner": "@grafana/alerting-squad",
-        "frontend": true,
-        "hideFromDocs": true
+        "description": "[Deprecated] Public dashboards are now enabled by default; to disable them, use the configuration setting. This feature toggle will be removed in the next major version.",
+        "stage": "GA",
+        "codeowner": "@grafana/sharing-squad",
+        "allowSelfServe": true
       }
     },
     {
       "metadata": {
         "name": "publicDashboardsEmailSharing",
-        "resourceVersion": "1707755276481",
-        "creationTimestamp": "2024-02-12T16:27:56Z"
+        "resourceVersion": "1671624000000",
+        "creationTimestamp": "2022-12-21T12:00:00Z"
       },
       "spec": {
         "description": "Enables public dashboard sharing to be restricted to only allowed emails",
@@ -812,98 +84,58 @@
     },
     {
       "metadata": {
-        "name": "influxdbBackendMigration",
-        "resourceVersion": "1707755276481",
-        "creationTimestamp": "2024-02-12T16:27:56Z"
+        "name": "lokiExperimentalStreaming",
+        "resourceVersion": "1687176000000",
+        "creationTimestamp": "2023-06-19T12:00:00Z"
       },
       "spec": {
-        "description": "Query InfluxDB InfluxQL without the proxy",
+        "description": "Support new streaming approach for loki (prototype, needs special loki build)",
+        "stage": "experimental",
+        "codeowner": "@grafana/observability-logs"
+      }
+    },
+    {
+      "metadata": {
+        "name": "featureHighlights",
+        "resourceVersion": "1643889600000",
+        "creationTimestamp": "2022-02-03T12:00:00Z"
+      },
+      "spec": {
+        "description": "Highlight Grafana Enterprise features",
         "stage": "GA",
-        "codeowner": "@grafana/observability-metrics",
-        "frontend": true
+        "codeowner": "@grafana/grafana-as-code",
+        "allowSelfServe": true
       }
     },
     {
       "metadata": {
-        "name": "angularDeprecationUI",
-        "resourceVersion": "1707755276481",
-        "creationTimestamp": "2024-02-12T16:27:56Z"
+        "name": "migrationLocking",
+        "resourceVersion": "1644926400000",
+        "creationTimestamp": "2022-02-15T12:00:00Z"
       },
       "spec": {
-        "description": "Display new Angular deprecation-related UI features",
+        "description": "Lock database during migrations",
+        "stage": "preview",
+        "codeowner": "@grafana/backend-platform"
+      }
+    },
+    {
+      "metadata": {
+        "name": "storage",
+        "resourceVersion": "1647518400000",
+        "creationTimestamp": "2022-03-17T12:00:00Z"
+      },
+      "spec": {
+        "description": "Configurable storage for dashboards, datasources, and resources",
         "stage": "experimental",
-        "codeowner": "@grafana/plugins-platform-backend",
-        "frontend": true
-      }
-    },
-    {
-      "metadata": {
-        "name": "grafanaAPIServerWithExperimentalAPIs",
-        "resourceVersion": "1707755276481",
-        "creationTimestamp": "2024-02-12T16:27:56Z"
-      },
-      "spec": {
-        "description": "Register experimental APIs with the k8s API server",
-        "stage": "experimental",
-        "codeowner": "@grafana/grafana-app-platform-squad",
-        "requiresDevMode": true,
-        "requiresRestart": true
-      }
-    },
-    {
-      "metadata": {
-        "name": "awsAsyncQueryCaching",
-        "resourceVersion": "1707755276481",
-        "creationTimestamp": "2024-02-12T16:27:56Z"
-      },
-      "spec": {
-        "description": "Enable caching for async queries for Redshift and Athena. Requires that the datasource has caching and async query support enabled",
-        "stage": "GA",
-        "codeowner": "@grafana/aws-datasources"
-      }
-    },
-    {
-      "metadata": {
-        "name": "wargamesTesting",
-        "resourceVersion": "1707755276481",
-        "creationTimestamp": "2024-02-12T16:27:56Z"
-      },
-      "spec": {
-        "description": "Placeholder feature flag for internal testing",
-        "stage": "experimental",
-        "codeowner": "@grafana/hosted-grafana-team"
-      }
-    },
-    {
-      "metadata": {
-        "name": "teamHttpHeaders",
-        "resourceVersion": "1707755276481",
-        "creationTimestamp": "2024-02-12T16:27:56Z"
-      },
-      "spec": {
-        "description": "Enables datasources to apply team headers to the client requests",
-        "stage": "experimental",
-        "codeowner": "@grafana/identity-access-team"
-      }
-    },
-    {
-      "metadata": {
-        "name": "dashboardScene",
-        "resourceVersion": "1707755276481",
-        "creationTimestamp": "2024-02-12T16:27:56Z"
-      },
-      "spec": {
-        "description": "Enables dashboard rendering using scenes for all roles",
-        "stage": "experimental",
-        "codeowner": "@grafana/dashboards-squad",
-        "frontend": true
+        "codeowner": "@grafana/grafana-app-platform-squad"
       }
     },
     {
       "metadata": {
         "name": "correlations",
-        "resourceVersion": "1707755276481",
-        "creationTimestamp": "2024-02-12T16:27:56Z"
+        "resourceVersion": "1663329600000",
+        "creationTimestamp": "2022-09-16T12:00:00Z"
       },
       "spec": {
         "description": "Correlations page",
@@ -914,9 +146,23 @@
     },
     {
       "metadata": {
+        "name": "exploreContentOutline",
+        "resourceVersion": "1699012800000",
+        "creationTimestamp": "2023-11-03T12:00:00Z"
+      },
+      "spec": {
+        "description": "Content outline sidebar",
+        "stage": "GA",
+        "codeowner": "@grafana/explore-squad",
+        "frontend": true,
+        "allowSelfServe": true
+      }
+    },
+    {
+      "metadata": {
         "name": "datasourceQueryMultiStatus",
-        "resourceVersion": "1707755276481",
-        "creationTimestamp": "2024-02-12T16:27:56Z"
+        "resourceVersion": "1651579200000",
+        "creationTimestamp": "2022-05-03T12:00:00Z"
       },
       "spec": {
         "description": "Introduce HTTP 207 Multi Status for api/ds/query",
@@ -926,12 +172,12 @@
     },
     {
       "metadata": {
-        "name": "traceQLStreaming",
-        "resourceVersion": "1707755276481",
-        "creationTimestamp": "2024-02-12T16:27:56Z"
+        "name": "traceToMetrics",
+        "resourceVersion": "1646654400000",
+        "creationTimestamp": "2022-03-07T12:00:00Z"
       },
       "spec": {
-        "description": "Enables response streaming of TraceQL queries of the Tempo data source",
+        "description": "Enable trace to metrics links",
         "stage": "experimental",
         "codeowner": "@grafana/observability-traces-and-profiling",
         "frontend": true
@@ -939,63 +185,22 @@
     },
     {
       "metadata": {
-        "name": "returnToPrevious",
-        "resourceVersion": "1707755276481",
-        "creationTimestamp": "2024-02-12T16:27:56Z"
+        "name": "autoMigrateOldPanels",
+        "resourceVersion": "1654948800000",
+        "creationTimestamp": "2022-06-11T12:00:00Z"
       },
       "spec": {
-        "description": "Enables the return to previous context functionality",
-        "stage": "experimental",
-        "codeowner": "@grafana/grafana-frontend-platform",
+        "description": "Migrate old angular panels to supported versions (graph, table-old, worldmap, etc)",
+        "stage": "preview",
+        "codeowner": "@grafana/dataviz-squad",
         "frontend": true
       }
     },
     {
       "metadata": {
-        "name": "cloudRBACRoles",
-        "resourceVersion": "1707755276481",
-        "creationTimestamp": "2024-02-12T16:27:56Z"
-      },
-      "spec": {
-        "description": "Enabled grafana cloud specific RBAC roles",
-        "stage": "experimental",
-        "codeowner": "@grafana/identity-access-team",
-        "requiresRestart": true,
-        "hideFromDocs": true
-      }
-    },
-    {
-      "metadata": {
-        "name": "kubernetesAggregator",
-        "resourceVersion": "1707755276481",
-        "creationTimestamp": "2024-02-12T16:27:56Z"
-      },
-      "spec": {
-        "description": "Enable grafana aggregator",
-        "stage": "experimental",
-        "codeowner": "@grafana/grafana-app-platform-squad",
-        "requiresRestart": true
-      }
-    },
-    {
-      "metadata": {
-        "name": "kubernetesFeatureToggles",
-        "resourceVersion": "1707755276481",
-        "creationTimestamp": "2024-02-12T16:27:56Z"
-      },
-      "spec": {
-        "description": "Use the kubernetes API for feature toggle management in the frontend",
-        "stage": "experimental",
-        "codeowner": "@grafana/grafana-operator-experience-squad",
-        "frontend": true,
-        "hideFromAdminPage": true
-      }
-    },
-    {
-      "metadata": {
         "name": "disableAngular",
-        "resourceVersion": "1707755276481",
-        "creationTimestamp": "2024-02-12T16:27:56Z"
+        "resourceVersion": "1679572800000",
+        "creationTimestamp": "2023-03-23T12:00:00Z"
       },
       "spec": {
         "description": "Dynamic flag to disable angular at runtime. The preferred method is to set `angular_support_enabled` to `false` in the [security] settings, which allows you to change the state at runtime.",
@@ -1008,8 +213,8 @@
     {
       "metadata": {
         "name": "canvasPanelNesting",
-        "resourceVersion": "1707755276481",
-        "creationTimestamp": "2024-02-12T16:27:56Z"
+        "resourceVersion": "1653998400000",
+        "creationTimestamp": "2022-05-31T12:00:00Z"
       },
       "spec": {
         "description": "Allow elements nesting",
@@ -1021,495 +226,9 @@
     },
     {
       "metadata": {
-        "name": "dashboardSceneSolo",
-        "resourceVersion": "1707755276481",
-        "creationTimestamp": "2024-02-12T16:27:56Z"
-      },
-      "spec": {
-        "description": "Enables rendering dashboards using scenes for solo panels",
-        "stage": "experimental",
-        "codeowner": "@grafana/dashboards-squad",
-        "frontend": true
-      }
-    },
-    {
-      "metadata": {
-        "name": "recordedQueriesMulti",
-        "resourceVersion": "1707755276481",
-        "creationTimestamp": "2024-02-12T16:27:56Z"
-      },
-      "spec": {
-        "description": "Enables writing multiple items from a single query within Recorded Queries",
-        "stage": "GA",
-        "codeowner": "@grafana/observability-metrics"
-      }
-    },
-    {
-      "metadata": {
-        "name": "pluginsSkipHostEnvVars",
-        "resourceVersion": "1707755276481",
-        "creationTimestamp": "2024-02-12T16:27:56Z"
-      },
-      "spec": {
-        "description": "Disables passing host environment variable to plugin processes",
-        "stage": "experimental",
-        "codeowner": "@grafana/plugins-platform-backend"
-      }
-    },
-    {
-      "metadata": {
-        "name": "autoMigrateGraphPanel",
-        "resourceVersion": "1707755276481",
-        "creationTimestamp": "2024-02-12T16:27:56Z"
-      },
-      "spec": {
-        "description": "Migrate old graph panel to supported time series panel - broken out from autoMigrateOldPanels to enable granular tracking",
-        "stage": "preview",
-        "codeowner": "@grafana/dataviz-squad",
-        "frontend": true
-      }
-    },
-    {
-      "metadata": {
-        "name": "lokiQuerySplittingConfig",
-        "resourceVersion": "1707755276481",
-        "creationTimestamp": "2024-02-12T16:27:56Z"
-      },
-      "spec": {
-        "description": "Give users the option to configure split durations for Loki queries",
-        "stage": "experimental",
-        "codeowner": "@grafana/observability-logs",
-        "frontend": true
-      }
-    },
-    {
-      "metadata": {
-        "name": "enableElasticsearchBackendQuerying",
-        "resourceVersion": "1707755276481",
-        "creationTimestamp": "2024-02-12T16:27:56Z"
-      },
-      "spec": {
-        "description": "Enable the processing of queries and responses in the Elasticsearch data source through backend",
-        "stage": "GA",
-        "codeowner": "@grafana/observability-logs",
-        "allowSelfServe": true
-      }
-    },
-    {
-      "metadata": {
-        "name": "refactorVariablesTimeRange",
-        "resourceVersion": "1707755276481",
-        "creationTimestamp": "2024-02-12T16:27:56Z"
-      },
-      "spec": {
-        "description": "Refactor time range variables flow to reduce number of API calls made when query variables are chained",
-        "stage": "preview",
-        "codeowner": "@grafana/dashboards-squad",
-        "hideFromAdminPage": true
-      }
-    },
-    {
-      "metadata": {
-        "name": "cloudWatchLogsMonacoEditor",
-        "resourceVersion": "1707755276481",
-        "creationTimestamp": "2024-02-12T16:27:56Z"
-      },
-      "spec": {
-        "description": "Enables the Monaco editor for CloudWatch Logs queries",
-        "stage": "GA",
-        "codeowner": "@grafana/aws-datasources",
-        "frontend": true,
-        "allowSelfServe": true
-      }
-    },
-    {
-      "metadata": {
-        "name": "grafanaAPIServerEnsureKubectlAccess",
-        "resourceVersion": "1707755276481",
-        "creationTimestamp": "2024-02-12T16:27:56Z"
-      },
-      "spec": {
-        "description": "Start an additional https handler and write kubectl options",
-        "stage": "experimental",
-        "codeowner": "@grafana/grafana-app-platform-squad",
-        "requiresDevMode": true,
-        "requiresRestart": true
-      }
-    },
-    {
-      "metadata": {
-        "name": "formatString",
-        "resourceVersion": "1707755276481",
-        "creationTimestamp": "2024-02-12T16:27:56Z"
-      },
-      "spec": {
-        "description": "Enable format string transformer",
-        "stage": "preview",
-        "codeowner": "@grafana/dataviz-squad",
-        "frontend": true
-      }
-    },
-    {
-      "metadata": {
-        "name": "transformationsVariableSupport",
-        "resourceVersion": "1707755276481",
-        "creationTimestamp": "2024-02-12T16:27:56Z"
-      },
-      "spec": {
-        "description": "Allows using variables in transformations",
-        "stage": "preview",
-        "codeowner": "@grafana/dataviz-squad",
-        "frontend": true
-      }
-    },
-    {
-      "metadata": {
-        "name": "traceToMetrics",
-        "resourceVersion": "1707755276481",
-        "creationTimestamp": "2024-02-12T16:27:56Z"
-      },
-      "spec": {
-        "description": "Enable trace to metrics links",
-        "stage": "experimental",
-        "codeowner": "@grafana/observability-traces-and-profiling",
-        "frontend": true
-      }
-    },
-    {
-      "metadata": {
-        "name": "influxdbRunQueriesInParallel",
-        "resourceVersion": "1707755276481",
-        "creationTimestamp": "2024-02-12T16:27:56Z"
-      },
-      "spec": {
-        "description": "Enables running InfluxDB Influxql queries in parallel",
-        "stage": "privatePreview",
-        "codeowner": "@grafana/observability-metrics"
-      }
-    },
-    {
-      "metadata": {
-        "name": "externalServiceAuth",
-        "resourceVersion": "1707755276481",
-        "creationTimestamp": "2024-02-12T16:27:56Z"
-      },
-      "spec": {
-        "description": "Starts an OAuth2 authentication provider for external services",
-        "stage": "experimental",
-        "codeowner": "@grafana/identity-access-team",
-        "requiresDevMode": true
-      }
-    },
-    {
-      "metadata": {
-        "name": "addFieldFromCalculationStatFunctions",
-        "resourceVersion": "1707755276481",
-        "creationTimestamp": "2024-02-12T16:27:56Z"
-      },
-      "spec": {
-        "description": "Add cumulative and window functions to the add field from calculation transformation",
-        "stage": "preview",
-        "codeowner": "@grafana/dataviz-squad",
-        "frontend": true
-      }
-    },
-    {
-      "metadata": {
-        "name": "alertingSimplifiedRouting",
-        "resourceVersion": "1707755276481",
-        "creationTimestamp": "2024-02-12T16:27:56Z"
-      },
-      "spec": {
-        "description": "Enables the simplified routing for alerting",
-        "stage": "experimental",
-        "codeowner": "@grafana/alerting-squad",
-        "hideFromDocs": true
-      }
-    },
-    {
-      "metadata": {
-        "name": "alertingQueryOptimization",
-        "resourceVersion": "1707755276481",
-        "creationTimestamp": "2024-02-12T16:27:56Z"
-      },
-      "spec": {
-        "description": "Optimizes eligible queries in order to reduce load on datasources",
-        "stage": "GA",
-        "codeowner": "@grafana/alerting-squad"
-      }
-    },
-    {
-      "metadata": {
-        "name": "nodeGraphDotLayout",
-        "resourceVersion": "1707755276481",
-        "creationTimestamp": "2024-02-12T16:27:56Z"
-      },
-      "spec": {
-        "description": "Changed the layout algorithm for the node graph",
-        "stage": "experimental",
-        "codeowner": "@grafana/observability-traces-and-profiling",
-        "frontend": true
-      }
-    },
-    {
-      "metadata": {
-        "name": "logsExploreTableVisualisation",
-        "resourceVersion": "1707755276481",
-        "creationTimestamp": "2024-02-12T16:27:56Z"
-      },
-      "spec": {
-        "description": "A table visualisation for logs in Explore",
-        "stage": "GA",
-        "codeowner": "@grafana/observability-logs",
-        "frontend": true
-      }
-    },
-    {
-      "metadata": {
-        "name": "prometheusConfigOverhaulAuth",
-        "resourceVersion": "1707755276481",
-        "creationTimestamp": "2024-02-12T16:27:56Z"
-      },
-      "spec": {
-        "description": "Update the Prometheus configuration page with the new auth component",
-        "stage": "GA",
-        "codeowner": "@grafana/observability-metrics"
-      }
-    },
-    {
-      "metadata": {
-        "name": "alertmanagerRemoteSecondary",
-        "resourceVersion": "1707755276481",
-        "creationTimestamp": "2024-02-12T16:27:56Z"
-      },
-      "spec": {
-        "description": "Enable Grafana to sync configuration and state with a remote Alertmanager.",
-        "stage": "experimental",
-        "codeowner": "@grafana/alerting-squad"
-      }
-    },
-    {
-      "metadata": {
-        "name": "jitterAlertRulesWithinGroups",
-        "resourceVersion": "1707755276481",
-        "creationTimestamp": "2024-02-12T16:27:56Z"
-      },
-      "spec": {
-        "description": "Distributes alert rule evaluations more evenly over time, including spreading out rules within the same group",
-        "stage": "preview",
-        "codeowner": "@grafana/alerting-squad",
-        "requiresRestart": true,
-        "hideFromDocs": true
-      }
-    },
-    {
-      "metadata": {
-        "name": "alertingSaveStatePeriodic",
-        "resourceVersion": "1707755276481",
-        "creationTimestamp": "2024-02-12T16:27:56Z"
-      },
-      "spec": {
-        "description": "Writes the state periodically to the database, asynchronous to rule evaluation",
-        "stage": "privatePreview",
-        "codeowner": "@grafana/alerting-squad"
-      }
-    },
-    {
-      "metadata": {
-        "name": "alertStateHistoryLokiOnly",
-        "resourceVersion": "1707755276481",
-        "creationTimestamp": "2024-02-12T16:27:56Z"
-      },
-      "spec": {
-        "description": "Disable Grafana alerts from emitting annotations when a remote Loki instance is available.",
-        "stage": "experimental",
-        "codeowner": "@grafana/alerting-squad"
-      }
-    },
-    {
-      "metadata": {
-        "name": "pluginsFrontendSandbox",
-        "resourceVersion": "1707755276481",
-        "creationTimestamp": "2024-02-12T16:27:56Z"
-      },
-      "spec": {
-        "description": "Enables the plugins frontend sandbox",
-        "stage": "experimental",
-        "codeowner": "@grafana/plugins-platform-backend",
-        "frontend": true
-      }
-    },
-    {
-      "metadata": {
-        "name": "lokiFormatQuery",
-        "resourceVersion": "1707755276481",
-        "creationTimestamp": "2024-02-12T16:27:56Z"
-      },
-      "spec": {
-        "description": "Enables the ability to format Loki queries",
-        "stage": "experimental",
-        "codeowner": "@grafana/observability-logs",
-        "frontend": true
-      }
-    },
-    {
-      "metadata": {
-        "name": "alertingInsights",
-        "resourceVersion": "1707755276481",
-        "creationTimestamp": "2024-02-12T16:27:56Z"
-      },
-      "spec": {
-        "description": "Show the new alerting insights landing page",
-        "stage": "GA",
-        "codeowner": "@grafana/alerting-squad",
-        "frontend": true,
-        "hideFromAdminPage": true
-      }
-    },
-    {
-      "metadata": {
-        "name": "nestedFolderPicker",
-        "resourceVersion": "1707755276481",
-        "creationTimestamp": "2024-02-12T16:27:56Z"
-      },
-      "spec": {
-        "description": "Enables the new folder picker to work with nested folders. Requires the nestedFolders feature toggle",
-        "stage": "GA",
-        "codeowner": "@grafana/grafana-frontend-platform",
-        "frontend": true,
-        "allowSelfServe": true
-      }
-    },
-    {
-      "metadata": {
-        "name": "alertingNoNormalState",
-        "resourceVersion": "1707755276481",
-        "creationTimestamp": "2024-02-12T16:27:56Z"
-      },
-      "spec": {
-        "description": "Stop maintaining state of alerts that are not firing",
-        "stage": "preview",
-        "codeowner": "@grafana/alerting-squad",
-        "hideFromAdminPage": true
-      }
-    },
-    {
-      "metadata": {
-        "name": "alertStateHistoryLokiSecondary",
-        "resourceVersion": "1707755276481",
-        "creationTimestamp": "2024-02-12T16:27:56Z"
-      },
-      "spec": {
-        "description": "Enable Grafana to write alert state history to an external Loki instance in addition to Grafana annotations.",
-        "stage": "experimental",
-        "codeowner": "@grafana/alerting-squad"
-      }
-    },
-    {
-      "metadata": {
-        "name": "pluginsAPIMetrics",
-        "resourceVersion": "1707755276481",
-        "creationTimestamp": "2024-02-12T16:27:56Z"
-      },
-      "spec": {
-        "description": "Sends metrics of public grafana packages usage by plugins",
-        "stage": "experimental",
-        "codeowner": "@grafana/plugins-platform-backend",
-        "frontend": true
-      }
-    },
-    {
-      "metadata": {
-        "name": "newFolderPicker",
-        "resourceVersion": "1707755276481",
-        "creationTimestamp": "2024-02-12T16:27:56Z"
-      },
-      "spec": {
-        "description": "Enables the nested folder picker without having nested folders enabled",
-        "stage": "experimental",
-        "codeowner": "@grafana/grafana-frontend-platform",
-        "frontend": true
-      }
-    },
-    {
-      "metadata": {
-        "name": "onPremToCloudMigrations",
-        "resourceVersion": "1707755276481",
-        "creationTimestamp": "2024-02-12T16:27:56Z"
-      },
-      "spec": {
-        "description": "In-development feature that will allow users to easily migrate their on-prem Grafana instances to Grafana Cloud.",
-        "stage": "experimental",
-        "codeowner": "@grafana/grafana-operator-experience-squad"
-      }
-    },
-    {
-      "metadata": {
-        "name": "migrationLocking",
-        "resourceVersion": "1707755276481",
-        "creationTimestamp": "2024-02-12T16:27:56Z"
-      },
-      "spec": {
-        "description": "Lock database during migrations",
-        "stage": "preview",
-        "codeowner": "@grafana/backend-platform"
-      }
-    },
-    {
-      "metadata": {
-        "name": "influxqlStreamingParser",
-        "resourceVersion": "1707755276481",
-        "creationTimestamp": "2024-02-12T16:27:56Z"
-      },
-      "spec": {
-        "description": "Enable streaming JSON parser for InfluxDB datasource InfluxQL query language",
-        "stage": "experimental",
-        "codeowner": "@grafana/observability-metrics"
-      }
-    },
-    {
-      "metadata": {
-        "name": "featureToggleAdminPage",
-        "resourceVersion": "1707755276481",
-        "creationTimestamp": "2024-02-12T16:27:56Z"
-      },
-      "spec": {
-        "description": "Enable admin page for managing feature toggles from the Grafana front-end",
-        "stage": "experimental",
-        "codeowner": "@grafana/grafana-operator-experience-squad",
-        "requiresRestart": true
-      }
-    },
-    {
-      "metadata": {
-        "name": "recoveryThreshold",
-        "resourceVersion": "1707755276481",
-        "creationTimestamp": "2024-02-12T16:27:56Z"
-      },
-      "spec": {
-        "description": "Enables feature recovery threshold (aka hysteresis) for threshold server-side expression",
-        "stage": "GA",
-        "codeowner": "@grafana/alerting-squad",
-        "requiresRestart": true
-      }
-    },
-    {
-      "metadata": {
-        "name": "annotationPermissionUpdate",
-        "resourceVersion": "1707755276481",
-        "creationTimestamp": "2024-02-12T16:27:56Z"
-      },
-      "spec": {
-        "description": "Separate annotation permissions from dashboard permissions to allow for more granular control.",
-        "stage": "experimental",
-        "codeowner": "@grafana/identity-access-team"
-      }
-    },
-    {
-      "metadata": {
         "name": "newVizTooltips",
-        "resourceVersion": "1707755276481",
-        "creationTimestamp": "2024-02-12T16:27:56Z"
+        "resourceVersion": "1699012800000",
+        "creationTimestamp": "2023-11-03T12:00:00Z"
       },
       "spec": {
         "description": "New visualizations tooltips UX",
@@ -1521,8 +240,8 @@
     {
       "metadata": {
         "name": "scenes",
-        "resourceVersion": "1707755276481",
-        "creationTimestamp": "2024-02-12T16:27:56Z"
+        "resourceVersion": "1657195200000",
+        "creationTimestamp": "2022-07-07T12:00:00Z"
       },
       "spec": {
         "description": "Experimental framework to build interactive dashboards",
@@ -1533,289 +252,34 @@
     },
     {
       "metadata": {
-        "name": "accessControlOnCall",
-        "resourceVersion": "1707755276481",
-        "creationTimestamp": "2024-02-12T16:27:56Z"
+        "name": "disableSecretsCompatibility",
+        "resourceVersion": "1657713600000",
+        "creationTimestamp": "2022-07-13T12:00:00Z"
       },
       "spec": {
-        "description": "Access control primitives for OnCall",
-        "stage": "preview",
-        "codeowner": "@grafana/identity-access-team",
-        "hideFromAdminPage": true
-      }
-    },
-    {
-      "metadata": {
-        "name": "disableSSEDataplane",
-        "resourceVersion": "1707755276481",
-        "creationTimestamp": "2024-02-12T16:27:56Z"
-      },
-      "spec": {
-        "description": "Disables dataplane specific processing in server side expressions.",
+        "description": "Disable duplicated secret storage in legacy tables",
         "stage": "experimental",
-        "codeowner": "@grafana/observability-metrics"
-      }
-    },
-    {
-      "metadata": {
-        "name": "cloudWatchWildCardDimensionValues",
-        "resourceVersion": "1707755276481",
-        "creationTimestamp": "2024-02-12T16:27:56Z"
-      },
-      "spec": {
-        "description": "Fetches dimension values from CloudWatch to correctly label wildcard dimensions",
-        "stage": "GA",
-        "codeowner": "@grafana/aws-datasources",
-        "allowSelfServe": true
-      }
-    },
-    {
-      "metadata": {
-        "name": "externalServiceAccounts",
-        "resourceVersion": "1707755276481",
-        "creationTimestamp": "2024-02-12T16:27:56Z"
-      },
-      "spec": {
-        "description": "Automatic service account and token setup for plugins",
-        "stage": "preview",
-        "codeowner": "@grafana/identity-access-team",
-        "hideFromAdminPage": true
-      }
-    },
-    {
-      "metadata": {
-        "name": "lokiStructuredMetadata",
-        "resourceVersion": "1707755276481",
-        "creationTimestamp": "2024-02-12T16:27:56Z"
-      },
-      "spec": {
-        "description": "Enables the loki data source to request structured metadata from the Loki server",
-        "stage": "experimental",
-        "codeowner": "@grafana/observability-logs"
-      }
-    },
-    {
-      "metadata": {
-        "name": "publicDashboards",
-        "resourceVersion": "1707755276481",
-        "creationTimestamp": "2024-02-12T16:27:56Z"
-      },
-      "spec": {
-        "description": "[Deprecated] Public dashboards are now enabled by default; to disable them, use the configuration setting. This feature toggle will be removed in the next major version.",
-        "stage": "GA",
-        "codeowner": "@grafana/sharing-squad",
-        "allowSelfServe": true
-      }
-    },
-    {
-      "metadata": {
-        "name": "showDashboardValidationWarnings",
-        "resourceVersion": "1707755276481",
-        "creationTimestamp": "2024-02-12T16:27:56Z"
-      },
-      "spec": {
-        "description": "Show warnings when dashboards do not validate against the schema",
-        "stage": "experimental",
-        "codeowner": "@grafana/dashboards-squad"
-      }
-    },
-    {
-      "metadata": {
-        "name": "lokiMetricDataplane",
-        "resourceVersion": "1707755276481",
-        "creationTimestamp": "2024-02-12T16:27:56Z"
-      },
-      "spec": {
-        "description": "Changes metric responses from Loki to be compliant with the dataplane specification.",
-        "stage": "GA",
-        "codeowner": "@grafana/observability-logs",
-        "allowSelfServe": true
-      }
-    },
-    {
-      "metadata": {
-        "name": "dashgpt",
-        "resourceVersion": "1707755276481",
-        "creationTimestamp": "2024-02-12T16:27:56Z"
-      },
-      "spec": {
-        "description": "Enable AI powered features in dashboards",
-        "stage": "preview",
-        "codeowner": "@grafana/dashboards-squad",
-        "frontend": true
-      }
-    },
-    {
-      "metadata": {
-        "name": "pluginsDynamicAngularDetectionPatterns",
-        "resourceVersion": "1707755276481",
-        "creationTimestamp": "2024-02-12T16:27:56Z"
-      },
-      "spec": {
-        "description": "Enables fetching Angular detection patterns for plugins from GCOM and fallback to hardcoded ones",
-        "stage": "experimental",
-        "codeowner": "@grafana/plugins-platform-backend"
-      }
-    },
-    {
-      "metadata": {
-        "name": "mlExpressions",
-        "resourceVersion": "1707755276481",
-        "creationTimestamp": "2024-02-12T16:27:56Z"
-      },
-      "spec": {
-        "description": "Enable support for Machine Learning in server-side expressions",
-        "stage": "experimental",
-        "codeowner": "@grafana/alerting-squad"
-      }
-    },
-    {
-      "metadata": {
-        "name": "configurableSchedulerTick",
-        "resourceVersion": "1707755276481",
-        "creationTimestamp": "2024-02-12T16:27:56Z"
-      },
-      "spec": {
-        "description": "Enable changing the scheduler base interval via configuration option unified_alerting.scheduler_tick_interval",
-        "stage": "experimental",
-        "codeowner": "@grafana/alerting-squad",
-        "requiresRestart": true,
-        "hideFromDocs": true
-      }
-    },
-    {
-      "metadata": {
-        "name": "metricsSummary",
-        "resourceVersion": "1707755276481",
-        "creationTimestamp": "2024-02-12T16:27:56Z"
-      },
-      "spec": {
-        "description": "Enables metrics summary queries in the Tempo data source",
-        "stage": "experimental",
-        "codeowner": "@grafana/observability-traces-and-profiling",
-        "frontend": true
-      }
-    },
-    {
-      "metadata": {
-        "name": "prometheusPromQAIL",
-        "resourceVersion": "1707755276481",
-        "creationTimestamp": "2024-02-12T16:27:56Z"
-      },
-      "spec": {
-        "description": "Prometheus and AI/ML to assist users in creating a query",
-        "stage": "experimental",
-        "codeowner": "@grafana/observability-metrics",
-        "frontend": true
-      }
-    },
-    {
-      "metadata": {
-        "name": "regressionTransformation",
-        "resourceVersion": "1707755276481",
-        "creationTimestamp": "2024-02-12T16:27:56Z"
-      },
-      "spec": {
-        "description": "Enables regression analysis transformation",
-        "stage": "preview",
-        "codeowner": "@grafana/dataviz-squad",
-        "frontend": true
-      }
-    },
-    {
-      "metadata": {
-        "name": "alertingBacktesting",
-        "resourceVersion": "1707755276481",
-        "creationTimestamp": "2024-02-12T16:27:56Z"
-      },
-      "spec": {
-        "description": "Rule backtesting API for alerting",
-        "stage": "experimental",
-        "codeowner": "@grafana/alerting-squad"
-      }
-    },
-    {
-      "metadata": {
-        "name": "prometheusDataplane",
-        "resourceVersion": "1707755276481",
-        "creationTimestamp": "2024-02-12T16:27:56Z"
-      },
-      "spec": {
-        "description": "Changes responses to from Prometheus to be compliant with the dataplane specification. In particular, when this feature toggle is active, the numeric `Field.Name` is set from 'Value' to the value of the `__name__` label.",
-        "stage": "GA",
-        "codeowner": "@grafana/observability-metrics",
-        "allowSelfServe": true
-      }
-    },
-    {
-      "metadata": {
-        "name": "renderAuthJWT",
-        "resourceVersion": "1707755276481",
-        "creationTimestamp": "2024-02-12T16:27:56Z"
-      },
-      "spec": {
-        "description": "Uses JWT-based auth for rendering instead of relying on remote cache",
-        "stage": "preview",
-        "codeowner": "@grafana/grafana-as-code",
-        "hideFromAdminPage": true
-      }
-    },
-    {
-      "metadata": {
-        "name": "reportingRetries",
-        "resourceVersion": "1707755276481",
-        "creationTimestamp": "2024-02-12T16:27:56Z"
-      },
-      "spec": {
-        "description": "Enables rendering retries for the reporting feature",
-        "stage": "preview",
-        "codeowner": "@grafana/sharing-squad",
+        "codeowner": "@grafana/hosted-grafana-team",
         "requiresRestart": true
       }
     },
     {
       "metadata": {
-        "name": "athenaAsyncQueryDataSupport",
-        "resourceVersion": "1707755276481",
-        "creationTimestamp": "2024-02-12T16:27:56Z"
+        "name": "logRequestsInstrumentedAsUnknown",
+        "resourceVersion": "1654862400000",
+        "creationTimestamp": "2022-06-10T12:00:00Z"
       },
       "spec": {
-        "description": "Enable async query data support for Athena",
-        "stage": "GA",
-        "codeowner": "@grafana/aws-datasources",
-        "frontend": true
-      }
-    },
-    {
-      "metadata": {
-        "name": "alertmanagerRemotePrimary",
-        "resourceVersion": "1707755276481",
-        "creationTimestamp": "2024-02-12T16:27:56Z"
-      },
-      "spec": {
-        "description": "Enable Grafana to have a remote Alertmanager instance as the primary Alertmanager.",
+        "description": "Logs the path for requests that are instrumented as unknown",
         "stage": "experimental",
-        "codeowner": "@grafana/alerting-squad"
-      }
-    },
-    {
-      "metadata": {
-        "name": "logRowsPopoverMenu",
-        "resourceVersion": "1707755276481",
-        "creationTimestamp": "2024-02-12T16:27:56Z"
-      },
-      "spec": {
-        "description": "Enable filtering menu displayed when text of a log line is selected",
-        "stage": "GA",
-        "codeowner": "@grafana/observability-logs",
-        "frontend": true
+        "codeowner": "@grafana/hosted-grafana-team"
       }
     },
     {
       "metadata": {
         "name": "dataConnectionsConsole",
-        "resourceVersion": "1707755276481",
-        "creationTimestamp": "2024-02-12T16:27:56Z"
+        "resourceVersion": "1654084800000",
+        "creationTimestamp": "2022-06-01T12:00:00Z"
       },
       "spec": {
         "description": "Enables a new top-level page called Connections. This page is an experiment that provides a better experience when you install and configure data sources and other plugins.",
@@ -1826,9 +290,34 @@
     },
     {
       "metadata": {
+        "name": "topnav",
+        "resourceVersion": "1655726400000",
+        "creationTimestamp": "2022-06-20T12:00:00Z"
+      },
+      "spec": {
+        "description": "Enables topnav support in external plugins. The new Grafana navigation cannot be disabled.",
+        "stage": "deprecated",
+        "codeowner": "@grafana/grafana-frontend-platform"
+      }
+    },
+    {
+      "metadata": {
+        "name": "returnToPrevious",
+        "resourceVersion": "1704798000000",
+        "creationTimestamp": "2024-01-09T11:00:00Z"
+      },
+      "spec": {
+        "description": "Enables the return to previous context functionality",
+        "stage": "experimental",
+        "codeowner": "@grafana/grafana-frontend-platform",
+        "frontend": true
+      }
+    },
+    {
+      "metadata": {
         "name": "grpcServer",
-        "resourceVersion": "1707755276481",
-        "creationTimestamp": "2024-02-12T16:27:56Z"
+        "resourceVersion": "1664280000000",
+        "creationTimestamp": "2022-09-27T12:00:00Z"
       },
       "spec": {
         "description": "Run the GRPC server",
@@ -1839,9 +328,23 @@
     },
     {
       "metadata": {
+        "name": "unifiedStorage",
+        "resourceVersion": "1669896000000",
+        "creationTimestamp": "2022-12-01T12:00:00Z"
+      },
+      "spec": {
+        "description": "SQL-based k8s storage",
+        "stage": "experimental",
+        "codeowner": "@grafana/grafana-app-platform-squad",
+        "requiresDevMode": true,
+        "requiresRestart": true
+      }
+    },
+    {
+      "metadata": {
         "name": "cloudWatchCrossAccountQuerying",
-        "resourceVersion": "1707755276481",
-        "creationTimestamp": "2024-02-12T16:27:56Z"
+        "resourceVersion": "1669636800000",
+        "creationTimestamp": "2022-11-28T12:00:00Z"
       },
       "spec": {
         "description": "Enables cross-account querying in CloudWatch datasources",
@@ -1852,9 +355,46 @@
     },
     {
       "metadata": {
+        "name": "redshiftAsyncQueryDataSupport",
+        "resourceVersion": "1661601600000",
+        "creationTimestamp": "2022-08-27T12:00:00Z"
+      },
+      "spec": {
+        "description": "Enable async query data support for Redshift",
+        "stage": "GA",
+        "codeowner": "@grafana/aws-datasources"
+      }
+    },
+    {
+      "metadata": {
+        "name": "athenaAsyncQueryDataSupport",
+        "resourceVersion": "1661601600000",
+        "creationTimestamp": "2022-08-27T12:00:00Z"
+      },
+      "spec": {
+        "description": "Enable async query data support for Athena",
+        "stage": "GA",
+        "codeowner": "@grafana/aws-datasources",
+        "frontend": true
+      }
+    },
+    {
+      "metadata": {
+        "name": "showDashboardValidationWarnings",
+        "resourceVersion": "1665748800000",
+        "creationTimestamp": "2022-10-14T12:00:00Z"
+      },
+      "spec": {
+        "description": "Show warnings when dashboards do not validate against the schema",
+        "stage": "experimental",
+        "codeowner": "@grafana/dashboards-squad"
+      }
+    },
+    {
+      "metadata": {
         "name": "mysqlAnsiQuotes",
-        "resourceVersion": "1707755276481",
-        "creationTimestamp": "2024-02-12T16:27:56Z"
+        "resourceVersion": "1665576000000",
+        "creationTimestamp": "2022-10-12T12:00:00Z"
       },
       "spec": {
         "description": "Use double quotes to escape keyword in a MySQL query",
@@ -1864,9 +404,103 @@
     },
     {
       "metadata": {
+        "name": "accessControlOnCall",
+        "resourceVersion": "1666180800000",
+        "creationTimestamp": "2022-10-19T12:00:00Z"
+      },
+      "spec": {
+        "description": "Access control primitives for OnCall",
+        "stage": "preview",
+        "codeowner": "@grafana/identity-access-team",
+        "hideFromAdminPage": true
+      }
+    },
+    {
+      "metadata": {
+        "name": "nestedFolders",
+        "resourceVersion": "1666440000000",
+        "creationTimestamp": "2022-10-22T12:00:00Z"
+      },
+      "spec": {
+        "description": "Enable folder nesting",
+        "stage": "preview",
+        "codeowner": "@grafana/backend-platform"
+      }
+    },
+    {
+      "metadata": {
+        "name": "nestedFolderPicker",
+        "resourceVersion": "1690200000000",
+        "creationTimestamp": "2023-07-24T12:00:00Z"
+      },
+      "spec": {
+        "description": "Enables the new folder picker to work with nested folders. Requires the nestedFolders feature toggle",
+        "stage": "GA",
+        "codeowner": "@grafana/grafana-frontend-platform",
+        "frontend": true,
+        "allowSelfServe": true
+      }
+    },
+    {
+      "metadata": {
+        "name": "alertingBacktesting",
+        "resourceVersion": "1666267200000",
+        "creationTimestamp": "2022-10-20T12:00:00Z"
+      },
+      "spec": {
+        "description": "Rule backtesting API for alerting",
+        "stage": "experimental",
+        "codeowner": "@grafana/alerting-squad"
+      }
+    },
+    {
+      "metadata": {
+        "name": "editPanelCSVDragAndDrop",
+        "resourceVersion": "1707523537136",
+        "creationTimestamp": "2022-12-20T12:00:00Z",
+        "annotations": {
+          "grafana.app/updatedTimestamp": "2024-02-10 00:05:37.1362 +0000 UTC"
+        }
+      },
+      "spec": {
+        "description": "Enables drag and drop for CSV and Excel files",
+        "stage": "experimental",
+        "codeowner": "@grafana/dataviz-squad",
+        "frontend": true
+      }
+    },
+    {
+      "metadata": {
+        "name": "alertingNoNormalState",
+        "resourceVersion": "1673697600000",
+        "creationTimestamp": "2023-01-14T12:00:00Z"
+      },
+      "spec": {
+        "description": "Stop maintaining state of alerts that are not firing",
+        "stage": "preview",
+        "codeowner": "@grafana/alerting-squad",
+        "hideFromAdminPage": true
+      }
+    },
+    {
+      "metadata": {
+        "name": "logsContextDatasourceUi",
+        "resourceVersion": "1674820800000",
+        "creationTimestamp": "2023-01-27T12:00:00Z"
+      },
+      "spec": {
+        "description": "Allow datasource to provide custom UI for context view",
+        "stage": "GA",
+        "codeowner": "@grafana/observability-logs",
+        "frontend": true,
+        "allowSelfServe": true
+      }
+    },
+    {
+      "metadata": {
         "name": "lokiQuerySplitting",
-        "resourceVersion": "1707755276481",
-        "creationTimestamp": "2024-02-12T16:27:56Z"
+        "resourceVersion": "1675944000000",
+        "creationTimestamp": "2023-02-09T12:00:00Z"
       },
       "spec": {
         "description": "Split large interval queries into subqueries with smaller time intervals",
@@ -1878,9 +512,22 @@
     },
     {
       "metadata": {
+        "name": "lokiQuerySplittingConfig",
+        "resourceVersion": "1679313600000",
+        "creationTimestamp": "2023-03-20T12:00:00Z"
+      },
+      "spec": {
+        "description": "Give users the option to configure split durations for Loki queries",
+        "stage": "experimental",
+        "codeowner": "@grafana/observability-logs",
+        "frontend": true
+      }
+    },
+    {
+      "metadata": {
         "name": "individualCookiePreferences",
-        "resourceVersion": "1707755276481",
-        "creationTimestamp": "2024-02-12T16:27:56Z"
+        "resourceVersion": "1677153600000",
+        "creationTimestamp": "2023-02-23T12:00:00Z"
       },
       "spec": {
         "description": "Support overriding cookie preferences per user",
@@ -1891,8 +538,8 @@
     {
       "metadata": {
         "name": "prometheusMetricEncyclopedia",
-        "resourceVersion": "1707755276481",
-        "creationTimestamp": "2024-02-12T16:27:56Z"
+        "resourceVersion": "1678190400000",
+        "creationTimestamp": "2023-03-07T12:00:00Z"
       },
       "spec": {
         "description": "Adds the metrics explorer component to the Prometheus query builder as an option in metric select",
@@ -1904,74 +551,222 @@
     },
     {
       "metadata": {
-        "name": "tableSharedCrosshair",
-        "resourceVersion": "1707755276481",
-        "creationTimestamp": "2024-02-12T16:27:56Z"
+        "name": "influxdbBackendMigration",
+        "resourceVersion": "1678881600000",
+        "creationTimestamp": "2023-03-15T12:00:00Z"
       },
       "spec": {
-        "description": "Enables shared crosshair in table panel",
-        "stage": "experimental",
-        "codeowner": "@grafana/dataviz-squad",
-        "frontend": true
-      }
-    },
-    {
-      "metadata": {
-        "name": "queryOverLive",
-        "resourceVersion": "1707755276481",
-        "creationTimestamp": "2024-02-12T16:27:56Z"
-      },
-      "spec": {
-        "description": "Use Grafana Live WebSocket to execute backend queries",
-        "stage": "experimental",
-        "codeowner": "@grafana/grafana-app-platform-squad",
-        "frontend": true
-      }
-    },
-    {
-      "metadata": {
-        "name": "panelTitleSearch",
-        "resourceVersion": "1707755276481",
-        "creationTimestamp": "2024-02-12T16:27:56Z"
-      },
-      "spec": {
-        "description": "Search for dashboards using panel title",
-        "stage": "preview",
-        "codeowner": "@grafana/grafana-app-platform-squad",
-        "hideFromAdminPage": true
-      }
-    },
-    {
-      "metadata": {
-        "name": "autoMigrateOldPanels",
-        "resourceVersion": "1707755276481",
-        "creationTimestamp": "2024-02-12T16:27:56Z"
-      },
-      "spec": {
-        "description": "Migrate old angular panels to supported versions (graph, table-old, worldmap, etc)",
-        "stage": "preview",
-        "codeowner": "@grafana/dataviz-squad",
-        "frontend": true
-      }
-    },
-    {
-      "metadata": {
-        "name": "disableEnvelopeEncryption",
-        "resourceVersion": "1707755276481",
-        "creationTimestamp": "2024-02-12T16:27:56Z"
-      },
-      "spec": {
-        "description": "Disable envelope encryption (emergency only)",
+        "description": "Query InfluxDB InfluxQL without the proxy",
         "stage": "GA",
+        "codeowner": "@grafana/observability-metrics",
+        "frontend": true
+      }
+    },
+    {
+      "metadata": {
+        "name": "influxqlStreamingParser",
+        "resourceVersion": "1701259200000",
+        "creationTimestamp": "2023-11-29T12:00:00Z"
+      },
+      "spec": {
+        "description": "Enable streaming JSON parser for InfluxDB datasource InfluxQL query language",
+        "stage": "experimental",
+        "codeowner": "@grafana/observability-metrics"
+      }
+    },
+    {
+      "metadata": {
+        "name": "influxdbRunQueriesInParallel",
+        "resourceVersion": "1706529600000",
+        "creationTimestamp": "2024-01-29T12:00:00Z"
+      },
+      "spec": {
+        "description": "Enables running InfluxDB Influxql queries in parallel",
+        "stage": "privatePreview",
+        "codeowner": "@grafana/observability-metrics"
+      }
+    },
+    {
+      "metadata": {
+        "name": "clientTokenRotation",
+        "resourceVersion": "1679572800000",
+        "creationTimestamp": "2023-03-23T12:00:00Z"
+      },
+      "spec": {
+        "description": "Replaces the current in-request token rotation so that the client initiates the rotation",
+        "stage": "GA",
+        "codeowner": "@grafana/identity-access-team"
+      }
+    },
+    {
+      "metadata": {
+        "name": "prometheusDataplane",
+        "resourceVersion": "1680091200000",
+        "creationTimestamp": "2023-03-29T12:00:00Z"
+      },
+      "spec": {
+        "description": "Changes responses to from Prometheus to be compliant with the dataplane specification. In particular, when this feature toggle is active, the numeric `Field.Name` is set from 'Value' to the value of the `__name__` label.",
+        "stage": "GA",
+        "codeowner": "@grafana/observability-metrics",
+        "allowSelfServe": true
+      }
+    },
+    {
+      "metadata": {
+        "name": "lokiMetricDataplane",
+        "resourceVersion": "1681387200000",
+        "creationTimestamp": "2023-04-13T12:00:00Z"
+      },
+      "spec": {
+        "description": "Changes metric responses from Loki to be compliant with the dataplane specification.",
+        "stage": "GA",
+        "codeowner": "@grafana/observability-logs",
+        "allowSelfServe": true
+      }
+    },
+    {
+      "metadata": {
+        "name": "lokiLogsDataplane",
+        "resourceVersion": "1689249600000",
+        "creationTimestamp": "2023-07-13T12:00:00Z"
+      },
+      "spec": {
+        "description": "Changes logs responses from Loki to be compliant with the dataplane specification.",
+        "stage": "experimental",
+        "codeowner": "@grafana/observability-logs"
+      }
+    },
+    {
+      "metadata": {
+        "name": "dataplaneFrontendFallback",
+        "resourceVersion": "1682337600000",
+        "creationTimestamp": "2023-04-24T12:00:00Z"
+      },
+      "spec": {
+        "description": "Support dataplane contract field name change for transformations and field name matchers where the name is different",
+        "stage": "GA",
+        "codeowner": "@grafana/observability-metrics",
+        "frontend": true,
+        "allowSelfServe": true
+      }
+    },
+    {
+      "metadata": {
+        "name": "disableSSEDataplane",
+        "resourceVersion": "1682337600000",
+        "creationTimestamp": "2023-04-24T12:00:00Z"
+      },
+      "spec": {
+        "description": "Disables dataplane specific processing in server side expressions.",
+        "stage": "experimental",
+        "codeowner": "@grafana/observability-metrics"
+      }
+    },
+    {
+      "metadata": {
+        "name": "alertStateHistoryLokiSecondary",
+        "resourceVersion": "1680177600000",
+        "creationTimestamp": "2023-03-30T12:00:00Z"
+      },
+      "spec": {
+        "description": "Enable Grafana to write alert state history to an external Loki instance in addition to Grafana annotations.",
+        "stage": "experimental",
+        "codeowner": "@grafana/alerting-squad"
+      }
+    },
+    {
+      "metadata": {
+        "name": "alertStateHistoryLokiPrimary",
+        "resourceVersion": "1680177600000",
+        "creationTimestamp": "2023-03-30T12:00:00Z"
+      },
+      "spec": {
+        "description": "Enable a remote Loki instance as the primary source for state history reads.",
+        "stage": "experimental",
+        "codeowner": "@grafana/alerting-squad"
+      }
+    },
+    {
+      "metadata": {
+        "name": "alertStateHistoryLokiOnly",
+        "resourceVersion": "1680177600000",
+        "creationTimestamp": "2023-03-30T12:00:00Z"
+      },
+      "spec": {
+        "description": "Disable Grafana alerts from emitting annotations when a remote Loki instance is available.",
+        "stage": "experimental",
+        "codeowner": "@grafana/alerting-squad"
+      }
+    },
+    {
+      "metadata": {
+        "name": "unifiedRequestLog",
+        "resourceVersion": "1680264000000",
+        "creationTimestamp": "2023-03-31T12:00:00Z"
+      },
+      "spec": {
+        "description": "Writes error logs to the request logger",
+        "stage": "experimental",
+        "codeowner": "@grafana/backend-platform"
+      }
+    },
+    {
+      "metadata": {
+        "name": "renderAuthJWT",
+        "resourceVersion": "1680523200000",
+        "creationTimestamp": "2023-04-03T12:00:00Z"
+      },
+      "spec": {
+        "description": "Uses JWT-based auth for rendering instead of relying on remote cache",
+        "stage": "preview",
         "codeowner": "@grafana/grafana-as-code",
         "hideFromAdminPage": true
       }
     },
     {
       "metadata": {
+        "name": "externalServiceAuth",
+        "resourceVersion": "1681214400000",
+        "creationTimestamp": "2023-04-11T12:00:00Z"
+      },
+      "spec": {
+        "description": "Starts an OAuth2 authentication provider for external services",
+        "stage": "experimental",
+        "codeowner": "@grafana/identity-access-team",
+        "requiresDevMode": true
+      }
+    },
+    {
+      "metadata": {
+        "name": "refactorVariablesTimeRange",
+        "resourceVersion": "1686052800000",
+        "creationTimestamp": "2023-06-06T12:00:00Z"
+      },
+      "spec": {
+        "description": "Refactor time range variables flow to reduce number of API calls made when query variables are chained",
+        "stage": "preview",
+        "codeowner": "@grafana/dashboards-squad",
+        "hideFromAdminPage": true
+      }
+    },
+    {
+      "metadata": {
+        "name": "enableElasticsearchBackendQuerying",
+        "resourceVersion": "1681473600000",
+        "creationTimestamp": "2023-04-14T12:00:00Z"
+      },
+      "spec": {
+        "description": "Enable the processing of queries and responses in the Elasticsearch data source through backend",
+        "stage": "GA",
+        "codeowner": "@grafana/observability-logs",
+        "allowSelfServe": true
+      }
+    },
+    {
+      "metadata": {
         "name": "faroDatasourceSelector",
-        "resourceVersion": "1707755276481",
-        "creationTimestamp": "2024-02-12T16:27:56Z"
+        "resourceVersion": "1683201600000",
+        "creationTimestamp": "2023-05-04T12:00:00Z"
       },
       "spec": {
         "description": "Enable the data source selector within the Frontend Apps section of the Frontend Observability",
@@ -1982,9 +777,225 @@
     },
     {
       "metadata": {
+        "name": "enableDatagridEditing",
+        "resourceVersion": "1707523537136",
+        "creationTimestamp": "2023-04-24T12:00:00Z",
+        "annotations": {
+          "grafana.app/updatedTimestamp": "2024-02-10 00:05:37.1362 +0000 UTC"
+        }
+      },
+      "spec": {
+        "description": "Enables the edit functionality in the datagrid panel",
+        "stage": "preview",
+        "codeowner": "@grafana/dataviz-squad",
+        "frontend": true
+      }
+    },
+    {
+      "metadata": {
+        "name": "extraThemes",
+        "resourceVersion": "1683720000000",
+        "creationTimestamp": "2023-05-10T12:00:00Z"
+      },
+      "spec": {
+        "description": "Enables extra themes",
+        "stage": "experimental",
+        "codeowner": "@grafana/grafana-frontend-platform",
+        "frontend": true
+      }
+    },
+    {
+      "metadata": {
+        "name": "lokiPredefinedOperations",
+        "resourceVersion": "1685707200000",
+        "creationTimestamp": "2023-06-02T12:00:00Z"
+      },
+      "spec": {
+        "description": "Adds predefined query operations to Loki query editor",
+        "stage": "experimental",
+        "codeowner": "@grafana/observability-logs",
+        "frontend": true
+      }
+    },
+    {
+      "metadata": {
+        "name": "pluginsFrontendSandbox",
+        "resourceVersion": "1685966400000",
+        "creationTimestamp": "2023-06-05T12:00:00Z"
+      },
+      "spec": {
+        "description": "Enables the plugins frontend sandbox",
+        "stage": "experimental",
+        "codeowner": "@grafana/plugins-platform-backend",
+        "frontend": true
+      }
+    },
+    {
+      "metadata": {
+        "name": "dashboardEmbed",
+        "resourceVersion": "1688644800000",
+        "creationTimestamp": "2023-07-06T12:00:00Z"
+      },
+      "spec": {
+        "description": "Allow embedding dashboard for external use in Code editors",
+        "stage": "experimental",
+        "codeowner": "@grafana/grafana-as-code",
+        "frontend": true
+      }
+    },
+    {
+      "metadata": {
+        "name": "frontendSandboxMonitorOnly",
+        "resourceVersion": "1688558400000",
+        "creationTimestamp": "2023-07-05T12:00:00Z"
+      },
+      "spec": {
+        "description": "Enables monitor only in the plugin frontend sandbox (if enabled)",
+        "stage": "experimental",
+        "codeowner": "@grafana/plugins-platform-backend",
+        "frontend": true
+      }
+    },
+    {
+      "metadata": {
+        "name": "sqlDatasourceDatabaseSelection",
+        "resourceVersion": "1707523537136",
+        "creationTimestamp": "2023-06-06T12:00:00Z",
+        "annotations": {
+          "grafana.app/updatedTimestamp": "2024-02-10 00:05:37.1362 +0000 UTC"
+        }
+      },
+      "spec": {
+        "description": "Enables previous SQL data source dataset dropdown behavior",
+        "stage": "preview",
+        "codeowner": "@grafana/dataviz-squad",
+        "frontend": true,
+        "hideFromAdminPage": true
+      }
+    },
+    {
+      "metadata": {
+        "name": "lokiFormatQuery",
+        "resourceVersion": "1687348800000",
+        "creationTimestamp": "2023-06-21T12:00:00Z"
+      },
+      "spec": {
+        "description": "Enables the ability to format Loki queries",
+        "stage": "experimental",
+        "codeowner": "@grafana/observability-logs",
+        "frontend": true
+      }
+    },
+    {
+      "metadata": {
+        "name": "cloudWatchLogsMonacoEditor",
+        "resourceVersion": "1686571200000",
+        "creationTimestamp": "2023-06-12T12:00:00Z"
+      },
+      "spec": {
+        "description": "Enables the Monaco editor for CloudWatch Logs queries",
+        "stage": "GA",
+        "codeowner": "@grafana/aws-datasources",
+        "frontend": true,
+        "allowSelfServe": true
+      }
+    },
+    {
+      "metadata": {
+        "name": "exploreScrollableLogsContainer",
+        "resourceVersion": "1686830400000",
+        "creationTimestamp": "2023-06-15T12:00:00Z"
+      },
+      "spec": {
+        "description": "Improves the scrolling behavior of logs in Explore",
+        "stage": "experimental",
+        "codeowner": "@grafana/observability-logs",
+        "frontend": true
+      }
+    },
+    {
+      "metadata": {
+        "name": "recordedQueriesMulti",
+        "resourceVersion": "1686744000000",
+        "creationTimestamp": "2023-06-14T12:00:00Z"
+      },
+      "spec": {
+        "description": "Enables writing multiple items from a single query within Recorded Queries",
+        "stage": "GA",
+        "codeowner": "@grafana/observability-metrics"
+      }
+    },
+    {
+      "metadata": {
+        "name": "pluginsDynamicAngularDetectionPatterns",
+        "resourceVersion": "1687780800000",
+        "creationTimestamp": "2023-06-26T12:00:00Z"
+      },
+      "spec": {
+        "description": "Enables fetching Angular detection patterns for plugins from GCOM and fallback to hardcoded ones",
+        "stage": "experimental",
+        "codeowner": "@grafana/plugins-platform-backend"
+      }
+    },
+    {
+      "metadata": {
+        "name": "vizAndWidgetSplit",
+        "resourceVersion": "1687867200000",
+        "creationTimestamp": "2023-06-27T12:00:00Z"
+      },
+      "spec": {
+        "description": "Split panels between visualizations and widgets",
+        "stage": "experimental",
+        "codeowner": "@grafana/dashboards-squad",
+        "frontend": true
+      }
+    },
+    {
+      "metadata": {
+        "name": "prometheusIncrementalQueryInstrumentation",
+        "resourceVersion": "1688558400000",
+        "creationTimestamp": "2023-07-05T12:00:00Z"
+      },
+      "spec": {
+        "description": "Adds RudderStack events to incremental queries",
+        "stage": "experimental",
+        "codeowner": "@grafana/observability-metrics",
+        "frontend": true
+      }
+    },
+    {
+      "metadata": {
+        "name": "logsExploreTableVisualisation",
+        "resourceVersion": "1707747885704",
+        "creationTimestamp": "2023-07-12T12:00:00Z",
+        "annotations": {
+          "grafana.app/updatedTimestamp": "2024-02-12 14:24:45.704022 +0000 UTC"
+        }
+      },
+      "spec": {
+        "description": "A table visualisation for logs in Explore",
+        "stage": "GA",
+        "codeowner": "@grafana/observability-logs",
+        "frontend": true
+      }
+    },
+    {
+      "metadata": {
+        "name": "awsDatasourcesTempCredentials",
+        "resourceVersion": "1688644800000",
+        "creationTimestamp": "2023-07-06T12:00:00Z"
+      },
+      "spec": {
+        "description": "Support temporary security credentials in AWS plugins for Grafana Cloud customers",
+        "stage": "experimental",
+        "codeowner": "@grafana/aws-datasources"
+      }
+    },
+    {
+      "metadata": {
         "name": "transformationsRedesign",
-        "resourceVersion": "1707755276481",
-        "creationTimestamp": "2024-02-12T16:27:56Z"
+        "resourceVersion": "1689163200000",
+        "creationTimestamp": "2023-07-12T12:00:00Z"
       },
       "spec": {
         "description": "Enables the transformations redesign",
@@ -1996,22 +1007,357 @@
     },
     {
       "metadata": {
-        "name": "panelTitleSearchInV1",
-        "resourceVersion": "1707755276481",
-        "creationTimestamp": "2024-02-12T16:27:56Z"
+        "name": "mlExpressions",
+        "resourceVersion": "1689249600000",
+        "creationTimestamp": "2023-07-13T12:00:00Z"
       },
       "spec": {
-        "description": "Enable searching for dashboards using panel title in search v1",
+        "description": "Enable support for Machine Learning in server-side expressions",
         "stage": "experimental",
-        "codeowner": "@grafana/backend-platform",
-        "requiresDevMode": true
+        "codeowner": "@grafana/alerting-squad"
+      }
+    },
+    {
+      "metadata": {
+        "name": "traceQLStreaming",
+        "resourceVersion": "1690372800000",
+        "creationTimestamp": "2023-07-26T12:00:00Z"
+      },
+      "spec": {
+        "description": "Enables response streaming of TraceQL queries of the Tempo data source",
+        "stage": "experimental",
+        "codeowner": "@grafana/observability-traces-and-profiling",
+        "frontend": true
+      }
+    },
+    {
+      "metadata": {
+        "name": "metricsSummary",
+        "resourceVersion": "1693224000000",
+        "creationTimestamp": "2023-08-28T12:00:00Z"
+      },
+      "spec": {
+        "description": "Enables metrics summary queries in the Tempo data source",
+        "stage": "experimental",
+        "codeowner": "@grafana/observability-traces-and-profiling",
+        "frontend": true
+      }
+    },
+    {
+      "metadata": {
+        "name": "grafanaAPIServerWithExperimentalAPIs",
+        "resourceVersion": "1696593600000",
+        "creationTimestamp": "2023-10-06T12:00:00Z"
+      },
+      "spec": {
+        "description": "Register experimental APIs with the k8s API server",
+        "stage": "experimental",
+        "codeowner": "@grafana/grafana-app-platform-squad",
+        "requiresDevMode": true,
+        "requiresRestart": true
+      }
+    },
+    {
+      "metadata": {
+        "name": "grafanaAPIServerEnsureKubectlAccess",
+        "resourceVersion": "1701864000000",
+        "creationTimestamp": "2023-12-06T12:00:00Z"
+      },
+      "spec": {
+        "description": "Start an additional https handler and write kubectl options",
+        "stage": "experimental",
+        "codeowner": "@grafana/grafana-app-platform-squad",
+        "requiresDevMode": true,
+        "requiresRestart": true
+      }
+    },
+    {
+      "metadata": {
+        "name": "featureToggleAdminPage",
+        "resourceVersion": "1689681600000",
+        "creationTimestamp": "2023-07-18T12:00:00Z"
+      },
+      "spec": {
+        "description": "Enable admin page for managing feature toggles from the Grafana front-end",
+        "stage": "experimental",
+        "codeowner": "@grafana/grafana-operator-experience-squad",
+        "requiresRestart": true
+      }
+    },
+    {
+      "metadata": {
+        "name": "awsAsyncQueryCaching",
+        "resourceVersion": "1689940800000",
+        "creationTimestamp": "2023-07-21T12:00:00Z"
+      },
+      "spec": {
+        "description": "Enable caching for async queries for Redshift and Athena. Requires that the datasource has caching and async query support enabled",
+        "stage": "GA",
+        "codeowner": "@grafana/aws-datasources"
+      }
+    },
+    {
+      "metadata": {
+        "name": "splitScopes",
+        "resourceVersion": "1689940800000",
+        "creationTimestamp": "2023-07-21T12:00:00Z"
+      },
+      "spec": {
+        "description": "Support faster dashboard and folder search by splitting permission scopes into parts",
+        "stage": "deprecated",
+        "codeowner": "@grafana/identity-access-team",
+        "requiresRestart": true,
+        "hideFromAdminPage": true
+      }
+    },
+    {
+      "metadata": {
+        "name": "permissionsFilterRemoveSubquery",
+        "resourceVersion": "1690977600000",
+        "creationTimestamp": "2023-08-02T12:00:00Z"
+      },
+      "spec": {
+        "description": "Alternative permission filter implementation that does not use subqueries for fetching the dashboard folder",
+        "stage": "experimental",
+        "codeowner": "@grafana/backend-platform"
+      }
+    },
+    {
+      "metadata": {
+        "name": "prometheusConfigOverhaulAuth",
+        "resourceVersion": "1689940800000",
+        "creationTimestamp": "2023-07-21T12:00:00Z"
+      },
+      "spec": {
+        "description": "Update the Prometheus configuration page with the new auth component",
+        "stage": "GA",
+        "codeowner": "@grafana/observability-metrics"
+      }
+    },
+    {
+      "metadata": {
+        "name": "configurableSchedulerTick",
+        "resourceVersion": "1690372800000",
+        "creationTimestamp": "2023-07-26T12:00:00Z"
+      },
+      "spec": {
+        "description": "Enable changing the scheduler base interval via configuration option unified_alerting.scheduler_tick_interval",
+        "stage": "experimental",
+        "codeowner": "@grafana/alerting-squad",
+        "requiresRestart": true,
+        "hideFromDocs": true
+      }
+    },
+    {
+      "metadata": {
+        "name": "influxdbSqlSupport",
+        "resourceVersion": "1690977600000",
+        "creationTimestamp": "2023-08-02T12:00:00Z"
+      },
+      "spec": {
+        "description": "Enable InfluxDB SQL query language support with new querying UI",
+        "stage": "GA",
+        "codeowner": "@grafana/observability-metrics",
+        "requiresRestart": true,
+        "allowSelfServe": true
+      }
+    },
+    {
+      "metadata": {
+        "name": "alertingNoDataErrorExecution",
+        "resourceVersion": "1692100800000",
+        "creationTimestamp": "2023-08-15T12:00:00Z"
+      },
+      "spec": {
+        "description": "Changes how Alerting state manager handles execution of NoData/Error",
+        "stage": "GA",
+        "codeowner": "@grafana/alerting-squad",
+        "requiresRestart": true
+      }
+    },
+    {
+      "metadata": {
+        "name": "angularDeprecationUI",
+        "resourceVersion": "1693310400000",
+        "creationTimestamp": "2023-08-29T12:00:00Z"
+      },
+      "spec": {
+        "description": "Display new Angular deprecation-related UI features",
+        "stage": "experimental",
+        "codeowner": "@grafana/plugins-platform-backend",
+        "frontend": true
+      }
+    },
+    {
+      "metadata": {
+        "name": "dashgpt",
+        "resourceVersion": "1700222400000",
+        "creationTimestamp": "2023-11-17T12:00:00Z"
+      },
+      "spec": {
+        "description": "Enable AI powered features in dashboards",
+        "stage": "preview",
+        "codeowner": "@grafana/dashboards-squad",
+        "frontend": true
+      }
+    },
+    {
+      "metadata": {
+        "name": "reportingRetries",
+        "resourceVersion": "1693483200000",
+        "creationTimestamp": "2023-08-31T12:00:00Z"
+      },
+      "spec": {
+        "description": "Enables rendering retries for the reporting feature",
+        "stage": "preview",
+        "codeowner": "@grafana/sharing-squad",
+        "requiresRestart": true
+      }
+    },
+    {
+      "metadata": {
+        "name": "sseGroupByDatasource",
+        "resourceVersion": "1694088000000",
+        "creationTimestamp": "2023-09-07T12:00:00Z"
+      },
+      "spec": {
+        "description": "Send query to the same datasource in a single request when using server side expressions. The `cloudWatchBatchQueries` feature toggle should be enabled if this used with CloudWatch.",
+        "stage": "experimental",
+        "codeowner": "@grafana/observability-metrics"
+      }
+    },
+    {
+      "metadata": {
+        "name": "libraryPanelRBAC",
+        "resourceVersion": "1697025600000",
+        "creationTimestamp": "2023-10-11T12:00:00Z"
+      },
+      "spec": {
+        "description": "Enables RBAC support for library panels",
+        "stage": "experimental",
+        "codeowner": "@grafana/dashboards-squad",
+        "requiresRestart": true
+      }
+    },
+    {
+      "metadata": {
+        "name": "lokiRunQueriesInParallel",
+        "resourceVersion": "1695124800000",
+        "creationTimestamp": "2023-09-19T12:00:00Z"
+      },
+      "spec": {
+        "description": "Enables running Loki queries in parallel",
+        "stage": "privatePreview",
+        "codeowner": "@grafana/observability-logs"
+      }
+    },
+    {
+      "metadata": {
+        "name": "wargamesTesting",
+        "resourceVersion": "1694606400000",
+        "creationTimestamp": "2023-09-13T12:00:00Z"
+      },
+      "spec": {
+        "description": "Placeholder feature flag for internal testing",
+        "stage": "experimental",
+        "codeowner": "@grafana/hosted-grafana-team"
+      }
+    },
+    {
+      "metadata": {
+        "name": "alertingInsights",
+        "resourceVersion": "1694692800000",
+        "creationTimestamp": "2023-09-14T12:00:00Z"
+      },
+      "spec": {
+        "description": "Show the new alerting insights landing page",
+        "stage": "GA",
+        "codeowner": "@grafana/alerting-squad",
+        "frontend": true,
+        "hideFromAdminPage": true
+      }
+    },
+    {
+      "metadata": {
+        "name": "externalCorePlugins",
+        "resourceVersion": "1695384000000",
+        "creationTimestamp": "2023-09-22T12:00:00Z"
+      },
+      "spec": {
+        "description": "Allow core plugins to be loaded as external",
+        "stage": "experimental",
+        "codeowner": "@grafana/plugins-platform-backend"
+      }
+    },
+    {
+      "metadata": {
+        "name": "pluginsAPIMetrics",
+        "resourceVersion": "1695297600000",
+        "creationTimestamp": "2023-09-21T12:00:00Z"
+      },
+      "spec": {
+        "description": "Sends metrics of public grafana packages usage by plugins",
+        "stage": "experimental",
+        "codeowner": "@grafana/plugins-platform-backend",
+        "frontend": true
+      }
+    },
+    {
+      "metadata": {
+        "name": "idForwarding",
+        "resourceVersion": "1695643200000",
+        "creationTimestamp": "2023-09-25T12:00:00Z"
+      },
+      "spec": {
+        "description": "Generate signed id token for identity that can be forwarded to plugins and external services",
+        "stage": "experimental",
+        "codeowner": "@grafana/identity-access-team"
+      }
+    },
+    {
+      "metadata": {
+        "name": "cloudWatchWildCardDimensionValues",
+        "resourceVersion": "1695816000000",
+        "creationTimestamp": "2023-09-27T12:00:00Z"
+      },
+      "spec": {
+        "description": "Fetches dimension values from CloudWatch to correctly label wildcard dimensions",
+        "stage": "GA",
+        "codeowner": "@grafana/aws-datasources",
+        "allowSelfServe": true
+      }
+    },
+    {
+      "metadata": {
+        "name": "externalServiceAccounts",
+        "resourceVersion": "1695902400000",
+        "creationTimestamp": "2023-09-28T12:00:00Z"
+      },
+      "spec": {
+        "description": "Automatic service account and token setup for plugins",
+        "stage": "preview",
+        "codeowner": "@grafana/identity-access-team",
+        "hideFromAdminPage": true
+      }
+    },
+    {
+      "metadata": {
+        "name": "panelMonitoring",
+        "resourceVersion": "1696766400000",
+        "creationTimestamp": "2023-10-08T12:00:00Z"
+      },
+      "spec": {
+        "description": "Enables panel monitoring through logs and measurements",
+        "stage": "experimental",
+        "codeowner": "@grafana/dataviz-squad",
+        "frontend": true
       }
     },
     {
       "metadata": {
         "name": "enableNativeHTTPHistogram",
-        "resourceVersion": "1707755276481",
-        "creationTimestamp": "2024-02-12T16:27:56Z"
+        "resourceVersion": "1696334400000",
+        "creationTimestamp": "2023-10-03T12:00:00Z"
       },
       "spec": {
         "description": "Enables native HTTP Histograms",
@@ -2021,9 +1367,41 @@
     },
     {
       "metadata": {
+        "name": "formatString",
+        "resourceVersion": "1707523537136",
+        "creationTimestamp": "2023-10-13T12:00:00Z",
+        "annotations": {
+          "grafana.app/updatedTimestamp": "2024-02-10 00:05:37.1362 +0000 UTC"
+        }
+      },
+      "spec": {
+        "description": "Enable format string transformer",
+        "stage": "preview",
+        "codeowner": "@grafana/dataviz-squad",
+        "frontend": true
+      }
+    },
+    {
+      "metadata": {
+        "name": "transformationsVariableSupport",
+        "resourceVersion": "1707523537136",
+        "creationTimestamp": "2023-10-04T12:00:00Z",
+        "annotations": {
+          "grafana.app/updatedTimestamp": "2024-02-10 00:05:37.1362 +0000 UTC"
+        }
+      },
+      "spec": {
+        "description": "Allows using variables in transformations",
+        "stage": "preview",
+        "codeowner": "@grafana/dataviz-squad",
+        "frontend": true
+      }
+    },
+    {
+      "metadata": {
         "name": "kubernetesPlaylists",
-        "resourceVersion": "1707755276481",
-        "creationTimestamp": "2024-02-12T16:27:56Z"
+        "resourceVersion": "1699444800000",
+        "creationTimestamp": "2023-11-08T12:00:00Z"
       },
       "spec": {
         "description": "Use the kubernetes API in the frontend for playlists, and route /api/playlist requests to k8s",
@@ -2034,14 +1412,672 @@
     },
     {
       "metadata": {
+        "name": "kubernetesSnapshots",
+        "resourceVersion": "1707374669879",
+        "creationTimestamp": "2023-12-04T12:00:00Z",
+        "annotations": {
+          "grafana.app/updatedTimestamp": "2024-02-08 06:44:29.879787 +0000 UTC"
+        }
+      },
+      "spec": {
+        "description": "Routes snapshot requests from /api to the /apis endpoint",
+        "stage": "experimental",
+        "codeowner": "@grafana/grafana-app-platform-squad",
+        "requiresRestart": true
+      }
+    },
+    {
+      "metadata": {
+        "name": "kubernetesQueryServiceRewrite",
+        "resourceVersion": "1706443200000",
+        "creationTimestamp": "2024-01-28T12:00:00Z"
+      },
+      "spec": {
+        "description": "Rewrite requests targeting /ds/query to the query service",
+        "stage": "experimental",
+        "codeowner": "@grafana/grafana-app-platform-squad",
+        "requiresDevMode": true,
+        "requiresRestart": true
+      }
+    },
+    {
+      "metadata": {
+        "name": "cloudWatchBatchQueries",
+        "resourceVersion": "1697803200000",
+        "creationTimestamp": "2023-10-20T12:00:00Z"
+      },
+      "spec": {
+        "description": "Runs CloudWatch metrics queries as separate batches",
+        "stage": "preview",
+        "codeowner": "@grafana/aws-datasources"
+      }
+    },
+    {
+      "metadata": {
+        "name": "recoveryThreshold",
+        "resourceVersion": "1696939200000",
+        "creationTimestamp": "2023-10-10T12:00:00Z"
+      },
+      "spec": {
+        "description": "Enables feature recovery threshold (aka hysteresis) for threshold server-side expression",
+        "stage": "GA",
+        "codeowner": "@grafana/alerting-squad",
+        "requiresRestart": true
+      }
+    },
+    {
+      "metadata": {
+        "name": "lokiStructuredMetadata",
+        "resourceVersion": "1700136000000",
+        "creationTimestamp": "2023-11-16T12:00:00Z"
+      },
+      "spec": {
+        "description": "Enables the loki data source to request structured metadata from the Loki server",
+        "stage": "experimental",
+        "codeowner": "@grafana/observability-logs"
+      }
+    },
+    {
+      "metadata": {
+        "name": "teamHttpHeaders",
+        "resourceVersion": "1697544000000",
+        "creationTimestamp": "2023-10-17T12:00:00Z"
+      },
+      "spec": {
+        "description": "Enables datasources to apply team headers to the client requests",
+        "stage": "experimental",
+        "codeowner": "@grafana/identity-access-team"
+      }
+    },
+    {
+      "metadata": {
+        "name": "awsDatasourcesNewFormStyling",
+        "resourceVersion": "1697112000000",
+        "creationTimestamp": "2023-10-12T12:00:00Z"
+      },
+      "spec": {
+        "description": "Applies new form styling for configuration and query editors in AWS plugins",
+        "stage": "preview",
+        "codeowner": "@grafana/aws-datasources",
+        "frontend": true
+      }
+    },
+    {
+      "metadata": {
         "name": "cachingOptimizeSerializationMemoryUsage",
-        "resourceVersion": "1707755276481",
-        "creationTimestamp": "2024-02-12T16:27:56Z"
+        "resourceVersion": "1697112000000",
+        "creationTimestamp": "2023-10-12T12:00:00Z"
       },
       "spec": {
         "description": "If enabled, the caching backend gradually serializes query responses for the cache, comparing against the configured `[caching]max_value_mb` value as it goes. This can can help prevent Grafana from running out of memory while attempting to cache very large query responses.",
         "stage": "experimental",
         "codeowner": "@grafana/grafana-operator-experience-squad"
+      }
+    },
+    {
+      "metadata": {
+        "name": "panelTitleSearchInV1",
+        "resourceVersion": "1697198400000",
+        "creationTimestamp": "2023-10-13T12:00:00Z"
+      },
+      "spec": {
+        "description": "Enable searching for dashboards using panel title in search v1",
+        "stage": "experimental",
+        "codeowner": "@grafana/backend-platform",
+        "requiresDevMode": true
+      }
+    },
+    {
+      "metadata": {
+        "name": "pluginsInstrumentationStatusSource",
+        "resourceVersion": "1697544000000",
+        "creationTimestamp": "2023-10-17T12:00:00Z"
+      },
+      "spec": {
+        "description": "Include a status source label for plugin request metrics and logs",
+        "stage": "experimental",
+        "codeowner": "@grafana/plugins-platform-backend"
+      }
+    },
+    {
+      "metadata": {
+        "name": "managedPluginsInstall",
+        "resourceVersion": "1697630400000",
+        "creationTimestamp": "2023-10-18T12:00:00Z"
+      },
+      "spec": {
+        "description": "Install managed plugins directly from plugins catalog",
+        "stage": "preview",
+        "codeowner": "@grafana/plugins-platform-backend"
+      }
+    },
+    {
+      "metadata": {
+        "name": "prometheusPromQAIL",
+        "resourceVersion": "1697716800000",
+        "creationTimestamp": "2023-10-19T12:00:00Z"
+      },
+      "spec": {
+        "description": "Prometheus and AI/ML to assist users in creating a query",
+        "stage": "experimental",
+        "codeowner": "@grafana/observability-metrics",
+        "frontend": true
+      }
+    },
+    {
+      "metadata": {
+        "name": "addFieldFromCalculationStatFunctions",
+        "resourceVersion": "1707523537136",
+        "creationTimestamp": "2023-11-03T12:00:00Z",
+        "annotations": {
+          "grafana.app/updatedTimestamp": "2024-02-10 00:05:37.1362 +0000 UTC"
+        }
+      },
+      "spec": {
+        "description": "Add cumulative and window functions to the add field from calculation transformation",
+        "stage": "preview",
+        "codeowner": "@grafana/dataviz-squad",
+        "frontend": true
+      }
+    },
+    {
+      "metadata": {
+        "name": "alertmanagerRemoteSecondary",
+        "resourceVersion": "1698667200000",
+        "creationTimestamp": "2023-10-30T12:00:00Z"
+      },
+      "spec": {
+        "description": "Enable Grafana to sync configuration and state with a remote Alertmanager.",
+        "stage": "experimental",
+        "codeowner": "@grafana/alerting-squad"
+      }
+    },
+    {
+      "metadata": {
+        "name": "alertmanagerRemotePrimary",
+        "resourceVersion": "1698667200000",
+        "creationTimestamp": "2023-10-30T12:00:00Z"
+      },
+      "spec": {
+        "description": "Enable Grafana to have a remote Alertmanager instance as the primary Alertmanager.",
+        "stage": "experimental",
+        "codeowner": "@grafana/alerting-squad"
+      }
+    },
+    {
+      "metadata": {
+        "name": "alertmanagerRemoteOnly",
+        "resourceVersion": "1698667200000",
+        "creationTimestamp": "2023-10-30T12:00:00Z"
+      },
+      "spec": {
+        "description": "Disable the internal Alertmanager and only use the external one defined.",
+        "stage": "experimental",
+        "codeowner": "@grafana/alerting-squad"
+      }
+    },
+    {
+      "metadata": {
+        "name": "annotationPermissionUpdate",
+        "resourceVersion": "1698753600000",
+        "creationTimestamp": "2023-10-31T12:00:00Z"
+      },
+      "spec": {
+        "description": "Separate annotation permissions from dashboard permissions to allow for more granular control.",
+        "stage": "experimental",
+        "codeowner": "@grafana/identity-access-team"
+      }
+    },
+    {
+      "metadata": {
+        "name": "extractFieldsNameDeduplication",
+        "resourceVersion": "1707523537136",
+        "creationTimestamp": "2023-11-02T12:00:00Z",
+        "annotations": {
+          "grafana.app/updatedTimestamp": "2024-02-10 00:05:37.1362 +0000 UTC"
+        }
+      },
+      "spec": {
+        "description": "Make sure extracted field names are unique in the dataframe",
+        "stage": "experimental",
+        "codeowner": "@grafana/dataviz-squad",
+        "frontend": true
+      }
+    },
+    {
+      "metadata": {
+        "name": "dashboardSceneForViewers",
+        "resourceVersion": "1698926400000",
+        "creationTimestamp": "2023-11-02T12:00:00Z"
+      },
+      "spec": {
+        "description": "Enables dashboard rendering using Scenes for viewer roles",
+        "stage": "experimental",
+        "codeowner": "@grafana/dashboards-squad",
+        "frontend": true
+      }
+    },
+    {
+      "metadata": {
+        "name": "dashboardScene",
+        "resourceVersion": "1699876800000",
+        "creationTimestamp": "2023-11-13T12:00:00Z"
+      },
+      "spec": {
+        "description": "Enables dashboard rendering using scenes for all roles",
+        "stage": "experimental",
+        "codeowner": "@grafana/dashboards-squad",
+        "frontend": true
+      }
+    },
+    {
+      "metadata": {
+        "name": "panelFilterVariable",
+        "resourceVersion": "1699012800000",
+        "creationTimestamp": "2023-11-03T12:00:00Z"
+      },
+      "spec": {
+        "description": "Enables use of the `systemPanelFilterVar` variable to filter panels in a dashboard",
+        "stage": "experimental",
+        "codeowner": "@grafana/dashboards-squad",
+        "frontend": true,
+        "hideFromDocs": true
+      }
+    },
+    {
+      "metadata": {
+        "name": "pdfTables",
+        "resourceVersion": "1699272000000",
+        "creationTimestamp": "2023-11-06T12:00:00Z"
+      },
+      "spec": {
+        "description": "Enables generating table data as PDF in reporting",
+        "stage": "preview",
+        "codeowner": "@grafana/sharing-squad"
+      }
+    },
+    {
+      "metadata": {
+        "name": "ssoSettingsApi",
+        "resourceVersion": "1699444800000",
+        "creationTimestamp": "2023-11-08T12:00:00Z"
+      },
+      "spec": {
+        "description": "Enables the SSO settings API",
+        "stage": "experimental",
+        "codeowner": "@grafana/identity-access-team"
+      }
+    },
+    {
+      "metadata": {
+        "name": "canvasPanelPanZoom",
+        "resourceVersion": "1703678400000",
+        "creationTimestamp": "2023-12-27T12:00:00Z"
+      },
+      "spec": {
+        "description": "Allow pan and zoom in canvas panel",
+        "stage": "preview",
+        "codeowner": "@grafana/dataviz-squad",
+        "frontend": true
+      }
+    },
+    {
+      "metadata": {
+        "name": "logsInfiniteScrolling",
+        "resourceVersion": "1699531200000",
+        "creationTimestamp": "2023-11-09T12:00:00Z"
+      },
+      "spec": {
+        "description": "Enables infinite scrolling for the Logs panel in Explore and Dashboards",
+        "stage": "experimental",
+        "codeowner": "@grafana/observability-logs",
+        "frontend": true
+      }
+    },
+    {
+      "metadata": {
+        "name": "flameGraphItemCollapsing",
+        "resourceVersion": "1699531200000",
+        "creationTimestamp": "2023-11-09T12:00:00Z"
+      },
+      "spec": {
+        "description": "Allow collapsing of flame graph items",
+        "stage": "experimental",
+        "codeowner": "@grafana/observability-traces-and-profiling",
+        "frontend": true
+      }
+    },
+    {
+      "metadata": {
+        "name": "alertingDetailsViewV2",
+        "resourceVersion": "1699531200000",
+        "creationTimestamp": "2023-11-09T12:00:00Z"
+      },
+      "spec": {
+        "description": "Enables the preview of the new alert details view",
+        "stage": "experimental",
+        "codeowner": "@grafana/alerting-squad",
+        "frontend": true,
+        "hideFromDocs": true
+      }
+    },
+    {
+      "metadata": {
+        "name": "datatrails",
+        "resourceVersion": "1700049600000",
+        "creationTimestamp": "2023-11-15T12:00:00Z"
+      },
+      "spec": {
+        "description": "Enables the new core app datatrails",
+        "stage": "experimental",
+        "codeowner": "@grafana/dashboards-squad",
+        "frontend": true,
+        "hideFromDocs": true
+      }
+    },
+    {
+      "metadata": {
+        "name": "alertingSimplifiedRouting",
+        "resourceVersion": "1699617600000",
+        "creationTimestamp": "2023-11-10T12:00:00Z"
+      },
+      "spec": {
+        "description": "Enables the simplified routing for alerting",
+        "stage": "experimental",
+        "codeowner": "@grafana/alerting-squad",
+        "hideFromDocs": true
+      }
+    },
+    {
+      "metadata": {
+        "name": "logRowsPopoverMenu",
+        "resourceVersion": "1700136000000",
+        "creationTimestamp": "2023-11-16T12:00:00Z"
+      },
+      "spec": {
+        "description": "Enable filtering menu displayed when text of a log line is selected",
+        "stage": "GA",
+        "codeowner": "@grafana/observability-logs",
+        "frontend": true
+      }
+    },
+    {
+      "metadata": {
+        "name": "pluginsSkipHostEnvVars",
+        "resourceVersion": "1700049600000",
+        "creationTimestamp": "2023-11-15T12:00:00Z"
+      },
+      "spec": {
+        "description": "Disables passing host environment variable to plugin processes",
+        "stage": "experimental",
+        "codeowner": "@grafana/plugins-platform-backend"
+      }
+    },
+    {
+      "metadata": {
+        "name": "tableSharedCrosshair",
+        "resourceVersion": "1707523537136",
+        "creationTimestamp": "2023-12-12T12:00:00Z",
+        "annotations": {
+          "grafana.app/updatedTimestamp": "2024-02-10 00:05:37.1362 +0000 UTC"
+        }
+      },
+      "spec": {
+        "description": "Enables shared crosshair in table panel",
+        "stage": "experimental",
+        "codeowner": "@grafana/dataviz-squad",
+        "frontend": true
+      }
+    },
+    {
+      "metadata": {
+        "name": "regressionTransformation",
+        "resourceVersion": "1707523537136",
+        "creationTimestamp": "2023-11-24T12:00:00Z",
+        "annotations": {
+          "grafana.app/updatedTimestamp": "2024-02-10 00:05:37.1362 +0000 UTC"
+        }
+      },
+      "spec": {
+        "description": "Enables regression analysis transformation",
+        "stage": "preview",
+        "codeowner": "@grafana/dataviz-squad",
+        "frontend": true
+      }
+    },
+    {
+      "metadata": {
+        "name": "displayAnonymousStats",
+        "resourceVersion": "1701259200000",
+        "creationTimestamp": "2023-11-29T12:00:00Z"
+      },
+      "spec": {
+        "description": "Enables anonymous stats to be shown in the UI for Grafana",
+        "stage": "GA",
+        "codeowner": "@grafana/identity-access-team",
+        "frontend": true
+      }
+    },
+    {
+      "metadata": {
+        "name": "lokiQueryHints",
+        "resourceVersion": "1702900800000",
+        "creationTimestamp": "2023-12-18T12:00:00Z"
+      },
+      "spec": {
+        "description": "Enables query hints for Loki",
+        "stage": "GA",
+        "codeowner": "@grafana/observability-logs",
+        "frontend": true
+      }
+    },
+    {
+      "metadata": {
+        "name": "kubernetesFeatureToggles",
+        "resourceVersion": "1703216580000",
+        "creationTimestamp": "2023-12-22T03:43:00Z"
+      },
+      "spec": {
+        "description": "Use the kubernetes API for feature toggle management in the frontend",
+        "stage": "experimental",
+        "codeowner": "@grafana/grafana-operator-experience-squad",
+        "frontend": true,
+        "hideFromAdminPage": true
+      }
+    },
+    {
+      "metadata": {
+        "name": "alertingPreviewUpgrade",
+        "resourceVersion": "1707425412785",
+        "creationTimestamp": "2024-01-03T12:00:00Z",
+        "annotations": {
+          "grafana.app/updatedTimestamp": "2024-02-08 20:50:12.785364 +0000 UTC"
+        }
+      },
+      "spec": {
+        "description": "Show Unified Alerting preview and upgrade page in legacy alerting",
+        "stage": "GA",
+        "codeowner": "@grafana/alerting-squad",
+        "requiresRestart": true
+      }
+    },
+    {
+      "metadata": {
+        "name": "enablePluginsTracingByDefault",
+        "resourceVersion": "1704801600000",
+        "creationTimestamp": "2024-01-09T12:00:00Z"
+      },
+      "spec": {
+        "description": "Enable plugin tracing for all external plugins",
+        "stage": "experimental",
+        "codeowner": "@grafana/plugins-platform-backend",
+        "requiresRestart": true
+      }
+    },
+    {
+      "metadata": {
+        "name": "cloudRBACRoles",
+        "resourceVersion": "1704888000000",
+        "creationTimestamp": "2024-01-10T12:00:00Z"
+      },
+      "spec": {
+        "description": "Enabled grafana cloud specific RBAC roles",
+        "stage": "experimental",
+        "codeowner": "@grafana/identity-access-team",
+        "requiresRestart": true,
+        "hideFromDocs": true
+      }
+    },
+    {
+      "metadata": {
+        "name": "alertingQueryOptimization",
+        "resourceVersion": "1704888000000",
+        "creationTimestamp": "2024-01-10T12:00:00Z"
+      },
+      "spec": {
+        "description": "Optimizes eligible queries in order to reduce load on datasources",
+        "stage": "GA",
+        "codeowner": "@grafana/alerting-squad"
+      }
+    },
+    {
+      "metadata": {
+        "name": "newFolderPicker",
+        "resourceVersion": "1705060800000",
+        "creationTimestamp": "2024-01-12T12:00:00Z"
+      },
+      "spec": {
+        "description": "Enables the nested folder picker without having nested folders enabled",
+        "stage": "experimental",
+        "codeowner": "@grafana/grafana-frontend-platform",
+        "frontend": true
+      }
+    },
+    {
+      "metadata": {
+        "name": "jitterAlertRulesWithinGroups",
+        "resourceVersion": "1705492800000",
+        "creationTimestamp": "2024-01-17T12:00:00Z"
+      },
+      "spec": {
+        "description": "Distributes alert rule evaluations more evenly over time, including spreading out rules within the same group",
+        "stage": "preview",
+        "codeowner": "@grafana/alerting-squad",
+        "requiresRestart": true,
+        "hideFromDocs": true
+      }
+    },
+    {
+      "metadata": {
+        "name": "onPremToCloudMigrations",
+        "resourceVersion": "1705894200000",
+        "creationTimestamp": "2024-01-22T03:30:00Z"
+      },
+      "spec": {
+        "description": "In-development feature that will allow users to easily migrate their on-prem Grafana instances to Grafana Cloud.",
+        "stage": "experimental",
+        "codeowner": "@grafana/grafana-operator-experience-squad"
+      }
+    },
+    {
+      "metadata": {
+        "name": "alertingSaveStatePeriodic",
+        "resourceVersion": "1705924800000",
+        "creationTimestamp": "2024-01-22T12:00:00Z"
+      },
+      "spec": {
+        "description": "Writes the state periodically to the database, asynchronous to rule evaluation",
+        "stage": "privatePreview",
+        "codeowner": "@grafana/alerting-squad"
+      }
+    },
+    {
+      "metadata": {
+        "name": "promQLScope",
+        "resourceVersion": "1706486400000",
+        "creationTimestamp": "2024-01-29T00:00:00Z"
+      },
+      "spec": {
+        "description": "In-development feature that will allow injection of labels into prometheus queries.",
+        "stage": "experimental",
+        "codeowner": "@grafana/observability-metrics"
+      }
+    },
+    {
+      "metadata": {
+        "name": "nodeGraphDotLayout",
+        "resourceVersion": "1704196800000",
+        "creationTimestamp": "2024-01-02T12:00:00Z"
+      },
+      "spec": {
+        "description": "Changed the layout algorithm for the node graph",
+        "stage": "experimental",
+        "codeowner": "@grafana/observability-traces-and-profiling",
+        "frontend": true
+      }
+    },
+    {
+      "metadata": {
+        "name": "groupToNestedTableTransformation",
+        "resourceVersion": "1707134400000",
+        "creationTimestamp": "2024-02-05T12:00:00Z"
+      },
+      "spec": {
+        "description": "Enables the group to nested table transformation",
+        "stage": "preview",
+        "codeowner": "@grafana/dataviz-squad",
+        "frontend": true
+      }
+    },
+    {
+      "metadata": {
+        "name": "newPDFRendering",
+        "resourceVersion": "1707425412785",
+        "creationTimestamp": "2024-02-08T20:50:12Z"
+      },
+      "spec": {
+        "description": "New implementation for the dashboard to PDF rendering",
+        "stage": "experimental",
+        "codeowner": "@grafana/sharing-squad"
+      }
+    },
+    {
+      "metadata": {
+        "name": "autoMigrateGraphPanel",
+        "resourceVersion": "1707433170195",
+        "creationTimestamp": "2024-02-08T22:59:30Z"
+      },
+      "spec": {
+        "description": "Migrate old graph panel to supported time series panel - broken out from autoMigrateOldPanels to enable granular tracking",
+        "stage": "preview",
+        "codeowner": "@grafana/dataviz-squad",
+        "frontend": true
+      }
+    },
+    {
+      "metadata": {
+        "name": "dashboardSceneSolo",
+        "resourceVersion": "1707577534071",
+        "creationTimestamp": "2024-02-10T15:05:34Z"
+      },
+      "spec": {
+        "description": "Enables rendering dashboards using scenes for solo panels",
+        "stage": "experimental",
+        "codeowner": "@grafana/dashboards-squad",
+        "frontend": true
+      }
+    },
+    {
+      "metadata": {
+        "name": "kubernetesAggregator",
+        "resourceVersion": "1707775742552",
+        "creationTimestamp": "2024-02-12T22:09:02Z"
+      },
+      "spec": {
+        "description": "Enable grafana aggregator",
+        "stage": "experimental",
+        "codeowner": "@grafana/grafana-app-platform-squad",
+        "requiresRestart": true
       }
     }
   ]


### PR DESCRIPTION
Older PRs adding feature toggles will have some issues merging and keeping the feature toggle history correct.  See: https://github.com/grafana/grafana/pull/81591/files#diff-33f79832890bdb4973989dd844fdbd980ee20a266ececffc8632a939cbb055ae

This PR reverts most of the changes to that file and applies the smaller diff.

See https://github.com/grafana/grafana/pull/82131 -- hopefully this is only an issue while while the open PRs get merged, but if it continues to be a problem, i'll look more closely.

Change to the file really should just be:
<img width="484" alt="image" src="https://github.com/grafana/grafana/assets/705951/54225c29-1061-4870-94aa-e6da339db252">
