### PR TITLE
Alerting: Refactor analytics to use pushMeasurements

### DIFF
--- a/packages/grafana-runtime/src/utils/logging.ts
+++ b/packages/grafana-runtime/src/utils/logging.ts
@@ -90,13 +90,11 @@ export function logMeasurement(type: string, values: MeasurementValues, context?
  * Each method combines the `defaultContext` (if provided), the `source`, and an optional `LogContext` parameter into a full context that is included with the log message.
  */
 export function createMonitoringLogger(source: string, defaultContext?: LogContext) {
-  const createFullContext = (contexts?: LogContext) => {
-    return {
-      source: source,
-      ...defaultContext,
-      ...contexts,
-    };
-  };
+  const createFullContext = (contexts?: LogContext) => ({
+    source: source,
+    ...defaultContext,
+    ...contexts,
+  });
 
   return {
     /**

--- a/packages/grafana-runtime/src/utils/logging.ts
+++ b/packages/grafana-runtime/src/utils/logging.ts
@@ -1,4 +1,4 @@
-import { faro, LogContext, LogLevel, MeasurementEvent } from '@grafana/faro-web-sdk';
+import { faro, LogContext, LogLevel } from '@grafana/faro-web-sdk';
 
 import { config } from '../config';
 
@@ -63,13 +63,13 @@ export function logError(err: Error, contexts?: LogContext) {
  *
  * @public
  */
-export function logMeasurement(measurement: Omit<MeasurementEvent, 'timestamp'>, context?: LogContext) {
+export type MeasurementValues = Record<string, number>;
+export function logMeasurement(type: string, values: MeasurementValues, context?: LogContext) {
   if (config.grafanaJavascriptAgent.enabled) {
-    faro.api.pushMeasurement(measurement, {
-      context: {
-        ...context,
-        ...measurement.context,
-      },
+    faro.api.pushMeasurement({
+      type,
+      values,
+      context,
     });
   }
 }
@@ -132,7 +132,7 @@ export function createMonitoringLogger(source: string, defaultContext?: LogConte
      * @param {MeasurementEvent} measurement - The measurement object to be recorded.
      * @param {LogContext} [contexts] - Optional additional context to be included.
      */
-    logMeasurement: (measurement: Omit<MeasurementEvent, 'timestamp'>, contexts?: LogContext) =>
-      logMeasurement(measurement, createFullContext(contexts)),
+    logMeasurement: (type: string, measurement: MeasurementValues, contexts?: LogContext) =>
+      logMeasurement(type, measurement, createFullContext(contexts)),
   };
 }

--- a/packages/grafana-runtime/src/utils/logging.ts
+++ b/packages/grafana-runtime/src/utils/logging.ts
@@ -1,4 +1,4 @@
-import { faro, LogContext, LogLevel } from '@grafana/faro-web-sdk';
+import { faro, LogContext, LogLevel, MeasurementEvent } from '@grafana/faro-web-sdk';
 
 import { config } from '../config';
 
@@ -59,6 +59,19 @@ export function logError(err: Error, contexts?: LogContext) {
 }
 
 /**
+ * Log a measurement
+ *
+ * @public
+ */
+export function logMeasurement(measurement: Omit<MeasurementEvent, 'timestamp'>, context?: LogContext) {
+  if (config.grafanaJavascriptAgent.enabled) {
+    faro.api.pushMeasurement(measurement, {
+      context,
+    });
+  }
+}
+
+/**
  * Creates a monitoring logger with four levels of logging methods: `logDebug`, `logInfo`, `logWarning`, and `logError`.
  * These methods use `faro.api.pushX` web SDK methods to report these logs or errors to the Faro collector.
  *
@@ -70,6 +83,7 @@ export function logError(err: Error, contexts?: LogContext) {
  * - `logInfo(message: string, contexts?: LogContext)`: Logs an informational message.
  * - `logWarning(message: string, contexts?: LogContext)`: Logs a warning message.
  * - `logError(error: Error, contexts?: LogContext)`: Logs an error message.
+ * - `logMeasurement(measurement: Omit<MeasurementEvent, 'timestamp'>, contexts?: LogContext)`: Logs a measurement.
  * Each method combines the `defaultContext` (if provided), the `source`, and an optional `LogContext` parameter into a full context that is included with the log message.
  */
 export function createMonitoringLogger(source: string, defaultContext?: LogContext) {

--- a/public/app/features/alerting/unified/Analytics.ts
+++ b/public/app/features/alerting/unified/Analytics.ts
@@ -115,9 +115,7 @@ export function withRulerRulesMetadataLogging<TFunc extends (...args: any[]) => 
         rulesCount,
         loadTimeMs: performance.now() - startLoadingTs,
       },
-      {
-        ...context,
-      }
+      context
     );
     return response;
   };

--- a/public/app/features/alerting/unified/Analytics.ts
+++ b/public/app/features/alerting/unified/Analytics.ts
@@ -40,7 +40,7 @@ export function withPerformanceLogging<TFunc extends (...args: any[]) => Promise
     const startLoadingTs = performance.now();
 
     const response = await func(...args);
-    const loadTimesMs = Number((performance.now() - startLoadingTs).toFixed(0));
+    const loadTimesMs = performance.now() - startLoadingTs;
 
     logMeasurement(
       type,

--- a/public/app/features/alerting/unified/Analytics.ts
+++ b/public/app/features/alerting/unified/Analytics.ts
@@ -31,7 +31,7 @@ const { logInfo, logError, logMeasurement } = createMonitoringLogger('features.a
 export { logInfo, logError, logMeasurement };
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-export function withPerformanceLogging<TFunc extends (type: string, ...args: any[]) => Promise<any>>(
+export function withPerformanceLogging<TFunc extends (...args: any[]) => Promise<any>>(
   type: string,
   func: TFunc,
   context: Record<string, string>
@@ -39,7 +39,6 @@ export function withPerformanceLogging<TFunc extends (type: string, ...args: any
   return async function (...args) {
     const startLoadingTs = performance.now();
 
-    // @ts-ignore
     const response = await func(...args);
     const loadTimesMs = Number((performance.now() - startLoadingTs).toFixed(0));
 

--- a/public/app/features/alerting/unified/Analytics.ts
+++ b/public/app/features/alerting/unified/Analytics.ts
@@ -43,13 +43,13 @@ export function withPerformanceLogging<TFunc extends (type: string, ...args: any
     const response = await func(...args);
     const loadTimesMs = Number((performance.now() - startLoadingTs).toFixed(0));
 
-    logMeasurement({
+    logMeasurement(
       type,
-      context,
-      values: {
+      {
         loadTimesMs,
       },
-    });
+      context
+    );
 
     return response;
   };
@@ -67,16 +67,16 @@ export function withPromRulesMetadataLogging<TFunc extends (...args: any[]) => P
 
     const { namespacesCount, groupsCount, rulesCount } = getPromRulesMetadata(response);
 
-    logMeasurement({
+    logMeasurement(
       type,
-      values: {
+      {
         loadTimeMs: performance.now() - startLoadingTs,
         namespacesCount,
         groupsCount,
         rulesCount,
       },
-      context,
-    });
+      context
+    );
     return response;
   };
 }
@@ -107,31 +107,31 @@ export function withRulerRulesMetadataLogging<TFunc extends (...args: any[]) => 
 
     const { namespacesCount, groupsCount, rulesCount } = getRulerRulesMetadata(response);
 
-    logMeasurement({
+    logMeasurement(
       type,
-      values: {
-        loadTimeMs: performance.now() - startLoadingTs,
-      },
-      context: {
+      {
         namespacesCount,
         groupsCount,
         rulesCount,
-        ...context,
+        loadTimeMs: performance.now() - startLoadingTs,
       },
-    });
+      {
+        ...context,
+      }
+    );
     return response;
   };
 }
 
 function getRulerRulesMetadata(rulerRules: RulerRulesConfigDTO) {
-  const namespacesCount = Object.keys(rulerRules).length;
+  const namespaces = Object.keys(rulerRules);
   const groups = Object.values(rulerRules).flatMap((groups) => groups);
   const rules = groups.flatMap((group) => group.rules);
 
   return {
-    namespacesCount: namespacesCount.toFixed(0),
-    groupsCount: groups.length.toFixed(0),
-    rulesCount: rules.length.toFixed(0),
+    namespacesCount: namespaces.length,
+    groupsCount: groups.length,
+    rulesCount: rules.length,
   };
 }
 

--- a/public/app/features/alerting/unified/api/alertingApi.ts
+++ b/public/app/features/alerting/unified/api/alertingApi.ts
@@ -11,17 +11,17 @@ export const backendSrvBaseQuery = (): BaseQueryFn<BackendSrvRequest> => async (
 
     const { data, ...meta } = await lastValueFrom(getBackendSrv().fetch(requestOptions));
 
-    logMeasurement({
-      type: 'backendSrvBaseQuery',
-      values: {
+    logMeasurement(
+      'backendSrvBaseQuery',
+      {
         loadTimeMs: performance.now() - requestStartTs,
       },
-      context: {
+      {
         url: requestOptions.url,
         method: requestOptions.method ?? 'GET',
         responseStatus: meta.statusText,
-      },
-    });
+      }
+    );
 
     return { data, meta };
   } catch (error) {

--- a/public/app/features/alerting/unified/api/alertingApi.ts
+++ b/public/app/features/alerting/unified/api/alertingApi.ts
@@ -3,7 +3,7 @@ import { lastValueFrom } from 'rxjs';
 
 import { BackendSrvRequest, getBackendSrv } from '@grafana/runtime';
 
-import { logInfo } from '../Analytics';
+import { logMeasurement } from '../Analytics';
 
 export const backendSrvBaseQuery = (): BaseQueryFn<BackendSrvRequest> => async (requestOptions) => {
   try {
@@ -11,11 +11,16 @@ export const backendSrvBaseQuery = (): BaseQueryFn<BackendSrvRequest> => async (
 
     const { data, ...meta } = await lastValueFrom(getBackendSrv().fetch(requestOptions));
 
-    logInfo('Request finished', {
-      loadTimeMs: (performance.now() - requestStartTs).toFixed(0),
-      url: requestOptions.url,
-      method: requestOptions.method ?? '',
-      responseStatus: meta.statusText,
+    logMeasurement({
+      type: 'backendSrvBaseQuery',
+      values: {
+        loadTimeMs: performance.now() - requestStartTs,
+      },
+      context: {
+        url: requestOptions.url,
+        method: requestOptions.method ?? 'GET',
+        responseStatus: meta.statusText,
+      },
     });
 
     return { data, meta };

--- a/public/app/features/alerting/unified/api/alertmanagerApi.ts
+++ b/public/app/features/alerting/unified/api/alertmanagerApi.ts
@@ -164,8 +164,8 @@ export const alertmanagerApi = alertingApi.injectEndpoints({
 
         // wrap our fetchConfig function with some performance logging functions
         const fetchAMconfigWithLogging = withPerformanceLogging(
+          'unifiedalerting/fetchAmConfig',
           fetchAlertManagerConfig,
-          `[${alertmanagerSourceName}] Alertmanager config loaded`,
           {
             dataSourceName: alertmanagerSourceName,
             thunk: 'unifiedalerting/fetchAmConfig',

--- a/public/app/features/alerting/unified/api/featureDiscoveryApi.ts
+++ b/public/app/features/alerting/unified/api/featureDiscoveryApi.ts
@@ -28,8 +28,8 @@ export const featureDiscoveryApi = alertingApi.injectEndpoints({
         }
 
         const discoverFeaturesWithLogging = withPerformanceLogging(
+          'unifiedalerting/featureDiscoveryApi/discoverDsFeatures',
           discoverFeatures,
-          `[${rulesSourceName}] Rules source features discovered`,
           {
             dataSourceName: rulesSourceName,
             endpoint: 'unifiedalerting/featureDiscoveryApi/discoverDsFeatures',

--- a/public/app/features/alerting/unified/state/actions.ts
+++ b/public/app/features/alerting/unified/state/actions.ts
@@ -205,14 +205,9 @@ export function fetchPromAndRulerRulesAction({
 export const fetchSilencesAction = createAsyncThunk(
   'unifiedalerting/fetchSilences',
   (alertManagerSourceName: string): Promise<Silence[]> => {
-    const fetchSilencesWithLogging = withPerformanceLogging(
-      fetchSilences,
-      `[${alertManagerSourceName}] Silences loaded`,
-      {
-        dataSourceName: alertManagerSourceName,
-        thunk: 'unifiedalerting/fetchSilences',
-      }
-    );
+    const fetchSilencesWithLogging = withPerformanceLogging('unifiedalerting/fetchSilences', fetchSilences, {
+      dataSourceName: alertManagerSourceName,
+    });
 
     return withSerializedError(fetchSilencesWithLogging(alertManagerSourceName));
   }
@@ -265,8 +260,8 @@ export const fetchRulesSourceBuildInfoAction = createAsyncThunk(
         const { id, name } = ds;
 
         const discoverFeaturesWithLogging = withPerformanceLogging(
+          'unifiedalerting/fetchPromBuildinfo',
           discoverFeatures,
-          `[${rulesSourceName}] Rules source features discovered`,
           {
             dataSourceName: rulesSourceName,
             thunk: 'unifiedalerting/fetchPromBuildinfo',

--- a/public/app/features/alerting/unified/state/actions.ts
+++ b/public/app/features/alerting/unified/state/actions.ts
@@ -333,11 +333,8 @@ export function fetchAllPromAndRulerRulesAction(
       })
     );
 
-    logMeasurement({
-      type: 'unifiedalerting/fetchAllPromAndRulerRulesAction',
-      values: {
-        loadTimeMs: performance.now() - allStartLoadingTs,
-      },
+    logMeasurement('unifiedalerting/fetchAllPromAndRulerRulesAction', {
+      loadTimeMs: performance.now() - allStartLoadingTs,
     });
   };
 }


### PR DESCRIPTION
**What is this feature?**

This PR refactors the existing perf monitoring functions to use `pushMeasurements` instead of `pushInfo`