### PR TITLE
Serviceaccounts: Add ability to add samename SA for different orgs

### DIFF
--- a/pkg/services/serviceaccounts/database/store.go
+++ b/pkg/services/serviceaccounts/database/store.go
@@ -42,10 +42,10 @@ func ProvideServiceAccountsStore(cfg *setting.Cfg, store db.DB, apiKeyService ap
 	}
 }
 
-// generatedLogin makes a generated string to have a ID for the service account across orgs and it's name
+// generateLogin makes a generated string to have a ID for the service account across orgs and it's name
 // this causes you to create a service account with the same name in different orgs
 // not the same name in the same org
-func generatedLogin(prefix string, orgId int64, name string) string {
+func generateLogin(prefix string, orgId int64, name string) string {
 	generatedLogin := fmt.Sprintf("%v-%v-%v", prefix, orgId, strings.ToLower(name))
 	// in case the name has multiple spaces or dashes in the prefix or otherwise, replace them with a single dash
 	generatedLogin = strings.Replace(generatedLogin, "--", "-", 1)
@@ -54,7 +54,7 @@ func generatedLogin(prefix string, orgId int64, name string) string {
 
 // CreateServiceAccount creates service account
 func (s *ServiceAccountsStoreImpl) CreateServiceAccount(ctx context.Context, orgId int64, saForm *serviceaccounts.CreateServiceAccountForm) (*serviceaccounts.ServiceAccountDTO, error) {
-	login := generatedLogin(serviceaccounts.ServiceAccountPrefix, orgId, saForm.Name)
+	login := generateLogin(serviceaccounts.ServiceAccountPrefix, orgId, saForm.Name)
 	isDisabled := false
 	role := org.RoleViewer
 	if saForm.IsDisabled != nil {
@@ -444,7 +444,7 @@ func (s *ServiceAccountsStoreImpl) MigrateApiKey(ctx context.Context, orgId int6
 func (s *ServiceAccountsStoreImpl) CreateServiceAccountFromApikey(ctx context.Context, key *apikey.APIKey) error {
 	prefix := "sa-autogen"
 	cmd := user.CreateUserCommand{
-		Login:            generatedLogin(prefix, key.OrgID, key.Name),
+		Login:            generateLogin(prefix, key.OrgID, key.Name),
 		Name:             fmt.Sprintf("%v-%v", prefix, key.Name),
 		OrgID:            key.OrgID,
 		DefaultOrgRole:   string(key.Role),

--- a/pkg/services/serviceaccounts/database/store.go
+++ b/pkg/services/serviceaccounts/database/store.go
@@ -42,10 +42,19 @@ func ProvideServiceAccountsStore(cfg *setting.Cfg, store db.DB, apiKeyService ap
 	}
 }
 
+// generatedLogin makes a generated string to have a ID for the service account across orgs and it's name
+// this causes you to create a service account with the same name in different orgs
+// not the same name in the same org
+func generatedLogin(prefix string, orgId int64, name string) string {
+	generatedLogin := fmt.Sprintf("%v-%v-%v", prefix, orgId, strings.ToLower(name))
+	// in case the name has multiple spaces or dashes in the prefix or otherwise, replace them with a single dash
+	generatedLogin = strings.Replace(generatedLogin, "--", "-", 1)
+	return strings.Replace(generatedLogin, " ", "-", -1)
+}
+
 // CreateServiceAccount creates service account
 func (s *ServiceAccountsStoreImpl) CreateServiceAccount(ctx context.Context, orgId int64, saForm *serviceaccounts.CreateServiceAccountForm) (*serviceaccounts.ServiceAccountDTO, error) {
-	generatedLogin := serviceaccounts.ServiceAccountPrefix + strings.ToLower(saForm.Name)
-	generatedLogin = strings.ReplaceAll(generatedLogin, " ", "-")
+	login := generatedLogin(serviceaccounts.ServiceAccountPrefix, orgId, saForm.Name)
 	isDisabled := false
 	role := org.RoleViewer
 	if saForm.IsDisabled != nil {
@@ -56,7 +65,7 @@ func (s *ServiceAccountsStoreImpl) CreateServiceAccount(ctx context.Context, org
 	}
 
 	newSA, err := s.userService.CreateServiceAccount(ctx, &user.CreateUserCommand{
-		Login:            generatedLogin,
+		Login:            login,
 		OrgID:            orgId,
 		Name:             saForm.Name,
 		IsDisabled:       isDisabled,
@@ -435,7 +444,7 @@ func (s *ServiceAccountsStoreImpl) MigrateApiKey(ctx context.Context, orgId int6
 func (s *ServiceAccountsStoreImpl) CreateServiceAccountFromApikey(ctx context.Context, key *apikey.APIKey) error {
 	prefix := "sa-autogen"
 	cmd := user.CreateUserCommand{
-		Login:            fmt.Sprintf("%v-%v-%v", prefix, key.OrgID, key.Name),
+		Login:            generatedLogin(prefix, key.OrgID, key.Name),
 		Name:             fmt.Sprintf("%v-%v", prefix, key.Name),
 		OrgID:            key.OrgID,
 		DefaultOrgRole:   string(key.Role),

--- a/pkg/services/serviceaccounts/database/store_test.go
+++ b/pkg/services/serviceaccounts/database/store_test.go
@@ -178,7 +178,6 @@ func TestStore_CreateServiceAccountRoleNone(t *testing.T) {
 
 	saDTO, err := store.CreateServiceAccount(context.Background(), serviceAccountOrgId, &saForm)
 	require.NoError(t, err)
-	assert.Equal(t, "sa-new-service-account", saDTO.Login)
 	assert.Equal(t, serviceAccountName, saDTO.Name)
 	assert.Equal(t, 0, int(saDTO.Tokens))
 

--- a/pkg/services/serviceaccounts/database/store_test.go
+++ b/pkg/services/serviceaccounts/database/store_test.go
@@ -30,8 +30,8 @@ func TestMain(m *testing.M) {
 // Service Account should not create an org on its own
 func TestStore_CreateServiceAccountOrgNonExistant(t *testing.T) {
 	_, store := setupTestDatabase(t)
+	serviceAccountName := "new Service Account"
 	t.Run("create service account", func(t *testing.T) {
-		serviceAccountName := "new Service Account"
 		serviceAccountOrgId := int64(1)
 		serviceAccountRole := org.RoleAdmin
 		isDisabled := true
@@ -47,12 +47,12 @@ func TestStore_CreateServiceAccountOrgNonExistant(t *testing.T) {
 }
 
 func TestStore_CreateServiceAccount(t *testing.T) {
+	serviceAccountName := "new Service Account"
 	t.Run("create service account", func(t *testing.T) {
 		_, store := setupTestDatabase(t)
 		orgQuery := &org.CreateOrgCommand{Name: orgimpl.MainOrgName}
 		orgResult, err := store.orgService.CreateWithMember(context.Background(), orgQuery)
 		require.NoError(t, err)
-		serviceAccountName := "new Service Account"
 		serviceAccountOrgId := orgResult.ID
 		serviceAccountRole := org.RoleAdmin
 		isDisabled := true
@@ -84,8 +84,6 @@ func TestStore_CreateServiceAccount(t *testing.T) {
 		orgQuery := &org.CreateOrgCommand{Name: orgimpl.MainOrgName}
 		orgResult, err := store.orgService.CreateWithMember(context.Background(), orgQuery)
 		require.NoError(t, err)
-		serviceAccountName := "new Service Account"
-
 		serviceAccountOrgId := orgResult.ID
 		serviceAccountRole := org.RoleAdmin
 		isDisabled := true
@@ -121,8 +119,6 @@ func TestStore_CreateServiceAccount(t *testing.T) {
 		orgQuery := &org.CreateOrgCommand{Name: orgimpl.MainOrgName}
 		orgResult, err := store.orgService.CreateWithMember(context.Background(), orgQuery)
 		require.NoError(t, err)
-		serviceAccountName := "new Service Account"
-
 		serviceAccountOrgId := orgResult.ID
 		serviceAccountRole := org.RoleAdmin
 		isDisabled := true

--- a/pkg/services/serviceaccounts/database/store_test.go
+++ b/pkg/services/serviceaccounts/database/store_test.go
@@ -178,13 +178,11 @@ func TestStore_CreateServiceAccountRoleNone(t *testing.T) {
 
 	saDTO, err := store.CreateServiceAccount(context.Background(), serviceAccountOrgId, &saForm)
 	require.NoError(t, err)
-	assert.Equal(t, "sa-new-service-account", saDTO.Login)
 	assert.Equal(t, serviceAccountName, saDTO.Name)
 	assert.Equal(t, 0, int(saDTO.Tokens))
 
 	retrieved, err := store.RetrieveServiceAccount(context.Background(), serviceAccountOrgId, saDTO.Id)
 	require.NoError(t, err)
-	assert.Equal(t, "sa-new-service-account", retrieved.Login)
 	assert.Equal(t, serviceAccountName, retrieved.Name)
 	assert.Equal(t, serviceAccountOrgId, retrieved.OrgId)
 	assert.Equal(t, string(serviceAccountRole), retrieved.Role)

--- a/pkg/services/serviceaccounts/database/store_test.go
+++ b/pkg/services/serviceaccounts/database/store_test.go
@@ -153,7 +153,6 @@ func TestStore_CreateServiceAccount(t *testing.T) {
 		require.NoError(t, err)
 		assert.Equal(t, serviceAccountName, saDTOSecond.Name)
 		assert.Equal(t, 0, int(saDTOSecond.Tokens))
-
 	})
 }
 

--- a/pkg/services/serviceaccounts/database/store_test.go
+++ b/pkg/services/serviceaccounts/database/store_test.go
@@ -178,6 +178,7 @@ func TestStore_CreateServiceAccountRoleNone(t *testing.T) {
 
 	saDTO, err := store.CreateServiceAccount(context.Background(), serviceAccountOrgId, &saForm)
 	require.NoError(t, err)
+	assert.Equal(t, "sa-new-service-account", saDTO.Login)
 	assert.Equal(t, serviceAccountName, saDTO.Name)
 	assert.Equal(t, 0, int(saDTO.Tokens))
 

--- a/pkg/services/sqlstore/migrations/user_mig.go
+++ b/pkg/services/sqlstore/migrations/user_mig.go
@@ -153,6 +153,14 @@ func addUserMigrations(mg *Migrator) {
 	mg.AddMigration("Add unique index user_uid", NewAddIndexMigration(userV2, &Index{
 		Cols: []string{"uid"}, Type: UniqueIndex,
 	}))
+
+	// Service accounts login were not unique per org. this migration is part of making it unique per org
+	// to be able to create service accounts that are unique per org
+	mg.AddMigration("Update login field for service accounts", NewRawSQLMigration("").
+		SQLite("UPDATE user SET login = 'sa-' || CAST(org_id AS TEXT) || '-' || REPLACE(login, 'sa-', '') WHERE login IS NOT NULL AND is_service_account = 1;").
+		Postgres("UPDATE \"user\" SET login = 'sa-' || org_id::text || '-' || REPLACE(login, 'sa-', '') WHERE login IS NOT NULL AND is_service_account = 1;").
+		Mysql("UPDATE user SET login = CONCAT('sa-', CAST(org_id AS CHAR), '-', REPLACE(login, 'sa-', '')) WHERE login IS NOT NULL AND is_service_account = 1;"))
+
 }
 
 const migSQLITEisServiceAccountNullable = `ALTER TABLE user ADD COLUMN tmp_service_account BOOLEAN DEFAULT 0;

--- a/pkg/services/sqlstore/migrations/user_mig.go
+++ b/pkg/services/sqlstore/migrations/user_mig.go
@@ -158,9 +158,8 @@ func addUserMigrations(mg *Migrator) {
 	// to be able to create service accounts that are unique per org
 	mg.AddMigration("Update login field for service accounts", NewRawSQLMigration("").
 		SQLite("UPDATE user SET login = 'sa-' || CAST(org_id AS TEXT) || '-' || REPLACE(login, 'sa-', '') WHERE login IS NOT NULL AND is_service_account = 1;").
-		Postgres("UPDATE \"user\" SET login = 'sa-' || org_id::text || '-' || REPLACE(login, 'sa-', '') WHERE login IS NOT NULL AND is_service_account = 1;").
+		Postgres("UPDATE \"user\" SET login = 'sa-' || org_id::text || '-' || REPLACE(login, 'sa-', '') WHERE login IS NOT NULL AND is_service_account = true;").
 		Mysql("UPDATE user SET login = CONCAT('sa-', CAST(org_id AS CHAR), '-', REPLACE(login, 'sa-', '')) WHERE login IS NOT NULL AND is_service_account = 1;"))
-
 }
 
 const migSQLITEisServiceAccountNullable = `ALTER TABLE user ADD COLUMN tmp_service_account BOOLEAN DEFAULT 0;

--- a/pkg/services/user/userimpl/user.go
+++ b/pkg/services/user/userimpl/user.go
@@ -406,6 +406,7 @@ func (s *Service) CreateServiceAccount(ctx context.Context, cmd *user.CreateUser
 	cmd.Email = cmd.Login
 	err := s.store.LoginConflict(ctx, cmd.Login, cmd.Email, s.cfg.CaseInsensitiveLogin)
 	if err != nil {
+		fmt.Printf("error %e", err)
 		return nil, serviceaccounts.ErrServiceAccountAlreadyExists.Errorf("service account with login %s already exists", cmd.Login)
 	}
 

--- a/pkg/services/user/userimpl/user.go
+++ b/pkg/services/user/userimpl/user.go
@@ -406,7 +406,6 @@ func (s *Service) CreateServiceAccount(ctx context.Context, cmd *user.CreateUser
 	cmd.Email = cmd.Login
 	err := s.store.LoginConflict(ctx, cmd.Login, cmd.Email, s.cfg.CaseInsensitiveLogin)
 	if err != nil {
-		fmt.Printf("error %e", err)
 		return nil, serviceaccounts.ErrServiceAccountAlreadyExists.Errorf("service account with login %s already exists", cmd.Login)
 	}
 


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**
We are checking for login name across orgs when we create Service accounts, this implementation adds the orgID as a "middle prefix". 

**NOTE:** We could add it as a suffix instead. Just implementation details

https://github.com/grafana/grafana/issues/83889

migrations tested on:
- sqlite ✅ 
- mysql ✅ 
- postgres ✅ 

testing done via:
```bash
make devenv sources=postgres
make devenv sources=mysql
```

removed the migration, inserted a service account and rerun grafana.