### PR TITLE
Grafana UI: `Modal` - Replace HorizontalGroup with Stack

### DIFF
--- a/.betterer.results
+++ b/.betterer.results
@@ -1,5 +1,5 @@
 // BETTERER RESULTS V2.
-// 
+//
 // If this file contains merge conflicts, use `betterer merge` to automatically resolve them:
 // https://phenomnomnominal.github.io/betterer/docs/results-file/#merge
 //

--- a/.betterer.results
+++ b/.betterer.results
@@ -1,5 +1,5 @@
 // BETTERER RESULTS V2.
-//
+// 
 // If this file contains merge conflicts, use `betterer merge` to automatically resolve them:
 // https://phenomnomnominal.github.io/betterer/docs/results-file/#merge
 //
@@ -863,9 +863,6 @@ exports[`better eslint`] = {
     ],
     "packages/grafana-ui/src/components/Menu/Menu.story.tsx:5381": [
       [0, 0, 0, "\'VerticalGroup\' import from \'../Layout/Layout\' is restricted from being used by a pattern. Use Stack component instead.", "0"]
-    ],
-    "packages/grafana-ui/src/components/Modal/Modal.tsx:5381": [
-      [0, 0, 0, "\'HorizontalGroup\' import from \'../Layout/Layout\' is restricted from being used by a pattern. Use Stack component instead.", "0"]
     ],
     "packages/grafana-ui/src/components/Modal/ModalsContext.tsx:5381": [
       [0, 0, 0, "Unexpected any. Specify a different type.", "0"],

--- a/packages/grafana-ui/src/components/Modal/Modal.tsx
+++ b/packages/grafana-ui/src/components/Modal/Modal.tsx
@@ -8,7 +8,7 @@ import { useStyles2 } from '../../themes';
 import { IconName } from '../../types';
 import { t } from '../../utils/i18n';
 import { IconButton } from '../IconButton/IconButton';
-import { HorizontalGroup } from '../Layout/Layout';
+import { Stack } from '../Layout/Stack/Stack';
 
 import { ModalHeader } from './ModalHeader';
 import { getModalStyles } from './getModalStyles';
@@ -105,23 +105,23 @@ function ModalButtonRow({ leftItems, children }: { leftItems?: React.ReactNode; 
   if (leftItems) {
     return (
       <div className={styles.modalButtonRow}>
-        <HorizontalGroup justify="space-between">
-          <HorizontalGroup justify="flex-start" spacing="md">
+        <Stack justifyContent="space-between">
+          <Stack justifyContent="flex-start" gap={2}>
             {leftItems}
-          </HorizontalGroup>
-          <HorizontalGroup justify="flex-end" spacing="md">
+          </Stack>
+          <Stack justifyContent="flex-end" gap={2}>
             {children}
-          </HorizontalGroup>
-        </HorizontalGroup>
+          </Stack>
+        </Stack>
       </div>
     );
   }
 
   return (
     <div className={styles.modalButtonRow}>
-      <HorizontalGroup justify="flex-end" spacing="md" wrap={true}>
+      <Stack justifyContent="flex-end" gap={2} wrap="wrap">
         {children}
-      </HorizontalGroup>
+      </Stack>
     </div>
   );
 }


### PR DESCRIPTION
What is this feature?

This is part of the epic https://github.com/grafana/grafana/issues/85510

Why do we need this feature?
To replace deprecated layout components with new ones.

Who is this feature for?
Everybody

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

**Before:**
![Captura de pantalla 2024-04-08 a las 18 52 17](https://github.com/grafana/grafana/assets/65417731/57c80de8-4cd8-4e6c-8433-b03e12d47cbe)

**After:**
![Captura de pantalla 2024-04-08 a las 18 53 10](https://github.com/grafana/grafana/assets/65417731/e16a1d80-3392-4e89-b305-99e8944e17ef)


Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
