### PR TITLE
Revert "Add FolderUID for library elements"

### DIFF
--- a/pkg/api/dashboard_test.go
+++ b/pkg/api/dashboard_test.go
@@ -1037,7 +1037,7 @@ func (m *mockLibraryPanelService) ConnectLibraryPanelsForDashboard(c context.Con
 	return nil
 }
 
-func (m *mockLibraryPanelService) ImportLibraryPanelsForDashboard(c context.Context, signedInUser identity.Requester, libraryPanels *simplejson.Json, panels []any, folderID int64, folderUID string) error {
+func (m *mockLibraryPanelService) ImportLibraryPanelsForDashboard(c context.Context, signedInUser identity.Requester, libraryPanels *simplejson.Json, panels []any, folderID int64) error {
 	return nil
 }
 

--- a/pkg/services/dashboardimport/service/service.go
+++ b/pkg/services/dashboardimport/service/service.go
@@ -141,7 +141,7 @@ func (s *ImportDashboardService) ImportDashboard(ctx context.Context, req *dashb
 
 	metrics.MFolderIDsServiceCount.WithLabelValues(metrics.DashboardImport).Inc()
 	// nolint:staticcheck
-	err = s.libraryPanelService.ImportLibraryPanelsForDashboard(ctx, req.User, libraryElements, generatedDash.Get("panels").MustArray(), req.FolderId, req.FolderUid)
+	err = s.libraryPanelService.ImportLibraryPanelsForDashboard(ctx, req.User, libraryElements, generatedDash.Get("panels").MustArray(), req.FolderId)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/services/dashboardimport/service/service_test.go
+++ b/pkg/services/dashboardimport/service/service_test.go
@@ -47,7 +47,7 @@ func TestImportDashboardService(t *testing.T) {
 		importLibraryPanelsForDashboard := false
 		connectLibraryPanelsForDashboardCalled := false
 		libraryPanelService := &libraryPanelServiceMock{
-			importLibraryPanelsForDashboardFunc: func(ctx context.Context, signedInUser identity.Requester, libraryPanels *simplejson.Json, panels []any, folderID int64, folderUID string) error {
+			importLibraryPanelsForDashboardFunc: func(ctx context.Context, signedInUser identity.Requester, libraryPanels *simplejson.Json, panels []any, folderID int64) error {
 				importLibraryPanelsForDashboard = true
 				return nil
 			},
@@ -75,8 +75,9 @@ func TestImportDashboardService(t *testing.T) {
 			Inputs: []dashboardimport.ImportDashboardInput{
 				{Name: "*", Type: "datasource", Value: "prom"},
 			},
-			User:      &user.SignedInUser{UserID: 2, OrgRole: org.RoleAdmin, OrgID: 3},
-			FolderUid: "folderUID",
+			User: &user.SignedInUser{UserID: 2, OrgRole: org.RoleAdmin, OrgID: 3},
+			// FolderId:  5,
+			FolderUid: "123",
 		}
 		resp, err := s.ImportDashboard(context.Background(), req)
 		require.NoError(t, err)
@@ -90,7 +91,7 @@ func TestImportDashboardService(t *testing.T) {
 		require.Equal(t, int64(3), importDashboardArg.OrgID)
 		require.Equal(t, int64(2), userID)
 		require.Equal(t, "prometheus", importDashboardArg.Dashboard.PluginID)
-		require.Equal(t, "folderUID", importDashboardArg.Dashboard.FolderUID)
+		require.Equal(t, "123", importDashboardArg.Dashboard.FolderUID)
 
 		panel := importDashboardArg.Dashboard.Data.Get("panels").GetIndex(0)
 		require.Equal(t, "prom", panel.Get("datasource").MustString())
@@ -142,7 +143,7 @@ func TestImportDashboardService(t *testing.T) {
 				{Name: "*", Type: "datasource", Value: "prom"},
 			},
 			User:      &user.SignedInUser{UserID: 2, OrgRole: org.RoleAdmin, OrgID: 3},
-			FolderUid: "folderUID",
+			FolderUid: "123",
 		}
 		resp, err := s.ImportDashboard(context.Background(), req)
 		require.NoError(t, err)
@@ -156,7 +157,7 @@ func TestImportDashboardService(t *testing.T) {
 		require.Equal(t, int64(3), importDashboardArg.OrgID)
 		require.Equal(t, int64(2), userID)
 		require.Equal(t, "", importDashboardArg.Dashboard.PluginID)
-		require.Equal(t, "folderUID", importDashboardArg.Dashboard.FolderUID)
+		require.Equal(t, "123", importDashboardArg.Dashboard.FolderUID)
 
 		panel := importDashboardArg.Dashboard.Data.Get("panels").GetIndex(0)
 		require.Equal(t, "prom", panel.Get("datasource").MustString())
@@ -210,7 +211,7 @@ func (s *dashboardServiceMock) ImportDashboard(ctx context.Context, dto *dashboa
 type libraryPanelServiceMock struct {
 	librarypanels.Service
 	connectLibraryPanelsForDashboardFunc func(c context.Context, signedInUser identity.Requester, dash *dashboards.Dashboard) error
-	importLibraryPanelsForDashboardFunc  func(c context.Context, signedInUser identity.Requester, libraryPanels *simplejson.Json, panels []any, folderID int64, folderUID string) error
+	importLibraryPanelsForDashboardFunc  func(c context.Context, signedInUser identity.Requester, libraryPanels *simplejson.Json, panels []any, folderID int64) error
 }
 
 var _ librarypanels.Service = (*libraryPanelServiceMock)(nil)
@@ -223,9 +224,9 @@ func (s *libraryPanelServiceMock) ConnectLibraryPanelsForDashboard(ctx context.C
 	return nil
 }
 
-func (s *libraryPanelServiceMock) ImportLibraryPanelsForDashboard(ctx context.Context, signedInUser identity.Requester, libraryPanels *simplejson.Json, panels []any, folderID int64, folderUID string) error {
+func (s *libraryPanelServiceMock) ImportLibraryPanelsForDashboard(ctx context.Context, signedInUser identity.Requester, libraryPanels *simplejson.Json, panels []any, folderID int64) error {
 	if s.importLibraryPanelsForDashboardFunc != nil {
-		return s.importLibraryPanelsForDashboardFunc(ctx, signedInUser, libraryPanels, panels, folderID, folderUID)
+		return s.importLibraryPanelsForDashboardFunc(ctx, signedInUser, libraryPanels, panels, folderID)
 	}
 
 	return nil

--- a/pkg/services/folder/folderimpl/folder_test.go
+++ b/pkg/services/folder/folderimpl/folder_test.go
@@ -448,12 +448,10 @@ func TestIntegrationNestedFolderService(t *testing.T) {
 
 			// nolint:staticcheck
 			libraryElementCmd.FolderID = parent.ID
-			libraryElementCmd.FolderUID = &parent.UID
 			_, err = lps.LibraryElementService.CreateElement(context.Background(), &signedInUser, libraryElementCmd)
 			require.NoError(t, err)
 			// nolint:staticcheck
 			libraryElementCmd.FolderID = subfolder.ID
-			libraryElementCmd.FolderUID = &subfolder.UID
 			_, err = lps.LibraryElementService.CreateElement(context.Background(), &signedInUser, libraryElementCmd)
 			require.NoError(t, err)
 
@@ -530,12 +528,10 @@ func TestIntegrationNestedFolderService(t *testing.T) {
 
 			// nolint:staticcheck
 			libraryElementCmd.FolderID = parent.ID
-			libraryElementCmd.FolderUID = &parent.UID
 			_, err = lps.LibraryElementService.CreateElement(context.Background(), &signedInUser, libraryElementCmd)
 			require.NoError(t, err)
 			// nolint:staticcheck
 			libraryElementCmd.FolderID = subfolder.ID
-			libraryElementCmd.FolderUID = &subfolder.UID
 			_, err = lps.LibraryElementService.CreateElement(context.Background(), &signedInUser, libraryElementCmd)
 			require.NoError(t, err)
 
@@ -671,13 +667,11 @@ func TestIntegrationNestedFolderService(t *testing.T) {
 					_ = createRule(t, alertStore, subfolder.UID, "sub alert")
 					// nolint:staticcheck
 					libraryElementCmd.FolderID = subfolder.ID
-					libraryElementCmd.FolderUID = &subPanel.FolderUID
 					subPanel, err = lps.LibraryElementService.CreateElement(context.Background(), &signedInUser, libraryElementCmd)
 					require.NoError(t, err)
 				}
 				// nolint:staticcheck
 				libraryElementCmd.FolderID = parent.ID
-				libraryElementCmd.FolderUID = &parent.UID
 				parentPanel, err := lps.LibraryElementService.CreateElement(context.Background(), &signedInUser, libraryElementCmd)
 				require.NoError(t, err)
 

--- a/pkg/services/libraryelements/database.go
+++ b/pkg/services/libraryelements/database.go
@@ -149,20 +149,14 @@ func (l *LibraryElementService) createLibraryElement(c context.Context, signedIn
 	}
 
 	metrics.MFolderIDsServiceCount.WithLabelValues(metrics.LibraryElements).Inc()
-	// folderUID *string will be changed to string
-	var folderUID string
-	if cmd.FolderUID != nil {
-		folderUID = *cmd.FolderUID
-	}
 	element := model.LibraryElement{
-		OrgID:     signedInUser.GetOrgID(),
-		FolderID:  cmd.FolderID, // nolint:staticcheck
-		FolderUID: folderUID,
-		UID:       createUID,
-		Name:      cmd.Name,
-		Model:     updatedModel,
-		Version:   1,
-		Kind:      cmd.Kind,
+		OrgID:    signedInUser.GetOrgID(),
+		FolderID: cmd.FolderID, // nolint:staticcheck
+		UID:      createUID,
+		Name:     cmd.Name,
+		Model:    updatedModel,
+		Version:  1,
+		Kind:     cmd.Kind,
 
 		Created: time.Now(),
 		Updated: time.Now(),

--- a/pkg/services/libraryelements/libraryelements_create_test.go
+++ b/pkg/services/libraryelements/libraryelements_create_test.go
@@ -15,7 +15,7 @@ func TestCreateLibraryElement(t *testing.T) {
 	scenarioWithPanel(t, "When an admin tries to create a library panel that already exists, it should fail",
 		func(t *testing.T, sc scenarioContext) {
 			// nolint:staticcheck
-			command := getCreatePanelCommand(sc.folder.ID, sc.folder.UID, "Text - Library Panel")
+			command := getCreatePanelCommand(sc.folder.ID, "Text - Library Panel")
 			sc.reqContext.Req.Body = mockRequestBody(command)
 			resp := sc.service.createHandler(sc.reqContext)
 			require.Equal(t, 400, resp.Status())
@@ -28,7 +28,6 @@ func TestCreateLibraryElement(t *testing.T) {
 					ID:          1,
 					OrgID:       1,
 					FolderID:    1, // nolint:staticcheck
-					FolderUID:   sc.folder.UID,
 					UID:         sc.initialResult.Result.UID,
 					Name:        "Text - Library Panel",
 					Kind:        int64(model.PanelElement),
@@ -69,7 +68,7 @@ func TestCreateLibraryElement(t *testing.T) {
 	testScenario(t, "When an admin tries to create a library panel that does not exists using an nonexistent UID, it should succeed",
 		func(t *testing.T, sc scenarioContext) {
 			// nolint:staticcheck
-			command := getCreatePanelCommand(sc.folder.ID, sc.folder.UID, "Nonexistent UID")
+			command := getCreatePanelCommand(sc.folder.ID, "Nonexistent UID")
 			command.UID = util.GenerateShortUID()
 			sc.reqContext.Req.Body = mockRequestBody(command)
 			resp := sc.service.createHandler(sc.reqContext)
@@ -79,7 +78,6 @@ func TestCreateLibraryElement(t *testing.T) {
 					ID:          1,
 					OrgID:       1,
 					FolderID:    1, // nolint:staticcheck
-					FolderUID:   sc.folder.UID,
 					UID:         command.UID,
 					Name:        "Nonexistent UID",
 					Kind:        int64(model.PanelElement),
@@ -120,7 +118,7 @@ func TestCreateLibraryElement(t *testing.T) {
 	scenarioWithPanel(t, "When an admin tries to create a library panel that does not exists using an existent UID, it should fail",
 		func(t *testing.T, sc scenarioContext) {
 			// nolint:staticcheck
-			command := getCreatePanelCommand(sc.folder.ID, sc.folder.UID, "Existing UID")
+			command := getCreatePanelCommand(sc.folder.ID, "Existing UID")
 			command.UID = sc.initialResult.Result.UID
 			sc.reqContext.Req.Body = mockRequestBody(command)
 			resp := sc.service.createHandler(sc.reqContext)
@@ -130,7 +128,7 @@ func TestCreateLibraryElement(t *testing.T) {
 	scenarioWithPanel(t, "When an admin tries to create a library panel that does not exists using an invalid UID, it should fail",
 		func(t *testing.T, sc scenarioContext) {
 			// nolint:staticcheck
-			command := getCreatePanelCommand(sc.folder.ID, sc.folder.UID, "Invalid UID")
+			command := getCreatePanelCommand(sc.folder.ID, "Invalid UID")
 			command.UID = "Testing an invalid UID"
 			sc.reqContext.Req.Body = mockRequestBody(command)
 			resp := sc.service.createHandler(sc.reqContext)
@@ -140,7 +138,7 @@ func TestCreateLibraryElement(t *testing.T) {
 	scenarioWithPanel(t, "When an admin tries to create a library panel that does not exists using an UID that is too long, it should fail",
 		func(t *testing.T, sc scenarioContext) {
 			// nolint:staticcheck
-			command := getCreatePanelCommand(sc.folder.ID, sc.folder.UID, "Invalid UID")
+			command := getCreatePanelCommand(sc.folder.ID, "Invalid UID")
 			command.UID = "j6T00KRZzj6T00KRZzj6T00KRZzj6T00KRZzj6T00K"
 			sc.reqContext.Req.Body = mockRequestBody(command)
 			resp := sc.service.createHandler(sc.reqContext)
@@ -149,7 +147,7 @@ func TestCreateLibraryElement(t *testing.T) {
 
 	testScenario(t, "When an admin tries to create a library panel where name and panel title differ, it should not update panel title",
 		func(t *testing.T, sc scenarioContext) {
-			command := getCreatePanelCommand(1, sc.folder.UID, "Library Panel Name")
+			command := getCreatePanelCommand(1, "Library Panel Name")
 			sc.reqContext.Req.Body = mockRequestBody(command)
 			resp := sc.service.createHandler(sc.reqContext)
 			var result = validateAndUnMarshalResponse(t, resp)
@@ -158,7 +156,6 @@ func TestCreateLibraryElement(t *testing.T) {
 					ID:          1,
 					OrgID:       1,
 					FolderID:    1, // nolint:staticcheck
-					FolderUID:   sc.folder.UID,
 					UID:         result.Result.UID,
 					Name:        "Library Panel Name",
 					Kind:        int64(model.PanelElement),

--- a/pkg/services/libraryelements/libraryelements_delete_test.go
+++ b/pkg/services/libraryelements/libraryelements_delete_test.go
@@ -74,7 +74,7 @@ func TestDeleteLibraryElement(t *testing.T) {
 				Data:  simplejson.NewFromAny(dashJSON),
 			}
 			// nolint:staticcheck
-			dashInDB := createDashboard(t, sc.sqlStore, sc.user, &dash, sc.folder.ID, sc.folder.UID)
+			dashInDB := createDashboard(t, sc.sqlStore, sc.user, &dash, sc.folder.ID)
 			err := sc.service.ConnectElementsToDashboard(sc.reqContext.Req.Context(), sc.reqContext.SignedInUser, []string{sc.initialResult.Result.UID}, dashInDB.ID)
 			require.NoError(t, err)
 

--- a/pkg/services/libraryelements/libraryelements_get_all_test.go
+++ b/pkg/services/libraryelements/libraryelements_get_all_test.go
@@ -39,7 +39,7 @@ func TestGetAllLibraryElements(t *testing.T) {
 	scenarioWithPanel(t, "When an admin tries to get all panel elements and both panels and variables exist, it should only return panels",
 		func(t *testing.T, sc scenarioContext) {
 			// nolint:staticcheck
-			command := getCreateVariableCommand(sc.folder.ID, sc.folder.UID, "query0")
+			command := getCreateVariableCommand(sc.folder.ID, "query0")
 			sc.reqContext.Req.Body = mockRequestBody(command)
 			resp := sc.service.createHandler(sc.reqContext)
 			require.Equal(t, 200, resp.Status())
@@ -64,7 +64,6 @@ func TestGetAllLibraryElements(t *testing.T) {
 							ID:          1,
 							OrgID:       1,
 							FolderID:    1, // nolint:staticcheck
-							FolderUID:   sc.folder.UID,
 							UID:         result.Result.Elements[0].UID,
 							Name:        "Text - Library Panel",
 							Kind:        int64(model.PanelElement),
@@ -107,7 +106,7 @@ func TestGetAllLibraryElements(t *testing.T) {
 	scenarioWithPanel(t, "When an admin tries to get all variable elements and both panels and variables exist, it should only return panels",
 		func(t *testing.T, sc scenarioContext) {
 			// nolint:staticcheck
-			command := getCreateVariableCommand(sc.folder.ID, sc.folder.UID, "query0")
+			command := getCreateVariableCommand(sc.folder.ID, "query0")
 			sc.reqContext.Req.Body = mockRequestBody(command)
 			resp := sc.service.createHandler(sc.reqContext)
 			require.Equal(t, 200, resp.Status())
@@ -132,7 +131,6 @@ func TestGetAllLibraryElements(t *testing.T) {
 							ID:          2,
 							OrgID:       1,
 							FolderID:    1, // nolint:staticcheck
-							FolderUID:   sc.folder.UID,
 							UID:         result.Result.Elements[0].UID,
 							Name:        "query0",
 							Kind:        int64(model.VariableElement),
@@ -174,7 +172,7 @@ func TestGetAllLibraryElements(t *testing.T) {
 	scenarioWithPanel(t, "When an admin tries to get all library panels and two exist, it should succeed",
 		func(t *testing.T, sc scenarioContext) {
 			// nolint:staticcheck
-			command := getCreatePanelCommand(sc.folder.ID, sc.folder.UID, "Text - Library Panel2")
+			command := getCreatePanelCommand(sc.folder.ID, "Text - Library Panel2")
 			sc.reqContext.Req.Body = mockRequestBody(command)
 			resp := sc.service.createHandler(sc.reqContext)
 			require.Equal(t, 200, resp.Status())
@@ -195,7 +193,6 @@ func TestGetAllLibraryElements(t *testing.T) {
 							ID:          1,
 							OrgID:       1,
 							FolderID:    1, // nolint:staticcheck
-							FolderUID:   sc.folder.UID,
 							UID:         result.Result.Elements[0].UID,
 							Name:        "Text - Library Panel",
 							Kind:        int64(model.PanelElement),
@@ -231,7 +228,6 @@ func TestGetAllLibraryElements(t *testing.T) {
 							ID:          2,
 							OrgID:       1,
 							FolderID:    1, // nolint:staticcheck
-							FolderUID:   sc.folder.UID,
 							UID:         result.Result.Elements[1].UID,
 							Name:        "Text - Library Panel2",
 							Kind:        int64(model.PanelElement),
@@ -274,7 +270,7 @@ func TestGetAllLibraryElements(t *testing.T) {
 	scenarioWithPanel(t, "When an admin tries to get all library panels and two exist and sort desc is set, it should succeed and the result should be correct",
 		func(t *testing.T, sc scenarioContext) {
 			// nolint:staticcheck
-			command := getCreatePanelCommand(sc.folder.ID, sc.folder.UID, "Text - Library Panel2")
+			command := getCreatePanelCommand(sc.folder.ID, "Text - Library Panel2")
 			sc.reqContext.Req.Body = mockRequestBody(command)
 			resp := sc.service.createHandler(sc.reqContext)
 			require.Equal(t, 200, resp.Status())
@@ -298,7 +294,6 @@ func TestGetAllLibraryElements(t *testing.T) {
 							ID:          2,
 							OrgID:       1,
 							FolderID:    1, // nolint:staticcheck
-							FolderUID:   sc.folder.UID,
 							UID:         result.Result.Elements[0].UID,
 							Name:        "Text - Library Panel2",
 							Kind:        int64(model.PanelElement),
@@ -334,7 +329,6 @@ func TestGetAllLibraryElements(t *testing.T) {
 							ID:          1,
 							OrgID:       1,
 							FolderID:    1, // nolint:staticcheck
-							FolderUID:   sc.folder.UID,
 							UID:         result.Result.Elements[1].UID,
 							Name:        "Text - Library Panel",
 							Kind:        int64(model.PanelElement),
@@ -377,7 +371,7 @@ func TestGetAllLibraryElements(t *testing.T) {
 	scenarioWithPanel(t, "When an admin tries to get all library panels and two exist and typeFilter is set to existing types, it should succeed and the result should be correct",
 		func(t *testing.T, sc scenarioContext) {
 			// nolint:staticcheck
-			command := getCreateCommandWithModel(sc.folder.ID, sc.folder.UID, "Gauge - Library Panel", model.PanelElement, []byte(`
+			command := getCreateCommandWithModel(sc.folder.ID, "Gauge - Library Panel", model.PanelElement, []byte(`
 			{
 			  "datasource": "${DS_GDEV-TESTDATA}",
 			  "id": 1,
@@ -391,7 +385,7 @@ func TestGetAllLibraryElements(t *testing.T) {
 			require.Equal(t, 200, resp.Status())
 
 			// nolint:staticcheck
-			command = getCreateCommandWithModel(sc.folder.ID, sc.folder.UID, "BarGauge - Library Panel", model.PanelElement, []byte(`
+			command = getCreateCommandWithModel(sc.folder.ID, "BarGauge - Library Panel", model.PanelElement, []byte(`
 			{
 			  "datasource": "${DS_GDEV-TESTDATA}",
 			  "id": 1,
@@ -423,7 +417,6 @@ func TestGetAllLibraryElements(t *testing.T) {
 							ID:          3,
 							OrgID:       1,
 							FolderID:    1, // nolint:staticcheck
-							FolderUID:   sc.folder.UID,
 							UID:         result.Result.Elements[0].UID,
 							Name:        "BarGauge - Library Panel",
 							Kind:        int64(model.PanelElement),
@@ -459,7 +452,6 @@ func TestGetAllLibraryElements(t *testing.T) {
 							ID:          2,
 							OrgID:       1,
 							FolderID:    1, // nolint:staticcheck
-							FolderUID:   sc.folder.UID,
 							UID:         result.Result.Elements[1].UID,
 							Name:        "Gauge - Library Panel",
 							Kind:        int64(model.PanelElement),
@@ -502,7 +494,7 @@ func TestGetAllLibraryElements(t *testing.T) {
 	scenarioWithPanel(t, "When an admin tries to get all library panels and two exist and typeFilter is set to a nonexistent type, it should succeed and the result should be correct",
 		func(t *testing.T, sc scenarioContext) {
 			// nolint:staticcheck
-			command := getCreateCommandWithModel(sc.folder.ID, sc.folder.UID, "Gauge - Library Panel", model.PanelElement, []byte(`
+			command := getCreateCommandWithModel(sc.folder.ID, "Gauge - Library Panel", model.PanelElement, []byte(`
 			{
 			  "datasource": "${DS_GDEV-TESTDATA}",
 			  "id": 1,
@@ -537,24 +529,25 @@ func TestGetAllLibraryElements(t *testing.T) {
 			}
 		})
 
-	scenarioWithPanel(t, "When an admin tries to get all library panels and two exist and folderFilterUIDs is set to existing folders, it should succeed and the result should be correct",
+	scenarioWithPanel(t, "When an admin tries to get all library panels and two exist and folderFilter is set to existing folders, it should succeed and the result should be correct",
 		func(t *testing.T, sc scenarioContext) {
 			newFolder := createFolder(t, sc, "NewFolder")
 			// nolint:staticcheck
-			command := getCreatePanelCommand(newFolder.ID, newFolder.UID, "Text - Library Panel2")
+			command := getCreatePanelCommand(newFolder.ID, "Text - Library Panel2")
 			sc.reqContext.Req.Body = mockRequestBody(command)
 			resp := sc.service.createHandler(sc.reqContext)
 			require.Equal(t, 200, resp.Status())
-			folderFilterUID := newFolder.UID
+			// nolint:staticcheck
+			folderFilter := strconv.FormatInt(newFolder.ID, 10)
+
 			err := sc.reqContext.Req.ParseForm()
 			require.NoError(t, err)
-			sc.reqContext.Req.Form.Add("folderFilterUIDs", folderFilterUID)
+			sc.reqContext.Req.Form.Add("folderFilter", folderFilter)
 			resp = sc.service.getAllHandler(sc.reqContext)
 			require.Equal(t, 200, resp.Status())
 
 			var result libraryElementsSearch
 			err = json.Unmarshal(resp.Body(), &result)
-
 			require.NoError(t, err)
 			var expected = libraryElementsSearch{
 				Result: libraryElementsSearchResult{
@@ -566,7 +559,6 @@ func TestGetAllLibraryElements(t *testing.T) {
 							ID:          2,
 							OrgID:       1,
 							FolderID:    newFolder.ID, // nolint:staticcheck
-							FolderUID:   newFolder.UID,
 							UID:         result.Result.Elements[0].UID,
 							Name:        "Text - Library Panel2",
 							Kind:        int64(model.PanelElement),
@@ -610,15 +602,15 @@ func TestGetAllLibraryElements(t *testing.T) {
 		func(t *testing.T, sc scenarioContext) {
 			newFolder := createFolder(t, sc, "NewFolder")
 			// nolint:staticcheck
-			command := getCreatePanelCommand(newFolder.ID, sc.folder.UID, "Text - Library Panel2")
+			command := getCreatePanelCommand(newFolder.ID, "Text - Library Panel2")
 			sc.reqContext.Req.Body = mockRequestBody(command)
 			resp := sc.service.createHandler(sc.reqContext)
 			require.Equal(t, 200, resp.Status())
-			folderFilterUIDs := "2020,2021"
+			folderFilter := "2020,2021"
 
 			err := sc.reqContext.Req.ParseForm()
 			require.NoError(t, err)
-			sc.reqContext.Req.Form.Add("folderFilterUIDs", folderFilterUIDs)
+			sc.reqContext.Req.Form.Add("folderFilter", folderFilter)
 			resp = sc.service.getAllHandler(sc.reqContext)
 			require.Equal(t, 200, resp.Status())
 
@@ -641,7 +633,7 @@ func TestGetAllLibraryElements(t *testing.T) {
 	scenarioWithPanel(t, "When an admin tries to get all library panels and two exist and folderFilter is set to General folder, it should succeed and the result should be correct",
 		func(t *testing.T, sc scenarioContext) {
 			// nolint:staticcheck
-			command := getCreatePanelCommand(sc.folder.ID, sc.folder.UID, "Text - Library Panel2")
+			command := getCreatePanelCommand(sc.folder.ID, "Text - Library Panel2")
 			sc.reqContext.Req.Body = mockRequestBody(command)
 			resp := sc.service.createHandler(sc.reqContext)
 			require.Equal(t, 200, resp.Status())
@@ -666,7 +658,6 @@ func TestGetAllLibraryElements(t *testing.T) {
 							ID:          1,
 							OrgID:       1,
 							FolderID:    1, // nolint:staticcheck
-							FolderUID:   sc.folder.UID,
 							UID:         result.Result.Elements[0].UID,
 							Name:        "Text - Library Panel",
 							Kind:        int64(model.PanelElement),
@@ -702,7 +693,6 @@ func TestGetAllLibraryElements(t *testing.T) {
 							ID:          2,
 							OrgID:       1,
 							FolderID:    1, // nolint:staticcheck
-							FolderUID:   sc.folder.UID,
 							UID:         result.Result.Elements[1].UID,
 							Name:        "Text - Library Panel2",
 							Kind:        int64(model.PanelElement),
@@ -745,7 +735,7 @@ func TestGetAllLibraryElements(t *testing.T) {
 	scenarioWithPanel(t, "When an admin tries to get all library panels and two exist and excludeUID is set, it should succeed and the result should be correct",
 		func(t *testing.T, sc scenarioContext) {
 			// nolint:staticcheck
-			command := getCreatePanelCommand(sc.folder.ID, sc.folder.UID, "Text - Library Panel2")
+			command := getCreatePanelCommand(sc.folder.ID, "Text - Library Panel2")
 			sc.reqContext.Req.Body = mockRequestBody(command)
 			resp := sc.service.createHandler(sc.reqContext)
 			require.Equal(t, 200, resp.Status())
@@ -769,7 +759,6 @@ func TestGetAllLibraryElements(t *testing.T) {
 							ID:          2,
 							OrgID:       1,
 							FolderID:    1, // nolint:staticcheck
-							FolderUID:   sc.folder.UID,
 							UID:         result.Result.Elements[0].UID,
 							Name:        "Text - Library Panel2",
 							Kind:        int64(model.PanelElement),
@@ -812,7 +801,7 @@ func TestGetAllLibraryElements(t *testing.T) {
 	scenarioWithPanel(t, "When an admin tries to get all library panels and two exist and perPage is 1, it should succeed and the result should be correct",
 		func(t *testing.T, sc scenarioContext) {
 			// nolint:staticcheck
-			command := getCreatePanelCommand(sc.folder.ID, sc.folder.UID, "Text - Library Panel2")
+			command := getCreatePanelCommand(sc.folder.ID, "Text - Library Panel2")
 			sc.reqContext.Req.Body = mockRequestBody(command)
 			resp := sc.service.createHandler(sc.reqContext)
 			require.Equal(t, 200, resp.Status())
@@ -836,7 +825,6 @@ func TestGetAllLibraryElements(t *testing.T) {
 							ID:          1,
 							OrgID:       1,
 							FolderID:    1, // nolint:staticcheck
-							FolderUID:   sc.folder.UID,
 							UID:         result.Result.Elements[0].UID,
 							Name:        "Text - Library Panel",
 							Kind:        int64(model.PanelElement),
@@ -879,7 +867,7 @@ func TestGetAllLibraryElements(t *testing.T) {
 	scenarioWithPanel(t, "When an admin tries to get all library panels and two exist and perPage is 1 and page is 2, it should succeed and the result should be correct",
 		func(t *testing.T, sc scenarioContext) {
 			// nolint:staticcheck
-			command := getCreatePanelCommand(sc.folder.ID, sc.folder.UID, "Text - Library Panel2")
+			command := getCreatePanelCommand(sc.folder.ID, "Text - Library Panel2")
 			sc.reqContext.Req.Body = mockRequestBody(command)
 			resp := sc.service.createHandler(sc.reqContext)
 			require.Equal(t, 200, resp.Status())
@@ -904,7 +892,6 @@ func TestGetAllLibraryElements(t *testing.T) {
 							ID:          2,
 							OrgID:       1,
 							FolderID:    1, // nolint:staticcheck
-							FolderUID:   sc.folder.UID,
 							UID:         result.Result.Elements[0].UID,
 							Name:        "Text - Library Panel2",
 							Kind:        int64(model.PanelElement),
@@ -947,7 +934,7 @@ func TestGetAllLibraryElements(t *testing.T) {
 	scenarioWithPanel(t, "When an admin tries to get all library panels and two exist and searchString exists in the description, it should succeed and the result should be correct",
 		func(t *testing.T, sc scenarioContext) {
 			// nolint:staticcheck
-			command := getCreateCommandWithModel(sc.folder.ID, sc.folder.UID, "Text - Library Panel2", model.PanelElement, []byte(`
+			command := getCreateCommandWithModel(sc.folder.ID, "Text - Library Panel2", model.PanelElement, []byte(`
 			{
 			  "datasource": "${DS_GDEV-TESTDATA}",
 			  "id": 1,
@@ -981,7 +968,6 @@ func TestGetAllLibraryElements(t *testing.T) {
 							ID:          1,
 							OrgID:       1,
 							FolderID:    1, // nolint:staticcheck
-							FolderUID:   sc.folder.UID,
 							UID:         result.Result.Elements[0].UID,
 							Name:        "Text - Library Panel",
 							Kind:        int64(model.PanelElement),
@@ -1024,7 +1010,7 @@ func TestGetAllLibraryElements(t *testing.T) {
 	scenarioWithPanel(t, "When an admin tries to get all library panels and two exist and searchString exists in both name and description, it should succeed and the result should be correct",
 		func(t *testing.T, sc scenarioContext) {
 			// nolint:staticcheck
-			command := getCreateCommandWithModel(sc.folder.ID, sc.folder.UID, "Some Other", model.PanelElement, []byte(`
+			command := getCreateCommandWithModel(sc.folder.ID, "Some Other", model.PanelElement, []byte(`
 			{
 			  "datasource": "${DS_GDEV-TESTDATA}",
 			  "id": 1,
@@ -1056,7 +1042,6 @@ func TestGetAllLibraryElements(t *testing.T) {
 							ID:          2,
 							OrgID:       1,
 							FolderID:    1, // nolint:staticcheck
-							FolderUID:   sc.folder.UID,
 							UID:         result.Result.Elements[0].UID,
 							Name:        "Some Other",
 							Kind:        int64(model.PanelElement),
@@ -1092,7 +1077,6 @@ func TestGetAllLibraryElements(t *testing.T) {
 							ID:          1,
 							OrgID:       1,
 							FolderID:    1, // nolint:staticcheck
-							FolderUID:   sc.folder.UID,
 							UID:         result.Result.Elements[1].UID,
 							Name:        "Text - Library Panel",
 							Kind:        int64(model.PanelElement),
@@ -1135,7 +1119,7 @@ func TestGetAllLibraryElements(t *testing.T) {
 	scenarioWithPanel(t, "When an admin tries to get all library panels and two exist and perPage is 1 and page is 1 and searchString is panel2, it should succeed and the result should be correct",
 		func(t *testing.T, sc scenarioContext) {
 			// nolint:staticcheck
-			command := getCreatePanelCommand(sc.folder.ID, sc.folder.UID, "Text - Library Panel2")
+			command := getCreatePanelCommand(sc.folder.ID, "Text - Library Panel2")
 			sc.reqContext.Req.Body = mockRequestBody(command)
 			resp := sc.service.createHandler(sc.reqContext)
 			require.Equal(t, 200, resp.Status())
@@ -1161,7 +1145,6 @@ func TestGetAllLibraryElements(t *testing.T) {
 							ID:          2,
 							OrgID:       1,
 							FolderID:    1, // nolint:staticcheck
-							FolderUID:   sc.folder.UID,
 							UID:         result.Result.Elements[0].UID,
 							Name:        "Text - Library Panel2",
 							Kind:        int64(model.PanelElement),
@@ -1204,7 +1187,7 @@ func TestGetAllLibraryElements(t *testing.T) {
 	scenarioWithPanel(t, "When an admin tries to get all library panels and two exist and perPage is 1 and page is 3 and searchString is panel, it should succeed and the result should be correct",
 		func(t *testing.T, sc scenarioContext) {
 			// nolint:staticcheck
-			command := getCreatePanelCommand(sc.folder.ID, sc.folder.UID, "Text - Library Panel2")
+			command := getCreatePanelCommand(sc.folder.ID, "Text - Library Panel2")
 			sc.reqContext.Req.Body = mockRequestBody(command)
 			resp := sc.service.createHandler(sc.reqContext)
 			require.Equal(t, 200, resp.Status())
@@ -1236,7 +1219,7 @@ func TestGetAllLibraryElements(t *testing.T) {
 	scenarioWithPanel(t, "When an admin tries to get all library panels and two exist and perPage is 1 and page is 3 and searchString does not exist, it should succeed and the result should be correct",
 		func(t *testing.T, sc scenarioContext) {
 			// nolint:staticcheck
-			command := getCreatePanelCommand(sc.folder.ID, sc.folder.UID, "Text - Library Panel2")
+			command := getCreatePanelCommand(sc.folder.ID, "Text - Library Panel2")
 			sc.reqContext.Req.Body = mockRequestBody(command)
 			resp := sc.service.createHandler(sc.reqContext)
 			require.Equal(t, 200, resp.Status())

--- a/pkg/services/libraryelements/libraryelements_get_test.go
+++ b/pkg/services/libraryelements/libraryelements_get_test.go
@@ -35,7 +35,6 @@ func TestGetLibraryElement(t *testing.T) {
 						ID:          1,
 						OrgID:       1,
 						FolderID:    1, // nolint:staticcheck
-						FolderUID:   sc.folder.UID,
 						UID:         res.Result.UID,
 						Name:        "Text - Library Panel",
 						Kind:        int64(model.PanelElement),
@@ -124,7 +123,7 @@ func TestGetLibraryElement(t *testing.T) {
 				Data:  simplejson.NewFromAny(dashJSON),
 			}
 			// nolint:staticcheck
-			dashInDB := createDashboard(t, sc.sqlStore, sc.user, &dash, sc.folder.ID, sc.folder.UID)
+			dashInDB := createDashboard(t, sc.sqlStore, sc.user, &dash, sc.folder.ID)
 			err := sc.service.ConnectElementsToDashboard(sc.reqContext.Req.Context(), sc.reqContext.SignedInUser, []string{sc.initialResult.Result.UID}, dashInDB.ID)
 			require.NoError(t, err)
 
@@ -134,7 +133,6 @@ func TestGetLibraryElement(t *testing.T) {
 						ID:          1,
 						OrgID:       1,
 						FolderID:    1, // nolint:staticcheck
-						FolderUID:   sc.folder.UID,
 						UID:         res.Result.UID,
 						Name:        "Text - Library Panel",
 						Kind:        int64(model.PanelElement),

--- a/pkg/services/libraryelements/libraryelements_patch_test.go
+++ b/pkg/services/libraryelements/libraryelements_patch_test.go
@@ -26,9 +26,8 @@ func TestPatchLibraryElement(t *testing.T) {
 		func(t *testing.T, sc scenarioContext) {
 			newFolder := createFolder(t, sc, "NewFolder")
 			cmd := model.PatchLibraryElementCommand{
-				FolderID:  newFolder.ID, // nolint:staticcheck
-				FolderUID: &newFolder.UID,
-				Name:      "Panel - New name",
+				FolderID: newFolder.ID, // nolint:staticcheck
+				Name:     "Panel - New name",
 				Model: []byte(`
 								{
 								  "datasource": "${DS_GDEV-TESTDATA}",
@@ -51,7 +50,6 @@ func TestPatchLibraryElement(t *testing.T) {
 					ID:          1,
 					OrgID:       1,
 					FolderID:    newFolder.ID, // nolint:staticcheck
-					FolderUID:   newFolder.UID,
 					UID:         sc.initialResult.Result.UID,
 					Name:        "Panel - New name",
 					Kind:        int64(model.PanelElement),
@@ -93,10 +91,9 @@ func TestPatchLibraryElement(t *testing.T) {
 		func(t *testing.T, sc scenarioContext) {
 			newFolder := createFolder(t, sc, "NewFolder")
 			cmd := model.PatchLibraryElementCommand{
-				FolderID:  newFolder.ID, // nolint:staticcheck
-				FolderUID: &newFolder.UID,
-				Kind:      int64(model.PanelElement),
-				Version:   1,
+				FolderID: newFolder.ID, // nolint:staticcheck
+				Kind:     int64(model.PanelElement),
+				Version:  1,
 			}
 			sc.ctx.Req = web.SetURLParams(sc.ctx.Req, map[string]string{":uid": sc.initialResult.Result.UID})
 			sc.reqContext.Req.Body = mockRequestBody(cmd)
@@ -105,7 +102,6 @@ func TestPatchLibraryElement(t *testing.T) {
 			var result = validateAndUnMarshalResponse(t, resp)
 			// nolint:staticcheck
 			sc.initialResult.Result.FolderID = newFolder.ID
-			sc.initialResult.Result.FolderUID = newFolder.UID
 			sc.initialResult.Result.Meta.CreatedBy.Name = userInDbName
 			sc.initialResult.Result.Meta.CreatedBy.AvatarUrl = userInDbAvatar
 			sc.initialResult.Result.Meta.Updated = result.Result.Meta.Updated
@@ -180,11 +176,10 @@ func TestPatchLibraryElement(t *testing.T) {
 	scenarioWithPanel(t, "When an admin tries to patch a library panel with an UID that is too long, it should fail",
 		func(t *testing.T, sc scenarioContext) {
 			cmd := model.PatchLibraryElementCommand{
-				FolderID:  -1, // nolint:staticcheck
-				FolderUID: &sc.folder.UID,
-				UID:       "j6T00KRZzj6T00KRZzj6T00KRZzj6T00KRZzj6T00K",
-				Kind:      int64(model.PanelElement),
-				Version:   1,
+				FolderID: -1, // nolint:staticcheck
+				UID:      "j6T00KRZzj6T00KRZzj6T00KRZzj6T00KRZzj6T00K",
+				Kind:     int64(model.PanelElement),
+				Version:  1,
 			}
 			sc.ctx.Req = web.SetURLParams(sc.ctx.Req, map[string]string{":uid": sc.initialResult.Result.UID})
 			sc.ctx.Req.Body = mockRequestBody(cmd)
@@ -195,17 +190,16 @@ func TestPatchLibraryElement(t *testing.T) {
 	scenarioWithPanel(t, "When an admin tries to patch a library panel with an existing UID, it should fail",
 		func(t *testing.T, sc scenarioContext) {
 			// nolint:staticcheck
-			command := getCreatePanelCommand(sc.folder.ID, sc.folder.UID, "Existing UID")
+			command := getCreatePanelCommand(sc.folder.ID, "Existing UID")
 			command.UID = util.GenerateShortUID()
 			sc.reqContext.Req.Body = mockRequestBody(command)
 			resp := sc.service.createHandler(sc.reqContext)
 			require.Equal(t, 200, resp.Status())
 			cmd := model.PatchLibraryElementCommand{
-				FolderID:  -1, // nolint:staticcheck
-				FolderUID: &sc.folder.UID,
-				UID:       command.UID,
-				Kind:      int64(model.PanelElement),
-				Version:   1,
+				FolderID: -1, // nolint:staticcheck
+				UID:      command.UID,
+				Kind:     int64(model.PanelElement),
+				Version:  1,
 			}
 			sc.ctx.Req = web.SetURLParams(sc.ctx.Req, map[string]string{":uid": sc.initialResult.Result.UID})
 			sc.ctx.Req.Body = mockRequestBody(cmd)
@@ -318,7 +312,7 @@ func TestPatchLibraryElement(t *testing.T) {
 	scenarioWithPanel(t, "When an admin tries to patch a library panel with a name that already exists, it should fail",
 		func(t *testing.T, sc scenarioContext) {
 			// nolint:staticcheck
-			command := getCreatePanelCommand(sc.folder.ID, sc.folder.UID, "Another Panel")
+			command := getCreatePanelCommand(sc.folder.ID, "Another Panel")
 			sc.ctx.Req.Body = mockRequestBody(command)
 			resp := sc.service.createHandler(sc.reqContext)
 			var result = validateAndUnMarshalResponse(t, resp)
@@ -337,15 +331,14 @@ func TestPatchLibraryElement(t *testing.T) {
 		func(t *testing.T, sc scenarioContext) {
 			newFolder := createFolder(t, sc, "NewFolder")
 			// nolint:staticcheck
-			command := getCreatePanelCommand(newFolder.ID, newFolder.UID, "Text - Library Panel")
+			command := getCreatePanelCommand(newFolder.ID, "Text - Library Panel")
 			sc.ctx.Req.Body = mockRequestBody(command)
 			resp := sc.service.createHandler(sc.reqContext)
 			var result = validateAndUnMarshalResponse(t, resp)
 			cmd := model.PatchLibraryElementCommand{
-				FolderID:  1, // nolint:staticcheck
-				FolderUID: &sc.folder.UID,
-				Version:   1,
-				Kind:      int64(model.PanelElement),
+				FolderID: 1, // nolint:staticcheck
+				Version:  1,
+				Kind:     int64(model.PanelElement),
 			}
 			sc.ctx.Req = web.SetURLParams(sc.ctx.Req, map[string]string{":uid": result.Result.UID})
 			sc.ctx.Req.Body = mockRequestBody(cmd)
@@ -356,25 +349,23 @@ func TestPatchLibraryElement(t *testing.T) {
 	scenarioWithPanel(t, "When an admin tries to patch a library panel in another org, it should fail",
 		func(t *testing.T, sc scenarioContext) {
 			cmd := model.PatchLibraryElementCommand{
-				FolderID:  sc.folder.ID, // nolint:staticcheck
-				FolderUID: &sc.folder.UID,
-				Version:   1,
-				Kind:      int64(model.PanelElement),
+				FolderID: sc.folder.ID, // nolint:staticcheck
+				Version:  1,
+				Kind:     int64(model.PanelElement),
 			}
 			sc.reqContext.OrgID = 2
 			sc.ctx.Req = web.SetURLParams(sc.ctx.Req, map[string]string{":uid": sc.initialResult.Result.UID})
 			sc.ctx.Req.Body = mockRequestBody(cmd)
 			resp := sc.service.patchHandler(sc.reqContext)
-			require.Equal(t, 400, resp.Status())
+			require.Equal(t, 404, resp.Status())
 		})
 
 	scenarioWithPanel(t, "When an admin tries to patch a library panel with an old version number, it should fail",
 		func(t *testing.T, sc scenarioContext) {
 			cmd := model.PatchLibraryElementCommand{
-				FolderID:  sc.folder.ID, // nolint:staticcheck
-				FolderUID: &sc.folder.UID,
-				Version:   1,
-				Kind:      int64(model.PanelElement),
+				FolderID: sc.folder.ID, // nolint:staticcheck
+				Version:  1,
+				Kind:     int64(model.PanelElement),
 			}
 			sc.ctx.Req = web.SetURLParams(sc.ctx.Req, map[string]string{":uid": sc.initialResult.Result.UID})
 			sc.ctx.Req.Body = mockRequestBody(cmd)
@@ -388,10 +379,9 @@ func TestPatchLibraryElement(t *testing.T) {
 	scenarioWithPanel(t, "When an admin tries to patch a library panel with an other kind, it should succeed but panel should not change",
 		func(t *testing.T, sc scenarioContext) {
 			cmd := model.PatchLibraryElementCommand{
-				FolderID:  sc.folder.ID, // nolint:staticcheck
-				FolderUID: &sc.folder.UID,
-				Version:   1,
-				Kind:      int64(model.VariableElement),
+				FolderID: sc.folder.ID, // nolint:staticcheck
+				Version:  1,
+				Kind:     int64(model.VariableElement),
 			}
 			sc.ctx.Req = web.SetURLParams(sc.ctx.Req, map[string]string{":uid": sc.initialResult.Result.UID})
 			sc.ctx.Req.Body = mockRequestBody(cmd)

--- a/pkg/services/libraryelements/libraryelements_permissions_test.go
+++ b/pkg/services/libraryelements/libraryelements_permissions_test.go
@@ -30,7 +30,7 @@ func TestLibraryElementPermissionsGeneralFolder(t *testing.T) {
 			func(t *testing.T, sc scenarioContext) {
 				sc.reqContext.SignedInUser.OrgRole = testCase.role
 
-				command := getCreatePanelCommand(0, "", "Library Panel Name")
+				command := getCreatePanelCommand(0, "Library Panel Name")
 				sc.reqContext.Req.Body = mockRequestBody(command)
 				resp := sc.service.createHandler(sc.reqContext)
 				require.Equal(t, testCase.status, resp.Status())
@@ -40,7 +40,7 @@ func TestLibraryElementPermissionsGeneralFolder(t *testing.T) {
 			func(t *testing.T, sc scenarioContext) {
 				folder := createFolder(t, sc, "Folder")
 				// nolint:staticcheck
-				command := getCreatePanelCommand(folder.ID, folder.UID, "Library Panel Name")
+				command := getCreatePanelCommand(folder.ID, "Library Panel Name")
 				sc.reqContext.Req.Body = mockRequestBody(command)
 				resp := sc.service.createHandler(sc.reqContext)
 				result := validateAndUnMarshalResponse(t, resp)
@@ -57,7 +57,7 @@ func TestLibraryElementPermissionsGeneralFolder(t *testing.T) {
 		testScenario(t, fmt.Sprintf("When %s tries to patch a library panel by moving it from the General folder, it should return correct status", testCase.role),
 			func(t *testing.T, sc scenarioContext) {
 				folder := createFolder(t, sc, "Folder")
-				command := getCreatePanelCommand(0, "", "Library Panel Name")
+				command := getCreatePanelCommand(0, "Library Panel Name")
 				sc.reqContext.Req.Body = mockRequestBody(command)
 				resp := sc.service.createHandler(sc.reqContext)
 				result := validateAndUnMarshalResponse(t, resp)
@@ -73,7 +73,7 @@ func TestLibraryElementPermissionsGeneralFolder(t *testing.T) {
 
 		testScenario(t, fmt.Sprintf("When %s tries to delete a library panel in the General folder, it should return correct status", testCase.role),
 			func(t *testing.T, sc scenarioContext) {
-				cmd := getCreatePanelCommand(0, "", "Library Panel Name")
+				cmd := getCreatePanelCommand(0, "Library Panel Name")
 				sc.reqContext.Req.Body = mockRequestBody(cmd)
 				resp := sc.service.createHandler(sc.reqContext)
 				result := validateAndUnMarshalResponse(t, resp)
@@ -86,7 +86,7 @@ func TestLibraryElementPermissionsGeneralFolder(t *testing.T) {
 
 		testScenario(t, fmt.Sprintf("When %s tries to get a library panel from General folder, it should return correct response", testCase.role),
 			func(t *testing.T, sc scenarioContext) {
-				cmd := getCreatePanelCommand(0, "", "Library Panel in General Folder")
+				cmd := getCreatePanelCommand(0, "Library Panel in General Folder")
 				sc.reqContext.Req.Body = mockRequestBody(cmd)
 				resp := sc.service.createHandler(sc.reqContext)
 				result := validateAndUnMarshalResponse(t, resp)
@@ -96,7 +96,6 @@ func TestLibraryElementPermissionsGeneralFolder(t *testing.T) {
 				result.Result.Meta.UpdatedBy.AvatarUrl = userInDbAvatar
 				result.Result.Meta.FolderName = "General"
 				result.Result.Meta.FolderUID = ""
-				result.Result.FolderUID = "general"
 				sc.reqContext.SignedInUser.OrgRole = testCase.role
 
 				sc.ctx.Req = web.SetURLParams(sc.ctx.Req, map[string]string{":uid": result.Result.UID})
@@ -112,7 +111,7 @@ func TestLibraryElementPermissionsGeneralFolder(t *testing.T) {
 
 		testScenario(t, fmt.Sprintf("When %s tries to get all library panels from General folder, it should return correct response", testCase.role),
 			func(t *testing.T, sc scenarioContext) {
-				cmd := getCreatePanelCommand(0, "", "Library Panel in General Folder")
+				cmd := getCreatePanelCommand(0, "Library Panel in General Folder")
 				sc.reqContext.Req.Body = mockRequestBody(cmd)
 				resp := sc.service.createHandler(sc.reqContext)
 				result := validateAndUnMarshalResponse(t, resp)
@@ -184,7 +183,7 @@ func TestLibraryElementCreatePermissions(t *testing.T) {
 				}
 
 				// nolint:staticcheck
-				command := getCreatePanelCommand(folder.ID, folder.UID, "Library Panel Name")
+				command := getCreatePanelCommand(folder.ID, "Library Panel Name")
 				sc.reqContext.Req.Body = mockRequestBody(command)
 				resp := sc.service.createHandler(sc.reqContext)
 				require.Equal(t, testCase.status, resp.Status())
@@ -237,7 +236,7 @@ func TestLibraryElementPatchPermissions(t *testing.T) {
 			func(t *testing.T, sc scenarioContext) {
 				fromFolder := createFolder(t, sc, "FromFolder")
 				// nolint:staticcheck
-				command := getCreatePanelCommand(fromFolder.ID, fromFolder.UID, "Library Panel Name")
+				command := getCreatePanelCommand(fromFolder.ID, "Library Panel Name")
 				sc.reqContext.Req.Body = mockRequestBody(command)
 				resp := sc.service.createHandler(sc.reqContext)
 				result := validateAndUnMarshalResponse(t, resp)
@@ -249,7 +248,7 @@ func TestLibraryElementPatchPermissions(t *testing.T) {
 				}
 
 				// nolint:staticcheck
-				cmd := model.PatchLibraryElementCommand{FolderID: toFolder.ID, FolderUID: &toFolder.UID, Version: 1, Kind: int64(model.PanelElement)}
+				cmd := model.PatchLibraryElementCommand{FolderID: toFolder.ID, Version: 1, Kind: int64(model.PanelElement)}
 				sc.ctx.Req = web.SetURLParams(sc.ctx.Req, map[string]string{":uid": result.Result.UID})
 				sc.reqContext.Req.Body = mockRequestBody(cmd)
 				resp = sc.service.patchHandler(sc.reqContext)
@@ -299,7 +298,7 @@ func TestLibraryElementDeletePermissions(t *testing.T) {
 			func(t *testing.T, sc scenarioContext) {
 				folder := createFolder(t, sc, "Folder")
 				// nolint:staticcheck
-				command := getCreatePanelCommand(folder.ID, folder.UID, "Library Panel Name")
+				command := getCreatePanelCommand(folder.ID, "Library Panel Name")
 				sc.reqContext.Req.Body = mockRequestBody(command)
 				resp := sc.service.createHandler(sc.reqContext)
 				result := validateAndUnMarshalResponse(t, resp)
@@ -318,29 +317,27 @@ func TestLibraryElementDeletePermissions(t *testing.T) {
 func TestLibraryElementsWithMissingFolders(t *testing.T) {
 	testScenario(t, "When a user tries to create a library panel in a folder that doesn't exist, it should fail",
 		func(t *testing.T, sc scenarioContext) {
-			command := getCreatePanelCommand(0, "badFolderUID", "Library Panel Name")
+			command := getCreatePanelCommand(-100, "Library Panel Name")
 			sc.reqContext.Req.Body = mockRequestBody(command)
 			resp := sc.service.createHandler(sc.reqContext)
-			fmt.Println(string(resp.Body()))
-			require.Equal(t, 400, resp.Status())
+			require.Equal(t, 404, resp.Status())
 		})
 
 	testScenario(t, "When a user tries to patch a library panel by moving it to a folder that doesn't exist, it should fail",
 		func(t *testing.T, sc scenarioContext) {
 			folder := createFolder(t, sc, "Folder")
 			// nolint:staticcheck
-			command := getCreatePanelCommand(folder.ID, folder.UID, "Library Panel Name")
+			command := getCreatePanelCommand(folder.ID, "Library Panel Name")
 			sc.reqContext.Req.Body = mockRequestBody(command)
 			resp := sc.service.createHandler(sc.reqContext)
 			result := validateAndUnMarshalResponse(t, resp)
 
-			folderUID := "badFolderUID"
 			// nolint:staticcheck
-			cmd := model.PatchLibraryElementCommand{FolderID: -100, FolderUID: &folderUID, Version: 1, Kind: int64(model.PanelElement)}
+			cmd := model.PatchLibraryElementCommand{FolderID: -100, Version: 1, Kind: int64(model.PanelElement)}
 			sc.ctx.Req = web.SetURLParams(sc.ctx.Req, map[string]string{":uid": result.Result.UID})
 			sc.reqContext.Req.Body = mockRequestBody(cmd)
 			resp = sc.service.patchHandler(sc.reqContext)
-			require.Equal(t, 400, resp.Status())
+			require.Equal(t, 404, resp.Status())
 		})
 }
 
@@ -370,7 +367,7 @@ func TestLibraryElementsGetPermissions(t *testing.T) {
 			func(t *testing.T, sc scenarioContext) {
 				folder := createFolder(t, sc, "Folder")
 				// nolint:staticcheck
-				cmd := getCreatePanelCommand(folder.ID, folder.UID, "Library Panel")
+				cmd := getCreatePanelCommand(folder.ID, "Library Panel")
 				sc.reqContext.Req.Body = mockRequestBody(cmd)
 				resp := sc.service.createHandler(sc.reqContext)
 				result := validateAndUnMarshalResponse(t, resp)
@@ -421,7 +418,7 @@ func TestLibraryElementsGetAllPermissions(t *testing.T) {
 				for i := 1; i <= 2; i++ {
 					folder := createFolder(t, sc, fmt.Sprintf("Folder%d", i))
 					// nolint:staticcheck
-					cmd := getCreatePanelCommand(folder.ID, folder.UID, fmt.Sprintf("Library Panel %d", i))
+					cmd := getCreatePanelCommand(folder.ID, fmt.Sprintf("Library Panel %d", i))
 					sc.reqContext.Req.Body = mockRequestBody(cmd)
 					resp := sc.service.createHandler(sc.reqContext)
 					result := validateAndUnMarshalResponse(t, resp)

--- a/pkg/services/libraryelements/model/model.go
+++ b/pkg/services/libraryelements/model/model.go
@@ -20,7 +20,6 @@ type LibraryElement struct {
 	OrgID int64 `xorm:"org_id"`
 	// Deprecated: use FolderUID instead
 	FolderID    int64  `xorm:"folder_id"`
-	FolderUID   string `xorm:"folder_uid"`
 	UID         string `xorm:"uid"`
 	Name        string
 	Kind        int64
@@ -42,7 +41,6 @@ type LibraryElementWithMeta struct {
 	OrgID int64 `xorm:"org_id"`
 	// Deprecated: use FolderUID instead
 	FolderID    int64  `xorm:"folder_id"`
-	FolderUID   string `xorm:"folder_uid"`
 	UID         string `xorm:"uid"`
 	Name        string
 	Kind        int64
@@ -55,6 +53,7 @@ type LibraryElementWithMeta struct {
 	Updated time.Time
 
 	FolderName          string
+	FolderUID           string `xorm:"folder_uid"`
 	ConnectedDashboards int64
 	CreatedBy           int64
 	UpdatedBy           int64
@@ -218,14 +217,13 @@ type GetLibraryElementCommand struct {
 
 // SearchLibraryElementsQuery is the query used for searching for Elements
 type SearchLibraryElementsQuery struct {
-	PerPage       int
-	Page          int
-	SearchString  string
-	SortDirection string
-	Kind          int
-	TypeFilter    string
-	ExcludeUID    string
-	// Deprecated: use FolderFilterUIDs instead
+	PerPage          int
+	Page             int
+	SearchString     string
+	SortDirection    string
+	Kind             int
+	TypeFilter       string
+	ExcludeUID       string
 	FolderFilter     string
 	FolderFilterUIDs string
 }

--- a/pkg/services/libraryelements/writers.go
+++ b/pkg/services/libraryelements/writers.go
@@ -82,7 +82,6 @@ type FolderFilter struct {
 func parseFolderFilter(query model.SearchLibraryElementsQuery) FolderFilter {
 	folderIDs := make([]string, 0)
 	folderUIDs := make([]string, 0)
-	// nolint:staticcheck
 	hasFolderFilter := len(strings.TrimSpace(query.FolderFilter)) > 0
 	hasFolderFilterUID := len(strings.TrimSpace(query.FolderFilterUIDs)) > 0
 
@@ -101,7 +100,6 @@ func parseFolderFilter(query model.SearchLibraryElementsQuery) FolderFilter {
 
 	if hasFolderFilter {
 		result.includeGeneralFolder = false
-		// nolint:staticcheck
 		folderIDs = strings.Split(query.FolderFilter, ",")
 		metrics.MFolderIDsServiceCount.WithLabelValues(metrics.LibraryElements).Inc()
 		// nolint:staticcheck

--- a/pkg/services/librarypanels/librarypanels.go
+++ b/pkg/services/librarypanels/librarypanels.go
@@ -42,7 +42,7 @@ func ProvideService(cfg *setting.Cfg, sqlStore db.DB, routeRegister routing.Rout
 // Service is a service for operating on library panels.
 type Service interface {
 	ConnectLibraryPanelsForDashboard(c context.Context, signedInUser identity.Requester, dash *dashboards.Dashboard) error
-	ImportLibraryPanelsForDashboard(c context.Context, signedInUser identity.Requester, libraryPanels *simplejson.Json, panels []any, folderID int64, folderUID string) error
+	ImportLibraryPanelsForDashboard(c context.Context, signedInUser identity.Requester, libraryPanels *simplejson.Json, panels []any, folderID int64) error
 }
 
 type LibraryInfo struct {
@@ -117,11 +117,11 @@ func connectLibraryPanelsRecursively(c context.Context, panels []any, libraryPan
 }
 
 // ImportLibraryPanelsForDashboard loops through all panels in dashboard JSON and creates any missing library panels in the database.
-func (lps *LibraryPanelService) ImportLibraryPanelsForDashboard(c context.Context, signedInUser identity.Requester, libraryPanels *simplejson.Json, panels []any, folderID int64, folderUID string) error {
-	return importLibraryPanelsRecursively(c, lps.LibraryElementService, signedInUser, libraryPanels, panels, folderID, folderUID)
+func (lps *LibraryPanelService) ImportLibraryPanelsForDashboard(c context.Context, signedInUser identity.Requester, libraryPanels *simplejson.Json, panels []any, folderID int64) error {
+	return importLibraryPanelsRecursively(c, lps.LibraryElementService, signedInUser, libraryPanels, panels, folderID)
 }
 
-func importLibraryPanelsRecursively(c context.Context, service libraryelements.Service, signedInUser identity.Requester, libraryPanels *simplejson.Json, panels []any, folderID int64, folderUID string) error {
+func importLibraryPanelsRecursively(c context.Context, service libraryelements.Service, signedInUser identity.Requester, libraryPanels *simplejson.Json, panels []any, folderID int64) error {
 	for _, panel := range panels {
 		panelAsJSON := simplejson.NewFromAny(panel)
 		libraryPanel := panelAsJSON.Get("libraryPanel")
@@ -132,7 +132,7 @@ func importLibraryPanelsRecursively(c context.Context, service libraryelements.S
 
 		// we have a row
 		if panelType == "row" {
-			err := importLibraryPanelsRecursively(c, service, signedInUser, libraryPanels, panelAsJSON.Get("panels").MustArray(), folderID, folderUID)
+			err := importLibraryPanelsRecursively(c, service, signedInUser, libraryPanels, panelAsJSON.Get("panels").MustArray(), folderID)
 			if err != nil {
 				return err
 			}
@@ -168,12 +168,11 @@ func importLibraryPanelsRecursively(c context.Context, service libraryelements.S
 
 			metrics.MFolderIDsServiceCount.WithLabelValues(metrics.LibraryPanels).Inc()
 			var cmd = model.CreateLibraryElementCommand{
-				FolderID:  folderID, // nolint:staticcheck
-				FolderUID: &folderUID,
-				Name:      name,
-				Model:     Model,
-				Kind:      int64(model.PanelElement),
-				UID:       UID,
+				FolderID: folderID, // nolint:staticcheck
+				Name:     name,
+				Model:    Model,
+				Kind:     int64(model.PanelElement),
+				UID:      UID,
 			}
 			_, err = service.CreateElement(c, signedInUser, cmd)
 			if err != nil {

--- a/pkg/services/sqlstore/migrations/libraryelements.go
+++ b/pkg/services/sqlstore/migrations/libraryelements.go
@@ -61,26 +61,4 @@ func addLibraryElementsMigrations(mg *migrator.Migrator) {
 
 	mg.AddMigration("alter library_element model to mediumtext", migrator.NewRawSQLMigration("").
 		Mysql("ALTER TABLE library_element MODIFY model MEDIUMTEXT NOT NULL;"))
-
-	q := `UPDATE library_element
-	SET folder_uid = dashboard.uid
-	FROM dashboard
-	WHERE library_element.folder_id = dashboard.folder_id AND library_element.org_id = dashboard.org_id`
-
-	if mg.Dialect.DriverName() == migrator.MySQL {
-		q = `UPDATE library_element
-		SET folder_uid = (
-			SELECT dashboard.uid
-			FROM dashboard
-			WHERE library_element.folder_id = dashboard.folder_id AND library_element.org_id = dashboard.org_id
-		)`
-	}
-
-	mg.AddMigration("add library_element folder uid", migrator.NewAddColumnMigration(libraryElementsV1, &migrator.Column{
-		Name: "folder_uid", Type: migrator.DB_NVarchar, Length: 40, Nullable: true,
-	}))
-
-	mg.AddMigration("populate library_element folder_uid", migrator.NewRawSQLMigration(q))
-
-	mg.AddMigration("add index library_element org_id-folder_uid-name-kind", migrator.NewAddIndexMigration(libraryElementsV1, &migrator.Index{Cols: []string{"org_id", "folder_uid", "name", "kind"}, Type: migrator.UniqueIndex}))
 }


### PR DESCRIPTION
Reverts grafana/grafana#79572

This was breaking instant builds due to a migration query error:

```
logger=migrator t=2024-03-01T15:27:21.855247277Z level=info msg="Executing migration" id="populate library_element folder_uid"                               
logger=migrator t=2024-03-01T15:27:21.860774506Z level=error msg="Executing migration failed" id="populate library_element folder_uid" error="Error 1242 (21 
000): Subquery returns more than 1 row" duration=5.528452ms                                                                         
logger=migrator t=2024-03-01T15:27:21.87239573Z level=info msg="Unlocking database"                                                                          
Error: ✗ migration failed (id = populate library_element folder_uid): Error 1242 (21000): Subquery returns more than 1 row   
```