### PR TITLE
Postgres: Allow disabling SNI on SSL-enabled connections

### DIFF
--- a/conf/defaults.ini
+++ b/conf/defaults.ini
@@ -138,6 +138,9 @@ log_queries =
 # For "mysql", use either "true", "false", or "skip-verify".
 ssl_mode = disable
 
+# For "postregs", use either "1" to enable or "0" to disable SNI
+ssl_sni =
+
 # Database drivers may support different transaction isolation levels.
 # Currently, only "mysql" driver supports isolation levels.
 # If the value is empty - driver's default isolation level is applied.

--- a/conf/sample.ini
+++ b/conf/sample.ini
@@ -124,6 +124,9 @@
 # For "mysql", use either "true", "false", or "skip-verify".
 ;ssl_mode = disable
 
+# For "postregs", use either "1" to enable or "0" to disable SNI
+;ssl_sni =
+
 # Database drivers may support different transaction isolation levels.
 # Currently, only "mysql" driver supports isolation levels.
 # If the value is empty - driver's default isolation level is applied.

--- a/docs/sources/setup-grafana/configure-grafana/_index.md
+++ b/docs/sources/setup-grafana/configure-grafana/_index.md
@@ -388,6 +388,10 @@ Set to `true` to log the sql calls and execution times.
 For Postgres, use use any [valid libpq `sslmode`](https://www.postgresql.org/docs/current/libpq-ssl.html#LIBPQ-SSL-SSLMODE-STATEMENTS), e.g.`disable`, `require`, `verify-full`, etc.
 For MySQL, use either `true`, `false`, or `skip-verify`.
 
+### ssl_sni
+
+For Postgres, set to `0` to disable [“Server Name Indication”](https://www.postgresql.org/docs/current/libpq-connect.html#LIBPQ-CONNECT-SSLSNI) (enabled by default on SSL-enabled connections).
+
 ### isolation_level
 
 Only the MySQL driver supports isolation levels in Grafana. In case the value is empty, the driver's default isolation level is applied. Available options are "READ-UNCOMMITTED", "READ-COMMITTED", "REPEATABLE-READ" or "SERIALIZABLE".

--- a/docs/sources/setup-grafana/configure-grafana/_index.md
+++ b/docs/sources/setup-grafana/configure-grafana/_index.md
@@ -390,7 +390,7 @@ For MySQL, use either `true`, `false`, or `skip-verify`.
 
 ### ssl_sni
 
-For Postgres, set to `0` to disable [“Server Name Indication”](https://www.postgresql.org/docs/current/libpq-connect.html#LIBPQ-CONNECT-SSLSNI) (enabled by default on SSL-enabled connections).
+For Postgres, set to `0` to disable [Server Name Indication](https://www.postgresql.org/docs/current/libpq-connect.html#LIBPQ-CONNECT-SSLSNI). This is enabled by default on SSL-enabled connections.
 
 ### isolation_level
 

--- a/pkg/services/sqlstore/database_config.go
+++ b/pkg/services/sqlstore/database_config.go
@@ -25,6 +25,7 @@ type DatabaseConfig struct {
 	Pwd                         string
 	Path                        string
 	SslMode                     string
+	SSLSNI                      string
 	CaCertPath                  string
 	ClientKeyPath               string
 	ClientCertPath              string
@@ -101,6 +102,7 @@ func (dbCfg *DatabaseConfig) readConfig(cfg *setting.Cfg) error {
 	dbCfg.ConnMaxLifetime = sec.Key("conn_max_lifetime").MustInt(14400)
 
 	dbCfg.SslMode = sec.Key("ssl_mode").String()
+	dbCfg.SSLSNI = sec.Key("ssl_sni").String()
 	dbCfg.CaCertPath = sec.Key("ca_cert_path").String()
 	dbCfg.ClientKeyPath = sec.Key("client_key_path").String()
 	dbCfg.ClientCertPath = sec.Key("client_cert_path").String()
@@ -168,12 +170,16 @@ func (dbCfg *DatabaseConfig) buildConnectionString(cfg *setting.Cfg, features fe
 
 		args := []any{dbCfg.User, addr.Host, addr.Port, dbCfg.Name, dbCfg.SslMode, dbCfg.ClientCertPath,
 			dbCfg.ClientKeyPath, dbCfg.CaCertPath}
+
 		for i, arg := range args {
 			if arg == "" {
 				args[i] = "''"
 			}
 		}
 		cnnstr = fmt.Sprintf("user=%s host=%s port=%s dbname=%s sslmode=%s sslcert=%s sslkey=%s sslrootcert=%s", args...)
+		if dbCfg.SSLSNI != "" {
+			cnnstr += fmt.Sprintf(" sslsni=%s", dbCfg.SSLSNI)
+		}
 		if dbCfg.Pwd != "" {
 			cnnstr += fmt.Sprintf(" password=%s", dbCfg.Pwd)
 		}


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

Starting from version 1.10.7 lib/pq [enables SNI](https://github.com/lib/pq/commit/957fc0b40156534f8dd356bc81679d7e1365242b).
However, this may be undesirable [for some cases](https://www.postgresql.org/docs/current/libpq-connect.html#LIBPQ-CONNECT-SSLSNI)
Also, causes tls-mode `verify-ca` not to work correctly #65816

**Why do we need this feature?**

This introduces a new database configuration for disabling `sslsni` by setting it to `0`.
By default is unset (fallbacks to the default `lib/pq` behaviour).
 
**Who is this feature for?**

[Add information on what kind of user the feature is for.]

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
