### PR TITLE
Table Panel: Fix condition for showing footer options

### DIFF
--- a/public/app/plugins/panel/table/module.tsx
+++ b/public/app/plugins/panel/table/module.tsx
@@ -169,7 +169,7 @@ export const plugin = new PanelPlugin<Options, FieldConfig>(TablePanel)
           },
         },
         defaultValue: '',
-        showIf: (cfg) => (cfg.footer?.show && !cfg.footer?.countRows),
+        showIf: (cfg) => cfg.footer?.show && !cfg.footer?.countRows,
       })
       .addCustomEditor({
         id: 'footer.enablePagination',

--- a/public/app/plugins/panel/table/module.tsx
+++ b/public/app/plugins/panel/table/module.tsx
@@ -169,9 +169,7 @@ export const plugin = new PanelPlugin<Options, FieldConfig>(TablePanel)
           },
         },
         defaultValue: '',
-        showIf: (cfg) =>
-          (cfg.footer?.show && !cfg.footer?.countRows) ||
-          (cfg.footer?.reducer?.length === 1 && cfg.footer?.reducer[0] !== ReducerID.count),
+        showIf: (cfg) => (cfg.footer?.show && !cfg.footer?.countRows),
       })
       .addCustomEditor({
         id: 'footer.enablePagination',


### PR DESCRIPTION
**What is this feature?**

This PR fixes an issue in which the `Fields` selection for the table footer will show even when the table footer isn't enabled.

**Why do we need this feature?**

Makes table panel configuration more consistent and less confusing.

**Who is this feature for?**

Users configuring the table panel.

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
