### PR TITLE
Alerting: Preserve newlines and whitespace for Prometheus and Loki queries

### DIFF
--- a/public/app/features/alerting/unified/components/rule-viewer/tabs/Query/DataSourceModelPreview.tsx
+++ b/public/app/features/alerting/unified/components/rule-viewer/tabs/Query/DataSourceModelPreview.tsx
@@ -19,11 +19,19 @@ interface DatasourceModelPreviewProps {
 
 function DatasourceModelPreview({ model, dataSource: datasource }: DatasourceModelPreviewProps): React.ReactNode {
   if (datasource.type === DataSourceType.Prometheus && isPromOrLokiQuery(model)) {
-    return <PrometheusQueryPreview query={model.expr} />;
+    return (
+      <pre>
+        <PrometheusQueryPreview query={model.expr} />
+      </pre>
+    );
   }
 
   if (datasource.type === DataSourceType.Loki && isPromOrLokiQuery(model)) {
-    return <LokiQueryPreview query={model.expr ?? ''} />;
+    return (
+      <pre>
+        <LokiQueryPreview query={model.expr ?? ''} />
+      </pre>
+    );
   }
 
   if (isSQLLikeQuery(model)) {

--- a/public/app/features/alerting/unified/components/rule-viewer/tabs/Query/DataSourceModelPreview.tsx
+++ b/public/app/features/alerting/unified/components/rule-viewer/tabs/Query/DataSourceModelPreview.tsx
@@ -19,19 +19,11 @@ interface DatasourceModelPreviewProps {
 
 function DatasourceModelPreview({ model, dataSource: datasource }: DatasourceModelPreviewProps): React.ReactNode {
   if (datasource.type === DataSourceType.Prometheus && isPromOrLokiQuery(model)) {
-    return (
-      <pre>
-        <PrometheusQueryPreview query={model.expr} />
-      </pre>
-    );
+    return <PrometheusQueryPreview query={model.expr} />;
   }
 
   if (datasource.type === DataSourceType.Loki && isPromOrLokiQuery(model)) {
-    return (
-      <pre>
-        <LokiQueryPreview query={model.expr ?? ''} />
-      </pre>
-    );
+    return <LokiQueryPreview query={model.expr ?? ''} />;
   }
 
   if (isSQLLikeQuery(model)) {

--- a/public/app/features/alerting/unified/components/rule-viewer/tabs/Query/LokiQueryPreview.tsx
+++ b/public/app/features/alerting/unified/components/rule-viewer/tabs/Query/LokiQueryPreview.tsx
@@ -8,7 +8,11 @@ interface Props {
 }
 
 const LokiQueryPreview = ({ query }: Props) => {
-  return <RawQuery query={query} language={{ grammar: lokiGrammar, name: 'promql' }} />;
+  return (
+    <pre>
+      <RawQuery query={query} language={{ grammar: lokiGrammar, name: 'promql' }} />
+    </pre>
+  );
 };
 
 export default LokiQueryPreview;

--- a/public/app/features/alerting/unified/components/rule-viewer/tabs/Query/PrometheusQueryPreview.tsx
+++ b/public/app/features/alerting/unified/components/rule-viewer/tabs/Query/PrometheusQueryPreview.tsx
@@ -8,7 +8,11 @@ interface Props {
 }
 
 const PrometheusQueryPreview = ({ query }: Props) => {
-  return <RawQuery query={query} language={{ grammar: promqlGrammar, name: 'promql' }} />;
+  return (
+    <pre>
+      <RawQuery query={query} language={{ grammar: promqlGrammar, name: 'promql' }} />
+    </pre>
+  );
 };
 
 export default PrometheusQueryPreview;


### PR DESCRIPTION
**What is this feature?**

This PR preserves newlines and other whitespace for Prometheus and Loki queries in the new alert rule detail view.

After
<img width="1336" alt="image" src="https://github.com/grafana/grafana/assets/868844/3d9ddb07-39e5-4bbc-b03a-65fa8569db4c">


Before
<img width="939" alt="Screenshot 2024-03-19 at 16 35 54" src="https://github.com/grafana/grafana/assets/868844/064eb681-3f5a-471f-b622-f887255a702e">
