### PR TITLE
Worker: Use CorsWorker to avoid CORS issues

### DIFF
--- a/public/app/features/dashboard-scene/saving/createDetectChangesWorker.ts
+++ b/public/app/features/dashboard-scene/saving/createDetectChangesWorker.ts
@@ -1,1 +1,3 @@
+import { CorsWorker as Worker } from 'app/core/utils/CorsWorker';
+
 export const createWorker = () => new Worker(new URL('./DetectChangesWorker.ts', import.meta.url));


### PR DESCRIPTION
**Problem**
When the worker for detecting dashboard changes was deployed, a CORS issue made the DashboardScene to break.

```
by default, worker inherits HTML document's location and pathname which leads to wrong public path value the CorsWorkerPlugin will override it with the value based on the initial worker chunk, ie.
initial worker chunk: http://host.com/cdn/scripts/worker-123.js
resulting public path: http://host.com/cdn/scripts
```

**Solution**
This is a known issue, and we have in Grafana a workaround for it using [CorsWorker](https://github.com/grafana/grafana/blob/main/public/app/core/utils/CorsWorker.ts).

Following [the example](https://github.com/grafana/grafana/blob/main/public/app/plugins/panel/nodeGraph/createLayoutWorker.ts) provided by @jackw (Thanks a tone ❤️ )