### PR TITLE
Use $host nginx variable instead of $http_host

### DIFF
--- a/docs/sources/tutorials/run-grafana-behind-a-proxy/index.md
+++ b/docs/sources/tutorials/run-grafana-behind-a-proxy/index.md
@@ -58,7 +58,7 @@ server {
   index index.html index.htm;
 
   location / {
-    proxy_set_header Host $http_host;
+    proxy_set_header Host $host;
     proxy_pass http://grafana;
   }
 
@@ -67,7 +67,7 @@ server {
     proxy_http_version 1.1;
     proxy_set_header Upgrade $http_upgrade;
     proxy_set_header Connection $connection_upgrade;
-    proxy_set_header Host $http_host;
+    proxy_set_header Host $host;
     proxy_pass http://grafana;
   }
 }
@@ -102,7 +102,7 @@ server {
   index index.html index.htm;
 
   location /grafana/ {
-    proxy_set_header Host $http_host;
+    proxy_set_header Host $host;
     proxy_pass http://grafana;
   }
 
@@ -111,7 +111,7 @@ server {
     proxy_http_version 1.1;
     proxy_set_header Upgrade $http_upgrade;
     proxy_set_header Connection $connection_upgrade;
-    proxy_set_header Host $http_host;
+    proxy_set_header Host $host;
     proxy_pass http://grafana;
   }
 }

--- a/docs/sources/tutorials/run-grafana-behind-a-proxy/index.md
+++ b/docs/sources/tutorials/run-grafana-behind-a-proxy/index.md
@@ -1,5 +1,4 @@
 ---
-Feedback Link: https://github.com/grafana/tutorials/issues/new
 aliases:
   - /docs/grafana/latest/installation/behind_proxy/
 authors:
@@ -32,18 +31,18 @@ When running Grafana behind a proxy, you need to configure the domain name to le
 domain = example.com
 ```
 
-- Restart Grafana for the new changes to take effect.
+- Restart Grafana for the changes to take effect.
 
 ## Configure reverse proxy
 
-### Configure NGINX
+### Configure nginx
 
-[NGINX](https://www.nginx.com) is a high performance load balancer, web server, and reverse proxy.
+[nginx](https://www.nginx.com) is a high performance load balancer, web server, and reverse proxy.
 
-- In your NGINX configuration file inside `http` section, add the following:
+- In your nginx configuration file inside the `http` section, add the following:
 
 ```nginx
-# this is required to proxy Grafana Live WebSocket connections.
+# This is required to proxy Grafana Live WebSocket connections.
 map $http_upgrade $connection_upgrade {
   default upgrade;
   '' close;
@@ -63,7 +62,7 @@ server {
     proxy_pass http://grafana;
   }
 
-# Proxy Grafana Live WebSocket connections.
+  # Proxy Grafana Live WebSocket connections.
   location /api/live/ {
     proxy_http_version 1.1;
     proxy_set_header Upgrade $http_upgrade;
@@ -74,17 +73,20 @@ server {
 }
 ```
 
-- Reload the NGINX configuration.
-- Navigate to port 80 on the machine NGINX is running on. You're greeted by the Grafana login page.
+- Reload the nginx configuration.
+- Navigate to port 80 on the machine nginx is running on.
+  You're greeted by the Grafana login page.
 
-For Grafana Live which uses WebSocket connections you may have to raise Nginx [worker_connections](https://nginx.org/en/docs/ngx_core_module.html#worker_connections) option which is 512 by default – which limits the number of possible concurrent connections with Grafana Live.
+For Grafana Live which uses WebSocket connections you may have to raise the nginx value for [`worker_connections`](https://nginx.org/en/docs/ngx_core_module.html#worker_connections) option which is `512` by default. The default value limits the number of possible concurrent connections with Grafana Live.
 
-Also, be aware that the above configuration will work only when the `proxy_pass` value for `location /` is a literal string. If you are using a variable here, [read this GitHub issue](https://github.com/grafana/grafana/issues/18299). You will need to add [an appropriate NGINX rewrite rule](https://www.nginx.com/blog/creating-nginx-rewrite-rules/).
+Also, be aware that the preceding configuration only works when the `proxy_pass` value for `location /` is a literal string.
+If you want to use a variable here, you must instead use [a rewrite rule](https://www.nginx.com/blog/creating-nginx-rewrite-rules/).
+For more information, refer to [the GitHub issue #18299](https://github.com/grafana/grafana/issues/18299).
 
-To configure NGINX to serve Grafana under a _sub path_, update the `location` block:
+To configure nginx to serve Grafana under a _sub path_, update the `location` block:
 
 ```nginx
-# this is required to proxy Grafana Live WebSocket connections.
+# This is required to proxy Grafana Live WebSocket connections.
 map $http_upgrade $connection_upgrade {
   default upgrade;
   '' close;
@@ -121,9 +123,11 @@ Add a rewrite rule to each location block:
  rewrite  ^/grafana/(.*)  /$1 break;
 ```
 
-{{% admonition type="note" %}}
-If Grafana is being served from behind a NGINX proxy with TLS termination enabled, then the `root_url` should be set accordingly. For example, if Grafana is being served from `https://example.com/grafana` then the `root_url` should be set to `https://example.com/grafana/` or `https://%(domain)s/grafana/` (and the corresponding `domain` should be set to `example.com`) in the `server` section of the Grafana configuration file. The `protocol` setting should be set to `http`, because the TLS handshake is being handled by NGINX.
-{{% /admonition %}}
+{{< admonition type="note" >}}
+If nginx is performing TLS termination, then you must set the `root_url` and `protocol` configuration accordingly.
+If you're serving Grafana from `https://example.com/grafana/` then the `root_url` is `https://example.com/grafana/` or `https://%(domain)s/grafana/` with the corresponding `domain` configuration value set to `example.com` in the `server` section of the Grafana configuration file.
+Set `protocol` to `http`.
+{{< /admonition >}}
 
 ### Configure HAProxy
 
@@ -146,9 +150,11 @@ backend grafana_backend
 
 ### Configure IIS
 
-> IIS requires that the URL Rewrite module is installed.
+{{< admonition type="note" >}}
+To use IIS, you must have the URL Rewrite module installed.
+{{< /admonition >}}
 
-To configure IIS to serve Grafana under a _sub path_, create an Inbound Rule for the parent website in IIS Manager with the following settings:
+To configure IIS to serve Grafana under a _sub path_, create an `Inbound Rule` for the parent website in **IIS Manager** with the following settings:
 
 - pattern: `grafana(/)?(.*)`
 - check the `Ignore case` checkbox
@@ -156,7 +162,7 @@ To configure IIS to serve Grafana under a _sub path_, create an Inbound Rule for
 - check the `Append query string` checkbox
 - check the `Stop processing of subsequent rules` checkbox
 
-This is the rewrite rule that is generated in the `web.config`:
+This is the rewrite rule that's generated in the `web.config`:
 
 ```xml
   <rewrite>
@@ -169,13 +175,13 @@ This is the rewrite rule that is generated in the `web.config`:
   </rewrite>
 ```
 
-See the [tutorial on IIS URL Rewrites](/tutorials/iis/) for more in-depth instructions.
+For more detailed instruction, refer to the [tutorial on IIS URL Rewrites](/tutorials/iis/).
 
 ### Configure Traefik
 
-[Traefik](https://traefik.io/traefik/) Cloud Native Reverse Proxy / Load Balancer / Edge Router
+[Traefik](https://traefik.io/traefik/) Cloud Native application proxy.
 
-Using the docker provider the following labels will configure the router and service for a domain or subdomain routing.
+Using the Docker provider and the following labels configures the router and service for a domain or subdomain routing.
 
 ```yaml
 labels:
@@ -183,7 +189,7 @@ labels:
   traefik.http.services.grafana.loadbalancer.server.port: 3000
 ```
 
-To deploy on a _sub path_
+To deploy on a _sub path_:
 
 ```yaml
 labels:
@@ -221,12 +227,14 @@ http:
 
 ## Alternative for serving Grafana under a sub path
 
-**Warning:** You only need this, if you do not handle the sub path serving via your reverse proxy configuration.
+{{< admonition type="note" >}}
+You only need this if you don't handle the sub path serving via your reverse proxy configuration.
+{{< /admonition >}}
 
-If you don't want or can't use the reverse proxy to handle serving Grafana from a _sub path_, you can set the config variable `server_from_sub_path` to `true`.
+If you don't want or can't use the reverse proxy to handle serving Grafana from a _sub path_, you can set the configuration variable `server_from_sub_path` to `true`.
 
 1. Include the sub path at the end of the `root_url`.
-2. Set `serve_from_sub_path` to `true`:
+1. Set `serve_from_sub_path` to `true`:
 
 ```bash
 [server]


### PR DESCRIPTION
Reported by a user in https://community.grafana.com/t/origin-now-allowed-with-nginx-http-3-quic/116351/1.

https://nginx.org/en/docs/http/ngx_http_core_module.html
> $host
> in this order of precedence: host name from the request line, or host name from the “Host” request header field, or the server name matching a request
> $http_name
> arbitrary request header field; the last part of a variable name is the field name converted to lower case with dashes replaced by underscores