### PR TITLE
WIP: custom logo/img for datasource instances

### DIFF
--- a/packages/grafana-data/src/types/datasource.ts
+++ b/packages/grafana-data/src/types/datasource.ts
@@ -623,6 +623,7 @@ export interface DataSourceJsonData {
   manageAlerts?: boolean;
   alertmanagerUid?: string;
   disableGrafanaCache?: boolean;
+  logoUrl?: string;
 }
 
 /**

--- a/public/app/features/datasources/components/DataSourcesListCard.tsx
+++ b/public/app/features/datasources/components/DataSourcesListCard.tsx
@@ -25,7 +25,7 @@ export function DataSourcesListCard({ dataSource, hasWriteRights, hasExploreRigh
     <Card href={hasWriteRights ? dsLink : undefined}>
       <Card.Heading>{dataSource.name}</Card.Heading>
       <Card.Figure>
-        <img src={dataSource.typeLogoUrl} alt="" height="40px" width="40px" className={styles.logo} />
+        <img src={dataSource.jsonData?.logoUrl || dataSource.typeLogoUrl} alt="" height="40px" width="40px" className={styles.logo} />
       </Card.Figure>
       <Card.Meta>
         {[

--- a/public/app/features/datasources/components/DataSourcesListCard.tsx
+++ b/public/app/features/datasources/components/DataSourcesListCard.tsx
@@ -25,7 +25,13 @@ export function DataSourcesListCard({ dataSource, hasWriteRights, hasExploreRigh
     <Card href={hasWriteRights ? dsLink : undefined}>
       <Card.Heading>{dataSource.name}</Card.Heading>
       <Card.Figure>
-        <img src={dataSource.jsonData?.logoUrl || dataSource.typeLogoUrl} alt="" height="40px" width="40px" className={styles.logo} />
+        <img
+          src={dataSource.jsonData?.logoUrl || dataSource.typeLogoUrl}
+          alt=""
+          height="40px"
+          width="40px"
+          className={styles.logo}
+        />
       </Card.Figure>
       <Card.Meta>
         {[

--- a/public/app/features/datasources/components/picker/DataSourceCard.tsx
+++ b/public/app/features/datasources/components/picker/DataSourceCard.tsx
@@ -31,7 +31,7 @@ export function DataSourceCard({ ds, onClick, selected, description, ...htmlProp
         </div>
       </Card.Heading>
       <Card.Figure className={styles.logo}>
-        <img src={ds.meta.info.logos.small} alt={`${ds.meta.name} Logo`} />
+        <img src={ds.jsonData?.logoUrl || ds.meta.info.logos.small} alt={`${ds.meta.name} Logo`} />
       </Card.Figure>
     </Card>
   );

--- a/public/app/features/datasources/components/picker/DataSourceLogo.tsx
+++ b/public/app/features/datasources/components/picker/DataSourceLogo.tsx
@@ -21,7 +21,7 @@ export function DataSourceLogo(props: DataSourceLogoProps) {
     <img
       className={styles.pickerDSLogo}
       alt={`${dataSource.meta.name} logo`}
-      src={dataSource.meta.info.logos.small}
+      src={dataSource.jsonData?.logoUrl || dataSource.meta.info.logos.small}
     ></img>
   );
 }

--- a/public/app/features/datasources/state/navModel.ts
+++ b/public/app/features/datasources/state/navModel.ts
@@ -14,7 +14,7 @@ export function buildNavModel(dataSource: DataSourceSettings, plugin: GenericDat
   const pluginMeta = plugin.meta;
   const highlightsEnabled = config.featureToggles.featureHighlights;
   const navModel: NavModelItem = {
-    img: pluginMeta.info.logos.large,
+    img: dataSource.jsonData?.logoUrl|| pluginMeta.info.logos.large,
     id: 'datasource-' + dataSource.uid,
     url: '',
     text: dataSource.name,

--- a/public/app/features/datasources/state/navModel.ts
+++ b/public/app/features/datasources/state/navModel.ts
@@ -14,7 +14,7 @@ export function buildNavModel(dataSource: DataSourceSettings, plugin: GenericDat
   const pluginMeta = plugin.meta;
   const highlightsEnabled = config.featureToggles.featureHighlights;
   const navModel: NavModelItem = {
-    img: dataSource.jsonData?.logoUrl|| pluginMeta.info.logos.large,
+    img: dataSource.jsonData?.logoUrl || pluginMeta.info.logos.large,
     id: 'datasource-' + dataSource.uid,
     url: '',
     text: dataSource.name,


### PR DESCRIPTION
currently datasource instances uses the same logo as its type. this PR allows to add custom logo to the datasource.