### PR TITLE
VizTooltips: Fix drag-zoom causing annotation init in other shared-cursor panels

### DIFF
--- a/packages/grafana-ui/src/components/uPlot/plugins/TooltipPlugin2.tsx
+++ b/packages/grafana-ui/src/components/uPlot/plugins/TooltipPlugin2.tsx
@@ -341,8 +341,10 @@ export const TooltipPlugin2 = ({
     });
 
     config.addHook('setSelect', (u) => {
-      if (clientZoom || queryZoom != null) {
-        if (maybeZoomAction(u.cursor!.event)) {
+      let e = u.cursor!.event;
+
+      if (e != null && (clientZoom || queryZoom != null)) {
+        if (maybeZoomAction(e)) {
           if (clientZoom && yDrag) {
             if (u.select.height >= MIN_ZOOM_DIST) {
               for (let key in u.scales!) {


### PR DESCRIPTION
with `newVizTooltips` enabled,  this ensures we only handle drag-selection actions (zoom, annotations) in the primary panel and not other cursor-synced panels in same dashboard.

https://github.com/grafana/support-escalations/issues/9105

dashboard for repro attached in https://github.com/grafana/support-escalations/issues/9105#issuecomment-1949576330