### PR TITLE
Chore: Remove individual `whatwg-fetch` imports in favour of `setupTests`

### DIFF
--- a/packages/grafana-prometheus/src/metric_find_query.test.ts
+++ b/packages/grafana-prometheus/src/metric_find_query.test.ts
@@ -1,7 +1,6 @@
 // Core Grafana history https://github.com/grafana/grafana/blob/v11.0.0-preview/public/app/plugins/datasource/prometheus/metric_find_query.test.ts
 import { Observable, of } from 'rxjs';
 
-import 'whatwg-fetch'; // fetch polyfill needed backendSrv
 import { DataSourceInstanceSettings, TimeRange, toUtc } from '@grafana/data';
 import { BackendDataSourceResponse, BackendSrvRequest, FetchResponse, TemplateSrv } from '@grafana/runtime';
 

--- a/public/app/core/components/NestedFolderPicker/NestedFolderPicker.test.tsx
+++ b/public/app/core/components/NestedFolderPicker/NestedFolderPicker.test.tsx
@@ -1,4 +1,3 @@
-import 'whatwg-fetch'; // fetch polyfill
 import { fireEvent, render as rtlRender, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { HttpResponse, http } from 'msw';

--- a/public/app/core/services/__mocks__/backend_srv.ts
+++ b/public/app/core/services/__mocks__/backend_srv.ts
@@ -1,5 +1,3 @@
-import 'whatwg-fetch'; // fetch polyfill needed for Headers
-
 import { of } from 'rxjs';
 
 import { BackendSrvRequest, FetchResponse } from '@grafana/runtime';

--- a/public/app/core/specs/backend_srv.test.ts
+++ b/public/app/core/specs/backend_srv.test.ts
@@ -1,4 +1,3 @@
-import 'whatwg-fetch'; // fetch polyfill needed for PhantomJs rendering
 import { Observable, of, lastValueFrom } from 'rxjs';
 import { fromFetch } from 'rxjs/fetch';
 import { delay } from 'rxjs/operators';

--- a/public/app/core/utils/fetch.test.ts
+++ b/public/app/core/utils/fetch.test.ts
@@ -1,4 +1,3 @@
-import 'whatwg-fetch'; // fetch polyfill needed for PhantomJs rendering
 import {
   isContentTypeApplicationJson,
   parseBody,

--- a/public/app/features/alerting/unified/CloneRuleEditor.test.tsx
+++ b/public/app/features/alerting/unified/CloneRuleEditor.test.tsx
@@ -1,4 +1,3 @@
-import 'whatwg-fetch';
 import { render, waitFor, waitForElementToBeRemoved, within } from '@testing-library/react';
 import { setupServer } from 'msw/node';
 import React from 'react';

--- a/public/app/features/alerting/unified/RuleEditorGrafanaRules.test.tsx
+++ b/public/app/features/alerting/unified/RuleEditorGrafanaRules.test.tsx
@@ -1,4 +1,3 @@
-import 'whatwg-fetch';
 import { screen, waitFor, waitForElementToBeRemoved, within } from '@testing-library/react';
 import userEvent, { PointerEventsCheckLevel } from '@testing-library/user-event';
 import React from 'react';

--- a/public/app/features/alerting/unified/RuleEditorRecordingRule.test.tsx
+++ b/public/app/features/alerting/unified/RuleEditorRecordingRule.test.tsx
@@ -1,4 +1,3 @@
-import 'whatwg-fetch';
 import { screen, waitFor, waitForElementToBeRemoved, within } from '@testing-library/react';
 import userEvent, { PointerEventsCheckLevel } from '@testing-library/user-event';
 import React from 'react';

--- a/public/app/features/alerting/unified/components/GrafanaAlertmanagerDeliveryWarning.test.tsx
+++ b/public/app/features/alerting/unified/components/GrafanaAlertmanagerDeliveryWarning.test.tsx
@@ -1,4 +1,3 @@
-import 'whatwg-fetch';
 import { render, screen, waitFor } from '@testing-library/react';
 import { setupServer } from 'msw/node';
 import React from 'react';

--- a/public/app/features/alerting/unified/components/PluginBridge.mock.ts
+++ b/public/app/features/alerting/unified/components/PluginBridge.mock.ts
@@ -1,5 +1,3 @@
-// bit of setup to mock HTTP request responses
-import 'whatwg-fetch';
 import { http, HttpResponse } from 'msw';
 import { setupServer } from 'msw/node';
 

--- a/public/app/features/alerting/unified/components/contact-points/__mocks__/grafanaManagedServer.ts
+++ b/public/app/features/alerting/unified/components/contact-points/__mocks__/grafanaManagedServer.ts
@@ -1,4 +1,3 @@
-import 'whatwg-fetch';
 import { http, HttpResponse } from 'msw';
 import { SetupServer } from 'msw/node';
 

--- a/public/app/features/alerting/unified/components/contact-points/__mocks__/mimirFlavoredServer.ts
+++ b/public/app/features/alerting/unified/components/contact-points/__mocks__/mimirFlavoredServer.ts
@@ -1,4 +1,3 @@
-import 'whatwg-fetch';
 import { http, HttpResponse } from 'msw';
 import { SetupServer } from 'msw/lib/node';
 

--- a/public/app/features/alerting/unified/components/contact-points/__mocks__/vanillaAlertmanagerServer.ts
+++ b/public/app/features/alerting/unified/components/contact-points/__mocks__/vanillaAlertmanagerServer.ts
@@ -1,4 +1,3 @@
-import 'whatwg-fetch';
 import { http, HttpResponse } from 'msw';
 import { SetupServer } from 'msw/lib/node';
 

--- a/public/app/features/alerting/unified/components/receivers/PayloadEditor.test.tsx
+++ b/public/app/features/alerting/unified/components/receivers/PayloadEditor.test.tsx
@@ -6,8 +6,6 @@ import { TestProvider } from 'test/helpers/TestProvider';
 
 import { PayloadEditor, RESET_TO_DEFAULT } from './PayloadEditor';
 
-import 'whatwg-fetch';
-
 const DEFAULT_PAYLOAD = `[
   {
     "annotations": {

--- a/public/app/features/alerting/unified/components/receivers/TemplatePreview.test.tsx
+++ b/public/app/features/alerting/unified/components/receivers/TemplatePreview.test.tsx
@@ -10,7 +10,6 @@ import { setBackendSrv } from '@grafana/runtime';
 import { backendSrv } from 'app/core/services/backend_srv';
 import { configureStore } from 'app/store/configureStore';
 
-import 'whatwg-fetch';
 import { TemplatePreviewResponse } from '../../api/templateApi';
 import {
   mockPreviewTemplateResponse,

--- a/public/app/features/alerting/unified/components/rule-editor/AnnotationsStep.test.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/AnnotationsStep.test.tsx
@@ -17,8 +17,6 @@ import { RuleFormValues } from '../../types/rule-form';
 import { Annotation } from '../../utils/constants';
 import { getDefaultFormValues } from '../../utils/rule-form';
 
-import 'whatwg-fetch';
-
 import AnnotationsStep from './AnnotationsStep';
 
 // To get anything displayed inside the Autosize component we need to mock it

--- a/public/app/features/alerting/unified/components/rule-editor/alert-rule-form/simplifiedRouting/SimplifiedRuleEditor.test.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/alert-rule-form/simplifiedRouting/SimplifiedRuleEditor.test.tsx
@@ -1,4 +1,3 @@
-import 'whatwg-fetch';
 import { render, screen, waitFor, waitForElementToBeRemoved } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import React from 'react';

--- a/public/app/features/alerting/unified/components/rule-viewer/__mocks__/server.ts
+++ b/public/app/features/alerting/unified/components/rule-viewer/__mocks__/server.ts
@@ -1,4 +1,3 @@
-import 'whatwg-fetch';
 import { http, HttpResponse } from 'msw';
 import { SetupServer, setupServer } from 'msw/node';
 

--- a/public/app/features/alerting/unified/components/rules/RuleDetails.test.tsx
+++ b/public/app/features/alerting/unified/components/rules/RuleDetails.test.tsx
@@ -1,4 +1,3 @@
-import 'whatwg-fetch';
 import { render, screen, waitFor } from '@testing-library/react';
 import { http, HttpResponse } from 'msw';
 import { setupServer } from 'msw/node';

--- a/public/app/features/alerting/unified/components/rules/RulesFilter.test.tsx
+++ b/public/app/features/alerting/unified/components/rules/RulesFilter.test.tsx
@@ -1,4 +1,3 @@
-import 'whatwg-fetch';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import React from 'react';

--- a/public/app/features/alerting/unified/components/rules/state-history/LokiStateHistory.test.tsx
+++ b/public/app/features/alerting/unified/components/rules/state-history/LokiStateHistory.test.tsx
@@ -1,4 +1,3 @@
-import 'whatwg-fetch';
 import { render, waitFor } from '@testing-library/react';
 import { http, HttpResponse } from 'msw';
 import { setupServer } from 'msw/node';

--- a/public/app/features/alerting/unified/hooks/useAbilities.test.tsx
+++ b/public/app/features/alerting/unified/hooks/useAbilities.test.tsx
@@ -1,4 +1,3 @@
-import 'whatwg-fetch';
 import { renderHook, waitFor } from '@testing-library/react';
 import { createBrowserHistory } from 'history';
 import React, { PropsWithChildren } from 'react';

--- a/public/app/features/alerting/unified/hooks/useExternalAMSelector.test.tsx
+++ b/public/app/features/alerting/unified/hooks/useExternalAMSelector.test.tsx
@@ -1,4 +1,3 @@
-import 'whatwg-fetch';
 import { renderHook, waitFor } from '@testing-library/react';
 import { http, HttpResponse } from 'msw';
 import { SetupServer, setupServer } from 'msw/node';

--- a/public/app/features/alerting/unified/mockApi.ts
+++ b/public/app/features/alerting/unified/mockApi.ts
@@ -1,4 +1,3 @@
-import 'whatwg-fetch';
 import { uniqueId } from 'lodash';
 import { http, HttpResponse } from 'msw';
 import { setupServer, SetupServer } from 'msw/node';

--- a/public/app/features/alerting/unified/mocks/alertRuleApi.ts
+++ b/public/app/features/alerting/unified/mocks/alertRuleApi.ts
@@ -1,4 +1,3 @@
-import 'whatwg-fetch';
 import { http, HttpResponse } from 'msw';
 import { SetupServer } from 'msw/node';
 

--- a/public/app/features/alerting/unified/mocks/alertmanagerApi.ts
+++ b/public/app/features/alerting/unified/mocks/alertmanagerApi.ts
@@ -1,4 +1,3 @@
-import 'whatwg-fetch';
 import { http, HttpResponse } from 'msw';
 import { SetupServer } from 'msw/node';
 

--- a/public/app/features/alerting/unified/mocks/plugins.ts
+++ b/public/app/features/alerting/unified/mocks/plugins.ts
@@ -1,4 +1,3 @@
-import 'whatwg-fetch';
 import { http, HttpResponse } from 'msw';
 import { SetupServer } from 'msw/lib/node';
 

--- a/public/app/features/alerting/unified/mocks/rulerApi.ts
+++ b/public/app/features/alerting/unified/mocks/rulerApi.ts
@@ -1,4 +1,3 @@
-import 'whatwg-fetch';
 import { http, HttpResponse } from 'msw';
 import { SetupServer } from 'msw/node';
 

--- a/public/app/features/alerting/unified/mocks/templatesApi.ts
+++ b/public/app/features/alerting/unified/mocks/templatesApi.ts
@@ -1,4 +1,3 @@
-import 'whatwg-fetch';
 import { http, HttpResponse } from 'msw';
 import { SetupServer } from 'msw/node';
 

--- a/public/app/features/browse-dashboards/BrowseDashboardsPage.test.tsx
+++ b/public/app/features/browse-dashboards/BrowseDashboardsPage.test.tsx
@@ -1,4 +1,3 @@
-import 'whatwg-fetch';
 import { render as rtlRender, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { HttpResponse, http } from 'msw';

--- a/public/app/features/browse-dashboards/BrowseFolderAlertingPage.test.tsx
+++ b/public/app/features/browse-dashboards/BrowseFolderAlertingPage.test.tsx
@@ -1,4 +1,3 @@
-import 'whatwg-fetch';
 import { render as rtlRender, screen } from '@testing-library/react';
 import { http, HttpResponse } from 'msw';
 import { SetupServer, setupServer } from 'msw/node';

--- a/public/app/features/browse-dashboards/BrowseFolderLibraryPanelsPage.test.tsx
+++ b/public/app/features/browse-dashboards/BrowseFolderLibraryPanelsPage.test.tsx
@@ -1,4 +1,3 @@
-import 'whatwg-fetch';
 import { render as rtlRender, screen } from '@testing-library/react';
 import { http, HttpResponse } from 'msw';
 import { SetupServer, setupServer } from 'msw/node';

--- a/public/app/features/dashboard-scene/panel-edit/PanelDataPane/PanelDataAlertingTab.test.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelDataPane/PanelDataAlertingTab.test.tsx
@@ -1,4 +1,3 @@
-import 'whatwg-fetch';
 import { act, render } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import React from 'react';

--- a/public/app/features/dashboard-scene/scene/LibraryVizPanel.test.ts
+++ b/public/app/features/dashboard-scene/scene/LibraryVizPanel.test.ts
@@ -1,4 +1,3 @@
-import 'whatwg-fetch';
 import { waitFor } from '@testing-library/dom';
 import { merge } from 'lodash';
 import { http, HttpResponse } from 'msw';

--- a/public/app/features/dashboard-scene/serialization/transformSceneToSaveModel.test.ts
+++ b/public/app/features/dashboard-scene/serialization/transformSceneToSaveModel.test.ts
@@ -1,4 +1,3 @@
-import 'whatwg-fetch';
 import { advanceTo } from 'jest-date-mock';
 import { map, of } from 'rxjs';
 

--- a/public/app/features/dashboard/components/ShareModal/SharePublicDashboard/SharePublicDashboard.test.tsx
+++ b/public/app/features/dashboard/components/ShareModal/SharePublicDashboard/SharePublicDashboard.test.tsx
@@ -1,4 +1,3 @@
-import 'whatwg-fetch';
 import { screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { http, HttpResponse } from 'msw';

--- a/public/app/features/dashboard/components/ShareModal/SharePublicDashboard/utilsTest.tsx
+++ b/public/app/features/dashboard/components/ShareModal/SharePublicDashboard/utilsTest.tsx
@@ -1,4 +1,3 @@
-import 'whatwg-fetch';
 import { fireEvent, render, screen, waitFor, waitForElementToBeRemoved } from '@testing-library/react';
 import { http, HttpResponse } from 'msw';
 import React from 'react';

--- a/public/app/features/dashboard/containers/PublicDashboardPageProxy.test.tsx
+++ b/public/app/features/dashboard/containers/PublicDashboardPageProxy.test.tsx
@@ -1,4 +1,3 @@
-import 'whatwg-fetch';
 import { render, screen, waitFor } from '@testing-library/react';
 import React from 'react';
 import { Provider } from 'react-redux';

--- a/public/app/features/explore/extensions/AddToDashboard/index.test.tsx
+++ b/public/app/features/explore/extensions/AddToDashboard/index.test.tsx
@@ -1,4 +1,3 @@
-import 'whatwg-fetch';
 import { act, render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import React, { ReactNode } from 'react';

--- a/public/app/features/manage-dashboards/components/PublicDashboardListTable/PublicDashboardListTable.test.tsx
+++ b/public/app/features/manage-dashboards/components/PublicDashboardListTable/PublicDashboardListTable.test.tsx
@@ -1,4 +1,3 @@
-import 'whatwg-fetch';
 import { render, screen, waitForElementToBeRemoved, within } from '@testing-library/react';
 import { http, HttpResponse } from 'msw';
 import { setupServer } from 'msw/node';

--- a/public/app/features/migrate-to-cloud/onprem/EmptyState/CallToAction/CallToAction.test.tsx
+++ b/public/app/features/migrate-to-cloud/onprem/EmptyState/CallToAction/CallToAction.test.tsx
@@ -1,4 +1,3 @@
-import 'whatwg-fetch'; // fetch polyfill
 import { render as rtlRender, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import React from 'react';

--- a/public/app/features/migrate-to-cloud/onprem/ResourcesTable.test.tsx
+++ b/public/app/features/migrate-to-cloud/onprem/ResourcesTable.test.tsx
@@ -1,4 +1,3 @@
-import 'whatwg-fetch'; // fetch polyfill
 import { render as rtlRender, screen } from '@testing-library/react';
 import React from 'react';
 import { TestProvider } from 'test/helpers/TestProvider';

--- a/public/app/features/playlist/PlaylistEditPage.test.tsx
+++ b/public/app/features/playlist/PlaylistEditPage.test.tsx
@@ -1,4 +1,3 @@
-import 'whatwg-fetch';
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { History, Location } from 'history';

--- a/public/app/features/playlist/PlaylistNewPage.test.tsx
+++ b/public/app/features/playlist/PlaylistNewPage.test.tsx
@@ -1,4 +1,3 @@
-import 'whatwg-fetch';
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import React from 'react';

--- a/public/app/features/plugins/loader/pluginLoader.mock.ts
+++ b/public/app/features/plugins/loader/pluginLoader.mock.ts
@@ -1,4 +1,3 @@
-import 'whatwg-fetch';
 import { http, HttpResponse } from 'msw';
 import { setupServer } from 'msw/node';
 

--- a/public/app/features/plugins/loader/systemjsHooks.test.ts
+++ b/public/app/features/plugins/loader/systemjsHooks.test.ts
@@ -1,6 +1,3 @@
-// mock fetch for SystemJS
-import 'whatwg-fetch';
-
 import { config } from '@grafana/runtime';
 
 jest.mock('./cache', () => ({

--- a/public/test/setupTests.ts
+++ b/public/test/setupTests.ts
@@ -1,3 +1,4 @@
+import 'whatwg-fetch';
 import '@testing-library/jest-dom';
 import { configure } from '@testing-library/react';
 import i18next from 'i18next';


### PR DESCRIPTION
## What is this feature?
Removes `whatwg-fetch` from individual tests in favour of importing once at `setupTests` level

## Why do we need this feature?
For motivation/detailed explanation, please see https://github.com/grafana/grafana/pull/85577