### PR TITLE
Alerting: Show error message when error is thrown after clicking create alert f…

### DIFF
--- a/public/app/features/dashboard/utils/getPanelMenu.ts
+++ b/public/app/features/dashboard/utils/getPanelMenu.ts
@@ -1,16 +1,20 @@
 import {
-  getTimeZone,
   PanelMenuItem,
   PluginExtensionPoints,
+  getTimeZone,
   urlUtil,
   type PluginExtensionPanelContext,
 } from '@grafana/data';
 import { AngularComponent, getPluginLinkExtensions, locationService } from '@grafana/runtime';
 import { PanelCtrl } from 'app/angular/panel/panel_ctrl';
 import config from 'app/core/config';
+import { createErrorNotification } from 'app/core/copy/appNotification';
 import { t } from 'app/core/internationalization';
+import { notifyApp } from 'app/core/reducers/appNotification';
 import { contextSrv } from 'app/core/services/context_srv';
+import { getMessageFromError } from 'app/core/utils/errors';
 import { getExploreUrl } from 'app/core/utils/explore';
+import { RuleFormValues } from 'app/features/alerting/unified/types/rule-form';
 import { panelToRuleFormValues } from 'app/features/alerting/unified/utils/rule-form';
 import { DashboardModel } from 'app/features/dashboard/state/DashboardModel';
 import { PanelModel } from 'app/features/dashboard/state/PanelModel';
@@ -28,7 +32,7 @@ import { InspectTab } from 'app/features/inspector/types';
 import { isPanelModelLibraryPanel } from 'app/features/library-panels/guard';
 import { createExtensionSubMenu } from 'app/features/plugins/extensions/utils';
 import { SHARED_DASHBOARD_QUERY } from 'app/plugins/datasource/dashboard';
-import { store } from 'app/store/store';
+import { dispatch, store } from 'app/store/store';
 
 import { getCreateAlertInMenuAvailability } from '../../alerting/unified/utils/access-control';
 import { navigateToExplore } from '../../explore/state/main';
@@ -206,8 +210,14 @@ export function getPanelMenu(
   });
 
   const createAlert = async () => {
-    const formValues = await panelToRuleFormValues(panel, dashboard);
-
+    let formValues: Partial<RuleFormValues> | undefined;
+    try {
+      formValues = await panelToRuleFormValues(panel, dashboard);
+    } catch (err) {
+      const message = `Error getting rule values from the panel: ${getMessageFromError(err)}`;
+      dispatch(notifyApp(createErrorNotification(message)));
+      return;
+    }
     const ruleFormUrl = urlUtil.renderUrl('/alerting/new', {
       defaults: JSON.stringify(formValues),
       returnTo: location.pathname + location.search,


### PR DESCRIPTION
**What is this feature?**

This PR shows the proper error message in case we get an error while trying to create an alert from a panel.
It might be that this panel is not correct after importing a wrong json, but the ui was not showing any error message and no feedback about what happened.

**Why do we need this feature?**

We need to provide the right error message in case something is wrong.

**Who is this feature for?**

All users.

**Special notes for your reviewer:**

Before the fix: 


https://github.com/grafana/grafana/assets/33540275/4d02607a-6f47-4591-a703-f09a976ab005

After the fix:


https://github.com/grafana/grafana/assets/33540275/6af7bd26-33eb-487e-94f0-ce4ab25d34bd



Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
