### PR TITLE
Dashboard scenes: Refactor scene save library panel

### DIFF
--- a/public/app/features/dashboard-scene/panel-edit/VizPanelManager.test.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/VizPanelManager.test.tsx
@@ -6,7 +6,6 @@ import { SceneGridItem, SceneQueryRunner, VizPanel } from '@grafana/scenes';
 import { DataQuery, DataSourceJsonData, DataSourceRef } from '@grafana/schema';
 import { getDashboardSrv } from 'app/features/dashboard/services/DashboardSrv';
 import { InspectTab } from 'app/features/inspector/types';
-import * as libAPI from 'app/features/library-panels/state/api';
 import { SHARED_DASHBOARD_QUERY } from 'app/plugins/datasource/dashboard';
 import { DASHBOARD_DATASOURCE_PLUGIN_ID } from 'app/plugins/datasource/dashboard/types';
 
@@ -212,45 +211,6 @@ describe('VizPanelManager', () => {
   });
 
   describe('library panels', () => {
-    it('saves library panels on commit', () => {
-      const panel = new VizPanel({
-        key: 'panel-1',
-        pluginId: 'text',
-      });
-
-      const libraryPanelModel = {
-        title: 'title',
-        uid: 'uid',
-        name: 'libraryPanelName',
-        model: vizPanelToPanel(panel),
-        type: 'panel',
-        version: 1,
-      };
-
-      const libraryPanel = new LibraryVizPanel({
-        isLoaded: true,
-        title: libraryPanelModel.title,
-        uid: libraryPanelModel.uid,
-        name: libraryPanelModel.name,
-        panelKey: panel.state.key!,
-        panel: panel,
-        _loadedPanel: libraryPanelModel,
-      });
-
-      new SceneGridItem({ body: libraryPanel });
-
-      const panelManager = VizPanelManager.createFor(panel);
-
-      const apiCall = jest
-        .spyOn(libAPI, 'updateLibraryVizPanel')
-        .mockResolvedValue({ type: 'panel', ...libAPI.libraryVizPanelToSaveModel(libraryPanel) });
-
-      panelManager.state.panel.setState({ title: 'new title' });
-      panelManager.commitChanges();
-
-      expect(apiCall.mock.calls[0][0].state.panel?.state.title).toBe('new title');
-    });
-
     it('unlinks library panel', () => {
       const panel = new VizPanel({
         key: 'panel-1',

--- a/public/app/features/dashboard-scene/panel-edit/VizPanelManager.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/VizPanelManager.tsx
@@ -31,7 +31,6 @@ import { useStyles2 } from '@grafana/ui';
 import { getPluginVersion } from 'app/features/dashboard/state/PanelModel';
 import { getLastUsedDatasourceFromStorage } from 'app/features/dashboard/utils/dashboard';
 import { storeLastUsedDataSourceInLocalStorage } from 'app/features/datasources/components/picker/utils';
-import { updateLibraryVizPanel } from 'app/features/library-panels/state/api';
 import { updateQueries } from 'app/features/query/state/updateQueries';
 import { GrafanaQuery } from 'app/plugins/datasource/grafana/types';
 import { QueryGroupOptions } from 'app/types';
@@ -365,24 +364,6 @@ export class VizPanelManager extends SceneObjectBase<VizPanelManagerState> {
           $data: this.state.$data?.clone(),
         }),
       });
-    }
-
-    if (sourcePanel.parent instanceof LibraryVizPanel) {
-      if (sourcePanel.parent.parent instanceof SceneGridItem) {
-        const newLibPanel = sourcePanel.parent.clone({
-          panel: this.state.panel.clone({
-            $data: this.state.$data?.clone(),
-          }),
-        });
-        sourcePanel.parent.parent.setState({
-          body: newLibPanel,
-        });
-        updateLibraryVizPanel(newLibPanel!).then((p) => {
-          if (sourcePanel.parent instanceof LibraryVizPanel) {
-            newLibPanel.setPanelFromLibPanel(p);
-          }
-        });
-      }
     }
   }
 


### PR DESCRIPTION
Small refactor to how we save library panels. Should also let the user stay in the edit view after save, as in the old architecture. 

Since editing library panels is sort of a special case I've opted to let the panel editor be responsible for saving the panel instead of the VizPanelManager, just to keep the VizPanelManager more focused on normal viz panels. Don't have a strong opinion on this, so the save functionality could move to the manager as well.