### PR TITLE
[v10.3.x] Chore: Remove grafana-delivery references

### DIFF
--- a/.github/workflows/create-security-patch-from-security-mirror.yml
+++ b/.github/workflows/create-security-patch-from-security-mirror.yml
@@ -1,5 +1,5 @@
-# Owned by grafana-delivery-squad
-# Intended to be dropped into the base repo (Ex: grafana/grafana) for use in the security mirror. 
+# Owned by grafana-release-guild
+# Intended to be dropped into the base repo (Ex: grafana/grafana) for use in the security mirror.
 name: Create security patch
 run-name: create-security-patch
 on:
@@ -17,7 +17,7 @@ jobs:
   trigger_downstream_create_security_patch:
     concurrency: create-patch-${{ github.ref_name }}
     uses: grafana/security-patch-actions/.github/workflows/create-patch.yml@main
-    if: github.repository == 'grafana/grafana-security-mirror' 
+    if: github.repository == 'grafana/grafana-security-mirror'
     with:
       repo: "${{ github.repository }}"
       src_ref: "${{ github.head_ref }}" # this is the source branch name, Ex: "feature/newthing"

--- a/.github/workflows/pr-patch-check.yml
+++ b/.github/workflows/pr-patch-check.yml
@@ -1,4 +1,4 @@
-# Owned by grafana-delivery-squad
+# Owned by grafana-release-guild
 # Intended to be dropped into the base repo Ex: grafana/grafana
 name: Check for patch conflicts
 run-name: check-patch-conflicts-${{ github.base_ref }}-${{ github.head_ref }}

--- a/.github/workflows/sync-mirror.yml
+++ b/.github/workflows/sync-mirror.yml
@@ -1,4 +1,4 @@
-# Owned by grafana-delivery-squad
+# Owned by grafana-release-guild
 # Intended to be dropped into the base repo, Ex: grafana/grafana
 name: Sync to mirror
 run-name: sync-to-mirror-${{ github.ref_name }}

--- a/contribute/drone-pipeline.md
+++ b/contribute/drone-pipeline.md
@@ -14,4 +14,4 @@ The Drone pipelines are built with [Starlark](https://github.com/bazelbuild/star
 - Open a PR where you can do test runs for your changes. If you need to experiment with secrets, create a PR in the [grafana-ci-sandbox repo](https://github.com/grafana/grafana-ci-sandbox), before opening a PR in the main repo.
 - Run `make drone` after making changes to the Starlark files. This builds the `.drone.yml` file.
 
-For further questions, reach out to the grafana-delivery squad.
+For further questions, reach out to the grafana-release-guild squad.

--- a/scripts/modowners/README.md
+++ b/scripts/modowners/README.md
@@ -35,7 +35,7 @@ Example CLI command to get a list of all owners with a count of the number of de
 Example output:
 
 ```
-@grafana/grafana-delivery 5
+@grafana/grafana-release-guild 5
 @grafana/grafana-bi-squad 2
 @grafana/grafana-app-platform-squad 13
 @grafana/observability-metrics 4
@@ -67,7 +67,7 @@ List all dependencies of given owner(s).
 
 Example CLI command to list all direct dependencies owned by Delivery and Authnz:
 
-`go run scripts/modowners/modowners.go modules -o @grafana/grafana-delivery,@grafana/identity-access-team go.mod`
+`go run scripts/modowners/modowners.go modules -o @grafana/grafana-release-guild,@grafana/identity-access-team go.mod`
 
 Example output:
 

--- a/scripts/modowners/modowners.go
+++ b/scripts/modowners/modowners.go
@@ -129,7 +129,7 @@ func owners(fileSystem fs.FS, logger *log.Logger, args []string) error {
 }
 
 // Print dependencies for a given owner. Can specify one or more owners.
-// An example CLI command to list all direct dependencies owned by Delivery and Authnz `go run scripts/modowners/modowners.go modules -o @grafana/grafana-delivery,@grafana/identity-access-team go.mod`
+// An example CLI command to list all direct dependencies owned by Delivery and Authnz `go run scripts/modowners/modowners.go modules -o @grafana/grafana-release-guild,@grafana/identity-access-team go.mod`
 func modules(fileSystem fs.FS, logger *log.Logger, args []string) error {
 	fs := flag.NewFlagSet("modules", flag.ExitOnError)
 	indirect := fs.Bool("i", false, "print indirect dependencies")


### PR DESCRIPTION
Backport a6bc262093c15538466f4168b3695ab0633ae659 from #82505

---

**What is this feature?**

Since `grafana/grafana-delivery` GH group is no more, is a good chance to remove all references from this repo and then also delete the team. We are getting pinged for PRs where we shouldn't. 

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle.
- [x] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
