### PR TITLE
Allow build and release process for Zipkin plugin

### DIFF
--- a/.github/workflows/core-plugins-build-and-release.yml
+++ b/.github/workflows/core-plugins-build-and-release.yml
@@ -14,7 +14,7 @@ on:
           - parca
           - stackdriver
           - tempo
-          # - zipkin
+          - zipkin
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}-${{ inputs.plugin_id }}


### PR DESCRIPTION
Thanks to [recent changes](https://github.com/grafana/grafana/pull/82157), it is now possible to build and release the Zipkin plugin, since now frontend-only plugins are supported.
Tagging @andresmgot for a double check that this is actually the case 🙏 