### PR TITLE
Query: Add query type to json marshal/unmarshal

### DIFF
--- a/pkg/apis/query/v0alpha1/query.go
+++ b/pkg/apis/query/v0alpha1/query.go
@@ -138,6 +138,9 @@ func (g GenericDataQuery) MarshalJSON() ([]byte, error) {
 	if g.MaxDataPoints > 0 {
 		vals["maxDataPoints"] = g.MaxDataPoints
 	}
+	if g.QueryType != "" {
+		vals["queryType"] = g.QueryType
+	}
 	return json.Marshal(vals)
 }
 
@@ -218,6 +221,17 @@ func (g *GenericDataQuery) unmarshal(vals map[string]any) error {
 			return fmt.Errorf("expected datasourceId as number (got: %t)", v)
 		}
 		g.DatasourceId = int64(count)
+		delete(vals, key)
+	}
+
+	key = "queryType"
+	v, ok = vals[key]
+	if ok {
+		queryType, ok := v.(string)
+		if !ok {
+			return fmt.Errorf("expected queryType as string (got: %t)", v)
+		}
+		g.QueryType = queryType
 		delete(vals, key)
 	}
 

--- a/pkg/apis/query/v0alpha1/query_test.go
+++ b/pkg/apis/query/v0alpha1/query_test.go
@@ -31,7 +31,8 @@ func TestParseQueriesIntoQueryDataRequest(t *testing.T) {
 				"timeRange": {
 					"from": "100",
 					"to": "200"
-				}
+				},
+				"queryType": "foo"
 			}
 		],
 		"from": "1692624667389",
@@ -66,6 +67,7 @@ func TestParseQueriesIntoQueryDataRequest(t *testing.T) {
 		  "uid": "old"
 		},
 		"maxDataPoints": 10,
+		"queryType": "foo",
 		"refId": "Z",
 		"timeRange": {
 		  "from": "100",


### PR DESCRIPTION


**What is this feature?**

Ensures `queryType` is propagated through for queries going through query service route.

**Why do we need this feature?**

Plugins using this value will break


Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
