### PR TITLE
Add script that notifies contributors that they have modified a generated file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -657,6 +657,7 @@ embed.go @grafana/grafana-as-code
 /.github/workflows/detect-breaking-changes-* @grafana/plugins-platform-frontend
 /.github/workflows/doc-validator.yml @grafana/docs-tooling
 /.github/workflows/epic-add-to-platform-ux-parent-project.yml @meanmina
+/.github/workflows/feature-toggles-documentation-manually-modified.yml @grafana/grafana-operator-experience-squad
 /.github/workflows/github-release.yml @grafana/grafana-release-guild
 /.github/workflows/issue-labeled.yml @armandgrillet
 /.github/workflows/issue-opened.yml @grafana/grafana-community-support

--- a/.github/workflows/feature-toggles-documentation-manually-modified.yml
+++ b/.github/workflows/feature-toggles-documentation-manually-modified.yml
@@ -1,0 +1,35 @@
+name: Comment that the modified features toggles file shouldn't be edited manually.
+on:
+  pull_request:
+    branches:
+      - main
+    paths:
+      - docs/sources/setup-grafana/configure-grafana/feature-toggles/index.md
+jobs:
+  comment:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/github-script@v7
+        with:
+          script: |
+            const hiddenPrefix = "<!-- MODIFIED FEATURE TOGGLES MESSAGE -->"
+            const hiddenPrefixRegExp = new RegExp(`^${hiddenPrefix}`;
+            const {data: comments} = await github.rest.issues.listComments({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+            });
+
+            if (!comments.some((comment) => comment.body.match(hiddenPrefixRegExp)))) {
+              github.rest.issues.createComment({
+                issue_number: context.issue.number,
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                body: `${hiddenPrefix}
+            Thank you for your contribution!
+
+            Unfortunately, the 'docs/sources/setup-grafana/configure-grafana/feature-toggles/index.md' file you have modified is auto-generated.
+
+            To make your intended changes, you instead need to modify https://github.com/grafana/grafana/blob/main/pkg/services/featuremgmt/registry.go and follow the instructions there to regenerate the documentation and other feature toggles files.`,
+              })
+            }


### PR DESCRIPTION
Note that this still needs a conditional to make the comment only if the feature-toggles file is out of sync.

Note also that in https://raintank-corp.slack.com/archives/C03E2AQKU2W/p1710240867957259, people are against comment noise so fixing the CI triggers is probably preferred.

Fixes the situation that arises when a PR like https://github.com/grafana/grafana/pull/84190 is opened which subsequently causes https://github.com/grafana/grafana/blob/59fed9278b0b3c5847ae16dcaff1484cefb6a8b9/pkg/services/featuremgmt/toggles_gen_test.go#L156 to fail.

Tagging Grafana Operator Experience Squad because they own the registry file that is the source of the generated documentation.