### PR TITLE
Datasources: Add fixed width to name field in config editor

### DIFF
--- a/public/app/features/datasources/components/BasicSettings.tsx
+++ b/public/app/features/datasources/components/BasicSettings.tsx
@@ -26,6 +26,7 @@ export function BasicSettings({ dataSourceName, isDefault, onDefaultChange, onNa
               'preselected in new panels."
               grow
               disabled={disabled}
+              labelWidth={14}
             >
               <Input
                 id="basic-settings-name"


### PR DESCRIPTION
**What is this feature?**

By fixating the width of this field, we at least give data sources a chance to align label width in the fields used in the config editor so that it looks better. 

**Why do we need this feature?**

[Add a description of the problem the feature is trying to solve.]

**Who is this feature for?**

[Add information on what kind of user the feature is for.]

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
