### PR TITLE
ci: Stop running ephemeral instances workflow when not needed

### DIFF
--- a/.github/workflows/ephemeral-instances-pr-comment.yml
+++ b/.github/workflows/ephemeral-instances-pr-comment.yml
@@ -4,7 +4,11 @@ on:
     types: [created]
 jobs:
   config:
-    runs-on: "ubuntu-latest"
+    if: github.event.sender.type == 'User' &&
+        github.event.issue.pull_request &&
+        startsWith(github.event.comment.body, '/deploy-to-hg')
+    runs-on:
+      labels: ubuntu-latest-8-cores
     outputs:
       has-secrets: ${{ steps.check.outputs.has-secrets }}
     steps:


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

Since https://github.com/grafana/grafana/pull/72503, the `config` job from the `Ephemeral instances: PR comment` workflow has been running on every comment. This is a regression as the `handle-pull-request-event` job only runs when necessary (i.e. when the appopriate PR comment is present).

**Why do we need this feature?**

Fixes a CI bug

**Who is this feature for?**

Internal maintainers

**Which issue(s) does this PR fix?**:

n/a

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
