### PR TITLE
Canvas: Address connection vertex bug

### DIFF
--- a/public/app/plugins/panel/canvas/components/connections/Connections.tsx
+++ b/public/app/plugins/panel/canvas/components/connections/Connections.tsx
@@ -392,7 +392,7 @@ export class Connections {
       const vertexIndex = this.selectedVertexIndex;
 
       if (connectionIndex !== undefined && vertexIndex !== undefined) {
-        const currentSource = this.scene.connections.state[connectionIndex].source;
+        const currentSource = this.selection.value!.source;
         if (currentSource.options.connections) {
           const currentConnections = [...currentSource.options.connections];
           if (currentConnections[connectionIndex].vertices) {
@@ -521,7 +521,7 @@ export class Connections {
       const vertexIndex = this.selectedVertexIndex;
 
       if (connectionIndex !== undefined && vertexIndex !== undefined) {
-        const currentSource = this.scene.connections.state[connectionIndex].source;
+        const currentSource = this.selection.value!.source;
         if (currentSource.options.connections) {
           const currentConnections = [...currentSource.options.connections];
           const newVertex = { x: (x - x1) / (x2 - x1), y: (y - y1) / (y2 - y1) };


### PR DESCRIPTION
Before



https://github.com/grafana/grafana/assets/22381771/5b8344e2-d56e-4f7b-ab8b-6c241a389794



After


https://github.com/grafana/grafana/assets/22381771/b04bd1de-7ab1-4f6b-b0cc-474bce0bf64d



Fixes #84606
Fixes #84403