### PR TITLE
Table Panel: Update background colors to respect transparency

### DIFF
--- a/packages/grafana-ui/src/components/Table/DefaultCell.tsx
+++ b/packages/grafana-ui/src/components/Table/DefaultCell.tsx
@@ -117,17 +117,21 @@ function getCellStyle(
   // Setup color variables
   let textColor: string | undefined = undefined;
   let bgColor: string | undefined = undefined;
+  let bgHoverColor: string | undefined = undefined;
+
 
   // Get colors
   const colors = getCellColors(tableStyles, cellOptions, displayValue);
   textColor = colors.textColor;
   bgColor = colors.bgColor;
+  bgHoverColor = colors.bgHoverColor;
 
   // If we have definied colors return those styles
   // Otherwise we return default styles
   return tableStyles.buildCellContainerStyle(
     textColor,
     bgColor,
+    bgHoverColor,
     !disableOverflowOnHover,
     isStringValue,
     shouldWrapText,

--- a/packages/grafana-ui/src/components/Table/DefaultCell.tsx
+++ b/packages/grafana-ui/src/components/Table/DefaultCell.tsx
@@ -119,7 +119,6 @@ function getCellStyle(
   let bgColor: string | undefined = undefined;
   let bgHoverColor: string | undefined = undefined;
 
-
   // Get colors
   const colors = getCellColors(tableStyles, cellOptions, displayValue);
   textColor = colors.textColor;

--- a/packages/grafana-ui/src/components/Table/styles.ts
+++ b/packages/grafana-ui/src/components/Table/styles.ts
@@ -14,6 +14,7 @@ export function useTableStyles(theme: GrafanaTheme2, cellHeightOption: TableCell
   const buildCellContainerStyle = (
     color?: string,
     background?: string,
+    backgroundHover?: string,
     overflowOnHover?: boolean,
     asCellText?: boolean,
     textShouldWrap?: boolean,
@@ -30,11 +31,11 @@ export function useTableStyles(theme: GrafanaTheme2, cellHeightOption: TableCell
 
       ...(asCellText
         ? {
-            overflow: 'hidden',
-            textOverflow: 'ellipsis',
-            userSelect: 'text',
-            whiteSpace: 'nowrap',
-          }
+          overflow: 'hidden',
+          textOverflow: 'ellipsis',
+          userSelect: 'text',
+          whiteSpace: 'nowrap',
+        }
         : {}),
 
       alignItems: 'center',
@@ -56,7 +57,7 @@ export function useTableStyles(theme: GrafanaTheme2, cellHeightOption: TableCell
         wordBreak: textShouldWrap ? 'break-word' : undefined,
         whiteSpace: textShouldWrap && overflowOnHover ? 'normal' : 'nowrap',
         boxShadow: overflowOnHover ? `0 0 2px ${theme.colors.primary.main}` : undefined,
-        background: rowStyled ? 'inherit' : background ?? theme.colors.background.primary,
+        background: rowStyled ? 'inherit' : backgroundHover ?? theme.colors.background.primary,
         zIndex: 1,
         '.cellActions': {
           color: '#FFF',
@@ -165,11 +166,11 @@ export function useTableStyles(theme: GrafanaTheme2, cellHeightOption: TableCell
         color: theme.colors.text.link,
       },
     }),
-    cellContainerText: buildCellContainerStyle(undefined, undefined, true, true),
-    cellContainerTextNoOverflow: buildCellContainerStyle(undefined, undefined, false, true),
+    cellContainerText: buildCellContainerStyle(undefined, undefined, undefined, true, true),
+    cellContainerTextNoOverflow: buildCellContainerStyle(undefined, undefined, undefined, false, true),
 
-    cellContainer: buildCellContainerStyle(undefined, undefined, true, false),
-    cellContainerNoOverflow: buildCellContainerStyle(undefined, undefined, false, false),
+    cellContainer: buildCellContainerStyle(undefined, undefined, undefined, true, false),
+    cellContainerNoOverflow: buildCellContainerStyle(undefined, undefined, undefined, false, false),
     cellText: css({
       overflow: 'hidden',
       textOverflow: 'ellipsis',

--- a/packages/grafana-ui/src/components/Table/styles.ts
+++ b/packages/grafana-ui/src/components/Table/styles.ts
@@ -31,11 +31,11 @@ export function useTableStyles(theme: GrafanaTheme2, cellHeightOption: TableCell
 
       ...(asCellText
         ? {
-          overflow: 'hidden',
-          textOverflow: 'ellipsis',
-          userSelect: 'text',
-          whiteSpace: 'nowrap',
-        }
+            overflow: 'hidden',
+            textOverflow: 'ellipsis',
+            userSelect: 'text',
+            whiteSpace: 'nowrap',
+          }
         : {}),
 
       alignItems: 'center',

--- a/packages/grafana-ui/src/components/Table/types.ts
+++ b/packages/grafana-ui/src/components/Table/types.ts
@@ -73,7 +73,7 @@ export interface GrafanaTableState extends TableState {
   lastExpandedOrCollapsedIndex?: number;
 }
 
-export interface GrafanaTableRow extends Row, UseExpandedRowProps<{}> {}
+export interface GrafanaTableRow extends Row, UseExpandedRowProps<{}> { }
 
 export interface Props {
   ariaLabel?: string;
@@ -146,4 +146,5 @@ export type TableFieldOptions = Omit<schema.TableFieldOptions, 'cellOptions'> & 
 export interface CellColors {
   textColor?: string;
   bgColor?: string;
+  bgHoverColor?: string;
 }

--- a/packages/grafana-ui/src/components/Table/types.ts
+++ b/packages/grafana-ui/src/components/Table/types.ts
@@ -73,7 +73,7 @@ export interface GrafanaTableState extends TableState {
   lastExpandedOrCollapsedIndex?: number;
 }
 
-export interface GrafanaTableRow extends Row, UseExpandedRowProps<{}> { }
+export interface GrafanaTableRow extends Row, UseExpandedRowProps<{}> {}
 
 export interface Props {
   ariaLabel?: string;

--- a/packages/grafana-ui/src/components/Table/utils.ts
+++ b/packages/grafana-ui/src/components/Table/utils.ts
@@ -609,6 +609,7 @@ export function getCellColors(
   // Setup color variables
   let textColor: string | undefined = undefined;
   let bgColor: string | undefined = undefined;
+  let bgHoverColor: string | undefined = undefined;
 
   if (cellOptions.type === TableCellDisplayMode.ColorText) {
     textColor = displayValue.color;
@@ -617,15 +618,18 @@ export function getCellColors(
 
     if (mode === TableCellBackgroundDisplayMode.Basic) {
       textColor = getTextColorForAlphaBackground(displayValue.color!, tableStyles.theme.isDark);
-      bgColor = tinycolor(displayValue.color).setAlpha(0.9).toRgbString();
+      bgColor = tinycolor(displayValue.color).toRgbString();
+      bgHoverColor = tinycolor(displayValue.color).setAlpha(1).toRgbString();
     } else if (mode === TableCellBackgroundDisplayMode.Gradient) {
+      const hoverColor = tinycolor(displayValue.color).setAlpha(1).toRgbString();
       const bgColor2 = tinycolor(displayValue.color)
         .darken(10 * darkeningFactor)
         .spin(5);
       textColor = getTextColorForAlphaBackground(displayValue.color!, tableStyles.theme.isDark);
       bgColor = `linear-gradient(120deg, ${bgColor2.toRgbString()}, ${displayValue.color})`;
+      bgHoverColor = `linear-gradient(120deg, ${bgColor2.setAlpha(1).toRgbString()}, ${hoverColor})`;
     }
   }
 
-  return { textColor, bgColor };
+  return { textColor, bgColor, bgHoverColor };
 }


### PR DESCRIPTION
This PR implements a fix in the table panel where configured colors will not show any transparency. This causes an issue for tables using multiple shades of the same color (through opacity) to end up having the same display. 

This was a result of setting the alpha channel on configured colors to 1 (fully opaque) so that the display will be correctly when hovering over a table cell. The fix for this is to add an additional color for table cells. In this case it removes the alpha channel on hover.

A video of this fix in action:


https://github.com/grafana/grafana/assets/199847/36ab6803-6855-4593-ad48-6695296805a8





**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
