### PR TITLE
Alerting docs: fix `docs/shared` API to render the current version

### DIFF
--- a/docs/sources/alerting/set-up/provision-alerting-resources/http-api-provisioning/_index.md
+++ b/docs/sources/alerting/set-up/provision-alerting-resources/http-api-provisioning/_index.md
@@ -17,4 +17,4 @@ weight: 400
 
 # Use the HTTP API to manage alerting resources
 
-{{< docs/shared lookup="alerts/alerting_provisioning.md" source="grafana" version="latest" >}}
+{{< docs/shared lookup="alerts/alerting_provisioning.md" source="grafana" version="<GRAFANA_VERSION>" >}}

--- a/docs/sources/developers/http_api/alerting_provisioning.md
+++ b/docs/sources/developers/http_api/alerting_provisioning.md
@@ -20,4 +20,4 @@ title: 'Alerting Provisioning HTTP API '
 
 # Alerting provisioning HTTP API
 
-{{< docs/shared lookup="alerts/alerting_provisioning.md" source="grafana" version="latest" >}}
+{{< docs/shared lookup="alerts/alerting_provisioning.md" source="grafana" version="<GRAFANA_VERSION>" >}}


### PR DESCRIPTION
Replace `latest` with `<GRAFANA_VERSION>` to render the current version in shared files. Discussed in Slack with @jdbaldry 

