### PR TITLE
Chore: Restore vectorator export

### DIFF
--- a/packages/grafana-data/src/index.ts
+++ b/packages/grafana-data/src/index.ts
@@ -46,3 +46,4 @@ export { getLinksSupplier } from './field/fieldOverrides';
 
 // deprecated
 export { CircularVector } from './vector/CircularVector';
+export { vectorator } from './vector/FunctionalVector';

--- a/packages/grafana-data/src/vector/FunctionalVector.ts
+++ b/packages/grafana-data/src/vector/FunctionalVector.ts
@@ -183,7 +183,7 @@ const emptyarray: any[] = [];
  *
  * @deprecated use a simple Arrays
  */
-function vectorator<T>(vector: FunctionalVector<T>) {
+export function vectorator<T>(vector: FunctionalVector<T>) {
   return {
     *[Symbol.iterator]() {
       for (let i = 0; i < vector.length; i++) {


### PR DESCRIPTION
In https://github.com/grafana/grafana/pull/83469 we stopped exporting Vector things...  there is no reason to ever use Vector, so this is not necessary (and has had deprecation messages for 1 year)

But it breaks enough stuff we should keep it for now