### PR TITLE
Chore: Add enabled status to authentication_ui_provider_clicked

### DIFF
--- a/public/app/features/auth-config/AuthProvidersListPage.tsx
+++ b/public/app/features/auth-config/AuthProvidersListPage.tsx
@@ -43,8 +43,8 @@ export const AuthConfigPageUnconnected = ({
 
   const authProviders = getRegisteredAuthProviders();
   const availableProviders = authProviders.filter((p) => !providerStatuses[p.id]?.hide);
-  const onProviderCardClick = (providerType: string) => {
-    reportInteraction('authentication_ui_provider_clicked', { provider: providerType });
+  const onProviderCardClick = (providerType: string, enabled: boolean) => {
+    reportInteraction('authentication_ui_provider_clicked', { provider: providerType, enabled });
   };
 
   const providerList = availableProviders.length
@@ -86,7 +86,7 @@ export const AuthConfigPageUnconnected = ({
                   authType={settings.type || 'OAuth'}
                   providerId={provider}
                   enabled={settings.enabled}
-                  onClick={() => onProviderCardClick(provider)}
+                  onClick={() => onProviderCardClick(provider, settings.enabled)}
                   //@ts-expect-error Remove legacy types
                   configPath={settings.configPath}
                 />


### PR DESCRIPTION

**What is this feature?**

Adds `enabled` status to `authentication_ui_provider_clicked` metadata.

**Why do we need this feature?**

[Add a description of the problem the feature is trying to solve.]

**Who is this feature for?**

[Add information on what kind of user the feature is for.]

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
