### PR TITLE
Alerting docs: note on images in notifications for cloud

### DIFF
--- a/docs/sources/alerting/configure-notifications/template-notifications/images-in-notifications.md
+++ b/docs/sources/alerting/configure-notifications/template-notifications/images-in-notifications.md
@@ -19,10 +19,14 @@ weight: 500
 
 # Use images in notifications
 
+{{% admonition type="note" %}}
+Grafana Cloud users can request this feature by [opening a support ticket in the Cloud Portal](/profile/org#support).
+{{% /admonition %}}
+
 Images in notifications helps recipients of alert notifications better understand why an alert has fired or resolved by including a screenshot of the panel associated with the alert.
 
 {{% admonition type="note" %}}
-This feature is not supported in Mimir or Loki, or when Grafana is configured to send alerts to other Alertmanagers such as the Prometheus Alertmanager
+This feature is not supported in Mimir or Loki, or when Grafana is configured to send alerts to other Alertmanagers such as the Prometheus Alertmanager.
 {{% /admonition %}}
 
 When an alert is fired or resolved Grafana takes a screenshot of the panel associated with the alert. This is determined via the Dashboard UID and Panel ID annotations of the rule. Grafana cannot take a screenshot for alerts that are not associated with a panel.


### PR DESCRIPTION
adds note that cloud users need to request the feature using a support ticket at the top.