### PR TITLE
Make: Speed up make run by removing redundant `make go-gen` in .bra

### DIFF
--- a/.bra.toml
+++ b/.bra.toml
@@ -1,6 +1,5 @@
 [run]
 init_cmds = [
-  ["GO_BUILD_DEV=1", "make", "gen-go"],
   ["GO_BUILD_DEV=1", "make", "build-go"],
   ["make", "gen-jsonnet"],
   ["./bin/grafana", "server", "-packaging=dev", "cfg:app_mode=development"]
@@ -17,7 +16,6 @@ watch_exts = [".go", ".ini", ".toml", ".template.html"]
 ignore_files = [".*_gen.go"]
 build_delay = 1500
 cmds = [
-  ["GO_BUILD_DEV=1", "make", "gen-go"],
   ["GO_BUILD_DEV=1", "make", "build-go"],
   ["make", "gen-jsonnet"],
   ["./bin/grafana", "server", "-packaging=dev", "cfg:app_mode=development"]


### PR DESCRIPTION
- build-go already calls gen-go
- calling twice really slows down backend build time (2x or worse when I hit memory pressure)
- It can also halt my computer since wire uses a lot of memory

build-go in Makefile:
```
build-go: gen-go ## Build all Go binaries.
	@echo "build go files"
	$(GO) run build.go $(GO_BUILD_FLAGS) build
```

**Special notes for your reviewer:**
 - This duplication had already been done in https://github.com/grafana/grafana/pull/62764
 - But then it was put back in in https://github.com/grafana/grafana/pull/80880
 - Note: Additional Problem not addressed here. If I save faster too frequently, the wire runs build up. (I will have 5 or so wire processes running, all using 3 GB Res). This suggests they are some how not being interrupted (wire ignores it, the interrupt isn't making to wire, not interrupting hard enough (kill)). This will also lock my computer due to memory usage -- but not having two of them should help some.

I don't think adding back the duplicate was the correct thing to do.

