### PR TITLE
Alerting: Improve alert list panel and alert rules toolbar permissions handling

### DIFF
--- a/public/app/features/alerting/unified/initAlerting.tsx
+++ b/public/app/features/alerting/unified/initAlerting.tsx
@@ -1,21 +1,29 @@
 import React from 'react';
 
 import { config } from '@grafana/runtime';
+import { contextSrv } from 'app/core/services/context_srv';
 
 import { addCustomRightAction } from '../../dashboard/components/DashNav/DashNav';
+
+import { getRulesPermissions } from './utils/access-control';
+import { GRAFANA_RULES_SOURCE_NAME } from './utils/datasource';
 
 const AlertRulesToolbarButton = React.lazy(
   () => import(/* webpackChunkName: "alert-rules-toolbar-button" */ './integration/AlertRulesToolbarButton')
 );
 
 export function initAlerting() {
-  addCustomRightAction({
-    show: () => config.unifiedAlertingEnabled || (config.featureToggles.alertingPreviewUpgrade ?? false),
-    component: ({ dashboard }) => (
-      <React.Suspense fallback={null} key="alert-rules-button">
-        {dashboard && <AlertRulesToolbarButton dashboardUid={dashboard.uid} />}
-      </React.Suspense>
-    ),
-    index: -2,
-  });
+  const grafanaRulesPermissions = getRulesPermissions(GRAFANA_RULES_SOURCE_NAME);
+
+  if (contextSrv.hasPermission(grafanaRulesPermissions.read)) {
+    addCustomRightAction({
+      show: () => config.unifiedAlertingEnabled || (config.featureToggles.alertingPreviewUpgrade ?? false),
+      component: ({ dashboard }) => (
+        <React.Suspense fallback={null} key="alert-rules-button">
+          {dashboard && <AlertRulesToolbarButton dashboardUid={dashboard.uid} />}
+        </React.Suspense>
+      ),
+      index: -2,
+    });
+  }
 }

--- a/public/app/plugins/panel/alertlist/UnifiedAlertList.tsx
+++ b/public/app/plugins/panel/alertlist/UnifiedAlertList.tsx
@@ -16,7 +16,6 @@ import {
   useStyles2,
 } from '@grafana/ui';
 import { config } from 'app/core/config';
-import { contextSrv } from 'app/core/services/context_srv';
 import alertDef from 'app/features/alerting/state/alertDef';
 import { alertRuleApi } from 'app/features/alerting/unified/api/alertRuleApi';
 import { INSTANCES_DISPLAY_LIMIT } from 'app/features/alerting/unified/components/rules/RuleDetails';
@@ -38,10 +37,10 @@ import { flattenCombinedRules, getFirstActiveAt } from 'app/features/alerting/un
 import { getDashboardSrv } from 'app/features/dashboard/services/DashboardSrv';
 import { DashboardModel } from 'app/features/dashboard/state';
 import { Matcher } from 'app/plugins/datasource/alertmanager/types';
-import { AccessControlAction, ThunkDispatch, useDispatch } from 'app/types';
+import { ThunkDispatch, useDispatch } from 'app/types';
 import { PromAlertingRuleState } from 'app/types/unified-alerting-dto';
 
-import { getRulesPermissions } from '../../../features/alerting/unified/utils/access-control';
+import { AlertingAction, useAlertingAbility } from '../../../features/alerting/unified/hooks/useAbilities';
 import { getAlertingRule } from '../../../features/alerting/unified/utils/rules';
 import { AlertingRule, CombinedRuleWithLocation } from '../../../types/unified-alerting';
 
@@ -97,6 +96,7 @@ const fetchPromAndRuler = ({
 function UnifiedAlertList(props: PanelProps<UnifiedAlertListOptions>) {
   const dispatch = useDispatch();
   const [limitInstances, toggleLimit] = useToggle(true);
+  const [, gmaViewAllowed] = useAlertingAbility(AlertingAction.ViewAlertRule);
 
   const { usePrometheusRulesByNamespaceQuery } = alertRuleApi;
 
@@ -138,9 +138,7 @@ function UnifiedAlertList(props: PanelProps<UnifiedAlertListOptions>) {
 
   // If the datasource is not defined we should NOT skip the query
   // Undefined dataSourceName means that there is no datasource filter applied and we should fetch all the rules
-  const shouldFetchGrafanaRules =
-    (!dataSourceName || dataSourceName === GRAFANA_RULES_SOURCE_NAME) &&
-    contextSrv.hasPermission(getRulesPermissions(GRAFANA_RULES_SOURCE_NAME).read);
+  const shouldFetchGrafanaRules = (!dataSourceName || dataSourceName === GRAFANA_RULES_SOURCE_NAME) && gmaViewAllowed;
 
   //For grafana managed rules, get the result using RTK Query to avoid the need of using the redux store
   //See https://github.com/grafana/grafana/pull/70482
@@ -452,10 +450,10 @@ export const getStyles = (theme: GrafanaTheme2) => ({
 });
 
 export function UnifiedAlertListPanel(props: PanelProps<UnifiedAlertListOptions>) {
-  if (
-    !contextSrv.hasPermission(AccessControlAction.AlertingRuleRead) &&
-    !contextSrv.hasPermission(AccessControlAction.AlertingRuleExternalRead)
-  ) {
+  const [, gmaReadAllowed] = useAlertingAbility(AlertingAction.ViewAlertRule);
+  const [, externalReadAllowed] = useAlertingAbility(AlertingAction.ViewExternalAlertRule);
+
+  if (!gmaReadAllowed && !externalReadAllowed) {
     return (
       <Alert title="Permission required">Sorry, you do not have the required permissions to read alert rules</Alert>
     );

--- a/public/app/plugins/panel/alertlist/UnifiedalertList.test.tsx
+++ b/public/app/plugins/panel/alertlist/UnifiedalertList.test.tsx
@@ -2,7 +2,6 @@ import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import React from 'react';
 import { Provider } from 'react-redux';
-import { act } from 'react-test-renderer';
 import { byRole, byText } from 'testing-library-selector';
 
 import { FieldConfigSource, getDefaultTimeRange, LoadingState, PanelProps, PluginExtensionTypes } from '@grafana/data';
@@ -170,9 +169,7 @@ describe('UnifiedAlertList', () => {
   it('subscribes to the dashboard refresh interval', async () => {
     jest.spyOn(defaultProps, 'replaceVariables').mockReturnValue('severity=critical');
 
-    await act(async () => {
-      renderPanel();
-    });
+    renderPanel();
 
     expect(dashboard.events.subscribe).toHaveBeenCalledTimes(1);
     expect(dashboard.events.subscribe.mock.calls[0][0]).toEqual(TimeRangeUpdatedEvent);
@@ -188,14 +185,12 @@ describe('UnifiedAlertList', () => {
 
     const user = userEvent.setup();
 
-    await act(async () => {
-      renderPanel({
-        alertInstanceLabelFilter: '$label',
-        dashboardAlerts: false,
-        alertName: '',
-        datasource: GRAFANA_RULES_SOURCE_NAME,
-        folder: undefined,
-      });
+    renderPanel({
+      alertInstanceLabelFilter: '$label',
+      dashboardAlerts: false,
+      alertName: '',
+      datasource: GRAFANA_RULES_SOURCE_NAME,
+      folder: undefined,
     });
 
     await waitFor(() => {
@@ -227,9 +222,7 @@ describe('UnifiedAlertList', () => {
   it('should render authorization error when user has no permission', async () => {
     jest.spyOn(contextSrv, 'hasPermission').mockReturnValue(false);
 
-    await act(async () => {
-      renderPanel();
-    });
+    renderPanel();
 
     expect(screen.getByRole('alert', { name: 'Permission required' })).toBeInTheDocument();
   });

--- a/public/app/plugins/panel/alertlist/UnifiedalertList.test.tsx
+++ b/public/app/plugins/panel/alertlist/UnifiedalertList.test.tsx
@@ -25,7 +25,7 @@ import {
 } from '../../../features/alerting/unified/mocks';
 import { GRAFANA_RULES_SOURCE_NAME } from '../../../features/alerting/unified/utils/datasource';
 
-import { UnifiedAlertList } from './UnifiedAlertList';
+import { UnifiedAlertListPanel } from './UnifiedAlertList';
 import { GroupMode, SortOrder, UnifiedAlertListOptions, ViewMode } from './types';
 import * as utils from './util';
 
@@ -159,12 +159,14 @@ const renderPanel = (options: Partial<UnifiedAlertListOptions> = defaultOptions)
 
   return render(
     <Provider store={store}>
-      <UnifiedAlertList {...props} />
+      <UnifiedAlertListPanel {...props} />
     </Provider>
   );
 };
 
 describe('UnifiedAlertList', () => {
+  jest.spyOn(contextSrv, 'hasPermission').mockReturnValue(true);
+
   it('subscribes to the dashboard refresh interval', async () => {
     jest.spyOn(defaultProps, 'replaceVariables').mockReturnValue('severity=critical');
 
@@ -180,7 +182,6 @@ describe('UnifiedAlertList', () => {
     await waitFor(() => {
       expect(screen.queryByText('Loading...')).not.toBeInTheDocument();
     });
-    jest.spyOn(contextSrv, 'hasPermission').mockReturnValue(true);
     const filterAlertsSpy = jest.spyOn(utils, 'filterAlerts');
 
     const replaceVarsSpy = jest.spyOn(defaultProps, 'replaceVariables').mockReturnValue('severity=critical');
@@ -221,5 +222,15 @@ describe('UnifiedAlertList', () => {
       }),
       expect.anything()
     );
+  });
+
+  it('should render authorization error when user has no permission', async () => {
+    jest.spyOn(contextSrv, 'hasPermission').mockReturnValue(false);
+
+    await act(async () => {
+      renderPanel();
+    });
+
+    expect(screen.getByRole('alert', { name: 'Permission required' })).toBeInTheDocument();
   });
 });

--- a/public/app/plugins/panel/alertlist/UnifiedalertList.test.tsx
+++ b/public/app/plugins/panel/alertlist/UnifiedalertList.test.tsx
@@ -171,7 +171,7 @@ describe('UnifiedAlertList', () => {
 
     renderPanel();
 
-    expect(dashboard.events.subscribe).toHaveBeenCalledTimes(1);
+    await waitFor(() => expect(dashboard.events.subscribe).toHaveBeenCalledTimes(1));
     expect(dashboard.events.subscribe.mock.calls[0][0]).toEqual(TimeRangeUpdatedEvent);
   });
 

--- a/public/app/plugins/panel/alertlist/module.tsx
+++ b/public/app/plugins/panel/alertlist/module.tsx
@@ -17,7 +17,7 @@ import { GRAFANA_DATASOURCE_NAME } from '../../../features/alerting/unified/util
 import { AlertList } from './AlertList';
 import { alertListPanelMigrationHandler } from './AlertListMigrationHandler';
 import { GroupBy } from './GroupByWithLoading';
-import { UnifiedAlertList } from './UnifiedAlertList';
+import { UnifiedAlertListPanel } from './UnifiedAlertList';
 import { AlertListSuggestionsSupplier } from './suggestions';
 import { AlertListOptions, GroupMode, ShowOption, SortOrder, UnifiedAlertListOptions, ViewMode } from './types';
 
@@ -156,7 +156,7 @@ const alertList = new PanelPlugin<AlertListOptions>(AlertList)
   .setMigrationHandler(alertListPanelMigrationHandler)
   .setSuggestionsSupplier(new AlertListSuggestionsSupplier());
 
-const unifiedAlertList = new PanelPlugin<UnifiedAlertListOptions>(UnifiedAlertList).setPanelOptions((builder) => {
+const unifiedAlertList = new PanelPlugin<UnifiedAlertListOptions>(UnifiedAlertListPanel).setPanelOptions((builder) => {
   builder
     .addRadio({
       path: 'viewMode',


### PR DESCRIPTION
**What is this feature?**
This PR fixes `AlertList` panel and `AlertRulesToolbar` behaviour when the user lacks necessary alerting permissions
The PR introduces earlier permissions checking to avoid futile alerting API calls and 403 errors


Fixes #83872

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
