### PR TITLE
Hack: Switching to Set instead of Add for now until we sort out middleware in core plugins

### DIFF
--- a/pkg/services/datasources/service/datasource.go
+++ b/pkg/services/datasources/service/datasource.go
@@ -680,7 +680,7 @@ func (s *Service) getCustomHeaders(jsonData *simplejson.Json, decryptedValues ma
 		}
 
 		if val, ok := decryptedValues[headerValueSuffix]; ok {
-			headers.Add(key, val)
+			headers.Set(key, val)
 		}
 	}
 

--- a/pkg/services/datasources/service/datasource_test.go
+++ b/pkg/services/datasources/service/datasource_test.go
@@ -1223,20 +1223,20 @@ func TestDataSource_CustomHeaders(t *testing.T) {
 			secureJsonData:  map[string][]byte{},
 			expectedHeaders: http.Header{},
 		},
-		{
-			name: "add multiple header value",
-			jsonData: simplejson.NewFromAny(map[string]any{
-				"httpHeaderName1": "X-Test-Header1",
-				"httpHeaderName2": "X-Test-Header1",
-			}),
-			secureJsonData: map[string][]byte{
-				"httpHeaderValue1": encryptedValue,
-				"httpHeaderValue2": encryptedValue,
-			},
-			expectedHeaders: http.Header{
-				"X-Test-Header1": []string{testValue, testValue},
-			},
-		},
+		// {
+		// 	name: "add multiple header value",
+		// 	jsonData: simplejson.NewFromAny(map[string]any{
+		// 		"httpHeaderName1": "X-Test-Header1",
+		// 		"httpHeaderName2": "X-Test-Header1",
+		// 	}),
+		// 	secureJsonData: map[string][]byte{
+		// 		"httpHeaderValue1": encryptedValue,
+		// 		"httpHeaderValue2": encryptedValue,
+		// 	},
+		// 	expectedHeaders: http.Header{
+		// 		"X-Test-Header1": []string{testValue, testValue},
+		// 	},
+		// },
 	}
 
 	for _, tc := range testCases {


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**
We have made duplicate headers possible https://github.com/grafana/grafana/pull/84289 but seems like some datasources are applying middleware multiple times (that should not be the case) and it causes headers to multiply unnecessarily - this is causing downstream errors.

This is a hacky attempt to keep the behaviour as it was before while we sort out the duplicate middleware application.

**Why do we need this feature?**

[Add a description of the problem the feature is trying to solve.]

**Who is this feature for?**

[Add information on what kind of user the feature is for.]

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
