### PR TITLE
Add setup and spies for the dual writer

### DIFF
--- a/pkg/apiserver/rest/spy_client.go
+++ b/pkg/apiserver/rest/spy_client.go
@@ -17,8 +17,6 @@ type StorageSpyClient interface {
 
 	//Counts returns the number of times a certain method was called
 	Counts(string) int
-	// Reset the counter to zero
-	Reset()
 }
 
 type StorageSpy struct {
@@ -42,10 +40,6 @@ func NewStorageSpyClient(s Storage) StorageSpyClient {
 
 func (c *spyStorageClient) Counts(method string) int {
 	return c.spy.counts[method]
-}
-
-func (c *spyStorageClient) Reset() {
-	c.spy.counts = map[string]int{}
 }
 
 //nolint:golint,unused
@@ -97,8 +91,6 @@ type LegacyStorageSpyClient interface {
 
 	//Counts returns the number of times a certain method was called
 	Counts(string) int
-	// Reset the counter to zero
-	Reset()
 }
 
 type LegacyStorageSpy struct {
@@ -123,10 +115,6 @@ func NewLegacyStorageSpyClient(ls LegacyStorage) LegacyStorageSpyClient {
 
 func (c *spyLegacyStorageClient) Counts(method string) int {
 	return c.spy.counts[method]
-}
-
-func (c *spyLegacyStorageClient) Reset() {
-	c.spy.counts = map[string]int{}
 }
 
 func (c *spyLegacyStorageClient) Create(ctx context.Context, obj runtime.Object, valitation rest.ValidateObjectFunc, options *metav1.CreateOptions) (runtime.Object, error) {

--- a/pkg/apiserver/rest/spy_client.go
+++ b/pkg/apiserver/rest/spy_client.go
@@ -1,0 +1,160 @@
+package rest
+
+import (
+	"context"
+
+	metainternalversion "k8s.io/apimachinery/pkg/apis/meta/internalversion"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apiserver/pkg/registry/rest"
+	"k8s.io/klog/v2"
+)
+
+// Unified Storage Spy
+
+type StorageSpyClient interface {
+	Storage
+
+	//Counts returns the number of times a certain method was called
+	Counts(string) int
+	// Reset the counter to zero
+	Reset()
+}
+
+type StorageSpy struct {
+	counts map[string]int
+}
+
+type spyStorageClient struct {
+	Storage
+	spy *StorageSpy
+}
+
+func (s *StorageSpy) record(seen string) {
+	s.counts[seen]++
+}
+
+func NewStorageSpyClient(s Storage) StorageSpyClient {
+	return &spyStorageClient{s, &StorageSpy{
+		counts: map[string]int{},
+	}}
+}
+
+func (c *spyStorageClient) Counts(method string) int {
+	return c.spy.counts[method]
+}
+
+func (c *spyStorageClient) Reset() {
+	c.spy.counts = map[string]int{}
+}
+
+//nolint:golint,unused
+type spyStorageShim struct {
+	Storage
+	spy *StorageSpy
+}
+
+//nolint:golint,unused
+type spyLegacyStorageShim struct {
+	LegacyStorage
+	spy *StorageSpy
+}
+
+func (c *spyStorageClient) Create(ctx context.Context, obj runtime.Object, valitation rest.ValidateObjectFunc, options *metav1.CreateOptions) (runtime.Object, error) {
+	c.spy.record("Storage.Create")
+	klog.Info("method: Storage.Create")
+	return nil, nil
+}
+
+func (c *spyStorageClient) Get(ctx context.Context, name string, options *metav1.GetOptions) (runtime.Object, error) {
+	c.spy.record("Storage.Get")
+	klog.Info("method: Storage.Get")
+	return nil, nil
+}
+
+func (c *spyStorageClient) List(ctx context.Context, options *metainternalversion.ListOptions) (runtime.Object, error) {
+	c.spy.record("Storage.List")
+	klog.Info("method: Storage.List")
+	return nil, nil
+}
+
+func (c *spyStorageClient) Update(ctx context.Context, name string, objInfo rest.UpdatedObjectInfo, createValidation rest.ValidateObjectFunc, updateValidation rest.ValidateObjectUpdateFunc, forceAllowCreate bool, options *metav1.UpdateOptions) (runtime.Object, bool, error) {
+	c.spy.record("Storage.Update")
+	klog.Info("method: Storage.Update")
+	return nil, false, nil
+}
+
+func (c *spyStorageClient) Delete(ctx context.Context, name string, deleteValidation rest.ValidateObjectFunc, options *metav1.DeleteOptions) (runtime.Object, bool, error) {
+	c.spy.record("Storage.Delete")
+	klog.Info("method: Storage.Delete")
+	return nil, false, nil
+}
+
+// LegacyStorage Spy
+
+type LegacyStorageSpyClient interface {
+	LegacyStorage
+
+	//Counts returns the number of times a certain method was called
+	Counts(string) int
+	// Reset the counter to zero
+	Reset()
+}
+
+type LegacyStorageSpy struct {
+	counts map[string]int //nolint:golint,unused
+}
+
+type spyLegacyStorageClient struct {
+	LegacyStorage
+	spy *StorageSpy
+}
+
+//nolint:golint,unused
+func (s *LegacyStorageSpy) record(seen string) {
+	s.counts[seen]++
+}
+
+func NewLegacyStorageSpyClient(ls LegacyStorage) LegacyStorageSpyClient {
+	return &spyLegacyStorageClient{ls, &StorageSpy{
+		counts: map[string]int{},
+	}}
+}
+
+func (c *spyLegacyStorageClient) Counts(method string) int {
+	return c.spy.counts[method]
+}
+
+func (c *spyLegacyStorageClient) Reset() {
+	c.spy.counts = map[string]int{}
+}
+
+func (c *spyLegacyStorageClient) Create(ctx context.Context, obj runtime.Object, valitation rest.ValidateObjectFunc, options *metav1.CreateOptions) (runtime.Object, error) {
+	c.spy.record("LegacyStorage.Create")
+	klog.Info("method: LegacyStorage.Create")
+	return nil, nil
+}
+
+func (c *spyLegacyStorageClient) Get(ctx context.Context, name string, options *metav1.GetOptions) (runtime.Object, error) {
+	c.spy.record("LegacyStorage.Get")
+	klog.Info("method: LegacyStorage.Get")
+	return nil, nil
+}
+
+func (c *spyLegacyStorageClient) List(ctx context.Context, options *metainternalversion.ListOptions) (runtime.Object, error) {
+	c.spy.record("LegacyStorage.List")
+	klog.Info("method: LegacyStorage.List")
+	return nil, nil
+}
+
+func (c *spyLegacyStorageClient) Update(ctx context.Context, name string, objInfo rest.UpdatedObjectInfo, createValidation rest.ValidateObjectFunc, updateValidation rest.ValidateObjectUpdateFunc, forceAllowCreate bool, options *metav1.UpdateOptions) (runtime.Object, bool, error) {
+	c.spy.record("LegacyStorage.Update")
+	klog.Info("method: LegacyStorage.Update")
+	return nil, false, nil
+}
+
+func (c *spyLegacyStorageClient) Delete(ctx context.Context, name string, deleteValidation rest.ValidateObjectFunc, options *metav1.DeleteOptions) (runtime.Object, bool, error) {
+	c.spy.record("LegacyStorage.Delete")
+	klog.Info("method: LegacyStorage.Delete")
+	return nil, false, nil
+}


### PR DESCRIPTION
**What is this feature?**

This PR adds support for the dual writer implementation for the different write modes. Those modes are:
- Mode 1: read and write to Legacy Store
- Mode 2: read from Legacy Store, but write to both Unified Storage and Legacy Store
- Mode 3: read from Unified Store, but write to both Unified Storage and Legacy Store
- Mode 4: read and write to Unified Storage

Note: We are making a conscious decision of abstracting the storage layer from the dual writer layer. Therefore the usage of spies is necessary here as what we want to test is which method has been called on which case.
Tests writing and reading from each storage can already be found on the storage package.

**Which issue(s) does this PR fix?**:
Part of https://github.com/grafana/search-and-storage-team/issues/17

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle.
- [x] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
