### PR TITLE
k8s: remove dependency on app_mode development

### DIFF
--- a/docs/sources/setup-grafana/configure-grafana/feature-toggles/index.md
+++ b/docs/sources/setup-grafana/configure-grafana/feature-toggles/index.md
@@ -115,6 +115,7 @@ Experimental features might be changed or removed without prior notice.
 | `scenes`                                    | Experimental framework to build interactive dashboards                                                                                                                                                                                                                            |
 | `disableSecretsCompatibility`               | Disable duplicated secret storage in legacy tables                                                                                                                                                                                                                                |
 | `logRequestsInstrumentedAsUnknown`          | Logs the path for requests that are instrumented as unknown                                                                                                                                                                                                                       |
+| `unifiedStorage`                            | SQL-based k8s storage                                                                                                                                                                                                                                                             |
 | `showDashboardValidationWarnings`           | Show warnings when dashboards do not validate against the schema                                                                                                                                                                                                                  |
 | `mysqlAnsiQuotes`                           | Use double quotes to escape keyword in a MySQL query                                                                                                                                                                                                                              |
 | `alertingBacktesting`                       | Rule backtesting API for alerting                                                                                                                                                                                                                                                 |
@@ -185,7 +186,6 @@ The following toggles require explicitly setting Grafana's [app mode]({{< relref
 
 | Feature toggle name                    | Description                                                    |
 | -------------------------------------- | -------------------------------------------------------------- |
-| `unifiedStorage`                       | SQL-based k8s storage                                          |
 | `grafanaAPIServerWithExperimentalAPIs` | Register experimental APIs with the k8s API server             |
 | `grafanaAPIServerEnsureKubectlAccess`  | Start an additional https handler and write kubectl options    |
 | `panelTitleSearchInV1`                 | Enable searching for dashboards using panel title in search v1 |

--- a/pkg/server/module_server.go
+++ b/pkg/server/module_server.go
@@ -106,12 +106,10 @@ func (s *ModuleServer) Run() error {
 	s.notifySystemd("READY=1")
 	s.log.Debug("Waiting on services...")
 
-	// Only allow individual dskit modules to run in dev mode.
-	if s.cfg.Env != setting.Dev {
-		if len(s.cfg.Target) > 1 || s.cfg.Target[0] != "all" {
-			s.log.Error("dskit module targeting is only supported in dev mode. Falling back to 'all'")
-			s.cfg.Target = []string{"all"}
-		}
+	// Only allow individual dskit modules to run in single target.
+	if len(s.cfg.Target) > 1 || s.cfg.Target[0] != "all" {
+		s.log.Error("dskit module targeting is only supported in dev mode. Falling back to 'all'")
+		s.cfg.Target = []string{"all"}
 	}
 
 	m := modules.New(s.cfg.Target)

--- a/pkg/server/module_server.go
+++ b/pkg/server/module_server.go
@@ -106,12 +106,6 @@ func (s *ModuleServer) Run() error {
 	s.notifySystemd("READY=1")
 	s.log.Debug("Waiting on services...")
 
-	// Only allow individual dskit modules to run in single target.
-	if len(s.cfg.Target) > 1 || s.cfg.Target[0] != "all" {
-		s.log.Error("dskit module targeting is only supported in dev mode. Falling back to 'all'")
-		s.cfg.Target = []string{"all"}
-	}
-
 	m := modules.New(s.cfg.Target)
 
 	// only run the instrumentation server module if were not running a module that already contains an http server

--- a/pkg/services/apiserver/service.go
+++ b/pkg/services/apiserver/service.go
@@ -243,7 +243,7 @@ func (s *service) start(ctx context.Context) error {
 
 	case grafanaapiserveroptions.StorageTypeUnified:
 		if !s.features.IsEnabledGlobally(featuremgmt.FlagUnifiedStorage) {
-			return fmt.Errorf("unified storage requires the unifiedStorage feature flag (and app_mode = development)")
+			return fmt.Errorf("unified storage requires the unifiedStorage feature flag")
 		}
 
 		eDB, err := dbimpl.ProvideEntityDB(s.db, s.cfg, s.features)

--- a/pkg/services/featuremgmt/registry.go
+++ b/pkg/services/featuremgmt/registry.go
@@ -224,7 +224,7 @@ var (
 			Name:            "unifiedStorage",
 			Description:     "SQL-based k8s storage",
 			Stage:           FeatureStageExperimental,
-			RequiresDevMode: true,
+			RequiresDevMode: false,
 			RequiresRestart: true, // new SQL tables created
 			Owner:           grafanaAppPlatformSquad,
 		},

--- a/pkg/services/featuremgmt/toggles_gen.csv
+++ b/pkg/services/featuremgmt/toggles_gen.csv
@@ -27,7 +27,7 @@ logRequestsInstrumentedAsUnknown,experimental,@grafana/hosted-grafana-team,false
 topnav,deprecated,@grafana/grafana-frontend-platform,false,false,false
 returnToPrevious,GA,@grafana/grafana-frontend-platform,false,false,true
 grpcServer,preview,@grafana/grafana-app-platform-squad,false,false,false
-unifiedStorage,experimental,@grafana/grafana-app-platform-squad,true,true,false
+unifiedStorage,experimental,@grafana/grafana-app-platform-squad,false,true,false
 cloudWatchCrossAccountQuerying,GA,@grafana/aws-datasources,false,false,false
 showDashboardValidationWarnings,experimental,@grafana/dashboards-squad,false,false,false
 mysqlAnsiQuotes,experimental,@grafana/search-and-storage,false,false,false

--- a/pkg/services/featuremgmt/toggles_gen.json
+++ b/pkg/services/featuremgmt/toggles_gen.json
@@ -437,14 +437,16 @@
     {
       "metadata": {
         "name": "unifiedStorage",
-        "resourceVersion": "1713545444177",
-        "creationTimestamp": "2024-04-19T16:50:44Z"
+        "resourceVersion": "1714723955745",
+        "creationTimestamp": "2024-04-19T16:50:44Z",
+        "annotations": {
+          "grafana.app/updatedTimestamp": "2024-05-03 08:12:35.745103 +0000 UTC"
+        }
       },
       "spec": {
         "description": "SQL-based k8s storage",
         "stage": "experimental",
         "codeowner": "@grafana/grafana-app-platform-squad",
-        "requiresDevMode": true,
         "requiresRestart": true
       }
     },

--- a/pkg/services/store/entity/README.md
+++ b/pkg/services/store/entity/README.md
@@ -17,8 +17,6 @@ There are 2 main tables, the `entity` table stores a "current" view of the objec
 The minimum config settings required are:
 
 ```ini
-; dev mode is required
-app_mode = development
 ; need to specify target here for override to work later
 target = all
 

--- a/pkg/services/store/entity/db/migrations/migrator.go
+++ b/pkg/services/store/entity/db/migrations/migrator.go
@@ -1,12 +1,8 @@
 package migrations
 
 import (
-	"context"
-	"fmt"
-
 	"github.com/grafana/grafana/pkg/services/featuremgmt"
 	"github.com/grafana/grafana/pkg/services/sqlstore/migrator"
-	"github.com/grafana/grafana/pkg/services/sqlstore/session"
 	"github.com/grafana/grafana/pkg/services/store/entity/db"
 )
 
@@ -24,51 +20,7 @@ func MigrateEntityStore(db db.EntityDBInterface, features featuremgmt.FeatureTog
 	mg := migrator.NewScopedMigrator(engine, db.GetCfg(), "entity")
 	mg.AddCreateMigration()
 
-	marker := initEntityTables(mg)
-
-	// While this feature is under development, we can completly wipe and recreate
-	// The initial plan is to keep the source of truth in existing SQL tables, and mirrot it
-	// to a kubernetes model.  Once the kubernetes model needs to be preserved,
-	// this code should be removed
-	exists, err := engine.IsTableExist("entity_migration_log")
-	if err != nil {
-		return err
-	}
-	if exists {
-		log, err := mg.GetMigrationLog()
-		if err != nil {
-			return err
-		}
-		_, found := log[marker]
-		if !found && len(log) > 0 {
-			// Remove the migration log (and potential other orphan tables)
-			tables := []string{"entity_migration_log"}
-
-			ctx := context.Background()
-			sess, err := db.GetSession()
-			if err != nil {
-				return err
-			}
-
-			err = sess.WithTransaction(ctx, func(tx *session.SessionTx) error {
-				for _, t := range tables {
-					_, err := tx.Exec(ctx, fmt.Sprintf("DROP TABLE IF EXISTS %s", t))
-					if err != nil {
-						return err
-					}
-				}
-				return nil
-			})
-			if err != nil {
-				return err
-			}
-
-			// remove old entries from in-memory log
-			for id := range log {
-				mg.RemoveMigrationLogs(id)
-			}
-		}
-	}
+	initEntityTables(mg)
 
 	// since it's a new feature enable migration locking by default
 	return mg.Start(true, 0)


### PR DESCRIPTION
**What is this feature?**

Ensure unified storage does not require app_mode = development.

**Why do we need this feature?**

The feature is already behind a feature toggle.

**Who is this feature for?**

search and storage

**Which issue(s) does this PR fix?**:

Fixes #

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle.
- [x] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
