### PR TITLE
Elasticsearch: Remove xpack button and make includeFrozen not dependant on it

### DIFF
--- a/pkg/tsdb/elasticsearch/client/client.go
+++ b/pkg/tsdb/elasticsearch/client/client.go
@@ -38,7 +38,6 @@ type DatasourceInfo struct {
 	Interval                   string
 	MaxConcurrentShardRequests int64
 	IncludeFrozen              bool
-	XPack                      bool
 }
 
 type ConfiguredFields struct {
@@ -262,7 +261,7 @@ func (c *baseClientImpl) getMultiSearchQueryParameters() string {
 	}
 	qs = append(qs, fmt.Sprintf("max_concurrent_shard_requests=%d", maxConcurrentShardRequests))
 
-	if c.ds.IncludeFrozen && c.ds.XPack {
+	if c.ds.IncludeFrozen {
 		qs = append(qs, "ignore_throttled=false")
 	}
 

--- a/pkg/tsdb/elasticsearch/client/client_test.go
+++ b/pkg/tsdb/elasticsearch/client/client_test.go
@@ -58,7 +58,6 @@ func TestClient_ExecuteMultisearch(t *testing.T) {
 			Interval:                   "Daily",
 			MaxConcurrentShardRequests: 6,
 			IncludeFrozen:              true,
-			XPack:                      true,
 		}
 
 		from := time.Date(2018, 5, 15, 17, 50, 0, 0, time.UTC)
@@ -148,7 +147,6 @@ func TestClient_ExecuteMultisearch(t *testing.T) {
 			Interval:                   "Daily",
 			MaxConcurrentShardRequests: 6,
 			IncludeFrozen:              true,
-			XPack:                      true,
 		}
 
 		from := time.Date(2018, 5, 15, 17, 50, 0, 0, time.UTC)
@@ -253,7 +251,6 @@ func TestClient_Index(t *testing.T) {
 				Interval:                   test.patternInDatasource,
 				MaxConcurrentShardRequests: 6,
 				IncludeFrozen:              true,
-				XPack:                      true,
 			}
 
 			from := time.Date(2018, 5, 10, 17, 50, 0, 0, time.UTC)

--- a/pkg/tsdb/elasticsearch/elasticsearch.go
+++ b/pkg/tsdb/elasticsearch/elasticsearch.go
@@ -157,11 +157,6 @@ func newInstanceSettings(httpClientProvider httpclient.Provider) datasource.Inst
 			includeFrozen = false
 		}
 
-		xpack, ok := jsonData["xpack"].(bool)
-		if !ok {
-			xpack = false
-		}
-
 		configuredFields := es.ConfiguredFields{
 			TimeField:       timeField,
 			LogLevelField:   logLevelField,
@@ -177,7 +172,6 @@ func newInstanceSettings(httpClientProvider httpclient.Provider) datasource.Inst
 			ConfiguredFields:           configuredFields,
 			Interval:                   interval,
 			IncludeFrozen:              includeFrozen,
-			XPack:                      xpack,
 		}
 		return model, nil
 	}

--- a/pkg/tsdb/elasticsearch/querydata_test.go
+++ b/pkg/tsdb/elasticsearch/querydata_test.go
@@ -57,7 +57,6 @@ func newFlowTestDsInfo(body []byte, statusCode int, requestCallback func(req *ht
 		HTTPClient:                 &client,
 		MaxConcurrentShardRequests: 42,
 		IncludeFrozen:              false,
-		XPack:                      true,
 	}
 }
 

--- a/public/app/plugins/datasource/elasticsearch/configuration/ElasticDetails.tsx
+++ b/public/app/plugins/datasource/elasticsearch/configuration/ElasticDetails.tsx
@@ -115,29 +115,18 @@ export const ElasticDetails = ({ value, onChange }: Props) => {
           placeholder="10s"
         />
       </InlineField>
-
-      <InlineField label="X-Pack enabled" labelWidth={29} tooltip="Enable or disable X-Pack specific features">
+      <InlineField
+        label="Include Frozen Indices"
+        htmlFor="es_config_frozenIndices"
+        labelWidth={29}
+        tooltip="Include frozen indices in searches."
+      >
         <InlineSwitch
-          id="es_config_xpackEnabled"
-          value={value.jsonData.xpack || false}
-          onChange={jsonDataSwitchChangeHandler('xpack', value, onChange)}
+          id="es_config_frozenIndices"
+          value={value.jsonData.includeFrozen ?? false}
+          onChange={jsonDataSwitchChangeHandler('includeFrozen', value, onChange)}
         />
       </InlineField>
-
-      {value.jsonData.xpack && (
-        <InlineField
-          label="Include Frozen Indices"
-          htmlFor="es_config_frozenIndices"
-          labelWidth={29}
-          tooltip="Include frozen indices in searches."
-        >
-          <InlineSwitch
-            id="es_config_frozenIndices"
-            value={value.jsonData.includeFrozen ?? false}
-            onChange={jsonDataSwitchChangeHandler('includeFrozen', value, onChange)}
-          />
-        </InlineField>
-      )}
     </ConfigSubSection>
   );
 };

--- a/public/app/plugins/datasource/elasticsearch/datasource.test.ts
+++ b/public/app/plugins/datasource/elasticsearch/datasource.test.ts
@@ -1056,19 +1056,13 @@ describe('ElasticDatasource', () => {
 
 describe('getMultiSearchUrl', () => {
   it('Should add correct params to URL if "includeFrozen" is enabled', () => {
-    const { ds } = getTestContext({ jsonData: { includeFrozen: true, xpack: true } });
+    const { ds } = getTestContext({ jsonData: { includeFrozen: true } });
 
     expect(ds.getMultiSearchUrl()).toMatch(/ignore_throttled=false/);
   });
 
   it('Should NOT add ignore_throttled if "includeFrozen" is disabled', () => {
-    const { ds } = getTestContext({ jsonData: { includeFrozen: false, xpack: true } });
-
-    expect(ds.getMultiSearchUrl()).not.toMatch(/ignore_throttled=false/);
-  });
-
-  it('Should NOT add ignore_throttled if "xpack" is disabled', () => {
-    const { ds } = getTestContext({ jsonData: { includeFrozen: true, xpack: false } });
+    const { ds } = getTestContext({ jsonData: { includeFrozen: false } });
 
     expect(ds.getMultiSearchUrl()).not.toMatch(/ignore_throttled=false/);
   });

--- a/public/app/plugins/datasource/elasticsearch/datasource.ts
+++ b/public/app/plugins/datasource/elasticsearch/datasource.ts
@@ -115,7 +115,6 @@ export class ElasticDatasource
   name: string;
   index: string;
   timeField: string;
-  xpack: boolean;
   interval: string;
   maxConcurrentShardRequests?: number;
   queryBuilder: ElasticQueryBuilder;
@@ -144,7 +143,6 @@ export class ElasticDatasource
 
     this.index = settingsData.index ?? instanceSettings.database ?? '';
     this.timeField = settingsData.timeField;
-    this.xpack = Boolean(settingsData.xpack);
     this.indexPattern = new IndexPattern(this.index, settingsData.interval);
     this.intervalPattern = settingsData.interval;
     this.interval = settingsData.timeInterval;
@@ -827,7 +825,7 @@ export class ElasticDatasource
       searchParams.append('max_concurrent_shard_requests', `${this.maxConcurrentShardRequests}`);
     }
 
-    if (this.xpack && this.includeFrozen) {
+    if (this.includeFrozen) {
       searchParams.append('ignore_throttled', 'false');
     }
 

--- a/public/app/plugins/datasource/elasticsearch/types.ts
+++ b/public/app/plugins/datasource/elasticsearch/types.ts
@@ -56,7 +56,6 @@ export interface ElasticsearchOptions extends DataSourceJsonData {
   timeField: string;
   // we used to have a field named `esVersion` in the past,
   // please do not use that name in the future.
-  xpack?: boolean;
   interval?: Interval;
   timeInterval: string;
   maxConcurrentShardRequests?: number;


### PR DESCRIPTION
Following up on https://github.com/grafana/grafana/pull/63460 and https://github.com/grafana/grafana/pull/63457, this PR addresses the issue highlighted in https://github.com/grafana/grafana/issues/65597.

The sole purpose of the `xpack` checkbox on the datasource configuration page has been to act as a gateway for accessing the "include-frozen" checkbox. As you can see in code changes, we are not using `xpack` setting in other places than with frozen indices. 

While there has been consideration to remove it previously, the decision was deferred to a major release to account for potential edge cases as breaking changes.

Identified edge case inconsistency:
1. Enable `xpack`
2. Enable `frozen-indices`
3. Disable `xpack`
4. Press [save]
At this juncture, the JSON configuration reflects `xpack=false, frozen=true`.

Historically, the utilization of the frozen-boolean mandated that both flags (`xpack` and `include-frozen`) be true. However, starting with version 11, the system will solely rely on the `frozenIndices` flag.

Fixes https://github.com/grafana/grafana/issues/65597.

# Release notice breaking change

The **xpack** checkbox dependency for enabling the **Include Frozen Indices** functionality has been removed, allowing direct control over frozen indices inclusion. Users should review their datasource settings to ensure the "Include Frozen Indices" option is configured as desired, particularly if xpack was previously disabled. This change aims to simplify configuration options and may affect queries if settings are not adjusted accordingly.