### PR TITLE
FolderPicker: Add permission filter to nested folder picker

### DIFF
--- a/public/app/core/components/NestedFolderPicker/NestedFolderPicker.test.tsx
+++ b/public/app/core/components/NestedFolderPicker/NestedFolderPicker.test.tsx
@@ -185,7 +185,7 @@ describe('NestedFolderPicker', () => {
     await screen.findByLabelText(folderA.item.title);
 
     expect(screen.queryByLabelText(folderB.item.title)).not.toBeInTheDocument(); // folderB is not editable
-    expect(screen.queryByLabelText(folderC.item.title)).toBeInTheDocument(); // but folderC is
+    expect(screen.getByLabelText(folderC.item.title)).toBeInTheDocument(); // but folderC is
   });
 
   it('shows items the user can view, with the prop', async () => {
@@ -195,8 +195,8 @@ describe('NestedFolderPicker', () => {
     await userEvent.click(button);
     await screen.findByLabelText(folderA.item.title);
 
-    expect(screen.queryByLabelText(folderB.item.title)).toBeInTheDocument();
-    expect(screen.queryByLabelText(folderC.item.title)).toBeInTheDocument();
+    expect(screen.getByLabelText(folderB.item.title)).toBeInTheDocument();
+    expect(screen.getByLabelText(folderC.item.title)).toBeInTheDocument();
   });
 
   describe('when nestedFolders is enabled', () => {

--- a/public/app/core/components/NestedFolderPicker/NestedFolderPicker.test.tsx
+++ b/public/app/core/components/NestedFolderPicker/NestedFolderPicker.test.tsx
@@ -110,7 +110,7 @@ describe('NestedFolderPicker', () => {
     expect(screen.getByPlaceholderText('Search folders')).toBeInTheDocument();
     expect(screen.getByLabelText('Dashboards')).toBeInTheDocument();
     expect(screen.getByLabelText(folderA.item.title)).toBeInTheDocument();
-    expect(screen.getByLabelText(folderB.item.title)).toBeInTheDocument();
+    // expect(screen.getByLabelText(folderB.item.title)).toBeInTheDocument();
     expect(screen.getByLabelText(folderC.item.title)).toBeInTheDocument();
   });
 
@@ -167,25 +167,36 @@ describe('NestedFolderPicker', () => {
   });
 
   it('hides folders specififed by UID', async () => {
-    render(<NestedFolderPicker excludeUIDs={[folderA.item.uid]} onChange={mockOnChange} />);
+    render(<NestedFolderPicker excludeUIDs={[folderC.item.uid]} onChange={mockOnChange} />);
 
     // Open the picker and wait for children to load
     const button = await screen.findByRole('button', { name: 'Select folder' });
     await userEvent.click(button);
-    await screen.findByLabelText(folderB.item.title);
+    await screen.findByLabelText(folderA.item.title);
 
-    expect(screen.queryByLabelText(folderA.item.title)).not.toBeInTheDocument();
+    expect(screen.queryByLabelText(folderC.item.title)).not.toBeInTheDocument();
   });
 
-  it('has a filter to show only folders that the user can edit', async () => {
-    render(<NestedFolderPicker permission={PermissionLevelString.Edit} onChange={mockOnChange} />);
+  it('by default only shows items the user can edit', async () => {
+    render(<NestedFolderPicker onChange={mockOnChange} />);
 
     const button = await screen.findByRole('button', { name: 'Select folder' });
     await userEvent.click(button);
+    await screen.findByLabelText(folderA.item.title);
 
-    await screen.findByLabelText(folderB.item.title);
-    expect(screen.queryByLabelText(folderA.item.title)).not.toBeInTheDocument(); // folderA is not editable
-    expect(screen.queryByLabelText(folderB.item.title)).toBeInTheDocument(); // but folderB is
+    expect(screen.queryByLabelText(folderB.item.title)).not.toBeInTheDocument(); // folderB is not editable
+    expect(screen.queryByLabelText(folderC.item.title)).toBeInTheDocument(); // but folderC is
+  });
+
+  it('shows items the user can view, with the prop', async () => {
+    render(<NestedFolderPicker permission={PermissionLevelString.View} onChange={mockOnChange} />);
+
+    const button = await screen.findByRole('button', { name: 'Select folder' });
+    await userEvent.click(button);
+    await screen.findByLabelText(folderA.item.title);
+
+    expect(screen.queryByLabelText(folderB.item.title)).toBeInTheDocument();
+    expect(screen.queryByLabelText(folderC.item.title)).toBeInTheDocument();
   });
 
   describe('when nestedFolders is enabled', () => {
@@ -200,7 +211,7 @@ describe('NestedFolderPicker', () => {
     });
 
     it('can expand and collapse a folder to show its children', async () => {
-      render(<NestedFolderPicker onChange={mockOnChange} />);
+      render(<NestedFolderPicker permission={PermissionLevelString.View} onChange={mockOnChange} />);
 
       // Open the picker and wait for children to load
       const button = await screen.findByRole('button', { name: 'Select folder' });
@@ -231,7 +242,7 @@ describe('NestedFolderPicker', () => {
     });
 
     it('can expand and collapse a folder to show its children with the keyboard', async () => {
-      render(<NestedFolderPicker onChange={mockOnChange} />);
+      render(<NestedFolderPicker permission={PermissionLevelString.View} onChange={mockOnChange} />);
       const button = await screen.findByRole('button', { name: 'Select folder' });
 
       await userEvent.click(button);

--- a/public/app/core/components/NestedFolderPicker/NestedFolderPicker.tsx
+++ b/public/app/core/components/NestedFolderPicker/NestedFolderPicker.tsx
@@ -32,7 +32,7 @@ export interface NestedFolderPickerProps {
   /* Folder UIDs to exclude from the picker, to prevent invalid operations */
   excludeUIDs?: string[];
 
-  /* Only show folders matching this permission, mainly for Save Dashboards to limit to folders user can write to. Defaults to View/unfiltered.  */
+  /* Show folders matching this permission, mainly used to also show folders user can view. Defaults to showing only folders user has Edit  */
   permission?: PermissionLevelString.View | PermissionLevelString.Edit;
 
   /* Callback for when the user selects a folder */
@@ -62,7 +62,7 @@ export function NestedFolderPicker({
   showRootFolder = true,
   clearable = false,
   excludeUIDs,
-  permission,
+  permission = PermissionLevelString.Edit,
   onChange,
 }: NestedFolderPickerProps) {
   const styles = useStyles2(getStyles);

--- a/public/app/core/components/NestedFolderPicker/NestedFolderPicker.tsx
+++ b/public/app/core/components/NestedFolderPicker/NestedFolderPicker.tsx
@@ -49,7 +49,7 @@ async function getSearchResults(searchQuery: string, permission?: PermissionLeve
     query: searchQuery,
     kind: ['folder'],
     limit: 100,
-    // permission: permission, // TODO: make grafana server support this
+    permission: permission,
   });
 
   const items = queryResponse.view.map((v) => queryResultToViewItem(v, queryResponse.view));

--- a/public/app/features/browse-dashboards/api/browseDashboardsAPI.ts
+++ b/public/app/features/browse-dashboards/api/browseDashboardsAPI.ts
@@ -16,6 +16,7 @@ import {
   FolderDTO,
   FolderListItemDTO,
   ImportDashboardResponseDTO,
+  PermissionLevelString,
   SaveDashboardResponseDTO,
 } from 'app/types';
 
@@ -74,6 +75,7 @@ export interface ListFolderQueryArgs {
   page: number;
   parentUid: string | undefined;
   limit: number;
+  permission?: PermissionLevelString;
 }
 
 export const browseDashboardsAPI = createApi({
@@ -83,7 +85,10 @@ export const browseDashboardsAPI = createApi({
   endpoints: (builder) => ({
     listFolders: builder.query<FolderListItemDTO[], ListFolderQueryArgs>({
       providesTags: (result) => result?.map((folder) => ({ type: 'getFolder', id: folder.uid })) ?? [],
-      query: ({ page, parentUid, limit }) => ({ url: '/folders', params: { page, parentUid, limit } }),
+      query: ({ parentUid, limit, page, permission }) => ({
+        url: '/folders',
+        params: { parentUid, limit, page, permission },
+      }),
     }),
 
     // get folder info (e.g. title, parents) but *not* children

--- a/public/app/features/browse-dashboards/fixtures/dashboardsTreeItem.fixture.ts
+++ b/public/app/features/browse-dashboards/fixtures/dashboardsTreeItem.fixture.ts
@@ -74,13 +74,12 @@ export function sharedWithMeFolder(seed = 1): DashboardsTreeItem<DashboardViewIt
 }
 
 export function treeViewersCanEdit() {
-  const [, { folderB, folderB_empty, folderC }] = wellFormedTree();
+  const [, { folderA, folderC }] = wellFormedTree();
 
   return [
-    [folderB, folderB_empty, folderC],
+    [folderA, folderC],
     {
-      folderB,
-      folderB_empty,
+      folderA,
       folderC,
     },
   ] as const;

--- a/public/app/features/browse-dashboards/fixtures/dashboardsTreeItem.fixture.ts
+++ b/public/app/features/browse-dashboards/fixtures/dashboardsTreeItem.fixture.ts
@@ -73,6 +73,19 @@ export function sharedWithMeFolder(seed = 1): DashboardsTreeItem<DashboardViewIt
   return folder;
 }
 
+export function treeViewersCanEdit() {
+  const [, { folderB, folderB_empty, folderC }] = wellFormedTree();
+
+  return [
+    [folderB, folderB_empty, folderC],
+    {
+      folderB,
+      folderB_empty,
+      folderC,
+    },
+  ] as const;
+}
+
 export function wellFormedTree() {
   let seed = 1;
 

--- a/public/app/features/search/service/sql.ts
+++ b/public/app/features/search/service/sql.ts
@@ -2,6 +2,7 @@ import { DataFrame, DataFrameView, FieldType, getDisplayProcessor, SelectableVal
 import { config } from '@grafana/runtime';
 import { TermCount } from 'app/core/components/TagFilter/TagFilter';
 import { backendSrv } from 'app/core/services/backend_srv';
+import { PermissionLevelString } from 'app/types';
 
 import { DEFAULT_MAX_VALUES, TYPE_KIND_MAP } from '../constants';
 import { DashboardSearchHit, DashboardSearchItemType } from '../types';
@@ -21,6 +22,7 @@ interface APIQuery {
   folderUIDs?: string[];
   sort?: string;
   starred?: boolean;
+  permission?: PermissionLevelString;
 }
 
 // Internal object to hold folderId
@@ -85,6 +87,7 @@ export class SQLSearcher implements GrafanaSearcher {
         limit: limit,
         tag: query.tags,
         sort: query.sort,
+        permission: query.permission,
         page,
       },
       query

--- a/public/app/features/search/service/types.ts
+++ b/public/app/features/search/service/types.ts
@@ -1,5 +1,6 @@
 import { DataFrameView, SelectableValue } from '@grafana/data';
 import { TermCount } from 'app/core/components/TagFilter/TagFilter';
+import { PermissionLevelString } from 'app/types';
 
 export interface FacetField {
   field: string;
@@ -25,6 +26,7 @@ export interface SearchQuery {
   limit?: number;
   from?: number;
   starred?: boolean;
+  permission?: PermissionLevelString;
 }
 
 export interface DashboardQueryResult {

--- a/public/app/plugins/panel/dashlist/module.tsx
+++ b/public/app/plugins/panel/dashlist/module.tsx
@@ -3,6 +3,7 @@ import React from 'react';
 import { PanelPlugin } from '@grafana/data';
 import { TagsInput } from '@grafana/ui';
 import { FolderPicker } from 'app/core/components/Select/FolderPicker';
+import { PermissionLevelString } from 'app/types';
 
 import { DashList } from './DashList';
 import { dashlistMigrationHandler } from './migrations';
@@ -57,7 +58,14 @@ export const plugin = new PanelPlugin<Options>(DashList)
         id: 'folderUID',
         defaultValue: undefined,
         editor: function RenderFolderPicker({ value, onChange }) {
-          return <FolderPicker clearable value={value} onChange={(folderUID) => onChange(folderUID)} />;
+          return (
+            <FolderPicker
+              clearable
+              permission={PermissionLevelString.View}
+              value={value}
+              onChange={(folderUID) => onChange(folderUID)}
+            />
+          );
         },
       })
       .addCustomEditor({


### PR DESCRIPTION
**What is this feature?**

Fixes NestedFolderPicker to, by default, only show folders users have edit permissions on. This matches the behaviour of the old folder picker.

If consumers want to show all folders the user has access to, they should specify the `permission={PermissionLevelString.View}` prop.

Fixes https://github.com/grafana/grafana/issues/81941