### PR TITLE
AzureMonitor: Fix mishandled resources vs workspaces

### DIFF
--- a/pkg/tsdb/azuremonitor/loganalytics/azure-log-analytics-datasource.go
+++ b/pkg/tsdb/azuremonitor/loganalytics/azure-log-analytics-datasource.go
@@ -485,11 +485,19 @@ func (e *AzureLogAnalyticsDatasource) createRequest(ctx context.Context, queryUR
 	}
 
 	if len(query.Resources) > 1 && query.QueryType == dataquery.AzureQueryTypeAzureLogAnalytics && !query.AppInsightsQuery {
-		body["workspaces"] = query.Resources
+		str := strings.ToLower(query.Resources[0])
+
+		if strings.Contains(str, "microsoft.operationalinsights/workspaces") {
+			body["workspaces"] = query.Resources
+		} else {
+			body["resources"] = query.Resources
+		}
 	}
+
 	if query.AppInsightsQuery {
 		body["applications"] = query.Resources
 	}
+
 	jsonValue, err := json.Marshal(body)
 	if err != nil {
 		return nil, fmt.Errorf("%v: %w", "failed to create request", err)
@@ -499,6 +507,7 @@ func (e *AzureLogAnalyticsDatasource) createRequest(ctx context.Context, queryUR
 	if err != nil {
 		return nil, fmt.Errorf("%v: %w", "failed to create request", err)
 	}
+
 	req.URL.Path = "/"
 	req.Header.Set("Content-Type", "application/json")
 	req.URL.Path = path.Join(req.URL.Path, query.URL)


### PR DESCRIPTION
Fixes #82853. This PR fixes an issue where calls to the Azure Monitor API where resources URIs **not** including the substring `microsoft.operationalinsights/workspaces` were incorrectly handled as `workspaces`.