### PR TITLE
EmailVerification: Generate emails after rename

### DIFF
--- a/public/emails/verify_email.html
+++ b/public/emails/verify_email.html
@@ -1,8 +1,8 @@
 <!doctype html>
-<html xmlns="http://www.w3.org/1999/xhtml" xmlns:v="urn:schemas-microsoft-com:vml" xmlns:o="urn:schemas-microsoft-com:office:office">
+<html lang="und" dir="auto" xmlns="http://www.w3.org/1999/xhtml" xmlns:v="urn:schemas-microsoft-com:vml" xmlns:o="urn:schemas-microsoft-com:office:office">
 
 <head>
-  <title>{{ Subject .Subject .TemplateData "Verify your new email - {{.Name}}" }}</title>
+  <title>{{ Subject .Subject .TemplateData "Verify your email - {{.Name}}" }}</title>
   {{ __dangerouslyInjectHTML `<!--[if !mso]><!-->` }}
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   {{ __dangerouslyInjectHTML `<!--<![endif]-->` }}
@@ -92,12 +92,10 @@
     }
 
   </style>
-  <style type="text/css">
-  </style>
 </head>
 
 <body style="word-spacing:normal;">
-  <div class="canvas" style="background-color: #fff;">
+  <div class="canvas" style="background-color: #fff;" lang="und" dir="auto">
     {{ __dangerouslyInjectHTML `<!--[if mso | IE]><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:600px;" width="600" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->` }}
     <div style="margin:0px auto;max-width:600px;">
       <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;">
@@ -114,7 +112,7 @@
                           <tbody>
                             <tr>
                               <td style="width:200px;">
-                                <img src="https://grafana.com/static/assets/img/logo_new_transparent_light_400x100.png" style="border:0;display:block;outline:none;text-decoration:none;height:auto;width:100%;font-size:13px;" width="200" height="auto">
+                                <img alt src="https://grafana.com/static/assets/img/logo_new_transparent_light_400x100.png" style="border:0;display:block;outline:none;text-decoration:none;height:auto;width:100%;font-size:13px;" width="200" height="auto">
                               </td>
                             </tr>
                           </tbody>
@@ -153,7 +151,7 @@
                       </td>
                     </tr>
                     <tr>
-                      <td align="center" vertical-align="middle" style="font-size:0px;padding:10px 25px;word-break:break-word;">
+                      <td align="center" style="font-size:0px;padding:10px 25px;word-break:break-word;">
                         <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="border-collapse:separate;line-height:100%;">
                           <tbody>
                             <tr>

--- a/public/emails/verify_email.txt
+++ b/public/emails/verify_email.txt
@@ -1,4 +1,4 @@
-{{HiddenSubject .Subject "Verify your new email - {{.Name}}"}}
+{{HiddenSubject .Subject "Verify your email - {{.Name}}"}}
 
 Hi {{.Name}},
 


### PR DESCRIPTION
**What is this feature?**
I renamed the email template files from verify_email_update to verify_email but never generated the html and txt files.

**Which issue(s) does this PR fix?**:
Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
