### PR TITLE
Traces: Add traces panel suggestion

### DIFF
--- a/.betterer.results
+++ b/.betterer.results
@@ -3340,10 +3340,6 @@ exports[`better eslint`] = {
     "public/app/features/explore/TraceView/components/TracePageHeader/Actions/ActionButton.tsx:5381": [
       [0, 0, 0, "Styles should be written using objects.", "0"]
     ],
-    "public/app/features/explore/TraceView/components/TracePageHeader/Actions/TracePageActions.tsx:5381": [
-      [0, 0, 0, "Styles should be written using objects.", "0"],
-      [0, 0, 0, "Styles should be written using objects.", "1"]
-    ],
     "public/app/features/explore/TraceView/components/TracePageHeader/SearchBar/NextPrevResult.tsx:5381": [
       [0, 0, 0, "Styles should be written using objects.", "0"],
       [0, 0, 0, "Styles should be written using objects.", "1"],
@@ -3403,11 +3399,7 @@ exports[`better eslint`] = {
       [0, 0, 0, "Styles should be written using objects.", "5"],
       [0, 0, 0, "Styles should be written using objects.", "6"],
       [0, 0, 0, "Styles should be written using objects.", "7"],
-      [0, 0, 0, "Styles should be written using objects.", "8"],
-      [0, 0, 0, "Styles should be written using objects.", "9"],
-      [0, 0, 0, "Styles should be written using objects.", "10"],
-      [0, 0, 0, "Styles should be written using objects.", "11"],
-      [0, 0, 0, "Styles should be written using objects.", "12"]
+      [0, 0, 0, "Styles should be written using objects.", "8"]
     ],
     "public/app/features/explore/TraceView/components/TraceTimelineViewer/SpanBarRow.tsx:5381": [
       [0, 0, 0, "Styles should be written using objects.", "0"],

--- a/.betterer.results.json
+++ b/.betterer.results.json
@@ -3838,12 +3838,6 @@
         "count": 1
       }
     ],
-    "/public/app/features/explore/TraceView/components/TracePageHeader/Actions/TracePageActions.tsx": [
-      {
-        "message": "Styles should be written using objects.",
-        "count": 2
-      }
-    ],
     "/public/app/features/explore/TraceView/components/TracePageHeader/SearchBar/NextPrevResult.tsx": [
       {
         "message": "Styles should be written using objects.",
@@ -3895,7 +3889,7 @@
     "/public/app/features/explore/TraceView/components/TracePageHeader/TracePageHeader.tsx": [
       {
         "message": "Styles should be written using objects.",
-        "count": 13
+        "count": 9
       }
     ],
     "/public/app/features/explore/TraceView/components/TraceTimelineViewer/SpanBarRow.tsx": [

--- a/.betterer.results.json
+++ b/.betterer.results.json
@@ -1028,12 +1028,6 @@
         "count": 5
       }
     ],
-    "/packages/grafana-ui/src/components/Splitter/Splitter.tsx": [
-      {
-        "message": "Do not use any type assertions.",
-        "count": 1
-      }
-    ],
     "/packages/grafana-ui/src/components/StatsPicker/StatsPicker.story.tsx": [
       {
         "message": "Unexpected any. Specify a different type.",
@@ -1564,12 +1558,6 @@
         "count": 1
       }
     ],
-    "/public/app/core/specs/time_series.test.ts": [
-      {
-        "message": "Unexpected any. Specify a different type.",
-        "count": 1
-      }
-    ],
     "/public/app/core/time_series2.ts": [
       {
         "message": "Unexpected any. Specify a different type.",
@@ -1787,12 +1775,6 @@
     "/public/app/features/alerting/unified/AlertWarning.tsx": [
       {
         "message": "Styles should be written using objects.",
-        "count": 1
-      }
-    ],
-    "/public/app/features/alerting/unified/AlertsFolderView.test.tsx": [
-      {
-        "message": "Unexpected any. Specify a different type.",
         "count": 1
       }
     ],
@@ -2930,12 +2912,6 @@
         "count": 1
       }
     ],
-    "/public/app/features/dashboard-scene/panel-edit/VizPanelManager.test.tsx": [
-      {
-        "message": "Unexpected any. Specify a different type.",
-        "count": 1
-      }
-    ],
     "/public/app/features/dashboard-scene/saving/SaveDashboardForm.tsx": [
       {
         "message": "Use data-testid for E2E selectors instead of aria-label",
@@ -2954,12 +2930,6 @@
         "count": 1
       }
     ],
-    "/public/app/features/dashboard-scene/scene/DashboardScene.test.tsx": [
-      {
-        "message": "Unexpected any. Specify a different type.",
-        "count": 1
-      }
-    ],
     "/public/app/features/dashboard-scene/scene/PanelMenuBehavior.tsx": [
       {
         "message": "Unexpected any. Specify a different type.",
@@ -2968,18 +2938,6 @@
       {
         "message": "Do not use any type assertions.",
         "count": 1
-      }
-    ],
-    "/public/app/features/dashboard-scene/scene/setDashboardPanelContext.test.ts": [
-      {
-        "message": "Unexpected any. Specify a different type.",
-        "count": 1
-      }
-    ],
-    "/public/app/features/dashboard-scene/serialization/angularMigration.test.ts": [
-      {
-        "message": "Unexpected any. Specify a different type.",
-        "count": 2
       }
     ],
     "/public/app/features/dashboard-scene/serialization/transformSaveModelToScene.test.ts": [
@@ -3055,7 +3013,7 @@
     "/public/app/features/dashboard/components/DashExportModal/DashboardExporter.test.ts": [
       {
         "message": "Unexpected any. Specify a different type.",
-        "count": 21
+        "count": 6
       }
     ],
     "/public/app/features/dashboard/components/DashExportModal/DashboardExporter.ts": [
@@ -3441,7 +3399,7 @@
     "/public/app/features/dashboard/state/DashboardMigrator.test.ts": [
       {
         "message": "Unexpected any. Specify a different type.",
-        "count": 19
+        "count": 12
       }
     ],
     "/public/app/features/dashboard/state/DashboardMigrator.ts": [
@@ -3457,7 +3415,7 @@
     "/public/app/features/dashboard/state/DashboardModel.repeat.test.ts": [
       {
         "message": "Unexpected any. Specify a different type.",
-        "count": 7
+        "count": 4
       }
     ],
     "/public/app/features/dashboard/state/DashboardModel.test.ts": [
@@ -3507,7 +3465,7 @@
     "/public/app/features/dashboard/state/initDashboard.test.ts": [
       {
         "message": "Unexpected any. Specify a different type.",
-        "count": 2
+        "count": 1
       }
     ],
     "/public/app/features/dashboard/utils/getPanelMenu.test.ts": [
@@ -4643,7 +4601,7 @@
     "/public/app/features/plugins/tests/datasource_srv.test.ts": [
       {
         "message": "Unexpected any. Specify a different type.",
-        "count": 4
+        "count": 3
       }
     ],
     "/public/app/features/plugins/utils.ts": [
@@ -4743,7 +4701,7 @@
     "/public/app/features/query/state/updateQueries.test.ts": [
       {
         "message": "Unexpected any. Specify a different type.",
-        "count": 12
+        "count": 11
       }
     ],
     "/public/app/features/search/page/components/ActionRow.tsx": [
@@ -5103,7 +5061,7 @@
     "/public/app/features/transformers/prepareTimeSeries/prepareTimeSeries.test.ts": [
       {
         "message": "Unexpected any. Specify a different type.",
-        "count": 2
+        "count": 1
       }
     ],
     "/public/app/features/transformers/prepareTimeSeries/prepareTimeSeries.ts": [
@@ -5266,12 +5224,6 @@
         "count": 1
       }
     ],
-    "/public/app/features/variables/query/QueryVariableEditor.test.tsx": [
-      {
-        "message": "Unexpected any. Specify a different type.",
-        "count": 1
-      }
-    ],
     "/public/app/features/variables/query/QueryVariableEditor.tsx": [
       {
         "message": "Unexpected any. Specify a different type.",
@@ -5309,7 +5261,7 @@
     "/public/app/features/variables/query/queryRunners.test.ts": [
       {
         "message": "Unexpected any. Specify a different type.",
-        "count": 7
+        "count": 1
       }
     ],
     "/public/app/features/variables/query/queryRunners.ts": [
@@ -7102,46 +7054,6 @@
       {
         "message": "Unexpected any. Specify a different type.",
         "count": 2
-      }
-    ],
-    "/public/app/plugins/panel/table-old/column_options.ts": [
-      {
-        "message": "Unexpected any. Specify a different type.",
-        "count": 22
-      }
-    ],
-    "/public/app/plugins/panel/table-old/editor.ts": [
-      {
-        "message": "Unexpected any. Specify a different type.",
-        "count": 9
-      }
-    ],
-    "/public/app/plugins/panel/table-old/module.ts": [
-      {
-        "message": "Unexpected any. Specify a different type.",
-        "count": 12
-      }
-    ],
-    "/public/app/plugins/panel/table-old/renderer.ts": [
-      {
-        "message": "Unexpected any. Specify a different type.",
-        "count": 12
-      },
-      {
-        "message": "Do not use any type assertions.",
-        "count": 1
-      }
-    ],
-    "/public/app/plugins/panel/table-old/transformers.ts": [
-      {
-        "message": "Unexpected any. Specify a different type.",
-        "count": 9
-      }
-    ],
-    "/public/app/plugins/panel/table-old/types.ts": [
-      {
-        "message": "Unexpected any. Specify a different type.",
-        "count": 13
       }
     ],
     "/public/app/plugins/panel/table/TablePanel.tsx": [

--- a/public/app/features/explore/TraceView/components/TracePageHeader/Actions/TracePageActions.tsx
+++ b/public/app/features/explore/TraceView/components/TracePageHeader/Actions/TracePageActions.tsx
@@ -12,21 +12,22 @@ import ActionButton from './ActionButton';
 
 export const getStyles = (theme: GrafanaTheme2) => {
   return {
-    TracePageActions: css`
-      label: TracePageActions;
-      display: flex;
-      align-items: center;
-      justify-content: center;
-      gap: 4px;
-    `,
-    feedback: css`
-      margin: 6px;
-      color: ${theme.colors.text.secondary};
-      font-size: ${theme.typography.bodySmall.fontSize};
-      &:hover {
-        color: ${theme.colors.text.link};
-      }
-    `,
+    TracePageActions: css({
+      label: 'TracePageActions',
+      display: 'flex',
+      alignItems: 'center',
+      justifyContent: 'center',
+      gap: '4px',
+      marginBottom: '10px',
+    }),
+    feedback: css({
+      margin: '6px 6px 6px 0',
+      color: theme.colors.text.secondary,
+      fontSize: theme.typography.bodySmall.fontSize,
+      '&:hover': {
+        color: theme.colors.text.link,
+      },
+    }),
   };
 };
 

--- a/public/app/features/explore/TraceView/components/TracePageHeader/TracePageHeader.tsx
+++ b/public/app/features/explore/TraceView/components/TracePageHeader/TracePageHeader.tsx
@@ -202,30 +202,34 @@ const getNewStyles = (theme: GrafanaTheme2) => {
         color: unset;
       }
     `,
-    header: css`
-      label: TracePageHeader;
-      background-color: ${theme.colors.background.primary};
-      padding: 0.5em 0 0 0;
-      position: sticky;
-      top: 0;
-      z-index: 5;
-    `,
-    titleRow: css`
-      align-items: flex-start;
-      display: flex;
-      padding: 0 8px;
-    `,
-    title: css`
-      color: inherit;
-      flex: 1;
-      font-size: 1.7em;
-      line-height: 1em;
-    `,
-    subtitle: css`
-      flex: 1;
-      line-height: 1em;
-      margin: -0.5em 0.5em 0.75em 0.5em;
-    `,
+    header: css({
+      label: 'TracePageHeader',
+      backgroundColor: theme.colors.background.primary,
+      padding: '0.5em 0 0 0',
+      position: 'sticky',
+      top: 0,
+      zIndex: 5,
+      textAlign: 'left',
+    }),
+    titleRow: css({
+      alignItems: 'flex-start',
+      display: 'flex',
+      padding: '0 8px',
+      flexWrap: 'wrap',
+    }),
+    title: css({
+      color: 'inherit',
+      flex: 1,
+      fontSize: '1.7em',
+      lineHeight: '1em',
+      marginBottom: 0,
+      minWidth: '200px',
+    }),
+    subtitle: css({
+      flex: 1,
+      lineHeight: '1em',
+      margin: '-0.5em 0.5em 0.75em 0.5em',
+    }),
     tag: css`
       margin: 0 0.5em 0 0;
     `,

--- a/public/app/features/panel/state/getAllSuggestions.ts
+++ b/public/app/features/panel/state/getAllSuggestions.ts
@@ -21,6 +21,7 @@ export const panelsToCheckFirst = [
   'logs',
   'candlestick',
   'flamegraph',
+  'traces',
 ];
 
 export async function getAllSuggestions(data?: PanelData, panel?: PanelModel): Promise<VisualizationSuggestion[]> {

--- a/public/app/plugins/panel/traces/module.tsx
+++ b/public/app/plugins/panel/traces/module.tsx
@@ -1,5 +1,6 @@
 import { PanelPlugin } from '@grafana/data';
 
 import { TracesPanel } from './TracesPanel';
+import { TracesSuggestionsSupplier } from './suggestions';
 
-export const plugin = new PanelPlugin(TracesPanel);
+export const plugin = new PanelPlugin(TracesPanel).setSuggestionsSupplier(new TracesSuggestionsSupplier());

--- a/public/app/plugins/panel/traces/suggestions.ts
+++ b/public/app/plugins/panel/traces/suggestions.ts
@@ -1,0 +1,29 @@
+import { VisualizationSuggestionsBuilder, VisualizationSuggestionScore } from '@grafana/data';
+import { SuggestionName } from 'app/types/suggestions';
+
+export class TracesSuggestionsSupplier {
+  getListWithDefaults(builder: VisualizationSuggestionsBuilder) {
+    return builder.getListAppender<{}, {}>({
+      name: SuggestionName.Trace,
+      pluginId: 'traces',
+    });
+  }
+
+  getSuggestionsForData(builder: VisualizationSuggestionsBuilder) {
+    if (!builder.data) {
+      return;
+    }
+
+    const dataFrame = builder.data.series[0];
+    if (!dataFrame) {
+      return;
+    }
+
+    if (builder.data.series.some((dataFrame) => dataFrame.meta?.preferredVisualisationType === 'trace')) {
+      this.getListWithDefaults(builder).append({
+        name: SuggestionName.Trace,
+        score: VisualizationSuggestionScore.Best,
+      });
+    }
+  }
+}

--- a/public/app/plugins/panel/traces/suggestions.ts
+++ b/public/app/plugins/panel/traces/suggestions.ts
@@ -19,7 +19,7 @@ export class TracesSuggestionsSupplier {
       return;
     }
 
-    if (builder.data.series.some((dataFrame) => dataFrame.meta?.preferredVisualisationType === 'trace')) {
+    if (builder.data.series[0].meta?.preferredVisualisationType === 'trace') {
       this.getListWithDefaults(builder).append({
         name: SuggestionName.Trace,
         score: VisualizationSuggestionScore.Best,

--- a/public/app/types/suggestions.ts
+++ b/public/app/types/suggestions.ts
@@ -28,4 +28,5 @@ export enum SuggestionName {
   DashboardList = 'Dashboard list',
   Logs = 'Logs',
   FlameGraph = 'Flame graph',
+  Trace = 'Trace',
 }


### PR DESCRIPTION
**What is this feature?**

Adds a traces panel to the suggested visualisations in a dashboard if traces data exists in the response.

**Why do we need this feature?**

So users can more easily view tracing data via the traces panel.

**Who is this feature for?**

Tracing users.

**Special notes for your reviewer:**

![Screenshot 2024-02-20 at 10 33 23](https://github.com/grafana/grafana/assets/90795735/86274c19-745e-44b7-8da0-a3dc2333dc93)
