### PR TITLE
Cloudwatch: Fix issue with Grafana Assume Role

### DIFF
--- a/pkg/tsdb/cloudwatch/cloudwatch.go
+++ b/pkg/tsdb/cloudwatch/cloudwatch.go
@@ -174,8 +174,8 @@ func (e *cloudWatchExecutor) getRequestContext(ctx context.Context, pluginCtx ba
 	}, nil
 }
 
-// useful for resource endpoints that are called before auth has been configured such as external-id
-func (e *cloudWatchExecutor) getRequestContextBeforeAuth(ctx context.Context, pluginCtx backend.PluginContext, _ string) (models.RequestContext, error) {
+// getRequestContextOnlySettings is useful for resource endpoints that are called before auth has been configured such as external-id that need access to settings but nothing else
+func (e *cloudWatchExecutor) getRequestContextOnlySettings(ctx context.Context, pluginCtx backend.PluginContext, _ string) (models.RequestContext, error) {
 	instance, err := e.getInstance(ctx, pluginCtx)
 	if err != nil {
 		return models.RequestContext{}, err

--- a/pkg/tsdb/cloudwatch/cloudwatch.go
+++ b/pkg/tsdb/cloudwatch/cloudwatch.go
@@ -174,6 +174,23 @@ func (e *cloudWatchExecutor) getRequestContext(ctx context.Context, pluginCtx ba
 	}, nil
 }
 
+// useful for resource endpoints that are called before auth has been configured such as external-id
+func (e *cloudWatchExecutor) getRequestContextBeforeAuth(ctx context.Context, pluginCtx backend.PluginContext, _ string) (models.RequestContext, error) {
+	instance, err := e.getInstance(ctx, pluginCtx)
+	if err != nil {
+		return models.RequestContext{}, err
+	}
+
+	return models.RequestContext{
+		OAMAPIProvider:        nil,
+		MetricsClientProvider: nil,
+		LogsAPIProvider:       nil,
+		EC2APIProvider:        nil,
+		Settings:              instance.Settings,
+		Logger:                e.logger.FromContext(ctx),
+	}, nil
+}
+
 func (e *cloudWatchExecutor) CallResource(ctx context.Context, req *backend.CallResourceRequest, sender backend.CallResourceResponseSender) error {
 	ctx = instrumentContext(ctx, "callResource", req.PluginContext)
 	return e.resourceHandler.CallResource(ctx, req, sender)

--- a/pkg/tsdb/cloudwatch/resource_handler.go
+++ b/pkg/tsdb/cloudwatch/resource_handler.go
@@ -25,7 +25,7 @@ func (e *cloudWatchExecutor) newResourceMux() *http.ServeMux {
 	mux.HandleFunc("/accounts", routes.ResourceRequestMiddleware(routes.AccountsHandler, e.logger, e.getRequestContext))
 	mux.HandleFunc("/namespaces", routes.ResourceRequestMiddleware(routes.NamespacesHandler, e.logger, e.getRequestContext))
 	mux.HandleFunc("/log-group-fields", routes.ResourceRequestMiddleware(routes.LogGroupFieldsHandler, e.logger, e.getRequestContext))
-	mux.HandleFunc("/external-id", routes.ResourceRequestMiddleware(routes.ExternalIdHandler, e.logger, e.getRequestContext))
+	mux.HandleFunc("/external-id", routes.ResourceRequestMiddleware(routes.ExternalIdHandler, e.logger, e.getRequestContextBeforeAuth))
 	mux.HandleFunc("/regions", routes.ResourceRequestMiddleware(routes.RegionsHandler, e.logger, e.getRequestContext))
 	// remove this once AWS's Cross Account Observability is supported in GovCloud
 	mux.HandleFunc("/legacy-log-groups", handleResourceReq(e.handleGetLogGroups, e.logger))

--- a/pkg/tsdb/cloudwatch/resource_handler.go
+++ b/pkg/tsdb/cloudwatch/resource_handler.go
@@ -25,7 +25,7 @@ func (e *cloudWatchExecutor) newResourceMux() *http.ServeMux {
 	mux.HandleFunc("/accounts", routes.ResourceRequestMiddleware(routes.AccountsHandler, e.logger, e.getRequestContext))
 	mux.HandleFunc("/namespaces", routes.ResourceRequestMiddleware(routes.NamespacesHandler, e.logger, e.getRequestContext))
 	mux.HandleFunc("/log-group-fields", routes.ResourceRequestMiddleware(routes.LogGroupFieldsHandler, e.logger, e.getRequestContext))
-	mux.HandleFunc("/external-id", routes.ResourceRequestMiddleware(routes.ExternalIdHandler, e.logger, e.getRequestContextBeforeAuth))
+	mux.HandleFunc("/external-id", routes.ResourceRequestMiddleware(routes.ExternalIdHandler, e.logger, e.getRequestContextOnlySettings))
 	mux.HandleFunc("/regions", routes.ResourceRequestMiddleware(routes.RegionsHandler, e.logger, e.getRequestContext))
 	// remove this once AWS's Cross Account Observability is supported in GovCloud
 	mux.HandleFunc("/legacy-log-groups", handleResourceReq(e.handleGetLogGroups, e.logger))

--- a/pkg/tsdb/cloudwatch/routes/external_id.go
+++ b/pkg/tsdb/cloudwatch/routes/external_id.go
@@ -14,8 +14,8 @@ type ExternalIdResponse struct {
 	ExternalId string `json:"externalId"`
 }
 
-func ExternalIdHandler(ctx context.Context, pluginCtx backend.PluginContext, reqCtxFactory models.RequestContextFactoryFunc, parameters url.Values) ([]byte, *models.HttpError) {
-	reqCtx, err := reqCtxFactory(ctx, pluginCtx, "default")
+func ExternalIdHandler(ctx context.Context, pluginCtx backend.PluginContext, reqCtxBeforeAuth models.RequestContextFactoryFunc, parameters url.Values) ([]byte, *models.HttpError) {
+	reqCtx, err := reqCtxBeforeAuth(ctx, pluginCtx, "")
 	if err != nil {
 		return nil, models.NewHttpError("error in ExternalIdHandler", http.StatusInternalServerError, err)
 	}


### PR DESCRIPTION
**What is this feature?**

Fix for an issue in Cloudwatch Data Source when using Grafana Assume Role where users are unable to see their external id until after they save the datasource.

**Why do we need this feature?**
To get an external id, we grab it off of the instance settings. However currently when we do so we also try to create an ec2 client and other such things that require auth details. This throws an error currently because the user has not saved/selected an auth type selection or a default region. However there's really no reason to create an ec2 client when all we need is to show something from the user's grafana settings. 

**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/grafana/issues/84229

**Special notes for your reviewer:**

I would like to add a test here, but find it difficult to see how to test this... we really need some kind of integration test here to test the endpoint with the factory function, but I only see handler tests. Maybe this can happen in another pr? Unless we see a good way to test this that I'm missing?

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
