### PR TITLE
Datasources: Fix expressions that reference hidden queries

### DIFF
--- a/public/app/features/query/state/runRequest.test.ts
+++ b/public/app/features/query/state/runRequest.test.ts
@@ -12,6 +12,7 @@ import {
   PanelData,
 } from '@grafana/data';
 import { setEchoSrv } from '@grafana/runtime';
+import { ExpressionDatasourceRef } from '@grafana/runtime/src/utils/DataSourceWithBackend';
 import { DataQuery } from '@grafana/schema';
 
 import { deepFreeze } from '../../../../test/core/redux/reducerTester';
@@ -32,6 +33,12 @@ jest.mock('app/features/dashboard/services/DashboardSrv', () => ({
     return {
       getCurrent: () => dashboardModel,
     };
+  },
+}));
+
+jest.mock('app/features/expressions/ExpressionDatasource', () => ({
+  dataSource: {
+    query: jest.fn(),
   },
 }));
 
@@ -530,6 +537,28 @@ describe('callQueryMethod', () => {
         ],
       })
     );
+  });
+
+  it('Should not call filterQuery when targets include expression query', async () => {
+    setup({
+      targets: [
+        {
+          refId: 'A',
+          q: 'SUM(foo)',
+        },
+        {
+          refId: 'B',
+          q: 'SUM(foo2)',
+        },
+        {
+          datasource: ExpressionDatasourceRef,
+          refId: 'C',
+          q: 'SUM(foo3)',
+        },
+      ],
+      filterQuery: (query: DataQuery) => query.refId !== 'A',
+    });
+    expect(filterQuerySpy).not.toHaveBeenCalled();
   });
 
   it('Should get ds default query when query is empty', async () => {

--- a/public/app/features/query/state/runRequest.ts
+++ b/public/app/features/query/state/runRequest.ts
@@ -201,15 +201,6 @@ export function callQueryMethod(
       : t
   );
 
-  // do not filter queries in case a custom query function is provided (for example in variable queries)
-  if (!queryFunction) {
-    request.targets = request.targets.filter((t) => datasource.filterQuery?.(t) ?? true);
-  }
-
-  if (request.targets.length === 0) {
-    return of<DataQueryResponse>({ data: [] });
-  }
-
   // If its a public datasource, just return the result. Expressions will be handled on the backend.
   if (config.publicDashboardAccessToken) {
     return from(datasource.query(request));
@@ -219,6 +210,15 @@ export function callQueryMethod(
     if (isExpressionReference(target.datasource)) {
       return expressionDatasource.query(request as DataQueryRequest<ExpressionQuery>);
     }
+  }
+
+  // do not filter queries in case a custom query function is provided (for example in variable queries)
+  if (!queryFunction) {
+    request.targets = request.targets.filter((t) => datasource.filterQuery?.(t) ?? true);
+  }
+
+  if (request.targets.length === 0) {
+    return of<DataQueryResponse>({ data: [] });
   }
 
   // Otherwise it is a standard datasource request


### PR DESCRIPTION
**What is this feature?**

The [Change query filtering](https://github.com/grafana/grafana/pull/84656) PR that was merged yesterday introduced a bug that caused expression queries that referenced hidden queries to stop working. This PR changes the order of things in the query runner, ensuring expression data source query method is triggered before any filtering takes place (in case target includes expression queries). 


**Why do we need this feature?**


**Who is this feature for?**

Users of Grafana

**Which issue(s) does this PR fix?**:



Fixes https://github.com/grafana/grafana/issues/84976

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
