### PR TITLE
Transformations: Update transformation disabled UI presentation

### DIFF
--- a/public/app/features/dashboard/components/TransformationsEditor/TransformationPickerNg.tsx
+++ b/public/app/features/dashboard/components/TransformationsEditor/TransformationPickerNg.tsx
@@ -265,7 +265,7 @@ function getTransformationGridStyles(theme: GrafanaTheme2) {
       color: `${theme.colors.text.disabled} !important`,
       'img': {
         filter: 'grayscale(100%)',
-        opacity: 0.1,
+        opacity: 0.33,
       },
     }),
     cardApplicableInfo: css({

--- a/public/app/features/dashboard/components/TransformationsEditor/TransformationPickerNg.tsx
+++ b/public/app/features/dashboard/components/TransformationsEditor/TransformationPickerNg.tsx
@@ -263,7 +263,7 @@ function getTransformationGridStyles(theme: GrafanaTheme2) {
     cardDisabled: css({
       backgroundColor: 'rgb(204, 204, 220, 0.045)',
       color: `${theme.colors.text.disabled} !important`,
-      'img': {
+      img: {
         filter: 'grayscale(100%)',
         opacity: 0.1,
       },

--- a/public/app/features/dashboard/components/TransformationsEditor/TransformationPickerNg.tsx
+++ b/public/app/features/dashboard/components/TransformationsEditor/TransformationPickerNg.tsx
@@ -263,6 +263,10 @@ function getTransformationGridStyles(theme: GrafanaTheme2) {
     cardDisabled: css({
       backgroundColor: 'rgb(204, 204, 220, 0.045)',
       color: `${theme.colors.text.disabled} !important`,
+      'img': {
+        filter: 'grayscale(100%)',
+        opacity: 0.1,
+      },
     }),
     cardApplicableInfo: css({
       position: 'absolute',
@@ -279,13 +283,7 @@ function getTransformationGridStyles(theme: GrafanaTheme2) {
 }
 
 const getImagePath = (id: string, disabled: boolean) => {
-  let folder = null;
-  if (!disabled) {
-    folder = config.theme2.isDark ? 'dark' : 'light';
-  } else {
-    folder = 'disabled';
-  }
-
+  const folder = config.theme2.isDark ? 'dark' : 'light';
   return `public/img/transformations/${folder}/${id}.svg`;
 };
 


### PR DESCRIPTION
This PR presents an alternate to #85506 where instead of adding icons for disabled transformations this applies CSS to disable the icons in grayscale.

This in action: 

<img width="313" alt="Screenshot 2024-04-04 at 1 35 22 AM" src="https://github.com/grafana/grafana/assets/199847/0af3aeba-91b6-47ef-888e-350bec9b5aba">

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
