### PR TITLE
Revert: Scenes/PanelEditor: Fix panel options search crash #82003

### DIFF
--- a/public/app/features/dashboard-scene/panel-edit/PanelOptionsPane.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelOptionsPane.tsx
@@ -5,7 +5,7 @@ import { GrafanaTheme2 } from '@grafana/data';
 import { selectors } from '@grafana/e2e-selectors';
 import { SceneComponentProps, SceneObjectBase, SceneObjectState, sceneGraph } from '@grafana/scenes';
 import { Box, ButtonGroup, FilterInput, RadioButtonGroup, ToolbarButton, useStyles2 } from '@grafana/ui';
-import { OptionFilter, RenderSearchHits } from 'app/features/dashboard/components/PanelEditor/OptionsPaneOptions';
+import { OptionFilter, renderSearchHits } from 'app/features/dashboard/components/PanelEditor/OptionsPaneOptions';
 import { getFieldOverrideCategories } from 'app/features/dashboard/components/PanelEditor/getFieldOverrideElements';
 import { getPanelFrameCategory2 } from 'app/features/dashboard/components/PanelEditor/getPanelFrameOptions';
 import { getVisualizationOptions2 } from 'app/features/dashboard/components/PanelEditor/getVisualizationOptions';
@@ -97,29 +97,24 @@ export class PanelOptionsPane extends SceneObjectBase<PanelOptionsPaneState> {
 
     if (isSearching) {
       mainBoxElements.push(
-        <RenderSearchHits
-          allOptions={[panelFrameOptions, ...(visualizationOptions ?? [])]}
-          overrides={justOverrides}
-          searchQuery={searchQuery}
-          key="render-search-hits"
-        />
+        renderSearchHits([panelFrameOptions, ...(visualizationOptions ?? [])], justOverrides, searchQuery)
       );
     } else {
       switch (listMode) {
         case OptionFilter.All:
-          mainBoxElements.push(<panelFrameOptions.Render key="panel-frame-options" />);
+          mainBoxElements.push(panelFrameOptions.render());
 
           for (const item of visualizationOptions ?? []) {
-            mainBoxElements.push(<item.Render key={item.props.id} />);
+            mainBoxElements.push(item.render());
           }
 
           for (const item of justOverrides) {
-            mainBoxElements.push(<item.Render key={item.props.id} />);
+            mainBoxElements.push(item.render());
           }
           break;
         case OptionFilter.Overrides:
           for (const item of justOverrides) {
-            mainBoxElements.push(<item.Render key={item.props.id} />);
+            mainBoxElements.push(item.render());
           }
         default:
           break;

--- a/public/app/features/dashboard/components/PanelEditor/OptionsPaneCategoryDescriptor.tsx
+++ b/public/app/features/dashboard/components/PanelEditor/OptionsPaneCategoryDescriptor.tsx
@@ -52,7 +52,7 @@ export class OptionsPaneCategoryDescriptor {
     return sub;
   }
 
-  Render = ({ searchQuery }: { searchQuery?: string }) => {
+  render(searchQuery?: string) {
     if (this.props.customRender) {
       return this.props.customRender();
     }
@@ -60,10 +60,8 @@ export class OptionsPaneCategoryDescriptor {
     return (
       <OptionsPaneCategory key={this.props.title} {...this.props}>
         {this.items.map((item) => item.render(searchQuery))}
-        {this.categories.map((category) => (
-          <category.Render key={category.props.id} searchQuery={searchQuery} />
-        ))}
+        {this.categories.map((category) => category.render(searchQuery))}
       </OptionsPaneCategory>
     );
-  };
+  }
 }

--- a/public/app/features/dashboard/components/PanelEditor/OptionsPaneOptions.tsx
+++ b/public/app/features/dashboard/components/PanelEditor/OptionsPaneOptions.tsx
@@ -54,14 +54,7 @@ export const OptionsPaneOptions = (props: OptionPaneRenderProps) => {
     : [panelFrameOptions, ...vizOptions];
 
   if (isSearching) {
-    mainBoxElements.push(
-      <RenderSearchHits
-        key="render-search-hits"
-        allOptions={allOptions}
-        overrides={justOverrides}
-        searchQuery={searchQuery}
-      />
-    );
+    mainBoxElements.push(renderSearchHits(allOptions, justOverrides, searchQuery));
 
     // If searching for angular panel, then we need to add notice that results are limited
     if (props.plugin.angularPanelCtrl) {
@@ -76,10 +69,10 @@ export const OptionsPaneOptions = (props: OptionPaneRenderProps) => {
       case OptionFilter.All:
         if (isPanelModelLibraryPanel(panel)) {
           // Library Panel options first
-          mainBoxElements.push(<libraryPanelOptions.Render key="library-panel-options" />);
+          mainBoxElements.push(libraryPanelOptions.render());
         }
         // Panel frame options second
-        mainBoxElements.push(<panelFrameOptions.Render key="panel-frame-options" />);
+        mainBoxElements.push(panelFrameOptions.render());
         // If angular add those options next
         if (props.plugin.angularPanelCtrl) {
           mainBoxElements.push(
@@ -88,16 +81,16 @@ export const OptionsPaneOptions = (props: OptionPaneRenderProps) => {
         }
         // Then add all panel and field defaults
         for (const item of vizOptions) {
-          mainBoxElements.push(<item.Render key={item.props.id} />);
+          mainBoxElements.push(item.render());
         }
 
         for (const item of justOverrides) {
-          mainBoxElements.push(<item.Render key={item.props.id} />);
+          mainBoxElements.push(item.render());
         }
         break;
       case OptionFilter.Overrides:
         for (const override of justOverrides) {
-          mainBoxElements.push(<override.Render key={override.props.id} />);
+          mainBoxElements.push(override.render());
         }
         break;
       case OptionFilter.Recent:
@@ -157,13 +150,11 @@ export enum OptionFilter {
   Recent = 'Recent',
 }
 
-interface RenderSearchHitsProps {
-  allOptions: OptionsPaneCategoryDescriptor[];
-  overrides: OptionsPaneCategoryDescriptor[];
-  searchQuery: string;
-}
-
-export function RenderSearchHits({ allOptions, overrides, searchQuery }: RenderSearchHitsProps) {
+export function renderSearchHits(
+  allOptions: OptionsPaneCategoryDescriptor[],
+  overrides: OptionsPaneCategoryDescriptor[],
+  searchQuery: string
+) {
   const engine = new OptionSearchEngine(allOptions, overrides);
   const { optionHits, totalCount, overrideHits } = engine.search(searchQuery);
 
@@ -177,9 +168,7 @@ export function RenderSearchHits({ allOptions, overrides, searchQuery }: RenderS
       >
         {optionHits.map((hit) => hit.render(searchQuery))}
       </OptionsPaneCategory>
-      {overrideHits.map((override) => (
-        <override.Render key={override.props.id} searchQuery={searchQuery} />
-      ))}
+      {overrideHits.map((override) => override.render(searchQuery))}
     </div>
   );
 }


### PR DESCRIPTION
Revert  #82003  due to these regression in panel options: 

#### Custom color picker not working
https://github.com/grafana/grafana/assets/239999/479027b8-99be-413b-abfe-8d822fccb850

####  Slider element in FieldConfig not working
https://github.com/grafana/grafana/assets/239999/d5ef6126-734d-444b-95c0-cbc2aa1c7917



Fixes: #82405 