### PR TITLE
Docs: add Configure tooltips page

### DIFF
--- a/docs/sources/panels-visualizations/configure-tooltips/index.md
+++ b/docs/sources/panels-visualizations/configure-tooltips/index.md
@@ -17,7 +17,7 @@ weight: 80
 
 # Configure tooltips
 
-<!--Intro: what are tooltips and what we do we use them for-->
+When you hover your cursor over a visualization, Grafana can display tooltips that contain more information about a data point like the exact time of a result. You can customize tooltips to to control how many series are included and their order. You can also copy the content from tooltips to use elsewhere. Learn more about configuring tooltips in [Tooltip options](#tooltip-options).
 
 ## Supported visualizations
 
@@ -43,25 +43,39 @@ Non-configurable tooltips:
 
 ## Tooltip options
 
+You can find the following options under the **Tooltip** section in the panel edit pane.
+
+{{% admonition type="note" %}}
+Not all of the options listed apply to all visualizations with tooltips.
+{{% /admonition %}}
+
 ### Tooltip mode
 
-- **Single** -
-- **All** -
-- **Hidden** -
+Choose how tooltips behave.
 
-When you choose All
+- **Single** - The tooltip only the single series that you're hovering over in the visualization.
+- **All** - The tooltip shows all series in the visualization. Grafana highlights the series that you are hovering over in bold in the series list in the tooltip.
+- **Hidden** - Tooltips aren't displayed when you interact with the visualization.
 
-- **None** -
-- **Ascending** -
-- **Descending** -
+You can use a [field override][] to hide individual series from the tooltip.
+
+### Values sort order
+
+When you set the **Tooltip mode** to **All**, the **Values sort order** option is displayed. This option controls the order in which values are listed in a tooltip. Choose from the following:
+
+- **None** - Grafana automatically sorts the values displayed in a tooltip.
+- **Ascending** - Values in the tooltip are listed from smallest to largest.
+- **Descending** - Values in the tooltip are listed from largest to smallest.
 
 ### Hover proximity
 
-Set the hover proximity to control...
+Set the hover proximity (in pixels) to control how close the cursor must be to a data point to trigger the tooltip to display.
+
+![Adding a hover proximity limit for tooltips](/media/docs/grafana/gif-grafana-10-4-hover-proximity.gif)
 
 ### Show histogram (y axis)
 
-Control whether or not the y-axis...
+For the heatmap visualization only, when you set the **Tooltip mode** to **Single**, the **Show histogram (Y axis)** option is displayed. This option controls whether or not the tooltip includes a histogram representing the y-axis.
 
 {{% docs/reference %}}
 [bar chart]: "/docs/grafana/ -> /docs/grafana/<GRAFANA VERSION>/panels-visualizations/visualizations/bar-chart"
@@ -99,4 +113,7 @@ Control whether or not the y-axis...
 
 [trend]: "/docs/grafana/ -> /docs/grafana/<GRAFANA VERSION>/panels-visualizations/visualizations/trend"
 [trend]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/visualizations/panels-visualizations/visualizations/trend"
+
+[field override]: "/docs/grafana/ -> /docs/grafana/<GRAFANA VERSION>/panels-visualizations/configure-overrides"
+[field override]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/visualizations/panels-visualizations/configure-overrides"
 {{% /docs/reference %}}

--- a/docs/sources/panels-visualizations/configure-tooltips/index.md
+++ b/docs/sources/panels-visualizations/configure-tooltips/index.md
@@ -17,7 +17,7 @@ weight: 75
 
 # Configure tooltips
 
-When you hover your cursor over a visualization, Grafana can display tooltips that contain more information about a data point like the exact time of a result. You can customize tooltips to to control how many series they include and the order of those values. You can also copy the content from tooltips to use elsewhere. Learn more about configuring tooltips in [Tooltip options](#tooltip-options).
+When you hover your cursor over a visualization, Grafana can display tooltips that contain more information about a data point, like the exact time of a result. You can customize tooltips to control how many series they include and the order of those values. You can also copy the content from tooltips to use elsewhere. Learn more about configuring tooltips in [Tooltip options](#tooltip-options).
 
 ## Supported visualizations
 
@@ -25,10 +25,10 @@ You can configure tooltips for the following visualizations:
 
 |                                  |                                  |
 | -------------------------------- | -------------------------------- |
-| [Bar chart][bar chart]           | [Status history][status history] |
-| [Heatmap][heatmap]               | [Time series][time series]       |
-| [Pie chart][pie chart]           | [Trend][trend]                   |
-| [State timeline][state timeline] |
+| [Bar chart][bar chart]           |  | [State timeline][state timeline]
+| [Candlestick][candlestick]               | [Status history][status history]      |
+| [Heatmap][heatmap]         | [Time series][time series]                    |
+| [Pie chart][pie chart]  | [Trend][trend] |
 
 <!--Also xy chart -->
 
@@ -71,6 +71,10 @@ Set the hover proximity (in pixels) to control how close the cursor must be to a
 ### Show histogram (Y axis)
 
 For the heatmap visualization only, when you set the **Tooltip mode** to **Single**, the **Show histogram (Y axis)** option is displayed. This option controls whether or not the tooltip includes a histogram representing the y-axis.
+
+### Show color scale
+
+For the heatmap visualization only, when you set the **Tooltip mode** to **Single**, the **Show color scale** option is displayed. This option controls whether or not the tooltip includes the color scale that's also represented in the legend.
 
 {{% docs/reference %}}
 [bar chart]: "/docs/grafana/ -> /docs/grafana/<GRAFANA VERSION>/panels-visualizations/visualizations/bar-chart"

--- a/docs/sources/panels-visualizations/configure-tooltips/index.md
+++ b/docs/sources/panels-visualizations/configure-tooltips/index.md
@@ -23,12 +23,12 @@ When you hover your cursor over a visualization, Grafana can display tooltips th
 
 You can configure tooltips for the following visualizations:
 
-|                                  |                                  |
-| -------------------------------- | -------------------------------- |
-| [Bar chart][bar chart]           |  | [State timeline][state timeline]
-| [Candlestick][candlestick]               | [Status history][status history]      |
-| [Heatmap][heatmap]         | [Time series][time series]                    |
-| [Pie chart][pie chart]  | [Trend][trend] |
+|                            |                                  |
+| -------------------------- | -------------------------------- |
+| [Bar chart][bar chart]     | [State timeline][state timeline] |
+| [Candlestick][candlestick] | [Status history][status history] |
+| [Heatmap][heatmap]         | [Time series][time series]       |
+| [Pie chart][pie chart]     | [Trend][trend]                   |
 
 <!--Also xy chart -->
 

--- a/docs/sources/panels-visualizations/configure-tooltips/index.md
+++ b/docs/sources/panels-visualizations/configure-tooltips/index.md
@@ -12,12 +12,12 @@ labels:
 menuTitle: Configure tooltips
 title: Configure tooltips
 description: Configure tooltips for your visualizations
-weight: 80
+weight: 75
 ---
 
 # Configure tooltips
 
-When you hover your cursor over a visualization, Grafana can display tooltips that contain more information about a data point like the exact time of a result. You can customize tooltips to to control how many series are included and their order. You can also copy the content from tooltips to use elsewhere. Learn more about configuring tooltips in [Tooltip options](#tooltip-options).
+When you hover your cursor over a visualization, Grafana can display tooltips that contain more information about a data point like the exact time of a result. You can customize tooltips to to control how many series they include and the order of those values. You can also copy the content from tooltips to use elsewhere. Learn more about configuring tooltips in [Tooltip options](#tooltip-options).
 
 ## Supported visualizations
 

--- a/docs/sources/panels-visualizations/configure-tooltips/index.md
+++ b/docs/sources/panels-visualizations/configure-tooltips/index.md
@@ -74,7 +74,9 @@ For the heatmap visualization only, when you set the **Tooltip mode** to **Singl
 
 ### Show color scale
 
-For the heatmap visualization only, when you set the **Tooltip mode** to **Single**, the **Show color scale** option is displayed. This option controls whether or not the tooltip includes the color scale that's also represented in the legend.
+For the heatmap visualization only, when you set the **Tooltip mode** to **Single**, the **Show color scale** option is displayed. This option controls whether or not the tooltip includes the color scale that's also represented in the legend. When the color scale is included in the tooltip, it shows the hovered value on the scale:
+
+![Heatmap with a tooltip displayed showing the hovered value reflected in the color scale](/media/docs/grafana/panels-visualizations/screenshot-heatmap-tooltip-color-scale-v11.0.png)
 
 {{% docs/reference %}}
 [bar chart]: "/docs/grafana/ -> /docs/grafana/<GRAFANA VERSION>/panels-visualizations/visualizations/bar-chart"

--- a/docs/sources/panels-visualizations/configure-tooltips/index.md
+++ b/docs/sources/panels-visualizations/configure-tooltips/index.md
@@ -23,23 +23,18 @@ When you hover your cursor over a visualization, Grafana can display tooltips th
 
 You can configure tooltips for the following visualizations:
 
-- [Bar chart][bar chart]
-- [Heatmap][heatmap]
-- [Pie chart][pie chart]
-- [State timeline][state timeline]
-- [Status history][status history]
-- [Time series][time series]
-- [Trend][trend]
+|                                  |                                  |
+| -------------------------------- | -------------------------------- |
+| [Bar chart][bar chart]           | [Status history][status history] |
+| [Heatmap][heatmap]               | [Time series][time series]       |
+| [Pie chart][pie chart]           | [Trend][trend]                   |
+| [State timeline][state timeline] |
+
 <!--Also xy chart -->
 
 Special tooltips: Geomap
 
-Non-configurable tooltips:
-
-- [Candlestick][candlestick]
-- [Canvas][canvas]
-- [Flame graph][flame graph]
-- [Node graph][node graph]
+Some visualizations (for example, [candlestick][] and [flame graph][]) have tooltips, but they aren't configurable. These visualizations don't have a **Tooltip** section in the panel editor pane.
 
 ## Tooltip options
 
@@ -84,9 +79,6 @@ For the heatmap visualization only, when you set the **Tooltip mode** to **Singl
 [candlestick]: "/docs/grafana/ -> /docs/grafana/<GRAFANA VERSION>/panels-visualizations/visualizations/candlestick"
 [candlestick]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/visualizations/panels-visualizations/visualizations/candlestick"
 
-[canvas]: "/docs/grafana/ -> /docs/grafana/<GRAFANA VERSION>/panels-visualizations/visualizations/canvas"
-[canvas]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/visualizations/panels-visualizations/visualizations/canvas"
-
 [flame graph]: "/docs/grafana/ -> /docs/grafana/<GRAFANA VERSION>/panels-visualizations/visualizations/flame-graph"
 [flame graph]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/visualizations/panels-visualizations/visualizations/flame-graph"
 
@@ -95,9 +87,6 @@ For the heatmap visualization only, when you set the **Tooltip mode** to **Singl
 
 [heatmap]: "/docs/grafana/ -> /docs/grafana/<GRAFANA VERSION>/panels-visualizations/visualizations/heatmap"
 [heatmap]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/visualizations/panels-visualizations/visualizations/heatmap"
-
-[node graph]: "/docs/grafana/ -> /docs/grafana/<GRAFANA VERSION>/panels-visualizations/visualizations/node-graph"
-[node graph]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/visualizations/panels-visualizations/visualizations/node-graph"
 
 [pie chart]: "/docs/grafana/ -> /docs/grafana/<GRAFANA VERSION>/panels-visualizations/visualizations/pie-chart"
 [pie chart]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/visualizations/panels-visualizations/visualizations/pie-chart"

--- a/docs/sources/panels-visualizations/configure-tooltips/index.md
+++ b/docs/sources/panels-visualizations/configure-tooltips/index.md
@@ -34,6 +34,8 @@ You can configure tooltips for the following visualizations:
 
 Some visualizations, for example [candlestick][] and [flame graph][], have tooltips, but they aren't configurable. These visualizations don't have a **Tooltip** section in the panel editor pane. [Geomaps][geomaps] provide you the option to have tooltips triggered upon click or hover under the **Map controls** options in the panel editor pane.
 
+<!-- if we add documentation for treemap, some info will need to be added in the paragraph above -->
+
 ## Tooltip options
 
 You can find the following options under the **Tooltip** section in the panel edit pane.
@@ -44,7 +46,7 @@ Not all of the options listed apply to all visualizations with tooltips.
 
 ### Tooltip mode
 
-Choose how tooltips behave.
+Choose how tooltips behave with the following options:
 
 - **Single** - The tooltip only the single series that you're hovering over in the visualization.
 - **All** - The tooltip shows all series in the visualization. Grafana highlights the series that you are hovering over in bold in the series list in the tooltip.
@@ -66,7 +68,7 @@ Set the hover proximity (in pixels) to control how close the cursor must be to a
 
 ![Adding a hover proximity limit for tooltips](/media/docs/grafana/gif-grafana-10-4-hover-proximity.gif)
 
-### Show histogram (y axis)
+### Show histogram (Y axis)
 
 For the heatmap visualization only, when you set the **Tooltip mode** to **Single**, the **Show histogram (Y axis)** option is displayed. This option controls whether or not the tooltip includes a histogram representing the y-axis.
 

--- a/docs/sources/panels-visualizations/configure-tooltips/index.md
+++ b/docs/sources/panels-visualizations/configure-tooltips/index.md
@@ -1,0 +1,102 @@
+---
+aliases:
+keywords:
+  - grafana
+  - tooltips
+  - documentation
+labels:
+  products:
+    - cloud
+    - enterprise
+    - oss
+menuTitle: Configure tooltips
+title: Configure tooltips
+description: Configure tooltips for your visualizations
+weight: 80
+---
+
+# Configure tooltips
+
+<!--Intro: what are tooltips and what we do we use them for-->
+
+## Supported visualizations
+
+You can configure tooltips for the following visualizations:
+
+- [Bar chart][bar chart]
+- [Heatmap][heatmap]
+- [Pie chart][pie chart]
+- [State timeline][state timeline]
+- [Status history][status history]
+- [Time series][time series]
+- [Trend][trend]
+<!--Also xy chart -->
+
+Special tooltips: Geomap
+
+Non-configurable tooltips:
+
+- [Candlestick][candlestick]
+- [Canvas][canvas]
+- [Flame graph][flame graph]
+- [Node graph][node graph]
+
+## Tooltip options
+
+### Tooltip mode
+
+- **Single** -
+- **All** -
+- **Hidden** -
+
+When you choose All
+
+- **None** -
+- **Ascending** -
+- **Descending** -
+
+### Hover proximity
+
+Set the hover proximity to control...
+
+### Show histogram (y axis)
+
+Control whether or not the y-axis...
+
+{{% docs/reference %}}
+[bar chart]: "/docs/grafana/ -> /docs/grafana/<GRAFANA VERSION>/panels-visualizations/visualizations/bar-chart"
+[bar chart]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/visualizations/panels-visualizations/visualizations/bar-chart"
+
+[candlestick]: "/docs/grafana/ -> /docs/grafana/<GRAFANA VERSION>/panels-visualizations/visualizations/candlestick"
+[candlestick]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/visualizations/panels-visualizations/visualizations/candlestick"
+
+[canvas]: "/docs/grafana/ -> /docs/grafana/<GRAFANA VERSION>/panels-visualizations/visualizations/canvas"
+[canvas]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/visualizations/panels-visualizations/visualizations/canvas"
+
+[flame graph]: "/docs/grafana/ -> /docs/grafana/<GRAFANA VERSION>/panels-visualizations/visualizations/flame-graph"
+[flame graph]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/visualizations/panels-visualizations/visualizations/flame-graph"
+
+[geomap]: "/docs/grafana/ -> /docs/grafana/<GRAFANA VERSION>/panels-visualizations/visualizations/geomap"
+[geomap]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/visualizations/panels-visualizations/visualizations/geomap"
+
+[heatmap]: "/docs/grafana/ -> /docs/grafana/<GRAFANA VERSION>/panels-visualizations/visualizations/heatmap"
+[heatmap]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/visualizations/panels-visualizations/visualizations/heatmap"
+
+[node graph]: "/docs/grafana/ -> /docs/grafana/<GRAFANA VERSION>/panels-visualizations/visualizations/node-graph"
+[node graph]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/visualizations/panels-visualizations/visualizations/node-graph"
+
+[pie chart]: "/docs/grafana/ -> /docs/grafana/<GRAFANA VERSION>/panels-visualizations/visualizations/pie-chart"
+[pie chart]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/visualizations/panels-visualizations/visualizations/pie-chart"
+
+[state timeline]: "/docs/grafana/ -> /docs/grafana/<GRAFANA VERSION>/panels-visualizations/visualizations/state-timeline"
+[state timeline]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/visualizations/panels-visualizations/visualizations/state-timeline"
+
+[status history]: "/docs/grafana/ -> /docs/grafana/<GRAFANA VERSION>/panels-visualizations/visualizations/status-history"
+[status history]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/visualizations/panels-visualizations/visualizations/status-history"
+
+[time series]: "/docs/grafana/ -> /docs/grafana/<GRAFANA VERSION>/panels-visualizations/visualizations/time-series"
+[time series]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/visualizations/panels-visualizations/visualizations/time-series"
+
+[trend]: "/docs/grafana/ -> /docs/grafana/<GRAFANA VERSION>/panels-visualizations/visualizations/trend"
+[trend]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/visualizations/panels-visualizations/visualizations/trend"
+{{% /docs/reference %}}

--- a/docs/sources/panels-visualizations/configure-tooltips/index.md
+++ b/docs/sources/panels-visualizations/configure-tooltips/index.md
@@ -32,9 +32,7 @@ You can configure tooltips for the following visualizations:
 
 <!--Also xy chart -->
 
-Special tooltips: Geomap
-
-Some visualizations (for example, [candlestick][] and [flame graph][]) have tooltips, but they aren't configurable. These visualizations don't have a **Tooltip** section in the panel editor pane.
+Some visualizations, for example [candlestick][] and [flame graph][], have tooltips, but they aren't configurable. These visualizations don't have a **Tooltip** section in the panel editor pane. [Geomaps][geomaps] provide you the option to have tooltips triggered upon click or hover under the **Map controls** options in the panel editor pane.
 
 ## Tooltip options
 
@@ -82,8 +80,8 @@ For the heatmap visualization only, when you set the **Tooltip mode** to **Singl
 [flame graph]: "/docs/grafana/ -> /docs/grafana/<GRAFANA VERSION>/panels-visualizations/visualizations/flame-graph"
 [flame graph]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/visualizations/panels-visualizations/visualizations/flame-graph"
 
-[geomap]: "/docs/grafana/ -> /docs/grafana/<GRAFANA VERSION>/panels-visualizations/visualizations/geomap"
-[geomap]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/visualizations/panels-visualizations/visualizations/geomap"
+[geomaps]: "/docs/grafana/ -> /docs/grafana/<GRAFANA VERSION>/panels-visualizations/visualizations/geomap#tooltip"
+[geomaps]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/visualizations/panels-visualizations/visualizations/geomap#tooltip"
 
 [heatmap]: "/docs/grafana/ -> /docs/grafana/<GRAFANA VERSION>/panels-visualizations/visualizations/heatmap"
 [heatmap]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/visualizations/panels-visualizations/visualizations/heatmap"


### PR DESCRIPTION
Adding documentation for configurable tooltips as this has been missing. This version of these tooltips is still in public preview in 10.4 and will be GA in 11.0. When these docs are backported, the 10.4 version will have a public preview note added.
