### PR TITLE
Alerting: Implement correct RBAC checks for creating new notification templates

### DIFF
--- a/public/app/features/alerting/unified/components/contact-points/ContactPoints.test.tsx
+++ b/public/app/features/alerting/unified/components/contact-points/ContactPoints.test.tsx
@@ -127,6 +127,11 @@ describe('contact points', () => {
         const deleteButton = await screen.queryByRole('menuitem', { name: 'delete' });
         expect(deleteButton).toBeDisabled();
       }
+
+      // check buttons in Notification Templates
+      const notificationTemplatesTab = screen.getByRole('tab', { name: 'Tab Notification Templates' });
+      await userEvent.click(notificationTemplatesTab);
+      expect(screen.getByRole('link', { name: 'Add notification template' })).toHaveAttribute('aria-disabled', 'true');
     });
 
     it('should call delete when clicked and not disabled', async () => {
@@ -326,6 +331,11 @@ describe('contact points', () => {
       const viewProvisioned = screen.getByRole('link', { name: 'view-action' });
       expect(viewProvisioned).toBeInTheDocument();
       expect(viewProvisioned).not.toBeDisabled();
+
+      // check buttons in Notification Templates
+      const notificationTemplatesTab = screen.getByRole('tab', { name: 'Tab Notification Templates' });
+      await userEvent.click(notificationTemplatesTab);
+      expect(screen.queryByRole('link', { name: 'Add notification template' })).not.toBeInTheDocument();
     });
   });
 });

--- a/public/app/features/alerting/unified/components/contact-points/ContactPoints.tsx
+++ b/public/app/features/alerting/unified/components/contact-points/ContactPoints.tsx
@@ -81,6 +81,9 @@ const ContactPoints = () => {
   const [exportContactPointsSupported, exportContactPointsAllowed] = useAlertmanagerAbility(
     AlertmanagerAction.ExportContactPoint
   );
+  const [createTemplateSupported, createTemplateAllowed] = useAlertmanagerAbility(
+    AlertmanagerAction.CreateNotificationTemplate
+  );
 
   const [DeleteModal, showDeleteModal] = useDeleteContactPointModal(deleteTrigger, updateAlertmanagerState.isLoading);
   const [ExportDrawer, showExportDrawer] = useExportContactPoint();
@@ -177,9 +180,16 @@ const ContactPoints = () => {
                       Create notification templates to customize your notifications.
                     </Text>
                     <Spacer />
-                    <LinkButton icon="plus" variant="primary" href="/alerting/notifications/templates/new">
-                      Add notification template
-                    </LinkButton>
+                    {createTemplateSupported && (
+                      <LinkButton
+                        icon="plus"
+                        variant="primary"
+                        href="/alerting/notifications/templates/new"
+                        disabled={!createTemplateAllowed}
+                      >
+                        Add notification template
+                      </LinkButton>
+                    )}
                   </Stack>
                   <NotificationTemplates />
                 </>


### PR DESCRIPTION
**What is this feature?**

Prior to this PR the button to add a new notification template was always shown regardless of wether it was supported for the current Alertmanager context or if the user has permissions to do so.

Changes in this PR bring the behaviour in line with the rest of the buttons; hiding it when not supported for the Alertmanager in context and disabling the action for users without sufficient permissions.