### PR TITLE
Panel Query Options: Support query caching options

### DIFF
--- a/public/app/features/dashboard-scene/panel-edit/PanelDataPane/PanelDataQueriesTab.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelDataPane/PanelDataQueriesTab.tsx
@@ -16,6 +16,7 @@ import { GrafanaQuery } from 'app/plugins/datasource/grafana/types';
 import { QueryGroupOptions } from 'app/types';
 
 import { PanelTimeRange } from '../../scene/PanelTimeRange';
+import { dashboardSceneGraph } from '../../utils/dashboardSceneGraph';
 import { VizPanelManager } from '../VizPanelManager';
 
 import { PanelDataPaneTabState, PanelDataPaneTab, TabId, PanelDataTabHeaderProps } from './types';
@@ -52,6 +53,7 @@ export class PanelDataQueriesTab extends SceneObjectBase<PanelDataQueriesTabStat
   buildQueryOptions(): QueryGroupOptions {
     const panelManager = this._panelManager;
     const panelObj = this._panelManager.state.panel;
+    const queryCachingOptions = dashboardSceneGraph.getPanelCacheOptionsBehavior(panelObj);
     const queryRunner = this._panelManager.queryRunner;
     const timeRangeObj = sceneGraph.getTimeRange(panelObj);
 
@@ -72,9 +74,6 @@ export class PanelDataQueriesTab extends SceneObjectBase<PanelDataQueriesTabStat
     let queries: QueryGroupOptions['queries'] = queryRunner.state.queries;
 
     return {
-      // TODO
-      // cacheTimeout: dsSettings?.meta.queryOptions?.cacheTimeout ? panel.cacheTimeout : undefined,
-      // queryCachingTTL: dsSettings?.cachingConfig?.enabled ? panel.queryCachingTTL : undefined,
       dataSource: {
         default: panelManager.state.dsSettings?.isDefault,
         type: panelManager.state.dsSettings?.type,
@@ -84,6 +83,12 @@ export class PanelDataQueriesTab extends SceneObjectBase<PanelDataQueriesTabStat
       maxDataPoints: queryRunner.state.maxDataPoints,
       minInterval: queryRunner.state.minInterval,
       timeRange: timeRangeOpts,
+      cacheTimeout: panelManager.state.dsSettings?.meta.queryOptions?.cacheTimeout
+        ? queryCachingOptions.state.cacheTimeout
+        : undefined,
+      queryCachingTTL: panelManager.state.dsSettings?.cachingConfig?.enabled
+        ? queryCachingOptions.state.queryCachingTTL
+        : undefined,
     };
   }
 

--- a/public/app/features/dashboard-scene/panel-edit/PanelDataPane/PanelDataQueriesTab.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelDataPane/PanelDataQueriesTab.tsx
@@ -84,10 +84,10 @@ export class PanelDataQueriesTab extends SceneObjectBase<PanelDataQueriesTabStat
       minInterval: queryRunner.state.minInterval,
       timeRange: timeRangeOpts,
       cacheTimeout: panelManager.state.dsSettings?.meta.queryOptions?.cacheTimeout
-        ? queryCachingOptions.state.cacheTimeout
+        ? queryCachingOptions?.state.cacheTimeout
         : undefined,
       queryCachingTTL: panelManager.state.dsSettings?.cachingConfig?.enabled
-        ? queryCachingOptions.state.queryCachingTTL
+        ? queryCachingOptions?.state.queryCachingTTL
         : undefined,
     };
   }

--- a/public/app/features/dashboard-scene/panel-edit/VizPanelManager.test.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/VizPanelManager.test.tsx
@@ -12,6 +12,7 @@ import { DASHBOARD_DATASOURCE_PLUGIN_ID } from 'app/plugins/datasource/dashboard
 import { PanelTimeRange, PanelTimeRangeState } from '../scene/PanelTimeRange';
 import { transformSaveModelToScene } from '../serialization/transformSaveModelToScene';
 import { DashboardModelCompatibilityWrapper } from '../utils/DashboardModelCompatibilityWrapper';
+import { dashboardSceneGraph } from '../utils/dashboardSceneGraph';
 import { findVizPanelByKey } from '../utils/utils';
 
 import { buildPanelEditScene } from './PanelEditor';
@@ -406,6 +407,30 @@ describe('VizPanelManager', () => {
           });
 
           expect(dataObj.state.minInterval).toBe('1s');
+        });
+      });
+
+      describe('query caching', () => {
+        it('updates cacheTimeout and queryCachingTTL', async () => {
+          const { vizPanelManager } = setupTest('panel-1');
+          vizPanelManager.activate();
+          await Promise.resolve();
+
+          const cacheOptionsBehavior = dashboardSceneGraph.getPanelCacheOptionsBehavior(vizPanelManager.state.panel);
+
+          vizPanelManager.changeQueryOptions({
+            cacheTimeout: '60',
+            queryCachingTTL: 200000,
+            dataSource: {
+              name: 'grafana-testdata',
+              type: 'grafana-testdata-datasource',
+              default: true,
+            },
+            queries: [],
+          });
+
+          expect(cacheOptionsBehavior!.state.cacheTimeout).toBe('60');
+          expect(cacheOptionsBehavior!.state.queryCachingTTL).toBe(200000);
         });
       });
     });

--- a/public/app/features/dashboard-scene/panel-edit/VizPanelManager.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/VizPanelManager.tsx
@@ -234,15 +234,15 @@ export class VizPanelManager extends SceneObjectBase<VizPanelManagerState> {
       panelObj.setState({ $timeRange: new PanelTimeRange(timeRangeObjStateUpdate) });
     }
 
-    if (options.cacheTimeout !== cacheOptionsBehavior.state.cacheTimeout) {
+    if (options.cacheTimeout !== cacheOptionsBehavior?.state.cacheTimeout) {
       cacheOptionsObjStateUpdate.cacheTimeout = options.cacheTimeout;
     }
 
-    if (options.queryCachingTTL !== cacheOptionsBehavior.state.queryCachingTTL) {
+    if (options.queryCachingTTL !== cacheOptionsBehavior?.state.queryCachingTTL) {
       cacheOptionsObjStateUpdate.queryCachingTTL = options.queryCachingTTL;
     }
 
-    cacheOptionsBehavior.setState(cacheOptionsObjStateUpdate);
+    cacheOptionsBehavior?.setState(cacheOptionsObjStateUpdate);
     dataObj.setState(dataObjStateUpdate);
     dataObj.runQueries();
   }

--- a/public/app/features/dashboard-scene/scene/DashboardScene.test.tsx
+++ b/public/app/features/dashboard-scene/scene/DashboardScene.test.tsx
@@ -27,6 +27,7 @@ import { djb2Hash } from '../utils/djb2Hash';
 import { DashboardControls } from './DashboardControls';
 import { DashboardLinksControls } from './DashboardLinksControls';
 import { DashboardScene, DashboardSceneState } from './DashboardScene';
+import { PanelQueryCachingOptionsBehavior } from './PanelQueryCachingOptionsBehavior';
 
 jest.mock('../settings/version-history/HistorySrv');
 jest.mock('../serialization/transformSaveModelToScene');
@@ -135,6 +136,18 @@ describe('DashboardScene', () => {
         dashboardUID: 'dash-1',
         panelId: 1,
         panelPluginType: 'table',
+      });
+    });
+
+    it('Should add query caching options', () => {
+      const queryRunner = sceneGraph.findObject(scene, (o) => o.state.key === 'data-query-runner-with-caching')!;
+      expect(scene.enrichDataRequest(queryRunner)).toEqual({
+        app: CoreApp.Dashboard,
+        dashboardUID: 'dash-1',
+        panelId: 3,
+        panelPluginType: 'table',
+        cacheTimeout: '60',
+        queryCachingTTL: 200000,
       });
     });
 
@@ -313,6 +326,20 @@ function buildTestScene(overrides?: Partial<DashboardSceneState>) {
             key: 'panel-2-clone-1',
             pluginId: 'table',
             $data: new SceneQueryRunner({ key: 'data-query-runner2', queries: [{ refId: 'A' }] }),
+          }),
+        }),
+        new SceneGridItem({
+          body: new VizPanel({
+            title: 'Panel with caching options',
+            key: 'panel-3',
+            pluginId: 'table',
+            $behaviors: [
+              new PanelQueryCachingOptionsBehavior({
+                cacheTimeout: '60',
+                queryCachingTTL: 200000,
+              }),
+            ],
+            $data: new SceneQueryRunner({ key: 'data-query-runner-with-caching', queries: [{ refId: 'A' }] }),
           }),
         }),
       ],

--- a/public/app/features/dashboard-scene/scene/DashboardScene.tsx
+++ b/public/app/features/dashboard-scene/scene/DashboardScene.tsx
@@ -550,7 +550,7 @@ export class DashboardScene extends SceneObjectBase<DashboardSceneState> {
   };
 
   /**
-   * Called by the SceneQueryRunner to privide contextural parameters (tracking) props for the request
+   * Called by the SceneQueryRunner to privide contextual parameters props for the request
    */
   public enrichDataRequest(sceneObject: SceneObject): Partial<DataQueryRequest> {
     const panel = getClosestVizPanel(sceneObject);
@@ -565,8 +565,8 @@ export class DashboardScene extends SceneObjectBase<DashboardSceneState> {
       }
 
       const cachingOptionsBehavior = dashboardSceneGraph.getPanelCacheOptionsBehavior(panel);
-      cachingOptions.cacheTimeout = cachingOptionsBehavior.state.cacheTimeout;
-      cachingOptions.queryCachingTTL = cachingOptionsBehavior.state.queryCachingTTL;
+      cachingOptions.cacheTimeout = cachingOptionsBehavior?.state.cacheTimeout;
+      cachingOptions.queryCachingTTL = cachingOptionsBehavior?.state.queryCachingTTL;
     }
 
     return {

--- a/public/app/features/dashboard-scene/scene/DashboardScene.tsx
+++ b/public/app/features/dashboard-scene/scene/DashboardScene.tsx
@@ -46,6 +46,7 @@ import { DecoratedRevisionModel } from '../settings/VersionsEditView';
 import { DashboardEditView } from '../settings/utils';
 import { historySrv } from '../settings/version-history';
 import { DashboardModelCompatibilityWrapper } from '../utils/DashboardModelCompatibilityWrapper';
+import { dashboardSceneGraph } from '../utils/dashboardSceneGraph';
 import { djb2Hash } from '../utils/djb2Hash';
 import { getDashboardUrl } from '../utils/urlBuilders';
 import { forceRenderChildren, getClosestVizPanel, getPanelIdForVizPanel, isPanelClone } from '../utils/utils';
@@ -554,6 +555,7 @@ export class DashboardScene extends SceneObjectBase<DashboardSceneState> {
   public enrichDataRequest(sceneObject: SceneObject): Partial<DataQueryRequest> {
     const panel = getClosestVizPanel(sceneObject);
     let panelId = 0;
+    const cachingOptions: Pick<DataQueryRequest, 'cacheTimeout' | 'queryCachingTTL'> = {};
 
     if (panel && panel.state.key) {
       if (isPanelClone(panel.state.key)) {
@@ -561,6 +563,10 @@ export class DashboardScene extends SceneObjectBase<DashboardSceneState> {
       } else {
         panelId = getPanelIdForVizPanel(panel);
       }
+
+      const cachingOptionsBehavior = dashboardSceneGraph.getPanelCacheOptionsBehavior(panel);
+      cachingOptions.cacheTimeout = cachingOptionsBehavior.state.cacheTimeout;
+      cachingOptions.queryCachingTTL = cachingOptionsBehavior.state.queryCachingTTL;
     }
 
     return {
@@ -568,6 +574,7 @@ export class DashboardScene extends SceneObjectBase<DashboardSceneState> {
       dashboardUID: this.state.uid,
       panelId,
       panelPluginType: panel?.state.pluginId,
+      ...cachingOptions,
     };
   }
 

--- a/public/app/features/dashboard-scene/scene/LibraryVizPanel.tsx
+++ b/public/app/features/dashboard-scene/scene/LibraryVizPanel.tsx
@@ -7,6 +7,7 @@ import { getLibraryPanel } from 'app/features/library-panels/state/api';
 import { createPanelDataProvider } from '../utils/createPanelDataProvider';
 
 import { panelMenuBehavior } from './PanelMenuBehavior';
+import { PanelQueryCachingOptionsBehavior } from './PanelQueryCachingOptionsBehavior';
 
 interface LibraryVizPanelState extends SceneObjectState {
   // Library panels use title from dashboard JSON's panel model, not from library panel definition, hence we pass it.
@@ -45,6 +46,7 @@ export class LibraryVizPanel extends SceneObjectBase<LibraryVizPanelState> {
     try {
       const libPanel = await getLibraryPanel(this.state.uid, true);
       const libPanelModel = new PanelModel(libPanel.model);
+
       vizPanel.setState({
         options: libPanelModel.options ?? {},
         fieldConfig: libPanelModel.fieldConfig,
@@ -52,6 +54,12 @@ export class LibraryVizPanel extends SceneObjectBase<LibraryVizPanelState> {
         displayMode: libPanelModel.transparent ? 'transparent' : undefined,
         description: libPanelModel.description,
         $data: createPanelDataProvider(libPanelModel),
+        $behaviors: [
+          new PanelQueryCachingOptionsBehavior({
+            cacheTimeout: libPanelModel.cacheTimeout,
+            queryCachingTTL: libPanelModel.queryCachingTTL,
+          }),
+        ],
       });
     } catch (err) {
       vizPanel.setState({

--- a/public/app/features/dashboard-scene/scene/PanelQueryCachingOptionsBehavior.ts
+++ b/public/app/features/dashboard-scene/scene/PanelQueryCachingOptionsBehavior.ts
@@ -1,0 +1,9 @@
+import { SceneObjectState, SceneObjectBase } from '@grafana/scenes';
+import { QueryGroupOptions } from 'app/types';
+
+export interface PanelQueryCachingOptionsBehaviorState extends SceneObjectState {
+  cacheTimeout: QueryGroupOptions['cacheTimeout'];
+  queryCachingTTL: QueryGroupOptions['queryCachingTTL'];
+}
+
+export class PanelQueryCachingOptionsBehavior extends SceneObjectBase<PanelQueryCachingOptionsBehaviorState> {}

--- a/public/app/features/dashboard-scene/serialization/transformSaveModelToScene.ts
+++ b/public/app/features/dashboard-scene/serialization/transformSaveModelToScene.ts
@@ -42,6 +42,7 @@ import { LibraryVizPanel } from '../scene/LibraryVizPanel';
 import { VizPanelLinks, VizPanelLinksMenu } from '../scene/PanelLinks';
 import { panelLinksBehavior, panelMenuBehavior } from '../scene/PanelMenuBehavior';
 import { PanelNotices } from '../scene/PanelNotices';
+import { PanelQueryCachingOptionsBehavior } from '../scene/PanelQueryCachingOptionsBehavior';
 import { PanelRepeaterGridItem } from '../scene/PanelRepeaterGridItem';
 import { PanelTimeRange } from '../scene/PanelTimeRange';
 import { RowRepeaterBehavior } from '../scene/RowRepeaterBehavior';
@@ -434,6 +435,12 @@ export function buildGridItemForPanel(panel: PanelModel): SceneGridItemLike {
     // To be replaced with it's own option persited option instead derived
     hoverHeader: !panel.title && !panel.timeFrom && !panel.timeShift,
     $data: createPanelDataProvider(panel),
+    $behaviors: [
+      new PanelQueryCachingOptionsBehavior({
+        cacheTimeout: panel.cacheTimeout,
+        queryCachingTTL: panel.queryCachingTTL,
+      }),
+    ],
     menu: new VizPanelMenu({
       $behaviors: [panelMenuBehavior],
     }),

--- a/public/app/features/dashboard-scene/serialization/transformSceneToSaveModel.ts
+++ b/public/app/features/dashboard-scene/serialization/transformSceneToSaveModel.ts
@@ -296,11 +296,11 @@ function vizPanelDataToPanel(
     ];
   }
 
-  if (cachingOptions.state.cacheTimeout) {
+  if (cachingOptions?.state.cacheTimeout) {
     // @ts-expect-error Graphite-specific option, not sure we should add it to schema
     panel.cacheTimeout = cachingOptions.state.cacheTimeout;
   }
-  if (cachingOptions.state.queryCachingTTL) {
+  if (cachingOptions?.state.queryCachingTTL) {
     // @ts-expect-error enterprise/cloud option, not sure we should add it to schema
     panel.queryCachingTTL = cachingOptions.state.queryCachingTTL;
   }

--- a/public/app/features/dashboard-scene/serialization/transformSceneToSaveModel.ts
+++ b/public/app/features/dashboard-scene/serialization/transformSceneToSaveModel.ts
@@ -265,6 +265,7 @@ function vizPanelDataToPanel(
 
   const panel: Pick<Panel, 'datasource' | 'targets' | 'maxDataPoints' | 'transformations'> = {};
   const queryRunner = getQueryRunnerFor(vizPanel);
+  const cachingOptions = dashboardSceneGraph.getPanelCacheOptionsBehavior(vizPanel);
 
   if (queryRunner) {
     panel.targets = queryRunner.state.queries;
@@ -293,6 +294,15 @@ function vizPanelDataToPanel(
         snapshot: data,
       },
     ];
+  }
+
+  if (cachingOptions.state.cacheTimeout) {
+    // @ts-expect-error Graphite-specific option, not sure we should add it to schema
+    panel.cacheTimeout = cachingOptions.state.cacheTimeout;
+  }
+  if (cachingOptions.state.queryCachingTTL) {
+    // @ts-expect-error enterprise/cloud option, not sure we should add it to schema
+    panel.queryCachingTTL = cachingOptions.state.queryCachingTTL;
   }
 
   return panel;

--- a/public/app/features/dashboard-scene/utils/dashboardSceneGraph.ts
+++ b/public/app/features/dashboard-scene/utils/dashboardSceneGraph.ts
@@ -63,8 +63,7 @@ function getPanelCacheOptionsBehavior(panel: VizPanel) {
   if (behavior instanceof PanelQueryCachingOptionsBehavior) {
     return behavior;
   }
-
-  throw new Error('PanelQueryCachingOptionsBehavior not found');
+  return null;
 }
 
 function getVizPanels(scene: DashboardScene): VizPanel[] {

--- a/public/app/features/dashboard-scene/utils/dashboardSceneGraph.ts
+++ b/public/app/features/dashboard-scene/utils/dashboardSceneGraph.ts
@@ -11,6 +11,7 @@ import {
 import { DashboardControls } from '../scene/DashboardControls';
 import { DashboardScene } from '../scene/DashboardScene';
 import { VizPanelLinks } from '../scene/PanelLinks';
+import { PanelQueryCachingOptionsBehavior } from '../scene/PanelQueryCachingOptionsBehavior';
 
 function getTimePicker(scene: DashboardScene) {
   const dashboardControls = getDashboardControls(scene);
@@ -57,6 +58,15 @@ function getPanelLinks(panel: VizPanel) {
   throw new Error('VizPanelLinks links not found');
 }
 
+function getPanelCacheOptionsBehavior(panel: VizPanel) {
+  const behavior = panel.state.$behaviors?.find((b) => b instanceof PanelQueryCachingOptionsBehavior);
+  if (behavior instanceof PanelQueryCachingOptionsBehavior) {
+    return behavior;
+  }
+
+  throw new Error('PanelQueryCachingOptionsBehavior not found');
+}
+
 function getVizPanels(scene: DashboardScene): VizPanel[] {
   const panels: VizPanel[] = [];
 
@@ -94,6 +104,7 @@ export const dashboardSceneGraph = {
   getRefreshPicker,
   getDashboardControls,
   getPanelLinks,
+  getPanelCacheOptionsBehavior,
   getVizPanels,
   getDataLayers,
 };


### PR DESCRIPTION
Closes https://github.com/grafana/grafana/issues/82311

Approached it using behavior attachable to `VizPanel` to avoid additional wrappers around the panels. Think this turned out pretty simple.
