### PR TITLE
Dashboard data source: Return error when used in mixed data source

### DIFF
--- a/public/app/plugins/datasource/dashboard/datasource.ts
+++ b/public/app/plugins/datasource/dashboard/datasource.ts
@@ -6,7 +6,6 @@ import {
   DataQueryResponse,
   DataSourceInstanceSettings,
   TestDataSourceResponse,
-  LoadingState,
 } from '@grafana/data';
 import { SceneDataProvider, SceneDataTransformer, SceneObject } from '@grafana/scenes';
 import { findVizPanelByKey, getVizPanelKeyForPanelId } from 'app/features/dashboard-scene/utils/utils';

--- a/public/app/plugins/datasource/dashboard/datasource.ts
+++ b/public/app/plugins/datasource/dashboard/datasource.ts
@@ -6,6 +6,7 @@ import {
   DataQueryResponse,
   DataSourceInstanceSettings,
   TestDataSourceResponse,
+  LoadingState,
 } from '@grafana/data';
 import { SceneDataProvider, SceneDataTransformer, SceneObject } from '@grafana/scenes';
 import { findVizPanelByKey, getVizPanelKeyForPanelId } from 'app/features/dashboard-scene/utils/utils';
@@ -26,6 +27,10 @@ export class DashboardDatasource extends DataSourceApi<DashboardQuery> {
 
   query(options: DataQueryRequest<DashboardQuery>): Observable<DataQueryResponse> {
     const scene: SceneObject | undefined = options.scopedVars?.__sceneObject?.value;
+
+    if (options.requestId.indexOf('mixed') > -1) {
+      throw new Error('Dashboard data source cannot be used with Mixed data source.');
+    }
 
     if (!scene) {
       throw new Error('Can only be called from a scene');


### PR DESCRIPTION
Based on top of [mdvictor/update-dashboard-ds-panel-if-source-changes](https://github.com/grafana/grafana/pull/85655).


I think this fixes an issue described by @ivanortegaalba  in https://github.com/grafana/grafana/pull/85655#issuecomment-2042960663. 

This is just a proposal, that honestly I'm not super happy with. But it brings the previous architecture behavior of Dashboard ds. It wasn't a real data source as it was not implementing `query` method, and it just used to throw an error when used from Mixed ds (mixed ds basically executes `ds.query`).

Intuitively the current implementation of the Dashboard ds should just work fine with Mixed ds, but I can't figure out why the observable returned from dashboard ds query method is not respected by mixed ds flow. @torkelo maybe you have some idea, you a bot more experienced with rxjs than I am.



