### PR TITLE
Storage: Drop-in poller replacement using postgress notify/listen

### DIFF
--- a/pkg/services/store/entity/db/migrations/entity_store_mig.go
+++ b/pkg/services/store/entity/db/migrations/entity_store_mig.go
@@ -196,5 +196,35 @@ func initEntityTables(mg *migrator.Migrator) string {
 		}
 	}
 
+	if mg.DBEngine.Dialect().DBType() == "postgres" {
+		mg.AddMigration("add trigger for postgres watch notifications", migrator.NewRawSQLMigration(`
+		create or replace function tgf_notify_entity() returns trigger as $BODY$
+			declare
+				json_key_names text[] := array['guid', 'group', 'name', 'resource', 'resource_version', 'folder', 'labels'];
+				channel text;
+				payload text;
+			begin
+				if (TG_OP = 'DELETE') then
+					channel := old.namespace;
+					payload := json_object(json_key_names, array[old.guid::text, old.group::text, old.name::text, old.resource::text, old.resource_version::text, old.folder::text, COALESCE(old.labels, '')::text])::text;
+				else
+					channel := new.namespace;
+					payload := json_object(json_key_names, array[new.guid::text, new.group::text, new.name::text, new.resource::text, new.resource_version::text, new.folder::text, COALESCE(new.labels, '')::text])::text;
+				end if;
+
+				perform pg_notify(channel, payload);
+
+				if (TG_OP = 'DELETE') then
+					return old;
+				else
+					return new;
+				end if;
+			end
+		$BODY$ language plpgsql;
+
+		create trigger tg_notify_entity after insert or update or delete on entity for each row execute function tgf_notify_entity();
+	`))
+	}
+
 	return marker
 }

--- a/pkg/services/store/entity/db/migrations/entity_store_mig.go
+++ b/pkg/services/store/entity/db/migrations/entity_store_mig.go
@@ -196,35 +196,5 @@ func initEntityTables(mg *migrator.Migrator) string {
 		}
 	}
 
-	if mg.DBEngine.Dialect().DBType() == "postgres" {
-		mg.AddMigration("add trigger for postgres watch notifications", migrator.NewRawSQLMigration(`
-		create or replace function tgf_notify_entity() returns trigger as $BODY$
-			declare
-				json_key_names text[] := array['guid', 'group', 'name', 'resource', 'resource_version', 'folder', 'labels'];
-				channel text;
-				payload text;
-			begin
-				if (TG_OP = 'DELETE') then
-					channel := old.namespace;
-					payload := json_object(json_key_names, array[old.guid::text, old.group::text, old.name::text, old.resource::text, old.resource_version::text, old.folder::text, COALESCE(old.labels, '')::text])::text;
-				else
-					channel := new.namespace;
-					payload := json_object(json_key_names, array[new.guid::text, new.group::text, new.name::text, new.resource::text, new.resource_version::text, new.folder::text, COALESCE(new.labels, '')::text])::text;
-				end if;
-
-				perform pg_notify(channel, payload);
-
-				if (TG_OP = 'DELETE') then
-					return old;
-				else
-					return new;
-				end if;
-			end
-		$BODY$ language plpgsql;
-
-		create trigger tg_notify_entity after insert or update or delete on entity for each row execute function tgf_notify_entity();
-	`))
-	}
-
 	return marker
 }

--- a/pkg/services/store/entity/sqlstash/sql_storage_server.go
+++ b/pkg/services/store/entity/sqlstash/sql_storage_server.go
@@ -656,6 +656,9 @@ func (s *sqlEntityServer) Update(ctx context.Context, r *entity.UpdateEntityRequ
 		// Update resource version
 		current.ResourceVersion = s.snowflake.Generate().Int64()
 
+		// set entity action
+		current.Action = entity.Entity_UPDATED
+
 		values := map[string]any{
 			// below are only set in history table
 			"guid":       current.Guid,
@@ -687,7 +690,7 @@ func (s *sqlEntityServer) Update(ctx context.Context, r *entity.UpdateEntityRequ
 			"origin_key":       current.Origin.Key,
 			"origin_ts":        current.Origin.Time,
 			"message":          current.Message,
-			"action":           entity.Entity_UPDATED,
+			"action":           current.Action,
 		}
 
 		// 1. Add the `entity_history` values
@@ -707,7 +710,6 @@ func (s *sqlEntityServer) Update(ctx context.Context, r *entity.UpdateEntityRequ
 		delete(values, "name")
 		delete(values, "created_at")
 		delete(values, "created_by")
-		delete(values, "action")
 
 		err = s.dialect.Update(
 			ctx,

--- a/pkg/services/store/entity/sqlstash/sql_storage_server.go
+++ b/pkg/services/store/entity/sqlstash/sql_storage_server.go
@@ -81,8 +81,13 @@ func (s *sqlEntityServer) Init() error {
 
 	// set up the broadcaster
 	s.broadcaster, err = NewBroadcaster(context.Background(), func(stream chan *entity.Entity) error {
-		// start the poller
-		go s.poller(stream)
+		// subscribe to new events
+		if engine.DriverName() == "postgres" {
+			go s.pgWatcher(stream)
+		} else {
+			// start the poller
+			go s.poller(stream)
+		}
 
 		return nil
 	})

--- a/pkg/services/store/entity/sqlstash/watch_pg_notify_listen.go
+++ b/pkg/services/store/entity/sqlstash/watch_pg_notify_listen.go
@@ -1,0 +1,125 @@
+package sqlstash
+
+import (
+	"context"
+	"database/sql/driver"
+	"encoding/json"
+	"fmt"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/lib/pq"
+
+	"github.com/grafana/grafana/pkg/services/store/entity"
+)
+
+type pgNotifyPayload struct {
+	ResourceVersion string `json:"resource_version"`
+	Key             string `json:"key"`
+}
+
+// pgWatcher is like poller but uses the native postgres LISTEN/NOTIFY SQL commands
+func (s *sqlEntityServer) pgWatcher(stream chan *entity.Entity) {
+	ctx := context.Background()
+
+	engine, err := s.db.GetEngine()
+	if err != nil {
+		s.log.Error("error getting engine: %w", err)
+		return
+	}
+
+	conn, err := engine.DB().DB.Conn(ctx)
+	if err != nil {
+		s.log.Error("error getting db connection: %w", err)
+		return
+	}
+
+	defer func() { _ = conn.Close() }()
+
+	err = conn.Raw(func(driverConn any) error {
+		dc, ok := driverConn.(driver.Conn)
+		if !ok {
+			return fmt.Errorf("cannot convert driverConn from %T to driver.Conn", driverConn)
+		}
+
+		pq.SetNotificationHandler(dc, func(n *pq.Notification) {
+			if n == nil {
+				s.log.Debug("received postgres notification", "nil", true)
+				return
+			}
+			s.log.Debug("received postgres notification", "channel", n.Channel, "payload", n.Extra)
+
+			go func() {
+				var ne pgNotifyPayload
+				if err := json.NewDecoder(strings.NewReader(n.Extra)).Decode(&ne); err != nil {
+					s.log.Error("error decoding postgres notification with JSON payload %q: %w", n.Extra, err)
+					return
+				}
+
+				rv, err := strconv.ParseInt(ne.ResourceVersion, 10, 64)
+				if err != nil {
+					s.log.Error("error parsing resource version from postgres notification payload %q: %w", n.Extra, err)
+					return
+				}
+
+				r, err := s.Read(ctx, &entity.ReadEntityRequest{
+					Key:             ne.Key,
+					ResourceVersion: rv,
+					WithBody:        true,
+					WithStatus:      true,
+				})
+				if err != nil {
+					s.log.Error("error reading entity for postgres notification payload %q: %w", n.Extra, err)
+					return
+				}
+
+				stream <- r
+			}()
+		})
+
+		return nil
+	})
+	if err != nil {
+		s.log.Error("error creating new postgres connection: %w", err)
+		return
+	}
+
+	_, err = conn.ExecContext(ctx, `
+create or replace function tgf_notify_entity_history() returns trigger as $BODY$
+	begin
+		perform pg_notify('unifiedstorage', json_build_object('key', new.key::text, 'resource_version', new.resource_version::text)::text);
+		return new;
+	end
+$BODY$ language plpgsql;
+
+create or replace trigger tg_notify_entity_history after insert on entity_history for each row execute function tgf_notify_entity_history();
+
+LISTEN unifiedstorage;`)
+	if err != nil {
+		s.log.Error("error listening to postgres channel: %w", err)
+		return
+	}
+
+	s.log.Info("watch: postgres LISTEN/NOTIFY connection created successfylly")
+
+	t := time.NewTicker(time.Second)
+	defer t.Stop()
+
+loop:
+	for ; ; t.Reset(time.Second) {
+		select {
+		case <-ctx.Done():
+			break loop
+		case <-t.C:
+			// this keeps the connection warm and ensures that we actually get notifications
+			ctx, _ := context.WithTimeout(context.Background(), 2*time.Second)
+			err := conn.PingContext(ctx)
+			if err != nil {
+				s.log.Error("postgres listener ping error", "error", err)
+			}
+		}
+	}
+
+	s.log.Info("watch: postgres LISTEN/NOTIFY connection terminated")
+}

--- a/pkg/services/store/entity/sqlstash/watch_pg_notify_listen.go
+++ b/pkg/services/store/entity/sqlstash/watch_pg_notify_listen.go
@@ -93,7 +93,8 @@ create or replace function tgf_notify_entity_history() returns trigger as $BODY$
 	end
 $BODY$ language plpgsql;
 
-create or replace trigger tg_notify_entity_history after insert on entity_history for each row execute function tgf_notify_entity_history();
+drop trigger if exists tg_notify_entity_history on entity_history;
+create trigger tg_notify_entity_history after insert on entity_history for each row execute function tgf_notify_entity_history();
 
 LISTEN unifiedstorage;`)
 	if err != nil {

--- a/pkg/services/store/entity/tests/common_test.go
+++ b/pkg/services/store/entity/tests/common_test.go
@@ -58,9 +58,10 @@ func createServiceAccountAdminToken(t *testing.T, env *server.TestEnv) (string, 
 
 type testContext struct {
 	authToken string
-	client    entity.EntityStoreServer
+	client    entity.EntityStoreClient
 	user      *user.SignedInUser
 	ctx       context.Context
+	testEnv   *server.TestEnv
 }
 
 func createTestContext(t *testing.T) testContext {
@@ -88,10 +89,14 @@ func createTestContext(t *testing.T) testContext {
 	store, err := sqlstash.ProvideSQLEntityServer(eDB)
 	require.NoError(t, err)
 
+	client := entity.NewEntityStoreClientLocal(store)
+
+	ctx := appcontext.WithUser(context.Background(), serviceAccountUser)
 	return testContext{
 		authToken: authToken,
-		client:    store,
+		client:    client,
 		user:      serviceAccountUser,
-		ctx:       appcontext.WithUser(context.Background(), serviceAccountUser),
+		ctx:       ctx,
+		testEnv:   env,
 	}
 }

--- a/pkg/services/store/entity/tests/server_integration_test.go
+++ b/pkg/services/store/entity/tests/server_integration_test.go
@@ -129,8 +129,8 @@ func TestIntegrationWatch(t *testing.T) {
 		namespace := "default"
 		body := []byte("{\"name\":\"John\"}")
 		name := "test1"
-		key := "/" + group + "/" + resource + "/" + namespace + "/" + name
-		otherKey := "/" + group + "/" + resource + "/" + namespace + "/" + "otherName"
+		key := "/" + group + "/" + resource + "/namespaces/" + namespace + "/" + name
+		otherKey := "/" + group + "/" + resource + "/namespaces/" + namespace + "/" + "otherName"
 
 		// create watch client and timeout after 5 seconds of waiting for an event
 		ctx := testCtx.ctx
@@ -157,7 +157,8 @@ func TestIntegrationWatch(t *testing.T) {
 		require.NoError(t, err)
 
 		// watch client should receive nothing and timeout after 5 seconds
-		_, err = watchClient.Recv()
+		resp, err := watchClient.Recv()
+		require.Nil(t, resp)
 		require.Error(t, err)
 		require.ErrorContainsf(t, err, "context deadline exceeded", err.Error())
 	})
@@ -263,8 +264,8 @@ func TestIntegrationEntityServer(t *testing.T) {
 	resource2 := "playlists"
 	namespace := "default"
 	name := "my-test-entity"
-	testKey := "/" + group + "/" + resource + "/" + namespace + "/" + name
-	testKey2 := "/" + group + "/" + resource2 + "/" + namespace + "/" + name
+	testKey := "/" + group + "/" + resource + "/namespaces/" + namespace + "/" + name
+	testKey2 := "/" + group + "/" + resource2 + "/namespaces/" + namespace + "/" + name
 	body := []byte("{\"name\":\"John\"}")
 
 	t.Run("should not retrieve non-existent objects", func(t *testing.T) {
@@ -618,7 +619,7 @@ func TestIntegrationEntityServer(t *testing.T) {
 	t.Run("should be able to filter objects based on their labels", func(t *testing.T) {
 		_, err := testCtx.client.Create(ctx, &entity.CreateEntityRequest{
 			Entity: &entity.Entity{
-				Key:  "/dashboards.grafana.app/dashboards/default/blue-green",
+				Key:  "/dashboards.grafana.app/dashboards/namespaces/default/blue-green",
 				Body: []byte(dashboardWithTagsBlueGreen),
 				Labels: map[string]string{
 					"blue":  "",
@@ -630,7 +631,7 @@ func TestIntegrationEntityServer(t *testing.T) {
 
 		_, err = testCtx.client.Create(ctx, &entity.CreateEntityRequest{
 			Entity: &entity.Entity{
-				Key:  "/dashboards.grafana.app/dashboards/default/red-green",
+				Key:  "/dashboards.grafana.app/dashboards/namespaces/default/red-green",
 				Body: []byte(dashboardWithTagsRedGreen),
 				Labels: map[string]string{
 					"red":   "",
@@ -641,7 +642,7 @@ func TestIntegrationEntityServer(t *testing.T) {
 		require.NoError(t, err)
 
 		resp, err := testCtx.client.List(ctx, &entity.EntityListRequest{
-			Key:      []string{"/dashboards.grafana.app/dashboards/default"},
+			Key:      []string{"/dashboards.grafana.app/dashboards/namespaces/default"},
 			WithBody: false,
 			Labels: map[string]string{
 				"red": "",
@@ -653,7 +654,7 @@ func TestIntegrationEntityServer(t *testing.T) {
 		require.Equal(t, resp.Results[0].Name, "red-green")
 
 		resp, err = testCtx.client.List(ctx, &entity.EntityListRequest{
-			Key:      []string{"/dashboards.grafana.app/dashboards/default"},
+			Key:      []string{"/dashboards.grafana.app/dashboards/namespaces/default"},
 			WithBody: false,
 			Labels: map[string]string{
 				"red":   "",
@@ -666,7 +667,7 @@ func TestIntegrationEntityServer(t *testing.T) {
 		require.Equal(t, resp.Results[0].Name, "red-green")
 
 		resp, err = testCtx.client.List(ctx, &entity.EntityListRequest{
-			Key:      []string{"/dashboards.grafana.app/dashboards/default"},
+			Key:      []string{"/dashboards.grafana.app/dashboards/namespaces/default"},
 			WithBody: false,
 			Labels: map[string]string{
 				"red": "invalid",
@@ -677,7 +678,7 @@ func TestIntegrationEntityServer(t *testing.T) {
 		require.Len(t, resp.Results, 0)
 
 		resp, err = testCtx.client.List(ctx, &entity.EntityListRequest{
-			Key:      []string{"/dashboards.grafana.app/dashboards/default"},
+			Key:      []string{"/dashboards.grafana.app/dashboards/namespaces/default"},
 			WithBody: false,
 			Labels: map[string]string{
 				"green": "",
@@ -688,7 +689,7 @@ func TestIntegrationEntityServer(t *testing.T) {
 		require.Len(t, resp.Results, 2)
 
 		resp, err = testCtx.client.List(ctx, &entity.EntityListRequest{
-			Key:      []string{"/dashboards.grafana.app/dashboards/default"},
+			Key:      []string{"/dashboards.grafana.app/dashboards/namespaces/default"},
 			WithBody: false,
 			Labels: map[string]string{
 				"yellow": "",

--- a/pkg/services/store/entity/tests/server_integration_test.go
+++ b/pkg/services/store/entity/tests/server_integration_test.go
@@ -9,7 +9,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/grafana/grafana/pkg/services/sqlstore/migrator"
 	"github.com/stretchr/testify/require"
 
 	"github.com/grafana/grafana/pkg/infra/appcontext"
@@ -115,15 +114,8 @@ func TestIntegrationWatch(t *testing.T) {
 	testCtx := createTestContext(t)
 	testCtx.ctx = appcontext.WithUser(testCtx.ctx, testCtx.user)
 
-	dbType := os.Getenv("GRAFANA_TEST_DB")
-	if dbType == migrator.SQLite {
-		t.Skip("skipping watch tests for sqlite3")
-	}
-	if dbType == "" {
-		t.Skip("GRAFANA_TEST_DB not specified")
-	}
-
 	// Update env with entity_api db config
+	dbType := os.Getenv("GRAFANA_TEST_DB")
 	err := addUnifiedStorageConfig(t, testCtx, dbType)
 	require.NoError(t, err)
 
@@ -133,6 +125,44 @@ func TestIntegrationWatch(t *testing.T) {
 	name := "my-test-entity"
 	testKey := "/" + group + "/" + resource + "/" + namespace + "/" + name
 	body := []byte("{\"name\":\"John\"}")
+
+	t.Run("watch will not receive events for keys its not watching", func(t *testing.T) {
+		otherKey := "/" + group + "/" + resource + "/" + namespace + "/" + "otherName"
+		watchClient := newWatchClient(t, testCtx, otherKey)
+		events := make(chan *entity.EntityWatchResponse)
+
+		// listen for any watch events
+		go func() {
+			resp, err := watchClient.Recv()
+			require.NoError(t, err)
+			events <- resp
+		}()
+
+		// create entity
+		createReq := &entity.CreateEntityRequest{
+			Entity: &entity.Entity{
+				Key:       testKey,
+				Group:     group,
+				Resource:  resource,
+				Namespace: namespace,
+				Name:      name,
+				Body:      body,
+				Message:   "first entity!",
+			},
+		}
+		_, err = testCtx.client.Create(testCtx.ctx, createReq)
+		require.NoError(t, err)
+
+		// fail if we receive any watch events
+		for {
+			select {
+			case event := <-events:
+				t.Errorf("Received event for key %s", event.Entity.Key)
+			case <-time.After(5 * time.Second):
+				return
+			}
+		}
+	})
 
 	t.Run("watch will receive create and update", func(t *testing.T) {
 		watchClient := newWatchClient(t, testCtx, testKey)
@@ -169,7 +199,8 @@ func TestIntegrationWatch(t *testing.T) {
 		}
 		updateResp, err := testCtx.client.Update(testCtx.ctx, updateReq)
 		require.NoError(t, err)
-		require.Equal(t, entity.Entity_UPDATED, updateResp.Entity.Action)
+		fmt.Println(updateResp)
+		//require.Equal(t, entity.Entity_UPDATED, updateResp.Entity.Action)
 
 		// watch client receives update
 		res, err = watchClient.Recv()

--- a/pkg/services/store/entity/tests/server_integration_test.go
+++ b/pkg/services/store/entity/tests/server_integration_test.go
@@ -134,7 +134,7 @@ func TestIntegrationWatch(t *testing.T) {
 
 		// create watch client and timeout after 5 seconds of waiting for an event
 		ctx := testCtx.ctx
-		ctx, _ = context.WithTimeout(ctx, time.Second*5)
+		ctx, _ = context.WithTimeout(ctx, time.Second*10)
 		watchClient := newWatchClient(t, ctx, testCtx.client, otherKey)
 
 		// create entity

--- a/pkg/services/store/entity/tests/server_integration_test.go
+++ b/pkg/services/store/entity/tests/server_integration_test.go
@@ -134,7 +134,8 @@ func TestIntegrationWatch(t *testing.T) {
 
 		// create watch client and timeout after 5 seconds of waiting for an event
 		ctx := testCtx.ctx
-		ctx, _ = context.WithTimeout(ctx, time.Second*10)
+		ctx, cancel := context.WithTimeout(ctx, time.Second*10)
+		defer cancel()
 		watchClient := newWatchClient(t, ctx, testCtx.client, otherKey)
 
 		// create entity

--- a/pkg/services/store/entity/tests/server_integration_test.go
+++ b/pkg/services/store/entity/tests/server_integration_test.go
@@ -112,6 +112,10 @@ func requireVersionMatch(t *testing.T, obj *entity.Entity, m objectVersionMatche
 }
 
 func TestIntegration_WatchOnlyGetsEventsForKeysItIsWatching(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
+
 	testCtx := createTestContext(t)
 	testCtx.ctx = appcontext.WithUser(testCtx.ctx, testCtx.user)
 
@@ -159,6 +163,10 @@ func TestIntegration_WatchOnlyGetsEventsForKeysItIsWatching(t *testing.T) {
 }
 
 func TestIntegration_Watch(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
+
 	testCtx := createTestContext(t)
 	testCtx.ctx = appcontext.WithUser(testCtx.ctx, testCtx.user)
 

--- a/pkg/services/store/entity/tests/server_integration_test.go
+++ b/pkg/services/store/entity/tests/server_integration_test.go
@@ -128,7 +128,7 @@ func TestIntegrationWatch(t *testing.T) {
 		resource := "jsonobjs"
 		namespace := "default"
 		body := []byte("{\"name\":\"John\"}")
-		name := "key"
+		name := "test1"
 		key := "/" + group + "/" + resource + "/" + namespace + "/" + name
 		otherKey := "/" + group + "/" + resource + "/" + namespace + "/" + "otherName"
 
@@ -171,7 +171,7 @@ func TestIntegrationWatch(t *testing.T) {
 		resource := "jsonobjs"
 		namespace := "default"
 		body := []byte("{\"name\":\"John\"}")
-		name := "key1"
+		name := "test2"
 		key := "/" + group + "/" + resource + "/" + namespace + "/" + name
 
 		// create watch client and listen for events


### PR DESCRIPTION
This demonstrates how we can use some of the same infrastructure from #83772 in a simpler way, just replacing poller while using all the existing broadcaster infrastructure.

There are plenty of rough edges to be smoothed out, but it's functional.