### PR TITLE
plugin-e2e: Fix flaky test

### DIFF
--- a/e2e/plugin-e2e/plugin-e2e-api-tests/as-admin-user/panelEditPage.spec.ts
+++ b/e2e/plugin-e2e/plugin-e2e-api-tests/as-admin-user/panelEditPage.spec.ts
@@ -1,4 +1,4 @@
-import { expect, test } from '@grafana/plugin-e2e';
+import { DashboardPage, expect, test } from '@grafana/plugin-e2e';
 
 import { formatExpectError } from '../errors';
 import { successfulDataQuery } from '../mocks/queries';
@@ -33,8 +33,11 @@ test.describe('query editor query data', () => {
 });
 
 test.describe('query editor with mocked responses', () => {
-  test('and resource `scenarios` is mocked', async ({ panelEditPage, selectors }) => {
-    await panelEditPage.mockResourceResponse('scenarios', scenarios);
+  test('and resource `scenarios` is mocked', async ({ page, selectors, grafanaVersion, request }) => {
+    const dashboardPage = new DashboardPage({ page, selectors, grafanaVersion, request });
+    await dashboardPage.goto();
+    await dashboardPage.mockResourceResponse('scenarios', scenarios);
+    const panelEditPage = await dashboardPage.addPanel();
     await panelEditPage.datasource.set('gdev-testdata');
     const queryEditorRow = await panelEditPage.getQueryEditorRow('A');
     await queryEditorRow.getByLabel('Scenario').last().click();


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

The purpose of this test is to verify that the API `<page>.mockResourceResponse` from plugin-e2e works as expected. This test turned out to be flaky, as the testdata datasource loads all scenarios immediately when the query editor is loaded. Sometimes, scenarios were loaded before the mock was created, leading the assertion to fail.  

This PR changes the test so that the mock is setup before creating the panel edit page. This will ensure the mocked data is returned when the testdata query editor is laoded. 

**Why do we need this feature?**

To verify scenarios in plugin-e2e. 

[Add a description of the problem the feature is trying to solve.]

**Who is this feature for?**

[Add information on what kind of user the feature is for.]

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
