### PR TITLE
GrafanaUI: `DateTimePicker` - replace `HorizontalGroup` with `Stack` component

### DIFF
--- a/packages/grafana-ui/src/components/DateTimePickers/DateTimePicker/DateTimePicker.tsx
+++ b/packages/grafana-ui/src/components/DateTimePickers/DateTimePicker/DateTimePicker.tsx
@@ -15,7 +15,7 @@ import { Button } from '../../Button/Button';
 import { InlineField } from '../../Forms/InlineField';
 import { Icon } from '../../Icon/Icon';
 import { Input } from '../../Input/Input';
-import { HorizontalGroup } from '../../Layout/Layout';
+import { Stack } from '../../Layout/Stack/Stack';
 import { getModalStyles } from '../../Modal/getModalStyles';
 import { Portal } from '../../Portal/Portal';
 import { TimeOfDayPicker, POPUP_CLASS_NAME } from '../TimeOfDayPicker';
@@ -329,14 +329,14 @@ const DateTimeCalendar = React.forwardRef<HTMLDivElement, DateTimeCalendarProps>
             disabledSeconds={disabledSeconds}
           />
         </div>
-        <HorizontalGroup>
+        <Stack>
           <Button type="button" onClick={() => onChange(dateTime(internalDate))}>
             Apply
           </Button>
           <Button variant="secondary" type="button" onClick={onClose}>
             Cancel
           </Button>
-        </HorizontalGroup>
+        </Stack>
       </div>
     );
   }


### PR DESCRIPTION
**What is this feature?**
This is part of the epic https://github.com/grafana/grafana/issues/85510

**Why do we need this feature?**
 To replace deprecated layout components with the new ones.

**Who is this feature for?**
Everybody

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Before:
<img width="412" alt="Captura de pantalla 2024-04-05 a las 16 10 31" src="https://github.com/grafana/grafana/assets/65417731/fa4953a4-37e6-4bd3-998e-515e92b4af00">

After:
<img width="438" alt="Captura de pantalla 2024-04-05 a las 16 10 22" src="https://github.com/grafana/grafana/assets/65417731/b089d952-ce07-40fa-93d1-e64b285b7eab">


Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
