### PR TITLE
AuthN: Use fetch user sync hook for render keys connected to a user

### DIFF
--- a/pkg/services/authn/authnimpl/service.go
+++ b/pkg/services/authn/authnimpl/service.go
@@ -89,7 +89,7 @@ func ProvideService(
 
 	usageStats.RegisterMetricsFunc(s.getUsageStats)
 
-	s.RegisterClient(clients.ProvideRender(userService, renderService))
+	s.RegisterClient(clients.ProvideRender(renderService))
 	s.RegisterClient(clients.ProvideAPIKey(apikeyService))
 
 	if cfg.LoginCookieName != "" {

--- a/pkg/services/authn/clients/render.go
+++ b/pkg/services/authn/clients/render.go
@@ -8,7 +8,6 @@ import (
 	"github.com/grafana/grafana/pkg/services/login"
 	"github.com/grafana/grafana/pkg/services/org"
 	"github.com/grafana/grafana/pkg/services/rendering"
-	"github.com/grafana/grafana/pkg/services/user"
 	"github.com/grafana/grafana/pkg/util/errutil"
 )
 
@@ -22,12 +21,11 @@ const (
 
 var _ authn.ContextAwareClient = new(Render)
 
-func ProvideRender(userService user.Service, renderService rendering.Service) *Render {
-	return &Render{userService, renderService}
+func ProvideRender(renderService rendering.Service) *Render {
+	return &Render{renderService}
 }
 
 type Render struct {
-	userService   user.Service
 	renderService rendering.Service
 }
 
@@ -42,26 +40,23 @@ func (c *Render) Authenticate(ctx context.Context, r *authn.Request) (*authn.Ide
 		return nil, errInvalidRenderKey.Errorf("found no render user for key: %s", key)
 	}
 
-	var identity *authn.Identity
 	if renderUsr.UserID <= 0 {
-		identity = &authn.Identity{
-			ID:           authn.NamespacedID(authn.NamespaceRenderService, 0),
-			OrgID:        renderUsr.OrgID,
-			OrgRoles:     map[int64]org.RoleType{renderUsr.OrgID: org.RoleType(renderUsr.OrgRole)},
-			ClientParams: authn.ClientParams{SyncPermissions: true},
-		}
-	} else {
-		usr, err := c.userService.GetSignedInUserWithCacheCtx(ctx, &user.GetSignedInUserQuery{UserID: renderUsr.UserID, OrgID: renderUsr.OrgID})
-		if err != nil {
-			return nil, err
-		}
-
-		identity = authn.IdentityFromSignedInUser(authn.NamespacedID(authn.NamespaceUser, usr.UserID), usr, authn.ClientParams{SyncPermissions: true}, login.RenderModule)
+		return &authn.Identity{
+			ID:              authn.NamespacedID(authn.NamespaceRenderService, 0),
+			OrgID:           renderUsr.OrgID,
+			OrgRoles:        map[int64]org.RoleType{renderUsr.OrgID: org.RoleType(renderUsr.OrgRole)},
+			ClientParams:    authn.ClientParams{SyncPermissions: true},
+			LastSeenAt:      time.Now(),
+			AuthenticatedBy: login.RenderModule,
+		}, nil
 	}
 
-	identity.LastSeenAt = time.Now()
-	identity.AuthenticatedBy = login.RenderModule
-	return identity, nil
+	return &authn.Identity{
+		ID:              authn.NamespacedID(authn.NamespaceUser, renderUsr.UserID),
+		LastSeenAt:      time.Now(),
+		AuthenticatedBy: login.RenderModule,
+		ClientParams:    authn.ClientParams{FetchSyncedUser: true, SyncPermissions: true},
+	}, nil
 }
 
 func (c *Render) Test(ctx context.Context, r *authn.Request) bool {

--- a/pkg/services/authn/clients/render_test.go
+++ b/pkg/services/authn/clients/render_test.go
@@ -14,7 +14,6 @@ import (
 	"github.com/grafana/grafana/pkg/services/org"
 	"github.com/grafana/grafana/pkg/services/rendering"
 	"github.com/grafana/grafana/pkg/services/user"
-	"github.com/grafana/grafana/pkg/services/user/usertest"
 )
 
 func TestRender_Authenticate(t *testing.T) {
@@ -60,22 +59,12 @@ func TestRender_Authenticate(t *testing.T) {
 			},
 			expectedIdentity: &authn.Identity{
 				ID:              "user:1",
-				OrgID:           1,
-				OrgName:         "test",
-				OrgRoles:        map[int64]org.RoleType{1: org.RoleAdmin},
-				IsGrafanaAdmin:  boolPtr(false),
 				AuthenticatedBy: login.RenderModule,
-				ClientParams:    authn.ClientParams{SyncPermissions: true},
+				ClientParams:    authn.ClientParams{FetchSyncedUser: true, SyncPermissions: true},
 			},
 			expectedRenderUsr: &rendering.RenderUser{
 				OrgID:  1,
 				UserID: 1,
-			},
-			expectedUsr: &user.SignedInUser{
-				UserID:  1,
-				OrgID:   1,
-				OrgName: "test",
-				OrgRole: "Admin",
 			},
 		},
 		{
@@ -97,7 +86,7 @@ func TestRender_Authenticate(t *testing.T) {
 			renderService := rendering.NewMockService(ctrl)
 			renderService.EXPECT().GetRenderUser(gomock.Any(), tt.renderKey).Return(tt.expectedRenderUsr, tt.expectedRenderUsr != nil)
 
-			c := ProvideRender(&usertest.FakeUserService{ExpectedSignedInUser: tt.expectedUsr}, renderService)
+			c := ProvideRender(renderService)
 			identity, err := c.Authenticate(context.Background(), tt.req)
 			if tt.expectedErr != nil {
 				assert.ErrorIs(t, tt.expectedErr, err)
@@ -141,7 +130,7 @@ func TestRender_Test(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.desc, func(t *testing.T) {
-			c := ProvideRender(&usertest.FakeUserService{}, &rendering.MockService{})
+			c := ProvideRender(&rendering.MockService{})
 			assert.Equal(t, tt.expected, c.Test(context.Background(), tt.req))
 		})
 	}

--- a/pkg/services/authn/clients/render_test.go
+++ b/pkg/services/authn/clients/render_test.go
@@ -13,7 +13,6 @@ import (
 	"github.com/grafana/grafana/pkg/services/login"
 	"github.com/grafana/grafana/pkg/services/org"
 	"github.com/grafana/grafana/pkg/services/rendering"
-	"github.com/grafana/grafana/pkg/services/user"
 )
 
 func TestRender_Authenticate(t *testing.T) {
@@ -22,7 +21,6 @@ func TestRender_Authenticate(t *testing.T) {
 		renderKey         string
 		req               *authn.Request
 		expectedErr       error
-		expectedUsr       *user.SignedInUser
 		expectedIdentity  *authn.Identity
 		expectedRenderUsr *rendering.RenderUser
 	}


### PR DESCRIPTION
**What is this feature?**
Instead of using user service directly we can use the sync hook to get information about render keys when connected to a user.

This is needed for when we move hooks and clients out.

**Which issue(s) does this PR fix?**:

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
