### PR TITLE
Dashboard: Hide time picker option will hide only time range picker

### DIFF
--- a/public/app/features/dashboard-scene/scene/DashboardControls.tsx
+++ b/public/app/features/dashboard-scene/scene/DashboardControls.tsx
@@ -54,12 +54,12 @@ function DashboardControlsRenderer({ model }: SceneComponentProps<DashboardContr
         {!editPanel && <DashboardLinksControls links={links} uid={dashboard.state.uid} />}
         {editPanel && <PanelEditControls panelEditor={editPanel} />}
       </Stack>
-      {!hideTimeControls && (
-        <Stack justifyContent={'flex-end'}>
+      <Stack justifyContent={'flex-end'}>
+        {!hideTimeControls && (
           <timePicker.Component model={timePicker} />
-          <refreshPicker.Component model={refreshPicker} />
-        </Stack>
-      )}
+        )}
+        <refreshPicker.Component model={refreshPicker} />
+      </Stack>
       {showDebugger && <SceneDebugger scene={model} key={'scene-debugger'} />}
     </div>
   );

--- a/public/app/features/dashboard/components/DashNav/DashNav.tsx
+++ b/public/app/features/dashboard/components/DashNav/DashNav.tsx
@@ -258,11 +258,7 @@ export const DashNav = React.memo<Props>((props) => {
   };
 
   const renderTimeControls = () => {
-    const { dashboard, updateTimeZoneForSession, hideTimePicker } = props;
-
-    if (hideTimePicker) {
-      return null;
-    }
+    const { dashboard, updateTimeZoneForSession } = props;
     return (
       <DashNavTimeControls
         dashboard={dashboard}

--- a/public/app/features/dashboard/components/DashNav/DashNavTimeControls.test.tsx
+++ b/public/app/features/dashboard/components/DashNav/DashNavTimeControls.test.tsx
@@ -66,4 +66,20 @@ describe('DashNavTimeControls', () => {
     );
     expect(container.queryByLabelText(/Refresh dashboard/i)).toBeInTheDocument();
   });
+
+  it('should render RefreshPicker in dashboard when timepicker is disabled', () => {
+    dashboardModel.timepicker = { hidden: true }
+    const container = render(
+      <DashNavTimeControls dashboard={dashboardModel} onChangeTimeZone={jest.fn()} key="time-controls" />
+    );
+    expect(container.queryByLabelText(/Refresh dashboard/i)).toBeInTheDocument();
+  });
+
+  it('should not render TimePickerWithHistory in dashboard when timepicker is disabled', () => {
+    dashboardModel.timepicker = { hidden: true }
+    const container = render(
+      <DashNavTimeControls dashboard={dashboardModel} onChangeTimeZone={jest.fn()} key="time-controls" />
+    );
+    expect(container.queryByLabelText(/Time range selected/i)).toBeFalsy();
+  });
 });

--- a/public/app/features/dashboard/components/DashNav/DashNavTimeControls.tsx
+++ b/public/app/features/dashboard/components/DashNav/DashNavTimeControls.tsx
@@ -93,7 +93,7 @@ export class DashNavTimeControls extends Component<Props> {
 
   render() {
     const { dashboard, isOnCanvas } = this.props;
-    const { refresh_intervals } = dashboard.timepicker;
+    const { refresh_intervals, hidden } = dashboard.timepicker;
     const intervals = getTimeSrv().getValidIntervals(refresh_intervals || defaultIntervals);
 
     const timePickerValue = getTimeSrv().timeRange();
@@ -108,7 +108,7 @@ export class DashNavTimeControls extends Component<Props> {
 
     return (
       <>
-        <TimePickerWithHistory
+        {!hidden && (<TimePickerWithHistory
           value={timePickerValue}
           onChange={this.onChangeTimePicker}
           timeZone={timeZone}
@@ -120,7 +120,7 @@ export class DashNavTimeControls extends Component<Props> {
           onChangeFiscalYearStartMonth={this.onChangeFiscalYearStartMonth}
           isOnCanvas={isOnCanvas}
           onToolbarTimePickerClick={this.props.onToolbarTimePickerClick}
-        />
+        />)}
         <RefreshPicker
           onIntervalChanged={this.onChangeRefreshInterval}
           onRefresh={this.onRefreshClick}


### PR DESCRIPTION
**What is this feature?**
On dashboard hide time picker, only time range picker will be hidden
![image](https://github.com/grafana/grafana/assets/23135339/b41d172f-d3af-4dc3-b717-58dd4b4d1291)

**Why do we need this feature?**
Hiding both time range picker and refresh button with hide time picker is bit miss leading. 
That refresh button sometimes is required, when dashboard does not need a time picker we hide it, but then the refresh button will disappear and to reload a new set of data we need to refresh the whole dashboard page... Also the auto refresh dropdown will go away and we will not be able to set the refresh interval in that case.

**Who is this feature for?**
Grafana enthusiasts and users

**Which issue(s) does this PR fix?**:
Fixes https://github.com/grafana/grafana/issues/11782

**Special notes for your reviewer:**
👋

Please check that:
- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [x] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
