### PR TITLE
IDFowrarding: ignore logging context canceled errors

### DIFF
--- a/pkg/services/auth/idimpl/service.go
+++ b/pkg/services/auth/idimpl/service.go
@@ -159,8 +159,10 @@ func (s *Service) hook(ctx context.Context, identity *authn.Identity, _ *authn.R
 	// FIXME(kalleep): we should probably lazy load this
 	token, err := s.SignIdentity(ctx, identity)
 	if err != nil {
-		namespace, id := identity.GetNamespacedID()
-		s.logger.FromContext(ctx).Error("Failed to sign id token", "err", err, "namespace", namespace, "id", id)
+		if shouldLogErr(err) {
+			namespace, id := identity.GetNamespacedID()
+			s.logger.FromContext(ctx).Error("Failed to sign id token", "err", err, "namespace", namespace, "id", id)
+		}
 		// for now don't return error so we don't break authentication from this hook
 		return nil
 	}
@@ -179,4 +181,8 @@ func getSubject(namespace, identifier string) string {
 
 func prefixCacheKey(key string) string {
 	return fmt.Sprintf("%s-%s", cachePrefix, key)
+}
+
+func shouldLogErr(err error) bool {
+	return !errors.Is(err, context.Canceled)
 }


### PR DESCRIPTION
**What is this feature?**
Reduce some error logging noise. We can skip logging context cancellations 

**Which issue(s) does this PR fix?**:

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
