### PR TITLE
Chore: Fix typo in template not found error message

### DIFF
--- a/public/app/features/alerting/unified/components/receivers/DuplicateTemplateView.tsx
+++ b/public/app/features/alerting/unified/components/receivers/DuplicateTemplateView.tsx
@@ -20,7 +20,7 @@ export const DuplicateTemplateView = ({ config, templateName, alertManagerSource
   if (!template) {
     return (
       <Alert severity="error" title="Template not found">
-        Sorry, this template does not seem to exists.
+        Sorry, this template does not seem to exist.
       </Alert>
     );
   }

--- a/public/app/features/alerting/unified/components/receivers/EditTemplateView.tsx
+++ b/public/app/features/alerting/unified/components/receivers/EditTemplateView.tsx
@@ -18,7 +18,7 @@ export const EditTemplateView = ({ config, templateName, alertManagerSourceName 
   if (!template) {
     return (
       <Alert severity="error" title="Template not found">
-        Sorry, this template does not seem to exists.
+        Sorry, this template does not seem to exist.
       </Alert>
     );
   }


### PR DESCRIPTION
"Sorry, this template does not seem to exist.", no "s" at the end.