### PR TITLE
Prometheus: Add missing Azure setting

### DIFF
--- a/pkg/setting/setting_azure.go
+++ b/pkg/setting/setting_azure.go
@@ -9,6 +9,10 @@ func (cfg *Cfg) readAzureSettings() {
 	azureSettings := &azsettings.AzureSettings{}
 
 	azureSection := cfg.Raw.Section("azure")
+	authSection := cfg.Raw.Section("auth")
+
+	// This setting is specific to Prometheus
+	azureSettings.AzureAuthEnabled = authSection.Key("azure_auth_enabled").MustBool(false)
 
 	// Cloud
 	cloudName := azureSection.Key("cloud").MustString(azsettings.AzurePublic)

--- a/pkg/setting/setting_azure_test.go
+++ b/pkg/setting/setting_azure_test.go
@@ -64,6 +64,27 @@ func TestAzureSettings(t *testing.T) {
 		}
 	})
 
+	t.Run("prometheus", func(t *testing.T) {
+		t.Run("should enable azure auth", func(t *testing.T) {
+			cfg := NewCfg()
+
+			authSection, err := cfg.Raw.NewSection("auth")
+			require.NoError(t, err)
+			_, err = authSection.NewKey("azure_auth_enabled", "true")
+			require.NoError(t, err)
+
+			cfg.readAzureSettings()
+			require.NotNil(t, cfg.Azure.AzureAuthEnabled)
+			assert.True(t, cfg.Azure.AzureAuthEnabled)
+		})
+		t.Run("should default to disabled", func(t *testing.T) {
+			cfg := NewCfg()
+
+			cfg.readAzureSettings()
+			require.NotNil(t, cfg.Azure.AzureAuthEnabled)
+			assert.False(t, cfg.Azure.AzureAuthEnabled)
+		})
+	})
 	t.Run("User Identity", func(t *testing.T) {
 		t.Run("should be disabled by default", func(t *testing.T) {
 			cfg := NewCfg()


### PR DESCRIPTION
#83261 did not account for the fact that the Azure settings did not originally set a value for `AzureAuthEnabled` as this was originally obtained outside of the Azure settings function.

This PR correctly sets the value from the `auth` section on the `AzureSettings` struct.