### PR TITLE
Alerting: Export pure function to convert query results to alert results

### DIFF
--- a/pkg/services/ngalert/eval/eval.go
+++ b/pkg/services/ngalert/eval/eval.go
@@ -83,8 +83,7 @@ func (r *conditionEvaluator) Evaluate(ctx context.Context, now time.Time) (Resul
 	if err != nil {
 		return nil, err
 	}
-	execResults := queryDataResponseToExecutionResults(r.condition, response)
-	return evaluateExecutionResult(execResults, now), nil
+	return EvaluateAlert(response, r.condition, now), nil
 }
 
 type evaluatorImpl struct {
@@ -106,6 +105,12 @@ func NewEvaluatorFactory(
 		expressionService: expressionService,
 		pluginsStore:      pluginsStore,
 	}
+}
+
+// EvaluateAlert takes the results of an executed query and evaluates it as an alert rule, returning alert states that the query produces.
+func EvaluateAlert(queryResponse *backend.QueryDataResponse, condition models.Condition, now time.Time) Results {
+	execResults := queryDataResponseToExecutionResults(condition, queryResponse)
+	return evaluateExecutionResult(execResults, now)
 }
 
 // invalidEvalResultFormatError is an error for invalid format of the alert definition evaluation results.


### PR DESCRIPTION
**What is this feature?**

Can be called like a library, in other contexts where you might already have query results and want to convert them directly to alert states.

**Why do we need this feature?**

Improves ability to use eval package like a library outside of the context of the grafana scheduler.

**Who is this feature for?**

n/a

**Which issue(s) does this PR fix?**:
n/a

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle.
- [x] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
