### PR TITLE
Graph (old): Migrate right y axis to TimeSeries via custom.axisPlacement

### DIFF
--- a/public/app/plugins/panel/timeseries/__snapshots__/migrations.test.ts.snap
+++ b/public/app/plugins/panel/timeseries/__snapshots__/migrations.test.ts.snap
@@ -657,6 +657,10 @@ exports[`Graph Migrations twoYAxis 1`] = `
             "value": 25,
           },
           {
+            "id": "custom.axisPlacement",
+            "value": "right",
+          },
+          {
             "id": "custom.axisLabel",
             "value": "Y222",
           },

--- a/public/app/plugins/panel/timeseries/migrations.ts
+++ b/public/app/plugins/panel/timeseries/migrations.ts
@@ -658,6 +658,11 @@ function fillY2DynamicValues(
     }
   }
 
+  props.push({
+    id: `custom.axisPlacement`,
+    value: AxisPlacement.Right,
+  });
+
   // Add any custom property
   const y1G = y1.custom ?? {};
   const y2G = y2.custom ?? {};


### PR DESCRIPTION
this ensures we migrate the right y axis via placement, otherwise TimeSeries will fail to create an additional axis if a unique label, unit, min, max was not specified in the Graph (old) angular config.

<img width="1194" alt="image" src="https://github.com/grafana/grafana/assets/43234/347e9b2e-a133-4c58-a0c9-5a58880f7da2">

---

import:

<details><summary>angular-2-y-axes-migration.json</summary>

```json
{
  "annotations": {
    "list": [
      {
        "builtIn": 1,
        "datasource": {
          "type": "grafana",
          "uid": "-- Grafana --"
        },
        "enable": true,
        "hide": true,
        "iconColor": "rgba(0, 211, 255, 1)",
        "name": "Annotations & Alerts",
        "type": "dashboard"
      }
    ]
  },
  "editable": true,
  "fiscalYearStartMonth": 0,
  "graphTooltip": 0,
  "id": 967,
  "links": [],
  "panels": [
    {
      "aliasColors": {},
      "bars": false,
      "dashLength": 10,
      "dashes": false,
      "datasource": {
        "type": "grafana-testdata-datasource",
        "uid": "PD8C576611E62080A"
      },
      "editable": true,
      "error": false,
      "fieldConfig": {
        "defaults": {
          "links": []
        },
        "overrides": []
      },
      "fill": 1,
      "fillGradient": 0,
      "gridPos": {
        "h": 13,
        "w": 15,
        "x": 0,
        "y": 0
      },
      "hiddenSeries": false,
      "id": 2,
      "legend": {
        "avg": false,
        "current": false,
        "max": false,
        "min": false,
        "show": true,
        "total": false,
        "values": false
      },
      "lines": true,
      "linewidth": 2,
      "nullPointMode": "connected",
      "options": {
        "alertThreshold": true
      },
      "percentage": false,
      "pluginVersion": "11.0.0-pre",
      "pointradius": 5,
      "points": false,
      "renderer": "flot",
      "seriesOverrides": [
        {
          "alias": "B-series",
          "yaxis": 2
        }
      ],
      "spaceLength": 10,
      "stack": false,
      "steppedLine": false,
      "targets": [
        {
          "datasource": {
            "type": "grafana-testdata-datasource",
            "uid": "PD8C576611E62080A"
          },
          "rawFrameContent": "[\n  {\n    \"schema\": {\n      \"refId\": \"A\",\n      \"fields\": [\n        {\n          \"config\": {},\n          \"name\": \"time\",\n          \"type\": \"time\",\n          \"typeInfo\": {\n            \"frame\": \"time.Time\"\n          }\n        },\n        {\n          \"config\": {},\n          \"name\": \"A-series\",\n          \"type\": \"number\",\n          \"typeInfo\": {\n            \"frame\": \"int64\",\n            \"nullable\": true\n          }\n        }\n      ]\n    },\n    \"data\": {\n      \"values\": [\n        [\n          1708966516445,\n          1708970836445,\n          1708975156445,\n          1708979476445,\n          1708983796445,\n          1708988116445\n        ],\n        [\n          1,\n          20,\n          90,\n          30,\n          5,\n          0\n        ]\n      ]\n    }\n  },\n  {\n    \"schema\": {\n      \"refId\": \"B\",\n      \"fields\": [\n        {\n          \"config\": {},\n          \"name\": \"time\",\n          \"type\": \"time\",\n          \"typeInfo\": {\n            \"frame\": \"time.Time\"\n          }\n        },\n        {\n          \"config\": {},\n          \"name\": \"B-series\",\n          \"type\": \"number\",\n          \"typeInfo\": {\n            \"frame\": \"int64\",\n            \"nullable\": true\n          }\n        }\n      ]\n    },\n    \"data\": {\n      \"values\": [\n        [\n          1708966516445,\n          1708970836445,\n          1708975156445,\n          1708979476445,\n          1708983796445,\n          1708988116445\n        ],\n        [\n          2000,\n          3000,\n          4000,\n          1000,\n          3000,\n          10000\n        ]\n      ]\n    }\n  }\n]",
          "refId": "A",
          "scenarioId": "raw_frame"
        }
      ],
      "thresholds": [],
      "timeRegions": [],
      "title": "Reproduced with embedded data",
      "tooltip": {
        "msResolution": false,
        "shared": true,
        "sort": 0,
        "value_type": "cumulative"
      },
      "type": "graph",
      "xaxis": {
        "mode": "time",
        "show": true,
        "values": []
      },
      "yaxes": [
        {
          "$$hashKey": "object:41",
          "format": "percent",
          "label": "Perecent",
          "logBase": 1,
          "show": true
        },
        {
          "$$hashKey": "object:42",
          "format": "short",
          "label": "Pressure",
          "logBase": 1,
          "show": true
        }
      ],
      "yaxis": {
        "align": false
      }
    },
    {
      "aliasColors": {},
      "bars": false,
      "dashLength": 10,
      "dashes": false,
      "datasource": {
        "type": "datasource",
        "uid": "-- Dashboard --"
      },
      "editable": true,
      "error": false,
      "fieldConfig": {
        "defaults": {
          "links": []
        },
        "overrides": []
      },
      "fill": 1,
      "fillGradient": 0,
      "gridPos": {
        "h": 13,
        "w": 15,
        "x": 0,
        "y": 13
      },
      "hiddenSeries": false,
      "id": 3,
      "legend": {
        "avg": false,
        "current": false,
        "max": false,
        "min": false,
        "show": true,
        "total": false,
        "values": false
      },
      "lines": true,
      "linewidth": 2,
      "nullPointMode": "connected",
      "options": {
        "alertThreshold": true
      },
      "percentage": false,
      "pluginVersion": "11.0.0-pre",
      "pointradius": 5,
      "points": false,
      "renderer": "flot",
      "seriesOverrides": [
        {
          "alias": "B-series",
          "yaxis": 2
        }
      ],
      "spaceLength": 10,
      "stack": false,
      "steppedLine": false,
      "targets": [
        {
          "datasource": {
            "type": "datasource",
            "uid": "-- Dashboard --"
          },
          "panelId": 2,
          "refId": "A"
        }
      ],
      "thresholds": [],
      "timeRegions": [],
      "title": "Reproduced with embedded data",
      "tooltip": {
        "msResolution": false,
        "shared": true,
        "sort": 0,
        "value_type": "cumulative"
      },
      "type": "graph",
      "xaxis": {
        "mode": "time",
        "show": true,
        "values": []
      },
      "yaxes": [
        {
          "$$hashKey": "object:41",
          "format": "short",
          "label": "",
          "logBase": 1,
          "show": true
        },
        {
          "$$hashKey": "object:42",
          "format": "short",
          "label": "",
          "logBase": 1,
          "show": true
        }
      ],
      "yaxis": {
        "align": false
      }
    }
  ],
  "schemaVersion": 39,
  "tags": [
    "debug",
    "debug-graph"
  ],
  "templating": {
    "list": []
  },
  "time": {
    "from": "2024-02-26T16:55:25.516Z",
    "to": "2024-02-26T22:55:25.517Z"
  },
  "timepicker": {},
  "timezone": "",
  "title": "angular-2-y-axes-migration",
  "uid": "cddztjq2hb6rkf",
  "version": 5,
  "weekStart": ""
}
```
</details>

http://localhost:3000/d/cddztjq2hb6rkf/angular-2-y-axes-migration?orgId=1

try migration:

http://localhost:3000/d/cddztjq2hb6rkf/angular-2-y-axes-migration?orgId=1&__feature.autoMigrateOldPanels

the bottom panel should have 2 axes after this PR, but only 1 without it.