### PR TITLE
Access Control: Get global role from request params

### DIFF
--- a/pkg/services/accesscontrol/middleware.go
+++ b/pkg/services/accesscontrol/middleware.go
@@ -352,6 +352,15 @@ func UseGlobalOrgFromRequestData(c *contextmodel.ReqContext) (int64, error) {
 	return c.SignedInUser.GetOrgID(), nil
 }
 
+// UseGlobalOrgFromRequestParams returns global org if `global` flag is set or the org where user is logged in.
+func UseGlobalOrgFromRequestParams(c *contextmodel.ReqContext) (int64, error) {
+	if c.QueryBool("global") {
+		return GlobalOrgID, nil
+	}
+
+	return c.SignedInUser.GetOrgID(), nil
+}
+
 func getOrgQueryFromRequest(c *contextmodel.ReqContext) (*QueryWithOrg, error) {
 	query := &QueryWithOrg{}
 


### PR DESCRIPTION
**What is this feature?**

It's an extension of #84359, we need to read `global` flag for some requests that refer to the global org.

**Why do we need this feature?**

Useful in combination with AuthorizeInOrgMiddleware().

**Who is this feature for?**

[Add information on what kind of user the feature is for.]

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
