### PR TITLE
Docs: add YouTube video link and description

### DIFF
--- a/docs/sources/panels-visualizations/visualizations/logs/index.md
+++ b/docs/sources/panels-visualizations/visualizations/logs/index.md
@@ -30,7 +30,7 @@ The logs visualization shows the result of queries that were entered in the Quer
 
 To limit the number of lines rendered, you can use the **Max data points** setting in the **Query options**. If it is not set, then the data source will usually enforce a default limit.
 
-The following video provides a walkthrough of creating a logs visualization. You'll also learn how to customize some settings and some log visualization caveats:
+The following video provides a walkthrough of creating a logs visualization. You'll also learn how to customize some settings and log visualization caveats:
 
 {{< youtube id="jSSi_x-fD_8" >}}
 

--- a/docs/sources/panels-visualizations/visualizations/logs/index.md
+++ b/docs/sources/panels-visualizations/visualizations/logs/index.md
@@ -30,7 +30,7 @@ The logs visualization shows the result of queries that were entered in the Quer
 
 To limit the number of lines rendered, you can use the **Max data points** setting in the **Query options**. If it is not set, then the data source will usually enforce a default limit.
 
-In the following video you can watch a walkthrough creating a Log Panel Visualization. You will learn as well how to customize a few settings and some Log Panel caveats, check out the video:
+The following video provides a walkthrough of creating a logs visualization. You'll also learn how to customize some settings and some log visualization caveats:
 
 {{< youtube id="jSSi_x-fD_8" >}}
 

--- a/docs/sources/panels-visualizations/visualizations/logs/index.md
+++ b/docs/sources/panels-visualizations/visualizations/logs/index.md
@@ -30,6 +30,10 @@ The logs visualization shows the result of queries that were entered in the Quer
 
 To limit the number of lines rendered, you can use the **Max data points** setting in the **Query options**. If it is not set, then the data source will usually enforce a default limit.
 
+In the following video you can watch a walkthrough creating a Log Panel Visualization. You will learn as well how to customize a few settings and some Log Panel caveats, check out the video:
+
+{{< youtube id="jSSi_x-fD_8" >}}
+
 ## Log level
 
 For logs where a **level** label is specified, we use the value of the label to determine the log level and update color accordingly. If the log doesn't have a level label specified, we try to find out if its content matches any of the supported expressions (see below for more information). The log level is always determined by the first match. In case Grafana is not able to determine a log level, it will be visualized with **unknown** log level. See [supported log levels and mappings of log level abbreviation and expressions][].


### PR DESCRIPTION
**What is this feature?**
Added a short description about the video and added the video to the page.

**Why do we need this feature?**
This will help users to visually understand the steps to create and configure a log. As well as drive traffic to the YT channel and _vice versa_.

**Who is this feature for?**
Everyone checking the documentation.

**Which issue(s) does this PR fix?**:
N/A

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
