### PR TITLE
Table Panel: Improve text wrapping on hover

### DIFF
--- a/packages/grafana-ui/src/components/Table/DefaultCell.tsx
+++ b/packages/grafana-ui/src/components/Table/DefaultCell.tsx
@@ -103,7 +103,7 @@ function getCellStyle(
   displayValue: DisplayValue,
   disableOverflowOnHover = false,
   isStringValue = false,
-  shouldWrapText = false,
+  shouldWrapText = false
 ) {
   // How much to darken elements depends upon if we're in dark mode
   const darkeningFactor = tableStyles.theme.isDark ? 1 : -0.7;
@@ -132,13 +132,23 @@ function getCellStyle(
   // If we have definied colors return those styles
   // Otherwise we return default styles
   if (textColor !== undefined || bgColor !== undefined) {
-    return tableStyles.buildCellContainerStyle(textColor, bgColor, !disableOverflowOnHover, isStringValue, shouldWrapText);
+    return tableStyles.buildCellContainerStyle(
+      textColor,
+      bgColor,
+      !disableOverflowOnHover,
+      isStringValue,
+      shouldWrapText
+    );
   }
 
   if (isStringValue) {
-    return disableOverflowOnHover ? tableStyles.buildCellContainerStyle(undefined, undefined, false, true, shouldWrapText) : tableStyles.buildCellContainerStyle(undefined, undefined, true, true, shouldWrapText);
+    return disableOverflowOnHover
+      ? tableStyles.buildCellContainerStyle(undefined, undefined, false, true, shouldWrapText)
+      : tableStyles.buildCellContainerStyle(undefined, undefined, true, true, shouldWrapText);
   } else {
-    return disableOverflowOnHover ? tableStyles.buildCellContainerStyle(undefined, undefined, false, shouldWrapText) : tableStyles.buildCellContainerStyle(undefined, undefined, true, false, shouldWrapText);
+    return disableOverflowOnHover
+      ? tableStyles.buildCellContainerStyle(undefined, undefined, false, shouldWrapText)
+      : tableStyles.buildCellContainerStyle(undefined, undefined, true, false, shouldWrapText);
   }
 }
 

--- a/packages/grafana-ui/src/components/Table/DefaultCell.tsx
+++ b/packages/grafana-ui/src/components/Table/DefaultCell.tsx
@@ -51,7 +51,8 @@ export const DefaultCell = (props: TableCellProps) => {
 
   const isStringValue = typeof value === 'string';
 
-  const textShouldWrap = displayValue.text.length < OG_TWEET_LENGTH && displayValue.text.search(/\s/) >= 0;
+  // Text should wrap when the content length is less than or equal to the length of an OG tweet and it contains whitespace
+  const textShouldWrap = displayValue.text.length <= OG_TWEET_LENGTH && displayValue.text.search(/\s/) >= 0;
   const cellStyle = getCellStyle(tableStyles, cellOptions, displayValue, inspectEnabled, isStringValue, textShouldWrap);
 
   if (isStringValue) {

--- a/packages/grafana-ui/src/components/Table/DefaultCell.tsx
+++ b/packages/grafana-ui/src/components/Table/DefaultCell.tsx
@@ -52,7 +52,7 @@ export const DefaultCell = (props: TableCellProps) => {
   const isStringValue = typeof value === 'string';
 
   // Text should wrap when the content length is less than or equal to the length of an OG tweet and it contains whitespace
-  const textShouldWrap = displayValue.text.length <= OG_TWEET_LENGTH && displayValue.text.search(/\s/) >= 0;
+  const textShouldWrap = displayValue.text.length <= OG_TWEET_LENGTH && /\s/.test(displayValue.text);
   const cellStyle = getCellStyle(tableStyles, cellOptions, displayValue, inspectEnabled, isStringValue, textShouldWrap);
 
   if (isStringValue) {

--- a/packages/grafana-ui/src/components/Table/DefaultCell.tsx
+++ b/packages/grafana-ui/src/components/Table/DefaultCell.tsx
@@ -29,6 +29,8 @@ export const DefaultCell = (props: TableCellProps) => {
   const [hover, setHover] = useState(false);
   let value: string | ReactElement;
 
+  const OG_TWEET_LENGTH = 140; // 🙏
+
   const onMouseLeave = () => {
     setHover(false);
   };
@@ -49,7 +51,8 @@ export const DefaultCell = (props: TableCellProps) => {
 
   const isStringValue = typeof value === 'string';
 
-  const cellStyle = getCellStyle(tableStyles, cellOptions, displayValue, inspectEnabled, isStringValue);
+  const textShouldWrap = displayValue.text.length < OG_TWEET_LENGTH && displayValue.text.search(/\s/) >= 0;
+  const cellStyle = getCellStyle(tableStyles, cellOptions, displayValue, inspectEnabled, isStringValue, textShouldWrap);
 
   if (isStringValue) {
     let justifyContent = cellProps.style?.justifyContent;
@@ -99,7 +102,8 @@ function getCellStyle(
   cellOptions: TableCellOptions,
   displayValue: DisplayValue,
   disableOverflowOnHover = false,
-  isStringValue = false
+  isStringValue = false,
+  shouldWrapText = false,
 ) {
   // How much to darken elements depends upon if we're in dark mode
   const darkeningFactor = tableStyles.theme.isDark ? 1 : -0.7;
@@ -128,13 +132,13 @@ function getCellStyle(
   // If we have definied colors return those styles
   // Otherwise we return default styles
   if (textColor !== undefined || bgColor !== undefined) {
-    return tableStyles.buildCellContainerStyle(textColor, bgColor, !disableOverflowOnHover, isStringValue);
+    return tableStyles.buildCellContainerStyle(textColor, bgColor, !disableOverflowOnHover, isStringValue, shouldWrapText);
   }
 
   if (isStringValue) {
-    return disableOverflowOnHover ? tableStyles.cellContainerTextNoOverflow : tableStyles.cellContainerText;
+    return disableOverflowOnHover ? tableStyles.buildCellContainerStyle(undefined, undefined, false, true, shouldWrapText) : tableStyles.buildCellContainerStyle(undefined, undefined, true, true, shouldWrapText);
   } else {
-    return disableOverflowOnHover ? tableStyles.cellContainerNoOverflow : tableStyles.cellContainer;
+    return disableOverflowOnHover ? tableStyles.buildCellContainerStyle(undefined, undefined, false, shouldWrapText) : tableStyles.buildCellContainerStyle(undefined, undefined, true, false, shouldWrapText);
   }
 }
 

--- a/packages/grafana-ui/src/components/Table/styles.ts
+++ b/packages/grafana-ui/src/components/Table/styles.ts
@@ -15,7 +15,8 @@ export function useTableStyles(theme: GrafanaTheme2, cellHeightOption: TableCell
     color?: string,
     background?: string,
     overflowOnHover?: boolean,
-    asCellText?: boolean
+    asCellText?: boolean,
+    textShouldWrap?: boolean,
   ) => {
     return css({
       label: overflowOnHover ? 'cellContainerOverflow' : 'cellContainerNoOverflow',
@@ -48,10 +49,10 @@ export function useTableStyles(theme: GrafanaTheme2, cellHeightOption: TableCell
 
       '&:hover': {
         overflow: overflowOnHover ? 'visible' : undefined,
-        width: overflowOnHover ? 'auto' : undefined,
-        height: overflowOnHover ? 'auto' : `${rowHeight - 1}px`,
+        width: textShouldWrap ? 'auto' : 'auto !important',
+        height: textShouldWrap ? 'auto !important' : `${rowHeight - 1}px`,
         minHeight: `${rowHeight - 1}px`,
-        wordBreak: overflowOnHover ? 'break-word' : undefined,
+        wordBreak: textShouldWrap ? 'break-word' : undefined,
         whiteSpace: overflowOnHover ? 'normal' : 'nowrap',
         boxShadow: overflowOnHover ? `0 0 2px ${theme.colors.primary.main}` : undefined,
         background: overflowOnHover ? background ?? theme.components.table.rowHoverBackground : undefined,
@@ -161,11 +162,6 @@ export function useTableStyles(theme: GrafanaTheme2, cellHeightOption: TableCell
         color: theme.colors.text.link,
       },
     }),
-    cellContainerText: buildCellContainerStyle(undefined, undefined, true, true),
-    cellContainerTextNoOverflow: buildCellContainerStyle(undefined, undefined, false, true),
-
-    cellContainer: buildCellContainerStyle(undefined, undefined, true, false),
-    cellContainerNoOverflow: buildCellContainerStyle(undefined, undefined, false, false),
     cellText: css({
       overflow: 'hidden',
       textOverflow: 'ellipsis',

--- a/packages/grafana-ui/src/components/Table/styles.ts
+++ b/packages/grafana-ui/src/components/Table/styles.ts
@@ -16,7 +16,7 @@ export function useTableStyles(theme: GrafanaTheme2, cellHeightOption: TableCell
     background?: string,
     overflowOnHover?: boolean,
     asCellText?: boolean,
-    textShouldWrap?: boolean,
+    textShouldWrap?: boolean
   ) => {
     return css({
       label: overflowOnHover ? 'cellContainerOverflow' : 'cellContainerNoOverflow',

--- a/packages/grafana-ui/src/components/Table/styles.ts
+++ b/packages/grafana-ui/src/components/Table/styles.ts
@@ -162,6 +162,11 @@ export function useTableStyles(theme: GrafanaTheme2, cellHeightOption: TableCell
         color: theme.colors.text.link,
       },
     }),
+    cellContainerText: buildCellContainerStyle(undefined, undefined, true, true),
+    cellContainerTextNoOverflow: buildCellContainerStyle(undefined, undefined, false, true),
+
+    cellContainer: buildCellContainerStyle(undefined, undefined, true, false),
+    cellContainerNoOverflow: buildCellContainerStyle(undefined, undefined, false, false),
     cellText: css({
       overflow: 'hidden',
       textOverflow: 'ellipsis',


### PR DESCRIPTION
**What is this feature?**

This is an elaboration on #83352 and cleans up the code. This implements more advanced behavior for text wrapping when cells are hovered.

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
