### PR TITLE
Prometheus: Reduce flakiness in prometheus e2e tests

### DIFF
--- a/docs/sources/datasources/azure-monitor/query-editor/index.md
+++ b/docs/sources/datasources/azure-monitor/query-editor/index.md
@@ -86,17 +86,17 @@ For example:
 - `Blob Type: {{ blobtype }}` becomes `Blob Type: PageBlob`, `Blob Type: BlockBlob`
 - `{{ resourcegroup }} - {{ resourcename }}` becomes `production - web_server`
 
-| Alias pattern                 | Description                                                                                            |
-| ----------------------------- | ------------------------------------------------------------------------------------------------------ |
-| `{{ subscriptionid }}`        | Replaced with the subscription ID.                                                                     |
-| `{{ subscription }}`          | Replaced with the subscription name.                                                                   |
-| `{{ resourcegroup }}`         | Replaced with the the resource group.                                                                  |
-| `{{ namespace }}`             | Replaced with the resource type or namespace, such as `Microsoft.Compute/virtualMachines`.             |
-| `{{ resourcename }}`          | Replaced with the resource name.                                                                       |
-| `{{ metric }}`                | Replaced with the metric name, such as "Percentage CPU".                                               |
+| Alias pattern                  | Description                                                                                            |
+| ------------------------------ | ------------------------------------------------------------------------------------------------------ |
+| `{{ subscriptionid }}`         | Replaced with the subscription ID.                                                                     |
+| `{{ subscription }}`           | Replaced with the subscription name.                                                                   |
+| `{{ resourcegroup }}`          | Replaced with the the resource group.                                                                  |
+| `{{ namespace }}`              | Replaced with the resource type or namespace, such as `Microsoft.Compute/virtualMachines`.             |
+| `{{ resourcename }}`           | Replaced with the resource name.                                                                       |
+| `{{ metric }}`                 | Replaced with the metric name, such as "Percentage CPU".                                               |
 | _`{{ arbitraryDimensionID }}`_ | Replaced with the value of the specified dimension. For example, `{{ blobtype }}` becomes `BlockBlob`. |
-| `{{ dimensionname }}`         | _(Legacy for backward compatibility)_ Replaced with the name of the first dimension.                   |
-| `{{ dimensionvalue }}`        | _(Legacy for backward compatibility)_ Replaced with the value of the first dimension.                  |
+| `{{ dimensionname }}`          | _(Legacy for backward compatibility)_ Replaced with the name of the first dimension.                   |
+| `{{ dimensionvalue }}`         | _(Legacy for backward compatibility)_ Replaced with the value of the first dimension.                  |
 
 ### Filter using dimensions
 

--- a/e2e/various-suite/prometheus-config.spec.ts
+++ b/e2e/various-suite/prometheus-config.spec.ts
@@ -13,33 +13,59 @@ describe('Prometheus config', () => {
     e2e.pages.AddDataSource.dataSourcePluginsV2(DATASOURCE_ID)
       .scrollIntoView()
       .should('be.visible') // prevents flakiness
-      .click();
+      .click({ force: true });
   });
 
-  it('should have a connection settings component', () => {
+  it(`should have the following components: 
+        connection settings
+        managed alerts
+        scrape interval
+        query timeout
+        default editor
+        disable metric lookup
+        prometheus type
+        cache level
+        incremental querying
+        disable recording rules
+        custom query parameters
+        http method
+      `, () => {
+    // connection settings
     e2e.components.DataSource.Prometheus.configPage.connectionSettings().should('be.visible');
-  });
-
-  it('should have a managed alerts component', () => {
+    // managed alerts
     cy.get(`#${selectors.components.DataSource.Prometheus.configPage.manageAlerts}`).scrollIntoView().should('exist');
-  });
-
-  it('should have a scrape interval component', () => {
+    // scrape interval
     e2e.components.DataSource.Prometheus.configPage.scrapeInterval().scrollIntoView().should('exist');
-  });
-
-  it('should have a query timeout component', () => {
+    // query timeout
     e2e.components.DataSource.Prometheus.configPage.queryTimeout().scrollIntoView().should('exist');
-  });
-
-  it('should have a default editor component', () => {
+    // default editor
     e2e.components.DataSource.Prometheus.configPage.defaultEditor().scrollIntoView().should('exist');
+    // disable metric lookup
+    cy.get(`#${selectors.components.DataSource.Prometheus.configPage.disableMetricLookup}`)
+      .scrollIntoView()
+      .should('exist');
+    // prometheus type
+    e2e.components.DataSource.Prometheus.configPage.prometheusType().scrollIntoView().should('exist');
+    // cache level
+    e2e.components.DataSource.Prometheus.configPage.cacheLevel().scrollIntoView().should('exist');
+    // incremental querying
+    cy.get(`#${selectors.components.DataSource.Prometheus.configPage.incrementalQuerying}`)
+      .scrollIntoView()
+      .should('exist');
+    // disable recording rules
+    cy.get(`#${selectors.components.DataSource.Prometheus.configPage.disableRecordingRules}`)
+      .scrollIntoView()
+      .should('exist');
+    // custom query parameters
+    e2e.components.DataSource.Prometheus.configPage.customQueryParameters().scrollIntoView().should('exist');
+    // http method
+    e2e.components.DataSource.Prometheus.configPage.httpMethod().scrollIntoView().should('exist');
   });
 
   it('should save the default editor when navigating to explore', () => {
     e2e.components.DataSource.Prometheus.configPage.defaultEditor().scrollIntoView().should('exist').click();
 
-    selectOption('Code');
+    selectOption('Builder');
 
     e2e.components.DataSource.Prometheus.configPage.connectionSettings().type('http://prom-url:9090');
 
@@ -50,21 +76,10 @@ describe('Prometheus config', () => {
     e2e.pages.Explore.visit();
 
     e2e.components.DataSourcePicker.container().should('be.visible').click();
-    cy.contains(DATASOURCE_TYPED_NAME).scrollIntoView().should('be.visible').click();
 
-    const monacoLoadingText = 'Loading...';
-    e2e.components.QueryField.container().should('be.visible').should('have.text', monacoLoadingText);
-    e2e.components.QueryField.container().should('be.visible').should('not.have.text', monacoLoadingText);
-  });
+    e2e.components.DataSourcePicker.container().type(`${DATASOURCE_TYPED_NAME}{enter}`);
 
-  it('should have a disable metric lookup component', () => {
-    cy.get(`#${selectors.components.DataSource.Prometheus.configPage.disableMetricLookup}`)
-      .scrollIntoView()
-      .should('exist');
-  });
-
-  it('should have a prometheus type component', () => {
-    e2e.components.DataSource.Prometheus.configPage.prometheusType().scrollIntoView().should('exist');
+    e2e.components.DataSource.Prometheus.queryEditor.builder.metricSelect().should('exist');
   });
 
   it('should allow a user to add the version when the Prom type is selected', () => {
@@ -79,12 +94,6 @@ describe('Prometheus config', () => {
     e2e.components.DataSource.Prometheus.configPage.cacheLevel().scrollIntoView().should('exist');
   });
 
-  it('should have an incremental querying component', () => {
-    cy.get(`#${selectors.components.DataSource.Prometheus.configPage.incrementalQuerying}`)
-      .scrollIntoView()
-      .should('exist');
-  });
-
   it('should allow a user to select a query overlap window when incremental querying is selected', () => {
     cy.get(`#${selectors.components.DataSource.Prometheus.configPage.incrementalQuerying}`)
       .scrollIntoView()
@@ -92,20 +101,6 @@ describe('Prometheus config', () => {
       .check({ force: true });
 
     e2e.components.DataSource.Prometheus.configPage.queryOverlapWindow().scrollIntoView().should('exist');
-  });
-
-  it('should have a disable recording rules component', () => {
-    cy.get(`#${selectors.components.DataSource.Prometheus.configPage.disableRecordingRules}`)
-      .scrollIntoView()
-      .should('exist');
-  });
-
-  it('should have a custom query parameters component', () => {
-    e2e.components.DataSource.Prometheus.configPage.customQueryParameters().scrollIntoView().should('exist');
-  });
-
-  it('should have an http method component', () => {
-    e2e.components.DataSource.Prometheus.configPage.httpMethod().scrollIntoView().should('exist');
   });
 
   // exemplars tested in exemplar.spec

--- a/e2e/various-suite/prometheus-config.spec.ts
+++ b/e2e/various-suite/prometheus-config.spec.ts
@@ -16,7 +16,7 @@ describe('Prometheus config', () => {
       .click({ force: true });
   });
 
-  it(`should have the following components: 
+  it(`should have the following components:
         connection settings
         managed alerts
         scrape interval


### PR DESCRIPTION
The config spec for Prometheus e2e tests was getting stuck choosing the data source while navigating to Explore page.

This fix reduces flakiness by consolidating tests and forcing the data source choice.

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
