### PR TITLE
Alerting: Keep order of time and mute time intervals consistent

### DIFF
--- a/pkg/services/ngalert/api/tooling/definitions/alertmanager.go
+++ b/pkg/services/ngalert/api/tooling/definitions/alertmanager.go
@@ -739,11 +739,11 @@ func (c *GettableApiAlertingConfig) GetReceivers() []*GettableApiReceiver {
 	return c.Receivers
 }
 
-func (c *GettableApiAlertingConfig) GetTimeIntervals() []config.TimeInterval { return c.TimeIntervals }
-
 func (c *GettableApiAlertingConfig) GetMuteTimeIntervals() []config.MuteTimeInterval {
 	return c.MuteTimeIntervals
 }
+
+func (c *GettableApiAlertingConfig) GetTimeIntervals() []config.TimeInterval { return c.TimeIntervals }
 
 func (c *GettableApiAlertingConfig) GetRoute() *Route {
 	return c.Route
@@ -802,11 +802,12 @@ func (c *GettableApiAlertingConfig) validate() error {
 
 // Config is the top-level configuration for Alertmanager's config files.
 type Config struct {
-	Global            *config.GlobalConfig      `yaml:"global,omitempty" json:"global,omitempty"`
-	Route             *Route                    `yaml:"route,omitempty" json:"route,omitempty"`
-	InhibitRules      []config.InhibitRule      `yaml:"inhibit_rules,omitempty" json:"inhibit_rules,omitempty"`
-	TimeIntervals     []config.TimeInterval     `yaml:"time_intervals,omitempty" json:"time_intervals,omitempty"`
+	Global       *config.GlobalConfig `yaml:"global,omitempty" json:"global,omitempty"`
+	Route        *Route               `yaml:"route,omitempty" json:"route,omitempty"`
+	InhibitRules []config.InhibitRule `yaml:"inhibit_rules,omitempty" json:"inhibit_rules,omitempty"`
+	// MuteTimeIntervals is deprecated and will be removed before Alertmanager 1.0.
 	MuteTimeIntervals []config.MuteTimeInterval `yaml:"mute_time_intervals,omitempty" json:"mute_time_intervals,omitempty"`
+	TimeIntervals     []config.TimeInterval     `yaml:"time_intervals,omitempty" json:"time_intervals,omitempty"`
 	Templates         []string                  `yaml:"templates" json:"templates"`
 }
 
@@ -939,15 +940,6 @@ func (c *Config) UnmarshalJSON(b []byte) error {
 	}
 
 	tiNames := make(map[string]struct{})
-	for _, ti := range c.TimeIntervals {
-		if ti.Name == "" {
-			return fmt.Errorf("missing name in time interval")
-		}
-		if _, ok := tiNames[ti.Name]; ok {
-			return fmt.Errorf("time interval %q is not unique", ti.Name)
-		}
-		tiNames[ti.Name] = struct{}{}
-	}
 	for _, mt := range c.MuteTimeIntervals {
 		if mt.Name == "" {
 			return fmt.Errorf("missing name in mute time interval")
@@ -956,6 +948,15 @@ func (c *Config) UnmarshalJSON(b []byte) error {
 			return fmt.Errorf("mute time interval %q is not unique", mt.Name)
 		}
 		tiNames[mt.Name] = struct{}{}
+	}
+	for _, ti := range c.TimeIntervals {
+		if ti.Name == "" {
+			return fmt.Errorf("missing name in time interval")
+		}
+		if _, ok := tiNames[ti.Name]; ok {
+			return fmt.Errorf("time interval %q is not unique", ti.Name)
+		}
+		tiNames[ti.Name] = struct{}{}
 	}
 	return checkTimeInterval(c.Route, tiNames)
 }
@@ -988,11 +989,11 @@ func (c *PostableApiAlertingConfig) GetReceivers() []*PostableApiReceiver {
 	return c.Receivers
 }
 
-func (c *PostableApiAlertingConfig) GetTimeIntervals() []config.TimeInterval { return c.TimeIntervals }
-
 func (c *PostableApiAlertingConfig) GetMuteTimeIntervals() []config.MuteTimeInterval {
 	return c.MuteTimeIntervals
 }
+
+func (c *PostableApiAlertingConfig) GetTimeIntervals() []config.TimeInterval { return c.TimeIntervals }
 
 func (c *PostableApiAlertingConfig) GetRoute() *Route {
 	return c.Route

--- a/pkg/services/ngalert/api/tooling/definitions/alertmanager_test.go
+++ b/pkg/services/ngalert/api/tooling/definitions/alertmanager_test.go
@@ -688,7 +688,7 @@ func Test_ConfigUnmashaling(t *testing.T) {
 		},
 		{
 			desc: "duplicate time and mute time interval names should error",
-			err:  errors.New("mute time interval \"test1\" is not unique"),
+			err:  errors.New("time interval \"test1\" is not unique"),
 			input: `
 				{
 				  "route": {

--- a/pkg/services/ngalert/api/tooling/definitions/alertmanager_test.go
+++ b/pkg/services/ngalert/api/tooling/definitions/alertmanager_test.go
@@ -485,49 +485,6 @@ func Test_ConfigUnmashaling(t *testing.T) {
 		err         error
 	}{
 		{
-			desc: "missing time interval name should error",
-			err:  errors.New("missing name in time interval"),
-			input: `
-				{
-				  "route": {
-					"receiver": "grafana-default-email"
-				  },
-				  "time_intervals": [
-					{
-					  "name": "",
-					  "time_intervals": [
-						{
-						  "times": [
-							{
-							  "start_time": "00:00",
-							  "end_time": "12:00"
-							}
-						  ]
-						}
-					  ]
-					}
-				  ],
-				  "templates": null,
-				  "receivers": [
-					{
-					  "name": "grafana-default-email",
-					  "grafana_managed_receiver_configs": [
-						{
-						  "uid": "uxwfZvtnz",
-						  "name": "email receiver",
-						  "type": "email",
-						  "disableResolveMessage": false,
-						  "settings": {
-							"addresses": "<example@email.com>"
-						  },
-						  "secureFields": {}
-						}
-					  ]
-					}
-				  ]
-				}
-			`,
-		}, {
 			desc: "missing mute time interval name should error",
 			err:  errors.New("missing name in mute time interval"),
 			input: `
@@ -572,14 +529,58 @@ func Test_ConfigUnmashaling(t *testing.T) {
 			`,
 		},
 		{
-			desc: "duplicate time interval names should error",
-			err:  errors.New("time interval \"test1\" is not unique"),
+			desc: "missing time interval name should error",
+			err:  errors.New("missing name in time interval"),
 			input: `
 				{
 				  "route": {
 					"receiver": "grafana-default-email"
 				  },
 				  "time_intervals": [
+					{
+					  "name": "",
+					  "time_intervals": [
+						{
+						  "times": [
+							{
+							  "start_time": "00:00",
+							  "end_time": "12:00"
+							}
+						  ]
+						}
+					  ]
+					}
+				  ],
+				  "templates": null,
+				  "receivers": [
+					{
+					  "name": "grafana-default-email",
+					  "grafana_managed_receiver_configs": [
+						{
+						  "uid": "uxwfZvtnz",
+						  "name": "email receiver",
+						  "type": "email",
+						  "disableResolveMessage": false,
+						  "settings": {
+							"addresses": "<example@email.com>"
+						  },
+						  "secureFields": {}
+						}
+					  ]
+					}
+				  ]
+				}
+			`,
+		},
+		{
+			desc: "duplicate mute time interval names should error",
+			err:  errors.New("mute time interval \"test1\" is not unique"),
+			input: `
+				{
+				  "route": {
+					"receiver": "grafana-default-email"
+				  },
+				  "mute_time_intervals": [
 					{
 					  "name": "test1",
 					  "time_intervals": [
@@ -629,14 +630,14 @@ func Test_ConfigUnmashaling(t *testing.T) {
 			`,
 		},
 		{
-			desc: "duplicate mute time interval names should error",
-			err:  errors.New("mute time interval \"test1\" is not unique"),
+			desc: "duplicate time interval names should error",
+			err:  errors.New("time interval \"test1\" is not unique"),
 			input: `
 				{
 				  "route": {
 					"receiver": "grafana-default-email"
 				  },
-				  "mute_time_intervals": [
+				  "time_intervals": [
 					{
 					  "name": "test1",
 					  "time_intervals": [

--- a/pkg/services/ngalert/notifier/config.go
+++ b/pkg/services/ngalert/notifier/config.go
@@ -111,12 +111,12 @@ func (a AlertingConfiguration) InhibitRules() []alertingNotify.InhibitRule {
 	return a.alertmanagerConfig.InhibitRules
 }
 
-func (a AlertingConfiguration) TimeIntervals() []alertingNotify.TimeInterval {
-	return a.alertmanagerConfig.TimeIntervals
-}
-
 func (a AlertingConfiguration) MuteTimeIntervals() []alertingNotify.MuteTimeInterval {
 	return a.alertmanagerConfig.MuteTimeIntervals
+}
+
+func (a AlertingConfiguration) TimeIntervals() []alertingNotify.TimeInterval {
+	return a.alertmanagerConfig.TimeIntervals
 }
 
 func (a AlertingConfiguration) Receivers() []*alertingNotify.APIReceiver {

--- a/pkg/services/ngalert/notifier/validation.go
+++ b/pkg/services/ngalert/notifier/validation.go
@@ -27,8 +27,8 @@ type staticValidator struct {
 // apiAlertingConfig contains the methods required to validate NotificationSettings and create autogen routes.
 type apiAlertingConfig[R receiver] interface {
 	GetReceivers() []R
-	GetTimeIntervals() []config.TimeInterval
 	GetMuteTimeIntervals() []config.MuteTimeInterval
+	GetTimeIntervals() []config.TimeInterval
 	GetRoute() *definitions.Route
 }
 
@@ -44,10 +44,10 @@ func NewNotificationSettingsValidator[R receiver](am apiAlertingConfig[R]) Notif
 	}
 
 	availableTimeIntervals := make(map[string]struct{})
-	for _, interval := range am.GetTimeIntervals() {
+	for _, interval := range am.GetMuteTimeIntervals() {
 		availableTimeIntervals[interval.Name] = struct{}{}
 	}
-	for _, interval := range am.GetMuteTimeIntervals() {
+	for _, interval := range am.GetTimeIntervals() {
 		availableTimeIntervals[interval.Name] = struct{}{}
 	}
 

--- a/pkg/tests/api/alerting/api_alertmanager_configuration_test.go
+++ b/pkg/tests/api/alerting/api_alertmanager_configuration_test.go
@@ -194,7 +194,10 @@ func TestIntegrationAlertmanagerConfiguration(t *testing.T) {
 			},
 		},
 	}, {
-		name: "configuration with time intervals",
+		// TODO: Mute time intervals is deprecated in Alertmanager and scheduled to be
+		// removed before version 1.0. Remove this test when support for mute time
+		// intervals is removed.
+		name: "configuration with mute time intervals",
 		cfg: apimodels.PostableUserConfig{
 			AlertmanagerConfig: apimodels.PostableApiAlertingConfig{
 				Config: apimodels.Config{
@@ -204,7 +207,7 @@ func TestIntegrationAlertmanagerConfiguration(t *testing.T) {
 							MuteTimeIntervals: []string{"weekends"},
 						}},
 					},
-					TimeIntervals: []config.TimeInterval{{
+					MuteTimeIntervals: []config.MuteTimeInterval{{
 						Name: "weekends",
 						TimeIntervals: []timeinterval.TimeInterval{{
 							Weekdays: []timeinterval.WeekdayRange{{
@@ -224,10 +227,7 @@ func TestIntegrationAlertmanagerConfiguration(t *testing.T) {
 			},
 		},
 	}, {
-		// TODO: Mute time intervals is deprecated in Alertmanager and scheduled to be
-		// removed before version 1.0. Remove this test when support for mute time
-		// intervals is removed.
-		name: "configuration with mute time intervals",
+		name: "configuration with time intervals",
 		cfg: apimodels.PostableUserConfig{
 			AlertmanagerConfig: apimodels.PostableApiAlertingConfig{
 				Config: apimodels.Config{
@@ -237,7 +237,7 @@ func TestIntegrationAlertmanagerConfiguration(t *testing.T) {
 							MuteTimeIntervals: []string{"weekends"},
 						}},
 					},
-					MuteTimeIntervals: []config.MuteTimeInterval{{
+					TimeIntervals: []config.TimeInterval{{
 						Name: "weekends",
 						TimeIntervals: []timeinterval.TimeInterval{{
 							Weekdays: []timeinterval.WeekdayRange{{


### PR DESCRIPTION
**What is this feature?**

This commit does not change behavior, it just keeps the order of time and mute time intervals consistent with the upstream code, and also adds a deprecation notice.

**Why do we need this feature?**

[Add a description of the problem the feature is trying to solve.]

**Who is this feature for?**

[Add information on what kind of user the feature is for.]

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle.
- [x] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
