### PR TITLE
Alerting: Use VirtualizedSelect for ContactPointSelector

### DIFF
--- a/public/app/features/alerting/unified/components/rule-editor/alert-rule-form/simplifiedRouting/contactPoint/ContactPointSelector.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/alert-rule-form/simplifiedRouting/contactPoint/ContactPointSelector.tsx
@@ -9,9 +9,9 @@ import {
   FieldValidationMessage,
   IconButton,
   InputControl,
-  Select,
   Stack,
   TextLink,
+  VirtualizedSelect,
   useStyles2,
 } from '@grafana/ui';
 import { RuleFormValues } from 'app/features/alerting/unified/types/rule-form';
@@ -42,9 +42,10 @@ export function ContactPointSelector({
   const contactPointInForm = watch(`contactPoints.${alertManager}.selectedContactPoint`);
 
   const selectedContactPointWithMetadata = options.find((option) => option.value.name === contactPointInForm)?.value;
-  const selectedContactPointSelectableValue = selectedContactPointWithMetadata
-    ? { value: selectedContactPointWithMetadata, label: selectedContactPointWithMetadata.name }
-    : undefined;
+  const selectedContactPointSelectableValue: SelectableValue<ContactPointWithMetadata> =
+    selectedContactPointWithMetadata
+      ? { value: selectedContactPointWithMetadata, label: selectedContactPointWithMetadata.name }
+      : { value: undefined, label: '' };
 
   const LOADING_SPINNER_DURATION = 1000;
 
@@ -80,8 +81,7 @@ export function ContactPointSelector({
             render={({ field: { onChange, ref, ...field }, fieldState: { error } }) => (
               <>
                 <div className={styles.contactPointsSelector}>
-                  <Select
-                    {...field}
+                  <VirtualizedSelect<ContactPointWithMetadata>
                     aria-label="Contact point"
                     defaultValue={selectedContactPointSelectableValue}
                     onChange={(value: SelectableValue<ContactPointWithMetadata>, _: ActionMeta) => {

--- a/public/app/features/alerting/unified/components/rule-editor/alert-rule-form/simplifiedRouting/contactPoint/ContactPointSelector.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/alert-rule-form/simplifiedRouting/contactPoint/ContactPointSelector.tsx
@@ -9,9 +9,9 @@ import {
   FieldValidationMessage,
   IconButton,
   InputControl,
+  Select,
   Stack,
   TextLink,
-  VirtualizedSelect,
   useStyles2,
 } from '@grafana/ui';
 import { RuleFormValues } from 'app/features/alerting/unified/types/rule-form';
@@ -29,6 +29,8 @@ export interface ContactPointSelectorProps {
   onSelectContactPoint: (contactPoint?: ContactPointWithMetadata) => void;
   refetchReceivers: () => Promise<unknown>;
 }
+
+const MAX_CONTACT_POINTS_RENDERED = 500;
 
 export function ContactPointSelector({
   alertManager,
@@ -81,7 +83,8 @@ export function ContactPointSelector({
             render={({ field: { onChange, ref, ...field }, fieldState: { error } }) => (
               <>
                 <div className={styles.contactPointsSelector}>
-                  <VirtualizedSelect<ContactPointWithMetadata>
+                  <Select<ContactPointWithMetadata>
+                    virtualized={options.length > MAX_CONTACT_POINTS_RENDERED}
                     aria-label="Contact point"
                     defaultValue={selectedContactPointSelectableValue}
                     onChange={(value: SelectableValue<ContactPointWithMetadata>, _: ActionMeta) => {


### PR DESCRIPTION
**What is this feature?**

This PR improves the performance when having a long list of contact points in the alert rule form ( using simplified routing).
The PR conditionally uses virtualized window when we have more than 500 contact points. Virtualized select does not support descriptions for options, so we prefer keeping this descriptions for users that use few number of contact points.

For testing it, I provisioned 5k contact points. (see attached video)

**Why do we need this feature?**

We need a UI that behaves smoothly when using a long list of contact points.

**Who is this feature for?**

All users.

**Special notes for your reviewer:**


https://github.com/grafana/grafana/assets/33540275/56a3b19c-938a-4067-89f3-9270a80071b9


Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
