### PR TITLE
Bump scenes to v4.5.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -255,7 +255,7 @@
     "@grafana/prometheus": "workspace:*",
     "@grafana/runtime": "workspace:*",
     "@grafana/saga-icons": "workspace:*",
-    "@grafana/scenes": "^4.5.3",
+    "@grafana/scenes": "^4.5.4",
     "@grafana/schema": "workspace:*",
     "@grafana/sql": "workspace:*",
     "@grafana/ui": "workspace:*",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4170,9 +4170,9 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@grafana/scenes@npm:^4.5.3":
-  version: 4.5.3
-  resolution: "@grafana/scenes@npm:4.5.3"
+"@grafana/scenes@npm:^4.5.4":
+  version: 4.5.4
+  resolution: "@grafana/scenes@npm:4.5.4"
   dependencies:
     "@grafana/e2e-selectors": "npm:10.3.3"
     react-grid-layout: "npm:1.3.4"
@@ -4186,7 +4186,7 @@ __metadata:
     "@grafana/ui": ^10.0.3
     react: ^18.0.0
     react-dom: ^18.0.0
-  checksum: 10/f1bdfe216e630833f9641e07b2ce295e20ee2f1cebeb0f2115cd81f4aa2204bb525034268b0b067ef7ff6d5070b817aabb27c7649d228a0dbf37affa9220f490
+  checksum: 10/db483dfd204b5b3f2d61b72e1a4209137734ed20d860f823e48a549fee2f2ef490ab26ed239a13aed095d74f929200cb18a666bb995aad6ef785fb806cac65ce
   languageName: node
   linkType: hard
 
@@ -18651,7 +18651,7 @@ __metadata:
     "@grafana/prometheus": "workspace:*"
     "@grafana/runtime": "workspace:*"
     "@grafana/saga-icons": "workspace:*"
-    "@grafana/scenes": "npm:^4.5.3"
+    "@grafana/scenes": "npm:^4.5.4"
     "@grafana/schema": "workspace:*"
     "@grafana/sql": "workspace:*"
     "@grafana/tsconfig": "npm:^1.3.0-rc1"


### PR DESCRIPTION
Bump scenes to [v4.5.4](https://github.com/grafana/scenes/releases/tag/v4.5.4)

This scenes release contains a bug fix for https://github.com/grafana/grafana/issues/84575 and will also help with https://github.com/grafana/grafana/issues/84573