### PR TITLE
Azure: list of clouds in frontend AzureSettings

### DIFF
--- a/packages/grafana-runtime/src/config.ts
+++ b/packages/grafana-runtime/src/config.ts
@@ -21,9 +21,15 @@ import {
 
 export interface AzureSettings {
   cloud?: string;
+  clouds?: AzureCloudInfo[];
   managedIdentityEnabled: boolean;
   workloadIdentityEnabled: boolean;
   userIdentityEnabled: boolean;
+}
+
+export interface AzureCloudInfo {
+  name: string;
+  displayName: string;
 }
 
 export type AppPluginConfig = {


### PR DESCRIPTION
This PR extends `@grafana/runtime`'s `AzureSettings` to include an optional list of clouds which could be sent to frontend when its different from the predefined list of clouds.

Related PR on backend: #83460

Will be used by the Azure frontend SDK: https://github.com/grafana/grafana-azure-sdk-react/pull/128