### PR TITLE
Alerting/Annotations: Return nothing from historian store if filtering by tags

### DIFF
--- a/pkg/services/annotations/annotationsimpl/loki/historian_store.go
+++ b/pkg/services/annotations/annotationsimpl/loki/historian_store.go
@@ -78,6 +78,11 @@ func (r *LokiHistorianStore) Get(ctx context.Context, query *annotations.ItemQue
 		return make([]*annotations.ItemDTO, 0), nil
 	}
 
+	// alert state history does not contain tags, so we should return nothing if we want to match all tags from the query
+	if len(query.Tags) > 0 && !query.MatchAny {
+		return make([]*annotations.ItemDTO, 0), nil
+	}
+
 	rule := &ngmodels.AlertRule{}
 	if query.AlertID != 0 {
 		var err error
@@ -173,7 +178,7 @@ func (r *LokiHistorianStore) annotationsFromStream(stream historian.Stream, ac a
 }
 
 func (r *LokiHistorianStore) GetTags(ctx context.Context, query *annotations.TagsQuery) (annotations.FindTagsResult, error) {
-	return annotations.FindTagsResult{}, nil
+	return annotations.FindTagsResult{Tags: []*annotations.TagsDTO{}}, nil
 }
 
 // util

--- a/pkg/services/annotations/annotationsimpl/loki/historian_store.go
+++ b/pkg/services/annotations/annotationsimpl/loki/historian_store.go
@@ -78,8 +78,9 @@ func (r *LokiHistorianStore) Get(ctx context.Context, query *annotations.ItemQue
 		return make([]*annotations.ItemDTO, 0), nil
 	}
 
-	// alert state history does not contain tags, so we should return nothing if we want to match all tags from the query
-	if len(query.Tags) > 0 && !query.MatchAny {
+	// if the query is filtering on tags, but not on a specific dashboard, we shouldn't query loki
+	// since state history won't have tags for annotations
+	if len(query.Tags) > 0 && query.DashboardID == 0 && query.DashboardUID == "" {
 		return make([]*annotations.ItemDTO, 0), nil
 	}
 

--- a/pkg/services/annotations/annotationsimpl/loki/historian_store_test.go
+++ b/pkg/services/annotations/annotationsimpl/loki/historian_store_test.go
@@ -255,19 +255,17 @@ func TestIntegrationAlertStateHistoryStore(t *testing.T) {
 			}
 		})
 
-		t.Run("should return nothing if query is for tags and match any is false", func(t *testing.T) {
+		t.Run("should return nothing if query is for tags only", func(t *testing.T) {
 			fakeLokiClient.rangeQueryRes = []historian.Stream{
 				historian.StatesToStream(ruleMetaFromRule(t, dashboardRules[dashboard1.UID][0]), transitions, map[string]string{}, log.NewNopLogger()),
 				historian.StatesToStream(ruleMetaFromRule(t, dashboardRules[dashboard1.UID][1]), transitions, map[string]string{}, log.NewNopLogger()),
 			}
 
 			query := annotations.ItemQuery{
-				OrgID:       1,
-				DashboardID: dashboard1.ID,
-				From:        start.UnixMilli(),
-				To:          start.Add(time.Second * time.Duration(numTransitions+1)).UnixMilli(),
-				Tags:        []string{"tag1"},
-				MatchAny:    false,
+				OrgID: 1,
+				From:  start.UnixMilli(),
+				To:    start.Add(time.Second * time.Duration(numTransitions+1)).UnixMilli(),
+				Tags:  []string{"tag1"},
 			}
 			res, err := store.Get(
 				context.Background(),

--- a/pkg/services/annotations/annotationsimpl/loki/historian_store_test.go
+++ b/pkg/services/annotations/annotationsimpl/loki/historian_store_test.go
@@ -254,6 +254,34 @@ func TestIntegrationAlertStateHistoryStore(t *testing.T) {
 				lastTime = item.Time
 			}
 		})
+
+		t.Run("should return nothing if query is for tags and match any is false", func(t *testing.T) {
+			fakeLokiClient.rangeQueryRes = []historian.Stream{
+				historian.StatesToStream(ruleMetaFromRule(t, dashboardRules[dashboard1.UID][0]), transitions, map[string]string{}, log.NewNopLogger()),
+				historian.StatesToStream(ruleMetaFromRule(t, dashboardRules[dashboard1.UID][1]), transitions, map[string]string{}, log.NewNopLogger()),
+			}
+
+			query := annotations.ItemQuery{
+				OrgID:       1,
+				DashboardID: dashboard1.ID,
+				From:        start.UnixMilli(),
+				To:          start.Add(time.Second * time.Duration(numTransitions+1)).UnixMilli(),
+				Tags:        []string{"tag1"},
+				MatchAny:    false,
+			}
+			res, err := store.Get(
+				context.Background(),
+				&query,
+				&annotation_ac.AccessResources{
+					Dashboards: map[string]int64{
+						dashboard1.UID: dashboard1.ID,
+					},
+					CanAccessDashAnnotations: true,
+				},
+			)
+			require.NoError(t, err)
+			require.Empty(t, res)
+		})
 	})
 
 	t.Run("Testing items from Loki stream", func(t *testing.T) {


### PR DESCRIPTION
**What is this feature?**

This PR changes the behavior of the historian store to return an empty list if the annotation query is filtered by tags and `matchAny` is false.

**Why do we need this feature?**

This fixes a bug where alert annotations appear on panels when changing "Filter by" to `Tags` on the built in dashboard annotation query.

**Who is this feature for?**

Users of Grafana managed alerting and dashboard annotations

**Which issue(s) does this PR fix?**:

TBD

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle.
- [x] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
