### PR TITLE
AuthN: reset email verified on email change

### DIFF
--- a/pkg/services/authn/authnimpl/sync/user_sync.go
+++ b/pkg/services/authn/authnimpl/sync/user_sync.go
@@ -234,6 +234,12 @@ func (s *UserSync) updateUserAttributes(ctx context.Context, usr *user.User, id 
 	if id.Email != "" && id.Email != usr.Email {
 		updateCmd.Email = id.Email
 		usr.Email = id.Email
+
+		// If we get a new email for a user we need to mark it as non-verified.
+		verified := false
+		updateCmd.EmailVerified = &verified
+		usr.EmailVerified = false
+
 		needsUpdate = true
 	}
 
@@ -391,6 +397,7 @@ func syncUserToIdentity(usr *user.User, id *authn.Identity) {
 	id.Login = usr.Login
 	id.Email = usr.Email
 	id.Name = usr.Name
+	id.EmailVerified = usr.EmailVerified
 	id.IsGrafanaAdmin = &usr.IsAdmin
 }
 

--- a/pkg/services/authn/authnimpl/sync/user_sync.go
+++ b/pkg/services/authn/authnimpl/sync/user_sync.go
@@ -238,7 +238,7 @@ func (s *UserSync) updateUserAttributes(ctx context.Context, usr *user.User, id 
 		// If we get a new email for a user we need to mark it as non-verified.
 		verified := false
 		updateCmd.EmailVerified = &verified
-		usr.EmailVerified = false
+		usr.EmailVerified = verified
 
 		needsUpdate = true
 	}


### PR DESCRIPTION
**What is this feature?**
When we get a new email for a user from id we need to set email_verified to false.

Part of https://github.com/grafana/identity-access-team/issues/625 and https://github.com/grafana/identity-access-team/issues/536

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
