### PR TITLE
Table Panel: Fix hover regression

### DIFF
--- a/packages/grafana-ui/src/components/Table/styles.ts
+++ b/packages/grafana-ui/src/components/Table/styles.ts
@@ -56,7 +56,7 @@ export function useTableStyles(theme: GrafanaTheme2, cellHeightOption: TableCell
         wordBreak: textShouldWrap ? 'break-word' : undefined,
         whiteSpace: textShouldWrap && overflowOnHover ? 'normal' : 'nowrap',
         boxShadow: overflowOnHover ? `0 0 2px ${theme.colors.primary.main}` : undefined,
-        background: rowStyled ? 'inherit' : background ?? undefined,
+        background: rowStyled ? 'inherit' : background ?? theme.colors.background.primary,
         zIndex: 1,
         '.cellActions': {
           color: '#FFF',


### PR DESCRIPTION
This PR implements a fix for a regression caused by https://github.com/grafana/grafana/pull/83939 which causes table cell background not to be set on hover when row formatting isn't applied. In the case that row formatting isn't applied this will apply the default theme background color.