### PR TITLE
Scopes: Add Filtering for ScopeDashoardBinding and Update Prometheus for ScopeFilterOperator Changes

### DIFF
--- a/pkg/apis/scope/v0alpha1/register.go
+++ b/pkg/apis/scope/v0alpha1/register.go
@@ -20,7 +20,7 @@ var ScopeResourceInfo = common.NewResourceInfo(GROUP, VERSION,
 	func() runtime.Object { return &ScopeList{} },
 )
 
-var ScopeDashboardResourceInfo = common.NewResourceInfo(GROUP, VERSION,
+var ScopeDashboardBindingResourceInfo = common.NewResourceInfo(GROUP, VERSION,
 	"scopedashboards", "scopedashboard", "ScopeDashboard",
 	func() runtime.Object { return &ScopeDashboardBinding{} },
 	func() runtime.Object { return &ScopeDashboardBindingList{} },

--- a/pkg/apis/scope/v0alpha1/register.go
+++ b/pkg/apis/scope/v0alpha1/register.go
@@ -21,7 +21,7 @@ var ScopeResourceInfo = common.NewResourceInfo(GROUP, VERSION,
 )
 
 var ScopeDashboardBindingResourceInfo = common.NewResourceInfo(GROUP, VERSION,
-	"scopedashboards", "scopedashboard", "ScopeDashboard",
+	"scopedashboardbindings", "scopedashboardbinding", "ScopeDashboardBinding",
 	func() runtime.Object { return &ScopeDashboardBinding{} },
 	func() runtime.Object { return &ScopeDashboardBindingList{} },
 )

--- a/pkg/apis/scope/v0alpha1/types.go
+++ b/pkg/apis/scope/v0alpha1/types.go
@@ -4,6 +4,11 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
+/*
+Please keep pkg/promlib/models/query.go and pkg/promlib/models/scope.go in sync
+with this file until this package is out of the grafana/grafana module.
+*/
+
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 type Scope struct {
 	metav1.TypeMeta   `json:",inline"`

--- a/pkg/promlib/models/query.go
+++ b/pkg/promlib/models/query.go
@@ -80,10 +80,21 @@ type ScopeSpec struct {
 // ScopeFilter is a hand copy of the ScopeFilter struct from pkg/apis/scope/v0alpha1/types.go
 // to avoid import (temp fix)
 type ScopeFilter struct {
-	Key      string `json:"key"`
-	Value    string `json:"value"`
-	Operator string `json:"operator"`
+	Key      string         `json:"key"`
+	Value    string         `json:"value"`
+	Operator FilterOperator `json:"operator"`
 }
+
+// FilterOperator is a hand copy of the ScopeFilter struct from pkg/apis/scope/v0alpha1/types.go
+type FilterOperator string
+
+// Hand copy of enum from pkg/apis/scope/v0alpha1/types.go
+const (
+	FilterOperatorEquals        FilterOperator = "equals"
+	FilterOperatorNotEquals     FilterOperator = "not-equals"
+	FilterOperatorRegexMatch    FilterOperator = "regex-match"
+	FilterOperatorRegexNotMatch FilterOperator = "regex-not-match"
+)
 
 // Internal interval and range variables
 const (

--- a/pkg/promlib/models/scope.go
+++ b/pkg/promlib/models/scope.go
@@ -63,13 +63,13 @@ func scopeFiltersToMatchers(filters []ScopeFilter) ([]*labels.Matcher, error) {
 	for _, f := range filters {
 		var mt labels.MatchType
 		switch f.Operator {
-		case "=":
+		case FilterOperatorEquals:
 			mt = labels.MatchEqual
-		case "!=":
+		case FilterOperatorNotEquals:
 			mt = labels.MatchNotEqual
-		case "=~":
+		case FilterOperatorRegexMatch:
 			mt = labels.MatchRegexp
-		case "!~":
+		case FilterOperatorRegexNotMatch:
 			mt = labels.MatchNotRegexp
 		default:
 			return nil, fmt.Errorf("unknown operator %q", f.Operator)

--- a/pkg/registry/apis/scope/register.go
+++ b/pkg/registry/apis/scope/register.go
@@ -68,7 +68,7 @@ func (b *ScopeAPIBuilder) InstallSchema(scheme *runtime.Scheme) error {
 	}
 
 	err = scheme.AddFieldLabelConversionFunc(
-		scope.ScopeDashboardResourceInfo.GroupVersionKind(),
+		scope.ScopeDashboardBindingResourceInfo.GroupVersionKind(),
 		func(label, value string) (string, string, error) {
 			fieldSet := SelectableScopeDashboardBindingFields(&scope.ScopeDashboardBinding{})
 			for key := range fieldSet {
@@ -76,7 +76,7 @@ func (b *ScopeAPIBuilder) InstallSchema(scheme *runtime.Scheme) error {
 					return label, value, nil
 				}
 			}
-			return "", "", fmt.Errorf("field label not supported for %s: %s", scope.ScopeDashboardResourceInfo.GroupVersionKind(), label)
+			return "", "", fmt.Errorf("field label not supported for %s: %s", scope.ScopeDashboardBindingResourceInfo.GroupVersionKind(), label)
 		},
 	)
 	if err != nil {
@@ -103,7 +103,7 @@ func (b *ScopeAPIBuilder) GetAPIGroupInfo(
 	apiGroupInfo := genericapiserver.NewDefaultAPIGroupInfo(scope.GROUP, scheme, metav1.ParameterCodec, codecs)
 
 	scopeResourceInfo := scope.ScopeResourceInfo
-	scopeDashboardResourceInfo := scope.ScopeDashboardResourceInfo
+	scopeDashboardResourceInfo := scope.ScopeDashboardBindingResourceInfo
 
 	storage := map[string]rest.Storage{}
 

--- a/pkg/registry/apis/scope/register.go
+++ b/pkg/registry/apis/scope/register.go
@@ -70,7 +70,7 @@ func (b *ScopeAPIBuilder) InstallSchema(scheme *runtime.Scheme) error {
 	err = scheme.AddFieldLabelConversionFunc(
 		scope.ScopeDashboardResourceInfo.GroupVersionKind(),
 		func(label, value string) (string, string, error) {
-			fieldSet := SelectableScopeDashboardFields(&scope.ScopeDashboard{})
+			fieldSet := SelectableScopeDashboardBindingFields(&scope.ScopeDashboardBinding{})
 			for key := range fieldSet {
 				if label == key {
 					return label, value, nil
@@ -113,7 +113,7 @@ func (b *ScopeAPIBuilder) GetAPIGroupInfo(
 	}
 	storage[scopeResourceInfo.StoragePath()] = scopeStorage
 
-	scopeDashboardStorage, err := newScopeDashboardStorage(scheme, optsGetter)
+	scopeDashboardStorage, err := newScopeDashboardBindingStorage(scheme, optsGetter)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/registry/apis/scope/register.go
+++ b/pkg/registry/apis/scope/register.go
@@ -54,13 +54,29 @@ func (b *ScopeAPIBuilder) InstallSchema(scheme *runtime.Scheme) error {
 	err = scheme.AddFieldLabelConversionFunc(
 		scope.ScopeResourceInfo.GroupVersionKind(),
 		func(label, value string) (string, string, error) {
-			fieldSet := SelectableFields(&scope.Scope{})
+			fieldSet := SelectableScopeFields(&scope.Scope{})
 			for key := range fieldSet {
 				if label == key {
 					return label, value, nil
 				}
 			}
 			return "", "", fmt.Errorf("field label not supported for %s: %s", scope.ScopeResourceInfo.GroupVersionKind(), label)
+		},
+	)
+	if err != nil {
+		return err
+	}
+
+	err = scheme.AddFieldLabelConversionFunc(
+		scope.ScopeDashboardResourceInfo.GroupVersionKind(),
+		func(label, value string) (string, string, error) {
+			fieldSet := SelectableScopeDashboardFields(&scope.ScopeDashboard{})
+			for key := range fieldSet {
+				if label == key {
+					return label, value, nil
+				}
+			}
+			return "", "", fmt.Errorf("field label not supported for %s: %s", scope.ScopeDashboardResourceInfo.GroupVersionKind(), label)
 		},
 	)
 	if err != nil {

--- a/pkg/registry/apis/scope/storage.go
+++ b/pkg/registry/apis/scope/storage.go
@@ -62,10 +62,10 @@ func newScopeStorage(scheme *runtime.Scheme, optsGetter generic.RESTOptionsGette
 	return &storage{Store: store}, nil
 }
 
-func newScopeDashboardStorage(scheme *runtime.Scheme, optsGetter generic.RESTOptionsGetter) (*storage, error) {
+func newScopeDashboardBindingStorage(scheme *runtime.Scheme, optsGetter generic.RESTOptionsGetter) (*storage, error) {
 	strategy := grafanaregistry.NewStrategy(scheme)
 
-	resourceInfo := scope.ScopeDashboardResourceInfo
+	resourceInfo := scope.ScopeDashboardBindingResourceInfo
 	store := &genericregistry.Store{
 		NewFunc:                   resourceInfo.NewFunc,
 		NewListFunc:               resourceInfo.NewListFunc,
@@ -104,10 +104,10 @@ func GetAttrs(obj runtime.Object) (labels.Set, fields.Set, error) {
 	if s, ok := obj.(*scope.Scope); ok {
 		return labels.Set(s.Labels), SelectableScopeFields(s), nil
 	}
-	if s, ok := obj.(*scope.ScopeDashboard); ok {
-		return labels.Set(s.Labels), SelectableScopeDashboardFields(s), nil
+	if s, ok := obj.(*scope.ScopeDashboardBinding); ok {
+		return labels.Set(s.Labels), SelectableScopeDashboardBindingFields(s), nil
 	}
-	return nil, nil, fmt.Errorf("not a scope or scopeDashboard object")
+	return nil, nil, fmt.Errorf("not a scope or ScopeDashboardBinding object")
 }
 
 // Matcher returns a generic.SelectionPredicate that matches on label and field selectors.
@@ -126,8 +126,8 @@ func SelectableScopeFields(obj *scope.Scope) fields.Set {
 	})
 }
 
-func SelectableScopeDashboardFields(obj *scope.ScopeDashboard) fields.Set {
+func SelectableScopeDashboardBindingFields(obj *scope.ScopeDashboardBinding) fields.Set {
 	return generic.MergeFieldsSets(generic.ObjectMetaFieldsSet(&obj.ObjectMeta, false), fields.Set{
-		"spec.scopeUid": obj.Spec.ScopeUID,
+		"spec.scope": obj.Spec.Scope,
 	})
 }

--- a/pkg/registry/apis/scope/storage.go
+++ b/pkg/registry/apis/scope/storage.go
@@ -101,12 +101,13 @@ func newScopeDashboardStorage(scheme *runtime.Scheme, optsGetter generic.RESTOpt
 }
 
 func GetAttrs(obj runtime.Object) (labels.Set, fields.Set, error) {
-	s, ok := obj.(*scope.Scope)
-	if !ok {
-		return nil, nil, fmt.Errorf("not a scope")
+	if s, ok := obj.(*scope.Scope); ok {
+		return labels.Set(s.Labels), SelectableScopeFields(s), nil
 	}
-
-	return labels.Set(s.Labels), SelectableFields(s), nil
+	if s, ok := obj.(*scope.ScopeDashboard); ok {
+		return labels.Set(s.Labels), SelectableScopeDashboardFields(s), nil
+	}
+	return nil, nil, fmt.Errorf("not a scope or scopeDashboard object")
 }
 
 // Matcher returns a generic.SelectionPredicate that matches on label and field selectors.
@@ -118,8 +119,15 @@ func Matcher(label labels.Selector, field fields.Selector) apistore.SelectionPre
 	}
 }
 
-func SelectableFields(obj *scope.Scope) fields.Set {
+func SelectableScopeFields(obj *scope.Scope) fields.Set {
 	return generic.MergeFieldsSets(generic.ObjectMetaFieldsSet(&obj.ObjectMeta, false), fields.Set{
-		"spec.type": obj.Spec.Type,
+		"spec.type":     obj.Spec.Type,
+		"spec.category": obj.Spec.Category,
+	})
+}
+
+func SelectableScopeDashboardFields(obj *scope.ScopeDashboard) fields.Set {
+	return generic.MergeFieldsSets(generic.ObjectMetaFieldsSet(&obj.ObjectMeta, false), fields.Set{
+		"spec.scopeUid": obj.Spec.ScopeUID,
 	})
 }


### PR DESCRIPTION
**What is this feature?**

 - Like https://github.com/grafana/grafana/pull/85169 but taking https://github.com/grafana/grafana/pull/84955 into account which renames `ScopeDashboard` to `ScopeDashboardBinding` (Additionally updates `ResourseInfo` to follow new name which was missed)
 - Updates Prometheus to use the new ScopeFilterOperators that were also changed in https://github.com/grafana/grafana/pull/84955 (e.g. `=` becomes `equals`)

**Special notes for your reviewer:**

 - New example url (where with `scope=whatev` whatev is the name (generatedName) of the scope: `/apis/scope.grafana.app/v0alpha1/namespaces/default/scopedashboardbindings?fieldSelector=spec.scope%3Dwhatev`
 - [ ] Question: I should be adding binding the name as well so the name changes in the API as well yes?
 - [x] I haven't verified if the FE is sending the new FilterOperator values when sending the scope in queries yet or not?
 
Example ScopeDashboardBinding creation:
```
###
POST http://admin:admin@localhost:3000/apis/scope.grafana.app/v0alpha1/namespaces/default/scopedashboardbindings
Content-Type: application/json
Accept: application/json

{
  "apiVersion": "scope.grafana.app/v0alpha1",
  "kind": "ScopeDashboardBinding",
  "metadata": {
    "generateName": "sdb"
  },
  "spec": {
    "dashboards": ["myID"],
    "scope": "fancyScope123"
  }
}
```

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
