### PR TITLE
Auth: Remove `oauth_skip_org_role_update_sync` as an option

### DIFF
--- a/conf/defaults.ini
+++ b/conf/defaults.ini
@@ -561,10 +561,6 @@ oauth_auto_login = false
 # OAuth state max age cookie duration in seconds. Defaults to 600 seconds.
 oauth_state_cookie_max_age = 600
 
-# Skip forced assignment of OrgID 1 or 'auto_assign_org_id' for social logins
-# Deprecated, use skip_org_role_sync option for specific provider instead.
-oauth_skip_org_role_update_sync = false
-
 # limit of api_key seconds to live before expiration
 api_key_max_seconds_to_live = -1
 

--- a/conf/sample.ini
+++ b/conf/sample.ini
@@ -538,10 +538,6 @@
 # OAuth state max age cookie duration in seconds. Defaults to 600 seconds.
 ;oauth_state_cookie_max_age = 600
 
-# Skip forced assignment of OrgID 1 or 'auto_assign_org_id' for social logins
-# Deprecated, use skip_org_role_sync option for specific provider instead.
-;oauth_skip_org_role_update_sync = false
-
 # limit of api_key seconds to live before expiration
 ;api_key_max_seconds_to_live = -1
 

--- a/docs/sources/setup-grafana/configure-grafana/_index.md
+++ b/docs/sources/setup-grafana/configure-grafana/_index.md
@@ -938,10 +938,10 @@ Administrators can increase this if they experience OAuth login state mismatch e
 ### oauth_skip_org_role_update_sync
 
 {{% admonition type="note" %}}
-This option is deprecated in favor of OAuth provider specific `skip_org_role_sync` settings. The following sections explain settings for each provider.
+This option is removed from G11 in favor of OAuth provider specific `skip_org_role_sync` settings. The following sections explain settings for each provider.
 {{% /admonition %}}
 
-If you want to change the `oauth_skip_org_role_update_sync` setting to `false`, then for each provider you have set up, use the `skip_org_role_sync` setting to specify whether you want to skip the synchronization.
+If you want to change the `oauth_skip_org_role_update_sync` setting from `true` to `false`, then each provider you have set up, use the `skip_org_role_sync` setting to specify whether you want to skip the synchronization.
 
 {{% admonition type="warning" %}}
 Currently if no organization role mapping is found for a user, Grafana doesn't update the user's organization role.

--- a/pkg/api/frontendsettings.go
+++ b/pkg/api/frontendsettings.go
@@ -327,7 +327,6 @@ func (hs *HTTPServer) getFrontendSettings(c *contextmodel.ReqContext) (*dtos.Fro
 	oauthProviders := hs.SocialService.GetOAuthInfoProviders()
 	frontendSettings.Auth = dtos.FrontendSettingsAuthDTO{
 		AuthProxyEnableLoginToken:     hs.Cfg.AuthProxy.EnableLoginToken,
-		OAuthSkipOrgRoleUpdateSync:    hs.Cfg.OAuthSkipOrgRoleUpdateSync,
 		SAMLSkipOrgRoleSync:           hs.Cfg.SAMLSkipOrgRoleSync,
 		LDAPSkipOrgRoleSync:           hs.Cfg.LDAPSkipOrgRoleSync,
 		JWTAuthSkipOrgRoleSync:        hs.Cfg.JWTAuth.SkipOrgRoleSync,

--- a/pkg/login/social/connectors/azuread_oauth_test.go
+++ b/pkg/login/social/connectors/azuread_oauth_test.go
@@ -800,8 +800,7 @@ func TestSocialAzureAD_SkipOrgRole(t *testing.T) {
 					SkipOrgRoleSync:         false,
 				},
 				cfg: &setting.Cfg{
-					AutoAssignOrgRole:          "",
-					OAuthSkipOrgRoleUpdateSync: false,
+					AutoAssignOrgRole: "",
 				},
 			},
 			claims: &azureClaims{
@@ -831,8 +830,7 @@ func TestSocialAzureAD_SkipOrgRole(t *testing.T) {
 					SkipOrgRoleSync:         false,
 				},
 				cfg: &setting.Cfg{
-					AutoAssignOrgRole:          "",
-					OAuthSkipOrgRoleUpdateSync: false,
+					AutoAssignOrgRole: "",
 				},
 			},
 			claims: &azureClaims{

--- a/pkg/login/social/connectors/gitlab_oauth_test.go
+++ b/pkg/login/social/connectors/gitlab_oauth_test.go
@@ -362,8 +362,7 @@ func TestSocialGitlab_extractFromToken(t *testing.T) {
 					TokenUrl:            tc.config.Endpoint.TokenURL,
 				},
 				&setting.Cfg{
-					AutoAssignOrgRole:          "",
-					OAuthSkipOrgRoleUpdateSync: false,
+					AutoAssignOrgRole: "",
 				}, &ssosettingstests.MockService{},
 				featuremgmt.WithFeatures())
 

--- a/pkg/login/social/connectors/okta_oauth_test.go
+++ b/pkg/login/social/connectors/okta_oauth_test.go
@@ -111,8 +111,7 @@ func TestSocialOkta_UserInfo(t *testing.T) {
 					SkipOrgRoleSync:         tt.settingSkipOrgRoleSync,
 				},
 				&setting.Cfg{
-					AutoAssignOrgRole:          tt.autoAssignOrgRole,
-					OAuthSkipOrgRoleUpdateSync: false,
+					AutoAssignOrgRole: tt.autoAssignOrgRole,
 				},
 				&ssosettingstests.MockService{},
 				featuremgmt.WithFeatures())

--- a/pkg/services/authn/clients/oauth.go
+++ b/pkg/services/authn/clients/oauth.go
@@ -162,9 +162,6 @@ func (c *OAuth) Authenticate(ctx context.Context, r *authn.Request) (*authn.Iden
 	}
 
 	orgRoles, isGrafanaAdmin, _ := getRoles(c.cfg, func() (org.RoleType, *bool, error) {
-		if c.cfg.OAuthSkipOrgRoleUpdateSync {
-			return "", nil, nil
-		}
 		return userInfo.Role, userInfo.IsGrafanaAdmin, nil
 	})
 

--- a/pkg/services/login/authinfo.go
+++ b/pkg/services/login/authinfo.go
@@ -78,12 +78,6 @@ func IsExternallySynced(cfg *setting.Cfg, authModule string, oauthInfo *social.O
 	case JWTModule:
 		return !cfg.JWTAuth.SkipOrgRoleSync
 	}
-	// then check the rest of the oauth providers
-	// FIXME: remove this once we remove the setting
-	// is a deprecated setting that is used to skip org role sync for all external oauth providers
-	if cfg.OAuthSkipOrgRoleUpdateSync {
-		return false
-	}
 	switch authModule {
 	case GoogleAuthModule, OktaAuthModule, AzureADAuthModule, GitLabAuthModule, GithubAuthModule, GrafanaComAuthModule, GenericOAuthModule:
 		if oauthInfo == nil {

--- a/pkg/services/login/authinfo_test.go
+++ b/pkg/services/login/authinfo_test.go
@@ -32,14 +32,6 @@ func TestIsExternallySynced(t *testing.T) {
 			provider:  AzureADAuthModule,
 			expected:  false,
 		},
-		// FIXME: remove this test as soon as we remove the deprecated setting for skipping org role sync for all external oauth providers
-		{
-			name:      "AzureAD external user should return that it is not externally synced when oauth org role sync is set",
-			cfg:       &setting.Cfg{OAuthSkipOrgRoleUpdateSync: true},
-			oauthInfo: &social.OAuthInfo{Enabled: true, SkipOrgRoleSync: false},
-			provider:  AzureADAuthModule,
-			expected:  false,
-		},
 		{
 			name:      "AzureAD external user should return that it is not externally synced when the provider is not enabled",
 			cfg:       &setting.Cfg{},

--- a/pkg/setting/setting.go
+++ b/pkg/setting/setting.go
@@ -1571,8 +1571,9 @@ func readAuthSettings(iniFile *ini.File, cfg *Cfg) (err error) {
 
 	cfg.OAuthCookieMaxAge = auth.Key("oauth_state_cookie_max_age").MustInt(600)
 	cfg.SignoutRedirectUrl = valueAsString(auth, "signout_redirect_url", "")
+
 	// Deprecated
-	cfg.OAuthSkipOrgRoleUpdateSync = auth.Key("oauth_skip_org_role_update_sync").MustBool(false)
+	cfg.OAuthSkipOrgRoleUpdateSync = true
 	if cfg.OAuthSkipOrgRoleUpdateSync {
 		cfg.Logger.Warn("[Deprecated] The oauth_skip_org_role_update_sync configuration setting is deprecated. Please use skip_org_role_sync inside the auth provider section instead.")
 	}

--- a/pkg/setting/setting.go
+++ b/pkg/setting/setting.go
@@ -1573,10 +1573,7 @@ func readAuthSettings(iniFile *ini.File, cfg *Cfg) (err error) {
 	cfg.SignoutRedirectUrl = valueAsString(auth, "signout_redirect_url", "")
 
 	// Deprecated
-	cfg.OAuthSkipOrgRoleUpdateSync = true
-	if cfg.OAuthSkipOrgRoleUpdateSync {
-		cfg.Logger.Warn("[Deprecated] The oauth_skip_org_role_update_sync configuration setting is deprecated. Please use skip_org_role_sync inside the auth provider section instead.")
-	}
+	cfg.OAuthSkipOrgRoleUpdateSync = false
 
 	cfg.DisableLogin = auth.Key("disable_login").MustBool(false)
 

--- a/pkg/setting/setting_session_test.go
+++ b/pkg/setting/setting_session_test.go
@@ -25,7 +25,7 @@ func TestSessionSettings(t *testing.T) {
 		})
 		require.Nil(t, err)
 
-		require.Equal(t, 1, logger.WarnLogs.Calls)
+		require.Equal(t, 2, logger.WarnLogs.Calls)
 		require.Greater(t, len(logger.WarnLogs.Message), 0)
 	})
 }

--- a/pkg/setting/setting_session_test.go
+++ b/pkg/setting/setting_session_test.go
@@ -25,7 +25,7 @@ func TestSessionSettings(t *testing.T) {
 		})
 		require.Nil(t, err)
 
-		require.Equal(t, 2, logger.WarnLogs.Calls)
+		require.Equal(t, 1, logger.WarnLogs.Calls)
 		require.Greater(t, len(logger.WarnLogs.Message), 0)
 	})
 }


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

We are removing the option of `oauth_skip_org_role_update_sync`  infavor of setting each providers `skip_org_role_sync` sync for each provider.

**Why do we need this feature?**

Users have the ability to configure the oauth skip settings for each provider. 

# Release notice breaking change

In 9.3 we released a way to set `case_insensitive_login` to true. This enables, lowercased username, login for users signing up with Grafana, for more information read our [blog post](https://grafana.com/blog/2022/12/12/guide-to-using-the-new-grafana-cli-user-identity-conflict-tool-in-grafana-9.3/).

If you encounter any issues with users signing up, we recommend everyone to use lowercase in their login, username otherwise refer to the blog post for how to solve any of the users that can be conflicting with their login/username.