### PR TITLE
GenAI: Update the component only when the response is fully generated

### DIFF
--- a/public/app/features/dashboard/components/GenAI/GenAIButton.tsx
+++ b/public/app/features/dashboard/components/GenAI/GenAIButton.tsx
@@ -174,7 +174,7 @@ export const GenAIButton = ({
               eventTrackingSrc={eventTrackingSrc}
             />
           }
-          placement="bottom-start"
+          placement="left-start"
           fitContent={true}
           show={showHistory}
           onClose={() => setShowHistory(false)}

--- a/public/app/features/dashboard/components/GenAI/GenAIButton.tsx
+++ b/public/app/features/dashboard/components/GenAI/GenAIButton.tsx
@@ -54,7 +54,7 @@ export const GenAIButton = ({
   } = useOpenAIStream(model, temperature);
 
   const [history, setHistory] = useState<string[]>([]);
-  const [showHistory, setShowHistory] = useState(true);
+  const [showHistory, setShowHistory] = useState(false);
 
   const hasHistory = history.length > 0;
   const isGenerating = streamStatus === StreamStatus.GENERATING;
@@ -70,9 +70,7 @@ export const GenAIButton = ({
         onClickProp?.(e);
         setMessages(typeof messages === 'function' ? messages() : messages);
       } else {
-        if (setShowHistory) {
-          setShowHistory(true);
-        }
+        setShowHistory(true);
       }
     }
 
@@ -178,7 +176,9 @@ export const GenAIButton = ({
           }
           placement="bottom-start"
           fitContent={true}
-          show={showHistory ? undefined : false}
+          show={showHistory}
+          onClose={() => setShowHistory(false)}
+          onOpen={() => setShowHistory(true)}
         >
           {button}
         </Toggletip>

--- a/public/app/features/dashboard/components/GenAI/GenAIHistory.tsx
+++ b/public/app/features/dashboard/components/GenAI/GenAIHistory.tsx
@@ -90,6 +90,8 @@ export const GenAIHistory = ({
   const onGenerateWithFeedback = (suggestion: string | QuickFeedbackType) => {
     if (suggestion !== QuickFeedbackType.Regenerate) {
       messages = [...messages, ...getFeedbackMessage(history[currentIndex - 1], suggestion)];
+    } else {
+      messages = [...messages, ...getFeedbackMessage(history[currentIndex - 1], 'Try again')];
     }
 
     setMessages(messages);

--- a/public/app/features/dashboard/components/GenAI/GenAIHistory.tsx
+++ b/public/app/features/dashboard/components/GenAI/GenAIHistory.tsx
@@ -2,18 +2,7 @@ import { css } from '@emotion/css';
 import React, { useEffect, useState } from 'react';
 
 import { GrafanaTheme2 } from '@grafana/data';
-import {
-  Alert,
-  Button,
-  HorizontalGroup,
-  Icon,
-  IconButton,
-  Input,
-  Text,
-  TextLink,
-  useStyles2,
-  VerticalGroup,
-} from '@grafana/ui';
+import { Alert, Button, Icon, IconButton, Input, Stack, Text, TextLink, useStyles2 } from '@grafana/ui';
 
 import { STOP_GENERATION_TEXT } from './GenAIButton';
 import { GenerationHistoryCarousel } from './GenerationHistoryCarousel';
@@ -100,7 +89,7 @@ export const GenAIHistory = ({
 
   const onGenerateWithFeedback = (suggestion: string | QuickFeedbackType) => {
     if (suggestion !== QuickFeedbackType.Regenerate) {
-      messages = [...messages, ...getFeedbackMessage(history[currentIndex], suggestion)];
+      messages = [...messages, ...getFeedbackMessage(history[currentIndex - 1], suggestion)];
     }
 
     setMessages(messages);
@@ -122,13 +111,11 @@ export const GenAIHistory = ({
   return (
     <div className={styles.container}>
       {showError && (
-        <div>
-          <Alert title="">
-            <VerticalGroup>
-              <div>Sorry, I was unable to complete your request. Please try again.</div>
-            </VerticalGroup>
-          </Alert>
-        </div>
+        <Alert title="">
+          <Stack direction={'column'}>
+            <p>Sorry, I was unable to complete your request. Please try again.</p>
+          </Stack>
+        </Alert>
       )}
 
       <Input
@@ -157,11 +144,11 @@ export const GenAIHistory = ({
         />
       </div>
       <div className={styles.applySuggestion}>
-        <HorizontalGroup justify={'flex-end'}>
+        <Stack justifyContent={'flex-end'} direction={'row'}>
           <Button icon={!isStreamGenerating ? 'check' : 'fa fa-spinner'} onClick={onApply}>
             {isStreamGenerating ? STOP_GENERATION_TEXT : 'Apply'}
           </Button>
-        </HorizontalGroup>
+        </Stack>
       </div>
       <div className={styles.footer}>
         <Icon name="exclamation-circle" aria-label="exclamation-circle" className={styles.infoColor} />
@@ -186,7 +173,7 @@ const getStyles = (theme: GrafanaTheme2) => ({
     display: 'flex',
     flexDirection: 'column',
     width: 520,
-    height: 250,
+    maxHeight: 350,
     // This is the space the footer height
     paddingBottom: 35,
   }),

--- a/public/app/features/dashboard/components/GenAI/GenAIHistory.tsx
+++ b/public/app/features/dashboard/components/GenAI/GenAIHistory.tsx
@@ -91,7 +91,7 @@ export const GenAIHistory = ({
     if (suggestion !== QuickFeedbackType.Regenerate) {
       messages = [...messages, ...getFeedbackMessage(history[currentIndex - 1], suggestion)];
     } else {
-      messages = [...messages, ...getFeedbackMessage(history[currentIndex - 1], 'Try again')];
+      messages = [...messages, ...getFeedbackMessage(history[currentIndex - 1], 'Please, regenerate')];
     }
 
     setMessages(messages);

--- a/public/app/features/dashboard/components/GenAI/hooks.ts
+++ b/public/app/features/dashboard/components/GenAI/hooks.ts
@@ -71,6 +71,12 @@ export function useOpenAIStream(
     [messages, model, temperature, notifyError]
   );
 
+  useEffect(() => {
+    if (messages.length > 0) {
+      setReply('');
+    }
+  }, [messages]);
+
   const { error: enabledError, value: enabled } = useAsync(
     async () => await isLLMPluginEnabled(),
     [isLLMPluginEnabled]

--- a/public/app/features/dashboard/components/GenAI/hooks.ts
+++ b/public/app/features/dashboard/components/GenAI/hooks.ts
@@ -52,6 +52,8 @@ export function useOpenAIStream(
   const [streamStatus, setStreamStatus] = useState<StreamStatus>(StreamStatus.IDLE);
   const [error, setError] = useState<Error>();
   const { error: notifyError } = useAppNotification();
+  // Accumulate response and it will only update the state of the attatched component when the stream is completed.
+  let partialReply = '';
 
   const onError = useCallback(
     (e: Error) => {
@@ -102,9 +104,12 @@ export function useOpenAIStream(
     return {
       enabled,
       stream: stream.subscribe({
-        next: setReply,
+        next: (reply) => {
+          partialReply = reply;
+        },
         error: onError,
         complete: () => {
+          setReply(partialReply);
           setStreamStatus(StreamStatus.COMPLETED);
           setTimeout(() => {
             setStreamStatus(StreamStatus.IDLE);


### PR DESCRIPTION
Fixes #79611, #76848

**Problem**
The previous approach triggered a set state for every stream response. This was causing the component to enter into many re-renders, where React was stopping them and missing part of the message.

**Solution**
Do not set the state on every stream result, and accumulate the response to only commit the set state when it is fully completed. This changes the experience, but we want to try with this approach, to ensure the experience is performant enough.

![2024-03-05 08 10 10](https://github.com/grafana/grafana/assets/5699976/6883f41b-ed7c-44ca-bc78-7a5db5907e32)


