### PR TITLE
Loki: Fix null pointer exception in case request returned an error

### DIFF
--- a/pkg/tsdb/loki/loki.go
+++ b/pkg/tsdb/loki/loki.go
@@ -240,6 +240,11 @@ func executeQuery(ctx context.Context, query *lokiQuery, req *backend.QueryDataR
 	defer span.End()
 
 	queryRes, err := runQuery(ctx, api, query, responseOpts, plog)
+	if queryRes == nil {
+		// we always want to return a backend.DataResponse object, even if we received just an error
+		queryRes = &backend.DataResponse{}
+	}
+
 	if err != nil {
 		span.RecordError(err)
 		span.SetStatus(codes.Error, err.Error())


### PR DESCRIPTION
**What is this feature?**

Recently we changed the response type in Loki's backend to always be a `backend.DataResponse`. This PR fixes the assumption that the object is always set.

`runQuery` might return a nil pointer, e.g. [here](https://github.com/grafana/grafana/blob/3fb6319d1b8cae1d7e359572673117cb8268df63/pkg/tsdb/loki/api.go#L168) or [here](https://github.com/grafana/grafana/blob/3fb6319d1b8cae1d7e359572673117cb8268df63/pkg/tsdb/loki/api.go#L231).