### PR TITLE
Alerting: Make hovercard accessible

### DIFF
--- a/public/app/features/alerting/unified/components/HoverCard.tsx
+++ b/public/app/features/alerting/unified/components/HoverCard.tsx
@@ -37,7 +37,7 @@ export const HoverCard = ({
   }
 
   const body = (
-    <Stack direction="column" gap={0}>
+    <Stack direction="column" gap={0} role="tooltip">
       {header && <div className={styles.card.header}>{header}</div>}
       <div className={styles.card.body}>{content}</div>
       {footer && <div className={styles.card.footer}>{footer}</div>}
@@ -69,6 +69,7 @@ export const HoverCard = ({
               onMouseLeave: hidePopper,
               onFocus: showPopper,
               onBlur: hidePopper,
+              tabIndex: 0,
             })}
           </>
         );


### PR DESCRIPTION
**What is this feature?**

Prior to this PR the hover card wouldn't be keyboard accessible, this adds the ability to focus the element with the keyboard and it will automatically show the tooltip.

Tested this with Chrome but should also work for the other browsers :)

<img width="868" alt="image" src="https://github.com/grafana/grafana/assets/868844/ae2aad73-0bdd-4da7-87af-f7e59b412894">
