### PR TITLE
postgres: add tests to handle multiple statements in the same query

### DIFF
--- a/pkg/tsdb/grafana-postgresql-datasource/postgres_snapshot_test.go
+++ b/pkg/tsdb/grafana-postgresql-datasource/postgres_snapshot_test.go
@@ -121,6 +121,8 @@ func TestIntegrationPostgresSnapshots(t *testing.T) {
 		{format: "time_series", name: "fill_value"},
 		{format: "time_series", name: "fill_value_wide"},
 		{format: "table", name: "simple"},
+		{format: "table", name: "multi_stat1"},
+		{format: "table", name: "multi_stat2"},
 		{format: "table", name: "no_rows"},
 		{format: "table", name: "types_numeric"},
 		{format: "table", name: "types_char"},

--- a/pkg/tsdb/grafana-postgresql-datasource/testdata/table/multi_stat1.golden.jsonc
+++ b/pkg/tsdb/grafana-postgresql-datasource/testdata/table/multi_stat1.golden.jsonc
@@ -1,0 +1,56 @@
+//  🌟 This was machine generated.  Do not edit. 🌟
+//  
+//  Frame[0] {
+//      "typeVersion": [
+//          0,
+//          0
+//      ],
+//      "executedQueryString": "SELECT t FROM tbl WHERE t='one'; SELECT t FROM tbl WHERE t='three';"
+//  }
+//  Name: 
+//  Dimensions: 1 Fields by 2 Rows
+//  +-----------------+
+//  | Name: t         |
+//  | Labels:         |
+//  | Type: []*string |
+//  +-----------------+
+//  | one             |
+//  | three           |
+//  +-----------------+
+//  
+//  
+//  🌟 This was machine generated.  Do not edit. 🌟
+{
+  "status": 200,
+  "frames": [
+    {
+      "schema": {
+        "meta": {
+          "typeVersion": [
+            0,
+            0
+          ],
+          "executedQueryString": "SELECT t FROM tbl WHERE t='one'; SELECT t FROM tbl WHERE t='three';"
+        },
+        "fields": [
+          {
+            "name": "t",
+            "type": "string",
+            "typeInfo": {
+              "frame": "string",
+              "nullable": true
+            }
+          }
+        ]
+      },
+      "data": {
+        "values": [
+          [
+            "one",
+            "three"
+          ]
+        ]
+      }
+    }
+  ]
+}

--- a/pkg/tsdb/grafana-postgresql-datasource/testdata/table/multi_stat1.sql
+++ b/pkg/tsdb/grafana-postgresql-datasource/testdata/table/multi_stat1.sql
@@ -1,0 +1,7 @@
+-- SELECT t FROM tbl WHERE t='one'; SELECT t FROM tbl WHERE t='three';
+-- lib/pq allows multiple queries to run, and return results for all the queries
+CREATE TEMPORARY TABLE tbl (
+    t text
+);
+
+INSERT INTO tbl (t) VALUES ('one'),('two'),('three');

--- a/pkg/tsdb/grafana-postgresql-datasource/testdata/table/multi_stat2.golden.jsonc
+++ b/pkg/tsdb/grafana-postgresql-datasource/testdata/table/multi_stat2.golden.jsonc
@@ -1,0 +1,56 @@
+//  🌟 This was machine generated.  Do not edit. 🌟
+//  
+//  Frame[0] {
+//      "typeVersion": [
+//          0,
+//          0
+//      ],
+//      "executedQueryString": "SET TIME ZONE -7; select * from tbl; SET TIME ZONE DEFAULT; select * from tbl;"
+//  }
+//  Name: 
+//  Dimensions: 1 Fields by 2 Rows
+//  +---------------------------------+
+//  | Name: d                         |
+//  | Labels:                         |
+//  | Type: []*time.Time              |
+//  +---------------------------------+
+//  | 2024-04-03 05:43:25 -0700 -0700 |
+//  | 2024-04-03 12:43:25 +0000 UTC   |
+//  +---------------------------------+
+//  
+//  
+//  🌟 This was machine generated.  Do not edit. 🌟
+{
+  "status": 200,
+  "frames": [
+    {
+      "schema": {
+        "meta": {
+          "typeVersion": [
+            0,
+            0
+          ],
+          "executedQueryString": "SET TIME ZONE -7; select * from tbl; SET TIME ZONE DEFAULT; select * from tbl;"
+        },
+        "fields": [
+          {
+            "name": "d",
+            "type": "time",
+            "typeInfo": {
+              "frame": "time.Time",
+              "nullable": true
+            }
+          }
+        ]
+      },
+      "data": {
+        "values": [
+          [
+            1712148205000,
+            1712148205000
+          ]
+        ]
+      }
+    }
+  ]
+}

--- a/pkg/tsdb/grafana-postgresql-datasource/testdata/table/multi_stat2.sql
+++ b/pkg/tsdb/grafana-postgresql-datasource/testdata/table/multi_stat2.sql
@@ -1,0 +1,7 @@
+-- SET TIME ZONE -7; select * from tbl; SET TIME ZONE DEFAULT; select * from tbl;
+-- the multiple statements can affect each other, their order must be correct.
+CREATE TEMPORARY TABLE tbl (
+    d timestamp with time zone
+);
+
+INSERT INTO tbl (d) VALUES ('2024-04-03T12:43:25UTC')

--- a/pkg/tsdb/grafana-postgresql-datasource/testdata/table/multi_stat2.sql
+++ b/pkg/tsdb/grafana-postgresql-datasource/testdata/table/multi_stat2.sql
@@ -1,5 +1,8 @@
 -- SET TIME ZONE -7; select * from tbl; SET TIME ZONE DEFAULT; select * from tbl;
--- the multiple statements can affect each other, their order must be correct.
+-- we are testing that you can run multiple statements in one "query",
+-- and those statements have effects on each other, in this example
+-- we load the same database-value in different time-zones,
+-- we should receive different values.
 CREATE TEMPORARY TABLE tbl (
     d timestamp with time zone
 );


### PR DESCRIPTION
tests only change.

we added snapshot tests to handle the scenario where multiple sql statements are sent in the same query.