### PR TITLE
datatrails: lazy load the breakdown queries, reduce panels, reduce number of points

### DIFF
--- a/public/app/features/trails/ActionTabs/BreakdownScene.tsx
+++ b/public/app/features/trails/ActionTabs/BreakdownScene.tsx
@@ -35,6 +35,8 @@ import { ByFrameRepeater } from './ByFrameRepeater';
 import { LayoutSwitcher } from './LayoutSwitcher';
 import { getLabelOptions } from './utils';
 
+const MAX_PANELS_IN_ALL_LABELS_BREAKDOWN = 60;
+
 export interface BreakdownSceneState extends SceneObjectState {
   body?: SceneObject;
   labels: Array<SelectableValue<string>>;
@@ -198,6 +200,10 @@ export function buildAllLayout(options: Array<SelectableValue<string>>, queryDef
       continue;
     }
 
+    if (children.length === MAX_PANELS_IN_ALL_LABELS_BREAKDOWN) {
+      break;
+    }
+
     const expr = queryDef.queries[0].expr.replaceAll(VAR_GROUP_BY_EXP, String(option.value));
     const unit = queryDef.unit;
 
@@ -207,7 +213,7 @@ export function buildAllLayout(options: Array<SelectableValue<string>>, queryDef
           .setTitle(option.label!)
           .setData(
             new SceneQueryRunner({
-              maxDataPoints: 300,
+              maxDataPoints: 250,
               datasource: trailDS,
               queries: [
                 {
@@ -236,12 +242,14 @@ export function buildAllLayout(options: Array<SelectableValue<string>>, queryDef
         templateColumns: GRID_TEMPLATE_COLUMNS,
         autoRows: '200px',
         children: children,
+        isLazy: true,
       }),
       new SceneCSSGridLayout({
         templateColumns: '1fr',
         autoRows: '200px',
         // Clone children since a scene object can only have one parent at a time
         children: children.map((c) => c.clone()),
+        isLazy: true,
       }),
     ],
   });


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

Reduces the number of simultaneous queries when the data trails breakdown is selected with "ALL" labels.
- Lazy loading, so only panels that have been scrolled to will have their queries activated
- Limited number of panels on this tab to 60
- Reduced the "max points" to 250 from 300

**Why do we need this feature?**

Panels with a large number of labels (e.g., ALERTS_FOR_STATE) would overload the browser with a burst of queries, causing a crash in some environments.

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
