### PR TITLE
Dashboard scenes: Remove panel menu options that are dashboard editing activities when not in edit mode.

### DIFF
--- a/public/app/features/dashboard-scene/scene/PanelMenuBehavior.test.tsx
+++ b/public/app/features/dashboard-scene/scene/PanelMenuBehavior.test.tsx
@@ -70,7 +70,7 @@ describe('panelMenuBehavior', () => {
 
     await new Promise((r) => setTimeout(r, 1));
 
-    expect(menu.state.items?.length).toBe(8);
+    expect(menu.state.items?.length).toBe(6);
     // verify view panel url keeps url params and adds viewPanel=<panel-key>
     expect(menu.state.items?.[0].href).toBe('/d/dash-1?from=now-5m&to=now&viewPanel=panel-12');
     // verify edit url keeps url time range
@@ -119,7 +119,7 @@ describe('panelMenuBehavior', () => {
 
       await new Promise((r) => setTimeout(r, 1));
 
-      expect(menu.state.items?.length).toBe(9);
+      expect(menu.state.items?.length).toBe(7);
 
       const extensionsSubMenu = menu.state.items?.find((i) => i.text === 'Extensions')?.subMenu;
 
@@ -158,7 +158,7 @@ describe('panelMenuBehavior', () => {
 
       await new Promise((r) => setTimeout(r, 1));
 
-      expect(menu.state.items?.length).toBe(9);
+      expect(menu.state.items?.length).toBe(7);
 
       const extensionsSubMenu = menu.state.items?.find((i) => i.text === 'Extensions')?.subMenu;
 
@@ -199,7 +199,7 @@ describe('panelMenuBehavior', () => {
 
       await new Promise((r) => setTimeout(r, 1));
 
-      expect(menu.state.items?.length).toBe(9);
+      expect(menu.state.items?.length).toBe(7);
 
       const extensionsSubMenu = menu.state.items?.find((i) => i.text === 'Extensions')?.subMenu;
       const menuItem = extensionsSubMenu?.find((i) => (i.text = 'Declare incident when...'));
@@ -347,7 +347,7 @@ describe('panelMenuBehavior', () => {
 
       await new Promise((r) => setTimeout(r, 1));
 
-      expect(menu.state.items?.length).toBe(9);
+      expect(menu.state.items?.length).toBe(7);
 
       const extensionsSubMenu = menu.state.items?.find((i) => i.text === 'Extensions')?.subMenu;
 
@@ -392,7 +392,7 @@ describe('panelMenuBehavior', () => {
 
       await new Promise((r) => setTimeout(r, 1));
 
-      expect(menu.state.items?.length).toBe(9);
+      expect(menu.state.items?.length).toBe(7);
 
       const extensionsSubMenu = menu.state.items?.find((i) => i.text === 'Extensions')?.subMenu;
 
@@ -445,7 +445,7 @@ describe('panelMenuBehavior', () => {
 
       await new Promise((r) => setTimeout(r, 1));
 
-      expect(menu.state.items?.length).toBe(9);
+      expect(menu.state.items?.length).toBe(7);
 
       const extensionsSubMenu = menu.state.items?.find((i) => i.text === 'Extensions')?.subMenu;
 
@@ -468,6 +468,43 @@ describe('panelMenuBehavior', () => {
           }),
         ])
       );
+    });
+
+    it('it should not contain remove and duplicate menu items when not in edit mode', async () => {
+      const { menu, panel } = await buildTestScene({});
+
+      panel.getPlugin = () => getPanelPlugin({ skipDataQuery: false });
+
+      mocks.contextSrv.hasAccessToExplore.mockReturnValue(true);
+      mocks.getExploreUrl.mockReturnValue(Promise.resolve('/explore'));
+
+      menu.activate();
+
+      await new Promise((r) => setTimeout(r, 1));
+
+      expect(menu.state.items?.find((i) => i.text === 'Remove')).toBeUndefined();
+      const moreMenu = menu.state.items?.find((i) => i.text === 'More...')?.subMenu;
+      expect(moreMenu?.find((i) => i.text === 'Duplicate')).toBeUndefined();
+      expect(moreMenu?.find((i) => i.text === 'Create library panel')).toBeUndefined();
+    });
+
+    it('it should contain remove and duplicate menu items when in edit mode', async () => {
+      const { scene, menu, panel } = await buildTestScene({});
+      scene.setState({ isEditing: true });
+
+      panel.getPlugin = () => getPanelPlugin({ skipDataQuery: false });
+
+      mocks.contextSrv.hasAccessToExplore.mockReturnValue(true);
+      mocks.getExploreUrl.mockReturnValue(Promise.resolve('/explore'));
+
+      menu.activate();
+
+      await new Promise((r) => setTimeout(r, 1));
+
+      expect(menu.state.items?.find((i) => i.text === 'Remove')).toBeDefined();
+      const moreMenu = menu.state.items?.find((i) => i.text === 'More...')?.subMenu;
+      expect(moreMenu?.find((i) => i.text === 'Duplicate')).toBeDefined();
+      expect(moreMenu?.find((i) => i.text === 'Create library panel')).toBeDefined();
     });
 
     it('should only contain explore when embedded', async () => {

--- a/public/app/features/dashboard-scene/scene/PanelMenuBehavior.tsx
+++ b/public/app/features/dashboard-scene/scene/PanelMenuBehavior.tsx
@@ -86,14 +86,16 @@ export function panelMenuBehavior(menu: VizPanelMenu) {
       shortcut: 'p s',
     });
 
-    moreSubMenu.push({
-      text: t('panel.header-menu.duplicate', `Duplicate`),
-      onClick: () => {
-        DashboardInteractions.panelMenuItemClicked('duplicate');
-        dashboard.duplicatePanel(panel);
-      },
-      shortcut: 'p d',
-    });
+    if (dashboard.state.isEditing) {
+      moreSubMenu.push({
+        text: t('panel.header-menu.duplicate', `Duplicate`),
+        onClick: () => {
+          DashboardInteractions.panelMenuItemClicked('duplicate');
+          dashboard.duplicatePanel(panel);
+        },
+        shortcut: 'p d',
+      });
+    }
 
     moreSubMenu.push({
       text: t('panel.header-menu.copy', `Copy`),
@@ -103,32 +105,34 @@ export function panelMenuBehavior(menu: VizPanelMenu) {
       },
     });
 
-    if (parent instanceof LibraryVizPanel) {
-      moreSubMenu.push({
-        text: t('panel.header-menu.unlink-library-panel', `Unlink library panel`),
-        onClick: () => {
-          DashboardInteractions.panelMenuItemClicked('unlinkLibraryPanel');
-          dashboard.showModal(
-            new UnlinkLibraryPanelModal({
-              panelRef: parent.getRef(),
-            })
-          );
-        },
-      });
-    } else {
-      moreSubMenu.push({
-        text: t('panel.header-menu.create-library-panel', `Create library panel`),
-        onClick: () => {
-          DashboardInteractions.panelMenuItemClicked('createLibraryPanel');
-          dashboard.showModal(
-            new ShareModal({
-              panelRef: panel.getRef(),
-              dashboardRef: dashboard.getRef(),
-              activeTab: shareDashboardType.libraryPanel,
-            })
-          );
-        },
-      });
+    if (dashboard.state.isEditing) {
+      if (parent instanceof LibraryVizPanel) {
+        moreSubMenu.push({
+          text: t('panel.header-menu.unlink-library-panel', `Unlink library panel`),
+          onClick: () => {
+            DashboardInteractions.panelMenuItemClicked('unlinkLibraryPanel');
+            dashboard.showModal(
+              new UnlinkLibraryPanelModal({
+                panelRef: parent.getRef(),
+              })
+            );
+          },
+        });
+      } else {
+        moreSubMenu.push({
+          text: t('panel.header-menu.create-library-panel', `Create library panel`),
+          onClick: () => {
+            DashboardInteractions.panelMenuItemClicked('createLibraryPanel');
+            dashboard.showModal(
+              new ShareModal({
+                panelRef: panel.getRef(),
+                dashboardRef: dashboard.getRef(),
+                activeTab: shareDashboardType.libraryPanel,
+              })
+            );
+          },
+        });
+      }
     }
 
     moreSubMenu.push({
@@ -196,20 +200,22 @@ export function panelMenuBehavior(menu: VizPanelMenu) {
       });
     }
 
-    items.push({
-      text: '',
-      type: 'divider',
-    });
+    if (dashboard.state.isEditing) {
+      items.push({
+        text: '',
+        type: 'divider',
+      });
 
-    items.push({
-      text: t('panel.header-menu.remove', `Remove`),
-      iconClassName: 'trash-alt',
-      onClick: () => {
-        DashboardInteractions.panelMenuItemClicked('remove');
-        onRemovePanel(dashboard, panel);
-      },
-      shortcut: 'p r',
-    });
+      items.push({
+        text: t('panel.header-menu.remove', `Remove`),
+        iconClassName: 'trash-alt',
+        onClick: () => {
+          DashboardInteractions.panelMenuItemClicked('remove');
+          onRemovePanel(dashboard, panel);
+        },
+        shortcut: 'p r',
+      });
+    }
 
     menu.setState({ items });
   };

--- a/public/app/features/dashboard-scene/scene/keyboardShortcuts.ts
+++ b/public/app/features/dashboard-scene/scene/keyboardShortcuts.ts
@@ -117,22 +117,24 @@ export function setupKeyboardShortcuts(scene: DashboardScene) {
 
   // toggle all panel legends (TODO)
   // delete panel
-  if (scene.state.isEditing) {
-    keybindings.addBinding({
-      key: 'p r',
-      onTrigger: withFocusedPanel(scene, (vizPanel: VizPanel) => {
+  keybindings.addBinding({
+    key: 'p r',
+    onTrigger: withFocusedPanel(scene, (vizPanel: VizPanel) => {
+      if (scene.state.isEditing) {
         onRemovePanel(scene, vizPanel);
-      }),
-    });
+      }
+    }),
+  });
 
-    // duplicate panel
-    keybindings.addBinding({
-      key: 'p d',
-      onTrigger: withFocusedPanel(scene, (vizPanel: VizPanel) => {
+  // duplicate panel
+  keybindings.addBinding({
+    key: 'p d',
+    onTrigger: withFocusedPanel(scene, (vizPanel: VizPanel) => {
+      if (scene.state.isEditing) {
         scene.duplicatePanel(vizPanel);
-      }),
-    });
-  }
+      }
+    }),
+  });
 
   // toggle all exemplars (TODO)
   // collapse all rows (TODO)

--- a/public/app/features/dashboard-scene/scene/keyboardShortcuts.ts
+++ b/public/app/features/dashboard-scene/scene/keyboardShortcuts.ts
@@ -117,20 +117,22 @@ export function setupKeyboardShortcuts(scene: DashboardScene) {
 
   // toggle all panel legends (TODO)
   // delete panel
-  keybindings.addBinding({
-    key: 'p r',
-    onTrigger: withFocusedPanel(scene, (vizPanel: VizPanel) => {
-      onRemovePanel(scene, vizPanel);
-    }),
-  });
+  if (scene.state.isEditing) {
+    keybindings.addBinding({
+      key: 'p r',
+      onTrigger: withFocusedPanel(scene, (vizPanel: VizPanel) => {
+        onRemovePanel(scene, vizPanel);
+      }),
+    });
 
-  // duplicate panel
-  keybindings.addBinding({
-    key: 'p d',
-    onTrigger: withFocusedPanel(scene, (vizPanel: VizPanel) => {
-      scene.duplicatePanel(vizPanel);
-    }),
-  });
+    // duplicate panel
+    keybindings.addBinding({
+      key: 'p d',
+      onTrigger: withFocusedPanel(scene, (vizPanel: VizPanel) => {
+        scene.duplicatePanel(vizPanel);
+      }),
+    });
+  }
 
   // toggle all exemplars (TODO)
   // collapse all rows (TODO)


### PR DESCRIPTION
**What is this feature?**
We only show the panel menu options that directly edit the state of the dashboard when we are in dashboard edit mode. The menu options affected are remove, duplicate, unlink library panel and create library panel.
