### PR TITLE
Chore: Use mapUtil from grafana-plugin-sdk-go

### DIFF
--- a/pkg/tsdb/azuremonitor/azmoncredentials/builder.go
+++ b/pkg/tsdb/azuremonitor/azmoncredentials/builder.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/grafana/grafana-azure-sdk-go/azcredentials"
 	"github.com/grafana/grafana-azure-sdk-go/azsettings"
-	"github.com/grafana/grafana-azure-sdk-go/util/maputil"
+	"github.com/grafana/grafana-plugin-sdk-go/data/utils/maputil"
 )
 
 func FromDatasourceData(data map[string]interface{}, secureData map[string]string) (azcredentials.AzureCredentials, error) {

--- a/pkg/tsdb/prometheus/azureauth/azure.go
+++ b/pkg/tsdb/prometheus/azureauth/azure.go
@@ -8,9 +8,9 @@ import (
 	"github.com/grafana/grafana-azure-sdk-go/azcredentials"
 	"github.com/grafana/grafana-azure-sdk-go/azhttpclient"
 	"github.com/grafana/grafana-azure-sdk-go/azsettings"
-	"github.com/grafana/grafana-azure-sdk-go/util/maputil"
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
 	sdkhttpclient "github.com/grafana/grafana-plugin-sdk-go/backend/httpclient"
+	"github.com/grafana/grafana-plugin-sdk-go/data/utils/maputil"
 
 	"github.com/grafana/grafana/pkg/promlib/utils"
 )


### PR DESCRIPTION
**What is this feature?**

New version of `grafana-azure-sdk-go` won't have `mapUtils` package. It was moved to `grafana-plugin-sdk-go`. 
Packages that use `mapUtil` should use it from `grafana-plugin-sdk-go`. 