### PR TITLE
Cloudwatch: Use debug.stack method to generate more useful stack trace

### DIFF
--- a/pkg/tsdb/cloudwatch/time_series_query.go
+++ b/pkg/tsdb/cloudwatch/time_series_query.go
@@ -4,13 +4,13 @@ import (
 	"context"
 	"fmt"
 	"regexp"
+	"runtime/debug"
 
 	"golang.org/x/sync/errgroup"
 
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
 	"github.com/grafana/grafana/pkg/tsdb/cloudwatch/features"
 	"github.com/grafana/grafana/pkg/tsdb/cloudwatch/models"
-	"github.com/grafana/grafana/pkg/tsdb/cloudwatch/utils"
 )
 
 type responseWrapper struct {
@@ -70,7 +70,7 @@ func (e *cloudWatchExecutor) executeTimeSeriesQuery(ctx context.Context, req *ba
 			eg.Go(func() error {
 				defer func() {
 					if err := recover(); err != nil {
-						e.logger.FromContext(ctx).Error("Execute Get Metric Data Query Panic", "error", err, "stack", utils.Stack(1))
+						e.logger.FromContext(ctx).Error("Execute Get Metric Data Query Panic", "error", err, "stack", string(debug.Stack()))
 						if theErr, ok := err.(error); ok {
 							resultChan <- &responseWrapper{
 								DataResponse: &backend.DataResponse{

--- a/pkg/tsdb/cloudwatch/utils/utils.go
+++ b/pkg/tsdb/cloudwatch/utils/utils.go
@@ -1,7 +1,5 @@
 package utils
 
-import "github.com/go-stack/stack"
-
 func Pointer[T any](arg T) *T { return &arg }
 
 func Depointerizer[T any](v *T) T {
@@ -11,12 +9,4 @@ func Depointerizer[T any](v *T) T {
 	}
 
 	return emptyValue
-}
-
-// Stack is copied from grafana/pkg/infra/log
-// TODO: maybe this should live in grafana-plugin-sdk-go?
-func Stack(skip int) string {
-	call := stack.Caller(skip)
-	s := stack.Trace().TrimBelow(call).TrimRuntime()
-	return s.String()
 }


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**
Modelled after this: https://github.com/grafana/grafana/pull/85118
Copying original description: 

> The current implementation does not lead to a stack trace being produced on Windows machines and doesn't allow us to debug correctly. This switch to the runtime/debug package produces stacks as expected.

More info in this thread: https://raintank-corp.slack.com/archives/C05K271Q8F5/p1710953298081879

Thanks @aangelisc!

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
