### PR TITLE
Password Policy: Update frontend facing messages

### DIFF
--- a/pkg/services/user/password.go
+++ b/pkg/services/user/password.go
@@ -8,8 +8,8 @@ import (
 )
 
 var (
-	ErrPasswordTooShort       = errutil.BadRequest("password.password-policy-too-short", errutil.WithPublicMessage("New password is too short")).Errorf("new password is too short")
-	ErrPasswordPolicyInfringe = errutil.BadRequest("password.password-policy-infringe", errutil.WithPublicMessage("New password doesn't comply with the password policy")).Errorf("new password doesn't comply with the password policy")
+	ErrPasswordTooShort       = errutil.BadRequest("password.password-policy-too-short", errutil.WithPublicMessage("New password is too short"))
+	ErrPasswordPolicyInfringe = errutil.BadRequest("password.password-policy-infringe", errutil.WithPublicMessage("New password doesn't comply with the password policy"))
 	MinPasswordLength         = 12
 )
 
@@ -33,12 +33,12 @@ func (p Password) Validate(config *setting.Cfg) error {
 func ValidatePassword(newPassword string, config *setting.Cfg) error {
 	if !config.BasicAuthStrongPasswordPolicy {
 		if len(newPassword) <= 4 {
-			return ErrPasswordTooShort
+			return ErrPasswordTooShort.Errorf("new password is too short")
 		}
 		return nil
 	}
 	if len(newPassword) < MinPasswordLength {
-		return ErrPasswordPolicyInfringe
+		return ErrPasswordPolicyInfringe.Errorf("new password is too short for the strong password policy")
 	}
 
 	hasUpperCase := false
@@ -67,5 +67,5 @@ func ValidatePassword(newPassword string, config *setting.Cfg) error {
 			return nil
 		}
 	}
-	return ErrPasswordPolicyInfringe
+	return ErrPasswordPolicyInfringe.Errorf("new password doesn't comply with the password policy")
 }

--- a/pkg/services/user/password.go
+++ b/pkg/services/user/password.go
@@ -8,8 +8,8 @@ import (
 )
 
 var (
-	ErrPasswordTooShort       = errutil.NewBase(errutil.StatusBadRequest, "password-policy-too-short", errutil.WithPublicMessage("New password is too short"))
-	ErrPasswordPolicyInfringe = errutil.NewBase(errutil.StatusBadRequest, "password-policy-infringe", errutil.WithPublicMessage("New password doesn't comply with the password policy"))
+	ErrPasswordTooShort       = errutil.BadRequest("password.password-policy-too-short", errutil.WithPublicMessage("New password is too short")).Errorf("new password is too short")
+	ErrPasswordPolicyInfringe = errutil.BadRequest("password.password-policy-infringe", errutil.WithPublicMessage("New password doesn't comply with the password policy")).Errorf("new password doesn't comply with the password policy")
 	MinPasswordLength         = 12
 )
 
@@ -38,7 +38,7 @@ func ValidatePassword(newPassword string, config *setting.Cfg) error {
 		return nil
 	}
 	if len(newPassword) < MinPasswordLength {
-		return ErrPasswordTooShort
+		return ErrPasswordPolicyInfringe
 	}
 
 	hasUpperCase := false

--- a/pkg/services/user/password_test.go
+++ b/pkg/services/user/password_test.go
@@ -21,7 +21,7 @@ func TestPasswowrdService_ValidatePasswordHardcodePolicy(t *testing.T) {
 		{
 			name:                        "should return error when the password has less than 4 characters and strong password policy is disabled",
 			passwordTest:                NUMBER,
-			expectedError:               ErrPasswordTooShort,
+			expectedError:               ErrPasswordTooShort.Errorf("new password is too short"),
 			strongPasswordPolicyEnabled: false,
 		},
 		{name: "should not return error when the password has 4 characters and strong password policy is disabled",
@@ -32,31 +32,31 @@ func TestPasswowrdService_ValidatePasswordHardcodePolicy(t *testing.T) {
 		{
 			name:                        "should return error when the password has less than 12 characters and strong password policy is enabled",
 			passwordTest:                NUMBER,
-			expectedError:               ErrPasswordPolicyInfringe,
+			expectedError:               ErrPasswordPolicyInfringe.Errorf("new password is too short for the strong password policy"),
 			strongPasswordPolicyEnabled: true,
 		},
 		{
 			name:                        "should return error when the password is missing an uppercase character and strong password policy is enabled",
 			passwordTest:                LOWERCASE + NUMBER + SYMBOLS,
-			expectedError:               ErrPasswordPolicyInfringe,
+			expectedError:               ErrPasswordPolicyInfringe.Errorf("new password doesn't comply with the password policy"),
 			strongPasswordPolicyEnabled: true,
 		},
 		{
 			name:                        "should return error when the password is missing a lowercase character and strong password policy is enabled",
 			passwordTest:                UPPERCASE + NUMBER + SYMBOLS,
-			expectedError:               ErrPasswordPolicyInfringe,
+			expectedError:               ErrPasswordPolicyInfringe.Errorf("new password doesn't comply with the password policy"),
 			strongPasswordPolicyEnabled: true,
 		},
 		{
 			name:                        "should return error when the password is missing a number character and strong password policy is enabled",
 			passwordTest:                LOWERCASE + UPPERCASE + SYMBOLS,
-			expectedError:               ErrPasswordPolicyInfringe,
+			expectedError:               ErrPasswordPolicyInfringe.Errorf("new password doesn't comply with the password policy"),
 			strongPasswordPolicyEnabled: true,
 		},
 		{
 			name:                        "should return error when the password is missing a symbol characters and strong password policy is enabled",
 			passwordTest:                LOWERCASE + UPPERCASE + NUMBER,
-			expectedError:               ErrPasswordPolicyInfringe,
+			expectedError:               ErrPasswordPolicyInfringe.Errorf("new password doesn't comply with the password policy"),
 			strongPasswordPolicyEnabled: true,
 		},
 		{

--- a/pkg/services/user/password_test.go
+++ b/pkg/services/user/password_test.go
@@ -32,7 +32,7 @@ func TestPasswowrdService_ValidatePasswordHardcodePolicy(t *testing.T) {
 		{
 			name:                        "should return error when the password has less than 12 characters and strong password policy is enabled",
 			passwordTest:                NUMBER,
-			expectedError:               ErrPasswordTooShort,
+			expectedError:               ErrPasswordPolicyInfringe,
 			strongPasswordPolicyEnabled: true,
 		},
 		{


### PR DESCRIPTION
**What is this feature?**

Updates the frontend facing messages.

**Why do we need this feature?**

Updating the message gives a clearer description of what's going on, rather than a generic `Internal server error`

![image](https://github.com/grafana/grafana/assets/2051016/c99361f8-422e-4b40-8869-7de1f7bef636)


**Who is this feature for?**

[Add information on what kind of user the feature is for.]

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #https://github.com/grafana/identity-access-team/issues/574

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
