### PR TITLE
Table panel: Add Apply to entire row option to colored text cell

### DIFF
--- a/packages/grafana-schema/src/common/common.gen.ts
+++ b/packages/grafana-schema/src/common/common.gen.ts
@@ -747,6 +747,7 @@ export interface TableAutoCellOptions {
  * Colored text cell options
  */
 export interface TableColorTextCellOptions {
+  applyToRow?: boolean;
   type: TableCellDisplayMode.ColorText;
 }
 

--- a/packages/grafana-schema/src/common/table.cue
+++ b/packages/grafana-schema/src/common/table.cue
@@ -36,6 +36,7 @@ TableAutoCellOptions: {
 // Colored text cell options
 TableColorTextCellOptions: {
 	type: TableCellDisplayMode & "color-text"
+	applyToRow?: bool
 } @cuetsy(kind="interface")
 
 // Json view cell options

--- a/public/app/plugins/panel/table/cells/ColorTextCellOptionEditor.tsx
+++ b/public/app/plugins/panel/table/cells/ColorTextCellOptionEditor.tsx
@@ -1,0 +1,28 @@
+import React from 'react';
+
+import { TableColorTextCellOptions } from '@grafana/schema';
+import { Field, Switch } from '@grafana/ui';
+
+import { TableCellEditorProps } from '../TableCellOptionEditor';
+
+export const ColorBackgroundCellOptionsEditor = ({
+    cellOptions,
+    onChange,
+}: TableCellEditorProps<TableColorTextCellOptions>) => {
+    // Handle row coloring changes
+    const onColorRowChange = () => {
+        cellOptions.applyToRow = !cellOptions.applyToRow;
+        onChange(cellOptions);
+    };
+
+    return (
+        <>
+            <Field
+                label="Apply to entire row"
+                description="If selected the entire row will be colored as this cell would be."
+            >
+                <Switch value={cellOptions.applyToRow} onChange={onColorRowChange} />
+            </Field>
+        </>
+    );
+};


### PR DESCRIPTION
**What is this feature?**

This PR adds the ability to apply the color text cell to an entire row. This matches the capability of the color background cell.

**Why do we need this feature?**

Being able to color text by row is in additional useful expansion of the ability to format the table rows.

**Who is this feature for?**

Users of the table panel.

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
