### PR TITLE
Transformations: Fix series to rows to work with only one series

### DIFF
--- a/packages/grafana-data/src/transformations/transformers/seriesToRows.test.ts
+++ b/packages/grafana-data/src/transformations/transformers/seriesToRows.test.ts
@@ -11,6 +11,33 @@ describe('Series to rows', () => {
     mockTransformationsRegistry([seriesToRowsTransformer]);
   });
 
+  it('should do transform even with only one series', async () => {
+    const cfg: DataTransformerConfig<SeriesToRowsTransformerOptions> = {
+      id: DataTransformerID.seriesToRows,
+      options: {},
+    };
+
+    const seriesA = toDataFrame({
+      name: 'A',
+      fields: [
+        { name: 'Time', type: FieldType.time, values: [1000] },
+        { name: 'Temp', type: FieldType.number, values: [1] },
+      ],
+    });
+
+    await expect(transformDataFrame([cfg], [seriesA])).toEmitValuesWith((received) => {
+      const result = received[0];
+
+      const expected: Field[] = [
+        createField('Time', FieldType.time, [1000]),
+        createField('Metric', FieldType.string, ['A']),
+        createField('Value', FieldType.number, [1]),
+      ];
+
+      expect(unwrap(result[0].fields)).toEqual(expected);
+    });
+  });
+
   it('combine two series into one', async () => {
     const cfg: DataTransformerConfig<SeriesToRowsTransformerOptions> = {
       id: DataTransformerID.seriesToRows,

--- a/packages/grafana-data/src/transformations/transformers/seriesToRows.ts
+++ b/packages/grafana-data/src/transformations/transformers/seriesToRows.ts
@@ -25,7 +25,7 @@ export const seriesToRowsTransformer: DataTransformerInfo<SeriesToRowsTransforme
   operator: (options) => (source) =>
     source.pipe(
       map((data) => {
-        if (!Array.isArray(data) || data.length <= 1) {
+        if (!Array.isArray(data) || data.length === 0) {
           return data;
         }
 


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

The series to rows transformation is entirely skipped when it only receives one timeseries. This is a problem for the subsequent transformations, because those can't work with both formats (no transformation done - metric and value separated). This commit attempts to fix this issue.


**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #83468

Please check that:
- [X] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
