### PR TITLE
[v9.5.x] Snapshots: Require delete within same org (backport)

### DIFF
--- a/pkg/api/dashboard_snapshot.go
+++ b/pkg/api/dashboard_snapshot.go
@@ -349,6 +349,9 @@ func (hs *HTTPServer) DeleteDashboardSnapshot(c *contextmodel.ReqContext) respon
 	if queryResult == nil {
 		return response.Error(http.StatusNotFound, "Failed to get dashboard snapshot", nil)
 	}
+	if queryResult.OrgID != c.OrgID {
+		return response.Error(http.StatusUnauthorized, "OrgID mismatch", nil)
+	}
 
 	if queryResult.External {
 		err := deleteExternalDashboardSnapshot(queryResult.ExternalDeleteURL)

--- a/pkg/api/dashboard_snapshot_test.go
+++ b/pkg/api/dashboard_snapshot_test.go
@@ -103,12 +103,11 @@ func TestDashboardSnapshotAPIEndpoint_singleSnapshot(t *testing.T) {
 				sc.handlerFunc = hs.DeleteDashboardSnapshotByDeleteKey
 				sc.fakeReqWithParams("GET", sc.url, map[string]string{"deleteKey": "12345"}).exec()
 
-				require.Equal(t, 200, sc.resp.Code)
+				require.Equal(t, 200, sc.resp.Code, "BODY: "+sc.resp.Body.String())
 				respJSON, err := simplejson.NewJson(sc.resp.Body.Bytes())
 				require.NoError(t, err)
 
 				assert.True(t, strings.HasPrefix(respJSON.Get("message").MustString(), "Snapshot deleted"))
-				assert.Equal(t, 1, respJSON.Get("id").MustInt())
 
 				assert.Equal(t, http.MethodGet, externalRequest.Method)
 				assert.Equal(t, ts.URL, fmt.Sprintf("http://%s", externalRequest.Host))
@@ -333,7 +332,7 @@ func TestGetDashboardSnapshotNotFound(t *testing.T) {
 			sc.handlerFunc = hs.DeleteDashboardSnapshot
 			sc.fakeReqWithParams("DELETE", sc.url, map[string]string{"key": "12345"}).exec()
 
-			assert.Equal(t, http.StatusNotFound, sc.resp.Code)
+			assert.Equal(t, http.StatusNotFound, sc.resp.Code, "BODY: "+sc.resp.Body.String())
 		}, sqlmock)
 
 	loggedInUserScenarioWithRole(t,
@@ -344,7 +343,7 @@ func TestGetDashboardSnapshotNotFound(t *testing.T) {
 			sc.handlerFunc = hs.DeleteDashboardSnapshotByDeleteKey
 			sc.fakeReqWithParams("DELETE", sc.url, map[string]string{"deleteKey": "12345"}).exec()
 
-			assert.Equal(t, http.StatusNotFound, sc.resp.Code)
+			assert.Equal(t, http.StatusNotFound, sc.resp.Code, "BODY: "+sc.resp.Body.String())
 		}, sqlmock)
 }
 
@@ -407,7 +406,7 @@ func TestGetDashboardSnapshotFailure(t *testing.T) {
 			sc.handlerFunc = hs.DeleteDashboardSnapshot
 			sc.fakeReqWithParams("DELETE", sc.url, map[string]string{"key": "12345"}).exec()
 
-			assert.Equal(t, http.StatusForbidden, sc.resp.Code)
+			assert.Equal(t, http.StatusForbidden, sc.resp.Code, "BODY: "+sc.resp.Body.String())
 		}, sqlmock)
 
 	loggedInUserScenarioWithRole(t,
@@ -418,7 +417,7 @@ func TestGetDashboardSnapshotFailure(t *testing.T) {
 			sc.handlerFunc = hs.DeleteDashboardSnapshotByDeleteKey
 			sc.fakeReqWithParams("DELETE", sc.url, map[string]string{"deleteKey": "12345"}).exec()
 
-			assert.Equal(t, http.StatusInternalServerError, sc.resp.Code)
+			assert.Equal(t, http.StatusInternalServerError, sc.resp.Code, "BODY: "+sc.resp.Body.String())
 		}, sqlmock)
 
 	loggedInUserScenarioWithRole(t,
@@ -429,7 +428,7 @@ func TestGetDashboardSnapshotFailure(t *testing.T) {
 			sc.handlerFunc = hs.DeleteDashboardSnapshotByDeleteKey
 			sc.fakeReqWithParams("DELETE", sc.url, map[string]string{"deleteKey": "12345"}).exec()
 
-			assert.Equal(t, http.StatusForbidden, sc.resp.Code)
+			assert.Equal(t, http.StatusForbidden, sc.resp.Code, "BODY: "+sc.resp.Body.String())
 		}, sqlmock)
 }
 

--- a/pkg/api/dashboard_snapshot_test.go
+++ b/pkg/api/dashboard_snapshot_test.go
@@ -44,6 +44,7 @@ func TestDashboardSnapshotAPIEndpoint_singleSnapshot(t *testing.T) {
 		dashSnapSvc.On("DeleteDashboardSnapshot", mock.Anything, mock.AnythingOfType("*dashboardsnapshots.DeleteDashboardSnapshotCommand")).Return(nil).Maybe()
 		res := &dashboardsnapshots.DashboardSnapshot{
 			ID:        1,
+			OrgID:     1,
 			Key:       "12345",
 			DeleteKey: "54321",
 			Dashboard: jsonModel,


### PR DESCRIPTION
Backport d80f83be011232ad02363c93dfedecdd23aeb098 from #84707

---

Manual backport with fix included from https://github.com/grafana/grafana/pull/83111 -- this is a replacement for https://github.com/grafana/grafana/pull/83942

The fix is already included in 10.4 (and 11)
