### PR TITLE
Loki: Pass time range variable in variable editor

### DIFF
--- a/.betterer.results.json
+++ b/.betterer.results.json
@@ -1028,12 +1028,6 @@
         "count": 5
       }
     ],
-    "/packages/grafana-ui/src/components/Splitter/Splitter.tsx": [
-      {
-        "message": "Do not use any type assertions.",
-        "count": 1
-      }
-    ],
     "/packages/grafana-ui/src/components/StatsPicker/StatsPicker.story.tsx": [
       {
         "message": "Unexpected any. Specify a different type.",

--- a/public/app/plugins/datasource/loki/components/VariableQueryEditor.test.tsx
+++ b/public/app/plugins/datasource/loki/components/VariableQueryEditor.test.tsx
@@ -7,7 +7,7 @@ import { TimeRange, dateTime } from '@grafana/data';
 import { TemplateSrv } from '@grafana/runtime';
 
 import { createLokiDatasource } from '../__mocks__/datasource';
-import { LokiVariableQuery, LokiVariableQueryType } from '../types';
+import { LokiVariableQueryType } from '../types';
 
 import { LokiVariableQueryEditor, Props } from './VariableQueryEditor';
 
@@ -156,5 +156,110 @@ describe('LokiVariableQueryEditor', () => {
     await waitFor(() =>
       expect(props.datasource.languageProvider.fetchLabels).toHaveBeenCalledWith({ timeRange: range })
     );
+  });
+
+  test('does not re-run fetch labels when type does not change', async () => {
+    const now = dateTime('2023-09-16T21:26:00Z');
+    const range: TimeRange = {
+      from: dateTime(now).subtract(2, 'days'),
+      to: now,
+      raw: {
+        from: 'now-2d',
+        to: 'now',
+      },
+    };
+    props.range = range;
+    props.query = {
+      refId: 'test',
+      type: LokiVariableQueryType.LabelValues,
+    };
+
+    props.datasource.languageProvider.fetchLabels = jest.fn().mockResolvedValue([]);
+    const { rerender } = render(<LokiVariableQueryEditor {...props} />);
+    rerender(
+      <LokiVariableQueryEditor {...props} query={{ ...props.query, type: LokiVariableQueryType.LabelValues }} />
+    );
+
+    await waitFor(() => {
+      expect(props.datasource.languageProvider.fetchLabels).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  test('runs fetch labels when type changes to from LabelNames to LabelValues', async () => {
+    const now = dateTime('2023-09-16T21:26:00Z');
+    const range: TimeRange = {
+      from: dateTime(now).subtract(2, 'days'),
+      to: now,
+      raw: {
+        from: 'now-2d',
+        to: 'now',
+      },
+    };
+    props.range = range;
+    props.query = {
+      refId: 'test',
+      type: LokiVariableQueryType.LabelNames,
+    };
+
+    props.datasource.languageProvider.fetchLabels = jest.fn().mockResolvedValue([]);
+    const { rerender } = render(<LokiVariableQueryEditor {...props} />);
+    rerender(
+      <LokiVariableQueryEditor {...props} query={{ ...props.query, type: LokiVariableQueryType.LabelValues }} />
+    );
+
+    await waitFor(() => {
+      expect(props.datasource.languageProvider.fetchLabels).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  test('runs fetch labels when type changes to LabelValues', async () => {
+    const now = dateTime('2023-09-16T21:26:00Z');
+    const range: TimeRange = {
+      from: dateTime(now).subtract(2, 'days'),
+      to: now,
+      raw: {
+        from: 'now-2d',
+        to: 'now',
+      },
+    };
+    props.range = range;
+    props.query = {
+      refId: 'test',
+      type: LokiVariableQueryType.LabelNames,
+    };
+
+    props.datasource.languageProvider.fetchLabels = jest.fn().mockResolvedValue([]);
+    // Starting with LabelNames
+    const { rerender } = render(<LokiVariableQueryEditor {...props} />);
+
+    // Changing to LabelValues, should run fetchLabels
+    rerender(
+      <LokiVariableQueryEditor {...props} query={{ ...props.query, type: LokiVariableQueryType.LabelValues }} />
+    );
+    await waitFor(() => {
+      expect(props.datasource.languageProvider.fetchLabels).toHaveBeenCalledTimes(1);
+    });
+
+    // Keeping the type of LabelValues, should not run additional fetchLabels
+    rerender(
+      <LokiVariableQueryEditor {...props} query={{ ...props.query, type: LokiVariableQueryType.LabelValues }} />
+    );
+    await waitFor(() => {
+      expect(props.datasource.languageProvider.fetchLabels).toHaveBeenCalledTimes(1);
+    });
+
+    // Changing to LabelNames, should not run additional fetchLabels
+    rerender(<LokiVariableQueryEditor {...props} query={{ ...props.query, type: LokiVariableQueryType.LabelNames }} />);
+    await waitFor(() => {
+      expect(props.datasource.languageProvider.fetchLabels).toHaveBeenCalledTimes(1);
+    });
+
+    // Changing to LabelValues, should run additional fetchLabels
+    rerender(
+      <LokiVariableQueryEditor {...props} query={{ ...props.query, type: LokiVariableQueryType.LabelValues }} />
+    );
+    await waitFor(() => {
+      expect(props.datasource.languageProvider.fetchLabels).toHaveBeenCalledTimes(2);
+    });
   });
 });

--- a/public/app/plugins/datasource/loki/components/VariableQueryEditor.test.tsx
+++ b/public/app/plugins/datasource/loki/components/VariableQueryEditor.test.tsx
@@ -3,10 +3,11 @@ import userEvent from '@testing-library/user-event';
 import React from 'react';
 import { select } from 'react-select-event';
 
+import { TimeRange, dateTime } from '@grafana/data';
 import { TemplateSrv } from '@grafana/runtime';
 
 import { createLokiDatasource } from '../__mocks__/datasource';
-import { LokiVariableQueryType } from '../types';
+import { LokiVariableQuery, LokiVariableQueryType } from '../types';
 
 import { LokiVariableQueryEditor, Props } from './VariableQueryEditor';
 
@@ -132,5 +133,28 @@ describe('LokiVariableQueryEditor', () => {
     await select(screen.getByLabelText('Label'), 'moon', { container: document.body });
     await select(screen.getByLabelText('Label'), 'luna', { container: document.body });
     await screen.findByText('luna');
+  });
+
+  test('Calls language provider fetchLabels with the time range received in props', async () => {
+    const now = dateTime('2023-09-16T21:26:00Z');
+    const range: TimeRange = {
+      from: dateTime(now).subtract(2, 'days'),
+      to: now,
+      raw: {
+        from: 'now-2d',
+        to: 'now',
+      },
+    };
+    props.range = range;
+    props.query = {
+      refId: 'test',
+      type: LokiVariableQueryType.LabelValues,
+      label: 'luna',
+    };
+
+    render(<LokiVariableQueryEditor {...props} />);
+    await waitFor(() =>
+      expect(props.datasource.languageProvider.fetchLabels).toHaveBeenCalledWith({ timeRange: range })
+    );
   });
 });

--- a/public/app/plugins/datasource/loki/components/VariableQueryEditor.tsx
+++ b/public/app/plugins/datasource/loki/components/VariableQueryEditor.tsx
@@ -38,7 +38,7 @@ export const LokiVariableQueryEditor = ({ onChange, query, datasource, range }: 
       return;
     }
 
-    datasource.languageProvider.fetchLabels({ timeRange: range }).then((labelNames: string[]) => {
+    datasource.languageProvider.fetchLabels({ timeRange: range }).then((labelNames) => {
       setLabelOptions(labelNames.map((labelName) => ({ label: labelName, value: labelName })));
     });
   }, [datasource, type]);

--- a/public/app/plugins/datasource/loki/components/VariableQueryEditor.tsx
+++ b/public/app/plugins/datasource/loki/components/VariableQueryEditor.tsx
@@ -41,7 +41,7 @@ export const LokiVariableQueryEditor = ({ onChange, query, datasource, range }: 
     datasource.languageProvider.fetchLabels({ timeRange: range }).then((labelNames) => {
       setLabelOptions(labelNames.map((labelName) => ({ label: labelName, value: labelName })));
     });
-  }, [datasource, type]);
+  }, [datasource, type, range]);
 
   const onQueryTypeChange = (newType: SelectableValue<QueryType>) => {
     setType(newType.value);

--- a/public/app/plugins/datasource/loki/components/VariableQueryEditor.tsx
+++ b/public/app/plugins/datasource/loki/components/VariableQueryEditor.tsx
@@ -44,7 +44,7 @@ export const LokiVariableQueryEditor = ({ onChange, query, datasource, range }: 
     datasource.languageProvider.fetchLabels({ timeRange: range }).then((labelNames) => {
       setLabelOptions(labelNames.map((labelName) => ({ label: labelName, value: labelName })));
     });
-  }, [datasource, type, previousType]);
+  }, [datasource, type, range, previousType]);
 
   const onQueryTypeChange = (newType: SelectableValue<QueryType>) => {
     setType(newType.value);

--- a/public/app/plugins/datasource/loki/components/VariableQueryEditor.tsx
+++ b/public/app/plugins/datasource/loki/components/VariableQueryEditor.tsx
@@ -1,4 +1,5 @@
 import React, { FormEvent, useState, useEffect } from 'react';
+import { usePrevious } from 'react-use';
 
 import { QueryEditorProps, SelectableValue } from '@grafana/data';
 import { InlineField, InlineFieldRow, Input, Select } from '@grafana/ui';
@@ -21,6 +22,7 @@ export const LokiVariableQueryEditor = ({ onChange, query, datasource, range }: 
   const [label, setLabel] = useState('');
   const [labelOptions, setLabelOptions] = useState<Array<SelectableValue<string>>>([]);
   const [stream, setStream] = useState('');
+  const previousType = usePrevious(type);
 
   useEffect(() => {
     if (!query) {
@@ -34,14 +36,15 @@ export const LokiVariableQueryEditor = ({ onChange, query, datasource, range }: 
   }, [query]);
 
   useEffect(() => {
-    if (type !== QueryType.LabelValues) {
+    // Fetch label names when the query type is LabelValues, and the previous type was not the same
+    if (type !== QueryType.LabelValues || previousType === type) {
       return;
     }
 
     datasource.languageProvider.fetchLabels({ timeRange: range }).then((labelNames) => {
       setLabelOptions(labelNames.map((labelName) => ({ label: labelName, value: labelName })));
     });
-  }, [datasource, type, range]);
+  }, [datasource, type, previousType]);
 
   const onQueryTypeChange = (newType: SelectableValue<QueryType>) => {
     setType(newType.value);

--- a/public/app/plugins/datasource/loki/components/VariableQueryEditor.tsx
+++ b/public/app/plugins/datasource/loki/components/VariableQueryEditor.tsx
@@ -16,7 +16,7 @@ export type Props = QueryEditorProps<LokiDatasource, LokiQuery, LokiOptions, Lok
 
 const refId = 'LokiVariableQueryEditor-VariableQuery';
 
-export const LokiVariableQueryEditor = ({ onChange, query, datasource }: Props) => {
+export const LokiVariableQueryEditor = ({ onChange, query, datasource, range }: Props) => {
   const [type, setType] = useState<number | undefined>(undefined);
   const [label, setLabel] = useState('');
   const [labelOptions, setLabelOptions] = useState<Array<SelectableValue<string>>>([]);
@@ -38,7 +38,7 @@ export const LokiVariableQueryEditor = ({ onChange, query, datasource }: Props) 
       return;
     }
 
-    datasource.languageProvider.fetchLabels().then((labelNames: string[]) => {
+    datasource.languageProvider.fetchLabels({ timeRange: range }).then((labelNames: string[]) => {
       setLabelOptions(labelNames.map((labelName) => ({ label: labelName, value: labelName })));
     });
   }, [datasource, type]);


### PR DESCRIPTION
Discovered while I was investigating https://github.com/grafana/grafana/issues/80508, but this is not relevant to the issue, because it affects only showing of label values in editor. But it linked to same fix in Prometheus https://github.com/grafana/grafana/pull/78950 so I created this fix in here as well. 