### PR TITLE
Docs: comment in SSO for terraform video

### DIFF
--- a/docs/sources/whatsnew/whats-new-in-v10-4.md
+++ b/docs/sources/whatsnew/whats-new-in-v10-4.md
@@ -217,7 +217,7 @@ We are working on adding complete support for configuring all other supported OA
 
 ![Screenshot of the Authentication provider list page](/media/docs/grafana-cloud/screenshot-sso-settings-ui-public-prev-v10.4.png)
 
-<!--{{< youtube id="q_fUgltb7-g" >}}-->
+{{< youtube id="q_fUgltb7-g" >}}
 
 [Documentation](https://grafana.com/docs/grafana/next/setup-grafana/configure-security/configure-authentication/)
 

--- a/docs/sources/whatsnew/whats-new-in-v10-4.md
+++ b/docs/sources/whatsnew/whats-new-in-v10-4.md
@@ -217,7 +217,7 @@ We are working on adding complete support for configuring all other supported OA
 
 ![Screenshot of the Authentication provider list page](/media/docs/grafana-cloud/screenshot-sso-settings-ui-public-prev-v10.4.png)
 
-{{< youtube id="q_fUgltb7-g" >}}
+{{< youtube id="xXW2eRTbjDY" >}}
 
 [Documentation](https://grafana.com/docs/grafana/next/setup-grafana/configure-security/configure-authentication/)
 


### PR DESCRIPTION
Adds SSO for Terraform back into What's new. The video was previously commented out because it wasn't correctly titled.