### PR TITLE
Util: Support parsing and splitting strings enclosed in quotes in util.SplitString

### DIFF
--- a/pkg/services/ldap/ldap.go
+++ b/pkg/services/ldap/ldap.go
@@ -18,6 +18,7 @@ import (
 	"github.com/grafana/grafana/pkg/services/login"
 	"github.com/grafana/grafana/pkg/services/org"
 	"github.com/grafana/grafana/pkg/setting"
+	"github.com/grafana/grafana/pkg/util"
 )
 
 // IConnection is interface for LDAP connection manipulation
@@ -99,7 +100,7 @@ func (server *Server) Dial() error {
 	var certPool *x509.CertPool
 	if server.Config.RootCACert != "" {
 		certPool = x509.NewCertPool()
-		for _, caCertFile := range strings.Split(server.Config.RootCACert, " ") {
+		for _, caCertFile := range util.SplitString(server.Config.RootCACert) {
 			// nolint:gosec
 			// We can ignore the gosec G304 warning on this one because `caCertFile` comes from ldap config.
 			pem, err := os.ReadFile(caCertFile)

--- a/pkg/util/strings.go
+++ b/pkg/util/strings.go
@@ -4,10 +4,13 @@ import (
 	"encoding/json"
 	"fmt"
 	"math"
+	"regexp"
 	"strings"
 	"time"
 	"unicode"
 )
+
+var stringListItemMatcher = regexp.MustCompile(`"[^"]+"|[^, ]+`)
 
 // StringsFallback2 returns the first of two not empty strings.
 func StringsFallback2(val1 string, val2 string) string {
@@ -42,6 +45,16 @@ func SplitString(str string) []string {
 			return []string{}
 		}
 		return res
+	}
+
+	// Support strings (with spaces) enclosed in quotation marks like "foo one", "bar two", "baz three"
+	if strings.Index(strings.TrimSpace(str), "\"") == 0 {
+		var result []string
+		matches := stringListItemMatcher.FindAllString(str, -1)
+		for _, match := range matches {
+			result = append(result, strings.Trim(match, "\""))
+		}
+		return result
 	}
 
 	return strings.Fields(strings.ReplaceAll(str, ",", " "))

--- a/pkg/util/strings.go
+++ b/pkg/util/strings.go
@@ -10,7 +10,7 @@ import (
 	"unicode"
 )
 
-var stringListItemMatcher = regexp.MustCompile(`"[^"]+"|[^, ]+`)
+var stringListItemMatcher = regexp.MustCompile(`"[^"]+"|[^,\t\n\v\f\r ]+`)
 
 // StringsFallback2 returns the first of two not empty strings.
 func StringsFallback2(val1 string, val2 string) string {
@@ -31,7 +31,8 @@ func stringsFallback(vals ...string) string {
 	return ""
 }
 
-// SplitString splits a string by commas or empty spaces.
+// SplitString splits a string and returns a list of strings. It supports JSON list syntax and strings separated by commas or spaces.
+// It supports quoted strings with spaces, e.g. "foo bar", "baz".
 func SplitString(str string) []string {
 	if len(str) == 0 {
 		return []string{}
@@ -47,17 +48,12 @@ func SplitString(str string) []string {
 		return res
 	}
 
-	// Support strings (with spaces) enclosed in quotation marks like "foo one", "bar two", "baz three"
-	if strings.Index(strings.TrimSpace(str), "\"") == 0 {
-		var result []string
-		matches := stringListItemMatcher.FindAllString(str, -1)
-		for _, match := range matches {
-			result = append(result, strings.Trim(match, "\""))
-		}
-		return result
+	var result []string
+	matches := stringListItemMatcher.FindAllString(str, -1)
+	for _, match := range matches {
+		result = append(result, strings.Trim(match, "\""))
 	}
-
-	return strings.Fields(strings.ReplaceAll(str, ",", " "))
+	return result
 }
 
 // GetAgeString returns a string representing certain time from years to minutes.

--- a/pkg/util/strings_test.go
+++ b/pkg/util/strings_test.go
@@ -56,7 +56,14 @@ func TestSplitString(t *testing.T) {
 		`["foo", "bar baz"]`:     {"foo", "bar baz"},
 		`["foo", "bar \"baz\""]`: {"foo", "bar \"baz\""},
 		` ["foo", "bar baz"]`:    {"foo", "bar baz"},
-		`[]`:                     {},
+		`"foo", "bar", "baz"`:    {"foo", "bar", "baz"},
+		`"foo" "bar" "baz"`:      {"foo", "bar", "baz"},
+		` "foo" "bar" "baz"  `:   {"foo", "bar", "baz"},
+		`"foo", "bar baz"`:       {"foo", "bar baz"},
+		`"foo", bar "baz"`:       {"foo", "bar", "baz"},
+		`"first string", "second string", "third string"`:               {"first string", "second string", "third string"},
+		`"first string" "second string" "third string" "fourth string"`: {"first string", "second string", "third string", "fourth string"},
+		`[]`: {},
 	}
 	for input, expected := range tests {
 		assert.EqualValues(t, expected, SplitString(input))


### PR DESCRIPTION
**What is this feature?**
Add support for parsing and splitting strings in the following formats:
1. `"first string", "second string", "third string"`, 
1. `"first string" "second string" "third string"`.

**Why do we need this feature?**
There are config parameters which are expecting a string list. Currently Grafana supports lists in a comma/space separated format and JSON list format (`[ "item1", "item2"]`). However there's another supported syntax which is used by the `role_values_*` config parameters of `auth.saml`. To unify and add JSON list syntax support for `role_values_*` (and be backward compatible) + to support strings which contain spaces in a list like the `root_ca_certs` from `ldap.toml`.

**Who is this feature for?**

[Add information on what kind of user the feature is for.]

**Which issue(s) does this PR fix?**:

Fixes #53942

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
