### PR TITLE
Auth: add Dex example to generic OAuth2 documentation

### DIFF
--- a/docs/sources/setup-grafana/configure-security/configure-authentication/generic-oauth/index.md
+++ b/docs/sources/setup-grafana/configure-security/configure-authentication/generic-oauth/index.md
@@ -516,3 +516,42 @@ To set up generic OAuth2 authentication with OneLogin, follow these steps:
    team_ids =
    allowed_organizations =
    ```
+
+### Set up OAuth2 with Dex
+
+To set up generic OAuth2 authentication with [Dex IdP](https://dexidp.io/), follow these
+steps:
+
+1. Add Grafana as a client in the Dex config YAML file:
+
+   ```yaml
+   staticClients:
+     - id: <client id>
+       name: Grafana
+       secret: <client secret>
+       redirectURIs:
+         - 'https://<grafana domain>/login/generic_oauth'
+   ```
+
+   {{% admonition type="note" %}}
+   Unlike many other OAuth2 providers, Dex doesn't provide `<client secret>`.
+   Instead, a secret can be generated with for example `openssl rand -hex 20`.
+   {{% /admonition %}}
+
+2. Update the `[auth.generic_oauth]` section of the Grafana configuration:
+
+   ```bash
+   [auth.generic_oauth]
+   name = Dex
+   enabled = true
+   client_id = <client id>
+   client_secret = <client secret>
+   scopes = openid email profile groups offline_access
+   auth_url = https://<dex base uri>/auth
+   token_url = https://<dex base uri>/token
+   api_url = https://<dex base uri>/userinfo
+   ```
+
+   `<dex base uri>` corresponds to the `issuer: ` configuration in Dex (e.g. the Dex
+   domain possibly including a path such as e.g. `/dex`). The `offline_access` scope is
+   needed when using [refresh tokens]({{< relref "#configure-a-refresh-token" >}}).


### PR DESCRIPTION
This patch adds an example configuration for setting up generic OAuth2 authentication using [Dex IdP](https://dexidp.io/).

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
