### PR TITLE
Page: Use browser native scrollbars for the main page content

### DIFF
--- a/.betterer.results
+++ b/.betterer.results
@@ -5835,12 +5835,6 @@ exports[`better eslint`] = {
       [0, 0, 0, "Styles should be written using objects.", "3"],
       [0, 0, 0, "Styles should be written using objects.", "4"]
     ],
-    "public/app/plugins/panel/gettingstarted/components/Step.tsx:5381": [
-      [0, 0, 0, "Styles should be written using objects.", "0"],
-      [0, 0, 0, "Styles should be written using objects.", "1"],
-      [0, 0, 0, "Styles should be written using objects.", "2"],
-      [0, 0, 0, "Styles should be written using objects.", "3"]
-    ],
     "public/app/plugins/panel/gettingstarted/components/TutorialCard.tsx:5381": [
       [0, 0, 0, "Styles should be written using objects.", "0"],
       [0, 0, 0, "Styles should be written using objects.", "1"],

--- a/docs/sources/setup-grafana/configure-grafana/feature-toggles/index.md
+++ b/docs/sources/setup-grafana/configure-grafana/feature-toggles/index.md
@@ -56,6 +56,7 @@ Some features are enabled by default. You can disable these feature by setting t
 | `lokiQueryHints`                     | Enables query hints for Loki                                                                                                                                                                                                 | Yes                |
 | `alertingPreviewUpgrade`             | Show Unified Alerting preview and upgrade page in legacy alerting                                                                                                                                                            | Yes                |
 | `alertingQueryOptimization`          | Optimizes eligible queries in order to reduce load on datasources                                                                                                                                                            |                    |
+| `betterPageScrolling`                | Removes CustomScrollbar from the UI, relying on native browser scrollbars                                                                                                                                                    | Yes                |
 | `alertingUpgradeDryrunOnStart`       | When activated in legacy alerting mode, this initiates a dry-run of the Unified Alerting upgrade during each startup. It logs any issues detected without implementing any actual changes.                                   | Yes                |
 
 ## Preview feature toggles
@@ -177,7 +178,6 @@ Experimental features might be changed or removed without prior notice.
 | `newPDFRendering`                           | New implementation for the dashboard to PDF rendering                                                                                                                                                                                                                             |
 | `kubernetesAggregator`                      | Enable grafana aggregator                                                                                                                                                                                                                                                         |
 | `expressionParser`                          | Enable new expression parser                                                                                                                                                                                                                                                      |
-| `removeCustomScrollbars`                    | Removes CustomScrollbar from the UI, relying on native browser scrollbars                                                                                                                                                                                                         |
 
 ## Development feature toggles
 

--- a/docs/sources/setup-grafana/configure-grafana/feature-toggles/index.md
+++ b/docs/sources/setup-grafana/configure-grafana/feature-toggles/index.md
@@ -177,6 +177,7 @@ Experimental features might be changed or removed without prior notice.
 | `newPDFRendering`                           | New implementation for the dashboard to PDF rendering                                                                                                                                                                                                                             |
 | `kubernetesAggregator`                      | Enable grafana aggregator                                                                                                                                                                                                                                                         |
 | `expressionParser`                          | Enable new expression parser                                                                                                                                                                                                                                                      |
+| `removeCustomScrollbars`                    | Removes CustomScrollbar from the UI, relying on native browser scrollbars                                                                                                                                                                                                         |
 
 ## Development feature toggles
 

--- a/packages/grafana-data/src/types/featureToggles.gen.ts
+++ b/packages/grafana-data/src/types/featureToggles.gen.ts
@@ -177,5 +177,6 @@ export interface FeatureToggles {
   kubernetesAggregator?: boolean;
   expressionParser?: boolean;
   groupByVariable?: boolean;
+  removeCustomScrollbars?: boolean;
   alertingUpgradeDryrunOnStart?: boolean;
 }

--- a/packages/grafana-data/src/types/featureToggles.gen.ts
+++ b/packages/grafana-data/src/types/featureToggles.gen.ts
@@ -177,6 +177,6 @@ export interface FeatureToggles {
   kubernetesAggregator?: boolean;
   expressionParser?: boolean;
   groupByVariable?: boolean;
-  removeCustomScrollbars?: boolean;
+  betterPageScrolling?: boolean;
   alertingUpgradeDryrunOnStart?: boolean;
 }

--- a/pkg/services/featuremgmt/registry.go
+++ b/pkg/services/featuremgmt/registry.go
@@ -1187,6 +1187,7 @@ var (
 			Stage:        FeatureStageExperimental,
 			FrontendOnly: true,
 			Owner:        grafanaFrontendPlatformSquad,
+			Expression:   "true", // enabled by default
 		},
 		{
 			Name:            "alertingUpgradeDryrunOnStart",

--- a/pkg/services/featuremgmt/registry.go
+++ b/pkg/services/featuremgmt/registry.go
@@ -1182,6 +1182,13 @@ var (
 			HideFromAdminPage: true,
 		},
 		{
+			Name:         "removeCustomScrollbars",
+			Description:  "Removes CustomScrollbar from the UI, relying on native browser scrollbars",
+			Stage:        FeatureStageExperimental,
+			FrontendOnly: true,
+			Owner:        grafanaFrontendPlatformSquad,
+		},
+		{
 			Name:            "alertingUpgradeDryrunOnStart",
 			Description:     "When activated in legacy alerting mode, this initiates a dry-run of the Unified Alerting upgrade during each startup. It logs any issues detected without implementing any actual changes.",
 			FrontendOnly:    false,

--- a/pkg/services/featuremgmt/registry.go
+++ b/pkg/services/featuremgmt/registry.go
@@ -1182,9 +1182,9 @@ var (
 			HideFromAdminPage: true,
 		},
 		{
-			Name:         "removeCustomScrollbars",
+			Name:         "betterPageScrolling",
 			Description:  "Removes CustomScrollbar from the UI, relying on native browser scrollbars",
-			Stage:        FeatureStageExperimental,
+			Stage:        FeatureStageGeneralAvailability,
 			FrontendOnly: true,
 			Owner:        grafanaFrontendPlatformSquad,
 			Expression:   "true", // enabled by default

--- a/pkg/services/featuremgmt/toggles_gen.csv
+++ b/pkg/services/featuremgmt/toggles_gen.csv
@@ -158,5 +158,5 @@ newPDFRendering,experimental,@grafana/sharing-squad,false,false,false
 kubernetesAggregator,experimental,@grafana/grafana-app-platform-squad,false,true,false
 expressionParser,experimental,@grafana/grafana-app-platform-squad,false,true,false
 groupByVariable,experimental,@grafana/dashboards-squad,false,false,false
-removeCustomScrollbars,experimental,@grafana/grafana-frontend-platform,false,false,true
+betterPageScrolling,GA,@grafana/grafana-frontend-platform,false,false,true
 alertingUpgradeDryrunOnStart,GA,@grafana/alerting-squad,false,true,false

--- a/pkg/services/featuremgmt/toggles_gen.csv
+++ b/pkg/services/featuremgmt/toggles_gen.csv
@@ -158,4 +158,5 @@ newPDFRendering,experimental,@grafana/sharing-squad,false,false,false
 kubernetesAggregator,experimental,@grafana/grafana-app-platform-squad,false,true,false
 expressionParser,experimental,@grafana/grafana-app-platform-squad,false,true,false
 groupByVariable,experimental,@grafana/dashboards-squad,false,false,false
+removeCustomScrollbars,experimental,@grafana/grafana-frontend-platform,false,false,true
 alertingUpgradeDryrunOnStart,GA,@grafana/alerting-squad,false,true,false

--- a/pkg/services/featuremgmt/toggles_gen.go
+++ b/pkg/services/featuremgmt/toggles_gen.go
@@ -643,6 +643,10 @@ const (
 	// Enable groupBy variable support in scenes dashboards
 	FlagGroupByVariable = "groupByVariable"
 
+	// FlagRemoveCustomScrollbars
+	// Removes CustomScrollbar from the UI, relying on native browser scrollbars
+	FlagRemoveCustomScrollbars = "removeCustomScrollbars"
+
 	// FlagAlertingUpgradeDryrunOnStart
 	// When activated in legacy alerting mode, this initiates a dry-run of the Unified Alerting upgrade during each startup. It logs any issues detected without implementing any actual changes.
 	FlagAlertingUpgradeDryrunOnStart = "alertingUpgradeDryrunOnStart"

--- a/pkg/services/featuremgmt/toggles_gen.go
+++ b/pkg/services/featuremgmt/toggles_gen.go
@@ -643,9 +643,9 @@ const (
 	// Enable groupBy variable support in scenes dashboards
 	FlagGroupByVariable = "groupByVariable"
 
-	// FlagRemoveCustomScrollbars
+	// FlagBetterPageScrolling
 	// Removes CustomScrollbar from the UI, relying on native browser scrollbars
-	FlagRemoveCustomScrollbars = "removeCustomScrollbars"
+	FlagBetterPageScrolling = "betterPageScrolling"
 
 	// FlagAlertingUpgradeDryrunOnStart
 	// When activated in legacy alerting mode, this initiates a dry-run of the Unified Alerting upgrade during each startup. It logs any issues detected without implementing any actual changes.

--- a/pkg/services/featuremgmt/toggles_gen.json
+++ b/pkg/services/featuremgmt/toggles_gen.json
@@ -5,281 +5,9 @@
   "items": [
     {
       "metadata": {
-        "name": "recoveryThreshold",
-        "resourceVersion": "1708108588074",
-        "creationTimestamp": "2024-02-16T18:36:28Z"
-      },
-      "spec": {
-        "description": "Enables feature recovery threshold (aka hysteresis) for threshold server-side expression",
-        "stage": "GA",
-        "codeowner": "@grafana/alerting-squad",
-        "requiresRestart": true
-      }
-    },
-    {
-      "metadata": {
-        "name": "teamHttpHeaders",
-        "resourceVersion": "1709290509653",
-        "creationTimestamp": "2024-02-16T18:36:28Z",
-        "annotations": {
-          "grafana.app/updatedTimestamp": "2024-03-01 10:55:09.653587 +0000 UTC"
-        }
-      },
-      "spec": {
-        "description": "Enables Team LBAC for datasources to apply team headers to the client requests",
-        "stage": "preview",
-        "codeowner": "@grafana/identity-access-team"
-      }
-    },
-    {
-      "metadata": {
-        "name": "logsExploreTableVisualisation",
-        "resourceVersion": "1708108588074",
-        "creationTimestamp": "2024-02-16T18:36:28Z"
-      },
-      "spec": {
-        "description": "A table visualisation for logs in Explore",
-        "stage": "GA",
-        "codeowner": "@grafana/observability-logs",
-        "frontend": true
-      }
-    },
-    {
-      "metadata": {
-        "name": "disableSecretsCompatibility",
-        "resourceVersion": "1708108588074",
-        "creationTimestamp": "2024-02-16T18:36:28Z"
-      },
-      "spec": {
-        "description": "Disable duplicated secret storage in legacy tables",
-        "stage": "experimental",
-        "codeowner": "@grafana/hosted-grafana-team",
-        "requiresRestart": true
-      }
-    },
-    {
-      "metadata": {
-        "name": "alertingBacktesting",
-        "resourceVersion": "1708108588074",
-        "creationTimestamp": "2024-02-16T18:36:28Z"
-      },
-      "spec": {
-        "description": "Rule backtesting API for alerting",
-        "stage": "experimental",
-        "codeowner": "@grafana/alerting-squad"
-      }
-    },
-    {
-      "metadata": {
-        "name": "alertStateHistoryLokiPrimary",
-        "resourceVersion": "1708108588074",
-        "creationTimestamp": "2024-02-16T18:36:28Z"
-      },
-      "spec": {
-        "description": "Enable a remote Loki instance as the primary source for state history reads.",
-        "stage": "experimental",
-        "codeowner": "@grafana/alerting-squad"
-      }
-    },
-    {
-      "metadata": {
-        "name": "pluginsInstrumentationStatusSource",
-        "resourceVersion": "1708108588074",
-        "creationTimestamp": "2024-02-16T18:36:28Z",
-        "deletionTimestamp": "2024-02-29T08:27:47Z"
-      },
-      "spec": {
-        "description": "Include a status source label for plugin request metrics and logs",
-        "stage": "experimental",
-        "codeowner": "@grafana/plugins-platform-backend"
-      }
-    },
-    {
-      "metadata": {
-        "name": "enablePluginsTracingByDefault",
-        "resourceVersion": "1708108588074",
-        "creationTimestamp": "2024-02-16T18:36:28Z"
-      },
-      "spec": {
-        "description": "Enable plugin tracing for all external plugins",
-        "stage": "experimental",
-        "codeowner": "@grafana/plugins-platform-backend",
-        "requiresRestart": true
-      }
-    },
-    {
-      "metadata": {
-        "name": "newFolderPicker",
-        "resourceVersion": "1708108588074",
-        "creationTimestamp": "2024-02-16T18:36:28Z"
-      },
-      "spec": {
-        "description": "Enables the nested folder picker without having nested folders enabled",
-        "stage": "experimental",
-        "codeowner": "@grafana/grafana-frontend-platform",
-        "frontend": true
-      }
-    },
-    {
-      "metadata": {
-        "name": "correlations",
-        "resourceVersion": "1708108588074",
-        "creationTimestamp": "2024-02-16T18:36:28Z"
-      },
-      "spec": {
-        "description": "Correlations page",
-        "stage": "GA",
-        "codeowner": "@grafana/explore-squad",
-        "allowSelfServe": true
-      }
-    },
-    {
-      "metadata": {
-        "name": "datasourceQueryMultiStatus",
-        "resourceVersion": "1708108588074",
-        "creationTimestamp": "2024-02-16T18:36:28Z"
-      },
-      "spec": {
-        "description": "Introduce HTTP 207 Multi Status for api/ds/query",
-        "stage": "experimental",
-        "codeowner": "@grafana/plugins-platform-backend"
-      }
-    },
-    {
-      "metadata": {
-        "name": "sqlDatasourceDatabaseSelection",
-        "resourceVersion": "1708108588074",
-        "creationTimestamp": "2024-02-16T18:36:28Z"
-      },
-      "spec": {
-        "description": "Enables previous SQL data source dataset dropdown behavior",
-        "stage": "preview",
-        "codeowner": "@grafana/dataviz-squad",
-        "frontend": true,
-        "hideFromAdminPage": true
-      }
-    },
-    {
-      "metadata": {
-        "name": "cloudWatchWildCardDimensionValues",
-        "resourceVersion": "1708108588074",
-        "creationTimestamp": "2024-02-16T18:36:28Z"
-      },
-      "spec": {
-        "description": "Fetches dimension values from CloudWatch to correctly label wildcard dimensions",
-        "stage": "GA",
-        "codeowner": "@grafana/aws-datasources",
-        "allowSelfServe": true
-      }
-    },
-    {
-      "metadata": {
-        "name": "addFieldFromCalculationStatFunctions",
-        "resourceVersion": "1708108588074",
-        "creationTimestamp": "2024-02-16T18:36:28Z"
-      },
-      "spec": {
-        "description": "Add cumulative and window functions to the add field from calculation transformation",
-        "stage": "preview",
-        "codeowner": "@grafana/dataviz-squad",
-        "frontend": true
-      }
-    },
-    {
-      "metadata": {
-        "name": "canvasPanelPanZoom",
-        "resourceVersion": "1708108588074",
-        "creationTimestamp": "2024-02-16T18:36:28Z"
-      },
-      "spec": {
-        "description": "Allow pan and zoom in canvas panel",
-        "stage": "preview",
-        "codeowner": "@grafana/dataviz-squad",
-        "frontend": true
-      }
-    },
-    {
-      "metadata": {
-        "name": "cloudRBACRoles",
-        "resourceVersion": "1708108588074",
-        "creationTimestamp": "2024-02-16T18:36:28Z"
-      },
-      "spec": {
-        "description": "Enabled grafana cloud specific RBAC roles",
-        "stage": "experimental",
-        "codeowner": "@grafana/identity-access-team",
-        "requiresRestart": true,
-        "hideFromDocs": true
-      }
-    },
-    {
-      "metadata": {
-        "name": "panelTitleSearch",
-        "resourceVersion": "1708108588074",
-        "creationTimestamp": "2024-02-16T18:36:28Z"
-      },
-      "spec": {
-        "description": "Search for dashboards using panel title",
-        "stage": "preview",
-        "codeowner": "@grafana/grafana-app-platform-squad",
-        "hideFromAdminPage": true
-      }
-    },
-    {
-      "metadata": {
-        "name": "mysqlAnsiQuotes",
-        "resourceVersion": "1708108588074",
-        "creationTimestamp": "2024-02-16T18:36:28Z"
-      },
-      "spec": {
-        "description": "Use double quotes to escape keyword in a MySQL query",
-        "stage": "experimental",
-        "codeowner": "@grafana/backend-platform"
-      }
-    },
-    {
-      "metadata": {
-        "name": "alertStateHistoryLokiSecondary",
-        "resourceVersion": "1708108588074",
-        "creationTimestamp": "2024-02-16T18:36:28Z"
-      },
-      "spec": {
-        "description": "Enable Grafana to write alert state history to an external Loki instance in addition to Grafana annotations.",
-        "stage": "experimental",
-        "codeowner": "@grafana/alerting-squad"
-      }
-    },
-    {
-      "metadata": {
-        "name": "grafanaAPIServerWithExperimentalAPIs",
-        "resourceVersion": "1708108588074",
-        "creationTimestamp": "2024-02-16T18:36:28Z"
-      },
-      "spec": {
-        "description": "Register experimental APIs with the k8s API server",
-        "stage": "experimental",
-        "codeowner": "@grafana/grafana-app-platform-squad",
-        "requiresDevMode": true,
-        "requiresRestart": true
-      }
-    },
-    {
-      "metadata": {
-        "name": "alertingSimplifiedRouting",
-        "resourceVersion": "1708108588074",
-        "creationTimestamp": "2024-02-16T18:36:28Z"
-      },
-      "spec": {
-        "description": "Enables users to easily configure alert notifications by specifying a contact point directly when editing or creating an alert rule",
-        "stage": "preview",
-        "codeowner": "@grafana/alerting-squad"
-      }
-    },
-    {
-      "metadata": {
         "name": "autoMigratePiechartPanel",
-        "resourceVersion": "1708108588074",
-        "creationTimestamp": "2024-02-16T18:36:28Z"
+        "resourceVersion": "1709568338306",
+        "creationTimestamp": "2024-03-04T16:05:38Z"
       },
       "spec": {
         "description": "Migrate old piechart panel to supported piechart panel - broken out from autoMigrateOldPanels to enable granular tracking",
@@ -290,22 +18,137 @@
     },
     {
       "metadata": {
-        "name": "autoMigrateWorldmapPanel",
-        "resourceVersion": "1708108588074",
-        "creationTimestamp": "2024-02-16T18:36:28Z"
+        "name": "grpcServer",
+        "resourceVersion": "1709568338306",
+        "creationTimestamp": "2024-03-04T16:05:38Z"
       },
       "spec": {
-        "description": "Migrate old worldmap panel to supported geomap panel - broken out from autoMigrateOldPanels to enable granular tracking",
+        "description": "Run the GRPC server",
         "stage": "preview",
+        "codeowner": "@grafana/grafana-app-platform-squad",
+        "hideFromAdminPage": true
+      }
+    },
+    {
+      "metadata": {
+        "name": "prometheusDataplane",
+        "resourceVersion": "1709568338306",
+        "creationTimestamp": "2024-03-04T16:05:38Z"
+      },
+      "spec": {
+        "description": "Changes responses to from Prometheus to be compliant with the dataplane specification. In particular, when this feature toggle is active, the numeric `Field.Name` is set from 'Value' to the value of the `__name__` label.",
+        "stage": "GA",
+        "codeowner": "@grafana/observability-metrics",
+        "allowSelfServe": true
+      }
+    },
+    {
+      "metadata": {
+        "name": "alertStateHistoryLokiSecondary",
+        "resourceVersion": "1709568338306",
+        "creationTimestamp": "2024-03-04T16:05:38Z"
+      },
+      "spec": {
+        "description": "Enable Grafana to write alert state history to an external Loki instance in addition to Grafana annotations.",
+        "stage": "experimental",
+        "codeowner": "@grafana/alerting-squad"
+      }
+    },
+    {
+      "metadata": {
+        "name": "frontendSandboxMonitorOnly",
+        "resourceVersion": "1709568338306",
+        "creationTimestamp": "2024-03-04T16:05:38Z"
+      },
+      "spec": {
+        "description": "Enables monitor only in the plugin frontend sandbox (if enabled)",
+        "stage": "experimental",
+        "codeowner": "@grafana/plugins-platform-backend",
+        "frontend": true
+      }
+    },
+    {
+      "metadata": {
+        "name": "dashgpt",
+        "resourceVersion": "1709568338306",
+        "creationTimestamp": "2024-03-04T16:05:38Z"
+      },
+      "spec": {
+        "description": "Enable AI powered features in dashboards",
+        "stage": "preview",
+        "codeowner": "@grafana/dashboards-squad",
+        "frontend": true
+      }
+    },
+    {
+      "metadata": {
+        "name": "live-service-web-worker",
+        "resourceVersion": "1709568338306",
+        "creationTimestamp": "2024-03-04T16:05:38Z"
+      },
+      "spec": {
+        "description": "This will use a webworker thread to processes events rather than the main thread",
+        "stage": "experimental",
+        "codeowner": "@grafana/grafana-app-platform-squad",
+        "frontend": true
+      }
+    },
+    {
+      "metadata": {
+        "name": "featureHighlights",
+        "resourceVersion": "1709568338306",
+        "creationTimestamp": "2024-03-04T16:05:38Z"
+      },
+      "spec": {
+        "description": "Highlight Grafana Enterprise features",
+        "stage": "GA",
+        "codeowner": "@grafana/grafana-as-code",
+        "allowSelfServe": true
+      }
+    },
+    {
+      "metadata": {
+        "name": "onPremToCloudMigrations",
+        "resourceVersion": "1709568338306",
+        "creationTimestamp": "2024-03-04T16:05:38Z"
+      },
+      "spec": {
+        "description": "In-development feature that will allow users to easily migrate their on-prem Grafana instances to Grafana Cloud.",
+        "stage": "experimental",
+        "codeowner": "@grafana/grafana-operator-experience-squad"
+      }
+    },
+    {
+      "metadata": {
+        "name": "extractFieldsNameDeduplication",
+        "resourceVersion": "1709568338306",
+        "creationTimestamp": "2024-03-04T16:05:38Z"
+      },
+      "spec": {
+        "description": "Make sure extracted field names are unique in the dataframe",
+        "stage": "experimental",
         "codeowner": "@grafana/dataviz-squad",
         "frontend": true
       }
     },
     {
       "metadata": {
+        "name": "ssoSettingsApi",
+        "resourceVersion": "1709568338306",
+        "creationTimestamp": "2024-03-04T16:05:38Z"
+      },
+      "spec": {
+        "description": "Enables the SSO settings API and the OAuth configuration UIs in Grafana",
+        "stage": "preview",
+        "codeowner": "@grafana/identity-access-team",
+        "allowSelfServe": true
+      }
+    },
+    {
+      "metadata": {
         "name": "prometheusIncrementalQueryInstrumentation",
-        "resourceVersion": "1708108588074",
-        "creationTimestamp": "2024-02-16T18:36:28Z"
+        "resourceVersion": "1709568338306",
+        "creationTimestamp": "2024-03-04T16:05:38Z"
       },
       "spec": {
         "description": "Adds RudderStack events to incremental queries",
@@ -316,21 +159,9 @@
     },
     {
       "metadata": {
-        "name": "prometheusConfigOverhaulAuth",
-        "resourceVersion": "1708108588074",
-        "creationTimestamp": "2024-02-16T18:36:28Z"
-      },
-      "spec": {
-        "description": "Update the Prometheus configuration page with the new auth component",
-        "stage": "GA",
-        "codeowner": "@grafana/observability-metrics"
-      }
-    },
-    {
-      "metadata": {
         "name": "prometheusPromQAIL",
-        "resourceVersion": "1708108588074",
-        "creationTimestamp": "2024-02-16T18:36:28Z"
+        "resourceVersion": "1709568338306",
+        "creationTimestamp": "2024-03-04T16:05:38Z"
       },
       "spec": {
         "description": "Prometheus and AI/ML to assist users in creating a query",
@@ -341,35 +172,85 @@
     },
     {
       "metadata": {
-        "name": "panelFilterVariable",
-        "resourceVersion": "1708108588074",
-        "creationTimestamp": "2024-02-16T18:36:28Z"
+        "name": "storage",
+        "resourceVersion": "1709568338306",
+        "creationTimestamp": "2024-03-04T16:05:38Z"
       },
       "spec": {
-        "description": "Enables use of the `systemPanelFilterVar` variable to filter panels in a dashboard",
+        "description": "Configurable storage for dashboards, datasources, and resources",
         "stage": "experimental",
-        "codeowner": "@grafana/dashboards-squad",
-        "frontend": true,
-        "hideFromDocs": true
+        "codeowner": "@grafana/grafana-app-platform-squad"
       }
     },
     {
       "metadata": {
-        "name": "pluginsSkipHostEnvVars",
-        "resourceVersion": "1708108588074",
-        "creationTimestamp": "2024-02-16T18:36:28Z"
+        "name": "refactorVariablesTimeRange",
+        "resourceVersion": "1709568338306",
+        "creationTimestamp": "2024-03-04T16:05:38Z"
       },
       "spec": {
-        "description": "Disables passing host environment variable to plugin processes",
+        "description": "Refactor time range variables flow to reduce number of API calls made when query variables are chained",
+        "stage": "preview",
+        "codeowner": "@grafana/dashboards-squad",
+        "hideFromAdminPage": true
+      }
+    },
+    {
+      "metadata": {
+        "name": "libraryPanelRBAC",
+        "resourceVersion": "1709568338306",
+        "creationTimestamp": "2024-03-04T16:05:38Z"
+      },
+      "spec": {
+        "description": "Enables RBAC support for library panels",
         "stage": "experimental",
-        "codeowner": "@grafana/plugins-platform-backend"
+        "codeowner": "@grafana/dashboards-squad",
+        "requiresRestart": true
+      }
+    },
+    {
+      "metadata": {
+        "name": "newVizTooltips",
+        "resourceVersion": "1709568338306",
+        "creationTimestamp": "2024-03-04T16:05:38Z"
+      },
+      "spec": {
+        "description": "New visualizations tooltips UX",
+        "stage": "preview",
+        "codeowner": "@grafana/dataviz-squad",
+        "frontend": true
+      }
+    },
+    {
+      "metadata": {
+        "name": "sseGroupByDatasource",
+        "resourceVersion": "1709568338306",
+        "creationTimestamp": "2024-03-04T16:05:38Z"
+      },
+      "spec": {
+        "description": "Send query to the same datasource in a single request when using server side expressions. The `cloudWatchBatchQueries` feature toggle should be enabled if this used with CloudWatch.",
+        "stage": "experimental",
+        "codeowner": "@grafana/observability-metrics"
+      }
+    },
+    {
+      "metadata": {
+        "name": "groupToNestedTableTransformation",
+        "resourceVersion": "1709568338306",
+        "creationTimestamp": "2024-03-04T16:05:38Z"
+      },
+      "spec": {
+        "description": "Enables the group to nested table transformation",
+        "stage": "preview",
+        "codeowner": "@grafana/dataviz-squad",
+        "frontend": true
       }
     },
     {
       "metadata": {
         "name": "publicDashboardsEmailSharing",
-        "resourceVersion": "1708108588074",
-        "creationTimestamp": "2024-02-16T18:36:28Z"
+        "resourceVersion": "1709568338306",
+        "creationTimestamp": "2024-03-04T16:05:38Z"
       },
       "spec": {
         "description": "Enables public dashboard sharing to be restricted to only allowed emails",
@@ -381,22 +262,21 @@
     },
     {
       "metadata": {
-        "name": "metricsSummary",
-        "resourceVersion": "1708108588074",
-        "creationTimestamp": "2024-02-16T18:36:28Z"
+        "name": "enableNativeHTTPHistogram",
+        "resourceVersion": "1709568338306",
+        "creationTimestamp": "2024-03-04T16:05:38Z"
       },
       "spec": {
-        "description": "Enables metrics summary queries in the Tempo data source",
+        "description": "Enables native HTTP Histograms",
         "stage": "experimental",
-        "codeowner": "@grafana/observability-traces-and-profiling",
-        "frontend": true
+        "codeowner": "@grafana/hosted-grafana-team"
       }
     },
     {
       "metadata": {
         "name": "tableSharedCrosshair",
-        "resourceVersion": "1708108588074",
-        "creationTimestamp": "2024-02-16T18:36:28Z"
+        "resourceVersion": "1709568338306",
+        "creationTimestamp": "2024-03-04T16:05:38Z"
       },
       "spec": {
         "description": "Enables shared crosshair in table panel",
@@ -407,759 +287,21 @@
     },
     {
       "metadata": {
-        "name": "regressionTransformation",
-        "resourceVersion": "1708108588074",
-        "creationTimestamp": "2024-02-16T18:36:28Z"
+        "name": "disableSSEDataplane",
+        "resourceVersion": "1709568338306",
+        "creationTimestamp": "2024-03-04T16:05:38Z"
       },
       "spec": {
-        "description": "Enables regression analysis transformation",
-        "stage": "preview",
-        "codeowner": "@grafana/dataviz-squad",
-        "frontend": true
-      }
-    },
-    {
-      "metadata": {
-        "name": "queryOverLive",
-        "resourceVersion": "1708108588074",
-        "creationTimestamp": "2024-02-16T18:36:28Z"
-      },
-      "spec": {
-        "description": "Use Grafana Live WebSocket to execute backend queries",
+        "description": "Disables dataplane specific processing in server side expressions.",
         "stage": "experimental",
-        "codeowner": "@grafana/grafana-app-platform-squad",
-        "frontend": true
-      }
-    },
-    {
-      "metadata": {
-        "name": "prometheusDataplane",
-        "resourceVersion": "1708108588074",
-        "creationTimestamp": "2024-02-16T18:36:28Z"
-      },
-      "spec": {
-        "description": "Changes responses to from Prometheus to be compliant with the dataplane specification. In particular, when this feature toggle is active, the numeric `Field.Name` is set from 'Value' to the value of the `__name__` label.",
-        "stage": "GA",
-        "codeowner": "@grafana/observability-metrics",
-        "allowSelfServe": true
-      }
-    },
-    {
-      "metadata": {
-        "name": "unifiedRequestLog",
-        "resourceVersion": "1708108588074",
-        "creationTimestamp": "2024-02-16T18:36:28Z"
-      },
-      "spec": {
-        "description": "Writes error logs to the request logger",
-        "stage": "experimental",
-        "codeowner": "@grafana/backend-platform"
-      }
-    },
-    {
-      "metadata": {
-        "name": "wargamesTesting",
-        "resourceVersion": "1708108588074",
-        "creationTimestamp": "2024-02-16T18:36:28Z"
-      },
-      "spec": {
-        "description": "Placeholder feature flag for internal testing",
-        "stage": "experimental",
-        "codeowner": "@grafana/hosted-grafana-team"
-      }
-    },
-    {
-      "metadata": {
-        "name": "alertmanagerRemotePrimary",
-        "resourceVersion": "1708108588074",
-        "creationTimestamp": "2024-02-16T18:36:28Z"
-      },
-      "spec": {
-        "description": "Enable Grafana to have a remote Alertmanager instance as the primary Alertmanager.",
-        "stage": "experimental",
-        "codeowner": "@grafana/alerting-squad"
-      }
-    },
-    {
-      "metadata": {
-        "name": "ssoSettingsApi",
-        "resourceVersion": "1708503560010",
-        "creationTimestamp": "2024-02-16T18:36:28Z",
-        "annotations": {
-          "grafana.app/updatedTimestamp": "2024-02-21 08:19:20.010283 +0000 UTC"
-        }
-      },
-      "spec": {
-        "description": "Enables the SSO settings API and the OAuth configuration UIs in Grafana",
-        "stage": "preview",
-        "codeowner": "@grafana/identity-access-team",
-        "allowSelfServe": true
-      }
-    },
-    {
-      "metadata": {
-        "name": "logsInfiniteScrolling",
-        "resourceVersion": "1708108588074",
-        "creationTimestamp": "2024-02-16T18:36:28Z"
-      },
-      "spec": {
-        "description": "Enables infinite scrolling for the Logs panel in Explore and Dashboards",
-        "stage": "experimental",
-        "codeowner": "@grafana/observability-logs",
-        "frontend": true
-      }
-    },
-    {
-      "metadata": {
-        "name": "displayAnonymousStats",
-        "resourceVersion": "1708108588074",
-        "creationTimestamp": "2024-02-16T18:36:28Z",
-        "deletionTimestamp": "2024-02-29T08:27:47Z"
-      },
-      "spec": {
-        "description": "Enables anonymous stats to be shown in the UI for Grafana",
-        "stage": "GA",
-        "codeowner": "@grafana/identity-access-team",
-        "frontend": true
-      }
-    },
-    {
-      "metadata": {
-        "name": "storage",
-        "resourceVersion": "1708108588074",
-        "creationTimestamp": "2024-02-16T18:36:28Z"
-      },
-      "spec": {
-        "description": "Configurable storage for dashboards, datasources, and resources",
-        "stage": "experimental",
-        "codeowner": "@grafana/grafana-app-platform-squad"
-      }
-    },
-    {
-      "metadata": {
-        "name": "newPDFRendering",
-        "resourceVersion": "1708108588074",
-        "creationTimestamp": "2024-02-16T18:36:28Z"
-      },
-      "spec": {
-        "description": "New implementation for the dashboard to PDF rendering",
-        "stage": "experimental",
-        "codeowner": "@grafana/sharing-squad"
-      }
-    },
-    {
-      "metadata": {
-        "name": "pluginsFrontendSandbox",
-        "resourceVersion": "1708108588074",
-        "creationTimestamp": "2024-02-16T18:36:28Z"
-      },
-      "spec": {
-        "description": "Enables the plugins frontend sandbox",
-        "stage": "experimental",
-        "codeowner": "@grafana/plugins-platform-backend",
-        "frontend": true
-      }
-    },
-    {
-      "metadata": {
-        "name": "logRequestsInstrumentedAsUnknown",
-        "resourceVersion": "1708108588074",
-        "creationTimestamp": "2024-02-16T18:36:28Z"
-      },
-      "spec": {
-        "description": "Logs the path for requests that are instrumented as unknown",
-        "stage": "experimental",
-        "codeowner": "@grafana/hosted-grafana-team"
-      }
-    },
-    {
-      "metadata": {
-        "name": "lokiStructuredMetadata",
-        "resourceVersion": "1708108588074",
-        "creationTimestamp": "2024-02-16T18:36:28Z"
-      },
-      "spec": {
-        "description": "Enables the loki data source to request structured metadata from the Loki server",
-        "stage": "GA",
-        "codeowner": "@grafana/observability-logs"
-      }
-    },
-    {
-      "metadata": {
-        "name": "managedPluginsInstall",
-        "resourceVersion": "1708108588074",
-        "creationTimestamp": "2024-02-16T18:36:28Z"
-      },
-      "spec": {
-        "description": "Install managed plugins directly from plugins catalog",
-        "stage": "preview",
-        "codeowner": "@grafana/plugins-platform-backend"
-      }
-    },
-    {
-      "metadata": {
-        "name": "dashboardSceneForViewers",
-        "resourceVersion": "1708108588074",
-        "creationTimestamp": "2024-02-16T18:36:28Z"
-      },
-      "spec": {
-        "description": "Enables dashboard rendering using Scenes for viewer roles",
-        "stage": "experimental",
-        "codeowner": "@grafana/dashboards-squad",
-        "frontend": true
-      }
-    },
-    {
-      "metadata": {
-        "name": "alertingDetailsViewV2",
-        "resourceVersion": "1708108588074",
-        "creationTimestamp": "2024-02-16T18:36:28Z"
-      },
-      "spec": {
-        "description": "Enables the preview of the new alert details view",
-        "stage": "experimental",
-        "codeowner": "@grafana/alerting-squad",
-        "frontend": true,
-        "hideFromDocs": true
-      }
-    },
-    {
-      "metadata": {
-        "name": "jitterAlertRulesWithinGroups",
-        "resourceVersion": "1708108588074",
-        "creationTimestamp": "2024-02-16T18:36:28Z"
-      },
-      "spec": {
-        "description": "Distributes alert rule evaluations more evenly over time, including spreading out rules within the same group",
-        "stage": "preview",
-        "codeowner": "@grafana/alerting-squad",
-        "requiresRestart": true,
-        "hideFromDocs": true
-      }
-    },
-    {
-      "metadata": {
-        "name": "unifiedStorage",
-        "resourceVersion": "1708108588074",
-        "creationTimestamp": "2024-02-16T18:36:28Z"
-      },
-      "spec": {
-        "description": "SQL-based k8s storage",
-        "stage": "experimental",
-        "codeowner": "@grafana/grafana-app-platform-squad",
-        "requiresDevMode": true,
-        "requiresRestart": true
-      }
-    },
-    {
-      "metadata": {
-        "name": "enableElasticsearchBackendQuerying",
-        "resourceVersion": "1708108588074",
-        "creationTimestamp": "2024-02-16T18:36:28Z"
-      },
-      "spec": {
-        "description": "Enable the processing of queries and responses in the Elasticsearch data source through backend",
-        "stage": "GA",
-        "codeowner": "@grafana/observability-logs",
-        "allowSelfServe": true
-      }
-    },
-    {
-      "metadata": {
-        "name": "cloudWatchLogsMonacoEditor",
-        "resourceVersion": "1708108588074",
-        "creationTimestamp": "2024-02-16T18:36:28Z"
-      },
-      "spec": {
-        "description": "Enables the Monaco editor for CloudWatch Logs queries",
-        "stage": "GA",
-        "codeowner": "@grafana/aws-datasources",
-        "frontend": true,
-        "allowSelfServe": true
-      }
-    },
-    {
-      "metadata": {
-        "name": "alertmanagerRemoteSecondary",
-        "resourceVersion": "1708108588074",
-        "creationTimestamp": "2024-02-16T18:36:28Z"
-      },
-      "spec": {
-        "description": "Enable Grafana to sync configuration and state with a remote Alertmanager.",
-        "stage": "experimental",
-        "codeowner": "@grafana/alerting-squad"
-      }
-    },
-    {
-      "metadata": {
-        "name": "disableAngular",
-        "resourceVersion": "1708108588074",
-        "creationTimestamp": "2024-02-16T18:36:28Z"
-      },
-      "spec": {
-        "description": "Dynamic flag to disable angular at runtime. The preferred method is to set `angular_support_enabled` to `false` in the [security] settings, which allows you to change the state at runtime.",
-        "stage": "preview",
-        "codeowner": "@grafana/dataviz-squad",
-        "frontend": true,
-        "hideFromAdminPage": true
-      }
-    },
-    {
-      "metadata": {
-        "name": "grafanaAPIServerEnsureKubectlAccess",
-        "resourceVersion": "1708108588074",
-        "creationTimestamp": "2024-02-16T18:36:28Z"
-      },
-      "spec": {
-        "description": "Start an additional https handler and write kubectl options",
-        "stage": "experimental",
-        "codeowner": "@grafana/grafana-app-platform-squad",
-        "requiresDevMode": true,
-        "requiresRestart": true
-      }
-    },
-    {
-      "metadata": {
-        "name": "alertingNoDataErrorExecution",
-        "resourceVersion": "1708108588074",
-        "creationTimestamp": "2024-02-16T18:36:28Z"
-      },
-      "spec": {
-        "description": "Changes how Alerting state manager handles execution of NoData/Error",
-        "stage": "GA",
-        "codeowner": "@grafana/alerting-squad",
-        "requiresRestart": true
-      }
-    },
-    {
-      "metadata": {
-        "name": "angularDeprecationUI",
-        "resourceVersion": "1708108588074",
-        "creationTimestamp": "2024-02-16T18:36:28Z"
-      },
-      "spec": {
-        "description": "Display Angular warnings in dashboards and panels",
-        "stage": "GA",
-        "codeowner": "@grafana/plugins-platform-backend",
-        "frontend": true
-      }
-    },
-    {
-      "metadata": {
-        "name": "lokiFormatQuery",
-        "resourceVersion": "1708108588074",
-        "creationTimestamp": "2024-02-16T18:36:28Z"
-      },
-      "spec": {
-        "description": "Enables the ability to format Loki queries",
-        "stage": "experimental",
-        "codeowner": "@grafana/observability-logs",
-        "frontend": true
-      }
-    },
-    {
-      "metadata": {
-        "name": "nestedFolderPicker",
-        "resourceVersion": "1708108588074",
-        "creationTimestamp": "2024-02-16T18:36:28Z"
-      },
-      "spec": {
-        "description": "Enables the new folder picker to work with nested folders. Requires the nestedFolders feature toggle",
-        "stage": "GA",
-        "codeowner": "@grafana/grafana-frontend-platform",
-        "frontend": true,
-        "allowSelfServe": true
-      }
-    },
-    {
-      "metadata": {
-        "name": "individualCookiePreferences",
-        "resourceVersion": "1708108588074",
-        "creationTimestamp": "2024-02-16T18:36:28Z"
-      },
-      "spec": {
-        "description": "Support overriding cookie preferences per user",
-        "stage": "experimental",
-        "codeowner": "@grafana/backend-platform"
-      }
-    },
-    {
-      "metadata": {
-        "name": "externalServiceAccounts",
-        "resourceVersion": "1708108588074",
-        "creationTimestamp": "2024-02-16T18:36:28Z"
-      },
-      "spec": {
-        "description": "Automatic service account and token setup for plugins",
-        "stage": "preview",
-        "codeowner": "@grafana/identity-access-team",
-        "hideFromAdminPage": true
-      }
-    },
-    {
-      "metadata": {
-        "name": "groupByVariable",
-        "resourceVersion": "1708108588074",
-        "creationTimestamp": "2024-02-16T18:36:28Z"
-      },
-      "spec": {
-        "description": "Enable groupBy variable support in scenes dashboards",
-        "stage": "experimental",
-        "codeowner": "@grafana/dashboards-squad",
-        "hideFromAdminPage": true,
-        "hideFromDocs": true
-      }
-    },
-    {
-      "metadata": {
-        "name": "autoMigrateGraphPanel",
-        "resourceVersion": "1708108588074",
-        "creationTimestamp": "2024-02-16T18:36:28Z"
-      },
-      "spec": {
-        "description": "Migrate old graph panel to supported time series panel - broken out from autoMigrateOldPanels to enable granular tracking",
-        "stage": "preview",
-        "codeowner": "@grafana/dataviz-squad",
-        "frontend": true
-      }
-    },
-    {
-      "metadata": {
-        "name": "dashgpt",
-        "resourceVersion": "1708108588074",
-        "creationTimestamp": "2024-02-16T18:36:28Z"
-      },
-      "spec": {
-        "description": "Enable AI powered features in dashboards",
-        "stage": "preview",
-        "codeowner": "@grafana/dashboards-squad",
-        "frontend": true
-      }
-    },
-    {
-      "metadata": {
-        "name": "kubernetesSnapshots",
-        "resourceVersion": "1708108588074",
-        "creationTimestamp": "2024-02-16T18:36:28Z"
-      },
-      "spec": {
-        "description": "Routes snapshot requests from /api to the /apis endpoint",
-        "stage": "experimental",
-        "codeowner": "@grafana/grafana-app-platform-squad",
-        "requiresRestart": true
-      }
-    },
-    {
-      "metadata": {
-        "name": "influxdbBackendMigration",
-        "resourceVersion": "1708108588074",
-        "creationTimestamp": "2024-02-16T18:36:28Z"
-      },
-      "spec": {
-        "description": "Query InfluxDB InfluxQL without the proxy",
-        "stage": "GA",
-        "codeowner": "@grafana/observability-metrics",
-        "frontend": true
-      }
-    },
-    {
-      "metadata": {
-        "name": "redshiftAsyncQueryDataSupport",
-        "resourceVersion": "1708108588074",
-        "creationTimestamp": "2024-02-16T18:36:28Z"
-      },
-      "spec": {
-        "description": "Enable async query data support for Redshift",
-        "stage": "GA",
-        "codeowner": "@grafana/aws-datasources"
-      }
-    },
-    {
-      "metadata": {
-        "name": "topnav",
-        "resourceVersion": "1708108588074",
-        "creationTimestamp": "2024-02-16T18:36:28Z"
-      },
-      "spec": {
-        "description": "Enables topnav support in external plugins. The new Grafana navigation cannot be disabled.",
-        "stage": "deprecated",
-        "codeowner": "@grafana/grafana-frontend-platform"
-      }
-    },
-    {
-      "metadata": {
-        "name": "lokiQuerySplittingConfig",
-        "resourceVersion": "1708108588074",
-        "creationTimestamp": "2024-02-16T18:36:28Z"
-      },
-      "spec": {
-        "description": "Give users the option to configure split durations for Loki queries",
-        "stage": "experimental",
-        "codeowner": "@grafana/observability-logs",
-        "frontend": true
-      }
-    },
-    {
-      "metadata": {
-        "name": "awsDatasourcesTempCredentials",
-        "resourceVersion": "1708108588074",
-        "creationTimestamp": "2024-02-16T18:36:28Z"
-      },
-      "spec": {
-        "description": "Support temporary security credentials in AWS plugins for Grafana Cloud customers",
-        "stage": "experimental",
-        "codeowner": "@grafana/aws-datasources"
-      }
-    },
-    {
-      "metadata": {
-        "name": "influxdbSqlSupport",
-        "resourceVersion": "1708108588074",
-        "creationTimestamp": "2024-02-16T18:36:28Z"
-      },
-      "spec": {
-        "description": "Enable InfluxDB SQL query language support with new querying UI",
-        "stage": "GA",
-        "codeowner": "@grafana/observability-metrics",
-        "requiresRestart": true,
-        "allowSelfServe": true
-      }
-    },
-    {
-      "metadata": {
-        "name": "autoMigrateTablePanel",
-        "resourceVersion": "1708108588074",
-        "creationTimestamp": "2024-02-16T18:36:28Z"
-      },
-      "spec": {
-        "description": "Migrate old table panel to supported table panel - broken out from autoMigrateOldPanels to enable granular tracking",
-        "stage": "preview",
-        "codeowner": "@grafana/dataviz-squad",
-        "frontend": true
-      }
-    },
-    {
-      "metadata": {
-        "name": "migrationLocking",
-        "resourceVersion": "1708108588074",
-        "creationTimestamp": "2024-02-16T18:36:28Z"
-      },
-      "spec": {
-        "description": "Lock database during migrations",
-        "stage": "preview",
-        "codeowner": "@grafana/backend-platform"
-      }
-    },
-    {
-      "metadata": {
-        "name": "accessControlOnCall",
-        "resourceVersion": "1708108588074",
-        "creationTimestamp": "2024-02-16T18:36:28Z"
-      },
-      "spec": {
-        "description": "Access control primitives for OnCall",
-        "stage": "preview",
-        "codeowner": "@grafana/identity-access-team",
-        "hideFromAdminPage": true
-      }
-    },
-    {
-      "metadata": {
-        "name": "faroDatasourceSelector",
-        "resourceVersion": "1708108588074",
-        "creationTimestamp": "2024-02-16T18:36:28Z"
-      },
-      "spec": {
-        "description": "Enable the data source selector within the Frontend Apps section of the Frontend Observability",
-        "stage": "preview",
-        "codeowner": "@grafana/app-o11y",
-        "frontend": true
-      }
-    },
-    {
-      "metadata": {
-        "name": "featureToggleAdminPage",
-        "resourceVersion": "1708108588074",
-        "creationTimestamp": "2024-02-16T18:36:28Z"
-      },
-      "spec": {
-        "description": "Enable admin page for managing feature toggles from the Grafana front-end",
-        "stage": "experimental",
-        "codeowner": "@grafana/grafana-operator-experience-squad",
-        "requiresRestart": true
-      }
-    },
-    {
-      "metadata": {
-        "name": "awsAsyncQueryCaching",
-        "resourceVersion": "1708108588074",
-        "creationTimestamp": "2024-02-16T18:36:28Z"
-      },
-      "spec": {
-        "description": "Enable caching for async queries for Redshift and Athena. Requires that the datasource has caching and async query support enabled",
-        "stage": "GA",
-        "codeowner": "@grafana/aws-datasources"
-      }
-    },
-    {
-      "metadata": {
-        "name": "reportingRetries",
-        "resourceVersion": "1708108588074",
-        "creationTimestamp": "2024-02-16T18:36:28Z"
-      },
-      "spec": {
-        "description": "Enables rendering retries for the reporting feature",
-        "stage": "preview",
-        "codeowner": "@grafana/sharing-squad",
-        "requiresRestart": true
-      }
-    },
-    {
-      "metadata": {
-        "name": "kubernetesAggregator",
-        "resourceVersion": "1708108588074",
-        "creationTimestamp": "2024-02-16T18:36:28Z"
-      },
-      "spec": {
-        "description": "Enable grafana aggregator",
-        "stage": "experimental",
-        "codeowner": "@grafana/grafana-app-platform-squad",
-        "requiresRestart": true
-      }
-    },
-    {
-      "metadata": {
-        "name": "publicDashboards",
-        "resourceVersion": "1708108588074",
-        "creationTimestamp": "2024-02-16T18:36:28Z"
-      },
-      "spec": {
-        "description": "[Deprecated] Public dashboards are now enabled by default; to disable them, use the configuration setting. This feature toggle will be removed in the next major version.",
-        "stage": "GA",
-        "codeowner": "@grafana/sharing-squad",
-        "allowSelfServe": true
-      }
-    },
-    {
-      "metadata": {
-        "name": "transformationsRedesign",
-        "resourceVersion": "1708108588074",
-        "creationTimestamp": "2024-02-16T18:36:28Z"
-      },
-      "spec": {
-        "description": "Enables the transformations redesign",
-        "stage": "GA",
-        "codeowner": "@grafana/observability-metrics",
-        "frontend": true,
-        "allowSelfServe": true
-      }
-    },
-    {
-      "metadata": {
-        "name": "traceQLStreaming",
-        "resourceVersion": "1708108588074",
-        "creationTimestamp": "2024-02-16T18:36:28Z"
-      },
-      "spec": {
-        "description": "Enables response streaming of TraceQL queries of the Tempo data source",
-        "stage": "experimental",
-        "codeowner": "@grafana/observability-traces-and-profiling",
-        "frontend": true
-      }
-    },
-    {
-      "metadata": {
-        "name": "formatString",
-        "resourceVersion": "1708108588074",
-        "creationTimestamp": "2024-02-16T18:36:28Z"
-      },
-      "spec": {
-        "description": "Enable format string transformer",
-        "stage": "preview",
-        "codeowner": "@grafana/dataviz-squad",
-        "frontend": true
-      }
-    },
-    {
-      "metadata": {
-        "name": "alertingQueryOptimization",
-        "resourceVersion": "1708108588074",
-        "creationTimestamp": "2024-02-16T18:36:28Z"
-      },
-      "spec": {
-        "description": "Optimizes eligible queries in order to reduce load on datasources",
-        "stage": "GA",
-        "codeowner": "@grafana/alerting-squad"
-      }
-    },
-    {
-      "metadata": {
-        "name": "nestedFolders",
-        "resourceVersion": "1708108588074",
-        "creationTimestamp": "2024-02-16T18:36:28Z"
-      },
-      "spec": {
-        "description": "Enable folder nesting",
-        "stage": "preview",
-        "codeowner": "@grafana/backend-platform"
-      }
-    },
-    {
-      "metadata": {
-        "name": "scenes",
-        "resourceVersion": "1708108588074",
-        "creationTimestamp": "2024-02-16T18:36:28Z"
-      },
-      "spec": {
-        "description": "Experimental framework to build interactive dashboards",
-        "stage": "experimental",
-        "codeowner": "@grafana/dashboards-squad",
-        "frontend": true
-      }
-    },
-    {
-      "metadata": {
-        "name": "extraThemes",
-        "resourceVersion": "1708108588074",
-        "creationTimestamp": "2024-02-16T18:36:28Z"
-      },
-      "spec": {
-        "description": "Enables extra themes",
-        "stage": "experimental",
-        "codeowner": "@grafana/grafana-frontend-platform",
-        "frontend": true
-      }
-    },
-    {
-      "metadata": {
-        "name": "annotationPermissionUpdate",
-        "resourceVersion": "1708108588074",
-        "creationTimestamp": "2024-02-16T18:36:28Z"
-      },
-      "spec": {
-        "description": "Separate annotation permissions from dashboard permissions to allow for more granular control.",
-        "stage": "experimental",
-        "codeowner": "@grafana/identity-access-team"
-      }
-    },
-    {
-      "metadata": {
-        "name": "extractFieldsNameDeduplication",
-        "resourceVersion": "1708108588074",
-        "creationTimestamp": "2024-02-16T18:36:28Z"
-      },
-      "spec": {
-        "description": "Make sure extracted field names are unique in the dataframe",
-        "stage": "experimental",
-        "codeowner": "@grafana/dataviz-squad",
-        "frontend": true
+        "codeowner": "@grafana/observability-metrics"
       }
     },
     {
       "metadata": {
         "name": "flameGraphItemCollapsing",
-        "resourceVersion": "1708108588074",
-        "creationTimestamp": "2024-02-16T18:36:28Z"
+        "resourceVersion": "1709568338306",
+        "creationTimestamp": "2024-03-04T16:05:38Z"
       },
       "spec": {
         "description": "Allow collapsing of flame graph items",
@@ -1170,680 +312,58 @@
     },
     {
       "metadata": {
-        "name": "alertingPreviewUpgrade",
-        "resourceVersion": "1708108588074",
-        "creationTimestamp": "2024-02-16T18:36:28Z"
+        "name": "nestedFolders",
+        "resourceVersion": "1709568338306",
+        "creationTimestamp": "2024-03-04T16:05:38Z"
       },
       "spec": {
-        "description": "Show Unified Alerting preview and upgrade page in legacy alerting",
-        "stage": "GA",
-        "codeowner": "@grafana/alerting-squad",
-        "requiresRestart": true
-      }
-    },
-    {
-      "metadata": {
-        "name": "disableEnvelopeEncryption",
-        "resourceVersion": "1708108588074",
-        "creationTimestamp": "2024-02-16T18:36:28Z"
-      },
-      "spec": {
-        "description": "Disable envelope encryption (emergency only)",
-        "stage": "GA",
-        "codeowner": "@grafana/grafana-as-code",
-        "hideFromAdminPage": true
-      }
-    },
-    {
-      "metadata": {
-        "name": "groupToNestedTableTransformation",
-        "resourceVersion": "1708108588074",
-        "creationTimestamp": "2024-02-16T18:36:28Z"
-      },
-      "spec": {
-        "description": "Enables the group to nested table transformation",
+        "description": "Enable folder nesting",
         "stage": "preview",
-        "codeowner": "@grafana/dataviz-squad",
-        "frontend": true
+        "codeowner": "@grafana/backend-platform"
       }
     },
     {
       "metadata": {
-        "name": "promQLScope",
-        "resourceVersion": "1708108588074",
-        "creationTimestamp": "2024-02-16T18:36:28Z"
+        "name": "externalCorePlugins",
+        "resourceVersion": "1709568338306",
+        "creationTimestamp": "2024-03-04T16:05:38Z"
       },
       "spec": {
-        "description": "In-development feature that will allow injection of labels into prometheus queries.",
+        "description": "Allow core plugins to be loaded as external",
         "stage": "experimental",
-        "codeowner": "@grafana/observability-metrics"
+        "codeowner": "@grafana/plugins-platform-backend"
       }
     },
     {
       "metadata": {
-        "name": "logsContextDatasourceUi",
-        "resourceVersion": "1708108588074",
-        "creationTimestamp": "2024-02-16T18:36:28Z"
+        "name": "annotationPermissionUpdate",
+        "resourceVersion": "1709568338306",
+        "creationTimestamp": "2024-03-04T16:05:38Z"
       },
       "spec": {
-        "description": "Allow datasource to provide custom UI for context view",
-        "stage": "GA",
-        "codeowner": "@grafana/observability-logs",
-        "frontend": true,
-        "allowSelfServe": true
-      }
-    },
-    {
-      "metadata": {
-        "name": "alertStateHistoryLokiOnly",
-        "resourceVersion": "1708108588074",
-        "creationTimestamp": "2024-02-16T18:36:28Z"
-      },
-      "spec": {
-        "description": "Disable Grafana alerts from emitting annotations when a remote Loki instance is available.",
+        "description": "Separate annotation permissions from dashboard permissions to allow for more granular control.",
         "stage": "experimental",
-        "codeowner": "@grafana/alerting-squad"
+        "codeowner": "@grafana/identity-access-team"
       }
     },
     {
       "metadata": {
-        "name": "transformationsVariableSupport",
-        "resourceVersion": "1708108588074",
-        "creationTimestamp": "2024-02-16T18:36:28Z"
+        "name": "newFolderPicker",
+        "resourceVersion": "1709568338306",
+        "creationTimestamp": "2024-03-04T16:05:38Z"
       },
       "spec": {
-        "description": "Allows using variables in transformations",
-        "stage": "preview",
-        "codeowner": "@grafana/dataviz-squad",
-        "frontend": true
-      }
-    },
-    {
-      "metadata": {
-        "name": "dashboardSceneSolo",
-        "resourceVersion": "1708108588074",
-        "creationTimestamp": "2024-02-16T18:36:28Z"
-      },
-      "spec": {
-        "description": "Enables rendering dashboards using scenes for solo panels",
+        "description": "Enables the nested folder picker without having nested folders enabled",
         "stage": "experimental",
-        "codeowner": "@grafana/dashboards-squad",
-        "frontend": true
-      }
-    },
-    {
-      "metadata": {
-        "name": "athenaAsyncQueryDataSupport",
-        "resourceVersion": "1708108588074",
-        "creationTimestamp": "2024-02-16T18:36:28Z"
-      },
-      "spec": {
-        "description": "Enable async query data support for Athena",
-        "stage": "GA",
-        "codeowner": "@grafana/aws-datasources",
-        "frontend": true
-      }
-    },
-    {
-      "metadata": {
-        "name": "lokiLogsDataplane",
-        "resourceVersion": "1708108588074",
-        "creationTimestamp": "2024-02-16T18:36:28Z"
-      },
-      "spec": {
-        "description": "Changes logs responses from Loki to be compliant with the dataplane specification.",
-        "stage": "experimental",
-        "codeowner": "@grafana/observability-logs"
-      }
-    },
-    {
-      "metadata": {
-        "name": "enableDatagridEditing",
-        "resourceVersion": "1708108588074",
-        "creationTimestamp": "2024-02-16T18:36:28Z"
-      },
-      "spec": {
-        "description": "Enables the edit functionality in the datagrid panel",
-        "stage": "preview",
-        "codeowner": "@grafana/dataviz-squad",
-        "frontend": true
-      }
-    },
-    {
-      "metadata": {
-        "name": "exploreScrollableLogsContainer",
-        "resourceVersion": "1708108588074",
-        "creationTimestamp": "2024-02-16T18:36:28Z"
-      },
-      "spec": {
-        "description": "Improves the scrolling behavior of logs in Explore",
-        "stage": "experimental",
-        "codeowner": "@grafana/observability-logs",
-        "frontend": true
-      }
-    },
-    {
-      "metadata": {
-        "name": "lokiRunQueriesInParallel",
-        "resourceVersion": "1708108588074",
-        "creationTimestamp": "2024-02-16T18:36:28Z"
-      },
-      "spec": {
-        "description": "Enables running Loki queries in parallel",
-        "stage": "privatePreview",
-        "codeowner": "@grafana/observability-logs"
-      }
-    },
-    {
-      "metadata": {
-        "name": "panelTitleSearchInV1",
-        "resourceVersion": "1708108588074",
-        "creationTimestamp": "2024-02-16T18:36:28Z"
-      },
-      "spec": {
-        "description": "Enable searching for dashboards using panel title in search v1",
-        "stage": "experimental",
-        "codeowner": "@grafana/backend-platform",
-        "requiresDevMode": true
-      }
-    },
-    {
-      "metadata": {
-        "name": "logRowsPopoverMenu",
-        "resourceVersion": "1708108588074",
-        "creationTimestamp": "2024-02-16T18:36:28Z"
-      },
-      "spec": {
-        "description": "Enable filtering menu displayed when text of a log line is selected",
-        "stage": "GA",
-        "codeowner": "@grafana/observability-logs",
-        "frontend": true
-      }
-    },
-    {
-      "metadata": {
-        "name": "lokiQueryHints",
-        "resourceVersion": "1708108588074",
-        "creationTimestamp": "2024-02-16T18:36:28Z"
-      },
-      "spec": {
-        "description": "Enables query hints for Loki",
-        "stage": "GA",
-        "codeowner": "@grafana/observability-logs",
-        "frontend": true
-      }
-    },
-    {
-      "metadata": {
-        "name": "lokiExperimentalStreaming",
-        "resourceVersion": "1708108588074",
-        "creationTimestamp": "2024-02-16T18:36:28Z"
-      },
-      "spec": {
-        "description": "Support new streaming approach for loki (prototype, needs special loki build)",
-        "stage": "experimental",
-        "codeowner": "@grafana/observability-logs"
-      }
-    },
-    {
-      "metadata": {
-        "name": "traceToMetrics",
-        "resourceVersion": "1708108588074",
-        "creationTimestamp": "2024-02-16T18:36:28Z",
-        "deletionTimestamp": "2024-02-29T08:27:47Z"
-      },
-      "spec": {
-        "description": "Enable trace to metrics links",
-        "stage": "experimental",
-        "codeowner": "@grafana/observability-traces-and-profiling",
-        "frontend": true
-      }
-    },
-    {
-      "metadata": {
-        "name": "grpcServer",
-        "resourceVersion": "1708108588074",
-        "creationTimestamp": "2024-02-16T18:36:28Z"
-      },
-      "spec": {
-        "description": "Run the GRPC server",
-        "stage": "preview",
-        "codeowner": "@grafana/grafana-app-platform-squad",
-        "hideFromAdminPage": true
-      }
-    },
-    {
-      "metadata": {
-        "name": "cloudWatchCrossAccountQuerying",
-        "resourceVersion": "1708108588074",
-        "creationTimestamp": "2024-02-16T18:36:28Z"
-      },
-      "spec": {
-        "description": "Enables cross-account querying in CloudWatch datasources",
-        "stage": "GA",
-        "codeowner": "@grafana/aws-datasources",
-        "allowSelfServe": true
-      }
-    },
-    {
-      "metadata": {
-        "name": "vizAndWidgetSplit",
-        "resourceVersion": "1708108588074",
-        "creationTimestamp": "2024-02-16T18:36:28Z"
-      },
-      "spec": {
-        "description": "Split panels between visualizations and widgets",
-        "stage": "experimental",
-        "codeowner": "@grafana/dashboards-squad",
-        "frontend": true
-      }
-    },
-    {
-      "metadata": {
-        "name": "panelMonitoring",
-        "resourceVersion": "1708108588074",
-        "creationTimestamp": "2024-02-16T18:36:28Z"
-      },
-      "spec": {
-        "description": "Enables panel monitoring through logs and measurements",
-        "stage": "GA",
-        "codeowner": "@grafana/dataviz-squad",
-        "frontend": true
-      }
-    },
-    {
-      "metadata": {
-        "name": "live-service-web-worker",
-        "resourceVersion": "1708108588074",
-        "creationTimestamp": "2024-02-16T18:36:28Z"
-      },
-      "spec": {
-        "description": "This will use a webworker thread to processes events rather than the main thread",
-        "stage": "experimental",
-        "codeowner": "@grafana/grafana-app-platform-squad",
-        "frontend": true
-      }
-    },
-    {
-      "metadata": {
-        "name": "returnToPrevious",
-        "resourceVersion": "1708108588074",
-        "creationTimestamp": "2024-02-16T18:36:28Z"
-      },
-      "spec": {
-        "description": "Enables the return to previous context functionality",
-        "stage": "preview",
         "codeowner": "@grafana/grafana-frontend-platform",
         "frontend": true
       }
     },
     {
       "metadata": {
-        "name": "cachingOptimizeSerializationMemoryUsage",
-        "resourceVersion": "1708108588074",
-        "creationTimestamp": "2024-02-16T18:36:28Z"
-      },
-      "spec": {
-        "description": "If enabled, the caching backend gradually serializes query responses for the cache, comparing against the configured `[caching]max_value_mb` value as it goes. This can can help prevent Grafana from running out of memory while attempting to cache very large query responses.",
-        "stage": "experimental",
-        "codeowner": "@grafana/grafana-operator-experience-squad"
-      }
-    },
-    {
-      "metadata": {
-        "name": "onPremToCloudMigrations",
-        "resourceVersion": "1708108588074",
-        "creationTimestamp": "2024-02-16T18:36:28Z"
-      },
-      "spec": {
-        "description": "In-development feature that will allow users to easily migrate their on-prem Grafana instances to Grafana Cloud.",
-        "stage": "experimental",
-        "codeowner": "@grafana/grafana-operator-experience-squad"
-      }
-    },
-    {
-      "metadata": {
-        "name": "featureHighlights",
-        "resourceVersion": "1708108588074",
-        "creationTimestamp": "2024-02-16T18:36:28Z"
-      },
-      "spec": {
-        "description": "Highlight Grafana Enterprise features",
-        "stage": "GA",
-        "codeowner": "@grafana/grafana-as-code",
-        "allowSelfServe": true
-      }
-    },
-    {
-      "metadata": {
-        "name": "splitScopes",
-        "resourceVersion": "1708108588074",
-        "creationTimestamp": "2024-02-16T18:36:28Z",
-        "deletionTimestamp": "2024-02-29T08:27:47Z"
-      },
-      "spec": {
-        "description": "Support faster dashboard and folder search by splitting permission scopes into parts",
-        "stage": "deprecated",
-        "codeowner": "@grafana/identity-access-team",
-        "requiresRestart": true,
-        "hideFromAdminPage": true
-      }
-    },
-    {
-      "metadata": {
-        "name": "nodeGraphDotLayout",
-        "resourceVersion": "1708108588074",
-        "creationTimestamp": "2024-02-16T18:36:28Z"
-      },
-      "spec": {
-        "description": "Changed the layout algorithm for the node graph",
-        "stage": "experimental",
-        "codeowner": "@grafana/observability-traces-and-profiling",
-        "frontend": true
-      }
-    },
-    {
-      "metadata": {
-        "name": "refactorVariablesTimeRange",
-        "resourceVersion": "1708108588074",
-        "creationTimestamp": "2024-02-16T18:36:28Z"
-      },
-      "spec": {
-        "description": "Refactor time range variables flow to reduce number of API calls made when query variables are chained",
-        "stage": "preview",
-        "codeowner": "@grafana/dashboards-squad",
-        "hideFromAdminPage": true
-      }
-    },
-    {
-      "metadata": {
-        "name": "externalServiceAuth",
-        "resourceVersion": "1708108588074",
-        "creationTimestamp": "2024-02-16T18:36:28Z",
-        "deletionTimestamp": "2024-02-29T08:27:47Z"
-      },
-      "spec": {
-        "description": "Starts an OAuth2 authentication provider for external services",
-        "stage": "experimental",
-        "codeowner": "@grafana/identity-access-team",
-        "requiresDevMode": true
-      }
-    },
-    {
-      "metadata": {
-        "name": "frontendSandboxMonitorOnly",
-        "resourceVersion": "1708108588074",
-        "creationTimestamp": "2024-02-16T18:36:28Z"
-      },
-      "spec": {
-        "description": "Enables monitor only in the plugin frontend sandbox (if enabled)",
-        "stage": "experimental",
-        "codeowner": "@grafana/plugins-platform-backend",
-        "frontend": true
-      }
-    },
-    {
-      "metadata": {
-        "name": "mlExpressions",
-        "resourceVersion": "1708108588074",
-        "creationTimestamp": "2024-02-16T18:36:28Z"
-      },
-      "spec": {
-        "description": "Enable support for Machine Learning in server-side expressions",
-        "stage": "experimental",
-        "codeowner": "@grafana/alerting-squad"
-      }
-    },
-    {
-      "metadata": {
-        "name": "libraryPanelRBAC",
-        "resourceVersion": "1708108588074",
-        "creationTimestamp": "2024-02-16T18:36:28Z"
-      },
-      "spec": {
-        "description": "Enables RBAC support for library panels",
-        "stage": "experimental",
-        "codeowner": "@grafana/dashboards-squad",
-        "requiresRestart": true
-      }
-    },
-    {
-      "metadata": {
-        "name": "kubernetesFeatureToggles",
-        "resourceVersion": "1708108588074",
-        "creationTimestamp": "2024-02-16T18:36:28Z"
-      },
-      "spec": {
-        "description": "Use the kubernetes API for feature toggle management in the frontend",
-        "stage": "experimental",
-        "codeowner": "@grafana/grafana-operator-experience-squad",
-        "frontend": true,
-        "hideFromAdminPage": true
-      }
-    },
-    {
-      "metadata": {
-        "name": "expressionParser",
-        "resourceVersion": "1708108588074",
-        "creationTimestamp": "2024-02-16T18:36:28Z"
-      },
-      "spec": {
-        "description": "Enable new expression parser",
-        "stage": "experimental",
-        "codeowner": "@grafana/grafana-app-platform-squad",
-        "requiresRestart": true
-      }
-    },
-    {
-      "metadata": {
-        "name": "autoMigrateStatPanel",
-        "resourceVersion": "1708108588074",
-        "creationTimestamp": "2024-02-16T18:36:28Z"
-      },
-      "spec": {
-        "description": "Migrate old stat panel to supported stat panel - broken out from autoMigrateOldPanels to enable granular tracking",
-        "stage": "preview",
-        "codeowner": "@grafana/dataviz-squad",
-        "frontend": true
-      }
-    },
-    {
-      "metadata": {
-        "name": "renderAuthJWT",
-        "resourceVersion": "1708108588074",
-        "creationTimestamp": "2024-02-16T18:36:28Z"
-      },
-      "spec": {
-        "description": "Uses JWT-based auth for rendering instead of relying on remote cache",
-        "stage": "preview",
-        "codeowner": "@grafana/grafana-as-code",
-        "hideFromAdminPage": true
-      }
-    },
-    {
-      "metadata": {
-        "name": "permissionsFilterRemoveSubquery",
-        "resourceVersion": "1708108588074",
-        "creationTimestamp": "2024-02-16T18:36:28Z"
-      },
-      "spec": {
-        "description": "Alternative permission filter implementation that does not use subqueries for fetching the dashboard folder",
-        "stage": "experimental",
-        "codeowner": "@grafana/backend-platform"
-      }
-    },
-    {
-      "metadata": {
-        "name": "pdfTables",
-        "resourceVersion": "1708108588074",
-        "creationTimestamp": "2024-02-16T18:36:28Z"
-      },
-      "spec": {
-        "description": "Enables generating table data as PDF in reporting",
-        "stage": "preview",
-        "codeowner": "@grafana/sharing-squad"
-      }
-    },
-    {
-      "metadata": {
-        "name": "influxqlStreamingParser",
-        "resourceVersion": "1708108588074",
-        "creationTimestamp": "2024-02-16T18:36:28Z"
-      },
-      "spec": {
-        "description": "Enable streaming JSON parser for InfluxDB datasource InfluxQL query language",
-        "stage": "experimental",
-        "codeowner": "@grafana/observability-metrics"
-      }
-    },
-    {
-      "metadata": {
-        "name": "showDashboardValidationWarnings",
-        "resourceVersion": "1708108588074",
-        "creationTimestamp": "2024-02-16T18:36:28Z"
-      },
-      "spec": {
-        "description": "Show warnings when dashboards do not validate against the schema",
-        "stage": "experimental",
-        "codeowner": "@grafana/dashboards-squad"
-      }
-    },
-    {
-      "metadata": {
-        "name": "lokiQuerySplitting",
-        "resourceVersion": "1708108588074",
-        "creationTimestamp": "2024-02-16T18:36:28Z"
-      },
-      "spec": {
-        "description": "Split large interval queries into subqueries with smaller time intervals",
-        "stage": "GA",
-        "codeowner": "@grafana/observability-logs",
-        "frontend": true,
-        "allowSelfServe": true
-      }
-    },
-    {
-      "metadata": {
-        "name": "lokiMetricDataplane",
-        "resourceVersion": "1708108588074",
-        "creationTimestamp": "2024-02-16T18:36:28Z"
-      },
-      "spec": {
-        "description": "Changes metric responses from Loki to be compliant with the dataplane specification.",
-        "stage": "GA",
-        "codeowner": "@grafana/observability-logs",
-        "allowSelfServe": true
-      }
-    },
-    {
-      "metadata": {
-        "name": "dashboardEmbed",
-        "resourceVersion": "1708108588074",
-        "creationTimestamp": "2024-02-16T18:36:28Z"
-      },
-      "spec": {
-        "description": "Allow embedding dashboard for external use in Code editors",
-        "stage": "experimental",
-        "codeowner": "@grafana/grafana-as-code",
-        "frontend": true
-      }
-    },
-    {
-      "metadata": {
-        "name": "pluginsAPIMetrics",
-        "resourceVersion": "1708108588074",
-        "creationTimestamp": "2024-02-16T18:36:28Z"
-      },
-      "spec": {
-        "description": "Sends metrics of public grafana packages usage by plugins",
-        "stage": "experimental",
-        "codeowner": "@grafana/plugins-platform-backend",
-        "frontend": true
-      }
-    },
-    {
-      "metadata": {
-        "name": "awsDatasourcesNewFormStyling",
-        "resourceVersion": "1708108588074",
-        "creationTimestamp": "2024-02-16T18:36:28Z"
-      },
-      "spec": {
-        "description": "Applies new form styling for configuration and query editors in AWS plugins",
-        "stage": "preview",
-        "codeowner": "@grafana/aws-datasources",
-        "frontend": true
-      }
-    },
-    {
-      "metadata": {
-        "name": "dashboardScene",
-        "resourceVersion": "1708108588074",
-        "creationTimestamp": "2024-02-16T18:36:28Z"
-      },
-      "spec": {
-        "description": "Enables dashboard rendering using scenes for all roles",
-        "stage": "experimental",
-        "codeowner": "@grafana/dashboards-squad",
-        "frontend": true
-      }
-    },
-    {
-      "metadata": {
-        "name": "canvasPanelNesting",
-        "resourceVersion": "1708108588074",
-        "creationTimestamp": "2024-02-16T18:36:28Z"
-      },
-      "spec": {
-        "description": "Allow elements nesting",
-        "stage": "experimental",
-        "codeowner": "@grafana/dataviz-squad",
-        "frontend": true,
-        "hideFromAdminPage": true
-      }
-    },
-    {
-      "metadata": {
-        "name": "alertingSaveStatePeriodic",
-        "resourceVersion": "1708108588074",
-        "creationTimestamp": "2024-02-16T18:36:28Z"
-      },
-      "spec": {
-        "description": "Writes the state periodically to the database, asynchronous to rule evaluation",
-        "stage": "privatePreview",
-        "codeowner": "@grafana/alerting-squad"
-      }
-    },
-    {
-      "metadata": {
-        "name": "sseGroupByDatasource",
-        "resourceVersion": "1708108588074",
-        "creationTimestamp": "2024-02-16T18:36:28Z"
-      },
-      "spec": {
-        "description": "Send query to the same datasource in a single request when using server side expressions. The `cloudWatchBatchQueries` feature toggle should be enabled if this used with CloudWatch.",
-        "stage": "experimental",
-        "codeowner": "@grafana/observability-metrics"
-      }
-    },
-    {
-      "metadata": {
-        "name": "kubernetesQueryServiceRewrite",
-        "resourceVersion": "1708108588074",
-        "creationTimestamp": "2024-02-16T18:36:28Z"
-      },
-      "spec": {
-        "description": "Rewrite requests targeting /ds/query to the query service",
-        "stage": "experimental",
-        "codeowner": "@grafana/grafana-app-platform-squad",
-        "requiresDevMode": true,
-        "requiresRestart": true
-      }
-    },
-    {
-      "metadata": {
         "name": "exploreContentOutline",
-        "resourceVersion": "1708108588074",
-        "creationTimestamp": "2024-02-16T18:36:28Z"
+        "resourceVersion": "1709568338306",
+        "creationTimestamp": "2024-03-04T16:05:38Z"
       },
       "spec": {
         "description": "Content outline sidebar",
@@ -1855,172 +375,35 @@
     },
     {
       "metadata": {
-        "name": "recordedQueriesMulti",
-        "resourceVersion": "1708108588074",
-        "creationTimestamp": "2024-02-16T18:36:28Z"
+        "name": "disableAngular",
+        "resourceVersion": "1709568338306",
+        "creationTimestamp": "2024-03-04T16:05:38Z"
       },
       "spec": {
-        "description": "Enables writing multiple items from a single query within Recorded Queries",
-        "stage": "GA",
-        "codeowner": "@grafana/observability-metrics"
-      }
-    },
-    {
-      "metadata": {
-        "name": "alertingInsights",
-        "resourceVersion": "1708108588074",
-        "creationTimestamp": "2024-02-16T18:36:28Z"
-      },
-      "spec": {
-        "description": "Show the new alerting insights landing page",
-        "stage": "GA",
-        "codeowner": "@grafana/alerting-squad",
+        "description": "Dynamic flag to disable angular at runtime. The preferred method is to set `angular_support_enabled` to `false` in the [security] settings, which allows you to change the state at runtime.",
+        "stage": "preview",
+        "codeowner": "@grafana/dataviz-squad",
         "frontend": true,
         "hideFromAdminPage": true
       }
     },
     {
       "metadata": {
-        "name": "idForwarding",
-        "resourceVersion": "1708108588074",
-        "creationTimestamp": "2024-02-16T18:36:28Z"
+        "name": "wargamesTesting",
+        "resourceVersion": "1709568338306",
+        "creationTimestamp": "2024-03-04T16:05:38Z"
       },
       "spec": {
-        "description": "Generate signed id token for identity that can be forwarded to plugins and external services",
-        "stage": "experimental",
-        "codeowner": "@grafana/identity-access-team"
-      }
-    },
-    {
-      "metadata": {
-        "name": "enableNativeHTTPHistogram",
-        "resourceVersion": "1708108588074",
-        "creationTimestamp": "2024-02-16T18:36:28Z"
-      },
-      "spec": {
-        "description": "Enables native HTTP Histograms",
+        "description": "Placeholder feature flag for internal testing",
         "stage": "experimental",
         "codeowner": "@grafana/hosted-grafana-team"
       }
     },
     {
       "metadata": {
-        "name": "alertmanagerRemoteOnly",
-        "resourceVersion": "1708108588074",
-        "creationTimestamp": "2024-02-16T18:36:28Z"
-      },
-      "spec": {
-        "description": "Disable the internal Alertmanager and only use the external one defined.",
-        "stage": "experimental",
-        "codeowner": "@grafana/alerting-squad"
-      }
-    },
-    {
-      "metadata": {
-        "name": "influxdbRunQueriesInParallel",
-        "resourceVersion": "1708108588074",
-        "creationTimestamp": "2024-02-16T18:36:28Z"
-      },
-      "spec": {
-        "description": "Enables running InfluxDB Influxql queries in parallel",
-        "stage": "privatePreview",
-        "codeowner": "@grafana/observability-metrics"
-      }
-    },
-    {
-      "metadata": {
-        "name": "newVizTooltips",
-        "resourceVersion": "1708108588074",
-        "creationTimestamp": "2024-02-16T18:36:28Z"
-      },
-      "spec": {
-        "description": "New visualizations tooltips UX",
-        "stage": "preview",
-        "codeowner": "@grafana/dataviz-squad",
-        "frontend": true
-      }
-    },
-    {
-      "metadata": {
-        "name": "prometheusMetricEncyclopedia",
-        "resourceVersion": "1708108588074",
-        "creationTimestamp": "2024-02-16T18:36:28Z"
-      },
-      "spec": {
-        "description": "Adds the metrics explorer component to the Prometheus query builder as an option in metric select",
-        "stage": "GA",
-        "codeowner": "@grafana/observability-metrics",
-        "frontend": true,
-        "allowSelfServe": true
-      }
-    },
-    {
-      "metadata": {
-        "name": "pluginsDynamicAngularDetectionPatterns",
-        "resourceVersion": "1708108588074",
-        "creationTimestamp": "2024-02-16T18:36:28Z"
-      },
-      "spec": {
-        "description": "Enables fetching Angular detection patterns for plugins from GCOM and fallback to hardcoded ones",
-        "stage": "experimental",
-        "codeowner": "@grafana/plugins-platform-backend"
-      }
-    },
-    {
-      "metadata": {
-        "name": "cloudWatchBatchQueries",
-        "resourceVersion": "1708108588074",
-        "creationTimestamp": "2024-02-16T18:36:28Z"
-      },
-      "spec": {
-        "description": "Runs CloudWatch metrics queries as separate batches",
-        "stage": "preview",
-        "codeowner": "@grafana/aws-datasources"
-      }
-    },
-    {
-      "metadata": {
-        "name": "alertingUpgradeDryrunOnStart",
-        "resourceVersion": "1708108588074",
-        "creationTimestamp": "2024-02-16T18:36:28Z"
-      },
-      "spec": {
-        "description": "When activated in legacy alerting mode, this initiates a dry-run of the Unified Alerting upgrade during each startup. It logs any issues detected without implementing any actual changes.",
-        "stage": "GA",
-        "codeowner": "@grafana/alerting-squad",
-        "requiresRestart": true
-      }
-    },
-    {
-      "metadata": {
-        "name": "autoMigrateOldPanels",
-        "resourceVersion": "1708108588074",
-        "creationTimestamp": "2024-02-16T18:36:28Z"
-      },
-      "spec": {
-        "description": "Migrate old angular panels to supported versions (graph, table-old, worldmap, etc)",
-        "stage": "preview",
-        "codeowner": "@grafana/dataviz-squad",
-        "frontend": true
-      }
-    },
-    {
-      "metadata": {
-        "name": "externalCorePlugins",
-        "resourceVersion": "1708108588074",
-        "creationTimestamp": "2024-02-16T18:36:28Z"
-      },
-      "spec": {
-        "description": "Allow core plugins to be loaded as external",
-        "stage": "experimental",
-        "codeowner": "@grafana/plugins-platform-backend"
-      }
-    },
-    {
-      "metadata": {
         "name": "alertingNoNormalState",
-        "resourceVersion": "1708108588074",
-        "creationTimestamp": "2024-02-16T18:36:28Z"
+        "resourceVersion": "1709568338306",
+        "creationTimestamp": "2024-03-04T16:05:38Z"
       },
       "spec": {
         "description": "Stop maintaining state of alerts that are not firing",
@@ -2031,35 +414,185 @@
     },
     {
       "metadata": {
-        "name": "dataplaneFrontendFallback",
-        "resourceVersion": "1708108588074",
-        "creationTimestamp": "2024-02-16T18:36:28Z"
+        "name": "individualCookiePreferences",
+        "resourceVersion": "1709568338306",
+        "creationTimestamp": "2024-03-04T16:05:38Z"
       },
       "spec": {
-        "description": "Support dataplane contract field name change for transformations and field name matchers where the name is different",
+        "description": "Support overriding cookie preferences per user",
+        "stage": "experimental",
+        "codeowner": "@grafana/backend-platform"
+      }
+    },
+    {
+      "metadata": {
+        "name": "unifiedRequestLog",
+        "resourceVersion": "1709568338306",
+        "creationTimestamp": "2024-03-04T16:05:38Z"
+      },
+      "spec": {
+        "description": "Writes error logs to the request logger",
+        "stage": "experimental",
+        "codeowner": "@grafana/backend-platform"
+      }
+    },
+    {
+      "metadata": {
+        "name": "permissionsFilterRemoveSubquery",
+        "resourceVersion": "1709568338306",
+        "creationTimestamp": "2024-03-04T16:05:38Z"
+      },
+      "spec": {
+        "description": "Alternative permission filter implementation that does not use subqueries for fetching the dashboard folder",
+        "stage": "experimental",
+        "codeowner": "@grafana/backend-platform"
+      }
+    },
+    {
+      "metadata": {
+        "name": "alertmanagerRemoteSecondary",
+        "resourceVersion": "1709568338306",
+        "creationTimestamp": "2024-03-04T16:05:38Z"
+      },
+      "spec": {
+        "description": "Enable Grafana to sync configuration and state with a remote Alertmanager.",
+        "stage": "experimental",
+        "codeowner": "@grafana/alerting-squad"
+      }
+    },
+    {
+      "metadata": {
+        "name": "pdfTables",
+        "resourceVersion": "1709568338306",
+        "creationTimestamp": "2024-03-04T16:05:38Z"
+      },
+      "spec": {
+        "description": "Enables generating table data as PDF in reporting",
+        "stage": "preview",
+        "codeowner": "@grafana/sharing-squad"
+      }
+    },
+    {
+      "metadata": {
+        "name": "correlations",
+        "resourceVersion": "1709568338306",
+        "creationTimestamp": "2024-03-04T16:05:38Z"
+      },
+      "spec": {
+        "description": "Correlations page",
         "stage": "GA",
-        "codeowner": "@grafana/observability-metrics",
-        "frontend": true,
+        "codeowner": "@grafana/explore-squad",
         "allowSelfServe": true
       }
     },
     {
       "metadata": {
-        "name": "disableSSEDataplane",
-        "resourceVersion": "1708108588074",
-        "creationTimestamp": "2024-02-16T18:36:28Z"
+        "name": "disableSecretsCompatibility",
+        "resourceVersion": "1709568338306",
+        "creationTimestamp": "2024-03-04T16:05:38Z"
       },
       "spec": {
-        "description": "Disables dataplane specific processing in server side expressions.",
+        "description": "Disable duplicated secret storage in legacy tables",
         "stage": "experimental",
-        "codeowner": "@grafana/observability-metrics"
+        "codeowner": "@grafana/hosted-grafana-team",
+        "requiresRestart": true
+      }
+    },
+    {
+      "metadata": {
+        "name": "canvasPanelPanZoom",
+        "resourceVersion": "1709568338306",
+        "creationTimestamp": "2024-03-04T16:05:38Z"
+      },
+      "spec": {
+        "description": "Allow pan and zoom in canvas panel",
+        "stage": "preview",
+        "codeowner": "@grafana/dataviz-squad",
+        "frontend": true
+      }
+    },
+    {
+      "metadata": {
+        "name": "pluginsSkipHostEnvVars",
+        "resourceVersion": "1709568338306",
+        "creationTimestamp": "2024-03-04T16:05:38Z"
+      },
+      "spec": {
+        "description": "Disables passing host environment variable to plugin processes",
+        "stage": "experimental",
+        "codeowner": "@grafana/plugins-platform-backend"
+      }
+    },
+    {
+      "metadata": {
+        "name": "logsExploreTableVisualisation",
+        "resourceVersion": "1709568338306",
+        "creationTimestamp": "2024-03-04T16:05:38Z"
+      },
+      "spec": {
+        "description": "A table visualisation for logs in Explore",
+        "stage": "GA",
+        "codeowner": "@grafana/observability-logs",
+        "frontend": true
+      }
+    },
+    {
+      "metadata": {
+        "name": "metricsSummary",
+        "resourceVersion": "1709568338306",
+        "creationTimestamp": "2024-03-04T16:05:38Z"
+      },
+      "spec": {
+        "description": "Enables metrics summary queries in the Tempo data source",
+        "stage": "experimental",
+        "codeowner": "@grafana/observability-traces-and-profiling",
+        "frontend": true
+      }
+    },
+    {
+      "metadata": {
+        "name": "managedPluginsInstall",
+        "resourceVersion": "1709568338306",
+        "creationTimestamp": "2024-03-04T16:05:38Z"
+      },
+      "spec": {
+        "description": "Install managed plugins directly from plugins catalog",
+        "stage": "preview",
+        "codeowner": "@grafana/plugins-platform-backend"
+      }
+    },
+    {
+      "metadata": {
+        "name": "alertingDetailsViewV2",
+        "resourceVersion": "1709568338306",
+        "creationTimestamp": "2024-03-04T16:05:38Z"
+      },
+      "spec": {
+        "description": "Enables the preview of the new alert details view",
+        "stage": "experimental",
+        "codeowner": "@grafana/alerting-squad",
+        "frontend": true,
+        "hideFromDocs": true
+      }
+    },
+    {
+      "metadata": {
+        "name": "autoMigrateWorldmapPanel",
+        "resourceVersion": "1709568338306",
+        "creationTimestamp": "2024-03-04T16:05:38Z"
+      },
+      "spec": {
+        "description": "Migrate old worldmap panel to supported geomap panel - broken out from autoMigrateOldPanels to enable granular tracking",
+        "stage": "preview",
+        "codeowner": "@grafana/dataviz-squad",
+        "frontend": true
       }
     },
     {
       "metadata": {
         "name": "lokiPredefinedOperations",
-        "resourceVersion": "1708108588074",
-        "creationTimestamp": "2024-02-16T18:36:28Z"
+        "resourceVersion": "1709568338306",
+        "creationTimestamp": "2024-03-04T16:05:38Z"
       },
       "spec": {
         "description": "Adds predefined query operations to Loki query editor",
@@ -2070,23 +603,47 @@
     },
     {
       "metadata": {
-        "name": "configurableSchedulerTick",
-        "resourceVersion": "1708108588074",
-        "creationTimestamp": "2024-02-16T18:36:28Z"
+        "name": "enableDatagridEditing",
+        "resourceVersion": "1709568338306",
+        "creationTimestamp": "2024-03-04T16:05:38Z"
       },
       "spec": {
-        "description": "Enable changing the scheduler base interval via configuration option unified_alerting.scheduler_tick_interval",
+        "description": "Enables the edit functionality in the datagrid panel",
+        "stage": "preview",
+        "codeowner": "@grafana/dataviz-squad",
+        "frontend": true
+      }
+    },
+    {
+      "metadata": {
+        "name": "addFieldFromCalculationStatFunctions",
+        "resourceVersion": "1709568338306",
+        "creationTimestamp": "2024-03-04T16:05:38Z"
+      },
+      "spec": {
+        "description": "Add cumulative and window functions to the add field from calculation transformation",
+        "stage": "preview",
+        "codeowner": "@grafana/dataviz-squad",
+        "frontend": true
+      }
+    },
+    {
+      "metadata": {
+        "name": "idForwarding",
+        "resourceVersion": "1709568338306",
+        "creationTimestamp": "2024-03-04T16:05:38Z"
+      },
+      "spec": {
+        "description": "Generate signed id token for identity that can be forwarded to plugins and external services",
         "stage": "experimental",
-        "codeowner": "@grafana/alerting-squad",
-        "requiresRestart": true,
-        "hideFromDocs": true
+        "codeowner": "@grafana/identity-access-team"
       }
     },
     {
       "metadata": {
         "name": "kubernetesPlaylists",
-        "resourceVersion": "1708108588074",
-        "creationTimestamp": "2024-02-16T18:36:28Z"
+        "resourceVersion": "1709568338306",
+        "creationTimestamp": "2024-03-04T16:05:38Z"
       },
       "spec": {
         "description": "Use the kubernetes API in the frontend for playlists, and route /api/playlist requests to k8s",
@@ -2097,9 +654,632 @@
     },
     {
       "metadata": {
+        "name": "kubernetesQueryServiceRewrite",
+        "resourceVersion": "1709568338306",
+        "creationTimestamp": "2024-03-04T16:05:38Z"
+      },
+      "spec": {
+        "description": "Rewrite requests targeting /ds/query to the query service",
+        "stage": "experimental",
+        "codeowner": "@grafana/grafana-app-platform-squad",
+        "requiresDevMode": true,
+        "requiresRestart": true
+      }
+    },
+    {
+      "metadata": {
+        "name": "panelTitleSearchInV1",
+        "resourceVersion": "1709568338306",
+        "creationTimestamp": "2024-03-04T16:05:38Z"
+      },
+      "spec": {
+        "description": "Enable searching for dashboards using panel title in search v1",
+        "stage": "experimental",
+        "codeowner": "@grafana/backend-platform",
+        "requiresDevMode": true
+      }
+    },
+    {
+      "metadata": {
+        "name": "dashboardScene",
+        "resourceVersion": "1709568338306",
+        "creationTimestamp": "2024-03-04T16:05:38Z"
+      },
+      "spec": {
+        "description": "Enables dashboard rendering using scenes for all roles",
+        "stage": "experimental",
+        "codeowner": "@grafana/dashboards-squad",
+        "frontend": true
+      }
+    },
+    {
+      "metadata": {
+        "name": "alertingSimplifiedRouting",
+        "resourceVersion": "1709568338306",
+        "creationTimestamp": "2024-03-04T16:05:38Z"
+      },
+      "spec": {
+        "description": "Enables users to easily configure alert notifications by specifying a contact point directly when editing or creating an alert rule",
+        "stage": "preview",
+        "codeowner": "@grafana/alerting-squad"
+      }
+    },
+    {
+      "metadata": {
+        "name": "athenaAsyncQueryDataSupport",
+        "resourceVersion": "1709568338306",
+        "creationTimestamp": "2024-03-04T16:05:38Z"
+      },
+      "spec": {
+        "description": "Enable async query data support for Athena",
+        "stage": "GA",
+        "codeowner": "@grafana/aws-datasources",
+        "frontend": true
+      }
+    },
+    {
+      "metadata": {
+        "name": "lokiRunQueriesInParallel",
+        "resourceVersion": "1709568338306",
+        "creationTimestamp": "2024-03-04T16:05:38Z"
+      },
+      "spec": {
+        "description": "Enables running Loki queries in parallel",
+        "stage": "privatePreview",
+        "codeowner": "@grafana/observability-logs"
+      }
+    },
+    {
+      "metadata": {
+        "name": "transformationsVariableSupport",
+        "resourceVersion": "1709568338306",
+        "creationTimestamp": "2024-03-04T16:05:38Z"
+      },
+      "spec": {
+        "description": "Allows using variables in transformations",
+        "stage": "preview",
+        "codeowner": "@grafana/dataviz-squad",
+        "frontend": true
+      }
+    },
+    {
+      "metadata": {
+        "name": "expressionParser",
+        "resourceVersion": "1709568338306",
+        "creationTimestamp": "2024-03-04T16:05:38Z"
+      },
+      "spec": {
+        "description": "Enable new expression parser",
+        "stage": "experimental",
+        "codeowner": "@grafana/grafana-app-platform-squad",
+        "requiresRestart": true
+      }
+    },
+    {
+      "metadata": {
+        "name": "disableEnvelopeEncryption",
+        "resourceVersion": "1709568338306",
+        "creationTimestamp": "2024-03-04T16:05:38Z"
+      },
+      "spec": {
+        "description": "Disable envelope encryption (emergency only)",
+        "stage": "GA",
+        "codeowner": "@grafana/grafana-as-code",
+        "hideFromAdminPage": true
+      }
+    },
+    {
+      "metadata": {
+        "name": "renderAuthJWT",
+        "resourceVersion": "1709568338306",
+        "creationTimestamp": "2024-03-04T16:05:38Z"
+      },
+      "spec": {
+        "description": "Uses JWT-based auth for rendering instead of relying on remote cache",
+        "stage": "preview",
+        "codeowner": "@grafana/grafana-as-code",
+        "hideFromAdminPage": true
+      }
+    },
+    {
+      "metadata": {
+        "name": "canvasPanelNesting",
+        "resourceVersion": "1709568338306",
+        "creationTimestamp": "2024-03-04T16:05:38Z"
+      },
+      "spec": {
+        "description": "Allow elements nesting",
+        "stage": "experimental",
+        "codeowner": "@grafana/dataviz-squad",
+        "frontend": true,
+        "hideFromAdminPage": true
+      }
+    },
+    {
+      "metadata": {
+        "name": "cloudRBACRoles",
+        "resourceVersion": "1709568338306",
+        "creationTimestamp": "2024-03-04T16:05:38Z"
+      },
+      "spec": {
+        "description": "Enabled grafana cloud specific RBAC roles",
+        "stage": "experimental",
+        "codeowner": "@grafana/identity-access-team",
+        "requiresRestart": true,
+        "hideFromDocs": true
+      }
+    },
+    {
+      "metadata": {
+        "name": "alertStateHistoryLokiOnly",
+        "resourceVersion": "1709568338306",
+        "creationTimestamp": "2024-03-04T16:05:38Z"
+      },
+      "spec": {
+        "description": "Disable Grafana alerts from emitting annotations when a remote Loki instance is available.",
+        "stage": "experimental",
+        "codeowner": "@grafana/alerting-squad"
+      }
+    },
+    {
+      "metadata": {
+        "name": "formatString",
+        "resourceVersion": "1709568338306",
+        "creationTimestamp": "2024-03-04T16:05:38Z"
+      },
+      "spec": {
+        "description": "Enable format string transformer",
+        "stage": "preview",
+        "codeowner": "@grafana/dataviz-squad",
+        "frontend": true
+      }
+    },
+    {
+      "metadata": {
+        "name": "alertingPreviewUpgrade",
+        "resourceVersion": "1709568338306",
+        "creationTimestamp": "2024-03-04T16:05:38Z"
+      },
+      "spec": {
+        "description": "Show Unified Alerting preview and upgrade page in legacy alerting",
+        "stage": "GA",
+        "codeowner": "@grafana/alerting-squad",
+        "requiresRestart": true
+      }
+    },
+    {
+      "metadata": {
+        "name": "publicDashboards",
+        "resourceVersion": "1709568338306",
+        "creationTimestamp": "2024-03-04T16:05:38Z"
+      },
+      "spec": {
+        "description": "[Deprecated] Public dashboards are now enabled by default; to disable them, use the configuration setting. This feature toggle will be removed in the next major version.",
+        "stage": "GA",
+        "codeowner": "@grafana/sharing-squad",
+        "allowSelfServe": true
+      }
+    },
+    {
+      "metadata": {
+        "name": "returnToPrevious",
+        "resourceVersion": "1709568338306",
+        "creationTimestamp": "2024-03-04T16:05:38Z"
+      },
+      "spec": {
+        "description": "Enables the return to previous context functionality",
+        "stage": "preview",
+        "codeowner": "@grafana/grafana-frontend-platform",
+        "frontend": true
+      }
+    },
+    {
+      "metadata": {
+        "name": "showDashboardValidationWarnings",
+        "resourceVersion": "1709568338306",
+        "creationTimestamp": "2024-03-04T16:05:38Z"
+      },
+      "spec": {
+        "description": "Show warnings when dashboards do not validate against the schema",
+        "stage": "experimental",
+        "codeowner": "@grafana/dashboards-squad"
+      }
+    },
+    {
+      "metadata": {
+        "name": "lokiLogsDataplane",
+        "resourceVersion": "1709568338306",
+        "creationTimestamp": "2024-03-04T16:05:38Z"
+      },
+      "spec": {
+        "description": "Changes logs responses from Loki to be compliant with the dataplane specification.",
+        "stage": "experimental",
+        "codeowner": "@grafana/observability-logs"
+      }
+    },
+    {
+      "metadata": {
+        "name": "transformationsRedesign",
+        "resourceVersion": "1709568338306",
+        "creationTimestamp": "2024-03-04T16:05:38Z"
+      },
+      "spec": {
+        "description": "Enables the transformations redesign",
+        "stage": "GA",
+        "codeowner": "@grafana/observability-metrics",
+        "frontend": true,
+        "allowSelfServe": true
+      }
+    },
+    {
+      "metadata": {
+        "name": "influxdbSqlSupport",
+        "resourceVersion": "1709568338306",
+        "creationTimestamp": "2024-03-04T16:05:38Z"
+      },
+      "spec": {
+        "description": "Enable InfluxDB SQL query language support with new querying UI",
+        "stage": "GA",
+        "codeowner": "@grafana/observability-metrics",
+        "requiresRestart": true,
+        "allowSelfServe": true
+      }
+    },
+    {
+      "metadata": {
+        "name": "unifiedStorage",
+        "resourceVersion": "1709568338306",
+        "creationTimestamp": "2024-03-04T16:05:38Z"
+      },
+      "spec": {
+        "description": "SQL-based k8s storage",
+        "stage": "experimental",
+        "codeowner": "@grafana/grafana-app-platform-squad",
+        "requiresDevMode": true,
+        "requiresRestart": true
+      }
+    },
+    {
+      "metadata": {
+        "name": "cloudWatchCrossAccountQuerying",
+        "resourceVersion": "1709568338306",
+        "creationTimestamp": "2024-03-04T16:05:38Z"
+      },
+      "spec": {
+        "description": "Enables cross-account querying in CloudWatch datasources",
+        "stage": "GA",
+        "codeowner": "@grafana/aws-datasources",
+        "allowSelfServe": true
+      }
+    },
+    {
+      "metadata": {
+        "name": "vizAndWidgetSplit",
+        "resourceVersion": "1709568338306",
+        "creationTimestamp": "2024-03-04T16:05:38Z"
+      },
+      "spec": {
+        "description": "Split panels between visualizations and widgets",
+        "stage": "experimental",
+        "codeowner": "@grafana/dashboards-squad",
+        "frontend": true
+      }
+    },
+    {
+      "metadata": {
+        "name": "nestedFolderPicker",
+        "resourceVersion": "1709568338306",
+        "creationTimestamp": "2024-03-04T16:05:38Z"
+      },
+      "spec": {
+        "description": "Enables the new folder picker to work with nested folders. Requires the nestedFolders feature toggle",
+        "stage": "GA",
+        "codeowner": "@grafana/grafana-frontend-platform",
+        "frontend": true,
+        "allowSelfServe": true
+      }
+    },
+    {
+      "metadata": {
+        "name": "exploreScrollableLogsContainer",
+        "resourceVersion": "1709568338306",
+        "creationTimestamp": "2024-03-04T16:05:38Z"
+      },
+      "spec": {
+        "description": "Improves the scrolling behavior of logs in Explore",
+        "stage": "experimental",
+        "codeowner": "@grafana/observability-logs",
+        "frontend": true
+      }
+    },
+    {
+      "metadata": {
+        "name": "alertmanagerRemoteOnly",
+        "resourceVersion": "1709568338306",
+        "creationTimestamp": "2024-03-04T16:05:38Z"
+      },
+      "spec": {
+        "description": "Disable the internal Alertmanager and only use the external one defined.",
+        "stage": "experimental",
+        "codeowner": "@grafana/alerting-squad"
+      }
+    },
+    {
+      "metadata": {
+        "name": "enablePluginsTracingByDefault",
+        "resourceVersion": "1709568338306",
+        "creationTimestamp": "2024-03-04T16:05:38Z"
+      },
+      "spec": {
+        "description": "Enable plugin tracing for all external plugins",
+        "stage": "experimental",
+        "codeowner": "@grafana/plugins-platform-backend",
+        "requiresRestart": true
+      }
+    },
+    {
+      "metadata": {
+        "name": "alertingQueryOptimization",
+        "resourceVersion": "1709568338306",
+        "creationTimestamp": "2024-03-04T16:05:38Z"
+      },
+      "spec": {
+        "description": "Optimizes eligible queries in order to reduce load on datasources",
+        "stage": "GA",
+        "codeowner": "@grafana/alerting-squad"
+      }
+    },
+    {
+      "metadata": {
+        "name": "kubernetesAggregator",
+        "resourceVersion": "1709568338306",
+        "creationTimestamp": "2024-03-04T16:05:38Z"
+      },
+      "spec": {
+        "description": "Enable grafana aggregator",
+        "stage": "experimental",
+        "codeowner": "@grafana/grafana-app-platform-squad",
+        "requiresRestart": true
+      }
+    },
+    {
+      "metadata": {
+        "name": "influxdbRunQueriesInParallel",
+        "resourceVersion": "1709568338306",
+        "creationTimestamp": "2024-03-04T16:05:38Z"
+      },
+      "spec": {
+        "description": "Enables running InfluxDB Influxql queries in parallel",
+        "stage": "privatePreview",
+        "codeowner": "@grafana/observability-metrics"
+      }
+    },
+    {
+      "metadata": {
+        "name": "dashboardEmbed",
+        "resourceVersion": "1709568338306",
+        "creationTimestamp": "2024-03-04T16:05:38Z"
+      },
+      "spec": {
+        "description": "Allow embedding dashboard for external use in Code editors",
+        "stage": "experimental",
+        "codeowner": "@grafana/grafana-as-code",
+        "frontend": true
+      }
+    },
+    {
+      "metadata": {
+        "name": "sqlDatasourceDatabaseSelection",
+        "resourceVersion": "1709568338306",
+        "creationTimestamp": "2024-03-04T16:05:38Z"
+      },
+      "spec": {
+        "description": "Enables previous SQL data source dataset dropdown behavior",
+        "stage": "preview",
+        "codeowner": "@grafana/dataviz-squad",
+        "frontend": true,
+        "hideFromAdminPage": true
+      }
+    },
+    {
+      "metadata": {
+        "name": "dashboardSceneForViewers",
+        "resourceVersion": "1709568338306",
+        "creationTimestamp": "2024-03-04T16:05:38Z"
+      },
+      "spec": {
+        "description": "Enables dashboard rendering using Scenes for viewer roles",
+        "stage": "experimental",
+        "codeowner": "@grafana/dashboards-squad",
+        "frontend": true
+      }
+    },
+    {
+      "metadata": {
+        "name": "jitterAlertRulesWithinGroups",
+        "resourceVersion": "1709568338306",
+        "creationTimestamp": "2024-03-04T16:05:38Z"
+      },
+      "spec": {
+        "description": "Distributes alert rule evaluations more evenly over time, including spreading out rules within the same group",
+        "stage": "preview",
+        "codeowner": "@grafana/alerting-squad",
+        "requiresRestart": true,
+        "hideFromDocs": true
+      }
+    },
+    {
+      "metadata": {
+        "name": "groupByVariable",
+        "resourceVersion": "1709568338306",
+        "creationTimestamp": "2024-03-04T16:05:38Z"
+      },
+      "spec": {
+        "description": "Enable groupBy variable support in scenes dashboards",
+        "stage": "experimental",
+        "codeowner": "@grafana/dashboards-squad",
+        "hideFromAdminPage": true,
+        "hideFromDocs": true
+      }
+    },
+    {
+      "metadata": {
+        "name": "alertStateHistoryLokiPrimary",
+        "resourceVersion": "1709568338306",
+        "creationTimestamp": "2024-03-04T16:05:38Z"
+      },
+      "spec": {
+        "description": "Enable a remote Loki instance as the primary source for state history reads.",
+        "stage": "experimental",
+        "codeowner": "@grafana/alerting-squad"
+      }
+    },
+    {
+      "metadata": {
+        "name": "grafanaAPIServerWithExperimentalAPIs",
+        "resourceVersion": "1709568338306",
+        "creationTimestamp": "2024-03-04T16:05:38Z"
+      },
+      "spec": {
+        "description": "Register experimental APIs with the k8s API server",
+        "stage": "experimental",
+        "codeowner": "@grafana/grafana-app-platform-squad",
+        "requiresDevMode": true,
+        "requiresRestart": true
+      }
+    },
+    {
+      "metadata": {
+        "name": "lokiQuerySplitting",
+        "resourceVersion": "1709568338306",
+        "creationTimestamp": "2024-03-04T16:05:38Z"
+      },
+      "spec": {
+        "description": "Split large interval queries into subqueries with smaller time intervals",
+        "stage": "GA",
+        "codeowner": "@grafana/observability-logs",
+        "frontend": true,
+        "allowSelfServe": true
+      }
+    },
+    {
+      "metadata": {
+        "name": "enableElasticsearchBackendQuerying",
+        "resourceVersion": "1709568338306",
+        "creationTimestamp": "2024-03-04T16:05:38Z"
+      },
+      "spec": {
+        "description": "Enable the processing of queries and responses in the Elasticsearch data source through backend",
+        "stage": "GA",
+        "codeowner": "@grafana/observability-logs",
+        "allowSelfServe": true
+      }
+    },
+    {
+      "metadata": {
+        "name": "extraThemes",
+        "resourceVersion": "1709568338306",
+        "creationTimestamp": "2024-03-04T16:05:38Z"
+      },
+      "spec": {
+        "description": "Enables extra themes",
+        "stage": "experimental",
+        "codeowner": "@grafana/grafana-frontend-platform",
+        "frontend": true
+      }
+    },
+    {
+      "metadata": {
+        "name": "pluginsAPIMetrics",
+        "resourceVersion": "1709568338306",
+        "creationTimestamp": "2024-03-04T16:05:38Z"
+      },
+      "spec": {
+        "description": "Sends metrics of public grafana packages usage by plugins",
+        "stage": "experimental",
+        "codeowner": "@grafana/plugins-platform-backend",
+        "frontend": true
+      }
+    },
+    {
+      "metadata": {
+        "name": "sqlExpressions",
+        "resourceVersion": "1709568338306",
+        "creationTimestamp": "2024-03-04T16:05:38Z"
+      },
+      "spec": {
+        "description": "Enables using SQL and DuckDB functions as Expressions.",
+        "stage": "experimental",
+        "codeowner": "@grafana/grafana-app-platform-squad"
+      }
+    },
+    {
+      "metadata": {
+        "name": "datasourceQueryMultiStatus",
+        "resourceVersion": "1709568338306",
+        "creationTimestamp": "2024-03-04T16:05:38Z"
+      },
+      "spec": {
+        "description": "Introduce HTTP 207 Multi Status for api/ds/query",
+        "stage": "experimental",
+        "codeowner": "@grafana/plugins-platform-backend"
+      }
+    },
+    {
+      "metadata": {
+        "name": "editPanelCSVDragAndDrop",
+        "resourceVersion": "1709568338306",
+        "creationTimestamp": "2024-03-04T16:05:38Z"
+      },
+      "spec": {
+        "description": "Enables drag and drop for CSV and Excel files",
+        "stage": "experimental",
+        "codeowner": "@grafana/dataviz-squad",
+        "frontend": true
+      }
+    },
+    {
+      "metadata": {
+        "name": "influxqlStreamingParser",
+        "resourceVersion": "1709568338306",
+        "creationTimestamp": "2024-03-04T16:05:38Z"
+      },
+      "spec": {
+        "description": "Enable streaming JSON parser for InfluxDB datasource InfluxQL query language",
+        "stage": "experimental",
+        "codeowner": "@grafana/observability-metrics"
+      }
+    },
+    {
+      "metadata": {
+        "name": "pluginsDynamicAngularDetectionPatterns",
+        "resourceVersion": "1709568338306",
+        "creationTimestamp": "2024-03-04T16:05:38Z"
+      },
+      "spec": {
+        "description": "Enables fetching Angular detection patterns for plugins from GCOM and fallback to hardcoded ones",
+        "stage": "experimental",
+        "codeowner": "@grafana/plugins-platform-backend"
+      }
+    },
+    {
+      "metadata": {
+        "name": "awsDatasourcesNewFormStyling",
+        "resourceVersion": "1709568338306",
+        "creationTimestamp": "2024-03-04T16:05:38Z"
+      },
+      "spec": {
+        "description": "Applies new form styling for configuration and query editors in AWS plugins",
+        "stage": "preview",
+        "codeowner": "@grafana/aws-datasources",
+        "frontend": true
+      }
+    },
+    {
+      "metadata": {
         "name": "datatrails",
-        "resourceVersion": "1708108588074",
-        "creationTimestamp": "2024-02-16T18:36:28Z"
+        "resourceVersion": "1709568338306",
+        "creationTimestamp": "2024-03-04T16:05:38Z"
       },
       "spec": {
         "description": "Enables the new core app datatrails",
@@ -2111,30 +1291,784 @@
     },
     {
       "metadata": {
-        "name": "editPanelCSVDragAndDrop",
-        "resourceVersion": "1708108588074",
-        "creationTimestamp": "2024-02-16T18:36:28Z"
+        "name": "alertingUpgradeDryrunOnStart",
+        "resourceVersion": "1709568338306",
+        "creationTimestamp": "2024-03-04T16:05:38Z"
       },
       "spec": {
-        "description": "Enables drag and drop for CSV and Excel files",
-        "stage": "experimental",
+        "description": "When activated in legacy alerting mode, this initiates a dry-run of the Unified Alerting upgrade during each startup. It logs any issues detected without implementing any actual changes.",
+        "stage": "GA",
+        "codeowner": "@grafana/alerting-squad",
+        "requiresRestart": true
+      }
+    },
+    {
+      "metadata": {
+        "name": "autoMigrateGraphPanel",
+        "resourceVersion": "1709568338306",
+        "creationTimestamp": "2024-03-04T16:05:38Z"
+      },
+      "spec": {
+        "description": "Migrate old graph panel to supported time series panel - broken out from autoMigrateOldPanels to enable granular tracking",
+        "stage": "preview",
         "codeowner": "@grafana/dataviz-squad",
         "frontend": true
       }
     },
     {
       "metadata": {
-        "name": "sqlExpressions",
-        "resourceVersion": "1709044973784",
-        "creationTimestamp": "2024-02-19T22:46:11Z",
-        "annotations": {
-          "grafana.app/updatedTimestamp": "2024-02-27 14:42:53.784398 +0000 UTC"
-        }
+        "name": "lokiQuerySplittingConfig",
+        "resourceVersion": "1709568338306",
+        "creationTimestamp": "2024-03-04T16:05:38Z"
       },
       "spec": {
-        "description": "Enables using SQL and DuckDB functions as Expressions.",
+        "description": "Give users the option to configure split durations for Loki queries",
         "stage": "experimental",
-        "codeowner": "@grafana/grafana-app-platform-squad"
+        "codeowner": "@grafana/observability-logs",
+        "frontend": true
+      }
+    },
+    {
+      "metadata": {
+        "name": "influxdbBackendMigration",
+        "resourceVersion": "1709568338306",
+        "creationTimestamp": "2024-03-04T16:05:38Z"
+      },
+      "spec": {
+        "description": "Query InfluxDB InfluxQL without the proxy",
+        "stage": "GA",
+        "codeowner": "@grafana/observability-metrics",
+        "frontend": true
+      }
+    },
+    {
+      "metadata": {
+        "name": "lokiMetricDataplane",
+        "resourceVersion": "1709568338306",
+        "creationTimestamp": "2024-03-04T16:05:38Z"
+      },
+      "spec": {
+        "description": "Changes metric responses from Loki to be compliant with the dataplane specification.",
+        "stage": "GA",
+        "codeowner": "@grafana/observability-logs",
+        "allowSelfServe": true
+      }
+    },
+    {
+      "metadata": {
+        "name": "faroDatasourceSelector",
+        "resourceVersion": "1709568338306",
+        "creationTimestamp": "2024-03-04T16:05:38Z"
+      },
+      "spec": {
+        "description": "Enable the data source selector within the Frontend Apps section of the Frontend Observability",
+        "stage": "preview",
+        "codeowner": "@grafana/app-o11y",
+        "frontend": true
+      }
+    },
+    {
+      "metadata": {
+        "name": "alertmanagerRemotePrimary",
+        "resourceVersion": "1709568338306",
+        "creationTimestamp": "2024-03-04T16:05:38Z"
+      },
+      "spec": {
+        "description": "Enable Grafana to have a remote Alertmanager instance as the primary Alertmanager.",
+        "stage": "experimental",
+        "codeowner": "@grafana/alerting-squad"
+      }
+    },
+    {
+      "metadata": {
+        "name": "promQLScope",
+        "resourceVersion": "1709568338306",
+        "creationTimestamp": "2024-03-04T16:05:38Z"
+      },
+      "spec": {
+        "description": "In-development feature that will allow injection of labels into prometheus queries.",
+        "stage": "experimental",
+        "codeowner": "@grafana/observability-metrics"
+      }
+    },
+    {
+      "metadata": {
+        "name": "nodeGraphDotLayout",
+        "resourceVersion": "1709568338306",
+        "creationTimestamp": "2024-03-04T16:05:38Z"
+      },
+      "spec": {
+        "description": "Changed the layout algorithm for the node graph",
+        "stage": "experimental",
+        "codeowner": "@grafana/observability-traces-and-profiling",
+        "frontend": true
+      }
+    },
+    {
+      "metadata": {
+        "name": "panelTitleSearch",
+        "resourceVersion": "1709568338306",
+        "creationTimestamp": "2024-03-04T16:05:38Z"
+      },
+      "spec": {
+        "description": "Search for dashboards using panel title",
+        "stage": "preview",
+        "codeowner": "@grafana/grafana-app-platform-squad",
+        "hideFromAdminPage": true
+      }
+    },
+    {
+      "metadata": {
+        "name": "alertingBacktesting",
+        "resourceVersion": "1709568338306",
+        "creationTimestamp": "2024-03-04T16:05:38Z"
+      },
+      "spec": {
+        "description": "Rule backtesting API for alerting",
+        "stage": "experimental",
+        "codeowner": "@grafana/alerting-squad"
+      }
+    },
+    {
+      "metadata": {
+        "name": "logRowsPopoverMenu",
+        "resourceVersion": "1709568338306",
+        "creationTimestamp": "2024-03-04T16:05:38Z"
+      },
+      "spec": {
+        "description": "Enable filtering menu displayed when text of a log line is selected",
+        "stage": "GA",
+        "codeowner": "@grafana/observability-logs",
+        "frontend": true
+      }
+    },
+    {
+      "metadata": {
+        "name": "logRequestsInstrumentedAsUnknown",
+        "resourceVersion": "1709568338306",
+        "creationTimestamp": "2024-03-04T16:05:38Z"
+      },
+      "spec": {
+        "description": "Logs the path for requests that are instrumented as unknown",
+        "stage": "experimental",
+        "codeowner": "@grafana/hosted-grafana-team"
+      }
+    },
+    {
+      "metadata": {
+        "name": "logsContextDatasourceUi",
+        "resourceVersion": "1709568338306",
+        "creationTimestamp": "2024-03-04T16:05:38Z"
+      },
+      "spec": {
+        "description": "Allow datasource to provide custom UI for context view",
+        "stage": "GA",
+        "codeowner": "@grafana/observability-logs",
+        "frontend": true,
+        "allowSelfServe": true
+      }
+    },
+    {
+      "metadata": {
+        "name": "cloudWatchWildCardDimensionValues",
+        "resourceVersion": "1709568338306",
+        "creationTimestamp": "2024-03-04T16:05:38Z"
+      },
+      "spec": {
+        "description": "Fetches dimension values from CloudWatch to correctly label wildcard dimensions",
+        "stage": "GA",
+        "codeowner": "@grafana/aws-datasources",
+        "allowSelfServe": true
+      }
+    },
+    {
+      "metadata": {
+        "name": "lokiQueryHints",
+        "resourceVersion": "1709568338306",
+        "creationTimestamp": "2024-03-04T16:05:38Z"
+      },
+      "spec": {
+        "description": "Enables query hints for Loki",
+        "stage": "GA",
+        "codeowner": "@grafana/observability-logs",
+        "frontend": true
+      }
+    },
+    {
+      "metadata": {
+        "name": "awsAsyncQueryCaching",
+        "resourceVersion": "1709568338306",
+        "creationTimestamp": "2024-03-04T16:05:38Z"
+      },
+      "spec": {
+        "description": "Enable caching for async queries for Redshift and Athena. Requires that the datasource has caching and async query support enabled",
+        "stage": "GA",
+        "codeowner": "@grafana/aws-datasources"
+      }
+    },
+    {
+      "metadata": {
+        "name": "angularDeprecationUI",
+        "resourceVersion": "1709568338306",
+        "creationTimestamp": "2024-03-04T16:05:38Z"
+      },
+      "spec": {
+        "description": "Display Angular warnings in dashboards and panels",
+        "stage": "GA",
+        "codeowner": "@grafana/plugins-platform-backend",
+        "frontend": true
+      }
+    },
+    {
+      "metadata": {
+        "name": "grafanaAPIServerEnsureKubectlAccess",
+        "resourceVersion": "1709568338306",
+        "creationTimestamp": "2024-03-04T16:05:38Z"
+      },
+      "spec": {
+        "description": "Start an additional https handler and write kubectl options",
+        "stage": "experimental",
+        "codeowner": "@grafana/grafana-app-platform-squad",
+        "requiresDevMode": true,
+        "requiresRestart": true
+      }
+    },
+    {
+      "metadata": {
+        "name": "externalServiceAccounts",
+        "resourceVersion": "1709568338306",
+        "creationTimestamp": "2024-03-04T16:05:38Z"
+      },
+      "spec": {
+        "description": "Automatic service account and token setup for plugins",
+        "stage": "preview",
+        "codeowner": "@grafana/identity-access-team",
+        "hideFromAdminPage": true
+      }
+    },
+    {
+      "metadata": {
+        "name": "cloudWatchBatchQueries",
+        "resourceVersion": "1709568338306",
+        "creationTimestamp": "2024-03-04T16:05:38Z"
+      },
+      "spec": {
+        "description": "Runs CloudWatch metrics queries as separate batches",
+        "stage": "preview",
+        "codeowner": "@grafana/aws-datasources"
+      }
+    },
+    {
+      "metadata": {
+        "name": "dashboardSceneSolo",
+        "resourceVersion": "1709568338306",
+        "creationTimestamp": "2024-03-04T16:05:38Z"
+      },
+      "spec": {
+        "description": "Enables rendering dashboards using scenes for solo panels",
+        "stage": "experimental",
+        "codeowner": "@grafana/dashboards-squad",
+        "frontend": true
+      }
+    },
+    {
+      "metadata": {
+        "name": "autoMigrateOldPanels",
+        "resourceVersion": "1709568338306",
+        "creationTimestamp": "2024-03-04T16:05:38Z"
+      },
+      "spec": {
+        "description": "Migrate old angular panels to supported versions (graph, table-old, worldmap, etc)",
+        "stage": "preview",
+        "codeowner": "@grafana/dataviz-squad",
+        "frontend": true
+      }
+    },
+    {
+      "metadata": {
+        "name": "redshiftAsyncQueryDataSupport",
+        "resourceVersion": "1709568338306",
+        "creationTimestamp": "2024-03-04T16:05:38Z"
+      },
+      "spec": {
+        "description": "Enable async query data support for Redshift",
+        "stage": "GA",
+        "codeowner": "@grafana/aws-datasources"
+      }
+    },
+    {
+      "metadata": {
+        "name": "configurableSchedulerTick",
+        "resourceVersion": "1709568338306",
+        "creationTimestamp": "2024-03-04T16:05:38Z"
+      },
+      "spec": {
+        "description": "Enable changing the scheduler base interval via configuration option unified_alerting.scheduler_tick_interval",
+        "stage": "experimental",
+        "codeowner": "@grafana/alerting-squad",
+        "requiresRestart": true,
+        "hideFromDocs": true
+      }
+    },
+    {
+      "metadata": {
+        "name": "alertingInsights",
+        "resourceVersion": "1709568338306",
+        "creationTimestamp": "2024-03-04T16:05:38Z"
+      },
+      "spec": {
+        "description": "Show the new alerting insights landing page",
+        "stage": "GA",
+        "codeowner": "@grafana/alerting-squad",
+        "frontend": true,
+        "hideFromAdminPage": true
+      }
+    },
+    {
+      "metadata": {
+        "name": "cachingOptimizeSerializationMemoryUsage",
+        "resourceVersion": "1709568338306",
+        "creationTimestamp": "2024-03-04T16:05:38Z"
+      },
+      "spec": {
+        "description": "If enabled, the caching backend gradually serializes query responses for the cache, comparing against the configured `[caching]max_value_mb` value as it goes. This can can help prevent Grafana from running out of memory while attempting to cache very large query responses.",
+        "stage": "experimental",
+        "codeowner": "@grafana/grafana-operator-experience-squad"
+      }
+    },
+    {
+      "metadata": {
+        "name": "migrationLocking",
+        "resourceVersion": "1709568338306",
+        "creationTimestamp": "2024-03-04T16:05:38Z"
+      },
+      "spec": {
+        "description": "Lock database during migrations",
+        "stage": "preview",
+        "codeowner": "@grafana/backend-platform"
+      }
+    },
+    {
+      "metadata": {
+        "name": "prometheusConfigOverhaulAuth",
+        "resourceVersion": "1709568338306",
+        "creationTimestamp": "2024-03-04T16:05:38Z"
+      },
+      "spec": {
+        "description": "Update the Prometheus configuration page with the new auth component",
+        "stage": "GA",
+        "codeowner": "@grafana/observability-metrics"
+      }
+    },
+    {
+      "metadata": {
+        "name": "traceQLStreaming",
+        "resourceVersion": "1709568338306",
+        "creationTimestamp": "2024-03-04T16:05:38Z"
+      },
+      "spec": {
+        "description": "Enables response streaming of TraceQL queries of the Tempo data source",
+        "stage": "experimental",
+        "codeowner": "@grafana/observability-traces-and-profiling",
+        "frontend": true
+      }
+    },
+    {
+      "metadata": {
+        "name": "kubernetesFeatureToggles",
+        "resourceVersion": "1709568338306",
+        "creationTimestamp": "2024-03-04T16:05:38Z"
+      },
+      "spec": {
+        "description": "Use the kubernetes API for feature toggle management in the frontend",
+        "stage": "experimental",
+        "codeowner": "@grafana/grafana-operator-experience-squad",
+        "frontend": true,
+        "hideFromAdminPage": true
+      }
+    },
+    {
+      "metadata": {
+        "name": "autoMigrateStatPanel",
+        "resourceVersion": "1709568338306",
+        "creationTimestamp": "2024-03-04T16:05:38Z"
+      },
+      "spec": {
+        "description": "Migrate old stat panel to supported stat panel - broken out from autoMigrateOldPanels to enable granular tracking",
+        "stage": "preview",
+        "codeowner": "@grafana/dataviz-squad",
+        "frontend": true
+      }
+    },
+    {
+      "metadata": {
+        "name": "accessControlOnCall",
+        "resourceVersion": "1709568338306",
+        "creationTimestamp": "2024-03-04T16:05:38Z"
+      },
+      "spec": {
+        "description": "Access control primitives for OnCall",
+        "stage": "preview",
+        "codeowner": "@grafana/identity-access-team",
+        "hideFromAdminPage": true
+      }
+    },
+    {
+      "metadata": {
+        "name": "alertingNoDataErrorExecution",
+        "resourceVersion": "1709568338306",
+        "creationTimestamp": "2024-03-04T16:05:38Z"
+      },
+      "spec": {
+        "description": "Changes how Alerting state manager handles execution of NoData/Error",
+        "stage": "GA",
+        "codeowner": "@grafana/alerting-squad",
+        "requiresRestart": true
+      }
+    },
+    {
+      "metadata": {
+        "name": "dataplaneFrontendFallback",
+        "resourceVersion": "1709568338306",
+        "creationTimestamp": "2024-03-04T16:05:38Z"
+      },
+      "spec": {
+        "description": "Support dataplane contract field name change for transformations and field name matchers where the name is different",
+        "stage": "GA",
+        "codeowner": "@grafana/observability-metrics",
+        "frontend": true,
+        "allowSelfServe": true
+      }
+    },
+    {
+      "metadata": {
+        "name": "cloudWatchLogsMonacoEditor",
+        "resourceVersion": "1709568338306",
+        "creationTimestamp": "2024-03-04T16:05:38Z"
+      },
+      "spec": {
+        "description": "Enables the Monaco editor for CloudWatch Logs queries",
+        "stage": "GA",
+        "codeowner": "@grafana/aws-datasources",
+        "frontend": true,
+        "allowSelfServe": true
+      }
+    },
+    {
+      "metadata": {
+        "name": "pluginsFrontendSandbox",
+        "resourceVersion": "1709568338306",
+        "creationTimestamp": "2024-03-04T16:05:38Z"
+      },
+      "spec": {
+        "description": "Enables the plugins frontend sandbox",
+        "stage": "experimental",
+        "codeowner": "@grafana/plugins-platform-backend",
+        "frontend": true
+      }
+    },
+    {
+      "metadata": {
+        "name": "lokiFormatQuery",
+        "resourceVersion": "1709568338306",
+        "creationTimestamp": "2024-03-04T16:05:38Z"
+      },
+      "spec": {
+        "description": "Enables the ability to format Loki queries",
+        "stage": "experimental",
+        "codeowner": "@grafana/observability-logs",
+        "frontend": true
+      }
+    },
+    {
+      "metadata": {
+        "name": "recoveryThreshold",
+        "resourceVersion": "1709568338306",
+        "creationTimestamp": "2024-03-04T16:05:38Z"
+      },
+      "spec": {
+        "description": "Enables feature recovery threshold (aka hysteresis) for threshold server-side expression",
+        "stage": "GA",
+        "codeowner": "@grafana/alerting-squad",
+        "requiresRestart": true
+      }
+    },
+    {
+      "metadata": {
+        "name": "logsInfiniteScrolling",
+        "resourceVersion": "1709568338306",
+        "creationTimestamp": "2024-03-04T16:05:38Z"
+      },
+      "spec": {
+        "description": "Enables infinite scrolling for the Logs panel in Explore and Dashboards",
+        "stage": "experimental",
+        "codeowner": "@grafana/observability-logs",
+        "frontend": true
+      }
+    },
+    {
+      "metadata": {
+        "name": "removeCustomScrollbars",
+        "resourceVersion": "1709568338306",
+        "creationTimestamp": "2024-03-04T16:05:38Z"
+      },
+      "spec": {
+        "description": "Removes CustomScrollbar from the UI, relying on native browser scrollbars",
+        "stage": "experimental",
+        "codeowner": "@grafana/grafana-frontend-platform",
+        "frontend": true
+      }
+    },
+    {
+      "metadata": {
+        "name": "queryOverLive",
+        "resourceVersion": "1709568338306",
+        "creationTimestamp": "2024-03-04T16:05:38Z"
+      },
+      "spec": {
+        "description": "Use Grafana Live WebSocket to execute backend queries",
+        "stage": "experimental",
+        "codeowner": "@grafana/grafana-app-platform-squad",
+        "frontend": true
+      }
+    },
+    {
+      "metadata": {
+        "name": "autoMigrateTablePanel",
+        "resourceVersion": "1709568338306",
+        "creationTimestamp": "2024-03-04T16:05:38Z"
+      },
+      "spec": {
+        "description": "Migrate old table panel to supported table panel - broken out from autoMigrateOldPanels to enable granular tracking",
+        "stage": "preview",
+        "codeowner": "@grafana/dataviz-squad",
+        "frontend": true
+      }
+    },
+    {
+      "metadata": {
+        "name": "lokiStructuredMetadata",
+        "resourceVersion": "1709568338306",
+        "creationTimestamp": "2024-03-04T16:05:38Z"
+      },
+      "spec": {
+        "description": "Enables the loki data source to request structured metadata from the Loki server",
+        "stage": "GA",
+        "codeowner": "@grafana/observability-logs"
+      }
+    },
+    {
+      "metadata": {
+        "name": "regressionTransformation",
+        "resourceVersion": "1709568338306",
+        "creationTimestamp": "2024-03-04T16:05:38Z"
+      },
+      "spec": {
+        "description": "Enables regression analysis transformation",
+        "stage": "preview",
+        "codeowner": "@grafana/dataviz-squad",
+        "frontend": true
+      }
+    },
+    {
+      "metadata": {
+        "name": "topnav",
+        "resourceVersion": "1709568338306",
+        "creationTimestamp": "2024-03-04T16:05:38Z"
+      },
+      "spec": {
+        "description": "Enables topnav support in external plugins. The new Grafana navigation cannot be disabled.",
+        "stage": "deprecated",
+        "codeowner": "@grafana/grafana-frontend-platform"
+      }
+    },
+    {
+      "metadata": {
+        "name": "kubernetesSnapshots",
+        "resourceVersion": "1709568338306",
+        "creationTimestamp": "2024-03-04T16:05:38Z"
+      },
+      "spec": {
+        "description": "Routes snapshot requests from /api to the /apis endpoint",
+        "stage": "experimental",
+        "codeowner": "@grafana/grafana-app-platform-squad",
+        "requiresRestart": true
+      }
+    },
+    {
+      "metadata": {
+        "name": "teamHttpHeaders",
+        "resourceVersion": "1709568338306",
+        "creationTimestamp": "2024-03-04T16:05:38Z"
+      },
+      "spec": {
+        "description": "Enables Team LBAC for datasources to apply team headers to the client requests",
+        "stage": "preview",
+        "codeowner": "@grafana/identity-access-team"
+      }
+    },
+    {
+      "metadata": {
+        "name": "newPDFRendering",
+        "resourceVersion": "1709568338306",
+        "creationTimestamp": "2024-03-04T16:05:38Z"
+      },
+      "spec": {
+        "description": "New implementation for the dashboard to PDF rendering",
+        "stage": "experimental",
+        "codeowner": "@grafana/sharing-squad"
+      }
+    },
+    {
+      "metadata": {
+        "name": "lokiExperimentalStreaming",
+        "resourceVersion": "1709568338306",
+        "creationTimestamp": "2024-03-04T16:05:38Z"
+      },
+      "spec": {
+        "description": "Support new streaming approach for loki (prototype, needs special loki build)",
+        "stage": "experimental",
+        "codeowner": "@grafana/observability-logs"
+      }
+    },
+    {
+      "metadata": {
+        "name": "reportingRetries",
+        "resourceVersion": "1709568338306",
+        "creationTimestamp": "2024-03-04T16:05:38Z"
+      },
+      "spec": {
+        "description": "Enables rendering retries for the reporting feature",
+        "stage": "preview",
+        "codeowner": "@grafana/sharing-squad",
+        "requiresRestart": true
+      }
+    },
+    {
+      "metadata": {
+        "name": "prometheusMetricEncyclopedia",
+        "resourceVersion": "1709568338306",
+        "creationTimestamp": "2024-03-04T16:05:38Z"
+      },
+      "spec": {
+        "description": "Adds the metrics explorer component to the Prometheus query builder as an option in metric select",
+        "stage": "GA",
+        "codeowner": "@grafana/observability-metrics",
+        "frontend": true,
+        "allowSelfServe": true
+      }
+    },
+    {
+      "metadata": {
+        "name": "recordedQueriesMulti",
+        "resourceVersion": "1709568338306",
+        "creationTimestamp": "2024-03-04T16:05:38Z"
+      },
+      "spec": {
+        "description": "Enables writing multiple items from a single query within Recorded Queries",
+        "stage": "GA",
+        "codeowner": "@grafana/observability-metrics"
+      }
+    },
+    {
+      "metadata": {
+        "name": "awsDatasourcesTempCredentials",
+        "resourceVersion": "1709568338306",
+        "creationTimestamp": "2024-03-04T16:05:38Z"
+      },
+      "spec": {
+        "description": "Support temporary security credentials in AWS plugins for Grafana Cloud customers",
+        "stage": "experimental",
+        "codeowner": "@grafana/aws-datasources"
+      }
+    },
+    {
+      "metadata": {
+        "name": "mlExpressions",
+        "resourceVersion": "1709568338306",
+        "creationTimestamp": "2024-03-04T16:05:38Z"
+      },
+      "spec": {
+        "description": "Enable support for Machine Learning in server-side expressions",
+        "stage": "experimental",
+        "codeowner": "@grafana/alerting-squad"
+      }
+    },
+    {
+      "metadata": {
+        "name": "featureToggleAdminPage",
+        "resourceVersion": "1709568338306",
+        "creationTimestamp": "2024-03-04T16:05:38Z"
+      },
+      "spec": {
+        "description": "Enable admin page for managing feature toggles from the Grafana front-end",
+        "stage": "experimental",
+        "codeowner": "@grafana/grafana-operator-experience-squad",
+        "requiresRestart": true
+      }
+    },
+    {
+      "metadata": {
+        "name": "panelMonitoring",
+        "resourceVersion": "1709568338306",
+        "creationTimestamp": "2024-03-04T16:05:38Z"
+      },
+      "spec": {
+        "description": "Enables panel monitoring through logs and measurements",
+        "stage": "GA",
+        "codeowner": "@grafana/dataviz-squad",
+        "frontend": true
+      }
+    },
+    {
+      "metadata": {
+        "name": "scenes",
+        "resourceVersion": "1709568338306",
+        "creationTimestamp": "2024-03-04T16:05:38Z"
+      },
+      "spec": {
+        "description": "Experimental framework to build interactive dashboards",
+        "stage": "experimental",
+        "codeowner": "@grafana/dashboards-squad",
+        "frontend": true
+      }
+    },
+    {
+      "metadata": {
+        "name": "mysqlAnsiQuotes",
+        "resourceVersion": "1709568338306",
+        "creationTimestamp": "2024-03-04T16:05:38Z"
+      },
+      "spec": {
+        "description": "Use double quotes to escape keyword in a MySQL query",
+        "stage": "experimental",
+        "codeowner": "@grafana/backend-platform"
+      }
+    },
+    {
+      "metadata": {
+        "name": "panelFilterVariable",
+        "resourceVersion": "1709568338306",
+        "creationTimestamp": "2024-03-04T16:05:38Z"
+      },
+      "spec": {
+        "description": "Enables use of the `systemPanelFilterVar` variable to filter panels in a dashboard",
+        "stage": "experimental",
+        "codeowner": "@grafana/dashboards-squad",
+        "frontend": true,
+        "hideFromDocs": true
+      }
+    },
+    {
+      "metadata": {
+        "name": "alertingSaveStatePeriodic",
+        "resourceVersion": "1709568338306",
+        "creationTimestamp": "2024-03-04T16:05:38Z"
+      },
+      "spec": {
+        "description": "Writes the state periodically to the database, asynchronous to rule evaluation",
+        "stage": "privatePreview",
+        "codeowner": "@grafana/alerting-squad"
       }
     }
   ]

--- a/pkg/services/featuremgmt/toggles_gen.json
+++ b/pkg/services/featuremgmt/toggles_gen.json
@@ -5,529 +5,37 @@
   "items": [
     {
       "metadata": {
-        "name": "autoMigratePiechartPanel",
-        "resourceVersion": "1709568338306",
-        "creationTimestamp": "2024-03-04T16:05:38Z"
+        "name": "recoveryThreshold",
+        "resourceVersion": "1708108588074",
+        "creationTimestamp": "2024-02-16T18:36:28Z"
       },
       "spec": {
-        "description": "Migrate old piechart panel to supported piechart panel - broken out from autoMigrateOldPanels to enable granular tracking",
-        "stage": "preview",
-        "codeowner": "@grafana/dataviz-squad",
-        "frontend": true
-      }
-    },
-    {
-      "metadata": {
-        "name": "grpcServer",
-        "resourceVersion": "1709568338306",
-        "creationTimestamp": "2024-03-04T16:05:38Z"
-      },
-      "spec": {
-        "description": "Run the GRPC server",
-        "stage": "preview",
-        "codeowner": "@grafana/grafana-app-platform-squad",
-        "hideFromAdminPage": true
-      }
-    },
-    {
-      "metadata": {
-        "name": "prometheusDataplane",
-        "resourceVersion": "1709568338306",
-        "creationTimestamp": "2024-03-04T16:05:38Z"
-      },
-      "spec": {
-        "description": "Changes responses to from Prometheus to be compliant with the dataplane specification. In particular, when this feature toggle is active, the numeric `Field.Name` is set from 'Value' to the value of the `__name__` label.",
+        "description": "Enables feature recovery threshold (aka hysteresis) for threshold server-side expression",
         "stage": "GA",
-        "codeowner": "@grafana/observability-metrics",
-        "allowSelfServe": true
-      }
-    },
-    {
-      "metadata": {
-        "name": "alertStateHistoryLokiSecondary",
-        "resourceVersion": "1709568338306",
-        "creationTimestamp": "2024-03-04T16:05:38Z"
-      },
-      "spec": {
-        "description": "Enable Grafana to write alert state history to an external Loki instance in addition to Grafana annotations.",
-        "stage": "experimental",
-        "codeowner": "@grafana/alerting-squad"
-      }
-    },
-    {
-      "metadata": {
-        "name": "frontendSandboxMonitorOnly",
-        "resourceVersion": "1709568338306",
-        "creationTimestamp": "2024-03-04T16:05:38Z"
-      },
-      "spec": {
-        "description": "Enables monitor only in the plugin frontend sandbox (if enabled)",
-        "stage": "experimental",
-        "codeowner": "@grafana/plugins-platform-backend",
-        "frontend": true
-      }
-    },
-    {
-      "metadata": {
-        "name": "dashgpt",
-        "resourceVersion": "1709568338306",
-        "creationTimestamp": "2024-03-04T16:05:38Z"
-      },
-      "spec": {
-        "description": "Enable AI powered features in dashboards",
-        "stage": "preview",
-        "codeowner": "@grafana/dashboards-squad",
-        "frontend": true
-      }
-    },
-    {
-      "metadata": {
-        "name": "live-service-web-worker",
-        "resourceVersion": "1709568338306",
-        "creationTimestamp": "2024-03-04T16:05:38Z"
-      },
-      "spec": {
-        "description": "This will use a webworker thread to processes events rather than the main thread",
-        "stage": "experimental",
-        "codeowner": "@grafana/grafana-app-platform-squad",
-        "frontend": true
-      }
-    },
-    {
-      "metadata": {
-        "name": "featureHighlights",
-        "resourceVersion": "1709568338306",
-        "creationTimestamp": "2024-03-04T16:05:38Z"
-      },
-      "spec": {
-        "description": "Highlight Grafana Enterprise features",
-        "stage": "GA",
-        "codeowner": "@grafana/grafana-as-code",
-        "allowSelfServe": true
-      }
-    },
-    {
-      "metadata": {
-        "name": "onPremToCloudMigrations",
-        "resourceVersion": "1709568338306",
-        "creationTimestamp": "2024-03-04T16:05:38Z"
-      },
-      "spec": {
-        "description": "In-development feature that will allow users to easily migrate their on-prem Grafana instances to Grafana Cloud.",
-        "stage": "experimental",
-        "codeowner": "@grafana/grafana-operator-experience-squad"
-      }
-    },
-    {
-      "metadata": {
-        "name": "extractFieldsNameDeduplication",
-        "resourceVersion": "1709568338306",
-        "creationTimestamp": "2024-03-04T16:05:38Z"
-      },
-      "spec": {
-        "description": "Make sure extracted field names are unique in the dataframe",
-        "stage": "experimental",
-        "codeowner": "@grafana/dataviz-squad",
-        "frontend": true
-      }
-    },
-    {
-      "metadata": {
-        "name": "ssoSettingsApi",
-        "resourceVersion": "1709568338306",
-        "creationTimestamp": "2024-03-04T16:05:38Z"
-      },
-      "spec": {
-        "description": "Enables the SSO settings API and the OAuth configuration UIs in Grafana",
-        "stage": "preview",
-        "codeowner": "@grafana/identity-access-team",
-        "allowSelfServe": true
-      }
-    },
-    {
-      "metadata": {
-        "name": "prometheusIncrementalQueryInstrumentation",
-        "resourceVersion": "1709568338306",
-        "creationTimestamp": "2024-03-04T16:05:38Z"
-      },
-      "spec": {
-        "description": "Adds RudderStack events to incremental queries",
-        "stage": "experimental",
-        "codeowner": "@grafana/observability-metrics",
-        "frontend": true
-      }
-    },
-    {
-      "metadata": {
-        "name": "prometheusPromQAIL",
-        "resourceVersion": "1709568338306",
-        "creationTimestamp": "2024-03-04T16:05:38Z"
-      },
-      "spec": {
-        "description": "Prometheus and AI/ML to assist users in creating a query",
-        "stage": "experimental",
-        "codeowner": "@grafana/observability-metrics",
-        "frontend": true
-      }
-    },
-    {
-      "metadata": {
-        "name": "storage",
-        "resourceVersion": "1709568338306",
-        "creationTimestamp": "2024-03-04T16:05:38Z"
-      },
-      "spec": {
-        "description": "Configurable storage for dashboards, datasources, and resources",
-        "stage": "experimental",
-        "codeowner": "@grafana/grafana-app-platform-squad"
-      }
-    },
-    {
-      "metadata": {
-        "name": "refactorVariablesTimeRange",
-        "resourceVersion": "1709568338306",
-        "creationTimestamp": "2024-03-04T16:05:38Z"
-      },
-      "spec": {
-        "description": "Refactor time range variables flow to reduce number of API calls made when query variables are chained",
-        "stage": "preview",
-        "codeowner": "@grafana/dashboards-squad",
-        "hideFromAdminPage": true
-      }
-    },
-    {
-      "metadata": {
-        "name": "libraryPanelRBAC",
-        "resourceVersion": "1709568338306",
-        "creationTimestamp": "2024-03-04T16:05:38Z"
-      },
-      "spec": {
-        "description": "Enables RBAC support for library panels",
-        "stage": "experimental",
-        "codeowner": "@grafana/dashboards-squad",
+        "codeowner": "@grafana/alerting-squad",
         "requiresRestart": true
       }
     },
     {
       "metadata": {
-        "name": "newVizTooltips",
-        "resourceVersion": "1709568338306",
-        "creationTimestamp": "2024-03-04T16:05:38Z"
+        "name": "teamHttpHeaders",
+        "resourceVersion": "1709290509653",
+        "creationTimestamp": "2024-02-16T18:36:28Z",
+        "annotations": {
+          "grafana.app/updatedTimestamp": "2024-03-01 10:55:09.653587 +0000 UTC"
+        }
       },
       "spec": {
-        "description": "New visualizations tooltips UX",
+        "description": "Enables Team LBAC for datasources to apply team headers to the client requests",
         "stage": "preview",
-        "codeowner": "@grafana/dataviz-squad",
-        "frontend": true
-      }
-    },
-    {
-      "metadata": {
-        "name": "sseGroupByDatasource",
-        "resourceVersion": "1709568338306",
-        "creationTimestamp": "2024-03-04T16:05:38Z"
-      },
-      "spec": {
-        "description": "Send query to the same datasource in a single request when using server side expressions. The `cloudWatchBatchQueries` feature toggle should be enabled if this used with CloudWatch.",
-        "stage": "experimental",
-        "codeowner": "@grafana/observability-metrics"
-      }
-    },
-    {
-      "metadata": {
-        "name": "groupToNestedTableTransformation",
-        "resourceVersion": "1709568338306",
-        "creationTimestamp": "2024-03-04T16:05:38Z"
-      },
-      "spec": {
-        "description": "Enables the group to nested table transformation",
-        "stage": "preview",
-        "codeowner": "@grafana/dataviz-squad",
-        "frontend": true
-      }
-    },
-    {
-      "metadata": {
-        "name": "publicDashboardsEmailSharing",
-        "resourceVersion": "1709568338306",
-        "creationTimestamp": "2024-03-04T16:05:38Z"
-      },
-      "spec": {
-        "description": "Enables public dashboard sharing to be restricted to only allowed emails",
-        "stage": "preview",
-        "codeowner": "@grafana/sharing-squad",
-        "hideFromAdminPage": true,
-        "hideFromDocs": true
-      }
-    },
-    {
-      "metadata": {
-        "name": "enableNativeHTTPHistogram",
-        "resourceVersion": "1709568338306",
-        "creationTimestamp": "2024-03-04T16:05:38Z"
-      },
-      "spec": {
-        "description": "Enables native HTTP Histograms",
-        "stage": "experimental",
-        "codeowner": "@grafana/hosted-grafana-team"
-      }
-    },
-    {
-      "metadata": {
-        "name": "tableSharedCrosshair",
-        "resourceVersion": "1709568338306",
-        "creationTimestamp": "2024-03-04T16:05:38Z"
-      },
-      "spec": {
-        "description": "Enables shared crosshair in table panel",
-        "stage": "experimental",
-        "codeowner": "@grafana/dataviz-squad",
-        "frontend": true
-      }
-    },
-    {
-      "metadata": {
-        "name": "disableSSEDataplane",
-        "resourceVersion": "1709568338306",
-        "creationTimestamp": "2024-03-04T16:05:38Z"
-      },
-      "spec": {
-        "description": "Disables dataplane specific processing in server side expressions.",
-        "stage": "experimental",
-        "codeowner": "@grafana/observability-metrics"
-      }
-    },
-    {
-      "metadata": {
-        "name": "flameGraphItemCollapsing",
-        "resourceVersion": "1709568338306",
-        "creationTimestamp": "2024-03-04T16:05:38Z"
-      },
-      "spec": {
-        "description": "Allow collapsing of flame graph items",
-        "stage": "experimental",
-        "codeowner": "@grafana/observability-traces-and-profiling",
-        "frontend": true
-      }
-    },
-    {
-      "metadata": {
-        "name": "nestedFolders",
-        "resourceVersion": "1709568338306",
-        "creationTimestamp": "2024-03-04T16:05:38Z"
-      },
-      "spec": {
-        "description": "Enable folder nesting",
-        "stage": "preview",
-        "codeowner": "@grafana/backend-platform"
-      }
-    },
-    {
-      "metadata": {
-        "name": "externalCorePlugins",
-        "resourceVersion": "1709568338306",
-        "creationTimestamp": "2024-03-04T16:05:38Z"
-      },
-      "spec": {
-        "description": "Allow core plugins to be loaded as external",
-        "stage": "experimental",
-        "codeowner": "@grafana/plugins-platform-backend"
-      }
-    },
-    {
-      "metadata": {
-        "name": "annotationPermissionUpdate",
-        "resourceVersion": "1709568338306",
-        "creationTimestamp": "2024-03-04T16:05:38Z"
-      },
-      "spec": {
-        "description": "Separate annotation permissions from dashboard permissions to allow for more granular control.",
-        "stage": "experimental",
         "codeowner": "@grafana/identity-access-team"
       }
     },
     {
       "metadata": {
-        "name": "newFolderPicker",
-        "resourceVersion": "1709568338306",
-        "creationTimestamp": "2024-03-04T16:05:38Z"
-      },
-      "spec": {
-        "description": "Enables the nested folder picker without having nested folders enabled",
-        "stage": "experimental",
-        "codeowner": "@grafana/grafana-frontend-platform",
-        "frontend": true
-      }
-    },
-    {
-      "metadata": {
-        "name": "exploreContentOutline",
-        "resourceVersion": "1709568338306",
-        "creationTimestamp": "2024-03-04T16:05:38Z"
-      },
-      "spec": {
-        "description": "Content outline sidebar",
-        "stage": "GA",
-        "codeowner": "@grafana/explore-squad",
-        "frontend": true,
-        "allowSelfServe": true
-      }
-    },
-    {
-      "metadata": {
-        "name": "disableAngular",
-        "resourceVersion": "1709568338306",
-        "creationTimestamp": "2024-03-04T16:05:38Z"
-      },
-      "spec": {
-        "description": "Dynamic flag to disable angular at runtime. The preferred method is to set `angular_support_enabled` to `false` in the [security] settings, which allows you to change the state at runtime.",
-        "stage": "preview",
-        "codeowner": "@grafana/dataviz-squad",
-        "frontend": true,
-        "hideFromAdminPage": true
-      }
-    },
-    {
-      "metadata": {
-        "name": "wargamesTesting",
-        "resourceVersion": "1709568338306",
-        "creationTimestamp": "2024-03-04T16:05:38Z"
-      },
-      "spec": {
-        "description": "Placeholder feature flag for internal testing",
-        "stage": "experimental",
-        "codeowner": "@grafana/hosted-grafana-team"
-      }
-    },
-    {
-      "metadata": {
-        "name": "alertingNoNormalState",
-        "resourceVersion": "1709568338306",
-        "creationTimestamp": "2024-03-04T16:05:38Z"
-      },
-      "spec": {
-        "description": "Stop maintaining state of alerts that are not firing",
-        "stage": "preview",
-        "codeowner": "@grafana/alerting-squad",
-        "hideFromAdminPage": true
-      }
-    },
-    {
-      "metadata": {
-        "name": "individualCookiePreferences",
-        "resourceVersion": "1709568338306",
-        "creationTimestamp": "2024-03-04T16:05:38Z"
-      },
-      "spec": {
-        "description": "Support overriding cookie preferences per user",
-        "stage": "experimental",
-        "codeowner": "@grafana/backend-platform"
-      }
-    },
-    {
-      "metadata": {
-        "name": "unifiedRequestLog",
-        "resourceVersion": "1709568338306",
-        "creationTimestamp": "2024-03-04T16:05:38Z"
-      },
-      "spec": {
-        "description": "Writes error logs to the request logger",
-        "stage": "experimental",
-        "codeowner": "@grafana/backend-platform"
-      }
-    },
-    {
-      "metadata": {
-        "name": "permissionsFilterRemoveSubquery",
-        "resourceVersion": "1709568338306",
-        "creationTimestamp": "2024-03-04T16:05:38Z"
-      },
-      "spec": {
-        "description": "Alternative permission filter implementation that does not use subqueries for fetching the dashboard folder",
-        "stage": "experimental",
-        "codeowner": "@grafana/backend-platform"
-      }
-    },
-    {
-      "metadata": {
-        "name": "alertmanagerRemoteSecondary",
-        "resourceVersion": "1709568338306",
-        "creationTimestamp": "2024-03-04T16:05:38Z"
-      },
-      "spec": {
-        "description": "Enable Grafana to sync configuration and state with a remote Alertmanager.",
-        "stage": "experimental",
-        "codeowner": "@grafana/alerting-squad"
-      }
-    },
-    {
-      "metadata": {
-        "name": "pdfTables",
-        "resourceVersion": "1709568338306",
-        "creationTimestamp": "2024-03-04T16:05:38Z"
-      },
-      "spec": {
-        "description": "Enables generating table data as PDF in reporting",
-        "stage": "preview",
-        "codeowner": "@grafana/sharing-squad"
-      }
-    },
-    {
-      "metadata": {
-        "name": "correlations",
-        "resourceVersion": "1709568338306",
-        "creationTimestamp": "2024-03-04T16:05:38Z"
-      },
-      "spec": {
-        "description": "Correlations page",
-        "stage": "GA",
-        "codeowner": "@grafana/explore-squad",
-        "allowSelfServe": true
-      }
-    },
-    {
-      "metadata": {
-        "name": "disableSecretsCompatibility",
-        "resourceVersion": "1709568338306",
-        "creationTimestamp": "2024-03-04T16:05:38Z"
-      },
-      "spec": {
-        "description": "Disable duplicated secret storage in legacy tables",
-        "stage": "experimental",
-        "codeowner": "@grafana/hosted-grafana-team",
-        "requiresRestart": true
-      }
-    },
-    {
-      "metadata": {
-        "name": "canvasPanelPanZoom",
-        "resourceVersion": "1709568338306",
-        "creationTimestamp": "2024-03-04T16:05:38Z"
-      },
-      "spec": {
-        "description": "Allow pan and zoom in canvas panel",
-        "stage": "preview",
-        "codeowner": "@grafana/dataviz-squad",
-        "frontend": true
-      }
-    },
-    {
-      "metadata": {
-        "name": "pluginsSkipHostEnvVars",
-        "resourceVersion": "1709568338306",
-        "creationTimestamp": "2024-03-04T16:05:38Z"
-      },
-      "spec": {
-        "description": "Disables passing host environment variable to plugin processes",
-        "stage": "experimental",
-        "codeowner": "@grafana/plugins-platform-backend"
-      }
-    },
-    {
-      "metadata": {
         "name": "logsExploreTableVisualisation",
-        "resourceVersion": "1709568338306",
-        "creationTimestamp": "2024-03-04T16:05:38Z"
+        "resourceVersion": "1708108588074",
+        "creationTimestamp": "2024-02-16T18:36:28Z"
       },
       "spec": {
         "description": "A table visualisation for logs in Explore",
@@ -538,477 +46,59 @@
     },
     {
       "metadata": {
-        "name": "metricsSummary",
-        "resourceVersion": "1709568338306",
-        "creationTimestamp": "2024-03-04T16:05:38Z"
+        "name": "disableSecretsCompatibility",
+        "resourceVersion": "1708108588074",
+        "creationTimestamp": "2024-02-16T18:36:28Z"
       },
       "spec": {
-        "description": "Enables metrics summary queries in the Tempo data source",
+        "description": "Disable duplicated secret storage in legacy tables",
         "stage": "experimental",
-        "codeowner": "@grafana/observability-traces-and-profiling",
-        "frontend": true
+        "codeowner": "@grafana/hosted-grafana-team",
+        "requiresRestart": true
       }
     },
     {
       "metadata": {
-        "name": "managedPluginsInstall",
-        "resourceVersion": "1709568338306",
-        "creationTimestamp": "2024-03-04T16:05:38Z"
+        "name": "alertingBacktesting",
+        "resourceVersion": "1708108588074",
+        "creationTimestamp": "2024-02-16T18:36:28Z"
       },
       "spec": {
-        "description": "Install managed plugins directly from plugins catalog",
-        "stage": "preview",
+        "description": "Rule backtesting API for alerting",
+        "stage": "experimental",
+        "codeowner": "@grafana/alerting-squad"
+      }
+    },
+    {
+      "metadata": {
+        "name": "alertStateHistoryLokiPrimary",
+        "resourceVersion": "1708108588074",
+        "creationTimestamp": "2024-02-16T18:36:28Z"
+      },
+      "spec": {
+        "description": "Enable a remote Loki instance as the primary source for state history reads.",
+        "stage": "experimental",
+        "codeowner": "@grafana/alerting-squad"
+      }
+    },
+    {
+      "metadata": {
+        "name": "pluginsInstrumentationStatusSource",
+        "resourceVersion": "1708108588074",
+        "creationTimestamp": "2024-02-16T18:36:28Z",
+        "deletionTimestamp": "2024-02-29T08:27:47Z"
+      },
+      "spec": {
+        "description": "Include a status source label for plugin request metrics and logs",
+        "stage": "experimental",
         "codeowner": "@grafana/plugins-platform-backend"
       }
     },
     {
       "metadata": {
-        "name": "alertingDetailsViewV2",
-        "resourceVersion": "1709568338306",
-        "creationTimestamp": "2024-03-04T16:05:38Z"
-      },
-      "spec": {
-        "description": "Enables the preview of the new alert details view",
-        "stage": "experimental",
-        "codeowner": "@grafana/alerting-squad",
-        "frontend": true,
-        "hideFromDocs": true
-      }
-    },
-    {
-      "metadata": {
-        "name": "autoMigrateWorldmapPanel",
-        "resourceVersion": "1709568338306",
-        "creationTimestamp": "2024-03-04T16:05:38Z"
-      },
-      "spec": {
-        "description": "Migrate old worldmap panel to supported geomap panel - broken out from autoMigrateOldPanels to enable granular tracking",
-        "stage": "preview",
-        "codeowner": "@grafana/dataviz-squad",
-        "frontend": true
-      }
-    },
-    {
-      "metadata": {
-        "name": "lokiPredefinedOperations",
-        "resourceVersion": "1709568338306",
-        "creationTimestamp": "2024-03-04T16:05:38Z"
-      },
-      "spec": {
-        "description": "Adds predefined query operations to Loki query editor",
-        "stage": "experimental",
-        "codeowner": "@grafana/observability-logs",
-        "frontend": true
-      }
-    },
-    {
-      "metadata": {
-        "name": "enableDatagridEditing",
-        "resourceVersion": "1709568338306",
-        "creationTimestamp": "2024-03-04T16:05:38Z"
-      },
-      "spec": {
-        "description": "Enables the edit functionality in the datagrid panel",
-        "stage": "preview",
-        "codeowner": "@grafana/dataviz-squad",
-        "frontend": true
-      }
-    },
-    {
-      "metadata": {
-        "name": "addFieldFromCalculationStatFunctions",
-        "resourceVersion": "1709568338306",
-        "creationTimestamp": "2024-03-04T16:05:38Z"
-      },
-      "spec": {
-        "description": "Add cumulative and window functions to the add field from calculation transformation",
-        "stage": "preview",
-        "codeowner": "@grafana/dataviz-squad",
-        "frontend": true
-      }
-    },
-    {
-      "metadata": {
-        "name": "idForwarding",
-        "resourceVersion": "1709568338306",
-        "creationTimestamp": "2024-03-04T16:05:38Z"
-      },
-      "spec": {
-        "description": "Generate signed id token for identity that can be forwarded to plugins and external services",
-        "stage": "experimental",
-        "codeowner": "@grafana/identity-access-team"
-      }
-    },
-    {
-      "metadata": {
-        "name": "kubernetesPlaylists",
-        "resourceVersion": "1709568338306",
-        "creationTimestamp": "2024-03-04T16:05:38Z"
-      },
-      "spec": {
-        "description": "Use the kubernetes API in the frontend for playlists, and route /api/playlist requests to k8s",
-        "stage": "experimental",
-        "codeowner": "@grafana/grafana-app-platform-squad",
-        "requiresRestart": true
-      }
-    },
-    {
-      "metadata": {
-        "name": "kubernetesQueryServiceRewrite",
-        "resourceVersion": "1709568338306",
-        "creationTimestamp": "2024-03-04T16:05:38Z"
-      },
-      "spec": {
-        "description": "Rewrite requests targeting /ds/query to the query service",
-        "stage": "experimental",
-        "codeowner": "@grafana/grafana-app-platform-squad",
-        "requiresDevMode": true,
-        "requiresRestart": true
-      }
-    },
-    {
-      "metadata": {
-        "name": "panelTitleSearchInV1",
-        "resourceVersion": "1709568338306",
-        "creationTimestamp": "2024-03-04T16:05:38Z"
-      },
-      "spec": {
-        "description": "Enable searching for dashboards using panel title in search v1",
-        "stage": "experimental",
-        "codeowner": "@grafana/backend-platform",
-        "requiresDevMode": true
-      }
-    },
-    {
-      "metadata": {
-        "name": "dashboardScene",
-        "resourceVersion": "1709568338306",
-        "creationTimestamp": "2024-03-04T16:05:38Z"
-      },
-      "spec": {
-        "description": "Enables dashboard rendering using scenes for all roles",
-        "stage": "experimental",
-        "codeowner": "@grafana/dashboards-squad",
-        "frontend": true
-      }
-    },
-    {
-      "metadata": {
-        "name": "alertingSimplifiedRouting",
-        "resourceVersion": "1709568338306",
-        "creationTimestamp": "2024-03-04T16:05:38Z"
-      },
-      "spec": {
-        "description": "Enables users to easily configure alert notifications by specifying a contact point directly when editing or creating an alert rule",
-        "stage": "preview",
-        "codeowner": "@grafana/alerting-squad"
-      }
-    },
-    {
-      "metadata": {
-        "name": "athenaAsyncQueryDataSupport",
-        "resourceVersion": "1709568338306",
-        "creationTimestamp": "2024-03-04T16:05:38Z"
-      },
-      "spec": {
-        "description": "Enable async query data support for Athena",
-        "stage": "GA",
-        "codeowner": "@grafana/aws-datasources",
-        "frontend": true
-      }
-    },
-    {
-      "metadata": {
-        "name": "lokiRunQueriesInParallel",
-        "resourceVersion": "1709568338306",
-        "creationTimestamp": "2024-03-04T16:05:38Z"
-      },
-      "spec": {
-        "description": "Enables running Loki queries in parallel",
-        "stage": "privatePreview",
-        "codeowner": "@grafana/observability-logs"
-      }
-    },
-    {
-      "metadata": {
-        "name": "transformationsVariableSupport",
-        "resourceVersion": "1709568338306",
-        "creationTimestamp": "2024-03-04T16:05:38Z"
-      },
-      "spec": {
-        "description": "Allows using variables in transformations",
-        "stage": "preview",
-        "codeowner": "@grafana/dataviz-squad",
-        "frontend": true
-      }
-    },
-    {
-      "metadata": {
-        "name": "expressionParser",
-        "resourceVersion": "1709568338306",
-        "creationTimestamp": "2024-03-04T16:05:38Z"
-      },
-      "spec": {
-        "description": "Enable new expression parser",
-        "stage": "experimental",
-        "codeowner": "@grafana/grafana-app-platform-squad",
-        "requiresRestart": true
-      }
-    },
-    {
-      "metadata": {
-        "name": "disableEnvelopeEncryption",
-        "resourceVersion": "1709568338306",
-        "creationTimestamp": "2024-03-04T16:05:38Z"
-      },
-      "spec": {
-        "description": "Disable envelope encryption (emergency only)",
-        "stage": "GA",
-        "codeowner": "@grafana/grafana-as-code",
-        "hideFromAdminPage": true
-      }
-    },
-    {
-      "metadata": {
-        "name": "renderAuthJWT",
-        "resourceVersion": "1709568338306",
-        "creationTimestamp": "2024-03-04T16:05:38Z"
-      },
-      "spec": {
-        "description": "Uses JWT-based auth for rendering instead of relying on remote cache",
-        "stage": "preview",
-        "codeowner": "@grafana/grafana-as-code",
-        "hideFromAdminPage": true
-      }
-    },
-    {
-      "metadata": {
-        "name": "canvasPanelNesting",
-        "resourceVersion": "1709568338306",
-        "creationTimestamp": "2024-03-04T16:05:38Z"
-      },
-      "spec": {
-        "description": "Allow elements nesting",
-        "stage": "experimental",
-        "codeowner": "@grafana/dataviz-squad",
-        "frontend": true,
-        "hideFromAdminPage": true
-      }
-    },
-    {
-      "metadata": {
-        "name": "cloudRBACRoles",
-        "resourceVersion": "1709568338306",
-        "creationTimestamp": "2024-03-04T16:05:38Z"
-      },
-      "spec": {
-        "description": "Enabled grafana cloud specific RBAC roles",
-        "stage": "experimental",
-        "codeowner": "@grafana/identity-access-team",
-        "requiresRestart": true,
-        "hideFromDocs": true
-      }
-    },
-    {
-      "metadata": {
-        "name": "alertStateHistoryLokiOnly",
-        "resourceVersion": "1709568338306",
-        "creationTimestamp": "2024-03-04T16:05:38Z"
-      },
-      "spec": {
-        "description": "Disable Grafana alerts from emitting annotations when a remote Loki instance is available.",
-        "stage": "experimental",
-        "codeowner": "@grafana/alerting-squad"
-      }
-    },
-    {
-      "metadata": {
-        "name": "formatString",
-        "resourceVersion": "1709568338306",
-        "creationTimestamp": "2024-03-04T16:05:38Z"
-      },
-      "spec": {
-        "description": "Enable format string transformer",
-        "stage": "preview",
-        "codeowner": "@grafana/dataviz-squad",
-        "frontend": true
-      }
-    },
-    {
-      "metadata": {
-        "name": "alertingPreviewUpgrade",
-        "resourceVersion": "1709568338306",
-        "creationTimestamp": "2024-03-04T16:05:38Z"
-      },
-      "spec": {
-        "description": "Show Unified Alerting preview and upgrade page in legacy alerting",
-        "stage": "GA",
-        "codeowner": "@grafana/alerting-squad",
-        "requiresRestart": true
-      }
-    },
-    {
-      "metadata": {
-        "name": "publicDashboards",
-        "resourceVersion": "1709568338306",
-        "creationTimestamp": "2024-03-04T16:05:38Z"
-      },
-      "spec": {
-        "description": "[Deprecated] Public dashboards are now enabled by default; to disable them, use the configuration setting. This feature toggle will be removed in the next major version.",
-        "stage": "GA",
-        "codeowner": "@grafana/sharing-squad",
-        "allowSelfServe": true
-      }
-    },
-    {
-      "metadata": {
-        "name": "returnToPrevious",
-        "resourceVersion": "1709568338306",
-        "creationTimestamp": "2024-03-04T16:05:38Z"
-      },
-      "spec": {
-        "description": "Enables the return to previous context functionality",
-        "stage": "preview",
-        "codeowner": "@grafana/grafana-frontend-platform",
-        "frontend": true
-      }
-    },
-    {
-      "metadata": {
-        "name": "showDashboardValidationWarnings",
-        "resourceVersion": "1709568338306",
-        "creationTimestamp": "2024-03-04T16:05:38Z"
-      },
-      "spec": {
-        "description": "Show warnings when dashboards do not validate against the schema",
-        "stage": "experimental",
-        "codeowner": "@grafana/dashboards-squad"
-      }
-    },
-    {
-      "metadata": {
-        "name": "lokiLogsDataplane",
-        "resourceVersion": "1709568338306",
-        "creationTimestamp": "2024-03-04T16:05:38Z"
-      },
-      "spec": {
-        "description": "Changes logs responses from Loki to be compliant with the dataplane specification.",
-        "stage": "experimental",
-        "codeowner": "@grafana/observability-logs"
-      }
-    },
-    {
-      "metadata": {
-        "name": "transformationsRedesign",
-        "resourceVersion": "1709568338306",
-        "creationTimestamp": "2024-03-04T16:05:38Z"
-      },
-      "spec": {
-        "description": "Enables the transformations redesign",
-        "stage": "GA",
-        "codeowner": "@grafana/observability-metrics",
-        "frontend": true,
-        "allowSelfServe": true
-      }
-    },
-    {
-      "metadata": {
-        "name": "influxdbSqlSupport",
-        "resourceVersion": "1709568338306",
-        "creationTimestamp": "2024-03-04T16:05:38Z"
-      },
-      "spec": {
-        "description": "Enable InfluxDB SQL query language support with new querying UI",
-        "stage": "GA",
-        "codeowner": "@grafana/observability-metrics",
-        "requiresRestart": true,
-        "allowSelfServe": true
-      }
-    },
-    {
-      "metadata": {
-        "name": "unifiedStorage",
-        "resourceVersion": "1709568338306",
-        "creationTimestamp": "2024-03-04T16:05:38Z"
-      },
-      "spec": {
-        "description": "SQL-based k8s storage",
-        "stage": "experimental",
-        "codeowner": "@grafana/grafana-app-platform-squad",
-        "requiresDevMode": true,
-        "requiresRestart": true
-      }
-    },
-    {
-      "metadata": {
-        "name": "cloudWatchCrossAccountQuerying",
-        "resourceVersion": "1709568338306",
-        "creationTimestamp": "2024-03-04T16:05:38Z"
-      },
-      "spec": {
-        "description": "Enables cross-account querying in CloudWatch datasources",
-        "stage": "GA",
-        "codeowner": "@grafana/aws-datasources",
-        "allowSelfServe": true
-      }
-    },
-    {
-      "metadata": {
-        "name": "vizAndWidgetSplit",
-        "resourceVersion": "1709568338306",
-        "creationTimestamp": "2024-03-04T16:05:38Z"
-      },
-      "spec": {
-        "description": "Split panels between visualizations and widgets",
-        "stage": "experimental",
-        "codeowner": "@grafana/dashboards-squad",
-        "frontend": true
-      }
-    },
-    {
-      "metadata": {
-        "name": "nestedFolderPicker",
-        "resourceVersion": "1709568338306",
-        "creationTimestamp": "2024-03-04T16:05:38Z"
-      },
-      "spec": {
-        "description": "Enables the new folder picker to work with nested folders. Requires the nestedFolders feature toggle",
-        "stage": "GA",
-        "codeowner": "@grafana/grafana-frontend-platform",
-        "frontend": true,
-        "allowSelfServe": true
-      }
-    },
-    {
-      "metadata": {
-        "name": "exploreScrollableLogsContainer",
-        "resourceVersion": "1709568338306",
-        "creationTimestamp": "2024-03-04T16:05:38Z"
-      },
-      "spec": {
-        "description": "Improves the scrolling behavior of logs in Explore",
-        "stage": "experimental",
-        "codeowner": "@grafana/observability-logs",
-        "frontend": true
-      }
-    },
-    {
-      "metadata": {
-        "name": "alertmanagerRemoteOnly",
-        "resourceVersion": "1709568338306",
-        "creationTimestamp": "2024-03-04T16:05:38Z"
-      },
-      "spec": {
-        "description": "Disable the internal Alertmanager and only use the external one defined.",
-        "stage": "experimental",
-        "codeowner": "@grafana/alerting-squad"
-      }
-    },
-    {
-      "metadata": {
         "name": "enablePluginsTracingByDefault",
-        "resourceVersion": "1709568338306",
-        "creationTimestamp": "2024-03-04T16:05:38Z"
+        "resourceVersion": "1708108588074",
+        "creationTimestamp": "2024-02-16T18:36:28Z"
       },
       "spec": {
         "description": "Enable plugin tracing for all external plugins",
@@ -1019,59 +109,47 @@
     },
     {
       "metadata": {
-        "name": "alertingQueryOptimization",
-        "resourceVersion": "1709568338306",
-        "creationTimestamp": "2024-03-04T16:05:38Z"
+        "name": "newFolderPicker",
+        "resourceVersion": "1708108588074",
+        "creationTimestamp": "2024-02-16T18:36:28Z"
       },
       "spec": {
-        "description": "Optimizes eligible queries in order to reduce load on datasources",
-        "stage": "GA",
-        "codeowner": "@grafana/alerting-squad"
-      }
-    },
-    {
-      "metadata": {
-        "name": "kubernetesAggregator",
-        "resourceVersion": "1709568338306",
-        "creationTimestamp": "2024-03-04T16:05:38Z"
-      },
-      "spec": {
-        "description": "Enable grafana aggregator",
+        "description": "Enables the nested folder picker without having nested folders enabled",
         "stage": "experimental",
-        "codeowner": "@grafana/grafana-app-platform-squad",
-        "requiresRestart": true
-      }
-    },
-    {
-      "metadata": {
-        "name": "influxdbRunQueriesInParallel",
-        "resourceVersion": "1709568338306",
-        "creationTimestamp": "2024-03-04T16:05:38Z"
-      },
-      "spec": {
-        "description": "Enables running InfluxDB Influxql queries in parallel",
-        "stage": "privatePreview",
-        "codeowner": "@grafana/observability-metrics"
-      }
-    },
-    {
-      "metadata": {
-        "name": "dashboardEmbed",
-        "resourceVersion": "1709568338306",
-        "creationTimestamp": "2024-03-04T16:05:38Z"
-      },
-      "spec": {
-        "description": "Allow embedding dashboard for external use in Code editors",
-        "stage": "experimental",
-        "codeowner": "@grafana/grafana-as-code",
+        "codeowner": "@grafana/grafana-frontend-platform",
         "frontend": true
       }
     },
     {
       "metadata": {
+        "name": "correlations",
+        "resourceVersion": "1708108588074",
+        "creationTimestamp": "2024-02-16T18:36:28Z"
+      },
+      "spec": {
+        "description": "Correlations page",
+        "stage": "GA",
+        "codeowner": "@grafana/explore-squad",
+        "allowSelfServe": true
+      }
+    },
+    {
+      "metadata": {
+        "name": "datasourceQueryMultiStatus",
+        "resourceVersion": "1708108588074",
+        "creationTimestamp": "2024-02-16T18:36:28Z"
+      },
+      "spec": {
+        "description": "Introduce HTTP 207 Multi Status for api/ds/query",
+        "stage": "experimental",
+        "codeowner": "@grafana/plugins-platform-backend"
+      }
+    },
+    {
+      "metadata": {
         "name": "sqlDatasourceDatabaseSelection",
-        "resourceVersion": "1709568338306",
-        "creationTimestamp": "2024-03-04T16:05:38Z"
+        "resourceVersion": "1708108588074",
+        "creationTimestamp": "2024-02-16T18:36:28Z"
       },
       "spec": {
         "description": "Enables previous SQL data source dataset dropdown behavior",
@@ -1083,53 +161,90 @@
     },
     {
       "metadata": {
-        "name": "dashboardSceneForViewers",
-        "resourceVersion": "1709568338306",
-        "creationTimestamp": "2024-03-04T16:05:38Z"
+        "name": "cloudWatchWildCardDimensionValues",
+        "resourceVersion": "1708108588074",
+        "creationTimestamp": "2024-02-16T18:36:28Z"
       },
       "spec": {
-        "description": "Enables dashboard rendering using Scenes for viewer roles",
-        "stage": "experimental",
-        "codeowner": "@grafana/dashboards-squad",
+        "description": "Fetches dimension values from CloudWatch to correctly label wildcard dimensions",
+        "stage": "GA",
+        "codeowner": "@grafana/aws-datasources",
+        "allowSelfServe": true
+      }
+    },
+    {
+      "metadata": {
+        "name": "addFieldFromCalculationStatFunctions",
+        "resourceVersion": "1708108588074",
+        "creationTimestamp": "2024-02-16T18:36:28Z"
+      },
+      "spec": {
+        "description": "Add cumulative and window functions to the add field from calculation transformation",
+        "stage": "preview",
+        "codeowner": "@grafana/dataviz-squad",
         "frontend": true
       }
     },
     {
       "metadata": {
-        "name": "jitterAlertRulesWithinGroups",
-        "resourceVersion": "1709568338306",
-        "creationTimestamp": "2024-03-04T16:05:38Z"
+        "name": "canvasPanelPanZoom",
+        "resourceVersion": "1708108588074",
+        "creationTimestamp": "2024-02-16T18:36:28Z"
       },
       "spec": {
-        "description": "Distributes alert rule evaluations more evenly over time, including spreading out rules within the same group",
+        "description": "Allow pan and zoom in canvas panel",
         "stage": "preview",
-        "codeowner": "@grafana/alerting-squad",
+        "codeowner": "@grafana/dataviz-squad",
+        "frontend": true
+      }
+    },
+    {
+      "metadata": {
+        "name": "cloudRBACRoles",
+        "resourceVersion": "1708108588074",
+        "creationTimestamp": "2024-02-16T18:36:28Z"
+      },
+      "spec": {
+        "description": "Enabled grafana cloud specific RBAC roles",
+        "stage": "experimental",
+        "codeowner": "@grafana/identity-access-team",
         "requiresRestart": true,
         "hideFromDocs": true
       }
     },
     {
       "metadata": {
-        "name": "groupByVariable",
-        "resourceVersion": "1709568338306",
-        "creationTimestamp": "2024-03-04T16:05:38Z"
+        "name": "panelTitleSearch",
+        "resourceVersion": "1708108588074",
+        "creationTimestamp": "2024-02-16T18:36:28Z"
       },
       "spec": {
-        "description": "Enable groupBy variable support in scenes dashboards",
-        "stage": "experimental",
-        "codeowner": "@grafana/dashboards-squad",
-        "hideFromAdminPage": true,
-        "hideFromDocs": true
+        "description": "Search for dashboards using panel title",
+        "stage": "preview",
+        "codeowner": "@grafana/grafana-app-platform-squad",
+        "hideFromAdminPage": true
       }
     },
     {
       "metadata": {
-        "name": "alertStateHistoryLokiPrimary",
-        "resourceVersion": "1709568338306",
-        "creationTimestamp": "2024-03-04T16:05:38Z"
+        "name": "mysqlAnsiQuotes",
+        "resourceVersion": "1708108588074",
+        "creationTimestamp": "2024-02-16T18:36:28Z"
       },
       "spec": {
-        "description": "Enable a remote Loki instance as the primary source for state history reads.",
+        "description": "Use double quotes to escape keyword in a MySQL query",
+        "stage": "experimental",
+        "codeowner": "@grafana/backend-platform"
+      }
+    },
+    {
+      "metadata": {
+        "name": "alertStateHistoryLokiSecondary",
+        "resourceVersion": "1708108588074",
+        "creationTimestamp": "2024-02-16T18:36:28Z"
+      },
+      "spec": {
+        "description": "Enable Grafana to write alert state history to an external Loki instance in addition to Grafana annotations.",
         "stage": "experimental",
         "codeowner": "@grafana/alerting-squad"
       }
@@ -1137,8 +252,8 @@
     {
       "metadata": {
         "name": "grafanaAPIServerWithExperimentalAPIs",
-        "resourceVersion": "1709568338306",
-        "creationTimestamp": "2024-03-04T16:05:38Z"
+        "resourceVersion": "1708108588074",
+        "creationTimestamp": "2024-02-16T18:36:28Z"
       },
       "spec": {
         "description": "Register experimental APIs with the k8s API server",
@@ -1150,166 +265,24 @@
     },
     {
       "metadata": {
-        "name": "lokiQuerySplitting",
-        "resourceVersion": "1709568338306",
-        "creationTimestamp": "2024-03-04T16:05:38Z"
+        "name": "alertingSimplifiedRouting",
+        "resourceVersion": "1708108588074",
+        "creationTimestamp": "2024-02-16T18:36:28Z"
       },
       "spec": {
-        "description": "Split large interval queries into subqueries with smaller time intervals",
-        "stage": "GA",
-        "codeowner": "@grafana/observability-logs",
-        "frontend": true,
-        "allowSelfServe": true
-      }
-    },
-    {
-      "metadata": {
-        "name": "enableElasticsearchBackendQuerying",
-        "resourceVersion": "1709568338306",
-        "creationTimestamp": "2024-03-04T16:05:38Z"
-      },
-      "spec": {
-        "description": "Enable the processing of queries and responses in the Elasticsearch data source through backend",
-        "stage": "GA",
-        "codeowner": "@grafana/observability-logs",
-        "allowSelfServe": true
-      }
-    },
-    {
-      "metadata": {
-        "name": "extraThemes",
-        "resourceVersion": "1709568338306",
-        "creationTimestamp": "2024-03-04T16:05:38Z"
-      },
-      "spec": {
-        "description": "Enables extra themes",
-        "stage": "experimental",
-        "codeowner": "@grafana/grafana-frontend-platform",
-        "frontend": true
-      }
-    },
-    {
-      "metadata": {
-        "name": "pluginsAPIMetrics",
-        "resourceVersion": "1709568338306",
-        "creationTimestamp": "2024-03-04T16:05:38Z"
-      },
-      "spec": {
-        "description": "Sends metrics of public grafana packages usage by plugins",
-        "stage": "experimental",
-        "codeowner": "@grafana/plugins-platform-backend",
-        "frontend": true
-      }
-    },
-    {
-      "metadata": {
-        "name": "sqlExpressions",
-        "resourceVersion": "1709568338306",
-        "creationTimestamp": "2024-03-04T16:05:38Z"
-      },
-      "spec": {
-        "description": "Enables using SQL and DuckDB functions as Expressions.",
-        "stage": "experimental",
-        "codeowner": "@grafana/grafana-app-platform-squad"
-      }
-    },
-    {
-      "metadata": {
-        "name": "datasourceQueryMultiStatus",
-        "resourceVersion": "1709568338306",
-        "creationTimestamp": "2024-03-04T16:05:38Z"
-      },
-      "spec": {
-        "description": "Introduce HTTP 207 Multi Status for api/ds/query",
-        "stage": "experimental",
-        "codeowner": "@grafana/plugins-platform-backend"
-      }
-    },
-    {
-      "metadata": {
-        "name": "editPanelCSVDragAndDrop",
-        "resourceVersion": "1709568338306",
-        "creationTimestamp": "2024-03-04T16:05:38Z"
-      },
-      "spec": {
-        "description": "Enables drag and drop for CSV and Excel files",
-        "stage": "experimental",
-        "codeowner": "@grafana/dataviz-squad",
-        "frontend": true
-      }
-    },
-    {
-      "metadata": {
-        "name": "influxqlStreamingParser",
-        "resourceVersion": "1709568338306",
-        "creationTimestamp": "2024-03-04T16:05:38Z"
-      },
-      "spec": {
-        "description": "Enable streaming JSON parser for InfluxDB datasource InfluxQL query language",
-        "stage": "experimental",
-        "codeowner": "@grafana/observability-metrics"
-      }
-    },
-    {
-      "metadata": {
-        "name": "pluginsDynamicAngularDetectionPatterns",
-        "resourceVersion": "1709568338306",
-        "creationTimestamp": "2024-03-04T16:05:38Z"
-      },
-      "spec": {
-        "description": "Enables fetching Angular detection patterns for plugins from GCOM and fallback to hardcoded ones",
-        "stage": "experimental",
-        "codeowner": "@grafana/plugins-platform-backend"
-      }
-    },
-    {
-      "metadata": {
-        "name": "awsDatasourcesNewFormStyling",
-        "resourceVersion": "1709568338306",
-        "creationTimestamp": "2024-03-04T16:05:38Z"
-      },
-      "spec": {
-        "description": "Applies new form styling for configuration and query editors in AWS plugins",
+        "description": "Enables users to easily configure alert notifications by specifying a contact point directly when editing or creating an alert rule",
         "stage": "preview",
-        "codeowner": "@grafana/aws-datasources",
-        "frontend": true
+        "codeowner": "@grafana/alerting-squad"
       }
     },
     {
       "metadata": {
-        "name": "datatrails",
-        "resourceVersion": "1709568338306",
-        "creationTimestamp": "2024-03-04T16:05:38Z"
+        "name": "autoMigratePiechartPanel",
+        "resourceVersion": "1708108588074",
+        "creationTimestamp": "2024-02-16T18:36:28Z"
       },
       "spec": {
-        "description": "Enables the new core app datatrails",
-        "stage": "experimental",
-        "codeowner": "@grafana/dashboards-squad",
-        "frontend": true,
-        "hideFromDocs": true
-      }
-    },
-    {
-      "metadata": {
-        "name": "alertingUpgradeDryrunOnStart",
-        "resourceVersion": "1709568338306",
-        "creationTimestamp": "2024-03-04T16:05:38Z"
-      },
-      "spec": {
-        "description": "When activated in legacy alerting mode, this initiates a dry-run of the Unified Alerting upgrade during each startup. It logs any issues detected without implementing any actual changes.",
-        "stage": "GA",
-        "codeowner": "@grafana/alerting-squad",
-        "requiresRestart": true
-      }
-    },
-    {
-      "metadata": {
-        "name": "autoMigrateGraphPanel",
-        "resourceVersion": "1709568338306",
-        "creationTimestamp": "2024-03-04T16:05:38Z"
-      },
-      "spec": {
-        "description": "Migrate old graph panel to supported time series panel - broken out from autoMigrateOldPanels to enable granular tracking",
+        "description": "Migrate old piechart panel to supported piechart panel - broken out from autoMigrateOldPanels to enable granular tracking",
         "stage": "preview",
         "codeowner": "@grafana/dataviz-squad",
         "frontend": true
@@ -1317,342 +290,35 @@
     },
     {
       "metadata": {
-        "name": "lokiQuerySplittingConfig",
-        "resourceVersion": "1709568338306",
-        "creationTimestamp": "2024-03-04T16:05:38Z"
+        "name": "autoMigrateWorldmapPanel",
+        "resourceVersion": "1708108588074",
+        "creationTimestamp": "2024-02-16T18:36:28Z"
       },
       "spec": {
-        "description": "Give users the option to configure split durations for Loki queries",
-        "stage": "experimental",
-        "codeowner": "@grafana/observability-logs",
+        "description": "Migrate old worldmap panel to supported geomap panel - broken out from autoMigrateOldPanels to enable granular tracking",
+        "stage": "preview",
+        "codeowner": "@grafana/dataviz-squad",
         "frontend": true
       }
     },
     {
       "metadata": {
-        "name": "influxdbBackendMigration",
-        "resourceVersion": "1709568338306",
-        "creationTimestamp": "2024-03-04T16:05:38Z"
+        "name": "prometheusIncrementalQueryInstrumentation",
+        "resourceVersion": "1708108588074",
+        "creationTimestamp": "2024-02-16T18:36:28Z"
       },
       "spec": {
-        "description": "Query InfluxDB InfluxQL without the proxy",
-        "stage": "GA",
+        "description": "Adds RudderStack events to incremental queries",
+        "stage": "experimental",
         "codeowner": "@grafana/observability-metrics",
         "frontend": true
       }
     },
     {
       "metadata": {
-        "name": "lokiMetricDataplane",
-        "resourceVersion": "1709568338306",
-        "creationTimestamp": "2024-03-04T16:05:38Z"
-      },
-      "spec": {
-        "description": "Changes metric responses from Loki to be compliant with the dataplane specification.",
-        "stage": "GA",
-        "codeowner": "@grafana/observability-logs",
-        "allowSelfServe": true
-      }
-    },
-    {
-      "metadata": {
-        "name": "faroDatasourceSelector",
-        "resourceVersion": "1709568338306",
-        "creationTimestamp": "2024-03-04T16:05:38Z"
-      },
-      "spec": {
-        "description": "Enable the data source selector within the Frontend Apps section of the Frontend Observability",
-        "stage": "preview",
-        "codeowner": "@grafana/app-o11y",
-        "frontend": true
-      }
-    },
-    {
-      "metadata": {
-        "name": "alertmanagerRemotePrimary",
-        "resourceVersion": "1709568338306",
-        "creationTimestamp": "2024-03-04T16:05:38Z"
-      },
-      "spec": {
-        "description": "Enable Grafana to have a remote Alertmanager instance as the primary Alertmanager.",
-        "stage": "experimental",
-        "codeowner": "@grafana/alerting-squad"
-      }
-    },
-    {
-      "metadata": {
-        "name": "promQLScope",
-        "resourceVersion": "1709568338306",
-        "creationTimestamp": "2024-03-04T16:05:38Z"
-      },
-      "spec": {
-        "description": "In-development feature that will allow injection of labels into prometheus queries.",
-        "stage": "experimental",
-        "codeowner": "@grafana/observability-metrics"
-      }
-    },
-    {
-      "metadata": {
-        "name": "nodeGraphDotLayout",
-        "resourceVersion": "1709568338306",
-        "creationTimestamp": "2024-03-04T16:05:38Z"
-      },
-      "spec": {
-        "description": "Changed the layout algorithm for the node graph",
-        "stage": "experimental",
-        "codeowner": "@grafana/observability-traces-and-profiling",
-        "frontend": true
-      }
-    },
-    {
-      "metadata": {
-        "name": "panelTitleSearch",
-        "resourceVersion": "1709568338306",
-        "creationTimestamp": "2024-03-04T16:05:38Z"
-      },
-      "spec": {
-        "description": "Search for dashboards using panel title",
-        "stage": "preview",
-        "codeowner": "@grafana/grafana-app-platform-squad",
-        "hideFromAdminPage": true
-      }
-    },
-    {
-      "metadata": {
-        "name": "alertingBacktesting",
-        "resourceVersion": "1709568338306",
-        "creationTimestamp": "2024-03-04T16:05:38Z"
-      },
-      "spec": {
-        "description": "Rule backtesting API for alerting",
-        "stage": "experimental",
-        "codeowner": "@grafana/alerting-squad"
-      }
-    },
-    {
-      "metadata": {
-        "name": "logRowsPopoverMenu",
-        "resourceVersion": "1709568338306",
-        "creationTimestamp": "2024-03-04T16:05:38Z"
-      },
-      "spec": {
-        "description": "Enable filtering menu displayed when text of a log line is selected",
-        "stage": "GA",
-        "codeowner": "@grafana/observability-logs",
-        "frontend": true
-      }
-    },
-    {
-      "metadata": {
-        "name": "logRequestsInstrumentedAsUnknown",
-        "resourceVersion": "1709568338306",
-        "creationTimestamp": "2024-03-04T16:05:38Z"
-      },
-      "spec": {
-        "description": "Logs the path for requests that are instrumented as unknown",
-        "stage": "experimental",
-        "codeowner": "@grafana/hosted-grafana-team"
-      }
-    },
-    {
-      "metadata": {
-        "name": "logsContextDatasourceUi",
-        "resourceVersion": "1709568338306",
-        "creationTimestamp": "2024-03-04T16:05:38Z"
-      },
-      "spec": {
-        "description": "Allow datasource to provide custom UI for context view",
-        "stage": "GA",
-        "codeowner": "@grafana/observability-logs",
-        "frontend": true,
-        "allowSelfServe": true
-      }
-    },
-    {
-      "metadata": {
-        "name": "cloudWatchWildCardDimensionValues",
-        "resourceVersion": "1709568338306",
-        "creationTimestamp": "2024-03-04T16:05:38Z"
-      },
-      "spec": {
-        "description": "Fetches dimension values from CloudWatch to correctly label wildcard dimensions",
-        "stage": "GA",
-        "codeowner": "@grafana/aws-datasources",
-        "allowSelfServe": true
-      }
-    },
-    {
-      "metadata": {
-        "name": "lokiQueryHints",
-        "resourceVersion": "1709568338306",
-        "creationTimestamp": "2024-03-04T16:05:38Z"
-      },
-      "spec": {
-        "description": "Enables query hints for Loki",
-        "stage": "GA",
-        "codeowner": "@grafana/observability-logs",
-        "frontend": true
-      }
-    },
-    {
-      "metadata": {
-        "name": "awsAsyncQueryCaching",
-        "resourceVersion": "1709568338306",
-        "creationTimestamp": "2024-03-04T16:05:38Z"
-      },
-      "spec": {
-        "description": "Enable caching for async queries for Redshift and Athena. Requires that the datasource has caching and async query support enabled",
-        "stage": "GA",
-        "codeowner": "@grafana/aws-datasources"
-      }
-    },
-    {
-      "metadata": {
-        "name": "angularDeprecationUI",
-        "resourceVersion": "1709568338306",
-        "creationTimestamp": "2024-03-04T16:05:38Z"
-      },
-      "spec": {
-        "description": "Display Angular warnings in dashboards and panels",
-        "stage": "GA",
-        "codeowner": "@grafana/plugins-platform-backend",
-        "frontend": true
-      }
-    },
-    {
-      "metadata": {
-        "name": "grafanaAPIServerEnsureKubectlAccess",
-        "resourceVersion": "1709568338306",
-        "creationTimestamp": "2024-03-04T16:05:38Z"
-      },
-      "spec": {
-        "description": "Start an additional https handler and write kubectl options",
-        "stage": "experimental",
-        "codeowner": "@grafana/grafana-app-platform-squad",
-        "requiresDevMode": true,
-        "requiresRestart": true
-      }
-    },
-    {
-      "metadata": {
-        "name": "externalServiceAccounts",
-        "resourceVersion": "1709568338306",
-        "creationTimestamp": "2024-03-04T16:05:38Z"
-      },
-      "spec": {
-        "description": "Automatic service account and token setup for plugins",
-        "stage": "preview",
-        "codeowner": "@grafana/identity-access-team",
-        "hideFromAdminPage": true
-      }
-    },
-    {
-      "metadata": {
-        "name": "cloudWatchBatchQueries",
-        "resourceVersion": "1709568338306",
-        "creationTimestamp": "2024-03-04T16:05:38Z"
-      },
-      "spec": {
-        "description": "Runs CloudWatch metrics queries as separate batches",
-        "stage": "preview",
-        "codeowner": "@grafana/aws-datasources"
-      }
-    },
-    {
-      "metadata": {
-        "name": "dashboardSceneSolo",
-        "resourceVersion": "1709568338306",
-        "creationTimestamp": "2024-03-04T16:05:38Z"
-      },
-      "spec": {
-        "description": "Enables rendering dashboards using scenes for solo panels",
-        "stage": "experimental",
-        "codeowner": "@grafana/dashboards-squad",
-        "frontend": true
-      }
-    },
-    {
-      "metadata": {
-        "name": "autoMigrateOldPanels",
-        "resourceVersion": "1709568338306",
-        "creationTimestamp": "2024-03-04T16:05:38Z"
-      },
-      "spec": {
-        "description": "Migrate old angular panels to supported versions (graph, table-old, worldmap, etc)",
-        "stage": "preview",
-        "codeowner": "@grafana/dataviz-squad",
-        "frontend": true
-      }
-    },
-    {
-      "metadata": {
-        "name": "redshiftAsyncQueryDataSupport",
-        "resourceVersion": "1709568338306",
-        "creationTimestamp": "2024-03-04T16:05:38Z"
-      },
-      "spec": {
-        "description": "Enable async query data support for Redshift",
-        "stage": "GA",
-        "codeowner": "@grafana/aws-datasources"
-      }
-    },
-    {
-      "metadata": {
-        "name": "configurableSchedulerTick",
-        "resourceVersion": "1709568338306",
-        "creationTimestamp": "2024-03-04T16:05:38Z"
-      },
-      "spec": {
-        "description": "Enable changing the scheduler base interval via configuration option unified_alerting.scheduler_tick_interval",
-        "stage": "experimental",
-        "codeowner": "@grafana/alerting-squad",
-        "requiresRestart": true,
-        "hideFromDocs": true
-      }
-    },
-    {
-      "metadata": {
-        "name": "alertingInsights",
-        "resourceVersion": "1709568338306",
-        "creationTimestamp": "2024-03-04T16:05:38Z"
-      },
-      "spec": {
-        "description": "Show the new alerting insights landing page",
-        "stage": "GA",
-        "codeowner": "@grafana/alerting-squad",
-        "frontend": true,
-        "hideFromAdminPage": true
-      }
-    },
-    {
-      "metadata": {
-        "name": "cachingOptimizeSerializationMemoryUsage",
-        "resourceVersion": "1709568338306",
-        "creationTimestamp": "2024-03-04T16:05:38Z"
-      },
-      "spec": {
-        "description": "If enabled, the caching backend gradually serializes query responses for the cache, comparing against the configured `[caching]max_value_mb` value as it goes. This can can help prevent Grafana from running out of memory while attempting to cache very large query responses.",
-        "stage": "experimental",
-        "codeowner": "@grafana/grafana-operator-experience-squad"
-      }
-    },
-    {
-      "metadata": {
-        "name": "migrationLocking",
-        "resourceVersion": "1709568338306",
-        "creationTimestamp": "2024-03-04T16:05:38Z"
-      },
-      "spec": {
-        "description": "Lock database during migrations",
-        "stage": "preview",
-        "codeowner": "@grafana/backend-platform"
-      }
-    },
-    {
-      "metadata": {
         "name": "prometheusConfigOverhaulAuth",
-        "resourceVersion": "1709568338306",
-        "creationTimestamp": "2024-03-04T16:05:38Z"
+        "resourceVersion": "1708108588074",
+        "creationTimestamp": "2024-02-16T18:36:28Z"
       },
       "spec": {
         "description": "Update the Prometheus configuration page with the new auth component",
@@ -1662,395 +328,22 @@
     },
     {
       "metadata": {
-        "name": "traceQLStreaming",
-        "resourceVersion": "1709568338306",
-        "creationTimestamp": "2024-03-04T16:05:38Z"
+        "name": "prometheusPromQAIL",
+        "resourceVersion": "1708108588074",
+        "creationTimestamp": "2024-02-16T18:36:28Z"
       },
       "spec": {
-        "description": "Enables response streaming of TraceQL queries of the Tempo data source",
+        "description": "Prometheus and AI/ML to assist users in creating a query",
         "stage": "experimental",
-        "codeowner": "@grafana/observability-traces-and-profiling",
-        "frontend": true
-      }
-    },
-    {
-      "metadata": {
-        "name": "kubernetesFeatureToggles",
-        "resourceVersion": "1709568338306",
-        "creationTimestamp": "2024-03-04T16:05:38Z"
-      },
-      "spec": {
-        "description": "Use the kubernetes API for feature toggle management in the frontend",
-        "stage": "experimental",
-        "codeowner": "@grafana/grafana-operator-experience-squad",
-        "frontend": true,
-        "hideFromAdminPage": true
-      }
-    },
-    {
-      "metadata": {
-        "name": "autoMigrateStatPanel",
-        "resourceVersion": "1709568338306",
-        "creationTimestamp": "2024-03-04T16:05:38Z"
-      },
-      "spec": {
-        "description": "Migrate old stat panel to supported stat panel - broken out from autoMigrateOldPanels to enable granular tracking",
-        "stage": "preview",
-        "codeowner": "@grafana/dataviz-squad",
-        "frontend": true
-      }
-    },
-    {
-      "metadata": {
-        "name": "accessControlOnCall",
-        "resourceVersion": "1709568338306",
-        "creationTimestamp": "2024-03-04T16:05:38Z"
-      },
-      "spec": {
-        "description": "Access control primitives for OnCall",
-        "stage": "preview",
-        "codeowner": "@grafana/identity-access-team",
-        "hideFromAdminPage": true
-      }
-    },
-    {
-      "metadata": {
-        "name": "alertingNoDataErrorExecution",
-        "resourceVersion": "1709568338306",
-        "creationTimestamp": "2024-03-04T16:05:38Z"
-      },
-      "spec": {
-        "description": "Changes how Alerting state manager handles execution of NoData/Error",
-        "stage": "GA",
-        "codeowner": "@grafana/alerting-squad",
-        "requiresRestart": true
-      }
-    },
-    {
-      "metadata": {
-        "name": "dataplaneFrontendFallback",
-        "resourceVersion": "1709568338306",
-        "creationTimestamp": "2024-03-04T16:05:38Z"
-      },
-      "spec": {
-        "description": "Support dataplane contract field name change for transformations and field name matchers where the name is different",
-        "stage": "GA",
         "codeowner": "@grafana/observability-metrics",
-        "frontend": true,
-        "allowSelfServe": true
-      }
-    },
-    {
-      "metadata": {
-        "name": "cloudWatchLogsMonacoEditor",
-        "resourceVersion": "1709568338306",
-        "creationTimestamp": "2024-03-04T16:05:38Z"
-      },
-      "spec": {
-        "description": "Enables the Monaco editor for CloudWatch Logs queries",
-        "stage": "GA",
-        "codeowner": "@grafana/aws-datasources",
-        "frontend": true,
-        "allowSelfServe": true
-      }
-    },
-    {
-      "metadata": {
-        "name": "pluginsFrontendSandbox",
-        "resourceVersion": "1709568338306",
-        "creationTimestamp": "2024-03-04T16:05:38Z"
-      },
-      "spec": {
-        "description": "Enables the plugins frontend sandbox",
-        "stage": "experimental",
-        "codeowner": "@grafana/plugins-platform-backend",
         "frontend": true
-      }
-    },
-    {
-      "metadata": {
-        "name": "lokiFormatQuery",
-        "resourceVersion": "1709568338306",
-        "creationTimestamp": "2024-03-04T16:05:38Z"
-      },
-      "spec": {
-        "description": "Enables the ability to format Loki queries",
-        "stage": "experimental",
-        "codeowner": "@grafana/observability-logs",
-        "frontend": true
-      }
-    },
-    {
-      "metadata": {
-        "name": "recoveryThreshold",
-        "resourceVersion": "1709568338306",
-        "creationTimestamp": "2024-03-04T16:05:38Z"
-      },
-      "spec": {
-        "description": "Enables feature recovery threshold (aka hysteresis) for threshold server-side expression",
-        "stage": "GA",
-        "codeowner": "@grafana/alerting-squad",
-        "requiresRestart": true
-      }
-    },
-    {
-      "metadata": {
-        "name": "logsInfiniteScrolling",
-        "resourceVersion": "1709568338306",
-        "creationTimestamp": "2024-03-04T16:05:38Z"
-      },
-      "spec": {
-        "description": "Enables infinite scrolling for the Logs panel in Explore and Dashboards",
-        "stage": "experimental",
-        "codeowner": "@grafana/observability-logs",
-        "frontend": true
-      }
-    },
-    {
-      "metadata": {
-        "name": "removeCustomScrollbars",
-        "resourceVersion": "1709568338306",
-        "creationTimestamp": "2024-03-04T16:05:38Z",
-        "deletionTimestamp": "2024-03-04T19:50:02Z"
-      },
-      "spec": {
-        "description": "Removes CustomScrollbar from the UI, relying on native browser scrollbars",
-        "stage": "experimental",
-        "codeowner": "@grafana/grafana-frontend-platform",
-        "frontend": true
-      }
-    },
-    {
-      "metadata": {
-        "name": "queryOverLive",
-        "resourceVersion": "1709568338306",
-        "creationTimestamp": "2024-03-04T16:05:38Z"
-      },
-      "spec": {
-        "description": "Use Grafana Live WebSocket to execute backend queries",
-        "stage": "experimental",
-        "codeowner": "@grafana/grafana-app-platform-squad",
-        "frontend": true
-      }
-    },
-    {
-      "metadata": {
-        "name": "autoMigrateTablePanel",
-        "resourceVersion": "1709568338306",
-        "creationTimestamp": "2024-03-04T16:05:38Z"
-      },
-      "spec": {
-        "description": "Migrate old table panel to supported table panel - broken out from autoMigrateOldPanels to enable granular tracking",
-        "stage": "preview",
-        "codeowner": "@grafana/dataviz-squad",
-        "frontend": true
-      }
-    },
-    {
-      "metadata": {
-        "name": "lokiStructuredMetadata",
-        "resourceVersion": "1709568338306",
-        "creationTimestamp": "2024-03-04T16:05:38Z"
-      },
-      "spec": {
-        "description": "Enables the loki data source to request structured metadata from the Loki server",
-        "stage": "GA",
-        "codeowner": "@grafana/observability-logs"
-      }
-    },
-    {
-      "metadata": {
-        "name": "regressionTransformation",
-        "resourceVersion": "1709568338306",
-        "creationTimestamp": "2024-03-04T16:05:38Z"
-      },
-      "spec": {
-        "description": "Enables regression analysis transformation",
-        "stage": "preview",
-        "codeowner": "@grafana/dataviz-squad",
-        "frontend": true
-      }
-    },
-    {
-      "metadata": {
-        "name": "topnav",
-        "resourceVersion": "1709568338306",
-        "creationTimestamp": "2024-03-04T16:05:38Z"
-      },
-      "spec": {
-        "description": "Enables topnav support in external plugins. The new Grafana navigation cannot be disabled.",
-        "stage": "deprecated",
-        "codeowner": "@grafana/grafana-frontend-platform"
-      }
-    },
-    {
-      "metadata": {
-        "name": "kubernetesSnapshots",
-        "resourceVersion": "1709568338306",
-        "creationTimestamp": "2024-03-04T16:05:38Z"
-      },
-      "spec": {
-        "description": "Routes snapshot requests from /api to the /apis endpoint",
-        "stage": "experimental",
-        "codeowner": "@grafana/grafana-app-platform-squad",
-        "requiresRestart": true
-      }
-    },
-    {
-      "metadata": {
-        "name": "teamHttpHeaders",
-        "resourceVersion": "1709568338306",
-        "creationTimestamp": "2024-03-04T16:05:38Z"
-      },
-      "spec": {
-        "description": "Enables Team LBAC for datasources to apply team headers to the client requests",
-        "stage": "preview",
-        "codeowner": "@grafana/identity-access-team"
-      }
-    },
-    {
-      "metadata": {
-        "name": "newPDFRendering",
-        "resourceVersion": "1709568338306",
-        "creationTimestamp": "2024-03-04T16:05:38Z"
-      },
-      "spec": {
-        "description": "New implementation for the dashboard to PDF rendering",
-        "stage": "experimental",
-        "codeowner": "@grafana/sharing-squad"
-      }
-    },
-    {
-      "metadata": {
-        "name": "lokiExperimentalStreaming",
-        "resourceVersion": "1709568338306",
-        "creationTimestamp": "2024-03-04T16:05:38Z"
-      },
-      "spec": {
-        "description": "Support new streaming approach for loki (prototype, needs special loki build)",
-        "stage": "experimental",
-        "codeowner": "@grafana/observability-logs"
-      }
-    },
-    {
-      "metadata": {
-        "name": "reportingRetries",
-        "resourceVersion": "1709568338306",
-        "creationTimestamp": "2024-03-04T16:05:38Z"
-      },
-      "spec": {
-        "description": "Enables rendering retries for the reporting feature",
-        "stage": "preview",
-        "codeowner": "@grafana/sharing-squad",
-        "requiresRestart": true
-      }
-    },
-    {
-      "metadata": {
-        "name": "prometheusMetricEncyclopedia",
-        "resourceVersion": "1709568338306",
-        "creationTimestamp": "2024-03-04T16:05:38Z"
-      },
-      "spec": {
-        "description": "Adds the metrics explorer component to the Prometheus query builder as an option in metric select",
-        "stage": "GA",
-        "codeowner": "@grafana/observability-metrics",
-        "frontend": true,
-        "allowSelfServe": true
-      }
-    },
-    {
-      "metadata": {
-        "name": "recordedQueriesMulti",
-        "resourceVersion": "1709568338306",
-        "creationTimestamp": "2024-03-04T16:05:38Z"
-      },
-      "spec": {
-        "description": "Enables writing multiple items from a single query within Recorded Queries",
-        "stage": "GA",
-        "codeowner": "@grafana/observability-metrics"
-      }
-    },
-    {
-      "metadata": {
-        "name": "awsDatasourcesTempCredentials",
-        "resourceVersion": "1709568338306",
-        "creationTimestamp": "2024-03-04T16:05:38Z"
-      },
-      "spec": {
-        "description": "Support temporary security credentials in AWS plugins for Grafana Cloud customers",
-        "stage": "experimental",
-        "codeowner": "@grafana/aws-datasources"
-      }
-    },
-    {
-      "metadata": {
-        "name": "mlExpressions",
-        "resourceVersion": "1709568338306",
-        "creationTimestamp": "2024-03-04T16:05:38Z"
-      },
-      "spec": {
-        "description": "Enable support for Machine Learning in server-side expressions",
-        "stage": "experimental",
-        "codeowner": "@grafana/alerting-squad"
-      }
-    },
-    {
-      "metadata": {
-        "name": "featureToggleAdminPage",
-        "resourceVersion": "1709568338306",
-        "creationTimestamp": "2024-03-04T16:05:38Z"
-      },
-      "spec": {
-        "description": "Enable admin page for managing feature toggles from the Grafana front-end",
-        "stage": "experimental",
-        "codeowner": "@grafana/grafana-operator-experience-squad",
-        "requiresRestart": true
-      }
-    },
-    {
-      "metadata": {
-        "name": "panelMonitoring",
-        "resourceVersion": "1709568338306",
-        "creationTimestamp": "2024-03-04T16:05:38Z"
-      },
-      "spec": {
-        "description": "Enables panel monitoring through logs and measurements",
-        "stage": "GA",
-        "codeowner": "@grafana/dataviz-squad",
-        "frontend": true
-      }
-    },
-    {
-      "metadata": {
-        "name": "scenes",
-        "resourceVersion": "1709568338306",
-        "creationTimestamp": "2024-03-04T16:05:38Z"
-      },
-      "spec": {
-        "description": "Experimental framework to build interactive dashboards",
-        "stage": "experimental",
-        "codeowner": "@grafana/dashboards-squad",
-        "frontend": true
-      }
-    },
-    {
-      "metadata": {
-        "name": "mysqlAnsiQuotes",
-        "resourceVersion": "1709568338306",
-        "creationTimestamp": "2024-03-04T16:05:38Z"
-      },
-      "spec": {
-        "description": "Use double quotes to escape keyword in a MySQL query",
-        "stage": "experimental",
-        "codeowner": "@grafana/backend-platform"
       }
     },
     {
       "metadata": {
         "name": "panelFilterVariable",
-        "resourceVersion": "1709568338306",
-        "creationTimestamp": "2024-03-04T16:05:38Z"
+        "resourceVersion": "1708108588074",
+        "creationTimestamp": "2024-02-16T18:36:28Z"
       },
       "spec": {
         "description": "Enables use of the `systemPanelFilterVar` variable to filter panels in a dashboard",
@@ -2062,9 +355,1457 @@
     },
     {
       "metadata": {
+        "name": "pluginsSkipHostEnvVars",
+        "resourceVersion": "1708108588074",
+        "creationTimestamp": "2024-02-16T18:36:28Z"
+      },
+      "spec": {
+        "description": "Disables passing host environment variable to plugin processes",
+        "stage": "experimental",
+        "codeowner": "@grafana/plugins-platform-backend"
+      }
+    },
+    {
+      "metadata": {
+        "name": "publicDashboardsEmailSharing",
+        "resourceVersion": "1708108588074",
+        "creationTimestamp": "2024-02-16T18:36:28Z"
+      },
+      "spec": {
+        "description": "Enables public dashboard sharing to be restricted to only allowed emails",
+        "stage": "preview",
+        "codeowner": "@grafana/sharing-squad",
+        "hideFromAdminPage": true,
+        "hideFromDocs": true
+      }
+    },
+    {
+      "metadata": {
+        "name": "metricsSummary",
+        "resourceVersion": "1708108588074",
+        "creationTimestamp": "2024-02-16T18:36:28Z"
+      },
+      "spec": {
+        "description": "Enables metrics summary queries in the Tempo data source",
+        "stage": "experimental",
+        "codeowner": "@grafana/observability-traces-and-profiling",
+        "frontend": true
+      }
+    },
+    {
+      "metadata": {
+        "name": "tableSharedCrosshair",
+        "resourceVersion": "1708108588074",
+        "creationTimestamp": "2024-02-16T18:36:28Z"
+      },
+      "spec": {
+        "description": "Enables shared crosshair in table panel",
+        "stage": "experimental",
+        "codeowner": "@grafana/dataviz-squad",
+        "frontend": true
+      }
+    },
+    {
+      "metadata": {
+        "name": "regressionTransformation",
+        "resourceVersion": "1708108588074",
+        "creationTimestamp": "2024-02-16T18:36:28Z"
+      },
+      "spec": {
+        "description": "Enables regression analysis transformation",
+        "stage": "preview",
+        "codeowner": "@grafana/dataviz-squad",
+        "frontend": true
+      }
+    },
+    {
+      "metadata": {
+        "name": "queryOverLive",
+        "resourceVersion": "1708108588074",
+        "creationTimestamp": "2024-02-16T18:36:28Z"
+      },
+      "spec": {
+        "description": "Use Grafana Live WebSocket to execute backend queries",
+        "stage": "experimental",
+        "codeowner": "@grafana/grafana-app-platform-squad",
+        "frontend": true
+      }
+    },
+    {
+      "metadata": {
+        "name": "prometheusDataplane",
+        "resourceVersion": "1708108588074",
+        "creationTimestamp": "2024-02-16T18:36:28Z"
+      },
+      "spec": {
+        "description": "Changes responses to from Prometheus to be compliant with the dataplane specification. In particular, when this feature toggle is active, the numeric `Field.Name` is set from 'Value' to the value of the `__name__` label.",
+        "stage": "GA",
+        "codeowner": "@grafana/observability-metrics",
+        "allowSelfServe": true
+      }
+    },
+    {
+      "metadata": {
+        "name": "unifiedRequestLog",
+        "resourceVersion": "1708108588074",
+        "creationTimestamp": "2024-02-16T18:36:28Z"
+      },
+      "spec": {
+        "description": "Writes error logs to the request logger",
+        "stage": "experimental",
+        "codeowner": "@grafana/backend-platform"
+      }
+    },
+    {
+      "metadata": {
+        "name": "wargamesTesting",
+        "resourceVersion": "1708108588074",
+        "creationTimestamp": "2024-02-16T18:36:28Z"
+      },
+      "spec": {
+        "description": "Placeholder feature flag for internal testing",
+        "stage": "experimental",
+        "codeowner": "@grafana/hosted-grafana-team"
+      }
+    },
+    {
+      "metadata": {
+        "name": "alertmanagerRemotePrimary",
+        "resourceVersion": "1708108588074",
+        "creationTimestamp": "2024-02-16T18:36:28Z"
+      },
+      "spec": {
+        "description": "Enable Grafana to have a remote Alertmanager instance as the primary Alertmanager.",
+        "stage": "experimental",
+        "codeowner": "@grafana/alerting-squad"
+      }
+    },
+    {
+      "metadata": {
+        "name": "ssoSettingsApi",
+        "resourceVersion": "1708503560010",
+        "creationTimestamp": "2024-02-16T18:36:28Z",
+        "annotations": {
+          "grafana.app/updatedTimestamp": "2024-02-21 08:19:20.010283 +0000 UTC"
+        }
+      },
+      "spec": {
+        "description": "Enables the SSO settings API and the OAuth configuration UIs in Grafana",
+        "stage": "preview",
+        "codeowner": "@grafana/identity-access-team",
+        "allowSelfServe": true
+      }
+    },
+    {
+      "metadata": {
+        "name": "logsInfiniteScrolling",
+        "resourceVersion": "1708108588074",
+        "creationTimestamp": "2024-02-16T18:36:28Z"
+      },
+      "spec": {
+        "description": "Enables infinite scrolling for the Logs panel in Explore and Dashboards",
+        "stage": "experimental",
+        "codeowner": "@grafana/observability-logs",
+        "frontend": true
+      }
+    },
+    {
+      "metadata": {
+        "name": "displayAnonymousStats",
+        "resourceVersion": "1708108588074",
+        "creationTimestamp": "2024-02-16T18:36:28Z",
+        "deletionTimestamp": "2024-02-29T08:27:47Z"
+      },
+      "spec": {
+        "description": "Enables anonymous stats to be shown in the UI for Grafana",
+        "stage": "GA",
+        "codeowner": "@grafana/identity-access-team",
+        "frontend": true
+      }
+    },
+    {
+      "metadata": {
+        "name": "storage",
+        "resourceVersion": "1708108588074",
+        "creationTimestamp": "2024-02-16T18:36:28Z"
+      },
+      "spec": {
+        "description": "Configurable storage for dashboards, datasources, and resources",
+        "stage": "experimental",
+        "codeowner": "@grafana/grafana-app-platform-squad"
+      }
+    },
+    {
+      "metadata": {
+        "name": "newPDFRendering",
+        "resourceVersion": "1708108588074",
+        "creationTimestamp": "2024-02-16T18:36:28Z"
+      },
+      "spec": {
+        "description": "New implementation for the dashboard to PDF rendering",
+        "stage": "experimental",
+        "codeowner": "@grafana/sharing-squad"
+      }
+    },
+    {
+      "metadata": {
+        "name": "pluginsFrontendSandbox",
+        "resourceVersion": "1708108588074",
+        "creationTimestamp": "2024-02-16T18:36:28Z"
+      },
+      "spec": {
+        "description": "Enables the plugins frontend sandbox",
+        "stage": "experimental",
+        "codeowner": "@grafana/plugins-platform-backend",
+        "frontend": true
+      }
+    },
+    {
+      "metadata": {
+        "name": "logRequestsInstrumentedAsUnknown",
+        "resourceVersion": "1708108588074",
+        "creationTimestamp": "2024-02-16T18:36:28Z"
+      },
+      "spec": {
+        "description": "Logs the path for requests that are instrumented as unknown",
+        "stage": "experimental",
+        "codeowner": "@grafana/hosted-grafana-team"
+      }
+    },
+    {
+      "metadata": {
+        "name": "lokiStructuredMetadata",
+        "resourceVersion": "1708108588074",
+        "creationTimestamp": "2024-02-16T18:36:28Z"
+      },
+      "spec": {
+        "description": "Enables the loki data source to request structured metadata from the Loki server",
+        "stage": "GA",
+        "codeowner": "@grafana/observability-logs"
+      }
+    },
+    {
+      "metadata": {
+        "name": "managedPluginsInstall",
+        "resourceVersion": "1708108588074",
+        "creationTimestamp": "2024-02-16T18:36:28Z"
+      },
+      "spec": {
+        "description": "Install managed plugins directly from plugins catalog",
+        "stage": "preview",
+        "codeowner": "@grafana/plugins-platform-backend"
+      }
+    },
+    {
+      "metadata": {
+        "name": "dashboardSceneForViewers",
+        "resourceVersion": "1708108588074",
+        "creationTimestamp": "2024-02-16T18:36:28Z"
+      },
+      "spec": {
+        "description": "Enables dashboard rendering using Scenes for viewer roles",
+        "stage": "experimental",
+        "codeowner": "@grafana/dashboards-squad",
+        "frontend": true
+      }
+    },
+    {
+      "metadata": {
+        "name": "alertingDetailsViewV2",
+        "resourceVersion": "1708108588074",
+        "creationTimestamp": "2024-02-16T18:36:28Z"
+      },
+      "spec": {
+        "description": "Enables the preview of the new alert details view",
+        "stage": "experimental",
+        "codeowner": "@grafana/alerting-squad",
+        "frontend": true,
+        "hideFromDocs": true
+      }
+    },
+    {
+      "metadata": {
+        "name": "jitterAlertRulesWithinGroups",
+        "resourceVersion": "1708108588074",
+        "creationTimestamp": "2024-02-16T18:36:28Z"
+      },
+      "spec": {
+        "description": "Distributes alert rule evaluations more evenly over time, including spreading out rules within the same group",
+        "stage": "preview",
+        "codeowner": "@grafana/alerting-squad",
+        "requiresRestart": true,
+        "hideFromDocs": true
+      }
+    },
+    {
+      "metadata": {
+        "name": "unifiedStorage",
+        "resourceVersion": "1708108588074",
+        "creationTimestamp": "2024-02-16T18:36:28Z"
+      },
+      "spec": {
+        "description": "SQL-based k8s storage",
+        "stage": "experimental",
+        "codeowner": "@grafana/grafana-app-platform-squad",
+        "requiresDevMode": true,
+        "requiresRestart": true
+      }
+    },
+    {
+      "metadata": {
+        "name": "enableElasticsearchBackendQuerying",
+        "resourceVersion": "1708108588074",
+        "creationTimestamp": "2024-02-16T18:36:28Z"
+      },
+      "spec": {
+        "description": "Enable the processing of queries and responses in the Elasticsearch data source through backend",
+        "stage": "GA",
+        "codeowner": "@grafana/observability-logs",
+        "allowSelfServe": true
+      }
+    },
+    {
+      "metadata": {
+        "name": "cloudWatchLogsMonacoEditor",
+        "resourceVersion": "1708108588074",
+        "creationTimestamp": "2024-02-16T18:36:28Z"
+      },
+      "spec": {
+        "description": "Enables the Monaco editor for CloudWatch Logs queries",
+        "stage": "GA",
+        "codeowner": "@grafana/aws-datasources",
+        "frontend": true,
+        "allowSelfServe": true
+      }
+    },
+    {
+      "metadata": {
+        "name": "alertmanagerRemoteSecondary",
+        "resourceVersion": "1708108588074",
+        "creationTimestamp": "2024-02-16T18:36:28Z"
+      },
+      "spec": {
+        "description": "Enable Grafana to sync configuration and state with a remote Alertmanager.",
+        "stage": "experimental",
+        "codeowner": "@grafana/alerting-squad"
+      }
+    },
+    {
+      "metadata": {
+        "name": "disableAngular",
+        "resourceVersion": "1708108588074",
+        "creationTimestamp": "2024-02-16T18:36:28Z"
+      },
+      "spec": {
+        "description": "Dynamic flag to disable angular at runtime. The preferred method is to set `angular_support_enabled` to `false` in the [security] settings, which allows you to change the state at runtime.",
+        "stage": "preview",
+        "codeowner": "@grafana/dataviz-squad",
+        "frontend": true,
+        "hideFromAdminPage": true
+      }
+    },
+    {
+      "metadata": {
+        "name": "grafanaAPIServerEnsureKubectlAccess",
+        "resourceVersion": "1708108588074",
+        "creationTimestamp": "2024-02-16T18:36:28Z"
+      },
+      "spec": {
+        "description": "Start an additional https handler and write kubectl options",
+        "stage": "experimental",
+        "codeowner": "@grafana/grafana-app-platform-squad",
+        "requiresDevMode": true,
+        "requiresRestart": true
+      }
+    },
+    {
+      "metadata": {
+        "name": "alertingNoDataErrorExecution",
+        "resourceVersion": "1708108588074",
+        "creationTimestamp": "2024-02-16T18:36:28Z"
+      },
+      "spec": {
+        "description": "Changes how Alerting state manager handles execution of NoData/Error",
+        "stage": "GA",
+        "codeowner": "@grafana/alerting-squad",
+        "requiresRestart": true
+      }
+    },
+    {
+      "metadata": {
+        "name": "angularDeprecationUI",
+        "resourceVersion": "1708108588074",
+        "creationTimestamp": "2024-02-16T18:36:28Z"
+      },
+      "spec": {
+        "description": "Display Angular warnings in dashboards and panels",
+        "stage": "GA",
+        "codeowner": "@grafana/plugins-platform-backend",
+        "frontend": true
+      }
+    },
+    {
+      "metadata": {
+        "name": "lokiFormatQuery",
+        "resourceVersion": "1708108588074",
+        "creationTimestamp": "2024-02-16T18:36:28Z"
+      },
+      "spec": {
+        "description": "Enables the ability to format Loki queries",
+        "stage": "experimental",
+        "codeowner": "@grafana/observability-logs",
+        "frontend": true
+      }
+    },
+    {
+      "metadata": {
+        "name": "nestedFolderPicker",
+        "resourceVersion": "1708108588074",
+        "creationTimestamp": "2024-02-16T18:36:28Z"
+      },
+      "spec": {
+        "description": "Enables the new folder picker to work with nested folders. Requires the nestedFolders feature toggle",
+        "stage": "GA",
+        "codeowner": "@grafana/grafana-frontend-platform",
+        "frontend": true,
+        "allowSelfServe": true
+      }
+    },
+    {
+      "metadata": {
+        "name": "individualCookiePreferences",
+        "resourceVersion": "1708108588074",
+        "creationTimestamp": "2024-02-16T18:36:28Z"
+      },
+      "spec": {
+        "description": "Support overriding cookie preferences per user",
+        "stage": "experimental",
+        "codeowner": "@grafana/backend-platform"
+      }
+    },
+    {
+      "metadata": {
+        "name": "externalServiceAccounts",
+        "resourceVersion": "1708108588074",
+        "creationTimestamp": "2024-02-16T18:36:28Z"
+      },
+      "spec": {
+        "description": "Automatic service account and token setup for plugins",
+        "stage": "preview",
+        "codeowner": "@grafana/identity-access-team",
+        "hideFromAdminPage": true
+      }
+    },
+    {
+      "metadata": {
+        "name": "groupByVariable",
+        "resourceVersion": "1708108588074",
+        "creationTimestamp": "2024-02-16T18:36:28Z"
+      },
+      "spec": {
+        "description": "Enable groupBy variable support in scenes dashboards",
+        "stage": "experimental",
+        "codeowner": "@grafana/dashboards-squad",
+        "hideFromAdminPage": true,
+        "hideFromDocs": true
+      }
+    },
+    {
+      "metadata": {
+        "name": "autoMigrateGraphPanel",
+        "resourceVersion": "1708108588074",
+        "creationTimestamp": "2024-02-16T18:36:28Z"
+      },
+      "spec": {
+        "description": "Migrate old graph panel to supported time series panel - broken out from autoMigrateOldPanels to enable granular tracking",
+        "stage": "preview",
+        "codeowner": "@grafana/dataviz-squad",
+        "frontend": true
+      }
+    },
+    {
+      "metadata": {
+        "name": "dashgpt",
+        "resourceVersion": "1708108588074",
+        "creationTimestamp": "2024-02-16T18:36:28Z"
+      },
+      "spec": {
+        "description": "Enable AI powered features in dashboards",
+        "stage": "preview",
+        "codeowner": "@grafana/dashboards-squad",
+        "frontend": true
+      }
+    },
+    {
+      "metadata": {
+        "name": "kubernetesSnapshots",
+        "resourceVersion": "1708108588074",
+        "creationTimestamp": "2024-02-16T18:36:28Z"
+      },
+      "spec": {
+        "description": "Routes snapshot requests from /api to the /apis endpoint",
+        "stage": "experimental",
+        "codeowner": "@grafana/grafana-app-platform-squad",
+        "requiresRestart": true
+      }
+    },
+    {
+      "metadata": {
+        "name": "influxdbBackendMigration",
+        "resourceVersion": "1708108588074",
+        "creationTimestamp": "2024-02-16T18:36:28Z"
+      },
+      "spec": {
+        "description": "Query InfluxDB InfluxQL without the proxy",
+        "stage": "GA",
+        "codeowner": "@grafana/observability-metrics",
+        "frontend": true
+      }
+    },
+    {
+      "metadata": {
+        "name": "redshiftAsyncQueryDataSupport",
+        "resourceVersion": "1708108588074",
+        "creationTimestamp": "2024-02-16T18:36:28Z"
+      },
+      "spec": {
+        "description": "Enable async query data support for Redshift",
+        "stage": "GA",
+        "codeowner": "@grafana/aws-datasources"
+      }
+    },
+    {
+      "metadata": {
+        "name": "topnav",
+        "resourceVersion": "1708108588074",
+        "creationTimestamp": "2024-02-16T18:36:28Z"
+      },
+      "spec": {
+        "description": "Enables topnav support in external plugins. The new Grafana navigation cannot be disabled.",
+        "stage": "deprecated",
+        "codeowner": "@grafana/grafana-frontend-platform"
+      }
+    },
+    {
+      "metadata": {
+        "name": "lokiQuerySplittingConfig",
+        "resourceVersion": "1708108588074",
+        "creationTimestamp": "2024-02-16T18:36:28Z"
+      },
+      "spec": {
+        "description": "Give users the option to configure split durations for Loki queries",
+        "stage": "experimental",
+        "codeowner": "@grafana/observability-logs",
+        "frontend": true
+      }
+    },
+    {
+      "metadata": {
+        "name": "awsDatasourcesTempCredentials",
+        "resourceVersion": "1708108588074",
+        "creationTimestamp": "2024-02-16T18:36:28Z"
+      },
+      "spec": {
+        "description": "Support temporary security credentials in AWS plugins for Grafana Cloud customers",
+        "stage": "experimental",
+        "codeowner": "@grafana/aws-datasources"
+      }
+    },
+    {
+      "metadata": {
+        "name": "influxdbSqlSupport",
+        "resourceVersion": "1708108588074",
+        "creationTimestamp": "2024-02-16T18:36:28Z"
+      },
+      "spec": {
+        "description": "Enable InfluxDB SQL query language support with new querying UI",
+        "stage": "GA",
+        "codeowner": "@grafana/observability-metrics",
+        "requiresRestart": true,
+        "allowSelfServe": true
+      }
+    },
+    {
+      "metadata": {
+        "name": "autoMigrateTablePanel",
+        "resourceVersion": "1708108588074",
+        "creationTimestamp": "2024-02-16T18:36:28Z"
+      },
+      "spec": {
+        "description": "Migrate old table panel to supported table panel - broken out from autoMigrateOldPanels to enable granular tracking",
+        "stage": "preview",
+        "codeowner": "@grafana/dataviz-squad",
+        "frontend": true
+      }
+    },
+    {
+      "metadata": {
+        "name": "migrationLocking",
+        "resourceVersion": "1708108588074",
+        "creationTimestamp": "2024-02-16T18:36:28Z"
+      },
+      "spec": {
+        "description": "Lock database during migrations",
+        "stage": "preview",
+        "codeowner": "@grafana/backend-platform"
+      }
+    },
+    {
+      "metadata": {
+        "name": "accessControlOnCall",
+        "resourceVersion": "1708108588074",
+        "creationTimestamp": "2024-02-16T18:36:28Z"
+      },
+      "spec": {
+        "description": "Access control primitives for OnCall",
+        "stage": "preview",
+        "codeowner": "@grafana/identity-access-team",
+        "hideFromAdminPage": true
+      }
+    },
+    {
+      "metadata": {
+        "name": "faroDatasourceSelector",
+        "resourceVersion": "1708108588074",
+        "creationTimestamp": "2024-02-16T18:36:28Z"
+      },
+      "spec": {
+        "description": "Enable the data source selector within the Frontend Apps section of the Frontend Observability",
+        "stage": "preview",
+        "codeowner": "@grafana/app-o11y",
+        "frontend": true
+      }
+    },
+    {
+      "metadata": {
+        "name": "featureToggleAdminPage",
+        "resourceVersion": "1708108588074",
+        "creationTimestamp": "2024-02-16T18:36:28Z"
+      },
+      "spec": {
+        "description": "Enable admin page for managing feature toggles from the Grafana front-end",
+        "stage": "experimental",
+        "codeowner": "@grafana/grafana-operator-experience-squad",
+        "requiresRestart": true
+      }
+    },
+    {
+      "metadata": {
+        "name": "awsAsyncQueryCaching",
+        "resourceVersion": "1708108588074",
+        "creationTimestamp": "2024-02-16T18:36:28Z"
+      },
+      "spec": {
+        "description": "Enable caching for async queries for Redshift and Athena. Requires that the datasource has caching and async query support enabled",
+        "stage": "GA",
+        "codeowner": "@grafana/aws-datasources"
+      }
+    },
+    {
+      "metadata": {
+        "name": "reportingRetries",
+        "resourceVersion": "1708108588074",
+        "creationTimestamp": "2024-02-16T18:36:28Z"
+      },
+      "spec": {
+        "description": "Enables rendering retries for the reporting feature",
+        "stage": "preview",
+        "codeowner": "@grafana/sharing-squad",
+        "requiresRestart": true
+      }
+    },
+    {
+      "metadata": {
+        "name": "kubernetesAggregator",
+        "resourceVersion": "1708108588074",
+        "creationTimestamp": "2024-02-16T18:36:28Z"
+      },
+      "spec": {
+        "description": "Enable grafana aggregator",
+        "stage": "experimental",
+        "codeowner": "@grafana/grafana-app-platform-squad",
+        "requiresRestart": true
+      }
+    },
+    {
+      "metadata": {
+        "name": "publicDashboards",
+        "resourceVersion": "1708108588074",
+        "creationTimestamp": "2024-02-16T18:36:28Z"
+      },
+      "spec": {
+        "description": "[Deprecated] Public dashboards are now enabled by default; to disable them, use the configuration setting. This feature toggle will be removed in the next major version.",
+        "stage": "GA",
+        "codeowner": "@grafana/sharing-squad",
+        "allowSelfServe": true
+      }
+    },
+    {
+      "metadata": {
+        "name": "transformationsRedesign",
+        "resourceVersion": "1708108588074",
+        "creationTimestamp": "2024-02-16T18:36:28Z"
+      },
+      "spec": {
+        "description": "Enables the transformations redesign",
+        "stage": "GA",
+        "codeowner": "@grafana/observability-metrics",
+        "frontend": true,
+        "allowSelfServe": true
+      }
+    },
+    {
+      "metadata": {
+        "name": "traceQLStreaming",
+        "resourceVersion": "1708108588074",
+        "creationTimestamp": "2024-02-16T18:36:28Z"
+      },
+      "spec": {
+        "description": "Enables response streaming of TraceQL queries of the Tempo data source",
+        "stage": "experimental",
+        "codeowner": "@grafana/observability-traces-and-profiling",
+        "frontend": true
+      }
+    },
+    {
+      "metadata": {
+        "name": "formatString",
+        "resourceVersion": "1708108588074",
+        "creationTimestamp": "2024-02-16T18:36:28Z"
+      },
+      "spec": {
+        "description": "Enable format string transformer",
+        "stage": "preview",
+        "codeowner": "@grafana/dataviz-squad",
+        "frontend": true
+      }
+    },
+    {
+      "metadata": {
+        "name": "alertingQueryOptimization",
+        "resourceVersion": "1708108588074",
+        "creationTimestamp": "2024-02-16T18:36:28Z"
+      },
+      "spec": {
+        "description": "Optimizes eligible queries in order to reduce load on datasources",
+        "stage": "GA",
+        "codeowner": "@grafana/alerting-squad"
+      }
+    },
+    {
+      "metadata": {
+        "name": "nestedFolders",
+        "resourceVersion": "1708108588074",
+        "creationTimestamp": "2024-02-16T18:36:28Z"
+      },
+      "spec": {
+        "description": "Enable folder nesting",
+        "stage": "preview",
+        "codeowner": "@grafana/backend-platform"
+      }
+    },
+    {
+      "metadata": {
+        "name": "scenes",
+        "resourceVersion": "1708108588074",
+        "creationTimestamp": "2024-02-16T18:36:28Z"
+      },
+      "spec": {
+        "description": "Experimental framework to build interactive dashboards",
+        "stage": "experimental",
+        "codeowner": "@grafana/dashboards-squad",
+        "frontend": true
+      }
+    },
+    {
+      "metadata": {
+        "name": "extraThemes",
+        "resourceVersion": "1708108588074",
+        "creationTimestamp": "2024-02-16T18:36:28Z"
+      },
+      "spec": {
+        "description": "Enables extra themes",
+        "stage": "experimental",
+        "codeowner": "@grafana/grafana-frontend-platform",
+        "frontend": true
+      }
+    },
+    {
+      "metadata": {
+        "name": "annotationPermissionUpdate",
+        "resourceVersion": "1708108588074",
+        "creationTimestamp": "2024-02-16T18:36:28Z"
+      },
+      "spec": {
+        "description": "Separate annotation permissions from dashboard permissions to allow for more granular control.",
+        "stage": "experimental",
+        "codeowner": "@grafana/identity-access-team"
+      }
+    },
+    {
+      "metadata": {
+        "name": "extractFieldsNameDeduplication",
+        "resourceVersion": "1708108588074",
+        "creationTimestamp": "2024-02-16T18:36:28Z"
+      },
+      "spec": {
+        "description": "Make sure extracted field names are unique in the dataframe",
+        "stage": "experimental",
+        "codeowner": "@grafana/dataviz-squad",
+        "frontend": true
+      }
+    },
+    {
+      "metadata": {
+        "name": "flameGraphItemCollapsing",
+        "resourceVersion": "1708108588074",
+        "creationTimestamp": "2024-02-16T18:36:28Z"
+      },
+      "spec": {
+        "description": "Allow collapsing of flame graph items",
+        "stage": "experimental",
+        "codeowner": "@grafana/observability-traces-and-profiling",
+        "frontend": true
+      }
+    },
+    {
+      "metadata": {
+        "name": "alertingPreviewUpgrade",
+        "resourceVersion": "1708108588074",
+        "creationTimestamp": "2024-02-16T18:36:28Z"
+      },
+      "spec": {
+        "description": "Show Unified Alerting preview and upgrade page in legacy alerting",
+        "stage": "GA",
+        "codeowner": "@grafana/alerting-squad",
+        "requiresRestart": true
+      }
+    },
+    {
+      "metadata": {
+        "name": "disableEnvelopeEncryption",
+        "resourceVersion": "1708108588074",
+        "creationTimestamp": "2024-02-16T18:36:28Z"
+      },
+      "spec": {
+        "description": "Disable envelope encryption (emergency only)",
+        "stage": "GA",
+        "codeowner": "@grafana/grafana-as-code",
+        "hideFromAdminPage": true
+      }
+    },
+    {
+      "metadata": {
+        "name": "groupToNestedTableTransformation",
+        "resourceVersion": "1708108588074",
+        "creationTimestamp": "2024-02-16T18:36:28Z"
+      },
+      "spec": {
+        "description": "Enables the group to nested table transformation",
+        "stage": "preview",
+        "codeowner": "@grafana/dataviz-squad",
+        "frontend": true
+      }
+    },
+    {
+      "metadata": {
+        "name": "promQLScope",
+        "resourceVersion": "1708108588074",
+        "creationTimestamp": "2024-02-16T18:36:28Z"
+      },
+      "spec": {
+        "description": "In-development feature that will allow injection of labels into prometheus queries.",
+        "stage": "experimental",
+        "codeowner": "@grafana/observability-metrics"
+      }
+    },
+    {
+      "metadata": {
+        "name": "logsContextDatasourceUi",
+        "resourceVersion": "1708108588074",
+        "creationTimestamp": "2024-02-16T18:36:28Z"
+      },
+      "spec": {
+        "description": "Allow datasource to provide custom UI for context view",
+        "stage": "GA",
+        "codeowner": "@grafana/observability-logs",
+        "frontend": true,
+        "allowSelfServe": true
+      }
+    },
+    {
+      "metadata": {
+        "name": "alertStateHistoryLokiOnly",
+        "resourceVersion": "1708108588074",
+        "creationTimestamp": "2024-02-16T18:36:28Z"
+      },
+      "spec": {
+        "description": "Disable Grafana alerts from emitting annotations when a remote Loki instance is available.",
+        "stage": "experimental",
+        "codeowner": "@grafana/alerting-squad"
+      }
+    },
+    {
+      "metadata": {
+        "name": "transformationsVariableSupport",
+        "resourceVersion": "1708108588074",
+        "creationTimestamp": "2024-02-16T18:36:28Z"
+      },
+      "spec": {
+        "description": "Allows using variables in transformations",
+        "stage": "preview",
+        "codeowner": "@grafana/dataviz-squad",
+        "frontend": true
+      }
+    },
+    {
+      "metadata": {
+        "name": "dashboardSceneSolo",
+        "resourceVersion": "1708108588074",
+        "creationTimestamp": "2024-02-16T18:36:28Z"
+      },
+      "spec": {
+        "description": "Enables rendering dashboards using scenes for solo panels",
+        "stage": "experimental",
+        "codeowner": "@grafana/dashboards-squad",
+        "frontend": true
+      }
+    },
+    {
+      "metadata": {
+        "name": "athenaAsyncQueryDataSupport",
+        "resourceVersion": "1708108588074",
+        "creationTimestamp": "2024-02-16T18:36:28Z"
+      },
+      "spec": {
+        "description": "Enable async query data support for Athena",
+        "stage": "GA",
+        "codeowner": "@grafana/aws-datasources",
+        "frontend": true
+      }
+    },
+    {
+      "metadata": {
+        "name": "lokiLogsDataplane",
+        "resourceVersion": "1708108588074",
+        "creationTimestamp": "2024-02-16T18:36:28Z"
+      },
+      "spec": {
+        "description": "Changes logs responses from Loki to be compliant with the dataplane specification.",
+        "stage": "experimental",
+        "codeowner": "@grafana/observability-logs"
+      }
+    },
+    {
+      "metadata": {
+        "name": "enableDatagridEditing",
+        "resourceVersion": "1708108588074",
+        "creationTimestamp": "2024-02-16T18:36:28Z"
+      },
+      "spec": {
+        "description": "Enables the edit functionality in the datagrid panel",
+        "stage": "preview",
+        "codeowner": "@grafana/dataviz-squad",
+        "frontend": true
+      }
+    },
+    {
+      "metadata": {
+        "name": "exploreScrollableLogsContainer",
+        "resourceVersion": "1708108588074",
+        "creationTimestamp": "2024-02-16T18:36:28Z"
+      },
+      "spec": {
+        "description": "Improves the scrolling behavior of logs in Explore",
+        "stage": "experimental",
+        "codeowner": "@grafana/observability-logs",
+        "frontend": true
+      }
+    },
+    {
+      "metadata": {
+        "name": "lokiRunQueriesInParallel",
+        "resourceVersion": "1708108588074",
+        "creationTimestamp": "2024-02-16T18:36:28Z"
+      },
+      "spec": {
+        "description": "Enables running Loki queries in parallel",
+        "stage": "privatePreview",
+        "codeowner": "@grafana/observability-logs"
+      }
+    },
+    {
+      "metadata": {
+        "name": "panelTitleSearchInV1",
+        "resourceVersion": "1708108588074",
+        "creationTimestamp": "2024-02-16T18:36:28Z"
+      },
+      "spec": {
+        "description": "Enable searching for dashboards using panel title in search v1",
+        "stage": "experimental",
+        "codeowner": "@grafana/backend-platform",
+        "requiresDevMode": true
+      }
+    },
+    {
+      "metadata": {
+        "name": "logRowsPopoverMenu",
+        "resourceVersion": "1708108588074",
+        "creationTimestamp": "2024-02-16T18:36:28Z"
+      },
+      "spec": {
+        "description": "Enable filtering menu displayed when text of a log line is selected",
+        "stage": "GA",
+        "codeowner": "@grafana/observability-logs",
+        "frontend": true
+      }
+    },
+    {
+      "metadata": {
+        "name": "lokiQueryHints",
+        "resourceVersion": "1708108588074",
+        "creationTimestamp": "2024-02-16T18:36:28Z"
+      },
+      "spec": {
+        "description": "Enables query hints for Loki",
+        "stage": "GA",
+        "codeowner": "@grafana/observability-logs",
+        "frontend": true
+      }
+    },
+    {
+      "metadata": {
+        "name": "lokiExperimentalStreaming",
+        "resourceVersion": "1708108588074",
+        "creationTimestamp": "2024-02-16T18:36:28Z"
+      },
+      "spec": {
+        "description": "Support new streaming approach for loki (prototype, needs special loki build)",
+        "stage": "experimental",
+        "codeowner": "@grafana/observability-logs"
+      }
+    },
+    {
+      "metadata": {
+        "name": "traceToMetrics",
+        "resourceVersion": "1708108588074",
+        "creationTimestamp": "2024-02-16T18:36:28Z",
+        "deletionTimestamp": "2024-02-29T08:27:47Z"
+      },
+      "spec": {
+        "description": "Enable trace to metrics links",
+        "stage": "experimental",
+        "codeowner": "@grafana/observability-traces-and-profiling",
+        "frontend": true
+      }
+    },
+    {
+      "metadata": {
+        "name": "grpcServer",
+        "resourceVersion": "1708108588074",
+        "creationTimestamp": "2024-02-16T18:36:28Z"
+      },
+      "spec": {
+        "description": "Run the GRPC server",
+        "stage": "preview",
+        "codeowner": "@grafana/grafana-app-platform-squad",
+        "hideFromAdminPage": true
+      }
+    },
+    {
+      "metadata": {
+        "name": "cloudWatchCrossAccountQuerying",
+        "resourceVersion": "1708108588074",
+        "creationTimestamp": "2024-02-16T18:36:28Z"
+      },
+      "spec": {
+        "description": "Enables cross-account querying in CloudWatch datasources",
+        "stage": "GA",
+        "codeowner": "@grafana/aws-datasources",
+        "allowSelfServe": true
+      }
+    },
+    {
+      "metadata": {
+        "name": "vizAndWidgetSplit",
+        "resourceVersion": "1708108588074",
+        "creationTimestamp": "2024-02-16T18:36:28Z"
+      },
+      "spec": {
+        "description": "Split panels between visualizations and widgets",
+        "stage": "experimental",
+        "codeowner": "@grafana/dashboards-squad",
+        "frontend": true
+      }
+    },
+    {
+      "metadata": {
+        "name": "panelMonitoring",
+        "resourceVersion": "1708108588074",
+        "creationTimestamp": "2024-02-16T18:36:28Z"
+      },
+      "spec": {
+        "description": "Enables panel monitoring through logs and measurements",
+        "stage": "GA",
+        "codeowner": "@grafana/dataviz-squad",
+        "frontend": true
+      }
+    },
+    {
+      "metadata": {
+        "name": "live-service-web-worker",
+        "resourceVersion": "1708108588074",
+        "creationTimestamp": "2024-02-16T18:36:28Z"
+      },
+      "spec": {
+        "description": "This will use a webworker thread to processes events rather than the main thread",
+        "stage": "experimental",
+        "codeowner": "@grafana/grafana-app-platform-squad",
+        "frontend": true
+      }
+    },
+    {
+      "metadata": {
+        "name": "returnToPrevious",
+        "resourceVersion": "1708108588074",
+        "creationTimestamp": "2024-02-16T18:36:28Z"
+      },
+      "spec": {
+        "description": "Enables the return to previous context functionality",
+        "stage": "preview",
+        "codeowner": "@grafana/grafana-frontend-platform",
+        "frontend": true
+      }
+    },
+    {
+      "metadata": {
+        "name": "cachingOptimizeSerializationMemoryUsage",
+        "resourceVersion": "1708108588074",
+        "creationTimestamp": "2024-02-16T18:36:28Z"
+      },
+      "spec": {
+        "description": "If enabled, the caching backend gradually serializes query responses for the cache, comparing against the configured `[caching]max_value_mb` value as it goes. This can can help prevent Grafana from running out of memory while attempting to cache very large query responses.",
+        "stage": "experimental",
+        "codeowner": "@grafana/grafana-operator-experience-squad"
+      }
+    },
+    {
+      "metadata": {
+        "name": "onPremToCloudMigrations",
+        "resourceVersion": "1708108588074",
+        "creationTimestamp": "2024-02-16T18:36:28Z"
+      },
+      "spec": {
+        "description": "In-development feature that will allow users to easily migrate their on-prem Grafana instances to Grafana Cloud.",
+        "stage": "experimental",
+        "codeowner": "@grafana/grafana-operator-experience-squad"
+      }
+    },
+    {
+      "metadata": {
+        "name": "featureHighlights",
+        "resourceVersion": "1708108588074",
+        "creationTimestamp": "2024-02-16T18:36:28Z"
+      },
+      "spec": {
+        "description": "Highlight Grafana Enterprise features",
+        "stage": "GA",
+        "codeowner": "@grafana/grafana-as-code",
+        "allowSelfServe": true
+      }
+    },
+    {
+      "metadata": {
+        "name": "splitScopes",
+        "resourceVersion": "1708108588074",
+        "creationTimestamp": "2024-02-16T18:36:28Z",
+        "deletionTimestamp": "2024-02-29T08:27:47Z"
+      },
+      "spec": {
+        "description": "Support faster dashboard and folder search by splitting permission scopes into parts",
+        "stage": "deprecated",
+        "codeowner": "@grafana/identity-access-team",
+        "requiresRestart": true,
+        "hideFromAdminPage": true
+      }
+    },
+    {
+      "metadata": {
+        "name": "nodeGraphDotLayout",
+        "resourceVersion": "1708108588074",
+        "creationTimestamp": "2024-02-16T18:36:28Z"
+      },
+      "spec": {
+        "description": "Changed the layout algorithm for the node graph",
+        "stage": "experimental",
+        "codeowner": "@grafana/observability-traces-and-profiling",
+        "frontend": true
+      }
+    },
+    {
+      "metadata": {
+        "name": "refactorVariablesTimeRange",
+        "resourceVersion": "1708108588074",
+        "creationTimestamp": "2024-02-16T18:36:28Z"
+      },
+      "spec": {
+        "description": "Refactor time range variables flow to reduce number of API calls made when query variables are chained",
+        "stage": "preview",
+        "codeowner": "@grafana/dashboards-squad",
+        "hideFromAdminPage": true
+      }
+    },
+    {
+      "metadata": {
+        "name": "externalServiceAuth",
+        "resourceVersion": "1708108588074",
+        "creationTimestamp": "2024-02-16T18:36:28Z",
+        "deletionTimestamp": "2024-02-29T08:27:47Z"
+      },
+      "spec": {
+        "description": "Starts an OAuth2 authentication provider for external services",
+        "stage": "experimental",
+        "codeowner": "@grafana/identity-access-team",
+        "requiresDevMode": true
+      }
+    },
+    {
+      "metadata": {
+        "name": "frontendSandboxMonitorOnly",
+        "resourceVersion": "1708108588074",
+        "creationTimestamp": "2024-02-16T18:36:28Z"
+      },
+      "spec": {
+        "description": "Enables monitor only in the plugin frontend sandbox (if enabled)",
+        "stage": "experimental",
+        "codeowner": "@grafana/plugins-platform-backend",
+        "frontend": true
+      }
+    },
+    {
+      "metadata": {
+        "name": "mlExpressions",
+        "resourceVersion": "1708108588074",
+        "creationTimestamp": "2024-02-16T18:36:28Z"
+      },
+      "spec": {
+        "description": "Enable support for Machine Learning in server-side expressions",
+        "stage": "experimental",
+        "codeowner": "@grafana/alerting-squad"
+      }
+    },
+    {
+      "metadata": {
+        "name": "libraryPanelRBAC",
+        "resourceVersion": "1708108588074",
+        "creationTimestamp": "2024-02-16T18:36:28Z"
+      },
+      "spec": {
+        "description": "Enables RBAC support for library panels",
+        "stage": "experimental",
+        "codeowner": "@grafana/dashboards-squad",
+        "requiresRestart": true
+      }
+    },
+    {
+      "metadata": {
+        "name": "kubernetesFeatureToggles",
+        "resourceVersion": "1708108588074",
+        "creationTimestamp": "2024-02-16T18:36:28Z"
+      },
+      "spec": {
+        "description": "Use the kubernetes API for feature toggle management in the frontend",
+        "stage": "experimental",
+        "codeowner": "@grafana/grafana-operator-experience-squad",
+        "frontend": true,
+        "hideFromAdminPage": true
+      }
+    },
+    {
+      "metadata": {
+        "name": "expressionParser",
+        "resourceVersion": "1708108588074",
+        "creationTimestamp": "2024-02-16T18:36:28Z"
+      },
+      "spec": {
+        "description": "Enable new expression parser",
+        "stage": "experimental",
+        "codeowner": "@grafana/grafana-app-platform-squad",
+        "requiresRestart": true
+      }
+    },
+    {
+      "metadata": {
+        "name": "autoMigrateStatPanel",
+        "resourceVersion": "1708108588074",
+        "creationTimestamp": "2024-02-16T18:36:28Z"
+      },
+      "spec": {
+        "description": "Migrate old stat panel to supported stat panel - broken out from autoMigrateOldPanels to enable granular tracking",
+        "stage": "preview",
+        "codeowner": "@grafana/dataviz-squad",
+        "frontend": true
+      }
+    },
+    {
+      "metadata": {
+        "name": "renderAuthJWT",
+        "resourceVersion": "1708108588074",
+        "creationTimestamp": "2024-02-16T18:36:28Z"
+      },
+      "spec": {
+        "description": "Uses JWT-based auth for rendering instead of relying on remote cache",
+        "stage": "preview",
+        "codeowner": "@grafana/grafana-as-code",
+        "hideFromAdminPage": true
+      }
+    },
+    {
+      "metadata": {
+        "name": "permissionsFilterRemoveSubquery",
+        "resourceVersion": "1708108588074",
+        "creationTimestamp": "2024-02-16T18:36:28Z"
+      },
+      "spec": {
+        "description": "Alternative permission filter implementation that does not use subqueries for fetching the dashboard folder",
+        "stage": "experimental",
+        "codeowner": "@grafana/backend-platform"
+      }
+    },
+    {
+      "metadata": {
+        "name": "pdfTables",
+        "resourceVersion": "1708108588074",
+        "creationTimestamp": "2024-02-16T18:36:28Z"
+      },
+      "spec": {
+        "description": "Enables generating table data as PDF in reporting",
+        "stage": "preview",
+        "codeowner": "@grafana/sharing-squad"
+      }
+    },
+    {
+      "metadata": {
+        "name": "influxqlStreamingParser",
+        "resourceVersion": "1708108588074",
+        "creationTimestamp": "2024-02-16T18:36:28Z"
+      },
+      "spec": {
+        "description": "Enable streaming JSON parser for InfluxDB datasource InfluxQL query language",
+        "stage": "experimental",
+        "codeowner": "@grafana/observability-metrics"
+      }
+    },
+    {
+      "metadata": {
+        "name": "showDashboardValidationWarnings",
+        "resourceVersion": "1708108588074",
+        "creationTimestamp": "2024-02-16T18:36:28Z"
+      },
+      "spec": {
+        "description": "Show warnings when dashboards do not validate against the schema",
+        "stage": "experimental",
+        "codeowner": "@grafana/dashboards-squad"
+      }
+    },
+    {
+      "metadata": {
+        "name": "lokiQuerySplitting",
+        "resourceVersion": "1708108588074",
+        "creationTimestamp": "2024-02-16T18:36:28Z"
+      },
+      "spec": {
+        "description": "Split large interval queries into subqueries with smaller time intervals",
+        "stage": "GA",
+        "codeowner": "@grafana/observability-logs",
+        "frontend": true,
+        "allowSelfServe": true
+      }
+    },
+    {
+      "metadata": {
+        "name": "lokiMetricDataplane",
+        "resourceVersion": "1708108588074",
+        "creationTimestamp": "2024-02-16T18:36:28Z"
+      },
+      "spec": {
+        "description": "Changes metric responses from Loki to be compliant with the dataplane specification.",
+        "stage": "GA",
+        "codeowner": "@grafana/observability-logs",
+        "allowSelfServe": true
+      }
+    },
+    {
+      "metadata": {
+        "name": "dashboardEmbed",
+        "resourceVersion": "1708108588074",
+        "creationTimestamp": "2024-02-16T18:36:28Z"
+      },
+      "spec": {
+        "description": "Allow embedding dashboard for external use in Code editors",
+        "stage": "experimental",
+        "codeowner": "@grafana/grafana-as-code",
+        "frontend": true
+      }
+    },
+    {
+      "metadata": {
+        "name": "pluginsAPIMetrics",
+        "resourceVersion": "1708108588074",
+        "creationTimestamp": "2024-02-16T18:36:28Z"
+      },
+      "spec": {
+        "description": "Sends metrics of public grafana packages usage by plugins",
+        "stage": "experimental",
+        "codeowner": "@grafana/plugins-platform-backend",
+        "frontend": true
+      }
+    },
+    {
+      "metadata": {
+        "name": "awsDatasourcesNewFormStyling",
+        "resourceVersion": "1708108588074",
+        "creationTimestamp": "2024-02-16T18:36:28Z"
+      },
+      "spec": {
+        "description": "Applies new form styling for configuration and query editors in AWS plugins",
+        "stage": "preview",
+        "codeowner": "@grafana/aws-datasources",
+        "frontend": true
+      }
+    },
+    {
+      "metadata": {
+        "name": "dashboardScene",
+        "resourceVersion": "1708108588074",
+        "creationTimestamp": "2024-02-16T18:36:28Z"
+      },
+      "spec": {
+        "description": "Enables dashboard rendering using scenes for all roles",
+        "stage": "experimental",
+        "codeowner": "@grafana/dashboards-squad",
+        "frontend": true
+      }
+    },
+    {
+      "metadata": {
+        "name": "canvasPanelNesting",
+        "resourceVersion": "1708108588074",
+        "creationTimestamp": "2024-02-16T18:36:28Z"
+      },
+      "spec": {
+        "description": "Allow elements nesting",
+        "stage": "experimental",
+        "codeowner": "@grafana/dataviz-squad",
+        "frontend": true,
+        "hideFromAdminPage": true
+      }
+    },
+    {
+      "metadata": {
         "name": "alertingSaveStatePeriodic",
-        "resourceVersion": "1709568338306",
-        "creationTimestamp": "2024-03-04T16:05:38Z"
+        "resourceVersion": "1708108588074",
+        "creationTimestamp": "2024-02-16T18:36:28Z"
       },
       "spec": {
         "description": "Writes the state periodically to the database, asynchronous to rule evaluation",
@@ -2074,12 +1815,333 @@
     },
     {
       "metadata": {
-        "name": "betterPageScrolling",
-        "resourceVersion": "1709581798271",
-        "creationTimestamp": "2024-03-04T19:49:10Z",
+        "name": "sseGroupByDatasource",
+        "resourceVersion": "1708108588074",
+        "creationTimestamp": "2024-02-16T18:36:28Z"
+      },
+      "spec": {
+        "description": "Send query to the same datasource in a single request when using server side expressions. The `cloudWatchBatchQueries` feature toggle should be enabled if this used with CloudWatch.",
+        "stage": "experimental",
+        "codeowner": "@grafana/observability-metrics"
+      }
+    },
+    {
+      "metadata": {
+        "name": "kubernetesQueryServiceRewrite",
+        "resourceVersion": "1708108588074",
+        "creationTimestamp": "2024-02-16T18:36:28Z"
+      },
+      "spec": {
+        "description": "Rewrite requests targeting /ds/query to the query service",
+        "stage": "experimental",
+        "codeowner": "@grafana/grafana-app-platform-squad",
+        "requiresDevMode": true,
+        "requiresRestart": true
+      }
+    },
+    {
+      "metadata": {
+        "name": "exploreContentOutline",
+        "resourceVersion": "1708108588074",
+        "creationTimestamp": "2024-02-16T18:36:28Z"
+      },
+      "spec": {
+        "description": "Content outline sidebar",
+        "stage": "GA",
+        "codeowner": "@grafana/explore-squad",
+        "frontend": true,
+        "allowSelfServe": true
+      }
+    },
+    {
+      "metadata": {
+        "name": "recordedQueriesMulti",
+        "resourceVersion": "1708108588074",
+        "creationTimestamp": "2024-02-16T18:36:28Z"
+      },
+      "spec": {
+        "description": "Enables writing multiple items from a single query within Recorded Queries",
+        "stage": "GA",
+        "codeowner": "@grafana/observability-metrics"
+      }
+    },
+    {
+      "metadata": {
+        "name": "alertingInsights",
+        "resourceVersion": "1708108588074",
+        "creationTimestamp": "2024-02-16T18:36:28Z"
+      },
+      "spec": {
+        "description": "Show the new alerting insights landing page",
+        "stage": "GA",
+        "codeowner": "@grafana/alerting-squad",
+        "frontend": true,
+        "hideFromAdminPage": true
+      }
+    },
+    {
+      "metadata": {
+        "name": "idForwarding",
+        "resourceVersion": "1708108588074",
+        "creationTimestamp": "2024-02-16T18:36:28Z"
+      },
+      "spec": {
+        "description": "Generate signed id token for identity that can be forwarded to plugins and external services",
+        "stage": "experimental",
+        "codeowner": "@grafana/identity-access-team"
+      }
+    },
+    {
+      "metadata": {
+        "name": "enableNativeHTTPHistogram",
+        "resourceVersion": "1708108588074",
+        "creationTimestamp": "2024-02-16T18:36:28Z"
+      },
+      "spec": {
+        "description": "Enables native HTTP Histograms",
+        "stage": "experimental",
+        "codeowner": "@grafana/hosted-grafana-team"
+      }
+    },
+    {
+      "metadata": {
+        "name": "alertmanagerRemoteOnly",
+        "resourceVersion": "1708108588074",
+        "creationTimestamp": "2024-02-16T18:36:28Z"
+      },
+      "spec": {
+        "description": "Disable the internal Alertmanager and only use the external one defined.",
+        "stage": "experimental",
+        "codeowner": "@grafana/alerting-squad"
+      }
+    },
+    {
+      "metadata": {
+        "name": "influxdbRunQueriesInParallel",
+        "resourceVersion": "1708108588074",
+        "creationTimestamp": "2024-02-16T18:36:28Z"
+      },
+      "spec": {
+        "description": "Enables running InfluxDB Influxql queries in parallel",
+        "stage": "privatePreview",
+        "codeowner": "@grafana/observability-metrics"
+      }
+    },
+    {
+      "metadata": {
+        "name": "newVizTooltips",
+        "resourceVersion": "1708108588074",
+        "creationTimestamp": "2024-02-16T18:36:28Z"
+      },
+      "spec": {
+        "description": "New visualizations tooltips UX",
+        "stage": "preview",
+        "codeowner": "@grafana/dataviz-squad",
+        "frontend": true
+      }
+    },
+    {
+      "metadata": {
+        "name": "prometheusMetricEncyclopedia",
+        "resourceVersion": "1708108588074",
+        "creationTimestamp": "2024-02-16T18:36:28Z"
+      },
+      "spec": {
+        "description": "Adds the metrics explorer component to the Prometheus query builder as an option in metric select",
+        "stage": "GA",
+        "codeowner": "@grafana/observability-metrics",
+        "frontend": true,
+        "allowSelfServe": true
+      }
+    },
+    {
+      "metadata": {
+        "name": "pluginsDynamicAngularDetectionPatterns",
+        "resourceVersion": "1708108588074",
+        "creationTimestamp": "2024-02-16T18:36:28Z"
+      },
+      "spec": {
+        "description": "Enables fetching Angular detection patterns for plugins from GCOM and fallback to hardcoded ones",
+        "stage": "experimental",
+        "codeowner": "@grafana/plugins-platform-backend"
+      }
+    },
+    {
+      "metadata": {
+        "name": "cloudWatchBatchQueries",
+        "resourceVersion": "1708108588074",
+        "creationTimestamp": "2024-02-16T18:36:28Z"
+      },
+      "spec": {
+        "description": "Runs CloudWatch metrics queries as separate batches",
+        "stage": "preview",
+        "codeowner": "@grafana/aws-datasources"
+      }
+    },
+    {
+      "metadata": {
+        "name": "alertingUpgradeDryrunOnStart",
+        "resourceVersion": "1708108588074",
+        "creationTimestamp": "2024-02-16T18:36:28Z"
+      },
+      "spec": {
+        "description": "When activated in legacy alerting mode, this initiates a dry-run of the Unified Alerting upgrade during each startup. It logs any issues detected without implementing any actual changes.",
+        "stage": "GA",
+        "codeowner": "@grafana/alerting-squad",
+        "requiresRestart": true
+      }
+    },
+    {
+      "metadata": {
+        "name": "autoMigrateOldPanels",
+        "resourceVersion": "1708108588074",
+        "creationTimestamp": "2024-02-16T18:36:28Z"
+      },
+      "spec": {
+        "description": "Migrate old angular panels to supported versions (graph, table-old, worldmap, etc)",
+        "stage": "preview",
+        "codeowner": "@grafana/dataviz-squad",
+        "frontend": true
+      }
+    },
+    {
+      "metadata": {
+        "name": "externalCorePlugins",
+        "resourceVersion": "1708108588074",
+        "creationTimestamp": "2024-02-16T18:36:28Z"
+      },
+      "spec": {
+        "description": "Allow core plugins to be loaded as external",
+        "stage": "experimental",
+        "codeowner": "@grafana/plugins-platform-backend"
+      }
+    },
+    {
+      "metadata": {
+        "name": "alertingNoNormalState",
+        "resourceVersion": "1708108588074",
+        "creationTimestamp": "2024-02-16T18:36:28Z"
+      },
+      "spec": {
+        "description": "Stop maintaining state of alerts that are not firing",
+        "stage": "preview",
+        "codeowner": "@grafana/alerting-squad",
+        "hideFromAdminPage": true
+      }
+    },
+    {
+      "metadata": {
+        "name": "dataplaneFrontendFallback",
+        "resourceVersion": "1708108588074",
+        "creationTimestamp": "2024-02-16T18:36:28Z"
+      },
+      "spec": {
+        "description": "Support dataplane contract field name change for transformations and field name matchers where the name is different",
+        "stage": "GA",
+        "codeowner": "@grafana/observability-metrics",
+        "frontend": true,
+        "allowSelfServe": true
+      }
+    },
+    {
+      "metadata": {
+        "name": "disableSSEDataplane",
+        "resourceVersion": "1708108588074",
+        "creationTimestamp": "2024-02-16T18:36:28Z"
+      },
+      "spec": {
+        "description": "Disables dataplane specific processing in server side expressions.",
+        "stage": "experimental",
+        "codeowner": "@grafana/observability-metrics"
+      }
+    },
+    {
+      "metadata": {
+        "name": "lokiPredefinedOperations",
+        "resourceVersion": "1708108588074",
+        "creationTimestamp": "2024-02-16T18:36:28Z"
+      },
+      "spec": {
+        "description": "Adds predefined query operations to Loki query editor",
+        "stage": "experimental",
+        "codeowner": "@grafana/observability-logs",
+        "frontend": true
+      }
+    },
+    {
+      "metadata": {
+        "name": "configurableSchedulerTick",
+        "resourceVersion": "1708108588074",
+        "creationTimestamp": "2024-02-16T18:36:28Z"
+      },
+      "spec": {
+        "description": "Enable changing the scheduler base interval via configuration option unified_alerting.scheduler_tick_interval",
+        "stage": "experimental",
+        "codeowner": "@grafana/alerting-squad",
+        "requiresRestart": true,
+        "hideFromDocs": true
+      }
+    },
+    {
+      "metadata": {
+        "name": "kubernetesPlaylists",
+        "resourceVersion": "1708108588074",
+        "creationTimestamp": "2024-02-16T18:36:28Z"
+      },
+      "spec": {
+        "description": "Use the kubernetes API in the frontend for playlists, and route /api/playlist requests to k8s",
+        "stage": "experimental",
+        "codeowner": "@grafana/grafana-app-platform-squad",
+        "requiresRestart": true
+      }
+    },
+    {
+      "metadata": {
+        "name": "datatrails",
+        "resourceVersion": "1708108588074",
+        "creationTimestamp": "2024-02-16T18:36:28Z"
+      },
+      "spec": {
+        "description": "Enables the new core app datatrails",
+        "stage": "experimental",
+        "codeowner": "@grafana/dashboards-squad",
+        "frontend": true,
+        "hideFromDocs": true
+      }
+    },
+    {
+      "metadata": {
+        "name": "editPanelCSVDragAndDrop",
+        "resourceVersion": "1708108588074",
+        "creationTimestamp": "2024-02-16T18:36:28Z"
+      },
+      "spec": {
+        "description": "Enables drag and drop for CSV and Excel files",
+        "stage": "experimental",
+        "codeowner": "@grafana/dataviz-squad",
+        "frontend": true
+      }
+    },
+    {
+      "metadata": {
+        "name": "sqlExpressions",
+        "resourceVersion": "1709044973784",
+        "creationTimestamp": "2024-02-19T22:46:11Z",
         "annotations": {
-          "grafana.app/updatedTimestamp": "2024-03-04 19:49:58.271886389 +0000 UTC"
+          "grafana.app/updatedTimestamp": "2024-02-27 14:42:53.784398 +0000 UTC"
         }
+      },
+      "spec": {
+        "description": "Enables using SQL and DuckDB functions as Expressions.",
+        "stage": "experimental",
+        "codeowner": "@grafana/grafana-app-platform-squad"
+      }
+    },
+    {
+      "metadata": {
+        "name": "betterPageScrolling",
+        "resourceVersion": "1709583501630",
+        "creationTimestamp": "2024-03-04T20:18:21Z"
       },
       "spec": {
         "description": "Removes CustomScrollbar from the UI, relying on native browser scrollbars",

--- a/pkg/services/featuremgmt/toggles_gen.json
+++ b/pkg/services/featuremgmt/toggles_gen.json
@@ -1810,7 +1810,8 @@
       "metadata": {
         "name": "removeCustomScrollbars",
         "resourceVersion": "1709568338306",
-        "creationTimestamp": "2024-03-04T16:05:38Z"
+        "creationTimestamp": "2024-03-04T16:05:38Z",
+        "deletionTimestamp": "2024-03-04T19:50:02Z"
       },
       "spec": {
         "description": "Removes CustomScrollbar from the UI, relying on native browser scrollbars",
@@ -2069,6 +2070,22 @@
         "description": "Writes the state periodically to the database, asynchronous to rule evaluation",
         "stage": "privatePreview",
         "codeowner": "@grafana/alerting-squad"
+      }
+    },
+    {
+      "metadata": {
+        "name": "betterPageScrolling",
+        "resourceVersion": "1709581798271",
+        "creationTimestamp": "2024-03-04T19:49:10Z",
+        "annotations": {
+          "grafana.app/updatedTimestamp": "2024-03-04 19:49:58.271886389 +0000 UTC"
+        }
+      },
+      "spec": {
+        "description": "Removes CustomScrollbar from the UI, relying on native browser scrollbars",
+        "stage": "GA",
+        "codeowner": "@grafana/grafana-frontend-platform",
+        "frontend": true
       }
     }
   ]

--- a/pkg/services/featuremgmt/toggles_gen_test.go
+++ b/pkg/services/featuremgmt/toggles_gen_test.go
@@ -126,7 +126,7 @@ func TestFeatureToggleFiles(t *testing.T) {
 						item.Annotations[utils.AnnoKeyUpdatedTimestamp] = created.String()
 						item.Spec = v // the current value
 					}
-				} else {
+				} else if item.DeletionTimestamp == nil {
 					item.DeletionTimestamp = &created
 					fmt.Printf("mark feature as deleted")
 				}

--- a/public/app/app.ts
+++ b/public/app/app.ts
@@ -132,7 +132,11 @@ export class GrafanaApp {
       initIconCache();
       // This needs to be done after the `initEchoSrv` since it is being used under the hood.
       startMeasure('frontend_app_init');
-      addClassIfNoOverlayScrollbar();
+
+      if (!config.featureToggles.betterPageScrolling) {
+        addClassIfNoOverlayScrollbar();
+      }
+
       setLocale(config.bootData.user.locale);
       setWeekStart(config.bootData.user.weekStart);
       setPanelRenderer(PanelRenderer);

--- a/public/app/core/components/FlaggedScroller.tsx
+++ b/public/app/core/components/FlaggedScroller.tsx
@@ -7,7 +7,7 @@ import { CustomScrollbar, useStyles2 } from '@grafana/ui';
 type FlaggedScrollerProps = Parameters<typeof CustomScrollbar>[0];
 
 export default function FlaggedScrollbar(props: FlaggedScrollerProps) {
-  if (config.featureToggles.removeCustomScrollbars) {
+  if (config.featureToggles.betterPageScrolling) {
     return <NativeScrollbar {...props}>{props.children}</NativeScrollbar>;
   }
 

--- a/public/app/core/components/FlaggedScroller.tsx
+++ b/public/app/core/components/FlaggedScroller.tsx
@@ -1,11 +1,14 @@
+import { css } from '@emotion/css';
 import React, { useEffect } from 'react';
 
+import { GrafanaTheme2 } from '@grafana/data';
 import { config } from '@grafana/runtime';
-import { CustomScrollbar, useTheme2 } from '@grafana/ui';
+import { CustomScrollbar, useStyles2, useTheme2 } from '@grafana/ui';
 
 type FlaggedScrollerProps = Parameters<typeof CustomScrollbar>[0];
 
 export default function FlaggedScroller(props: FlaggedScrollerProps) {
+  const styles = useStyles2(getStyles);
   const theme = useTheme2();
 
   useEffect(() => {
@@ -16,8 +19,21 @@ export default function FlaggedScroller(props: FlaggedScrollerProps) {
   }, [theme]);
 
   if (config.featureToggles.removeCustomScrollbars) {
-    return props.children;
+    return <div className={styles.nativeScrollbars}>{props.children}</div>;
   }
 
   return <CustomScrollbar {...props} />;
+}
+
+function getStyles(theme: GrafanaTheme2) {
+  return {
+    nativeScrollbars: css({
+      minHeight: `calc(100% + 0px)`,
+      maxHeight: `calc(100% + 0px)`,
+      display: 'flex',
+      flexDirection: 'column',
+      flexGrow: 1,
+      overflow: 'auto',
+    }),
+  };
 }

--- a/public/app/core/components/FlaggedScroller.tsx
+++ b/public/app/core/components/FlaggedScroller.tsx
@@ -1,4 +1,4 @@
-import { css } from '@emotion/css';
+import { css, cx } from '@emotion/css';
 import React, { useEffect, useRef } from 'react';
 
 import { config } from '@grafana/runtime';
@@ -32,7 +32,8 @@ function NativeScrollbar({ children, scrollRefCallback, scrollTop }: FlaggedScro
   }, [scrollTop]);
 
   return (
-    <div ref={ref} className={styles.nativeScrollbars}>
+    // Set the .scrollbar-view class to help e2e tests find this, like in CustomScrollbar
+    <div ref={ref} className={cx(styles.nativeScrollbars, 'scrollbar-view')}>
       {children}
     </div>
   );

--- a/public/app/core/components/FlaggedScroller.tsx
+++ b/public/app/core/components/FlaggedScroller.tsx
@@ -1,0 +1,23 @@
+import React, { useEffect } from 'react';
+
+import { config } from '@grafana/runtime';
+import { CustomScrollbar, useTheme2 } from '@grafana/ui';
+
+type FlaggedScrollerProps = Parameters<typeof CustomScrollbar>[0];
+
+export default function FlaggedScroller(props: FlaggedScrollerProps) {
+  const theme = useTheme2();
+
+  useEffect(() => {
+    if (config.featureToggles.removeCustomScrollbars && window.location.search.includes('styleScrollbars')) {
+      // @ts-ignore - no, trust me, scrollbarColor really is there
+      document.body.style.scrollbarColor = `${theme.colors.action.focus} transparent`;
+    }
+  }, [theme]);
+
+  if (config.featureToggles.removeCustomScrollbars) {
+    return props.children;
+  }
+
+  return <CustomScrollbar {...props} />;
+}

--- a/public/app/core/components/Page/Page.tsx
+++ b/public/app/core/components/Page/Page.tsx
@@ -2,11 +2,10 @@ import { css, cx } from '@emotion/css';
 import React, { useLayoutEffect } from 'react';
 
 import { GrafanaTheme2, PageLayoutType } from '@grafana/data';
-import { config } from '@grafana/runtime';
 import { useStyles2 } from '@grafana/ui';
 import { useGrafana } from 'app/core/context/GrafanaContext';
 
-import FlaggedScroller from '../FlaggedScroller';
+import FlaggedScrollbar from '../FlaggedScroller';
 
 import { PageContents } from './PageContents';
 import { PageHeader } from './PageHeader';
@@ -51,13 +50,10 @@ export const Page: PageType = ({
     }
   }, [navModel, pageNav, chrome, layout]);
 
-  // When the
-  // const applyPrimaryBgClass = config.featureToggles.removeCustomScrollbars && layout === PageLayoutType.Standard;
-
   return (
     <div className={cx(styles.wrapper, className)} {...otherProps}>
       {layout === PageLayoutType.Standard && (
-        <FlaggedScroller autoHeightMin={'100%'} scrollTop={scrollTop} scrollRefCallback={scrollRef}>
+        <FlaggedScrollbar autoHeightMin={'100%'} scrollTop={scrollTop} scrollRefCallback={scrollRef}>
           <div className={styles.pageInner}>
             {pageHeaderNav && (
               <PageHeader
@@ -72,13 +68,13 @@ export const Page: PageType = ({
             {pageNav && pageNav.children && <PageTabs navItem={pageNav} />}
             <div className={styles.pageContent}>{children}</div>
           </div>
-        </FlaggedScroller>
+        </FlaggedScrollbar>
       )}
 
       {layout === PageLayoutType.Canvas && (
-        <FlaggedScroller autoHeightMin={'100%'} scrollTop={scrollTop} scrollRefCallback={scrollRef}>
+        <FlaggedScrollbar autoHeightMin={'100%'} scrollTop={scrollTop} scrollRefCallback={scrollRef}>
           <div className={styles.canvasContent}>{children}</div>
-        </FlaggedScroller>
+        </FlaggedScrollbar>
       )}
 
       {layout === PageLayoutType.Custom && children}

--- a/public/app/core/components/Page/Page.tsx
+++ b/public/app/core/components/Page/Page.tsx
@@ -2,6 +2,7 @@ import { css, cx } from '@emotion/css';
 import React, { useLayoutEffect } from 'react';
 
 import { GrafanaTheme2, PageLayoutType } from '@grafana/data';
+import { config } from '@grafana/runtime';
 import { useStyles2 } from '@grafana/ui';
 import { useGrafana } from 'app/core/context/GrafanaContext';
 
@@ -50,6 +51,9 @@ export const Page: PageType = ({
     }
   }, [navModel, pageNav, chrome, layout]);
 
+  // When the
+  // const applyPrimaryBgClass = config.featureToggles.removeCustomScrollbars && layout === PageLayoutType.Standard;
+
   return (
     <div className={cx(styles.wrapper, className)} {...otherProps}>
       {layout === PageLayoutType.Standard && (
@@ -97,6 +101,9 @@ const getStyles = (theme: GrafanaTheme2) => {
     pageContent: css({
       label: 'page-content',
       flexGrow: 1,
+    }),
+    primaryBg: css({
+      background: theme.colors.background.primary,
     }),
     pageInner: css({
       label: 'page-inner',

--- a/public/app/core/components/Page/Page.tsx
+++ b/public/app/core/components/Page/Page.tsx
@@ -1,10 +1,11 @@
-// Libraries
 import { css, cx } from '@emotion/css';
 import React, { useLayoutEffect } from 'react';
 
 import { GrafanaTheme2, PageLayoutType } from '@grafana/data';
-import { CustomScrollbar, useStyles2 } from '@grafana/ui';
+import { useStyles2 } from '@grafana/ui';
 import { useGrafana } from 'app/core/context/GrafanaContext';
+
+import FlaggedScroller from '../FlaggedScroller';
 
 import { PageContents } from './PageContents';
 import { PageHeader } from './PageHeader';
@@ -52,7 +53,7 @@ export const Page: PageType = ({
   return (
     <div className={cx(styles.wrapper, className)} {...otherProps}>
       {layout === PageLayoutType.Standard && (
-        <CustomScrollbar autoHeightMin={'100%'} scrollTop={scrollTop} scrollRefCallback={scrollRef}>
+        <FlaggedScroller autoHeightMin={'100%'} scrollTop={scrollTop} scrollRefCallback={scrollRef}>
           <div className={styles.pageInner}>
             {pageHeaderNav && (
               <PageHeader
@@ -67,13 +68,15 @@ export const Page: PageType = ({
             {pageNav && pageNav.children && <PageTabs navItem={pageNav} />}
             <div className={styles.pageContent}>{children}</div>
           </div>
-        </CustomScrollbar>
+        </FlaggedScroller>
       )}
+
       {layout === PageLayoutType.Canvas && (
-        <CustomScrollbar autoHeightMin={'100%'} scrollTop={scrollTop} scrollRefCallback={scrollRef}>
+        <FlaggedScroller autoHeightMin={'100%'} scrollTop={scrollTop} scrollRefCallback={scrollRef}>
           <div className={styles.canvasContent}>{children}</div>
-        </CustomScrollbar>
+        </FlaggedScroller>
       )}
+
       {layout === PageLayoutType.Custom && children}
     </div>
   );

--- a/public/app/core/components/Page/types.ts
+++ b/public/app/core/components/Page/types.ts
@@ -20,9 +20,15 @@ export interface PageProps extends HTMLAttributes<HTMLDivElement> {
   subTitle?: React.ReactNode;
   /** Control the page layout. */
   layout?: PageLayoutType;
-  /** Can be used to get the scroll container element to access scroll position */
+  /**
+   * @deprecated - not used with removeCustomScrollbars feature flag
+   * Can be used to get the scroll container element to access scroll position
+   * */
   scrollRef?: RefCallback<HTMLDivElement>;
-  /** Can be used to update the current scroll position */
+  /**
+   * @deprecated - not used with removeCustomScrollbars feature flag
+   * Can be used to update the current scroll position
+   * */
   scrollTop?: number;
 }
 

--- a/public/app/core/components/Page/types.ts
+++ b/public/app/core/components/Page/types.ts
@@ -21,14 +21,14 @@ export interface PageProps extends HTMLAttributes<HTMLDivElement> {
   /** Control the page layout. */
   layout?: PageLayoutType;
   /**
-   * @deprecated - not used with removeCustomScrollbars feature flag
    * Can be used to get the scroll container element to access scroll position
    * */
+  // Probably will deprecate this in the future in favor of just scrolling document.body directly
   scrollRef?: RefCallback<HTMLDivElement>;
   /**
-   * @deprecated - not used with removeCustomScrollbars feature flag
    * Can be used to update the current scroll position
    * */
+  // Probably will deprecate this in the future in favor of just scrolling document.body directly
   scrollTop?: number;
 }
 

--- a/public/app/plugins/panel/gettingstarted/components/Step.tsx
+++ b/public/app/plugins/panel/gettingstarted/components/Step.tsx
@@ -56,7 +56,7 @@ const getStyles = (theme: GrafanaTheme2) => {
       color: theme.v1.palette.blue95,
     }),
     cards: css({
-      overflow: 'auto',
+      overflowX: 'auto',
       overflowY: 'hidden',
       width: '100%',
       display: 'flex',

--- a/public/app/plugins/panel/gettingstarted/components/Step.tsx
+++ b/public/app/plugins/panel/gettingstarted/components/Step.tsx
@@ -37,30 +37,30 @@ export const Step = ({ step }: Props) => {
 
 const getStyles = (theme: GrafanaTheme2) => {
   return {
-    setup: css`
-      display: flex;
-      width: 95%;
-    `,
-    info: css`
-      width: 172px;
-      margin-right: 5%;
+    setup: css({
+      display: 'flex',
+      width: '95%',
+    }),
+    info: css({
+      width: '172px',
+      marginRight: '5%',
 
-      ${theme.breakpoints.down('xxl')} {
-        margin-right: ${theme.spacing(4)};
-      }
-      ${theme.breakpoints.down('sm')} {
-        display: none;
-      }
-    `,
-    title: css`
-      color: ${theme.v1.palette.blue95};
-    `,
-    cards: css`
-      overflow-x: scroll;
-      overflow-y: hidden;
-      width: 100%;
-      display: flex;
-      justify-content: flex-start;
-    `,
+      [theme.breakpoints.down('xxl')]: {
+        marginRight: theme.spacing(4),
+      },
+      [theme.breakpoints.down('sm')]: {
+        display: 'none',
+      },
+    }),
+    title: css({
+      color: theme.v1.palette.blue95,
+    }),
+    cards: css({
+      overflow: 'auto',
+      overflowY: 'hidden',
+      width: '100%',
+      display: 'flex',
+      justifyContent: 'flex-start',
+    }),
   };
 };

--- a/public/sass/components/_scrollbar.scss
+++ b/public/sass/components/_scrollbar.scss
@@ -115,6 +115,7 @@
 }
 
 // Scrollbars
+// Note, this is not applied by default if the `betterPageScrolling` feature flag is applied
 .no-overlay-scrollbar {
   ::-webkit-scrollbar {
     width: 8px;


### PR DESCRIPTION
This PR removes the `<CustomScrollbar />` component from the main `<Page />`, to prefer using platform default scrollbars. This behaviour is controlled via the `betterPageScrolling` feature toggle, which is enabled by default.

As raised in https://github.com/grafana/grafana/issues/80429, there's now cross-browser support for customising the native browser scrollbar in a limited and declarative manner. However, I believe there is little need to customise the scroll bar at at least the page level - we should defer to doing less and preferring platform defaults.

This PR adds a new 'FlaggedScrollbars' interim component that wraps grafana-ui's CustomScrollbars, or uses a `NativeScrollbars` component when the toggle is enabled. The goal is to later remove `FlaggedScrollbars` and `NativeScrollbars`, and just scroll the document body element.

Part of https://github.com/grafana/grafana/issues/80429 

## Screenshots

On Windows, Chrome does not use 'overlay' scroll bars, so they used to get CustomScrollbars. Firefox does use overlay scroll bars, is it never used CustomScrollbars, and should see no change through this

### Regular tall page

| Before (default) | Before (hover) | After | Firefox |
|---|---|---|-|
| ![image](https://github.com/grafana/grafana/assets/46142/1a5d8e9e-6b56-493b-86f6-89e8e5c82877)  | ![image](https://github.com/grafana/grafana/assets/46142/d47dad29-4ac2-4960-9417-5ab95fd5de06)  |  ![image](https://github.com/grafana/grafana/assets/46142/c55e13fc-1470-4916-91e3-0000599577d0) | ![image](https://github.com/grafana/grafana/assets/46142/822599d8-2587-42bf-9c4c-9b5937e036b3) |



### Non-scrolling page

| Before | After | Firefox |
|--------|-------|---------|
| ![image](https://github.com/grafana/grafana/assets/46142/6720e543-c598-4040-8d9e-a4dea8e9b7f2) | ![image](https://github.com/grafana/grafana/assets/46142/f67a84fd-c58e-495a-844d-1ba4097e9767) | ![image](https://github.com/grafana/grafana/assets/46142/52d4e67c-453d-4d1f-8fea-d40b72343954) |
 



### Small dashboard without scroll bars

| Before | After | Firefox |
|--------|-------|---------|
| ![image](https://github.com/grafana/grafana/assets/46142/01c1d07b-4bfe-4d7e-a37b-cf861a937e5d) | ![image](https://github.com/grafana/grafana/assets/46142/8fefce2a-0c2d-4cc3-8376-194c64a133a0) | ![image](https://github.com/grafana/grafana/assets/46142/9332621f-0e8e-41a6-a257-bd696f2c8a65) |



### Large dashboard with scroll bars

| Before | After | Firefox |
|--------|-------|---------|
| ![image](https://github.com/grafana/grafana/assets/46142/2cc15313-40cc-44e0-bff3-bf0e1aa68ed3) | ![image](https://github.com/grafana/grafana/assets/46142/e3ecbaac-a3a3-43c0-a493-3fab2e11fd8b) | ![image](https://github.com/grafana/grafana/assets/46142/7cf1a3f3-fb7d-4043-86d0-2a05c064bff1) |