### PR TITLE
E2C: Use cloudMigrationIsTarget config

### DIFF
--- a/public/app/features/admin/migrate-to-cloud/MigrateToCloud.tsx
+++ b/public/app/features/admin/migrate-to-cloud/MigrateToCloud.tsx
@@ -7,8 +7,5 @@ import { Page as CloudPage } from './cloud/Page';
 import { Page as OnPremPage } from './onprem/Page';
 
 export default function MigrateToCloud() {
-  // TODO replace this with a proper config value when it's available
-  const isMigrationTarget = config.namespace.startsWith('stack-');
-
-  return <Page navId="migrate-to-cloud">{isMigrationTarget ? <CloudPage /> : <OnPremPage />}</Page>;
+  return <Page navId="migrate-to-cloud">{config.cloudMigrationIsTarget ? <CloudPage /> : <OnPremPage />}</Page>;
 }


### PR DESCRIPTION
Uses the proper `config.cloudMigrationIsTarget` config option, introduced in https://github.com/grafana/grafana/pull/83419 to control showing the On prem vs cloud UI.