### PR TITLE
Cloudwatch: Fix new ConfigEditor to add the custom namespace field 

### DIFF
--- a/public/app/plugins/datasource/cloudwatch/components/ConfigEditor/ConfigEditor.test.tsx
+++ b/public/app/plugins/datasource/cloudwatch/components/ConfigEditor/ConfigEditor.test.tsx
@@ -216,6 +216,11 @@ describe('Render', () => {
       await waitFor(async () => expect(screen.getByText('Assume Role ARN')).toBeInTheDocument());
     });
 
+    it('should display namespace field', async () => {
+      setup();
+      await waitFor(async () => expect(screen.getByText('Namespaces of Custom Metrics')).toBeInTheDocument());
+    });
+
     it('should show a deprecation warning if `arn` auth type is used', async () => {
       setup({
         jsonData: {

--- a/public/app/plugins/datasource/cloudwatch/components/ConfigEditor/ConfigEditor.tsx
+++ b/public/app/plugins/datasource/cloudwatch/components/ConfigEditor/ConfigEditor.tsx
@@ -107,7 +107,15 @@ export const ConfigEditor = (props: Props) => {
           })
         }
         externalId={externalId}
-      />
+      >
+        <Field label="Namespaces of Custom Metrics">
+          <Input
+            placeholder="Namespace1,Namespace2"
+            value={options.jsonData.customMetricsNamespaces || ''}
+            onChange={onUpdateDatasourceJsonDataOption(props, 'customMetricsNamespaces')}
+          />
+        </Field>
+      </ConnectionConfig>
       {config.secureSocksDSProxyEnabled && (
         <SecureSocksProxySettingsNewStyling options={options} onOptionsChange={onOptionsChange} />
       )}


### PR DESCRIPTION

**What is this feature?**

When we migrated to the new form styling, I missed adding a custom namespace field. This is how it looks now with awsDatasourcesNewFormStyling toggle on: 

<img width="675" alt="Screenshot 2024-03-01 at 12 05 45" src="https://github.com/grafana/grafana/assets/16140639/03ee1482-21ca-4c27-9d27-6d3d6af2f2c5">


**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes https://github.com/grafana/grafana/issues/83734

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
