### PR TITLE
InfluxDB: Fix fetching tag values only for selected measurement

### DIFF
--- a/public/app/plugins/datasource/influxdb/components/editor/query/influxql/visual/VisualInfluxQLEditor.tsx
+++ b/public/app/plugins/datasource/influxdb/components/editor/query/influxql/visual/VisualInfluxQLEditor.tsx
@@ -134,7 +134,7 @@ export const VisualInfluxQLEditor = (props: Props): JSX.Element => {
           getTagKeyOptions={getMemoizedTagKeys}
           getTagValueOptions={(key) =>
             withTemplateVariableOptions(
-              allTagKeys.then((keys) => getTagValues(datasource, filterTags(query.tags ?? [], keys), key)),
+              allTagKeys.then((keys) => getTagValues(datasource, filterTags(query.tags ?? [], keys), key, measurement)),
               wrapRegex
             )
           }


### PR DESCRIPTION
**What is this feature?**

We were fetching all values of all tags while populating the filters. That means the dropdown has values that are not for the selected measurement. See the docs https://docs.influxdata.com/influxdb/v1/query_language/explore-schema/#show-tag-values
This PR is adding a measurement filter. 

**Why do we need this feature?**

To be able to show only what's necessary

**Who is this feature for?**

InfluxDB influxql users

Fixes https://github.com/grafana/grafana/issues/81122
Fixes https://github.com/grafana/grafana/issues/81648

