### PR TITLE
Alerting: Assume rule not found when everything is undefined

### DIFF
--- a/public/app/features/alerting/unified/RuleViewer.tsx
+++ b/public/app/features/alerting/unified/RuleViewer.tsx
@@ -74,7 +74,12 @@ const RuleViewerV2Wrapper = (props: RuleViewerProps) => {
     );
   }
 
-  return null;
+  // if we get here assume we can't find the rule
+  return (
+    <AlertingPageWrapper pageNav={defaultPageNav} navId="alert-list">
+      <EntityNotFound entity="Rule" />
+    </AlertingPageWrapper>
+  );
 };
 
 interface ErrorMessageProps {


### PR DESCRIPTION
**What is this feature?**

With this PR we make the assumption that a rule isn't found when `loading=false` and `rule=undefined` and `error=undefined`.

This scenario happens when a Grafana Managed alert rule is not found – none of the API requests will fail because we fetch the entire namespace / group and those contain other rules.