### PR TITLE
Prometheus: AzureCredentials from Azure React SDK

### DIFF
--- a/package.json
+++ b/package.json
@@ -234,6 +234,7 @@
     "@grafana-plugins/stackdriver": "workspace:*",
     "@grafana-plugins/tempo": "workspace:*",
     "@grafana/aws-sdk": "0.3.1",
+    "@grafana/azure-sdk": "0.0.1",
     "@grafana/data": "workspace:*",
     "@grafana/e2e-selectors": "workspace:*",
     "@grafana/experimental": "1.7.10",

--- a/public/app/plugins/datasource/prometheus/configuration/AzureAuthSettings.tsx
+++ b/public/app/plugins/datasource/prometheus/configuration/AzureAuthSettings.tsx
@@ -1,11 +1,12 @@
 import { cx } from '@emotion/css';
 import React, { FormEvent, useMemo, useState } from 'react';
 
+import { AzureCredentials } from '@grafana/azure-sdk';
 import { config } from '@grafana/runtime';
 import { InlineField, InlineFieldRow, InlineSwitch, Input } from '@grafana/ui';
 import { HttpSettingsBaseProps } from '@grafana/ui/src/components/DataSourceSettings/types';
 
-import { KnownAzureClouds, AzureCredentials } from './AzureCredentials';
+import { KnownAzureClouds } from './AzureCredentials';
 import { getCredentials, updateCredentials } from './AzureCredentialsConfig';
 import { AzureCredentialsForm } from './AzureCredentialsForm';
 

--- a/public/app/plugins/datasource/prometheus/configuration/AzureCredentials.ts
+++ b/public/app/plugins/datasource/prometheus/configuration/AzureCredentials.ts
@@ -1,3 +1,4 @@
+import { AzureCredentials } from '@grafana/azure-sdk';
 import { SelectableValue } from '@grafana/data';
 
 export enum AzureCloud {
@@ -13,42 +14,14 @@ export const KnownAzureClouds: Array<SelectableValue<AzureCloud>> = [
   { value: AzureCloud.USGovernment, label: 'Azure US Government' },
 ];
 
-export type AzureAuthType = 'msi' | 'clientsecret' | 'workloadidentity';
-
-export type ConcealedSecret = symbol;
-
-interface AzureCredentialsBase {
-  authType: AzureAuthType;
-  defaultSubscriptionId?: string;
-}
-
-export interface AzureManagedIdentityCredentials extends AzureCredentialsBase {
-  authType: 'msi';
-}
-
-export interface AzureWorkloadIdentityCredentials extends AzureCredentialsBase {
-  authType: 'workloadidentity';
-}
-
-export interface AzureClientSecretCredentials extends AzureCredentialsBase {
-  authType: 'clientsecret';
-  azureCloud?: string;
-  tenantId?: string;
-  clientId?: string;
-  clientSecret?: string | ConcealedSecret;
-}
-
-export type AzureCredentials =
-  | AzureManagedIdentityCredentials
-  | AzureClientSecretCredentials
-  | AzureWorkloadIdentityCredentials;
-
 export function isCredentialsComplete(credentials: AzureCredentials): boolean {
   switch (credentials.authType) {
+    case 'currentuser':
     case 'msi':
     case 'workloadidentity':
       return true;
     case 'clientsecret':
+    case 'clientsecret-obo':
       return !!(credentials.azureCloud && credentials.tenantId && credentials.clientId && credentials.clientSecret);
   }
 }

--- a/public/app/plugins/datasource/prometheus/configuration/AzureCredentials.ts
+++ b/public/app/plugins/datasource/prometheus/configuration/AzureCredentials.ts
@@ -1,4 +1,3 @@
-import { AzureCredentials } from '@grafana/azure-sdk';
 import { SelectableValue } from '@grafana/data';
 
 export enum AzureCloud {
@@ -13,15 +12,3 @@ export const KnownAzureClouds: Array<SelectableValue<AzureCloud>> = [
   { value: AzureCloud.China, label: 'Azure China' },
   { value: AzureCloud.USGovernment, label: 'Azure US Government' },
 ];
-
-export function isCredentialsComplete(credentials: AzureCredentials): boolean {
-  switch (credentials.authType) {
-    case 'currentuser':
-    case 'msi':
-    case 'workloadidentity':
-      return true;
-    case 'clientsecret':
-    case 'clientsecret-obo':
-      return !!(credentials.azureCloud && credentials.tenantId && credentials.clientId && credentials.clientSecret);
-  }
-}

--- a/public/app/plugins/datasource/prometheus/configuration/AzureCredentialsConfig.ts
+++ b/public/app/plugins/datasource/prometheus/configuration/AzureCredentialsConfig.ts
@@ -1,7 +1,8 @@
+import { AzureCredentials, ConcealedSecret } from '@grafana/azure-sdk';
 import { DataSourceSettings } from '@grafana/data';
 import { config } from '@grafana/runtime';
 
-import { AzureCloud, AzureCredentials, ConcealedSecret } from './AzureCredentials';
+import { AzureCloud } from './AzureCredentials';
 
 const concealed: ConcealedSecret = Symbol('Concealed client secret');
 
@@ -66,6 +67,8 @@ export function getCredentials(options: DataSourceSettings<any, any>): AzureCred
         clientId: credentials.clientId,
         clientSecret: getSecret(options),
       };
+    default:
+      throw new Error(`Azure authentication type '${credentials.authType}' not supported by the Prometheus datasource.`);
   }
 }
 
@@ -122,6 +125,9 @@ export function updateCredentials(
       };
 
       return options;
+
+    default:
+      throw new Error(`Azure authentication type '${credentials.authType}' not supported by the Prometheus datasource.`);
   }
 }
 

--- a/public/app/plugins/datasource/prometheus/configuration/AzureCredentialsForm.test.tsx
+++ b/public/app/plugins/datasource/prometheus/configuration/AzureCredentialsForm.test.tsx
@@ -13,7 +13,6 @@ const setup = (propsFunc?: (props: Props) => Props) => {
       tenantId: 'e7f3f661-a933-3h3f-0294-31c4f962ec48',
       clientId: '34509fad-c0r9-45df-9e25-f1ee34af6900',
       clientSecret: undefined,
-      defaultSubscriptionId: '44987801-6nn6-49he-9b2d-9106972f9789',
     },
     azureCloudOptions: [
       { value: 'azuremonitor', label: 'Azure' },
@@ -21,7 +20,6 @@ const setup = (propsFunc?: (props: Props) => Props) => {
       { value: 'chinaazuremonitor', label: 'Azure China' },
     ],
     onCredentialsChange: jest.fn(),
-    getSubscriptions: jest.fn().mockResolvedValue([]),
   };
 
   if (propsFunc) {

--- a/public/app/plugins/datasource/prometheus/configuration/AzureCredentialsForm.tsx
+++ b/public/app/plugins/datasource/prometheus/configuration/AzureCredentialsForm.tsx
@@ -1,11 +1,10 @@
 import { cx } from '@emotion/css';
-import React, { ChangeEvent, useEffect, useMemo, useReducer, useState } from 'react';
+import React, { ChangeEvent, useMemo } from 'react';
 
+import { AzureAuthType, AzureCredentials } from '@grafana/azure-sdk';
 import { SelectableValue } from '@grafana/data';
 import { config } from '@grafana/runtime';
 import { InlineFormLabel, Button, Select, Input } from '@grafana/ui';
-
-import { AzureAuthType, AzureCredentials, isCredentialsComplete } from './AzureCredentials';
 
 export interface Props {
   managedIdentityEnabled: boolean;
@@ -13,7 +12,6 @@ export interface Props {
   credentials: AzureCredentials;
   azureCloudOptions?: SelectableValue[];
   onCredentialsChange: (updatedCredentials: AzureCredentials) => void;
-  getSubscriptions?: () => Promise<SelectableValue[]>;
   disabled?: boolean;
 }
 
@@ -22,15 +20,10 @@ export const AzureCredentialsForm = (props: Props) => {
     credentials,
     azureCloudOptions,
     onCredentialsChange,
-    getSubscriptions,
     disabled,
     managedIdentityEnabled,
     workloadIdentityEnabled,
   } = props;
-  const hasRequiredFields = isCredentialsComplete(credentials);
-
-  const [subscriptions, setSubscriptions] = useState<Array<SelectableValue<string>>>([]);
-  const [loadSubscriptionsClicked, onLoadSubscriptions] = useReducer((val) => val + 1, 0);
 
   const authTypeOptions = useMemo(() => {
     let opts: Array<SelectableValue<AzureAuthType>> = [
@@ -56,42 +49,7 @@ export const AzureCredentialsForm = (props: Props) => {
     return opts;
   }, [managedIdentityEnabled, workloadIdentityEnabled]);
 
-  useEffect(() => {
-    if (!getSubscriptions || !hasRequiredFields) {
-      updateSubscriptions([]);
-      return;
-    }
-    let canceled = false;
-    getSubscriptions().then((result) => {
-      if (!canceled) {
-        updateSubscriptions(result, loadSubscriptionsClicked);
-      }
-    });
-    return () => {
-      canceled = true;
-    };
-    // This effect is intended to be called only once initially and on Load Subscriptions click
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [loadSubscriptionsClicked]);
-
-  const updateSubscriptions = (received: Array<SelectableValue<string>>, autoSelect = false) => {
-    setSubscriptions(received);
-    if (getSubscriptions) {
-      if (autoSelect && !credentials.defaultSubscriptionId && received.length > 0) {
-        // Selecting the default subscription if subscriptions received but no default subscription selected
-        onSubscriptionChange(received[0]);
-      } else if (credentials.defaultSubscriptionId) {
-        const found = received.find((opt) => opt.value === credentials.defaultSubscriptionId);
-        if (!found) {
-          // Unselecting the default subscription if it isn't found among the received subscriptions
-          onSubscriptionChange(undefined);
-        }
-      }
-    }
-  };
-
   const onAuthTypeChange = (selected: SelectableValue<AzureAuthType>) => {
-    setSubscriptions([]);
     const defaultAuthType = managedIdentityEnabled
       ? 'msi'
       : workloadIdentityEnabled
@@ -100,18 +58,15 @@ export const AzureCredentialsForm = (props: Props) => {
     const updated: AzureCredentials = {
       ...credentials,
       authType: selected.value || defaultAuthType,
-      defaultSubscriptionId: undefined,
     };
     onCredentialsChange(updated);
   };
 
   const onAzureCloudChange = (selected: SelectableValue<string>) => {
     if (credentials.authType === 'clientsecret') {
-      setSubscriptions([]);
       const updated: AzureCredentials = {
         ...credentials,
         azureCloud: selected.value,
-        defaultSubscriptionId: undefined,
       };
       onCredentialsChange(updated);
     }
@@ -119,11 +74,9 @@ export const AzureCredentialsForm = (props: Props) => {
 
   const onTenantIdChange = (event: ChangeEvent<HTMLInputElement>) => {
     if (credentials.authType === 'clientsecret') {
-      setSubscriptions([]);
       const updated: AzureCredentials = {
         ...credentials,
         tenantId: event.target.value,
-        defaultSubscriptionId: undefined,
       };
       onCredentialsChange(updated);
     }
@@ -131,11 +84,9 @@ export const AzureCredentialsForm = (props: Props) => {
 
   const onClientIdChange = (event: ChangeEvent<HTMLInputElement>) => {
     if (credentials.authType === 'clientsecret') {
-      setSubscriptions([]);
       const updated: AzureCredentials = {
         ...credentials,
         clientId: event.target.value,
-        defaultSubscriptionId: undefined,
       };
       onCredentialsChange(updated);
     }
@@ -143,11 +94,9 @@ export const AzureCredentialsForm = (props: Props) => {
 
   const onClientSecretChange = (event: ChangeEvent<HTMLInputElement>) => {
     if (credentials.authType === 'clientsecret') {
-      setSubscriptions([]);
       const updated: AzureCredentials = {
         ...credentials,
         clientSecret: event.target.value,
-        defaultSubscriptionId: undefined,
       };
       onCredentialsChange(updated);
     }
@@ -155,23 +104,14 @@ export const AzureCredentialsForm = (props: Props) => {
 
   const onClientSecretReset = () => {
     if (credentials.authType === 'clientsecret') {
-      setSubscriptions([]);
       const updated: AzureCredentials = {
         ...credentials,
         clientSecret: '',
-        defaultSubscriptionId: undefined,
       };
       onCredentialsChange(updated);
     }
   };
 
-  const onSubscriptionChange = (selected: SelectableValue<string> | undefined) => {
-    const updated: AzureCredentials = {
-      ...credentials,
-      defaultSubscriptionId: selected?.value,
-    };
-    onCredentialsChange(updated);
-  };
   const prometheusConfigOverhaulAuth = config.featureToggles.prometheusConfigOverhaulAuth;
 
   return (
@@ -281,42 +221,6 @@ export const AzureCredentialsForm = (props: Props) => {
               </div>
             </div>
           )}
-        </>
-      )}
-      {getSubscriptions && (
-        <>
-          <div className="gf-form-inline">
-            <div className="gf-form">
-              <InlineFormLabel className="width-12">Default Subscription</InlineFormLabel>
-              <div className={cx(prometheusConfigOverhaulAuth ? 'width-20' : 'width-25')}>
-                <Select
-                  value={
-                    credentials.defaultSubscriptionId
-                      ? subscriptions.find((opt) => opt.value === credentials.defaultSubscriptionId)
-                      : undefined
-                  }
-                  options={subscriptions}
-                  onChange={onSubscriptionChange}
-                  isDisabled={disabled}
-                />
-              </div>
-            </div>
-          </div>
-          <div className="gf-form-inline">
-            <div className="gf-form">
-              <div className="max-width-30 gf-form-inline">
-                <Button
-                  variant="secondary"
-                  size="sm"
-                  type="button"
-                  onClick={onLoadSubscriptions}
-                  disabled={!hasRequiredFields}
-                >
-                  Load Subscriptions
-                </Button>
-              </div>
-            </div>
-          </div>
         </>
       )}
     </div>

--- a/yarn.lock
+++ b/yarn.lock
@@ -3486,6 +3486,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@grafana/azure-sdk@npm:0.0.1":
+  version: 0.0.1
+  resolution: "@grafana/azure-sdk@npm:0.0.1"
+  dependencies:
+    ts-jest: "npm:29.1.1"
+  checksum: 10/17d435b13213894868276a40494bb9d3cb78adf69501966f6411c40ea7e2563f5d3800f603c8f6ee9c96a69f137e83eafa5cb3b71ffa3c34c31cf8f45a695efd
+  languageName: node
+  linkType: hard
+
 "@grafana/data@npm:10.4.0-pre, @grafana/data@workspace:*, @grafana/data@workspace:packages/grafana-data":
   version: 0.0.0-use.local
   resolution: "@grafana/data@workspace:packages/grafana-data"
@@ -18003,6 +18012,7 @@ __metadata:
     "@grafana-plugins/stackdriver": "workspace:*"
     "@grafana-plugins/tempo": "workspace:*"
     "@grafana/aws-sdk": "npm:0.3.1"
+    "@grafana/azure-sdk": "npm:0.0.1"
     "@grafana/data": "workspace:*"
     "@grafana/e2e-selectors": "workspace:*"
     "@grafana/eslint-config": "npm:7.0.0"
@@ -29538,6 +29548,39 @@ __metadata:
   bin:
     ts-jest: cli.js
   checksum: 10/59d7122ea1a861aec510b19d30517df81c09ce89b9c2e6d40425c97bd2006a437f169bd6ec965b5b239b82a0ad773ca8fc40cc51f956b380ffc3a964682e9260
+  languageName: node
+  linkType: hard
+
+"ts-jest@npm:29.1.1":
+  version: 29.1.1
+  resolution: "ts-jest@npm:29.1.1"
+  dependencies:
+    bs-logger: "npm:0.x"
+    fast-json-stable-stringify: "npm:2.x"
+    jest-util: "npm:^29.0.0"
+    json5: "npm:^2.2.3"
+    lodash.memoize: "npm:4.x"
+    make-error: "npm:1.x"
+    semver: "npm:^7.5.3"
+    yargs-parser: "npm:^21.0.1"
+  peerDependencies:
+    "@babel/core": ">=7.0.0-beta.0 <8"
+    "@jest/types": ^29.0.0
+    babel-jest: ^29.0.0
+    jest: ^29.0.0
+    typescript: ">=4.3 <6"
+  peerDependenciesMeta:
+    "@babel/core":
+      optional: true
+    "@jest/types":
+      optional: true
+    babel-jest:
+      optional: true
+    esbuild:
+      optional: true
+  bin:
+    ts-jest: cli.js
+  checksum: 10/30e8259baba95dd786e64f7c18b864e904598f3ba07911be4d9bd29ca9c3c0024bad4ccf8ec0abd2a2fa14b06622cbbadff1b3be822189c657196442d33ee6ca
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Use frontend `AzureCredentials` definitions from the `@grafana/azure-sdk` library to share common parts of the Azure authentication logic among multiple datasources.