### PR TITLE
Tempo: Add support for ad-hoc filters

### DIFF
--- a/public/app/plugins/datasource/tempo/datasource.test.ts
+++ b/public/app/plugins/datasource/tempo/datasource.test.ts
@@ -1136,6 +1136,59 @@ describe('label values', () => {
   });
 });
 
+describe('should provide functionality for ad-hoc filters', () => {
+  let datasource: TempoDatasource;
+
+  beforeEach(() => {
+    datasource = createTempoDatasource();
+    jest.spyOn(datasource, 'metadataRequest').mockImplementation(
+      createMetadataRequest({
+        data: {
+          scopes: [{ name: 'span', tags: ['label1', 'label2'] }],
+          tagValues: [
+            {
+              type: 'value1',
+              value: 'value1',
+              label: 'value1',
+            },
+            {
+              type: 'value2',
+              value: 'value2',
+              label: 'value2',
+            },
+          ],
+        },
+      })
+    );
+  });
+
+  it('for getTagKeys', async () => {
+    const response = await datasource.getTagKeys();
+    expect(response).toEqual([{ text: 'span.label1' }, { text: 'span.label2' }]);
+  });
+
+  it('for getTagValues', async () => {
+    const now = dateTime('2021-04-20T15:55:00Z');
+    const options = {
+      key: 'span.label1',
+      filters: [],
+      timeRange: {
+        from: now,
+        to: now,
+        raw: {
+          from: 'now-15m',
+          to: 'now',
+        },
+      },
+    };
+    const response = await datasource.getTagValues(options);
+    expect(response).toEqual([
+      { text: { type: 'value1', value: 'value1', label: 'value1' } },
+      { text: { type: 'value2', value: 'value2', label: 'value2' } },
+    ]);
+  });
+});
+
 const prometheusMock = (): DataSourceApi => {
   return {
     query: jest.fn(() =>

--- a/public/app/plugins/datasource/tempo/datasource.ts
+++ b/public/app/plugins/datasource/tempo/datasource.ts
@@ -17,7 +17,6 @@ import {
   FieldType,
   isValidGoDuration,
   LoadingState,
-  MetricFindValue,
   rangeUtil,
   ScopedVars,
   SelectableValue,
@@ -214,7 +213,7 @@ export class TempoDatasource extends DataSourceWithBackend<TempoQuery, TempoJson
   }
 
   // Allows to retrieve the list of tags for ad-hoc filters
-  async getTagKeys(): Promise<MetricFindValue[]> {
+  async getTagKeys(): Promise<Array<{ text: string }>> {
     await this.languageProvider.fetchTags();
     const tags = this.languageProvider.tagsV2 || [];
     return tags
@@ -226,7 +225,7 @@ export class TempoDatasource extends DataSourceWithBackend<TempoQuery, TempoJson
   }
 
   // Allows to retrieve the list of tag values for ad-hoc filters
-  getTagValues(options: DataSourceGetTagValuesOptions): Promise<MetricFindValue[]> {
+  getTagValues(options: DataSourceGetTagValuesOptions): Promise<Array<{ text: string }>> {
     return this.labelValuesQuery(options.key.replace(/^(resource|span)\./, ''));
   }
 

--- a/public/app/plugins/datasource/tempo/datasource.ts
+++ b/public/app/plugins/datasource/tempo/datasource.ts
@@ -11,11 +11,13 @@ import {
   DataQueryResponse,
   DataQueryResponseData,
   DataSourceApi,
+  DataSourceGetTagValuesOptions,
   DataSourceInstanceSettings,
   dateTime,
   FieldType,
   isValidGoDuration,
   LoadingState,
+  MetricFindValue,
   rangeUtil,
   ScopedVars,
   SelectableValue,
@@ -209,6 +211,23 @@ export class TempoDatasource extends DataSourceWithBackend<TempoQuery, TempoJson
     return options.flatMap((option: SelectableValue<string>) =>
       option.value !== undefined ? [{ text: option.value }] : []
     );
+  }
+
+  // Allows to retrieve the list of tags for ad-hoc filters
+  async getTagKeys(): Promise<MetricFindValue[]> {
+    await this.languageProvider.fetchTags();
+    const tags = this.languageProvider.tagsV2 || [];
+    return tags
+      .map(({ name, tags }) =>
+        tags.filter((tag) => tag !== undefined).map((t) => (name !== 'intrinsic' ? `${name}.${t}` : `${t}`))
+      )
+      .flat()
+      .map((tag) => ({ text: tag }));
+  }
+
+  // Allows to retrieve the list of tag values for ad-hoc filters
+  getTagValues(options: DataSourceGetTagValuesOptions): Promise<MetricFindValue[]> {
+    return this.labelValuesQuery(options.key.replace(/^(resource|span)\./, ''));
   }
 
   init = async () => {


### PR DESCRIPTION
**What is this feature?**

Adds support for ad-hoc filters.

**Why do we need this feature?**

So that we can use ad-hoc filters to retrieve tags and tag values.

**Who is this feature for?**

Tempo users.