### PR TITLE
SQLStore: Cleanup migrationLocking

### DIFF
--- a/conf/sample.ini
+++ b/conf/sample.ini
@@ -161,7 +161,7 @@
 # For "mysql" and "postgres" only. Lock the database for the migrations, default is true.
 ;migration_locking = true
 
-# For "mysql" and "postgres" only if migrationLocking is set. How many seconds to wait before failing to lock the database for the migrations, default is 0.
+# For "mysql" and "postgres" only. How many seconds to wait before failing to lock the database for the migrations, default is 0.
 ;locking_attempt_timeout_sec = 0
 
 # For "sqlite" only. How many times to retry query in case of database is locked failures. Default is 0 (disabled).

--- a/docs/sources/setup-grafana/configure-grafana/_index.md
+++ b/docs/sources/setup-grafana/configure-grafana/_index.md
@@ -378,7 +378,7 @@ Set to `false` to disable database locking during the migrations. Default is tru
 
 ### locking_attempt_timeout_sec
 
-For "mysql", if the `migrationLocking` feature toggle is set, specify the time (in seconds) to wait before failing to lock the database for the migrations. Default is 0.
+For "mysql" and "postgres" only. Specify the time (in seconds) to wait before failing to lock the database for the migrations. Default is 0.
 
 ### log_queries
 

--- a/pkg/services/featuremgmt/toggles_gen.json
+++ b/pkg/services/featuremgmt/toggles_gen.json
@@ -265,7 +265,8 @@
       "metadata": {
         "name": "migrationLocking",
         "resourceVersion": "1711130211436",
-        "creationTimestamp": "2024-03-22T17:56:51Z"
+        "creationTimestamp": "2024-03-22T17:56:51Z",
+        "deletionTimestamp": "2024-03-25T05:44:42Z"
       },
       "spec": {
         "description": "Lock database during migrations",


### PR DESCRIPTION
The `migrationLocking` feature toggle was removed in https://github.com/grafana/grafana/pull/84983 -- this cleans up some of the docs so we no-longer reference it.