### PR TITLE
Prometheus: Remove < and > from Query Builder Label Matcher operations

### DIFF
--- a/packages/grafana-prometheus/src/querybuilder/components/LabelFilterItem.tsx
+++ b/packages/grafana-prometheus/src/querybuilder/components/LabelFilterItem.tsx
@@ -189,8 +189,6 @@ export function LabelFilterItem({
 const operators = [
   { label: '=', value: '=', isMultiValue: false },
   { label: '!=', value: '!=', isMultiValue: false },
-  { label: '<', value: '<', isMultiValue: false },
-  { label: '>', value: '>', isMultiValue: false },
   { label: '=~', value: '=~', isMultiValue: true },
   { label: '!~', value: '!~', isMultiValue: true },
 ];

--- a/public/app/plugins/datasource/prometheus/querybuilder/components/LabelFilterItem.tsx
+++ b/public/app/plugins/datasource/prometheus/querybuilder/components/LabelFilterItem.tsx
@@ -190,8 +190,6 @@ export function LabelFilterItem({
 const operators = [
   { label: '=', value: '=', isMultiValue: false },
   { label: '!=', value: '!=', isMultiValue: false },
-  { label: '<', value: '<', isMultiValue: false },
-  { label: '>', value: '>', isMultiValue: false },
   { label: '=~', value: '=~', isMultiValue: true },
   { label: '!~', value: '!~', isMultiValue: true },
 ];


### PR DESCRIPTION
**What is this feature?**

Before:

![image showing invalid less than and greater than operators in label matchers](https://github.com/grafana/grafana/assets/1692624/a48dc64f-dc75-4139-856c-5083f8933878)

After:

![image with those matchers no longer in the builder](https://github.com/grafana/grafana/assets/1692624/9c0df56b-d6c9-4cf2-97e6-4799e5c673c8)


**Why do we need this feature?**

PromQL doesn't support `<` or `>` (see [prometheus/prometheus issue](https://github.com/prometheus/prometheus/issues/12934#issuecomment-1766168296)) for label matchers, so the builder should not be showing them in the UI as options.
