### PR TITLE
Cloudwatch: Fix bug related to external ids with grafana assume role

### DIFF
--- a/pkg/tsdb/cloudwatch/cloudwatch.go
+++ b/pkg/tsdb/cloudwatch/cloudwatch.go
@@ -149,18 +149,21 @@ func (e *cloudWatchExecutor) getRequestContext(ctx context.Context, pluginCtx ba
 	instance, err := e.getInstance(ctx, pluginCtx)
 	if region == defaultRegion {
 		if err != nil {
+			e.logger.Error("Error getting instance in getRequestContext", "err", err)
 			return models.RequestContext{}, err
 		}
 		r = instance.Settings.Region
 	}
 
-	ec2Client, err := e.getEC2Client(ctx, pluginCtx, defaultRegion)
+	ec2Client, err := e.getEC2Client(ctx, pluginCtx, r)
 	if err != nil {
+		e.logger.Error("Error getting EC2 client in getRequestContext", "err", err)
 		return models.RequestContext{}, err
 	}
 
 	sess, err := instance.newSession(r)
 	if err != nil {
+		e.logger.Error("Error getting session in getRequestContext", "err", err)
 		return models.RequestContext{}, err
 	}
 
@@ -324,6 +327,7 @@ func (ds *DataSource) newSession(region string) (*session.Session, error) {
 func (e *cloudWatchExecutor) newSessionFromContext(ctx context.Context, pluginCtx backend.PluginContext, region string) (*session.Session, error) {
 	instance, err := e.getInstance(ctx, pluginCtx)
 	if err != nil {
+		e.logger.Error("Error getting instance in newSessionFromContext", "err", err)
 		return nil, err
 	}
 
@@ -362,6 +366,7 @@ func (e *cloudWatchExecutor) getCWLogsClient(ctx context.Context, pluginCtx back
 func (e *cloudWatchExecutor) getEC2Client(ctx context.Context, pluginCtx backend.PluginContext, region string) (models.EC2APIProvider, error) {
 	sess, err := e.newSessionFromContext(ctx, pluginCtx, region)
 	if err != nil {
+		e.logger.Error("Error getting session in getEC2Client", "err", err)
 		return nil, err
 	}
 

--- a/pkg/tsdb/cloudwatch/models/settings.go
+++ b/pkg/tsdb/cloudwatch/models/settings.go
@@ -44,6 +44,15 @@ func LoadCloudWatchSettings(ctx context.Context, config backend.DataSourceInstan
 	}
 
 	instance.GrafanaSettings = *awsds.ReadAuthSettings(ctx)
+	if len(instance.GrafanaSettings.AllowedAuthProviders) > 0 {
+		authType, err := awsds.ToAuthType(instance.GrafanaSettings.AllowedAuthProviders[0])
+		if err != nil {
+			logger := backend.Logger.FromContext(ctx)
+			logger.Error("Failed to convert auth type", "error", err)
+			return CloudWatchSettings{}, err
+		}
+		instance.AuthType = authType
+	}
 
 	return instance, nil
 }

--- a/pkg/tsdb/cloudwatch/routes/external_id.go
+++ b/pkg/tsdb/cloudwatch/routes/external_id.go
@@ -15,10 +15,9 @@ type ExternalIdResponse struct {
 }
 
 func ExternalIdHandler(ctx context.Context, pluginCtx backend.PluginContext, reqCtxFactory models.RequestContextFactoryFunc, parameters url.Values) ([]byte, *models.HttpError) {
-	logger := backend.Logger.FromContext(ctx)
 	reqCtx, err := reqCtxFactory(ctx, pluginCtx, "us-east-2")
 	if err != nil {
-		logger.Error("error in ExternalIdHandler when calling reqCtxFactory", "error", err)
+		reqCtx.Logger.Error("error in ExternalIdHandler when calling reqCtxFactory", "error", err)
 		return nil, models.NewHttpError("error in ExternalIdHandler", http.StatusInternalServerError, err)
 	}
 
@@ -27,7 +26,7 @@ func ExternalIdHandler(ctx context.Context, pluginCtx backend.PluginContext, req
 	}
 	jsonResponse, err := json.Marshal(response)
 	if err != nil {
-		logger.Error("error in ExternalIdHandler when marshalling response", "error", err)
+		reqCtx.Logger.Error("error in ExternalIdHandler when marshalling response", "error", err)
 		return nil, models.NewHttpError("error in ExternalIdHandler", http.StatusInternalServerError, err)
 	}
 

--- a/pkg/tsdb/cloudwatch/routes/external_id.go
+++ b/pkg/tsdb/cloudwatch/routes/external_id.go
@@ -15,8 +15,10 @@ type ExternalIdResponse struct {
 }
 
 func ExternalIdHandler(ctx context.Context, pluginCtx backend.PluginContext, reqCtxFactory models.RequestContextFactoryFunc, parameters url.Values) ([]byte, *models.HttpError) {
-	reqCtx, err := reqCtxFactory(ctx, pluginCtx, "default")
+	logger := backend.Logger.FromContext(ctx)
+	reqCtx, err := reqCtxFactory(ctx, pluginCtx, "us-east-2")
 	if err != nil {
+		logger.Error("error in ExternalIdHandler when calling reqCtxFactory", "error", err)
 		return nil, models.NewHttpError("error in ExternalIdHandler", http.StatusInternalServerError, err)
 	}
 
@@ -25,6 +27,7 @@ func ExternalIdHandler(ctx context.Context, pluginCtx backend.PluginContext, req
 	}
 	jsonResponse, err := json.Marshal(response)
 	if err != nil {
+		logger.Error("error in ExternalIdHandler when marshalling response", "error", err)
 		return nil, models.NewHttpError("error in ExternalIdHandler", http.StatusInternalServerError, err)
 	}
 


### PR DESCRIPTION
**What is this feature?**

Users were unable to see externalIds for new datasources after we made a change which pulls the externalId off a settings object (which as a side effect creates a new ec2 client to be used later). This factory to get the settings object was failing because we were not passing it a valid region and we were not passing it a valid auth type (it defaults to `Default`, which is not a valid auth type in grafana cloud)

**Which issue(s) does this PR fix?**:
Fixes https://github.com/grafana/grafana/issues/84229

**Special notes for your reviewer:**
To reproduce bug locally:
- In grafana.ini:
```
[aws]
allowed_auth_providers = keys,grafana_assume_role
external_id = 'anystring'
```
- create a new cloudwatch datasource
- select grafana assume role
- note you can not see the external id and instead see error in network tab



Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
