### PR TITLE
Docs: update docs for dashgpt GA G11 

### DIFF
--- a/docs/sources/dashboards/build-dashboards/create-dashboard/index.md
+++ b/docs/sources/dashboards/build-dashboards/create-dashboard/index.md
@@ -77,8 +77,7 @@ Dashboards and panels allow you to show your data in visual form. Each panel nee
 
    Alternatively, click **Apply** if you want to see your changes applied to the dashboard first. Then click the save icon in the dashboard header.
 
-1. Enter a summary of your dashboard changes or have Grafana create one using [generative AI features][].
-1. Enter a title for your dashboard or have Grafana create one using [generative AI features][]
+1. Enter a title and description of your dashboard changes or have Grafana create them using [generative AI features][].
 1. Select a folder, if applicable.
 1. Click **Save**.
 1. To add more panels to the dashboard, click **Add** in the dashboard header and select **Visualization** in the drop-down.

--- a/docs/sources/dashboards/build-dashboards/create-dashboard/index.md
+++ b/docs/sources/dashboards/build-dashboards/create-dashboard/index.md
@@ -62,10 +62,7 @@ Dashboards and panels allow you to show your data in visual form. Each panel nee
 
    For more information about individual visualizations, refer to [Visualizations options][].
 
-1. Under **Panel options**, enter a title and description for your panel.
-
-   Alternatively, Grafana can generate a panel title and description for you using the OpenAI integration. Learn more in the [Set up generative AI features for dashboards documentation][].
-
+1. Under **Panel options**, enter a title and description for your panel or have Grafana create them using [generative AI features][].
 1. Refer to the following documentation for ways you can adjust panel settings.
 
    While not required, most visualizations need some adjustment before they properly display the information that you need.
@@ -80,14 +77,9 @@ Dashboards and panels allow you to show your data in visual form. Each panel nee
 
    Alternatively, click **Apply** if you want to see your changes applied to the dashboard first. Then click the save icon in the dashboard header.
 
-1. Enter a summary of your dashboard changes.
-
-   Alternatively, Grafana can generate a summary for you using the OpenAI integration. Learn more in the [Set up generative AI features for dashboards documentation][].
-
-1. Enter a title for your dashboard and select a folder, if applicable.
-
-   Alternatively, Grafana can generate a dashboard title for you using the OpenAI integration. Learn more in the [Set up generative AI features for dashboards documentation][].
-
+1. Enter a summary of your dashboard changes or have Grafana create one using [generative AI features][].
+1. Enter a title for your dashboard or have Grafana create one using [generative AI features][]
+1. Select a folder, if applicable.
 1. Click **Save**.
 1. To add more panels to the dashboard, click **Add** in the dashboard header and select **Visualization** in the drop-down.
 
@@ -197,6 +189,6 @@ You can size a dashboard panel to suits your needs.
 [Configure standard options]: "/docs/grafana/ -> /docs/grafana/<GRAFANA VERSION>/panels-visualizations/configure-standard-options"
 [Configure standard options]: "/docs/grafana-cloud/ -> /docs/grafana/<GRAFANA VERSION>/panels-visualizations/configure-standard-options"
 
-[Set up generative AI features for dashboards documentation]: "/docs/grafana/ -> /docs/grafana/<GRAFANA VERSION>/dashboards/manage-dashboards#set-up-generative-ai-features-for-dashboards"
-[Set up generative AI features for dashboards documentation]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/visualizations/dashboards/manage-dashboards#set-up-generative-ai-features-for-dashboards"
+[generative AI features]: "/docs/grafana/ -> /docs/grafana/<GRAFANA VERSION>/dashboards/manage-dashboards#set-up-generative-ai-features-for-dashboards"
+[generative AI features]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/visualizations/dashboards/manage-dashboards#set-up-generative-ai-features-for-dashboards"
 {{% /docs/reference %}}

--- a/docs/sources/dashboards/build-dashboards/create-dashboard/index.md
+++ b/docs/sources/dashboards/build-dashboards/create-dashboard/index.md
@@ -77,7 +77,7 @@ Dashboards and panels allow you to show your data in visual form. Each panel nee
 
    Alternatively, click **Apply** if you want to see your changes applied to the dashboard first. Then click the save icon in the dashboard header.
 
-1. Enter a title and description of your dashboard changes or have Grafana create them using [generative AI features][].
+1. Enter a title and description for your dashboard or have Grafana create them using [generative AI features][].
 1. Select a folder, if applicable.
 1. Click **Save**.
 1. To add more panels to the dashboard, click **Add** in the dashboard header and select **Visualization** in the drop-down.

--- a/docs/sources/dashboards/manage-dashboards/index.md
+++ b/docs/sources/dashboards/manage-dashboards/index.md
@@ -100,14 +100,12 @@ For more information about dashboard permissions, refer to [Dashboard permission
 
 ## Set up generative AI features for dashboards
 
-{{< docs/public-preview product="Generative AI in dashboards" featureFlag="`dashgpt`" >}}
-
 You can use generative AI to help you with the following tasks:
 
 - **Generate panel and dashboard titles and descriptions**: Generate a title and description based on the data you’ve added for your panel or dashboard. This is useful when you want to visualize your data quickly and don’t want to spend time coming up with a title or description.
 - **Generate dashboard save changes summary**: Generate a summary of the changes you’ve made to a dashboard when you save it. This is great for easily tracking the history of a dashboard.
 
-To access these features, enable the `dashgpt` feature toggle. Then install and configure Grafana’s Large Language Model (LLM) app plugin. For more information, refer to the [Grafana LLM plugin documentation][].
+To access these features, install and configure Grafana’s Large Language Model (LLM) app plugin. For more information, refer to the [Grafana LLM plugin documentation][].
 
 When enabled, the **✨ Auto generate** option displays next to the **Title** and **Description** fields in your panels and dashboards, or when you press the **Save** button.
 

--- a/docs/sources/dashboards/use-dashboards/index.md
+++ b/docs/sources/dashboards/use-dashboards/index.md
@@ -36,7 +36,7 @@ The following image and descriptions highlight all dashboard features.
 {{< figure src="/media/docs/grafana/dashboards/screenshot-dashboard-annotated-9-5-0.png" width="700px" alt="An annotated image of a dashboard" >}}
 
 - (1) **Grafana home**: Click **Home** in the breadcrumb to be redirected to the home page configured in the Grafana instance.
-- (2) **Dashboard title**: When you click the dashboard title, you can search for dashboards contained in the current folder.
+- (2) **Dashboard title**: When you click the dashboard title, you can search for dashboards contained in the current folder. You can create your own dashboard titles or have Grafana create them for you using [generative AI features][].
 - (3) **Share dashboard or panel**: Use this option to share the current dashboard or panel using a link or snapshot. You can also export the dashboard definition from the share modal.
 - (4) **Add**: Use this option to add a panel, dashboard row, or library panel to the current dashboard.
 - (5) **Save dashboard**: Click to save changes to your dashboard.
@@ -53,6 +53,7 @@ The following image and descriptions highlight all dashboard features.
   - Library panels can be shared among many dashboards.
   - To move a panel, drag the panel header to another location.
   - To resize a panel, click and drag the lower right corner of the panel.
+  - Use [generative AI features][] to create panel titles and descriptions.
 - (14) **Graph legend**: Change series colors, y-axis and series visibility directly from the legend.
 - (15) **Dashboard row**: A dashboard row is a logical divider within a dashboard that groups panels together.
   - Rows can be collapsed or expanded allowing you to hide parts of the dashboard.
@@ -232,4 +233,7 @@ You can control the time range of a dashboard by providing the following query p
 
 [repeating rows]: "/docs/grafana/ -> /docs/grafana/<GRAFANA VERSION>/dashboards/build-dashboards/create-dashboard#configure-repeating-rows"
 [repeating rows]: "/docs/grafana-cloud/ -> /docs/grafana/<GRAFANA VERSION>/dashboards/build-dashboards/create-dashboard#configure-repeating-rows"
+
+[generative AI features]: "/docs/grafana/ -> /docs/grafana/<GRAFANA_VERSION>/dashboards/manage-dashboards#set-up-generative-ai-features-for-dashboards"
+[generative AI features]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/visualizations/dashboards/manage-dashboards#set-up-generative-ai-features-for-dashboards"
 {{% /docs/reference %}}

--- a/docs/sources/getting-started/build-first-dashboard.md
+++ b/docs/sources/getting-started/build-first-dashboard.md
@@ -69,7 +69,7 @@ To create your first dashboard using the built-in `-- Grafana --` data source:
 
    Alternatively, click **Apply** if you want to see your changes applied to the dashboard first. Then click the save icon in the dashboard header.
 
-1. Add a descriptive title for the dashboard or have Grafana create them using [generative AI features](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/dashboards/manage-dashboards#set-up-generative-ai-features-for-dashboards), and then click **Save**.
+1. Add a descriptive title for the dashboard, or have Grafana create one using [generative AI features](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/dashboards/manage-dashboards#set-up-generative-ai-features-for-dashboards), and then click **Save**.
 
 Congratulations, you have created your first dashboard and it's displaying results.
 

--- a/docs/sources/getting-started/build-first-dashboard.md
+++ b/docs/sources/getting-started/build-first-dashboard.md
@@ -69,9 +69,7 @@ To create your first dashboard using the built-in `-- Grafana --` data source:
 
    Alternatively, click **Apply** if you want to see your changes applied to the dashboard first. Then click the save icon in the dashboard header.
 
-1. Add a descriptive title for the dashboard, and then click **Save**.
-
-   Alternatively, Grafana can generate a dashboard title and summary for you using the OpenAI integration. Learn more in the [Set up generative AI features for dashboards documentation](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/dashboards/manage-dashboards#set-up-generative-ai-features-for-dashboards).
+1. Add a descriptive title for the dashboard or have Grafana create them using [generative AI features](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/dashboards/manage-dashboards#set-up-generative-ai-features-for-dashboards), and then click **Save**.
 
 Congratulations, you have created your first dashboard and it's displaying results.
 

--- a/docs/sources/panels-visualizations/visualizations/traces/index.md
+++ b/docs/sources/panels-visualizations/visualizations/traces/index.md
@@ -56,7 +56,7 @@ This procedure uses dashboard variables and templates to allow you to enter trac
 1. Select **Add visualization** from a new dashboard or select **Add Panel** on an existing dashboard.
 1. Search for and select the appropriate tracing data source.
 1. In the top-right of the panel editor, select the **Visualizations** tab, search for, and select **Traces**.
-1. Under the **Panel options**, enter a **Title** for your trace panel. For more information on the panel editor, refer to the [Configure panel options documentation][].
+1. Under the **Panel options**, enter a **Title** for your trace panel or have Grafana create one using [generative AI features][]. For more information on the panel editor, refer to the [Configure panel options documentation][].
 1. In the query editor, select the **TraceQL** query type tab.
 1. Enter `${traceId}` in the TraceQL query field to create a dashboard variable. This variable is used as the template query.
 
@@ -80,7 +80,7 @@ It’s more useful to instead be able to use TraceQL queries to search for speci
 1. Select the same trace data source you used in the previous section.
 1. In the top-right of the panel editor, select the **Visualizations** tab, search for, and select **Table**.
 1. In the query editor, select the **TraceQL** tab.
-1. Under the **Panel options**, enter a **Title** for your trace panel.
+1. Under the **Panel options**, enter a **Title** for your trace panel or have Grafana create one using [generative AI features][].
 1. Add an appropriate TraceQL query to search for traces that you would like to visualize in the dashboard. This example uses a simple, static query. You can write the TraceQL query as a template query to take advantage of other dashboard variables, if they exist. This lets you create dynamic queries based on these variables.
 
    {{< figure src="/static/img/docs/panels/traces/screenshot-traces-dynamic-query.png" caption="Create a dynamic query" >}}
@@ -134,4 +134,7 @@ You should now see a list of matching traces in the table visualization. While s
 
 [Tempo data source]: "/docs/grafana/ -> /docs/grafana/<GRAFANA VERSION>/datasources/tempo"
 [Tempo data source]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/connect-externally-hosted/data-sources/tempo"
+
+[generative AI features]: "/docs/grafana/ -> /docs/grafana/<GRAFANA_VERSION>/dashboards/manage-dashboards#set-up-generative-ai-features-for-dashboards"
+[generative AI features]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/visualizations/dashboards/manage-dashboards#set-up-generative-ai-features-for-dashboards"
 {{% /docs/reference %}}


### PR DESCRIPTION
Removes public preview note
Shortens references to AI features in panel and dashboard creation docs
Adds some more references to AI features

Note: This page also needs to have public preview note removed, as well as other updates:
https://grafana.com/docs/grafana-cloud/alerting-and-irm/machine-learning/configure/llm-plugin/