### PR TITLE
Dashboard scenes: Export isExpressionReference to be accessible from scenes

### DIFF
--- a/packages/grafana-runtime/src/index.ts
+++ b/packages/grafana-runtime/src/index.ts
@@ -17,6 +17,7 @@ export {
   type HealthCheckResultDetails,
   HealthStatus,
   type StreamOptionsProvider,
+  isExpressionReference,
 } from './utils/DataSourceWithBackend';
 export {
   toDataQueryResponse,

--- a/packages/grafana-runtime/src/utils/DataSourceWithBackend.ts
+++ b/packages/grafana-runtime/src/utils/DataSourceWithBackend.ts
@@ -43,7 +43,7 @@ export const ExpressionDatasourceRef = Object.freeze({
 });
 
 /**
- * @internal
+ * @public
  */
 export function isExpressionReference(ref?: DataSourceRef | string | null): boolean {
   if (!ref) {


### PR DESCRIPTION
**What is this feature?**
 Exports isExpressionReference so that scenes can identify if a datasource is an expression.