### PR TITLE
Visualizations-TablePanel: added YouTube link to Table Panel

### DIFF
--- a/docs/sources/panels-visualizations/visualizations/table/index.md
+++ b/docs/sources/panels-visualizations/visualizations/table/index.md
@@ -31,7 +31,7 @@ Tables are very flexible, supporting multiple modes for time series and for tabl
 
 {{< figure src="/static/img/docs/tables/table_visualization.png" max-width="1200px" lightbox="true" caption="Table visualization" >}}
 
-The following video will give you a visual walkthrough over the configurations and settings you can set in a table panel. If you get stuck not knowing where is a setting in the documentation or want to see a configuration in action, check it out in the video below.
+The following video provides a visual walkthrough of the options you can set in a table visualization. If you want to see a configuration in action, check it out in the video:
 
 {{< youtube id="PCY7O8EJeJY" >}}
 

--- a/docs/sources/panels-visualizations/visualizations/table/index.md
+++ b/docs/sources/panels-visualizations/visualizations/table/index.md
@@ -31,7 +31,7 @@ Tables are very flexible, supporting multiple modes for time series and for tabl
 
 {{< figure src="/static/img/docs/tables/table_visualization.png" max-width="1200px" lightbox="true" caption="Table visualization" >}}
 
-<!--add intro sentence here -->
+The following video will give you a visual walkthrough over the configurations and settings you can set in a table panel. If you get stuck not knowing where is a setting in the documentation or want to see a configuration in action, check it out in the video below.
 
 {{< youtube id="PCY7O8EJeJY" >}}
 

--- a/docs/sources/panels-visualizations/visualizations/table/index.md
+++ b/docs/sources/panels-visualizations/visualizations/table/index.md
@@ -27,6 +27,9 @@ weight: 100
 
 # Table
 
+{{< youtube id="PCY7O8EJeJY" >}}
+
+
 Tables are very flexible, supporting multiple modes for time series and for tables, annotation, and raw JSON data. This visualization also provides date formatting, value formatting, and coloring options. In addition to formatting and coloring options, Grafana also provides a variety of _Cell types_ which you can use to display gauges, sparklines, and other rich data displays.
 
 {{< figure src="/static/img/docs/tables/table_visualization.png" max-width="1200px" lightbox="true" caption="Table visualization" >}}

--- a/docs/sources/panels-visualizations/visualizations/table/index.md
+++ b/docs/sources/panels-visualizations/visualizations/table/index.md
@@ -27,12 +27,13 @@ weight: 100
 
 # Table
 
-{{< youtube id="PCY7O8EJeJY" >}}
-
-
 Tables are very flexible, supporting multiple modes for time series and for tables, annotation, and raw JSON data. This visualization also provides date formatting, value formatting, and coloring options. In addition to formatting and coloring options, Grafana also provides a variety of _Cell types_ which you can use to display gauges, sparklines, and other rich data displays.
 
 {{< figure src="/static/img/docs/tables/table_visualization.png" max-width="1200px" lightbox="true" caption="Table visualization" >}}
+
+<!--add intro sentence here -->
+
+{{< youtube id="PCY7O8EJeJY" >}}
 
 ## Annotation and alert support
 

--- a/docs/sources/panels-visualizations/visualizations/table/index.md
+++ b/docs/sources/panels-visualizations/visualizations/table/index.md
@@ -31,7 +31,7 @@ Tables are very flexible, supporting multiple modes for time series and for tabl
 
 {{< figure src="/static/img/docs/tables/table_visualization.png" max-width="1200px" lightbox="true" caption="Table visualization" >}}
 
-The following video provides a visual walkthrough of the options you can set in a table visualization. If you want to see a configuration in action, check it out in the video:
+The following video provides a visual walkthrough of the options you can set in a table visualization. If you want to see a configuration in action, check out the video:
 
 {{< youtube id="PCY7O8EJeJY" >}}
 


### PR DESCRIPTION
**What is this feature?**

A video was published about the Table panel visualizations.
Added the YouTube link to the Table Panel Visualization page.

**Why do we need this feature?**

Add capacity to users to view how the steps are done.

**Who is this feature for?**

Everyone checking the docs about Table Panels.

**Which issue(s) does this PR fix?**:

N/A

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [x] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
