### PR TITLE
[DOC] Adds missing link to Pyroscope core data source

### DIFF
--- a/docs/sources/datasources/_index.md
+++ b/docs/sources/datasources/_index.md
@@ -103,6 +103,7 @@ These built-in core data sources are also included in the Grafana documentation:
 - [OpenTSDB]({{< relref "./opentsdb" >}})
 - [PostgreSQL]({{< relref "./postgres" >}})
 - [Prometheus]({{< relref "./prometheus" >}})
+- [Pyroscope]({{< relref "./pyroscope" >}})
 - [Tempo]({{< relref "./tempo" >}})
 - [Testdata]({{< relref "./testdata" >}})
 - [Zipkin]({{< relref "./zipkin" >}})


### PR DESCRIPTION
Grafana Pyroscope is a core shipped data source.
