### PR TITLE
BarChart: Show tooltip options unconditionally

### DIFF
--- a/public/app/plugins/panel/barchart/module.tsx
+++ b/public/app/plugins/panel/barchart/module.tsx
@@ -236,10 +236,7 @@ export const plugin = new PanelPlugin<Options, FieldConfig>(BarChartPanel)
       description: 'Use the color value for a sibling field to color each bar value.',
     });
 
-    if (!context.options?.fullHighlight || context.options?.stacking === StackingMode.None) {
-      commonOptionsBuilder.addTooltipOptions(builder);
-    }
-
+    commonOptionsBuilder.addTooltipOptions(builder);
     commonOptionsBuilder.addLegendOptions(builder);
     commonOptionsBuilder.addTextSizeOptions(builder, false);
   })


### PR DESCRIPTION
tooltip options work properly these days with/without stacked mode and with/without full column highlight mode.

this shows the tooltip options in panel edit unconditionally.