### PR TITLE
DashboardScene: Detect changes when live is enabled from settings

### DIFF
--- a/package.json
+++ b/package.json
@@ -255,7 +255,7 @@
     "@grafana/prometheus": "workspace:*",
     "@grafana/runtime": "workspace:*",
     "@grafana/saga-icons": "workspace:*",
-    "@grafana/scenes": "^4.2.0",
+    "@grafana/scenes": "^4.2.1",
     "@grafana/schema": "workspace:*",
     "@grafana/sql": "workspace:*",
     "@grafana/ui": "workspace:*",

--- a/public/app/features/dashboard-scene/saving/DashboardSceneChangeTracker.ts
+++ b/public/app/features/dashboard-scene/saving/DashboardSceneChangeTracker.ts
@@ -68,6 +68,9 @@ export class DashboardSceneChangeTracker {
         this.detectChanges();
       }
     }
+    if (payload.changedObject instanceof behaviors.LiveNowTimer) {
+      this.detectChanges();
+    }
     if (isSceneVariableInstance(payload.changedObject)) {
       this.detectChanges();
     }

--- a/public/app/features/dashboard-scene/scene/DashboardScene.test.tsx
+++ b/public/app/features/dashboard-scene/scene/DashboardScene.test.tsx
@@ -212,7 +212,7 @@ describe('DashboardScene', () => {
         const restoredLiveNowTimer = scene.state.$behaviors?.find(
           (b) => b instanceof behaviors.LiveNowTimer
         ) as behaviors.LiveNowTimer;
-        expect(restoredLiveNowTimer.state).toBeFalsy();
+        expect(restoredLiveNowTimer.state.enabled).toBeFalsy();
       });
 
       it('A change to time picker visibility settings should set isDirty true', () => {

--- a/public/app/features/dashboard-scene/scene/DashboardScene.test.tsx
+++ b/public/app/features/dashboard-scene/scene/DashboardScene.test.tsx
@@ -200,6 +200,21 @@ describe('DashboardScene', () => {
         expect(dashboardSceneGraph.getRefreshPicker(scene)!.state.intervals).toEqual(prevState);
       });
 
+      it('A enabling/disabling live now setting should set isDirty true', () => {
+        const liveNowTimer = scene.state.$behaviors?.find(
+          (b) => b instanceof behaviors.LiveNowTimer
+        ) as behaviors.LiveNowTimer;
+        liveNowTimer.enable();
+
+        expect(scene.state.isDirty).toBe(true);
+
+        scene.exitEditMode({ skipConfirm: true });
+        const restoredLiveNowTimer = scene.state.$behaviors?.find(
+          (b) => b instanceof behaviors.LiveNowTimer
+        ) as behaviors.LiveNowTimer;
+        expect(restoredLiveNowTimer.state).toBeFalsy();
+      });
+
       it('A change to time picker visibility settings should set isDirty true', () => {
         const dashboardControls = scene.state.controls!;
         const prevState = dashboardControls.state.hideTimeControls;
@@ -923,7 +938,7 @@ function buildTestScene(overrides?: Partial<DashboardSceneState>) {
       timeZone: 'browser',
     }),
     controls: new DashboardControls({}),
-    $behaviors: [new behaviors.CursorSync({})],
+    $behaviors: [new behaviors.CursorSync({}), new behaviors.LiveNowTimer({})],
     body: new SceneGridLayout({
       children: [
         new DashboardGridItem({

--- a/public/app/features/dashboard-scene/serialization/transformSaveModelToScene.ts
+++ b/public/app/features/dashboard-scene/serialization/transformSaveModelToScene.ts
@@ -304,7 +304,7 @@ export function createDashboardSceneFromDashboardModel(oldModel: DashboardModel)
       registerDashboardMacro,
       registerDashboardSceneTracking(oldModel),
       registerPanelInteractionsReporter,
-      new behaviors.LiveNowTimer(oldModel.liveNow),
+      new behaviors.LiveNowTimer({ enabled: oldModel.liveNow }),
     ],
     $data: new DashboardDataLayerSet({ annotationLayers, alertStatesLayer }),
     controls: new DashboardControls({

--- a/yarn.lock
+++ b/yarn.lock
@@ -4170,9 +4170,9 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@grafana/scenes@npm:^4.2.0":
-  version: 4.2.0
-  resolution: "@grafana/scenes@npm:4.2.0"
+"@grafana/scenes@npm:^4.2.1":
+  version: 4.2.1
+  resolution: "@grafana/scenes@npm:4.2.1"
   dependencies:
     "@grafana/e2e-selectors": "npm:10.3.3"
     react-grid-layout: "npm:1.3.4"
@@ -4186,7 +4186,7 @@ __metadata:
     "@grafana/ui": ^10.0.3
     react: ^18.0.0
     react-dom: ^18.0.0
-  checksum: 10/546bc27da9bde69dce23da4907014b8e0ff630a1dd43c87152f6537cebfeb31c4b3c475d05db7a93d241f7c9865cc0b1a16cc068c48dac2f4d589ecca11362de
+  checksum: 10/bebf65762a05c68902cd5bb1f372dd6434eaca99bb2f937dfa10767f59f0d5de196e545855012431c8bbd2e99753a3950506f6d1ec52be1cbd546ff3c56a8045
   languageName: node
   linkType: hard
 
@@ -18652,7 +18652,7 @@ __metadata:
     "@grafana/prometheus": "workspace:*"
     "@grafana/runtime": "workspace:*"
     "@grafana/saga-icons": "workspace:*"
-    "@grafana/scenes": "npm:^4.2.0"
+    "@grafana/scenes": "npm:^4.2.1"
     "@grafana/schema": "workspace:*"
     "@grafana/sql": "workspace:*"
     "@grafana/tsconfig": "npm:^1.3.0-rc1"


### PR DESCRIPTION
**Problem**
When the "Refresh charts" option was enabled, the save changes button didn't enable due to undetected changes by the change tracker.

**This PR depends on https://github.com/grafana/scenes/pull/662**