### PR TITLE
I18n: Only export approved strings from crowdin

### DIFF
--- a/.github/workflows/i18n-crowdin-download.yml
+++ b/.github/workflows/i18n-crowdin-download.yml
@@ -27,6 +27,7 @@ jobs:
           download_sources: false
           download_translations: true
           export_only_approved: true
+          skip_untranslated_strings: true
           localization_branch_name: i18n_crowdin_translations
           create_pull_request: true
           pull_request_title: 'I18n: Download translations from Crowdin'


### PR DESCRIPTION
Set `skip_untranslated_strings` to hopefully prevent PRs with only empty translation strings from being exported.