### PR TITLE
DasbhoardScene: Fixes panel menu new alert rule action

### DIFF
--- a/.betterer.results
+++ b/.betterer.results
@@ -2588,10 +2588,9 @@ exports[`better eslint`] = {
       [0, 0, 0, "Unexpected any. Specify a different type.", "0"]
     ],
     "public/app/features/dashboard-scene/scene/PanelMenuBehavior.tsx:5381": [
-      [0, 0, 0, "Do not use any type assertions.", "0"],
+      [0, 0, 0, "Unexpected any. Specify a different type.", "0"],
       [0, 0, 0, "Unexpected any. Specify a different type.", "1"],
-      [0, 0, 0, "Unexpected any. Specify a different type.", "2"],
-      [0, 0, 0, "Do not use any type assertions.", "3"]
+      [0, 0, 0, "Do not use any type assertions.", "2"]
     ],
     "public/app/features/dashboard-scene/scene/setDashboardPanelContext.test.ts:5381": [
       [0, 0, 0, "Unexpected any. Specify a different type.", "0"]

--- a/public/app/features/dashboard-scene/scene/PanelMenuBehavior.tsx
+++ b/public/app/features/dashboard-scene/scene/PanelMenuBehavior.tsx
@@ -130,7 +130,7 @@ export function panelMenuBehavior(menu: VizPanelMenu) {
 
     moreSubMenu.push({
       text: t('panel.header-menu.new-alert-rule', `New alert rule`),
-      onClick: (e) => onCreateAlert(panel, dashboard),
+      onClick: (e) => onCreateAlert(panel),
     });
 
     if (hasLegendOptions(panel.state.options)) {
@@ -423,7 +423,7 @@ export function removePanel(dashboard: DashboardScene, panel: VizPanel, ask: boo
   }
 }
 
-const onCreateAlert = async (panel: VizPanel, dashboard: DashboardScene) => {
+const onCreateAlert = async (panel: VizPanel) => {
   DashboardInteractions.panelMenuItemClicked('create-alert');
 
   const formValues = await scenesPanelToRuleFormValues(panel);

--- a/public/app/features/dashboard-scene/scene/PanelMenuBehavior.tsx
+++ b/public/app/features/dashboard-scene/scene/PanelMenuBehavior.tsx
@@ -11,7 +11,6 @@ import { config, getPluginLinkExtensions, locationService } from '@grafana/runti
 import {
   LocalValueVariable,
   SceneFlexLayout,
-  SceneGridItem,
   SceneGridLayout,
   SceneGridRow,
   SceneObject,
@@ -22,16 +21,14 @@ import {
 import { DataQuery, OptionsWithLegend } from '@grafana/schema';
 import appEvents from 'app/core/app_events';
 import { t } from 'app/core/internationalization';
-import { panelToRuleFormValues } from 'app/features/alerting/unified/utils/rule-form';
+import { scenesPanelToRuleFormValues } from 'app/features/alerting/unified/utils/rule-form';
 import { shareDashboardType } from 'app/features/dashboard/components/ShareModal/utils';
-import { DashboardModel, PanelModel } from 'app/features/dashboard/state';
 import { InspectTab } from 'app/features/inspector/types';
 import { getScenePanelLinksSupplier } from 'app/features/panel/panellinks/linkSuppliers';
 import { createExtensionSubMenu } from 'app/features/plugins/extensions/utils';
 import { addDataTrailPanelAction } from 'app/features/trails/dashboardIntegration';
 import { ShowConfirmModalEvent } from 'app/types/events';
 
-import { gridItemToPanel, transformSceneToSaveModel } from '../serialization/transformSceneToSaveModel';
 import { ShareModal } from '../sharing/ShareModal';
 import { DashboardInteractions } from '../utils/interactions';
 import { getEditPanelUrl, getInspectUrl, getViewPanelUrl, tryGetExploreUrlForPanel } from '../utils/urlBuilders';
@@ -56,11 +53,6 @@ export function panelMenuBehavior(menu: VizPanelMenu) {
     const panelId = getPanelIdForVizPanel(panel);
     const dashboard = getDashboardSceneFor(panel);
     const { isEmbedded } = dashboard.state.meta;
-    const panelJson = gridItemToPanel(panel.parent as SceneGridItem);
-    const panelModel = new PanelModel(panelJson);
-    const dashboardJson = transformSceneToSaveModel(dashboard);
-    const dashboardModel = new DashboardModel(dashboardJson);
-
     const exploreMenuItem = await getExploreMenuItem(panel);
 
     // For embedded dashboards we only have explore action for now
@@ -138,7 +130,7 @@ export function panelMenuBehavior(menu: VizPanelMenu) {
 
     moreSubMenu.push({
       text: t('panel.header-menu.new-alert-rule', `New alert rule`),
-      onClick: (e) => onCreateAlert(e, panelModel, dashboardModel),
+      onClick: (e) => onCreateAlert(panel, dashboard),
     });
 
     if (hasLegendOptions(panel.state.options)) {
@@ -431,21 +423,18 @@ export function removePanel(dashboard: DashboardScene, panel: VizPanel, ask: boo
   }
 }
 
-const onCreateAlert = (event: React.MouseEvent, panel: PanelModel, dashboard: DashboardModel) => {
-  event.preventDefault();
-  createAlert(panel, dashboard);
+const onCreateAlert = async (panel: VizPanel, dashboard: DashboardScene) => {
   DashboardInteractions.panelMenuItemClicked('create-alert');
-};
 
-const createAlert = async (panel: PanelModel, dashboard: DashboardModel) => {
-  const formValues = await panelToRuleFormValues(panel, dashboard);
-
+  const formValues = await scenesPanelToRuleFormValues(panel);
   const ruleFormUrl = urlUtil.renderUrl('/alerting/new', {
     defaults: JSON.stringify(formValues),
     returnTo: location.pathname + location.search,
   });
 
   locationService.push(ruleFormUrl);
+
+  DashboardInteractions.panelMenuItemClicked('create-alert');
 };
 
 export function toggleVizPanelLegend(vizPanel: VizPanel): void {


### PR DESCRIPTION
I noticed the panel menu not working, crashed in transformSceneToSaveModel (think that is fixed in other PR). but then started looking at why we are calling it and newing up old DashboardModel and old PanelModel in the menu (this is what the compatibility wrappers are for). 

But then I found that it was used in the new alert rule action, and passed to a function that interpolates queries (and expert panel.scopedVars to have scoped vars, etc) so that function will not work in scenes if you pass it a persisted model. 

For the new alert rule button in panel edit we have already implemented a scenes version of  `panelToRuleFormValues`  . 