### PR TITLE
Search: Include collapsed panels in search v2

### DIFF
--- a/pkg/services/store/kind/dashboard/testdata/with-library-panels-info.json
+++ b/pkg/services/store/kind/dashboard/testdata/with-library-panels-info.json
@@ -45,6 +45,32 @@
           "type": "panel"
         }
       ]
+    },
+    {
+      "UID": "with-library-panels#3",
+      "kind": "panel",
+      "name": "collapsed row",
+      "fields": {
+        "type": "row"
+      }
+    },
+    {
+      "UID": "with-library-panels#42",
+      "kind": "panel",
+      "name": "blue pie",
+      "fields": {
+        "type": ""
+      },
+      "references": [
+        {
+          "family": "librarypanel",
+          "identifier": "l3d2s634-fdgf-75u4-3fg3-67j966ii7jur"
+        },
+        {
+          "family": "plugin",
+          "type": "panel"
+        }
+      ]
     }
   ],
   "references": [
@@ -58,6 +84,10 @@
     {
       "family": "librarypanel",
       "identifier": "e1d5f519-dabd-47c6-9ad7-83d181ce1cee"
+    },
+    {
+      "family": "librarypanel",
+      "identifier": "l3d2s634-fdgf-75u4-3fg3-67j966ii7jur"
     },
     {
       "family": "plugin",

--- a/pkg/services/store/kind/dashboard/testdata/with-library-panels.json
+++ b/pkg/services/store/kind/dashboard/testdata/with-library-panels.json
@@ -49,6 +49,34 @@
           "uid": "e1d5f519-dabd-47c6-9ad7-83d181ce1cee"
         },
         "title": "green pie"
+      },
+      {
+        "collapsed": true,
+        "gridPos": {
+          "h": 1,
+          "w": 24,
+          "x": 0,
+          "y": 9
+        },
+        "id": 3,
+        "panels": [
+          {
+            "gridPos": {
+              "h": 8,
+              "w": 12,
+              "x": 12,
+              "y": 0
+            },
+            "id": 42,
+            "libraryPanel": {
+              "name": "blue pie",
+              "uid": "l3d2s634-fdgf-75u4-3fg3-67j966ii7jur"
+            },
+            "title": "blue pie"
+          }
+        ],
+        "title": "collapsed row",
+        "type": "row"
       }
     ],
     "refresh": "",


### PR DESCRIPTION

<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

This is a bug fix for panel title search in search v2.

**Why do we need this feature?**

Panels in collapsed rows are currently not being included in panel title search in search v2. This PR fixes this bug.

**Who is this feature for?**

Users with the `panelTitleSearch` feature flag enabled.

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fix for https://github.com/grafana/support-escalations/issues/9284

**Special notes for your reviewer:**
This is my understanding of how [TestReadSummaries](https://github.com/grafana/grafana/blob/9d002c4db437293efb5ebfcf30ca18821b358946/pkg/services/store/kind/dashboard/summary_test.go#L70) works. (1) It takes the `with-library-panels.json` and reads it. (2) The output of what is being read is expected to match the contents of `with-library-panels-info.json`.

As part of this PR, I added a new collapsed row and panel to `with-library-panels.json`. During the reading process, the other panels get a "ds" [reference](https://github.com/grafana/grafana/blob/9d002c4db437293efb5ebfcf30ca18821b358946/pkg/services/store/kind/dashboard/testdata/with-library-panels-info.json#L37) even though they themselves don't contain a `datasource` field. The new panel I added doesn't get a "ds" [reference](https://github.com/grafana/grafana/blob/9d002c4db437293efb5ebfcf30ca18821b358946/pkg/services/store/kind/dashboard/testdata/with-library-panels-info.json#L64) unless I directly include a `datasource` field in `with-library-panels.json`.

This didn't seem like a key aspect of the test to me, but happy to look further into it if someone thinks it would be worthwhile to do so.

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
