### PR TITLE
docs: rewrite grafana-com oauth to better align with naming conventions

### DIFF
--- a/docs/sources/setup-grafana/configure-security/configure-authentication/_index.md
+++ b/docs/sources/setup-grafana/configure-security/configure-authentication/_index.md
@@ -19,19 +19,19 @@ Grafana provides many ways to authenticate users. Some authentication integratio
 
 The following table shows all supported authentication providers and the features available for them. [Team sync]({{< relref "../configure-team-sync" >}}) and [active sync]({{< relref "./enhanced-ldap#active-ldap-synchronization" >}}) are only available in Grafana Enterprise.
 
-| Provider                                            | Multi Org Mapping | Enforce Sync | Role Mapping | Grafana Admin Mapping | Team Sync | Allowed groups | Active Sync | Skip OrgRole mapping | Auto Login | Single Logout |
-| :-------------------------------------------------- | :---------------- | :----------- | :----------- | :-------------------- | :-------- | :------------- | :---------- | :------------------- | :--------- | :------------ |
-| [Auth Proxy]({{< relref "./auth-proxy" >}})         | no                | yes          | yes          | no                    | yes       | no             | N/A         | no                   | N/A        | N/A           |
-| [Azure AD OAuth]({{< relref "./azuread" >}})        | no                | yes          | yes          | yes                   | yes       | yes            | N/A         | yes                  | yes        | yes           |
-| [Generic OAuth]({{< relref "./generic-oauth" >}})   | no                | yes          | yes          | yes                   | yes       | no             | N/A         | yes                  | yes        | yes           |
-| [GitHub OAuth]({{< relref "./github" >}})           | no                | yes          | yes          | yes                   | yes       | yes            | N/A         | yes                  | yes        | yes           |
-| [GitLab OAuth]({{< relref "./gitlab" >}})           | no                | yes          | yes          | yes                   | yes       | yes            | N/A         | yes                  | yes        | yes           |
-| [Google OAuth]({{< relref "./google" >}})           | no                | no           | no           | no                    | yes       | no             | N/A         | no                   | yes        | yes           |
-| [Grafana.com OAuth]({{< relref "./grafana-com" >}}) | no                | no           | yes          | no                    | N/A       | N/A            | N/A         | yes                  | yes        | yes           |
-| [Okta OAuth]({{< relref "./okta" >}})               | no                | yes          | yes          | yes                   | yes       | yes            | N/A         | yes                  | yes        | yes           |
-| [SAML]({{< relref "./saml" >}}) (Enterprise only)   | yes               | yes          | yes          | yes                   | yes       | yes            | N/A         | yes                  | yes        | yes           |
-| [LDAP]({{< relref "./ldap" >}})                     | yes               | yes          | yes          | yes                   | yes       | yes            | yes         | no                   | N/A        | N/A           |
-| [JWT Proxy]({{< relref "./jwt" >}})                 | no                | yes          | yes          | yes                   | no        | no             | N/A         | no                   | N/A        | N/A           |
+| Provider                                              | Multi Org Mapping | Enforce Sync | Role Mapping | Grafana Admin Mapping | Team Sync | Allowed groups | Active Sync | Skip OrgRole mapping | Auto Login | Single Logout |
+| :---------------------------------------------------- | :---------------- | :----------- | :----------- | :-------------------- | :-------- | :------------- | :---------- | :------------------- | :--------- | :------------ |
+| [Auth Proxy]({{< relref "./auth-proxy" >}})           | no                | yes          | yes          | no                    | yes       | no             | N/A         | no                   | N/A        | N/A           |
+| [Azure AD OAuth]({{< relref "./azuread" >}})          | no                | yes          | yes          | yes                   | yes       | yes            | N/A         | yes                  | yes        | yes           |
+| [Generic OAuth]({{< relref "./generic-oauth" >}})     | no                | yes          | yes          | yes                   | yes       | no             | N/A         | yes                  | yes        | yes           |
+| [GitHub OAuth]({{< relref "./github" >}})             | no                | yes          | yes          | yes                   | yes       | yes            | N/A         | yes                  | yes        | yes           |
+| [GitLab OAuth]({{< relref "./gitlab" >}})             | no                | yes          | yes          | yes                   | yes       | yes            | N/A         | yes                  | yes        | yes           |
+| [Google OAuth]({{< relref "./google" >}})             | no                | no           | no           | no                    | yes       | no             | N/A         | no                   | yes        | yes           |
+| [Grafana.com OAuth]({{< relref "./grafana-cloud" >}}) | no                | no           | yes          | no                    | N/A       | N/A            | N/A         | yes                  | yes        | yes           |
+| [Okta OAuth]({{< relref "./okta" >}})                 | no                | yes          | yes          | yes                   | yes       | yes            | N/A         | yes                  | yes        | yes           |
+| [SAML]({{< relref "./saml" >}}) (Enterprise only)     | yes               | yes          | yes          | yes                   | yes       | yes            | N/A         | yes                  | yes        | yes           |
+| [LDAP]({{< relref "./ldap" >}})                       | yes               | yes          | yes          | yes                   | yes       | yes            | yes         | no                   | N/A        | N/A           |
+| [JWT Proxy]({{< relref "./jwt" >}})                   | no                | yes          | yes          | yes                   | no        | no             | N/A         | no                   | N/A        | N/A           |
 
 N/A = Not applicable
 

--- a/docs/sources/setup-grafana/configure-security/configure-authentication/generic-oauth/index.md
+++ b/docs/sources/setup-grafana/configure-security/configure-authentication/generic-oauth/index.md
@@ -27,7 +27,7 @@ Grafana provides OAuth2 integrations for the following auth providers:
 - [GitHub OAuth]({{< relref "../github" >}})
 - [GitLab OAuth]({{< relref "../gitlab" >}})
 - [Google OAuth]({{< relref "../google" >}})
-- [Grafana Com OAuth]({{< relref "../grafana-com" >}})
+- [Grafana Com OAuth]({{< relref "../grafana-cloud" >}})
 - [Keycloak OAuth]({{< relref "../keycloak" >}})
 - [Okta OAuth]({{< relref "../okta" >}})
 

--- a/docs/sources/setup-grafana/configure-security/configure-authentication/grafana-cloud/index.md
+++ b/docs/sources/setup-grafana/configure-security/configure-authentication/grafana-cloud/index.md
@@ -1,29 +1,29 @@
 ---
 aliases:
-  - ../../../auth/grafana-com/
-description: Grafana Com Authentication
+  - ../../../auth/grafana-cloud/
+description: Grafana Cloud Authentication
 labels:
   products:
     - cloud
-menuTitle: Grafana Com OAuth2
-title: Configure Grafana Com authentication
+menuTitle: Grafana Cloud OAuth2
+title: Configure Grafana Cloud authentication
 weight: 1200
 ---
 
-# Configure Grafana Com authentication
+# Configure Grafana Cloud authentication
 
-To enable GrafanaCom as your authentication provider, you configure it to generate a client ID and a secret key.
+To enable Grafana Cloud as the Identity Provider for a Grafana instance, generate a client ID and client secret and apply the configuration to Grafana.
 
-## Create GrafanaCom OAuth keys
+## Create Grafana Cloud OAuth Client Credentials
 
-To use GrafanaCom authentication:
+To use Grafana Cloud authentication:
 
-1. Log in to [GrafanaCom](/).
+1. Log in to [Grafana Cloud](/).
 1. To create an OAuth client, locate your organization and click **OAuth Clients**.
 1. Click **Add OAuth Client Application**.
 1. Add the name and URL of your running Grafana instance.
 1. Click **Add OAuth Client**.
-1. Copy the client ID and secret key or the configuration that has been generated.
+1. Copy the client ID and client secret or the configuration that has been generated.
 
 The following snippet shows an example configuration:
 
@@ -50,7 +50,7 @@ auto_login = true
 
 ## Skip organization role sync
 
-If a user signs in with their Grafana.com credentials, their assigned org role overrides the role defined in the Grafana instance. To prevent Grafana.com roles from synchronizing, set `skip_org_role_sync` to `true`. This is useful if you want to manage the organization roles for your users from within Grafana.
+If a user signs in with their Grafana Cloud credentials, their assigned org role overrides the role defined in the Grafana instance. To prevent Grafana Cloud roles from synchronizing, set `skip_org_role_sync` to `true`. This is useful if you want to manage the organization roles for your users from within Grafana.
 
 ```ini
 [auth.grafana_com]


### PR DESCRIPTION
This is a small docs update to better align the user-facing naming of Grafana Cloud, instead of the name GrafanaCom. I'm not exactly sure what happens when renaming a file in the docs - are redirects configured automatically? I will confirm this before merging since we don't want to break the old link.