### PR TITLE
Email: trigger email verification flow

### DIFF
--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -191,6 +191,7 @@ func (hs *HTTPServer) registerRoutes() {
 	// update user email
 	if hs.Cfg.Smtp.Enabled && hs.Cfg.VerifyEmailEnabled {
 		r.Get("/user/email/update", reqSignedInNoAnonymous, routing.Wrap(hs.UpdateUserEmail))
+		r.Post("/api/user/email/start-verify", reqSignedInNoAnonymous, routing.Wrap(hs.StartEmailVerificaton))
 	}
 
 	// invited

--- a/pkg/api/user.go
+++ b/pkg/api/user.go
@@ -290,7 +290,7 @@ func (hs *HTTPServer) StartEmailVerificaton(c *contextmodel.ReqContext) response
 		return response.Error(http.StatusBadRequest, "Only users can verify their email", nil)
 	}
 
-	if c.SignedInUser.GetEmailVerified() {
+	if c.SignedInUser.IsEmailVerified() {
 		// email is already verified so we don't need to trigger the flow.
 		return response.Respond(http.StatusNotModified, nil)
 	}

--- a/pkg/api/user.go
+++ b/pkg/api/user.go
@@ -264,12 +264,12 @@ func (hs *HTTPServer) handleUpdateUser(ctx context.Context, cmd user.UpdateUserC
 			if err != nil {
 				return response.Error(http.StatusBadRequest, "Invalid email address", err)
 			}
-			return hs.verifyEmailUpdate(ctx, normalized, user.EmailUpdateAction, usr)
+			return hs.startEmailVerification(ctx, normalized, user.EmailUpdateAction, usr)
 		}
 		if len(cmd.Login) != 0 && usr.Login != cmd.Login {
 			normalized, err := ValidateAndNormalizeEmail(cmd.Login)
 			if err == nil && usr.Email != normalized {
-				return hs.verifyEmailUpdate(ctx, cmd.Login, user.LoginUpdateAction, usr)
+				return hs.startEmailVerification(ctx, cmd.Login, user.LoginUpdateAction, usr)
 			}
 		}
 	}
@@ -284,7 +284,34 @@ func (hs *HTTPServer) handleUpdateUser(ctx context.Context, cmd user.UpdateUserC
 	return response.Success("User updated")
 }
 
-func (hs *HTTPServer) verifyEmailUpdate(ctx context.Context, email string, field user.UpdateEmailActionType, usr *user.User) response.Response {
+func (hs *HTTPServer) StartEmailVerificaton(c *contextmodel.ReqContext) response.Response {
+	namespace, id := c.SignedInUser.GetNamespacedID()
+	if !identity.IsNamespace(namespace, identity.NamespaceUser) {
+		return response.Error(http.StatusBadRequest, "Only users can verify their email", nil)
+	}
+
+	if c.SignedInUser.GetEmailVerified() {
+		// email is already verified so we don't need to trigger the flow.
+		return response.Respond(http.StatusNotModified, nil)
+	}
+
+	userID, err := strconv.ParseInt(id, 10, 64)
+	if err != nil {
+		return response.Error(http.StatusInternalServerError, "Got invalid user id", err)
+	}
+
+	usr, err := hs.userService.GetByID(c.Req.Context(), &user.GetUserByIDQuery{
+		ID: userID,
+	})
+
+	if err != nil {
+		return response.ErrOrFallback(http.StatusInternalServerError, "Failed to fetch user", err)
+	}
+
+	return hs.startEmailVerification(c.Req.Context(), usr.Email, user.EmailUpdateAction, usr)
+}
+
+func (hs *HTTPServer) startEmailVerification(ctx context.Context, email string, field user.UpdateEmailActionType, usr *user.User) response.Response {
 	if err := hs.userVerifier.Start(ctx, user.StartVerifyEmailCommand{
 		User:   *usr,
 		Email:  email,

--- a/pkg/api/user_test.go
+++ b/pkg/api/user_test.go
@@ -10,13 +10,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/grafana/grafana/pkg/services/accesscontrol"
-	"github.com/grafana/grafana/pkg/services/notifications"
-	"github.com/grafana/grafana/pkg/services/secrets/fakes"
-	tempuser "github.com/grafana/grafana/pkg/services/temp_user"
-	"github.com/grafana/grafana/pkg/services/temp_user/tempuserimpl"
-	"github.com/grafana/grafana/pkg/web/webtest"
-
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/oauth2"
@@ -30,23 +23,30 @@ import (
 	"github.com/grafana/grafana/pkg/infra/remotecache"
 	"github.com/grafana/grafana/pkg/login/social"
 	"github.com/grafana/grafana/pkg/login/social/socialtest"
+	"github.com/grafana/grafana/pkg/services/accesscontrol"
 	"github.com/grafana/grafana/pkg/services/accesscontrol/acimpl"
 	acmock "github.com/grafana/grafana/pkg/services/accesscontrol/mock"
+	"github.com/grafana/grafana/pkg/services/auth/idtest"
 	contextmodel "github.com/grafana/grafana/pkg/services/contexthandler/model"
 	"github.com/grafana/grafana/pkg/services/login"
 	"github.com/grafana/grafana/pkg/services/login/authinfoimpl"
 	"github.com/grafana/grafana/pkg/services/login/authinfotest"
+	"github.com/grafana/grafana/pkg/services/notifications"
 	"github.com/grafana/grafana/pkg/services/org/orgimpl"
 	"github.com/grafana/grafana/pkg/services/quota/quotatest"
 	"github.com/grafana/grafana/pkg/services/searchusers"
 	"github.com/grafana/grafana/pkg/services/searchusers/filters"
 	"github.com/grafana/grafana/pkg/services/secrets/database"
+	"github.com/grafana/grafana/pkg/services/secrets/fakes"
 	secretsManager "github.com/grafana/grafana/pkg/services/secrets/manager"
 	"github.com/grafana/grafana/pkg/services/supportbundles/supportbundlestest"
+	tempuser "github.com/grafana/grafana/pkg/services/temp_user"
+	"github.com/grafana/grafana/pkg/services/temp_user/tempuserimpl"
 	"github.com/grafana/grafana/pkg/services/user"
 	"github.com/grafana/grafana/pkg/services/user/userimpl"
 	"github.com/grafana/grafana/pkg/services/user/usertest"
 	"github.com/grafana/grafana/pkg/setting"
+	"github.com/grafana/grafana/pkg/web/webtest"
 )
 
 const newEmail = "newemail@localhost"
@@ -397,7 +397,7 @@ func setupUpdateEmailTests(t *testing.T, cfg *setting.Cfg) (*user.User, *HTTPSer
 	require.NoError(t, err)
 
 	nsMock := notifications.MockNotificationService()
-	verifier := userimpl.ProvideVerifier(cfg, userSvc, tempUserService, nsMock)
+	verifier := userimpl.ProvideVerifier(cfg, userSvc, tempUserService, nsMock, &idtest.MockService{})
 
 	hs := &HTTPServer{
 		Cfg:                 cfg,
@@ -620,7 +620,7 @@ func TestUser_UpdateEmail(t *testing.T) {
 			hs.tempUserService = tempUserSvc
 			hs.NotificationService = nsMock
 			hs.SecretsService = fakes.NewFakeSecretsService()
-			hs.userVerifier = userimpl.ProvideVerifier(settings, userSvc, tempUserSvc, nsMock)
+			hs.userVerifier = userimpl.ProvideVerifier(settings, userSvc, tempUserSvc, nsMock, &idtest.MockService{})
 			// User is internal
 			hs.authInfoService = &authinfotest.FakeService{ExpectedError: user.ErrUserNotFound}
 		})

--- a/pkg/services/auth/id.go
+++ b/pkg/services/auth/id.go
@@ -11,6 +11,9 @@ import (
 type IDService interface {
 	// SignIdentity signs a id token for provided identity that can be forwarded to plugins and external services
 	SignIdentity(ctx context.Context, identity identity.Requester) (string, error)
+
+	// RemoveIDToken removes any locally stored id tokens for key
+	RemoveIDToken(ctx context.Context, identity identity.Requester) error
 }
 
 type IDSigner interface {

--- a/pkg/services/auth/id.go
+++ b/pkg/services/auth/id.go
@@ -19,5 +19,7 @@ type IDSigner interface {
 
 type IDClaims struct {
 	jwt.Claims
+	Email           string `json:"email"`
+	EmailVerified   bool   `json:"email_verified"`
 	AuthenticatedBy string `json:"authenticatedBy,omitempty"`
 }

--- a/pkg/services/auth/identity/requester.go
+++ b/pkg/services/auth/identity/requester.go
@@ -32,8 +32,8 @@ type Requester interface {
 	// GetEmail returns the email of the active entity.
 	// Can be empty.
 	GetEmail() string
-	// GetEmailVerified returns if email is verified for entity.
-	GetEmailVerified() bool
+	// IsEmailVerified returns if email is verified for entity.
+	IsEmailVerified() bool
 	// GetIsGrafanaAdmin returns true if the user is a server admin
 	GetIsGrafanaAdmin() bool
 	// GetLogin returns the login of the active entity

--- a/pkg/services/auth/identity/requester.go
+++ b/pkg/services/auth/identity/requester.go
@@ -32,6 +32,8 @@ type Requester interface {
 	// GetEmail returns the email of the active entity.
 	// Can be empty.
 	GetEmail() string
+	// GetEmailVerified returns if email is verified for entity.
+	GetEmailVerified() bool
 	// GetIsGrafanaAdmin returns true if the user is a server admin
 	GetIsGrafanaAdmin() bool
 	// GetLogin returns the login of the active entity

--- a/pkg/services/auth/idimpl/service.go
+++ b/pkg/services/auth/idimpl/service.go
@@ -90,10 +90,12 @@ func (s *Service) SignIdentity(ctx context.Context, id identity.Requester) (stri
 		}
 
 		if identity.IsNamespace(namespace, identity.NamespaceUser) {
-			if err := s.setUserClaims(ctx, identifier, claims); err != nil {
+			if err := s.setUserClaims(ctx, id, identifier, claims); err != nil {
 				return "", err
 			}
 		}
+
+		fmt.Println(claims)
 
 		token, err := s.signer.SignIDToken(ctx, claims)
 		if err != nil {
@@ -130,7 +132,7 @@ func (s *Service) SignIdentity(ctx context.Context, id identity.Requester) (stri
 	return result.(string), nil
 }
 
-func (s *Service) setUserClaims(ctx context.Context, identifier string, claims *auth.IDClaims) error {
+func (s *Service) setUserClaims(ctx context.Context, ident identity.Requester, identifier string, claims *auth.IDClaims) error {
 	id, err := strconv.ParseInt(identifier, 10, 64)
 	if err != nil {
 		return err
@@ -151,6 +153,8 @@ func (s *Service) setUserClaims(ctx context.Context, identifier string, claims *
 	}
 
 	claims.AuthenticatedBy = info.AuthModule
+	claims.Email = ident.GetEmail()
+	claims.EmailVerified = ident.GetEmailVerified()
 
 	return nil
 }

--- a/pkg/services/auth/idimpl/service.go
+++ b/pkg/services/auth/idimpl/service.go
@@ -95,8 +95,6 @@ func (s *Service) SignIdentity(ctx context.Context, id identity.Requester) (stri
 			}
 		}
 
-		fmt.Println(claims)
-
 		token, err := s.signer.SignIDToken(ctx, claims)
 		if err != nil {
 			s.metrics.failedTokenSigningCounter.Inc()
@@ -130,6 +128,10 @@ func (s *Service) SignIdentity(ctx context.Context, id identity.Requester) (stri
 	}
 
 	return result.(string), nil
+}
+
+func (s *Service) RemoveIDToken(ctx context.Context, id identity.Requester) error {
+	return s.cache.Delete(ctx, prefixCacheKey(id.GetCacheKey()))
 }
 
 func (s *Service) setUserClaims(ctx context.Context, ident identity.Requester, identifier string, claims *auth.IDClaims) error {

--- a/pkg/services/auth/idimpl/service.go
+++ b/pkg/services/auth/idimpl/service.go
@@ -144,6 +144,9 @@ func (s *Service) setUserClaims(ctx context.Context, ident identity.Requester, i
 		return nil
 	}
 
+	claims.Email = ident.GetEmail()
+	claims.EmailVerified = ident.IsEmailVerified()
+
 	info, err := s.authInfoService.GetAuthInfo(ctx, &login.GetAuthInfoQuery{UserId: id})
 	if err != nil {
 		// we ignore errors when a user don't have external user auth
@@ -155,8 +158,6 @@ func (s *Service) setUserClaims(ctx context.Context, ident identity.Requester, i
 	}
 
 	claims.AuthenticatedBy = info.AuthModule
-	claims.Email = ident.GetEmail()
-	claims.EmailVerified = ident.IsEmailVerified()
 
 	return nil
 }

--- a/pkg/services/auth/idimpl/service.go
+++ b/pkg/services/auth/idimpl/service.go
@@ -156,7 +156,7 @@ func (s *Service) setUserClaims(ctx context.Context, ident identity.Requester, i
 
 	claims.AuthenticatedBy = info.AuthModule
 	claims.Email = ident.GetEmail()
-	claims.EmailVerified = ident.GetEmailVerified()
+	claims.EmailVerified = ident.IsEmailVerified()
 
 	return nil
 }

--- a/pkg/services/auth/idtest/mock.go
+++ b/pkg/services/auth/idtest/mock.go
@@ -4,7 +4,29 @@ import (
 	"context"
 
 	"github.com/grafana/grafana/pkg/services/auth"
+	"github.com/grafana/grafana/pkg/services/auth/identity"
 )
+
+var _ auth.IDService = (*MockService)(nil)
+
+type MockService struct {
+	SignIdentityFn  func(ctx context.Context, identity identity.Requester) (string, error)
+	RemoveIDTokenFn func(ctx context.Context, identity identity.Requester) error
+}
+
+func (m *MockService) SignIdentity(ctx context.Context, identity identity.Requester) (string, error) {
+	if m.SignIdentityFn != nil {
+		return m.SignIdentityFn(ctx, identity)
+	}
+	return "", nil
+}
+
+func (m *MockService) RemoveIDToken(ctx context.Context, identity identity.Requester) error {
+	if m.SignIdentityFn != nil {
+		return m.RemoveIDTokenFn(ctx, identity)
+	}
+	return nil
+}
 
 type MockSigner struct {
 	SignIDTokenFn func(ctx context.Context, claims *auth.IDClaims) (string, error)

--- a/pkg/services/auth/idtest/mock.go
+++ b/pkg/services/auth/idtest/mock.go
@@ -22,7 +22,7 @@ func (m *MockService) SignIdentity(ctx context.Context, identity identity.Reques
 }
 
 func (m *MockService) RemoveIDToken(ctx context.Context, identity identity.Requester) error {
-	if m.SignIdentityFn != nil {
+	if m.RemoveIDTokenFn != nil {
 		return m.RemoveIDTokenFn(ctx, identity)
 	}
 	return nil

--- a/pkg/services/authn/authnimpl/sync/user_sync.go
+++ b/pkg/services/authn/authnimpl/sync/user_sync.go
@@ -407,4 +407,5 @@ func syncSignedInUserToIdentity(usr *user.SignedInUser, identity *authn.Identity
 	identity.LastSeenAt = usr.LastSeenAt
 	identity.IsDisabled = usr.IsDisabled
 	identity.IsGrafanaAdmin = &usr.IsGrafanaAdmin
+	identity.EmailVerified = usr.EmailVerified
 }

--- a/pkg/services/authn/identity.go
+++ b/pkg/services/authn/identity.go
@@ -125,7 +125,7 @@ func (i *Identity) GetEmail() string {
 	return i.Email
 }
 
-func (i *Identity) GetEmailVerified() bool {
+func (i *Identity) IsEmailVerified() bool {
 	return i.EmailVerified
 }
 

--- a/pkg/services/authn/identity.go
+++ b/pkg/services/authn/identity.go
@@ -55,6 +55,8 @@ type Identity struct {
 	Name string
 	// Email is the email address of the entity. Should be unique.
 	Email string
+	// EmailVerified is true if entity has verified their email with grafana.
+	EmailVerified bool
 	// IsGrafanaAdmin is true if the entity is a Grafana admin.
 	IsGrafanaAdmin *bool
 	// AuthenticatedBy is the name of the authentication client that was used to authenticate the current Identity.
@@ -121,6 +123,10 @@ func (i *Identity) GetDisplayName() string {
 
 func (i *Identity) GetEmail() string {
 	return i.Email
+}
+
+func (i *Identity) GetEmailVerified() bool {
+	return i.EmailVerified
 }
 
 func (i *Identity) GetIDToken() string {

--- a/pkg/services/user/identity.go
+++ b/pkg/services/user/identity.go
@@ -22,6 +22,7 @@ type SignedInUser struct {
 	Login            string
 	Name             string
 	Email            string
+	EmailVerified    bool
 	AuthenticatedBy  string
 	ApiKeyID         int64 `xorm:"api_key_id"`
 	IsServiceAccount bool  `xorm:"is_service_account"`
@@ -239,6 +240,10 @@ func (u *SignedInUser) IsNil() bool {
 // Can be empty.
 func (u *SignedInUser) GetEmail() string {
 	return u.Email
+}
+
+func (u *SignedInUser) GetEmailVerified() bool {
+	return u.EmailVerified
 }
 
 // GetDisplayName returns the display name of the active entity

--- a/pkg/services/user/identity.go
+++ b/pkg/services/user/identity.go
@@ -242,7 +242,7 @@ func (u *SignedInUser) GetEmail() string {
 	return u.Email
 }
 
-func (u *SignedInUser) GetEmailVerified() bool {
+func (u *SignedInUser) IsEmailVerified() bool {
 	return u.EmailVerified
 }
 

--- a/pkg/services/user/model.go
+++ b/pkg/services/user/model.go
@@ -228,6 +228,7 @@ type StartVerifyEmailCommand struct {
 }
 
 type CompleteEmailVerifyCommand struct {
+	User identity.Requester
 	Code string
 }
 

--- a/pkg/services/user/userimpl/store.go
+++ b/pkg/services/user/userimpl/store.go
@@ -382,6 +382,7 @@ func (ss *sqlStore) GetSignedInUser(ctx context.Context, query *user.GetSignedIn
 		u.uid                 as user_uid,
 		u.is_admin            as is_grafana_admin,
 		u.email               as email,
+		u.email_verified      as email_verified,
 		u.login               as login,
 		u.name                as name,
 		u.is_disabled         as is_disabled,


### PR DESCRIPTION
**What is this feature?**
Part of https://github.com/grafana/identity-access-team/issues/536 and https://github.com/grafana/identity-access-team/issues/625.

This pr adds a api endpoint to trigger email verification flow. On top of that it also adds `EmailVerified` to Identity interface.

We will include `email` and `email_verified` claim in generated id tokens. Whenever a email verification is completed we remove stored id tokens to make sure a new token with correct values is generated. 

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
