### PR TITLE
Table: PoC/Hack - custom expanded element on row click

### DIFF
--- a/packages/grafana-ui/src/components/Table/RowsList.tsx
+++ b/packages/grafana-ui/src/components/Table/RowsList.tsx
@@ -45,6 +45,7 @@ interface RowsListProps {
   timeRange?: TimeRange;
   footerPaginationEnabled: boolean;
   initialRowIndex?: number;
+  expandedRowIndex?: Map<number, React.ReactElement>;
 }
 
 export const RowsList = (props: RowsListProps) => {
@@ -217,6 +218,8 @@ export const RowsList = (props: RowsListProps) => {
           'aria-selected': 'true',
         };
       }
+
+      const expandedRowElement = props?.expandedRowIndex?.has(index) && props.expandedRowIndex.get(index);
       return (
         <div
           {...row.getRowProps({ style, ...additionalProps })}
@@ -225,6 +228,7 @@ export const RowsList = (props: RowsListProps) => {
           onMouseEnter={() => onRowHover(index, data)}
           onMouseLeave={onRowLeave}
         >
+          {expandedRowElement && <>{expandedRowElement}</>}
           {/*add the nested data to the DOM first to prevent a 1px border CSS issue on the last cell of the row*/}
           {nestedDataField && tableState.expanded[row.id] && (
             <ExpandedRow
@@ -265,6 +269,7 @@ export const RowsList = (props: RowsListProps) => {
       theme.components.table.rowHoverBackground,
       timeRange,
       width,
+      props.expandedRowIndex,
     ]
   );
 

--- a/packages/grafana-ui/src/components/Table/Table.tsx
+++ b/packages/grafana-ui/src/components/Table/Table.tsx
@@ -56,6 +56,7 @@ export const Table = memo((props: Props) => {
     timeRange,
     enableSharedCrosshair = false,
     initialRowIndex = undefined,
+    expandedRowIndex = undefined,
   } = props;
 
   const listRef = useRef<VariableSizeList>(null);
@@ -329,6 +330,7 @@ export const Table = memo((props: Props) => {
                 footerPaginationEnabled={Boolean(enablePagination)}
                 enableSharedCrosshair={enableSharedCrosshair}
                 initialRowIndex={initialRowIndex}
+                expandedRowIndex={expandedRowIndex}
               />
             </div>
           ) : (

--- a/packages/grafana-ui/src/components/Table/types.ts
+++ b/packages/grafana-ui/src/components/Table/types.ts
@@ -101,6 +101,7 @@ export interface Props {
   initialRowIndex?: number;
   // For cell interaction controlled by parent component
   onCellClick?: onTableCellClickArgs;
+  expandedRowIndex?: Map<number, React.ReactElement>;
 }
 
 // The arguments passed to the calling component on click of a table cell

--- a/public/app/features/explore/Logs/ExpandedRow.tsx
+++ b/public/app/features/explore/Logs/ExpandedRow.tsx
@@ -1,0 +1,24 @@
+import { css } from '@emotion/css';
+import React from 'react';
+
+import { GrafanaTheme2 } from '@grafana/data';
+import { useTheme2 } from '@grafana/ui';
+
+export const ExpandedRow = () => {
+  const theme = useTheme2();
+  const styles = getStyles(theme);
+  return <div className={styles.wrapper}>Hello expanded row</div>;
+};
+
+function getStyles(theme: GrafanaTheme2) {
+  return {
+    wrapper: css({
+      position: 'absolute',
+      top: '100%',
+      width: '100%',
+      height: '100px',
+      background: 'red',
+      zIndex: 1,
+    }),
+  };
+}

--- a/public/app/features/explore/Logs/LogsTable.tsx
+++ b/public/app/features/explore/Logs/LogsTable.tsx
@@ -24,6 +24,7 @@ import { LogsFrame } from 'app/features/logs/logsFrame';
 
 import { getFieldLinksForExplore } from '../utils/links';
 
+import { ExpandedRow } from './ExpandedRow';
 import { FieldNameMeta } from './LogsTableWrap';
 
 interface Props {
@@ -44,6 +45,11 @@ export function LogsTable(props: Props) {
   const { timeZone, splitOpen, range, logsSortOrder, width, dataFrame, columnsWithMeta, logsFrame } = props;
   const [tableFrame, setTableFrame] = useState<DataFrame | undefined>(undefined);
   const timeIndex = logsFrame?.timeField.index;
+  const [selectedRowIndex, setSelectedRowIndex] = useState<number | undefined>();
+
+  const map = new Map();
+  map.set(selectedRowIndex, <ExpandedRow />);
+  console.log('selectedIndex', selectedRowIndex);
 
   const prepareTableFrame = useCallback(
     (frame: DataFrame): DataFrame => {
@@ -169,6 +175,15 @@ export function LogsTable(props: Props) {
 
   return (
     <Table
+      expandedRowIndex={map}
+      onCellClick={(rect, colIndex, rowIndex, event) => {
+        if (rowIndex === selectedRowIndex) {
+          setSelectedRowIndex(undefined);
+        } else {
+          setSelectedRowIndex(rowIndex);
+        }
+        console.log(rect, colIndex, rowIndex, event);
+      }}
       data={tableFrame}
       width={width}
       onCellFilterAdded={props.onClickFilterLabel && props.onClickFilterOutLabel ? onCellFilterAdded : undefined}


### PR DESCRIPTION
**What is this feature?**

PoC: Hacking together absolutely positioned custom element on callback of table cell click.

**Why do we need this feature?**
😎 

https://github.com/grafana/grafana/assets/109082771/75a2fc45-8836-4a55-bcc5-96ea1c617076


**Who is this feature for?**
😎 

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
