### PR TITLE
Cascader: Don't lose input value when typing

### DIFF
--- a/packages/grafana-ui/src/components/Cascader/Cascader.tsx
+++ b/packages/grafana-ui/src/components/Cascader/Cascader.tsx
@@ -46,6 +46,7 @@ interface CascaderState {
   //Array for cascade navigation
   rcValue: SelectableValue<string[]>;
   activeLabel: string;
+  inputValue: string;
 }
 
 export interface CascaderOption {
@@ -84,6 +85,7 @@ export class Cascader extends PureComponent<CascaderProps, CascaderState> {
       focusCascade: false,
       rcValue,
       activeLabel,
+      inputValue: '',
     };
   }
 
@@ -141,6 +143,7 @@ export class Cascader extends PureComponent<CascaderProps, CascaderState> {
       focusCascade: true,
       activeLabel,
       isSearching: false,
+      inputValue: activeLabel,
     };
     this.setState(state);
     this.props.onSelect(selectedOptions[selectedOptions.length - 1].value);
@@ -152,6 +155,7 @@ export class Cascader extends PureComponent<CascaderProps, CascaderState> {
     const activeLabel = this.props.displayAllSelectedLevels ? obj.label : obj.singleLabel || '';
     const state: CascaderState = {
       activeLabel: activeLabel,
+      inputValue: activeLabel,
       rcValue: { value: valueArray, label: activeLabel },
       isSearching: false,
       focusCascade: false,
@@ -163,6 +167,7 @@ export class Cascader extends PureComponent<CascaderProps, CascaderState> {
   onCreateOption = (value: string) => {
     this.setState({
       activeLabel: value,
+      inputValue: value,
       rcValue: [],
       isSearching: false,
     });
@@ -192,26 +197,26 @@ export class Cascader extends PureComponent<CascaderProps, CascaderState> {
   };
 
   onInputKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
-    if (['ArrowDown', 'ArrowUp', 'Enter', 'ArrowLeft', 'ArrowRight', 'Backspace'].includes(e.key)) {
+    if (['ArrowDown', 'ArrowUp', 'Enter', 'ArrowLeft', 'ArrowRight'].includes(e.key)) {
       return;
     }
+    const { activeLabel } = this.state;
     this.setState({
       focusCascade: false,
       isSearching: true,
+      inputValue: activeLabel,
     });
   };
 
   onSelectInputChange = (value: string) => {
-    if (value === '') {
-      this.setState({
-        isSearching: false,
-      });
-    }
+    this.setState({
+      inputValue: value,
+    });
   };
 
   render() {
     const { allowCustomValue, formatCreateLabel, placeholder, width, changeOnSelect, options, disabled } = this.props;
-    const { focusCascade, isSearching, rcValue, activeLabel } = this.state;
+    const { focusCascade, isSearching, rcValue, activeLabel, inputValue } = this.state;
 
     const searchableOptions = this.getSearchableOptions(options);
 
@@ -230,6 +235,7 @@ export class Cascader extends PureComponent<CascaderProps, CascaderState> {
             width={width}
             onInputChange={this.onSelectInputChange}
             disabled={disabled}
+            inputValue={inputValue}
           />
         ) : (
           <RCCascader


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

Currently when you type on the Cascader input after something has been selected, it deletes your selection. For instance if you use "suffix:unit1" and want to change it to "suffix:unit2" you have to retype it all instead of it allowing you to make a simple change from "1" to "2".

Comment explaining what is happening on the original issue:
> What happens is that when you open the Cascader, it renders the rc-cascader component, but as you start typing something it switches it to a regular Select and just loses what was on the input.

> I've tried to fix this quickly by having the Select input being controlled, but that makes some parts of this interaction not ideal, for instance selecting the whole input and then typing doesn't replace the whole content, just adds what you typed to the end, so I'd like to get some input on if this is a good solution or not before moving ahead with the fix

**Why do we need this feature?**

To make it simpler to type a different value on the Cascader.

**Who is this feature for?**

Anyone who use cascader.

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #82896

**Special notes for your reviewer:**
I will like for someone to have a double check at this to see if this makes sense at all or if introducing this causes more issues than it solves things.

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
