### PR TITLE
Alerting: Implement SaveAndApplyDefaultConfig in the forked Alertmanager (remote primary mode)

### DIFF
--- a/pkg/services/ngalert/remote/forked_alertmanager_test.go
+++ b/pkg/services/ngalert/remote/forked_alertmanager_test.go
@@ -402,15 +402,16 @@ func TestForkedAlertmanager_ModeRemotePrimary(t *testing.T) {
 		internal.EXPECT().SaveAndApplyDefaultConfig(ctx).Return(nil).Once()
 		require.NoError(tt, forked.SaveAndApplyDefaultConfig(ctx))
 
-		// If there's an error in any Alertmanager, it should be returned.
-		internal, remote, forked = genTestAlertmanagers(tt, modeRemotePrimary)
-		remote.EXPECT().SaveAndApplyDefaultConfig(ctx).Return(nil).Once()
-		internal.EXPECT().SaveAndApplyDefaultConfig(ctx).Return(expErr).Once()
-		require.ErrorIs(tt, forked.SaveAndApplyDefaultConfig(ctx), expErr)
-
+		// An error in the remote Alertmanager should be returned.
 		_, remote, forked = genTestAlertmanagers(tt, modeRemotePrimary)
 		remote.EXPECT().SaveAndApplyDefaultConfig(ctx).Return(expErr).Once()
 		require.ErrorIs(tt, forked.SaveAndApplyDefaultConfig(ctx), expErr)
+
+		// An error in the internal Alertmanager should not be returned.
+		internal, remote, forked = genTestAlertmanagers(tt, modeRemotePrimary)
+		remote.EXPECT().SaveAndApplyDefaultConfig(ctx).Return(nil).Once()
+		internal.EXPECT().SaveAndApplyDefaultConfig(ctx).Return(expErr).Once()
+		require.NoError(tt, forked.SaveAndApplyDefaultConfig(ctx))
 	})
 
 	t.Run("GetStatus", func(tt *testing.T) {

--- a/pkg/services/ngalert/remote/remote_primary_forked_alertmanager.go
+++ b/pkg/services/ngalert/remote/remote_primary_forked_alertmanager.go
@@ -46,7 +46,10 @@ func (fam *RemotePrimaryForkedAlertmanager) SaveAndApplyDefaultConfig(ctx contex
 		return fmt.Errorf("failed to send the default configuration to the remote Alertmanager: %w", err)
 	}
 
-	return fam.internal.SaveAndApplyDefaultConfig(ctx)
+	if err := fam.internal.SaveAndApplyDefaultConfig(ctx); err != nil {
+		fam.log.Error("Error applying the default configuration to the internal Alertmanager", "err", err)
+	}
+	return nil
 }
 
 func (fam *RemotePrimaryForkedAlertmanager) GetStatus() apimodels.GettableStatus {

--- a/pkg/services/ngalert/remote/remote_primary_forked_alertmanager.go
+++ b/pkg/services/ngalert/remote/remote_primary_forked_alertmanager.go
@@ -37,14 +37,16 @@ func (fam *RemotePrimaryForkedAlertmanager) ApplyConfig(ctx context.Context, con
 	return nil
 }
 
-// TODO: save the new configuration hash in memory.
 func (fam *RemotePrimaryForkedAlertmanager) SaveAndApplyConfig(ctx context.Context, config *apimodels.PostableUserConfig) error {
 	return nil
 }
 
-// TODO: save the new configuration hash in memory.
 func (fam *RemotePrimaryForkedAlertmanager) SaveAndApplyDefaultConfig(ctx context.Context) error {
-	return nil
+	if err := fam.remote.SaveAndApplyDefaultConfig(ctx); err != nil {
+		return fmt.Errorf("failed to send the default configuration to the remote Alertmanager: %w", err)
+	}
+
+	return fam.internal.SaveAndApplyDefaultConfig(ctx)
 }
 
 func (fam *RemotePrimaryForkedAlertmanager) GetStatus() apimodels.GettableStatus {


### PR DESCRIPTION
This PR implements `SaveAndApplyDefaultConfig` on the forked Alertmanager struct for remote primary mode.

The method call is delegated first to the remote Alertmanager and then to the internal one. Errors in the remote Alertmanager are returned, but errors in the internal Alertmanager are just logged.