### PR TITLE
Alerting: Remove concurrent_render_limit in legacy alerting

### DIFF
--- a/conf/defaults.ini
+++ b/conf/defaults.ini
@@ -1354,10 +1354,6 @@ error_or_timeout = alerting
 # Default setting for how Grafana handles nodata or null values in alerting. (alerting, no_data, keep_state, ok)
 nodata_or_nullvalues = no_data
 
-# Alert notifications can include images, but rendering many images at the same time can overload the server
-# This limit will protect the server from render overloading and make sure notifications are sent out quickly
-concurrent_render_limit = 5
-
 # Default setting for alert calculation timeout. Default value is 30
 evaluation_timeout_seconds = 30
 

--- a/conf/sample.ini
+++ b/conf/sample.ini
@@ -1227,10 +1227,6 @@ max_annotations_to_keep =
 # Default setting for how Grafana handles nodata or null values in alerting. (alerting, no_data, keep_state, ok)
 ;nodata_or_nullvalues = no_data
 
-# Alert notifications can include images, but rendering many images at the same time can overload the server
-# This limit will protect the server from render overloading and make sure notifications are sent out quickly
-;concurrent_render_limit = 5
-
 # Default setting for alert calculation timeout. Default value is 30
 ;evaluation_timeout_seconds = 30
 

--- a/docs/sources/setup-grafana/image-rendering/_index.md
+++ b/docs/sources/setup-grafana/image-rendering/_index.md
@@ -30,7 +30,7 @@ You can also render a PNG by hovering over the panel to display the actions menu
 
 ## Alerting and render limits
 
-Alert notifications can include images, but rendering many images at the same time can overload the server where the renderer is running. For instructions of how to configure this, see [concurrent_render_limit]({{< relref "../configure-grafana#concurrent_render_limit" >}}).
+Alert notifications can include images, but rendering many images at the same time can overload the server where the renderer is running. For instructions of how to configure this, see [max_concurrent_screenshots]({{< relref "../configure-grafana#max_concurrent_screenshots" >}}).
 
 ## Install Grafana Image Renderer plugin
 

--- a/pkg/services/alerting/notifier.go
+++ b/pkg/services/alerting/notifier.go
@@ -219,7 +219,7 @@ func (n *notificationService) renderAndUploadImage(evalCtx *EvalContext, timeout
 		},
 		Width:           1000,
 		Height:          500,
-		ConcurrentLimit: n.cfg.AlertingRenderLimit,
+		ConcurrentLimit: 5,
 		Theme:           models.ThemeDark,
 	}
 

--- a/pkg/services/screenshot/screenshot.go
+++ b/pkg/services/screenshot/screenshot.go
@@ -122,7 +122,7 @@ func (s *HeadlessScreenshotService) Take(ctx context.Context, opts ScreenshotOpt
 		Width:           opts.Width,
 		Height:          opts.Height,
 		Theme:           opts.Theme,
-		ConcurrentLimit: s.cfg.AlertingRenderLimit,
+		ConcurrentLimit: s.cfg.RendererConcurrentRequestLimit,
 		Path:            u.String(),
 	}
 

--- a/pkg/services/screenshot/screenshot_test.go
+++ b/pkg/services/screenshot/screenshot_test.go
@@ -54,7 +54,7 @@ func TestHeadlessScreenshotService(t *testing.T) {
 		Height:          DefaultHeight,
 		Theme:           DefaultTheme,
 		Path:            "d-solo/foo/bar?from=now-6h&orgId=2&panelId=4&to=now-2h",
-		ConcurrentLimit: cfg.AlertingRenderLimit,
+		ConcurrentLimit: cfg.RendererConcurrentRequestLimit,
 	}
 
 	opts.From = "now-6h"

--- a/pkg/setting/setting.go
+++ b/pkg/setting/setting.go
@@ -507,7 +507,6 @@ type Cfg struct {
 	// Alerting
 	AlertingEnabled            *bool
 	ExecuteAlerts              bool
-	AlertingRenderLimit        int
 	AlertingErrorOrTimeout     string
 	AlertingNoDataOrNullValues string
 
@@ -1770,7 +1769,6 @@ func (cfg *Cfg) readAlertingSettings(iniFile *ini.File) error {
 		cfg.AlertingEnabled = &enabled
 	}
 	cfg.ExecuteAlerts = alerting.Key("execute_alerts").MustBool(true)
-	cfg.AlertingRenderLimit = alerting.Key("concurrent_render_limit").MustInt(5)
 
 	cfg.AlertingErrorOrTimeout = valueAsString(alerting, "error_or_timeout", "alerting")
 	cfg.AlertingNoDataOrNullValues = valueAsString(alerting, "nodata_or_nullvalues", "no_data")


### PR DESCRIPTION
**What is this feature?**
This PR is a part of the efforts to remove the deprecated alerting. It removes a setting `[alerting].concurrent_render_limit`. The setting was used in HeadlessScreenshotService, which is used by the Unified Alerting screenshot service with its own rate-limiting mechanism. Therefore, I chose to replace the setting with the global setting `[rendering].concurrent_render_request_limit` whose default value is 30. 

**Why do we need this feature?**
Remove legacy alerting.

**Who is this feature for?**
This change should not affect anyone. 

**Which issue(s) does this PR fix?**:
Contributes to https://github.com/grafana/grafana/issues/81268

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle.
- [x] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
