### PR TITLE
Chore: fix shellchecks

### DIFF
--- a/scripts/check-breaking-changes.sh
+++ b/scripts/check-breaking-changes.sh
@@ -17,7 +17,15 @@ while IFS=" " read -r -a package; do
   CURRENT="./pr/$PACKAGE_PATH"
 
   # Temporarily skipping these packages as they don't have any exposed static typing
-  if [[ ${SKIP_PACKAGES[@]} =~ "$PACKAGE_PATH" ]]; then
+  SKIP_PACKAGE_FOUND=0
+  for skip_pkg in "${SKIP_PACKAGES[@]}"; do
+    if [[ "$PACKAGE_PATH" == "$skip_pkg" ]]; then
+      SKIP_PACKAGE_FOUND=1
+      break
+    fi
+  done
+
+  if [[ $SKIP_PACKAGE_FOUND -eq 1 ]]; then
     continue
   fi
 

--- a/scripts/ci-frontend-metrics.sh
+++ b/scripts/ci-frontend-metrics.sh
@@ -15,7 +15,7 @@ CLASSNAME_PROP="$(grep -r -o -E --include="*.ts*" "\.*.className=\W.*\W.*" publi
 EMOTION_IMPORTS="$(grep -r -o -E --include="*.ts*" --exclude="*.test*" "\{.*css.*\} from '@emotion/css'" public/app | wc -l)"
 TS_FILES="$(find public/app -type f -name "*.ts*" -not -name "*.test*" | wc -l)"
 
-TOTAL_BUNDLE="$(du -sk $BUILD_FOLDER | cut -f1)"
+TOTAL_BUNDLE="$(du -sk "$BUILD_FOLDER" | cut -f1)"
 OUTDATED_DEPENDENCIES="$(yarn outdated --all | grep -oP '[[:digit:]]+ *(?= dependencies are out of date)')"
 ## Disabled due to yarn PnP update breaking npm audit
 #VULNERABILITY_AUDIT="$(yarn npm audit --all --recursive --json)"


### PR DESCRIPTION
While trying to merge in[ an unrelated shell script](https://github.com/grafana/grafana-enterprise/pull/6302) in enterprise, the ci was failing due to shellcheck issues on these two scripts. This PR fixes the related errors