### PR TITLE
Dashboards: Add isViewing to mustKeepProps

### DIFF
--- a/public/app/features/dashboard/state/PanelModel.ts
+++ b/public/app/features/dashboard/state/PanelModel.ts
@@ -98,6 +98,7 @@ const mustKeepProps: { [str: string]: boolean } = {
   links: true,
   fullscreen: true,
   isEditing: true,
+  isViewing: true,
   hasRefreshed: true,
   events: true,
   cacheTimeout: true,


### PR DESCRIPTION
Fixes an issue where refreshing an auto-migrated panel in view mode caused it to be blank.