### PR TITLE
Plugins: Add reportInteraction into plugin search

### DIFF
--- a/public/app/features/plugins/admin/components/PluginListItem.tsx
+++ b/public/app/features/plugins/admin/components/PluginListItem.tsx
@@ -3,6 +3,7 @@ import React from 'react';
 import Skeleton from 'react-loading-skeleton';
 
 import { GrafanaTheme2 } from '@grafana/data';
+import { locationService, reportInteraction } from '@grafana/runtime';
 import { Badge, Icon, Stack, useStyles2 } from '@grafana/ui';
 import { SkeletonComponent, attachSkeleton } from '@grafana/ui/src/unstable';
 
@@ -23,8 +24,17 @@ function PluginListItemComponent({ plugin, pathName, displayMode = PluginListDis
   const styles = useStyles2(getStyles);
   const isList = displayMode === PluginListDisplayMode.List;
 
+  const reportUserClickInteraction = () => {
+    if (locationService.getSearchObject()?.q) {
+      reportInteraction('plugins_search_user_click', {});
+    }
+  };
   return (
-    <a href={`${pathName}/${plugin.id}`} className={cx(styles.container, { [styles.list]: isList })}>
+    <a
+      href={`${pathName}/${plugin.id}`}
+      className={cx(styles.container, { [styles.list]: isList })}
+      onClick={reportUserClickInteraction}
+    >
       <PluginLogo src={plugin.info.logos.small} className={styles.pluginLogo} height={LOGO_SIZE} alt="" />
       <h2 className={cx(styles.name, 'plugin-name')}>{plugin.name}</h2>
       <div className={cx(styles.content, 'plugin-content')}>

--- a/public/app/features/plugins/admin/state/selectors.ts
+++ b/public/app/features/plugins/admin/state/selectors.ts
@@ -1,6 +1,7 @@
 import { createSelector } from '@reduxjs/toolkit';
 
 import { PluginError, PluginType, unEscapeStringFromRegex } from '@grafana/data';
+import { reportInteraction } from '@grafana/runtime';
 
 import { filterByKeyword } from '../helpers';
 import { RequestStatus, PluginCatalogStoreState } from '../types';
@@ -35,6 +36,9 @@ export const selectPlugins = (filters: PluginFilters) =>
     const keyword = filters.keyword ? unEscapeStringFromRegex(filters.keyword.toLowerCase()) : '';
     const filteredPluginIds = keyword !== '' ? filterByKeyword(plugins, keyword) : null;
 
+    if (keyword) {
+      reportInteraction('plugins_search', { resultsCount: filteredPluginIds?.length });
+    }
     return plugins.filter((plugin) => {
       if (keyword && filteredPluginIds == null) {
         return false;


### PR DESCRIPTION
**What is this feature?**
Add reportInteraction to be able to see metrics when user performs the search: how many results are there and if after that user clicks on found plugin

**Which issue(s) does this PR fix?**:
Fixes #83887