### PR TITLE
Alerting: Fix broken panelId links

### DIFF
--- a/public/app/features/alerting/unified/components/rules/RulesGroup.tsx
+++ b/public/app/features/alerting/unified/components/rules/RulesGroup.tsx
@@ -278,7 +278,7 @@ export const RulesGroup = React.memo(({ group, namespace, expandAll, viewMode }:
           namespace={namespace}
           group={group}
           onClose={() => closeEditModal()}
-          folderUrl={folder?.canEdit ? makeFolderSettingsLink(folder) : undefined}
+          folderUrl={folder?.canEdit ? makeFolderSettingsLink(folder.uid) : undefined}
           folderUid={folderUID}
         />
       )}

--- a/public/app/features/alerting/unified/utils/misc.test.ts
+++ b/public/app/features/alerting/unified/utils/misc.test.ts
@@ -1,4 +1,16 @@
-import { sortAlerts, wrapWithQuotes, escapeQuotes, createExploreLink } from 'app/features/alerting/unified/utils/misc';
+import {
+  sortAlerts,
+  wrapWithQuotes,
+  escapeQuotes,
+  createExploreLink,
+  makeLabelBasedSilenceLink,
+  makeDataSourceLink,
+  makeFolderLink,
+  makeFolderAlertsLink,
+  makeFolderSettingsLink,
+  makeDashboardLink,
+  makePanelLink,
+} from 'app/features/alerting/unified/utils/misc';
 import { SortOrder } from 'app/plugins/panel/alertlist/types';
 import { Alert } from 'app/types/unified-alerting';
 import { GrafanaAlertState } from 'app/types/unified-alerting-dto';
@@ -93,5 +105,34 @@ describe('createExploreLink', () => {
     expect(url).toBe(
       '/explore?left=%7B%22datasource%22%3A%22uid%22%2C%22queries%22%3A%5B%7B%22refId%22%3A%22A%22%2C%22datasource%22%3A%7B%22uid%22%3A%22uid%22%2C%22type%22%3A%22type%22%7D%2C%22expr%22%3A%22cpu_utilization+%3E+0.5%22%7D%5D%2C%22range%22%3A%7B%22from%22%3A%22now-1h%22%2C%22to%22%3A%22now%22%7D%7D'
     );
+  });
+});
+
+describe('create links', () => {
+  it('should create silence link', () => {
+    expect(makeLabelBasedSilenceLink('grafana', { foo: 'bar' })).toBe('');
+  });
+
+  it('should create data source link', () => {
+    expect(makeDataSourceLink('my-data-source')).toBe('/datasources/edit/my-data-source');
+  });
+
+  it('should make folder link', () => {
+    expect(makeFolderLink('abc123')).toBe('/dashboards/f/abc123');
+  });
+
+  it('should make folder alerts link', () => {
+    expect(makeFolderAlertsLink('abc123', 'my-title')).toBe('/dashboards/f/abc123/my-title/alerting');
+  });
+
+  it('should make folder settings link', () => {
+    expect(makeFolderSettingsLink('abc123')).toBe('/dashboards/f/abc123/settings');
+  });
+
+  it('should make dashboard link', () => {
+    expect(makeDashboardLink('abc123 def456')).toBe('/d/abc123%20def456');
+  });
+  it('should make panel link', () => {
+    expect(makePanelLink('dashboard uid', '1')).toBe('/d/dashboard%20uid?viewPanel=1');
   });
 });

--- a/public/app/features/alerting/unified/utils/misc.test.ts
+++ b/public/app/features/alerting/unified/utils/misc.test.ts
@@ -110,7 +110,9 @@ describe('createExploreLink', () => {
 
 describe('create links', () => {
   it('should create silence link', () => {
-    expect(makeLabelBasedSilenceLink('grafana', { foo: 'bar' })).toBe('');
+    expect(makeLabelBasedSilenceLink('grafana', { foo: 'bar', bar: 'baz' })).toBe(
+      '/alerting/silence/new?alertmanager=grafana&matcher=foo%3Dbar&matcher=bar%3Dbaz'
+    );
   });
 
   it('should create data source link', () => {

--- a/public/app/features/alerting/unified/utils/misc.ts
+++ b/public/app/features/alerting/unified/utils/misc.ts
@@ -157,14 +157,8 @@ export function makeDashboardLink(dashboardUID: string): string {
   return createUrl(`/d/${encodeURIComponent(dashboardUID)}`);
 }
 
-type PanelLinkParams = {
-  viewPanel?: string;
-  editPanel?: string;
-  tab?: 'alert' | 'transform' | 'query';
-};
-
-export function makePanelLink(dashboardUID: string, panelId: string, queryParams: PanelLinkParams = {}): string {
-  const panelParams = new URLSearchParams(queryParams);
+export function makePanelLink(dashboardUID: string, panelId: string): string {
+  const panelParams = new URLSearchParams({ viewPanel: panelId });
   return createUrl(`/d/${encodeURIComponent(dashboardUID)}`, panelParams);
 }
 

--- a/public/app/features/alerting/unified/utils/misc.ts
+++ b/public/app/features/alerting/unified/utils/misc.ts
@@ -14,8 +14,6 @@ import {
   mapStateWithReasonToBaseState,
 } from 'app/types/unified-alerting-dto';
 
-import { FolderDTO } from '../../../../types';
-
 import { ALERTMANAGER_NAME_QUERY_KEY } from './constants';
 import { getRulesSourceName, isCloudRulesSource } from './datasource';
 import { getMatcherQueryParams } from './matchers';
@@ -149,8 +147,8 @@ export function makeFolderAlertsLink(folderUID: string, title: string): string {
   return createUrl(`/dashboards/f/${folderUID}/${title}/alerting`);
 }
 
-export function makeFolderSettingsLink(folder: FolderDTO): string {
-  return createUrl(`/dashboards/f/${folder.uid}/settings`);
+export function makeFolderSettingsLink(uid: string): string {
+  return createUrl(`/dashboards/f/${uid}/settings`);
 }
 
 export function makeDashboardLink(dashboardUID: string): string {


### PR DESCRIPTION
**What is this feature?**

A regression introduced in https://github.com/grafana/grafana/pull/81902 made all links to a specific panel go to the dashboard instead.

**Special notes for your reviewer:**

Since we're removed the deprecation notice in `main` we can simplify this function again. 
I also added some tests for link creation functions that were missing.