### PR TITLE
Loki: Fix permalink timerange when multiple logs share a timestamp

### DIFF
--- a/public/app/features/explore/Logs/Logs.test.tsx
+++ b/public/app/features/explore/Logs/Logs.test.tsx
@@ -411,6 +411,34 @@ describe('Logs', () => {
       );
       expect(createAndCopyShortLink).toHaveBeenCalledWith(expect.stringMatching('visualisationType%22:%22logs'));
     });
+
+    it('should call createAndCopyShortLink on permalinkClick - with infinite scrolling', async () => {
+      const featureToggleValue = config.featureToggles.logsInfiniteScrolling;
+      config.featureToggles.logsInfiniteScrolling = true;
+      const rows = [
+        makeLog({ uid: '1', rowId: 'id1', timeEpochMs: 1 }),
+        makeLog({ uid: '2', rowId: 'id2', timeEpochMs: 1 }),
+        makeLog({ uid: '3', rowId: 'id3', timeEpochMs: 2 }),
+        makeLog({ uid: '4', rowId: 'id3', timeEpochMs: 2 }),
+      ];
+
+      const panelState: Partial<ExplorePanelsState> = { logs: { id: 'not-included', visualisationType: 'logs' } };
+      setup({ loading: false, panelState, logRows: rows });
+
+      const row = screen.getAllByRole('row');
+      await userEvent.hover(row[3]);
+
+      const linkButton = screen.getByLabelText('Copy shortlink');
+      await userEvent.click(linkButton);
+
+      expect(createAndCopyShortLink).toHaveBeenCalledWith(
+        expect.stringMatching(
+          'range%22:%7B%22from%22:%222019-01-01T10:00:00.000Z%22,%22to%22:%221970-01-01T00:00:00.002Z%22%7D'
+        )
+      );
+      expect(createAndCopyShortLink).toHaveBeenCalledWith(expect.stringMatching('visualisationType%22:%22logs'));
+      config.featureToggles.logsInfiniteScrolling = featureToggleValue;
+    });
   });
 
   describe('with table visualisation', () => {

--- a/public/app/features/explore/Logs/Logs.tsx
+++ b/public/app/features/explore/Logs/Logs.tsx
@@ -463,7 +463,7 @@ class UnthemedLogs extends PureComponent<Props, State> {
 
     return {
       from: new Date(this.props.absoluteRange.from).toISOString(),
-      to: new Date(prevLog ? prevLog.timeEpochMs : this.props.absoluteRange.to).toISOString(),
+      to: new Date(prevLog ? new Date(prevLog.timeEpochMs + 1) : this.props.absoluteRange.to).toISOString(),
     };
   }
 

--- a/public/app/features/explore/Logs/Logs.tsx
+++ b/public/app/features/explore/Logs/Logs.tsx
@@ -437,6 +437,16 @@ class UnthemedLogs extends PureComponent<Props, State> {
     };
   };
 
+  getPreviousLog(row: LogRowModel, allLogs: LogRowModel[]): LogRowModel | null {
+    for (let i = allLogs.indexOf(row) - 1; i >= 0; i--) {
+      if (allLogs[i].timeEpochMs > row.timeEpochMs) {
+        return allLogs[i];
+      }
+    }
+
+    return null;
+  }
+
   getPermalinkRange(row: LogRowModel) {
     const range = {
       from: new Date(this.props.absoluteRange.from).toISOString(),
@@ -449,7 +459,7 @@ class UnthemedLogs extends PureComponent<Props, State> {
     // With infinite scrolling, the time range of the log line can be after the absolute range or beyond the request line limit, so we need to adjust
     // Look for the previous sibling log, and use its timestamp
     const allLogs = this.props.logRows.filter((logRow) => logRow.dataFrame.refId === row.dataFrame.refId);
-    const prevLog = allLogs[allLogs.indexOf(row) - 1];
+    const prevLog = this.getPreviousLog(row, allLogs);
 
     if (row.timeEpochMs > this.props.absoluteRange.to && !prevLog) {
       // Because there's no sibling and the current `to` is oldest than the log, we have no reference we can use for the interval
@@ -463,7 +473,7 @@ class UnthemedLogs extends PureComponent<Props, State> {
 
     return {
       from: new Date(this.props.absoluteRange.from).toISOString(),
-      to: new Date(prevLog ? new Date(prevLog.timeEpochMs + 1) : this.props.absoluteRange.to).toISOString(),
+      to: new Date(prevLog ? prevLog.timeEpochMs : this.props.absoluteRange.to).toISOString(),
     };
   }
 


### PR DESCRIPTION
**What is this feature?**

Similar to https://github.com/grafana/grafana/blob/main/public/app/features/explore/Logs/Logs.tsx#L460 we should slide `1ms` here as well.