### PR TITLE
LibraryPanelRBAC: Fix issue with importing dashboards containing library panels

### DIFF
--- a/pkg/services/libraryelements/api.go
+++ b/pkg/services/libraryelements/api.go
@@ -26,7 +26,7 @@ func (l *LibraryElementService) registerAPIEndpoints() {
 			entities.Post("/", authorize(ac.EvalPermission(ActionLibraryPanelsCreate)), routing.Wrap(l.createHandler))
 			entities.Delete("/:uid", authorize(ac.EvalPermission(ActionLibraryPanelsDelete, uidScope)), routing.Wrap(l.deleteHandler))
 			entities.Get("/", authorize(ac.EvalPermission(ActionLibraryPanelsRead)), routing.Wrap(l.getAllHandler))
-			entities.Get("/:uid", authorize(ac.EvalPermission(ActionLibraryPanelsRead, uidScope)), routing.Wrap(l.getHandler))
+			entities.Get("/:uid", authorize(ac.EvalPermission(ActionLibraryPanelsRead)), routing.Wrap(l.getHandler))
 			entities.Get("/:uid/connections/", authorize(ac.EvalPermission(ActionLibraryPanelsRead, uidScope)), routing.Wrap(l.getConnectionsHandler))
 			entities.Get("/name/:name", routing.Wrap(l.getByNameHandler))
 			entities.Patch("/:uid", authorize(ac.EvalPermission(ActionLibraryPanelsWrite, uidScope)), routing.Wrap(l.patchHandler))
@@ -140,7 +140,8 @@ func (l *LibraryElementService) deleteHandler(c *contextmodel.ReqContext) respon
 // 404: notFoundError
 // 500: internalServerError
 func (l *LibraryElementService) getHandler(c *contextmodel.ReqContext) response.Response {
-	element, err := l.getLibraryElementByUid(c.Req.Context(), c.SignedInUser,
+	ctx := c.Req.Context()
+	element, err := l.getLibraryElementByUid(ctx, c.SignedInUser,
 		model.GetLibraryElementCommand{
 			UID:        web.Params(c.Req)[":uid"],
 			FolderName: dashboards.RootFolderName,
@@ -148,6 +149,15 @@ func (l *LibraryElementService) getHandler(c *contextmodel.ReqContext) response.
 	)
 	if err != nil {
 		return toLibraryElementError(err, "Failed to get library element")
+	}
+
+	if l.features.IsEnabled(ctx, featuremgmt.FlagLibraryPanelRBAC) {
+		allowed, err := l.AccessControl.Evaluate(ctx, c.SignedInUser, ac.EvalPermission(ActionLibraryPanelsRead, ScopeLibraryPanelsProvider.GetResourceScopeUID(web.Params(c.Req)[":uid"])))
+		if err != nil {
+			return response.Error(http.StatusInternalServerError, "unable to evaluate library panel permissions", err)
+		} else if !allowed {
+			return response.Error(http.StatusForbidden, "insufficient permissions for getting library panel", err)
+		}
 	}
 
 	return response.JSON(http.StatusOK, model.LibraryElementResponse{Result: element})

--- a/pkg/services/libraryelements/database.go
+++ b/pkg/services/libraryelements/database.go
@@ -296,7 +296,12 @@ func (l *LibraryElementService) getLibraryElements(c context.Context, store db.D
 		builder.Write(getFromLibraryElementDTOWithMeta(store.GetDialect()))
 		builder.Write(" INNER JOIN dashboard AS dashboard on le.folder_id = dashboard.id AND le.folder_id <> 0")
 		writeParamSelectorSQL(&builder, params...)
-		builder.WriteDashboardPermissionFilter(signedInUser, dashboardaccess.PERMISSION_VIEW, searchstore.TypeFolder)
+
+		// use permission filter if lib panel RBAC isn't enabled
+		if !l.features.IsEnabled(c, featuremgmt.FlagLibraryPanelRBAC) {
+			builder.WriteDashboardPermissionFilter(signedInUser, dashboardaccess.PERMISSION_VIEW, searchstore.TypeFolder)
+		}
+
 		builder.Write(` OR dashboard.id=0`)
 		if err := session.SQL(builder.GetSQLString(), builder.GetParams()...).Find(&libraryElements); err != nil {
 			return err


### PR DESCRIPTION
Fixes an issue where users couldn't import dashboards containing library panels if the libraryPanelRBAC feature flag was enabled.

When we're importing a dashboard containing library panels, we first check if we already have any library panels in the DB with the same UID as those in the dashboard we're importing. If it doesn't exist, a `404` is returned from the server, but if any other error code is returned, an error is thrown.
Part of the issue was the line
```
entities.Get("/:uid", authorize(ac.EvalPermission(ActionLibraryPanelsRead, uidScope)), routing.Wrap(l.getHandler))
```
in libraryelements/api.go.
If `EvalPermission` fails it always causes a `403` to be returned, when what we want is a `404`.
To fix this behavior, I've changed it so we change the line to
```
entities.Get("/:uid", authorize(ac.EvalPermission(ActionLibraryPanelsRead)), routing.Wrap(l.getHandler))
```
and add the logic for returning the correct error code to the get handler.

Unfortunately that alone isn't enough as it sort of introduces another issue when we try to access a library panel we don't have permission for, returning a `404` instead of a `403`.
This is because the `getLibraryElements` function in libraryelements/database.go has some logic to filter out library panels the requesting user doesn't have permission for. But that means we can't tell from the result whether the library panel just doesn't exist, or if we don't have permissions for it.
To fix this, I've made that particular piece of logic run only if we _don't_ have libraryPanelRBAC enabled.