### PR TITLE
datatrails: add ability to deselect currently metric

### DIFF
--- a/public/app/features/trails/DataTrailsHistory.tsx
+++ b/public/app/features/trails/DataTrailsHistory.tsx
@@ -69,7 +69,7 @@ export class DataTrailHistory extends SceneObjectBase<DataTrailsHistoryState> {
           this.state.steps[0].trailState = sceneUtils.cloneSceneObjectState(oldState, { history: this });
         }
 
-        if (newState.metric) {
+        if (newState.metric || oldState.metric) {
           this.addTrailStep(trail, 'metric');
         }
       }
@@ -131,7 +131,7 @@ export class DataTrailHistory extends SceneObjectBase<DataTrailsHistoryState> {
     return (
       <Stack direction="column">
         <div>{step.type}</div>
-        {step.type === 'metric' && <div>{step.trailState.metric}</div>}
+        {step.type === 'metric' && <div>{step.trailState.metric || '<deselected>'}</div>}
       </Stack>
     );
   }
@@ -163,29 +163,38 @@ export class DataTrailHistory extends SceneObjectBase<DataTrailsHistoryState> {
     return (
       <div className={styles.container}>
         <div className={styles.heading}>History</div>
-        {steps.map((step, index) => (
-          <Tooltip content={() => model.renderStepTooltip(step)} key={index}>
-            <button
-              className={cx(
-                // Base for all steps
-                styles.step,
-                // Specifics per step type
-                styles.stepTypes[step.type],
-                // To highlight selected step
-                model.state.currentStep === index ? styles.stepSelected : '',
-                // To alter the look of steps with distant non-directly preceding parent
-                alternatePredecessorStyle.get(index) ?? '',
-                // To remove direct link for steps that don't have a direct parent
-                index !== step.parentIndex + 1 ? styles.stepOmitsDirectLeftLink : '',
-                // To remove the direct parent link on the start node as well
-                index === 0 ? styles.stepOmitsDirectLeftLink : '',
-                // To darken steps that aren't the current step's ancesters
-                !ancestry.has(index) ? styles.stepIsNotAncestorOfCurrent : ''
-              )}
-              onClick={() => model.goBackToStep(index)}
-            ></button>
-          </Tooltip>
-        ))}
+        {steps.map((step, index) => {
+          let stepType = step.type;
+
+          if (stepType === 'metric' && step.trailState.metric === undefined) {
+            // If we're resetting the metric, we want it to look like a start node
+            stepType = 'start';
+          }
+
+          return (
+            <Tooltip content={() => model.renderStepTooltip(step)} key={index}>
+              <button
+                className={cx(
+                  // Base for all steps
+                  styles.step,
+                  // Specifics per step type
+                  styles.stepTypes[stepType],
+                  // To highlight selected step
+                  model.state.currentStep === index ? styles.stepSelected : '',
+                  // To alter the look of steps with distant non-directly preceding parent
+                  alternatePredecessorStyle.get(index) ?? '',
+                  // To remove direct link for steps that don't have a direct parent
+                  index !== step.parentIndex + 1 ? styles.stepOmitsDirectLeftLink : '',
+                  // To remove the direct parent link on the start node as well
+                  index === 0 ? styles.stepOmitsDirectLeftLink : '',
+                  // To darken steps that aren't the current step's ancesters
+                  !ancestry.has(index) ? styles.stepIsNotAncestorOfCurrent : ''
+                )}
+                onClick={() => model.goBackToStep(index)}
+              ></button>
+            </Tooltip>
+          );
+        })}
       </div>
     );
   };

--- a/public/app/features/trails/DataTrailsHistory.tsx
+++ b/public/app/features/trails/DataTrailsHistory.tsx
@@ -131,7 +131,7 @@ export class DataTrailHistory extends SceneObjectBase<DataTrailsHistoryState> {
     return (
       <Stack direction="column">
         <div>{step.type}</div>
-        {step.type === 'metric' && <div>{step.trailState.metric || '<deselected>'}</div>}
+        {step.type === 'metric' && <div>{step.trailState.metric || 'Select new metric'}</div>}
       </Stack>
     );
   }

--- a/public/app/features/trails/MetricScene.tsx
+++ b/public/app/features/trails/MetricScene.tsx
@@ -29,6 +29,7 @@ import {
   ActionViewType,
   getVariablesWithMetricConstant,
   MakeOptional,
+  MetricSelectedEvent,
   trailDS,
   VAR_GROUP_BY,
   VAR_METRIC_EXPR,
@@ -150,6 +151,13 @@ export class MetricActionBar extends SceneObjectBase<MetricActionBarState> {
       <Box paddingY={1}>
         <div className={styles.actions}>
           <Stack gap={1}>
+            <ToolbarButton
+              variant={'canvas'}
+              tooltip="Deselect current metric so a new metric can be chosen"
+              onClick={() => trail.publishEvent(new MetricSelectedEvent(undefined))}
+            >
+              Select new metric
+            </ToolbarButton>
             <ToolbarButton
               variant={'canvas'}
               icon="compass"

--- a/public/app/features/trails/MetricScene.tsx
+++ b/public/app/features/trails/MetricScene.tsx
@@ -153,7 +153,7 @@ export class MetricActionBar extends SceneObjectBase<MetricActionBarState> {
           <Stack gap={1}>
             <ToolbarButton
               variant={'canvas'}
-              tooltip="Deselect current metric so a new metric can be chosen"
+              tooltip="Remove existing metric and choose a new metric"
               onClick={() => trail.publishEvent(new MetricSelectedEvent(undefined))}
             >
               Select new metric

--- a/public/app/features/trails/shared.ts
+++ b/public/app/features/trails/shared.ts
@@ -44,6 +44,6 @@ export function getVariablesWithMetricConstant(metric: string) {
   ];
 }
 
-export class MetricSelectedEvent extends BusEventWithPayload<string> {
+export class MetricSelectedEvent extends BusEventWithPayload<string | undefined> {
   public static type = 'metric-selected-event';
 }


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

Added an option to remove the currently selected metric, and return to the main metric selector.
![image](https://github.com/grafana/grafana/assets/38694490/6ae8693f-a78e-4092-ade0-0b32eb01586c)

Creates a new trail node for metric changed.
![image](https://github.com/grafana/grafana/assets/38694490/4c9fd35d-a03d-4ee7-ba87-14188d673446)
It looks similar to the start node, as it is a sort of restart.

**Special notes for your reviewer:**

- [ ] Decide on which button/menu approach works best
- [ ] Decide how to display the metric change node to indicate that the metric has been deselected
- [x] Use a 'green' start/clear node instead of orange

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
