### PR TITLE
RBAC: Don't return an error if no resolver was found to mutate a scope

### DIFF
--- a/pkg/services/accesscontrol/acimpl/accesscontrol.go
+++ b/pkg/services/accesscontrol/acimpl/accesscontrol.go
@@ -2,7 +2,6 @@ package acimpl
 
 import (
 	"context"
-	"errors"
 
 	"github.com/prometheus/client_golang/prometheus"
 
@@ -56,9 +55,6 @@ func (a *AccessControl) Evaluate(ctx context.Context, user identity.Requester, e
 
 	resolvedEvaluator, err := evaluator.MutateScopes(ctx, a.resolvers.GetScopeAttributeMutator(user.GetOrgID()))
 	if err != nil {
-		if errors.Is(err, accesscontrol.ErrResolverNotFound) {
-			return false, nil
-		}
 		return false, err
 	}
 

--- a/pkg/services/accesscontrol/mock/mock.go
+++ b/pkg/services/accesscontrol/mock/mock.go
@@ -2,7 +2,6 @@ package mock
 
 import (
 	"context"
-	"errors"
 
 	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/plugins"
@@ -121,9 +120,6 @@ func (m *Mock) Evaluate(ctx context.Context, usr identity.Requester, evaluator a
 
 	resolvedEvaluator, err := evaluator.MutateScopes(ctx, m.scopeResolvers.GetScopeAttributeMutator(usr.GetOrgID()))
 	if err != nil {
-		if errors.Is(err, accesscontrol.ErrResolverNotFound) {
-			return false, nil
-		}
 		return false, err
 	}
 

--- a/pkg/services/accesscontrol/resolvers.go
+++ b/pkg/services/accesscontrol/resolvers.go
@@ -69,7 +69,9 @@ func (s *Resolvers) GetScopeAttributeMutator(orgID int64) ScopeAttributeMutator 
 			s.log.Debug("Resolved scope", "scope", scope, "resolved_scopes", scopes)
 			return scopes, nil
 		}
-		return nil, ErrResolverNotFound
+
+		// If there is no resolver registered for this scope, just return it as-is
+		return []string{scope}, nil
 	}
 }
 

--- a/pkg/services/accesscontrol/resolvers_test.go
+++ b/pkg/services/accesscontrol/resolvers_test.go
@@ -91,12 +91,11 @@ func TestResolvers_AttributeScope(t *testing.T) {
 			wantCalls:     1,
 		},
 		{
-			name:          "should return error if no resolver is found for scope",
+			name:          "should return same scope if no resolver is found for scope",
 			orgID:         1,
 			evaluator:     accesscontrol.EvalPermission("dashboards:read", "dashboards:id:1"),
-			wantEvaluator: nil,
+			wantEvaluator: accesscontrol.EvalPermission("dashboards:read", "dashboards:id:1"),
 			wantCalls:     0,
-			wantErr:       accesscontrol.ErrResolverNotFound,
 		},
 	}
 	for _, tt := range tests {


### PR DESCRIPTION
**What is this feature?**

This PR reverts part of https://github.com/grafana/grafana/pull/54208 in order to allow for `accesscontrol.EvalAll` to succeed if some scopes don't need mutation.

**Why do we need this feature?**

This prevents `EvalAll` from working as intended, which currently is causing rules to be hidden from the alerting API that should otherwise be returned.

<details>

<br/>

<summary>Example</summary>

If a user has `folder:read` with scope `folders:uid:general` and `datasources:query` with scope `datasources:uid:*` (i.e. permission to read in all folders and query all datasources) and we evaluate the following:

```go
accesscontrol.EvalAll(
	accesscontrol.EvalPermission(
		dashboards.ActionFoldersRead,
		dashboards.ScopeFoldersProvider.GetResourceScopeUID(<f_uid>)
	),
	accesscontrol.EvalPermission(
		datasources.ActionQuery, 
		datasources.ScopeProvider.GetResourceScopeUID(<ds_uid>)
	),
)
```
The user will be rejected for the action being guarded because permission eval fails when trying to resolve the `datasources:uid:<ds_uid>` scope.

<br/>

</details>

**Who is this feature for?**

Users of alerting API, and any future authorization logic that depends on this code path using `EvalAll`

**Which issue(s) does this PR fix?**:

Fixes #85319

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle.
- [x] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
