### PR TITLE
Alerting: Scheduler and registry handle rules by an interface

### DIFF
--- a/pkg/services/ngalert/schedule/alert_rule.go
+++ b/pkg/services/ngalert/schedule/alert_rule.go
@@ -24,6 +24,8 @@ import (
 )
 
 type Rule interface {
+	Run(key ngmodels.AlertRuleKey) error
+	Stop(reason error)
 	Eval(eval *Evaluation) (bool, *Evaluation)
 	Update(lastVersion RuleVersionAndPauseStatus) bool
 }
@@ -181,11 +183,11 @@ func (a *alertRuleInfo) Update(lastVersion RuleVersionAndPauseStatus) bool {
 }
 
 // stop sends an instruction to the rule evaluation routine to shut down. an optional shutdown reason can be given.
-func (a *alertRuleInfo) stop(reason error) {
+func (a *alertRuleInfo) Stop(reason error) {
 	a.stopFn(reason)
 }
 
-func (a *alertRuleInfo) run(key ngmodels.AlertRuleKey) error {
+func (a *alertRuleInfo) Run(key ngmodels.AlertRuleKey) error {
 	grafanaCtx := ngmodels.WithRuleKey(a.ctx, key)
 	logger := a.logger.FromContext(grafanaCtx)
 	logger.Debug("Alert rule routine started")

--- a/pkg/services/ngalert/schedule/alert_rule.go
+++ b/pkg/services/ngalert/schedule/alert_rule.go
@@ -30,9 +30,9 @@ type Rule interface {
 	Update(lastVersion RuleVersionAndPauseStatus) bool
 }
 
-type ruleFactoryFunc func(context.Context) *alertRuleInfo
+type ruleFactoryFunc func(context.Context) Rule
 
-func (f ruleFactoryFunc) new(ctx context.Context) *alertRuleInfo {
+func (f ruleFactoryFunc) new(ctx context.Context) Rule {
 	return f(ctx)
 }
 
@@ -51,7 +51,7 @@ func newRuleFactory(
 	evalAppliedHook evalAppliedFunc,
 	stopAppliedHook stopAppliedFunc,
 ) ruleFactoryFunc {
-	return func(ctx context.Context) *alertRuleInfo {
+	return func(ctx context.Context) Rule {
 		return newAlertRuleInfo(
 			ctx,
 			appURL,

--- a/pkg/services/ngalert/schedule/alert_rule.go
+++ b/pkg/services/ngalert/schedule/alert_rule.go
@@ -25,6 +25,7 @@ import (
 
 type Rule interface {
 	Eval(eval *Evaluation) (bool, *Evaluation)
+	Update(lastVersion RuleVersionAndPauseStatus) bool
 }
 
 type ruleFactoryFunc func(context.Context) *alertRuleInfo
@@ -162,7 +163,7 @@ func (a *alertRuleInfo) Eval(eval *Evaluation) (bool, *Evaluation) {
 }
 
 // update sends an instruction to the rule evaluation routine to update the scheduled rule to the specified version. The specified version must be later than the current version, otherwise no update will happen.
-func (a *alertRuleInfo) update(lastVersion RuleVersionAndPauseStatus) bool {
+func (a *alertRuleInfo) Update(lastVersion RuleVersionAndPauseStatus) bool {
 	// check if the channel is not empty.
 	select {
 	case <-a.updateCh:

--- a/pkg/services/ngalert/schedule/alert_rule.go
+++ b/pkg/services/ngalert/schedule/alert_rule.go
@@ -23,6 +23,10 @@ import (
 	"go.opentelemetry.io/otel/trace"
 )
 
+type Rule interface {
+	Eval(eval *Evaluation) (bool, *Evaluation)
+}
+
 type ruleFactoryFunc func(context.Context) *alertRuleInfo
 
 func (f ruleFactoryFunc) new(ctx context.Context) *alertRuleInfo {
@@ -141,7 +145,7 @@ func newAlertRuleInfo(
 //   - false when the send operation is stopped
 //
 // the second element contains a dropped message that was sent by a concurrent sender.
-func (a *alertRuleInfo) eval(eval *Evaluation) (bool, *Evaluation) {
+func (a *alertRuleInfo) Eval(eval *Evaluation) (bool, *Evaluation) {
 	// read the channel in unblocking manner to make sure that there is no concurrent send operation.
 	var droppedMsg *Evaluation
 	select {

--- a/pkg/services/ngalert/schedule/alert_rule.go
+++ b/pkg/services/ngalert/schedule/alert_rule.go
@@ -73,7 +73,7 @@ type ruleProvider interface {
 
 type alertRuleInfo struct {
 	evalCh   chan *Evaluation
-	updateCh chan ruleVersionAndPauseStatus
+	updateCh chan RuleVersionAndPauseStatus
 	ctx      context.Context
 	stopFn   util.CancelCauseFunc
 
@@ -115,7 +115,7 @@ func newAlertRuleInfo(
 	ctx, stop := util.WithCancelCause(parent)
 	return &alertRuleInfo{
 		evalCh:               make(chan *Evaluation),
-		updateCh:             make(chan ruleVersionAndPauseStatus),
+		updateCh:             make(chan RuleVersionAndPauseStatus),
 		ctx:                  ctx,
 		stopFn:               stop,
 		appURL:               appURL,
@@ -158,7 +158,7 @@ func (a *alertRuleInfo) eval(eval *Evaluation) (bool, *Evaluation) {
 }
 
 // update sends an instruction to the rule evaluation routine to update the scheduled rule to the specified version. The specified version must be later than the current version, otherwise no update will happen.
-func (a *alertRuleInfo) update(lastVersion ruleVersionAndPauseStatus) bool {
+func (a *alertRuleInfo) update(lastVersion RuleVersionAndPauseStatus) bool {
 	// check if the channel is not empty.
 	select {
 	case <-a.updateCh:

--- a/pkg/services/ngalert/schedule/alert_rule.go
+++ b/pkg/services/ngalert/schedule/alert_rule.go
@@ -72,7 +72,7 @@ type ruleProvider interface {
 }
 
 type alertRuleInfo struct {
-	evalCh   chan *evaluation
+	evalCh   chan *Evaluation
 	updateCh chan ruleVersionAndPauseStatus
 	ctx      context.Context
 	stopFn   util.CancelCauseFunc
@@ -114,7 +114,7 @@ func newAlertRuleInfo(
 ) *alertRuleInfo {
 	ctx, stop := util.WithCancelCause(parent)
 	return &alertRuleInfo{
-		evalCh:               make(chan *evaluation),
+		evalCh:               make(chan *Evaluation),
 		updateCh:             make(chan ruleVersionAndPauseStatus),
 		ctx:                  ctx,
 		stopFn:               stop,
@@ -141,9 +141,9 @@ func newAlertRuleInfo(
 //   - false when the send operation is stopped
 //
 // the second element contains a dropped message that was sent by a concurrent sender.
-func (a *alertRuleInfo) eval(eval *evaluation) (bool, *evaluation) {
+func (a *alertRuleInfo) eval(eval *Evaluation) (bool, *Evaluation) {
 	// read the channel in unblocking manner to make sure that there is no concurrent send operation.
-	var droppedMsg *evaluation
+	var droppedMsg *Evaluation
 	select {
 	case droppedMsg = <-a.evalCh:
 	default:
@@ -295,7 +295,7 @@ func (a *alertRuleInfo) run(key ngmodels.AlertRuleKey) error {
 	}
 }
 
-func (a *alertRuleInfo) evaluate(ctx context.Context, key ngmodels.AlertRuleKey, f fingerprint, attempt int64, e *evaluation, span trace.Span, retry bool) error {
+func (a *alertRuleInfo) evaluate(ctx context.Context, key ngmodels.AlertRuleKey, f fingerprint, attempt int64, e *Evaluation, span trace.Span, retry bool) error {
 	orgID := fmt.Sprint(key.OrgID)
 	evalTotal := a.metrics.EvalTotal.WithLabelValues(orgID)
 	evalDuration := a.metrics.EvalDuration.WithLabelValues(orgID)

--- a/pkg/services/ngalert/schedule/alert_rule_test.go
+++ b/pkg/services/ngalert/schedule/alert_rule_test.go
@@ -37,7 +37,7 @@ func TestAlertRuleInfo(t *testing.T) {
 			r := blankRuleInfoForTests(context.Background())
 			resultCh := make(chan bool)
 			go func() {
-				resultCh <- r.update(RuleVersionAndPauseStatus{fingerprint(rand.Uint64()), false})
+				resultCh <- r.Update(RuleVersionAndPauseStatus{fingerprint(rand.Uint64()), false})
 			}()
 			select {
 			case <-r.updateCh:
@@ -55,14 +55,14 @@ func TestAlertRuleInfo(t *testing.T) {
 			wg.Add(1)
 			go func() {
 				wg.Done()
-				r.update(version1)
+				r.Update(version1)
 				wg.Done()
 			}()
 			wg.Wait()
 			wg.Add(2) // one when time1 is sent, another when go-routine for time2 has started
 			go func() {
 				wg.Done()
-				r.update(version2)
+				r.Update(version2)
 			}()
 			wg.Wait() // at this point tick 1 has already been dropped
 			select {
@@ -169,7 +169,7 @@ func TestAlertRuleInfo(t *testing.T) {
 			r := blankRuleInfoForTests(context.Background())
 			r.stop(errRuleDeleted)
 			require.ErrorIs(t, r.ctx.Err(), errRuleDeleted)
-			require.False(t, r.update(RuleVersionAndPauseStatus{fingerprint(rand.Uint64()), false}))
+			require.False(t, r.Update(RuleVersionAndPauseStatus{fingerprint(rand.Uint64()), false}))
 		})
 		t.Run("eval should do nothing", func(t *testing.T) {
 			r := blankRuleInfoForTests(context.Background())
@@ -221,7 +221,7 @@ func TestAlertRuleInfo(t *testing.T) {
 					}
 					switch rand.Intn(max) + 1 {
 					case 1:
-						r.update(RuleVersionAndPauseStatus{fingerprint(rand.Uint64()), false})
+						r.Update(RuleVersionAndPauseStatus{fingerprint(rand.Uint64()), false})
 					case 2:
 						r.Eval(&Evaluation{
 							scheduledAt: time.Now(),

--- a/pkg/services/ngalert/schedule/alert_rule_test.go
+++ b/pkg/services/ngalert/schedule/alert_rule_test.go
@@ -37,7 +37,7 @@ func TestAlertRuleInfo(t *testing.T) {
 			r := blankRuleInfoForTests(context.Background())
 			resultCh := make(chan bool)
 			go func() {
-				resultCh <- r.update(ruleVersionAndPauseStatus{fingerprint(rand.Uint64()), false})
+				resultCh <- r.update(RuleVersionAndPauseStatus{fingerprint(rand.Uint64()), false})
 			}()
 			select {
 			case <-r.updateCh:
@@ -48,8 +48,8 @@ func TestAlertRuleInfo(t *testing.T) {
 		})
 		t.Run("update should drop any concurrent sending to updateCh", func(t *testing.T) {
 			r := blankRuleInfoForTests(context.Background())
-			version1 := ruleVersionAndPauseStatus{fingerprint(rand.Uint64()), false}
-			version2 := ruleVersionAndPauseStatus{fingerprint(rand.Uint64()), false}
+			version1 := RuleVersionAndPauseStatus{fingerprint(rand.Uint64()), false}
+			version2 := RuleVersionAndPauseStatus{fingerprint(rand.Uint64()), false}
 
 			wg := sync.WaitGroup{}
 			wg.Add(1)
@@ -169,7 +169,7 @@ func TestAlertRuleInfo(t *testing.T) {
 			r := blankRuleInfoForTests(context.Background())
 			r.stop(errRuleDeleted)
 			require.ErrorIs(t, r.ctx.Err(), errRuleDeleted)
-			require.False(t, r.update(ruleVersionAndPauseStatus{fingerprint(rand.Uint64()), false}))
+			require.False(t, r.update(RuleVersionAndPauseStatus{fingerprint(rand.Uint64()), false}))
 		})
 		t.Run("eval should do nothing", func(t *testing.T) {
 			r := blankRuleInfoForTests(context.Background())
@@ -221,7 +221,7 @@ func TestAlertRuleInfo(t *testing.T) {
 					}
 					switch rand.Intn(max) + 1 {
 					case 1:
-						r.update(ruleVersionAndPauseStatus{fingerprint(rand.Uint64()), false})
+						r.update(RuleVersionAndPauseStatus{fingerprint(rand.Uint64()), false})
 					case 2:
 						r.eval(&Evaluation{
 							scheduledAt: time.Now(),
@@ -519,8 +519,8 @@ func TestRuleRoutine(t *testing.T) {
 		require.Greaterf(t, expectedToBeSent, 0, "State manager was expected to return at least one state that can be expired")
 
 		t.Run("should do nothing if version in channel is the same", func(t *testing.T) {
-			ruleInfo.updateCh <- ruleVersionAndPauseStatus{ruleFp, false}
-			ruleInfo.updateCh <- ruleVersionAndPauseStatus{ruleFp, false} // second time just to make sure that previous messages were handled
+			ruleInfo.updateCh <- RuleVersionAndPauseStatus{ruleFp, false}
+			ruleInfo.updateCh <- RuleVersionAndPauseStatus{ruleFp, false} // second time just to make sure that previous messages were handled
 
 			actualStates := sch.stateManager.GetStatesForRuleUID(rule.OrgID, rule.UID)
 			require.Len(t, actualStates, len(states))
@@ -529,7 +529,7 @@ func TestRuleRoutine(t *testing.T) {
 		})
 
 		t.Run("should clear the state and expire firing alerts if version in channel is greater", func(t *testing.T) {
-			ruleInfo.updateCh <- ruleVersionAndPauseStatus{ruleFp + 1, false}
+			ruleInfo.updateCh <- RuleVersionAndPauseStatus{ruleFp + 1, false}
 
 			require.Eventually(t, func() bool {
 				return len(sender.Calls()) > 0

--- a/pkg/services/ngalert/schedule/alert_rule_test.go
+++ b/pkg/services/ngalert/schedule/alert_rule_test.go
@@ -82,7 +82,7 @@ func TestAlertRuleInfo(t *testing.T) {
 				folderTitle: util.GenerateShortUID(),
 			}
 			go func() {
-				result, dropped := r.eval(data)
+				result, dropped := r.Eval(data)
 				resultCh <- evalResponse{result, dropped}
 			}()
 			select {
@@ -115,7 +115,7 @@ func TestAlertRuleInfo(t *testing.T) {
 			wg.Add(1)
 			go func() {
 				wg.Done()
-				result, dropped := r.eval(data)
+				result, dropped := r.Eval(data)
 				wg.Done()
 				resultCh1 <- evalResponse{result, dropped}
 			}()
@@ -123,7 +123,7 @@ func TestAlertRuleInfo(t *testing.T) {
 			wg.Add(2) // one when time1 is sent, another when go-routine for time2 has started
 			go func() {
 				wg.Done()
-				result, dropped := r.eval(data2)
+				result, dropped := r.Eval(data2)
 				resultCh2 <- evalResponse{result, dropped}
 			}()
 			wg.Wait() // at this point tick 1 has already been dropped
@@ -150,7 +150,7 @@ func TestAlertRuleInfo(t *testing.T) {
 				folderTitle: util.GenerateShortUID(),
 			}
 			go func() {
-				result, dropped := r.eval(data)
+				result, dropped := r.Eval(data)
 				resultCh <- evalResponse{result, dropped}
 			}()
 			runtime.Gosched()
@@ -179,7 +179,7 @@ func TestAlertRuleInfo(t *testing.T) {
 				rule:        models.AlertRuleGen()(),
 				folderTitle: util.GenerateShortUID(),
 			}
-			success, dropped := r.eval(data)
+			success, dropped := r.Eval(data)
 			require.False(t, success)
 			require.Nilf(t, dropped, "expected no dropped evaluations but got one")
 		})
@@ -223,7 +223,7 @@ func TestAlertRuleInfo(t *testing.T) {
 					case 1:
 						r.update(RuleVersionAndPauseStatus{fingerprint(rand.Uint64()), false})
 					case 2:
-						r.eval(&Evaluation{
+						r.Eval(&Evaluation{
 							scheduledAt: time.Now(),
 							rule:        models.AlertRuleGen()(),
 							folderTitle: util.GenerateShortUID(),

--- a/pkg/services/ngalert/schedule/alert_rule_test.go
+++ b/pkg/services/ngalert/schedule/alert_rule_test.go
@@ -154,7 +154,7 @@ func TestAlertRuleInfo(t *testing.T) {
 				resultCh <- evalResponse{result, dropped}
 			}()
 			runtime.Gosched()
-			r.stop(nil)
+			r.Stop(nil)
 			select {
 			case result := <-resultCh:
 				require.False(t, result.success)
@@ -167,13 +167,13 @@ func TestAlertRuleInfo(t *testing.T) {
 	t.Run("when rule evaluation is stopped", func(t *testing.T) {
 		t.Run("Update should do nothing", func(t *testing.T) {
 			r := blankRuleInfoForTests(context.Background())
-			r.stop(errRuleDeleted)
+			r.Stop(errRuleDeleted)
 			require.ErrorIs(t, r.ctx.Err(), errRuleDeleted)
 			require.False(t, r.Update(RuleVersionAndPauseStatus{fingerprint(rand.Uint64()), false}))
 		})
 		t.Run("eval should do nothing", func(t *testing.T) {
 			r := blankRuleInfoForTests(context.Background())
-			r.stop(nil)
+			r.Stop(nil)
 			data := &Evaluation{
 				scheduledAt: time.Now(),
 				rule:        models.AlertRuleGen()(),
@@ -185,14 +185,14 @@ func TestAlertRuleInfo(t *testing.T) {
 		})
 		t.Run("stop should do nothing", func(t *testing.T) {
 			r := blankRuleInfoForTests(context.Background())
-			r.stop(nil)
-			r.stop(nil)
+			r.Stop(nil)
+			r.Stop(nil)
 		})
 		t.Run("stop should do nothing if parent context stopped", func(t *testing.T) {
 			ctx, cancelFn := context.WithCancel(context.Background())
 			r := blankRuleInfoForTests(ctx)
 			cancelFn()
-			r.stop(nil)
+			r.Stop(nil)
 		})
 	})
 	t.Run("should be thread-safe", func(t *testing.T) {
@@ -229,7 +229,7 @@ func TestAlertRuleInfo(t *testing.T) {
 							folderTitle: util.GenerateShortUID(),
 						})
 					case 3:
-						r.stop(nil)
+						r.Stop(nil)
 					}
 				}
 				wg.Done()
@@ -279,7 +279,7 @@ func TestRuleRoutine(t *testing.T) {
 			t.Cleanup(cancel)
 			ruleInfo := factory.new(ctx)
 			go func() {
-				_ = ruleInfo.run(rule.GetKey())
+				_ = ruleInfo.Run(rule.GetKey())
 			}()
 
 			expectedTime := time.UnixMicro(rand.Int63())
@@ -428,7 +428,7 @@ func TestRuleRoutine(t *testing.T) {
 			ctx, cancel := context.WithCancel(context.Background())
 			ruleInfo := factory.new(ctx)
 			go func() {
-				err := ruleInfo.run(models.AlertRuleKey{})
+				err := ruleInfo.Run(models.AlertRuleKey{})
 				stoppedChan <- err
 			}()
 
@@ -448,11 +448,11 @@ func TestRuleRoutine(t *testing.T) {
 			factory := ruleFactoryFromScheduler(sch)
 			ruleInfo := factory.new(context.Background())
 			go func() {
-				err := ruleInfo.run(rule.GetKey())
+				err := ruleInfo.Run(rule.GetKey())
 				stoppedChan <- err
 			}()
 
-			ruleInfo.stop(errRuleDeleted)
+			ruleInfo.Stop(errRuleDeleted)
 			err := waitForErrChannel(t, stoppedChan)
 			require.NoError(t, err)
 
@@ -479,7 +479,7 @@ func TestRuleRoutine(t *testing.T) {
 		ruleInfo := factory.new(ctx)
 
 		go func() {
-			_ = ruleInfo.run(rule.GetKey())
+			_ = ruleInfo.Run(rule.GetKey())
 		}()
 
 		// init evaluation loop so it got the rule version
@@ -561,7 +561,7 @@ func TestRuleRoutine(t *testing.T) {
 		ruleInfo := factory.new(ctx)
 
 		go func() {
-			_ = ruleInfo.run(rule.GetKey())
+			_ = ruleInfo.Run(rule.GetKey())
 		}()
 
 		ruleInfo.evalCh <- &Evaluation{
@@ -667,7 +667,7 @@ func TestRuleRoutine(t *testing.T) {
 			ruleInfo := factory.new(ctx)
 
 			go func() {
-				_ = ruleInfo.run(rule.GetKey())
+				_ = ruleInfo.Run(rule.GetKey())
 			}()
 
 			ruleInfo.evalCh <- &Evaluation{
@@ -701,7 +701,7 @@ func TestRuleRoutine(t *testing.T) {
 		ruleInfo := factory.new(ctx)
 
 		go func() {
-			_ = ruleInfo.run(rule.GetKey())
+			_ = ruleInfo.Run(rule.GetKey())
 		}()
 
 		ruleInfo.evalCh <- &Evaluation{

--- a/pkg/services/ngalert/schedule/alert_rule_test.go
+++ b/pkg/services/ngalert/schedule/alert_rule_test.go
@@ -29,7 +29,7 @@ import (
 func TestAlertRuleInfo(t *testing.T) {
 	type evalResponse struct {
 		success     bool
-		droppedEval *evaluation
+		droppedEval *Evaluation
 	}
 
 	t.Run("when rule evaluation is not stopped", func(t *testing.T) {
@@ -76,7 +76,7 @@ func TestAlertRuleInfo(t *testing.T) {
 			r := blankRuleInfoForTests(context.Background())
 			expected := time.Now()
 			resultCh := make(chan evalResponse)
-			data := &evaluation{
+			data := &Evaluation{
 				scheduledAt: expected,
 				rule:        models.AlertRuleGen()(),
 				folderTitle: util.GenerateShortUID(),
@@ -101,12 +101,12 @@ func TestAlertRuleInfo(t *testing.T) {
 			time2 := time.UnixMilli(rand.Int63n(math.MaxInt64))
 			resultCh1 := make(chan evalResponse)
 			resultCh2 := make(chan evalResponse)
-			data := &evaluation{
+			data := &Evaluation{
 				scheduledAt: time1,
 				rule:        models.AlertRuleGen()(),
 				folderTitle: util.GenerateShortUID(),
 			}
-			data2 := &evaluation{
+			data2 := &Evaluation{
 				scheduledAt: time2,
 				rule:        data.rule,
 				folderTitle: data.folderTitle,
@@ -144,7 +144,7 @@ func TestAlertRuleInfo(t *testing.T) {
 		t.Run("eval should exit when context is cancelled", func(t *testing.T) {
 			r := blankRuleInfoForTests(context.Background())
 			resultCh := make(chan evalResponse)
-			data := &evaluation{
+			data := &Evaluation{
 				scheduledAt: time.Now(),
 				rule:        models.AlertRuleGen()(),
 				folderTitle: util.GenerateShortUID(),
@@ -174,7 +174,7 @@ func TestAlertRuleInfo(t *testing.T) {
 		t.Run("eval should do nothing", func(t *testing.T) {
 			r := blankRuleInfoForTests(context.Background())
 			r.stop(nil)
-			data := &evaluation{
+			data := &Evaluation{
 				scheduledAt: time.Now(),
 				rule:        models.AlertRuleGen()(),
 				folderTitle: util.GenerateShortUID(),
@@ -223,7 +223,7 @@ func TestAlertRuleInfo(t *testing.T) {
 					case 1:
 						r.update(ruleVersionAndPauseStatus{fingerprint(rand.Uint64()), false})
 					case 2:
-						r.eval(&evaluation{
+						r.eval(&Evaluation{
 							scheduledAt: time.Now(),
 							rule:        models.AlertRuleGen()(),
 							folderTitle: util.GenerateShortUID(),
@@ -284,7 +284,7 @@ func TestRuleRoutine(t *testing.T) {
 
 			expectedTime := time.UnixMicro(rand.Int63())
 
-			ruleInfo.evalCh <- &evaluation{
+			ruleInfo.evalCh <- &Evaluation{
 				scheduledAt: expectedTime,
 				rule:        rule,
 				folderTitle: folderTitle,
@@ -483,7 +483,7 @@ func TestRuleRoutine(t *testing.T) {
 		}()
 
 		// init evaluation loop so it got the rule version
-		ruleInfo.evalCh <- &evaluation{
+		ruleInfo.evalCh <- &Evaluation{
 			scheduledAt: sch.clock.Now(),
 			rule:        rule,
 			folderTitle: folderTitle,
@@ -564,7 +564,7 @@ func TestRuleRoutine(t *testing.T) {
 			_ = ruleInfo.run(rule.GetKey())
 		}()
 
-		ruleInfo.evalCh <- &evaluation{
+		ruleInfo.evalCh <- &Evaluation{
 			scheduledAt: sch.clock.Now(),
 			rule:        rule,
 		}
@@ -670,7 +670,7 @@ func TestRuleRoutine(t *testing.T) {
 				_ = ruleInfo.run(rule.GetKey())
 			}()
 
-			ruleInfo.evalCh <- &evaluation{
+			ruleInfo.evalCh <- &Evaluation{
 				scheduledAt: sch.clock.Now(),
 				rule:        rule,
 			}
@@ -704,7 +704,7 @@ func TestRuleRoutine(t *testing.T) {
 			_ = ruleInfo.run(rule.GetKey())
 		}()
 
-		ruleInfo.evalCh <- &evaluation{
+		ruleInfo.evalCh <- &Evaluation{
 			scheduledAt: sch.clock.Now(),
 			rule:        rule,
 		}

--- a/pkg/services/ngalert/schedule/loaded_metrics_reader.go
+++ b/pkg/services/ngalert/schedule/loaded_metrics_reader.go
@@ -10,7 +10,7 @@ import (
 
 var _ eval.AlertingResultsReader = AlertingResultsFromRuleState{}
 
-func (a *alertRuleInfo) newLoadedMetricsReader(rule *ngmodels.AlertRule) eval.AlertingResultsReader {
+func (a *alertRule) newLoadedMetricsReader(rule *ngmodels.AlertRule) eval.AlertingResultsReader {
 	return &AlertingResultsFromRuleState{
 		Manager: a.stateManager,
 		Rule:    rule,

--- a/pkg/services/ngalert/schedule/registry.go
+++ b/pkg/services/ngalert/schedule/registry.go
@@ -18,7 +18,7 @@ import (
 var errRuleDeleted = errors.New("rule deleted")
 
 type ruleFactory interface {
-	new(context.Context) *alertRuleInfo
+	new(context.Context) Rule
 }
 
 type alertRuleInfoRegistry struct {

--- a/pkg/services/ngalert/schedule/registry.go
+++ b/pkg/services/ngalert/schedule/registry.go
@@ -76,7 +76,7 @@ type ruleVersionAndPauseStatus struct {
 	IsPaused    bool
 }
 
-type evaluation struct {
+type Evaluation struct {
 	scheduledAt time.Time
 	rule        *models.AlertRule
 	folderTitle string

--- a/pkg/services/ngalert/schedule/registry.go
+++ b/pkg/services/ngalert/schedule/registry.go
@@ -71,7 +71,7 @@ func (r *alertRuleInfoRegistry) keyMap() map[models.AlertRuleKey]struct{} {
 	return definitionsIDs
 }
 
-type ruleVersionAndPauseStatus struct {
+type RuleVersionAndPauseStatus struct {
 	Fingerprint fingerprint
 	IsPaused    bool
 }

--- a/pkg/services/ngalert/schedule/registry.go
+++ b/pkg/services/ngalert/schedule/registry.go
@@ -21,18 +21,18 @@ type ruleFactory interface {
 	new(context.Context) Rule
 }
 
-type alertRuleInfoRegistry struct {
+type ruleRegistry struct {
 	mu    sync.Mutex
 	rules map[models.AlertRuleKey]Rule
 }
 
-func newRuleRegistry() alertRuleInfoRegistry {
-	return alertRuleInfoRegistry{rules: make(map[models.AlertRuleKey]Rule)}
+func newRuleRegistry() ruleRegistry {
+	return ruleRegistry{rules: make(map[models.AlertRuleKey]Rule)}
 }
 
 // getOrCreate gets rule routine from registry by the key. If it does not exist, it creates a new one.
 // Returns a pointer to the rule routine and a flag that indicates whether it is a new struct or not.
-func (r *alertRuleInfoRegistry) getOrCreate(context context.Context, key models.AlertRuleKey, factory ruleFactory) (Rule, bool) {
+func (r *ruleRegistry) getOrCreate(context context.Context, key models.AlertRuleKey, factory ruleFactory) (Rule, bool) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 
@@ -44,7 +44,7 @@ func (r *alertRuleInfoRegistry) getOrCreate(context context.Context, key models.
 	return rule, !ok
 }
 
-func (r *alertRuleInfoRegistry) exists(key models.AlertRuleKey) bool {
+func (r *ruleRegistry) exists(key models.AlertRuleKey) bool {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 
@@ -55,7 +55,7 @@ func (r *alertRuleInfoRegistry) exists(key models.AlertRuleKey) bool {
 // del removes pair that has specific key from the registry.
 // Returns 2-tuple where the first element is value of the removed pair
 // and the second element indicates whether element with the specified key existed.
-func (r *alertRuleInfoRegistry) del(key models.AlertRuleKey) (Rule, bool) {
+func (r *ruleRegistry) del(key models.AlertRuleKey) (Rule, bool) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	rule, ok := r.rules[key]
@@ -65,7 +65,7 @@ func (r *alertRuleInfoRegistry) del(key models.AlertRuleKey) (Rule, bool) {
 	return rule, ok
 }
 
-func (r *alertRuleInfoRegistry) keyMap() map[models.AlertRuleKey]struct{} {
+func (r *ruleRegistry) keyMap() map[models.AlertRuleKey]struct{} {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	definitionsIDs := make(map[models.AlertRuleKey]struct{}, len(r.rules))

--- a/pkg/services/ngalert/schedule/registry.go
+++ b/pkg/services/ngalert/schedule/registry.go
@@ -23,21 +23,21 @@ type ruleFactory interface {
 
 type alertRuleInfoRegistry struct {
 	mu            sync.Mutex
-	alertRuleInfo map[models.AlertRuleKey]*alertRuleInfo
+	alertRuleInfo map[models.AlertRuleKey]Rule
 }
 
 // getOrCreateInfo gets rule routine information from registry by the key. If it does not exist, it creates a new one.
 // Returns a pointer to the rule routine information and a flag that indicates whether it is a new struct or not.
-func (r *alertRuleInfoRegistry) getOrCreateInfo(context context.Context, key models.AlertRuleKey, factory ruleFactory) (*alertRuleInfo, bool) {
+func (r *alertRuleInfoRegistry) getOrCreateInfo(context context.Context, key models.AlertRuleKey, factory ruleFactory) (Rule, bool) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 
-	info, ok := r.alertRuleInfo[key]
+	rule, ok := r.alertRuleInfo[key]
 	if !ok {
-		info = factory.new(context)
-		r.alertRuleInfo[key] = info
+		rule = factory.new(context)
+		r.alertRuleInfo[key] = rule
 	}
-	return info, !ok
+	return rule, !ok
 }
 
 func (r *alertRuleInfoRegistry) exists(key models.AlertRuleKey) bool {
@@ -51,14 +51,14 @@ func (r *alertRuleInfoRegistry) exists(key models.AlertRuleKey) bool {
 // del removes pair that has specific key from alertRuleInfo.
 // Returns 2-tuple where the first element is value of the removed pair
 // and the second element indicates whether element with the specified key existed.
-func (r *alertRuleInfoRegistry) del(key models.AlertRuleKey) (*alertRuleInfo, bool) {
+func (r *alertRuleInfoRegistry) del(key models.AlertRuleKey) (Rule, bool) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
-	info, ok := r.alertRuleInfo[key]
+	rule, ok := r.alertRuleInfo[key]
 	if ok {
 		delete(r.alertRuleInfo, key)
 	}
-	return info, ok
+	return rule, ok
 }
 
 func (r *alertRuleInfoRegistry) keyMap() map[models.AlertRuleKey]struct{} {

--- a/pkg/services/ngalert/schedule/registry.go
+++ b/pkg/services/ngalert/schedule/registry.go
@@ -30,9 +30,9 @@ func newRuleRegistry() alertRuleInfoRegistry {
 	return alertRuleInfoRegistry{rules: make(map[models.AlertRuleKey]Rule)}
 }
 
-// getOrCreateInfo gets rule routine information from registry by the key. If it does not exist, it creates a new one.
-// Returns a pointer to the rule routine information and a flag that indicates whether it is a new struct or not.
-func (r *alertRuleInfoRegistry) getOrCreateInfo(context context.Context, key models.AlertRuleKey, factory ruleFactory) (Rule, bool) {
+// getOrCreate gets rule routine from registry by the key. If it does not exist, it creates a new one.
+// Returns a pointer to the rule routine and a flag that indicates whether it is a new struct or not.
+func (r *alertRuleInfoRegistry) getOrCreate(context context.Context, key models.AlertRuleKey, factory ruleFactory) (Rule, bool) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 

--- a/pkg/services/ngalert/schedule/schedule.go
+++ b/pkg/services/ngalert/schedule/schedule.go
@@ -171,7 +171,7 @@ func (sch *schedule) deleteAlertRule(keys ...ngmodels.AlertRuleKey) {
 			continue
 		}
 		// stop rule evaluation
-		ruleInfo.stop(errRuleDeleted)
+		ruleInfo.Stop(errRuleDeleted)
 	}
 	// Our best bet at this point is that we update the metrics with what we hope to schedule in the next tick.
 	alertRules, _ := sch.schedulableAlertRules.all()
@@ -264,7 +264,7 @@ func (sch *schedule) processTick(ctx context.Context, dispatcherGroup *errgroup.
 
 		if newRoutine && !invalidInterval {
 			dispatcherGroup.Go(func() error {
-				return ruleInfo.run(key)
+				return ruleInfo.Run(key)
 			})
 		}
 

--- a/pkg/services/ngalert/schedule/schedule.go
+++ b/pkg/services/ngalert/schedule/schedule.go
@@ -116,7 +116,7 @@ func NewScheduler(cfg SchedulerCfg, stateManager *state.Manager) *schedule {
 	}
 
 	sch := schedule{
-		registry:              alertRuleInfoRegistry{alertRuleInfo: make(map[ngmodels.AlertRuleKey]*alertRuleInfo)},
+		registry:              alertRuleInfoRegistry{alertRuleInfo: make(map[ngmodels.AlertRuleKey]Rule)},
 		maxAttempts:           cfg.MaxAttempts,
 		clock:                 cfg.C,
 		baseInterval:          cfg.BaseInterval,
@@ -202,7 +202,7 @@ func (sch *schedule) schedulePeriodic(ctx context.Context, t *ticker.T) error {
 }
 
 type readyToRunItem struct {
-	ruleInfo *alertRuleInfo
+	ruleInfo Rule
 	Evaluation
 }
 
@@ -300,7 +300,7 @@ func (sch *schedule) processTick(ctx context.Context, dispatcherGroup *errgroup.
 		if _, isUpdated := updated[key]; isUpdated && !isReadyToRun {
 			// if we do not need to eval the rule, check the whether rule was just updated and if it was, notify evaluation routine about that
 			sch.log.Debug("Rule has been updated. Notifying evaluation routine", key.LogContext()...)
-			go func(ri *alertRuleInfo, rule *ngmodels.AlertRule) {
+			go func(ri Rule, rule *ngmodels.AlertRule) {
 				ri.Update(RuleVersionAndPauseStatus{
 					Fingerprint: ruleWithFolder{rule: rule, folderTitle: folderTitle}.Fingerprint(),
 					IsPaused:    rule.IsPaused,

--- a/pkg/services/ngalert/schedule/schedule.go
+++ b/pkg/services/ngalert/schedule/schedule.go
@@ -252,7 +252,7 @@ func (sch *schedule) processTick(ctx context.Context, dispatcherGroup *errgroup.
 	)
 	for _, item := range alertRules {
 		key := item.GetKey()
-		ruleInfo, newRoutine := sch.registry.getOrCreateInfo(ctx, key, ruleFactory)
+		ruleInfo, newRoutine := sch.registry.getOrCreate(ctx, key, ruleFactory)
 
 		// enforce minimum evaluation interval
 		if item.IntervalSeconds < int64(sch.minRuleInterval.Seconds()) {

--- a/pkg/services/ngalert/schedule/schedule.go
+++ b/pkg/services/ngalert/schedule/schedule.go
@@ -330,7 +330,7 @@ func (sch *schedule) processTick(ctx context.Context, dispatcherGroup *errgroup.
 
 		time.AfterFunc(time.Duration(int64(i)*step), func() {
 			key := item.rule.GetKey()
-			success, dropped := item.ruleInfo.eval(&item.Evaluation)
+			success, dropped := item.ruleInfo.Eval(&item.Evaluation)
 			if !success {
 				sch.log.Debug("Scheduled evaluation was canceled because evaluation routine was stopped", append(key.LogContext(), "time", tick)...)
 				return

--- a/pkg/services/ngalert/schedule/schedule.go
+++ b/pkg/services/ngalert/schedule/schedule.go
@@ -47,7 +47,7 @@ type schedule struct {
 	// base tick rate (fastest possible configured check)
 	baseInterval time.Duration
 
-	// each alert rule gets its own channel and routine
+	// each rule gets its own channel and routine
 	registry ruleRegistry
 
 	maxAttempts int64

--- a/pkg/services/ngalert/schedule/schedule.go
+++ b/pkg/services/ngalert/schedule/schedule.go
@@ -203,7 +203,7 @@ func (sch *schedule) schedulePeriodic(ctx context.Context, t *ticker.T) error {
 
 type readyToRunItem struct {
 	ruleInfo *alertRuleInfo
-	evaluation
+	Evaluation
 }
 
 // TODO refactor to accept a callback for tests that will be called with things that are returned currently, and return nothing.
@@ -291,7 +291,7 @@ func (sch *schedule) processTick(ctx context.Context, dispatcherGroup *errgroup.
 
 		if isReadyToRun {
 			sch.log.Debug("Rule is ready to run on the current tick", "uid", item.UID, "tick", tickNum, "frequency", itemFrequency, "offset", offset)
-			readyToRun = append(readyToRun, readyToRunItem{ruleInfo: ruleInfo, evaluation: evaluation{
+			readyToRun = append(readyToRun, readyToRunItem{ruleInfo: ruleInfo, Evaluation: Evaluation{
 				scheduledAt: tick,
 				rule:        item,
 				folderTitle: folderTitle,
@@ -330,7 +330,7 @@ func (sch *schedule) processTick(ctx context.Context, dispatcherGroup *errgroup.
 
 		time.AfterFunc(time.Duration(int64(i)*step), func() {
 			key := item.rule.GetKey()
-			success, dropped := item.ruleInfo.eval(&item.evaluation)
+			success, dropped := item.ruleInfo.eval(&item.Evaluation)
 			if !success {
 				sch.log.Debug("Scheduled evaluation was canceled because evaluation routine was stopped", append(key.LogContext(), "time", tick)...)
 				return

--- a/pkg/services/ngalert/schedule/schedule.go
+++ b/pkg/services/ngalert/schedule/schedule.go
@@ -116,7 +116,7 @@ func NewScheduler(cfg SchedulerCfg, stateManager *state.Manager) *schedule {
 	}
 
 	sch := schedule{
-		registry:              alertRuleInfoRegistry{alertRuleInfo: make(map[ngmodels.AlertRuleKey]Rule)},
+		registry:              newRuleRegistry(),
 		maxAttempts:           cfg.MaxAttempts,
 		clock:                 cfg.C,
 		baseInterval:          cfg.BaseInterval,

--- a/pkg/services/ngalert/schedule/schedule.go
+++ b/pkg/services/ngalert/schedule/schedule.go
@@ -301,7 +301,7 @@ func (sch *schedule) processTick(ctx context.Context, dispatcherGroup *errgroup.
 			// if we do not need to eval the rule, check the whether rule was just updated and if it was, notify evaluation routine about that
 			sch.log.Debug("Rule has been updated. Notifying evaluation routine", key.LogContext()...)
 			go func(ri *alertRuleInfo, rule *ngmodels.AlertRule) {
-				ri.update(RuleVersionAndPauseStatus{
+				ri.Update(RuleVersionAndPauseStatus{
 					Fingerprint: ruleWithFolder{rule: rule, folderTitle: folderTitle}.Fingerprint(),
 					IsPaused:    rule.IsPaused,
 				})

--- a/pkg/services/ngalert/schedule/schedule.go
+++ b/pkg/services/ngalert/schedule/schedule.go
@@ -48,7 +48,7 @@ type schedule struct {
 	baseInterval time.Duration
 
 	// each alert rule gets its own channel and routine
-	registry alertRuleInfoRegistry
+	registry ruleRegistry
 
 	maxAttempts int64
 
@@ -165,13 +165,13 @@ func (sch *schedule) deleteAlertRule(keys ...ngmodels.AlertRuleKey) {
 			sch.log.Info("Alert rule cannot be removed from the scheduler as it is not scheduled", key.LogContext()...)
 		}
 		// Delete the rule routine
-		ruleInfo, ok := sch.registry.del(key)
+		ruleRoutine, ok := sch.registry.del(key)
 		if !ok {
 			sch.log.Info("Alert rule cannot be stopped as it is not running", key.LogContext()...)
 			continue
 		}
 		// stop rule evaluation
-		ruleInfo.Stop(errRuleDeleted)
+		ruleRoutine.Stop(errRuleDeleted)
 	}
 	// Our best bet at this point is that we update the metrics with what we hope to schedule in the next tick.
 	alertRules, _ := sch.schedulableAlertRules.all()
@@ -202,7 +202,7 @@ func (sch *schedule) schedulePeriodic(ctx context.Context, t *ticker.T) error {
 }
 
 type readyToRunItem struct {
-	ruleInfo Rule
+	ruleRoutine Rule
 	Evaluation
 }
 
@@ -252,7 +252,7 @@ func (sch *schedule) processTick(ctx context.Context, dispatcherGroup *errgroup.
 	)
 	for _, item := range alertRules {
 		key := item.GetKey()
-		ruleInfo, newRoutine := sch.registry.getOrCreate(ctx, key, ruleFactory)
+		ruleRoutine, newRoutine := sch.registry.getOrCreate(ctx, key, ruleFactory)
 
 		// enforce minimum evaluation interval
 		if item.IntervalSeconds < int64(sch.minRuleInterval.Seconds()) {
@@ -264,7 +264,7 @@ func (sch *schedule) processTick(ctx context.Context, dispatcherGroup *errgroup.
 
 		if newRoutine && !invalidInterval {
 			dispatcherGroup.Go(func() error {
-				return ruleInfo.Run(key)
+				return ruleRoutine.Run(key)
 			})
 		}
 
@@ -291,7 +291,7 @@ func (sch *schedule) processTick(ctx context.Context, dispatcherGroup *errgroup.
 
 		if isReadyToRun {
 			sch.log.Debug("Rule is ready to run on the current tick", "uid", item.UID, "tick", tickNum, "frequency", itemFrequency, "offset", offset)
-			readyToRun = append(readyToRun, readyToRunItem{ruleInfo: ruleInfo, Evaluation: Evaluation{
+			readyToRun = append(readyToRun, readyToRunItem{ruleRoutine: ruleRoutine, Evaluation: Evaluation{
 				scheduledAt: tick,
 				rule:        item,
 				folderTitle: folderTitle,
@@ -300,12 +300,12 @@ func (sch *schedule) processTick(ctx context.Context, dispatcherGroup *errgroup.
 		if _, isUpdated := updated[key]; isUpdated && !isReadyToRun {
 			// if we do not need to eval the rule, check the whether rule was just updated and if it was, notify evaluation routine about that
 			sch.log.Debug("Rule has been updated. Notifying evaluation routine", key.LogContext()...)
-			go func(ri Rule, rule *ngmodels.AlertRule) {
-				ri.Update(RuleVersionAndPauseStatus{
+			go func(routine Rule, rule *ngmodels.AlertRule) {
+				routine.Update(RuleVersionAndPauseStatus{
 					Fingerprint: ruleWithFolder{rule: rule, folderTitle: folderTitle}.Fingerprint(),
 					IsPaused:    rule.IsPaused,
 				})
-			}(ruleInfo, item)
+			}(ruleRoutine, item)
 			updatedRules = append(updatedRules, ngmodels.AlertRuleKeyWithVersion{
 				Version:      item.Version,
 				AlertRuleKey: item.GetKey(),
@@ -330,7 +330,7 @@ func (sch *schedule) processTick(ctx context.Context, dispatcherGroup *errgroup.
 
 		time.AfterFunc(time.Duration(int64(i)*step), func() {
 			key := item.rule.GetKey()
-			success, dropped := item.ruleInfo.Eval(&item.Evaluation)
+			success, dropped := item.ruleRoutine.Eval(&item.Evaluation)
 			if !success {
 				sch.log.Debug("Scheduled evaluation was canceled because evaluation routine was stopped", append(key.LogContext(), "time", tick)...)
 				return

--- a/pkg/services/ngalert/schedule/schedule.go
+++ b/pkg/services/ngalert/schedule/schedule.go
@@ -301,7 +301,7 @@ func (sch *schedule) processTick(ctx context.Context, dispatcherGroup *errgroup.
 			// if we do not need to eval the rule, check the whether rule was just updated and if it was, notify evaluation routine about that
 			sch.log.Debug("Rule has been updated. Notifying evaluation routine", key.LogContext()...)
 			go func(ri *alertRuleInfo, rule *ngmodels.AlertRule) {
-				ri.update(ruleVersionAndPauseStatus{
+				ri.update(RuleVersionAndPauseStatus{
 					Fingerprint: ruleWithFolder{rule: rule, folderTitle: folderTitle}.Fingerprint(),
 					IsPaused:    rule.IsPaused,
 				})

--- a/pkg/services/ngalert/schedule/schedule_unit_test.go
+++ b/pkg/services/ngalert/schedule/schedule_unit_test.go
@@ -365,7 +365,7 @@ func TestSchedule_deleteAlertRule(t *testing.T) {
 			key := rule.GetKey()
 			info, _ := sch.registry.getOrCreate(context.Background(), key, ruleFactory)
 			sch.deleteAlertRule(key)
-			require.ErrorIs(t, info.(*alertRuleInfo).ctx.Err(), errRuleDeleted)
+			require.ErrorIs(t, info.(*alertRule).ctx.Err(), errRuleDeleted)
 			require.False(t, sch.registry.exists(key))
 		})
 	})

--- a/pkg/services/ngalert/schedule/schedule_unit_test.go
+++ b/pkg/services/ngalert/schedule/schedule_unit_test.go
@@ -365,7 +365,7 @@ func TestSchedule_deleteAlertRule(t *testing.T) {
 			key := rule.GetKey()
 			info, _ := sch.registry.getOrCreateInfo(context.Background(), key, ruleFactory)
 			sch.deleteAlertRule(key)
-			require.ErrorIs(t, info.ctx.Err(), errRuleDeleted)
+			require.ErrorIs(t, info.(*alertRuleInfo).ctx.Err(), errRuleDeleted)
 			require.False(t, sch.registry.exists(key))
 		})
 	})

--- a/pkg/services/ngalert/schedule/schedule_unit_test.go
+++ b/pkg/services/ngalert/schedule/schedule_unit_test.go
@@ -363,7 +363,7 @@ func TestSchedule_deleteAlertRule(t *testing.T) {
 			ruleFactory := ruleFactoryFromScheduler(sch)
 			rule := models.AlertRuleGen()()
 			key := rule.GetKey()
-			info, _ := sch.registry.getOrCreateInfo(context.Background(), key, ruleFactory)
+			info, _ := sch.registry.getOrCreate(context.Background(), key, ruleFactory)
 			sch.deleteAlertRule(key)
 			require.ErrorIs(t, info.(*alertRuleInfo).ctx.Err(), errRuleDeleted)
 			require.False(t, sch.registry.exists(key))


### PR DESCRIPTION
**What is this feature?**

Adds an exported interface, `Rule`, that is used in place of the concrete alertRuleInfo. This decouples the scheduler fully from the rule implementation.

Rename accordingly:
- alertRuleInfoRegistry -> ruleRegistry
- alertRuleInfo -> alertRule

**Why do we need this feature?**

This PR gives the scheduler support for alternative implementations of rules.

Also, the tests for the rule routine now use the rule's public API rather than writing directly to internal channels. The tests are more realistic and cover more code.

**Which issue(s) does this PR fix?**:

n/a

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle.
- [x] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
