### PR TITLE
Auth: Only call rotate token if we have a session expiry cookie

### DIFF
--- a/public/app/core/services/backend_srv.ts
+++ b/public/app/core/services/backend_srv.ts
@@ -19,7 +19,7 @@ import { AppEvents, DataQueryErrorType } from '@grafana/data';
 import { BackendSrv as BackendService, BackendSrvRequest, config, FetchError, FetchResponse } from '@grafana/runtime';
 import appEvents from 'app/core/app_events';
 import { getConfig } from 'app/core/config';
-import { getSessionExpiry } from 'app/core/utils/auth';
+import { getSessionExpiry, hasSessionExpiry } from 'app/core/utils/auth';
 import { loadUrlToken } from 'app/core/utils/urlToken';
 import { DashboardModel } from 'app/features/dashboard/state';
 import { DashboardSearchItem } from 'app/features/search/types';
@@ -390,10 +390,11 @@ export class BackendSrv implements BackendService {
                 }
 
                 let authChecker = this.loginPing();
-
-                const expired = getSessionExpiry() * 1000 < Date.now();
-                if (expired) {
-                  authChecker = this.rotateToken();
+                if (hasSessionExpiry()) {
+                  const expired = getSessionExpiry() * 1000 < Date.now();
+                  if (expired) {
+                    authChecker = this.rotateToken();
+                  }
                 }
 
                 return from(authChecker).pipe(

--- a/public/app/core/specs/backend_srv.test.ts
+++ b/public/app/core/specs/backend_srv.test.ts
@@ -86,6 +86,11 @@ const getTestContext = (overides?: object, mockFromFetch = true) => {
   };
 };
 
+jest.mock('app/core/utils/auth', () => ({
+  getSessionExpiry: () => 1,
+  hasSessionExpiry: () => true,
+}));
+
 describe('backendSrv', () => {
   describe('parseRequestOptions', () => {
     it.each`

--- a/public/app/core/utils/auth.ts
+++ b/public/app/core/utils/auth.ts
@@ -11,3 +11,7 @@ export function getSessionExpiry() {
 
   return parseInt(expiresStr, 10);
 }
+
+export function hasSessionExpiry() {
+  return document.cookie.split('; ').findIndex((row) => row.startsWith('grafana_session_expiry=')) > -1;
+}


### PR DESCRIPTION
**What is this feature?**
When getting a 401 response we always tried to rotate token. This works correctly as long as a user has a sessions cookie. But there are cases when a user don't have one (anonymous and auth proxy). When the server respond with a 401 this is causing a infinite reload loop for that page.

To solve this we only call rotate token if we have a _session expiry cookie_ and in all other cases we call `GET /api/login/ping` to determine if user is authenticated.

For 10.3.x and below this can be mitigated by disabling the feature toggle. But in 10.4.x the toggle is removed and this is the default behaviour.

**Why do we need this feature?**
To solve issue with infinite page reload loop for users without a sessions.

**Which issue(s) does this PR fix?**:

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
