### PR TITLE
[draft] Datasources: Introduce new base class

### DIFF
--- a/packages/grafana-data/src/types/datasource.ts
+++ b/packages/grafana-data/src/types/datasource.ts
@@ -250,6 +250,9 @@ abstract class DataSourceApi<
 
   /**
    * Query for data, and optionally stream results
+   *
+   * @deprecated -- the query method is now defined in {@link DataSourceBase}. If your building a frontend data source, extend DataSourceBase class.
+   * If you are building a backend data source, extend DataSourceWithBackend class.
    */
   abstract query(request: DataQueryRequest<TQuery>): Promise<DataQueryResponse> | Observable<DataQueryResponse>;
 
@@ -259,13 +262,15 @@ abstract class DataSourceApi<
    * When verification fails - errors specific to the data source should be handled here and converted to
    * a TestingStatus object. Unknown errors and HTTP errors can be re-thrown and will be handled here:
    * public/app/features/datasources/state/actions.ts
+   *
+   * @deprecated -- {@link DataSourceBase.testDatasource} is now defined in testDatasource. Extend DataSourceBase instead of DataSourceAPI.
    */
   abstract testDatasource(): Promise<TestDataSourceResponse>;
 
   /**
-   * This function is not called automatically unless running within the DataSourceWithBackend
+   * Optionally, you can implement this method to conditionally prevent certain queries from being executed.
+   * Return false to prevent the query from being executed.
    *
-   * @deprecated
    */
   filterQuery?(query: TQuery): boolean;
 

--- a/packages/grafana-runtime/src/index.ts
+++ b/packages/grafana-runtime/src/index.ts
@@ -24,6 +24,7 @@ export {
   HealthStatus,
   type StreamOptionsProvider,
 } from './utils/DataSourceWithBackend';
+export { DataSourceBase } from './utils/DataSourceBase';
 export {
   toDataQueryResponse,
   frameToMetricFindValue,

--- a/packages/grafana-runtime/src/utils/DataSourceBase.ts
+++ b/packages/grafana-runtime/src/utils/DataSourceBase.ts
@@ -1,0 +1,57 @@
+import { Observable } from 'rxjs';
+
+import {
+  DataSourceApi,
+  DataSourceInstanceSettings,
+  ScopedVars,
+  AdHocVariableFilter,
+  TestDataSourceResponse,
+  DataQueryRequest,
+  DataQueryResponse,
+} from '@grafana/data';
+import { DataQuery, DataSourceJsonData } from '@grafana/schema';
+
+/**
+ * This class provides generic default implementations for data source plugin methods.
+ * Extend this class to implement a data source plugin.
+ *
+ * @public
+ */
+export abstract class DataSourceBase<
+  TQuery extends DataQuery = DataQuery,
+  TOptions extends DataSourceJsonData = DataSourceJsonData,
+> extends DataSourceApi<TQuery, TOptions> {
+  constructor(instanceSettings: DataSourceInstanceSettings<TOptions>) {
+    super(instanceSettings);
+  }
+
+  /**
+   * Test & verify datasource settings & connection details (returning TestingStatus)
+   *
+   * When verification fails - errors specific to the data source should be handled here and converted to
+   * a TestingStatus object. Unknown errors and HTTP errors can be re-thrown and will be handled here:
+   * public/app/features/datasources/state/actions.ts
+   */
+  abstract testDatasource(): Promise<TestDataSourceResponse>;
+
+  /**
+   * Query for data, and optionally stream results
+   */
+  abstract query(request: DataQueryRequest<TQuery>): Promise<DataQueryResponse> | Observable<DataQueryResponse>;
+
+  /**
+   * Override to apply template variables and adhoc filters.  The result is usually also `TQuery`, but sometimes this can
+   * be used to modify the query structure before sending to the backend.
+   *
+   */
+  abstract applyTemplateVariables(query: TQuery, scopedVars: ScopedVars, filters?: AdHocVariableFilter[]): TQuery;
+
+  /**
+   * Apply template variables for explore
+   *
+   * @internal
+   */
+  interpolateVariablesInQueries(queries: TQuery[], scopedVars: ScopedVars, filters?: AdHocVariableFilter[]): TQuery[] {
+    return queries.map((q) => this.applyTemplateVariables(q, scopedVars, filters));
+  }
+}

--- a/packages/grafana-runtime/src/utils/DataSourceBase.ts
+++ b/packages/grafana-runtime/src/utils/DataSourceBase.ts
@@ -44,7 +44,9 @@ export abstract class DataSourceBase<
    * be used to modify the query structure before sending to the backend.
    *
    */
-  abstract applyTemplateVariables(query: TQuery, scopedVars: ScopedVars, filters?: AdHocVariableFilter[]): TQuery;
+  applyTemplateVariables(query: TQuery, scopedVars: ScopedVars, filters?: AdHocVariableFilter[]): TQuery {
+    return query;
+  }
 
   /**
    * Apply template variables for explore


### PR DESCRIPTION
**What is this feature?**

The purpose of this PR is to streamline DX and query execution flow between backend data source plugins and frontend data source plugins. 

**Why do we need this feature?**

Currently, the query execution flow for frontend and backend data source plugin differs a bit. Data sources that extend `DataSourceWithBackend` don't need to implement the query method as this is handled in the base class. The plugin just needs to implement `filterQuery` (if filtering is required) and `applyTemplateVariables`, and then these methods will be called from within the `query` method in the base class. Currently, `filterQuery` and `applyTemplateVariables` are defined in the `DataSourceWithBackend` class, although there is noting backend specific about these methods. 

Frontend plugins need to implement the query method, and handle any filtering and variable interpolation as part of that. This is causing a lot of confusion among data source developers. It would be nice if non-backend plugins could simply implement `filterQuery` and `applyTemplateVariables`, and then that would be handled by the framework before the `query` method is called. 

**How?**

This PR introduces a new base class that sits between the DataSourceAPI and DataSourceWithBackend / frontend data source plugins. This allows us to provide default implementations for common methods such as `applyTemplateVariables`. `applyTemplateVariables` and `filterQuery` are removed from DataSourceWithBackend and added to the query runner, enabling the same query execution flow for frontend and backend plugins. 

![datasourcebase](https://github.com/grafana/grafana/assets/2388950/6ef328e5-5b01-46e7-ab1a-996bc01911fb)


This change would have no impact on backend data sources. For frontend plugins. things would also work as before. However, from G11 we would encourage them to extend `DataSourceBase` rather than `DataSourceAPI`, and simply implement `applyTemplateVariables` and `filterQuery`. 



@ryantxu do you know if this comment below is still valid? If not, we can skip DataSourceBase and just implement defaults in DataSourceAPI? But I don't know - maybe useful to have this base class anyway? Feels like a lot of the props and methods (´variables´, ´annotations´, ´targetContainsTemplate´) could make use of decent default implementation. 
https://github.com/grafana/grafana/blob/acf97e43b664cf966f4c85d53580e4a5573e59cc/packages/grafana-data/src/types/datasource.ts#L194-L195

**Who is this feature for?**

Plugin developers

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

This is just a draft PR, so I have not yet updated the query runner for alerting, annotations etc. 

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
