### PR TITLE
CodeEditor: Ensure latest onChange callback is called

### DIFF
--- a/packages/grafana-ui/src/components/Monaco/CodeEditor.tsx
+++ b/packages/grafana-ui/src/components/Monaco/CodeEditor.tsx
@@ -102,7 +102,7 @@ class UnthemedCodeEditor extends PureComponent<Props> {
   };
 
   handleOnMount = (editor: MonacoEditorType, monaco: Monaco) => {
-    const { getSuggestions, language, onChange, onEditorDidMount } = this.props;
+    const { getSuggestions, language, onEditorDidMount } = this.props;
 
     this.modelId = editor.getModel()?.id;
     this.getEditorValue = () => editor.getValue();
@@ -119,12 +119,18 @@ class UnthemedCodeEditor extends PureComponent<Props> {
       }
     });
 
-    if (onChange) {
-      editor.getModel()?.onDidChangeContent(() => onChange(editor.getValue()));
-    }
+    editor.getModel()?.onDidChangeContent(this.handleChangeContent);
 
     if (onEditorDidMount) {
       onEditorDidMount(editor, monaco);
+    }
+  };
+
+  handleChangeContent = () => {
+    const { onChange } = this.props;
+
+    if (onChange) {
+      onChange(this.getEditorValue());
     }
   };
 


### PR DESCRIPTION
Fixes the Monaco CodeEditor component to call the latest/current `props.onChange`, rather than capturing it's initial value in the `handleOnMount`.

This enables consumers to properly update state based on it.

Fixes https://github.com/grafana/grafana/issues/81687