### PR TITLE
Canvas: Hide background image size editor options for SVG based elements

### DIFF
--- a/public/app/features/canvas/runtime/element.tsx
+++ b/public/app/features/canvas/runtime/element.tsx
@@ -20,7 +20,7 @@ import { Scene } from './scene';
 
 let counter = 0;
 
-const SVGElements = new Set<string>(['parallelogram', 'triangle', 'cloud', 'ellipse']);
+export const SVGElements = new Set<string>(['parallelogram', 'triangle', 'cloud', 'ellipse']);
 
 export class ElementState implements LayerElement {
   // UID necessary for moveable to work (for now)

--- a/public/app/plugins/panel/canvas/editor/options.ts
+++ b/public/app/plugins/panel/canvas/editor/options.ts
@@ -2,6 +2,7 @@ import { capitalize } from 'lodash';
 
 import { PanelOptionsSupplier } from '@grafana/data/src/panel/PanelPlugin';
 import { CanvasConnection, CanvasElementOptions, ConnectionDirection } from 'app/features/canvas';
+import { SVGElements } from 'app/features/canvas/runtime/element';
 import { ColorDimensionEditor, ResourceDimensionEditor, ScaleDimensionEditor } from 'app/features/dimensions/editors';
 import { BackgroundSizeEditor } from 'app/features/dimensions/editors/BackgroundSizeEditor';
 
@@ -60,6 +61,14 @@ export const optionBuilder: OptionSuppliers = {
         editor: BackgroundSizeEditor,
         settings: {
           resourceType: 'image',
+        },
+        showIf: () => {
+          // Do not show image size editor for SVG based elements
+          if (context.options?.type) {
+            return !SVGElements.has(context.options.type);
+          }
+
+          return true;
         },
       });
   },

--- a/public/app/plugins/panel/canvas/editor/options.ts
+++ b/public/app/plugins/panel/canvas/editor/options.ts
@@ -64,6 +64,7 @@ export const optionBuilder: OptionSuppliers = {
         },
         showIf: () => {
           // Do not show image size editor for SVG based elements
+          // See https://github.com/grafana/grafana/issues/84843#issuecomment-2010921066 for additional context
           if (context.options?.type) {
             return !SVGElements.has(context.options.type);
           }


### PR DESCRIPTION
It turns out that `background-size` and `background-repeat` properties only apply to html elements and not svg elements. Given this and the low relative value of this feature, I suggest that a "good enough" solution may be to just hide the background size editor options entirely for SVG based elements and come back to this if / when the feature request comes up. This way we can avoid having useless editor options on release. See [this comment for additional context on the issue](https://github.com/grafana/grafana/issues/84843#issuecomment-2010921066).

https://github.com/grafana/grafana/assets/22381771/a159a918-e6bd-450e-be6f-4bf01efc0d3a


Fixes https://github.com/grafana/grafana/issues/84843