### PR TITLE
Docs: Update documentation for Elasticsearch 

### DIFF
--- a/docs/sources/datasources/elasticsearch/_index.md
+++ b/docs/sources/datasources/elasticsearch/_index.md
@@ -34,7 +34,7 @@ The following will help you get started working with Elasticsearch and Grafana:
 
 This data source supports these versions of Elasticsearch:
 
-- v7.16+
+- v7.17+
 - v8.x
 
 Our maintenance policy for Elasticsearch data source is aligned with the [Elastic Product End of Life Dates](https://www.elastic.co/support/eol) and we ensure proper functionality for supported versions. If you are using an Elasticsearch with version that is past its end-of-life (EOL), you can still execute queries, but you will receive a notification in the query builder indicating that the version of Elasticsearch you are using is no longer supported. It's important to note that in such cases, we do not guarantee the correctness of the functionality, and we will not be addressing any related issues.

--- a/docs/sources/datasources/elasticsearch/query-editor/index.md
+++ b/docs/sources/datasources/elasticsearch/query-editor/index.md
@@ -27,7 +27,7 @@ Grafana provides a query editor for Elasticsearch. Elasticsearch queries are in 
 See [Lucene query syntax](https://www.elastic.co/guide/en/kibana/current/lucene-query.html) and [Query string syntax](https://www.elastic.co/guide/en/elasticsearch/reference/8.9/query-dsl-query-string-query.html#query-string-syntax) if you are new to working with Lucene queries in Elasticsearch.
 
 {{% admonition type="note" %}}
-When composing Lucene queries, ensure that you use uppercase boolean operators: AND, OR, and NOT. Lowercase versions of these operators are not correctly parsed by Elasticsearch.
+When composing Lucene queries, ensure that you use uppercase boolean operators: `AND`, `OR`, and `NOT`. Lowercase versions of these operators are not supported by the Lucene query language.
 {{% /admonition %}}
 
 {{< figure src="/static/img/docs/elasticsearch/elastic-query-editor-10.1.png" max-width="800px" class="docs-image--no-shadow" caption="Elasticsearch query editor" >}}

--- a/docs/sources/datasources/elasticsearch/query-editor/index.md
+++ b/docs/sources/datasources/elasticsearch/query-editor/index.md
@@ -24,7 +24,11 @@ weight: 300
 # Elasticsearch query editor
 
 Grafana provides a query editor for Elasticsearch. Elasticsearch queries are in Lucene format.
-See [Lucene query syntax](https://www.elastic.co/guide/en/kibana/current/lucene-query.html) and and [Query string syntax](https://www.elastic.co/guide/en/elasticsearch/reference/8.9/query-dsl-query-string-query.html#query-string-syntax) if you are new to working with Lucene queries in Elasticsearch.
+See [Lucene query syntax](https://www.elastic.co/guide/en/kibana/current/lucene-query.html) and [Query string syntax](https://www.elastic.co/guide/en/elasticsearch/reference/8.9/query-dsl-query-string-query.html#query-string-syntax) if you are new to working with Lucene queries in Elasticsearch.
+
+{{% admonition type="note" %}}
+When composing Lucene queries, ensure that you use uppercase boolean operators: AND, OR, and NOT. Lowercase versions of these operators are not correctly parsed by Elasticsearch.
+{{% /admonition %}}
 
 {{< figure src="/static/img/docs/elasticsearch/elastic-query-editor-10.1.png" max-width="800px" class="docs-image--no-shadow" caption="Elasticsearch query editor" >}}
 

--- a/docs/sources/datasources/elasticsearch/query-editor/index.md
+++ b/docs/sources/datasources/elasticsearch/query-editor/index.md
@@ -27,7 +27,7 @@ Grafana provides a query editor for Elasticsearch. Elasticsearch queries are in 
 See [Lucene query syntax](https://www.elastic.co/guide/en/kibana/current/lucene-query.html) and [Query string syntax](https://www.elastic.co/guide/en/elasticsearch/reference/8.9/query-dsl-query-string-query.html#query-string-syntax) if you are new to working with Lucene queries in Elasticsearch.
 
 {{% admonition type="note" %}}
-When composing Lucene queries, ensure that you use uppercase boolean operators: `AND`, `OR`, and `NOT`. Lowercase versions of these operators are not supported by the Lucene query language.
+When composing Lucene queries, ensure that you use uppercase boolean operators: `AND`, `OR`, and `NOT`. Lowercase versions of these operators are not supported by the Lucene query syntax.
 {{% /admonition %}}
 
 {{< figure src="/static/img/docs/elasticsearch/elastic-query-editor-10.1.png" max-width="800px" class="docs-image--no-shadow" caption="Elasticsearch query editor" >}}

--- a/docs/sources/panels-visualizations/query-transform-data/expression-queries/index.md
+++ b/docs/sources/panels-visualizations/query-transform-data/expression-queries/index.md
@@ -104,7 +104,7 @@ So if you have numbers with labels like `{host=web01}` in `$A` and another numbe
 - An item with no labels will join to anything.
 - If both `$A` and `$B` each contain only one item (one series, or one number), they will join.
 - If labels are exact math they will join.
-- If labels are a subset of the other, for example and item in `$A` is labeled `{host=A,dc=MIA}` and and item in `$B` is labeled `{host=A}` they will join.
+- If labels are a subset of the other, for example and item in `$A` is labeled `{host=A,dc=MIA}` and item in `$B` is labeled `{host=A}` they will join.
 - Currently, if within a variable such as `$A` there are different tag _keys_ for each item, the join behavior is undefined.
 
 The relational and logical operators return 0 for false 1 for true.

--- a/docs/sources/setup-grafana/configure-security/configure-authentication/saml/index.md
+++ b/docs/sources/setup-grafana/configure-security/configure-authentication/saml/index.md
@@ -69,7 +69,7 @@ By default, SP-initiated requests are enabled. For instructions on how to enable
    - [`assertion_attribute_email`]({{< relref "../../../configure-grafana/enterprise-configuration#assertion_attribute_email" >}})
    - [`assertion_attribute_name`]({{< relref "../../../configure-grafana/enterprise-configuration#assertion_attribute_name" >}})
    - [`assertion_attribute_groups`]({{< relref "../../../configure-grafana/enterprise-configuration#assertion_attribute_groups" >}})
-1. Save the configuration file and and then restart the Grafana server.
+1. Save the configuration file and then restart the Grafana server.
 
 When you are finished, the Grafana configuration might look like this example:
 


### PR DESCRIPTION
This PR updates Elasticsearch documentation:
- removes `and and` (I have found 2 more places where `and and` was in documentation, so I updated that as well)
- updates last supported ES version for Grafana 11 to v `7.17+` based on https://www.elastic.co/support/eol
- adds documentation that users neeed to use uppercase boolean operators AND, OR, NOT and lowercased won't be [arsed by ES

Fixes https://github.com/grafana/grafana/issues/82934
Fixes https://github.com/grafana/grafana/issues/84282