### PR TITLE
Dashboards: Fix canceling of all outstanding requests when variable requests are slow.

### DIFF
--- a/public/app/features/variables/state/actions.ts
+++ b/public/app/features/variables/state/actions.ts
@@ -932,7 +932,7 @@ export const initVariablesTransaction =
       const uid = toStateKey(urlUid);
       const state = getState();
       const lastKey = getIfExistsLastKey(state);
-      if (lastKey) {
+      if (lastKey && lastKey !== uid) {
         const transactionState = getVariablesState(lastKey, state).transaction;
         if (transactionState.status === TransactionStatus.Fetching) {
           // previous dashboard is still fetching variables, cancel all requests


### PR DESCRIPTION
**What is this feature?**
This is a weird one. Under som circumstances the dashboard page will unmount and mount again. If the user is on a slow connection we might end up with a race condition where the variable request from the dashboard we're trying to load, is canceled by itself.

This PR is sort of a band-aid because ideally the dashboard should not mount twice.

https://github.com/grafana/support-escalations/issues/9790
https://github.com/grafana/support-escalations/issues/9749