### PR TITLE
Alerting: Fix redirect after saving a notification template

### DIFF
--- a/public/app/features/alerting/unified/components/contact-points/ContactPoints.test.tsx
+++ b/public/app/features/alerting/unified/components/contact-points/ContactPoints.test.tsx
@@ -1,7 +1,7 @@
 import { render, screen, waitFor, waitForElementToBeRemoved } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { noop } from 'lodash';
-import React, { PropsWithChildren } from 'react';
+import React, { ComponentProps, PropsWithChildren } from 'react';
 import { TestProvider } from 'test/helpers/TestProvider';
 
 import { selectors } from '@grafana/e2e-selectors';
@@ -40,6 +40,18 @@ import setupVanillaAlertmanagerFlavoredServer, {
  */
 const server = setupMswServer();
 
+const renderWithProvider = (
+  providerProps?: Partial<ComponentProps<typeof AlertmanagerProvider>>,
+  contactPointProps?: Partial<ComponentProps<typeof ContactPoints>>
+) =>
+  render(
+    <TestProvider>
+      <AlertmanagerProvider accessType={'notification'} {...providerProps}>
+        <ContactPoints {...contactPointProps} />
+      </AlertmanagerProvider>
+    </TestProvider>
+  );
+
 describe('contact points', () => {
   beforeEach(() => {
     // The location service is stateful between tests - `TestProvider` uses the same instance between each test
@@ -58,13 +70,37 @@ describe('contact points', () => {
       setupGrafanaManagedServer(server);
     });
 
+    describe('tabs behaviour', () => {
+      test('loads contact points tab', async () => {
+        locationService.push('/?tab=contact_points');
+        renderWithProvider();
+
+        expect(await screen.findByText(/add contact point/i)).toBeInTheDocument();
+      });
+
+      test('loads templates tab', async () => {
+        locationService.push('/?tab=templates');
+        renderWithProvider();
+
+        expect(await screen.findByText(/add notification template/i)).toBeInTheDocument();
+      });
+
+      test('defaults to contact points tab with invalid query param', async () => {
+        locationService.push('/?tab=foo_bar');
+        renderWithProvider();
+
+        expect(await screen.findByText(/add contact point/i)).toBeInTheDocument();
+      });
+
+      test('defaults to contact points tab with no query param', async () => {
+        renderWithProvider();
+
+        expect(await screen.findByText(/add contact point/i)).toBeInTheDocument();
+      });
+    });
+
     it('should show / hide loading states, have all actions enabled', async () => {
-      render(
-        <AlertmanagerProvider accessType={'notification'}>
-          <ContactPoints />
-        </AlertmanagerProvider>,
-        { wrapper: TestProvider }
-      );
+      renderWithProvider();
 
       await waitFor(async () => {
         expect(screen.getByText('Loading...')).toBeInTheDocument();
@@ -103,12 +139,7 @@ describe('contact points', () => {
     it('should disable certain actions if the user has no write permissions', async () => {
       grantUserPermissions([AccessControlAction.AlertingNotificationsRead]);
 
-      render(
-        <AlertmanagerProvider accessType={'notification'}>
-          <ContactPoints />
-        </AlertmanagerProvider>,
-        { wrapper: TestProvider }
-      );
+      renderWithProvider();
 
       // wait for loading to be done
       await waitFor(async () => {
@@ -211,12 +242,7 @@ describe('contact points', () => {
     });
 
     it('should be able to search', async () => {
-      render(
-        <AlertmanagerProvider accessType={'notification'}>
-          <ContactPoints />
-        </AlertmanagerProvider>,
-        { wrapper: TestProvider }
-      );
+      renderWithProvider();
 
       const searchInput = screen.getByRole('textbox', { name: 'search contact points' });
       await userEvent.type(searchInput, 'slack');
@@ -254,13 +280,7 @@ describe('contact points', () => {
     });
 
     it('should show / hide loading states, have the right actions enabled', async () => {
-      render(
-        <TestProvider>
-          <AlertmanagerProvider accessType={'notification'} alertmanagerSourceName={MIMIR_DATASOURCE_UID}>
-            <ContactPoints />
-          </AlertmanagerProvider>
-        </TestProvider>
-      );
+      renderWithProvider({ alertmanagerSourceName: MIMIR_DATASOURCE_UID });
 
       await waitFor(async () => {
         expect(screen.getByText('Loading...')).toBeInTheDocument();

--- a/public/app/features/alerting/unified/components/contact-points/ContactPoints.tsx
+++ b/public/app/features/alerting/unified/components/contact-points/ContactPoints.tsx
@@ -3,7 +3,7 @@ import uFuzzy from '@leeoniya/ufuzzy';
 import { SerializedError } from '@reduxjs/toolkit';
 import { groupBy, size, uniq, upperFirst } from 'lodash';
 import pluralize from 'pluralize';
-import React, { Fragment, ReactNode, useCallback, useEffect, useMemo, useState } from 'react';
+import React, { Fragment, ReactNode, useCallback, useMemo, useState } from 'react';
 import { Link } from 'react-router-dom';
 import { useToggle } from 'react-use';
 
@@ -70,8 +70,8 @@ export enum ActiveTab {
 const DEFAULT_PAGE_SIZE = 10;
 
 const useTabQueryParam = () => {
-  const [queryParams] = useURLSearchParams();
-  return useMemo(() => {
+  const [queryParams, setQueryParams] = useURLSearchParams();
+  const param = useMemo(() => {
     const queryParam = queryParams.get('tab');
 
     if (!queryParam || !Object.values(ActiveTab).map(String).includes(queryParam)) {
@@ -80,14 +80,17 @@ const useTabQueryParam = () => {
 
     return queryParam || ActiveTab.ContactPoints;
   }, [queryParams]);
+
+  const setParam = (tab: string) => setQueryParams({ tab });
+
+  return [param, setParam] as const;
 };
 
 const ContactPoints = () => {
   const { selectedAlertmanager } = useAlertmanager();
-  const [queryParams, setQueryParams] = useURLSearchParams();
-  const activeTabVal = useTabQueryParam();
+  const [queryParams] = useURLSearchParams();
+  const [activeTab, setActiveTab] = useTabQueryParam();
 
-  const [activeTab, setActiveTab] = useState(activeTabVal);
   let { isLoading, error, contactPoints } = useContactPointsWithStatus();
   const { deleteTrigger, updateAlertmanagerState } = useDeleteContactPoint(selectedAlertmanager!);
   const [addContactPointSupported, addContactPointAllowed] = useAlertmanagerAbility(
@@ -107,10 +110,6 @@ const ContactPoints = () => {
 
   const showingContactPoints = activeTab === ActiveTab.ContactPoints;
   const showNotificationTemplates = activeTab === ActiveTab.NotificationTemplates;
-
-  useEffect(() => {
-    setQueryParams({ tab: activeTab });
-  }, [activeTab, setQueryParams]);
 
   if (error) {
     // TODO fix this type casting, when error comes from "getContactPointsStatus" it probably won't be a SerializedError

--- a/public/app/features/alerting/unified/components/contact-points/ContactPoints.tsx
+++ b/public/app/features/alerting/unified/components/contact-points/ContactPoints.tsx
@@ -81,7 +81,7 @@ const useTabQueryParam = () => {
     return queryParam || ActiveTab.ContactPoints;
   }, [queryParams]);
 
-  const setParam = (tab: string) => setQueryParams({ tab });
+  const setParam = (tab: ActiveTab) => setQueryParams({ tab });
 
   return [param, setParam] as const;
 };

--- a/public/app/features/alerting/unified/components/receivers/TemplateForm.tsx
+++ b/public/app/features/alerting/unified/components/receivers/TemplateForm.tsx
@@ -22,6 +22,7 @@ import {
   Box,
 } from '@grafana/ui';
 import { useCleanup } from 'app/core/hooks/useCleanup';
+import { ActiveTab as ContactPointsActiveTabs } from 'app/features/alerting/unified/components/contact-points/ContactPoints';
 import { AlertManagerCortexConfig, TestTemplateAlert } from 'app/plugins/datasource/alertmanager/types';
 import { useDispatch } from 'app/types';
 
@@ -146,6 +147,7 @@ export const TemplateForm = ({ existing, alertManagerSourceName, config, provena
         oldConfig: config,
         successMessage: 'Template saved.',
         redirectPath: '/alerting/notifications',
+        redirectSearch: `tab=${ContactPointsActiveTabs.NotificationTemplates}`,
       })
     );
   };
@@ -176,7 +178,9 @@ export const TemplateForm = ({ existing, alertManagerSourceName, config, provena
       </Button>
       <LinkButton
         disabled={loading}
-        href={makeAMLink('alerting/notifications', alertManagerSourceName)}
+        href={makeAMLink('alerting/notifications', alertManagerSourceName, {
+          tab: ContactPointsActiveTabs.NotificationTemplates,
+        })}
         variant="secondary"
         size="sm"
       >


### PR DESCRIPTION
**What is this feature?**

Redirects to the correct UI after saving a notification template

**Why do we need this feature?**

Adds query param handling for the tabs within the contact points page, so saving a notification template would send you back to the Contact Points tab. This fixes it

**Which issue(s) does this PR fix?**:
Fixes #83471 

