### PR TITLE
Documentation: Updated yaml for influxdb data sources

### DIFF
--- a/docs/sources/datasources/influxdb/_index.md
+++ b/docs/sources/datasources/influxdb/_index.md
@@ -220,6 +220,7 @@ datasources:
     access: proxy
     url: http://localhost:8086
     jsonData:
+      version: SQL
       dbName: site
       httpMode: POST
     secureJsonData:

--- a/docs/sources/datasources/influxdb/_index.md
+++ b/docs/sources/datasources/influxdb/_index.md
@@ -203,9 +203,8 @@ datasources:
     access: proxy
     url: http://localhost:8086
     jsonData:
-      version: SQL
-      metadata:
-        - database: <bucket-name>
+      dbName: site
+      httpHeaderName1: 'Authorization'
     secureJsonData:
       httpHeaderValue1: 'Token <token>'
 ```
@@ -216,7 +215,7 @@ datasources:
 apiVersion: 1
 
 datasources:
-  - name: InfluxDB_v2_InfluxQL
+  - name: InfluxDB_v3_InfluxQL
     type: influxdb
     access: proxy
     url: http://localhost:8086


### PR DESCRIPTION
**What is this feature?**

I believe the documentation for how to add a influxdb datasource was missing a few properties so I updated the documentation to reflect what is working for me

**Why do we need this feature?**

To help others which want to add an influx v2 datasource to Grafana

**Who is this feature for?**

Users that are looking for an example on how to add a influxdb v2 datasource to grafana

