### PR TITLE
K8s: Add accept header to ctx

### DIFF
--- a/pkg/apiserver/builder/helper.go
+++ b/pkg/apiserver/builder/helper.go
@@ -20,6 +20,8 @@ import (
 	"k8s.io/apiserver/pkg/util/openapi"
 	k8sscheme "k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/kube-openapi/pkg/common"
+
+	"github.com/grafana/grafana/pkg/apiserver/endpoints/filters"
 )
 
 func SetupConfig(
@@ -70,7 +72,11 @@ func SetupConfig(
 		if err != nil {
 			panic(fmt.Sprintf("could not build handler chain func: %s", err.Error()))
 		}
-		return genericapiserver.DefaultBuildHandlerChain(requestHandler, c)
+
+		handler := genericapiserver.DefaultBuildHandlerChain(requestHandler, c)
+		handler = filters.WithAcceptHeader(handler)
+
+		return handler
 	}
 
 	k8sVersion, err := getK8sApiserverVersion()

--- a/pkg/apiserver/endpoints/filters/accept.go
+++ b/pkg/apiserver/endpoints/filters/accept.go
@@ -1,0 +1,15 @@
+package filters
+
+import (
+	"net/http"
+
+	"github.com/grafana/grafana/pkg/apiserver/endpoints/request"
+)
+
+// WithAcceptHeader adds the Accept header to the request context.
+func WithAcceptHeader(handler http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		ctx := request.WithAcceptHeader(req.Context(), req.Header.Get("Accept"))
+		handler.ServeHTTP(w, req.WithContext(ctx))
+	})
+}

--- a/pkg/apiserver/endpoints/filters/accept_test.go
+++ b/pkg/apiserver/endpoints/filters/accept_test.go
@@ -1,0 +1,46 @@
+package filters
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/grafana/grafana/pkg/apiserver/endpoints/request"
+	"github.com/stretchr/testify/require"
+)
+
+func TestWithAcceptHeader(t *testing.T) {
+	t.Run("should not set accept header in context for empty header", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/", nil)
+
+		rr := httptest.NewRecorder()
+		handler := &fakeHandler{}
+		WithAcceptHeader(handler).ServeHTTP(rr, req)
+
+		acceptHeader, ok := request.AcceptHeaderFrom(handler.ctx)
+		require.False(t, ok)
+		require.Empty(t, acceptHeader)
+	})
+
+	t.Run("should set accept header in context", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/", nil)
+		req.Header.Set("Accept", "application/json")
+
+		rr := httptest.NewRecorder()
+		handler := &fakeHandler{}
+		WithAcceptHeader(handler).ServeHTTP(rr, req)
+
+		acceptHeader, ok := request.AcceptHeaderFrom(handler.ctx)
+		require.True(t, ok)
+		require.Equal(t, "application/json", acceptHeader)
+	})
+}
+
+type fakeHandler struct {
+	ctx context.Context
+}
+
+func (h *fakeHandler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
+	h.ctx = req.Context()
+}

--- a/pkg/apiserver/endpoints/request/accept.go
+++ b/pkg/apiserver/endpoints/request/accept.go
@@ -1,0 +1,22 @@
+package request
+
+import (
+	"context"
+)
+
+type acceptHeaderKey struct{}
+
+// WithAcceptHeader adds the accept header to the supplied context.
+func WithAcceptHeader(ctx context.Context, acceptHeader string) context.Context {
+	// only add the accept header to ctx if it is not empty
+	if acceptHeader == "" {
+		return ctx
+	}
+	return context.WithValue(ctx, acceptHeaderKey{}, acceptHeader)
+}
+
+// AcceptHeaderFrom returns the accept header from the supplied context and a boolean indicating if the value was present.
+func AcceptHeaderFrom(ctx context.Context) (string, bool) {
+	acceptHeader, ok := ctx.Value(acceptHeaderKey{}).(string)
+	return acceptHeader, ok
+}

--- a/pkg/apiserver/endpoints/request/accept_test.go
+++ b/pkg/apiserver/endpoints/request/accept_test.go
@@ -1,0 +1,26 @@
+package request
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestAcceptHeader(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("should not set ctx for empty header", func(t *testing.T) {
+		out := WithAcceptHeader(ctx, "")
+		acceptHeader, ok := AcceptHeaderFrom(out)
+		require.False(t, ok)
+		require.Empty(t, acceptHeader)
+	})
+
+	t.Run("should add header to ctx", func(t *testing.T) {
+		out := WithAcceptHeader(ctx, "application/json")
+		acceptHeader, ok := AcceptHeaderFrom(out)
+		require.True(t, ok)
+		require.Equal(t, "application/json", acceptHeader)
+	})
+}


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

This stashes the `Accept` header in context so that it's available in `rest.StandardStorage` methods.

**Why do we need this feature?**



**Who is this feature for?**

@ryantxu 

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
