### PR TITLE
Fix: Cache busting of plugins module.js file

### DIFF
--- a/public/app/features/plugins/loader/cache.ts
+++ b/public/app/features/plugins/loader/cache.ts
@@ -35,7 +35,7 @@ export function resolveWithCache(url: string, defaultBust = initializedAt): stri
 }
 
 function extractPath(address: string): string | undefined {
-  const match = /\/.+\/(plugins\/.+\/module)\.js/i.exec(address);
+  const match = /\/?.+\/(plugins\/.+\/module)\.js/i.exec(address);
   if (!match) {
     return;
   }


### PR DESCRIPTION


<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

The cachebuster allows us to append plugin version information to the end of the `module.js` url however it looks like the fix we implemented in #81658 broke the regex in our cachebuster.

### before
![image](https://github.com/grafana/grafana/assets/73201/8240b8a2-679b-4288-9734-4777fe2838ea)


### after
![image](https://github.com/grafana/grafana/assets/73201/5f9a3222-a5dc-46bf-ae41-31cbd1018e1e)


**Why do we need this feature?**

To leverage browser caching.

**Who is this feature for?**

Grafana users

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**
I'd like to revisit this cachebuster at some point to only use pluginId and not attempt to extract it from paths/urls with regexs which feels quite brittle.

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
