### PR TITLE
Scenes: Fix issue where annotations with same name wouldn't render properly

### DIFF
--- a/public/app/features/dashboard-scene/serialization/transformSaveModelToScene.ts
+++ b/public/app/features/dashboard-scene/serialization/transformSaveModelToScene.ts
@@ -1,3 +1,5 @@
+import { uniqueId } from 'lodash';
+
 import { DataFrameDTO, DataFrameJSON, TypedVariableModel } from '@grafana/data';
 import { config } from '@grafana/runtime';
 import {
@@ -248,7 +250,7 @@ export function createDashboardSceneFromDashboardModel(oldModel: DashboardModel)
     annotationLayers = oldModel.annotations?.list.map((a) => {
       // Each annotation query is an individual data layer
       return new DashboardAnnotationsDataLayer({
-        key: `annotations-${a.name}`,
+        key: uniqueId('annotations-'),
         query: a,
         name: a.name,
         isEnabled: Boolean(a.enable),


### PR DESCRIPTION
Fixes the issue by assigning a unique ID as `DashboardAnnotationsDataLayer` key rather than just using the name.

Closes #85457