### PR TITLE
Alerting: Rename "classic condition" to "classic condition (legacy)"

### DIFF
--- a/public/app/features/expressions/types.ts
+++ b/public/app/features/expressions/types.ts
@@ -26,7 +26,7 @@ export const getExpressionLabel = (type: ExpressionQueryType) => {
     case ExpressionQueryType.resample:
       return 'Resample';
     case ExpressionQueryType.classic:
-      return 'Classic condition';
+      return 'Classic condition (legacy)';
     case ExpressionQueryType.threshold:
       return 'Threshold';
     case ExpressionQueryType.sql:
@@ -53,7 +53,7 @@ export const expressionTypes: Array<SelectableValue<ExpressionQueryType>> = [
   },
   {
     value: ExpressionQueryType.classic,
-    label: 'Classic condition',
+    label: 'Classic condition (legacy)',
     description:
       'Takes one or more time series returned from a query or an expression and checks if any of the series match the condition. Disables multi-dimensional alerts for this rule.',
   },


### PR DESCRIPTION
**What is this feature?**

This renames the existing "classic condition" expression to "classic condition (legacy)" to dissuade users from using it.

It does not support multi-dimensional alerting and collapses values from multiple dimensions into a single one. 

This confuses a lot of users and they would be better served with the reducer + threshold expression combination.