### PR TITLE
Chore: Adding log also for cases where datasource UID length is invalid

### DIFF
--- a/pkg/services/datasources/service/store.go
+++ b/pkg/services/datasources/service/store.go
@@ -381,6 +381,13 @@ func (ss *SqlStore) UpdateDataSource(ctx context.Context, cmd *datasources.Updat
 
 		err = updateIsDefaultFlag(ds, sess)
 
+		if cmd.UpdateSecretFn != nil {
+			if err := cmd.UpdateSecretFn(); err != nil {
+				ss.logger.Error("Failed to update datasource secrets -- rolling back update", "UID", cmd.UID, "name", cmd.Name, "type", cmd.Type, "orgId", cmd.OrgID)
+				return err
+			}
+		}
+
 		if cmd.UID != "" {
 			if err := util.ValidateUID(cmd.UID); err != nil {
 				logDeprecatedInvalidDsUid(ss.logger, cmd.UID, cmd.Name, err)

--- a/pkg/services/datasources/service/store.go
+++ b/pkg/services/datasources/service/store.go
@@ -253,7 +253,7 @@ func (ss *SqlStore) AddDataSource(ctx context.Context, cmd *datasources.AddDataS
 				return fmt.Errorf("failed to generate UID for datasource %q: %w", cmd.Name, err)
 			}
 			cmd.UID = uid
-		} else if !util.IsValidShortUID(cmd.UID) {
+		} else if err := util.ValidateUID(cmd.UID); err != nil {
 			logDeprecatedInvalidDsUid(ss.logger, cmd.UID, cmd.Name)
 		}
 
@@ -388,7 +388,7 @@ func (ss *SqlStore) UpdateDataSource(ctx context.Context, cmd *datasources.Updat
 			}
 		}
 
-		if !util.IsValidShortUID(cmd.UID) {
+		if err := util.ValidateUID(cmd.UID); err != nil {
 			logDeprecatedInvalidDsUid(ss.logger, cmd.UID, cmd.Name)
 		}
 

--- a/pkg/services/datasources/service/store_test.go
+++ b/pkg/services/datasources/service/store_test.go
@@ -131,6 +131,7 @@ func TestIntegrationDataAccess(t *testing.T) {
 			ds := initDatasource(db)
 			cmd := defaultUpdateDatasourceCommand
 			cmd.ID = ds.ID
+			cmd.UID = ds.UID
 			cmd.Version = ds.Version
 			ss := SqlStore{db: db}
 			_, err := ss.UpdateDataSource(context.Background(), &cmd)
@@ -145,6 +146,7 @@ func TestIntegrationDataAccess(t *testing.T) {
 
 			cmd := defaultUpdateDatasourceCommand
 			cmd.ID = ds.ID
+			cmd.UID = ds.UID
 			_, err := ss.UpdateDataSource(context.Background(), &cmd)
 			require.NoError(t, err)
 
@@ -161,6 +163,7 @@ func TestIntegrationDataAccess(t *testing.T) {
 
 			cmd := datasources.UpdateDataSourceCommand{
 				ID:      ds.ID,
+				UID:     ds.UID,
 				OrgID:   10,
 				Name:    "nisse",
 				Type:    datasources.DS_GRAPHITE,
@@ -185,6 +188,7 @@ func TestIntegrationDataAccess(t *testing.T) {
 
 			cmd := &datasources.UpdateDataSourceCommand{
 				ID:     ds.ID,
+				UID:    ds.UID,
 				OrgID:  10,
 				Name:   "nisse",
 				Type:   datasources.DS_GRAPHITE,
@@ -203,6 +207,7 @@ func TestIntegrationDataAccess(t *testing.T) {
 
 			cmd := &datasources.UpdateDataSourceCommand{
 				ID:      ds.ID,
+				UID:     ds.UID,
 				OrgID:   10,
 				Name:    "nisse",
 				Type:    datasources.DS_GRAPHITE,

--- a/pkg/services/datasources/service/store_test.go
+++ b/pkg/services/datasources/service/store_test.go
@@ -131,7 +131,6 @@ func TestIntegrationDataAccess(t *testing.T) {
 			ds := initDatasource(db)
 			cmd := defaultUpdateDatasourceCommand
 			cmd.ID = ds.ID
-			cmd.UID = ds.UID
 			cmd.Version = ds.Version
 			ss := SqlStore{db: db}
 			_, err := ss.UpdateDataSource(context.Background(), &cmd)
@@ -146,7 +145,6 @@ func TestIntegrationDataAccess(t *testing.T) {
 
 			cmd := defaultUpdateDatasourceCommand
 			cmd.ID = ds.ID
-			cmd.UID = ds.UID
 			_, err := ss.UpdateDataSource(context.Background(), &cmd)
 			require.NoError(t, err)
 
@@ -163,7 +161,6 @@ func TestIntegrationDataAccess(t *testing.T) {
 
 			cmd := datasources.UpdateDataSourceCommand{
 				ID:      ds.ID,
-				UID:     ds.UID,
 				OrgID:   10,
 				Name:    "nisse",
 				Type:    datasources.DS_GRAPHITE,
@@ -188,7 +185,6 @@ func TestIntegrationDataAccess(t *testing.T) {
 
 			cmd := &datasources.UpdateDataSourceCommand{
 				ID:     ds.ID,
-				UID:    ds.UID,
 				OrgID:  10,
 				Name:   "nisse",
 				Type:   datasources.DS_GRAPHITE,
@@ -207,7 +203,6 @@ func TestIntegrationDataAccess(t *testing.T) {
 
 			cmd := &datasources.UpdateDataSourceCommand{
 				ID:      ds.ID,
-				UID:     ds.UID,
 				OrgID:   10,
 				Name:    "nisse",
 				Type:    datasources.DS_GRAPHITE,


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**
Extending invalid UID logging to also include cases where UID length is invalid. This PR follows https://github.com/grafana/grafana/issues/68447

**Why do we need this feature?**

Makes logging for invalid UID cases complete.

**Who is this feature for?**
Preparation for enforcing UID format in the future.

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #84442

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
