### PR TITLE
Alerting: Reduce set of fields that could trigger alert state change

### DIFF
--- a/pkg/services/ngalert/schedule/registry.go
+++ b/pkg/services/ngalert/schedule/registry.go
@@ -280,6 +280,24 @@ func (r ruleWithFolder) Fingerprint() fingerprint {
 		keys = make([]string, maxLen)
 	}
 
+	writeLabels := func(lbls map[string]string) {
+		// maps do not guarantee predictable sequence of keys.
+		// Therefore, to make hash stable, we need to sort keys
+		if len(lbls) == 0 {
+			return
+		}
+		idx := 0
+		for labelName := range lbls {
+			keys[idx] = labelName
+			idx++
+		}
+		sub := keys[:idx]
+		sort.Strings(sub)
+		for _, name := range sub {
+			writeString(name)
+			writeString(lbls[name])
+		}
+	}
 	writeQuery := func() {
 		// The order of queries is not important as they represent an expression tree.
 		// Therefore, the order of elements should not change the hash. Sort by RefID because it is the unique key.
@@ -308,6 +326,7 @@ func (r ruleWithFolder) Fingerprint() fingerprint {
 	writeString(rule.Title)
 	writeString(rule.NamespaceUID)
 	writeString(r.folderTitle)
+	writeLabels(rule.Labels)
 	writeString(rule.Condition)
 	writeQuery()
 
@@ -328,6 +347,7 @@ func (r ruleWithFolder) Fingerprint() fingerprint {
 	writeInt(rule.OrgID)
 	writeInt(rule.IntervalSeconds)
 	writeInt(int64(rule.For))
+	writeLabels(rule.Annotations)
 	if rule.DashboardUID != nil {
 		writeString(*rule.DashboardUID)
 	}

--- a/pkg/services/ngalert/schedule/registry.go
+++ b/pkg/services/ngalert/schedule/registry.go
@@ -280,24 +280,6 @@ func (r ruleWithFolder) Fingerprint() fingerprint {
 		keys = make([]string, maxLen)
 	}
 
-	writeLabels := func(lbls map[string]string) {
-		// maps do not guarantee predictable sequence of keys.
-		// Therefore, to make hash stable, we need to sort keys
-		if len(lbls) == 0 {
-			return
-		}
-		idx := 0
-		for labelName := range lbls {
-			keys[idx] = labelName
-			idx++
-		}
-		sub := keys[:idx]
-		sort.Strings(sub)
-		for _, name := range sub {
-			writeString(name)
-			writeString(lbls[name])
-		}
-	}
 	writeQuery := func() {
 		// The order of queries is not important as they represent an expression tree.
 		// Therefore, the order of elements should not change the hash. Sort by RefID because it is the unique key.
@@ -326,7 +308,6 @@ func (r ruleWithFolder) Fingerprint() fingerprint {
 	writeString(rule.Title)
 	writeString(rule.NamespaceUID)
 	writeString(r.folderTitle)
-	writeLabels(rule.Labels)
 	writeString(rule.Condition)
 	writeQuery()
 
@@ -347,7 +328,6 @@ func (r ruleWithFolder) Fingerprint() fingerprint {
 	writeInt(rule.OrgID)
 	writeInt(rule.IntervalSeconds)
 	writeInt(int64(rule.For))
-	writeLabels(rule.Annotations)
 	if rule.DashboardUID != nil {
 		writeString(*rule.DashboardUID)
 	}

--- a/pkg/services/ngalert/schedule/registry.go
+++ b/pkg/services/ngalert/schedule/registry.go
@@ -345,9 +345,7 @@ func (r ruleWithFolder) Fingerprint() fingerprint {
 	// TODO consider removing fields below from the fingerprint
 	writeInt(rule.ID)
 	writeInt(rule.OrgID)
-	writeInt(rule.IntervalSeconds)
 	writeInt(int64(rule.For))
-	writeLabels(rule.Annotations)
 	if rule.DashboardUID != nil {
 		writeString(*rule.DashboardUID)
 	}

--- a/pkg/services/ngalert/schedule/registry_test.go
+++ b/pkg/services/ngalert/schedule/registry_test.go
@@ -369,10 +369,12 @@ func TestRuleWithFolderFingerprint(t *testing.T) {
 		f2 := ruleWithFolder{rule: rule, folderTitle: uuid.NewString()}.Fingerprint()
 		require.NotEqual(t, f, f2)
 	})
-	t.Run("Version and Updated should be excluded from fingerprint", func(t *testing.T) {
+	t.Run("some fields should be excluded from fingerprint", func(t *testing.T) {
 		cp := models.CopyRule(rule)
 		cp.Version++
 		cp.Updated = cp.Updated.Add(1 * time.Second)
+		cp.Annotations = map[string]string{"key-annotation": "value-annotation"}
+		cp.Labels = map[string]string{"key-label": "value-label"}
 
 		f2 := ruleWithFolder{rule: cp, folderTitle: title}.Fingerprint()
 		require.Equal(t, f, f2)
@@ -459,8 +461,10 @@ func TestRuleWithFolderFingerprint(t *testing.T) {
 		}
 
 		excludedFields := map[string]struct{}{
-			"Version": {},
-			"Updated": {},
+			"Version":     {},
+			"Updated":     {},
+			"Labels":      {},
+			"Annotations": {},
 		}
 
 		tp := reflect.TypeOf(rule).Elem()

--- a/pkg/services/ngalert/schedule/registry_test.go
+++ b/pkg/services/ngalert/schedule/registry_test.go
@@ -369,12 +369,10 @@ func TestRuleWithFolderFingerprint(t *testing.T) {
 		f2 := ruleWithFolder{rule: rule, folderTitle: uuid.NewString()}.Fingerprint()
 		require.NotEqual(t, f, f2)
 	})
-	t.Run("some fields should be excluded from fingerprint", func(t *testing.T) {
+	t.Run("Version and Updated should be excluded from fingerprint", func(t *testing.T) {
 		cp := models.CopyRule(rule)
 		cp.Version++
 		cp.Updated = cp.Updated.Add(1 * time.Second)
-		cp.Annotations = map[string]string{"key-annotation": "value-annotation"}
-		cp.Labels = map[string]string{"key-label": "value-label"}
 
 		f2 := ruleWithFolder{rule: cp, folderTitle: title}.Fingerprint()
 		require.Equal(t, f, f2)
@@ -461,10 +459,8 @@ func TestRuleWithFolderFingerprint(t *testing.T) {
 		}
 
 		excludedFields := map[string]struct{}{
-			"Version":     {},
-			"Updated":     {},
-			"Labels":      {},
-			"Annotations": {},
+			"Version": {},
+			"Updated": {},
 		}
 
 		tp := reflect.TypeOf(rule).Elem()

--- a/pkg/services/ngalert/schedule/registry_test.go
+++ b/pkg/services/ngalert/schedule/registry_test.go
@@ -369,10 +369,12 @@ func TestRuleWithFolderFingerprint(t *testing.T) {
 		f2 := ruleWithFolder{rule: rule, folderTitle: uuid.NewString()}.Fingerprint()
 		require.NotEqual(t, f, f2)
 	})
-	t.Run("Version and Updated should be excluded from fingerprint", func(t *testing.T) {
+	t.Run("Version, Updated, IntervalSeconds and Annotations should be excluded from fingerprint", func(t *testing.T) {
 		cp := models.CopyRule(rule)
 		cp.Version++
 		cp.Updated = cp.Updated.Add(1 * time.Second)
+		cp.IntervalSeconds++
+		cp.Annotations["test"] = "test"
 
 		f2 := ruleWithFolder{rule: cp, folderTitle: title}.Fingerprint()
 		require.Equal(t, f, f2)
@@ -459,8 +461,10 @@ func TestRuleWithFolderFingerprint(t *testing.T) {
 		}
 
 		excludedFields := map[string]struct{}{
-			"Version": {},
-			"Updated": {},
+			"Version":         {},
+			"Updated":         {},
+			"IntervalSeconds": {},
+			"Annotations":     {},
 		}
 
 		tp := reflect.TypeOf(rule).Elem()

--- a/pkg/services/ngalert/schedule/registry_test.go
+++ b/pkg/services/ngalert/schedule/registry_test.go
@@ -374,6 +374,7 @@ func TestRuleWithFolderFingerprint(t *testing.T) {
 		cp.Version++
 		cp.Updated = cp.Updated.Add(1 * time.Second)
 		cp.IntervalSeconds++
+		cp.Annotations = make(map[string]string)
 		cp.Annotations["test"] = "test"
 
 		f2 := ruleWithFolder{rule: cp, folderTitle: title}.Fingerprint()


### PR DESCRIPTION
**What is this feature?**

We want to avoid too much change of alert state based on change on alert's fields. For that we ignore some fields from the diff.

This is a rather cautious first pull request, ~~but I would love to make another pull request for `IntervalSeconds`~~. We could even go further as [pointed](https://github.com/grafana/grafana/issues/83250) by @yuri-tceretian but I can do in another PR.

**Why do we need this feature?**

There is great issue by @yuri-tceretian  that detail all fo this https://github.com/grafana/grafana/issues/83250

**Who is this feature for?**

Everyone who use alerting and updates.

**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/grafana/issues/83250

cc @yuri-tceretian 