### PR TITLE
Update GitHub Actions to add `datasource/Parca` label

### DIFF
--- a/.github/pr-commands.json
+++ b/.github/pr-commands.json
@@ -148,6 +148,12 @@
   },
   {
     "type": "changedfiles",
+    "matches": [ "public/app/plugins/datasource/parca/**/*"],
+    "action": "updateLabel",
+    "addLabel": "datasource/Parca"
+  },
+  {
+    "type": "changedfiles",
     "matches": [ "public/app/plugins/datasource/grafana-pyroscope-datasource/**/*", "pkg/tsdb/grafana-pyroscope-datasource/**/*"],
     "action": "updateLabel",
     "addLabel": "datasource/grafana-pyroscope"


### PR DESCRIPTION
There is no action that adds the `datasource/Parca` when Parca files are modified. This PR fixes that.