### PR TITLE
Dashboards: Fix issue with changing panel JSON from edit view

### DIFF
--- a/public/app/features/inspector/InspectJSONTab.tsx
+++ b/public/app/features/inspector/InspectJSONTab.tsx
@@ -82,18 +82,19 @@ export function InspectJSONTab({ panel, dashboard, data, onClose }: Props) {
           appEvents.emit(AppEvents.alertError, ['Unable to apply']);
         } else {
           const updates = JSON.parse(text);
-          dashboard!.shouldUpdateDashboardPanelFromJSON(updates, panel!);
+          dashboard!.shouldUpdateDashboardPanelFromJSON(updates, panel);
 
           //Report relevant updates
           reportPanelInspectInteraction(InspectTab.JSON, 'apply', {
-            panel_type_changed: panel!.type !== updates.type,
-            panel_id_changed: panel!.id !== updates.id,
-            panel_grid_pos_changed: !isEqual(panel!.gridPos, updates.gridPos),
-            panel_targets_changed: !isEqual(panel!.targets, updates.targets),
+            panel_type_changed: panel.type !== updates.type,
+            panel_id_changed: panel.id !== updates.id,
+            panel_grid_pos_changed: !isEqual(panel.gridPos, updates.gridPos),
+            panel_targets_changed: !isEqual(panel.targets, updates.targets),
           });
 
-          panel!.restoreModel(updates);
-          panel!.refresh();
+          panel.restoreModel(updates);
+          panel.configRev++;
+          panel.refresh();
           appEvents.emit(AppEvents.alertSuccess, ['Panel model updated']);
         }
       } catch (err) {

--- a/public/app/features/inspector/InspectJSONTab.tsx
+++ b/public/app/features/inspector/InspectJSONTab.tsx
@@ -78,11 +78,11 @@ export function InspectJSONTab({ panel, dashboard, data, onClose }: Props) {
   const onApplyPanelModel = useCallback(() => {
     if (panel && dashboard && text) {
       try {
-        if (!dashboard!.meta.canEdit) {
+        if (!dashboard.meta.canEdit) {
           appEvents.emit(AppEvents.alertError, ['Unable to apply']);
         } else {
           const updates = JSON.parse(text);
-          dashboard!.shouldUpdateDashboardPanelFromJSON(updates, panel);
+          dashboard.shouldUpdateDashboardPanelFromJSON(updates, panel);
 
           //Report relevant updates
           reportPanelInspectInteraction(InspectTab.JSON, 'apply', {


### PR DESCRIPTION
Fixes an issue where changing the panel json from the panel edit view would show the change visually in the panel view, but would not persist the change when "Apply" is pressed.