### PR TITLE
DashboardScene: Reset query variable query and definition on datasource change

### DIFF
--- a/public/app/features/dashboard-scene/settings/variables/editors/QueryVariableEditor.test.tsx
+++ b/public/app/features/dashboard-scene/settings/variables/editors/QueryVariableEditor.test.tsx
@@ -152,6 +152,8 @@ describe('QueryVariableEditor', () => {
     });
 
     expect(variable.state.datasource).toEqual({ uid: 'mock-ds-3', type: 'prometheus' });
+    expect(variable.state.query).toBe('');
+    expect(variable.state.definition).toBe('');
   });
 
   it('should update the variable state when changing the query', async () => {

--- a/public/app/features/dashboard-scene/settings/variables/editors/QueryVariableEditor.tsx
+++ b/public/app/features/dashboard-scene/settings/variables/editors/QueryVariableEditor.tsx
@@ -36,6 +36,12 @@ export function QueryVariableEditor({ variable, onRunQuery }: QueryVariableEdito
   };
   const onDataSourceChange = (dsInstanceSettings: DataSourceInstanceSettings) => {
     const datasource: DataSourceRef = { uid: dsInstanceSettings.uid, type: dsInstanceSettings.type };
+
+    if (variable.state.datasource && variable.state.datasource.type !== datasource.type) {
+      variable.setState({ datasource, query: '', definition: '' });
+      return;
+    }
+
     variable.setState({ datasource });
   };
   const onQueryChange = (query: VariableQueryType) => {


### PR DESCRIPTION
Issue: When changing query variable datasource `query` was not reset in scenes dashboards (compared to old logic). This would cause errors when new query editor would try to parse previous query.

- [x] reset query variable query on datasource change (based on previous logic in [`changeQueryVariableDataSource`](https://github.com/grafana/grafana/blob/0c44a6f9bb9cf547e16cec3db398d9cfd8bc534c/public/app/features/variables/query/actions.ts)) 
- [x] reset query variable definition on datasource change
- [x] add test 

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #83624

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
