### PR TITLE
IAM - UserRolePicker bugfix 

### DIFF
--- a/public/app/core/components/RolePicker/TeamRolePicker.tsx
+++ b/public/app/core/components/RolePicker/TeamRolePicker.tsx
@@ -1,3 +1,4 @@
+import { isEqual } from 'lodash';
 import React, { useEffect } from 'react';
 import { useAsyncFn } from 'react-use';
 
@@ -44,13 +45,12 @@ export const TeamRolePicker = ({
   width,
   isLoading,
 }: Props) => {
-  const [{ loading, value: appliedRoles = roles || [] }, getTeamRoles] = useAsyncFn(async () => {
+  const [teamRolesState, getTeamRoles] = useAsyncFn(async () => {
     try {
-      if (roles) {
-        return roles;
-      }
-      if (apply && Boolean(pendingRoles?.length)) {
-        return pendingRoles;
+      if (isEqual(roles, teamRolesState.value)) {
+        if (apply && Boolean(pendingRoles?.length)) {
+          return pendingRoles;
+        }
       }
 
       if (contextSrv.hasPermission(AccessControlAction.ActionTeamsRolesList) && teamId > 0) {
@@ -84,8 +84,8 @@ export const TeamRolePicker = ({
       apply={apply}
       onRolesChange={onRolesChange}
       roleOptions={roleOptions}
-      appliedRoles={appliedRoles}
-      isLoading={loading || isLoading}
+      appliedRoles={teamRolesState.value || []}
+      isLoading={teamRolesState.loading || isLoading}
       disabled={disabled}
       basicRoleDisabled={true}
       canUpdateRoles={canUpdateRoles}

--- a/public/app/core/components/RolePicker/UserRolePicker.tsx
+++ b/public/app/core/components/RolePicker/UserRolePicker.tsx
@@ -1,3 +1,4 @@
+import { isEqual } from 'lodash';
 import React, { useEffect } from 'react';
 import { useAsyncFn } from 'react-use';
 
@@ -53,15 +54,14 @@ export const UserRolePicker = ({
   width,
   isLoading,
 }: Props) => {
-  const [{ loading, value: appliedRoles = roles || [] }, getUserRoles] = useAsyncFn(async () => {
+  const [userRolesState, getUserRoles] = useAsyncFn(async () => {
     try {
-      if (roles) {
+      if (isEqual(roles, userRolesState.value)) {
         return roles;
       }
       if (apply && Boolean(pendingRoles?.length)) {
         return pendingRoles;
       }
-
       if (contextSrv.hasPermission(AccessControlAction.ActionUserRolesList) && userId > 0) {
         return await fetchUserRoles(userId, orgId);
       }
@@ -94,12 +94,12 @@ export const UserRolePicker = ({
 
   return (
     <RolePicker
-      appliedRoles={appliedRoles}
+      appliedRoles={userRolesState.value || []}
       basicRole={basicRole}
       onRolesChange={onRolesChange}
       onBasicRoleChange={onBasicRoleChange}
       roleOptions={roleOptions}
-      isLoading={loading || isLoading}
+      isLoading={userRolesState.loading || isLoading}
       disabled={disabled}
       basicRoleDisabled={basicRoleDisabled}
       basicRoleDisabledMessage={basicRoleDisabledMessage}

--- a/public/app/core/components/RolePicker/UserRolePicker.tsx
+++ b/public/app/core/components/RolePicker/UserRolePicker.tsx
@@ -56,7 +56,7 @@ export const UserRolePicker = ({
 }: Props) => {
   const [userRolesState, getUserRoles] = useAsyncFn(async () => {
     try {
-      if (isEqual(roles, userRolesState.value)) {
+      if (roles && isEqual(roles, userRolesState.value)) {
         return roles;
       }
       if (apply && Boolean(pendingRoles?.length)) {

--- a/public/app/features/serviceaccounts/components/ServiceAccountsListItem.tsx
+++ b/public/app/features/serviceaccounts/components/ServiceAccountsListItem.tsx
@@ -24,9 +24,6 @@ const getServiceAccountsAriaLabel = (name: string) => {
   return `Edit service account's ${name} details`;
 };
 
-/**
- * TODO(aarongodin): it appears this file is unused - check if it can be removed
- */
 const ServiceAccountListItemComponent = memo(
   ({
     serviceAccount,

--- a/public/app/features/serviceaccounts/components/ServiceAccountsListItem.tsx
+++ b/public/app/features/serviceaccounts/components/ServiceAccountsListItem.tsx
@@ -24,6 +24,9 @@ const getServiceAccountsAriaLabel = (name: string) => {
   return `Edit service account's ${name} details`;
 };
 
+/**
+ * TODO(aarongodin): it appears this file is unused - check if it can be removed
+ */
 const ServiceAccountListItemComponent = memo(
   ({
     serviceAccount,


### PR DESCRIPTION
This fixes a bug in the UserRolePicker where the updated role assignments to the user were not fetched after the state of the assigned roles changed. Previous to this change, if you updated the roles assigned to the user from the org users page, the select window for the RolePicker would close but not fetch the new assignments. The update was persisted but would require a page refresh or navigation to pick up the changes.