### PR TITLE
Alerting: Log expression command types during evaluation

### DIFF
--- a/pkg/expr/classic/classic.go
+++ b/pkg/expr/classic/classic.go
@@ -216,6 +216,10 @@ func (cmd *ConditionsCmd) executeCond(_ context.Context, _ time.Time, cond condi
 	return isCondFiring, isCondNoData, matches, nil
 }
 
+func (cmd *ConditionsCmd) String() string {
+	return "classic_condition"
+}
+
 func compareWithOperator(b1, b2 bool, operator ConditionOperatorType) bool {
 	if operator == "or" {
 		return b1 || b2

--- a/pkg/expr/classic/classic.go
+++ b/pkg/expr/classic/classic.go
@@ -216,7 +216,7 @@ func (cmd *ConditionsCmd) executeCond(_ context.Context, _ time.Time, cond condi
 	return isCondFiring, isCondNoData, matches, nil
 }
 
-func (cmd *ConditionsCmd) String() string {
+func (cmd *ConditionsCmd) Type() string {
 	return "classic_condition"
 }
 

--- a/pkg/expr/commands.go
+++ b/pkg/expr/commands.go
@@ -17,6 +17,7 @@ import (
 
 // Command is an interface for all expression commands.
 type Command interface {
+	fmt.Stringer
 	NeedsVars() []string
 	Execute(ctx context.Context, now time.Time, vars mathexp.Vars, tracer tracing.Tracer) (mathexp.Results, error)
 }
@@ -73,6 +74,10 @@ func (gm *MathCommand) Execute(ctx context.Context, _ time.Time, vars mathexp.Va
 	span.SetAttributes(attribute.String("expression", gm.RawExpression))
 	defer span.End()
 	return gm.Expression.Execute(gm.refID, vars, tracer)
+}
+
+func (gm *MathCommand) String() string {
+	return TypeMath.String()
 }
 
 // ReduceCommand is an expression command for reduction of a timeseries such as a min, mean, or max.
@@ -201,6 +206,10 @@ func (gr *ReduceCommand) Execute(ctx context.Context, _ time.Time, vars mathexp.
 	return newRes, nil
 }
 
+func (gr *ReduceCommand) String() string {
+	return TypeReduce.String()
+}
+
 // ResampleCommand is an expression command for resampling of a timeseries.
 type ResampleCommand struct {
 	Window        time.Duration
@@ -312,6 +321,10 @@ func (gr *ResampleCommand) Execute(ctx context.Context, now time.Time, vars math
 	return newRes, nil
 }
 
+func (gr *ResampleCommand) String() string {
+	return TypeResample.String()
+}
+
 // CommandType is the type of the expression command.
 type CommandType int
 
@@ -342,6 +355,8 @@ func (gt CommandType) String() string {
 		return "resample"
 	case TypeClassicConditions:
 		return "classic_conditions"
+	case TypeThreshold:
+		return "threshold"
 	case TypeSQL:
 		return "sql"
 	default:

--- a/pkg/expr/commands.go
+++ b/pkg/expr/commands.go
@@ -17,9 +17,9 @@ import (
 
 // Command is an interface for all expression commands.
 type Command interface {
-	fmt.Stringer
 	NeedsVars() []string
 	Execute(ctx context.Context, now time.Time, vars mathexp.Vars, tracer tracing.Tracer) (mathexp.Results, error)
+	Type() string
 }
 
 // MathCommand is a command for a math expression such as "1 + $GA / 2"
@@ -76,7 +76,7 @@ func (gm *MathCommand) Execute(ctx context.Context, _ time.Time, vars mathexp.Va
 	return gm.Expression.Execute(gm.refID, vars, tracer)
 }
 
-func (gm *MathCommand) String() string {
+func (gm *MathCommand) Type() string {
 	return TypeMath.String()
 }
 
@@ -206,7 +206,7 @@ func (gr *ReduceCommand) Execute(ctx context.Context, _ time.Time, vars mathexp.
 	return newRes, nil
 }
 
-func (gr *ReduceCommand) String() string {
+func (gr *ReduceCommand) Type() string {
 	return TypeReduce.String()
 }
 
@@ -321,7 +321,7 @@ func (gr *ResampleCommand) Execute(ctx context.Context, now time.Time, vars math
 	return newRes, nil
 }
 
-func (gr *ResampleCommand) String() string {
+func (gr *ResampleCommand) Type() string {
 	return TypeResample.String()
 }
 

--- a/pkg/expr/graph.go
+++ b/pkg/expr/graph.go
@@ -138,14 +138,14 @@ func (dp *DataPipeline) UniqueCommands() []string {
 		switch t := node.(type) {
 		case *CMDNode:
 			if t.Command != nil {
-				name = fmt.Sprintf("expr(%s)", t.Command)
+				name = fmt.Sprintf("expr(%s)", t.Command.Type())
 			}
 		case *DSNode:
 			if t.datasource != nil {
 				name = t.datasource.Type
 			}
 		case *MLNode:
-			name = fmt.Sprintf("ml(%s)", t.command)
+			name = fmt.Sprintf("ml(%s)", t.command.Type())
 		}
 		if name == "" {
 			continue

--- a/pkg/expr/hysteresis.go
+++ b/pkg/expr/hysteresis.go
@@ -77,7 +77,7 @@ func (h *HysteresisCommand) Execute(ctx context.Context, now time.Time, vars mat
 	return mathexp.Results{Values: append(loadingResults.Values, unloadingResults.Values...)}, nil
 }
 
-func (h HysteresisCommand) String() string {
+func (h HysteresisCommand) Type() string {
 	return "hysteresis"
 }
 

--- a/pkg/expr/hysteresis.go
+++ b/pkg/expr/hysteresis.go
@@ -77,6 +77,10 @@ func (h *HysteresisCommand) Execute(ctx context.Context, now time.Time, vars mat
 	return mathexp.Results{Values: append(loadingResults.Values, unloadingResults.Values...)}, nil
 }
 
+func (h HysteresisCommand) String() string {
+	return "hysteresis"
+}
+
 func NewHysteresisCommand(refID string, referenceVar string, loadCondition ThresholdCommand, unloadCondition ThresholdCommand, l Fingerprints) (*HysteresisCommand, error) {
 	return &HysteresisCommand{
 		RefID:                  refID,

--- a/pkg/expr/ml/node.go
+++ b/pkg/expr/ml/node.go
@@ -31,6 +31,8 @@ type Command interface {
 	// Execute creates a payload send request to the ML API by calling the function argument sendRequest, and then parses response.
 	// Function sendRequest is supposed to abstract the client configuration such creating http request, adding authorization parameters, host etc.
 	Execute(from, to time.Time, sendRequest func(method string, path string, payload []byte) (response.Response, error)) (*backend.QueryDataResponse, error)
+
+	Type() string
 }
 
 // UnmarshalCommand parses a config parameters and creates a command. Requires key `type` to be specified.

--- a/pkg/expr/ml/outlier.go
+++ b/pkg/expr/ml/outlier.go
@@ -19,7 +19,7 @@ type OutlierCommand struct {
 
 var _ Command = OutlierCommand{}
 
-func (c OutlierCommand) String() string {
+func (c OutlierCommand) Type() string {
 	return "outlier"
 }
 

--- a/pkg/expr/ml/outlier.go
+++ b/pkg/expr/ml/outlier.go
@@ -19,6 +19,10 @@ type OutlierCommand struct {
 
 var _ Command = OutlierCommand{}
 
+func (c OutlierCommand) String() string {
+	return "outlier"
+}
+
 func (c OutlierCommand) DatasourceUID() string {
 	return c.config.DatasourceUID
 }

--- a/pkg/expr/ml/testing.go
+++ b/pkg/expr/ml/testing.go
@@ -42,3 +42,7 @@ func (f *FakeCommand) Execute(from, to time.Time, executor func(method string, p
 	}
 	return f.Response, f.Error
 }
+
+func (f *FakeCommand) Type() string {
+	return "fake"
+}

--- a/pkg/expr/nodes.go
+++ b/pkg/expr/nodes.go
@@ -187,6 +187,13 @@ type DSNode struct {
 	request    Request
 }
 
+func (dn *DSNode) String() string {
+	if dn.datasource == nil {
+		return "unknown"
+	}
+	return dn.datasource.Type
+}
+
 // NodeType returns the data pipeline node type.
 func (dn *DSNode) NodeType() NodeType {
 	return TypeDatasourceNode

--- a/pkg/expr/sql_command.go
+++ b/pkg/expr/sql_command.go
@@ -104,6 +104,6 @@ func (gr *SQLCommand) Execute(ctx context.Context, now time.Time, vars mathexp.V
 	return rsp, nil
 }
 
-func (gr *SQLCommand) String() string {
+func (gr *SQLCommand) Type() string {
 	return TypeSQL.String()
 }

--- a/pkg/expr/sql_command.go
+++ b/pkg/expr/sql_command.go
@@ -103,3 +103,7 @@ func (gr *SQLCommand) Execute(ctx context.Context, now time.Time, vars mathexp.V
 
 	return rsp, nil
 }
+
+func (gr *SQLCommand) String() string {
+	return TypeSQL.String()
+}

--- a/pkg/expr/threshold.go
+++ b/pkg/expr/threshold.go
@@ -128,6 +128,10 @@ func (tc *ThresholdCommand) Execute(ctx context.Context, now time.Time, vars mat
 	return mathCommand.Execute(ctx, now, vars, tracer)
 }
 
+func (tc *ThresholdCommand) String() string {
+	return TypeThreshold.String()
+}
+
 // createMathExpression converts all the info we have about a "threshold" expression in to a Math expression
 func createMathExpression(referenceVar string, thresholdFunc ThresholdType, args []float64, invert bool) (string, error) {
 	var exp string

--- a/pkg/expr/threshold.go
+++ b/pkg/expr/threshold.go
@@ -128,7 +128,7 @@ func (tc *ThresholdCommand) Execute(ctx context.Context, now time.Time, vars mat
 	return mathCommand.Execute(ctx, now, vars, tracer)
 }
 
-func (tc *ThresholdCommand) String() string {
+func (tc *ThresholdCommand) Type() string {
 	return TypeThreshold.String()
 }
 

--- a/pkg/services/ngalert/eval/eval.go
+++ b/pkg/services/ngalert/eval/eval.go
@@ -73,7 +73,7 @@ func (r *conditionEvaluator) EvaluateRaw(ctx context.Context, now time.Time) (re
 		defer cancel()
 		execCtx = timeoutCtx
 	}
-	logger.FromContext(ctx).Debug("Executing pipeline", "commands", strings.Join(r.pipeline.UniqueCommands(), ","))
+	logger.FromContext(ctx).Debug("Executing pipeline", "commands", strings.Join(r.pipeline.GetCommandTypes(), ","), "datasources", strings.Join(r.pipeline.GetDatasourceTypes(), ","))
 	return r.expressionService.ExecutePipeline(execCtx, now, r.pipeline)
 }
 

--- a/pkg/services/ngalert/eval/eval.go
+++ b/pkg/services/ngalert/eval/eval.go
@@ -73,6 +73,7 @@ func (r *conditionEvaluator) EvaluateRaw(ctx context.Context, now time.Time) (re
 		defer cancel()
 		execCtx = timeoutCtx
 	}
+	logger.FromContext(ctx).Debug("Executing pipeline", "commands", strings.Join(r.pipeline.UniqueCommands(), ","))
 	return r.expressionService.ExecutePipeline(execCtx, now, r.pipeline)
 }
 


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**
This feature adds a debug log that emits a list of expression and data sources used in the query:
- the context label `commands` will contain the unique list of server-side expressions used in the query. 
- the context label `datasources` will contain the unique list of data source queries. 
- if query contains ML node, the `datasources` context will have item like `ml_<type>`, e.g. `ml_outlier`.

Example 
```
logger=ngalert.eval rule_uid=ac186829-811b-4e65-ba62-c4ef125eb880 org_id=1 t=2024-03-15T17:10:30.0039539-04:00 level=debug msg="Executing pipeline" commands=hysteresis,reduce datasources=testdata

logger=ngalert.eval rule_uid=ddcw94nij6vibf org_id=1 t=2024-03-15T17:10:26.6877927-04:00 level=debug msg="Executing pipeline" commands=classic_condition datasources=testdata
```

**Why do we need this feature?**
This will give more insight into what type of query is being evaluated and can help with troubleshooting and analytics.

**Who is this feature for?**
Developers, administrators
