### PR TITLE
E2C: Migration summary

### DIFF
--- a/public/app/features/migrate-to-cloud/api.ts
+++ b/public/app/features/migrate-to-cloud/api.ts
@@ -187,6 +187,12 @@ export const migrateToCloudAPI = createApi({
       },
     }),
 
+    startMigration: builder.mutation<void, void>({
+      queryFn: async () => {
+        return dataWithMockDelay(undefined);
+      },
+    }),
+
     listResources: builder.query<MigrationResourceDTO[], void>({
       providesTags: ['resource'],
       queryFn: async () => {
@@ -204,4 +210,5 @@ export const {
   useDeleteMigrationTokenMutation,
   useHasMigrationTokenQuery,
   useListResourcesQuery,
+  useStartMigrationMutation,
 } = migrateToCloudAPI;

--- a/public/app/features/migrate-to-cloud/onprem/MigrationInfo.tsx
+++ b/public/app/features/migrate-to-cloud/onprem/MigrationInfo.tsx
@@ -2,15 +2,18 @@ import React, { ReactNode } from 'react';
 
 import { Stack, Text } from '@grafana/ui';
 
-export function MigrationInfo({ title, value }: { title: NonNullable<ReactNode>; value: NonNullable<ReactNode> }) {
+interface MigrationInfoProps {
+  title: NonNullable<ReactNode>;
+  value: NonNullable<ReactNode>;
+}
+
+export function MigrationInfo({ title, value }: MigrationInfoProps) {
   return (
     <Stack direction="column">
       <Text variant="bodySmall" color="secondary">
         {title}
       </Text>
-      <Text variant="h4" element="span">
-        {value}
-      </Text>
+      <Text variant="h4">{value}</Text>
     </Stack>
   );
 }

--- a/public/app/features/migrate-to-cloud/onprem/MigrationInfo.tsx
+++ b/public/app/features/migrate-to-cloud/onprem/MigrationInfo.tsx
@@ -1,0 +1,16 @@
+import React, { ReactNode } from 'react';
+
+import { Stack, Text } from '@grafana/ui';
+
+export function MigrationInfo({ title, value }: { title: NonNullable<ReactNode>; value: NonNullable<ReactNode> }) {
+  return (
+    <Stack direction="column">
+      <Text variant="bodySmall" color="secondary">
+        {title}
+      </Text>
+      <Text variant="h4" element="span">
+        {value}
+      </Text>
+    </Stack>
+  );
+}

--- a/public/app/features/migrate-to-cloud/onprem/Page.tsx
+++ b/public/app/features/migrate-to-cloud/onprem/Page.tsx
@@ -38,7 +38,7 @@ export const Page = () => {
         )}
 
         {status.stackURL && (
-          <Box borderColor="weak" borderStyle="solid" padding={2}>
+          <Box borderColor="weak" borderStyle="solid" padding={2} display="flex" gap={4} alignItems="center">
             <Stack gap={4} alignItems="center">
               <MigrationInfo
                 title={t('migrate-to-cloud.summary.target-stack-title', 'Uploading to')}
@@ -51,17 +51,15 @@ export const Page = () => {
                   </>
                 }
               />
-
-              <div style={{ flex: '1 1 auto' }} />
-
-              <Button
-                disabled={isBusy}
-                onClick={() => startMigration()}
-                icon={startMigrationIsLoading ? 'spinner' : undefined}
-              >
-                <Trans i18nKey="migrate-to-cloud.summary.start-migration">Upload everything</Trans>
-              </Button>
             </Stack>
+
+            <Button
+              disabled={isBusy}
+              onClick={() => startMigration()}
+              icon={startMigrationIsLoading ? 'spinner' : undefined}
+            >
+              <Trans i18nKey="migrate-to-cloud.summary.start-migration">Upload everything</Trans>
+            </Button>
           </Box>
         )}
 

--- a/public/app/features/migrate-to-cloud/onprem/Page.tsx
+++ b/public/app/features/migrate-to-cloud/onprem/Page.tsx
@@ -13,9 +13,7 @@ import { ResourcesTable } from './ResourcesTable';
 
 export const Page = () => {
   const { data: status, isFetching } = useGetStatusQuery();
-  const { data: resources } = useListResourcesQuery(status?.enabled ? undefined : skipToken, {
-    pollingInterval: 5 * 1000,
-  });
+  const { data: resources } = useListResourcesQuery(status?.enabled ? undefined : skipToken);
   const [startMigration, { isLoading: startMigrationIsLoading, isError: startMigrationIsError }] =
     useStartMigrationMutation();
   const [isDisconnecting, setIsDisconnecting] = useState(false);

--- a/public/app/features/migrate-to-cloud/onprem/Page.tsx
+++ b/public/app/features/migrate-to-cloud/onprem/Page.tsx
@@ -38,7 +38,15 @@ export const Page = () => {
         )}
 
         {status.stackURL && (
-          <Box borderColor="weak" borderStyle="solid" padding={2} display="flex" gap={4} alignItems="center">
+          <Box
+            borderColor="weak"
+            borderStyle="solid"
+            padding={2}
+            display="flex"
+            gap={4}
+            alignItems="center"
+            justifyContent="space-between"
+          >
             <Stack gap={4} alignItems="center">
               <MigrationInfo
                 title={t('migrate-to-cloud.summary.target-stack-title', 'Uploading to')}

--- a/public/app/features/migrate-to-cloud/onprem/Page.tsx
+++ b/public/app/features/migrate-to-cloud/onprem/Page.tsx
@@ -1,32 +1,71 @@
 import { skipToken } from '@reduxjs/toolkit/query/react';
 import React, { useState } from 'react';
 
-import { Button, Stack, Text } from '@grafana/ui';
-import { Trans } from 'app/core/internationalization';
+import { Alert, Box, Button, Stack } from '@grafana/ui';
+import { Trans, t } from 'app/core/internationalization';
 
-import { useGetStatusQuery, useListResourcesQuery } from '../api';
+import { useGetStatusQuery, useListResourcesQuery, useStartMigrationMutation } from '../api';
 
 import { DisconnectModal } from './DisconnectModal';
 import { EmptyState } from './EmptyState/EmptyState';
+import { MigrationInfo } from './MigrationInfo';
 import { ResourcesTable } from './ResourcesTable';
 
 export const Page = () => {
   const { data: status, isFetching } = useGetStatusQuery();
-  const { data: resources } = useListResourcesQuery(status?.enabled ? undefined : skipToken);
+  const { data: resources } = useListResourcesQuery(status?.enabled ? undefined : skipToken, {
+    pollingInterval: 5 * 1000,
+  });
+  const [startMigration, { isLoading: startMigrationIsLoading, isError: startMigrationIsError }] =
+    useStartMigrationMutation();
   const [isDisconnecting, setIsDisconnecting] = useState(false);
 
   if (!status?.enabled) {
     return <EmptyState />;
   }
 
+  const isBusy = isFetching || isDisconnecting || startMigrationIsLoading;
+
   return (
     <>
-      <Stack direction="column" alignItems="flex-start">
-        {status.stackURL && <Text variant="h4">{status.stackURL}</Text>}
+      <Stack direction="column" gap={4}>
+        {startMigrationIsError && (
+          <Alert
+            severity="error"
+            title={t(
+              'migrate-to-cloud.summary.error-starting-migration',
+              'There was an error starting cloud migration'
+            )}
+          />
+        )}
 
-        <Button disabled={isFetching || isDisconnecting} variant="secondary" onClick={() => setIsDisconnecting(true)}>
-          <Trans i18nKey="migrate-to-cloud.resources.disconnect">Disconnect</Trans>
-        </Button>
+        {status.stackURL && (
+          <Box borderColor="weak" borderStyle="solid" padding={2}>
+            <Stack gap={4} alignItems="center">
+              <MigrationInfo
+                title={t('migrate-to-cloud.summary.target-stack-title', 'Uploading to')}
+                value={
+                  <>
+                    {status.stackURL}{' '}
+                    <Button onClick={() => setIsDisconnecting(true)} disabled={isBusy} variant="secondary" size="sm">
+                      <Trans i18nKey="migrate-to-cloud.summary.disconnect">Disconnect</Trans>
+                    </Button>
+                  </>
+                }
+              />
+
+              <div style={{ flex: '1 1 auto' }} />
+
+              <Button
+                disabled={isBusy}
+                onClick={() => startMigration()}
+                icon={startMigrationIsLoading ? 'spinner' : undefined}
+              >
+                <Trans i18nKey="migrate-to-cloud.summary.start-migration">Upload everything</Trans>
+              </Button>
+            </Stack>
+          </Box>
+        )}
 
         {resources && <ResourcesTable resources={resources} />}
       </Stack>

--- a/public/app/features/migrate-to-cloud/onprem/Page.tsx
+++ b/public/app/features/migrate-to-cloud/onprem/Page.tsx
@@ -47,19 +47,17 @@ export const Page = () => {
             alignItems="center"
             justifyContent="space-between"
           >
-            <Stack gap={4} alignItems="center">
-              <MigrationInfo
-                title={t('migrate-to-cloud.summary.target-stack-title', 'Uploading to')}
-                value={
-                  <>
-                    {status.stackURL}{' '}
-                    <Button onClick={() => setIsDisconnecting(true)} disabled={isBusy} variant="secondary" size="sm">
-                      <Trans i18nKey="migrate-to-cloud.summary.disconnect">Disconnect</Trans>
-                    </Button>
-                  </>
-                }
-              />
-            </Stack>
+            <MigrationInfo
+              title={t('migrate-to-cloud.summary.target-stack-title', 'Uploading to')}
+              value={
+                <>
+                  {status.stackURL}{' '}
+                  <Button onClick={() => setIsDisconnecting(true)} disabled={isBusy} variant="secondary" size="sm">
+                    <Trans i18nKey="migrate-to-cloud.summary.disconnect">Disconnect</Trans>
+                  </Button>
+                </>
+              }
+            />
 
             <Button
               disabled={isBusy}

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -789,8 +789,11 @@
       "datasource": "Data source",
       "unknown": "Unknown"
     },
-    "resources": {
-      "disconnect": "Disconnect"
+    "summary": {
+      "disconnect": "Disconnect",
+      "error-starting-migration": "There was an error starting cloud migration",
+      "start-migration": "Upload everything",
+      "target-stack-title": "Uploading to"
     },
     "token-status": {
       "active": "Token created and active",

--- a/public/locales/pseudo-LOCALE/grafana.json
+++ b/public/locales/pseudo-LOCALE/grafana.json
@@ -789,8 +789,11 @@
       "datasource": "Đäŧä şőūřčę",
       "unknown": "Ůŉĸŉőŵŉ"
     },
-    "resources": {
-      "disconnect": "Đįşčőŉŉęčŧ"
+    "summary": {
+      "disconnect": "Đįşčőŉŉęčŧ",
+      "error-starting-migration": "Ŧĥęřę ŵäş äŉ ęřřőř şŧäřŧįŉģ čľőūđ mįģřäŧįőŉ",
+      "start-migration": "Ůpľőäđ ęvęřyŧĥįŉģ",
+      "target-stack-title": "Ůpľőäđįŉģ ŧő"
     },
     "token-status": {
       "active": "Ŧőĸęŉ čřęäŧęđ äŉđ äčŧįvę",


### PR DESCRIPTION
Adds the Migration Summary box to the top of Migrate to Cloud to show the current connected stack, disconnect, and to start the migration.


![7345_2024-03-21-11-17_firefox](https://github.com/grafana/grafana/assets/46142/7daa79cb-f20e-4f47-a461-0808bd28aa93)


 - Adds `startMigration` API mutation. It doesn't really do anything, not even a mocked behaviour. I figured this is more dependant on real functionality, so I think this is fine for now.
 - Adds migration info to the on-prem Page

Fixes https://github.com/grafana/grafana/issues/84553 