### PR TITLE
 Table Panel: Improvements to text overflow hover

### DIFF
--- a/packages/grafana-ui/src/components/Table/DefaultCell.tsx
+++ b/packages/grafana-ui/src/components/Table/DefaultCell.tsx
@@ -125,10 +125,12 @@ function getCellStyle(
     }
   }
 
+  const isLongString = isStringValue && displayValue.text.length > 100 && Number.isNaN(displayValue.numeric);
+
   // If we have definied colors return those styles
   // Otherwise we return default styles
   if (textColor !== undefined || bgColor !== undefined) {
-    return tableStyles.buildCellContainerStyle(textColor, bgColor, !disableOverflowOnHover, isStringValue);
+    return tableStyles.buildCellContainerStyle(textColor, bgColor, !disableOverflowOnHover, isStringValue, isLongString);
   }
 
   if (isStringValue) {

--- a/packages/grafana-ui/src/components/Table/DefaultCell.tsx
+++ b/packages/grafana-ui/src/components/Table/DefaultCell.tsx
@@ -125,16 +125,18 @@ function getCellStyle(
     }
   }
 
-  const isLongString = isStringValue && displayValue.text.length > 100 && Number.isNaN(displayValue.numeric);
+  // const isLongString = isStringValue && displayValue.text.length > 100 && Number.isNaN(displayValue.numeric);
+  const isShortString = displayValue.text.length < 100 && displayValue.text.search(/\s/) >= 0;
+  console.log({text: displayValue.text, isShortString})
 
   // If we have definied colors return those styles
   // Otherwise we return default styles
   if (textColor !== undefined || bgColor !== undefined) {
-    return tableStyles.buildCellContainerStyle(textColor, bgColor, !disableOverflowOnHover, isStringValue, isLongString);
+    return tableStyles.buildCellContainerStyle(textColor, bgColor, !disableOverflowOnHover, isStringValue, isShortString);
   }
 
   if (isStringValue) {
-    return disableOverflowOnHover ? tableStyles.cellContainerTextNoOverflow : tableStyles.cellContainerText;
+    return disableOverflowOnHover ? tableStyles.buildCellContainerStyle(undefined, undefined, true, true, isShortString) : tableStyles.cellContainerText;
   } else {
     return disableOverflowOnHover ? tableStyles.cellContainerNoOverflow : tableStyles.cellContainer;
   }

--- a/packages/grafana-ui/src/components/Table/styles.ts
+++ b/packages/grafana-ui/src/components/Table/styles.ts
@@ -15,7 +15,8 @@ export function useTableStyles(theme: GrafanaTheme2, cellHeightOption: TableCell
     color?: string,
     background?: string,
     overflowOnHover?: boolean,
-    asCellText?: boolean
+    asCellText?: boolean,
+    isLongString?: boolean,
   ) => {
     return css({
       label: overflowOnHover ? 'cellContainerOverflow' : 'cellContainerNoOverflow',
@@ -51,7 +52,7 @@ export function useTableStyles(theme: GrafanaTheme2, cellHeightOption: TableCell
         width: overflowOnHover ? 'auto' : undefined,
         height: overflowOnHover ? 'auto' : `${rowHeight - 1}px`,
         minHeight: `${rowHeight - 1}px`,
-        wordBreak: overflowOnHover ? 'break-word' : undefined,
+        wordBreak: overflowOnHover && asCellText ? 'break-word' : undefined,
         whiteSpace: overflowOnHover ? 'normal' : 'nowrap',
         boxShadow: overflowOnHover ? `0 0 2px ${theme.colors.primary.main}` : undefined,
         background: overflowOnHover ? background ?? theme.components.table.rowHoverBackground : undefined,

--- a/packages/grafana-ui/src/components/Table/styles.ts
+++ b/packages/grafana-ui/src/components/Table/styles.ts
@@ -16,7 +16,7 @@ export function useTableStyles(theme: GrafanaTheme2, cellHeightOption: TableCell
     background?: string,
     overflowOnHover?: boolean,
     asCellText?: boolean,
-    isLongString?: boolean,
+    isShortString?: boolean,
   ) => {
     return css({
       label: overflowOnHover ? 'cellContainerOverflow' : 'cellContainerNoOverflow',
@@ -49,10 +49,10 @@ export function useTableStyles(theme: GrafanaTheme2, cellHeightOption: TableCell
 
       '&:hover': {
         overflow: overflowOnHover ? 'visible' : undefined,
-        width: overflowOnHover ? 'auto' : undefined,
+        width: overflowOnHover && isShortString ? 'auto !important' : 'auto',
         height: overflowOnHover ? 'auto' : `${rowHeight - 1}px`,
         minHeight: `${rowHeight - 1}px`,
-        wordBreak: overflowOnHover && asCellText ? 'break-word' : undefined,
+        wordBreak: overflowOnHover && asCellText && isShortString ? 'break-word' : undefined,
         whiteSpace: overflowOnHover ? 'normal' : 'nowrap',
         boxShadow: overflowOnHover ? `0 0 2px ${theme.colors.primary.main}` : undefined,
         background: overflowOnHover ? background ?? theme.components.table.rowHoverBackground : undefined,

--- a/packages/grafana-ui/src/components/Table/styles.ts
+++ b/packages/grafana-ui/src/components/Table/styles.ts
@@ -49,7 +49,7 @@ export function useTableStyles(theme: GrafanaTheme2, cellHeightOption: TableCell
 
       '&:hover': {
         overflow: overflowOnHover ? 'visible' : undefined,
-        width: overflowOnHover && isShortString ? 'auto !important' : 'auto',
+        width: overflowOnHover && isShortString ? 'auto' : 'auto !important',
         height: overflowOnHover ? 'auto' : `${rowHeight - 1}px`,
         minHeight: `${rowHeight - 1}px`,
         wordBreak: overflowOnHover && asCellText && isShortString ? 'break-word' : undefined,


### PR DESCRIPTION
Working on improvements for text wrapping hover behavior to elaborate on feedback from #82872

This looks at the length of the displayed value in the table, if it's relatively short (140 characters or less) and contains whitespace this will cause the hovering to wrap. However, if it's not the case the hover will overflow. There's a performance trade-off here in terms of the string length so we may not be getting every possible wrapping scenario perfect, but this seems to work fairly well.

Video in action:

https://github.com/grafana/grafana/assets/199847/3556e3ea-817a-426b-aaba-3e6b9c86c343

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
