### PR TITLE
Plugins Catalog: Fix plugin details page initial flickering

### DIFF
--- a/public/app/features/plugins/admin/state/hooks.ts
+++ b/public/app/features/plugins/admin/state/hooks.ts
@@ -84,7 +84,10 @@ export const useLocalFetchStatus = () => {
 };
 
 export const useFetchStatus = () => {
-  const isLoading = useSelector(selectIsRequestPending(fetchAll.typePrefix));
+  const isAllLoading = useSelector(selectIsRequestPending(fetchAll.typePrefix));
+  const isLocalLoading = useSelector(selectIsRequestPending('plugins/fetchLocal'));
+  const isRemoteLoading = useSelector(selectIsRequestPending('plugins/fetchRemote'));
+  const isLoading = isAllLoading || isLocalLoading || isRemoteLoading;
   const error = useSelector(selectRequestError(fetchAll.typePrefix));
 
   return { isLoading, error };


### PR DESCRIPTION
### What changed?

There was a flickering when the plugin details page (e.g. `/plugins/heywesty-trafficlight-panel`) was accessed directly (not navigating to it from the all plugins list). This was caused by the fetch status already showing "not loading" while the plugin still not being available on the redux store. This PR is aiming to fix this by also waiting for the remote and local plugin API calls to be fulfilled before rendering the details page.
