### PR TITLE
Loki: Interpolate variables in live queries

### DIFF
--- a/public/app/plugins/datasource/loki/datasource.test.ts
+++ b/public/app/plugins/datasource/loki/datasource.test.ts
@@ -1654,7 +1654,7 @@ describe('LokiDatasource', () => {
     });
   });
 
-  describe('runLiveQueryThroughBackend', () => {
+  describe('live tailing', () => {
     it('interpolates variables with scopedVars and filters', () => {
       const ds = createLokiDatasource();
       const query: LokiQuery = { expr: '{app=$app}', refId: 'A' };
@@ -1662,8 +1662,8 @@ describe('LokiDatasource', () => {
       const filters: AdHocFilter[] = [];
 
       jest.spyOn(ds, 'applyTemplateVariables').mockImplementation((query) => query);
-      ds.runLiveQueryThroughBackend({ targets: [query], scopedVars, filters } as DataQueryRequest<LokiQuery>);
-      expect(ds.applyTemplateVariables).toHaveBeenCalledWith(query, scopedVars, filters);
+      ds.query({ targets: [query], scopedVars, filters, liveStreaming: true } as DataQueryRequest<LokiQuery>);
+      expect(ds.applyTemplateVariables).toHaveBeenCalledWith(expect.objectContaining(query), scopedVars, filters);
     });
   });
 });

--- a/public/app/plugins/datasource/loki/datasource.test.ts
+++ b/public/app/plugins/datasource/loki/datasource.test.ts
@@ -18,6 +18,7 @@ import {
   TimeRange,
   ToggleFilterAction,
   DataQueryRequest,
+  ScopedVars,
 } from '@grafana/data';
 import {
   BackendSrv,
@@ -1650,6 +1651,19 @@ describe('LokiDatasource', () => {
       expect(async () => {
         await ds.statsMetadataRequest('/index');
       }).rejects.toThrow('invalid metadata request url: /index');
+    });
+  });
+
+  describe('runLiveQueryThroughBackend', () => {
+    it('interpolates variables with scopedVars and filters', () => {
+      const ds = createLokiDatasource();
+      const query: LokiQuery = { expr: '{app=$app}', refId: 'A' };
+      const scopedVars: ScopedVars = { app: { text: 'interpolated', value: 'interpolated' } };
+      const filters: AdHocFilter[] = [];
+
+      jest.spyOn(ds, 'applyTemplateVariables').mockImplementation((query) => query);
+      ds.runLiveQueryThroughBackend({ targets: [query], scopedVars, filters } as DataQueryRequest<LokiQuery>);
+      expect(ds.applyTemplateVariables).toHaveBeenCalledWith(query, scopedVars, filters);
     });
   });
 });

--- a/public/app/plugins/datasource/loki/datasource.ts
+++ b/public/app/plugins/datasource/loki/datasource.ts
@@ -344,7 +344,7 @@ export class LokiDatasource
    * @returns An Observable of DataQueryResponse with live query results or an empty response if no suitable queries are found.
    * @todo: The name says "backend" but it's actually running the query through the frontend. We should fix this.
    */
-  runLiveQueryThroughBackend(request: DataQueryRequest<LokiQuery>): Observable<DataQueryResponse> {
+  private runLiveQueryThroughBackend(request: DataQueryRequest<LokiQuery>): Observable<DataQueryResponse> {
     // and only for logs-queries, not metric queries
     const logsQueries = request.targets.filter((query) => query.expr !== '' && isLogsQuery(query.expr));
     if (logsQueries.length === 0) {

--- a/public/app/plugins/datasource/loki/datasource.ts
+++ b/public/app/plugins/datasource/loki/datasource.ts
@@ -340,7 +340,7 @@ export class LokiDatasource
 
   /**
    * Used within the `query` to execute live queries.
-   * It is intended for explore-mode and logs-queries, not metric queries.
+   * It is intended for logs-queries, not metric queries.
    * @returns An Observable of DataQueryResponse with live query results or an empty response if no suitable queries are found.
    * @todo: The name says "backend" but it's actually running the query through the frontend. We should fix this.
    */


### PR DESCRIPTION
Fixes https://github.com/grafana/grafana/issues/83822

We originally haven't interpolated variables in live tailing queries as these queries were run only in explore where template variables and adhoc filters are not supported. But because of https://github.com/grafana/grafana/issues/83822, we need to support it, so this PR fixes it + adds test. 