### PR TITLE
DashboardScene: Reset editIndex on variable delete

### DIFF
--- a/public/app/features/dashboard-scene/settings/VariablesEditView.test.tsx
+++ b/public/app/features/dashboard-scene/settings/VariablesEditView.test.tsx
@@ -145,9 +145,11 @@ describe('VariablesEditView', () => {
     });
 
     it('should delete a variable', () => {
-      variableView.setState({ editIndex: 0 });
-      expect(variableView.state.editIndex).toBe(0);
       const variableIdentifier = 'customVar';
+
+      variableView.onEdit(variableIdentifier);
+      expect(variableView.state.editIndex).toBe(0);
+
       variableView.onDelete(variableIdentifier);
       expect(variableView.getVariables()).toHaveLength(2);
       expect(variableView.getVariables()[0].state.name).toBe('customVar2');

--- a/public/app/features/dashboard-scene/settings/VariablesEditView.test.tsx
+++ b/public/app/features/dashboard-scene/settings/VariablesEditView.test.tsx
@@ -145,10 +145,13 @@ describe('VariablesEditView', () => {
     });
 
     it('should delete a variable', () => {
+      variableView.setState({ editIndex: 0 });
+      expect(variableView.state.editIndex).toBe(0);
       const variableIdentifier = 'customVar';
       variableView.onDelete(variableIdentifier);
       expect(variableView.getVariables()).toHaveLength(2);
       expect(variableView.getVariables()[0].state.name).toBe('customVar2');
+      expect(variableView.state.editIndex).toBeUndefined();
     });
 
     it('should change order of variables', () => {

--- a/public/app/features/dashboard-scene/settings/VariablesEditView.tsx
+++ b/public/app/features/dashboard-scene/settings/VariablesEditView.tsx
@@ -78,6 +78,8 @@ export class VariablesEditView extends SceneObjectBase<VariablesEditViewState> i
 
     // Update the state or the variables array
     this.getVariableSet().setState({ variables: updatedVariables });
+    // Remove editIndex otherwise switches to next variable in list
+    this.setState({ editIndex: undefined });
   };
 
   public getVariables() {
@@ -278,6 +280,8 @@ function VariableEditorSettingsView({
         onGoBack={onGoBack}
         onDelete={onDelete}
         onValidateVariableName={onValidateVariableName}
+        // force refresh when navigating using back/forward between variables
+        key={variable.state.key}
       />
     </Page>
   );


### PR DESCRIPTION
- [x] reset `editIndex` on variable delete
- [x] force remount of `VariableEditorForm` on variable change via `key` prop (used when navigating between varibles with back/forward) 
             - this is an alternative to resetting `defaultValue`/`value` in `VariableTextField` elements that don't refresh when navigating between variables


**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #83613

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
