### PR TITLE
Logs panel: Table UI - remove beta badge

### DIFF
--- a/public/app/features/explore/Logs/Logs.tsx
+++ b/public/app/features/explore/Logs/Logs.tsx
@@ -654,21 +654,13 @@ class UnthemedLogs extends PureComponent<Props, State> {
         </PanelChrome>
         <PanelChrome
           titleItems={[
-            config.featureToggles.logsExploreTableVisualisation
-              ? this.state.visualisationType === 'logs'
-                ? null
-                : [
-                    <PanelChrome.TitleItem title="Experimental" key="A">
-                      <FeatureBadge
-                        featureState={FeatureState.beta}
-                        tooltip="Table view is experimental and may change in future versions"
-                      />
-                    </PanelChrome.TitleItem>,
-                    <PanelChrome.TitleItem title="Feedback" key="B">
-                      <LogsFeedback feedbackUrl="https://forms.gle/5YyKdRQJ5hzq4c289" />
-                    </PanelChrome.TitleItem>,
-                  ]
-              : null,
+            config.featureToggles.logsExploreTableVisualisation ? (
+              this.state.visualisationType === 'logs' ? null : (
+                <PanelChrome.TitleItem title="Feedback">
+                  <LogsFeedback feedbackUrl="https://forms.gle/5YyKdRQJ5hzq4c289" />
+                </PanelChrome.TitleItem>
+              )
+            ) : null,
           ]}
           title={'Logs'}
           actions={

--- a/public/app/features/explore/Logs/Logs.tsx
+++ b/public/app/features/explore/Logs/Logs.tsx
@@ -13,7 +13,6 @@ import {
   EventBus,
   ExploreLogsPanelState,
   ExplorePanelsState,
-  FeatureState,
   Field,
   GrafanaTheme2,
   LinkModel,
@@ -36,7 +35,6 @@ import { config, reportInteraction } from '@grafana/runtime';
 import { DataQuery, TimeZone } from '@grafana/schema';
 import {
   Button,
-  FeatureBadge,
   InlineField,
   InlineFieldRow,
   InlineSwitch,
@@ -656,7 +654,7 @@ class UnthemedLogs extends PureComponent<Props, State> {
           titleItems={[
             config.featureToggles.logsExploreTableVisualisation ? (
               this.state.visualisationType === 'logs' ? null : (
-                <PanelChrome.TitleItem title="Feedback">
+                <PanelChrome.TitleItem title="Feedback" key="A">
                   <LogsFeedback feedbackUrl="https://forms.gle/5YyKdRQJ5hzq4c289" />
                 </PanelChrome.TitleItem>
               )


### PR DESCRIPTION
**What is this feature?**
Forgot to remove the icon when we [removed the feature flag](https://github.com/grafana/grafana/pull/81185).

<img width="324" alt="image" src="https://github.com/grafana/grafana/assets/109082771/bfe2eabf-363e-43ef-ac32-ed2e6daa77a8">

=>

<img width="418" alt="image" src="https://github.com/grafana/grafana/assets/109082771/505c80c5-b341-465b-b447-6035b3807c40">

Please check that:
- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
