### PR TITLE
Plugins: Add intraMode 1 into fuzzy search for plugins

### DIFF
--- a/public/app/features/plugins/admin/helpers.ts
+++ b/public/app/features/plugins/admin/helpers.ts
@@ -376,7 +376,7 @@ function getPluginDetailsForFuzzySearch(plugins: CatalogPlugin[]): string[] {
 }
 export function filterByKeyword(plugins: CatalogPlugin[], query: string) {
   const dataArray = getPluginDetailsForFuzzySearch(plugins);
-  let uf = new uFuzzy({});
+  let uf = new uFuzzy({ intraMode: 1, intraSub: 0 });
   let idxs = uf.filter(dataArray, query);
   if (idxs === null) {
     return null;


### PR DESCRIPTION
Add `intraMode: 1` and `intraSub: 0` into fuzzy search for plugins to improve the search
