### PR TITLE
samlsettings: add sso settings saml feature flag

### DIFF
--- a/packages/grafana-data/src/types/featureToggles.gen.ts
+++ b/packages/grafana-data/src/types/featureToggles.gen.ts
@@ -181,4 +181,5 @@ export interface FeatureToggles {
   alertingUpgradeDryrunOnStart?: boolean;
   scopeFilters?: boolean;
   emailVerificationEnforcement?: boolean;
+  ssoSettingsSAML?: boolean;
 }

--- a/pkg/services/featuremgmt/registry.go
+++ b/pkg/services/featuremgmt/registry.go
@@ -1219,7 +1219,7 @@ var (
 		},
 		{
 			Name:              "ssoSettingsSAML",
-			Description:       "Enables the SSO settings API and the SAML configuration UIs in Grafana",
+			Description:       "Use the new SSO Settings API to configure the SAML connector",
 			Stage:             FeatureStageExperimental,
 			Owner:             identityAccessTeam,
 			HideFromDocs:      true,

--- a/pkg/services/featuremgmt/registry.go
+++ b/pkg/services/featuremgmt/registry.go
@@ -1217,6 +1217,14 @@ var (
 			HideFromDocs:      true,
 			HideFromAdminPage: true,
 		},
+		{
+			Name:              "ssoSettingsSAML",
+			Description:       "Enables the SSO settings API and the SAML configuration UIs in Grafana",
+			Stage:             FeatureStageExperimental,
+			Owner:             identityAccessTeam,
+			HideFromDocs:      true,
+			HideFromAdminPage: true,
+		},
 	}
 )
 

--- a/pkg/services/featuremgmt/toggles_gen.csv
+++ b/pkg/services/featuremgmt/toggles_gen.csv
@@ -162,3 +162,4 @@ betterPageScrolling,GA,@grafana/grafana-frontend-platform,false,false,true
 alertingUpgradeDryrunOnStart,GA,@grafana/alerting-squad,false,true,false
 scopeFilters,experimental,@grafana/dashboards-squad,false,false,false
 emailVerificationEnforcement,experimental,@grafana/identity-access-team,false,false,false
+ssoSettingsSAML,experimental,@grafana/identity-access-team,false,false,false

--- a/pkg/services/featuremgmt/toggles_gen.go
+++ b/pkg/services/featuremgmt/toggles_gen.go
@@ -660,6 +660,6 @@ const (
 	FlagEmailVerificationEnforcement = "emailVerificationEnforcement"
 
 	// FlagSsoSettingsSAML
-	// Enables the SSO settings API and the SAML configuration UIs in Grafana
+	// Use the new SSO Settings API to configure the SAML connector
 	FlagSsoSettingsSAML = "ssoSettingsSAML"
 )

--- a/pkg/services/featuremgmt/toggles_gen.go
+++ b/pkg/services/featuremgmt/toggles_gen.go
@@ -658,4 +658,8 @@ const (
 	// FlagEmailVerificationEnforcement
 	// Force email verification for users, even when authenticating through sso.
 	FlagEmailVerificationEnforcement = "emailVerificationEnforcement"
+
+	// FlagSsoSettingsSAML
+	// Enables the SSO settings API and the SAML configuration UIs in Grafana
+	FlagSsoSettingsSAML = "ssoSettingsSAML"
 )

--- a/pkg/services/featuremgmt/toggles_gen.json
+++ b/pkg/services/featuremgmt/toggles_gen.json
@@ -2118,6 +2118,20 @@
         "hideFromAdminPage": true,
         "hideFromDocs": true
       }
+    },
+    {
+      "metadata": {
+        "name": "ssoSettingsSAML",
+        "resourceVersion": "1710409277313",
+        "creationTimestamp": "2024-03-14T09:41:17Z"
+      },
+      "spec": {
+        "description": "Enables the SSO settings API and the SAML configuration UIs in Grafana",
+        "stage": "experimental",
+        "codeowner": "@grafana/identity-access-team",
+        "hideFromAdminPage": true,
+        "hideFromDocs": true
+      }
     }
   ]
 }

--- a/pkg/services/featuremgmt/toggles_gen.json
+++ b/pkg/services/featuremgmt/toggles_gen.json
@@ -2122,11 +2122,14 @@
     {
       "metadata": {
         "name": "ssoSettingsSAML",
-        "resourceVersion": "1710409277313",
-        "creationTimestamp": "2024-03-14T09:41:17Z"
+        "resourceVersion": "1710411764296",
+        "creationTimestamp": "2024-03-14T09:41:17Z",
+        "annotations": {
+          "grafana.app/updatedTimestamp": "2024-03-14 10:22:44.296694 +0000 UTC"
+        }
       },
       "spec": {
-        "description": "Enables the SSO settings API and the SAML configuration UIs in Grafana",
+        "description": "Use the new SSO Settings API to configure the SAML connector",
         "stage": "experimental",
         "codeowner": "@grafana/identity-access-team",
         "hideFromAdminPage": true,

--- a/pkg/services/ssosettings/ssosettingsimpl/service.go
+++ b/pkg/services/ssosettings/ssosettingsimpl/service.go
@@ -414,7 +414,6 @@ func (s *Service) decryptSecrets(ctx context.Context, settings map[string]any) (
 
 func (s *Service) isProviderConfigurable(provider string) bool {
 	_, ok := s.cfg.SSOSettingsConfigurableProviders[provider]
-
 	return ok
 }
 

--- a/pkg/services/ssosettings/ssosettingsimpl/service.go
+++ b/pkg/services/ssosettings/ssosettingsimpl/service.go
@@ -417,10 +417,6 @@ func (s *Service) decryptSecrets(ctx context.Context, settings map[string]any) (
 func (s *Service) isProviderConfigurable(provider string) bool {
 	_, ok := s.cfg.SSOSettingsConfigurableProviders[provider]
 
-	if provider == "saml" && !s.features.IsEnabledGlobally(featuremgmt.FlagSsoSettingsSAML) {
-		return false
-	}
-
 	return ok
 }
 

--- a/pkg/services/ssosettings/ssosettingsimpl/service.go
+++ b/pkg/services/ssosettings/ssosettingsimpl/service.go
@@ -28,13 +28,12 @@ import (
 var _ ssosettings.Service = (*Service)(nil)
 
 type Service struct {
-	logger   log.Logger
-	cfg      *setting.Cfg
-	store    ssosettings.Store
-	ac       ac.AccessControl
-	secrets  secrets.Service
-	metrics  *metrics
-	features featuremgmt.FeatureToggles
+	logger  log.Logger
+	cfg     *setting.Cfg
+	store   ssosettings.Store
+	ac      ac.AccessControl
+	secrets secrets.Service
+	metrics *metrics
 
 	fbStrategies []ssosettings.FallbackStrategy
 	reloadables  map[string]ssosettings.Reloadable
@@ -59,12 +58,11 @@ func ProvideService(cfg *setting.Cfg, sqlStore db.DB, ac ac.AccessControl,
 		secrets:      secrets,
 		metrics:      newMetrics(registerer),
 		reloadables:  make(map[string]ssosettings.Reloadable),
-		features:     features,
 	}
 
 	usageStats.RegisterMetricsFunc(svc.getUsageStats)
 
-	if svc.features.IsEnabledGlobally(featuremgmt.FlagSsoSettingsApi) {
+	if features.IsEnabledGlobally(featuremgmt.FlagSsoSettingsApi) {
 		ssoSettingsApi := api.ProvideApi(svc, routeRegister, ac)
 		ssoSettingsApi.RegisterAPIEndpoints()
 	}

--- a/pkg/services/ssosettings/ssosettingsimpl/service.go
+++ b/pkg/services/ssosettings/ssosettingsimpl/service.go
@@ -28,12 +28,13 @@ import (
 var _ ssosettings.Service = (*Service)(nil)
 
 type Service struct {
-	logger  log.Logger
-	cfg     *setting.Cfg
-	store   ssosettings.Store
-	ac      ac.AccessControl
-	secrets secrets.Service
-	metrics *metrics
+	logger   log.Logger
+	cfg      *setting.Cfg
+	store    ssosettings.Store
+	ac       ac.AccessControl
+	secrets  secrets.Service
+	metrics  *metrics
+	features featuremgmt.FeatureToggles
 
 	fbStrategies []ssosettings.FallbackStrategy
 	reloadables  map[string]ssosettings.Reloadable
@@ -58,11 +59,12 @@ func ProvideService(cfg *setting.Cfg, sqlStore db.DB, ac ac.AccessControl,
 		secrets:      secrets,
 		metrics:      newMetrics(registerer),
 		reloadables:  make(map[string]ssosettings.Reloadable),
+		features:     features,
 	}
 
 	usageStats.RegisterMetricsFunc(svc.getUsageStats)
 
-	if features.IsEnabledGlobally(featuremgmt.FlagSsoSettingsApi) {
+	if svc.features.IsEnabledGlobally(featuremgmt.FlagSsoSettingsApi) {
 		ssoSettingsApi := api.ProvideApi(svc, routeRegister, ac)
 		ssoSettingsApi.RegisterAPIEndpoints()
 	}
@@ -414,6 +416,11 @@ func (s *Service) decryptSecrets(ctx context.Context, settings map[string]any) (
 
 func (s *Service) isProviderConfigurable(provider string) bool {
 	_, ok := s.cfg.SSOSettingsConfigurableProviders[provider]
+
+	if provider == "saml" && !s.features.IsEnabledGlobally(featuremgmt.FlagSsoSettingsSAML) {
+		return false
+	}
+
 	return ok
 }
 


### PR DESCRIPTION
**What is this feature?**

Adds a feature flag for SSO Settings SAML configuration.

**Why do we need this feature?**

The SSO Settings SAML configuration is still under development, and we must ensure backwards compatibility.

**Who is this feature for?**

IAM

**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/identity-access-team/issues/597

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
