### PR TITLE
Add better logging to the dual writer

### DIFF
--- a/pkg/apiserver/rest/dualwriter.go
+++ b/pkg/apiserver/rest/dualwriter.go
@@ -3,6 +3,7 @@ package rest
 import (
 	"context"
 
+	"github.com/grafana/grafana/pkg/infra/log"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metainternalversion "k8s.io/apimachinery/pkg/apis/meta/internalversion"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -62,6 +63,7 @@ type LegacyStorage interface {
 type DualWriter struct {
 	Storage
 	Legacy LegacyStorage
+	Log    log.Logger
 }
 
 type DualWriterMode int
@@ -82,6 +84,7 @@ func NewDualWriter(legacy LegacyStorage, storage Storage) *DualWriter {
 	return &DualWriter{
 		Storage: storage,
 		Legacy:  legacy,
+		Log:     log.New("dualwriter"),
 	}
 }
 

--- a/pkg/apiserver/rest/dualwriter.go
+++ b/pkg/apiserver/rest/dualwriter.go
@@ -8,7 +8,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apiserver/pkg/registry/rest"
-	"k8s.io/klog"
 )
 
 var (
@@ -84,31 +83,6 @@ func NewDualWriter(legacy LegacyStorage, storage Storage) *DualWriter {
 		Storage: storage,
 		Legacy:  legacy,
 	}
-}
-
-// Create overrides the default behavior of the Storage and writes to both the LegacyStorage and Storage.
-func (d *DualWriter) Create(ctx context.Context, obj runtime.Object, createValidation rest.ValidateObjectFunc, options *metav1.CreateOptions) (runtime.Object, error) {
-	if legacy, ok := d.Legacy.(rest.Creater); ok {
-		created, err := legacy.Create(ctx, obj, createValidation, options)
-		if err != nil {
-			return nil, err
-		}
-
-		accessor, err := meta.Accessor(created)
-		if err != nil {
-			return created, err
-		}
-		accessor.SetResourceVersion("")
-		accessor.SetUID("")
-
-		rsp, err := d.Storage.Create(ctx, created, createValidation, options)
-		if err != nil {
-			klog.Error("unable to create object in duplicate storage", "error", err)
-		}
-		return rsp, err
-	}
-
-	return d.Storage.Create(ctx, obj, createValidation, options)
 }
 
 // Update overrides the default behavior of the Storage and writes to both the LegacyStorage and Storage.

--- a/pkg/apiserver/rest/dualwriter.go
+++ b/pkg/apiserver/rest/dualwriter.go
@@ -3,7 +3,6 @@ package rest
 import (
 	"context"
 
-	"github.com/grafana/grafana/pkg/infra/log"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metainternalversion "k8s.io/apimachinery/pkg/apis/meta/internalversion"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -63,7 +62,6 @@ type LegacyStorage interface {
 type DualWriter struct {
 	Storage
 	Legacy LegacyStorage
-	Log    log.Logger
 }
 
 type DualWriterMode int
@@ -84,7 +82,6 @@ func NewDualWriter(legacy LegacyStorage, storage Storage) *DualWriter {
 	return &DualWriter{
 		Storage: storage,
 		Legacy:  legacy,
-		Log:     log.New("dualwriter"),
 	}
 }
 

--- a/pkg/apiserver/rest/dualwriter_mode1.go
+++ b/pkg/apiserver/rest/dualwriter_mode1.go
@@ -7,6 +7,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apiserver/pkg/registry/rest"
+	"k8s.io/klog/v2"
 )
 
 type DualWriterMode1 struct {
@@ -23,8 +24,9 @@ func NewDualWriterMode1(legacy LegacyStorage, storage Storage) *DualWriterMode1 
 func (d *DualWriterMode1) Create(ctx context.Context, obj runtime.Object, createValidation rest.ValidateObjectFunc, options *metav1.CreateOptions) (runtime.Object, error) {
 	legacy, ok := d.Legacy.(rest.Creater)
 	if !ok {
-		d.Log.Error("legacy storage rest.Creater is missing", ctx)
-		return nil, errors.New("legacy storage rest.Creater is missing")
+		err := errors.New("legacy storage rest.Creater is missing")
+		klog.FromContext(ctx).Error(err, "legacy storage rest.Creater is missing")
+		return nil, err
 	}
 
 	return legacy.Create(ctx, obj, createValidation, options)

--- a/pkg/apiserver/rest/dualwriter_mode1.go
+++ b/pkg/apiserver/rest/dualwriter_mode1.go
@@ -14,6 +14,8 @@ type DualWriterMode1 struct {
 	DualWriter
 }
 
+var noCreaterMethod = errors.New("legacy storage rest.Creater is missing")
+
 // NewDualWriterMode1 returns a new DualWriter in mode 1.
 // Mode 1 represents writing to and reading from LegacyStorage.
 func NewDualWriterMode1(legacy LegacyStorage, storage Storage) *DualWriterMode1 {
@@ -24,9 +26,8 @@ func NewDualWriterMode1(legacy LegacyStorage, storage Storage) *DualWriterMode1 
 func (d *DualWriterMode1) Create(ctx context.Context, obj runtime.Object, createValidation rest.ValidateObjectFunc, options *metav1.CreateOptions) (runtime.Object, error) {
 	legacy, ok := d.Legacy.(rest.Creater)
 	if !ok {
-		err := errors.New("legacy storage rest.Creater is missing")
-		klog.FromContext(ctx).Error(err, "unable to create object in legacy storage")
-		return nil, err
+		klog.FromContext(ctx).Error(noCreaterMethod, "legacy storage rest.Creater is missing")
+		return nil, noCreaterMethod
 	}
 
 	return legacy.Create(ctx, obj, createValidation, options)

--- a/pkg/apiserver/rest/dualwriter_mode1.go
+++ b/pkg/apiserver/rest/dualwriter_mode1.go
@@ -21,7 +21,7 @@ func NewDualWriterMode1(legacy LegacyStorage, storage Storage) *DualWriterMode1 
 
 // Create overrides the default behavior of the DualWriter and writes only to LegacyStorage.
 func (d *DualWriterMode1) Create(ctx context.Context, obj runtime.Object, createValidation rest.ValidateObjectFunc, options *metav1.CreateOptions) (runtime.Object, error) {
-	legacy, ok := d.legacy.(rest.Creater)
+	legacy, ok := d.Legacy.(rest.Creater)
 	if !ok {
 		return nil, fmt.Errorf("legacy storage rest.Creater is missing")
 	}

--- a/pkg/apiserver/rest/dualwriter_mode1.go
+++ b/pkg/apiserver/rest/dualwriter_mode1.go
@@ -25,7 +25,7 @@ func (d *DualWriterMode1) Create(ctx context.Context, obj runtime.Object, create
 	legacy, ok := d.Legacy.(rest.Creater)
 	if !ok {
 		err := errors.New("legacy storage rest.Creater is missing")
-		klog.FromContext(ctx).Error(err, "legacy storage rest.Creater is missing")
+		klog.FromContext(ctx).Error(err, "unable to create object in legacy storage")
 		return nil, err
 	}
 

--- a/pkg/apiserver/rest/dualwriter_mode1.go
+++ b/pkg/apiserver/rest/dualwriter_mode1.go
@@ -14,7 +14,7 @@ type DualWriterMode1 struct {
 	DualWriter
 }
 
-var noCreaterMethod = errors.New("legacy storage rest.Creater is missing")
+var errNoCreaterMethod = errors.New("legacy storage rest.Creater is missing")
 
 // NewDualWriterMode1 returns a new DualWriter in mode 1.
 // Mode 1 represents writing to and reading from LegacyStorage.
@@ -26,8 +26,8 @@ func NewDualWriterMode1(legacy LegacyStorage, storage Storage) *DualWriterMode1 
 func (d *DualWriterMode1) Create(ctx context.Context, obj runtime.Object, createValidation rest.ValidateObjectFunc, options *metav1.CreateOptions) (runtime.Object, error) {
 	legacy, ok := d.Legacy.(rest.Creater)
 	if !ok {
-		klog.FromContext(ctx).Error(noCreaterMethod, "legacy storage rest.Creater is missing")
-		return nil, noCreaterMethod
+		klog.FromContext(ctx).Error(errNoCreaterMethod, "legacy storage rest.Creater is missing")
+		return nil, errNoCreaterMethod
 	}
 
 	return legacy.Create(ctx, obj, createValidation, options)

--- a/pkg/apiserver/rest/dualwriter_mode1.go
+++ b/pkg/apiserver/rest/dualwriter_mode1.go
@@ -2,7 +2,7 @@ package rest
 
 import (
 	"context"
-	"fmt"
+	"errors"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -23,7 +23,8 @@ func NewDualWriterMode1(legacy LegacyStorage, storage Storage) *DualWriterMode1 
 func (d *DualWriterMode1) Create(ctx context.Context, obj runtime.Object, createValidation rest.ValidateObjectFunc, options *metav1.CreateOptions) (runtime.Object, error) {
 	legacy, ok := d.Legacy.(rest.Creater)
 	if !ok {
-		return nil, fmt.Errorf("legacy storage rest.Creater is missing")
+		d.Log.Error("legacy storage rest.Creater is missing", ctx)
+		return nil, errors.New("legacy storage rest.Creater is missing")
 	}
 
 	return legacy.Create(ctx, obj, createValidation, options)

--- a/pkg/apiserver/rest/dualwriter_mode2.go
+++ b/pkg/apiserver/rest/dualwriter_mode2.go
@@ -8,6 +8,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apiserver/pkg/registry/rest"
+	"k8s.io/klog/v2"
 )
 
 type DualWriterMode2 struct {
@@ -29,7 +30,7 @@ func (d *DualWriterMode2) Create(ctx context.Context, obj runtime.Object, create
 
 	created, err := legacy.Create(ctx, obj, createValidation, options)
 	if err != nil {
-		d.Log.Error("unable to create object in legacy storage", "error", err, ctx)
+		klog.FromContext(ctx).Error(err, "unable to create object in legacy storage")
 		return created, err
 	}
 
@@ -49,7 +50,7 @@ func (d *DualWriterMode2) Create(ctx context.Context, obj runtime.Object, create
 
 	rsp, err := d.Storage.Create(ctx, c, createValidation, options)
 	if err != nil {
-		d.Log.Error("unable to create object in unified storage", "error", err, "mode", Mode2, ctx)
+		klog.FromContext(ctx).Error(err, "unable to create object in unified storage", "mode", Mode2)
 	}
 	return rsp, err
 }

--- a/pkg/apiserver/rest/dualwriter_mode2.go
+++ b/pkg/apiserver/rest/dualwriter_mode2.go
@@ -23,7 +23,7 @@ func NewDualWriterMode2(legacy LegacyStorage, storage Storage) *DualWriterMode2 
 
 // Create overrides the default behavior of the DualWriter and writes to LegacyStorage and Storage.
 func (d *DualWriterMode2) Create(ctx context.Context, obj runtime.Object, createValidation rest.ValidateObjectFunc, options *metav1.CreateOptions) (runtime.Object, error) {
-	legacy, ok := d.legacy.(rest.Creater)
+	legacy, ok := d.Legacy.(rest.Creater)
 	if !ok {
 		return nil, fmt.Errorf("legacy storage rest.Creater is missing")
 	}

--- a/pkg/apiserver/rest/dualwriter_mode2.go
+++ b/pkg/apiserver/rest/dualwriter_mode2.go
@@ -50,7 +50,7 @@ func (d *DualWriterMode2) Create(ctx context.Context, obj runtime.Object, create
 
 	rsp, err := d.Storage.Create(ctx, c, createValidation, options)
 	if err != nil {
-		klog.FromContext(ctx).Error(err, "unable to create object in unified storage", "mode", Mode2)
+		klog.FromContext(ctx).Error(err, "unable to create object in Storage", "mode", 2)
 	}
 	return rsp, err
 }

--- a/pkg/apiserver/rest/dualwriter_mode2.go
+++ b/pkg/apiserver/rest/dualwriter_mode2.go
@@ -30,7 +30,7 @@ func (d *DualWriterMode2) Create(ctx context.Context, obj runtime.Object, create
 
 	created, err := legacy.Create(ctx, obj, createValidation, options)
 	if err != nil {
-		klog.FromContext(ctx).Error(err, "unable to create object in legacy storage")
+		klog.FromContext(ctx).Error(err, "unable to create object in legacy storage", "mode", 2)
 		return created, err
 	}
 

--- a/pkg/apiserver/rest/dualwriter_mode3.go
+++ b/pkg/apiserver/rest/dualwriter_mode3.go
@@ -29,7 +29,7 @@ func (d *DualWriterMode3) Create(ctx context.Context, obj runtime.Object, create
 
 	created, err := d.Storage.Create(ctx, obj, createValidation, options)
 	if err != nil {
-		klog.FromContext(ctx).Error(err, "unable to create object in unified storage", "mode", Mode3)
+		klog.FromContext(ctx).Error(err, "unable to create object in Storage", "mode", 3)
 		return created, err
 	}
 

--- a/pkg/apiserver/rest/dualwriter_mode3.go
+++ b/pkg/apiserver/rest/dualwriter_mode3.go
@@ -7,6 +7,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apiserver/pkg/registry/rest"
+	"k8s.io/klog/v2"
 )
 
 type DualWriterMode3 struct {
@@ -28,12 +29,12 @@ func (d *DualWriterMode3) Create(ctx context.Context, obj runtime.Object, create
 
 	created, err := d.Storage.Create(ctx, obj, createValidation, options)
 	if err != nil {
-		d.Log.Error("unable to create object in unified storage", "error", err, "mode", Mode3, ctx)
+		klog.FromContext(ctx).Error(err, "unable to create object in unified storage", "mode", Mode3)
 		return created, err
 	}
 
 	if _, err := legacy.Create(ctx, obj, createValidation, options); err != nil {
-		d.Log.Error("unable to create object in legacy storage", "error", err)
+		klog.FromContext(ctx).Error(err, "unable to create object in legacy storage")
 	}
 	return created, nil
 }

--- a/pkg/apiserver/rest/dualwriter_mode3.go
+++ b/pkg/apiserver/rest/dualwriter_mode3.go
@@ -22,7 +22,7 @@ func NewDualWriterMode3(legacy LegacyStorage, storage Storage) *DualWriterMode3 
 
 // Create overrides the default behavior of the DualWriter and writes to LegacyStorage and Storage.
 func (d *DualWriterMode3) Create(ctx context.Context, obj runtime.Object, createValidation rest.ValidateObjectFunc, options *metav1.CreateOptions) (runtime.Object, error) {
-	legacy, ok := d.legacy.(rest.Creater)
+	legacy, ok := d.Legacy.(rest.Creater)
 	if !ok {
 		return nil, fmt.Errorf("legacy storage rest.Creater is missing")
 	}

--- a/pkg/apiserver/rest/dualwriter_mode3.go
+++ b/pkg/apiserver/rest/dualwriter_mode3.go
@@ -7,7 +7,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apiserver/pkg/registry/rest"
-	"k8s.io/klog"
 )
 
 type DualWriterMode3 struct {
@@ -29,11 +28,12 @@ func (d *DualWriterMode3) Create(ctx context.Context, obj runtime.Object, create
 
 	created, err := d.Storage.Create(ctx, obj, createValidation, options)
 	if err != nil {
+		d.Log.Error("unable to create object in unified storage", "error", err, "mode", Mode3, ctx)
 		return created, err
 	}
 
 	if _, err := legacy.Create(ctx, obj, createValidation, options); err != nil {
-		klog.Error("unable to create object in legacy storage", "error", err)
+		d.Log.Error("unable to create object in legacy storage", "error", err)
 	}
 	return created, nil
 }

--- a/pkg/apiserver/rest/dualwriter_mode3.go
+++ b/pkg/apiserver/rest/dualwriter_mode3.go
@@ -34,7 +34,7 @@ func (d *DualWriterMode3) Create(ctx context.Context, obj runtime.Object, create
 	}
 
 	if _, err := legacy.Create(ctx, obj, createValidation, options); err != nil {
-		klog.FromContext(ctx).Error(err, "unable to create object in legacy storage")
+		klog.FromContext(ctx).Error(err, "unable to create object in legacy storage", "mode", 3)
 	}
 	return created, nil
 }


### PR DESCRIPTION
**What is this feature?**

Use a better log for the dual writer.

**Why do we need this feature?**

Besides more verbose and support for key-value logs, it allows for the context to be passes, which makes troubleshooting easier.

**Which issue(s) does this PR fix?**:

Relates to https://github.com/grafana/search-and-storage-team/issues/17

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle.
- [x] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
