### PR TITLE
InfluxDB: Fix panic when reading concurrency count during influxql health check

### DIFF
--- a/pkg/tsdb/influxdb/healthcheck.go
+++ b/pkg/tsdb/influxdb/healthcheck.go
@@ -37,7 +37,7 @@ func (s *Service) CheckHealth(ctx context.Context, req *backend.CheckHealthReque
 	case influxVersionFlux:
 		return CheckFluxHealth(ctx, dsInfo, req)
 	case influxVersionInfluxQL:
-		return CheckInfluxQLHealth(ctx, dsInfo, s.features)
+		return CheckInfluxQLHealth(ctx, dsInfo, req, s.features)
 	case influxVersionSQL:
 		return CheckSQLHealth(ctx, dsInfo, req)
 	default:
@@ -80,10 +80,12 @@ func CheckFluxHealth(ctx context.Context, dsInfo *models.DatasourceInfo,
 	return getHealthCheckMessage(logger, "", errors.New("error getting flux query buckets"))
 }
 
-func CheckInfluxQLHealth(ctx context.Context, dsInfo *models.DatasourceInfo, features featuremgmt.FeatureToggles) (*backend.CheckHealthResult, error) {
+func CheckInfluxQLHealth(ctx context.Context, dsInfo *models.DatasourceInfo, req *backend.CheckHealthRequest, features featuremgmt.FeatureToggles) (*backend.CheckHealthResult, error) {
 	logger := logger.FromContext(ctx)
 	tracer := tracing.DefaultTracer()
 	resp, err := influxql.Query(ctx, tracer, dsInfo, &backend.QueryDataRequest{
+		PluginContext: req.PluginContext,
+		Headers:       req.Headers,
 		Queries: []backend.DataQuery{
 			{
 				RefID:     refID,


### PR DESCRIPTION
**What is this feature?**

When `influxdbRunQueriesInParallel` is enabled for the InfluxDB data source, during "Save&Test" step, the data source panics because of a "Nil Pointer". This happens because now the query needs a config value. We try to read it from PluginContext from the request itself. But for the `healthcheck` request we don't forward the plugin context. So it panics. This PR is fixing this edge case. 

**Why do we need this feature?**

Better health check operation

**Who is this feature for?**

People who use `influxdbRunQueriesInParallel` feature flag.

**Special notes for your reviewer:**
### How to test
- Enable `influxdbRunQueriesInParallel` feature flag
- Try to create a new InfluxDB data source in `devenv`
  - URL: `http://localhost:8086`
  - Custom HTTP Headers
    - Header: `Authorization`
    - Value `Token mytoken`
  - Database: `mybucket` 
- Hit `Save&Test` and observe the error
- Switch to this branch and try again.

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
