### PR TITLE
Alerting: Backport use Alertmanager API v2 to 9.5.x

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -63,7 +63,7 @@ require (
 	github.com/google/uuid v1.3.0
 	github.com/google/wire v0.5.0
 	github.com/gorilla/websocket v1.5.0
-	github.com/grafana/alerting v0.0.0-20230502194537-ce9fba922d97
+	github.com/grafana/alerting v0.0.0-20240216133158-fbb9275f6319
 	github.com/grafana/cuetsy v0.1.6
 	github.com/grafana/grafana-aws-sdk v0.12.0
 	github.com/grafana/grafana-azure-sdk-go v1.9.0

--- a/go.sum
+++ b/go.sum
@@ -1285,8 +1285,8 @@ github.com/gorilla/websocket v1.4.1/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/ad
 github.com/gorilla/websocket v1.4.2/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 github.com/gorilla/websocket v1.5.0 h1:PPwGk2jz7EePpoHN/+ClbZu8SPxiqlu12wZP/3sWmnc=
 github.com/gorilla/websocket v1.5.0/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
-github.com/grafana/alerting v0.0.0-20230502194537-ce9fba922d97 h1:Zi7sQOEquRNK+dPKNNZ3J3aczF+qPlLpsRzRQC13rTc=
-github.com/grafana/alerting v0.0.0-20230502194537-ce9fba922d97/go.mod h1:5edgy6tQY4+W2wuJdi8g2GjbVmpJufguy7QGIRl2q4o=
+github.com/grafana/alerting v0.0.0-20240216133158-fbb9275f6319 h1:w+/lg6KIa+A8xQDHanZ0NWT116y2CSuDme7pi8IJdms=
+github.com/grafana/alerting v0.0.0-20240216133158-fbb9275f6319/go.mod h1:5edgy6tQY4+W2wuJdi8g2GjbVmpJufguy7QGIRl2q4o=
 github.com/grafana/codejen v0.0.3 h1:tAWxoTUuhgmEqxJPOLtJoxlPBbMULFwKFOcRsPRPXDw=
 github.com/grafana/codejen v0.0.3/go.mod h1:zmwwM/DRyQB7pfuBjTWII3CWtxcXh8LTwAYGfDfpR6s=
 github.com/grafana/cuetsy v0.1.6 h1:61QGIDy1rVABU3OkoarOn0+qPdGopIJr34PyWVmGDfs=


### PR DESCRIPTION
**What is this feature?**

This commit backports grafana/alerting#159 to v9.5.x. It uses the [v9.5.x](https://github.com/grafana/alerting/tree/v9.5.x) branch in grafana/alerting.

The previous release of 9.5.x was based on commit [ce9fba9](https://github.com/grafana/alerting/commit/ce9fba922d970c74d00c523b2cfe73d50189a149) and has been updated to commit [fbb9275](https://github.com/grafana/alerting/commit/fbb9275f631991dc9a75887502810ae9154786f9).

```go
diff --git a/receivers/alertmanager/config.go b/receivers/alertmanager/config.go
index c941941..098c51a 100644
--- a/receivers/alertmanager/config.go
+++ b/receivers/alertmanager/config.go
@@ -33,7 +33,7 @@ func NewConfig(jsonData json.RawMessage, decryptFn receivers.DecryptFunc) (Confi
 		if uS == "" {
 			continue
 		}
-		uS = strings.TrimSuffix(uS, "/") + "/api/v2/alerts"
+		uS = strings.TrimSuffix(uS, "/") + "/api/v1/alerts"
 		u, err := url.Parse(uS)
 		if err != nil {
 			return Config{}, fmt.Errorf("invalid url property in settings: %w", err)
diff --git a/receivers/alertmanager/config_test.go b/receivers/alertmanager/config_test.go
index acf1fdc..3d5e925 100644
--- a/receivers/alertmanager/config_test.go
+++ b/receivers/alertmanager/config_test.go
@@ -27,7 +27,7 @@ func TestNewConfig(t *testing.T) {
 			settings: `{
 				"url": "://alertmanager.com"
 			}`,
-			expectedInitError: `invalid url property in settings: parse "://alertmanager.com/api/v2/alerts": missing protocol scheme`,
+			expectedInitError: `invalid url property in settings: parse "://alertmanager.com/api/v1/alerts": missing protocol scheme`,
 		},
 		{
 			name: "Error in initing: empty URL",
@@ -48,7 +48,7 @@ func TestNewConfig(t *testing.T) {
 			settings: `{
 				"url": "https://alertmanager-01.com,://url"
 			}`,
-			expectedInitError: "invalid url property in settings: parse \"://url/api/v2/alerts\": missing protocol scheme",
+			expectedInitError: "invalid url property in settings: parse \"://url/api/v1/alerts\": missing protocol scheme",
 		}, {
 			name: "Single URL",
 			settings: `{
@@ -56,7 +56,7 @@ func TestNewConfig(t *testing.T) {
 			}`,
 			expectedConfig: Config{
 				URLs: []*url.URL{
-					receiversTesting.ParseURLUnsafe("https://alertmanager-01.com/api/v2/alerts"),
+					receiversTesting.ParseURLUnsafe("https://alertmanager-01.com/api/v1/alerts"),
 				},
 				User:     "",
 				Password: "",
@@ -69,9 +69,9 @@ func TestNewConfig(t *testing.T) {
 			}`,
 			expectedConfig: Config{
 				URLs: []*url.URL{
-					receiversTesting.ParseURLUnsafe("https://alertmanager-01.com/api/v2/alerts"),
-					receiversTesting.ParseURLUnsafe("https://alertmanager-02.com/api/v2/alerts"),
-					receiversTesting.ParseURLUnsafe("https://alertmanager-03.com/api/v2/alerts"),
+					receiversTesting.ParseURLUnsafe("https://alertmanager-01.com/api/v1/alerts"),
+					receiversTesting.ParseURLUnsafe("https://alertmanager-02.com/api/v1/alerts"),
+					receiversTesting.ParseURLUnsafe("https://alertmanager-03.com/api/v1/alerts"),
 				},
 				User:     "",
 				Password: "",
@@ -86,7 +86,7 @@ func TestNewConfig(t *testing.T) {
 			}`,
 			expectedConfig: Config{
 				URLs: []*url.URL{
-					receiversTesting.ParseURLUnsafe("https://alertmanager-01.com/api/v2/alerts"),
+					receiversTesting.ParseURLUnsafe("https://alertmanager-01.com/api/v1/alerts"),
 				},
 				User:     "grafana",
 				Password: "admin",
@@ -98,7 +98,7 @@ func TestNewConfig(t *testing.T) {
 			secrets:  receiversTesting.ReadSecretsJSONForTesting(FullValidSecretsForTesting),
 			expectedConfig: Config{
 				URLs: []*url.URL{
-					receiversTesting.ParseURLUnsafe("https://alertmanager-01.com/api/v2/alerts"),
+					receiversTesting.ParseURLUnsafe("https://alertmanager-01.com/api/v1/alerts"),
 				},
 				User:     "grafana",
 				Password: "grafana-admin",
```

**Why do we need this feature?**

To avoid breaking users of 9.5.x when Alertmanager 0.27 is released.

**Who is this feature for?**

[Add information on what kind of user the feature is for.]

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
