### PR TITLE
Alerting: Set mimir implementation in jsonData by default when creating a new a…

### DIFF
--- a/public/app/plugins/datasource/alertmanager/ConfigEditor.tsx
+++ b/public/app/plugins/datasource/alertmanager/ConfigEditor.tsx
@@ -1,5 +1,5 @@
 import { produce } from 'immer';
-import React from 'react';
+import React, { useEffect } from 'react';
 import { Link } from 'react-router-dom';
 
 import { SIGV4ConnectionConfig } from '@grafana/aws-sdk';
@@ -32,6 +32,17 @@ const IMPL_OPTIONS: Array<SelectableValue<AlertManagerImplementation>> = [
 
 export const ConfigEditor = (props: Props) => {
   const { options, onOptionsChange } = props;
+
+  // As we default to Mimir, we need to make sure the implementation is set from the start
+  useEffect(() => {
+    if (!options.jsonData.implementation) {
+      onOptionsChange(
+        produce(options, (draft) => {
+          draft.jsonData.implementation = AlertManagerImplementation.mimir;
+        })
+      );
+    }
+  }, [options, onOptionsChange]);
 
   return (
     <>


### PR DESCRIPTION
**What is this feature?**

In the UI, when creating a new alert manager data source, we decided to default to `mimir` implementation. But we were not setting the implementation field in the `jsonData` we send to the BE when saving the data source.
This leads to have a wrong alert routing (actually not working at all) , because in the BE side , the mimir implementation is not detected (as it's empty).

This is what happens:
1. User clicks new data source /alert manager type.
2. this creates immediately a data source with an `empty jsonData` field
3. UI decides that as the jsonData.implementation is empty, we default to `mimir` implementation. But it does not update the field in the UI, we only update this field when selecting an option in the implementation dropdown. 
4. BE receives an empty implementation, and it does not default to Mimir :x: => inconsistency

This PR updates the default implementation to `mimir` field in the jsonData if the implementation is not touched (mimir by default)

Fixes https://github.com/grafana/grafana/issues/80204

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
