### PR TITLE
Notifications: Redact URL from errors

### DIFF
--- a/pkg/services/notifications/webhook.go
+++ b/pkg/services/notifications/webhook.go
@@ -4,10 +4,12 @@ import (
 	"bytes"
 	"context"
 	"crypto/tls"
+	"errors"
 	"fmt"
 	"io"
 	"net"
 	"net/http"
+	"net/url"
 	"time"
 
 	"github.com/grafana/grafana/pkg/util"
@@ -80,7 +82,7 @@ func (ns *NotificationService) sendWebRequestSync(ctx context.Context, webhook *
 
 	resp, err := netClient.Do(request)
 	if err != nil {
-		return err
+		return redactURL(err)
 	}
 	defer func() {
 		if err := resp.Body.Close(); err != nil {
@@ -96,16 +98,25 @@ func (ns *NotificationService) sendWebRequestSync(ctx context.Context, webhook *
 	if webhook.Validation != nil {
 		err := webhook.Validation(body, resp.StatusCode)
 		if err != nil {
-			ns.log.Debug("Webhook failed validation", "url", webhook.Url, "statuscode", resp.Status, "body", string(body))
+			ns.log.Debug("Webhook failed validation", "statuscode", resp.Status, "body", string(body))
 			return fmt.Errorf("webhook failed validation: %w", err)
 		}
 	}
 
 	if resp.StatusCode/100 == 2 {
-		ns.log.Debug("Webhook succeeded", "url", webhook.Url, "statuscode", resp.Status)
+		ns.log.Debug("Webhook succeeded", "statuscode", resp.Status)
 		return nil
 	}
 
-	ns.log.Debug("Webhook failed", "url", webhook.Url, "statuscode", resp.Status, "body", string(body))
+	ns.log.Debug("Webhook failed", "statuscode", resp.Status, "body", string(body))
 	return fmt.Errorf("webhook response status %v", resp.Status)
+}
+
+func redactURL(err error) error {
+	var e *url.Error
+	if !errors.As(err, &e) {
+		return err
+	}
+	e.URL = "<redacted>"
+	return e
 }


### PR DESCRIPTION
**What is this feature?**

The notification service's webhook feature does not redact the URL from errors. So, the URL can show up in logs, and it's also reflected back in the UI in error toasts.

Redact this, and remove the full URL from logs.

**Why do we need this feature?**

Better to not log this, on the off chance it contains a secret due to whatever 3rd party system is receiving the webhook.

**Who is this feature for?**

Anyone using webhooks, usually via alert notifications.

**Which issue(s) does this PR fix?**:

n/a

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle.
- [x] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
