### PR TITLE
Tooltip: Add value calculation option for multi tooltip in time series panel

### DIFF
--- a/packages/grafana-schema/src/common/common.gen.ts
+++ b/packages/grafana-schema/src/common/common.gen.ts
@@ -666,11 +666,16 @@ export enum BarGaugeSizing {
  * TODO docs
  */
 export interface VizTooltipOptions {
+  calcs?: Array<string>;
   maxHeight?: number;
   maxWidth?: number;
   mode: TooltipDisplayMode;
   sort: SortOrder;
 }
+
+export const defaultVizTooltipOptions: Partial<VizTooltipOptions> = {
+  calcs: [],
+};
 
 export interface Labels {}
 

--- a/packages/grafana-schema/src/common/mudball.cue
+++ b/packages/grafana-schema/src/common/mudball.cue
@@ -258,6 +258,7 @@ VizTooltipOptions: {
 	sort: SortOrder
 	maxWidth?: number
 	maxHeight?: number
+	calcs?:  [...string]
 } @cuetsy(kind="interface")
 
 Labels: {

--- a/packages/grafana-ui/src/options/builder/tooltip.tsx
+++ b/packages/grafana-ui/src/options/builder/tooltip.tsx
@@ -1,4 +1,4 @@
-import { PanelOptionsEditorBuilder, StatsPickerConfigSettings, standardEditorsRegistry } from '@grafana/data';
+import { PanelOptionsEditorBuilder, ReducerID, fieldReducers } from '@grafana/data';
 import { OptionsWithTooltip, TooltipDisplayMode, SortOrder } from '@grafana/schema';
 
 export function addTooltipOptions<T extends OptionsWithTooltip>(
@@ -81,16 +81,17 @@ export function addTooltipOptions<T extends OptionsWithTooltip>(
     });
 
   if (showTooltipCalcs) {
-    builder.addCustomEditor<StatsPickerConfigSettings, string[]>({
-      id: 'tooltip.calcs',
+    builder.addMultiSelect({
+      name: 'Values calculations',
       path: 'tooltip.calcs',
-      name: 'Values',
       category: ['Tooltip'],
-      description: 'Select values or calculations to show in tooltip',
-      editor: standardEditorsRegistry.get('stats-picker').editor,
-      defaultValue: [],
+      description: 'Select calculations to show in tooltip',
       settings: {
-        allowMultiple: true,
+        options: [
+          { value: ReducerID.sum, label: fieldReducers.get(ReducerID.sum).name },
+          { value: ReducerID.mean, label: fieldReducers.get(ReducerID.mean).name },
+          { value: ReducerID.count, label: fieldReducers.get(ReducerID.count).name },
+        ],
       },
       showIf: (options: T) => options.tooltip?.mode === TooltipDisplayMode.Multi,
     });

--- a/packages/grafana-ui/src/options/builder/tooltip.tsx
+++ b/packages/grafana-ui/src/options/builder/tooltip.tsx
@@ -5,8 +5,7 @@ export function addTooltipOptions<T extends OptionsWithTooltip>(
   builder: PanelOptionsEditorBuilder<T>,
   singleOnly = false,
   setProximity = false,
-  defaultOptions?: Partial<OptionsWithTooltip>,
-  showTooltipCalcs = false
+  defaultOptions?: Partial<OptionsWithTooltip>
 ) {
   const category = ['Tooltip'];
   const modeOptions = singleOnly

--- a/packages/grafana-ui/src/options/builder/tooltip.tsx
+++ b/packages/grafana-ui/src/options/builder/tooltip.tsx
@@ -1,11 +1,12 @@
-import { PanelOptionsEditorBuilder } from '@grafana/data';
+import { PanelOptionsEditorBuilder, StatsPickerConfigSettings, standardEditorsRegistry } from '@grafana/data';
 import { OptionsWithTooltip, TooltipDisplayMode, SortOrder } from '@grafana/schema';
 
 export function addTooltipOptions<T extends OptionsWithTooltip>(
   builder: PanelOptionsEditorBuilder<T>,
   singleOnly = false,
   setProximity = false,
-  defaultOptions?: Partial<OptionsWithTooltip>
+  defaultOptions?: Partial<OptionsWithTooltip>,
+  tooltipStats = false
 ) {
   const category = ['Tooltip'];
   const modeOptions = singleOnly
@@ -78,4 +79,20 @@ export function addTooltipOptions<T extends OptionsWithTooltip>(
       },
       showIf: (options: T) => false, //options.tooltip?.mode !== TooltipDisplayMode.None,
     });
+
+  if (tooltipStats) {
+    builder.addCustomEditor<StatsPickerConfigSettings, string[]>({
+      id: 'tooltip.calcs',
+      path: 'tooltip.calcs',
+      name: 'Values',
+      category: ['Tooltip'],
+      description: 'Select values or calculations to show in tooltip',
+      editor: standardEditorsRegistry.get('stats-picker').editor,
+      defaultValue: [],
+      settings: {
+        allowMultiple: true,
+      },
+      showIf: (options: T) => options.tooltip?.mode === TooltipDisplayMode.Multi,
+    });
+  }
 }

--- a/packages/grafana-ui/src/options/builder/tooltip.tsx
+++ b/packages/grafana-ui/src/options/builder/tooltip.tsx
@@ -6,7 +6,7 @@ export function addTooltipOptions<T extends OptionsWithTooltip>(
   singleOnly = false,
   setProximity = false,
   defaultOptions?: Partial<OptionsWithTooltip>,
-  tooltipStats = false
+  showTooltipCalcs = false
 ) {
   const category = ['Tooltip'];
   const modeOptions = singleOnly
@@ -80,7 +80,7 @@ export function addTooltipOptions<T extends OptionsWithTooltip>(
       showIf: (options: T) => false, //options.tooltip?.mode !== TooltipDisplayMode.None,
     });
 
-  if (tooltipStats) {
+  if (showTooltipCalcs) {
     builder.addCustomEditor<StatsPickerConfigSettings, string[]>({
       id: 'tooltip.calcs',
       path: 'tooltip.calcs',

--- a/packages/grafana-ui/src/options/builder/tooltip.tsx
+++ b/packages/grafana-ui/src/options/builder/tooltip.tsx
@@ -1,4 +1,4 @@
-import { PanelOptionsEditorBuilder, ReducerID, fieldReducers } from '@grafana/data';
+import { PanelOptionsEditorBuilder } from '@grafana/data';
 import { OptionsWithTooltip, TooltipDisplayMode, SortOrder } from '@grafana/schema';
 
 export function addTooltipOptions<T extends OptionsWithTooltip>(
@@ -79,21 +79,4 @@ export function addTooltipOptions<T extends OptionsWithTooltip>(
       },
       showIf: (options: T) => false, //options.tooltip?.mode !== TooltipDisplayMode.None,
     });
-
-  if (showTooltipCalcs) {
-    builder.addMultiSelect({
-      name: 'Values calculations',
-      path: 'tooltip.calcs',
-      category: ['Tooltip'],
-      description: 'Select calculations to show in tooltip',
-      settings: {
-        options: [
-          { value: ReducerID.sum, label: fieldReducers.get(ReducerID.sum).name },
-          { value: ReducerID.mean, label: fieldReducers.get(ReducerID.mean).name },
-          { value: ReducerID.count, label: fieldReducers.get(ReducerID.count).name },
-        ],
-      },
-      showIf: (options: T) => options.tooltip?.mode === TooltipDisplayMode.Multi,
-    });
-  }
 }

--- a/public/app/plugins/panel/timeseries/TimeSeriesPanel.tsx
+++ b/public/app/plugins/panel/timeseries/TimeSeriesPanel.tsx
@@ -161,6 +161,7 @@ export const TimeSeriesPanel = ({
                           isPinned={isPinned}
                           annotate={enableAnnotationCreation ? annotate : undefined}
                           scrollable={isTooltipScrollable(options.tooltip)}
+                          calcs={options.tooltip.calcs}
                         />
                       );
                     }}

--- a/public/app/plugins/panel/timeseries/module.tsx
+++ b/public/app/plugins/panel/timeseries/module.tsx
@@ -12,7 +12,7 @@ export const plugin = new PanelPlugin<Options, FieldConfig>(TimeSeriesPanel)
   .setPanelChangeHandler(graphPanelChangedHandler)
   .useFieldConfig(getGraphFieldConfig(defaultGraphConfig))
   .setPanelOptions((builder) => {
-    commonOptionsBuilder.addTooltipOptions(builder, false, true);
+    commonOptionsBuilder.addTooltipOptions(builder, false, true, undefined, true);
     commonOptionsBuilder.addLegendOptions(builder);
 
     builder.addCustomEditor({

--- a/public/app/plugins/panel/timeseries/module.tsx
+++ b/public/app/plugins/panel/timeseries/module.tsx
@@ -12,7 +12,7 @@ export const plugin = new PanelPlugin<Options, FieldConfig>(TimeSeriesPanel)
   .setPanelChangeHandler(graphPanelChangedHandler)
   .useFieldConfig(getGraphFieldConfig(defaultGraphConfig))
   .setPanelOptions((builder) => {
-    commonOptionsBuilder.addTooltipOptions(builder, false, true, undefined, true);
+    commonOptionsBuilder.addTooltipOptions(builder, false, true, undefined);
     commonOptionsBuilder.addLegendOptions(builder);
 
     builder.addCustomEditor({


### PR DESCRIPTION
This PR adds value calculation option for multi tooltip in time series panel. 

<img width="758" alt="image" src="https://github.com/grafana/grafana/assets/30407135/441730a3-19f1-46bb-af35-9a57832a740f">
