### PR TITLE
Alerting: make feature flag alertingSimplifiedRouting public

### DIFF
--- a/docs/sources/setup-grafana/configure-grafana/feature-toggles/index.md
+++ b/docs/sources/setup-grafana/configure-grafana/feature-toggles/index.md
@@ -92,7 +92,7 @@ Some features are enabled by default. You can disable these feature by setting t
 | `addFieldFromCalculationStatFunctions` | Add cumulative and window functions to the add field from calculation transformation                                                                                                         |
 | `pdfTables`                            | Enables generating table data as PDF in reporting                                                                                                                                            |
 | `canvasPanelPanZoom`                   | Allow pan and zoom in canvas panel                                                                                                                                                           |
-| `alertingSimplifiedRouting`            | This feature enables users to easily configure alert notifications by specifying a contact point directly when editing or creating an alert rule                                             |
+| `alertingSimplifiedRouting`            | Enables users to easily configure alert notifications by specifying a contact point directly when editing or creating an alert rule                                                          |
 | `regressionTransformation`             | Enables regression analysis transformation                                                                                                                                                   |
 | `groupToNestedTableTransformation`     | Enables the group to nested table transformation                                                                                                                                             |
 

--- a/docs/sources/setup-grafana/configure-grafana/feature-toggles/index.md
+++ b/docs/sources/setup-grafana/configure-grafana/feature-toggles/index.md
@@ -92,6 +92,7 @@ Some features are enabled by default. You can disable these feature by setting t
 | `addFieldFromCalculationStatFunctions` | Add cumulative and window functions to the add field from calculation transformation                                                                                                         |
 | `pdfTables`                            | Enables generating table data as PDF in reporting                                                                                                                                            |
 | `canvasPanelPanZoom`                   | Allow pan and zoom in canvas panel                                                                                                                                                           |
+| `alertingSimplifiedRouting`            | This feature enables users to easily configure alert notifications by specifying a contact point directly when editing or creating an alert rule                                             |
 | `regressionTransformation`             | Enables regression analysis transformation                                                                                                                                                   |
 | `groupToNestedTableTransformation`     | Enables the group to nested table transformation                                                                                                                                             |
 

--- a/pkg/services/featuremgmt/registry.go
+++ b/pkg/services/featuremgmt/registry.go
@@ -1053,11 +1053,10 @@ var (
 		},
 		{
 			Name:         "alertingSimplifiedRouting",
-			Description:  "Enables the simplified routing for alerting",
-			Stage:        FeatureStageExperimental,
+			Description:  "This feature enables users to easily configure alert notifications by specifying a contact point directly when editing or creating an alert rule",
+			Stage:        FeatureStagePublicPreview,
 			FrontendOnly: false,
 			Owner:        grafanaAlertingSquad,
-			HideFromDocs: true,
 		},
 		{
 			Name:         "logRowsPopoverMenu",

--- a/pkg/services/featuremgmt/registry.go
+++ b/pkg/services/featuremgmt/registry.go
@@ -1053,7 +1053,7 @@ var (
 		},
 		{
 			Name:         "alertingSimplifiedRouting",
-			Description:  "This feature enables users to easily configure alert notifications by specifying a contact point directly when editing or creating an alert rule",
+			Description:  "Enables users to easily configure alert notifications by specifying a contact point directly when editing or creating an alert rule",
 			Stage:        FeatureStagePublicPreview,
 			FrontendOnly: false,
 			Owner:        grafanaAlertingSquad,

--- a/pkg/services/featuremgmt/toggles_gen.csv
+++ b/pkg/services/featuremgmt/toggles_gen.csv
@@ -141,7 +141,7 @@ logsInfiniteScrolling,experimental,@grafana/observability-logs,false,false,true
 flameGraphItemCollapsing,experimental,@grafana/observability-traces-and-profiling,false,false,true
 alertingDetailsViewV2,experimental,@grafana/alerting-squad,false,false,true
 datatrails,experimental,@grafana/dashboards-squad,false,false,true
-alertingSimplifiedRouting,experimental,@grafana/alerting-squad,false,false,false
+alertingSimplifiedRouting,preview,@grafana/alerting-squad,false,false,false
 logRowsPopoverMenu,GA,@grafana/observability-logs,false,false,true
 pluginsSkipHostEnvVars,experimental,@grafana/plugins-platform-backend,false,false,false
 tableSharedCrosshair,experimental,@grafana/dataviz-squad,false,false,true

--- a/pkg/services/featuremgmt/toggles_gen.go
+++ b/pkg/services/featuremgmt/toggles_gen.go
@@ -576,7 +576,7 @@ const (
 	FlagDatatrails = "datatrails"
 
 	// FlagAlertingSimplifiedRouting
-	// This feature enables users to easily configure alert notifications by specifying a contact point directly when editing or creating an alert rule
+	// Enables users to easily configure alert notifications by specifying a contact point directly when editing or creating an alert rule
 	FlagAlertingSimplifiedRouting = "alertingSimplifiedRouting"
 
 	// FlagLogRowsPopoverMenu

--- a/pkg/services/featuremgmt/toggles_gen.go
+++ b/pkg/services/featuremgmt/toggles_gen.go
@@ -576,7 +576,7 @@ const (
 	FlagDatatrails = "datatrails"
 
 	// FlagAlertingSimplifiedRouting
-	// Enables the simplified routing for alerting
+	// This feature enables users to easily configure alert notifications by specifying a contact point directly when editing or creating an alert rule
 	FlagAlertingSimplifiedRouting = "alertingSimplifiedRouting"
 
 	// FlagLogRowsPopoverMenu

--- a/pkg/services/featuremgmt/toggles_gen.json
+++ b/pkg/services/featuremgmt/toggles_gen.json
@@ -2087,14 +2087,16 @@
     {
       "metadata": {
         "name": "alertingSimplifiedRouting",
-        "resourceVersion": "1707928895402",
-        "creationTimestamp": "2024-02-14T16:41:35Z"
+        "resourceVersion": "1708033274313",
+        "creationTimestamp": "2024-02-14T16:41:35Z",
+        "annotations": {
+          "grafana.app/updatedTimestamp": "2024-02-15 21:41:14.3138752 +0000 UTC"
+        }
       },
       "spec": {
-        "description": "Enables the simplified routing for alerting",
-        "stage": "experimental",
-        "codeowner": "@grafana/alerting-squad",
-        "hideFromDocs": true
+        "description": "This feature enables users to easily configure alert notifications by specifying a contact point directly when editing or creating an alert rule",
+        "stage": "preview",
+        "codeowner": "@grafana/alerting-squad"
       }
     },
     {

--- a/pkg/services/featuremgmt/toggles_gen.json
+++ b/pkg/services/featuremgmt/toggles_gen.json
@@ -2087,14 +2087,14 @@
     {
       "metadata": {
         "name": "alertingSimplifiedRouting",
-        "resourceVersion": "1708033274313",
+        "resourceVersion": "1708033557575",
         "creationTimestamp": "2024-02-14T16:41:35Z",
         "annotations": {
-          "grafana.app/updatedTimestamp": "2024-02-15 21:41:14.3138752 +0000 UTC"
+          "grafana.app/updatedTimestamp": "2024-02-15 21:45:57.5750554 +0000 UTC"
         }
       },
       "spec": {
-        "description": "This feature enables users to easily configure alert notifications by specifying a contact point directly when editing or creating an alert rule",
+        "description": "Enables users to easily configure alert notifications by specifying a contact point directly when editing or creating an alert rule",
         "stage": "preview",
         "codeowner": "@grafana/alerting-squad"
       }


### PR DESCRIPTION
This makes the feature flag `alertingSimplifiedRouting` to be visible in the documentation and changes it's status to "public preview".