### PR TITLE
Scenes: Fix row crash when removing a panel from it

### DIFF
--- a/public/app/features/dashboard-scene/scene/DashboardScene.test.tsx
+++ b/public/app/features/dashboard-scene/scene/DashboardScene.test.tsx
@@ -537,7 +537,6 @@ describe('DashboardScene', () => {
         const body = scene.state.body as SceneGridLayout;
         const gridRow = body.state.children[2] as SceneGridRow;
 
-        console.log(gridRow.state.children);
         expect(gridRow.state.children.length).toBe(1);
       });
 

--- a/public/app/features/dashboard-scene/scene/DashboardScene.test.tsx
+++ b/public/app/features/dashboard-scene/scene/DashboardScene.test.tsx
@@ -30,6 +30,7 @@ import { DashboardControls } from './DashboardControls';
 import { DashboardGridItem } from './DashboardGridItem';
 import { DashboardScene, DashboardSceneState } from './DashboardScene';
 import { LibraryVizPanel } from './LibraryVizPanel';
+import { RowActions } from './row-actions/RowActions';
 
 jest.mock('../settings/version-history/HistorySrv');
 jest.mock('../serialization/transformSaveModelToScene');
@@ -535,6 +536,8 @@ describe('DashboardScene', () => {
 
         const body = scene.state.body as SceneGridLayout;
         const gridRow = body.state.children[2] as SceneGridRow;
+
+        console.log(gridRow.state.children);
         expect(gridRow.state.children.length).toBe(1);
       });
 
@@ -888,6 +891,7 @@ function buildTestScene(overrides?: Partial<DashboardSceneState>) {
         }),
         new SceneGridRow({
           key: 'panel-3',
+          actions: new RowActions({}),
           children: [
             new DashboardGridItem({
               body: new VizPanel({

--- a/public/app/features/dashboard-scene/scene/DashboardScene.tsx
+++ b/public/app/features/dashboard-scene/scene/DashboardScene.tsx
@@ -661,7 +661,7 @@ export class DashboardScene extends SceneObjectBase<DashboardSceneState> {
     }
 
     if (row) {
-      row.forEachChild((child: SceneObject) => {
+      row.state.children.forEach((child: SceneObject) => {
         if (child.state.key !== key) {
           panels.push(child);
         }


### PR DESCRIPTION
Fixes issue where removing a panel from a row in scenes would throw an error and glitch the dashboard row.

Fixes https://github.com/grafana/grafana/issues/84194