### PR TITLE
Canvas: Add mode that enables one click data link access

### DIFF
--- a/packages/grafana-schema/src/raw/composable/canvas/panelcfg/x/CanvasPanelCfg_types.gen.ts
+++ b/packages/grafana-schema/src/raw/composable/canvas/panelcfg/x/CanvasPanelCfg_types.gen.ts
@@ -124,6 +124,10 @@ export interface Options {
    */
   panZoom: boolean;
   /**
+   * Enable quick access to data links when element is configured with one data link
+   */
+  quickDataLinkAccess: boolean;
+  /**
    * The root element of canvas (frame), where all canvas elements are nested
    * TODO: Figure out how to define a default value for this
    */
@@ -151,5 +155,6 @@ export const defaultOptions: Partial<Options> = {
   infinitePan: true,
   inlineEditing: true,
   panZoom: true,
+  quickDataLinkAccess: false,
   showAdvancedTypes: true,
 };

--- a/public/app/features/canvas/runtime/scene.tsx
+++ b/public/app/features/canvas/runtime/scene.tsx
@@ -74,6 +74,7 @@ export class Scene {
   currentLayer?: FrameState;
   isEditingEnabled?: boolean;
   shouldShowAdvancedTypes?: boolean;
+  isQuickDataLinkAccessEnabled?: boolean;
   shouldPanZoom?: boolean;
   shouldInfinitePan?: boolean;
   skipNextSelectionBroadcast = false;
@@ -112,12 +113,13 @@ export class Scene {
     cfg: CanvasFrameOptions,
     enableEditing: boolean,
     showAdvancedTypes: boolean,
+    quickDataLinkAccess: boolean,
     panZoom: boolean,
     infinitePan: boolean,
     public onSave: (cfg: CanvasFrameOptions) => void,
     panel: CanvasPanel
   ) {
-    this.root = this.load(cfg, enableEditing, showAdvancedTypes, panZoom, infinitePan);
+    this.root = this.load(cfg, enableEditing, showAdvancedTypes, quickDataLinkAccess, panZoom, infinitePan);
 
     this.subscription = this.editModeEnabled.subscribe((open) => {
       if (!this.moveable || !this.isEditingEnabled) {
@@ -154,6 +156,7 @@ export class Scene {
     cfg: CanvasFrameOptions,
     enableEditing: boolean,
     showAdvancedTypes: boolean,
+    quickDataLinkAccess: boolean,
     panZoom: boolean,
     infinitePan: boolean
   ) {
@@ -168,6 +171,7 @@ export class Scene {
 
     this.isEditingEnabled = enableEditing;
     this.shouldShowAdvancedTypes = showAdvancedTypes;
+    this.isQuickDataLinkAccessEnabled = quickDataLinkAccess;
     this.shouldPanZoom = panZoom;
     this.shouldInfinitePan = infinitePan;
 

--- a/public/app/plugins/panel/canvas/CanvasPanel.tsx
+++ b/public/app/plugins/panel/canvas/CanvasPanel.tsx
@@ -67,6 +67,7 @@ export class CanvasPanel extends Component<Props, State> {
       this.props.options.root,
       this.props.options.inlineEditing,
       this.props.options.showAdvancedTypes,
+      this.props.options.quickDataLinkAccess,
       this.props.options.panZoom,
       this.props.options.infinitePan,
       this.onUpdateScene,
@@ -229,12 +230,15 @@ export class CanvasPanel extends Component<Props, State> {
     const inlineEditingSwitched = this.props.options.inlineEditing !== nextProps.options.inlineEditing;
     const shouldShowAdvancedTypesSwitched =
       this.props.options.showAdvancedTypes !== nextProps.options.showAdvancedTypes;
+    const quickDataLinkAccessEnabledSwitched =
+      this.props.options.quickDataLinkAccess !== nextProps.options.quickDataLinkAccess;
     const panZoomSwitched = this.props.options.panZoom !== nextProps.options.panZoom;
     const infinitePanSwitched = this.props.options.infinitePan !== nextProps.options.infinitePan;
     if (
       this.needsReload ||
       inlineEditingSwitched ||
       shouldShowAdvancedTypesSwitched ||
+      quickDataLinkAccessEnabledSwitched ||
       panZoomSwitched ||
       infinitePanSwitched
     ) {
@@ -248,6 +252,7 @@ export class CanvasPanel extends Component<Props, State> {
         nextProps.options.root,
         nextProps.options.inlineEditing,
         nextProps.options.showAdvancedTypes,
+        nextProps.options.quickDataLinkAccess,
         nextProps.options.panZoom,
         nextProps.options.infinitePan
       );

--- a/public/app/plugins/panel/canvas/module.tsx
+++ b/public/app/plugins/panel/canvas/module.tsx
@@ -26,12 +26,20 @@ export const addStandardCanvasEditorOptions = (builder: PanelOptionsEditorBuilde
   });
 
   builder.addBooleanSwitch({
+    path: 'quickDataLinkAccess',
+    name: 'Quick data link access',
+    description: 'Enable one click access to data links for elements with a single data link',
+    defaultValue: false,
+  });
+
+  builder.addBooleanSwitch({
     path: 'panZoom',
     name: 'Pan and zoom',
     description: 'Enable pan and zoom',
     defaultValue: false,
     showIf: (opts) => config.featureToggles.canvasPanelPanZoom,
   });
+
   builder.addCustomEditor({
     id: 'panZoomHelp',
     path: 'panZoomHelp',
@@ -39,6 +47,7 @@ export const addStandardCanvasEditorOptions = (builder: PanelOptionsEditorBuilde
     editor: PanZoomHelp,
     showIf: (opts) => config.featureToggles.canvasPanelPanZoom && opts.panZoom,
   });
+
   builder.addBooleanSwitch({
     path: 'infinitePan',
     name: 'Infinite panning',

--- a/public/app/plugins/panel/canvas/panelcfg.cue
+++ b/public/app/plugins/panel/canvas/panelcfg.cue
@@ -92,6 +92,8 @@ composableKinds: PanelCfg: {
 					inlineEditing: bool | *true
 					// Show all available element types
 					showAdvancedTypes: bool | *true
+					// Enable quick access to data links when element is configured with one data link
+					quickDataLinkAccess: bool | *false
 					// Enable pan and zoom
 					panZoom: bool | *true
 					// Enable infinite pan

--- a/public/app/plugins/panel/canvas/panelcfg.gen.ts
+++ b/public/app/plugins/panel/canvas/panelcfg.gen.ts
@@ -122,6 +122,10 @@ export interface Options {
    */
   panZoom: boolean;
   /**
+   * Enable quick access to data links when element is configured with one data link
+   */
+  quickDataLinkAccess: boolean;
+  /**
    * The root element of canvas (frame), where all canvas elements are nested
    * TODO: Figure out how to define a default value for this
    */
@@ -149,5 +153,6 @@ export const defaultOptions: Partial<Options> = {
   infinitePan: true,
   inlineEditing: true,
   panZoom: true,
+  quickDataLinkAccess: false,
   showAdvancedTypes: true,
 };


### PR DESCRIPTION
This is a pretty common community request (see [here](https://github.com/grafana/grafana/issues/81347#issuecomment-2025478689) and [here](https://github.com/grafana/grafana/discussions/56835?sort=new#discussioncomment-4315463)) and an impactful quality of life improvement. 

For now, added a global toggle that enables a "quick data link access mode" that allows users to navigate to a data link in one seamless click vs messing with the tooltip. This only works for elements that have only one data link configured, else the tooltip mode will still be used.

https://github.com/grafana/grafana/assets/22381771/9d11a270-69b4-46a2-a4ab-0ea42503b5eb

Test dashboard is [this local gdev dashboard](http://localhost:3000/d/adf95uwu7w1s0e/panel-tests-canvas-datalinks?orgId=1)

Fixes https://github.com/grafana/grafana/issues/79698
Fixes https://github.com/grafana/grafana/issues/77246