### PR TITLE
Prometheus: Use correct logic for frontend package feature flag

### DIFF
--- a/public/app/plugins/datasource/prometheus/module.ts
+++ b/public/app/plugins/datasource/prometheus/module.ts
@@ -14,10 +14,10 @@ import { PrometheusDatasource } from './datasource';
 
 const usePackage = config.featureToggles.usePrometheusFrontendPackage;
 
-const PrometheusDataSourceUsed = usePackage ? PrometheusDatasource : PrometheusDatasourcePackage;
-const PromQueryEditorByAppUsed = usePackage ? PromQueryEditorByApp : PromQueryEditorByAppPackage;
-const ConfigEditorUsed = usePackage ? ConfigEditor : ConfigEditorPackage;
-const PromCheatSheetUsed = usePackage ? PromCheatSheet : PromCheatSheetPackage;
+const PrometheusDataSourceUsed = usePackage ? PrometheusDatasourcePackage : PrometheusDatasource;
+const PromQueryEditorByAppUsed = usePackage ? PromQueryEditorByAppPackage : PromQueryEditorByApp;
+const ConfigEditorUsed = usePackage ? ConfigEditorPackage : ConfigEditor;
+const PromCheatSheetUsed = usePackage ? PromCheatSheetPackage : PromCheatSheet;
 
 // @ts-ignore These type errors will be removed when we fully migrate to the @grafana/prometheus package
 export const plugin = new DataSourcePlugin(PrometheusDataSourceUsed)


### PR DESCRIPTION
This is a fix to use the correct logic for a feature toggle that uses the `grafana/prometheus` frontend package in grafana Prometheus data source.

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
