### PR TITLE
nullToValueField: clear field.state.calcs on change

### DIFF
--- a/packages/grafana-data/src/transformations/transformers/nulls/nullToValue.ts
+++ b/packages/grafana-data/src/transformations/transformers/nulls/nullToValue.ts
@@ -17,15 +17,22 @@ export function nullToValue(frame: DataFrame) {
 
 export function nullToValueField(field: Field, noValue: number) {
   const transformedVals = field.values.slice();
+  let changed = false;
 
   for (let i = 0; i < transformedVals.length; i++) {
     if (transformedVals[i] === null) {
       transformedVals[i] = noValue;
+      changed = true;
     }
   }
 
   return {
     ...field,
+    // clear field.state.calcs if anything changed
+    state: {
+      ...field.state,
+      calcs: changed ? undefined : field.state?.calcs,
+    },
     values: transformedVals,
   };
 }


### PR DESCRIPTION
Close https://github.com/grafana/grafana/issues/84483. This fixes the issue for me, but there might be a better way (e.g. setting noValue on the first call to reduceField() so that the cached value is correct).