### PR TITLE
Chore: Align usage of tsconfig in yarn workspaces to 1.3.0-rc1

### DIFF
--- a/packages/grafana-data/package.json
+++ b/packages/grafana-data/package.json
@@ -62,7 +62,7 @@
     "xss": "^1.0.14"
   },
   "devDependencies": {
-    "@grafana/tsconfig": "^1.2.0-rc1",
+    "@grafana/tsconfig": "^1.3.0-rc1",
     "@rollup/plugin-commonjs": "25.0.7",
     "@rollup/plugin-json": "6.1.0",
     "@rollup/plugin-node-resolve": "15.2.3",

--- a/packages/grafana-e2e-selectors/package.json
+++ b/packages/grafana-e2e-selectors/package.json
@@ -50,7 +50,7 @@
     "rollup-plugin-node-externals": "^5.0.0"
   },
   "dependencies": {
-    "@grafana/tsconfig": "^1.2.0-rc1",
+    "@grafana/tsconfig": "^1.3.0-rc1",
     "tslib": "2.6.2",
     "typescript": "5.3.3"
   }

--- a/packages/grafana-e2e/package.json
+++ b/packages/grafana-e2e/package.json
@@ -65,7 +65,7 @@
     "@cypress/webpack-preprocessor": "5.17.1",
     "@grafana/e2e-selectors": "11.0.0-pre",
     "@grafana/schema": "11.0.0-pre",
-    "@grafana/tsconfig": "^1.2.0-rc1",
+    "@grafana/tsconfig": "^1.3.0-rc1",
     "@mochajs/json-file-reporter": "^1.2.0",
     "babel-loader": "9.1.3",
     "blink-diff": "1.0.13",

--- a/packages/grafana-flamegraph/package.json
+++ b/packages/grafana-flamegraph/package.json
@@ -59,7 +59,7 @@
     "@babel/core": "7.23.9",
     "@babel/preset-env": "7.23.9",
     "@babel/preset-react": "7.23.3",
-    "@grafana/tsconfig": "^1.2.0-rc1",
+    "@grafana/tsconfig": "^1.3.0-rc1",
     "@rollup/plugin-node-resolve": "15.2.3",
     "@testing-library/jest-dom": "^6.1.2",
     "@testing-library/react": "14.2.1",

--- a/packages/grafana-plugin-configs/package.json
+++ b/packages/grafana-plugin-configs/package.json
@@ -7,7 +7,7 @@
     "tslib": "2.6.2"
   },
   "devDependencies": {
-    "@grafana/tsconfig": "^1.2.0-rc1",
+    "@grafana/tsconfig": "^1.3.0-rc1",
     "copy-webpack-plugin": "12.0.2",
     "eslint-webpack-plugin": "4.0.1",
     "fork-ts-checker-webpack-plugin": "9.0.2",

--- a/packages/grafana-runtime/package.json
+++ b/packages/grafana-runtime/package.json
@@ -50,7 +50,7 @@
     "tslib": "2.6.2"
   },
   "devDependencies": {
-    "@grafana/tsconfig": "^1.2.0-rc1",
+    "@grafana/tsconfig": "^1.3.0-rc1",
     "@rollup/plugin-commonjs": "25.0.7",
     "@rollup/plugin-node-resolve": "15.2.3",
     "@testing-library/dom": "9.3.4",

--- a/packages/grafana-schema/package.json
+++ b/packages/grafana-schema/package.json
@@ -36,7 +36,7 @@
     "postpack": "mv package.json.bak package.json"
   },
   "devDependencies": {
-    "@grafana/tsconfig": "^1.2.0-rc1",
+    "@grafana/tsconfig": "^1.3.0-rc1",
     "@rollup/plugin-commonjs": "25.0.7",
     "@rollup/plugin-json": "6.1.0",
     "@rollup/plugin-node-resolve": "15.2.3",

--- a/packages/grafana-ui/package.json
+++ b/packages/grafana-ui/package.json
@@ -111,7 +111,7 @@
   },
   "devDependencies": {
     "@babel/core": "7.23.9",
-    "@grafana/tsconfig": "^1.2.0-rc1",
+    "@grafana/tsconfig": "^1.3.0-rc1",
     "@rollup/plugin-node-resolve": "15.2.3",
     "@storybook/addon-a11y": "7.4.5",
     "@storybook/addon-actions": "7.4.5",

--- a/plugins-bundled/internal/input-datasource/package.json
+++ b/plugins-bundled/internal/input-datasource/package.json
@@ -14,7 +14,7 @@
   },
   "author": "Grafana Labs",
   "devDependencies": {
-    "@grafana/tsconfig": "^1.2.0-rc1",
+    "@grafana/tsconfig": "^1.3.0-rc1",
     "@types/jest": "26.0.15",
     "@types/react": "18.0.28",
     "copy-webpack-plugin": "11.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3334,7 +3334,7 @@ __metadata:
   resolution: "@grafana-plugins/input-datasource@workspace:plugins-bundled/internal/input-datasource"
   dependencies:
     "@grafana/data": "npm:11.0.0-pre"
-    "@grafana/tsconfig": "npm:^1.2.0-rc1"
+    "@grafana/tsconfig": "npm:^1.3.0-rc1"
     "@grafana/ui": "npm:11.0.0-pre"
     "@types/jest": "npm:26.0.15"
     "@types/react": "npm:18.0.28"
@@ -3537,7 +3537,7 @@ __metadata:
   dependencies:
     "@braintree/sanitize-url": "npm:7.0.0"
     "@grafana/schema": "npm:11.0.0-pre"
-    "@grafana/tsconfig": "npm:^1.2.0-rc1"
+    "@grafana/tsconfig": "npm:^1.3.0-rc1"
     "@rollup/plugin-commonjs": "npm:25.0.7"
     "@rollup/plugin-json": "npm:6.1.0"
     "@rollup/plugin-node-resolve": "npm:15.2.3"
@@ -3611,7 +3611,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@grafana/e2e-selectors@workspace:packages/grafana-e2e-selectors"
   dependencies:
-    "@grafana/tsconfig": "npm:^1.2.0-rc1"
+    "@grafana/tsconfig": "npm:^1.3.0-rc1"
     "@rollup/plugin-commonjs": "npm:25.0.7"
     "@rollup/plugin-node-resolve": "npm:15.2.3"
     "@types/node": "npm:20.11.19"
@@ -3635,7 +3635,7 @@ __metadata:
     "@cypress/webpack-preprocessor": "npm:5.17.1"
     "@grafana/e2e-selectors": "npm:11.0.0-pre"
     "@grafana/schema": "npm:11.0.0-pre"
-    "@grafana/tsconfig": "npm:^1.2.0-rc1"
+    "@grafana/tsconfig": "npm:^1.3.0-rc1"
     "@mochajs/json-file-reporter": "npm:^1.2.0"
     "@rollup/plugin-node-resolve": "npm:15.2.3"
     "@types/chrome-remote-interface": "npm:0.31.10"
@@ -3800,7 +3800,7 @@ __metadata:
     "@babel/preset-react": "npm:7.23.3"
     "@emotion/css": "npm:11.11.2"
     "@grafana/data": "npm:11.0.0-pre"
-    "@grafana/tsconfig": "npm:^1.2.0-rc1"
+    "@grafana/tsconfig": "npm:^1.3.0-rc1"
     "@grafana/ui": "npm:11.0.0-pre"
     "@leeoniya/ufuzzy": "npm:1.0.14"
     "@rollup/plugin-node-resolve": "npm:15.2.3"
@@ -3912,7 +3912,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@grafana/plugin-configs@workspace:packages/grafana-plugin-configs"
   dependencies:
-    "@grafana/tsconfig": "npm:^1.2.0-rc1"
+    "@grafana/tsconfig": "npm:^1.3.0-rc1"
     copy-webpack-plugin: "npm:12.0.2"
     eslint-webpack-plugin: "npm:4.0.1"
     fork-ts-checker-webpack-plugin: "npm:9.0.2"
@@ -4046,7 +4046,7 @@ __metadata:
     "@grafana/e2e-selectors": "npm:11.0.0-pre"
     "@grafana/faro-web-sdk": "npm:^1.3.6"
     "@grafana/schema": "npm:11.0.0-pre"
-    "@grafana/tsconfig": "npm:^1.2.0-rc1"
+    "@grafana/tsconfig": "npm:^1.3.0-rc1"
     "@grafana/ui": "npm:11.0.0-pre"
     "@rollup/plugin-commonjs": "npm:25.0.7"
     "@rollup/plugin-node-resolve": "npm:15.2.3"
@@ -4107,7 +4107,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@grafana/schema@workspace:packages/grafana-schema"
   dependencies:
-    "@grafana/tsconfig": "npm:^1.2.0-rc1"
+    "@grafana/tsconfig": "npm:^1.3.0-rc1"
     "@rollup/plugin-commonjs": "npm:25.0.7"
     "@rollup/plugin-json": "npm:6.1.0"
     "@rollup/plugin-node-resolve": "npm:15.2.3"
@@ -4189,7 +4189,7 @@ __metadata:
     "@grafana/e2e-selectors": "npm:11.0.0-pre"
     "@grafana/faro-web-sdk": "npm:^1.3.6"
     "@grafana/schema": "npm:11.0.0-pre"
-    "@grafana/tsconfig": "npm:^1.2.0-rc1"
+    "@grafana/tsconfig": "npm:^1.3.0-rc1"
     "@leeoniya/ufuzzy": "npm:1.0.14"
     "@monaco-editor/react": "npm:4.6.0"
     "@popperjs/core": "npm:2.11.8"


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

Aligns usage of grafana/ts-config to version 1.3.0-rc1.

**Why do we need this feature?**

To clean up file system where yarn is creating loads of node_modules directories for this package.

**Who is this feature for?**

Grafana devs

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
