### PR TITLE
fix(alerting): only expose metrics if executing alerts

### DIFF
--- a/pkg/services/ngalert/ngalert.go
+++ b/pkg/services/ngalert/ngalert.go
@@ -279,6 +279,7 @@ func (ng *AlertNG) init() error {
 	cfg := state.ManagerCfg{
 		Metrics:                        ng.Metrics.GetStateMetrics(),
 		ExternalURL:                    appUrl,
+		ExecuteAlerts:                  ng.Cfg.UnifiedAlerting.ExecuteAlerts,
 		InstanceStore:                  ng.store,
 		Images:                         ng.ImageService,
 		Clock:                          clk,

--- a/pkg/services/ngalert/ngalert.go
+++ b/pkg/services/ngalert/ngalert.go
@@ -279,7 +279,7 @@ func (ng *AlertNG) init() error {
 	cfg := state.ManagerCfg{
 		Metrics:                        ng.Metrics.GetStateMetrics(),
 		ExternalURL:                    appUrl,
-		ExecuteAlerts:                  ng.Cfg.UnifiedAlerting.ExecuteAlerts,
+		DisableExecution:               !ng.Cfg.UnifiedAlerting.ExecuteAlerts,
 		InstanceStore:                  ng.store,
 		Images:                         ng.ImageService,
 		Clock:                          clk,

--- a/pkg/services/ngalert/state/manager.go
+++ b/pkg/services/ngalert/state/manager.go
@@ -71,7 +71,7 @@ type ManagerCfg struct {
 	ApplyNoDataAndErrorToAllStates bool
 	RulesPerRuleGroupLimit         int64
 
-	ExecuteAlerts bool
+	DisableExecution bool
 
 	Tracer tracing.Tracer
 	Log    log.Logger
@@ -81,7 +81,7 @@ func NewManager(cfg ManagerCfg, statePersister StatePersister) *Manager {
 	// Metrics for the cache use a collector, so they need access to the register directly.
 	c := newCache()
 	// Only expose the metrics if this grafana server does execute alerts.
-	if cfg.Metrics != nil && cfg.ExecuteAlerts {
+	if cfg.Metrics != nil && !cfg.DisableExecution {
 		c.RegisterMetrics(cfg.Metrics.Registerer())
 	}
 

--- a/pkg/services/ngalert/state/manager.go
+++ b/pkg/services/ngalert/state/manager.go
@@ -71,6 +71,8 @@ type ManagerCfg struct {
 	ApplyNoDataAndErrorToAllStates bool
 	RulesPerRuleGroupLimit         int64
 
+	ExecuteAlerts bool
+
 	Tracer tracing.Tracer
 	Log    log.Logger
 }
@@ -78,7 +80,8 @@ type ManagerCfg struct {
 func NewManager(cfg ManagerCfg, statePersister StatePersister) *Manager {
 	// Metrics for the cache use a collector, so they need access to the register directly.
 	c := newCache()
-	if cfg.Metrics != nil {
+	// Only expose the metrics if this grafana server does execute alerts.
+	if cfg.Metrics != nil && cfg.ExecuteAlerts {
 		c.RegisterMetrics(cfg.Metrics.Registerer())
 	}
 


### PR DESCRIPTION
This PR only exposes the metrics of the cache if it is also executing alerts. This is needed as we run in the cloud a subsystem that already exposes these metrics and we otherwise end up with the wrong metrics.