### PR TITLE
FeatureToggles: Remove unused feature flag

### DIFF
--- a/packages/grafana-data/src/types/featureToggles.gen.ts
+++ b/packages/grafana-data/src/types/featureToggles.gen.ts
@@ -175,6 +175,5 @@ export interface FeatureToggles {
   groupByVariable?: boolean;
   betterPageScrolling?: boolean;
   scopeFilters?: boolean;
-  emailVerificationEnforcement?: boolean;
   ssoSettingsSAML?: boolean;
 }

--- a/pkg/services/featuremgmt/registry.go
+++ b/pkg/services/featuremgmt/registry.go
@@ -1167,14 +1167,6 @@ var (
 			HideFromAdminPage: true,
 		},
 		{
-			Name:              "emailVerificationEnforcement",
-			Description:       "Force email verification for users, even when authenticating through sso.",
-			Stage:             FeatureStageExperimental,
-			Owner:             identityAccessTeam,
-			HideFromDocs:      true,
-			HideFromAdminPage: true,
-		},
-		{
 			Name:              "ssoSettingsSAML",
 			Description:       "Use the new SSO Settings API to configure the SAML connector",
 			Stage:             FeatureStageExperimental,

--- a/pkg/services/featuremgmt/toggles_gen.csv
+++ b/pkg/services/featuremgmt/toggles_gen.csv
@@ -156,5 +156,4 @@ expressionParser,experimental,@grafana/grafana-app-platform-squad,false,true,fal
 groupByVariable,experimental,@grafana/dashboards-squad,false,false,false
 betterPageScrolling,GA,@grafana/grafana-frontend-platform,false,false,true
 scopeFilters,experimental,@grafana/dashboards-squad,false,false,false
-emailVerificationEnforcement,experimental,@grafana/identity-access-team,false,false,false
 ssoSettingsSAML,experimental,@grafana/identity-access-team,false,false,false

--- a/pkg/services/featuremgmt/toggles_gen.go
+++ b/pkg/services/featuremgmt/toggles_gen.go
@@ -635,10 +635,6 @@ const (
 	// Enables the use of scope filters in Grafana
 	FlagScopeFilters = "scopeFilters"
 
-	// FlagEmailVerificationEnforcement
-	// Force email verification for users, even when authenticating through sso.
-	FlagEmailVerificationEnforcement = "emailVerificationEnforcement"
-
 	// FlagSsoSettingsSAML
 	// Use the new SSO Settings API to configure the SAML connector
 	FlagSsoSettingsSAML = "ssoSettingsSAML"

--- a/pkg/services/featuremgmt/toggles_gen.json
+++ b/pkg/services/featuremgmt/toggles_gen.json
@@ -2114,7 +2114,8 @@
       "metadata": {
         "name": "emailVerificationEnforcement",
         "resourceVersion": "1710164083965",
-        "creationTimestamp": "2024-03-11T13:34:43Z"
+        "creationTimestamp": "2024-03-11T13:34:43Z",
+        "deletionTimestamp": "2024-03-22T11:25:34Z"
       },
       "spec": {
         "description": "Force email verification for users, even when authenticating through sso.",


### PR DESCRIPTION
**What is this feature?**
This flag was added in https://github.com/grafana/grafana/pull/84184 but with the solution we are going with we don't need it and can just rely on `cloudRBACRoles` flag.

**Which issue(s) does this PR fix?**:

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
