### PR TITLE
[Expression] Fix the display name of the threshold expression result

### DIFF
--- a/pkg/expr/threshold.go
+++ b/pkg/expr/threshold.go
@@ -120,7 +120,7 @@ func (tc *ThresholdCommand) Execute(ctx context.Context, now time.Time, vars mat
 		return mathexp.Results{}, err
 	}
 
-	mathCommand, err := NewMathCommand(tc.ReferenceVar, mathExpression)
+	mathCommand, err := NewMathCommand(tc.RefID, mathExpression)
 	if err != nil {
 		return mathexp.Results{}, err
 	}


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

Fix the display name of the threshold expression result.

**Why do we need this feature?**

Before this fix, when I created a threshold expression [C], the result's name was displayed as [A] which is wrong and confusing.
![image](https://github.com/grafana/grafana/assets/49775184/ddafec3a-9408-4cc4-b3be-19dceadc3599)
![image](https://github.com/grafana/grafana/assets/49775184/b1f70181-6101-4f86-a92d-5133124fefd1)

After this fix, the name of the result displays correctly. The display name should be the same as the refID.
![image](https://github.com/grafana/grafana/assets/49775184/e6d995d1-c705-4556-953c-cc2a939b218c)
![image](https://github.com/grafana/grafana/assets/49775184/c93e41d7-42d5-4e9d-ada4-719a21cce054)

**To fix this issue, when creating a math command for this threshold expression, the RefID should be used rather than the ReferenceVar. Please refer to the the change I made in the code in "file changed".** 

**Who is this feature for?**

Users who use the threshold expression.

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
