### PR TITLE
Alerting: Create metric for rules using simple notifications

### DIFF
--- a/pkg/services/ngalert/metrics/scheduler.go
+++ b/pkg/services/ngalert/metrics/scheduler.go
@@ -97,7 +97,7 @@ func NewSchedulerMetrics(r prometheus.Registerer) *Scheduler {
 				Namespace: Namespace,
 				Subsystem: Subsystem,
 				Name:      "simple_notification_rules",
-				Help:      "The number of simple notification rules.",
+				Help:      "The number of alert rules using simplified routing.",
 			},
 			[]string{"org"},
 		),

--- a/pkg/services/ngalert/metrics/scheduler.go
+++ b/pkg/services/ngalert/metrics/scheduler.go
@@ -20,6 +20,7 @@ type Scheduler struct {
 	EvalDuration                        *prometheus.HistogramVec
 	ProcessDuration                     *prometheus.HistogramVec
 	SendDuration                        *prometheus.HistogramVec
+	SimpleNotificationRules             *prometheus.GaugeVec
 	GroupRules                          *prometheus.GaugeVec
 	Groups                              *prometheus.GaugeVec
 	SchedulePeriodicDuration            prometheus.Histogram
@@ -88,6 +89,15 @@ func NewSchedulerMetrics(r prometheus.Registerer) *Scheduler {
 				Name:      "rule_send_alerts_duration_seconds",
 				Help:      "The time to send the alerts to Alertmanager.",
 				Buckets:   []float64{.01, .1, .5, 1, 5, 10, 15, 30, 60, 120, 180, 240, 300},
+			},
+			[]string{"org"},
+		),
+		SimpleNotificationRules: promauto.With(r).NewGaugeVec(
+			prometheus.GaugeOpts{
+				Namespace: Namespace,
+				Subsystem: Subsystem,
+				Name:      "simple_notification_rules",
+				Help:      "The number of simple notification rules.",
 			},
 			[]string{"org"},
 		),

--- a/pkg/services/ngalert/metrics/scheduler.go
+++ b/pkg/services/ngalert/metrics/scheduler.go
@@ -96,7 +96,7 @@ func NewSchedulerMetrics(r prometheus.Registerer) *Scheduler {
 			prometheus.GaugeOpts{
 				Namespace: Namespace,
 				Subsystem: Subsystem,
-				Name:      "simple_notification_rules",
+				Name:      "simple_routing_rules",
 				Help:      "The number of alert rules using simplified routing.",
 			},
 			[]string{"org"},


### PR DESCRIPTION
**What is this feature?**

Adds basic gauge metric for simple notification rules introduced in #81011

**Why do we need this feature?**

This allows for measuring usage of the new feature.

**Who is this feature for?**

Admins, anyone tracking Grafana's internal metrics


**Special notes for your reviewer:**

The check isn't behind the toggle for the feature so will always report a value, even if the settings aren't being used. I'm 50:50 on guarding it or not, open to feedback there.

Please check that:
- [x] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle.
- [x] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
