### PR TITLE
Run downstream patch check only for `grafana/grafana`

### DIFF
--- a/.github/workflows/pr-patch-check.yml
+++ b/.github/workflows/pr-patch-check.yml
@@ -17,6 +17,7 @@ on:
 # target branch onto the source branch, to verify compatibility before merging.
 jobs:
   trigger_downstream_patch_check:
+    if: github.repository == 'grafana/grafana'
     uses: grafana/security-patch-actions/.github/workflows/test-patches.yml@main
     with:
       src_repo: "${{ github.repository }}"

--- a/.github/workflows/pr-patch-check.yml
+++ b/.github/workflows/pr-patch-check.yml
@@ -17,8 +17,8 @@ on:
 # target branch onto the source branch, to verify compatibility before merging.
 jobs:
   trigger_downstream_patch_check:
-    if: github.repository == 'grafana/grafana'
     uses: grafana/security-patch-actions/.github/workflows/test-patches.yml@main
+    if: github.repository == 'grafana/grafana'
     with:
       src_repo: "${{ github.repository }}"
       src_ref: "${{ github.head_ref }}" # this is the source branch name, Ex: "feature/newthing"


### PR DESCRIPTION
Avoid downstream patch check to be run in repo that are not `grafana/grafana`.