### PR TITLE
E2C: Initial config to switch between cloud and onprem pages

### DIFF
--- a/public/app/features/admin/migrate-to-cloud/MigrateToCloud.tsx
+++ b/public/app/features/admin/migrate-to-cloud/MigrateToCloud.tsx
@@ -1,13 +1,14 @@
 import React from 'react';
 
+import { config } from '@grafana/runtime';
 import { Page } from 'app/core/components/Page/Page';
 
-import { EmptyState } from './onprem/EmptyState/EmptyState';
+import { Page as CloudPage } from './cloud/Page';
+import { Page as OnPremPage } from './onprem/Page';
 
 export default function MigrateToCloud() {
-  return (
-    <Page navId="migrate-to-cloud">
-      <EmptyState />
-    </Page>
-  );
+  // TODO replace this with a proper config value when it's available
+  const isMigrationTarget = config.namespace.startsWith('stack-');
+
+  return <Page navId="migrate-to-cloud">{isMigrationTarget ? <CloudPage /> : <OnPremPage />}</Page>;
 }

--- a/public/app/features/admin/migrate-to-cloud/cloud/InfoPane.tsx
+++ b/public/app/features/admin/migrate-to-cloud/cloud/InfoPane.tsx
@@ -5,7 +5,7 @@ import { GrafanaTheme2 } from '@grafana/data';
 import { Box, Stack, TextLink, useStyles2 } from '@grafana/ui';
 import { t, Trans } from 'app/core/internationalization';
 
-import { InfoItem } from '../../shared/InfoItem';
+import { InfoItem } from '../shared/InfoItem';
 
 export const InfoPane = () => {
   const styles = useStyles2(getStyles);

--- a/public/app/features/admin/migrate-to-cloud/cloud/MigrationTokenPane.tsx
+++ b/public/app/features/admin/migrate-to-cloud/cloud/MigrationTokenPane.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 import { Box, Button, Text } from '@grafana/ui';
 import { t, Trans } from 'app/core/internationalization';
 
-import { InfoItem } from '../../shared/InfoItem';
+import { InfoItem } from '../shared/InfoItem';
 
 export const MigrationTokenPane = () => {
   const onGenerateToken = () => {

--- a/public/app/features/admin/migrate-to-cloud/cloud/Page.tsx
+++ b/public/app/features/admin/migrate-to-cloud/cloud/Page.tsx
@@ -7,7 +7,7 @@ import { Grid, useStyles2 } from '@grafana/ui';
 import { InfoPane } from './InfoPane';
 import { MigrationTokenPane } from './MigrationTokenPane';
 
-export const EmptyState = () => {
+export const Page = () => {
   const styles = useStyles2(getStyles);
 
   return (

--- a/public/app/features/admin/migrate-to-cloud/onprem/Page.tsx
+++ b/public/app/features/admin/migrate-to-cloud/onprem/Page.tsx
@@ -1,0 +1,8 @@
+import React from 'react';
+
+import { EmptyState } from './EmptyState/EmptyState';
+
+export const Page = () => {
+  // TODO logic to determine whether to show the empty state or the resource table
+  return <EmptyState />;
+};


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

- switch between cloud/onprem pages based on `namespace` (for now)

**Why do we need this feature?**

- show different pages in cloud/onprem

**Who is this feature for?**

- everyone using E2C

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

For https://github.com/grafana/grafana/issues/82362

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
