### PR TITLE
[v10.4.x] Alerting docs: Fix broken links in TF Provisioning page

### DIFF
--- a/docs/sources/alerting/set-up/provision-alerting-resources/terraform-provisioning/index.md
+++ b/docs/sources/alerting/set-up/provision-alerting-resources/terraform-provisioning/index.md
@@ -393,17 +393,17 @@ For more examples on the concept of this guide:
 [alerting-rules]: "/docs/grafana/ -> /docs/grafana/<GRAFANA_VERSION>/alerting/alerting-rules"
 [alerting-rules]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/alerting-and-irm/alerting/alerting-rules"
 
-[contact-points]: "/docs/grafana/ -> /docs/grafana/<GRAFANA_VERSION>/alerting/configure-notifications/manage-contact-points"
-[contact-points]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/alerting-and-irm/alerting/configure-notifications/manage-contact-points"
+[contact-points]: "/docs/grafana/ -> /docs/grafana/<GRAFANA_VERSION>/alerting/manage-notifications/manage-contact-points"
+[contact-points]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/alerting-and-irm/alerting/manage-notifications/manage-contact-points"
 
-[mute-timings]: "/docs/grafana/ -> /docs/grafana/<GRAFANA_VERSION>/alerting/configure-notifications/mute-timings"
-[mute-timings]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/alerting-and-irm/alerting/configure-notifications/mute-timings"
+[mute-timings]: "/docs/grafana/ -> /docs/grafana/<GRAFANA_VERSION>/alerting/manage-notifications/mute-timings"
+[mute-timings]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/alerting-and-irm/alerting/manage-notifications/mute-timings"
 
-[notification-policy]: "/docs/grafana/ -> /docs/grafana/<GRAFANA_VERSION>/alerting/configure-notifications/create-notification-policy"
-[notification-policy]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/alerting-and-irm/alerting/configure-notifications/create-notification-policy"
+[notification-policy]: "/docs/grafana/ -> /docs/grafana/<GRAFANA_VERSION>/alerting/alerting-rules/create-notification-policy"
+[notification-policy]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/alerting-and-irm/alerting/alerting-rules/create-notification-policy"
 
-[notification-template]: "/docs/grafana/ -> /docs/grafana/<GRAFANA_VERSION>/alerting/configure-notifications/template-notifications"
-[notification-template]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/alerting-and-irm/alerting/configure-notifications/template-notifications"
+[notification-template]: "/docs/grafana/ -> /docs/grafana/<GRAFANA_VERSION>/alerting/manage-notifications/template-notifications"
+[notification-template]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/alerting-and-irm/alerting/manage-notifications/template-notifications"
 
 [alerting_export]: "/docs/grafana/ -> /docs/grafana/<GRAFANA_VERSION>/alerting/set-up/provision-alerting-resources/export-alerting-resources"
 [alerting_export]: "/docs/grafana-cloud/ -> /docs/grafana/<GRAFANA_VERSION>/alerting/set-up/provision-alerting-resources/export-alerting-resources"


### PR DESCRIPTION
Fix errors:


```
WARN  [en] REF_NOT_FOUND: Ref "/docs/grafana/v10.4/alerting/configure-notifications/template-notifications" from page "docs/grafana/v10.4/alerting/set-up/provision-alerting-resources/terraform-provisioning/index.md": page not found

WARN  [en] REF_NOT_FOUND: Ref "/docs/grafana/v10.4/alerting/configure-notifications/create-notification-policy" from page "docs/grafana/v10.4/alerting/set-up/provision-alerting-resources/terraform-provisioning/index.md": page not found

WARN  [en] REF_NOT_FOUND: Ref "/docs/grafana/v10.4/alerting/configure-notifications/mute-timings" from page "docs/grafana/v10.4/alerting/set-up/provision-alerting-resources/terraform-provisioning/index.md": page not found

WARN  [en] REF_NOT_FOUND: Ref "/docs/grafana/v10.4/alerting/configure-notifications/manage-contact-points" from page "docs/grafana/v10.4/alerting/set-up/provision-alerting-resources/terraform-provisioning/index.md": page not found

```

```
WARN  [en] REF_NOT_FOUND: Ref "/docs/grafana/latest/alerting/configure-notifications/template-notifications" from page "docs/grafana/latest/alerting/set-up/provision-alerting-resources/terraform-provisioning/index.md": page not found

WARN  [en] REF_NOT_FOUND: Ref "/docs/grafana/latest/alerting/configure-notifications/create-notification-policy" from page "docs/grafana/latest/alerting/set-up/provision-alerting-resources/terraform-provisioning/index.md": page not found

WARN  [en] REF_NOT_FOUND: Ref "/docs/grafana/latest/alerting/configure-notifications/mute-timings" from page "docs/grafana/latest/alerting/set-up/provision-alerting-resources/terraform-provisioning/index.md": page not found

WARN  [en] REF_NOT_FOUND: Ref "/docs/grafana/latest/alerting/configure-notifications/manage-contact-points" from page "docs/grafana/latest/alerting/set-up/provision-alerting-resources/terraform-provisioning/index.md": page not found
```