### PR TITLE
LLMApp: Skip 404 requests to know if the plugin exists

### DIFF
--- a/public/app/features/dashboard/components/GenAI/utils.test.ts
+++ b/public/app/features/dashboard/components/GenAI/utils.test.ts
@@ -16,6 +16,16 @@ jest.mock('@grafana/experimental', () => ({
   },
 }));
 
+jest.mock('@grafana/runtime', () => ({
+  ...jest.requireActual('@grafana/runtime'),
+  config: {
+    ...jest.requireActual('@grafana/runtime').config,
+    apps: {
+      'grafana-llm-app': true,
+    },
+  },
+}));
+
 describe('getDashboardChanges', () => {
   it('should correctly split user changes and migration changes', () => {
     // Mock data for testing

--- a/public/app/features/dashboard/components/GenAI/utils.ts
+++ b/public/app/features/dashboard/components/GenAI/utils.ts
@@ -1,6 +1,7 @@
 import { pick } from 'lodash';
 
 import { llms } from '@grafana/experimental';
+import { config } from '@grafana/runtime';
 import { Panel } from '@grafana/schema';
 
 import { DashboardModel, PanelModel } from '../../state';
@@ -63,6 +64,10 @@ export function getDashboardChanges(dashboard: DashboardModel): {
  * @returns true if the LLM plugin is enabled.
  */
 export async function isLLMPluginEnabled() {
+  if (!config.apps['grafana-llm-app']) {
+    return false;
+  }
+
   // Check if the LLM plugin is enabled.
   // If not, we won't be able to make requests, so return early.
   return llms.openai.health().then((response) => response.ok);


### PR DESCRIPTION
I get really annoyed seeing these error requests every time I open dashboard settings or panel edit. 

![Screenshot 2024-03-27 at 08 40 44](https://github.com/grafana/grafana/assets/10999/f14b383c-8751-429d-bf27-d804fad35985)

If tests needs updating, can anyone who wrote this help? 


