### PR TITLE
Fixes #81465: Exclude-null now it's getting initialized properly by default

### DIFF
--- a/public/app/features/transformers/FilterByValueTransformer/FilterByValueTransformerEditor.test.tsx
+++ b/public/app/features/transformers/FilterByValueTransformer/FilterByValueTransformerEditor.test.tsx
@@ -7,7 +7,7 @@ import { FilterByValueMatch, FilterByValueType } from '@grafana/data/src/transfo
 import { FilterByValueTransformerEditor } from './FilterByValueTransformerEditor';
 
 describe('FilterByValueTransformerEditor', () => {
-  it('adds a filter with default isNull option when onAddFilter is called', () => {
+  it('correctly applies the default isNull option when onAddFilter is first called', () => {
     // Mock onChange function
     const onChangeMock = jest.fn();
 

--- a/public/app/features/transformers/FilterByValueTransformer/FilterByValueTransformerEditor.test.tsx
+++ b/public/app/features/transformers/FilterByValueTransformer/FilterByValueTransformerEditor.test.tsx
@@ -1,0 +1,55 @@
+import React from 'react';
+import { render, fireEvent} from '@testing-library/react';
+import { FilterByValueTransformerEditor } from './FilterByValueTransformerEditor';
+import {DataFrame, FieldType, ValueMatcherID, valueMatchers} from "@grafana/data";
+import {FilterByValueMatch, FilterByValueType} from "@grafana/data/src/transformations/transformers/filterByValue";
+
+describe('FilterByValueTransformerEditor', () => {
+  it('adds a filter with default isNull option when onAddFilter is called', () => {
+    // Mock onChange function
+    const onChangeMock = jest.fn();
+
+    // Mock options
+    const options = {
+      type: FilterByValueType.include,
+      match: FilterByValueMatch.all,
+      filters: [],
+    };
+
+    // Mock input
+    const input: DataFrame[] = [
+      {
+        fields: [
+          { name: 'person', type: FieldType.string, config: { displayName: 'Person' }, values: ['john', 'jill', 'jeremy', ''] },
+          { name: 'city', type: FieldType.string, config: { displayName: 'City' }, values: ['london', 'budapest', '', 'lisbon'] }
+        ],
+        length: 4
+      }
+    ];
+
+    // Render the component
+    const { getByText } = render(
+      <FilterByValueTransformerEditor input={input} options={options} onChange={onChangeMock} />
+    );
+
+    // Find and click the "Add condition" button
+    fireEvent.click(getByText('Add condition'));
+
+    // Check if onChange was called with the correct filter
+    expect(onChangeMock).toHaveBeenCalledWith({
+      filters: [
+        {
+          fieldName: 'Person',
+          config: {
+            id: ValueMatcherID.isNull,
+            options: valueMatchers.get(ValueMatcherID.isNull).getDefaultOptions(
+              { name: 'person', type: FieldType.string, config: { displayName: 'Person' }, values: ['john', 'jill', 'jeremy', ''] }
+            ),
+          },
+        },
+      ],
+      match: FilterByValueMatch.all,
+      type: FilterByValueType.include,
+    });
+  });
+});

--- a/public/app/features/transformers/FilterByValueTransformer/FilterByValueTransformerEditor.test.tsx
+++ b/public/app/features/transformers/FilterByValueTransformer/FilterByValueTransformerEditor.test.tsx
@@ -1,8 +1,10 @@
+import { render, fireEvent } from '@testing-library/react';
 import React from 'react';
-import { render, fireEvent} from '@testing-library/react';
+
+import { DataFrame, FieldType, ValueMatcherID, valueMatchers } from '@grafana/data';
+import { FilterByValueMatch, FilterByValueType } from '@grafana/data/src/transformations/transformers/filterByValue';
+
 import { FilterByValueTransformerEditor } from './FilterByValueTransformerEditor';
-import {DataFrame, FieldType, ValueMatcherID, valueMatchers} from "@grafana/data";
-import {FilterByValueMatch, FilterByValueType} from "@grafana/data/src/transformations/transformers/filterByValue";
 
 describe('FilterByValueTransformerEditor', () => {
   it('adds a filter with default isNull option when onAddFilter is called', () => {
@@ -20,11 +22,21 @@ describe('FilterByValueTransformerEditor', () => {
     const input: DataFrame[] = [
       {
         fields: [
-          { name: 'person', type: FieldType.string, config: { displayName: 'Person' }, values: ['john', 'jill', 'jeremy', ''] },
-          { name: 'city', type: FieldType.string, config: { displayName: 'City' }, values: ['london', 'budapest', '', 'lisbon'] }
+          {
+            name: 'person',
+            type: FieldType.string,
+            config: { displayName: 'Person' },
+            values: ['john', 'jill', 'jeremy', ''],
+          },
+          {
+            name: 'city',
+            type: FieldType.string,
+            config: { displayName: 'City' },
+            values: ['london', 'budapest', '', 'lisbon'],
+          },
         ],
-        length: 4
-      }
+        length: 4,
+      },
     ];
 
     // Render the component
@@ -42,9 +54,12 @@ describe('FilterByValueTransformerEditor', () => {
           fieldName: 'Person',
           config: {
             id: ValueMatcherID.isNull,
-            options: valueMatchers.get(ValueMatcherID.isNull).getDefaultOptions(
-              { name: 'person', type: FieldType.string, config: { displayName: 'Person' }, values: ['john', 'jill', 'jeremy', ''] }
-            ),
+            options: valueMatchers.get(ValueMatcherID.isNull).getDefaultOptions({
+              name: 'person',
+              type: FieldType.string,
+              config: { displayName: 'Person' },
+              values: ['john', 'jill', 'jeremy', ''],
+            }),
           },
         },
       ],

--- a/public/app/features/transformers/FilterByValueTransformer/FilterByValueTransformerEditor.tsx
+++ b/public/app/features/transformers/FilterByValueTransformer/FilterByValueTransformerEditor.tsx
@@ -49,7 +49,7 @@ export const FilterByValueTransformerEditor = (props: TransformerUIProps<FilterB
     }
 
     const filters = cloneDeep(options.filters);
-    const matcher = valueMatchers.get(ValueMatcherID.greater);
+    const matcher = valueMatchers.get(ValueMatcherID.isNull);
 
     filters.push({
       fieldName: getFieldDisplayName(field, frame, input),


### PR DESCRIPTION
**What is this feature?**

This is a fix to a bug that happens when a add condition is made in the Filter-by-Value transformation. The bug exists because the default filter condition that is visually selected doesn't match the actual condition in the program. The bug fix simply consists in changing the default filter in the FilterByValueTransformerEditor.tsx from greater to isNull. To confirm this fix, I tested it in a new file named FilterByValueTransformerEditor.test.tsx.

**Why do we need this feature?**

This change is necessary because, when a new condition is added to the transformation Filter-by-Value in a dashboard table, the values filtered with the default condition in the old version of the program are according to a different filter that's visually selected to the user, which can be a bit confusing. This forces the user to update the filter to use the functionality without it's visually wrong, which shouldn't be necessary. 

**Who is this feature for?**

This change is useful for the users that use the transformation Filter-by-Values, since every single time a condition is added the bug happens.

**Which issue(s) does this PR fix?**:

Fixes #81465

**Special notes for your reviewer:**

I'm not entirely sure if the test location is appropriate, but I place it in the same folder as the file I changed because there are a lot of test files that follows this pattern as well.