### PR TITLE
K8s: Use tracing handler from component-base

### DIFF
--- a/pkg/apiserver/builder/helper.go
+++ b/pkg/apiserver/builder/helper.go
@@ -19,6 +19,7 @@ import (
 	genericapiserver "k8s.io/apiserver/pkg/server"
 	"k8s.io/apiserver/pkg/util/openapi"
 	k8sscheme "k8s.io/client-go/kubernetes/scheme"
+	k8stracing "k8s.io/component-base/tracing"
 	"k8s.io/kube-openapi/pkg/common"
 
 	"github.com/grafana/grafana/pkg/apiserver/endpoints/filters"
@@ -75,6 +76,7 @@ func SetupConfig(
 
 		handler := genericapiserver.DefaultBuildHandlerChain(requestHandler, c)
 		handler = filters.WithAcceptHeader(handler)
+		handler = k8stracing.WithTracing(handler, serverConfig.TracerProvider, "grafana-apiserver")
 
 		return handler
 	}

--- a/pkg/services/apiserver/standalone/options/tracing.go
+++ b/pkg/services/apiserver/standalone/options/tracing.go
@@ -72,9 +72,12 @@ func (o *TracingOptions) Validate() []error {
 }
 
 func (o *TracingOptions) ApplyTo(config *genericapiserver.RecommendedConfig) error {
-	utilfeature.DefaultMutableFeatureGate.SetFromMap(map[string]bool{
+	if err := utilfeature.DefaultMutableFeatureGate.SetFromMap(map[string]bool{
 		string(genericfeatures.APIServerTracing): false,
-	})
+	}); err != nil {
+		return err
+	}
+
 	tracingCfg := tracing.NewEmptyTracingConfig()
 	var err error
 

--- a/pkg/services/apiserver/standalone/options/tracing.go
+++ b/pkg/services/apiserver/standalone/options/tracing.go
@@ -11,7 +11,10 @@ import (
 	"github.com/grafana/grafana/pkg/setting"
 	"github.com/spf13/pflag"
 	"go.opentelemetry.io/otel/attribute"
+	genericfeatures "k8s.io/apiserver/pkg/features"
 	genericapiserver "k8s.io/apiserver/pkg/server"
+	utilfeature "k8s.io/apiserver/pkg/util/feature"
+	k8stracing "k8s.io/component-base/tracing"
 )
 
 type TracingOptions struct {
@@ -69,6 +72,9 @@ func (o *TracingOptions) Validate() []error {
 }
 
 func (o *TracingOptions) ApplyTo(config *genericapiserver.RecommendedConfig) error {
+	utilfeature.DefaultMutableFeatureGate.SetFromMap(map[string]bool{
+		string(genericfeatures.APIServerTracing): false,
+	})
 	tracingCfg := tracing.NewEmptyTracingConfig()
 	var err error
 
@@ -102,6 +108,10 @@ func (o *TracingOptions) ApplyTo(config *genericapiserver.RecommendedConfig) err
 
 	o.TracingService = ts
 	config.TracerProvider = ts.GetTracerProvider()
+
+	if config.LoopbackClientConfig != nil {
+		config.LoopbackClientConfig.Wrap(k8stracing.WrapperFor(config.TracerProvider))
+	}
 
 	config.AddPostStartHookOrDie("grafana-tracing-service", func(hookCtx genericapiserver.PostStartHookContext) error {
 		ctx, cancel := context.WithCancel(context.Background())


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

## What is this feature?

This uses [WithTracing from component-base](https://github.com/kubernetes/component-base/blob/9d90bf7eaa57df6d6e0dd316529274b3c5747f5f/tracing/utils.go#L94) instead of the [WithTracing used by default](https://github.com/kubernetes/kubernetes/blob/6673e7a93d8f0e81343309350e3ec7e7afc7fd73/staging/src/k8s.io/apiserver/pkg/endpoints/filters/traces.go#L33) in `k8s.io/apiserver`.

## Why do we need this feature?

The primary difference is the removal of [otelhttp.WithPublicEndpoint()](https://pkg.go.dev/go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp#WithPublicEndpoint) by using `tracing.WithTracing` from `k8s.io/component-base`:

> WithPublicEndpoint configures the Handler to link the span with an incoming span context. If this option is not provided, then the association is a child association instead of a link.

### Before (linked traces using WithPublicEndpoint)
<img width="740" alt="image" src="https://github.com/grafana/grafana/assets/360020/2b66093e-58ed-4fc1-8c21-d8e4f3952ac7">

<img width="722" alt="image" src="https://github.com/grafana/grafana/assets/360020/fbf435c8-b371-481d-aac6-90c11a54921f">
</details>

### After (parent/child)
<img width="735" alt="image" src="https://github.com/grafana/grafana/assets/360020/8e22adc3-2f9a-4fd6-99af-ea7596b6ba05">


**Who is this feature for?**

[Add information on what kind of user the feature is for.]

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
