### PR TITLE
Docs: removes note as recovery threshold now in cloud

### DIFF
--- a/docs/sources/alerting/alerting-rules/create-grafana-managed-rule.md
+++ b/docs/sources/alerting/alerting-rules/create-grafana-managed-rule.md
@@ -78,10 +78,6 @@ Define a query to get the data you want to measure and a condition that needs to
 
    b. Click **Preview** to verify that the expression is successful.
 
-{{% admonition type="note" %}}
-The recovery threshold feature is currently only available in OSS.
-{{% /admonition %}}
-
 1. To add a recovery threshold, turn the **Custom recovery threshold** toggle on and fill in a value for when your alert rule should stop firing.
 
    You can only add one recovery threshold in a query and it must be the alert condition.


### PR DESCRIPTION

recovery threshold is now enabled in cloud, so removing the note.