### PR TITLE
Chore: Promlib allows extendOptions to be nil

### DIFF
--- a/pkg/promlib/healthcheck.go
+++ b/pkg/promlib/healthcheck.go
@@ -16,11 +16,8 @@ const (
 	refID = "__healthcheck__"
 )
 
-var logger = backend.NewLoggerWith("logger", "tsdb.prometheus")
-
 func (s *Service) CheckHealth(ctx context.Context, req *backend.CheckHealthRequest) (*backend.CheckHealthResult,
 	error) {
-	logger := logger.FromContext(ctx)
 	ds, err := s.getInstance(ctx, req.PluginContext)
 
 	// check that the datasource exists
@@ -34,17 +31,17 @@ func (s *Service) CheckHealth(ctx context.Context, req *backend.CheckHealthReque
 
 	hc, err := healthcheck(ctx, req, ds)
 	if err != nil {
-		logger.Warn("Error performing prometheus healthcheck", "err", err.Error())
+		s.logger.Warn("Error performing prometheus healthcheck", "err", err.Error())
 		return nil, err
 	}
 
-	heuristics, err := getHeuristics(ctx, ds)
+	heuristics, err := getHeuristics(ctx, ds, s.logger)
 	if err != nil {
-		logger.Warn("Failed to get prometheus heuristics", "err", err.Error())
+		s.logger.Warn("Failed to get prometheus heuristics", "err", err.Error())
 	} else {
 		jsonDetails, err := json.Marshal(heuristics)
 		if err != nil {
-			logger.Warn("Failed to marshal heuristics", "err", err)
+			s.logger.Warn("Failed to marshal heuristics", "err", err)
 		} else {
 			hc.JSONDetails = jsonDetails
 		}

--- a/pkg/promlib/healthcheck.go
+++ b/pkg/promlib/healthcheck.go
@@ -29,19 +29,21 @@ func (s *Service) CheckHealth(ctx context.Context, req *backend.CheckHealthReque
 		return getHealthCheckMessage("", errors.New("invalid datasource info received"))
 	}
 
+	logger := s.logger.FromContext(ctx)
+
 	hc, err := healthcheck(ctx, req, ds)
 	if err != nil {
-		s.logger.Warn("Error performing prometheus healthcheck", "err", err.Error())
+		logger.Warn("Error performing prometheus healthcheck", "err", err.Error())
 		return nil, err
 	}
 
-	heuristics, err := getHeuristics(ctx, ds, s.logger)
+	heuristics, err := getHeuristics(ctx, ds, logger)
 	if err != nil {
-		s.logger.Warn("Failed to get prometheus heuristics", "err", err.Error())
+		logger.Warn("Failed to get prometheus heuristics", "err", err.Error())
 	} else {
 		jsonDetails, err := json.Marshal(heuristics)
 		if err != nil {
-			s.logger.Warn("Failed to marshal heuristics", "err", err)
+			logger.Warn("Failed to marshal heuristics", "err", err)
 		} else {
 			hc.JSONDetails = jsonDetails
 		}

--- a/pkg/promlib/healthcheck_test.go
+++ b/pkg/promlib/healthcheck_test.go
@@ -82,8 +82,10 @@ func getMockProvider[T http.RoundTripper]() *sdkhttpclient.Provider {
 func Test_healthcheck(t *testing.T) {
 	t.Run("should do a successful health check", func(t *testing.T) {
 		httpProvider := getMockProvider[*healthCheckSuccessRoundTripper]()
+		logger := backend.NewLoggerWith("logger", "test")
 		s := &Service{
-			im: datasource.NewInstanceManager(newInstanceSettings(httpProvider, backend.NewLoggerWith("logger", "test"), mockExtendClientOpts)),
+			im:     datasource.NewInstanceManager(newInstanceSettings(httpProvider, logger, mockExtendClientOpts)),
+			logger: logger,
 		}
 
 		req := &backend.CheckHealthRequest{
@@ -98,8 +100,10 @@ func Test_healthcheck(t *testing.T) {
 
 	t.Run("should return an error for an unsuccessful health check", func(t *testing.T) {
 		httpProvider := getMockProvider[*healthCheckFailRoundTripper]()
+		logger := backend.NewLoggerWith("logger", "test")
 		s := &Service{
-			im: datasource.NewInstanceManager(newInstanceSettings(httpProvider, backend.NewLoggerWith("logger", "test"), mockExtendClientOpts)),
+			im:     datasource.NewInstanceManager(newInstanceSettings(httpProvider, logger, mockExtendClientOpts)),
+			logger: logger,
 		}
 
 		req := &backend.CheckHealthRequest{

--- a/pkg/promlib/heuristics.go
+++ b/pkg/promlib/heuristics.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
+	"github.com/grafana/grafana-plugin-sdk-go/backend/log"
 )
 
 const (
@@ -85,10 +86,10 @@ func (s *Service) GetHeuristics(ctx context.Context, req HeuristicsRequest) (*He
 	if err != nil {
 		return nil, err
 	}
-	return getHeuristics(ctx, ds)
+	return getHeuristics(ctx, ds, s.logger)
 }
 
-func getHeuristics(ctx context.Context, i *instance) (*Heuristics, error) {
+func getHeuristics(ctx context.Context, i *instance, logger log.Logger) (*Heuristics, error) {
 	heuristics := Heuristics{
 		Application: "unknown",
 		Features: Features{

--- a/pkg/promlib/heuristics.go
+++ b/pkg/promlib/heuristics.go
@@ -86,7 +86,8 @@ func (s *Service) GetHeuristics(ctx context.Context, req HeuristicsRequest) (*He
 	if err != nil {
 		return nil, err
 	}
-	return getHeuristics(ctx, ds, s.logger)
+	logger := s.logger.FromContext(ctx)
+	return getHeuristics(ctx, ds, logger)
 }
 
 func getHeuristics(ctx context.Context, i *instance, logger log.Logger) (*Heuristics, error) {

--- a/pkg/promlib/heuristics_test.go
+++ b/pkg/promlib/heuristics_test.go
@@ -52,8 +52,10 @@ func Test_GetHeuristics(t *testing.T) {
 			status: http.StatusOK,
 		}
 		httpProvider := newHeuristicsSDKProvider(rt)
+		logger := backend.NewLoggerWith("logger", "test")
 		s := &Service{
-			im: datasource.NewInstanceManager(newInstanceSettings(httpProvider, backend.NewLoggerWith("logger", "test"), mockExtendClientOpts)),
+			im:     datasource.NewInstanceManager(newInstanceSettings(httpProvider, logger, mockExtendClientOpts)),
+			logger: logger,
 		}
 
 		req := HeuristicsRequest{
@@ -72,8 +74,10 @@ func Test_GetHeuristics(t *testing.T) {
 			status: http.StatusOK,
 		}
 		httpProvider := newHeuristicsSDKProvider(rt)
+		logger := backend.NewLoggerWith("logger", "test")
 		s := &Service{
-			im: datasource.NewInstanceManager(newInstanceSettings(httpProvider, backend.NewLoggerWith("logger", "test"), mockExtendClientOpts)),
+			im:     datasource.NewInstanceManager(newInstanceSettings(httpProvider, logger, mockExtendClientOpts)),
+			logger: logger,
 		}
 
 		req := HeuristicsRequest{

--- a/pkg/promlib/library.go
+++ b/pkg/promlib/library.go
@@ -52,9 +52,11 @@ func newInstanceSettings(httpClientProvider *sdkhttpclient.Provider, log log.Log
 			return nil, fmt.Errorf("error creating transport options: %v", err)
 		}
 
-		err = extendOptions(ctx, settings, opts)
-		if err != nil {
-			return nil, fmt.Errorf("error extending transport options: %v", err)
+		if extendOptions != nil {
+			err = extendOptions(ctx, settings, opts)
+			if err != nil {
+				return nil, fmt.Errorf("error extending transport options: %v", err)
+			}
 		}
 
 		httpClient, err := httpClientProvider.New(*opts)

--- a/pkg/promlib/library_test.go
+++ b/pkg/promlib/library_test.go
@@ -144,5 +144,4 @@ func mockRequest() *backend.CallResourceRequest {
 		URL:    "/api/v1/series",
 		Body:   []byte("match%5B%5D: ALERTS\nstart: 1655271408\nend: 1655293008"),
 	}
-
 }


### PR DESCRIPTION
**What is this feature?**

The `extendOptions` method can be nil and we are checking this to prevent errors and panics.
Also in `healthCheck` and `heuristics` we use the service logger instead of creating a new one. 

**Why do we need this feature?**

For a better and safer promlib

**Who is this feature for?**

Prometheus data source developers
