### PR TITLE
E2C: Show latest migration run instead of the first

### DIFF
--- a/public/app/features/migrate-to-cloud/api/index.ts
+++ b/public/app/features/migrate-to-cloud/api/index.ts
@@ -4,7 +4,7 @@ import { BaseQueryFn, QueryDefinition } from '@reduxjs/toolkit/dist/query';
 import { generatedAPI } from './endpoints.gen';
 
 export const cloudMigrationAPI = generatedAPI.enhanceEndpoints({
-  addTagTypes: ['cloud-migration-config', 'cloud-migration-run'],
+  addTagTypes: ['cloud-migration-config', 'cloud-migration-run', 'cloud-migration-run-list'],
   endpoints: {
     // List Cloud Configs
     getMigrationList: {
@@ -27,7 +27,7 @@ export const cloudMigrationAPI = generatedAPI.enhanceEndpoints({
     },
 
     getCloudMigrationRunList: {
-      providesTags: ['cloud-migration-run'] /* should this be a -list? */,
+      providesTags: ['cloud-migration-run-list'],
     },
 
     getCloudMigrationRun: {
@@ -35,7 +35,7 @@ export const cloudMigrationAPI = generatedAPI.enhanceEndpoints({
     },
 
     runCloudMigration: {
-      invalidatesTags: ['cloud-migration-run'],
+      invalidatesTags: ['cloud-migration-run-list'],
     },
 
     getDashboardByUid(endpoint) {

--- a/public/app/features/migrate-to-cloud/onprem/Page.tsx
+++ b/public/app/features/migrate-to-cloud/onprem/Page.tsx
@@ -33,7 +33,7 @@ import { ResourcesTable } from './ResourcesTable';
 
 function useGetLatestMigrationDestination() {
   const result = useGetMigrationListQuery();
-  const latestMigration = result.data?.migrations?.[0];
+  const latestMigration = result.data?.migrations?.at(-1);
 
   return {
     ...result,
@@ -43,7 +43,7 @@ function useGetLatestMigrationDestination() {
 
 function useGetLatestMigrationRun(migrationId?: number) {
   const listResult = useGetCloudMigrationRunListQuery(migrationId ? { id: migrationId } : skipToken);
-  const latestMigrationRun = listResult.data?.runs?.[0];
+  const latestMigrationRun = listResult.data?.runs?.at(-1);
 
   const runResult = useGetCloudMigrationRunQuery(
     latestMigrationRun?.id && migrationId ? { runId: latestMigrationRun.id, id: migrationId } : skipToken


### PR DESCRIPTION
Fixes two issues with the frontend's API calls for migrations:

 - Correctly show the last migration config / migration run instead of the first result
 - When running a migration, only the migration run _list_ needs invalidating. Migration runs are more or less immutable (at the moment), so running a migration doesn't invalidate it