### PR TITLE
Storage: Use our own key format and support unnamespaced objects

### DIFF
--- a/pkg/services/apiserver/storage/entity/utils.go
+++ b/pkg/services/apiserver/storage/entity/utils.go
@@ -19,7 +19,6 @@ import (
 	entityStore "github.com/grafana/grafana/pkg/services/store/entity"
 )
 
-// this is terrible... but just making it work!!!!
 func entityToResource(rsp *entityStore.Entity, res runtime.Object, codec runtime.Codec) error {
 	var err error
 
@@ -99,7 +98,7 @@ func entityToResource(rsp *entityStore.Entity, res runtime.Object, codec runtime
 	return nil
 }
 
-func resourceToEntity(key string, res runtime.Object, requestInfo *request.RequestInfo, codec runtime.Codec) (*entityStore.Entity, error) {
+func resourceToEntity(res runtime.Object, requestInfo *request.RequestInfo, codec runtime.Codec) (*entityStore.Entity, error) {
 	metaAccessor, err := meta.Accessor(res)
 	if err != nil {
 		return nil, err
@@ -111,14 +110,22 @@ func resourceToEntity(key string, res runtime.Object, requestInfo *request.Reque
 	}
 	rv, _ := strconv.ParseInt(metaAccessor.GetResourceVersion(), 10, 64)
 
+	k := &entityStore.Key{
+		Group:       requestInfo.APIGroup,
+		Resource:    requestInfo.Resource,
+		Namespace:   requestInfo.Namespace,
+		Name:        metaAccessor.GetName(),
+		Subresource: requestInfo.Subresource,
+	}
+
 	rsp := &entityStore.Entity{
-		Group:           requestInfo.APIGroup,
+		Group:           k.Group,
 		GroupVersion:    requestInfo.APIVersion,
-		Resource:        requestInfo.Resource,
-		Subresource:     requestInfo.Subresource,
-		Namespace:       metaAccessor.GetNamespace(),
-		Key:             key,
-		Name:            metaAccessor.GetName(),
+		Resource:        k.Resource,
+		Subresource:     k.Subresource,
+		Namespace:       k.Namespace,
+		Key:             k.String(),
+		Name:            k.Name,
 		Guid:            string(metaAccessor.GetUID()),
 		ResourceVersion: rv,
 		Folder:          grafanaAccessor.GetFolder(),

--- a/pkg/services/apiserver/storage/entity/utils_test.go
+++ b/pkg/services/apiserver/storage/entity/utils_test.go
@@ -24,22 +24,18 @@ func TestResourceToEntity(t *testing.T) {
 	updatedAt := createdAt.Add(time.Hour).Truncate(time.Second)
 	updatedAtStr := updatedAt.UTC().Format(time.RFC3339)
 
-	apiVersion := "v0alpha1"
-	requestInfo := &request.RequestInfo{
-		APIVersion: apiVersion,
-	}
-
 	Scheme := runtime.NewScheme()
 	Scheme.AddKnownTypes(v0alpha1.PlaylistResourceInfo.GroupVersion(), &v0alpha1.Playlist{})
 	Codecs := serializer.NewCodecFactory(Scheme)
 
 	testCases := []struct {
-		key                  string
+		requestInfo          *request.RequestInfo
 		resource             runtime.Object
 		codec                runtime.Codec
 		expectedKey          string
 		expectedGroupVersion string
 		expectedName         string
+		expectedNamespace    string
 		expectedTitle        string
 		expectedGuid         string
 		expectedVersion      string
@@ -55,11 +51,14 @@ func TestResourceToEntity(t *testing.T) {
 		expectedBody         []byte
 	}{
 		{
-			key: "/playlist.grafana.app/playlists/default/test-uid",
+			requestInfo: &request.RequestInfo{
+				APIGroup:   "playlist.grafana.app",
+				APIVersion: "v0alpha1",
+				Resource:   "playlists",
+				Namespace:  "default",
+				Name:       "test-name",
+			},
 			resource: &v0alpha1.Playlist{
-				TypeMeta: metav1.TypeMeta{
-					APIVersion: apiVersion,
-				},
 				ObjectMeta: metav1.ObjectMeta{
 					CreationTimestamp: createdAt,
 					Labels:            map[string]string{"label1": "value1", "label2": "value2"},
@@ -83,9 +82,10 @@ func TestResourceToEntity(t *testing.T) {
 					},
 				},
 			},
-			expectedKey:          "/playlist.grafana.app/playlists/default/test-uid",
-			expectedGroupVersion: apiVersion,
+			expectedKey:          "/playlist.grafana.app/playlists/namespaces/default/test-name",
+			expectedGroupVersion: "v0alpha1",
 			expectedName:         "test-name",
+			expectedNamespace:    "default",
 			expectedTitle:        "A playlist",
 			expectedGuid:         "test-uid",
 			expectedVersion:      "1",
@@ -104,10 +104,11 @@ func TestResourceToEntity(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.resource.GetObjectKind().GroupVersionKind().Kind+" to entity conversion should succeed", func(t *testing.T) {
-			entity, err := resourceToEntity(tc.key, tc.resource, requestInfo, Codecs.LegacyCodec(v0alpha1.PlaylistResourceInfo.GroupVersion()))
+			entity, err := resourceToEntity(tc.resource, tc.requestInfo, Codecs.LegacyCodec(v0alpha1.PlaylistResourceInfo.GroupVersion()))
 			require.NoError(t, err)
 			assert.Equal(t, tc.expectedKey, entity.Key)
 			assert.Equal(t, tc.expectedName, entity.Name)
+			assert.Equal(t, tc.expectedNamespace, entity.Namespace)
 			assert.Equal(t, tc.expectedTitle, entity.Title)
 			assert.Equal(t, tc.expectedGroupVersion, entity.GroupVersion)
 			assert.Equal(t, tc.expectedName, entity.Name)
@@ -152,7 +153,7 @@ func TestEntityToResource(t *testing.T) {
 	}{
 		{
 			entity: &entityStore.Entity{
-				Key:             "/playlist.grafana.app/playlists/default/test-uid",
+				Key:             "/playlist.grafana.app/playlists/namespaces/default/test-uid",
 				GroupVersion:    "v0alpha1",
 				Name:            "test-uid",
 				Title:           "A playlist",

--- a/pkg/services/store/entity/key.go
+++ b/pkg/services/store/entity/key.go
@@ -14,10 +14,10 @@ type Key struct {
 }
 
 func ParseKey(key string) (*Key, error) {
-	// /<group>/<resource>/<namespace>(/<name>(/<subresource>))
-	parts := strings.SplitN(key, "/", 6)
-	if len(parts) < 4 {
-		return nil, fmt.Errorf("invalid key (expecting at least 3 parts): %s", key)
+	// /<group>/<resource>[/namespaces/<namespace>][/<name>[/<subresource>]]
+	parts := strings.Split(key, "/")
+	if len(parts) < 3 {
+		return nil, fmt.Errorf("invalid key (expecting at least 2 parts): %s", key)
 	}
 
 	if parts[0] != "" {
@@ -25,24 +25,45 @@ func ParseKey(key string) (*Key, error) {
 	}
 
 	k := &Key{
-		Group:     parts[1],
-		Resource:  parts[2],
-		Namespace: parts[3],
+		Group:    parts[1],
+		Resource: parts[2],
 	}
 
-	if len(parts) > 4 {
-		k.Name = parts[4]
+	if len(parts) == 3 {
+		return k, nil
 	}
 
-	if len(parts) > 5 {
-		k.Subresource = parts[5]
+	if parts[3] != "namespaces" {
+		k.Name = parts[3]
+		if len(parts) > 4 {
+			k.Subresource = strings.Join(parts[4:], "/")
+		}
+		return k, nil
+	}
+
+	if len(parts) < 5 {
+		return nil, fmt.Errorf("invalid key (expecting namespace after 'namespaces'): %s", key)
+	}
+
+	k.Namespace = parts[4]
+
+	if len(parts) == 5 {
+		return k, nil
+	}
+
+	k.Name = parts[5]
+	if len(parts) > 6 {
+		k.Subresource = strings.Join(parts[6:], "/")
 	}
 
 	return k, nil
 }
 
 func (k *Key) String() string {
-	s := "/" + k.Group + "/" + k.Resource + "/" + k.Namespace
+	s := "/" + k.Group + "/" + k.Resource
+	if len(k.Namespace) > 0 {
+		s += "/namespaces/" + k.Namespace
+	}
 	if len(k.Name) > 0 {
 		s += "/" + k.Name
 		if len(k.Subresource) > 0 {

--- a/pkg/services/store/entity/sqlstash/sql_storage_server.go
+++ b/pkg/services/store/entity/sqlstash/sql_storage_server.go
@@ -1099,8 +1099,12 @@ func (s *sqlEntityServer) List(ctx context.Context, r *entity.EntityListRequest)
 				return nil, err
 			}
 
-			args = append(args, key.Namespace, key.Group, key.Resource)
-			whereclause := "(" + s.dialect.Quote("namespace") + "=? AND " + s.dialect.Quote("group") + "=? AND " + s.dialect.Quote("resource") + "=?"
+			args = append(args, key.Group, key.Resource)
+			whereclause := "(" + s.dialect.Quote("group") + "=? AND " + s.dialect.Quote("resource") + "=?"
+			if key.Namespace != "" {
+				args = append(args, key.Namespace)
+				whereclause += " AND " + s.dialect.Quote("namespace") + "=?"
+			}
 			if key.Name != "" {
 				args = append(args, key.Name)
 				whereclause += " AND " + s.dialect.Quote("name") + "=?"
@@ -1257,8 +1261,12 @@ func (s *sqlEntityServer) watchInit(ctx context.Context, r *entity.EntityWatchRe
 				return err
 			}
 
-			args = append(args, key.Namespace, key.Group, key.Resource)
-			whereclause := "(" + s.dialect.Quote("namespace") + "=? AND " + s.dialect.Quote("group") + "=? AND " + s.dialect.Quote("resource") + "=?"
+			args = append(args, key.Group, key.Resource)
+			whereclause := "(" + s.dialect.Quote("group") + "=? AND " + s.dialect.Quote("resource") + "=?"
+			if key.Namespace != "" {
+				args = append(args, key.Namespace)
+				whereclause += " AND " + s.dialect.Quote("namespace") + "=?"
+			}
 			if key.Name != "" {
 				args = append(args, key.Name)
 				whereclause += " AND " + s.dialect.Quote("name") + "=?"
@@ -1465,7 +1473,7 @@ func watchMatches(r *entity.EntityWatchRequest, result *entity.Entity) bool {
 				return false
 			}
 
-			if key.Namespace == result.Namespace && key.Group == result.Group && key.Resource == result.Resource && (key.Name == "" || key.Name == result.Name) {
+			if key.Group == result.Group && key.Resource == result.Resource && (key.Namespace == "" || key.Namespace == result.Namespace) && (key.Name == "" || key.Name == result.Name) {
 				matched = true
 				break
 			}

--- a/pkg/services/store/entity/sqlstash/sql_storage_server_test.go
+++ b/pkg/services/store/entity/sqlstash/sql_storage_server_test.go
@@ -34,7 +34,7 @@ func TestCreate(t *testing.T) {
 				Resource:  "playlists",
 				Namespace: "default",
 				Name:      "set-minimum-uid",
-				Key:       "/playlist.grafana.app/playlists/default/set-minimum-uid",
+				Key:       "/playlist.grafana.app/playlists/namespaces/default/set-minimum-uid",
 				CreatedBy: "set-minimum-creator",
 				Origin:    &entity.EntityOriginInfo{},
 			},
@@ -44,7 +44,7 @@ func TestCreate(t *testing.T) {
 		{
 			"request with no entity creator",
 			&entity.Entity{
-				Key: "/playlist.grafana.app/playlists/default/set-only-key",
+				Key: "/playlist.grafana.app/playlists/namespaces/default/set-only-key",
 			},
 			true,
 			false,


### PR DESCRIPTION
This PR updates our key format so that we can tell the difference between a namespaced key an an unnamespaced one.

After this change we completely ignore the `key` provided by `keyFunc` and always assemble the requested key from `requestInfo`.

The new key format uses the same `/namespaces/<namespace>` format as the urls, but still follows the etcd key ordering of group, resource, namespace, name, subresource.

I made a few other tweaks while in the file, removing the retries during update (which were intended to deal with etcd lag as far as I can tell) and moving the decoder struct definition to the end of the file.