### PR TITLE
Alerting: Add "Keep Last State" backend functionality

### DIFF
--- a/pkg/services/ngalert/migration/alert_rule.go
+++ b/pkg/services/ngalert/migration/alert_rule.go
@@ -235,7 +235,7 @@ func transNoData(l log.Logger, s string) ngmodels.NoDataState {
 	case legacymodels.NoDataSetAlerting:
 		return ngmodels.Alerting
 	case legacymodels.NoDataKeepState:
-		return ngmodels.NoData // "keep last state" translates to no data because we now emit a special alert when the state is "noData". The result is that the evaluation will not return firing and instead we'll raise the special alert.
+		return ngmodels.KeepLast
 	default:
 		l.Warn("Unable to translate execution of NoData state. Using default execution", "old", s, "new", ngmodels.NoData)
 		return ngmodels.NoData
@@ -247,9 +247,7 @@ func transExecErr(l log.Logger, s string) ngmodels.ExecutionErrorState {
 	case "", legacymodels.ExecutionErrorSetAlerting:
 		return ngmodels.AlertingErrState
 	case legacymodels.ExecutionErrorKeepState:
-		// Keep last state is translated to error as we now emit a
-		// DatasourceError alert when the state is error
-		return ngmodels.ErrorErrState
+		return ngmodels.KeepLastErrState
 	case legacymodels.ExecutionErrorSetOk:
 		return ngmodels.OkErrState
 	default:

--- a/pkg/services/ngalert/models/alert_rule.go
+++ b/pkg/services/ngalert/models/alert_rule.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"sort"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/google/go-cmp/cmp"
@@ -143,7 +144,12 @@ const (
 	StateReasonPaused        = "Paused"
 	StateReasonUpdated       = "Updated"
 	StateReasonRuleDeleted   = "RuleDeleted"
+	StateReasonKeepLast      = "KeepLast"
 )
+
+func ConcatReasons(reasons ...string) string {
+	return strings.Join(reasons, ", ")
+}
 
 var (
 	// InternalLabelNameSet are labels that grafana automatically include as part of the labelset.

--- a/pkg/services/ngalert/models/alert_rule.go
+++ b/pkg/services/ngalert/models/alert_rule.go
@@ -53,6 +53,8 @@ func NoDataStateFromString(state string) (NoDataState, error) {
 		return NoData, nil
 	case string(OK):
 		return OK, nil
+	case string(KeepLast):
+		return KeepLast, nil
 	default:
 		return "", fmt.Errorf("unknown NoData state option %s", state)
 	}
@@ -62,6 +64,7 @@ const (
 	Alerting NoDataState = "Alerting"
 	NoData   NoDataState = "NoData"
 	OK       NoDataState = "OK"
+	KeepLast NoDataState = "KeepLast"
 )
 
 // swagger:enum ExecutionErrorState
@@ -79,6 +82,8 @@ func ErrStateFromString(opt string) (ExecutionErrorState, error) {
 		return ErrorErrState, nil
 	case string(OkErrState):
 		return OkErrState, nil
+	case string(KeepLastErrState):
+		return KeepLastErrState, nil
 	default:
 		return "", fmt.Errorf("unknown Error state option %s", opt)
 	}
@@ -88,6 +93,7 @@ const (
 	AlertingErrState ExecutionErrorState = "Alerting"
 	ErrorErrState    ExecutionErrorState = "Error"
 	OkErrState       ExecutionErrorState = "OK"
+	KeepLastErrState ExecutionErrorState = "KeepLast"
 )
 
 const (

--- a/pkg/services/ngalert/state/historian/core.go
+++ b/pkg/services/ngalert/state/historian/core.go
@@ -22,12 +22,6 @@ func shouldRecord(transition state.StateTransition) bool {
 		return false
 	}
 
-	// Do not log transitions when keeping last state
-	toKeepLast := strings.Contains(transition.StateReason, models.StateReasonKeepLast) && !strings.Contains(transition.PreviousStateReason, models.StateReasonKeepLast)
-	if toKeepLast {
-		return false
-	}
-
 	// Do not log not transitioned states normal states if it was marked as stale
 	if transition.StateReason == models.StateReasonMissingSeries && transition.PreviousState == eval.Normal && transition.State.State == eval.Normal {
 		return false
@@ -44,6 +38,12 @@ func shouldRecord(transition state.StateTransition) bool {
 // This is stricter than shouldRecord to avoid cluttering panels with state transitions.
 func ShouldRecordAnnotation(t state.StateTransition) bool {
 	if !shouldRecord(t) {
+		return false
+	}
+
+	// Do not log transitions when keeping last state
+	toKeepLast := strings.Contains(t.StateReason, models.StateReasonKeepLast) && !strings.Contains(t.PreviousStateReason, models.StateReasonKeepLast)
+	if toKeepLast {
 		return false
 	}
 

--- a/pkg/services/ngalert/state/historian/core.go
+++ b/pkg/services/ngalert/state/historian/core.go
@@ -22,6 +22,12 @@ func shouldRecord(transition state.StateTransition) bool {
 		return false
 	}
 
+	// Do not log transitions when keeping last state
+	toKeepLast := strings.Contains(transition.StateReason, models.StateReasonKeepLast) && !strings.Contains(transition.PreviousStateReason, models.StateReasonKeepLast)
+	if toKeepLast {
+		return false
+	}
+
 	// Do not log not transitioned states normal states if it was marked as stale
 	if transition.StateReason == models.StateReasonMissingSeries && transition.PreviousState == eval.Normal && transition.State.State == eval.Normal {
 		return false

--- a/pkg/services/ngalert/state/manager.go
+++ b/pkg/services/ngalert/state/manager.go
@@ -316,14 +316,14 @@ func (st *Manager) ProcessEvalResults(ctx context.Context, evaluatedAt time.Time
 }
 
 func (st *Manager) setNextStateForRule(ctx context.Context, alertRule *ngModels.AlertRule, results eval.Results, extraLabels data.Labels, logger log.Logger) []StateTransition {
-	if st.applyNoDataAndErrorToAllStates && results.IsNoData() && (alertRule.NoDataState == ngModels.Alerting || alertRule.NoDataState == ngModels.OK) { // If it is no data, check the mapping and switch all results to the new state
+	if st.applyNoDataAndErrorToAllStates && results.IsNoData() && (alertRule.NoDataState == ngModels.Alerting || alertRule.NoDataState == ngModels.OK || alertRule.NoDataState == ngModels.KeepLast) { // If it is no data, check the mapping and switch all results to the new state
 		// TODO aggregate UID of datasources that returned NoData into one and provide as auxiliary info, probably annotation
 		transitions := st.setNextStateForAll(ctx, alertRule, results[0], logger)
 		if len(transitions) > 0 {
 			return transitions // if there are no current states for the rule. Create ones for each result
 		}
 	}
-	if st.applyNoDataAndErrorToAllStates && results.IsError() && (alertRule.ExecErrState == ngModels.AlertingErrState || alertRule.ExecErrState == ngModels.OkErrState) {
+	if st.applyNoDataAndErrorToAllStates && results.IsError() && (alertRule.ExecErrState == ngModels.AlertingErrState || alertRule.ExecErrState == ngModels.OkErrState || alertRule.ExecErrState == ngModels.KeepLastErrState) {
 		// TODO squash all errors into one, and provide as annotation
 		transitions := st.setNextStateForAll(ctx, alertRule, results[0], logger)
 		if len(transitions) > 0 {
@@ -352,11 +352,6 @@ func (st *Manager) setNextStateForAll(ctx context.Context, alertRule *ngModels.A
 // Set the current state based on evaluation results
 func (st *Manager) setNextState(ctx context.Context, alertRule *ngModels.AlertRule, currentState *State, result eval.Result, logger log.Logger) StateTransition {
 	start := st.clock.Now()
-
-	// If either no data or error state is set to keep last state, do so
-	if result.State == eval.NoData && alertRule.NoDataState == ngModels.KeepLast || result.State == eval.Error && alertRule.ExecErrState == ngModels.KeepLastErrState {
-		st.keepLastState(alertRule, currentState, &result)
-	}
 
 	currentState.LastEvaluationTime = result.EvaluatedAt
 	currentState.EvaluationDuration = result.EvaluationDuration
@@ -398,10 +393,10 @@ func (st *Manager) setNextState(ctx context.Context, alertRule *ngModels.AlertRu
 	switch result.State {
 	case eval.Normal:
 		logger.Debug("Setting next state", "handler", "resultNormal")
-		resultNormal(currentState, alertRule, result, logger)
+		resultNormal(currentState, alertRule, result, logger, "")
 	case eval.Alerting:
 		logger.Debug("Setting next state", "handler", "resultAlerting")
-		resultAlerting(currentState, alertRule, result, logger)
+		resultAlerting(currentState, alertRule, result, logger, "")
 	case eval.Error:
 		logger.Debug("Setting next state", "handler", "resultError")
 		resultError(currentState, alertRule, result, logger)
@@ -418,7 +413,7 @@ func (st *Manager) setNextState(ctx context.Context, alertRule *ngModels.AlertRu
 	if currentState.State != result.State &&
 		result.State != eval.Normal &&
 		result.State != eval.Alerting {
-		currentState.StateReason = result.State.String()
+		currentState.StateReason = resultStateReason(result, alertRule)
 	}
 
 	// Set Resolved property so the scheduler knows to send a postable alert
@@ -452,14 +447,12 @@ func (st *Manager) setNextState(ctx context.Context, alertRule *ngModels.AlertRu
 	return nextState
 }
 
-func (st *Manager) keepLastState(alertRule *ngModels.AlertRule, currentState *State, result *eval.Result) {
-	if currentState.State == eval.Pending && result.EvaluatedAt.Sub(currentState.StartsAt) >= alertRule.For {
-		// respect For duration if the current state is pending
-		result.State = eval.Alerting
-	} else {
-		// keep the current state
-		result.State = currentState.State
+func resultStateReason(result eval.Result, rule *ngModels.AlertRule) string {
+	if rule.ExecErrState == ngModels.KeepLastErrState || rule.NoDataState == ngModels.KeepLast {
+		return ngModels.ConcatReasons(result.State.String(), ngModels.StateReasonKeepLast)
 	}
+
+	return result.State.String()
 }
 
 func (st *Manager) GetAll(orgID int64) []*State {

--- a/pkg/services/ngalert/state/manager.go
+++ b/pkg/services/ngalert/state/manager.go
@@ -352,6 +352,12 @@ func (st *Manager) setNextStateForAll(ctx context.Context, alertRule *ngModels.A
 // Set the current state based on evaluation results
 func (st *Manager) setNextState(ctx context.Context, alertRule *ngModels.AlertRule, currentState *State, result eval.Result, logger log.Logger) StateTransition {
 	start := st.clock.Now()
+
+	// If either no data or error state is set to keep last state, don't update the state
+	if result.State == eval.NoData && alertRule.NoDataState == ngModels.KeepLast || result.State == eval.Error && alertRule.ExecErrState == ngModels.KeepLastErrState {
+		result.State = currentState.State
+	}
+
 	currentState.LastEvaluationTime = result.EvaluatedAt
 	currentState.EvaluationDuration = result.EvaluationDuration
 	currentState.Results = append(currentState.Results, Evaluation{

--- a/pkg/services/ngalert/state/manager_test.go
+++ b/pkg/services/ngalert/state/manager_test.go
@@ -876,7 +876,7 @@ func TestProcessEvalResults(t *testing.T) {
 			},
 		},
 		{
-			desc:      "normal -> normal -> alerting -> alerting - keeps last state when result is NoData and NoDataState is KeepLast",
+			desc:      "normal -> normal (NoData, KeepLastState) -> alerting -> alerting (NoData, KeepLastState) - keeps last state when result is NoData and NoDataState is KeepLast",
 			alertRule: baseRuleWith(models.WithForNTimes(0), models.WithNoDataExecAs(models.KeepLast)),
 			evalResults: map[time.Time]eval.Results{
 				t1: {
@@ -898,11 +898,12 @@ func TestProcessEvalResults(t *testing.T) {
 					Labels:            labels["system + rule + labels1"],
 					ResultFingerprint: labels1.Fingerprint(),
 					State:             eval.Alerting,
+					StateReason:       models.ConcatReasons(eval.NoData.String(), models.StateReasonKeepLast),
 					Results: []state.Evaluation{
 						newEvaluation(t1, eval.Normal),
-						newEvaluation(t2, eval.Normal),
+						newEvaluation(t2, eval.NoData),
 						newEvaluation(t3, eval.Alerting),
-						newEvaluation(tn(4), eval.Alerting),
+						newEvaluation(tn(4), eval.NoData),
 					},
 					StartsAt:           t3,
 					EndsAt:             tn(4).Add(state.ResendDelay * 4),
@@ -911,7 +912,7 @@ func TestProcessEvalResults(t *testing.T) {
 			},
 		},
 		{
-			desc:      "normal -> pending -> pending -> alerting - keep last state respects For when result is NoData",
+			desc:      "normal -> pending -> pending (NoData, KeepLastState) -> alerting (NoData, KeepLastState) - keep last state respects For when result is NoData",
 			alertRule: baseRuleWith(models.WithForNTimes(2), models.WithNoDataExecAs(models.KeepLast)),
 			evalResults: map[time.Time]eval.Results{
 				t1: {
@@ -933,9 +934,10 @@ func TestProcessEvalResults(t *testing.T) {
 					Labels:            labels["system + rule + labels1"],
 					ResultFingerprint: labels1.Fingerprint(),
 					State:             eval.Alerting,
+					StateReason:       models.ConcatReasons(eval.NoData.String(), models.StateReasonKeepLast),
 					Results: []state.Evaluation{
-						newEvaluation(t3, eval.Pending),
-						newEvaluation(tn(4), eval.Alerting),
+						newEvaluation(t3, eval.NoData),
+						newEvaluation(tn(4), eval.NoData),
 					},
 					StartsAt:           tn(4),
 					EndsAt:             tn(4).Add(state.ResendDelay * 4),
@@ -1081,7 +1083,7 @@ func TestProcessEvalResults(t *testing.T) {
 			},
 		},
 		{
-			desc:      "normal -> normal -> alerting -> alerting - keeps last state when result is Error and ExecErrState is KeepLast",
+			desc:      "normal -> normal (Error, KeepLastState) -> alerting -> alerting (Error, KeepLastState) - keeps last state when result is Error and ExecErrState is KeepLast",
 			alertRule: baseRuleWith(models.WithForNTimes(0), models.WithErrorExecAs(models.KeepLastErrState)),
 			evalResults: map[time.Time]eval.Results{
 				t1: {
@@ -1103,11 +1105,12 @@ func TestProcessEvalResults(t *testing.T) {
 					Labels:            labels["system + rule + labels1"],
 					ResultFingerprint: labels1.Fingerprint(),
 					State:             eval.Alerting,
+					StateReason:       models.ConcatReasons(eval.Error.String(), models.StateReasonKeepLast),
 					Results: []state.Evaluation{
 						newEvaluation(t1, eval.Normal),
-						newEvaluation(t2, eval.Normal),
+						newEvaluation(t2, eval.Error),
 						newEvaluation(t3, eval.Alerting),
-						newEvaluation(tn(4), eval.Alerting),
+						newEvaluation(tn(4), eval.Error),
 					},
 					StartsAt:           t3,
 					EndsAt:             tn(4).Add(state.ResendDelay * 4),
@@ -1116,7 +1119,7 @@ func TestProcessEvalResults(t *testing.T) {
 			},
 		},
 		{
-			desc:      "normal -> pending -> pending -> alerting - keep last state respects For when result is Error",
+			desc:      "normal -> pending -> pending (Error, KeepLastState) -> alerting (Error, KeepLastState) - keep last state respects For when result is Error",
 			alertRule: baseRuleWith(models.WithForNTimes(2), models.WithErrorExecAs(models.KeepLastErrState)),
 			evalResults: map[time.Time]eval.Results{
 				t1: {
@@ -1138,9 +1141,10 @@ func TestProcessEvalResults(t *testing.T) {
 					Labels:            labels["system + rule + labels1"],
 					ResultFingerprint: labels1.Fingerprint(),
 					State:             eval.Alerting,
+					StateReason:       models.ConcatReasons(eval.Error.String(), models.StateReasonKeepLast),
 					Results: []state.Evaluation{
-						newEvaluation(t3, eval.Pending),
-						newEvaluation(tn(4), eval.Alerting),
+						newEvaluation(t3, eval.Error),
+						newEvaluation(tn(4), eval.Error),
 					},
 					StartsAt:           tn(4),
 					EndsAt:             tn(4).Add(state.ResendDelay * 4),

--- a/pkg/services/ngalert/state/manager_test.go
+++ b/pkg/services/ngalert/state/manager_test.go
@@ -876,6 +876,41 @@ func TestProcessEvalResults(t *testing.T) {
 			},
 		},
 		{
+			desc:      "normal -> normal -> alerting -> alerting - keeps last state when result is NoData and NoDataState is KeepLast",
+			alertRule: baseRuleWith(models.WithForNTimes(0), models.WithNoDataExecAs(models.KeepLast)),
+			evalResults: map[time.Time]eval.Results{
+				t1: {
+					newResult(eval.WithState(eval.Normal), eval.WithLabels(labels1)),
+				},
+				t2: {
+					newResult(eval.WithState(eval.NoData), eval.WithLabels(labels1)), // TODO fix it because NoData does not have same labels
+				},
+				t3: {
+					newResult(eval.WithState(eval.Alerting), eval.WithLabels(labels1)),
+				},
+				tn(4): {
+					newResult(eval.WithState(eval.NoData), eval.WithLabels(labels1)), // TODO fix it because NoData does not have same labels
+				},
+			},
+			expectedAnnotations: 1,
+			expectedStates: []*state.State{
+				{
+					Labels:            labels["system + rule + labels1"],
+					ResultFingerprint: labels1.Fingerprint(),
+					State:             eval.Alerting,
+					Results: []state.Evaluation{
+						newEvaluation(t1, eval.Normal),
+						newEvaluation(t2, eval.Normal),
+						newEvaluation(t3, eval.Alerting),
+						newEvaluation(tn(4), eval.Alerting),
+					},
+					StartsAt:           t3,
+					EndsAt:             tn(4).Add(state.ResendDelay * 4),
+					LastEvaluationTime: tn(4),
+				},
+			},
+		},
+		{
 			desc:      "normal -> normal when result is NoData and NoDataState is ok",
 			alertRule: baseRuleWith(models.WithNoDataExecAs(models.OK)),
 			evalResults: map[time.Time]eval.Results{
@@ -1009,6 +1044,41 @@ func TestProcessEvalResults(t *testing.T) {
 					LastEvaluationTime: t2,
 					EvaluationDuration: evaluationDuration,
 					Annotations:        map[string]string{"annotation": "test", "Error": "[sse.dataQueryError] failed to execute query [A]: this is an error"},
+				},
+			},
+		},
+		{
+			desc:      "normal -> normal -> alerting -> alerting - keeps last state when result is Error and ExecErrState is KeepLast",
+			alertRule: baseRuleWith(models.WithForNTimes(0), models.WithErrorExecAs(models.KeepLastErrState)),
+			evalResults: map[time.Time]eval.Results{
+				t1: {
+					newResult(eval.WithState(eval.Normal), eval.WithLabels(labels1)),
+				},
+				t2: {
+					newResult(eval.WithError(expr.MakeQueryError("A", "datasource_uid_1", errors.New("this is an error"))), eval.WithLabels(labels1)), // TODO fix it because error labels are different
+				},
+				t3: {
+					newResult(eval.WithState(eval.Alerting), eval.WithLabels(labels1)),
+				},
+				tn(4): {
+					newResult(eval.WithError(expr.MakeQueryError("A", "datasource_uid_1", errors.New("this is an error"))), eval.WithLabels(labels1)), // TODO fix it because error labels are different
+				},
+			},
+			expectedAnnotations: 1,
+			expectedStates: []*state.State{
+				{
+					Labels:            labels["system + rule + labels1"],
+					ResultFingerprint: labels1.Fingerprint(),
+					State:             eval.Alerting,
+					Results: []state.Evaluation{
+						newEvaluation(t1, eval.Normal),
+						newEvaluation(t2, eval.Normal),
+						newEvaluation(t3, eval.Alerting),
+						newEvaluation(tn(4), eval.Alerting),
+					},
+					StartsAt:           t3,
+					EndsAt:             tn(4).Add(state.ResendDelay * 4),
+					LastEvaluationTime: tn(4),
 				},
 			},
 		},

--- a/pkg/services/ngalert/state/state.go
+++ b/pkg/services/ngalert/state/state.go
@@ -394,9 +394,9 @@ func resultKeepLast(state *State, rule *models.AlertRule, result eval.Result, lo
 		logger.Debug("Execution keep last state is Normal", "handler", "resultNormal")
 		resultNormal(state, rule, result, logger, reason)
 	default:
-		err := fmt.Errorf("unsupported keep last state: %s", state.State)
-		state.SetError(err, state.StartsAt, nextEndsTime(rule.IntervalSeconds, result.EvaluatedAt))
-		state.Annotations["Error"] = err.Error()
+		// this should not happen, add as failsafe
+		logger.Debug("Reverting invalid state to normal", "handler", "resultNormal")
+		resultNormal(state, rule, result, logger, reason)
 	}
 }
 

--- a/pkg/services/ngalert/state/state.go
+++ b/pkg/services/ngalert/state/state.go
@@ -265,6 +265,7 @@ func resultAlerting(state *State, rule *models.AlertRule, result eval.Result, lo
 		}
 	}
 }
+
 func resultError(state *State, rule *models.AlertRule, result eval.Result, logger log.Logger) {
 	switch rule.ExecErrState {
 	case models.AlertingErrState:

--- a/pkg/services/ngalert/state/state.go
+++ b/pkg/services/ngalert/state/state.go
@@ -191,7 +191,7 @@ func NewEvaluationValues(m map[string]eval.NumberValueCapture) map[string]*float
 	return result
 }
 
-func resultNormal(state *State, _ *models.AlertRule, result eval.Result, logger log.Logger) {
+func resultNormal(state *State, _ *models.AlertRule, result eval.Result, logger log.Logger, reason string) {
 	if state.State == eval.Normal {
 		logger.Debug("Keeping state", "state", state.State)
 	} else {
@@ -206,11 +206,11 @@ func resultNormal(state *State, _ *models.AlertRule, result eval.Result, logger 
 			"next_ends_at",
 			nextEndsAt)
 		// Normal states have the same start and end timestamps
-		state.SetNormal("", nextEndsAt, nextEndsAt)
+		state.SetNormal(reason, nextEndsAt, nextEndsAt)
 	}
 }
 
-func resultAlerting(state *State, rule *models.AlertRule, result eval.Result, logger log.Logger) {
+func resultAlerting(state *State, rule *models.AlertRule, result eval.Result, logger log.Logger, reason string) {
 	switch state.State {
 	case eval.Alerting:
 		prevEndsAt := state.EndsAt
@@ -235,7 +235,7 @@ func resultAlerting(state *State, rule *models.AlertRule, result eval.Result, lo
 				state.EndsAt,
 				"next_ends_at",
 				nextEndsAt)
-			state.SetAlerting("", result.EvaluatedAt, nextEndsAt)
+			state.SetAlerting(reason, result.EvaluatedAt, nextEndsAt)
 		}
 	default:
 		nextEndsAt := nextEndsTime(rule.IntervalSeconds, result.EvaluatedAt)
@@ -250,7 +250,7 @@ func resultAlerting(state *State, rule *models.AlertRule, result eval.Result, lo
 				state.EndsAt,
 				"next_ends_at",
 				nextEndsAt)
-			state.SetPending("", result.EvaluatedAt, nextEndsAt)
+			state.SetPending(reason, result.EvaluatedAt, nextEndsAt)
 		} else {
 			logger.Debug("Changing state",
 				"previous_state",
@@ -261,19 +261,20 @@ func resultAlerting(state *State, rule *models.AlertRule, result eval.Result, lo
 				state.EndsAt,
 				"next_ends_at",
 				nextEndsAt)
-			state.SetAlerting("", result.EvaluatedAt, nextEndsAt)
+			state.SetAlerting(reason, result.EvaluatedAt, nextEndsAt)
 		}
 	}
 }
 
 func resultError(state *State, rule *models.AlertRule, result eval.Result, logger log.Logger) {
+	handlerStr := "resultError"
+
 	switch rule.ExecErrState {
 	case models.AlertingErrState:
-		logger.Debug("Execution error state is Alerting", "handler", "resultAlerting", "previous_handler", "resultError")
-		resultAlerting(state, rule, result, logger)
+		logger.Debug("Execution error state is Alerting", "handler", "resultAlerting", "previous_handler", handlerStr)
+		resultAlerting(state, rule, result, logger, models.StateReasonError)
 		// This is a special case where Alerting and Pending should also have an error and reason
 		state.Error = result.Error
-		state.StateReason = models.StateReasonError
 	case models.ErrorErrState:
 		if state.State == eval.Error {
 			prevEndsAt := state.EndsAt
@@ -317,8 +318,10 @@ func resultError(state *State, rule *models.AlertRule, result eval.Result, logge
 			}
 		}
 	case models.OkErrState:
-		logger.Debug("Execution error state is Normal", "handler", "resultNormal", "previous_handler", "resultError")
-		resultNormal(state, rule, result, logger)
+		logger.Debug("Execution error state is Normal", "handler", "resultNormal", "previous_handler", handlerStr)
+		resultNormal(state, rule, result, logger, "") // TODO: Should we add a reason?
+	case models.KeepLastErrState:
+		resultKeepLast(state, rule, result, logger, handlerStr)
 	default:
 		err := fmt.Errorf("unsupported execution error state: %s", rule.ExecErrState)
 		state.SetError(err, state.StartsAt, nextEndsTime(rule.IntervalSeconds, result.EvaluatedAt))
@@ -327,11 +330,12 @@ func resultError(state *State, rule *models.AlertRule, result eval.Result, logge
 }
 
 func resultNoData(state *State, rule *models.AlertRule, result eval.Result, logger log.Logger) {
+	handlerStr := "resultNoData"
+
 	switch rule.NoDataState {
 	case models.Alerting:
-		logger.Debug("Execution no data state is Alerting", "handler", "resultAlerting", "previous_handler", "resultNoData")
-		resultAlerting(state, rule, result, logger)
-		state.StateReason = models.StateReasonNoData
+		logger.Debug("Execution no data state is Alerting", "handler", "resultAlerting", "previous_handler", handlerStr)
+		resultAlerting(state, rule, result, logger, models.StateReasonNoData)
 	case models.NoData:
 		if state.State == eval.NoData {
 			prevEndsAt := state.EndsAt
@@ -358,11 +362,37 @@ func resultNoData(state *State, rule *models.AlertRule, result eval.Result, logg
 			state.SetNoData("", result.EvaluatedAt, nextEndsAt)
 		}
 	case models.OK:
-		logger.Debug("Execution no data state is Normal", "handler", "resultNormal", "previous_handler", "resultNoData")
-		resultNormal(state, rule, result, logger)
-		state.StateReason = models.StateReasonNoData
+		logger.Debug("Execution no data state is Normal", "handler", "resultNormal", "previous_handler", handlerStr)
+		resultNormal(state, rule, result, logger, models.StateReasonNoData)
+	case models.KeepLast:
+		resultKeepLast(state, rule, result, logger, handlerStr)
 	default:
 		err := fmt.Errorf("unsupported no data state: %s", rule.NoDataState)
+		state.SetError(err, state.StartsAt, nextEndsTime(rule.IntervalSeconds, result.EvaluatedAt))
+		state.Annotations["Error"] = err.Error()
+	}
+}
+
+func resultKeepLast(state *State, rule *models.AlertRule, result eval.Result, logger log.Logger, previousHandler string) {
+	reason := models.ConcatReasons(result.State.String(), models.StateReasonKeepLast)
+
+	switch state.State {
+	case eval.Alerting:
+		logger.Debug("Execution keep last state is Alerting", "handler", "resultAlerting", "previous_handler", previousHandler)
+		resultAlerting(state, rule, result, logger, reason)
+	case eval.Pending:
+		// respect 'for' setting on rule
+		if result.EvaluatedAt.Sub(state.StartsAt) >= rule.For {
+			logger.Debug("Execution keep last state is Pending", "handler", "resultAlerting", "previous_handler", previousHandler)
+			resultAlerting(state, rule, result, logger, reason)
+		} else {
+			logger.Debug("Ignoring set next state to pending")
+		}
+	case eval.Normal:
+		logger.Debug("Execution keep last state is Normal", "handler", "resultNormal", "previous_handler", previousHandler)
+		resultNormal(state, rule, result, logger, reason)
+	default:
+		err := fmt.Errorf("unsupported keep last state: %s", state.State)
 		state.SetError(err, state.StartsAt, nextEndsTime(rule.IntervalSeconds, result.EvaluatedAt))
 		state.Annotations["Error"] = err.Error()
 	}

--- a/pkg/services/ngalert/state/state.go
+++ b/pkg/services/ngalert/state/state.go
@@ -526,12 +526,16 @@ func ParseFormattedState(stateStr string) (eval.State, string, error) {
 		}
 	}
 	if p == 0 {
-		return -1, "", errors.New("invalid state format")
+		p = len(stateStr)
 	}
 
 	state, err := eval.ParseStateString(stateStr[:p])
 	if err != nil {
 		return -1, "", err
+	}
+
+	if p == len(stateStr) {
+		return state, "", nil
 	}
 
 	reason := strings.Trim(stateStr[p+1:], "()")

--- a/pkg/services/ngalert/state/state.go
+++ b/pkg/services/ngalert/state/state.go
@@ -517,21 +517,24 @@ func FormatStateAndReason(state eval.State, reason string) string {
 // ParseFormattedState parses a state string in the format "state (reason)"
 // and returns the state and reason separately.
 func ParseFormattedState(stateStr string) (eval.State, string, error) {
-	split := strings.Split(stateStr, " ")
-	if len(split) == 0 {
+	p := 0
+	// walk string until we find a space
+	for i, c := range stateStr {
+		if c == ' ' {
+			p = i
+			break
+		}
+	}
+	if p == 0 {
 		return -1, "", errors.New("invalid state format")
 	}
 
-	state, err := eval.ParseStateString(split[0])
+	state, err := eval.ParseStateString(stateStr[:p])
 	if err != nil {
 		return -1, "", err
 	}
 
-	var reason string
-	if len(split) > 1 {
-		reason = strings.Trim(split[1], "()")
-	}
-
+	reason := strings.Trim(stateStr[p+1:], "()")
 	return state, reason, nil
 }
 

--- a/pkg/services/ngalert/state/state_test.go
+++ b/pkg/services/ngalert/state/state_test.go
@@ -681,6 +681,15 @@ func TestParseFormattedState(t *testing.T) {
 		require.Equal(t, ngmodels.StateReasonMissingSeries, reason)
 	})
 
+	t.Run("should parse formatted state with concatenated reasons", func(t *testing.T) {
+		stateStr := "Normal (Error, KeepLast)"
+		s, reason, err := ParseFormattedState(stateStr)
+		require.NoError(t, err)
+
+		require.Equal(t, eval.Normal, s)
+		require.Equal(t, ngmodels.ConcatReasons(ngmodels.StateReasonError, ngmodels.StateReasonKeepLast), reason)
+	})
+
 	t.Run("should error on empty string", func(t *testing.T) {
 		stateStr := ""
 		_, _, err := ParseFormattedState(stateStr)

--- a/public/app/features/alerting/unified/components/rule-editor/GrafanaAlertStatePicker.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/GrafanaAlertStatePicker.tsx
@@ -15,6 +15,7 @@ const options: SelectableValue[] = [
   { value: GrafanaAlertStateDecision.NoData, label: 'No Data' },
   { value: GrafanaAlertStateDecision.OK, label: 'OK' },
   { value: GrafanaAlertStateDecision.Error, label: 'Error' },
+  { value: GrafanaAlertStateDecision.KeepLast, label: 'Keep Last State' },
 ];
 
 export const GrafanaAlertStatePicker = ({ includeNoData, includeError, ...props }: Props) => {

--- a/public/app/types/unified-alerting-dto.ts
+++ b/public/app/types/unified-alerting-dto.ts
@@ -178,7 +178,7 @@ export interface RulerAlertingRuleDTO extends RulerRuleBaseDTO {
 export enum GrafanaAlertStateDecision {
   Alerting = 'Alerting',
   NoData = 'NoData',
-  KeepLastState = 'KeepLastState',
+  KeepLast = 'KeepLast',
   OK = 'OK',
   Error = 'Error',
 }


### PR DESCRIPTION
**What is this feature?**

This PR adds the backend functionality that emulates the "keep last state" feature from legacy alerting in Grafana managed alerting (GMA). 

Setting either NoDataState or ExecutionErrorState to `KeepLast` will persist the previous state of the alert instance and set the state reason to a concatenation of the evaluation result and `KeepLast`, e.g. `NoData, KeepLast`. This will respect the pending period (`for`) of a rule, which in practice means that associated alert instances will move to the `Alerting` state if the `Pending` state is kept for long. 

Some examples:

- t0:`[Normal] => [Normal]`, t1:`[NoData] => [Normal]`, t2:`[NoData] => [Normal]`
- with `for=2` - t0:`[Alerting] => [Pending]`, t1:`[NoData] => [Pending]`, t2:`[NoData] => [Alerting]`

**Why do we need this feature?**

This allows users to avoid being notified of no data and error evaluations on their alert rules. 

**Who is this feature for?**

Users of Grafana managed alerting. 

**Which issue(s) does this PR fix?**:

Resolves #82585
Related to #77800

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
