### PR TITLE
Grafana E2E: Add deprecation notice and update docs

### DIFF
--- a/contribute/developer-guide.md
+++ b/contribute/developer-guide.md
@@ -172,7 +172,7 @@ make test-go-integration-postgres
 
 ### Run end-to-end tests
 
-The end to end tests in Grafana use [Cypress](https://www.cypress.io/) and [Playwright](https://playwright.dev/) to run automated scripts in a browser. Read more about our Cypress [e2e framework](/contribute/style-guides/e2e.md).
+Grafana uses [Cypress](https://www.cypress.io/) to end-to-end test core features. Core plugins use [Playwright](https://playwright.dev/) to run automated end-to-end tests. You can find more information on how to add end-to-end tests to your core plugin [here](./style-guides/e2e-plugins.md)
 
 #### Running Cypress tests
 

--- a/contribute/style-guides/e2e-core.md
+++ b/contribute/style-guides/e2e-core.md
@@ -22,4 +22,4 @@ The above commands use some utils scripts under [_\<repo-root>/e2e_](../../e2e) 
 
 ## Test suites
 
-All the integration tests are located at _\<repo-root>/e2e/suite\<x>/specs_. The page objects and reusable flows are in the [_\<repo-root>/packages/grafana-e2e_](../../packages/grafana-e2e) package.
+All the integration tests are located at _\<repo-root>/e2e/suite\<x>/specs_.

--- a/contribute/style-guides/e2e-plugins.md
+++ b/contribute/style-guides/e2e-plugins.md
@@ -1,28 +1,35 @@
-# End-to-End Tests for plugins
+# end-to-end tests for plugins
 
-Be sure that you've read the [generalized E2E document](e2e.md).
+When end-to-end testing Grafana plugins, it's recommended to use the [`@grafana/plugin-e2e`](https://www.npmjs.com/package/@grafana/plugin-e2e?activeTab=readme) testing tool. `@grafana/plugin-e2e` extends [`@playwright/test`](https://playwright.dev/) capabilities with relevant fixtures, models, and expect matchers; enabling comprehensive end-to-end testing of Grafana plugins across multiple versions of Grafana. For information on how to get started with Plugin end-to-end testing and Playwright, checkout the [Get started](https://grafana.com/developers/plugin-tools/e2e-test-a-plugin/get-started) guide.
+
+## Adding end-to-end tests for a core plugin
+
+Playwright end-to-end tests for plugins should be added to the [`e2e/plugin-e2e`](https://github.com/grafana/grafana/tree/main/e2e/plugin-e2e) directory.
+
+1. Add a new directory that has the name as your plugin [`here`](https://github.com/grafana/grafana/tree/main/e2e/plugin-e2e). This is where your plugin tests will be kept.
+
+2. Playwright uses [projects](https://playwright.dev/docs/test-projects) to logically group tests together. All tests in a project share the same configuration.
+   In the [Playwright config file](https://github.com/grafana/grafana/blob/main/playwright.config.ts), add a new project item. Make sure the `name` and the `testDir` sub directory matches the name of the directory that contains your plugin tests.
+   Adding `'authenticate'` to the list of dependencies and specifying `'playwright/.auth/admin.json'` as storage state will ensure all tests in your project will start already authenticated as an admin user. If you wish to use a different role for and perhaps test RBAC for some of your tests, please refer to the plugin-e2e [documentation](https://grafana.com/developers/plugin-tools/e2e-test-a-plugin/use-authentication).
+
+   ```ts
+   {
+      name: 'mysql',
+      testDir: path.join(testDirRoot, '/mysql'),
+      use: {
+        ...devices['Desktop Chrome'],
+        storageState: 'playwright/.auth/admin.json',
+      },
+      dependencies: ['authenticate'],
+    },
+   ```
+
+3. Update the [CODEOWNERS](https://github.com/grafana/grafana/blob/main/.github/CODEOWNERS/#L315) file so that your team is owner of the tests in the directory you added in step 1.
 
 ## Commands
 
-- `yarn test:e2e` will run [Grafana's E2E utility](../../packages/grafana-e2e) against an already running Grafana server.
-- `yarn test:e2e:update` will run `test:e2e` but instead of asserting that screenshots match their expected fixtures, they'll be replaced with new ones.
+- `yarn e2e:playwright` will run all Playwright tests. Optionally, you can provide the `--project mysql` argument to run tests in a certain project.
 
-Your running Grafana instance can be targeted by setting the `CYPRESS_BASE_URL`, `CYPRESS_USERNAME` and `CYPRESS_PASSWORD` environment variableS:
+The script above assumes you have Grafana running on `localhost:3000`. You may change this by providing environment variables.
 
-```shell
-CYPRESS_BASE_URL=https://localhost:3000 CYPRESS_USERNAME=admin CYPRESS_PASSWORD=admin yarn test:e2e
-```
-
-## Test suites
-
-All tests are located at _\<repo-root>/cypress/integration_ by default.
-
-## Things to test
-
-- Add data source (if applicable)
-- Add panel
-- Edit panel
-- Annotations (if applicable)
-- Aliases (if applicable)
-- Template variables
-- "Explore" view
+`HOST=127.0.0.1 PORT=3001 yarn e2e:playwright`

--- a/contribute/style-guides/e2e.md
+++ b/contribute/style-guides/e2e.md
@@ -1,13 +1,13 @@
 # End-to-End tests
 
-Grafana Labs uses a minimal [homegrown solution](../../packages/grafana-e2e) built on top of [Cypress](https://cypress.io) for its end-to-end (E2E) tests.
+Grafana Labs uses a minimal [homegrown solution](../../e2e/utils/index.ts) built on top of [Cypress](https://cypress.io) for its end-to-end (E2E) tests.
 
 Important notes:
 
 - We generally store all element identifiers ([CSS selectors](https://mdn.io/docs/Web/CSS/CSS_Selectors)) within the framework for reuse and maintainability.
 - We generally do not use stubs or mocks as to fully simulate a real user.
 - Cypress' promises [do not behave as you'd expect](https://docs.cypress.io/guides/core-concepts/introduction-to-cypress.html#Mixing-Async-and-Sync-code).
-- [Testing core Grafana](e2e-core.md) is slightly different than [testing plugins](e2e-plugins.md).
+- [Testing core Grafana](e2e-core.md) is different than [testing plugins](e2e-plugins.md) - core Grafana uses Cypress whereas plugins use [Playwright test](https://playwright.dev/).
 
 ## Framework structure
 

--- a/packages/grafana-e2e/README.md
+++ b/packages/grafana-e2e/README.md
@@ -2,4 +2,4 @@
 
 > [!CAUTION]
 > This package is deprecated.
-> I you'd like to write end-to-end tests for a Grafana plugin (core or external), use the [`@grafana/plugin-e2e`](https://grafana.com/developers/plugin-tools/e2e-test-a-plugin/introduction) package. For end-to-end testing non-plugin related core features, you can add your Cypress tests [here](https://github.com/grafana/grafana/tree/main/e2e).
+> If you'd like to write end-to-end tests for a Grafana plugin (core or external), use the [`@grafana/plugin-e2e`](https://grafana.com/developers/plugin-tools/e2e-test-a-plugin/introduction) package.

--- a/packages/grafana-e2e/README.md
+++ b/packages/grafana-e2e/README.md
@@ -1,5 +1,5 @@
 # Grafana End-to-End Test library
 
-> **@grafana/e2e is currently in BETA**.
-
-This package contains an API wrapper built on top of [Cypress](https://www.cypress.io) that simplifies creating end-to-end tests for Grafana. More information can be found [here](https://github.com/grafana/grafana/blob/main/contribute/style-guides/e2e.md).
+> [!CAUTION]
+> This package is deprecated.
+> I you'd like to write end-to-end tests for a Grafana plugin (core or external), use the [`@grafana/plugin-e2e`](https://grafana.com/developers/plugin-tools/e2e-test-a-plugin/introduction) package. For end-to-end testing non-plugin related core features, you can add your Cypress tests [here](https://github.com/grafana/grafana/tree/main/e2e).


### PR DESCRIPTION
**What is this feature?**

By the time G11 is released, [`@grafana/plugin-e2e`](https://www.npmjs.com/package/@grafana/plugin-e2e?activeTab=readme) will be generally available so we should deprecate the [`@grafana/e2e`](https://www.npmjs.com/package/@grafana/e2e?activeTab=readme) package. The plan for phasing out `grafana/e2e` is as follows:
1. Before Grafana 11.0.0 is released:  Add deprecation notice in the `grafana/e2e` readme and update all docs referring to `grafana/e2e`
2. After Grafana 11.0.0 is released: Deprecate the package in NPM
3. Before Grafana 11.1.0 is released: Delete the grafana/e2e package code entirely from the Grafana repo

This PR adds a deprecation notice and updates docs (step 1). This change will be communicated in the changelog, the release notes, community slack and (likely) in a blog post. 

The style guide has three articles covering e2e testing - [e2e.md](https://github.com/grafana/grafana/blob/d15fcdf52adcd84ced5070fd777251f47cb317c1/contribute/style-guides/e2e.md), [e2e-core.md](https://github.com/grafana/grafana/blob/d15fcdf52adcd84ced5070fd777251f47cb317c1/contribute/style-guides/e2e-core.md) and [e2e-plugins.md](https://github.com/grafana/grafana/blob/d15fcdf52adcd84ced5070fd777251f47cb317c1/contribute/style-guides/e2e-core.md). The e2e-plugins.md is now updated with relevant info. I made a few minor changes to the e2e and e2e-core docs, but feels like there are still a few things that are irrelevant, so it probably needs to be looked into by someone from the frontend platform. Pinging @ashharrison90 since I know you were involved in the migration from Cypress 9. 

**Who is this feature for?**

Plugin authors

**Which issue(s) does this PR fix?**:

Part of https://github.com/grafana/grafana/issues/77484

Fixes #85625

# Release notice breaking change
The `@grafana/e2e` package is deprecated in Grafana 11.0.0. If your Grafana plugin has end-to-end tests that use `@grafana/e2e`, it's recommended to replace them with [`@grafana/plugin-e2e`](https://www.npmjs.com/package/@grafana/plugin-e2e?activeTab=readme) and Playwright. For information on how to migrate, please refer to the plugin-e2e [docs](https://grafana.com/developers/plugin-tools/e2e-test-a-plugin/migrate-from-grafana-e2e). 
