### PR TITLE
Alerting: Pass queryType parameter to the query model in recording rules preview

### DIFF
--- a/public/app/features/alerting/unified/components/rule-editor/RecordingRuleEditor.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/RecordingRuleEditor.tsx
@@ -68,8 +68,11 @@ export const RecordingRuleEditor: FC<RecordingRuleEditorProps> = ({
         datasource: changedQuery.datasource,
         refId: changedQuery.refId,
         editorMode: changedQuery.editorMode,
-        instant: Boolean(changedQuery.instant),
-        range: Boolean(changedQuery.range),
+        // Instant and range are used by Prometheus queries
+        instant: changedQuery.instant,
+        range: changedQuery.range,
+        // Query type is used by Loki queries
+        queryType: changedQuery.queryType,
         legendFormat: changedQuery.legendFormat,
       },
     };


### PR DESCRIPTION
**What is this feature?**
This pull request includes the addition of the `queryType` parameter in the query model sent to the eval endpoint. The Loki team is in the process of phasing out the `range` and `instant` properties, opting to use queryType instead.

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
