### PR TITLE
Dashboards: Fix issue where long ad-hoc values broke UI

### DIFF
--- a/public/app/features/variables/adhoc/picker/AdHocFilterValue.tsx
+++ b/public/app/features/variables/adhoc/picker/AdHocFilterValue.tsx
@@ -1,7 +1,8 @@
+import { css } from '@emotion/css';
 import React from 'react';
 
 import { AdHocVariableFilter, DataSourceRef, MetricFindValue, SelectableValue } from '@grafana/data';
-import { SegmentAsync } from '@grafana/ui';
+import { SegmentAsync, useStyles2 } from '@grafana/ui';
 import { getTimeSrv } from 'app/features/dashboard/services/TimeSrv';
 
 import { getDatasourceSrv } from '../../../plugins/datasource_srv';
@@ -25,12 +26,13 @@ export const AdHocFilterValue = ({
   placeHolder,
   allFilters,
 }: Props) => {
+  const styles = useStyles2(getStyles);
   const loadValues = () => fetchFilterValues(datasource, filterKey, allFilters);
 
   return (
     <div className="gf-form" data-testid="AdHocFilterValue-value-wrapper">
       <SegmentAsync
-        className="query-segment-value"
+        className={styles.segment}
         disabled={disabled}
         placeholder={placeHolder}
         value={filterValue}
@@ -58,3 +60,15 @@ const fetchFilterValues = async (
   const metrics = await ds.getTagValues({ key, filters: otherFilters, timeRange });
   return metrics.map((m: MetricFindValue) => ({ label: m.text, value: m.text }));
 };
+
+function getStyles() {
+  return {
+    segment: css({
+      display: 'block',
+      overflow: 'hidden',
+      textOverflow: 'ellipsis',
+      whiteSpace: 'nowrap',
+      maxWidth: '500px',
+    }),
+  };
+}


### PR DESCRIPTION
Before:

<img width="1367" alt="image" src="https://github.com/grafana/grafana/assets/45561153/e8b8ae0a-3338-4b72-bab6-839b00a6d1a8">

After:

<img width="772" alt="image" src="https://github.com/grafana/grafana/assets/45561153/5faa93be-7e31-46aa-b002-691c396b8484">


Closes #69285

