### PR TITLE
Table Panel: Fix display of ad-hoc filter actions

### DIFF
--- a/packages/grafana-ui/src/components/Table/styles.ts
+++ b/packages/grafana-ui/src/components/Table/styles.ts
@@ -24,7 +24,7 @@ export function useTableStyles(theme: GrafanaTheme2, cellHeightOption: TableCell
       // Cell height need to account for row border
       height: `${rowHeight - 1}px`,
 
-      display: asCellText ? 'block' : 'flex',
+      display: 'flex',
 
       ...(asCellText
         ? {


### PR DESCRIPTION
**What is this feature?**

This fixes an issue that came along with some changes that were made to improve table performance by not rendering actions for all table cells because they're not displayed. This was [identified here](https://github.com/grafana/grafana/pull/76906/files#r1487341197).

Should be fairly straightforward to check by creating a table with the test datasource, and enabling ad-hoc filters for a numeric filters.  It shouldn't show the overflow as it does in the linked comment.