### PR TITLE
[v10.4.x] Canvas: Infinite Pan Backport

### DIFF
--- a/docs/sources/developers/kinds/composable/canvas/panelcfg/schema-reference.md
+++ b/docs/sources/developers/kinds/composable/canvas/panelcfg/schema-reference.md
@@ -141,6 +141,7 @@ It extends [BaseDimensionConfig](#basedimensionconfig).
 
 | Property            | Type            | Required | Default | Description                                                                                                                          |
 |---------------------|-----------------|----------|---------|--------------------------------------------------------------------------------------------------------------------------------------|
+| `infinitePan`       | boolean         | **Yes**  | `true`  | Enable infinite pan                                                                                                                  |
 | `inlineEditing`     | boolean         | **Yes**  | `true`  | Enable inline editing                                                                                                                |
 | `panZoom`           | boolean         | **Yes**  | `true`  | Enable pan and zoom                                                                                                                  |
 | `root`              | [object](#root) | **Yes**  |         | The root element of canvas (frame), where all canvas elements are nested<br/>TODO: Figure out how to define a default value for this |

--- a/packages/grafana-schema/src/raw/composable/canvas/panelcfg/x/CanvasPanelCfg_types.gen.ts
+++ b/packages/grafana-schema/src/raw/composable/canvas/panelcfg/x/CanvasPanelCfg_types.gen.ts
@@ -106,6 +106,10 @@ export const defaultCanvasElementOptions: Partial<CanvasElementOptions> = {
 
 export interface Options {
   /**
+   * Enable infinite pan
+   */
+  infinitePan: boolean;
+  /**
    * Enable inline editing
    */
   inlineEditing: boolean;
@@ -138,6 +142,7 @@ export interface Options {
 }
 
 export const defaultOptions: Partial<Options> = {
+  infinitePan: true,
   inlineEditing: true,
   panZoom: true,
   showAdvancedTypes: true,

--- a/public/app/features/canvas/runtime/SceneTransformWrapper.tsx
+++ b/public/app/features/canvas/runtime/SceneTransformWrapper.tsx
@@ -14,12 +14,40 @@ export const SceneTransformWrapper = ({ scene, children: sceneDiv }: SceneTransf
   const onZoom = (zoomPanPinchRef: ReactZoomPanPinchRef) => {
     const scale = zoomPanPinchRef.state.scale;
     scene.scale = scale;
+
+    if (scene.shouldInfinitePan) {
+      const isScaleZoomedOut = scale < 1;
+
+      if (isScaleZoomedOut) {
+        scene.updateSize(scene.width / scale, scene.height / scale);
+        scene.panel.forceUpdate();
+      }
+    }
   };
 
   const onZoomStop = (zoomPanPinchRef: ReactZoomPanPinchRef) => {
     const scale = zoomPanPinchRef.state.scale;
     scene.scale = scale;
     updateMoveable(scale);
+  };
+
+  const onPanning = (_: ReactZoomPanPinchRef, event: MouseEvent | TouchEvent) => {
+    if (scene.shouldInfinitePan && event instanceof MouseEvent) {
+      // Get deltaX and deltaY from pan event and add it to current canvas dimensions
+      let deltaX = event.movementX;
+      let deltaY = event.movementY;
+      if (deltaX > 0) {
+        deltaX = 0;
+      }
+      if (deltaY > 0) {
+        deltaY = 0;
+      }
+
+      // TODO: Consider bounding to the scene elements instead of allowing "infinite" panning
+      // TODO: Consider making scene grow in all directions vs just down to the right / bottom
+      scene.updateSize(scene.width - deltaX, scene.height - deltaY);
+      scene.panel.forceUpdate();
+    }
   };
 
   const onTransformed = (
@@ -60,6 +88,9 @@ export const SceneTransformWrapper = ({ scene, children: sceneDiv }: SceneTransf
     }
   };
 
+  // Set panel content overflow to hidden to prevent canvas content from overflowing
+  scene.div?.parentElement?.parentElement?.parentElement?.parentElement?.setAttribute('style', `overflow: hidden`);
+
   return (
     <TransformWrapper
       doubleClick={{ mode: 'reset' }}
@@ -67,9 +98,11 @@ export const SceneTransformWrapper = ({ scene, children: sceneDiv }: SceneTransf
       onZoom={onZoom}
       onZoomStop={onZoomStop}
       onTransformed={onTransformed}
-      limitToBounds={true}
       disabled={!config.featureToggles.canvasPanelPanZoom || !scene.shouldPanZoom}
       panning={{ allowLeftClickPan: false }}
+      limitToBounds={!scene.shouldInfinitePan}
+      minScale={scene.shouldInfinitePan ? 0.1 : undefined}
+      onPanning={onPanning}
     >
       <TransformComponent>
         {/* The <div> element has child elements that allow for mouse events, so we need to disable the linter rule */}

--- a/public/app/features/canvas/runtime/scene.tsx
+++ b/public/app/features/canvas/runtime/scene.tsx
@@ -71,6 +71,7 @@ export class Scene {
   isEditingEnabled?: boolean;
   shouldShowAdvancedTypes?: boolean;
   shouldPanZoom?: boolean;
+  shouldInfinitePan?: boolean;
   skipNextSelectionBroadcast = false;
   ignoreDataUpdate = false;
   panel: CanvasPanel;
@@ -108,10 +109,11 @@ export class Scene {
     enableEditing: boolean,
     showAdvancedTypes: boolean,
     panZoom: boolean,
+    infinitePan: boolean,
     public onSave: (cfg: CanvasFrameOptions) => void,
     panel: CanvasPanel
   ) {
-    this.root = this.load(cfg, enableEditing, showAdvancedTypes, panZoom);
+    this.root = this.load(cfg, enableEditing, showAdvancedTypes, panZoom, infinitePan);
 
     this.subscription = this.editModeEnabled.subscribe((open) => {
       if (!this.moveable || !this.isEditingEnabled) {
@@ -144,7 +146,13 @@ export class Scene {
     return !this.byName.has(v);
   };
 
-  load(cfg: CanvasFrameOptions, enableEditing: boolean, showAdvancedTypes: boolean, panZoom: boolean) {
+  load(
+    cfg: CanvasFrameOptions,
+    enableEditing: boolean,
+    showAdvancedTypes: boolean,
+    panZoom: boolean,
+    infinitePan: boolean
+  ) {
     this.root = new RootElement(
       cfg ?? {
         type: 'frame',
@@ -157,6 +165,7 @@ export class Scene {
     this.isEditingEnabled = enableEditing;
     this.shouldShowAdvancedTypes = showAdvancedTypes;
     this.shouldPanZoom = panZoom;
+    this.shouldInfinitePan = infinitePan;
 
     setTimeout(() => {
       if (this.div) {

--- a/public/app/plugins/panel/canvas/CanvasPanel.tsx
+++ b/public/app/plugins/panel/canvas/CanvasPanel.tsx
@@ -68,6 +68,7 @@ export class CanvasPanel extends Component<Props, State> {
       this.props.options.inlineEditing,
       this.props.options.showAdvancedTypes,
       this.props.options.panZoom,
+      this.props.options.infinitePan,
       this.onUpdateScene,
       this
     );
@@ -229,7 +230,14 @@ export class CanvasPanel extends Component<Props, State> {
     const shouldShowAdvancedTypesSwitched =
       this.props.options.showAdvancedTypes !== nextProps.options.showAdvancedTypes;
     const panZoomSwitched = this.props.options.panZoom !== nextProps.options.panZoom;
-    if (this.needsReload || inlineEditingSwitched || shouldShowAdvancedTypesSwitched || panZoomSwitched) {
+    const infinitePanSwitched = this.props.options.infinitePan !== nextProps.options.infinitePan;
+    if (
+      this.needsReload ||
+      inlineEditingSwitched ||
+      shouldShowAdvancedTypesSwitched ||
+      panZoomSwitched ||
+      infinitePanSwitched
+    ) {
       if (inlineEditingSwitched) {
         // Replace scene div to prevent selecto instance leaks
         this.scene.revId++;
@@ -240,7 +248,8 @@ export class CanvasPanel extends Component<Props, State> {
         nextProps.options.root,
         nextProps.options.inlineEditing,
         nextProps.options.showAdvancedTypes,
-        nextProps.options.panZoom
+        nextProps.options.panZoom,
+        nextProps.options.infinitePan
       );
       this.scene.updateSize(nextProps.width, nextProps.height);
       this.scene.updateData(nextProps.data);

--- a/public/app/plugins/panel/canvas/module.tsx
+++ b/public/app/plugins/panel/canvas/module.tsx
@@ -39,6 +39,14 @@ export const addStandardCanvasEditorOptions = (builder: PanelOptionsEditorBuilde
     editor: PanZoomHelp,
     showIf: (opts) => config.featureToggles.canvasPanelPanZoom && opts.panZoom,
   });
+  builder.addBooleanSwitch({
+    path: 'infinitePan',
+    name: 'Infinite panning',
+    description:
+      'Enable infinite panning - useful for expansive canvases. Warning: this an experimental feature and currently only works well with elements that are top / left constrained',
+    defaultValue: false,
+    showIf: (opts) => config.featureToggles.canvasPanelPanZoom && opts.panZoom,
+  });
 };
 
 export const plugin = new PanelPlugin<Options>(CanvasPanel)

--- a/public/app/plugins/panel/canvas/panelcfg.cue
+++ b/public/app/plugins/panel/canvas/panelcfg.cue
@@ -90,6 +90,8 @@ composableKinds: PanelCfg: {
 					showAdvancedTypes: bool | *true
 					// Enable pan and zoom
 					panZoom: bool | *true
+					// Enable infinite pan
+					infinitePan: bool | *true
 					// The root element of canvas (frame), where all canvas elements are nested
 					// TODO: Figure out how to define a default value for this
 					root: {

--- a/public/app/plugins/panel/canvas/panelcfg.gen.ts
+++ b/public/app/plugins/panel/canvas/panelcfg.gen.ts
@@ -103,6 +103,10 @@ export const defaultCanvasElementOptions: Partial<CanvasElementOptions> = {
 
 export interface Options {
   /**
+   * Enable infinite pan
+   */
+  infinitePan: boolean;
+  /**
    * Enable inline editing
    */
   inlineEditing: boolean;
@@ -135,6 +139,7 @@ export interface Options {
 }
 
 export const defaultOptions: Partial<Options> = {
+  infinitePan: true,
   inlineEditing: true,
   panZoom: true,
   showAdvancedTypes: true,


### PR DESCRIPTION
Backport into v10.4.x from https://github.com/grafana/grafana/pull/84968.

Adds option for infinitePan when panZoom is enabled in Canvas.