### PR TITLE
[v11.0.x] Bump scenes to 4.1.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -252,7 +252,7 @@
     "@grafana/prometheus": "workspace:*",
     "@grafana/runtime": "workspace:*",
     "@grafana/saga-icons": "workspace:*",
-    "@grafana/scenes": "4.0.1",
+    "@grafana/scenes": "4.1.2",
     "@grafana/schema": "workspace:*",
     "@grafana/sql": "workspace:*",
     "@grafana/ui": "workspace:*",

--- a/public/app/features/dashboard-scene/serialization/transformSaveModelToScene.test.ts
+++ b/public/app/features/dashboard-scene/serialization/transformSaveModelToScene.test.ts
@@ -234,8 +234,10 @@ describe('transformSaveModelToScene', () => {
       expect(rowScene.state.children[0]).toBeInstanceOf(DashboardGridItem);
       expect(rowScene.state.children[1]).toBeInstanceOf(DashboardGridItem);
       expect(rowScene.state.children[2]).toBeInstanceOf(DashboardGridItem);
-      expect((rowScene.state.children[1] as DashboardGridItem).state.body!).toBeInstanceOf(AddLibraryPanelWidget);
-      expect((rowScene.state.children[2] as DashboardGridItem).state.body!).toBeInstanceOf(LibraryVizPanel);
+      // Panels are sorted by position in the row
+      expect((rowScene.state.children[0] as DashboardGridItem).state.body!).toBeInstanceOf(AddLibraryPanelWidget);
+      expect((rowScene.state.children[1] as DashboardGridItem).state.body!).toBeInstanceOf(LibraryVizPanel);
+      expect((rowScene.state.children[2] as DashboardGridItem).state.body!).toBeInstanceOf(VizPanel);
     });
 
     it('should create panels within expanded row', () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -4126,9 +4126,9 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@grafana/scenes@npm:4.0.1":
-  version: 4.0.1
-  resolution: "@grafana/scenes@npm:4.0.1"
+"@grafana/scenes@npm:4.1.2":
+  version: 4.1.2
+  resolution: "@grafana/scenes@npm:4.1.2"
   dependencies:
     "@grafana/e2e-selectors": "npm:10.3.3"
     react-grid-layout: "npm:1.3.4"
@@ -4142,7 +4142,7 @@ __metadata:
     "@grafana/ui": ^10.0.3
     react: ^18.0.0
     react-dom: ^18.0.0
-  checksum: 10/e12737e1a73155ef48bc507b20a2e47d1d7784730c625d799ea74b8719f0bfa2babc193ecdbcb85727ac81dbba0bfad27d4090696b34a7ed1a97caa9813540de
+  checksum: 10/3627d1f200b30872615d9427af3bdac534f8a39a5dd1ba1b3a55b9e6664cf5f0e9750fd9c0d36d1e54d7dd20f7e74a8f5e56f3e145e02f315bd9f104cdb448bd
   languageName: node
   linkType: hard
 
@@ -18565,7 +18565,7 @@ __metadata:
     "@grafana/prometheus": "workspace:*"
     "@grafana/runtime": "workspace:*"
     "@grafana/saga-icons": "workspace:*"
-    "@grafana/scenes": "npm:4.0.1"
+    "@grafana/scenes": "npm:4.1.2"
     "@grafana/schema": "workspace:*"
     "@grafana/sql": "workspace:*"
     "@grafana/tsconfig": "npm:^1.3.0-rc1"


### PR DESCRIPTION
Backport 9ba9cbf3005d889076eb5bebe61653a2a35447df from #85470

---

Bump scenes to [V4.1.2](https://github.com/grafana/scenes/releases/tag/v4.1.2)

This scenes release contains bug fixes for an escalation.
