### PR TITLE
CI: Remove inline-builds flag

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,7 @@ COPY public public
 
 RUN apk add --no-cache make build-base python3
 
-RUN yarn install --immutable --inline-builds
+RUN yarn install --immutable
 
 COPY tsconfig.json .eslintrc .editorconfig .browserslistrc .prettierrc.js ./
 COPY public public


### PR DESCRIPTION
The `inline-builds` flag was erroneously included. This is unneeded for production builds and only needed when debugging issues.