### PR TITLE
k8s: ensure unified storage address is populated from config ini

### DIFF
--- a/pkg/services/apiserver/config.go
+++ b/pkg/services/apiserver/config.go
@@ -49,6 +49,7 @@ func applyGrafanaConfig(cfg *setting.Cfg, features featuremgmt.FeatureToggles, o
 
 	o.StorageOptions.StorageType = options.StorageType(apiserverCfg.Key("storage_type").MustString(string(options.StorageTypeLegacy)))
 	o.StorageOptions.DataPath = apiserverCfg.Key("storage_path").MustString(filepath.Join(cfg.DataPath, "grafana-apiserver"))
+	o.StorageOptions.Address = apiserverCfg.Key("address").MustString(o.StorageOptions.Address)
 	o.ExtraOptions.DevMode = features.IsEnabledGlobally(featuremgmt.FlagGrafanaAPIServerEnsureKubectlAccess)
 	o.ExtraOptions.ExternalAddress = host
 	o.ExtraOptions.APIURL = apiURL


### PR DESCRIPTION
**What is this feature?**

Ensure the grafana-apiserver.address field is populated from config ini

**Why do we need this feature?**

Was missing in https://github.com/grafana/grafana/pull/84006

**Who is this feature for?**

Grafana Search and Storage

**Which issue(s) does this PR fix?**:
NA
