### PR TITLE
[v11.0.x] Auth: Convert SetDefaultOrgHook to PostLoginHook

### DIFF
--- a/pkg/services/anonymous/anonimpl/impl.go
+++ b/pkg/services/anonymous/anonimpl/impl.go
@@ -112,7 +112,7 @@ func (a *AnonDeviceService) untagDevice(ctx context.Context,
 
 	errD := a.anonStore.DeleteDevice(ctx, deviceID)
 	if errD != nil {
-		a.log.Debug("Failed to untag device", "error", err)
+		a.log.Debug("Failed to untag device", "error", errD)
 	}
 }
 

--- a/pkg/services/authn/authnimpl/service.go
+++ b/pkg/services/authn/authnimpl/service.go
@@ -162,7 +162,7 @@ func ProvideService(
 
 	s.RegisterPostAuthHook(rbacSync.SyncPermissionsHook, 120)
 
-	s.RegisterPostAuthHook(orgUserSyncService.SetDefaultOrgHook, 130)
+	s.RegisterPostLoginHook(orgUserSyncService.SetDefaultOrgHook, 140)
 
 	return s
 }

--- a/pkg/services/authn/authnimpl/sync/org_sync.go
+++ b/pkg/services/authn/authnimpl/sync/org_sync.go
@@ -132,9 +132,9 @@ func (s *OrgSync) SyncOrgRolesHook(ctx context.Context, id *authn.Identity, _ *a
 	return nil
 }
 
-func (s *OrgSync) SetDefaultOrgHook(ctx context.Context, currentIdentity *authn.Identity, r *authn.Request) error {
-	if s.cfg.LoginDefaultOrgId < 1 || currentIdentity == nil {
-		return nil
+func (s *OrgSync) SetDefaultOrgHook(ctx context.Context, currentIdentity *authn.Identity, r *authn.Request, err error) {
+	if s.cfg.LoginDefaultOrgId < 1 || currentIdentity == nil || err != nil {
+		return
 	}
 
 	ctxLogger := s.log.FromContext(ctx)
@@ -142,33 +142,30 @@ func (s *OrgSync) SetDefaultOrgHook(ctx context.Context, currentIdentity *authn.
 	namespace, identifier := currentIdentity.GetNamespacedID()
 	if namespace != identity.NamespaceUser {
 		ctxLogger.Debug("Skipping default org sync, not a user", "namespace", namespace)
-		return nil
+		return
 	}
 
 	userID, err := identity.IntIdentifier(namespace, identifier)
 	if err != nil {
 		ctxLogger.Debug("Skipping default org sync, invalid ID for identity", "id", currentIdentity.ID, "namespace", namespace, "err", err)
-		return nil
+		return
 	}
 
 	hasAssignedToOrg, err := s.validateUsingOrg(ctx, userID, s.cfg.LoginDefaultOrgId)
 	if err != nil {
 		ctxLogger.Error("Skipping default org sync, failed to validate user's organizations", "id", currentIdentity.ID, "err", err)
-		return nil
+		return
 	}
 
 	if !hasAssignedToOrg {
 		ctxLogger.Debug("Skipping default org sync, user is not assigned to org", "id", currentIdentity.ID, "org", s.cfg.LoginDefaultOrgId)
-		return nil
+		return
 	}
 
 	cmd := user.SetUsingOrgCommand{UserID: userID, OrgID: s.cfg.LoginDefaultOrgId}
-	if err := s.userService.SetUsingOrg(ctx, &cmd); err != nil {
-		ctxLogger.Error("Failed to set default org", "id", currentIdentity.ID, "err", err)
-		return err
+	if svcErr := s.userService.SetUsingOrg(ctx, &cmd); svcErr != nil {
+		ctxLogger.Error("Failed to set default org", "id", currentIdentity.ID, "err", svcErr)
 	}
-
-	return nil
 }
 
 func (s *OrgSync) validateUsingOrg(ctx context.Context, userID int64, orgID int64) (bool, error) {


### PR DESCRIPTION
Backport 8796d2d30750319b916baacf08c37ceff3bf86a0 from #85649

---

**What is this feature?**
Convert `SetDefaultOrgHook` to `PostLoginHook`.

**Why do we need this feature?**
Currently the `SetDefaultOrgHook` is executed after the `Session` auth client as well which causes that the default org gets set after a reload.

**Who is this feature for?**

[Add information on what kind of user the feature is for.]

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
