### PR TITLE
Alerting: Fix AlertsFolderView not showing rules when using nested folders

### DIFF
--- a/public/app/features/alerting/unified/AlertsFolderView.test.tsx
+++ b/public/app/features/alerting/unified/AlertsFolderView.test.tsx
@@ -42,13 +42,14 @@ const mockFolder = (folderOverride: Partial<FolderState> = {}): FolderState => {
 };
 
 describe('AlertsFolderView tests', () => {
-  it('Should display grafana alert rules when the namespace name matches the folder name', () => {
+  it('Should display grafana alert rules when the folder uid matches the name space uid', () => {
     // Arrange
     const folder = mockFolder();
 
     const grafanaNamespace: CombinedRuleNamespace = {
       name: folder.title,
       rulesSource: GRAFANA_RULES_SOURCE_NAME,
+      uid: 'folder-1',
       groups: [
         {
           name: 'group1',
@@ -91,13 +92,14 @@ describe('AlertsFolderView tests', () => {
     expect(alertRows[5]).toHaveTextContent('Test Alert 6');
   });
 
-  it('Should not display alert rules when the namespace name does not match the folder name', () => {
+  it('Should not display alert rules when the namespace uid does not match the folder uid', () => {
     // Arrange
     const folder = mockFolder();
 
     const grafanaNamespace: CombinedRuleNamespace = {
       name: 'Folder without alerts',
       rulesSource: GRAFANA_RULES_SOURCE_NAME,
+      uid: 'folder-2',
       groups: [
         {
           name: 'default',
@@ -130,6 +132,7 @@ describe('AlertsFolderView tests', () => {
     const grafanaNamespace: CombinedRuleNamespace = {
       name: folder.title,
       rulesSource: GRAFANA_RULES_SOURCE_NAME,
+      uid: 'folder-1',
       groups: [
         {
           name: 'default',
@@ -162,6 +165,7 @@ describe('AlertsFolderView tests', () => {
     const grafanaNamespace: CombinedRuleNamespace = {
       name: folder.title,
       rulesSource: GRAFANA_RULES_SOURCE_NAME,
+      uid: 'folder-1',
       groups: [
         {
           name: 'default',

--- a/public/app/features/alerting/unified/AlertsFolderView.tsx
+++ b/public/app/features/alerting/unified/AlertsFolderView.tsx
@@ -50,7 +50,8 @@ export const AlertsFolderView = ({ folder }: Props) => {
   const { nameFilter, labelFilter, sortOrder, setNameFilter, setLabelFilter, setSortOrder } =
     useAlertsFolderViewParams();
 
-  const matchingNamespace = combinedNamespaces.find((namespace) => namespace.name === folder.title);
+  const matchingNamespace = combinedNamespaces.find((namespace) => namespace.uid === folder.uid);
+
   const alertRules = matchingNamespace?.groups.flatMap((group) => group.rules) ?? [];
 
   const filteredRules = filterAndSortRules(alertRules, nameFilter, labelFilter, sortOrder ?? SortOrder.Ascending);


### PR DESCRIPTION
**What is this feature?**

This PR fixes the Alerts Folder View not showing the rules that match the folder when using nested folders.

**Special notes for your reviewer:**
After the fix, enabling nested folders:

<img width="566" alt="Screenshot 2024-03-14 at 14 18 46" src="https://github.com/grafana/grafana/assets/33540275/c94471bc-a4a1-4360-a629-17df38c756b2">


Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
