### PR TITLE
Annotation query: Render query result in alert box

### DIFF
--- a/.betterer.results
+++ b/.betterer.results
@@ -2391,9 +2391,6 @@ exports[`better eslint`] = {
       [0, 0, 0, "Do not use any type assertions.", "2"],
       [0, 0, 0, "Do not use any type assertions.", "3"]
     ],
-    "public/app/features/annotations/components/StandardAnnotationQueryEditor.tsx:5381": [
-      [0, 0, 0, "Styles should be written using objects.", "0"]
-    ],
     "public/app/features/annotations/events_processing.ts:5381": [
       [0, 0, 0, "Unexpected any. Specify a different type.", "0"]
     ],

--- a/e2e/plugin-e2e/plugin-e2e-api-tests/as-admin-user/annotationEditPage.spec.ts
+++ b/e2e/plugin-e2e/plugin-e2e-api-tests/as-admin-user/annotationEditPage.spec.ts
@@ -1,5 +1,5 @@
-import { selectors } from '@grafana/e2e-selectors';
 import { expect, test } from '@grafana/plugin-e2e';
+import { AlertVariant } from '@grafana/ui';
 
 import {
   successfulAnnotationQueryWithData,
@@ -12,19 +12,33 @@ interface Scenario {
   name: string;
   mock: object;
   text: string;
+  severity: AlertVariant;
   status: number;
 }
 
 const scenarios: Scenario[] = [
-  { name: 'error', mock: failedAnnotationQuery, text: 'Google API Error 400', status: 400 },
+  { name: 'error', severity: 'error', mock: failedAnnotationQuery, text: 'Google API Error 400', status: 400 },
   {
     name: 'multiple errors',
+    severity: 'error',
     mock: failedAnnotationQueryWithMultipleErrors,
     text: 'Google API Error 400Google API Error 401',
     status: 400,
   },
-  { name: 'data', mock: successfulAnnotationQueryWithData, text: '2 events (from 2 fields)', status: 200 },
-  { name: 'empty result', mock: successfulAnnotationQueryWithoutData, text: 'No events found', status: 200 },
+  {
+    name: 'data',
+    severity: 'success',
+    mock: successfulAnnotationQueryWithData,
+    text: '2 events (from 2 fields)',
+    status: 200,
+  },
+  {
+    name: 'empty result',
+    severity: 'warning',
+    mock: successfulAnnotationQueryWithoutData,
+    text: 'No events found',
+    status: 200,
+  },
 ];
 
 for (const scenario of scenarios) {
@@ -34,7 +48,6 @@ for (const scenario of scenarios) {
     await page.getByLabel('Scenario').last().fill('CSV Content');
     await page.keyboard.press('Tab');
     await annotationEditPage.runQuery();
-    const resultContainerSelector = selectors.components.Annotations.editor.resultContainer;
-    await expect(annotationEditPage.getByTestIdOrAriaLabel(resultContainerSelector)).toContainText(scenario.text);
+    await expect(annotationEditPage).toHaveAlert(scenario.severity, { hasText: scenario.text });
   });
 }

--- a/e2e/plugin-e2e/plugin-e2e-api-tests/as-admin-user/annotationEditPage.spec.ts
+++ b/e2e/plugin-e2e/plugin-e2e-api-tests/as-admin-user/annotationEditPage.spec.ts
@@ -1,15 +1,40 @@
+import { selectors } from '@grafana/e2e-selectors';
 import { expect, test } from '@grafana/plugin-e2e';
 
-import { formatExpectError } from '../errors';
-import { successfulAnnotationQuery } from '../mocks/queries';
+import {
+  successfulAnnotationQueryWithData,
+  failedAnnotationQueryWithMultipleErrors,
+  successfulAnnotationQueryWithoutData,
+  failedAnnotationQuery,
+} from '../mocks/queries';
 
-test('annotation query data with mocked response', async ({ annotationEditPage, page }) => {
-  annotationEditPage.mockQueryDataResponse(successfulAnnotationQuery);
-  await annotationEditPage.datasource.set('gdev-testdata');
-  await page.getByLabel('Scenario').last().fill('CSV Content');
-  await page.keyboard.press('Tab');
-  await expect(
-    annotationEditPage.runQuery(),
-    formatExpectError('Expected annotation query to execute successfully')
-  ).toBeOK();
-});
+interface Scenario {
+  name: string;
+  mock: object;
+  text: string;
+  status: number;
+}
+
+const scenarios: Scenario[] = [
+  { name: 'error', mock: failedAnnotationQuery, text: 'Google API Error 400', status: 400 },
+  {
+    name: 'multiple errors',
+    mock: failedAnnotationQueryWithMultipleErrors,
+    text: 'Google API Error 400Google API Error 401',
+    status: 400,
+  },
+  { name: 'data', mock: successfulAnnotationQueryWithData, text: '2 events (from 2 fields)', status: 200 },
+  { name: 'empty result', mock: successfulAnnotationQueryWithoutData, text: 'No events found', status: 200 },
+];
+
+for (const scenario of scenarios) {
+  test(`annotation query data with ${scenario.name}`, async ({ annotationEditPage, page }) => {
+    annotationEditPage.mockQueryDataResponse(scenario.mock, scenario.status);
+    const resultContainerSelector = selectors.components.Annotations.editor.resultContainer;
+    await annotationEditPage.datasource.set('gdev-testdata');
+    await page.getByLabel('Scenario').last().fill('CSV Content');
+    await page.keyboard.press('Tab');
+    await annotationEditPage.runQuery();
+    await expect(annotationEditPage.getByTestIdOrAriaLabel(resultContainerSelector)).toContainText(scenario.text);
+  });
+}

--- a/e2e/plugin-e2e/plugin-e2e-api-tests/as-admin-user/annotationEditPage.spec.ts
+++ b/e2e/plugin-e2e/plugin-e2e-api-tests/as-admin-user/annotationEditPage.spec.ts
@@ -30,11 +30,11 @@ const scenarios: Scenario[] = [
 for (const scenario of scenarios) {
   test(`annotation query data with ${scenario.name}`, async ({ annotationEditPage, page }) => {
     annotationEditPage.mockQueryDataResponse(scenario.mock, scenario.status);
-    const resultContainerSelector = selectors.components.Annotations.editor.resultContainer;
     await annotationEditPage.datasource.set('gdev-testdata');
     await page.getByLabel('Scenario').last().fill('CSV Content');
     await page.keyboard.press('Tab');
     await annotationEditPage.runQuery();
+    const resultContainerSelector = selectors.components.Annotations.editor.resultContainer;
     await expect(annotationEditPage.getByTestIdOrAriaLabel(resultContainerSelector)).toContainText(scenario.text);
   });
 }

--- a/e2e/plugin-e2e/plugin-e2e-api-tests/mocks/queries.ts
+++ b/e2e/plugin-e2e/plugin-e2e-api-tests/mocks/queries.ts
@@ -37,7 +37,32 @@ export const successfulDataQuery = {
   },
 };
 
-export const successfulAnnotationQuery = {
+export const failedAnnotationQuery: object = {
+  results: {
+    Anno: {
+      error: 'Google API Error 400',
+      errorSource: '',
+      status: 500,
+    },
+  },
+};
+
+export const failedAnnotationQueryWithMultipleErrors: object = {
+  results: {
+    Anno1: {
+      error: 'Google API Error 400',
+      errorSource: '',
+      status: 400,
+    },
+    Anno2: {
+      error: 'Google API Error 401',
+      errorSource: '',
+      status: 401,
+    },
+  },
+};
+
+export const successfulAnnotationQueryWithData: object = {
   results: {
     Anno: {
       status: 200,
@@ -69,6 +94,42 @@ export const successfulAnnotationQuery = {
               [1702973084093, 1702973084099],
               ['val1', 'val2'],
             ],
+          },
+        },
+      ],
+    },
+  },
+};
+
+export const successfulAnnotationQueryWithoutData: object = {
+  results: {
+    Anno: {
+      status: 200,
+      frames: [
+        {
+          schema: {
+            refId: 'Anno',
+            fields: [
+              {
+                name: 'time',
+                type: 'time',
+                typeInfo: {
+                  frame: 'time.Time',
+                  nullable: true,
+                },
+              },
+              {
+                name: 'col2',
+                type: 'string',
+                typeInfo: {
+                  frame: 'string',
+                  nullable: true,
+                },
+              },
+            ],
+          },
+          data: {
+            values: [],
           },
         },
       ],

--- a/packages/grafana-e2e-selectors/src/selectors/components.ts
+++ b/packages/grafana-e2e-selectors/src/selectors/components.ts
@@ -527,6 +527,10 @@ export const Components = {
   Annotations: {
     annotationsTypeInput: 'annotations-type-input',
     annotationsChoosePanelInput: 'choose-panels-input',
+    editor: {
+      testButton: 'data-testid annotations-test-button',
+      resultContainer: 'data-testid annotations-query-result-container',
+    },
   },
   Tooltip: {
     container: 'data-testid tooltip',

--- a/public/app/features/annotations/components/StandardAnnotationQueryEditor.tsx
+++ b/public/app/features/annotations/components/StandardAnnotationQueryEditor.tsx
@@ -114,7 +114,7 @@ export default class StandardAnnotationQueryEditor extends PureComponent<Props, 
 
   renderStatus() {
     const { response, running } = this.state;
-    let text = '...';
+    let text = '';
     let severity: AlertVariant = 'info';
 
     if (running || response?.panelData?.state === LoadingState.Loading || !response) {
@@ -154,23 +154,13 @@ export default class StandardAnnotationQueryEditor extends PureComponent<Props, 
           )}
         </div>
         <Space v={2} layout="block" />
-        <div
-        // className={cx(css`
-        //   margin: 4px 0px;
-        //   padding: 4px;
-        //   display: flex;
-        //   justify-content: space-between;
-        //   align-items: center;
-        // `)}
+        <Alert
+          data-testid={selectors.components.Annotations.editor.resultContainer}
+          severity={severity}
+          title="Query result"
         >
-          <Alert
-            data-testid={selectors.components.Annotations.editor.resultContainer}
-            severity={severity}
-            title="Query result"
-          >
-            {text}
-          </Alert>
-        </div>
+          {text}
+        </Alert>
       </>
     );
   }

--- a/public/app/features/annotations/components/StandardAnnotationQueryEditor.tsx
+++ b/public/app/features/annotations/components/StandardAnnotationQueryEditor.tsx
@@ -1,4 +1,4 @@
-import React, { PureComponent } from 'react';
+import React, { PureComponent, ReactElement } from 'react';
 import { lastValueFrom } from 'rxjs';
 
 import {
@@ -114,26 +114,36 @@ export default class StandardAnnotationQueryEditor extends PureComponent<Props, 
 
   renderStatus() {
     const { response, running } = this.state;
-    let text = '';
+    let text: ReactElement;
     let severity: AlertVariant = 'info';
 
     if (running || response?.panelData?.state === LoadingState.Loading || !response) {
-      text = 'loading...';
+      text = <p>{'loading...'}</p>;
     } else {
       const { events, panelData } = response;
 
       if (panelData?.errors) {
         severity = 'error';
-        text = panelData.errors?.map((e) => e.message).join('. ') ?? 'There was an error fetching data';
+        text = (
+          <>
+            {panelData.errors.map((e, i) => (
+              <p key={i}>{e.message}</p>
+            ))}
+          </>
+        );
       } else if (panelData?.error) {
         severity = 'error';
-        text = panelData.error.message ?? 'There was an error fetching data';
+        text = <p>{panelData.error.message ?? 'There was an error fetching data'}</p>;
       } else if (!events?.length) {
         severity = 'warning';
-        text = 'No events found';
+        text = <p>No events found</p>;
       } else {
         const frame = panelData?.series?.[0] ?? panelData?.annotations?.[0];
-        text = `${events.length} events (from ${frame?.fields.length} fields)`;
+        text = (
+          <p>
+            `{events.length} events (from {frame?.fields.length} fields)`
+          </p>
+        );
       }
     }
     return (

--- a/public/app/features/annotations/components/StandardAnnotationQueryEditor.tsx
+++ b/public/app/features/annotations/components/StandardAnnotationQueryEditor.tsx
@@ -141,7 +141,7 @@ export default class StandardAnnotationQueryEditor extends PureComponent<Props, 
         const frame = panelData?.series?.[0] ?? panelData?.annotations?.[0];
         text = (
           <p>
-            `{events.length} events (from {frame?.fields.length} fields)`
+            {events.length} events (from {frame?.fields.length} fields)
           </p>
         );
       }

--- a/public/app/features/annotations/components/StandardAnnotationQueryEditor.tsx
+++ b/public/app/features/annotations/components/StandardAnnotationQueryEditor.tsx
@@ -123,7 +123,7 @@ export default class StandardAnnotationQueryEditor extends PureComponent<Props, 
       return 'warning';
     }
 
-    return 'info';
+    return 'success';
   }
 
   renderStatusText(response: AnnotationQueryResponse, running: boolean | undefined): ReactElement {

--- a/public/app/features/annotations/components/StandardAnnotationQueryEditor.tsx
+++ b/public/app/features/annotations/components/StandardAnnotationQueryEditor.tsx
@@ -1,4 +1,3 @@
-import { css, cx } from '@emotion/css';
 import React, { PureComponent } from 'react';
 import { lastValueFrom } from 'rxjs';
 
@@ -11,7 +10,8 @@ import {
   DataSourcePluginContextProvider,
   LoadingState,
 } from '@grafana/data';
-import { Button, Icon, IconName, Spinner } from '@grafana/ui';
+import { selectors } from '@grafana/e2e-selectors';
+import { Alert, AlertVariant, Button, Space, Spinner } from '@grafana/ui';
 import { getDashboardSrv } from 'app/features/dashboard/services/DashboardSrv';
 import { getTimeSrv } from 'app/features/dashboard/services/TimeSrv';
 import { PanelModel } from 'app/features/dashboard/state';
@@ -114,61 +114,64 @@ export default class StandardAnnotationQueryEditor extends PureComponent<Props, 
 
   renderStatus() {
     const { response, running } = this.state;
-    let rowStyle = 'alert-info';
     let text = '...';
-    let icon: IconName | undefined = undefined;
+    let severity: AlertVariant = 'info';
 
     if (running || response?.panelData?.state === LoadingState.Loading || !response) {
       text = 'loading...';
     } else {
       const { events, panelData } = response;
 
-      if (panelData?.error) {
-        rowStyle = 'alert-error';
-        icon = 'exclamation-triangle';
-        text = panelData.error.message ?? 'error';
+      if (panelData?.errors) {
+        severity = 'error';
+        text = panelData.errors?.map((e) => e.message).join('. ') ?? 'There was an error fetching data';
+      } else if (panelData?.error) {
+        severity = 'error';
+        text = panelData.error.message ?? 'There was an error fetching data';
       } else if (!events?.length) {
-        rowStyle = 'alert-warning';
-        icon = 'exclamation-triangle';
+        severity = 'warning';
         text = 'No events found';
       } else {
         const frame = panelData?.series?.[0] ?? panelData?.annotations?.[0];
-
         text = `${events.length} events (from ${frame?.fields.length} fields)`;
       }
     }
     return (
-      <div
-        className={cx(
-          rowStyle,
-          css`
-            margin: 4px 0px;
-            padding: 4px;
-            display: flex;
-            justify-content: space-between;
-            align-items: center;
-          `
-        )}
-      >
-        <div>
-          {icon && (
-            <>
-              <Icon name={icon} />
-              &nbsp;
-            </>
-          )}
-          {text}
-        </div>
+      <>
+        <Space v={2} />
         <div>
           {running ? (
             <Spinner />
           ) : (
-            <Button variant="secondary" size="xs" onClick={this.onRunQuery}>
-              TEST
+            <Button
+              data-testid={selectors.components.Annotations.editor.testButton}
+              variant="secondary"
+              size="xs"
+              onClick={this.onRunQuery}
+            >
+              Test annotation query
             </Button>
           )}
         </div>
-      </div>
+        <Space v={2} layout="block" />
+        <div
+        // className={cx(css`
+        //   margin: 4px 0px;
+        //   padding: 4px;
+        //   display: flex;
+        //   justify-content: space-between;
+        //   align-items: center;
+        // `)}
+        >
+          <Alert
+            data-testid={selectors.components.Annotations.editor.resultContainer}
+            severity={severity}
+            title="Query result"
+          >
+            {text}
+          </Alert>
+        </div>
+      </>
     );
   }
 


### PR DESCRIPTION
**What is this feature?**

I'm trying to add e2e tests to the annotation edit page. As part of that, I need to click the `TEST` button to trigger a new query, and check the status of the executed query. This is tricky though since none of these elements have e2e-selectors. This PR adds proper selectors and also renders the annotation query result in an Alert component rather than displaying an icon next to the result.

The changes certainly doesn't look perfect, and there are a bunch of this that I'd like to improve in this page. But we'll have to save that for another time.  

Before             |  After
:-------------------------:|:-------------------------:
![annotations-before](https://github.com/grafana/grafana/assets/2388950/258b8834-a2d8-4902-a78f-077aa278eb8f) | ![annotations](https://github.com/grafana/grafana/assets/2388950/acad96b9-fb06-455d-81cb-5e2e20b3fe42) 


[Add a brief description of what the feature or update does.]

**Why do we need this feature?**

To be able to provide a good e2e testing experience for the data source plugins that define a custom annotation editor. 

[Add a description of the problem the feature is trying to solve.]

**Who is this feature for?**

Plugin authors

[Add information on what kind of user the feature is for.]

**Which issue(s) does this PR fix?**:

Part of https://github.com/grafana/plugin-tools/issues/724

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Planning to add e2e tests, but need to merge this PR so that I can update the selectors in [grafana/plugin-e2e](https://github.com/grafana/plugin-tools/tree/main/packages/plugin-e2e).


Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
