### PR TITLE
DatePickerWithInput: use `floating-ui` so calendar can overflow scroll containers

### DIFF
--- a/.betterer.results
+++ b/.betterer.results
@@ -4136,12 +4136,6 @@ exports[`better eslint`] = {
     "public/app/features/search/utils.ts:5381": [
       [0, 0, 0, "Do not use any type assertions.", "0"]
     ],
-    "public/app/features/serviceaccounts/components/CreateTokenModal.tsx:5381": [
-      [0, 0, 0, "Styles should be written using objects.", "0"],
-      [0, 0, 0, "Styles should be written using objects.", "1"],
-      [0, 0, 0, "Styles should be written using objects.", "2"],
-      [0, 0, 0, "Styles should be written using objects.", "3"]
-    ],
     "public/app/features/serviceaccounts/components/ServiceAccountProfile.tsx:5381": [
       [0, 0, 0, "Styles should be written using objects.", "0"]
     ],

--- a/packages/grafana-ui/src/components/DateTimePickers/DatePicker/DatePicker.tsx
+++ b/packages/grafana-ui/src/components/DateTimePickers/DatePicker/DatePicker.tsx
@@ -67,7 +67,6 @@ export const getStyles = (theme: GrafanaTheme2) => {
   return {
     modal: css({
       zIndex: theme.zIndex.modal,
-      position: 'absolute',
       boxShadow: theme.shadows.z3,
       backgroundColor: theme.colors.background.primary,
       border: `1px solid ${theme.colors.border.weak}`,

--- a/packages/grafana-ui/src/components/DateTimePickers/DatePickerWithInput/DatePickerWithInput.tsx
+++ b/packages/grafana-ui/src/components/DateTimePickers/DatePickerWithInput/DatePickerWithInput.tsx
@@ -51,7 +51,7 @@ export const DatePickerWithInput = ({
   ];
 
   const { context, refs, floatingStyles } = useFloating({
-    open: open,
+    open,
     placement: 'bottom-start',
     onOpenChange: setOpen,
     middleware,
@@ -81,7 +81,7 @@ export const DatePickerWithInput = ({
         {...rest}
         {...getReferenceProps()}
       />
-      <div ref={refs.setFloating} style={floatingStyles} {...getFloatingProps()}>
+      <div className={styles.popover} ref={refs.setFloating} style={floatingStyles} {...getFloatingProps()}>
         <DatePicker
           isOpen={open}
           value={value && typeof value !== 'string' ? value : dateTime().toDate()}
@@ -111,6 +111,9 @@ const getStyles = () => {
         display: 'none',
         WebkitAppearance: 'none',
       },
+    }),
+    popover: css({
+      zIndex: 1,
     }),
   };
 };

--- a/packages/grafana-ui/src/components/DateTimePickers/DatePickerWithInput/DatePickerWithInput.tsx
+++ b/packages/grafana-ui/src/components/DateTimePickers/DatePickerWithInput/DatePickerWithInput.tsx
@@ -1,5 +1,6 @@
 import { css } from '@emotion/css';
-import React, { ChangeEvent } from 'react';
+import { autoUpdate, flip, shift, useClick, useDismiss, useFloating, useInteractions } from '@floating-ui/react';
+import React, { ChangeEvent, useState } from 'react';
 
 import { dateTime } from '@grafana/data';
 
@@ -35,17 +36,41 @@ export const DatePickerWithInput = ({
   placeholder = 'Date',
   ...rest
 }: DatePickerWithInputProps) => {
-  const [open, setOpen] = React.useState(false);
+  const [open, setOpen] = useState(false);
   const styles = useStyles2(getStyles);
+
+  // the order of middleware is important!
+  // see https://floating-ui.com/docs/arrow#order
+  const middleware = [
+    flip({
+      // see https://floating-ui.com/docs/flip#combining-with-shift
+      crossAxis: false,
+      boundary: document.body,
+    }),
+    shift(),
+  ];
+
+  const { context, refs, floatingStyles } = useFloating({
+    open: open,
+    placement: 'bottom-start',
+    onOpenChange: setOpen,
+    middleware,
+    whileElementsMounted: autoUpdate,
+    strategy: 'fixed',
+  });
+
+  const click = useClick(context);
+  const dismiss = useDismiss(context);
+  const { getReferenceProps, getFloatingProps } = useInteractions([dismiss, click]);
 
   return (
     <div className={styles.container}>
       <Input
+        ref={refs.setReference}
         type="text"
         autoComplete={'off'}
         placeholder={placeholder}
         value={value ? formatDate(value) : value}
-        onClick={() => setOpen(true)}
         onChange={(ev: ChangeEvent<HTMLInputElement>) => {
           // Allow resetting the date
           if (ev.target.value === '') {
@@ -54,20 +79,23 @@ export const DatePickerWithInput = ({
         }}
         className={styles.input}
         {...rest}
+        {...getReferenceProps()}
       />
-      <DatePicker
-        isOpen={open}
-        value={value && typeof value !== 'string' ? value : dateTime().toDate()}
-        minDate={minDate}
-        maxDate={maxDate}
-        onChange={(ev) => {
-          onChange(ev);
-          if (closeOnSelect) {
-            setOpen(false);
-          }
-        }}
-        onClose={() => setOpen(false)}
-      />
+      <div ref={refs.setFloating} style={floatingStyles} {...getFloatingProps()}>
+        <DatePicker
+          isOpen={open}
+          value={value && typeof value !== 'string' ? value : dateTime().toDate()}
+          minDate={minDate}
+          maxDate={maxDate}
+          onChange={(ev) => {
+            onChange(ev);
+            if (closeOnSelect) {
+              setOpen(false);
+            }
+          }}
+          onClose={() => setOpen(false)}
+        />
+      </div>
     </div>
   );
 };

--- a/public/app/features/serviceaccounts/components/CreateTokenModal.tsx
+++ b/public/app/features/serviceaccounts/components/CreateTokenModal.tsx
@@ -84,13 +84,7 @@ export const CreateTokenModal = ({ isOpen, token, serviceAccountLogin, onCreateT
   const modalTitle = !token ? 'Add service account token' : 'Service account token created';
 
   return (
-    <Modal
-      isOpen={isOpen}
-      title={modalTitle}
-      onDismiss={onCloseInternal}
-      className={styles.modal}
-      contentClassName={styles.modalContent}
-    >
+    <Modal isOpen={isOpen} title={modalTitle} onDismiss={onCloseInternal} className={styles.modal}>
       {!token ? (
         <div>
           <Field
@@ -176,17 +170,14 @@ const getSecondsToLive = (date: Date | string) => {
 
 const getStyles = (theme: GrafanaTheme2) => {
   return {
-    modal: css`
-      width: 550px;
-    `,
-    modalContent: css`
-      overflow: visible;
-    `,
-    modalTokenRow: css`
-      display: flex;
-    `,
-    modalCopyToClipboardButton: css`
-      margin-left: ${theme.spacing(0.5)};
-    `,
+    modal: css({
+      width: '550px',
+    }),
+    modalTokenRow: css({
+      display: 'flex',
+    }),
+    modalCopyToClipboardButton: css({
+      marginLeft: theme.spacing(0.5),
+    }),
   };
 };


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

- utilises `floating-ui` in `DatePickerWithInput` to position the calendar element
- removes some (now) unnecessary css overrides from `CreateTokenModal`
- removes `position: absolute;` from the base `DatePicker` component
  - this is only used by `DatePickerWithInput` internally so there's no change at all
  - **however** it's possible this is being used externally, so removing this would be a slight change in behaviour 
- converts `CreateTokenModal` to use emotion object styles

**Why do we need this feature?**

- so `DatePickerWithInput` can overflow scroll containers/modals correctly
- see https://raintank-corp.slack.com/archives/C036J5B39/p1709039819608849 for context

**Who is this feature for?**

- everyone!

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

- sibling enterprise PR: https://github.com/grafana/grafana-enterprise/pull/6332

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
