### PR TITLE
Datasource API: Add config to ctx

### DIFF
--- a/pkg/registry/apis/datasource/register.go
+++ b/pkg/registry/apis/datasource/register.go
@@ -36,7 +36,7 @@ type DataSourceAPIBuilder struct {
 	connectionResourceInfo common.ResourceInfo
 
 	pluginJSON      plugins.JSONData
-	client          plugins.Client // will only ever be called with the same pluginid!
+	client          PluginClient // will only ever be called with the same pluginid!
 	datasources     PluginDatasourceProvider
 	contextProvider PluginContextWrapper
 	accessControl   accesscontrol.AccessControl
@@ -82,9 +82,17 @@ func RegisterAPIService(
 	return builder, nil // only used for wire
 }
 
+// PluginClient is a subset of the plugins.Client interface with the only method
+// used supported (yet) by the datasource API
+type PluginClient interface {
+	backend.QueryDataHandler
+	backend.CheckHealthHandler
+	backend.CallResourceHandler
+}
+
 func NewDataSourceAPIBuilder(
 	plugin plugins.JSONData,
-	client plugins.Client,
+	client PluginClient,
 	datasources PluginDatasourceProvider,
 	contextProvider PluginContextWrapper,
 	accessControl accesscontrol.AccessControl) (*DataSourceAPIBuilder, error) {

--- a/pkg/registry/apis/datasource/register.go
+++ b/pkg/registry/apis/datasource/register.go
@@ -82,8 +82,8 @@ func RegisterAPIService(
 	return builder, nil // only used for wire
 }
 
-// PluginClient is a subset of the plugins.Client interface with the only method
-// used supported (yet) by the datasource API
+// PluginClient is a subset of the plugins.Client interface with only the
+// functions supported (yet) by the datasource API
 type PluginClient interface {
 	backend.QueryDataHandler
 	backend.CheckHealthHandler

--- a/pkg/registry/apis/datasource/sub_health.go
+++ b/pkg/registry/apis/datasource/sub_health.go
@@ -40,6 +40,7 @@ func (r *subHealthREST) Connect(ctx context.Context, name string, opts runtime.O
 			responder.Error(err)
 			return
 		}
+		ctx = backend.WithGrafanaConfig(ctx, pluginCtx.GrafanaConfig)
 
 		healthResponse, err := r.builder.client.CheckHealth(ctx, &backend.CheckHealthRequest{
 			PluginContext: pluginCtx,

--- a/pkg/registry/apis/datasource/sub_query.go
+++ b/pkg/registry/apis/datasource/sub_query.go
@@ -77,6 +77,7 @@ func (r *subQueryREST) Connect(ctx context.Context, name string, opts runtime.Ob
 	if err != nil {
 		return nil, err
 	}
+	ctx = backend.WithGrafanaConfig(ctx, pluginCtx.GrafanaConfig)
 
 	return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 		queries, dsRef, err := r.readQueries(req)

--- a/pkg/registry/apis/datasource/sub_resource.go
+++ b/pkg/registry/apis/datasource/sub_resource.go
@@ -50,6 +50,7 @@ func (r *subResourceREST) Connect(ctx context.Context, name string, opts runtime
 	if err != nil {
 		return nil, err
 	}
+	ctx = backend.WithGrafanaConfig(ctx, pluginCtx.GrafanaConfig)
 
 	return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 		body, err := io.ReadAll(req.Body)


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

Two small changes here:
 - Reduce the scope of the plugin client requested in `NewDataSourceAPIBuilder`. It's not needed to request a client that implements the `*Stream` functions, nor `CollectMetrics` since those functions are not supported and not all the core plugins implement them.
 - Adds the `GrafanaConfig` to the request `ctx` so plugins can obtain it from the context as in [here](https://github.com/grafana/grafana/blob/main/pkg/tsdb/prometheus/querydata/request.go/#L92). 

