### PR TITLE
Table: Allow custom component render in rows

### DIFF
--- a/packages/grafana-ui/src/components/Table/RowsList.tsx
+++ b/packages/grafana-ui/src/components/Table/RowsList.tsx
@@ -45,6 +45,7 @@ interface RowsListProps {
   timeRange?: TimeRange;
   footerPaginationEnabled: boolean;
   initialRowIndex?: number;
+  expandedRows?: Map<number, React.ReactElement>;
 }
 
 export const RowsList = (props: RowsListProps) => {
@@ -68,6 +69,7 @@ export const RowsList = (props: RowsListProps) => {
     listRef,
     enableSharedCrosshair = false,
     initialRowIndex = undefined,
+    expandedRows,
   } = props;
 
   const [rowHighlightIndex, setRowHighlightIndex] = useState<number | undefined>(initialRowIndex);
@@ -210,6 +212,7 @@ export const RowsList = (props: RowsListProps) => {
       prepareRow(row);
 
       const expandedRowStyle = tableState.expanded[row.id] ? css({ '&:hover': { background: 'inherit' } }) : {};
+      const expandedRowElement = expandedRows?.has(index) && expandedRows.get(index);
 
       if (rowHighlightIndex !== undefined && row.index === rowHighlightIndex) {
         style = { ...style, backgroundColor: theme.components.table.rowHoverBackground };
@@ -234,6 +237,9 @@ export const RowsList = (props: RowsListProps) => {
               cellHeight={cellHeight}
             />
           )}
+          {/* Render absolutely positioned row component */}
+          {expandedRowElement && <>{expandedRowElement}</>}
+          {/* Render the table cells */}
           {row.cells.map((cell: Cell, index: number) => (
             <TableCell
               key={index}
@@ -264,6 +270,7 @@ export const RowsList = (props: RowsListProps) => {
       theme.components.table.rowHoverBackground,
       timeRange,
       width,
+      expandedRows,
     ]
   );
 

--- a/packages/grafana-ui/src/components/Table/Table.test.tsx
+++ b/packages/grafana-ui/src/components/Table/Table.test.tsx
@@ -673,4 +673,19 @@ describe('Table', () => {
       expect(selected).toBeVisible();
     });
   });
+
+  describe('when mounted with custom row element', () => {
+    it('the custom component should be visible', async () => {
+      const expandedRows = new Map();
+      expandedRows.set(2, <span>Hello custom row component!</span>);
+
+      getTestContext({
+        expandedRows: expandedRows,
+      });
+      expect(getTable()).toBeInTheDocument();
+
+      const span = within(getTable()).getByText('Hello custom row component!');
+      expect(span).toBeVisible();
+    });
+  });
 });

--- a/packages/grafana-ui/src/components/Table/Table.test.tsx
+++ b/packages/grafana-ui/src/components/Table/Table.test.tsx
@@ -684,8 +684,9 @@ describe('Table', () => {
       });
       expect(getTable()).toBeInTheDocument();
 
-      const span = within(getTable()).getByText('Hello custom row component!');
-      expect(span).toBeVisible();
+      const rows = within(getTable()).getAllByRole('row');
+      // First row is columnheader
+      expect(within(rows[3]).getByText('Hello custom row component!')).toBeVisible();
     });
   });
 });

--- a/packages/grafana-ui/src/components/Table/Table.tsx
+++ b/packages/grafana-ui/src/components/Table/Table.tsx
@@ -49,6 +49,7 @@ export const Table = memo((props: Props) => {
     timeRange,
     enableSharedCrosshair = false,
     initialRowIndex = undefined,
+    expandedRows = undefined,
   } = props;
 
   const listRef = useRef<VariableSizeList>(null);
@@ -320,6 +321,7 @@ export const Table = memo((props: Props) => {
                 footerPaginationEnabled={Boolean(enablePagination)}
                 enableSharedCrosshair={enableSharedCrosshair}
                 initialRowIndex={initialRowIndex}
+                expandedRows={expandedRows}
               />
             </div>
           ) : (

--- a/packages/grafana-ui/src/components/Table/types.ts
+++ b/packages/grafana-ui/src/components/Table/types.ts
@@ -99,6 +99,7 @@ export interface Props {
   enableSharedCrosshair?: boolean;
   // The index of the field value that the table will initialize scrolled to
   initialRowIndex?: number;
+  expandedRows?: Map<number, React.ReactElement>;
 }
 
 /**


### PR DESCRIPTION

**What is this feature?**
Demonstrated in this [PoC](https://github.com/grafana/grafana/pull/82756/files), it would be pretty cool to render additional context below interaction of a row in a table, like clicking on a log line and getting some additional metrics, or even providing UI that could change the active query!

**Why do we need this feature?**
It's a good tool for developers building additional interactivity on top of the table.

**Who is this feature for?**
Developers who want to build additional interactivity on top of table. Like me.

**Special notes for your reviewer:**
This is just a cleaner version of https://github.com/grafana/grafana/pull/82756, still a proposal/PoC

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
