### PR TITLE
Alerting: Handle unspecified implementations of alertmanager datasource when sending externally

### DIFF
--- a/pkg/services/ngalert/sender/router.go
+++ b/pkg/services/ngalert/sender/router.go
@@ -6,8 +6,8 @@ import (
 	"errors"
 	"fmt"
 	"net/url"
+	"path"
 	"sort"
-	"strings"
 	"sync"
 	"time"
 
@@ -268,16 +268,8 @@ func (d *AlertsRouter) buildExternalURL(ds *datasources.DataSource) (string, err
 		if parsed.Path == "" {
 			parsed.Path = "/"
 		}
-		// Only add /alertmanager if it is not already present.
-		containsAlertmanagerSegment := false
-		parts := strings.Split(parsed.Path, "/")
-		for _, part := range parts {
-			if part == "alertmanager" {
-				containsAlertmanagerSegment = true
-				break
-			}
-		}
-		if !containsAlertmanagerSegment {
+		lastSegment := path.Base(parsed.Path)
+		if lastSegment != "alertmanager" {
 			parsed = parsed.JoinPath("/alertmanager")
 		}
 	}

--- a/pkg/services/ngalert/sender/router.go
+++ b/pkg/services/ngalert/sender/router.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"net/url"
 	"sort"
+	"strings"
 	"sync"
 	"time"
 
@@ -267,7 +268,18 @@ func (d *AlertsRouter) buildExternalURL(ds *datasources.DataSource) (string, err
 		if parsed.Path == "" {
 			parsed.Path = "/"
 		}
-		parsed = parsed.JoinPath("/alertmanager")
+		// Only add /alertmanager if it is not already present.
+		containsAlertmanagerSegment := false
+		parts := strings.Split(parsed.Path, "/")
+		for _, part := range parts {
+			if part == "alertmanager" {
+				containsAlertmanagerSegment = true
+				break
+			}
+		}
+		if !containsAlertmanagerSegment {
+			parsed = parsed.JoinPath("/alertmanager")
+		}
 	}
 
 	// If basic auth is enabled we need to build the url with basic auth baked in.

--- a/pkg/services/ngalert/sender/router_test.go
+++ b/pkg/services/ngalert/sender/router_test.go
@@ -542,11 +542,12 @@ func TestBuildExternalURL(t *testing.T) {
 		{
 			name: "adds /alertmanager to path when implementation is not specified",
 			ds: &datasources.DataSource{
-				URL: "https://localhost:9000/alertmanager",
+				URL: "https://localhost:9000",
 				JsonData: func() *simplejson.Json {
 					return simplejson.New()
 				}(),
 			},
+			expectedURL: "https://localhost:9000/alertmanager",
 		},
 		{
 			name: "adds /alertmanager to path when implementation is mimir",
@@ -585,7 +586,7 @@ func TestBuildExternalURL(t *testing.T) {
 			expectedURL: "https://localhost:9000/path/to/am",
 		},
 		{
-			name: "do not add /alertmanager to path when a segment already contains it",
+			name: "do not add /alertmanager to path when last segment already contains it",
 			ds: &datasources.DataSource{
 				URL: "https://localhost:9000/path/to/alertmanager",
 				JsonData: func() *simplejson.Json {
@@ -597,7 +598,7 @@ func TestBuildExternalURL(t *testing.T) {
 			expectedURL: "https://localhost:9000/path/to/alertmanager",
 		},
 		{
-			name: "add /alertmanager to path when a segment does not exactly match it",
+			name: "add /alertmanager to path when last segment does not exactly match",
 			ds: &datasources.DataSource{
 				URL: "https://localhost:9000/path/to/alertmanagerasdf",
 				JsonData: func() *simplejson.Json {
@@ -606,7 +607,19 @@ func TestBuildExternalURL(t *testing.T) {
 					return r
 				}(),
 			},
-			expectedURL: "https://localhost:9000/alertmanagerasdf/alertmanager",
+			expectedURL: "https://localhost:9000/path/to/alertmanagerasdf/alertmanager",
+		},
+		{
+			name: "add /alertmanager to path when exists but is not last segment",
+			ds: &datasources.DataSource{
+				URL: "https://localhost:9000/alertmanager/path/to/am",
+				JsonData: func() *simplejson.Json {
+					r := simplejson.New()
+					r.Set("implementation", "mimir")
+					return r
+				}(),
+			},
+			expectedURL: "https://localhost:9000/alertmanager/path/to/am/alertmanager",
 		},
 	}
 	for _, test := range tests {

--- a/pkg/services/ngalert/sender/router_test.go
+++ b/pkg/services/ngalert/sender/router_test.go
@@ -584,6 +584,30 @@ func TestBuildExternalURL(t *testing.T) {
 			},
 			expectedURL: "https://localhost:9000/path/to/am",
 		},
+		{
+			name: "do not add /alertmanager to path when a segment already contains it",
+			ds: &datasources.DataSource{
+				URL: "https://localhost:9000/path/to/alertmanager",
+				JsonData: func() *simplejson.Json {
+					r := simplejson.New()
+					r.Set("implementation", "mimir")
+					return r
+				}(),
+			},
+			expectedURL: "https://localhost:9000/path/to/alertmanager",
+		},
+		{
+			name: "add /alertmanager to path when a segment does not exactly match it",
+			ds: &datasources.DataSource{
+				URL: "https://localhost:9000/path/to/alertmanagerasdf",
+				JsonData: func() *simplejson.Json {
+					r := simplejson.New()
+					r.Set("implementation", "mimir")
+					return r
+				}(),
+			},
+			expectedURL: "https://localhost:9000/alertmanagerasdf/alertmanager",
+		},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {

--- a/pkg/services/ngalert/sender/router_test.go
+++ b/pkg/services/ngalert/sender/router_test.go
@@ -439,6 +439,11 @@ func TestBuildExternalURL(t *testing.T) {
 			name: "datasource without auth",
 			ds: &datasources.DataSource{
 				URL: "https://localhost:9000",
+				JsonData: func() *simplejson.Json {
+					r := simplejson.New()
+					r.Set("implementation", "prometheus")
+					return r
+				}(),
 			},
 			expectedURL: "https://localhost:9000",
 		},
@@ -446,6 +451,11 @@ func TestBuildExternalURL(t *testing.T) {
 			name: "datasource without auth and with path",
 			ds: &datasources.DataSource{
 				URL: "https://localhost:9000/path/to/am",
+				JsonData: func() *simplejson.Json {
+					r := simplejson.New()
+					r.Set("implementation", "prometheus")
+					return r
+				}(),
 			},
 			expectedURL: "https://localhost:9000/path/to/am",
 		},
@@ -458,6 +468,11 @@ func TestBuildExternalURL(t *testing.T) {
 				SecureJsonData: map[string][]byte{
 					"basicAuthPassword": []byte("123"),
 				},
+				JsonData: func() *simplejson.Json {
+					r := simplejson.New()
+					r.Set("implementation", "prometheus")
+					return r
+				}(),
 			},
 			expectedURL: "https://johndoe:123@localhost:9000",
 		},
@@ -470,6 +485,11 @@ func TestBuildExternalURL(t *testing.T) {
 				SecureJsonData: map[string][]byte{
 					"basicAuthPassword": []byte("123#!"),
 				},
+				JsonData: func() *simplejson.Json {
+					r := simplejson.New()
+					r.Set("implementation", "prometheus")
+					return r
+				}(),
 			},
 			expectedURL: "https://johndoe:123%23%21@localhost:9000",
 		},
@@ -482,6 +502,11 @@ func TestBuildExternalURL(t *testing.T) {
 				SecureJsonData: map[string][]byte{
 					"basicAuthPassword": []byte("123"),
 				},
+				JsonData: func() *simplejson.Json {
+					r := simplejson.New()
+					r.Set("implementation", "prometheus")
+					return r
+				}(),
 			},
 			expectedURL: "https://johndoe:123@localhost:9000/path/to/am",
 		},
@@ -494,6 +519,11 @@ func TestBuildExternalURL(t *testing.T) {
 				SecureJsonData: map[string][]byte{
 					"basicAuthPassword": []byte("123"),
 				},
+				JsonData: func() *simplejson.Json {
+					r := simplejson.New()
+					r.Set("implementation", "prometheus")
+					return r
+				}(),
 			},
 			expectedURL: "http://johndoe:123@localhost:9000/path/to/am",
 		},
@@ -501,8 +531,22 @@ func TestBuildExternalURL(t *testing.T) {
 			name: "with no scheme specified not auth in the datasource",
 			ds: &datasources.DataSource{
 				URL: "localhost:9000/path/to/am",
+				JsonData: func() *simplejson.Json {
+					r := simplejson.New()
+					r.Set("implementation", "prometheus")
+					return r
+				}(),
 			},
 			expectedURL: "http://localhost:9000/path/to/am",
+		},
+		{
+			name: "adds /alertmanager to path when implementation is not specified",
+			ds: &datasources.DataSource{
+				URL: "https://localhost:9000/alertmanager",
+				JsonData: func() *simplejson.Json {
+					return simplejson.New()
+				}(),
+			},
 		},
 		{
 			name: "adds /alertmanager to path when implementation is mimir",


### PR DESCRIPTION
**What is this feature?**

Choosing `Mimir` as the alertmanager datasource implementation now seems to leave out the implementation field entirely.

However, the backend's detection of this was not updated. So, it fails to detect whether a datasource is actually mimir/cortex. This means it does not inject `/alertmanager` into the URL when sending alerts. causing alerts to be sent to the wrong path.

**Why do we need this feature?**

Fixes sending to an external alertmanager when the backend is mimir or cortex.

**Who is this feature for?**

Anyone who is sending alerts from Grafana ruler to external mimir/cortex alertmanager.

**Which issue(s) does this PR fix?**:

n/a

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle.
- [x] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
