### PR TITLE
Alerting: Protect possible undefined

### DIFF
--- a/public/app/core/components/TimelineChart/TimelineChart.tsx
+++ b/public/app/core/components/TimelineChart/TimelineChart.tsx
@@ -59,7 +59,7 @@ export class TimelineChart extends React.Component<TimelineProps> {
       rowHeight: alignedFrame.fields.length > 2 ? this.props.rowHeight : 1,
       getValueColor: this.getValueColor,
       // @ts-ignore
-      hoverMulti: this.props.tooltip.mode === TooltipDisplayMode.Multi,
+      hoverMulti: this.props.tooltip?.mode === TooltipDisplayMode.Multi,
     });
   };
 


### PR DESCRIPTION
This PR fixes alert state history being broken after this [change](https://github.com/grafana/grafana/pull/82278/files#diff-23046d32c83cdf7ec1154f83c428c5d4bb99afc8dcb0790bc070fa5133a14afbR62).


Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
