### PR TITLE
CloudWatch: Fix queries being filtered out when an expression depended on its results

### DIFF
--- a/public/app/plugins/datasource/cloudwatch/datasource.test.ts
+++ b/public/app/plugins/datasource/cloudwatch/datasource.test.ts
@@ -138,7 +138,7 @@ describe('datasource', () => {
 
     test.each(testTable)('should filter out hidden queries unless id is provided', ({ query, valid }) => {
       const { datasource } = setupMockedDataSource();
-      expect(datasource.filterQuery(query)).toEqual(valid);
+      expect(datasource.isQueryEnabled(query)).toEqual(valid);
     });
 
     it('should interpolate variables in the query', async () => {

--- a/public/app/plugins/datasource/cloudwatch/datasource.ts
+++ b/public/app/plugins/datasource/cloudwatch/datasource.ts
@@ -76,14 +76,14 @@ export class CloudWatchDatasource
     this.defaultLogGroups = instanceSettings.jsonData.defaultLogGroups;
   }
 
-  filterQuery(query: CloudWatchQuery) {
+  isQueryEnabled(query: CloudWatchQuery) {
     return query.hide !== true || (isCloudWatchMetricsQuery(query) && query.id !== '');
   }
 
   query(options: DataQueryRequest<CloudWatchQuery>): Observable<DataQueryResponse> {
     options = cloneDeep(options);
 
-    let queries = options.targets.filter(this.filterQuery);
+    const queries = options.targets.filter(this.isQueryEnabled);
 
     const logQueries: CloudWatchLogsQuery[] = [];
     const metricsQueries: CloudWatchMetricsQuery[] = [];


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

From Grafana 11 queries are now filtered in the query runner see (https://github.com/grafana/grafana/pull/84656). This PR fixes an issue where expressions referencing a hidden query did not work. This is because the `filterQuery` function is now called in the query runner, whereas before it was only called inside `datasource.query`. The change in this PR renames the `filterQuery` function to `isQueryEnabled` which is only used in `datasource.query`. Since we aren't implementing the `filterQuery` function, our queries are not filtered when running expression queries. This preserves the existing behaviour.

**Why do we need this feature?**

[Add a description of the problem the feature is trying to solve.]

**Who is this feature for?**

[Add information on what kind of user the feature is for.]

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
