### PR TITLE
Dropdown: Fix keyboard accessibility

### DIFF
--- a/packages/grafana-ui/src/components/Dropdown/Dropdown.tsx
+++ b/packages/grafana-ui/src/components/Dropdown/Dropdown.tsx
@@ -1,5 +1,6 @@
 import { css } from '@emotion/css';
 import {
+  FloatingFocusManager,
   autoUpdate,
   flip,
   offset as floatingUIOffset,
@@ -9,7 +10,6 @@ import {
   useFloating,
   useInteractions,
 } from '@floating-ui/react';
-import { FocusScope } from '@react-aria/focus';
 import React, { useEffect, useRef, useState } from 'react';
 import { CSSTransition } from 'react-transition-group';
 
@@ -83,7 +83,7 @@ export const Dropdown = React.memo(({ children, overlay, placement, offset, onVi
       })}
       {show && (
         <Portal>
-          <FocusScope autoFocus restoreFocus contain>
+          <FloatingFocusManager context={context}>
             {/*
               this is handling bubbled events from the inner overlay
               see https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/main/docs/rules/no-static-element-interactions.md#case-the-event-handler-is-only-being-used-to-capture-bubbled-events
@@ -100,7 +100,7 @@ export const Dropdown = React.memo(({ children, overlay, placement, offset, onVi
                 <div ref={transitionRef}>{ReactUtils.renderOrCallToRender(overlay, { ...getFloatingProps() })}</div>
               </CSSTransition>
             </div>
-          </FocusScope>
+          </FloatingFocusManager>
         </Portal>
       )}
     </>

--- a/packages/grafana-ui/src/components/Menu/Menu.tsx
+++ b/packages/grafana-ui/src/components/Menu/Menu.tsx
@@ -32,6 +32,7 @@ const MenuComp = React.forwardRef<HTMLDivElement, MenuProps>(
     return (
       <div
         {...otherProps}
+        tabIndex={-1}
         ref={localRef}
         className={styles.wrapper}
         role="menu"

--- a/packages/grafana-ui/src/components/Menu/Menu.tsx
+++ b/packages/grafana-ui/src/components/Menu/Menu.tsx
@@ -4,6 +4,7 @@ import React, { useImperativeHandle, useRef } from 'react';
 import { GrafanaTheme2 } from '@grafana/data';
 
 import { useStyles2 } from '../../themes';
+import { Box } from '../Layout/Box/Box';
 
 import { MenuDivider } from './MenuDivider';
 import { MenuGroup } from './MenuGroup';
@@ -30,14 +31,19 @@ const MenuComp = React.forwardRef<HTMLDivElement, MenuProps>(
     const [handleKeys] = useMenuFocus({ isMenuOpen: true, localRef, onOpen, onClose, onKeyDown });
 
     return (
-      <div
+      <Box
         {...otherProps}
-        tabIndex={-1}
-        ref={localRef}
-        className={styles.wrapper}
-        role="menu"
         aria-label={ariaLabel}
+        backgroundColor="primary"
+        borderRadius="default"
+        boxShadow="z3"
+        display="inline-block"
         onKeyDown={handleKeys}
+        paddingX={0}
+        paddingY={0.5}
+        ref={localRef}
+        role="menu"
+        tabIndex={-1}
       >
         {header && (
           <div
@@ -50,7 +56,7 @@ const MenuComp = React.forwardRef<HTMLDivElement, MenuProps>(
           </div>
         )}
         {children}
-      </div>
+      </Box>
     );
   }
 );
@@ -70,13 +76,6 @@ const getStyles = (theme: GrafanaTheme2) => {
     }),
     headerBorder: css({
       borderBottom: `1px solid ${theme.colors.border.weak}`,
-    }),
-    wrapper: css({
-      background: theme.colors.background.primary,
-      boxShadow: theme.shadows.z3,
-      display: 'inline-block',
-      borderRadius: theme.shape.radius.default,
-      padding: theme.spacing(0.5, 0),
     }),
   };
 };

--- a/packages/grafana-ui/src/components/Menu/Menu.tsx
+++ b/packages/grafana-ui/src/components/Menu/Menu.tsx
@@ -27,12 +27,11 @@ const MenuComp = React.forwardRef<HTMLDivElement, MenuProps>(
     const localRef = useRef<HTMLDivElement>(null);
     useImperativeHandle(forwardedRef, () => localRef.current!);
 
-    const [handleKeys] = useMenuFocus({ localRef, onOpen, onClose, onKeyDown });
+    const [handleKeys] = useMenuFocus({ isMenuOpen: true, localRef, onOpen, onClose, onKeyDown });
 
     return (
       <div
         {...otherProps}
-        tabIndex={-1}
         ref={localRef}
         className={styles.wrapper}
         role="menu"
@@ -66,17 +65,21 @@ export const Menu = Object.assign(MenuComp, {
 const getStyles = (theme: GrafanaTheme2) => {
   return {
     header: css({
-      padding: `${theme.spacing(0.5, 1, 1, 1)}`,
+      padding: theme.spacing(0.5, 1, 1, 1),
     }),
     headerBorder: css({
       borderBottom: `1px solid ${theme.colors.border.weak}`,
     }),
     wrapper: css({
-      background: `${theme.colors.background.primary}`,
-      boxShadow: `${theme.shadows.z3}`,
-      display: `inline-block`,
-      borderRadius: `${theme.shape.radius.default}`,
-      padding: `${theme.spacing(0.5, 0)}`,
+      background: theme.colors.background.primary,
+      boxShadow: theme.shadows.z3,
+      display: 'inline-block',
+      borderRadius: theme.shape.radius.default,
+      padding: theme.spacing(0.5, 0),
+
+      '&:focus': {
+        outline: 'none',
+      },
     }),
   };
 };

--- a/packages/grafana-ui/src/components/Menu/Menu.tsx
+++ b/packages/grafana-ui/src/components/Menu/Menu.tsx
@@ -76,10 +76,6 @@ const getStyles = (theme: GrafanaTheme2) => {
       display: 'inline-block',
       borderRadius: theme.shape.radius.default,
       padding: theme.spacing(0.5, 0),
-
-      '&:focus': {
-        outline: 'none',
-      },
     }),
   };
 };

--- a/packages/grafana-ui/src/components/Menu/MenuItem.tsx
+++ b/packages/grafana-ui/src/components/Menu/MenuItem.tsx
@@ -79,7 +79,6 @@ export const MenuItem = React.memo(
     const styles = useStyles2(getStyles);
     const [isActive, setIsActive] = useState(active);
     const [isSubMenuOpen, setIsSubMenuOpen] = useState(false);
-    const [openedWithArrow, setOpenedWithArrow] = useState(false);
     const onMouseEnter = useCallback(() => {
       if (disabled) {
         return;
@@ -128,7 +127,6 @@ export const MenuItem = React.memo(
           event.stopPropagation();
           if (hasSubMenu) {
             setIsSubMenuOpen(true);
-            setOpenedWithArrow(true);
             setIsActive(true);
           }
           break;
@@ -178,8 +176,6 @@ export const MenuItem = React.memo(
               <SubMenu
                 items={childItems}
                 isOpen={isSubMenuOpen}
-                openedWithArrow={openedWithArrow}
-                setOpenedWithArrow={setOpenedWithArrow}
                 close={closeSubMenu}
                 customStyle={customSubMenuContainerStyles}
               />
@@ -219,7 +215,7 @@ const getStyles = (theme: GrafanaTheme2) => {
       width: '100%',
       position: 'relative',
 
-      '&:hover, &:focus, &:focus-visible': {
+      '&:hover, &:focus-visible': {
         background: theme.colors.action.hover,
         color: theme.colors.text.primary,
         textDecoration: 'none',

--- a/packages/grafana-ui/src/components/Menu/SubMenu.test.tsx
+++ b/packages/grafana-ui/src/components/Menu/SubMenu.test.tsx
@@ -13,9 +13,7 @@ describe('SubMenu', () => {
       <MenuItem key="subitem2" label="subitem2" icon="apps" />,
     ];
 
-    render(
-      <SubMenu items={items} isOpen={true} openedWithArrow={false} setOpenedWithArrow={jest.fn()} close={jest.fn()} />
-    );
+    render(<SubMenu items={items} isOpen={true} close={jest.fn()} />);
 
     expect(screen.getByTestId(selectors.components.Menu.SubMenu.icon)).toBeInTheDocument();
 

--- a/packages/grafana-ui/src/components/Menu/SubMenu.tsx
+++ b/packages/grafana-ui/src/components/Menu/SubMenu.tsx
@@ -17,10 +17,6 @@ export interface SubMenuProps {
   items?: Array<ReactElement<MenuItemProps>>;
   /** Open */
   isOpen: boolean;
-  /** Marks whether subMenu was opened with arrow */
-  openedWithArrow: boolean;
-  /** Changes value of openedWithArrow */
-  setOpenedWithArrow: (openedWithArrow: boolean) => void;
   /** Closes the subMenu */
   close: () => void;
   /** Custom style */
@@ -28,46 +24,42 @@ export interface SubMenuProps {
 }
 
 /** @internal */
-export const SubMenu = React.memo(
-  ({ items, isOpen, openedWithArrow, setOpenedWithArrow, close, customStyle }: SubMenuProps) => {
-    const styles = useStyles2(getStyles);
-    const localRef = useRef<HTMLDivElement>(null);
-    const [handleKeys] = useMenuFocus({
-      localRef,
-      isMenuOpen: isOpen,
-      openedWithArrow,
-      setOpenedWithArrow,
-      close,
-    });
+export const SubMenu = React.memo(({ items, isOpen, close, customStyle }: SubMenuProps) => {
+  const styles = useStyles2(getStyles);
+  const localRef = useRef<HTMLDivElement>(null);
+  const [handleKeys] = useMenuFocus({
+    localRef,
+    isMenuOpen: isOpen,
+    close,
+  });
 
-    const [pushLeft, setPushLeft] = useState(false);
-    useEffect(() => {
-      if (isOpen && localRef.current) {
-        setPushLeft(isElementOverflowing(localRef.current));
-      }
-    }, [isOpen]);
+  const [pushLeft, setPushLeft] = useState(false);
+  useEffect(() => {
+    if (isOpen && localRef.current) {
+      setPushLeft(isElementOverflowing(localRef.current));
+    }
+  }, [isOpen]);
 
-    return (
-      <>
-        <div className={styles.iconWrapper} aria-hidden data-testid={selectors.components.Menu.SubMenu.icon}>
-          <Icon name="angle-right" className={styles.icon} />
-        </div>
-        {isOpen && (
-          <div
-            ref={localRef}
-            className={cx(styles.subMenu, { [styles.pushLeft]: pushLeft })}
-            data-testid={selectors.components.Menu.SubMenu.container}
-            style={customStyle}
-          >
-            <div tabIndex={-1} className={styles.itemsWrapper} role="menu" onKeyDown={handleKeys}>
-              {items}
-            </div>
+  return (
+    <>
+      <div className={styles.iconWrapper} aria-hidden data-testid={selectors.components.Menu.SubMenu.icon}>
+        <Icon name="angle-right" className={styles.icon} />
+      </div>
+      {isOpen && (
+        <div
+          ref={localRef}
+          className={cx(styles.subMenu, { [styles.pushLeft]: pushLeft })}
+          data-testid={selectors.components.Menu.SubMenu.container}
+          style={customStyle}
+        >
+          <div tabIndex={-1} className={styles.itemsWrapper} role="menu" onKeyDown={handleKeys}>
+            {items}
           </div>
-        )}
-      </>
-    );
-  }
-);
+        </div>
+      )}
+    </>
+  );
+});
 
 SubMenu.displayName = 'SubMenu';
 

--- a/packages/grafana-ui/src/components/Menu/hooks.test.tsx
+++ b/packages/grafana-ui/src/components/Menu/hooks.test.tsx
@@ -141,18 +141,15 @@ describe('useMenuFocus', () => {
     expect(onKeyDown).toHaveBeenCalledTimes(2);
   });
 
-  it('focuses on first item when menu was opened with arrow', () => {
+  it('focuses on first item', () => {
     const ref = createRef<HTMLDivElement>();
 
     render(getMenuElement(ref));
 
     const isMenuOpen = true;
-    const openedWithArrow = true;
-    const setOpenedWithArrow = jest.fn();
-    renderHook(() => useMenuFocus({ localRef: ref, isMenuOpen, openedWithArrow, setOpenedWithArrow }));
+    renderHook(() => useMenuFocus({ localRef: ref, isMenuOpen }));
 
     expect(screen.getByText('Item 1').tabIndex).toBe(0);
-    expect(setOpenedWithArrow).toHaveBeenCalledWith(false);
   });
 
   it('clicks focused item when Enter key is pressed', () => {

--- a/packages/grafana-ui/src/components/Menu/hooks.ts
+++ b/packages/grafana-ui/src/components/Menu/hooks.ts
@@ -8,8 +8,6 @@ const UNFOCUSED = -1;
 export interface UseMenuFocusProps {
   localRef: RefObject<HTMLDivElement>;
   isMenuOpen?: boolean;
-  openedWithArrow?: boolean;
-  setOpenedWithArrow?: (openedWithArrow: boolean) => void;
   close?: () => void;
   onOpen?: (focusOnItem: (itemId: number) => void) => void;
   onClose?: () => void;
@@ -23,8 +21,6 @@ export type UseMenuFocusReturn = [(event: React.KeyboardEvent) => void];
 export const useMenuFocus = ({
   localRef,
   isMenuOpen,
-  openedWithArrow,
-  setOpenedWithArrow,
   close,
   onOpen,
   onClose,
@@ -33,11 +29,10 @@ export const useMenuFocus = ({
   const [focusedItem, setFocusedItem] = useState(UNFOCUSED);
 
   useEffect(() => {
-    if (isMenuOpen && openedWithArrow) {
+    if (isMenuOpen) {
       setFocusedItem(0);
-      setOpenedWithArrow?.(false);
     }
-  }, [isMenuOpen, openedWithArrow, setOpenedWithArrow]);
+  }, [isMenuOpen]);
 
   useEffect(() => {
     const menuItems = localRef?.current?.querySelectorAll<HTMLElement | HTMLButtonElement | HTMLAnchorElement>(

--- a/public/app/features/alerting/unified/components/contact-points/ContactPoints.test.tsx
+++ b/public/app/features/alerting/unified/components/contact-points/ContactPoints.test.tsx
@@ -126,6 +126,8 @@ describe('contact points', () => {
         await userEvent.click(button);
         const deleteButton = await screen.queryByRole('menuitem', { name: 'delete' });
         expect(deleteButton).toBeDisabled();
+        // click outside the menu to close it otherwise we can't interact with the rest of the page
+        await userEvent.click(document.body);
       }
 
       // check buttons in Notification Templates


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

- correctly passes `isMenuOpen` to `useMenuFocus`
- removes the `openedWithArrow`/`setOpenedWithArrow` concepts as we want the same behaviour no matter what
  - ~technically a breaking change for `Menu`?~
    - nope, both `MenuItem` and `SubMenu` are marked as `@internal` 🙌 
  - i suspect no one is using these properties externally as they're very internal 
- replaces `FocusScope` with `FloatingFocusManager` (this doesn't really change anything, just thought we might as well while we're here)

**Why do we need this feature?**

- so it's properly keyboard accessible
- think this is actually an overall improvement and not just fixing a regression, as before the focus would be on the containing menu element and you'd have to press the down arrow before focusing an individual option. now we immediately focus the first option in the menu 🥳 

**Who is this feature for?**

- everyone!

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #84652 

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
