### PR TITLE
Plugins: Fetch instance provisioned plugins in cloud, to check full installation

### DIFF
--- a/public/app/features/plugins/admin/api.ts
+++ b/public/app/features/plugins/admin/api.ts
@@ -134,11 +134,11 @@ export async function getInstancePlugins(): Promise<InstancePlugin[]> {
 }
 
 export async function getProvisionedPlugins(): Promise<ProvisionedPlugin[]> {
-  const { items: instancePlugins }: { items: ProvisionedPlugin[] } = await getBackendSrv().get(
+  const { items: provisionedPlugins }: { items: Array<{ type: string }> } = await getBackendSrv().get(
     `${INSTANCE_API_ROOT}/provisioned-plugins`
   );
 
-  return instancePlugins;
+  return provisionedPlugins.map(plugin => ({ slug: plugin.type }));
 }
 
 export async function installPlugin(id: string) {

--- a/public/app/features/plugins/admin/api.ts
+++ b/public/app/features/plugins/admin/api.ts
@@ -138,7 +138,7 @@ export async function getProvisionedPlugins(): Promise<ProvisionedPlugin[]> {
     `${INSTANCE_API_ROOT}/provisioned-plugins`
   );
 
-  return provisionedPlugins.map(plugin => ({ slug: plugin.type }));
+  return provisionedPlugins.map((plugin) => ({ slug: plugin.type }));
 }
 
 export async function installPlugin(id: string) {

--- a/public/app/features/plugins/admin/api.ts
+++ b/public/app/features/plugins/admin/api.ts
@@ -4,7 +4,15 @@ import { accessControlQueryParam } from 'app/core/utils/accessControl';
 
 import { API_ROOT, GCOM_API_ROOT, INSTANCE_API_ROOT } from './constants';
 import { isLocalPluginVisibleByConfig, isRemotePluginVisibleByConfig } from './helpers';
-import { LocalPlugin, RemotePlugin, CatalogPluginDetails, Version, PluginVersion, InstancePlugin } from './types';
+import {
+  LocalPlugin,
+  RemotePlugin,
+  CatalogPluginDetails,
+  Version,
+  PluginVersion,
+  InstancePlugin,
+  ProvisionedPlugin,
+} from './types';
 
 export async function getPluginDetails(id: string): Promise<CatalogPluginDetails> {
   const remote = await getRemotePlugin(id);
@@ -120,6 +128,14 @@ export async function getLocalPlugins(): Promise<LocalPlugin[]> {
 export async function getInstancePlugins(): Promise<InstancePlugin[]> {
   const { items: instancePlugins }: { items: InstancePlugin[] } = await getBackendSrv().get(
     `${INSTANCE_API_ROOT}/plugins`
+  );
+
+  return instancePlugins;
+}
+
+export async function getProvisionedPlugins(): Promise<ProvisionedPlugin[]> {
+  const { items: instancePlugins }: { items: ProvisionedPlugin[] } = await getBackendSrv().get(
+    `${INSTANCE_API_ROOT}/provisioned-plugins`
   );
 
   return instancePlugins;

--- a/public/app/features/plugins/admin/helpers.test.ts
+++ b/public/app/features/plugins/admin/helpers.test.ts
@@ -112,6 +112,30 @@ describe('Plugins/Helpers', () => {
       config.featureToggles.managedPluginsInstall = oldFeatureTogglesManagedPluginsInstall;
       config.pluginAdminExternalManageEnabled = oldPluginAdminExternalManageEnabled;
     });
+
+    test('plugins should be fully installed if they are installed and it is provisioned', () => {
+      const pluginId = 'plugin-1';
+
+      const oldFeatureTogglesManagedPluginsInstall = config.featureToggles.managedPluginsInstall;
+      const oldPluginAdminExternalManageEnabled = config.pluginAdminExternalManageEnabled;
+
+      config.featureToggles.managedPluginsInstall = true;
+      config.pluginAdminExternalManageEnabled = true;
+
+      const merged = mergeLocalsAndRemotes({
+        local: [...localPlugins, getLocalPluginMock({ id: pluginId })],
+        remote: [...remotePlugins, getRemotePluginMock({ slug: pluginId })],
+        provisioned: [{ slug: pluginId }],
+      });
+      const findMerged = (mergedId: string) => merged.find(({ id }) => id === mergedId);
+
+      expect(merged).toHaveLength(5);
+      expect(findMerged(pluginId)).not.toBeUndefined();
+      expect(findMerged(pluginId)?.isFullyInstalled).toBe(true);
+
+      config.featureToggles.managedPluginsInstall = oldFeatureTogglesManagedPluginsInstall;
+      config.pluginAdminExternalManageEnabled = oldPluginAdminExternalManageEnabled;
+    });
   });
 
   describe('mergeLocalAndRemote()', () => {

--- a/public/app/features/plugins/admin/helpers.ts
+++ b/public/app/features/plugins/admin/helpers.ts
@@ -39,7 +39,7 @@ export function mergeLocalsAndRemotes({
   }, new Map<string, InstancePlugin>());
 
   const provisionedSet = provisioned.reduce((map, provisionedPlugin) => {
-    map.add(provisionedPlugin.type);
+    map.add(provisionedPlugin.slug);
     return map;
   }, new Set<string>());
 

--- a/public/app/features/plugins/admin/helpers.ts
+++ b/public/app/features/plugins/admin/helpers.ts
@@ -7,17 +7,27 @@ import { contextSrv } from 'app/core/core';
 import { getBackendSrv } from 'app/core/services/backend_srv';
 import { AccessControlAction } from 'app/types';
 
-import { CatalogPlugin, InstancePlugin, LocalPlugin, RemotePlugin, RemotePluginStatus, Version } from './types';
+import {
+  CatalogPlugin,
+  InstancePlugin,
+  LocalPlugin,
+  ProvisionedPlugin,
+  RemotePlugin,
+  RemotePluginStatus,
+  Version,
+} from './types';
 
 export function mergeLocalsAndRemotes({
   local = [],
   remote = [],
   instance = [],
+  provisioned = [],
   pluginErrors: errors,
 }: {
   local: LocalPlugin[];
   remote?: RemotePlugin[];
   instance?: InstancePlugin[];
+  provisioned?: ProvisionedPlugin[];
   pluginErrors?: PluginError[];
 }): CatalogPlugin[] {
   const catalogPlugins: CatalogPlugin[] = [];
@@ -27,6 +37,11 @@ export function mergeLocalsAndRemotes({
     map.set(instancePlugin.pluginSlug, instancePlugin);
     return map;
   }, new Map<string, InstancePlugin>());
+
+  const provisionedSet = provisioned.reduce((map, provisionedPlugin) => {
+    map.add(provisionedPlugin.type);
+    return map;
+  }, new Set<string>());
 
   // add locals
   local.forEach((localPlugin) => {
@@ -51,7 +66,7 @@ export function mergeLocalsAndRemotes({
       if (configCore.featureToggles.managedPluginsInstall && config.pluginAdminExternalManageEnabled) {
         catalogPlugin.isFullyInstalled = catalogPlugin.isCore
           ? true
-          : instancesMap.has(remotePlugin.slug) && catalogPlugin.isInstalled;
+          : (instancesMap.has(remotePlugin.slug) || provisionedSet.has(remotePlugin.slug)) && catalogPlugin.isInstalled;
 
         catalogPlugin.isInstalled = instancesMap.has(remotePlugin.slug) || catalogPlugin.isInstalled;
 

--- a/public/app/features/plugins/admin/types.ts
+++ b/public/app/features/plugins/admin/types.ts
@@ -324,5 +324,5 @@ export type InstancePlugin = {
 };
 
 export type ProvisionedPlugin = {
-  type: string; // type contains the plugin slug
+  slug: string;
 };

--- a/public/app/features/plugins/admin/types.ts
+++ b/public/app/features/plugins/admin/types.ts
@@ -322,3 +322,7 @@ export type InstancePlugin = {
   pluginSlug: string;
   version: string;
 };
+
+export type ProvisionedPlugin = {
+  type: string; // type contains the plugin slug
+};


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

For cloud plugins, it fetches the provisioned plugins of an instance to check for full installation.

**Why do we need this feature?**

This is needed to solve a bug where provisioned plugins didn't show as installed in cloud

**Who is this feature for?**

Provisioned plugin users.

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
