### PR TITLE
BrowseDashboards: Add subpath to URLs on Browse Dashboards page

### DIFF
--- a/public/app/features/browse-dashboards/api/services.ts
+++ b/public/app/features/browse-dashboards/api/services.ts
@@ -1,5 +1,4 @@
 import { config, getBackendSrv } from '@grafana/runtime';
-import { getConfig } from 'app/core/config';
 import { GENERAL_FOLDER_UID } from 'app/features/search/constants';
 import { getGrafanaSearcher, NestedFolderDTO } from 'app/features/search/service';
 import { queryResultToViewItem } from 'app/features/search/service/utils';
@@ -31,7 +30,7 @@ export async function listFolders(
       limit: pageSize,
     });
   }
-  const subUrlPrefix = getConfig().appSubUrl ?? '';
+  const subUrlPrefix = config.appSubUrl ?? '';
 
   return folders.map((item) => ({
     kind: 'folder',

--- a/public/app/features/browse-dashboards/api/services.ts
+++ b/public/app/features/browse-dashboards/api/services.ts
@@ -1,4 +1,5 @@
 import { config, getBackendSrv } from '@grafana/runtime';
+import { getConfig } from 'app/core/config';
 import { GENERAL_FOLDER_UID } from 'app/features/search/constants';
 import { getGrafanaSearcher, NestedFolderDTO } from 'app/features/search/service';
 import { queryResultToViewItem } from 'app/features/search/service/utils';
@@ -30,6 +31,7 @@ export async function listFolders(
       limit: pageSize,
     });
   }
+  const subUrlPrefix = getConfig().appSubUrl ?? '';
 
   return folders.map((item) => ({
     kind: 'folder',
@@ -37,7 +39,7 @@ export async function listFolders(
     title: item.title,
     parentTitle,
     parentUID,
-    url: isSharedWithMe(item.uid) ? undefined : `/dashboards/f/${item.uid}/`,
+    url: isSharedWithMe(item.uid) ? undefined : `${subUrlPrefix}/dashboards/f/${item.uid}/`,
   }));
 }
 

--- a/public/app/features/browse-dashboards/api/services.ts
+++ b/public/app/features/browse-dashboards/api/services.ts
@@ -39,6 +39,8 @@ export async function listFolders(
     title: item.title,
     parentTitle,
     parentUID,
+
+    // URLs from the backend come with subUrlPrefix already included, so we need to do it again here
     url: isSharedWithMe(item.uid) ? undefined : `${subUrlPrefix}/dashboards/f/${item.uid}/`,
   }));
 }

--- a/public/app/features/browse-dashboards/api/services.ts
+++ b/public/app/features/browse-dashboards/api/services.ts
@@ -39,7 +39,7 @@ export async function listFolders(
     parentTitle,
     parentUID,
 
-    // URLs from the backend come with subUrlPrefix already included, so we need to do it again here
+    // URLs from the backend come with subUrlPrefix already included, so match that behaviour here
     url: isSharedWithMe(item.uid) ? undefined : `${subUrlPrefix}/dashboards/f/${item.uid}/`,
   }));
 }


### PR DESCRIPTION
Fixes #74275 