### PR TITLE
Table Panel: Text wrapping fix inspect viewing issues

### DIFF
--- a/packages/grafana-ui/src/components/Table/DefaultCell.tsx
+++ b/packages/grafana-ui/src/components/Table/DefaultCell.tsx
@@ -132,8 +132,13 @@ function getCellStyle(
 
   // If we have definied colors return those styles
   // Otherwise we return default styles
- 
-  return tableStyles.buildCellContainerStyle(textColor, bgColor, !disableOverflowOnHover, isStringValue, shouldWrapText);
+  return tableStyles.buildCellContainerStyle(
+    textColor,
+    bgColor,
+    !disableOverflowOnHover,
+    isStringValue,
+    shouldWrapText
+  );
 }
 
 function getLinkStyle(tableStyles: TableStyles, cellOptions: TableCellOptions, targetClassName: string | undefined) {

--- a/packages/grafana-ui/src/components/Table/DefaultCell.tsx
+++ b/packages/grafana-ui/src/components/Table/DefaultCell.tsx
@@ -132,25 +132,8 @@ function getCellStyle(
 
   // If we have definied colors return those styles
   // Otherwise we return default styles
-  if (textColor !== undefined || bgColor !== undefined) {
-    return tableStyles.buildCellContainerStyle(
-      textColor,
-      bgColor,
-      !disableOverflowOnHover,
-      isStringValue,
-      shouldWrapText
-    );
-  }
-
-  if (isStringValue) {
-    return disableOverflowOnHover
-      ? tableStyles.buildCellContainerStyle(undefined, undefined, false, true, shouldWrapText)
-      : tableStyles.buildCellContainerStyle(undefined, undefined, true, true, shouldWrapText);
-  } else {
-    return disableOverflowOnHover
-      ? tableStyles.buildCellContainerStyle(undefined, undefined, false, shouldWrapText)
-      : tableStyles.buildCellContainerStyle(undefined, undefined, true, false, shouldWrapText);
-  }
+ 
+  return tableStyles.buildCellContainerStyle(textColor, bgColor, !disableOverflowOnHover, isStringValue, shouldWrapText);
 }
 
 function getLinkStyle(tableStyles: TableStyles, cellOptions: TableCellOptions, targetClassName: string | undefined) {

--- a/packages/grafana-ui/src/components/Table/styles.ts
+++ b/packages/grafana-ui/src/components/Table/styles.ts
@@ -49,14 +49,14 @@ export function useTableStyles(theme: GrafanaTheme2, cellHeightOption: TableCell
 
       '&:hover': {
         overflow: overflowOnHover ? 'visible' : undefined,
-        width: textShouldWrap ? 'auto' : 'auto !important',
+        width: textShouldWrap || !overflowOnHover ? 'auto' : 'auto !important',
         height: textShouldWrap ? 'auto !important' : `${rowHeight - 1}px`,
         minHeight: `${rowHeight - 1}px`,
         wordBreak: textShouldWrap ? 'break-word' : undefined,
         whiteSpace: overflowOnHover ? 'normal' : 'nowrap',
         boxShadow: overflowOnHover ? `0 0 2px ${theme.colors.primary.main}` : undefined,
         background: overflowOnHover ? background ?? theme.components.table.rowHoverBackground : undefined,
-        zIndex: overflowOnHover ? 1 : undefined,
+        zIndex: 1,
         '.cellActions': {
           visibility: 'visible',
           opacity: 1,

--- a/packages/grafana-ui/src/components/Table/styles.ts
+++ b/packages/grafana-ui/src/components/Table/styles.ts
@@ -53,7 +53,7 @@ export function useTableStyles(theme: GrafanaTheme2, cellHeightOption: TableCell
         height: textShouldWrap || overflowOnHover ? 'auto !important' : `${rowHeight - 1}px`,
         minHeight: `${rowHeight - 1}px`,
         wordBreak: textShouldWrap ? 'break-word' : undefined,
-        whiteSpace: 'nowrap',
+        whiteSpace: textShouldWrap && overflowOnHover ? 'normal' : 'nowrap',
         boxShadow: overflowOnHover ? `0 0 2px ${theme.colors.primary.main}` : undefined,
         background: overflowOnHover ? background ?? theme.components.table.rowHoverBackground : undefined,
         zIndex: 1,

--- a/packages/grafana-ui/src/components/Table/styles.ts
+++ b/packages/grafana-ui/src/components/Table/styles.ts
@@ -50,7 +50,7 @@ export function useTableStyles(theme: GrafanaTheme2, cellHeightOption: TableCell
       '&:hover': {
         overflow: overflowOnHover ? 'visible' : undefined,
         width: textShouldWrap || !overflowOnHover ? 'auto' : 'auto !important',
-        height: textShouldWrap ? 'auto !important' : `${rowHeight - 1}px`,
+        height: textShouldWrap || overflowOnHover ? 'auto !important' : `${rowHeight - 1}px`,
         minHeight: `${rowHeight - 1}px`,
         wordBreak: textShouldWrap ? 'break-word' : undefined,
         whiteSpace: overflowOnHover ? 'normal' : 'nowrap',

--- a/packages/grafana-ui/src/components/Table/styles.ts
+++ b/packages/grafana-ui/src/components/Table/styles.ts
@@ -53,7 +53,7 @@ export function useTableStyles(theme: GrafanaTheme2, cellHeightOption: TableCell
         height: textShouldWrap || overflowOnHover ? 'auto !important' : `${rowHeight - 1}px`,
         minHeight: `${rowHeight - 1}px`,
         wordBreak: textShouldWrap ? 'break-word' : undefined,
-        whiteSpace: overflowOnHover ? 'normal' : 'nowrap',
+        whiteSpace: 'nowrap',
         boxShadow: overflowOnHover ? `0 0 2px ${theme.colors.primary.main}` : undefined,
         background: overflowOnHover ? background ?? theme.components.table.rowHoverBackground : undefined,
         zIndex: 1,


### PR DESCRIPTION
This PR fixes an issue that came up with #83642 in which values aren't wrapping correctly when `Inspect Cell` is enabled.

It also simplifies the styling logic as undefined values for colors are acceptable and can be used when calling `buildCellContainerStyle`

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
