### PR TITLE
Alerting docs: fix incorrect `docs/reference` link

### DIFF
--- a/docs/sources/alerting/set-up/provision-alerting-resources/export-alerting-resources/index.md
+++ b/docs/sources/alerting/set-up/provision-alerting-resources/export-alerting-resources/index.md
@@ -154,7 +154,7 @@ These endpoints accept a `download` parameter to download a file containing the 
 
 [alerting_file_provisioning]: "/docs/ -> /docs/grafana/<GRAFANA_VERSION>/alerting/set-up/provision-alerting-resources/file-provisioning"
 
-[alerting_file_provisioning_template]: "/docs/ -> /docs/grafana/<GRAFANA_VERSION>/alerting/set-up/provision-alerting-resources/file-provisioning/#import-templates"
+[alerting_file_provisioning_template]: "/docs/ -> /docs/grafana/<GRAFANA_VERSION>/alerting/set-up/provision-alerting-resources/file-provisioning#import-templates"
 
 [export_rule]: "/docs/grafana/ -> /docs/grafana/<GRAFANA_VERSION>/alerting/set-up/provision-alerting-resources/http-api-provisioning/#span-idroute-get-alert-rule-exportspan-export-an-alert-rule-in-provisioning-file-format-_routegetalertruleexport_"
 [export_rule]: "/docs/grafana-cloud/ -> /docs/grafana/<GRAFANA_VERSION>/alerting/set-up/provision-alerting-resources/http-api-provisioning/#span-idroute-get-alert-rule-exportspan-export-an-alert-rule-in-provisioning-file-format-_routegetalertruleexport_"


### PR DESCRIPTION

@jdbaldry

this was 404 link due to setting up the anchor link with a slash like: `url/#anchor-title`. Removing the slash (`url#anchor-title`)  fixes it. 

fyi, I am unsure if this was detected by the doc validator or was merged directly. 

It is strange that some doc references below in this doc works well when using `url/#span-`