### PR TITLE
Cfg: Add a setting to configure if the local file system is available

### DIFF
--- a/conf/defaults.ini
+++ b/conf/defaults.ini
@@ -94,6 +94,10 @@ read_timeout = 0
 #exampleHeader1 = exampleValue1
 #exampleHeader2 = exampleValue2
 
+[environment]
+# Sets whether the local file system is available for Grafana to use. Default is true for backward compatibility.
+local_file_system_available = true
+
 #################################### GRPC Server #########################
 [grpc_server]
 network = "tcp"

--- a/packages/grafana-data/src/types/config.ts
+++ b/packages/grafana-data/src/types/config.ts
@@ -226,6 +226,7 @@ export interface GrafanaConfig {
   sqlConnectionLimits: SqlConnectionLimits;
   sharedWithMeFolderUID?: string;
   rootFolderUID?: string;
+  localFileSystemAvailable?: boolean;
 
   // The namespace to use for kubernetes apiserver requests
   namespace: string;

--- a/packages/grafana-runtime/src/config.ts
+++ b/packages/grafana-runtime/src/config.ts
@@ -171,6 +171,7 @@ export class GrafanaBootConfig implements GrafanaConfig {
   disableFrontendSandboxForPlugins: string[] = [];
   sharedWithMeFolderUID: string | undefined;
   rootFolderUID: string | undefined;
+  localFileSystemAvailable: boolean | undefined;
 
   constructor(options: GrafanaBootConfig) {
     this.bootData = options.bootData;

--- a/pkg/api/dtos/frontend_settings.go
+++ b/pkg/api/dtos/frontend_settings.go
@@ -260,4 +260,6 @@ type FrontendSettingsDTO struct {
 	// Enterprise
 	Licensing     *FrontendSettingsLicensingDTO     `json:"licensing,omitempty"`
 	Whitelabeling *FrontendSettingsWhitelabelingDTO `json:"whitelabeling,omitempty"`
+
+	LocalFilesystemAvailable bool `json:"localFilesystemAvailable"`
 }

--- a/pkg/api/dtos/frontend_settings.go
+++ b/pkg/api/dtos/frontend_settings.go
@@ -261,5 +261,5 @@ type FrontendSettingsDTO struct {
 	Licensing     *FrontendSettingsLicensingDTO     `json:"licensing,omitempty"`
 	Whitelabeling *FrontendSettingsWhitelabelingDTO `json:"whitelabeling,omitempty"`
 
-	LocalFilesystemAvailable bool `json:"localFilesystemAvailable"`
+	LocalFileSystemAvailable bool `json:"localFileSystemAvailable"`
 }

--- a/pkg/api/frontendsettings.go
+++ b/pkg/api/frontendsettings.go
@@ -220,6 +220,7 @@ func (hs *HTTPServer) getFrontendSettings(c *contextmodel.ReqContext) (*dtos.Fro
 		PublicDashboardsEnabled:             hs.Cfg.PublicDashboardsEnabled,
 		SharedWithMeFolderUID:               folder.SharedWithMeFolderUID,
 		RootFolderUID:                       accesscontrol.GeneralFolderUID,
+		LocalFileSystemAvailable:            hs.Cfg.LocalFileSystemAvailable,
 
 		BuildInfo: dtos.FrontendSettingsBuildInfoDTO{
 			HideVersion:   hideVersion,

--- a/pkg/setting/setting.go
+++ b/pkg/setting/setting.go
@@ -366,6 +366,8 @@ type Cfg struct {
 	StackID string
 	Slug    string
 
+	LocalFSAvailable bool
+
 	// Deprecated
 	ForceMigration bool
 
@@ -1063,6 +1065,7 @@ func (cfg *Cfg) parseINIFile(iniFile *ini.File) error {
 	cfg.Env = valueAsString(iniFile.Section(""), "app_mode", "development")
 	cfg.StackID = valueAsString(iniFile.Section("environment"), "stack_id", "")
 	cfg.Slug = valueAsString(iniFile.Section("environment"), "stack_slug", "")
+	cfg.LocalFSAvailable = iniFile.Section("environment").Key("local_fs_available").MustBool(true)
 	//nolint:staticcheck
 	cfg.ForceMigration = iniFile.Section("").Key("force_migration").MustBool(false)
 	cfg.InstanceName = valueAsString(iniFile.Section(""), "instance_name", "unknown_instance_name")

--- a/pkg/setting/setting.go
+++ b/pkg/setting/setting.go
@@ -366,7 +366,7 @@ type Cfg struct {
 	StackID string
 	Slug    string
 
-	LocalFSAvailable bool
+	LocalFileSystemAvailable bool
 
 	// Deprecated
 	ForceMigration bool
@@ -1065,7 +1065,7 @@ func (cfg *Cfg) parseINIFile(iniFile *ini.File) error {
 	cfg.Env = valueAsString(iniFile.Section(""), "app_mode", "development")
 	cfg.StackID = valueAsString(iniFile.Section("environment"), "stack_id", "")
 	cfg.Slug = valueAsString(iniFile.Section("environment"), "stack_slug", "")
-	cfg.LocalFSAvailable = iniFile.Section("environment").Key("local_fs_available").MustBool(true)
+	cfg.LocalFileSystemAvailable = iniFile.Section("environment").Key("local_file_system_available").MustBool(true)
 	//nolint:staticcheck
 	cfg.ForceMigration = iniFile.Section("").Key("force_migration").MustBool(false)
 	cfg.InstanceName = valueAsString(iniFile.Section(""), "instance_name", "unknown_instance_name")

--- a/public/app/features/auth-config/fields.tsx
+++ b/public/app/features/auth-config/fields.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { validate as uuidValidate } from 'uuid';
 
+import { config } from '@grafana/runtime';
 import { TextLink } from '@grafana/ui';
 import { contextSrv } from 'app/core/core';
 
@@ -343,16 +344,19 @@ export function fieldMap(provider: string): Record<string, FieldData> {
       label: 'TLS client ca',
       description: 'The file path to the trusted certificate authority list. Is not applicable on Grafana Cloud.',
       type: 'text',
+      hidden: !config.localFileSystemAvailable,
     },
     tlsClientCert: {
       label: 'TLS client cert',
       description: 'The file path to the certificate. Is not applicable on Grafana Cloud.',
       type: 'text',
+      hidden: !config.localFileSystemAvailable,
     },
     tlsClientKey: {
       label: 'TLS client key',
       description: 'The file path to the key. Is not applicable on Grafana Cloud.',
       type: 'text',
+      hidden: !config.localFileSystemAvailable,
     },
     tlsSkipVerifyInsecure: {
       label: 'TLS skip verify',


### PR DESCRIPTION
**What is this feature?**
1. Add a new config parameter to the `environment` section called `local_file_system_available` for setting whether the local file system is accessible by Grafana. Default to `true` to prevent a breaking change.
1. Only show TLS client cert, client key, client ca when local_filesystem_available is true

**Why do we need this feature?**
There are settings in Grafana and in plugins that are opening files (certificates) from the local filesystem and the local file system is not available for example on Grafana Cloud.

**Who is this feature for?**

[Add information on what kind of user the feature is for.]

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
