### PR TITLE
Dashboard: Fix issue where out-of-view shared query panels caused blank dependent panels

### DIFF
--- a/public/app/features/dashboard/dashgrid/PanelStateWrapper.test.tsx
+++ b/public/app/features/dashboard/dashgrid/PanelStateWrapper.test.tsx
@@ -74,6 +74,8 @@ function setupTestContext(options: Partial<Props>) {
     </Provider>
   );
 
+  // Needed so mocks work
+  props.panel.refreshWhenInView = false;
   return { rerender, props, subject, store };
 }
 

--- a/public/app/features/dashboard/state/DashboardModel.ts
+++ b/public/app/features/dashboard/state/DashboardModel.ts
@@ -440,10 +440,21 @@ export class DashboardModel implements TimeModel {
       return;
     }
 
-    for (const panel of this.panels) {
-      if (!this.otherPanelInFullscreen(panel) && (event.refreshAll || event.panelIds.includes(panel.id))) {
-        panel.refresh();
+    const panelsToRefresh = this.panels.filter(
+      (panel) => !this.otherPanelInFullscreen(panel) && (event.refreshAll || event.panelIds.includes(panel.id))
+    );
+
+    // We have to mark every panel as refreshWhenInView /before/ we actually refresh any
+    // in case there is a shared query, as otherwise that might refresh before the source panel is
+    // marked for refresh, preventing the panel from updating
+    if (!this.isSnapshot()) {
+      for (const panel of panelsToRefresh) {
+        panel.refreshWhenInView = true;
       }
+    }
+
+    for (const panel of panelsToRefresh) {
+      panel.refresh();
     }
   }
 

--- a/public/app/features/dashboard/state/PanelModel.ts
+++ b/public/app/features/dashboard/state/PanelModel.ts
@@ -203,7 +203,7 @@ export class PanelModel implements DataConfigSource, IPanelModel {
   cacheTimeout?: string | null;
   queryCachingTTL?: number | null;
   isNew?: boolean;
-  refreshWhenInView = false;
+  refreshWhenInView = true;
 
   cachedPluginOptions: Record<string, PanelOptionsCache> = {};
   legend?: { show: boolean; sort?: string; sortDesc?: boolean };


### PR DESCRIPTION
Coming from an [escalation](https://github.com/grafana/support-escalations/issues/9555)

Fixes an issue where if we have a dashboard with panels using the dashboard data source whose source panel is out of view, those first panels show as empty.