### PR TITLE
datatrails: fix: clear undefined query params on history step change

### DIFF
--- a/public/app/features/trails/DataTrail.test.tsx
+++ b/public/app/features/trails/DataTrail.test.tsx
@@ -130,5 +130,19 @@ describe('DataTrail', () => {
         });
       });
     });
+    describe('When going back to history step 0', () => {
+      beforeEach(() => {
+        trail.publishEvent(new MetricSelectedEvent('first_metric'));
+        trail.publishEvent(new MetricSelectedEvent('second_metric'));
+        trail.state.history.goBackToStep(0);
+      });
+
+      it('Should remove metric from state and url', () => {
+        expect(trail.state.metric).toBe(undefined);
+
+        expect(locationService.getSearchObject().metric).toBe(undefined);
+        expect(locationService.getSearch().has('metric')).toBe(false);
+      });
+    });
   });
 });

--- a/public/app/features/trails/DataTrail.tsx
+++ b/public/app/features/trails/DataTrail.tsx
@@ -153,6 +153,11 @@ export class DataTrail extends SceneObjectBase<DataTrailState> {
       return;
     }
     const urlState = getUrlSyncManager().getUrlState(this);
+
+    // Clear the search
+    const location = locationService.getLocation();
+    locationService.replace({ ...location, search: '' });
+    // Replace the search with the new current urlState
     locationService.partial(urlState, true);
   }
 

--- a/public/app/features/trails/DataTrail.tsx
+++ b/public/app/features/trails/DataTrail.tsx
@@ -1,7 +1,7 @@
 import { css } from '@emotion/css';
 import React from 'react';
 
-import { AdHocVariableFilter, GrafanaTheme2, VariableHide } from '@grafana/data';
+import { AdHocVariableFilter, GrafanaTheme2, VariableHide, urlUtil } from '@grafana/data';
 import { locationService } from '@grafana/runtime';
 import {
   AdHocFiltersVariable,
@@ -152,13 +152,11 @@ export class DataTrail extends SceneObjectBase<DataTrailState> {
       // Embedded trails should not be altering the URL
       return;
     }
-    const urlState = getUrlSyncManager().getUrlState(this);
 
-    // Clear the search
-    const location = locationService.getLocation();
-    locationService.replace({ ...location, search: '' });
-    // Replace the search with the new current urlState
-    locationService.partial(urlState, true);
+    const urlState = getUrlSyncManager().getUrlState(this);
+    const fullUrl = urlUtil.renderUrl(locationService.getLocation().pathname, urlState);
+
+    locationService.replace(fullUrl);
   }
 
   private _handleMetricSelectedEvent(evt: MetricSelectedEvent) {

--- a/public/app/features/trails/DataTrail.tsx
+++ b/public/app/features/trails/DataTrail.tsx
@@ -156,7 +156,7 @@ export class DataTrail extends SceneObjectBase<DataTrailState> {
     const urlState = getUrlSyncManager().getUrlState(this);
     const fullUrl = urlUtil.renderUrl(locationService.getLocation().pathname, urlState);
 
-    locationService.replace(fullUrl);
+    locationService.replace(encodeURI(fullUrl));
   }
 
   private _handleMetricSelectedEvent(evt: MetricSelectedEvent) {


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->


Reported bug:
> URL state bug
> - Select a metric
> - Use history trail to go back to select metric view
> - Url is not updated so if I reload the page I get back the metric I had previously selected (and not the select metric view)

Changing step to where metric was `undefined` did not remove `metric` from the url query parameter list due to how the `partial` function works. This PR clears the query before applying `partial`, cleaning the URL query of all undefined params.

This resolves the bug as reported, and will resolve future bugs related to undefined state values not updating in the URL on step change.

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
