### PR TITLE
VizTooltips: Fix series labels after zooming

### DIFF
--- a/packages/grafana-data/src/transformations/transformers/joinDataFrames.ts
+++ b/packages/grafana-data/src/transformations/transformers/joinDataFrames.ts
@@ -57,6 +57,11 @@ export interface JoinOptions {
   keepOriginIndices?: boolean;
 
   /**
+   * @internal -- keep any pre-cached state.displayName
+   */
+  keepDisplayNames?: boolean;
+
+  /**
    * @internal -- Optionally specify a join mode (outer or inner)
    */
   mode?: JoinMode;
@@ -223,8 +228,10 @@ export function joinDataFrames(options: JoinOptions): DataFrame | undefined {
     for (const field of fields) {
       a.push(field.values);
       originalFields.push(field);
-      // clear field displayName state
-      delete field.state?.displayName;
+      if (!options.keepDisplayNames) {
+        // clear field displayName state
+        delete field.state?.displayName;
+      }
       // store frame field order for tabular data join
       frameFieldsOrder.push(fieldsOrder);
       fieldsOrder++;

--- a/public/app/core/components/GraphNG/utils.ts
+++ b/public/app/core/components/GraphNG/utils.ts
@@ -110,6 +110,11 @@ export function preparePlotFrame(frames: DataFrame[], dimFields: XYFieldMatchers
     joinBy: dimFields.x,
     keep: dimFields.y,
     keepOriginIndices: true,
+
+    // the join transformer force-deletes our state.displayName cache unless keepDisplayNames: true
+    // https://github.com/grafana/grafana/pull/31121
+    // https://github.com/grafana/grafana/pull/71806
+    keepDisplayNames: true,
   });
 
   if (alignedFrame) {

--- a/public/app/core/components/TimelineChart/utils.ts
+++ b/public/app/core/components/TimelineChart/utils.ts
@@ -21,6 +21,7 @@ import {
   getFieldConfigWithMinMax,
   ThresholdsMode,
   TimeRange,
+  cacheFieldDisplayNames,
 } from '@grafana/data';
 import { maybeSortFrame } from '@grafana/data/src/transformations/transformers/joinDataFrames';
 import { applyNullInsertThreshold } from '@grafana/data/src/transformations/transformers/nulls/nullInsertThreshold';
@@ -437,6 +438,9 @@ export function prepareTimelineFields(
   if (!series?.length) {
     return { warn: 'No data in response' };
   }
+
+  cacheFieldDisplayNames(series);
+
   let hasTimeseries = false;
   const frames: DataFrame[] = [];
 

--- a/public/app/plugins/panel/timeseries/utils.ts
+++ b/public/app/plugins/panel/timeseries/utils.ts
@@ -10,6 +10,7 @@ import {
   isBooleanUnit,
   SortedVector,
   TimeRange,
+  cacheFieldDisplayNames,
 } from '@grafana/data';
 import { convertFieldType } from '@grafana/data/src/transformations/transformers/convertFieldType';
 import { applyNullInsertThreshold } from '@grafana/data/src/transformations/transformers/nulls/nullInsertThreshold';
@@ -81,6 +82,8 @@ export function prepareGraphableFields(
   if (!series?.length) {
     return null;
   }
+
+  cacheFieldDisplayNames(series);
 
   let useNumericX = xNumFieldIdx != null;
 


### PR DESCRIPTION
in https://github.com/grafana/grafana/pull/82278 we broke series labels in `newVizTooltips` after a zoom or data update happened. this affects all panels that internally use the `join()` transform: TimeSeries, Trend, Candlestick, StateTimeline, StatusHistory. the reason for this is that we now use the `state.displayName` cache, which the join transform clears, resulting in a tooltip where every series label is `Value`.

with `newVizTooltips` enabled, try zooming here:

<details><summary>test-displayName</summary>

```json
{
  "annotations": {
    "list": [
      {
        "builtIn": 1,
        "datasource": {
          "type": "grafana",
          "uid": "-- Grafana --"
        },
        "enable": true,
        "hide": true,
        "iconColor": "rgba(0, 211, 255, 1)",
        "name": "Annotations & Alerts",
        "type": "dashboard"
      }
    ]
  },
  "editable": true,
  "fiscalYearStartMonth": 0,
  "graphTooltip": 0,
  "id": 960,
  "links": [],
  "panels": [
    {
      "datasource": {
        "type": "grafana-testdata-datasource",
        "uid": "PD8C576611E62080A"
      },
      "fieldConfig": {
        "defaults": {
          "color": {
            "mode": "palette-classic"
          },
          "custom": {
            "axisBorderShow": false,
            "axisCenteredZero": false,
            "axisColorMode": "text",
            "axisLabel": "",
            "axisPlacement": "auto",
            "barAlignment": 0,
            "drawStyle": "line",
            "fillOpacity": 0,
            "gradientMode": "none",
            "hideFrom": {
              "legend": false,
              "tooltip": false,
              "viz": false
            },
            "insertNulls": false,
            "lineInterpolation": "linear",
            "lineWidth": 1,
            "pointSize": 5,
            "scaleDistribution": {
              "type": "linear"
            },
            "showPoints": "auto",
            "spanNulls": false,
            "stacking": {
              "group": "A",
              "mode": "none"
            },
            "thresholdsStyle": {
              "mode": "off"
            }
          },
          "mappings": [],
          "thresholds": {
            "mode": "absolute",
            "steps": [
              {
                "color": "green",
                "value": null
              },
              {
                "color": "red",
                "value": 80
              }
            ]
          }
        },
        "overrides": []
      },
      "gridPos": {
        "h": 8,
        "w": 12,
        "x": 0,
        "y": 0
      },
      "id": 1,
      "maxDataPoints": 20,
      "options": {
        "legend": {
          "calcs": [],
          "displayMode": "list",
          "placement": "bottom",
          "showLegend": true
        },
        "tooltip": {
          "mode": "multi",
          "sort": "none"
        }
      },
      "targets": [
        {
          "datasource": {
            "type": "grafana-testdata-datasource",
            "uid": "PD8C576611E62080A"
          },
          "rawFrameContent": "[\n  {\n    \"schema\": {\n      \"refId\": \"A\",\n      \"meta\": {\n        \"typeVersion\": [\n          0,\n          0\n        ],\n        \"custom\": {\n          \"customStat\": 10\n        }\n      },\n      \"fields\": [\n        {\n          \"name\": \"time\",\n          \"type\": \"time\",\n          \"typeInfo\": {\n            \"frame\": \"time.Time\",\n            \"nullable\": true\n          },\n          \"config\": {\n            \"interval\": 1200000\n          }\n        },\n        {\n          \"name\": \"Value\",\n          \"type\": \"number\",\n          \"typeInfo\": {\n            \"frame\": \"float64\",\n            \"nullable\": true\n          },\n          \"labels\": {},\n          \"config\": {\n            \"displayNameFromDS\": \"/home\"\n          }\n        }\n      ]\n    },\n    \"data\": {\n      \"values\": [\n        [\n          1708124387714,\n          1708125587714,\n          1708126787714,\n          1708127987714,\n          1708129187714,\n          1708130387714,\n          1708131587714,\n          1708132787714,\n          1708133987714,\n          1708135187714,\n          1708136387714,\n          1708137587714,\n          1708138787714,\n          1708139987714,\n          1708141187714,\n          1708142387714,\n          1708143587714,\n          1708144787714\n        ],\n        [\n          87.74493454259552,\n          87.70327735227342,\n          87.60876417363104,\n          87.3933092289412,\n          87.69839285455646,\n          87.84473692332674,\n          87.78972865687192,\n          87.33196187893796,\n          87.52625485365458,\n          87.35940134893863,\n          87.59221125186751,\n          87.18378170823021,\n          87.59843933977962,\n          88.07412065509368,\n          88.4221077514413,\n          88.09336895466113,\n          88.13332372267072,\n          88.61968144662782\n        ]\n      ]\n    }\n  },\n  {\n    \"schema\": {\n      \"refId\": \"A\",\n      \"meta\": {\n        \"typeVersion\": [\n          0,\n          0\n        ],\n        \"custom\": {\n          \"customStat\": 10\n        }\n      },\n      \"fields\": [\n        {\n          \"name\": \"time\",\n          \"type\": \"time\",\n          \"typeInfo\": {\n            \"frame\": \"time.Time\",\n            \"nullable\": true\n          },\n          \"config\": {\n            \"interval\": 1200000\n          }\n        },\n        {\n          \"name\": \"Value\",\n          \"type\": \"number\",\n          \"typeInfo\": {\n            \"frame\": \"float64\",\n            \"nullable\": true\n          },\n          \"labels\": {},\n          \"config\": {\n            \"displayNameFromDS\": \"/var\"\n          }\n        }\n      ]\n    },\n    \"data\": {\n      \"values\": [\n        [\n          1708124387714,\n          1708125587714,\n          1708126787714,\n          1708127987714,\n          1708129187714,\n          1708130387714,\n          1708131587714,\n          1708132787714,\n          1708133987714,\n          1708135187714,\n          1708136387714,\n          1708137587714,\n          1708138787714,\n          1708139987714,\n          1708141187714,\n          1708142387714,\n          1708143587714,\n          1708144787714\n        ],\n        [\n          87.74493454259552,\n          88.22734969167445,\n          88.19230947445003,\n          88.5835591385582,\n          88.71762472501396,\n          88.58446735710271,\n          88.42702056059603,\n          88.33985440123418,\n          88.46144475891312,\n          88.07349872725625,\n          88.14284930613923,\n          87.98502828412816,\n          87.5955472960121,\n          87.63804908091646,\n          87.31162098297617,\n          87.40195427167482,\n          87.79796969069763,\n          88.18316423869722\n        ]\n      ]\n    }\n  }\n]",
          "refId": "A",
          "scenarioId": "raw_frame"
        }
      ],
      "title": "Panel Title",
      "type": "timeseries"
    }
  ],
  "schemaVersion": 39,
  "tags": [],
  "templating": {
    "list": []
  },
  "time": {
    "from": "now-6h",
    "to": "now"
  },
  "timepicker": {},
  "timezone": "browser",
  "title": "test-displayName",
  "uid": "fdd11lzkpshdsb",
  "version": 1,
  "weekStart": ""
}
```
</details>

<img width="351" alt="image" src="https://github.com/grafana/grafana/assets/43234/f43014b6-db60-4eef-b0f4-4b465ad03cca">

---
https://github.com/grafana/grafana/blob/f23f50f58d7ab5cb1fd88b42b6c58ec09c1a159d/packages/grafana-ui/src/components/VizTooltip/utils.ts#L131 