### PR TITLE
Dashboards: Fix an issue where the dashboard would unmount and then mount again causing requests to cancel under some circumstances

### DIFF
--- a/public/app/features/dashboard/containers/DashboardPageProxy.test.tsx
+++ b/public/app/features/dashboard/containers/DashboardPageProxy.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, act, waitFor } from '@testing-library/react';
+import { act, render, screen, waitFor } from '@testing-library/react';
 import React from 'react';
 import { Provider } from 'react-redux';
 import { Router } from 'react-router-dom';
@@ -30,6 +30,23 @@ const dashMock: DashboardDTO = {
   },
   meta: {
     canEdit: false,
+  },
+};
+
+const homeMock = {
+  ...dashMock,
+  dashboard: {
+    ...dashMock.dashboard,
+    uid: '',
+    title: 'Home',
+  },
+};
+
+const homeMockEditable = {
+  ...homeMock,
+  meta: {
+    ...homeMock.meta,
+    canEdit: true,
   },
 };
 
@@ -126,7 +143,7 @@ describe('DashboardPageProxy', () => {
 
     describe('when user can edit a dashboard ', () => {
       it('should not render DashboardScenePage if route is Home', async () => {
-        getDashboardScenePageStateManager().setDashboardCache(HOME_DASHBOARD_CACHE_KEY, dashMockEditable);
+        getDashboardScenePageStateManager().setDashboardCache(HOME_DASHBOARD_CACHE_KEY, homeMockEditable);
         act(() => {
           setup({
             route: { routeName: DashboardRoutes.Home, component: () => null, path: '/' },
@@ -155,7 +172,7 @@ describe('DashboardPageProxy', () => {
 
     describe('when user can only view a dashboard ', () => {
       it('should render DashboardScenePage if route is Home', async () => {
-        getDashboardScenePageStateManager().setDashboardCache(HOME_DASHBOARD_CACHE_KEY, dashMock);
+        getDashboardScenePageStateManager().setDashboardCache(HOME_DASHBOARD_CACHE_KEY, homeMock);
         act(() => {
           setup({
             route: { routeName: DashboardRoutes.Home, component: () => null, path: '/' },
@@ -169,15 +186,28 @@ describe('DashboardPageProxy', () => {
       });
 
       it('should render DashboardScenePage if route is Normal and has uid', async () => {
-        getDashboardScenePageStateManager().setDashboardCache('abc-def', dashMock);
+        getDashboardScenePageStateManager().setDashboardCache('uid', dashMock);
         act(() => {
           setup({
             route: { routeName: DashboardRoutes.Normal, component: () => null, path: '/' },
-            match: { params: { uid: 'abc-def' }, isExact: true, path: '/', url: '/' },
+            match: { params: { uid: 'uid' }, isExact: true, path: '/', url: '/' },
           });
         });
         await waitFor(() => {
           expect(screen.queryAllByTestId('dashboard-scene-page')).toHaveLength(1);
+        });
+      });
+
+      it('should render not DashboardScenePage if dashboard UID does not match route UID', async () => {
+        getDashboardScenePageStateManager().setDashboardCache('uid', dashMock);
+        act(() => {
+          setup({
+            route: { routeName: DashboardRoutes.Normal, component: () => null, path: '/' },
+            match: { params: { uid: 'wrongUID' }, isExact: true, path: '/', url: '/' },
+          });
+        });
+        await waitFor(() => {
+          expect(screen.queryAllByTestId('dashboard-scene-page')).toHaveLength(0);
         });
       });
     });

--- a/public/app/features/dashboard/containers/DashboardPageProxy.tsx
+++ b/public/app/features/dashboard/containers/DashboardPageProxy.tsx
@@ -53,6 +53,10 @@ function DashboardPageProxy(props: DashboardPageProxyProps) {
     return null;
   }
 
+  if (dashboard.value && dashboard.value.dashboard.uid && dashboard.value.dashboard.uid !== props.match.params.uid) {
+    return null;
+  }
+
   if (
     dashboard.value &&
     !(dashboard.value.meta.canEdit || dashboard.value.meta.canMakeEditable) &&


### PR DESCRIPTION
**What is this feature?**

Replaces #84978

The dashboard page you are trying to navigate will unmount and mount again when navigating between two dashboards. If the user is on a slow connection we might end up with a race condition where the variable request from the dashboard we're trying to load, is canceled by itself.

This eliminates the extra mount.