### PR TITLE
AuthN: Use sync hook to fetch service account

### DIFF
--- a/pkg/services/authn/authnimpl/service.go
+++ b/pkg/services/authn/authnimpl/service.go
@@ -90,7 +90,7 @@ func ProvideService(
 	usageStats.RegisterMetricsFunc(s.getUsageStats)
 
 	s.RegisterClient(clients.ProvideRender(userService, renderService))
-	s.RegisterClient(clients.ProvideAPIKey(apikeyService, userService))
+	s.RegisterClient(clients.ProvideAPIKey(apikeyService))
 
 	if cfg.LoginCookieName != "" {
 		s.RegisterClient(clients.ProvideSession(cfg, sessionService))

--- a/pkg/services/authn/authnimpl/sync/user_sync.go
+++ b/pkg/services/authn/authnimpl/sync/user_sync.go
@@ -111,7 +111,7 @@ func (s *UserSync) FetchSyncedUserHook(ctx context.Context, identity *authn.Iden
 		return nil
 	}
 	namespace, id := identity.GetNamespacedID()
-	if namespace != authn.NamespaceUser {
+	if namespace != authn.NamespaceUser && namespace != authn.NamespaceServiceAccount {
 		return nil
 	}
 

--- a/pkg/services/authn/clients/api_key_test.go
+++ b/pkg/services/authn/clients/api_key_test.go
@@ -16,7 +16,6 @@ import (
 	"github.com/grafana/grafana/pkg/services/authn"
 	"github.com/grafana/grafana/pkg/services/login"
 	"github.com/grafana/grafana/pkg/services/org"
-	"github.com/grafana/grafana/pkg/services/user"
 )
 
 var (
@@ -29,7 +28,6 @@ func TestAPIKey_Authenticate(t *testing.T) {
 		desc             string
 		req              *authn.Request
 		expectedKey      *apikey.APIKey
-		expectedUser     *user.SignedInUser
 		expectedErr      error
 		expectedIdentity *authn.Identity
 	}


### PR DESCRIPTION
**What is this feature?**
Instead of using user service directly we can use the sync hook to get information about service account.

This is needed for when we move hooks and clients out.

**Which issue(s) does this PR fix?**:
Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
