### PR TITLE
postgres: do not use unexported grafana-core config

### DIFF
--- a/pkg/tsdb/grafana-postgresql-datasource/postgres.go
+++ b/pkg/tsdb/grafana-postgresql-datasource/postgres.go
@@ -28,7 +28,7 @@ func ProvideService(cfg *setting.Cfg) *Service {
 		tlsManager: newTLSManager(logger, cfg.DataPath),
 		logger:     logger,
 	}
-	s.im = datasource.NewInstanceManager(s.newInstanceSettings(cfg))
+	s.im = datasource.NewInstanceManager(s.newInstanceSettings())
 	return s
 }
 
@@ -55,7 +55,7 @@ func (s *Service) QueryData(ctx context.Context, req *backend.QueryDataRequest) 
 	return dsInfo.QueryData(ctx, req)
 }
 
-func newPostgres(ctx context.Context, cfg *setting.Cfg, dsInfo sqleng.DataSourceInfo, cnnstr string, logger log.Logger, settings backend.DataSourceInstanceSettings) (*sql.DB, *sqleng.DataSourceHandler, error) {
+func newPostgres(ctx context.Context, userFacingDefaultError string, rowLimit int64, dsInfo sqleng.DataSourceInfo, cnnstr string, logger log.Logger, settings backend.DataSourceInstanceSettings) (*sql.DB, *sqleng.DataSourceHandler, error) {
 	connector, err := pq.NewConnector(cnnstr)
 	if err != nil {
 		logger.Error("postgres connector creation failed", "error", err)
@@ -82,7 +82,7 @@ func newPostgres(ctx context.Context, cfg *setting.Cfg, dsInfo sqleng.DataSource
 	config := sqleng.DataPluginConfiguration{
 		DSInfo:            dsInfo,
 		MetricColumnTypes: []string{"UNKNOWN", "TEXT", "VARCHAR", "CHAR"},
-		RowLimit:          cfg.DataProxyRowLimit,
+		RowLimit:          rowLimit,
 	}
 
 	queryResultTransformer := postgresQueryResultTransformer{}
@@ -93,7 +93,7 @@ func newPostgres(ctx context.Context, cfg *setting.Cfg, dsInfo sqleng.DataSource
 	db.SetMaxIdleConns(config.DSInfo.JsonData.MaxIdleConns)
 	db.SetConnMaxLifetime(time.Duration(config.DSInfo.JsonData.ConnMaxLifetime) * time.Second)
 
-	handler, err := sqleng.NewQueryDataHandler(cfg.UserFacingDefaultError, db, config, &queryResultTransformer, newPostgresMacroEngine(dsInfo.JsonData.Timescaledb),
+	handler, err := sqleng.NewQueryDataHandler(userFacingDefaultError, db, config, &queryResultTransformer, newPostgresMacroEngine(dsInfo.JsonData.Timescaledb),
 		logger)
 	if err != nil {
 		logger.Error("Failed connecting to Postgres", "err", err)
@@ -104,20 +104,25 @@ func newPostgres(ctx context.Context, cfg *setting.Cfg, dsInfo sqleng.DataSource
 	return db, handler, nil
 }
 
-func (s *Service) newInstanceSettings(cfg *setting.Cfg) datasource.InstanceFactoryFunc {
+func (s *Service) newInstanceSettings() datasource.InstanceFactoryFunc {
 	logger := s.logger
 	return func(ctx context.Context, settings backend.DataSourceInstanceSettings) (instancemgmt.Instance, error) {
-		logger.Debug("Creating Postgres query endpoint")
+		cfg := backend.GrafanaConfigFromContext(ctx)
+		sqlCfg, err := cfg.SQL()
+		if err != nil {
+			return nil, err
+		}
+
 		jsonData := sqleng.JsonData{
-			MaxOpenConns:        cfg.SqlDatasourceMaxOpenConnsDefault,
-			MaxIdleConns:        cfg.SqlDatasourceMaxIdleConnsDefault,
-			ConnMaxLifetime:     cfg.SqlDatasourceMaxConnLifetimeDefault,
+			MaxOpenConns:        sqlCfg.DefaultMaxOpenConns,
+			MaxIdleConns:        sqlCfg.DefaultMaxOpenConns,
+			ConnMaxLifetime:     sqlCfg.DefaultMaxConnLifetimeSeconds,
 			Timescaledb:         false,
 			ConfigurationMethod: "file-path",
 			SecureDSProxy:       false,
 		}
 
-		err := json.Unmarshal(settings.JSONData, &jsonData)
+		err = json.Unmarshal(settings.JSONData, &jsonData)
 		if err != nil {
 			return nil, fmt.Errorf("error reading settings: %w", err)
 		}
@@ -143,7 +148,12 @@ func (s *Service) newInstanceSettings(cfg *setting.Cfg) datasource.InstanceFacto
 			return nil, err
 		}
 
-		_, handler, err := newPostgres(ctx, cfg, dsInfo, cnnstr, logger, settings)
+		userFacingDefaultError, err := cfg.UserFacingDefaultError()
+		if err != nil {
+			return nil, err
+		}
+
+		_, handler, err := newPostgres(ctx, userFacingDefaultError, sqlCfg.RowLimit, dsInfo, cnnstr, logger, settings)
 
 		if err != nil {
 			logger.Error("Failed connecting to Postgres", "err", err)

--- a/pkg/tsdb/grafana-postgresql-datasource/postgres.go
+++ b/pkg/tsdb/grafana-postgresql-datasource/postgres.go
@@ -115,7 +115,7 @@ func (s *Service) newInstanceSettings() datasource.InstanceFactoryFunc {
 
 		jsonData := sqleng.JsonData{
 			MaxOpenConns:        sqlCfg.DefaultMaxOpenConns,
-			MaxIdleConns:        sqlCfg.DefaultMaxOpenConns,
+			MaxIdleConns:        sqlCfg.DefaultMaxIdleConns,
 			ConnMaxLifetime:     sqlCfg.DefaultMaxConnLifetimeSeconds,
 			Timescaledb:         false,
 			ConfigurationMethod: "file-path",

--- a/pkg/tsdb/grafana-postgresql-datasource/postgres_snapshot_test.go
+++ b/pkg/tsdb/grafana-postgresql-datasource/postgres_snapshot_test.go
@@ -16,7 +16,6 @@ import (
 	"github.com/grafana/grafana-plugin-sdk-go/experimental"
 	"github.com/stretchr/testify/require"
 
-	"github.com/grafana/grafana/pkg/setting"
 	"github.com/grafana/grafana/pkg/tsdb/sqleng"
 
 	_ "github.com/lib/pq"
@@ -143,10 +142,6 @@ func TestIntegrationPostgresSnapshots(t *testing.T) {
 				return sql
 			}
 
-			cfg := setting.NewCfg()
-			cfg.DataPath = t.TempDir()
-			cfg.DataProxyRowLimit = 10000
-
 			jsonData := sqleng.JsonData{
 				MaxOpenConns:        0,
 				MaxIdleConns:        2,
@@ -164,7 +159,7 @@ func TestIntegrationPostgresSnapshots(t *testing.T) {
 
 			cnnstr := getCnnStr()
 
-			db, handler, err := newPostgres(context.Background(), cfg, dsInfo, cnnstr, logger, backend.DataSourceInstanceSettings{})
+			db, handler, err := newPostgres(context.Background(), "error", 10000, dsInfo, cnnstr, logger, backend.DataSourceInstanceSettings{})
 
 			t.Cleanup((func() {
 				_, err := db.Exec("DROP TABLE tbl")

--- a/pkg/tsdb/grafana-postgresql-datasource/postgres_test.go
+++ b/pkg/tsdb/grafana-postgresql-datasource/postgres_test.go
@@ -191,10 +191,6 @@ func TestIntegrationPostgres(t *testing.T) {
 		return sql
 	}
 
-	cfg := setting.NewCfg()
-	cfg.DataPath = t.TempDir()
-	cfg.DataProxyRowLimit = 10000
-
 	jsonData := sqleng.JsonData{
 		MaxOpenConns:        0,
 		MaxIdleConns:        2,
@@ -212,7 +208,7 @@ func TestIntegrationPostgres(t *testing.T) {
 
 	cnnstr := postgresTestDBConnString()
 
-	db, exe, err := newPostgres(context.Background(), cfg, dsInfo, cnnstr, logger, backend.DataSourceInstanceSettings{})
+	db, exe, err := newPostgres(context.Background(), "error", 10000, dsInfo, cnnstr, logger, backend.DataSourceInstanceSettings{})
 
 	require.NoError(t, err)
 
@@ -1266,9 +1262,7 @@ func TestIntegrationPostgres(t *testing.T) {
 
 		t.Run("When row limit set to 1", func(t *testing.T) {
 			dsInfo := sqleng.DataSourceInfo{}
-			conf := setting.NewCfg()
-			conf.DataProxyRowLimit = 1
-			_, handler, err := newPostgres(context.Background(), conf, dsInfo, cnnstr, logger, backend.DataSourceInstanceSettings{})
+			_, handler, err := newPostgres(context.Background(), "error", 1, dsInfo, cnnstr, logger, backend.DataSourceInstanceSettings{})
 
 			require.NoError(t, err)
 


### PR DESCRIPTION
(part of https://github.com/grafana/grafana/issues/77722)
as part of decoupling the postgres datasource from core-grafana, we are removing imports that import code from core-grafana.
this PR removes the reading of config-values from core-grafana, and replaces it with reading them from exported functions.
(NOTE: one still remains, `cfg.DataPath`, we will remove that separately)

how to test:
1. 
- modify the following config-option:
```
[log]
user_facing_default_error = "something here"
```
- now run grafana, create a postgres datasource plugin, make sure postgres is not running, and press [save&test]. you should get `something here` as part of the error message

2.
- modify the following config-option:
```
[dataproxy]
row_limit = 13
```
- run a postgres query that should return more than 13 rows. verify that it only returned 13 rows, and an error message

3.
- modify  the following config-option:
```
[sql_datasources]
max_open_conns_default = 3
max_idle_conns_default = 4
max_conn_lifetime_default = 5
```
- unfortunately there is no easy way to verify these in a running grafana instance. best i can recommend is to run grafana in a debugger, set a breakpoint here:  
-https://github.com/grafana/grafana/blob/f6cd1a8e94d6b6ad1dfeed60fdd8e384b4ca399f/pkg/tsdb/grafana-postgresql-datasource/postgres.go#L125, and when the code reaches it, verify that the `jsonData` structure's related fields have the correct values