### PR TITLE
Alerting: Remove object matchers from GettableStatus

### DIFF
--- a/pkg/services/ngalert/api/tooling/definitions/alertmanager.go
+++ b/pkg/services/ngalert/api/tooling/definitions/alertmanager.go
@@ -873,7 +873,7 @@ func (r *Route) AsAMRoute() *config.Route {
 	return amRoute
 }
 
-// AsGrafanaRoute returns a Grafana route from an Alertmanager route. The Matchers are converted to ObjectMatchers.
+// AsGrafanaRoute returns a Grafana route from an Alertmanager route.
 func AsGrafanaRoute(r *config.Route) *Route {
 	gRoute := &Route{
 		Receiver:          r.Receiver,
@@ -882,7 +882,7 @@ func AsGrafanaRoute(r *config.Route) *Route {
 		GroupByAll:        r.GroupByAll,
 		Match:             r.Match,
 		MatchRE:           r.MatchRE,
-		ObjectMatchers:    ObjectMatchers(r.Matchers),
+		Matchers:          r.Matchers,
 		MuteTimeIntervals: r.MuteTimeIntervals,
 		Continue:          r.Continue,
 


### PR DESCRIPTION
**What is this feature?**

This commit removes object matchers from `GettableStatus` as the Grafana UI now supports UTF-8 in matchers.

**Why do we need this feature?**

[Add a description of the problem the feature is trying to solve.]

**Who is this feature for?**

[Add information on what kind of user the feature is for.]

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle.
- [x] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
