### PR TITLE
Alerting: Implement DeleteSilence in the forked AM (remote primary)

### DIFF
--- a/pkg/services/ngalert/remote/forked_alertmanager_test.go
+++ b/pkg/services/ngalert/remote/forked_alertmanager_test.go
@@ -422,15 +422,23 @@ func TestForkedAlertmanager_ModeRemotePrimary(t *testing.T) {
 	})
 
 	t.Run("DeleteSilence", func(tt *testing.T) {
-		// We should delete the silence in the remote Alertmanager.
-		_, remote, forked := genTestAlertmanagers(tt, modeRemotePrimary)
-		remote.EXPECT().DeleteSilence(mock.Anything, mock.Anything).Return(nil).Once()
-		require.NoError(tt, forked.DeleteSilence(ctx, ""))
+		// We should delete the silence in both Alertmanagers.
+		testID := "test-id"
+		internal, remote, forked := genTestAlertmanagers(tt, modeRemotePrimary)
+		remote.EXPECT().DeleteSilence(mock.Anything, testID).Return(nil).Once()
+		internal.EXPECT().DeleteSilence(mock.Anything, testID).Return(nil).Once()
+		require.NoError(tt, forked.DeleteSilence(ctx, testID))
 
 		// If there's an error in the remote Alertmanager, the error should be returned.
 		_, remote, forked = genTestAlertmanagers(tt, modeRemotePrimary)
-		remote.EXPECT().DeleteSilence(mock.Anything, mock.Anything).Return(expErr).Maybe()
-		require.ErrorIs(tt, expErr, forked.DeleteSilence(ctx, ""))
+		remote.EXPECT().DeleteSilence(mock.Anything, testID).Return(expErr).Maybe()
+		require.ErrorIs(tt, expErr, forked.DeleteSilence(ctx, testID))
+
+		// An error in the internal Alertmanager should not be returned.
+		internal, remote, forked = genTestAlertmanagers(tt, modeRemotePrimary)
+		remote.EXPECT().DeleteSilence(mock.Anything, testID).Return(nil).Maybe()
+		internal.EXPECT().DeleteSilence(mock.Anything, testID).Return(nil).Maybe()
+		require.NoError(tt, forked.DeleteSilence(ctx, testID))
 	})
 
 	t.Run("GetSilence", func(tt *testing.T) {

--- a/pkg/services/ngalert/remote/remote_primary_forked_alertmanager.go
+++ b/pkg/services/ngalert/remote/remote_primary_forked_alertmanager.go
@@ -56,7 +56,13 @@ func (fam *RemotePrimaryForkedAlertmanager) CreateSilence(ctx context.Context, s
 }
 
 func (fam *RemotePrimaryForkedAlertmanager) DeleteSilence(ctx context.Context, id string) error {
-	return fam.remote.DeleteSilence(ctx, id)
+	if err := fam.remote.DeleteSilence(ctx, id); err != nil {
+		return err
+	}
+	if err := fam.internal.DeleteSilence(ctx, id); err != nil {
+		fam.log.Error("Error deleting silence in the internal Alertmanager", "err", err, "id", id)
+	}
+	return nil
 }
 
 func (fam *RemotePrimaryForkedAlertmanager) GetSilence(ctx context.Context, id string) (apimodels.GettableSilence, error) {


### PR DESCRIPTION
This PR implements the `DeleteSilence()` method in the forked Alertmanager struct for remote primary mode.

This method deletes a silence in the remote Alertmanager given a silence UID and then attempts to do the same in the internal Alertmanager. If we fail to delete a silence in the internal Alertmanager, we log the error.