### PR TITLE
Docker: Fix missing go dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -57,6 +57,7 @@ COPY .bingo .bingo
 COPY pkg/util/xorm/go.* pkg/util/xorm/
 COPY pkg/apiserver/go.* pkg/apiserver/
 COPY pkg/apimachinery/go.* pkg/apimachinery/
+COPY pkg/build/wire/go.* pkg/build/wire/
 COPY pkg/promlib/go.* pkg/promlib/
 
 RUN go mod download


### PR DESCRIPTION
**What is this feature?**

copies missing dependencies to dockerfile

**Why do we need this feature?**

grafana does not build

```
 > [go-builder 11/25] RUN go mod download:
0.303 go: cannot load module pkg/build/wire listed in go.work file: open pkg/build/wire/go.mod: no such file or directory
------
Dockerfile:64
--------------------
  62 |     COPY pkg/promlib/go.* pkg/promlib/
  63 |
  64 | >>> RUN go mod download
  65 |     RUN if [[ "$BINGO" = "true" ]]; then \
  66 |           go install github.com/bwplotka/bingo@latest && \
  ```

**Who is this feature for?**

users who use dockerfile

**Which issue(s) does this PR fix?**:

n/a

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
