### PR TITLE
Devenv: Add groups to jwt_proxy

### DIFF
--- a/devenv/docker/blocks/auth/jwt_proxy/cloak.sql
+++ b/devenv/docker/blocks/auth/jwt_proxy/cloak.sql
@@ -2,8 +2,8 @@
 -- PostgreSQL database dump
 --
 
--- Dumped from database version 12.2 (Debian 12.2-2.pgdg100+1)
--- Dumped by pg_dump version 12.2 (Debian 12.2-2.pgdg100+1)
+-- Dumped from database version 16.1
+-- Dumped by pg_dump version 16.1
 
 SET statement_timeout = 0;
 SET lock_timeout = 0;
@@ -386,7 +386,7 @@ CREATE TABLE public.component_config (
     id character varying(36) NOT NULL,
     component_id character varying(36) NOT NULL,
     name character varying(255) NOT NULL,
-    value character varying(4000)
+    value text
 );
 
 
@@ -488,7 +488,8 @@ CREATE TABLE public.event_entity (
     session_id character varying(255),
     event_time bigint,
     type character varying(255),
-    user_id character varying(255)
+    user_id character varying(255),
+    details_json_long_value text
 );
 
 
@@ -1097,7 +1098,7 @@ ALTER TABLE public.resource_scope OWNER TO keycloak;
 CREATE TABLE public.resource_server (
     id character varying(36) NOT NULL,
     allow_rs_remote_mgmt boolean DEFAULT false NOT NULL,
-    policy_enforce_mode character varying(15) NOT NULL,
+    policy_enforce_mode smallint NOT NULL,
     decision_strategy smallint DEFAULT 1 NOT NULL
 );
 
@@ -1132,8 +1133,8 @@ CREATE TABLE public.resource_server_policy (
     name character varying(255) NOT NULL,
     description character varying(255),
     type character varying(255) NOT NULL,
-    decision_strategy character varying(20),
-    logic character varying(20),
+    decision_strategy smallint,
+    logic smallint,
     resource_server_id character varying(36) NOT NULL,
     owner character varying(255)
 );
@@ -1484,7 +1485,6 @@ bfbcc1e9-f129-4336-a0cd-b6960a811bd9	\N	direct-grant-validate-password	master	5f
 5a2470c4-3136-4cf0-8383-e74a413ccd48	\N	direct-grant-validate-otp	master	99865746-4232-46f0-84b5-20952fe9eb51	0	20	f	\N	\N
 47c96943-ad68-4d93-afff-ff54fc86eb0b	\N	registration-page-form	master	1695e7d2-ad80-4502-8479-8121a6e2a2f0	0	10	t	8fb96669-d28d-4173-a8f4-dc24d41c7d27	\N
 a6678624-1bd4-4793-bfac-68551cf0ac7c	\N	registration-user-creation	master	8fb96669-d28d-4173-a8f4-dc24d41c7d27	0	20	f	\N	\N
-5b45827d-5dfd-4152-a99e-373cb975ef87	\N	registration-profile-action	master	8fb96669-d28d-4173-a8f4-dc24d41c7d27	0	40	f	\N	\N
 5a2fb70d-63ae-4604-b37c-ae043d6a900d	\N	registration-password-action	master	8fb96669-d28d-4173-a8f4-dc24d41c7d27	0	50	f	\N	\N
 0b06a30e-daa7-498a-9fdb-899abbf36450	\N	registration-recaptcha-action	master	8fb96669-d28d-4173-a8f4-dc24d41c7d27	3	60	f	\N	\N
 b6ab0b5d-8184-4609-bb81-da8413dfb858	\N	reset-credentials-choose-user	master	954b046d-2b24-405e-84ee-c44ffe603df2	0	10	f	\N	\N
@@ -1511,11 +1511,6 @@ d600bb67-e258-44be-8f69-f1bae9c35a0f	\N	idp-username-password-form	master	ca3a36
 90cc39a9-cddb-49bd-b9f5-d64d03341333	\N	auth-otp-form	master	a7d23655-efbb-4950-8ab6-50dbc85681a0	0	20	f	\N	\N
 b0634301-594e-42db-9736-6c90ebbeb8b2	\N	http-basic-authenticator	master	57c56583-d91c-4399-bd15-05a1a17d48c1	0	10	f	\N	\N
 34fa4d44-716b-4b2a-b98e-aa9748154292	\N	docker-http-basic-authenticator	master	032b05cf-0007-44da-a370-b42039f6b762	0	10	f	\N	\N
-4838277a-46ea-4d95-bd86-d8dc6fdce352	\N	no-cookie-redirect	master	1c7af06b-3085-46c3-849c-34c67f581b9e	0	10	f	\N	\N
-59a349ee-20ce-42d8-b20b-8f902c09742d	\N	\N	master	1c7af06b-3085-46c3-849c-34c67f581b9e	0	20	t	85c00992-77dd-4262-8744-a9dd8521e98e	\N
-d9b5fa46-6595-4406-9841-2c0720dbf644	\N	basic-auth	master	85c00992-77dd-4262-8744-a9dd8521e98e	0	10	f	\N	\N
-3a4ee6f1-1528-47c7-aeda-f317248b3b93	\N	basic-auth-otp	master	85c00992-77dd-4262-8744-a9dd8521e98e	3	20	f	\N	\N
-014847fc-06df-4ddf-a8f2-deeb0f1eb59a	\N	auth-spnego	master	85c00992-77dd-4262-8744-a9dd8521e98e	3	30	f	\N	\N
 b46bc4f6-2fe5-44d5-b47f-36880742cf50	\N	auth-cookie	grafana	a38aeb47-f27e-4e68-82ff-7cc7371a47a7	2	10	f	\N	\N
 6cec48cc-066a-4e3e-8158-85351bfa4c27	\N	auth-spnego	grafana	a38aeb47-f27e-4e68-82ff-7cc7371a47a7	3	20	f	\N	\N
 63c55c5a-ad11-4f83-9d6e-d8ca2efcaf66	\N	identity-provider-redirector	grafana	a38aeb47-f27e-4e68-82ff-7cc7371a47a7	2	25	f	\N	\N
@@ -1530,7 +1525,6 @@ b46bc4f6-2fe5-44d5-b47f-36880742cf50	\N	auth-cookie	grafana	a38aeb47-f27e-4e68-8
 d87abeef-9f1d-46f5-9f36-acd7eaf21a72	\N	direct-grant-validate-otp	grafana	b3491338-0630-4232-97e7-a518c254b248	0	20	f	\N	\N
 4f204bab-0311-44b4-80b6-37d23fd0fd5a	\N	registration-page-form	grafana	9d02badd-cb1c-4655-bf5e-f888861433ff	0	10	t	c3ed2ad1-cfb4-49fa-8c75-cf5047527c68	\N
 2d4ee446-623c-42a0-8d4a-9f6c4f7f28ec	\N	registration-user-creation	grafana	c3ed2ad1-cfb4-49fa-8c75-cf5047527c68	0	20	f	\N	\N
-d806effc-dd17-4468-9a98-4e1c2f9e799d	\N	registration-profile-action	grafana	c3ed2ad1-cfb4-49fa-8c75-cf5047527c68	0	40	f	\N	\N
 306fa749-c191-43c6-bf04-0eb6d3d02732	\N	registration-password-action	grafana	c3ed2ad1-cfb4-49fa-8c75-cf5047527c68	0	50	f	\N	\N
 7de9bbee-eb3d-4f3e-a134-e7e8d4a6df25	\N	registration-recaptcha-action	grafana	c3ed2ad1-cfb4-49fa-8c75-cf5047527c68	3	60	f	\N	\N
 8a31d18e-1622-4eac-8eff-9434fa9cade3	\N	reset-credentials-choose-user	grafana	3085fb68-fc1f-4e1c-a8be-33fb45194b04	0	10	f	\N	\N
@@ -1557,11 +1551,6 @@ b8ce6905-73eb-493b-9ce1-408ec55e3c46	\N	conditional-user-configured	grafana	21fb
 54d7692d-c0e3-40ef-9ef9-d9e8227d618d	\N	auth-otp-form	grafana	21fbd70a-286f-431a-abc4-fbf6590fcdc3	0	20	f	\N	\N
 3722f24d-6ffb-4b20-a481-1fd8a17afdf6	\N	http-basic-authenticator	grafana	ba53abf5-9a64-4371-810b-67378eb3d781	0	10	f	\N	\N
 a700b05f-a61d-4eeb-ad75-1a3df05ed429	\N	docker-http-basic-authenticator	grafana	95e02703-f5bc-4e04-8bef-f6adc2d8173f	0	10	f	\N	\N
-035c4f94-03a6-4101-a729-f3c01ee4c490	\N	no-cookie-redirect	grafana	f397495e-d073-4ef1-babf-569a338db596	0	10	f	\N	\N
-29f310db-b302-44b2-9182-4b91648cbabf	\N	\N	grafana	f397495e-d073-4ef1-babf-569a338db596	0	20	t	56c40f89-4d69-46fd-bb18-d6c01808d2af	\N
-4e7d257c-e013-4597-a44d-b186a85606af	\N	basic-auth	grafana	56c40f89-4d69-46fd-bb18-d6c01808d2af	0	10	f	\N	\N
-2ba05817-a59f-4e72-a565-f3b4591390dc	\N	basic-auth-otp	grafana	56c40f89-4d69-46fd-bb18-d6c01808d2af	3	20	f	\N	\N
-5db9c781-6718-4674-a833-9a4ac3e8212e	\N	auth-spnego	grafana	56c40f89-4d69-46fd-bb18-d6c01808d2af	3	30	f	\N	\N
 5f032dbb-bd37-425b-af1e-ba555c7a8245	\N	\N	grafana	b478ecfb-db7e-4797-a245-8fc3b4dec884	1	30	t	b3491338-0630-4232-97e7-a518c254b248	\N
 \.
 
@@ -1589,8 +1578,6 @@ ca3a3600-552c-4849-9a9d-826c8aa3e646	Verify Existing Account by Re-authenticatio
 a7d23655-efbb-4950-8ab6-50dbc85681a0	First broker login - Conditional OTP	Flow to determine if the OTP is required for the authentication	master	basic-flow	f	t
 57c56583-d91c-4399-bd15-05a1a17d48c1	saml ecp	SAML ECP Profile Authentication Flow	master	basic-flow	t	t
 032b05cf-0007-44da-a370-b42039f6b762	docker auth	Used by Docker clients to authenticate against the IDP	master	basic-flow	t	t
-1c7af06b-3085-46c3-849c-34c67f581b9e	http challenge	An authentication flow based on challenge-response HTTP Authentication Schemes	master	basic-flow	t	t
-85c00992-77dd-4262-8744-a9dd8521e98e	Authentication Options	Authentication options.	master	basic-flow	f	t
 a38aeb47-f27e-4e68-82ff-7cc7371a47a7	browser	browser based authentication	grafana	basic-flow	t	t
 c53e357f-e276-43aa-b36c-46366a7ffd35	forms	Username, password, otp and other auth forms.	grafana	basic-flow	f	t
 cf4831e9-3e1d-452e-984e-e6d4d9eeafb5	Browser - Conditional OTP	Flow to determine if the OTP is required for the authentication	grafana	basic-flow	f	t
@@ -1609,8 +1596,6 @@ df86516c-dcb1-41a8-877e-eb8805bcac8c	User creation or linking	Flow for the exist
 21fbd70a-286f-431a-abc4-fbf6590fcdc3	First broker login - Conditional OTP	Flow to determine if the OTP is required for the authentication	grafana	basic-flow	f	t
 ba53abf5-9a64-4371-810b-67378eb3d781	saml ecp	SAML ECP Profile Authentication Flow	grafana	basic-flow	t	t
 95e02703-f5bc-4e04-8bef-f6adc2d8173f	docker auth	Used by Docker clients to authenticate against the IDP	grafana	basic-flow	t	t
-f397495e-d073-4ef1-babf-569a338db596	http challenge	An authentication flow based on challenge-response HTTP Authentication Schemes	grafana	basic-flow	t	t
-56c40f89-4d69-46fd-bb18-d6c01808d2af	Authentication Options	Authentication options.	grafana	basic-flow	f	t
 \.
 
 
@@ -1840,6 +1825,7 @@ d30340a8-630b-416e-8c93-3ccf932d34f3	false	display.on.consent.screen
 d30340a8-630b-416e-8c93-3ccf932d34f3	false	include.in.token.scope
 a96603aa-e6db-4b3e-8baa-679c75ccfc8f	false	display.on.consent.screen
 a96603aa-e6db-4b3e-8baa-679c75ccfc8f	false	include.in.token.scope
+c61f5b19-c17e-49a1-91b8-a0296411b928		gui.order
 \.
 
 
@@ -1979,6 +1965,7 @@ a8698f4f-5fa1-4baa-be05-87d03052af49	c61f5b19-c17e-49a1-91b8-a0296411b928	f
 169f1dea-80f0-4a99-8509-9abb70ab0a5c	a5bb3a5f-fd26-4be6-9557-26e20a03d33d	f
 169f1dea-80f0-4a99-8509-9abb70ab0a5c	d6ffe9fc-a03c-4496-85dc-dbb5e7754587	f
 169f1dea-80f0-4a99-8509-9abb70ab0a5c	c61f5b19-c17e-49a1-91b8-a0296411b928	f
+09b79548-8426-4c0e-8e0b-7488467532c7	c61f5b19-c17e-49a1-91b8-a0296411b928	t
 \.
 
 
@@ -2086,6 +2073,7 @@ d47557df-07ff-4cae-bedd-b584c0697852	f95566ed-b955-4668-88fc-e7413fd98615	allowe
 2ae4acc4-c6d6-4d2f-92c6-3a222a7d078a	28d2466c-5af6-4786-a8a2-c25d6cb4833f	allowed-protocol-mapper-types	oidc-sha256-pairwise-sub-mapper
 880a35e4-65a1-4697-836d-fbc46641d676	28d2466c-5af6-4786-a8a2-c25d6cb4833f	allowed-protocol-mapper-types	oidc-full-name-mapper
 b087e631-754f-4c03-8cfc-354c7e7456fe	28d2466c-5af6-4786-a8a2-c25d6cb4833f	allowed-protocol-mapper-types	oidc-usermodel-property-mapper
+258b8704-0587-4208-996f-96627992e370	80af2f23-4a51-498a-a011-732cf9cfa8f8	priority	100
 079e63d4-0862-4e63-a62f-1a168cbbc25c	28d2466c-5af6-4786-a8a2-c25d6cb4833f	allowed-protocol-mapper-types	saml-user-property-mapper
 da61fbc2-7533-4bc1-b0c4-357db9f108e4	28d2466c-5af6-4786-a8a2-c25d6cb4833f	allowed-protocol-mapper-types	oidc-address-mapper
 37a4be58-26b0-4d4a-9c41-a89b27fc25f6	28d2466c-5af6-4786-a8a2-c25d6cb4833f	allowed-protocol-mapper-types	saml-user-attribute-mapper
@@ -2112,7 +2100,6 @@ bb8c28ca-bb74-4a07-82c3-8293354517be	9877acf2-e1cc-4038-a3c2-75db29b432e0	secret
 64ea89c8-a2ce-4d2d-896d-aa49e7ca9fcc	9877acf2-e1cc-4038-a3c2-75db29b432e0	kid	7d80efc5-222b-4b6d-9b99-c3b516a59733
 bec1483f-75e7-46e8-916c-102db4cbefb5	80af2f23-4a51-498a-a011-732cf9cfa8f8	certificate	MIICnTCCAYUCBgF+u1ir8jANBgkqhkiG9w0BAQsFADASMRAwDgYDVQQDDAdncmFmYW5hMB4XDTIyMDIwMjE2NDkxN1oXDTMyMDIwMjE2NTA1N1owEjEQMA4GA1UEAwwHZ3JhZmFuYTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAKg5kB303DkDs5jSW1b7b7kvKfxIJorHD+7wPz2TcisfTu7rchrqAJiR/HtsPICyAw1h5ef8fGgCJf/k0z00osl/COvK8iHUdvGUnubuKUXaVwlbyaTnnyjSMUAkx+67OCrkY9B2drtZrtVc+fwnggqCsCkpoXg97tcUyfPlcUJnanxsYbirZ5KH+/e+x1jlsuBiwxascmB4IoT/zJknk5l1IVXmSOiDgqhzKRfHhVlRijOlfKyCn/EDtiv7wyQTP9wvd97zGPJqkkF2yNxueMftJsgGkF6+CZMY71BioOWAt2V8OwI32b/1v30DhtBmKdoUNGpEeCjSk91zzZqTFZUCAwEAATANBgkqhkiG9w0BAQsFAAOCAQEABlW64QxuREB81VMGsyhj4Q5RykFaVuD5O8YlwUpmVfAVLzb0Drf54Kn4bnpnckKyYV+T+HsN4QXt81UE41xH0Aai2H3vrGH+PJf6aLPCDE+jpMqtN3n6IgImJXJPL8upMfhhWDv4nkM4uynEwWupzmrKi4oJuTETSMktJby4o6//XWnCzCVMoAGFJU4gtjBUzOMLW26zD+yc+BuUtfR3HzItVHSZKQSNSFO0kVS68RgrER8qJw07z3BOJ2bPpPM0PYyEngGMaowz/T6lI32ymGMWYMAnslthS1KAW9xcTBwnrW1nMhe5a0LPxIktys/wJtxIHZLc5sOddGT4xYklLg==
 48e8b904-1393-43a4-aaa1-30e2d9634b36	80af2f23-4a51-498a-a011-732cf9cfa8f8	privateKey	MIIEowIBAAKCAQEAqDmQHfTcOQOzmNJbVvtvuS8p/EgmiscP7vA/PZNyKx9O7utyGuoAmJH8e2w8gLIDDWHl5/x8aAIl/+TTPTSiyX8I68ryIdR28ZSe5u4pRdpXCVvJpOefKNIxQCTH7rs4KuRj0HZ2u1mu1Vz5/CeCCoKwKSmheD3u1xTJ8+VxQmdqfGxhuKtnkof7977HWOWy4GLDFqxyYHgihP/MmSeTmXUhVeZI6IOCqHMpF8eFWVGKM6V8rIKf8QO2K/vDJBM/3C933vMY8mqSQXbI3G54x+0myAaQXr4JkxjvUGKg5YC3ZXw7AjfZv/W/fQOG0GYp2hQ0akR4KNKT3XPNmpMVlQIDAQABAoIBAF3kEt3FZoyj1j97WOOJXmf7PPHDy081n1z61jEl9FjBFqse2gbPiBmfkU3JsVMbB70WYN1D/KOIX3EdZBELKbhQoMgJ826SSPi4vJ+jWYHVRTLB+h+B70E3X6mvXa+O6uB1rIgTNl2Gxp/rTtM/scLwAiZXR/n2hzGgNr9b1gT7D7kyCUIKDiJsQed2pA6ZbSDNTQQDE2qeN/Rr/+VV4XRuIIdBXn+Brap8ihjx4Gnn/SDBKM3MZoacwgS+9CZNhLjs8Ou4xD+KyitbbGGY4ZK/ZW2eSAH4ra8vVGTDK6bJrMTAE/73A23Evp/sKtRkFqcNumJ3rCykcAJorDUK48ECgYEA0TpkTwK6f2a72ncmw7Xzy4zdu+FdkI9PzWmS4IrbYOYRwsRMQLowsUPIdtU0EMrs7PRl1dSQa3/kAnw5J8wogkqVf4dJ3/lb/N5qtsjHP87N35QMXnMdE/BC6o7t5e+iRoHMloAuSBonGC9uBn1UeHWrNeLCB8+upJoSEBKbEQ0CgYEAzdSoKL4CJo31gVEqoJFPzPemsYGmV6Zl1Vj8mqMbQd8wcJoSJWbNV/3sfpIqdvOJOXQrzm+LYIbhhUnS3ZlGBmFsqUtC7dw3AqLg53msCyJLxmCIib0m/ONCY9qczV4OkUM6HVAdgzmMqqhk5ZB70IdUyStn2meqXKXLGFlLJKkCgYEAuizHTTcUVIFJ7x/PMp8ZjKqQM7pZ02Rykkm7FGr6wsJ2U2TwpTgIU/QI0RTt+3NWV5MxepBm4gEvFrcK9MrJ0QYk+RGdPttYay5Ors8B3Vlb//Jw/ypXWYKVSLpeHhiZwTuGnPT6OdZrqy2pLcUgAQBTlONt3B2FPZqLMBoeOZECgYBuCwm0bpF7x13AO4LMwaOmc6jdMfGa3s2G2MKEcjt6ZjbhnJ2i/Wk/Z/RuXvrxCZcN7nwVLDGZ88LSnftsmiuD8cZEZIZt4NRQRoBzgOtoMHfOoYGeElCr11yBQjme2nBzXTvOvCxrIfOAsfLvgOWRQSklPF2TuOSuD72bUPIJsQKBgBbeb8rIXKRRFC3A0IkKm8C51gG8mMgPdxZMKKuVhpb6D8B5aPh+WW44yNOpn7LInYI4jzf3Kv+kcj0PNH3nFaplnyCGFfmUIg27SAsRcrJcTlXtIKooZw6oPU+dQfAo11suArVAVD6OQc/7z99VoIpLN0cUHfS/g0H1dx/r/32o
-258b8704-0587-4208-996f-96627992e370	80af2f23-4a51-498a-a011-732cf9cfa8f8	priority	100
 12cd94c5-bd7e-4a5c-95e2-256b0bcf14bd	261e38de-3e1f-40a3-9200-f5aac1975701	allowed-protocol-mapper-types	oidc-address-mapper
 f33b34f1-3793-4786-a281-b286fce52f45	261e38de-3e1f-40a3-9200-f5aac1975701	allowed-protocol-mapper-types	saml-role-list-mapper
 d056c1de-9aa1-46a0-a644-fafb33088967	261e38de-3e1f-40a3-9200-f5aac1975701	allowed-protocol-mapper-types	saml-user-property-mapper
@@ -2226,11 +2213,11 @@ b4c89bc8-3945-4963-80b5-3da62e8c54ad	18a7066b-fe71-410e-9581-69f78347ec29
 --
 
 COPY public.credential (id, salt, type, user_id, created_date, user_label, secret_data, credential_data, priority) FROM stdin;
-d4b2c483-1dd3-47f6-86bf-42548009918d	\N	password	74e29604-ff35-42bb-a26d-4d0b81ef0917	1643820449817	\N	{"value":"Hou7HlbGvohOx6II0VSCP4BIGI4Cyzy+BcXbPUQe/kaMQzNU77kH2pOKZ236UPfkiCyOLe7A3oS0afExA+ymAQ==","salt":"urXvCw0KdWf9s74km4G+lA==","additionalParameters":{}}	{"hashIterations":27500,"algorithm":"pbkdf2-sha256","additionalParameters":{}}	10
 cb2bd4ed-94b8-4259-bcaa-9250c3fb28d3	\N	password	6db3c5e5-b84b-4f9d-a7a8-8d05b03c929d	1657026827644	\N	{"value":"q3Z59Nh/5bdezDEpCwEbMPu8d+VgJ5WetafXkR8l0FlsTTkSDQgW+j6GaM3seJR93p3/jCxyfsvZl062d1pq7w==","salt":"ohuHnjLnwF9dBZ38DRJJWg==","additionalParameters":{}}	{"hashIterations":27500,"algorithm":"pbkdf2-sha256","additionalParameters":{}}	10
-b58e1964-6466-40b2-879c-982b724d7f9c	\N	password	88692d07-bb9a-46cf-844c-7ff5c529cd04	1657026904515	\N	{"value":"+/0zWjiJyE3+dCOEf0SO6G3n1/LsFAVoDAZREKTfN4vQ5xJH8srJoCjxcgb+bI1crMr8gknDlFyGRy7CpYn2VQ==","salt":"v/2okNt3wGOZz+x4DjOCDQ==","additionalParameters":{}}	{"hashIterations":27500,"algorithm":"pbkdf2-sha256","additionalParameters":{}}	10
-3ff7dd8f-a299-4b51-bf5d-99665ccfd313	\N	password	8f58cbec-6e40-4bab-bff0-1c5ff899fe2e	1657026943075	\N	{"value":"nMYodMJMiq/J8g9vRPktGc7WSWnOKr6leMDZX4p9K9KgAUYeXFDSu+d29PWWn0rFn93dL0PNdIdHWNQhfkIDMg==","salt":"rmi9WLHgarmIXGukecSIig==","additionalParameters":{}}	{"hashIterations":27500,"algorithm":"pbkdf2-sha256","additionalParameters":{}}	10
 c9582964-cfdd-49a1-99fb-847604b0c78c	\N	password	1a85b7e0-4baa-420b-89f8-1cea43a540dd	1662480997923	\N	{"value":"ViNTHbpBUNdtH1qGSlip7WFI8Z9lvcGQdbL8Yw48zUgB46jVFbD1eNrOw68p3ovDwfDCIJKm34EFNbw9/uzHSg==","salt":"Z9P8RfnrQwCn0xUTpWC2DQ==","additionalParameters":{}}	{"hashIterations":27500,"algorithm":"pbkdf2-sha256","additionalParameters":{}}	10
+b58e1964-6466-40b2-879c-982b724d7f9c	\N	password	88692d07-bb9a-46cf-844c-7ff5c529cd04	1657026904515	\N	{"value":"L/GNO2HAU90A/ajXqyZyujncf+GfJiLWzNVTIDAVj1k=","salt":"L6WsIapZ+hKo0809G6c6SA==","additionalParameters":{}}	{"hashIterations":27500,"algorithm":"pbkdf2-sha256","additionalParameters":{}}	10
+d4b2c483-1dd3-47f6-86bf-42548009918d	\N	password	74e29604-ff35-42bb-a26d-4d0b81ef0917	1643820449817	\N	{"value":"GweNaTEq3+hCqr5bBhnfqUd0oAiv8G4eUBkQUqtqiTI=","salt":"z64RYF8zRJz9ko0KDrIPxw==","additionalParameters":{}}	{"hashIterations":27500,"algorithm":"pbkdf2-sha256","additionalParameters":{}}	10
+3ff7dd8f-a299-4b51-bf5d-99665ccfd313	\N	password	8f58cbec-6e40-4bab-bff0-1c5ff899fe2e	1657026943075	\N	{"value":"81KWe14rtsbn3SS6YbWzBy2SvBQhmH+0MDHkK7aXCbo=","salt":"CnzQUkkAMD1tPk1KFDDm1w==","additionalParameters":{}}	{"hashIterations":27500,"algorithm":"pbkdf2-sha256","additionalParameters":{}}	10
 \.
 
 
@@ -2239,118 +2226,125 @@ c9582964-cfdd-49a1-99fb-847604b0c78c	\N	password	1a85b7e0-4baa-420b-89f8-1cea43a
 --
 
 COPY public.databasechangelog (id, author, filename, dateexecuted, orderexecuted, exectype, md5sum, description, comments, tag, liquibase, contexts, labels, deployment_id) FROM stdin;
-authn-3.4.0.CR1-refresh-token-max-reuse	glavoie@gmail.com	META-INF/jpa-changelog-authz-3.4.0.CR1.xml	2022-02-02 16:47:26.706593	49	EXECUTED	\N	addColumn tableName=REALM		\N	3.5.4	\N	\N	3820445829
-1.0.0.Final-KEYCLOAK-5461	sthorger@redhat.com	META-INF/jpa-changelog-1.0.0.Final.xml	2022-02-02 16:47:26.017844	1	EXECUTED	\N	createTable tableName=APPLICATION_DEFAULT_ROLES; createTable tableName=CLIENT; createTable tableName=CLIENT_SESSION; createTable tableName=CLIENT_SESSION_ROLE; createTable tableName=COMPOSITE_ROLE; createTable tableName=CREDENTIAL; createTable tab...		\N	3.5.4	\N	\N	3820445829
-1.0.0.Final-KEYCLOAK-5461	sthorger@redhat.com	META-INF/db2-jpa-changelog-1.0.0.Final.xml	2022-02-02 16:47:26.03122	2	MARK_RAN	\N	createTable tableName=APPLICATION_DEFAULT_ROLES; createTable tableName=CLIENT; createTable tableName=CLIENT_SESSION; createTable tableName=CLIENT_SESSION_ROLE; createTable tableName=COMPOSITE_ROLE; createTable tableName=CREDENTIAL; createTable tab...		\N	3.5.4	\N	\N	3820445829
-1.1.0.Beta1	sthorger@redhat.com	META-INF/jpa-changelog-1.1.0.Beta1.xml	2022-02-02 16:47:26.06085	3	EXECUTED	\N	delete tableName=CLIENT_SESSION_ROLE; delete tableName=CLIENT_SESSION; delete tableName=USER_SESSION; createTable tableName=CLIENT_ATTRIBUTES; createTable tableName=CLIENT_SESSION_NOTE; createTable tableName=APP_NODE_REGISTRATIONS; addColumn table...		\N	3.5.4	\N	\N	3820445829
-1.1.0.Final	sthorger@redhat.com	META-INF/jpa-changelog-1.1.0.Final.xml	2022-02-02 16:47:26.065284	4	EXECUTED	\N	renameColumn newColumnName=EVENT_TIME, oldColumnName=TIME, tableName=EVENT_ENTITY		\N	3.5.4	\N	\N	3820445829
-4.8.0-KEYCLOAK-8835	sguilhen@redhat.com	META-INF/jpa-changelog-4.8.0.xml	2022-02-02 16:47:26.928034	70	EXECUTED	\N	addNotNullConstraint columnName=SSO_MAX_LIFESPAN_REMEMBER_ME, tableName=REALM; addNotNullConstraint columnName=SSO_IDLE_TIMEOUT_REMEMBER_ME, tableName=REALM		\N	3.5.4	\N	\N	3820445829
-1.2.0.Beta1	psilva@redhat.com	META-INF/jpa-changelog-1.2.0.Beta1.xml	2022-02-02 16:47:26.130908	5	EXECUTED	\N	delete tableName=CLIENT_SESSION_ROLE; delete tableName=CLIENT_SESSION_NOTE; delete tableName=CLIENT_SESSION; delete tableName=USER_SESSION; createTable tableName=PROTOCOL_MAPPER; createTable tableName=PROTOCOL_MAPPER_CONFIG; createTable tableName=...		\N	3.5.4	\N	\N	3820445829
-1.2.0.Beta1	psilva@redhat.com	META-INF/db2-jpa-changelog-1.2.0.Beta1.xml	2022-02-02 16:47:26.133863	6	MARK_RAN	\N	delete tableName=CLIENT_SESSION_ROLE; delete tableName=CLIENT_SESSION_NOTE; delete tableName=CLIENT_SESSION; delete tableName=USER_SESSION; createTable tableName=PROTOCOL_MAPPER; createTable tableName=PROTOCOL_MAPPER_CONFIG; createTable tableName=...		\N	3.5.4	\N	\N	3820445829
-1.2.0.RC1	bburke@redhat.com	META-INF/jpa-changelog-1.2.0.CR1.xml	2022-02-02 16:47:26.183318	7	EXECUTED	\N	delete tableName=CLIENT_SESSION_ROLE; delete tableName=CLIENT_SESSION_NOTE; delete tableName=CLIENT_SESSION; delete tableName=USER_SESSION_NOTE; delete tableName=USER_SESSION; createTable tableName=MIGRATION_MODEL; createTable tableName=IDENTITY_P...		\N	3.5.4	\N	\N	3820445829
-1.2.0.RC1	bburke@redhat.com	META-INF/db2-jpa-changelog-1.2.0.CR1.xml	2022-02-02 16:47:26.186858	8	MARK_RAN	\N	delete tableName=CLIENT_SESSION_ROLE; delete tableName=CLIENT_SESSION_NOTE; delete tableName=CLIENT_SESSION; delete tableName=USER_SESSION_NOTE; delete tableName=USER_SESSION; createTable tableName=MIGRATION_MODEL; createTable tableName=IDENTITY_P...		\N	3.5.4	\N	\N	3820445829
-1.2.0.Final	keycloak	META-INF/jpa-changelog-1.2.0.Final.xml	2022-02-02 16:47:26.19172	9	EXECUTED	\N	update tableName=CLIENT; update tableName=CLIENT; update tableName=CLIENT		\N	3.5.4	\N	\N	3820445829
-1.3.0	bburke@redhat.com	META-INF/jpa-changelog-1.3.0.xml	2022-02-02 16:47:26.242162	10	EXECUTED	\N	delete tableName=CLIENT_SESSION_ROLE; delete tableName=CLIENT_SESSION_PROT_MAPPER; delete tableName=CLIENT_SESSION_NOTE; delete tableName=CLIENT_SESSION; delete tableName=USER_SESSION_NOTE; delete tableName=USER_SESSION; createTable tableName=ADMI...		\N	3.5.4	\N	\N	3820445829
-1.4.0	bburke@redhat.com	META-INF/jpa-changelog-1.4.0.xml	2022-02-02 16:47:26.275929	11	EXECUTED	\N	delete tableName=CLIENT_SESSION_AUTH_STATUS; delete tableName=CLIENT_SESSION_ROLE; delete tableName=CLIENT_SESSION_PROT_MAPPER; delete tableName=CLIENT_SESSION_NOTE; delete tableName=CLIENT_SESSION; delete tableName=USER_SESSION_NOTE; delete table...		\N	3.5.4	\N	\N	3820445829
-1.4.0	bburke@redhat.com	META-INF/db2-jpa-changelog-1.4.0.xml	2022-02-02 16:47:26.278548	12	MARK_RAN	\N	delete tableName=CLIENT_SESSION_AUTH_STATUS; delete tableName=CLIENT_SESSION_ROLE; delete tableName=CLIENT_SESSION_PROT_MAPPER; delete tableName=CLIENT_SESSION_NOTE; delete tableName=CLIENT_SESSION; delete tableName=USER_SESSION_NOTE; delete table...		\N	3.5.4	\N	\N	3820445829
-1.5.0	bburke@redhat.com	META-INF/jpa-changelog-1.5.0.xml	2022-02-02 16:47:26.287616	13	EXECUTED	\N	delete tableName=CLIENT_SESSION_AUTH_STATUS; delete tableName=CLIENT_SESSION_ROLE; delete tableName=CLIENT_SESSION_PROT_MAPPER; delete tableName=CLIENT_SESSION_NOTE; delete tableName=CLIENT_SESSION; delete tableName=USER_SESSION_NOTE; delete table...		\N	3.5.4	\N	\N	3820445829
-1.6.1_from15	mposolda@redhat.com	META-INF/jpa-changelog-1.6.1.xml	2022-02-02 16:47:26.299798	14	EXECUTED	\N	addColumn tableName=REALM; addColumn tableName=KEYCLOAK_ROLE; addColumn tableName=CLIENT; createTable tableName=OFFLINE_USER_SESSION; createTable tableName=OFFLINE_CLIENT_SESSION; addPrimaryKey constraintName=CONSTRAINT_OFFL_US_SES_PK2, tableName=...		\N	3.5.4	\N	\N	3820445829
-1.6.1_from16-pre	mposolda@redhat.com	META-INF/jpa-changelog-1.6.1.xml	2022-02-02 16:47:26.302088	15	MARK_RAN	\N	delete tableName=OFFLINE_CLIENT_SESSION; delete tableName=OFFLINE_USER_SESSION		\N	3.5.4	\N	\N	3820445829
-1.6.1_from16	mposolda@redhat.com	META-INF/jpa-changelog-1.6.1.xml	2022-02-02 16:47:26.303889	16	MARK_RAN	\N	dropPrimaryKey constraintName=CONSTRAINT_OFFLINE_US_SES_PK, tableName=OFFLINE_USER_SESSION; dropPrimaryKey constraintName=CONSTRAINT_OFFLINE_CL_SES_PK, tableName=OFFLINE_CLIENT_SESSION; addColumn tableName=OFFLINE_USER_SESSION; update tableName=OF...		\N	3.5.4	\N	\N	3820445829
-1.6.1	mposolda@redhat.com	META-INF/jpa-changelog-1.6.1.xml	2022-02-02 16:47:26.306641	17	EXECUTED	\N	empty		\N	3.5.4	\N	\N	3820445829
-1.7.0	bburke@redhat.com	META-INF/jpa-changelog-1.7.0.xml	2022-02-02 16:47:26.338791	18	EXECUTED	\N	createTable tableName=KEYCLOAK_GROUP; createTable tableName=GROUP_ROLE_MAPPING; createTable tableName=GROUP_ATTRIBUTE; createTable tableName=USER_GROUP_MEMBERSHIP; createTable tableName=REALM_DEFAULT_GROUPS; addColumn tableName=IDENTITY_PROVIDER; ...		\N	3.5.4	\N	\N	3820445829
-1.8.0	mposolda@redhat.com	META-INF/jpa-changelog-1.8.0.xml	2022-02-02 16:47:26.381463	19	EXECUTED	\N	addColumn tableName=IDENTITY_PROVIDER; createTable tableName=CLIENT_TEMPLATE; createTable tableName=CLIENT_TEMPLATE_ATTRIBUTES; createTable tableName=TEMPLATE_SCOPE_MAPPING; dropNotNullConstraint columnName=CLIENT_ID, tableName=PROTOCOL_MAPPER; ad...		\N	3.5.4	\N	\N	3820445829
-1.8.0-2	keycloak	META-INF/jpa-changelog-1.8.0.xml	2022-02-02 16:47:26.390165	20	EXECUTED	\N	dropDefaultValue columnName=ALGORITHM, tableName=CREDENTIAL; update tableName=CREDENTIAL		\N	3.5.4	\N	\N	3820445829
-authz-3.4.0.CR1-resource-server-pk-change-part1	glavoie@gmail.com	META-INF/jpa-changelog-authz-3.4.0.CR1.xml	2022-02-02 16:47:26.679075	45	EXECUTED	\N	addColumn tableName=RESOURCE_SERVER_POLICY; addColumn tableName=RESOURCE_SERVER_RESOURCE; addColumn tableName=RESOURCE_SERVER_SCOPE		\N	3.5.4	\N	\N	3820445829
-1.8.0	mposolda@redhat.com	META-INF/db2-jpa-changelog-1.8.0.xml	2022-02-02 16:47:26.392862	21	MARK_RAN	\N	addColumn tableName=IDENTITY_PROVIDER; createTable tableName=CLIENT_TEMPLATE; createTable tableName=CLIENT_TEMPLATE_ATTRIBUTES; createTable tableName=TEMPLATE_SCOPE_MAPPING; dropNotNullConstraint columnName=CLIENT_ID, tableName=PROTOCOL_MAPPER; ad...		\N	3.5.4	\N	\N	3820445829
-1.8.0-2	keycloak	META-INF/db2-jpa-changelog-1.8.0.xml	2022-02-02 16:47:26.395652	22	MARK_RAN	\N	dropDefaultValue columnName=ALGORITHM, tableName=CREDENTIAL; update tableName=CREDENTIAL		\N	3.5.4	\N	\N	3820445829
-1.9.0	mposolda@redhat.com	META-INF/jpa-changelog-1.9.0.xml	2022-02-02 16:47:26.40969	23	EXECUTED	\N	update tableName=REALM; update tableName=REALM; update tableName=REALM; update tableName=REALM; update tableName=CREDENTIAL; update tableName=CREDENTIAL; update tableName=CREDENTIAL; update tableName=REALM; update tableName=REALM; customChange; dr...		\N	3.5.4	\N	\N	3820445829
-1.9.1	keycloak	META-INF/jpa-changelog-1.9.1.xml	2022-02-02 16:47:26.414344	24	EXECUTED	\N	modifyDataType columnName=PRIVATE_KEY, tableName=REALM; modifyDataType columnName=PUBLIC_KEY, tableName=REALM; modifyDataType columnName=CERTIFICATE, tableName=REALM		\N	3.5.4	\N	\N	3820445829
-1.9.1	keycloak	META-INF/db2-jpa-changelog-1.9.1.xml	2022-02-02 16:47:26.416193	25	MARK_RAN	\N	modifyDataType columnName=PRIVATE_KEY, tableName=REALM; modifyDataType columnName=CERTIFICATE, tableName=REALM		\N	3.5.4	\N	\N	3820445829
-1.9.2	keycloak	META-INF/jpa-changelog-1.9.2.xml	2022-02-02 16:47:26.437367	26	EXECUTED	\N	createIndex indexName=IDX_USER_EMAIL, tableName=USER_ENTITY; createIndex indexName=IDX_USER_ROLE_MAPPING, tableName=USER_ROLE_MAPPING; createIndex indexName=IDX_USER_GROUP_MAPPING, tableName=USER_GROUP_MEMBERSHIP; createIndex indexName=IDX_USER_CO...		\N	3.5.4	\N	\N	3820445829
-9.0.1-KEYCLOAK-12579-recreate-constraints	keycloak	META-INF/jpa-changelog-9.0.1.xml	2022-02-02 16:47:26.981645	84	MARK_RAN	\N	addUniqueConstraint constraintName=SIBLING_NAMES, tableName=KEYCLOAK_GROUP		\N	3.5.4	\N	\N	3820445829
-authz-2.0.0	psilva@redhat.com	META-INF/jpa-changelog-authz-2.0.0.xml	2022-02-02 16:47:26.481647	27	EXECUTED	\N	createTable tableName=RESOURCE_SERVER; addPrimaryKey constraintName=CONSTRAINT_FARS, tableName=RESOURCE_SERVER; addUniqueConstraint constraintName=UK_AU8TT6T700S9V50BU18WS5HA6, tableName=RESOURCE_SERVER; createTable tableName=RESOURCE_SERVER_RESOU...		\N	3.5.4	\N	\N	3820445829
-authz-2.5.1	psilva@redhat.com	META-INF/jpa-changelog-authz-2.5.1.xml	2022-02-02 16:47:26.484459	28	EXECUTED	\N	update tableName=RESOURCE_SERVER_POLICY		\N	3.5.4	\N	\N	3820445829
-2.1.0-KEYCLOAK-5461	bburke@redhat.com	META-INF/jpa-changelog-2.1.0.xml	2022-02-02 16:47:26.523006	29	EXECUTED	\N	createTable tableName=BROKER_LINK; createTable tableName=FED_USER_ATTRIBUTE; createTable tableName=FED_USER_CONSENT; createTable tableName=FED_USER_CONSENT_ROLE; createTable tableName=FED_USER_CONSENT_PROT_MAPPER; createTable tableName=FED_USER_CR...		\N	3.5.4	\N	\N	3820445829
-2.2.0	bburke@redhat.com	META-INF/jpa-changelog-2.2.0.xml	2022-02-02 16:47:26.532066	30	EXECUTED	\N	addColumn tableName=ADMIN_EVENT_ENTITY; createTable tableName=CREDENTIAL_ATTRIBUTE; createTable tableName=FED_CREDENTIAL_ATTRIBUTE; modifyDataType columnName=VALUE, tableName=CREDENTIAL; addForeignKeyConstraint baseTableName=FED_CREDENTIAL_ATTRIBU...		\N	3.5.4	\N	\N	3820445829
-2.3.0	bburke@redhat.com	META-INF/jpa-changelog-2.3.0.xml	2022-02-02 16:47:26.541837	31	EXECUTED	\N	createTable tableName=FEDERATED_USER; addPrimaryKey constraintName=CONSTR_FEDERATED_USER, tableName=FEDERATED_USER; dropDefaultValue columnName=TOTP, tableName=USER_ENTITY; dropColumn columnName=TOTP, tableName=USER_ENTITY; addColumn tableName=IDE...		\N	3.5.4	\N	\N	3820445829
-2.4.0	bburke@redhat.com	META-INF/jpa-changelog-2.4.0.xml	2022-02-02 16:47:26.545809	32	EXECUTED	\N	customChange		\N	3.5.4	\N	\N	3820445829
-2.5.0	bburke@redhat.com	META-INF/jpa-changelog-2.5.0.xml	2022-02-02 16:47:26.549823	33	EXECUTED	\N	customChange; modifyDataType columnName=USER_ID, tableName=OFFLINE_USER_SESSION		\N	3.5.4	\N	\N	3820445829
-2.5.0-unicode-oracle	hmlnarik@redhat.com	META-INF/jpa-changelog-2.5.0.xml	2022-02-02 16:47:26.55176	34	MARK_RAN	\N	modifyDataType columnName=DESCRIPTION, tableName=AUTHENTICATION_FLOW; modifyDataType columnName=DESCRIPTION, tableName=CLIENT_TEMPLATE; modifyDataType columnName=DESCRIPTION, tableName=RESOURCE_SERVER_POLICY; modifyDataType columnName=DESCRIPTION,...		\N	3.5.4	\N	\N	3820445829
-2.5.0-unicode-other-dbs	hmlnarik@redhat.com	META-INF/jpa-changelog-2.5.0.xml	2022-02-02 16:47:26.567305	35	EXECUTED	\N	modifyDataType columnName=DESCRIPTION, tableName=AUTHENTICATION_FLOW; modifyDataType columnName=DESCRIPTION, tableName=CLIENT_TEMPLATE; modifyDataType columnName=DESCRIPTION, tableName=RESOURCE_SERVER_POLICY; modifyDataType columnName=DESCRIPTION,...		\N	3.5.4	\N	\N	3820445829
-2.5.0-duplicate-email-support	slawomir@dabek.name	META-INF/jpa-changelog-2.5.0.xml	2022-02-02 16:47:26.570727	36	EXECUTED	\N	addColumn tableName=REALM		\N	3.5.4	\N	\N	3820445829
-2.5.0-unique-group-names	hmlnarik@redhat.com	META-INF/jpa-changelog-2.5.0.xml	2022-02-02 16:47:26.578396	37	EXECUTED	\N	addUniqueConstraint constraintName=SIBLING_NAMES, tableName=KEYCLOAK_GROUP		\N	3.5.4	\N	\N	3820445829
-2.5.1	bburke@redhat.com	META-INF/jpa-changelog-2.5.1.xml	2022-02-02 16:47:26.581391	38	EXECUTED	\N	addColumn tableName=FED_USER_CONSENT		\N	3.5.4	\N	\N	3820445829
-3.0.0	bburke@redhat.com	META-INF/jpa-changelog-3.0.0.xml	2022-02-02 16:47:26.584204	39	EXECUTED	\N	addColumn tableName=IDENTITY_PROVIDER		\N	3.5.4	\N	\N	3820445829
-3.2.0-fix	keycloak	META-INF/jpa-changelog-3.2.0.xml	2022-02-02 16:47:26.585877	40	MARK_RAN	\N	addNotNullConstraint columnName=REALM_ID, tableName=CLIENT_INITIAL_ACCESS		\N	3.5.4	\N	\N	3820445829
-3.2.0-fix-with-keycloak-5416	keycloak	META-INF/jpa-changelog-3.2.0.xml	2022-02-02 16:47:26.587657	41	MARK_RAN	\N	dropIndex indexName=IDX_CLIENT_INIT_ACC_REALM, tableName=CLIENT_INITIAL_ACCESS; addNotNullConstraint columnName=REALM_ID, tableName=CLIENT_INITIAL_ACCESS; createIndex indexName=IDX_CLIENT_INIT_ACC_REALM, tableName=CLIENT_INITIAL_ACCESS		\N	3.5.4	\N	\N	3820445829
-3.2.0-fix-offline-sessions	hmlnarik	META-INF/jpa-changelog-3.2.0.xml	2022-02-02 16:47:26.591561	42	EXECUTED	\N	customChange		\N	3.5.4	\N	\N	3820445829
-3.2.0-fixed	keycloak	META-INF/jpa-changelog-3.2.0.xml	2022-02-02 16:47:26.669981	43	EXECUTED	\N	addColumn tableName=REALM; dropPrimaryKey constraintName=CONSTRAINT_OFFL_CL_SES_PK2, tableName=OFFLINE_CLIENT_SESSION; dropColumn columnName=CLIENT_SESSION_ID, tableName=OFFLINE_CLIENT_SESSION; addPrimaryKey constraintName=CONSTRAINT_OFFL_CL_SES_P...		\N	3.5.4	\N	\N	3820445829
-3.3.0	keycloak	META-INF/jpa-changelog-3.3.0.xml	2022-02-02 16:47:26.673701	44	EXECUTED	\N	addColumn tableName=USER_ENTITY		\N	3.5.4	\N	\N	3820445829
-authz-3.4.0.CR1-resource-server-pk-change-part2-KEYCLOAK-6095	hmlnarik@redhat.com	META-INF/jpa-changelog-authz-3.4.0.CR1.xml	2022-02-02 16:47:26.681987	46	EXECUTED	\N	customChange		\N	3.5.4	\N	\N	3820445829
-authz-3.4.0.CR1-resource-server-pk-change-part3-fixed	glavoie@gmail.com	META-INF/jpa-changelog-authz-3.4.0.CR1.xml	2022-02-02 16:47:26.683661	47	MARK_RAN	\N	dropIndex indexName=IDX_RES_SERV_POL_RES_SERV, tableName=RESOURCE_SERVER_POLICY; dropIndex indexName=IDX_RES_SRV_RES_RES_SRV, tableName=RESOURCE_SERVER_RESOURCE; dropIndex indexName=IDX_RES_SRV_SCOPE_RES_SRV, tableName=RESOURCE_SERVER_SCOPE		\N	3.5.4	\N	\N	3820445829
-authz-3.4.0.CR1-resource-server-pk-change-part3-fixed-nodropindex	glavoie@gmail.com	META-INF/jpa-changelog-authz-3.4.0.CR1.xml	2022-02-02 16:47:26.702743	48	EXECUTED	\N	addNotNullConstraint columnName=RESOURCE_SERVER_CLIENT_ID, tableName=RESOURCE_SERVER_POLICY; addNotNullConstraint columnName=RESOURCE_SERVER_CLIENT_ID, tableName=RESOURCE_SERVER_RESOURCE; addNotNullConstraint columnName=RESOURCE_SERVER_CLIENT_ID, ...		\N	3.5.4	\N	\N	3820445829
-3.4.0	keycloak	META-INF/jpa-changelog-3.4.0.xml	2022-02-02 16:47:26.734467	50	EXECUTED	\N	addPrimaryKey constraintName=CONSTRAINT_REALM_DEFAULT_ROLES, tableName=REALM_DEFAULT_ROLES; addPrimaryKey constraintName=CONSTRAINT_COMPOSITE_ROLE, tableName=COMPOSITE_ROLE; addPrimaryKey constraintName=CONSTR_REALM_DEFAULT_GROUPS, tableName=REALM...		\N	3.5.4	\N	\N	3820445829
-3.4.0-KEYCLOAK-5230	hmlnarik@redhat.com	META-INF/jpa-changelog-3.4.0.xml	2022-02-02 16:47:26.78037	51	EXECUTED	\N	createIndex indexName=IDX_FU_ATTRIBUTE, tableName=FED_USER_ATTRIBUTE; createIndex indexName=IDX_FU_CONSENT, tableName=FED_USER_CONSENT; createIndex indexName=IDX_FU_CONSENT_RU, tableName=FED_USER_CONSENT; createIndex indexName=IDX_FU_CREDENTIAL, t...		\N	3.5.4	\N	\N	3820445829
-3.4.1	psilva@redhat.com	META-INF/jpa-changelog-3.4.1.xml	2022-02-02 16:47:26.783989	52	EXECUTED	\N	modifyDataType columnName=VALUE, tableName=CLIENT_ATTRIBUTES		\N	3.5.4	\N	\N	3820445829
-3.4.2	keycloak	META-INF/jpa-changelog-3.4.2.xml	2022-02-02 16:47:26.786619	53	EXECUTED	\N	update tableName=REALM		\N	3.5.4	\N	\N	3820445829
-3.4.2-KEYCLOAK-5172	mkanis@redhat.com	META-INF/jpa-changelog-3.4.2.xml	2022-02-02 16:47:26.788788	54	EXECUTED	\N	update tableName=CLIENT		\N	3.5.4	\N	\N	3820445829
-4.0.0-KEYCLOAK-6335	bburke@redhat.com	META-INF/jpa-changelog-4.0.0.xml	2022-02-02 16:47:26.794881	55	EXECUTED	\N	createTable tableName=CLIENT_AUTH_FLOW_BINDINGS; addPrimaryKey constraintName=C_CLI_FLOW_BIND, tableName=CLIENT_AUTH_FLOW_BINDINGS		\N	3.5.4	\N	\N	3820445829
-4.0.0-CLEANUP-UNUSED-TABLE	bburke@redhat.com	META-INF/jpa-changelog-4.0.0.xml	2022-02-02 16:47:26.799493	56	EXECUTED	\N	dropTable tableName=CLIENT_IDENTITY_PROV_MAPPING		\N	3.5.4	\N	\N	3820445829
-4.0.0-KEYCLOAK-6228	bburke@redhat.com	META-INF/jpa-changelog-4.0.0.xml	2022-02-02 16:47:26.810686	57	EXECUTED	\N	dropUniqueConstraint constraintName=UK_JKUWUVD56ONTGSUHOGM8UEWRT, tableName=USER_CONSENT; dropNotNullConstraint columnName=CLIENT_ID, tableName=USER_CONSENT; addColumn tableName=USER_CONSENT; addUniqueConstraint constraintName=UK_JKUWUVD56ONTGSUHO...		\N	3.5.4	\N	\N	3820445829
-4.0.0-KEYCLOAK-5579-fixed	mposolda@redhat.com	META-INF/jpa-changelog-4.0.0.xml	2022-02-02 16:47:26.861332	58	EXECUTED	\N	dropForeignKeyConstraint baseTableName=CLIENT_TEMPLATE_ATTRIBUTES, constraintName=FK_CL_TEMPL_ATTR_TEMPL; renameTable newTableName=CLIENT_SCOPE_ATTRIBUTES, oldTableName=CLIENT_TEMPLATE_ATTRIBUTES; renameColumn newColumnName=SCOPE_ID, oldColumnName...		\N	3.5.4	\N	\N	3820445829
-authz-4.0.0.CR1	psilva@redhat.com	META-INF/jpa-changelog-authz-4.0.0.CR1.xml	2022-02-02 16:47:26.877018	59	EXECUTED	\N	createTable tableName=RESOURCE_SERVER_PERM_TICKET; addPrimaryKey constraintName=CONSTRAINT_FAPMT, tableName=RESOURCE_SERVER_PERM_TICKET; addForeignKeyConstraint baseTableName=RESOURCE_SERVER_PERM_TICKET, constraintName=FK_FRSRHO213XCX4WNKOG82SSPMT...		\N	3.5.4	\N	\N	3820445829
-authz-4.0.0.Beta3	psilva@redhat.com	META-INF/jpa-changelog-authz-4.0.0.Beta3.xml	2022-02-02 16:47:26.881203	60	EXECUTED	\N	addColumn tableName=RESOURCE_SERVER_POLICY; addColumn tableName=RESOURCE_SERVER_PERM_TICKET; addForeignKeyConstraint baseTableName=RESOURCE_SERVER_PERM_TICKET, constraintName=FK_FRSRPO2128CX4WNKOG82SSRFY, referencedTableName=RESOURCE_SERVER_POLICY		\N	3.5.4	\N	\N	3820445829
-authz-4.2.0.Final	mhajas@redhat.com	META-INF/jpa-changelog-authz-4.2.0.Final.xml	2022-02-02 16:47:26.886177	61	EXECUTED	\N	createTable tableName=RESOURCE_URIS; addForeignKeyConstraint baseTableName=RESOURCE_URIS, constraintName=FK_RESOURCE_SERVER_URIS, referencedTableName=RESOURCE_SERVER_RESOURCE; customChange; dropColumn columnName=URI, tableName=RESOURCE_SERVER_RESO...		\N	3.5.4	\N	\N	3820445829
-authz-4.2.0.Final-KEYCLOAK-9944	hmlnarik@redhat.com	META-INF/jpa-changelog-authz-4.2.0.Final.xml	2022-02-02 16:47:26.890482	62	EXECUTED	\N	addPrimaryKey constraintName=CONSTRAINT_RESOUR_URIS_PK, tableName=RESOURCE_URIS		\N	3.5.4	\N	\N	3820445829
-4.2.0-KEYCLOAK-6313	wadahiro@gmail.com	META-INF/jpa-changelog-4.2.0.xml	2022-02-02 16:47:26.893518	63	EXECUTED	\N	addColumn tableName=REQUIRED_ACTION_PROVIDER		\N	3.5.4	\N	\N	3820445829
-4.3.0-KEYCLOAK-7984	wadahiro@gmail.com	META-INF/jpa-changelog-4.3.0.xml	2022-02-02 16:47:26.895621	64	EXECUTED	\N	update tableName=REQUIRED_ACTION_PROVIDER		\N	3.5.4	\N	\N	3820445829
-4.6.0-KEYCLOAK-7950	psilva@redhat.com	META-INF/jpa-changelog-4.6.0.xml	2022-02-02 16:47:26.89756	65	EXECUTED	\N	update tableName=RESOURCE_SERVER_RESOURCE		\N	3.5.4	\N	\N	3820445829
-4.6.0-KEYCLOAK-8377	keycloak	META-INF/jpa-changelog-4.6.0.xml	2022-02-02 16:47:26.908059	66	EXECUTED	\N	createTable tableName=ROLE_ATTRIBUTE; addPrimaryKey constraintName=CONSTRAINT_ROLE_ATTRIBUTE_PK, tableName=ROLE_ATTRIBUTE; addForeignKeyConstraint baseTableName=ROLE_ATTRIBUTE, constraintName=FK_ROLE_ATTRIBUTE_ID, referencedTableName=KEYCLOAK_ROLE...		\N	3.5.4	\N	\N	3820445829
-4.6.0-KEYCLOAK-8555	gideonray@gmail.com	META-INF/jpa-changelog-4.6.0.xml	2022-02-02 16:47:26.912693	67	EXECUTED	\N	createIndex indexName=IDX_COMPONENT_PROVIDER_TYPE, tableName=COMPONENT		\N	3.5.4	\N	\N	3820445829
-4.7.0-KEYCLOAK-1267	sguilhen@redhat.com	META-INF/jpa-changelog-4.7.0.xml	2022-02-02 16:47:26.915771	68	EXECUTED	\N	addColumn tableName=REALM		\N	3.5.4	\N	\N	3820445829
-4.7.0-KEYCLOAK-7275	keycloak	META-INF/jpa-changelog-4.7.0.xml	2022-02-02 16:47:26.924465	69	EXECUTED	\N	renameColumn newColumnName=CREATED_ON, oldColumnName=LAST_SESSION_REFRESH, tableName=OFFLINE_USER_SESSION; addNotNullConstraint columnName=CREATED_ON, tableName=OFFLINE_USER_SESSION; addColumn tableName=OFFLINE_USER_SESSION; customChange; createIn...		\N	3.5.4	\N	\N	3820445829
-authz-7.0.0-KEYCLOAK-10443	psilva@redhat.com	META-INF/jpa-changelog-authz-7.0.0.xml	2022-02-02 16:47:26.93061	71	EXECUTED	\N	addColumn tableName=RESOURCE_SERVER		\N	3.5.4	\N	\N	3820445829
-8.0.0-adding-credential-columns	keycloak	META-INF/jpa-changelog-8.0.0.xml	2022-02-02 16:47:26.933771	72	EXECUTED	\N	addColumn tableName=CREDENTIAL; addColumn tableName=FED_USER_CREDENTIAL		\N	3.5.4	\N	\N	3820445829
+1.6.1	mposolda@redhat.com	META-INF/jpa-changelog-1.6.1.xml	2022-02-02 16:47:26.306641	17	EXECUTED	9:d41d8cd98f00b204e9800998ecf8427e	empty		\N	3.5.4	\N	\N	3820445829
+authz-2.5.1	psilva@redhat.com	META-INF/jpa-changelog-authz-2.5.1.xml	2022-02-02 16:47:26.484459	28	EXECUTED	9:44bae577f551b3738740281eceb4ea70	update tableName=RESOURCE_SERVER_POLICY		\N	3.5.4	\N	\N	3820445829
 8.0.0-updating-credential-data-not-oracle	keycloak	META-INF/jpa-changelog-8.0.0.xml	2022-02-02 16:47:26.937673	73	EXECUTED	\N	update tableName=CREDENTIAL; update tableName=CREDENTIAL; update tableName=CREDENTIAL; update tableName=FED_USER_CREDENTIAL; update tableName=FED_USER_CREDENTIAL; update tableName=FED_USER_CREDENTIAL		\N	3.5.4	\N	\N	3820445829
 8.0.0-updating-credential-data-oracle	keycloak	META-INF/jpa-changelog-8.0.0.xml	2022-02-02 16:47:26.939218	74	MARK_RAN	\N	update tableName=CREDENTIAL; update tableName=CREDENTIAL; update tableName=CREDENTIAL; update tableName=FED_USER_CREDENTIAL; update tableName=FED_USER_CREDENTIAL; update tableName=FED_USER_CREDENTIAL		\N	3.5.4	\N	\N	3820445829
-8.0.0-credential-cleanup-fixed	keycloak	META-INF/jpa-changelog-8.0.0.xml	2022-02-02 16:47:26.945819	75	EXECUTED	\N	dropDefaultValue columnName=COUNTER, tableName=CREDENTIAL; dropDefaultValue columnName=DIGITS, tableName=CREDENTIAL; dropDefaultValue columnName=PERIOD, tableName=CREDENTIAL; dropDefaultValue columnName=ALGORITHM, tableName=CREDENTIAL; dropColumn ...		\N	3.5.4	\N	\N	3820445829
-8.0.0-resource-tag-support	keycloak	META-INF/jpa-changelog-8.0.0.xml	2022-02-02 16:47:26.950255	76	EXECUTED	\N	addColumn tableName=MIGRATION_MODEL; createIndex indexName=IDX_UPDATE_TIME, tableName=MIGRATION_MODEL		\N	3.5.4	\N	\N	3820445829
-9.0.0-always-display-client	keycloak	META-INF/jpa-changelog-9.0.0.xml	2022-02-02 16:47:26.955505	77	EXECUTED	\N	addColumn tableName=CLIENT		\N	3.5.4	\N	\N	3820445829
-9.0.0-drop-constraints-for-column-increase	keycloak	META-INF/jpa-changelog-9.0.0.xml	2022-02-02 16:47:26.957216	78	MARK_RAN	\N	dropUniqueConstraint constraintName=UK_FRSR6T700S9V50BU18WS5PMT, tableName=RESOURCE_SERVER_PERM_TICKET; dropUniqueConstraint constraintName=UK_FRSR6T700S9V50BU18WS5HA6, tableName=RESOURCE_SERVER_RESOURCE; dropPrimaryKey constraintName=CONSTRAINT_O...		\N	3.5.4	\N	\N	3820445829
-9.0.0-increase-column-size-federated-fk	keycloak	META-INF/jpa-changelog-9.0.0.xml	2022-02-02 16:47:26.966746	79	EXECUTED	\N	modifyDataType columnName=CLIENT_ID, tableName=FED_USER_CONSENT; modifyDataType columnName=CLIENT_REALM_CONSTRAINT, tableName=KEYCLOAK_ROLE; modifyDataType columnName=OWNER, tableName=RESOURCE_SERVER_POLICY; modifyDataType columnName=CLIENT_ID, ta...		\N	3.5.4	\N	\N	3820445829
-9.0.0-recreate-constraints-after-column-increase	keycloak	META-INF/jpa-changelog-9.0.0.xml	2022-02-02 16:47:26.969643	80	MARK_RAN	\N	addNotNullConstraint columnName=CLIENT_ID, tableName=OFFLINE_CLIENT_SESSION; addNotNullConstraint columnName=OWNER, tableName=RESOURCE_SERVER_PERM_TICKET; addNotNullConstraint columnName=REQUESTER, tableName=RESOURCE_SERVER_PERM_TICKET; addNotNull...		\N	3.5.4	\N	\N	3820445829
-9.0.1-add-index-to-client.client_id	keycloak	META-INF/jpa-changelog-9.0.1.xml	2022-02-02 16:47:26.975764	81	EXECUTED	\N	createIndex indexName=IDX_CLIENT_ID, tableName=CLIENT		\N	3.5.4	\N	\N	3820445829
-9.0.1-KEYCLOAK-12579-drop-constraints	keycloak	META-INF/jpa-changelog-9.0.1.xml	2022-02-02 16:47:26.977227	82	MARK_RAN	\N	dropUniqueConstraint constraintName=SIBLING_NAMES, tableName=KEYCLOAK_GROUP		\N	3.5.4	\N	\N	3820445829
-9.0.1-KEYCLOAK-12579-add-not-null-constraint	keycloak	META-INF/jpa-changelog-9.0.1.xml	2022-02-02 16:47:26.980058	83	EXECUTED	\N	addNotNullConstraint columnName=PARENT_GROUP, tableName=KEYCLOAK_GROUP		\N	3.5.4	\N	\N	3820445829
-9.0.1-add-index-to-events	keycloak	META-INF/jpa-changelog-9.0.1.xml	2022-02-02 16:47:26.985465	85	EXECUTED	\N	createIndex indexName=IDX_EVENT_TIME, tableName=EVENT_ENTITY		\N	3.5.4	\N	\N	3820445829
-map-remove-ri	keycloak	META-INF/jpa-changelog-11.0.0.xml	2022-02-02 16:47:26.98869	86	EXECUTED	\N	dropForeignKeyConstraint baseTableName=REALM, constraintName=FK_TRAF444KK6QRKMS7N56AIWQ5Y; dropForeignKeyConstraint baseTableName=KEYCLOAK_ROLE, constraintName=FK_KJHO5LE2C0RAL09FL8CM9WFW9		\N	3.5.4	\N	\N	3820445829
-map-remove-ri	keycloak	META-INF/jpa-changelog-12.0.0.xml	2022-02-02 16:47:26.992854	87	EXECUTED	\N	dropForeignKeyConstraint baseTableName=REALM_DEFAULT_GROUPS, constraintName=FK_DEF_GROUPS_GROUP; dropForeignKeyConstraint baseTableName=REALM_DEFAULT_ROLES, constraintName=FK_H4WPD7W4HSOOLNI3H0SW7BTJE; dropForeignKeyConstraint baseTableName=CLIENT...		\N	3.5.4	\N	\N	3820445829
-12.1.0-add-realm-localization-table	keycloak	META-INF/jpa-changelog-12.0.0.xml	2022-02-02 16:47:26.999694	88	EXECUTED	\N	createTable tableName=REALM_LOCALIZATIONS; addPrimaryKey tableName=REALM_LOCALIZATIONS		\N	3.5.4	\N	\N	3820445829
-8.0.0-updating-credential-data-not-oracle-fixed	keycloak	META-INF/jpa-changelog-8.0.0.xml	2023-01-09 14:34:23.080082	89	MARK_RAN	8:83f7a671792ca98b3cbd3a1a34862d3d	update tableName=CREDENTIAL; update tableName=CREDENTIAL; update tableName=CREDENTIAL; update tableName=FED_USER_CREDENTIAL; update tableName=FED_USER_CREDENTIAL; update tableName=FED_USER_CREDENTIAL		\N	4.8.0	\N	\N	3274862955
-8.0.0-updating-credential-data-oracle-fixed	keycloak	META-INF/jpa-changelog-8.0.0.xml	2023-01-09 14:34:23.099857	90	MARK_RAN	8:f58ad148698cf30707a6efbdf8061aa7	update tableName=CREDENTIAL; update tableName=CREDENTIAL; update tableName=CREDENTIAL; update tableName=FED_USER_CREDENTIAL; update tableName=FED_USER_CREDENTIAL; update tableName=FED_USER_CREDENTIAL		\N	4.8.0	\N	\N	3274862955
-default-roles	keycloak	META-INF/jpa-changelog-13.0.0.xml	2023-01-09 14:34:23.144776	91	EXECUTED	8:72d03345fda8e2f17093d08801947773	addColumn tableName=REALM; customChange		\N	4.8.0	\N	\N	3274862955
-default-roles-cleanup	keycloak	META-INF/jpa-changelog-13.0.0.xml	2023-01-09 14:34:23.155298	92	EXECUTED	8:61c9233951bd96ffecd9ba75f7d978a4	dropTable tableName=REALM_DEFAULT_ROLES; dropTable tableName=CLIENT_DEFAULT_ROLES		\N	4.8.0	\N	\N	3274862955
-13.0.0-KEYCLOAK-16844	keycloak	META-INF/jpa-changelog-13.0.0.xml	2023-01-09 14:34:23.162911	93	EXECUTED	8:ea82e6ad945cec250af6372767b25525	createIndex indexName=IDX_OFFLINE_USS_PRELOAD, tableName=OFFLINE_USER_SESSION		\N	4.8.0	\N	\N	3274862955
-map-remove-ri-13.0.0	keycloak	META-INF/jpa-changelog-13.0.0.xml	2023-01-09 14:34:23.17617	94	EXECUTED	8:d3f4a33f41d960ddacd7e2ef30d126b3	dropForeignKeyConstraint baseTableName=DEFAULT_CLIENT_SCOPE, constraintName=FK_R_DEF_CLI_SCOPE_SCOPE; dropForeignKeyConstraint baseTableName=CLIENT_SCOPE_CLIENT, constraintName=FK_C_CLI_SCOPE_SCOPE; dropForeignKeyConstraint baseTableName=CLIENT_SC...		\N	4.8.0	\N	\N	3274862955
-13.0.0-KEYCLOAK-17992-drop-constraints	keycloak	META-INF/jpa-changelog-13.0.0.xml	2023-01-09 14:34:23.1803	95	MARK_RAN	8:1284a27fbd049d65831cb6fc07c8a783	dropPrimaryKey constraintName=C_CLI_SCOPE_BIND, tableName=CLIENT_SCOPE_CLIENT; dropIndex indexName=IDX_CLSCOPE_CL, tableName=CLIENT_SCOPE_CLIENT; dropIndex indexName=IDX_CL_CLSCOPE, tableName=CLIENT_SCOPE_CLIENT		\N	4.8.0	\N	\N	3274862955
-13.0.0-increase-column-size-federated	keycloak	META-INF/jpa-changelog-13.0.0.xml	2023-01-09 14:34:23.190613	96	EXECUTED	8:9d11b619db2ae27c25853b8a37cd0dea	modifyDataType columnName=CLIENT_ID, tableName=CLIENT_SCOPE_CLIENT; modifyDataType columnName=SCOPE_ID, tableName=CLIENT_SCOPE_CLIENT		\N	4.8.0	\N	\N	3274862955
-13.0.0-KEYCLOAK-17992-recreate-constraints	keycloak	META-INF/jpa-changelog-13.0.0.xml	2023-01-09 14:34:23.193934	97	MARK_RAN	8:3002bb3997451bb9e8bac5c5cd8d6327	addNotNullConstraint columnName=CLIENT_ID, tableName=CLIENT_SCOPE_CLIENT; addNotNullConstraint columnName=SCOPE_ID, tableName=CLIENT_SCOPE_CLIENT; addPrimaryKey constraintName=C_CLI_SCOPE_BIND, tableName=CLIENT_SCOPE_CLIENT; createIndex indexName=...		\N	4.8.0	\N	\N	3274862955
-json-string-accomodation-fixed	keycloak	META-INF/jpa-changelog-13.0.0.xml	2023-01-09 14:34:23.202965	98	EXECUTED	8:dfbee0d6237a23ef4ccbb7a4e063c163	addColumn tableName=REALM_ATTRIBUTE; update tableName=REALM_ATTRIBUTE; dropColumn columnName=VALUE, tableName=REALM_ATTRIBUTE; renameColumn newColumnName=VALUE, oldColumnName=VALUE_NEW, tableName=REALM_ATTRIBUTE		\N	4.8.0	\N	\N	3274862955
-14.0.0-KEYCLOAK-11019	keycloak	META-INF/jpa-changelog-14.0.0.xml	2023-01-09 14:34:23.212244	99	EXECUTED	8:75f3e372df18d38c62734eebb986b960	createIndex indexName=IDX_OFFLINE_CSS_PRELOAD, tableName=OFFLINE_CLIENT_SESSION; createIndex indexName=IDX_OFFLINE_USS_BY_USER, tableName=OFFLINE_USER_SESSION; createIndex indexName=IDX_OFFLINE_USS_BY_USERSESS, tableName=OFFLINE_USER_SESSION		\N	4.8.0	\N	\N	3274862955
-14.0.0-KEYCLOAK-18286	keycloak	META-INF/jpa-changelog-14.0.0.xml	2023-01-09 14:34:23.2164	100	MARK_RAN	8:7fee73eddf84a6035691512c85637eef	createIndex indexName=IDX_CLIENT_ATT_BY_NAME_VALUE, tableName=CLIENT_ATTRIBUTES		\N	4.8.0	\N	\N	3274862955
-14.0.0-KEYCLOAK-18286-revert	keycloak	META-INF/jpa-changelog-14.0.0.xml	2023-01-09 14:34:23.227895	101	MARK_RAN	8:7a11134ab12820f999fbf3bb13c3adc8	dropIndex indexName=IDX_CLIENT_ATT_BY_NAME_VALUE, tableName=CLIENT_ATTRIBUTES		\N	4.8.0	\N	\N	3274862955
-14.0.0-KEYCLOAK-18286-supported-dbs	keycloak	META-INF/jpa-changelog-14.0.0.xml	2023-01-09 14:34:23.235491	102	EXECUTED	8:c0f6eaac1f3be773ffe54cb5b8482b70	createIndex indexName=IDX_CLIENT_ATT_BY_NAME_VALUE, tableName=CLIENT_ATTRIBUTES		\N	4.8.0	\N	\N	3274862955
-14.0.0-KEYCLOAK-18286-unsupported-dbs	keycloak	META-INF/jpa-changelog-14.0.0.xml	2023-01-09 14:34:23.238498	103	MARK_RAN	8:18186f0008b86e0f0f49b0c4d0e842ac	createIndex indexName=IDX_CLIENT_ATT_BY_NAME_VALUE, tableName=CLIENT_ATTRIBUTES		\N	4.8.0	\N	\N	3274862955
-KEYCLOAK-17267-add-index-to-user-attributes	keycloak	META-INF/jpa-changelog-14.0.0.xml	2023-01-09 14:34:23.24435	104	EXECUTED	8:09c2780bcb23b310a7019d217dc7b433	createIndex indexName=IDX_USER_ATTRIBUTE_NAME, tableName=USER_ATTRIBUTE		\N	4.8.0	\N	\N	3274862955
-KEYCLOAK-18146-add-saml-art-binding-identifier	keycloak	META-INF/jpa-changelog-14.0.0.xml	2023-01-09 14:34:23.250444	105	EXECUTED	8:276a44955eab693c970a42880197fff2	customChange		\N	4.8.0	\N	\N	3274862955
-15.0.0-KEYCLOAK-18467	keycloak	META-INF/jpa-changelog-15.0.0.xml	2023-01-09 14:34:23.261701	106	EXECUTED	8:ba8ee3b694d043f2bfc1a1079d0760d7	addColumn tableName=REALM_LOCALIZATIONS; update tableName=REALM_LOCALIZATIONS; dropColumn columnName=TEXTS, tableName=REALM_LOCALIZATIONS; renameColumn newColumnName=TEXTS, oldColumnName=TEXTS_NEW, tableName=REALM_LOCALIZATIONS; addNotNullConstrai...		\N	4.8.0	\N	\N	3274862955
-17.0.0-9562	keycloak	META-INF/jpa-changelog-17.0.0.xml	2023-01-09 14:34:23.269577	107	EXECUTED	8:5e06b1d75f5d17685485e610c2851b17	createIndex indexName=IDX_USER_SERVICE_ACCOUNT, tableName=USER_ENTITY		\N	4.8.0	\N	\N	3274862955
-18.0.0-10625-IDX_ADMIN_EVENT_TIME	keycloak	META-INF/jpa-changelog-18.0.0.xml	2023-01-09 14:34:23.276738	108	EXECUTED	8:4b80546c1dc550ac552ee7b24a4ab7c0	createIndex indexName=IDX_ADMIN_EVENT_TIME, tableName=ADMIN_EVENT_ENTITY		\N	4.8.0	\N	\N	3274862955
-19.0.0-10135	keycloak	META-INF/jpa-changelog-19.0.0.xml	2023-01-09 14:34:23.297485	109	EXECUTED	8:af510cd1bb2ab6339c45372f3e491696	customChange		\N	4.8.0	\N	\N	3274862955
-20.0.0-12964-supported-dbs	keycloak	META-INF/jpa-changelog-20.0.0.xml	2023-01-09 14:34:23.305463	110	EXECUTED	8:05c99fc610845ef66ee812b7921af0ef	createIndex indexName=IDX_GROUP_ATT_BY_NAME_VALUE, tableName=GROUP_ATTRIBUTE		\N	4.8.0	\N	\N	3274862955
-20.0.0-12964-unsupported-dbs	keycloak	META-INF/jpa-changelog-20.0.0.xml	2023-01-09 14:34:23.309005	111	MARK_RAN	8:314e803baf2f1ec315b3464e398b8247	createIndex indexName=IDX_GROUP_ATT_BY_NAME_VALUE, tableName=GROUP_ATTRIBUTE		\N	4.8.0	\N	\N	3274862955
-client-attributes-string-accomodation-fixed	keycloak	META-INF/jpa-changelog-20.0.0.xml	2023-01-09 14:34:23.318788	112	EXECUTED	8:56e4677e7e12556f70b604c573840100	addColumn tableName=CLIENT_ATTRIBUTES; update tableName=CLIENT_ATTRIBUTES; dropColumn columnName=VALUE, tableName=CLIENT_ATTRIBUTES; renameColumn newColumnName=VALUE, oldColumnName=VALUE_NEW, tableName=CLIENT_ATTRIBUTES		\N	4.8.0	\N	\N	3274862955
+3.4.2	keycloak	META-INF/jpa-changelog-3.4.2.xml	2022-02-02 16:47:26.786619	53	EXECUTED	9:8f23e334dbc59f82e0a328373ca6ced0	update tableName=REALM		\N	3.5.4	\N	\N	3820445829
+1.0.0.Final-KEYCLOAK-5461	sthorger@redhat.com	META-INF/jpa-changelog-1.0.0.Final.xml	2022-02-02 16:47:26.017844	1	EXECUTED	9:6f1016664e21e16d26517a4418f5e3df	createTable tableName=APPLICATION_DEFAULT_ROLES; createTable tableName=CLIENT; createTable tableName=CLIENT_SESSION; createTable tableName=CLIENT_SESSION_ROLE; createTable tableName=COMPOSITE_ROLE; createTable tableName=CREDENTIAL; createTable tab...		\N	3.5.4	\N	\N	3820445829
+1.0.0.Final-KEYCLOAK-5461	sthorger@redhat.com	META-INF/db2-jpa-changelog-1.0.0.Final.xml	2022-02-02 16:47:26.03122	2	MARK_RAN	9:828775b1596a07d1200ba1d49e5e3941	createTable tableName=APPLICATION_DEFAULT_ROLES; createTable tableName=CLIENT; createTable tableName=CLIENT_SESSION; createTable tableName=CLIENT_SESSION_ROLE; createTable tableName=COMPOSITE_ROLE; createTable tableName=CREDENTIAL; createTable tab...		\N	3.5.4	\N	\N	3820445829
+1.1.0.Beta1	sthorger@redhat.com	META-INF/jpa-changelog-1.1.0.Beta1.xml	2022-02-02 16:47:26.06085	3	EXECUTED	9:5f090e44a7d595883c1fb61f4b41fd38	delete tableName=CLIENT_SESSION_ROLE; delete tableName=CLIENT_SESSION; delete tableName=USER_SESSION; createTable tableName=CLIENT_ATTRIBUTES; createTable tableName=CLIENT_SESSION_NOTE; createTable tableName=APP_NODE_REGISTRATIONS; addColumn table...		\N	3.5.4	\N	\N	3820445829
+1.1.0.Final	sthorger@redhat.com	META-INF/jpa-changelog-1.1.0.Final.xml	2022-02-02 16:47:26.065284	4	EXECUTED	9:c07e577387a3d2c04d1adc9aaad8730e	renameColumn newColumnName=EVENT_TIME, oldColumnName=TIME, tableName=EVENT_ENTITY		\N	3.5.4	\N	\N	3820445829
+1.2.0.Beta1	psilva@redhat.com	META-INF/jpa-changelog-1.2.0.Beta1.xml	2022-02-02 16:47:26.130908	5	EXECUTED	9:b68ce996c655922dbcd2fe6b6ae72686	delete tableName=CLIENT_SESSION_ROLE; delete tableName=CLIENT_SESSION_NOTE; delete tableName=CLIENT_SESSION; delete tableName=USER_SESSION; createTable tableName=PROTOCOL_MAPPER; createTable tableName=PROTOCOL_MAPPER_CONFIG; createTable tableName=...		\N	3.5.4	\N	\N	3820445829
+1.2.0.Beta1	psilva@redhat.com	META-INF/db2-jpa-changelog-1.2.0.Beta1.xml	2022-02-02 16:47:26.133863	6	MARK_RAN	9:543b5c9989f024fe35c6f6c5a97de88e	delete tableName=CLIENT_SESSION_ROLE; delete tableName=CLIENT_SESSION_NOTE; delete tableName=CLIENT_SESSION; delete tableName=USER_SESSION; createTable tableName=PROTOCOL_MAPPER; createTable tableName=PROTOCOL_MAPPER_CONFIG; createTable tableName=...		\N	3.5.4	\N	\N	3820445829
+1.2.0.RC1	bburke@redhat.com	META-INF/jpa-changelog-1.2.0.CR1.xml	2022-02-02 16:47:26.183318	7	EXECUTED	9:765afebbe21cf5bbca048e632df38336	delete tableName=CLIENT_SESSION_ROLE; delete tableName=CLIENT_SESSION_NOTE; delete tableName=CLIENT_SESSION; delete tableName=USER_SESSION_NOTE; delete tableName=USER_SESSION; createTable tableName=MIGRATION_MODEL; createTable tableName=IDENTITY_P...		\N	3.5.4	\N	\N	3820445829
+1.2.0.RC1	bburke@redhat.com	META-INF/db2-jpa-changelog-1.2.0.CR1.xml	2022-02-02 16:47:26.186858	8	MARK_RAN	9:db4a145ba11a6fdaefb397f6dbf829a1	delete tableName=CLIENT_SESSION_ROLE; delete tableName=CLIENT_SESSION_NOTE; delete tableName=CLIENT_SESSION; delete tableName=USER_SESSION_NOTE; delete tableName=USER_SESSION; createTable tableName=MIGRATION_MODEL; createTable tableName=IDENTITY_P...		\N	3.5.4	\N	\N	3820445829
+1.2.0.Final	keycloak	META-INF/jpa-changelog-1.2.0.Final.xml	2022-02-02 16:47:26.19172	9	EXECUTED	9:9d05c7be10cdb873f8bcb41bc3a8ab23	update tableName=CLIENT; update tableName=CLIENT; update tableName=CLIENT		\N	3.5.4	\N	\N	3820445829
+1.3.0	bburke@redhat.com	META-INF/jpa-changelog-1.3.0.xml	2022-02-02 16:47:26.242162	10	EXECUTED	9:18593702353128d53111f9b1ff0b82b8	delete tableName=CLIENT_SESSION_ROLE; delete tableName=CLIENT_SESSION_PROT_MAPPER; delete tableName=CLIENT_SESSION_NOTE; delete tableName=CLIENT_SESSION; delete tableName=USER_SESSION_NOTE; delete tableName=USER_SESSION; createTable tableName=ADMI...		\N	3.5.4	\N	\N	3820445829
+1.4.0	bburke@redhat.com	META-INF/jpa-changelog-1.4.0.xml	2022-02-02 16:47:26.275929	11	EXECUTED	9:6122efe5f090e41a85c0f1c9e52cbb62	delete tableName=CLIENT_SESSION_AUTH_STATUS; delete tableName=CLIENT_SESSION_ROLE; delete tableName=CLIENT_SESSION_PROT_MAPPER; delete tableName=CLIENT_SESSION_NOTE; delete tableName=CLIENT_SESSION; delete tableName=USER_SESSION_NOTE; delete table...		\N	3.5.4	\N	\N	3820445829
+1.4.0	bburke@redhat.com	META-INF/db2-jpa-changelog-1.4.0.xml	2022-02-02 16:47:26.278548	12	MARK_RAN	9:e1ff28bf7568451453f844c5d54bb0b5	delete tableName=CLIENT_SESSION_AUTH_STATUS; delete tableName=CLIENT_SESSION_ROLE; delete tableName=CLIENT_SESSION_PROT_MAPPER; delete tableName=CLIENT_SESSION_NOTE; delete tableName=CLIENT_SESSION; delete tableName=USER_SESSION_NOTE; delete table...		\N	3.5.4	\N	\N	3820445829
+1.5.0	bburke@redhat.com	META-INF/jpa-changelog-1.5.0.xml	2022-02-02 16:47:26.287616	13	EXECUTED	9:7af32cd8957fbc069f796b61217483fd	delete tableName=CLIENT_SESSION_AUTH_STATUS; delete tableName=CLIENT_SESSION_ROLE; delete tableName=CLIENT_SESSION_PROT_MAPPER; delete tableName=CLIENT_SESSION_NOTE; delete tableName=CLIENT_SESSION; delete tableName=USER_SESSION_NOTE; delete table...		\N	3.5.4	\N	\N	3820445829
+1.6.1_from15	mposolda@redhat.com	META-INF/jpa-changelog-1.6.1.xml	2022-02-02 16:47:26.299798	14	EXECUTED	9:6005e15e84714cd83226bf7879f54190	addColumn tableName=REALM; addColumn tableName=KEYCLOAK_ROLE; addColumn tableName=CLIENT; createTable tableName=OFFLINE_USER_SESSION; createTable tableName=OFFLINE_CLIENT_SESSION; addPrimaryKey constraintName=CONSTRAINT_OFFL_US_SES_PK2, tableName=...		\N	3.5.4	\N	\N	3820445829
+1.6.1_from16-pre	mposolda@redhat.com	META-INF/jpa-changelog-1.6.1.xml	2022-02-02 16:47:26.302088	15	MARK_RAN	9:bf656f5a2b055d07f314431cae76f06c	delete tableName=OFFLINE_CLIENT_SESSION; delete tableName=OFFLINE_USER_SESSION		\N	3.5.4	\N	\N	3820445829
+1.6.1_from16	mposolda@redhat.com	META-INF/jpa-changelog-1.6.1.xml	2022-02-02 16:47:26.303889	16	MARK_RAN	9:f8dadc9284440469dcf71e25ca6ab99b	dropPrimaryKey constraintName=CONSTRAINT_OFFLINE_US_SES_PK, tableName=OFFLINE_USER_SESSION; dropPrimaryKey constraintName=CONSTRAINT_OFFLINE_CL_SES_PK, tableName=OFFLINE_CLIENT_SESSION; addColumn tableName=OFFLINE_USER_SESSION; update tableName=OF...		\N	3.5.4	\N	\N	3820445829
+1.7.0	bburke@redhat.com	META-INF/jpa-changelog-1.7.0.xml	2022-02-02 16:47:26.338791	18	EXECUTED	9:3368ff0be4c2855ee2dd9ca813b38d8e	createTable tableName=KEYCLOAK_GROUP; createTable tableName=GROUP_ROLE_MAPPING; createTable tableName=GROUP_ATTRIBUTE; createTable tableName=USER_GROUP_MEMBERSHIP; createTable tableName=REALM_DEFAULT_GROUPS; addColumn tableName=IDENTITY_PROVIDER; ...		\N	3.5.4	\N	\N	3820445829
+1.8.0	mposolda@redhat.com	META-INF/jpa-changelog-1.8.0.xml	2022-02-02 16:47:26.381463	19	EXECUTED	9:8ac2fb5dd030b24c0570a763ed75ed20	addColumn tableName=IDENTITY_PROVIDER; createTable tableName=CLIENT_TEMPLATE; createTable tableName=CLIENT_TEMPLATE_ATTRIBUTES; createTable tableName=TEMPLATE_SCOPE_MAPPING; dropNotNullConstraint columnName=CLIENT_ID, tableName=PROTOCOL_MAPPER; ad...		\N	3.5.4	\N	\N	3820445829
+1.8.0-2	keycloak	META-INF/jpa-changelog-1.8.0.xml	2022-02-02 16:47:26.390165	20	EXECUTED	9:f91ddca9b19743db60e3057679810e6c	dropDefaultValue columnName=ALGORITHM, tableName=CREDENTIAL; update tableName=CREDENTIAL		\N	3.5.4	\N	\N	3820445829
+1.8.0	mposolda@redhat.com	META-INF/db2-jpa-changelog-1.8.0.xml	2022-02-02 16:47:26.392862	21	MARK_RAN	9:831e82914316dc8a57dc09d755f23c51	addColumn tableName=IDENTITY_PROVIDER; createTable tableName=CLIENT_TEMPLATE; createTable tableName=CLIENT_TEMPLATE_ATTRIBUTES; createTable tableName=TEMPLATE_SCOPE_MAPPING; dropNotNullConstraint columnName=CLIENT_ID, tableName=PROTOCOL_MAPPER; ad...		\N	3.5.4	\N	\N	3820445829
+1.8.0-2	keycloak	META-INF/db2-jpa-changelog-1.8.0.xml	2022-02-02 16:47:26.395652	22	MARK_RAN	9:f91ddca9b19743db60e3057679810e6c	dropDefaultValue columnName=ALGORITHM, tableName=CREDENTIAL; update tableName=CREDENTIAL		\N	3.5.4	\N	\N	3820445829
+1.9.0	mposolda@redhat.com	META-INF/jpa-changelog-1.9.0.xml	2022-02-02 16:47:26.40969	23	EXECUTED	9:bc3d0f9e823a69dc21e23e94c7a94bb1	update tableName=REALM; update tableName=REALM; update tableName=REALM; update tableName=REALM; update tableName=CREDENTIAL; update tableName=CREDENTIAL; update tableName=CREDENTIAL; update tableName=REALM; update tableName=REALM; customChange; dr...		\N	3.5.4	\N	\N	3820445829
+1.9.1	keycloak	META-INF/jpa-changelog-1.9.1.xml	2022-02-02 16:47:26.414344	24	EXECUTED	9:c9999da42f543575ab790e76439a2679	modifyDataType columnName=PRIVATE_KEY, tableName=REALM; modifyDataType columnName=PUBLIC_KEY, tableName=REALM; modifyDataType columnName=CERTIFICATE, tableName=REALM		\N	3.5.4	\N	\N	3820445829
+1.9.1	keycloak	META-INF/db2-jpa-changelog-1.9.1.xml	2022-02-02 16:47:26.416193	25	MARK_RAN	9:0d6c65c6f58732d81569e77b10ba301d	modifyDataType columnName=PRIVATE_KEY, tableName=REALM; modifyDataType columnName=CERTIFICATE, tableName=REALM		\N	3.5.4	\N	\N	3820445829
+1.9.2	keycloak	META-INF/jpa-changelog-1.9.2.xml	2022-02-02 16:47:26.437367	26	EXECUTED	9:fc576660fc016ae53d2d4778d84d86d0	createIndex indexName=IDX_USER_EMAIL, tableName=USER_ENTITY; createIndex indexName=IDX_USER_ROLE_MAPPING, tableName=USER_ROLE_MAPPING; createIndex indexName=IDX_USER_GROUP_MAPPING, tableName=USER_GROUP_MEMBERSHIP; createIndex indexName=IDX_USER_CO...		\N	3.5.4	\N	\N	3820445829
+authz-2.0.0	psilva@redhat.com	META-INF/jpa-changelog-authz-2.0.0.xml	2022-02-02 16:47:26.481647	27	EXECUTED	9:43ed6b0da89ff77206289e87eaa9c024	createTable tableName=RESOURCE_SERVER; addPrimaryKey constraintName=CONSTRAINT_FARS, tableName=RESOURCE_SERVER; addUniqueConstraint constraintName=UK_AU8TT6T700S9V50BU18WS5HA6, tableName=RESOURCE_SERVER; createTable tableName=RESOURCE_SERVER_RESOU...		\N	3.5.4	\N	\N	3820445829
+2.1.0-KEYCLOAK-5461	bburke@redhat.com	META-INF/jpa-changelog-2.1.0.xml	2022-02-02 16:47:26.523006	29	EXECUTED	9:bd88e1f833df0420b01e114533aee5e8	createTable tableName=BROKER_LINK; createTable tableName=FED_USER_ATTRIBUTE; createTable tableName=FED_USER_CONSENT; createTable tableName=FED_USER_CONSENT_ROLE; createTable tableName=FED_USER_CONSENT_PROT_MAPPER; createTable tableName=FED_USER_CR...		\N	3.5.4	\N	\N	3820445829
+2.2.0	bburke@redhat.com	META-INF/jpa-changelog-2.2.0.xml	2022-02-02 16:47:26.532066	30	EXECUTED	9:a7022af5267f019d020edfe316ef4371	addColumn tableName=ADMIN_EVENT_ENTITY; createTable tableName=CREDENTIAL_ATTRIBUTE; createTable tableName=FED_CREDENTIAL_ATTRIBUTE; modifyDataType columnName=VALUE, tableName=CREDENTIAL; addForeignKeyConstraint baseTableName=FED_CREDENTIAL_ATTRIBU...		\N	3.5.4	\N	\N	3820445829
+2.3.0	bburke@redhat.com	META-INF/jpa-changelog-2.3.0.xml	2022-02-02 16:47:26.541837	31	EXECUTED	9:fc155c394040654d6a79227e56f5e25a	createTable tableName=FEDERATED_USER; addPrimaryKey constraintName=CONSTR_FEDERATED_USER, tableName=FEDERATED_USER; dropDefaultValue columnName=TOTP, tableName=USER_ENTITY; dropColumn columnName=TOTP, tableName=USER_ENTITY; addColumn tableName=IDE...		\N	3.5.4	\N	\N	3820445829
+2.4.0	bburke@redhat.com	META-INF/jpa-changelog-2.4.0.xml	2022-02-02 16:47:26.545809	32	EXECUTED	9:eac4ffb2a14795e5dc7b426063e54d88	customChange		\N	3.5.4	\N	\N	3820445829
+2.5.0	bburke@redhat.com	META-INF/jpa-changelog-2.5.0.xml	2022-02-02 16:47:26.549823	33	EXECUTED	9:54937c05672568c4c64fc9524c1e9462	customChange; modifyDataType columnName=USER_ID, tableName=OFFLINE_USER_SESSION		\N	3.5.4	\N	\N	3820445829
+2.5.0-unicode-oracle	hmlnarik@redhat.com	META-INF/jpa-changelog-2.5.0.xml	2022-02-02 16:47:26.55176	34	MARK_RAN	9:3a32bace77c84d7678d035a7f5a8084e	modifyDataType columnName=DESCRIPTION, tableName=AUTHENTICATION_FLOW; modifyDataType columnName=DESCRIPTION, tableName=CLIENT_TEMPLATE; modifyDataType columnName=DESCRIPTION, tableName=RESOURCE_SERVER_POLICY; modifyDataType columnName=DESCRIPTION,...		\N	3.5.4	\N	\N	3820445829
+2.5.0-unicode-other-dbs	hmlnarik@redhat.com	META-INF/jpa-changelog-2.5.0.xml	2022-02-02 16:47:26.567305	35	EXECUTED	9:33d72168746f81f98ae3a1e8e0ca3554	modifyDataType columnName=DESCRIPTION, tableName=AUTHENTICATION_FLOW; modifyDataType columnName=DESCRIPTION, tableName=CLIENT_TEMPLATE; modifyDataType columnName=DESCRIPTION, tableName=RESOURCE_SERVER_POLICY; modifyDataType columnName=DESCRIPTION,...		\N	3.5.4	\N	\N	3820445829
+2.5.0-duplicate-email-support	slawomir@dabek.name	META-INF/jpa-changelog-2.5.0.xml	2022-02-02 16:47:26.570727	36	EXECUTED	9:61b6d3d7a4c0e0024b0c839da283da0c	addColumn tableName=REALM		\N	3.5.4	\N	\N	3820445829
+2.5.0-unique-group-names	hmlnarik@redhat.com	META-INF/jpa-changelog-2.5.0.xml	2022-02-02 16:47:26.578396	37	EXECUTED	9:8dcac7bdf7378e7d823cdfddebf72fda	addUniqueConstraint constraintName=SIBLING_NAMES, tableName=KEYCLOAK_GROUP		\N	3.5.4	\N	\N	3820445829
+2.5.1	bburke@redhat.com	META-INF/jpa-changelog-2.5.1.xml	2022-02-02 16:47:26.581391	38	EXECUTED	9:a2b870802540cb3faa72098db5388af3	addColumn tableName=FED_USER_CONSENT		\N	3.5.4	\N	\N	3820445829
+3.0.0	bburke@redhat.com	META-INF/jpa-changelog-3.0.0.xml	2022-02-02 16:47:26.584204	39	EXECUTED	9:132a67499ba24bcc54fb5cbdcfe7e4c0	addColumn tableName=IDENTITY_PROVIDER		\N	3.5.4	\N	\N	3820445829
+3.2.0-fix	keycloak	META-INF/jpa-changelog-3.2.0.xml	2022-02-02 16:47:26.585877	40	MARK_RAN	9:938f894c032f5430f2b0fafb1a243462	addNotNullConstraint columnName=REALM_ID, tableName=CLIENT_INITIAL_ACCESS		\N	3.5.4	\N	\N	3820445829
+3.2.0-fix-with-keycloak-5416	keycloak	META-INF/jpa-changelog-3.2.0.xml	2022-02-02 16:47:26.587657	41	MARK_RAN	9:845c332ff1874dc5d35974b0babf3006	dropIndex indexName=IDX_CLIENT_INIT_ACC_REALM, tableName=CLIENT_INITIAL_ACCESS; addNotNullConstraint columnName=REALM_ID, tableName=CLIENT_INITIAL_ACCESS; createIndex indexName=IDX_CLIENT_INIT_ACC_REALM, tableName=CLIENT_INITIAL_ACCESS		\N	3.5.4	\N	\N	3820445829
+3.2.0-fix-offline-sessions	hmlnarik	META-INF/jpa-changelog-3.2.0.xml	2022-02-02 16:47:26.591561	42	EXECUTED	9:fc86359c079781adc577c5a217e4d04c	customChange		\N	3.5.4	\N	\N	3820445829
+3.2.0-fixed	keycloak	META-INF/jpa-changelog-3.2.0.xml	2022-02-02 16:47:26.669981	43	EXECUTED	9:59a64800e3c0d09b825f8a3b444fa8f4	addColumn tableName=REALM; dropPrimaryKey constraintName=CONSTRAINT_OFFL_CL_SES_PK2, tableName=OFFLINE_CLIENT_SESSION; dropColumn columnName=CLIENT_SESSION_ID, tableName=OFFLINE_CLIENT_SESSION; addPrimaryKey constraintName=CONSTRAINT_OFFL_CL_SES_P...		\N	3.5.4	\N	\N	3820445829
+3.3.0	keycloak	META-INF/jpa-changelog-3.3.0.xml	2022-02-02 16:47:26.673701	44	EXECUTED	9:d48d6da5c6ccf667807f633fe489ce88	addColumn tableName=USER_ENTITY		\N	3.5.4	\N	\N	3820445829
+authz-3.4.0.CR1-resource-server-pk-change-part1	glavoie@gmail.com	META-INF/jpa-changelog-authz-3.4.0.CR1.xml	2022-02-02 16:47:26.679075	45	EXECUTED	9:dde36f7973e80d71fceee683bc5d2951	addColumn tableName=RESOURCE_SERVER_POLICY; addColumn tableName=RESOURCE_SERVER_RESOURCE; addColumn tableName=RESOURCE_SERVER_SCOPE		\N	3.5.4	\N	\N	3820445829
+authz-3.4.0.CR1-resource-server-pk-change-part2-KEYCLOAK-6095	hmlnarik@redhat.com	META-INF/jpa-changelog-authz-3.4.0.CR1.xml	2022-02-02 16:47:26.681987	46	EXECUTED	9:b855e9b0a406b34fa323235a0cf4f640	customChange		\N	3.5.4	\N	\N	3820445829
+authz-3.4.0.CR1-resource-server-pk-change-part3-fixed	glavoie@gmail.com	META-INF/jpa-changelog-authz-3.4.0.CR1.xml	2022-02-02 16:47:26.683661	47	MARK_RAN	9:51abbacd7b416c50c4421a8cabf7927e	dropIndex indexName=IDX_RES_SERV_POL_RES_SERV, tableName=RESOURCE_SERVER_POLICY; dropIndex indexName=IDX_RES_SRV_RES_RES_SRV, tableName=RESOURCE_SERVER_RESOURCE; dropIndex indexName=IDX_RES_SRV_SCOPE_RES_SRV, tableName=RESOURCE_SERVER_SCOPE		\N	3.5.4	\N	\N	3820445829
+authz-3.4.0.CR1-resource-server-pk-change-part3-fixed-nodropindex	glavoie@gmail.com	META-INF/jpa-changelog-authz-3.4.0.CR1.xml	2022-02-02 16:47:26.702743	48	EXECUTED	9:bdc99e567b3398bac83263d375aad143	addNotNullConstraint columnName=RESOURCE_SERVER_CLIENT_ID, tableName=RESOURCE_SERVER_POLICY; addNotNullConstraint columnName=RESOURCE_SERVER_CLIENT_ID, tableName=RESOURCE_SERVER_RESOURCE; addNotNullConstraint columnName=RESOURCE_SERVER_CLIENT_ID, ...		\N	3.5.4	\N	\N	3820445829
+authn-3.4.0.CR1-refresh-token-max-reuse	glavoie@gmail.com	META-INF/jpa-changelog-authz-3.4.0.CR1.xml	2022-02-02 16:47:26.706593	49	EXECUTED	9:d198654156881c46bfba39abd7769e69	addColumn tableName=REALM		\N	3.5.4	\N	\N	3820445829
+3.4.0	keycloak	META-INF/jpa-changelog-3.4.0.xml	2022-02-02 16:47:26.734467	50	EXECUTED	9:cfdd8736332ccdd72c5256ccb42335db	addPrimaryKey constraintName=CONSTRAINT_REALM_DEFAULT_ROLES, tableName=REALM_DEFAULT_ROLES; addPrimaryKey constraintName=CONSTRAINT_COMPOSITE_ROLE, tableName=COMPOSITE_ROLE; addPrimaryKey constraintName=CONSTR_REALM_DEFAULT_GROUPS, tableName=REALM...		\N	3.5.4	\N	\N	3820445829
+3.4.0-KEYCLOAK-5230	hmlnarik@redhat.com	META-INF/jpa-changelog-3.4.0.xml	2022-02-02 16:47:26.78037	51	EXECUTED	9:7c84de3d9bd84d7f077607c1a4dcb714	createIndex indexName=IDX_FU_ATTRIBUTE, tableName=FED_USER_ATTRIBUTE; createIndex indexName=IDX_FU_CONSENT, tableName=FED_USER_CONSENT; createIndex indexName=IDX_FU_CONSENT_RU, tableName=FED_USER_CONSENT; createIndex indexName=IDX_FU_CREDENTIAL, t...		\N	3.5.4	\N	\N	3820445829
+3.4.1	psilva@redhat.com	META-INF/jpa-changelog-3.4.1.xml	2022-02-02 16:47:26.783989	52	EXECUTED	9:5a6bb36cbefb6a9d6928452c0852af2d	modifyDataType columnName=VALUE, tableName=CLIENT_ATTRIBUTES		\N	3.5.4	\N	\N	3820445829
+3.4.2-KEYCLOAK-5172	mkanis@redhat.com	META-INF/jpa-changelog-3.4.2.xml	2022-02-02 16:47:26.788788	54	EXECUTED	9:9156214268f09d970cdf0e1564d866af	update tableName=CLIENT		\N	3.5.4	\N	\N	3820445829
+4.0.0-KEYCLOAK-6335	bburke@redhat.com	META-INF/jpa-changelog-4.0.0.xml	2022-02-02 16:47:26.794881	55	EXECUTED	9:db806613b1ed154826c02610b7dbdf74	createTable tableName=CLIENT_AUTH_FLOW_BINDINGS; addPrimaryKey constraintName=C_CLI_FLOW_BIND, tableName=CLIENT_AUTH_FLOW_BINDINGS		\N	3.5.4	\N	\N	3820445829
+4.0.0-CLEANUP-UNUSED-TABLE	bburke@redhat.com	META-INF/jpa-changelog-4.0.0.xml	2022-02-02 16:47:26.799493	56	EXECUTED	9:229a041fb72d5beac76bb94a5fa709de	dropTable tableName=CLIENT_IDENTITY_PROV_MAPPING		\N	3.5.4	\N	\N	3820445829
+4.0.0-KEYCLOAK-6228	bburke@redhat.com	META-INF/jpa-changelog-4.0.0.xml	2022-02-02 16:47:26.810686	57	EXECUTED	9:079899dade9c1e683f26b2aa9ca6ff04	dropUniqueConstraint constraintName=UK_JKUWUVD56ONTGSUHOGM8UEWRT, tableName=USER_CONSENT; dropNotNullConstraint columnName=CLIENT_ID, tableName=USER_CONSENT; addColumn tableName=USER_CONSENT; addUniqueConstraint constraintName=UK_JKUWUVD56ONTGSUHO...		\N	3.5.4	\N	\N	3820445829
+4.0.0-KEYCLOAK-5579-fixed	mposolda@redhat.com	META-INF/jpa-changelog-4.0.0.xml	2022-02-02 16:47:26.861332	58	EXECUTED	9:139b79bcbbfe903bb1c2d2a4dbf001d9	dropForeignKeyConstraint baseTableName=CLIENT_TEMPLATE_ATTRIBUTES, constraintName=FK_CL_TEMPL_ATTR_TEMPL; renameTable newTableName=CLIENT_SCOPE_ATTRIBUTES, oldTableName=CLIENT_TEMPLATE_ATTRIBUTES; renameColumn newColumnName=SCOPE_ID, oldColumnName...		\N	3.5.4	\N	\N	3820445829
+authz-4.0.0.CR1	psilva@redhat.com	META-INF/jpa-changelog-authz-4.0.0.CR1.xml	2022-02-02 16:47:26.877018	59	EXECUTED	9:b55738ad889860c625ba2bf483495a04	createTable tableName=RESOURCE_SERVER_PERM_TICKET; addPrimaryKey constraintName=CONSTRAINT_FAPMT, tableName=RESOURCE_SERVER_PERM_TICKET; addForeignKeyConstraint baseTableName=RESOURCE_SERVER_PERM_TICKET, constraintName=FK_FRSRHO213XCX4WNKOG82SSPMT...		\N	3.5.4	\N	\N	3820445829
+authz-4.0.0.Beta3	psilva@redhat.com	META-INF/jpa-changelog-authz-4.0.0.Beta3.xml	2022-02-02 16:47:26.881203	60	EXECUTED	9:e0057eac39aa8fc8e09ac6cfa4ae15fe	addColumn tableName=RESOURCE_SERVER_POLICY; addColumn tableName=RESOURCE_SERVER_PERM_TICKET; addForeignKeyConstraint baseTableName=RESOURCE_SERVER_PERM_TICKET, constraintName=FK_FRSRPO2128CX4WNKOG82SSRFY, referencedTableName=RESOURCE_SERVER_POLICY		\N	3.5.4	\N	\N	3820445829
+authz-4.2.0.Final	mhajas@redhat.com	META-INF/jpa-changelog-authz-4.2.0.Final.xml	2022-02-02 16:47:26.886177	61	EXECUTED	9:42a33806f3a0443fe0e7feeec821326c	createTable tableName=RESOURCE_URIS; addForeignKeyConstraint baseTableName=RESOURCE_URIS, constraintName=FK_RESOURCE_SERVER_URIS, referencedTableName=RESOURCE_SERVER_RESOURCE; customChange; dropColumn columnName=URI, tableName=RESOURCE_SERVER_RESO...		\N	3.5.4	\N	\N	3820445829
+authz-4.2.0.Final-KEYCLOAK-9944	hmlnarik@redhat.com	META-INF/jpa-changelog-authz-4.2.0.Final.xml	2022-02-02 16:47:26.890482	62	EXECUTED	9:9968206fca46eecc1f51db9c024bfe56	addPrimaryKey constraintName=CONSTRAINT_RESOUR_URIS_PK, tableName=RESOURCE_URIS		\N	3.5.4	\N	\N	3820445829
+4.2.0-KEYCLOAK-6313	wadahiro@gmail.com	META-INF/jpa-changelog-4.2.0.xml	2022-02-02 16:47:26.893518	63	EXECUTED	9:92143a6daea0a3f3b8f598c97ce55c3d	addColumn tableName=REQUIRED_ACTION_PROVIDER		\N	3.5.4	\N	\N	3820445829
+4.3.0-KEYCLOAK-7984	wadahiro@gmail.com	META-INF/jpa-changelog-4.3.0.xml	2022-02-02 16:47:26.895621	64	EXECUTED	9:82bab26a27195d889fb0429003b18f40	update tableName=REQUIRED_ACTION_PROVIDER		\N	3.5.4	\N	\N	3820445829
+4.6.0-KEYCLOAK-7950	psilva@redhat.com	META-INF/jpa-changelog-4.6.0.xml	2022-02-02 16:47:26.89756	65	EXECUTED	9:e590c88ddc0b38b0ae4249bbfcb5abc3	update tableName=RESOURCE_SERVER_RESOURCE		\N	3.5.4	\N	\N	3820445829
+4.6.0-KEYCLOAK-8377	keycloak	META-INF/jpa-changelog-4.6.0.xml	2022-02-02 16:47:26.908059	66	EXECUTED	9:5c1f475536118dbdc38d5d7977950cc0	createTable tableName=ROLE_ATTRIBUTE; addPrimaryKey constraintName=CONSTRAINT_ROLE_ATTRIBUTE_PK, tableName=ROLE_ATTRIBUTE; addForeignKeyConstraint baseTableName=ROLE_ATTRIBUTE, constraintName=FK_ROLE_ATTRIBUTE_ID, referencedTableName=KEYCLOAK_ROLE...		\N	3.5.4	\N	\N	3820445829
+4.6.0-KEYCLOAK-8555	gideonray@gmail.com	META-INF/jpa-changelog-4.6.0.xml	2022-02-02 16:47:26.912693	67	EXECUTED	9:e7c9f5f9c4d67ccbbcc215440c718a17	createIndex indexName=IDX_COMPONENT_PROVIDER_TYPE, tableName=COMPONENT		\N	3.5.4	\N	\N	3820445829
+4.7.0-KEYCLOAK-1267	sguilhen@redhat.com	META-INF/jpa-changelog-4.7.0.xml	2022-02-02 16:47:26.915771	68	EXECUTED	9:88e0bfdda924690d6f4e430c53447dd5	addColumn tableName=REALM		\N	3.5.4	\N	\N	3820445829
+4.7.0-KEYCLOAK-7275	keycloak	META-INF/jpa-changelog-4.7.0.xml	2022-02-02 16:47:26.924465	69	EXECUTED	9:f53177f137e1c46b6a88c59ec1cb5218	renameColumn newColumnName=CREATED_ON, oldColumnName=LAST_SESSION_REFRESH, tableName=OFFLINE_USER_SESSION; addNotNullConstraint columnName=CREATED_ON, tableName=OFFLINE_USER_SESSION; addColumn tableName=OFFLINE_USER_SESSION; customChange; createIn...		\N	3.5.4	\N	\N	3820445829
+4.8.0-KEYCLOAK-8835	sguilhen@redhat.com	META-INF/jpa-changelog-4.8.0.xml	2022-02-02 16:47:26.928034	70	EXECUTED	9:a74d33da4dc42a37ec27121580d1459f	addNotNullConstraint columnName=SSO_MAX_LIFESPAN_REMEMBER_ME, tableName=REALM; addNotNullConstraint columnName=SSO_IDLE_TIMEOUT_REMEMBER_ME, tableName=REALM		\N	3.5.4	\N	\N	3820445829
+authz-7.0.0-KEYCLOAK-10443	psilva@redhat.com	META-INF/jpa-changelog-authz-7.0.0.xml	2022-02-02 16:47:26.93061	71	EXECUTED	9:fd4ade7b90c3b67fae0bfcfcb42dfb5f	addColumn tableName=RESOURCE_SERVER		\N	3.5.4	\N	\N	3820445829
+8.0.0-adding-credential-columns	keycloak	META-INF/jpa-changelog-8.0.0.xml	2022-02-02 16:47:26.933771	72	EXECUTED	9:aa072ad090bbba210d8f18781b8cebf4	addColumn tableName=CREDENTIAL; addColumn tableName=FED_USER_CREDENTIAL		\N	3.5.4	\N	\N	3820445829
+8.0.0-credential-cleanup-fixed	keycloak	META-INF/jpa-changelog-8.0.0.xml	2022-02-02 16:47:26.945819	75	EXECUTED	9:2b9cc12779be32c5b40e2e67711a218b	dropDefaultValue columnName=COUNTER, tableName=CREDENTIAL; dropDefaultValue columnName=DIGITS, tableName=CREDENTIAL; dropDefaultValue columnName=PERIOD, tableName=CREDENTIAL; dropDefaultValue columnName=ALGORITHM, tableName=CREDENTIAL; dropColumn ...		\N	3.5.4	\N	\N	3820445829
+8.0.0-resource-tag-support	keycloak	META-INF/jpa-changelog-8.0.0.xml	2022-02-02 16:47:26.950255	76	EXECUTED	9:91fa186ce7a5af127a2d7a91ee083cc5	addColumn tableName=MIGRATION_MODEL; createIndex indexName=IDX_UPDATE_TIME, tableName=MIGRATION_MODEL		\N	3.5.4	\N	\N	3820445829
+9.0.0-always-display-client	keycloak	META-INF/jpa-changelog-9.0.0.xml	2022-02-02 16:47:26.955505	77	EXECUTED	9:6335e5c94e83a2639ccd68dd24e2e5ad	addColumn tableName=CLIENT		\N	3.5.4	\N	\N	3820445829
+9.0.0-drop-constraints-for-column-increase	keycloak	META-INF/jpa-changelog-9.0.0.xml	2022-02-02 16:47:26.957216	78	MARK_RAN	9:6bdb5658951e028bfe16fa0a8228b530	dropUniqueConstraint constraintName=UK_FRSR6T700S9V50BU18WS5PMT, tableName=RESOURCE_SERVER_PERM_TICKET; dropUniqueConstraint constraintName=UK_FRSR6T700S9V50BU18WS5HA6, tableName=RESOURCE_SERVER_RESOURCE; dropPrimaryKey constraintName=CONSTRAINT_O...		\N	3.5.4	\N	\N	3820445829
+9.0.0-increase-column-size-federated-fk	keycloak	META-INF/jpa-changelog-9.0.0.xml	2022-02-02 16:47:26.966746	79	EXECUTED	9:d5bc15a64117ccad481ce8792d4c608f	modifyDataType columnName=CLIENT_ID, tableName=FED_USER_CONSENT; modifyDataType columnName=CLIENT_REALM_CONSTRAINT, tableName=KEYCLOAK_ROLE; modifyDataType columnName=OWNER, tableName=RESOURCE_SERVER_POLICY; modifyDataType columnName=CLIENT_ID, ta...		\N	3.5.4	\N	\N	3820445829
+9.0.0-recreate-constraints-after-column-increase	keycloak	META-INF/jpa-changelog-9.0.0.xml	2022-02-02 16:47:26.969643	80	MARK_RAN	9:077cba51999515f4d3e7ad5619ab592c	addNotNullConstraint columnName=CLIENT_ID, tableName=OFFLINE_CLIENT_SESSION; addNotNullConstraint columnName=OWNER, tableName=RESOURCE_SERVER_PERM_TICKET; addNotNullConstraint columnName=REQUESTER, tableName=RESOURCE_SERVER_PERM_TICKET; addNotNull...		\N	3.5.4	\N	\N	3820445829
+9.0.1-add-index-to-client.client_id	keycloak	META-INF/jpa-changelog-9.0.1.xml	2022-02-02 16:47:26.975764	81	EXECUTED	9:be969f08a163bf47c6b9e9ead8ac2afb	createIndex indexName=IDX_CLIENT_ID, tableName=CLIENT		\N	3.5.4	\N	\N	3820445829
+9.0.1-KEYCLOAK-12579-drop-constraints	keycloak	META-INF/jpa-changelog-9.0.1.xml	2022-02-02 16:47:26.977227	82	MARK_RAN	9:6d3bb4408ba5a72f39bd8a0b301ec6e3	dropUniqueConstraint constraintName=SIBLING_NAMES, tableName=KEYCLOAK_GROUP		\N	3.5.4	\N	\N	3820445829
+9.0.1-KEYCLOAK-12579-add-not-null-constraint	keycloak	META-INF/jpa-changelog-9.0.1.xml	2022-02-02 16:47:26.980058	83	EXECUTED	9:966bda61e46bebf3cc39518fbed52fa7	addNotNullConstraint columnName=PARENT_GROUP, tableName=KEYCLOAK_GROUP		\N	3.5.4	\N	\N	3820445829
+9.0.1-KEYCLOAK-12579-recreate-constraints	keycloak	META-INF/jpa-changelog-9.0.1.xml	2022-02-02 16:47:26.981645	84	MARK_RAN	9:8dcac7bdf7378e7d823cdfddebf72fda	addUniqueConstraint constraintName=SIBLING_NAMES, tableName=KEYCLOAK_GROUP		\N	3.5.4	\N	\N	3820445829
+9.0.1-add-index-to-events	keycloak	META-INF/jpa-changelog-9.0.1.xml	2022-02-02 16:47:26.985465	85	EXECUTED	9:7d93d602352a30c0c317e6a609b56599	createIndex indexName=IDX_EVENT_TIME, tableName=EVENT_ENTITY		\N	3.5.4	\N	\N	3820445829
+map-remove-ri	keycloak	META-INF/jpa-changelog-11.0.0.xml	2022-02-02 16:47:26.98869	86	EXECUTED	9:71c5969e6cdd8d7b6f47cebc86d37627	dropForeignKeyConstraint baseTableName=REALM, constraintName=FK_TRAF444KK6QRKMS7N56AIWQ5Y; dropForeignKeyConstraint baseTableName=KEYCLOAK_ROLE, constraintName=FK_KJHO5LE2C0RAL09FL8CM9WFW9		\N	3.5.4	\N	\N	3820445829
+map-remove-ri	keycloak	META-INF/jpa-changelog-12.0.0.xml	2022-02-02 16:47:26.992854	87	EXECUTED	9:a9ba7d47f065f041b7da856a81762021	dropForeignKeyConstraint baseTableName=REALM_DEFAULT_GROUPS, constraintName=FK_DEF_GROUPS_GROUP; dropForeignKeyConstraint baseTableName=REALM_DEFAULT_ROLES, constraintName=FK_H4WPD7W4HSOOLNI3H0SW7BTJE; dropForeignKeyConstraint baseTableName=CLIENT...		\N	3.5.4	\N	\N	3820445829
+12.1.0-add-realm-localization-table	keycloak	META-INF/jpa-changelog-12.0.0.xml	2022-02-02 16:47:26.999694	88	EXECUTED	9:fffabce2bc01e1a8f5110d5278500065	createTable tableName=REALM_LOCALIZATIONS; addPrimaryKey tableName=REALM_LOCALIZATIONS		\N	3.5.4	\N	\N	3820445829
+8.0.0-updating-credential-data-not-oracle-fixed	keycloak	META-INF/jpa-changelog-8.0.0.xml	2023-01-09 14:34:23.080082	89	MARK_RAN	9:1ae6be29bab7c2aa376f6983b932be37	update tableName=CREDENTIAL; update tableName=CREDENTIAL; update tableName=CREDENTIAL; update tableName=FED_USER_CREDENTIAL; update tableName=FED_USER_CREDENTIAL; update tableName=FED_USER_CREDENTIAL		\N	4.8.0	\N	\N	3274862955
+8.0.0-updating-credential-data-oracle-fixed	keycloak	META-INF/jpa-changelog-8.0.0.xml	2023-01-09 14:34:23.099857	90	MARK_RAN	9:14706f286953fc9a25286dbd8fb30d97	update tableName=CREDENTIAL; update tableName=CREDENTIAL; update tableName=CREDENTIAL; update tableName=FED_USER_CREDENTIAL; update tableName=FED_USER_CREDENTIAL; update tableName=FED_USER_CREDENTIAL		\N	4.8.0	\N	\N	3274862955
+default-roles	keycloak	META-INF/jpa-changelog-13.0.0.xml	2023-01-09 14:34:23.144776	91	EXECUTED	9:fa8a5b5445e3857f4b010bafb5009957	addColumn tableName=REALM; customChange		\N	4.8.0	\N	\N	3274862955
+default-roles-cleanup	keycloak	META-INF/jpa-changelog-13.0.0.xml	2023-01-09 14:34:23.155298	92	EXECUTED	9:67ac3241df9a8582d591c5ed87125f39	dropTable tableName=REALM_DEFAULT_ROLES; dropTable tableName=CLIENT_DEFAULT_ROLES		\N	4.8.0	\N	\N	3274862955
+13.0.0-KEYCLOAK-16844	keycloak	META-INF/jpa-changelog-13.0.0.xml	2023-01-09 14:34:23.162911	93	EXECUTED	9:ad1194d66c937e3ffc82386c050ba089	createIndex indexName=IDX_OFFLINE_USS_PRELOAD, tableName=OFFLINE_USER_SESSION		\N	4.8.0	\N	\N	3274862955
+map-remove-ri-13.0.0	keycloak	META-INF/jpa-changelog-13.0.0.xml	2023-01-09 14:34:23.17617	94	EXECUTED	9:d9be619d94af5a2f5d07b9f003543b91	dropForeignKeyConstraint baseTableName=DEFAULT_CLIENT_SCOPE, constraintName=FK_R_DEF_CLI_SCOPE_SCOPE; dropForeignKeyConstraint baseTableName=CLIENT_SCOPE_CLIENT, constraintName=FK_C_CLI_SCOPE_SCOPE; dropForeignKeyConstraint baseTableName=CLIENT_SC...		\N	4.8.0	\N	\N	3274862955
+13.0.0-KEYCLOAK-17992-drop-constraints	keycloak	META-INF/jpa-changelog-13.0.0.xml	2023-01-09 14:34:23.1803	95	MARK_RAN	9:544d201116a0fcc5a5da0925fbbc3bde	dropPrimaryKey constraintName=C_CLI_SCOPE_BIND, tableName=CLIENT_SCOPE_CLIENT; dropIndex indexName=IDX_CLSCOPE_CL, tableName=CLIENT_SCOPE_CLIENT; dropIndex indexName=IDX_CL_CLSCOPE, tableName=CLIENT_SCOPE_CLIENT		\N	4.8.0	\N	\N	3274862955
+13.0.0-increase-column-size-federated	keycloak	META-INF/jpa-changelog-13.0.0.xml	2023-01-09 14:34:23.190613	96	EXECUTED	9:43c0c1055b6761b4b3e89de76d612ccf	modifyDataType columnName=CLIENT_ID, tableName=CLIENT_SCOPE_CLIENT; modifyDataType columnName=SCOPE_ID, tableName=CLIENT_SCOPE_CLIENT		\N	4.8.0	\N	\N	3274862955
+13.0.0-KEYCLOAK-17992-recreate-constraints	keycloak	META-INF/jpa-changelog-13.0.0.xml	2023-01-09 14:34:23.193934	97	MARK_RAN	9:8bd711fd0330f4fe980494ca43ab1139	addNotNullConstraint columnName=CLIENT_ID, tableName=CLIENT_SCOPE_CLIENT; addNotNullConstraint columnName=SCOPE_ID, tableName=CLIENT_SCOPE_CLIENT; addPrimaryKey constraintName=C_CLI_SCOPE_BIND, tableName=CLIENT_SCOPE_CLIENT; createIndex indexName=...		\N	4.8.0	\N	\N	3274862955
+json-string-accomodation-fixed	keycloak	META-INF/jpa-changelog-13.0.0.xml	2023-01-09 14:34:23.202965	98	EXECUTED	9:e07d2bc0970c348bb06fb63b1f82ddbf	addColumn tableName=REALM_ATTRIBUTE; update tableName=REALM_ATTRIBUTE; dropColumn columnName=VALUE, tableName=REALM_ATTRIBUTE; renameColumn newColumnName=VALUE, oldColumnName=VALUE_NEW, tableName=REALM_ATTRIBUTE		\N	4.8.0	\N	\N	3274862955
+14.0.0-KEYCLOAK-11019	keycloak	META-INF/jpa-changelog-14.0.0.xml	2023-01-09 14:34:23.212244	99	EXECUTED	9:24fb8611e97f29989bea412aa38d12b7	createIndex indexName=IDX_OFFLINE_CSS_PRELOAD, tableName=OFFLINE_CLIENT_SESSION; createIndex indexName=IDX_OFFLINE_USS_BY_USER, tableName=OFFLINE_USER_SESSION; createIndex indexName=IDX_OFFLINE_USS_BY_USERSESS, tableName=OFFLINE_USER_SESSION		\N	4.8.0	\N	\N	3274862955
+14.0.0-KEYCLOAK-18286	keycloak	META-INF/jpa-changelog-14.0.0.xml	2023-01-09 14:34:23.2164	100	MARK_RAN	9:259f89014ce2506ee84740cbf7163aa7	createIndex indexName=IDX_CLIENT_ATT_BY_NAME_VALUE, tableName=CLIENT_ATTRIBUTES		\N	4.8.0	\N	\N	3274862955
+14.0.0-KEYCLOAK-18286-revert	keycloak	META-INF/jpa-changelog-14.0.0.xml	2023-01-09 14:34:23.227895	101	MARK_RAN	9:04baaf56c116ed19951cbc2cca584022	dropIndex indexName=IDX_CLIENT_ATT_BY_NAME_VALUE, tableName=CLIENT_ATTRIBUTES		\N	4.8.0	\N	\N	3274862955
+14.0.0-KEYCLOAK-18286-supported-dbs	keycloak	META-INF/jpa-changelog-14.0.0.xml	2023-01-09 14:34:23.235491	102	EXECUTED	9:60ca84a0f8c94ec8c3504a5a3bc88ee8	createIndex indexName=IDX_CLIENT_ATT_BY_NAME_VALUE, tableName=CLIENT_ATTRIBUTES		\N	4.8.0	\N	\N	3274862955
+14.0.0-KEYCLOAK-18286-unsupported-dbs	keycloak	META-INF/jpa-changelog-14.0.0.xml	2023-01-09 14:34:23.238498	103	MARK_RAN	9:d3d977031d431db16e2c181ce49d73e9	createIndex indexName=IDX_CLIENT_ATT_BY_NAME_VALUE, tableName=CLIENT_ATTRIBUTES		\N	4.8.0	\N	\N	3274862955
+KEYCLOAK-17267-add-index-to-user-attributes	keycloak	META-INF/jpa-changelog-14.0.0.xml	2023-01-09 14:34:23.24435	104	EXECUTED	9:0b305d8d1277f3a89a0a53a659ad274c	createIndex indexName=IDX_USER_ATTRIBUTE_NAME, tableName=USER_ATTRIBUTE		\N	4.8.0	\N	\N	3274862955
+KEYCLOAK-18146-add-saml-art-binding-identifier	keycloak	META-INF/jpa-changelog-14.0.0.xml	2023-01-09 14:34:23.250444	105	EXECUTED	9:2c374ad2cdfe20e2905a84c8fac48460	customChange		\N	4.8.0	\N	\N	3274862955
+15.0.0-KEYCLOAK-18467	keycloak	META-INF/jpa-changelog-15.0.0.xml	2023-01-09 14:34:23.261701	106	EXECUTED	9:47a760639ac597360a8219f5b768b4de	addColumn tableName=REALM_LOCALIZATIONS; update tableName=REALM_LOCALIZATIONS; dropColumn columnName=TEXTS, tableName=REALM_LOCALIZATIONS; renameColumn newColumnName=TEXTS, oldColumnName=TEXTS_NEW, tableName=REALM_LOCALIZATIONS; addNotNullConstrai...		\N	4.8.0	\N	\N	3274862955
+17.0.0-9562	keycloak	META-INF/jpa-changelog-17.0.0.xml	2023-01-09 14:34:23.269577	107	EXECUTED	9:a6272f0576727dd8cad2522335f5d99e	createIndex indexName=IDX_USER_SERVICE_ACCOUNT, tableName=USER_ENTITY		\N	4.8.0	\N	\N	3274862955
+18.0.0-10625-IDX_ADMIN_EVENT_TIME	keycloak	META-INF/jpa-changelog-18.0.0.xml	2023-01-09 14:34:23.276738	108	EXECUTED	9:015479dbd691d9cc8669282f4828c41d	createIndex indexName=IDX_ADMIN_EVENT_TIME, tableName=ADMIN_EVENT_ENTITY		\N	4.8.0	\N	\N	3274862955
+19.0.0-10135	keycloak	META-INF/jpa-changelog-19.0.0.xml	2023-01-09 14:34:23.297485	109	EXECUTED	9:9518e495fdd22f78ad6425cc30630221	customChange		\N	4.8.0	\N	\N	3274862955
+20.0.0-12964-supported-dbs	keycloak	META-INF/jpa-changelog-20.0.0.xml	2023-01-09 14:34:23.305463	110	EXECUTED	9:e5f243877199fd96bcc842f27a1656ac	createIndex indexName=IDX_GROUP_ATT_BY_NAME_VALUE, tableName=GROUP_ATTRIBUTE		\N	4.8.0	\N	\N	3274862955
+20.0.0-12964-unsupported-dbs	keycloak	META-INF/jpa-changelog-20.0.0.xml	2023-01-09 14:34:23.309005	111	MARK_RAN	9:1a6fcaa85e20bdeae0a9ce49b41946a5	createIndex indexName=IDX_GROUP_ATT_BY_NAME_VALUE, tableName=GROUP_ATTRIBUTE		\N	4.8.0	\N	\N	3274862955
+client-attributes-string-accomodation-fixed	keycloak	META-INF/jpa-changelog-20.0.0.xml	2023-01-09 14:34:23.318788	112	EXECUTED	9:3f332e13e90739ed0c35b0b25b7822ca	addColumn tableName=CLIENT_ATTRIBUTES; update tableName=CLIENT_ATTRIBUTES; dropColumn columnName=VALUE, tableName=CLIENT_ATTRIBUTES; renameColumn newColumnName=VALUE, oldColumnName=VALUE_NEW, tableName=CLIENT_ATTRIBUTES		\N	4.8.0	\N	\N	3274862955
+21.0.2-17277	keycloak	META-INF/jpa-changelog-21.0.2.xml	2024-02-14 09:01:09.307684	113	EXECUTED	9:7ee1f7a3fb8f5588f171fb9a6ab623c0	customChange		\N	4.23.2	\N	\N	7901269232
+21.1.0-19404	keycloak	META-INF/jpa-changelog-21.1.0.xml	2024-02-14 09:01:09.324282	114	EXECUTED	9:3d7e830b52f33676b9d64f7f2b2ea634	modifyDataType columnName=DECISION_STRATEGY, tableName=RESOURCE_SERVER_POLICY; modifyDataType columnName=LOGIC, tableName=RESOURCE_SERVER_POLICY; modifyDataType columnName=POLICY_ENFORCE_MODE, tableName=RESOURCE_SERVER		\N	4.23.2	\N	\N	7901269232
+21.1.0-19404-2	keycloak	META-INF/jpa-changelog-21.1.0.xml	2024-02-14 09:01:09.327044	115	MARK_RAN	9:627d032e3ef2c06c0e1f73d2ae25c26c	addColumn tableName=RESOURCE_SERVER_POLICY; update tableName=RESOURCE_SERVER_POLICY; dropColumn columnName=DECISION_STRATEGY, tableName=RESOURCE_SERVER_POLICY; renameColumn newColumnName=DECISION_STRATEGY, oldColumnName=DECISION_STRATEGY_NEW, tabl...		\N	4.23.2	\N	\N	7901269232
+22.0.0-17484-updated	keycloak	META-INF/jpa-changelog-22.0.0.xml	2024-02-14 09:01:09.332189	116	EXECUTED	9:90af0bfd30cafc17b9f4d6eccd92b8b3	customChange		\N	4.23.2	\N	\N	7901269232
+22.0.5-24031	keycloak	META-INF/jpa-changelog-22.0.0.xml	2024-02-14 09:01:09.333603	117	MARK_RAN	9:a60d2d7b315ec2d3eba9e2f145f9df28	customChange		\N	4.23.2	\N	\N	7901269232
+23.0.0-12062	keycloak	META-INF/jpa-changelog-23.0.0.xml	2024-02-14 09:01:09.340927	118	EXECUTED	9:2168fbe728fec46ae9baf15bf80927b8	addColumn tableName=COMPONENT_CONFIG; update tableName=COMPONENT_CONFIG; dropColumn columnName=VALUE, tableName=COMPONENT_CONFIG; renameColumn newColumnName=VALUE, oldColumnName=VALUE_NEW, tableName=COMPONENT_CONFIG		\N	4.23.2	\N	\N	7901269232
+23.0.0-17258	keycloak	META-INF/jpa-changelog-23.0.0.xml	2024-02-14 09:01:09.343484	119	EXECUTED	9:36506d679a83bbfda85a27ea1864dca8	addColumn tableName=EVENT_ENTITY		\N	4.23.2	\N	\N	7901269232
 \.
 
 
@@ -2385,9 +2379,9 @@ grafana	a5bb3a5f-fd26-4be6-9557-26e20a03d33d	f
 grafana	d6ffe9fc-a03c-4496-85dc-dbb5e7754587	f
 grafana	d6077ed7-b265-4f82-9336-24614967bd5d	t
 grafana	699671ab-e7c1-4fcf-beb8-ea54f1471fc1	t
-grafana	c61f5b19-c17e-49a1-91b8-a0296411b928	f
 grafana	d30340a8-630b-416e-8c93-3ccf932d34f3	t
 master	a96603aa-e6db-4b3e-8baa-679c75ccfc8f	t
+grafana	c61f5b19-c17e-49a1-91b8-a0296411b928	t
 \.
 
 
@@ -2395,7 +2389,7 @@ master	a96603aa-e6db-4b3e-8baa-679c75ccfc8f	t
 -- Data for Name: event_entity; Type: TABLE DATA; Schema: public; Owner: keycloak
 --
 
-COPY public.event_entity (id, client_id, details_json, error, ip_address, realm_id, session_id, event_time, type, user_id) FROM stdin;
+COPY public.event_entity (id, client_id, details_json, error, ip_address, realm_id, session_id, event_time, type, user_id, details_json_long_value) FROM stdin;
 \.
 
 
@@ -2524,6 +2518,9 @@ COPY public.idp_mapper_config (idp_mapper_id, value, name) FROM stdin;
 --
 
 COPY public.keycloak_group (id, name, parent_group, realm_id) FROM stdin;
+f1975bf4-6e92-479a-923c-d7d5b65d684c	First	 	grafana
+fe974984-8b18-4925-beef-37b6cfb6af7b	Second	 	grafana
+4cc0bd0f-9071-42a9-b282-be22515156ba	Third	 	grafana
 \.
 
 
@@ -2628,6 +2625,7 @@ c9a895d1-c901-46b0-91cf-2c67902b4a93	a5a8fed6-0bca-4646-9946-2fe84175353b	t	${ro
 COPY public.migration_model (id, version, update_time) FROM stdin;
 g5slr	12.0.1	1643820448
 wupxt	20.0.2	1673274863
+y2nke	23.0.1	1707901269
 \.
 
 
@@ -2710,13 +2708,13 @@ b4854867-3bfb-409b-92a8-6ec37db17f99	phone number verified	openid-connect	oidc-u
 1fc8999a-04d9-421b-8557-e417a3750358	realm roles	openid-connect	oidc-usermodel-realm-role-mapper	\N	d6077ed7-b265-4f82-9336-24614967bd5d
 384e97dd-36ad-4b0e-af63-d0cb3a2153d4	allowed web origins	openid-connect	oidc-allowed-origins-mapper	\N	699671ab-e7c1-4fcf-beb8-ea54f1471fc1
 f03cac68-3f0e-4068-9adf-ee64567689a7	upn	openid-connect	oidc-usermodel-property-mapper	\N	c61f5b19-c17e-49a1-91b8-a0296411b928
-04183ee1-b558-4f63-839f-922d30b34a9e	groups	openid-connect	oidc-usermodel-realm-role-mapper	\N	c61f5b19-c17e-49a1-91b8-a0296411b928
 df78645e-c32b-4160-b79f-42e622d71982	locale	openid-connect	oidc-usermodel-attribute-mapper	805aebc8-9d01-42b6-bcce-6ce48ca63ef0	\N
 0108b99f-2f31-4e73-9597-cb29e0e8c486	username	openid-connect	oidc-usermodel-property-mapper	\N	f619a55a-d565-4cc0-8bf4-4dbaab5382fe
 70b0a264-a7c3-43ff-b24f-14ca4f5f118e	login	openid-connect	oidc-usermodel-property-mapper	\N	0a7c7dde-23d7-4a93-bdee-4a8963aee9a4
 2f8ee9af-b6dd-4790-9e7b-cce83a603566	name	openid-connect	oidc-full-name-mapper	\N	d4723cd4-f717-44b7-a9b0-6c32c5ecd23f
 854a81a5-8e06-4257-98ec-0e3087356223	acr loa level	openid-connect	oidc-acr-mapper	\N	d30340a8-630b-416e-8c93-3ccf932d34f3
 53832401-d27c-489e-801f-9807cdaa4b08	acr loa level	openid-connect	oidc-acr-mapper	\N	a96603aa-e6db-4b3e-8baa-679c75ccfc8f
+6814ca6a-2d7d-495d-87ad-53e12b561808	groups	openid-connect	oidc-group-membership-mapper	\N	c61f5b19-c17e-49a1-91b8-a0296411b928
 \.
 
 
@@ -2991,12 +2989,6 @@ f03cac68-3f0e-4068-9adf-ee64567689a7	true	id.token.claim
 f03cac68-3f0e-4068-9adf-ee64567689a7	true	access.token.claim
 f03cac68-3f0e-4068-9adf-ee64567689a7	upn	claim.name
 f03cac68-3f0e-4068-9adf-ee64567689a7	String	jsonType.label
-04183ee1-b558-4f63-839f-922d30b34a9e	true	multivalued
-04183ee1-b558-4f63-839f-922d30b34a9e	foo	user.attribute
-04183ee1-b558-4f63-839f-922d30b34a9e	true	id.token.claim
-04183ee1-b558-4f63-839f-922d30b34a9e	true	access.token.claim
-04183ee1-b558-4f63-839f-922d30b34a9e	groups	claim.name
-04183ee1-b558-4f63-839f-922d30b34a9e	String	jsonType.label
 df78645e-c32b-4160-b79f-42e622d71982	true	userinfo.token.claim
 df78645e-c32b-4160-b79f-42e622d71982	locale	user.attribute
 df78645e-c32b-4160-b79f-42e622d71982	true	id.token.claim
@@ -3025,6 +3017,13 @@ df78645e-c32b-4160-b79f-42e622d71982	String	jsonType.label
 854a81a5-8e06-4257-98ec-0e3087356223	true	access.token.claim
 53832401-d27c-489e-801f-9807cdaa4b08	true	id.token.claim
 53832401-d27c-489e-801f-9807cdaa4b08	true	access.token.claim
+6814ca6a-2d7d-495d-87ad-53e12b561808	true	introspection.token.claim
+6814ca6a-2d7d-495d-87ad-53e12b561808	true	userinfo.token.claim
+6814ca6a-2d7d-495d-87ad-53e12b561808	true	id.token.claim
+6814ca6a-2d7d-495d-87ad-53e12b561808	true	access.token.claim
+6814ca6a-2d7d-495d-87ad-53e12b561808	groups	claim.name
+6814ca6a-2d7d-495d-87ad-53e12b561808	false	full.path
+6814ca6a-2d7d-495d-87ad-53e12b561808	true	multivalued
 \.
 
 
@@ -3199,16 +3198,16 @@ ad4dfd2c-307a-4563-b93a-0bb726b4ccaa	VERIFY_EMAIL	Verify Email	master	t	f	VERIFY
 2c7fffa4-ff20-4015-9a97-cc6a19e698ba	UPDATE_PROFILE	Update Profile	master	t	f	UPDATE_PROFILE	40
 c76d17f4-eacf-497a-ab5a-f78936bbc50e	CONFIGURE_TOTP	Configure OTP	master	t	f	CONFIGURE_TOTP	10
 83de9f97-43df-4265-982c-5414a2b19985	UPDATE_PASSWORD	Update Password	master	t	f	UPDATE_PASSWORD	30
-9f538737-770e-4731-abd9-e98172a85d2f	terms_and_conditions	Terms and Conditions	master	f	f	terms_and_conditions	20
 306fc47e-d8ae-4bb1-b2bc-53608a44536c	update_user_locale	Update User Locale	master	t	f	update_user_locale	1000
 f158f7d8-8b7f-414c-b1bd-0dde83c91133	delete_account	Delete Account	master	f	f	delete_account	60
 969a57d1-c906-4f49-87d6-3cbba2f3898a	VERIFY_EMAIL	Verify Email	grafana	t	f	VERIFY_EMAIL	50
 233d5b8e-6f36-450f-bffd-43b82e27295c	UPDATE_PROFILE	Update Profile	grafana	t	f	UPDATE_PROFILE	40
 ab3a9aa7-3d1b-4fb1-93ad-9412142deed3	CONFIGURE_TOTP	Configure OTP	grafana	t	f	CONFIGURE_TOTP	10
 988d8e0d-35ef-4e6a-8b48-821cca56acf2	UPDATE_PASSWORD	Update Password	grafana	t	f	UPDATE_PASSWORD	30
-0e2b6144-5c2c-4dcb-92d8-00529b19a7a5	terms_and_conditions	Terms and Conditions	grafana	f	f	terms_and_conditions	20
 94993a02-f883-4f8a-a549-d48f95aabed2	update_user_locale	Update User Locale	grafana	t	f	update_user_locale	1000
 72d09b7f-acde-4b90-af9a-ea3c642a2f6d	delete_account	Delete Account	grafana	f	f	delete_account	60
+9f538737-770e-4731-abd9-e98172a85d2f	TERMS_AND_CONDITIONS	Terms and Conditions	master	f	f	TERMS_AND_CONDITIONS	20
+0e2b6144-5c2c-4dcb-92d8-00529b19a7a5	TERMS_AND_CONDITIONS	Terms and Conditions	grafana	f	f	TERMS_AND_CONDITIONS	20
 \.
 
 
@@ -3386,6 +3385,11 @@ COPY public.user_federation_provider (id, changed_sync_period, display_name, ful
 --
 
 COPY public.user_group_membership (group_id, user_id) FROM stdin;
+f1975bf4-6e92-479a-923c-d7d5b65d684c	88692d07-bb9a-46cf-844c-7ff5c529cd04
+f1975bf4-6e92-479a-923c-d7d5b65d684c	8f58cbec-6e40-4bab-bff0-1c5ff899fe2e
+fe974984-8b18-4925-beef-37b6cfb6af7b	88692d07-bb9a-46cf-844c-7ff5c529cd04
+4cc0bd0f-9071-42a9-b282-be22515156ba	6db3c5e5-b84b-4f9d-a7a8-8d05b03c929d
+4cc0bd0f-9071-42a9-b282-be22515156ba	1a85b7e0-4baa-420b-89f8-1cea43a540dd
 \.
 
 


### PR DESCRIPTION
**What is this feature?**
Setup `jwt_proxy` with predefined Groups and add those to the JWT under the claim `groups`.

Added 3 groups for testing:
```
Name: First
Members: jwt-editor, jwt-viewer
---
Name: Second
Members: jwt-editor
---
Name: Third
Members: jwt-admin, jwt-grafanaadmin
```

**Why do we need this feature?**
To test `groups_attribute_path` which has been introduced in #82175 

**Who is this feature for?**

[Add information on what kind of user the feature is for.]

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
