### PR TITLE
datatrails: hide "add to filter" button when there is no label value to add to filter

### DIFF
--- a/public/app/features/trails/ActionTabs/AddToFiltersGraphAction.tsx
+++ b/public/app/features/trails/ActionTabs/AddToFiltersGraphAction.tsx
@@ -41,6 +41,15 @@ export class AddToFiltersGraphAction extends SceneObjectBase<AddToFiltersGraphAc
   };
 
   public static Component = ({ model }: SceneComponentProps<AddToFiltersGraphAction>) => {
+    const state = model.useState();
+    const labels = state.frame.fields[1]?.labels || {};
+
+    const canAddToFilters = Object.keys(labels).length !== 0;
+
+    if (!canAddToFilters) {
+      return null;
+    }
+
     return (
       <Button variant="secondary" size="sm" fill="solid" onClick={model.onClick}>
         Add to filters


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

When dealing with a panel in the datatrails label breakdown where it is showing data for the `<unspecified>` label value case, hide the "add to filter" button.
![image](https://github.com/grafana/grafana/assets/38694490/5bc92bf1-8359-4317-ba04-a375bc7b8284)

If the button is not hidden, clicking it has no effect and may cause confusion.


**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
