### PR TITLE
Chore: ignore Go coverage .out files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -214,3 +214,5 @@ public/app/plugins/**/dist/
 /public/app/features/transformers/docs/*.js
 /scripts/docs/generate-transformations.js
 
+# Go coverage files created with go test -cover -coverprogile=something.out ...
+*.out


### PR DESCRIPTION
**What is this feature?**

Adds an entry to `.gitignore` to ignore `*.out` files, which are generated by Go when creating cover profile files. Example command used to generate coverage files and then use them:
```shell
go test -race -cover -coverprofile=coverage.out -covermode=atomic && go tool cover -html=coverage.out
```
Note that the extension is just a convention, but there are some automated tools that use it by default already.

**Why do we need this feature?**

To prevent accidentally committing coverage files, which should be dynamically generated.

**Who is this feature for?**

Developers.

**Which issue(s) does this PR fix?**:

None.

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
