### PR TITLE
Explore: Translate table title in runtime to get a better test id

### DIFF
--- a/public/app/features/explore/Table/TableContainer.tsx
+++ b/public/app/features/explore/Table/TableContainer.tsx
@@ -7,7 +7,7 @@ import { getTemplateSrv } from '@grafana/runtime';
 import { TimeZone } from '@grafana/schema';
 import { Table, AdHocFilterItem, PanelChrome, withTheme2, Themeable2 } from '@grafana/ui';
 import { config } from 'app/core/config';
-import { t, Trans } from 'app/core/internationalization';
+import { t } from 'app/core/internationalization';
 import {
   hasDeprecatedParentRowIndex,
   migrateFromParentRowIndexToNestedFrames,
@@ -59,11 +59,7 @@ export class TableContainer extends PureComponent<Props> {
       name = data.refId || `${i}`;
     }
 
-    return name ? (
-      <Trans i18nKey="explore.table.title-with-name">Table - {{ name }}</Trans>
-    ) : (
-      t('explore.table.title', 'Table')
-    );
+    return name ? t('explore.table.title-with-name', 'Table - {{name}}', { name }) : t('explore.table.title', 'Table');
   }
 
   render() {

--- a/public/app/features/explore/Table/TableContainer.tsx
+++ b/public/app/features/explore/Table/TableContainer.tsx
@@ -59,10 +59,9 @@ export class TableContainer extends PureComponent<Props> {
       name = data.refId || `${i}`;
     }
 
-    return name ?
-      t('explore.table.title-with-name', 'Table - {{name}}', { name, interpolation: { escapeValue: false } })
-      :
-      t('explore.table.title', 'Table');
+    return name
+      ? t('explore.table.title-with-name', 'Table - {{name}}', { name, interpolation: { escapeValue: false } })
+      : t('explore.table.title', 'Table');
   }
 
   render() {

--- a/public/app/features/explore/Table/TableContainer.tsx
+++ b/public/app/features/explore/Table/TableContainer.tsx
@@ -59,7 +59,10 @@ export class TableContainer extends PureComponent<Props> {
       name = data.refId || `${i}`;
     }
 
-    return name ? t('explore.table.title-with-name', 'Table - {{name}}', { name }) : t('explore.table.title', 'Table');
+    return name ?
+      t('explore.table.title-with-name', 'Table - {{name}}', { name, interpolation: { escapeValue: false } })
+      :
+      t('explore.table.title', 'Table');
   }
 
   render() {


### PR DESCRIPTION
This is to avoid passing a ReactNode to PanelChrome's title as it generates incorrect testId. Please check [this discussion](https://github.com/grafana/grafana/pull/82231#discussion_r1485890969) for more details.

<details>
<summary>raw frames for testing</summary>
```json
[
  {
    "name": "metric{label=\"value\"}<b onmouseover=alert('Wufff!')>click me!</b>",
    "fields": [
      {
        "name": "test",
        "values": [1,2]
      }
    ]
  }
]
```
</details>