### PR TITLE
docs: link annotation queries video to documentation

### DIFF
--- a/docs/sources/dashboards/build-dashboards/annotate-visualizations/index.md
+++ b/docs/sources/dashboards/build-dashboards/annotate-visualizations/index.md
@@ -86,6 +86,10 @@ Alternatively, to add an annotation, press Ctrl/Cmd and click the panel, and the
 
 In the dashboard settings, under **Annotations**, you can add new queries to fetch annotations using any data source, including the built-in data annotation data source. Annotation queries return events that can be visualized as event markers in graphs across the dashboard.
 
+Check out the video below for a quick tutorial.
+
+{{< youtube id="2istdJpPj2Y" >}}
+
 ### Add new annotation queries
 
 To add a new annotation query to a dashboard, take the following steps:


### PR DESCRIPTION
**What is this feature?**

Embed https://www.youtube.com/watch?v=2istdJpPj2Y to Grafana docs

**Why do we need this feature?**

To drive traffic to our YouTube channel from the docs

**Who is this feature for?**

Users who want to add annotation queries to their dashboards

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
