### PR TITLE
Scopes: Add more BE filtering (field selectors)

### DIFF
--- a/pkg/registry/apis/scope/register.go
+++ b/pkg/registry/apis/scope/register.go
@@ -54,13 +54,29 @@ func (b *ScopeAPIBuilder) InstallSchema(scheme *runtime.Scheme) error {
 	err = scheme.AddFieldLabelConversionFunc(
 		scope.ScopeResourceInfo.GroupVersionKind(),
 		func(label, value string) (string, string, error) {
-			fieldSet := SelectableFields(&scope.Scope{})
+			fieldSet := SelectableScopeFields(&scope.Scope{})
 			for key := range fieldSet {
 				if label == key {
 					return label, value, nil
 				}
 			}
 			return "", "", fmt.Errorf("field label not supported for %s: %s", scope.ScopeResourceInfo.GroupVersionKind(), label)
+		},
+	)
+	if err != nil {
+		return err
+	}
+
+	err = scheme.AddFieldLabelConversionFunc(
+		scope.ScopeDashboardResourceInfo.GroupVersionKind(),
+		func(label, value string) (string, string, error) {
+			fieldSet := SelectableScopeDashboardFields(&scope.ScopeDashboard{})
+			for key := range fieldSet {
+				if label == key {
+					return label, value, nil
+				}
+			}
+			return "", "", fmt.Errorf("field label not supported for %s: %s", scope.ScopeDashboardResourceInfo.GroupVersionKind(), label)
 		},
 	)
 	if err != nil {

--- a/pkg/registry/apis/scope/storage.go
+++ b/pkg/registry/apis/scope/storage.go
@@ -101,12 +101,13 @@ func newScopeDashboardStorage(scheme *runtime.Scheme, optsGetter generic.RESTOpt
 }
 
 func GetAttrs(obj runtime.Object) (labels.Set, fields.Set, error) {
-	s, ok := obj.(*scope.Scope)
-	if !ok {
-		return nil, nil, fmt.Errorf("not a scope")
+	if s, ok := obj.(*scope.Scope); ok {
+		return labels.Set(s.Labels), SelectableScopeFields(s), nil
 	}
-
-	return labels.Set(s.Labels), SelectableFields(s), nil
+	if s, ok := obj.(*scope.ScopeDashboard); ok {
+		return labels.Set(s.Labels), SelectableScopeDashboardFields(s), nil
+	}
+	return nil, nil, fmt.Errorf("not a scope or scopeDashboard object")
 }
 
 // Matcher returns a generic.SelectionPredicate that matches on label and field selectors.
@@ -118,8 +119,15 @@ func Matcher(label labels.Selector, field fields.Selector) apistore.SelectionPre
 	}
 }
 
-func SelectableFields(obj *scope.Scope) fields.Set {
+func SelectableScopeFields(obj *scope.Scope) fields.Set {
 	return generic.MergeFieldsSets(generic.ObjectMetaFieldsSet(&obj.ObjectMeta, false), fields.Set{
-		"spec.type": obj.Spec.Type,
+		"spec.type":     obj.Spec.Type,
+		"spec.category": obj.Spec.Category,
+	})
+}
+
+func SelectableScopeDashboardFields(obj *scope.ScopeDashboard) fields.Set {
+	return generic.MergeFieldsSets(generic.ObjectMetaFieldsSet(&obj.ObjectMeta, false), fields.Set{
+		"spec.scopeUid": obj.Spec.ScopeUID,
 	})
 }


### PR DESCRIPTION
**What is this feature?**

Expand field selectors into scopeDashboard.

**Special notes for your reviewer:**

ScopeDashboard has `DashboardUIDs []string`, and that isn't selectable by field selectors I don't think. So I think we will likely end up changing the type:
 - Maybe be a 1-1 mapping
 - Maybe use labels or annotations instead of field properties?

Example scope Rest API request with filtering:

```curl
curl -X 'GET' \
  'http://admin:admin@localhost:3000/apis/scope.grafana.app/v0alpha1/scopes?fieldSelector=spec.type%3Dscope%2Cspec.category%3DCategory%203' \
  -H 'accept: application/json'
```

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
