### PR TITLE
Alerting docs: Update `Alert rules` intro and `Introduction` pages

### DIFF
--- a/docs/sources/alerting/fundamentals/_index.md
+++ b/docs/sources/alerting/fundamentals/_index.md
@@ -63,7 +63,7 @@ A rule using the PromQL expression above creates as many alert instances as the 
 
 Alert instances are matched to notification policies using label matchers. This provides a flexible way to organize and route alerts to different receivers.
 
-Each policy consists of a set of label matchers (0 or more) that specify which alert instances (identified by their labels) they are or aren’t interested in handling. Notification policies are defined as a tree structure where the root of the notification policy tree is called the Default notification policy, and each policy can have child policies.
+Each policy consists of a set of label matchers (0 or more) that specify which alert instances (identified by their labels) they handle. Notification policies are defined as a tree structure where the root of the notification policy tree is called the **Default notification policy**. Each policy can have child policies.
 
 {{< figure src="/media/docs/alerting/notification-routing.png" max-width="750px" caption="Notification policy routing" >}}
 

--- a/docs/sources/alerting/fundamentals/_index.md
+++ b/docs/sources/alerting/fundamentals/_index.md
@@ -55,7 +55,7 @@ A rule using the PromQL expression above creates as many alert instances as the 
 
 {{< figure src="/static/img/docs/alerting/unified/multi-dimensional-alert.png" caption="Multiple alert instances from a single alert rule" >}}
 
-[Alert rules are frequently evaluated][alert-rule-evaluation] and updates the state of their alert instances accordingly. Only alert instances that are in a firing or resolved state are routed to notification policies to be handled.
+[Alert rules are frequently evaluated][alert-rule-evaluation] and the state of their alert instances is updated accordingly. Only alert instances that are in a firing or resolved state are routed to notification policies to be handled.
 
 ### Notification policies
 

--- a/docs/sources/alerting/fundamentals/_index.md
+++ b/docs/sources/alerting/fundamentals/_index.md
@@ -84,7 +84,7 @@ Grafana Alerting is built on the Prometheus model of designing alerting systems.
 Prometheus-based alerting systems have two main components:
 
 - An alert generator that evaluates alert rules and sends firing and resolved alerts to the alert receiver.
-- an alert receiver (also known as Alertmanager) that receives the alerts and is responsible for handling them and sending their notifications.
+- An alert receiver (also known as Alertmanager) that receives the alerts and is responsible for handling them and sending their notifications.
 
 Grafana doesn’t use Prometheus as its default alert generator because Grafana Alerting needs to work with many other data sources in addition to Prometheus.
 

--- a/docs/sources/alerting/fundamentals/_index.md
+++ b/docs/sources/alerting/fundamentals/_index.md
@@ -83,7 +83,7 @@ Grafana Alerting is built on the Prometheus model of designing alerting systems.
 
 Prometheus-based alerting systems have two main components:
 
-- an alert generator that evaluates alert rules and sends firing and resolved alerts to the alert receiver.
+- An alert generator that evaluates alert rules and sends firing and resolved alerts to the alert receiver.
 - an alert receiver (also known as Alertmanager) that receives the alerts and is responsible for handling them and sending their notifications.
 
 Grafana doesn’t use Prometheus as its default alert generator because Grafana Alerting needs to work with many other data sources in addition to Prometheus.

--- a/docs/sources/alerting/fundamentals/_index.md
+++ b/docs/sources/alerting/fundamentals/_index.md
@@ -88,7 +88,7 @@ Prometheus-based alerting systems have two main components:
 
 Grafana doesn’t use Prometheus as its default alert generator because Grafana Alerting needs to work with many other data sources in addition to Prometheus.
 
-However, Grafana can also use Prometheus as alert generator and external alertmanagers. For more information about how to use distinct alerting systems, refer to the [Grafana alert rule types][alert-rules].
+However, Grafana can also use Prometheus as an alert generator as well as external Alertmanagers. For more information about how to use distinct alerting systems, refer to the [Grafana alert rule types][alert-rules].
 
 ## Design your Alerting system
 

--- a/docs/sources/alerting/fundamentals/_index.md
+++ b/docs/sources/alerting/fundamentals/_index.md
@@ -45,6 +45,24 @@ The alert rule state is determined by the “worst case” state of the alert in
 
 The alert rule health is determined by the status of the evaluation of the alert rule, which can be Ok, Error, and NoData.
 
+**Alert instances (aka multi-dimensional alerts)**
+
+Each alert rule can create multiple alert instances, also known as multi-dimensional alerts. This is exceptionally powerful as it allows us to observe multiple series in a single expression.
+
+```promql
+sum by(cpu) (
+  rate(node_cpu_seconds_total{mode!="idle"}[1m])
+)
+```
+
+A rule using this PromQL expression creates as many alert instances as the amount of CPUs we are observing after the first evaluation, enabling a single rule to report the status of each CPU.
+
+{{< figure src="/static/img/docs/alerting/unified/multi-dimensional-alert.png" caption="A multi-dimensional Grafana managed alert rule" >}}
+
+The alert rule is frequently evaluated and can update the state of the alert instances. Only firing and resolved alert instances are sent to the [Alertmanager][alert-manager] which handles the notification.
+
+{{!--< figure src="/media/docs/alerting/how-alerting-works-alertmanager.png" max-width="750px">}}
+
 ### Labels and states
 
 Alert rules are uniquely identified by sets of key/value pairs called labels. Each key is a label name and each value is a label value. For example, one alert might have the labels `foo=bar` and another alert rule might have the labels `foo=baz`. An alert rule can have many labels such as `foo=bar,bar=baz`, but it cannot have the same label twice such as `foo=bar,foo=baz`. Two alert rules cannot have the same labels either, and if two alert rules have the same labels such as `foo=bar,bar=baz` and `foo=bar,bar=baz` then one of the alerts will be discarded. Firing alerts are resolved when the condition in the alert rule is no longer met, or the alert rule is deleted.

--- a/docs/sources/alerting/fundamentals/alert-rules/_index.md
+++ b/docs/sources/alerting/fundamentals/alert-rules/_index.md
@@ -24,34 +24,13 @@ weight: 100
 An alert rule is a set of evaluation criteria for when an alert rule should fire. An alert rule consists of:
 
 - queries and expressions that select the data set to evaluate.
-- conditions (the threshold) that the query must meet or exceed to trigger the alert.
-- an interval that specifies how frequent the [alert rule is evaluated][alert-rule-evaluation].
-- a duration that indicates how long the condition must be met.
+- conditions (the threshold) that the query must meet or exceed to trigger the alert instance.
+- an interval that specifies the frequency of [alert rule evaluation][alert-rule-evaluation] and a duration indicating how long the condition must be met to trigger the alert instance.
 - other options like the behavior in the absence of data, notification messages, and more.
-
-## Alert instances (aka multi-dimensional alerts)
-
-Each alert rule can create multiple alert instances, also known as multi-dimensional alerts. This is exceptionally powerful as it allows us to observe multiple series in a single expression.
-
-```promql
-sum by(cpu) (
-  rate(node_cpu_seconds_total{mode!="idle"}[1m])
-)
-```
-
-A rule using this PromQL expression creates as many alert instances as the amount of CPUs we are observing after the first evaluation, enabling a single rule to report the status of each CPU.
-
-{{< figure src="/static/img/docs/alerting/unified/multi-dimensional-alert.png" caption="A multi-dimensional Grafana managed alert rule" >}}
-
-The alert rule is frequently evaluated and can update the state of the alert instances. Only firing and resolved alert instances are sent to the [Alertmanager][alert-manager] which handles the notification.
-
-{{< figure src="/media/docs/alerting/how-alerting-works-alertmanager.png" max-width="750px">}}
-
-## Alert rule types
 
 Grafana supports two different alert rule types: Grafana-managed alert rules and Data source-managed alert rules.
 
-### Grafana-managed alert rules
+## Grafana-managed alert rules
 
 Grafana-managed alert rules are the most flexible alert rule type. They allow you to create alerts that can act on data from any of our [supported data sources](#supported-data-sources), and use multiple data sources in a single alert rule.
 
@@ -63,9 +42,9 @@ Additionaly, you can also add [expressions to transform your data][expression-qu
 
 1. Alert rules are evaluated by the Alert Rule Evaluation Engine from within Grafana.
 
-1. Firing and resolved alert instances are delivered to the internal Grafana Alertmanager which handles notifications.
+1. Firing and resolved alert instances are delivered to the internal Grafana [Alertmanager][alert-manager] which handles notifications.
 
-#### Supported data sources
+### Supported data sources
 
 Grafana-managed alert rules can query backend data sources if Grafana Alerting enabled by specifying `{"backend": true, "alerting": true}` in the [plugin.json](/developers/plugin-tools/reference-plugin-json).
 
@@ -74,28 +53,26 @@ The following data sources are supported:
 - [Enterprise data source plugins](/grafana/plugins/data-source-plugins/?enterprise=1) and others maintained by Grafana such as [AWS Athena](/grafana/plugins/grafana-athena-datasource/), [AWS X-Ray](/grafana/plugins/grafana-x-ray-datasource/), [AWS Redshift](/grafana/plugins/grafana-redshift-datasource/), [AWS Timestream](/grafana/plugins/grafana-timestream-datasource/), [AWS IoT SiteWise](/grafana/plugins/grafana-iot-sitewise-datasource/), [Azure Data Explorer](/grafana/plugins/grafana-azure-data-explorer-datasource/), [Azure Monitor](/grafana/plugins/grafana-azure-monitor-datasource/), [ClickHouse](/grafana/plugins/grafana-clickhouse-datasource/), [Cloudwatch](/grafana/plugins/cloudwatch/), [CSV](/grafana/plugins/marcusolsson-csv-datasource/), [Elasticsearch](/grafana/plugins/elasticsearch/), [Falcon LogScale](/grafana/plugins/grafana-falconlogscale-datasource/), [GitHub](/grafana/plugins/grafana-github-datasource/), [Google BigQuery](/grafana/plugins/grafana-bigquery-datasource/), [Google Cloud Monitoring](/grafana/plugins/stackdriver/), [Graphite](/grafana/plugins/graphite/), [Loki](/grafana/plugins/loki/), [InfluxDB](/grafana/plugins/influxdb/), [Infinity](/grafana/plugins/yesoreyeram-infinity-datasource/), [MSSQL](/grafana/plugins/mssql/), [MySQL](/grafana/plugins/mysql/), [OpenSearch](/grafana/plugins/grafana-opensearch-datasource/), [OpenTSDB](/grafana/plugins/opentsdb/), [Oracle](/grafana/plugins/grafana-oracle-datasource/), [Orbit](/grafana/plugins/grafana-orbit-datasource/), [PostgreSQL](/grafana/plugins/postgres/), [Prometheus](/grafana/plugins/prometheus/), [Sentry](/grafana/plugins/grafana-sentry-datasource/), [SurrealDB](/grafana/plugins/grafana-surrealdb-datasource/), and [TestData](/grafana/plugins/grafana-testdata-datasource/).
 - Backend data sources maintained by the [community](/grafana/plugins/data-source-plugins/?signature=community) and [partners](/grafana/plugins/data-source-plugins/?signature=commercial) that enable alerting.
 
-### Data source-managed alert rules
+## Data source-managed alert rules
 
 Data source-managed alert rules can improve query performance via [recording rules](#recording-rules) and ensure high-availability and fault tolerance when implementing a distributed architecture.
 
 They are only supported for Prometheus-based or Loki data sources with the Ruler API enabled. For more information, refer to the [Loki Ruler API](/docs/loki/<GRAFANA_VERSION>/api/#ruler) or [Mimir Ruler API](/docs/mimir/<GRAFANA_VERSION>/references/http-api/#ruler).
 
-{{< figure src="/media/docs/alerting/mimir-managed-alerting-architecture.png" max-width="750px" caption="Mimir-managed alerting architecture" >}}
+{{< figure src="/media/docs/alerting/mimir-managed-alerting-architecture-v2.png" max-width="750px" caption="Mimir-managed alerting architecture" >}}
 
 1. Alert rules are created and stored within the data source itself.
-1. Alert rules can only query Prometheus-based data. It can use either queries or recording rules.
+1. Alert rules can only query Prometheus-based data. It can use either queries or [recording rules](#recording-rules).
 1. Alert rules are evaluated by the Alert Rule Evaluation Engine.
-1. Firing and resolved alert instances are delivered to the configured Alertmanager which handles notifications.
+1. Firing and resolved alert instances are delivered to the configured [Alertmanager][alert-manager] which handles notifications.
 
-#### Recording rules
+### Recording rules
 
 A recording rule allows you to pre-compute frequently needed or computationally expensive expressions and save their result as a new set of time series. This is useful if you want to run alerts on aggregated data or if you have dashboards that query computationally expensive expressions repeatedly.
 
-Querying this new time series is faster, especially for dashboards since they query the same expression every time the dashboards refresh.
+Querying this new time series is faster, especially for dashboards since they query the same expression every time the dashboards refresh. For more information, refer to [Create recording rules][create-recording-rules].
 
-Note that Grafana Enterprise and Grafana Cloud offer an alternative to recorded rules in the form of [recorded queries][recorded-queries] that can be executed against any data source.
-
-For more information on recording rules, refer to [Create recording rules][create-recording-rules].
+Alternatively, Grafana Enterprise and Grafana Cloud offer [recorded queries][recorded-queries] that can be executed against any data source.
 
 ## Comparison between alert rule types
 
@@ -112,9 +89,6 @@ When choosing which alert rule type to use, consider the following comparison be
 | Alert rule evaluation and delivery                                             | Alert rule evaluation and delivery is done from within Grafana, using an external Alertmanager; or both.                     | Alert rule evaluation and alert delivery is distributed, meaning there is no single point of failure.                                                   |
 
 {{% docs/reference %}}
-
-[alert-manager]: "/docs/grafana/ -> /docs/grafana/<GRAFANA_VERSION>/alerting/fundamentals/notifications/alertmanager"
-[alert-manager]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/alerting-and-irm/alerting/fundamentals/notifications/alertmanager"
 
 [alert-manager]: "/docs/grafana/ -> /docs/grafana/<GRAFANA_VERSION>/alerting/fundamentals/notifications/alertmanager"
 [alert-manager]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/alerting-and-irm/alerting/fundamentals/notifications/alertmanager"

--- a/docs/sources/alerting/fundamentals/alert-rules/_index.md
+++ b/docs/sources/alerting/fundamentals/alert-rules/_index.md
@@ -28,7 +28,7 @@ An alert rule is a set of evaluation criteria for when an alert rule should fire
 - An interval that specifies the frequency of [alert rule evaluation][alert-rule-evaluation] and a duration indicating how long the condition must be met to trigger the alert instance.
 - Other customizable options, for example, setting what should happen in the absence of data, notification messages, and more.
 
-Grafana supports two different alert rule types: Grafana-managed alert rules and Data source-managed alert rules.
+Grafana supports two different alert rule types: Grafana-managed alert rules and data source-managed alert rules.
 
 ## Grafana-managed alert rules
 

--- a/docs/sources/alerting/fundamentals/alert-rules/_index.md
+++ b/docs/sources/alerting/fundamentals/alert-rules/_index.md
@@ -21,33 +21,51 @@ weight: 100
 
 # Alert rules
 
-An alert rule is a set of evaluation criteria for when an alert rule should fire. An alert rule consists of one or more [queries and expressions, a condition][queries-and-conditions], and the duration over which the condition needs to be met to start firing.
+An alert rule is a set of evaluation criteria for when an alert rule should fire. An alert rule consists of:
 
-While queries and expressions select the data set to evaluate, a condition sets the threshold that an alert must meet or exceed to create an alert.
+- queries and expressions that select the data set to evaluate.
+- conditions (the threshold) that the query must meet or exceed to trigger the alert.
+- an interval that specifies how frequent the [alert rule is evaluated][alert-rule-evaluation].
+- a duration that indicates how long the condition must be met.
+- other options like the behavior in the absence of data, notification messages, and more.
 
-An interval specifies how frequently an [alert rule is evaluated][alert-rule-evaluation]. Duration, when configured, indicates how long a condition must be met. The alert rules can also define alerting behavior in the absence of data.
+## Alert instances (aka multi-dimensional alerts)
 
-Grafana supports two different alert rule types: [Grafana-managed alert rules](#grafana-managed-alert-rules) and [Data source-managed alert rules](#data-source-managed-alert-rules).
+Each alert rule can create multiple alert instances, also known as multi-dimensional alerts. This is exceptionally powerful as it allows us to observe multiple series in a single expression.
 
-## Grafana-managed alert rules
+```promql
+sum by(cpu) (
+  rate(node_cpu_seconds_total{mode!="idle"}[1m])
+)
+```
 
-Grafana-managed alert rules are the most flexible alert rule type. They allow you to create alerts that can act on data from any of our supported data sources.
+A rule using this PromQL expression creates as many alert instances as the amount of CPUs we are observing after the first evaluation, enabling a single rule to report the status of each CPU.
 
-In addition to supporting multiple data sources, you can also add expressions to transform your data and set alert conditions. Using images in alert notifications is also supported. This is the only type of rule that allows alerting from multiple data sources in a single rule definition.
+{{< figure src="/static/img/docs/alerting/unified/multi-dimensional-alert.png" caption="A multi-dimensional Grafana managed alert rule" >}}
 
-The following diagram shows how Grafana-managed alerting works.
+The alert rule is frequently evaluated and can update the state of the alert instances. Only firing and resolved alert instances are sent to the [Alertmanager][alert-manager] which handles the notification.
 
-{{< figure src="/media/docs/alerting/grafana-managed-rule.png" max-width="750px" caption="Grafana-managed alerting" >}}
+{{< figure src="/media/docs/alerting/how-alerting-works-alertmanager.png" max-width="750px">}}
+
+## Alert rule types
+
+Grafana supports two different alert rule types: Grafana-managed alert rules and Data source-managed alert rules.
+
+### Grafana-managed alert rules
+
+Grafana-managed alert rules are the most flexible alert rule type. They allow you to create alerts that can act on data from any of our [supported data sources](#supported-data-sources), and use multiple data sources in a single alert rule.
+
+Additionaly, you can also add [expressions to transform your data][expression-queries], set custom alert conditions, and include [images in alert notifications][notification-images].
+
+{{< figure src="/media/docs/alerting/grafana-managed-alerting-architecture.png" max-width="750px" caption="How Grafana-managed alerting works by default" >}}
 
 1. Alert rules are created within Grafana based on one or more data sources.
 
 1. Alert rules are evaluated by the Alert Rule Evaluation Engine from within Grafana.
 
-1. Alerts are delivered using the internal Grafana Alertmanager.
+1. Firing and resolved alert instances are delivered to the internal Grafana Alertmanager which handles notifications.
 
-   Note that you can also configure alerts to be delivered using an external Alertmanager; or use both internal and external alertmanagers.
-
-### Supported data sources
+#### Supported data sources
 
 Grafana-managed alert rules can query backend data sources if Grafana Alerting enabled by specifying `{"backend": true, "alerting": true}` in the [plugin.json](/developers/plugin-tools/reference-plugin-json).
 
@@ -56,45 +74,26 @@ The following data sources are supported:
 - [Enterprise data source plugins](/grafana/plugins/data-source-plugins/?enterprise=1) and others maintained by Grafana such as [AWS Athena](/grafana/plugins/grafana-athena-datasource/), [AWS X-Ray](/grafana/plugins/grafana-x-ray-datasource/), [AWS Redshift](/grafana/plugins/grafana-redshift-datasource/), [AWS Timestream](/grafana/plugins/grafana-timestream-datasource/), [AWS IoT SiteWise](/grafana/plugins/grafana-iot-sitewise-datasource/), [Azure Data Explorer](/grafana/plugins/grafana-azure-data-explorer-datasource/), [Azure Monitor](/grafana/plugins/grafana-azure-monitor-datasource/), [ClickHouse](/grafana/plugins/grafana-clickhouse-datasource/), [Cloudwatch](/grafana/plugins/cloudwatch/), [CSV](/grafana/plugins/marcusolsson-csv-datasource/), [Elasticsearch](/grafana/plugins/elasticsearch/), [Falcon LogScale](/grafana/plugins/grafana-falconlogscale-datasource/), [GitHub](/grafana/plugins/grafana-github-datasource/), [Google BigQuery](/grafana/plugins/grafana-bigquery-datasource/), [Google Cloud Monitoring](/grafana/plugins/stackdriver/), [Graphite](/grafana/plugins/graphite/), [Loki](/grafana/plugins/loki/), [InfluxDB](/grafana/plugins/influxdb/), [Infinity](/grafana/plugins/yesoreyeram-infinity-datasource/), [MSSQL](/grafana/plugins/mssql/), [MySQL](/grafana/plugins/mysql/), [OpenSearch](/grafana/plugins/grafana-opensearch-datasource/), [OpenTSDB](/grafana/plugins/opentsdb/), [Oracle](/grafana/plugins/grafana-oracle-datasource/), [Orbit](/grafana/plugins/grafana-orbit-datasource/), [PostgreSQL](/grafana/plugins/postgres/), [Prometheus](/grafana/plugins/prometheus/), [Sentry](/grafana/plugins/grafana-sentry-datasource/), [SurrealDB](/grafana/plugins/grafana-surrealdb-datasource/), and [TestData](/grafana/plugins/grafana-testdata-datasource/).
 - Backend data sources maintained by the [community](/grafana/plugins/data-source-plugins/?signature=community) and [partners](/grafana/plugins/data-source-plugins/?signature=commercial) that enable alerting.
 
-### Multi-dimensional alerts
+### Data source-managed alert rules
 
-Grafana-managed alerting supports multi-dimensional alerting. Each alert rule can create multiple alert instances. This is exceptionally powerful if you are observing multiple series in a single expression.
+Data source-managed alert rules can improve query performance via [recording rules](#recording-rules) and ensure high-availability and fault tolerance when implementing a distributed architecture.
 
-Consider the following PromQL expression:
+They are only supported for Prometheus-based or Loki data sources with the Ruler API enabled. For more information, refer to the [Loki Ruler API](/docs/loki/<GRAFANA_VERSION>/api/#ruler) or [Mimir Ruler API](/docs/mimir/<GRAFANA_VERSION>/references/http-api/#ruler).
 
-```promql
-sum by(cpu) (
-  rate(node_cpu_seconds_total{mode!="idle"}[1m])
-)
-```
-
-A rule using this expression will create as many alert instances as the amount of CPUs we are observing after the first evaluation, allowing a single rule to report the status of each CPU.
-
-{{< figure src="/static/img/docs/alerting/unified/multi-dimensional-alert.png" caption="A multi-dimensional Grafana managed alert rule" >}}
-
-## Data source-managed alert rules
-
-To create data source-managed alert rules, you must have a compatible Prometheus or Loki data source.
-
-You can check if your data source supports rule creation via Grafana by testing the data source and observing if the Ruler API is supported.
-
-For more information on the Ruler API, refer to [Ruler API](/docs/loki/latest/api/#ruler).
-
-The following diagram shows how data source-managed alerting works.
-
-{{< figure src="/media/docs/alerting/loki-mimir-rule.png" max-width="750px" caption="Grafana Mimir/Loki-managed alerting" >}}
+{{< figure src="/media/docs/alerting/mimir-managed-alerting-architecture.png" max-width="750px" caption="Mimir-managed alerting architecture" >}}
 
 1. Alert rules are created and stored within the data source itself.
-1. Alert rules can only be created based on Prometheus data.
-1. Alert rule evaluation and delivery is distributed across multiple nodes for high availability and fault tolerance.
+1. Alert rules can only query Prometheus-based data. It can use either queries or recording rules.
+1. Alert rules are evaluated by the Alert Rule Evaluation Engine.
+1. Firing and resolved alert instances are delivered to the configured Alertmanager which handles notifications.
 
-### Recording rules
+#### Recording rules
 
 A recording rule allows you to pre-compute frequently needed or computationally expensive expressions and save their result as a new set of time series. This is useful if you want to run alerts on aggregated data or if you have dashboards that query computationally expensive expressions repeatedly.
 
 Querying this new time series is faster, especially for dashboards since they query the same expression every time the dashboards refresh.
 
-Grafana Enterprise offers an alternative to recorded rules in the form of recorded queries that can be executed against any data source.
+Note that Grafana Enterprise and Grafana Cloud offer an alternative to recorded rules in the form of [recorded queries][recorded-queries] that can be executed against any data source.
 
 For more information on recording rules, refer to [Create recording rules][create-recording-rules].
 
@@ -104,7 +103,7 @@ When choosing which alert rule type to use, consider the following comparison be
 
 | <div style="width:200px">Feature</div>                                         | <div style="width:200px">Grafana-managed alert rule</div>                                                                    | <div style="width:200px">Data source-managed alert rule                                                                                                 |
 | ------------------------------------------------------------------------------ | ---------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Create alert rules<wbr /> based on data from any of our supported data sources | Yes                                                                                                                          | No: You can only create alert rules that are based on Prometheus data. The data source must have the Ruler API enabled.                                 |
+| Create alert rules<wbr /> based on data from any of our supported data sources | Yes                                                                                                                          | No. You can only create alert rules that are based on Prometheus-based data.                                                                            |
 | Mix and match data sources                                                     | Yes                                                                                                                          | No                                                                                                                                                      |
 | Includes support for recording rules                                           | No                                                                                                                           | Yes                                                                                                                                                     |
 | Add expressions to transform<wbr /> your data and set alert conditions         | Yes                                                                                                                          | No                                                                                                                                                      |
@@ -112,11 +111,13 @@ When choosing which alert rule type to use, consider the following comparison be
 | Scaling                                                                        | More resource intensive, depend on the database, and are likely to suffer from transient errors. They only scale vertically. | Store alert rules within the data source itself and allow for “infinite” scaling. Generate and send alert notifications from the location of your data. |
 | Alert rule evaluation and delivery                                             | Alert rule evaluation and delivery is done from within Grafana, using an external Alertmanager; or both.                     | Alert rule evaluation and alert delivery is distributed, meaning there is no single point of failure.                                                   |
 
-**Note:**
-
-If you are using non-Prometheus data, we recommend choosing Grafana-managed alert rules. Otherwise, choose Grafana Mimir or Grafana Loki alert rules where possible.
-
 {{% docs/reference %}}
+
+[alert-manager]: "/docs/grafana/ -> /docs/grafana/<GRAFANA_VERSION>/alerting/fundamentals/notifications/alertmanager"
+[alert-manager]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/alerting-and-irm/alerting/fundamentals/notifications/alertmanager"
+
+[alert-manager]: "/docs/grafana/ -> /docs/grafana/<GRAFANA_VERSION>/alerting/fundamentals/notifications/alertmanager"
+[alert-manager]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/alerting-and-irm/alerting/fundamentals/notifications/alertmanager"
 
 [create-recording-rules]: "/docs/grafana/ -> /docs/grafana/<GRAFANA_VERSION>/alerting/alerting-rules/create-mimir-loki-managed-recording-rule"
 [create-recording-rules]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/alerting-and-irm/alerting/alerting-rules/create-mimir-loki-managed-recording-rule"
@@ -124,7 +125,15 @@ If you are using non-Prometheus data, we recommend choosing Grafana-managed aler
 [alert-rule-evaluation]: "/docs/grafana/ -> /docs/grafana/<GRAFANA_VERSION>/alerting/fundamentals/alert-rules/rule-evaluation"
 [alert-rule-evaluation]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/alerting-and-irm/alerting/fundamentals/alert-rules/rule-evaluation"
 
+[expression-queries]: "/docs/grafana/ -> /docs/grafana/<GRAFANA_VERSION>/alerting/fundamentals/alert-rules/queries-conditions#expression-queries"
+[expression-queries]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/alerting-and-irm/alerting/fundamentals/alert-rules/queries-conditions#expression-queries"
+
 [queries-and-conditions]: "/docs/grafana/ -> /docs/grafana/<GRAFANA_VERSION>/alerting/fundamentals/alert-rules/queries-conditions"
 [queries-and-conditions]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/alerting-and-irm/alerting/fundamentals/alert-rules/queries-conditions"
+
+[notification-images]: "/docs/grafana/ -> /docs/grafana/<GRAFANA_VERSION>/alerting/configure-notifications/template-notifications/images-in-notifications"
+[notification-images]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/alerting-and-irm/alerting/configure-notifications/template-notifications/images-in-notifications"
+
+[recorded-queries]: "/docs/ -> /docs/grafana/<GRAFANA_VERSION>/administration/recorded-queries"
 
 {{% /docs/reference %}}

--- a/docs/sources/alerting/fundamentals/alert-rules/_index.md
+++ b/docs/sources/alerting/fundamentals/alert-rules/_index.md
@@ -34,7 +34,7 @@ Grafana supports two different alert rule types: Grafana-managed alert rules and
 
 Grafana-managed alert rules are the most flexible alert rule type. They allow you to create alerts that can act on data from any of our [supported data sources](#supported-data-sources), and use multiple data sources in a single alert rule.
 
-Additionaly, you can also add [expressions to transform your data][expression-queries], set custom alert conditions, and include [images in alert notifications][notification-images].
+Additionally, you can also add [expressions to transform your data][expression-queries], set custom alert conditions, and include [images in alert notifications][notification-images].
 
 {{< figure src="/media/docs/alerting/grafana-managed-alerting-architecture.png" max-width="750px" caption="How Grafana-managed alerting works by default" >}}
 

--- a/docs/sources/alerting/fundamentals/alert-rules/_index.md
+++ b/docs/sources/alerting/fundamentals/alert-rules/_index.md
@@ -23,10 +23,10 @@ weight: 100
 
 An alert rule is a set of evaluation criteria for when an alert rule should fire. An alert rule consists of:
 
-- queries and expressions that select the data set to evaluate.
-- conditions (the threshold) that the query must meet or exceed to trigger the alert instance.
-- an interval that specifies the frequency of [alert rule evaluation][alert-rule-evaluation] and a duration indicating how long the condition must be met to trigger the alert instance.
-- other options like the behavior in the absence of data, notification messages, and more.
+- Queries and expressions that select the data set to evaluate.
+- A condition (the threshold) that the query must meet or exceed to trigger the alert instance.
+- An interval that specifies the frequency of [alert rule evaluation][alert-rule-evaluation] and a duration indicating how long the condition must be met to trigger the alert instance.
+- Other customizable options, for example, setting what should happen in the absence of data, notification messages, and more.
 
 Grafana supports two different alert rule types: Grafana-managed alert rules and Data source-managed alert rules.
 

--- a/docs/sources/alerting/fundamentals/alert-rules/annotation-label.md
+++ b/docs/sources/alerting/fundamentals/alert-rules/annotation-label.md
@@ -39,6 +39,8 @@ Labels are a fundamental component of alerting:
 - Contact points can access labels to send notification messages that contain specific alert information.
 - The Alertmanager uses labels to match alerts for silences and alert groups in notification policies.
 
+Note that two alert rules cannot have the same labels. If two alert rules have the same labels such as `foo=bar,bar=baz` and `foo=bar,bar=baz` then one of the alerts will be discarded.
+
 ### How label matching works
 
 Use labels and label matchers to link alert rules to notification policies and silences. This allows for a flexible way to manage your alert instances, specify which policy should handle them, and which alerts to silence.

--- a/docs/sources/alerting/fundamentals/alert-rules/state-and-health.md
+++ b/docs/sources/alerting/fundamentals/alert-rules/state-and-health.md
@@ -28,11 +28,13 @@ There are three key components: [alert rule state](#alert-rule-state), [alert in
 
 An alert rule can be in either of the following states:
 
-| State       | Description                                                                                    |
-| ----------- | ---------------------------------------------------------------------------------------------- |
-| **Normal**  | None of the time series returned by the evaluation engine is in a `Pending` or `Firing` state. |
-| **Pending** | At least one time series returned by the evaluation engine is `Pending`.                       |
-| **Firing**  | At least one time series returned by the evaluation engine is `Firing`.                        |
+| State       | Description                                                                                        |
+| ----------- | -------------------------------------------------------------------------------------------------- |
+| **Normal**  | None of the alert instances returned by the evaluation engine is in a `Pending` or `Firing` state. |
+| **Pending** | At least one alert instances returned by the evaluation engine is `Pending`.                       |
+| **Firing**  | At least one alert instances returned by the evaluation engine is `Firing`.                        |
+
+The alert rule state is determined by the “worst case” state of the alert instances produced. For example, if one alert instance is firing, the alert rule state will also be firing.
 
 {{% admonition type="note" %}}
 Alerts will transition first to `pending` and then `firing`, thus it will take at least two evaluation cycles before an alert is fired.

--- a/docs/sources/alerting/fundamentals/notifications/alertmanager.md
+++ b/docs/sources/alerting/fundamentals/notifications/alertmanager.md
@@ -18,7 +18,7 @@ weight: 111
 
 Grafana sends firing and resolved alerts to Alertmanagers. The Alertmanager receives alerts, handles silencing, inhibition, grouping, and routing by sending notifications out via your channel of choice, for example, email or Slack.
 
-Grafana has its own Alertmanager, referred to as "Grafana" in the user interface, but also supports sending alerts to other Alertmanagers too, such as the [Prometheus Alertmanager](https://prometheus.io/docs/alerting/latest/alertmanager/).
+Grafana has its own Alertmanager, referred to as "Grafana" in the user interface, but also supports sending alerts to other Alertmanagers, such as the [Prometheus Alertmanager](https://prometheus.io/docs/alerting/latest/alertmanager/). You can use both internal and external alertmanagers.
 
 The Grafana Alertmanager uses notification policies and contact points to configure how and where a notification is sent; how often a notification should be sent; and whether alerts should all be sent in the same notification, sent in grouped notifications based on a set of labels, or as separate notifications.
 

--- a/docs/sources/alerting/fundamentals/notifications/alertmanager.md
+++ b/docs/sources/alerting/fundamentals/notifications/alertmanager.md
@@ -18,7 +18,7 @@ weight: 111
 
 Grafana sends firing and resolved alerts to Alertmanagers. The Alertmanager receives alerts, handles silencing, inhibition, grouping, and routing by sending notifications out via your channel of choice, for example, email or Slack.
 
-Grafana has its own Alertmanager, referred to as "Grafana" in the user interface, but also supports sending alerts to other Alertmanagers, such as the [Prometheus Alertmanager](https://prometheus.io/docs/alerting/latest/alertmanager/). You can use both internal and external alertmanagers.
+Grafana has its own Alertmanager, referred to as "Grafana" in the user interface, but also supports sending alerts to other Alertmanagers, such as the [Prometheus Alertmanager](https://prometheus.io/docs/alerting/latest/alertmanager/). You can use both internal and external Alertmanagers.
 
 The Grafana Alertmanager uses notification policies and contact points to configure how and where a notification is sent; how often a notification should be sent; and whether alerts should all be sent in the same notification, sent in grouped notifications based on a set of labels, or as separate notifications.
 


### PR DESCRIPTION
Update [Alert rules](https://grafana.com/docs/grafana/next/alerting/fundamentals/alert-rules/) and [Introduction](https://grafana.com/docs/grafana/next/alerting/fundamentals/)

- Restructure a bit the sections and concepts to follow the Alert creation and handling process

- Highlight more the key features, differences, and concepts.

- Consistency using the `Alert instance` term. 

- Update diagrams.

