### PR TITLE
Dashboard scenes: Library panel menu progress. Allow remove and duplicate panel. Populate the inspect panel JSON.

### DIFF
--- a/public/app/features/dashboard-scene/inspect/InspectJsonTab.tsx
+++ b/public/app/features/dashboard-scene/inspect/InspectJsonTab.tsx
@@ -30,6 +30,7 @@ import { PanelRepeaterGridItem } from '../scene/PanelRepeaterGridItem';
 import { buildGridItemForPanel } from '../serialization/transformSaveModelToScene';
 import { gridItemToPanel } from '../serialization/transformSceneToSaveModel';
 import { getDashboardSceneFor, getPanelIdForVizPanel, getQueryRunnerFor } from '../utils/utils';
+import { LibraryVizPanel } from '../scene/LibraryVizPanel';
 
 export type ShowContent = 'panel-json' | 'panel-data' | 'data-frames';
 
@@ -202,6 +203,8 @@ function getJsonText(show: ShowContent, panel: VizPanel): string {
 
       if (panel.parent instanceof SceneGridItem || panel.parent instanceof PanelRepeaterGridItem) {
         objToStringify = gridItemToPanel(panel.parent);
+      } else if (panel.parent instanceof LibraryVizPanel && panel.parent.parent) {
+        objToStringify = gridItemToPanel(panel.parent.parent);
       }
       break;
     }

--- a/public/app/features/dashboard-scene/scene/DashboardScene.tsx
+++ b/public/app/features/dashboard-scene/scene/DashboardScene.tsx
@@ -49,6 +49,7 @@ import { forceRenderChildren, getClosestVizPanel, getPanelIdForVizPanel, isPanel
 
 import { DashboardControls } from './DashboardControls';
 import { DashboardSceneUrlSync } from './DashboardSceneUrlSync';
+import { LibraryVizPanel } from './LibraryVizPanel';
 import { PanelRepeaterGridItem } from './PanelRepeaterGridItem';
 import { ViewPanelScene } from './ViewPanelScene';
 import { setupKeyboardShortcuts } from './keyboardShortcuts';
@@ -414,6 +415,36 @@ export class DashboardScene extends SceneObjectBase<DashboardSceneState> {
     return this._initialState;
   }
 
+  public duplicateLibraryPanel(libraryPanel: LibraryVizPanel) {
+    if (!libraryPanel.parent) {
+      return;
+    }
+    const gridItem = libraryPanel.parent;
+
+    if (!(gridItem instanceof SceneGridItem || PanelRepeaterGridItem)) {
+      console.error('Trying to duplicate a panel in a layout that is not SceneGridItem or PanelRepeaterGridItem');
+      return;
+    }
+
+    const { key: gridItemKey, ...gridItemToDuplicateState } = sceneUtils.cloneSceneObjectState(gridItem.state);
+
+    const newGridItem = new SceneGridItem({
+      ...gridItemToDuplicateState,
+      body: new LibraryVizPanel(libraryPanel?.state),
+    });
+
+    if (!(this.state.body instanceof SceneGridLayout)) {
+      console.error('Trying to duplicate a panel in a layout that is not SceneGridLayout ');
+      return;
+    }
+
+    const sceneGridLayout = this.state.body;
+
+    sceneGridLayout.setState({
+      children: [...sceneGridLayout.state.children, newGridItem],
+    });
+  }
+
   public duplicatePanel(vizPanel: VizPanel) {
     if (!vizPanel.parent) {
       return;
@@ -460,12 +491,12 @@ export class DashboardScene extends SceneObjectBase<DashboardSceneState> {
     });
   }
 
-  public copyPanel(vizPanel: VizPanel) {
-    if (!vizPanel.parent) {
+  public copyPanel(panel: VizPanel | LibraryVizPanel) {
+    if (!panel.parent) {
       return;
     }
 
-    const gridItem = vizPanel.parent;
+    const gridItem = panel.parent;
 
     const jsonData = gridItemToPanel(gridItem);
 

--- a/public/app/features/dashboard-scene/scene/DashboardScene.tsx
+++ b/public/app/features/dashboard-scene/scene/DashboardScene.tsx
@@ -491,12 +491,12 @@ export class DashboardScene extends SceneObjectBase<DashboardSceneState> {
     });
   }
 
-  public copyPanel(panel: VizPanel | LibraryVizPanel) {
-    if (!panel.parent) {
+  public copyPanel(vizPanel: VizPanel) {
+    if (!vizPanel.parent) {
       return;
     }
 
-    const gridItem = panel.parent;
+    const gridItem = vizPanel.parent;
 
     const jsonData = gridItemToPanel(gridItem);
 

--- a/public/app/features/dashboard-scene/scene/PanelMenuBehavior.tsx
+++ b/public/app/features/dashboard-scene/scene/PanelMenuBehavior.tsx
@@ -45,7 +45,8 @@ export function panelMenuBehavior(menu: VizPanelMenu) {
   const asyncFunc = async () => {
     // hm.. add another generic param to SceneObject to specify parent type?
     // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
-    const panel = menu.parent as VizPanel;
+    const panel = sceneGraph.getAncestor(menu, VizPanel);
+    const libraryPanel = panel.parent instanceof LibraryVizPanel ? panel.parent : undefined;
     const plugin = panel.getPlugin();
 
     const items: PanelMenuItem[] = [];
@@ -203,7 +204,7 @@ export function panelMenuBehavior(menu: VizPanelMenu) {
       iconClassName: 'trash-alt',
       onClick: () => {
         DashboardInteractions.panelMenuItemClicked('remove');
-        removePanel(dashboard, panel, true);
+        removePanel(dashboard, libraryPanel || panel, true);
       },
       shortcut: 'p r',
     });
@@ -377,7 +378,7 @@ function createExtensionContext(panel: VizPanel, dashboard: DashboardScene): Plu
   };
 }
 
-export function removePanel(dashboard: DashboardScene, panel: VizPanel, ask: boolean) {
+export function removePanel(dashboard: DashboardScene, panel: VizPanel | LibraryVizPanel, ask: boolean) {
   const vizPanelData = sceneGraph.getData(panel);
   let panelHasAlert = false;
 

--- a/public/app/features/dashboard-scene/scene/PanelMenuBehavior.tsx
+++ b/public/app/features/dashboard-scene/scene/PanelMenuBehavior.tsx
@@ -107,7 +107,7 @@ export function panelMenuBehavior(menu: VizPanelMenu) {
       text: t('panel.header-menu.copy', `Copy`),
       onClick: () => {
         DashboardInteractions.panelMenuItemClicked('copy');
-        dashboard.copyPanel(libraryPanel || panel);
+        dashboard.copyPanel(panel);
       },
     });
 

--- a/public/app/features/dashboard-scene/scene/PanelMenuBehavior.tsx
+++ b/public/app/features/dashboard-scene/scene/PanelMenuBehavior.tsx
@@ -98,7 +98,7 @@ export function panelMenuBehavior(menu: VizPanelMenu) {
       text: t('panel.header-menu.duplicate', `Duplicate`),
       onClick: () => {
         DashboardInteractions.panelMenuItemClicked('duplicate');
-        dashboard.duplicatePanel(panel);
+        libraryPanel ? dashboard.duplicateLibraryPanel(libraryPanel) : dashboard.duplicatePanel(panel);
       },
       shortcut: 'p d',
     });
@@ -107,7 +107,7 @@ export function panelMenuBehavior(menu: VizPanelMenu) {
       text: t('panel.header-menu.copy', `Copy`),
       onClick: () => {
         DashboardInteractions.panelMenuItemClicked('copy');
-        dashboard.copyPanel(panel);
+        dashboard.copyPanel(libraryPanel || panel);
       },
     });
 


### PR DESCRIPTION
**What is this feature?**

This lets the user remove and duplicate library panels.

It also populates the inspect panel JSON. It's however a bit unclear to me what should be included in the inspect panel JSON. Right now only the reference to the library panel is included.

![image](https://github.com/grafana/grafana/assets/468940/2196c66d-c853-4024-b60b-4aeb43b4a3c5)

I've also experimented with including the resulting panel from the libary panel into the inspect. But this doesn't really represent what the object structure actually looks like.

![image](https://github.com/grafana/grafana/assets/468940/aca34fca-2e37-4b94-8eec-b3c53e46ca79)
