### PR TITLE
Alerting: Refactor ruleRoutine to take an entire ruleInfo instance

### DIFF
--- a/pkg/services/ngalert/schedule/schedule_unit_test.go
+++ b/pkg/services/ngalert/schedule/schedule_unit_test.go
@@ -384,22 +384,22 @@ func TestSchedule_ruleRoutine(t *testing.T) {
 	for _, evalState := range normalStates {
 		// TODO rewrite when we are able to mock/fake state manager
 		t.Run(fmt.Sprintf("when rule evaluation happens (evaluation state %s)", evalState), func(t *testing.T) {
-			evalChan := make(chan *evaluation)
 			evalAppliedChan := make(chan time.Time)
 			sch, ruleStore, instanceStore, reg := createSchedule(evalAppliedChan, nil)
 
 			rule := models.AlertRuleGen(withQueryForState(t, evalState))()
 			ruleStore.PutRule(context.Background(), rule)
 			folderTitle := ruleStore.getNamespaceTitle(rule.NamespaceUID)
+			ctx, cancel := context.WithCancel(context.Background())
+			t.Cleanup(cancel)
+			ruleInfo := newAlertRuleInfo(ctx)
 			go func() {
-				ctx, cancel := context.WithCancel(context.Background())
-				t.Cleanup(cancel)
-				_ = sch.ruleRoutine(ctx, rule.GetKey(), evalChan, make(chan ruleVersionAndPauseStatus))
+				_ = sch.ruleRoutine(rule.GetKey(), ruleInfo)
 			}()
 
 			expectedTime := time.UnixMicro(rand.Int63())
 
-			evalChan <- &evaluation{
+			ruleInfo.evalCh <- &evaluation{
 				scheduledAt: expectedTime,
 				rule:        rule,
 				folderTitle: folderTitle,
@@ -540,8 +540,9 @@ func TestSchedule_ruleRoutine(t *testing.T) {
 			require.NotEmpty(t, expectedStates)
 
 			ctx, cancel := context.WithCancel(context.Background())
+			ruleInfo := newAlertRuleInfo(ctx)
 			go func() {
-				err := sch.ruleRoutine(ctx, models.AlertRuleKey{}, make(chan *evaluation), make(chan ruleVersionAndPauseStatus))
+				err := sch.ruleRoutine(models.AlertRuleKey{}, ruleInfo)
 				stoppedChan <- err
 			}()
 
@@ -550,7 +551,7 @@ func TestSchedule_ruleRoutine(t *testing.T) {
 			require.NoError(t, err)
 			require.Equal(t, len(expectedStates), len(sch.stateManager.GetStatesForRuleUID(rule.OrgID, rule.UID)))
 		})
-		t.Run("and clean up the state if delete is cancellation reason ", func(t *testing.T) {
+		t.Run("and clean up the state if delete is cancellation reason for inner context", func(t *testing.T) {
 			stoppedChan := make(chan error)
 			sch, _, _, _ := createSchedule(make(chan time.Time), nil)
 
@@ -558,13 +559,13 @@ func TestSchedule_ruleRoutine(t *testing.T) {
 			_ = sch.stateManager.ProcessEvalResults(context.Background(), sch.clock.Now(), rule, eval.GenerateResults(rand.Intn(5)+1, eval.ResultGen(eval.WithEvaluatedAt(sch.clock.Now()))), nil)
 			require.NotEmpty(t, sch.stateManager.GetStatesForRuleUID(rule.OrgID, rule.UID))
 
-			ctx, cancel := util.WithCancelCause(context.Background())
+			ruleInfo := newAlertRuleInfo(context.Background())
 			go func() {
-				err := sch.ruleRoutine(ctx, rule.GetKey(), make(chan *evaluation), make(chan ruleVersionAndPauseStatus))
+				err := sch.ruleRoutine(rule.GetKey(), ruleInfo)
 				stoppedChan <- err
 			}()
 
-			cancel(errRuleDeleted)
+			ruleInfo.stop(errRuleDeleted)
 			err := waitForErrChannel(t, stoppedChan)
 			require.NoError(t, err)
 
@@ -577,9 +578,7 @@ func TestSchedule_ruleRoutine(t *testing.T) {
 		folderTitle := "folderName"
 		ruleFp := ruleWithFolder{rule, folderTitle}.Fingerprint()
 
-		evalChan := make(chan *evaluation)
 		evalAppliedChan := make(chan time.Time)
-		updateChan := make(chan ruleVersionAndPauseStatus)
 
 		sender := NewSyncAlertsSenderMock()
 		sender.EXPECT().Send(mock.Anything, rule.GetKey(), mock.Anything).Return()
@@ -587,15 +586,17 @@ func TestSchedule_ruleRoutine(t *testing.T) {
 		sch, ruleStore, _, _ := createSchedule(evalAppliedChan, sender)
 		ruleStore.PutRule(context.Background(), rule)
 		sch.schedulableAlertRules.set([]*models.AlertRule{rule}, map[models.FolderKey]string{rule.GetFolderKey(): folderTitle})
+		ctx, cancel := context.WithCancel(context.Background())
+		t.Cleanup(cancel)
+		ruleInfo := newAlertRuleInfo(ctx)
 
 		go func() {
-			ctx, cancel := context.WithCancel(context.Background())
-			t.Cleanup(cancel)
-			_ = sch.ruleRoutine(ctx, rule.GetKey(), evalChan, updateChan)
+
+			_ = sch.ruleRoutine(rule.GetKey(), ruleInfo)
 		}()
 
 		// init evaluation loop so it got the rule version
-		evalChan <- &evaluation{
+		ruleInfo.evalCh <- &evaluation{
 			scheduledAt: sch.clock.Now(),
 			rule:        rule,
 			folderTitle: folderTitle,
@@ -631,8 +632,8 @@ func TestSchedule_ruleRoutine(t *testing.T) {
 		require.Greaterf(t, expectedToBeSent, 0, "State manager was expected to return at least one state that can be expired")
 
 		t.Run("should do nothing if version in channel is the same", func(t *testing.T) {
-			updateChan <- ruleVersionAndPauseStatus{ruleFp, false}
-			updateChan <- ruleVersionAndPauseStatus{ruleFp, false} // second time just to make sure that previous messages were handled
+			ruleInfo.updateCh <- ruleVersionAndPauseStatus{ruleFp, false}
+			ruleInfo.updateCh <- ruleVersionAndPauseStatus{ruleFp, false} // second time just to make sure that previous messages were handled
 
 			actualStates := sch.stateManager.GetStatesForRuleUID(rule.OrgID, rule.UID)
 			require.Len(t, actualStates, len(states))
@@ -641,7 +642,7 @@ func TestSchedule_ruleRoutine(t *testing.T) {
 		})
 
 		t.Run("should clear the state and expire firing alerts if version in channel is greater", func(t *testing.T) {
-			updateChan <- ruleVersionAndPauseStatus{ruleFp + 1, false}
+			ruleInfo.updateCh <- ruleVersionAndPauseStatus{ruleFp + 1, false}
 
 			require.Eventually(t, func() bool {
 				return len(sender.Calls()) > 0
@@ -659,7 +660,6 @@ func TestSchedule_ruleRoutine(t *testing.T) {
 		rule := models.AlertRuleGen(withQueryForState(t, eval.Error))()
 		rule.ExecErrState = models.ErrorErrState
 
-		evalChan := make(chan *evaluation)
 		evalAppliedChan := make(chan time.Time)
 
 		sender := NewSyncAlertsSenderMock()
@@ -668,14 +668,16 @@ func TestSchedule_ruleRoutine(t *testing.T) {
 		sch, ruleStore, _, reg := createSchedule(evalAppliedChan, sender)
 		sch.maxAttempts = 3
 		ruleStore.PutRule(context.Background(), rule)
+		ctx, cancel := context.WithCancel(context.Background())
+		t.Cleanup(cancel)
+		ruleInfo := newAlertRuleInfo(ctx)
 
 		go func() {
-			ctx, cancel := context.WithCancel(context.Background())
-			t.Cleanup(cancel)
-			_ = sch.ruleRoutine(ctx, rule.GetKey(), evalChan, make(chan ruleVersionAndPauseStatus))
+
+			_ = sch.ruleRoutine(rule.GetKey(), ruleInfo)
 		}()
 
-		evalChan <- &evaluation{
+		ruleInfo.evalCh <- &evaluation{
 			scheduledAt: sch.clock.Now(),
 			rule:        rule,
 		}
@@ -765,7 +767,6 @@ func TestSchedule_ruleRoutine(t *testing.T) {
 			// eval.Alerting makes state manager to create notifications for alertmanagers
 			rule := models.AlertRuleGen(withQueryForState(t, eval.Alerting))()
 
-			evalChan := make(chan *evaluation)
 			evalAppliedChan := make(chan time.Time)
 
 			sender := NewSyncAlertsSenderMock()
@@ -773,14 +774,16 @@ func TestSchedule_ruleRoutine(t *testing.T) {
 
 			sch, ruleStore, _, _ := createSchedule(evalAppliedChan, sender)
 			ruleStore.PutRule(context.Background(), rule)
+			ctx, cancel := context.WithCancel(context.Background())
+			t.Cleanup(cancel)
+			ruleInfo := newAlertRuleInfo(ctx)
 
 			go func() {
-				ctx, cancel := context.WithCancel(context.Background())
-				t.Cleanup(cancel)
-				_ = sch.ruleRoutine(ctx, rule.GetKey(), evalChan, make(chan ruleVersionAndPauseStatus))
+
+				_ = sch.ruleRoutine(rule.GetKey(), ruleInfo)
 			}()
 
-			evalChan <- &evaluation{
+			ruleInfo.evalCh <- &evaluation{
 				scheduledAt: sch.clock.Now(),
 				rule:        rule,
 			}
@@ -798,7 +801,6 @@ func TestSchedule_ruleRoutine(t *testing.T) {
 	t.Run("when there are no alerts to send it should not call notifiers", func(t *testing.T) {
 		rule := models.AlertRuleGen(withQueryForState(t, eval.Normal))()
 
-		evalChan := make(chan *evaluation)
 		evalAppliedChan := make(chan time.Time)
 
 		sender := NewSyncAlertsSenderMock()
@@ -806,14 +808,15 @@ func TestSchedule_ruleRoutine(t *testing.T) {
 
 		sch, ruleStore, _, _ := createSchedule(evalAppliedChan, sender)
 		ruleStore.PutRule(context.Background(), rule)
+		ctx, cancel := context.WithCancel(context.Background())
+		t.Cleanup(cancel)
+		ruleInfo := newAlertRuleInfo(ctx)
 
 		go func() {
-			ctx, cancel := context.WithCancel(context.Background())
-			t.Cleanup(cancel)
-			_ = sch.ruleRoutine(ctx, rule.GetKey(), evalChan, make(chan ruleVersionAndPauseStatus))
+			_ = sch.ruleRoutine(rule.GetKey(), ruleInfo)
 		}()
 
-		evalChan <- &evaluation{
+		ruleInfo.evalCh <- &evaluation{
 			scheduledAt: sch.clock.Now(),
 			rule:        rule,
 		}

--- a/pkg/services/ngalert/schedule/schedule_unit_test.go
+++ b/pkg/services/ngalert/schedule/schedule_unit_test.go
@@ -591,7 +591,6 @@ func TestSchedule_ruleRoutine(t *testing.T) {
 		ruleInfo := newAlertRuleInfo(ctx)
 
 		go func() {
-
 			_ = sch.ruleRoutine(rule.GetKey(), ruleInfo)
 		}()
 
@@ -673,7 +672,6 @@ func TestSchedule_ruleRoutine(t *testing.T) {
 		ruleInfo := newAlertRuleInfo(ctx)
 
 		go func() {
-
 			_ = sch.ruleRoutine(rule.GetKey(), ruleInfo)
 		}()
 
@@ -779,7 +777,6 @@ func TestSchedule_ruleRoutine(t *testing.T) {
 			ruleInfo := newAlertRuleInfo(ctx)
 
 			go func() {
-
 				_ = sch.ruleRoutine(rule.GetKey(), ruleInfo)
 			}()
 


### PR DESCRIPTION
**What is this feature?**

Updates the rule routine to work in terms of the rule object, setting up for a future further simplification.
Updates tests to use the objects on the ruleInfo, making them more realistic.

**Why do we need this feature?**

n/a

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle.
- [x] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
