### PR TITLE
Alerting: Remove video from Alert Getting Started page

### DIFF
--- a/.betterer.results
+++ b/.betterer.results
@@ -2222,18 +2222,6 @@ exports[`better eslint`] = {
       [0, 0, 0, "Styles should be written using objects.", "3"],
       [0, 0, 0, "Styles should be written using objects.", "4"]
     ],
-    "public/app/features/alerting/unified/home/GettingStarted.tsx:5381": [
-      [0, 0, 0, "Styles should be written using objects.", "0"],
-      [0, 0, 0, "Styles should be written using objects.", "1"],
-      [0, 0, 0, "Styles should be written using objects.", "2"],
-      [0, 0, 0, "Styles should be written using objects.", "3"],
-      [0, 0, 0, "Styles should be written using objects.", "4"],
-      [0, 0, 0, "Styles should be written using objects.", "5"],
-      [0, 0, 0, "Styles should be written using objects.", "6"],
-      [0, 0, 0, "Styles should be written using objects.", "7"],
-      [0, 0, 0, "Styles should be written using objects.", "8"],
-      [0, 0, 0, "Styles should be written using objects.", "9"]
-    ],
     "public/app/features/alerting/unified/hooks/useAlertmanagerConfig.ts:5381": [
       [0, 0, 0, "Do not use any type assertions.", "0"]
     ],

--- a/.betterer.results
+++ b/.betterer.results
@@ -2232,12 +2232,7 @@ exports[`better eslint`] = {
       [0, 0, 0, "Styles should be written using objects.", "6"],
       [0, 0, 0, "Styles should be written using objects.", "7"],
       [0, 0, 0, "Styles should be written using objects.", "8"],
-      [0, 0, 0, "Styles should be written using objects.", "9"],
-      [0, 0, 0, "Styles should be written using objects.", "10"],
-      [0, 0, 0, "Styles should be written using objects.", "11"],
-      [0, 0, 0, "Styles should be written using objects.", "12"],
-      [0, 0, 0, "Styles should be written using objects.", "13"],
-      [0, 0, 0, "Styles should be written using objects.", "14"]
+      [0, 0, 0, "Styles should be written using objects.", "9"]
     ],
     "public/app/features/alerting/unified/hooks/useAlertmanagerConfig.ts:5381": [
       [0, 0, 0, "Do not use any type assertions.", "0"]

--- a/public/app/features/alerting/unified/home/GettingStarted.tsx
+++ b/public/app/features/alerting/unified/home/GettingStarted.tsx
@@ -68,7 +68,7 @@ export default function GettingStarted() {
               points.
             </li>
           </ul>
-          <TextLink href="https://grafana.com/docs/grafana/latest/alerting/" icon="angle-right" inline={false}>
+          <TextLink href="https://grafana.com/docs/grafana/latest/alerting/" icon="angle-right" inline={false} external>
             Read more in the docs
           </TextLink>
         </Stack>

--- a/public/app/features/alerting/unified/home/GettingStarted.tsx
+++ b/public/app/features/alerting/unified/home/GettingStarted.tsx
@@ -76,31 +76,31 @@ export default function GettingStarted() {
 }
 
 const getWelcomePageStyles = (theme: GrafanaTheme2) => ({
-  grid: css`
-    display: grid;
-    grid-template-rows: min-content auto auto;
-    grid-template-columns: 1fr;
-    gap: ${theme.spacing(2)};
-    width: 100%;
+  grid: css({
+    display: 'grid',
+    gridTemplateRows: 'min-content auto auto',
+    gridTemplateColumns: '1fr',
+    gap: theme.spacing(2),
+    width: '100%',
 
-    ${theme.breakpoints.up('lg')} {
-      grid-template-columns: 3fr 2fr;
-    }
-  `,
-  ctaContainer: css`
-    grid-column: 1 / span 5;
-  `,
-  svgContainer: css`
-    & svg {
-      max-width: 900px;
-    }
-  `,
-  list: css`
-    margin: ${theme.spacing(0, 2)};
-    & > li {
-      margin-bottom: ${theme.spacing(1)};
-    }
-  `,
+    [theme.breakpoints.up('lg')]: {
+      gridTemplateColumns: '3fr 2fr',
+    },
+  }),
+  ctaContainer: css({
+    gridColumn: '1 / span 5',
+  }),
+  svgContainer: css({
+    '& svg': {
+      maxWidth: '900px',
+    },
+  }),
+  list: css({
+    margin: theme.spacing(0, 2),
+    '& > li': {
+      marginBottom: theme.spacing(1),
+    },
+  }),
 });
 
 export function WelcomeHeader({ className }: { className?: string }) {
@@ -144,26 +144,25 @@ const getWelcomeHeaderStyles = (theme: GrafanaTheme2) => ({
     color: theme.colors.text.secondary,
     paddingBottom: theme.spacing(2),
   }),
-  ctaContainer: css`
-    padding: ${theme.spacing(2)};
-    display: flex;
-    gap: ${theme.spacing(4)};
-    justify-content: space-between;
-    flex-wrap: wrap;
+  ctaContainer: css({
+    padding: theme.spacing(2),
+    display: 'flex',
+    gap: theme.spacing(4),
+    justifyContent: 'space-between',
+    flexWrap: 'wrap',
 
-    ${theme.breakpoints.down('lg')} {
-      flex-direction: column;
-    }
-  `,
+    [theme.breakpoints.down('lg')]: {
+      flexDirection: 'column',
+    },
+  }),
+  separator: css({
+    width: '1px',
+    backgroundColor: theme.colors.border.medium,
 
-  separator: css`
-    width: 1px;
-    background-color: ${theme.colors.border.medium};
-
-    ${theme.breakpoints.down('lg')} {
-      display: none;
-    }
-  `,
+    [theme.breakpoints.down('lg')]: {
+      display: 'none',
+    },
+  }),
 });
 
 interface WelcomeCTABoxProps {
@@ -192,31 +191,31 @@ function WelcomeCTABox({ title, description, href, hrefText }: WelcomeCTABoxProp
 }
 
 const getWelcomeCTAButtonStyles = (theme: GrafanaTheme2) => ({
-  container: css`
-    flex: 1;
-    min-width: 240px;
-    display: grid;
-    row-gap: ${theme.spacing(1)};
-    grid-template-columns: min-content 1fr 1fr 1fr;
-    grid-template-rows: min-content auto min-content;
+  container: css({
+    flex: 1,
+    minWidth: '240px',
+    display: 'grid',
+    rowGap: theme.spacing(1),
+    gridTemplateColumns: 'min-content 1fr 1fr 1fr',
+    gridTemplateRows: 'min-content auto min-content',
 
-    & h2 {
-      margin-bottom: 0;
-      grid-column: 2 / span 3;
-      grid-row: 1;
-    }
-  `,
+    '& h2': {
+      marginBottom: 0,
+      gridColumn: '2 / span 3',
+      gridRow: 1,
+    },
+  }),
 
-  desc: css`
-    grid-column: 2 / span 3;
-    grid-row: 2;
-  `,
+  desc: css({
+    gridColumn: '2 / span 3',
+    gridRow: 2,
+  }),
 
-  actionRow: css`
-    grid-column: 2 / span 3;
-    grid-row: 3;
-    max-width: 240px;
-  `,
+  actionRow: css({
+    gridColumn: '2 / span 3',
+    gridRow: 3,
+    maxWidth: '240px',
+  }),
 });
 
 function ContentBox({ children, className }: React.PropsWithChildren<{ className?: string }>) {
@@ -226,9 +225,9 @@ function ContentBox({ children, className }: React.PropsWithChildren<{ className
 }
 
 const getContentBoxStyles = (theme: GrafanaTheme2) => ({
-  box: css`
-    padding: ${theme.spacing(2)};
-    background-color: ${theme.colors.background.secondary};
-    border-radius: ${theme.shape.radius.default};
-  `,
+  box: css({
+    padding: theme.spacing(2),
+    backgroundColor: theme.colors.background.secondary,
+    borderRadius: theme.shape.radius.default,
+  }),
 });

--- a/public/app/features/alerting/unified/home/GettingStarted.tsx
+++ b/public/app/features/alerting/unified/home/GettingStarted.tsx
@@ -67,21 +67,6 @@ export default function GettingStarted({ showWelcomeHeader }: { showWelcomeHeade
           </div>
         </Stack>
       </ContentBox>
-      <ContentBox className={styles.videoBlock}>
-        <iframe
-          title="Alerting - Introductory video"
-          src="https://player.vimeo.com/video/720001629?h=c6c1732f92"
-          width="960"
-          height="540"
-          allow="autoplay; fullscreen"
-          allowFullScreen
-          frameBorder="0"
-          // This is necessary because color-scheme defined on :root has impact on iframe elements
-          // More about how color-scheme works for iframes https://github.com/w3c/csswg-drafts/issues/4772
-          // Summary: If the color scheme of an iframe differs from embedding document iframe gets an opaque canvas bg appropriate to its color scheme
-          style={{ colorScheme: 'light dark' }}
-        ></iframe>
-      </ContentBox>
     </div>
   );
 }

--- a/public/app/features/alerting/unified/home/GettingStarted.tsx
+++ b/public/app/features/alerting/unified/home/GettingStarted.tsx
@@ -4,7 +4,7 @@ import SVG from 'react-inlinesvg';
 
 import { GrafanaTheme2 } from '@grafana/data';
 import { EmbeddedScene, SceneFlexLayout, SceneFlexItem, SceneReactObject } from '@grafana/scenes';
-import { Icon, useStyles2, useTheme2, Stack } from '@grafana/ui';
+import { useStyles2, useTheme2, Stack, Text, TextLink } from '@grafana/ui';
 
 export const getOverviewScene = () => {
   return new EmbeddedScene({
@@ -26,9 +26,9 @@ export default function GettingStarted() {
 
   return (
     <div className={styles.grid}>
-      <ContentBox className={styles.flowBlock}>
-        <div>
-          <h3>How it works</h3>
+      <ContentBox>
+        <Stack direction="column" gap={1}>
+          <Text element="h3">How it works</Text>
           <ul className={styles.list}>
             <li>
               Grafana alerting periodically queries data sources and evaluates the condition defined in the alert rule
@@ -37,19 +37,24 @@ export default function GettingStarted() {
             <li>Firing instances are routed to notification policies based on matching labels</li>
             <li>Notifications are sent out to the contact points specified in the notification policy</li>
           </ul>
-        </div>
-        <SVG
-          src={`public/img/alerting/at_a_glance_${theme.name.toLowerCase()}.svg`}
-          width={undefined}
-          height={undefined}
-        />
+          <div className={styles.svgContainer}>
+            <Stack justifyContent={'center'}>
+              <SVG
+                src={`public/img/alerting/at_a_glance_${theme.name.toLowerCase()}.svg`}
+                width={undefined}
+                height={undefined}
+              />
+            </Stack>
+          </div>
+        </Stack>
       </ContentBox>
-      <ContentBox className={styles.gettingStartedBlock}>
-        <h3>Get started</h3>
-        <Stack direction="column">
+      <ContentBox>
+        <Stack direction="column" gap={1}>
+          <Text element="h3">Get started</Text>
           <ul className={styles.list}>
             <li>
-              <strong>Create an alert rule</strong> by adding queries and expressions from multiple data sources.
+              <Text weight="bold">Create an alert rule</Text> by adding queries and expressions from multiple data
+              sources.
             </li>
             <li>
               <strong>Add labels</strong> to your alert rules <strong>to connect them to notification policies</strong>
@@ -61,9 +66,9 @@ export default function GettingStarted() {
               <strong>Configure notification policies</strong> to route your alert instances to contact points.
             </li>
           </ul>
-          <div>
-            <ArrowLink href="https://grafana.com/docs/grafana/latest/alerting/" title="Read more in the Docs" />
-          </div>
+          <TextLink href="https://grafana.com/docs/grafana/latest/alerting/" icon="angle-right" inline={false}>
+            Read more in the docs
+          </TextLink>
         </Stack>
       </ContentBox>
     </div>
@@ -74,48 +79,21 @@ const getWelcomePageStyles = (theme: GrafanaTheme2) => ({
   grid: css`
     display: grid;
     grid-template-rows: min-content auto auto;
-    grid-template-columns: 1fr 1fr 1fr 1fr 1fr;
+    grid-template-columns: 1fr;
     gap: ${theme.spacing(2)};
     width: 100%;
+
+    ${theme.breakpoints.up('lg')} {
+      grid-template-columns: 3fr 2fr;
+    }
   `,
   ctaContainer: css`
     grid-column: 1 / span 5;
   `,
-  flowBlock: css`
-    grid-column: 1 / span 5;
-
-    display: flex;
-    flex-wrap: wrap;
-    gap: ${theme.spacing(1)};
-
-    & > div {
-      flex: 2;
-      min-width: 350px;
+  svgContainer: css`
+    & svg {
+      max-width: 900px;
     }
-    & > svg {
-      flex: 3;
-      min-width: 500px;
-    }
-  `,
-  videoBlock: css`
-    grid-column: 3 / span 3;
-
-    // Video required
-    position: relative;
-    padding: 56.25% 0 0 0; /* 16:9 */
-
-    iframe {
-      position: absolute;
-      top: ${theme.spacing(2)};
-      left: ${theme.spacing(2)};
-      width: calc(100% - ${theme.spacing(4)});
-      height: calc(100% - ${theme.spacing(4)});
-      border: none;
-    }
-  `,
-  gettingStartedBlock: css`
-    grid-column: 1 / span 2;
-    justify-content: space-between;
   `,
   list: css`
     margin: ${theme.spacing(0, 2)};
@@ -167,7 +145,7 @@ const getWelcomeHeaderStyles = (theme: GrafanaTheme2) => ({
     paddingBottom: theme.spacing(2),
   }),
   ctaContainer: css`
-    padding: ${theme.spacing(4, 2)};
+    padding: ${theme.spacing(2)};
     display: flex;
     gap: ${theme.spacing(4)};
     justify-content: space-between;
@@ -200,12 +178,14 @@ function WelcomeCTABox({ title, description, href, hrefText }: WelcomeCTABoxProp
 
   return (
     <div className={styles.container}>
-      <h3 className={styles.title}>{title}</h3>
+      <Text element="h2" variant="h3">
+        {title}
+      </Text>
       <div className={styles.desc}>{description}</div>
       <div className={styles.actionRow}>
-        <a href={href} className={styles.link}>
+        <TextLink href={href} inline={false}>
           {hrefText}
-        </a>
+        </TextLink>
       </div>
     </div>
   );
@@ -216,15 +196,15 @@ const getWelcomeCTAButtonStyles = (theme: GrafanaTheme2) => ({
     flex: 1;
     min-width: 240px;
     display: grid;
-    gap: ${theme.spacing(1)};
+    row-gap: ${theme.spacing(1)};
     grid-template-columns: min-content 1fr 1fr 1fr;
     grid-template-rows: min-content auto min-content;
-  `,
 
-  title: css`
-    margin-bottom: 0;
-    grid-column: 2 / span 3;
-    grid-row: 1;
+    & h2 {
+      margin-bottom: 0;
+      grid-column: 2 / span 3;
+      grid-row: 1;
+    }
   `,
 
   desc: css`
@@ -236,10 +216,6 @@ const getWelcomeCTAButtonStyles = (theme: GrafanaTheme2) => ({
     grid-column: 2 / span 3;
     grid-row: 3;
     max-width: 240px;
-  `,
-
-  link: css`
-    color: ${theme.colors.text.link};
   `,
 });
 
@@ -254,22 +230,5 @@ const getContentBoxStyles = (theme: GrafanaTheme2) => ({
     padding: ${theme.spacing(2)};
     background-color: ${theme.colors.background.secondary};
     border-radius: ${theme.shape.radius.default};
-  `,
-});
-
-function ArrowLink({ href, title }: { href: string; title: string }) {
-  const styles = useStyles2(getArrowLinkStyles);
-
-  return (
-    <a href={href} className={styles.link} rel="noreferrer">
-      {title} <Icon name="angle-right" size="xl" />
-    </a>
-  );
-}
-
-const getArrowLinkStyles = (theme: GrafanaTheme2) => ({
-  link: css`
-    display: block;
-    color: ${theme.colors.text.link};
   `,
 });

--- a/public/app/features/alerting/unified/home/GettingStarted.tsx
+++ b/public/app/features/alerting/unified/home/GettingStarted.tsx
@@ -57,13 +57,15 @@ export default function GettingStarted() {
               sources.
             </li>
             <li>
-              <strong>Add labels</strong> to your alert rules <strong>to connect them to notification policies</strong>
+              <Text weight="bold">Add labels</Text> to your alert rules{' '}
+              <Text weight="bold">to connect them to notification policies</Text>
             </li>
             <li>
-              <strong>Configure contact points</strong> to define where to send your notifications to.
+              <Text weight="bold">Configure contact points</Text> to define where to send your notifications to.
             </li>
             <li>
-              <strong>Configure notification policies</strong> to route your alert instances to contact points.
+              <Text weight="bold">Configure notification policies</Text> to route your alert instances to contact
+              points.
             </li>
           </ul>
           <TextLink href="https://grafana.com/docs/grafana/latest/alerting/" icon="angle-right" inline={false}>

--- a/public/app/features/alerting/unified/home/GettingStarted.tsx
+++ b/public/app/features/alerting/unified/home/GettingStarted.tsx
@@ -20,13 +20,12 @@ export const getOverviewScene = () => {
   });
 };
 
-export default function GettingStarted({ showWelcomeHeader }: { showWelcomeHeader?: boolean }) {
+export default function GettingStarted() {
   const theme = useTheme2();
   const styles = useStyles2(getWelcomePageStyles);
 
   return (
     <div className={styles.grid}>
-      {showWelcomeHeader && <WelcomeHeader className={styles.ctaContainer} />}
       <ContentBox className={styles.flowBlock}>
         <div>
           <h3>How it works</h3>

--- a/public/app/features/alerting/unified/home/GettingStarted.tsx
+++ b/public/app/features/alerting/unified/home/GettingStarted.tsx
@@ -95,6 +95,7 @@ const getWelcomePageStyles = (theme: GrafanaTheme2) => ({
   svgContainer: css({
     '& svg': {
       maxWidth: '900px',
+      flex: 1,
     },
   }),
   list: css({


### PR DESCRIPTION
**What is this feature?**

Removes the video from the Alerting getting started page, and organises the columns a little with this in mind

Before:
![before](https://github.com/grafana/grafana/assets/4377076/01c27d62-34e0-4f3c-a1f9-9ed3c5ad75ea)


After:
![after](https://github.com/grafana/grafana/assets/4377076/f213d01e-0629-4140-9c5b-65b970c31ae6)


**Why do we need this feature?**

As per https://github.com/grafana/grafana/issues/76020, tidying up the getting started page for alerting

**Which issue(s) does this PR fix?**:
Fixes #76020

**Special notes for your reviewer:**
I held off migrating everything to `@grafana/ui` components in this PR, as it would likely result in a number of other small changes to the UI that I didn't want to conflate with the simple change of removing the video.

