### PR TITLE
[v10.2.x] Prometheus: Fix $__rate_interval calculation

### DIFF
--- a/pkg/tsdb/prometheus/models/query.go
+++ b/pkg/tsdb/prometheus/models/query.go
@@ -96,7 +96,6 @@ func Parse(query backend.DataQuery, dsScrapeInterval string, intervalCalculator 
 		query.Interval,
 		calculatedMinStep,
 		model.Interval,
-		dsScrapeInterval,
 		timeRange,
 	)
 	var rangeQuery, instantQuery bool
@@ -228,14 +227,12 @@ func calculateRateInterval(
 // queryInterval                Requested interval in milliseconds. This value may be overridden by MinStep in query options
 // calculatedMinStep            Calculated final step value. It was calculated in calculatePrometheusInterval
 // requestedMinStep             Requested minimum step value. QueryModel.interval
-// dsScrapeInterval             Data source scrape interval in the config
 // timeRange                    Requested time range for query
 func interpolateVariables(
 	expr string,
 	queryInterval time.Duration,
 	calculatedMinStep time.Duration,
 	requestedMinStep string,
-	dsScrapeInterval string,
 	timeRange time.Duration,
 ) string {
 	rangeMs := timeRange.Milliseconds()
@@ -247,9 +244,6 @@ func interpolateVariables(
 	} else {
 		if requestedMinStep == varInterval || requestedMinStep == varIntervalAlt {
 			requestedMinStep = calculatedMinStep.String()
-		}
-		if requestedMinStep == "" {
-			requestedMinStep = dsScrapeInterval
 		}
 		rateInterval = calculateRateInterval(queryInterval, requestedMinStep)
 	}

--- a/pkg/tsdb/prometheus/models/query_test.go
+++ b/pkg/tsdb/prometheus/models/query_test.go
@@ -571,7 +571,7 @@ func TestRateInterval(t *testing.T) {
 				},
 			},
 			want: &models.Query{
-				Expr: "rate(rpc_durations_seconds_count[2m0s])",
+				Expr: "rate(rpc_durations_seconds_count[2m30s])",
 				Step: time.Second * 30,
 			},
 		},
@@ -637,75 +637,6 @@ func TestRateInterval(t *testing.T) {
 			require.Equal(t, tt.want.Step, res.Step)
 		})
 	}
-
-	t.Run("minStep is auto and ds scrape interval 30s and time range 1 hour", func(t *testing.T) {
-		query := backend.DataQuery{
-			RefID:         "G",
-			QueryType:     "",
-			MaxDataPoints: 1613,
-			Interval:      30 * time.Second,
-			TimeRange: backend.TimeRange{
-				From: now,
-				To:   now.Add(1 * time.Hour),
-			},
-			JSON: []byte(`{
-			"datasource":{"type":"prometheus","uid":"zxS5e5W4k"},
-			"datasourceId":38,
-			"editorMode":"code",
-			"exemplar":false,
-			"expr":"sum(rate(process_cpu_seconds_total[$__rate_interval]))",
-			"instant":false,
-			"interval":"",
-			"intervalMs":30000,
-			"key":"Q-f96b6729-c47a-4ea8-8f71-a79774cf9bd5-0",
-			"legendFormat":"__auto",
-			"maxDataPoints":1613,
-			"range":true,
-			"refId":"G",
-			"requestId":"1G",
-			"utcOffsetSec":3600
-		}`),
-		}
-		res, err := models.Parse(query, "30s", intervalCalculator, false)
-		require.NoError(t, err)
-		require.Equal(t, "sum(rate(process_cpu_seconds_total[2m0s]))", res.Expr)
-		require.Equal(t, 30*time.Second, res.Step)
-	})
-
-	t.Run("minStep is auto and ds scrape interval 15s and time range 5 minutes", func(t *testing.T) {
-		query := backend.DataQuery{
-			RefID:         "A",
-			QueryType:     "",
-			MaxDataPoints: 1055,
-			Interval:      15 * time.Second,
-			TimeRange: backend.TimeRange{
-				From: now,
-				To:   now.Add(5 * time.Minute),
-			},
-			JSON: []byte(`{
-			"datasource": {
-		        "type": "prometheus",
-		        "uid": "2z9d6ElGk"
-		    },
-		    "editorMode": "code",
-		    "expr": "sum(rate(cache_requests_total[$__rate_interval]))",
-		    "legendFormat": "__auto",
-		    "range": true,
-		    "refId": "A",
-		    "exemplar": false,
-		    "requestId": "1A",
-		    "utcOffsetSec": 0,
-		    "interval": "",
-		    "datasourceId": 508,
-		    "intervalMs": 15000,
-		    "maxDataPoints": 1055
-		}`),
-		}
-		res, err := models.Parse(query, "15s", intervalCalculator, false)
-		require.NoError(t, err)
-		require.Equal(t, "sum(rate(cache_requests_total[1m0s]))", res.Expr)
-		require.Equal(t, 15*time.Second, res.Step)
-	})
 }
 
 func mockQuery(expr string, interval string, intervalMs int64, timeRange *backend.TimeRange) backend.DataQuery {
@@ -716,7 +647,7 @@ func mockQuery(expr string, interval string, intervalMs int64, timeRange *backen
 		}
 	}
 	return backend.DataQuery{
-		Interval: time.Duration(intervalMs) * time.Millisecond,
+		Interval: 2 * time.Minute,
 		JSON: []byte(fmt.Sprintf(`{
 			"expr": "%s",
 			"format": "time_series",


### PR DESCRIPTION
Manual Backport b607a4e0a2ee2a9b368c6ebcf4021249768b347e from #77234

---

#### Background Information
`$__rate_interval` calculation is explained [here in detail](https://grafana.com/docs/grafana/latest/datasources/prometheus/template-variables/#use-__rate_interval).
Shortly it is `max($__interval + Scrape interval, 4 * Scrape interval)` **where Scrape interval is the “Min step” setting (also known as query*interval, a setting per PromQL query) if any is set. Otherwise, Grafana uses the Prometheus data source’s “Scrape interval” setting.**
Why we need that in the first place is explained here in [this beautiful blog post](https://grafana.com/blog/2020/09/28/new-in-grafana-7.2-__rate_interval-for-prometheus-rate-queries-that-just-work/).
`$__interval` calculation is explained [here](https://grafana.com/docs/grafana/latest/dashboards/variables/add-template-variables/#__interval).

For all data sources, we have a `Min Interval` value. The default value of this is `15s` or you can set it differently in data source settings. To be able to interpolate `$__interval` we also send `intervalMs`. This is **always** the millisecond value of `Interval` in the panel below.

**Last 2 Days time range**
![image](https://github.com/grafana/grafana/assets/820946/3d7278d5-c195-4efc-be4e-c72641e702e3)


In the Prometheus query editor, we also have `Min Step` for queries. 
![image](https://github.com/grafana/grafana/assets/820946/4872ddd1-1e9f-4009-9587-ddd4575591d3)

Users might want to override `Min Interval` or `Min Step`. 

`Min Interval` setting has precedence over the scrape interval as set in the data source.
`Min Step` setting has precedence over the `Min Interval`.

Backend receives that as `interval`. This can be seen in `Query Inspector`.

So let's use the values below as example. 
| | |
|--|--|
| Data source Scrape Interval | 30s |
| Time Range | Last 2 Days |
| Interval (calculated Automatically) | 1m |
| Min Interval (Overriden) | 100s |
| Min Step (Overriden) | 150s |

![image](https://github.com/grafana/grafana/assets/820946/b81984c1-5d25-4b4d-b490-eb9748ad00f2)


Based on the documentation let's put the values in the equation and find the `$__rate_interval` value. 
```
max($__interval + query.interval, 4 * query.interval)
max(       60   +  150 ,          4 * 150)          
```

So this should give the value as 600s. And the `step` value we send to Prometheus should be `150s => 2m30s`.  Let's see it in the query inspector:
![image](https://github.com/grafana/grafana/assets/820946/91dc5388-7eec-4c90-a4c8-76427dcc6886)

As you can see something is not quite right. So this PR is fixing it. Let's switch to this branch and run our query again.
![image](https://github.com/grafana/grafana/assets/820946/0d912b16-ef76-4723-acdc-0571b6df7953)


**Who is this feature for?**

Prometheus users

**Special notes for your reviewer:**
- I updated the variable names since they were quite confusing
- I put some comments 

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
