### PR TITLE
Fixes #83443: Relative links now work as panel links

### DIFF
--- a/e2e/dashboards/PanelLinksDashboard.json
+++ b/e2e/dashboards/PanelLinksDashboard.json
@@ -1,0 +1,140 @@
+{
+    "annotations": {
+      "list": [
+        {
+          "builtIn": 1,
+          "datasource": {
+            "type": "grafana",
+            "uid": "-- Grafana --"
+          },
+          "enable": true,
+          "hide": true,
+          "iconColor": "rgba(0, 211, 255, 1)",
+          "name": "Annotations & Alerts",
+          "type": "dashboard"
+        }
+      ]
+    },
+    "editable": true,
+    "fiscalYearStartMonth": 0,
+    "graphTooltip": 0,
+    "id": 129,
+    "links": [],
+    "panels": [
+      {
+        "datasource": {
+          "type": "grafana-testdata-datasource",
+          "uid": "PD8C576611E62080A"
+        },
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "mode": "palette-classic"
+            },
+            "custom": {
+              "axisBorderShow": false,
+              "axisCenteredZero": false,
+              "axisColorMode": "text",
+              "axisLabel": "",
+              "axisPlacement": "auto",
+              "barAlignment": 0,
+              "drawStyle": "line",
+              "fillOpacity": 0,
+              "gradientMode": "none",
+              "hideFrom": {
+                "legend": false,
+                "tooltip": false,
+                "viz": false
+              },
+              "insertNulls": false,
+              "lineInterpolation": "linear",
+              "lineWidth": 1,
+              "pointSize": 5,
+              "scaleDistribution": {
+                "type": "linear"
+              },
+              "showPoints": "auto",
+              "spanNulls": false,
+              "stacking": {
+                "group": "A",
+                "mode": "none"
+              },
+              "thresholdsStyle": {
+                "mode": "off"
+              }
+            },
+            "mappings": [],
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "value": null
+                },
+                {
+                  "color": "red",
+                  "value": 80
+                }
+              ]
+            }
+          },
+          "overrides": []
+        },
+        "gridPos": {
+          "h": 8,
+          "w": 12,
+          "x": 0,
+          "y": 0
+        },
+        "id": 1,
+        "links": [
+          {
+            "title": "",
+            "url": "../d/ZqZnVvFZz/datasource-tests-shared-queries?orgId=1&from=1712134139216&to=1712155739216&viewPanel=2"
+          }
+        ],
+        "options": {
+          "legend": {
+            "calcs": [],
+            "displayMode": "list",
+            "placement": "bottom",
+            "showLegend": true
+          },
+          "tooltip": {
+            "maxHeight": 600,
+            "mode": "single",
+            "sort": "none"
+          }
+        },
+        "targets": [
+          {
+            "datasource": {
+              "type": "grafana-testdata-datasource",
+              "uid": "PD8C576611E62080A"
+            },
+            "refId": "A",
+            "scenarioId": "random_walk",
+            "seriesCount": 1
+          }
+        ],
+        "title": "Panel Title",
+        "type": "timeseries"
+      }
+    ],
+    "schemaVersion": 39,
+    "tags": [],
+    "templating": {
+      "list": []
+    },
+    "time": {
+      "from": "now-6h",
+      "to": "now"
+    },
+    "timeRangeUpdatedDuringEditOrView": false,
+    "timepicker": {},
+    "timezone": "browser",
+    "title": "PanelLinkTest",
+    "uid": "adhmn0o369qf4d",
+    "version": 1,
+    "weekStart": ""
+  }

--- a/e2e/panels-suite/relative-panel-links.spec.ts
+++ b/e2e/panels-suite/relative-panel-links.spec.ts
@@ -1,0 +1,25 @@
+import { e2e } from '../utils';
+import PanelLinksDashboard from '../dashboards/PanelLinksDashboard.json';
+
+describe('Dashboards', () => {
+  beforeEach(() => {
+    e2e.flows.login(Cypress.env('USERNAME'), Cypress.env('PASSWORD'));
+  });
+
+  after(() => {
+    e2e.flows.revertAllChanges();
+  });
+
+  it('should restore scroll position', () => {
+    e2e.flows.importDashboard(PanelLinksDashboard,2000)
+    // Click in panel link button
+    cy.get('.css-1pkl4m8-panel-header-item').click() 
+    // Verify that the page does not show a 404 error
+    try {
+        cy.get('.u-over',{ timeout: 2000 }).should('not.contain', 'not found')
+      } catch (error) {
+        cy.log('Relative link did not work proprely');
+      }
+  
+  });
+});

--- a/packages/grafana-data/src/utils/location.ts
+++ b/packages/grafana-data/src/utils/location.ts
@@ -17,6 +17,14 @@ const maybeParseUrl = (input: string): URL | undefined => {
   }
 };
 
+// .. and /.. must come first of . and /.
+enum problematicRelativeLinks {
+  '..',
+  '/..',
+  '.',
+  '/.',
+}
+
 /**
  *
  * @param url
@@ -43,6 +51,16 @@ const stripBaseFromUrl = (urlOrPath: string): string => {
     segmentToStrip = `${window.location.origin}${appSubUrl}`;
   }
 
+  // strip bases of some problematic relative links
+  if (!isAbsoluteUrl){
+    for (const segment in problematicRelativeLinks){
+      if (urlOrPath.startsWith(segment)){
+        segmentToStrip =  segment;
+        break;
+      }
+    }
+  }
+  
   // Check if the segment is either exactly the same as the url
   // or followed by a '/' so it does not replace incorrect similarly named segments
   // i.e. /grafana should not replace /grafanadashboards


### PR DESCRIPTION
Changed function stripBaseFromUrl from location.ts so that relative links have their base stripped. Also added an e2e test (relative-panel-links.spec.ts) and a dashboard to be used in the test (PanelLinksDashboard.json).
Solves issue #83443.