### PR TITLE
Update ephemeral instances workflow to get version from package.json

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -686,8 +686,8 @@ embed.go @grafana/grafana-as-code
 /.github/workflows/publish-kinds-release.yml @grafana/platform-cat
 /.github/workflows/verify-kinds.yml @grafana/platform-cat
 /.github/workflows/dashboards-issue-add-label.yml @grafana/dashboards-squad
-/.github/workflows/ephemeral-instances-pr-comment.yml @grafana/grafana-operator-experience-squad
-/.github/workflows/ephemeral-instances-pr-opened-closed.yml @grafana/grafana-operator-experience-squad
+/.github/workflows/ephemeral-instances-pr-comment.yml @grafana/grafana-backend-services-squad
+/.github/workflows/ephemeral-instances-pr-opened-closed.yml @grafana/grafana-backend-services-squad
 /.github/workflows/create-security-patch-from-security-mirror.yml @grafana/grafana-release-guild
 /.github/workflows/core-plugins-build-and-release.yml @grafana/plugins-platform-frontend @grafana/plugins-platform-backend
 /.github/workflows/i18n-crowdin-upload.yml @grafana/grafana-frontend-platform

--- a/.github/workflows/ephemeral-instances-pr-comment.yml
+++ b/.github/workflows/ephemeral-instances-pr-comment.yml
@@ -2,7 +2,6 @@ name: 'Ephemeral instances: PR comment'
 on:
   issue_comment:
     types: [created]
-  push:
 jobs:
   config:
     runs-on: "ubuntu-latest"
@@ -26,10 +25,10 @@ jobs:
 
   handle-pull-request-event:
     needs: config
-    # if: needs.config.outputs.has-secrets &&
-    #     github.event.sender.type == 'User' &&
-    #     github.event.issue.pull_request &&
-    #     startsWith(github.event.comment.body, '/deploy-to-hg')
+    if: needs.config.outputs.has-secrets &&
+        github.event.sender.type == 'User' &&
+        github.event.issue.pull_request &&
+        startsWith(github.event.comment.body, '/deploy-to-hg')
     runs-on:
       labels: ubuntu-latest-8-cores
     continue-on-error: true

--- a/.github/workflows/ephemeral-instances-pr-comment.yml
+++ b/.github/workflows/ephemeral-instances-pr-comment.yml
@@ -2,6 +2,7 @@ name: 'Ephemeral instances: PR comment'
 on:
   issue_comment:
     types: [created]
+  push:
 jobs:
   config:
     runs-on: "ubuntu-latest"
@@ -25,10 +26,10 @@ jobs:
 
   handle-pull-request-event:
     needs: config
-    if: needs.config.outputs.has-secrets &&
-        github.event.sender.type == 'User' &&
-        github.event.issue.pull_request &&
-        startsWith(github.event.comment.body, '/deploy-to-hg')
+    # if: needs.config.outputs.has-secrets &&
+    #     github.event.sender.type == 'User' &&
+    #     github.event.issue.pull_request &&
+    #     startsWith(github.event.comment.body, '/deploy-to-hg')
     runs-on:
       labels: ubuntu-latest-8-cores
     continue-on-error: true
@@ -52,13 +53,18 @@ jobs:
           token: ${{ steps.generate_token.outputs.token }}
           ref: main
           path: ephemeral
-
+      - name: Get latest grafana version number
+        run: |
+          # if package.json contains e.g. 11.0.0-pre, this writes 11.0.0 to version.txt
+          curl https://raw.githubusercontent.com/grafana/grafana/main/package.json | jq -r .version | grep -o  '^[0-9\.]*' > version.txt
       - name: Run action
         env:
           GITHUB_EVENT: ${{ toJson(github.event)}}
         run: |
-          GRAFANA_VERSION=10.1.0
-
+          # Create a prerelease version number using the latest version from package.json and some metadata from the github event.
+          v=$(cat version.txt)
+          export GRAFANA_VERSION="$v-ephemeral-${{ github.event.issue.number}}-${{ github.run_number }}-${{ github.run_attempt }}"
+          echo "${GRAFANA_VERSION}"
           cd $GITHUB_WORKSPACE/ephemeral/src
           go run . \
             -GITHUB_TOKEN="${{ steps.generate_token.outputs.token }}" \

--- a/.github/workflows/ephemeral-instances-pr-comment.yml
+++ b/.github/workflows/ephemeral-instances-pr-comment.yml
@@ -71,7 +71,7 @@ jobs:
             -GITHUB_TRIGGERING_ACTOR="${{ github.triggering_actor }}" \
             -GCOM_HOST="${{ secrets.EI_GCOM_HOST }}" \
             -GCOM_TOKEN="${{ secrets.EI_GCOM_TOKEN }}" \
-            -HOSTED_GRAFANA_IMAGE_TAG="$GRAFANA_VERSION-ephemeral-oss-${{ github.event.issue.number}}-${{ github.run_number }}-${{ github.run_attempt }}" \
+            -HOSTED_GRAFANA_IMAGE_TAG="$GRAFANA_VERSION" \
             -REGISTRY="${{ secrets.EI_EPHEMERAL_INSTANCES_REGISTRY }}" \
             -GRAFANA_VERSION="$GRAFANA_VERSION" \
             -GCP_SERVICE_ACCOUNT_KEY_BASE64="${{ secrets.EI_GCP_SERVICE_ACCOUNT_KEY_BASE64 }}" \


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

Update the ephemeral instances workflow to get the GRAFANA_VERSION from the grafana/grafana package.json, instead of having it hard-coded.

**Why do we need this feature?**

We want our ephemeral instances to self-report as a current version of grafana, instead of an old one. This will help avoid a situation where a large proportion of our dev instances are running an old version of grafana. In particular, this has caused a lot of confusion around the rollout of feature toggles.


**Who is this feature for?**

All Grafana Labs engineers who use ephemeral instances, and all Grafana Labs engineers who roll out feature toggles.

**Which issue(s) does this PR fix?**:

Contribues to https://github.com/grafana/hosted-grafana/issues/5323

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->



**Special notes for your reviewer:**

I ran a version of this job, skipping a few of the workflow checks, to see if the GRAFANA_VERSION looks sensible. It does ([see run](https://github.com/grafana/grafana/actions/runs/8422318752/job/23061344601#step:6:235)). (the workflow overall was expected to fail, but that does not matter here.)

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
