### PR TITLE
Infinite Scroll: wait for users to reach the top before triggering new requests

### DIFF
--- a/public/app/features/logs/components/InfiniteScroll.test.tsx
+++ b/public/app/features/logs/components/InfiniteScroll.test.tsx
@@ -43,7 +43,7 @@ function ScrollWithWrapper({ children, ...props }: Props) {
   return (
     <div style={{ height: 40, overflowY: 'scroll' }} ref={scrollRef} data-testid="scroll-element">
       {initialized && (
-        <InfiniteScroll {...props} scrollElement={scrollRef.current!}>
+        <InfiniteScroll {...props} scrollElement={scrollRef.current!} topScrollEnabled>
           {children}
         </InfiniteScroll>
       )}
@@ -83,6 +83,7 @@ function setup(loadMoreMock: () => void, startPosition: number, rows: LogRowMode
       rows={rows}
       scrollElement={element as unknown as HTMLDivElement}
       loadMoreLogs={loadMoreMock}
+      topScrollEnabled
     >
       <div data-testid="contents" style={{ height: 100 }} />
     </InfiniteScroll>
@@ -136,7 +137,7 @@ describe('InfiniteScroll', () => {
         'Requests more logs when scrolling %s',
         async (direction: string, startPosition: number, endPosition: number) => {
           const loadMoreMock = jest.fn();
-          const { scrollTo, element, wheel } = setup(loadMoreMock, startPosition, rows, order);
+          const { scrollTo, element } = setup(loadMoreMock, startPosition, rows, order);
 
           expect(await screen.findByTestId('contents')).toBeInTheDocument();
 

--- a/public/app/features/logs/components/InfiniteScroll.test.tsx
+++ b/public/app/features/logs/components/InfiniteScroll.test.tsx
@@ -265,18 +265,6 @@ describe('InfiniteScroll', () => {
           }
         );
       });
-
-      describe('Scrolling to the top', () => {
-        test('Waits for the user to reach the edge before triggering a new query', async () => {
-          const loadMoreMock = jest.fn();
-          const { wheel } = setup(loadMoreMock, 10, rows, order);
-
-          wheel(-10);
-          expect(loadMoreMock).not.toHaveBeenCalled();
-          wheel(-5);
-          expect(loadMoreMock).toHaveBeenCalled();
-        });
-      });
     }
   );
 });

--- a/public/app/features/logs/components/InfiniteScroll.test.tsx
+++ b/public/app/features/logs/components/InfiniteScroll.test.tsx
@@ -266,15 +266,14 @@ describe('InfiniteScroll', () => {
       });
 
       describe('Scrolling to the top', () => {
-        test(
-          'Waits for the user to reach the edge before triggering a new query', async () => {
-            const loadMoreMock = jest.fn();
-            const { wheel } = setup(loadMoreMock, 10, rows, order);
-  
-            wheel(-10);
-            expect(loadMoreMock).not.toHaveBeenCalled();
-            wheel(-5);
-            expect(loadMoreMock).toHaveBeenCalled();
+        test('Waits for the user to reach the edge before triggering a new query', async () => {
+          const loadMoreMock = jest.fn();
+          const { wheel } = setup(loadMoreMock, 10, rows, order);
+
+          wheel(-10);
+          expect(loadMoreMock).not.toHaveBeenCalled();
+          wheel(-5);
+          expect(loadMoreMock).toHaveBeenCalled();
         });
       });
     }

--- a/public/app/features/logs/components/InfiniteScroll.tsx
+++ b/public/app/features/logs/components/InfiniteScroll.tsx
@@ -33,6 +33,7 @@ export const InfiniteScroll = ({
   const [lowerOutOfRange, setLowerOutOfRange] = useState(false);
   const [upperLoading, setUpperLoading] = useState(false);
   const [lowerLoading, setLowerLoading] = useState(false);
+  const [onTopEdge, setOnTopEdge] = useState(scrollElement?.scrollTop === 0 || false);
   const rowsRef = useRef<LogRowModel[]>(rows);
   const lastScroll = useRef<number>(scrollElement?.scrollTop || 0);
 
@@ -78,6 +79,7 @@ export const InfiniteScroll = ({
       if (!scrollElement || !loadMoreLogs || !rows.length || loading || !config.featureToggles.logsInfiniteScrolling) {
         return;
       }
+      setOnTopEdge(scrollElement?.scrollTop === 0);
       event.stopImmediatePropagation();
       const scrollDirection = shouldLoadMore(event, scrollElement, lastScroll.current);
       lastScroll.current = scrollElement.scrollTop;
@@ -91,6 +93,9 @@ export const InfiniteScroll = ({
     }
 
     function scrollTop() {
+      if (!onTopEdge) {
+        return;
+      }
       const newRange = canScrollTop(getVisibleRange(rows), range, timeZone, sortOrder);
       if (!newRange) {
         setUpperOutOfRange(true);
@@ -127,7 +132,7 @@ export const InfiniteScroll = ({
       scrollElement.removeEventListener('scroll', handleScroll);
       scrollElement.removeEventListener('wheel', handleScroll);
     };
-  }, [loadMoreLogs, loading, range, rows, scrollElement, sortOrder, timeZone]);
+  }, [loadMoreLogs, loading, onTopEdge, range, rows, scrollElement, sortOrder, timeZone]);
 
   // We allow "now" to move when using relative time, so we hide the message so it doesn't flash.
   const hideTopMessage = sortOrder === LogsSortOrder.Descending && isRelativeTime(range.raw.to);

--- a/public/app/features/logs/components/InfiniteScroll.tsx
+++ b/public/app/features/logs/components/InfiniteScroll.tsx
@@ -29,7 +29,7 @@ export const InfiniteScroll = ({
   scrollElement,
   sortOrder,
   timeZone,
-  topScrollEnabled = false
+  topScrollEnabled = false,
 }: Props) => {
   const [upperOutOfRange, setUpperOutOfRange] = useState(false);
   const [lowerOutOfRange, setLowerOutOfRange] = useState(false);

--- a/public/app/features/logs/components/InfiniteScroll.tsx
+++ b/public/app/features/logs/components/InfiniteScroll.tsx
@@ -17,6 +17,7 @@ export type Props = {
   scrollElement?: HTMLDivElement;
   sortOrder: LogsSortOrder;
   timeZone: TimeZone;
+  topScrollEnabled?: boolean;
 };
 
 export const InfiniteScroll = ({
@@ -28,6 +29,7 @@ export const InfiniteScroll = ({
   scrollElement,
   sortOrder,
   timeZone,
+  topScrollEnabled = false
 }: Props) => {
   const [upperOutOfRange, setUpperOutOfRange] = useState(false);
   const [lowerOutOfRange, setLowerOutOfRange] = useState(false);
@@ -85,7 +87,7 @@ export const InfiniteScroll = ({
       lastScroll.current = scrollElement.scrollTop;
       if (scrollDirection === ScrollDirection.NoScroll) {
         return;
-      } else if (scrollDirection === ScrollDirection.Top) {
+      } else if (scrollDirection === ScrollDirection.Top && topScrollEnabled) {
         scrollTop();
       } else {
         scrollBottom();

--- a/public/app/features/logs/components/InfiniteScroll.tsx
+++ b/public/app/features/logs/components/InfiniteScroll.tsx
@@ -35,7 +35,6 @@ export const InfiniteScroll = ({
   const [lowerOutOfRange, setLowerOutOfRange] = useState(false);
   const [upperLoading, setUpperLoading] = useState(false);
   const [lowerLoading, setLowerLoading] = useState(false);
-  const [onTopEdge, setOnTopEdge] = useState(scrollElement?.scrollTop === 0 || false);
   const rowsRef = useRef<LogRowModel[]>(rows);
   const lastScroll = useRef<number>(scrollElement?.scrollTop || 0);
 
@@ -81,7 +80,6 @@ export const InfiniteScroll = ({
       if (!scrollElement || !loadMoreLogs || !rows.length || loading || !config.featureToggles.logsInfiniteScrolling) {
         return;
       }
-      setOnTopEdge(scrollElement?.scrollTop === 0);
       event.stopImmediatePropagation();
       const scrollDirection = shouldLoadMore(event, scrollElement, lastScroll.current);
       lastScroll.current = scrollElement.scrollTop;
@@ -89,15 +87,12 @@ export const InfiniteScroll = ({
         return;
       } else if (scrollDirection === ScrollDirection.Top && topScrollEnabled) {
         scrollTop();
-      } else {
+      } else if (scrollDirection === ScrollDirection.Bottom) {
         scrollBottom();
       }
     }
 
     function scrollTop() {
-      if (!onTopEdge) {
-        return;
-      }
       const newRange = canScrollTop(getVisibleRange(rows), range, timeZone, sortOrder);
       if (!newRange) {
         setUpperOutOfRange(true);
@@ -134,7 +129,7 @@ export const InfiniteScroll = ({
       scrollElement.removeEventListener('scroll', handleScroll);
       scrollElement.removeEventListener('wheel', handleScroll);
     };
-  }, [loadMoreLogs, loading, onTopEdge, range, rows, scrollElement, sortOrder, timeZone]);
+  }, [loadMoreLogs, loading, range, rows, scrollElement, sortOrder, timeZone, topScrollEnabled]);
 
   // We allow "now" to move when using relative time, so we hide the message so it doesn't flash.
   const hideTopMessage = sortOrder === LogsSortOrder.Descending && isRelativeTime(range.raw.to);


### PR DESCRIPTION
To address recent feedback on the behavior of the scroll, we will now require an extra event when scrolling top before triggering a new request. This allows the user to reach to the top of the list, without that triggering infinite scrolling.

> I still find this  kind of confusing and a bit annoying when scrolling around that when I roll to the top it re-runs the query.

**What is this feature?**

Enhancement.

**Which issue(s) does this PR fix?**:

Part of https://github.com/grafana/grafana/issues/71728

**Special notes for your reviewer:**

Old behavior:

https://github.com/grafana/grafana/assets/1069378/b7bd4919-56d9-4a67-98cd-10afab68266b

New behavior:

https://github.com/grafana/grafana/assets/1069378/c882557b-7c2c-4b37-add7-1b4af27047e3
