### PR TITLE
FeatureToggles: Allow changing prod env safe feature toggles via URL

### DIFF
--- a/packages/grafana-runtime/src/config.ts
+++ b/packages/grafana-runtime/src/config.ts
@@ -248,7 +248,8 @@ function overrideFeatureTogglesFromUrl(config: GrafanaBootConfig, allowWhiteList
     'autoMigrateTablePanel',
     'autoMigratePiechartPanel',
     'autoMigrateWorldmapPanel',
-    'autoMigrateStatPanel, disableAngular',
+    'autoMigrateStatPanel',
+    'disableAngular',
   ]);
 
   const params = new URLSearchParams(window.location.search);

--- a/packages/grafana-runtime/src/config.ts
+++ b/packages/grafana-runtime/src/config.ts
@@ -235,21 +235,21 @@ function overrideFeatureTogglesFromLocalStorage(config: GrafanaBootConfig) {
   }
 }
 
-const prodUrlAllowedFeatureFlags = new Set([
-  'autoMigrateOldPanels',
-  'autoMigrateGraphPanel',
-  'autoMigrateTablePanel',
-  'autoMigratePiechartPanel',
-  'autoMigrateWorldmapPanel',
-  'autoMigrateStatPanel, disableAngular',
-]);
-
 function overrideFeatureTogglesFromUrl(config: GrafanaBootConfig, allowWhiteListed = false) {
   if (window.location.href.indexOf('__feature') === -1) {
     return;
   }
 
   const isLocalDevEnv = config.buildInfo.env === 'development';
+
+  const prodUrlAllowedFeatureFlags = new Set([
+    'autoMigrateOldPanels',
+    'autoMigrateGraphPanel',
+    'autoMigrateTablePanel',
+    'autoMigratePiechartPanel',
+    'autoMigrateWorldmapPanel',
+    'autoMigrateStatPanel, disableAngular',
+  ]);
 
   const params = new URLSearchParams(window.location.search);
   params.forEach((value, key) => {

--- a/packages/grafana-runtime/src/config.ts
+++ b/packages/grafana-runtime/src/config.ts
@@ -235,7 +235,7 @@ function overrideFeatureTogglesFromLocalStorage(config: GrafanaBootConfig) {
   }
 }
 
-function overrideFeatureTogglesFromUrl(config: GrafanaBootConfig, allowWhiteListed = false) {
+function overrideFeatureTogglesFromUrl(config: GrafanaBootConfig) {
   if (window.location.href.indexOf('__feature') === -1) {
     return;
   }


### PR DESCRIPTION
This PR allows setting the feature flags via URL for prod environments, if the flag is considered safe. Current safe list includes deprecation related feature flags.

```['autoMigrateOldPanels', 'autoMigrateGraphPanel', 'autoMigrateTablePanel', 'autoMigratePiechartPanel', 'autoMigrateWorldmapPanel', 'autoMigrateStatPanel, disableAngular']``` 


Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
