### PR TITLE
Loki: Fix failing test waiting for `Loading...` copy

### DIFF
--- a/public/app/plugins/datasource/loki/components/LokiQueryField.test.tsx
+++ b/public/app/plugins/datasource/loki/components/LokiQueryField.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
 import React, { ComponentProps } from 'react';
 
 import { dateTime } from '@grafana/data';
@@ -33,7 +33,9 @@ describe('LokiQueryField', () => {
   it('refreshes metrics when time range changes over 1 minute', async () => {
     const { rerender } = render(<LokiQueryField {...props} />);
 
-    expect(await screen.findByText('Loading...')).toBeInTheDocument();
+    await waitFor(async () => {
+      expect(await screen.findByText('Loading...')).toBeInTheDocument();
+    });
 
     expect(props.datasource.languageProvider.fetchLabels).not.toHaveBeenCalled();
 
@@ -55,7 +57,9 @@ describe('LokiQueryField', () => {
   it('does not refreshes metrics when time range change by less than 1 minute', async () => {
     const { rerender } = render(<LokiQueryField {...props} />);
 
-    expect(await screen.findByText('Loading...')).toBeInTheDocument();
+    await waitFor(async () => {
+      expect(await screen.findByText('Loading...')).toBeInTheDocument();
+    });
 
     expect(props.datasource.languageProvider.fetchLabels).not.toHaveBeenCalled();
 

--- a/public/app/plugins/datasource/loki/components/monaco-query-field/MonacoFieldWrapper.test.tsx
+++ b/public/app/plugins/datasource/loki/components/monaco-query-field/MonacoFieldWrapper.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
 import React from 'react';
 
 import { createLokiDatasource } from '../../__mocks__/datasource';
@@ -24,6 +24,8 @@ describe('MonacoFieldWrapper', () => {
   test('Renders with no errors', async () => {
     renderComponent();
 
-    expect(await screen.findByText('Loading...')).toBeInTheDocument();
+    await waitFor(async () => {
+      expect(await screen.findByText('Loading...')).toBeInTheDocument();
+    });
   });
 });


### PR DESCRIPTION
**What is this feature?**

Fix failing tests that are expecting a `Loading...` copy to appear, which is not rendered immediately. 