### PR TITLE
Snapshots: Require delete within same org (backport)

### DIFF
--- a/pkg/api/dashboard_snapshot.go
+++ b/pkg/api/dashboard_snapshot.go
@@ -356,6 +356,9 @@ func (hs *HTTPServer) DeleteDashboardSnapshot(c *contextmodel.ReqContext) respon
 	if queryResult == nil {
 		return response.Error(http.StatusNotFound, "Failed to get dashboard snapshot", nil)
 	}
+	if queryResult.OrgID != c.OrgID {
+		return response.Error(http.StatusUnauthorized, "OrgID mismatch", nil)
+	}
 
 	if queryResult.External {
 		err := deleteExternalDashboardSnapshot(queryResult.ExternalDeleteURL)

--- a/pkg/api/dashboard_snapshot_test.go
+++ b/pkg/api/dashboard_snapshot_test.go
@@ -9,21 +9,21 @@ import (
 	"testing"
 	"time"
 
-	"github.com/grafana/grafana/pkg/services/accesscontrol"
-	"github.com/grafana/grafana/pkg/services/accesscontrol/acimpl"
-	"github.com/grafana/grafana/pkg/services/user"
-	"github.com/grafana/grafana/pkg/web/webtest"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 
 	"github.com/grafana/grafana/pkg/components/simplejson"
 	"github.com/grafana/grafana/pkg/infra/db/dbtest"
+	"github.com/grafana/grafana/pkg/services/accesscontrol"
+	"github.com/grafana/grafana/pkg/services/accesscontrol/acimpl"
 	"github.com/grafana/grafana/pkg/services/dashboards"
 	"github.com/grafana/grafana/pkg/services/dashboardsnapshots"
 	"github.com/grafana/grafana/pkg/services/guardian"
 	"github.com/grafana/grafana/pkg/services/org"
+	"github.com/grafana/grafana/pkg/services/user"
 	"github.com/grafana/grafana/pkg/setting"
+	"github.com/grafana/grafana/pkg/web/webtest"
 )
 
 func TestHTTPServer_DeleteDashboardSnapshot(t *testing.T) {
@@ -148,12 +148,11 @@ func TestDashboardSnapshotAPIEndpoint_singleSnapshot(t *testing.T) {
 				sc.handlerFunc = hs.DeleteDashboardSnapshotByDeleteKey
 				sc.fakeReqWithParams("GET", sc.url, map[string]string{"deleteKey": "12345"}).exec()
 
-				require.Equal(t, 200, sc.resp.Code)
+				require.Equal(t, 200, sc.resp.Code, "BODY: "+sc.resp.Body.String())
 				respJSON, err := simplejson.NewJson(sc.resp.Body.Bytes())
 				require.NoError(t, err)
 
 				assert.True(t, strings.HasPrefix(respJSON.Get("message").MustString(), "Snapshot deleted"))
-				assert.Equal(t, 1, respJSON.Get("id").MustInt())
 
 				assert.Equal(t, http.MethodGet, externalRequest.Method)
 				assert.Equal(t, ts.URL, fmt.Sprintf("http://%s", externalRequest.Host))
@@ -271,7 +270,7 @@ func TestGetDashboardSnapshotNotFound(t *testing.T) {
 			sc.handlerFunc = hs.DeleteDashboardSnapshot
 			sc.fakeReqWithParams("DELETE", sc.url, map[string]string{"key": "12345"}).exec()
 
-			assert.Equal(t, http.StatusNotFound, sc.resp.Code)
+			assert.Equal(t, http.StatusNotFound, sc.resp.Code, "BODY: "+sc.resp.Body.String())
 		}, sqlmock)
 
 	loggedInUserScenarioWithRole(t,
@@ -282,7 +281,7 @@ func TestGetDashboardSnapshotNotFound(t *testing.T) {
 			sc.handlerFunc = hs.DeleteDashboardSnapshotByDeleteKey
 			sc.fakeReqWithParams("DELETE", sc.url, map[string]string{"deleteKey": "12345"}).exec()
 
-			assert.Equal(t, http.StatusNotFound, sc.resp.Code)
+			assert.Equal(t, http.StatusNotFound, sc.resp.Code, "BODY: "+sc.resp.Body.String())
 		}, sqlmock)
 }
 
@@ -345,7 +344,7 @@ func TestGetDashboardSnapshotFailure(t *testing.T) {
 			sc.handlerFunc = hs.DeleteDashboardSnapshot
 			sc.fakeReqWithParams("DELETE", sc.url, map[string]string{"key": "12345"}).exec()
 
-			assert.Equal(t, http.StatusForbidden, sc.resp.Code)
+			assert.Equal(t, http.StatusForbidden, sc.resp.Code, "BODY: "+sc.resp.Body.String())
 		}, sqlmock)
 
 	loggedInUserScenarioWithRole(t,
@@ -356,7 +355,7 @@ func TestGetDashboardSnapshotFailure(t *testing.T) {
 			sc.handlerFunc = hs.DeleteDashboardSnapshotByDeleteKey
 			sc.fakeReqWithParams("DELETE", sc.url, map[string]string{"deleteKey": "12345"}).exec()
 
-			assert.Equal(t, http.StatusInternalServerError, sc.resp.Code)
+			assert.Equal(t, http.StatusInternalServerError, sc.resp.Code, "BODY: "+sc.resp.Body.String())
 		}, sqlmock)
 
 	loggedInUserScenarioWithRole(t,
@@ -367,7 +366,7 @@ func TestGetDashboardSnapshotFailure(t *testing.T) {
 			sc.handlerFunc = hs.DeleteDashboardSnapshotByDeleteKey
 			sc.fakeReqWithParams("DELETE", sc.url, map[string]string{"deleteKey": "12345"}).exec()
 
-			assert.Equal(t, http.StatusForbidden, sc.resp.Code)
+			assert.Equal(t, http.StatusForbidden, sc.resp.Code, "BODY: "+sc.resp.Body.String())
 		}, sqlmock)
 }
 
@@ -391,6 +390,7 @@ func setUpSnapshotTest(t *testing.T, userId int64, deleteUrl string) dashboardsn
 
 	res := &dashboardsnapshots.DashboardSnapshot{
 		ID:        1,
+		OrgID:     1,
 		Key:       "12345",
 		DeleteKey: "54321",
 		Dashboard: jsonModel,


### PR DESCRIPTION
Manual backport with fix included from https://github.com/grafana/grafana/pull/83111 -- this is a replacement for https://github.com/grafana/grafana/pull/83942

The fix is already included in 10.4 (and 11)