### PR TITLE
Docker: Add workaround for building on `arm64`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -38,6 +38,9 @@ ARG GO_BUILD_TAGS="oss"
 ARG WIRE_TAGS="oss"
 ARG BINGO="true"
 
+# This is required to allow building on arm64 due to https://github.com/golang/go/issues/22040
+RUN apk add --no-cache binutils-gold
+
 # Install build dependencies
 RUN if grep -i -q alpine /etc/issue; then \
       apk add --no-cache gcc g++ make git; \


### PR DESCRIPTION
Due to a [linker issue](https://github.com/golang/go/issues/22040) on Mac ARM64, the docker build currently fails locally. Adding `binutils-gold` solves this.