### PR TITLE
DataTrails: Do not create a new VizPanel every activation

### DIFF
--- a/public/app/features/trails/AutomaticMetricQueries/AutoVizPanel.tsx
+++ b/public/app/features/trails/AutomaticMetricQueries/AutoVizPanel.tsx
@@ -20,10 +20,11 @@ export class AutoVizPanel extends SceneObjectBase<AutoVizPanelState> {
   }
 
   public onActivate() {
-    const { autoQuery } = getMetricSceneFor(this).state;
-    this.setState({
-      panel: this.getVizPanelFor(autoQuery.main),
-    });
+    if (!this.state.panel) {
+      const { autoQuery } = getMetricSceneFor(this).state;
+
+      this.setState({ panel: this.getVizPanelFor(autoQuery.main) });
+    }
   }
 
   private getQuerySelector(def: AutoQueryDef) {
@@ -43,9 +44,7 @@ export class AutoVizPanel extends SceneObjectBase<AutoVizPanelState> {
 
     const def = metricScene.state.autoQuery.variants.find((q) => q.variant === variant)!;
 
-    this.setState({
-      panel: this.getVizPanelFor(def),
-    });
+    this.setState({ panel: this.getVizPanelFor(def) });
     metricScene.setState({ queryDef: def });
   };
 

--- a/public/app/features/trails/MetricGraphScene.tsx
+++ b/public/app/features/trails/MetricGraphScene.tsx
@@ -72,8 +72,6 @@ function getStyles(theme: GrafanaTheme2) {
 }
 
 function buildGraphTopView() {
-  const bodyAutoVizPanel = new AutoVizPanel({});
-
   return new SceneFlexLayout({
     direction: 'column',
     $behaviors: [new behaviors.CursorSync({ key: 'metricCrosshairSync', sync: DashboardCursorSync.Crosshair })],
@@ -81,7 +79,7 @@ function buildGraphTopView() {
       new SceneFlexItem({
         minHeight: MAIN_PANEL_MIN_HEIGHT,
         maxHeight: MAIN_PANEL_MAX_HEIGHT,
-        body: bodyAutoVizPanel,
+        body: new AutoVizPanel({}),
       }),
       new SceneFlexItem({
         ySizing: 'content',


### PR DESCRIPTION
Noticed that new metric queries where being issued when going back and forth between old history views (for say different time ranges or metric names). 

Tracked it down to AutoVizPanel creating a new VizPanel every activation (and hence a new SceneQueryRunner). 

There is still an issue here where the history item initially does not have any data when you select a new metric, I think we create the step before queries complete, so if you back to to a previous step and then back to latest (The new metric selected step) it will re-query the data as the step was created without data. Maybe a bit tricky to fix, we would have to update the history step after queries complete. Anyway I think we can wait with fixing that. (Want to look at data cache in scenes that is separate from caching full scene object trees) 