### PR TITLE
Alerting: Deprecate single alert rule provisioning endpoints in favor of group endpoints

### DIFF
--- a/docs/sources/shared/alerts/alerting_provisioning.md
+++ b/docs/sources/shared/alerts/alerting_provisioning.md
@@ -34,11 +34,11 @@ For managing resources related to [data source-managed alerts]({{< relref "/docs
 
 | Method | URI                                                              | Name                                                                    | Summary                                                               |
 | ------ | ---------------------------------------------------------------- | ----------------------------------------------------------------------- | --------------------------------------------------------------------- |
-| DELETE | /api/v1/provisioning/alert-rules/:uid                            | [route delete alert rule](#route-delete-alert-rule)                     | Delete a specific alert rule by UID.                                  |
-| GET    | /api/v1/provisioning/alert-rules/:uid                            | [route get alert rule](#route-get-alert-rule)                           | Get a specific alert rule by UID.                                     |
-| POST   | /api/v1/provisioning/alert-rules                                 | [route post alert rule](#route-post-alert-rule)                         | Create a new alert rule.                                              |
-| PUT    | /api/v1/provisioning/alert-rules/:uid                            | [route put alert rule](#route-put-alert-rule)                           | Update an existing alert rule.                                        |
-| GET    | /api/v1/provisioning/alert-rules/:uid/export                     | [route get alert rule export](#route-get-alert-rule-export)             | Export an alert rule in provisioning file format.                     |
+| DELETE | /api/v1/provisioning/alert-rules/:uid                            | [route delete alert rule](#route-delete-alert-rule)                     | DEPRECATED: Delete a specific alert rule by UID.                      |
+| GET    | /api/v1/provisioning/alert-rules/:uid                            | [route get alert rule](#route-get-alert-rule)                           | DEPRECATED: Get a specific alert rule by UID.                         |
+| POST   | /api/v1/provisioning/alert-rules                                 | [route post alert rule](#route-post-alert-rule)                         | DEPRECATED: Create a new alert rule.                                  |
+| PUT    | /api/v1/provisioning/alert-rules/:uid                            | [route put alert rule](#route-put-alert-rule)                           | DEPRECATED: Update an existing alert rule.                            |
+| GET    | /api/v1/provisioning/alert-rules/:uid/export                     | [route get alert rule export](#route-get-alert-rule-export)             | DEPRECATED: Export an alert rule in provisioning file format.         |
 | GET    | /api/v1/provisioning/folder/:folderUid/rule-groups/:group        | [route get alert rule group](#route-get-alert-rule-group)               | Get a rule group.                                                     |
 | PUT    | /api/v1/provisioning/folder/:folderUid/rule-groups/:group        | [route put alert rule group](#route-put-alert-rule-group)               | Update the interval of a rule group or modify the rules of the group. |
 | GET    | /api/v1/provisioning/folder/:folderUid/rule-groups/:group/export | [route get alert rule group export](#route-get-alert-rule-group-export) | Export an alert rule group in provisioning file format.               |
@@ -179,7 +179,7 @@ To reset the notification policy tree to the default and unlock it for editing i
 
 ## Paths
 
-### <span id="route-delete-alert-rule"></span> Delete a specific alert rule by UID. (_RouteDeleteAlertRule_)
+### <span id="route-delete-alert-rule"></span> DEPRECATED: Delete a specific alert rule by UID. (_RouteDeleteAlertRule_)
 
 ```
 DELETE /api/v1/provisioning/alert-rules/:uid
@@ -292,7 +292,7 @@ Status: No Content
 
 ###### <span id="route-delete-template-204-schema"></span> Schema
 
-### <span id="route-get-alert-rule"></span> Get a specific alert rule by UID. (_RouteGetAlertRule_)
+### <span id="route-get-alert-rule"></span> DEPRECATED: Get a specific alert rule by UID. (_RouteGetAlertRule_)
 
 ```
 GET /api/v1/provisioning/alert-rules/:uid
@@ -327,7 +327,7 @@ Status: Not Found
 
 ###### <span id="route-get-alert-rule-404-schema"></span> Schema
 
-### <span id="route-get-alert-rule-export"></span> Export an alert rule in provisioning file format. (_RouteGetAlertRuleExport_)
+### <span id="route-get-alert-rule-export"></span> DEPRECATED: Export an alert rule in provisioning file format. (_RouteGetAlertRuleExport_)
 
 ```
 GET /api/v1/provisioning/alert-rules/:uid/export
@@ -878,7 +878,7 @@ Status: Not Found
 
 ###### <span id="route-get-templates-404-schema"></span> Schema
 
-### <span id="route-post-alert-rule"></span> Create a new alert rule. (_RoutePostAlertRule_)
+### <span id="route-post-alert-rule"></span> DEPRECATED: Create a new alert rule. (_RoutePostAlertRule_)
 
 ```
 POST /api/v1/provisioning/alert-rules
@@ -1016,7 +1016,7 @@ Status: Bad Request
 
 [ValidationError](#validation-error)
 
-### <span id="route-put-alert-rule"></span> Update an existing alert rule. (_RoutePutAlertRule_)
+### <span id="route-put-alert-rule"></span> DEPRECATED: Update an existing alert rule. (_RoutePutAlertRule_)
 
 ```
 PUT /api/v1/provisioning/alert-rules/:uid

--- a/pkg/services/ngalert/api/tooling/api.json
+++ b/pkg/services/ngalert/api/tooling/api.json
@@ -5013,9 +5013,10 @@
       }
      }
     },
-    "summary": "Create a new alert rule.",
+    "summary": "DEPRECATED: Create a new alert rule.",
     "tags": [
-     "provisioning"
+     "provisioning",
+     "deprecated"
     ]
    }
   },
@@ -5110,9 +5111,10 @@
       "description": " The alert rule was deleted successfully."
      }
     },
-    "summary": "Delete a specific alert rule by UID.",
+    "summary": "DEPRECATED: Delete a specific alert rule by UID.",
     "tags": [
-     "provisioning"
+     "provisioning",
+     "deprecated"
     ]
    },
    "get": {
@@ -5137,9 +5139,10 @@
       "description": " Not found."
      }
     },
-    "summary": "Get a specific alert rule by UID.",
+    "summary": "DEPRECATED: Get a specific alert rule by UID.",
     "tags": [
-     "provisioning"
+     "provisioning",
+     "deprecated"
     ]
    },
    "put": {
@@ -5182,9 +5185,10 @@
       }
      }
     },
-    "summary": "Update an existing alert rule.",
+    "summary": "DEPRECATED: Update an existing alert rule.",
     "tags": [
-     "provisioning"
+     "provisioning",
+     "deprecated"
     ]
    }
   },
@@ -5237,9 +5241,10 @@
       "description": " Not found."
      }
     },
-    "summary": "Export an alert rule in provisioning file format.",
+    "summary": "DEPRECATED: Export an alert rule in provisioning file format.",
     "tags": [
-     "provisioning"
+     "provisioning",
+     "deprecated"
     ]
    }
   },

--- a/pkg/services/ngalert/api/tooling/definitions/provisioning_alert_rules.go
+++ b/pkg/services/ngalert/api/tooling/definitions/provisioning_alert_rules.go
@@ -28,17 +28,17 @@ import (
 //       200: AlertingFileExport
 //       404: description: Not found.
 
-// swagger:route GET /v1/provisioning/alert-rules/{UID} provisioning stable RouteGetAlertRule
+// swagger:route GET /v1/provisioning/alert-rules/{UID} provisioning stable deprecated RouteGetAlertRule
 //
-// Get a specific alert rule by UID.
+// DEPRECATED: Get a specific alert rule by UID.
 //
 //     Responses:
 //       200: ProvisionedAlertRule
 //       404: description: Not found.
 
-// swagger:route GET /v1/provisioning/alert-rules/{UID}/export provisioning stable RouteGetAlertRuleExport
+// swagger:route GET /v1/provisioning/alert-rules/{UID}/export provisioning stable deprecated RouteGetAlertRuleExport
 //
-// Export an alert rule in provisioning file format.
+// DEPRECATED: Export an alert rule in provisioning file format.
 //
 //     Produces:
 //     - application/json
@@ -51,9 +51,9 @@ import (
 //       200: AlertingFileExport
 //       404: description: Not found.
 
-// swagger:route POST /v1/provisioning/alert-rules provisioning stable RoutePostAlertRule
+// swagger:route POST /v1/provisioning/alert-rules provisioning stable deprecated RoutePostAlertRule
 //
-// Create a new alert rule.
+// DEPRECATED: Create a new alert rule.
 //
 //     Consumes:
 //     - application/json
@@ -62,9 +62,9 @@ import (
 //       201: ProvisionedAlertRule
 //       400: ValidationError
 
-// swagger:route PUT /v1/provisioning/alert-rules/{UID} provisioning stable RoutePutAlertRule
+// swagger:route PUT /v1/provisioning/alert-rules/{UID} provisioning stable deprecated RoutePutAlertRule
 //
-// Update an existing alert rule.
+// DEPRECATED: Update an existing alert rule.
 //
 //     Consumes:
 //     - application/json
@@ -73,9 +73,9 @@ import (
 //       200: ProvisionedAlertRule
 //       400: ValidationError
 
-// swagger:route DELETE /v1/provisioning/alert-rules/{UID} provisioning stable RouteDeleteAlertRule
+// swagger:route DELETE /v1/provisioning/alert-rules/{UID} provisioning stable deprecated RouteDeleteAlertRule
 //
-// Delete a specific alert rule by UID.
+// DEPRECATED: Delete a specific alert rule by UID.
 //
 //     Responses:
 //       204: description: The alert rule was deleted successfully.

--- a/pkg/services/ngalert/api/tooling/spec.json
+++ b/pkg/services/ngalert/api/tooling/spec.json
@@ -2190,9 +2190,10 @@
         ],
         "tags": [
           "provisioning",
-          "stable"
+          "stable",
+          "deprecated"
         ],
-        "summary": "Create a new alert rule.",
+        "summary": "DEPRECATED: Create a new alert rule.",
         "operationId": "RoutePostAlertRule",
         "parameters": [
           {
@@ -2298,9 +2299,10 @@
       "get": {
         "tags": [
           "provisioning",
-          "stable"
+          "stable",
+          "deprecated"
         ],
-        "summary": "Get a specific alert rule by UID.",
+        "summary": "DEPRECATED: Get a specific alert rule by UID.",
         "operationId": "RouteGetAlertRule",
         "parameters": [
           {
@@ -2329,9 +2331,10 @@
         ],
         "tags": [
           "provisioning",
-          "stable"
+          "stable",
+          "deprecated"
         ],
-        "summary": "Update an existing alert rule.",
+        "summary": "DEPRECATED: Update an existing alert rule.",
         "operationId": "RoutePutAlertRule",
         "parameters": [
           {
@@ -2372,9 +2375,10 @@
       "delete": {
         "tags": [
           "provisioning",
-          "stable"
+          "stable",
+          "deprecated"
         ],
-        "summary": "Delete a specific alert rule by UID.",
+        "summary": "DEPRECATED: Delete a specific alert rule by UID.",
         "operationId": "RouteDeleteAlertRule",
         "parameters": [
           {
@@ -2408,9 +2412,10 @@
         ],
         "tags": [
           "provisioning",
-          "stable"
+          "stable",
+          "deprecated"
         ],
-        "summary": "Export an alert rule in provisioning file format.",
+        "summary": "DEPRECATED: Export an alert rule in provisioning file format.",
         "operationId": "RouteGetAlertRuleExport",
         "parameters": [
           {

--- a/public/api-merged.json
+++ b/public/api-merged.json
@@ -9702,9 +9702,10 @@
           "application/json"
         ],
         "tags": [
-          "provisioning"
+          "provisioning",
+          "deprecated"
         ],
-        "summary": "Create a new alert rule.",
+        "summary": "DEPRECATED: Create a new alert rule.",
         "operationId": "RoutePostAlertRule",
         "parameters": [
           {
@@ -9808,9 +9809,10 @@
     "/v1/provisioning/alert-rules/{UID}": {
       "get": {
         "tags": [
-          "provisioning"
+          "provisioning",
+          "deprecated"
         ],
-        "summary": "Get a specific alert rule by UID.",
+        "summary": "DEPRECATED: Get a specific alert rule by UID.",
         "operationId": "RouteGetAlertRule",
         "parameters": [
           {
@@ -9838,9 +9840,10 @@
           "application/json"
         ],
         "tags": [
-          "provisioning"
+          "provisioning",
+          "deprecated"
         ],
-        "summary": "Update an existing alert rule.",
+        "summary": "DEPRECATED: Update an existing alert rule.",
         "operationId": "RoutePutAlertRule",
         "parameters": [
           {
@@ -9880,9 +9883,10 @@
       },
       "delete": {
         "tags": [
-          "provisioning"
+          "provisioning",
+          "deprecated"
         ],
-        "summary": "Delete a specific alert rule by UID.",
+        "summary": "DEPRECATED: Delete a specific alert rule by UID.",
         "operationId": "RouteDeleteAlertRule",
         "parameters": [
           {
@@ -9915,9 +9919,10 @@
           "text/hcl"
         ],
         "tags": [
-          "provisioning"
+          "provisioning",
+          "deprecated"
         ],
-        "summary": "Export an alert rule in provisioning file format.",
+        "summary": "DEPRECATED: Export an alert rule in provisioning file format.",
         "operationId": "RouteGetAlertRuleExport",
         "parameters": [
           {

--- a/public/openapi3.json
+++ b/public/openapi3.json
@@ -22616,9 +22616,10 @@
             "description": "ValidationError"
           }
         },
-        "summary": "Create a new alert rule.",
+        "summary": "DEPRECATED: Create a new alert rule.",
         "tags": [
-          "provisioning"
+          "provisioning",
+          "deprecated"
         ]
       }
     },
@@ -22744,9 +22745,10 @@
             "description": " The alert rule was deleted successfully."
           }
         },
-        "summary": "Delete a specific alert rule by UID.",
+        "summary": "DEPRECATED: Delete a specific alert rule by UID.",
         "tags": [
-          "provisioning"
+          "provisioning",
+          "deprecated"
         ]
       },
       "get": {
@@ -22777,9 +22779,10 @@
             "description": " Not found."
           }
         },
-        "summary": "Get a specific alert rule by UID.",
+        "summary": "DEPRECATED: Get a specific alert rule by UID.",
         "tags": [
-          "provisioning"
+          "provisioning",
+          "deprecated"
         ]
       },
       "put": {
@@ -22834,9 +22837,10 @@
             "description": "ValidationError"
           }
         },
-        "summary": "Update an existing alert rule.",
+        "summary": "DEPRECATED: Update an existing alert rule.",
         "tags": [
-          "provisioning"
+          "provisioning",
+          "deprecated"
         ]
       }
     },
@@ -22912,9 +22916,10 @@
             "description": " Not found."
           }
         },
-        "summary": "Export an alert rule in provisioning file format.",
+        "summary": "DEPRECATED: Export an alert rule in provisioning file format.",
         "tags": [
-          "provisioning"
+          "provisioning",
+          "deprecated"
         ]
       }
     },


### PR DESCRIPTION
**What is this feature?**

This PR marks all single rule endpoints as deprecated, in anticipation of shifting to groups as the working unit in the alerting API.

**Who is this feature for?**

Users of alerting API

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle.
- [x] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
