### PR TITLE
datatrails: standardize loading and blocking message indicators

### DIFF
--- a/public/app/features/trails/StatusWrapper.tsx
+++ b/public/app/features/trails/StatusWrapper.tsx
@@ -1,0 +1,39 @@
+import { css } from '@emotion/css';
+import React, { ReactNode } from 'react';
+
+import { GrafanaTheme2 } from '@grafana/data';
+import { LoadingPlaceholder, useStyles2 } from '@grafana/ui';
+
+type Props = {
+  blockingMessage?: string;
+  isLoading?: boolean;
+  children?: ReactNode;
+};
+
+export function StatusWrapper({ blockingMessage, isLoading, children }: Props) {
+  const styles = useStyles2(getStyles);
+
+  if (isLoading && !blockingMessage) {
+    blockingMessage = 'Loading...';
+  }
+
+  if (isLoading) {
+    return <LoadingPlaceholder className={styles.statusMessage} text={blockingMessage} />;
+  }
+
+  if (!blockingMessage) {
+    return children;
+  }
+
+  return <div className={styles.statusMessage}>{blockingMessage}</div>;
+}
+
+function getStyles(theme: GrafanaTheme2) {
+  return {
+    statusMessage: css({
+      fontStyle: 'italic',
+      marginTop: theme.spacing(7),
+      textAlign: 'center',
+    }),
+  };
+}


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

Standardizes the Loading indicators and blocking status messages.
Breakdown tab will not show label selector if there was a fetching error.

---
![image](https://github.com/grafana/grafana/assets/38694490/69366891-0ab3-4f19-bb0c-6b90b5f0854b)

![image](https://github.com/grafana/grafana/assets/38694490/0daff125-7ba7-4431-baf9-9baad9ede6ba)

---
![image](https://github.com/grafana/grafana/assets/38694490/999340eb-39ac-4bba-884b-4522a2199b14)

![image](https://github.com/grafana/grafana/assets/38694490/1f2ba6cc-d7da-464b-babe-a0bd39a4b82d)
---

![image](https://github.com/grafana/grafana/assets/38694490/9c52baa2-c9a1-4b71-ac06-fd5a3d995540)

![image](https://github.com/grafana/grafana/assets/38694490/c58506dc-3ca5-4489-8962-e688f822316c)

(The error handling is still inconsistent, as errors aren't currently bubbling up from the labels variable. For the "Overview" and "Breakdown" tab, we can't yet determine if the lack of data is due to an error, or due to there not being any labels. This will be addressed in the future)


**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
