### PR TITLE
Alerting docs: remove admonition/notes related to old Grafana versions

### DIFF
--- a/docs/sources/alerting/configure-notifications/create-notification-policy.md
+++ b/docs/sources/alerting/configure-notifications/create-notification-policy.md
@@ -37,10 +37,6 @@ For more information on notification policies, see [fundamentals of Notification
 
 ## Edit default notification policy
 
-{{% admonition type="note" %}}
-Before Grafana v8.2, the configuration of the embedded Alertmanager was shared across organizations. Users of Grafana 8.0 and 8.1 are advised to use the new Grafana 8 Alerts only if they have one organization. Otherwise, silences for the Grafana managed alerts will be visible by all organizations.
-{{% /admonition %}}
-
 1. In the left-side menu, click **Alerts & IRM** and then **Alerting**.
 1. Click **Notification policies**.
 1. From the **Choose Alertmanager** dropdown, select an external Alertmanager. By default, the **Grafana Alertmanager** is selected.

--- a/docs/sources/alerting/set-up/configure-alertmanager/index.md
+++ b/docs/sources/alerting/set-up/configure-alertmanager/index.md
@@ -27,11 +27,7 @@ Grafana Alerting does not support sending alerts to the AWS Managed Service for 
 
 Once you have added the Alertmanager, you can use the Grafana Alerting UI to manage silences, contact points, and notification policies. A drop-down option in these pages allows you to switch between alertmanagers.
 
-{{% admonition type="note" %}}
-Starting with Grafana 9.2, the URL configuration of external alertmanagers from the Admin tab on the Alerting page is deprecated. It will be removed in a future release.
-{{% /admonition %}}
-
-External alertmanagers should now be configured as data sources using Grafana Configuration from the main Grafana navigation menu. This enables you to manage the contact points and notification policies of external alertmanagers from within Grafana and also encrypts HTTP basic authentication credentials that were previously visible when configuring external alertmanagers by URL.
+External alertmanagers should now be configured as data sources using Grafana Configuration from the main Grafana navigation menu. This enables you to manage the contact points and notification policies of external alertmanagers from within Grafana and also encrypts HTTP basic authentication credentials.
 
 To add an external Alertmanager, complete the following steps.
 


### PR DESCRIPTION
This PR removes alerting notes about old Grafana versions. 

The current documentation supports instructions to the latest major release.  Notes or instructions related to previous versions are irrelevant and should be removed. 