### PR TITLE
datatrails: fix dark mode drawer background clashing with data trail backgrounds

### DIFF
--- a/public/app/features/trails/Integrations/SceneDrawer.tsx
+++ b/public/app/features/trails/Integrations/SceneDrawer.tsx
@@ -1,7 +1,9 @@
+import { css } from '@emotion/css';
 import React from 'react';
 
+import { GrafanaTheme2 } from '@grafana/data';
 import { SceneComponentProps, SceneObjectBase, SceneObject, SceneObjectState } from '@grafana/scenes';
-import { Drawer } from '@grafana/ui';
+import { Drawer, useStyles2 } from '@grafana/ui';
 import appEvents from 'app/core/app_events';
 import { ShowModalReactEvent } from 'app/types/events';
 
@@ -13,9 +15,11 @@ export type SceneDrawerProps = {
 
 export function SceneDrawer(props: SceneDrawerProps) {
   const { scene, title, onDismiss } = props;
+  const styles = useStyles2(getStyles);
+
   return (
     <Drawer title={title} onClose={onDismiss} size="lg">
-      <div style={{ display: 'flex', height: '100%' }}>
+      <div className={styles.drawerInnerWrapper}>
         <scene.Component model={scene} />
       </div>
     </Drawer>
@@ -43,4 +47,18 @@ export function launchSceneDrawerInGlobalModal(props: Omit<SceneDrawerProps, 'on
   };
 
   appEvents.publish(new ShowModalReactEvent(payload));
+}
+
+function getStyles(theme: GrafanaTheme2) {
+  return {
+    drawerInnerWrapper: css({
+      display: 'flex',
+      padding: theme.spacing(2),
+      background: theme.isDark ? theme.colors.background.canvas : theme.colors.background.primary,
+      position: 'absolute',
+      left: 0,
+      right: 0,
+      top: 0,
+    }),
+  };
 }


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

Makes the embedding drawer use a background that would be present on the data trails page so that the colors align well in both dark mode and light mode.

![image](https://github.com/grafana/grafana/assets/38694490/ff92ef8a-2899-4294-803c-835a68fc4392)

![image](https://github.com/grafana/grafana/assets/38694490/517ddd3f-9f5f-44da-bbc3-39d94c917bed)


**Why do we need this feature?**

To fix these background artifacts:
![image](https://github.com/grafana/grafana/assets/38694490/bbaa6446-6db9-456e-8b29-a3b494d27d99)



**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
