### PR TITLE
MigrateToCloud: Add API interface for frontend

### DIFF
--- a/public/app/core/reducers/root.ts
+++ b/public/app/core/reducers/root.ts
@@ -2,6 +2,7 @@ import { ReducersMapObject } from '@reduxjs/toolkit';
 import { AnyAction, combineReducers } from 'redux';
 
 import sharedReducers from 'app/core/reducers';
+import { migrateToCloudAPI } from 'app/features/admin/migrate-to-cloud/api';
 import ldapReducers from 'app/features/admin/state/reducers';
 import alertingReducers from 'app/features/alerting/state/reducers';
 import apiKeysReducers from 'app/features/api-keys/state/reducers';
@@ -55,6 +56,7 @@ const rootReducers = {
   [alertingApi.reducerPath]: alertingApi.reducer,
   [publicDashboardApi.reducerPath]: publicDashboardApi.reducer,
   [browseDashboardsAPI.reducerPath]: browseDashboardsAPI.reducer,
+  [migrateToCloudAPI.reducerPath]: migrateToCloudAPI.reducer,
 };
 
 const addedReducers = {};

--- a/public/app/features/admin/migrate-to-cloud/MigrateToCloud.tsx
+++ b/public/app/features/admin/migrate-to-cloud/MigrateToCloud.tsx
@@ -1,7 +1,19 @@
 import React from 'react';
 
+import { Stack, Text } from '@grafana/ui';
 import { Page } from 'app/core/components/Page/Page';
 
+import { useGetStatusQuery } from './api';
+
 export default function MigrateToCloud() {
-  return <Page navId="migrate-to-cloud">TODO</Page>;
+  const { data } = useGetStatusQuery();
+
+  return (
+    <Page navId="migrate-to-cloud">
+      <Stack>
+        <Text>TODO</Text>
+        <pre>{JSON.stringify(data)}</pre>
+      </Stack>
+    </Page>
+  );
 }

--- a/public/app/features/admin/migrate-to-cloud/api.ts
+++ b/public/app/features/admin/migrate-to-cloud/api.ts
@@ -1,0 +1,45 @@
+import { BaseQueryFn, createApi } from '@reduxjs/toolkit/query/react';
+import { lastValueFrom } from 'rxjs';
+
+import { BackendSrvRequest, getBackendSrv } from '@grafana/runtime';
+
+interface RequestOptions extends BackendSrvRequest {
+  manageError?: (err: unknown) => { error: unknown };
+  showErrorAlert?: boolean;
+}
+
+function createBackendSrvBaseQuery({ baseURL }: { baseURL: string }): BaseQueryFn<RequestOptions> {
+  async function backendSrvBaseQuery(requestOptions: RequestOptions) {
+    try {
+      const { data: responseData, ...meta } = await lastValueFrom(
+        getBackendSrv().fetch({
+          ...requestOptions,
+          url: baseURL + requestOptions.url,
+          showErrorAlert: requestOptions.showErrorAlert,
+        })
+      );
+      return { data: responseData, meta };
+    } catch (error) {
+      return requestOptions.manageError ? requestOptions.manageError(error) : { error };
+    }
+  }
+
+  return backendSrvBaseQuery;
+}
+
+interface MigrateToCloudStatusDTO {
+  enabled: boolean;
+}
+
+export const migrateToCloudAPI = createApi({
+  reducerPath: 'migrateToCloudAPI',
+  baseQuery: createBackendSrvBaseQuery({ baseURL: '/api' }),
+  endpoints: (builder) => ({
+    // TODO :)
+    getStatus: builder.query<MigrateToCloudStatusDTO, void>({
+      queryFn: () => ({ data: { enabled: false } }),
+    }),
+  }),
+});
+
+export const { useGetStatusQuery } = migrateToCloudAPI;

--- a/public/app/features/admin/migrate-to-cloud/fixtures/mswAPI.ts
+++ b/public/app/features/admin/migrate-to-cloud/fixtures/mswAPI.ts
@@ -1,0 +1,15 @@
+import { HttpResponse, http } from 'msw';
+import { SetupServer, setupServer } from 'msw/node';
+
+export function registerAPIHandlers(): SetupServer {
+  const server = setupServer(
+    // TODO
+    http.get('/api/cloudmigration/status', () => {
+      return HttpResponse.json({
+        enabled: false,
+      });
+    })
+  );
+
+  return server;
+}


### PR DESCRIPTION
Sets up API layer for the Cloud Migration UI:

 - creates RTK Query slice, with a dummy API using queryFn
 - creates MSW mock API for unit tests
 - sets up a unit test to validate the above works :)

Part of #82361