### PR TITLE
Chore: Update influxdb docs with new parameter insecureGrpc

### DIFF
--- a/docs/sources/datasources/influxdb/_index.md
+++ b/docs/sources/datasources/influxdb/_index.md
@@ -224,6 +224,7 @@ datasources:
       version: SQL
       dbName: site
       httpMode: POST
+      insecureGrpc: false
     secureJsonData:
       token: '<api-token>'
 ```


### PR DESCRIPTION
**What is this feature?**

Add the `insecureGrpc` parameter in the example. 