### PR TITLE
[DOC] Adding deprecation for Loki query in Tempo data source

### DIFF
--- a/docs/sources/datasources/tempo/query-editor/_index.md
+++ b/docs/sources/datasources/tempo/query-editor/_index.md
@@ -101,6 +101,10 @@ To query a particular trace:
 
 ## Query Loki for traces
 
+{{< admonition type="caution" >}}
+Starting with release Grafana v11, the Loki query tab will no longer be available.
+{{< /admonition >}}
+
 To find traces to visualize, you can use the [Loki query editor]({{< relref "../../loki#loki-query-editor" >}}).
 For results, you must configure [derived fields]({{< relref "../../loki#configure-derived-fields" >}}) in the Loki data source that point to this data source.
 

--- a/docs/sources/datasources/tempo/query-editor/_index.md
+++ b/docs/sources/datasources/tempo/query-editor/_index.md
@@ -102,7 +102,7 @@ To query a particular trace:
 ## Query Loki for traces
 
 {{< admonition type="caution" >}}
-Starting with release Grafana v11, the Loki query tab will no longer be available.
+Starting with release Grafana v11, the Loki query tab will no longer be available in the Tempo data source.
 {{< /admonition >}}
 
 To find traces to visualize, you can use the [Loki query editor]({{< relref "../../loki#loki-query-editor" >}}).


### PR DESCRIPTION
**Who is this feature for?**

Adds a deprecation for the Loki query tab in the Tempo data source. 

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [X] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
