### PR TITLE
Revert "ci(docs): Disable tag requirement for pushing release docs"

### DIFF
--- a/.github/workflows/publish-technical-documentation-release.yml
+++ b/.github/workflows/publish-technical-documentation-release.yml
@@ -28,13 +28,23 @@ jobs:
       - name: "Install Actions from library"
         run: "npm install --production --prefix ./actions"
 
+      - name: "Determine if there is a matching release tag"
+        id: "has-matching-release-tag"
+        uses: "./actions/has-matching-release-tag"
+        with:
+          ref_name: "${{ github.ref_name }}"
+          release_tag_regexp: "^v(0|[1-9]\\d*)\\.(0|[1-9]\\d*)\\.(0|[1-9]\\d*)$"
+          release_branch_regexp: "^v(0|[1-9]\\d*)\\.(0|[1-9]\\d*)\\.x$"
+
       - name: "Determine technical documentation version"
+        if: "steps.has-matching-release-tag.outputs.bool == 'true'"
         uses: "./actions/docs-target"
         id: "target"
         with:
           ref_name: "${{ github.ref_name }}"
 
       - name: "Clone website-sync Action"
+        if: "steps.has-matching-release-tag.outputs.bool == 'true'"
         # WEBSITE_SYNC_TOKEN is a fine-grained GitHub Personal Access Token that expires.
         # It must be regenerated in the grafanabot GitHub account and requires a Grafana organization
         # GitHub administrator to update the organization secret.
@@ -44,10 +54,11 @@ jobs:
       - name: "Switch to HEAD of version branch for tags"
         # Tags aren't necessarily made to the HEAD of the version branch.
         # The documentation to be published is always on the HEAD of the version branch.
-        if: "github.ref_type == 'tag'"
+        if: "steps.has-matching-release-tag.outputs.bool == 'true' && github.ref_type == 'tag'"
         run: "git switch --detach origin/${{ steps.target.outputs.target }}.x"
 
       - name: "Publish to website repository (release)"
+        if: "steps.has-matching-release-tag.outputs.bool == 'true'"
         uses: "./.github/actions/website-sync"
         id: "publish-release"
         with:


### PR DESCRIPTION
Reverts grafana/grafana#84825

Restore original behavior once workaround is no longer needed.