### PR TITLE
plugins-platform: fix: plugin extension component to receive context

### DIFF
--- a/public/app/features/plugins/extensions/getPluginExtensions.ts
+++ b/public/app/features/plugins/extensions/getPluginExtensions.ts
@@ -102,7 +102,7 @@ export const getPluginExtensions: GetExtensions = ({ context, extensionPointId, 
 
           title: extensionConfig.title,
           description: extensionConfig.description,
-          component: wrapWithPluginContext(pluginId, extensionConfig.component),
+          component: wrapWithPluginContext(pluginId, extensionConfig.component, frozenContext),
         };
 
         extensions.push(extension);

--- a/public/app/features/plugins/extensions/utils.test.tsx
+++ b/public/app/features/plugins/extensions/utils.test.tsx
@@ -445,12 +445,16 @@ describe('Plugin Extensions / Utils', () => {
   });
 
   describe('wrapExtensionComponentWithContext()', () => {
-    const ExampleComponent = () => {
+    type ExtensionContext = {
+      audience: string;
+    };
+
+    const ExampleComponent = ({ context }: { context?: ExtensionContext }) => {
       const { meta } = usePluginContext();
 
       return (
         <div>
-          <h1>Hello Grafana!</h1> Version: {meta.info.version}
+          <h1>Hello {context?.audience ?? 'Grafana'}!</h1> Version: {meta.info.version}
         </div>
       );
     };
@@ -463,6 +467,16 @@ describe('Plugin Extensions / Utils', () => {
 
       expect(await screen.findByText('Hello Grafana!')).toBeVisible();
       expect(screen.getByText('Version: 1.0.0')).toBeVisible();
+    });
+
+    it('should pass the extension context in props for the wrapped component', async () => {
+      const pluginId = 'grafana-worldmap-panel';
+      const extensionContext = { audience: 'Grafanistas' };
+      const Component = wrapWithPluginContext(pluginId, ExampleComponent, extensionContext);
+
+      render(<Component />);
+
+      expect(await screen.findByText('Hello Grafanistas!')).toBeVisible();
     });
   });
 });

--- a/public/app/features/plugins/extensions/utils.tsx
+++ b/public/app/features/plugins/extensions/utils.tsx
@@ -68,7 +68,7 @@ type ModalWrapperProps = {
   onDismiss: () => void;
 };
 
-export const wrapWithPluginContext = <T,>(pluginId: string, Component: React.ComponentType<T>) => {
+export const wrapWithPluginContext = <T,>(pluginId: string, Component: React.ComponentType<T>, context?: unknown) => {
   const WrappedExtensionComponent = (props: T & React.JSX.IntrinsicAttributes) => {
     const {
       error,
@@ -92,7 +92,7 @@ export const wrapWithPluginContext = <T,>(pluginId: string, Component: React.Com
 
     return (
       <PluginContextProvider meta={pluginMeta}>
-        <Component {...props} />
+        <Component {...props} context={context} />
       </PluginContextProvider>
     );
   };


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

The documentation mentions that it's possible receive the extension `context` object as a prop of the component extension:
- https://grafana.com/developers/plugin-tools/ui-extensions/register-an-extension

E.g., 

```ts
type Props = {
  context: PluginExtensionSampleContext;
};

export const MyExtension = ({ context }: Props) => (
  <Button onClick={() => {}} variant="secondary" type="button">
    Create incident from {context.name}
  </Button>
);
```

However, I wasn't able to get the context.

This PR seems to fix that.


**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
