### PR TITLE
RBAC: Add batching to role permissions queries in migrations

### DIFF
--- a/pkg/services/sqlstore/migrations/accesscontrol/dashboard_permissions.go
+++ b/pkg/services/sqlstore/migrations/accesscontrol/dashboard_permissions.go
@@ -356,7 +356,16 @@ func (m *managedFolderAlertActionsMigrator) Exec(sess *xorm.Session, mg *migrato
 	}
 
 	var permissions []ac.Permission
-	if err := sess.SQL("SELECT role_id, action, scope FROM permission WHERE role_id IN(?"+strings.Repeat(" ,?", len(ids)-1)+") AND scope LIKE 'folders:%'", ids...).Find(&permissions); err != nil {
+	roleQueryBatchSize := 100
+	err := batch(len(ids), roleQueryBatchSize, func(start, end int) error {
+		var batchPermissions []ac.Permission
+		if err := sess.SQL("SELECT role_id, action, scope FROM permission WHERE role_id IN(?"+strings.Repeat(" ,?", len(ids[start:end])-1)+") AND scope LIKE 'folders:%'", ids[start:end]...).Find(&batchPermissions); err != nil {
+			return err
+		}
+		permissions = append(permissions, batchPermissions...)
+		return nil
+	})
+	if err != nil {
 		return err
 	}
 
@@ -416,7 +425,7 @@ func (m *managedFolderAlertActionsMigrator) Exec(sess *xorm.Session, mg *migrato
 		return nil
 	}
 
-	err := batch(len(toAdd), batchSize, func(start, end int) error {
+	err = batch(len(toAdd), batchSize, func(start, end int) error {
 		if _, err := sess.InsertMulti(toAdd[start:end]); err != nil {
 			return err
 		}
@@ -468,7 +477,16 @@ func (m *managedFolderAlertActionsRepeatMigrator) Exec(sess *xorm.Session, mg *m
 	}
 
 	var permissions []ac.Permission
-	if err := sess.SQL("SELECT role_id, action, scope FROM permission WHERE role_id IN(?"+strings.Repeat(" ,?", len(ids)-1)+") AND scope LIKE 'folders:%'", ids...).Find(&permissions); err != nil {
+	roleQueryBatchSize := 100
+	err := batch(len(ids), roleQueryBatchSize, func(start, end int) error {
+		var batchPermissions []ac.Permission
+		if err := sess.SQL("SELECT role_id, action, scope FROM permission WHERE role_id IN(?"+strings.Repeat(" ,?", len(ids[start:end])-1)+") AND scope LIKE 'folders:%'", ids[start:end]...).Find(&batchPermissions); err != nil {
+			return err
+		}
+		permissions = append(permissions, batchPermissions...)
+		return nil
+	})
+	if err != nil {
 		return err
 	}
 
@@ -542,7 +560,7 @@ func (m *managedFolderAlertActionsRepeatMigrator) Exec(sess *xorm.Session, mg *m
 		return nil
 	}
 
-	err := batch(len(toAdd), batchSize, func(start, end int) error {
+	err = batch(len(toAdd), batchSize, func(start, end int) error {
 		if _, err := sess.InsertMulti(toAdd[start:end]); err != nil {
 			return err
 		}
@@ -582,7 +600,16 @@ func (m *managedFolderLibraryPanelActionsMigrator) Exec(sess *xorm.Session, mg *
 	}
 
 	var permissions []ac.Permission
-	if err := sess.SQL("SELECT role_id, action, scope FROM permission WHERE role_id IN(?"+strings.Repeat(" ,?", len(ids)-1)+") AND scope LIKE 'folders:%'", ids...).Find(&permissions); err != nil {
+	roleQueryBatchSize := 100
+	err := batch(len(ids), roleQueryBatchSize, func(start, end int) error {
+		var batchPermissions []ac.Permission
+		if err := sess.SQL("SELECT role_id, action, scope FROM permission WHERE role_id IN(?"+strings.Repeat(" ,?", len(ids[start:end])-1)+") AND scope LIKE 'folders:%'", ids[start:end]...).Find(&batchPermissions); err != nil {
+			return err
+		}
+		permissions = append(permissions, batchPermissions...)
+		return nil
+	})
+	if err != nil {
 		return err
 	}
 
@@ -647,7 +674,7 @@ func (m *managedFolderLibraryPanelActionsMigrator) Exec(sess *xorm.Session, mg *
 		return nil
 	}
 
-	err := batch(len(toAdd), batchSize, func(start, end int) error {
+	err = batch(len(toAdd), batchSize, func(start, end int) error {
 		if _, err := sess.InsertMulti(toAdd[start:end]); err != nil {
 			return err
 		}


### PR DESCRIPTION
Fixes #83649.

Followup to dadfc5613dbaed70b6d02dadbc7f895e7f223d14 and https://github.com/grafana/grafana/pull/78899#discussion_r1447430195. Performs the same role-permissions query batching for other similar migrations that may exceed engine limits for customers with lots of managed roles.