### PR TITLE
[v10.4.x] InfluxDB: Fix interpolation of multi value template variables by adding parenthesis around them

### DIFF
--- a/public/app/plugins/datasource/influxdb/datasource.test.ts
+++ b/public/app/plugins/datasource/influxdb/datasource.test.ts
@@ -452,7 +452,7 @@ describe('InfluxDataSource Frontend Mode', () => {
           .withIncludeAll(true)
           .build();
         const result = ds.interpolateQueryExpr(value, variableMock, 'select from /^($tempVar)$/');
-        const expectation = `env|env2|env3`;
+        const expectation = `(env|env2|env3)`;
         expect(result).toBe(expectation);
       });
 
@@ -476,7 +476,7 @@ describe('InfluxDataSource Frontend Mode', () => {
         const value = [`/special/path`, `/some/other/path`];
         const variableMock = queryBuilder().withId('tempVar').withName('tempVar').withMulti().build();
         const result = ds.interpolateQueryExpr(value, variableMock, `select that where path = '$tempVar'`);
-        const expectation = `\\/special\\/path|\\/some\\/other\\/path`;
+        const expectation = `(\\/special\\/path|\\/some\\/other\\/path)`;
         expect(result).toBe(expectation);
       });
 
@@ -505,7 +505,7 @@ describe('InfluxDataSource Frontend Mode', () => {
           .build();
         const value = [`/special/path`, `/some/other/path`];
         const result = ds.interpolateQueryExpr(value, variableMock, `select that where path = /$tempVar/`);
-        const expectation = `\\/special\\/path|\\/some\\/other\\/path`;
+        const expectation = `(\\/special\\/path|\\/some\\/other\\/path)`;
         expect(result).toBe(expectation);
       });
     });

--- a/public/app/plugins/datasource/influxdb/datasource.ts
+++ b/public/app/plugins/datasource/influxdb/datasource.ts
@@ -309,7 +309,8 @@ export default class InfluxDatasource extends DataSourceWithBackend<InfluxQuery,
       }
 
       // If the value is a string array first escape them then join them with pipe
-      return value.map((v) => escapeRegex(v)).join('|');
+      // then put inside parenthesis.
+      return `(${value.map((v) => escapeRegex(v)).join('|')})`;
     }
 
     // If the variable is not a multi-value variable
@@ -324,7 +325,8 @@ export default class InfluxDatasource extends DataSourceWithBackend<InfluxQuery,
       }
 
       // If the value is a string array first escape them then join them with pipe
-      return value.map((v) => escapeRegex(v)).join('|');
+      // then put inside parenthesis.
+      return `(${value.map((v) => escapeRegex(v)).join('|')})`;
     }
 
     return value;


### PR DESCRIPTION
Backport 757fa06b85f8e1e9d416134e383fc15d7d521fa7 from #83577

---

**What is this feature?**

Historically we put parenthesis around multi-value template variables. But during the series of interpolation fixes that was missed. Since it wasn't covered with unit tests we couldn't detect the problem. This PR is addressing this issue.

**Why do we need this feature?**

Better interpolation

**Who is this feature for?**

InfluxDB users with template variables which has "multi-value" or "include all" configuration

**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/grafana/issues/83538


