### PR TITLE
Playlists: Fix kiosk mode not activating when starting a playlist

### DIFF
--- a/public/app/core/components/AppChrome/AppChrome.tsx
+++ b/public/app/core/components/AppChrome/AppChrome.tsx
@@ -3,7 +3,7 @@ import classNames from 'classnames';
 import React, { PropsWithChildren, useEffect } from 'react';
 
 import { GrafanaTheme2 } from '@grafana/data';
-import { locationService } from '@grafana/runtime';
+import { locationSearchToObject, locationService } from '@grafana/runtime';
 import { useStyles2, LinkButton, useTheme2 } from '@grafana/ui';
 import config from 'app/core/config';
 import { useGrafana } from 'app/core/context/GrafanaContext';
@@ -66,6 +66,12 @@ export function AppChrome({ children }: Props) {
     // We only want to pay attention when the location changes
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [chrome, url]);
+
+  // Sync updates from kiosk mode query string back into app chrome
+  useEffect(() => {
+    const queryParams = locationSearchToObject(search);
+    chrome.setKioskModeFromUrl(queryParams.kiosk);
+  }, [chrome, search]);
 
   // Chromeless routes are without topNav, mega menu, search & command palette
   // We check chromeless twice here instead of having a separate path so {children}

--- a/public/app/core/components/AppChrome/AppChromeService.tsx
+++ b/public/app/core/components/AppChrome/AppChromeService.tsx
@@ -64,6 +64,10 @@ export class AppChromeService {
   }
 
   public update(update: Partial<AppChromeState>) {
+    if (update.kioskMode !== undefined) {
+      // debugger;
+    }
+
     const current = this.state.getValue();
     const newState: AppChromeState = {
       ...current,
@@ -191,13 +195,19 @@ export class AppChromeService {
   }
 
   public setKioskModeFromUrl(kiosk: UrlQueryValue) {
+    let newKioskMode: KioskMode | undefined;
+
     switch (kiosk) {
       case 'tv':
-        this.update({ kioskMode: KioskMode.TV });
+        newKioskMode = KioskMode.TV;
         break;
       case '1':
       case true:
-        this.update({ kioskMode: KioskMode.Full });
+        newKioskMode = KioskMode.Full;
+    }
+
+    if (newKioskMode && newKioskMode !== this.state.getValue().kioskMode) {
+      this.update({ kioskMode: newKioskMode });
     }
   }
 

--- a/public/app/core/components/AppChrome/AppChromeService.tsx
+++ b/public/app/core/components/AppChrome/AppChromeService.tsx
@@ -64,10 +64,6 @@ export class AppChromeService {
   }
 
   public update(update: Partial<AppChromeState>) {
-    if (update.kioskMode !== undefined) {
-      // debugger;
-    }
-
     const current = this.state.getValue();
     const newState: AppChromeState = {
       ...current,


### PR DESCRIPTION
When starting a playlist from the UI in Kiosk mode, the Playlists page navigates to the dashboard with `kiosk` in the query string, however it would not take affect until reloading the page.

This is because app.ts sets kiosk mode based on the query string on initial app start only, and doesn't react to changes in it 

https://github.com/grafana/grafana/blob/cb8fe527f648dcd7a7fe95b210b5350d478e7c40/public/app/app.ts#L239-L240


This PR adds an effect watching for the change in the query string in AppChrome. I'm not really sure if this is the best place for it, but I couldn't think of anywhere better :/