### PR TITLE
Remove hanging text block from traces->profiles docs

### DIFF
--- a/docs/sources/shared/datasources/tempo-traces-to-profiles.md
+++ b/docs/sources/shared/datasources/tempo-traces-to-profiles.md
@@ -96,5 +96,3 @@ To use a custom query with the configuration, follow these steps:
 1.  Switch on **Use custom query** to enter a custom query.
 1.  Specify a custom query to be used to query profile data. You can use various variables to make that query relevant for current span. The link is shown only if all the variables are interpolated with non-empty values to prevent creating an invalid query. You can interpolate the configured tags using the `$__tags` keyword.
 1.  Select **Save and Test**.
-
-                                                                                                                                                                                                         |


### PR DESCRIPTION
Some extra newlines and a hanging pipe character are causing this docs page to render a bit oddly on the website

![Screenshot 2024-03-04 at 12 07 59 PM](https://github.com/grafana/grafana/assets/9610816/0103537b-02df-47fe-bf7a-1dd027e21fa4)
