### PR TITLE
Alerting: Return better error for invalid time range on alert queries

### DIFF
--- a/pkg/services/ngalert/api/api_provisioning.go
+++ b/pkg/services/ngalert/api/api_provisioning.go
@@ -488,10 +488,10 @@ func (srv *ProvisioningSrv) RoutePutAlertRuleGroup(c *contextmodel.ReqContext, a
 	if errors.Is(err, alerting_models.ErrAlertRuleFailedValidation) {
 		return ErrResp(http.StatusBadRequest, err, "")
 	}
+	if errors.Is(err, store.ErrOptimisticLock) {
+		return ErrResp(http.StatusConflict, err, "")
+	}
 	if err != nil {
-		if errors.Is(err, store.ErrOptimisticLock) {
-			return ErrResp(http.StatusConflict, err, "")
-		}
 		return response.ErrOrFallback(http.StatusInternalServerError, "", err)
 	}
 	return response.JSON(http.StatusOK, ag)

--- a/pkg/services/ngalert/models/alert_query.go
+++ b/pkg/services/ngalert/models/alert_query.go
@@ -303,7 +303,8 @@ func (aq *AlertQuery) PreSave() error {
 	}
 
 	if ok := isExpression || aq.RelativeTimeRange.isValid(); !ok {
-		return fmt.Errorf("invalid relative time range: %+v", aq.RelativeTimeRange)
+		// return fmt.Errorf("invalid relative time range: %+v", aq.RelativeTimeRange)
+		return ErrInvalidRelativeTimeRange(aq.RefID, aq.RelativeTimeRange)
 	}
 	return nil
 }

--- a/pkg/services/ngalert/models/alert_query.go
+++ b/pkg/services/ngalert/models/alert_query.go
@@ -303,7 +303,6 @@ func (aq *AlertQuery) PreSave() error {
 	}
 
 	if ok := isExpression || aq.RelativeTimeRange.isValid(); !ok {
-		// return fmt.Errorf("invalid relative time range: %+v", aq.RelativeTimeRange)
 		return ErrInvalidRelativeTimeRange(aq.RefID, aq.RelativeTimeRange)
 	}
 	return nil

--- a/pkg/services/ngalert/models/errors.go
+++ b/pkg/services/ngalert/models/errors.go
@@ -8,9 +8,14 @@ var (
 	errAlertRuleConflictMsg  = "conflicting alert rule found [rule_uid: '{{ .Public.RuleUID }}', title: '{{ .Public.Title }}', namespace_uid: '{{ .Public.NamespaceUID }}']: {{ .Public.Error }}"
 	ErrAlertRuleConflictBase = errutil.Conflict("alerting.alert-rule.conflict").
 					MustTemplate(errAlertRuleConflictMsg, errutil.WithPublic(errAlertRuleConflictMsg))
-	ErrAlertRuleGroupNotFound = errutil.NotFound("alerting.alert-rule.notFound")
+	ErrAlertRuleGroupNotFound       = errutil.NotFound("alerting.alert-rule.notFound")
+	ErrInvalidRelativeTimeRangeBase = errutil.BadRequest("alerting.alert-rule.invalidRelativeTime").MustTemplate("Invalid alert rule query {{ .Public.RefID }}: invalid relative time range [From: {{ .Public.From }}, To: {{ .Public.To }}]")
 )
 
 func ErrAlertRuleConflict(rule AlertRule, underlying error) error {
 	return ErrAlertRuleConflictBase.Build(errutil.TemplateData{Public: map[string]any{"RuleUID": rule.UID, "Title": rule.Title, "NamespaceUID": rule.NamespaceUID, "Error": underlying.Error()}, Error: underlying})
+}
+
+func ErrInvalidRelativeTimeRange(refID string, rtr RelativeTimeRange) error {
+	return ErrInvalidRelativeTimeRangeBase.Build(errutil.TemplateData{Public: map[string]any{"RefID": refID, "From": rtr.From, "To": rtr.To}})
 }


### PR DESCRIPTION
**What is this feature?**

For all APIs, using a bad time range on a query block yields a very nondescript error `"message":"Internal Server Error"`.

Fix the status code to 400 and return a more clear errutil-style error instead.

**Who is this feature for?**

Clients trying to troubleshoot their queries.

**Which issue(s) does this PR fix?**:
n/a

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle.
- [x] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
