### PR TITLE
Alerting: Fix reading props from undefined in settings

### DIFF
--- a/public/app/features/alerting/unified/components/receivers/grafanaAppReceivers/useReceiversMetadata.ts
+++ b/public/app/features/alerting/unified/components/receivers/grafanaAppReceivers/useReceiversMetadata.ts
@@ -39,7 +39,7 @@ export function getOnCallMetadata(
   }
 
   const matchingOnCallIntegration = onCallIntegrations.find(
-    (integration) => integration.integration_url === receiver.settings.url
+    (integration) => integration.integration_url === receiver.settings?.url
   );
 
   return {

--- a/public/app/features/alerting/unified/mockApi.ts
+++ b/public/app/features/alerting/unified/mockApi.ts
@@ -120,7 +120,9 @@ class GrafanaReceiverConfigBuilder {
   }
 
   addSetting(key: string, value: string): GrafanaReceiverConfigBuilder {
-    this.grafanaReceiverConfig.settings[key] = value;
+    if (this.grafanaReceiverConfig.settings) {
+      this.grafanaReceiverConfig.settings[key] = value;
+    }
     return this;
   }
 

--- a/public/app/plugins/datasource/alertmanager/types.ts
+++ b/public/app/plugins/datasource/alertmanager/types.ts
@@ -71,7 +71,7 @@ export type GrafanaManagedReceiverConfig = {
   disableResolveMessage: boolean;
   secureFields?: Record<string, boolean>;
   secureSettings?: Record<string, any>;
-  settings: Record<string, any>;
+  settings?: Record<string, any>; // sometimes settings are optional for security reasons (RBAC)
   type: string;
   name: string;
   updated?: string;


### PR DESCRIPTION
**What is this feature?**

This pr fixes reading url from undefined. When using simplified routing , the new api for getting receivers does not return settings field.

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
