### PR TITLE
Area Build/Packaging: release process - remove image check for armhf rpm no longer being built

### DIFF
--- a/scripts/list-release-artifacts.sh
+++ b/scripts/list-release-artifacts.sh
@@ -12,8 +12,6 @@ ERSION_DEB="${ERSION//-/\~}"
 ASSETS=$(cat << EOF
 gs://${BUCKET}/artifacts/downloads/${VERSION}/oss/release/grafana-${ERSION_DEB}-1.aarch64.rpm
 gs://${BUCKET}/artifacts/downloads/${VERSION}/oss/release/grafana-${ERSION_DEB}-1.aarch64.rpm.sha256
-gs://${BUCKET}/artifacts/downloads/${VERSION}/oss/release/grafana-${ERSION_DEB}-1.armhfp.rpm
-gs://${BUCKET}/artifacts/downloads/${VERSION}/oss/release/grafana-${ERSION_DEB}-1.armhfp.rpm.sha256
 gs://${BUCKET}/artifacts/downloads/${VERSION}/oss/release/grafana-${ERSION_DEB}-1.x86_64.rpm
 gs://${BUCKET}/artifacts/downloads/${VERSION}/oss/release/grafana-${ERSION_DEB}-1.x86_64.rpm.sha256
 gs://${BUCKET}/artifacts/downloads/${VERSION}/oss/release/grafana-${ERSION}.darwin-amd64.tar.gz


### PR DESCRIPTION


**What is this feature?**

The build process is checking for a file that is no longer being built (armhf.rpm) and fails during the drone build.  This removes the check for the file along with the checksum file.

**Why do we need this feature?**

Cleans up the release process

**Who is this feature for?**

release guild

**Which issue(s) does this PR fix?**:

N/A

