### PR TITLE
Add onClick behaviour to links to new tooltips

### DIFF
--- a/public/app/features/visualization/data-hover/ExemplarHoverView.tsx
+++ b/public/app/features/visualization/data-hover/ExemplarHoverView.tsx
@@ -2,7 +2,7 @@ import { css } from '@emotion/css';
 import React from 'react';
 
 import { GrafanaTheme2, LinkModel } from '@grafana/data';
-import { LinkButton, useStyles2 } from '@grafana/ui';
+import { DataLinkButton, useStyles2 } from '@grafana/ui';
 import { VizTooltipRow } from '@grafana/ui/src/components/VizTooltip/VizTooltipRow';
 import { renderValue } from 'app/plugins/panel/geomap/utils/uiUtils';
 
@@ -42,23 +42,7 @@ export const ExemplarHoverView = ({ displayValues, links, header = 'Exemplar' }:
       {links && links.length > 0 && (
         <div className={styles.exemplarFooter}>
           {links.map((link, i) => (
-            <LinkButton
-              key={i}
-              href={link.href}
-              className={styles.linkButton}
-              onClick={
-                link.onClick
-                  ? (event) => {
-                      if (!(event.ctrlKey || event.metaKey || event.shiftKey) && link.onClick) {
-                        event.preventDefault();
-                        link.onClick(event);
-                      }
-                    }
-                  : undefined
-              }
-            >
-              {link.title}
-            </LinkButton>
+            <DataLinkButton link={link} key={i} buttonProps={{ size: 'md' }} />
           ))}
         </div>
       )}

--- a/public/app/features/visualization/data-hover/ExemplarHoverView.tsx
+++ b/public/app/features/visualization/data-hover/ExemplarHoverView.tsx
@@ -42,7 +42,21 @@ export const ExemplarHoverView = ({ displayValues, links, header = 'Exemplar' }:
       {links && links.length > 0 && (
         <div className={styles.exemplarFooter}>
           {links.map((link, i) => (
-            <LinkButton key={i} href={link.href} className={styles.linkButton}>
+            <LinkButton
+              key={i}
+              href={link.href}
+              className={styles.linkButton}
+              onClick={
+                link.onClick
+                  ? (event) => {
+                      if (!(event.ctrlKey || event.metaKey || event.shiftKey) && link.onClick) {
+                        event.preventDefault();
+                        link.onClick(event);
+                      }
+                    }
+                  : undefined
+              }
+            >
               {link.title}
             </LinkButton>
           ))}


### PR DESCRIPTION
**What is this feature?**

This PR adds a call to the `onClick` function of a link if it exists. It replicates the behaviour of the previous tooltips (it was using the `DataLink` component, and handling the link's `onClick` ([ref](https://github.com/grafana/grafana/blob/b20da139ad0fe96299321c347baa4da36860ea54/packages/grafana-ui/src/components/DataLinks/DataLinkButton.tsx#L22)))

**Why do we need this feature?**

We need this feature to be able to override the link and behaviour when clicking on it, since we usually have the information related to that point in there.

**Who is this feature for?**

It replicates existing behaviour in the old tooltips, so for everyone relying on the `onClick` attribute of the link.

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
