### PR TITLE
Makefile: refactoring .PHONY

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,6 @@ WIRE_TAGS = "oss"
 -include local/Makefile
 include .bingo/Variables.mk
 
-.PHONY: all deps-go deps-js deps build-go build-backend build-server build-cli build-js build build-docker-full build-docker-full-ubuntu lint-go golangci-lint test-go test-js gen-ts test run run-frontend clean devenv devenv-down protobuf drone help gen-go gen-cue fix-cue gen-feature-toggles
 
 GO = go
 GO_FILES ?= ./pkg/... ./pkg/apiserver/... ./pkg/apimachinery/... ./pkg/promlib/...
@@ -19,17 +18,22 @@ targets := $(shell echo '$(sources)' | tr "," " ")
 
 GO_INTEGRATION_TESTS := $(shell find ./pkg -type f -name '*_test.go' -exec grep -l '^func TestIntegration' '{}' '+' | grep -o '\(.*\)/' | sort -u)
 
+.PHONY: all
 all: deps build
 
 ##@ Dependencies
 
+.PHONY: deps-go
 deps-go: ## Install backend dependencies.
 	$(GO) run build.go setup
 
+.PHONY: deps-js
 deps-js: node_modules ## Install frontend dependencies.
 
+.PHONY: deps
 deps: deps-js ## Install all dependencies.
 
+.PHONY: node_modules
 node_modules: package.json yarn.lock ## Install node modules.
 	@echo "install frontend dependencies"
 	YARN_ENABLE_PROGRESS_BARS=false yarn install --immutable
@@ -47,6 +51,7 @@ $(MERGED_SPEC_TARGET): swagger-oss-gen swagger-enterprise-gen $(NGALERT_SPEC_TAR
 	# known conflicts DsPermissionType, AddApiKeyCommand, Json, Duration (identical models referenced by both specs)
 	$(SWAGGER) mixin -q $(SPEC_TARGET) $(ENTERPRISE_SPEC_TARGET) $(NGALERT_SPEC_TARGET) --ignore-conflicts -o $(MERGED_SPEC_TARGET)
 
+.PHONY: swagger-oss-gen
 swagger-oss-gen: $(SWAGGER) ## Generate API Swagger specification
 	@echo "re-generating swagger for OSS"
 	rm -f $(SPEC_TARGET)
@@ -58,6 +63,7 @@ swagger-oss-gen: $(SWAGGER) ## Generate API Swagger specification
 	--exclude-tag=enterprise
 
 # this file only exists if enterprise is enabled
+.PHONY: swagger-enterprise-gen
 ENTERPRISE_EXT_FILE = pkg/extensions/ext.go
 ifeq ("$(wildcard $(ENTERPRISE_EXT_FILE))","") ## if enterprise is not enabled
 swagger-enterprise-gen:
@@ -74,11 +80,14 @@ swagger-enterprise-gen: $(SWAGGER) ## Generate API Swagger specification
 	--include-tag=enterprise
 endif
 
+.PHONY: swagger-gen
 swagger-gen: gen-go $(MERGED_SPEC_TARGET) swagger-validate
 
+.PHONY: swagger-validate
 swagger-validate: $(MERGED_SPEC_TARGET) $(SWAGGER) ## Validate API spec
 	$(SWAGGER) validate --skip-warnings $(<)
 
+.PHONY: swagger-clean
 swagger-clean:
 	rm -f $(SPEC_TARGET) $(MERGED_SPEC_TARGET) $(OAPI_SPEC_TARGET)
 
@@ -97,15 +106,18 @@ lefthook-uninstall: $(LEFTHOOK)
 ##@ OpenAPI 3
 OAPI_SPEC_TARGET = public/openapi3.json
 
+.PHONY: openapi3-gen
 openapi3-gen: swagger-gen ## Generates OpenApi 3 specs from the Swagger 2 already generated
 	$(GO) run scripts/openapi3/openapi3conv.go $(MERGED_SPEC_TARGET) $(OAPI_SPEC_TARGET)
 
 ##@ Building
+.PHONY: gen-cue
 gen-cue: ## Do all CUE/Thema code generation
 	@echo "generate code from .cue files"
 	go generate ./kinds/gen.go
 	go generate ./public/app/plugins/gen.go
 
+.PHONY: gen-feature-toggles
 gen-feature-toggles:
 ## First go test run fails because it will re-generate the feature toggles.
 ## Second go test run will compare the generated files and pass.
@@ -117,34 +129,42 @@ gen-feature-toggles:
 		go test -v ./pkg/services/featuremgmt/...; \
 	fi
 
+.PHONY: gen-go
 gen-go:
 	@echo "generate go files"
 	$(GO) run ./pkg/build/wire/cmd/wire/main.go gen -tags $(WIRE_TAGS) ./pkg/server
 
+.PHONY: fix-cue
 fix-cue: $(CUE)
 	@echo "formatting cue files"
 	$(CUE) fix kinds/**/*.cue
 	$(CUE) fix public/app/plugins/**/**/*.cue
 
+.PHONY: gen-jsonnet
 gen-jsonnet:
 	go generate ./devenv/jsonnet
 
+.PHONY: build-go
 build-go: gen-go ## Build all Go binaries.
 	@echo "build go files"
 	$(GO) run build.go $(GO_BUILD_FLAGS) build
 
+.PHONY: build-backend
 build-backend: ## Build Grafana backend.
 	@echo "build backend"
 	$(GO) run build.go $(GO_BUILD_FLAGS) build-backend
 
+.PHONY: build-server
 build-server: ## Build Grafana server.
 	@echo "build server"
 	$(GO) run build.go $(GO_BUILD_FLAGS) build-server
 
+.PHONY: build-cli
 build-cli: ## Build Grafana CLI application.
 	@echo "build grafana-cli"
 	$(GO) run build.go $(GO_BUILD_FLAGS) build-cli
 
+.PHONY: build-js
 build-js: ## Build frontend assets.
 	@echo "build frontend"
 	yarn run build
@@ -152,6 +172,7 @@ build-js: ## Build frontend assets.
 
 PLUGIN_ID ?=
 
+.PHONY: build-plugin-go
 build-plugin-go: ## Build decoupled plugins
 	@echo "build plugin $(PLUGIN_ID)"
 	@cd pkg/tsdb; \
@@ -161,11 +182,14 @@ build-plugin-go: ## Build decoupled plugins
 	fi; \
 	mage -v buildplugin $(PLUGIN_ID)
 
+.PHONY: build
 build: build-go build-js ## Build backend and frontend.
 
+.PHONY: run
 run: $(BRA) ## Build and run web server on filesystem changes.
 	$(BRA) run
 
+.PHONY: run-frontend
 run-frontend: deps-js ## Fetch js dependencies and watch frontend for rebuild
 	yarn start
 
@@ -217,22 +241,27 @@ test-go-integration-memcached: ## Run integration tests for memcached cache.
 	$(GO) clean -testcache
 	MEMCACHED_HOSTS=localhost:11211 $(GO) test -run IntegrationMemcached -covermode=atomic -timeout=2m $(GO_INTEGRATION_TESTS)
 
+.PHONY: test-js
 test-js: ## Run tests for frontend.
 	@echo "test frontend"
 	yarn test
 
+.PHONY: test
 test: test-go test-js ## Run all tests.
 
 ##@ Linting
+.PHONY: golangci-lint
 golangci-lint: $(GOLANGCI_LINT)
 	@echo "lint via golangci-lint"
 	$(GOLANGCI_LINT) run \
 		--config .golangci.toml \
 		$(GO_FILES)
 
+.PHONY: lint-go
 lint-go: golangci-lint ## Run all code checks for backend. You can use GO_FILES to specify exact files to check
 
 # with disabled SC1071 we are ignored some TCL,Expect `/usr/bin/env expect` scripts
+.PHONY: shellcheck
 shellcheck: $(SH_FILES) ## Run checks for shell scripts.
 	@docker run --rm -v "$$PWD:/mnt" koalaman/shellcheck:stable \
 	$(SH_FILES) -e SC1071 -e SC2162
@@ -242,6 +271,7 @@ shellcheck: $(SH_FILES) ## Run checks for shell scripts.
 TAG_SUFFIX=$(if $(WIRE_TAGS)!=oss,-$(WIRE_TAGS))
 PLATFORM=linux/amd64
 
+.PHONY: build-docker-full
 build-docker-full: ## Build Docker image for development.
 	@echo "build docker container"
 	tar -ch . | \
@@ -255,6 +285,7 @@ build-docker-full: ## Build Docker image for development.
 	--tag grafana/grafana$(TAG_SUFFIX):dev \
 	$(DOCKER_BUILD_ARGS)
 
+.PHONY: build-docker-full-ubuntu
 build-docker-full-ubuntu: ## Build Docker image based on Ubuntu for development.
 	@echo "build docker container"
 	tar -ch . | \
@@ -274,6 +305,7 @@ build-docker-full-ubuntu: ## Build Docker image based on Ubuntu for development.
 
 # create docker-compose file with provided sources and start them
 # example: make devenv sources=postgres,auth/openldap
+.PHONY: devenv
 ifeq ($(sources),)
 devenv:
 	@printf 'You have to define sources for this command \nexample: make devenv sources=postgres,openldap\n'
@@ -287,15 +319,18 @@ devenv: devenv-down ## Start optional services, e.g. postgres, prometheus, and e
 	docker-compose up -d --build
 endif
 
+.PHONY: devenv-down
 devenv-down: ## Stop optional services.
 	@cd devenv; \
 	test -f docker-compose.yaml && \
 	docker-compose down || exit 0;
 
+.PHONY: devenv-postgres
 devenv-postgres:
 	@cd devenv; \
 	sources=postgres_tests
 
+.PHONY: devenv-mysql
 devenv-mysql:
 	@cd devenv; \
 	sources=mysql_tests
@@ -307,18 +342,21 @@ devenv-mysql:
 # go-gettable dependency and so getting it installed can be inconvenient.
 #
 # If you are working on changes to protobuf interfaces you may either use
-# this target or run the individual scripts below directly.
+# this target or run the individual scripts below directly
+.PHONY: protobuf
 protobuf: ## Compile protobuf definitions
 	bash scripts/protobuf-check.sh
 	bash pkg/plugins/backendplugin/pluginextensionv2/generate.sh
 	bash pkg/plugins/backendplugin/secretsmanagerplugin/generate.sh
 	bash pkg/services/store/entity/generate.sh
 
+.PHONY: clean
 clean: ## Clean up intermediate build artifacts.
 	@echo "cleaning"
 	rm -rf node_modules
 	rm -rf public/build
 
+.PHONY: gen-ts
 gen-ts:
 	@echo "generating TypeScript definitions"
 	go get github.com/tkrajina/typescriptify-golang-structs/typescriptify@v0.1.7
@@ -328,6 +366,7 @@ gen-ts:
 # This repository's configuration is protected (https://readme.drone.io/signature/).
 # Use this make target to regenerate the configuration YAML files when
 # you modify starlark files.
+.PHONY: drone
 drone: $(DRONE)
 	bash scripts/drone/env-var-check.sh
 	$(DRONE) starlark --format
@@ -335,11 +374,14 @@ drone: $(DRONE)
 	$(DRONE) --server https://drone.grafana.net sign --save grafana/grafana
 
 # Generate an Emacs tags table (https://www.gnu.org/software/emacs/manual/html_node/emacs/Tags-Tables.html) for Starlark files.
+.PHONY: scripts/drone/TAGS
 scripts/drone/TAGS: $(shell find scripts/drone -name '*.star')
 	etags --lang none --regex="/def \(\w+\)[^:]+:/\1/" --regex="/\s*\(\w+\) =/\1/" $^ -o $@
 
+.PHONY: format-drone
 format-drone:
 	buildifier --lint=fix -r scripts/drone
 
+.PHONY: help
 help: ## Display this help.
 	@awk 'BEGIN {FS = ":.*##"; printf "\nUsage:\n  make \033[36m<target>\033[0m\n"} /^[a-zA-Z_-]+:.*?##/ { printf "  \033[36m%-15s\033[0m %s\n", $$1, $$2 } /^##@/ { printf "\n\033[1m%s\033[0m\n", substr($$0, 5) } ' $(MAKEFILE_LIST)


### PR DESCRIPTION
PHONY is set on one line, which makes it cumbersome and difficult to maintain as more functions are added. And I found that many functions were not set to enter PHONY

Now set your own PHONY for each function

The changes are as follows:

1、modify: These are all set on the top line of the corresponding function,Convenient for better maintenance in the future
3、addition: node_modules、swagger-validate、swagger-clean、build-plugin-go...etc


Fixes #85439

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
