### PR TITLE
Loki: Remove deprecated `instant` and `range` properties from query

### DIFF
--- a/packages/grafana-schema/src/raw/composable/loki/dataquery/x/LokiDataQuery_types.gen.ts
+++ b/packages/grafana-schema/src/raw/composable/loki/dataquery/x/LokiDataQuery_types.gen.ts
@@ -43,10 +43,6 @@ export interface LokiDataQuery extends common.DataQuery {
    */
   expr: string;
   /**
-   * @deprecated, now use queryType.
-   */
-  instant?: boolean;
-  /**
    * Used to override the name of the series.
    */
   legendFormat?: string;
@@ -54,10 +50,6 @@ export interface LokiDataQuery extends common.DataQuery {
    * Used to limit the number of log rows returned.
    */
   maxLines?: number;
-  /**
-   * @deprecated, now use queryType.
-   */
-  range?: boolean;
   /**
    * @deprecated, now use step.
    */

--- a/pkg/tsdb/loki/kinds/dataquery/types_dataquery_gen.go
+++ b/pkg/tsdb/loki/kinds/dataquery/types_dataquery_gen.go
@@ -83,9 +83,6 @@ type LokiDataQuery struct {
 	// the results from a hidden query may be used as the input to other queries (SSE etc)
 	Hide *bool `json:"hide,omitempty"`
 
-	// @deprecated, now use queryType.
-	Instant *bool `json:"instant,omitempty"`
-
 	// Used to override the name of the series.
 	LegendFormat *string `json:"legendFormat,omitempty"`
 
@@ -95,9 +92,6 @@ type LokiDataQuery struct {
 	// Specify the query flavor
 	// TODO make this required and give it a default
 	QueryType *string `json:"queryType,omitempty"`
-
-	// @deprecated, now use queryType.
-	Range *bool `json:"range,omitempty"`
 
 	// A unique identifier for the query within the list of targets.
 	// In server side expressions, the refId is used as a variable name to identify results.

--- a/public/app/plugins/datasource/loki/dataquery.cue
+++ b/public/app/plugins/datasource/loki/dataquery.cue
@@ -36,10 +36,6 @@ composableKinds: DataQuery: {
 				// @deprecated, now use step.
 				resolution?: int64
 				editorMode?: #QueryEditorMode
-				// @deprecated, now use queryType.
-				range?: bool
-				// @deprecated, now use queryType.
-				instant?: bool
 				// Used to set step value for range queries.
 				step?: string
 

--- a/public/app/plugins/datasource/loki/dataquery.gen.ts
+++ b/public/app/plugins/datasource/loki/dataquery.gen.ts
@@ -40,10 +40,6 @@ export interface Loki extends common.DataQuery {
    */
   expr: string;
   /**
-   * @deprecated, now use queryType.
-   */
-  instant?: boolean;
-  /**
    * Used to override the name of the series.
    */
   legendFormat?: string;
@@ -51,10 +47,6 @@ export interface Loki extends common.DataQuery {
    * Used to limit the number of log rows returned.
    */
   maxLines?: number;
-  /**
-   * @deprecated, now use queryType.
-   */
-  range?: boolean;
   /**
    * @deprecated, now use step.
    */

--- a/public/app/plugins/datasource/loki/datasource.ts
+++ b/public/app/plugins/datasource/loki/datasource.ts
@@ -967,7 +967,6 @@ export class LokiDatasource
       refId: id,
       expr,
       maxLines,
-      instant,
       queryType: instant ? LokiQueryType.Instant : LokiQueryType.Range,
     };
 


### PR DESCRIPTION
**What is this feature?**

Removes the deprecated `instant` and `range` properties from the `LokiQuery` object.

**Which issue(s) does this PR fix?**:

Fixes #67367

# Release notice breaking change

The deprecated properties `instant`, and `range` have been removed from Loki's query definition. The recommended way to determine the query type is to use the `queryType` property.
