### PR TITLE
DataQuery: Track panel plugin id not type

### DIFF
--- a/packages/grafana-data/src/types/datasource.ts
+++ b/packages/grafana-data/src/types/datasource.ts
@@ -555,7 +555,7 @@ export interface DataQueryRequest<TQuery extends DataQuery = DataQuery> {
   rangeRaw?: RawTimeRange;
   timeInfo?: string; // The query time description (blue text in the upper right)
   panelId?: number;
-  panelPluginType?: string;
+  panelPluginId?: string;
   dashboardUID?: string;
 
   /** Filters to dynamically apply to all queries */

--- a/packages/grafana-runtime/src/analytics/types.ts
+++ b/packages/grafana-runtime/src/analytics/types.ts
@@ -29,7 +29,7 @@ export interface DataRequestInfo extends Partial<DashboardInfo> {
   datasourceUid: string;
   datasourceType: string;
   panelId?: number;
-  panelPluginType?: string;
+  panelPluginId?: string;
   panelName?: string;
   duration: number;
   error?: string;

--- a/packages/grafana-runtime/src/utils/DataSourceWithBackend.ts
+++ b/packages/grafana-runtime/src/utils/DataSourceWithBackend.ts
@@ -80,7 +80,7 @@ enum PluginRequestHeaders {
   DatasourceUID = 'X-Datasource-Uid', // can be used for routing/ load balancing
   DashboardUID = 'X-Dashboard-Uid', // mainly useful for debugging slow queries
   PanelID = 'X-Panel-Id', // mainly useful for debugging slow queries
-  PanelPluginType = 'X-Panel-Plugin-Type',
+  PanelPluginId = 'X-Panel-Plugin-Id',
   QueryGroupID = 'X-Query-Group-Id', // mainly useful to find related queries with query splitting
   FromExpression = 'X-Grafana-From-Expr', // used by datasources to identify expression queries
   SkipQueryCache = 'X-Cache-Skip', // used by datasources to skip the query cache
@@ -227,8 +227,8 @@ class DataSourceWithBackend<
     if (request.panelId) {
       headers[PluginRequestHeaders.PanelID] = `${request.panelId}`;
     }
-    if (request.panelPluginType) {
-      headers[PluginRequestHeaders.PanelPluginType] = `${request.panelPluginType}`;
+    if (request.panelPluginId) {
+      headers[PluginRequestHeaders.PanelPluginId] = `${request.panelPluginId}`;
     }
     if (request.queryGroupId) {
       headers[PluginRequestHeaders.QueryGroupID] = `${request.queryGroupId}`;

--- a/pkg/api/pluginproxy/ds_proxy.go
+++ b/pkg/api/pluginproxy/ds_proxy.go
@@ -344,7 +344,7 @@ func (proxy *DataSourceProxy) logRequest() {
 		}
 	}
 
-	panelPluginType := proxy.ctx.Req.Header.Get("X-Panel-Plugin-Type")
+	panelPluginId := proxy.ctx.Req.Header.Get("X-Panel-Plugin-Id")
 
 	ctxLogger := logger.FromContext(proxy.ctx.Req.Context())
 	ctxLogger.Info("Proxying incoming request",
@@ -354,7 +354,7 @@ func (proxy *DataSourceProxy) logRequest() {
 		"datasource", proxy.ds.Type,
 		"uri", proxy.ctx.Req.RequestURI,
 		"method", proxy.ctx.Req.Method,
-		"panelPluginType", panelPluginType,
+		"panelPluginId", panelPluginId,
 		"body", body)
 }
 

--- a/pkg/services/pluginsintegration/clientmiddleware/tracing_header_middleware.go
+++ b/pkg/services/pluginsintegration/clientmiddleware/tracing_header_middleware.go
@@ -34,7 +34,7 @@ func (m *TracingHeaderMiddleware) applyHeaders(ctx context.Context, req backend.
 		return
 	}
 
-	var headersList = []string{query.HeaderQueryGroupID, query.HeaderPanelID, query.HeaderDashboardUID, query.HeaderDatasourceUID, query.HeaderFromExpression, `X-Grafana-Org-Id`, query.HeaderPanelPluginType}
+	var headersList = []string{query.HeaderQueryGroupID, query.HeaderPanelID, query.HeaderDashboardUID, query.HeaderDatasourceUID, query.HeaderFromExpression, `X-Grafana-Org-Id`, query.HeaderPanelPluginId}
 
 	for _, headerName := range headersList {
 		gotVal := reqCtx.Req.Header.Get(headerName)

--- a/pkg/services/query/query.go
+++ b/pkg/services/query/query.go
@@ -28,13 +28,13 @@ import (
 )
 
 const (
-	HeaderPluginID        = "X-Plugin-Id"      // can be used for routing
-	HeaderDatasourceUID   = "X-Datasource-Uid" // can be used for routing/ load balancing
-	HeaderDashboardUID    = "X-Dashboard-Uid"  // mainly useful for debugging slow queries
-	HeaderPanelID         = "X-Panel-Id"       // mainly useful for debugging slow queries
-	HeaderPanelPluginType = "X-Panel-Plugin-Type"
-	HeaderQueryGroupID    = "X-Query-Group-Id"    // mainly useful for finding related queries with query chunking
-	HeaderFromExpression  = "X-Grafana-From-Expr" // used by datasources to identify expression queries
+	HeaderPluginID       = "X-Plugin-Id"      // can be used for routing
+	HeaderDatasourceUID  = "X-Datasource-Uid" // can be used for routing/ load balancing
+	HeaderDashboardUID   = "X-Dashboard-Uid"  // mainly useful for debugging slow queries
+	HeaderPanelID        = "X-Panel-Id"       // mainly useful for debugging slow queries
+	HeaderPanelPluginId  = "X-Panel-Plugin-Id"
+	HeaderQueryGroupID   = "X-Query-Group-Id"    // mainly useful for finding related queries with query chunking
+	HeaderFromExpression = "X-Grafana-From-Expr" // used by datasources to identify expression queries
 )
 
 func ProvideService(

--- a/public/app/features/dashboard-scene/scene/DashboardScene.test.tsx
+++ b/public/app/features/dashboard-scene/scene/DashboardScene.test.tsx
@@ -123,13 +123,13 @@ describe('DashboardScene', () => {
       scene.onEnterEditMode();
     });
 
-    it('Should add app, uid, panelId and panelPluginType', () => {
+    it('Should add app, uid, panelId and panelPluginId', () => {
       const queryRunner = sceneGraph.findObject(scene, (o) => o.state.key === 'data-query-runner')!;
       expect(scene.enrichDataRequest(queryRunner)).toEqual({
         app: CoreApp.Dashboard,
         dashboardUID: 'dash-1',
         panelId: 1,
-        panelPluginType: 'table',
+        panelPluginId: 'table',
       });
     });
 

--- a/public/app/features/dashboard-scene/scene/DashboardScene.tsx
+++ b/public/app/features/dashboard-scene/scene/DashboardScene.tsx
@@ -555,7 +555,7 @@ export class DashboardScene extends SceneObjectBase<DashboardSceneState> {
       app: CoreApp.Dashboard,
       dashboardUID: this.state.uid,
       panelId,
-      panelPluginType: panel?.state.pluginId,
+      panelPluginId: panel?.state.pluginId,
     };
   }
 

--- a/public/app/features/dashboard/state/PanelModel.ts
+++ b/public/app/features/dashboard/state/PanelModel.ts
@@ -377,7 +377,7 @@ export class PanelModel implements DataConfigSource, IPanelModel {
       datasource: this.datasource,
       queries: this.targets,
       panelId: this.id,
-      panelPluginType: this.type,
+      panelPluginId: this.type,
       dashboardUID: dashboardUID,
       timezone: dashboardTimezone,
       timeRange: timeData.timeRange,

--- a/public/app/features/query/state/PanelQueryRunner.ts
+++ b/public/app/features/query/state/PanelQueryRunner.ts
@@ -50,7 +50,7 @@ export interface QueryRunnerOptions<
   datasource: DataSourceRef | DataSourceApi<TQuery, TOptions> | null;
   queries: TQuery[];
   panelId?: number;
-  panelPluginType?: string;
+  panelPluginId?: string;
   dashboardUID?: string;
   timezone: TimeZone;
   timeRange: TimeRange;
@@ -258,7 +258,7 @@ export class PanelQueryRunner {
       timezone,
       datasource,
       panelId,
-      panelPluginType,
+      panelPluginId,
       dashboardUID,
       timeRange,
       timeInfo,
@@ -280,7 +280,7 @@ export class PanelQueryRunner {
       requestId: getNextRequestId(),
       timezone,
       panelId,
-      panelPluginType,
+      panelPluginId,
       dashboardUID,
       range: timeRange,
       timeInfo,

--- a/public/app/features/query/state/queryAnalytics.test.ts
+++ b/public/app/features/query/state/queryAnalytics.test.ts
@@ -103,7 +103,7 @@ function getTestData(
       scopedVars: {},
       targets: [],
       timezone: 'utc',
-      panelPluginType: 'timeseries',
+      panelPluginId: 'timeseries',
       ...overrides,
     },
     series: series || [],
@@ -135,7 +135,7 @@ describe('emitDataRequestEvent', () => {
           duration: 1,
           totalQueries: 0,
           cachedQueries: 0,
-          panelPluginType: 'timeseries',
+          panelPluginId: 'timeseries',
         })
       );
     });
@@ -163,7 +163,7 @@ describe('emitDataRequestEvent', () => {
           duration: 1,
           totalQueries: 2,
           cachedQueries: 1,
-          panelPluginType: 'timeseries',
+          panelPluginId: 'timeseries',
         })
       );
     });
@@ -191,7 +191,7 @@ describe('emitDataRequestEvent', () => {
           duration: 1,
           totalQueries: 1,
           cachedQueries: 1,
-          panelPluginType: 'timeseries',
+          panelPluginId: 'timeseries',
         })
       );
     });
@@ -238,7 +238,7 @@ describe('emitDataRequestEvent', () => {
           dataSize: 0,
           duration: 1,
           totalQueries: 0,
-          panelPluginType: 'timeseries',
+          panelPluginId: 'timeseries',
         })
       );
     });
@@ -275,7 +275,7 @@ describe('emitDataRequestEvent', () => {
           dataSize: 0,
           duration: 1,
           totalQueries: 0,
-          panelPluginType: 'timeseries',
+          panelPluginId: 'timeseries',
         })
       );
     });

--- a/public/app/features/query/state/queryAnalytics.ts
+++ b/public/app/features/query/state/queryAnalytics.ts
@@ -29,7 +29,7 @@ export function emitDataRequestEvent(datasource: DataSourceApi) {
       datasourceType: datasource.type,
       dataSize: 0,
       panelId: 0,
-      panelPluginType: data.request?.panelPluginType,
+      panelPluginId: data.request?.panelPluginId,
       duration: data.request.endTime! - data.request.startTime,
     };
 

--- a/public/app/plugins/datasource/graphite/datasource.ts
+++ b/public/app/plugins/datasource/graphite/datasource.ts
@@ -248,7 +248,7 @@ export class GraphiteDatasource
 
   addTracingHeaders(
     httpOptions: { headers: any },
-    options: { dashboardId?: number; panelId?: number; panelPluginType?: string }
+    options: { dashboardId?: number; panelId?: number; panelPluginId?: string }
   ) {
     const proxyMode = !this.url.match(/^http/);
     if (proxyMode) {
@@ -258,8 +258,8 @@ export class GraphiteDatasource
       if (options.panelId) {
         httpOptions.headers['X-Panel-Id'] = options.panelId;
       }
-      if (options.panelPluginType) {
-        httpOptions.headers['X-Panel-Plugin-Id'] = options.panelPluginType;
+      if (options.panelPluginId) {
+        httpOptions.headers['X-Panel-Plugin-Id'] = options.panelPluginId;
       }
     }
   }


### PR DESCRIPTION
Tweaks https://github.com/grafana/grafana/pull/81164  

Almost everywhere we refer to specific plugins by id not type (plugin.json they have an id),  everywhere in the code base it's by id we refer to plugins (except in dashoard json where it's a type property name). 

I would like to change this panel tracking property / header to use the name we have aligned on. Plugin type I think we should avoid unless we talking about different forms of plugins (Panel, Data source, App etc) 