### PR TITLE
Transformations - make substring and not substring transformer case insensitive.

### DIFF
--- a/packages/grafana-data/src/transformations/matchers/valueMatchers/substringMatchers.test.ts
+++ b/packages/grafana-data/src/transformations/matchers/valueMatchers/substringMatchers.test.ts
@@ -9,7 +9,7 @@ describe('value substring to matcher', () => {
       fields: [
         {
           name: 'temp',
-          values: ['24', null, '10', 'asd', '42'],
+          values: ['24', null, '10', 'asd', '42', 'ASD'],
         },
       ],
     }),
@@ -28,6 +28,20 @@ describe('value substring to matcher', () => {
     const valueIndex = 0;
 
     expect(matcher(valueIndex, field, frame, data)).toBeTruthy();
+  });
+
+  it('should match case insensitive', () => {
+    const frame = data[0];
+    const field = frame.fields[0];
+    const valueIndex = 5;
+    const caseInsensitiveMatcher = getValueMatcher({
+      id: ValueMatcherID.substring,
+      options: {
+        value: 'asd',
+      },
+    });
+
+    expect(caseInsensitiveMatcher(valueIndex, field, frame, data)).toBeTruthy();
   });
 
   // Added for https://github.com/grafana/grafana/pull/83548#pullrequestreview-1904931540 where the matcher was not handling null values

--- a/packages/grafana-data/src/transformations/matchers/valueMatchers/substringMatchers.ts
+++ b/packages/grafana-data/src/transformations/matchers/valueMatchers/substringMatchers.ts
@@ -11,7 +11,11 @@ const isSubstringMatcher: ValueMatcherInfo<BasicValueMatcherOptions> = {
   get: (options) => {
     return (valueIndex: number, field: Field) => {
       const value = field.values[valueIndex];
-      return (value && value.includes(options.value)) || options.value === '';
+      return (value 
+              && options.value 
+              && value.toLowerCase().includes(options.value.toLowerCase())
+              ) 
+              || options.value === '';
     };
   },
   getOptionsDisplayText: () => {
@@ -28,7 +32,11 @@ const isNotSubstringValueMatcher: ValueMatcherInfo<BasicValueMatcherOptions> = {
   get: (options) => {
     return (valueIndex: number, field: Field) => {
       const value = field.values[valueIndex];
-      return typeof value === 'string' && options.value !== '' && !value.includes(options.value);
+      return typeof value === 'string' 
+              && options.value 
+              && value
+              && options.value !== '' 
+              && !value.toLowerCase().includes(options.value.toLowerCase());
     };
   },
   getOptionsDisplayText: () => {

--- a/packages/grafana-data/src/transformations/matchers/valueMatchers/substringMatchers.ts
+++ b/packages/grafana-data/src/transformations/matchers/valueMatchers/substringMatchers.ts
@@ -11,11 +11,9 @@ const isSubstringMatcher: ValueMatcherInfo<BasicValueMatcherOptions> = {
   get: (options) => {
     return (valueIndex: number, field: Field) => {
       const value = field.values[valueIndex];
-      return (value 
-              && options.value 
-              && value.toLowerCase().includes(options.value.toLowerCase())
-              ) 
-              || options.value === '';
+      return (
+        (value && options.value && value.toLowerCase().includes(options.value.toLowerCase())) || options.value === ''
+      );
     };
   },
   getOptionsDisplayText: () => {
@@ -32,11 +30,13 @@ const isNotSubstringValueMatcher: ValueMatcherInfo<BasicValueMatcherOptions> = {
   get: (options) => {
     return (valueIndex: number, field: Field) => {
       const value = field.values[valueIndex];
-      return typeof value === 'string' 
-              && options.value 
-              && value
-              && options.value !== '' 
-              && !value.toLowerCase().includes(options.value.toLowerCase());
+      return (
+        typeof value === 'string' &&
+        options.value &&
+        value &&
+        options.value !== '' &&
+        !value.toLowerCase().includes(options.value.toLowerCase())
+      );
     };
   },
   getOptionsDisplayText: () => {


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

Got some [feedback](https://raintank-corp.slack.com/archives/C036J5B39/p1709890324917879?thread_ts=1709852108.538739&cid=C036J5B39) on the substring transformer for value filtering that it would be nicer if it was case insensitive. So this adds that :)

**Why do we need this feature?**

Sometimes you don't know if something is cased when searching for it.

**Who is this feature for?**

everyone

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
