### PR TITLE
Dashboard scenes: Unlink library panel inside edit mode

### DIFF
--- a/public/app/features/dashboard-scene/panel-edit/PanelEditor.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditor.tsx
@@ -20,6 +20,7 @@ export interface PanelEditorState extends SceneObjectState {
   dataPane?: PanelDataPane;
   vizManager: VizPanelManager;
   showLibraryPanelSaveModal?: boolean;
+  showLibraryPanelUnlinkModal?: boolean;
 }
 
 export class PanelEditor extends SceneObjectBase<PanelEditorState> {
@@ -212,8 +213,21 @@ export class PanelEditor extends SceneObjectBase<PanelEditorState> {
     locationService.partial({ editPanel: null });
   };
 
-  public onDismissLibraryPanelModal = () => {
+  public onDismissLibraryPanelSaveModal = () => {
     this.setState({ showLibraryPanelSaveModal: false });
+  };
+
+  public onUnlinkLibraryPanel = () => {
+    this.setState({ showLibraryPanelUnlinkModal: true });
+  };
+
+  public onDismissUnlinkLibraryPanelModal = () => {
+    this.setState({ showLibraryPanelUnlinkModal: false });
+  };
+
+  public onConfirmUnlinkLibraryPanel = () => {
+    this.state.vizManager.unlinkLibraryPanel();
+    this.setState({ showLibraryPanelUnlinkModal: false });
   };
 }
 

--- a/public/app/features/dashboard-scene/panel-edit/PanelEditorRenderer.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditorRenderer.tsx
@@ -6,6 +6,7 @@ import { SceneComponentProps } from '@grafana/scenes';
 import { Button, ToolbarButton, useStyles2 } from '@grafana/ui';
 
 import { NavToolbarActions } from '../scene/NavToolbarActions';
+import { UnlinkModal } from '../scene/UnlinkModal';
 import { getDashboardSceneFor, getLibraryPanel } from '../utils/utils';
 
 import { PanelEditor } from './PanelEditor';
@@ -58,7 +59,7 @@ export function PanelEditorRenderer({ model }: SceneComponentProps<PanelEditor>)
 
 function VizAndDataPane({ model }: SceneComponentProps<PanelEditor>) {
   const dashboard = getDashboardSceneFor(model);
-  const { vizManager, dataPane, showLibraryPanelSaveModal } = model.useState();
+  const { vizManager, dataPane, showLibraryPanelSaveModal, showLibraryPanelUnlinkModal } = model.useState();
   const { sourcePanel } = vizManager.useState();
   const libraryPanel = getLibraryPanel(sourcePanel.resolve());
   const { controls } = dashboard.useState();
@@ -88,10 +89,17 @@ function VizAndDataPane({ model }: SceneComponentProps<PanelEditor>) {
         {showLibraryPanelSaveModal && libraryPanel && (
           <SaveLibraryVizPanelModal
             libraryPanel={libraryPanel}
-            onDismiss={model.onDismissLibraryPanelModal}
+            onDismiss={model.onDismissLibraryPanelSaveModal}
             onConfirm={model.onConfirmSaveLibraryPanel}
             onDiscard={model.onDiscard}
           ></SaveLibraryVizPanelModal>
+        )}
+        {showLibraryPanelUnlinkModal && libraryPanel && (
+          <UnlinkModal
+            onDismiss={model.onDismissUnlinkLibraryPanelModal}
+            onConfirm={model.onConfirmUnlinkLibraryPanel}
+            isOpen
+          />
         )}
         {dataPane && (
           <>

--- a/public/app/features/dashboard-scene/panel-edit/VizPanelManager.test.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/VizPanelManager.test.tsx
@@ -250,6 +250,40 @@ describe('VizPanelManager', () => {
 
       expect(apiCall.mock.calls[0][0].state.panel?.state.title).toBe('new title');
     });
+
+    it('unlinks library panel', () => {
+      const panel = new VizPanel({
+        key: 'panel-1',
+        pluginId: 'text',
+      });
+
+      const libraryPanelModel = {
+        title: 'title',
+        uid: 'uid',
+        name: 'libraryPanelName',
+        model: vizPanelToPanel(panel),
+        type: 'panel',
+        version: 1,
+      };
+
+      const libraryPanel = new LibraryVizPanel({
+        isLoaded: true,
+        title: libraryPanelModel.title,
+        uid: libraryPanelModel.uid,
+        name: libraryPanelModel.name,
+        panelKey: panel.state.key!,
+        panel: panel,
+        _loadedPanel: libraryPanelModel,
+      });
+
+      const gridItem = new SceneGridItem({ body: libraryPanel });
+
+      const panelManager = VizPanelManager.createFor(panel);
+      panelManager.unlinkLibraryPanel();
+
+      const sourcePanel = panelManager.state.sourcePanel.resolve();
+      expect(sourcePanel.parent?.state.key).toBe(gridItem.state.key);
+    });
   });
 
   describe('query options', () => {

--- a/public/app/features/dashboard-scene/panel-edit/VizPanelManager.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/VizPanelManager.tsx
@@ -338,6 +338,24 @@ export class VizPanelManager extends SceneObjectBase<VizPanelManagerState> {
     });
   }
 
+  public unlinkLibraryPanel() {
+    const sourcePanel = this.state.sourcePanel.resolve();
+    if (!(sourcePanel.parent instanceof LibraryVizPanel)) {
+      throw new Error('VizPanel is not a child of a library panel');
+    }
+
+    const gridItem = sourcePanel.parent.parent;
+    if (!(gridItem instanceof SceneGridItem)) {
+      throw new Error('Library panel not a child of a grid item');
+    }
+
+    const newSourcePanel = this.state.panel.clone({ $data: this.state.$data?.clone() });
+    gridItem.setState({
+      body: newSourcePanel,
+    });
+    this.setState({ sourcePanel: newSourcePanel.getRef() });
+  }
+
   public commitChanges() {
     const sourcePanel = this.state.sourcePanel.resolve();
 


### PR DESCRIPTION
**What is this feature?**
Let's the user unlink a library panel from inside the edit mode and continue editing the panel as a normal panel.


https://github.com/grafana/grafana/assets/468940/5bec3046-c924-429f-bdb9-8a1cc6aa4769

