### PR TITLE
Transforms: Fix field matching in Format time, and add tpl var interpolation

### DIFF
--- a/packages/grafana-data/src/transformations/transformers/formatTime.test.ts
+++ b/packages/grafana-data/src/transformations/transformers/formatTime.test.ts
@@ -2,7 +2,7 @@ import { toDataFrame } from '../../dataframe/processDataFrame';
 import { FieldType } from '../../types/dataFrame';
 import { mockTransformationsRegistry } from '../../utils/tests/mockTransformationsRegistry';
 
-import { createTimeFormatter, formatTimeTransformer } from './formatTime';
+import { applyFormatTime, formatTimeTransformer } from './formatTime';
 
 describe('Format Time Transformer', () => {
   beforeAll(() => {
@@ -16,7 +16,6 @@ describe('Format Time Transformer', () => {
       timezone: 'utc',
     };
 
-    const formatter = createTimeFormatter(options.timeField, options.outputFormat, options.timezone);
     const frame = toDataFrame({
       fields: [
         {
@@ -27,8 +26,32 @@ describe('Format Time Transformer', () => {
       ],
     });
 
-    const newFrame = formatter(frame.fields);
-    expect(newFrame[0].values).toEqual(['2021-02', '2023-07', '2023-04', '2023-07', '2023-08']);
+    const newFrames = applyFormatTime(options, [frame]);
+    expect(newFrames[0].fields[0].values).toEqual(['2021-02', '2023-07', '2023-04', '2023-07', '2023-08']);
+  });
+
+  it('will match on getFieldDisplayName', () => {
+    const options = {
+      timeField: 'Created',
+      outputFormat: 'YYYY-MM',
+      timezone: 'utc',
+    };
+
+    const frame = toDataFrame({
+      fields: [
+        {
+          name: 'created',
+          type: FieldType.time,
+          values: [1612939600000, 1689192000000, 1682025600000, 1690328089000, 1691011200000],
+          config: {
+            displayName: 'Created',
+          },
+        },
+      ],
+    });
+
+    const newFrames = applyFormatTime(options, [frame]);
+    expect(newFrames[0].fields[0].values).toEqual(['2021-02', '2023-07', '2023-04', '2023-07', '2023-08']);
   });
 
   it('will handle formats with times', () => {
@@ -38,7 +61,6 @@ describe('Format Time Transformer', () => {
       timezone: 'utc',
     };
 
-    const formatter = createTimeFormatter(options.timeField, options.outputFormat, options.timezone);
     const frame = toDataFrame({
       fields: [
         {
@@ -49,8 +71,8 @@ describe('Format Time Transformer', () => {
       ],
     });
 
-    const newFrame = formatter(frame.fields);
-    expect(newFrame[0].values).toEqual([
+    const newFrames = applyFormatTime(options, [frame]);
+    expect(newFrames[0].fields[0].values).toEqual([
       '2021-02 6:46:40 am',
       '2023-07 8:00:00 pm',
       '2023-04 9:20:00 pm',
@@ -66,7 +88,6 @@ describe('Format Time Transformer', () => {
       timezone: 'utc',
     };
 
-    const formatter = createTimeFormatter(options.timeField, options.outputFormat, options.timezone);
     const frame = toDataFrame({
       fields: [
         {
@@ -77,8 +98,8 @@ describe('Format Time Transformer', () => {
       ],
     });
 
-    const newFrame = formatter(frame.fields);
-    expect(newFrame[0].values).toEqual([
+    const newFrames = applyFormatTime(options, [frame]);
+    expect(newFrames[0].fields[0].values).toEqual([
       '2021-02 6:46:40 am',
       '2023-07 8:00:00 pm',
       '2023-04 9:20:00 pm',

--- a/packages/grafana-data/src/transformations/transformers/formatTime.ts
+++ b/packages/grafana-data/src/transformations/transformers/formatTime.ts
@@ -2,7 +2,8 @@ import { map } from 'rxjs/operators';
 
 import { TimeZone } from '@grafana/schema';
 
-import { DataFrame, Field, TransformationApplicabilityLevels } from '../../types';
+import { cacheFieldDisplayNames } from '../../field';
+import { DataFrame, TransformationApplicabilityLevels } from '../../types';
 import { DataTransformerInfo } from '../../types/transformations';
 
 import { fieldToStringField } from './convertFieldType';
@@ -37,18 +38,7 @@ export const formatTimeTransformer: DataTransformerInfo<FormatTimeTransformerOpt
   operator: (options) => (source) =>
     source.pipe(
       map((data) => {
-        // If a field and a format are configured
-        // then format the time output
-        const formatter = createTimeFormatter(options.timeField, options.outputFormat, options.timezone);
-
-        if (!Array.isArray(data) || data.length === 0) {
-          return data;
-        }
-
-        return data.map((frame) => ({
-          ...frame,
-          fields: formatter(frame.fields),
-        }));
+        return applyFormatTime(options, data);
       })
     ),
 };
@@ -56,21 +46,24 @@ export const formatTimeTransformer: DataTransformerInfo<FormatTimeTransformerOpt
 /**
  * @internal
  */
-export const createTimeFormatter = (timeField: string, outputFormat: string, timezone: string) => (fields: Field[]) => {
-  return fields.map((field) => {
-    // Find the configured field
-    if (field.name === timeField) {
-      // Update values to use the configured format
-      let formattedField = null;
-      if (timezone) {
-        formattedField = fieldToStringField(field, outputFormat, { timeZone: timezone });
-      } else {
-        formattedField = fieldToStringField(field, outputFormat);
+export const applyFormatTime = (
+  { timeField, outputFormat, timezone }: FormatTimeTransformerOptions,
+  data: DataFrame[]
+) => {
+  if (!Array.isArray(data) || data.length === 0) {
+    return data;
+  }
+
+  cacheFieldDisplayNames(data);
+
+  return data.map((frame) => ({
+    ...frame,
+    fields: frame.fields.map((field) => {
+      if (field.state?.displayName === timeField) {
+        field = fieldToStringField(field, outputFormat, { timeZone: timezone });
       }
 
-      return formattedField;
-    }
-
-    return field;
-  });
+      return field;
+    }),
+  }));
 };


### PR DESCRIPTION
previously, this transformer was displaying field names returned by `getFieldDisplayName()` but matching them using `field.name`, so they would not always match. this switches to using `getFieldDisplayName()` in both the editor and the matcher. also added a test.

also, it simplifies the transformer a bit and updates the test to account for the above logic.

additionally, it adds template variable interpolation for `outputFormat` so that subsequent "group by" transforms relying on the formatted field can be changed ad-hoc (part of the bigger epic: https://github.com/grafana/grafana/issues/25469)

this dashboard shows both the field matching fix and the interpolation:

<details><summary>formatTime-test.json</summary>

```json
{
  "annotations": {
    "list": [
      {
        "builtIn": 1,
        "datasource": {
          "type": "grafana",
          "uid": "-- Grafana --"
        },
        "enable": true,
        "hide": true,
        "iconColor": "rgba(0, 211, 255, 1)",
        "name": "Annotations & Alerts",
        "type": "dashboard"
      }
    ]
  },
  "editable": true,
  "fiscalYearStartMonth": 0,
  "graphTooltip": 0,
  "id": 998,
  "links": [],
  "panels": [
    {
      "datasource": {
        "type": "grafana-testdata-datasource",
        "uid": "PD8C576611E62080A"
      },
      "description": "",
      "fieldConfig": {
        "defaults": {
          "color": {
            "mode": "thresholds"
          },
          "custom": {
            "align": "auto",
            "cellOptions": {
              "type": "auto"
            },
            "inspect": false
          },
          "mappings": [],
          "thresholds": {
            "mode": "absolute",
            "steps": [
              {
                "color": "green",
                "value": null
              },
              {
                "color": "red",
                "value": 80
              }
            ]
          }
        },
        "overrides": []
      },
      "gridPos": {
        "h": 13,
        "w": 15,
        "x": 0,
        "y": 0
      },
      "id": 2,
      "options": {
        "cellHeight": "sm",
        "footer": {
          "countRows": false,
          "fields": "",
          "reducer": [
            "sum"
          ],
          "show": false
        },
        "showHeader": true
      },
      "pluginVersion": "11.0.0-pre",
      "targets": [
        {
          "datasource": {
            "type": "grafana-testdata-datasource",
            "uid": "PD8C576611E62080A"
          },
          "rawFrameContent": "[\n  {\n    \"schema\": {\n      \"refId\": \"Created\",\n      \"name\": \"issues\",\n      \"fields\": [\n        {\n          \"config\": {\n            \"displayName\": \"Key\"\n          },\n          \"labels\": {},\n          \"name\": \"key\",\n          \"type\": \"string\",\n          \"typeInfo\": {\n            \"frame\": \"string\",\n            \"nullable\": true\n          }\n        },\n        {\n          \"config\": {\n            \"displayName\": \"Created\"\n          },\n          \"labels\": {},\n          \"name\": \"created\",\n          \"type\": \"time\",\n          \"typeInfo\": {\n            \"frame\": \"time.Time\",\n            \"nullable\": true\n          }\n        }\n      ]\n    },\n    \"data\": {\n      \"values\": [\n        [\n          \"SF-1863\",\n          \"SF-1862\",\n          \"SF-1861\",\n          \"SF-1860\",\n          \"SF-1859\",\n          \"SF-1858\",\n          \"SF-1857\",\n          \"SF-1856\",\n          \"SF-1855\",\n          \"SF-1854\",\n          \"SF-1853\",\n          \"SF-1852\",\n          \"SF-1851\",\n          \"PTO-100\",\n          \"PTO-99\",\n          \"PS0029205-2\",\n          \"PS0026870-3\",\n          \"PS0026128-4\",\n          \"PS0025876-6\",\n          \"PS0025876-5\",\n          \"PS0025816-57\",\n          \"PS0025816-56\",\n          \"PS0025816-55\",\n          \"PS0025816-54\",\n          \"PS0025816-53\",\n          \"PS0025816-52\",\n          \"PS0024868-19\",\n          \"PS0024868-18\",\n          \"PS0023884-12\",\n          \"PS0023285-66\",\n          \"PS0022125-20\",\n          \"PS0020328-22\",\n          \"PS0020328-21\",\n          \"PS0018547-1\",\n          \"PS0018228-9\",\n          \"PS0018228-8\",\n          \"PS0016942-15\",\n          \"PS0016073-7\",\n          \"PS0011493-1\",\n          \"PS0009616-235\",\n          \"PS0005363-76\",\n          \"PS-8527\",\n          \"PS-8526\",\n          \"PS-8525\",\n          \"PS-8524\",\n          \"PS-8523\",\n          \"PS-8522\",\n          \"PS-8521\",\n          \"PS-8520\",\n          \"PS-8519\"\n        ],\n        [\n          1710177503710,\n          1709847191185,\n          1709840600792,\n          1709838120074,\n          1709836188764,\n          1709831316057,\n          1709761210192,\n          1709748960206,\n          1709740011528,\n          1709673236933,\n          1709672638016,\n          1709658801490,\n          1709618065051,\n          1709680274897,\n          1710195308883,\n          1709738721958,\n          1709652740992,\n          1709763222739,\n          1709824292784,\n          1709824220715,\n          1710195456846,\n          1709856404989,\n          1709856361641,\n          1709856325124,\n          1709848103773,\n          1709680345741,\n          1709846982308,\n          1709663202938,\n          1709636525756,\n          1709830139043,\n          1710127816144,\n          1710195423087,\n          1709757597091,\n          1710190370271,\n          1709663284954,\n          1709663260637,\n          1709763455433,\n          1710207024533,\n          1709781191294,\n          1709710333084,\n          1709836416655,\n          1710195544641,\n          1710188949035,\n          1710188860003,\n          1710188830916,\n          1710188781453,\n          1710188771454,\n          1710188692100,\n          1710188649941,\n          1709856465542\n        ]\n      ]\n    }\n  }\n]",
          "refId": "A",
          "scenarioId": "raw_frame"
        }
      ],
      "title": "Reproduced with embedded data",
      "transformations": [
        {
          "id": "formatTime",
          "options": {
            "outputFormat": "${format}",
            "timeField": "Created",
            "timezone": "",
            "useTimezone": true
          }
        },
        {
          "id": "groupBy",
          "options": {
            "fields": {
              "Created": {
                "aggregations": [],
                "operation": "groupby"
              },
              "Key": {
                "aggregations": [
                  "count"
                ],
                "operation": "aggregate"
              }
            }
          }
        }
      ],
      "type": "table"
    }
  ],
  "schemaVersion": 39,
  "tags": [
    "debug",
    "debug-timeseries"
  ],
  "templating": {
    "list": [
      {
        "current": {
          "selected": false,
          "text": "YYYY",
          "value": "YYYY"
        },
        "hide": 0,
        "includeAll": false,
        "multi": false,
        "name": "format",
        "options": [
          {
            "selected": true,
            "text": "YYYY",
            "value": "YYYY"
          },
          {
            "selected": false,
            "text": "YYYY-MM",
            "value": "YYYY-MM"
          },
          {
            "selected": false,
            "text": "YYYY-MM-DD",
            "value": "YYYY-MM-DD"
          },
          {
            "selected": false,
            "text": "YYYY-WW",
            "value": "YYYY-WW"
          }
        ],
        "query": "YYYY,YYYY-MM,YYYY-MM-DD,YYYY-WW",
        "queryValue": "",
        "skipUrlSync": false,
        "type": "custom"
      }
    ]
  },
  "time": {
    "from": "now-6h",
    "to": "now"
  },
  "timeRangeUpdatedDuringEditOrView": false,
  "timepicker": {},
  "timezone": "",
  "title": "formatTime-test",
  "uid": "bdfem2zo24n40a",
  "version": 9,
  "weekStart": ""
}
```
</details>