### PR TITLE
[v11.0.x] Bump scenes to v4.5.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -252,7 +252,7 @@
     "@grafana/prometheus": "workspace:*",
     "@grafana/runtime": "workspace:*",
     "@grafana/saga-icons": "workspace:*",
-    "@grafana/scenes": "4.2.1",
+    "@grafana/scenes": "^4.5.4",
     "@grafana/schema": "workspace:*",
     "@grafana/sql": "workspace:*",
     "@grafana/ui": "workspace:*",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4126,9 +4126,9 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@grafana/scenes@npm:4.2.1":
-  version: 4.2.1
-  resolution: "@grafana/scenes@npm:4.2.1"
+"@grafana/scenes@npm:^4.5.4":
+  version: 4.5.4
+  resolution: "@grafana/scenes@npm:4.5.4"
   dependencies:
     "@grafana/e2e-selectors": "npm:10.3.3"
     react-grid-layout: "npm:1.3.4"
@@ -4142,7 +4142,7 @@ __metadata:
     "@grafana/ui": ^10.0.3
     react: ^18.0.0
     react-dom: ^18.0.0
-  checksum: 10/bebf65762a05c68902cd5bb1f372dd6434eaca99bb2f937dfa10767f59f0d5de196e545855012431c8bbd2e99753a3950506f6d1ec52be1cbd546ff3c56a8045
+  checksum: 10/db483dfd204b5b3f2d61b72e1a4209137734ed20d860f823e48a549fee2f2ef490ab26ed239a13aed095d74f929200cb18a666bb995aad6ef785fb806cac65ce
   languageName: node
   linkType: hard
 
@@ -18666,7 +18666,7 @@ __metadata:
     "@grafana/prometheus": "workspace:*"
     "@grafana/runtime": "workspace:*"
     "@grafana/saga-icons": "workspace:*"
-    "@grafana/scenes": "npm:4.2.1"
+    "@grafana/scenes": "npm:^4.5.4"
     "@grafana/schema": "workspace:*"
     "@grafana/sql": "workspace:*"
     "@grafana/tsconfig": "npm:^1.3.0-rc1"


### PR DESCRIPTION
Backport 432936cdcf66b5fa3fd5016bb704b78afa82fcd3 from #85681

---

Bump scenes to [v4.5.4](https://github.com/grafana/scenes/releases/tag/v4.5.4)

This scenes release contains a bug fix for https://github.com/grafana/grafana/issues/84575 and will also help with https://github.com/grafana/grafana/issues/84573
