### PR TITLE
Chore: Move TLS settings to the Extra Security Measures section (SSO Settings UI)

### DIFF
--- a/public/app/features/auth-config/fields.tsx
+++ b/public/app/features/auth-config/fields.tsx
@@ -86,12 +86,11 @@ export const sectionFields: Section = {
         { name: 'teamIdsAttributePath', dependsOn: 'defineAllowedTeamsIds' },
         'usePkce',
         'useRefreshToken',
+        'tlsSkipVerifyInsecure',
+        'tlsClientCert',
+        'tlsClientKey',
+        'tlsClientCa',
       ],
-    },
-    {
-      name: 'TLS',
-      id: 'tls',
-      fields: ['tlsSkipVerifyInsecure', 'tlsClientCert', 'tlsClientKey', 'tlsClientCa'],
     },
   ],
 };


### PR DESCRIPTION
**What is this feature?**
This PR removes the TLS section from the Generic OAuth UI and moves its fields to the `Extra Security Measures` section.

**Why do we need this feature?**


**Who is this feature for?**

[Add information on what kind of user the feature is for.]

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
