### PR TITLE
k8s: add support for configuring the gRPC storage server address

### DIFF
--- a/pkg/services/apiserver/options/storage.go
+++ b/pkg/services/apiserver/options/storage.go
@@ -2,6 +2,7 @@ package options
 
 import (
 	"fmt"
+	"net"
 
 	"github.com/spf13/pflag"
 	genericapiserver "k8s.io/apiserver/pkg/server"
@@ -21,17 +22,20 @@ const (
 type StorageOptions struct {
 	StorageType StorageType
 	DataPath    string
+	Address     string
 }
 
 func NewStorageOptions() *StorageOptions {
 	return &StorageOptions{
 		StorageType: StorageTypeLegacy,
+		Address:     "localhost:10000",
 	}
 }
 
 func (o *StorageOptions) AddFlags(fs *pflag.FlagSet) {
 	fs.StringVar((*string)(&o.StorageType), "grafana-apiserver-storage-type", string(o.StorageType), "Storage type")
 	fs.StringVar(&o.DataPath, "grafana-apiserver-storage-path", o.DataPath, "Storage path for file storage")
+	fs.StringVar((*string)(&o.Address), "grafana-apiserver-storage-address", string(o.Address), "Remote grpc address endpoint")
 }
 
 func (o *StorageOptions) Validate() []error {
@@ -41,6 +45,10 @@ func (o *StorageOptions) Validate() []error {
 		// no-op
 	default:
 		errs = append(errs, fmt.Errorf("--grafana-apiserver-storage-type must be one of %s, %s, %s, %s, %s", StorageTypeFile, StorageTypeEtcd, StorageTypeLegacy, StorageTypeUnified, StorageTypeUnifiedGrpc))
+	}
+
+	if _, _, err := net.SplitHostPort(o.Address); err != nil {
+		errs = append(errs, fmt.Errorf("--grafana-apiserver-storage-address must be a valid network address: %v", err))
 	}
 	return errs
 }

--- a/pkg/services/apiserver/options/storage.go
+++ b/pkg/services/apiserver/options/storage.go
@@ -35,7 +35,7 @@ func NewStorageOptions() *StorageOptions {
 func (o *StorageOptions) AddFlags(fs *pflag.FlagSet) {
 	fs.StringVar((*string)(&o.StorageType), "grafana-apiserver-storage-type", string(o.StorageType), "Storage type")
 	fs.StringVar(&o.DataPath, "grafana-apiserver-storage-path", o.DataPath, "Storage path for file storage")
-	fs.StringVar((*string)(&o.Address), "grafana-apiserver-storage-address", string(o.Address), "Remote grpc address endpoint")
+	fs.StringVar(&o.Address, "grafana-apiserver-storage-address", string(o.Address), "Remote grpc address endpoint")
 }
 
 func (o *StorageOptions) Validate() []error {

--- a/pkg/services/apiserver/options/storage.go
+++ b/pkg/services/apiserver/options/storage.go
@@ -35,7 +35,7 @@ func NewStorageOptions() *StorageOptions {
 func (o *StorageOptions) AddFlags(fs *pflag.FlagSet) {
 	fs.StringVar((*string)(&o.StorageType), "grafana-apiserver-storage-type", string(o.StorageType), "Storage type")
 	fs.StringVar(&o.DataPath, "grafana-apiserver-storage-path", o.DataPath, "Storage path for file storage")
-	fs.StringVar(&o.Address, "grafana-apiserver-storage-address", string(o.Address), "Remote grpc address endpoint")
+	fs.StringVar(&o.Address, "grafana-apiserver-storage-address", o.Address, "Remote grpc address endpoint")
 }
 
 func (o *StorageOptions) Validate() []error {

--- a/pkg/services/apiserver/service.go
+++ b/pkg/services/apiserver/service.go
@@ -261,8 +261,7 @@ func (s *service) start(ctx context.Context) error {
 
 	case grafanaapiserveroptions.StorageTypeUnifiedGrpc:
 		// Create a connection to the gRPC server
-		// TODO: support configuring the gRPC server address
-		conn, err := grpc.Dial("localhost:10000", grpc.WithTransportCredentials(insecure.NewCredentials()))
+		conn, err := grpc.Dial(o.StorageOptions.Address, grpc.WithTransportCredentials(insecure.NewCredentials()))
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
**What is this feature?**
k8s: add support for configuring the gRPC storage server address

**Why do we need this feature?**
Allow running the gRPC server remotely

**Who is this feature for?**

Grafana Search and Storage 

**Which issue(s) does this PR fix?**:

