### PR TITLE
RBAC: Fix access checks for interactions with RBAC roles in hosted Grafana

### DIFF
--- a/pkg/services/accesscontrol/middleware.go
+++ b/pkg/services/accesscontrol/middleware.go
@@ -338,18 +338,24 @@ func UseOrgFromRequestData(c *contextmodel.ReqContext) (int64, error) {
 }
 
 // UseGlobalOrgFromRequestData returns global org if `global` flag is set or the org where user is logged in.
-func UseGlobalOrgFromRequestData(c *contextmodel.ReqContext) (int64, error) {
-	query, err := getOrgQueryFromRequest(c)
-	if err != nil {
-		// Special case of macaron handling invalid params
-		return NoOrgID, org.ErrOrgNotFound.Errorf("failed to get organization from context: %w", err)
-	}
+// If RBACSingleOrganization is set, the org where user is logged in is returned - this is intended only for cloud workflows, where instances are limited to a single organization.
+func UseGlobalOrgFromRequestData(cfg *setting.Cfg) func(*contextmodel.ReqContext) (int64, error) {
+	return func(c *contextmodel.ReqContext) (int64, error) {
 
-	if query.Global {
-		return GlobalOrgID, nil
-	}
+		query, err := getOrgQueryFromRequest(c)
+		if err != nil {
+			// Special case of macaron handling invalid params
+			return NoOrgID, org.ErrOrgNotFound.Errorf("failed to get organization from context: %w", err)
+		}
 
-	return c.SignedInUser.GetOrgID(), nil
+		// We only check permissions in the global organization if we are not running a SingleOrganization setup
+		// That allows Organization Admins to modify global roles and make global assignments.
+		if query.Global && !cfg.RBACSingleOrganization {
+			return GlobalOrgID, nil
+		}
+
+		return c.SignedInUser.GetOrgID(), nil
+	}
 }
 
 // UseGlobalOrgFromRequestParams returns global org if `global` flag is set or the org where user is logged in.

--- a/pkg/services/accesscontrol/middleware.go
+++ b/pkg/services/accesscontrol/middleware.go
@@ -341,7 +341,6 @@ func UseOrgFromRequestData(c *contextmodel.ReqContext) (int64, error) {
 // If RBACSingleOrganization is set, the org where user is logged in is returned - this is intended only for cloud workflows, where instances are limited to a single organization.
 func UseGlobalOrgFromRequestData(cfg *setting.Cfg) func(*contextmodel.ReqContext) (int64, error) {
 	return func(c *contextmodel.ReqContext) (int64, error) {
-
 		query, err := getOrgQueryFromRequest(c)
 		if err != nil {
 			// Special case of macaron handling invalid params


### PR DESCRIPTION
**What is this feature?**

Only checks global permissions if `RBACSingleOrganization` is not set.

**Why do we need this feature?**

`RBACSingleOrganization` is used for cloud instances which always only have a single organization. For instance, when `RBACSingleOrganization` is set, organization admins can update basic roles.

**Who is this feature for?**

HG users

**Enterprise counterpart**

https://github.com/grafana/grafana-enterprise/pull/6435