### PR TITLE
Dashboard:  option to cut filling of values to current moment using timeGroup or unixEpochGroup macros

### DIFF
--- a/pkg/tsdb/mysql/macros.go
+++ b/pkg/tsdb/mysql/macros.go
@@ -98,7 +98,7 @@ func (m *mySQLMacroEngine) evaluateMacro(timeRange backend.TimeRange, query *bac
 		if len(args) == 4 && args[3] == "true" {
 			query.TimeRange.To = time.Now()
 		} else if len(args) == 4 && args[3] != "false" {
-			return "", fmt.Errorf("fourth argument must be 'true' or 'false'")
+			return "", fmt.Errorf("fourth argument of %v must be 'true' or 'false'", name)
 		}
 		return fmt.Sprintf("UNIX_TIMESTAMP(%s) DIV %.0f * %.0f", args[0], interval.Seconds(), interval.Seconds()), nil
 	case "__timeGroupAlias":
@@ -138,7 +138,7 @@ func (m *mySQLMacroEngine) evaluateMacro(timeRange backend.TimeRange, query *bac
 		if len(args) == 4 && args[3] == "true" {
 			query.TimeRange.To = time.Now()
 		} else if len(args) == 4 && args[3] != "false" {
-			return "", fmt.Errorf("fourth argument must be 'true' or 'false'")
+			return "", fmt.Errorf("fourth argument of %v must be 'true' or 'false'", name)
 		}
 		return fmt.Sprintf("%s DIV %v * %v", args[0], interval.Seconds(), interval.Seconds()), nil
 	case "__unixEpochGroupAlias":

--- a/pkg/tsdb/mysql/macros.go
+++ b/pkg/tsdb/mysql/macros.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"regexp"
 	"strings"
+	"time"
 
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
 	"github.com/grafana/grafana-plugin-sdk-go/backend/gtime"
@@ -88,11 +89,16 @@ func (m *mySQLMacroEngine) evaluateMacro(timeRange backend.TimeRange, query *bac
 		if err != nil {
 			return "", fmt.Errorf("error parsing interval %v", args[1])
 		}
-		if len(args) == 3 {
+		if len(args) == 3 || len(args) == 4 {
 			err := sqleng.SetupFillmode(query, interval, args[2])
 			if err != nil {
 				return "", err
 			}
+		}
+		if len(args) == 4 && args[3] == "true" {
+			query.TimeRange.To = time.Now()
+		} else if len(args) == 4 && args[3] != "false" {
+			return "", fmt.Errorf("fourth argument must be 'true' or 'false'")
 		}
 		return fmt.Sprintf("UNIX_TIMESTAMP(%s) DIV %.0f * %.0f", args[0], interval.Seconds(), interval.Seconds()), nil
 	case "__timeGroupAlias":
@@ -123,11 +129,16 @@ func (m *mySQLMacroEngine) evaluateMacro(timeRange backend.TimeRange, query *bac
 		if err != nil {
 			return "", fmt.Errorf("error parsing interval %v", args[1])
 		}
-		if len(args) == 3 {
+		if len(args) == 3 || len(args) == 4 {
 			err := sqleng.SetupFillmode(query, interval, args[2])
 			if err != nil {
 				return "", err
 			}
+		}
+		if len(args) == 4 && args[3] == "true" {
+			query.TimeRange.To = time.Now()
+		} else if len(args) == 4 && args[3] != "false" {
+			return "", fmt.Errorf("fourth argument must be 'true' or 'false'")
 		}
 		return fmt.Sprintf("%s DIV %v * %v", args[0], interval.Seconds(), interval.Seconds()), nil
 	case "__unixEpochGroupAlias":


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

This feature gives user option to specify the time range of filled values used in timeGroup macro

**Which issue(s) does this PR fix?**:

Closes #83663 

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
