### PR TITLE
Prometheus: avoid unnecessary network requests

### DIFF
--- a/packages/grafana-prometheus/src/querybuilder/components/PromQueryBuilder.test.tsx
+++ b/packages/grafana-prometheus/src/querybuilder/components/PromQueryBuilder.test.tsx
@@ -11,7 +11,7 @@ import {
   QueryHint,
   TimeRange,
 } from '@grafana/data';
-import { TemplateSrv } from '@grafana/runtime';
+import { config, TemplateSrv } from '@grafana/runtime';
 
 import { PrometheusDatasource } from '../../datasource';
 import PromQlLanguageProvider from '../../language_provider';
@@ -59,6 +59,10 @@ const bugQuery: PromVisualQuery = {
   ],
 };
 
+afterEach(() => {
+  jest.restoreAllMocks();
+});
+
 describe('PromQueryBuilder', () => {
   it('shows empty just with metric selected', async () => {
     setup();
@@ -102,6 +106,28 @@ describe('PromQueryBuilder', () => {
     datasource.getVariables = jest.fn().mockReturnValue([]);
     await openMetricSelect(container);
     await waitFor(() => expect(datasource.getVariables).toBeCalled());
+  });
+
+  it('checks if the LLM plugin is enabled when the `prometheusPromQAIL` feature is enabled', async () => {
+    jest.replaceProperty(config, 'featureToggles', {
+      prometheusPromQAIL: true,
+    });
+    const mockIsLLMPluginEnabled = jest.fn();
+    mockIsLLMPluginEnabled.mockResolvedValue(true);
+    jest.spyOn(require('./promQail/state/helpers'), 'isLLMPluginEnabled').mockImplementation(mockIsLLMPluginEnabled);
+    setup();
+    await waitFor(() => expect(mockIsLLMPluginEnabled).toHaveBeenCalledTimes(1));
+  });
+
+  it('does not check if the LLM plugin is enabled when the `prometheusPromQAIL` feature is disabled', async () => {
+    jest.replaceProperty(config, 'featureToggles', {
+      prometheusPromQAIL: false,
+    });
+    const mockIsLLMPluginEnabled = jest.fn();
+    mockIsLLMPluginEnabled.mockResolvedValue(true);
+    jest.spyOn(require('./promQail/state/helpers'), 'isLLMPluginEnabled').mockImplementation(mockIsLLMPluginEnabled);
+    setup();
+    await waitFor(() => expect(mockIsLLMPluginEnabled).toHaveBeenCalledTimes(0));
   });
 
   // <LegacyPrometheus>

--- a/packages/grafana-prometheus/src/querybuilder/components/PromQueryBuilder.tsx
+++ b/packages/grafana-prometheus/src/querybuilder/components/PromQueryBuilder.tsx
@@ -36,15 +36,12 @@ export interface PromQueryBuilderProps {
   showExplain: boolean;
 }
 
-// initial commit for hackathon-2023-08-promqail
-// AI/ML + Prometheus
-const prometheusPromQAIL = config.featureToggles.prometheusPromQAIL;
-
 export const PromQueryBuilder = React.memo<PromQueryBuilderProps>((props) => {
   const { datasource, query, onChange, onRunQuery, data, showExplain } = props;
   const [highlightedOp, setHighlightedOp] = useState<QueryBuilderOperation | undefined>();
   const [showDrawer, setShowDrawer] = useState<boolean>(false);
   const [llmAppEnabled, updateLlmAppEnabled] = useState<boolean>(false);
+  const { prometheusPromQAIL } = config.featureToggles; // AI/ML + Prometheus
 
   const lang = { grammar: promqlGrammar, name: 'promql' };
 
@@ -55,8 +52,11 @@ export const PromQueryBuilder = React.memo<PromQueryBuilderProps>((props) => {
       const check = await isLLMPluginEnabled();
       updateLlmAppEnabled(check);
     }
-    checkLlms();
-  }, []);
+
+    if (prometheusPromQAIL) {
+      checkLlms();
+    }
+  }, [prometheusPromQAIL]);
 
   return (
     <>

--- a/public/app/plugins/datasource/prometheus/querybuilder/components/PromQueryBuilder.test.tsx
+++ b/public/app/plugins/datasource/prometheus/querybuilder/components/PromQueryBuilder.test.tsx
@@ -59,6 +59,10 @@ const bugQuery: PromVisualQuery = {
   ],
 };
 
+afterEach(() => {
+  jest.restoreAllMocks();
+});
+
 describe('PromQueryBuilder', () => {
   it('shows empty just with metric selected', async () => {
     setup();

--- a/public/app/plugins/datasource/prometheus/querybuilder/components/PromQueryBuilder.test.tsx
+++ b/public/app/plugins/datasource/prometheus/querybuilder/components/PromQueryBuilder.test.tsx
@@ -11,7 +11,7 @@ import {
   QueryHint,
   TimeRange,
 } from '@grafana/data';
-import { TemplateSrv } from '@grafana/runtime';
+import { config, TemplateSrv } from '@grafana/runtime';
 
 import { PrometheusDatasource } from '../../datasource';
 import PromQlLanguageProvider from '../../language_provider';
@@ -102,6 +102,28 @@ describe('PromQueryBuilder', () => {
     datasource.getVariables = jest.fn().mockReturnValue([]);
     await openMetricSelect(container);
     await waitFor(() => expect(datasource.getVariables).toBeCalled());
+  });
+
+  it('checks if the LLM plugin is enabled when the `prometheusPromQAIL` feature is enabled', async () => {
+    jest.replaceProperty(config, 'featureToggles', {
+      prometheusPromQAIL: true,
+    });
+    const mockIsLLMPluginEnabled = jest.fn();
+    mockIsLLMPluginEnabled.mockResolvedValue(true);
+    jest.spyOn(require('./promQail/state/helpers'), 'isLLMPluginEnabled').mockImplementation(mockIsLLMPluginEnabled);
+    setup();
+    await waitFor(() => expect(mockIsLLMPluginEnabled).toHaveBeenCalledTimes(1));
+  });
+
+  it('does not check if the LLM plugin is enabled when the `prometheusPromQAIL` feature is disabled', async () => {
+    jest.replaceProperty(config, 'featureToggles', {
+      prometheusPromQAIL: false,
+    });
+    const mockIsLLMPluginEnabled = jest.fn();
+    mockIsLLMPluginEnabled.mockResolvedValue(true);
+    jest.spyOn(require('./promQail/state/helpers'), 'isLLMPluginEnabled').mockImplementation(mockIsLLMPluginEnabled);
+    setup();
+    await waitFor(() => expect(mockIsLLMPluginEnabled).toHaveBeenCalledTimes(0));
   });
 
   // <LegacyPrometheus>

--- a/public/app/plugins/datasource/prometheus/querybuilder/components/PromQueryBuilder.tsx
+++ b/public/app/plugins/datasource/prometheus/querybuilder/components/PromQueryBuilder.tsx
@@ -36,15 +36,12 @@ export interface Props {
   showExplain: boolean;
 }
 
-// initial commit for hackathon-2023-08-promqail
-// AI/ML + Prometheus
-const prometheusPromQAIL = config.featureToggles.prometheusPromQAIL;
-
 export const PromQueryBuilder = React.memo<Props>((props) => {
   const { datasource, query, onChange, onRunQuery, data, showExplain } = props;
   const [highlightedOp, setHighlightedOp] = useState<QueryBuilderOperation | undefined>();
   const [showDrawer, setShowDrawer] = useState<boolean>(false);
   const [llmAppEnabled, updateLlmAppEnabled] = useState<boolean>(false);
+  const { prometheusPromQAIL } = config.featureToggles; // AI/ML + Prometheus
 
   const lang = { grammar: promqlGrammar, name: 'promql' };
 
@@ -55,8 +52,11 @@ export const PromQueryBuilder = React.memo<Props>((props) => {
       const check = await isLLMPluginEnabled();
       updateLlmAppEnabled(check);
     }
-    checkLlms();
-  }, []);
+
+    if (prometheusPromQAIL) {
+      checkLlms();
+    }
+  }, [prometheusPromQAIL]);
 
   return (
     <>


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this?**

This PR is a performance fix for the [Prometheus Data Source](https://grafana.com/grafana/plugins/prometheus).

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #83315

**Special notes for your reviewer:**

In `PromQueryBuilder.tsx`, you might be wondering why we'd move the `prometheusPromQAIL` variable inside the component. This change facilitates unit testing. Without this change, we run into Jest-specific variable scope issues in our unit tests.

This PR makes parallel updates to `public/app/plugins/datasource/prometheus` and `packages/grafana-prometheus` (for context, see #81641).

**Checklist:**
- [x] It works as expected from a user's perspective.

**Demo:**

https://github.com/grafana/grafana/assets/5732000/6b7c9b60-4753-4a1e-9008-cd7480f4911f