### PR TITLE
Alerting: Add placeholder to the Email Contact Point Message

### DIFF
--- a/pkg/services/ngalert/notifier/channels_config/available_channels.go
+++ b/pkg/services/ngalert/notifier/channels_config/available_channels.go
@@ -267,6 +267,7 @@ func GetAvailableNotifiers() []*NotifierPlugin {
 					Description:  "Optional message. You can use templates to customize this field. Using a custom message will replace the default message",
 					Element:      ElementTypeTextArea,
 					PropertyName: "message",
+					Placeholder:  alertingTemplates.DefaultMessageEmbed,
 				},
 				{ // New in 9.0.
 					Label:        "Subject",


### PR DESCRIPTION
Discussed and agreed by @konrad147 

This PR adds a placeholder to the message input of the Email Contact Point, indicating the default value that will be used. 

**Before**

<img width="563" alt="Screenshot 2024-03-07 at 13 07 30" src="https://github.com/grafana/grafana/assets/825430/483f48c5-42fd-46b7-9c00-130268d982cb">

**Now**

<img width="563" alt="Screenshot 2024-03-07 at 13 02 54" src="https://github.com/grafana/grafana/assets/825430/06c34834-2339-4b5e-9127-03937b698395">


This minor change clarifies the connection between contact point templating properties and notification templates. 

Other contact points already display the placeholder value-this one seems to be missing.
