### PR TITLE
Docs: Update "What's new in G10?"

### DIFF
--- a/docs/sources/whatsnew/whats-new-in-v10-0.md
+++ b/docs/sources/whatsnew/whats-new-in-v10-0.md
@@ -423,4 +423,4 @@ The answer is Private Data Source Connect (PDC), available now in public preview
 
 ### App plugins can start using react-router v6
 
-We've added support for using `react-router` v6 in app plugins. However, we still support the use of `react-router` v5 for plugins that need to support a minimum Grafana version earlier than v10.  For more information, refer to our [react-router migration guide](https://grafana.com/developers/plugin-tools/migration-guides/update-from-grafana-versions/migrate-9_x-to-10_x#update-to-react-router-v6).
+We've added support for using `react-router` v6 in app plugins. However, we still support the use of `react-router` v5 for plugins that need to support a minimum Grafana version earlier than v10. For more information, refer to our [react-router migration guide](https://grafana.com/developers/plugin-tools/migration-guides/update-from-grafana-versions/migrate-9_x-to-10_x#update-to-react-router-v6).

--- a/docs/sources/whatsnew/whats-new-in-v10-0.md
+++ b/docs/sources/whatsnew/whats-new-in-v10-0.md
@@ -419,7 +419,6 @@ To query these data sources from Grafana Cloud, you've had to open your private 
 
 The answer is Private Data Source Connect (PDC), available now in public preview in Grafana Cloud Pro and Advanced. PDC uses SOCKS over SSH to establish a secure connection between a lightweight PDC agent you deploy on your network and your Grafana Cloud stack. PDC keeps the network connection totally under your control. It’s easy to set up and manage, uses industry-standard security protocols, and works across public cloud vendors and a wide variety of secure networks. Learn more in our [Private data source connect documentation](/docs/grafana-cloud/data-configuration/configure-private-datasource-connect).
 
-
 ## Plugins
 
 ### App plugins can start using react-router v6

--- a/docs/sources/whatsnew/whats-new-in-v10-0.md
+++ b/docs/sources/whatsnew/whats-new-in-v10-0.md
@@ -423,4 +423,4 @@ The answer is Private Data Source Connect (PDC), available now in public preview
 
 ### App plugins can start using react-router v6
 
-While we keep supporting plugins that use react-router v5, we also added support for using react-router v6 in your app plugin. Please check out our [react-router migration guide](https://grafana.com/developers/plugin-tools/migration-guides/update-from-grafana-versions/migrate-9_x-to-10_x#update-to-react-router-v6) for more information.
+We've added support for using `react-router` v6 in app plugins. However, we still support the use of `react-router` v5 for plugins that need to support a minimum Grafana version earlier than v10.  For more information, refer to our [react-router migration guide](https://grafana.com/developers/plugin-tools/migration-guides/update-from-grafana-versions/migrate-9_x-to-10_x#update-to-react-router-v6).

--- a/docs/sources/whatsnew/whats-new-in-v10-0.md
+++ b/docs/sources/whatsnew/whats-new-in-v10-0.md
@@ -418,3 +418,10 @@ Some data sources, like MySQL databases, Prometheus instances or Elasticsearch c
 To query these data sources from Grafana Cloud, you've had to open your private network to a range of IP addresses, a non-starter for many IT Security teams. The challenge is, how do you connect to your private data from Grafana Cloud, without exposing your network?
 
 The answer is Private Data Source Connect (PDC), available now in public preview in Grafana Cloud Pro and Advanced. PDC uses SOCKS over SSH to establish a secure connection between a lightweight PDC agent you deploy on your network and your Grafana Cloud stack. PDC keeps the network connection totally under your control. It’s easy to set up and manage, uses industry-standard security protocols, and works across public cloud vendors and a wide variety of secure networks. Learn more in our [Private data source connect documentation](/docs/grafana-cloud/data-configuration/configure-private-datasource-connect).
+
+
+## Plugins
+
+### App plugins can start using react-router v6
+
+While we keep supporting plugins that use react-router v5, we also added support for using react-router v6 in your app plugin. Please check out our [react-router migration guide](https://grafana.com/developers/plugin-tools/migration-guides/update-from-grafana-versions/migrate-9_x-to-10_x#update-to-react-router-v6) for more information.


### PR DESCRIPTION
Fixes https://github.com/grafana/grafana/issues/81988.

### What changed?

In Grafana 10 we introduced support for using react-router v6 in app plugins. This PR adds a link to our [migration guide on the developer portal](https://grafana.com/developers/plugin-tools/migration-guides/update-from-grafana-versions/migrate-9_x-to-10_x#update-to-react-router-v6) in order to make it easier to find.


**Screenshot**
---
![Screenshot 2024-02-27 at 06 30 32](https://github.com/grafana/grafana/assets/9974811/6a1ef075-05d6-4fdc-a5ef-730790a8d004)
