### PR TITLE
Chore: Taint ArrayVector with `never` to further discourage

### DIFF
--- a/.betterer.results
+++ b/.betterer.results
@@ -439,11 +439,6 @@ exports[`better eslint`] = {
       [0, 0, 0, "Unexpected any. Specify a different type.", "3"],
       [0, 0, 0, "Unexpected any. Specify a different type.", "4"]
     ],
-    "packages/grafana-data/src/vector/ArrayVector.ts:5381": [
-      [0, 0, 0, "Unexpected any. Specify a different type.", "0"],
-      [0, 0, 0, "Unexpected any. Specify a different type.", "1"],
-      [0, 0, 0, "Unexpected any. Specify a different type.", "2"]
-    ],
     "packages/grafana-data/src/vector/CircularVector.ts:5381": [
       [0, 0, 0, "Unexpected any. Specify a different type.", "0"]
     ],

--- a/packages/grafana-data/src/vector/ArrayVector.test.ts
+++ b/packages/grafana-data/src/vector/ArrayVector.test.ts
@@ -2,6 +2,9 @@ import { Field, FieldType } from '../types';
 
 import { ArrayVector } from './ArrayVector';
 
+// There's lots of @ts-expect-error here, because we actually expect it to be a typescript error
+// to further encourge developers not to use ArrayVector
+
 describe('ArrayVector', () => {
   beforeEach(() => {
     jest.spyOn(console, 'warn').mockImplementation();
@@ -9,12 +12,14 @@ describe('ArrayVector', () => {
 
   it('should init 150k with 65k Array.push() chonking', () => {
     const arr = Array.from({ length: 150e3 }, (v, i) => i);
+    /// @ts-expect-error
     const av = new ArrayVector(arr);
 
     expect(av.toArray()).toEqual(arr);
   });
 
   it('should support add and push', () => {
+    /// @ts-expect-error
     const av = new ArrayVector<number>();
     av.add(1);
     av.push(2);
@@ -28,17 +33,26 @@ describe('ArrayVector', () => {
       name: 'test',
       config: {},
       type: FieldType.number,
+      /// @ts-expect-error
       values: new ArrayVector(), // this defaults to `new ArrayVector<any>()`
     };
     expect(field).toBeDefined();
 
     // Before collapsing Vector, ReadWriteVector, and MutableVector these all worked fine
+
+    /// @ts-expect-error
     field.values = new ArrayVector();
+    /// @ts-expect-error
     field.values = new ArrayVector(undefined);
+    /// @ts-expect-error
     field.values = new ArrayVector([1, 2, 3]);
+    /// @ts-expect-error
     field.values = new ArrayVector([]);
+    /// @ts-expect-error
     field.values = new ArrayVector([1, undefined]);
+    /// @ts-expect-error
     field.values = new ArrayVector([null]);
+    /// @ts-expect-error
     field.values = new ArrayVector(['a', 'b', 'c']);
     expect(field.values.length).toBe(3);
   });

--- a/packages/grafana-data/src/vector/ArrayVector.ts
+++ b/packages/grafana-data/src/vector/ArrayVector.ts
@@ -6,12 +6,12 @@ let notified = false;
  *
  * @deprecated use a simple Array<T>
  */
-export class ArrayVector<T = any> extends Array<T> {
+export class ArrayVector<T = unknown> extends Array<T> {
   get buffer() {
     return this;
   }
 
-  set buffer(values: any[]) {
+  set buffer(values: T[]) {
     this.length = 0;
 
     const len = values?.length;
@@ -27,10 +27,10 @@ export class ArrayVector<T = any> extends Array<T> {
   }
 
   /**
-   * This any type is here to make the change type changes in v10 non breaking for plugins.
-   * Before you could technically assign field.values any typed ArrayVector no matter what the Field<T> T type was.
+   * ArrayVector is deprecated and should not be used. If you get a Typescript error here, use plain arrays for field.values.
    */
-  constructor(buffer?: any[]) {
+  // `never` is used to force a build-type error from Typescript to encourage developers to move away from using this
+  constructor(buffer: never) {
     super();
     this.buffer = buffer ?? [];
 


### PR DESCRIPTION
Following [ArrayVector's deprecation](https://github.com/grafana/grafana/pull/66187), its constructor is now marked with `never` so it generates Typescript errors at build time, encouraging developers to switch to using plain arrays.

ArrayVector remains the same at runtime to prevent any breakages, and the array prototype hack still remains.

This will only impact developers at build-time when updating @grafana/data to the future version 11.

# Release notice breaking change

The Vector interface that was deprecated in Grafana 10 has been further deprecated. Using it will now generate build-time Typescript errors, but remain working at runtime. If you're still using ArrayVector in your code, it should be removed immediately and replaced with plain arrays. Plugins compiled against older versions and depend on calling get/set will continue to work because the Array prototype still has a modified prototype.  This will be removed in the future