### PR TITLE
datatrails: Remove prefix filter

### DIFF
--- a/public/app/features/trails/MetricCategory/MetricCategoryCascader.tsx
+++ b/public/app/features/trails/MetricCategory/MetricCategoryCascader.tsx
@@ -1,6 +1,6 @@
-import React, { useMemo, useReducer, useState } from 'react';
+import React, { useMemo } from 'react';
 
-import { Cascader, CascaderOption, HorizontalGroup, Button } from '@grafana/ui';
+import { Cascader, CascaderOption } from '@grafana/ui';
 
 import { useMetricCategories } from './useMetricCategories';
 
@@ -15,36 +15,19 @@ export function MetricCategoryCascader({ metricNames, onSelect, disabled, initia
   const categoryTree = useMetricCategories(metricNames);
   const options = useMemo(() => createCasaderOptions(categoryTree), [categoryTree]);
 
-  const [disableClear, setDisableClear] = useState(initialValue == null);
-
-  // Increments whenever clear is pressed, to reset the Cascader component
-  const [cascaderKey, resetCascader] = useReducer((x) => x + 1, 0);
-
-  const clear = () => {
-    resetCascader();
-    setDisableClear(true);
-    onSelect(undefined);
-  };
-
   return (
-    <HorizontalGroup>
-      <Cascader
-        key={cascaderKey} // To reset the component to `undefined`
-        displayAllSelectedLevels={true}
-        width={40}
-        separator="_"
-        hideActiveLevelLabel={false}
-        placeholder={'No filter'}
-        onSelect={(prefix) => {
-          setDisableClear(!prefix);
-          onSelect(prefix);
-        }}
-        {...{ options, disabled, initialValue }}
-      />
-      <Button disabled={disableClear || disabled} onClick={clear} variant="secondary">
-        Clear
-      </Button>
-    </HorizontalGroup>
+    <Cascader
+      displayAllSelectedLevels={true}
+      width={40}
+      separator="_"
+      hideActiveLevelLabel={false}
+      placeholder={'No filter'}
+      isClearable
+      onSelect={(prefix) => {
+        onSelect(prefix);
+      }}
+      {...{ options, disabled, initialValue }}
+    />
   );
 }
 

--- a/public/app/features/trails/MetricSelectScene.tsx
+++ b/public/app/features/trails/MetricSelectScene.tsx
@@ -354,14 +354,6 @@ export class MetricSelectScene extends SceneObjectBase<MetricSelectSceneState> {
               disabled={disableSearch}
             />
           </Field>
-          <Field label="Filter by prefix" className={styles.prefixField} error={prefixError} invalid={!!prefixError}>
-            <MetricCategoryCascader
-              metricNames={metricsAfterSearch || []}
-              onSelect={model.onPrefixFilterChange}
-              disabled={disableSearch}
-              initialValue={prefixFilter}
-            />
-          </Field>
           <InlineSwitch
             showLabel={true}
             label="Show previews"
@@ -428,9 +420,6 @@ function getStyles(theme: GrafanaTheme2) {
     }),
     searchField: css({
       flexGrow: 1,
-      marginBottom: 0,
-    }),
-    prefixField: css({
       marginBottom: 0,
     }),
   };

--- a/public/app/features/trails/MetricSelectScene.tsx
+++ b/public/app/features/trails/MetricSelectScene.tsx
@@ -354,16 +354,7 @@ export class MetricSelectScene extends SceneObjectBase<MetricSelectSceneState> {
               disabled={disableSearch}
             />
           </Field>
-          <InlineSwitch
-            showLabel={true}
-            label="Show previews"
-            value={showPreviews}
-            onChange={model.onTogglePreviews}
-            disabled={disableSearch}
-          />
-        </div>
-        <div className={styles.header}>
-          <Field label="Filter by prefix" error={prefixError} invalid={!!prefixError}>
+          <Field label="Filter by prefix" className={styles.prefixField} error={prefixError} invalid={!!prefixError}>
             <MetricCategoryCascader
               metricNames={metricsAfterSearch || []}
               onSelect={model.onPrefixFilterChange}
@@ -371,6 +362,13 @@ export class MetricSelectScene extends SceneObjectBase<MetricSelectSceneState> {
               initialValue={prefixFilter}
             />
           </Field>
+          <InlineSwitch
+            showLabel={true}
+            label="Show previews"
+            value={showPreviews}
+            onChange={model.onTogglePreviews}
+            disabled={disableSearch}
+          />
         </div>
         {metricNamesStatus.error && (
           <Alert title="Unable to retrieve metric names" severity="error">
@@ -430,6 +428,9 @@ function getStyles(theme: GrafanaTheme2) {
     }),
     searchField: css({
       flexGrow: 1,
+      marginBottom: 0,
+    }),
+    prefixField: css({
       marginBottom: 0,
     }),
   };

--- a/public/app/features/trails/MetricSelectScene.tsx
+++ b/public/app/features/trails/MetricSelectScene.tsx
@@ -23,7 +23,6 @@ import { VariableHide } from '@grafana/schema';
 import { Input, InlineSwitch, Field, Alert, Icon, useStyles2 } from '@grafana/ui';
 
 import { getPreviewPanelFor } from './AutomaticMetricQueries/previewPanel';
-import { MetricCategoryCascader } from './MetricCategory/MetricCategoryCascader';
 import { MetricScene } from './MetricScene';
 import { SelectMetricAction } from './SelectMetricAction';
 import { StatusWrapper } from './StatusWrapper';
@@ -380,7 +379,7 @@ function getStyles(theme: GrafanaTheme2) {
       flexGrow: 0,
       display: 'flex',
       gap: theme.spacing(2),
-      marginBottom: theme.spacing(1),
+      marginBottom: theme.spacing(2),
       alignItems: 'flex-end',
     }),
     searchField: css({

--- a/public/app/features/trails/MetricSelectScene.tsx
+++ b/public/app/features/trails/MetricSelectScene.tsx
@@ -44,9 +44,7 @@ export interface MetricSelectSceneState extends SceneObjectState {
   body: SceneCSSGridLayout;
   searchQuery?: string;
   showPreviews?: boolean;
-  prefixFilter?: string;
   metricsAfterSearch?: string[];
-  metricsAfterFilter?: string[];
 }
 
 const ROW_PREVIEW_HEIGHT = '175px';
@@ -158,32 +156,15 @@ export class MetricSelectScene extends SceneObjectBase<MetricSelectSceneState> {
     }
   }
 
-  private applyMetricPrefixFilter() {
-    // This should occur after an `applyMetricSearch`, or if the prefix filter has changed
-    const { metricsAfterSearch, prefixFilter } = this.state;
-
-    if (!prefixFilter || !metricsAfterSearch) {
-      this.setState({ metricsAfterFilter: metricsAfterSearch });
-    } else {
-      const metricsAfterFilter = metricsAfterSearch.filter((metric) => metric.startsWith(prefixFilter));
-      this.setState({ metricsAfterFilter });
-    }
-  }
-
   private updateMetrics(applySearchAndFilter = true) {
     if (applySearchAndFilter) {
       // Set to false if these are not required (because they can be assumed to have been suitably called).
       this.applyMetricSearch();
-      this.applyMetricPrefixFilter();
     }
 
-    const { metricsAfterFilter } = this.state;
+    const { metricsAfterSearch } = this.state;
 
-    if (!metricsAfterFilter) {
-      return;
-    }
-
-    const metricNames = metricsAfterFilter;
+    const metricNames = metricsAfterSearch || [];
     const trail = getTrailFor(this);
     const sortedMetricNames =
       trail.state.metric !== undefined ? sortRelatedMetrics(metricNames, trail.state.metric) : metricNames;
@@ -302,29 +283,18 @@ export class MetricSelectScene extends SceneObjectBase<MetricSelectSceneState> {
     this.buildLayout();
   }, 500);
 
-  public onPrefixFilterChange = (prefixFilter: string | undefined) => {
-    this.setState({ prefixFilter });
-    this.prefixFilterChangedDebounced();
-  };
-
-  private prefixFilterChangedDebounced = debounce(() => {
-    this.applyMetricPrefixFilter();
-    this.updateMetrics(false); // Only needed to applyMetricPrefixFilter
-    this.buildLayout();
-  }, 1000);
-
   public onTogglePreviews = () => {
     this.setState({ showPreviews: !this.state.showPreviews });
     this.buildLayout();
   };
 
   public static Component = ({ model }: SceneComponentProps<MetricSelectScene>) => {
-    const { searchQuery, showPreviews, body, metricsAfterSearch, metricsAfterFilter, prefixFilter } = model.useState();
+    const { searchQuery, showPreviews, body } = model.useState();
     const { children } = body.useState();
     const styles = useStyles2(getStyles);
 
     const metricNamesStatus = useVariableStatus(VAR_METRIC_NAMES, model);
-    const tooStrict = children.length === 0 && (searchQuery || prefixFilter);
+    const tooStrict = children.length === 0 && searchQuery;
     const noMetrics = !metricNamesStatus.isLoading && model.currentMetricNames.size === 0;
 
     const isLoading = metricNamesStatus.isLoading && children.length === 0;
@@ -334,11 +304,6 @@ export class MetricSelectScene extends SceneObjectBase<MetricSelectSceneState> {
       : (noMetrics && 'There are no results found. Try a different time range or a different data source.') ||
         (tooStrict && 'There are no results found. Try adjusting your search or filters.') ||
         undefined;
-
-    const prefixError =
-      prefixFilter && metricsAfterSearch != null && !metricsAfterFilter?.length
-        ? 'The current prefix filter is not available with the current search terms.'
-        : undefined;
 
     const disableSearch = metricNamesStatus.error || metricNamesStatus.isLoading;
 


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

Removes the prefix filter from the metric select scene, along with all support code in that scene.

![image](https://github.com/grafana/grafana/assets/38694490/e2cd3df4-372d-4bb9-a436-703e847b7e73)


The "MetricCategory" component and hooks implementation is kept as it hasn't been ruled out to be used in some form in the future. It has been corrected to use the built-in clear button so as to not require an external clear button.


**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
