### PR TITLE
CloudMigration:  Add service to list all migrations

### DIFF
--- a/pkg/services/cloudmigration/cloudmigration.go
+++ b/pkg/services/cloudmigration/cloudmigration.go
@@ -10,7 +10,7 @@ type Service interface {
 	SaveEncryptedToken(context.Context, string) error
 	// migration
 	GetMigration(context.Context, int64) (*CloudMigrationResponse, error)
-	GetMigrationList(context.Context) ([]CloudMigrationResponse, error)
+	GetMigrationList(context.Context) (*CloudMigrationListResponse, error)
 	CreateMigration(context.Context, CloudMigrationRequest) (*CloudMigrationResponse, error)
 	UpdateMigration(context.Context, int64, CloudMigrationRequest) (*CloudMigrationResponse, error)
 	RunMigration(context.Context, string) (*CloudMigrationRun, error)

--- a/pkg/services/cloudmigration/cloudmigrationimpl/cloudmigration.go
+++ b/pkg/services/cloudmigration/cloudmigrationimpl/cloudmigration.go
@@ -198,7 +198,7 @@ func (s *Service) GetMigration(ctx context.Context, id int64) (*cloudmigration.C
 	return nil, nil
 }
 
-func (s *Service) GetMigrationList(ctx context.Context) ([]cloudmigration.CloudMigrationResponse, error) {
+func (s *Service) GetMigrationList(ctx context.Context) (*cloudmigration.CloudMigrationListResponse, error) {
 	values, err := s.store.GetAllCloudMigrations(ctx)
 	if err != nil {
 		return nil, err
@@ -213,7 +213,7 @@ func (s *Service) GetMigrationList(ctx context.Context) ([]cloudmigration.CloudM
 			Updated: v.Updated,
 		})
 	}
-	return migrations, nil
+	return &cloudmigration.CloudMigrationListResponse{Migrations: migrations}, nil
 }
 
 func (s *Service) CreateMigration(ctx context.Context, cm cloudmigration.CloudMigrationRequest) (*cloudmigration.CloudMigrationResponse, error) {

--- a/pkg/services/cloudmigration/cloudmigrationimpl/cloudmigration.go
+++ b/pkg/services/cloudmigration/cloudmigrationimpl/cloudmigration.go
@@ -192,8 +192,9 @@ func (s *Service) SaveEncryptedToken(ctx context.Context, token string) error {
 }
 
 func (s *Service) GetMigration(ctx context.Context, id int64) (*cloudmigration.CloudMigrationResponse, error) {
-	ctx, span := s.tracer.Start(ctx, "CloudMigrationService.GetMigration")
-	defer span.End()
+	// commenting to fix linter, uncomment when this function is implemented
+	// ctx, span := s.tracer.Start(ctx, "CloudMigrationService.GetMigration")
+	// defer span.End()
 
 	return nil, nil
 }

--- a/pkg/services/cloudmigration/cloudmigrationimpl/cloudmigration.go
+++ b/pkg/services/cloudmigration/cloudmigrationimpl/cloudmigration.go
@@ -20,7 +20,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 )
 
-// CloudMigrationsServiceImpl Define the Service Implementation.
+// Service Define the cloudmigration.Service Implementation.
 type Service struct {
 	store store
 
@@ -192,13 +192,28 @@ func (s *Service) SaveEncryptedToken(ctx context.Context, token string) error {
 }
 
 func (s *Service) GetMigration(ctx context.Context, id int64) (*cloudmigration.CloudMigrationResponse, error) {
-	// TODO: Implement method
+	ctx, span := s.tracer.Start(ctx, "CloudMigrationService.GetMigration")
+	defer span.End()
+
 	return nil, nil
 }
 
 func (s *Service) GetMigrationList(ctx context.Context) ([]cloudmigration.CloudMigrationResponse, error) {
-	// TODO: Implement method
-	return nil, nil
+	values, err := s.store.GetAllCloudMigrations(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	migrations := make([]cloudmigration.CloudMigrationResponse, 0)
+	for _, v := range values {
+		migrations = append(migrations, cloudmigration.CloudMigrationResponse{
+			ID:      v.ID,
+			Stack:   v.Stack,
+			Created: v.Created,
+			Updated: v.Updated,
+		})
+	}
+	return migrations, nil
 }
 
 func (s *Service) CreateMigration(ctx context.Context, cm cloudmigration.CloudMigrationRequest) (*cloudmigration.CloudMigrationResponse, error) {

--- a/pkg/services/cloudmigration/cloudmigrationimpl/cloudmigration_noop.go
+++ b/pkg/services/cloudmigration/cloudmigrationimpl/cloudmigration_noop.go
@@ -30,7 +30,7 @@ func (s *NoopServiceImpl) GetMigration(ctx context.Context, id int64) (*cloudmig
 	return nil, cloudmigration.ErrFeatureDisabledError
 }
 
-func (s *NoopServiceImpl) GetMigrationList(ctx context.Context) ([]cloudmigration.CloudMigrationResponse, error) {
+func (s *NoopServiceImpl) GetMigrationList(ctx context.Context) (*cloudmigration.CloudMigrationListResponse, error) {
 	return nil, cloudmigration.ErrFeatureDisabledError
 }
 

--- a/pkg/services/cloudmigration/cloudmigrationimpl/store.go
+++ b/pkg/services/cloudmigration/cloudmigrationimpl/store.go
@@ -8,4 +8,5 @@ import (
 
 type store interface {
 	MigrateDatasources(context.Context, *cloudmigration.MigrateDatasourcesRequest) (*cloudmigration.MigrateDatasourcesResponse, error)
+	GetAllCloudMigrations(ctx context.Context) ([]*cloudmigration.CloudMigration, error)
 }

--- a/pkg/services/cloudmigration/cloudmigrationimpl/xorm_store.go
+++ b/pkg/services/cloudmigration/cloudmigrationimpl/xorm_store.go
@@ -2,6 +2,7 @@ package cloudmigrationimpl
 
 import (
 	"context"
+
 	"github.com/grafana/grafana/pkg/infra/db"
 	"github.com/grafana/grafana/pkg/services/cloudmigration"
 )

--- a/pkg/services/cloudmigration/cloudmigrationimpl/xorm_store.go
+++ b/pkg/services/cloudmigration/cloudmigrationimpl/xorm_store.go
@@ -2,7 +2,6 @@ package cloudmigrationimpl
 
 import (
 	"context"
-
 	"github.com/grafana/grafana/pkg/infra/db"
 	"github.com/grafana/grafana/pkg/services/cloudmigration"
 )
@@ -13,4 +12,13 @@ type sqlStore struct {
 
 func (ss *sqlStore) MigrateDatasources(ctx context.Context, request *cloudmigration.MigrateDatasourcesRequest) (*cloudmigration.MigrateDatasourcesResponse, error) {
 	return nil, cloudmigration.ErrInternalNotImplementedError
+}
+
+func (ss *sqlStore) GetAllCloudMigrations(ctx context.Context) ([]*cloudmigration.CloudMigration, error) {
+	var migrations = make([]*cloudmigration.CloudMigration, 0)
+	err := ss.db.WithDbSession(ctx, func(sess *db.Session) error { return sess.Find(&migrations) })
+	if err != nil {
+		return nil, err
+	}
+	return migrations, nil
 }

--- a/pkg/services/cloudmigration/cloudmigrationimpl/xorm_store_test.go
+++ b/pkg/services/cloudmigration/cloudmigrationimpl/xorm_store_test.go
@@ -1,9 +1,55 @@
 package cloudmigrationimpl
 
 import (
+	"context"
+	"strconv"
 	"testing"
+
+	"github.com/grafana/grafana/pkg/infra/db"
+	"github.com/grafana/grafana/pkg/tests/testsuite"
+	"github.com/stretchr/testify/require"
 )
+
+func TestMain(m *testing.M) {
+	testsuite.Run(m)
+}
 
 func TestMigrateDatasources(t *testing.T) {
 	// TODO: Write this test
+}
+
+func TestGetAllCloudMigrations(t *testing.T) {
+	testDB := db.InitTestDB(t)
+	s := &sqlStore{db: testDB}
+	ctx := context.Background()
+
+	t.Run("get all cloud_migrations", func(t *testing.T) {
+		// replace this with proper method when created
+		_, err := testDB.GetSqlxSession().Exec(ctx, `
+			INSERT INTO cloud_migration (id, auth_token, stack, created, updated)
+			VALUES (1, '12345', 'stack1', '2024-03-25 15:30:36.000', '2024-03-27 15:30:43.000'),
+ 				(2, '6789', 'stack2', '2024-03-25 15:30:36.000', '2024-03-27 15:30:43.000'),
+ 				(3, '777', 'stack3', '2024-03-25 15:30:36.000', '2024-03-27 15:30:43.000');
+		`)
+		require.NoError(t, err)
+
+		value, err := s.GetAllCloudMigrations(ctx)
+		require.NoError(t, err)
+		require.Equal(t, 3, len(value))
+		for _, m := range value {
+			switch m.ID {
+			case 1:
+				require.Equal(t, "stack1", m.Stack)
+				require.Equal(t, "12345", m.AuthToken)
+			case 2:
+				require.Equal(t, "stack2", m.Stack)
+				require.Equal(t, "6789", m.AuthToken)
+			case 3:
+				require.Equal(t, "stack3", m.Stack)
+				require.Equal(t, "777", m.AuthToken)
+			default:
+				require.Fail(t, "ID value not expected: "+strconv.FormatInt(m.ID, 10))
+			}
+		}
+	})
 }

--- a/pkg/services/cloudmigration/model.go
+++ b/pkg/services/cloudmigration/model.go
@@ -58,6 +58,10 @@ type CloudMigrationResponse struct {
 	Updated time.Time `json:"updated"`
 }
 
+type CloudMigrationListResponse struct {
+	Migrations []CloudMigrationResponse `json:"migrations"`
+}
+
 type MigrateDatasourcesRequest struct {
 	MigrateToPDC       bool
 	MigrateCredentials bool


### PR DESCRIPTION
**What is this feature?**
Adds the service to return all cloud migrations

Fixes https://github.com/grafana/grafana-operator-experience-squad/issues/709

Example response running locally:
![image](https://github.com/grafana/grafana/assets/34773040/8730f6ec-c64e-4045-95d2-242ebccc5017)

Notes:
In ticket it was only required that we return the stack id for each migration, but since we have this struct already created to return migration information, I decided to use the same, so it is the same information across the same API (and there is no private information exposed)

```golang
type CloudMigrationResponse struct {
	ID      int64     `json:"id"`
	Stack   string    `json:"stack"`
	Created time.Time `json:"created"`
	Updated time.Time `json:"updated"`
}

```

Please check that:
- [x] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
