### PR TITLE
Alerting: Minor changes to UI help text and descriptions

### DIFF
--- a/public/app/features/alerting/unified/components/receivers/TemplateForm.tsx
+++ b/public/app/features/alerting/unified/components/receivers/TemplateForm.tsx
@@ -280,7 +280,7 @@ function TemplatingGuideline() {
       </Stack>
 
       <div className={styles.snippets}>
-        To make templating easier, we provide a few snippets in the content editor to help you speed up your workflow.
+        For auto-completion of common templating code, type the following keywords in the content editor:
         <div className={styles.code}>
           {Object.values(snippets)
             .map((s) => s.label)

--- a/public/app/features/alerting/unified/components/rule-editor/AnnotationsStep.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/AnnotationsStep.tsx
@@ -89,9 +89,6 @@ const AnnotationsStep = () => {
   };
 
   function getAnnotationsSectionDescription() {
-    const docsLink =
-      'https://grafana.com/docs/grafana/latest/alerting/fundamentals/annotation-label/variables-label-annotation';
-
     return (
       <Stack direction="row" gap={0.5} alignItems="baseline">
         <Text variant="bodySmall" color="secondary">
@@ -101,8 +98,6 @@ const AnnotationsStep = () => {
           contentText={`Annotations add metadata to provide more information on the alert in your alert notification messages. 
           For example, add a Summary annotation to tell you which value caused the alert to fire or which server it happened on. 
           Annotations can contain a combination of text and template code.`}
-          externalLink={docsLink}
-          linkText={`Read about annotations`}
           title="Annotations"
         />
       </Stack>

--- a/public/app/features/alerting/unified/components/rule-editor/LabelsField.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/LabelsField.tsx
@@ -284,7 +284,7 @@ const LabelsField: FC<Props> = ({ dataSourceName }) => {
         <Text element="h5">Labels</Text>
         <Stack direction={'row'} gap={1}>
           <Text variant="bodySmall" color="secondary">
-            Add labels to your rule to annotate your rules, ease searching, or route to a notification policy.
+            Add labels to your rule for searching, silencing, or routing to a notification policy.
           </Text>
           <NeedHelpInfo
             contentText="The dropdown only displays labels that you have previously used for alerts.


### PR DESCRIPTION
Discussed and agreed by @konrad147 

- Update `Configure labels` text description
- Remove link to Templating docs in `Alert rules / Annotations` UI because it is considered an advanced use case 
- Update `Templating guideline` text description in Notification templates UI

Please check that:
- [x] It works as expected from a user's perspective.

