### PR TITLE
mysql: PoC: allow tls-without-certificates

### DIFF
--- a/pkg/tsdb/mysql/mysql.go
+++ b/pkg/tsdb/mysql/mysql.go
@@ -136,6 +136,14 @@ func newInstanceSettings(logger log.Logger) datasource.InstanceFactoryFunc {
 				return nil, err
 			}
 			cnnstr += "&tls=" + tlsConfigString
+		} else {
+			if dsInfo.JsonData.MySQLRequireTLS {
+				if dsInfo.JsonData.TlsSkipVerify {
+					cnnstr += "&tls=skip-verify"
+				} else {
+					cnnstr += "&tls=true"
+				}
+			}
 		}
 
 		if dsInfo.JsonData.Timezone != "" {

--- a/pkg/tsdb/sqleng/sql_engine.go
+++ b/pkg/tsdb/sqleng/sql_engine.go
@@ -59,6 +59,7 @@ type JsonData struct {
 	SecureDSProxyUsername   string `json:"secureSocksProxyUsername"`
 	AllowCleartextPasswords bool   `json:"allowCleartextPasswords"`
 	AuthenticationType      string `json:"authenticationType"`
+	MySQLRequireTLS         bool   `json:"mySQLRequireTLS"`
 }
 
 type DataSourceInfo struct {

--- a/public/app/plugins/datasource/mysql/configuration/ConfigurationEditor.tsx
+++ b/public/app/plugins/datasource/mysql/configuration/ConfigurationEditor.tsx
@@ -116,6 +116,10 @@ export const ConfigurationEditor = (props: DataSourcePluginOptionsEditorProps<My
           />
         </Field>
 
+        <Field label="use TLS" description="use a TLS connection">
+          <Switch onChange={onSwitchChanged('mySQLRequireTLS')} value={jsonData.mySQLRequireTLS ?? false} />
+        </Field>
+
         <Field
           label="Use TLS Client Auth"
           description="Enables TLS authentication using client cert configured in secure json data."

--- a/public/app/plugins/datasource/mysql/types.ts
+++ b/public/app/plugins/datasource/mysql/types.ts
@@ -2,6 +2,7 @@ import { SQLOptions, SQLQuery } from '@grafana/sql';
 
 export interface MySQLOptions extends SQLOptions {
   allowCleartextPasswords?: boolean;
+  mySQLRequireTLS?: boolean;
 }
 
 export interface MySQLQuery extends SQLQuery {}


### PR DESCRIPTION
proof of concept solution to enable tls-without-certificates for the mysql plugin. this approach has two weaknesses:

- if a certificate (client or root) is set, we rely on plugin-sdk's `GetTLSConfig`, and if this custom toggle is used, we handle it by ourselves..meaning there are two different codepaths to do something similar.
- the user-interface is not good. we have a bunch of checkboxes and textareas.. this should change into an easier to use user-interface somehow... we can probably keep the current json-data (we probably have to), but change the visual representation to make it more intuitive, perhaps a wizard-style thing?


(related to https://github.com/grafana/grafana/issues/63429) 