### PR TITLE
Annotations: Fix annotation title

### DIFF
--- a/.betterer.results
+++ b/.betterer.results
@@ -1485,7 +1485,8 @@ exports[`better eslint`] = {
       [0, 0, 0, "Unexpected any. Specify a different type.", "0"],
       [0, 0, 0, "Unexpected any. Specify a different type.", "1"],
       [0, 0, 0, "Do not use any type assertions.", "2"],
-      [0, 0, 0, "Unexpected any. Specify a different type.", "3"]
+      [0, 0, 0, "Unexpected any. Specify a different type.", "3"],
+      [0, 0, 0, "Unexpected any. Specify a different type.", "4"]
     ],
     "public/app/features/alerting/state/query_part.ts:5381": [
       [0, 0, 0, "Unexpected any. Specify a different type.", "0"],

--- a/public/app/features/alerting/state/alertDef.ts
+++ b/public/app/features/alerting/state/alertDef.ts
@@ -207,6 +207,25 @@ function getAlertAnnotationInfo(ah: any) {
   return '';
 }
 
+// Copy of getAlertAnnotationInfo, used in annotation tooltip
+function getAlertAnnotationText(annotationData: any) {
+  // backward compatibility, can be removed in grafana 5.x
+  // old way stored evalMatches in data property directly,
+  // new way stores it in evalMatches property on new data object
+
+  if (isArray(annotationData)) {
+    return joinEvalMatches(annotationData, ', ');
+  } else if (isArray(annotationData.evalMatches)) {
+    return joinEvalMatches(annotationData.evalMatches, ', ');
+  }
+
+  if (annotationData.error) {
+    return 'Error: ' + annotationData.error;
+  }
+
+  return '';
+}
+
 export default {
   alertQueryDef: alertQueryDef,
   getStateDisplayModel: getStateDisplayModel,
@@ -218,5 +237,6 @@ export default {
   reducerTypes: reducerTypes,
   createReducerPart: createReducerPart,
   getAlertAnnotationInfo: getAlertAnnotationInfo,
+  getAlertAnnotationText: getAlertAnnotationText,
   alertStateSortScore: alertStateSortScore,
 };

--- a/public/app/plugins/panel/timeseries/plugins/annotations2/AnnotationTooltip2.tsx
+++ b/public/app/plugins/panel/timeseries/plugins/annotations2/AnnotationTooltip2.tsx
@@ -56,7 +56,7 @@ export const AnnotationTooltip2 = ({ annoVals, annoIdx, timeZone, onEdit }: Prop
 
     // alertText = alertDef.getAlertAnnotationInfo(annotation); // @TODO ??
   } else if (annoVals.title?.[annoIdx]) {
-    text = annoVals.title[annoIdx] + text ? `<br />${text}` : '';
+    text = annoVals.title[annoIdx] + (text ? `<br />${text}` : '');
   }
 
   return (

--- a/public/app/plugins/panel/timeseries/plugins/annotations2/AnnotationTooltip2.tsx
+++ b/public/app/plugins/panel/timeseries/plugins/annotations2/AnnotationTooltip2.tsx
@@ -54,7 +54,7 @@ export const AnnotationTooltip2 = ({ annoVals, annoIdx, timeZone, onEdit }: Prop
       </div>
     );
 
-    // alertText = alertDef.getAlertAnnotationInfo(annotation); // @TODO ??
+    alertText = annoVals.data?.[annoIdx] ? alertDef.getAlertAnnotationText(annoVals.data[annoIdx]) : '';
   } else if (annoVals.title?.[annoIdx]) {
     text = annoVals.title[annoIdx] + (text ? `<br />${text}` : '');
   }


### PR DESCRIPTION
- Fixes annotation title
- Updates alert text



**Special notes for your reviewer:**
- duplicated `getAlertAnnotationInfo` function as it's being used by Graph

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
