### PR TITLE
Chore: Remove Form usage in NewFolderForm components

### DIFF
--- a/public/app/features/browse-dashboards/components/NewFolderForm.tsx
+++ b/public/app/features/browse-dashboards/components/NewFolderForm.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { useForm } from 'react-hook-form';
 
 import { selectors } from '@grafana/e2e-selectors';
-import { Button, Input, Field, HorizontalGroup } from '@grafana/ui';
+import { Button, Input, Field, Stack } from '@grafana/ui';
 import { Trans, t } from 'app/core/internationalization';
 
 import { validationSrv } from '../../manage-dashboards/services/ValidationSrv';
@@ -65,14 +65,14 @@ export function NewFolderForm({ onCancel, onConfirm }: Props) {
           })}
         />
       </Field>
-      <HorizontalGroup>
+      <Stack>
         <Button variant="secondary" fill="outline" onClick={onCancel}>
           <Trans i18nKey="browse-dashboards.new-folder-form.cancel-label">Cancel</Trans>
         </Button>
         <Button type="submit">
           <Trans i18nKey="browse-dashboards.new-folder-form.create-label">Create</Trans>
         </Button>
-      </HorizontalGroup>
+      </Stack>
     </form>
   );
 }

--- a/public/app/features/browse-dashboards/components/NewFolderForm.tsx
+++ b/public/app/features/browse-dashboards/components/NewFolderForm.tsx
@@ -1,7 +1,8 @@
 import React from 'react';
+import { useForm } from 'react-hook-form';
 
 import { selectors } from '@grafana/e2e-selectors';
-import { Button, Input, Form, Field, HorizontalGroup } from '@grafana/ui';
+import { Button, Input, Field, HorizontalGroup } from '@grafana/ui';
 import { Trans, t } from 'app/core/internationalization';
 
 import { validationSrv } from '../../manage-dashboards/services/ValidationSrv';
@@ -18,6 +19,12 @@ interface FormModel {
 const initialFormModel: FormModel = { folderName: '' };
 
 export function NewFolderForm({ onCancel, onConfirm }: Props) {
+  const {
+    handleSubmit,
+    register,
+    formState: { errors },
+  } = useForm<FormModel>();
+  
   const translatedFolderNameRequiredPhrase = t(
     'browse-dashboards.action.new-folder-name-required-phrase',
     'Folder name is required.'
@@ -38,37 +45,33 @@ export function NewFolderForm({ onCancel, onConfirm }: Props) {
   const fieldNameLabel = t('browse-dashboards.new-folder-form.name-label', 'Folder name');
 
   return (
-    <Form
-      defaultValues={initialFormModel}
-      onSubmit={(form: FormModel) => onConfirm(form.folderName)}
-      data-testid={selectors.pages.BrowseDashboards.NewFolderForm.form}
+    <form
+      name="addFolder"
+      onSubmit={handleSubmit((folder)=> onConfirm(folder.folderName))} 
     >
-      {({ register, errors }) => (
-        <>
-          <Field
-            label={fieldNameLabel}
-            invalid={!!errors.folderName}
-            error={errors.folderName && errors.folderName.message}
-          >
-            <Input
-              data-testid={selectors.pages.BrowseDashboards.NewFolderForm.nameInput}
-              id="folder-name-input"
-              {...register('folderName', {
-                required: translatedFolderNameRequiredPhrase,
-                validate: async (v) => await validateFolderName(v),
-              })}
-            />
-          </Field>
-          <HorizontalGroup>
-            <Button variant="secondary" fill="outline" onClick={onCancel}>
-              <Trans i18nKey="browse-dashboards.new-folder-form.cancel-label">Cancel</Trans>
-            </Button>
-            <Button type="submit">
-              <Trans i18nKey="browse-dashboards.new-folder-form.create-label">Create</Trans>
-            </Button>
-          </HorizontalGroup>
-        </>
-      )}
-    </Form>
+      <Field
+        label={fieldNameLabel}
+        invalid={!!errors.folderName}
+        error={errors.folderName && errors.folderName.message}
+      >
+        <Input
+          data-testid={selectors.pages.BrowseDashboards.NewFolderForm.nameInput}
+          id="folder-name-input"
+          defaultValue={initialFormModel.folderName}
+          {...register('folderName', {
+            required: translatedFolderNameRequiredPhrase,
+            validate: async (v) => await validateFolderName(v),
+          })}
+        />
+      </Field>
+      <HorizontalGroup>
+        <Button variant="secondary" fill="outline" onClick={onCancel}>
+          <Trans i18nKey="browse-dashboards.new-folder-form.cancel-label">Cancel</Trans>
+        </Button>
+        <Button type="submit">
+          <Trans i18nKey="browse-dashboards.new-folder-form.create-label">Create</Trans>
+        </Button>
+      </HorizontalGroup>
+    </form>
   );
 }

--- a/public/app/features/browse-dashboards/components/NewFolderForm.tsx
+++ b/public/app/features/browse-dashboards/components/NewFolderForm.tsx
@@ -48,6 +48,7 @@ export function NewFolderForm({ onCancel, onConfirm }: Props) {
     <form
       name="addFolder"
       onSubmit={handleSubmit((folder)=> onConfirm(folder.folderName))} 
+      data-testid={selectors.pages.BrowseDashboards.NewFolderForm.form}
     >
       <Field
         label={fieldNameLabel}

--- a/public/app/features/browse-dashboards/components/NewFolderForm.tsx
+++ b/public/app/features/browse-dashboards/components/NewFolderForm.tsx
@@ -47,7 +47,7 @@ export function NewFolderForm({ onCancel, onConfirm }: Props) {
   return (
     <form
       name="addFolder"
-      onSubmit={handleSubmit((folder)=> onConfirm(folder.folderName))} 
+      onSubmit={handleSubmit((form)=> onConfirm(form.folderName))} 
       data-testid={selectors.pages.BrowseDashboards.NewFolderForm.form}
     >
       <Field

--- a/public/app/features/browse-dashboards/components/NewFolderForm.tsx
+++ b/public/app/features/browse-dashboards/components/NewFolderForm.tsx
@@ -23,8 +23,8 @@ export function NewFolderForm({ onCancel, onConfirm }: Props) {
     handleSubmit,
     register,
     formState: { errors },
-  } = useForm<FormModel>();
-  
+  } = useForm<FormModel>({ defaultValues: initialFormModel });
+
   const translatedFolderNameRequiredPhrase = t(
     'browse-dashboards.action.new-folder-name-required-phrase',
     'Folder name is required.'
@@ -47,7 +47,7 @@ export function NewFolderForm({ onCancel, onConfirm }: Props) {
   return (
     <form
       name="addFolder"
-      onSubmit={handleSubmit((form)=> onConfirm(form.folderName))} 
+      onSubmit={handleSubmit((form) => onConfirm(form.folderName))}
       data-testid={selectors.pages.BrowseDashboards.NewFolderForm.form}
     >
       <Field


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

Remove the Form component usage from NewFolderForm and replace HorizontalGroup with Stack
public/app/features/browse-dashboards/components/NewFolderForm.tsx

**Why do we need this feature?**

Part of the Form deprecation epic.


**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Part of https://github.com/grafana/grafana/issues/81226

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
