### PR TITLE
Angular deprecation: Prefer local "angularDetected" value to the remote one

### DIFF
--- a/public/app/features/plugins/admin/__mocks__/localPlugin.mock.ts
+++ b/public/app/features/plugins/admin/__mocks__/localPlugin.mock.ts
@@ -68,4 +68,5 @@ export default {
   signature: 'valid',
   signatureType: 'community',
   signatureOrg: 'Alexander Zobnin',
+  angularDetected: false,
 } as LocalPlugin;

--- a/public/app/features/plugins/admin/__mocks__/remotePlugin.mock.ts
+++ b/public/app/features/plugins/admin/__mocks__/remotePlugin.mock.ts
@@ -47,4 +47,5 @@ export default {
       links: [],
     },
   },
+  angularDetected: false,
 } as RemotePlugin;

--- a/public/app/features/plugins/admin/helpers.test.ts
+++ b/public/app/features/plugins/admin/helpers.test.ts
@@ -182,6 +182,7 @@ describe('Plugins/Helpers', () => {
         type: 'app',
         updatedAt: '2021-05-18T14:53:01.000Z',
         isFullyInstalled: false,
+        angularDetected: false,
       });
     });
 
@@ -261,6 +262,7 @@ describe('Plugins/Helpers', () => {
         updatedAt: '2021-08-25',
         installedVersion: '4.2.2',
         isFullyInstalled: true,
+        angularDetected: false,
       });
     });
 
@@ -312,6 +314,7 @@ describe('Plugins/Helpers', () => {
         updatedAt: '2021-05-18T14:53:01.000Z',
         installedVersion: '4.2.2',
         isFullyInstalled: true,
+        angularDetected: false,
       });
     });
 
@@ -693,6 +696,35 @@ describe('Plugins/Helpers', () => {
 
       // No local or remote
       expect(mapToCatalogPlugin()).toMatchObject({ updatedAt: '' });
+    });
+
+    test('`.angularDetected` - prefers the local', () => {
+      // Both false shoul return false
+      expect(
+        mapToCatalogPlugin({ ...localPlugin, angularDetected: false }, { ...remotePlugin, angularDetected: false })
+      ).toMatchObject({ angularDetected: false });
+
+      // Remote version is using angular, local isn't, should prefer local
+      expect(
+        mapToCatalogPlugin({ ...localPlugin, angularDetected: false }, { ...remotePlugin, angularDetected: true })
+      ).toMatchObject({ angularDetected: false });
+
+      // Remote only
+      expect(mapToCatalogPlugin(undefined, remotePlugin)).toMatchObject({ angularDetected: false });
+      expect(mapToCatalogPlugin(undefined, { ...remotePlugin, angularDetected: true })).toMatchObject({
+        angularDetected: true,
+      });
+
+      // Local only
+      expect(mapToCatalogPlugin({ ...localPlugin, angularDetected: false }, undefined)).toMatchObject({
+        angularDetected: false,
+      });
+      expect(mapToCatalogPlugin({ ...localPlugin, angularDetected: true }, undefined)).toMatchObject({
+        angularDetected: true,
+      });
+
+      // No local or remote
+      expect(mapToCatalogPlugin()).toMatchObject({ angularDetected: undefined });
     });
   });
 

--- a/public/app/features/plugins/admin/helpers.ts
+++ b/public/app/features/plugins/admin/helpers.ts
@@ -249,7 +249,7 @@ export function mapToCatalogPlugin(local?: LocalPlugin, remote?: RemotePlugin, e
     error: error?.errorCode,
     // Only local plugins have access control metadata
     accessControl: local?.accessControl,
-    angularDetected: local?.angularDetected || remote?.angularDetected,
+    angularDetected: local?.angularDetected ?? remote?.angularDetected,
     isFullyInstalled: Boolean(local) || isDisabled,
     iam: local?.iam,
   };


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

Ensures that, in the catalog, Grafana prefers the local `angularDetected` value (provided by the Grafana backend, so the value for the plugin that's actually installed) to the remote one (provided by GCOM, so the value for the latest version published in the catalog).

This fixes an issue where the angular badge and warning are displayed in the catalog pages when testing an unpublished plugin that has stopped using Angular, but whose latest published version in GCOM is marked as `angularDetected = true`.

Before this PR, in such scenario Grafana used to prefer the value in GCOM (`angularDetected = true`) to the one for the new unpublished version (`angularDetected = false`).

This new behaviour introduced in the PR is more clear, especially for plugin developers who are testing a WIP/unpublished plugin update that migrated the plugin from Angular to React.

**Why do we need this feature?**

Solves confusion for plugin developers migrating Angular plugins to React.

**Who is this feature for?**

Plugin developers, but all Grafana users in general as well, because this behaviour makes more sense.

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle.
- [x] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
