### PR TITLE
Alerting docs: document `mute-timings` export endpoints

### DIFF
--- a/docs/sources/alerting/set-up/provision-alerting-resources/export-alerting-resources/index.md
+++ b/docs/sources/alerting/set-up/provision-alerting-resources/export-alerting-resources/index.md
@@ -137,6 +137,8 @@ The **Alerting HTTP API** provides specific endpoints for exporting alerting res
 | Alert rules              | GET /api/v1/provisioning/alert-rules/:uid/export                     | [Export an alert rule in provisioning file format.][export_rule]                         |
 | Contact points           | GET /api/v1/provisioning/contact-points/export                       | [Export all contact points in provisioning file format.][export_contacts]                |
 | Notification policy tree | GET /api/v1/provisioning/policies/export                             | [Export the notification policy tree in provisioning file format.][export_notifications] |
+| Mute timings             | GET /api/v1/provisioning/mute-timings/export                         | [Export all mute timings in provisioning file format.][export_mute_timings]              |
+| Mute timings             | GET /api/v1/provisioning/mute-timings/:name/export                   | [Export a mute timing in provisioning file format.][export_mute_timing]                  |
 
 These endpoints accept a `download` parameter to download a file containing the exported resources.
 
@@ -167,6 +169,12 @@ These endpoints accept a `download` parameter to download a file containing the 
 
 [export_contacts]: "/docs/grafana/ -> /docs/grafana/<GRAFANA_VERSION>/alerting/set-up/provision-alerting-resources/http-api-provisioning/#span-idroute-get-contactpoints-exportspan-export-all-contact-points-in-provisioning-file-format-_routegetcontactpointsexport_"
 [export_contacts]: "/docs/grafana-cloud/ -> /docs/grafana/<GRAFANA_VERSION>/alerting/set-up/provision-alerting-resources/http-api-provisioning/#span-idroute-get-contactpoints-exportspan-export-all-contact-points-in-provisioning-file-format-_routegetcontactpointsexport_"
+
+[export_mute_timing]: "/docs/grafana/ -> /docs/grafana/<GRAFANA_VERSION>/alerting/set-up/provision-alerting-resources/http-api-provisioning/#span-idroute-get-mute-timing-exportspan-export-a-mute-timing-in-provisioning-file-format-_routegetmutetimingexport_"
+[export_mute_timing]: "/docs/grafana-cloud/ -> /docs/grafana/<GRAFANA_VERSION>/alerting/set-up/provision-alerting-resources/http-api-provisioning/#span-idroute-get-mute-timing-exportspan-export-a-mute-timing-in-provisioning-file-format-_routegetmutetimingexport_"
+
+[export_mute_timings]: "/docs/grafana/ -> /docs/grafana/<GRAFANA_VERSION>/alerting/set-up/provision-alerting-resources/http-api-provisioning/#span-idroute-get-mute-timings-exportspan-export-all-mute-timings-in-provisioning-file-format-_routegetmutetimingsexport_"
+[export_mute_timings]: "/docs/grafana-cloud/ -> /docs/grafana/<GRAFANA_VERSION>/alerting/set-up/provision-alerting-resources/http-api-provisioning/#span-idroute-get-mute-timings-exportspan-export-all-mute-timings-in-provisioning-file-format-_routegetmutetimingsexport_"
 
 [export_notifications]: "/docs/grafana/ -> /docs/grafana/<GRAFANA_VERSION>/alerting/set-up/provision-alerting-resources/http-api-provisioning/#span-idroute-get-policy-tree-exportspan-export-the-notification-policy-tree-in-provisioning-file-format-_routegetpolicytreeexport_"
 [export_notifications]: "/docs/grafana-cloud/ -> /docs/grafana/<GRAFANA_VERSION>/alerting/set-up/provision-alerting-resources/http-api-provisioning/#span-idroute-get-policy-tree-exportspan-export-the-notification-policy-tree-in-provisioning-file-format-_routegetpolicytreeexport_"

--- a/docs/sources/shared/alerts/alerting_provisioning.md
+++ b/docs/sources/shared/alerts/alerting_provisioning.md
@@ -145,13 +145,15 @@ For managing resources related to [data source-managed alerts]({{< relref "/docs
 
 ### Mute timings
 
-| Method | URI                                     | Name                                                  | Summary                          |
-| ------ | --------------------------------------- | ----------------------------------------------------- | -------------------------------- |
-| DELETE | /api/v1/provisioning/mute-timings/:name | [route delete mute timing](#route-delete-mute-timing) | Delete a mute timing.            |
-| GET    | /api/v1/provisioning/mute-timings/:name | [route get mute timing](#route-get-mute-timing)       | Get a mute timing.               |
-| GET    | /api/v1/provisioning/mute-timings       | [route get mute timings](#route-get-mute-timings)     | Get all the mute timings.        |
-| POST   | /api/v1/provisioning/mute-timings       | [route post mute timing](#route-post-mute-timing)     | Create a new mute timing.        |
-| PUT    | /api/v1/provisioning/mute-timings/:name | [route put mute timing](#route-put-mute-timing)       | Replace an existing mute timing. |
+| Method | URI                                            | Name                                                            | Summary                                              |
+| ------ | ---------------------------------------------- | --------------------------------------------------------------- | ---------------------------------------------------- |
+| DELETE | /api/v1/provisioning/mute-timings/:name        | [route delete mute timing](#route-delete-mute-timing)           | Delete a mute timing.                                |
+| GET    | /api/v1/provisioning/mute-timings/:name        | [route get mute timing](#route-get-mute-timing)                 | Get a mute timing.                                   |
+| GET    | /api/v1/provisioning/mute-timings              | [route get mute timings](#route-get-mute-timings)               | Get all the mute timings.                            |
+| POST   | /api/v1/provisioning/mute-timings              | [route post mute timing](#route-post-mute-timing)               | Create a new mute timing.                            |
+| PUT    | /api/v1/provisioning/mute-timings/:name        | [route put mute timing](#route-put-mute-timing)                 | Replace an existing mute timing.                     |
+| GET    | /api/v1/provisioning/mute-timings/export       | [route get mute timings export](#route-get-mute-timings-export) | Export all mute timings in provisioning file format. |
+| GET    | /api/v1/provisioning/mute-timings/:name/export | [route get mute timing export](#route-get-mute-timing-export)   | Export a mute timing in provisioning file format.    |
 
 ### Templates
 
@@ -630,6 +632,83 @@ Status: OK
 ###### <span id="route-get-mute-timings-200-schema"></span> Schema
 
 [MuteTimings](#mute-timings)
+
+### <span id="route-get-mute-timings-export"></span> Export all mute timings in provisioning file format. (_RouteGetMuteTimingsExport_)
+
+```
+GET /api/v1/provisioning/mute-timings/export
+```
+
+#### Parameters
+
+| Name     | Source  | Type    | Go type  | Separator | Required | Default  | Description                                                                                                                       |
+| -------- | ------- | ------- | -------- | --------- | :------: | -------- | --------------------------------------------------------------------------------------------------------------------------------- |
+| download | `query` | boolean | `bool`   |           |          |          | Whether to initiate a download of the file or not.                                                                                |
+| format   | `query` | string  | `string` |           |          | `"yaml"` | Format of the downloaded file, either yaml or json. Accept header can also be used, but the query parameter will take precedence. |
+
+#### All responses
+
+| Code                                      | Status    | Description       | Has headers | Schema                                              |
+| ----------------------------------------- | --------- | ----------------- | :---------: | --------------------------------------------------- |
+| [200](#route-get-mute-timings-export-200) | OK        | MuteTimingsExport |             | [schema](#route-get-mute-timings-export-200-schema) |
+| [403](#route-get-mute-timings-export-403) | Forbidden | PermissionDenied  |             | [schema](#route-get-mute-timings-export-403-schema) |
+
+#### Responses
+
+##### <span id="route-get-mute-timings-export-200"></span> 200 - MuteTimingsExport
+
+Status: OK
+
+###### <span id="route-get-mute-timings-export-200-schema"></span> Schema
+
+[AlertingFileExport](#alerting-file-export)
+
+##### <span id="route-get-mute-timings-export-403"></span> 403 - PermissionDenied
+
+Status: Forbidden
+
+###### <span id="route-get-mute-timings-export-403-schema"></span> Schema
+
+[PermissionDenied](#permission-denied)
+
+### <span id="route-get-mute-timing-export"></span> Export a mute timing in provisioning file format. (_RouteGetMuteTimingExport_)
+
+```
+GET /api/v1/provisioning/mute-timings/:name/export
+```
+
+#### Parameters
+
+| Name     | Source  | Type    | Go type  | Separator | Required | Default  | Description                                                                                                                       |
+| -------- | ------- | ------- | -------- | --------- | :------: | -------- | --------------------------------------------------------------------------------------------------------------------------------- |
+| name     | `path`  | string  | `string` |           |    ✓     |          | Mute timing name.                                                                                                                 |
+| download | `query` | boolean | `bool`   |           |          |          | Whether to initiate a download of the file or not.                                                                                |
+| format   | `query` | string  | `string` |           |          | `"yaml"` | Format of the downloaded file, either yaml or json. Accept header can also be used, but the query parameter will take precedence. |
+
+#### All responses
+
+| Code                                     | Status    | Description      | Has headers | Schema                                              |
+| ---------------------------------------- | --------- | ---------------- | :---------: | --------------------------------------------------- |
+| [200](#route-get-mute-timing-export-200) | OK        | MuteTimingExport |             | [schema](#route-get-mute-timings-export-200-schema) |
+| [403](#route-get-mute-timing-export-403) | Forbidden | PermissionDenied |             | [schema](#route-get-mute-timings-export-403-schema) |
+
+#### Responses
+
+##### <span id="route-get-mute-timing-export-200"></span> 200 - MuteTimingExport
+
+Status: OK
+
+###### <span id="route-get-mute-timing-export-200-schema"></span> Schema
+
+[AlertingFileExport](#alerting-file-export)
+
+##### <span id="route-get-mute-timing-export-403"></span> 403 - PermissionDenied
+
+Status: Forbidden
+
+###### <span id="route-get-mute-timing-export-403-schema"></span> Schema
+
+[PermissionDenied](#permission-denied)
 
 ### <span id="route-get-policy-tree"></span> Get the notification policy tree. (_RouteGetPolicyTree_)
 
@@ -1392,6 +1471,14 @@ Status: Accepted
 | time_intervals | [][TimeInterval](#time-interval) | `[]*TimeInterval` |          |         |             |         |
 
 {{% /responsive-table %}}
+
+### <span id="mute-timing-export"></span> MuteTimingExport
+
+**Properties**
+
+### <span id="mute-timings-export"></span> MuteTimingsExport
+
+**Properties**
 
 ### <span id="mute-timings"></span> MuteTimings
 


### PR DESCRIPTION
Documentation for the export mute timing endpoints:
-  `/api/v1/provisioning/mute-timings/export` 
-  `/api/v1/provisioning/mute-timings/:name/export` 

#### [HTTP Alerting API](https://grafana.com/docs/grafana/next/alerting/set-up/provision-alerting-resources/http-api-provisioning/)

![Screenshot 2024-03-01 at 21 35 39](https://github.com/grafana/grafana/assets/825430/5f8f8d83-141d-4833-98de-37bbf65b5ef1)

#### [Export alerting resources](https://grafana.com/docs/grafana/next/alerting/set-up/provision-alerting-resources/export-alerting-resources/#export-api-endpoints)


![Screenshot 2024-03-01 at 21 35 14](https://github.com/grafana/grafana/assets/825430/dd5a56ad-a822-4b07-983d-6fc5e5823038)
