### PR TITLE
GrafanaUI: `IconButton` - replace HorizontalGroup and VerticalGroup with Stack component

### DIFF
--- a/packages/grafana-ui/src/components/IconButton/IconButton.story.tsx
+++ b/packages/grafana-ui/src/components/IconButton/IconButton.story.tsx
@@ -4,7 +4,7 @@ import React from 'react';
 
 import { useTheme2 } from '../../themes';
 import { IconSize, IconName } from '../../types';
-import { HorizontalGroup, VerticalGroup } from '../Layout/Layout';
+import { Stack } from '../Layout/Stack/Stack';
 
 import { BasePropsWithTooltip, IconButton, IconButtonVariant, Props as IconButtonProps } from './IconButton';
 import mdx from './IconButton.mdx';
@@ -57,7 +57,7 @@ export const ExamplesSizes = (args: BasePropsWithTooltip) => {
   });
 
   return (
-    <HorizontalGroup justify="center">
+    <Stack justifyContent="center">
       {variants.map((variant) => {
         return (
           <div
@@ -93,7 +93,7 @@ export const ExamplesSizes = (args: BasePropsWithTooltip) => {
           </div>
         ))}
       </div>
-    </HorizontalGroup>
+    </Stack>
   );
 };
 
@@ -115,7 +115,7 @@ export const ExamplesBackground = (args: BasePropsWithTooltip) => {
           background: theme.colors.background[background],
         })}
       >
-        <VerticalGroup spacing="md">
+        <Stack direction="column" gap={2}>
           <div>{background}</div>
           <div
             className={css({
@@ -128,7 +128,7 @@ export const ExamplesBackground = (args: BasePropsWithTooltip) => {
             })}
             <IconButton name="times" size="xl" tooltip={args.tooltip} disabled />
           </div>
-        </VerticalGroup>
+        </Stack>
       </div>
     );
   };


### PR DESCRIPTION
**What is this feature?**

This is part of the epic [Deprecated layout components: get rid of Layout.tsx including HorizontalGroup and VerticalGroup](https://github.com/grafana/grafana/issues/85510) 

**Why do we need this feature?**
To replace deprecated layout components with the new ones.

**Who is this feature for?**
Everybody

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

#### Examples Background story:
Before:
<img width="708" alt="Captura de pantalla 2024-04-05 a las 11 43 46" src="https://github.com/grafana/grafana/assets/65417731/9b5f76bc-8f20-47a3-b0b9-e7e7a18c0e39">

After:
<img width="702" alt="Captura de pantalla 2024-04-05 a las 11 43 20" src="https://github.com/grafana/grafana/assets/65417731/01fb4ccc-ee75-4e72-8ee8-c28f9779892b">

#### Examples Sizes story:
Before:
<img width="1235" alt="Captura de pantalla 2024-04-05 a las 11 44 08" src="https://github.com/grafana/grafana/assets/65417731/6cf5431b-fd71-4328-9999-7bf33c4e2530">

After:
<img width="1235" alt="Captura de pantalla 2024-04-05 a las 11 44 28" src="https://github.com/grafana/grafana/assets/65417731/22af8d44-31ea-4e0c-b846-a1d5c3499a91">

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
