### PR TITLE
PostgreSQL: Fix the verify-ca mode

### DIFF
--- a/pkg/tsdb/grafana-postgresql-datasource/postgres.go
+++ b/pkg/tsdb/grafana-postgresql-datasource/postgres.go
@@ -224,6 +224,14 @@ func (s *Service) generateConnectionString(dsInfo sqleng.DataSourceInfo) (string
 
 	connStr += fmt.Sprintf(" sslmode='%s'", escape(tlsSettings.Mode))
 
+	// there is an issue with the lib/pq module, the `verify-ca` tls mode
+	// does not work correctly. ( see https://github.com/lib/pq/issues/1106 )
+	// to workaround the problem, if the `verify-ca` mode is chosen,
+	// we disable sslsni.
+	if tlsSettings.Mode == "verify-ca" {
+		connStr += " sslsni=0"
+	}
+
 	// Attach root certificate if provided
 	if tlsSettings.RootCertFile != "" {
 		logger.Debug("Setting server root certificate", "tlsRootCert", tlsSettings.RootCertFile)

--- a/pkg/tsdb/grafana-postgresql-datasource/postgres_test.go
+++ b/pkg/tsdb/grafana-postgresql-datasource/postgres_test.go
@@ -58,6 +58,15 @@ func TestIntegrationGenerateConnectionString(t *testing.T) {
 			expConnStr:  "user='user' password='password' host='host' dbname='database' sslmode='verify-full'",
 		},
 		{
+			desc:        "verify-ca automatically adds disable-sni",
+			host:        "host:1234",
+			user:        "user",
+			password:    "password",
+			database:    "database",
+			tlsSettings: tlsSettings{Mode: "verify-ca"},
+			expConnStr:  "user='user' password='password' host='host' dbname='database' port=1234 sslmode='verify-ca' sslsni=0",
+		},
+		{
 			desc:        "TCP/port host",
 			host:        "host:1234",
 			user:        "user",


### PR DESCRIPTION
fixes https://github.com/grafana/grafana/issues/65816 (again)

there are 4 modes for TLS in the postgres plugin: `disable`, `require`, `verify-ca`, `verify-full`.

the mode `verify-ca` does not work correctly, this PR fixes it.

how to test:

configure grafana using the scenario described here: https://github.com/grafana/oss-big-tent-tools/tree/main/tls-setups/postgres#verify-server-cert-ignore-host . you should be able to [save&test] the postgres database.