### PR TITLE
Dashboard: Allow `auto` refresh option when saving a dashboard

### DIFF
--- a/pkg/services/dashboards/service/dashboard_service.go
+++ b/pkg/services/dashboards/service/dashboard_service.go
@@ -278,7 +278,7 @@ func validateDashboardRefreshInterval(minRefreshInterval string, dash *dashboard
 	}
 
 	refresh := dash.Data.Get("refresh").MustString("")
-	if refresh == "" {
+	if refresh == "" || refresh == "auto" {
 		// since no refresh is set it is a valid refresh rate
 		return nil
 	}


### PR DESCRIPTION
**What is this feature?**

Allow `auto` as value to `refresh` when saving a dashboard.

**Why do we need this feature?**

To save `auto` as a value for `refresh`?

**Who is this feature for?**

Any user

**Which issue(s) does this PR fix?**:

Fixes #80842

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
