### PR TITLE
LDAP: Fix LDAP users authenticated via auth proxy not being able to use LDAP active sync

### DIFF
--- a/pkg/services/authn/authnimpl/service.go
+++ b/pkg/services/authn/authnimpl/service.go
@@ -123,7 +123,7 @@ func ProvideService(
 	}
 
 	if s.cfg.AuthProxyEnabled && len(proxyClients) > 0 {
-		proxy, err := clients.ProvideProxy(cfg, cache, userService, proxyClients...)
+		proxy, err := clients.ProvideProxy(cfg, cache, userService, authInfoService, proxyClients...)
 		if err != nil {
 			s.log.Error("Failed to configure auth proxy", "err", err)
 		} else {

--- a/pkg/services/authn/authnimpl/service.go
+++ b/pkg/services/authn/authnimpl/service.go
@@ -123,7 +123,7 @@ func ProvideService(
 	}
 
 	if s.cfg.AuthProxyEnabled && len(proxyClients) > 0 {
-		proxy, err := clients.ProvideProxy(cfg, cache, userService, authInfoService, proxyClients...)
+		proxy, err := clients.ProvideProxy(cfg, cache, proxyClients...)
 		if err != nil {
 			s.log.Error("Failed to configure auth proxy", "err", err)
 		} else {

--- a/pkg/services/authn/clients/proxy.go
+++ b/pkg/services/authn/clients/proxy.go
@@ -96,9 +96,8 @@ func (c *Proxy) Authenticate(ctx context.Context, r *authn.Request) (*authn.Iden
 					// Maybe caching the auth module used with the user ID would be a good idea
 					AuthenticatedBy: login.AuthProxyAuthModule,
 					ClientParams: authn.ClientParams{
-						FetchSyncedUser:   true,
-						SyncPermissions:   true,
-						CacheAuthProxyKey: cacheKey,
+						FetchSyncedUser: true,
+						SyncPermissions: true,
 					},
 				}, nil
 			}

--- a/pkg/services/authn/clients/proxy.go
+++ b/pkg/services/authn/clients/proxy.go
@@ -15,7 +15,6 @@ import (
 	authidentity "github.com/grafana/grafana/pkg/services/auth/identity"
 	"github.com/grafana/grafana/pkg/services/authn"
 	"github.com/grafana/grafana/pkg/services/login"
-	"github.com/grafana/grafana/pkg/services/user"
 	"github.com/grafana/grafana/pkg/setting"
 	"github.com/grafana/grafana/pkg/util"
 	"github.com/grafana/grafana/pkg/util/errutil"
@@ -43,12 +42,12 @@ var (
 	_ authn.ContextAwareClient = new(Proxy)
 )
 
-func ProvideProxy(cfg *setting.Cfg, cache proxyCache, userSrv user.Service, authInfoService login.AuthInfoService, clients ...authn.ProxyClient) (*Proxy, error) {
+func ProvideProxy(cfg *setting.Cfg, cache proxyCache, clients ...authn.ProxyClient) (*Proxy, error) {
 	list, err := parseAcceptList(cfg.AuthProxyWhitelist)
 	if err != nil {
 		return nil, err
 	}
-	return &Proxy{log.New(authn.ClientProxy), cfg, cache, userSrv, authInfoService, clients, list}, nil
+	return &Proxy{log.New(authn.ClientProxy), cfg, cache, clients, list}, nil
 }
 
 type proxyCache interface {
@@ -58,13 +57,11 @@ type proxyCache interface {
 }
 
 type Proxy struct {
-	log             log.Logger
-	cfg             *setting.Cfg
-	cache           proxyCache
-	userSrv         user.Service
-	authInfoService login.AuthInfoService
-	clients         []authn.ProxyClient
-	acceptedIPs     []*net.IPNet
+	log         log.Logger
+	cfg         *setting.Cfg
+	cache       proxyCache
+	clients     []authn.ProxyClient
+	acceptedIPs []*net.IPNet
 }
 
 func (c *Proxy) Name() string {

--- a/pkg/services/authn/clients/proxy_test.go
+++ b/pkg/services/authn/clients/proxy_test.go
@@ -13,8 +13,6 @@ import (
 
 	"github.com/grafana/grafana/pkg/services/authn"
 	"github.com/grafana/grafana/pkg/services/authn/authntest"
-	"github.com/grafana/grafana/pkg/services/login/authinfotest"
-	"github.com/grafana/grafana/pkg/services/user/usertest"
 	"github.com/grafana/grafana/pkg/setting"
 )
 
@@ -114,7 +112,7 @@ func TestProxy_Authenticate(t *testing.T) {
 				calledAdditional = additional
 				return nil, nil
 			}}
-			c, err := ProvideProxy(cfg, &fakeCache{expectedErr: errors.New("")}, usertest.NewUserServiceFake(), &authinfotest.FakeService{}, proxyClient)
+			c, err := ProvideProxy(cfg, &fakeCache{expectedErr: errors.New("")}, proxyClient)
 			require.NoError(t, err)
 
 			_, err = c.Authenticate(context.Background(), tt.req)
@@ -211,7 +209,7 @@ func TestProxy_Hook(t *testing.T) {
 	withRole := func(role string) func(t *testing.T) {
 		cacheKey := fmt.Sprintf("users:johndoe-%s", role)
 		return func(t *testing.T) {
-			c, err := ProvideProxy(cfg, cache, usertest.NewUserServiceFake(), &authinfotest.FakeService{}, authntest.MockProxyClient{})
+			c, err := ProvideProxy(cfg, cache, authntest.MockProxyClient{})
 			require.NoError(t, err)
 			userIdentity := &authn.Identity{
 				ID: userID,

--- a/pkg/services/authn/clients/proxy_test.go
+++ b/pkg/services/authn/clients/proxy_test.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/grafana/grafana/pkg/services/authn"
 	"github.com/grafana/grafana/pkg/services/authn/authntest"
+	"github.com/grafana/grafana/pkg/services/login/authinfotest"
 	"github.com/grafana/grafana/pkg/services/user/usertest"
 	"github.com/grafana/grafana/pkg/setting"
 )
@@ -113,7 +114,7 @@ func TestProxy_Authenticate(t *testing.T) {
 				calledAdditional = additional
 				return nil, nil
 			}}
-			c, err := ProvideProxy(cfg, &fakeCache{expectedErr: errors.New("")}, usertest.NewUserServiceFake(), proxyClient)
+			c, err := ProvideProxy(cfg, &fakeCache{expectedErr: errors.New("")}, usertest.NewUserServiceFake(), &authinfotest.FakeService{}, proxyClient)
 			require.NoError(t, err)
 
 			_, err = c.Authenticate(context.Background(), tt.req)
@@ -210,7 +211,7 @@ func TestProxy_Hook(t *testing.T) {
 	withRole := func(role string) func(t *testing.T) {
 		cacheKey := fmt.Sprintf("users:johndoe-%s", role)
 		return func(t *testing.T) {
-			c, err := ProvideProxy(cfg, cache, usertest.NewUserServiceFake(), authntest.MockProxyClient{})
+			c, err := ProvideProxy(cfg, cache, usertest.NewUserServiceFake(), &authinfotest.FakeService{}, authntest.MockProxyClient{})
 			require.NoError(t, err)
 			userIdentity := &authn.Identity{
 				ID: userID,

--- a/pkg/services/contexthandler/contexthandler.go
+++ b/pkg/services/contexthandler/contexthandler.go
@@ -120,7 +120,7 @@ func (h *ContextHandler) Middleware(next http.Handler) http.Handler {
 			reqContext.UserToken = identity.SessionToken
 			reqContext.IsSignedIn = !reqContext.SignedInUser.IsAnonymous
 			reqContext.AllowAnonymous = reqContext.SignedInUser.IsAnonymous
-			reqContext.IsRenderCall = identity.AuthenticatedBy == login.RenderModule
+			reqContext.IsRenderCall = identity.GetAuthenticatedBy() == login.RenderModule
 		}
 
 		reqContext.Logger = reqContext.Logger.New("userId", reqContext.UserID, "orgId", reqContext.OrgID, "uname", reqContext.Login)


### PR DESCRIPTION
**What is this feature?**

Users authenticated with auth proxy via the LDAP client were being stored as auth_proxy (grafana db) users instead of ldap users.

The changes to the auth client should gradually fix this users to have an LDAP entry instead.

(Possible research avenue into changing behavior of search to ignore the latest login method used)

https://github.com/grafana/grafana/blob/9c9e5e68c8bbdc30dcfe7080e5104de3a5c217b6/pkg/services/user/userimpl/store.go#L632

**Why do we need this feature?**

[Add a description of the problem the feature is trying to solve.]

**Who is this feature for?**

[Add information on what kind of user the feature is for.]

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
