### PR TITLE
Dashboard Scenes: Fix issue where the trying to open the menu on a library panel would cause an error and not open the menu.

### DIFF
--- a/public/app/features/dashboard-scene/scene/PanelMenuBehavior.tsx
+++ b/public/app/features/dashboard-scene/scene/PanelMenuBehavior.tsx
@@ -56,7 +56,8 @@ export function panelMenuBehavior(menu: VizPanelMenu) {
     const panelId = getPanelIdForVizPanel(panel);
     const dashboard = getDashboardSceneFor(panel);
     const { isEmbedded } = dashboard.state.meta;
-    const panelJson = gridItemToPanel(panel.parent as SceneGridItem);
+    const gridItem = panel.parent instanceof LibraryVizPanel ? panel.parent.parent : panel.parent;
+    const panelJson = gridItemToPanel(gridItem as SceneGridItem);
     const panelModel = new PanelModel(panelJson);
     const dashboardJson = transformSceneToSaveModel(dashboard);
     const dashboardModel = new DashboardModel(dashboardJson);

--- a/public/app/features/dashboard-scene/scene/PanelMenuBehavior.tsx
+++ b/public/app/features/dashboard-scene/scene/PanelMenuBehavior.tsx
@@ -56,8 +56,7 @@ export function panelMenuBehavior(menu: VizPanelMenu) {
     const panelId = getPanelIdForVizPanel(panel);
     const dashboard = getDashboardSceneFor(panel);
     const { isEmbedded } = dashboard.state.meta;
-    const gridItem = panel.parent instanceof LibraryVizPanel ? panel.parent.parent : panel.parent;
-    const panelJson = gridItemToPanel(gridItem as SceneGridItem);
+    const panelJson = gridItemToPanel(sceneGraph.getAncestor(panel, SceneGridItem));
     const panelModel = new PanelModel(panelJson);
     const dashboardJson = transformSceneToSaveModel(dashboard);
     const dashboardModel = new DashboardModel(dashboardJson);


### PR DESCRIPTION
**What is this feature?**

Fixes an issue where trying to open the menu of a library panel causes an error and does not open the library panel. Because the library panel wraps the panel, when accessing the panel.parent we're getting the library panel instead of the grid item.

**Which issue(s) does this PR fix?**:

Fixes #82348