### PR TITLE
RBAC: add debug log for permission evaluation

### DIFF
--- a/pkg/services/accesscontrol/acimpl/accesscontrol.go
+++ b/pkg/services/accesscontrol/acimpl/accesscontrol.go
@@ -62,7 +62,7 @@ func (a *AccessControl) Evaluate(ctx context.Context, user identity.Requester, e
 		return false, err
 	}
 
-	a.debug(ctx, user, "Evaluating resolved permissions", evaluator)
+	a.debug(ctx, user, "Evaluating resolved permissions", resolvedEvaluator)
 	return resolvedEvaluator.Evaluate(permissions), nil
 }
 

--- a/pkg/services/accesscontrol/acimpl/accesscontrol.go
+++ b/pkg/services/accesscontrol/acimpl/accesscontrol.go
@@ -38,18 +38,17 @@ func (a *AccessControl) Evaluate(ctx context.Context, user identity.Requester, e
 		return false, nil
 	}
 
-	namespace, identifier := user.GetNamespacedID()
-
 	// If the user is in no organization, then the evaluation must happen based on the user's global permissions
 	permissions := user.GetPermissions()
 	if user.GetOrgID() == accesscontrol.NoOrgID {
 		permissions = user.GetGlobalPermissions()
 	}
 	if len(permissions) == 0 {
-		a.log.Debug("No permissions set for entity", "namespace", namespace, "id", identifier, "orgID", user.GetOrgID(), "login", user.GetLogin())
+		a.debug(ctx, user, "No permissions set", evaluator)
 		return false, nil
 	}
 
+	a.debug(ctx, user, "Evaluating permissions", evaluator)
 	// Test evaluation without scope resolver first, this will prevent 403 for wildcard scopes when resource does not exist
 	if evaluator.Evaluate(permissions) {
 		return true, nil
@@ -63,9 +62,15 @@ func (a *AccessControl) Evaluate(ctx context.Context, user identity.Requester, e
 		return false, err
 	}
 
+	a.debug(ctx, user, "Evaluating resolved permissions", evaluator)
 	return resolvedEvaluator.Evaluate(permissions), nil
 }
 
 func (a *AccessControl) RegisterScopeAttributeResolver(prefix string, resolver accesscontrol.ScopeAttributeResolver) {
 	a.resolvers.AddScopeAttributeResolver(prefix, resolver)
+}
+
+func (a *AccessControl) debug(ctx context.Context, ident identity.Requester, msg string, eval accesscontrol.Evaluator) {
+	namespace, id := ident.GetNamespacedID()
+	a.log.FromContext(ctx).Debug(msg, "namespace", namespace, "id", id, "orgID", ident.GetOrgID(), eval.GoString())
 }


### PR DESCRIPTION
**What is this feature?**
It is useful when debugging RBAC to be able to emit debug logs for what permissions are being evaluated.
These logs will include _namespace_ and _id_ of identity and permissions we want to evaluate against.


[Add a brief description of what the feature or update does.]

**Why do we need this feature?**

[Add a description of the problem the feature is trying to solve.]

**Who is this feature for?**

[Add information on what kind of user the feature is for.]

**Which issue(s) does this PR fix?**:

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
