### PR TITLE
Alerting: Marshal incoming json.RawMessage in diff

### DIFF
--- a/pkg/services/ngalert/models/alert_rule.go
+++ b/pkg/services/ngalert/models/alert_rule.go
@@ -346,7 +346,11 @@ func (alertRule *AlertRule) Diff(rule *AlertRule, ignore ...string) cmputil.Diff
 
 	// json.RawMessage is a slice of bytes and therefore cmp's default behavior is to compare it by byte, which is not really useful
 	var jsonCmp = cmp.Transformer("", func(in json.RawMessage) string {
-		return string(in)
+		b, err := json.Marshal(in)
+		if err != nil {
+			return string(in)
+		}
+		return string(b)
 	})
 	ops = append(
 		ops,

--- a/pkg/services/ngalert/models/alert_rule_test.go
+++ b/pkg/services/ngalert/models/alert_rule_test.go
@@ -656,6 +656,21 @@ func TestDiff(t *testing.T) {
 			}
 		})
 
+		t.Run("should correctly detect no change with '<' and '>' in query", func(t *testing.T) {
+			old := query1
+			new := query1
+			old.Model = json.RawMessage(`{"field1": "$A \u003c 1"}`)
+			new.Model = json.RawMessage(`{"field1": "$A < 1"}`)
+			rule1.Data = []AlertQuery{old}
+			rule2.Data = []AlertQuery{new}
+
+			diff := rule1.Diff(rule2)
+			assert.Nil(t, diff)
+
+			// reset rule1
+			rule1.Data = []AlertQuery{query1}
+		})
+
 		t.Run("should detect new changes in array if too many fields changed", func(t *testing.T) {
 			query2 := query1
 			query2.QueryType = "test"


### PR DESCRIPTION
**What is this feature?**

This PR slightly changes the behavior of the transformer for `json.RawMessage` when comparing two alert rules. It marshals the value and casts the resultant byte array to a string in order to ensure the encoding of the resultant string is the same for both rules.

**Why do we need this feature?**

This allows users to delete rules in groups that contain rules that would fail validation, if they were to be validated.

**Who is this feature for?**

Users of Grafana-managed alerting.

**Which issue(s) does this PR fix?**:

Fixes #81840

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle.
- [x] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
