### PR TITLE
Table Panel: Fix issue causing incorrect background coloring

### DIFF
--- a/packages/grafana-data/src/themes/createVisualizationColors.ts
+++ b/packages/grafana-data/src/themes/createVisualizationColors.ts
@@ -52,7 +52,7 @@ export function createVisualizationColors(colors: ThemeColors): ThemeVisualizati
   }
 
   // special colors
-  byNameIndex['transparent'] = 'rgba(0,0,0,0)';
+  byNameIndex['transparent'] = colors.mode === 'light' ? 'rgba(255, 255, 255, 0)' : 'rgba(0,0,0,0)';
   byNameIndex['panel-bg'] = colors.background.primary;
   byNameIndex['text'] = colors.text.primary;
 

--- a/packages/grafana-ui/src/components/Table/utils.ts
+++ b/packages/grafana-ui/src/components/Table/utils.ts
@@ -617,7 +617,7 @@ export function getCellColors(
 
     if (mode === TableCellBackgroundDisplayMode.Basic) {
       textColor = getTextColorForAlphaBackground(displayValue.color!, tableStyles.theme.isDark);
-      bgColor = tinycolor(displayValue.color).setAlpha(1).toRgbString();
+      bgColor = tinycolor(displayValue.color).setAlpha(0.9).toRgbString();
     } else if (mode === TableCellBackgroundDisplayMode.Gradient) {
       const bgColor2 = tinycolor(displayValue.color)
         .darken(10 * darkeningFactor)


### PR DESCRIPTION
This fixes an issue in which table background cells would be colored dark even in light mode. This issue is coming from the use of transparent black as a transparent color which then later has opacity removed. This PR uses transparent white when in light mode and transparent black when in dark mode.

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
