### PR TITLE
Tempo: Better fallbacks for metrics query

### DIFF
--- a/public/app/plugins/datasource/tempo/datasource.ts
+++ b/public/app/plugins/datasource/tempo/datasource.ts
@@ -714,7 +714,7 @@ export class TempoDatasource extends DataSourceWithBackend<TempoQuery, TempoJson
     }).pipe(
       map((response) => {
         return {
-          data: formatTraceQLMetrics(response.data),
+          data: formatTraceQLMetrics(queryValue, response.data),
         };
       }),
       catchError((err) => {

--- a/public/app/plugins/datasource/tempo/resultTransformer.ts
+++ b/public/app/plugins/datasource/tempo/resultTransformer.ts
@@ -637,7 +637,7 @@ const metricsValueToString = (value: ProtoValue): string => {
 };
 
 export function formatTraceQLMetrics(query: string, data: TraceqlMetricsResponse) {
-  const frames = data.series.map((series) => {
+  const frames = data.series.map((series, index) => {
     const labels: Labels = {};
     series.labels?.forEach((label) => {
       labels[label.key] = metricsValueToString(label.value);
@@ -654,7 +654,7 @@ export function formatTraceQLMetrics(query: string, data: TraceqlMetricsResponse
       }
     }
     return createDataFrame({
-      refId: series.promLabels,
+      refId: `A${index}`,
       fields: [
         {
           name: 'time',

--- a/public/app/plugins/datasource/tempo/resultTransformer.ts
+++ b/public/app/plugins/datasource/tempo/resultTransformer.ts
@@ -633,7 +633,10 @@ function transformToTraceData(data: TraceSearchMetadata) {
 }
 
 const metricsValueToString = (value: ProtoValue): string => {
-  return '' + (value.stringValue || value.intValue || value.doubleValue || value.boolValue || '""');
+  if (value.stringValue) {
+    return `"${value.stringValue}"`;
+  }
+  return '' + (value.intValue || value.doubleValue || value.boolValue || '""');
 };
 
 export function formatTraceQLMetrics(query: string, data: TraceqlMetricsResponse) {
@@ -650,7 +653,7 @@ export function formatTraceQLMetrics(query: string, data: TraceqlMetricsResponse
         name = metricsValueToString(series.labels[0].value);
       } else {
         // otherwise build a string using the label keys and values
-        name = `{${series.labels.map((label) => `${label.key}=${metricsValueToString(label.value)}`).join(',')}}`;
+        name = `{${series.labels.map((label) => `${label.key}=${metricsValueToString(label.value)}`).join(', ')}}`;
       }
     }
     return createDataFrame({

--- a/public/app/plugins/datasource/tempo/resultTransformer.ts
+++ b/public/app/plugins/datasource/tempo/resultTransformer.ts
@@ -657,7 +657,7 @@ export function formatTraceQLMetrics(query: string, data: TraceqlMetricsResponse
       }
     }
     return createDataFrame({
-      refId: `A${index}`,
+      refId: name || `A${index}`,
       fields: [
         {
           name: 'time',

--- a/public/app/plugins/datasource/tempo/resultTransformer.ts
+++ b/public/app/plugins/datasource/tempo/resultTransformer.ts
@@ -633,19 +633,26 @@ function transformToTraceData(data: TraceSearchMetadata) {
 }
 
 const metricsValueToString = (value: ProtoValue): string => {
-  return '' + (value.stringValue || value.intValue || value.doubleValue || value.boolValue || '');
+  return '' + (value.stringValue || value.intValue || value.doubleValue || value.boolValue || '""');
 };
 
-export function formatTraceQLMetrics(data: TraceqlMetricsResponse) {
+export function formatTraceQLMetrics(query: string, data: TraceqlMetricsResponse) {
   const frames = data.series.map((series) => {
     const labels: Labels = {};
-    series.labels.forEach((label) => {
+    series.labels?.forEach((label) => {
       labels[label.key] = metricsValueToString(label.value);
     });
-    const displayName =
-      series.labels.length === 1
-        ? metricsValueToString(series.labels[0].value)
-        : `{${series.labels.map((label) => `${label.key}=${metricsValueToString(label.value)}`).join(',')}}`;
+    // If it's a single series, use the query as the displayName fallback
+    let name = data.series.length === 1 ? query : '';
+    if (series.labels) {
+      if (series.labels.length === 1) {
+        // For single label series, use the label value as the displayName to improve readability
+        name = metricsValueToString(series.labels[0].value);
+      } else {
+        // otherwise build a string using the label keys and values
+        name = `{${series.labels.map((label) => `${label.key}=${metricsValueToString(label.value)}`).join(',')}}`;
+      }
+    }
     return createDataFrame({
       refId: series.promLabels,
       fields: [
@@ -655,12 +662,12 @@ export function formatTraceQLMetrics(data: TraceqlMetricsResponse) {
           values: series.samples.map((sample) => parseInt(sample.timestampMs, 10)),
         },
         {
-          name: series.promLabels,
+          name: name,
           labels,
           type: FieldType.number,
           values: series.samples.map((sample) => sample.value),
           config: {
-            displayNameFromDS: displayName,
+            displayNameFromDS: name,
           },
         },
       ],


### PR DESCRIPTION

**What is this feature?**

This PR fixes a couple of bugs we were seeing when Tempo returned no labels or labels with empty values for a specific query when using the metrics endpoint.

When there are no labels and the results contains a single series, we fallback to the query string, to mimic the Prometheus datasource.

When the value for a label is an empty string we force the series name to be `""` since this is the actual value of the label. In Tempo the values are typed so we know that `""` is the value of empty string instead of the absence of value. 

**Why do we need this feature?**

We were seeing errors and undesired behaviours when querying the metrics endpoint of Tempo.

**Who is this feature for?**

Users of the Tempo datasource. 

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes https://github.com/grafana/tempo/issues/3429

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
