### PR TITLE
Chore: Remove deprecated exploreId from QueryEditorProps

### DIFF
--- a/packages/grafana-data/src/types/datasource.ts
+++ b/packages/grafana-data/src/types/datasource.ts
@@ -429,10 +429,6 @@ export interface QueryEditorProps<
    */
   data?: PanelData;
   range?: TimeRange;
-  /**
-   * @deprecated This is not used anymore and will be removed in a future release.
-   */
-  exploreId?: string;
   history?: Array<HistoryItem<TQuery>>;
   queries?: DataQuery[];
   app?: CoreApp;


### PR DESCRIPTION
Removes the deprecated (in `10.3`) `exploreId` property from`QueryEditorProps`.

Fixes #78747

# Release notice breaking change

Since https://github.com/grafana/grafana/pull/38942 `exploreId` is no longer supplied to query editors in Explore. The property was deprecated in `10.3.0` and is now removed. If your query editor needs to know from which app is being rendered, you can check the `app` prop in `QueryEditorProps`.