### PR TITLE
Prometheus: Default support labels value endpoint with match param when prom type and version not set

### DIFF
--- a/public/app/plugins/datasource/prometheus/datasource.test.ts
+++ b/public/app/plugins/datasource/prometheus/datasource.test.ts
@@ -24,7 +24,7 @@ import {
   prometheusSpecialRegexEscape,
 } from './datasource';
 import PromQlLanguageProvider from './language_provider';
-import { PrometheusCacheLevel, PromOptions, PromQuery, PromQueryRequest } from './types';
+import { PromApplication, PrometheusCacheLevel, PromOptions, PromQuery, PromQueryRequest } from './types';
 
 const fetchMock = jest.fn().mockReturnValue(of(createDefaultPromResponse()));
 
@@ -98,6 +98,13 @@ describe('PrometheusDatasource', () => {
     });
   });
 
+  describe('Type and version', () => {
+    it('Default support labels match endpoint over series when type and version not set', () => {
+      const labelsMatchSupport = ds.hasLabelsMatchAPISupport();
+      expect(labelsMatchSupport).toBe(true);
+    });
+  });
+
   describe('Query', () => {
     it('throws if using direct access', async () => {
       const instanceSettings = {
@@ -108,6 +115,8 @@ describe('PrometheusDatasource', () => {
         access: 'direct',
         jsonData: {
           customQueryParameters: '',
+          prometheusVersion: '2.20.0',
+          prometheusType: PromApplication.Prometheus,
         },
       } as unknown as DataSourceInstanceSettings<PromOptions>;
       const range = { from: time({ seconds: 63 }), to: time({ seconds: 183 }) };

--- a/public/app/plugins/datasource/prometheus/datasource.ts
+++ b/public/app/plugins/datasource/prometheus/datasource.ts
@@ -188,9 +188,9 @@ export class PrometheusDatasource
   }
 
   _isDatasourceVersionGreaterOrEqualTo(targetVersion: string, targetFlavor: PromApplication): boolean {
-    // User hasn't configured flavor/version yet, default behavior is to not support features that require version configuration when not provided
+    // User hasn't configured flavor/version yet, default behavior is to support labels match api support
     if (!this.datasourceConfigurationPrometheusVersion || !this.datasourceConfigurationPrometheusFlavor) {
-      return false;
+      return true;
     }
 
     if (targetFlavor !== this.datasourceConfigurationPrometheusFlavor) {

--- a/public/app/plugins/datasource/prometheus/metric_find_query.test.ts
+++ b/public/app/plugins/datasource/prometheus/metric_find_query.test.ts
@@ -23,7 +23,11 @@ const instanceSettings = {
   uid: 'ABCDEF',
   user: 'test',
   password: 'mupp',
-  jsonData: { httpMethod: 'GET' },
+  jsonData: {
+    httpMethod: 'GET',
+    prometheusVersion: '2.20.0',
+    prometheusType: PromApplication.Prometheus,
+  },
 } as Partial<DataSourceInstanceSettings<PromOptions>> as DataSourceInstanceSettings<PromOptions>;
 
 const raw: TimeRange = {


### PR DESCRIPTION
Fixes https://github.com/grafana/grafana/issues/81059

**What is this?**

When a user creates a new Prometheus data source in Grafana and does not set the type and version, we will support the labels values endpoint with match parameter (labelsMatch) over the series endpoint.

`/api/v1/label/__name__/values?match[]=<series_selector>`

Special note: The metrics browser still relies on the series endpoint and that will be be refactored in future work.

**Why are we defaulting to labels match over series?**

For many reasons listed here: 

First, when we made the type and version detection feature in the config section, many people did not have the most current versions of Prometheus and so were still needing to have the series endpoint be default. It is now a year and a half later and most people have update Prometheus versions that support the labels match endpoint.

Second, we are moving to refactor all series endpoint calls out of the Prometheus data source plugin and this is a part of that work. 

Third, the series endpoint is expensive to call and we think that people should have to opt into that.

**Special notes for your reviewer:**

1. Create a new Prometheus data source.
2. In the config section, do not set the type and version.
3. Go to the metric builder and open the metric select.
4. Type a partial metric name and check the network tab to see that `/api/v1/label/__name__/values?match[]=<series_selector>` has been called.

Also, to see the series endpoint called, set the type and version in the config section to Prometheus type < 2.24 or follow the following guidelines for not supporting the label endpoint with match[] param


https://github.com/grafana/grafana/blob/f3986f0dc73470298fa0a7319716f1b25e937843/public/app/plugins/datasource/prometheus/datasource.ts#L176-L188 




Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
