### PR TITLE
DataTrails: Remove the adhoc filters label

### DIFF
--- a/public/app/features/trails/DataTrail.tsx
+++ b/public/app/features/trails/DataTrail.tsx
@@ -1,7 +1,7 @@
 import { css } from '@emotion/css';
 import React from 'react';
 
-import { AdHocVariableFilter, GrafanaTheme2 } from '@grafana/data';
+import { AdHocVariableFilter, GrafanaTheme2, VariableHide } from '@grafana/data';
 import { locationService } from '@grafana/runtime';
 import {
   AdHocFiltersVariable,
@@ -211,6 +211,7 @@ function getVariableSet(initialDS?: string, metric?: string, initialFilters?: Ad
       new AdHocFiltersVariable({
         name: VAR_FILTERS,
         datasource: trailDS,
+        hide: VariableHide.hideLabel,
         layout: 'vertical',
         filters: initialFilters ?? [],
         baseFilters: getBaseFiltersForMetric(metric),


### PR DESCRIPTION
Fixes the floating "filters" label (removes it) 

![Screenshot 2024-02-22 at 15 01 21](https://github.com/grafana/grafana/assets/10999/bd889390-8017-49a4-8edb-447f5eb79eb8)
