### PR TITLE
[DOC] Tempo data source: fix broken link and clarify traces to profile

### DIFF
--- a/docs/sources/datasources/tempo/configure-tempo-data-source.md
+++ b/docs/sources/datasources/tempo/configure-tempo-data-source.md
@@ -91,10 +91,6 @@ The following table describes the ways in which you can configure your trace to 
 
 ## Trace to metrics
 
-{{% admonition type="note" %}}
-This feature is behind the `traceToMetrics` [feature toggle](/docs/grafana/<GRAFANA_VERSION>/setup-grafana/configure-grafana#feature_toggles). This feature is enabled in Grafana Cloud.
-{{% /admonition %}}
-
 The **Trace to metrics** setting configures the [trace to metrics feature](/blog/2022/08/18/new-in-grafana-9.1-trace-to-metrics-allows-users-to-navigate-from-a-trace-span-to-a-selected-data-source/) available when integrating Grafana with Tempo.
 
 {{< youtube id="TkapvLeMMpc" >}}

--- a/docs/sources/datasources/tempo/configure-tempo-data-source.md
+++ b/docs/sources/datasources/tempo/configure-tempo-data-source.md
@@ -92,8 +92,7 @@ The following table describes the ways in which you can configure your trace to 
 ## Trace to metrics
 
 {{% admonition type="note" %}}
-This feature is behind the `traceToMetrics` [feature toggle][configure-grafana-feature-toggles].
-If you use Grafana Cloud, open a [support ticket in the Cloud Portal](/profile/org#support) to access this feature.
+This feature is behind the `traceToMetrics` [feature toggle](/docs/grafana/<GRAFANA_VERSION>/setup-grafana/configure-grafana#feature_toggles). This feature is enabled in Grafana Cloud.
 {{% /admonition %}}
 
 The **Trace to metrics** setting configures the [trace to metrics feature](/blog/2022/08/18/new-in-grafana-9.1-trace-to-metrics-allows-users-to-navigate-from-a-trace-span-to-a-selected-data-source/) available when integrating Grafana with Tempo.
@@ -119,7 +118,7 @@ To use a simple configuration, follow these steps:
 
 ### Custom queries
 
-To use custom queriess with the configuration, follow these steps:
+To use custom queries with the configuration, follow these steps:
 
 1. Select a metrics data source from the **Data source** drop-down.
 1. Optional: Choose any tags to use in the query. If left blank, the default values of `cluster`, `hostname`, `namespace`, `pod`, `service.name` and `service.namespace` are used.
@@ -285,9 +284,6 @@ datasources:
 {{% docs/reference %}}
 [build-dashboards]: "/docs/grafana/ -> /docs/grafana/<GRAFANA VERSION>/dashboards/build-dashboards"
 [build-dashboards]: "/docs/grafana-cloud/ -> /docs/grafana/<GRAFANA VERSION>/dashboards/build-dashboards"
-
-[configure-grafana-feature-toggles]: "/docs/grafana/ -> /docs/grafana/<GRAFANA VERSION>/setup-grafana/configure-grafana#feature_toggles"
-[configure-grafana-feature-toggles]: "/docs/grafana-cloud/ -> /docs/grafana/<GRAFANA VERSION>/setup-grafana/configure-grafana#feature_toggles"
 
 [data-source-management]: "/docs/grafana/ -> /docs/grafana/<GRAFANA VERSION>/administration/data-source-management"
 [data-source-management]: "/docs/grafana-cloud/ -> /docs/grafana/<GRAFANA VERSION>/administration/data-source-management"

--- a/docs/sources/shared/datasources/tempo-traces-to-profiles.md
+++ b/docs/sources/shared/datasources/tempo-traces-to-profiles.md
@@ -46,7 +46,9 @@ Hover over a particular block in the flame graph to see more details about the r
 
 To use a basic configuration, follow these steps:
 
-1. Select a Pyroscope data source from the **Data source** drop-down.
+1. In the left menu, select **Connections** > **Data sources**.
+1. Select a Tempo data source from the **Data source** drop-down.
+1. Scroll down to the **Traces to profiles** section.
 1. Optional: Choose any tags to use in the query. If left blank, the default values of `service.name` and `service.namespace` are used.
 
    The tags you configure must be present in the spans attributes or resources for a trace-to-profiles span link to appear.
@@ -58,16 +60,18 @@ To use a basic configuration, follow these steps:
    The profile type or app must be selected for the query to be valid. Grafana doesn't show any data if the profile type or app isn’t selected when a query runs.
    ![Traces to profile configuration options in the Tempo data source](/media/docs/tempo/profiles/Tempo-data-source-profiles-Settings.png)
 
-1. Do not select **Use custom query**.
 1. Select **Save and Test**.
 
-If you have configured a Pyroscope data source and no profile data is available or the **Profiles for this span** button and the embedded flame graph is not visible, verify that the `pyroscope.profile.id` key-value pair exists in your span tags.
+If you have configured a Pyroscope data source and no profile data is available or the **Profiles for this span**
+button and the embedded flame graph isn't visible, verify that the `pyroscope.profile.id` key-value pair exists in your span tags.
 
 ## Configure a custom query
 
 To use a custom query with the configuration, follow these steps:
 
-1. Select a Pyroscope data source from the **Data source** drop-down.
+1. In the left menu, select **Connections** > **Data sources**.
+1. Select a Tempo data source from the **Data source** drop-down.
+1. Scroll down to the **Traces to profiles** section.
 1. Optional: Choose any tags to use in the query. If left blank, the default values of `service.name` and `service.namespace` are used.
 
    These tags can be used in the custom query with `${__tags}` variable. This variable interpolates the mapped tags as list in an appropriate syntax for the data source. Only the tags that were present in the span are included; tags that aren't present are omitted. You can also configure a new name for the tag. This is useful in cases where the tag has dots in the name and the target data source doesn't allow using dots in labels. For example, you can remap `service.name` to `service_name`. If you don’t map any tags here, you can still use any tag in the query, for example: `method="${__span.tags.method}"`. You can learn more about custom query variables [here](/docs/grafana/latest/datasources/tempo/configure-tempo-data-source/#custom-query-variables).
@@ -77,14 +81,14 @@ To use a custom query with the configuration, follow these steps:
 1. Specify a custom query to be used to query profile data. You can use various variables to make that query relevant for current span. The link is shown only if all the variables are interpolated with non-empty values to prevent creating an invalid query. You can interpolate the configured tags using the `$__tags` keyword.
 1. Select **Save and Test**.
 
-## Configure trace to profiles
+## Configuration options
 
-The following table describes options for configuring your trace to profiles settings:
+The following table describes options for configuring your Trace to profiles settings:
 
 | Setting name         | Description                                                                                                                                                                                                                                                                                                     |
 | -------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | **Data source**      | Defines the target data source. You can currently select a Pyroscope \[profiling\] data source.                                                                                                                                                                                                                 |
 | **Tags**             | Defines the tags to use in the profile query. Default: `cluster`, `hostname`, `namespace`, `pod`, `service.name`, `service.namespace`. You can change the tag name for example to remove dots from the name if they are not allowed in the target data source. For example, map `http.status` to `http_status`. |
-| **Profile type**     | Defines the profile type that will be used in the query.                                                                                                                                                                                                                                                        |
+| **Profile type**     | Defines the profile type that used in the query.                                                                                                                                                                                                                                                        |
 | **Use custom query** | Toggles use of custom query with interpolation.                                                                                                                                                                                                                                                                 |
 | **Query**            | Input to write custom query. Use variable interpolation to customize it with variables from span.                                                                                                                                                                                                               |

--- a/docs/sources/shared/datasources/tempo-traces-to-profiles.md
+++ b/docs/sources/shared/datasources/tempo-traces-to-profiles.md
@@ -42,14 +42,27 @@ To use trace to profiles, you must have a configured Grafana Pyroscope data sour
 This lets you see resource consumption in a flame graph visualization for each span without having to navigate away from the current view.
 Hover over a particular block in the flame graph to see more details about the resources being consumed.
 
+## Configuration options
+
+The following table describes options for configuring your Trace to profiles settings:
+
+| Setting name         | Description                                                                                                                                                                                                                                                                                                     |
+| -------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Data source**      | Defines the target data source. You can currently select a Pyroscope \[profiling\] data source.                                                                                                                                                                                                                 |
+| **Tags**             | Defines the tags to use in the profile query. Default: `cluster`, `hostname`, `namespace`, `pod`, `service.name`, `service.namespace`. You can change the tag name for example to remove dots from the name if they are not allowed in the target data source. For example, map `http.status` to `http_status`. |
+| **Profile type**     | Defines the profile type that used in the query.                                                                                                                                                                                                                                                        |
+| **Use custom query** | Toggles use of custom query with interpolation.                                                                                                                                                                                                                                                                 |
+| **Query**            | Input to write custom query. Use variable interpolation to customize it with variables from span.
+
 ## Use a basic configuration
 
 To use a basic configuration, follow these steps:
 
 1. In the left menu, select **Connections** > **Data sources**.
-1. Select a Tempo data source from the **Data source** drop-down.
+1. Select your configured Tempo data source from the **Data source** list.
 1. Scroll down to the **Traces to profiles** section.
-1. Optional: Choose any tags to use in the query. If left blank, the default values of `service.name` and `service.namespace` are used.
+1. Select a Pyroscope data source in the **Data source** drop-down.
+1. Optional: Add one or more tags to use in the query. If left blank, the default values of `service.name` and `service.namespace` are used.
 
    The tags you configure must be present in the spans attributes or resources for a trace-to-profiles span link to appear.
 
@@ -70,8 +83,9 @@ button and the embedded flame graph isn't visible, verify that the `pyroscope.pr
 To use a custom query with the configuration, follow these steps:
 
 1. In the left menu, select **Connections** > **Data sources**.
-1. Select a Tempo data source from the **Data source** drop-down.
+1. Select a configured Tempo data source from the **Data source** list.
 1. Scroll down to the **Traces to profiles** section.
+1. Select a Pyroscope data source in the **Data source** drop-down.
 1. Optional: Choose any tags to use in the query. If left blank, the default values of `service.name` and `service.namespace` are used.
 
    These tags can be used in the custom query with `${__tags}` variable. This variable interpolates the mapped tags as list in an appropriate syntax for the data source. Only the tags that were present in the span are included; tags that aren't present are omitted. You can also configure a new name for the tag. This is useful in cases where the tag has dots in the name and the target data source doesn't allow using dots in labels. For example, you can remap `service.name` to `service_name`. If you don’t map any tags here, you can still use any tag in the query, for example: `method="${__span.tags.method}"`. You can learn more about custom query variables [here](/docs/grafana/latest/datasources/tempo/configure-tempo-data-source/#custom-query-variables).
@@ -81,14 +95,4 @@ To use a custom query with the configuration, follow these steps:
 1. Specify a custom query to be used to query profile data. You can use various variables to make that query relevant for current span. The link is shown only if all the variables are interpolated with non-empty values to prevent creating an invalid query. You can interpolate the configured tags using the `$__tags` keyword.
 1. Select **Save and Test**.
 
-## Configuration options
-
-The following table describes options for configuring your Trace to profiles settings:
-
-| Setting name         | Description                                                                                                                                                                                                                                                                                                     |
-| -------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **Data source**      | Defines the target data source. You can currently select a Pyroscope \[profiling\] data source.                                                                                                                                                                                                                 |
-| **Tags**             | Defines the tags to use in the profile query. Default: `cluster`, `hostname`, `namespace`, `pod`, `service.name`, `service.namespace`. You can change the tag name for example to remove dots from the name if they are not allowed in the target data source. For example, map `http.status` to `http_status`. |
-| **Profile type**     | Defines the profile type that used in the query.                                                                                                                                                                                                                                                        |
-| **Use custom query** | Toggles use of custom query with interpolation.                                                                                                                                                                                                                                                                 |
-| **Query**            | Input to write custom query. Use variable interpolation to customize it with variables from span.                                                                                                                                                                                                               |
+                                                                                                                                                                                                         |

--- a/docs/sources/shared/datasources/tempo-traces-to-profiles.md
+++ b/docs/sources/shared/datasources/tempo-traces-to-profiles.md
@@ -50,9 +50,9 @@ The following table describes options for configuring your Trace to profiles set
 | -------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | **Data source**      | Defines the target data source. You can currently select a Pyroscope \[profiling\] data source.                                                                                                                                                                                                                 |
 | **Tags**             | Defines the tags to use in the profile query. Default: `cluster`, `hostname`, `namespace`, `pod`, `service.name`, `service.namespace`. You can change the tag name for example to remove dots from the name if they are not allowed in the target data source. For example, map `http.status` to `http_status`. |
-| **Profile type**     | Defines the profile type that used in the query.                                                                                                                                                                                                                                                        |
+| **Profile type**     | Defines the profile type that used in the query.                                                                                                                                                                                                                                                                |
 | **Use custom query** | Toggles use of custom query with interpolation.                                                                                                                                                                                                                                                                 |
-| **Query**            | Input to write custom query. Use variable interpolation to customize it with variables from span.
+| **Query**            | Input to write custom query. Use variable interpolation to customize it with variables from span.                                                                                                                                                                                                               |
 
 ## Use a basic configuration
 
@@ -82,17 +82,17 @@ button and the embedded flame graph isn't visible, verify that the `pyroscope.pr
 
 To use a custom query with the configuration, follow these steps:
 
-1. In the left menu, select **Connections** > **Data sources**.
-1. Select a configured Tempo data source from the **Data source** list.
-1. Scroll down to the **Traces to profiles** section.
-1. Select a Pyroscope data source in the **Data source** drop-down.
-1. Optional: Choose any tags to use in the query. If left blank, the default values of `service.name` and `service.namespace` are used.
+1.  In the left menu, select **Connections** > **Data sources**.
+1.  Select a configured Tempo data source from the **Data source** list.
+1.  Scroll down to the **Traces to profiles** section.
+1.  Select a Pyroscope data source in the **Data source** drop-down.
+1.  Optional: Choose any tags to use in the query. If left blank, the default values of `service.name` and `service.namespace` are used.
 
-   These tags can be used in the custom query with `${__tags}` variable. This variable interpolates the mapped tags as list in an appropriate syntax for the data source. Only the tags that were present in the span are included; tags that aren't present are omitted. You can also configure a new name for the tag. This is useful in cases where the tag has dots in the name and the target data source doesn't allow using dots in labels. For example, you can remap `service.name` to `service_name`. If you don’t map any tags here, you can still use any tag in the query, for example: `method="${__span.tags.method}"`. You can learn more about custom query variables [here](/docs/grafana/latest/datasources/tempo/configure-tempo-data-source/#custom-query-variables).
+    These tags can be used in the custom query with `${__tags}` variable. This variable interpolates the mapped tags as list in an appropriate syntax for the data source. Only the tags that were present in the span are included; tags that aren't present are omitted. You can also configure a new name for the tag. This is useful in cases where the tag has dots in the name and the target data source doesn't allow using dots in labels. For example, you can remap `service.name` to `service_name`. If you don’t map any tags here, you can still use any tag in the query, for example: `method="${__span.tags.method}"`. You can learn more about custom query variables [here](/docs/grafana/latest/datasources/tempo/configure-tempo-data-source/#custom-query-variables).
 
-1. Select one or more profile types to use in the query. Select the drop-down and choose options from the menu.
-1. Switch on **Use custom query** to enter a custom query.
-1. Specify a custom query to be used to query profile data. You can use various variables to make that query relevant for current span. The link is shown only if all the variables are interpolated with non-empty values to prevent creating an invalid query. You can interpolate the configured tags using the `$__tags` keyword.
-1. Select **Save and Test**.
+1.  Select one or more profile types to use in the query. Select the drop-down and choose options from the menu.
+1.  Switch on **Use custom query** to enter a custom query.
+1.  Specify a custom query to be used to query profile data. You can use various variables to make that query relevant for current span. The link is shown only if all the variables are interpolated with non-empty values to prevent creating an invalid query. You can interpolate the configured tags using the `$__tags` keyword.
+1.  Select **Save and Test**.
 
                                                                                                                                                                                                          |


### PR DESCRIPTION
**What is this feature?**

Fix a broken link in the Tempo data source doc under the note in Trace to metrics. 

Fix incorrect instructions in the Traces to profile content. 

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [X] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
