### PR TITLE
VizTooltips: Switch data links display to column

### DIFF
--- a/packages/grafana-ui/src/components/VizTooltip/VizTooltipFooter.tsx
+++ b/packages/grafana-ui/src/components/VizTooltip/VizTooltipFooter.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 
 import { Field, GrafanaTheme2, LinkModel } from '@grafana/data';
 
-import { Button, ButtonProps, DataLinkButton, HorizontalGroup } from '..';
+import { Button, ButtonProps, DataLinkButton, Stack } from '..';
 import { useStyles2 } from '../../themes';
 
 interface VizTooltipFooterProps {
@@ -22,11 +22,11 @@ export const VizTooltipFooter = ({ dataLinks, annotate }: VizTooltipFooterProps)
     };
 
     return (
-      <HorizontalGroup>
+      <Stack direction="column" justifyContent="flex-start">
         {dataLinks.map((link, i) => (
           <DataLinkButton key={i} link={link} buttonProps={buttonProps} />
         ))}
-      </HorizontalGroup>
+      </Stack>
     );
   };
 
@@ -52,10 +52,6 @@ const getStyles = (theme: GrafanaTheme2) => ({
     padding: theme.spacing(0),
   }),
   dataLinks: css({
-    overflowX: 'auto',
-    overflowY: 'hidden',
-    whiteSpace: 'nowrap',
-    maskImage: 'linear-gradient(90deg, rgba(0, 0, 0, 1) 80%, transparent)',
     borderTop: `1px solid ${theme.colors.border.medium}`,
     padding: theme.spacing(1),
   }),


### PR DESCRIPTION

![data links column](https://github.com/grafana/grafana/assets/88068998/f0356b41-c82e-43f1-99b9-6ec26b0bd1d9)


Fixes #84824
Fixes https://github.com/grafana/support-escalations/issues/9778


Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
