### PR TITLE
SSE: Group data source node execution by data source and time range

### DIFF
--- a/pkg/expr/nodes.go
+++ b/pkg/expr/nodes.go
@@ -254,10 +254,13 @@ func executeDSNodesGrouped(ctx context.Context, now time.Time, vars mathexp.Vars
 		uid   string // in theory I think this all I need for the key, but rather be safe
 		id    int64
 		orgID int64
+		to    int64
+		from  int64
 	}
 	byDS := make(map[dsKey][]*DSNode)
 	for _, node := range nodes {
-		k := dsKey{id: node.datasource.ID, uid: node.datasource.UID, orgID: node.orgID}
+		timeRange := node.timeRange.AbsoluteTime(now)
+		k := dsKey{id: node.datasource.ID, uid: node.datasource.UID, orgID: node.orgID, to: timeRange.To.Unix(), from: timeRange.From.Unix()}
 		byDS[k] = append(byDS[k], node)
 	}
 


### PR DESCRIPTION
This is related to this support escalation https://github.com/grafana/support-escalations/issues/9553 and the conversation in [slack](https://raintank-corp.slack.com/archives/C01LJ5F8NRX/p1709309630665769) about it, but basically when the `sseByDatasource` toggle was enabled it caused issues with some alerts due to the fact that the ElasticSearch datasource didn't support running a query where the different sub-queries had different ranges. This was fixed in Elastic, but we're likely to have this issue with other datasources if we just toggle it on. (From a quick check in core grafana, the Cloud Monitoring, CloudWatch, and Influx datasource plugins all make the assumption that the query range of the first query applies to all of them). While the datasource plugins arguably shouldn't do this, many of them do, so this is a solution that fixes it in one spot in the batching instead of having all the plugins be updated and possibly missing one.

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
