### PR TITLE
Graphite: second function as another function argument parsing error fix

### DIFF
--- a/docs/sources/datasources/graphite/query-editor/index.md
+++ b/docs/sources/datasources/graphite/query-editor/index.md
@@ -55,6 +55,10 @@ Some functions like aliasByNode support an optional second argument. To add an a
 
 To learn more, refer to [Graphite's documentation on functions](https://graphite.readthedocs.io/en/latest/functions.html).
 
+{{% admonition type="warning" %}}
+Some functions take a second argument that may be a function that returns a series. If you are adding a second argument that is a function, it is suggested to use a series reference from a second query instead of the function itself. The query editor does not currently support parsing of a second argument that is a function when switching between the query editor and the code editor.
+{{% /admonition %}}
+
 ### Sort labels
 
 If you have the same labels on multiple graphs, they are both sorted differently and use different colors.

--- a/public/app/plugins/datasource/graphite/graphite_query.ts
+++ b/public/app/plugins/datasource/graphite/graphite_query.ts
@@ -376,14 +376,8 @@ function handleMultipleSeriesByTagsParams(astNode: AstNode) {
 function handleDivideSeriesListsNestedFunctions(astNode: AstNode) {
   // if divideSeriesLists function, the second parameters should be strings
   if (astNode.name === 'divideSeriesLists' && astNode.params && astNode.params.length >= 2) {
-    let count = 0;
-
-    astNode.params = astNode.params.map((p: AstNode) => {
-      if (p.type === 'function') {
-        count += 1;
-      }
-
-      if (count === 2 && p.type === 'function') {
+    astNode.params = astNode.params.map((p: AstNode, idx: number) => {
+      if (idx === 1 && p.type === 'function') {
         // convert nested 2nd functions as parametors to a strings
         // all nested functions should be strings
         // if the node is a function it will have params

--- a/public/app/plugins/datasource/graphite/specs/graphite_query.test.ts
+++ b/public/app/plugins/datasource/graphite/specs/graphite_query.test.ts
@@ -111,11 +111,11 @@ describe('Graphite query model', () => {
     });
   });
 
-  describe('when query has multiple seriesByTags functions as parameters it updates the model target correctly', () => {
+  describe('When the second parameter of a function is a function, the graphite parser breaks', () => {
     /* 
       all functions that take parameters as functions can have a bug where writing a query
-      in code with two seriesByTags funcs as params and then 
-      switching from code to builder parsers the second function in a way that 
+      in code where the second parameter of the function IS A FUNCTION, 
+      then switching from code to builder parsers the second function in a way that 
       changes the order of the params and wraps the first param in the second param.
       
       asPercent(seriesByTag('namespace=asd'), (seriesByTag('namespace=fgh')) 
@@ -126,33 +126,94 @@ describe('Graphite query model', () => {
       where each function is wrapped in another function
       https://github.com/grafana/grafana/blob/main/public/app/plugins/datasource/graphite/graphite_query.ts#LL187C8-L187C8
 
-      Parsing the second seriesByTag function as param as a string fixes this issue 
+      Parsing the second "function as param" as a string fixes this issue 
 
       This is one of the edge cases that could be a reason for either refactoring or rebuilding the Graphite query builder
     */
-    beforeEach(() => {
-      ctx.target = { refId: 'A', target: `asPercent(seriesByTag('namespace=asd'), seriesByTag('namespace=fgh'))` };
-      ctx.targets = [ctx.target];
-      ctx.queryModel = new GraphiteQuery(ctx.datasource, ctx.target, ctx.templateSrv);
+    describe('when query has multiple seriesByTags functions as parameters it updates the model target correctly', () => {
+      beforeEach(() => {
+        ctx.target = { refId: 'A', target: `asPercent(seriesByTag('namespace=asd'), seriesByTag('namespace=fgh'))` };
+        ctx.targets = [ctx.target];
+        ctx.queryModel = new GraphiteQuery(ctx.datasource, ctx.target, ctx.templateSrv);
+      });
+
+      it('should parse the second function param as a string and not a second function', () => {
+        const targets = [
+          {
+            refId: 'A',
+            datasource: {
+              type: 'graphite',
+              uid: 'zzz',
+            },
+            target: "asPercent(seriesByTag('namespace=jkl'), seriesByTag('namespace=fgh'))",
+            textEditor: false,
+            key: '123',
+          },
+        ];
+        expect(ctx.queryModel.segments.length).toBe(0);
+        expect(ctx.queryModel.functions.length).toBe(2);
+        ctx.queryModel.updateModelTarget(targets);
+        expect(ctx.queryModel.target.target).not.toContain('seriesByTag(seriesByTag(');
+      });
     });
 
-    it('should parse the second function param as a string and not a second function', () => {
-      const targets = [
-        {
+    describe('when query has divideSeriesLists function where second parameter is a function is parses correctly', () => {
+      it('should parse the second function param as a string and not a second function', () => {
+        const functionAsParam = 'scaleToSeconds(carbon.agents.0df7e0ba2701-a.cache.queries,1)';
+
+        ctx.target = {
           refId: 'A',
-          datasource: {
-            type: 'graphite',
-            uid: 'zzz',
+          target: `divideSeriesLists(scaleToSeconds(nonNegativeDerivative(carbon.agents.0df7e0ba2701-a.cache.queries), 1), ${functionAsParam})`,
+        };
+        ctx.targets = [ctx.target];
+        ctx.queryModel = new GraphiteQuery(ctx.datasource, ctx.target, ctx.templateSrv);
+
+        const targets = [
+          {
+            refId: 'A',
+            datasource: {
+              type: 'graphite',
+              uid: 'zzz',
+            },
+            target: `divideSeriesLists(scaleToSeconds(nonNegativeDerivative(carbon.agents.0df7e0ba2701-a.cache.queries), 1), ${functionAsParam})`,
+            textEditor: false,
+            key: '123',
           },
-          target: "asPercent(seriesByTag('namespace=jkl'), seriesByTag('namespace=fgh'))",
-          textEditor: false,
-          key: '123',
-        },
-      ];
-      expect(ctx.queryModel.segments.length).toBe(0);
-      expect(ctx.queryModel.functions.length).toBe(2);
-      ctx.queryModel.updateModelTarget(targets);
-      expect(ctx.queryModel.target.target).not.toContain('seriesByTag(seriesByTag(');
+        ];
+        expect(ctx.queryModel.segments.length).toBe(5);
+        expect(ctx.queryModel.functions.length).toBe(3);
+        ctx.queryModel.updateModelTarget(targets);
+        expect(ctx.queryModel.target.target).toContain(functionAsParam);
+      });
+
+      it('should recursively parse a second function param that contains another function as a string and not a second function', () => {
+        const nestedFunctionAsParam =
+          'scaleToSeconds(nonNegativeDerivative(carbon.agents.0df7e0ba2701-a.cache.queries,1))';
+
+        ctx.target = {
+          refId: 'A',
+          target: `divideSeriesLists(scaleToSeconds(nonNegativeDerivative(carbon.agents.0df7e0ba2701-a.cache.queries), 1), ${nestedFunctionAsParam})`,
+        };
+        ctx.targets = [ctx.target];
+        ctx.queryModel = new GraphiteQuery(ctx.datasource, ctx.target, ctx.templateSrv);
+
+        const targets = [
+          {
+            refId: 'A',
+            datasource: {
+              type: 'graphite',
+              uid: 'zzz',
+            },
+            target: `divideSeriesLists(scaleToSeconds(nonNegativeDerivative(carbon.agents.0df7e0ba2701-a.cache.queries), 1), ${nestedFunctionAsParam})`,
+            textEditor: false,
+            key: '123',
+          },
+        ];
+        expect(ctx.queryModel.segments.length).toBe(5);
+        expect(ctx.queryModel.functions.length).toBe(3);
+        ctx.queryModel.updateModelTarget(targets);
+        expect(ctx.queryModel.target.target).toContain(nestedFunctionAsParam);
+      });
     });
   });
 });


### PR DESCRIPTION
Fixes https://github.com/grafana/support-escalations/issues/9890

**What is this fix?**

The Graphite query editor has known parsing issues when switching between code and query editor. When the following case occurs, the query is changed, which is not good. This fixes parsing issues for the `divideSeriesLists` function with second argument functions and second argument nested functions.

Here is an example you can test with:

1. Write a query in the code editor that uses divideSeriesLists.

```
divideSeriesLists(scaleToSeconds(nonNegativeDerivative(carbon.agents.0df7e0ba2701-a.cache.queries), 1), scaleToSeconds(carbon.agents.0df7e0ba2701-a.cache.queries,1))
```

(This nested query contains a second argument that is a function. This is where the parser breaks. It can only parse an onion-like number of nested functions. If there is a second argument function, it will parse that incorrectly.)

2. Switch to query editor

3. Update any part of the query. Change a tag, change an argument in a function, do anything to update the query. 

Here is an example of a small change, the function `scaleToSeconds(carbon.agents.0df7e0ba2701-a.cache.**queues**,1)` where queries is changed to queues.

4. Switch back to the code editor. See that the query is not changed


Docs have also been updated for a future workaround for this. Customers can use a series reference where they write the second argument function in a separate query row and then reference it in the additional query.

QUERY A: `scaleToSeconds(carbon.agents.0df7e0ba2701-a.cache.queries,1)`

QUERY B: `divideSeriesLists(scaleToSeconds(nonNegativeDerivative(carbon.agents.0df7e0ba2701-a.cache.queries), 1), #A)`



Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
