### PR TITLE
Chore: Add examples of updating some tests to use new test-utils `render` method

### DIFF
--- a/public/app/core/components/AppChrome/AppChrome.test.tsx
+++ b/public/app/core/components/AppChrome/AppChrome.test.tsx
@@ -1,9 +1,7 @@
-import { render, screen, waitFor, act } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { KBarProvider } from 'kbar';
 import React, { ReactNode } from 'react';
-import { TestProvider } from 'test/helpers/TestProvider';
 import { getGrafanaContextMock } from 'test/mocks/getGrafanaContextMock';
+import { render, screen, waitFor, act } from 'test/test-utils';
 
 import { DataFrame, DataFrameView, FieldType } from '@grafana/data';
 import { config } from '@grafana/runtime';
@@ -62,13 +60,9 @@ const setup = (children: ReactNode) => {
   const context = getGrafanaContextMock();
 
   const renderResult = render(
-    <KBarProvider>
-      <TestProvider grafanaContext={context}>
-        <AppChrome>
-          <div data-testid="page-children">{children}</div>
-        </AppChrome>
-      </TestProvider>
-    </KBarProvider>
+    <AppChrome>
+      <div data-testid="page-children">{children}</div>
+    </AppChrome>
   );
 
   return { renderResult, context };

--- a/public/app/core/components/AppChrome/AppChrome.test.tsx
+++ b/public/app/core/components/AppChrome/AppChrome.test.tsx
@@ -1,4 +1,5 @@
 import userEvent from '@testing-library/user-event';
+import { KBarProvider } from 'kbar';
 import React, { ReactNode } from 'react';
 import { getGrafanaContextMock } from 'test/mocks/getGrafanaContextMock';
 import { render, screen, waitFor, act } from 'test/test-utils';
@@ -60,9 +61,11 @@ const setup = (children: ReactNode) => {
   const context = getGrafanaContextMock();
 
   const renderResult = render(
-    <AppChrome>
-      <div data-testid="page-children">{children}</div>
-    </AppChrome>
+    <KBarProvider>
+      <AppChrome>
+        <div data-testid="page-children">{children}</div>
+      </AppChrome>
+    </KBarProvider>
   );
 
   return { renderResult, context };

--- a/public/app/core/components/AppChrome/OrganizationSwitcher/OrganizationSwitcher.test.tsx
+++ b/public/app/core/components/AppChrome/OrganizationSwitcher/OrganizationSwitcher.test.tsx
@@ -1,6 +1,5 @@
-import { render, screen } from '@testing-library/react';
 import React from 'react';
-import { TestProvider } from 'test/helpers/TestProvider';
+import { render, screen } from 'test/test-utils';
 
 import { OrgRole } from '@grafana/data';
 import { ContextSrv, setContextSrv } from 'app/core/services/context_srv';
@@ -21,11 +20,7 @@ jest.mock('app/types', () => ({
 }));
 
 const renderWithProvider = ({ initialState }: { initialState?: Partial<appTypes.StoreState> }) => {
-  render(
-    <TestProvider storeState={initialState}>
-      <OrganizationSwitcher />
-    </TestProvider>
-  );
+  render(<OrganizationSwitcher />, { preloadedState: initialState });
 };
 
 describe('OrganisationSwitcher', () => {

--- a/public/app/core/components/NestedFolderPicker/NestedFolderPicker.test.tsx
+++ b/public/app/core/components/NestedFolderPicker/NestedFolderPicker.test.tsx
@@ -1,10 +1,8 @@
 import 'whatwg-fetch'; // fetch polyfill
-import { fireEvent, render as rtlRender, screen } from '@testing-library/react';
-import userEvent from '@testing-library/user-event';
 import { HttpResponse, http } from 'msw';
 import { SetupServer, setupServer } from 'msw/node';
 import React from 'react';
-import { TestProvider } from 'test/helpers/TestProvider';
+import { render, screen, fireEvent, userEvent } from 'test/test-utils';
 
 import { config } from '@grafana/runtime';
 import { backendSrv } from 'app/core/services/backend_srv';
@@ -16,7 +14,6 @@ import {
 } from '../../../features/browse-dashboards/fixtures/dashboardsTreeItem.fixture';
 
 import { NestedFolderPicker } from './NestedFolderPicker';
-
 const [mockTree, { folderA, folderB, folderC, folderA_folderA, folderA_folderB }] = wellFormedTree();
 const [mockTreeThatViewersCanEdit /* shares folders with wellFormedTree */] = treeViewersCanEdit();
 
@@ -24,10 +21,6 @@ jest.mock('@grafana/runtime', () => ({
   ...jest.requireActual('@grafana/runtime'),
   getBackendSrv: () => backendSrv,
 }));
-
-function render(...[ui, options]: Parameters<typeof rtlRender>) {
-  rtlRender(<TestProvider>{ui}</TestProvider>, options);
-}
 
 describe('NestedFolderPicker', () => {
   const mockOnChange = jest.fn();

--- a/public/app/features/alerting/unified/CloneRuleEditor.test.tsx
+++ b/public/app/features/alerting/unified/CloneRuleEditor.test.tsx
@@ -1,9 +1,7 @@
 import 'whatwg-fetch';
-import { render, waitFor, waitForElementToBeRemoved, within } from '@testing-library/react';
 import { setupServer } from 'msw/node';
 import React from 'react';
-import { FormProvider, useForm } from 'react-hook-form';
-import { TestProvider } from 'test/helpers/TestProvider';
+import { render, waitFor, waitForElementToBeRemoved, within } from 'test/test-utils';
 import { byRole, byTestId, byText } from 'testing-library-selector';
 
 import { selectors } from '@grafana/e2e-selectors/src';
@@ -29,15 +27,12 @@ import {
   mockRulerAlertingRule,
   mockRulerGrafanaRule,
   mockRulerRuleGroup,
-  mockStore,
 } from './mocks';
 import { mockAlertmanagerConfigResponse } from './mocks/alertmanagerApi';
 import { mockRulerRulesApiResponse, mockRulerRulesGroupApiResponse } from './mocks/rulerApi';
 import { AlertingQueryRunner } from './state/AlertingQueryRunner';
-import { RuleFormValues } from './types/rule-form';
 import { Annotation } from './utils/constants';
 import { GRAFANA_RULES_SOURCE_NAME } from './utils/datasource';
-import { getDefaultFormValues } from './utils/rule-form';
 import { hashRulerRule } from './utils/rule-id';
 
 jest.mock('./components/rule-editor/ExpressionEditor', () => ({
@@ -83,10 +78,10 @@ const ui = {
   loadingIndicator: byText('Loading the rule'),
 };
 
-function getProvidersWrapper() {
-  return function Wrapper({ children }: React.PropsWithChildren<{}>) {
-    const store = mockStore((store) => {
-      store.unifiedAlerting.dataSources['grafana'] = {
+const preloadedState = {
+  unifiedAlerting: {
+    dataSources: {
+      grafana: {
         loading: false,
         dispatched: true,
         result: {
@@ -94,11 +89,11 @@ function getProvidersWrapper() {
           name: 'grafana',
           rulerConfig: {
             dataSourceName: 'grafana',
-            apiVersion: 'legacy',
+            apiVersion: 'legacy' as const,
           },
         },
-      };
-      store.unifiedAlerting.dataSources['my-prom-ds'] = {
+      },
+      'my-prom-ds': {
         loading: false,
         dispatched: true,
         result: {
@@ -106,21 +101,13 @@ function getProvidersWrapper() {
           name: 'my-prom-ds',
           rulerConfig: {
             dataSourceName: 'my-prom-ds',
-            apiVersion: 'config',
+            apiVersion: 'config' as const,
           },
         },
-      };
-    });
-
-    const formApi = useForm<RuleFormValues>({ defaultValues: getDefaultFormValues() });
-
-    return (
-      <TestProvider store={store}>
-        <FormProvider {...formApi}>{children}</FormProvider>
-      </TestProvider>
-    );
-  };
-}
+      },
+    },
+  },
+};
 
 const amConfig: AlertManagerCortexConfig = {
   alertmanager_config: {
@@ -163,7 +150,7 @@ describe('CloneRuleEditor', function () {
       mockAlertmanagerConfigResponse(server, GRAFANA_RULES_SOURCE_NAME, amConfig);
 
       render(<CloneRuleEditor sourceRuleId={{ uid: 'grafana-rule-1', ruleSourceName: 'grafana' }} />, {
-        wrapper: getProvidersWrapper(),
+        preloadedState,
       });
 
       await waitForElementToBeRemoved(ui.loadingIndicator.query());
@@ -234,7 +221,7 @@ describe('CloneRuleEditor', function () {
           }}
         />,
         {
-          wrapper: getProvidersWrapper(),
+          preloadedState,
         }
       );
 

--- a/public/app/features/alerting/unified/components/GrafanaAlertmanagerDeliveryWarning.test.tsx
+++ b/public/app/features/alerting/unified/components/GrafanaAlertmanagerDeliveryWarning.test.tsx
@@ -1,12 +1,10 @@
 import 'whatwg-fetch';
-import { render, screen, waitFor } from '@testing-library/react';
 import { setupServer } from 'msw/node';
 import React from 'react';
-import { Provider } from 'react-redux';
+import { render, screen, waitFor } from 'test/test-utils';
 
 import { setBackendSrv } from '@grafana/runtime';
 import { backendSrv } from 'app/core/services/backend_srv';
-import { configureStore } from 'app/store/configureStore';
 
 import { AlertmanagerChoice } from '../../../../plugins/datasource/alertmanager/types';
 import { mockAlertmanagerChoiceResponse } from '../mocks/alertmanagerApi';
@@ -36,9 +34,7 @@ describe('GrafanaAlertmanagerDeliveryWarning', () => {
       numExternalAlertmanagers: 0,
     });
 
-    const { container } = renderWithStore(
-      <GrafanaAlertmanagerDeliveryWarning currentAlertmanager="custom-alertmanager" />
-    );
+    const { container } = render(<GrafanaAlertmanagerDeliveryWarning currentAlertmanager="custom-alertmanager" />);
 
     expect(container).toBeEmptyDOMElement();
   });
@@ -49,7 +45,7 @@ describe('GrafanaAlertmanagerDeliveryWarning', () => {
       numExternalAlertmanagers: 1,
     });
 
-    renderWithStore(<GrafanaAlertmanagerDeliveryWarning currentAlertmanager={GRAFANA_RULES_SOURCE_NAME} />);
+    render(<GrafanaAlertmanagerDeliveryWarning currentAlertmanager={GRAFANA_RULES_SOURCE_NAME} />);
 
     expect(await screen.findByText('Grafana alerts are not delivered to Grafana Alertmanager')).toBeVisible();
   });
@@ -60,7 +56,7 @@ describe('GrafanaAlertmanagerDeliveryWarning', () => {
       numExternalAlertmanagers: 1,
     });
 
-    renderWithStore(<GrafanaAlertmanagerDeliveryWarning currentAlertmanager={GRAFANA_RULES_SOURCE_NAME} />);
+    render(<GrafanaAlertmanagerDeliveryWarning currentAlertmanager={GRAFANA_RULES_SOURCE_NAME} />);
 
     expect(await screen.findByText('You have additional Alertmanagers to configure')).toBeVisible();
   });
@@ -71,7 +67,7 @@ describe('GrafanaAlertmanagerDeliveryWarning', () => {
       numExternalAlertmanagers: 1,
     });
 
-    const { container } = renderWithStore(
+    const { container } = render(
       <GrafanaAlertmanagerDeliveryWarning currentAlertmanager={GRAFANA_RULES_SOURCE_NAME} />
     );
 
@@ -86,7 +82,7 @@ describe('GrafanaAlertmanagerDeliveryWarning', () => {
       numExternalAlertmanagers: 0,
     });
 
-    const { container } = renderWithStore(
+    const { container } = render(
       <GrafanaAlertmanagerDeliveryWarning currentAlertmanager={GRAFANA_RULES_SOURCE_NAME} />
     );
 
@@ -95,9 +91,3 @@ describe('GrafanaAlertmanagerDeliveryWarning', () => {
     });
   });
 });
-
-function renderWithStore(element: JSX.Element) {
-  const store = configureStore();
-
-  return render(<Provider store={store}>{element}</Provider>);
-}

--- a/public/app/features/alerting/unified/components/mute-timings/MuteTimingsTable.test.tsx
+++ b/public/app/features/alerting/unified/components/mute-timings/MuteTimingsTable.test.tsx
@@ -1,10 +1,6 @@
-import { render, waitFor } from '@testing-library/react';
 import React from 'react';
-import { Provider } from 'react-redux';
-import { Router } from 'react-router-dom';
+import { render, waitFor } from 'test/test-utils';
 
-import { locationService } from '@grafana/runtime';
-import { configureStore } from 'app/store/configureStore';
 import { AccessControlAction } from 'app/types';
 
 import { grantUserPermissions } from '../../mocks';
@@ -18,16 +14,10 @@ jest.mock('app/types', () => ({
   useDispatch: () => jest.fn(),
 }));
 const renderWithProvider = (alertManagerSource?: string) => {
-  const store = configureStore();
-
   return render(
-    <Provider store={store}>
-      <Router history={locationService.getHistory()}>
-        <AlertmanagerProvider accessType={'notification'} alertmanagerSourceName={alertManagerSource}>
-          <MuteTimingsTable alertManagerSourceName={alertManagerSource ?? GRAFANA_DATASOURCE_NAME} />
-        </AlertmanagerProvider>
-      </Router>
-    </Provider>
+    <AlertmanagerProvider accessType={'notification'} alertmanagerSourceName={alertManagerSource}>
+      <MuteTimingsTable alertManagerSourceName={alertManagerSource ?? GRAFANA_DATASOURCE_NAME} />
+    </AlertmanagerProvider>
   );
 };
 

--- a/public/app/features/alerting/unified/components/rules/RulesTable.test.tsx
+++ b/public/app/features/alerting/unified/components/rules/RulesTable.test.tsx
@@ -1,11 +1,7 @@
-import { render } from '@testing-library/react';
-import userEvent from '@testing-library/user-event';
 import React from 'react';
-import { Provider } from 'react-redux';
-import { MemoryRouter } from 'react-router-dom';
+import { render, userEvent } from 'test/test-utils';
 import { byRole } from 'testing-library-selector';
 
-import { configureStore } from 'app/store/configureStore';
 import { CombinedRule } from 'app/types/unified-alerting';
 
 import { AlertRuleAction, useAlertRuleAbility } from '../../hooks/useAbilities';
@@ -31,15 +27,7 @@ const ui = {
 };
 
 function renderRulesTable(rule: CombinedRule) {
-  const store = configureStore();
-
-  render(
-    <Provider store={store}>
-      <MemoryRouter>
-        <RulesTable rules={[rule]} />
-      </MemoryRouter>
-    </Provider>
-  );
+  render(<RulesTable rules={[rule]} />);
 }
 
 const user = userEvent.setup();

--- a/public/app/features/alerting/unified/hooks/useIsRuleEditable.test.tsx
+++ b/public/app/features/alerting/unified/hooks/useIsRuleEditable.test.tsx
@@ -1,6 +1,4 @@
-import { renderHook, waitFor } from '@testing-library/react';
-import React from 'react';
-import { Provider } from 'react-redux';
+import { renderHook, waitFor, getWrapper } from 'test/test-utils';
 
 import { contextSrv } from 'app/core/services/context_srv';
 import { AccessControlAction, FolderDTO, StoreState } from 'app/types';
@@ -137,8 +135,7 @@ function mockPermissions(grantedPermissions: AccessControlAction[]) {
 function getProviderWrapper() {
   const dataSources = getMockedDataSources();
   const store = mockUnifiedAlertingStore({ dataSources });
-  const wrapper = ({ children }: React.PropsWithChildren<{}>) => <Provider store={store}>{children}</Provider>;
-  return wrapper;
+  return getWrapper({ store });
 }
 
 function getMockedDataSources(): StoreState['unifiedAlerting']['dataSources'] {

--- a/public/app/features/alerting/unified/state/AlertmanagerContext.test.tsx
+++ b/public/app/features/alerting/unified/state/AlertmanagerContext.test.tsx
@@ -1,7 +1,7 @@
-import { renderHook } from '@testing-library/react';
 import { createMemoryHistory } from 'history';
 import React from 'react';
 import { MemoryRouter, Router } from 'react-router-dom';
+import { getWrapper, renderHook } from 'test/test-utils';
 
 import store from 'app/core/store';
 import { AlertManagerImplementation } from 'app/plugins/datasource/alertmanager/types';
@@ -66,10 +66,13 @@ describe('useAlertmanager', () => {
     const history = createMemoryHistory();
     history.push({ search: `alertmanager=${externalAmProm.name}` });
 
+    const Wrapper = getWrapper({ renderWithRouter: false });
     const wrapper = ({ children }: React.PropsWithChildren) => (
-      <Router history={history}>
-        <AlertmanagerProvider accessType="instance">{children}</AlertmanagerProvider>
-      </Router>
+      <Wrapper>
+        <Router history={history}>
+          <AlertmanagerProvider accessType="instance">{children}</AlertmanagerProvider>
+        </Router>
+      </Wrapper>
     );
 
     const { result } = renderHook(() => useAlertmanager(), { wrapper });

--- a/public/app/features/browse-dashboards/components/CreateNewButton.test.tsx
+++ b/public/app/features/browse-dashboards/components/CreateNewButton.test.tsx
@@ -1,7 +1,5 @@
-import { render as rtlRender, screen, within } from '@testing-library/react';
-import userEvent from '@testing-library/user-event';
 import React from 'react';
-import { TestProvider } from 'test/helpers/TestProvider';
+import { render, screen, within, userEvent } from 'test/test-utils';
 
 import { FolderDTO } from 'app/types';
 
@@ -10,10 +8,6 @@ import { mockFolderDTO } from '../fixtures/folder.fixture';
 import CreateNewButton from './CreateNewButton';
 
 const mockParentFolder = mockFolderDTO();
-
-function render(...[ui, options]: Parameters<typeof rtlRender>) {
-  rtlRender(<TestProvider>{ui}</TestProvider>, options);
-}
 
 async function renderAndOpen(folder?: FolderDTO) {
   render(<CreateNewButton canCreateDashboard canCreateFolder parentFolder={folder} />);

--- a/public/app/features/dashboard/containers/DashboardPage.test.tsx
+++ b/public/app/features/dashboard/containers/DashboardPage.test.tsx
@@ -1,3 +1,4 @@
+import { KBarProvider } from 'kbar';
 import React from 'react';
 import { match } from 'react-router-dom';
 import { useEffectOnce } from 'react-use';
@@ -187,9 +188,11 @@ describe('DashboardPage', () => {
       };
 
       render(
-        <AppChrome>
-          <UnthemedDashboardPage {...props} />
-        </AppChrome>
+        <KBarProvider>
+          <AppChrome>
+            <UnthemedDashboardPage {...props} />
+          </AppChrome>
+        </KBarProvider>
       );
 
       await screen.findByText('My dashboard');

--- a/public/app/features/dashboard/containers/DashboardPage.test.tsx
+++ b/public/app/features/dashboard/containers/DashboardPage.test.tsx
@@ -1,26 +1,20 @@
-import { render, screen, waitFor } from '@testing-library/react';
-import { KBarProvider } from 'kbar';
 import React from 'react';
-import { Provider } from 'react-redux';
-import { match, Router } from 'react-router-dom';
+import { match } from 'react-router-dom';
 import { useEffectOnce } from 'react-use';
 import { mockToolkitActionCreator } from 'test/core/redux/mocks';
-import { TestProvider } from 'test/helpers/TestProvider';
-import { getGrafanaContextMock } from 'test/mocks/getGrafanaContextMock';
+import { render, screen, waitFor } from 'test/test-utils';
 
 import { createTheme } from '@grafana/data';
 import { selectors } from '@grafana/e2e-selectors';
-import { config, locationService, setDataSourceSrv } from '@grafana/runtime';
+import { config, setDataSourceSrv } from '@grafana/runtime';
 import { Dashboard } from '@grafana/schema';
 import { notifyApp } from 'app/core/actions';
 import { AppChrome } from 'app/core/components/AppChrome/AppChrome';
-import { GrafanaContext } from 'app/core/context/GrafanaContext';
 import { getRouteComponentProps } from 'app/core/navigation/__mocks__/routeProps';
 import { RouteDescriptor } from 'app/core/navigation/types';
 import { HOME_NAV_ID } from 'app/core/reducers/navModel';
 import { DashboardInitPhase, DashboardMeta, DashboardRoutes } from 'app/types';
 
-import { configureStore } from '../../../store/configureStore';
 import { Props as LazyLoaderProps } from '../dashgrid/LazyLoader';
 import { DashboardSrv, setDashboardSrv } from '../services/DashboardSrv';
 import { DashboardModel } from '../state';
@@ -102,7 +96,6 @@ function setup(propOverrides?: Partial<Props>) {
     },
   ];
 
-  const store = configureStore();
   const props: Props = {
     ...getRouteComponentProps({
       match: { params: { slug: 'my-dash', uid: '11' } } as unknown as match,
@@ -129,29 +122,11 @@ function setup(propOverrides?: Partial<Props>) {
 
   Object.assign(props, propOverrides);
 
-  const context = getGrafanaContextMock();
-
-  const { unmount, rerender } = render(
-    <GrafanaContext.Provider value={context}>
-      <Provider store={store}>
-        <Router history={locationService.getHistory()}>
-          <UnthemedDashboardPage {...props} />
-        </Router>
-      </Provider>
-    </GrafanaContext.Provider>
-  );
+  const { unmount, rerender } = render(<UnthemedDashboardPage {...props} />);
 
   const wrappedRerender = (newProps: Partial<Props>) => {
     Object.assign(props, newProps);
-    return rerender(
-      <GrafanaContext.Provider value={context}>
-        <Provider store={store}>
-          <Router history={locationService.getHistory()}>
-            <UnthemedDashboardPage {...props} />
-          </Router>
-        </Provider>
-      </GrafanaContext.Provider>
-    );
+    return rerender(<UnthemedDashboardPage {...props} />);
   };
 
   return { rerender: wrappedRerender, unmount };
@@ -212,13 +187,9 @@ describe('DashboardPage', () => {
       };
 
       render(
-        <KBarProvider>
-          <TestProvider>
-            <AppChrome>
-              <UnthemedDashboardPage {...props} />
-            </AppChrome>
-          </TestProvider>
-        </KBarProvider>
+        <AppChrome>
+          <UnthemedDashboardPage {...props} />
+        </AppChrome>
       );
 
       await screen.findByText('My dashboard');

--- a/public/app/features/panel/components/PanelDataErrorView.test.tsx
+++ b/public/app/features/panel/components/PanelDataErrorView.test.tsx
@@ -1,11 +1,9 @@
-import { render, screen } from '@testing-library/react';
 import { defaultsDeep } from 'lodash';
 import React from 'react';
-import { Provider } from 'react-redux';
+import { render, screen } from 'test/test-utils';
 
 import { FieldType, getDefaultTimeRange, LoadingState } from '@grafana/data';
 import { PanelDataErrorViewProps } from '@grafana/runtime';
-import { configureStore } from 'app/store/configureStore';
 
 import { PanelDataErrorView } from './PanelDataErrorView';
 
@@ -84,12 +82,7 @@ function renderWithProps(overrides?: Partial<PanelDataErrorViewProps>) {
   };
 
   const props = defaultsDeep(overrides ?? {}, defaults);
-  const store = configureStore();
 
-  const stuff = render(
-    <Provider store={store}>
-      <PanelDataErrorView {...props} />
-    </Provider>
-  );
+  const stuff = render(<PanelDataErrorView {...props} />);
   return { ...stuff };
 }


### PR DESCRIPTION
**What is this feature?**

Updates some "randomly" picked test to show how the approach in #85672 would work within the existing tests. This particular test doesn't necessarily need to be merged, but the changes should all be valid

**Who is this feature for?**

Grafana UI developers


