### PR TITLE
DashboardScene: Empty dashboard state

### DIFF
--- a/public/app/features/dashboard-scene/scene/DashboardScene.tsx
+++ b/public/app/features/dashboard-scene/scene/DashboardScene.tsx
@@ -407,6 +407,24 @@ export class DashboardScene extends SceneObjectBase<DashboardSceneState> {
     return this._initialState;
   }
 
+  public addPanel(vizPanel: VizPanel): void {
+    // TODO: need logic for adding a panel when other panels exist
+    // This is the logic when dashboard is empty
+    this.setState({
+      body: new SceneGridLayout({
+        children: [
+          new SceneGridItem({
+            height: 10,
+            width: 10,
+            x: 0.2,
+            y: 0,
+            body: vizPanel,
+          }),
+        ],
+      }),
+    });
+  }
+
   public duplicatePanel(vizPanel: VizPanel) {
     if (!vizPanel.parent) {
       return;
@@ -536,6 +554,20 @@ export class DashboardScene extends SceneObjectBase<DashboardSceneState> {
 
   public onOpenSettings = () => {
     locationService.partial({ editview: 'settings' });
+  };
+
+  public isEmpty = (): boolean => {
+    const { body, viewPanelScene } = this.state;
+
+    if (!!viewPanelScene) {
+      return !!viewPanelScene.state.body;
+    }
+
+    if (body instanceof SceneFlexLayout || body instanceof SceneGridLayout) {
+      return body.state.children.length === 0;
+    }
+
+    throw new Error('Invalid body type');
   };
 
   /**

--- a/public/app/features/dashboard-scene/scene/DashboardSceneRenderer.tsx
+++ b/public/app/features/dashboard-scene/scene/DashboardSceneRenderer.tsx
@@ -7,6 +7,7 @@ import { SceneComponentProps, SceneDebugger } from '@grafana/scenes';
 import { CustomScrollbar, useStyles2 } from '@grafana/ui';
 import { Page } from 'app/core/components/Page/Page';
 import { getNavModel } from 'app/core/selectors/navModel';
+import DashboardEmpty from 'app/features/dashboard/dashgrid/DashboardEmpty';
 import { useSelector } from 'app/types';
 
 import { DashboardScene } from './DashboardScene';
@@ -21,6 +22,15 @@ export function DashboardSceneRenderer({ model }: SceneComponentProps<DashboardS
   const bodyToRender = model.getBodyToRender();
   const navModel = getNavModel(navIndex, 'dashboards/browse');
   const showDebugger = location.search.includes('scene-debugger');
+
+  if (model.isEmpty()) {
+    return (
+      <Page navModel={navModel} pageNav={pageNav} layout={PageLayoutType.Custom}>
+        <NavToolbarActions dashboard={model} />
+        <DashboardEmpty dashboard={model} canCreate={!!model.state.meta.canEdit} />
+      </Page>
+    );
+  }
 
   if (editview) {
     return (

--- a/public/app/features/dashboard-scene/scene/DashboardSceneRenderer.tsx
+++ b/public/app/features/dashboard-scene/scene/DashboardSceneRenderer.tsx
@@ -23,15 +23,6 @@ export function DashboardSceneRenderer({ model }: SceneComponentProps<DashboardS
   const navModel = getNavModel(navIndex, 'dashboards/browse');
   const showDebugger = location.search.includes('scene-debugger');
 
-  if (model.isEmpty()) {
-    return (
-      <Page navModel={navModel} pageNav={pageNav} layout={PageLayoutType.Custom}>
-        <NavToolbarActions dashboard={model} />
-        <DashboardEmpty dashboard={model} canCreate={!!model.state.meta.canEdit} />
-      </Page>
-    );
-  }
-
   if (editview) {
     return (
       <>
@@ -41,6 +32,29 @@ export function DashboardSceneRenderer({ model }: SceneComponentProps<DashboardS
     );
   }
 
+  const emptyState = (
+    <>
+      <div className={styles.controls}>{showDebugger && <SceneDebugger scene={model} key={'scene-debugger'} />}</div>
+      <DashboardEmpty dashboard={model} canCreate={!!model.state.meta.canEdit} />
+    </>
+  );
+
+  const withPanels = (
+    <>
+      {controls && (
+        <div className={styles.controls}>
+          {controls.map((control) => (
+            <control.Component key={control.state.key} model={control} />
+          ))}
+          {showDebugger && <SceneDebugger scene={model} key={'scene-debugger'} />}
+        </div>
+      )}
+      <div className={cx(styles.body)}>
+        <bodyToRender.Component model={bodyToRender} />
+      </div>
+    </>
+  );
+
   return (
     <Page navModel={navModel} pageNav={pageNav} layout={PageLayoutType.Custom}>
       {editPanel && <editPanel.Component model={editPanel} />}
@@ -48,18 +62,7 @@ export function DashboardSceneRenderer({ model }: SceneComponentProps<DashboardS
         <CustomScrollbar autoHeightMin={'100%'}>
           <div className={styles.canvasContent}>
             <NavToolbarActions dashboard={model} />
-
-            {controls && (
-              <div className={styles.controls}>
-                {controls.map((control) => (
-                  <control.Component key={control.state.key} model={control} />
-                ))}
-                {showDebugger && <SceneDebugger scene={model} key={'scene-debugger'} />}
-              </div>
-            )}
-            <div className={cx(styles.body)}>
-              <bodyToRender.Component model={bodyToRender} />
-            </div>
+            {model.isEmpty() ? emptyState : withPanels}
           </div>
         </CustomScrollbar>
       )}
@@ -96,6 +99,7 @@ function getStyles(theme: GrafanaTheme2) {
       background: theme.colors.background.canvas,
       zIndex: theme.zIndex.activePanel,
       padding: theme.spacing(2, 0),
+      marginLeft: 'auto',
     }),
   };
 }

--- a/public/app/features/dashboard/dashgrid/DashboardEmpty.tsx
+++ b/public/app/features/dashboard/dashgrid/DashboardEmpty.tsx
@@ -1,20 +1,25 @@
 import { css } from '@emotion/css';
 import React from 'react';
 
-import { GrafanaTheme2 } from '@grafana/data';
+import { GrafanaTheme2, getDataSourceRef } from '@grafana/data';
 import { selectors } from '@grafana/e2e-selectors';
-import { config, locationService } from '@grafana/runtime';
+import { config, getDataSourceSrv, locationService } from '@grafana/runtime';
+import { VizPanel, VizPanelMenu, SceneDataTransformer, SceneQueryRunner } from '@grafana/scenes';
 import { Button, useStyles2, Text, Box, Stack } from '@grafana/ui';
 import { Trans } from 'app/core/internationalization';
 import { DashboardModel } from 'app/features/dashboard/state';
 import { onAddLibraryPanel, onCreateNewPanel, onImportDashboard } from 'app/features/dashboard/utils/dashboard';
+import { DashboardScene } from 'app/features/dashboard-scene/scene/DashboardScene';
+import { VizPanelLinks, VizPanelLinksMenu } from 'app/features/dashboard-scene/scene/PanelLinks';
+import { panelMenuBehavior } from 'app/features/dashboard-scene/scene/PanelMenuBehavior';
 import { DashboardInteractions } from 'app/features/dashboard-scene/utils/interactions';
+import { getPanelIdForVizPanel } from 'app/features/dashboard-scene/utils/utils';
 import { useDispatch, useSelector } from 'app/types';
 
 import { setInitialDatasource } from '../state/reducers';
 
 export interface Props {
-  dashboard: DashboardModel;
+  dashboard: DashboardModel | DashboardScene;
   canCreate: boolean;
 }
 
@@ -22,6 +27,7 @@ const DashboardEmpty = ({ dashboard, canCreate }: Props) => {
   const styles = useStyles2(getStyles);
   const dispatch = useDispatch();
   const initialDatasource = useSelector((state) => state.dashboard.initialDatasource);
+  const isDashboardScene = dashboard instanceof DashboardScene;
 
   return (
     <Stack alignItems="center" justifyContent="center">
@@ -47,11 +53,32 @@ const DashboardEmpty = ({ dashboard, canCreate }: Props) => {
                 icon="plus"
                 data-testid={selectors.pages.AddDashboard.itemButton('Create new panel button')}
                 onClick={() => {
-                  const id = onCreateNewPanel(dashboard, initialDatasource);
+                  if (isDashboardScene) {
+                    const vizPanel = new VizPanel({
+                      title: 'Panel Title',
+                      key: 'panel-1', // the first panel should always be panel-1
+                      pluginId: 'timeseries',
+                      titleItems: [new VizPanelLinks({ menu: new VizPanelLinksMenu({}) })],
+                      menu: new VizPanelMenu({
+                        $behaviors: [panelMenuBehavior],
+                      }),
+                      $data: new SceneDataTransformer({
+                        $data: new SceneQueryRunner({
+                          queries: [{ refId: 'A' }],
+                          datasource: getDataSourceRef(getDataSourceSrv().getInstanceSettings(null)!),
+                        }),
+                        transformations: [],
+                      }),
+                    });
+                    dashboard.addPanel(vizPanel);
+                    const id = getPanelIdForVizPanel(vizPanel);
+                    locationService.partial({ editPanel: id, firstPanel: true });
+                  } else {
+                    const id = onCreateNewPanel(dashboard, initialDatasource);
+                    locationService.partial({ editPanel: id, firstPanel: true });
+                    dispatch(setInitialDatasource(undefined));
+                  }
                   DashboardInteractions.emptyDashboardButtonClicked({ item: 'add_visualization' });
-
-                  locationService.partial({ editPanel: id, firstPanel: true });
-                  dispatch(setInitialDatasource(undefined));
                 }}
                 disabled={!canCreate}
               >
@@ -104,7 +131,11 @@ const DashboardEmpty = ({ dashboard, canCreate }: Props) => {
                   data-testid={selectors.pages.AddDashboard.itemButton('Add a panel from the panel library button')}
                   onClick={() => {
                     DashboardInteractions.emptyDashboardButtonClicked({ item: 'import_from_library' });
-                    onAddLibraryPanel(dashboard);
+                    if (isDashboardScene) {
+                      // TODO: dashboard scene logic for adding a library panel
+                    } else {
+                      onAddLibraryPanel(dashboard);
+                    }
                   }}
                   disabled={!canCreate}
                 >


### PR DESCRIPTION
Added:

- Logic for empty dashboard
- `Add visualization` functionality

`Import dashboard` worked and didn't need any changes

`Add library panel` depends on future work which will be a separate PR
 
Closes #82126 