### PR TITLE
Transformations: Add applicability function to group to nested table

### DIFF
--- a/packages/grafana-data/src/transformations/transformers/groupBy.ts
+++ b/packages/grafana-data/src/transformations/transformers/groupBy.ts
@@ -7,6 +7,9 @@ import { DataTransformerInfo } from '../../types/transformations';
 import { reduceField, ReducerID } from '../fieldReducer';
 
 import { DataTransformerID } from './ids';
+import { findMaxFields } from './utils';
+
+const MINIMUM_FIELDS_REQUIRED = 2;
 
 export enum GroupByOperationID {
   aggregate = 'aggregate',
@@ -34,32 +37,19 @@ export const groupByTransformer: DataTransformerInfo<GroupByTransformerOptions> 
     fields: {},
   },
   isApplicable: (data: DataFrame[]) => {
-    let maxFields = 0;
-
     // Group by needs at least two fields
     // a field to group on and a field to aggregate
     // We make sure that at least one frame has at
     // least two fields
-    for (const frame of data) {
-      if (frame.fields.length > maxFields) {
-        maxFields = frame.fields.length;
-      }
-    }
+    const maxFields = findMaxFields(data);
 
-    return maxFields >= 2
+    return maxFields >= MINIMUM_FIELDS_REQUIRED
       ? TransformationApplicabilityLevels.Applicable
       : TransformationApplicabilityLevels.NotApplicable;
   },
   isApplicableDescription: (data: DataFrame[]) => {
-    let maxFields = 0;
-
-    for (const frame of data) {
-      if (frame.fields.length > maxFields) {
-        maxFields = frame.fields.length;
-      }
-    }
-
-    return `The Group by transformation requires a series with at least two fields to work. The maximum number of fields found on a series is ${maxFields}`;
+    const maxFields = findMaxFields(data);
+    return `The Group by transformation requires a series with at least ${MINIMUM_FIELDS_REQUIRED} fields to work. The maximum number of fields found on a series is ${maxFields}`;
   },
   /**
    * Return a modified copy of the series. If the transform is not or should not

--- a/packages/grafana-data/src/transformations/transformers/groupToNestedTable.ts
+++ b/packages/grafana-data/src/transformations/transformers/groupToNestedTable.ts
@@ -3,13 +3,15 @@ import { map } from 'rxjs/operators';
 import { guessFieldTypeForField } from '../../dataframe/processDataFrame';
 import { getFieldDisplayName } from '../../field/fieldState';
 import { DataFrame, Field, FieldType } from '../../types/dataFrame';
-import { DataTransformerInfo } from '../../types/transformations';
+import { DataTransformerInfo, TransformationApplicabilityLevels } from '../../types/transformations';
 import { ReducerID, reduceField } from '../fieldReducer';
 
 import { GroupByFieldOptions, createGroupedFields, groupValuesByKey } from './groupBy';
 import { DataTransformerID } from './ids';
+import { findMaxFields } from './utils';
 
 export const SHOW_NESTED_HEADERS_DEFAULT = true;
+const MINIMUM_FIELDS_REQUIRED = 2;
 
 enum GroupByOperationID {
   aggregate = 'aggregate',
@@ -33,7 +35,19 @@ export const groupToNestedTable: DataTransformerInfo<GroupToNestedTableTransform
     showSubframeHeaders: SHOW_NESTED_HEADERS_DEFAULT,
     fields: {},
   },
+  isApplicable: (data) => {
+    // Group to nested table needs at least two fields
+    // a field to group on and to show in the nested table
+    const maxFields = findMaxFields(data);
 
+    return maxFields >= MINIMUM_FIELDS_REQUIRED
+      ? TransformationApplicabilityLevels.Applicable
+      : TransformationApplicabilityLevels.NotApplicable;
+  },
+  isApplicableDescription: (data: DataFrame[]) => {
+    const maxFields = findMaxFields(data);
+    return `The Group to nested table transformation requires a series with at least ${MINIMUM_FIELDS_REQUIRED} fields to work. The maximum number of fields found on a series is ${maxFields}`;
+  },
   /**
    * Return a modified copy of the series. If the transform is not or should not
    * be applied, just return the input series

--- a/packages/grafana-data/src/transformations/transformers/utils.ts
+++ b/packages/grafana-data/src/transformations/transformers/utils.ts
@@ -1,3 +1,22 @@
+import { DataFrame } from "../../types";
+
 export const transformationsVariableSupport = () => {
   return (window as any)?.grafanaBootData?.settings?.featureToggles?.transformationsVariableSupport;
 };
+
+/**
+ * Retrieve the maximum number of fields in a series of a dataframe.
+ */
+export function findMaxFields(data: DataFrame[]) {
+  let maxFields = 0;
+
+  // Group to nested table needs at least two fields
+  // a field to group on and to show in the nested table
+  for (const frame of data) {
+    if (frame.fields.length > maxFields) {
+      maxFields = frame.fields.length;
+    }
+  }
+
+  return maxFields;
+}

--- a/packages/grafana-data/src/transformations/transformers/utils.ts
+++ b/packages/grafana-data/src/transformations/transformers/utils.ts
@@ -1,4 +1,4 @@
-import { DataFrame } from "../../types";
+import { DataFrame } from '../../types';
 
 export const transformationsVariableSupport = () => {
   return (window as any)?.grafanaBootData?.settings?.featureToggles?.transformationsVariableSupport;


### PR DESCRIPTION
**What is this feature?**

This PR adds an applicability function to the Group to nested table transformation so that it will show in shaded format when there isn't enough data to properly use it.

https://github.com/grafana/grafana/assets/199847/b401ec7d-87cf-4059-8765-17c07ecb0664


**Why do we need this feature?**

This makes it more clear to users when this transformation is useful and useable.

**Who is this feature for?**

Users of the group to nested table transformation.

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
