### PR TITLE
ReturnToPrevious: create tests to check `reportInteraction`

### DIFF
--- a/public/app/core/components/AppChrome/ReturnToPrevious/ReturnToPrevious.test.tsx
+++ b/public/app/core/components/AppChrome/ReturnToPrevious/ReturnToPrevious.test.tsx
@@ -49,6 +49,7 @@ describe('ReturnToPrevious', () => {
       action: 'clicked',
       page: '/dashboards',
     });
+    expect(reportInteraction).toHaveBeenCalledTimes(1);
   });
 
   it('should trigger event once when clicking on the Close button', async () => {
@@ -60,5 +61,6 @@ describe('ReturnToPrevious', () => {
       action: 'dismissed',
       page: '/dashboards',
     });
+    expect(reportInteraction).toHaveBeenCalledTimes(1);
   });
 });

--- a/public/app/core/components/AppChrome/ReturnToPrevious/ReturnToPrevious.test.tsx
+++ b/public/app/core/components/AppChrome/ReturnToPrevious/ReturnToPrevious.test.tsx
@@ -1,0 +1,57 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import React from 'react';
+import { TestProvider } from 'test/helpers/TestProvider';
+import { getGrafanaContextMock } from 'test/mocks/getGrafanaContextMock';
+
+import { reportInteraction } from '@grafana/runtime';
+
+import { ReturnToPrevious, ReturnToPreviousProps } from './ReturnToPrevious';
+
+const mockReturnToPreviousProps: ReturnToPreviousProps = {
+  title: 'Dashboards Page',
+  href: '/dashboards',
+};
+jest.mock('@grafana/runtime', () => {
+  return {
+    ...jest.requireActual('@grafana/runtime'),
+    reportInteraction: jest.fn(),
+  };
+});
+const reportInteractionMock = jest.mocked(reportInteraction);
+
+const setup = () => {
+  const grafanaContext = getGrafanaContextMock();
+  grafanaContext.chrome.setReturnToPrevious(mockReturnToPreviousProps);
+  return render(
+    <TestProvider grafanaContext={grafanaContext}>
+      <ReturnToPrevious {...mockReturnToPreviousProps} />
+    </TestProvider>
+  );
+};
+
+describe('ReturnToPrevious', () => {
+  afterEach(() => {
+    window.sessionStorage.clear();
+  });
+  it('should render component', async () => {
+    setup();
+    expect(await screen.findByTitle('Back to Dashboards Page')).toBeInTheDocument();
+  });
+
+  it('should trigger event once when clicking on the Close button', async () => {
+    setup();
+    const closeBtn = await screen.findByRole('button', { name: 'Close' });
+    expect(closeBtn).toBeInTheDocument();
+    await userEvent.click(closeBtn);
+    const [args] = reportInteractionMock.mock.calls;
+    const [interactionName, properties] = args;
+
+    expect(reportInteractionMock.mock.calls.length).toBe(1);
+    expect(interactionName).toBe('grafana_return_to_previous_button_dismissed');
+    expect(properties).toEqual({
+      action: 'dismissed',
+      page: mockReturnToPreviousProps.href,
+    });
+  });
+});

--- a/public/app/core/components/AppChrome/ReturnToPrevious/ReturnToPrevious.test.tsx
+++ b/public/app/core/components/AppChrome/ReturnToPrevious/ReturnToPrevious.test.tsx
@@ -12,6 +12,13 @@ const mockReturnToPreviousProps: ReturnToPreviousProps = {
   title: 'Dashboards Page',
   href: '/dashboards',
 };
+const reportInteractionMock = jest.mocked(reportInteraction);
+jest.mock('@grafana/runtime', () => {
+  return {
+    ...jest.requireActual('@grafana/runtime'),
+    reportInteraction: reportInteractionMock,
+  };
+});
 jest.mock('@grafana/runtime', () => {
   return {
     ...jest.requireActual('@grafana/runtime'),
@@ -48,7 +55,7 @@ describe('ReturnToPrevious', () => {
     const returnButton = await screen.findByTitle('Back to Dashboards Page');
     expect(returnButton).toBeInTheDocument();
     await userEvent.click(returnButton);
-    const mockCalls = (reportInteraction as jest.Mock).mock.calls;
+    const mockCalls = reportInteractionMock.mock.calls;
     /* The report is called 'grafana_return_to_previous_button_dismissed' but the action is 'clicked' */
     const mockReturn = mockCalls.filter((call) => call[0] === 'grafana_return_to_previous_button_dismissed');
     expect(mockReturn).toHaveLength(1);
@@ -60,7 +67,7 @@ describe('ReturnToPrevious', () => {
     const closeBtn = await screen.findByRole('button', { name: 'Close' });
     expect(closeBtn).toBeInTheDocument();
     await userEvent.click(closeBtn);
-    const mockCalls = (reportInteraction as jest.Mock).mock.calls;
+    const mockCalls = reportInteractionMock.mock.calls;
     /* The report is called 'grafana_return_to_previous_button_dismissed' but the action is 'dismissed' */
     const mockDismissed = mockCalls.filter((call) => call[0] === 'grafana_return_to_previous_button_dismissed');
     expect(mockDismissed).toHaveLength(1);

--- a/public/app/core/components/AppChrome/ReturnToPrevious/ReturnToPrevious.test.tsx
+++ b/public/app/core/components/AppChrome/ReturnToPrevious/ReturnToPrevious.test.tsx
@@ -29,11 +29,14 @@ const setup = () => {
 };
 
 describe('ReturnToPrevious', () => {
-  /* We enabled the feature toggle */
-  config.featureToggles.returnToPrevious = true;
+  beforeEach(() => {
+    /* We enabled the feature toggle */
+    config.featureToggles.returnToPrevious = true;
+  });
   afterEach(() => {
     window.sessionStorage.clear();
     jest.resetAllMocks();
+    config.featureToggles.returnToPrevious = false;
   });
   it('should render component', async () => {
     setup();
@@ -45,22 +48,21 @@ describe('ReturnToPrevious', () => {
     const returnButton = await screen.findByTitle('Back to Dashboards Page');
     expect(returnButton).toBeInTheDocument();
     await userEvent.click(returnButton);
-    expect(reportInteraction).toHaveBeenCalledWith('grafana_return_to_previous_button_dismissed', {
-      action: 'clicked',
-      page: '/dashboards',
-    });
-    expect(reportInteraction).toHaveBeenCalledTimes(1);
+    const mockCalls = (reportInteraction as jest.Mock).mock.calls;
+    /* The report is called 'grafana_return_to_previous_button_dismissed' but the action is 'clicked' */
+    const mockReturn = mockCalls.filter((call) => call[0] === 'grafana_return_to_previous_button_dismissed');
+    expect(mockReturn).toHaveLength(1);
   });
 
   it('should trigger event once when clicking on the Close button', async () => {
     setup();
+
     const closeBtn = await screen.findByRole('button', { name: 'Close' });
     expect(closeBtn).toBeInTheDocument();
     await userEvent.click(closeBtn);
-    expect(reportInteraction).toHaveBeenCalledWith('grafana_return_to_previous_button_dismissed', {
-      action: 'dismissed',
-      page: '/dashboards',
-    });
-    expect(reportInteraction).toHaveBeenCalledTimes(1);
+    const mockCalls = (reportInteraction as jest.Mock).mock.calls;
+    /* The report is called 'grafana_return_to_previous_button_dismissed' but the action is 'dismissed' */
+    const mockDismissed = mockCalls.filter((call) => call[0] === 'grafana_return_to_previous_button_dismissed');
+    expect(mockDismissed).toHaveLength(1);
   });
 });

--- a/public/app/core/components/AppChrome/ReturnToPrevious/ReturnToPrevious.tsx
+++ b/public/app/core/components/AppChrome/ReturnToPrevious/ReturnToPrevious.tsx
@@ -2,7 +2,7 @@ import { css } from '@emotion/css';
 import React, { useCallback } from 'react';
 
 import { GrafanaTheme2 } from '@grafana/data';
-import { locationService, reportInteraction } from '@grafana/runtime';
+import { locationService } from '@grafana/runtime';
 import { useStyles2 } from '@grafana/ui';
 import { useGrafana } from 'app/core/context/GrafanaContext';
 import { t } from 'app/core/internationalization';
@@ -24,9 +24,8 @@ export const ReturnToPrevious = ({ href, title }: ReturnToPreviousProps) => {
   }, [href, chrome]);
 
   const handleOnDismiss = useCallback(() => {
-    reportInteraction('grafana_return_to_previous_button_dismissed', { action: 'dismissed', page: href });
     chrome.clearReturnToPrevious('dismissed');
-  }, [href, chrome]);
+  }, [chrome]);
 
   return (
     <div className={styles.returnToPrevious}>


### PR DESCRIPTION
**What is this feature?**

Adds tests to check if `reportInteraction` is not triggered more than once per event.

**Why do we need this feature?**

To avoid faulty data

**Who is this feature for?**

All those who are concerned about the reliability of data obtained from monitoring the RTP functionality.

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
