### PR TITLE
Queries: Fix debug logging of metrics queries

### DIFF
--- a/pkg/services/query/query.go
+++ b/pkg/services/query/query.go
@@ -306,12 +306,12 @@ func (s *ServiceImpl) parseMetricRequest(ctx context.Context, user identity.Requ
 			req.parsedQueries[ds.UID] = []parsedQuery{}
 		}
 
-		s.log.Debug("Processing metrics query", "query", query)
-
 		modelJSON, err := query.MarshalJSON()
 		if err != nil {
 			return nil, err
 		}
+
+		s.log.Debug("Processing metrics query", "query", string(modelJSON))
 
 		req.parsedQueries[ds.UID] = append(req.parsedQueries[ds.UID], parsedQuery{
 			datasource: ds,


### PR DESCRIPTION
**What is this feature?**

I noticed while searching for my logged queries, the value type is unsupported by the logger. This is not an issue with the console logger, but the file logger chokes on it (this appears to be due to go's implementation of marshal). 

<img width="1111" alt="image" src="https://github.com/grafana/grafana/assets/41969079/15df535b-aee2-43d3-8fc6-da87416444fa">

Now in all log formats, the log will appear as: 
`logger=query_data t=2024-03-04T23:35:27.815503-05:00 level=debug msg="Processing metrics query" query="{\"datasource\":{\"type\":\"datasource\",\"uid\":\"grafana\"},\"datasourceId\":-1,\"intervalMs\":2000,\"maxDataPoints\":1107,\"queryType\":\"randomWalk\",\"refId\":\"A\"}"`


