### PR TITLE
Prometheus: Add $__interval_s and $__rate_inteval_s to go along with $__interval_ms and $__rate_interval_ms

### DIFF
--- a/docs/sources/dashboards/variables/add-template-variables/index.md
+++ b/docs/sources/dashboards/variables/add-template-variables/index.md
@@ -292,6 +292,10 @@ In the InfluxDB data source, the legacy variable `$interval` is the same variabl
 
 The InfluxDB and Elasticsearch data sources have `Group by time interval` fields that are used to hard code the interval or to set the minimum limit for the `$__interval` variable (by using the `>` syntax -> `>10m`).
 
+### $\_\_interval_s
+
+This variable is the `$__interval` variable in seconds, not a time interval formatted string. For example, if the `$__interval` is `20m` then the `$__interval_ms` is `1200`.
+
 ### $\_\_interval_ms
 
 This variable is the `$__interval` variable in milliseconds, not a time interval formatted string. For example, if the `$__interval` is `20m` then the `$__interval_ms` is `1200000`.
@@ -324,6 +328,10 @@ Currently only supported for Prometheus and Loki data sources. This variable rep
 ### $\_\_rate_interval
 
 Currently only supported for Prometheus data sources. The `$__rate_interval` variable is meant to be used in the rate function. Refer to [Prometheus query variables][] for details.
+
+### $\_\_rate_interval_s
+
+This variable is the `$__rate_interval` variable in seconds, not a time-interval-formatted string. For example, if the `$__rate_interval` is `20m` then the `$__rate_interval_s` is `1200`.
 
 ### $\_\_rate_interval_ms
 

--- a/pkg/promlib/models/query.go
+++ b/pkg/promlib/models/query.go
@@ -72,11 +72,13 @@ type PrometheusQueryProperties struct {
 // Internal interval and range variables
 const (
 	varInterval       = "$__interval"
+	varIntervalS      = "$__interval_s"
 	varIntervalMs     = "$__interval_ms"
 	varRange          = "$__range"
 	varRangeS         = "$__range_s"
 	varRangeMs        = "$__range_ms"
 	varRateInterval   = "$__rate_interval"
+	varRateIntervalS  = "$__rate_interval_s"
 	varRateIntervalMs = "$__rate_interval_ms"
 )
 
@@ -84,11 +86,13 @@ const (
 // Repetitive code, we should have functionality to unify these
 const (
 	varIntervalAlt       = "${__interval}"
+	varIntervalSAlt      = "${__interval_s}"
 	varIntervalMsAlt     = "${__interval_ms}"
 	varRangeAlt          = "${__range}"
 	varRangeSAlt         = "${__range_s}"
 	varRangeMsAlt        = "${__range_ms}"
 	varRateIntervalAlt   = "${__rate_interval}"
+	varRateIntervalSAlt  = "${__rate_interval_s}"
 	varRateIntervalMsAlt = "${__rate_interval_ms}"
 )
 
@@ -320,30 +324,34 @@ func interpolateVariables(
 	}
 
 	expr = strings.ReplaceAll(expr, varIntervalMs, strconv.FormatInt(int64(calculatedStep/time.Millisecond), 10))
+	expr = strings.ReplaceAll(expr, varIntervalS, strconv.FormatInt(int64(calculatedStep/time.Second), 10))
 	expr = strings.ReplaceAll(expr, varInterval, gtime.FormatInterval(calculatedStep))
 	expr = strings.ReplaceAll(expr, varRangeMs, strconv.FormatInt(rangeMs, 10))
 	expr = strings.ReplaceAll(expr, varRangeS, strconv.FormatInt(rangeSRounded, 10))
 	expr = strings.ReplaceAll(expr, varRange, strconv.FormatInt(rangeSRounded, 10)+"s")
 	expr = strings.ReplaceAll(expr, varRateIntervalMs, strconv.FormatInt(int64(rateInterval/time.Millisecond), 10))
+	expr = strings.ReplaceAll(expr, varRateIntervalS, strconv.FormatInt(int64(rateInterval/time.Second), 10))
 	expr = strings.ReplaceAll(expr, varRateInterval, rateInterval.String())
 
 	// Repetitive code, we should have functionality to unify these
 	expr = strings.ReplaceAll(expr, varIntervalMsAlt, strconv.FormatInt(int64(calculatedStep/time.Millisecond), 10))
+	expr = strings.ReplaceAll(expr, varIntervalSAlt, strconv.FormatInt(int64(calculatedStep/time.Second), 10))
 	expr = strings.ReplaceAll(expr, varIntervalAlt, gtime.FormatInterval(calculatedStep))
 	expr = strings.ReplaceAll(expr, varRangeMsAlt, strconv.FormatInt(rangeMs, 10))
 	expr = strings.ReplaceAll(expr, varRangeSAlt, strconv.FormatInt(rangeSRounded, 10))
 	expr = strings.ReplaceAll(expr, varRangeAlt, strconv.FormatInt(rangeSRounded, 10)+"s")
 	expr = strings.ReplaceAll(expr, varRateIntervalMsAlt, strconv.FormatInt(int64(rateInterval/time.Millisecond), 10))
+	expr = strings.ReplaceAll(expr, varRateIntervalSAlt, strconv.FormatInt(int64(rateInterval/time.Second), 10))
 	expr = strings.ReplaceAll(expr, varRateIntervalAlt, rateInterval.String())
 	return expr
 }
 
 func isVariableInterval(interval string) bool {
-	if interval == varInterval || interval == varIntervalMs || interval == varRateInterval || interval == varRateIntervalMs {
+	if interval == varInterval || interval == varIntervalS || interval == varIntervalMs || interval == varRateInterval || interval == varRateIntervalS || interval == varRateIntervalMs {
 		return true
 	}
 	// Repetitive code, we should have functionality to unify these
-	if interval == varIntervalAlt || interval == varIntervalMsAlt || interval == varRateIntervalAlt || interval == varRateIntervalMsAlt {
+	if interval == varIntervalAlt || interval == varIntervalSAlt || interval == varIntervalMsAlt || interval == varRateIntervalAlt || interval == varRateIntervalSAlt || interval == varRateIntervalMsAlt {
 		return true
 	}
 	return false


### PR DESCRIPTION
**What is this feature?**

Added two new variables $__interval_s and $__rate_inteval_s. Equivalents of already existing $__interval_ms and $__rate_inteval_ms but in seconds. 

**Why do we need this feature?**

For some usecases it is simply more convenient to operate on seconds rather milliseconds (depending on the metric). `$__rate_interval_s` is simpler and less error-prone compared to `($__rate_interval_s / 1e3)`.

Fixes #

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
