### PR TITLE
Storage Api: Adds traces

### DIFF
--- a/conf/defaults.ini
+++ b/conf/defaults.ini
@@ -104,6 +104,8 @@ address = "127.0.0.1:10000"
 use_tls = false
 cert_file =
 key_file =
+# this will log the request and response for each unary gRPC call
+enable_logging = false
 
 #################################### Database ############################
 [database]

--- a/pkg/services/apiserver/service.go
+++ b/pkg/services/apiserver/service.go
@@ -251,7 +251,7 @@ func (s *service) start(ctx context.Context) error {
 			return err
 		}
 
-		storeServer, err := sqlstash.ProvideSQLEntityServer(eDB)
+		storeServer, err := sqlstash.ProvideSQLEntityServer(eDB, s.tracing)
 		if err != nil {
 			return err
 		}

--- a/pkg/services/apiserver/storage/entity/test/watch_test.go
+++ b/pkg/services/apiserver/storage/entity/test/watch_test.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	"testing"
 
+	"github.com/grafana/grafana/pkg/infra/tracing"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"k8s.io/apimachinery/pkg/api/apitesting"
@@ -71,7 +72,11 @@ func createTestContext(t *testing.T) (entityStore.EntityStoreClient, factory.Des
 	err = eDB.Init()
 	require.NoError(t, err)
 
-	store, err := sqlstash.ProvideSQLEntityServer(eDB)
+	traceConfig, err := tracing.ParseTracingConfig(cfg)
+	require.NoError(t, err)
+	tracer, err := tracing.ProvideService(traceConfig)
+	require.NoError(t, err)
+	store, err := sqlstash.ProvideSQLEntityServer(eDB, tracer)
 	require.NoError(t, err)
 
 	client := entityStore.NewEntityStoreClientLocal(store)

--- a/pkg/services/grpcserver/interceptors/logging.go
+++ b/pkg/services/grpcserver/interceptors/logging.go
@@ -17,11 +17,11 @@ func LoggingUnaryInterceptor(cfg *setting.Cfg, logger log.Logger) grpc.UnaryServ
 	) (resp any, err error) {
 		resp, err = handler(ctx, req)
 		if cfg.GRPCServerEnableLogging {
-			logger = logger.FromContext(ctx)
+			ctxLogger := logger.FromContext(ctx)
 			if err != nil {
-				logger.Error("gRPC call", "method", info.FullMethod, "req", req, "err", err)
+				ctxLogger.Error("gRPC call", "method", info.FullMethod, "req", req, "err", err)
 			} else {
-				logger.Info("gRPC call", "method", info.FullMethod, "req", req, "resp", resp)
+				ctxLogger.Info("gRPC call", "method", info.FullMethod, "req", req, "resp", resp)
 			}
 		}
 		return resp, err

--- a/pkg/services/grpcserver/interceptors/logging.go
+++ b/pkg/services/grpcserver/interceptors/logging.go
@@ -1,0 +1,22 @@
+package interceptors
+
+import (
+	"context"
+
+	"github.com/grafana/grafana/pkg/infra/log"
+	"google.golang.org/grpc"
+)
+
+func LoggingUnaryInterceptor(logger log.Logger) grpc.UnaryServerInterceptor {
+	return func(
+		ctx context.Context,
+		req any,
+		info *grpc.UnaryServerInfo,
+		handler grpc.UnaryHandler,
+	) (resp any, err error) {
+		logger = logger.FromContext(ctx)
+		logger.Info("gRPC call received", "method", info.FullMethod, "req", req)
+		resp, err = handler(ctx, req)
+		return resp, err
+	}
+}

--- a/pkg/services/grpcserver/interceptors/logging.go
+++ b/pkg/services/grpcserver/interceptors/logging.go
@@ -15,8 +15,8 @@ func LoggingUnaryInterceptor(logger log.Logger) grpc.UnaryServerInterceptor {
 		handler grpc.UnaryHandler,
 	) (resp any, err error) {
 		logger = logger.FromContext(ctx)
-		logger.Info("gRPC call received", "method", info.FullMethod, "req", req)
 		resp, err = handler(ctx, req)
+		logger.Info("gRPC call received", "method", info.FullMethod, "req", req, "resp", resp, "err", err)
 		return resp, err
 	}
 }

--- a/pkg/services/grpcserver/interceptors/logging.go
+++ b/pkg/services/grpcserver/interceptors/logging.go
@@ -4,19 +4,26 @@ import (
 	"context"
 
 	"github.com/grafana/grafana/pkg/infra/log"
+	"github.com/grafana/grafana/pkg/setting"
 	"google.golang.org/grpc"
 )
 
-func LoggingUnaryInterceptor(logger log.Logger) grpc.UnaryServerInterceptor {
+func LoggingUnaryInterceptor(cfg *setting.Cfg, logger log.Logger) grpc.UnaryServerInterceptor {
 	return func(
 		ctx context.Context,
 		req any,
 		info *grpc.UnaryServerInfo,
 		handler grpc.UnaryHandler,
 	) (resp any, err error) {
-		logger = logger.FromContext(ctx)
 		resp, err = handler(ctx, req)
-		logger.Info("gRPC call received", "method", info.FullMethod, "req", req, "resp", resp, "err", err)
+		if cfg.GRPCServerEnableLogging {
+			logger = logger.FromContext(ctx)
+			if err != nil {
+				logger.Error("gRPC call", "method", info.FullMethod, "req", req, "err", err)
+			} else {
+				logger.Info("gRPC call", "method", info.FullMethod, "req", req, "resp", resp)
+			}
+		}
 		return resp, err
 	}
 }

--- a/pkg/services/grpcserver/service.go
+++ b/pkg/services/grpcserver/service.go
@@ -73,6 +73,7 @@ func ProvideService(cfg *setting.Cfg, features featuremgmt.FeatureToggles, authe
 			grpc_middleware.ChainUnaryServer(
 				grpcAuth.UnaryServerInterceptor(authenticator.Authenticate),
 				interceptors.TracingUnaryInterceptor(tracer),
+				interceptors.LoggingUnaryInterceptor(s.logger), // needs to be registered after tracing interceptor to get trace id
 				middleware.UnaryServerInstrumentInterceptor(grpcRequestDuration),
 			),
 		),

--- a/pkg/services/grpcserver/service.go
+++ b/pkg/services/grpcserver/service.go
@@ -73,7 +73,7 @@ func ProvideService(cfg *setting.Cfg, features featuremgmt.FeatureToggles, authe
 			grpc_middleware.ChainUnaryServer(
 				grpcAuth.UnaryServerInterceptor(authenticator.Authenticate),
 				interceptors.TracingUnaryInterceptor(tracer),
-				interceptors.LoggingUnaryInterceptor(s.logger), // needs to be registered after tracing interceptor to get trace id
+				interceptors.LoggingUnaryInterceptor(s.cfg, s.logger), // needs to be registered after tracing interceptor to get trace id
 				middleware.UnaryServerInstrumentInterceptor(grpcRequestDuration),
 			),
 		),

--- a/pkg/services/store/entity/server/service.go
+++ b/pkg/services/store/entity/server/service.go
@@ -114,7 +114,7 @@ func (s *service) start(ctx context.Context) error {
 		return err
 	}
 
-	store, err := sqlstash.ProvideSQLEntityServer(eDB)
+	store, err := sqlstash.ProvideSQLEntityServer(eDB, s.tracing)
 	if err != nil {
 		return err
 	}

--- a/pkg/services/store/entity/server/service.go
+++ b/pkg/services/store/entity/server/service.go
@@ -64,6 +64,7 @@ func ProvideService(
 	if err != nil {
 		return nil, err
 	}
+	tracingCfg.ServiceName = "unified-storage"
 
 	tracing, err := tracing.ProvideService(tracingCfg)
 	if err != nil {

--- a/pkg/services/store/entity/sqlstash/sql_storage_server.go
+++ b/pkg/services/store/entity/sqlstash/sql_storage_server.go
@@ -230,6 +230,7 @@ func readEntity(rows *sql.Rows, r FieldSelectRequest) (*entity.Entity, error) {
 func (s *sqlEntityServer) Read(ctx context.Context, r *entity.ReadEntityRequest) (*entity.Entity, error) {
 	ctx, span := s.tracer.Start(ctx, "storage_server.Read")
 	defer span.End()
+	span.SetAttributes(attribute.String("request", r.String()))
 	s.log = s.log.FromContext(ctx)
 
 	if err := s.Init(); err != nil {
@@ -301,6 +302,7 @@ func (s *sqlEntityServer) read(ctx context.Context, tx session.SessionQuerier, r
 func (s *sqlEntityServer) Create(ctx context.Context, r *entity.CreateEntityRequest) (*entity.CreateEntityResponse, error) {
 	ctx, span := s.tracer.Start(ctx, "storage_server.Create")
 	defer span.End()
+	span.SetAttributes(attribute.String("request", r.String()))
 	s.log = s.log.FromContext(ctx)
 
 	if err := s.Init(); err != nil {
@@ -523,6 +525,7 @@ func (s *sqlEntityServer) Create(ctx context.Context, r *entity.CreateEntityRequ
 func (s *sqlEntityServer) Update(ctx context.Context, r *entity.UpdateEntityRequest) (*entity.UpdateEntityResponse, error) {
 	ctx, span := s.tracer.Start(ctx, "storage_server.Update")
 	defer span.End()
+	span.SetAttributes(attribute.String("request", r.String()))
 	s.log = s.log.FromContext(ctx)
 
 	if err := s.Init(); err != nil {
@@ -802,6 +805,7 @@ func (s *sqlEntityServer) setLabels(ctx context.Context, tx *session.SessionTx, 
 func (s *sqlEntityServer) Delete(ctx context.Context, r *entity.DeleteEntityRequest) (*entity.DeleteEntityResponse, error) {
 	ctx, span := s.tracer.Start(ctx, "storage_server.Delete")
 	defer span.End()
+	span.SetAttributes(attribute.String("request", r.String()))
 	s.log = s.log.FromContext(ctx)
 
 	if err := s.Init(); err != nil {
@@ -980,6 +984,7 @@ func (s *sqlEntityServer) doDelete(ctx context.Context, tx *session.SessionTx, e
 func (s *sqlEntityServer) History(ctx context.Context, r *entity.EntityHistoryRequest) (*entity.EntityHistoryResponse, error) {
 	ctx, span := s.tracer.Start(ctx, "storage_server.History")
 	defer span.End()
+	span.SetAttributes(attribute.String("request", r.String()))
 	s.log = s.log.FromContext(ctx)
 
 	if err := s.Init(); err != nil {
@@ -1178,6 +1183,7 @@ func ParseSortBy(sort string) (*SortBy, error) {
 //nolint:gocyclo
 func (s *sqlEntityServer) List(ctx context.Context, r *entity.EntityListRequest) (*entity.EntityListResponse, error) {
 	ctx, span := s.tracer.Start(ctx, "storage_server.List")
+	span.SetAttributes(attribute.String("request", r.String()))
 	defer span.End()
 	s.log = s.log.FromContext(ctx)
 
@@ -1388,6 +1394,7 @@ func (s *sqlEntityServer) List(ctx context.Context, r *entity.EntityListRequest)
 
 		rsp.Results = append(rsp.Results, result)
 	}
+	span.AddEvent("processed rows", trace.WithAttributes(attribute.Int("row_count", len(rsp.Results))))
 
 	return rsp, err
 }
@@ -1865,6 +1872,7 @@ func (s *sqlEntityServer) watchEvent(r *entity.EntityWatchRequest, result *entit
 func (s *sqlEntityServer) FindReferences(ctx context.Context, r *entity.ReferenceRequest) (*entity.EntityListResponse, error) {
 	ctx, span := s.tracer.Start(ctx, "storage_server.FindReferences")
 	defer span.End()
+	span.SetAttributes(attribute.String("request", r.String()))
 	s.log = s.log.FromContext(ctx)
 
 	if err := s.Init(); err != nil {

--- a/pkg/services/store/entity/sqlstash/sql_storage_server.go
+++ b/pkg/services/store/entity/sqlstash/sql_storage_server.go
@@ -246,6 +246,7 @@ func (s *sqlEntityServer) Read(ctx context.Context, r *entity.ReadEntityRequest)
 	res, err := s.read(ctx, s.sess, r)
 	if err != nil {
 		s.log.Error("read error", "error", err, "method", "read")
+		return nil, err
 	}
 	return res, nil
 }

--- a/pkg/services/store/entity/sqlstash/sql_storage_server.go
+++ b/pkg/services/store/entity/sqlstash/sql_storage_server.go
@@ -2001,7 +2001,7 @@ func (s *sqlEntityServer) exec(ctx context.Context, tx *session.SessionTx, state
 	ctx, span := s.tracer.Start(ctx, "storage_server.exec", trace.WithAttributes(attribute.String("statement", statement)))
 	defer span.End()
 
-	_, err := tx.Exec(ctx, statement, args)
+	_, err := tx.Exec(ctx, statement, args...)
 	return err
 }
 

--- a/pkg/services/store/entity/sqlstash/sql_storage_server.go
+++ b/pkg/services/store/entity/sqlstash/sql_storage_server.go
@@ -1566,7 +1566,7 @@ func (s *sqlEntityServer) watchInit(ctx context.Context, r *entity.EntityWatchRe
 
 			s.log.Debug("watch init", "query", query, "args", args)
 
-			rows, err := s.query(w.Context(), query, args...)
+			rows, err := s.query(ctx, query, args...)
 			if err != nil {
 				return err
 			}

--- a/pkg/services/store/entity/sqlstash/sql_storage_server.go
+++ b/pkg/services/store/entity/sqlstash/sql_storage_server.go
@@ -236,7 +236,6 @@ func readEntity(rows *sql.Rows, r FieldSelectRequest) (*entity.Entity, error) {
 func (s *sqlEntityServer) Read(ctx context.Context, r *entity.ReadEntityRequest) (*entity.Entity, error) {
 	ctx, span := s.tracer.Start(ctx, "storage_server.Read")
 	defer span.End()
-	span.SetAttributes(attribute.String("request", r.String()))
 	ctxLogger := s.log.FromContext(ctx)
 
 	if err := s.Init(); err != nil {
@@ -313,7 +312,6 @@ func (s *sqlEntityServer) read(ctx context.Context, tx session.SessionQuerier, r
 func (s *sqlEntityServer) Create(ctx context.Context, r *entity.CreateEntityRequest) (*entity.CreateEntityResponse, error) {
 	ctx, span := s.tracer.Start(ctx, "storage_server.Create")
 	defer span.End()
-	span.SetAttributes(attribute.String("request", r.String()))
 	ctxLogger := s.log.FromContext(ctx)
 
 	if err := s.Init(); err != nil {
@@ -543,7 +541,6 @@ func (s *sqlEntityServer) Create(ctx context.Context, r *entity.CreateEntityRequ
 func (s *sqlEntityServer) Update(ctx context.Context, r *entity.UpdateEntityRequest) (*entity.UpdateEntityResponse, error) {
 	ctx, span := s.tracer.Start(ctx, "storage_server.Update")
 	defer span.End()
-	span.SetAttributes(attribute.String("request", r.String()))
 	ctxLogger := s.log.FromContext(ctx)
 
 	if err := s.Init(); err != nil {
@@ -826,7 +823,6 @@ func (s *sqlEntityServer) setLabels(ctx context.Context, tx *session.SessionTx, 
 func (s *sqlEntityServer) Delete(ctx context.Context, r *entity.DeleteEntityRequest) (*entity.DeleteEntityResponse, error) {
 	ctx, span := s.tracer.Start(ctx, "storage_server.Delete")
 	defer span.End()
-	span.SetAttributes(attribute.String("request", r.String()))
 	ctxLogger := s.log.FromContext(ctx)
 
 	if err := s.Init(); err != nil {
@@ -1010,7 +1006,6 @@ func (s *sqlEntityServer) doDelete(ctx context.Context, tx *session.SessionTx, e
 func (s *sqlEntityServer) History(ctx context.Context, r *entity.EntityHistoryRequest) (*entity.EntityHistoryResponse, error) {
 	ctx, span := s.tracer.Start(ctx, "storage_server.History")
 	defer span.End()
-	span.SetAttributes(attribute.String("request", r.String()))
 	ctxLogger := s.log.FromContext(ctx)
 
 	if err := s.Init(); err != nil {
@@ -1216,7 +1211,6 @@ func ParseSortBy(sort string) (*SortBy, error) {
 //nolint:gocyclo
 func (s *sqlEntityServer) List(ctx context.Context, r *entity.EntityListRequest) (*entity.EntityListResponse, error) {
 	ctx, span := s.tracer.Start(ctx, "storage_server.List")
-	span.SetAttributes(attribute.String("request", r.String()))
 	defer span.End()
 	ctxLogger := s.log.FromContext(ctx)
 
@@ -1919,7 +1913,6 @@ func (s *sqlEntityServer) watchEvent(r *entity.EntityWatchRequest, result *entit
 func (s *sqlEntityServer) FindReferences(ctx context.Context, r *entity.ReferenceRequest) (*entity.EntityListResponse, error) {
 	ctx, span := s.tracer.Start(ctx, "storage_server.FindReferences")
 	defer span.End()
-	span.SetAttributes(attribute.String("request", r.String()))
 	ctxLogger := s.log.FromContext(ctx)
 
 	if err := s.Init(); err != nil {

--- a/pkg/services/store/entity/sqlstash/sql_storage_server.go
+++ b/pkg/services/store/entity/sqlstash/sql_storage_server.go
@@ -246,9 +246,8 @@ func (s *sqlEntityServer) Read(ctx context.Context, r *entity.ReadEntityRequest)
 	res, err := s.read(ctx, s.sess, r)
 	if err != nil {
 		s.log.Error("read error", "error", err, "method", "read")
-		return nil, err
 	}
-	return res, nil
+	return res, err
 }
 
 func (s *sqlEntityServer) read(ctx context.Context, tx session.SessionQuerier, r *entity.ReadEntityRequest) (*entity.Entity, error) {

--- a/pkg/services/store/entity/sqlstash/sql_storage_server.go
+++ b/pkg/services/store/entity/sqlstash/sql_storage_server.go
@@ -738,7 +738,7 @@ func (s *sqlEntityServer) Update(ctx context.Context, r *entity.UpdateEntityRequ
 		delete(values, "created_at")
 		delete(values, "created_by")
 
-		err = s.dialect.Update(
+		err = s.update(
 			ctx,
 			tx,
 			entityTable,
@@ -748,7 +748,7 @@ func (s *sqlEntityServer) Update(ctx context.Context, r *entity.UpdateEntityRequ
 			},
 		)
 		if err != nil {
-			s.log.Error("error updating entity", "msg", err.Error())
+			s.log.Error("error updating entity", "error", err.Error(), "method", "update")
 			return err
 		}
 
@@ -2009,11 +2009,8 @@ func (s *sqlEntityServer) insert(ctx context.Context, tx *session.SessionTx, tab
 	ctx, span := s.tracer.Start(ctx, "storage_server.insert", trace.WithAttributes(attribute.String("table", table)))
 	defer span.End()
 
-	if err := s.dialect.Insert(ctx, tx, table, values); err != nil {
-		s.log.Error("error performing insert", "table", table, "msg", err.Error())
-		return err
-	}
-	return nil
+	err := s.dialect.Insert(ctx, tx, table, values)
+	return err
 }
 
 func (s *sqlEntityServer) update(ctx context.Context, tx *session.SessionTx, table string, row map[string]any, where map[string]any) error {
@@ -2027,8 +2024,5 @@ func (s *sqlEntityServer) update(ctx context.Context, tx *session.SessionTx, tab
 		row,
 		where,
 	)
-	if err != nil {
-		s.log.Error("error performing update", "table", table, "msg", err.Error())
-	}
 	return err
 }

--- a/pkg/services/store/entity/sqlstash/sql_storage_server_test.go
+++ b/pkg/services/store/entity/sqlstash/sql_storage_server_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"testing"
 
+	"github.com/grafana/grafana/pkg/infra/tracing"
 	"github.com/stretchr/testify/require"
 
 	"github.com/grafana/grafana/pkg/infra/db"
@@ -132,7 +133,12 @@ func setUpTestServer(t *testing.T) entity.EntityStoreServer {
 		featuremgmt.WithFeatures(featuremgmt.FlagUnifiedStorage))
 	require.NoError(t, err)
 
-	s, err := ProvideSQLEntityServer(entityDB)
+	traceConfig, err := tracing.ParseTracingConfig(sqlStore.Cfg)
+	require.NoError(t, err)
+	tracer, err := tracing.ProvideService(traceConfig)
+	require.NoError(t, err)
+
+	s, err := ProvideSQLEntityServer(entityDB, tracer)
 	require.NoError(t, err)
 	return s
 }

--- a/pkg/services/store/entity/tests/common_test.go
+++ b/pkg/services/store/entity/tests/common_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"testing"
 
+	"github.com/grafana/grafana/pkg/infra/tracing"
 	"github.com/stretchr/testify/require"
 
 	"github.com/grafana/grafana/pkg/components/satokengen"
@@ -85,7 +86,11 @@ func createTestContext(t *testing.T) testContext {
 	err = eDB.Init()
 	require.NoError(t, err)
 
-	store, err := sqlstash.ProvideSQLEntityServer(eDB)
+	traceConfig, err := tracing.ParseTracingConfig(env.Cfg)
+	require.NoError(t, err)
+	tracer, err := tracing.ProvideService(traceConfig)
+	require.NoError(t, err)
+	store, err := sqlstash.ProvideSQLEntityServer(eDB, tracer)
 	require.NoError(t, err)
 
 	client := entity.NewEntityStoreClientLocal(store)

--- a/pkg/setting/setting.go
+++ b/pkg/setting/setting.go
@@ -470,9 +470,10 @@ type Cfg struct {
 	RBACSingleOrganization bool
 
 	// GRPC Server.
-	GRPCServerNetwork   string
-	GRPCServerAddress   string
-	GRPCServerTLSConfig *tls.Config
+	GRPCServerNetwork       string
+	GRPCServerAddress       string
+	GRPCServerTLSConfig     *tls.Config
+	GRPCServerEnableLogging bool // log request and response of each unary gRPC call
 
 	CustomResponseHeaders map[string]string
 
@@ -1756,6 +1757,7 @@ func readGRPCServerSettings(cfg *Cfg, iniFile *ini.File) error {
 
 	cfg.GRPCServerNetwork = valueAsString(server, "network", "tcp")
 	cfg.GRPCServerAddress = valueAsString(server, "address", "")
+	cfg.GRPCServerEnableLogging = server.Key("enable_logging").MustBool(false)
 	switch cfg.GRPCServerNetwork {
 	case "unix":
 		if cfg.GRPCServerAddress != "" {


### PR DESCRIPTION
**Summary**
This instruments the US storage server for tracing, adds error logging, and adds a configurable logger interceptor to our gRPC service.

**Changes/notes**
- storage server is instrumented with traces
- the gRPC service already exposes traces, so those are picked up now
- adds a logging interceptor to the gRPC service. Logging is configurable and off by default. This will log the call method, request and response for all gRPC services
- adds basic error logging to the storage server
- all logs produced by the storage server will have a traceID attached
- we don't have a span for `Watch()` because it's length is unbounded and could result in huge traces. However, there is a span on the `poll()` method.