### PR TITLE
Chore: Remove deprecated ExploreQueryFieldProps

### DIFF
--- a/packages/grafana-data/src/types/datasource.ts
+++ b/packages/grafana-data/src/types/datasource.ts
@@ -445,15 +445,6 @@ export enum ExploreMode {
   Tracing = 'Tracing',
 }
 
-/**
- * @deprecated use QueryEditorProps instead
- */
-export type ExploreQueryFieldProps<
-  DSType extends DataSourceApi<TQuery, TOptions>,
-  TQuery extends DataQuery = DataQuery,
-  TOptions extends DataSourceJsonData = DataSourceJsonData,
-> = QueryEditorProps<DSType, TQuery, TOptions>;
-
 export interface QueryEditorHelpProps<TQuery extends DataQuery = DataQuery> {
   datasource: DataSourceApi<TQuery>;
   query: TQuery;


### PR DESCRIPTION
Since https://github.com/grafana/grafana/pull/38942 (grafana `8.2.0`) the `ExploreQueryFieldProps` type was deprecated. This PR removes it.

# Release notice breaking change

Since https://github.com/grafana/grafana/pull/38942 (Grafana `8.2.0`) the `ExploreQueryFieldProps` type was deprecated and is now removed.