### PR TITLE
IP range AC for data sources: compare the base of the URL only

### DIFF
--- a/pkg/services/pluginsintegration/clientmiddleware/grafana_request_id_header_middleware.go
+++ b/pkg/services/pluginsintegration/clientmiddleware/grafana_request_id_header_middleware.go
@@ -6,7 +6,6 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"net/url"
-	"path"
 
 	"github.com/google/uuid"
 
@@ -51,16 +50,15 @@ func (m *HostedGrafanaACHeaderMiddleware) applyGrafanaRequestIDHeader(ctx contex
 
 	// Check if the request is for a datasource that is allowed to have the header
 	dsURL := pCtx.DataSourceInstanceSettings.URL
-	// Only look at the scheme and host, ignore the path
 	dsBaseURL, err := url.Parse(dsURL)
 	if err != nil {
 		m.log.Debug("Failed to parse data source URL", "error", err)
 		return
 	}
-	dsBaseURL.Path = ""
 	foundMatch := false
 	for _, allowedURL := range m.cfg.IPRangeACAllowedURLs {
-		if path.Clean(allowedURL) == path.Clean(dsBaseURL.String()) {
+		// Only look at the scheme and host, ignore the path
+		if allowedURL.Host == dsBaseURL.Host && allowedURL.Scheme == dsBaseURL.Scheme {
 			foundMatch = true
 			break
 		}

--- a/pkg/services/pluginsintegration/clientmiddleware/grafana_request_id_header_middleware.go
+++ b/pkg/services/pluginsintegration/clientmiddleware/grafana_request_id_header_middleware.go
@@ -5,6 +5,7 @@ import (
 	"crypto/hmac"
 	"crypto/sha256"
 	"encoding/hex"
+	"net/url"
 	"path"
 
 	"github.com/google/uuid"
@@ -49,17 +50,23 @@ func (m *HostedGrafanaACHeaderMiddleware) applyGrafanaRequestIDHeader(ctx contex
 	}
 
 	// Check if the request is for a datasource that is allowed to have the header
-	target := pCtx.DataSourceInstanceSettings.URL
-
+	dsURL := pCtx.DataSourceInstanceSettings.URL
+	// Only look at the scheme and host, ignore the path
+	dsBaseURL, err := url.Parse(dsURL)
+	if err != nil {
+		m.log.Debug("Failed to parse data source URL", "error", err)
+		return
+	}
+	dsBaseURL.Path = ""
 	foundMatch := false
 	for _, allowedURL := range m.cfg.IPRangeACAllowedURLs {
-		if path.Clean(allowedURL) == path.Clean(target) {
+		if path.Clean(allowedURL) == path.Clean(dsBaseURL.String()) {
 			foundMatch = true
 			break
 		}
 	}
 	if !foundMatch {
-		m.log.Debug("Data source URL not among the allow-listed URLs", "url", target)
+		m.log.Debug("Data source URL not among the allow-listed URLs", "url", dsBaseURL.String())
 		return
 	}
 

--- a/pkg/services/pluginsintegration/clientmiddleware/grafana_request_id_header_middleware_test.go
+++ b/pkg/services/pluginsintegration/clientmiddleware/grafana_request_id_header_middleware_test.go
@@ -85,9 +85,9 @@ func Test_HostedGrafanaACHeaderMiddleware(t *testing.T) {
 		require.Len(t, cdt.CallResourceReq.Headers[GrafanaSignedRequestID], 0)
 	})
 
-	t.Run("Should set Grafana request ID headers if a sanitized data source URL is in the allow list", func(t *testing.T) {
+	t.Run("Should set Grafana request ID headers if a sanitized base data source URL is in the allow list", func(t *testing.T) {
 		cfg := setting.NewCfg()
-		cfg.IPRangeACAllowedURLs = []string{"https://logs.GRAFANA.net/"}
+		cfg.IPRangeACAllowedURLs = []string{"https://logs.GRAFANA.net/some/path"}
 		cfg.IPRangeACSecretKey = "secret"
 		cdt := clienttest.NewClientDecoratorTest(t, clienttest.WithMiddlewares(NewHostedGrafanaACHeaderMiddleware(cfg)))
 

--- a/pkg/services/pluginsintegration/clientmiddleware/grafana_request_id_header_middleware_test.go
+++ b/pkg/services/pluginsintegration/clientmiddleware/grafana_request_id_header_middleware_test.go
@@ -90,7 +90,7 @@ func Test_HostedGrafanaACHeaderMiddleware(t *testing.T) {
 
 	t.Run("Should set Grafana request ID headers if URL scheme and host match a URL from the allow list", func(t *testing.T) {
 		cfg := setting.NewCfg()
-		allowedURL := &url.URL{Scheme: "https", Host: "logs.GRAFANA.net"}
+		allowedURL := &url.URL{Scheme: "https", Host: "logs.grafana.net"}
 		cfg.IPRangeACAllowedURLs = []*url.URL{allowedURL}
 		cfg.IPRangeACSecretKey = "secret"
 		cdt := clienttest.NewClientDecoratorTest(t, clienttest.WithMiddlewares(NewHostedGrafanaACHeaderMiddleware(cfg)))
@@ -109,8 +109,8 @@ func Test_HostedGrafanaACHeaderMiddleware(t *testing.T) {
 		}, nopCallResourceSender)
 		require.NoError(t, err)
 
-		require.Len(t, cdt.CallResourceReq.Headers[GrafanaRequestID], 0)
-		require.Len(t, cdt.CallResourceReq.Headers[GrafanaSignedRequestID], 0)
+		require.Len(t, cdt.CallResourceReq.Headers[GrafanaRequestID], 1)
+		require.Len(t, cdt.CallResourceReq.Headers[GrafanaSignedRequestID], 1)
 	})
 
 	t.Run("Should set Grafana internal request header if the request is internal (doesn't have X-Real-IP header set)", func(t *testing.T) {

--- a/pkg/setting/setting.go
+++ b/pkg/setting/setting.go
@@ -339,7 +339,7 @@ type Cfg struct {
 
 	// IP range access control
 	IPRangeACEnabled     bool
-	IPRangeACAllowedURLs []string
+	IPRangeACAllowedURLs []*url.URL
 	IPRangeACSecretKey   string
 
 	// SQL Data sources
@@ -1949,7 +1949,15 @@ func (cfg *Cfg) readDataSourceSecuritySettings() {
 	cfg.IPRangeACEnabled = datasources.Key("enabled").MustBool(false)
 	cfg.IPRangeACSecretKey = datasources.Key("secret_key").MustString("")
 	allowedURLString := datasources.Key("allow_list").MustString("")
-	cfg.IPRangeACAllowedURLs = util.SplitString(allowedURLString)
+	for _, urlString := range util.SplitString(allowedURLString) {
+		allowedURL, err := url.Parse(urlString)
+		if err != nil {
+			cfg.Logger.Error("Error parsing allowed URL for IP range access control", "error", err)
+			continue
+		} else {
+			cfg.IPRangeACAllowedURLs = append(cfg.IPRangeACAllowedURLs, allowedURL)
+		}
+	}
 }
 
 func (cfg *Cfg) readSqlDataSourceSettings() {


### PR DESCRIPTION
**What is this feature?**

Ignore the DS query path when comparing the DS URL to the allow listed URLs for data source IP range access control.

**Why do we need this feature?**

Makes it simpler to put together an allow list - you only need to know the base URL of the data source, and not the query path that it expects queries on.

**Who is this feature for?**

Currently internal only.

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Related to https://github.com/grafana/identity-access-team/issues/363

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
