### PR TITLE
Azure/GCM: Update `filterQuery` methods to carry out migrations

### DIFF
--- a/public/app/plugins/datasource/azuremonitor/datasource.ts
+++ b/public/app/plugins/datasource/azuremonitor/datasource.ts
@@ -76,8 +76,10 @@ export default class Datasource extends DataSourceWithBackend<AzureMonitorQuery,
     if (!item.queryType) {
       return false;
     }
+
+    const query = migrateQuery(item);
     const ds = this.pseudoDatasource[item.queryType];
-    return ds?.filterQuery?.(item) ?? true;
+    return ds?.filterQuery?.(query) ?? true;
   }
 
   query(options: DataQueryRequest<AzureMonitorQuery>): Observable<DataQueryResponse> {

--- a/public/app/plugins/datasource/cloud-monitoring/datasource.ts
+++ b/public/app/plugins/datasource/cloud-monitoring/datasource.ts
@@ -303,10 +303,12 @@ export default class CloudMonitoringDatasource extends DataSourceWithBackend<
     }, {} as T);
   }
 
-  filterQuery(query: CloudMonitoringQuery): boolean {
-    if (query.hide) {
+  filterQuery(item: CloudMonitoringQuery): boolean {
+    if (item.hide) {
       return false;
     }
+
+    const query = this.migrateQuery(item);
 
     if (query.queryType === QueryType.SLO) {
       if (!query.sloQuery) {


### PR DESCRIPTION
Due to changes in #84656 the `filterQuery` method is now called before migrations on a query are executed. This means that older queries do not have the expected properties in the `filterQuery` methods and will be unexpectedly hidden.

This PR carries the migrations out as a part of the `filterQuery` method.