### PR TITLE
fix: datatrails: start step is "metric select" after reinitializing from URL

### DIFF
--- a/public/app/features/trails/DataTrail.tsx
+++ b/public/app/features/trails/DataTrail.tsx
@@ -191,7 +191,7 @@ export class DataTrail extends SceneObjectBase<DataTrailState> {
   };
 }
 
-function getTopSceneFor(metric?: string) {
+export function getTopSceneFor(metric?: string) {
   if (metric) {
     return new MetricScene({ metric: metric });
   } else {


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

Ensures that the start step is always metric-free (when restoring data trail from a URL state).

If restoring data trail state from a URL (or from browser refresh), the data trail history would only show one node: the start node. This could include the current metric, resulting in no way to return back to a "start" state that has no metric selected.

If there is a metric in the URL state, the selection of the metric becomes a second step.
Thus, now the first step is always without a metric, and displays the metric selection scene.

However, if reloading a saved trail that was persisted before this fix, it is still possible to get a start node with a selected metric. Do we want to ensure a metric-free start node is present when reloading old trails? Bookmarks?

Additionally, this is ONLY concerned with metrics. Any filters, time range changes, etc. will be in effect on the start step, and the second step will be a metric change step.


**Why do we need this feature?**

A mechanism to get back to a cleaner state.


**Which issue(s) does this PR fix?**:

- #81593

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

An easy way to encounter this issue is to reload the browser after having selected a metric.

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
