### PR TITLE
grafana-data: fix the export of arrayvector

### DIFF
--- a/packages/grafana-data/src/index.ts
+++ b/packages/grafana-data/src/index.ts
@@ -47,3 +47,4 @@ export { getLinksSupplier } from './field/fieldOverrides';
 // deprecated
 export { CircularVector } from './vector/CircularVector';
 export { vectorator } from './vector/FunctionalVector';
+export { ArrayVector } from './vector/ArrayVector';


### PR DESCRIPTION
in https://github.com/grafana/grafana/pull/83608 `ArrayVector` was added back to grafana, but it was not exported. this PR fixes that. 