### PR TITLE
Alerting: Add state history polling interval

### DIFF
--- a/public/app/features/alerting/unified/components/rules/state-history/LokiStateHistory.tsx
+++ b/public/app/features/alerting/unified/components/rules/state-history/LokiStateHistory.tsx
@@ -19,6 +19,7 @@ interface Props {
   ruleUID: string;
 }
 
+const STATE_HISTORY_POLLING_INTERVAL = 10 * 1000; // 10 seconds
 const MAX_TIMELINE_SERIES = 12;
 
 const LokiStateHistory = ({ ruleUID }: Props) => {
@@ -38,12 +39,19 @@ const LokiStateHistory = ({ ruleUID }: Props) => {
     isLoading,
     isError,
     error,
-  } = useGetRuleHistoryQuery({
-    ruleUid: ruleUID,
-    from: queryTimeRange.from.unix(),
-    to: queryTimeRange.to.unix(),
-    limit: 250,
-  });
+  } = useGetRuleHistoryQuery(
+    {
+      ruleUid: ruleUID,
+      from: queryTimeRange.from.unix(),
+      to: queryTimeRange.to.unix(),
+      limit: 250,
+    },
+    {
+      refetchOnFocus: true,
+      refetchOnReconnect: true,
+      pollingInterval: STATE_HISTORY_POLLING_INTERVAL,
+    }
+  );
 
   const { dataFrames, historyRecords, commonLabels, totalRecordsCount } = useRuleHistoryRecords(
     stateHistory,


### PR DESCRIPTION
**What is this feature?**

Refresh the alert state history on re-focus, re-connect and on a 10-second interval to allow users to observe the history of an alert rule without having to manually refresh the page and switch tabs.