### PR TITLE
RBAC: add kind, attribute and identifier to annotation permissions during the migration

### DIFF
--- a/pkg/services/sqlstore/migrations/accesscontrol/dashboard_permissions.go
+++ b/pkg/services/sqlstore/migrations/accesscontrol/dashboard_permissions.go
@@ -730,14 +730,22 @@ func (m *managedDashboardAnnotationActionsMigrator) Exec(sess *xorm.Session, mg 
 
 	for roleId, mappedPermissions := range mapped {
 		for scope, roleActions := range mappedPermissions {
+			// Create a temporary permission to split the scope into kind, attribute and identifier
+			tempPerm := ac.Permission{
+				Scope: scope,
+			}
+			kind, attribute, identifier := tempPerm.SplitScope()
 			if roleActions[dashboards.ActionDashboardsRead] {
 				if !roleActions[ac.ActionAnnotationsRead] {
 					toAdd = append(toAdd, ac.Permission{
-						RoleID:  roleId,
-						Updated: now,
-						Created: now,
-						Scope:   scope,
-						Action:  ac.ActionAnnotationsRead,
+						RoleID:     roleId,
+						Updated:    now,
+						Created:    now,
+						Scope:      scope,
+						Action:     ac.ActionAnnotationsRead,
+						Kind:       kind,
+						Attribute:  attribute,
+						Identifier: identifier,
 					})
 				}
 			}
@@ -745,29 +753,38 @@ func (m *managedDashboardAnnotationActionsMigrator) Exec(sess *xorm.Session, mg 
 			if roleActions[dashboards.ActionDashboardsWrite] {
 				if !roleActions[ac.ActionAnnotationsCreate] {
 					toAdd = append(toAdd, ac.Permission{
-						RoleID:  roleId,
-						Updated: now,
-						Created: now,
-						Scope:   scope,
-						Action:  ac.ActionAnnotationsCreate,
+						RoleID:     roleId,
+						Updated:    now,
+						Created:    now,
+						Scope:      scope,
+						Action:     ac.ActionAnnotationsCreate,
+						Kind:       kind,
+						Attribute:  attribute,
+						Identifier: identifier,
 					})
 				}
 				if !roleActions[ac.ActionAnnotationsDelete] {
 					toAdd = append(toAdd, ac.Permission{
-						RoleID:  roleId,
-						Updated: now,
-						Created: now,
-						Scope:   scope,
-						Action:  ac.ActionAnnotationsDelete,
+						RoleID:     roleId,
+						Updated:    now,
+						Created:    now,
+						Scope:      scope,
+						Action:     ac.ActionAnnotationsDelete,
+						Kind:       kind,
+						Attribute:  attribute,
+						Identifier: identifier,
 					})
 				}
 				if !roleActions[ac.ActionAnnotationsWrite] {
 					toAdd = append(toAdd, ac.Permission{
-						RoleID:  roleId,
-						Updated: now,
-						Created: now,
-						Scope:   scope,
-						Action:  ac.ActionAnnotationsWrite,
+						RoleID:     roleId,
+						Updated:    now,
+						Created:    now,
+						Scope:      scope,
+						Action:     ac.ActionAnnotationsWrite,
+						Kind:       kind,
+						Attribute:  attribute,
+						Identifier: identifier,
 					})
 				}
 			}


### PR DESCRIPTION
**What is this feature?**

When migrating from `annotations:type:dashboard` scope to folder/dashboard based scopes, the split scope elements were not being set. This PR extends the migration to also set kind, attribute and identifier.

**Why do we need this feature?**

We are transitioning from one scope field to split scope fields.

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
