### PR TITLE
InfluxDB: Fix measurement interpolation on visual query builder

### DIFF
--- a/public/app/plugins/datasource/influxdb/datasource.test.ts
+++ b/public/app/plugins/datasource/influxdb/datasource.test.ts
@@ -289,7 +289,7 @@ describe('InfluxDataSource Frontend Mode', () => {
     function influxChecks(query: InfluxQuery) {
       expect(templateSrv.replace).toBeCalledTimes(12);
       expect(query.alias).toBe(text);
-      expect(query.measurement).toBe(justText);
+      expect(query.measurement).toBe(textWithFormatRegex);
       expect(query.policy).toBe(justText);
       expect(query.limit).toBe(justText);
       expect(query.slimit).toBe(justText);

--- a/public/app/plugins/datasource/influxdb/datasource.ts
+++ b/public/app/plugins/datasource/influxdb/datasource.ts
@@ -297,7 +297,12 @@ export default class InfluxDatasource extends DataSourceWithBackend<InfluxQuery,
       ), // The raw sql query text
       alias: this.templateSrv.replace(query.alias ?? '', scopedVars),
       limit: this.templateSrv.replace(query.limit?.toString() ?? '', scopedVars),
-      measurement: this.templateSrv.replace(query.measurement ?? '', scopedVars),
+      measurement: this.templateSrv.replace(
+        query.measurement ?? '',
+        scopedVars,
+        (value: string | string[] = [], variable: QueryVariableModel) =>
+          this.interpolateQueryExpr(value, variable, query.measurement)
+      ),
       policy: this.templateSrv.replace(query.policy ?? '', scopedVars),
       slimit: this.templateSrv.replace(query.slimit?.toString() ?? '', scopedVars),
       tz: this.templateSrv.replace(query.tz ?? '', scopedVars),

--- a/public/app/plugins/datasource/influxdb/datasource_backend_mode.test.ts
+++ b/public/app/plugins/datasource/influxdb/datasource_backend_mode.test.ts
@@ -180,7 +180,7 @@ describe('InfluxDataSource Backend Mode', () => {
     function influxChecks(query: InfluxQuery) {
       expect(templateSrv.replace).toBeCalledTimes(12);
       expect(query.alias).toBe(text);
-      expect(query.measurement).toBe(justText);
+      expect(query.measurement).toBe(textWithFormatRegex);
       expect(query.policy).toBe(justText);
       expect(query.limit).toBe(justText);
       expect(query.slimit).toBe(justText);


### PR DESCRIPTION
**What is this feature?**

When using a template variable for a `measurement`, if the variable has multiple values selected, the interpolation was failing on visual query builder but not on raw code editor. This PR is fixing it. 

**Why do we need this feature?**

Better influxql interpolation

**Who is this feature for?**

InfluxDB influxql users

**Special notes for your reviewer:**

### How to test it?
- Create a dashboard with a measurement template variable
  - query: `SHOW MEASUREMENTS`
  - Select `Multi-value`
- On the query panel use this template variable for measurement. 
- See everything is working. 
- Select more than one value for the measurement template variable
- Refresh the query see there is no data
- Switch to this branch and check again.

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
