### PR TITLE
Canvas: Fix datalink positioning glitch

### DIFF
--- a/public/app/features/canvas/runtime/element.tsx
+++ b/public/app/features/canvas/runtime/element.tsx
@@ -486,6 +486,7 @@ export class ElementState implements LayerElement {
   };
 
   onElementClick = (event: React.MouseEvent) => {
+    this.handleTooltip(event);
     this.onTooltipCallback();
   };
 


### PR DESCRIPTION
Fix issue where if tooltip was pinned and you clicked on another element with a datalink the tooltip content would update but position would remain static.

Before

https://github.com/grafana/grafana/assets/22381771/0f5694f0-165f-448d-addc-00c141df447e



After


https://github.com/grafana/grafana/assets/22381771/df86a648-8a51-49e8-a345-5a5b8e1d6f63

[debug-Data.links.in.Canvas-2024-02-23.16_09_32.json.txt](https://github.com/grafana/grafana/files/14488092/debug-Data.links.in.Canvas-2024-02-23.16_09_32.json.txt)


Fixes https://github.com/grafana/grafana/issues/83344
