### PR TITLE
datatrails: detect if current trail state is bookmarked

### DIFF
--- a/public/app/features/trails/DataTrail.tsx
+++ b/public/app/features/trails/DataTrail.tsx
@@ -86,6 +86,8 @@ export class DataTrail extends SceneObjectBase<DataTrailState> {
       const newStepWasAppended = newNumberOfSteps > oldNumberOfSteps;
 
       if (newStepWasAppended) {
+        // In order for the `useBookmarkState` to re-evaluate after a new step was made:
+        this.forceRender();
         // Do nothing because the state is already up to date -- it created a new step!
         return;
       }

--- a/public/app/features/trails/MetricScene.tsx
+++ b/public/app/features/trails/MetricScene.tsx
@@ -1,5 +1,5 @@
 import { css } from '@emotion/css';
-import React, { useState } from 'react';
+import React from 'react';
 
 import { DashboardCursorSync, GrafanaTheme2 } from '@grafana/data';
 import {
@@ -26,7 +26,7 @@ import { getAutoQueriesForMetric } from './AutomaticMetricQueries/AutoQueryEngin
 import { AutoVizPanel } from './AutomaticMetricQueries/AutoVizPanel';
 import { AutoQueryDef, AutoQueryInfo } from './AutomaticMetricQueries/types';
 import { ShareTrailButton } from './ShareTrailButton';
-import { getTrailStore } from './TrailStore/TrailStore';
+import { useBookmarkState } from './TrailStore/useBookmarkState';
 import {
   ActionViewDefinition,
   ActionViewType,
@@ -120,10 +120,12 @@ export interface MetricActionBarState extends SceneObjectState {}
 
 export class MetricActionBar extends SceneObjectBase<MetricActionBarState> {
   public onOpenTrail = () => {
+    console.log('ON OPEN TRAIL');
     this.publishEvent(new OpenEmbeddedTrailEvent(), true);
   };
 
   public getLinkToExplore = async () => {
+    console.log('GET LINK TO EXPLORE');
     const metricScene = sceneGraph.getAncestor(this, MetricScene);
     const trail = getTrailFor(this);
     const dsValue = getDataSource(trail);
@@ -151,13 +153,8 @@ export class MetricActionBar extends SceneObjectBase<MetricActionBarState> {
     const metricScene = sceneGraph.getAncestor(model, MetricScene);
     const styles = useStyles2(getStyles);
     const trail = getTrailFor(model);
-    const [isBookmarked, setBookmarked] = useState(false);
+    const [isBookmarked, toggleBookmark] = useBookmarkState(trail);
     const { actionView } = metricScene.useState();
-
-    const onBookmarkTrail = () => {
-      getTrailStore().addBookmark(trail);
-      setBookmarked(!isBookmarked);
-    };
 
     return (
       <Box paddingY={1}>
@@ -180,7 +177,7 @@ export class MetricActionBar extends SceneObjectBase<MetricActionBarState> {
                 )
               }
               tooltip={'Bookmark'}
-              onClick={onBookmarkTrail}
+              onClick={toggleBookmark}
             />
             {trail.state.embedded && (
               <ToolbarButton variant={'canvas'} onClick={model.onOpenTrail}>

--- a/public/app/features/trails/MetricScene.tsx
+++ b/public/app/features/trails/MetricScene.tsx
@@ -120,12 +120,10 @@ export interface MetricActionBarState extends SceneObjectState {}
 
 export class MetricActionBar extends SceneObjectBase<MetricActionBarState> {
   public onOpenTrail = () => {
-    console.log('ON OPEN TRAIL');
     this.publishEvent(new OpenEmbeddedTrailEvent(), true);
   };
 
   public getLinkToExplore = async () => {
-    console.log('GET LINK TO EXPLORE');
     const metricScene = sceneGraph.getAncestor(this, MetricScene);
     const trail = getTrailFor(this);
     const dsValue = getDataSource(trail);

--- a/public/app/features/trails/TrailStore/TrailStore.test.ts
+++ b/public/app/features/trails/TrailStore/TrailStore.test.ts
@@ -167,7 +167,7 @@ describe('TrailStore', () => {
     });
   });
   describe('Initialize store with one bookmark trail', () => {
-    beforeAll(() => {
+    beforeEach(() => {
       localStorage.clear();
       localStorage.setItem(
         BOOKMARKED_TRAILS_KEY,
@@ -223,6 +223,35 @@ describe('TrailStore', () => {
       const trail = store.bookmarks[0].resolve();
       store.setRecentTrail(trail);
       expect(store.recent.length).toBe(1);
+    });
+
+    it('should be able to obtain index of bookmark', () => {
+      const trail = store.bookmarks[0].resolve();
+      const index = store.getBookmarkIndex(trail);
+      expect(index).toBe(0);
+    });
+
+    it('index should be undefined for removed bookmarks', () => {
+      const trail = store.bookmarks[0].resolve();
+      store.removeBookmark(0);
+      const index = store.getBookmarkIndex(trail);
+      expect(index).toBe(undefined);
+    });
+
+    it('index should be undefined for a trail that has changed since it was bookmarked', () => {
+      const trail = store.bookmarks[0].resolve();
+      trail.setState({ metric: 'something_completely_different' });
+      const index = store.getBookmarkIndex(trail);
+      expect(index).toBe(undefined);
+    });
+
+    it('should be able to obtain index of a bookmark for a trail that changed back to bookmarked state', () => {
+      const trail = store.bookmarks[0].resolve();
+      const bookmarkedMetric = trail.state.metric;
+      trail.setState({ metric: 'something_completely_different' });
+      trail.setState({ metric: bookmarkedMetric });
+      const index = store.getBookmarkIndex(trail);
+      expect(index).toBe(0);
     });
 
     it('should remove a bookmark', () => {

--- a/public/app/features/trails/TrailStore/useBookmarkState.ts
+++ b/public/app/features/trails/TrailStore/useBookmarkState.ts
@@ -1,0 +1,39 @@
+import { useState } from 'react';
+
+import { DataTrail } from '../DataTrail';
+
+import { getTrailStore } from './TrailStore';
+
+export function useBookmarkState(trail: DataTrail) {
+  // Note that trail object may stay the same, but the state used by `getBookmarkIndex` result may
+  // differ for each re-render of this hook
+  const getBookmarkIndex = () => getTrailStore().getBookmarkIndex(trail);
+
+  const indexOnRender = getBookmarkIndex();
+
+  const [bookmarkIndex, setBookmarkIndex] = useState(indexOnRender);
+
+  // Check if index changed and force a re-render
+  if (indexOnRender !== bookmarkIndex) {
+    setBookmarkIndex(indexOnRender);
+  }
+
+  const isBookmarked = bookmarkIndex != null;
+
+  const toggleBookmark = () => {
+    if (isBookmarked) {
+      let indexToRemove = getBookmarkIndex();
+      while (indexToRemove != null) {
+        // This loop will remove all indices that have an equivalent bookmark key
+        getTrailStore().removeBookmark(indexToRemove);
+        indexToRemove = getBookmarkIndex();
+      }
+    } else {
+      getTrailStore().addBookmark(trail);
+    }
+    setBookmarkIndex(getBookmarkIndex());
+  };
+
+  const result: [typeof isBookmarked, typeof toggleBookmark] = [isBookmarked, toggleBookmark];
+  return result;
+}


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

We were able to add bookmarks, but not remove them, or determine if the currently selected trail state was bookmarked.

With this PR, now we can.

![image](https://github.com/grafana/grafana/assets/38694490/26cc9437-1f0b-4155-8e1c-97fee34c30fb)

If multiple steps (from any trail) happen to have the same state as a bookmark, the bookmark star toggle will light up when all state-equivalent trails are selected.
When a bookmark is removed using the star toggle, we will ensure that there are no bookmarks with equivalent state (e.g., from old stale data where it was possible to save duplicate states).

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
