### PR TITLE
Popover Menu: fix issue hiding menu behind scrollable container

### DIFF
--- a/public/app/features/explore/Logs/PopoverMenu.tsx
+++ b/public/app/features/explore/Logs/PopoverMenu.tsx
@@ -94,7 +94,7 @@ function track(action: string, selectionLength: number, dataSourceType: string |
 
 const getStyles = (theme: GrafanaTheme2) => ({
   menu: css({
-    position: 'absolute',
+    position: 'fixed',
     zIndex: theme.zIndex.modal,
   }),
 });

--- a/public/app/features/logs/components/LogRows.tsx
+++ b/public/app/features/logs/components/LogRows.tsx
@@ -121,10 +121,9 @@ class UnThemedLogRows extends PureComponent<Props, State> {
     if (!this.logRowsRef.current) {
       return false;
     }
-    const parentBounds = this.logRowsRef.current?.getBoundingClientRect();
     this.setState({
       selection,
-      popoverMenuCoordinates: { x: e.clientX - parentBounds.left, y: e.clientY - parentBounds.top },
+      popoverMenuCoordinates: { x: e.clientX, y: e.clientY },
       selectedRow: row,
     });
     document.addEventListener('click', this.handleDeselection);

--- a/public/app/features/logs/components/LogRows.tsx
+++ b/public/app/features/logs/components/LogRows.tsx
@@ -128,6 +128,7 @@ class UnThemedLogRows extends PureComponent<Props, State> {
     });
     document.addEventListener('click', this.handleDeselection);
     document.addEventListener('contextmenu', this.handleDeselection);
+    document.addEventListener('selectionchange', this.handleDeselection);
     return true;
   };
 
@@ -146,6 +147,7 @@ class UnThemedLogRows extends PureComponent<Props, State> {
   closePopoverMenu = () => {
     document.removeEventListener('click', this.handleDeselection);
     document.removeEventListener('contextmenu', this.handleDeselection);
+    document.removeEventListener('selectionchange', this.handleDeselection);
     this.setState({
       selection: '',
       popoverMenuCoordinates: { x: 0, y: 0 },

--- a/public/app/features/logs/components/LogRows.tsx
+++ b/public/app/features/logs/components/LogRows.tsx
@@ -124,8 +124,8 @@ class UnThemedLogRows extends PureComponent<Props, State> {
 
     const MENU_WIDTH = 270;
     const MENU_HEIGHT = 105;
-    const x = (e.clientX + MENU_WIDTH) > window.innerWidth ? window.innerWidth - MENU_WIDTH : e.clientX;
-    const y = (e.clientY + MENU_HEIGHT) > window.innerHeight ? window.innerHeight - MENU_HEIGHT : e.clientY;
+    const x = e.clientX + MENU_WIDTH > window.innerWidth ? window.innerWidth - MENU_WIDTH : e.clientX;
+    const y = e.clientY + MENU_HEIGHT > window.innerHeight ? window.innerHeight - MENU_HEIGHT : e.clientY;
 
     this.setState({
       selection,

--- a/public/app/features/logs/components/LogRows.tsx
+++ b/public/app/features/logs/components/LogRows.tsx
@@ -121,9 +121,15 @@ class UnThemedLogRows extends PureComponent<Props, State> {
     if (!this.logRowsRef.current) {
       return false;
     }
+
+    const MENU_WIDTH = 270;
+    const MENU_HEIGHT = 105;
+    const x = (e.clientX + MENU_WIDTH) > window.innerWidth ? window.innerWidth - MENU_WIDTH : e.clientX;
+    const y = (e.clientY + MENU_HEIGHT) > window.innerHeight ? window.innerHeight - MENU_HEIGHT : e.clientY;
+
     this.setState({
       selection,
-      popoverMenuCoordinates: { x: e.clientX, y: e.clientY },
+      popoverMenuCoordinates: { x, y },
       selectedRow: row,
     });
     document.addEventListener('click', this.handleDeselection);


### PR DESCRIPTION
This PR fixes an issue that caused the popover menu to be hidden behind the scrollable container.
Additionally, it also fixes an issue where clicking on selected text kept the menu open, identified [here](https://github.com/grafana/grafana/pull/82440#issuecomment-1944042683).

**What is this feature?**

Enhancement/bug fix.

**Which issue(s) does this PR fix?**:

Part of #76129

**Special notes for your reviewer:**

Uploading Demo.mov…


