### PR TITLE
[10.1.x] Fix spellcheck

### DIFF
--- a/contribute/merge-pull-request.md
+++ b/contribute/merge-pull-request.md
@@ -48,8 +48,8 @@ Instead, when it is merged & closed then a bot will look for the most appropriat
 
 That milestone should always reflect the branch that the pull request is merged into.
 For every major and minor release there is a milestone ending with `.x` (e.g. `10.0.x` for the 10.0.x releases).
-Pull requests targetting `main` should use the `.x` milestone of the next minor (or major) version (you can find that version number inside the `package.json` file).
-Backport pull requestss should use the version of the target branch (e.g. `9.4.x` for the `v9.4.x` branch).
+Pull requests targeting `main` should use the `.x` milestone of the next minor (or major) version (you can find that version number inside the `package.json` file).
+Backport pull requests should use the version of the target branch (e.g. `9.4.x` for the `v9.4.x` branch).
 
 ### Include in changelog and release notes?
 

--- a/packages/README.md
+++ b/packages/README.md
@@ -36,7 +36,7 @@ Every commit to main that has changes within the `packages` directory is a subje
 
 > All of the steps below must be performed on a release branch, according to Grafana Release Guide.
 
-> You must be logged in to NPM as part of Grafana NPM org before attempting to publish to the npm registery.
+> You must be logged in to NPM as part of Grafana NPM org before attempting to publish to the npm registry.
 
 1. Run `yarn packages:clean` script from the root directory. This will delete any previous builds of the packages.
 2. Run `yarn packages:prepare` script from the root directory. This performs tests on the packages and prompts for the version of the packages. The version should be the same as the one being released.


### PR DESCRIPTION
Fixes typo in documentation that is preventing the CI to run in other PRs.
In main this is fixed, but the commit contains other changes that we don't want to backport.