### PR TITLE
E2C: Refactor api with dataWithMockDelay helper:

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -381,6 +381,7 @@ playwright.config.ts @grafana/plugins-platform-frontend
 /public/app/core/components/TimelineChart/ @grafana/dataviz-squad
 /public/app/features/all.ts @grafana/grafana-frontend-platform
 /public/app/features/admin/ @grafana/identity-access-team
+/public/app/features/admin/migrate-to-cloud @grafana/grafana-frontend-platform
 /public/app/features/auth-config/ @grafana/identity-access-team
 /public/app/features/annotations/ @grafana/dashboards-squad
 /public/app/features/api-keys/ @grafana/identity-access-team

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -381,7 +381,10 @@ playwright.config.ts @grafana/plugins-platform-frontend
 /public/app/core/components/TimelineChart/ @grafana/dataviz-squad
 /public/app/features/all.ts @grafana/grafana-frontend-platform
 /public/app/features/admin/ @grafana/identity-access-team
+
+# Temp owners until Enterprise team takes over
 /public/app/features/admin/migrate-to-cloud @grafana/grafana-frontend-platform
+
 /public/app/features/auth-config/ @grafana/identity-access-team
 /public/app/features/annotations/ @grafana/dashboards-squad
 /public/app/features/api-keys/ @grafana/identity-access-team

--- a/public/app/features/admin/migrate-to-cloud/api.ts
+++ b/public/app/features/admin/migrate-to-cloud/api.ts
@@ -40,6 +40,14 @@ const MOCK_DELAY_MS = 1000;
 const MOCK_TOKEN = 'TODO_thisWillBeABigLongToken';
 let HAS_MIGRATION_TOKEN = false;
 
+function dataWithMockDelay<T>(data: T): Promise<{ data: T }> {
+  return new Promise((resolve) => {
+    setTimeout(() => {
+      resolve({ data });
+    }, MOCK_DELAY_MS);
+  });
+}
+
 export const migrateToCloudAPI = createApi({
   tagTypes: ['migrationToken'],
   reducerPath: 'migrateToCloudAPI',
@@ -47,38 +55,29 @@ export const migrateToCloudAPI = createApi({
   endpoints: (builder) => ({
     // TODO :)
     getStatus: builder.query<MigrateToCloudStatusDTO, void>({
-      queryFn: () => ({ data: { enabled: false } }),
+      queryFn: () => dataWithMockDelay({ enabled: true }),
     }),
+
     createMigrationToken: builder.mutation<CreateMigrationTokenResponseDTO, void>({
       invalidatesTags: ['migrationToken'],
       queryFn: async () => {
-        return new Promise((resolve) => {
-          setTimeout(() => {
-            HAS_MIGRATION_TOKEN = true;
-            resolve({ data: { token: MOCK_TOKEN } });
-          }, MOCK_DELAY_MS);
-        });
+        HAS_MIGRATION_TOKEN = true;
+        return dataWithMockDelay({ token: MOCK_TOKEN });
       },
     }),
+
     deleteMigrationToken: builder.mutation<void, void>({
       invalidatesTags: ['migrationToken'],
       queryFn: async () => {
-        return new Promise((resolve) => {
-          setTimeout(() => {
-            HAS_MIGRATION_TOKEN = false;
-            resolve({ data: undefined });
-          }, MOCK_DELAY_MS);
-        });
+        HAS_MIGRATION_TOKEN = false;
+        return dataWithMockDelay(undefined);
       },
     }),
+
     hasMigrationToken: builder.query<boolean, void>({
       providesTags: ['migrationToken'],
       queryFn: async () => {
-        return new Promise((resolve) => {
-          setTimeout(() => {
-            resolve({ data: HAS_MIGRATION_TOKEN });
-          }, MOCK_DELAY_MS);
-        });
+        return dataWithMockDelay(HAS_MIGRATION_TOKEN);
       },
     }),
   }),


### PR DESCRIPTION
Just a tiny refactor to hide away all the Promise -> setTimeout boilerplate when mocking the APIs.

Also updated codeowners to set frontend platform as (temporary) owners of E2C.