### PR TITLE
Alerting: do not check for folder in file provisioning

### DIFF
--- a/pkg/services/ngalert/provisioning/alert_rules.go
+++ b/pkg/services/ngalert/provisioning/alert_rules.go
@@ -663,8 +663,8 @@ func (service *AlertRuleService) ensureRuleNamespace(ctx context.Context, user i
 		return fmt.Errorf("%w: folderUID must be set", models.ErrAlertRuleFailedValidation)
 	}
 
-	if user == nil {
-		// user is nil when this is called during file provisioning,
+	if service.folderService == nil {
+		// folder service is nil when this is called during file provisioning,
 		// which already creates the folder if it does not exist
 		return nil
 	}

--- a/pkg/services/provisioning/provisioning.go
+++ b/pkg/services/provisioning/provisioning.go
@@ -248,7 +248,7 @@ func (ps *ProvisioningServiceImpl) ProvisionAlerting(ctx context.Context) error 
 	ruleService := provisioning.NewAlertRuleService(
 		st,
 		st,
-		ps.folderService,
+		nil,
 		ps.dashboardService,
 		ps.quotaService,
 		ps.SQLStore,


### PR DESCRIPTION
**What is this feature?**
In PR https://github.com/grafana/grafana/issues/83938 we introduced a check that a folder with specific UID exists. We made a special case when `user` is nil to skip the check in the file provisioning. However, later, I merged a PR that introduces a user in file provisioning https://github.com/grafana/grafana/pull/84480, which effectively broke that assumption. 

This PR replaces nil user with nil folder service to avoid the check in the file provisioning because the folder is ensured before in file provisioning and the user is needed for other future activities.

