### PR TITLE
SigningKeys: Add added_at when creating new signing key

### DIFF
--- a/pkg/services/signingkeys/signingkeysimpl/service.go
+++ b/pkg/services/signingkeys/signingkeysimpl/service.go
@@ -177,12 +177,14 @@ func (s *Service) addPrivateKey(ctx context.Context, keyID string, alg jose.Sign
 		return nil, err
 	}
 
-	expiry := time.Now().Add(30 * 24 * time.Hour)
+	now := time.Now()
+	expiry := now.Add(30 * 24 * time.Hour)
 	key, err := s.store.Add(ctx, &signingkeys.SigningKey{
 		KeyID:      keyID,
 		PrivateKey: encoded,
 		ExpiresAt:  &expiry,
 		Alg:        alg,
+		AddedAt:    now,
 	}, force)
 
 	if err != nil && !errors.Is(err, signingkeys.ErrSigningKeyAlreadyExists) {


### PR DESCRIPTION
**What is this feature?**
Add missing field when creating new signing key. Without the field this operation always fails with mysql as database

**Which issue(s) does this PR fix?**:

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
