### PR TITLE
datatrails: handle "single" layout when switching to "all" labels

### DIFF
--- a/public/app/features/trails/ActionTabs/LayoutSwitcher.tsx
+++ b/public/app/features/trails/ActionTabs/LayoutSwitcher.tsx
@@ -50,7 +50,7 @@ export class LayoutSwitcher extends SceneObjectBase<LayoutSwitcherState> {
       return null;
     }
 
-    const layout = layouts[index] || layouts[0];
+    const layout = layouts[index];
 
     return <layout.Component model={layout} />;
   };

--- a/public/app/features/trails/ActionTabs/LayoutSwitcher.tsx
+++ b/public/app/features/trails/ActionTabs/LayoutSwitcher.tsx
@@ -20,13 +20,21 @@ export class LayoutSwitcher extends SceneObjectBase<LayoutSwitcherState> {
 
   public Selector({ model }: { model: LayoutSwitcher }) {
     const { options } = model.useState();
-    const { layout } = model.getMetricScene().useState();
+    const activeLayout = model.useActiveLayout();
 
     return (
       <Field label="View">
-        <RadioButtonGroup options={options} value={layout} onChange={model.onLayoutChange} />
+        <RadioButtonGroup options={options} value={activeLayout} onChange={model.onLayoutChange} />
       </Field>
     );
+  }
+
+  private useActiveLayout() {
+    const { options } = this.useState();
+    const { layout } = this.getMetricScene().useState();
+
+    const activeLayout = options.map((option) => option.value).includes(layout) ? layout : options[0].value;
+    return activeLayout;
   }
 
   public onLayoutChange = (active: LayoutType) => {
@@ -35,14 +43,14 @@ export class LayoutSwitcher extends SceneObjectBase<LayoutSwitcherState> {
 
   public static Component = ({ model }: SceneComponentProps<LayoutSwitcher>) => {
     const { layouts, options } = model.useState();
-    const { layout: activeLayout } = model.getMetricScene().useState();
+    const activeLayout = model.useActiveLayout();
 
     const index = options.findIndex((o) => o.value === activeLayout);
     if (index === -1) {
       return null;
     }
 
-    const layout = layouts[index];
+    const layout = layouts[index] || layouts[0];
 
     return <layout.Component model={layout} />;
   };


### PR DESCRIPTION
**What is this feature?**

The breakdown view's "All" labels option does not have a "Single" layout mode, but each specific label option does. When "single" layout was selected, and the user switched to "All," no layout would appear.

Now, switching to "All" will temporarily select "Grid" layout for when "Single" layout is not an option.
Until the user makes an explicit layout switch, the selection will remain "Single" when that layout is available as an option.


**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
