### PR TITLE
Chore: Remove redundant error check

### DIFF
--- a/pkg/services/ngalert/notifier/compat.go
+++ b/pkg/services/ngalert/notifier/compat.go
@@ -66,9 +66,6 @@ func PostableToGettableGrafanaReceiver(r *apimodels.PostableGrafanaReceiver, pro
 
 		for k, v := range r.SecureSettings {
 			decryptedValue := decryptFn(v)
-			if err != nil {
-				return apimodels.GettableGrafanaReceiver{}, err
-			}
 			if decryptedValue == "" {
 				continue
 			} else {


### PR DESCRIPTION
We're checking an error that we've already checked, inside a loop, after calling a function that doesn't return an error. At that point, the error is always nil.