### PR TITLE
Logs popover: allow click listeners to run before closing the menu

### DIFF
--- a/public/app/features/logs/components/LogRows.tsx
+++ b/public/app/features/logs/components/LogRows.tsx
@@ -151,7 +151,7 @@ class UnThemedLogRows extends PureComponent<Props, State> {
     // Otherwise selectionchange fires before other click listeners, potentially skipping user actions.
     setTimeout(() => {
       this.closePopoverMenu();
-    }, 100)
+    }, 100);
   };
 
   closePopoverMenu = () => {

--- a/public/app/features/logs/components/LogRows.tsx
+++ b/public/app/features/logs/components/LogRows.tsx
@@ -151,7 +151,7 @@ class UnThemedLogRows extends PureComponent<Props, State> {
     // Otherwise selectionchange fires before other click listeners, potentially skipping user actions.
     setTimeout(() => {
       this.closePopoverMenu();
-    }, 250)
+    }, 100)
   };
 
   closePopoverMenu = () => {

--- a/public/app/features/logs/components/LogRows.tsx
+++ b/public/app/features/logs/components/LogRows.tsx
@@ -147,7 +147,11 @@ class UnThemedLogRows extends PureComponent<Props, State> {
     if (document.getSelection()?.toString()) {
       return;
     }
-    this.closePopoverMenu();
+    // Give time to the browser to process click events originating from the menu before closing it.
+    // Otherwise selectionchange fires before other click listeners, potentially skipping user actions.
+    setTimeout(() => {
+      this.closePopoverMenu();
+    }, 250)
   };
 
   closePopoverMenu = () => {
@@ -177,6 +181,7 @@ class UnThemedLogRows extends PureComponent<Props, State> {
   componentWillUnmount() {
     document.removeEventListener('click', this.handleDeselection);
     document.removeEventListener('contextmenu', this.handleDeselection);
+    document.removeEventListener('selectionchange', this.handleDeselection);
     if (this.renderAllTimer) {
       clearTimeout(this.renderAllTimer);
     }


### PR DESCRIPTION
We recently added a `selectionchange` listener, to close the menu when the user clicked on the selected text, but as a side effect, in Chrome, it stopped reacting to user actions within the menu.

Here, we're adding a small time buffer to allow the browser to process click events before closing the menu, without losing the fix to close the menu when the selection is cleared.