### PR TITLE
Alerting: Fix removing nested policy

### DIFF
--- a/public/app/features/alerting/unified/utils/routeTree.test.ts
+++ b/public/app/features/alerting/unified/utils/routeTree.test.ts
@@ -65,14 +65,17 @@ describe('omitRouteFromRouteTree', () => {
       receiver: 'root',
       routes: [
         { id: 'route-2', receiver: 'receiver-2' },
-        { id: 'route-3', receiver: 'receiver-3' },
+        { id: 'route-3', receiver: 'receiver-3', routes: [{ id: 'route-4', receiver: 'receiver-4' }] },
       ],
     };
 
-    expect(omitRouteFromRouteTree({ id: 'route-2' }, tree)).toEqual({
+    expect(omitRouteFromRouteTree({ id: 'route-4' }, tree)).toEqual({
       id: 'route-1',
       receiver: 'root',
-      routes: [{ id: 'route-3', receiver: 'receiver-3', routes: undefined }],
+      routes: [
+        { id: 'route-2', receiver: 'receiver-2' },
+        { id: 'route-3', receiver: 'receiver-3', routes: [] },
+      ],
     });
   });
 

--- a/public/app/features/alerting/unified/utils/routeTree.ts
+++ b/public/app/features/alerting/unified/utils/routeTree.ts
@@ -58,7 +58,7 @@ export const omitRouteFromRouteTree = (findRoute: RouteWithID, routeTree: RouteW
           return acc;
         }
 
-        acc.push(route);
+        acc.push(findAndOmit(route));
         return acc;
       }, []),
     };


### PR DESCRIPTION
A small regression in https://github.com/grafana/grafana/pull/84304 prevented policies nested more than 1 level deep from being removed properly since the `findAndOmit` function was not being called recursively.

Tests also passed because they only tested one level of recursion, the existing test has been updated to account for arbitrary tree depth.