### PR TITLE
VizTooltip: Remove use of LayoutItemContext

### DIFF
--- a/public/app/plugins/panel/timeseries/plugins/annotations2/AnnotationEditor2.tsx
+++ b/public/app/plugins/panel/timeseries/plugins/annotations2/AnnotationEditor2.tsx
@@ -1,19 +1,9 @@
 import { css } from '@emotion/css';
-import React, { useContext, useEffect, useRef } from 'react';
+import React, { useRef } from 'react';
 import { useAsyncFn, useClickAway } from 'react-use';
 
 import { AnnotationEventUIModel, GrafanaTheme2, dateTimeFormat, systemDateFormats } from '@grafana/data';
-import {
-  Button,
-  Field,
-  Form,
-  HorizontalGroup,
-  InputControl,
-  LayoutItemContext,
-  TextArea,
-  usePanelContext,
-  useStyles2,
-} from '@grafana/ui';
+import { Button, Field, Form, HorizontalGroup, InputControl, TextArea, usePanelContext, useStyles2 } from '@grafana/ui';
 import { TagFilter } from 'app/core/components/TagFilter/TagFilter';
 import { getAnnotationTags } from 'app/features/annotations/api';
 
@@ -36,9 +26,6 @@ export const AnnotationEditor2 = ({ annoVals, annoIdx, dismiss, timeZone, ...oth
   const clickAwayRef = useRef(null);
 
   useClickAway(clickAwayRef, dismiss);
-
-  const layoutCtx = useContext(LayoutItemContext);
-  useEffect(() => layoutCtx.boostZIndex(), [layoutCtx]);
 
   const [createAnnotationState, createAnnotation] = useAsyncFn(async (event: AnnotationEventUIModel) => {
     const result = await onAnnotationCreate!(event);

--- a/public/app/plugins/panel/timeseries/plugins/annotations2/AnnotationTooltip2.tsx
+++ b/public/app/plugins/panel/timeseries/plugins/annotations2/AnnotationTooltip2.tsx
@@ -1,8 +1,8 @@
 import { css } from '@emotion/css';
-import React, { useContext, useEffect } from 'react';
+import React from 'react';
 
 import { GrafanaTheme2, dateTimeFormat, systemDateFormats, textUtil } from '@grafana/data';
-import { HorizontalGroup, IconButton, LayoutItemContext, Tag, usePanelContext, useStyles2 } from '@grafana/ui';
+import { HorizontalGroup, IconButton, Tag, usePanelContext, useStyles2 } from '@grafana/ui';
 import alertDef from 'app/features/alerting/state/alertDef';
 
 interface Props {
@@ -24,9 +24,6 @@ export const AnnotationTooltip2 = ({ annoVals, annoIdx, timeZone, onEdit }: Prop
   const dashboardUID = annoVals.dashboardUID?.[annoIdx];
   const canEdit = canEditAnnotations(dashboardUID);
   const canDelete = canDeleteAnnotations(dashboardUID) && onAnnotationDelete != null;
-
-  const layoutCtx = useContext(LayoutItemContext);
-  useEffect(() => layoutCtx.boostZIndex(), [layoutCtx]);
 
   const timeFormatter = (value: number) =>
     dateTimeFormat(value, {


### PR DESCRIPTION
this extracts the viztooltip bits from the more general LayoutItemContext removal: https://github.com/grafana/grafana/pull/83465