### PR TITLE
Google Cloud Monitor: Fix `res` being accessed after it becomes `nil` in `promql_query.go`

### DIFF
--- a/pkg/tsdb/cloud-monitoring/promql_query.go
+++ b/pkg/tsdb/cloud-monitoring/promql_query.go
@@ -42,15 +42,16 @@ func (promQLQ *cloudMonitoringProm) run(ctx context.Context, req *backend.QueryD
 	}
 
 	res, err := doRequestProm(r, dsInfo, requestBody)
+	if err != nil {
+		dr.Error = err
+		return dr, promResponse{}, "", nil
+	}
+
 	defer func() {
 		if err := res.Body.Close(); err != nil {
 			s.logger.Error("Failed to close response body", "err", err)
 		}
 	}()
-	if err != nil {
-		dr.Error = err
-		return dr, promResponse{}, "", nil
-	}
 
 	return dr, parseProm(res), r.URL.RawQuery, nil
 }


### PR DESCRIPTION
Fixes https://github.com/grafana/support-escalations/issues/9574. This PR fixes an issue where `res` was accessed inside a deferred function, which was called after `res` became `nil` (so `res.Body` also is), which was throwing an exception.