### PR TITLE
Access control: Improve annotation delete performance

### DIFF
--- a/pkg/services/annotations/accesscontrol/accesscontrol.go
+++ b/pkg/services/annotations/accesscontrol/accesscontrol.go
@@ -1,7 +1,6 @@
 package accesscontrol
 
 import (
-	"bytes"
 	"context"
 
 	"github.com/grafana/grafana/pkg/infra/db"
@@ -88,8 +87,7 @@ func (authz *AuthService) getAnnotationDashboard(ctx context.Context, query *ann
 	var items []annotations.Item
 	params := make([]any, 0)
 	err := authz.db.WithDbSession(ctx, func(sess *db.Session) error {
-		var sql bytes.Buffer
-		sql.WriteString(`
+		sql := `
 			SELECT
 				a.id,
 				a.org_id,
@@ -97,10 +95,10 @@ func (authz *AuthService) getAnnotationDashboard(ctx context.Context, query *ann
 			FROM annotation as a
 			INNER JOIN dashboard as d ON a.dashboard_id = d.id
 			WHERE a.org_id = ? AND a.id = ?
-			`)
+			`
 		params = append(params, orgID, query.AnnotationID)
 
-		return sess.SQL(sql.String(), params...).Find(&items)
+		return sess.SQL(sql, params...).Find(&items)
 	})
 	if err != nil {
 		return nil, err

--- a/pkg/services/annotations/accesscontrol/accesscontrol.go
+++ b/pkg/services/annotations/accesscontrol/accesscontrol.go
@@ -88,9 +88,8 @@ func (authz *AuthService) getAnnotationDashboard(ctx context.Context, query *ann
 			SELECT
 				a.id,
 				a.org_id,
-				d.id as dashboard_id
+				a.dashboard_id
 			FROM annotation as a
-			INNER JOIN dashboard as d ON a.dashboard_id = d.id
 			WHERE a.org_id = ? AND a.id = ?
 			`
 		params = append(params, orgID, query.AnnotationID)


### PR DESCRIPTION
**What is this feature?**

This PR improves performance of annotation delete endpoint. 

**Why do we need this feature?**

When number of dashboards available to user is significant, there's a performance degradation. We simply use dashboard IDs/UIDs as a filter for access control query. This is inefficient in case of one annotation since it's only linked to one dashboard. So reducing filter to specific dashboard fixes a problem.

**Who is this feature for?**

[Add information on what kind of user the feature is for.]

**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/identity-access-team/issues/606

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
