### PR TITLE
Alerting: Fix editing Grafana folder via alert rule editor

### DIFF
--- a/public/app/features/alerting/unified/components/rule-editor/GrafanaEvaluationBehavior.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/GrafanaEvaluationBehavior.tsx
@@ -137,6 +137,7 @@ function FolderGroupAndEvaluationInterval({
         <EditCloudGroupModal
           namespace={existingNamespace ?? emptyNamespace}
           group={existingGroup ?? emptyGroup}
+          folderUid={folderUid}
           onClose={() => closeEditGroupModal()}
           intervalEditOnly
           hideFolder={true}


### PR DESCRIPTION
**What is this feature?**

Prior to this PR editing a Grafana alert rule and updating the group details from there would result in a "404 not found / permission denied" error from the backend because we weren't treating it as a Grafana folder (when `folderUid` is `undefined` it assumes we are trying to update a Mimir group).