### PR TITLE
CloudWatch: Fetch externalId from settings instead of env

### DIFF
--- a/pkg/tsdb/cloudwatch/routes/external_id.go
+++ b/pkg/tsdb/cloudwatch/routes/external_id.go
@@ -5,9 +5,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/url"
-	"os"
 
-	"github.com/grafana/grafana-aws-sdk/pkg/awsds"
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
 	"github.com/grafana/grafana/pkg/tsdb/cloudwatch/models"
 )
@@ -17,8 +15,13 @@ type ExternalIdResponse struct {
 }
 
 func ExternalIdHandler(ctx context.Context, pluginCtx backend.PluginContext, reqCtxFactory models.RequestContextFactoryFunc, parameters url.Values) ([]byte, *models.HttpError) {
+	reqCtx, err := reqCtxFactory(ctx, pluginCtx, "default")
+	if err != nil {
+		return nil, models.NewHttpError("error in ExternalIdHandler", http.StatusInternalServerError, err)
+	}
+
 	response := ExternalIdResponse{
-		ExternalId: os.Getenv(awsds.GrafanaAssumeRoleExternalIdKeyName),
+		ExternalId: reqCtx.Settings.GrafanaSettings.ExternalID,
 	}
 	jsonResponse, err := json.Marshal(response)
 	if err != nil {

--- a/pkg/tsdb/cloudwatch/routes/external_id_test.go
+++ b/pkg/tsdb/cloudwatch/routes/external_id_test.go
@@ -1,19 +1,30 @@
 package routes
 
 import (
+	"context"
 	"net/http"
 	"net/http/httptest"
 	"testing"
 
+	"github.com/grafana/grafana-aws-sdk/pkg/awsds"
+	"github.com/grafana/grafana-plugin-sdk-go/backend"
+	"github.com/grafana/grafana/pkg/tsdb/cloudwatch/models"
 	"github.com/stretchr/testify/assert"
 )
 
 func Test_external_id_route(t *testing.T) {
-	t.Run("successfully returns an external id from the env", func(t *testing.T) {
+	t.Run("successfully returns an external id from the instance", func(t *testing.T) {
 		t.Setenv("AWS_AUTH_EXTERNAL_ID", "mock-external-id")
 		rr := httptest.NewRecorder()
 
-		handler := http.HandlerFunc(ResourceRequestMiddleware(ExternalIdHandler, logger, nil))
+		factoryFunc := func(_ context.Context, _ backend.PluginContext, region string) (reqCtx models.RequestContext, err error) {
+			return models.RequestContext{
+				Settings: models.CloudWatchSettings{
+					GrafanaSettings: awsds.AuthSettings{ExternalID: "mock-external-id"},
+				},
+			}, nil
+		}
+		handler := http.HandlerFunc(ResourceRequestMiddleware(ExternalIdHandler, logger, factoryFunc))
 		req := httptest.NewRequest("GET", "/external-id", nil)
 
 		handler.ServeHTTP(rr, req)
@@ -25,7 +36,12 @@ func Test_external_id_route(t *testing.T) {
 	t.Run("returns an empty string if there is no external id", func(t *testing.T) {
 		rr := httptest.NewRecorder()
 
-		handler := http.HandlerFunc(ResourceRequestMiddleware(ExternalIdHandler, logger, nil))
+		factoryFunc := func(_ context.Context, _ backend.PluginContext, region string) (reqCtx models.RequestContext, err error) {
+			return models.RequestContext{
+				Settings: models.CloudWatchSettings{},
+			}, nil
+		}
+		handler := http.HandlerFunc(ResourceRequestMiddleware(ExternalIdHandler, logger, factoryFunc))
 		req := httptest.NewRequest("GET", "/external-id", nil)
 
 		handler.ServeHTTP(rr, req)


### PR DESCRIPTION
Split off from https://github.com/grafana/grafana/pull/83278 

part of #82194

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
