### PR TITLE
Chore: Add e2e selector for expression button

### DIFF
--- a/packages/grafana-e2e-selectors/src/selectors/components.ts
+++ b/packages/grafana-e2e-selectors/src/selectors/components.ts
@@ -278,6 +278,7 @@ export const Components = {
     queryInspectorButton: 'Query inspector button',
     queryHistoryButton: 'data-testid query-history-button',
     addQuery: 'data-testid query-tab-add-query',
+    addExpression: 'data-testid query-tab-add-expression',
   },
   QueryHistory: {
     queryText: 'Query text',

--- a/public/app/features/dashboard-scene/panel-edit/PanelDataPane/PanelDataQueriesTab.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelDataPane/PanelDataQueriesTab.tsx
@@ -216,7 +216,7 @@ function PanelDataQueriesTabRendered({ model }: SceneComponentProps<PanelDataQue
             icon="plus"
             onClick={model.onAddExpressionClick}
             variant="secondary"
-            data-testid="query-tab-add-expression"
+            data-testid={selectors.components.QueryTab.addExpression}
           >
             <span>Expression&nbsp;</span>
           </Button>

--- a/public/app/features/query/components/QueryGroup.test.tsx
+++ b/public/app/features/query/components/QueryGroup.test.tsx
@@ -2,6 +2,7 @@ import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import React from 'react';
 
+import { selectors } from '@grafana/e2e-selectors';
 import config from 'app/core/config';
 import { mockDataSource } from 'app/features/alerting/unified/mocks';
 import { DataSourceType } from 'app/features/alerting/unified/utils/datasource';
@@ -48,7 +49,7 @@ describe('QueryGroup', () => {
   it('Should add expression on click', async () => {
     renderScenario({});
 
-    const addExpressionButton = await screen.findByTestId('query-tab-add-expression');
+    const addExpressionButton = await screen.findByTestId('data-testid query-tab-add-expression');
     const queryRowsContainer = await screen.findByTestId('query-editor-rows');
     expect(queryRowsContainer.children.length).toBe(2);
 
@@ -75,7 +76,7 @@ describe('QueryGroup', () => {
   it('New expression should be expanded', async () => {
     renderScenario({});
 
-    const addExpressionButton = await screen.findByTestId('query-tab-add-expression');
+    const addExpressionButton = await screen.findByTestId(selectors.components.QueryTab.addExpression);
     const queryRowsContainer = await screen.findByTestId('query-editor-rows');
     await userEvent.click(addExpressionButton);
 

--- a/public/app/features/query/components/QueryGroup.tsx
+++ b/public/app/features/query/components/QueryGroup.tsx
@@ -304,7 +304,7 @@ export class QueryGroup extends PureComponent<Props, State> {
             onClick={this.onAddExpressionClick}
             variant="secondary"
             className={styles.expressionButton}
-            data-testid="query-tab-add-expression"
+            data-testid={selectors.components.QueryTab.addExpression}
           >
             <span>Expression&nbsp;</span>
           </Button>


### PR DESCRIPTION
**What is this feature?**

Moves selector for the expressions button to the grafana/e2e-selector package. 

**Why do we need this feature?**

Need a consistent way to interact with the the expression button in an e2e test.

**Who is this feature for?**

Developers

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
