### PR TITLE
Logs Panel: Add CSV to download options

### DIFF
--- a/public/app/features/explore/Logs/LogsMetaRow.test.tsx
+++ b/public/app/features/explore/Logs/LogsMetaRow.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { fireEvent, render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import saveAs from 'file-saver';
 import React, { ComponentProps } from 'react';

--- a/public/app/features/explore/Logs/LogsMetaRow.test.tsx
+++ b/public/app/features/explore/Logs/LogsMetaRow.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import saveAs from 'file-saver';
 import React, { ComponentProps } from 'react';
@@ -224,11 +224,49 @@ describe('LogsMetaRow', () => {
         entryFieldIndex: 0,
         dataFrame: toDataFrame({
           name: 'logs',
+          refId: 'A',
           fields: [
             {
               name: 'time',
               type: FieldType.time,
               values: ['1970-01-01T00:00:00Z'],
+            },
+            {
+              name: 'message',
+              type: FieldType.string,
+              values: ['INFO 1'],
+              labels: {
+                foo: 'bar',
+              },
+            },
+          ],
+        }),
+        entry: 'test entry',
+        hasAnsi: false,
+        hasUnescapedContent: false,
+        labels: {
+          foo: 'bar',
+        },
+        logLevel: LogLevel.info,
+        raw: '',
+        timeEpochMs: 10,
+        timeEpochNs: '123456789',
+        timeFromNow: '',
+        timeLocal: '',
+        timeUtc: '',
+        uid: '2',
+      },
+      {
+        rowIndex: 2,
+        entryFieldIndex: 1,
+        dataFrame: toDataFrame({
+          name: 'logs',
+          refId: 'B',
+          fields: [
+            {
+              name: 'time',
+              type: FieldType.time,
+              values: ['1970-01-02T00:00:00Z'],
             },
             {
               name: 'message',
@@ -266,10 +304,11 @@ describe('LogsMetaRow', () => {
       })
     );
 
-    expect(saveAs).toBeCalled();
+    expect(saveAs).toBeCalledTimes(2);
+
     const blob = (saveAs as unknown as jest.Mock).mock.lastCall[0];
     expect(blob.type).toBe('text/csv;charset=utf-8');
     const text = await blob.text();
-    expect(text).toBe(`"time","message bar"\r\n1970-01-01T00:00:00Z,INFO 1`);
+    expect(text).toBe(`"time","message bar"\r\n1970-01-02T00:00:00Z,INFO 1`);
   });
 });

--- a/public/app/features/explore/Logs/LogsMetaRow.test.tsx
+++ b/public/app/features/explore/Logs/LogsMetaRow.test.tsx
@@ -303,8 +303,7 @@ describe('LogsMetaRow', () => {
         name: 'csv',
       })
     );
-
-    expect(saveAs).toBeCalledTimes(2);
+    expect(saveAs).toBeCalled();
 
     const blob = (saveAs as unknown as jest.Mock).mock.lastCall[0];
     expect(blob.type).toBe('text/csv;charset=utf-8');

--- a/public/app/features/explore/Logs/LogsMetaRow.test.tsx
+++ b/public/app/features/explore/Logs/LogsMetaRow.test.tsx
@@ -3,10 +3,12 @@ import userEvent from '@testing-library/user-event';
 import saveAs from 'file-saver';
 import React, { ComponentProps } from 'react';
 
-import { FieldType, LogLevel, LogsDedupStrategy, toDataFrame } from '@grafana/data';
+import { FieldType, LogLevel, LogsDedupStrategy, standardTransformersRegistry, toDataFrame } from '@grafana/data';
+import { organizeFieldsTransformer } from '@grafana/data/src/transformations/transformers/organize';
 
 import { MAX_CHARACTERS } from '../../logs/components/LogRowMessage';
 import { logRowsToReadableJson } from '../../logs/utils';
+import { extractFieldsTransformer } from '../../transformers/extractFields/extractFields';
 
 import { LogsMetaRow } from './LogsMetaRow';
 
@@ -199,5 +201,75 @@ describe('LogsMetaRow', () => {
     expect(blob.type).toBe('application/json;charset=utf-8');
     const text = await blob.text();
     expect(text).toBe(JSON.stringify(logRowsToReadableJson(rows)));
+  });
+
+  it('renders a button to download CSV', async () => {
+    const transformers = [extractFieldsTransformer, organizeFieldsTransformer];
+    standardTransformersRegistry.setInit(() => {
+      return transformers.map((t) => {
+        return {
+          id: t.id,
+          aliasIds: t.aliasIds,
+          name: t.name,
+          transformation: t,
+          description: t.description,
+          editor: () => null,
+        };
+      });
+    });
+
+    const rows = [
+      {
+        rowIndex: 1,
+        entryFieldIndex: 0,
+        dataFrame: toDataFrame({
+          name: 'logs',
+          fields: [
+            {
+              name: 'time',
+              type: FieldType.time,
+              values: ['1970-01-01T00:00:00Z'],
+            },
+            {
+              name: 'message',
+              type: FieldType.string,
+              values: ['INFO 1'],
+              labels: {
+                foo: 'bar',
+              },
+            },
+          ],
+        }),
+        entry: 'test entry',
+        hasAnsi: false,
+        hasUnescapedContent: false,
+        labels: {
+          foo: 'bar',
+        },
+        logLevel: LogLevel.info,
+        raw: '',
+        timeEpochMs: 10,
+        timeEpochNs: '123456789',
+        timeFromNow: '',
+        timeLocal: '',
+        timeUtc: '',
+        uid: '2',
+      },
+    ];
+    setup({ logRows: rows });
+
+    await userEvent.click(screen.getByText('Download').closest('button')!);
+
+    await userEvent.click(
+      screen.getByRole('menuitem', {
+        name: 'csv',
+      })
+    );
+
+    expect(saveAs).toBeCalled();
+    const blob = (saveAs as unknown as jest.Mock).mock.lastCall[0];
+    expect(blob.type).toBe('text/csv;charset=utf-8');
+    const text = await blob.text();
+    expect(text).toBe(`"time","message bar"\r\n1970-01-01T00:00:00Z,INFO 1`);
   });
 });

--- a/public/app/features/explore/Logs/LogsMetaRow.tsx
+++ b/public/app/features/explore/Logs/LogsMetaRow.tsx
@@ -73,8 +73,6 @@ export const LogsMetaRow = React.memo(
         area: 'logs-meta-row',
       });
 
-      const fileName = `Explore-logs-${dateTimeFormat(new Date())}.json`;
-
       switch (format) {
         case DownloadFormat.Text:
           downloadLogsModelAsTxt({ meta, rows: logRows }, 'Explore');
@@ -84,7 +82,7 @@ export const LogsMetaRow = React.memo(
           const blob = new Blob([JSON.stringify(jsonLogs)], {
             type: 'application/json;charset=utf-8',
           });
-
+          const fileName = `Explore-logs-${dateTimeFormat(new Date())}.json`;
           saveAs(blob, fileName);
           break;
         case DownloadFormat.CSV:

--- a/public/app/features/explore/Logs/LogsMetaRow.tsx
+++ b/public/app/features/explore/Logs/LogsMetaRow.tsx
@@ -104,7 +104,7 @@ export const LogsMetaRow = React.memo(
               },
             });
             const transformedDataFrame = await lastValueFrom(transformDataFrame(transforms, [dataFrame]));
-            downloadDataFrameAsCsv(transformedDataFrame[0], 'Explore-logs');
+            downloadDataFrameAsCsv(transformedDataFrame[0], `Explore-logs-${dataFrame.refId}`);
           });
       }
     };

--- a/public/app/features/explore/Logs/LogsMetaRow.tsx
+++ b/public/app/features/explore/Logs/LogsMetaRow.tsx
@@ -1,16 +1,29 @@
 import { css } from '@emotion/css';
 import saveAs from 'file-saver';
 import React from 'react';
+import { lastValueFrom } from 'rxjs';
 
-import { LogsDedupStrategy, LogsMetaItem, LogsMetaKind, LogRowModel, CoreApp, dateTimeFormat } from '@grafana/data';
+import {
+  LogsDedupStrategy,
+  LogsMetaItem,
+  LogsMetaKind,
+  LogRowModel,
+  CoreApp,
+  dateTimeFormat,
+  transformDataFrame,
+  DataTransformerConfig,
+  CustomTransformOperator,
+} from '@grafana/data';
 import { reportInteraction } from '@grafana/runtime';
 import { Button, Dropdown, Menu, ToolbarButton, Tooltip, useStyles2 } from '@grafana/ui';
 
-import { downloadLogsModelAsTxt } from '../../inspector/utils/download';
+import { downloadDataFrameAsCsv, downloadLogsModelAsTxt } from '../../inspector/utils/download';
 import { LogLabels } from '../../logs/components/LogLabels';
 import { MAX_CHARACTERS } from '../../logs/components/LogRowMessage';
 import { logRowsToReadableJson } from '../../logs/utils';
 import { MetaInfoText, MetaItemProps } from '../MetaInfoText';
+
+import { getLogsExtractFields } from './LogsTable';
 
 const getStyles = () => ({
   metaContainer: css`
@@ -35,6 +48,7 @@ export type Props = {
 enum DownloadFormat {
   Text = 'text',
   Json = 'json',
+  CSV = 'csv',
 }
 
 export const LogsMetaRow = React.memo(
@@ -51,12 +65,14 @@ export const LogsMetaRow = React.memo(
   }: Props) => {
     const style = useStyles2(getStyles);
 
-    const downloadLogs = (format: DownloadFormat) => {
+    const downloadLogs = async (format: DownloadFormat) => {
       reportInteraction('grafana_logs_download_logs_clicked', {
         app: CoreApp.Explore,
         format,
         area: 'logs-meta-row',
       });
+
+      const fileName = `Explore-logs-${dateTimeFormat(new Date())}.json`;
 
       switch (format) {
         case DownloadFormat.Text:
@@ -68,9 +84,22 @@ export const LogsMetaRow = React.memo(
             type: 'application/json;charset=utf-8',
           });
 
-          const fileName = `Explore-logs-${dateTimeFormat(new Date())}.json`;
           saveAs(blob, fileName);
           break;
+        case DownloadFormat.CSV:
+          const dataFrame = logRows[0].dataFrame;
+          const transforms: Array<DataTransformerConfig | CustomTransformOperator> = getLogsExtractFields(dataFrame);
+          transforms.push({
+            id: 'organize',
+            options: {
+              excludeByName: {
+                ['labels']: true,
+                ['labelTypes']: true,
+              },
+            },
+          });
+          const transformedDataFrame = await lastValueFrom(transformDataFrame(transforms, [dataFrame]));
+          downloadDataFrameAsCsv(transformedDataFrame[0], fileName);
       }
     };
 
@@ -131,6 +160,7 @@ export const LogsMetaRow = React.memo(
       <Menu>
         <Menu.Item label="txt" onClick={() => downloadLogs(DownloadFormat.Text)} />
         <Menu.Item label="json" onClick={() => downloadLogs(DownloadFormat.Json)} />
+        <Menu.Item label="csv" onClick={() => downloadLogs(DownloadFormat.CSV)} />
       </Menu>
     );
     return (

--- a/public/app/features/explore/Logs/LogsTable.tsx
+++ b/public/app/features/explore/Logs/LogsTable.tsx
@@ -105,7 +105,7 @@ export function LogsTable(props: Props) {
       }
 
       // create extract JSON transformation for every field that is `json.RawMessage`
-      const transformations: Array<DataTransformerConfig | CustomTransformOperator> = extractFields(dataFrame);
+      const transformations: Array<DataTransformerConfig | CustomTransformOperator> = getLogsExtractFields(dataFrame);
 
       let labelFilters = buildLabelFilters(columnsWithMeta);
 
@@ -197,7 +197,7 @@ const isFieldFilterable = (field: Field, bodyName: string, timeName: string) => 
 
 // TODO: explore if `logsFrame.ts` can help us with getting the right fields
 // TODO Why is typeInfo not defined on the Field interface?
-function extractFields(dataFrame: DataFrame) {
+export function getLogsExtractFields(dataFrame: DataFrame) {
   return dataFrame.fields
     .filter((field: Field & { typeInfo?: { frame: string } }) => {
       const isFieldLokiLabels =


### PR DESCRIPTION
**What is this feature?**
Adding CSV option to logs download.
<img width="618" alt="image" src="https://github.com/grafana/grafana/assets/109082771/24111d95-e3e2-4dca-86c2-05b64f421238">

**Why do we need this feature?**
We got this feedback quite a bit from the logs table feedback form while it was in public preview.
While there is a CSV download in the query inspector the labels aren't extracted so it's not really helpful, also it's not anywhere near the other download options in the UI so I get that users are confused.

**Who is this feature for?**
Users of logs in explore.

**Special notes for your reviewer:**


Please check that:
- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
