### PR TITLE
Docs: add ClickHouse to exploring logs/traces page

### DIFF
--- a/docs/sources/explore/logs-integration.md
+++ b/docs/sources/explore/logs-integration.md
@@ -21,6 +21,7 @@ Explore is a powerful tool for logging and log analysis. It allows you to invest
 - [Cloudwatch]({{< relref "../datasources/aws-cloudwatch" >}})
 - [InfluxDB]({{< relref "../datasources/influxdb" >}})
 - [Azure Monitor]({{< relref "../datasources/azure-monitor" >}})
+- [ClickHouse](https://github.com/grafana/clickhouse-datasource)
 
 With Explore, you can efficiently monitor, troubleshoot, and respond to incidents by analyzing your logs and identifying the root causes. It also helps you to correlate logs with other telemetry signals such as metrics, traces or profiles, by viewing them side-by-side.
 

--- a/docs/sources/explore/trace-integration.md
+++ b/docs/sources/explore/trace-integration.md
@@ -23,6 +23,7 @@ Supported data sources are:
 - [Zipkin]({{< relref "../datasources/zipkin/" >}})
 - [X-Ray](https://grafana.com/grafana/plugins/grafana-x-ray-datasource)
 - [Azure Monitor Application Insights]({{< relref "../datasources/azure-monitor/" >}})
+- [ClickHouse](https://github.com/grafana/clickhouse-datasource)
 
 For information on how to configure queries for the data sources listed above, refer to the documentation for specific data source.
 
@@ -38,6 +39,7 @@ For information on querying each data source, refer to their documentation:
 - [Jaeger query editor]({{< relref "../datasources/jaeger/#query-the-data-source" >}})
 - [Zipkin query editor]({{< relref "../datasources/zipkin/#query-the-data-source" >}})
 - [Azure Monitor Application Insights query editor]({{< relref "../datasources/azure-monitor/query-editor/#query-application-insights-traces" >}})
+- [ClickHouse query editor](https://clickhouse.com/docs/en/integrations/grafana/query-builder#traces)
 
 ## Trace view
 


### PR DESCRIPTION
**What is this feature?**

Adds links to the ClickHouse data source plugin on the "logs and tracing in explore" pages

**Why do we need this feature?**

The ClickHouse data source now supports logs & tracing in explore.
This plugin is developed [within the Grafana organization](https://github.com/grafana/clickhouse-datasource) as the official ClickHouse data source for Grafana.

---

Thanks!