### PR TITLE
VizTooltip: Improve edge positioning and a11y

### DIFF
--- a/packages/grafana-ui/src/components/uPlot/plugins/TooltipPlugin2.tsx
+++ b/packages/grafana-ui/src/components/uPlot/plugins/TooltipPlugin2.tsx
@@ -509,7 +509,13 @@ export const TooltipPlugin2 = ({
 
   if (plot && isHovering) {
     return createPortal(
-      <div className={cx(styles.tooltipWrapper, isPinned && styles.pinned)} style={style} ref={domRef}>
+      <div
+        className={cx(styles.tooltipWrapper, isPinned && styles.pinned)}
+        style={style}
+        aria-live="polite"
+        aria-atomic="true"
+        ref={domRef}
+      >
         {isPinned && <CloseButton onClick={dismiss} />}
         {contents}
       </div>,
@@ -527,7 +533,7 @@ const getStyles = (theme: GrafanaTheme2, maxWidth?: number, maxHeight?: number) 
     zIndex: theme.zIndex.tooltip,
     whiteSpace: 'pre',
     borderRadius: theme.shape.radius.default,
-    position: 'absolute',
+    position: 'fixed',
     background: theme.colors.background.primary,
     border: `1px solid ${theme.colors.border.weak}`,
     boxShadow: theme.shadows.z2,


### PR DESCRIPTION
- prevents scrollbars from appearing when tooltip appears/inits at bottom or right viewport edges (`position: fixed`)
- pulls a couple `aria` attrs that already exist in `VizTooltipContainer`