### PR TITLE
Alerting docs: Fix format issues in recent Slack tutorial

### DIFF
--- a/docs/sources/alerting/configure-notifications/manage-contact-points/_index.md
+++ b/docs/sources/alerting/configure-notifications/manage-contact-points/_index.md
@@ -123,7 +123,7 @@ Once configured, you can use integrations as part of your contact points to rece
 | Pushover                 | `pushover`                |
 | Sensu                    | `sensu`                   |
 | Sensu Go                 | `sensugo`                 |
-| Slack                    | `slack`                   |
+| [Slack][slack]           | `slack`                   |
 | Telegram                 | `telegram`                |
 | Threema                  | `threema`                 |
 | VictorOps                | `victorops`               |
@@ -135,6 +135,9 @@ Once configured, you can use integrations as part of your contact points to rece
 
 [oncall]: "/docs/grafana/ -> /docs/grafana/<GRAFANA_VERSION>/alerting/configure-notifications/manage-contact-points/integrations/configure-oncall"
 [oncall]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/alerting-and-irm/alerting/configure-notifications/manage-contact-points/integrations/configure-oncall"
+
+[slack]: "/docs/grafana/ -> /docs/grafana/<GRAFANA_VERSION>/alerting/configure-notifications/manage-contact-points/integrations/configure-slack"
+[slack]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/alerting-and-irm/alerting/configure-notifications/manage-contact-points/integrations/configure-slack"
 
 [webhook]: "/docs/grafana/ -> /docs/grafana/<GRAFANA_VERSION>/alerting/configure-notifications/manage-contact-points/integrations/webhook-notifier"
 [webhook]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/alerting-and-irm/alerting/configure-notifications/manage-contact-points/integrations/webhook-notifier"

--- a/docs/sources/alerting/configure-notifications/manage-contact-points/integrations/configure-slack.md
+++ b/docs/sources/alerting/configure-notifications/manage-contact-points/integrations/configure-slack.md
@@ -24,11 +24,12 @@ There are two ways of integrating Slack into Grafana Alerting.
 
 1. Use a [Slack API token](https://api.slack.com/authentication/token-types)
 
-Enable your app to access the Slack API. If, for example, you are interested in more granular control over permissions, or your project is expected to regularly scale, resulting in new channels being created, this is the best option.
+   Enable your app to access the Slack API. If, for example, you are interested in more granular control over permissions, or your project is expected to regularly scale, resulting in new channels being created, this is the best option.
 
 1. Use a [Webhook URL](https://api.slack.com/messaging/webhooks)
 
-Webhooks is the simpler way to post messages into Slack. Slack automatically creates a bot user with all the necessary permissions to post messages to one particular channel of your choice.
+   Webhooks is the simpler way to post messages into Slack. Slack automatically creates a bot user with all the necessary permissions to post messages to one particular channel of your choice.
+
 {{< admonition type="note" >}}
 Grafana Alerting only allows one Slack channel per contact point.
 {{< /admonition >}}
@@ -71,7 +72,7 @@ To create your Slack integration in Grafana Alerting, complete the following ste
    - In the **Token** field, copy in the Bot User OAuth Token that starts with “xoxb-”.
 1. If you are using a Webhook URL, in the **Webhook** field, copy in your Slack app Webhook URL.
 1. Click **Test** to check that your integration works.
-   1[]. Click **Save contact point**.
+1. Click **Save contact point**.
 
 ## Next steps
 

--- a/docs/sources/alerting/configure-notifications/manage-contact-points/integrations/configure-slack.md
+++ b/docs/sources/alerting/configure-notifications/manage-contact-points/integrations/configure-slack.md
@@ -87,7 +87,7 @@ To add the contact point and integration you created to your default notificatio
 If you have more than one contact point, add a new notification policy rather than edit the default one, so you can route specific alerts to Slack. For more information, refer to [Notification policies][nested-policy].
 
 {{% docs/reference %}}
-[nested-policy]: "/docs/grafana/ -> /docs/grafana/<GRAFANA_VERSION>/alerting/alerting-rules/create-notification-policy/#add-new-nested-policy"
+[nested-policy]: "/docs/grafana/ -> /docs/grafana/<GRAFANA_VERSION>/alerting/configure-notifications/create-notification-policy#add-new-nested-policy"
 
-[nested-policy]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/alerting-and-irm/alerting/configure-notifications/create-notification-policy/#add-new-nested-policy"
+[nested-policy]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/alerting-and-irm/alerting/configure-notifications/create-notification-policy#add-new-nested-policy"
 {{% /docs/reference %}}


### PR DESCRIPTION
Fix format issues at https://grafana.com/docs/grafana/next/alerting/configure-notifications/manage-contact-points/integrations/configure-slack/
