### PR TITLE
mysql: socks proxy: use plugin-sdk

### DIFF
--- a/pkg/tsdb/mysql/mysql.go
+++ b/pkg/tsdb/mysql/mysql.go
@@ -18,7 +18,6 @@ import (
 	"github.com/grafana/grafana-plugin-sdk-go/backend/datasource"
 	sdkhttpclient "github.com/grafana/grafana-plugin-sdk-go/backend/httpclient"
 	"github.com/grafana/grafana-plugin-sdk-go/backend/instancemgmt"
-	sdkproxy "github.com/grafana/grafana-plugin-sdk-go/backend/proxy"
 	"github.com/grafana/grafana-plugin-sdk-go/data"
 	"github.com/grafana/grafana-plugin-sdk-go/data/sqlutil"
 
@@ -26,7 +25,6 @@ import (
 	"github.com/grafana/grafana/pkg/infra/httpclient"
 	"github.com/grafana/grafana/pkg/setting"
 	"github.com/grafana/grafana/pkg/tsdb/sqleng"
-	"github.com/grafana/grafana/pkg/tsdb/sqleng/proxyutil"
 )
 
 const (
@@ -89,12 +87,20 @@ func newInstanceSettings(cfg *setting.Cfg, logger log.Logger) datasource.Instanc
 			protocol = "unix"
 		}
 
+		proxyClient, err := settings.ProxyClient(ctx)
+		if err != nil {
+			return nil, err
+		}
+
 		// register the secure socks proxy dialer context, if enabled
-		proxyOpts := proxyutil.GetSQLProxyOptions(cfg.SecureSocksDSProxy, dsInfo, settings.Name, settings.Type)
-		if sdkproxy.New(proxyOpts).SecureSocksProxyEnabled() {
+		if proxyClient.SecureSocksProxyEnabled() {
+			dialer, err := proxyClient.NewSecureSocksProxyContextDialer()
+			if err != nil {
+				return nil, err
+			}
 			// UID is only unique per org, the only way to ensure uniqueness is to do it by connection information
 			uniqueIdentifier := dsInfo.User + dsInfo.DecryptedSecureJSONData["password"] + dsInfo.URL + dsInfo.Database
-			protocol, err = registerProxyDialerContext(protocol, uniqueIdentifier, proxyOpts)
+			protocol, err = registerProxyDialerContext(protocol, uniqueIdentifier, dialer)
 			if err != nil {
 				return nil, err
 			}

--- a/pkg/tsdb/mysql/proxy.go
+++ b/pkg/tsdb/mysql/proxy.go
@@ -7,15 +7,14 @@ import (
 	"net"
 
 	"github.com/go-sql-driver/mysql"
-	sdkproxy "github.com/grafana/grafana-plugin-sdk-go/backend/proxy"
 	"golang.org/x/net/proxy"
 )
 
 // registerProxyDialerContext registers a new dialer context to be used by mysql when the proxy network is
 // specified in the connection string
-func registerProxyDialerContext(protocol, cnnstr string, opts *sdkproxy.Options) (string, error) {
-	// the dialer contains the true network used behind the scenes
-	dialer, err := getProxyDialerContext(protocol, opts)
+func registerProxyDialerContext(protocol, cnnstr string, dialer proxy.Dialer) (string, error) {
+	// the mysqlDialer contains the true network used behind the scenes
+	mysqlDialer, err := getProxyDialerContext(protocol, dialer)
 	if err != nil {
 		return "", err
 	}
@@ -24,7 +23,7 @@ func registerProxyDialerContext(protocol, cnnstr string, opts *sdkproxy.Options)
 	// have a unique network per connection string
 	hash := fmt.Sprintf("%x", md5.Sum([]byte(cnnstr)))
 	network := "proxy-" + hash
-	mysql.RegisterDialContext(network, dialer.DialContext)
+	mysql.RegisterDialContext(network, mysqlDialer.DialContext)
 
 	return network, nil
 }
@@ -36,14 +35,10 @@ type mySQLContextDialer struct {
 }
 
 // getProxyDialerContext returns a context dialer that will send the request through to the secure socks proxy
-func getProxyDialerContext(actualNetwork string, opts *sdkproxy.Options) (*mySQLContextDialer, error) {
-	dialer, err := sdkproxy.New(opts).NewSecureSocksProxyContextDialer()
-	if err != nil {
-		return nil, err
-	}
+func getProxyDialerContext(actualNetwork string, dialer proxy.Dialer) (*mySQLContextDialer, error) {
 	contextDialer, ok := dialer.(proxy.ContextDialer)
 	if !ok {
-		return nil, err
+		return nil, fmt.Errorf("mysql proxy creation failed")
 	}
 	return &mySQLContextDialer{dialer: contextDialer, network: actualNetwork}, nil
 }

--- a/pkg/tsdb/mysql/proxy_test.go
+++ b/pkg/tsdb/mysql/proxy_test.go
@@ -3,29 +3,32 @@ package mysql
 import (
 	"context"
 	"fmt"
+	"net"
 	"testing"
 
 	"github.com/go-sql-driver/mysql"
-	"github.com/grafana/grafana/pkg/setting"
-	"github.com/grafana/grafana/pkg/tsdb/sqleng"
-	"github.com/grafana/grafana/pkg/tsdb/sqleng/proxyutil"
 	"github.com/stretchr/testify/require"
+	"golang.org/x/net/proxy"
 )
 
+type testDialer struct {
+}
+
+func (d *testDialer) Dial(network, addr string) (c net.Conn, err error) {
+	return nil, fmt.Errorf("test-dialer: Dial is not functional")
+}
+
+func (d *testDialer) DialContext(ctx context.Context, network, address string) (net.Conn, error) {
+	return nil, fmt.Errorf("test-dialer: DialContext is not functional")
+}
+
+var _ proxy.Dialer = (&testDialer{})
+var _ proxy.ContextDialer = (&testDialer{})
+
 func TestMySQLProxyDialer(t *testing.T) {
-	settings := proxyutil.SetupTestSecureSocksProxySettings(t)
-	proxySettings := setting.SecureSocksDSProxySettings{
-		Enabled:      true,
-		ClientCert:   settings.ClientCert,
-		ClientKey:    settings.ClientKey,
-		RootCA:       settings.RootCA,
-		ProxyAddress: settings.ProxyAddress,
-		ServerName:   settings.ServerName,
-	}
 	protocol := "tcp"
-	opts := proxyutil.GetSQLProxyOptions(proxySettings, sqleng.DataSourceInfo{UID: "1", JsonData: sqleng.JsonData{SecureDSProxy: true}}, "mysql", "mysql")
 	dbURL := "localhost:5432"
-	network, err := registerProxyDialerContext(protocol, dbURL, opts)
+	network, err := registerProxyDialerContext(protocol, dbURL, &testDialer{})
 	require.NoError(t, err)
 	driver := mysql.MySQLDriver{}
 	cnnstr := fmt.Sprintf("test:test@%s(%s)/db",
@@ -38,7 +41,7 @@ func TestMySQLProxyDialer(t *testing.T) {
 	})
 
 	t.Run("Multiple networks can be created", func(t *testing.T) {
-		network, err := registerProxyDialerContext(protocol, dbURL, opts)
+		network, err := registerProxyDialerContext(protocol, dbURL, &testDialer{})
 		require.NoError(t, err)
 		cnnstr2 := fmt.Sprintf("test:test@%s(%s)/db",
 			network,
@@ -56,6 +59,6 @@ func TestMySQLProxyDialer(t *testing.T) {
 		require.NoError(t, err)
 		_, err = conn.Connect(context.Background())
 		require.Error(t, err)
-		require.Contains(t, err.Error(), fmt.Sprintf("socks connect %s %s->%s", protocol, settings.ProxyAddress, dbURL))
+		require.Contains(t, err.Error(), "test-dialer: DialContext is not functional")
 	})
 }


### PR DESCRIPTION
the `grafana-plugin-sdk-go` module contains a helper function to get the socks proxy configuration, so we switch to that. this also allows us to remove one use of a grafana-core config ( `cfg.SecureSocksDSProxy` )

(part of https://github.com/grafana/grafana/issues/77722)

how to test locally:
- (we will use the `microsocks` socks proxy, if you don't have it, on a mac you  can install it with `brew install microsocks`)
- add this to your grafana-config:
```
[secure_socks_datasource_proxy]
enabled = true
proxy_address = localhost:5555
allow_insecure = true
```
- run grafana
- run `microsocks -i 127.0.0.1 -p 5555` in a terminal
- run grafana, create a mysql data source and in it's config-page enable the `Secure Socks Proxy` setting at the bottom, press [save & test]. 
- verify in the terminal with `microsocks` that it wrote a new line containing `connected to`
- verify that the datasource plugin works (run a sample sql query, like `select 42`)
