### PR TITLE
Recording Rules: Use `queryType` instead of `instant`/`range` flags

### DIFF
--- a/public/app/features/alerting/unified/components/rule-editor/RecordingRuleEditor.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/RecordingRuleEditor.tsx
@@ -68,8 +68,7 @@ export const RecordingRuleEditor: FC<RecordingRuleEditorProps> = ({
         datasource: changedQuery.datasource,
         refId: changedQuery.refId,
         editorMode: changedQuery.editorMode,
-        instant: Boolean(changedQuery.instant),
-        range: Boolean(changedQuery.range),
+        queryType: changedQuery.queryType,
         legendFormat: changedQuery.legendFormat,
       },
     };


### PR DESCRIPTION
**What is this feature?**

The `instant`/`range` flags are deprecated since Grafana 8.4.0. Using `queryType` is the preferred way of defining a query type.
