### PR TITLE
DashboardSceneChangeTracker: Do not load the worker until is editing

### DIFF
--- a/public/app/features/dashboard-scene/saving/DashboardSceneChangeTracker.ts
+++ b/public/app/features/dashboard-scene/saving/DashboardSceneChangeTracker.ts
@@ -22,12 +22,11 @@ import { DashboardChangeInfo } from './shared';
 
 export class DashboardSceneChangeTracker {
   private _changeTrackerSub: Unsubscribable | undefined;
-  private _changesWorker: Worker;
+  private _changesWorker?: Worker;
   private _dashboard: DashboardScene;
 
   constructor(dashboard: DashboardScene) {
     this._dashboard = dashboard;
-    this._changesWorker = createWorker();
   }
 
   private onStateChanged({ payload }: SceneObjectStateChangedEvent) {
@@ -95,8 +94,15 @@ export class DashboardSceneChangeTracker {
     }
   }
 
+  private init() {
+    this._changesWorker = createWorker();
+  }
+
   public startTrackingChanges() {
-    this._changesWorker.onmessage = (e: MessageEvent<DashboardChangeInfo>) => {
+    if (!this._changesWorker) {
+      this.init();
+    }
+    this._changesWorker!.onmessage = (e: MessageEvent<DashboardChangeInfo>) => {
       this.updateIsDirty(e.data);
     };
 
@@ -112,6 +118,6 @@ export class DashboardSceneChangeTracker {
 
   public terminate() {
     this.stopTrackingChanges();
-    this._changesWorker.terminate();
+    this._changesWorker?.terminate();
   }
 }

--- a/public/app/features/dashboard-scene/scene/DashboardScene.test.tsx
+++ b/public/app/features/dashboard-scene/scene/DashboardScene.test.tsx
@@ -66,6 +66,23 @@ describe('DashboardScene', () => {
   });
 
   describe('Editing and discarding', () => {
+    describe('Given scene in view mode', () => {
+      it('Should set isEditing to false', () => {
+        const scene = buildTestScene();
+        scene.activate();
+
+        expect(scene.state.isEditing).toBeFalsy();
+      });
+
+      it('Should not start the detect changes worker', () => {
+        const scene = buildTestScene();
+        scene.activate();
+
+        // @ts-expect-error it is a private property
+        expect(scene._changesWorker).toBeUndefined();
+      });
+    });
+
     describe('Given scene in edit mode', () => {
       let scene: DashboardScene;
       let deactivateScene: () => void;


### PR DESCRIPTION
**Problem**
When using EmbeddedDashboard the plugin breaks because it tries to load the changes detector worker.

**Solution**
Do not load the worker until the dashboard is in edit mode only load the worker when needed. 