### PR TITLE
Plugins: Remove unused metadata.md file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -359,7 +359,6 @@
 /.vim @zoltanbedi
 /jest.config.js @grafana/frontend-ops
 /latest.json @grafana/frontend-ops
-/metadata.md @grafana/plugins-platform
 /stylelint.config.js @grafana/frontend-ops
 /tools/ @grafana/frontend-ops
 /lefthook.yml @grafana/frontend-ops


### PR DESCRIPTION
This file seemed to be erroneously added in this PR https://github.com/grafana/grafana/pull/32703. I don't see any references to it so I believe it's safe to remove