### PR TITLE
Chore: Define promlib depguard rules

### DIFF
--- a/.golangci.toml
+++ b/.golangci.toml
@@ -67,6 +67,19 @@ files = [
   "**/pkg/tsdb/cloudwatch/**/*",
 ]
 
+[linters-settings.depguard.rules.promlib]
+list-mode = "lax"
+deny = [
+  { pkg = "github.com/grafana/grafana/pkg", desc = "promlib is not allowed to import grafana core" }
+]
+allow = [
+  "github.com/grafana/grafana/pkg/promlib"
+]
+files = [
+  "**/pkg/promlib/*",
+  "**/pkg/promlib/**/*"
+]
+
 [linters-settings.gocritic]
 enabled-checks = ["ruleguard"]
 [linters-settings.gocritic.settings.ruleguard]

--- a/.golangci.toml
+++ b/.golangci.toml
@@ -68,7 +68,7 @@ files = [
 ]
 
 [linters-settings.depguard.rules.promlib]
-list-mode = "lax"
+list-mode = "lax" # allow unless explicitely denied
 deny = [
   { pkg = "github.com/grafana/grafana/pkg", desc = "promlib is not allowed to import grafana core" }
 ]

--- a/pkg/promlib/healthcheck_test.go
+++ b/pkg/promlib/healthcheck_test.go
@@ -36,7 +36,7 @@ func (rt *healthCheckSuccessRoundTripper) RoundTrip(req *http.Request) (*http.Re
 				"resultType": "scalar",
 				"result": [
 					1692969348.331,
-					"2"
+					"3"
 				]
 			}
 		}`)),

--- a/pkg/promlib/models/query.go
+++ b/pkg/promlib/models/query.go
@@ -11,6 +11,7 @@ import (
 	"github.com/grafana/grafana-plugin-sdk-go/backend/gtime"
 	"github.com/prometheus/prometheus/model/labels"
 
+	"github.com/grafana/grafana/pkg/apis/scope/v0alpha1"
 	"github.com/grafana/grafana/pkg/promlib/intervalv2"
 )
 
@@ -153,7 +154,7 @@ type Query struct {
 	RangeQuery    bool
 	ExemplarQuery bool
 	UtcOffsetSec  int64
-	Scope         *ScopeSpec
+	Scope         *v0alpha1.ScopeSpec
 }
 
 type Scope struct {

--- a/pkg/promlib/models/query.go
+++ b/pkg/promlib/models/query.go
@@ -11,7 +11,6 @@ import (
 	"github.com/grafana/grafana-plugin-sdk-go/backend/gtime"
 	"github.com/prometheus/prometheus/model/labels"
 
-	"github.com/grafana/grafana/pkg/apis/scope/v0alpha1"
 	"github.com/grafana/grafana/pkg/promlib/intervalv2"
 )
 
@@ -154,7 +153,7 @@ type Query struct {
 	RangeQuery    bool
 	ExemplarQuery bool
 	UtcOffsetSec  int64
-	Scope         *v0alpha1.ScopeSpec
+	Scope         *ScopeSpec
 }
 
 type Scope struct {


### PR DESCRIPTION
**What is this feature?**

Define rules to prevent accidental `grafana/grafana` imports in promlib.
https://github.com/OpenPeeDeeP/depguard?tab=readme-ov-file#golangci-lint

After creating [a commit](https://github.com/grafana/grafana/pull/85082/commits/9f0538859744bec798e531e4de02140d3f13c151) that has a code against rules the linter gives us the error, [see here](https://drone.grafana.net/grafana/grafana/169001/4/6).

Successful pipeline: https://drone.grafana.net/grafana/grafana/169004/4/6 

**Who is this feature for?**

promlib developers

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
