### PR TITLE
Alerting: Fix bug in screenshot service using incorrect limit

### DIFF
--- a/pkg/services/screenshot/screenshot.go
+++ b/pkg/services/screenshot/screenshot.go
@@ -122,7 +122,7 @@ func (s *HeadlessScreenshotService) Take(ctx context.Context, opts ScreenshotOpt
 		Width:           opts.Width,
 		Height:          opts.Height,
 		Theme:           opts.Theme,
-		ConcurrentLimit: s.cfg.AlertingRenderLimit,
+		ConcurrentLimit: s.cfg.RendererConcurrentRequestLimit,
 		Path:            u.String(),
 	}
 

--- a/pkg/services/screenshot/screenshot_test.go
+++ b/pkg/services/screenshot/screenshot_test.go
@@ -54,7 +54,7 @@ func TestHeadlessScreenshotService(t *testing.T) {
 		Height:          DefaultHeight,
 		Theme:           DefaultTheme,
 		Path:            "d-solo/foo/bar?from=now-6h&orgId=2&panelId=4&to=now-2h",
-		ConcurrentLimit: cfg.AlertingRenderLimit,
+		ConcurrentLimit: cfg.RendererConcurrentRequestLimit,
 	}
 
 	opts.From = "now-6h"


### PR DESCRIPTION
**What is this feature?**

This commit fixes a bug in the screenshot service where `[alerting].concurrent_render_limit` was used instead of `[rendering].concurrent_render_request_limit`, as in the docs.

**Why do we need this feature?**

[Add a description of the problem the feature is trying to solve.]

**Who is this feature for?**

[Add information on what kind of user the feature is for.]

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle.
- [x] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
