### PR TITLE
Elasticsearch: Fix adhoc filters not applied in frontend mode

### DIFF
--- a/public/app/plugins/datasource/elasticsearch/LegacyQueryRunner.ts
+++ b/public/app/plugins/datasource/elasticsearch/LegacyQueryRunner.ts
@@ -151,7 +151,11 @@ export class LegacyQueryRunner {
 
   query(request: DataQueryRequest<ElasticsearchQuery>): Observable<DataQueryResponse> {
     let payload = '';
-    const targets = this.datasource.interpolateVariablesInQueries(cloneDeep(request.targets), request.scopedVars);
+    const targets = this.datasource.interpolateVariablesInQueries(
+      cloneDeep(request.targets),
+      request.scopedVars,
+      request.filters
+    );
     const sentTargets: ElasticsearchQuery[] = [];
     let targetsContainsLogsQuery = targets.some((target) => hasMetricOfType(target, 'logs'));
 


### PR DESCRIPTION
**What is this feature?**

This PR fixes a bug where ad-hoc filters are not applied when Elasticsearch is querying in frontend mode.