### PR TITLE
Chore: Add a key prop to warning component to prevent "should have a unique key prop" error

### DIFF
--- a/public/app/features/query/components/QueryEditorRow.tsx
+++ b/public/app/features/query/components/QueryEditorRow.tsx
@@ -405,6 +405,7 @@ export class QueryEditorRow<TQuery extends DataQuery> extends PureComponent<Prop
 
     return (
       <Badge
+        key="query-warning"
         color="orange"
         icon="exclamation-triangle"
         text={


### PR DESCRIPTION
**What is this feature?**

When you are editing a query on the Prometheus (or any other datasource that can give you a warning) dashboard panel and Prometheus returns a warning we show that warning on the header.
But after having the warning we get a `Warning: Each child in a list should have a unique "key" prop. error on the browser console.`
This was happening because warning component (`Badge`) was [rendering in a map and didn't have a key](https://github.com/grafana/grafana/blob/834843614790236df7314912bad58f9fa381af36/public/app/features/query/components/QueryEditorRow.tsx#L437).

### How to reproduce
- Spin up a Prometheus datasource 
- Use a metric that is not a counter with rate -> i.e.`rate(go_gc_heap_goal_bytes[1m])`
- Observe you have a warning and observe you have the error in the console.

