### PR TITLE
RBAC: Don't refetch permissions when searching for users in authenticated org

### DIFF
--- a/pkg/api/org_users.go
+++ b/pkg/api/org_users.go
@@ -324,10 +324,13 @@ func (hs *HTTPServer) searchOrgUsersHelper(c *contextmodel.ReqContext, query *or
 	// Get accesscontrol metadata and IPD labels for users in the target org
 	accessControlMetadata := map[string]accesscontrol.Metadata{}
 	if c.QueryBool("accesscontrol") {
-		permissionsList, err := hs.accesscontrolService.GetUserPermissionsInOrg(c.Req.Context(), c.SignedInUser, query.OrgID)
-		permissions := accesscontrol.GroupScopesByAction(permissionsList)
-		if err != nil {
-			return nil, err
+		permissions := c.SignedInUser.GetPermissions()
+		if query.OrgID != c.SignedInUser.GetOrgID() {
+			permissionsList, err := hs.accesscontrolService.GetUserPermissionsInOrg(c.Req.Context(), c.SignedInUser, query.OrgID)
+			if err != nil {
+				return nil, err
+			}
+			permissions = accesscontrol.GroupScopesByAction(permissionsList)
 		}
 		accessControlMetadata = accesscontrol.GetResourcesMetadata(c.Req.Context(), permissions, "users:id:", userIDs)
 	}


### PR DESCRIPTION
**What is this feature?**
The user search query in org became reallly slow on bigger instances after https://github.com/grafana/grafana/pull/83392.

When we are searching for users in currently authenticated org we do not have to refetch all permissions. This is the first pr to improve this.

To improve the other case, when searching for users in a different org than the one the user is authenticated in, we could "re-authenticate" the user in that org using authnService and then call GetUserPermission so we don't have to rely on permission search.

**Which issue(s) does this PR fix?**:

Part of https://github.com/grafana/grafana/issues/84541

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
