### PR TITLE
Docs: Add information about supported Loki versions by Loki data source

### DIFF
--- a/docs/sources/datasources/loki/_index.md
+++ b/docs/sources/datasources/loki/_index.md
@@ -37,7 +37,6 @@ The following guides will help you get started with Loki:
 This data source supports these versions of Loki:
 
 - v2.8+
-- v3.0+
 
 ## Adding a data source
 

--- a/docs/sources/datasources/loki/_index.md
+++ b/docs/sources/datasources/loki/_index.md
@@ -32,6 +32,13 @@ The following guides will help you get started with Loki:
 - [LogQL](/docs/loki/latest/logql/)
 - [Loki query editor]({{< relref "./query-editor" >}})
 
+## Supported Loki versions
+
+This data source supports these versions of Loki:
+
+- v2.8+
+- v3.0+
+
 ## Adding a data source
 
 For instructions on how to add a data source to Grafana, refer to the [administration documentation][data-source-management]


### PR DESCRIPTION
We are adding information about the supported versions of Loki by the Loki data source in the released version of Grafana, to ensure users have access to this information.