### PR TITLE
Alerting: Async loading of rules from the database

### DIFF
--- a/docs/sources/setup-grafana/configure-grafana/feature-toggles/index.md
+++ b/docs/sources/setup-grafana/configure-grafana/feature-toggles/index.md
@@ -178,6 +178,7 @@ Experimental features might be changed or removed without prior notice.
 | `nodeGraphDotLayout`                        | Changed the layout algorithm for the node graph                                                                                                                                                                                                                                   |
 | `newPDFRendering`                           | New implementation for the dashboard to PDF rendering                                                                                                                                                                                                                             |
 | `kubernetesAggregator`                      | Enable grafana aggregator                                                                                                                                                                                                                                                         |
+| `alertingFetchRulesAsync`                   | Eventually consistent loading of alert rules from the database                                                                                                                                                                                                                    |
 
 ## Development feature toggles
 

--- a/packages/grafana-data/src/types/featureToggles.gen.ts
+++ b/packages/grafana-data/src/types/featureToggles.gen.ts
@@ -182,4 +182,5 @@ export interface FeatureToggles {
   newPDFRendering?: boolean;
   kubernetesAggregator?: boolean;
   groupByVariable?: boolean;
+  alertingFetchRulesAsync?: boolean;
 }

--- a/pkg/services/featuremgmt/registry.go
+++ b/pkg/services/featuremgmt/registry.go
@@ -1221,6 +1221,17 @@ var (
 			HideFromDocs:      true,
 			HideFromAdminPage: true,
 		},
+		{
+			Name:              "alertingFetchRulesAsync",
+			Description:       "Eventually consistent loading of alert rules from the database",
+			Stage:             FeatureStageExperimental,
+			Owner:             grafanaAlertingSquad,
+			AllowSelfServe:    false,
+			HideFromDocs:      false,
+			HideFromAdminPage: false,
+			RequiresRestart:   true,
+			FrontendOnly:      false,
+		},
 	}
 )
 

--- a/pkg/services/featuremgmt/toggles_gen.csv
+++ b/pkg/services/featuremgmt/toggles_gen.csv
@@ -163,3 +163,4 @@ groupToNestedTableTransformation,preview,@grafana/dataviz-squad,false,false,true
 newPDFRendering,experimental,@grafana/sharing-squad,false,false,false
 kubernetesAggregator,experimental,@grafana/grafana-app-platform-squad,false,true,false
 groupByVariable,experimental,@grafana/dashboards-squad,false,false,false
+alertingFetchRulesAsync,experimental,@grafana/alerting-squad,false,true,false

--- a/pkg/services/featuremgmt/toggles_gen.go
+++ b/pkg/services/featuremgmt/toggles_gen.go
@@ -662,4 +662,8 @@ const (
 	// FlagGroupByVariable
 	// Enable groupBy variable support in scenes dashboards
 	FlagGroupByVariable = "groupByVariable"
+
+	// FlagAlertingFetchRulesAsync
+	// Eventually consistent loading of alert rules from the database
+	FlagAlertingFetchRulesAsync = "alertingFetchRulesAsync"
 )

--- a/pkg/services/featuremgmt/toggles_gen.json
+++ b/pkg/services/featuremgmt/toggles_gen.json
@@ -2109,6 +2109,22 @@
         "codeowner": "@grafana/plugins-platform-backend",
         "requiresRestart": true
       }
+    },
+    {
+      "metadata": {
+        "name": "alertingFetchRulesAsync",
+        "resourceVersion": "1707946216855",
+        "creationTimestamp": "2024-02-14T21:30:01Z",
+        "annotations": {
+          "grafana.app/updatedTimestamp": "2024-02-14 21:30:16.855050454 +0000 UTC"
+        }
+      },
+      "spec": {
+        "description": "Eventually consistent loading of alert rules from the database",
+        "stage": "experimental",
+        "codeowner": "@grafana/alerting-squad",
+        "requiresRestart": true
+      }
     }
   ]
 }

--- a/pkg/services/ngalert/ngalert.go
+++ b/pkg/services/ngalert/ngalert.go
@@ -447,10 +447,10 @@ func (ng *AlertNG) Run(ctx context.Context) error {
 		//
 		ng.stateManager.Warm(ctx, ng.store)
 
-		// Make sure we've at least tried to load rules before the scheduler starts.
-		ng.fetcher.Refresh(ctx)
-
 		if ng.FeatureToggles.IsEnabled(ctx, featuremgmt.FlagAlertingFetchRulesAsync) {
+			// Make sure we've at least tried to load rules before the scheduler starts.
+			ng.fetcher.Refresh(ctx)
+
 			children.Go(func() error {
 				return ng.fetcher.Run(subCtx)
 			})

--- a/pkg/services/ngalert/ngalert.go
+++ b/pkg/services/ngalert/ngalert.go
@@ -446,6 +446,9 @@ func (ng *AlertNG) Run(ctx context.Context) error {
 		//
 		ng.stateManager.Warm(ctx, ng.store)
 
+		// Make sure we've at least tried to load rules before the scheduler starts.
+		ng.fetcher.Refresh(ctx)
+
 		children.Go(func() error {
 			return ng.fetcher.Run(subCtx)
 		})

--- a/pkg/services/ngalert/schedule/fetcher.go
+++ b/pkg/services/ngalert/schedule/fetcher.go
@@ -9,6 +9,7 @@ import (
 	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/services/ngalert/metrics"
 	"github.com/grafana/grafana/pkg/services/ngalert/models"
+	"github.com/grafana/grafana/pkg/setting"
 )
 
 // RulesStore is a store that provides alert rules for scheduling
@@ -36,6 +37,10 @@ type BackgroundFetcher struct {
 }
 
 func NewBackgroundFetcher(cfg FetcherCfg, ruleStore RulesStore, metrics *metrics.Scheduler, logger log.Logger) *BackgroundFetcher {
+	if cfg.ReloadInterval <= 0 {
+		logger.Warn("A nonpositive reload interval was provided, falling back to the default")
+		cfg.ReloadInterval = setting.SchedulerBaseInterval
+	}
 	return &BackgroundFetcher{
 		cfg:                cfg,
 		ticker:             time.NewTicker(cfg.ReloadInterval),

--- a/pkg/services/ngalert/schedule/fetcher.go
+++ b/pkg/services/ngalert/schedule/fetcher.go
@@ -55,7 +55,7 @@ func NewBackgroundFetcher(cfg FetcherCfg, ruleStore RulesStore, metrics *metrics
 // Refresh forces a synchronous refresh and blocks until the refresh is done.
 // This is thread-safe with the periodic background refresh.
 func (f *BackgroundFetcher) Refresh(ctx context.Context) {
-	f.updateSchedulableAlertRules(context.Background())
+	f.updateSchedulableAlertRules(ctx)
 }
 
 func (f *BackgroundFetcher) Run(ctx context.Context) error {

--- a/pkg/services/ngalert/schedule/fetcher.go
+++ b/pkg/services/ngalert/schedule/fetcher.go
@@ -100,6 +100,13 @@ func (f *BackgroundFetcher) updateSchedulableAlertRules(ctx context.Context) {
 // It returns diff that contains rule keys that were updated since the last poll,
 // and an error if the database query encountered problems.
 func (sch *schedule) updateSchedulableAlertRules(ctx context.Context) (diff, error) {
+	if sch.fetchAsync {
+		r, f := sch.fetcher.Rules()
+		d := sch.schedulableAlertRules.set(r, f)
+		sch.log.Debug("Alert rules loaded for tick", "rulesCount", len(r), "foldersCount", len(f), "updatedRules", len(d.updated))
+		return d, nil
+	}
+
 	start := time.Now()
 	defer func() {
 		sch.metrics.UpdateSchedulableAlertRulesDuration.Observe(

--- a/pkg/services/ngalert/schedule/fetcher.go
+++ b/pkg/services/ngalert/schedule/fetcher.go
@@ -44,15 +44,17 @@ func NewBackgroundFetcher(cfg FetcherCfg, ruleStore RulesStore, metrics *metrics
 	}
 }
 
-func (f *BackgroundFetcher) Run(ctx context.Context) {
+func (f *BackgroundFetcher) Run(ctx context.Context) error {
+	f.logger.Info("Starting rules fetcher")
 	for {
 		select {
 		case <-f.ticker.C:
-			f.logger.Debug("Refreshing rules from storage.")
+			f.logger.Debug("Refreshing rules from storage")
 			f.updateSchedulableAlertRules(context.Background())
 		case <-ctx.Done():
 			f.ticker.Stop()
-			f.logger.Info("Fetcher is shut down.")
+			f.logger.Info("Fetcher is shut down")
+			return nil
 		}
 	}
 }

--- a/pkg/services/ngalert/schedule/fetcher_test.go
+++ b/pkg/services/ngalert/schedule/fetcher_test.go
@@ -1,0 +1,111 @@
+package schedule
+
+import (
+	context "context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/grafana/grafana/pkg/infra/log"
+	"github.com/grafana/grafana/pkg/services/ngalert/metrics"
+	models "github.com/grafana/grafana/pkg/services/ngalert/models"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/stretchr/testify/require"
+)
+
+func TestFetcher(t *testing.T) {
+	t.Parallel() // Some tests here do a time.Wait()
+
+	t.Run("empty on construction", func(t *testing.T) {
+		ruleStore := newFakeRulesStore()
+		fetcher := createTestFetcher(1*time.Second, ruleStore)
+
+		r, f := fetcher.Rules()
+
+		require.Empty(t, r)
+		require.Empty(t, f)
+	})
+
+	t.Run("stores rules from latest fetch", func(t *testing.T) {
+		ruleStore := newFakeRulesStore()
+		ruleStore.PutRule(context.Background(), models.AlertRuleGen()())
+		fetcher := createTestFetcher(1*time.Second, ruleStore)
+
+		fetcher.updateSchedulableAlertRules(context.Background())
+		r, f := fetcher.Rules()
+
+		require.Len(t, r, 1)
+		require.Len(t, f, 1)
+	})
+
+	t.Run("Refresh updates fetcher with new objects", func(t *testing.T) {
+		ruleStore := newFakeRulesStore()
+		ruleGen := models.AlertRuleGen(models.WithUniqueID())
+		ruleStore.PutRule(context.Background(), ruleGen())
+		fetcher := createTestFetcher(1*time.Second, ruleStore)
+		fetcher.updateSchedulableAlertRules(context.Background())
+
+		ruleStore.PutRule(context.Background(), models.AlertRuleGen()())
+		r, _ := fetcher.Rules()
+		require.Len(t, r, 1)
+		fetcher.Refresh(context.Background())
+		r, _ = fetcher.Rules()
+
+		require.Len(t, r, 2)
+	})
+
+	t.Run("keeps last state if fetch fails", func(t *testing.T) {
+		ruleStore := newFakeRulesStore()
+		ruleGen := models.AlertRuleGen(models.WithUniqueID())
+		ruleStore.PutRule(context.Background(), ruleGen())
+		fetcher := createTestFetcher(1*time.Second, ruleStore)
+		fetcher.Refresh(context.Background())
+		fetcher.ruleStore = &fakeFailingRuleStore{}
+		r, _ := fetcher.Rules()
+		require.Len(t, r, 1)
+
+		fetcher.Refresh(context.Background())
+		r, _ = fetcher.Rules()
+
+		require.Len(t, r, 1)
+	})
+
+	t.Run("fetches asynchronously in background if run", func(t *testing.T) {
+		ruleStore := newFakeRulesStore()
+		ruleGen := models.AlertRuleGen(models.WithUniqueID())
+		ruleStore.PutRule(context.Background(), ruleGen())
+		fetcher := createTestFetcher(1*time.Millisecond, ruleStore)
+		r, _ := fetcher.Rules()
+		require.Len(t, r, 0)
+
+		ctx, stop := context.WithCancel(context.Background())
+		go func() {
+			err := fetcher.Run(ctx)
+			require.NoError(t, err)
+		}()
+		time.Sleep(10 * time.Millisecond)
+		stop()
+
+		r, _ = fetcher.Rules()
+		require.Len(t, r, 1)
+	})
+}
+
+func createTestFetcher(reloadInterval time.Duration, ruleStore RulesStore) *BackgroundFetcher {
+	metrics := metrics.NewSchedulerMetrics(prometheus.NewRegistry())
+	logger := log.NewNopLogger()
+	cfg := FetcherCfg{
+		ReloadInterval: reloadInterval,
+	}
+	return NewBackgroundFetcher(cfg, ruleStore, metrics, logger)
+}
+
+type fakeFailingRuleStore struct{}
+
+func (f *fakeFailingRuleStore) GetAlertRulesKeysForScheduling(ctx context.Context) ([]models.AlertRuleKeyWithVersion, error) {
+	return nil, errors.New("GetAlertRulesKeysForScheduling failed")
+}
+
+func (f *fakeFailingRuleStore) GetAlertRulesForScheduling(ctx context.Context, query *models.GetAlertRulesForSchedulingQuery) error {
+	return errors.New("GetAlertRulesKeysForScheduling failed")
+}

--- a/pkg/services/ngalert/schedule/schedule.go
+++ b/pkg/services/ngalert/schedule/schedule.go
@@ -81,6 +81,7 @@ type schedule struct {
 	appURL               *url.URL
 	disableGrafanaFolder bool
 	jitterEvaluations    JitterStrategy
+	fetchAsync           bool
 
 	metrics *metrics.Scheduler
 
@@ -105,6 +106,7 @@ type SchedulerCfg struct {
 	DisableGrafanaFolder bool
 	AppURL               *url.URL
 	JitterEvaluations    JitterStrategy
+	FetchAsync           bool
 	EvaluatorFactory     eval.EvaluatorFactory
 	RuleStore            RulesStore
 	Metrics              *metrics.Scheduler
@@ -134,6 +136,7 @@ func NewScheduler(cfg SchedulerCfg, stateManager *state.Manager, fetcher RulesFe
 		appURL:                cfg.AppURL,
 		disableGrafanaFolder:  cfg.DisableGrafanaFolder,
 		jitterEvaluations:     cfg.JitterEvaluations,
+		fetchAsync:            cfg.FetchAsync,
 		stateManager:          stateManager,
 		minRuleInterval:       cfg.MinRuleInterval,
 		schedulableAlertRules: alertRulesRegistry{rules: make(map[ngmodels.AlertRuleKey]*ngmodels.AlertRule)},

--- a/pkg/services/ngalert/schedule/schedule_unit_test.go
+++ b/pkg/services/ngalert/schedule/schedule_unit_test.go
@@ -114,6 +114,8 @@ func TestProcessTicks(t *testing.T) {
 	// create alert rule under main org with one second interval
 	alertRule1 := models.AlertRuleGen(models.WithOrgID(mainOrgID), models.WithInterval(cfg.BaseInterval), models.WithTitle("rule-1"))()
 	ruleStore.PutRule(ctx, alertRule1)
+	// Assume for the sake of the test that the eventually consistent rule fetches are "fast enough."
+	fetcher.Refresh(ctx)
 
 	t.Run("on 1st tick alert rule should be evaluated", func(t *testing.T) {
 		tick = tick.Add(cfg.BaseInterval)
@@ -143,6 +145,7 @@ func TestProcessTicks(t *testing.T) {
 	// add alert rule under main org with three base intervals
 	alertRule2 := models.AlertRuleGen(models.WithOrgID(mainOrgID), models.WithInterval(3*cfg.BaseInterval), models.WithTitle("rule-2"))()
 	ruleStore.PutRule(ctx, alertRule2)
+	fetcher.Refresh(ctx)
 
 	t.Run("on 2nd tick first alert rule should be evaluated", func(t *testing.T) {
 		tick = tick.Add(cfg.BaseInterval)
@@ -289,6 +292,7 @@ func TestProcessTicks(t *testing.T) {
 		tick = tick.Add(cfg.BaseInterval)
 
 		ruleStore.DeleteRule(alertRule1)
+		fetcher.Refresh(ctx)
 
 		scheduled, stopped, updated := sched.processTick(ctx, dispatcherGroup, tick)
 
@@ -328,6 +332,7 @@ func TestProcessTicks(t *testing.T) {
 	// create alert rule with one base interval
 	alertRule3 := models.AlertRuleGen(models.WithOrgID(mainOrgID), models.WithInterval(cfg.BaseInterval), models.WithTitle("rule-3"))()
 	ruleStore.PutRule(ctx, alertRule3)
+	fetcher.Refresh(ctx)
 
 	t.Run("on 10th tick a new alert rule should be evaluated", func(t *testing.T) {
 		tick = tick.Add(cfg.BaseInterval)
@@ -350,6 +355,7 @@ func TestProcessTicks(t *testing.T) {
 		}
 
 		ruleStore.PutRule(context.Background(), newRule2)
+		fetcher.Refresh(ctx)
 
 		tick = tick.Add(cfg.BaseInterval)
 		scheduled, stopped, updated := sched.processTick(ctx, dispatcherGroup, tick)


### PR DESCRIPTION
**What is this feature?**

Currently, rules are fetched synchronously in `processTick` every `baseInterval` seconds (10 seconds). processTick blocks until the fetch is complete.

On some large instances, this can take several seconds if there are many rules (we see 3-5s regularly in Cloud).

This creates a few problems:
- Drastically increases the likelihood of dropping ticks, as there is a 10 second window to fetch and THEN load.
- Rule refresh rate is inherently tied to baseInterval and cannot be independently tuned on big instances.
- This interferes with Jittering. Jittering relies on this [spreading within a tick](https://github.com/grafana/grafana/blob/3482c8ef09d3edb07b5df6312f4bb82a1fdd814f/pkg/services/ngalert/schedule/schedule.go#L315-L323), which bleeds over into the next tick if fetching takes a long time. The overlap creates phantom spikes of evaluations.

This PR performs the rule reload asynchronously in the background, on a timer. Rule updates are now more eventually consistent. When the scheduler is considered in isolation, it reads the rules from memory instead of from the database. This drastically speeds up processTick and removes the overhead of database queries. The result is fewer dropped ticks and more effective jittering on instances with many rules or slow databases.

In the future we'd like to reload rules based on their fingerprint changing rather than the version field changing. One reason why we can't is this [optimization](https://github.com/grafana/grafana/blob/3482c8ef09d3edb07b5df6312f4bb82a1fdd814f/pkg/services/ngalert/schedule/fetcher.go#L21-L30). Removing the optimization makes the above problems worse in the case where rules didn't change, and porting the optimization to use fingerprint requires a database migration. Right now, the async version skips the optimization; if it becomes a problem, we can consider porting it in the future.

 Behind a feature flag by default.

**Who is this feature for?**

Operators with many rules or slow database connections.

**Which issue(s) does this PR fix?**:
n/a

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle.
- [x] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
