### PR TITLE
Chore: Add initial `test-utils` file with render helper, wrapping in (most) providers

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -31,7 +31,7 @@ module.exports = {
   transformIgnorePatterns: [
     `/node_modules/(?!${esModules})`, // exclude es modules to prevent TS complaining
   ],
-  moduleDirectories: ['public', 'node_modules'],
+  moduleDirectories: ['public', 'node_modules', 'public/test'],
   roots: ['<rootDir>/public/app', '<rootDir>/public/test', '<rootDir>/packages', '<rootDir>/scripts/tests'],
   testRegex: '(\\.|/)(test)\\.(jsx?|tsx?)$',
   moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx', 'json'],
@@ -54,6 +54,7 @@ module.exports = {
     '^@grafana/schema/dist/esm/(.*)$': '<rootDir>/packages/grafana-schema/src/$1',
     // prevent systemjs amd extra from breaking tests.
     'systemjs/dist/extras/amd': '<rootDir>/public/test/mocks/systemjsAMDExtra.ts',
+    '@grafana/test-utils': '<rootDir>/public/test/test-utils.tsx',
   },
   // Log the test results with dynamic Loki tags. Drone CI only
   reporters: ['default', ['<rootDir>/public/test/log-reporter.js', { enable: process.env.DRONE === 'true' }]],

--- a/jest.config.js
+++ b/jest.config.js
@@ -31,7 +31,7 @@ module.exports = {
   transformIgnorePatterns: [
     `/node_modules/(?!${esModules})`, // exclude es modules to prevent TS complaining
   ],
-  moduleDirectories: ['public', 'node_modules', 'public/test'],
+  moduleDirectories: ['public', 'node_modules'],
   roots: ['<rootDir>/public/app', '<rootDir>/public/test', '<rootDir>/packages', '<rootDir>/scripts/tests'],
   testRegex: '(\\.|/)(test)\\.(jsx?|tsx?)$',
   moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx', 'json'],
@@ -54,7 +54,6 @@ module.exports = {
     '^@grafana/schema/dist/esm/(.*)$': '<rootDir>/packages/grafana-schema/src/$1',
     // prevent systemjs amd extra from breaking tests.
     'systemjs/dist/extras/amd': '<rootDir>/public/test/mocks/systemjsAMDExtra.ts',
-    '@grafana/test-utils': '<rootDir>/public/test/test-utils.tsx',
   },
   // Log the test results with dynamic Loki tags. Drone CI only
   reporters: ['default', ['<rootDir>/public/test/log-reporter.js', { enable: process.env.DRONE === 'true' }]],

--- a/public/test/helpers/TestProvider.tsx
+++ b/public/test/helpers/TestProvider.tsx
@@ -20,6 +20,8 @@ export interface Props {
 
 /**
  * Wrapps component in redux store provider, Router and GrafanaContext
+ *
+ * @deprecated Use `@grafana/test-utils` `render` method instead
  */
 export function TestProvider(props: Props) {
   const { store = configureStore(props.storeState), children } = props;

--- a/public/test/helpers/TestProvider.tsx
+++ b/public/test/helpers/TestProvider.tsx
@@ -21,7 +21,7 @@ export interface Props {
 /**
  * Wrapps component in redux store provider, Router and GrafanaContext
  *
- * @deprecated Use `@grafana/test-utils` `render` method instead
+ * @deprecated Use `test/test-utils` `render` method instead
  */
 export function TestProvider(props: Props) {
   const { store = configureStore(props.storeState), children } = props;

--- a/public/test/mocks/react-inlinesvg.tsx
+++ b/public/test/mocks/react-inlinesvg.tsx
@@ -1,6 +1,17 @@
-import React from 'react';
+import React, { Ref } from 'react';
 
-export default function ReactInlineSVG({ src, innerRef, cacheRequests, preProcessor, ...rest }) {
+export default function ReactInlineSVG({
+  src,
+  innerRef,
+  cacheRequests,
+  preProcessor,
+  ...rest
+}: {
+  src: string;
+  innerRef: Ref<SVGSVGElement>;
+  cacheRequests: boolean;
+  preProcessor: () => string;
+}) {
   return <svg id={src} ref={innerRef} {...rest} />;
 }
 

--- a/public/test/test-utils.tsx
+++ b/public/test/test-utils.tsx
@@ -1,0 +1,111 @@
+import { ToolkitStore } from '@reduxjs/toolkit/dist/configureStore';
+import { render, RenderOptions } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { KBarProvider } from 'kbar';
+import React from 'react';
+import { Provider } from 'react-redux';
+import { MemoryRouter } from 'react-router-dom';
+import { PreloadedState } from 'redux';
+import { getGrafanaContextMock } from 'test/mocks/getGrafanaContextMock';
+
+import { config } from '@grafana/runtime';
+import { ErrorBoundaryAlert } from '@grafana/ui';
+import { GrafanaContext, GrafanaContextType } from 'app/core/context/GrafanaContext';
+import { ModalsContextProvider } from 'app/core/context/ModalsContextProvider';
+import { ThemeProvider } from 'app/core/utils/ConfigProvider';
+import { configureStore } from 'app/store/configureStore';
+import { StoreState } from 'app/types/store';
+
+interface ExtendedRenderOptions extends RenderOptions {
+  /**
+   * Partial state to use for preloading store when rendering tests
+   */
+  preloadedState?: PreloadedState<StoreState>;
+  /**
+   * Optional
+   */
+  store?: ToolkitStore;
+  renderWithRouter?: boolean;
+}
+
+/**
+ * Wraps children in empty fragment - used to conditionally render in a router or not,
+ * as needed by tests
+ */
+const FragmentWrapper = ({ children }: { children: React.ReactNode }) => {
+  return children;
+};
+
+/**
+ * Get a wrapper component that implements all of the providers that components
+ * within the app will need
+ */
+const getWrapper = ({
+  store,
+  renderWithRouter,
+  grafanaContext,
+}: {
+  store?: ToolkitStore;
+  /**
+   * Should the wrapper be generated with a wrapping Router component?
+   * Useful if you're testing something that needs more nuanced routing behaviour
+   * and you want full control over it instead
+   */
+  renderWithRouter?: boolean;
+  grafanaContext?: GrafanaContextType;
+}): React.FC<{ children: React.ReactNode }> => {
+  const reduxStore = store || configureStore();
+  /**
+   * Conditional router - either a MemoryRouter or just a Fragment
+   */
+  const PotentialRouter = renderWithRouter ? MemoryRouter : FragmentWrapper;
+
+  const context = {
+    ...getGrafanaContextMock(),
+    ...grafanaContext,
+  };
+
+  /**
+   * Returns a wrapper that should (closely) match the main `AppWrapper`, so any tests are rendering
+   * in mostly the same providers as a "real" hierarchy
+   */
+  return function Wrapper({ children }: { children?: React.ReactNode }) {
+    return (
+      <Provider store={reduxStore}>
+        <ErrorBoundaryAlert style="page">
+          <GrafanaContext.Provider value={context}>
+            <ThemeProvider value={config.theme2}>
+              <KBarProvider>
+                <PotentialRouter>
+                  <ModalsContextProvider>{children}</ModalsContextProvider>
+                </PotentialRouter>
+              </KBarProvider>
+            </ThemeProvider>
+          </GrafanaContext.Provider>
+        </ErrorBoundaryAlert>
+      </Provider>
+    );
+  };
+};
+
+/**
+ * Extended [@testing-library/react render](https://testing-library.com/docs/react-testing-library/api/#render)
+ * method which wraps the passed element in all of the necessary Providers,
+ * so it can render correctly in the context of the application
+ */
+const customRender = (
+  ui: React.ReactElement,
+  { renderWithRouter = true, ...renderOptions }: ExtendedRenderOptions = {}
+) => {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const store = renderOptions.preloadedState ? configureStore(renderOptions?.preloadedState as any) : undefined;
+  const AllTheProviders = renderOptions.wrapper || getWrapper({ store, renderWithRouter });
+
+  return {
+    ...render(ui, { wrapper: AllTheProviders, ...renderOptions }),
+    store,
+  };
+};
+
+export * from '@testing-library/react';
+export { customRender as render, getWrapper, userEvent };

--- a/public/test/test-utils.tsx
+++ b/public/test/test-utils.tsx
@@ -2,7 +2,7 @@ import { ToolkitStore } from '@reduxjs/toolkit/dist/configureStore';
 import { render, RenderOptions } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { KBarProvider } from 'kbar';
-import React from 'react';
+import React, { ComponentProps, Fragment, PropsWithChildren } from 'react';
 import { Provider } from 'react-redux';
 import { MemoryRouter } from 'react-router-dom';
 import { PreloadedState } from 'redux';
@@ -18,23 +18,25 @@ import { StoreState } from 'app/types/store';
 
 interface ExtendedRenderOptions extends RenderOptions {
   /**
+   * Optional store to use for rendering. If not provided, a fresh store will be generated
+   * via `configureStore` method
+   */
+  store?: ToolkitStore;
+  /**
    * Partial state to use for preloading store when rendering tests
    */
   preloadedState?: PreloadedState<StoreState>;
   /**
-   * Optional
+   * Should the wrapper be generated with a wrapping Router component?
+   * Useful if you're testing something that needs more nuanced routing behaviour
+   * and you want full control over it instead
    */
-  store?: ToolkitStore;
   renderWithRouter?: boolean;
+  /**
+   * Props to pass to `MemoryRouter`, if being used
+   */
+  routerOptions?: ComponentProps<typeof MemoryRouter>;
 }
-
-/**
- * Wraps children in empty fragment - used to conditionally render in a router or not,
- * as needed by tests
- */
-const FragmentWrapper = ({ children }: { children: React.ReactNode }) => {
-  return children;
-};
 
 /**
  * Get a wrapper component that implements all of the providers that components
@@ -43,22 +45,16 @@ const FragmentWrapper = ({ children }: { children: React.ReactNode }) => {
 const getWrapper = ({
   store,
   renderWithRouter,
+  routerOptions,
   grafanaContext,
-}: {
-  store?: ToolkitStore;
-  /**
-   * Should the wrapper be generated with a wrapping Router component?
-   * Useful if you're testing something that needs more nuanced routing behaviour
-   * and you want full control over it instead
-   */
-  renderWithRouter?: boolean;
+}: ExtendedRenderOptions & {
   grafanaContext?: GrafanaContextType;
-}): React.FC<{ children: React.ReactNode }> => {
+}) => {
   const reduxStore = store || configureStore();
   /**
    * Conditional router - either a MemoryRouter or just a Fragment
    */
-  const PotentialRouter = renderWithRouter ? MemoryRouter : FragmentWrapper;
+  const PotentialRouter = renderWithRouter ? MemoryRouter : Fragment;
 
   const context = {
     ...getGrafanaContextMock(),
@@ -69,14 +65,14 @@ const getWrapper = ({
    * Returns a wrapper that should (closely) match the main `AppWrapper`, so any tests are rendering
    * in mostly the same providers as a "real" hierarchy
    */
-  return function Wrapper({ children }: { children?: React.ReactNode }) {
+  return function Wrapper({ children }: PropsWithChildren) {
     return (
       <Provider store={reduxStore}>
         <ErrorBoundaryAlert style="page">
           <GrafanaContext.Provider value={context}>
             <ThemeProvider value={config.theme2}>
               <KBarProvider>
-                <PotentialRouter>
+                <PotentialRouter {...routerOptions}>
                   <ModalsContextProvider>{children}</ModalsContextProvider>
                 </PotentialRouter>
               </KBarProvider>
@@ -99,7 +95,7 @@ const customRender = (
 ) => {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const store = renderOptions.preloadedState ? configureStore(renderOptions?.preloadedState as any) : undefined;
-  const AllTheProviders = renderOptions.wrapper || getWrapper({ store, renderWithRouter });
+  const AllTheProviders = renderOptions.wrapper || getWrapper({ store, renderWithRouter, ...renderOptions });
 
   return {
     ...render(ui, { wrapper: AllTheProviders, ...renderOptions }),

--- a/public/test/test-utils.tsx
+++ b/public/test/test-utils.tsx
@@ -1,18 +1,14 @@
 import { ToolkitStore } from '@reduxjs/toolkit/dist/configureStore';
 import { render, RenderOptions } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { KBarProvider } from 'kbar';
 import React, { ComponentProps, Fragment, PropsWithChildren } from 'react';
 import { Provider } from 'react-redux';
 import { MemoryRouter } from 'react-router-dom';
 import { PreloadedState } from 'redux';
 import { getGrafanaContextMock } from 'test/mocks/getGrafanaContextMock';
 
-import { config } from '@grafana/runtime';
-import { ErrorBoundaryAlert } from '@grafana/ui';
 import { GrafanaContext, GrafanaContextType } from 'app/core/context/GrafanaContext';
 import { ModalsContextProvider } from 'app/core/context/ModalsContextProvider';
-import { ThemeProvider } from 'app/core/utils/ConfigProvider';
 import { configureStore } from 'app/store/configureStore';
 import { StoreState } from 'app/types/store';
 
@@ -62,23 +58,17 @@ const getWrapper = ({
   };
 
   /**
-   * Returns a wrapper that should (closely) match the main `AppWrapper`, so any tests are rendering
+   * Returns a wrapper that should (eventually?) match the main `AppWrapper`, so any tests are rendering
    * in mostly the same providers as a "real" hierarchy
    */
   return function Wrapper({ children }: PropsWithChildren) {
     return (
       <Provider store={reduxStore}>
-        <ErrorBoundaryAlert style="page">
-          <GrafanaContext.Provider value={context}>
-            <ThemeProvider value={config.theme2}>
-              <KBarProvider>
-                <PotentialRouter {...routerOptions}>
-                  <ModalsContextProvider>{children}</ModalsContextProvider>
-                </PotentialRouter>
-              </KBarProvider>
-            </ThemeProvider>
-          </GrafanaContext.Provider>
-        </ErrorBoundaryAlert>
+        <GrafanaContext.Provider value={context}>
+          <PotentialRouter {...routerOptions}>
+            <ModalsContextProvider>{children}</ModalsContextProvider>
+          </PotentialRouter>
+        </GrafanaContext.Provider>
       </Provider>
     );
   };

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,8 +11,7 @@
     "incremental": true,
     "tsBuildInfoFile": "./tsconfig.tsbuildinfo",
     "paths": {
-      "@grafana/schema/dist/esm/*": ["../packages/grafana-schema/src/*"],
-      "@grafana/test-utils": ["./test/test-utils.tsx"]
+      "@grafana/schema/dist/esm/*": ["../packages/grafana-schema/src/*"]
     }
   },
   "extends": "@grafana/tsconfig/base.json",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,14 +11,15 @@
     "incremental": true,
     "tsBuildInfoFile": "./tsconfig.tsbuildinfo",
     "paths": {
-      "@grafana/schema/dist/esm/*": ["../packages/grafana-schema/src/*"]
+      "@grafana/schema/dist/esm/*": ["../packages/grafana-schema/src/*"],
+      "@grafana/test-utils": ["./test/test-utils.tsx"]
     }
   },
   "extends": "@grafana/tsconfig/base.json",
   "include": [
     "public/app/**/*.ts*",
     "public/e2e-test/**/*.ts",
-    "public/test/**/*.ts",
+    "public/test/**/*.ts*",
     "public/vendor/**/*.ts",
     "packages/grafana-data/typings",
     "packages/grafana-ui/src/types"


### PR DESCRIPTION
**What is this feature?**
This takes the existing TestProvider approach and extends it to provider a helper method for rendering components in the UI tests.
https://testing-library.com/docs/react-testing-library/setup/#custom-render

This approach abstracts the app hierarchy even more within the tests, so in most cases, all you need to render a component is 
```
import { render } from '@grafana/test-utils';
```


**Why do we need this feature?**
Simplified testing approach, where the tests need to know even less about the implementation of the component being tested.

**Who is this feature for?**

Grafana UI Developers


