### PR TITLE
Tooltip / Toggletip content link styling: Remove global a element selector inside tooltips

### DIFF
--- a/packages/grafana-ui/src/components/Toggletip/Toggletip.test.tsx
+++ b/packages/grafana-ui/src/components/Toggletip/Toggletip.test.tsx
@@ -246,12 +246,12 @@ describe('Toggletip', () => {
 
     render(
       <>
-        <Toggletip placement="auto" content={outsideLinkButton} show>
+        <Toggletip placement="auto" content={insideLinkButton} show>
           <Button type="button" data-testid="myButton">
             Click me!
           </Button>
         </Toggletip>
-        {insideLinkButton}
+        {outsideLinkButton}
       </>
     );
 

--- a/packages/grafana-ui/src/components/Toggletip/Toggletip.test.tsx
+++ b/packages/grafana-ui/src/components/Toggletip/Toggletip.test.tsx
@@ -2,7 +2,7 @@
 import userEvent from '@testing-library/user-event';
 import React from 'react';
 
-import { Button } from '../Button';
+import { Button, LinkButton } from '../Button';
 
 import { Toggletip } from './Toggletip';
 
@@ -233,5 +233,31 @@ describe('Toggletip', () => {
 
       expect(afterButton).toHaveFocus();
     });
+  });
+
+  it(`should render LinkButtons correctly with no additional styles`, () => {
+    const identicalProps = {
+      children: 'Click me!',
+      href: 'https://grafana.com',
+    };
+
+    const outsideLinkButton = <LinkButton {...identicalProps} data-testid="outside" />;
+    const insideLinkButton = <LinkButton {...identicalProps} data-testid="inside" />;
+
+    render(
+      <>
+        <Toggletip placement="auto" content={outsideLinkButton} show>
+          <Button type="button" data-testid="myButton">
+            Click me!
+          </Button>
+        </Toggletip>
+        {insideLinkButton}
+      </>
+    );
+
+    const outsideButton = screen.getByTestId('outside');
+    const insideButton = screen.getByTestId('inside');
+
+    expect(getComputedStyle(outsideButton).cssText).toStrictEqual(getComputedStyle(insideButton).cssText);
   });
 });

--- a/packages/grafana-ui/src/utils/tooltipUtils.ts
+++ b/packages/grafana-ui/src/utils/tooltipUtils.ts
@@ -1,7 +1,7 @@
 import { css } from '@emotion/css';
 import { Placement } from '@floating-ui/react';
 
-import { colorManipulator, GrafanaTheme2 } from '@grafana/data';
+import { GrafanaTheme2 } from '@grafana/data';
 
 import { TooltipPlacement } from '../components/Tooltip';
 
@@ -44,19 +44,6 @@ export function buildTooltipTheme(
 
       "&[data-popper-interactive='false']": {
         pointerEvents: 'none',
-      },
-
-      code: {
-        border: 'none',
-        display: 'inline',
-        background: colorManipulator.darken(tooltipBg, 0.1),
-        color: tooltipText,
-        whiteSpace: 'normal',
-      },
-
-      pre: {
-        background: colorManipulator.darken(tooltipBg, 0.1),
-        color: tooltipText,
       },
     }),
     headerClose: css({

--- a/packages/grafana-ui/src/utils/tooltipUtils.ts
+++ b/packages/grafana-ui/src/utils/tooltipUtils.ts
@@ -58,15 +58,6 @@ export function buildTooltipTheme(
         background: colorManipulator.darken(tooltipBg, 0.1),
         color: tooltipText,
       },
-
-      a: {
-        color: tooltipText,
-        textDecoration: 'underline',
-      },
-
-      'a:hover': {
-        textDecoration: 'none',
-      },
     }),
     headerClose: css({
       color: theme.colors.text.secondary,


### PR DESCRIPTION
**What is this feature?**

Removes the global `a` tag selector targeting all links inside tooltips and toggletips.

**Why do we need this feature?**

It overrides the Saga Design system by default when using something like `<LinkButton />` inside a Toggletip. The current workaround without this change is to reapply the styles that should be applied by default (which becomes a maintainability nightmare...).

**Who is this feature for?**

All users.

**Which issue(s) does this PR fix?**:
Un-ticketed.

**Special notes for your reviewer:**

I felt a little bit silly adding the test but I also thought it could be easy for it to be added back in by mistake so was worth putting in?

I also toyed with removing the global selectors for `code` and `pre` in the `buildTooltipTheme` function because they equally should not be there but chose not to to limit the scope of the PR. Is it worth removing those at the same time, too?

**Before**

![A screenshot of a Toggletip with a LinkButton inside. The LinkButton text is almost black against a dark blue background and has a text underline.](https://github.com/grafana/grafana/assets/6906380/91d3bb98-c2f5-4cd7-aea7-f675954da6a8)

**After**
![A screenshot of a Toggletip with a LinkButton inside. The LinkButton text looks identical to where it is used elsewhere in the application, blue background with white text.](https://github.com/grafana/grafana/assets/6906380/c797d683-6091-4980-8cd4-b7f3c1da06bf)

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
