### PR TITLE
K8s: skip invalid items in GetList when not invoked as part of SendInitialEvents

### DIFF
--- a/pkg/apiserver/storage/file/file.go
+++ b/pkg/apiserver/storage/file/file.go
@@ -496,15 +496,15 @@ func (s *Storage) GetList(ctx context.Context, key string, opts storage.ListOpti
 			return err
 		}
 
+		if err := s.validateMinimumResourceVersion(opts.ResourceVersion, currentVersion); err != nil {
+			// Below log left for debug. It's usually not an error condition
+			// klog.Infof("failed to assert minimum resource version constraint against list version")
+			continue
+		}
+
 		ok, err := opts.Predicate.Matches(obj)
 		if err == nil && ok {
 			v.Set(reflect.Append(v, reflect.ValueOf(obj).Elem()))
-
-			if err := s.validateMinimumResourceVersion(opts.ResourceVersion, currentVersion); err != nil {
-				// Below log left for debug. It's usually not an error condition
-				// klog.Infof("failed to assert minimum resource version constraint against list version")
-				continue
-			}
 		}
 	}
 


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

I merged the massive file-storage PR earlier but it still had this minor regression in GetList where filtering of items was not being applied because of the order or operations.

Moving the check up before appending to destination list helps, as also making sure that such logic only runs when GetList is not invoked as part of Watch (SendInitialEvents) flow.

Other than above, a bit of cleanup for some repeated code and some hardcoded code for tests which forgot to use the emtpy Group as an aid when deciphering keys.

**Why do we need this feature?**

A working file storage

**Who is this feature for?**

Grafana App Platform

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
