### PR TITLE
Alerting: Extract large closures in ruleRoutine

### DIFF
--- a/pkg/services/ngalert/schedule/alert_rule.go
+++ b/pkg/services/ngalert/schedule/alert_rule.go
@@ -186,14 +186,14 @@ func (a *alertRuleInfo) run(key ngmodels.AlertRuleKey) error {
 	logger := a.logger.FromContext(grafanaCtx)
 	logger.Debug("Alert rule routine started")
 
-	orgID := fmt.Sprint(key.OrgID)
-	evalTotal := a.metrics.EvalTotal.WithLabelValues(orgID)
-	evalDuration := a.metrics.EvalDuration.WithLabelValues(orgID)
-	evalTotalFailures := a.metrics.EvalFailures.WithLabelValues(orgID)
-	processDuration := a.metrics.ProcessDuration.WithLabelValues(orgID)
-	sendDuration := a.metrics.SendDuration.WithLabelValues(orgID)
-
 	evaluate := func(ctx context.Context, f fingerprint, attempt int64, e *evaluation, span trace.Span, retry bool) error {
+		orgID := fmt.Sprint(key.OrgID)
+		evalTotal := a.metrics.EvalTotal.WithLabelValues(orgID)
+		evalDuration := a.metrics.EvalDuration.WithLabelValues(orgID)
+		evalTotalFailures := a.metrics.EvalFailures.WithLabelValues(orgID)
+		processDuration := a.metrics.ProcessDuration.WithLabelValues(orgID)
+		sendDuration := a.metrics.SendDuration.WithLabelValues(orgID)
+
 		logger := logger.New("version", e.rule.Version, "fingerprint", f, "attempt", attempt, "now", e.scheduledAt).FromContext(ctx)
 		start := a.clock.Now()
 


### PR DESCRIPTION
**What is this feature?**

These closures (especially evaluate) made more sense in old versions of Grafana, when they used to be just a couple lines long. Now they are multiple screens long. It doesn't make sense anymore and increases the cognitive complexity of the rule routine. They also have negative effects on stacktraces, and also completely break profiles. Let's promote them to real methods.

**Which issue(s) does this PR fix?**:

n/a

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle.
- [x] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
