### PR TITLE
Prometheus: Prevent duplicate registration of custom header middleware

### DIFF
--- a/pkg/promlib/client/transport.go
+++ b/pkg/promlib/client/transport.go
@@ -37,7 +37,6 @@ func middlewares(logger log.Logger, httpMethod string) []sdkhttpclient.Middlewar
 	middlewares := []sdkhttpclient.Middleware{
 		// TODO: probably isn't needed anymore and should by done by http infra code
 		middleware.CustomQueryParameters(logger),
-		sdkhttpclient.CustomHeadersMiddleware(),
 	}
 
 	// Needed to control GET vs POST method of the requests

--- a/pkg/promlib/client/transport_test.go
+++ b/pkg/promlib/client/transport_test.go
@@ -22,6 +22,6 @@ func TestCreateTransportOptions(t *testing.T) {
 		opts, err := CreateTransportOptions(context.Background(), settings, backend.NewLoggerWith("logger", "test"))
 		require.NoError(t, err)
 		require.Equal(t, http.Header{"Foo": []string{"bar"}}, opts.Header)
-		require.Equal(t, 2, len(opts.Middlewares))
+		require.Equal(t, 1, len(opts.Middlewares))
 	})
 }


### PR DESCRIPTION
**What is this feature?**

Since the `CustomHeader` is already default middleware, due to [existing logic](https://github.com/grafana/grafana-plugin-sdk-go/blob/9e6a51de64cea97ac43543b35e3439103cc28435/backend/httpclient/provider.go#L162) and a [change in header behaviour](https://github.com/grafana/grafana-plugin-sdk-go/pull/830), this middleware will execute twice for Prometheus, resulting in issues downstream.

**Why do we need this feature?**

It prevents setting duplicate values for custom headers for outgoing Prometheus requests and solves the issues we're experiencing in Grafana Cloud.

<!--
**Who is this feature for?**

[Add information on what kind of user the feature is for.]

**Which issue(s) does this PR fix?**:



- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"



Fixes #

**Special notes for your reviewer:**

Please check that:
- [X] It works as expected from a user's perspective.
- [X] If this is a pre-GA feature, it is behind a feature toggle.
- [X] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
-->