### PR TITLE
K8s: bug fixes for file storage to allow for watcher initialization on startup

### DIFF
--- a/pkg/apiserver/storage/file/file.go
+++ b/pkg/apiserver/storage/file/file.go
@@ -447,7 +447,6 @@ func (s *Storage) GuaranteedUpdate(
 			if err := ensureDir(dirpath); err != nil {
 				return err
 			}
-
 		}
 
 		if !exists(fpath) && !ignoreNotFound {

--- a/pkg/apiserver/storage/file/file.go
+++ b/pkg/apiserver/storage/file/file.go
@@ -9,7 +9,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"os"
 	"path/filepath"
 	"reflect"
 	"strings"
@@ -310,7 +309,7 @@ func (s *Storage) Get(ctx context.Context, key string, opts storage.GetOptions, 
 
 	// Since it's a get, check if the dir exists and return early as needed
 	dirname := filepath.Dir(filename)
-	if _, err := os.Stat(dirname); err != nil {
+	if !exists(dirname) {
 		return apierrors.NewNotFound(s.gr, s.nameFromKey(key))
 	}
 
@@ -374,7 +373,7 @@ func (s *Storage) GetList(ctx context.Context, key string, opts storage.ListOpti
 
 	dirname := s.dirPath(key)
 	// Since it's a get, check if the dir exists and return early as needed
-	if _, err := os.Stat(dirname); err != nil {
+	if !exists(dirname) {
 		return apierrors.NewNotFound(s.gr, s.nameFromKey(key))
 	}
 

--- a/pkg/apiserver/storage/file/file.go
+++ b/pkg/apiserver/storage/file/file.go
@@ -308,7 +308,7 @@ func (s *Storage) Get(ctx context.Context, key string, opts storage.GetOptions, 
 	filename := s.filePath(key)
 
 	// Since it's a get, check if the dir exists and return early as needed
-	dirname := filepath.Dir(filename)
+	dirname := s.dirPath(key)
 	if !exists(dirname) {
 		return apierrors.NewNotFound(s.gr, s.nameFromKey(key))
 	}

--- a/pkg/apiserver/storage/file/file.go
+++ b/pkg/apiserver/storage/file/file.go
@@ -374,7 +374,8 @@ func (s *Storage) GetList(ctx context.Context, key string, opts storage.ListOpti
 	dirpath := s.dirPath(key)
 	// Since it's a get, check if the dir exists and return early as needed
 	if !exists(dirpath) {
-		return apierrors.NewNotFound(s.gr, s.nameFromKey(key))
+		// ensure we return empty list in listObj insted of a not found error
+		return nil
 	}
 
 	objs, err := readDirRecursive(s.codec, dirpath, s.newFunc)

--- a/pkg/apiserver/storage/file/file.go
+++ b/pkg/apiserver/storage/file/file.go
@@ -120,12 +120,12 @@ func (s *Storage) Versioner() storage.Versioner {
 // in seconds (0 means forever). If no error is returned and out is not nil, out will be
 // set to the read value from database.
 func (s *Storage) Create(ctx context.Context, key string, obj runtime.Object, out runtime.Object, ttl uint64) error {
-	filename := s.filePath(key)
-	if exists(filename) {
+	fpath := s.filePath(key)
+	if exists(fpath) {
 		return storage.NewKeyExistsError(key, 0)
 	}
 
-	dirname := filepath.Dir(filename)
+	dirname := filepath.Dir(fpath)
 	if err := ensureDir(dirname); err != nil {
 		return err
 	}
@@ -148,7 +148,7 @@ func (s *Storage) Create(ctx context.Context, key string, obj runtime.Object, ou
 		return err
 	}
 
-	if err := writeFile(s.codec, filename, obj); err != nil {
+	if err := writeFile(s.codec, fpath, obj); err != nil {
 		return err
 	}
 
@@ -186,7 +186,7 @@ func (s *Storage) Delete(
 	validateDeletion storage.ValidateObjectFunc,
 	cachedExistingObject runtime.Object,
 ) error {
-	filename := s.filePath(key)
+	fpath := s.filePath(key)
 	var currentState runtime.Object
 	var stateIsCurrent bool
 	if cachedExistingObject != nil {
@@ -241,7 +241,7 @@ func (s *Storage) Delete(
 			return err
 		}
 
-		if err := deleteFile(filename); err != nil {
+		if err := deleteFile(fpath); err != nil {
 			return err
 		}
 
@@ -305,15 +305,15 @@ func (s *Storage) Watch(ctx context.Context, key string, opts storage.ListOption
 // The returned contents may be delayed, but it is guaranteed that they will
 // match 'opts.ResourceVersion' according 'opts.ResourceVersionMatch'.
 func (s *Storage) Get(ctx context.Context, key string, opts storage.GetOptions, objPtr runtime.Object) error {
-	filename := s.filePath(key)
+	fpath := s.filePath(key)
 
 	// Since it's a get, check if the dir exists and return early as needed
-	dirname := s.dirPath(key)
+	dirname := filepath.Dir(fpath)
 	if !exists(dirname) {
 		return apierrors.NewNotFound(s.gr, s.nameFromKey(key))
 	}
 
-	obj, err := readFile(s.codec, filename, func() runtime.Object {
+	obj, err := readFile(s.codec, fpath, func() runtime.Object {
 		return objPtr
 	})
 	if err != nil {
@@ -371,13 +371,13 @@ func (s *Storage) GetList(ctx context.Context, key string, opts storage.ListOpti
 		}
 	}
 
-	dirname := s.dirPath(key)
+	dirpath := s.dirPath(key)
 	// Since it's a get, check if the dir exists and return early as needed
-	if !exists(dirname) {
+	if !exists(dirpath) {
 		return apierrors.NewNotFound(s.gr, s.nameFromKey(key))
 	}
 
-	objs, err := readDirRecursive(s.codec, dirname, s.newFunc)
+	objs, err := readDirRecursive(s.codec, dirpath, s.newFunc)
 	if err != nil {
 		return err
 	}
@@ -435,18 +435,26 @@ func (s *Storage) GuaranteedUpdate(
 	var res storage.ResponseMeta
 	for attempt := 1; attempt <= MaxUpdateAttempts; attempt = attempt + 1 {
 		var (
-			filename = s.filePath(key)
+			fpath   = s.filePath(key)
+			dirpath = filepath.Dir(fpath)
 
 			obj     runtime.Object
 			err     error
 			created bool
 		)
 
-		if !exists(filename) && !ignoreNotFound {
+		if !exists(dirpath) {
+			if err := ensureDir(dirpath); err != nil {
+				return err
+			}
+
+		}
+
+		if !exists(fpath) && !ignoreNotFound {
 			return apierrors.NewNotFound(s.gr, s.nameFromKey(key))
 		}
 
-		obj, err = readFile(s.codec, filename, s.newFunc)
+		obj, err = readFile(s.codec, fpath, s.newFunc)
 		if err != nil {
 			// fallback to new object if the file is not found
 			obj = s.newFunc()
@@ -493,7 +501,7 @@ func (s *Storage) GuaranteedUpdate(
 		if err := s.Versioner().UpdateObject(updatedObj, *generatedRV); err != nil {
 			return err
 		}
-		if err := writeFile(s.codec, filename, updatedObj); err != nil {
+		if err := writeFile(s.codec, fpath, updatedObj); err != nil {
 			return err
 		}
 		eventType := watch.Modified

--- a/pkg/apiserver/storage/file/util.go
+++ b/pkg/apiserver/storage/file/util.go
@@ -22,11 +22,11 @@ func (s *Storage) filePath(key string) string {
 	return fileName
 }
 
+// this is for constructing dirPath in a sanitized way provided you have
+// already calculated the key. In order to go in the other direction, from a file path
+// key to its dir, use the go standard library: filepath.Dir
 func (s *Storage) dirPath(key string) string {
-	// Replace backslashes with underscores to avoid creating bogus subdirectories
-	key = strings.Replace(key, "\\", "_", -1)
-	dirName := filepath.Join(s.root, filepath.Clean(key))
-	return dirName
+	return dirPath(s.root, key)
 }
 
 func writeFile(codec runtime.Codec, path string, obj runtime.Object) error {
@@ -82,6 +82,13 @@ func deleteFile(path string) error {
 func exists(filepath string) bool {
 	_, err := os.Stat(filepath)
 	return err == nil
+}
+
+func dirPath(root string, key string) string {
+	// Replace backslashes with underscores to avoid creating bogus subdirectories
+	key = strings.Replace(key, "\\", "_", -1)
+	dirName := filepath.Join(root, filepath.Clean(key))
+	return dirName
 }
 
 func ensureDir(dirname string) error {

--- a/pkg/services/apiserver/config.go
+++ b/pkg/services/apiserver/config.go
@@ -48,7 +48,7 @@ func applyGrafanaConfig(cfg *setting.Cfg, features featuremgmt.FeatureToggles, o
 	o.RecommendedOptions.CoreAPI = nil
 
 	o.StorageOptions.StorageType = options.StorageType(apiserverCfg.Key("storage_type").MustString(string(options.StorageTypeLegacy)))
-	o.StorageOptions.DataPath = filepath.Join(cfg.DataPath, "grafana-apiserver")
+	o.StorageOptions.DataPath = apiserverCfg.Key("storage_path").MustString(filepath.Join(cfg.DataPath, "grafana-apiserver"))
 	o.ExtraOptions.DevMode = features.IsEnabledGlobally(featuremgmt.FlagGrafanaAPIServerEnsureKubectlAccess)
 	o.ExtraOptions.ExternalAddress = host
 	o.ExtraOptions.APIURL = apiURL

--- a/pkg/services/apiserver/options/aggregator.go
+++ b/pkg/services/apiserver/options/aggregator.go
@@ -89,7 +89,14 @@ func (o *AggregatorServerOptions) ApplyTo(aggregatorConfig *aggregatorapiserver.
 		return err
 	}
 	// override the RESTOptionsGetter to use the file storage options getter
-	aggregatorConfig.GenericConfig.RESTOptionsGetter = filestorage.NewRESTOptionsGetter(dataPath, etcdOptions.StorageConfig)
+	restOptionsGetter, err := filestorage.NewRESTOptionsGetter(dataPath, etcdOptions.StorageConfig,
+		"apiregistration.k8s.io/apiservices",
+		"service.grafana.app/externalnames",
+	)
+	if err != nil {
+		return err
+	}
+	aggregatorConfig.GenericConfig.RESTOptionsGetter = restOptionsGetter
 
 	// prevent generic API server from installing the OpenAPI handler. Aggregator server has its own customized OpenAPI handler.
 	genericConfig.SkipOpenAPIInstallation = true

--- a/pkg/services/apiserver/options/storage.go
+++ b/pkg/services/apiserver/options/storage.go
@@ -31,7 +31,7 @@ func NewStorageOptions() *StorageOptions {
 
 func (o *StorageOptions) AddFlags(fs *pflag.FlagSet) {
 	fs.StringVar((*string)(&o.StorageType), "grafana-apiserver-storage-type", string(o.StorageType), "Storage type")
-	fs.StringVar((*string)(&o.DataPath), "grafana-apiserver-storage-path", o.DataPath, "Storage path for file storage")
+	fs.StringVar(&o.DataPath, "grafana-apiserver-storage-path", o.DataPath, "Storage path for file storage")
 }
 
 func (o *StorageOptions) Validate() []error {

--- a/pkg/services/apiserver/options/storage.go
+++ b/pkg/services/apiserver/options/storage.go
@@ -31,7 +31,7 @@ func NewStorageOptions() *StorageOptions {
 
 func (o *StorageOptions) AddFlags(fs *pflag.FlagSet) {
 	fs.StringVar((*string)(&o.StorageType), "grafana-apiserver-storage-type", string(o.StorageType), "Storage type")
-	fs.StringVar((*string)(&o.DataPath), "grafana-apiserver-storage-path", string(o.DataPath), "Storage path for file storage")
+	fs.StringVar((*string)(&o.DataPath), "grafana-apiserver-storage-path", o.DataPath, "Storage path for file storage")
 }
 
 func (o *StorageOptions) Validate() []error {

--- a/pkg/services/apiserver/options/storage.go
+++ b/pkg/services/apiserver/options/storage.go
@@ -31,7 +31,7 @@ func NewStorageOptions() *StorageOptions {
 
 func (o *StorageOptions) AddFlags(fs *pflag.FlagSet) {
 	fs.StringVar((*string)(&o.StorageType), "grafana-apiserver-storage-type", string(o.StorageType), "Storage type")
-	fs.StringVar((*string)(&o.StorageType), "grafana-apiserver-storage-path", string(o.StorageType), "Storage path for file storage")
+	fs.StringVar((*string)(&o.DataPath), "grafana-apiserver-storage-path", string(o.DataPath), "Storage path for file storage")
 }
 
 func (o *StorageOptions) Validate() []error {

--- a/pkg/services/apiserver/service.go
+++ b/pkg/services/apiserver/service.go
@@ -277,7 +277,11 @@ func (s *service) start(ctx context.Context) error {
 	case grafanaapiserveroptions.StorageTypeLegacy:
 		fallthrough
 	case grafanaapiserveroptions.StorageTypeFile:
-		serverConfig.RESTOptionsGetter = filestorage.NewRESTOptionsGetter(o.StorageOptions.DataPath, o.RecommendedOptions.Etcd.StorageConfig)
+		restOptionsGetter, err := filestorage.NewRESTOptionsGetter(o.StorageOptions.DataPath, o.RecommendedOptions.Etcd.StorageConfig)
+		if err != nil {
+			return err
+		}
+		serverConfig.RESTOptionsGetter = restOptionsGetter
 	}
 
 	// Add OpenAPI specs for each group+version

--- a/pkg/services/apiserver/service.go
+++ b/pkg/services/apiserver/service.go
@@ -31,6 +31,7 @@ import (
 	"github.com/grafana/grafana/pkg/services/apiserver/aggregator"
 	"github.com/grafana/grafana/pkg/services/apiserver/auth/authenticator"
 	"github.com/grafana/grafana/pkg/services/apiserver/auth/authorizer"
+	"github.com/grafana/grafana/pkg/services/apiserver/endpoints/request"
 	grafanaapiserveroptions "github.com/grafana/grafana/pkg/services/apiserver/options"
 	entitystorage "github.com/grafana/grafana/pkg/services/apiserver/storage/entity"
 	"github.com/grafana/grafana/pkg/services/apiserver/utils"
@@ -366,11 +367,9 @@ func (s *service) startAggregator(
 	serverConfig *genericapiserver.RecommendedConfig,
 	server *genericapiserver.GenericAPIServer,
 ) (*genericapiserver.GenericAPIServer, error) {
-	externalNamesNamespace := "default"
-	if s.cfg.StackID != "" {
-		externalNamesNamespace = fmt.Sprintf("stack-%s", s.cfg.StackID)
-	}
-	aggregatorConfig, err := aggregator.CreateAggregatorConfig(s.options, *serverConfig, externalNamesNamespace)
+	namespaceMapper := request.GetNamespaceMapper(s.cfg)
+
+	aggregatorConfig, err := aggregator.CreateAggregatorConfig(s.options, *serverConfig, namespaceMapper(1))
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/services/apiserver/service.go
+++ b/pkg/services/apiserver/service.go
@@ -368,7 +368,7 @@ func (s *service) startAggregator(
 ) (*genericapiserver.GenericAPIServer, error) {
 	externalNamesNamespace := "default"
 	if s.cfg.StackID != "" {
-		externalNamesNamespace = s.cfg.StackID
+		externalNamesNamespace = fmt.Sprintf("stack-%s", s.cfg.StackID)
 	}
 	aggregatorConfig, err := aggregator.CreateAggregatorConfig(s.options, *serverConfig, externalNamesNamespace)
 	if err != nil {


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

Fixes a range of configuration and other bugs for file storage.

The RESTOptionsGetter, optionally, allows one to specify initial directories to bootstrap which read/watch operations on start aren't able to establish/mkdir and otherwise cause failures in aggregation init.

Other tidbits in this changeset:

* Guaranteed Update was missing an ensureDir.
* Refactored the variable names to make more sense. Paths are paths, not just names.
* The DirPath helper on storage is quite different from standard library `filepath.Dir`. Both have their uses, so left a comment noting the difference.

**Why do we need this feature?**

To use with externalnames and apiregistration until unified is ready.

**Who is this feature for?**

Grafana App Platform

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
