### PR TITLE
[v10.2.x] Docs: clarify query formatting for time range variable queries

### DIFF
--- a/docs/sources/panels-visualizations/configure-data-links/index.md
+++ b/docs/sources/panels-visualizations/configure-data-links/index.md
@@ -48,6 +48,8 @@ These variables allow you to include the current time range in the data link URL
 - `__url_time_range` - current dashboard's time range (i.e. `?from=now-6h&to=now`)
 - `$__from and $__to` - For more information, refer to [Global variables][].
 
+When you create data links using time range variables like `__url_time_range` in the URL, you have to form the query parameter syntax yourself; that is, you must format the URL by appending query parameters using the question mark (`?`) and ampersand (`&`) syntax. These characters aren't automatically generated.
+
 ## Series variables
 
 Series-specific variables are available under `__series` namespace:
@@ -72,6 +74,8 @@ Value-specific variables are available under `__value` namespace:
 - `__value.calc` - calculation name if the value is result of calculation
 
 Using value-specific variables in data links can show different results depending on the set option of Tooltip mode.
+
+When you create data links using time range variables like `__value.time` in the URL, you have to form the query parameter syntax yourself; that is, you must add the question mark (`?`) and ampersand (`&`). These characters aren't automatically generated.
 
 ## Data variables
 


### PR DESCRIPTION
Backport e552e21221d9e958b1f9ff6bb162fe764bd81d8d from #84074

---

Clarifies that when you create data links using time range variables in the URL,  you need to add the `?` and `&` characters in the query as they're not automatically generated by Grafana. Per discussion on issue #83345.

Fixes #83345
