### PR TITLE
Tempo: Show <1ms when durationMs not in response

### DIFF
--- a/public/app/plugins/datasource/tempo/resultTransformer.test.ts
+++ b/public/app/plugins/datasource/tempo/resultTransformer.test.ts
@@ -79,6 +79,7 @@ describe('createTableFrameFromTraceQlQuery()', () => {
     expect(frame.fields[4].name).toBe('traceDuration');
     expect(frame.fields[4].type).toBe('number');
     expect(frame.fields[4].values[2]).toBe(44);
+    expect(frame.fields[4].values[1]).toBe('<1ms');
     // Subframes field
     expect(frame.fields[5].name).toBe('nested');
     expect(frame.fields[5].type).toBe('nestedFrames');

--- a/public/app/plugins/datasource/tempo/resultTransformer.ts
+++ b/public/app/plugins/datasource/tempo/resultTransformer.ts
@@ -468,7 +468,7 @@ function transformToTraceData(data: TraceSearchMetadata) {
   return {
     traceID: data.traceID,
     startTime: parseInt(data.startTimeUnixNano!, 10) / 1000000,
-    traceDuration: data.durationMs,
+    traceDuration: data.durationMs || '<1ms',
     traceService: data.rootServiceName || '',
     traceName: data.rootTraceName || '',
   };
@@ -915,7 +915,7 @@ interface TraceTableData {
   spanID?: string;
   startTime?: number;
   name?: string;
-  traceDuration?: number;
+  traceDuration?: number | string;
 }
 
 function transformSpanToTraceData(span: Span, spanSet: Spanset, trace: TraceSearchMetadata): TraceTableData {

--- a/public/app/plugins/datasource/tempo/testResponse.ts
+++ b/public/app/plugins/datasource/tempo/testResponse.ts
@@ -2368,7 +2368,6 @@ export const traceQlResponse = {
       rootServiceName: 'lb',
       rootTraceName: 'HTTP Client',
       startTimeUnixNano: '1643342166678000000',
-      durationMs: 93,
       spanSets: [
         {
           attributes: [


### PR DESCRIPTION
**What is this feature?**

Show <1ms when `durationMs` not in response.

**Why do we need this feature?**

So the duration field is not blank. More context [here](https://github.com/grafana/grafana/issues/85252#issuecomment-2022652982).

**Who is this feature for?**

Tempo users.

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes https://github.com/grafana/grafana/issues/85252