### PR TITLE
Alerting: Support deleting rule groups in the provisioning API

### DIFF
--- a/pkg/services/ngalert/api/api_provisioning_test.go
+++ b/pkg/services/ngalert/api/api_provisioning_test.go
@@ -343,24 +343,40 @@ func TestProvisioningApi(t *testing.T) {
 	})
 
 	t.Run("alert rule groups", func(t *testing.T) {
-		t.Run("are present, GET returns 200", func(t *testing.T) {
+		t.Run("are present", func(t *testing.T) {
 			sut := createProvisioningSrvSut(t)
 			rc := createTestRequestCtx()
 			insertRule(t, sut, createTestAlertRule("rule", 1))
 
-			response := sut.RouteGetAlertRuleGroup(&rc, "folder-uid", "my-cool-group")
+			t.Run("GET returns 200", func(t *testing.T) {
+				response := sut.RouteGetAlertRuleGroup(&rc, "folder-uid", "my-cool-group")
 
-			require.Equal(t, 200, response.Status())
+				require.Equal(t, 200, response.Status())
+			})
+
+			t.Run("DELETE returns 204", func(t *testing.T) {
+				response := sut.RouteDeleteAlertRuleGroup(&rc, "folder-uid", "my-cool-group")
+
+				require.Equal(t, 204, response.Status())
+			})
 		})
 
-		t.Run("are missing, GET returns 404", func(t *testing.T) {
+		t.Run("are missing", func(t *testing.T) {
 			sut := createProvisioningSrvSut(t)
 			rc := createTestRequestCtx()
 			insertRule(t, sut, createTestAlertRule("rule", 1))
 
-			response := sut.RouteGetAlertRuleGroup(&rc, "folder-uid", "does not exist")
+			t.Run("GET returns 404", func(t *testing.T) {
+				response := sut.RouteGetAlertRuleGroup(&rc, "folder-uid", "does not exist")
 
-			require.Equal(t, 404, response.Status())
+				require.Equal(t, 404, response.Status())
+			})
+
+			t.Run("DELETE returns 404", func(t *testing.T) {
+				response := sut.RouteDeleteAlertRuleGroup(&rc, "folder-uid", "does not exist")
+
+				require.Equal(t, 404, response.Status())
+			})
 		})
 
 		t.Run("are invalid at group level", func(t *testing.T) {
@@ -1587,6 +1603,7 @@ func createTestEnv(t *testing.T, testConfig string) testEnvironment {
 		})
 	sqlStore := db.InitTestDB(t)
 	store := store.DBstore{
+		Logger:   log,
 		SQLStore: sqlStore,
 		Cfg: setting.UnifiedAlertingSettings{
 			BaseInterval: time.Second * 10,

--- a/pkg/services/ngalert/api/authorization.go
+++ b/pkg/services/ngalert/api/authorization.go
@@ -253,7 +253,8 @@ func (api *API) authorize(method, path string) web.Handler {
 		http.MethodPost + "/api/v1/provisioning/alert-rules",
 		http.MethodPut + "/api/v1/provisioning/alert-rules/{UID}",
 		http.MethodDelete + "/api/v1/provisioning/alert-rules/{UID}",
-		http.MethodPut + "/api/v1/provisioning/folder/{FolderUID}/rule-groups/{Group}":
+		http.MethodPut + "/api/v1/provisioning/folder/{FolderUID}/rule-groups/{Group}",
+		http.MethodDelete + "/api/v1/provisioning/folder/{FolderUID}/rule-groups/{Group}":
 		eval = ac.EvalPermission(ac.ActionAlertingProvisioningWrite) // organization scope
 	case http.MethodGet + "/api/v1/notifications/time-intervals/{name}",
 		http.MethodGet + "/api/v1/notifications/time-intervals":

--- a/pkg/services/ngalert/api/authorization_test.go
+++ b/pkg/services/ngalert/api/authorization_test.go
@@ -40,7 +40,7 @@ func TestAuthorize(t *testing.T) {
 		}
 		paths[p] = methods
 	}
-	require.Len(t, paths, 64)
+	require.Len(t, paths, 65)
 
 	ac := acmock.New()
 	api := &API{AccessControl: ac}

--- a/pkg/services/ngalert/api/authorization_test.go
+++ b/pkg/services/ngalert/api/authorization_test.go
@@ -40,7 +40,7 @@ func TestAuthorize(t *testing.T) {
 		}
 		paths[p] = methods
 	}
-	require.Len(t, paths, 65)
+	require.Len(t, paths, 64)
 
 	ac := acmock.New()
 	api := &API{AccessControl: ac}

--- a/pkg/services/ngalert/api/generated_base_api_provisioning.go
+++ b/pkg/services/ngalert/api/generated_base_api_provisioning.go
@@ -21,6 +21,7 @@ import (
 
 type ProvisioningApi interface {
 	RouteDeleteAlertRule(*contextmodel.ReqContext) response.Response
+	RouteDeleteAlertRuleGroup(*contextmodel.ReqContext) response.Response
 	RouteDeleteContactpoints(*contextmodel.ReqContext) response.Response
 	RouteDeleteMuteTiming(*contextmodel.ReqContext) response.Response
 	RouteDeleteTemplate(*contextmodel.ReqContext) response.Response
@@ -56,6 +57,12 @@ func (f *ProvisioningApiHandler) RouteDeleteAlertRule(ctx *contextmodel.ReqConte
 	// Parse Path Parameters
 	uIDParam := web.Params(ctx.Req)[":UID"]
 	return f.handleRouteDeleteAlertRule(ctx, uIDParam)
+}
+func (f *ProvisioningApiHandler) RouteDeleteAlertRuleGroup(ctx *contextmodel.ReqContext) response.Response {
+	// Parse Path Parameters
+	folderUIDParam := web.Params(ctx.Req)[":FolderUID"]
+	groupParam := web.Params(ctx.Req)[":Group"]
+	return f.handleRouteDeleteAlertRuleGroup(ctx, folderUIDParam, groupParam)
 }
 func (f *ProvisioningApiHandler) RouteDeleteContactpoints(ctx *contextmodel.ReqContext) response.Response {
 	// Parse Path Parameters
@@ -234,6 +241,18 @@ func (api *API) RegisterProvisioningApiEndpoints(srv ProvisioningApi, m *metrics
 				http.MethodDelete,
 				"/api/v1/provisioning/alert-rules/{UID}",
 				api.Hooks.Wrap(srv.RouteDeleteAlertRule),
+				m,
+			),
+		)
+		group.Delete(
+			toMacaronPath("/api/v1/provisioning/folder/{FolderUID}/rule-groups/{Group}"),
+			requestmeta.SetOwner(requestmeta.TeamAlerting),
+			requestmeta.SetSLOGroup(requestmeta.SLOGroupHighSlow),
+			api.authorize(http.MethodDelete, "/api/v1/provisioning/folder/{FolderUID}/rule-groups/{Group}"),
+			metrics.Instrument(
+				http.MethodDelete,
+				"/api/v1/provisioning/folder/{FolderUID}/rule-groups/{Group}",
+				api.Hooks.Wrap(srv.RouteDeleteAlertRuleGroup),
 				m,
 			),
 		)

--- a/pkg/services/ngalert/api/provisioning.go
+++ b/pkg/services/ngalert/api/provisioning.go
@@ -135,3 +135,7 @@ func (f *ProvisioningApiHandler) handleRouteExportMuteTiming(ctx *contextmodel.R
 func (f *ProvisioningApiHandler) handleRouteExportMuteTimings(ctx *contextmodel.ReqContext) response.Response {
 	return f.svc.RouteGetMuteTimingsExport(ctx)
 }
+
+func (f *ProvisioningApiHandler) handleRouteDeleteAlertRuleGroup(ctx *contextmodel.ReqContext, folderUID, group string) response.Response {
+	return f.svc.RouteDeleteAlertRuleGroup(ctx, folderUID, group)
+}

--- a/pkg/services/ngalert/api/tooling/api.json
+++ b/pkg/services/ngalert/api/tooling/api.json
@@ -5962,6 +5962,44 @@
    }
   },
   "/v1/provisioning/folder/{FolderUID}/rule-groups/{Group}": {
+   "delete": {
+    "description": "Delete rule group",
+    "operationId": "RouteDeleteAlertRuleGroup",
+    "parameters": [
+     {
+      "in": "path",
+      "name": "FolderUID",
+      "required": true,
+      "type": "string"
+     },
+     {
+      "in": "path",
+      "name": "Group",
+      "required": true,
+      "type": "string"
+     }
+    ],
+    "responses": {
+     "204": {
+      "description": " The alert rule group was deleted successfully."
+     },
+     "403": {
+      "description": "ForbiddenError",
+      "schema": {
+       "$ref": "#/definitions/ForbiddenError"
+      }
+     },
+     "404": {
+      "description": "NotFound",
+      "schema": {
+       "$ref": "#/definitions/NotFound"
+      }
+     }
+    },
+    "tags": [
+     "provisioning"
+    ]
+   },
    "get": {
     "operationId": "RouteGetAlertRuleGroup",
     "parameters": [

--- a/pkg/services/ngalert/api/tooling/definitions/provisioning_alert_rules.go
+++ b/pkg/services/ngalert/api/tooling/definitions/provisioning_alert_rules.go
@@ -168,6 +168,15 @@ type ProvisionedAlertRule struct {
 //       200: AlertRuleGroup
 //       404: description: Not found.
 
+// swagger:route DELETE /v1/provisioning/folder/{FolderUID}/rule-groups/{Group} provisioning stable RouteDeleteAlertRuleGroup
+//
+// Delete rule group
+//
+//     Responses:
+//       204: description: The alert rule group was deleted successfully.
+//       403: ForbiddenError
+//       404: NotFound
+
 // swagger:route GET /v1/provisioning/folder/{FolderUID}/rule-groups/{Group}/export provisioning stable RouteGetAlertRuleGroupExport
 //
 // Export an alert rule group in provisioning file format.
@@ -192,13 +201,13 @@ type ProvisionedAlertRule struct {
 //       200: AlertRuleGroup
 //       400: ValidationError
 
-// swagger:parameters RouteGetAlertRuleGroup RoutePutAlertRuleGroup RouteGetAlertRuleGroupExport
+// swagger:parameters RouteGetAlertRuleGroup RoutePutAlertRuleGroup RouteGetAlertRuleGroupExport RouteDeleteAlertRuleGroup
 type FolderUIDPathParam struct {
 	// in:path
 	FolderUID string `json:"FolderUID"`
 }
 
-// swagger:parameters RouteGetAlertRuleGroup RoutePutAlertRuleGroup RouteGetAlertRuleGroupExport
+// swagger:parameters RouteGetAlertRuleGroup RoutePutAlertRuleGroup RouteGetAlertRuleGroupExport RouteDeleteAlertRuleGroup
 type RuleGroupPathParam struct {
 	// in:path
 	Group string `json:"Group"`

--- a/pkg/services/ngalert/api/tooling/post.json
+++ b/pkg/services/ngalert/api/tooling/post.json
@@ -7721,6 +7721,44 @@
    }
   },
   "/v1/provisioning/folder/{FolderUID}/rule-groups/{Group}": {
+   "delete": {
+    "description": "Delete rule group",
+    "operationId": "RouteDeleteAlertRuleGroup",
+    "parameters": [
+     {
+      "in": "path",
+      "name": "FolderUID",
+      "required": true,
+      "type": "string"
+     },
+     {
+      "in": "path",
+      "name": "Group",
+      "required": true,
+      "type": "string"
+     }
+    ],
+    "responses": {
+     "204": {
+      "description": " The alert rule group was deleted successfully."
+     },
+     "403": {
+      "description": "ForbiddenError",
+      "schema": {
+       "$ref": "#/definitions/ForbiddenError"
+      }
+     },
+     "404": {
+      "description": "NotFound",
+      "schema": {
+       "$ref": "#/definitions/NotFound"
+      }
+     }
+    },
+    "tags": [
+     "provisioning"
+    ]
+   },
    "get": {
     "operationId": "RouteGetAlertRuleGroup",
     "parameters": [

--- a/pkg/services/ngalert/api/tooling/spec.json
+++ b/pkg/services/ngalert/api/tooling/spec.json
@@ -2690,6 +2690,45 @@
             }
           }
         }
+      },
+      "delete": {
+        "description": "Delete rule group",
+        "tags": [
+          "provisioning",
+          "stable"
+        ],
+        "operationId": "RouteDeleteAlertRuleGroup",
+        "parameters": [
+          {
+            "type": "string",
+            "name": "FolderUID",
+            "in": "path",
+            "required": true
+          },
+          {
+            "type": "string",
+            "name": "Group",
+            "in": "path",
+            "required": true
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": " The alert rule group was deleted successfully."
+          },
+          "403": {
+            "description": "ForbiddenError",
+            "schema": {
+              "$ref": "#/definitions/ForbiddenError"
+            }
+          },
+          "404": {
+            "description": "NotFound",
+            "schema": {
+              "$ref": "#/definitions/NotFound"
+            }
+          }
+        }
       }
     },
     "/v1/provisioning/folder/{FolderUID}/rule-groups/{Group}/export": {

--- a/public/api-merged.json
+++ b/public/api-merged.json
@@ -10904,6 +10904,44 @@
             }
           }
         }
+      },
+      "delete": {
+        "description": "Delete rule group",
+        "tags": [
+          "provisioning"
+        ],
+        "operationId": "RouteDeleteAlertRuleGroup",
+        "parameters": [
+          {
+            "type": "string",
+            "name": "FolderUID",
+            "in": "path",
+            "required": true
+          },
+          {
+            "type": "string",
+            "name": "Group",
+            "in": "path",
+            "required": true
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": " The alert rule group was deleted successfully."
+          },
+          "403": {
+            "description": "ForbiddenError",
+            "schema": {
+              "$ref": "#/definitions/ForbiddenError"
+            }
+          },
+          "404": {
+            "description": "NotFound",
+            "schema": {
+              "$ref": "#/definitions/NotFound"
+            }
+          }
+        }
       }
     },
     "/v1/provisioning/folder/{FolderUID}/rule-groups/{Group}/export": {

--- a/public/openapi3.json
+++ b/public/openapi3.json
@@ -24656,6 +24656,56 @@
       }
     },
     "/v1/provisioning/folder/{FolderUID}/rule-groups/{Group}": {
+      "delete": {
+        "description": "Delete rule group",
+        "operationId": "RouteDeleteAlertRuleGroup",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "FolderUID",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "Group",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": " The alert rule group was deleted successfully."
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ForbiddenError"
+                }
+              }
+            },
+            "description": "ForbiddenError"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/NotFound"
+                }
+              }
+            },
+            "description": "NotFound"
+          }
+        },
+        "tags": [
+          "provisioning"
+        ]
+      },
       "get": {
         "operationId": "RouteGetAlertRuleGroup",
         "parameters": [


### PR DESCRIPTION
Adds support for DELETE to the provisioning API's alert rule groups route, which allows deleting the rule group with a single API call. Previously, groups were deleted by deleting rules one-by-one.

Fixes #81860

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
