### PR TITLE
Canvas: Fix crash when trying to add wind turbine element

### DIFF
--- a/public/app/plugins/panel/canvas/utils.ts
+++ b/public/app/plugins/panel/canvas/utils.ts
@@ -148,11 +148,11 @@ export function getDataLinks(
 
     // Text config
     const isTextTiedToFieldData =
-      elementConfig.text?.field &&
-      visibleFields.some((field) => getFieldDisplayName(field, frame) === elementConfig.text?.field);
+      elementConfig?.text?.field &&
+      visibleFields.some((field) => getFieldDisplayName(field, frame) === elementConfig?.text?.field);
     const isTextColorTiedToFieldData =
-      elementConfig.color?.field &&
-      visibleFields.some((field) => getFieldDisplayName(field, frame) === elementConfig.color?.field);
+      elementConfig?.color?.field &&
+      visibleFields.some((field) => getFieldDisplayName(field, frame) === elementConfig?.color?.field);
 
     // General element config
     const isElementBackgroundColorTiedToFieldData =
@@ -167,36 +167,38 @@ export function getDataLinks(
 
     // Icon config
     const isIconSVGTiedToFieldData =
-      elementConfig.path?.field &&
-      visibleFields.some((field) => getFieldDisplayName(field, frame) === elementConfig.path?.field);
+      elementConfig?.path?.field &&
+      visibleFields.some((field) => getFieldDisplayName(field, frame) === elementConfig?.path?.field);
     const isIconColorTiedToFieldData =
-      elementConfig.fill?.field &&
-      visibleFields.some((field) => getFieldDisplayName(field, frame) === elementConfig.fill?.field);
+      elementConfig?.fill?.field &&
+      visibleFields.some((field) => getFieldDisplayName(field, frame) === elementConfig?.fill?.field);
 
     // Wind turbine config (maybe remove / not support this?)
     const isWindTurbineRPMTiedToFieldData =
-      elementConfig.rpm?.field &&
-      visibleFields.some((field) => getFieldDisplayName(field, frame) === elementConfig.rpm?.field);
+      elementConfig?.rpm?.field &&
+      visibleFields.some((field) => getFieldDisplayName(field, frame) === elementConfig?.rpm?.field);
 
     // Server config
     const isServerBlinkRateTiedToFieldData =
-      elementConfig.blinkRate?.field &&
-      visibleFields.some((field) => getFieldDisplayName(field, frame) === elementConfig.blinkRate?.field);
+      elementConfig?.blinkRate?.field &&
+      visibleFields.some((field) => getFieldDisplayName(field, frame) === elementConfig?.blinkRate?.field);
     const isServerStatusColorTiedToFieldData =
-      elementConfig.statusColor?.field &&
-      visibleFields.some((field) => getFieldDisplayName(field, frame) === elementConfig.statusColor?.field);
+      elementConfig?.statusColor?.field &&
+      visibleFields.some((field) => getFieldDisplayName(field, frame) === elementConfig?.statusColor?.field);
     const isServerBulbColorTiedToFieldData =
-      elementConfig.bulbColor?.field &&
-      visibleFields.some((field) => getFieldDisplayName(field, frame) === elementConfig.bulbColor?.field);
+      elementConfig?.bulbColor?.field &&
+      visibleFields.some((field) => getFieldDisplayName(field, frame) === elementConfig?.bulbColor?.field);
 
     if (isTextTiedToFieldData) {
-      const field = visibleFields.filter((field) => getFieldDisplayName(field, frame) === elementConfig.text?.field)[0];
+      const field = visibleFields.filter(
+        (field) => getFieldDisplayName(field, frame) === elementConfig?.text?.field
+      )[0];
       addDataLinkForField(field, data, linkLookup, links);
     }
 
     if (isTextColorTiedToFieldData) {
       const field = visibleFields.filter(
-        (field) => getFieldDisplayName(field, frame) === elementConfig.color?.field
+        (field) => getFieldDisplayName(field, frame) === elementConfig?.color?.field
       )[0];
       addDataLinkForField(field, data, linkLookup, links);
     }
@@ -223,37 +225,41 @@ export function getDataLinks(
     }
 
     if (isIconSVGTiedToFieldData) {
-      const field = visibleFields.filter((field) => getFieldDisplayName(field, frame) === elementConfig.path?.field)[0];
+      const field = visibleFields.filter(
+        (field) => getFieldDisplayName(field, frame) === elementConfig?.path?.field
+      )[0];
       addDataLinkForField(field, data, linkLookup, links);
     }
 
     if (isIconColorTiedToFieldData) {
-      const field = visibleFields.filter((field) => getFieldDisplayName(field, frame) === elementConfig.fill?.field)[0];
+      const field = visibleFields.filter(
+        (field) => getFieldDisplayName(field, frame) === elementConfig?.fill?.field
+      )[0];
       addDataLinkForField(field, data, linkLookup, links);
     }
 
     if (isWindTurbineRPMTiedToFieldData) {
-      const field = visibleFields.filter((field) => getFieldDisplayName(field, frame) === elementConfig.rpm?.field)[0];
+      const field = visibleFields.filter((field) => getFieldDisplayName(field, frame) === elementConfig?.rpm?.field)[0];
       addDataLinkForField(field, data, linkLookup, links);
     }
 
     if (isServerBlinkRateTiedToFieldData) {
       const field = visibleFields.filter(
-        (field) => getFieldDisplayName(field, frame) === elementConfig.blinkRate?.field
+        (field) => getFieldDisplayName(field, frame) === elementConfig?.blinkRate?.field
       )[0];
       addDataLinkForField(field, data, linkLookup, links);
     }
 
     if (isServerStatusColorTiedToFieldData) {
       const field = visibleFields.filter(
-        (field) => getFieldDisplayName(field, frame) === elementConfig.statusColor?.field
+        (field) => getFieldDisplayName(field, frame) === elementConfig?.statusColor?.field
       )[0];
       addDataLinkForField(field, data, linkLookup, links);
     }
 
     if (isServerBulbColorTiedToFieldData) {
       const field = visibleFields.filter(
-        (field) => getFieldDisplayName(field, frame) === elementConfig.bulbColor?.field
+        (field) => getFieldDisplayName(field, frame) === elementConfig?.bulbColor?.field
       )[0];
       addDataLinkForField(field, data, linkLookup, links);
     }


### PR DESCRIPTION
Fix wind turbine element that was crashing / sometimes crashing the entire panel when trying to add a wind turbine element.

Note: this does not impact already added wind turbine elements, and only crashes when trying to add this element type

Fix was improving optional chaining of recent canvas datalink code 

Before


https://github.com/grafana/grafana/assets/22381771/38b8f1ad-2330-4d0a-ba99-20e7ecf28dd4



After


https://github.com/grafana/grafana/assets/22381771/956fe8e9-fc96-4e44-b020-a1537b562543

