### PR TITLE
Alerting docs: document HTTP API to create templates

### DIFF
--- a/docs/sources/alerting/set-up/provision-alerting-resources/export-alerting-resources/index.md
+++ b/docs/sources/alerting/set-up/provision-alerting-resources/export-alerting-resources/index.md
@@ -131,13 +131,13 @@ To export mute timings from the Grafana UI, complete the following steps.
 
 You can use the [Alerting HTTP API][alerting_http_provisioning] to return existing alerting resources in JSON and import them to another Grafana instance using the same endpoint.
 
-| Resource                                                       | URI                                 | Methods          |
-| -------------------------------------------------------------- | ----------------------------------- | ---------------- |
-| [Alert rules][alerting_http_alertrules]                        | /api/v1/provisioning/alert-rules    | GET,POST,PUT,DEL |
-| [Contact points][alerting_http_contactpoints]                  | /api/v1/provisioning/contact-points | GET,POST,PUT,DEL |
-| [Notification policy tree][alerting_http_notificationpolicies] | /api/v1/provisioning/policies       | GET,PUT,DEL      |
-| [Mute timings][alerting_http_mutetimings]                      | /api/v1/provisioning/mute-timings   | GET,POST,PUT,DEL |
-| [Templates][alerting_http_templates]                           | /api/v1/provisioning/templates      | GET,PUT,DEL      |
+| Resource                                                       | URI                                 |
+| -------------------------------------------------------------- | ----------------------------------- |
+| [Alert rules][alerting_http_alertrules]                        | /api/v1/provisioning/alert-rules    |
+| [Contact points][alerting_http_contactpoints]                  | /api/v1/provisioning/contact-points |
+| [Notification policy tree][alerting_http_notificationpolicies] | /api/v1/provisioning/policies       |
+| [Mute timings][alerting_http_mutetimings]                      | /api/v1/provisioning/mute-timings   |
+| [Templates][alerting_http_templates]                           | /api/v1/provisioning/templates      |
 
 However, note the standard endpoints return a JSON format that is not compatible for provisioning through configuration files or Terraform, except the `/export` endpoints listed below.
 

--- a/docs/sources/shared/alerts/alerting_provisioning.md
+++ b/docs/sources/shared/alerts/alerting_provisioning.md
@@ -157,12 +157,12 @@ For managing resources related to [data source-managed alerts]({{< relref "/docs
 
 ### Templates
 
-| Method | URI                                  | Name                                            | Summary                                    |
-| ------ | ------------------------------------ | ----------------------------------------------- | ------------------------------------------ |
-| DELETE | /api/v1/provisioning/templates/:name | [route delete template](#route-delete-template) | Delete a template.                         |
-| GET    | /api/v1/provisioning/templates/:name | [route get template](#route-get-template)       | Get a notification template.               |
-| GET    | /api/v1/provisioning/templates       | [route get templates](#route-get-templates)     | Get all notification templates.            |
-| PUT    | /api/v1/provisioning/templates/:name | [route put template](#route-put-template)       | Updates an existing notification template. |
+| Method | URI                                  | Name                                            | Summary                                   |
+| ------ | ------------------------------------ | ----------------------------------------------- | ----------------------------------------- |
+| DELETE | /api/v1/provisioning/templates/:name | [route delete template](#route-delete-template) | Delete a template.                        |
+| GET    | /api/v1/provisioning/templates/:name | [route get template](#route-get-template)       | Get a notification template.              |
+| GET    | /api/v1/provisioning/templates       | [route get templates](#route-get-templates)     | Get all notification templates.           |
+| PUT    | /api/v1/provisioning/templates/:name | [route put template](#route-put-template)       | Create or update a notification template. |
 
 ## Edit resources in the Grafana UI
 
@@ -1200,7 +1200,7 @@ Status: Bad Request
 
 [ValidationError](#validation-error)
 
-### <span id="route-put-template"></span> Updates an existing notification template. (_RoutePutTemplate_)
+### <span id="route-put-template"></span> Create or update a notification template. (_RoutePutTemplate_)
 
 ```
 PUT /api/v1/provisioning/templates/:name


### PR DESCRIPTION
I thought there was no HTTP API endpoint to create notification templates because of the [existing docs](https://grafana.com/docs/grafana/latest/developers/http_api/alerting_provisioning/#templates) and [ngalert/api/api_provisioning.go#L40](https://github.com/grafana/grafana/blob/main/pkg/services/ngalert/api/api_provisioning.go#L40). 

But I noticed the Terraform provider also creates templates via `PUT` request to `/api/v1/provisioning/templates/:name`. 

I tested it with `curl` command and it works:

```bash
curl -X PUT 'http://localhost:3000/api/v1/provisioning/templates/my_new_template' \
     -H 'Content-Type: application/json' \
     -H 'Authorization: Bearer <api-token>' \
     -d ‘{"template": "three cats firing alerts"}'
```

This PR is a minor doc change to clarify this. I expect this being the last PR in the recent updates of the Alerting Provisioning docs. 
