### PR TITLE
Fix GitHub action to add `datasource/Jaeger` label

### DIFF
--- a/.github/pr-commands.json
+++ b/.github/pr-commands.json
@@ -118,7 +118,7 @@
   },
   {
     "type": "changedfiles",
-    "matches": [ "public/app/plugins/datasource/jaeger"],
+    "matches": [ "public/app/plugins/datasource/jaeger/**/*"],
     "action": "updateLabel",
     "addLabel": "datasource/Jaeger"
   },


### PR DESCRIPTION
The path used to look for Jaeger files is incorrect and thus the `datasource/Jaeger` label is not added. This PR fixes that.