### PR TITLE
Jaeger: Add tests

### DIFF
--- a/public/app/plugins/datasource/jaeger/datasource.test.ts
+++ b/public/app/plugins/datasource/jaeger/datasource.test.ts
@@ -319,7 +319,7 @@ describe('when performing testDataSource', () => {
   });
 });
 
-describe("Test behavior with unmocked time", () => {
+describe('Test behavior with unmocked time', () => {
   beforeEach(() => {
     jest.clearAllMocks();
   });
@@ -328,31 +328,31 @@ describe("Test behavior with unmocked time", () => {
     jest.restoreAllMocks();
   });
 
-  it("getTimeRange()", async () => {
+  it('getTimeRange()', async () => {
     const ds = new JaegerDatasource(defaultSettings);
     const timeRange = ds.getTimeRange();
     const now = Date.now();
-    expect(timeRange.end).toBeCloseTo(now * 1000, -4)
-    expect(timeRange.start).toBeCloseTo((now - 6 * 3600 * 1000) * 1000, -4)
-  })
+    expect(timeRange.end).toBeCloseTo(now * 1000, -4);
+    expect(timeRange.start).toBeCloseTo((now - 6 * 3600 * 1000) * 1000, -4);
+  });
 
   it("call for `query()` when `queryType === 'dependencyGraph'`", async () => {
     const mock = setupFetchMock({ data: [testResponse] });
     const ds = new JaegerDatasource(defaultSettings);
 
-    ds.query({...defaultQuery, targets: [{queryType: "dependencyGraph", refId: '1',}]})
+    ds.query({ ...defaultQuery, targets: [{ queryType: 'dependencyGraph', refId: '1' }] });
     const now = Date.now();
 
     const url = mock.mock.calls[0][0].url;
     const endTsMatch = url.match(/endTs=(\d+)/);
     expect(endTsMatch).not.toBeNull();
-    expect(parseInt(endTsMatch![1], 10)).toBeCloseTo(now, -4)
+    expect(parseInt(endTsMatch![1], 10)).toBeCloseTo(now, -4);
 
     const lookbackMatch = url.match(/lookback=(\d+)/);
     expect(lookbackMatch).not.toBeNull();
-    expect(parseInt(lookbackMatch![1], 10)).toBe(21600000)
-  })
-})
+    expect(parseInt(lookbackMatch![1], 10)).toBe(21600000);
+  });
+});
 
 function setupFetchMock(response: unknown, mock?: ReturnType<typeof backendSrv.fetch>) {
   const defaultMock = () => mock ?? of(createFetchResponse(response));

--- a/public/app/plugins/datasource/jaeger/datasource.test.ts
+++ b/public/app/plugins/datasource/jaeger/datasource.test.ts
@@ -319,6 +319,16 @@ describe('when performing testDataSource', () => {
   });
 });
 
+describe("Test unmocked behavior", () => {
+  it("getTimeRange()", async () => {
+    const ds = new JaegerDatasource(defaultSettings);
+    const timeRange = ds.getTimeRange();
+    const now = Date.now();
+    expect(timeRange.end).toBeCloseTo(now * 1000, -4)
+    expect(timeRange.start).toBeCloseTo((now - 6 * 3600 * 1000) * 1000, -4)
+  })
+})
+
 function setupFetchMock(response: unknown, mock?: ReturnType<typeof backendSrv.fetch>) {
   const defaultMock = () => mock ?? of(createFetchResponse(response));
 

--- a/public/app/plugins/datasource/jaeger/datasource.test.ts
+++ b/public/app/plugins/datasource/jaeger/datasource.test.ts
@@ -340,7 +340,7 @@ describe("Test behavior with unmocked time", () => {
     const mock = setupFetchMock({ data: [testResponse] });
     const ds = new JaegerDatasource(defaultSettings);
 
-    ds.query({targets: [{queryType: "dependencyGraph"}]} as any)
+    ds.query({...defaultQuery, targets: [{queryType: "dependencyGraph", refId: '1',}]})
     const now = Date.now();
 
     const url = mock.mock.calls[0][0].url;


### PR DESCRIPTION
Add a couple of tests. These will be mainly used to prevent regressions when decoupling Jaeger.