### PR TITLE
Chore: Fix test to retry fetching provisioned dashboard until is in place

### DIFF
--- a/pkg/tests/api/dashboards/api_dashboards_test.go
+++ b/pkg/tests/api/dashboards/api_dashboards_test.go
@@ -11,6 +11,7 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -32,6 +33,7 @@ import (
 	"github.com/grafana/grafana/pkg/tests/testinfra"
 	"github.com/grafana/grafana/pkg/tests/testsuite"
 	"github.com/grafana/grafana/pkg/util"
+	"github.com/grafana/grafana/pkg/util/retryer"
 )
 
 func TestMain(m *testing.M) {
@@ -169,21 +171,37 @@ providers:
 
 	t.Run("when provisioned directory is not empty, dashboard should be created", func(t *testing.T) {
 		title := "Grafana Dev Overview & Home"
-		u := fmt.Sprintf("http://admin:admin@%s/api/search?query=%s", grafanaListedAddr, url.QueryEscape(title))
-		// nolint:gosec
-		resp, err := http.Get(u)
-		require.NoError(t, err)
-		assert.Equal(t, http.StatusOK, resp.StatusCode)
-		t.Cleanup(func() {
-			err := resp.Body.Close()
-			require.NoError(t, err)
-		})
-		b, err := io.ReadAll(resp.Body)
-		require.NoError(t, err)
 		dashboardList := &model.HitList{}
-		err = json.Unmarshal(b, dashboardList)
+
+		retry := 0
+		retries := 5
+		// retry until the provisioned dashboard is ready
+		err := retryer.Retry(func() (retryer.RetrySignal, error) {
+			retry++
+			u := fmt.Sprintf("http://admin:admin@%s/api/search?query=%s", grafanaListedAddr, url.QueryEscape(title))
+			// nolint:gosec
+			resp, err := http.Get(u)
+			require.NoError(t, err)
+			assert.Equal(t, http.StatusOK, resp.StatusCode)
+			t.Cleanup(func() {
+				err := resp.Body.Close()
+				require.NoError(t, err)
+			})
+			b, err := io.ReadAll(resp.Body)
+			require.NoError(t, err)
+			err = json.Unmarshal(b, dashboardList)
+			require.NoError(t, err)
+			if dashboardList.Len() == 0 {
+				if retry >= retries {
+					return retryer.FuncError, fmt.Errorf("max retries exceeded")
+				}
+				t.Log("Dashboard is not ready", "retry", retry)
+				return retryer.FuncFailure, nil
+			}
+			return retryer.FuncComplete, nil
+		}, retries, time.Millisecond*time.Duration(10), time.Second)
 		require.NoError(t, err)
-		assert.Equal(t, 1, dashboardList.Len())
+
 		var dashboardUID string
 		var dashboardID int64
 		for _, d := range *dashboardList {


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

fixes flaky [test](https://drone.grafana.net/grafana/grafana/169969/1/8)

**Why do we need this feature?**

in the specific test we start the server for provisioning some resources and we expected that everything is in place
however, sometimes we used to query too fast and provisioning was not completed yet (as a result the dashboard was not created yet and test occasionally used to fail)
this fix retries checking for the dashboard existence for five times with exponential backoff for one second before failing

**Who is this feature for?**

[Add information on what kind of user the feature is for.]

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
