### PR TITLE
datatrails: avoid double scrollbar with new viz tooltips

### DIFF
--- a/public/app/features/trails/ActionTabs/panelConfigs.ts
+++ b/public/app/features/trails/ActionTabs/panelConfigs.ts
@@ -3,6 +3,6 @@ import { SortOrder } from '@grafana/schema/dist/esm/index';
 import { TooltipDisplayMode } from '@grafana/ui';
 
 export const breakdownPanelOptions = PanelOptionsBuilders.timeseries()
-  .setOption('tooltip', { mode: TooltipDisplayMode.Multi, sort: SortOrder.Descending, maxHeight: 250 })
+  .setOption('tooltip', { mode: TooltipDisplayMode.Multi, sort: SortOrder.Descending })
   .setOption('legend', { showLegend: false })
   .build();


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

When enabling the "new viz" tooltips, prevent this double scrollbar effect:
![image](https://github.com/grafana/grafana/assets/38694490/a0891612-7208-49fc-bdf9-6873ac3e4b8e)

The current default height works well, and the scrollbar is singular and works as expected:
![image](https://github.com/grafana/grafana/assets/38694490/2ec58d41-9f46-4108-b209-02bbe911bc53)


**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
