### PR TITLE
Canvas: Add datalink support to rectangle and ellipse elements

### DIFF
--- a/docs/sources/panels-visualizations/visualizations/canvas/index.md
+++ b/docs/sources/panels-visualizations/visualizations/canvas/index.md
@@ -127,7 +127,7 @@ The inline editing toggle lets you lock or unlock the canvas. When turned off th
 
 ### Data links
 
-Canvases support [data links](https://grafana.com/docs/grafana/latest/panels-visualizations/configure-data-links/). You can create a data link for a metric-value element and display it for all elements that use the field name by following these steps:
+Canvases support [data links](https://grafana.com/docs/grafana/latest/panels-visualizations/configure-data-links/), but only for metric-value, text, rectangle, and ellipse elements. You can add a data link by following these steps:
 
 1. Set an element to be tied to a field value.
 1. Turn off the inline editing toggle.

--- a/public/app/features/canvas/elements/ellipse.tsx
+++ b/public/app/features/canvas/elements/ellipse.tsx
@@ -6,6 +6,7 @@ import { config } from 'app/core/config';
 import { DimensionContext } from 'app/features/dimensions/context';
 import { ColorDimensionEditor } from 'app/features/dimensions/editors/ColorDimensionEditor';
 import { TextDimensionEditor } from 'app/features/dimensions/editors/TextDimensionEditor';
+import { getDataLinks } from 'app/plugins/panel/canvas/utils';
 
 import { CanvasElementItem, CanvasElementProps, defaultBgColor, defaultTextColor } from '../element';
 import { Align, VAlign, EllipseConfig, EllipseData } from '../types';
@@ -97,6 +98,8 @@ export const ellipseItem: CanvasElementItem<EllipseConfig, EllipseData> = {
     if (cfg.color) {
       data.color = ctx.getColor(cfg.color).value();
     }
+
+    data.links = getDataLinks(ctx, cfg, data.text);
 
     return data;
   },

--- a/public/app/features/canvas/elements/rectangle.tsx
+++ b/public/app/features/canvas/elements/rectangle.tsx
@@ -7,6 +7,7 @@ import { config } from 'app/core/config';
 import { DimensionContext } from 'app/features/dimensions/context';
 import { ColorDimensionEditor } from 'app/features/dimensions/editors/ColorDimensionEditor';
 import { TextDimensionEditor } from 'app/features/dimensions/editors/TextDimensionEditor';
+import { getDataLinks } from 'app/plugins/panel/canvas/utils';
 
 import { CanvasElementItem, CanvasElementProps, defaultBgColor, defaultTextColor } from '../element';
 import { Align, TextConfig, TextData, VAlign } from '../types';
@@ -80,6 +81,8 @@ export const rectangleItem: CanvasElementItem<TextConfig, TextData> = {
     if (cfg.color) {
       data.color = ctx.getColor(cfg.color).value();
     }
+
+    data.links = getDataLinks(ctx, cfg, data.text);
 
     return data;
   },


### PR DESCRIPTION
Add datalink support to rectangle and ellipse elements

Before 


https://github.com/grafana/grafana/assets/22381771/d0917cee-17ae-45ef-84d4-009f63da8092






After


https://github.com/grafana/grafana/assets/22381771/98bb4d02-e3b9-47ba-bb5e-2a976dcfdd00




[Add support of datalinks to more elements-1709595415129.json](https://github.com/grafana/grafana/files/14488374/Add.support.of.datalinks.to.more.elements-1709595415129.json)


Fixes https://github.com/grafana/grafana/issues/83346

Opened up [this new GitHub issue](https://github.com/grafana/grafana/issues/83871) to explore supporting datalinks for the remainder of canvas elements (i.e. icon, server, maybe button (as another mode potentially of just click and go to data link instead of API call)) etc.