### PR TITLE
Docs: Add missing visualizations to Grafana vizualization index page

### DIFF
--- a/docs/sources/panels-visualizations/visualizations/_index.md
+++ b/docs/sources/panels-visualizations/visualizations/_index.md
@@ -33,7 +33,7 @@ If you are unsure which visualization to pick, Grafana can provide visualization
   - [Heatmap][] visualizes data in two dimensions, used typically for the magnitude of a phenomenon.
   - [Pie chart][] is typically used where proportionality is important.
   - [Candlestick][] is typically for financial data where the focus is price/data movement.
-  - [Gauge][] The traditional rounded gauge showing how far is a single metric from a threshold.
+  - [Gauge][] is the traditional rounded visual showing how far a single metric is from a threshold.
 - Stats & numbers
   - [Stat][] for big stats and optional sparkline.
   - [Bar gauge][] is a horizontal or vertical bar gauge.

--- a/docs/sources/panels-visualizations/visualizations/_index.md
+++ b/docs/sources/panels-visualizations/visualizations/_index.md
@@ -33,6 +33,7 @@ If you are unsure which visualization to pick, Grafana can provide visualization
   - [Heatmap][] visualizes data in two dimensions, used typically for the magnitude of a phenomenon.
   - [Pie chart][] is typically used where proportionality is important.
   - [Candlestick][] is typically for financial data where the focus is price/data movement.
+  - [Gauge][] The traditional rounded gauge showing how far is a single metric from a threshold.
 - Stats & numbers
   - [Stat][] for big stats and optional sparkline.
   - [Bar gauge][] is a horizontal or vertical bar gauge.
@@ -42,6 +43,8 @@ If you are unsure which visualization to pick, Grafana can provide visualization
   - [Node graph][] for directed graphs or networks.
   - [Traces][] is the main visualization for traces.
   - [Flame graph][] is the main visualization for profiling.
+  - [Canvas][] free visualization panel allowing you to create your own visualization.
+  - [Geomap][] is a visual representation helping you to visualize or track assets in a map.
 - Widgets
   - [Dashboard list][] can list dashboards.
   - [Alert list][] can list alerts.
@@ -121,6 +124,12 @@ A state timeline shows discrete state changes over time. When used with time ser
 
 [Flame graph]: "/docs/grafana/ -> /docs/grafana/<GRAFANA VERSION>/panels-visualizations/visualizations/flame-graph"
 [Flame graph]: "/docs/grafana-cloud/ -> /docs/grafana/<GRAFANA VERSION>/panels-visualizations/visualizations/flame-graph"
+
+[Canvas]: "/docs/grafana/ -> /docs/grafana/<GRAFANA VERSION>/panels-visualizations/visualizations/canvas"
+[Canvas]: "/docs/grafana-cloud/ -> /docs/grafana/<GRAFANA VERSION>/panels-visualizations/visualizations/canvas"
+
+[Geomap]: "/docs/grafana/ -> /docs/grafana/<GRAFANA VERSION>/panels-visualizations/visualizations/geomap"
+[Geomap]: "/docs/grafana-cloud/ -> /docs/grafana/<GRAFANA VERSION>/panels-visualizations/visualizations/geomap"
 
 [Status history]: "/docs/grafana/ -> /docs/grafana/<GRAFANA VERSION>/panels-visualizations/visualizations/status-history"
 [Status history]: "/docs/grafana-cloud/ -> /docs/grafana/<GRAFANA VERSION>/panels-visualizations/visualizations/status-history"

--- a/docs/sources/panels-visualizations/visualizations/_index.md
+++ b/docs/sources/panels-visualizations/visualizations/_index.md
@@ -43,8 +43,8 @@ If you are unsure which visualization to pick, Grafana can provide visualization
   - [Node graph][] for directed graphs or networks.
   - [Traces][] is the main visualization for traces.
   - [Flame graph][] is the main visualization for profiling.
-  - [Canvas][] free visualization panel allowing you to create your own visualization.
-  - [Geomap][] is a visual representation helping you to visualize or track assets in a map.
+  - [Canvas][] allows you to explicitly place elements within static and dynamic layouts. 
+  - [Geomap][] helps you visualize geospatial data.
 - Widgets
   - [Dashboard list][] can list dashboards.
   - [Alert list][] can list alerts.

--- a/docs/sources/panels-visualizations/visualizations/_index.md
+++ b/docs/sources/panels-visualizations/visualizations/_index.md
@@ -43,7 +43,7 @@ If you are unsure which visualization to pick, Grafana can provide visualization
   - [Node graph][] for directed graphs or networks.
   - [Traces][] is the main visualization for traces.
   - [Flame graph][] is the main visualization for profiling.
-  - [Canvas][] allows you to explicitly place elements within static and dynamic layouts. 
+  - [Canvas][] allows you to explicitly place elements within static and dynamic layouts.
   - [Geomap][] helps you visualize geospatial data.
 - Widgets
   - [Dashboard list][] can list dashboards.


### PR DESCRIPTION
There were 3 visualization types missing in the list. Added: Geomap, Canvas and Gauge.
Hope the links work, just added them at the bottom, although Gauge was already there.

**What is this feature?**

Noticed there were some visualizations missing in the list.
I am thinking for a future PR to sort the visualizations alphabetically for ease when trying to find them instead of the weird sections: Misc, Stats, Graphs, etc. This would match the left menu as well, although for some reason Time series is not alphabetical.

**Why do we need this feature?**

The items are missing in the doc.

**Who is this feature for?**

Everyone

**Which issue(s) does this PR fix?**:
No issue open.

**Special notes for your reviewer:**
I just added the links at the bottom. I hope they work.

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
