### PR TITLE
TracesPanel: Expose focusedSpanLink and createFocusSpanLink as options

### DIFF
--- a/public/app/features/explore/TraceView/TraceView.tsx
+++ b/public/app/features/explore/TraceView/TraceView.tsx
@@ -64,10 +64,20 @@ type Props = {
   datasource: DataSourceApi<DataQuery, DataSourceJsonData, {}> | undefined;
   topOfViewRef?: RefObject<HTMLDivElement>;
   createSpanLink?: SpanLinkFunc;
+  focusedSpanId?: string;
+  createFocusSpanLink?: (traceId: string, spanId: string) => LinkModel<Field>;
 };
 
 export function TraceView(props: Props) {
-  const { traceProp, datasource, topOfViewRef, exploreId, createSpanLink: createSpanLinkFromProps } = props;
+  const {
+    traceProp,
+    datasource,
+    topOfViewRef,
+    exploreId,
+    createSpanLink: createSpanLinkFromProps,
+    focusedSpanId: focusedSpanIdFromProps,
+    createFocusSpanLink: createFocusSpanLinkFromProps,
+  } = props;
 
   const {
     detailStates,
@@ -101,12 +111,15 @@ export function TraceView(props: Props) {
    */
   const [spanNameColumnWidth, setSpanNameColumnWidth] = useState(0.4);
 
-  const [focusedSpanId, createFocusSpanLink] = useFocusSpanLink({
+  const [focusedSpanIdExplore, createFocusSpanLinkExplore] = useFocusSpanLink({
     refId: props.dataFrames[0]?.refId,
     exploreId: props.exploreId!,
     datasource,
     splitOpenFn: props.splitOpenFn!,
   });
+
+  const focusedSpanId = focusedSpanIdFromProps ?? focusedSpanIdExplore;
+  const createFocusSpanLink = createFocusSpanLinkFromProps ?? createFocusSpanLinkExplore;
 
   const traceTimeline: TTraceTimeline = useMemo(
     () => ({

--- a/public/app/plugins/panel/traces/TracesPanel.tsx
+++ b/public/app/plugins/panel/traces/TracesPanel.tsx
@@ -2,7 +2,7 @@ import { css } from '@emotion/css';
 import React, { useMemo, createRef } from 'react';
 import { useAsync } from 'react-use';
 
-import { PanelProps } from '@grafana/data';
+import { Field, LinkModel, PanelProps } from '@grafana/data';
 import { getDataSourceSrv } from '@grafana/runtime';
 import { TraceView } from 'app/features/explore/TraceView/TraceView';
 import { SpanLinkFunc } from 'app/features/explore/TraceView/components';
@@ -17,6 +17,8 @@ const styles = {
 
 export interface TracesPanelOptions {
   createSpanLink?: SpanLinkFunc;
+  focusedSpanId?: string;
+  createFocusSpanLink?: (traceId: string, spanId: string) => LinkModel<Field>;
 }
 
 export const TracesPanel = ({ data, options }: PanelProps<TracesPanelOptions>) => {
@@ -44,6 +46,8 @@ export const TracesPanel = ({ data, options }: PanelProps<TracesPanelOptions>) =
         datasource={dataSource.value}
         topOfViewRef={topOfViewRef}
         createSpanLink={options.createSpanLink}
+        focusedSpanId={options.focusedSpanId}
+        createFocusSpanLink={options.createFocusSpanLink}
       />
     </div>
   );


### PR DESCRIPTION
**What is this feature?**

Exposes `focusedSpanLink` and `createFocusSpanLink`  as options for `TracesPanel`,  so focused span link and link content can be customized for the panel outside of explore. 

**Why do we need this feature?**

So span link and focused span can be overriden by app plugin developers when using `TracesPanel` with scenes.
Specificaly App o11y needs this to fix https://github.com/grafana/app-observability-plugin/issues/859

