### PR TITLE
Explore: Add padding to query content in query inspector

### DIFF
--- a/public/app/features/explore/ExploreQueryInspector.tsx
+++ b/public/app/features/explore/ExploreQueryInspector.tsx
@@ -1,10 +1,11 @@
+import { css } from '@emotion/css';
 import React, { useEffect, useState } from 'react';
 import { connect, ConnectedProps } from 'react-redux';
 
-import { CoreApp, LoadingState } from '@grafana/data';
+import { CoreApp, GrafanaTheme2, LoadingState } from '@grafana/data';
 import { reportInteraction } from '@grafana/runtime/src';
 import { defaultTimeZone, TimeZone } from '@grafana/schema';
-import { TabbedContainer, TabConfig } from '@grafana/ui';
+import { TabbedContainer, TabConfig, useStyles2 } from '@grafana/ui';
 import { requestIdGenerator } from 'app/core/utils/explore';
 import { ExploreDrawer } from 'app/features/explore/ExploreDrawer';
 import { InspectDataTab } from 'app/features/inspector/InspectDataTab';
@@ -40,6 +41,7 @@ export function ExploreQueryInspector(props: Props) {
   if (!errors?.length && queryResponse?.error) {
     errors = [queryResponse.error];
   }
+  const styles = useStyles2(getStyles);
 
   useEffect(() => {
     reportInteraction('grafana_explore_query_inspector_opened');
@@ -82,11 +84,13 @@ export function ExploreQueryInspector(props: Props) {
     value: 'query',
     icon: 'info-circle',
     content: (
-      <QueryInspector
-        instanceId={isMixed ? mixedRequestId(0, requestIdGenerator(exploreId)) : requestIdGenerator(exploreId)}
-        data={queryResponse}
-        onRefreshQuery={() => props.runQueries({ exploreId })}
-      />
+      <div className={styles.queryInspectorWrapper}>
+        <QueryInspector
+          instanceId={isMixed ? mixedRequestId(0, requestIdGenerator(exploreId)) : requestIdGenerator(exploreId)}
+          data={queryResponse}
+          onRefreshQuery={() => props.runQueries({ exploreId })}
+        />
+      </div>
     ),
   };
 
@@ -120,6 +124,12 @@ function mapStateToProps(state: StoreState, { exploreId }: { exploreId: string }
 const mapDispatchToProps = {
   runQueries,
 };
+
+const getStyles = (theme: GrafanaTheme2) => ({
+  queryInspectorWrapper: css({
+    paddingBottom: theme.spacing(3),
+  }),
+});
 
 const connector = connect(mapStateToProps, mapDispatchToProps);
 


### PR DESCRIPTION
This adds padding to the query tab of the query inspector. When the user scrolls to the bottom of the JSON content, there will be some padding, making it easier to expand the last field. 

Before:
![padding-before](https://github.com/grafana/grafana/assets/58232930/71e7001a-5597-47a5-b673-acd7783f960c)

After:
![Screenshot 2024-03-27 at 1 22 39 PM](https://github.com/grafana/grafana/assets/58232930/347f090c-006e-46a6-851f-b933b8e033fa)

Fixes #82408 

Please check that:
- [ ] It works as expected from a user's perspective.

