### PR TITLE
RBAC: hide save button for users who can't save dashboard

### DIFF
--- a/public/app/features/dashboard/components/PanelEditor/PanelEditor.tsx
+++ b/public/app/features/dashboard/components/PanelEditor/PanelEditor.tsx
@@ -333,27 +333,28 @@ export class PanelEditorUnconnected extends PureComponent<Props> {
       >
         Discard
       </Button>,
-      this.props.panel.libraryPanel ? (
-        <Button
-          onClick={this.onSaveLibraryPanel}
-          variant="primary"
-          size={size}
-          title="Apply changes and save library panel"
-          key="save-panel"
-        >
-          Save library panel
-        </Button>
-      ) : (
-        <Button
-          onClick={this.onSaveDashboard}
-          title="Apply changes and save dashboard"
-          key="save"
-          size={size}
-          variant="secondary"
-        >
-          Save
-        </Button>
-      ),
+      this.props.dashboard.meta.canSave &&
+        (this.props.panel.libraryPanel ? (
+          <Button
+            onClick={this.onSaveLibraryPanel}
+            variant="primary"
+            size={size}
+            title="Apply changes and save library panel"
+            key="save-panel"
+          >
+            Save library panel
+          </Button>
+        ) : (
+          <Button
+            onClick={this.onSaveDashboard}
+            title="Apply changes and save dashboard"
+            key="save"
+            size={size}
+            variant="secondary"
+          >
+            Save
+          </Button>
+        )),
       <Button
         onClick={this.onBack}
         variant="primary"


### PR DESCRIPTION
**What is this feature?**

A tiny change to hide the dashboard save button for users who don't have access to save a dashboard (for instance, for users who can view and edit a dashboard when _viewers_can_edit_ is enabled, but aren't able to save the changes).

**Why do we need this feature?**

So that the UI matches what user can do on the backend.

This is how it looks for users with save access:
<img width="946" alt="Screenshot 2024-04-08 at 18 41 00" src="https://github.com/grafana/grafana/assets/9482349/1133bab4-4f47-4a01-85ef-02510177b14e">

And this is how it looks for users without save access:
<img width="951" alt="Screenshot 2024-04-08 at 18 41 23" src="https://github.com/grafana/grafana/assets/9482349/9accb165-b802-4399-bc47-3a9ab0a0a4b2">
