### PR TITLE
mssql: socks proxy: use plugin-sdk

### DIFF
--- a/pkg/tsdb/mssql/mssql.go
+++ b/pkg/tsdb/mssql/mssql.go
@@ -16,7 +16,6 @@ import (
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
 	"github.com/grafana/grafana-plugin-sdk-go/backend/datasource"
 	"github.com/grafana/grafana-plugin-sdk-go/backend/instancemgmt"
-	sdkproxy "github.com/grafana/grafana-plugin-sdk-go/backend/proxy"
 	"github.com/grafana/grafana-plugin-sdk-go/data"
 	"github.com/grafana/grafana-plugin-sdk-go/data/sqlutil"
 	mssql "github.com/microsoft/go-mssqldb"
@@ -26,7 +25,6 @@ import (
 	"github.com/grafana/grafana/pkg/setting"
 	"github.com/grafana/grafana/pkg/tsdb/mssql/utils"
 	"github.com/grafana/grafana/pkg/tsdb/sqleng"
-	"github.com/grafana/grafana/pkg/tsdb/sqleng/proxyutil"
 	"github.com/grafana/grafana/pkg/util"
 )
 
@@ -67,7 +65,7 @@ func (s *Service) QueryData(ctx context.Context, req *backend.QueryDataRequest) 
 }
 
 func newInstanceSettings(cfg *setting.Cfg, logger log.Logger) datasource.InstanceFactoryFunc {
-	return func(_ context.Context, settings backend.DataSourceInstanceSettings) (instancemgmt.Instance, error) {
+	return func(ctx context.Context, settings backend.DataSourceInstanceSettings) (instancemgmt.Instance, error) {
 		jsonData := sqleng.JsonData{
 			MaxOpenConns:      cfg.SqlDatasourceMaxOpenConnsDefault,
 			MaxIdleConns:      cfg.SqlDatasourceMaxIdleConnsDefault,
@@ -113,14 +111,22 @@ func newInstanceSettings(cfg *setting.Cfg, logger log.Logger) datasource.Instanc
 			driverName = "azuresql"
 		}
 
+		proxyClient, err := settings.ProxyClient(ctx)
+		if err != nil {
+			return nil, err
+		}
+
 		// register a new proxy driver if the secure socks proxy is enabled
-		proxyOpts := proxyutil.GetSQLProxyOptions(cfg.SecureSocksDSProxy, dsInfo, settings.Name, settings.Type)
-		if sdkproxy.New(proxyOpts).SecureSocksProxyEnabled() {
+		if proxyClient.SecureSocksProxyEnabled() {
+			dialer, err := proxyClient.NewSecureSocksProxyContextDialer()
+			if err != nil {
+				return nil, err
+			}
 			URL, err := ParseURL(dsInfo.URL, logger)
 			if err != nil {
 				return nil, err
 			}
-			driverName, err = createMSSQLProxyDriver(cnnstr, URL.Hostname(), proxyOpts)
+			driverName, err = createMSSQLProxyDriver(cnnstr, URL.Hostname(), dialer)
 			if err != nil {
 				return nil, err
 			}

--- a/pkg/tsdb/mssql/proxy.go
+++ b/pkg/tsdb/mssql/proxy.go
@@ -10,14 +10,13 @@ import (
 	"net"
 	"slices"
 
-	sdkproxy "github.com/grafana/grafana-plugin-sdk-go/backend/proxy"
 	mssql "github.com/microsoft/go-mssqldb"
 	"golang.org/x/net/proxy"
 )
 
 // createMSSQLProxyDriver creates and registers a new sql driver that uses a mssql connector and updates the dialer to
 // route connections through the secure socks proxy
-func createMSSQLProxyDriver(cnnstr string, hostName string, opts *sdkproxy.Options) (string, error) {
+func createMSSQLProxyDriver(cnnstr string, hostName string, dialer proxy.Dialer) (string, error) {
 	// create a unique driver per connection string
 	hash := fmt.Sprintf("%x", md5.Sum([]byte(cnnstr)))
 	driverName := "mssql-proxy-" + hash
@@ -29,7 +28,7 @@ func createMSSQLProxyDriver(cnnstr string, hostName string, opts *sdkproxy.Optio
 			return "", err
 		}
 
-		driver, err := newMSSQLProxyDriver(connector, hostName, opts)
+		driver, err := newMSSQLProxyDriver(connector, hostName, dialer)
 		if err != nil {
 			return "", err
 		}
@@ -62,12 +61,7 @@ var _ driver.DriverContext = (*mssqlProxyDriver)(nil)
 
 // newMSSQLProxyDriver updates the dialer for a mssql connector with a dialer that proxys connections through the secure socks proxy
 // and returns a new mssql driver to register
-func newMSSQLProxyDriver(connector *mssql.Connector, hostName string, opts *sdkproxy.Options) (*mssqlProxyDriver, error) {
-	dialer, err := sdkproxy.New(opts).NewSecureSocksProxyContextDialer()
-	if err != nil {
-		return nil, err
-	}
-
+func newMSSQLProxyDriver(connector *mssql.Connector, hostName string, dialer proxy.Dialer) (*mssqlProxyDriver, error) {
 	contextDialer, ok := dialer.(proxy.ContextDialer)
 	if !ok {
 		return nil, errors.New("unable to cast socks proxy dialer to context proxy dialer")


### PR DESCRIPTION
the `grafana-plugin-sdk-go` module contains a helper function to get the socks proxy configuration, so we switch to that. this also allows us to remove one use of a grafana-core config ( `cfg.SecureSocksDSProxy` )

(part of https://github.com/grafana/grafana/issues/77722)

how to test locally:
- (we will use the `microsocks` socks proxy, if you don't have it, on a mac you  can install it with `brew install microsocks`)
- add this to your grafana-config:
```
[secure_socks_datasource_proxy]
enabled = true
proxy_address = localhost:5555
allow_insecure = true
```
- run grafana
- run `microsocks -i 127.0.0.1 -p 5555` in a terminal
- run grafana, create a mssql data source and in it's config-page enable the `Secure Socks Proxy` setting at the bottom, press [save & test]. 
- verify in the terminal with `microsocks` that it wrote a new line containing `connected to`
- verify that the datasource plugin works (run a sample sql query, like `select 42`)
