### PR TITLE
Alerting: Fix panic in provisioning filter contacts by unknown name

### DIFF
--- a/pkg/services/ngalert/provisioning/contactpoints.go
+++ b/pkg/services/ngalert/provisioning/contactpoints.go
@@ -80,7 +80,7 @@ func (ecp *ContactPointService) GetContactPoints(ctx context.Context, q ContactP
 		return nil, convertRecSvcErr(err)
 	}
 	grafanaReceivers := []*apimodels.GettableGrafanaReceiver{}
-	if q.Name != "" {
+	if q.Name != "" && len(res) > 0 {
 		grafanaReceivers = res[0].GettableGrafanaReceivers.GrafanaManagedReceivers // we only expect one receiver group
 	} else {
 		for _, r := range res {

--- a/pkg/services/ngalert/provisioning/contactpoints_test.go
+++ b/pkg/services/ngalert/provisioning/contactpoints_test.go
@@ -53,6 +53,15 @@ func TestContactPointService(t *testing.T) {
 		require.Equal(t, "slack receiver", cps[0].Name)
 	})
 
+	t.Run("service filters contact points by name, returns empty when no match", func(t *testing.T) {
+		sut := createContactPointServiceSut(t, secretsService)
+
+		cps, err := sut.GetContactPoints(context.Background(), cpsQueryWithName(1, "unknown"), nil)
+		require.NoError(t, err)
+
+		require.Len(t, cps, 0)
+	})
+
 	t.Run("service stitches contact point into org's AM config", func(t *testing.T) {
 		sut := createContactPointServiceSut(t, secretsService)
 		newCp := createTestContactPoint()


### PR DESCRIPTION
**What is this feature?**

Prevents a panic for `index out of range` when querying `api/v1/provisioning/contact-points` with a `name` query parameter that filters for a contact point name that doesn't exist.

**Why do we need this feature?**

Prevent panic.

**Who is this feature for?**

Users of alerting provisioning API / alerting Terraform provider.
