### PR TITLE
Alerting: External AM fix parsing basic auth with escape characters

### DIFF
--- a/pkg/services/ngalert/sender/router.go
+++ b/pkg/services/ngalert/sender/router.go
@@ -275,17 +275,16 @@ func (d *AlertsRouter) buildExternalURL(ds *datasources.DataSource) (string, err
 		}
 	}
 
-	// if basic auth is enabled we need to build the url with basic auth baked in
-	if !ds.BasicAuth {
-		return parsed.String(), nil
+	// If basic auth is enabled we need to build the url with basic auth baked in.
+	if ds.BasicAuth {
+		password := d.secretService.GetDecryptedValue(context.Background(), ds.SecureJsonData, "basicAuthPassword", "")
+		if password == "" {
+			return "", fmt.Errorf("basic auth enabled but no password set")
+		}
+		parsed.User = url.UserPassword(ds.BasicAuthUser, password)
 	}
 
-	password := d.secretService.GetDecryptedValue(context.Background(), ds.SecureJsonData, "basicAuthPassword", "")
-	if password == "" {
-		return "", fmt.Errorf("basic auth enabled but no password set")
-	}
-	return fmt.Sprintf("%s://%s:%s@%s%s%s", parsed.Scheme, ds.BasicAuthUser,
-		password, parsed.Host, parsed.Path, parsed.RawQuery), nil
+	return parsed.String(), nil
 }
 
 func (d *AlertsRouter) Send(ctx context.Context, key models.AlertRuleKey, alerts definitions.PostableAlerts) {

--- a/pkg/services/ngalert/sender/router_test.go
+++ b/pkg/services/ngalert/sender/router_test.go
@@ -462,6 +462,18 @@ func TestBuildExternalURL(t *testing.T) {
 			expectedURL: "https://johndoe:123@localhost:9000",
 		},
 		{
+			name: "datasource with auth that needs escaping",
+			ds: &datasources.DataSource{
+				URL:           "https://localhost:9000",
+				BasicAuth:     true,
+				BasicAuthUser: "johndoe",
+				SecureJsonData: map[string][]byte{
+					"basicAuthPassword": []byte("123#!"),
+				},
+			},
+			expectedURL: "https://johndoe:123%23%21@localhost:9000",
+		},
+		{
 			name: "datasource with auth and path",
 			ds: &datasources.DataSource{
 				URL:           "https://localhost:9000/path/to/am",


### PR DESCRIPTION
**What is this feature?**

Fixes parsing of external AM basic auth when it contains characters than need to be escaped.

**Why do we need this feature?**

External AMs with basic auth containing characters than need to be escaped were failing parse.

**Who is this feature for?**

Users of grafana alerting with external alertmanagers.

**Which issue(s) does this PR fix?**:

Fixes #84679

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
