### PR TITLE
CI: Skip CodeQL analysis if repo is not `grafana/grafana`

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -25,6 +25,7 @@ jobs:
   analyze:
     name: Analyze
     runs-on: ubuntu-latest
+    if: github.repository == 'grafana/grafana'
 
     strategy:
       fail-fast: false
@@ -67,4 +68,3 @@ jobs:
 
     - name: Perform CodeQL Analysis
       uses: github/codeql-action/analyze@v2
-      if: github.repository == 'grafana/grafana'


### PR DESCRIPTION
Follow-up of https://github.com/grafana/grafana/pull/85532.