### PR TITLE
Users and ServiceAccount table: UX consistency updates

### DIFF
--- a/public/app/features/admin/Users/UsersTable.tsx
+++ b/public/app/features/admin/Users/UsersTable.tsx
@@ -8,10 +8,12 @@ import {
   FetchDataFunc,
   Icon,
   InteractiveTable,
+  LinkButton,
   Pagination,
   Stack,
   Tag,
   Text,
+  TextLink,
   Tooltip,
 } from '@grafana/ui';
 import { TagBadge } from 'app/core/components/TagFilter/TagBadge';
@@ -40,6 +42,7 @@ export const UsersTable = ({
 }: UsersTableProps) => {
   const showLicensedRole = useMemo(() => users.some((user) => user.licensedRole), [users]);
   const showBelongsTo = useMemo(() => users.some((user) => user.orgs), [users]);
+
   const columns: Array<Column<UserDTO>> = useMemo(
     () => [
       {
@@ -50,7 +53,13 @@ export const UsersTable = ({
       {
         id: 'login',
         header: 'Login',
-        cell: ({ cell: { value } }: Cell<'login'>) => value,
+        cell: ({ row: { original } }: Cell<'login'>) => {
+          return (
+            <TextLink color="primary" inline={false} href={`admin/users/edit/${original.id}`} title="Edit user">
+              {original.login}
+            </TextLink>
+          );
+        },
         sortType: 'string',
       },
       {
@@ -138,11 +147,14 @@ export const UsersTable = ({
         header: '',
         cell: ({ row: { original } }: Cell) => {
           return (
-            <a href={`admin/users/edit/${original.id}`} aria-label={`Edit team ${original.name}`}>
-              <Tooltip content={'Edit user'}>
-                <Icon name={'pen'} />
-              </Tooltip>
-            </a>
+            <LinkButton
+              variant="secondary"
+              size="sm"
+              icon="pen"
+              href={`admin/users/edit/${original.id}`}
+              aria-label={`Edit user ${original.name}`}
+              tooltip={'Edit user'}
+            />
           );
         },
       },

--- a/public/app/features/serviceaccounts/ServiceAccountTable.tsx
+++ b/public/app/features/serviceaccounts/ServiceAccountTable.tsx
@@ -133,7 +133,7 @@ const getCellContent = (
       );
     case 'id':
       return (
-        <TextLink href={href} aria-label={ariaLabel} color="secondary">
+        <TextLink href={href} aria-label={ariaLabel} color="secondary" inline={false}>
           {original.login}
         </TextLink>
       );
@@ -141,14 +141,14 @@ const getCellContent = (
       return (
         <Stack alignItems="center">
           <Icon name="key-skeleton-alt" />
-          <TextLink href={href} aria-label={ariaLabel} color="primary">
+          <TextLink href={href} aria-label={ariaLabel} color="primary" inline={false}>
             {value || 'No tokens'}
           </TextLink>
         </Stack>
       );
     default:
       return (
-        <TextLink href={href} aria-label={ariaLabel} color="primary">
+        <TextLink href={href} aria-label={ariaLabel} color="primary" inline={false}>
           {value}
         </TextLink>
       );

--- a/public/app/features/teams/TeamList.tsx
+++ b/public/app/features/teams/TeamList.tsx
@@ -17,7 +17,6 @@ import {
   Pagination,
   Stack,
   TextLink,
-  Tooltip,
   useStyles2,
 } from '@grafana/ui';
 import EmptyListCTA from 'app/core/components/EmptyListCTA/EmptyListCTA';
@@ -181,15 +180,14 @@ export const TeamList = ({
           return (
             <Stack direction="row" justifyContent="flex-end" gap={2}>
               {canReadTeam && (
-                <Tooltip content={'Edit team'}>
-                  <LinkButton
-                    href={`org/teams/edit/${original.id}`}
-                    aria-label={`Edit team ${original.name}`}
-                    icon="pen"
-                    size="sm"
-                    variant="secondary"
-                  />
-                </Tooltip>
+                <LinkButton
+                  href={`org/teams/edit/${original.id}`}
+                  aria-label={`Edit team ${original.name}`}
+                  icon="pen"
+                  size="sm"
+                  variant="secondary"
+                  tooltip={'Edit team'}
+                />
               )}
               <DeleteButton
                 aria-label={`Delete team ${original.name}`}


### PR DESCRIPTION
The small differences I think make it feel unpolished and messy 

* Align on using inline=false for these table links (Since they are not inline). Setting to false makes links blue and underlined on hover 
* Align on using standard edit link button in users table instead custom link with icon inside 
* Make login a link in users table (so first column is a link in users, team and service account tables) 

