### PR TITLE
Alerting docs: add `Template variable interpolation` section in file provisioning

### DIFF
--- a/docs/sources/alerting/set-up/provision-alerting-resources/file-provisioning/index.md
+++ b/docs/sources/alerting/set-up/provision-alerting-resources/file-provisioning/index.md
@@ -759,6 +759,39 @@ deleteMuteTimes:
     name: mti_1
 ```
 
+## Template variable interpolation
+
+Provisioning interpolates environment variables using the `$variable` syntax.
+
+```yaml
+contactPoints:
+  - orgId: 1
+    name: My Contact Email Point
+    receivers:
+      - uid: 1
+        type: email
+        settings:
+          addresses: $EMAIL
+```
+
+In this example, provisioning will replace `$EMAIL` with the value of the `EMAIL` environment variable or an empty string if it is not present. For more information, refer to [Using environment variables in the Provision documentation][provisioning_env_vars].
+
+Note that the provisioning interpolation may unexpectedly substitute template variables in alerting resources.
+
+In alerting resources, you can use template variables with the same `$variable` syntax for some properties. For instance:
+
+- Alert rule labels
+- Alert rule annotations (omits interpolation)
+- Contact point messages
+- Notification template content (omits interpolation)
+
+Properties that omit the provisioning interpolation, like annotation or notification templates, do not require changes. For the others, if you’ve defined a template variable such as `$variable`, **use `$$variable` to avoid interpolation.**
+
+For example, considering a `subject` property in the `contactPoints.receivers.settings` object alongside an undefined environment variable.
+
+1. `subject: '{{ $labels }}'` will convert to `subject: '{{ }}'` which is incorrect.
+1. `subject: '{{ $$labels }}'` will convert to `subject: '{{ $labels }}'` as desired.
+
 ## More examples
 
 For more examples on the concept of this guide:
@@ -785,6 +818,7 @@ For more examples on the concept of this guide:
 [export_mute_timings]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/alerting-and-irm/alerting/set-up/provision-alerting-resources/export-alerting-resources#export-mute-timings"
 
 [provisioning]: "/docs/ -> /docs/grafana/<GRAFANA_VERSION>/administration/provisioning"
+[provisioning_env_vars]: "/docs/ -> /docs/grafana/<GRAFANA_VERSION>/administration/provisioning#using-environment-variables"
 
 [reload-provisioning-configurations]: "/docs/ -> /docs/grafana/<GRAFANA_VERSION>/developers/http_api/admin#reload-provisioning-configurations"
 

--- a/docs/sources/alerting/set-up/provision-alerting-resources/file-provisioning/index.md
+++ b/docs/sources/alerting/set-up/provision-alerting-resources/file-provisioning/index.md
@@ -787,7 +787,7 @@ In alerting resources, you can use template variables with the same `$variable` 
 
 Properties that omit the provisioning interpolation, like annotation or notification templates, do not require changes. For the others, if you’ve defined a template variable such as `$variable`, **use `$$variable` to avoid interpolation.**
 
-For example, considering a `subject` property in the `contactPoints.receivers.settings` object alongside an undefined environment variable.
+For example, you could use a `subject` property in the `contactPoints.receivers.settings` object alongside an undefined environment variable.
 
 1. `subject: '{{ $labels }}'` will convert to `subject: '{{ }}'` which is incorrect.
 1. `subject: '{{ $$labels }}'` will convert to `subject: '{{ $labels }}'` as desired.

--- a/docs/sources/alerting/set-up/provision-alerting-resources/file-provisioning/index.md
+++ b/docs/sources/alerting/set-up/provision-alerting-resources/file-provisioning/index.md
@@ -776,21 +776,22 @@ contactPoints:
 
 In this example, provisioning replaces `$EMAIL` with the value of the `EMAIL` environment variable or an empty string if it is not present. For more information, refer to [Using environment variables in the Provision documentation][provisioning_env_vars].
 
-Note that the provisioning interpolation may unexpectedly substitute template variables in alerting resources.
+In alerting resources, most properties support template variable interpolation, with a few exceptions:
 
-In alerting resources, you can use template variables with the same `$variable` syntax for some properties. For instance:
+- Alert rule annotations: `groups[].rules[].annotations`
+- Alert rule time range: `groups[].rules[].relativeTimeRange`
+- Alert rule query model: `groups[].rules[].data.model`
+- Mute timings name: `muteTimes[].name`
+- Mute timings time intervals: `muteTimes[].time_intervals[]`
+- Notification template name: `templates[].name`
+- Notification template content: `templates[].template`
 
-- Alert rule labels
-- Alert rule annotations (omits interpolation)
-- Contact point messages
-- Notification template content (omits interpolation)
+Note for properties that support interpolation, you may unexpectedly substitute template variables when not intended. To avoid this, you can escape the `$variable` with `$$variable`.
 
-Properties that omit the provisioning interpolation, like annotation or notification templates, do not require changes. For the others, if you’ve defined a template variable such as `$variable`, **use `$$variable` to avoid interpolation.**
+For example, when provisioning a `subject` property in a `contactPoints.receivers.settings` object that is meant to use the `$labels` variable.
 
-For example, you could use a `subject` property in the `contactPoints.receivers.settings` object alongside an undefined environment variable.
-
-1. `subject: '{{ $labels }}'` will convert to `subject: '{{ }}'` which is incorrect.
-1. `subject: '{{ $$labels }}'` will convert to `subject: '{{ $labels }}'` as desired.
+1. `subject: '{{ $labels }}'` will interpolate, incorrectly defining the subject as `subject: '{{ }}'`.
+1. `subject: '{{ $$labels }}'` will not interpolate, correctly defining the subject as `subject: '{{ $labels }}'`.
 
 ## More examples
 

--- a/docs/sources/alerting/set-up/provision-alerting-resources/file-provisioning/index.md
+++ b/docs/sources/alerting/set-up/provision-alerting-resources/file-provisioning/index.md
@@ -774,7 +774,7 @@ contactPoints:
           addresses: $EMAIL
 ```
 
-In this example, provisioning will replace `$EMAIL` with the value of the `EMAIL` environment variable or an empty string if it is not present. For more information, refer to [Using environment variables in the Provision documentation][provisioning_env_vars].
+In this example, provisioning replaces `$EMAIL` with the value of the `EMAIL` environment variable or an empty string if it is not present. For more information, refer to [Using environment variables in the Provision documentation][provisioning_env_vars].
 
 Note that the provisioning interpolation may unexpectedly substitute template variables in alerting resources.
 


### PR DESCRIPTION
Closes https://github.com/grafana/grafana/issues/71007. Relates to https://github.com/grafana/grafana/issues/71006

- How to interpolate environment variables in your alerting provisioning files.
- How to avoid interpolation using $$.
- Which fields are interpolated and which aren't. (ex. Labels are interpolated but Annotations aren't)