### PR TITLE
Table: custom column header components

### DIFF
--- a/packages/grafana-ui/src/components/Table/HeaderRow.tsx
+++ b/packages/grafana-ui/src/components/Table/HeaderRow.tsx
@@ -49,7 +49,7 @@ function renderHeaderCell(
   column: any,
   tableStyles: TableStyles,
   showTypeIcons?: boolean,
-  CustomHeaderComponent?: React.ReactElement
+  customHeaderComponent?: React.ReactElement
 ) {
   const headerProps = column.getHeaderProps();
   const field = column.field ?? null;
@@ -60,7 +60,6 @@ function renderHeaderCell(
 
   headerProps.style.position = 'absolute';
   headerProps.style.justifyContent = column.justifyContent;
-  console.log('customHeaderComponent', CustomHeaderComponent);
 
   return (
     <div className={tableStyles.headerCell} {...headerProps} role="columnheader">
@@ -84,7 +83,7 @@ function renderHeaderCell(
       {!column.canSort && column.render('Header')}
       {!column.canSort && column.canFilter && <Filter column={column} tableStyles={tableStyles} field={field} />}
       {column.canResize && <div {...column.getResizerProps()} className={tableStyles.resizeHandle} />}
-      {CustomHeaderComponent && CustomHeaderComponent}
+      {customHeaderComponent && customHeaderComponent}
     </div>
   );
 }

--- a/packages/grafana-ui/src/components/Table/HeaderRow.tsx
+++ b/packages/grafana-ui/src/components/Table/HeaderRow.tsx
@@ -13,10 +13,11 @@ export interface HeaderRowProps {
   headerGroups: HeaderGroup[];
   showTypeIcons?: boolean;
   tableStyles: TableStyles;
+  columnHeaders: Map<number, React.ReactElement>;
 }
 
 export const HeaderRow = (props: HeaderRowProps) => {
-  const { headerGroups, showTypeIcons, tableStyles } = props;
+  const { headerGroups, showTypeIcons, tableStyles, columnHeaders } = props;
   const e2eSelectorsTable = selectors.components.Panels.Visualization.Table;
 
   return (
@@ -31,9 +32,12 @@ export const HeaderRow = (props: HeaderRowProps) => {
             aria-label={e2eSelectorsTable.header}
             role="row"
           >
-            {headerGroup.headers.map((column: Column, index: number) =>
-              renderHeaderCell(column, tableStyles, showTypeIcons)
-            )}
+            {headerGroup.headers.map((column: Column, index: number) => {
+              if (columnHeaders && columnHeaders.has(index)) {
+                return renderHeaderCell(column, tableStyles, showTypeIcons, columnHeaders.get(index));
+              }
+              return renderHeaderCell(column, tableStyles, showTypeIcons);
+            })}
           </div>
         );
       })}
@@ -41,7 +45,12 @@ export const HeaderRow = (props: HeaderRowProps) => {
   );
 };
 
-function renderHeaderCell(column: any, tableStyles: TableStyles, showTypeIcons?: boolean) {
+function renderHeaderCell(
+  column: any,
+  tableStyles: TableStyles,
+  showTypeIcons?: boolean,
+  CustomHeaderComponent?: React.ReactElement
+) {
   const headerProps = column.getHeaderProps();
   const field = column.field ?? null;
 
@@ -51,6 +60,7 @@ function renderHeaderCell(column: any, tableStyles: TableStyles, showTypeIcons?:
 
   headerProps.style.position = 'absolute';
   headerProps.style.justifyContent = column.justifyContent;
+  console.log('customHeaderComponent', CustomHeaderComponent);
 
   return (
     <div className={tableStyles.headerCell} {...headerProps} role="columnheader">
@@ -74,6 +84,7 @@ function renderHeaderCell(column: any, tableStyles: TableStyles, showTypeIcons?:
       {!column.canSort && column.render('Header')}
       {!column.canSort && column.canFilter && <Filter column={column} tableStyles={tableStyles} field={field} />}
       {column.canResize && <div {...column.getResizerProps()} className={tableStyles.resizeHandle} />}
+      {CustomHeaderComponent && CustomHeaderComponent}
     </div>
   );
 }

--- a/packages/grafana-ui/src/components/Table/HeaderRow.tsx
+++ b/packages/grafana-ui/src/components/Table/HeaderRow.tsx
@@ -32,12 +32,9 @@ export const HeaderRow = (props: HeaderRowProps) => {
             aria-label={e2eSelectorsTable.header}
             role="row"
           >
-            {headerGroup.headers.map((column: Column, index: number) => {
-              if (columnHeaders && columnHeaders.has(index)) {
-                return renderHeaderCell(column, tableStyles, showTypeIcons, columnHeaders.get(index));
-              }
-              return renderHeaderCell(column, tableStyles, showTypeIcons);
-            })}
+            {headerGroup.headers.map((column: Column, index: number) => (
+              renderHeaderCell(column, tableStyles, showTypeIcons, columnHeaders.get(index));
+            ))}
           </div>
         );
       })}

--- a/packages/grafana-ui/src/components/Table/Table.test.tsx
+++ b/packages/grafana-ui/src/components/Table/Table.test.tsx
@@ -673,4 +673,22 @@ describe('Table', () => {
       expect(selected).toBeVisible();
     });
   });
+
+  describe('when mounted with custom header icons', () => {
+    it('the custom icons should be rendered in the right field', async () => {
+      const headerIconMap = new Map();
+      headerIconMap.set(2, <span role={'menuitem'}>Icon!</span>);
+      getTestContext({
+        columnHeaders: headerIconMap,
+      });
+      expect(getTable()).toBeInTheDocument();
+
+      const rows = within(getTable()).getAllByRole('row');
+      expect(rows).toHaveLength(5);
+
+      let selected = within(within(getTable()).getAllByRole('columnheader')[2]).getByRole('menuitem');
+      expect(selected).toBeVisible();
+      expect(within(selected).getByText('Icon!')).toBeInTheDocument();
+    });
+  });
 });

--- a/packages/grafana-ui/src/components/Table/Table.tsx
+++ b/packages/grafana-ui/src/components/Table/Table.tsx
@@ -49,6 +49,7 @@ export const Table = memo((props: Props) => {
     timeRange,
     enableSharedCrosshair = false,
     initialRowIndex = undefined,
+    columnHeaders = new Map(),
   } = props;
 
   const listRef = useRef<VariableSizeList>(null);
@@ -296,7 +297,12 @@ export const Table = memo((props: Props) => {
       <CustomScrollbar hideVerticalTrack={true}>
         <div className={tableStyles.tableContentWrapper(totalColumnsWidth)}>
           {!noHeader && (
-            <HeaderRow headerGroups={headerGroups} showTypeIcons={showTypeIcons} tableStyles={tableStyles} />
+            <HeaderRow
+              headerGroups={headerGroups}
+              showTypeIcons={showTypeIcons}
+              tableStyles={tableStyles}
+              columnHeaders={columnHeaders}
+            />
           )}
           {itemCount > 0 ? (
             <div data-testid={selectors.components.Panels.Visualization.Table.body} ref={variableSizeListScrollbarRef}>

--- a/packages/grafana-ui/src/components/Table/types.ts
+++ b/packages/grafana-ui/src/components/Table/types.ts
@@ -99,6 +99,8 @@ export interface Props {
   enableSharedCrosshair?: boolean;
   // The index of the field value that the table will initialize scrolled to
   initialRowIndex?: number;
+  // Map of react elements to render within column headers, index is field id
+  columnHeaders: Map<number, React.ReactElement>;
 }
 
 /**

--- a/packages/grafana-ui/src/components/Table/types.ts
+++ b/packages/grafana-ui/src/components/Table/types.ts
@@ -100,7 +100,7 @@ export interface Props {
   // The index of the field value that the table will initialize scrolled to
   initialRowIndex?: number;
   // Map of react elements to render within column headers, index is field id
-  columnHeaders: Map<number, React.ReactElement>;
+  columnHeaders?: Map<number, React.ReactElement>;
 }
 
 /**

--- a/public/app/features/explore/Logs/LogsTable.tsx
+++ b/public/app/features/explore/Logs/LogsTable.tsx
@@ -18,7 +18,7 @@ import {
   ValueLinkConfig,
 } from '@grafana/data';
 import { config } from '@grafana/runtime';
-import { AdHocFilterItem, Icon, Table } from '@grafana/ui';
+import { AdHocFilterItem, Table } from '@grafana/ui';
 import { FILTER_FOR_OPERATOR, FILTER_OUT_OPERATOR } from '@grafana/ui/src/components/Table/types';
 import { LogsFrame } from 'app/features/logs/logsFrame';
 
@@ -167,12 +167,8 @@ export function LogsTable(props: Props) {
     }
   };
 
-  const map = new Map();
-  map.set(0, <Icon name={'ellipsis-v'} />);
-
   return (
     <Table
-      columnHeaders={map}
       data={tableFrame}
       width={width}
       onCellFilterAdded={props.onClickFilterLabel && props.onClickFilterOutLabel ? onCellFilterAdded : undefined}

--- a/public/app/features/explore/Logs/LogsTable.tsx
+++ b/public/app/features/explore/Logs/LogsTable.tsx
@@ -18,7 +18,7 @@ import {
   ValueLinkConfig,
 } from '@grafana/data';
 import { config } from '@grafana/runtime';
-import { AdHocFilterItem, Table } from '@grafana/ui';
+import { AdHocFilterItem, Icon, Table } from '@grafana/ui';
 import { FILTER_FOR_OPERATOR, FILTER_OUT_OPERATOR } from '@grafana/ui/src/components/Table/types';
 import { LogsFrame } from 'app/features/logs/logsFrame';
 
@@ -167,8 +167,12 @@ export function LogsTable(props: Props) {
     }
   };
 
+  const map = new Map();
+  map.set(0, <Icon name={'ellipsis-v'} />);
+
   return (
     <Table
+      columnHeaders={map}
       data={tableFrame}
       width={width}
       onCellFilterAdded={props.onClickFilterLabel && props.onClickFilterOutLabel ? onCellFilterAdded : undefined}


### PR DESCRIPTION
**What is this feature?**
Specific usages of the table might have additional functionality that need to be exposed to end users. This PR provides the ability for developers to pass in a map of react elements that will (hopefully) facilitate more ways for users to visualize and interact with their data!

**Why do we need this feature?**
So we can add interactive menus for logs and other table implementations. 

**Who is this feature for?**
Developers building interactive UIs with table.


**Special notes for your reviewer:**
Example usage:
```
  const map = new Map();
  map.set(0, <Icon name={'ellipsis-v'} />)

  return (
    <Table
      columnHeaders={map}
      data={tableFrame}
     // {...tableProps}
    />
  );
```
Which will set the icon relatively positioned after any other table header icons.
<img width="213" alt="image" src="https://github.com/grafana/grafana/assets/109082771/94c063d2-0fe2-4b38-853f-3ee4269108ba">

However if you want to absolutely position within the cell, that's ok too, as long as you leave some space for the resize-handlers (if active).
<img width="1047" alt="image" src="https://github.com/grafana/grafana/assets/109082771/ab36afd6-8000-493b-b6cf-ad07c65c1fa7">

Although the absolute positioned solution might want additional right padding on the table cell to keep content from overlapping with menu, but that can be addressed in a later PR (maybe we want to right-align icons instead of absolutely positioning things, etc)

Opening this PR to start the conversation, I'm not wed to any particular implementation and would love to hear any other ideas!

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
