### PR TITLE
Schemas: Restore spec core go generation

### DIFF
--- a/kinds/gen.go
+++ b/kinds/gen.go
@@ -39,6 +39,7 @@ func main() {
 
 	// All the jennies that comprise the core kinds generator pipeline
 	coreKindsGen.Append(
+		&codegen.GoSpecJenny{},
 		codegen.CoreKindJenny(cuectx.GoCoreKindParentPath, nil),
 		codegen.BaseCoreRegistryJenny(filepath.Join("pkg", "registry", "corekind"), cuectx.GoCoreKindParentPath),
 		codegen.LatestMajorsOrXJenny(

--- a/pkg/codegen/jenny_go_spec.go
+++ b/pkg/codegen/jenny_go_spec.go
@@ -1,0 +1,46 @@
+package codegen
+
+import (
+	"cuelang.org/go/cue"
+	"fmt"
+	"github.com/dave/dst/dstutil"
+	"github.com/grafana/kindsys"
+
+	"github.com/grafana/codejen"
+	"github.com/grafana/thema/encoding/gocode"
+	"github.com/grafana/thema/encoding/openapi"
+)
+
+type GoSpecJenny struct {
+	ApplyFuncs []dstutil.ApplyFunc
+}
+
+func (jenny *GoSpecJenny) JennyName() string {
+	return "GoResourceTypes"
+}
+
+func (jenny *GoSpecJenny) Generate(kinds ...kindsys.Kind) (codejen.Files, error) {
+	files := make(codejen.Files, len(kinds))
+	for i, v := range kinds {
+		name := v.Lineage().Name()
+		b, err := gocode.GenerateTypesOpenAPI(v.Lineage().Latest(),
+			&gocode.TypeConfigOpenAPI{
+				Config: &openapi.Config{
+					Group:    false,
+					RootName: "Spec",
+					Subpath:  cue.MakePath(cue.Str("spec")),
+				},
+				PackageName: name,
+				ApplyFuncs:  append(jenny.ApplyFuncs, PrefixDropper(v.Props().Common().Name)),
+			},
+		)
+
+		if err != nil {
+			return nil, err
+		}
+
+		files[i] = *codejen.NewFile(fmt.Sprintf("pkg/kinds/%s/%s_spec_gen.go", name, name), b, jenny)
+	}
+
+	return files, nil
+}

--- a/pkg/codegen/jenny_go_spec.go
+++ b/pkg/codegen/jenny_go_spec.go
@@ -1,12 +1,12 @@
 package codegen
 
 import (
-	"cuelang.org/go/cue"
 	"fmt"
-	"github.com/dave/dst/dstutil"
-	"github.com/grafana/kindsys"
 
+	"cuelang.org/go/cue"
+	"github.com/dave/dst/dstutil"
 	"github.com/grafana/codejen"
+	"github.com/grafana/kindsys"
 	"github.com/grafana/thema/encoding/gocode"
 	"github.com/grafana/thema/encoding/openapi"
 )


### PR DESCRIPTION
I deleted go generation by mistake in this PR: https://github.com/grafana/grafana/pull/83310 😅😂 .
I used the minimum code to make it works. 