### PR TITLE
Grafana UI: `FilterPill.story.tsx` - Replace `HorizontalGroup` with `Stack`

### DIFF
--- a/.betterer.results
+++ b/.betterer.results
@@ -1,5 +1,5 @@
 // BETTERER RESULTS V2.
-// 
+//
 // If this file contains merge conflicts, use `betterer merge` to automatically resolve them:
 // https://phenomnomnominal.github.io/betterer/docs/results-file/#merge
 //

--- a/.betterer.results
+++ b/.betterer.results
@@ -1,5 +1,5 @@
 // BETTERER RESULTS V2.
-//
+// 
 // If this file contains merge conflicts, use `betterer merge` to automatically resolve them:
 // https://phenomnomnominal.github.io/betterer/docs/results-file/#merge
 //
@@ -819,9 +819,6 @@ exports[`better eslint`] = {
     ],
     "packages/grafana-ui/src/components/Dropdown/Dropdown.story.tsx:5381": [
       [0, 0, 0, "\'VerticalGroup\' import from \'../Layout/Layout\' is restricted from being used by a pattern. Use Stack component instead.", "0"]
-    ],
-    "packages/grafana-ui/src/components/FilterPill/FilterPill.story.tsx:5381": [
-      [0, 0, 0, "\'HorizontalGroup\' import from \'../Layout/Layout\' is restricted from being used by a pattern. Use Stack component instead.", "0"]
     ],
     "packages/grafana-ui/src/components/Forms/Checkbox.story.tsx:5381": [
       [0, 0, 0, "\'VerticalGroup\' import from \'../Layout/Layout\' is restricted from being used by a pattern. Use Stack component instead.", "0"]

--- a/packages/grafana-ui/src/components/FilterPill/FilterPill.story.tsx
+++ b/packages/grafana-ui/src/components/FilterPill/FilterPill.story.tsx
@@ -2,7 +2,7 @@ import { Meta, StoryFn } from '@storybook/react';
 import React, { useState } from 'react';
 
 import { getAvailableIcons } from '../../types';
-import { HorizontalGroup } from '../Layout/Layout';
+import { Stack } from '../Layout/Stack/Stack';
 
 import { FilterPill } from './FilterPill';
 import mdx from './FilterPill.mdx';
@@ -30,11 +30,11 @@ export const Example = () => {
   const elements = ['Singapore', 'Paris', 'Stockholm', 'New York', 'London'];
 
   return (
-    <HorizontalGroup>
+    <Stack>
       {elements.map((item) => (
         <FilterPill key={item} label={item} selected={item === selected} onClick={() => setSelected(item)} />
       ))}
-    </HorizontalGroup>
+    </Stack>
   );
 };
 


### PR DESCRIPTION
**What is this feature?**

This is part of the epic https://github.com/grafana/grafana/issues/85510

**Why do we need this feature?**
To replace deprecated layout components with new ones.

**Who is this feature for?**
Everybody

**Which issue(s) does this PR fix?:**

Fixes #

**Special notes for your reviewer:**

**Before:**
![Captura de pantalla 2024-04-08 a las 15 27 25](https://github.com/grafana/grafana/assets/65417731/f12e0682-ccfe-4d98-8c83-a93de2ca14ff)

![Captura de pantalla 2024-04-08 a las 15 27 15](https://github.com/grafana/grafana/assets/65417731/a298178b-e304-4fbb-987e-1f7b41c8b36b)

**After:**
![Captura de pantalla 2024-04-08 a las 15 27 52](https://github.com/grafana/grafana/assets/65417731/3b3db42c-8039-452e-a471-a2ecad4d856c)

![Captura de pantalla 2024-04-08 a las 15 28 11](https://github.com/grafana/grafana/assets/65417731/c7875a92-a59d-41e9-8041-e5cd6b41339e)


Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
