### PR TITLE
Alerting: Dry-run legacy upgrade on startup

### DIFF
--- a/docs/sources/setup-grafana/configure-grafana/feature-toggles/index.md
+++ b/docs/sources/setup-grafana/configure-grafana/feature-toggles/index.md
@@ -58,7 +58,7 @@ Some features are enabled by default. You can disable these feature by setting t
 | `lokiQueryHints`                     | Enables query hints for Loki                                                                                                                                                                                                 | Yes                |
 | `alertingPreviewUpgrade`             | Show Unified Alerting preview and upgrade page in legacy alerting                                                                                                                                                            | Yes                |
 | `alertingQueryOptimization`          | Optimizes eligible queries in order to reduce load on datasources                                                                                                                                                            |                    |
-| `alertingUpgradeDryrunOnStart`       | When activated in legacy alerting mode, this initiates a dry-run of the Unified Alerting upgrade during each startup. It logs any issues detected without implementing any actual changes.                                   |                    |
+| `alertingUpgradeDryrunOnStart`       | When activated in legacy alerting mode, this initiates a dry-run of the Unified Alerting upgrade during each startup. It logs any issues detected without implementing any actual changes.                                   | Yes                |
 
 ## Preview feature toggles
 

--- a/docs/sources/setup-grafana/configure-grafana/feature-toggles/index.md
+++ b/docs/sources/setup-grafana/configure-grafana/feature-toggles/index.md
@@ -58,7 +58,7 @@ Some features are enabled by default. You can disable these feature by setting t
 | `lokiQueryHints`                     | Enables query hints for Loki                                                                                                                                                                                                 | Yes                |
 | `alertingPreviewUpgrade`             | Show Unified Alerting preview and upgrade page in legacy alerting                                                                                                                                                            | Yes                |
 | `alertingQueryOptimization`          | Optimizes eligible queries in order to reduce load on datasources                                                                                                                                                            |                    |
-| `alertingUpgradeDryrunOnStart`       | Dry-run Unified Alerting upgrade on startup                                                                                                                                                                                  |                    |
+| `alertingUpgradeDryrunOnStart`       | When activated in legacy alerting mode, this initiates a dry-run of the Unified Alerting upgrade during each startup. It logs any issues detected without implementing any actual changes.                                   |                    |
 
 ## Preview feature toggles
 

--- a/docs/sources/setup-grafana/configure-grafana/feature-toggles/index.md
+++ b/docs/sources/setup-grafana/configure-grafana/feature-toggles/index.md
@@ -58,6 +58,7 @@ Some features are enabled by default. You can disable these feature by setting t
 | `lokiQueryHints`                     | Enables query hints for Loki                                                                                                                                                                                                 | Yes                |
 | `alertingPreviewUpgrade`             | Show Unified Alerting preview and upgrade page in legacy alerting                                                                                                                                                            | Yes                |
 | `alertingQueryOptimization`          | Optimizes eligible queries in order to reduce load on datasources                                                                                                                                                            |                    |
+| `alertingUpgradeDryrunOnStart`       | Dry-run Unified Alerting upgrade on startup                                                                                                                                                                                  |                    |
 
 ## Preview feature toggles
 

--- a/packages/grafana-data/src/types/featureToggles.gen.ts
+++ b/packages/grafana-data/src/types/featureToggles.gen.ts
@@ -181,4 +181,5 @@ export interface FeatureToggles {
   newPDFRendering?: boolean;
   kubernetesAggregator?: boolean;
   groupByVariable?: boolean;
+  alertingUpgradeDryrunOnStart?: boolean;
 }

--- a/pkg/services/featuremgmt/registry.go
+++ b/pkg/services/featuremgmt/registry.go
@@ -1214,6 +1214,14 @@ var (
 			HideFromDocs:      true,
 			HideFromAdminPage: true,
 		},
+		{
+			Name:            "alertingUpgradeDryrunOnStart",
+			Description:     "Dry-run Unified Alerting upgrade on startup",
+			FrontendOnly:    false,
+			Stage:           FeatureStageGeneralAvailability,
+			Owner:           grafanaAlertingSquad,
+			RequiresRestart: true,
+		},
 	}
 )
 

--- a/pkg/services/featuremgmt/registry.go
+++ b/pkg/services/featuremgmt/registry.go
@@ -1221,6 +1221,7 @@ var (
 			Stage:           FeatureStageGeneralAvailability,
 			Owner:           grafanaAlertingSquad,
 			RequiresRestart: true,
+			Expression:      "true", // enabled by default
 		},
 	}
 )

--- a/pkg/services/featuremgmt/registry.go
+++ b/pkg/services/featuremgmt/registry.go
@@ -1216,7 +1216,7 @@ var (
 		},
 		{
 			Name:            "alertingUpgradeDryrunOnStart",
-			Description:     "Dry-run Unified Alerting upgrade on startup",
+			Description:     "When activated in legacy alerting mode, this initiates a dry-run of the Unified Alerting upgrade during each startup. It logs any issues detected without implementing any actual changes.",
 			FrontendOnly:    false,
 			Stage:           FeatureStageGeneralAvailability,
 			Owner:           grafanaAlertingSquad,

--- a/pkg/services/featuremgmt/toggles_gen.csv
+++ b/pkg/services/featuremgmt/toggles_gen.csv
@@ -162,3 +162,4 @@ groupToNestedTableTransformation,preview,@grafana/dataviz-squad,false,false,true
 newPDFRendering,experimental,@grafana/sharing-squad,false,false,false
 kubernetesAggregator,experimental,@grafana/grafana-app-platform-squad,false,true,false
 groupByVariable,experimental,@grafana/dashboards-squad,false,false,false
+alertingUpgradeDryrunOnStart,GA,@grafana/alerting-squad,false,true,false

--- a/pkg/services/featuremgmt/toggles_gen.go
+++ b/pkg/services/featuremgmt/toggles_gen.go
@@ -658,4 +658,8 @@ const (
 	// FlagGroupByVariable
 	// Enable groupBy variable support in scenes dashboards
 	FlagGroupByVariable = "groupByVariable"
+
+	// FlagAlertingUpgradeDryrunOnStart
+	// Dry-run Unified Alerting upgrade on startup
+	FlagAlertingUpgradeDryrunOnStart = "alertingUpgradeDryrunOnStart"
 )

--- a/pkg/services/featuremgmt/toggles_gen.go
+++ b/pkg/services/featuremgmt/toggles_gen.go
@@ -660,6 +660,6 @@ const (
 	FlagGroupByVariable = "groupByVariable"
 
 	// FlagAlertingUpgradeDryrunOnStart
-	// Dry-run Unified Alerting upgrade on startup
+	// When activated in legacy alerting mode, this initiates a dry-run of the Unified Alerting upgrade during each startup. It logs any issues detected without implementing any actual changes.
 	FlagAlertingUpgradeDryrunOnStart = "alertingUpgradeDryrunOnStart"
 )

--- a/pkg/services/featuremgmt/toggles_gen.json
+++ b/pkg/services/featuremgmt/toggles_gen.json
@@ -2124,6 +2124,19 @@
         "codeowner": "@grafana/plugins-platform-backend",
         "requiresRestart": true
       }
+    },
+    {
+      "metadata": {
+        "name": "alertingUpgradeDryrunOnStart",
+        "resourceVersion": "1708030876229",
+        "creationTimestamp": "2024-02-15T21:01:16Z"
+      },
+      "spec": {
+        "description": "Dry-run Unified Alerting upgrade on startup",
+        "stage": "GA",
+        "codeowner": "@grafana/alerting-squad",
+        "requiresRestart": true
+      }
     }
   ]
 }

--- a/pkg/services/featuremgmt/toggles_gen.json
+++ b/pkg/services/featuremgmt/toggles_gen.json
@@ -2128,11 +2128,14 @@
     {
       "metadata": {
         "name": "alertingUpgradeDryrunOnStart",
-        "resourceVersion": "1708030876229",
-        "creationTimestamp": "2024-02-15T21:01:16Z"
+        "resourceVersion": "1708098586429",
+        "creationTimestamp": "2024-02-15T21:01:16Z",
+        "annotations": {
+          "grafana.app/updatedTimestamp": "2024-02-16 15:49:46.429030423 +0000 UTC"
+        }
       },
       "spec": {
-        "description": "Dry-run Unified Alerting upgrade on startup",
+        "description": "When activated in legacy alerting mode, this initiates a dry-run of the Unified Alerting upgrade during each startup. It logs any issues detected without implementing any actual changes.",
         "stage": "GA",
         "codeowner": "@grafana/alerting-squad",
         "requiresRestart": true

--- a/pkg/services/ngalert/migration/channel_test.go
+++ b/pkg/services/ngalert/migration/channel_test.go
@@ -417,7 +417,7 @@ func TestSetupAlertmanagerConfig(t *testing.T) {
 
 			service := NewTestMigrationService(t, sqlStore, nil)
 			m := service.newOrgMigration(1)
-			pairs, err := m.migrateChannels(tt.channels)
+			pairs, err := m.migrateChannels(tt.channels, m.log)
 			if tt.expErr != nil {
 				require.Error(t, err)
 				require.EqualError(t, err, tt.expErr.Error())

--- a/pkg/services/ngalert/migration/permissions.go
+++ b/pkg/services/ngalert/migration/permissions.go
@@ -408,7 +408,7 @@ func (sync *sync) createFolder(ctx context.Context, orgID int64, title string, n
 			// but the only folders we should be creating here are ones with permission
 			// hash suffix or general alerting. Neither of which is likely to spuriously
 			// conflict with an existing folder.
-			sync.log.Warn("Folder already exists, using existing folder", "title", title)
+			sync.log.FromContext(ctx).Warn("Folder already exists, using existing folder", "title", title)
 			f, err := sync.migrationStore.GetFolder(ctx, &folder.GetFolderQuery{OrgID: orgID, Title: &title, SignedInUser: getMigrationUser(orgID)})
 			if err != nil {
 				return nil, err

--- a/pkg/services/ngalert/migration/service.go
+++ b/pkg/services/ngalert/migration/service.go
@@ -371,6 +371,7 @@ func (ms *migrationService) Run(ctx context.Context) error {
 
 				// Append a field to log when dry-running
 				errMigration = ms.store.InTransaction(ctx, func(ctx context.Context) error {
+					ctx = log.WithContextualAttributes(ctx, []any{"dryrun", "true"})
 					err := ms.applyTransition(ctx, t)
 					if err != nil {
 						return err

--- a/pkg/services/ngalert/migration/service.go
+++ b/pkg/services/ngalert/migration/service.go
@@ -471,9 +471,9 @@ func (ms *migrationService) applyTransition(ctx context.Context, t transition) e
 	})
 	if t.DryrunUpgrade {
 		if errors.Is(err, ErrSuccessRollback) {
-			ms.log.FromContext(ctx).Info("Dry-run upgrade succeeded. No changes were made.")
+			ms.log.FromContext(ctx).Info("Dry-run upgrade succeeded. No changes were made. Current legacy alerting setup is ready to upgrade.")
 		} else {
-			ms.log.FromContext(ctx).Warn("Dry-run upgrade failed. No changes were made.", "err", err)
+			ms.log.FromContext(ctx).Warn("Dry-run upgrade failed. No changes were made. Current legacy alerting setup will fail to upgrade, issues must be fixed before upgrading Grafana to v11 as legacy alerting will be removed. See https://grafana.com/docs/grafana/v10.4/alerting/set-up/migrating-alerts/ for more details.", "err", err)
 		}
 		// Dry should never error.
 		return nil

--- a/pkg/services/ngalert/migration/service.go
+++ b/pkg/services/ngalert/migration/service.go
@@ -438,7 +438,7 @@ func (ms *migrationService) applyTransition(ctx context.Context, t transition) e
 		}
 
 		if t.DryrunUpgrade {
-			l.Info("Dry-running upgrade", "cleanOnUpgrade", t.CleanOnUpgrade)
+			l.Info(fmt.Sprintf("Dry-running upgrade. To deactivate on-start dry-run, disable the feature flag '%s'", featuremgmt.FlagAlertingUpgradeDryrunOnStart), "cleanOnUpgrade", t.CleanOnUpgrade)
 		} else {
 			l.Info("Applying transition", "currentType", t.CurrentType, "desiredType", t.DesiredType, "cleanOnDowngrade", t.CleanOnDowngrade, "cleanOnUpgrade", t.CleanOnUpgrade)
 		}

--- a/pkg/services/ngalert/migration/store/database.go
+++ b/pkg/services/ngalert/migration/store/database.go
@@ -443,6 +443,7 @@ var revertPermissions = []accesscontrol.Permission{
 func (ms *migrationStore) RevertOrg(ctx context.Context, orgID int64) error {
 	return ms.store.InTransaction(ctx, func(ctx context.Context) error {
 		return ms.store.WithDbSession(ctx, func(sess *db.Session) error {
+			l := ms.log.FromContext(ctx)
 			if _, err := sess.Exec("DELETE FROM alert_rule WHERE org_id = ?", orgID); err != nil {
 				return err
 			}
@@ -456,7 +457,7 @@ func (ms *migrationStore) RevertOrg(ctx context.Context, orgID int64) error {
 				return err
 			}
 			if err := ms.DeleteFolders(ctx, orgID, state.CreatedFolders...); err != nil {
-				ms.log.Warn("Failed to delete migrated folders", "orgId", orgID, "err", err)
+				l.Warn("Failed to delete migrated folders", "orgId", orgID, "err", err)
 			}
 
 			if _, err := sess.Exec("DELETE FROM alert_configuration WHERE org_id = ?", orgID); err != nil {
@@ -485,7 +486,7 @@ func (ms *migrationStore) RevertOrg(ctx context.Context, orgID int64) error {
 			}
 			for _, f := range files {
 				if err := os.Remove(f); err != nil {
-					ms.log.Error("Failed to remove silence file", "file", f, "err", err)
+					l.Error("Failed to remove silence file", "file", f, "err", err)
 				}
 			}
 
@@ -500,6 +501,7 @@ func (ms *migrationStore) RevertOrg(ctx context.Context, orgID int64) error {
 func (ms *migrationStore) RevertAllOrgs(ctx context.Context) error {
 	return ms.store.InTransaction(ctx, func(ctx context.Context) error {
 		return ms.store.WithDbSession(ctx, func(sess *db.Session) error {
+			l := ms.log.FromContext(ctx)
 			if _, err := sess.Exec("DELETE FROM alert_rule"); err != nil {
 				return err
 			}
@@ -518,7 +520,7 @@ func (ms *migrationStore) RevertAllOrgs(ctx context.Context) error {
 					return err
 				}
 				if err := ms.DeleteFolders(ctx, o.ID, state.CreatedFolders...); err != nil {
-					ms.log.Warn("Failed to delete migrated folders", "orgId", o.ID, "err", err)
+					l.Warn("Failed to delete migrated folders", "orgId", o.ID, "err", err)
 					continue
 				}
 			}
@@ -549,7 +551,7 @@ func (ms *migrationStore) RevertAllOrgs(ctx context.Context) error {
 			}
 			for _, f := range files {
 				if err := os.Remove(f); err != nil {
-					ms.log.Error("Failed to remove silence file", "file", f, "err", err)
+					l.Error("Failed to remove silence file", "file", f, "err", err)
 				}
 			}
 

--- a/pkg/services/ngalert/migration/testing.go
+++ b/pkg/services/ngalert/migration/testing.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/grafana/grafana/pkg/infra/serverlock"
 	"github.com/grafana/grafana/pkg/infra/tracing"
+	"github.com/grafana/grafana/pkg/services/featuremgmt"
 	apimodels "github.com/grafana/grafana/pkg/services/ngalert/api/tooling/definitions"
 	migrationStore "github.com/grafana/grafana/pkg/services/ngalert/migration/store"
 	fake_secrets "github.com/grafana/grafana/pkg/services/secrets/fakes"
@@ -24,6 +25,7 @@ func NewTestMigrationService(t *testing.T, sqlStore *sqlstore.SQLStore, cfg *set
 	svc, err := ProvideService(
 		serverlock.ProvideService(sqlStore, tracing.InitializeTracerForTest()),
 		cfg,
+		featuremgmt.WithFeatures(),
 		sqlStore,
 		migrationStore.NewTestMigrationStore(t, sqlStore, cfg),
 		fake_secrets.NewFakeSecretsService(),

--- a/pkg/services/ngalert/migration/ualert.go
+++ b/pkg/services/ngalert/migration/ualert.go
@@ -45,7 +45,7 @@ func (om *OrgMigration) migrateDashboard(ctx context.Context, dashID int64, aler
 		du.AddAlertErrors(err, alerts...)
 		return du
 	}
-	l := om.log.New(
+	l := om.log.FromContext(ctx).New(
 		"dashboardTitle", dashboard.Title,
 		"dashboardUid", dashboard.UID,
 	)
@@ -70,7 +70,7 @@ func (om *OrgMigration) migrateOrgAlerts(ctx context.Context) ([]*migmodels.Dash
 	if err != nil {
 		return nil, fmt.Errorf("load alerts: %w", err)
 	}
-	om.log.Info("Alerts found to migrate", "alerts", cnt)
+	om.log.FromContext(ctx).Info("Alerts found to migrate", "alerts", cnt)
 
 	dashboardUpgrades := make([]*migmodels.DashboardUpgrade, 0, len(mappedAlerts))
 	for dashID, alerts := range mappedAlerts {
@@ -86,7 +86,7 @@ func (om *OrgMigration) migrateOrgChannels(ctx context.Context) ([]*migmodels.Co
 		return nil, fmt.Errorf("load notification channels: %w", err)
 	}
 
-	pairs, err := om.migrateChannels(channels)
+	pairs, err := om.migrateChannels(channels, om.log.FromContext(ctx))
 	if err != nil {
 		return nil, err
 	}
@@ -94,7 +94,7 @@ func (om *OrgMigration) migrateOrgChannels(ctx context.Context) ([]*migmodels.Co
 }
 
 func (om *OrgMigration) migrateOrg(ctx context.Context) ([]*migmodels.DashboardUpgrade, []*migmodels.ContactPair, error) {
-	om.log.Info("Migrating alerts for organisation")
+	om.log.FromContext(ctx).Info("Migrating alerts for organisation")
 	pairs, err := om.migrateOrgChannels(ctx)
 	if err != nil {
 		return nil, nil, fmt.Errorf("migrate channels: %w", err)

--- a/pkg/services/ngalert/migration/ualert.go
+++ b/pkg/services/ngalert/migration/ualert.go
@@ -49,7 +49,7 @@ func (om *OrgMigration) migrateDashboard(ctx context.Context, dashID int64, aler
 		"dashboardTitle", dashboard.Title,
 		"dashboardUid", dashboard.UID,
 	)
-	l.Info("Migrating alerts for dashboard", "alertCount", len(alerts))
+	l.Debug("Migrating alerts for dashboard", "alertCount", len(alerts))
 
 	du := migmodels.NewDashboardUpgrade(dashID)
 	du.UID = dashboard.UID


### PR DESCRIPTION
**What is this feature?**

Adds a feature flag (`alertingUpgradeDryrunOnStart`) that will dry-run the legacy alert upgrade on startup. It is enabled by default.

**Why do we need this feature?**

When on legacy alerting, this feature flag will log the results of the legacy alerting upgrade on startup and draw attention to anything in the current legacy alerting configuration that will cause issues when the upgrade is eventually performed. It acts as a log warning for those where action is required before upgrading to Grafana v11 where legacy alerting will be removed.

**Who is this feature for?**

Users on legacy alerting.

**Special notes for your reviewer:**

While fairly fast, the upgrade can increase grafana startup time. On a real-world test instance with the following setup:

Folders: 520
Dashboards with alerts: 2,285
Alerts: 11,967
Permission rows: 100,327

This adds between 4-21s to startup time depending on if there were issues found or not.

Because of this, it can be deactivated through the feature flag `alertingUpgradeDryrunOnStart`

### Example logs

Success but with lots of alerts that have duplicate names in the same folder:

```
INFO [02-16|09:57:21] Dry-running upgrade. To deactivate on-start dry-run, disable the feature flag 'alertingUpgradeDryrunOnStart' logger=ngalert.migration dryrun=true cleanOnUpgrade=false
INFO [02-16|09:57:21] Migrating alerts for organisation        logger=ngalert.migration orgID=1 dryrun=true
WARN [02-16|09:57:21] Failed to create receiver                logger=ngalert.migration orgID=1 dryrun=true type=hipchat name="hipchat test" uid=f6d13b1e-68c7-4b6b-ae0f-0b65e83af3e4 error="'hipchat': discontinued"
INFO [02-16|09:57:21] Alerts found to migrate                  logger=ngalert.migration orgID=1 dryrun=true alerts=296
INFO [02-16|09:57:21] Writing alertmanager config              logger=ngalert.migration orgID=1 dryrun=true receivers=25 routes=1
WARN [02-16|09:57:21] Failed to find folder for dashboard      logger=ngalert.migration orgID=1 dryrun=true dashboardTitle="New dashboard missing" dashboardUid=d12136e4-38cd-4abd-909a-86d602f7e13c missingFolderId=123123 error="folder with id 123123 not found"
INFO [02-16|09:57:21] Migrating alert to the general alerting folder logger=ngalert.migration orgID=1 dryrun=true dashboardTitle="New dashboard missing" dashboardUid=d12136e4-38cd-4abd-909a-86d602f7e13c
INFO [02-16|09:57:21] Dashboard has custom permissions, create a new folder for alerts. logger=ngalert.migration orgID=1 dryrun=true dashboardTitle="Admin Dashboard" dashboardUid=c460bfee-04f9-45e2-8eb2-1d5ca4cff3ad folderUid=a0d8d30a-8303-4200-8b94-f80fc1c54b4e folderName="custom alerts" newFolder="custom alerts Alerts - a4bcfc3994dcfacac06198c8b184c778"
WARN [02-16|09:57:21] failed to parse user ID                  logger=folder-service namespaceID=user userID=0 error="identifier is not initialized"
INFO [02-16|09:57:21] Alert rule title modified to be unique within folder logger=ngalert.migration orgID=1 dryrun=true legacyRuleId=90 ruleUid=bdcyyascpmfb7b old="Fake Data Down Alert" new="Fake Data Down Alert #2"
INFO [02-16|09:57:21] Alert rule title modified to be unique within folder logger=ngalert.migration orgID=1 dryrun=true legacyRuleId=104 ruleUid=cdcyyascum802f old="Fake Data Down Alert" new="Fake Data Down Alert #2"
INFO [02-16|09:57:21] Alert rule title modified to be unique within folder logger=ngalert.migration orgID=1 dryrun=true legacyRuleId=118 ruleUid=adcyyasblo1s0a old="Fake Data Down Alert" new="Fake Data Down Alert #2"
INFO [02-16|09:57:21] Alert rule title modified to be unique within folder logger=ngalert.migration orgID=1 dryrun=true legacyRuleId=132 ruleUid=ddcyyasby5jice old="Fake Data Down Alert" new="Fake Data Down Alert #2"
INFO [02-16|09:57:21] Alert rule title modified to be unique within folder logger=ngalert.migration orgID=1 dryrun=true legacyRuleId=146 ruleUid=bdcyyasbbogeba old="Fake Data Down Alert" new="Fake Data Down Alert #2"
INFO [02-16|09:57:21] Alert rule title modified to be unique within folder logger=ngalert.migration orgID=1 dryrun=true legacyRuleId=160 ruleUid=fdcyyascx44cja old="Fake Data Down Alert" new="Fake Data Down Alert #2"
INFO [02-16|09:57:21] Alert rule title modified to be unique within folder logger=ngalert.migration orgID=1 dryrun=true legacyRuleId=174 ruleUid=fdcyyasbo5y4jf old="Fake Data Down Alert" new="Fake Data Down Alert #2"
INFO [02-16|09:57:21] Alert rule title modified to be unique within folder logger=ngalert.migration orgID=1 dryrun=true legacyRuleId=188 ruleUid=cdcyyasd23x1fb old="Fake Data Down Alert" new="Fake Data Down Alert #2"
INFO [02-16|09:57:21] Alert rule title modified to be unique within folder logger=ngalert.migration orgID=1 dryrun=true legacyRuleId=202 ruleUid=adcyyasc35c77f old="Fake Data Down Alert" new="Fake Data Down Alert #2"
INFO [02-16|09:57:21] Alert rule title modified to be unique within folder logger=ngalert.migration orgID=1 dryrun=true legacyRuleId=216 ruleUid=adcyyasc5n8jnd old="Fake Data Down Alert" new="Fake Data Down Alert #2"
INFO [02-16|09:57:21] Alert rule title modified to be unique within folder logger=ngalert.migration orgID=1 dryrun=true legacyRuleId=230 ruleUid=adcyyasd73pq9b old="Fake Data Down Alert" new="Fake Data Down Alert #2"
INFO [02-16|09:57:21] Alert rule title modified to be unique within folder logger=ngalert.migration orgID=1 dryrun=true legacyRuleId=244 ruleUid=adcyyasd9lm2rf old="Fake Data Down Alert" new="Fake Data Down Alert #2"
INFO [02-16|09:57:21] Alert rule title modified to be unique within folder logger=ngalert.migration orgID=1 dryrun=true legacyRuleId=258 ruleUid=adcyyasbt5qtcc old="Fake Data Down Alert" new="Fake Data Down Alert #2"
INFO [02-16|09:57:21] Alert rule title modified to be unique within folder logger=ngalert.migration orgID=1 dryrun=true legacyRuleId=272 ruleUid=bdcyyascan18jb old="Fake Data Down Alert" new="Fake Data Down Alert #2"
INFO [02-16|09:57:21] Alert rule title modified to be unique within folder logger=ngalert.migration orgID=1 dryrun=true legacyRuleId=286 ruleUid=cdcyyasbgo937c old="Fake Data Down Alert" new="Fake Data Down Alert #2"
INFO [02-16|09:57:21] Alert rule title modified to be unique within folder logger=ngalert.migration orgID=1 dryrun=true legacyRuleId=300 ruleUid=edcyyascd4xkzf old="Fake Data Down Alert" new="Fake Data Down Alert #2"
INFO [02-16|09:57:21] Alert rule title modified to be unique within folder logger=ngalert.migration orgID=1 dryrun=true legacyRuleId=314 ruleUid=adcyyasci4q9te old="Fake Data Down Alert" new="Fake Data Down Alert #2"
INFO [02-16|09:57:21] Alert rule title modified to be unique within folder logger=ngalert.migration orgID=1 dryrun=true legacyRuleId=328 ruleUid=cdcyyasdelernd old="Fake Data Down Alert" new="Fake Data Down Alert #2"
INFO [02-16|09:57:21] Alert rule title modified to be unique within folder logger=ngalert.migration orgID=1 dryrun=true legacyRuleId=342 ruleUid=ddcyyasckmmmba old="Fake Data Down Alert" new="Fake Data Down Alert #2"
INFO [02-16|09:57:21] Alert rule title modified to be unique within folder logger=ngalert.migration orgID=1 dryrun=true legacyRuleId=637 ruleUid=bdcyyasdh3b41b old="Fake Data Down Alert" new="Fake Data Down Alert #2"
INFO [02-16|09:57:21] Creating silence for rules with ExecutionErrorState = keep_state logger=ngalert.migration orgID=1 dryrun=true rules=1
INFO [02-16|09:57:21] Creating silence for rules with NoDataState = keep_state logger=ngalert.migration orgID=1 dryrun=true rules=1
INFO [02-16|09:57:21] Dry-run upgrade succeeded. No changes were made. Current legacy alerting setup is ready to upgrade.
 logger=ngalert.migration dryrun=true
```
Failure after garbling one of the alert json settings:

```
INFO [02-16|09:59:56] Dry-running upgrade. To deactivate on-start dry-run, disable the feature flag 'alertingUpgradeDryrunOnStart' logger=ngalert.migration dryrun=true cleanOnUpgrade=false
INFO [02-16|09:59:56] Migrating alerts for organisation        logger=ngalert.migration orgID=1 dryrun=true
WARN [02-16|09:59:56] Failed to create receiver                logger=ngalert.migration orgID=1 dryrun=true type=hipchat name="hipchat test" uid=f6d13b1e-68c7-4b6b-ae0f-0b65e83af3e4 error="'hipchat': discontinued"
INFO [02-16|09:59:56] Alerts found to migrate                  logger=ngalert.migration orgID=1 dryrun=true alerts=296
WARN [02-16|09:59:56] Failed to migrate alert                  logger=ngalert.migration orgID=1 dryrun=true dashboardTitle="Custom Alerting with TestData" dashboardUid=e7623ee3-178e-490b-b94b-adaebc9dfb98 ruleId=87 ruleName="Fake Data Down Alert" error="parse settings: json: cannot unmarshal number into Go struct field dashAlertSettings.noDataState of type string"
WARN [02-16|11:01:44] Dry-run upgrade failed. No changes were made. Current legacy alerting setup will fail to upgrade, issues must be fixed before upgrading Grafana to v11 as legacy alerting will be removed. See https://grafana.com/docs/grafana/v10.4/alerting/set-up/migrating-alerts/ for more details. logger=ngalert.migration dryrun=true err="executing migration: migrate org 1: migrate alert 'Fake Data Down Alert': parse settings: json: cannot unmarshal number into Go struct field dashAlertSettings.noDataState of type string"
```
