### PR TITLE
Chore: Bump to latest version of plugin-e2e

### DIFF
--- a/e2e/plugin-e2e/plugin-e2e-api-tests/as-admin-user/panelDataAssertion.spec.ts
+++ b/e2e/plugin-e2e/plugin-e2e-api-tests/as-admin-user/panelDataAssertion.spec.ts
@@ -1,4 +1,4 @@
-import { expect, test, PanelEditPage, DashboardPage } from '@grafana/plugin-e2e';
+import { expect, test, DashboardPage } from '@grafana/plugin-e2e';
 
 import { formatExpectError } from '../errors';
 import { successfulDataQuery } from '../mocks/queries';
@@ -6,17 +6,8 @@ import { successfulDataQuery } from '../mocks/queries';
 const REACT_TABLE_DASHBOARD = { uid: 'U_bZIMRMk' };
 
 test.describe('panel edit page', () => {
-  test('table panel data assertions with provisioned dashboard', async ({
-    page,
-    selectors,
-    grafanaVersion,
-    request,
-  }) => {
-    const panelEditPage = new PanelEditPage(
-      { page, selectors, grafanaVersion, request },
-      { dashboard: REACT_TABLE_DASHBOARD, id: '4' }
-    );
-    await panelEditPage.goto();
+  test('table panel data assertions with provisioned dashboard', async ({ gotoPanelEditPage }) => {
+    const panelEditPage = await gotoPanelEditPage({ dashboard: REACT_TABLE_DASHBOARD, id: '4' });
     await expect(
       panelEditPage.panel.locator,
       formatExpectError('Could not locate panel in panel edit page')
@@ -70,15 +61,15 @@ test.describe('panel edit page', () => {
 });
 
 test.describe('dashboard page', () => {
-  test('getting panel by title', async ({ page, selectors, grafanaVersion, request }) => {
-    const dashboardPage = new DashboardPage({ page, selectors, grafanaVersion, request }, REACT_TABLE_DASHBOARD);
+  test('getting panel by title', async ({ gotoDashboardPage }) => {
+    const dashboardPage = await gotoDashboardPage(REACT_TABLE_DASHBOARD);
     await dashboardPage.goto();
     const panel = await dashboardPage.getPanelByTitle('Colored background');
     await expect(panel.fieldNames).toContainText(['Field', 'Max', 'Mean', 'Last']);
   });
 
-  test('getting panel by id', async ({ page, selectors, grafanaVersion, request }) => {
-    const dashboardPage = new DashboardPage({ page, selectors, grafanaVersion, request }, REACT_TABLE_DASHBOARD);
+  test('getting panel by id', async ({ gotoDashboardPage }) => {
+    const dashboardPage = await gotoDashboardPage(REACT_TABLE_DASHBOARD);
     await dashboardPage.goto();
     const panel = await dashboardPage.getPanelById('4');
     await expect(panel.fieldNames, formatExpectError('Could not locate header elements in table panel')).toContainText([

--- a/e2e/plugin-e2e/plugin-e2e-api-tests/as-admin-user/panelEditPage.spec.ts
+++ b/e2e/plugin-e2e/plugin-e2e-api-tests/as-admin-user/panelEditPage.spec.ts
@@ -33,9 +33,7 @@ test.describe('query editor query data', () => {
 });
 
 test.describe('query editor with mocked responses', () => {
-  test('and resource `scenarios` is mocked', async ({ page, selectors, grafanaVersion, request }) => {
-    const dashboardPage = new DashboardPage({ page, selectors, grafanaVersion, request });
-    await dashboardPage.goto();
+  test('and resource `scenarios` is mocked', async ({ selectors, dashboardPage }) => {
     await dashboardPage.mockResourceResponse('scenarios', scenarios);
     const panelEditPage = await dashboardPage.addPanel();
     await panelEditPage.datasource.set('gdev-testdata');

--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "@emotion/eslint-plugin": "11.11.0",
     "@grafana/eslint-config": "7.0.0",
     "@grafana/eslint-plugin": "link:./packages/grafana-eslint-rules",
-    "@grafana/plugin-e2e": "^0.19.0",
+    "@grafana/plugin-e2e": "^0.21.0",
     "@grafana/tsconfig": "^1.3.0-rc1",
     "@manypkg/get-packages": "^2.2.0",
     "@playwright/test": "^1.41.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3890,16 +3890,16 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@grafana/plugin-e2e@npm:^0.19.0":
-  version: 0.19.0
-  resolution: "@grafana/plugin-e2e@npm:0.19.0"
+"@grafana/plugin-e2e@npm:^0.21.0":
+  version: 0.21.0
+  resolution: "@grafana/plugin-e2e@npm:0.21.0"
   dependencies:
     semver: "npm:^7.5.4"
     uuid: "npm:^9.0.1"
     yaml: "npm:^2.3.4"
   peerDependencies:
     "@playwright/test": ^1.41.2
-  checksum: 10/d47913d4abd07b245892d834b06ca44ecec767151134575d9e2679b93fad190cd6957542f6f0ddd12eaa4199b3282b557ddbb0ba88df13eb107986e35ed17d62
+  checksum: 10/0c158508e425ed1fe1219dde66149f23ede1a6d39219a688e351ac8cdac9938aeea65d922d0fd0965203069c8a7844afc3bac4f04c5f78f6bee3535b7de9b1ac
   languageName: node
   linkType: hard
 
@@ -18397,7 +18397,7 @@ __metadata:
     "@grafana/lezer-logql": "npm:0.2.3"
     "@grafana/monaco-logql": "npm:^0.0.7"
     "@grafana/o11y-ds-frontend": "workspace:*"
-    "@grafana/plugin-e2e": "npm:^0.19.0"
+    "@grafana/plugin-e2e": "npm:^0.21.0"
     "@grafana/prometheus": "workspace:*"
     "@grafana/runtime": "workspace:*"
     "@grafana/scenes": "npm:^3.11.0"


### PR DESCRIPTION

**What is this feature?**

Bump to latest version of plugin-e2e and update tests so they use new `gotoDashboardPage` and `gotoPanelEditPage` fixture.

**Why do we need this feature?**

Plugin authors

[Add a description of the problem the feature is trying to solve.]

**Who is this feature for?**

[Add information on what kind of user the feature is for.]

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
