### PR TITLE
datatrails: add generally embeddable scene to `@grafana/runtime`

### DIFF
--- a/packages/grafana-runtime/src/index.ts
+++ b/packages/grafana-runtime/src/index.ts
@@ -52,3 +52,4 @@ export {
 export { usePluginInteractionReporter } from './analytics/plugins/usePluginInteractionReporter';
 export { setReturnToPreviousHook, useReturnToPrevious } from './utils/returnToPrevious';
 export { type EmbeddedDashboardProps, EmbeddedDashboard, setEmbeddedDashboard } from './components/EmbeddedDashboard';
+export { type DataTrailEmbeddedState, DataTrailEmbedded, setDataTrailEmbedded } from './scenes/DataTrailEmbedded';

--- a/packages/grafana-runtime/src/scenes/DataTrailEmbedded.tsx
+++ b/packages/grafana-runtime/src/scenes/DataTrailEmbedded.tsx
@@ -1,0 +1,22 @@
+import { AdHocVariableFilter } from '@grafana/data';
+import { SceneObject, SceneObjectState, SceneTimeRangeLike } from '@grafana/scenes';
+
+export interface DataTrailEmbeddedState extends SceneObjectState {
+  timeRange: SceneTimeRangeLike;
+  metric?: string;
+  filters?: AdHocVariableFilter[];
+  dataSourceUid?: string;
+}
+
+type SceneClass<TState extends SceneObjectState> = new (state: TState) => SceneObject<TState>;
+
+// Note, this is similar to `DataTrailDrawer`
+
+export let DataTrailEmbedded: SceneClass<DataTrailEmbeddedState>;
+/**
+ *
+ * @internal
+ */
+export function setDataTrailEmbedded(ref: typeof DataTrailEmbedded) {
+  DataTrailEmbedded = ref;
+}

--- a/public/app/app.ts
+++ b/public/app/app.ts
@@ -35,6 +35,7 @@ import {
   setPluginExtensionGetter,
   setEmbeddedDashboard,
   setAppEvents,
+  setDataTrailEmbedded,
   setReturnToPreviousHook,
   setPluginExtensionsHook,
 } from '@grafana/runtime';
@@ -145,6 +146,7 @@ export class GrafanaApp {
       setPanelDataErrorView(PanelDataErrorView);
       setLocationSrv(locationService);
       setEmbeddedDashboard(EmbeddedDashboardLazy);
+      setDataTrailEmbedded(DataTrailEmbedded);
       setTimeZoneResolver(() => config.bootData.user.timezone);
       initGrafanaLive();
 

--- a/public/app/features/trails/Integrations/DataTrailEmbedded.tsx
+++ b/public/app/features/trails/Integrations/DataTrailEmbedded.tsx
@@ -1,16 +1,12 @@
 import React from 'react';
 
-import { AdHocVariableFilter } from '@grafana/data';
-import { SceneComponentProps, SceneObjectBase, SceneObjectState, SceneTimeRangeLike } from '@grafana/scenes';
+import { DataTrailEmbeddedState as DataTrailEmbeddedStateRuntime } from '@grafana/runtime';
+import { SceneComponentProps, SceneObjectBase } from '@grafana/scenes';
 
 import { DataTrail } from '../DataTrail';
 
-export interface DataTrailEmbeddedState extends SceneObjectState {
-  timeRange: SceneTimeRangeLike;
-  metric?: string;
-  filters?: AdHocVariableFilter[];
-  dataSourceUid?: string;
-}
+export type DataTrailEmbeddedState = DataTrailEmbeddedStateRuntime;
+
 export class DataTrailEmbedded extends SceneObjectBase<DataTrailEmbeddedState> {
   static Component = DataTrailEmbeddedRenderer;
 


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->


**What is this feature?**

`DataTrailsEmbedded` scene has been added to `@grafana/runtime` so that app plugins can embed the data trails "explore metrics" experience.

Note:
- This PR extends from https://github.com/grafana/grafana/pull/84521

# Usage example (from other plugins)

Unless you can import from this branch's `@grafana/runtime`, you can still get the functionality by using `import * as runtime...` as shown below. Typescript will not like it, but the javascript will function.


(if this gets merged, the `* as runtime` import will not be necessary, as your plugin will be able to reference the type definitions from a new version of `@grafana/runtime`)
```ts
import * as runtime  from '@grafana/runtime'


export function PageFour() {
  const s = useStyles2(getStyles);

  const trail = new runtime.DataTrailEmbedded({
    metric: 'ALERTS',
    dsRef: {},
    timeRange: new SceneTimeRange({from: 'now-1h', to: 'now'}),
  });


  return (
    <PluginPage layout={PageLayoutType.Canvas}>
      <div className={s.page} data-testid={testIds.pageFour.container}>
          <trail.Component model={trail} />
      </div>
    </PluginPage>
  );
}
```

![image](https://github.com/grafana/grafana/assets/38694490/eae6b908-4aa1-43f8-9dd5-0c11dd708e99)

(Note: The dark magenta on the labels has been removed)

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
