### PR TITLE
Logs Popover Menu: Available within table view

### DIFF
--- a/public/app/features/explore/Logs/Logs.tsx
+++ b/public/app/features/explore/Logs/Logs.tsx
@@ -809,10 +809,13 @@ class UnthemedLogs extends PureComponent<Props, State> {
                   logsFrames={this.props.logsFrames ?? []}
                   onClickFilterLabel={onClickFilterLabel}
                   onClickFilterOutLabel={onClickFilterOutLabel}
+                  onClickFilterValue={this.props.onClickFilterValue}
+                  onClickFilterOutValue={this.props.onClickFilterOutValue}
                   panelState={this.props.panelState?.logs}
                   theme={theme}
                   updatePanelState={this.updatePanelState}
                   datasourceType={this.props.datasourceType}
+                  app={CoreApp.Explore}
                 />
               </div>
             )}

--- a/public/app/features/explore/Logs/PopoverMenu.test.tsx
+++ b/public/app/features/explore/Logs/PopoverMenu.test.tsx
@@ -9,7 +9,7 @@ import { PopoverMenu } from './PopoverMenu';
 const row = createLogRow();
 
 test('Does not render if the filter functions are not defined', () => {
-  render(<PopoverMenu selection="test" x={0} y={0} row={row} close={() => {}} />);
+  render(<PopoverMenu selection="test" x={0} y={0} refId={row.dataFrame.refId} close={() => {}} />);
 
   expect(screen.queryByText('Copy selection')).not.toBeInTheDocument();
 });
@@ -17,7 +17,14 @@ test('Does not render if the filter functions are not defined', () => {
 test('Renders copy and line contains filter', async () => {
   const onClickFilterValue = jest.fn();
   render(
-    <PopoverMenu selection="test" x={0} y={0} row={row} close={() => {}} onClickFilterValue={onClickFilterValue} />
+    <PopoverMenu
+      selection="test"
+      x={0}
+      y={0}
+      refId={row.dataFrame.refId}
+      close={() => {}}
+      onClickFilterValue={onClickFilterValue}
+    />
   );
 
   expect(screen.getByText('Copy selection')).toBeInTheDocument();
@@ -36,7 +43,7 @@ test('Renders copy and line does not contain filter', async () => {
       selection="test"
       x={0}
       y={0}
-      row={row}
+      refId={row.dataFrame.refId}
       close={() => {}}
       onClickFilterOutValue={onClickFilterOutValue}
     />
@@ -57,7 +64,7 @@ test('Renders copy, line contains filter, and line does not contain filter', () 
       selection="test"
       x={0}
       y={0}
-      row={row}
+      refId={row.dataFrame.refId}
       close={() => {}}
       onClickFilterValue={() => {}}
       onClickFilterOutValue={() => {}}
@@ -76,7 +83,7 @@ test('Can be dismissed with escape', async () => {
       selection="test"
       x={0}
       y={0}
-      row={row}
+      refId={row.dataFrame.refId}
       close={close}
       onClickFilterValue={() => {}}
       onClickFilterOutValue={() => {}}

--- a/public/app/features/explore/Logs/PopoverMenu.tsx
+++ b/public/app/features/explore/Logs/PopoverMenu.tsx
@@ -1,7 +1,7 @@
 import { css } from '@emotion/css';
 import React, { useEffect, useRef } from 'react';
 
-import { GrafanaTheme2, LogRowModel } from '@grafana/data';
+import { GrafanaTheme2 } from '@grafana/data';
 import { reportInteraction } from '@grafana/runtime';
 import { Menu, useStyles2 } from '@grafana/ui';
 

--- a/public/app/features/explore/Logs/PopoverMenu.tsx
+++ b/public/app/features/explore/Logs/PopoverMenu.tsx
@@ -13,8 +13,9 @@ interface PopoverMenuProps {
   y: number;
   onClickFilterValue?: (value: string, refId?: string) => void;
   onClickFilterOutValue?: (value: string, refId?: string) => void;
-  row: LogRowModel;
   close: () => void;
+  refId?: string;
+  dataSourceType?: string;
 }
 
 export const PopoverMenu = ({
@@ -23,8 +24,9 @@ export const PopoverMenu = ({
   onClickFilterValue,
   onClickFilterOutValue,
   selection,
-  row,
   close,
+  refId,
+  dataSourceType,
 }: PopoverMenuProps) => {
   const containerRef = useRef<HTMLDivElement | null>(null);
   const styles = useStyles2(getStyles);
@@ -56,16 +58,16 @@ export const PopoverMenu = ({
           onClick={() => {
             copyText(selection, containerRef);
             close();
-            track('copy', selection.length, row.datasourceType);
+            track('copy', selection.length, dataSourceType);
           }}
         />
         {onClickFilterValue && (
           <Menu.Item
             label="Add as line contains filter"
             onClick={() => {
-              onClickFilterValue(selection, row.dataFrame.refId);
+              onClickFilterValue(selection, refId);
               close();
-              track('line_contains', selection.length, row.datasourceType);
+              track('line_contains', selection.length, dataSourceType);
             }}
           />
         )}
@@ -73,9 +75,9 @@ export const PopoverMenu = ({
           <Menu.Item
             label="Add as line does not contain filter"
             onClick={() => {
-              onClickFilterOutValue(selection, row.dataFrame.refId);
+              onClickFilterOutValue(selection, refId);
               close();
-              track('line_does_not_contain', selection.length, row.datasourceType);
+              track('line_does_not_contain', selection.length, dataSourceType);
             }}
           />
         )}

--- a/public/app/features/logs/components/LogRows.tsx
+++ b/public/app/features/logs/components/LogRows.tsx
@@ -209,7 +209,8 @@ class UnThemedLogRows extends PureComponent<Props, State> {
         {this.state.selection && this.state.selectedRow && (
           <PopoverMenu
             close={this.closePopoverMenu}
-            row={this.state.selectedRow}
+            refId={this.state.selectedRow.dataFrame?.refId}
+            dataSourceType={this.state.selectedRow.datasourceType}
             selection={this.state.selection}
             {...this.state.popoverMenuCoordinates}
             onClickFilterValue={rest.onClickFilterValue}


### PR DESCRIPTION
Analog to the Logs or "list" view, we could easily support the popover menu in the Table view. These changes should also potentially be useful for the Logs app.

As far as I can see, it behaves in the same way as it does in the Logs view.

**Which issue(s) does this PR fix?**:

Part of https://github.com/grafana/grafana/issues/76129

**Special notes for your reviewer:**

Give it a try, let me know if you find anything unusual.

**Known limitations**: clipping when selecting close to the right scroll.

![imagen](https://github.com/grafana/grafana/assets/1069378/8746a495-9c66-4677-9280-f07c47337a48)

<img src="https://github.com/grafana/grafana/assets/1069378/184fc58f-286a-4b7a-b1e6-6643e6917a75" width="400">

The same thing happens with the Logs view, so we should tackle both afterwards.

![imagen](https://github.com/grafana/grafana/assets/1069378/baca7350-fa8f-4dc0-b374-56962b748070)
