### PR TITLE
Storage Server: Avoid incorrect parsing of connection string

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -38,6 +38,18 @@
           "--hg-key=$HGAPIKEY"]
     },
     {
+      "name": "Run Storage Server",
+      "type": "go",
+      "request": "launch",
+      "mode": "auto",
+      "program": "${workspaceFolder}/pkg/cmd/grafana/",
+      "env": {
+        "GF_DEFAULT_TARGET": "storage-server"
+      },
+      "cwd": "${workspaceFolder}",
+      "args": ["server", "target", "--homepath", "${workspaceFolder}", "--packaging", "dev"]
+    },
+    {
       "name": "Attach to Chrome",
       "port": 9222,
       "request": "attach",

--- a/pkg/services/store/entity/db/dbimpl/dbimpl.go
+++ b/pkg/services/store/entity/db/dbimpl/dbimpl.go
@@ -69,7 +69,7 @@ func (db *EntityDB) GetEngine() (*xorm.Engine, error) {
 			}
 
 			connectionString := fmt.Sprintf(
-				"user=%s password=%s host=%s port=%s dbname=%s sslmode=%s", // sslcert=%s sslkey=%s sslrootcert=%s",
+				"user='%s' password='%s' host='%s' port='%s' dbname='%s' sslmode='%s'", // sslcert='%s' sslkey='%s' sslrootcert='%s'",
 				dbUser, dbPass, addr.Host, addr.Port, dbName, dbSslMode, // ss.dbCfg.ClientCertPath, ss.dbCfg.ClientKeyPath, ss.dbCfg.CaCertPath
 			)
 


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

This is a fix to avoid incorrect parsing of connection string. The string is generated from config by storage server to connect to to the backing database.

**Why do we need this feature?**

In case of Postgres, we were generating the string like `"user=grafana pass= host=postgres.example port=4567"`.

This triggered an edge case in `pq` (the go postgres driver) to parse `pass` to be equal to `host=postgres.example`, and host being reset to default value.

Using single quotes in the connection string fixed this.


**Who is this feature for?**


**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->


**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
