### PR TITLE
Loki: Replace imports of `infra/httpclient` with SDK

### DIFF
--- a/pkg/tsdb/loki/healthcheck_test.go
+++ b/pkg/tsdb/loki/healthcheck_test.go
@@ -76,10 +76,9 @@ func (provider *healthCheckProvider[T]) GetTransport(opts ...httpclient.Options)
 }
 
 // Return a mocked HTTP client provider.
-// 
+//
 // Example taken from `pkg/promlib/healthcheck_test.go`
 func getMockProvider[T http.RoundTripper]() *httpclient.Provider {
-	
 	p := &healthCheckProvider[T]{
 		RoundTripper: new(T),
 	}

--- a/pkg/tsdb/loki/healthcheck_test.go
+++ b/pkg/tsdb/loki/healthcheck_test.go
@@ -10,8 +10,8 @@ import (
 
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
 	"github.com/grafana/grafana-plugin-sdk-go/backend/datasource"
-	sdkHttpClient "github.com/grafana/grafana-plugin-sdk-go/backend/httpclient"
-	"github.com/grafana/grafana/pkg/infra/httpclient"
+	"github.com/grafana/grafana-plugin-sdk-go/backend/httpclient"
+
 	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/infra/tracing"
 	"github.com/grafana/grafana/pkg/services/featuremgmt"
@@ -64,14 +64,14 @@ func (rt *healthCheckFailRoundTripper) RoundTrip(req *http.Request) (*http.Respo
 	}, nil
 }
 
-func (provider *healthCheckProvider[T]) New(opts ...sdkHttpClient.Options) (*http.Client, error) {
+func (provider *healthCheckProvider[T]) New(opts ...httpclient.Options) (*http.Client, error) {
 	client := &http.Client{}
 	provider.RoundTripper = new(T)
 	client.Transport = *provider.RoundTripper
 	return client, nil
 }
 
-func (provider *healthCheckProvider[T]) GetTransport(opts ...sdkHttpClient.Options) (http.RoundTripper, error) {
+func (provider *healthCheckProvider[T]) GetTransport(opts ...httpclient.Options) (http.RoundTripper, error) {
 	return *new(T), nil
 }
 
@@ -85,7 +85,7 @@ func Test_healthcheck(t *testing.T) {
 	t.Run("should do a successful health check", func(t *testing.T) {
 		httpProvider := getMockProvider[*healthCheckSuccessRoundTripper]()
 		s := &Service{
-			im:       datasource.NewInstanceManager(newInstanceSettings(httpProvider)),
+			im:       datasource.NewInstanceManager(newInstanceSettings(&httpProvider.Provider)),
 			features: featuremgmt.WithFeatures(featuremgmt.FlagLokiLogsDataplane, featuremgmt.FlagLokiMetricDataplane),
 			tracer:   tracing.InitializeTracerForTest(),
 			logger:   log.New("loki test"),
@@ -104,7 +104,7 @@ func Test_healthcheck(t *testing.T) {
 	t.Run("should return an error for an unsuccessful health check", func(t *testing.T) {
 		httpProvider := getMockProvider[*healthCheckFailRoundTripper]()
 		s := &Service{
-			im:       datasource.NewInstanceManager(newInstanceSettings(httpProvider)),
+			im:       datasource.NewInstanceManager(newInstanceSettings(&httpProvider.Provider)),
 			features: featuremgmt.WithFeatures(featuremgmt.FlagLokiLogsDataplane, featuremgmt.FlagLokiMetricDataplane),
 			tracer:   tracing.InitializeTracerForTest(),
 			logger:   log.New("loki test"),

--- a/pkg/tsdb/loki/healthcheck_test.go
+++ b/pkg/tsdb/loki/healthcheck_test.go
@@ -75,7 +75,11 @@ func (provider *healthCheckProvider[T]) GetTransport(opts ...httpclient.Options)
 	return *new(T), nil
 }
 
+// Return a mocked HTTP client provider.
+// 
+// Example taken from `pkg/promlib/healthcheck_test.go`
 func getMockProvider[T http.RoundTripper]() *httpclient.Provider {
+	
 	p := &healthCheckProvider[T]{
 		RoundTripper: new(T),
 	}

--- a/pkg/tsdb/loki/loki.go
+++ b/pkg/tsdb/loki/loki.go
@@ -19,7 +19,7 @@ import (
 	"go.opentelemetry.io/otel/codes"
 	"go.opentelemetry.io/otel/trace"
 
-	"github.com/grafana/grafana/pkg/infra/httpclient"
+	"github.com/grafana/grafana-plugin-sdk-go/backend/httpclient"
 	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/infra/tracing"
 	"github.com/grafana/grafana/pkg/services/featuremgmt"
@@ -42,7 +42,7 @@ var (
 	_ backend.CallResourceHandler = (*Service)(nil)
 )
 
-func ProvideService(httpClientProvider httpclient.Provider, features featuremgmt.FeatureToggles, tracer tracing.Tracer) *Service {
+func ProvideService(httpClientProvider *httpclient.Provider, features featuremgmt.FeatureToggles, tracer tracing.Tracer) *Service {
 	return &Service{
 		im:       datasource.NewInstanceManager(newInstanceSettings(httpClientProvider)),
 		features: features,
@@ -88,7 +88,7 @@ func parseQueryModel(raw json.RawMessage) (*QueryJSONModel, error) {
 	return model, err
 }
 
-func newInstanceSettings(httpClientProvider httpclient.Provider) datasource.InstanceFactoryFunc {
+func newInstanceSettings(httpClientProvider *httpclient.Provider) datasource.InstanceFactoryFunc {
 	return func(ctx context.Context, settings backend.DataSourceInstanceSettings) (instancemgmt.Instance, error) {
 		opts, err := settings.HTTPClientOptions(ctx)
 		if err != nil {


### PR DESCRIPTION
As part of the decoupling of Loki plugin, this PR replaces all imports of `github.com/grafana/grafana/pkg/infra/httpclient` with the `grafana-plugin-sdk-go` SDK.