### PR TITLE
StateTimeline: Fix data links causing unrendering of string fields

### DIFF
--- a/public/app/core/components/GraphNG/GraphNG.tsx
+++ b/public/app/core/components/GraphNG/GraphNG.tsx
@@ -106,14 +106,14 @@ export class GraphNG extends Component<GraphNGProps, GraphNGState> {
 
     const preparePlotFrameFn = preparePlotFrame ?? defaultPreparePlotFrame;
 
-    const matchY = fieldMatchers.get(FieldMatcherID.byTypes).get(new Set([FieldType.number, FieldType.enum]));
+    const matchYDefault = fieldMatchers.get(FieldMatcherID.byTypes).get(new Set([FieldType.number, FieldType.enum]));
 
     // if there are data links, we have to keep all fields so they're index-matched, then filter out dimFields.y
     const withLinks = frames.some((frame) => frame.fields.some((field) => (field.config.links?.length ?? 0) > 0));
 
     const dimFields = fields ?? {
       x: fieldMatchers.get(FieldMatcherID.firstTimeField).get({}),
-      y: withLinks ? () => true : matchY,
+      y: withLinks ? () => true : matchYDefault,
     };
 
     const alignedFrame = preparePlotFrameFn(frames, dimFields, props.timeRange);
@@ -150,7 +150,7 @@ export class GraphNG extends Component<GraphNGProps, GraphNGState> {
         // filter join field and dimFields.y
         alignedFrameFinal = {
           ...alignedFrame,
-          fields: alignedFrame.fields.filter((field, i) => i === 0 || matchY(field, alignedFrame, [alignedFrame])),
+          fields: alignedFrame.fields.filter((field, i) => i === 0 || dimFields.y(field, alignedFrame, [alignedFrame])),
         };
       }
 


### PR DESCRIPTION
fixes a regression introduced in https://github.com/grafana/grafana/pull/83654 causing string fields not to render in GraphNG-based panels when panel data links are added. the only panel that currently renders string fields is StateTimeline.

can be reproduced in http://localhost:3000/d/mIJjFy8Kz/timeline-demo?orgId=1

https://github.com/grafana/grafana/blob/main/devenv/dev-dashboards/panel-timeline/timeline-modes.json

[Kooha-2024-03-27-08-14-24.webm](https://github.com/grafana/grafana/assets/43234/34e09f2a-1fb3-4fb1-91d8-2117676c6c2c)