### PR TITLE
CI: Remove arm32 artifacts from check

### DIFF
--- a/pkg/build/packaging/artifacts.go
+++ b/pkg/build/packaging/artifacts.go
@@ -81,32 +81,32 @@ var ArtifactConfigs = []buildArtifact{
 		Arch:       "arm64",
 		urlPostfix: ".linux-arm64.tar.gz",
 	},
-	{
-		Os:         debOS,
-		Arch:       "armv7",
-		urlPostfix: "_armhf.deb",
-	},
-	{
-		Os:             debOS,
-		Arch:           "armv6",
-		packagePostfix: "-rpi",
-		urlPostfix:     "_armhf.deb",
-	},
-	{
-		Os:         rhelOS,
-		Arch:       "armv7",
-		urlPostfix: ".armhfp.rpm",
-	},
-	{
-		Os:         "linux",
-		Arch:       "armv6",
-		urlPostfix: ".linux-armv6.tar.gz",
-	},
-	{
-		Os:         "linux",
-		Arch:       "armv7",
-		urlPostfix: ".linux-armv7.tar.gz",
-	},
+	// {
+	// 	Os:         debOS,
+	// 	Arch:       "armv7",
+	// 	urlPostfix: "_armhf.deb",
+	// },
+	// {
+	// 	Os:             debOS,
+	// 	Arch:           "armv6",
+	// 	packagePostfix: "-rpi",
+	// 	urlPostfix:     "_armhf.deb",
+	// },
+	// {
+	// 	Os:         rhelOS,
+	// 	Arch:       "armv7",
+	// 	urlPostfix: ".armhfp.rpm",
+	// },
+	// {
+	// 	Os:         "linux",
+	// 	Arch:       "armv6",
+	// 	urlPostfix: ".linux-armv6.tar.gz",
+	// },
+	// {
+	// 	Os:         "linux",
+	// 	Arch:       "armv7",
+	// 	urlPostfix: ".linux-armv7.tar.gz",
+	// },
 	{
 		Os:         "darwin",
 		Arch:       "amd64",


### PR DESCRIPTION
In order to prevent the `gcom` publish step from failing, this backports a portion of #77064. The changes here will remove the check for the existence of the `arm32` packages.