### PR TITLE
Alerting docs: update `disable_provenance` TF mute_timing

### DIFF
--- a/docs/sources/alerting/set-up/provision-alerting-resources/terraform-provisioning/index.md
+++ b/docs/sources/alerting/set-up/provision-alerting-resources/terraform-provisioning/index.md
@@ -338,8 +338,6 @@ resource "grafana_message_template" "my_template" {
 ...
 ```
 
-Note that `disable_provenance` is not supported for [grafana_mute_timing](https://registry.terraform.io/providers/grafana/grafana/latest/docs/resources/mute_timing).
-
 ## Provision Grafana resources with Terraform
 
 To create the previous alerting resources in Grafana with the Terraform CLI, complete the following steps.


### PR DESCRIPTION
Update docs for https://github.com/grafana/terraform-provider-grafana/pull/1417, which was also documented at the [Grafana Terraform docs](https://registry.terraform.io/providers/grafana/grafana/2.15.0/docs/resources/mute_timing). 