### PR TITLE
Alerting: Stop returning autogen routes for non-admin on api/v2/status

### DIFF
--- a/pkg/services/ngalert/api/api_alertmanager.go
+++ b/pkg/services/ngalert/api/api_alertmanager.go
@@ -50,7 +50,12 @@ func (srv AlertmanagerSrv) RouteGetAMStatus(c *contextmodel.ReqContext) response
 		return errResp
 	}
 
-	return response.JSON(http.StatusOK, am.GetStatus())
+	status := am.GetStatus()
+	if !c.SignedInUser.HasRole(org.RoleAdmin) {
+		notifier.RemoveAutogenConfigIfExists(status.Config.Route)
+	}
+
+	return response.JSON(http.StatusOK, status)
 }
 
 func (srv AlertmanagerSrv) RouteCreateSilence(c *contextmodel.ReqContext, postableSilence apimodels.PostableSilence) response.Response {


### PR DESCRIPTION
**What is this feature?**

Stops returning simplified routing autogenerated routes on `api/alertmanager/grafana/api/v2/status` for non-admins.

**Why do we need this feature?**

`api/alertmanager/grafana/config/api/v1/alerts` already removes autogenerated routes for non-admins, this PR extends this to `api/alertmanager/grafana/api/v2/status`

**Who is this feature for?**

Users of simplified routing