### PR TITLE
K8s: enable insecure to skip server cert validation for now

### DIFF
--- a/pkg/services/apiserver/aggregator/aggregator.go
+++ b/pkg/services/apiserver/aggregator/aggregator.go
@@ -146,12 +146,9 @@ func CreateAggregatorConfig(commandOptions *options.Options, sharedConfig generi
 	}
 
 	remoteServicesConfig := &RemoteServicesConfig{
-		// TODO: determine if we can switch to commandOptions.ExtraOptions.DevMode for Insecure flag below
-		// without insecure, aggregator is checking the referrer / externalname service name
-		// such as v0alpha1.{MT_SERVICE_GROUP_NAME}.grafana.app.stack-{STACK_ID}.svc
-		// against the TLS cert, which it will obviously fail
-		// This disables server cert validation for the aggregated servers
-		// Client certificate validation is still active on their side
+		// TODO: in practice, we should only use the insecure flag when commandOptions.ExtraOptions.DevMode == true
+		// But given the bug in K8s, we are forced to set it to true until the below PR is merged and available
+		// https://github.com/kubernetes/kubernetes/pull/123808
 		InsecureSkipTLSVerify:  true,
 		ExternalNamesNamespace: externalNamesNamespace,
 		CABundle:               caBundlePEM,

--- a/pkg/services/apiserver/aggregator/aggregator.go
+++ b/pkg/services/apiserver/aggregator/aggregator.go
@@ -146,7 +146,13 @@ func CreateAggregatorConfig(commandOptions *options.Options, sharedConfig generi
 	}
 
 	remoteServicesConfig := &RemoteServicesConfig{
-		InsecureSkipTLSVerify:  commandOptions.ExtraOptions.DevMode,
+		// TODO: determine if we can switch to commandOptions.ExtraOptions.DevMode for Insecure flag below
+		// without insecure, aggregator is checking the referrer / externalname service name
+		// such as v0alpha1.{MT_SERVICE_GROUP_NAME}.grafana.app.stack-{STACK_ID}.svc
+		// against the TLS cert, which it will obviously fail
+		// This disables server cert validation for the aggregated servers
+		// Client certificate validation is still active on their side
+		InsecureSkipTLSVerify:  true,
 		ExternalNamesNamespace: externalNamesNamespace,
 		CABundle:               caBundlePEM,
 		Services:               remoteServices,


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

Aggregation is almost setup. There are some weird issues happening with TLS errors where parent servers want to ensure that child certs (which are MT) conform to the `externalname` service `Name` in addition to matching `Host`. Matching `Name` isn't feasible for us as it contains the Stack ID in cloud. Disabling until we have a proper grip on the issue.

Current warning without this fix:
```
failed to verify certificate: x509: certificate is valid for {MT_TENANT_APP}.{MT_TENANT_APP_NAMESPACE}.svc.cluster.local, not v0alpha1.{MT_TENANT_APP}.{STACK_ID}.svc
```

The warning causes the child server kinds to not register.

**Why do we need this feature?**

We need to at least start testing aggregation more regularly in cloud and this is an issue we can fix in parallel.

**Who is this feature for?**

Grafana App Platform

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
