### PR TITLE
SQLStore: Improve recursive CTE support detection

### DIFF
--- a/pkg/services/sqlstore/sqlstore.go
+++ b/pkg/services/sqlstore/sqlstore.go
@@ -382,7 +382,7 @@ func (ss *SQLStore) RecursiveQueriesAreSupported() (bool, error) {
 		}); err != nil {
 			var driverErr *mysql.MySQLError
 			if errors.As(err, &driverErr) {
-				if driverErr.Number == mysqlerr.ER_PARSE_ERROR {
+				if driverErr.Number == mysqlerr.ER_PARSE_ERROR || driverErr.Number == mysqlerr.ER_NOT_SUPPORTED_YET {
 					return false, nil
 				}
 			}


### PR DESCRIPTION
**What is this feature?**

Improve recursive CTE support detection for Vitess. Vitess returns a not supported error, not a parse error

```
logger=context userId=2 orgId=1 uname=d@nozzle.io t=2024-02-24T20:07:01.99543679Z level=error msg="Search failed" error="Error 1235 (42000): VT12001: unsupported: recursive common table expression" remote_addr=82.102.30.98 traceID=
logger=context userId=2 orgId=1 uname=d@nozzle.io t=2024-02-24T20:07:01.99578076Z level=error msg="Request Completed" method=GET path=/api/search status=500 remote_addr=82.102.30.98 time_ms=5 duration=5.613509ms size=40 referer="https://grafana.nozzle.app/?orgId=1" handler=/api/search/
logger=context userId=2 orgId=1 uname=d@nozzle.io t=2024-02-24T20:07:31.772972473Z level=error msg="Folder API error" error="Error 1235 (42000): VT12001: unsupported: recursive common table expression" remote_addr=82.102.30.98 traceID=
```

**Why do we need this feature?**

Grafana >= v10 can't run with Vitess as the config db

**Who is this feature for?**

Vitess users

**Which issue(s) does this PR fix?**:

- Partial: https://github.com/grafana/grafana/issues/73725#issuecomment-1793547863

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle.
- [x] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
