### PR TITLE
PanelTitleSearch: Show datasource usage in plugins

### DIFF
--- a/pkg/services/searchV2/bluge.go
+++ b/pkg/services/searchV2/bluge.go
@@ -435,6 +435,12 @@ func doSearchQuery(
 		hasConstraints = true
 	}
 
+	// Datasource
+	if q.DatasourceType != "" {
+		fullQuery.AddMust(bluge.NewTermQuery(q.DatasourceType).SetField(documentFieldDSType))
+		hasConstraints = true
+	}
+
 	// Folder
 	if q.Location != "" {
 		fullQuery.AddMust(bluge.NewTermQuery(q.Location).SetField(documentFieldLocation))

--- a/pkg/services/searchV2/bluge.go
+++ b/pkg/services/searchV2/bluge.go
@@ -435,7 +435,7 @@ func doSearchQuery(
 		hasConstraints = true
 	}
 
-	// Datasource
+	// DatasourceType
 	if q.DatasourceType != "" {
 		fullQuery.AddMust(bluge.NewTermQuery(q.DatasourceType).SetField(documentFieldDSType))
 		hasConstraints = true

--- a/pkg/services/searchV2/types.go
+++ b/pkg/services/searchV2/types.go
@@ -18,7 +18,7 @@ type DashboardQuery struct {
 	Query              string       `json:"query"`
 	Location           string       `json:"location,omitempty"` // parent folder ID
 	Sort               string       `json:"sort,omitempty"`     // field ASC/DESC
-	Datasource         string       `json:"ds_uid,omitempty"`   // "datasource" collides with the JSON value at the same leel :()
+	Datasource         string       `json:"ds_uid,omitempty"`   // "datasource" collides with the JSON value at the same level :()
 	DatasourceType     string       `json:"ds_type,omitempty"`
 	Tags               []string     `json:"tags,omitempty"`
 	Kind               []string     `json:"kind,omitempty"`

--- a/public/app/features/plugins/admin/components/PluginUsage.tsx
+++ b/public/app/features/plugins/admin/components/PluginUsage.tsx
@@ -4,7 +4,7 @@ import { useAsync } from 'react-use';
 import AutoSizer from 'react-virtualized-auto-sizer';
 import { of } from 'rxjs';
 
-import { GrafanaTheme2, PluginMeta } from '@grafana/data';
+import { GrafanaTheme2, PluginMeta, PluginType } from '@grafana/data';
 import { config } from '@grafana/runtime';
 import { Alert, Spinner, useStyles2 } from '@grafana/ui';
 import EmptyListCTA from 'app/core/components/EmptyListCTA/EmptyListCTA';
@@ -19,6 +19,13 @@ export function PluginUsage({ plugin }: Props) {
   const styles = useStyles2(getStyles);
 
   const searchQuery = useMemo<SearchQuery>(() => {
+    if (plugin.type === PluginType.datasource) {
+      return {
+        query: '*',
+        ds_type: plugin.id,
+        kind: ['dashboard'],
+      };
+    }
     return {
       query: '*',
       panel_type: plugin.id,

--- a/public/app/features/plugins/admin/hooks/usePluginDetailsTabs.tsx
+++ b/public/app/features/plugins/admin/hooks/usePluginDetailsTabs.tsx
@@ -51,7 +51,10 @@ export const usePluginDetailsTabs = (plugin?: CatalogPlugin, pageId?: PluginTabI
       });
     }
 
-    if (config.featureToggles.panelTitleSearch && pluginConfig.meta.type === PluginType.panel) {
+    if (
+      config.featureToggles.panelTitleSearch &&
+      (pluginConfig.meta.type === PluginType.panel || pluginConfig.meta.type === PluginType.datasource)
+    ) {
       navModelChildren.push({
         text: PluginTabLabels.USAGE,
         icon: 'list-ul',


### PR DESCRIPTION
Currently we show panel usage when panelTitleSearch is enabled.  This PR extends that behavior to also show datasource usage:

<img width="1149" alt="image" src="https://github.com/grafana/grafana/assets/705951/f0092539-462d-4fc4-8159-675ae029289b">
