### PR TITLE
Auth: encrypt/decrypt SAML secrets in SSO settings service

### DIFF
--- a/pkg/services/ssosettings/ssosettingsimpl/service.go
+++ b/pkg/services/ssosettings/ssosettingsimpl/service.go
@@ -501,7 +501,7 @@ func overrideMaps(maps ...map[string]any) map[string]any {
 }
 
 func isSecret(fieldName string) bool {
-	secretFieldPatterns := []string{"secret"}
+	secretFieldPatterns := []string{"secret", "private", "certificate"}
 
 	for _, v := range secretFieldPatterns {
 		if strings.Contains(strings.ToLower(fieldName), strings.ToLower(v)) {

--- a/pkg/services/ssosettings/ssosettingsimpl/service_test.go
+++ b/pkg/services/ssosettings/ssosettingsimpl/service_test.go
@@ -1309,16 +1309,22 @@ func TestService_decryptSecrets(t *testing.T) {
 			setup: func(env testEnv) {
 				env.secrets.On("Decrypt", mock.Anything, []byte("client_secret"), mock.Anything).Return([]byte("decrypted-client-secret"), nil).Once()
 				env.secrets.On("Decrypt", mock.Anything, []byte("other_secret"), mock.Anything).Return([]byte("decrypted-other-secret"), nil).Once()
+				env.secrets.On("Decrypt", mock.Anything, []byte("private_key"), mock.Anything).Return([]byte("decrypted-private-key"), nil).Once()
+				env.secrets.On("Decrypt", mock.Anything, []byte("certificate"), mock.Anything).Return([]byte("decrypted-certificate"), nil).Once()
 			},
 			settings: map[string]any{
 				"enabled":       true,
 				"client_secret": base64.RawStdEncoding.EncodeToString([]byte("client_secret")),
 				"other_secret":  base64.RawStdEncoding.EncodeToString([]byte("other_secret")),
+				"private_key":   base64.RawStdEncoding.EncodeToString([]byte("private_key")),
+				"certificate":   base64.RawStdEncoding.EncodeToString([]byte("certificate")),
 			},
 			want: map[string]any{
 				"enabled":       true,
 				"client_secret": "decrypted-client-secret",
 				"other_secret":  "decrypted-other-secret",
+				"private_key":   "decrypted-private-key",
+				"certificate":   "decrypted-certificate",
 			},
 		},
 		{
@@ -1356,7 +1362,7 @@ func TestService_decryptSecrets(t *testing.T) {
 			wantErr: true,
 		},
 		{
-			name: "should return an error decryption fails",
+			name: "should return an error if decryption fails",
 			setup: func(env testEnv) {
 				env.secrets.On("Decrypt", mock.Anything, []byte("client_secret"), mock.Anything).Return(nil, errors.New("decryption failed")).Once()
 			},


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

The SAML secret fields (such as `private_key` and `certificate`) will be encrypted at rest.

**Why do we need this feature?**

Storing secrets in clear text is a security risk.

**Who is this feature for?**

Everyone using SAML SSO.

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
