### PR TITLE
Disable skip button when feature is enabled

### DIFF
--- a/public/app/core/components/ForgottenPassword/ChangePassword.tsx
+++ b/public/app/core/components/ForgottenPassword/ChangePassword.tsx
@@ -2,6 +2,7 @@ import React, { SyntheticEvent, useState } from 'react';
 import { useForm } from 'react-hook-form';
 
 import { selectors } from '@grafana/e2e-selectors';
+import { config } from '@grafana/runtime';
 import { Tooltip, Field, VerticalGroup, Button, Alert, useStyles2 } from '@grafana/ui';
 
 import { getStyles } from '../Login/LoginForm';
@@ -85,7 +86,7 @@ export const ChangePassword = ({ onSubmit, onSkip, showDefaultPasswordWarning }:
           Submit
         </Button>
 
-        {onSkip && (
+        {!config.auth.basicAuthStrongPasswordPolicy && onSkip && (
           <Tooltip
             content="If you skip you will be prompted to change password next time you log in."
             placement="bottom"


### PR DESCRIPTION
**What is this feature?**

This PR will disable the skip button when logging in with the `admin` user and requesting to update your password and the Strong Password Policy is enabled.

**Why do we need this feature?**

The `admin` user uses as default the `admin` password, which is incompatible with the Strong Password Policy. This PR addresses that scenario.

**Who is this feature for?**

[Add information on what kind of user the feature is for.]

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes https://github.com/grafana/identity-access-team/issues/596

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
