### PR TITLE
VizTooltips: Render data links only when anchored

### DIFF
--- a/public/app/plugins/panel/state-timeline/StateTimelineTooltip2.tsx
+++ b/public/app/plugins/panel/state-timeline/StateTimelineTooltip2.tsx
@@ -1,6 +1,6 @@
-import React from 'react';
+import React, { ReactNode } from 'react';
 
-import { Field, FieldType, getFieldDisplayName, LinkModel, TimeRange } from '@grafana/data';
+import { FieldType, getFieldDisplayName, TimeRange } from '@grafana/data';
 import { SortOrder } from '@grafana/schema/dist/esm/common/common.gen';
 import { TooltipDisplayMode, useStyles2 } from '@grafana/ui';
 import { VizTooltipContent } from '@grafana/ui/src/components/VizTooltip/VizTooltipContent';
@@ -65,12 +65,14 @@ export const StateTimelineTooltip2 = ({
     contentItems.push({ label: 'Duration', value: duration });
   }
 
-  let links: Array<LinkModel<Field>> = [];
+  let footer: ReactNode;
 
-  if (seriesIdx != null) {
+  if (isPinned && seriesIdx != null) {
     const field = seriesFrame.fields[seriesIdx];
     const dataIdx = dataIdxs[seriesIdx]!;
-    links = getDataLinks(field, dataIdx);
+    const links = getDataLinks(field, dataIdx);
+
+    footer = <VizTooltipFooter dataLinks={links} annotate={annotate} />;
   }
 
   const headerItem: VizTooltipItem = {
@@ -79,14 +81,10 @@ export const StateTimelineTooltip2 = ({
   };
 
   return (
-    <div>
-      <div className={styles.wrapper}>
-        <VizTooltipHeader item={headerItem} isPinned={isPinned} />
-        <VizTooltipContent items={contentItems} isPinned={isPinned} scrollable={scrollable} />
-        {(links.length > 0 || isPinned) && (
-          <VizTooltipFooter dataLinks={links} annotate={isPinned ? annotate : undefined} />
-        )}
-      </div>
+    <div className={styles.wrapper}>
+      <VizTooltipHeader item={headerItem} isPinned={isPinned} />
+      <VizTooltipContent items={contentItems} isPinned={isPinned} scrollable={scrollable} />
+      {footer}
     </div>
   );
 };

--- a/public/app/plugins/panel/timeseries/TimeSeriesTooltip.tsx
+++ b/public/app/plugins/panel/timeseries/TimeSeriesTooltip.tsx
@@ -1,7 +1,7 @@
 import { css } from '@emotion/css';
-import React from 'react';
+import React, { ReactNode } from 'react';
 
-import { DataFrame, FieldType, LinkModel, Field, getFieldDisplayName } from '@grafana/data';
+import { DataFrame, FieldType, getFieldDisplayName } from '@grafana/data';
 import { SortOrder, TooltipDisplayMode } from '@grafana/schema/dist/esm/common/common.gen';
 import { useStyles2 } from '@grafana/ui';
 import { VizTooltipContent } from '@grafana/ui/src/components/VizTooltip/VizTooltipContent';
@@ -59,12 +59,14 @@ export const TimeSeriesTooltip = ({
     (field) => field.type === FieldType.number
   );
 
-  let links: Array<LinkModel<Field>> = [];
+  let footer: ReactNode;
 
-  if (seriesIdx != null) {
+  if (isPinned && seriesIdx != null) {
     const field = seriesFrame.fields[seriesIdx];
     const dataIdx = dataIdxs[seriesIdx]!;
-    links = getDataLinks(field, dataIdx);
+    const links = getDataLinks(field, dataIdx);
+
+    footer = <VizTooltipFooter dataLinks={links} annotate={annotate} />;
   }
 
   const headerItem: VizTooltipItem = {
@@ -73,14 +75,10 @@ export const TimeSeriesTooltip = ({
   };
 
   return (
-    <div>
-      <div className={styles.wrapper}>
-        <VizTooltipHeader item={headerItem} isPinned={isPinned} />
-        <VizTooltipContent items={contentItems} isPinned={isPinned} scrollable={scrollable} />
-        {(links.length > 0 || isPinned) && (
-          <VizTooltipFooter dataLinks={links} annotate={isPinned ? annotate : undefined} />
-        )}
-      </div>
+    <div className={styles.wrapper}>
+      <VizTooltipHeader item={headerItem} isPinned={isPinned} />
+      <VizTooltipContent items={contentItems} isPinned={isPinned} scrollable={scrollable} />
+      {footer}
     </div>
   );
 };

--- a/public/app/plugins/panel/xychart/XYChartTooltip.tsx
+++ b/public/app/plugins/panel/xychart/XYChartTooltip.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { ReactNode } from 'react';
 
 import { DataFrame, Field, getFieldDisplayName } from '@grafana/data';
 import { alpha } from '@grafana/data/src/themes/colorManipulator';
@@ -83,13 +83,19 @@ export const XYChartTooltip = ({ dataIdxs, seriesIdx, data, allSeries, dismiss, 
     });
   }
 
-  const links = getDataLinks(yField, rowIndex);
+  let footer: ReactNode;
+
+  if (isPinned && seriesIdx != null) {
+    const links = getDataLinks(yField, rowIndex);
+
+    footer = <VizTooltipFooter dataLinks={links} />;
+  }
 
   return (
     <div className={styles.wrapper}>
       <VizTooltipHeader item={headerItem} isPinned={isPinned} />
       <VizTooltipContent items={contentItems} isPinned={isPinned} />
-      {(links.length > 0 || isPinned) && <VizTooltipFooter dataLinks={links} />}
+      {footer}
     </div>
   );
 };


### PR DESCRIPTION
turns out it's pretty expensive to re-generate datalinks while live-hovering dense datasets. 

this rolls back the changes in https://github.com/grafana/grafana/pull/83638 until we can improve the datalink gen performance.

(also removes an unnecessary `<div>` wrapper)