### PR TITLE
Docs: fix config file info in upgrade guide

### DIFF
--- a/docs/sources/shared/back-up/back-up-grafana.md
+++ b/docs/sources/shared/back-up/back-up-grafana.md
@@ -18,7 +18,7 @@ Copy Grafana configuration files that you might have modified in your Grafana de
 The Grafana configuration files are located in the following directories:
 
 - Default configuration: `$WORKING_DIR/defaults.ini` (Don't change this file)
-- Custom configuration: `$WORKING_DIR/conf/custom.ini` or `$WORKING_DIR/grafana/grafana.ini`
+- Custom configuration: `$WORKING_DIR/custom.ini`
 
 For more information on where to find configuration files, refer to [Configuration file location](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/setup-grafana/configure-grafana/#configuration-file-location).
 

--- a/docs/sources/shared/back-up/back-up-grafana.md
+++ b/docs/sources/shared/back-up/back-up-grafana.md
@@ -17,7 +17,7 @@ Copy Grafana configuration files that you might have modified in your Grafana de
 
 The Grafana configuration files are located in the following directories:
 
-- Default configuration: `$WORKING_DIR/conf/defaults.ini` (Don't change this file)
+- Default configuration: `$WORKING_DIR/defaults.ini` (Don't change this file)
 - Custom configuration: `$WORKING_DIR/conf/custom.ini` or `$WORKING_DIR/grafana/grafana.ini`
 
 For more information on where to find configuration files, refer to [Configuration file location](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/setup-grafana/configure-grafana/#configuration-file-location).

--- a/docs/sources/shared/back-up/back-up-grafana.md
+++ b/docs/sources/shared/back-up/back-up-grafana.md
@@ -17,7 +17,10 @@ Copy Grafana configuration files that you might have modified in your Grafana de
 
 The Grafana configuration files are located in the following directories:
 
-- Custom configuration: `$WORKING_DIR/conf/custom.ini`
+- Default configuration: `$WORKING_DIR/conf/defaults.ini` (Don't change this file)
+- Custom configuration: `$WORKING_DIR/conf/custom.ini` or `grafana.ini`
+
+For more information on where to find configuration files, refer to [Configuration file location](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/setup-grafana/configure-grafana/#configuration-file-location).
 
 {{% admonition type="note" %}}
 If you installed Grafana using the `deb` or `rpm` packages, then your configuration file is located at

--- a/docs/sources/shared/back-up/back-up-grafana.md
+++ b/docs/sources/shared/back-up/back-up-grafana.md
@@ -17,7 +17,7 @@ Copy Grafana configuration files that you might have modified in your Grafana de
 
 The Grafana configuration files are located in the following directories:
 
-- Default configuration: `$WORKING_DIR/conf/defaults.ini`
+- Default configuration: `$WORKING_DIR/conf/config.ini`
 - Custom configuration: `$WORKING_DIR/conf/custom.ini`
 
 {{% admonition type="note" %}}

--- a/docs/sources/shared/back-up/back-up-grafana.md
+++ b/docs/sources/shared/back-up/back-up-grafana.md
@@ -18,7 +18,7 @@ Copy Grafana configuration files that you might have modified in your Grafana de
 The Grafana configuration files are located in the following directories:
 
 - Default configuration: `$WORKING_DIR/conf/defaults.ini` (Don't change this file)
-- Custom configuration: `$WORKING_DIR/conf/custom.ini` or `grafana.ini`
+- Custom configuration: `$WORKING_DIR/conf/custom.ini` or `$WORKING_DIR/grafana/grafana.ini`
 
 For more information on where to find configuration files, refer to [Configuration file location](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/setup-grafana/configure-grafana/#configuration-file-location).
 

--- a/docs/sources/shared/back-up/back-up-grafana.md
+++ b/docs/sources/shared/back-up/back-up-grafana.md
@@ -17,7 +17,6 @@ Copy Grafana configuration files that you might have modified in your Grafana de
 
 The Grafana configuration files are located in the following directories:
 
-- Default configuration: `$WORKING_DIR/conf/config.ini`
 - Custom configuration: `$WORKING_DIR/conf/custom.ini`
 
 {{% admonition type="note" %}}

--- a/docs/sources/shared/upgrade/upgrade-common-tasks.md
+++ b/docs/sources/shared/upgrade/upgrade-common-tasks.md
@@ -84,7 +84,7 @@ To upgrade Grafana installed using RPM or YUM complete the following steps:
 
 To upgrade Grafana running in a Docker container, complete the following steps:
 
-1. In your current installation of Grafana, save your custom configuration changes to the custom configuration file, `custom.ini` or `grafana.ini`.
+1. Use Grafana [environment variables](https://grafana.com/docs/grafana/latest/setup-grafana/configure-grafana/#override-configuration-with-environment-variables) to save your custom configurations; this is the recommended method. Alternatively, you can copy your configuration files manually by accessing the deployed container. 
 
    This enables you to upgrade Grafana without the risk of losing your configuration changes.
 

--- a/docs/sources/shared/upgrade/upgrade-common-tasks.md
+++ b/docs/sources/shared/upgrade/upgrade-common-tasks.md
@@ -84,7 +84,7 @@ To upgrade Grafana installed using RPM or YUM complete the following steps:
 
 To upgrade Grafana running in a Docker container, complete the following steps:
 
-1. Use Grafana [environment variables](https://grafana.com/docs/grafana/latest/setup-grafana/configure-grafana/#override-configuration-with-environment-variables) to save your custom configurations; this is the recommended method. Alternatively, you can copy your configuration files manually by accessing the deployed container. 
+1. Use Grafana [environment variables](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/setup-grafana/configure-grafana/#override-configuration-with-environment-variables) to save your custom configurations; this is the recommended method. Alternatively, you can copy your configuration files manually by accessing the deployed container. 
 
    This enables you to upgrade Grafana without the risk of losing your configuration changes.
 

--- a/docs/sources/shared/upgrade/upgrade-common-tasks.md
+++ b/docs/sources/shared/upgrade/upgrade-common-tasks.md
@@ -84,7 +84,7 @@ To upgrade Grafana installed using RPM or YUM complete the following steps:
 
 To upgrade Grafana running in a Docker container, complete the following steps:
 
-1. Use Grafana [environment variables](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/setup-grafana/configure-grafana/#override-configuration-with-environment-variables) to save your custom configurations; this is the recommended method. Alternatively, you can copy your configuration files manually by accessing the deployed container. 
+1. Use Grafana [environment variables](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/setup-grafana/configure-grafana/#override-configuration-with-environment-variables) to save your custom configurations; this is the recommended method. Alternatively, you can view your configuration files manually by accessing the deployed container. 
 
    This enables you to upgrade Grafana without the risk of losing your configuration changes.
 

--- a/docs/sources/shared/upgrade/upgrade-common-tasks.md
+++ b/docs/sources/shared/upgrade/upgrade-common-tasks.md
@@ -119,7 +119,7 @@ To upgrade Grafana installed on Windows, complete the following steps:
 
 To upgrade Grafana installed on Mac, complete the following steps:
 
-1. In your current installation of Grafana, save your custom configuration changes to the custom configuration file, `custom.ini` or `grafana.ini`.
+1. In your current installation of Grafana, save your custom configuration changes to the custom configuration file, `custom.ini`.
 
    This enables you to upgrade Grafana without the risk of losing your configuration changes.
 

--- a/docs/sources/shared/upgrade/upgrade-common-tasks.md
+++ b/docs/sources/shared/upgrade/upgrade-common-tasks.md
@@ -84,7 +84,7 @@ To upgrade Grafana installed using RPM or YUM complete the following steps:
 
 To upgrade Grafana running in a Docker container, complete the following steps:
 
-1. Use Grafana [environment variables](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/setup-grafana/configure-grafana/#override-configuration-with-environment-variables) to save your custom configurations; this is the recommended method. Alternatively, you can view your configuration files manually by accessing the deployed container. 
+1. Use Grafana [environment variables](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/setup-grafana/configure-grafana/#override-configuration-with-environment-variables) to save your custom configurations; this is the recommended method. Alternatively, you can view your configuration files manually by accessing the deployed container.
 
    This enables you to upgrade Grafana without the risk of losing your configuration changes.
 

--- a/docs/sources/shared/upgrade/upgrade-common-tasks.md
+++ b/docs/sources/shared/upgrade/upgrade-common-tasks.md
@@ -8,13 +8,13 @@ title: Upgrade guide common tasks
 
 ## Upgrade Grafana
 
-The following sections provide instructions for how to upgrade Grafana based on your installation method.
+The following sections provide instructions for how to upgrade Grafana based on your installation method. For more information on where to find configuration files, refer to [Configuration file location](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/setup-grafana/configure-grafana/#configuration-file-location).
 
 ### Debian
 
 To upgrade Grafana installed from a Debian package (`.deb`), complete the following steps:
 
-1. In your current installation of Grafana, save your custom configuration changes to a file named `<grafana_install_dir>/conf/custom.ini`.
+1. In your current installation of Grafana, save your custom configuration changes to a file named `/etc/grafana/grafana.ini`. This path is specified in the Grafana init.d script using the `--config` file parameter.
 
    This enables you to upgrade Grafana without the risk of losing your configuration changes.
 
@@ -61,7 +61,7 @@ To upgrade Grafana installed from the binary `.tar.gz` package, complete the fol
 
 To upgrade Grafana installed using RPM or YUM complete the following steps:
 
-1. In your current installation of Grafana, save your custom configuration changes to a file named `<grafana_install_dir>/conf/custom.ini`.
+1. In your current installation of Grafana, save your custom configuration changes to a file named `/etc/grafana/grafana.ini`. This path is specified in the Grafana init.d script using the `--config` file parameter.
 
    This enables you to upgrade Grafana without the risk of losing your configuration changes.
 

--- a/docs/sources/shared/upgrade/upgrade-common-tasks.md
+++ b/docs/sources/shared/upgrade/upgrade-common-tasks.md
@@ -14,7 +14,7 @@ The following sections provide instructions for how to upgrade Grafana based on 
 
 To upgrade Grafana installed from a Debian package (`.deb`), complete the following steps:
 
-1. In your current installation of Grafana, save your custom configuration changes to a file named `/etc/grafana/grafana.ini`. This path is specified in the Grafana init.d script using the `--config` file parameter.
+1. In your current installation of Grafana, save your custom configuration changes to a file named `/user/local/etc/grafana/grafana.ini`.
 
    This enables you to upgrade Grafana without the risk of losing your configuration changes.
 
@@ -32,7 +32,7 @@ To upgrade Grafana installed from a Debian package (`.deb`), complete the follow
 
 To upgrade Grafana installed from the Grafana Labs APT repository, complete the following steps:
 
-1. In your current installation of Grafana, save your custom configuration changes to a file named `<grafana_install_dir>/conf/custom.ini`.
+1. In your current installation of Grafana, save your custom configuration changes to a file named `/user/local/etc/grafana/grafana.ini`.
 
    This enables you to upgrade Grafana without the risk of losing your configuration changes.
 
@@ -49,7 +49,7 @@ Grafana automatically updates when you run `apt-get upgrade`.
 
 To upgrade Grafana installed from the binary `.tar.gz` package, complete the following steps:
 
-1. In your current installation of Grafana, save your custom configuration changes to a file named `<grafana_install_dir>/conf/custom.ini`.
+1. In your current installation of Grafana, save your custom configuration changes to the custom configuration file, `custom.ini` or `grafana.ini`.
 
    This enables you to upgrade Grafana without the risk of losing your configuration changes.
 
@@ -61,7 +61,7 @@ To upgrade Grafana installed from the binary `.tar.gz` package, complete the fol
 
 To upgrade Grafana installed using RPM or YUM complete the following steps:
 
-1. In your current installation of Grafana, save your custom configuration changes to a file named `/etc/grafana/grafana.ini`. This path is specified in the Grafana init.d script using the `--config` file parameter.
+1. In your current installation of Grafana, save your custom configuration changes to a file named `/user/local/etc/grafana/grafana.ini`.
 
    This enables you to upgrade Grafana without the risk of losing your configuration changes.
 
@@ -84,7 +84,7 @@ To upgrade Grafana installed using RPM or YUM complete the following steps:
 
 To upgrade Grafana running in a Docker container, complete the following steps:
 
-1. In your current installation of Grafana, save your custom configuration changes to a file named `<grafana_install_dir>/conf/custom.ini`.
+1. In your current installation of Grafana, save your custom configuration changes to the custom configuration file, `custom.ini` or `grafana.ini`.
 
    This enables you to upgrade Grafana without the risk of losing your configuration changes.
 
@@ -105,7 +105,7 @@ To upgrade Grafana running in a Docker container, complete the following steps:
 
 To upgrade Grafana installed on Windows, complete the following steps:
 
-1. In your current installation of Grafana, save your custom configuration changes to a file named `<grafana_install_dir>/conf/custom.ini`.
+1. In your current installation of Grafana, save your custom configuration changes to a file named `/user/local/etc/conf/custom.ini`.
 
    This enables you to upgrade Grafana without the risk of losing your configuration changes.
 
@@ -119,7 +119,7 @@ To upgrade Grafana installed on Windows, complete the following steps:
 
 To upgrade Grafana installed on Mac, complete the following steps:
 
-1. In your current installation of Grafana, save your custom configuration changes to a file named `<grafana_install_dir>/conf/custom.ini`.
+1. In your current installation of Grafana, save your custom configuration changes to a file named `/user/local/etc/conf/custom.ini`.
 
    This enables you to upgrade Grafana without the risk of losing your configuration changes.
 

--- a/docs/sources/shared/upgrade/upgrade-common-tasks.md
+++ b/docs/sources/shared/upgrade/upgrade-common-tasks.md
@@ -14,7 +14,7 @@ The following sections provide instructions for how to upgrade Grafana based on 
 
 To upgrade Grafana installed from a Debian package (`.deb`), complete the following steps:
 
-1. In your current installation of Grafana, save your custom configuration changes to a file named `/user/local/etc/grafana/grafana.ini`.
+1. In your current installation of Grafana, save your custom configuration changes to a file named `<grafana_install_dir>/grafana.ini`.
 
    This enables you to upgrade Grafana without the risk of losing your configuration changes.
 
@@ -32,7 +32,7 @@ To upgrade Grafana installed from a Debian package (`.deb`), complete the follow
 
 To upgrade Grafana installed from the Grafana Labs APT repository, complete the following steps:
 
-1. In your current installation of Grafana, save your custom configuration changes to a file named `/user/local/etc/grafana/grafana.ini`.
+1. In your current installation of Grafana, save your custom configuration changes to a file named `<grafana_install_dir>/grafana.ini`.
 
    This enables you to upgrade Grafana without the risk of losing your configuration changes.
 
@@ -61,7 +61,7 @@ To upgrade Grafana installed from the binary `.tar.gz` package, complete the fol
 
 To upgrade Grafana installed using RPM or YUM complete the following steps:
 
-1. In your current installation of Grafana, save your custom configuration changes to a file named `/user/local/etc/grafana/grafana.ini`.
+1. In your current installation of Grafana, save your custom configuration changes to a file named `<grafana_install_dir>/grafana.ini`.
 
    This enables you to upgrade Grafana without the risk of losing your configuration changes.
 
@@ -105,7 +105,7 @@ To upgrade Grafana running in a Docker container, complete the following steps:
 
 To upgrade Grafana installed on Windows, complete the following steps:
 
-1. In your current installation of Grafana, save your custom configuration changes to a file named `/user/local/etc/conf/custom.ini`.
+1. In your current installation of Grafana, save your custom configuration changes to a file named `<grafana_install_dir>/conf/custom.ini`.
 
    This enables you to upgrade Grafana without the risk of losing your configuration changes.
 
@@ -119,7 +119,7 @@ To upgrade Grafana installed on Windows, complete the following steps:
 
 To upgrade Grafana installed on Mac, complete the following steps:
 
-1. In your current installation of Grafana, save your custom configuration changes to a file named `/user/local/etc/conf/custom.ini`.
+1. In your current installation of Grafana, save your custom configuration changes to the custom configuration file, `custom.ini` or `grafana.ini`.
 
    This enables you to upgrade Grafana without the risk of losing your configuration changes.
 


### PR DESCRIPTION
Fixes the names and locations of config files in upgrade guides