### PR TITLE
Loki: Fix fetching of label names if no previous equality operator

### DIFF
--- a/public/app/plugins/datasource/loki/querybuilder/components/LokiQueryBuilder.test.tsx
+++ b/public/app/plugins/datasource/loki/querybuilder/components/LokiQueryBuilder.test.tsx
@@ -107,6 +107,27 @@ describe('LokiQueryBuilder', () => {
     expect(props.datasource.languageProvider.fetchSeriesLabels).not.toBeCalled();
   });
 
+  it('uses fetchLabels preselected label have regex equality matcher with match everything value (.*)', async () => {
+    const props = createDefaultProps();
+    props.datasource.getDataSamples = jest.fn().mockResolvedValue([]);
+    props.datasource.languageProvider.fetchSeriesLabels = jest.fn();
+    props.datasource.languageProvider.fetchLabels = jest.fn().mockReturnValue(['a', 'b']);
+
+    const query: LokiVisualQuery = {
+      labels: [
+        { op: '=~', label: 'cluster', value: '.*' },
+        { op: '=', label: 'job', value: 'grafana' },
+      ],
+      operations: [],
+    };
+    render(<LokiQueryBuilder {...props} query={query} />);
+    const labels = screen.getByText(/Label filters/);
+    const selects = getAllByRole(getSelectParent(labels)!, 'combobox');
+    await userEvent.click(selects[3]);
+    expect(props.datasource.languageProvider.fetchLabels).toBeCalledWith({ timeRange: mockTimeRange });
+    expect(props.datasource.languageProvider.fetchSeriesLabels).not.toBeCalled();
+  });
+
   it('uses fetchSeriesLabels preselected label have regex equality matcher', async () => {
     const props = createDefaultProps();
     props.datasource.getDataSamples = jest.fn().mockResolvedValue([]);

--- a/public/app/plugins/datasource/loki/querybuilder/components/LokiQueryBuilder.tsx
+++ b/public/app/plugins/datasource/loki/querybuilder/components/LokiQueryBuilder.tsx
@@ -58,7 +58,10 @@ export const LokiQueryBuilder = React.memo<Props>(
     const onGetLabelNames = async (forLabel: Partial<QueryBuilderLabelFilter>): Promise<string[]> => {
       const labelsToConsider = query.labels.filter((x) => x !== forLabel);
 
-      if (labelsToConsider.length === 0) {
+      const hasEqualityOperation = labelsToConsider.find(
+        (filter) => filter.op === '=' || (filter.op === '=~' && new RegExp(filter.value).test('') === false)
+      );
+      if (labelsToConsider.length === 0 || !hasEqualityOperation) {
         return await datasource.languageProvider.fetchLabels({ timeRange });
       }
 


### PR DESCRIPTION
**What is this feature?**

Similar to https://github.com/grafana/grafana/pull/82251 but just fixes it for `onGetLabelNames`.

**Which issue(s) does this PR fix?**:

Fixes #82530
