### PR TITLE
Alerting: move store.ErrAlertRuleGroupNotFound to models package

### DIFF
--- a/pkg/services/ngalert/api/api_provisioning.go
+++ b/pkg/services/ngalert/api/api_provisioning.go
@@ -397,10 +397,7 @@ func (srv *ProvisioningSrv) RouteDeleteAlertRule(c *contextmodel.ReqContext, UID
 func (srv *ProvisioningSrv) RouteGetAlertRuleGroup(c *contextmodel.ReqContext, folder string, group string) response.Response {
 	g, err := srv.alertRules.GetRuleGroup(c.Req.Context(), c.SignedInUser.GetOrgID(), folder, group)
 	if err != nil {
-		if errors.Is(err, store.ErrAlertRuleGroupNotFound) {
-			return ErrResp(http.StatusNotFound, err, "")
-		}
-		return ErrResp(http.StatusInternalServerError, err, "")
+		return response.ErrOrFallback(http.StatusInternalServerError, "", err)
 	}
 	return response.JSON(http.StatusOK, ApiAlertRuleGroupFromAlertRuleGroup(g))
 }
@@ -446,10 +443,7 @@ func (srv *ProvisioningSrv) RouteGetAlertRulesExport(c *contextmodel.ReqContext)
 func (srv *ProvisioningSrv) RouteGetAlertRuleGroupExport(c *contextmodel.ReqContext, folder string, group string) response.Response {
 	g, err := srv.alertRules.GetAlertRuleGroupWithFolderTitle(c.Req.Context(), c.SignedInUser.GetOrgID(), folder, group)
 	if err != nil {
-		if errors.Is(err, store.ErrAlertRuleGroupNotFound) {
-			return ErrResp(http.StatusNotFound, err, "")
-		}
-		return ErrResp(http.StatusInternalServerError, err, "failed to get alert rule group")
+		return response.ErrOrFallback(http.StatusInternalServerError, "failed to get alert rule group", err)
 	}
 
 	e, err := AlertingFileExportFromAlertRuleGroupWithFolderTitle([]alerting_models.AlertRuleGroupWithFolderTitle{g})
@@ -510,10 +504,7 @@ func (srv *ProvisioningSrv) RouteDeleteAlertRuleGroup(c *contextmodel.ReqContext
 	provenance := determineProvenance(c)
 	err := srv.alertRules.DeleteRuleGroup(c.Req.Context(), c.SignedInUser.GetOrgID(), folderUID, group, alerting_models.Provenance(provenance))
 	if err != nil {
-		if errors.Is(err, store.ErrAlertRuleGroupNotFound) {
-			return ErrResp(http.StatusNotFound, err, "")
-		}
-		return ErrResp(http.StatusInternalServerError, err, "")
+		return response.ErrOrFallback(http.StatusInternalServerError, "", err)
 	}
 	return response.JSON(http.StatusNoContent, "")
 }

--- a/pkg/services/ngalert/models/errors.go
+++ b/pkg/services/ngalert/models/errors.go
@@ -8,6 +8,7 @@ var (
 	errAlertRuleConflictMsg  = "conflicting alert rule found [rule_uid: '{{ .Public.RuleUID }}', title: '{{ .Public.Title }}', namespace_uid: '{{ .Public.NamespaceUID }}']: {{ .Public.Error }}"
 	ErrAlertRuleConflictBase = errutil.Conflict("alerting.alert-rule.conflict").
 					MustTemplate(errAlertRuleConflictMsg, errutil.WithPublic(errAlertRuleConflictMsg))
+	ErrAlertRuleGroupNotFound = errutil.NotFound("alerting.alert-rule.notFound")
 )
 
 func ErrAlertRuleConflict(rule AlertRule, underlying error) error {

--- a/pkg/services/ngalert/provisioning/alert_rules.go
+++ b/pkg/services/ngalert/provisioning/alert_rules.go
@@ -134,8 +134,8 @@ func (service *AlertRuleService) CreateAlertRule(ctx context.Context, rule model
 		return models.AlertRule{}, errors.Join(models.ErrAlertRuleFailedValidation, fmt.Errorf("cannot create rule with UID '%s': %w", rule.UID, err))
 	}
 	interval, err := service.ruleStore.GetRuleGroupInterval(ctx, rule.OrgID, rule.NamespaceUID, rule.RuleGroup)
-	// if the alert group does not exists we just use the default interval
-	if err != nil && errors.Is(err, store.ErrAlertRuleGroupNotFound) {
+	// if the alert group does not exist we just use the default interval
+	if err != nil && errors.Is(err, models.ErrAlertRuleGroupNotFound) {
 		interval = service.defaultIntervalSeconds
 	} else if err != nil {
 		return models.AlertRule{}, err
@@ -199,7 +199,7 @@ func (service *AlertRuleService) GetRuleGroup(ctx context.Context, orgID int64, 
 		return models.AlertRuleGroup{}, err
 	}
 	if len(ruleList) == 0 {
-		return models.AlertRuleGroup{}, store.ErrAlertRuleGroupNotFound
+		return models.AlertRuleGroup{}, models.ErrAlertRuleGroupNotFound.Errorf("")
 	}
 	res := models.AlertRuleGroup{
 		Title:     ruleList[0].RuleGroup,
@@ -288,7 +288,7 @@ func (service *AlertRuleService) DeleteRuleGroup(ctx context.Context, orgID int6
 		return err
 	}
 	if len(ruleList) == 0 {
-		return store.ErrAlertRuleGroupNotFound
+		return models.ErrAlertRuleGroupNotFound.Errorf("")
 	}
 
 	// Check provenance for all rules in the group. Fail to delete if any deletions aren't allowed.
@@ -530,7 +530,7 @@ func (service *AlertRuleService) GetAlertRuleGroupWithFolderTitle(ctx context.Co
 		return models.AlertRuleGroupWithFolderTitle{}, err
 	}
 	if len(ruleList) == 0 {
-		return models.AlertRuleGroupWithFolderTitle{}, store.ErrAlertRuleGroupNotFound
+		return models.AlertRuleGroupWithFolderTitle{}, models.ErrAlertRuleGroupNotFound.Errorf("")
 	}
 
 	dq := dashboards.GetDashboardQuery{

--- a/pkg/services/ngalert/store/alert_rule.go
+++ b/pkg/services/ngalert/store/alert_rule.go
@@ -33,8 +33,7 @@ const AlertRuleMaxTitleLength = 190
 const AlertRuleMaxRuleGroupNameLength = 190
 
 var (
-	ErrAlertRuleGroupNotFound = errors.New("rulegroup not found")
-	ErrOptimisticLock         = errors.New("version conflict while updating a record in the database with optimistic locking")
+	ErrOptimisticLock = errors.New("version conflict while updating a record in the database with optimistic locking")
 )
 
 func getAlertRuleByUID(sess *db.Session, alertRuleUID string, orgID int64) (*ngmodels.AlertRule, error) {
@@ -446,7 +445,7 @@ func (st DBstore) GetRuleGroupInterval(ctx context.Context, orgID int64, namespa
 			ngmodels.AlertRule{OrgID: orgID, RuleGroup: ruleGroup, NamespaceUID: namespaceUID},
 		)
 		if len(ruleGroups) == 0 {
-			return ErrAlertRuleGroupNotFound
+			return ngmodels.ErrAlertRuleGroupNotFound.Errorf("")
 		}
 		interval = ruleGroups[0].IntervalSeconds
 		return err


### PR DESCRIPTION
**What is this feature?**
Moves store.ErrAlertRuleGroupNotFound to models.ErrAlertRuleGroupNotFound  and also convert it to errutil

**Why do we need this feature?**
This will let us avoid circular dependencies in future PRs.

**Who is this feature for?**
Developers. Related to https://github.com/grafana/grafana/pull/77007
