### PR TITLE
[v10.1.x] Fix typos

### DIFF
--- a/.github/bot.md
+++ b/.github/bot.md
@@ -9,8 +9,8 @@ Comment commands:
 
 Label commands:
 
-* Add label `bot/question` the the bot will close with standard question message and add label `type/question`
-* Add label `bot/duplicate` the the bot will close with standard duplicate message and add label `type/duplicate`
+* Add label `bot/question` the bot will close with standard question message and add label `type/question`
+* Add label `bot/duplicate` the bot will close with standard duplicate message and add label `type/duplicate`
 * Add label `bot/needs more info` for bot to request more info (or use comment command mentioned above)
 * Add label `bot/close feature request` for bot to close a feature request with standard message and adds label `not implemented`
 * Add label `bot/no new info` for bot to close an issue where we asked for more info but has not received any updates in at least 14 days.

--- a/contribute/style-guides/frontend.md
+++ b/contribute/style-guides/frontend.md
@@ -180,7 +180,7 @@ const getStyles = (theme: GrafanaTheme2) => ({
 });
 ```
 
-Use hook useStyles2(getStyles) to memoize the styles generation and try to avoid passing props to the the getStyles function and instead compose classes using emotion cx function.
+Use hook useStyles2(getStyles) to memoize the styles generation and try to avoid passing props to the getStyles function and instead compose classes using emotion cx function.
 
 #### Use `ALL_CAPS` for constants.
 

--- a/docs/sources/alerting/set-up/provision-alerting-resources/file-provisioning/index.md
+++ b/docs/sources/alerting/set-up/provision-alerting-resources/file-provisioning/index.md
@@ -606,7 +606,7 @@ templates:
   - orgId: 1
     # <string, required> name of the template, must be unique
     name: my_first_template
-    # <string, required> content of the the template
+    # <string, required> content of the template
     template: Alerting with a custom text template
 ```
 

--- a/docs/sources/datasources/azure-monitor/query-editor/index.md
+++ b/docs/sources/datasources/azure-monitor/query-editor/index.md
@@ -90,7 +90,7 @@ For example:
 | ----------------------------- | ------------------------------------------------------------------------------------------------------ |
 | `{{ subscriptionid }}`        | Replaced with the subscription ID.                                                                     |
 | `{{ subscription }}`          | Replaced with the subscription name.                                                                   |
-| `{{ resourcegroup }}`         | Replaced with the resource group.                                                                  |
+| `{{ resourcegroup }}`         | Replaced with the resource group.                                                                      |
 | `{{ namespace }}`             | Replaced with the resource type or namespace, such as `Microsoft.Compute/virtualMachines`.             |
 | `{{ resourcename }}`          | Replaced with the resource name.                                                                       |
 | `{{ metric }}`                | Replaced with the metric name, such as "Percentage CPU".                                               |

--- a/docs/sources/datasources/azure-monitor/query-editor/index.md
+++ b/docs/sources/datasources/azure-monitor/query-editor/index.md
@@ -90,7 +90,7 @@ For example:
 | ----------------------------- | ------------------------------------------------------------------------------------------------------ |
 | `{{ subscriptionid }}`        | Replaced with the subscription ID.                                                                     |
 | `{{ subscription }}`          | Replaced with the subscription name.                                                                   |
-| `{{ resourcegroup }}`         | Replaced with the the resource group.                                                                  |
+| `{{ resourcegroup }}`         | Replaced with the resource group.                                                                  |
 | `{{ namespace }}`             | Replaced with the resource type or namespace, such as `Microsoft.Compute/virtualMachines`.             |
 | `{{ resourcename }}`          | Replaced with the resource name.                                                                       |
 | `{{ metric }}`                | Replaced with the metric name, such as "Percentage CPU".                                               |

--- a/docs/sources/shared/visualizations/connect-null-values.md
+++ b/docs/sources/shared/visualizations/connect-null-values.md
@@ -8,6 +8,6 @@ Choose how null values, which are gaps in the data, appear on the graph. Null va
 
 ![Connect null values option](/static/img/docs/time-series-panel/connect-null-values-option-v9.png)
 
-- **Never:** Time series data points with gaps in the the data are never connected.
-- **Always:** Time series data points with gaps in the the data are always connected.
+- **Never:** Time series data points with gaps in the data are never connected.
+- **Always:** Time series data points with gaps in the data are always connected.
 - **Threshold:** Specify a threshold above which gaps in the data are no longer connected. This can be useful when the connected gaps in the data are of a known size and/or within a known range, and gaps outside this range should no longer be connected.

--- a/docs/sources/shared/visualizations/disconnect-values.md
+++ b/docs/sources/shared/visualizations/disconnect-values.md
@@ -8,5 +8,5 @@ Choose whether to set a threshold above which values in the data should be disco
 
 {{< figure src="/media/docs/grafana/screenshot-grafana-10-1-disconnect-values.png" max-width="750px" >}}
 
-- **Never:** Time series data points in the the data are never disconnected.
+- **Never:** Time series data points in the data are never disconnected.
 - **Threshold:** Specify a threshold above which values in the data are disconnected. This can be useful when desired values in the data are of a known size and/or within a known range, and values outside this range should no longer be connected.


### PR DESCRIPTION
Backport 2a429cd7db84d2783311b81c6334260107922fce from #83621

---

Fix typos
