### PR TITLE
Sandbox: Fix custom variable query editors not working inside the sandbox

### DIFF
--- a/public/app/features/plugins/sandbox/document_sandbox.ts
+++ b/public/app/features/plugins/sandbox/document_sandbox.ts
@@ -2,7 +2,7 @@ import { isNearMembraneProxy, ProxyTarget } from '@locker/near-membrane-shared';
 import { cloneDeep } from 'lodash';
 import Prism from 'prismjs';
 
-import { DataSourceApi } from '@grafana/data';
+import { CustomVariableSupport, DataSourceApi } from '@grafana/data';
 import { config } from '@grafana/runtime';
 
 import { forbiddenElements } from './constants';
@@ -138,7 +138,7 @@ export function patchObjectAsLiveTarget(obj: unknown) {
     !(obj instanceof Function) &&
     // conditions for allowed objects
     // react class components
-    (isReactClassComponent(obj) || obj instanceof DataSourceApi)
+    (isReactClassComponent(obj) || obj instanceof DataSourceApi || obj instanceof CustomVariableSupport)
   ) {
     Reflect.defineProperty(obj, SANDBOX_LIVE_VALUE, {});
   } else {


### PR DESCRIPTION
**What is this feature?**

It fixes an issue where datasources with custom variable query editors wouldn't work inside the sandbox. The query editor was not displayed.

**Why do we need this feature?**

To make sure all datasources work inside the sandbox.

**Who is this feature for?**

All users of datasources with custom variable query editors.

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
