### PR TITLE
Sql: Fix an issue with connection limits not updating when jsonData is updated

### DIFF
--- a/packages/grafana-sql/src/components/NumberInput.tsx
+++ b/packages/grafana-sql/src/components/NumberInput.tsx
@@ -1,0 +1,37 @@
+import React from 'react';
+
+import { Input } from '@grafana/ui/src/components/Input/Input';
+
+type NumberInputProps = {
+  value: number;
+  defaultValue: number;
+  onChange: (value: number) => void;
+  width: number;
+  placeholder?: string;
+  disabled?: boolean;
+};
+
+export function NumberInput({ value, defaultValue, onChange, width, placeholder, disabled }: NumberInputProps) {
+  const [isEmpty, setIsEmpty] = React.useState(false);
+  return (
+    <Input
+      type="number"
+      placeholder={placeholder ?? String(defaultValue)}
+      value={isEmpty ? '' : value}
+      onChange={(e) => {
+        if (e.currentTarget.value?.trim() === '') {
+          setIsEmpty(true);
+          onChange(defaultValue);
+        } else {
+          setIsEmpty(false);
+          const newVal = Number(e.currentTarget.value);
+          if (!Number.isNaN(newVal)) {
+            onChange(newVal);
+          }
+        }
+      }}
+      width={width}
+      disabled={disabled}
+    />
+  );
+}

--- a/packages/grafana-sql/src/components/configuration/ConnectionLimits.tsx
+++ b/packages/grafana-sql/src/components/configuration/ConnectionLimits.tsx
@@ -121,7 +121,7 @@ export const ConnectionLimits = <T extends SQLConnectionLimits>(props: Props<T>)
         label={
           <Label>
             <Stack gap={0.5}>
-              <span>Auto Max Idle</span>
+              <span>Auto max idle</span>
               <Tooltip
                 content={
                   <span>
@@ -171,7 +171,6 @@ export const ConnectionLimits = <T extends SQLConnectionLimits>(props: Props<T>)
               onJSONDataNumberChanged('maxIdleConns')(value);
             }}
             width={labelWidth}
-            disabled={autoIdle}
           />
         )}
       </Field>

--- a/packages/grafana-sql/src/components/configuration/ConnectionLimits.tsx
+++ b/packages/grafana-sql/src/components/configuration/ConnectionLimits.tsx
@@ -6,7 +6,8 @@ import { config } from '@grafana/runtime';
 import { Field, Icon, InlineLabel, Label, Switch, Tooltip } from '@grafana/ui';
 
 import { SQLConnectionLimits, SQLOptions } from '../../types';
-import { NumberInput } from '../NumberInput';
+
+import { NumberInput } from './NumberInput';
 
 interface Props<T> {
   onOptionsChange: Function;
@@ -108,8 +109,7 @@ export const ConnectionLimits = <T extends SQLConnectionLimits>(props: Props<T>)
       >
         <NumberInput
           value={jsonData.maxOpenConns}
-          defaultValue={0}
-          placeholder="unlimited"
+          defaultValue={config.sqlConnectionLimits.maxOpenConns}
           onChange={(value) => {
             onMaxConnectionsChanged(value);
           }}
@@ -166,7 +166,7 @@ export const ConnectionLimits = <T extends SQLConnectionLimits>(props: Props<T>)
         ) : (
           <NumberInput
             value={jsonData.maxIdleConns}
-            defaultValue={2}
+            defaultValue={config.sqlConnectionLimits.maxIdleConns}
             onChange={(value) => {
               onJSONDataNumberChanged('maxIdleConns')(value);
             }}
@@ -197,7 +197,7 @@ export const ConnectionLimits = <T extends SQLConnectionLimits>(props: Props<T>)
       >
         <NumberInput
           value={jsonData.connMaxLifetime}
-          defaultValue={14400}
+          defaultValue={config.sqlConnectionLimits.connMaxLifetime}
           onChange={(value) => {
             onJSONDataNumberChanged('connMaxLifetime')(value);
           }}

--- a/packages/grafana-sql/src/components/configuration/ConnectionLimits.tsx
+++ b/packages/grafana-sql/src/components/configuration/ConnectionLimits.tsx
@@ -3,30 +3,20 @@ import React from 'react';
 import { DataSourceSettings } from '@grafana/data';
 import { ConfigSubSection, Stack } from '@grafana/experimental';
 import { config } from '@grafana/runtime';
-import { Field, Icon, InlineLabel, Input, Label, Switch, Tooltip } from '@grafana/ui';
+import { Field, Icon, InlineLabel, Label, Switch, Tooltip } from '@grafana/ui';
 
 import { SQLConnectionLimits, SQLOptions } from '../../types';
+import { NumberInput } from '../NumberInput';
 
 interface Props<T> {
   onOptionsChange: Function;
   options: DataSourceSettings<SQLOptions>;
 }
 
-function toNumber(text: string): number {
-  if (text.trim() === '') {
-    // calling `Number('')` returns zero,
-    // so we have to handle this case
-    return NaN;
-  }
-
-  return Number(text);
-}
-
 export const ConnectionLimits = <T extends SQLConnectionLimits>(props: Props<T>) => {
   const { onOptionsChange, options } = props;
   const jsonData = options.jsonData;
   const autoIdle = jsonData.maxIdleConnsAuto !== undefined ? jsonData.maxIdleConnsAuto : false;
-  const [connMaxLifetimeEmpty, setConnMaxLifetimeEmpty] = React.useState(false);
 
   // Update JSON data with new values
   const updateJsonData = (values: {}) => {
@@ -93,8 +83,6 @@ export const ConnectionLimits = <T extends SQLConnectionLimits>(props: Props<T>)
 
   const labelWidth = 40;
 
-  const defaultMaxLifetime = 14400;
-
   return (
     <ConfigSubSection title="Connection limits">
       <Field
@@ -118,15 +106,12 @@ export const ConnectionLimits = <T extends SQLConnectionLimits>(props: Props<T>)
           </Label>
         }
       >
-        <Input
-          type="number"
+        <NumberInput
+          value={jsonData.maxOpenConns}
+          defaultValue={0}
           placeholder="unlimited"
-          defaultValue={jsonData.maxOpenConns}
-          onChange={(e) => {
-            const newVal = toNumber(e.currentTarget.value);
-            if (!Number.isNaN(newVal)) {
-              onMaxConnectionsChanged(newVal);
-            }
+          onChange={(value) => {
+            onMaxConnectionsChanged(value);
           }}
           width={labelWidth}
         />
@@ -179,15 +164,11 @@ export const ConnectionLimits = <T extends SQLConnectionLimits>(props: Props<T>)
         {autoIdle ? (
           <InlineLabel width={labelWidth}>{options.jsonData.maxIdleConns}</InlineLabel>
         ) : (
-          <Input
-            type="number"
-            placeholder="2"
-            defaultValue={jsonData.maxIdleConns}
-            onChange={(e) => {
-              const newVal = toNumber(e.currentTarget.value);
-              if (!Number.isNaN(newVal)) {
-                onJSONDataNumberChanged('maxIdleConns')(newVal);
-              }
+          <NumberInput
+            value={jsonData.maxIdleConns}
+            defaultValue={2}
+            onChange={(value) => {
+              onJSONDataNumberChanged('maxIdleConns')(value);
             }}
             width={labelWidth}
             disabled={autoIdle}
@@ -214,22 +195,11 @@ export const ConnectionLimits = <T extends SQLConnectionLimits>(props: Props<T>)
           </Label>
         }
       >
-        <Input
-          type="number"
-          placeholder={String(defaultMaxLifetime)}
-          value={connMaxLifetimeEmpty ? '' : jsonData.connMaxLifetime}
-          onChange={(e) => {
-            if (e.currentTarget.value === '') {
-              setConnMaxLifetimeEmpty(true);
-              onJSONDataNumberChanged('connMaxLifetime')(defaultMaxLifetime);
-            } else {
-              setConnMaxLifetimeEmpty(false);
-            }
-
-            const newVal = toNumber(e.currentTarget.value);
-            if (!Number.isNaN(newVal)) {
-              onJSONDataNumberChanged('connMaxLifetime')(newVal);
-            }
+        <NumberInput
+          value={jsonData.connMaxLifetime}
+          defaultValue={14400}
+          onChange={(value) => {
+            onJSONDataNumberChanged('connMaxLifetime')(value);
           }}
           width={labelWidth}
         />

--- a/packages/grafana-sql/src/components/configuration/ConnectionLimits.tsx
+++ b/packages/grafana-sql/src/components/configuration/ConnectionLimits.tsx
@@ -118,7 +118,7 @@ export const ConnectionLimits = <T extends SQLConnectionLimits>(props: Props<T>)
         <Input
           type="number"
           placeholder="unlimited"
-          defaultValue={jsonData.maxOpenConns}
+          value={jsonData.maxOpenConns}
           onChange={(e) => {
             const newVal = toNumber(e.currentTarget.value);
             if (!Number.isNaN(newVal)) {
@@ -179,7 +179,7 @@ export const ConnectionLimits = <T extends SQLConnectionLimits>(props: Props<T>)
           <Input
             type="number"
             placeholder="2"
-            defaultValue={jsonData.maxIdleConns}
+            value={jsonData.maxIdleConns}
             onChange={(e) => {
               const newVal = toNumber(e.currentTarget.value);
               if (!Number.isNaN(newVal)) {
@@ -214,7 +214,7 @@ export const ConnectionLimits = <T extends SQLConnectionLimits>(props: Props<T>)
         <Input
           type="number"
           placeholder="14400"
-          defaultValue={jsonData.connMaxLifetime}
+          value={jsonData.connMaxLifetime}
           onChange={(e) => {
             const newVal = toNumber(e.currentTarget.value);
             if (!Number.isNaN(newVal)) {

--- a/packages/grafana-sql/src/components/configuration/ConnectionLimits.tsx
+++ b/packages/grafana-sql/src/components/configuration/ConnectionLimits.tsx
@@ -26,6 +26,7 @@ export const ConnectionLimits = <T extends SQLConnectionLimits>(props: Props<T>)
   const { onOptionsChange, options } = props;
   const jsonData = options.jsonData;
   const autoIdle = jsonData.maxIdleConnsAuto !== undefined ? jsonData.maxIdleConnsAuto : false;
+  const [connMaxLifetimeEmpty, setConnMaxLifetimeEmpty] = React.useState(false);
 
   // Update JSON data with new values
   const updateJsonData = (values: {}) => {
@@ -92,6 +93,8 @@ export const ConnectionLimits = <T extends SQLConnectionLimits>(props: Props<T>)
 
   const labelWidth = 40;
 
+  const defaultMaxLifetime = 14400;
+
   return (
     <ConfigSubSection title="Connection limits">
       <Field
@@ -118,7 +121,7 @@ export const ConnectionLimits = <T extends SQLConnectionLimits>(props: Props<T>)
         <Input
           type="number"
           placeholder="unlimited"
-          value={jsonData.maxOpenConns}
+          defaultValue={jsonData.maxOpenConns}
           onChange={(e) => {
             const newVal = toNumber(e.currentTarget.value);
             if (!Number.isNaN(newVal)) {
@@ -179,7 +182,7 @@ export const ConnectionLimits = <T extends SQLConnectionLimits>(props: Props<T>)
           <Input
             type="number"
             placeholder="2"
-            value={jsonData.maxIdleConns}
+            defaultValue={jsonData.maxIdleConns}
             onChange={(e) => {
               const newVal = toNumber(e.currentTarget.value);
               if (!Number.isNaN(newVal)) {
@@ -213,9 +216,16 @@ export const ConnectionLimits = <T extends SQLConnectionLimits>(props: Props<T>)
       >
         <Input
           type="number"
-          placeholder="14400"
-          value={jsonData.connMaxLifetime}
+          placeholder={String(defaultMaxLifetime)}
+          value={connMaxLifetimeEmpty ? '' : jsonData.connMaxLifetime}
           onChange={(e) => {
+            if (e.currentTarget.value === '') {
+              setConnMaxLifetimeEmpty(true);
+              onJSONDataNumberChanged('connMaxLifetime')(defaultMaxLifetime);
+            } else {
+              setConnMaxLifetimeEmpty(false);
+            }
+
             const newVal = toNumber(e.currentTarget.value);
             if (!Number.isNaN(newVal)) {
               onJSONDataNumberChanged('connMaxLifetime')(newVal);

--- a/packages/grafana-sql/src/components/configuration/NumberInput.tsx
+++ b/packages/grafana-sql/src/components/configuration/NumberInput.tsx
@@ -7,10 +7,9 @@ type NumberInputProps = {
   defaultValue: number;
   onChange: (value: number) => void;
   width: number;
-  disabled?: boolean;
 };
 
-export function NumberInput({ value, defaultValue, onChange, width, disabled }: NumberInputProps) {
+export function NumberInput({ value, defaultValue, onChange, width }: NumberInputProps) {
   const [isEmpty, setIsEmpty] = React.useState(false);
   return (
     <Input
@@ -30,7 +29,6 @@ export function NumberInput({ value, defaultValue, onChange, width, disabled }: 
         }
       }}
       width={width}
-      disabled={disabled}
     />
   );
 }

--- a/packages/grafana-sql/src/components/configuration/NumberInput.tsx
+++ b/packages/grafana-sql/src/components/configuration/NumberInput.tsx
@@ -7,16 +7,15 @@ type NumberInputProps = {
   defaultValue: number;
   onChange: (value: number) => void;
   width: number;
-  placeholder?: string;
   disabled?: boolean;
 };
 
-export function NumberInput({ value, defaultValue, onChange, width, placeholder, disabled }: NumberInputProps) {
+export function NumberInput({ value, defaultValue, onChange, width, disabled }: NumberInputProps) {
   const [isEmpty, setIsEmpty] = React.useState(false);
   return (
     <Input
       type="number"
-      placeholder={placeholder ?? String(defaultValue)}
+      placeholder={String(defaultValue)}
       value={isEmpty ? '' : value}
       onChange={(e) => {
         if (e.currentTarget.value?.trim() === '') {


### PR DESCRIPTION
This PR fixes an issue with connection limit fields not updating when jsonData is updated.

cc @leventebalogh 

Before the fix: 
- The PDC plugin extension sets `jsonData.connMaxLifetime` to 300 whenever a PDC connection is set. 
- It is only reflected in the UI when the `Max lifetime` field is not set previously by the user.
- Once the user sets the value, the PDC plugin extension updates the JSON data, but it is not reflected in the UI. 
- Saving the data source and reloading the page shows the value correctly

https://github.com/grafana/grafana/assets/561365/f7d05344-02e2-49a4-8c4b-43a92ffe69fd

After the fix: 
- UI reflects changes in JSON data without reloading the page

https://github.com/grafana/grafana/assets/561365/ed1d3a16-a6ef-4708-9b9c-0fdd625335a8
 
Please check that:
- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
