### PR TITLE
Chore: Replace sqlstore with db interface

### DIFF
--- a/pkg/api/folder_bench_test.go
+++ b/pkg/api/folder_bench_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/grafana/grafana/pkg/api/routing"
 	"github.com/grafana/grafana/pkg/bus"
 	"github.com/grafana/grafana/pkg/components/simplejson"
+	"github.com/grafana/grafana/pkg/infra/db"
 	"github.com/grafana/grafana/pkg/infra/localcache"
 	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/infra/tracing"
@@ -66,7 +67,7 @@ const (
 )
 
 type benchScenario struct {
-	db *sqlstore.SQLStore
+	db db.DB
 	// signedInUser is the user that is signed in to the server
 	cfg          *setting.Cfg
 	signedInUser *user.SignedInUser
@@ -448,7 +449,7 @@ func setupServer(b testing.TB, sc benchScenario, features featuremgmt.FeatureTog
 
 	quotaSrv := quotatest.New(false, nil)
 
-	dashStore, err := database.ProvideDashboardStore(sc.db, sc.db.Cfg, features, tagimpl.ProvideService(sc.db), quotaSrv)
+	dashStore, err := database.ProvideDashboardStore(sc.db, sc.cfg, features, tagimpl.ProvideService(sc.db), quotaSrv)
 	require.NoError(b, err)
 
 	folderStore := folderimpl.ProvideDashboardFolderStore(sc.db)

--- a/pkg/api/http_server.go
+++ b/pkg/api/http_server.go
@@ -96,7 +96,6 @@ import (
 	spm "github.com/grafana/grafana/pkg/services/secrets/kvstore/migrations"
 	"github.com/grafana/grafana/pkg/services/serviceaccounts"
 	"github.com/grafana/grafana/pkg/services/shorturls"
-	"github.com/grafana/grafana/pkg/services/sqlstore"
 	"github.com/grafana/grafana/pkg/services/star"
 	starApi "github.com/grafana/grafana/pkg/services/star/api"
 	"github.com/grafana/grafana/pkg/services/stats"
@@ -231,7 +230,7 @@ type ServerOptions struct {
 
 func ProvideHTTPServer(opts ServerOptions, cfg *setting.Cfg, routeRegister routing.RouteRegister, bus bus.Bus,
 	renderService rendering.Service, licensing licensing.Licensing, hooksService *hooks.HooksService,
-	cacheService *localcache.CacheService, sqlStore *sqlstore.SQLStore,
+	cacheService *localcache.CacheService, sqlStore db.DB,
 	pluginRequestValidator validations.PluginRequestValidator, pluginStaticRouteResolver plugins.StaticRouteResolver,
 	pluginDashboardService plugindashboards.Service, pluginStore pluginstore.Store, pluginClient plugins.Client,
 	pluginErrorResolver plugins.ErrorResolver, pluginInstaller plugins.Installer, settingsProvider setting.Provider,

--- a/pkg/server/test_env.go
+++ b/pkg/server/test_env.go
@@ -1,19 +1,21 @@
 package server
 
 import (
+	"github.com/grafana/grafana/pkg/infra/db"
 	"github.com/grafana/grafana/pkg/infra/httpclient"
 	"github.com/grafana/grafana/pkg/plugins/manager/registry"
 	"github.com/grafana/grafana/pkg/services/featuremgmt"
 	"github.com/grafana/grafana/pkg/services/grpcserver"
 	"github.com/grafana/grafana/pkg/services/notifications"
 	"github.com/grafana/grafana/pkg/services/oauthtoken/oauthtokentest"
-	"github.com/grafana/grafana/pkg/services/sqlstore"
+	"github.com/grafana/grafana/pkg/setting"
 	"github.com/grafana/grafana/pkg/web"
 )
 
 func ProvideTestEnv(
 	server *Server,
-	store *sqlstore.SQLStore,
+	db db.DB,
+	cfg *setting.Cfg,
 	ns *notifications.NotificationServiceMock,
 	grpcServer grpcserver.Provider,
 	pluginRegistry registry.Service,
@@ -23,7 +25,8 @@ func ProvideTestEnv(
 ) (*TestEnv, error) {
 	return &TestEnv{
 		Server:              server,
-		SQLStore:            store,
+		SQLStore:            db,
+		Cfg:                 cfg,
 		NotificationService: ns,
 		GRPCServer:          grpcServer,
 		PluginRegistry:      pluginRegistry,
@@ -35,7 +38,8 @@ func ProvideTestEnv(
 
 type TestEnv struct {
 	Server              *Server
-	SQLStore            *sqlstore.SQLStore
+	SQLStore            db.DB
+	Cfg                 *setting.Cfg
 	NotificationService *notifications.NotificationServiceMock
 	GRPCServer          grpcserver.Provider
 	PluginRegistry      registry.Service

--- a/pkg/server/wire.go
+++ b/pkg/server/wire.go
@@ -432,7 +432,7 @@ func Initialize(cfg *setting.Cfg, opts Options, apiOpts api.ServerOptions) (*Ser
 
 func InitializeForTest(t sqlutil.ITestDB, cfg *setting.Cfg, opts Options, apiOpts api.ServerOptions) (*TestEnv, error) {
 	wire.Build(wireExtsTestSet)
-	return &TestEnv{Server: &Server{}, SQLStore: &sqlstore.SQLStore{}}, nil
+	return &TestEnv{Server: &Server{}, SQLStore: &sqlstore.SQLStore{}, Cfg: &setting.Cfg{}}, nil
 }
 
 func InitializeForCLI(cfg *setting.Cfg) (Runner, error) {

--- a/pkg/services/accesscontrol/resourcepermissions/api_test.go
+++ b/pkg/services/accesscontrol/resourcepermissions/api_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/grafana/grafana/pkg/services/team/teamimpl"
 	"github.com/grafana/grafana/pkg/services/user"
 	"github.com/grafana/grafana/pkg/services/user/userimpl"
+	"github.com/grafana/grafana/pkg/setting"
 	"github.com/grafana/grafana/pkg/web"
 )
 
@@ -165,7 +166,7 @@ func TestApi_getPermissions(t *testing.T) {
 			service, sql, _ := setupTestEnvironment(t, testOptions)
 			server := setupTestServer(t, &user.SignedInUser{OrgID: 1, Permissions: map[int64]map[string][]string{1: accesscontrol.GroupScopesByAction(tt.permissions)}}, service)
 
-			seedPermissions(t, tt.resourceID, sql, service)
+			seedPermissions(t, tt.resourceID, sql, sql.Cfg, service)
 
 			permissions, recorder := getPermission(t, server, testOptions.Resource, tt.resourceID)
 			assert.Equal(t, tt.expectedStatus, recorder.Code)
@@ -505,19 +506,19 @@ func checkSeededPermissions(t *testing.T, permissions []resourcePermissionDTO) {
 	}
 }
 
-func seedPermissions(t *testing.T, resourceID string, sql db.DB, service *Service) {
+func seedPermissions(t *testing.T, resourceID string, sql db.DB, cfg *setting.Cfg, service *Service) {
 	t.Helper()
 	// seed team 1 with "Edit" permission on dashboard 1
-	teamSvc, err := teamimpl.ProvideService(sql, sql.Cfg)
+	teamSvc, err := teamimpl.ProvideService(sql, cfg)
 	require.NoError(t, err)
 	team, err := teamSvc.CreateTeam("test", "test@test.com", 1)
 	require.NoError(t, err)
 	_, err = service.SetTeamPermission(context.Background(), team.OrgID, team.ID, resourceID, "Edit")
 	require.NoError(t, err)
 	// seed user 1 with "View" permission on dashboard 1
-	orgSvc, err := orgimpl.ProvideService(sql, sql.Cfg, quotatest.New(false, nil))
+	orgSvc, err := orgimpl.ProvideService(sql, cfg, quotatest.New(false, nil))
 	require.NoError(t, err)
-	usrSvc, err := userimpl.ProvideService(sql, orgSvc, sql.Cfg, nil, nil, &quotatest.FakeQuotaService{}, supportbundlestest.NewFakeBundleService())
+	usrSvc, err := userimpl.ProvideService(sql, orgSvc, cfg, nil, nil, &quotatest.FakeQuotaService{}, supportbundlestest.NewFakeBundleService())
 	require.NoError(t, err)
 	u, err := usrSvc.Create(context.Background(), &user.CreateUserCommand{Login: "test", OrgID: 1})
 	require.NoError(t, err)

--- a/pkg/services/accesscontrol/resourcepermissions/api_test.go
+++ b/pkg/services/accesscontrol/resourcepermissions/api_test.go
@@ -116,7 +116,7 @@ func TestApi_getDescription(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.desc, func(t *testing.T) {
-			service, _, _ := setupTestEnvironment(t, tt.options)
+			service, _, _, _ := setupTestEnvironment(t, tt.options)
 			server := setupTestServer(t, &user.SignedInUser{OrgID: 1, Permissions: map[int64]map[string][]string{1: accesscontrol.GroupScopesByAction(tt.permissions)}}, service)
 
 			req, err := http.NewRequest(http.MethodGet, fmt.Sprintf("/api/access-control/%s/description", tt.options.Resource), nil)
@@ -163,10 +163,10 @@ func TestApi_getPermissions(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.desc, func(t *testing.T) {
-			service, sql, _ := setupTestEnvironment(t, testOptions)
+			service, sql, cfg, _ := setupTestEnvironment(t, testOptions)
 			server := setupTestServer(t, &user.SignedInUser{OrgID: 1, Permissions: map[int64]map[string][]string{1: accesscontrol.GroupScopesByAction(tt.permissions)}}, service)
 
-			seedPermissions(t, tt.resourceID, sql, sql.Cfg, service)
+			seedPermissions(t, tt.resourceID, sql, cfg, service)
 
 			permissions, recorder := getPermission(t, server, testOptions.Resource, tt.resourceID)
 			assert.Equal(t, tt.expectedStatus, recorder.Code)
@@ -240,7 +240,7 @@ func TestApi_setBuiltinRolePermission(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.desc, func(t *testing.T) {
-			service, _, _ := setupTestEnvironment(t, testOptions)
+			service, _, _, _ := setupTestEnvironment(t, testOptions)
 			server := setupTestServer(t, &user.SignedInUser{OrgID: 1, Permissions: map[int64]map[string][]string{1: accesscontrol.GroupScopesByAction(tt.permissions)}}, service)
 
 			recorder := setPermission(t, server, testOptions.Resource, tt.resourceID, tt.permission, "builtInRoles", tt.builtInRole)
@@ -318,7 +318,7 @@ func TestApi_setTeamPermission(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.desc, func(t *testing.T) {
-			service, _, teamSvc := setupTestEnvironment(t, testOptions)
+			service, _, _, teamSvc := setupTestEnvironment(t, testOptions)
 			server := setupTestServer(t, &user.SignedInUser{OrgID: 1, Permissions: map[int64]map[string][]string{1: accesscontrol.GroupScopesByAction(tt.permissions)}}, service)
 
 			// seed team
@@ -401,16 +401,16 @@ func TestApi_setUserPermission(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.desc, func(t *testing.T) {
-			service, sql, _ := setupTestEnvironment(t, testOptions)
+			service, sql, cfg, _ := setupTestEnvironment(t, testOptions)
 			server := setupTestServer(t, &user.SignedInUser{
 				OrgID:       1,
 				Permissions: map[int64]map[string][]string{1: accesscontrol.GroupScopesByAction(tt.permissions)},
 			}, service)
 
 			// seed user
-			orgSvc, err := orgimpl.ProvideService(sql, sql.Cfg, quotatest.New(false, nil))
+			orgSvc, err := orgimpl.ProvideService(sql, cfg, quotatest.New(false, nil))
 			require.NoError(t, err)
-			usrSvc, err := userimpl.ProvideService(sql, orgSvc, sql.Cfg, nil, nil, &quotatest.FakeQuotaService{}, supportbundlestest.NewFakeBundleService())
+			usrSvc, err := userimpl.ProvideService(sql, orgSvc, cfg, nil, nil, &quotatest.FakeQuotaService{}, supportbundlestest.NewFakeBundleService())
 			require.NoError(t, err)
 			_, err = usrSvc.Create(context.Background(), &user.CreateUserCommand{Login: "test", OrgID: 1})
 			require.NoError(t, err)

--- a/pkg/services/accesscontrol/resourcepermissions/api_test.go
+++ b/pkg/services/accesscontrol/resourcepermissions/api_test.go
@@ -13,13 +13,13 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/grafana/grafana/pkg/infra/db"
 	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/services/accesscontrol"
 	"github.com/grafana/grafana/pkg/services/contexthandler/ctxkey"
 	contextmodel "github.com/grafana/grafana/pkg/services/contexthandler/model"
 	"github.com/grafana/grafana/pkg/services/org/orgimpl"
 	"github.com/grafana/grafana/pkg/services/quota/quotatest"
-	"github.com/grafana/grafana/pkg/services/sqlstore"
 	"github.com/grafana/grafana/pkg/services/supportbundles/supportbundlestest"
 	"github.com/grafana/grafana/pkg/services/team/teamimpl"
 	"github.com/grafana/grafana/pkg/services/user"
@@ -505,7 +505,7 @@ func checkSeededPermissions(t *testing.T, permissions []resourcePermissionDTO) {
 	}
 }
 
-func seedPermissions(t *testing.T, resourceID string, sql *sqlstore.SQLStore, service *Service) {
+func seedPermissions(t *testing.T, resourceID string, sql db.DB, service *Service) {
 	t.Helper()
 	// seed team 1 with "Edit" permission on dashboard 1
 	teamSvc, err := teamimpl.ProvideService(sql, sql.Cfg)

--- a/pkg/services/accesscontrol/resourcepermissions/store_test.go
+++ b/pkg/services/accesscontrol/resourcepermissions/store_test.go
@@ -17,10 +17,10 @@ import (
 	"github.com/grafana/grafana/pkg/services/org/orgimpl"
 	"github.com/grafana/grafana/pkg/services/quota/quotatest"
 	"github.com/grafana/grafana/pkg/services/serviceaccounts"
-	"github.com/grafana/grafana/pkg/services/sqlstore"
 	"github.com/grafana/grafana/pkg/services/supportbundles/supportbundlestest"
 	"github.com/grafana/grafana/pkg/services/user"
 	"github.com/grafana/grafana/pkg/services/user/userimpl"
+	"github.com/grafana/grafana/pkg/setting"
 	"github.com/grafana/grafana/pkg/tests/testsuite"
 )
 
@@ -88,7 +88,7 @@ func TestIntegrationStore_SetUserResourcePermission(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.desc, func(t *testing.T) {
-			store, _ := setupTestEnv(t)
+			store, _, _ := setupTestEnv(t)
 
 			for _, s := range test.seeds {
 				_, err := store.SetUserResourcePermission(context.Background(), test.orgID, accesscontrol.User{ID: test.userID}, s, nil)
@@ -176,7 +176,7 @@ func TestIntegrationStore_SetTeamResourcePermission(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.desc, func(t *testing.T) {
-			store, _ := setupTestEnv(t)
+			store, _, _ := setupTestEnv(t)
 
 			for _, s := range test.seeds {
 				_, err := store.SetTeamResourcePermission(context.Background(), test.orgID, test.teamID, s, nil)
@@ -264,7 +264,7 @@ func TestIntegrationStore_SetBuiltInResourcePermission(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.desc, func(t *testing.T) {
-			store, _ := setupTestEnv(t)
+			store, _, _ := setupTestEnv(t)
 
 			for _, s := range test.seeds {
 				_, err := store.SetBuiltInResourcePermission(context.Background(), test.orgID, test.builtInRole, s, nil)
@@ -339,7 +339,7 @@ func TestIntegrationStore_SetResourcePermissions(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.desc, func(t *testing.T) {
-			store, _ := setupTestEnv(t)
+			store, _, _ := setupTestEnv(t)
 
 			permissions, err := store.SetResourcePermissions(context.Background(), tt.orgID, tt.commands, ResourceHooks{})
 			require.NoError(t, err)
@@ -469,8 +469,8 @@ func TestIntegrationStore_GetResourcePermissions(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.desc, func(t *testing.T) {
-			store, sql := setupTestEnv(t)
-			orgService, err := orgimpl.ProvideService(sql, sql.Cfg, quotatest.New(false, nil))
+			store, sql, cfg := setupTestEnv(t)
+			orgService, err := orgimpl.ProvideService(sql, cfg, quotatest.New(false, nil))
 			require.NoError(t, err)
 
 			err = sql.WithDbSession(context.Background(), func(sess *db.Session) error {
@@ -508,7 +508,7 @@ func TestIntegrationStore_GetResourcePermissions(t *testing.T) {
 			})
 			require.NoError(t, err)
 
-			seedResourcePermissions(t, store, sql, orgService, tt.query.Actions, tt.query.Resource, tt.query.ResourceID, tt.query.ResourceAttribute, tt.numUsers, tt.numServiceAccounts)
+			seedResourcePermissions(t, store, sql, cfg, orgService, tt.query.Actions, tt.query.Resource, tt.query.ResourceID, tt.query.ResourceAttribute, tt.numUsers, tt.numServiceAccounts)
 
 			tt.query.User = tt.user
 			permissions, err := store.GetResourcePermissions(context.Background(), tt.user.OrgID, tt.query)
@@ -519,7 +519,7 @@ func TestIntegrationStore_GetResourcePermissions(t *testing.T) {
 }
 
 func seedResourcePermissions(
-	t *testing.T, store *store, sql *sqlstore.SQLStore, orgService org.Service,
+	t *testing.T, store *store, sql db.DB, cfg *setting.Cfg, orgService org.Service,
 	actions []string, resource, resourceID, resourceAttribute string, numUsers, numServiceAccounts int,
 ) {
 	t.Helper()
@@ -527,7 +527,7 @@ func seedResourcePermissions(
 	orgID, err := orgService.GetOrCreate(context.Background(), "test")
 	require.NoError(t, err)
 
-	usrSvc, err := userimpl.ProvideService(sql, orgService, sql.Cfg, nil, nil, quotatest.New(false, nil), supportbundlestest.NewFakeBundleService())
+	usrSvc, err := userimpl.ProvideService(sql, orgService, cfg, nil, nil, quotatest.New(false, nil), supportbundlestest.NewFakeBundleService())
 	require.NoError(t, err)
 
 	create := func(login string, isServiceAccount bool) {
@@ -557,9 +557,9 @@ func seedResourcePermissions(
 	}
 }
 
-func setupTestEnv(t testing.TB) (*store, *sqlstore.SQLStore) {
+func setupTestEnv(t testing.TB) (*store, db.DB, *setting.Cfg) {
 	sql := db.InitTestDB(t)
-	return NewStore(sql, featuremgmt.WithFeatures()), sql
+	return NewStore(sql, featuremgmt.WithFeatures()), sql, sql.Cfg
 }
 
 func TestStore_IsInherited(t *testing.T) {
@@ -681,7 +681,7 @@ func TestIntegrationStore_DeleteResourcePermissions(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.desc, func(t *testing.T) {
-			store, _ := setupTestEnv(t)
+			store, _, _ := setupTestEnv(t)
 
 			_, err := store.SetResourcePermissions(context.Background(), 1, []SetResourcePermissionsCommand{
 				{

--- a/pkg/services/annotations/accesscontrol/accesscontrol_test.go
+++ b/pkg/services/annotations/accesscontrol/accesscontrol_test.go
@@ -28,8 +28,9 @@ func TestIntegrationAuthorize(t *testing.T) {
 	}
 
 	sql := db.InitTestDB(t)
+	cfg := sql.Cfg
 
-	dash1 := testutil.CreateDashboard(t, sql, featuremgmt.WithFeatures(), dashboards.SaveDashboardCommand{
+	dash1 := testutil.CreateDashboard(t, sql, cfg, featuremgmt.WithFeatures(), dashboards.SaveDashboardCommand{
 		UserID: 1,
 		OrgID:  1,
 		Dashboard: simplejson.NewFromAny(map[string]any{
@@ -37,7 +38,7 @@ func TestIntegrationAuthorize(t *testing.T) {
 		}),
 	})
 
-	dash2 := testutil.CreateDashboard(t, sql, featuremgmt.WithFeatures(), dashboards.SaveDashboardCommand{
+	dash2 := testutil.CreateDashboard(t, sql, cfg, featuremgmt.WithFeatures(), dashboards.SaveDashboardCommand{
 		UserID: 1,
 		OrgID:  1,
 		Dashboard: simplejson.NewFromAny(map[string]any{

--- a/pkg/services/annotations/annotationsimpl/annotations_test.go
+++ b/pkg/services/annotations/annotationsimpl/annotations_test.go
@@ -25,7 +25,6 @@ import (
 	"github.com/grafana/grafana/pkg/services/folder/folderimpl"
 	"github.com/grafana/grafana/pkg/services/guardian"
 	"github.com/grafana/grafana/pkg/services/quota/quotatest"
-	"github.com/grafana/grafana/pkg/services/sqlstore"
 	"github.com/grafana/grafana/pkg/services/supportbundles/supportbundlestest"
 	"github.com/grafana/grafana/pkg/services/tag/tagimpl"
 	"github.com/grafana/grafana/pkg/services/user"
@@ -51,7 +50,7 @@ func TestIntegrationAnnotationListingWithRBAC(t *testing.T) {
 
 	repo := ProvideService(sql, cfg, features, tagService)
 
-	dashboard1 := testutil.CreateDashboard(t, sql, features, dashboards.SaveDashboardCommand{
+	dashboard1 := testutil.CreateDashboard(t, sql, cfg, features, dashboards.SaveDashboardCommand{
 		UserID:   1,
 		OrgID:    1,
 		IsFolder: false,
@@ -60,7 +59,7 @@ func TestIntegrationAnnotationListingWithRBAC(t *testing.T) {
 		}),
 	})
 
-	_ = testutil.CreateDashboard(t, sql, features, dashboards.SaveDashboardCommand{
+	_ = testutil.CreateDashboard(t, sql, cfg, features, dashboards.SaveDashboardCommand{
 		UserID:   1,
 		OrgID:    1,
 		IsFolder: false,
@@ -209,7 +208,7 @@ func TestIntegrationAnnotationListingWithInheritedRBAC(t *testing.T) {
 	allDashboards := make([]dashInfo, 0, folder.MaxNestedFolderDepth+1)
 	annotationsTexts := make([]string, 0, folder.MaxNestedFolderDepth+1)
 
-	setupFolderStructure := func() *sqlstore.SQLStore {
+	setupFolderStructure := func() db.DB {
 		sql := db.InitTestDB(t)
 
 		// enable nested folders so that the folder table is populated for all the tests
@@ -253,7 +252,7 @@ func TestIntegrationAnnotationListingWithInheritedRBAC(t *testing.T) {
 				t.Fail()
 			}
 
-			dashboard := testutil.CreateDashboard(t, sql, features, dashboards.SaveDashboardCommand{
+			dashboard := testutil.CreateDashboard(t, sql, cfg, features, dashboards.SaveDashboardCommand{
 				UserID:   usr.UserID,
 				OrgID:    orgID,
 				IsFolder: false,

--- a/pkg/services/annotations/annotationsimpl/loki/historian_store_test.go
+++ b/pkg/services/annotations/annotationsimpl/loki/historian_store_test.go
@@ -43,8 +43,9 @@ func TestIntegrationAlertStateHistoryStore(t *testing.T) {
 	}
 
 	sql := db.InitTestDB(t)
+	cfg := sql.Cfg
 
-	dashboard1 := testutil.CreateDashboard(t, sql, featuremgmt.WithFeatures(), dashboards.SaveDashboardCommand{
+	dashboard1 := testutil.CreateDashboard(t, sql, cfg, featuremgmt.WithFeatures(), dashboards.SaveDashboardCommand{
 		UserID: 1,
 		OrgID:  1,
 		Dashboard: simplejson.NewFromAny(map[string]any{
@@ -52,7 +53,7 @@ func TestIntegrationAlertStateHistoryStore(t *testing.T) {
 		}),
 	})
 
-	dashboard2 := testutil.CreateDashboard(t, sql, featuremgmt.WithFeatures(), dashboards.SaveDashboardCommand{
+	dashboard2 := testutil.CreateDashboard(t, sql, cfg, featuremgmt.WithFeatures(), dashboards.SaveDashboardCommand{
 		UserID: 1,
 		OrgID:  1,
 		Dashboard: simplejson.NewFromAny(map[string]any{

--- a/pkg/services/annotations/annotationsimpl/xorm_store_test.go
+++ b/pkg/services/annotations/annotationsimpl/xorm_store_test.go
@@ -59,7 +59,7 @@ func TestIntegrationAnnotations(t *testing.T) {
 			assert.NoError(t, err)
 		})
 
-		dashboard := testutil.CreateDashboard(t, sql, featuremgmt.WithFeatures(), dashboards.SaveDashboardCommand{
+		dashboard := testutil.CreateDashboard(t, sql, cfg, featuremgmt.WithFeatures(), dashboards.SaveDashboardCommand{
 			UserID: 1,
 			OrgID:  1,
 			Dashboard: simplejson.NewFromAny(map[string]any{
@@ -67,7 +67,7 @@ func TestIntegrationAnnotations(t *testing.T) {
 			}),
 		})
 
-		dashboard2 := testutil.CreateDashboard(t, sql, featuremgmt.WithFeatures(), dashboards.SaveDashboardCommand{
+		dashboard2 := testutil.CreateDashboard(t, sql, cfg, featuremgmt.WithFeatures(), dashboards.SaveDashboardCommand{
 			UserID: 1,
 			OrgID:  1,
 			Dashboard: simplejson.NewFromAny(map[string]any{

--- a/pkg/services/annotations/testutil/testutil.go
+++ b/pkg/services/annotations/testutil/testutil.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/grafana/grafana/pkg/infra/db"
 	"github.com/grafana/grafana/pkg/services/accesscontrol"
 	"github.com/grafana/grafana/pkg/services/dashboards"
 	dashboardstore "github.com/grafana/grafana/pkg/services/dashboards/database"
@@ -13,10 +14,11 @@ import (
 	"github.com/grafana/grafana/pkg/services/sqlstore"
 	"github.com/grafana/grafana/pkg/services/tag/tagimpl"
 	"github.com/grafana/grafana/pkg/services/user"
+	"github.com/grafana/grafana/pkg/setting"
 	"github.com/stretchr/testify/require"
 )
 
-func SetupRBACRole(t *testing.T, db *sqlstore.SQLStore, user *user.SignedInUser) *accesscontrol.Role {
+func SetupRBACRole(t *testing.T, db db.DB, user *user.SignedInUser) *accesscontrol.Role {
 	t.Helper()
 
 	var role *accesscontrol.Role
@@ -49,7 +51,7 @@ func SetupRBACRole(t *testing.T, db *sqlstore.SQLStore, user *user.SignedInUser)
 	return role
 }
 
-func SetupRBACPermission(t *testing.T, db *sqlstore.SQLStore, role *accesscontrol.Role, user *user.SignedInUser) {
+func SetupRBACPermission(t *testing.T, db db.DB, role *accesscontrol.Role, user *user.SignedInUser) {
 	t.Helper()
 
 	err := db.WithDbSession(context.Background(), func(sess *sqlstore.DBSession) error {
@@ -76,12 +78,12 @@ func SetupRBACPermission(t *testing.T, db *sqlstore.SQLStore, role *accesscontro
 	require.NoError(t, err)
 }
 
-func CreateDashboard(t *testing.T, sql *sqlstore.SQLStore, features featuremgmt.FeatureToggles, cmd dashboards.SaveDashboardCommand) *dashboards.Dashboard {
+func CreateDashboard(t *testing.T, db db.DB, cfg *setting.Cfg, features featuremgmt.FeatureToggles, cmd dashboards.SaveDashboardCommand) *dashboards.Dashboard {
 	t.Helper()
 
 	dashboardStore, err := dashboardstore.ProvideDashboardStore(
-		sql,
-		sql.Cfg,
+		db,
+		cfg,
 		features,
 		tagimpl.ProvideService(sql),
 		quotatest.New(false, nil),

--- a/pkg/services/annotations/testutil/testutil.go
+++ b/pkg/services/annotations/testutil/testutil.go
@@ -85,7 +85,7 @@ func CreateDashboard(t *testing.T, db db.DB, cfg *setting.Cfg, features featurem
 		db,
 		cfg,
 		features,
-		tagimpl.ProvideService(sql),
+		tagimpl.ProvideService(db),
 		quotatest.New(false, nil),
 	)
 	require.NoError(t, err)

--- a/pkg/services/correlations/correlationstest/fake.go
+++ b/pkg/services/correlations/correlationstest/fake.go
@@ -2,22 +2,23 @@ package correlationstest
 
 import (
 	"github.com/grafana/grafana/pkg/api/routing"
+	"github.com/grafana/grafana/pkg/bus"
+	"github.com/grafana/grafana/pkg/infra/db"
 	"github.com/grafana/grafana/pkg/services/accesscontrol/acimpl"
 	"github.com/grafana/grafana/pkg/services/correlations"
 	"github.com/grafana/grafana/pkg/services/datasources"
 	fakeDatasources "github.com/grafana/grafana/pkg/services/datasources/fakes"
 	"github.com/grafana/grafana/pkg/services/quota/quotatest"
-	"github.com/grafana/grafana/pkg/services/sqlstore"
 	"github.com/grafana/grafana/pkg/setting"
 )
 
-func New(sqlStore *sqlstore.SQLStore) *correlations.CorrelationsService {
+func New(db db.DB, cfg *setting.Cfg, bus bus.Bus) *correlations.CorrelationsService {
 	ds := &fakeDatasources.FakeDataSourceService{
 		DataSources: []*datasources.DataSource{
 			{ID: 1, UID: "graphite", Type: datasources.DS_GRAPHITE},
 		},
 	}
 
-	correlationsSvc, _ := correlations.ProvideService(sqlStore, routing.NewRouteRegister(), ds, acimpl.ProvideAccessControl(setting.NewCfg()), sqlStore.Bus(), quotatest.New(false, nil), sqlStore.Cfg)
+	correlationsSvc, _ := correlations.ProvideService(db, routing.NewRouteRegister(), ds, acimpl.ProvideAccessControl(setting.NewCfg()), bus, quotatest.New(false, nil), cfg)
 	return correlationsSvc
 }

--- a/pkg/services/dashboards/database/database_test.go
+++ b/pkg/services/dashboards/database/database_test.go
@@ -43,7 +43,7 @@ func TestIntegrationDashboardDataAccess(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping integration test")
 	}
-	var sqlStore *sqlstore.SQLStore
+	var sqlStore db.DB
 	var cfg *setting.Cfg
 	var savedFolder, savedDash, savedDash2 *dashboards.Dashboard
 	var dashboardStore dashboards.Store

--- a/pkg/services/folder/folderimpl/dashboard_folder_store_test.go
+++ b/pkg/services/folder/folderimpl/dashboard_folder_store_test.go
@@ -12,7 +12,6 @@ import (
 	"github.com/grafana/grafana/pkg/services/dashboards/database"
 	"github.com/grafana/grafana/pkg/services/featuremgmt"
 	"github.com/grafana/grafana/pkg/services/quota/quotatest"
-	"github.com/grafana/grafana/pkg/services/sqlstore"
 	"github.com/grafana/grafana/pkg/services/tag/tagimpl"
 	"github.com/grafana/grafana/pkg/setting"
 	"github.com/grafana/grafana/pkg/tests/testsuite"
@@ -24,7 +23,7 @@ func TestMain(m *testing.M) {
 }
 
 func TestIntegrationDashboardFolderStore(t *testing.T) {
-	var sqlStore *sqlstore.SQLStore
+	var sqlStore db.DB
 	var cfg *setting.Cfg
 	var dashboardStore dashboards.Store
 
@@ -39,7 +38,7 @@ func TestIntegrationDashboardFolderStore(t *testing.T) {
 		setup()
 		var orgId int64 = 1
 		title := "Very Unique Name"
-		var sqlStore *sqlstore.SQLStore
+		var sqlStore db.DB
 		var folder1, folder2 *dashboards.Dashboard
 		sqlStore = db.InitTestDB(t)
 		folderStore := ProvideDashboardFolderStore(sqlStore)

--- a/pkg/services/folder/folderimpl/sqlstore_test.go
+++ b/pkg/services/folder/folderimpl/sqlstore_test.go
@@ -13,11 +13,13 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/grafana/grafana/pkg/infra/db"
 	"github.com/grafana/grafana/pkg/services/folder"
 	"github.com/grafana/grafana/pkg/services/org"
 	"github.com/grafana/grafana/pkg/services/org/orgimpl"
 	"github.com/grafana/grafana/pkg/services/quota/quotatest"
 	"github.com/grafana/grafana/pkg/services/sqlstore"
+	"github.com/grafana/grafana/pkg/setting"
 	"github.com/grafana/grafana/pkg/util"
 )
 
@@ -886,10 +888,10 @@ func TestIntegrationGetFolders(t *testing.T) {
 	})
 }
 
-func CreateOrg(t *testing.T, db *sqlstore.SQLStore) int64 {
+func CreateOrg(t *testing.T, db db.DB, cfg *setting.Cfg) int64 {
 	t.Helper()
 
-	orgService, err := orgimpl.ProvideService(db, db.Cfg, quotatest.New(false, nil))
+	orgService, err := orgimpl.ProvideService(db, cfg, quotatest.New(false, nil))
 	require.NoError(t, err)
 	orgID, err := orgService.GetOrCreate(context.Background(), "test-org")
 	require.NoError(t, err)

--- a/pkg/services/folder/folderimpl/sqlstore_test.go
+++ b/pkg/services/folder/folderimpl/sqlstore_test.go
@@ -34,7 +34,7 @@ func TestIntegrationCreate(t *testing.T) {
 	db := sqlstore.InitTestDB(t)
 	folderStore := ProvideStore(db, db.Cfg)
 
-	orgID := CreateOrg(t, db)
+	orgID := CreateOrg(t, db, db.Cfg)
 
 	t.Run("creating a folder without providing a UID should fail", func(t *testing.T) {
 		_, err := folderStore.Create(context.Background(), folder.CreateFolderCommand{
@@ -154,7 +154,7 @@ func TestIntegrationDelete(t *testing.T) {
 	db := sqlstore.InitTestDB(t)
 	folderStore := ProvideStore(db, db.Cfg)
 
-	orgID := CreateOrg(t, db)
+	orgID := CreateOrg(t, db, db.Cfg)
 
 	/*
 		t.Run("attempt to delete unknown folder should fail", func(t *testing.T) {
@@ -201,7 +201,7 @@ func TestIntegrationUpdate(t *testing.T) {
 	db := sqlstore.InitTestDB(t)
 	folderStore := ProvideStore(db, db.Cfg)
 
-	orgID := CreateOrg(t, db)
+	orgID := CreateOrg(t, db, db.Cfg)
 
 	// create parent folder
 	parent, err := folderStore.Create(context.Background(), folder.CreateFolderCommand{
@@ -376,7 +376,7 @@ func TestIntegrationGet(t *testing.T) {
 	db := sqlstore.InitTestDB(t)
 	folderStore := ProvideStore(db, db.Cfg)
 
-	orgID := CreateOrg(t, db)
+	orgID := CreateOrg(t, db, db.Cfg)
 
 	// create folder
 	uid1 := util.GenerateShortUID()
@@ -493,7 +493,7 @@ func TestIntegrationGetParents(t *testing.T) {
 	db := sqlstore.InitTestDB(t)
 	folderStore := ProvideStore(db, db.Cfg)
 
-	orgID := CreateOrg(t, db)
+	orgID := CreateOrg(t, db, db.Cfg)
 
 	// create folder
 	uid1 := util.GenerateShortUID()
@@ -561,7 +561,7 @@ func TestIntegrationGetChildren(t *testing.T) {
 	db := sqlstore.InitTestDB(t)
 	folderStore := ProvideStore(db, db.Cfg)
 
-	orgID := CreateOrg(t, db)
+	orgID := CreateOrg(t, db, db.Cfg)
 
 	// create folder
 	uid1 := util.GenerateShortUID()
@@ -741,7 +741,7 @@ func TestIntegrationGetHeight(t *testing.T) {
 	db := sqlstore.InitTestDB(t)
 	folderStore := ProvideStore(db, db.Cfg)
 
-	orgID := CreateOrg(t, db)
+	orgID := CreateOrg(t, db, db.Cfg)
 
 	// create folder
 	uid1 := util.GenerateShortUID()
@@ -774,7 +774,7 @@ func TestIntegrationGetFolders(t *testing.T) {
 	db := sqlstore.InitTestDB(t)
 	folderStore := ProvideStore(db, db.Cfg)
 
-	orgID := CreateOrg(t, db)
+	orgID := CreateOrg(t, db, db.Cfg)
 
 	// create folders
 	uids := make([]string, 0)

--- a/pkg/services/ngalert/store/alert_rule_test.go
+++ b/pkg/services/ngalert/store/alert_rule_test.go
@@ -24,7 +24,6 @@ import (
 	"github.com/grafana/grafana/pkg/services/folder/folderimpl"
 	"github.com/grafana/grafana/pkg/services/ngalert/testutil"
 	"github.com/grafana/grafana/pkg/services/org"
-	"github.com/grafana/grafana/pkg/services/sqlstore"
 	"github.com/grafana/grafana/pkg/services/user"
 
 	"github.com/stretchr/testify/require"
@@ -867,7 +866,7 @@ func createFolder(t *testing.T, store *DBstore, uid, title string, orgID int64, 
 	require.NoError(t, err)
 }
 
-func setupFolderService(t *testing.T, sqlStore *sqlstore.SQLStore, cfg *setting.Cfg, features featuremgmt.FeatureToggles) folder.Service {
+func setupFolderService(t *testing.T, sqlStore db.DB, cfg *setting.Cfg, features featuremgmt.FeatureToggles) folder.Service {
 	tracer := tracing.InitializeTracerForTest()
 	inProcBus := bus.ProvideBus(tracer)
 	folderStore := folderimpl.ProvideDashboardFolderStore(sqlStore)

--- a/pkg/services/ngalert/testutil/testutil.go
+++ b/pkg/services/ngalert/testutil/testutil.go
@@ -19,7 +19,6 @@ import (
 	"github.com/grafana/grafana/pkg/services/folder/foldertest"
 	"github.com/grafana/grafana/pkg/services/guardian"
 	"github.com/grafana/grafana/pkg/services/quota/quotatest"
-	"github.com/grafana/grafana/pkg/services/sqlstore"
 	"github.com/grafana/grafana/pkg/services/supportbundles/supportbundlestest"
 	"github.com/grafana/grafana/pkg/services/tag/tagimpl"
 	"github.com/grafana/grafana/pkg/setting"
@@ -30,7 +29,7 @@ func SetupFolderService(tb testing.TB, cfg *setting.Cfg, db db.DB, dashboardStor
 	return folderimpl.ProvideService(ac, bus, cfg, dashboardStore, folderStore, db, features, supportbundlestest.NewFakeBundleService(), nil)
 }
 
-func SetupDashboardService(tb testing.TB, sqlStore *sqlstore.SQLStore, fs *folderimpl.DashboardFolderStoreImpl, cfg *setting.Cfg) (*dashboardservice.DashboardServiceImpl, dashboards.Store) {
+func SetupDashboardService(tb testing.TB, sqlStore db.DB, fs *folderimpl.DashboardFolderStoreImpl, cfg *setting.Cfg) (*dashboardservice.DashboardServiceImpl, dashboards.Store) {
 	tb.Helper()
 
 	origNewGuardian := guardian.New
@@ -51,7 +50,7 @@ func SetupDashboardService(tb testing.TB, sqlStore *sqlstore.SQLStore, fs *folde
 	features := featuremgmt.WithFeatures()
 	quotaService := quotatest.New(false, nil)
 
-	dashboardStore, err := database.ProvideDashboardStore(sqlStore, sqlStore.Cfg, features, tagimpl.ProvideService(sqlStore), quotaService)
+	dashboardStore, err := database.ProvideDashboardStore(sqlStore, cfg, features, tagimpl.ProvideService(sqlStore), quotaService)
 	require.NoError(tb, err)
 
 	dashboardService, err := dashboardservice.ProvideDashboardServiceImpl(

--- a/pkg/services/org/orgimpl/store_test.go
+++ b/pkg/services/org/orgimpl/store_test.go
@@ -621,7 +621,7 @@ func TestIntegration_SQLStore_GetOrgUsers(t *testing.T) {
 	o, err := orgSvc.CreateWithMember(context.Background(), &org.CreateOrgCommand{Name: "test org"})
 	require.NoError(t, err)
 
-	seedOrgUsers(t, &orgUserStore, store, 10, userSvc, o.ID)
+	seedOrgUsers(t, &orgUserStore, 10, userSvc, o.ID)
 
 	tests := []struct {
 		desc             string
@@ -682,7 +682,7 @@ func TestIntegration_SQLStore_GetOrgUsers(t *testing.T) {
 	}
 }
 
-func seedOrgUsers(t *testing.T, orgUserStore store, store *sqlstore.SQLStore, numUsers int, usrSvc user.Service, orgID int64) {
+func seedOrgUsers(t *testing.T, orgUserStore store, numUsers int, usrSvc user.Service, orgID int64) {
 	t.Helper()
 
 	// Seed users
@@ -798,7 +798,7 @@ func TestIntegration_SQLStore_SearchOrgUsers(t *testing.T) {
 	o, err := orgSvc.CreateWithMember(context.Background(), &org.CreateOrgCommand{Name: "test org"})
 	require.NoError(t, err)
 
-	seedOrgUsers(t, &orgUserStore, store, 10, userSvc, o.ID)
+	seedOrgUsers(t, &orgUserStore, 10, userSvc, o.ID)
 
 	tests := []struct {
 		desc             string

--- a/pkg/services/pluginsintegration/plugins_integration_test.go
+++ b/pkg/services/pluginsintegration/plugins_integration_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/grafana/grafana/pkg/services/featuremgmt"
 	"github.com/grafana/grafana/pkg/services/pluginsintegration/pluginstore"
 	"github.com/grafana/grafana/pkg/services/searchV2"
+	"github.com/grafana/grafana/pkg/services/sqlstore"
 	"github.com/grafana/grafana/pkg/setting"
 	"github.com/grafana/grafana/pkg/tests/testsuite"
 	"github.com/grafana/grafana/pkg/tsdb/azuremonitor"
@@ -88,7 +89,7 @@ func TestIntegrationPluginManager(t *testing.T) {
 	pg := postgres.ProvideService(cfg)
 	my := mysql.ProvideService()
 	ms := mssql.ProvideService(cfg)
-	sv2 := searchV2.ProvideService(cfg, db.InitTestDB(t), nil, nil, tracer, features, nil, nil, nil)
+	sv2 := searchV2.ProvideService(cfg, db.InitTestDB(t, sqlstore.InitTestDBOpt{Cfg: cfg}), nil, nil, tracer, features, nil, nil, nil)
 	graf := grafanads.ProvideService(sv2, nil)
 	pyroscope := pyroscope.ProvideService(hcp)
 	parca := parca.ProvideService(hcp)

--- a/pkg/services/publicdashboards/database/database_test.go
+++ b/pkg/services/publicdashboards/database/database_test.go
@@ -20,7 +20,6 @@ import (
 	. "github.com/grafana/grafana/pkg/services/publicdashboards/models"
 	"github.com/grafana/grafana/pkg/services/publicdashboards/service"
 	"github.com/grafana/grafana/pkg/services/quota/quotatest"
-	"github.com/grafana/grafana/pkg/services/sqlstore"
 	"github.com/grafana/grafana/pkg/services/tag/tagimpl"
 	"github.com/grafana/grafana/pkg/services/user"
 	"github.com/grafana/grafana/pkg/setting"
@@ -48,7 +47,7 @@ func TestIntegrationListPublicDashboard(t *testing.T) {
 		t.Skip("skipping integration test")
 	}
 
-	var sqlStore *sqlstore.SQLStore
+	var sqlStore db.DB
 	var cfg *setting.Cfg
 
 	var aDash *dashboards.Dashboard
@@ -68,7 +67,7 @@ func TestIntegrationListPublicDashboard(t *testing.T) {
 		quotaService := quotatest.New(false, nil)
 		dashboardStore, err := dashboardsDB.ProvideDashboardStore(sqlStore, cfg, featuremgmt.WithFeatures(), tagimpl.ProvideService(sqlStore), quotaService)
 		require.NoError(t, err)
-		publicdashboardStore = ProvideStore(sqlStore, sqlStore.Cfg, featuremgmt.WithFeatures())
+		publicdashboardStore = ProvideStore(sqlStore, cfg, featuremgmt.WithFeatures())
 
 		bDash = insertTestDashboard(t, dashboardStore, "b", orgId, "", false)
 		aDash = insertTestDashboard(t, dashboardStore, "a", orgId, "", false)

--- a/pkg/services/publicdashboards/service/common_test.go
+++ b/pkg/services/publicdashboards/service/common_test.go
@@ -3,6 +3,7 @@ package service
 import (
 	"testing"
 
+	"github.com/grafana/grafana/pkg/infra/db"
 	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/services/annotations"
 	"github.com/grafana/grafana/pkg/services/annotations/annotationsimpl"
@@ -15,6 +16,7 @@ import (
 	"github.com/grafana/grafana/pkg/services/publicdashboards/service/intervalv2"
 	"github.com/grafana/grafana/pkg/services/sqlstore"
 	"github.com/grafana/grafana/pkg/services/tag/tagimpl"
+	"github.com/grafana/grafana/pkg/setting"
 )
 
 func newPublicDashboardServiceImpl(
@@ -22,17 +24,17 @@ func newPublicDashboardServiceImpl(
 	publicDashboardStore publicdashboards.Store,
 	dashboardService dashboards.DashboardService,
 	annotationsRepo annotations.Repository,
-) (*PublicDashboardServiceImpl, *sqlstore.SQLStore) {
+) (*PublicDashboardServiceImpl, db.DB, *setting.Cfg) {
 	t.Helper()
 
-	sqlStore := sqlstore.InitTestDB(t)
-	tagService := tagimpl.ProvideService(sqlStore)
+	db := sqlstore.InitTestDB(t)
+	tagService := tagimpl.ProvideService(db)
 	if annotationsRepo == nil {
-		annotationsRepo = annotationsimpl.ProvideService(sqlStore, sqlStore.Cfg, featuremgmt.WithFeatures(), tagService)
+		annotationsRepo = annotationsimpl.ProvideService(db, db.Cfg, featuremgmt.WithFeatures(), tagService)
 	}
 
 	if publicDashboardStore == nil {
-		publicDashboardStore = database.ProvideStore(sqlStore, sqlStore.Cfg, featuremgmt.WithFeatures())
+		publicDashboardStore = database.ProvideStore(db, db.Cfg, featuremgmt.WithFeatures())
 	}
 	serviceWrapper := ProvideServiceWrapper(publicDashboardStore)
 
@@ -48,5 +50,5 @@ func newPublicDashboardServiceImpl(
 		serviceWrapper:     serviceWrapper,
 		license:            license,
 		features:           featuremgmt.WithFeatures(),
-	}, sqlStore
+	}, db, db.Cfg
 }

--- a/pkg/services/publicdashboards/service/query_test.go
+++ b/pkg/services/publicdashboards/service/query_test.go
@@ -677,12 +677,12 @@ const (
 
 func TestGetQueryDataResponse(t *testing.T) {
 	fakeDashboardService := &dashboards.FakeDashboardService{}
-	service, sqlStore := newPublicDashboardServiceImpl(t, nil, fakeDashboardService, nil)
+	service, sqlStore, _ := newPublicDashboardServiceImpl(t, nil, fakeDashboardService, nil)
 	fakeQueryService := &query.FakeQueryService{}
 	fakeQueryService.On("QueryData", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&backend.QueryDataResponse{}, nil)
 	service.QueryDataService = fakeQueryService
 
-	dashboardStore, err := dashboardsDB.ProvideDashboardStore(sqlStore, sqlStore.Cfg, featuremgmt.WithFeatures(), tagimpl.ProvideService(sqlStore), quotatest.New(false, nil))
+	dashboardStore, err := dashboardsDB.ProvideDashboardStore(sqlStore, service.cfg, featuremgmt.WithFeatures(), tagimpl.ProvideService(sqlStore), quotatest.New(false, nil))
 	require.NoError(t, err)
 
 	publicDashboardQueryDTO := PublicDashboardQueryDTO{
@@ -739,7 +739,7 @@ func TestFindAnnotations(t *testing.T) {
 			Return(&PublicDashboard{Uid: "uid1", IsEnabled: true}, nil)
 		fakeDashboardService := &dashboards.FakeDashboardService{}
 		fakeDashboardService.On("GetDashboard", mock.Anything, mock.Anything, mock.Anything).Return(dashboards.NewDashboard("dash1"), nil)
-		service, _ := newPublicDashboardServiceImpl(t, fakeStore, fakeDashboardService, nil)
+		service, _, _ := newPublicDashboardServiceImpl(t, fakeStore, fakeDashboardService, nil)
 
 		reqDTO := AnnotationsQueryDTO{
 			From: 1,
@@ -792,7 +792,7 @@ func TestFindAnnotations(t *testing.T) {
 		fakeDashboardService := &dashboards.FakeDashboardService{}
 		fakeDashboardService.On("GetDashboard", mock.Anything, mock.Anything, mock.Anything).Return(dashboard, nil)
 
-		service, _ := newPublicDashboardServiceImpl(t, fakeStore, fakeDashboardService, annotationsRepo)
+		service, _, _ := newPublicDashboardServiceImpl(t, fakeStore, fakeDashboardService, annotationsRepo)
 
 		annotationsRepo.On("Find", mock.Anything, mock.Anything).Return([]*annotations.ItemDTO{
 			{
@@ -849,7 +849,7 @@ func TestFindAnnotations(t *testing.T) {
 		fakeDashboardService := &dashboards.FakeDashboardService{}
 		fakeDashboardService.On("GetDashboard", mock.Anything, mock.Anything, mock.Anything).Return(dashboard, nil)
 
-		service, _ := newPublicDashboardServiceImpl(t, fakeStore, fakeDashboardService, annotationsRepo)
+		service, _, _ := newPublicDashboardServiceImpl(t, fakeStore, fakeDashboardService, annotationsRepo)
 
 		annotationsRepo.On("Find", mock.Anything, mock.Anything).Return([]*annotations.ItemDTO{
 			{
@@ -918,7 +918,7 @@ func TestFindAnnotations(t *testing.T) {
 		fakeDashboardService := &dashboards.FakeDashboardService{}
 		fakeDashboardService.On("GetDashboard", mock.Anything, mock.Anything, mock.Anything).Return(dashboard, nil)
 
-		service, _ := newPublicDashboardServiceImpl(t, fakeStore, fakeDashboardService, annotationsRepo)
+		service, _, _ := newPublicDashboardServiceImpl(t, fakeStore, fakeDashboardService, annotationsRepo)
 
 		annotationsRepo.On("Find", mock.Anything, mock.Anything).Return([]*annotations.ItemDTO{
 			{
@@ -958,7 +958,7 @@ func TestFindAnnotations(t *testing.T) {
 		fakeStore.On("FindByAccessToken", mock.Anything, mock.AnythingOfType("string")).Return(pubdash, nil)
 		fakeDashboardService := &dashboards.FakeDashboardService{}
 		fakeDashboardService.On("GetDashboard", mock.Anything, mock.Anything, mock.Anything).Return(dashboard, nil)
-		service, _ := newPublicDashboardServiceImpl(t, fakeStore, fakeDashboardService, nil)
+		service, _, _ := newPublicDashboardServiceImpl(t, fakeStore, fakeDashboardService, nil)
 
 		items, err := service.FindAnnotations(context.Background(), AnnotationsQueryDTO{}, "abc123")
 
@@ -988,7 +988,7 @@ func TestFindAnnotations(t *testing.T) {
 		fakeStore.On("FindByAccessToken", mock.Anything, mock.AnythingOfType("string")).Return(pubdash, nil)
 		fakeDashboardService := &dashboards.FakeDashboardService{}
 		fakeDashboardService.On("GetDashboard", mock.Anything, mock.Anything, mock.Anything).Return(dashboard, nil)
-		service, _ := newPublicDashboardServiceImpl(t, fakeStore, fakeDashboardService, nil)
+		service, _, _ := newPublicDashboardServiceImpl(t, fakeStore, fakeDashboardService, nil)
 
 		items, err := service.FindAnnotations(context.Background(), AnnotationsQueryDTO{}, "abc123")
 
@@ -1020,7 +1020,7 @@ func TestFindAnnotations(t *testing.T) {
 		fakeDashboardService := &dashboards.FakeDashboardService{}
 		fakeDashboardService.On("GetDashboard", mock.Anything, mock.Anything, mock.Anything).Return(dash, nil)
 
-		service, _ := newPublicDashboardServiceImpl(t, fakeStore, fakeDashboardService, annotationsRepo)
+		service, _, _ := newPublicDashboardServiceImpl(t, fakeStore, fakeDashboardService, annotationsRepo)
 
 		items, err := service.FindAnnotations(context.Background(), AnnotationsQueryDTO{}, "abc123")
 
@@ -1061,7 +1061,7 @@ func TestFindAnnotations(t *testing.T) {
 			},
 		}, nil).Maybe()
 
-		service, _ := newPublicDashboardServiceImpl(t, fakeStore, fakeDashboardService, annotationsRepo)
+		service, _, _ := newPublicDashboardServiceImpl(t, fakeStore, fakeDashboardService, annotationsRepo)
 
 		items, err := service.FindAnnotations(context.Background(), AnnotationsQueryDTO{}, "abc123")
 
@@ -1084,8 +1084,8 @@ func TestFindAnnotations(t *testing.T) {
 }
 
 func TestGetMetricRequest(t *testing.T) {
-	service, sqlStore := newPublicDashboardServiceImpl(t, nil, nil, nil)
-	dashboardStore, err := dashboardsDB.ProvideDashboardStore(sqlStore, sqlStore.Cfg, featuremgmt.WithFeatures(), tagimpl.ProvideService(sqlStore), quotatest.New(false, nil))
+	service, sqlStore, cfg := newPublicDashboardServiceImpl(t, nil, nil, nil)
+	dashboardStore, err := dashboardsDB.ProvideDashboardStore(sqlStore, cfg, featuremgmt.WithFeatures(), tagimpl.ProvideService(sqlStore), quotatest.New(false, nil))
 	require.NoError(t, err)
 	dashboard := insertTestDashboard(t, dashboardStore, "testDashie", 1, 0, "", true, []map[string]interface{}{}, nil)
 
@@ -1165,9 +1165,9 @@ func TestGetUniqueDashboardDatasourceUids(t *testing.T) {
 
 func TestBuildMetricRequest(t *testing.T) {
 	fakeDashboardService := &dashboards.FakeDashboardService{}
-	service, sqlStore := newPublicDashboardServiceImpl(t, nil, fakeDashboardService, nil)
+	service, sqlStore, cfg := newPublicDashboardServiceImpl(t, nil, fakeDashboardService, nil)
 
-	dashboardStore, err := dashboardsDB.ProvideDashboardStore(sqlStore, sqlStore.Cfg, featuremgmt.WithFeatures(), tagimpl.ProvideService(sqlStore), quotatest.New(false, nil))
+	dashboardStore, err := dashboardsDB.ProvideDashboardStore(sqlStore, cfg, featuremgmt.WithFeatures(), tagimpl.ProvideService(sqlStore), quotatest.New(false, nil))
 	require.NoError(t, err)
 	publicDashboard := insertTestDashboard(t, dashboardStore, "testDashie", 1, 0, "", true, []map[string]interface{}{}, nil)
 	nonPublicDashboard := insertTestDashboard(t, dashboardStore, "testNonPublicDashie", 1, 0, "", true, []map[string]interface{}{}, nil)

--- a/pkg/services/publicdashboards/service/service_test.go
+++ b/pkg/services/publicdashboards/service/service_test.go
@@ -387,7 +387,7 @@ func TestGetPublicDashboardForView(t *testing.T) {
 			fakeStore.On("FindByAccessToken", mock.Anything, mock.Anything).Return(test.StoreResp.pd, test.StoreResp.err)
 			fakeDashboardService := &dashboards.FakeDashboardService{}
 			fakeDashboardService.On("GetDashboard", mock.Anything, mock.Anything, mock.Anything).Return(test.StoreResp.d, test.StoreResp.err)
-			service, _ := newPublicDashboardServiceImpl(t, fakeStore, fakeDashboardService, nil)
+			service, _, _ := newPublicDashboardServiceImpl(t, fakeStore, fakeDashboardService, nil)
 
 			dashboardFullWithMeta, err := service.GetPublicDashboardForView(context.Background(), test.AccessToken)
 			if test.ErrResp != nil {
@@ -496,7 +496,7 @@ func TestGetPublicDashboard(t *testing.T) {
 			fakeDashboardService.On("GetDashboard", mock.Anything, mock.Anything, mock.Anything).Return(test.StoreResp.d, test.StoreResp.err)
 			fakeStore := &FakePublicDashboardStore{}
 			fakeStore.On("FindByAccessToken", mock.Anything, mock.Anything).Return(test.StoreResp.pd, test.StoreResp.err)
-			service, _ := newPublicDashboardServiceImpl(t, fakeStore, fakeDashboardService, nil)
+			service, _, _ := newPublicDashboardServiceImpl(t, fakeStore, fakeDashboardService, nil)
 
 			pdc, dash, err := service.FindPublicDashboardAndDashboardByAccessToken(context.Background(), test.AccessToken)
 			if test.ErrResp != nil {
@@ -559,7 +559,7 @@ func TestGetEnabledPublicDashboard(t *testing.T) {
 			fakeStore.On("FindByAccessToken", mock.Anything, mock.Anything).Return(test.StoreResp.pd, test.StoreResp.err)
 			fakeDashboardService := &dashboards.FakeDashboardService{}
 			fakeDashboardService.On("GetDashboard", mock.Anything, mock.Anything, mock.Anything).Return(test.StoreResp.d, test.StoreResp.err)
-			service, _ := newPublicDashboardServiceImpl(t, fakeStore, fakeDashboardService, nil)
+			service, _, _ := newPublicDashboardServiceImpl(t, fakeStore, fakeDashboardService, nil)
 
 			pdc, dash, err := service.FindEnabledPublicDashboardAndDashboardByAccessToken(context.Background(), test.AccessToken)
 			if test.ErrResp != nil {
@@ -583,10 +583,10 @@ func TestGetEnabledPublicDashboard(t *testing.T) {
 func TestCreatePublicDashboard(t *testing.T) {
 	t.Run("Create public dashboard", func(t *testing.T) {
 		fakeDashboardService := &dashboards.FakeDashboardService{}
-		service, sqlStore := newPublicDashboardServiceImpl(t, nil, fakeDashboardService, nil)
+		service, sqlStore, cfg := newPublicDashboardServiceImpl(t, nil, fakeDashboardService, nil)
 
 		quotaService := quotatest.New(false, nil)
-		dashboardStore, err := dashboardsDB.ProvideDashboardStore(sqlStore, sqlStore.Cfg, featuremgmt.WithFeatures(), tagimpl.ProvideService(sqlStore), quotaService)
+		dashboardStore, err := dashboardsDB.ProvideDashboardStore(sqlStore, cfg, featuremgmt.WithFeatures(), tagimpl.ProvideService(sqlStore), quotaService)
 		require.NoError(t, err)
 		dashboard := insertTestDashboard(t, dashboardStore, "testDashie", 1, 0, "", true, []map[string]any{}, nil)
 		fakeDashboardService.On("GetDashboard", mock.Anything, mock.Anything, mock.Anything).Return(dashboard, nil)
@@ -664,9 +664,9 @@ func TestCreatePublicDashboard(t *testing.T) {
 	for _, tt := range testCases {
 		t.Run(fmt.Sprintf("Create public dashboard with %s null boolean fields stores them as false", tt.Name), func(t *testing.T) {
 			fakeDashboardService := &dashboards.FakeDashboardService{}
-			service, sqlStore := newPublicDashboardServiceImpl(t, nil, fakeDashboardService, nil)
+			service, sqlStore, cfg := newPublicDashboardServiceImpl(t, nil, fakeDashboardService, nil)
 			quotaService := quotatest.New(false, nil)
-			dashboardStore, err := dashboardsDB.ProvideDashboardStore(sqlStore, sqlStore.Cfg, featuremgmt.WithFeatures(), tagimpl.ProvideService(sqlStore), quotaService)
+			dashboardStore, err := dashboardsDB.ProvideDashboardStore(sqlStore, cfg, featuremgmt.WithFeatures(), tagimpl.ProvideService(sqlStore), quotaService)
 			require.NoError(t, err)
 			dashboard := insertTestDashboard(t, dashboardStore, "testDashie", 1, 0, "", true, []map[string]any{}, nil)
 			fakeDashboardService.On("GetDashboard", mock.Anything, mock.Anything, mock.Anything).Return(dashboard, nil)
@@ -696,9 +696,9 @@ func TestCreatePublicDashboard(t *testing.T) {
 
 	t.Run("Validate pubdash has default time setting value", func(t *testing.T) {
 		fakeDashboardService := &dashboards.FakeDashboardService{}
-		service, sqlStore := newPublicDashboardServiceImpl(t, nil, fakeDashboardService, nil)
+		service, sqlStore, cfg := newPublicDashboardServiceImpl(t, nil, fakeDashboardService, nil)
 		quotaService := quotatest.New(false, nil)
-		dashboardStore, err := dashboardsDB.ProvideDashboardStore(sqlStore, sqlStore.Cfg, featuremgmt.WithFeatures(), tagimpl.ProvideService(sqlStore), quotaService)
+		dashboardStore, err := dashboardsDB.ProvideDashboardStore(sqlStore, cfg, featuremgmt.WithFeatures(), tagimpl.ProvideService(sqlStore), quotaService)
 		require.NoError(t, err)
 		dashboard := insertTestDashboard(t, dashboardStore, "testDashie", 1, 0, "", true, []map[string]any{}, nil)
 		fakeDashboardService.On("GetDashboard", mock.Anything, mock.Anything, mock.Anything).Return(dashboard, nil)
@@ -723,9 +723,9 @@ func TestCreatePublicDashboard(t *testing.T) {
 
 	t.Run("Creates pubdash whose dashboard has template variables successfully", func(t *testing.T) {
 		fakeDashboardService := &dashboards.FakeDashboardService{}
-		service, sqlStore := newPublicDashboardServiceImpl(t, nil, fakeDashboardService, nil)
+		service, sqlStore, cfg := newPublicDashboardServiceImpl(t, nil, fakeDashboardService, nil)
 		quotaService := quotatest.New(false, nil)
-		dashboardStore, err := dashboardsDB.ProvideDashboardStore(sqlStore, sqlStore.Cfg, featuremgmt.WithFeatures(), tagimpl.ProvideService(sqlStore), quotaService)
+		dashboardStore, err := dashboardsDB.ProvideDashboardStore(sqlStore, cfg, featuremgmt.WithFeatures(), tagimpl.ProvideService(sqlStore), quotaService)
 		require.NoError(t, err)
 
 		templateVars := make([]map[string]any, 1)
@@ -769,7 +769,7 @@ func TestCreatePublicDashboard(t *testing.T) {
 		fakeDashboardService := &dashboards.FakeDashboardService{}
 		fakeDashboardService.On("GetDashboard", mock.Anything, mock.Anything, mock.Anything).Return(dashboard, nil)
 
-		service, _ := newPublicDashboardServiceImpl(t, publicDashboardStore, fakeDashboardService, nil)
+		service, _, _ := newPublicDashboardServiceImpl(t, publicDashboardStore, fakeDashboardService, nil)
 
 		isEnabled := true
 		dto := &SavePublicDashboardDTO{
@@ -789,9 +789,9 @@ func TestCreatePublicDashboard(t *testing.T) {
 
 	t.Run("Create public dashboard with given pubdash uid", func(t *testing.T) {
 		fakeDashboardService := &dashboards.FakeDashboardService{}
-		service, sqlStore := newPublicDashboardServiceImpl(t, nil, fakeDashboardService, nil)
+		service, sqlStore, cfg := newPublicDashboardServiceImpl(t, nil, fakeDashboardService, nil)
 		quotaService := quotatest.New(false, nil)
-		dashboardStore, err := dashboardsDB.ProvideDashboardStore(sqlStore, sqlStore.Cfg, featuremgmt.WithFeatures(), tagimpl.ProvideService(sqlStore), quotaService)
+		dashboardStore, err := dashboardsDB.ProvideDashboardStore(sqlStore, cfg, featuremgmt.WithFeatures(), tagimpl.ProvideService(sqlStore), quotaService)
 		require.NoError(t, err)
 		dashboard := insertTestDashboard(t, dashboardStore, "testDashie", 1, 0, "", true, []map[string]any{}, nil)
 		fakeDashboardService.On("GetDashboard", mock.Anything, mock.Anything, mock.Anything).Return(dashboard, nil)
@@ -835,7 +835,7 @@ func TestCreatePublicDashboard(t *testing.T) {
 		publicDashboardStore.On("FindByDashboardUid", mock.Anything, mock.Anything, mock.Anything).Return(nil, ErrPublicDashboardNotFound.Errorf(""))
 		fakeDashboardService := &dashboards.FakeDashboardService{}
 		fakeDashboardService.On("GetDashboard", mock.Anything, mock.Anything, mock.Anything).Return(dashboard, nil)
-		service, _ := newPublicDashboardServiceImpl(t, publicDashboardStore, fakeDashboardService, nil)
+		service, _, _ := newPublicDashboardServiceImpl(t, publicDashboardStore, fakeDashboardService, nil)
 
 		isEnabled := true
 		dto := &SavePublicDashboardDTO{
@@ -855,9 +855,9 @@ func TestCreatePublicDashboard(t *testing.T) {
 
 	t.Run("Create public dashboard with given pubdash access token", func(t *testing.T) {
 		fakeDashboardService := &dashboards.FakeDashboardService{}
-		service, sqlStore := newPublicDashboardServiceImpl(t, nil, fakeDashboardService, nil)
+		service, sqlStore, cfg := newPublicDashboardServiceImpl(t, nil, fakeDashboardService, nil)
 		quotaService := quotatest.New(false, nil)
-		dashboardStore, err := dashboardsDB.ProvideDashboardStore(sqlStore, sqlStore.Cfg, featuremgmt.WithFeatures(), tagimpl.ProvideService(sqlStore), quotaService)
+		dashboardStore, err := dashboardsDB.ProvideDashboardStore(sqlStore, cfg, featuremgmt.WithFeatures(), tagimpl.ProvideService(sqlStore), quotaService)
 		require.NoError(t, err)
 		dashboard := insertTestDashboard(t, dashboardStore, "testDashie", 1, 0, "", true, []map[string]interface{}{}, nil)
 		fakeDashboardService.On("GetDashboard", mock.Anything, mock.Anything, mock.Anything).Return(dashboard, nil)
@@ -895,7 +895,7 @@ func TestCreatePublicDashboard(t *testing.T) {
 
 		publicDashboardStore := &FakePublicDashboardStore{}
 		publicDashboardStore.On("FindByAccessToken", mock.Anything, mock.Anything).Return(pubdash, nil)
-		service, _ := newPublicDashboardServiceImpl(t, publicDashboardStore, nil, nil)
+		service, _, _ := newPublicDashboardServiceImpl(t, publicDashboardStore, nil, nil)
 
 		_, err := service.NewPublicDashboardAccessToken(context.Background())
 		require.Error(t, err)
@@ -907,9 +907,9 @@ func TestCreatePublicDashboard(t *testing.T) {
 		publicdashboardStore.On("FindByDashboardUid", mock.Anything, mock.Anything, mock.Anything).Return(&PublicDashboard{Uid: "newPubdashUid"}, nil)
 		publicdashboardStore.On("Find", mock.Anything, mock.Anything).Return(nil, nil)
 		fakeDashboardService := &dashboards.FakeDashboardService{}
-		service, sqlStore := newPublicDashboardServiceImpl(t, publicdashboardStore, fakeDashboardService, nil)
+		service, sqlStore, cfg := newPublicDashboardServiceImpl(t, publicdashboardStore, fakeDashboardService, nil)
 
-		dashboardStore, err := dashboardsDB.ProvideDashboardStore(sqlStore, sqlStore.Cfg, featuremgmt.WithFeatures(), tagimpl.ProvideService(sqlStore), quotatest.New(false, nil))
+		dashboardStore, err := dashboardsDB.ProvideDashboardStore(sqlStore, cfg, featuremgmt.WithFeatures(), tagimpl.ProvideService(sqlStore), quotatest.New(false, nil))
 		require.NoError(t, err)
 		dashboard := insertTestDashboard(t, dashboardStore, "testDashie", 1, 0, "", true, []map[string]any{}, nil)
 		fakeDashboardService.On("GetDashboard", mock.Anything, mock.Anything, mock.Anything).Return(dashboard, nil)
@@ -932,10 +932,10 @@ func TestCreatePublicDashboard(t *testing.T) {
 
 	t.Run("Validate pubdash has default share value", func(t *testing.T) {
 		fakeDashboardService := &dashboards.FakeDashboardService{}
-		service, sqlStore := newPublicDashboardServiceImpl(t, nil, fakeDashboardService, nil)
+		service, sqlStore, cfg := newPublicDashboardServiceImpl(t, nil, fakeDashboardService, nil)
 
 		quotaService := quotatest.New(false, nil)
-		dashboardStore, err := dashboardsDB.ProvideDashboardStore(sqlStore, sqlStore.Cfg, featuremgmt.WithFeatures(), tagimpl.ProvideService(sqlStore), quotaService)
+		dashboardStore, err := dashboardsDB.ProvideDashboardStore(sqlStore, cfg, featuremgmt.WithFeatures(), tagimpl.ProvideService(sqlStore), quotaService)
 		require.NoError(t, err)
 		dashboard := insertTestDashboard(t, dashboardStore, "testDashie", 1, 0, "", true, []map[string]any{}, nil)
 		fakeDashboardService.On("GetDashboard", mock.Anything, mock.Anything, mock.Anything).Return(dashboard, nil)
@@ -970,10 +970,10 @@ func assertFalseIfNull(t *testing.T, expectedValue bool, nullableValue *bool) {
 
 func TestUpdatePublicDashboard(t *testing.T) {
 	fakeDashboardService := &dashboards.FakeDashboardService{}
-	service, sqlStore := newPublicDashboardServiceImpl(t, nil, fakeDashboardService, nil)
+	service, sqlStore, cfg := newPublicDashboardServiceImpl(t, nil, fakeDashboardService, nil)
 
 	quotaService := quotatest.New(false, nil)
-	dashboardStore, err := dashboardsDB.ProvideDashboardStore(sqlStore, sqlStore.Cfg, featuremgmt.WithFeatures(), tagimpl.ProvideService(sqlStore), quotaService)
+	dashboardStore, err := dashboardsDB.ProvideDashboardStore(sqlStore, cfg, featuremgmt.WithFeatures(), tagimpl.ProvideService(sqlStore), quotaService)
 	require.NoError(t, err)
 	dashboard := insertTestDashboard(t, dashboardStore, "testDashie", 1, 0, "", true, []map[string]any{}, nil)
 	dashboard2 := insertTestDashboard(t, dashboardStore, "testDashie2", 1, 0, "", true, []map[string]any{}, nil)
@@ -1153,10 +1153,10 @@ func TestUpdatePublicDashboard(t *testing.T) {
 	for _, tt := range testCases {
 		t.Run(fmt.Sprintf("Update public dashboard with %s null boolean fields let those fields with old persisted value", tt.Name), func(t *testing.T) {
 			fakeDashboardService := &dashboards.FakeDashboardService{}
-			service, sqlStore := newPublicDashboardServiceImpl(t, nil, fakeDashboardService, nil)
+			service, sqlStore, cfg := newPublicDashboardServiceImpl(t, nil, fakeDashboardService, nil)
 
 			quotaService := quotatest.New(false, nil)
-			dashboardStore, err := dashboardsDB.ProvideDashboardStore(sqlStore, sqlStore.Cfg, featuremgmt.WithFeatures(), tagimpl.ProvideService(sqlStore), quotaService)
+			dashboardStore, err := dashboardsDB.ProvideDashboardStore(sqlStore, cfg, featuremgmt.WithFeatures(), tagimpl.ProvideService(sqlStore), quotaService)
 			require.NoError(t, err)
 			dashboard := insertTestDashboard(t, dashboardStore, "testDashie", 1, 0, "", true, []map[string]any{}, nil)
 			fakeDashboardService.On("GetDashboard", mock.Anything, mock.Anything, mock.Anything).Return(dashboard, nil)
@@ -1273,7 +1273,7 @@ func TestDeletePublicDashboard(t *testing.T) {
 			if tt.ExpectedErrResp == nil || tt.mockDeleteStore.StoreRespErr != nil {
 				store.On("Delete", mock.Anything, mock.Anything).Return(tt.mockDeleteStore.AffectedRowsResp, tt.mockDeleteStore.StoreRespErr)
 			}
-			service, _ := newPublicDashboardServiceImpl(t, store, nil, nil)
+			service, _, _ := newPublicDashboardServiceImpl(t, store, nil, nil)
 
 			err := service.Delete(context.Background(), "pubdashUID", "uid")
 			if tt.ExpectedErrResp != nil {
@@ -1490,7 +1490,7 @@ func TestPublicDashboardServiceImpl_ListPublicDashboards(t *testing.T) {
 			store := NewFakePublicDashboardStore(t)
 			store.On("FindAllWithPagination", mock.Anything, mock.Anything).
 				Return(tt.mockResponse.PublicDashboardListResponseWithPagination, tt.mockResponse.Err)
-			pd, _ := newPublicDashboardServiceImpl(t, store, nil, nil)
+			pd, _, _ := newPublicDashboardServiceImpl(t, store, nil, nil)
 			pd.ac = ac
 
 			got, err := pd.FindAllWithPagination(tt.args.ctx, tt.args.query)

--- a/pkg/services/searchV2/service_bench_test.go
+++ b/pkg/services/searchV2/service_bench_test.go
@@ -15,7 +15,6 @@ import (
 	"github.com/grafana/grafana/pkg/services/featuremgmt"
 	"github.com/grafana/grafana/pkg/services/org"
 	"github.com/grafana/grafana/pkg/services/org/orgtest"
-	"github.com/grafana/grafana/pkg/services/sqlstore"
 	"github.com/grafana/grafana/pkg/services/store"
 	"github.com/grafana/grafana/pkg/services/user"
 	"github.com/grafana/grafana/pkg/setting"
@@ -98,7 +97,7 @@ func runSearchService(searchService *StandardSearchService) error {
 }
 
 // Populates database with dashboards and folders
-func populateDB(folderCount, dashboardsPerFolder int, sqlStore *sqlstore.SQLStore) error {
+func populateDB(folderCount, dashboardsPerFolder int, sqlStore db.DB) error {
 	// Insert folders
 	offset := 1
 	if errInsert := actest.ConcurrentBatch(actest.Concurrency, folderCount, actest.BatchSize, func(start, end int) error {

--- a/pkg/services/secrets/manager/manager_test.go
+++ b/pkg/services/secrets/manager/manager_test.go
@@ -438,13 +438,13 @@ func TestIntegration_SecretsService(t *testing.T) {
 	ctx := context.Background()
 	someData := []byte(`some-data`)
 
-	tcs := map[string]func(*testing.T, *sqlstore.SQLStore, *SecretsService){
-		"regular": func(t *testing.T, _ *sqlstore.SQLStore, svc *SecretsService) {
+	tcs := map[string]func(*testing.T, db.DB, *SecretsService){
+		"regular": func(t *testing.T, _ db.DB, svc *SecretsService) {
 			// We encrypt some data normally, no transactions implied.
 			_, err := svc.Encrypt(ctx, someData, secrets.WithoutScope())
 			require.NoError(t, err)
 		},
-		"within successful InTransaction": func(t *testing.T, store *sqlstore.SQLStore, svc *SecretsService) {
+		"within successful InTransaction": func(t *testing.T, store db.DB, svc *SecretsService) {
 			require.NoError(t, store.InTransaction(ctx, func(ctx context.Context) error {
 				// We encrypt some data within a transaction that shares the db session.
 				_, err := svc.Encrypt(ctx, someData, secrets.WithoutScope())
@@ -454,7 +454,7 @@ func TestIntegration_SecretsService(t *testing.T) {
 				return nil
 			}))
 		},
-		"within unsuccessful InTransaction": func(t *testing.T, store *sqlstore.SQLStore, svc *SecretsService) {
+		"within unsuccessful InTransaction": func(t *testing.T, store db.DB, svc *SecretsService) {
 			require.NotNil(t, store.InTransaction(ctx, func(ctx context.Context) error {
 				// We encrypt some data within a transaction that shares the db session.
 				_, err := svc.Encrypt(ctx, someData, secrets.WithoutScope())
@@ -464,7 +464,7 @@ func TestIntegration_SecretsService(t *testing.T) {
 				return errors.New("error")
 			}))
 		},
-		"within unsuccessful InTransaction (plus forced db fetch)": func(t *testing.T, store *sqlstore.SQLStore, svc *SecretsService) {
+		"within unsuccessful InTransaction (plus forced db fetch)": func(t *testing.T, store db.DB, svc *SecretsService) {
 			require.NotNil(t, store.InTransaction(ctx, func(ctx context.Context) error {
 				// We encrypt some data within a transaction that shares the db session.
 				encrypted, err := svc.Encrypt(ctx, someData, secrets.WithoutScope())
@@ -483,7 +483,7 @@ func TestIntegration_SecretsService(t *testing.T) {
 				return errors.New("error")
 			}))
 		},
-		"within successful WithTransactionalDbSession": func(t *testing.T, store *sqlstore.SQLStore, svc *SecretsService) {
+		"within successful WithTransactionalDbSession": func(t *testing.T, store db.DB, svc *SecretsService) {
 			require.NoError(t, store.WithTransactionalDbSession(ctx, func(sess *sqlstore.DBSession) error {
 				// We encrypt some data within a transaction that does not share the db session.
 				_, err := svc.Encrypt(ctx, someData, secrets.WithoutScope())
@@ -493,7 +493,7 @@ func TestIntegration_SecretsService(t *testing.T) {
 				return nil
 			}))
 		},
-		"within unsuccessful WithTransactionalDbSession": func(t *testing.T, store *sqlstore.SQLStore, svc *SecretsService) {
+		"within unsuccessful WithTransactionalDbSession": func(t *testing.T, store db.DB, svc *SecretsService) {
 			require.NotNil(t, store.WithTransactionalDbSession(ctx, func(sess *sqlstore.DBSession) error {
 				// We encrypt some data within a transaction that does not share the db session.
 				_, err := svc.Encrypt(ctx, someData, secrets.WithoutScope())
@@ -503,7 +503,7 @@ func TestIntegration_SecretsService(t *testing.T) {
 				return errors.New("error")
 			}))
 		},
-		"within unsuccessful WithTransactionalDbSession (plus forced db fetch)": func(t *testing.T, store *sqlstore.SQLStore, svc *SecretsService) {
+		"within unsuccessful WithTransactionalDbSession (plus forced db fetch)": func(t *testing.T, store db.DB, svc *SecretsService) {
 			require.NotNil(t, store.WithTransactionalDbSession(ctx, func(sess *sqlstore.DBSession) error {
 				// We encrypt some data within a transaction that does not share the db session.
 				encrypted, err := svc.Encrypt(ctx, someData, secrets.WithoutScope())

--- a/pkg/services/serviceaccounts/database/stats_test.go
+++ b/pkg/services/serviceaccounts/database/stats_test.go
@@ -16,9 +16,9 @@ import (
 func TestIntegrationStore_UsageStats(t *testing.T) {
 	saToCreate := tests.TestUser{Login: "servicetestwithTeam@admin", IsServiceAccount: true}
 	db, store := setupTestDatabase(t)
-	sa := tests.SetupUserServiceAccount(t, db, saToCreate)
+	sa := tests.SetupUserServiceAccount(t, db, store.cfg, saToCreate)
 
-	db.Cfg.SATokenExpirationDayLimit = 4
+	store.cfg.SATokenExpirationDayLimit = 4
 
 	keyName := t.Name()
 	key, err := satokengen.New(keyName)

--- a/pkg/services/serviceaccounts/database/store_test.go
+++ b/pkg/services/serviceaccounts/database/store_test.go
@@ -289,7 +289,7 @@ func TestStore_MigrateApiKeys(t *testing.T) {
 			store.cfg.AutoAssignOrgRole = "Viewer"
 			_, err := store.orgService.CreateWithMember(context.Background(), &org.CreateOrgCommand{Name: "main"})
 			require.NoError(t, err)
-			key := tests.SetupApiKey(t, db, c.key)
+			key := tests.SetupApiKey(t, db, store.cfg, c.key)
 			err = store.MigrateApiKey(context.Background(), key.OrgID, key.ID)
 			if c.expectedErr != nil {
 				require.ErrorIs(t, err, c.expectedErr)
@@ -402,7 +402,7 @@ func TestStore_MigrateAllApiKeys(t *testing.T) {
 			require.NoError(t, err)
 
 			for _, key := range c.keys {
-				tests.SetupApiKey(t, db, key)
+				tests.SetupApiKey(t, db, store.cfg, key)
 			}
 
 			results, err := store.MigrateApiKeysToServiceAccounts(context.Background(), c.orgId)

--- a/pkg/services/serviceaccounts/database/token_store_test.go
+++ b/pkg/services/serviceaccounts/database/token_store_test.go
@@ -14,7 +14,7 @@ import (
 func TestStore_AddServiceAccountToken(t *testing.T) {
 	userToCreate := tests.TestUser{Login: "servicetestwithTeam@admin", IsServiceAccount: true}
 	db, store := setupTestDatabase(t)
-	user := tests.SetupUserServiceAccount(t, db, db.Cfg, userToCreate)
+	user := tests.SetupUserServiceAccount(t, db, store.cfg, userToCreate)
 
 	type testCasesAdd struct {
 		secondsToLive int64
@@ -76,7 +76,7 @@ func TestStore_AddServiceAccountToken(t *testing.T) {
 func TestStore_AddServiceAccountToken_WrongServiceAccount(t *testing.T) {
 	saToCreate := tests.TestUser{Login: "servicetestwithTeam@admin", IsServiceAccount: true}
 	db, store := setupTestDatabase(t)
-	sa := tests.SetupUserServiceAccount(t, db, db.Cfg, saToCreate)
+	sa := tests.SetupUserServiceAccount(t, db, store.cfg, saToCreate)
 
 	keyName := t.Name()
 	key, err := apikeygen.New(sa.OrgID, keyName)
@@ -96,7 +96,7 @@ func TestStore_AddServiceAccountToken_WrongServiceAccount(t *testing.T) {
 func TestStore_RevokeServiceAccountToken(t *testing.T) {
 	userToCreate := tests.TestUser{Login: "servicetestwithTeam@admin", IsServiceAccount: true}
 	db, store := setupTestDatabase(t)
-	sa := tests.SetupUserServiceAccount(t, db, db.Cfg, userToCreate)
+	sa := tests.SetupUserServiceAccount(t, db, store.cfg, userToCreate)
 
 	keyName := t.Name()
 	key, err := apikeygen.New(sa.OrgID, keyName)
@@ -136,7 +136,7 @@ func TestStore_RevokeServiceAccountToken(t *testing.T) {
 func TestStore_DeleteServiceAccountToken(t *testing.T) {
 	userToCreate := tests.TestUser{Login: "servicetestwithTeam@admin", IsServiceAccount: true}
 	db, store := setupTestDatabase(t)
-	sa := tests.SetupUserServiceAccount(t, db, db.Cfg, userToCreate)
+	sa := tests.SetupUserServiceAccount(t, db, store.cfg, userToCreate)
 
 	keyName := t.Name()
 	key, err := apikeygen.New(sa.OrgID, keyName)

--- a/pkg/services/serviceaccounts/database/token_store_test.go
+++ b/pkg/services/serviceaccounts/database/token_store_test.go
@@ -14,7 +14,7 @@ import (
 func TestStore_AddServiceAccountToken(t *testing.T) {
 	userToCreate := tests.TestUser{Login: "servicetestwithTeam@admin", IsServiceAccount: true}
 	db, store := setupTestDatabase(t)
-	user := tests.SetupUserServiceAccount(t, db, userToCreate)
+	user := tests.SetupUserServiceAccount(t, db, db.Cfg, userToCreate)
 
 	type testCasesAdd struct {
 		secondsToLive int64
@@ -76,7 +76,7 @@ func TestStore_AddServiceAccountToken(t *testing.T) {
 func TestStore_AddServiceAccountToken_WrongServiceAccount(t *testing.T) {
 	saToCreate := tests.TestUser{Login: "servicetestwithTeam@admin", IsServiceAccount: true}
 	db, store := setupTestDatabase(t)
-	sa := tests.SetupUserServiceAccount(t, db, saToCreate)
+	sa := tests.SetupUserServiceAccount(t, db, db.Cfg, saToCreate)
 
 	keyName := t.Name()
 	key, err := apikeygen.New(sa.OrgID, keyName)
@@ -96,7 +96,7 @@ func TestStore_AddServiceAccountToken_WrongServiceAccount(t *testing.T) {
 func TestStore_RevokeServiceAccountToken(t *testing.T) {
 	userToCreate := tests.TestUser{Login: "servicetestwithTeam@admin", IsServiceAccount: true}
 	db, store := setupTestDatabase(t)
-	sa := tests.SetupUserServiceAccount(t, db, userToCreate)
+	sa := tests.SetupUserServiceAccount(t, db, db.Cfg, userToCreate)
 
 	keyName := t.Name()
 	key, err := apikeygen.New(sa.OrgID, keyName)
@@ -136,7 +136,7 @@ func TestStore_RevokeServiceAccountToken(t *testing.T) {
 func TestStore_DeleteServiceAccountToken(t *testing.T) {
 	userToCreate := tests.TestUser{Login: "servicetestwithTeam@admin", IsServiceAccount: true}
 	db, store := setupTestDatabase(t)
-	sa := tests.SetupUserServiceAccount(t, db, userToCreate)
+	sa := tests.SetupUserServiceAccount(t, db, db.Cfg, userToCreate)
 
 	keyName := t.Name()
 	key, err := apikeygen.New(sa.OrgID, keyName)

--- a/pkg/services/serviceaccounts/manager/service.go
+++ b/pkg/services/serviceaccounts/manager/service.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/grafana/grafana/pkg/infra/db"
 	"github.com/grafana/grafana/pkg/infra/kvstore"
 	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/infra/usagestats"
@@ -15,7 +16,6 @@ import (
 	"github.com/grafana/grafana/pkg/services/serviceaccounts"
 	"github.com/grafana/grafana/pkg/services/serviceaccounts/database"
 	"github.com/grafana/grafana/pkg/services/serviceaccounts/secretscan"
-	"github.com/grafana/grafana/pkg/services/sqlstore"
 	"github.com/grafana/grafana/pkg/services/user"
 	"github.com/grafana/grafana/pkg/setting"
 )
@@ -39,7 +39,7 @@ type ServiceAccountsService struct {
 func ProvideServiceAccountsService(
 	cfg *setting.Cfg,
 	usageStats usagestats.Service,
-	store *sqlstore.SQLStore,
+	store db.DB,
 	apiKeyService apikey.Service,
 	kvStore kvstore.KVStore,
 	userService user.Service,

--- a/pkg/services/ssosettings/database/database_test.go
+++ b/pkg/services/ssosettings/database/database_test.go
@@ -9,7 +9,6 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/grafana/grafana/pkg/infra/db"
-	"github.com/grafana/grafana/pkg/services/sqlstore"
 	"github.com/grafana/grafana/pkg/services/ssosettings"
 	"github.com/grafana/grafana/pkg/services/ssosettings/models"
 	"github.com/grafana/grafana/pkg/tests/testsuite"
@@ -91,7 +90,7 @@ func TestIntegrationUpsertSSOSettings(t *testing.T) {
 		t.Skip("skipping integration test")
 	}
 
-	var sqlStore *sqlstore.SQLStore
+	var sqlStore db.DB
 	var ssoSettingsStore *SSOSettingsStore
 
 	setup := func() {
@@ -270,7 +269,7 @@ func TestIntegrationListSSOSettings(t *testing.T) {
 		t.Skip("skipping integration test")
 	}
 
-	var sqlStore *sqlstore.SQLStore
+	var sqlStore db.DB
 	var ssoSettingsStore *SSOSettingsStore
 
 	setup := func() {
@@ -336,7 +335,7 @@ func TestIntegrationDeleteSSOSettings(t *testing.T) {
 		t.Skip("skipping integration test")
 	}
 
-	var sqlStore *sqlstore.SQLStore
+	var sqlStore db.DB
 	var ssoSettingsStore *SSOSettingsStore
 
 	setup := func() {
@@ -478,7 +477,7 @@ func populateSSOSettings(sqlStore db.DB, template models.SSOSettings, providers 
 	})
 }
 
-func getSSOSettingsCountByDeleted(sqlStore *sqlstore.SQLStore) (deleted, notDeleted int64, err error) {
+func getSSOSettingsCountByDeleted(sqlStore db.DB) (deleted, notDeleted int64, err error) {
 	err = sqlStore.WithDbSession(context.Background(), func(sess *db.Session) error {
 		deleted, err = sess.Table("sso_setting").Where("is_deleted = ?", sqlStore.GetDialect().BooleanStr(true)).Count()
 		if err != nil {
@@ -491,7 +490,7 @@ func getSSOSettingsCountByDeleted(sqlStore *sqlstore.SQLStore) (deleted, notDele
 	return
 }
 
-func getSSOSettingsByProvider(sqlStore *sqlstore.SQLStore, provider string, deleted bool) (*models.SSOSettings, error) {
+func getSSOSettingsByProvider(sqlStore db.DB, provider string, deleted bool) (*models.SSOSettings, error) {
 	var model models.SSOSettings
 	var err error
 

--- a/pkg/services/ssosettings/database/database_test.go
+++ b/pkg/services/ssosettings/database/database_test.go
@@ -28,7 +28,7 @@ func TestIntegrationGetSSOSettings(t *testing.T) {
 		t.Skip("skipping integration test")
 	}
 
-	var sqlStore *sqlstore.SQLStore
+	var sqlStore db.DB
 	var ssoSettingsStore *SSOSettingsStore
 
 	setup := func() {
@@ -458,7 +458,7 @@ func TestIntegrationDeleteSSOSettings(t *testing.T) {
 	})
 }
 
-func populateSSOSettings(sqlStore *sqlstore.SQLStore, template models.SSOSettings, providers ...string) error {
+func populateSSOSettings(sqlStore db.DB, template models.SSOSettings, providers ...string) error {
 	return sqlStore.WithDbSession(context.Background(), func(sess *db.Session) error {
 		for _, provider := range providers {
 			settings := models.SSOSettings{

--- a/pkg/services/stats/statsimpl/stats_test.go
+++ b/pkg/services/stats/statsimpl/stats_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/grafana/grafana/pkg/bus"
 	"github.com/grafana/grafana/pkg/infra/db"
+	"github.com/grafana/grafana/pkg/infra/tracing"
 	"github.com/grafana/grafana/pkg/services/correlations"
 	"github.com/grafana/grafana/pkg/services/correlations/correlationstest"
 	"github.com/grafana/grafana/pkg/services/org"
@@ -89,7 +90,8 @@ func populateDB(t *testing.T, db db.DB, cfg *setting.Cfg) {
 	orgService, _ := orgimpl.ProvideService(db, cfg, quotatest.New(false, nil))
 	userSvc, _ := userimpl.ProvideService(db, orgService, cfg, nil, nil, &quotatest.FakeQuotaService{}, supportbundlestest.NewFakeBundleService())
 
-	correlationsSvc := correlationstest.New(db, cfg, &bus.InProcBus{})
+	bus := bus.ProvideBus(tracing.InitializeTracerForTest())
+	correlationsSvc := correlationstest.New(db, cfg, bus)
 
 	c := make([]correlations.Correlation, 2)
 	for i := range c {

--- a/pkg/services/store/entity/tests/common_test.go
+++ b/pkg/services/store/entity/tests/common_test.go
@@ -28,7 +28,7 @@ func TestMain(m *testing.M) {
 func createServiceAccountAdminToken(t *testing.T, env *server.TestEnv) (string, *user.SignedInUser) {
 	t.Helper()
 
-	account := saTests.SetupUserServiceAccount(t, env.SQLStore, saTests.TestUser{
+	account := saTests.SetupUserServiceAccount(t, env.SQLStore, env.SQLStore.Cfg, saTests.TestUser{
 		Name:             "grpc-server-sa",
 		Role:             string(org.RoleAdmin),
 		Login:            "grpc-server-sa",
@@ -38,7 +38,7 @@ func createServiceAccountAdminToken(t *testing.T, env *server.TestEnv) (string, 
 	keyGen, err := satokengen.New(saAPI.ServiceID)
 	require.NoError(t, err)
 
-	_ = saTests.SetupApiKey(t, env.SQLStore, saTests.TestApiKey{
+	_ = saTests.SetupApiKey(t, env.SQLStore, env.SQLStore.Cfg, saTests.TestApiKey{
 		Name:             "grpc-server-test",
 		Role:             org.RoleAdmin,
 		OrgId:            account.OrgID,

--- a/pkg/services/store/entity/tests/common_test.go
+++ b/pkg/services/store/entity/tests/common_test.go
@@ -28,7 +28,7 @@ func TestMain(m *testing.M) {
 func createServiceAccountAdminToken(t *testing.T, env *server.TestEnv) (string, *user.SignedInUser) {
 	t.Helper()
 
-	account := saTests.SetupUserServiceAccount(t, env.SQLStore, env.SQLStore.Cfg, saTests.TestUser{
+	account := saTests.SetupUserServiceAccount(t, env.SQLStore, env.Cfg, saTests.TestUser{
 		Name:             "grpc-server-sa",
 		Role:             string(org.RoleAdmin),
 		Login:            "grpc-server-sa",
@@ -38,7 +38,7 @@ func createServiceAccountAdminToken(t *testing.T, env *server.TestEnv) (string, 
 	keyGen, err := satokengen.New(saAPI.ServiceID)
 	require.NoError(t, err)
 
-	_ = saTests.SetupApiKey(t, env.SQLStore, env.SQLStore.Cfg, saTests.TestApiKey{
+	_ = saTests.SetupApiKey(t, env.SQLStore, env.Cfg, saTests.TestApiKey{
 		Name:             "grpc-server-test",
 		Role:             org.RoleAdmin,
 		OrgId:            account.OrgID,
@@ -79,7 +79,7 @@ func createTestContext(t *testing.T) testContext {
 
 	authToken, serviceAccountUser := createServiceAccountAdminToken(t, env)
 
-	eDB, err := dbimpl.ProvideEntityDB(env.SQLStore, env.SQLStore.Cfg, env.FeatureToggles)
+	eDB, err := dbimpl.ProvideEntityDB(env.SQLStore, env.Cfg, env.FeatureToggles)
 	require.NoError(t, err)
 
 	err = eDB.Init()

--- a/pkg/services/store/testdata/public_testdata.golden.jsonc
+++ b/pkg/services/store/testdata/public_testdata.golden.jsonc
@@ -12,15 +12,15 @@
 //  }
 //  Name: 
 //  Dimensions: 3 Fields by 3 Rows
-//  +----------------------------+----------------------+---------------+
-//  | Name: name                 | Name: mediaType      | Name: size    |
-//  | Labels:                    | Labels:              | Labels:       |
-//  | Type: []string             | Type: []string       | Type: []int64 |
-//  +----------------------------+----------------------+---------------+
-//  | countries.geojson          | application/geo+json | 255943        |
-//  | example-with-style.geojson | application/geo+json | 3332          |
-//  | usa-states.geojson         | application/geo+json | 89263         |
-//  +----------------------------+----------------------+---------------+
+//  +----------------------------+--------------------------+---------------+
+//  | Name: name                 | Name: mediaType          | Name: size    |
+//  | Labels:                    | Labels:                  | Labels:       |
+//  | Type: []string             | Type: []string           | Type: []int64 |
+//  +----------------------------+--------------------------+---------------+
+//  | countries.geojson          | application/octet-stream | 255943        |
+//  | example-with-style.geojson | application/octet-stream | 3332          |
+//  | usa-states.geojson         | application/octet-stream | 89263         |
+//  +----------------------------+--------------------------+---------------+
 //  
 //  
 //  🌟 This was machine generated.  Do not edit. 🌟
@@ -74,9 +74,9 @@
             "usa-states.geojson"
           ],
           [
-            "application/geo+json",
-            "application/geo+json",
-            "application/geo+json"
+            "application/octet-stream",
+            "application/octet-stream",
+            "application/octet-stream"
           ],
           [
             255943,

--- a/pkg/services/store/testdata/public_testdata.golden.jsonc
+++ b/pkg/services/store/testdata/public_testdata.golden.jsonc
@@ -11,15 +11,16 @@
 //      }
 //  }
 //  Name: 
-//  Dimensions: 3 Fields by 2 Rows
-//  +--------------------+----------------------+---------------+
-//  | Name: name         | Name: mediaType      | Name: size    |
-//  | Labels:            | Labels:              | Labels:       |
-//  | Type: []string     | Type: []string       | Type: []int64 |
-//  +--------------------+----------------------+---------------+
-//  | countries.geojson  | application/geo+json | 255943        |
-//  | usa-states.geojson | application/geo+json | 89263         |
-//  +--------------------+----------------------+---------------+
+//  Dimensions: 3 Fields by 3 Rows
+//  +----------------------------+----------------------+---------------+
+//  | Name: name                 | Name: mediaType      | Name: size    |
+//  | Labels:                    | Labels:              | Labels:       |
+//  | Type: []string             | Type: []string       | Type: []int64 |
+//  +----------------------------+----------------------+---------------+
+//  | countries.geojson          | application/geo+json | 255943        |
+//  | example-with-style.geojson | application/geo+json | 3332          |
+//  | usa-states.geojson         | application/geo+json | 89263         |
+//  +----------------------------+----------------------+---------------+
 //  
 //  
 //  🌟 This was machine generated.  Do not edit. 🌟
@@ -69,14 +70,17 @@
         "values": [
           [
             "countries.geojson",
+            "example-with-style.geojson",
             "usa-states.geojson"
           ],
           [
+            "application/geo+json",
             "application/geo+json",
             "application/geo+json"
           ],
           [
             255943,
+            3332,
             89263
           ]
         ]

--- a/pkg/services/store/testdata/public_testdata.golden.jsonc
+++ b/pkg/services/store/testdata/public_testdata.golden.jsonc
@@ -11,16 +11,15 @@
 //      }
 //  }
 //  Name: 
-//  Dimensions: 3 Fields by 3 Rows
-//  +----------------------------+--------------------------+---------------+
-//  | Name: name                 | Name: mediaType          | Name: size    |
-//  | Labels:                    | Labels:                  | Labels:       |
-//  | Type: []string             | Type: []string           | Type: []int64 |
-//  +----------------------------+--------------------------+---------------+
-//  | countries.geojson          | application/octet-stream | 255943        |
-//  | example-with-style.geojson | application/octet-stream | 3332          |
-//  | usa-states.geojson         | application/octet-stream | 89263         |
-//  +----------------------------+--------------------------+---------------+
+//  Dimensions: 3 Fields by 2 Rows
+//  +--------------------+----------------------+---------------+
+//  | Name: name         | Name: mediaType      | Name: size    |
+//  | Labels:            | Labels:              | Labels:       |
+//  | Type: []string     | Type: []string       | Type: []int64 |
+//  +--------------------+----------------------+---------------+
+//  | countries.geojson  | application/geo+json | 255943        |
+//  | usa-states.geojson | application/geo+json | 89263         |
+//  +--------------------+----------------------+---------------+
 //  
 //  
 //  🌟 This was machine generated.  Do not edit. 🌟
@@ -70,17 +69,14 @@
         "values": [
           [
             "countries.geojson",
-            "example-with-style.geojson",
             "usa-states.geojson"
           ],
           [
-            "application/octet-stream",
-            "application/octet-stream",
-            "application/octet-stream"
+            "application/geo+json",
+            "application/geo+json"
           ],
           [
             255943,
-            3332,
             89263
           ]
         ]

--- a/pkg/services/team/teamimpl/store_test.go
+++ b/pkg/services/team/teamimpl/store_test.go
@@ -16,12 +16,12 @@ import (
 	"github.com/grafana/grafana/pkg/services/org/orgimpl"
 	"github.com/grafana/grafana/pkg/services/quota/quotaimpl"
 	"github.com/grafana/grafana/pkg/services/serviceaccounts"
-	"github.com/grafana/grafana/pkg/services/sqlstore"
 	"github.com/grafana/grafana/pkg/services/supportbundles/supportbundlestest"
 	"github.com/grafana/grafana/pkg/services/team"
 	"github.com/grafana/grafana/pkg/services/team/sortopts"
 	"github.com/grafana/grafana/pkg/services/user"
 	"github.com/grafana/grafana/pkg/services/user/userimpl"
+	"github.com/grafana/grafana/pkg/setting"
 	"github.com/grafana/grafana/pkg/tests/testsuite"
 )
 
@@ -526,17 +526,17 @@ func TestIntegrationSQLStore_GetTeamMembers_ACFilter(t *testing.T) {
 	userIds := make([]int64, 4)
 
 	// Seed 2 teams with 2 members
-	setup := func(store *sqlstore.SQLStore) {
-		teamSvc, err := ProvideService(store, store.Cfg)
+	setup := func(store db.DB, cfg *setting.Cfg) {
+		teamSvc, err := ProvideService(store, cfg)
 		require.NoError(t, err)
 		team1, errCreateTeam := teamSvc.CreateTeam("group1 name", "test1@example.org", testOrgID)
 		require.NoError(t, errCreateTeam)
 		team2, errCreateTeam := teamSvc.CreateTeam("group2 name", "test2@example.org", testOrgID)
 		require.NoError(t, errCreateTeam)
-		quotaService := quotaimpl.ProvideService(store, store.Cfg)
-		orgSvc, err := orgimpl.ProvideService(store, store.Cfg, quotaService)
+		quotaService := quotaimpl.ProvideService(store, cfg)
+		orgSvc, err := orgimpl.ProvideService(store, cfg, quotaService)
 		require.NoError(t, err)
-		userSvc, err := userimpl.ProvideService(store, orgSvc, store.Cfg, teamSvc, nil, quotaService, supportbundlestest.NewFakeBundleService())
+		userSvc, err := userimpl.ProvideService(store, orgSvc, cfg, teamSvc, nil, quotaService, supportbundlestest.NewFakeBundleService())
 		require.NoError(t, err)
 
 		for i := 0; i < 4; i++ {
@@ -561,7 +561,7 @@ func TestIntegrationSQLStore_GetTeamMembers_ACFilter(t *testing.T) {
 	}
 
 	store := db.InitTestDB(t, db.InitTestDBOpt{})
-	setup(store)
+	setup(store, store.Cfg)
 	teamSvc, err := ProvideService(store, store.Cfg)
 	require.NoError(t, err)
 

--- a/pkg/tests/api/alerting/api_admin_configuration_test.go
+++ b/pkg/tests/api/alerting/api_admin_configuration_test.go
@@ -41,13 +41,13 @@ func TestIntegrationAdminConfiguration_SendingToExternalAlertmanagers(t *testing
 		AppModeProduction:              true,
 	})
 
-	grafanaListedAddr, s := testinfra.StartGrafana(t, dir, path)
+	grafanaListedAddr, env := testinfra.StartGrafanaEnv(t, dir, path)
 
-	orgService, err := orgimpl.ProvideService(s, s.Cfg, quotatest.New(false, nil))
+	orgService, err := orgimpl.ProvideService(env.SQLStore, env.Cfg, quotatest.New(false, nil))
 	require.NoError(t, err)
 
 	// Create a user to make authenticated requests
-	userID := createUser(t, s, s.Cfg, user.CreateUserCommand{
+	userID := createUser(t, env.SQLStore, env.Cfg, user.CreateUserCommand{
 		DefaultOrgRole: string(org.RoleAdmin),
 		Login:          "grafana",
 		Password:       "password",
@@ -63,7 +63,7 @@ func TestIntegrationAdminConfiguration_SendingToExternalAlertmanagers(t *testing
 	require.Equal(t, disableOrgID, orgID)
 
 	// create user under different organisation
-	createUser(t, s, s.Cfg, user.CreateUserCommand{
+	createUser(t, env.SQLStore, env.Cfg, user.CreateUserCommand{
 		DefaultOrgRole: string(org.RoleAdmin),
 		Password:       "admin-42",
 		Login:          "admin-42",
@@ -362,8 +362,8 @@ func TestIntegrationAdminConfiguration_CannotCreateInhibitionRules(t *testing.T)
 		EnableUnifiedAlerting: true,
 		AppModeProduction:     true,
 	})
-	grafanaListedAddr, store := testinfra.StartGrafana(t, dir, path)
-	createUser(t, store, store.Cfg, user.CreateUserCommand{
+	grafanaListedAddr, env := testinfra.StartGrafanaEnv(t, dir, path)
+	createUser(t, env.SQLStore, env.Cfg, user.CreateUserCommand{
 		DefaultOrgRole: string(org.RoleAdmin),
 		Password:       "admin",
 		Login:          "admin",

--- a/pkg/tests/api/alerting/api_admin_configuration_test.go
+++ b/pkg/tests/api/alerting/api_admin_configuration_test.go
@@ -47,7 +47,7 @@ func TestIntegrationAdminConfiguration_SendingToExternalAlertmanagers(t *testing
 	require.NoError(t, err)
 
 	// Create a user to make authenticated requests
-	userID := createUser(t, s, user.CreateUserCommand{
+	userID := createUser(t, s, s.Cfg, user.CreateUserCommand{
 		DefaultOrgRole: string(org.RoleAdmin),
 		Login:          "grafana",
 		Password:       "password",
@@ -63,7 +63,7 @@ func TestIntegrationAdminConfiguration_SendingToExternalAlertmanagers(t *testing
 	require.Equal(t, disableOrgID, orgID)
 
 	// create user under different organisation
-	createUser(t, s, user.CreateUserCommand{
+	createUser(t, s, s.Cfg, user.CreateUserCommand{
 		DefaultOrgRole: string(org.RoleAdmin),
 		Password:       "admin-42",
 		Login:          "admin-42",
@@ -363,7 +363,7 @@ func TestIntegrationAdminConfiguration_CannotCreateInhibitionRules(t *testing.T)
 		AppModeProduction:     true,
 	})
 	grafanaListedAddr, store := testinfra.StartGrafana(t, dir, path)
-	createUser(t, store, user.CreateUserCommand{
+	createUser(t, store, store.Cfg, user.CreateUserCommand{
 		DefaultOrgRole: string(org.RoleAdmin),
 		Password:       "admin",
 		Login:          "admin",

--- a/pkg/tests/api/alerting/api_alertmanager_configuration_test.go
+++ b/pkg/tests/api/alerting/api_alertmanager_configuration_test.go
@@ -33,7 +33,7 @@ func TestIntegrationAlertmanagerConfiguration(t *testing.T) {
 		AppModeProduction:     true,
 	})
 	grafanaListedAddr, store := testinfra.StartGrafana(t, dir, path)
-	createUser(t, store, user.CreateUserCommand{
+	createUser(t, store, store.Cfg, user.CreateUserCommand{
 		DefaultOrgRole: string(org.RoleAdmin),
 		Password:       "admin",
 		Login:          "admin",
@@ -292,7 +292,7 @@ func TestIntegrationAlertmanagerConfigurationIsTransactional(t *testing.T) {
 	alertConfigURL := fmt.Sprintf("http://editor:editor@%s/api/alertmanager/grafana/config/api/v1/alerts", grafanaListedAddr)
 
 	// create user under main organisation
-	userID := createUser(t, store, user.CreateUserCommand{
+	userID := createUser(t, store, store.Cfg, user.CreateUserCommand{
 		DefaultOrgRole: string(org.RoleEditor),
 		Password:       "editor",
 		Login:          "editor",
@@ -304,7 +304,7 @@ func TestIntegrationAlertmanagerConfigurationIsTransactional(t *testing.T) {
 	orgID := newOrg.ID
 
 	// create user under different organisation
-	createUser(t, store, user.CreateUserCommand{
+	createUser(t, store, store.Cfg, user.CreateUserCommand{
 		DefaultOrgRole: string(org.RoleEditor),
 		Password:       "editor-42",
 		Login:          "editor-42",
@@ -404,7 +404,7 @@ func TestIntegrationAlertmanagerConfigurationPersistSecrets(t *testing.T) {
 	grafanaListedAddr, store := testinfra.StartGrafana(t, dir, path)
 	alertConfigURL := fmt.Sprintf("http://editor:editor@%s/api/alertmanager/grafana/config/api/v1/alerts", grafanaListedAddr)
 
-	createUser(t, store, user.CreateUserCommand{
+	createUser(t, store, store.Cfg, user.CreateUserCommand{
 		DefaultOrgRole: string(org.RoleEditor),
 		Password:       "editor",
 		Login:          "editor",

--- a/pkg/tests/api/alerting/api_alertmanager_configuration_test.go
+++ b/pkg/tests/api/alerting/api_alertmanager_configuration_test.go
@@ -32,8 +32,8 @@ func TestIntegrationAlertmanagerConfiguration(t *testing.T) {
 		EnableUnifiedAlerting: true,
 		AppModeProduction:     true,
 	})
-	grafanaListedAddr, store := testinfra.StartGrafana(t, dir, path)
-	createUser(t, store, store.Cfg, user.CreateUserCommand{
+	grafanaListedAddr, env := testinfra.StartGrafanaEnv(t, dir, path)
+	createUser(t, env.SQLStore, env.Cfg, user.CreateUserCommand{
 		DefaultOrgRole: string(org.RoleAdmin),
 		Password:       "admin",
 		Login:          "admin",
@@ -283,16 +283,16 @@ func TestIntegrationAlertmanagerConfigurationIsTransactional(t *testing.T) {
 		AppModeProduction:                     true,
 	})
 
-	grafanaListedAddr, store := testinfra.StartGrafana(t, dir, path)
+	grafanaListedAddr, env := testinfra.StartGrafanaEnv(t, dir, path)
 
-	orgService, err := orgimpl.ProvideService(store, store.Cfg, quotatest.New(false, nil))
+	orgService, err := orgimpl.ProvideService(env.SQLStore, env.Cfg, quotatest.New(false, nil))
 	require.NoError(t, err)
 
 	// editor from main organisation requests configuration
 	alertConfigURL := fmt.Sprintf("http://editor:editor@%s/api/alertmanager/grafana/config/api/v1/alerts", grafanaListedAddr)
 
 	// create user under main organisation
-	userID := createUser(t, store, store.Cfg, user.CreateUserCommand{
+	userID := createUser(t, env.SQLStore, env.Cfg, user.CreateUserCommand{
 		DefaultOrgRole: string(org.RoleEditor),
 		Password:       "editor",
 		Login:          "editor",
@@ -304,7 +304,7 @@ func TestIntegrationAlertmanagerConfigurationIsTransactional(t *testing.T) {
 	orgID := newOrg.ID
 
 	// create user under different organisation
-	createUser(t, store, store.Cfg, user.CreateUserCommand{
+	createUser(t, env.SQLStore, env.Cfg, user.CreateUserCommand{
 		DefaultOrgRole: string(org.RoleEditor),
 		Password:       "editor-42",
 		Login:          "editor-42",
@@ -401,10 +401,10 @@ func TestIntegrationAlertmanagerConfigurationPersistSecrets(t *testing.T) {
 		AppModeProduction:     true,
 	})
 
-	grafanaListedAddr, store := testinfra.StartGrafana(t, dir, path)
+	grafanaListedAddr, env := testinfra.StartGrafanaEnv(t, dir, path)
 	alertConfigURL := fmt.Sprintf("http://editor:editor@%s/api/alertmanager/grafana/config/api/v1/alerts", grafanaListedAddr)
 
-	createUser(t, store, store.Cfg, user.CreateUserCommand{
+	createUser(t, env.SQLStore, env.Cfg, user.CreateUserCommand{
 		DefaultOrgRole: string(org.RoleEditor),
 		Password:       "editor",
 		Login:          "editor",

--- a/pkg/tests/api/alerting/api_alertmanager_test.go
+++ b/pkg/tests/api/alerting/api_alertmanager_test.go
@@ -50,20 +50,20 @@ func TestIntegrationAMConfigAccess(t *testing.T) {
 		AppModeProduction:     true,
 	})
 
-	grafanaListedAddr, store := testinfra.StartGrafana(t, dir, path)
+	grafanaListedAddr, env := testinfra.StartGrafanaEnv(t, dir, path)
 
 	// Create a users to make authenticated requests
-	createUser(t, store, store.Cfg, user.CreateUserCommand{
+	createUser(t, env.SQLStore, env.Cfg, user.CreateUserCommand{
 		DefaultOrgRole: string(org.RoleViewer),
 		Password:       "viewer",
 		Login:          "viewer",
 	})
-	createUser(t, store, store.Cfg, user.CreateUserCommand{
+	createUser(t, env.SQLStore, env.Cfg, user.CreateUserCommand{
 		DefaultOrgRole: string(org.RoleEditor),
 		Password:       "editor",
 		Login:          "editor",
 	})
-	createUser(t, store, store.Cfg, user.CreateUserCommand{
+	createUser(t, env.SQLStore, env.Cfg, user.CreateUserCommand{
 		DefaultOrgRole: string(org.RoleAdmin),
 		Password:       "admin",
 		Login:          "admin",
@@ -425,7 +425,7 @@ func TestIntegrationAlertAndGroupsQuery(t *testing.T) {
 		AppModeProduction:     true,
 	})
 
-	grafanaListedAddr, store := testinfra.StartGrafana(t, dir, path)
+	grafanaListedAddr, env := testinfra.StartGrafanaEnv(t, dir, path)
 
 	// unauthenticated request to get the alerts should fail
 	{
@@ -444,7 +444,7 @@ func TestIntegrationAlertAndGroupsQuery(t *testing.T) {
 	}
 
 	// Create a user to make authenticated requests
-	createUser(t, store, store.Cfg, user.CreateUserCommand{
+	createUser(t, env.SQLStore, env.Cfg, user.CreateUserCommand{
 		DefaultOrgRole: string(org.RoleEditor),
 		Password:       "password",
 		Login:          "grafana",
@@ -587,20 +587,20 @@ func TestIntegrationRulerAccess(t *testing.T) {
 		AppModeProduction:     true,
 	})
 
-	grafanaListedAddr, store := testinfra.StartGrafana(t, dir, path)
+	grafanaListedAddr, env := testinfra.StartGrafanaEnv(t, dir, path)
 
 	// Create a users to make authenticated requests
-	createUser(t, store, store.Cfg, user.CreateUserCommand{
+	createUser(t, env.SQLStore, env.Cfg, user.CreateUserCommand{
 		DefaultOrgRole: string(org.RoleViewer),
 		Password:       "viewer",
 		Login:          "viewer",
 	})
-	createUser(t, store, store.Cfg, user.CreateUserCommand{
+	createUser(t, env.SQLStore, env.Cfg, user.CreateUserCommand{
 		DefaultOrgRole: string(org.RoleEditor),
 		Password:       "editor",
 		Login:          "editor",
 	})
-	createUser(t, store, store.Cfg, user.CreateUserCommand{
+	createUser(t, env.SQLStore, env.Cfg, user.CreateUserCommand{
 		DefaultOrgRole: string(org.RoleAdmin),
 		Password:       "admin",
 		Login:          "admin",
@@ -704,14 +704,14 @@ func TestIntegrationDeleteFolderWithRules(t *testing.T) {
 		AppModeProduction:     true,
 	})
 
-	grafanaListedAddr, store := testinfra.StartGrafana(t, dir, path)
+	grafanaListedAddr, env := testinfra.StartGrafanaEnv(t, dir, path)
 
-	createUser(t, store, store.Cfg, user.CreateUserCommand{
+	createUser(t, env.SQLStore, env.Cfg, user.CreateUserCommand{
 		DefaultOrgRole: string(org.RoleViewer),
 		Password:       "viewer",
 		Login:          "viewer",
 	})
-	createUser(t, store, store.Cfg, user.CreateUserCommand{
+	createUser(t, env.SQLStore, env.Cfg, user.CreateUserCommand{
 		DefaultOrgRole: string(org.RoleEditor),
 		Password:       "editor",
 		Login:          "editor",
@@ -868,9 +868,9 @@ func TestIntegrationAlertRuleCRUD(t *testing.T) {
 		AppModeProduction:     true,
 	})
 
-	grafanaListedAddr, store := testinfra.StartGrafana(t, dir, path)
+	grafanaListedAddr, env := testinfra.StartGrafanaEnv(t, dir, path)
 
-	createUser(t, store, store.Cfg, user.CreateUserCommand{
+	createUser(t, env.SQLStore, env.Cfg, user.CreateUserCommand{
 		DefaultOrgRole: string(org.RoleEditor),
 		Password:       "password",
 		Login:          "grafana",
@@ -1865,8 +1865,8 @@ func TestIntegrationAlertmanagerCreateSilence(t *testing.T) {
 		EnableUnifiedAlerting: true,
 		AppModeProduction:     true,
 	})
-	grafanaListedAddr, store := testinfra.StartGrafana(t, dir, path)
-	createUser(t, store, store.Cfg, user.CreateUserCommand{
+	grafanaListedAddr, env := testinfra.StartGrafanaEnv(t, dir, path)
+	createUser(t, env.SQLStore, env.Cfg, user.CreateUserCommand{
 		DefaultOrgRole: string(org.RoleAdmin),
 		Password:       "admin",
 		Login:          "admin",
@@ -2018,20 +2018,19 @@ func TestIntegrationAlertmanagerStatus(t *testing.T) {
 		AppModeProduction:     true,
 	})
 
-	grafanaListedAddr, store := testinfra.StartGrafana(t, dir, path)
-	cfg := store.Cfg
+	grafanaListedAddr, env := testinfra.StartGrafanaEnv(t, dir, path)
 	// Create a users to make authenticated requests
-	createUser(t, store, cfg, user.CreateUserCommand{
+	createUser(t, env.SQLStore, env.Cfg, user.CreateUserCommand{
 		DefaultOrgRole: string(org.RoleViewer),
 		Password:       "viewer",
 		Login:          "viewer",
 	})
-	createUser(t, store, cfg, user.CreateUserCommand{
+	createUser(t, env.SQLStore, env.Cfg, user.CreateUserCommand{
 		DefaultOrgRole: string(org.RoleEditor),
 		Password:       "editor",
 		Login:          "editor",
 	})
-	createUser(t, store, cfg, user.CreateUserCommand{
+	createUser(t, env.SQLStore, env.Cfg, user.CreateUserCommand{
 		DefaultOrgRole: string(org.RoleAdmin),
 		Password:       "admin",
 		Login:          "admin",
@@ -2154,10 +2153,10 @@ func TestIntegrationQuota(t *testing.T) {
 		AppModeProduction:     true,
 	})
 
-	grafanaListedAddr, store := testinfra.StartGrafana(t, dir, path)
+	grafanaListedAddr, env := testinfra.StartGrafanaEnv(t, dir, path)
 
 	// Create a user to make authenticated requests
-	createUser(t, store, store.Cfg, user.CreateUserCommand{
+	createUser(t, env.SQLStore, env.Cfg, user.CreateUserCommand{
 		// needs permission to update org quota
 		IsAdmin:        true,
 		DefaultOrgRole: string(org.RoleEditor),
@@ -2355,9 +2354,9 @@ func TestIntegrationEval(t *testing.T) {
 		AppModeProduction:     true,
 	})
 
-	grafanaListedAddr, store := testinfra.StartGrafana(t, dir, path)
+	grafanaListedAddr, env := testinfra.StartGrafanaEnv(t, dir, path)
 
-	createUser(t, store, store.Cfg, user.CreateUserCommand{
+	createUser(t, env.SQLStore, env.Cfg, user.CreateUserCommand{
 		DefaultOrgRole: string(org.RoleEditor),
 		Password:       "password",
 		Login:          "grafana",

--- a/pkg/tests/api/alerting/api_alertmanager_test.go
+++ b/pkg/tests/api/alerting/api_alertmanager_test.go
@@ -19,13 +19,13 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/grafana/grafana/pkg/expr"
+	"github.com/grafana/grafana/pkg/infra/db"
 	apimodels "github.com/grafana/grafana/pkg/services/ngalert/api/tooling/definitions"
 	ngmodels "github.com/grafana/grafana/pkg/services/ngalert/models"
 	ngstore "github.com/grafana/grafana/pkg/services/ngalert/store"
 	"github.com/grafana/grafana/pkg/services/org"
 	"github.com/grafana/grafana/pkg/services/org/orgimpl"
 	"github.com/grafana/grafana/pkg/services/quota/quotaimpl"
-	"github.com/grafana/grafana/pkg/services/sqlstore"
 	"github.com/grafana/grafana/pkg/services/supportbundles/supportbundlestest"
 	"github.com/grafana/grafana/pkg/services/user"
 	"github.com/grafana/grafana/pkg/services/user/userimpl"
@@ -53,17 +53,17 @@ func TestIntegrationAMConfigAccess(t *testing.T) {
 	grafanaListedAddr, store := testinfra.StartGrafana(t, dir, path)
 
 	// Create a users to make authenticated requests
-	createUser(t, store, user.CreateUserCommand{
+	createUser(t, store, store.Cfg, user.CreateUserCommand{
 		DefaultOrgRole: string(org.RoleViewer),
 		Password:       "viewer",
 		Login:          "viewer",
 	})
-	createUser(t, store, user.CreateUserCommand{
+	createUser(t, store, store.Cfg, user.CreateUserCommand{
 		DefaultOrgRole: string(org.RoleEditor),
 		Password:       "editor",
 		Login:          "editor",
 	})
-	createUser(t, store, user.CreateUserCommand{
+	createUser(t, store, store.Cfg, user.CreateUserCommand{
 		DefaultOrgRole: string(org.RoleAdmin),
 		Password:       "admin",
 		Login:          "admin",
@@ -444,7 +444,7 @@ func TestIntegrationAlertAndGroupsQuery(t *testing.T) {
 	}
 
 	// Create a user to make authenticated requests
-	createUser(t, store, user.CreateUserCommand{
+	createUser(t, store, store.Cfg, user.CreateUserCommand{
 		DefaultOrgRole: string(org.RoleEditor),
 		Password:       "password",
 		Login:          "grafana",
@@ -590,17 +590,17 @@ func TestIntegrationRulerAccess(t *testing.T) {
 	grafanaListedAddr, store := testinfra.StartGrafana(t, dir, path)
 
 	// Create a users to make authenticated requests
-	createUser(t, store, user.CreateUserCommand{
+	createUser(t, store, store.Cfg, user.CreateUserCommand{
 		DefaultOrgRole: string(org.RoleViewer),
 		Password:       "viewer",
 		Login:          "viewer",
 	})
-	createUser(t, store, user.CreateUserCommand{
+	createUser(t, store, store.Cfg, user.CreateUserCommand{
 		DefaultOrgRole: string(org.RoleEditor),
 		Password:       "editor",
 		Login:          "editor",
 	})
-	createUser(t, store, user.CreateUserCommand{
+	createUser(t, store, store.Cfg, user.CreateUserCommand{
 		DefaultOrgRole: string(org.RoleAdmin),
 		Password:       "admin",
 		Login:          "admin",
@@ -706,12 +706,12 @@ func TestIntegrationDeleteFolderWithRules(t *testing.T) {
 
 	grafanaListedAddr, store := testinfra.StartGrafana(t, dir, path)
 
-	createUser(t, store, user.CreateUserCommand{
+	createUser(t, store, store.Cfg, user.CreateUserCommand{
 		DefaultOrgRole: string(org.RoleViewer),
 		Password:       "viewer",
 		Login:          "viewer",
 	})
-	createUser(t, store, user.CreateUserCommand{
+	createUser(t, store, store.Cfg, user.CreateUserCommand{
 		DefaultOrgRole: string(org.RoleEditor),
 		Password:       "editor",
 		Login:          "editor",
@@ -870,7 +870,7 @@ func TestIntegrationAlertRuleCRUD(t *testing.T) {
 
 	grafanaListedAddr, store := testinfra.StartGrafana(t, dir, path)
 
-	createUser(t, store, user.CreateUserCommand{
+	createUser(t, store, store.Cfg, user.CreateUserCommand{
 		DefaultOrgRole: string(org.RoleEditor),
 		Password:       "password",
 		Login:          "grafana",
@@ -1866,7 +1866,7 @@ func TestIntegrationAlertmanagerCreateSilence(t *testing.T) {
 		AppModeProduction:     true,
 	})
 	grafanaListedAddr, store := testinfra.StartGrafana(t, dir, path)
-	createUser(t, store, user.CreateUserCommand{
+	createUser(t, store, store.Cfg, user.CreateUserCommand{
 		DefaultOrgRole: string(org.RoleAdmin),
 		Password:       "admin",
 		Login:          "admin",
@@ -2019,19 +2019,19 @@ func TestIntegrationAlertmanagerStatus(t *testing.T) {
 	})
 
 	grafanaListedAddr, store := testinfra.StartGrafana(t, dir, path)
-
+	cfg := store.Cfg
 	// Create a users to make authenticated requests
-	createUser(t, store, user.CreateUserCommand{
+	createUser(t, store, cfg, user.CreateUserCommand{
 		DefaultOrgRole: string(org.RoleViewer),
 		Password:       "viewer",
 		Login:          "viewer",
 	})
-	createUser(t, store, user.CreateUserCommand{
+	createUser(t, store, cfg, user.CreateUserCommand{
 		DefaultOrgRole: string(org.RoleEditor),
 		Password:       "editor",
 		Login:          "editor",
 	})
-	createUser(t, store, user.CreateUserCommand{
+	createUser(t, store, cfg, user.CreateUserCommand{
 		DefaultOrgRole: string(org.RoleAdmin),
 		Password:       "admin",
 		Login:          "admin",
@@ -2157,7 +2157,7 @@ func TestIntegrationQuota(t *testing.T) {
 	grafanaListedAddr, store := testinfra.StartGrafana(t, dir, path)
 
 	// Create a user to make authenticated requests
-	createUser(t, store, user.CreateUserCommand{
+	createUser(t, store, store.Cfg, user.CreateUserCommand{
 		// needs permission to update org quota
 		IsAdmin:        true,
 		DefaultOrgRole: string(org.RoleEditor),
@@ -2357,7 +2357,7 @@ func TestIntegrationEval(t *testing.T) {
 
 	grafanaListedAddr, store := testinfra.StartGrafana(t, dir, path)
 
-	createUser(t, store, user.CreateUserCommand{
+	createUser(t, store, store.Cfg, user.CreateUserCommand{
 		DefaultOrgRole: string(org.RoleEditor),
 		Password:       "password",
 		Login:          "grafana",
@@ -2641,16 +2641,16 @@ func rulesNamespaceWithoutVariableValues(t *testing.T, b []byte) (string, map[st
 	return string(json), m
 }
 
-func createUser(t *testing.T, store *sqlstore.SQLStore, cmd user.CreateUserCommand) int64 {
+func createUser(t *testing.T, db db.DB, cfg *setting.Cfg, cmd user.CreateUserCommand) int64 {
 	t.Helper()
 
-	store.Cfg.AutoAssignOrg = true
-	store.Cfg.AutoAssignOrgId = 1
+	cfg.AutoAssignOrg = true
+	cfg.AutoAssignOrgId = 1
 
-	quotaService := quotaimpl.ProvideService(store, store.Cfg)
-	orgService, err := orgimpl.ProvideService(store, store.Cfg, quotaService)
+	quotaService := quotaimpl.ProvideService(db, cfg)
+	orgService, err := orgimpl.ProvideService(db, cfg, quotaService)
 	require.NoError(t, err)
-	usrSvc, err := userimpl.ProvideService(store, orgService, store.Cfg, nil, nil, quotaService, supportbundlestest.NewFakeBundleService())
+	usrSvc, err := userimpl.ProvideService(db, orgService, cfg, nil, nil, quotaService, supportbundlestest.NewFakeBundleService())
 	require.NoError(t, err)
 
 	u, err := usrSvc.Create(context.Background(), &cmd)

--- a/pkg/tests/api/alerting/api_available_channel_test.go
+++ b/pkg/tests/api/alerting/api_available_channel_test.go
@@ -25,10 +25,10 @@ func TestIntegrationAvailableChannels(t *testing.T) {
 		AppModeProduction:     true,
 	})
 
-	grafanaListedAddr, store := testinfra.StartGrafana(t, dir, path)
+	grafanaListedAddr, env := testinfra.StartGrafanaEnv(t, dir, path)
 
 	// Create a user to make authenticated requests
-	createUser(t, store, store.Cfg, user.CreateUserCommand{
+	createUser(t, env.SQLStore, env.Cfg, user.CreateUserCommand{
 		DefaultOrgRole: string(org.RoleEditor),
 		Password:       "password",
 		Login:          "grafana",

--- a/pkg/tests/api/alerting/api_available_channel_test.go
+++ b/pkg/tests/api/alerting/api_available_channel_test.go
@@ -28,7 +28,7 @@ func TestIntegrationAvailableChannels(t *testing.T) {
 	grafanaListedAddr, store := testinfra.StartGrafana(t, dir, path)
 
 	// Create a user to make authenticated requests
-	createUser(t, store, user.CreateUserCommand{
+	createUser(t, store, store.Cfg, user.CreateUserCommand{
 		DefaultOrgRole: string(org.RoleEditor),
 		Password:       "password",
 		Login:          "grafana",

--- a/pkg/tests/api/alerting/api_backtesting_test.go
+++ b/pkg/tests/api/alerting/api_backtesting_test.go
@@ -36,7 +36,7 @@ func TestBacktesting(t *testing.T) {
 
 	grafanaListedAddr, env := testinfra.StartGrafanaEnv(t, dir, path)
 
-	userId := createUser(t, env.SQLStore, user.CreateUserCommand{
+	userId := createUser(t, env.SQLStore, env.SQLStore.Cfg, user.CreateUserCommand{
 		DefaultOrgRole: string(org.RoleAdmin),
 		Password:       "admin",
 		Login:          "admin",
@@ -92,7 +92,7 @@ func TestBacktesting(t *testing.T) {
 	})
 
 	t.Run("if user does not have permissions", func(t *testing.T) {
-		testUserId := createUser(t, env.SQLStore, user.CreateUserCommand{
+		testUserId := createUser(t, env.SQLStore, env.SQLStore.Cfg, user.CreateUserCommand{
 			DefaultOrgRole: string(roletype.RoleNone),
 			Password:       "test",
 			Login:          "test",

--- a/pkg/tests/api/alerting/api_backtesting_test.go
+++ b/pkg/tests/api/alerting/api_backtesting_test.go
@@ -36,7 +36,7 @@ func TestBacktesting(t *testing.T) {
 
 	grafanaListedAddr, env := testinfra.StartGrafanaEnv(t, dir, path)
 
-	userId := createUser(t, env.SQLStore, env.SQLStore.Cfg, user.CreateUserCommand{
+	userId := createUser(t, env.SQLStore, env.Cfg, user.CreateUserCommand{
 		DefaultOrgRole: string(org.RoleAdmin),
 		Password:       "admin",
 		Login:          "admin",
@@ -92,7 +92,7 @@ func TestBacktesting(t *testing.T) {
 	})
 
 	t.Run("if user does not have permissions", func(t *testing.T) {
-		testUserId := createUser(t, env.SQLStore, env.SQLStore.Cfg, user.CreateUserCommand{
+		testUserId := createUser(t, env.SQLStore, env.Cfg, user.CreateUserCommand{
 			DefaultOrgRole: string(roletype.RoleNone),
 			Password:       "test",
 			Login:          "test",

--- a/pkg/tests/api/alerting/api_notification_channel_test.go
+++ b/pkg/tests/api/alerting/api_notification_channel_test.go
@@ -53,7 +53,7 @@ func TestIntegrationTestReceivers(t *testing.T) {
 
 		grafanaListedAddr, env := testinfra.StartGrafanaEnv(t, dir, path)
 
-		createUser(t, env.SQLStore, env.SQLStore.Cfg, user.CreateUserCommand{
+		createUser(t, env.SQLStore, env.Cfg, user.CreateUserCommand{
 			DefaultOrgRole: string(org.RoleEditor),
 			Login:          "grafana",
 			Password:       "password",
@@ -86,7 +86,7 @@ func TestIntegrationTestReceivers(t *testing.T) {
 
 		grafanaListedAddr, env := testinfra.StartGrafanaEnv(t, dir, path)
 
-		createUser(t, env.SQLStore, env.SQLStore.Cfg, user.CreateUserCommand{
+		createUser(t, env.SQLStore, env.Cfg, user.CreateUserCommand{
 			DefaultOrgRole: string(org.RoleEditor),
 			Login:          "grafana",
 			Password:       "password",
@@ -169,7 +169,7 @@ func TestIntegrationTestReceivers(t *testing.T) {
 
 		grafanaListedAddr, env := testinfra.StartGrafanaEnv(t, dir, path)
 
-		createUser(t, env.SQLStore, env.SQLStore.Cfg, user.CreateUserCommand{
+		createUser(t, env.SQLStore, env.Cfg, user.CreateUserCommand{
 			DefaultOrgRole: string(org.RoleEditor),
 			Login:          "grafana",
 			Password:       "password",
@@ -249,7 +249,7 @@ func TestIntegrationTestReceivers(t *testing.T) {
 
 		grafanaListedAddr, env := testinfra.StartGrafanaEnv(t, dir, path)
 
-		createUser(t, env.SQLStore, env.SQLStore.Cfg, user.CreateUserCommand{
+		createUser(t, env.SQLStore, env.Cfg, user.CreateUserCommand{
 			DefaultOrgRole: string(org.RoleEditor),
 			Login:          "grafana",
 			Password:       "password",
@@ -350,7 +350,7 @@ func TestIntegrationTestReceivers(t *testing.T) {
 
 		grafanaListedAddr, env := testinfra.StartGrafanaEnv(t, dir, path)
 
-		createUser(t, env.SQLStore, env.SQLStore.Cfg, user.CreateUserCommand{
+		createUser(t, env.SQLStore, env.Cfg, user.CreateUserCommand{
 			DefaultOrgRole: string(org.RoleEditor),
 			Login:          "grafana",
 			Password:       "password",
@@ -429,7 +429,7 @@ func TestIntegrationTestReceivers(t *testing.T) {
 
 		grafanaListedAddr, env := testinfra.StartGrafanaEnv(t, dir, path)
 
-		createUser(t, env.SQLStore, env.SQLStore.Cfg, user.CreateUserCommand{
+		createUser(t, env.SQLStore, env.Cfg, user.CreateUserCommand{
 			DefaultOrgRole: string(org.RoleEditor),
 			Login:          "grafana",
 			Password:       "password",
@@ -516,7 +516,7 @@ func TestIntegrationTestReceivers(t *testing.T) {
 
 		grafanaListedAddr, env := testinfra.StartGrafanaEnv(t, dir, path)
 
-		createUser(t, env.SQLStore, env.SQLStore.Cfg, user.CreateUserCommand{
+		createUser(t, env.SQLStore, env.Cfg, user.CreateUserCommand{
 			DefaultOrgRole: string(org.RoleEditor),
 			Login:          "grafana",
 			Password:       "password",
@@ -633,7 +633,7 @@ func TestIntegrationTestReceiversAlertCustomization(t *testing.T) {
 
 		grafanaListedAddr, env := testinfra.StartGrafanaEnv(t, dir, path)
 
-		createUser(t, env.SQLStore, env.SQLStore.Cfg, user.CreateUserCommand{
+		createUser(t, env.SQLStore, env.Cfg, user.CreateUserCommand{
 			DefaultOrgRole: string(org.RoleEditor),
 			Login:          "grafana",
 			Password:       "password",
@@ -726,7 +726,7 @@ func TestIntegrationTestReceiversAlertCustomization(t *testing.T) {
 
 		grafanaListedAddr, env := testinfra.StartGrafanaEnv(t, dir, path)
 
-		createUser(t, env.SQLStore, env.SQLStore.Cfg, user.CreateUserCommand{
+		createUser(t, env.SQLStore, env.Cfg, user.CreateUserCommand{
 			DefaultOrgRole: string(org.RoleEditor),
 			Login:          "grafana",
 			Password:       "password",
@@ -814,7 +814,7 @@ func TestIntegrationTestReceiversAlertCustomization(t *testing.T) {
 
 		grafanaListedAddr, env := testinfra.StartGrafanaEnv(t, dir, path)
 
-		createUser(t, env.SQLStore, env.SQLStore.Cfg, user.CreateUserCommand{
+		createUser(t, env.SQLStore, env.Cfg, user.CreateUserCommand{
 			DefaultOrgRole: string(org.RoleEditor),
 			Login:          "grafana",
 			Password:       "password",
@@ -943,7 +943,7 @@ func TestIntegrationNotificationChannels(t *testing.T) {
 	}
 
 	// Create a user to make authenticated requests
-	createUser(t, env.SQLStore, env.SQLStore.Cfg, user.CreateUserCommand{
+	createUser(t, env.SQLStore, env.Cfg, user.CreateUserCommand{
 		DefaultOrgRole: string(org.RoleEditor),
 		Password:       "password",
 		Login:          "grafana",

--- a/pkg/tests/api/alerting/api_notification_channel_test.go
+++ b/pkg/tests/api/alerting/api_notification_channel_test.go
@@ -53,7 +53,7 @@ func TestIntegrationTestReceivers(t *testing.T) {
 
 		grafanaListedAddr, env := testinfra.StartGrafanaEnv(t, dir, path)
 
-		createUser(t, env.SQLStore, user.CreateUserCommand{
+		createUser(t, env.SQLStore, env.SQLStore.Cfg, user.CreateUserCommand{
 			DefaultOrgRole: string(org.RoleEditor),
 			Login:          "grafana",
 			Password:       "password",
@@ -86,7 +86,7 @@ func TestIntegrationTestReceivers(t *testing.T) {
 
 		grafanaListedAddr, env := testinfra.StartGrafanaEnv(t, dir, path)
 
-		createUser(t, env.SQLStore, user.CreateUserCommand{
+		createUser(t, env.SQLStore, env.SQLStore.Cfg, user.CreateUserCommand{
 			DefaultOrgRole: string(org.RoleEditor),
 			Login:          "grafana",
 			Password:       "password",
@@ -169,7 +169,7 @@ func TestIntegrationTestReceivers(t *testing.T) {
 
 		grafanaListedAddr, env := testinfra.StartGrafanaEnv(t, dir, path)
 
-		createUser(t, env.SQLStore, user.CreateUserCommand{
+		createUser(t, env.SQLStore, env.SQLStore.Cfg, user.CreateUserCommand{
 			DefaultOrgRole: string(org.RoleEditor),
 			Login:          "grafana",
 			Password:       "password",
@@ -249,7 +249,7 @@ func TestIntegrationTestReceivers(t *testing.T) {
 
 		grafanaListedAddr, env := testinfra.StartGrafanaEnv(t, dir, path)
 
-		createUser(t, env.SQLStore, user.CreateUserCommand{
+		createUser(t, env.SQLStore, env.SQLStore.Cfg, user.CreateUserCommand{
 			DefaultOrgRole: string(org.RoleEditor),
 			Login:          "grafana",
 			Password:       "password",
@@ -350,7 +350,7 @@ func TestIntegrationTestReceivers(t *testing.T) {
 
 		grafanaListedAddr, env := testinfra.StartGrafanaEnv(t, dir, path)
 
-		createUser(t, env.SQLStore, user.CreateUserCommand{
+		createUser(t, env.SQLStore, env.SQLStore.Cfg, user.CreateUserCommand{
 			DefaultOrgRole: string(org.RoleEditor),
 			Login:          "grafana",
 			Password:       "password",
@@ -429,7 +429,7 @@ func TestIntegrationTestReceivers(t *testing.T) {
 
 		grafanaListedAddr, env := testinfra.StartGrafanaEnv(t, dir, path)
 
-		createUser(t, env.SQLStore, user.CreateUserCommand{
+		createUser(t, env.SQLStore, env.SQLStore.Cfg, user.CreateUserCommand{
 			DefaultOrgRole: string(org.RoleEditor),
 			Login:          "grafana",
 			Password:       "password",
@@ -516,7 +516,7 @@ func TestIntegrationTestReceivers(t *testing.T) {
 
 		grafanaListedAddr, env := testinfra.StartGrafanaEnv(t, dir, path)
 
-		createUser(t, env.SQLStore, user.CreateUserCommand{
+		createUser(t, env.SQLStore, env.SQLStore.Cfg, user.CreateUserCommand{
 			DefaultOrgRole: string(org.RoleEditor),
 			Login:          "grafana",
 			Password:       "password",
@@ -633,7 +633,7 @@ func TestIntegrationTestReceiversAlertCustomization(t *testing.T) {
 
 		grafanaListedAddr, env := testinfra.StartGrafanaEnv(t, dir, path)
 
-		createUser(t, env.SQLStore, user.CreateUserCommand{
+		createUser(t, env.SQLStore, env.SQLStore.Cfg, user.CreateUserCommand{
 			DefaultOrgRole: string(org.RoleEditor),
 			Login:          "grafana",
 			Password:       "password",
@@ -726,7 +726,7 @@ func TestIntegrationTestReceiversAlertCustomization(t *testing.T) {
 
 		grafanaListedAddr, env := testinfra.StartGrafanaEnv(t, dir, path)
 
-		createUser(t, env.SQLStore, user.CreateUserCommand{
+		createUser(t, env.SQLStore, env.SQLStore.Cfg, user.CreateUserCommand{
 			DefaultOrgRole: string(org.RoleEditor),
 			Login:          "grafana",
 			Password:       "password",
@@ -814,7 +814,7 @@ func TestIntegrationTestReceiversAlertCustomization(t *testing.T) {
 
 		grafanaListedAddr, env := testinfra.StartGrafanaEnv(t, dir, path)
 
-		createUser(t, env.SQLStore, user.CreateUserCommand{
+		createUser(t, env.SQLStore, env.SQLStore.Cfg, user.CreateUserCommand{
 			DefaultOrgRole: string(org.RoleEditor),
 			Login:          "grafana",
 			Password:       "password",
@@ -943,7 +943,7 @@ func TestIntegrationNotificationChannels(t *testing.T) {
 	}
 
 	// Create a user to make authenticated requests
-	createUser(t, env.SQLStore, user.CreateUserCommand{
+	createUser(t, env.SQLStore, env.SQLStore.Cfg, user.CreateUserCommand{
 		DefaultOrgRole: string(org.RoleEditor),
 		Password:       "password",
 		Login:          "grafana",

--- a/pkg/tests/api/alerting/api_notifications_time_interval_test.go
+++ b/pkg/tests/api/alerting/api_notifications_time_interval_test.go
@@ -29,7 +29,7 @@ func TestTimeInterval(t *testing.T) {
 
 	grafanaListedAddr, store := testinfra.StartGrafana(t, dir, path)
 
-	createUser(t, store, user.CreateUserCommand{
+	createUser(t, store, store.Cfg, user.CreateUserCommand{
 		DefaultOrgRole: string(org.RoleAdmin),
 		Password:       "admin",
 		Login:          "admin",

--- a/pkg/tests/api/alerting/api_notifications_time_interval_test.go
+++ b/pkg/tests/api/alerting/api_notifications_time_interval_test.go
@@ -27,9 +27,9 @@ func TestTimeInterval(t *testing.T) {
 		AppModeProduction:     true,
 	})
 
-	grafanaListedAddr, store := testinfra.StartGrafana(t, dir, path)
+	grafanaListedAddr, env := testinfra.StartGrafanaEnv(t, dir, path)
 
-	createUser(t, store, store.Cfg, user.CreateUserCommand{
+	createUser(t, env.SQLStore, env.Cfg, user.CreateUserCommand{
 		DefaultOrgRole: string(org.RoleAdmin),
 		Password:       "admin",
 		Login:          "admin",

--- a/pkg/tests/api/alerting/api_prometheus_test.go
+++ b/pkg/tests/api/alerting/api_prometheus_test.go
@@ -37,10 +37,10 @@ func TestIntegrationPrometheusRules(t *testing.T) {
 		AppModeProduction:     true,
 	})
 
-	grafanaListedAddr, store := testinfra.StartGrafana(t, dir, path)
+	grafanaListedAddr, env := testinfra.StartGrafanaEnv(t, dir, path)
 
 	// Create a user to make authenticated requests
-	createUser(t, store, store.Cfg, user.CreateUserCommand{
+	createUser(t, env.SQLStore, env.Cfg, user.CreateUserCommand{
 		DefaultOrgRole: string(org.RoleEditor),
 		Password:       "password",
 		Login:          "grafana",
@@ -347,10 +347,10 @@ func TestIntegrationPrometheusRulesFilterByDashboard(t *testing.T) {
 		AppModeProduction:    true,
 	})
 
-	grafanaListedAddr, store := testinfra.StartGrafana(t, dir, path)
+	grafanaListedAddr, env := testinfra.StartGrafanaEnv(t, dir, path)
 
 	// Create a user to make authenticated requests
-	createUser(t, store, store.Cfg, user.CreateUserCommand{
+	createUser(t, env.SQLStore, env.Cfg, user.CreateUserCommand{
 		DefaultOrgRole: string(org.RoleEditor),
 		Password:       "password",
 		Login:          "grafana",
@@ -657,10 +657,10 @@ func TestIntegrationPrometheusRulesPermissions(t *testing.T) {
 		AppModeProduction:     true,
 	})
 
-	grafanaListedAddr, store := testinfra.StartGrafana(t, dir, path)
+	grafanaListedAddr, env := testinfra.StartGrafanaEnv(t, dir, path)
 
 	// Create a user to make authenticated requests
-	userID := createUser(t, store, store.Cfg, user.CreateUserCommand{
+	userID := createUser(t, env.SQLStore, env.Cfg, user.CreateUserCommand{
 		DefaultOrgRole: string(org.RoleEditor),
 		Password:       "password",
 		Login:          "grafana",
@@ -669,7 +669,7 @@ func TestIntegrationPrometheusRulesPermissions(t *testing.T) {
 	apiClient := newAlertingApiClient(grafanaListedAddr, "grafana", "password")
 
 	// access control permissions store
-	permissionsStore := resourcepermissions.NewStore(store, featuremgmt.WithFeatures())
+	permissionsStore := resourcepermissions.NewStore(env.SQLStore, featuremgmt.WithFeatures())
 
 	// Create the namespace we'll save our alerts to.
 	apiClient.CreateFolder(t, "folder1", "folder1")

--- a/pkg/tests/api/alerting/api_prometheus_test.go
+++ b/pkg/tests/api/alerting/api_prometheus_test.go
@@ -40,7 +40,7 @@ func TestIntegrationPrometheusRules(t *testing.T) {
 	grafanaListedAddr, store := testinfra.StartGrafana(t, dir, path)
 
 	// Create a user to make authenticated requests
-	createUser(t, store, user.CreateUserCommand{
+	createUser(t, store, store.Cfg, user.CreateUserCommand{
 		DefaultOrgRole: string(org.RoleEditor),
 		Password:       "password",
 		Login:          "grafana",
@@ -350,7 +350,7 @@ func TestIntegrationPrometheusRulesFilterByDashboard(t *testing.T) {
 	grafanaListedAddr, store := testinfra.StartGrafana(t, dir, path)
 
 	// Create a user to make authenticated requests
-	createUser(t, store, user.CreateUserCommand{
+	createUser(t, store, store.Cfg, user.CreateUserCommand{
 		DefaultOrgRole: string(org.RoleEditor),
 		Password:       "password",
 		Login:          "grafana",
@@ -660,7 +660,7 @@ func TestIntegrationPrometheusRulesPermissions(t *testing.T) {
 	grafanaListedAddr, store := testinfra.StartGrafana(t, dir, path)
 
 	// Create a user to make authenticated requests
-	userID := createUser(t, store, user.CreateUserCommand{
+	userID := createUser(t, store, store.Cfg, user.CreateUserCommand{
 		DefaultOrgRole: string(org.RoleEditor),
 		Password:       "password",
 		Login:          "grafana",

--- a/pkg/tests/api/alerting/api_provisioning_test.go
+++ b/pkg/tests/api/alerting/api_provisioning_test.go
@@ -37,17 +37,17 @@ func TestIntegrationProvisioning(t *testing.T) {
 	grafanaListedAddr, store := testinfra.StartGrafana(t, dir, path)
 
 	// Create a users to make authenticated requests
-	createUser(t, store, user.CreateUserCommand{
+	createUser(t, store, store.Cfg, user.CreateUserCommand{
 		DefaultOrgRole: string(org.RoleViewer),
 		Password:       "viewer",
 		Login:          "viewer",
 	})
-	createUser(t, store, user.CreateUserCommand{
+	createUser(t, store, store.Cfg, user.CreateUserCommand{
 		DefaultOrgRole: string(org.RoleEditor),
 		Password:       "editor",
 		Login:          "editor",
 	})
-	createUser(t, store, user.CreateUserCommand{
+	createUser(t, store, store.Cfg, user.CreateUserCommand{
 		DefaultOrgRole: string(org.RoleAdmin),
 		Password:       "admin",
 		Login:          "admin",
@@ -387,7 +387,7 @@ func TestMuteTimings(t *testing.T) {
 
 	grafanaListedAddr, store := testinfra.StartGrafana(t, dir, path)
 
-	createUser(t, store, user.CreateUserCommand{
+	createUser(t, store, store.Cfg, user.CreateUserCommand{
 		DefaultOrgRole: string(org.RoleAdmin),
 		Password:       "admin",
 		Login:          "admin",

--- a/pkg/tests/api/alerting/api_provisioning_test.go
+++ b/pkg/tests/api/alerting/api_provisioning_test.go
@@ -34,20 +34,20 @@ func TestIntegrationProvisioning(t *testing.T) {
 		AppModeProduction:     true,
 	})
 
-	grafanaListedAddr, store := testinfra.StartGrafana(t, dir, path)
+	grafanaListedAddr, env := testinfra.StartGrafanaEnv(t, dir, path)
 
 	// Create a users to make authenticated requests
-	createUser(t, store, store.Cfg, user.CreateUserCommand{
+	createUser(t, env.SQLStore, env.Cfg, user.CreateUserCommand{
 		DefaultOrgRole: string(org.RoleViewer),
 		Password:       "viewer",
 		Login:          "viewer",
 	})
-	createUser(t, store, store.Cfg, user.CreateUserCommand{
+	createUser(t, env.SQLStore, env.Cfg, user.CreateUserCommand{
 		DefaultOrgRole: string(org.RoleEditor),
 		Password:       "editor",
 		Login:          "editor",
 	})
-	createUser(t, store, store.Cfg, user.CreateUserCommand{
+	createUser(t, env.SQLStore, env.Cfg, user.CreateUserCommand{
 		DefaultOrgRole: string(org.RoleAdmin),
 		Password:       "admin",
 		Login:          "admin",
@@ -385,9 +385,9 @@ func TestMuteTimings(t *testing.T) {
 		AppModeProduction:     true,
 	})
 
-	grafanaListedAddr, store := testinfra.StartGrafana(t, dir, path)
+	grafanaListedAddr, env := testinfra.StartGrafanaEnv(t, dir, path)
 
-	createUser(t, store, store.Cfg, user.CreateUserCommand{
+	createUser(t, env.SQLStore, env.Cfg, user.CreateUserCommand{
 		DefaultOrgRole: string(org.RoleAdmin),
 		Password:       "admin",
 		Login:          "admin",

--- a/pkg/tests/api/alerting/api_ruler_test.go
+++ b/pkg/tests/api/alerting/api_ruler_test.go
@@ -55,7 +55,7 @@ func TestIntegrationAlertRulePermissions(t *testing.T) {
 	permissionsStore := resourcepermissions.NewStore(store, featuremgmt.WithFeatures())
 
 	// Create a user to make authenticated requests
-	userID := createUser(t, store, user.CreateUserCommand{
+	userID := createUser(t, store, store.Cfg, user.CreateUserCommand{
 		DefaultOrgRole: string(org.RoleEditor),
 		Password:       "password",
 		Login:          "grafana",
@@ -339,7 +339,7 @@ func TestIntegrationAlertRuleNestedPermissions(t *testing.T) {
 	permissionsStore := resourcepermissions.NewStore(store, featuremgmt.WithFeatures())
 
 	// Create a user to make authenticated requests
-	userID := createUser(t, store, user.CreateUserCommand{
+	userID := createUser(t, store, store.Cfg, user.CreateUserCommand{
 		DefaultOrgRole: string(org.RoleEditor),
 		Password:       "password",
 		Login:          "grafana",
@@ -735,7 +735,7 @@ func TestAlertRulePostExport(t *testing.T) {
 	permissionsStore := resourcepermissions.NewStore(store, featuremgmt.WithFeatures())
 
 	// Create a user to make authenticated requests
-	userID := createUser(t, store, user.CreateUserCommand{
+	userID := createUser(t, store, store.Cfg, user.CreateUserCommand{
 		DefaultOrgRole: string(org.RoleEditor),
 		Password:       "password",
 		Login:          "grafana",
@@ -814,7 +814,7 @@ func TestIntegrationAlertRuleConflictingTitle(t *testing.T) {
 	grafanaListedAddr, store := testinfra.StartGrafana(t, dir, path)
 
 	// Create user
-	createUser(t, store, user.CreateUserCommand{
+	createUser(t, store, store.Cfg, user.CreateUserCommand{
 		DefaultOrgRole: string(org.RoleAdmin),
 		Password:       "admin",
 		Login:          "admin",
@@ -904,7 +904,7 @@ func TestIntegrationRulerRulesFilterByDashboard(t *testing.T) {
 	grafanaListedAddr, store := testinfra.StartGrafana(t, dir, path)
 
 	// Create a user to make authenticated requests
-	createUser(t, store, user.CreateUserCommand{
+	createUser(t, store, store.Cfg, user.CreateUserCommand{
 		DefaultOrgRole: string(org.RoleEditor),
 		Password:       "password",
 		Login:          "grafana",
@@ -1244,7 +1244,7 @@ func TestIntegrationRuleGroupSequence(t *testing.T) {
 	grafanaListedAddr, store := testinfra.StartGrafana(t, dir, path)
 
 	// Create a user to make authenticated requests
-	createUser(t, store, user.CreateUserCommand{
+	createUser(t, store, store.Cfg, user.CreateUserCommand{
 		DefaultOrgRole: string(org.RoleEditor),
 		Password:       "password",
 		Login:          "grafana",
@@ -1339,7 +1339,7 @@ func TestIntegrationRuleCreate(t *testing.T) {
 		AppModeProduction:     true,
 	})
 	grafanaListedAddr, store := testinfra.StartGrafana(t, dir, path)
-	createUser(t, store, user.CreateUserCommand{
+	createUser(t, store, store.Cfg, user.CreateUserCommand{
 		DefaultOrgRole: string(org.RoleAdmin),
 		Password:       "admin",
 		Login:          "admin",
@@ -1415,7 +1415,7 @@ func TestIntegrationRuleUpdate(t *testing.T) {
 	permissionsStore := resourcepermissions.NewStore(store, featuremgmt.WithFeatures())
 
 	// Create a user to make authenticated requests
-	userID := createUser(t, store, user.CreateUserCommand{
+	userID := createUser(t, store, store.Cfg, user.CreateUserCommand{
 		DefaultOrgRole: string(org.RoleEditor),
 		Password:       "password",
 		Login:          "grafana",
@@ -1438,7 +1438,7 @@ func TestIntegrationRuleUpdate(t *testing.T) {
 	}
 
 	// Create a user to make authenticated requests
-	createUser(t, store, user.CreateUserCommand{
+	createUser(t, store, store.Cfg, user.CreateUserCommand{
 		DefaultOrgRole: string(org.RoleAdmin),
 		Password:       "admin",
 		Login:          "admin",
@@ -1631,7 +1631,7 @@ func TestIntegrationRulePause(t *testing.T) {
 	grafanaListedAddr, store := testinfra.StartGrafana(t, dir, path)
 
 	// Create a user to make authenticated requests
-	createUser(t, store, user.CreateUserCommand{
+	createUser(t, store, store.Cfg, user.CreateUserCommand{
 		DefaultOrgRole: string(org.RoleEditor),
 		Password:       "password",
 		Login:          "grafana",
@@ -1761,7 +1761,7 @@ func TestIntegrationHysteresisRule(t *testing.T) {
 	grafanaListedAddr, store := testinfra.StartGrafana(t, dir, p)
 
 	// Create a user to make authenticated requests
-	createUser(t, store, user.CreateUserCommand{
+	createUser(t, store, store.Cfg, user.CreateUserCommand{
 		DefaultOrgRole: string(org.RoleAdmin),
 		Password:       "password",
 		Login:          "grafana",
@@ -1835,7 +1835,7 @@ func TestIntegrationRuleNotificationSettings(t *testing.T) {
 	grafanaListedAddr, store := testinfra.StartGrafana(t, dir, p)
 
 	// Create a user to make authenticated requests
-	createUser(t, store, user.CreateUserCommand{
+	createUser(t, store, store.Cfg, user.CreateUserCommand{
 		DefaultOrgRole: string(org.RoleAdmin),
 		Password:       "password",
 		Login:          "grafana",

--- a/pkg/tests/api/alerting/api_ruler_test.go
+++ b/pkg/tests/api/alerting/api_ruler_test.go
@@ -51,11 +51,11 @@ func TestIntegrationAlertRulePermissions(t *testing.T) {
 		AppModeProduction:     true,
 	})
 
-	grafanaListedAddr, store := testinfra.StartGrafana(t, dir, p)
-	permissionsStore := resourcepermissions.NewStore(store, featuremgmt.WithFeatures())
+	grafanaListedAddr, env := testinfra.StartGrafanaEnv(t, dir, p)
+	permissionsStore := resourcepermissions.NewStore(env.SQLStore, featuremgmt.WithFeatures())
 
 	// Create a user to make authenticated requests
-	userID := createUser(t, store, store.Cfg, user.CreateUserCommand{
+	userID := createUser(t, env.SQLStore, env.Cfg, user.CreateUserCommand{
 		DefaultOrgRole: string(org.RoleEditor),
 		Password:       "password",
 		Login:          "grafana",
@@ -335,11 +335,11 @@ func TestIntegrationAlertRuleNestedPermissions(t *testing.T) {
 		AppModeProduction:     true,
 	})
 
-	grafanaListedAddr, store := testinfra.StartGrafana(t, dir, p)
-	permissionsStore := resourcepermissions.NewStore(store, featuremgmt.WithFeatures())
+	grafanaListedAddr, env := testinfra.StartGrafanaEnv(t, dir, p)
+	permissionsStore := resourcepermissions.NewStore(env.SQLStore, featuremgmt.WithFeatures())
 
 	// Create a user to make authenticated requests
-	userID := createUser(t, store, store.Cfg, user.CreateUserCommand{
+	userID := createUser(t, env.SQLStore, env.Cfg, user.CreateUserCommand{
 		DefaultOrgRole: string(org.RoleEditor),
 		Password:       "password",
 		Login:          "grafana",
@@ -731,11 +731,11 @@ func TestAlertRulePostExport(t *testing.T) {
 		AppModeProduction:     true,
 	})
 
-	grafanaListedAddr, store := testinfra.StartGrafana(t, dir, p)
-	permissionsStore := resourcepermissions.NewStore(store, featuremgmt.WithFeatures())
+	grafanaListedAddr, env := testinfra.StartGrafanaEnv(t, dir, p)
+	permissionsStore := resourcepermissions.NewStore(env.SQLStore, featuremgmt.WithFeatures())
 
 	// Create a user to make authenticated requests
-	userID := createUser(t, store, store.Cfg, user.CreateUserCommand{
+	userID := createUser(t, env.SQLStore, env.Cfg, user.CreateUserCommand{
 		DefaultOrgRole: string(org.RoleEditor),
 		Password:       "password",
 		Login:          "grafana",
@@ -811,10 +811,10 @@ func TestIntegrationAlertRuleConflictingTitle(t *testing.T) {
 		AppModeProduction:     true,
 	})
 
-	grafanaListedAddr, store := testinfra.StartGrafana(t, dir, path)
+	grafanaListedAddr, env := testinfra.StartGrafanaEnv(t, dir, path)
 
 	// Create user
-	createUser(t, store, store.Cfg, user.CreateUserCommand{
+	createUser(t, env.SQLStore, env.Cfg, user.CreateUserCommand{
 		DefaultOrgRole: string(org.RoleAdmin),
 		Password:       "admin",
 		Login:          "admin",
@@ -901,10 +901,10 @@ func TestIntegrationRulerRulesFilterByDashboard(t *testing.T) {
 		AppModeProduction:    true,
 	})
 
-	grafanaListedAddr, store := testinfra.StartGrafana(t, dir, path)
+	grafanaListedAddr, env := testinfra.StartGrafanaEnv(t, dir, path)
 
 	// Create a user to make authenticated requests
-	createUser(t, store, store.Cfg, user.CreateUserCommand{
+	createUser(t, env.SQLStore, env.Cfg, user.CreateUserCommand{
 		DefaultOrgRole: string(org.RoleEditor),
 		Password:       "password",
 		Login:          "grafana",
@@ -1241,10 +1241,10 @@ func TestIntegrationRuleGroupSequence(t *testing.T) {
 		DisableAnonymous:      true,
 		AppModeProduction:     true,
 	})
-	grafanaListedAddr, store := testinfra.StartGrafana(t, dir, path)
+	grafanaListedAddr, env := testinfra.StartGrafanaEnv(t, dir, path)
 
 	// Create a user to make authenticated requests
-	createUser(t, store, store.Cfg, user.CreateUserCommand{
+	createUser(t, env.SQLStore, env.Cfg, user.CreateUserCommand{
 		DefaultOrgRole: string(org.RoleEditor),
 		Password:       "password",
 		Login:          "grafana",
@@ -1338,8 +1338,8 @@ func TestIntegrationRuleCreate(t *testing.T) {
 		EnableUnifiedAlerting: true,
 		AppModeProduction:     true,
 	})
-	grafanaListedAddr, store := testinfra.StartGrafana(t, dir, path)
-	createUser(t, store, store.Cfg, user.CreateUserCommand{
+	grafanaListedAddr, env := testinfra.StartGrafanaEnv(t, dir, path)
+	createUser(t, env.SQLStore, env.Cfg, user.CreateUserCommand{
 		DefaultOrgRole: string(org.RoleAdmin),
 		Password:       "admin",
 		Login:          "admin",
@@ -1411,11 +1411,11 @@ func TestIntegrationRuleUpdate(t *testing.T) {
 		DisableAnonymous:      true,
 		AppModeProduction:     true,
 	})
-	grafanaListedAddr, store := testinfra.StartGrafana(t, dir, path)
-	permissionsStore := resourcepermissions.NewStore(store, featuremgmt.WithFeatures())
+	grafanaListedAddr, env := testinfra.StartGrafanaEnv(t, dir, path)
+	permissionsStore := resourcepermissions.NewStore(env.SQLStore, featuremgmt.WithFeatures())
 
 	// Create a user to make authenticated requests
-	userID := createUser(t, store, store.Cfg, user.CreateUserCommand{
+	userID := createUser(t, env.SQLStore, env.Cfg, user.CreateUserCommand{
 		DefaultOrgRole: string(org.RoleEditor),
 		Password:       "password",
 		Login:          "grafana",
@@ -1438,7 +1438,7 @@ func TestIntegrationRuleUpdate(t *testing.T) {
 	}
 
 	// Create a user to make authenticated requests
-	createUser(t, store, store.Cfg, user.CreateUserCommand{
+	createUser(t, env.SQLStore, env.Cfg, user.CreateUserCommand{
 		DefaultOrgRole: string(org.RoleAdmin),
 		Password:       "admin",
 		Login:          "admin",
@@ -1628,10 +1628,10 @@ func TestIntegrationRulePause(t *testing.T) {
 		DisableAnonymous:      true,
 		AppModeProduction:     true,
 	})
-	grafanaListedAddr, store := testinfra.StartGrafana(t, dir, path)
+	grafanaListedAddr, env := testinfra.StartGrafanaEnv(t, dir, path)
 
 	// Create a user to make authenticated requests
-	createUser(t, store, store.Cfg, user.CreateUserCommand{
+	createUser(t, env.SQLStore, env.Cfg, user.CreateUserCommand{
 		DefaultOrgRole: string(org.RoleEditor),
 		Password:       "password",
 		Login:          "grafana",
@@ -1758,10 +1758,10 @@ func TestIntegrationHysteresisRule(t *testing.T) {
 		EnableFeatureToggles:         []string{featuremgmt.FlagConfigurableSchedulerTick, featuremgmt.FlagRecoveryThreshold},
 	})
 
-	grafanaListedAddr, store := testinfra.StartGrafana(t, dir, p)
+	grafanaListedAddr, env := testinfra.StartGrafanaEnv(t, dir, p)
 
 	// Create a user to make authenticated requests
-	createUser(t, store, store.Cfg, user.CreateUserCommand{
+	createUser(t, env.SQLStore, env.Cfg, user.CreateUserCommand{
 		DefaultOrgRole: string(org.RoleAdmin),
 		Password:       "password",
 		Login:          "grafana",
@@ -1832,10 +1832,10 @@ func TestIntegrationRuleNotificationSettings(t *testing.T) {
 		EnableFeatureToggles:         []string{featuremgmt.FlagConfigurableSchedulerTick, featuremgmt.FlagAlertingSimplifiedRouting},
 	})
 
-	grafanaListedAddr, store := testinfra.StartGrafana(t, dir, p)
+	grafanaListedAddr, env := testinfra.StartGrafanaEnv(t, dir, p)
 
 	// Create a user to make authenticated requests
-	createUser(t, store, store.Cfg, user.CreateUserCommand{
+	createUser(t, env.SQLStore, env.Cfg, user.CreateUserCommand{
 		DefaultOrgRole: string(org.RoleAdmin),
 		Password:       "password",
 		Login:          "grafana",

--- a/pkg/tests/api/alerting/api_testing_test.go
+++ b/pkg/tests/api/alerting/api_testing_test.go
@@ -48,7 +48,7 @@ func TestGrafanaRuleConfig(t *testing.T) {
 
 	grafanaListedAddr, env := testinfra.StartGrafanaEnv(t, dir, path)
 
-	userId := createUser(t, env.SQLStore, user.CreateUserCommand{
+	userId := createUser(t, env.SQLStore, env.SQLStore.Cfg, user.CreateUserCommand{
 		DefaultOrgRole: string(org.RoleAdmin),
 		Password:       "admin",
 		Login:          "admin",
@@ -260,7 +260,7 @@ func TestGrafanaRuleConfig(t *testing.T) {
 
 		t.Skip("flakey tests - skipping") //TODO: Fix tests and remove skip.
 
-		testUserId := createUser(t, env.SQLStore, user.CreateUserCommand{
+		testUserId := createUser(t, env.SQLStore, env.SQLStore.Cfg, user.CreateUserCommand{
 			DefaultOrgRole: "DOESNOTEXIST", // Needed so that the SignedInUser has OrgId=1. Otherwise, datasource will not be found.
 			Password:       "test",
 			Login:          "test",

--- a/pkg/tests/api/alerting/api_testing_test.go
+++ b/pkg/tests/api/alerting/api_testing_test.go
@@ -48,7 +48,7 @@ func TestGrafanaRuleConfig(t *testing.T) {
 
 	grafanaListedAddr, env := testinfra.StartGrafanaEnv(t, dir, path)
 
-	userId := createUser(t, env.SQLStore, env.SQLStore.Cfg, user.CreateUserCommand{
+	userId := createUser(t, env.SQLStore, env.Cfg, user.CreateUserCommand{
 		DefaultOrgRole: string(org.RoleAdmin),
 		Password:       "admin",
 		Login:          "admin",
@@ -260,7 +260,7 @@ func TestGrafanaRuleConfig(t *testing.T) {
 
 		t.Skip("flakey tests - skipping") //TODO: Fix tests and remove skip.
 
-		testUserId := createUser(t, env.SQLStore, env.SQLStore.Cfg, user.CreateUserCommand{
+		testUserId := createUser(t, env.SQLStore, env.Cfg, user.CreateUserCommand{
 			DefaultOrgRole: "DOESNOTEXIST", // Needed so that the SignedInUser has OrgId=1. Otherwise, datasource will not be found.
 			Password:       "test",
 			Login:          "test",

--- a/pkg/tests/api/azuremonitor/azuremonitor_test.go
+++ b/pkg/tests/api/azuremonitor/azuremonitor_test.go
@@ -36,7 +36,7 @@ func TestIntegrationAzureMonitor(t *testing.T) {
 	grafanaListeningAddr, testEnv := testinfra.StartGrafanaEnv(t, dir, path)
 	ctx := context.Background()
 
-	u := testinfra.CreateUser(t, testEnv.SQLStore, user.CreateUserCommand{
+	u := testinfra.CreateUser(t, testEnv.SQLStore, testEnv.Cfg, user.CreateUserCommand{
 		DefaultOrgRole: string(org.RoleAdmin),
 		Password:       "admin",
 		Login:          "admin",

--- a/pkg/tests/api/correlations/common_test.go
+++ b/pkg/tests/api/correlations/common_test.go
@@ -142,9 +142,9 @@ func (c TestContext) getURL(url string, user User) string {
 func (c TestContext) createOrg(name string) int64 {
 	c.t.Helper()
 	store := c.env.SQLStore
-	store.Cfg.AutoAssignOrg = false
-	quotaService := quotaimpl.ProvideService(store, store.Cfg)
-	orgService, err := orgimpl.ProvideService(store, store.Cfg, quotaService)
+	c.env.Cfg.AutoAssignOrg = false
+	quotaService := quotaimpl.ProvideService(store, c.env.Cfg)
+	orgService, err := orgimpl.ProvideService(store, c.env.Cfg, quotaService)
 	require.NoError(c.t, err)
 	orgId, err := orgService.GetOrCreate(context.Background(), name)
 	require.NoError(c.t, err)
@@ -154,13 +154,13 @@ func (c TestContext) createOrg(name string) int64 {
 func (c TestContext) createUser(cmd user.CreateUserCommand) User {
 	c.t.Helper()
 	store := c.env.SQLStore
-	store.Cfg.AutoAssignOrg = true
-	store.Cfg.AutoAssignOrgId = 1
+	c.env.Cfg.AutoAssignOrg = true
+	c.env.Cfg.AutoAssignOrgId = 1
 
-	quotaService := quotaimpl.ProvideService(store, store.Cfg)
-	orgService, err := orgimpl.ProvideService(store, store.Cfg, quotaService)
+	quotaService := quotaimpl.ProvideService(store, c.env.Cfg)
+	orgService, err := orgimpl.ProvideService(store, c.env.Cfg, quotaService)
 	require.NoError(c.t, err)
-	usrSvc, err := userimpl.ProvideService(store, orgService, store.Cfg, nil, nil, quotaService, supportbundlestest.NewFakeBundleService())
+	usrSvc, err := userimpl.ProvideService(store, orgService, c.env.Cfg, nil, nil, quotaService, supportbundlestest.NewFakeBundleService())
 	require.NoError(c.t, err)
 
 	user, err := usrSvc.Create(context.Background(), &cmd)

--- a/pkg/tests/api/dashboards/api_dashboards_test.go
+++ b/pkg/tests/api/dashboards/api_dashboards_test.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/grafana/grafana/pkg/api/dtos"
 	"github.com/grafana/grafana/pkg/components/simplejson"
+	"github.com/grafana/grafana/pkg/infra/db"
 	"github.com/grafana/grafana/pkg/services/dashboardimport"
 	"github.com/grafana/grafana/pkg/services/dashboards"
 	"github.com/grafana/grafana/pkg/services/folder"
@@ -25,10 +26,10 @@ import (
 	"github.com/grafana/grafana/pkg/services/plugindashboards"
 	"github.com/grafana/grafana/pkg/services/quota/quotaimpl"
 	"github.com/grafana/grafana/pkg/services/search/model"
-	"github.com/grafana/grafana/pkg/services/sqlstore"
 	"github.com/grafana/grafana/pkg/services/supportbundles/supportbundlestest"
 	"github.com/grafana/grafana/pkg/services/user"
 	"github.com/grafana/grafana/pkg/services/user/userimpl"
+	"github.com/grafana/grafana/pkg/setting"
 	"github.com/grafana/grafana/pkg/tests/testinfra"
 	"github.com/grafana/grafana/pkg/tests/testsuite"
 	"github.com/grafana/grafana/pkg/util"
@@ -53,8 +54,9 @@ func TestIntegrationDashboardQuota(t *testing.T) {
 	})
 
 	grafanaListedAddr, store := testinfra.StartGrafana(t, dir, path)
+	cfg := store.Cfg
 	// Create user
-	createUser(t, store, user.CreateUserCommand{
+	createUser(t, store, cfg, user.CreateUserCommand{
 		DefaultOrgRole: string(org.RoleAdmin),
 		Password:       "admin",
 		Login:          "admin",
@@ -110,16 +112,16 @@ func TestIntegrationDashboardQuota(t *testing.T) {
 	})
 }
 
-func createUser(t *testing.T, store *sqlstore.SQLStore, cmd user.CreateUserCommand) int64 {
+func createUser(t *testing.T, db db.DB, cfg *setting.Cfg, cmd user.CreateUserCommand) int64 {
 	t.Helper()
 
-	store.Cfg.AutoAssignOrg = true
-	store.Cfg.AutoAssignOrgId = 1
+	cfg.AutoAssignOrg = true
+	cfg.AutoAssignOrgId = 1
 
-	quotaService := quotaimpl.ProvideService(store, store.Cfg)
-	orgService, err := orgimpl.ProvideService(store, store.Cfg, quotaService)
+	quotaService := quotaimpl.ProvideService(db, cfg)
+	orgService, err := orgimpl.ProvideService(db, cfg, quotaService)
 	require.NoError(t, err)
-	usrSvc, err := userimpl.ProvideService(store, orgService, store.Cfg, nil, nil, quotaService, supportbundlestest.NewFakeBundleService())
+	usrSvc, err := userimpl.ProvideService(db, orgService, cfg, nil, nil, quotaService, supportbundlestest.NewFakeBundleService())
 	require.NoError(t, err)
 
 	u, err := usrSvc.Create(context.Background(), &cmd)
@@ -156,8 +158,9 @@ providers:
 	err = os.WriteFile(provDashboardFile, input, 0644)
 	require.NoError(t, err)
 	grafanaListedAddr, store := testinfra.StartGrafana(t, dir, path)
+	cfg := store.Cfg
 	// Create user
-	createUser(t, store, user.CreateUserCommand{
+	createUser(t, store, cfg, user.CreateUserCommand{
 		DefaultOrgRole: string(org.RoleAdmin),
 		Password:       "admin",
 		Login:          "admin",
@@ -292,8 +295,9 @@ func TestIntegrationCreate(t *testing.T) {
 	})
 
 	grafanaListedAddr, store := testinfra.StartGrafana(t, dir, path)
+	cfg := store.Cfg
 	// Create user
-	createUser(t, store, user.CreateUserCommand{
+	createUser(t, store, cfg, user.CreateUserCommand{
 		DefaultOrgRole: string(org.RoleAdmin),
 		Password:       "admin",
 		Login:          "admin",

--- a/pkg/tests/api/dashboards/api_dashboards_test.go
+++ b/pkg/tests/api/dashboards/api_dashboards_test.go
@@ -53,8 +53,8 @@ func TestIntegrationDashboardQuota(t *testing.T) {
 		DashboardOrgQuota: &dashboardQuota,
 	})
 
-	grafanaListedAddr, store := testinfra.StartGrafana(t, dir, path)
-	cfg := store.Cfg
+	grafanaListedAddr, env := testinfra.StartGrafanaEnv(t, dir, path)
+	store, cfg := env.SQLStore, env.Cfg
 	// Create user
 	createUser(t, store, cfg, user.CreateUserCommand{
 		DefaultOrgRole: string(org.RoleAdmin),
@@ -157,8 +157,8 @@ providers:
 	provDashboardFile := filepath.Join(provDashboardsDir, "home.json")
 	err = os.WriteFile(provDashboardFile, input, 0644)
 	require.NoError(t, err)
-	grafanaListedAddr, store := testinfra.StartGrafana(t, dir, path)
-	cfg := store.Cfg
+	grafanaListedAddr, env := testinfra.StartGrafanaEnv(t, dir, path)
+	store, cfg := env.SQLStore, env.Cfg
 	// Create user
 	createUser(t, store, cfg, user.CreateUserCommand{
 		DefaultOrgRole: string(org.RoleAdmin),
@@ -294,8 +294,8 @@ func TestIntegrationCreate(t *testing.T) {
 		DisableAnonymous: true,
 	})
 
-	grafanaListedAddr, store := testinfra.StartGrafana(t, dir, path)
-	cfg := store.Cfg
+	grafanaListedAddr, env := testinfra.StartGrafanaEnv(t, dir, path)
+	store, cfg := env.SQLStore, env.Cfg
 	// Create user
 	createUser(t, store, cfg, user.CreateUserCommand{
 		DefaultOrgRole: string(org.RoleAdmin),

--- a/pkg/tests/api/elasticsearch/elasticsearch_test.go
+++ b/pkg/tests/api/elasticsearch/elasticsearch_test.go
@@ -36,7 +36,7 @@ func TestIntegrationElasticsearch(t *testing.T) {
 	grafanaListeningAddr, testEnv := testinfra.StartGrafanaEnv(t, dir, path)
 	ctx := context.Background()
 
-	u := testinfra.CreateUser(t, testEnv.SQLStore, user.CreateUserCommand{
+	u := testinfra.CreateUser(t, testEnv.SQLStore, testEnv.Cfg, user.CreateUserCommand{
 		DefaultOrgRole: string(org.RoleAdmin),
 		Password:       "admin",
 		Login:          "admin",

--- a/pkg/tests/api/folders/api_folder_test.go
+++ b/pkg/tests/api/folders/api_folder_test.go
@@ -9,14 +9,15 @@ import (
 	"github.com/go-openapi/runtime"
 	"github.com/grafana/grafana-openapi-client-go/client/folders"
 	"github.com/grafana/grafana-openapi-client-go/models"
+	"github.com/grafana/grafana/pkg/infra/db"
 	"github.com/grafana/grafana/pkg/services/featuremgmt"
 	"github.com/grafana/grafana/pkg/services/org"
 	"github.com/grafana/grafana/pkg/services/org/orgimpl"
 	"github.com/grafana/grafana/pkg/services/quota/quotaimpl"
-	"github.com/grafana/grafana/pkg/services/sqlstore"
 	"github.com/grafana/grafana/pkg/services/supportbundles/supportbundlestest"
 	"github.com/grafana/grafana/pkg/services/user"
 	"github.com/grafana/grafana/pkg/services/user/userimpl"
+	"github.com/grafana/grafana/pkg/setting"
 	"github.com/grafana/grafana/pkg/tests"
 	"github.com/grafana/grafana/pkg/tests/testinfra"
 	"github.com/stretchr/testify/assert"
@@ -36,8 +37,9 @@ func TestIntegrationUpdateFolder(t *testing.T) {
 	})
 
 	grafanaListedAddr, store := testinfra.StartGrafana(t, dir, path)
+	cfg := store.Cfg
 	// Create user
-	createUser(t, store, user.CreateUserCommand{
+	createUser(t, store, cfg, user.CreateUserCommand{
 		DefaultOrgRole: string(org.RoleAdmin),
 		Password:       "admin",
 		Login:          "admin",
@@ -72,8 +74,9 @@ func TestIntegrationCreateFolder(t *testing.T) {
 	})
 
 	grafanaListedAddr, store := testinfra.StartGrafana(t, dir, path)
+	cfg := store.Cfg
 	// Create user
-	createUser(t, store, user.CreateUserCommand{
+	createUser(t, store, cfg, user.CreateUserCommand{
 		DefaultOrgRole: string(org.RoleAdmin),
 		Password:       "admin",
 		Login:          "admin",
@@ -112,8 +115,9 @@ func TestIntegrationNestedFoldersOn(t *testing.T) {
 	})
 
 	grafanaListedAddr, store := testinfra.StartGrafana(t, dir, path)
+	cfg := store.Cfg
 	// Create user
-	createUser(t, store, user.CreateUserCommand{
+	createUser(t, store, cfg, user.CreateUserCommand{
 		DefaultOrgRole: string(org.RoleAdmin),
 		Password:       "admin",
 		Login:          "admin",
@@ -202,16 +206,16 @@ func TestIntegrationNestedFoldersOn(t *testing.T) {
 	})
 }
 
-func createUser(t *testing.T, store *sqlstore.SQLStore, cmd user.CreateUserCommand) int64 {
+func createUser(t *testing.T, db db.DB, cfg *setting.Cfg, cmd user.CreateUserCommand) int64 {
 	t.Helper()
 
-	store.Cfg.AutoAssignOrg = true
-	store.Cfg.AutoAssignOrgId = orgID
+	cfg.AutoAssignOrg = true
+	cfg.AutoAssignOrgId = orgID
 
-	quotaService := quotaimpl.ProvideService(store, store.Cfg)
-	orgService, err := orgimpl.ProvideService(store, store.Cfg, quotaService)
+	quotaService := quotaimpl.ProvideService(db, cfg)
+	orgService, err := orgimpl.ProvideService(db, cfg, quotaService)
 	require.NoError(t, err)
-	usrSvc, err := userimpl.ProvideService(store, orgService, store.Cfg, nil, nil, quotaService, supportbundlestest.NewFakeBundleService())
+	usrSvc, err := userimpl.ProvideService(db, orgService, cfg, nil, nil, quotaService, supportbundlestest.NewFakeBundleService())
 	require.NoError(t, err)
 
 	u, err := usrSvc.Create(context.Background(), &cmd)

--- a/pkg/tests/api/folders/api_folder_test.go
+++ b/pkg/tests/api/folders/api_folder_test.go
@@ -36,8 +36,8 @@ func TestIntegrationUpdateFolder(t *testing.T) {
 		EnableQuota:      true,
 	})
 
-	grafanaListedAddr, store := testinfra.StartGrafana(t, dir, path)
-	cfg := store.Cfg
+	grafanaListedAddr, env := testinfra.StartGrafanaEnv(t, dir, path)
+	store, cfg := env.SQLStore, env.Cfg
 	// Create user
 	createUser(t, store, cfg, user.CreateUserCommand{
 		DefaultOrgRole: string(org.RoleAdmin),
@@ -73,8 +73,8 @@ func TestIntegrationCreateFolder(t *testing.T) {
 		EnableQuota:      true,
 	})
 
-	grafanaListedAddr, store := testinfra.StartGrafana(t, dir, path)
-	cfg := store.Cfg
+	grafanaListedAddr, env := testinfra.StartGrafanaEnv(t, dir, path)
+	store, cfg := env.SQLStore, env.Cfg
 	// Create user
 	createUser(t, store, cfg, user.CreateUserCommand{
 		DefaultOrgRole: string(org.RoleAdmin),
@@ -114,8 +114,8 @@ func TestIntegrationNestedFoldersOn(t *testing.T) {
 		EnableFeatureToggles: []string{featuremgmt.FlagNestedFolders},
 	})
 
-	grafanaListedAddr, store := testinfra.StartGrafana(t, dir, path)
-	cfg := store.Cfg
+	grafanaListedAddr, env := testinfra.StartGrafanaEnv(t, dir, path)
+	store, cfg := env.SQLStore, env.Cfg
 	// Create user
 	createUser(t, store, cfg, user.CreateUserCommand{
 		DefaultOrgRole: string(org.RoleAdmin),

--- a/pkg/tests/api/folders/api_folders_test.go
+++ b/pkg/tests/api/folders/api_folders_test.go
@@ -35,8 +35,8 @@ func TestGetFolders(t *testing.T) {
 		EnableFeatureToggles:  []string{featuremgmt.FlagNestedFolders},
 	})
 
-	grafanaListedAddr, store := testinfra.StartGrafana(t, dir, p)
-	cfg := store.Cfg
+	grafanaListedAddr, env := testinfra.StartGrafanaEnv(t, dir, p)
+	store, cfg := env.SQLStore, env.Cfg
 
 	orgID := int64(1)
 

--- a/pkg/tests/api/folders/api_folders_test.go
+++ b/pkg/tests/api/folders/api_folders_test.go
@@ -36,23 +36,24 @@ func TestGetFolders(t *testing.T) {
 	})
 
 	grafanaListedAddr, store := testinfra.StartGrafana(t, dir, p)
+	cfg := store.Cfg
 
 	orgID := int64(1)
 
 	// Create a users to make authenticated requests
-	tests.CreateUser(t, store, user.CreateUserCommand{
+	tests.CreateUser(t, store, cfg, user.CreateUserCommand{
 		DefaultOrgRole: string(org.RoleViewer),
 		OrgID:          orgID,
 		Password:       "viewer",
 		Login:          "viewer",
 	})
-	tests.CreateUser(t, store, user.CreateUserCommand{
+	tests.CreateUser(t, store, cfg, user.CreateUserCommand{
 		OrgID:          orgID,
 		DefaultOrgRole: string(org.RoleEditor),
 		Password:       "editor",
 		Login:          "editor",
 	})
-	tests.CreateUser(t, store, user.CreateUserCommand{
+	tests.CreateUser(t, store, cfg, user.CreateUserCommand{
 		OrgID:          orgID,
 		DefaultOrgRole: string(org.RoleAdmin),
 		Password:       "admin",

--- a/pkg/tests/api/graphite/graphite_test.go
+++ b/pkg/tests/api/graphite/graphite_test.go
@@ -36,7 +36,7 @@ func TestIntegrationGraphite(t *testing.T) {
 	grafanaListeningAddr, testEnv := testinfra.StartGrafanaEnv(t, dir, path)
 	ctx := context.Background()
 
-	u := testinfra.CreateUser(t, testEnv.SQLStore, user.CreateUserCommand{
+	u := testinfra.CreateUser(t, testEnv.SQLStore, testEnv.Cfg, user.CreateUserCommand{
 		DefaultOrgRole: string(org.RoleAdmin),
 		Password:       "admin",
 		Login:          "admin",

--- a/pkg/tests/api/influxdb/influxdb_test.go
+++ b/pkg/tests/api/influxdb/influxdb_test.go
@@ -36,7 +36,7 @@ func TestIntegrationInflux(t *testing.T) {
 	grafanaListeningAddr, testEnv := testinfra.StartGrafanaEnv(t, dir, path)
 	ctx := context.Background()
 
-	u := testinfra.CreateUser(t, testEnv.SQLStore, user.CreateUserCommand{
+	u := testinfra.CreateUser(t, testEnv.SQLStore, testEnv.Cfg, user.CreateUserCommand{
 		DefaultOrgRole: string(org.RoleAdmin),
 		Password:       "admin",
 		Login:          "admin",

--- a/pkg/tests/api/loki/loki_test.go
+++ b/pkg/tests/api/loki/loki_test.go
@@ -36,7 +36,7 @@ func TestIntegrationLoki(t *testing.T) {
 	grafanaListeningAddr, testEnv := testinfra.StartGrafanaEnv(t, dir, path)
 	ctx := context.Background()
 
-	u := testinfra.CreateUser(t, testEnv.SQLStore, user.CreateUserCommand{
+	u := testinfra.CreateUser(t, testEnv.SQLStore, testEnv.Cfg, user.CreateUserCommand{
 		DefaultOrgRole: string(org.RoleAdmin),
 		Password:       "admin",
 		Login:          "admin",

--- a/pkg/tests/api/opentdsb/opentdsb_test.go
+++ b/pkg/tests/api/opentdsb/opentdsb_test.go
@@ -36,7 +36,7 @@ func TestIntegrationOpenTSDB(t *testing.T) {
 	grafanaListeningAddr, testEnv := testinfra.StartGrafanaEnv(t, dir, path)
 	ctx := context.Background()
 
-	u := testinfra.CreateUser(t, testEnv.SQLStore, user.CreateUserCommand{
+	u := testinfra.CreateUser(t, testEnv.SQLStore, testEnv.Cfg, user.CreateUserCommand{
 		DefaultOrgRole: string(org.RoleAdmin),
 		Password:       "admin",
 		Login:          "admin",

--- a/pkg/tests/api/plugins/api_plugins_test.go
+++ b/pkg/tests/api/plugins/api_plugins_test.go
@@ -56,7 +56,8 @@ func TestIntegrationPlugins(t *testing.T) {
 		setting.BuildVersion = origBuildVersion
 	})
 
-	grafanaListedAddr, store := testinfra.StartGrafana(t, dir, cfgPath)
+	grafanaListedAddr, env := testinfra.StartGrafanaEnv(t, dir, cfgPath)
+	store := env.SQLStore
 
 	type testCase struct {
 		desc        string
@@ -66,8 +67,8 @@ func TestIntegrationPlugins(t *testing.T) {
 	}
 
 	t.Run("Install", func(t *testing.T) {
-		createUser(t, store, store.Cfg, user.CreateUserCommand{Login: usernameNonAdmin, Password: defaultPassword, IsAdmin: false})
-		createUser(t, store, store.Cfg, user.CreateUserCommand{Login: usernameAdmin, Password: defaultPassword, IsAdmin: true})
+		createUser(t, store, env.Cfg, user.CreateUserCommand{Login: usernameNonAdmin, Password: defaultPassword, IsAdmin: false})
+		createUser(t, store, env.Cfg, user.CreateUserCommand{Login: usernameAdmin, Password: defaultPassword, IsAdmin: true})
 
 		t.Run("Request is forbidden if not from an admin", func(t *testing.T) {
 			status, body := makePostRequest(t, grafanaAPIURL(usernameNonAdmin, grafanaListedAddr, "plugins/grafana-plugin/install"))

--- a/pkg/tests/api/plugins/backendplugin/backendplugin_test.go
+++ b/pkg/tests/api/plugins/backendplugin/backendplugin_test.go
@@ -482,11 +482,11 @@ func newTestScenario(t *testing.T, name string, opts []testScenarioOption, callb
 		})
 	}
 	tsCtx.grafanaListeningAddr = grafanaListeningAddr
-	testEnv.SQLStore.Cfg.LoginCookieName = loginCookieName
+	testEnv.Cfg.LoginCookieName = loginCookieName
 	tsCtx.testEnv = testEnv
 	ctx := context.Background()
 
-	u := testinfra.CreateUser(t, testEnv.SQLStore, user.CreateUserCommand{
+	u := testinfra.CreateUser(t, testEnv.SQLStore, testEnv.Cfg, user.CreateUserCommand{
 		DefaultOrgRole: string(org.RoleAdmin),
 		Password:       "admin",
 		Login:          "admin",
@@ -646,7 +646,7 @@ func (tsCtx *testScenarioContext) runQueryDataTest(t *testing.T, mr dtos.MetricR
 		require.NoError(t, err)
 
 		require.NotEmpty(t, tsCtx.outgoingRequest.Header.Get("Accept-Encoding"))
-		require.Equal(t, fmt.Sprintf("Grafana/%s", tsCtx.testEnv.SQLStore.Cfg.BuildVersion), tsCtx.outgoingRequest.Header.Get("User-Agent"))
+		require.Equal(t, fmt.Sprintf("Grafana/%s", tsCtx.testEnv.Cfg.BuildVersion), tsCtx.outgoingRequest.Header.Get("User-Agent"))
 
 		callback(received)
 	})
@@ -704,7 +704,7 @@ func (tsCtx *testScenarioContext) runCheckHealthTest(t *testing.T, callback func
 		require.NoError(t, err)
 
 		require.NotEmpty(t, tsCtx.outgoingRequest.Header.Get("Accept-Encoding"))
-		require.Equal(t, fmt.Sprintf("Grafana/%s", tsCtx.testEnv.SQLStore.Cfg.BuildVersion), tsCtx.outgoingRequest.Header.Get("User-Agent"))
+		require.Equal(t, fmt.Sprintf("Grafana/%s", tsCtx.testEnv.Cfg.BuildVersion), tsCtx.outgoingRequest.Header.Get("User-Agent"))
 
 		callback(received)
 	})
@@ -779,7 +779,7 @@ func (tsCtx *testScenarioContext) runCallResourceTest(t *testing.T, callback fun
 		require.Empty(t, tsCtx.outgoingRequest.Header.Get("X-Some-Conn-Header"))
 		require.Empty(t, tsCtx.outgoingRequest.Header.Get("Proxy-Connection"))
 		require.NotEmpty(t, tsCtx.outgoingRequest.Header.Get("Accept-Encoding"))
-		require.Equal(t, fmt.Sprintf("Grafana/%s", tsCtx.testEnv.SQLStore.Cfg.BuildVersion), tsCtx.outgoingRequest.Header.Get("User-Agent"))
+		require.Equal(t, fmt.Sprintf("Grafana/%s", tsCtx.testEnv.Cfg.BuildVersion), tsCtx.outgoingRequest.Header.Get("User-Agent"))
 
 		callback(received, resp)
 	})

--- a/pkg/tests/api/prometheus/prometheus_test.go
+++ b/pkg/tests/api/prometheus/prometheus_test.go
@@ -35,7 +35,7 @@ func TestIntegrationPrometheus(t *testing.T) {
 	grafanaListeningAddr, testEnv := testinfra.StartGrafanaEnv(t, dir, path)
 	ctx := context.Background()
 
-	u := testinfra.CreateUser(t, testEnv.SQLStore, user.CreateUserCommand{
+	u := testinfra.CreateUser(t, testEnv.SQLStore, testEnv.Cfg, user.CreateUserCommand{
 		DefaultOrgRole: string(org.RoleAdmin),
 		Password:       "admin",
 		Login:          "admin",

--- a/pkg/tests/api/stats/admin_test.go
+++ b/pkg/tests/api/stats/admin_test.go
@@ -67,10 +67,10 @@ func grafanaSetup(t *testing.T, opts testinfra.GrafanaOpts) string {
 	// Setup Grafana and its Database
 	dir, path := testinfra.CreateGrafDir(t, opts)
 
-	grafanaListedAddr, store := testinfra.StartGrafana(t, dir, path)
+	grafanaListedAddr, env := testinfra.StartGrafanaEnv(t, dir, path)
 
 	// Create a user to make authenticated requests
-	createUser(t, store, store.Cfg, user.CreateUserCommand{
+	createUser(t, env.SQLStore, env.Cfg, user.CreateUserCommand{
 		DefaultOrgRole: string(org.RoleAdmin),
 		Login:          "grafana",
 		Password:       "password",

--- a/pkg/tests/api/stats/admin_test.go
+++ b/pkg/tests/api/stats/admin_test.go
@@ -8,13 +8,14 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/grafana/grafana/pkg/infra/db"
 	"github.com/grafana/grafana/pkg/services/org"
 	"github.com/grafana/grafana/pkg/services/org/orgimpl"
 	"github.com/grafana/grafana/pkg/services/quota/quotaimpl"
-	"github.com/grafana/grafana/pkg/services/sqlstore"
 	"github.com/grafana/grafana/pkg/services/supportbundles/supportbundlestest"
 	"github.com/grafana/grafana/pkg/services/user"
 	"github.com/grafana/grafana/pkg/services/user/userimpl"
+	"github.com/grafana/grafana/pkg/setting"
 	"github.com/grafana/grafana/pkg/tests/testinfra"
 	"github.com/grafana/grafana/pkg/tests/testsuite"
 )
@@ -69,7 +70,7 @@ func grafanaSetup(t *testing.T, opts testinfra.GrafanaOpts) string {
 	grafanaListedAddr, store := testinfra.StartGrafana(t, dir, path)
 
 	// Create a user to make authenticated requests
-	createUser(t, store, user.CreateUserCommand{
+	createUser(t, store, store.Cfg, user.CreateUserCommand{
 		DefaultOrgRole: string(org.RoleAdmin),
 		Login:          "grafana",
 		Password:       "password",
@@ -79,16 +80,16 @@ func grafanaSetup(t *testing.T, opts testinfra.GrafanaOpts) string {
 	return fmt.Sprintf("http://%s:%s@%s/api/admin/stats", "grafana", "password", grafanaListedAddr)
 }
 
-func createUser(t *testing.T, store *sqlstore.SQLStore, cmd user.CreateUserCommand) int64 {
+func createUser(t *testing.T, db db.DB, cfg *setting.Cfg, cmd user.CreateUserCommand) int64 {
 	t.Helper()
 
-	store.Cfg.AutoAssignOrg = true
-	store.Cfg.AutoAssignOrgId = 1
+	cfg.AutoAssignOrg = true
+	cfg.AutoAssignOrgId = 1
 
-	quotaService := quotaimpl.ProvideService(store, store.Cfg)
-	orgService, err := orgimpl.ProvideService(store, store.Cfg, quotaService)
+	quotaService := quotaimpl.ProvideService(db, cfg)
+	orgService, err := orgimpl.ProvideService(db, cfg, quotaService)
 	require.NoError(t, err)
-	usrSvc, err := userimpl.ProvideService(store, orgService, store.Cfg, nil, nil, quotaService, supportbundlestest.NewFakeBundleService())
+	usrSvc, err := userimpl.ProvideService(db, orgService, cfg, nil, nil, quotaService, supportbundlestest.NewFakeBundleService())
 	require.NoError(t, err)
 
 	u, err := usrSvc.Create(context.Background(), &cmd)

--- a/pkg/tests/apis/helper.go
+++ b/pkg/tests/apis/helper.go
@@ -375,13 +375,13 @@ func (c K8sTestHelper) createTestUsers(orgName string) OrgUsers {
 
 	store := c.env.SQLStore
 	defer func() {
-		store.Cfg.AutoAssignOrg = false
-		store.Cfg.AutoAssignOrgId = 1 // the default
+		c.env.Cfg.AutoAssignOrg = false
+		c.env.Cfg.AutoAssignOrgId = 1 // the default
 	}()
 
-	quotaService := quotaimpl.ProvideService(store, store.Cfg)
+	quotaService := quotaimpl.ProvideService(store, c.env.Cfg)
 
-	orgService, err := orgimpl.ProvideService(store, store.Cfg, quotaService)
+	orgService, err := orgimpl.ProvideService(store, c.env.Cfg, quotaService)
 	require.NoError(c.t, err)
 
 	orgId := int64(1)
@@ -389,15 +389,15 @@ func (c K8sTestHelper) createTestUsers(orgName string) OrgUsers {
 		orgId, err = orgService.GetOrCreate(context.Background(), orgName)
 		require.NoError(c.t, err)
 	}
-	store.Cfg.AutoAssignOrg = true
-	store.Cfg.AutoAssignOrgId = int(orgId)
+	c.env.Cfg.AutoAssignOrg = true
+	c.env.Cfg.AutoAssignOrgId = int(orgId)
 
-	teamSvc, err := teamimpl.ProvideService(store, store.Cfg)
+	teamSvc, err := teamimpl.ProvideService(store, c.env.Cfg)
 	require.NoError(c.t, err)
 
 	cache := localcache.ProvideService()
 	userSvc, err := userimpl.ProvideService(store,
-		orgService, store.Cfg, teamSvc, cache, quotaService,
+		orgService, c.env.Cfg, teamSvc, cache, quotaService,
 		supportbundlestest.NewFakeBundleService())
 	require.NoError(c.t, err)
 

--- a/pkg/tests/testinfra/testinfra.go
+++ b/pkg/tests/testinfra/testinfra.go
@@ -249,6 +249,7 @@ func CreateGrafDir(t *testing.T, opts ...GrafanaOpts) (string, string) {
 		return section, err
 	}
 
+	queryRetries := 3
 	for _, o := range opts {
 		if o.EnableCSP {
 			securitySect, err := cfg.NewSection("security")
@@ -363,14 +364,9 @@ func CreateGrafDir(t *testing.T, opts ...GrafanaOpts) (string, string) {
 			require.NoError(t, err)
 		}
 		// retry queries 3 times by default
-		queryRetries := 3
 		if o.QueryRetries != 0 {
 			queryRetries = int(o.QueryRetries)
 		}
-		logSection, err := getOrCreateSection("database")
-		require.NoError(t, err)
-		_, err = logSection.NewKey("query_retries", fmt.Sprintf("%d", queryRetries))
-		require.NoError(t, err)
 
 		if o.NGAlertSchedulerBaseInterval > 0 {
 			unifiedAlertingSection, err := getOrCreateSection("unified_alerting")
@@ -381,6 +377,10 @@ func CreateGrafDir(t *testing.T, opts ...GrafanaOpts) (string, string) {
 			require.NoError(t, err)
 		}
 	}
+	logSection, err := getOrCreateSection("database")
+	require.NoError(t, err)
+	_, err = logSection.NewKey("query_retries", fmt.Sprintf("%d", queryRetries))
+	require.NoError(t, err)
 
 	cfgPath := filepath.Join(cfgDir, "test.ini")
 	err = cfg.SaveTo(cfgPath)

--- a/pkg/tests/utils.go
+++ b/pkg/tests/utils.go
@@ -9,27 +9,28 @@ import (
 
 	"github.com/go-openapi/strfmt"
 	goapi "github.com/grafana/grafana-openapi-client-go/client"
+	"github.com/grafana/grafana/pkg/infra/db"
 	"github.com/grafana/grafana/pkg/services/accesscontrol/resourcepermissions"
 	"github.com/grafana/grafana/pkg/services/org"
 	"github.com/grafana/grafana/pkg/services/org/orgimpl"
 	"github.com/grafana/grafana/pkg/services/quota/quotaimpl"
-	"github.com/grafana/grafana/pkg/services/sqlstore"
 	"github.com/grafana/grafana/pkg/services/supportbundles/supportbundlestest"
 	"github.com/grafana/grafana/pkg/services/user"
 	"github.com/grafana/grafana/pkg/services/user/userimpl"
+	"github.com/grafana/grafana/pkg/setting"
 	"github.com/stretchr/testify/require"
 )
 
-func CreateUser(t *testing.T, store *sqlstore.SQLStore, cmd user.CreateUserCommand) int64 {
+func CreateUser(t *testing.T, db db.DB, cfg *setting.Cfg, cmd user.CreateUserCommand) int64 {
 	t.Helper()
 
-	store.Cfg.AutoAssignOrg = true
-	store.Cfg.AutoAssignOrgId = 1
+	cfg.AutoAssignOrg = true
+	cfg.AutoAssignOrgId = 1
 
-	quotaService := quotaimpl.ProvideService(store, store.Cfg)
-	orgService, err := orgimpl.ProvideService(store, store.Cfg, quotaService)
+	quotaService := quotaimpl.ProvideService(db, cfg)
+	orgService, err := orgimpl.ProvideService(db, cfg, quotaService)
 	require.NoError(t, err)
-	usrSvc, err := userimpl.ProvideService(store, orgService, store.Cfg, nil, nil, quotaService, supportbundlestest.NewFakeBundleService())
+	usrSvc, err := userimpl.ProvideService(db, orgService, cfg, nil, nil, quotaService, supportbundlestest.NewFakeBundleService())
 	require.NoError(t, err)
 
 	u, err := usrSvc.Create(context.Background(), &cmd)

--- a/pkg/tests/web/index_view_test.go
+++ b/pkg/tests/web/index_view_test.go
@@ -125,8 +125,9 @@ func TestIntegrationIndexViewAnalytics(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			grafDir, cfgPath := testinfra.CreateGrafDir(t, testinfra.GrafanaOpts{})
-			addr, store := testinfra.StartGrafana(t, grafDir, cfgPath)
-			createdUser := testinfra.CreateUser(t, store, user.CreateUserCommand{
+			addr, env := testinfra.StartGrafanaEnv(t, grafDir, cfgPath)
+			store := env.SQLStore
+			createdUser := testinfra.CreateUser(t, store, env.Cfg, user.CreateUserCommand{
 				Login:    "admin",
 				Password: "admin",
 				Email:    "admin@grafana.com",


### PR DESCRIPTION
This may look like a large PR, but it's mostly automatic.

It replaces `*sqlstore.SQLStore` with `db.DB` in all the services. However, some "lazy" services relied on the `setting.Cfg` to be part of the SQLStore instead of injecting a config explicitly. This PR fixes it, too.

Next steps (once this is merged) would be to make `sqlstore.SQLStore.Cfg` private and hopefully get rid of the sqlstore package altogether (by moving DB connection logic into `infra/db`).