### PR TITLE
RBAC: handle partially resolved scopes

### DIFF
--- a/pkg/services/accesscontrol/evaluator_test.go
+++ b/pkg/services/accesscontrol/evaluator_test.go
@@ -428,7 +428,7 @@ func TestEval_MutateScopes(t *testing.T) {
 		assert.ErrorIs(t, err, ErrResolverNotFound)
 	})
 
-	t.Run("should return return if at least one scope was resolved", func(t *testing.T) {
+	t.Run("should return if at least one scope was resolved", func(t *testing.T) {
 		eval := EvalAll(
 			EvalPermission("action:1", "scope:uid:1"),
 			EvalPermission("action:2", "scope:id:1"),

--- a/pkg/services/accesscontrol/evaluator_test.go
+++ b/pkg/services/accesscontrol/evaluator_test.go
@@ -449,9 +449,10 @@ func TestEval_MutateScopes(t *testing.T) {
 		assert.Equal(t, 2, calls)
 		assert.Equal(t, 1, resolved)
 
-		eval.Evaluate(map[string][]string{
+		hasAccess := eval.Evaluate(map[string][]string{
 			"action:1": {"scope:uid:1"},
 			"action:2": {"scope:uid:2"},
 		})
+		assert.True(t, hasAccess)
 	})
 }

--- a/pkg/services/accesscontrol/evaluator_test.go
+++ b/pkg/services/accesscontrol/evaluator_test.go
@@ -410,3 +410,48 @@ func TestEval(t *testing.T) {
 		})
 	}
 }
+
+func TestEval_MutateScopes(t *testing.T) {
+	t.Run("should return error if none of the scopes was a resolved", func(t *testing.T) {
+		eval := EvalAll(
+			EvalPermission("action:1", "scope:uid:1"),
+			EvalPermission("action:2", "scope:id:1"),
+		)
+
+		calls := 0
+		_, err := eval.MutateScopes(context.Background(), func(ctx context.Context, s string) ([]string, error) {
+			calls += 1
+			return nil, ErrResolverNotFound
+		})
+
+		assert.Equal(t, 2, calls)
+		assert.ErrorIs(t, err, ErrResolverNotFound)
+	})
+
+	t.Run("should return return if at least one scope was resolved", func(t *testing.T) {
+		eval := EvalAll(
+			EvalPermission("action:1", "scope:uid:1"),
+			EvalPermission("action:2", "scope:id:1"),
+		)
+
+		calls := 0
+		resolved := 0
+		eval, err := eval.MutateScopes(context.Background(), func(ctx context.Context, s string) ([]string, error) {
+			calls += 1
+			if s == "scope:id:1" {
+				resolved += 1
+				return []string{"scope:uid:2"}, nil
+			}
+			return nil, ErrResolverNotFound
+		})
+
+		assert.NoError(t, err)
+		assert.Equal(t, 2, calls)
+		assert.Equal(t, 1, resolved)
+
+		eval.Evaluate(map[string][]string{
+			"action:1": {"scope:uid:1"},
+			"action:2": {"scope:uid:2"},
+		})
+	})
+}


### PR DESCRIPTION
**What is this feature?**
When resolving scopes something that we did not consider was when a subset of scopes is resolved but others are not.

To address this we always fallback to original evaluator if there was no resolver for it. We keep track if any evaluator was resolved and either exit early in the case nothing was resolved or retry evaluation if at least one scope was resolved. 

This is a alternative pr for https://github.com/grafana/grafana/pull/85320

**Why do we need this feature?**
To make partially resolved scopes work when using either `EvalAll` or `EvalAny`

**Who is this feature for?**
Users of alerting API, and any future authorization logic that depends on this code path using `EvalAll` or `EvalAny`
Fixes #

**Special notes for your reviewer:**



Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
