### PR TITLE
PostgreSQL: Display correct initial value for tls mode

### DIFF
--- a/public/app/plugins/datasource/grafana-postgresql-datasource/configuration/ConfigurationEditor.tsx
+++ b/public/app/plugins/datasource/grafana-postgresql-datasource/configuration/ConfigurationEditor.tsx
@@ -175,7 +175,7 @@ export const PostgresConfigEditor = (props: DataSourcePluginOptionsEditorProps<P
         >
           <Select
             options={tlsModes}
-            value={jsonData.sslmode || PostgresTLSModes.verifyFull}
+            value={jsonData.sslmode || PostgresTLSModes.require}
             onChange={onJSONDataOptionSelected('sslmode')}
             width={WIDTH_LONG}
           />


### PR DESCRIPTION
when the backend-code chooses the ssl-mode setting, if the value is `""` (empty-string), it considers it to be equal to `"require"`:
https://github.com/grafana/grafana/blob/2a1a5145d00bf992ab87e6cbd7cc37466eb31386/pkg/tsdb/grafana-postgresql-datasource/tls/tls.go#L123-L125

(we can also check in the previous (non `pgx`) version's codebase, that the `lib/pq` module treated `""` and `"require"` the same way: https://github.com/lib/pq/blob/3d613208bca2e74f2a20e04126ed30bcb5c4cc27/ssl.go#L21 )

this PR adjusts the frontend to do the same (if the value is empty, assume `require`).