### PR TITLE
TimeRangeList: absolute time range list not scrollable

### DIFF
--- a/packages/grafana-ui/src/components/DateTimePickers/TimeRangePicker/TimePickerContent.tsx
+++ b/packages/grafana-ui/src/components/DateTimePickers/TimeRangePicker/TimePickerContent.tsx
@@ -280,6 +280,8 @@ const getStyles = (
     borderRadius: theme.shape.radius.default,
     border: `1px solid ${theme.colors.border.weak}`,
     [`${isReversed ? 'left' : 'right'}`]: 0,
+    display: 'flex',
+    flexDirection: 'column',
   }),
   body: css({
     display: 'flex',
@@ -292,7 +294,8 @@ const getStyles = (
     flexDirection: 'column',
     borderRight: `${isReversed ? 'none' : `1px solid ${theme.colors.border.weak}`}`,
     width: `${!hideQuickRanges ? '60%' : '100%'}`,
-    overflow: 'hidden',
+    overflowY: 'scroll',
+    overflowX: 'hidden',
     order: isReversed ? 1 : 0,
   }),
   rightSide: css({

--- a/packages/grafana-ui/src/components/DateTimePickers/TimeRangePicker/TimePickerContent.tsx
+++ b/packages/grafana-ui/src/components/DateTimePickers/TimeRangePicker/TimePickerContent.tsx
@@ -294,8 +294,7 @@ const getStyles = (
     flexDirection: 'column',
     borderRight: `${isReversed ? 'none' : `1px solid ${theme.colors.border.weak}`}`,
     width: `${!hideQuickRanges ? '60%' : '100%'}`,
-    overflowY: 'scroll',
-    overflowX: 'hidden',
+    overflow: 'auto',
     order: isReversed ? 1 : 0,
   }),
   rightSide: css({

--- a/packages/grafana-ui/src/components/DateTimePickers/TimeRangePicker/TimeRangeList.tsx
+++ b/packages/grafana-ui/src/components/DateTimePickers/TimeRangePicker/TimeRangeList.tsx
@@ -46,7 +46,7 @@ const Options = ({ options, value, onChange, title }: Props) => {
 
   return (
     <>
-      <ul className={styles.list} aria-roledescription={t('time-picker.time-range.aria-role', 'Time range selection')}>
+      <ul aria-roledescription={t('time-picker.time-range.aria-role', 'Time range selection')}>
         {options.map((option, index) => (
           <TimeRangeOption
             key={keyForOption(option, index)}
@@ -73,24 +73,25 @@ function isEqual(x: TimeOption, y?: TimeOption): boolean {
   return y.from === x.from && y.to === x.to;
 }
 
-const getStyles = () => ({
+const getStyles = (theme: GrafanaTheme2) => ({
   title: css({
     display: 'flex',
     alignItems: 'center',
     justifyContent: 'space-between',
     padding: '8px 16px 5px 9px',
+
+    '+ ul': {
+      [theme.breakpoints.up('lg')]: {
+        height: '116px',
+        overflowY: 'scroll',
+      },
+    },
   }),
 });
 
-const getOptionsStyles = (theme: GrafanaTheme2) => ({
+const getOptionsStyles = () => ({
   grow: css({
     flexGrow: 1,
     alignItems: 'flex-start',
-  }),
-  list: css({
-    [theme.breakpoints.up('lg')]: {
-      height: '116px',
-      overflowY: 'scroll',
-    },
   }),
 });

--- a/packages/grafana-ui/src/components/DateTimePickers/TimeRangePicker/TimeRangeList.tsx
+++ b/packages/grafana-ui/src/components/DateTimePickers/TimeRangePicker/TimeRangeList.tsx
@@ -1,7 +1,7 @@
 import { css } from '@emotion/css';
 import React, { ReactNode } from 'react';
 
-import { TimeOption } from '@grafana/data';
+import { TimeOption, GrafanaTheme2 } from '@grafana/data';
 
 import { useStyles2 } from '../../../themes';
 import { t } from '../../../utils/i18n';
@@ -46,7 +46,7 @@ const Options = ({ options, value, onChange, title }: Props) => {
 
   return (
     <>
-      <ul aria-roledescription={t('time-picker.time-range.aria-role', 'Time range selection')}>
+      <ul className={styles.list} aria-roledescription={t('time-picker.time-range.aria-role', 'Time range selection')}>
         {options.map((option, index) => (
           <TimeRangeOption
             key={keyForOption(option, index)}
@@ -82,9 +82,15 @@ const getStyles = () => ({
   }),
 });
 
-const getOptionsStyles = () => ({
+const getOptionsStyles = (theme: GrafanaTheme2) => ({
   grow: css({
     flexGrow: 1,
     alignItems: 'flex-start',
+  }),
+  list: css({
+    [theme.breakpoints.up('lg')]: {
+      height: '116px',
+      overflowY: 'scroll',
+    },
   }),
 });

--- a/packages/grafana-ui/src/components/DateTimePickers/TimeRangePicker/TimeRangeList.tsx
+++ b/packages/grafana-ui/src/components/DateTimePickers/TimeRangePicker/TimeRangeList.tsx
@@ -1,7 +1,7 @@
 import { css } from '@emotion/css';
 import React, { ReactNode } from 'react';
 
-import { TimeOption, GrafanaTheme2 } from '@grafana/data';
+import { TimeOption } from '@grafana/data';
 
 import { useStyles2 } from '../../../themes';
 import { t } from '../../../utils/i18n';
@@ -73,19 +73,12 @@ function isEqual(x: TimeOption, y?: TimeOption): boolean {
   return y.from === x.from && y.to === x.to;
 }
 
-const getStyles = (theme: GrafanaTheme2) => ({
+const getStyles = () => ({
   title: css({
     display: 'flex',
     alignItems: 'center',
     justifyContent: 'space-between',
     padding: '8px 16px 5px 9px',
-
-    '+ ul': {
-      [theme.breakpoints.up('lg')]: {
-        height: '116px',
-        overflowY: 'scroll',
-      },
-    },
   }),
 });
 


### PR DESCRIPTION
**What is this feature?**

Fix the `Recently used absolute ranges` list not scrolling when the `TimePickerContent` has two columns.

![imagen](https://github.com/grafana/grafana/assets/65417731/c6eec756-9eb0-43ef-bc93-003da412ef2d)


**Why do we need this feature?**

To be able to show and access all the items on the `Recently used absolute ranges` list.

**Who is this feature for?**

Everyone using the TimeRangePicker and its absolute ranges.

**Which issue(s) does this PR fix?**:

Fixes #82037 

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
