### PR TITLE
Chore: Fix trailing spaces in prometheus min step

### DIFF
--- a/packages/grafana-prometheus/src/querybuilder/components/PromQueryBuilderOptions.tsx
+++ b/packages/grafana-prometheus/src/querybuilder/components/PromQueryBuilderOptions.tsx
@@ -37,7 +37,7 @@ export const PromQueryBuilderOptions = React.memo<PromQueryBuilderOptionsProps>(
     };
 
     const onChangeStep = (evt: React.FormEvent<HTMLInputElement>) => {
-      onChange({ ...query, interval: evt.currentTarget.value });
+      onChange({ ...query, interval: evt.currentTarget.value.trim() });
       onRunQuery();
     };
 

--- a/public/app/plugins/datasource/prometheus/querybuilder/components/PromQueryBuilderOptions.tsx
+++ b/public/app/plugins/datasource/prometheus/querybuilder/components/PromQueryBuilderOptions.tsx
@@ -36,7 +36,7 @@ export const PromQueryBuilderOptions = React.memo<Props>(({ query, app, onChange
   };
 
   const onChangeStep = (evt: React.FormEvent<HTMLInputElement>) => {
-    onChange({ ...query, interval: evt.currentTarget.value });
+    onChange({ ...query, interval: evt.currentTarget.value.trim() });
     onRunQuery();
   };
 


### PR DESCRIPTION
This PR updates Prometheus query editor to handle trailing spaces. 


Tested by deploying changes locally and testing that trailing spaces does not raise errors: 

https://github.com/grafana/grafana/assets/43913498/a84e17cc-f065-4fc0-877e-3561990e871c



Fixes #81121

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
