### PR TITLE
E2C: Resources table refactor

### DIFF
--- a/pkg/services/cloudmigration/model.go
+++ b/pkg/services/cloudmigration/model.go
@@ -143,6 +143,7 @@ type Base64HGInstance struct {
 
 // dtos for cms api
 
+// swagger:enum MigrateDataType
 type MigrateDataType string
 
 const (
@@ -162,6 +163,7 @@ type MigrateDataRequestItemDTO struct {
 	Data  interface{}     `json:"data"`
 }
 
+// swagger:enum ItemStatus
 type ItemStatus string
 
 const (
@@ -175,8 +177,11 @@ type MigrateDataResponseDTO struct {
 }
 
 type MigrateDataResponseItemDTO struct {
-	Type   MigrateDataType `json:"type"`
-	RefID  string          `json:"refId"`
-	Status ItemStatus      `json:"status"`
-	Error  string          `json:"error,omitempty"`
+	// required:true
+	Type MigrateDataType `json:"type"`
+	// required:true
+	RefID string `json:"refId"`
+	// required:true
+	Status ItemStatus `json:"status"`
+	Error  string     `json:"error,omitempty"`
 }

--- a/public/api-enterprise-spec.json
+++ b/public/api-enterprise-spec.json
@@ -2776,6 +2776,14 @@
         }
       }
     },
+    "CloudMigrationRequest": {
+      "type": "object",
+      "properties": {
+        "authToken": {
+          "type": "string"
+        }
+      }
+    },
     "CloudMigrationResponse": {
       "type": "object",
       "properties": {
@@ -4539,9 +4547,6 @@
         }
       }
     },
-    "ItemStatus": {
-      "type": "string"
-    },
     "JSONWebKey": {
       "description": "JSONWebKey represents a public or private key in JWK format. It can be\nmarshaled into JSON and unmarshaled from JSON.",
       "type": "object",
@@ -4896,6 +4901,11 @@
     },
     "MigrateDataResponseItemDTO": {
       "type": "object",
+      "required": [
+        "type",
+        "refId",
+        "status"
+      ],
       "properties": {
         "error": {
           "type": "string"
@@ -4904,7 +4914,19 @@
           "type": "string"
         },
         "status": {
-          "$ref": "#/definitions/ItemStatus"
+          "type": "string",
+          "enum": [
+            "OK",
+            "ERROR"
+          ]
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "DASHBOARD",
+            "DATASOURCE",
+            "FOLDER"
+          ]
         }
       }
     },

--- a/public/api-merged.json
+++ b/public/api-merged.json
@@ -15499,9 +15499,6 @@
         }
       }
     },
-    "ItemStatus": {
-      "type": "string"
-    },
     "JSONWebKey": {
       "description": "JSONWebKey represents a public or private key in JWK format. It can be\nmarshaled into JSON and unmarshaled from JSON.",
       "type": "object",

--- a/public/api-merged.json
+++ b/public/api-merged.json
@@ -15954,6 +15954,11 @@
     },
     "MigrateDataResponseItemDTO": {
       "type": "object",
+      "required": [
+        "type",
+        "refId",
+        "status"
+      ],
       "properties": {
         "error": {
           "type": "string"
@@ -15962,15 +15967,21 @@
           "type": "string"
         },
         "status": {
-          "$ref": "#/definitions/ItemStatus"
+          "type": "string",
+          "enum": [
+            "OK",
+            "ERROR"
+          ]
         },
         "type": {
-          "$ref": "#/definitions/MigrateDataType"
+          "type": "string",
+          "enum": [
+            "DASHBOARD",
+            "DATASOURCE",
+            "FOLDER"
+          ]
         }
       }
-    },
-    "MigrateDataType": {
-      "type": "string"
     },
     "MoveFolderCommand": {
       "description": "MoveFolderCommand captures the information required by the folder service\nto move a folder.",

--- a/public/app/features/migrate-to-cloud/api/endpoints.gen.ts
+++ b/public/app/features/migrate-to-cloud/api/endpoints.gen.ts
@@ -93,13 +93,11 @@ export type ErrorResponseBody = {
 export type CloudMigrationRequest = {
   authToken?: string;
 };
-export type ItemStatus = string;
-export type MigrateDataType = string;
 export type MigrateDataResponseItemDto = {
   error?: string;
-  refId?: string;
-  status?: ItemStatus;
-  type?: MigrateDataType;
+  refId: string;
+  status: 'OK' | 'ERROR';
+  type: 'DASHBOARD' | 'DATASOURCE' | 'FOLDER';
 };
 export type MigrateDataResponseDto = {
   id?: number;

--- a/public/app/features/migrate-to-cloud/api/index.ts
+++ b/public/app/features/migrate-to-cloud/api/index.ts
@@ -1,6 +1,5 @@
 export * from './endpoints.gen';
 import { BaseQueryFn, QueryDefinition } from '@reduxjs/toolkit/dist/query';
-import { A } from 'msw/lib/core/HttpResponse-vQNlixkj';
 
 import { generatedAPI } from './endpoints.gen';
 

--- a/public/app/features/migrate-to-cloud/api/index.ts
+++ b/public/app/features/migrate-to-cloud/api/index.ts
@@ -1,4 +1,7 @@
 export * from './endpoints.gen';
+import { BaseQueryFn, QueryDefinition } from '@reduxjs/toolkit/dist/query';
+import { A } from 'msw/lib/core/HttpResponse-vQNlixkj';
+
 import { generatedAPI } from './endpoints.gen';
 
 export const cloudMigrationAPI = generatedAPI.enhanceEndpoints({
@@ -35,5 +38,24 @@ export const cloudMigrationAPI = generatedAPI.enhanceEndpoints({
     runCloudMigration: {
       invalidatesTags: ['cloud-migration-run'],
     },
+
+    getDashboardByUid(endpoint) {
+      suppressErrorsOnQuery(endpoint);
+    },
   },
 });
+
+function suppressErrorsOnQuery<QueryArg, BaseQuery extends BaseQueryFn, TagTypes extends string, ResultType>(
+  endpoint: QueryDefinition<QueryArg, BaseQuery, TagTypes, ResultType>
+) {
+  if (!endpoint.query) {
+    return;
+  }
+
+  const originalQuery = endpoint.query;
+  endpoint.query = (...args) => {
+    const baseQuery = originalQuery(...args);
+    baseQuery.showErrorAlert = false;
+    return baseQuery;
+  };
+}

--- a/public/app/features/migrate-to-cloud/fixtures/migrationItems.ts
+++ b/public/app/features/migrate-to-cloud/fixtures/migrationItems.ts
@@ -1,0 +1,31 @@
+import { Chance } from 'chance';
+
+import { MigrateDataResponseItemDto } from '../api';
+
+export function wellFormedDatasourceMigrationItem(
+  seed = 1,
+  partial: Partial<MigrateDataResponseItemDto> = {}
+): MigrateDataResponseItemDto {
+  const random = Chance(seed);
+
+  return {
+    type: 'DATASOURCE',
+    refId: random.guid(),
+    status: random.pickone(['OK', 'ERROR']),
+    ...partial,
+  };
+}
+
+export function wellFormedDashboardMigrationItem(
+  seed = 1,
+  partial: Partial<MigrateDataResponseItemDto> = {}
+): MigrateDataResponseItemDto {
+  const random = Chance(seed);
+
+  return {
+    type: 'DASHBOARD',
+    refId: random.guid(),
+    status: random.pickone(['OK', 'ERROR']),
+    ...partial,
+  };
+}

--- a/public/app/features/migrate-to-cloud/fixtures/mswAPI.ts
+++ b/public/app/features/migrate-to-cloud/fixtures/mswAPI.ts
@@ -4,12 +4,30 @@ import { SetupServer, setupServer } from 'msw/node';
 export function registerAPIHandlers(): SetupServer {
   const server = setupServer(
     // TODO
-    http.get('/api/cloudmigration/status', () => {
+    http.get('/api/dashboards/uid/:uid', ({ request, params }) => {
+      if (params.uid === 'dashboard-404') {
+        return HttpResponse.json(
+          {
+            message: 'Dashboard not found',
+          },
+          {
+            status: 404,
+          }
+        );
+      }
+
       return HttpResponse.json({
-        enabled: false,
+        dashboard: {
+          title: 'My Dashboard',
+        },
+        meta: {
+          folderTitle: 'Dashboards',
+        },
       });
     })
   );
+
+  server.listen();
 
   return server;
 }

--- a/public/app/features/migrate-to-cloud/fixtures/others.ts
+++ b/public/app/features/migrate-to-cloud/fixtures/others.ts
@@ -1,0 +1,44 @@
+import { Chance } from 'chance';
+
+import { DataSourceInstanceSettings, PluginType } from '@grafana/data';
+
+export function wellFormedDatasource(
+  seed = 1,
+  custom: Partial<DataSourceInstanceSettings> = {}
+): DataSourceInstanceSettings {
+  const random = Chance(seed);
+
+  return {
+    id: random.integer(),
+    uid: random.guid(),
+    type: random.word(),
+    name: random.sentence({ words: 3 }),
+    readOnly: false,
+    jsonData: {},
+    meta: {
+      id: random.word(),
+      name: random.word(),
+      type: PluginType.datasource,
+      module: random.word(),
+      baseUrl: random.url(),
+
+      info: {
+        author: {
+          name: random.name(),
+        },
+        description: random.sentence({ words: 5 }),
+
+        links: [],
+        logos: {
+          large: random.url(),
+          small: random.url(),
+        },
+        screenshots: [],
+        updated: random.date().toISOString(),
+        version: '1.0.0',
+      },
+    },
+    access: 'direct',
+    ...custom,
+  };
+}

--- a/public/app/features/migrate-to-cloud/onprem/NameCell.tsx
+++ b/public/app/features/migrate-to-cloud/onprem/NameCell.tsx
@@ -1,0 +1,102 @@
+import { css } from '@emotion/css';
+import React, { useMemo } from 'react';
+import Skeleton from 'react-loading-skeleton';
+
+import { CellProps, Stack, Text, Icon, useStyles2 } from '@grafana/ui';
+import { getSvgSize } from '@grafana/ui/src/components/Icon/utils';
+
+import { useGetDashboardByUidQuery } from '../api';
+import { MigrationResourceDTOMock, MigrationResourceDatasource, MigrationResourceDashboard } from '../mockAPI';
+
+export function NameCell(props: CellProps<MigrationResourceDTOMock>) {
+  const data = props.row.original;
+
+  return (
+    <Stack direction="row" gap={2} alignItems="center">
+      <ResourceIcon resource={data} />
+
+      <Stack direction="column" gap={0}>
+        {data.type === 'datasource' ? <DatasourceInfo data={data} /> : <DashboardInfo data={data} />}
+      </Stack>
+    </Stack>
+  );
+}
+
+function getDashboardTitle(dashboardData: object) {
+  if ('title' in dashboardData && typeof dashboardData.title === 'string') {
+    return dashboardData.title;
+  }
+
+  return undefined;
+}
+
+function DatasourceInfo({ data }: { data: MigrationResourceDatasource }) {
+  return (
+    <>
+      <span>{data.resource.name}</span>
+      <Text color="secondary">{data.resource.type}</Text>
+    </>
+  );
+}
+
+// TODO: really, the API should return this directly
+function DashboardInfo({ data }: { data: MigrationResourceDashboard }) {
+  const { data: dashboardData, isError } = useGetDashboardByUidQuery({
+    uid: data.resource.uid,
+  });
+
+  const dashboardName = useMemo(() => {
+    return (dashboardData?.dashboard && getDashboardTitle(dashboardData.dashboard)) ?? data.resource.uid;
+  }, [dashboardData, data.resource.uid]);
+
+  if (isError) {
+    return (
+      <>
+        <Text italic>Unable to load dashboard</Text>
+        <Text color="secondary">Dashboard {data.uid}</Text>
+      </>
+    );
+  }
+
+  if (!dashboardData) {
+    return (
+      <>
+        <Skeleton width={250} />
+        <Skeleton width={130} />
+      </>
+    );
+  }
+
+  return (
+    <>
+      <span>{dashboardName}</span>
+      <Text color="secondary">{dashboardData.meta?.folderTitle ?? 'Dashboards'}</Text>
+    </>
+  );
+}
+
+function ResourceIcon({ resource }: { resource: MigrationResourceDTOMock }) {
+  const styles = useStyles2(getIconStyles);
+
+  if (resource.type === 'dashboard') {
+    return <Icon size="xl" name="dashboard" />;
+  }
+
+  if (resource.type === 'datasource' && resource.resource.icon) {
+    return <img className={styles.icon} src={resource.resource.icon} alt="" />;
+  } else if (resource.type === 'datasource') {
+    return <Icon size="xl" name="database" />;
+  }
+
+  return undefined;
+}
+
+function getIconStyles() {
+  return {
+    icon: css({
+      display: 'block',
+      width: getSvgSize('xl'),
+      height: getSvgSize('xl'),
+    }),
+  };
+}

--- a/public/app/features/migrate-to-cloud/onprem/ResourcesTable.test.tsx
+++ b/public/app/features/migrate-to-cloud/onprem/ResourcesTable.test.tsx
@@ -1,0 +1,132 @@
+import 'whatwg-fetch'; // fetch polyfill
+import { render as rtlRender, screen } from '@testing-library/react';
+import { SetupServer } from 'msw/lib/node';
+import React from 'react';
+import { TestProvider } from 'test/helpers/TestProvider';
+
+import { setBackendSrv, config } from '@grafana/runtime';
+import { backendSrv } from 'app/core/services/backend_srv';
+
+import { wellFormedDashboardMigrationItem, wellFormedDatasourceMigrationItem } from '../fixtures/migrationItems';
+import { registerAPIHandlers } from '../fixtures/mswAPI';
+import { wellFormedDatasource } from '../fixtures/others';
+
+import { ResourcesTable } from './ResourcesTable';
+
+setBackendSrv(backendSrv);
+
+function render(...[ui, options]: Parameters<typeof rtlRender>) {
+  rtlRender(<TestProvider>{ui}</TestProvider>, options);
+}
+
+describe('ResourcesTable', () => {
+  let server: SetupServer;
+  let originalDatasources: (typeof config)['datasources'];
+
+  const datasourceA = wellFormedDatasource(1, {
+    uid: 'datasource-a-uid',
+    name: 'Datasource A',
+  });
+
+  beforeAll(() => {
+    server = registerAPIHandlers();
+    originalDatasources = config.datasources;
+
+    config.datasources = {
+      ...config.datasources,
+      [datasourceA.name]: datasourceA,
+    };
+  });
+
+  afterAll(() => {
+    server.close();
+    config.datasources = originalDatasources;
+  });
+
+  it('renders data sources', async () => {
+    const resources = [
+      wellFormedDatasourceMigrationItem(1, {
+        refId: datasourceA.uid,
+      }),
+    ];
+
+    render(<ResourcesTable resources={resources} />);
+
+    expect(screen.getByText('Datasource A')).toBeInTheDocument();
+  });
+
+  it('renders data sources when their data is missing', () => {
+    const item = wellFormedDatasourceMigrationItem(2);
+    const resources = [item];
+
+    render(<ResourcesTable resources={resources} />);
+
+    expect(screen.getByText(`Data source ${item.refId}`)).toBeInTheDocument();
+    expect(screen.getByText(`Unknown data source`)).toBeInTheDocument();
+  });
+
+  it('renders dashboards', async () => {
+    const resources = [wellFormedDashboardMigrationItem(1)];
+
+    render(<ResourcesTable resources={resources} />);
+
+    expect(await screen.findByText('My Dashboard')).toBeInTheDocument();
+  });
+
+  it('renders dashboards when their data is missing', async () => {
+    const resources = [
+      wellFormedDashboardMigrationItem(2, {
+        refId: 'dashboard-404',
+      }),
+    ];
+
+    render(<ResourcesTable resources={resources} />);
+
+    expect(await screen.findByText('Unable to load dashboard')).toBeInTheDocument();
+    expect(await screen.findByText('Dashboard dashboard-404')).toBeInTheDocument();
+  });
+
+  it('renders the success status correctly', () => {
+    const resources = [
+      wellFormedDatasourceMigrationItem(1, {
+        refId: datasourceA.uid,
+        status: 'OK',
+      }),
+    ];
+
+    render(<ResourcesTable resources={resources} />);
+
+    expect(screen.getByText('Uploaded to cloud')).toBeInTheDocument();
+  });
+
+  it('renders the success error correctly', () => {
+    const resources = [
+      wellFormedDatasourceMigrationItem(1, {
+        refId: datasourceA.uid,
+        status: 'ERROR',
+      }),
+    ];
+
+    render(<ResourcesTable resources={resources} />);
+
+    expect(screen.getByText('Error')).toBeInTheDocument();
+  });
+
+  it("shows a details button when there's an error description", () => {
+    const resources = [
+      wellFormedDatasourceMigrationItem(1, {
+        refId: datasourceA.uid,
+        status: 'ERROR',
+        error: 'Some error',
+      }),
+    ];
+
+    render(<ResourcesTable resources={resources} />);
+
+    expect(
+      screen.getByRole('button', {
+        name: 'Details',
+      })
+    ).toBeInTheDocument();
+  });
+});

--- a/public/app/features/migrate-to-cloud/onprem/ResourcesTable.tsx
+++ b/public/app/features/migrate-to-cloud/onprem/ResourcesTable.tsx
@@ -2,14 +2,14 @@ import React from 'react';
 
 import { InteractiveTable } from '@grafana/ui';
 
-import { MigrationResourceDTOMock } from '../mockAPI';
+import { MigrateDataResponseItemDto } from '../api';
 
 import { NameCell } from './NameCell';
 import { StatusCell } from './StatusCell';
 import { TypeCell } from './TypeCell';
 
 interface ResourcesTableProps {
-  resources: MigrationResourceDTOMock[];
+  resources: MigrateDataResponseItemDto[];
 }
 
 const columns = [
@@ -19,5 +19,5 @@ const columns = [
 ];
 
 export function ResourcesTable({ resources }: ResourcesTableProps) {
-  return <InteractiveTable columns={columns} data={resources} getRowId={(r) => r.uid} pageSize={15} />;
+  return <InteractiveTable columns={columns} data={resources} getRowId={(r) => r.refId} pageSize={15} />;
 }

--- a/public/app/features/migrate-to-cloud/onprem/ResourcesTable.tsx
+++ b/public/app/features/migrate-to-cloud/onprem/ResourcesTable.tsx
@@ -1,13 +1,12 @@
-import { css } from '@emotion/css';
-import React, { useMemo } from 'react';
-import Skeleton from 'react-loading-skeleton';
+import React from 'react';
 
-import { InteractiveTable, CellProps, Stack, Text, Icon, useStyles2, Button } from '@grafana/ui';
-import { getSvgSize } from '@grafana/ui/src/components/Icon/utils';
-import { t } from 'app/core/internationalization';
+import { InteractiveTable } from '@grafana/ui';
 
-import { useGetDashboardByUidQuery } from '../api';
-import { MigrationResourceDTOMock, MigrationResourceDashboard, MigrationResourceDatasource } from '../mockAPI';
+import { MigrationResourceDTOMock } from '../mockAPI';
+
+import { NameCell } from './NameCell';
+import { StatusCell } from './StatusCell';
+import { TypeCell } from './TypeCell';
 
 interface ResourcesTableProps {
   resources: MigrationResourceDTOMock[];
@@ -21,133 +20,4 @@ const columns = [
 
 export function ResourcesTable({ resources }: ResourcesTableProps) {
   return <InteractiveTable columns={columns} data={resources} getRowId={(r) => r.uid} pageSize={15} />;
-}
-
-function NameCell(props: CellProps<MigrationResourceDTOMock>) {
-  const data = props.row.original;
-
-  return (
-    <Stack direction="row" gap={2} alignItems="center">
-      <ResourceIcon resource={data} />
-
-      <Stack direction="column" gap={0}>
-        {data.type === 'datasource' ? <DatasourceInfo data={data} /> : <DashboardInfo data={data} />}
-      </Stack>
-    </Stack>
-  );
-}
-
-function getDashboardTitle(dashboardData: object) {
-  if ('title' in dashboardData && typeof dashboardData.title === 'string') {
-    return dashboardData.title;
-  }
-
-  return undefined;
-}
-
-function DatasourceInfo({ data }: { data: MigrationResourceDatasource }) {
-  return (
-    <>
-      <span>{data.resource.name}</span>
-      <Text color="secondary">{data.resource.type}</Text>
-    </>
-  );
-}
-
-// TODO: really, the API should return this directly
-function DashboardInfo({ data }: { data: MigrationResourceDashboard }) {
-  const { data: dashboardData } = useGetDashboardByUidQuery({
-    uid: data.resource.uid,
-  });
-
-  const dashboardName = useMemo(() => {
-    return (dashboardData?.dashboard && getDashboardTitle(dashboardData.dashboard)) ?? data.resource.uid;
-  }, [dashboardData, data.resource.uid]);
-
-  if (!dashboardData) {
-    return (
-      <>
-        <span>
-          <Skeleton width={250} />
-        </span>
-        <span>
-          <Skeleton width={130} />
-        </span>
-      </>
-    );
-  }
-
-  return (
-    <>
-      <span>{dashboardName}</span>
-      <Text color="secondary">{dashboardData.meta?.folderTitle ?? 'Dashboards'}</Text>
-    </>
-  );
-}
-
-function TypeCell(props: CellProps<MigrationResourceDTOMock>) {
-  const { type } = props.row.original;
-
-  if (type === 'datasource') {
-    return t('migrate-to-cloud.resource-type.datasource', 'Data source');
-  }
-
-  if (type === 'dashboard') {
-    return t('migrate-to-cloud.resource-type.dashboard', 'Dashboard');
-  }
-
-  return t('migrate-to-cloud.resource-type.unknown', 'Unknown');
-}
-
-function StatusCell(props: CellProps<MigrationResourceDTOMock>) {
-  const { status, statusMessage } = props.row.original;
-
-  if (status === 'not-migrated') {
-    return <Text color="secondary">{t('migrate-to-cloud.resource-status.not-migrated', 'Not yet uploaded')}</Text>;
-  } else if (status === 'migrating') {
-    return <Text color="info">{t('migrate-to-cloud.resource-status.migrating', 'Uploading...')}</Text>;
-  } else if (status === 'migrated') {
-    return <Text color="success">{t('migrate-to-cloud.resource-status.migrated', 'Uploaded to cloud')}</Text>;
-  } else if (status === 'failed') {
-    return (
-      <Stack alignItems="center">
-        <Text color="error">{t('migrate-to-cloud.resource-status.failed', 'Error')}</Text>
-
-        {statusMessage && (
-          // TODO: trigger a proper modal, probably from the parent, on click
-          <Button size="sm" variant="secondary" onClick={() => window.alert(statusMessage)}>
-            {t('migrate-to-cloud.resource-status.error-details-button', 'Details')}
-          </Button>
-        )}
-      </Stack>
-    );
-  }
-
-  return <Text color="secondary">{t('migrate-to-cloud.resource-status.unknown', 'Unknown')}</Text>;
-}
-
-function ResourceIcon({ resource }: { resource: MigrationResourceDTOMock }) {
-  const styles = useStyles2(getIconStyles);
-
-  if (resource.type === 'dashboard') {
-    return <Icon size="xl" name="dashboard" />;
-  }
-
-  if (resource.type === 'datasource' && resource.resource.icon) {
-    return <img className={styles.icon} src={resource.resource.icon} alt="" />;
-  } else if (resource.type === 'datasource') {
-    return <Icon size="xl" name="database" />;
-  }
-
-  return undefined;
-}
-
-function getIconStyles() {
-  return {
-    icon: css({
-      display: 'block',
-      width: getSvgSize('xl'),
-      height: getSvgSize('xl'),
-    }),
-  };
 }

--- a/public/app/features/migrate-to-cloud/onprem/StatusCell.tsx
+++ b/public/app/features/migrate-to-cloud/onprem/StatusCell.tsx
@@ -1,0 +1,33 @@
+import React from 'react';
+
+import { CellProps, Text, Stack, Button } from '@grafana/ui';
+import { t } from 'app/core/internationalization';
+
+import { MigrationResourceDTOMock } from '../mockAPI';
+
+export function StatusCell(props: CellProps<MigrationResourceDTOMock>) {
+  const { status, statusMessage } = props.row.original;
+
+  if (status === 'not-migrated') {
+    return <Text color="secondary">{t('migrate-to-cloud.resource-status.not-migrated', 'Not yet uploaded')}</Text>;
+  } else if (status === 'migrating') {
+    return <Text color="info">{t('migrate-to-cloud.resource-status.migrating', 'Uploading...')}</Text>;
+  } else if (status === 'migrated') {
+    return <Text color="success">{t('migrate-to-cloud.resource-status.migrated', 'Uploaded to cloud')}</Text>;
+  } else if (status === 'failed') {
+    return (
+      <Stack alignItems="center">
+        <Text color="error">{t('migrate-to-cloud.resource-status.failed', 'Error')}</Text>
+
+        {statusMessage && (
+          // TODO: trigger a proper modal, probably from the parent, on click
+          <Button size="sm" variant="secondary" onClick={() => window.alert(statusMessage)}>
+            {t('migrate-to-cloud.resource-status.error-details-button', 'Details')}
+          </Button>
+        )}
+      </Stack>
+    );
+  }
+
+  return <Text color="secondary">{t('migrate-to-cloud.resource-status.unknown', 'Unknown')}</Text>;
+}

--- a/public/app/features/migrate-to-cloud/onprem/StatusCell.tsx
+++ b/public/app/features/migrate-to-cloud/onprem/StatusCell.tsx
@@ -3,25 +3,25 @@ import React from 'react';
 import { CellProps, Text, Stack, Button } from '@grafana/ui';
 import { t } from 'app/core/internationalization';
 
-import { MigrationResourceDTOMock } from '../mockAPI';
+import { MigrateDataResponseItemDto } from '../api';
 
-export function StatusCell(props: CellProps<MigrationResourceDTOMock>) {
-  const { status, statusMessage } = props.row.original;
+export function StatusCell(props: CellProps<MigrateDataResponseItemDto>) {
+  const { status, error } = props.row.original;
 
-  if (status === 'not-migrated') {
-    return <Text color="secondary">{t('migrate-to-cloud.resource-status.not-migrated', 'Not yet uploaded')}</Text>;
-  } else if (status === 'migrating') {
-    return <Text color="info">{t('migrate-to-cloud.resource-status.migrating', 'Uploading...')}</Text>;
-  } else if (status === 'migrated') {
+  // Keep these here to preserve the translations
+  // t('migrate-to-cloud.resource-status.not-migrated', 'Not yet uploaded')
+  // t('migrate-to-cloud.resource-status.migrating', 'Uploading...')
+
+  if (status === 'OK') {
     return <Text color="success">{t('migrate-to-cloud.resource-status.migrated', 'Uploaded to cloud')}</Text>;
-  } else if (status === 'failed') {
+  } else if (status === 'ERROR') {
     return (
       <Stack alignItems="center">
         <Text color="error">{t('migrate-to-cloud.resource-status.failed', 'Error')}</Text>
 
-        {statusMessage && (
+        {error && (
           // TODO: trigger a proper modal, probably from the parent, on click
-          <Button size="sm" variant="secondary" onClick={() => window.alert(statusMessage)}>
+          <Button size="sm" variant="secondary" onClick={() => window.alert(error)}>
             {t('migrate-to-cloud.resource-status.error-details-button', 'Details')}
           </Button>
         )}

--- a/public/app/features/migrate-to-cloud/onprem/TypeCell.tsx
+++ b/public/app/features/migrate-to-cloud/onprem/TypeCell.tsx
@@ -1,18 +1,19 @@
 import { CellProps } from '@grafana/ui';
 import { t } from 'app/core/internationalization';
 
-import { MigrationResourceDTOMock } from '../mockAPI';
+import { MigrateDataResponseItemDto } from '../api';
 
-export function TypeCell(props: CellProps<MigrationResourceDTOMock>) {
+export function TypeCell(props: CellProps<MigrateDataResponseItemDto>) {
   const { type } = props.row.original;
 
-  if (type === 'datasource') {
-    return t('migrate-to-cloud.resource-type.datasource', 'Data source');
+  switch (type) {
+    case 'DATASOURCE':
+      return t('migrate-to-cloud.resource-type.datasource', 'Data source');
+    case 'DASHBOARD':
+      return t('migrate-to-cloud.resource-type.dashboard', 'Dashboard');
+    case 'FOLDER':
+      return t('migrate-to-cloud.resource-type.folder', 'Folder');
+    default:
+      return t('migrate-to-cloud.resource-type.unknown', 'Unknown');
   }
-
-  if (type === 'dashboard') {
-    return t('migrate-to-cloud.resource-type.dashboard', 'Dashboard');
-  }
-
-  return t('migrate-to-cloud.resource-type.unknown', 'Unknown');
 }

--- a/public/app/features/migrate-to-cloud/onprem/TypeCell.tsx
+++ b/public/app/features/migrate-to-cloud/onprem/TypeCell.tsx
@@ -1,0 +1,18 @@
+import { CellProps } from '@grafana/ui';
+import { t } from 'app/core/internationalization';
+
+import { MigrationResourceDTOMock } from '../mockAPI';
+
+export function TypeCell(props: CellProps<MigrationResourceDTOMock>) {
+  const { type } = props.row.original;
+
+  if (type === 'datasource') {
+    return t('migrate-to-cloud.resource-type.datasource', 'Data source');
+  }
+
+  if (type === 'dashboard') {
+    return t('migrate-to-cloud.resource-type.dashboard', 'Dashboard');
+  }
+
+  return t('migrate-to-cloud.resource-type.unknown', 'Unknown');
+}

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -786,9 +786,14 @@
       "not-migrated": "Not yet uploaded",
       "unknown": "Unknown"
     },
+    "resource-table": {
+      "unknown-datasource-title": "Data source {{datasourceUID}}",
+      "unknown-datasource-type": "Unknown data source"
+    },
     "resource-type": {
       "dashboard": "Dashboard",
       "datasource": "Data source",
+      "folder": "Folder",
       "unknown": "Unknown"
     },
     "summary": {

--- a/public/locales/pseudo-LOCALE/grafana.json
+++ b/public/locales/pseudo-LOCALE/grafana.json
@@ -786,9 +786,14 @@
       "not-migrated": "Ńőŧ yęŧ ūpľőäđęđ",
       "unknown": "Ůŉĸŉőŵŉ"
     },
+    "resource-table": {
+      "unknown-datasource-title": "Đäŧä şőūřčę {{datasourceUID}}",
+      "unknown-datasource-type": "Ůŉĸŉőŵŉ đäŧä şőūřčę"
+    },
     "resource-type": {
       "dashboard": "Đäşĥþőäřđ",
       "datasource": "Đäŧä şőūřčę",
+      "folder": "Főľđęř",
       "unknown": "Ůŉĸŉőŵŉ"
     },
     "summary": {

--- a/public/openapi3.json
+++ b/public/openapi3.json
@@ -6277,9 +6277,6 @@
         },
         "type": "object"
       },
-      "ItemStatus": {
-        "type": "string"
-      },
       "JSONWebKey": {
         "description": "JSONWebKey represents a public or private key in JWK format. It can be\nmarshaled into JSON and unmarshaled from JSON.",
         "properties": {

--- a/public/openapi3.json
+++ b/public/openapi3.json
@@ -6739,16 +6739,27 @@
             "type": "string"
           },
           "status": {
-            "$ref": "#/components/schemas/ItemStatus"
+            "enum": [
+              "OK",
+              "ERROR"
+            ],
+            "type": "string"
           },
           "type": {
-            "$ref": "#/components/schemas/MigrateDataType"
+            "enum": [
+              "DASHBOARD",
+              "DATASOURCE",
+              "FOLDER"
+            ],
+            "type": "string"
           }
         },
+        "required": [
+          "type",
+          "refId",
+          "status"
+        ],
         "type": "object"
-      },
-      "MigrateDataType": {
-        "type": "string"
       },
       "MoveFolderCommand": {
         "description": "MoveFolderCommand captures the information required by the folder service\nto move a folder.",


### PR DESCRIPTION
Refactors the Cloud Migration resources table to clean it all up and make it easier to maintain 😌 

 - Updated the go-swagger annotations to enumerate enums (so we actually get `status: "OK" | "ERROR"`, etc in our types)
 - Use the 'native' `MigrateDataResponseItemDto` type in the resource table, instead of converting that to our mock type
 - Move NameCell, TypeCell, and StatusCell all into their own files
 - Adds error handling to the (hopefully temp) `getDashboardByUid` stuff in case dashboards are deleted after the migration