### PR TITLE
Alerting docs: improve visibility on the distinct options to edit provisioned resources

### DIFF
--- a/docs/sources/alerting/set-up/provision-alerting-resources/_index.md
+++ b/docs/sources/alerting/set-up/provision-alerting-resources/_index.md
@@ -33,8 +33,10 @@ Choose from the options below to import (or provision) your Grafana Alerting res
 1. [Use configuration files to provision your alerting resources][alerting_file_provisioning], such as alert rules and contact points, through files on disk.
 
    {{< admonition type="note" >}}
-   Provisioning with configuration files is not available in Grafana Cloud.
-   {{< /admonition >}}
+
+   - You cannot edit provisioned resources from files in the Grafana UI.
+   - Provisioning with configuration files is not available in Grafana Cloud.
+     {{< /admonition >}}
 
 1. Use [Terraform to provision alerting resources][alerting_tf_provisioning].
 

--- a/docs/sources/alerting/set-up/provision-alerting-resources/export-alerting-resources/index.md
+++ b/docs/sources/alerting/set-up/provision-alerting-resources/export-alerting-resources/index.md
@@ -20,7 +20,19 @@ weight: 300
 
 # Export alerting resources
 
-Export your alerting resources, such as alert rules, contact points, and notification policies for provisioning, automatically importing single folders and single groups. Use the [Grafana UI](#export-from-the-grafana-ui) or the [HTTP Alerting API](#http-alerting-api) to export these resources.
+Export your alerting resources, such as alert rules, contact points, and notification policies for provisioning, automatically importing single folders and single groups.
+
+There are distinct methods to export your alerting resources:
+
+- [Grafana UI](#export-from-the-grafana-ui) exports in Terraform format and YAML or JSON formats for file provisioning.
+- [HTTP Alerting API](#http-alerting-api) exports in JSON API format used by the HTTP Alerting API.
+- [HTTP Alerting API - Export endpoints](#export-api-endpoints) exports in YAML or JSON formats for file provisioning.
+
+{{< admonition type="note" >}}
+Alerting resources imported through [file provisioning](/docs/grafana/<GRAFANA_VERSION>/alerting/set-up/provision-alerting-resources/file-provisioning) cannot be edited in the Grafana UI. This prevents changes made in the UI from being overridden by file provisioning during Grafana restarts.
+
+If you need to modify provisioned alerting resources in Grafana, refer to [edit HTTP API alerting resources in the Grafana UI](/docs/grafana/<GRAFANA_VERSION>/alerting/set-up/provision-alerting-resources/http-api-provisioning#edit-resources-in-the-grafana-ui) or to [edit Terraform alerting resources in the Grafana UI](/docs/grafana/<GRAFANA_VERSION>/alerting/set-up/provision-alerting-resources/terraform-provisioning#enable-editing-resources-in-the-grafana-ui).
+{{< /admonition >}}
 
 ## Export from the Grafana UI
 


### PR DESCRIPTION
Specify more clearly the distinct methods to edit provisioned resources on the [Export alerting resources guide](https://grafana.com/docs/grafana/next/alerting/set-up/provision-alerting-resources/export-alerting-resources/) and [Provisioning alerting resources guide](https://grafana.com/docs/grafana/next/alerting/set-up/provision-alerting-resources/).