### PR TITLE
Prometheus: Error handling for undefined type

### DIFF
--- a/packages/grafana-prometheus/src/language_provider.ts
+++ b/packages/grafana-prometheus/src/language_provider.ts
@@ -41,7 +41,7 @@ export function getMetadataString(metric: string, metadata: PromMetricsMetadata)
     return undefined;
   }
   const { type, help } = metadata[metric];
-  return `${type.toUpperCase()}: ${help}`;
+  return `${type?.toUpperCase()}: ${help}`;
 }
 
 export function getMetadataHelp(metric: string, metadata: PromMetricsMetadata): string | undefined {

--- a/packages/grafana-prometheus/src/query_hints.ts
+++ b/packages/grafana-prometheus/src/query_hints.ts
@@ -50,7 +50,7 @@ export function getQueryHints(query: string, series?: any[], datasource?: Promet
         queryTokens.find((metricName) => {
           // Only considering first type information, could be non-deterministic
           const metadata = metricsMetadata[metricName];
-          if (metadata && metadata.type.toLowerCase() === 'counter') {
+          if (metadata && metadata.type?.toLowerCase() === 'counter') {
             certain = true;
             return true;
           } else {

--- a/packages/grafana-prometheus/src/querybuilder/shared/QueryBuilderHints.tsx
+++ b/packages/grafana-prometheus/src/querybuilder/shared/QueryBuilderHints.tsx
@@ -61,7 +61,7 @@ export const QueryBuilderHints = <T extends PromLokiVisualQuery>({
                   size="sm"
                   className={styles.hint}
                 >
-                  hint: {hint.fix?.title || hint.fix?.action?.type.toLowerCase().replace('_', ' ')}
+                  hint: {hint.fix?.title || hint.fix?.action?.type?.toLowerCase().replace('_', ' ')}
                 </Button>
               </Tooltip>
             );

--- a/public/app/plugins/datasource/prometheus/language_provider.ts
+++ b/public/app/plugins/datasource/prometheus/language_provider.ts
@@ -41,7 +41,7 @@ export function getMetadataString(metric: string, metadata: PromMetricsMetadata)
     return undefined;
   }
   const { type, help } = metadata[metric];
-  return `${type.toUpperCase()}: ${help}`;
+  return `${type?.toUpperCase()}: ${help}`;
 }
 
 export function getMetadataHelp(metric: string, metadata: PromMetricsMetadata): string | undefined {

--- a/public/app/plugins/datasource/prometheus/query_hints.ts
+++ b/public/app/plugins/datasource/prometheus/query_hints.ts
@@ -50,7 +50,7 @@ export function getQueryHints(query: string, series?: any[], datasource?: Promet
         queryTokens.find((metricName) => {
           // Only considering first type information, could be non-deterministic
           const metadata = metricsMetadata[metricName];
-          if (metadata && metadata.type.toLowerCase() === 'counter') {
+          if (metadata && metadata.type?.toLowerCase() === 'counter') {
             certain = true;
             return true;
           } else {

--- a/public/app/plugins/datasource/prometheus/querybuilder/shared/QueryBuilderHints.tsx
+++ b/public/app/plugins/datasource/prometheus/querybuilder/shared/QueryBuilderHints.tsx
@@ -62,7 +62,7 @@ export const QueryBuilderHints = <T extends PromLokiVisualQuery>({
                   size="sm"
                   className={styles.hint}
                 >
-                  hint: {hint.fix?.title || hint.fix?.action?.type.toLowerCase().replace('_', ' ')}
+                  hint: {hint.fix?.title || hint.fix?.action?.type?.toLowerCase().replace('_', ' ')}
                 </Button>
               </Tooltip>
             );


### PR DESCRIPTION
**What is this?**

This is a little error handling for undefined metadata type in Prometheus. 

Actual Prometheus had a accidental breaking change where metadata type was changed from 'type' to 'Type' resulting in errors being thrown in Grafana Prometheus. This was fixed but there are some docker instances out there that still have the error present. This fix provides some error handling so that the Grafana Prometheus frontend does not break as a result of this.

<img width="1262" alt="Screenshot 2024-03-06 at 1 01 34 PM" src="https://github.com/grafana/grafana/assets/25674746/edaeba4e-9a88-45e9-8235-7a45d241d5b5">
<img width="595" alt="Screenshot 2024-03-06 at 1 02 08 PM" src="https://github.com/grafana/grafana/assets/25674746/df709340-481e-4db7-8e47-d4c031f9138b">
<img width="656" alt="Screenshot 2024-03-06 at 1 02 24 PM" src="https://github.com/grafana/grafana/assets/25674746/b4ae88ea-3c99-4aea-affa-818316ef3b0e">


Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
