### PR TITLE
Plugins: Selectively load plugins using script tags

### DIFF
--- a/public/app/features/plugins/loader/cache.ts
+++ b/public/app/features/plugins/loader/cache.ts
@@ -1,15 +1,10 @@
 import { clearPluginSettingsCache } from '../pluginSettings';
 
-const cache: Record<string, CacheablePluginEntry> = {};
+const cache: Record<string, CacheablePlugin> = {};
 const initializedAt: number = Date.now();
 
 type CacheablePlugin = {
   path: string;
-  version: string;
-  isAngular?: boolean;
-};
-
-type CacheablePluginEntry = {
   version: string;
   isAngular?: boolean;
 };
@@ -20,6 +15,7 @@ export function registerPluginInCache({ path, version, isAngular }: CacheablePlu
     cache[key] = {
       version: encodeURI(version),
       isAngular,
+      path,
     };
   }
 }
@@ -37,13 +33,12 @@ export function resolveWithCache(url: string, defaultBust = initializedAt): stri
   if (!path) {
     return `${url}?_cache=${defaultBust}`;
   }
-
-  const version = cache[path].version;
+  const version = cache[path]?.version;
   const bust = version || defaultBust;
   return `${url}?_cache=${bust}`;
 }
 
-export function getPluginFromCache(path: string): CacheablePluginEntry | undefined {
+export function getPluginFromCache(path: string): CacheablePlugin | undefined {
   const key = extractPath(path);
   if (!key) {
     return;

--- a/public/app/features/plugins/loader/cache.ts
+++ b/public/app/features/plugins/loader/cache.ts
@@ -1,17 +1,26 @@
 import { clearPluginSettingsCache } from '../pluginSettings';
 
-const cache: Record<string, string> = {};
+const cache: Record<string, CacheablePluginEntry> = {};
 const initializedAt: number = Date.now();
 
 type CacheablePlugin = {
   path: string;
   version: string;
+  isAngular?: boolean;
 };
 
-export function registerPluginInCache({ path, version }: CacheablePlugin): void {
+type CacheablePluginEntry = {
+  version: string;
+  isAngular?: boolean;
+};
+
+export function registerPluginInCache({ path, version, isAngular }: CacheablePlugin): void {
   const key = extractPath(path);
   if (key && !cache[key]) {
-    cache[key] = encodeURI(version);
+    cache[key] = {
+      version: encodeURI(version),
+      isAngular,
+    };
   }
 }
 
@@ -29,9 +38,17 @@ export function resolveWithCache(url: string, defaultBust = initializedAt): stri
     return `${url}?_cache=${defaultBust}`;
   }
 
-  const version = cache[path];
+  const version = cache[path].version;
   const bust = version || defaultBust;
   return `${url}?_cache=${bust}`;
+}
+
+export function getPluginFromCache(path: string): CacheablePluginEntry | undefined {
+  const key = extractPath(path);
+  if (!key) {
+    return;
+  }
+  return cache[key];
 }
 
 function extractPath(address: string): string | undefined {

--- a/public/app/features/plugins/loader/types.ts
+++ b/public/app/features/plugins/loader/types.ts
@@ -4,5 +4,4 @@ export type SystemJSWithLoaderHooks = typeof System & {
   shouldFetch: (url: string) => Boolean;
   fetch: (url: string, options?: Record<string, unknown>) => Promise<Response>;
   onload: (err: unknown, id: string) => void;
-  prepareImport: () => Promise<void>;
 };

--- a/public/app/features/plugins/loader/types.ts
+++ b/public/app/features/plugins/loader/types.ts
@@ -1,7 +1,8 @@
 // Extend the System type with the loader hooks we use
 // to provide backwards compatibility with older version of Systemjs
 export type SystemJSWithLoaderHooks = typeof System & {
-  shouldFetch: () => Boolean;
+  shouldFetch: (url: string) => Boolean;
   fetch: (url: string, options?: Record<string, unknown>) => Promise<Response>;
   onload: (err: unknown, id: string) => void;
+  prepareImport: () => Promise<void>;
 };

--- a/public/app/features/plugins/plugin_loader.ts
+++ b/public/app/features/plugins/plugin_loader.ts
@@ -28,7 +28,7 @@ SystemJS.addImportMap({ imports });
 
 const systemJSPrototype: SystemJSWithLoaderHooks = SystemJS.constructor.prototype;
 
-// This controls whether SystemJS will load a plugin with a script tag or fetch and eval.
+// This instructs SystemJS to load a plugin using fetch and eval if it returns a truthy value, otherwise it will load the plugin using a script tag.
 // We only want to fetch and eval plugins that are hosted on a CDN or are Angular plugins.
 systemJSPrototype.shouldFetch = function (url) {
   const pluginInfo = getPluginFromCache(url);


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

This PR makes changes to the frontend Systemjs plugin loader to selectively load plugins via script tags instead of the fetch eval strategy. The logic in this PR will only load modern react plugins that are on the filesystem via script tags. Older angular plugins (which can contain various module formats) and plugins loaded via the CDN will continue to use fetch/eval as we need to be able to transform them.

**Why do we need this feature?**

- minor speed boost to plugin loading as we won't be passing large strings of javascript to eval.
- users that would like to enable CSP without `unsafe-eval`  can do so as long as they do not use Angular plugins or the FE sandbox.
- in the future plugin loading can take advantage of subresource integrity hashes to validate scripts before execution.

![image](https://github.com/grafana/grafana/assets/73201/6a057176-51e8-4d5f-be06-123c7ebd2ddb)


**Who is this feature for?**

Grafana users?

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #85746

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
