### PR TITLE
Rollback `ansicolor` package to `1.1.100` to fix ansi styled logs

### DIFF
--- a/package.json
+++ b/package.json
@@ -289,7 +289,7 @@
     "angular-bindonce": "0.3.1",
     "angular-route": "1.8.3",
     "angular-sanitize": "1.8.3",
-    "ansicolor": "2.0.1",
+    "ansicolor": "1.1.100",
     "baron": "3.0.3",
     "brace": "0.11.1",
     "calculate-size": "1.1.1",

--- a/packages/grafana-ui/package.json
+++ b/packages/grafana-ui/package.json
@@ -61,7 +61,7 @@
     "@react-aria/focus": "3.16.1",
     "@react-aria/overlays": "3.21.0",
     "@react-aria/utils": "3.23.1",
-    "ansicolor": "2.0.1",
+    "ansicolor": "1.1.100",
     "calculate-size": "1.1.1",
     "classnames": "2.5.1",
     "d3": "7.8.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -11308,6 +11308,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"ansicolor@npm:1.1.100":
+  version: 1.1.100
+  resolution: "ansicolor@npm:1.1.100"
+  checksum: 10/9420e96f44b578153dfd11e2d829d633ca2699452419aff48314219d66b7b69a9b6d994d2f2350b1d29a9826e33500b87fe85606629a8889cd52ce806908f4a9
+  languageName: node
+  linkType: hard
+
 "ansicolor@npm:2.0.1":
   version: 2.0.1
   resolution: "ansicolor@npm:2.0.1"
@@ -18256,7 +18263,7 @@ __metadata:
     angular-bindonce: "npm:0.3.1"
     angular-route: "npm:1.8.3"
     angular-sanitize: "npm:1.8.3"
-    ansicolor: "npm:2.0.1"
+    ansicolor: "npm:1.1.100"
     autoprefixer: "npm:10.4.17"
     baron: "npm:3.0.3"
     blob-polyfill: "npm:7.0.20220408"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4188,7 +4188,7 @@ __metadata:
     "@types/testing-library__jest-dom": "npm:5.14.9"
     "@types/tinycolor2": "npm:1.4.6"
     "@types/uuid": "npm:9.0.8"
-    ansicolor: "npm:2.0.1"
+    ansicolor: "npm:1.1.100"
     calculate-size: "npm:1.1.1"
     classnames: "npm:2.5.1"
     common-tags: "npm:1.8.2"
@@ -11312,13 +11312,6 @@ __metadata:
   version: 1.1.100
   resolution: "ansicolor@npm:1.1.100"
   checksum: 10/9420e96f44b578153dfd11e2d829d633ca2699452419aff48314219d66b7b69a9b6d994d2f2350b1d29a9826e33500b87fe85606629a8889cd52ce806908f4a9
-  languageName: node
-  linkType: hard
-
-"ansicolor@npm:2.0.1":
-  version: 2.0.1
-  resolution: "ansicolor@npm:2.0.1"
-  checksum: 10/71a553fde28462985e78e3af091858c2b6d06e9eb51cb88a5440b0fe70f38901156a9b80b345cead744d9dc3e23497a233019d205d248ffaa72226781b88722a
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
**What is this feature?**

Logs can be colored using ansicolors. The bump of `ansicolor` to `2.0.1` caused some issues with that color coding. As a quick fix this PR rolls the change in https://github.com/grafana/grafana/pull/81493 back and sets `ansicolor` back to `1.1.100`.