### PR TITLE
A11y: Adjust placeholder text color to pass a11y tests

### DIFF
--- a/packages/grafana-data/src/themes/createColors.ts
+++ b/packages/grafana-data/src/themes/createColors.ts
@@ -180,7 +180,7 @@ class LightColors implements ThemeColorsBase<Partial<ThemeRichColor>> {
   text = {
     primary: `rgba(${this.blackBase}, 1)`,
     secondary: `rgba(${this.blackBase}, 0.75)`,
-    disabled: `rgba(${this.blackBase}, 0.50)`,
+    disabled: `rgba(${this.blackBase}, 0.64)`,
     link: this.primary.text,
     maxContrast: palette.black,
   };


### PR DESCRIPTION
**What is this feature?**

`placeholder`s  texts are mainly using `theme.color.text.disabled` and this color is not passing a11y test when using the light theme.

**Why do we need this feature?**

To improve accessibility

**Who is this feature for?**

All who care about accessibility

**Which issue(s) does this PR fix?**:

Fixes #79571

**Special notes for your reviewer:**
As I see it, I have two options:
1. Change the color of the `disabled` text in light mode, so we will fix this a11y problem everywhere
2. Change the color used by placeholders to another value
I chose the first option as is the more efficient one but not sure if we can change the color values without any issues.

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
