### PR TITLE
AuthProxy: Fix missing session for ldap auth proxy users

### DIFF
--- a/pkg/api/login.go
+++ b/pkg/api/login.go
@@ -126,9 +126,10 @@ func (hs *HTTPServer) LoginView(c *contextmodel.ReqContext) {
 
 	if c.IsSignedIn {
 		// Assign login token to auth proxy users if enable_login_token = true
+		// LDAP users authenticated by auth proxy are also assigned login token but their auth module is LDAP
 		if hs.Cfg.AuthProxy.Enabled &&
 			hs.Cfg.AuthProxy.EnableLoginToken &&
-			c.SignedInUser.AuthenticatedBy == loginservice.AuthProxyAuthModule {
+			(c.SignedInUser.AuthenticatedBy == loginservice.AuthProxyAuthModule || c.SignedInUser.AuthenticatedBy == loginservice.LDAPAuthModule) {
 			user := &user.User{ID: c.SignedInUser.UserID, Email: c.SignedInUser.Email, Login: c.SignedInUser.Login}
 			err := hs.loginUserWithUser(user, c)
 			if err != nil {


### PR DESCRIPTION
**What is this feature?**

Regression: LDAP users authenticated via auth proxy did not have sessions assigned when enable_login_token was enabled. 

This happened due to a mismatch between auth module checked (auth_proxy) and provided (ldap). 

This mismatch in provided auth modules was introduced in https://github.com/grafana/grafana/pull/83715 as the active sync feature depends on the user's auth module being ldap
