### PR TITLE
Azure: Update http client creation

### DIFF
--- a/pkg/services/pluginsintegration/plugins_integration_test.go
+++ b/pkg/services/pluginsintegration/plugins_integration_test.go
@@ -74,7 +74,7 @@ func TestIntegrationPluginManager(t *testing.T) {
 	tracer := tracing.InitializeTracerForTest()
 
 	hcp := httpclient.NewProvider()
-	am := azuremonitor.ProvideService(hcp)
+	am := azuremonitor.ProvideService()
 	cw := cloudwatch.ProvideService(hcp)
 	cm := cloudmonitoring.ProvideService(hcp)
 	es := elasticsearch.ProvideService(hcp, tracer)

--- a/pkg/tsdb/azuremonitor/azuremonitor_test.go
+++ b/pkg/tsdb/azuremonitor/azuremonitor_test.go
@@ -13,7 +13,6 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/grafana/grafana-azure-sdk-go/azcredentials"
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
-	"github.com/grafana/grafana-plugin-sdk-go/backend/httpclient"
 	"github.com/grafana/grafana-plugin-sdk-go/backend/instancemgmt"
 	"github.com/grafana/grafana-plugin-sdk-go/backend/log"
 
@@ -111,7 +110,7 @@ func TestNewInstanceSettings(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			factory := NewInstanceSettings(&httpclient.Provider{}, map[string]azDatasourceExecutor{}, log.DefaultLogger)
+			factory := NewInstanceSettings(map[string]azDatasourceExecutor{}, log.DefaultLogger)
 			instance, err := factory(context.Background(), tt.settings)
 			tt.Err(t, err)
 			if !cmp.Equal(instance, tt.expectedModel) {

--- a/pkg/tsdb/azuremonitor/standalone/datasource.go
+++ b/pkg/tsdb/azuremonitor/standalone/datasource.go
@@ -4,7 +4,6 @@ import (
 	"context"
 
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
-	"github.com/grafana/grafana-plugin-sdk-go/backend/httpclient"
 	"github.com/grafana/grafana-plugin-sdk-go/backend/instancemgmt"
 	azuremonitor "github.com/grafana/grafana/pkg/tsdb/azuremonitor"
 )
@@ -17,7 +16,7 @@ var (
 
 func NewDatasource(context.Context, backend.DataSourceInstanceSettings) (instancemgmt.Instance, error) {
 	return &Datasource{
-		Service: azuremonitor.ProvideService(httpclient.NewProvider()),
+		Service: azuremonitor.ProvideService(),
 	}, nil
 }
 


### PR DESCRIPTION
Something that was missed when decoupling was to remove the `httpclient` argument in the `ProvideService` call. Without this, the default core Grafana `httpclient` would still be used which is misleading as all of the core middleware would then be used in data source requests.

This change instantiates a new `httpclient` using the method from the plugin SDK. This will bring Azure Monitor into alignment with all the other decoupled/external data sources and only the middleware available to those data sources will be used.