### PR TITLE
DashboardScene: Fixes issue with mobile responsive layout due to repeated grid item class

### DIFF
--- a/public/app/features/dashboard-scene/scene/DashboardGridItem.test.tsx
+++ b/public/app/features/dashboard-scene/scene/DashboardGridItem.test.tsx
@@ -1,8 +1,10 @@
 import { getPanelPlugin } from '@grafana/data/test/__mocks__/pluginMocks';
 import { setPluginImportUtils } from '@grafana/runtime';
-import { SceneGridLayout } from '@grafana/scenes';
+import { SceneGridLayout, VizPanel } from '@grafana/scenes';
 
 import { activateFullSceneTree, buildPanelRepeaterScene } from '../utils/test-utils';
+
+import { DashboardGridItem } from './DashboardGridItem';
 
 setPluginImportUtils({
   importPanelPlugin: (id: string) => Promise.resolve(getPanelPlugin({})),
@@ -115,5 +117,19 @@ describe('PanelRepeaterGridItem', () => {
     expect(repeater.state.repeatedPanels?.[0].state.$variables?.state.variables[0].state.name).toBe(
       '_____default_sys_repeat_var_____'
     );
+  });
+
+  it('Should return className when repeat variable is set', () => {
+    const { repeater } = buildPanelRepeaterScene({ variableQueryTime: 0 });
+
+    expect(repeater.getClassName()).toBe('panel-repeater-grid-item');
+  });
+
+  it('Should not className variable is not set', () => {
+    const gridItem = new DashboardGridItem({
+      body: new VizPanel({ pluginId: 'text' }),
+    });
+
+    expect(gridItem.getClassName()).toBe('');
   });
 });

--- a/public/app/features/dashboard-scene/scene/DashboardGridItem.tsx
+++ b/public/app/features/dashboard-scene/scene/DashboardGridItem.tsx
@@ -170,7 +170,7 @@ export class DashboardGridItem extends SceneObjectBase<DashboardGridItemState> i
   }
 
   public getClassName() {
-    return 'panel-repeater-grid-item';
+    return this.state.variableName ? 'panel-repeater-grid-item' : '';
   }
 
   public isRepeated() {


### PR DESCRIPTION
After the introduction of DashboardGridItem the getClassName function was causing all grid items to have a `panel-repeater-grid-item` class, which was resulting in all non repeated panels having 0 height. 

