### PR TITLE
Histogram: Fix heuristic for x axis distribution from bucket progression

### DIFF
--- a/packages/grafana-data/src/transformations/transformers/histogram.ts
+++ b/packages/grafana-data/src/transformations/transformers/histogram.ts
@@ -403,7 +403,7 @@ export function buildHistogram(frames: DataFrame[], options?: HistogramTransform
     }
   }
 
-  const getBucket = (v: number) => incrRoundDn(v - bucketOffset, bucketSize!) + bucketOffset;
+  const getBucket = (v: number) => roundDecimals(incrRoundDn(v - bucketOffset, bucketSize!) + bucketOffset, 9);
 
   // guess number of decimals
   let bucketDecimals = (('' + bucketSize).match(/\.\d+$/) ?? ['.'])[0].length - 1;

--- a/public/app/plugins/panel/histogram/Histogram.tsx
+++ b/public/app/plugins/panel/histogram/Histogram.tsx
@@ -50,12 +50,16 @@ export interface HistogramProps extends Themeable2 {
 
 export function getBucketSize(frame: DataFrame) {
   // assumes BucketMin is fields[0] and BucktMax is fields[1]
-  return frame.fields[0].type === FieldType.string ? 1 : roundDecimals(frame.fields[1].values[0] - frame.fields[0].values[0], 9);
+  return frame.fields[0].type === FieldType.string
+    ? 1
+    : roundDecimals(frame.fields[1].values[0] - frame.fields[0].values[0], 9);
 }
 
 export function getBucketSize1(frame: DataFrame) {
   // assumes BucketMin is fields[0] and BucktMax is fields[1]
-  return frame.fields[0].type === FieldType.string ? 1 : roundDecimals(frame.fields[1].values[1] - frame.fields[0].values[1], 9);
+  return frame.fields[0].type === FieldType.string
+    ? 1
+    : roundDecimals(frame.fields[1].values[1] - frame.fields[0].values[1], 9);
 }
 
 const prepConfig = (frame: DataFrame, theme: GrafanaTheme2) => {

--- a/public/app/plugins/panel/histogram/Histogram.tsx
+++ b/public/app/plugins/panel/histogram/Histogram.tsx
@@ -8,6 +8,7 @@ import {
   getFieldColorModeForField,
   getFieldSeriesColor,
   GrafanaTheme2,
+  roundDecimals,
 } from '@grafana/data';
 import {
   histogramBucketSizes,
@@ -49,12 +50,12 @@ export interface HistogramProps extends Themeable2 {
 
 export function getBucketSize(frame: DataFrame) {
   // assumes BucketMin is fields[0] and BucktMax is fields[1]
-  return frame.fields[0].type === FieldType.string ? 1 : frame.fields[1].values[0] - frame.fields[0].values[0];
+  return frame.fields[0].type === FieldType.string ? 1 : roundDecimals(frame.fields[1].values[0] - frame.fields[0].values[0], 9);
 }
 
 export function getBucketSize1(frame: DataFrame) {
   // assumes BucketMin is fields[0] and BucktMax is fields[1]
-  return frame.fields[0].type === FieldType.string ? 1 : frame.fields[1].values[1] - frame.fields[0].values[1];
+  return frame.fields[0].type === FieldType.string ? 1 : roundDecimals(frame.fields[1].values[1] - frame.fields[0].values[1], 9);
 }
 
 const prepConfig = (frame: DataFrame, theme: GrafanaTheme2) => {


### PR DESCRIPTION
Fixes https://github.com/grafana/support-escalations/issues/9595

we have some internal heuristics that try to figure out if we should use a log or linear bucket x axis. this is done by analyzing the first two buckets and seeing if they're the same width. if they are, then linear, else log. this comparison can return the wrong result with float value buckets due to precision errors in float math.

this fixes things by rounding all buckets to 9 decimal places so we never get buckets like `9.0000000000000199`.

test dashboard:

[histogram-bucket-float.json](https://github.com/grafana/grafana/files/14510733/histogram-bucket-float.json)

before:
<img width="1144" alt="image" src="https://github.com/grafana/grafana/assets/43234/af3a96dc-e257-4377-b021-abd7f774fcf0">

after:
<img width="1144" alt="image" src="https://github.com/grafana/grafana/assets/43234/10481d26-4687-420c-93cc-904b974af0b9">