### PR TITLE
InfluxDB: Fix escaping template variable when it was used in parentheses

### DIFF
--- a/public/app/plugins/datasource/influxdb/datasource.test.ts
+++ b/public/app/plugins/datasource/influxdb/datasource.test.ts
@@ -443,6 +443,19 @@ describe('InfluxDataSource Frontend Mode', () => {
         expect(result).toBe(expectation);
       });
 
+      it('should return the escaped value if the value wrapped in regex 3', () => {
+        const value = ['env', 'env2', 'env3'];
+        const variableMock = queryBuilder()
+          .withId('tempVar')
+          .withName('tempVar')
+          .withMulti(false)
+          .withIncludeAll(true)
+          .build();
+        const result = ds.interpolateQueryExpr(value, variableMock, 'select from /^($tempVar)$/');
+        const expectation = `env|env2|env3`;
+        expect(result).toBe(expectation);
+      });
+
       it('should **not** return the escaped value if the value **is not** wrapped in regex', () => {
         const value = '/special/path';
         const variableMock = queryBuilder().withId('tempVar').withName('tempVar').withMulti(false).build();

--- a/public/app/plugins/datasource/influxdb/datasource.ts
+++ b/public/app/plugins/datasource/influxdb/datasource.ts
@@ -316,8 +316,8 @@ export default class InfluxDatasource extends DataSourceWithBackend<InfluxQuery,
     // we want to see how it's been used. If it is used in a regex expression
     // we escape it. Otherwise, we return it directly.
     // regex below checks if the variable inside /^...$/ (^ and $ is optional)
-    // i.e. /^$myVar$/ or /$myVar/
-    const regex = new RegExp(`\\/(?:\\^)?\\$${variable.name}(?:\\$)?\\/`, 'gm');
+    // i.e. /^$myVar$/ or /$myVar/ or /^($myVar)$/
+    const regex = new RegExp(`\\/(?:\\^)?(.*)(\\$${variable.name})(.*)(?:\\$)?\\/`, 'gm');
     if (regex.test(query)) {
       if (typeof value === 'string') {
         return escapeRegex(value);


### PR DESCRIPTION
**What is this feature?**

When you have a template variable that is not a "multi-value" but has "include all option" and use it in parentheses it isn't properly escaped. This PR is fixing this by updating the matcher regex pattern. 

**Who is this feature for?**

InfluxDB users

## How to test
Set up a variable as shown:
![image](https://github.com/grafana/grafana/assets/820946/587e2a00-3769-4b1b-ac39-9581852438b3)

Use it as shown:
With parentheses
![image](https://github.com/grafana/grafana/assets/820946/eea741bb-6387-4cbe-8ea7-84c19cf2444c)

Without parentheses
![image](https://github.com/grafana/grafana/assets/820946/5a39f821-09f6-44c0-9576-e3b3b50554f7)

