### PR TITLE
Explore: Remove deprecated `query` option from `splitOpen`

### DIFF
--- a/packages/grafana-data/src/types/explore.ts
+++ b/packages/grafana-data/src/types/explore.ts
@@ -58,7 +58,7 @@ export interface ExploreLogsPanelState {
 
 export interface SplitOpenOptions<T extends AnyQuery = AnyQuery> {
   datasourceUid: string;
-  queries?: T[];
+  queries: T[];
   range?: TimeRange;
   panelsState?: ExplorePanelsState;
   correlationHelperData?: ExploreCorrelationHelperData;

--- a/packages/grafana-data/src/types/explore.ts
+++ b/packages/grafana-data/src/types/explore.ts
@@ -58,8 +58,6 @@ export interface ExploreLogsPanelState {
 
 export interface SplitOpenOptions<T extends AnyQuery = AnyQuery> {
   datasourceUid: string;
-  /** @deprecated Will be removed in a future version. Use queries instead. */
-  query?: T;
   queries?: T[];
   range?: TimeRange;
   panelsState?: ExplorePanelsState;

--- a/public/app/features/explore/state/main.ts
+++ b/public/app/features/explore/state/main.ts
@@ -61,13 +61,16 @@ export const setPaneState = createAction<SetPaneStateActionPayload>('explore/set
 export const clearPanes = createAction('explore/clearPanes');
 
 /**
- * Ensure Explore doesn't exceed supported number of panes and initializes the new pane.
+ * Creates a new Explore pane.
+ * If 2 panes already exist, the last one (right) is closed before creating a new one.
  */
 export const splitOpen = createAsyncThunk(
   'explore/splitOpen',
   async (options: SplitOpenOptions | undefined, { getState, dispatch }) => {
     // we currently support showing only 2 panes in explore, so if this action is dispatched we know it has been dispatched from the "first" pane.
     const originState = Object.values(getState().explore.panes)[0];
+
+    const queries = options?.queries ?? originState?.queries ?? [];
 
     Object.keys(getState().explore.panes).forEach((paneId, index) => {
       // Only 2 panes are supported. Remove panes before create a new one.
@@ -88,7 +91,7 @@ export const splitOpen = createAsyncThunk(
       createNewSplitOpenPane({
         exploreId: newPaneId,
         datasource: options?.datasourceUid || originState?.datasourceInstance?.getRef(),
-        queries: options?.queries ? withUniqueRefIds(options.queries) : [],
+        queries: withUniqueRefIds(queries),
         range: splitRange,
         panelsState: options?.panelsState || originState?.panelsState,
         correlationHelperData: options?.correlationHelperData,

--- a/public/app/features/explore/state/main.ts
+++ b/public/app/features/explore/state/main.ts
@@ -69,8 +69,6 @@ export const splitOpen = createAsyncThunk(
     // we currently support showing only 2 panes in explore, so if this action is dispatched we know it has been dispatched from the "first" pane.
     const originState = Object.values(getState().explore.panes)[0];
 
-    const queries = options?.queries ?? (options?.query ? [options?.query] : originState?.queries || []);
-
     Object.keys(getState().explore.panes).forEach((paneId, index) => {
       // Only 2 panes are supported. Remove panes before create a new one.
       if (index >= 1) {
@@ -90,7 +88,7 @@ export const splitOpen = createAsyncThunk(
       createNewSplitOpenPane({
         exploreId: newPaneId,
         datasource: options?.datasourceUid || originState?.datasourceInstance?.getRef(),
-        queries: withUniqueRefIds(queries),
+        queries: options?.queries ? withUniqueRefIds(options.queries) : [],
         range: splitRange,
         panelsState: options?.panelsState || originState?.panelsState,
         correlationHelperData: options?.correlationHelperData,


### PR DESCRIPTION
The `query` option in `splitOpen` was deprecated in `10.1` and is now being removed.

Fixes #71531

# Release notice breaking change

The `query` option in `splitOpen` was deprecated in `10.1` and is now being removed.
