### PR TITLE
Tempo: Update condition for migration from old nativeSearch editor

### DIFF
--- a/public/app/plugins/datasource/tempo/datasource.ts
+++ b/public/app/plugins/datasource/tempo/datasource.ts
@@ -274,7 +274,11 @@ export class TempoDatasource extends DataSourceWithBackend<TempoQuery, TempoJson
         targets.nativeSearch[0].queryType === 'nativeSearch'
       ) {
         const migratedQuery = migrateFromSearchToTraceQLSearch(targets.nativeSearch[0]);
-        targets.traceqlSearch = [migratedQuery];
+        if (targets.traceqlSearch?.length) {
+          targets.traceqlSearch.push(migratedQuery);
+        } else {
+          targets.traceqlSearch = [migratedQuery];
+        }
       }
     }
 


### PR DESCRIPTION
**What is this feature?**

Updates the condition for migration from old `nativeSearch` editor to new `traceqlSearch` editor to ensure we push to the `traceqlSearch` targets array if there are multiple targets (queries).

**Why do we need this feature?**

More precise migration.

**Who is this feature for?**

Tempo users.