### PR TITLE
Tempo: Reset tag value when key changed in Search tab

### DIFF
--- a/public/app/plugins/datasource/tempo/SearchTraceQLEditor/SearchField.test.tsx
+++ b/public/app/plugins/datasource/tempo/SearchTraceQLEditor/SearchField.test.tsx
@@ -125,19 +125,19 @@ describe('SearchField', () => {
       jest.advanceTimersByTime(1000);
       const tag22 = await screen.findByText('tag22');
       await user.click(tag22);
-      expect(updateFilter).toHaveBeenCalledWith({ ...filter, tag: 'tag22' });
+      expect(updateFilter).toHaveBeenCalledWith({ ...filter, tag: 'tag22', value: [] });
 
       // Select tag1 as the tag
       await user.click(select);
       jest.advanceTimersByTime(1000);
       const tag1 = await screen.findByText('tag1');
       await user.click(tag1);
-      expect(updateFilter).toHaveBeenCalledWith({ ...filter, tag: 'tag1' });
+      expect(updateFilter).toHaveBeenCalledWith({ ...filter, tag: 'tag1', value: [] });
 
       // Remove the tag
       const tagRemove = await screen.findByLabelText('select-clear-value');
       await user.click(tagRemove);
-      expect(updateFilter).toHaveBeenCalledWith({ ...filter, value: undefined });
+      expect(updateFilter).toHaveBeenCalledWith({ ...filter, value: [] });
     }
   });
 

--- a/public/app/plugins/datasource/tempo/SearchTraceQLEditor/SearchField.tsx
+++ b/public/app/plugins/datasource/tempo/SearchTraceQLEditor/SearchField.tsx
@@ -159,7 +159,7 @@ const SearchField = ({
           )}
           value={filter.tag}
           onChange={(v) => {
-            updateFilter({ ...filter, tag: v?.value });
+            updateFilter({ ...filter, tag: v?.value, value: [] });
           }}
           placeholder="Select tag"
           isClearable


### PR DESCRIPTION
**What is this feature?**

Resets tag value when key changed in Search tab.

**Why do we need this feature?**

Changing the key means a new set of values, so we do not want to retain the old value as it is invalid.

**Who is this feature for?**

Tempo users.