### PR TITLE
mysql: do not use unexported grafana-core config

### DIFF
--- a/pkg/services/pluginsintegration/plugins_integration_test.go
+++ b/pkg/services/pluginsintegration/plugins_integration_test.go
@@ -86,7 +86,7 @@ func TestIntegrationPluginManager(t *testing.T) {
 	tmpo := tempo.ProvideService(hcp)
 	td := testdatasource.ProvideService()
 	pg := postgres.ProvideService(cfg)
-	my := mysql.ProvideService(cfg, hcp)
+	my := mysql.ProvideService()
 	ms := mssql.ProvideService(cfg)
 	sv2 := searchV2.ProvideService(cfg, db.InitTestDB(t), nil, nil, tracer, features, nil, nil, nil)
 	graf := grafanads.ProvideService(sv2, nil)

--- a/pkg/tsdb/mysql/macros.go
+++ b/pkg/tsdb/mysql/macros.go
@@ -8,7 +8,6 @@ import (
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
 	"github.com/grafana/grafana-plugin-sdk-go/backend/gtime"
 	"github.com/grafana/grafana-plugin-sdk-go/backend/log"
-	"github.com/grafana/grafana/pkg/setting"
 	"github.com/grafana/grafana/pkg/tsdb/sqleng"
 )
 
@@ -23,11 +22,11 @@ type mySQLMacroEngine struct {
 	userError string
 }
 
-func newMysqlMacroEngine(logger log.Logger, cfg *setting.Cfg) sqleng.SQLMacroEngine {
+func newMysqlMacroEngine(logger log.Logger, userFacingDefaultError string) sqleng.SQLMacroEngine {
 	return &mySQLMacroEngine{
 		SQLMacroEngineBase: sqleng.NewSQLMacroEngineBase(),
 		logger:             logger,
-		userError:          cfg.UserFacingDefaultError,
+		userError:          userFacingDefaultError,
 	}
 }
 

--- a/pkg/tsdb/mysql/macros_test.go
+++ b/pkg/tsdb/mysql/macros_test.go
@@ -7,7 +7,6 @@ import (
 	"time"
 
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
-	"github.com/grafana/grafana/pkg/setting"
 
 	"github.com/stretchr/testify/require"
 )
@@ -194,7 +193,7 @@ func TestMacroEngine(t *testing.T) {
 }
 
 func TestMacroEngineConcurrency(t *testing.T) {
-	engine := newMysqlMacroEngine(backend.NewLoggerWith("logger", "test"), setting.NewCfg())
+	engine := newMysqlMacroEngine(backend.NewLoggerWith("logger", "test"), "error")
 	query1 := backend.DataQuery{
 		JSON: []byte{},
 	}

--- a/pkg/tsdb/mysql/mysql_test.go
+++ b/pkg/tsdb/mysql/mysql_test.go
@@ -13,7 +13,6 @@ import (
 	"github.com/grafana/grafana-plugin-sdk-go/data"
 	"github.com/stretchr/testify/require"
 
-	"github.com/grafana/grafana/pkg/setting"
 	"github.com/grafana/grafana/pkg/tsdb/sqleng"
 )
 
@@ -67,7 +66,7 @@ func TestIntegrationMySQL(t *testing.T) {
 
 	db := InitMySQLTestDB(t, config.DSInfo.JsonData)
 
-	exe, err := sqleng.NewQueryDataHandler("", db, config, &rowTransformer, newMysqlMacroEngine(logger, setting.NewCfg()), logger)
+	exe, err := sqleng.NewQueryDataHandler("", db, config, &rowTransformer, newMysqlMacroEngine(logger, ""), logger)
 
 	require.NoError(t, err)
 
@@ -1179,7 +1178,7 @@ func TestIntegrationMySQL(t *testing.T) {
 
 			queryResultTransformer := mysqlQueryResultTransformer{}
 
-			handler, err := sqleng.NewQueryDataHandler("", db, config, &queryResultTransformer, newMysqlMacroEngine(logger, setting.NewCfg()), logger)
+			handler, err := sqleng.NewQueryDataHandler("", db, config, &queryResultTransformer, newMysqlMacroEngine(logger, ""), logger)
 			require.NoError(t, err)
 
 			t.Run("When doing a table query that returns 2 rows should limit the result to 1 row", func(t *testing.T) {


### PR DESCRIPTION
as part of decoupling the mysql datasource from core-grafana, we are removing imports that import code from core-grafana.
this PR removes the reading of config-values from core-grafana, and replaces it with reading them from exported functions.

how to test:
1. 
- modify the following config-option:
```
[log]
user_facing_default_error = "something here"
```
- now run grafana, create a mysql datasource plugin, make sure mysql is not running, and press [save&test]. you should get `something here` as part of the error message

2.
- modify the following config-option:
```
[dataproxy]
row_limit = 13
```
- run a mysql query that should return more than 13 rows. verify that it only returned 13 rows, and an error message

3.
- modify  the following config-option:
```
[sql_datasources]
max_open_conns_default = 3
max_idle_conns_default = 4
max_conn_lifetime_default = 5
```
- unfortunately there is no easy way to verify these in a running grafana instance. best i can recommend is to run grafana in a debugger, set a breakpoint here:  https://github.com/grafana/grafana/blob/e0b79a3e7c4ccc392a8db264e473982c08a9d5b6/pkg/tsdb/mysql/mysql.go#L66 , and when the code reaches it, verify that the `jsonData` structure's related fields have the correct values