### PR TITLE
postgres: add more tests (to handle zero-rows queries)

### DIFF
--- a/pkg/tsdb/grafana-postgresql-datasource/postgres_snapshot_test.go
+++ b/pkg/tsdb/grafana-postgresql-datasource/postgres_snapshot_test.go
@@ -98,6 +98,7 @@ func TestIntegrationPostgresSnapshots(t *testing.T) {
 		format string
 	}{
 		{format: "time_series", name: "simple"},
+		{format: "time_series", name: "no_rows"},
 		{format: "time_series", name: "7x_compat_metric_label"},
 		{format: "time_series", name: "convert_to_float64"},
 		{format: "time_series", name: "convert_to_float64_not"},
@@ -105,6 +106,7 @@ func TestIntegrationPostgresSnapshots(t *testing.T) {
 		{format: "time_series", name: "fill_previous"},
 		{format: "time_series", name: "fill_value"},
 		{format: "table", name: "simple"},
+		{format: "table", name: "no_rows"},
 		{format: "table", name: "types_numeric"},
 		{format: "table", name: "types_char"},
 		{format: "table", name: "types_datetime"},

--- a/pkg/tsdb/grafana-postgresql-datasource/testdata/table/no_rows.golden.jsonc
+++ b/pkg/tsdb/grafana-postgresql-datasource/testdata/table/no_rows.golden.jsonc
@@ -1,0 +1,36 @@
+//  🌟 This was machine generated.  Do not edit. 🌟
+//  
+//  Frame[0] {
+//      "typeVersion": [
+//          0,
+//          0
+//      ],
+//      "executedQueryString": "SELECT * FROM tbl WHERE false"
+//  }
+//  Name: 
+//  Dimensions: 0 Fields by 0 Rows
+//  +
+//  +
+//  
+//  
+//  🌟 This was machine generated.  Do not edit. 🌟
+{
+  "status": 200,
+  "frames": [
+    {
+      "schema": {
+        "meta": {
+          "typeVersion": [
+            0,
+            0
+          ],
+          "executedQueryString": "SELECT * FROM tbl WHERE false"
+        },
+        "fields": []
+      },
+      "data": {
+        "values": []
+      }
+    }
+  ]
+}

--- a/pkg/tsdb/grafana-postgresql-datasource/testdata/table/no_rows.sql
+++ b/pkg/tsdb/grafana-postgresql-datasource/testdata/table/no_rows.sql
@@ -1,0 +1,12 @@
+-- SELECT * FROM tbl WHERE false
+CREATE TEMPORARY TABLE tbl (
+    "time" timestamp with time zone,
+    v double precision,
+    c text
+);
+
+INSERT INTO tbl ("time", v, c) VALUES
+('2023-12-24 14:30:03 UTC', 10, 'a'),
+('2023-12-24 14:30:03 UTC', 110, 'b'),
+('2023-12-24 14:31:03 UTC', 20, 'a'),
+('2023-12-24 14:31:03 UTC', 120, 'b');

--- a/pkg/tsdb/grafana-postgresql-datasource/testdata/time_series/no_rows.golden.jsonc
+++ b/pkg/tsdb/grafana-postgresql-datasource/testdata/time_series/no_rows.golden.jsonc
@@ -1,0 +1,36 @@
+//  🌟 This was machine generated.  Do not edit. 🌟
+//  
+//  Frame[0] {
+//      "typeVersion": [
+//          0,
+//          0
+//      ],
+//      "executedQueryString": "SELECT * FROM tbl WHERE false"
+//  }
+//  Name: 
+//  Dimensions: 0 Fields by 0 Rows
+//  +
+//  +
+//  
+//  
+//  🌟 This was machine generated.  Do not edit. 🌟
+{
+  "status": 200,
+  "frames": [
+    {
+      "schema": {
+        "meta": {
+          "typeVersion": [
+            0,
+            0
+          ],
+          "executedQueryString": "SELECT * FROM tbl WHERE false"
+        },
+        "fields": []
+      },
+      "data": {
+        "values": []
+      }
+    }
+  ]
+}

--- a/pkg/tsdb/grafana-postgresql-datasource/testdata/time_series/no_rows.sql
+++ b/pkg/tsdb/grafana-postgresql-datasource/testdata/time_series/no_rows.sql
@@ -1,0 +1,12 @@
+-- SELECT * FROM tbl WHERE false
+CREATE TEMPORARY TABLE tbl (
+    "time" timestamp with time zone,
+    v double precision,
+    c text
+);
+
+INSERT INTO tbl ("time", v, c) VALUES
+('2023-12-24 14:30:03 UTC', 10, 'a'),
+('2023-12-24 14:30:03 UTC', 110, 'b'),
+('2023-12-24 14:31:03 UTC', 20, 'a'),
+('2023-12-24 14:31:03 UTC', 120, 'b');


### PR DESCRIPTION
test only change.

we add snapshot-tests that cover the "no rows returned for query" scenario.