### PR TITLE
Prometheus: Azure clouds from Azure React SDK

### DIFF
--- a/public/app/plugins/datasource/prometheus/configuration/AzureAuthSettings.tsx
+++ b/public/app/plugins/datasource/prometheus/configuration/AzureAuthSettings.tsx
@@ -2,10 +2,11 @@ import { cx } from '@emotion/css';
 import React, { FormEvent, useMemo, useState } from 'react';
 
 import { config } from '@grafana/runtime';
+import { SelectableValue } from "@grafana/data";
 import { InlineField, InlineFieldRow, InlineSwitch, Input } from '@grafana/ui';
 import { HttpSettingsBaseProps } from '@grafana/ui/src/components/DataSourceSettings/types';
 
-import { KnownAzureClouds, AzureCredentials } from './AzureCredentials';
+import { AzureCredentials, getAzureClouds } from '@grafana/azure-sdk';
 import { getCredentials, updateCredentials } from './AzureCredentialsConfig';
 import { AzureCredentialsForm } from './AzureCredentialsForm';
 
@@ -15,6 +16,12 @@ export const AzureAuthSettings = (props: HttpSettingsBaseProps) => {
   const [overrideAudienceChecked, setOverrideAudienceChecked] = useState<boolean>(
     !!dataSourceConfig.jsonData.azureEndpointResourceId
   );
+
+  const clouds = useMemo(() => {
+    return getAzureClouds().map<SelectableValue>(c => {
+      return { value: c.name, label: c.displayName }
+    });
+  }, []);
 
   const credentials = useMemo(() => getCredentials(dataSourceConfig), [dataSourceConfig]);
 
@@ -52,7 +59,7 @@ export const AzureAuthSettings = (props: HttpSettingsBaseProps) => {
         managedIdentityEnabled={config.azure.managedIdentityEnabled}
         workloadIdentityEnabled={config.azure.workloadIdentityEnabled}
         credentials={credentials}
-        azureCloudOptions={KnownAzureClouds}
+        azureCloudOptions={clouds}
         onCredentialsChange={onCredentialsChange}
         disabled={dataSourceConfig.readOnly}
       />

--- a/public/app/plugins/datasource/prometheus/configuration/AzureCredentials.ts
+++ b/public/app/plugins/datasource/prometheus/configuration/AzureCredentials.ts
@@ -1,18 +1,3 @@
-import { SelectableValue } from '@grafana/data';
-
-export enum AzureCloud {
-  Public = 'AzureCloud',
-  China = 'AzureChinaCloud',
-  USGovernment = 'AzureUSGovernment',
-  None = '',
-}
-
-export const KnownAzureClouds: Array<SelectableValue<AzureCloud>> = [
-  { value: AzureCloud.Public, label: 'Azure' },
-  { value: AzureCloud.China, label: 'Azure China' },
-  { value: AzureCloud.USGovernment, label: 'Azure US Government' },
-];
-
 export type AzureAuthType = 'msi' | 'clientsecret' | 'workloadidentity';
 
 export type ConcealedSecret = symbol;

--- a/public/app/plugins/datasource/prometheus/configuration/AzureCredentialsConfig.ts
+++ b/public/app/plugins/datasource/prometheus/configuration/AzureCredentialsConfig.ts
@@ -1,9 +1,13 @@
 import { DataSourceSettings } from '@grafana/data';
 import { config } from '@grafana/runtime';
 
-import { AzureCloud, AzureCredentials, ConcealedSecret } from './AzureCredentials';
+import { AzureCredentials, ConcealedSecret } from './AzureCredentials';
 
 const concealed: ConcealedSecret = Symbol('Concealed client secret');
+
+export enum AzureCloud {
+  Public = 'AzureCloud',
+}
 
 function getDefaultAzureCloud(): string {
   return config.azure.cloud || AzureCloud.Public;


### PR DESCRIPTION
Use @grafana/azure-sdk to get list of available Azure clouds rather than a hardcoded list in the Prometheus datasource itself.

Depends on
* #82344

Similar to
* https://github.com/grafana/azure-data-explorer-datasource/pull/800