### PR TITLE
Table Panel: Update column filters to use Stack component

### DIFF
--- a/packages/grafana-ui/src/components/Table/FilterList.tsx
+++ b/packages/grafana-ui/src/components/Table/FilterList.tsx
@@ -169,7 +169,6 @@ export const FilterList = ({
   }, [onChange, values, items, selectedItems]);
 
   return (
-    // spacing="md"
     <Stack direction="column" gap={0.25}>
       {!showOperators && <FilterInput placeholder="Filter values" onChange={setSearchFilter} value={searchFilter} />}
       {showOperators && (
@@ -207,7 +206,6 @@ export const FilterList = ({
         </List>
       )}
       {items.length && (
-        // spacing="xs"
         <Stack direction="column" gap={0.25}>
           <div className={cx(styles.selectDivider)} />
           <div className={cx(styles.filterListRow)}>

--- a/packages/grafana-ui/src/components/Table/FilterList.tsx
+++ b/packages/grafana-ui/src/components/Table/FilterList.tsx
@@ -4,7 +4,7 @@ import { FixedSizeList as List } from 'react-window';
 
 import { GrafanaTheme2, formattedValueToString, getValueFormat, SelectableValue } from '@grafana/data';
 
-import { ButtonSelect, Checkbox, FilterInput, HorizontalGroup, Label, VerticalGroup } from '..';
+import { ButtonSelect, Checkbox, FilterInput, Label, Stack } from '..';
 import { useStyles2, useTheme2 } from '../../themes';
 
 interface Props {
@@ -169,11 +169,12 @@ export const FilterList = ({
   }, [onChange, values, items, selectedItems]);
 
   return (
-    <VerticalGroup spacing="md">
+    // spacing="md"
+    <Stack direction="column" gap={0.25}>
       {!showOperators && <FilterInput placeholder="Filter values" onChange={setSearchFilter} value={searchFilter} />}
       {showOperators && (
-        <HorizontalGroup>
-          <ButtonSelect<string>
+        <Stack direction="row" gap={0}>
+          <ButtonSelect
             variant="canvas"
             options={OPERATORS}
             onChange={setOperator}
@@ -181,7 +182,7 @@ export const FilterList = ({
             tooltip={operator.description}
           />
           <FilterInput placeholder="Filter values" onChange={setSearchFilter} value={searchFilter} />
-        </HorizontalGroup>
+        </Stack>
       )}
       {!items.length && <Label>No values</Label>}
       {items.length && (
@@ -206,7 +207,8 @@ export const FilterList = ({
         </List>
       )}
       {items.length && (
-        <VerticalGroup spacing="xs">
+        // spacing="xs"
+        <Stack direction="column" gap={0.25}>
           <div className={cx(styles.selectDivider)} />
           <div className={cx(styles.filterListRow)}>
             <Checkbox
@@ -217,9 +219,9 @@ export const FilterList = ({
               onChange={onSelectChanged}
             />
           </div>
-        </VerticalGroup>
+        </Stack>
       )}
-    </VerticalGroup>
+    </Stack>
   );
 };
 


### PR DESCRIPTION
This PR updates the Column filter of the table to use the `Stack` component from `@grafana/ui`. This removes the deprecated `HoritzonalGroup` and `VerticalGroup` components. This also tightens up the spacing of the component a bit to make layout more clear.

Before:

<img width="530" alt="Screenshot 2024-03-01 at 4 00 45 PM" src="https://github.com/grafana/grafana/assets/199847/93473e79-5361-44aa-8bd6-fd15d81ea6d3">

After:

<img width="549" alt="Screenshot 2024-03-01 at 3 58 04 PM" src="https://github.com/grafana/grafana/assets/199847/ba41bc43-c409-4737-b9dd-1b063e748bec">


**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
