### PR TITLE
OAuth: Improve domain validation

### DIFF
--- a/pkg/login/social/connectors/google_oauth.go
+++ b/pkg/login/social/connectors/google_oauth.go
@@ -308,5 +308,5 @@ func (s *SocialGoogle) isHDAllowed(hd string) error {
 		}
 	}
 
-	return errutil.Forbidden("the hd claim found in the ID token is not present in the allowed domains")
+	return errutil.Forbidden("the hd claim found in the ID token is not present in the allowed domains", errutil.WithPublicMessage("Invalid domain"))
 }

--- a/pkg/login/social/connectors/google_oauth.go
+++ b/pkg/login/social/connectors/google_oauth.go
@@ -37,6 +37,7 @@ type googleUserData struct {
 	Email         string `json:"email"`
 	Name          string `json:"name"`
 	EmailVerified bool   `json:"email_verified"`
+	HD            string `json:"hd"`
 	rawJSON       []byte `json:"-"`
 }
 
@@ -113,6 +114,10 @@ func (s *SocialGoogle) UserInfo(ctx context.Context, client *http.Client, token 
 
 	if !data.EmailVerified {
 		return nil, fmt.Errorf("user email is not verified")
+	}
+
+	if err := s.isHDAllowed(data.HD); err != nil {
+		return nil, err
 	}
 
 	groups, errPage := s.retrieveGroups(ctx, client, data)
@@ -289,4 +294,18 @@ func (s *SocialGoogle) getGroupsPage(ctx context.Context, client *http.Client, u
 	}
 
 	return &data, nil
+}
+
+func (s *SocialGoogle) isHDAllowed(hd string) error {
+	if len(s.info.AllowedDomains) == 0 {
+		return nil
+	}
+
+	for _, allowedDomain := range s.info.AllowedDomains {
+		if hd == allowedDomain {
+			return nil
+		}
+	}
+
+	return fmt.Errorf("the HD claim found in the ID token is not whitelisted by the allowed domains")
 }

--- a/pkg/login/social/connectors/google_oauth.go
+++ b/pkg/login/social/connectors/google_oauth.go
@@ -17,6 +17,7 @@ import (
 	ssoModels "github.com/grafana/grafana/pkg/services/ssosettings/models"
 	"github.com/grafana/grafana/pkg/services/ssosettings/validation"
 	"github.com/grafana/grafana/pkg/setting"
+	"github.com/grafana/grafana/pkg/util/errutil"
 )
 
 const (
@@ -307,5 +308,5 @@ func (s *SocialGoogle) isHDAllowed(hd string) error {
 		}
 	}
 
-	return fmt.Errorf("the HD claim found in the ID token is not whitelisted by the allowed domains")
+	return errutil.Forbidden("the hd claim found in the ID token is not present in the allowed domains")
 }

--- a/pkg/login/social/connectors/google_oauth_test.go
+++ b/pkg/login/social/connectors/google_oauth_test.go
@@ -890,3 +890,47 @@ func TestSocialGoogle_Reload(t *testing.T) {
 		})
 	}
 }
+
+func TestIsHDAllowed(t *testing.T) {
+	testCases := []struct {
+		name                 string
+		email                string
+		allowedDomains       []string
+		expectedErrorMessage string
+	}{
+		{
+			name:                 "should not fail if no allowed domains are set",
+			email:                "mycompany.com",
+			allowedDomains:       []string{},
+			expectedErrorMessage: "",
+		},
+		{
+			name:                 "should not fail if email is from allowed domain",
+			email:                "mycompany.com",
+			allowedDomains:       []string{"grafana.com", "mycompany.com", "example.com"},
+			expectedErrorMessage: "",
+		},
+		{
+			name:                 "should fail if email is not from allowed domain",
+			email:                "mycompany.com",
+			allowedDomains:       []string{"grafana.com", "example.com"},
+			expectedErrorMessage: "the HD claim found in the ID token is not whitelisted by the allowed domains",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			info := &social.OAuthInfo{}
+			info.AllowedDomains = tc.allowedDomains
+			s := NewGoogleProvider(info, &setting.Cfg{}, &ssosettingstests.MockService{}, featuremgmt.WithFeatures())
+			err := s.isHDAllowed(tc.email)
+
+			if tc.expectedErrorMessage != "" {
+				require.Error(t, err)
+				require.Contains(t, err.Error(), tc.expectedErrorMessage)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}

--- a/pkg/login/social/connectors/google_oauth_test.go
+++ b/pkg/login/social/connectors/google_oauth_test.go
@@ -914,7 +914,7 @@ func TestIsHDAllowed(t *testing.T) {
 			name:                 "should fail if email is not from allowed domain",
 			email:                "mycompany.com",
 			allowedDomains:       []string{"grafana.com", "example.com"},
-			expectedErrorMessage: "the HD claim found in the ID token is not whitelisted by the allowed domains",
+			expectedErrorMessage: "the hd claim found in the ID token is not present in the allowed domains",
 		},
 	}
 


### PR DESCRIPTION
**What is this feature?**

This PR improves domain validation between the response token id `hd` claim and the `allowed_domains` configuration setting for Google OAuth

**Which issue(s) does this PR fix?**:

Fixes #https://github.com/grafana/identity-access-team/issues/508

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
