### PR TITLE
Document `verification_email_max_lifetime_duration` config option

### DIFF
--- a/conf/defaults.ini
+++ b/conf/defaults.ini
@@ -500,6 +500,9 @@ editors_can_admin = false
 # The duration in time a user invitation remains valid before expiring. This setting should be expressed as a duration. Examples: 6h (hours), 2d (days), 1w (week). Default is 24h (24 hours). The minimum supported duration is 15m (15 minutes).
 user_invite_max_lifetime_duration = 24h
 
+# The duration in time a verification email, used to update the email address of a user, remains valid before expiring. This setting should be expressed as a duration. Examples: 6h (hours), 2d (days), 1w (week). Default is 1h (1 hour).
+verification_email_max_lifetime_duration = 1h
+
 # Enter a comma-separated list of usernames to hide them in the Grafana UI. These users are shown to Grafana admins and to themselves.
 hidden_users =
 

--- a/conf/sample.ini
+++ b/conf/sample.ini
@@ -476,6 +476,9 @@
 # The duration in time a user invitation remains valid before expiring. This setting should be expressed as a duration. Examples: 6h (hours), 2d (days), 1w (week). Default is 24h (24 hours). The minimum supported duration is 15m (15 minutes).
 ;user_invite_max_lifetime_duration = 24h
 
+# The duration in time a verification email, used to update the email address of a user, remains valid before expiring. This setting should be expressed as a duration. Examples: 6h (hours), 2d (days), 1w (week). Default is 1h (1 hour).
+;verification_email_max_lifetime_duration = 1h
+
 # Enter a comma-separated list of users login to hide them in the Grafana UI. These users are shown to Grafana admins and themselves.
 ; hidden_users =
 

--- a/docs/sources/setup-grafana/configure-grafana/_index.md
+++ b/docs/sources/setup-grafana/configure-grafana/_index.md
@@ -833,7 +833,7 @@ The available options are `Viewer` (default), `Admin`, `Editor`, and `None`. For
 
 ### verify_email_enabled
 
-Require email validation before sign up completes. Default is `false`.
+Require email validation before sign up completes or when updating a user email address. Default is `false`.
 
 ### login_hint
 
@@ -877,6 +877,12 @@ Default is `false`.
 The duration in time a user invitation remains valid before expiring.
 This setting should be expressed as a duration. Examples: 6h (hours), 2d (days), 1w (week).
 Default is `24h` (24 hours). The minimum supported duration is `15m` (15 minutes).
+
+### verification_email_max_lifetime_duration
+
+The duration in time a verification email, used to update the email address of a user, remains valid before expiring.
+This setting should be expressed as a duration. Examples: 6h (hours), 2d (days), 1w (week).
+Default is 1h (1 hour).
 
 ### hidden_users
 


### PR DESCRIPTION
Document `verification_email_max_lifetime_duration` config option introduced in https://github.com/grafana/grafana/pull/82914.
