### PR TITLE
Docs: Update Tempo datasource to correct traces to metrics/profiles.

### DIFF
--- a/docs/sources/datasources/tempo/configure-tempo-data-source.md
+++ b/docs/sources/datasources/tempo/configure-tempo-data-source.md
@@ -102,8 +102,7 @@ The following table describes the ways in which you can configure your trace to 
 ## Trace to metrics
 
 {{% admonition type="note" %}}
-This feature is behind the `traceToMetrics` [feature toggle][configure-grafana-feature-toggles].
-If you use Grafana Cloud, open a [support ticket in the Cloud Portal](/profile/org#support) to access this feature.
+This feature is behind the `traceToMetrics` [feature toggle](/docs/grafana/<GRAFANA_VERSION>/setup-grafana/configure-grafana/feature-toggles). This feature is already available in Grafana Cloud.
 {{% /admonition %}}
 
 The **Trace to metrics** setting configures the [trace to metrics feature](/blog/2022/08/18/new-in-grafana-9.1-trace-to-metrics-allows-users-to-navigate-from-a-trace-span-to-a-selected-data-source/) available when integrating Grafana with Tempo.
@@ -116,7 +115,7 @@ To configure trace to metrics:
 
    You can also click **Open advanced data source picker** to see more options, including adding a data source.
 
-1. Create any desired linked queries.
+2. Create any desired linked queries.
 
 | Setting name    | Description                                                                                                                                                                                                                                                     |
 | --------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
@@ -244,9 +243,6 @@ datasources:
 {{% docs/reference %}}
 [build-dashboards]: "/docs/grafana/ -> /docs/grafana/<GRAFANA VERSION>/dashboards/build-dashboards"
 [build-dashboards]: "/docs/grafana-cloud/ -> /docs/grafana/<GRAFANA VERSION>/dashboards/build-dashboards"
-
-[configure-grafana-feature-toggles]: "/docs/grafana/ -> /docs/grafana/<GRAFANA VERSION>/setup-grafana/configure-grafana#feature_toggles"
-[configure-grafana-feature-toggles]: "/docs/grafana-cloud/ -> /docs/grafana/<GRAFANA VERSION>/setup-grafana/configure-grafana#feature_toggles"
 
 [data-source-management]: "/docs/grafana/ -> /docs/grafana/<GRAFANA VERSION>/administration/data-source-management"
 [data-source-management]: "/docs/grafana-cloud/ -> /docs/grafana/<GRAFANA VERSION>/administration/data-source-management"

--- a/docs/sources/shared/datasources/tempo-traces-to-profiles.md
+++ b/docs/sources/shared/datasources/tempo-traces-to-profiles.md
@@ -16,7 +16,9 @@ labels:
 
 <!-- # Trace to profiles  -->
 
-{{< docs/experimental product="Trace to profiles" featureFlag="traceToProfiles" >}}
+{{% admonition type="note" %}}
+Trace to profiles is an experimental feature. Engineering and on-call support is not available. Documentation is either limited or not provided outside of code comments. No SLA is provided. Enable the `traceToProfiles` feature toggle in Grafana to use this feature. This feature is already available in Grafana Cloud.
+{{% /admonition %}}
 
 Using Trace to profiles, you can use Grafana’s ability to correlate different signals by adding the functionality to link between traces and profiles.
 

--- a/docs/sources/shared/datasources/tempo-traces-to-profiles.md
+++ b/docs/sources/shared/datasources/tempo-traces-to-profiles.md
@@ -40,6 +40,10 @@ To use trace to profiles, you must have a configured Grafana Pyroscope data sour
 
 To use a simple configuration, follow these steps:
 
+1. In the left menu, select **Connections** > **Data sources**.
+1. Select your configured Tempo data source from **Data source** list.
+1. Scroll down to the **Traces to profiles** section.
+1. Select your configured Pyroscope data source in the **Data source** drop-down.
 1. Select a Pyroscope data source from the **Data source** drop-down.
 1. Optional: Choose any tags to use in the query. If left blank, the default values of `service.name` and `service.namespace` are used.
 
@@ -57,7 +61,10 @@ To use a simple configuration, follow these steps:
 
 To use a custom query with the configuration, follow these steps:
 
-1. Select a Pyroscope data source from the **Data source** drop-down.
+1. In the left menu, select **Connections** > **Data sources**.
+1. Select a configured Tempo data source from the **Data source** list.
+1. Scroll down to the **Traces to profiles** section.
+1. Select a Pyroscope data source in the **Data source** drop-down.
 1. Optional: Choose any tags that will be used in the query. If left blank, the default values of `service.name` and `service.namespace` are used.
 
    These tags can be used in the custom query with `${__tags}` variable. This variable interpolates the mapped tags as list in an appropriate syntax for the data source and will only include the tags that were present in the span omitting those that weren’t present. You can optionally configure a new name for the tag. This is useful in cases where the tag has dots in the name and the target data source doesn't allow using dots in labels. For example, you can remap `service.name` to `service_name` in such a case. If you don’t map any tags here, you can still use any tag in the query like this `method="${__span.tags.method}"`.


### PR DESCRIPTION
**What is this feature?**

Grafana Cloud already has both of these features enabled by default, 10.3.3 does not and requires feature flags for both.

**Why do we need this feature?**

The documentation for 10.3.3 was incorrect.

**Who is this feature for?**

Users of the Tempo data source.

**Which issue(s) does this PR fix?**:
N/A

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
