### PR TITLE
E2C: Add cloud migration is_target server config option

### DIFF
--- a/conf/defaults.ini
+++ b/conf/defaults.ini
@@ -1808,3 +1808,8 @@ read_only_toggles =
 [public_dashboards]
 # Set to false to disable public dashboards
 enabled = true
+
+###################################### Cloud Migration ######################################
+[cloud_migration]
+# Set to true to enable target-side migration UI
+is_target = false

--- a/packages/grafana-data/src/types/config.ts
+++ b/packages/grafana-data/src/types/config.ts
@@ -227,7 +227,7 @@ export interface GrafanaConfig {
   sharedWithMeFolderUID?: string;
   rootFolderUID?: string;
   localFileSystemAvailable?: boolean;
-  cloudMigrationIsTarget: boolean;
+  cloudMigrationIsTarget?: boolean;
 
   // The namespace to use for kubernetes apiserver requests
   namespace: string;

--- a/packages/grafana-data/src/types/config.ts
+++ b/packages/grafana-data/src/types/config.ts
@@ -227,6 +227,7 @@ export interface GrafanaConfig {
   sharedWithMeFolderUID?: string;
   rootFolderUID?: string;
   localFileSystemAvailable?: boolean;
+  cloudMigrationIsTarget: boolean;
 
   // The namespace to use for kubernetes apiserver requests
   namespace: string;

--- a/packages/grafana-runtime/src/config.ts
+++ b/packages/grafana-runtime/src/config.ts
@@ -172,6 +172,7 @@ export class GrafanaBootConfig implements GrafanaConfig {
   sharedWithMeFolderUID: string | undefined;
   rootFolderUID: string | undefined;
   localFileSystemAvailable: boolean | undefined;
+  cloudMigrationIsTarget: boolean | undefined;
 
   constructor(options: GrafanaBootConfig) {
     this.bootData = options.bootData;

--- a/pkg/api/dtos/frontend_settings.go
+++ b/pkg/api/dtos/frontend_settings.go
@@ -247,6 +247,8 @@ type FrontendSettingsDTO struct {
 	PublicDashboardAccessToken string `json:"publicDashboardAccessToken"`
 	PublicDashboardsEnabled    bool   `json:"publicDashboardsEnabled"`
 
+	CloudMigrationIsTarget bool `json:"cloudMigrationIsTarget"`
+
 	DateFormats setting.DateFormats `json:"dateFormats,omitempty"`
 
 	LoginError string `json:"loginError,omitempty"`

--- a/pkg/api/frontendsettings.go
+++ b/pkg/api/frontendsettings.go
@@ -161,6 +161,7 @@ func (hs *HTTPServer) getFrontendSettings(c *contextmodel.ReqContext) (*dtos.Fro
 	hasAccess := accesscontrol.HasAccess(hs.AccessControl, c)
 	secretsManagerPluginEnabled := kvstore.EvaluateRemoteSecretsPlugin(c.Req.Context(), hs.secretsPluginManager, hs.Cfg) == nil
 	trustedTypesDefaultPolicyEnabled := (hs.Cfg.CSPEnabled && strings.Contains(hs.Cfg.CSPTemplate, "require-trusted-types-for")) || (hs.Cfg.CSPReportOnlyEnabled && strings.Contains(hs.Cfg.CSPReportOnlyTemplate, "require-trusted-types-for"))
+	isCloudMigrationTarget := hs.Features.IsEnabled(c.Req.Context(), featuremgmt.FlagOnPremToCloudMigrations) && hs.Cfg.CloudMigrationIsTarget
 
 	frontendSettings := &dtos.FrontendSettingsDTO{
 		DefaultDatasource:                   defaultDS,
@@ -218,7 +219,7 @@ func (hs *HTTPServer) getFrontendSettings(c *contextmodel.ReqContext) (*dtos.Fro
 		DisableFrontendSandboxForPlugins:    hs.Cfg.DisableFrontendSandboxForPlugins,
 		PublicDashboardAccessToken:          c.PublicDashboardAccessToken,
 		PublicDashboardsEnabled:             hs.Cfg.PublicDashboardsEnabled,
-		CloudMigrationIsTarget:              hs.Features.IsEnabled(c.Req.Context(), featuremgmt.FlagOnPremToCloudMigrations) && hs.Cfg.CloudMigrationIsTarget,
+		CloudMigrationIsTarget:              isCloudMigrationTarget,
 		SharedWithMeFolderUID:               folder.SharedWithMeFolderUID,
 		RootFolderUID:                       accesscontrol.GeneralFolderUID,
 		LocalFileSystemAvailable:            hs.Cfg.LocalFileSystemAvailable,

--- a/pkg/api/frontendsettings.go
+++ b/pkg/api/frontendsettings.go
@@ -94,6 +94,8 @@ func (hs *HTTPServer) GetFrontendSettings(c *contextmodel.ReqContext) {
 }
 
 // getFrontendSettings returns a json object with all the settings needed for front end initialisation.
+//
+//nolint:gocyclo
 func (hs *HTTPServer) getFrontendSettings(c *contextmodel.ReqContext) (*dtos.FrontendSettingsDTO, error) {
 	availablePlugins, err := hs.availablePlugins(c.Req.Context(), c.SignedInUser.GetOrgID())
 	if err != nil {

--- a/pkg/api/frontendsettings.go
+++ b/pkg/api/frontendsettings.go
@@ -218,6 +218,7 @@ func (hs *HTTPServer) getFrontendSettings(c *contextmodel.ReqContext) (*dtos.Fro
 		DisableFrontendSandboxForPlugins:    hs.Cfg.DisableFrontendSandboxForPlugins,
 		PublicDashboardAccessToken:          c.PublicDashboardAccessToken,
 		PublicDashboardsEnabled:             hs.Cfg.PublicDashboardsEnabled,
+		CloudMigrationIsTarget:              hs.Features.IsEnabled(c.Req.Context(), featuremgmt.FlagOnPremToCloudMigrations) && hs.Cfg.CloudMigrationIsTarget,
 		SharedWithMeFolderUID:               folder.SharedWithMeFolderUID,
 		RootFolderUID:                       accesscontrol.GeneralFolderUID,
 		LocalFileSystemAvailable:            hs.Cfg.LocalFileSystemAvailable,

--- a/pkg/setting/setting.go
+++ b/pkg/setting/setting.go
@@ -495,6 +495,9 @@ type Cfg struct {
 	// Public dashboards
 	PublicDashboardsEnabled bool
 
+	// Cloud Migration
+	CloudMigrationIsTarget bool
+
 	// Feature Management Settings
 	FeatureManagement FeatureMgmtSettings
 
@@ -1286,6 +1289,7 @@ func (cfg *Cfg) parseINIFile(iniFile *ini.File) error {
 
 	cfg.readFeatureManagementConfig()
 	cfg.readPublicDashboardsSettings()
+	cfg.readCloudMigrationSettings()
 
 	// read experimental scopes settings.
 	scopesSection := iniFile.Section("scopes")
@@ -2004,4 +2008,9 @@ func (cfg *Cfg) readLiveSettings(iniFile *ini.File) error {
 func (cfg *Cfg) readPublicDashboardsSettings() {
 	publicDashboards := cfg.Raw.Section("public_dashboards")
 	cfg.PublicDashboardsEnabled = publicDashboards.Key("enabled").MustBool(true)
+}
+
+func (cfg *Cfg) readCloudMigrationSettings() {
+	cloudMigration := cfg.Raw.Section("cloud_migration")
+	cfg.CloudMigrationIsTarget = cloudMigration.Key("is_target").MustBool(false)
 }


### PR DESCRIPTION
 - Adds a backend server config flag to control whether the instance is to be the target of a cloud migration
 - Typically this value would only ever be enabled in Grafana Cloud and would rely on other cloud-only infra, so it's not added to the sample.ini, nor is further documentation added for it other than code comments.