### PR TITLE
Scenes: Remove normal and library panels from layout or rows

### DIFF
--- a/public/app/features/dashboard-scene/scene/DashboardScene.test.tsx
+++ b/public/app/features/dashboard-scene/scene/DashboardScene.test.tsx
@@ -25,6 +25,7 @@ import { djb2Hash } from '../utils/djb2Hash';
 
 import { DashboardControls } from './DashboardControls';
 import { DashboardScene, DashboardSceneState } from './DashboardScene';
+import { LibraryVizPanel } from './LibraryVizPanel';
 
 jest.mock('../settings/version-history/HistorySrv');
 jest.mock('../serialization/transformSaveModelToScene');
@@ -244,7 +245,7 @@ describe('DashboardScene', () => {
         const body = scene.state.body as SceneGridLayout;
         const gridItem = body.state.children[0] as SceneGridItem;
 
-        expect(body.state.children.length).toBe(5);
+        expect(body.state.children.length).toBe(6);
         expect(gridItem.state.body!.state.key).toBe('panel-5');
         expect(gridItem.state.y).toBe(0);
       });
@@ -255,8 +256,8 @@ describe('DashboardScene', () => {
         const body = scene.state.body as SceneGridLayout;
         const gridItem = body.state.children[0] as SceneGridItem;
 
-        expect(body.state.children.length).toBe(5);
-        expect(gridItem.state.body!.state.key).toBe('panel-5');
+        expect(body.state.children.length).toBe(6);
+        expect(gridItem.state.body!.state.key).toBe('panel-7');
       });
 
       it('Should create and add a new row to the dashboard', () => {
@@ -265,8 +266,8 @@ describe('DashboardScene', () => {
         const body = scene.state.body as SceneGridLayout;
         const gridRow = body.state.children[0] as SceneGridRow;
 
-        expect(body.state.children.length).toBe(3);
-        expect(gridRow.state.key).toBe('panel-5');
+        expect(body.state.children.length).toBe(4);
+        expect(gridRow.state.key).toBe('panel-7');
         expect(gridRow.state.children[0].state.key).toBe('griditem-1');
         expect(gridRow.state.children[1].state.key).toBe('griditem-2');
       });
@@ -313,7 +314,7 @@ describe('DashboardScene', () => {
         const body = scene.state.body as SceneGridLayout;
         const gridRow = body.state.children[0] as SceneGridRow;
 
-        expect(body.state.children.length).toBe(4);
+        expect(body.state.children.length).toBe(5);
         expect(gridRow.state.children.length).toBe(0);
       });
 
@@ -359,8 +360,8 @@ describe('DashboardScene', () => {
         const body = scene.state.body as SceneGridLayout;
         const gridItem = body.state.children[0] as SceneGridItem;
 
-        expect(body.state.children.length).toBe(5);
-        expect(gridItem.state.body!.state.key).toBe('panel-5');
+        expect(body.state.children.length).toBe(6);
+        expect(gridItem.state.body!.state.key).toBe('panel-7');
         expect(gridItem.state.y).toBe(0);
         expect(scene.state.hasCopiedPanel).toBe(false);
       });
@@ -371,9 +372,50 @@ describe('DashboardScene', () => {
         const body = scene.state.body as SceneGridLayout;
         const gridItem = body.state.children[0] as SceneGridItem;
 
-        expect(body.state.children.length).toBe(5);
-        expect(gridItem.state.body!.state.key).toBe('panel-5');
+        expect(body.state.children.length).toBe(6);
+        expect(gridItem.state.body!.state.key).toBe('panel-7');
         expect(gridItem.state.y).toBe(0);
+      });
+
+      it('Should remove a panel', () => {
+        const vizPanel = ((scene.state.body as SceneGridLayout).state.children[0] as SceneGridItem).state.body;
+        scene.removePanel(vizPanel as VizPanel);
+
+        const body = scene.state.body as SceneGridLayout;
+        expect(body.state.children.length).toBe(4);
+      });
+
+      it('Should remove a panel within a row', () => {
+        const vizPanel = (
+          ((scene.state.body as SceneGridLayout).state.children[2] as SceneGridRow).state.children[0] as SceneGridItem
+        ).state.body;
+        scene.removePanel(vizPanel as VizPanel);
+
+        const body = scene.state.body as SceneGridLayout;
+        const gridRow = body.state.children[2] as SceneGridRow;
+        expect(gridRow.state.children.length).toBe(1);
+      });
+
+      it('Should remove a library panel', () => {
+        const libraryPanel = ((scene.state.body as SceneGridLayout).state.children[4] as SceneGridItem).state.body;
+        const vizPanel = (libraryPanel as LibraryVizPanel).state.panel;
+        scene.removePanel(vizPanel as VizPanel);
+
+        const body = scene.state.body as SceneGridLayout;
+        expect(body.state.children.length).toBe(4);
+      });
+
+      it('Should remove a library panel within a row', () => {
+        const libraryPanel = (
+          ((scene.state.body as SceneGridLayout).state.children[2] as SceneGridRow).state.children[1] as SceneGridItem
+        ).state.body;
+        const vizPanel = (libraryPanel as LibraryVizPanel).state.panel;
+
+        scene.removePanel(vizPanel as VizPanel);
+
+        const body = scene.state.body as SceneGridLayout;
+        const gridRow = body.state.children[2] as SceneGridRow;
+        expect(gridRow.state.children.length).toBe(1);
       });
     });
   });
@@ -565,6 +607,19 @@ function buildTestScene(overrides?: Partial<DashboardSceneState>) {
                 pluginId: 'table',
               }),
             }),
+            new SceneGridItem({
+              body: new LibraryVizPanel({
+                uid: 'uid',
+                name: 'libraryPanel',
+                panelKey: 'panel-5',
+                title: 'Library Panel',
+                panel: new VizPanel({
+                  title: 'Library Panel',
+                  key: 'panel-5',
+                  pluginId: 'table',
+                }),
+              }),
+            }),
           ],
         }),
         new SceneGridItem({
@@ -573,6 +628,19 @@ function buildTestScene(overrides?: Partial<DashboardSceneState>) {
             key: 'panel-2-clone-1',
             pluginId: 'table',
             $data: new SceneQueryRunner({ key: 'data-query-runner2', queries: [{ refId: 'A' }] }),
+          }),
+        }),
+        new SceneGridItem({
+          body: new LibraryVizPanel({
+            uid: 'uid',
+            name: 'libraryPanel',
+            panelKey: 'panel-6',
+            title: 'Library Panel',
+            panel: new VizPanel({
+              title: 'Library Panel',
+              key: 'panel-6',
+              pluginId: 'table',
+            }),
           }),
         }),
       ],

--- a/public/app/features/dashboard-scene/scene/DashboardScene.tsx
+++ b/public/app/features/dashboard-scene/scene/DashboardScene.tsx
@@ -585,16 +585,7 @@ export class DashboardScene extends SceneObjectBase<DashboardSceneState> {
 
       row.setState({ children: panels });
 
-      const layout = this.state.body;
-
-      if (layout instanceof SceneGridLayout || layout instanceof SceneFlexLayout) {
-        const children: SceneObject[] = layout.state.children;
-        const index = children.findIndex((child) => child.state.key === row?.state.key);
-
-        children.splice(index, 1, row);
-
-        layout.setState({ children });
-      }
+      this.state.body.forceRender();
 
       return;
     }

--- a/public/app/features/dashboard-scene/scene/PanelMenuBehavior.tsx
+++ b/public/app/features/dashboard-scene/scene/PanelMenuBehavior.tsx
@@ -8,16 +8,7 @@ import {
   urlUtil,
 } from '@grafana/data';
 import { config, getPluginLinkExtensions, locationService } from '@grafana/runtime';
-import {
-  LocalValueVariable,
-  SceneFlexLayout,
-  SceneGridLayout,
-  SceneGridRow,
-  SceneObject,
-  VizPanel,
-  VizPanelMenu,
-  sceneGraph,
-} from '@grafana/scenes';
+import { LocalValueVariable, SceneGridRow, VizPanel, VizPanelMenu, sceneGraph } from '@grafana/scenes';
 import { DataQuery, OptionsWithLegend } from '@grafana/schema';
 import appEvents from 'app/core/app_events';
 import { t } from 'app/core/internationalization';
@@ -203,7 +194,7 @@ export function panelMenuBehavior(menu: VizPanelMenu) {
       iconClassName: 'trash-alt',
       onClick: () => {
         DashboardInteractions.panelMenuItemClicked('remove');
-        removePanel(dashboard, panel, true);
+        onRemovePanel(dashboard, panel);
       },
       shortcut: 'p r',
     });
@@ -377,7 +368,7 @@ function createExtensionContext(panel: VizPanel, dashboard: DashboardScene): Plu
   };
 }
 
-export function removePanel(dashboard: DashboardScene, panel: VizPanel, ask: boolean) {
+export function onRemovePanel(dashboard: DashboardScene, panel: VizPanel) {
   const vizPanelData = sceneGraph.getData(panel);
   let panelHasAlert = false;
 
@@ -385,40 +376,23 @@ export function removePanel(dashboard: DashboardScene, panel: VizPanel, ask: boo
     panelHasAlert = true;
   }
 
-  if (ask !== false) {
-    const text2 =
-      panelHasAlert && !config.unifiedAlertingEnabled
-        ? 'Panel includes an alert rule. removing the panel will also remove the alert rule'
-        : undefined;
-    const confirmText = panelHasAlert ? 'YES' : undefined;
+  const text2 =
+    panelHasAlert && !config.unifiedAlertingEnabled
+      ? 'Panel includes an alert rule. removing the panel will also remove the alert rule'
+      : undefined;
+  const confirmText = panelHasAlert ? 'YES' : undefined;
 
-    appEvents.publish(
-      new ShowConfirmModalEvent({
-        title: 'Remove panel',
-        text: 'Are you sure you want to remove this panel?',
-        text2: text2,
-        icon: 'trash-alt',
-        confirmText: confirmText,
-        yesText: 'Remove',
-        onConfirm: () => removePanel(dashboard, panel, false),
-      })
-    );
-
-    return;
-  }
-
-  const panels: SceneObject[] = [];
-  dashboard.state.body.forEachChild((child: SceneObject) => {
-    if (child.state.key !== panel.parent?.state.key) {
-      panels.push(child);
-    }
-  });
-
-  const layout = dashboard.state.body;
-
-  if (layout instanceof SceneGridLayout || SceneFlexLayout) {
-    layout.setState({ children: panels });
-  }
+  appEvents.publish(
+    new ShowConfirmModalEvent({
+      title: 'Remove panel',
+      text: 'Are you sure you want to remove this panel?',
+      text2: text2,
+      icon: 'trash-alt',
+      confirmText: confirmText,
+      yesText: 'Remove',
+      onConfirm: () => dashboard.removePanel(panel),
+    })
+  );
 }
 
 const onCreateAlert = async (panel: VizPanel) => {

--- a/public/app/features/dashboard-scene/scene/keyboardShortcuts.ts
+++ b/public/app/features/dashboard-scene/scene/keyboardShortcuts.ts
@@ -8,7 +8,7 @@ import { getEditPanelUrl, getInspectUrl, getViewPanelUrl, tryGetExploreUrlForPan
 import { getPanelIdForVizPanel } from '../utils/utils';
 
 import { DashboardScene } from './DashboardScene';
-import { removePanel, toggleVizPanelLegend } from './PanelMenuBehavior';
+import { onRemovePanel, toggleVizPanelLegend } from './PanelMenuBehavior';
 
 export function setupKeyboardShortcuts(scene: DashboardScene) {
   const keybindings = new KeybindingSet();
@@ -120,7 +120,7 @@ export function setupKeyboardShortcuts(scene: DashboardScene) {
   keybindings.addBinding({
     key: 'p r',
     onTrigger: withFocusedPanel(scene, (vizPanel: VizPanel) => {
-      removePanel(scene, vizPanel, true);
+      onRemovePanel(scene, vizPanel);
     }),
   });
 


### PR DESCRIPTION
Allows panels and library panels to be removed through the panel menu. Also works for panels and library panels within rows.

Closes https://github.com/grafana/grafana/issues/83891
Closes https://github.com/grafana/grafana/issues/83477