### PR TITLE
GrafanaUI: `ConfirmModal` - replace `HorizontalGroup` with `Stack` and `Box` component

### DIFF
--- a/.betterer.results
+++ b/.betterer.results
@@ -831,9 +831,6 @@ exports[`better eslint`] = {
       [0, 0, 0, "Unexpected any. Specify a different type.", "0"],
       [0, 0, 0, "Unexpected any. Specify a different type.", "1"]
     ],
-    "packages/grafana-ui/src/components/ConfirmModal/ConfirmModal.tsx:5381": [
-      [0, 0, 0, "\'HorizontalGroup\' import from \'../Layout/Layout\' is restricted from being used by a pattern. Use Stack component instead.", "0"]
-    ],
     "packages/grafana-ui/src/components/DataLinks/DataLinkInput.tsx:5381": [
       [0, 0, 0, "Do not use any type assertions.", "0"]
     ],

--- a/packages/grafana-ui/src/components/ConfirmModal/ConfirmModal.tsx
+++ b/packages/grafana-ui/src/components/ConfirmModal/ConfirmModal.tsx
@@ -8,7 +8,8 @@ import { useStyles2 } from '../../themes';
 import { IconName } from '../../types/icon';
 import { Button, ButtonVariant } from '../Button';
 import { Input } from '../Input/Input';
-import { HorizontalGroup } from '../Layout/Layout';
+import { Box } from '../Layout/Box/Box';
+import { Stack } from '../Layout/Stack/Stack';
 import { Modal } from '../Modal/Modal';
 
 export interface ConfirmModalProps {
@@ -102,9 +103,11 @@ export const ConfirmModal = ({
         {description ? <div className={styles.modalDescription}>{description}</div> : null}
         {confirmationText ? (
           <div className={styles.modalConfirmationInput}>
-            <HorizontalGroup>
-              <Input placeholder={`Type "${confirmationText}" to confirm`} onChange={onConfirmationTextChange} />
-            </HorizontalGroup>
+            <Stack alignItems="flex-start">
+              <Box>
+                <Input placeholder={`Type "${confirmationText}" to confirm`} onChange={onConfirmationTextChange} />
+              </Box>
+            </Stack>
           </div>
         ) : null}
       </div>


### PR DESCRIPTION
**What is this feature?**

This is part of the epic https://github.com/grafana/grafana/issues/85510

**Why do we need this feature?**

 To replace deprecated layout components with the new ones.

**Who is this feature for?**

Everybody

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

**Before**
<img width="563" alt="Captura de pantalla 2024-04-05 a las 15 40 41" src="https://github.com/grafana/grafana/assets/65417731/73d01ccc-e6c4-49bc-85ff-4824204ce0b6">

**After**
<img width="591" alt="Captura de pantalla 2024-04-05 a las 15 40 50" src="https://github.com/grafana/grafana/assets/65417731/625fb184-8db9-46c7-b311-6c67709eb285">


Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
