### PR TITLE
DataTrails: Sticky controls

### DIFF
--- a/public/app/features/trails/DataTrail.tsx
+++ b/public/app/features/trails/DataTrail.tsx
@@ -233,13 +233,17 @@ function getStyles(theme: GrafanaTheme2) {
       flexGrow: 1,
       display: 'flex',
       flexDirection: 'column',
-      gap: theme.spacing(1),
     }),
     controls: css({
       display: 'flex',
       gap: theme.spacing(1),
+      padding: theme.spacing(1, 0),
       alignItems: 'flex-end',
       flexWrap: 'wrap',
+      position: 'sticky',
+      background: theme.isDark ? theme.colors.background.canvas : theme.colors.background.primary,
+      zIndex: theme.zIndex.activePanel,
+      top: 0,
     }),
   };
 }

--- a/public/app/features/trails/DataTrail.tsx
+++ b/public/app/features/trails/DataTrail.tsx
@@ -242,7 +242,7 @@ function getStyles(theme: GrafanaTheme2) {
       flexWrap: 'wrap',
       position: 'sticky',
       background: theme.isDark ? theme.colors.background.canvas : theme.colors.background.primary,
-      zIndex: theme.zIndex.activePanel,
+      zIndex: theme.zIndex.activePanel + 1,
       top: 0,
     }),
   };


### PR DESCRIPTION
I think this simple take on it works quite well and can be refined later. 

Cool things to consider in the future

* An option to include main graph in sticky bit (but should be an optional option in the options dropdown we removed)
* Possibly an option to disable sticky (not sure we need it)
  


https://github.com/grafana/grafana/assets/10999/a96477eb-3a59-4adc-ab4f-0f3481efafdc

