### PR TITLE
datatrails: fix stability issues between conflict between browser history, URL sync, and trail history

### DIFF
--- a/public/app/features/trails/ActionTabs/MetricOverviewScene.tsx
+++ b/public/app/features/trails/ActionTabs/MetricOverviewScene.tsx
@@ -97,6 +97,7 @@ export class MetricOverviewScene extends SceneObjectBase<MetricOverviewSceneStat
                 {
                   // Using a memory router allows us to use TextLinks in embedded mode where there might not be a wrapping Router
                   // Avoids "Invariant failed: You should not use <Link> outside a <Router>"
+                  // TODO: Should be removed after https://github.com/grafana/grafana/pull/84916 is merged
                 }
                 {labelOptions.map((l) => (
                   <TextLink

--- a/public/app/features/trails/ActionTabs/MetricOverviewScene.tsx
+++ b/public/app/features/trails/ActionTabs/MetricOverviewScene.tsx
@@ -94,7 +94,6 @@ export class MetricOverviewScene extends SceneObjectBase<MetricOverviewSceneStat
               {labelOptions.length === 0 && 'Unable to fetch labels.'}
               {labelOptions.map((l) => (
                 <TextLink
-                  icon="tag-alt"
                   key={l.label}
                   href={`#View breakdown for ${l.label}`}
                   title={`View breakdown for ${l.label}`}

--- a/public/app/features/trails/ActionTabs/MetricOverviewScene.tsx
+++ b/public/app/features/trails/ActionTabs/MetricOverviewScene.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 
+import { locationService } from '@grafana/runtime';
 import {
   QueryVariable,
   SceneComponentProps,
@@ -8,7 +9,7 @@ import {
   SceneObjectState,
   VariableDependencyConfig,
 } from '@grafana/scenes';
-import { Button, Stack, Text } from '@grafana/ui';
+import { Button, Stack, Text, TextLink } from '@grafana/ui';
 
 import { PromMetricsMetadataItem } from '../../../plugins/datasource/prometheus/types';
 import { ALL_VARIABLE_VALUE } from '../../variables/constants';
@@ -93,22 +94,24 @@ export class MetricOverviewScene extends SceneObjectBase<MetricOverviewSceneStat
               <Text weight={'medium'}>Labels</Text>
               {labelOptions.length === 0 && 'Unable to fetch labels.'}
               {labelOptions.map((l) => (
-                <Button
-                  size="sm"
-                  variant="secondary"
+                <TextLink
                   icon="tag-alt"
                   key={l.label}
-                  onClick={() => {
+                  href={`#View breakdown for ${l.label}`}
+                  title={`View breakdown for ${l.label}`}
+                  onClick={(event) => {
+                    event.preventDefault();
+                    event.stopPropagation();
                     sceneGraph.getAncestor(model, MetricScene).setActionView('breakdown');
                     const groupByVar = sceneGraph.lookupVariable(VAR_GROUP_BY, model);
                     if (groupByVar instanceof QueryVariable) {
                       groupByVar.setState({ value: l.value });
                     }
+                    return false;
                   }}
-                  title="View breakdown"
                 >
                   {l.label!}
-                </Button>
+                </TextLink>
               ))}
             </Stack>
           </>

--- a/public/app/features/trails/ActionTabs/MetricOverviewScene.tsx
+++ b/public/app/features/trails/ActionTabs/MetricOverviewScene.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import { MemoryRouter } from 'react-router-dom';
 
 import {
   QueryVariable,
@@ -93,32 +92,25 @@ export class MetricOverviewScene extends SceneObjectBase<MetricOverviewSceneStat
             <Stack direction="column" gap={0.5}>
               <Text weight={'medium'}>Labels</Text>
               {labelOptions.length === 0 && 'Unable to fetch labels.'}
-              <MemoryRouter>
-                {
-                  // Using a memory router allows us to use TextLinks in embedded mode where there might not be a wrapping Router
-                  // Avoids "Invariant failed: You should not use <Link> outside a <Router>"
-                  // TODO: Should be removed after https://github.com/grafana/grafana/pull/84916 is merged
-                }
-                {labelOptions.map((l) => (
-                  <TextLink
-                    key={l.label}
-                    href={`#View breakdown for ${l.label}`}
-                    title={`View breakdown for ${l.label}`}
-                    onClick={(event) => {
-                      event.preventDefault();
-                      event.stopPropagation();
-                      sceneGraph.getAncestor(model, MetricScene).setActionView('breakdown');
-                      const groupByVar = sceneGraph.lookupVariable(VAR_GROUP_BY, model);
-                      if (groupByVar instanceof QueryVariable) {
-                        groupByVar.setState({ value: l.value });
-                      }
-                      return false;
-                    }}
-                  >
-                    {l.label!}
-                  </TextLink>
-                ))}
-              </MemoryRouter>
+              {labelOptions.map((l) => (
+                <TextLink
+                  key={l.label}
+                  href={`#View breakdown for ${l.label}`}
+                  title={`View breakdown for ${l.label}`}
+                  onClick={(event) => {
+                    event.preventDefault();
+                    event.stopPropagation();
+                    sceneGraph.getAncestor(model, MetricScene).setActionView('breakdown');
+                    const groupByVar = sceneGraph.lookupVariable(VAR_GROUP_BY, model);
+                    if (groupByVar instanceof QueryVariable) {
+                      groupByVar.setState({ value: l.value });
+                    }
+                    return false;
+                  }}
+                >
+                  {l.label!}
+                </TextLink>
+              ))}
             </Stack>
           </>
         </Stack>

--- a/public/app/features/trails/ActionTabs/MetricOverviewScene.tsx
+++ b/public/app/features/trails/ActionTabs/MetricOverviewScene.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 
-import { locationService } from '@grafana/runtime';
 import {
   QueryVariable,
   SceneComponentProps,
@@ -9,7 +8,7 @@ import {
   SceneObjectState,
   VariableDependencyConfig,
 } from '@grafana/scenes';
-import { Button, Stack, Text, TextLink } from '@grafana/ui';
+import { Stack, Text, TextLink } from '@grafana/ui';
 
 import { PromMetricsMetadataItem } from '../../../plugins/datasource/prometheus/types';
 import { ALL_VARIABLE_VALUE } from '../../variables/constants';

--- a/public/app/features/trails/ActionTabs/MetricOverviewScene.tsx
+++ b/public/app/features/trails/ActionTabs/MetricOverviewScene.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { MemoryRouter } from 'react-router-dom';
 
 import {
   QueryVariable,
@@ -92,25 +93,31 @@ export class MetricOverviewScene extends SceneObjectBase<MetricOverviewSceneStat
             <Stack direction="column" gap={0.5}>
               <Text weight={'medium'}>Labels</Text>
               {labelOptions.length === 0 && 'Unable to fetch labels.'}
-              {labelOptions.map((l) => (
-                <TextLink
-                  key={l.label}
-                  href={`#View breakdown for ${l.label}`}
-                  title={`View breakdown for ${l.label}`}
-                  onClick={(event) => {
-                    event.preventDefault();
-                    event.stopPropagation();
-                    sceneGraph.getAncestor(model, MetricScene).setActionView('breakdown');
-                    const groupByVar = sceneGraph.lookupVariable(VAR_GROUP_BY, model);
-                    if (groupByVar instanceof QueryVariable) {
-                      groupByVar.setState({ value: l.value });
-                    }
-                    return false;
-                  }}
-                >
-                  {l.label!}
-                </TextLink>
-              ))}
+              <MemoryRouter>
+                {
+                  // Using a memory router allows us to use TextLinks in embedded mode where there might not be a wrapping Router
+                  // Avoids "Invariant failed: You should not use <Link> outside a <Router>"
+                }
+                {labelOptions.map((l) => (
+                  <TextLink
+                    key={l.label}
+                    href={`#View breakdown for ${l.label}`}
+                    title={`View breakdown for ${l.label}`}
+                    onClick={(event) => {
+                      event.preventDefault();
+                      event.stopPropagation();
+                      sceneGraph.getAncestor(model, MetricScene).setActionView('breakdown');
+                      const groupByVar = sceneGraph.lookupVariable(VAR_GROUP_BY, model);
+                      if (groupByVar instanceof QueryVariable) {
+                        groupByVar.setState({ value: l.value });
+                      }
+                      return false;
+                    }}
+                  >
+                    {l.label!}
+                  </TextLink>
+                ))}
+              </MemoryRouter>
             </Stack>
           </>
         </Stack>

--- a/public/app/features/trails/ActionTabs/MetricOverviewScene.tsx
+++ b/public/app/features/trails/ActionTabs/MetricOverviewScene.tsx
@@ -8,12 +8,13 @@ import {
   SceneObjectState,
   VariableDependencyConfig,
 } from '@grafana/scenes';
-import { Stack, Text, TextLink } from '@grafana/ui';
+import { Button, Stack, Text } from '@grafana/ui';
 
 import { PromMetricsMetadataItem } from '../../../plugins/datasource/prometheus/types';
 import { ALL_VARIABLE_VALUE } from '../../variables/constants';
+import { MetricScene } from '../MetricScene';
 import { StatusWrapper } from '../StatusWrapper';
-import { TRAILS_ROUTE, VAR_DATASOURCE_EXPR, VAR_GROUP_BY } from '../shared';
+import { VAR_DATASOURCE_EXPR, VAR_GROUP_BY } from '../shared';
 import { getMetricSceneFor, getTrailFor } from '../utils';
 
 import { getLabelOptions } from './utils';
@@ -91,26 +92,24 @@ export class MetricOverviewScene extends SceneObjectBase<MetricOverviewSceneStat
             <Stack direction="column" gap={0.5}>
               <Text weight={'medium'}>Labels</Text>
               {labelOptions.length === 0 && 'Unable to fetch labels.'}
-              {labelOptions.map((l) =>
-                getTrailFor(model).state.embedded ? (
-                  // Do not render as TextLink when in embedded mode, as any direct URL
-                  // manipulation will take the browser out out of the current page.
-                  <div key={l.label}>{l.label}</div>
-                ) : (
-                  <TextLink
-                    key={l.label}
-                    href={sceneGraph.interpolate(
-                      model,
-                      `${TRAILS_ROUTE}$\{__url.params:exclude:actionView,var-groupby}&actionView=breakdown&var-groupby=${encodeURIComponent(
-                        l.value!
-                      )}`
-                    )}
-                    title="View breakdown"
-                  >
-                    {l.label!}
-                  </TextLink>
-                )
-              )}
+              {labelOptions.map((l) => (
+                <Button
+                  size="sm"
+                  variant="secondary"
+                  icon="tag-alt"
+                  key={l.label}
+                  onClick={() => {
+                    sceneGraph.getAncestor(model, MetricScene).setActionView('breakdown');
+                    const groupByVar = sceneGraph.lookupVariable(VAR_GROUP_BY, model);
+                    if (groupByVar instanceof QueryVariable) {
+                      groupByVar.setState({ value: l.value });
+                    }
+                  }}
+                  title="View breakdown"
+                >
+                  {l.label!}
+                </Button>
+              ))}
             </Stack>
           </>
         </Stack>

--- a/public/app/features/trails/DataTrail.test.tsx
+++ b/public/app/features/trails/DataTrail.test.tsx
@@ -1,5 +1,4 @@
 import { locationService, setDataSourceSrv } from '@grafana/runtime';
-import { getUrlSyncManager } from '@grafana/scenes';
 
 import { MockDataSourceSrv, mockDataSource } from '../alerting/unified/mocks';
 import { DataSourceType } from '../alerting/unified/utils/datasource';
@@ -22,14 +21,13 @@ describe('DataTrail', () => {
     );
   });
 
-  describe('Given starting trail with url sync and no url state', () => {
+  describe('Given starting non-embedded trail with url sync and no url state', () => {
     let trail: DataTrail;
     const preTrailUrl = '/';
 
     beforeEach(() => {
       trail = new DataTrail({});
       locationService.push(preTrailUrl);
-      getUrlSyncManager().initSync(trail);
       activateFullSceneTree(trail);
     });
 

--- a/public/app/features/trails/DataTrail.test.tsx
+++ b/public/app/features/trails/DataTrail.test.tsx
@@ -24,10 +24,11 @@ describe('DataTrail', () => {
 
   describe('Given starting trail with url sync and no url state', () => {
     let trail: DataTrail;
+    const preTrailUrl = '/';
 
     beforeEach(() => {
       trail = new DataTrail({});
-      locationService.push('/');
+      locationService.push(preTrailUrl);
       getUrlSyncManager().initSync(trail);
       activateFullSceneTree(trail);
     });
@@ -73,6 +74,15 @@ describe('DataTrail', () => {
       it('Should set history step 1 parentIndex to 0', () => {
         expect(trail.state.history.state.steps[1].parentIndex).toBe(0);
       });
+
+      describe('And browser back button is pressed', () => {
+        locationService.getHistory().goBack();
+
+        it('Should return to original URL', () => {
+          const { pathname } = locationService.getLocation();
+          expect(pathname).toEqual(preTrailUrl);
+        });
+      });
     });
 
     describe('When going back to history step 1', () => {
@@ -110,6 +120,15 @@ describe('DataTrail', () => {
 
         it('Should set history step 3 parent index to 1', () => {
           expect(trail.state.history.state.steps[3].parentIndex).toBe(1);
+        });
+
+        describe('And browser back button is pressed', () => {
+          locationService.getHistory().goBack();
+
+          it('Should return to original URL', () => {
+            const { pathname } = locationService.getLocation();
+            expect(pathname).toEqual(preTrailUrl);
+          });
         });
       });
     });

--- a/public/app/features/trails/DataTrail.tsx
+++ b/public/app/features/trails/DataTrail.tsx
@@ -88,9 +88,10 @@ export class DataTrail extends SceneObjectBase<DataTrailState> {
       const newStepWasAppended = newNumberOfSteps > oldNumberOfSteps;
 
       if (newStepWasAppended) {
+        this.syncTrailToUrl();
         // In order for the `useBookmarkState` to re-evaluate after a new step was made:
         this.forceRender();
-        // Do nothing because the state is already up to date -- it created a new step!
+        // Do nothing else because the step state is already up to date -- it created a new step!
         return;
       }
 

--- a/public/app/features/trails/DataTrail.tsx
+++ b/public/app/features/trails/DataTrail.tsx
@@ -33,7 +33,6 @@ import { MetricsHeader } from './MetricsHeader';
 import { getTrailStore } from './TrailStore/TrailStore';
 import { MetricDatasourceHelper } from './helpers/MetricDatasourceHelper';
 import { MetricSelectedEvent, trailDS, VAR_DATASOURCE, VAR_FILTERS } from './shared';
-import { getUrlForTrail } from './utils';
 
 export interface DataTrailState extends SceneObjectState {
   topScene?: SceneObject;
@@ -103,12 +102,15 @@ export class DataTrail extends SceneObjectBase<DataTrailState> {
       // History changed because a different node was selected
       const step = newState.steps[newState.currentStep];
 
+      if (!step) {
+        return;
+      }
+
       this.goBackToStep(step);
     });
 
     return () => {
       if (!this.state.embedded) {
-        getUrlSyncManager().cleanUp(this);
         getTrailStore().setRecentTrail(this);
       }
     };
@@ -135,29 +137,25 @@ export class DataTrail extends SceneObjectBase<DataTrailState> {
   }
 
   private goBackToStep(step: DataTrailHistoryStep) {
-    if (!this.state.embedded) {
-      getUrlSyncManager().cleanUp(this);
-    }
-
     if (!step.trailState.metric) {
       step.trailState.metric = undefined;
     }
 
     this.setState(step.trailState);
+    this.syncTrailToUrl();
+  }
 
-    if (!this.state.embedded) {
-      locationService.replace(getUrlForTrail(this));
-
-      getUrlSyncManager().initSync(this);
+  private syncTrailToUrl() {
+    if (this.state.embedded) {
+      // Embedded trails should not be altering the URL
+      return;
     }
+    const urlState = getUrlSyncManager().getUrlState(this);
+    locationService.partial(urlState, true);
   }
 
   private _handleMetricSelectedEvent(evt: MetricSelectedEvent) {
-    if (this.state.embedded) {
-      this.setState(this.getSceneUpdatesForNewMetricValue(evt.payload));
-    } else {
-      locationService.partial({ metric: evt.payload, actionView: null });
-    }
+    this.setState(this.getSceneUpdatesForNewMetricValue(evt.payload));
 
     // Add metric to adhoc filters baseFilter
     const filterVar = sceneGraph.lookupVariable(VAR_FILTERS, this);

--- a/public/app/features/trails/DataTrail.tsx
+++ b/public/app/features/trails/DataTrail.tsx
@@ -88,6 +88,7 @@ export class DataTrail extends SceneObjectBase<DataTrailState> {
       const newStepWasAppended = newNumberOfSteps > oldNumberOfSteps;
 
       if (newStepWasAppended) {
+        // A new step is a significant change. Update the URL to match the new state.
         this.syncTrailToUrl();
         // In order for the `useBookmarkState` to re-evaluate after a new step was made:
         this.forceRender();

--- a/public/app/features/trails/DataTrailsApp.tsx
+++ b/public/app/features/trails/DataTrailsApp.tsx
@@ -11,6 +11,7 @@ import { Page } from 'app/core/components/Page/Page';
 import { DataTrail } from './DataTrail';
 import { DataTrailsHome } from './DataTrailsHome';
 import { MetricsHeader } from './MetricsHeader';
+import { getTrailStore } from './TrailStore/TrailStore';
 import { HOME_ROUTE, TRAILS_ROUTE } from './shared';
 import { getMetricName, getUrlForTrail, newMetricsTrail } from './utils';
 
@@ -76,10 +77,13 @@ function DataTrailView({ trail }: { trail: DataTrail }) {
     if (!isInitialized) {
       // Set the initial state based on the URL.
       getUrlSyncManager().initSync(trail);
-      // Any further changes to the state should occur directly to the state, not through the URL,
-      // So we want to stop listening after this point.
+      // Any further changes to the state should occur directly to the state, not through the URL.
+      // We want to stop automatically syncing the URL state (and vice versa) to the trail after this point.
+      // Moving forward in the lifecycle of the trail, we will make explicit calls to trail.syncTrailToUrl()
+      // so we can ensure the URL is kept up to date at key points.
       getUrlSyncManager().cleanUp(trail);
 
+      getTrailStore().setRecentTrail(trail);
       setIsInitialized(true);
     }
   }, [trail, isInitialized]);

--- a/public/app/features/trails/DataTrailsApp.tsx
+++ b/public/app/features/trails/DataTrailsApp.tsx
@@ -4,14 +4,13 @@ import { Route, Switch } from 'react-router-dom';
 
 import { GrafanaTheme2, PageLayoutType } from '@grafana/data';
 import { locationService } from '@grafana/runtime';
-import { getUrlSyncManager, SceneComponentProps, SceneObjectBase, SceneObjectState } from '@grafana/scenes';
+import { SceneComponentProps, SceneObjectBase, SceneObjectState, getUrlSyncManager } from '@grafana/scenes';
 import { useStyles2 } from '@grafana/ui';
 import { Page } from 'app/core/components/Page/Page';
 
 import { DataTrail } from './DataTrail';
 import { DataTrailsHome } from './DataTrailsHome';
 import { MetricsHeader } from './MetricsHeader';
-import { getTrailStore } from './TrailStore/TrailStore';
 import { HOME_ROUTE, TRAILS_ROUTE } from './shared';
 import { getMetricName, getUrlForTrail, newMetricsTrail } from './utils';
 
@@ -75,8 +74,12 @@ function DataTrailView({ trail }: { trail: DataTrail }) {
 
   useEffect(() => {
     if (!isInitialized) {
+      // Set the initial state based on the URL.
       getUrlSyncManager().initSync(trail);
-      getTrailStore().setRecentTrail(trail);
+      // Any further changes to the state should occur directly to the state, not through the URL,
+      // So we want to stop listening after this point.
+      getUrlSyncManager().cleanUp(trail);
+
       setIsInitialized(true);
     }
   }, [trail, isInitialized]);

--- a/public/app/features/trails/DataTrailsHistory.tsx
+++ b/public/app/features/trails/DataTrailsHistory.tsx
@@ -13,7 +13,7 @@ import {
 } from '@grafana/scenes';
 import { useStyles2, Tooltip, Stack } from '@grafana/ui';
 
-import { DataTrail, DataTrailState } from './DataTrail';
+import { DataTrail, DataTrailState, getTopSceneFor } from './DataTrail';
 import { VAR_FILTERS } from './shared';
 import { getTrailFor, isSceneTimeRangeState } from './utils';
 
@@ -45,6 +45,20 @@ export class DataTrailHistory extends SceneObjectBase<DataTrailsHistoryState> {
     if (this.state.steps.length === 0) {
       // We always want to ensure in initial 'start' step
       this.addTrailStep(trail, 'start');
+
+      if (trail.state.metric) {
+        // But if our current trail has a metric, we want to remove it and the topScene,
+        // so that the "start" step always displays a metric select screen.
+
+        // So we remove the metric and update the topscene for the "start" step
+        const { metric, ...startState } = trail.state;
+        startState.topScene = getTopSceneFor(undefined);
+        this.state.steps[0].trailState = startState;
+
+        // But must add a secondary step to represent the selection of the metric
+        // for this restored trail state
+        this.addTrailStep(trail, 'metric');
+      }
     }
 
     trail.subscribeToState((newState, oldState) => {

--- a/public/app/features/trails/Integrations/SceneDrawer.tsx
+++ b/public/app/features/trails/Integrations/SceneDrawer.tsx
@@ -18,21 +18,6 @@ export function SceneDrawer(props: SceneDrawerProps) {
   const { scene, title, onDismiss } = props;
   const styles = useStyles2(getStyles);
 
-  useEffect(() => {
-    // Adding this additional push prevents an embed in scenes dashboards from going back too far
-    locationService.push(locationService.getLocation());
-
-    const unregister = locationService.getHistory().listen((location, action) => {
-      if (action === 'POP') {
-        // Use the 'back' button to dismiss
-        locationService.push(location); // Undo the effects of the back button, and push the location back
-        onDismiss(); // Call the drawer modal's dismiss
-      }
-    });
-
-    return unregister;
-  }, [onDismiss]);
-
   return (
     <Drawer title={title} onClose={onDismiss} size="lg">
       <div className={styles.drawerInnerWrapper}>

--- a/public/app/features/trails/Integrations/SceneDrawer.tsx
+++ b/public/app/features/trails/Integrations/SceneDrawer.tsx
@@ -1,8 +1,7 @@
 import { css } from '@emotion/css';
-import React, { useEffect } from 'react';
+import React from 'react';
 
 import { GrafanaTheme2 } from '@grafana/data';
-import { locationService } from '@grafana/runtime';
 import { SceneComponentProps, SceneObjectBase, SceneObject, SceneObjectState } from '@grafana/scenes';
 import { Drawer, useStyles2 } from '@grafana/ui';
 import appEvents from 'app/core/app_events';


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

Fixes a number of problems with the browser history (e.g., back/forward buttons) and how they interact with the trail nodes.

Before:
- Back button would occasionally create new steps (while remaining on the trail)
- Sometimes certain state transitions would alter the URL, and trigger the creation of trail steps.
- In embedded mode, links to select label breakdowns from the overview were disabled because they would go to a new URL

After:
- Back button will take you to the page you were at before entering the "trail", going forward would return you to that trail
- No new nodes are created while using browsing back and forward buttons
- Updated that label links to breakdowns, making this feature work in embedded mode as well (using onClick to change the state, vs. href)

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
