### PR TITLE
[v10.2.x] Dashboards: Run shared queries even when source panel is in collapsed row

### DIFF
--- a/public/app/features/dashboard/state/DashboardModel.ts
+++ b/public/app/features/dashboard/state/DashboardModel.ts
@@ -516,12 +516,22 @@ export class DashboardModel implements TimeModel {
     }
   }
 
-  getPanelById(id: number): PanelModel | null {
+  getPanelById(id: number, includeCollapsed = false): PanelModel | null {
     if (this.panelInEdit && this.panelInEdit.id === id) {
       return this.panelInEdit;
     }
 
-    return this.panels.find((p) => p.id === id) ?? null;
+    if (includeCollapsed) {
+      for (const panel of this.panelIterator()) {
+        if (panel.id === id) {
+          return panel;
+        }
+      }
+
+      return null;
+    } else {
+      return this.panels.find((p) => p.id === id) ?? null;
+    }
   }
 
   canEditPanel(panel?: PanelModel | null): boolean | undefined | null {

--- a/public/app/plugins/datasource/dashboard/runSharedRequest.ts
+++ b/public/app/plugins/datasource/dashboard/runSharedRequest.ts
@@ -11,6 +11,7 @@ import {
   DataTopic,
 } from '@grafana/data';
 import { getDashboardSrv } from 'app/features/dashboard/services/DashboardSrv';
+import { PanelModel } from 'app/features/dashboard/state';
 import { QueryRunnerOptions } from 'app/features/query/state/PanelQueryRunner';
 
 import { DashboardQuery, SHARED_DASHBOARD_QUERY } from './types';
@@ -42,7 +43,12 @@ export function runSharedRequest(options: QueryRunnerOptions, query: DashboardQu
       return undefined;
     }
 
-    const listenToPanel = dashboard?.getPanelById(listenToPanelId);
+    // Source panel might be contained in a collapsed row, in which
+    // case we need to create a PanelModel
+    let listenToPanel = dashboard?.getPanelById(listenToPanelId, true);
+    if (!(listenToPanel instanceof PanelModel)) {
+      listenToPanel = new PanelModel(listenToPanel);
+    }
 
     if (!listenToPanel) {
       subscriber.next(getQueryError('Unknown Panel: ' + listenToPanelId));


### PR DESCRIPTION
Backport 6989db1ad357bd17286bd1c1058c45ffc59a3f9b from #77792

---

Fixes an issue where panels using a shared query would show no data if the source panel was in a collapsed row.
