### PR TITLE
Alerting: Only append `/alertmanager` when sending alerts to mimir targets if not already present

### DIFF
--- a/pkg/services/ngalert/sender/router.go
+++ b/pkg/services/ngalert/sender/router.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"net/url"
+	"path"
 	"sort"
 	"sync"
 	"time"
@@ -270,7 +271,10 @@ func (d *AlertsRouter) buildExternalURL(ds *datasources.DataSource) (string, err
 			if parsed.Path == "" {
 				parsed.Path = "/"
 			}
-			parsed = parsed.JoinPath("/alertmanager")
+			lastSegment := path.Base(parsed.Path)
+			if lastSegment != "alertmanager" {
+				parsed = parsed.JoinPath("/alertmanager")
+			}
 		default:
 		}
 	}

--- a/pkg/services/ngalert/sender/router_test.go
+++ b/pkg/services/ngalert/sender/router_test.go
@@ -540,6 +540,42 @@ func TestBuildExternalURL(t *testing.T) {
 			},
 			expectedURL: "https://localhost:9000/path/to/am",
 		},
+		{
+			name: "do not add /alertmanager to path when last segment already contains it",
+			ds: &datasources.DataSource{
+				URL: "https://localhost:9000/path/to/alertmanager",
+				JsonData: func() *simplejson.Json {
+					r := simplejson.New()
+					r.Set("implementation", "mimir")
+					return r
+				}(),
+			},
+			expectedURL: "https://localhost:9000/path/to/alertmanager",
+		},
+		{
+			name: "add /alertmanager to path when last segment does not exactly match",
+			ds: &datasources.DataSource{
+				URL: "https://localhost:9000/path/to/alertmanagerasdf",
+				JsonData: func() *simplejson.Json {
+					r := simplejson.New()
+					r.Set("implementation", "mimir")
+					return r
+				}(),
+			},
+			expectedURL: "https://localhost:9000/path/to/alertmanagerasdf/alertmanager",
+		},
+		{
+			name: "add /alertmanager to path when exists but is not last segment",
+			ds: &datasources.DataSource{
+				URL: "https://localhost:9000/alertmanager/path/to/am",
+				JsonData: func() *simplejson.Json {
+					r := simplejson.New()
+					r.Set("implementation", "mimir")
+					return r
+				}(),
+			},
+			expectedURL: "https://localhost:9000/alertmanager/path/to/am/alertmanager",
+		},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {


### PR DESCRIPTION
**What is this feature?**

When sending alerts, we need to add `/alertmanager` to URLs if it's a mimir/cortex target.

However, we saw several cases where users manually added this already. Fix this logic to handle this edge case, we now only add the segment if it's not already present.

**Which issue(s) does this PR fix?**:

n/a

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle.
- [x] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
