### PR TITLE
Fix InteractiveTable: React, less hooks rendered than previous render

### DIFF
--- a/packages/grafana-ui/src/components/InteractiveTable/InteractiveTable.story.tsx
+++ b/packages/grafana-ui/src/components/InteractiveTable/InteractiveTable.story.tsx
@@ -1,7 +1,10 @@
 import { Meta, StoryFn, StoryObj } from '@storybook/react';
-import React, { useCallback, useState } from 'react';
+import React, { useCallback, useMemo, useState } from 'react';
 
 import { InteractiveTable, CellProps, LinkButton } from '@grafana/ui';
+
+import { Field } from '../Forms/Field';
+import { Input } from '../Input/Input';
 
 import { FetchDataArgs, InteractiveTableHeaderTooltip } from './InteractiveTable';
 import mdx from './InteractiveTable.mdx';
@@ -125,9 +128,9 @@ const meta: Meta<typeof InteractiveTable<CarData>> = {
   argTypes: {},
 };
 
-type TableStory = StoryObj<typeof InteractiveTable<CarData>>;
+type TableStoryObj = StoryObj<typeof InteractiveTable<CarData>>;
 
-export const Basic: TableStory = {
+export const Basic: TableStoryObj = {
   args: {
     columns: [
       {
@@ -169,7 +172,7 @@ const ExpandedCell = ({ car }: CarData) => {
   return <p>{car}</p>;
 };
 
-export const WithRowExpansion: TableStory = {
+export const WithRowExpansion: TableStoryObj = {
   args: {
     renderExpandedRow: ExpandedCell,
   },
@@ -216,11 +219,33 @@ export const WithCustomCell: StoryObj<typeof InteractiveTable<WithCustomCellData
   },
 };
 
-export const WithPagination: TableStory = {
-  args: {
-    pageSize: 15,
-    data: pageableData,
-  },
+export const WithPagination: StoryFn<typeof InteractiveTable> = (args) => {
+  const [filter, setFilter] = useState('');
+
+  const data = useMemo(() => {
+    if (filter) {
+      return pageableData.filter((d) => d.firstName.toLowerCase().includes(filter.toLowerCase()));
+    }
+    return pageableData;
+  }, [filter]);
+
+  return (
+    <>
+      <Field label={'Filter data'}>
+        <Input
+          placeholder={'Filter by first name'}
+          onChange={(event) => {
+            setFilter(event.currentTarget.value);
+          }}
+        />
+      </Field>
+      <InteractiveTable {...args} data={data} />
+    </>
+  );
+};
+
+WithPagination.args = {
+  pageSize: 15,
 };
 
 const headerTooltips: Record<string, InteractiveTableHeaderTooltip> = {
@@ -238,7 +263,7 @@ const headerTooltips: Record<string, InteractiveTableHeaderTooltip> = {
     iconName: 'plus-square',
   },
 };
-export const WithHeaderTooltips: TableStory = {
+export const WithHeaderTooltips: TableStoryObj = {
   args: {
     headerTooltips,
   },

--- a/packages/grafana-ui/src/components/InteractiveTable/InteractiveTable.tsx
+++ b/packages/grafana-ui/src/components/InteractiveTable/InteractiveTable.tsx
@@ -141,6 +141,8 @@ interface BaseProps<TableData extends object> {
   headerTooltips?: Record<string, InteractiveTableHeaderTooltip>;
   /**
    * Number of rows per page. A value of zero disables pagination. Defaults to 0.
+   * A React hooks error will be thrown if pageSize goes from greater than 0 to 0 or vice versa. If enabling pagination,
+   * make sure pageSize remains a non-zero value.
    */
   pageSize?: number;
   /**
@@ -196,7 +198,7 @@ export function InteractiveTable<TableData extends object>({
   const tableHooks: Array<PluginHook<TableData>> = [useSortBy, useExpanded];
 
   const multiplePages = data.length > pageSize;
-  const paginationEnabled = pageSize > 0 && multiplePages;
+  const paginationEnabled = pageSize > 0;
 
   if (paginationEnabled) {
     tableHooks.push(usePagination);
@@ -304,7 +306,7 @@ export function InteractiveTable<TableData extends object>({
           })}
         </tbody>
       </table>
-      {paginationEnabled && (
+      {paginationEnabled && multiplePages && (
         <span>
           <Pagination
             currentPage={tableInstance.state.pageIndex + 1}


### PR DESCRIPTION
## What is this feature?

There was an error state introduced where pagination could be enabled or disabled based on data length change.

## Why do we need this feature?

If using pagination and your implementation allows for filtering of the table data. An exception would be through due to react rendering more (or less) hooks than the previous render.

## Which issue(s) does this PR fix?

- resolves: https://github.com/grafana/grafana-adaptive-metrics-app/issues/306

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
