### PR TITLE
Logs volume: Add options to specify field to group by

### DIFF
--- a/packages/grafana-data/src/types/logs.ts
+++ b/packages/grafana-data/src/types/logs.ts
@@ -185,6 +185,7 @@ export type SupplementaryQueryOptions = LogsVolumeOption | LogsSampleOptions;
  */
 export type LogsVolumeOption = {
   type: SupplementaryQueryType.LogsVolume;
+  field?: string;
 };
 
 /**
@@ -237,7 +238,8 @@ export interface DataSourceWithSupplementaryQueriesSupport<TQuery extends DataQu
    */
   getSupplementaryRequest?(
     type: SupplementaryQueryType,
-    request: DataQueryRequest<TQuery>
+    request: DataQueryRequest<TQuery>,
+    options?: SupplementaryQueryOptions
   ): DataQueryRequest<TQuery> | undefined;
   /**
    * Returns supplementary query types that data source supports.

--- a/public/app/plugins/datasource/loki/datasource.test.ts
+++ b/public/app/plugins/datasource/loki/datasource.test.ts
@@ -1348,6 +1348,7 @@ describe('LokiDatasource', () => {
           queryType: LokiQueryType.Range,
           refId: 'log-volume-A',
           supportingQueryType: SupportingQueryType.LogsVolume,
+          legendFormat: '{{ level }}',
         });
       });
 
@@ -1366,6 +1367,7 @@ describe('LokiDatasource', () => {
           queryType: LokiQueryType.Range,
           refId: 'log-volume-A',
           supportingQueryType: SupportingQueryType.LogsVolume,
+          legendFormat: '{{ level }}',
         });
       });
 
@@ -1393,6 +1395,30 @@ describe('LokiDatasource', () => {
             }
           )
         ).toEqual(undefined);
+      });
+
+      it('return logs volume query with defined field', () => {
+        const query = ds.getSupplementaryQuery(
+          { type: SupplementaryQueryType.LogsVolume, field: 'test' },
+          {
+            expr: '{label="value"}',
+            queryType: LokiQueryType.Range,
+            refId: 'A',
+          }
+        );
+        expect(query?.expr).toEqual('sum by (test) (count_over_time({label="value"} | drop __error__[$__auto]))');
+      });
+
+      it('return logs volume query with level as field if no field specified', () => {
+        const query = ds.getSupplementaryQuery(
+          { type: SupplementaryQueryType.LogsVolume },
+          {
+            expr: '{label="value"}',
+            queryType: LokiQueryType.Range,
+            refId: 'A',
+          }
+        );
+        expect(query?.expr).toEqual('sum by (level) (count_over_time({label="value"} | drop __error__[$__auto]))');
       });
     });
 


### PR DESCRIPTION
This PR expands the `getSupplementaryRequest` API with adding optional `SupplementaryQueryOptions`. This is going to help us in the future with having a way, how users can change a field to group by on. Currently, this is for example in Loki hard coded to `level`, but with this option, we will be able to update it.

It also adds `legendFormat` to logs volume query, as it makes the results for other labels than level more readable. 

Relevant for https://github.com/grafana/logs-app/issues/97