### PR TITLE
Alerting: Fix infinite re-render when linking to alert redirect page

### DIFF
--- a/public/app/features/alerting/unified/hooks/useCombinedRule.ts
+++ b/public/app/features/alerting/unified/hooks/useCombinedRule.ts
@@ -67,7 +67,7 @@ export function useCloudCombinedRulesMatching(
   const { dsFeatures, isLoadingDsFeatures } = useDataSourceFeatures(ruleSourceName);
 
   const {
-    currentData: promRuleNs = [],
+    currentData,
     isLoading: isLoadingPromRules,
     error: promRuleNsError,
   } = alertRuleApi.endpoints.prometheusRuleNamespaces.useQuery({
@@ -87,6 +87,7 @@ export function useCloudCombinedRulesMatching(
     if (promRuleNsError) {
       throw new Error('Unable to obtain Prometheus rules');
     }
+    const promRuleNs = currentData || [];
 
     const rulerGroups: RulerRuleGroupDTO[] = [];
     if (dsFeatures?.rulerConfig) {
@@ -114,7 +115,7 @@ export function useCloudCombinedRulesMatching(
     const rules = namespaces.flatMap((ns) => ns.groups.flatMap((group) => group.rules));
 
     return rules;
-  }, [dsSettings, dsFeatures, isLoadingPromRules, promRuleNsError, promRuleNs, fetchRulerRuleGroup]);
+  }, [dsSettings, dsFeatures, isLoadingPromRules, promRuleNsError, currentData, fetchRulerRuleGroup]);
 
   return { loading: isLoadingDsFeatures || loading, error: error, rules: value };
 }


### PR DESCRIPTION
**What is this feature?**

This is a small fix that fixes when linking to the alert rule redirect from another area of Grafana, it stops the browser window from crashing and works correctly.

**Why do we need this feature?**

When a user navigates to any alert rule redirect for a second time it causes an infinite re-render and locks up the Browser window. It is unable to be recovered and the only solution is to kill the window.

**Who is this feature for?**

All users.

**Which issue(s) does this PR fix?**:

 Un-ticketed.

**Special notes for your reviewer:**

**Before**

https://github.com/grafana/grafana/assets/6906380/967e1c5e-4b15-441e-8390-066bba8e89fd

**After**

https://github.com/grafana/grafana/assets/6906380/d98447fa-a30e-467a-a882-321b83b76b1b


Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
