### PR TITLE
Postgres/Mysql/Mssql: Handle no-rows results correctly

### DIFF
--- a/pkg/tsdb/grafana-postgresql-datasource/postgres_test.go
+++ b/pkg/tsdb/grafana-postgresql-datasource/postgres_test.go
@@ -1417,8 +1417,7 @@ func TestIntegrationPostgres(t *testing.T) {
 			frames := queryResult.Frames
 			require.Len(t, frames, 1)
 			require.Equal(t, 0, frames[0].Rows())
-			require.NotNil(t, frames[0].Fields)
-			require.Empty(t, frames[0].Fields)
+			require.Len(t, frames[0].Fields, 2)
 		})
 	})
 }

--- a/pkg/tsdb/grafana-postgresql-datasource/testdata/table/no_rows.golden.jsonc
+++ b/pkg/tsdb/grafana-postgresql-datasource/testdata/table/no_rows.golden.jsonc
@@ -8,9 +8,13 @@
 //      "executedQueryString": "SELECT * FROM tbl WHERE false"
 //  }
 //  Name: 
-//  Dimensions: 0 Fields by 0 Rows
-//  +
-//  +
+//  Dimensions: 3 Fields by 0 Rows
+//  +--------------------+------------------+-----------------+
+//  | Name: time         | Name: v          | Name: c         |
+//  | Labels:            | Labels:          | Labels:         |
+//  | Type: []*time.Time | Type: []*float64 | Type: []*string |
+//  +--------------------+------------------+-----------------+
+//  +--------------------+------------------+-----------------+
 //  
 //  
 //  🌟 This was machine generated.  Do not edit. 🌟
@@ -26,10 +30,39 @@
           ],
           "executedQueryString": "SELECT * FROM tbl WHERE false"
         },
-        "fields": []
+        "fields": [
+          {
+            "name": "time",
+            "type": "time",
+            "typeInfo": {
+              "frame": "time.Time",
+              "nullable": true
+            }
+          },
+          {
+            "name": "v",
+            "type": "number",
+            "typeInfo": {
+              "frame": "float64",
+              "nullable": true
+            }
+          },
+          {
+            "name": "c",
+            "type": "string",
+            "typeInfo": {
+              "frame": "string",
+              "nullable": true
+            }
+          }
+        ]
       },
       "data": {
-        "values": []
+        "values": [
+          [],
+          [],
+          []
+        ]
       }
     }
   ]

--- a/pkg/tsdb/grafana-postgresql-datasource/testdata/time_series/no_rows_wide.golden.jsonc
+++ b/pkg/tsdb/grafana-postgresql-datasource/testdata/time_series/no_rows_wide.golden.jsonc
@@ -8,9 +8,13 @@
 //      "executedQueryString": "SELECT * FROM tbl WHERE false"
 //  }
 //  Name: 
-//  Dimensions: 0 Fields by 0 Rows
-//  +
-//  +
+//  Dimensions: 3 Fields by 0 Rows
+//  +--------------------+------------------+------------------+
+//  | Name: Time         | Name: v1         | Name: v2         |
+//  | Labels:            | Labels:          | Labels:          |
+//  | Type: []*time.Time | Type: []*float64 | Type: []*float64 |
+//  +--------------------+------------------+------------------+
+//  +--------------------+------------------+------------------+
 //  
 //  
 //  🌟 This was machine generated.  Do not edit. 🌟
@@ -26,10 +30,39 @@
           ],
           "executedQueryString": "SELECT * FROM tbl WHERE false"
         },
-        "fields": []
+        "fields": [
+          {
+            "name": "Time",
+            "type": "time",
+            "typeInfo": {
+              "frame": "time.Time",
+              "nullable": true
+            }
+          },
+          {
+            "name": "v1",
+            "type": "number",
+            "typeInfo": {
+              "frame": "float64",
+              "nullable": true
+            }
+          },
+          {
+            "name": "v2",
+            "type": "number",
+            "typeInfo": {
+              "frame": "float64",
+              "nullable": true
+            }
+          }
+        ]
       },
       "data": {
-        "values": []
+        "values": [
+          [],
+          [],
+          []
+        ]
       }
     }
   ]

--- a/pkg/tsdb/mysql/mysql_test.go
+++ b/pkg/tsdb/mysql/mysql_test.go
@@ -1274,8 +1274,7 @@ func TestIntegrationMySQL(t *testing.T) {
 			frames := queryResult.Frames
 			require.Len(t, frames, 1)
 			require.Equal(t, 0, frames[0].Rows())
-			require.NotNil(t, frames[0].Fields)
-			require.Empty(t, frames[0].Fields)
+			require.Len(t, frames[0].Fields, 2)
 		})
 	})
 }


### PR DESCRIPTION
NOTE: this PR improves the current situation, but it is also a breaking change. we will have to decide if we want to do this or not.

(fixes https://github.com/grafana/grafana/issues/82306)

when an sql query returns zero rows (for example `SELECT * FROM table1 WHERE false`), the current behavior is to return a single dataframe, that has no fields.

this PR adjusts this so that:
- it keeps the current behavior for the situation where the following two are both true:
    - format=time series
    - frame is a "long"  frame ( https://grafana.com/developers/plugin-tools/introduction/data-frames#long-format )
- in other situations it keeps the fields, which will have no values in them

the idea is to have the dataframe the same shape both in no-rows and has-rows situations.
(the long-frame in timeseries-format is complicated. in that case we convert the frame to a wide-frame, so we change it's shape. but with zero-rows it's not possible to do the transformation, so we don't know how many fields the frame would have if has-rows).

context:
- before `9.4.0` we did not modify the frame at all when it had zero rows.
- in `9.4.0` we changed it with this PR: https://github.com/grafana/grafana/pull/59121 . we were fixing a bug with it. after this change, we returned no dataframes at all, in the zero-rows situation.
- in `10.0.0` we changed it again with this PR: https://github.com/grafana/grafana/pull/67844 . we were fixing a bug with it. after this change, we returned a single dataframe, with all the metadata, but no fields.

( additional internal dicussion at https://raintank-corp.slack.com/archives/C02P3H4118V/p1709554119716519 )


how to test:
- go through the 2 change-PRs mentioned above. find the bug-reports that they were fixing, and try those again. are they ok now, are they not? also check any related-issues that appear in those 2 change-PRs.
- potential issues:
    - in the past it seems alerting had problems with this format (fields exist, but have no values in them), and a fix was proposed for alerting ( https://github.com/grafana/grafana/pull/55683 ) but it was not merged, because we changed the sql behavior.. we'll need to doublecheck if that stuff works now.

# Release notice breaking change

When using the Postgres, MySQL and MsSQL datasources, the way we represent the result of a query that returns no rows has changed slightly. Previously such a response contained no fields, now it contains all the fields from the database, but those fields contain no values. If you are using transforms that rely on the structure of the data in such a case, please doublecheck them. 