### PR TITLE
RolePicker: Don't try to fetch roles for new form

### DIFF
--- a/public/app/core/components/RolePicker/TeamRolePicker.tsx
+++ b/public/app/core/components/RolePicker/TeamRolePicker.tsx
@@ -53,7 +53,7 @@ export const TeamRolePicker = ({
         return pendingRoles;
       }
 
-      if (contextSrv.hasPermission(AccessControlAction.ActionTeamsRolesList)) {
+      if (contextSrv.hasPermission(AccessControlAction.ActionTeamsRolesList) && teamId > 0) {
         return await fetchTeamRoles(teamId);
       }
     } catch (e) {

--- a/public/app/core/components/RolePicker/UserRolePicker.tsx
+++ b/public/app/core/components/RolePicker/UserRolePicker.tsx
@@ -62,7 +62,7 @@ export const UserRolePicker = ({
         return pendingRoles;
       }
 
-      if (contextSrv.hasPermission(AccessControlAction.ActionUserRolesList)) {
+      if (contextSrv.hasPermission(AccessControlAction.ActionUserRolesList) && userId > 0) {
         return await fetchUserRoles(userId, orgId);
       }
     } catch (e) {


### PR DESCRIPTION
**What is this feature?**
While investigating other issue I noticed that role picker always tried to fetch roles for entity resulting in a 500 error because it don't exists yet. In this pr I just add a guard to prevent to fetch the roles when no userId/teamId is passed.

I will make a pr to update the response status as well, should be 404.

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
