### PR TITLE
Alerting: Skip fetching receivers status in the alert rule form

### DIFF
--- a/public/app/features/alerting/unified/components/contact-points/useContactPoints.tsx
+++ b/public/app/features/alerting/unified/components/contact-points/useContactPoints.tsx
@@ -50,9 +50,9 @@ export function useContactPointsWithStatus({
   const fetchContactPointsStatus = alertmanagerApi.endpoints.getContactPointsStatus.useQuery(undefined, {
     refetchOnFocus: true,
     refetchOnReconnect: true,
-    // re-fetch status every so often for up-to-date information
+    // re-fetch status every so often for up-to-date information, allow disabling by passing "receiverStatusPollingInterval: 0"
     pollingInterval: receiverStatusPollingInterval,
-    // skip fetching receiver statuses if not Grafana AM or if we're explicitly told to skip
+    // skip fetching receiver statuses if not Grafana AM
     skip: !isGrafanaAlertmanager,
   });
 

--- a/public/app/features/alerting/unified/components/contact-points/useContactPoints.tsx
+++ b/public/app/features/alerting/unified/components/contact-points/useContactPoints.tsx
@@ -29,10 +29,14 @@ const RECEIVER_STATUS_POLLING_INTERVAL = 10 * 1000; // 10 seconds
  */
 interface UseContactPointsWithStatusOptions {
   includePoliciesCount: boolean;
+  skipFetchingReceiverStatus?: boolean;
 }
 
 export function useContactPointsWithStatus(
-  { includePoliciesCount }: UseContactPointsWithStatusOptions = { includePoliciesCount: true }
+  { includePoliciesCount, skipFetchingReceiverStatus }: UseContactPointsWithStatusOptions = {
+    includePoliciesCount: true,
+    skipFetchingReceiverStatus: false,
+  }
 ) {
   const { selectedAlertmanager, isGrafanaAlertmanager } = useAlertmanager();
   const { installed: onCallPluginInstalled, loading: onCallPluginStatusLoading } = usePluginBridge(
@@ -45,8 +49,8 @@ export function useContactPointsWithStatus(
     refetchOnReconnect: true,
     // re-fetch status every so often for up-to-date information
     pollingInterval: RECEIVER_STATUS_POLLING_INTERVAL,
-    // skip fetching receiver statuses if not Grafana AM
-    skip: !isGrafanaAlertmanager,
+    // skip fetching receiver statuses if not Grafana AM or if we're explicitly told to skip
+    skip: !isGrafanaAlertmanager || skipFetchingReceiverStatus,
   });
 
   // fetch notifier metadata from the Grafana API if we're using a Grafana AM – this will be used to add additional

--- a/public/app/features/alerting/unified/components/contact-points/useContactPoints.tsx
+++ b/public/app/features/alerting/unified/components/contact-points/useContactPoints.tsx
@@ -29,15 +29,18 @@ const RECEIVER_STATUS_POLLING_INTERVAL = 10 * 1000; // 10 seconds
  */
 interface UseContactPointsWithStatusOptions {
   includePoliciesCount: boolean;
-  skipFetchingReceiverStatus?: boolean;
+  receiverStatusPollingInterval?: number;
 }
 
-export function useContactPointsWithStatus(
-  { includePoliciesCount, skipFetchingReceiverStatus }: UseContactPointsWithStatusOptions = {
-    includePoliciesCount: true,
-    skipFetchingReceiverStatus: false,
-  }
-) {
+const defaultHookOptions = {
+  includePoliciesCount: true,
+  receiverStatusPollingInterval: RECEIVER_STATUS_POLLING_INTERVAL,
+};
+
+export function useContactPointsWithStatus({
+  includePoliciesCount,
+  receiverStatusPollingInterval,
+}: UseContactPointsWithStatusOptions = defaultHookOptions) {
   const { selectedAlertmanager, isGrafanaAlertmanager } = useAlertmanager();
   const { installed: onCallPluginInstalled, loading: onCallPluginStatusLoading } = usePluginBridge(
     SupportedPlugin.OnCall
@@ -48,9 +51,9 @@ export function useContactPointsWithStatus(
     refetchOnFocus: true,
     refetchOnReconnect: true,
     // re-fetch status every so often for up-to-date information
-    pollingInterval: RECEIVER_STATUS_POLLING_INTERVAL,
+    pollingInterval: receiverStatusPollingInterval,
     // skip fetching receiver statuses if not Grafana AM or if we're explicitly told to skip
-    skip: !isGrafanaAlertmanager || skipFetchingReceiverStatus,
+    skip: !isGrafanaAlertmanager,
   });
 
   // fetch notifier metadata from the Grafana API if we're using a Grafana AM – this will be used to add additional

--- a/public/app/features/alerting/unified/components/rule-editor/alert-rule-form/simplifiedRouting/AlertManagerRouting.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/alert-rule-form/simplifiedRouting/AlertManagerRouting.tsx
@@ -29,7 +29,7 @@ export function AlertManagerManualRouting({ alertManager }: AlertManagerManualRo
     error: errorInContactPointStatus,
     contactPoints,
     refetchReceivers,
-  } = useContactPointsWithStatus({ includePoliciesCount: false });
+  } = useContactPointsWithStatus({ includePoliciesCount: false, skipFetchingReceiverStatus: true });
   const [selectedContactPointWithMetadata, setSelectedContactPointWithMetadata] = useState<
     ContactPointWithMetadata | undefined
   >();

--- a/public/app/features/alerting/unified/components/rule-editor/alert-rule-form/simplifiedRouting/AlertManagerRouting.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/alert-rule-form/simplifiedRouting/AlertManagerRouting.tsx
@@ -29,7 +29,7 @@ export function AlertManagerManualRouting({ alertManager }: AlertManagerManualRo
     error: errorInContactPointStatus,
     contactPoints,
     refetchReceivers,
-  } = useContactPointsWithStatus({ includePoliciesCount: false, skipFetchingReceiverStatus: true });
+  } = useContactPointsWithStatus({ includePoliciesCount: false, receiverStatusPollingInterval: 0 });
   const [selectedContactPointWithMetadata, setSelectedContactPointWithMetadata] = useState<
     ContactPointWithMetadata | undefined
   >();


### PR DESCRIPTION
**What is this feature?**
This PR adds skipping the fetch for receivers status when we are in the alert rule form using simplified routing. 
Previously, this process caused certain inputs to experience significant delays as the simplified section was being re-rendered due to the status fetch.

**Who is this feature for?**
All users


Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
