### PR TITLE
CI: Skip analysis steps if not needed

### DIFF
--- a/.github/workflows/pr-codeql-analysis-go.yml
+++ b/.github/workflows/pr-codeql-analysis-go.yml
@@ -14,6 +14,7 @@ jobs:
   analyze:
     name: Analyze
     runs-on: ubuntu-latest
+    if: github.repository == 'grafana/grafana'
 
     steps:
     - name: "Generate token"
@@ -50,4 +51,3 @@ jobs:
 
     - name: Perform CodeQL Analysis
       uses: github/codeql-action/analyze@v2
-      if: github.repository == 'grafana/grafana'

--- a/.github/workflows/pr-codeql-analysis-javascript.yml
+++ b/.github/workflows/pr-codeql-analysis-javascript.yml
@@ -16,6 +16,7 @@ jobs:
   analyze:
     name: Analyze
     runs-on: ubuntu-latest
+    if: github.repository == 'grafana/grafana'
 
     steps:
     - name: Checkout repository
@@ -33,4 +34,3 @@ jobs:
 
     - name: Perform CodeQL Analysis
       uses: github/codeql-action/analyze@v2
-      if: github.repository == 'grafana/grafana'

--- a/.github/workflows/pr-codeql-analysis-python.yml
+++ b/.github/workflows/pr-codeql-analysis-python.yml
@@ -14,6 +14,7 @@ jobs:
   analyze:
     name: Analyze
     runs-on: ubuntu-latest
+    if: github.repository == 'grafana/grafana'
 
     steps:
     - name: Checkout repository
@@ -31,4 +32,3 @@ jobs:
 
     - name: Perform CodeQL Analysis
       uses: github/codeql-action/analyze@v2
-      if: github.repository == 'grafana/grafana'


### PR DESCRIPTION
CodeQL analysis steps are run also outside of `grafana/grafana`, causing some failures. This PR fixes that.