### PR TITLE
Dashboard scenes: debounce name validation when saving dashboards

### DIFF
--- a/public/app/features/dashboard-scene/saving/SaveDashboardAsForm.tsx
+++ b/public/app/features/dashboard-scene/saving/SaveDashboardAsForm.tsx
@@ -1,3 +1,4 @@
+import debounce from 'debounce-promise';
 import React from 'react';
 import { UseFormSetValue, useForm } from 'react-hook-form';
 
@@ -11,7 +12,6 @@ import { DashboardScene } from '../scene/DashboardScene';
 import { SaveDashboardDrawer } from './SaveDashboardDrawer';
 import { DashboardChangeInfo, NameAlreadyExistsError, SaveButton, isNameExistsError } from './shared';
 import { useSaveDashboard } from './useSaveDashboard';
-
 interface SaveDashboardAsFormDTO {
   firstName?: string;
   title: string;
@@ -29,7 +29,7 @@ export interface Props {
 export function SaveDashboardAsForm({ dashboard, drawer, changeInfo }: Props) {
   const { changedSaveModel } = changeInfo;
 
-  const { register, handleSubmit, setValue, formState, getValues, watch } = useForm<SaveDashboardAsFormDTO>({
+  const { register, handleSubmit, setValue, formState, getValues, watch, trigger } = useForm<SaveDashboardAsFormDTO>({
     mode: 'onBlur',
     defaultValues: {
       title: changeInfo.isNew ? changedSaveModel.title! : `${changedSaveModel.title} Copy`,
@@ -98,6 +98,9 @@ export function SaveDashboardAsForm({ dashboard, drawer, changeInfo }: Props) {
         <Input
           {...register('title', { required: 'Required', validate: validateDashboardName })}
           aria-label="Save dashboard title field"
+          onChange={debounce(async () => {
+            trigger('title');
+          }, 400)}
           autoFocus
         />
       </Field>

--- a/public/app/features/dashboard-scene/saving/SaveDashboardAsForm.tsx
+++ b/public/app/features/dashboard-scene/saving/SaveDashboardAsForm.tsx
@@ -12,6 +12,7 @@ import { DashboardScene } from '../scene/DashboardScene';
 import { SaveDashboardDrawer } from './SaveDashboardDrawer';
 import { DashboardChangeInfo, NameAlreadyExistsError, SaveButton, isNameExistsError } from './shared';
 import { useSaveDashboard } from './useSaveDashboard';
+
 interface SaveDashboardAsFormDTO {
   firstName?: string;
   title: string;


### PR DESCRIPTION
**What is this feature?**
I noticed we're shooting off one request, to validate that the dashboard name isn't taken, for every change to the title, in the dashboard save form.

This is a bit weird to me, it should only trigger the validation `onBlur`, but for some reason it's triggering it for every `onChange`.

For now, until we can find the reason, I think we should `debounce` the `onChange` event so that we limit the number of requests sent.
