### PR TITLE
ReturnToPrevious: Check the state of the RTP feature toggle in the hook

### DIFF
--- a/public/app/core/components/AppChrome/AppChromeService.tsx
+++ b/public/app/core/components/AppChrome/AppChromeService.tsx
@@ -90,11 +90,11 @@ export class AppChromeService {
   }
 
   public setReturnToPrevious = (returnToPrevious: ReturnToPreviousProps) => {
-    const previousPage = this.state.getValue().returnToPrevious;
     const isReturnToPreviousEnabled = config.featureToggles.returnToPrevious;
     if (!isReturnToPreviousEnabled) {
       return;
     }
+    const previousPage = this.state.getValue().returnToPrevious;
     reportInteraction('grafana_return_to_previous_button_created', {
       page: returnToPrevious.href,
       previousPage: previousPage?.href,
@@ -105,6 +105,10 @@ export class AppChromeService {
   };
 
   public clearReturnToPrevious = (interactionAction: 'clicked' | 'dismissed' | 'auto_dismissed') => {
+    const isReturnToPreviousEnabled = config.featureToggles.returnToPrevious;
+    if (!isReturnToPreviousEnabled) {
+      return;
+    }
     const existingRtp = this.state.getValue().returnToPrevious;
     if (existingRtp) {
       reportInteraction('grafana_return_to_previous_button_dismissed', {

--- a/public/app/core/components/AppChrome/AppChromeService.tsx
+++ b/public/app/core/components/AppChrome/AppChromeService.tsx
@@ -91,13 +91,18 @@ export class AppChromeService {
 
   public setReturnToPrevious = (returnToPrevious: ReturnToPreviousProps) => {
     const previousPage = this.state.getValue().returnToPrevious;
-    reportInteraction('grafana_return_to_previous_button_created', {
-      page: returnToPrevious.href,
-      previousPage: previousPage?.href,
-    });
+    const isReturnToPreviousEnabled = config.featureToggles.returnToPrevious;
+    if (isReturnToPreviousEnabled) {
+      reportInteraction('grafana_return_to_previous_button_created', {
+        page: returnToPrevious.href,
+        previousPage: previousPage?.href,
+      });
 
-    this.update({ returnToPrevious });
-    window.sessionStorage.setItem('returnToPrevious', JSON.stringify(returnToPrevious));
+      this.update({ returnToPrevious });
+      window.sessionStorage.setItem('returnToPrevious', JSON.stringify(returnToPrevious));
+    } else {
+      locationService.push(returnToPrevious.href);
+    }
   };
 
   public clearReturnToPrevious = (interactionAction: 'clicked' | 'dismissed' | 'auto_dismissed') => {

--- a/public/app/core/components/AppChrome/AppChromeService.tsx
+++ b/public/app/core/components/AppChrome/AppChromeService.tsx
@@ -92,17 +92,16 @@ export class AppChromeService {
   public setReturnToPrevious = (returnToPrevious: ReturnToPreviousProps) => {
     const previousPage = this.state.getValue().returnToPrevious;
     const isReturnToPreviousEnabled = config.featureToggles.returnToPrevious;
-    if (isReturnToPreviousEnabled) {
-      reportInteraction('grafana_return_to_previous_button_created', {
-        page: returnToPrevious.href,
-        previousPage: previousPage?.href,
-      });
-
-      this.update({ returnToPrevious });
-      window.sessionStorage.setItem('returnToPrevious', JSON.stringify(returnToPrevious));
-    } else {
-      locationService.push(returnToPrevious.href);
+    if (!isReturnToPreviousEnabled) {
+      return;
     }
+    reportInteraction('grafana_return_to_previous_button_created', {
+      page: returnToPrevious.href,
+      previousPage: previousPage?.href,
+    });
+
+    this.update({ returnToPrevious });
+    window.sessionStorage.setItem('returnToPrevious', JSON.stringify(returnToPrevious));
   };
 
   public clearReturnToPrevious = (interactionAction: 'clicked' | 'dismissed' | 'auto_dismissed') => {

--- a/public/app/features/alerting/unified/components/rules/RuleDetailsActionButtons.tsx
+++ b/public/app/features/alerting/unified/components/rules/RuleDetailsActionButtons.tsx
@@ -137,31 +137,18 @@ export const RuleDetailsActionButtons = ({ rule, rulesSource, isViewMode }: Prop
     const dashboardUID = rule.annotations[Annotation.dashboardUID];
     if (dashboardUID) {
       buttons.push(
-        config.featureToggles.returnToPrevious ? (
-          <LinkButton
-            size="sm"
-            key="dashboard"
-            variant="primary"
-            icon="apps"
-            href={`d/${encodeURIComponent(dashboardUID)}`}
-            onClick={() => {
-              setReturnToPrevious(rule.name);
-            }}
-          >
-            Go to dashboard
-          </LinkButton>
-        ) : (
-          <LinkButton
-            size="sm"
-            key="dashboard"
-            variant="primary"
-            icon="apps"
-            target="_blank"
-            href={`d/${encodeURIComponent(dashboardUID)}`}
-          >
-            Go to dashboard
-          </LinkButton>
-        )
+        <LinkButton
+          size="sm"
+          key="dashboard"
+          variant="primary"
+          icon="apps"
+          href={`d/${encodeURIComponent(dashboardUID)}`}
+          onClick={() => {
+            setReturnToPrevious(rule.name);
+          }}
+        >
+          Go to dashboard
+        </LinkButton>
       );
       const panelId = rule.annotations[Annotation.panelID];
       if (panelId) {

--- a/public/app/features/alerting/unified/components/rules/RuleDetailsActionButtons.tsx
+++ b/public/app/features/alerting/unified/components/rules/RuleDetailsActionButtons.tsx
@@ -135,6 +135,7 @@ export const RuleDetailsActionButtons = ({ rule, rulesSource, isViewMode }: Prop
   }
   if (rule.annotations[Annotation.dashboardUID]) {
     const dashboardUID = rule.annotations[Annotation.dashboardUID];
+    const isReturnToPreviousEnabled = config.featureToggles.returnToPrevious;
     if (dashboardUID) {
       buttons.push(
         <LinkButton
@@ -142,6 +143,7 @@ export const RuleDetailsActionButtons = ({ rule, rulesSource, isViewMode }: Prop
           key="dashboard"
           variant="primary"
           icon="apps"
+          target={isReturnToPreviousEnabled ? undefined : '_blank'}
           href={`d/${encodeURIComponent(dashboardUID)}`}
           onClick={() => {
             setReturnToPrevious(rule.name);


### PR DESCRIPTION
**What is this feature?**

We add a check for the RTP feature toggle state in the hook.

**Why do we need this feature?**

To automatically do the check, so devs don't need to worry about it when implementing the RTP functionality.

**Who is this feature for?**

Everyone using the RTP functionality.

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
