### PR TITLE
K8s: Prevent the use of arbitrary namespaces

### DIFF
--- a/pkg/services/apiserver/auth/authorizer/org_id.go
+++ b/pkg/services/apiserver/auth/authorizer/org_id.go
@@ -37,9 +37,13 @@ func (auth orgIDAuthorizer) Authorize(ctx context.Context, a authorizer.Attribut
 		return authorizer.DecisionDeny, fmt.Sprintf("error reading namespace: %v", err), nil
 	}
 
-	// No opinion when the namespace is arbitrary
-	if info.OrgID == -1 {
+	// No opinion when the namespace is empty
+	if info.Value == "" {
 		return authorizer.DecisionNoOpinion, "", nil
+	}
+
+	if info.OrgID == -1 {
+		return authorizer.DecisionDeny, "org id is required", nil
 	}
 
 	if info.StackID != "" {

--- a/pkg/services/apiserver/auth/authorizer/stack_id.go
+++ b/pkg/services/apiserver/auth/authorizer/stack_id.go
@@ -37,8 +37,8 @@ func (auth stackIDAuthorizer) Authorize(ctx context.Context, a authorizer.Attrib
 		return authorizer.DecisionDeny, fmt.Sprintf("error reading namespace: %v", err), nil
 	}
 
-	// No opinion when the namespace is arbitrary
-	if info.OrgID == -1 {
+	// No opinion when the namespace is empty
+	if info.Value == "" {
 		return authorizer.DecisionNoOpinion, "", nil
 	}
 


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

Prevent the use of arbitrary namespaces when creating K8s resources.

**Why do we need this feature?**

Currently users can add resources in essentially any namespace that doesn't match the `org-` and `stack-` patterns.

**Who is this feature for?**

[Add information on what kind of user the feature is for.]

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
