### PR TITLE
QueryLibrary: Use default variable values in render

### DIFF
--- a/pkg/apis/query/v0alpha1/template/render.go
+++ b/pkg/apis/query/v0alpha1/template/render.go
@@ -43,7 +43,11 @@ func RenderTemplate(qt QueryTemplate, selectedValues map[string][]string) ([]Tar
 			s = s[1 : len(s)-1]
 			var offSet int64
 			for _, r := range reps {
-				value := []rune(FormatVariables(r.format, selectedValues[r.Key]))
+				sV := selectedValues[r.Key]
+				if sV == nil {
+					sV = r.DefaultValues
+				}
+				value := []rune(FormatVariables(r.format, sV))
 				if r.Position == nil {
 					return nil, fmt.Errorf("nil position not support yet, will be full replacement")
 				}

--- a/pkg/apis/query/v0alpha1/template/render_test.go
+++ b/pkg/apis/query/v0alpha1/template/render_test.go
@@ -12,7 +12,8 @@ var nestedFieldRender = QueryTemplate{
 	Title: "Test",
 	Variables: []TemplateVariable{
 		{
-			Key: "metricName",
+			Key:           "metricName",
+			DefaultValues: []string{"cow_count"},
 		},
 	},
 	Targets: []Target{
@@ -64,11 +65,44 @@ var nestedFieldRenderedTargets = []Target{
 	},
 }
 
+var nestedFieldDefaultRenderedTargets = []Target{
+	{
+		DataType: data.FrameTypeUnknown,
+		Variables: map[string][]VariableReplacement{
+			"metricName": {
+				{
+					Path: "$.nestedObject.anArray[0]",
+					Position: &Position{
+						Start: 0,
+						End:   3,
+					},
+				},
+			},
+		},
+		//DataTypeVersion: data.FrameTypeVersion{0, 0},
+		Properties: apidata.NewDataQuery(
+			map[string]any{
+				"nestedObject": map[string]any{
+					"anArray": []any{"cow_count", .2},
+				},
+			}),
+	},
+}
+
 func TestNestedFieldRender(t *testing.T) {
 	rT, err := RenderTemplate(nestedFieldRender, map[string][]string{"metricName": {"up"}})
 	require.NoError(t, err)
 	require.Equal(t,
 		nestedFieldRenderedTargets,
+		rT,
+	)
+}
+
+func TestNestedFieldDefaultsRender(t *testing.T) {
+	rT, err := RenderTemplate(nestedFieldRender, nil)
+	require.NoError(t, err)
+	require.Equal(t,
+		nestedFieldDefaultRenderedTargets,
 		rT,
 	)
 }


### PR DESCRIPTION
**What is this feature?**

Default values in the template were ignored, this makes it so they are used if the values are not applied.
