### PR TITLE
Refactor: Store plugin load error in registry

### DIFF
--- a/pkg/plugins/manager/pipeline/bootstrap/bootstrap.go
+++ b/pkg/plugins/manager/pipeline/bootstrap/bootstrap.go
@@ -78,6 +78,9 @@ func (b *Bootstrap) Bootstrap(ctx context.Context, src plugins.PluginSource, fou
 			if err != nil {
 				stepFailed = true
 				b.log.Error("Could not decorate plugin", "pluginId", p.ID, "error", err)
+				p.Status.Errored = true
+				p.Status.Message = err.Error()
+				bootstrappedPlugins = append(bootstrappedPlugins, p)
 				break
 			}
 		}

--- a/pkg/plugins/manager/pipeline/bootstrap/bootstrap_test.go
+++ b/pkg/plugins/manager/pipeline/bootstrap/bootstrap_test.go
@@ -1,0 +1,50 @@
+package bootstrap
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/grafana/grafana/pkg/plugins"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBootstrap(t *testing.T) {
+	t.Run("Test Bootstrap", func(t *testing.T) {
+		p := &plugins.Plugin{}
+		opts := Opts{
+			ConstructFunc: func(ctx context.Context, src plugins.PluginSource, bundles []*plugins.FoundBundle) ([]*plugins.Plugin, error) {
+				return []*plugins.Plugin{p}, nil
+			},
+			DecorateFuncs: []DecorateFunc{
+				func(ctx context.Context, p *plugins.Plugin) (*plugins.Plugin, error) {
+					return p, nil
+				},
+			},
+		}
+		b := New(nil, opts)
+		res, err := b.Bootstrap(context.Background(), nil, nil)
+		require.NoError(t, err)
+		require.Equal(t, []*plugins.Plugin{p}, res)
+	})
+
+	t.Run("Test Bootstrap with decorate error", func(t *testing.T) {
+		p := &plugins.Plugin{}
+		opts := Opts{
+			ConstructFunc: func(ctx context.Context, src plugins.PluginSource, bundles []*plugins.FoundBundle) ([]*plugins.Plugin, error) {
+				return []*plugins.Plugin{p}, nil
+			},
+			DecorateFuncs: []DecorateFunc{
+				func(ctx context.Context, p *plugins.Plugin) (*plugins.Plugin, error) {
+					return nil, errors.New("decorate error")
+				},
+			},
+		}
+		b := New(nil, opts)
+		res, err := b.Bootstrap(context.Background(), nil, nil)
+		require.NoError(t, err)
+		require.Len(t, res, 1)
+		require.True(t, res[0].Status.Errored)
+		require.Equal(t, "decorate error", res[0].Status.Message)
+	})
+}

--- a/pkg/plugins/manager/pipeline/initialization/initialization_test.go
+++ b/pkg/plugins/manager/pipeline/initialization/initialization_test.go
@@ -1,0 +1,82 @@
+package initialization
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/grafana/grafana/pkg/plugins"
+	"github.com/grafana/grafana/pkg/plugins/manager/fakes"
+	"github.com/stretchr/testify/require"
+)
+
+func TestInitialize(t *testing.T) {
+	t.Run("Test Initialize", func(t *testing.T) {
+		p := &plugins.Plugin{}
+		opts := Opts{
+			InitializeFuncs: []InitializeFunc{},
+		}
+		b := New(nil, opts)
+		res, err := b.Initialize(context.Background(), []*plugins.Plugin{p})
+		require.NoError(t, err)
+		require.Equal(t, []*plugins.Plugin{p}, res)
+	})
+
+	t.Run("Test Initialize with error", func(t *testing.T) {
+		p := &plugins.Plugin{}
+		opts := Opts{
+			InitializeFuncs: []InitializeFunc{
+				func(ctx context.Context, p *plugins.Plugin) (*plugins.Plugin, error) {
+					return nil, errors.New("initialize error")
+				},
+			},
+		}
+		b := New(nil, opts)
+		res, err := b.Initialize(context.Background(), []*plugins.Plugin{p})
+		require.NoError(t, err)
+		require.Len(t, res, 1)
+		require.True(t, res[0].Status.Errored)
+		require.Equal(t, "initialize error", res[0].Status.Message)
+	})
+
+	t.Run("Test Initialize with existing error", func(t *testing.T) {
+		p := &plugins.Plugin{
+			Status: plugins.PluginStatus{
+				Errored: true,
+				Message: "bootstrap error",
+			},
+		}
+		opts := Opts{
+			InitializeFuncs: []InitializeFunc{
+				func(ctx context.Context, p *plugins.Plugin) (*plugins.Plugin, error) {
+					return p, nil
+				},
+			},
+		}
+		b := New(nil, opts)
+		res, err := b.Initialize(context.Background(), []*plugins.Plugin{p})
+		require.NoError(t, err)
+		require.Len(t, res, 1)
+		require.True(t, res[0].Status.Errored)
+		require.Equal(t, "bootstrap error", res[0].Status.Message)
+	})
+
+	t.Run("Test Initialize should register a plugin even after an error", func(t *testing.T) {
+		p := &plugins.Plugin{
+			Status: plugins.PluginStatus{
+				Errored: true,
+				Message: "bootstrap error",
+			},
+		}
+		pluginRegistry := fakes.NewFakePluginRegistry()
+		register := PluginRegistrationStep(pluginRegistry)
+		opts := Opts{
+			InitializeFuncs: []InitializeFunc{register},
+		}
+		b := New(nil, opts)
+		res, err := b.Initialize(context.Background(), []*plugins.Plugin{p})
+		require.NoError(t, err)
+		require.Len(t, res, 1)
+		require.Len(t, pluginRegistry.Plugins(context.Background()), 1)
+	})
+}

--- a/pkg/plugins/manager/pipeline/initialization/steps.go
+++ b/pkg/plugins/manager/pipeline/initialization/steps.go
@@ -3,6 +3,8 @@ package initialization
 import (
 	"context"
 	"errors"
+	"reflect"
+	"runtime"
 
 	"github.com/grafana/grafana/pkg/plugins"
 	"github.com/grafana/grafana/pkg/plugins/envvars"
@@ -114,4 +116,12 @@ func (r *PluginRegistration) Initialize(ctx context.Context, p *plugins.Plugin) 
 	}
 
 	return p, nil
+}
+
+func getFunctionName(i interface{}) string {
+	return runtime.FuncForPC(reflect.ValueOf(i).Pointer()).Name()
+}
+
+func isRegistrationFunc(i interface{}) bool {
+	return getFunctionName(i) == getFunctionName((&PluginRegistration{}).Initialize)
 }

--- a/pkg/plugins/manager/pipeline/validation/validation_test.go
+++ b/pkg/plugins/manager/pipeline/validation/validation_test.go
@@ -1,0 +1,62 @@
+package validation
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/grafana/grafana/pkg/plugins"
+	"github.com/stretchr/testify/require"
+)
+
+func TestValidate(t *testing.T) {
+	t.Run("Test Validate", func(t *testing.T) {
+		p := &plugins.Plugin{}
+		opts := Opts{
+			ValidateFuncs: []ValidateFunc{},
+		}
+		b := New(nil, opts)
+		res, err := b.Validate(context.Background(), []*plugins.Plugin{p})
+		require.NoError(t, err)
+		require.Equal(t, []*plugins.Plugin{p}, res)
+	})
+
+	t.Run("Test Validate with error", func(t *testing.T) {
+		p := &plugins.Plugin{}
+		opts := Opts{
+			ValidateFuncs: []ValidateFunc{
+				func(ctx context.Context, p *plugins.Plugin) error {
+					return errors.New("Validate error")
+				},
+			},
+		}
+		b := New(nil, opts)
+		res, err := b.Validate(context.Background(), []*plugins.Plugin{p})
+		require.NoError(t, err)
+		require.Len(t, res, 1)
+		require.True(t, res[0].Status.Errored)
+		require.Equal(t, "Validate error", res[0].Status.Message)
+	})
+
+	t.Run("Test Validate with existing error", func(t *testing.T) {
+		p := &plugins.Plugin{
+			Status: plugins.PluginStatus{
+				Errored: true,
+				Message: "bootstrap error",
+			},
+		}
+		opts := Opts{
+			ValidateFuncs: []ValidateFunc{
+				func(ctx context.Context, p *plugins.Plugin) error {
+					return nil
+				},
+			},
+		}
+		b := New(nil, opts)
+		res, err := b.Validate(context.Background(), []*plugins.Plugin{p})
+		require.NoError(t, err)
+		require.Len(t, res, 1)
+		require.True(t, res[0].Status.Errored)
+		require.Equal(t, "bootstrap error", res[0].Status.Message)
+	})
+}

--- a/pkg/plugins/manager/process/process.go
+++ b/pkg/plugins/manager/process/process.go
@@ -20,7 +20,7 @@ func ProvideService() *Service {
 }
 
 func (s *Service) Start(ctx context.Context, p *plugins.Plugin) error {
-	if !p.IsManaged() || !p.Backend || p.SignatureError != nil {
+	if !p.IsManaged() || !p.Backend || p.SignatureError != nil || p.Status.Errored {
 		return nil
 	}
 

--- a/pkg/plugins/manager/process/process_test.go
+++ b/pkg/plugins/manager/process/process_test.go
@@ -24,6 +24,7 @@ func TestProcessManager_Start(t *testing.T) {
 			managed            bool
 			backend            bool
 			signatureError     *plugins.SignatureError
+			statusError        bool
 			expectedStartCount int
 		}{
 			{
@@ -48,6 +49,13 @@ func TestProcessManager_Start(t *testing.T) {
 				expectedStartCount: 0,
 			},
 			{
+				name:               "Managed backend plugin with status error will not be started",
+				managed:            true,
+				backend:            true,
+				statusError:        true,
+				expectedStartCount: 0,
+			},
+			{
 				name:               "Managed backend plugin with no signature errors will be started",
 				managed:            true,
 				backend:            true,
@@ -66,6 +74,7 @@ func TestProcessManager_Start(t *testing.T) {
 				p := createPlugin(t, bp, func(plugin *plugins.Plugin) {
 					plugin.Backend = tc.backend
 					plugin.SignatureError = tc.signatureError
+					plugin.Status.Errored = tc.statusError
 				})
 
 				m := ProvideService()

--- a/pkg/plugins/manager/registry/in_memory.go
+++ b/pkg/plugins/manager/registry/in_memory.go
@@ -27,7 +27,11 @@ func NewInMemory() *InMemory {
 }
 
 func (i *InMemory) Plugin(_ context.Context, pluginID, _ string) (*plugins.Plugin, bool) {
-	return i.plugin(pluginID)
+	p, exists := i.plugin(pluginID)
+	if !exists {
+		return nil, false
+	}
+	return p, !p.Status.Errored
 }
 
 func (i *InMemory) Plugins(_ context.Context) []*plugins.Plugin {
@@ -36,7 +40,9 @@ func (i *InMemory) Plugins(_ context.Context) []*plugins.Plugin {
 
 	res := make([]*plugins.Plugin, 0, len(i.store))
 	for _, p := range i.store {
-		res = append(res, p)
+		if !p.Status.Errored {
+			res = append(res, p)
+		}
 	}
 
 	return res

--- a/pkg/plugins/manager/registry/in_memory_test.go
+++ b/pkg/plugins/manager/registry/in_memory_test.go
@@ -179,6 +179,33 @@ func TestInMemory_Plugin(t *testing.T) {
 			expected: nil,
 			exists:   false,
 		},
+		{
+			name: "Errored plugin",
+			mocks: mocks{
+				store: map[string]*plugins.Plugin{
+					pluginID: {
+						JSONData: plugins.JSONData{
+							ID: pluginID,
+						},
+						Status: plugins.PluginStatus{
+							Errored: true,
+						},
+					},
+				},
+			},
+			args: args{
+				pluginID: pluginID,
+			},
+			expected: &plugins.Plugin{
+				JSONData: plugins.JSONData{
+					ID: pluginID,
+				},
+				Status: plugins.PluginStatus{
+					Errored: true,
+				},
+			},
+			exists: false,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -238,6 +265,33 @@ func TestInMemory_Plugins(t *testing.T) {
 				store: map[string]*plugins.Plugin{},
 			},
 			expected: []*plugins.Plugin{},
+		},
+		{
+			name: "Plugins with errors",
+			mocks: mocks{
+				store: map[string]*plugins.Plugin{
+					pluginID: {
+						JSONData: plugins.JSONData{
+							ID: pluginID,
+						},
+					},
+					"test-panel": {
+						JSONData: plugins.JSONData{
+							ID: "test-panel",
+						},
+						Status: plugins.PluginStatus{
+							Errored: true,
+						},
+					},
+				},
+			},
+			expected: []*plugins.Plugin{
+				{
+					JSONData: plugins.JSONData{
+						ID: pluginID,
+					},
+				},
+			},
 		},
 	}
 	for _, tt := range tests {

--- a/pkg/plugins/plugins.go
+++ b/pkg/plugins/plugins.go
@@ -66,12 +66,19 @@ type Plugin struct {
 
 	SkipHostEnvVars bool
 
+	Status PluginStatus
+
 	mu sync.Mutex
 }
 
 type AngularMeta struct {
 	Detected        bool `json:"detected"`
 	HideDeprecation bool `json:"hideDeprecation"`
+}
+
+type PluginStatus struct {
+	Errored bool
+	Message string
 }
 
 // JSONData represents the plugin's plugin.json

--- a/pkg/services/pluginsintegration/pluginstore/plugins.go
+++ b/pkg/services/pluginsintegration/pluginstore/plugins.go
@@ -32,6 +32,8 @@ type Plugin struct {
 
 	Angular plugins.AngularMeta
 
+	Status plugins.PluginStatus
+
 	ExternalService *auth.ExternalService
 }
 
@@ -73,6 +75,7 @@ func ToGrafanaDTO(p *plugins.Plugin) Plugin {
 		Module:            p.Module,
 		BaseURL:           p.BaseURL,
 		ExternalService:   p.ExternalService,
+		Status:            p.Status,
 
 		Angular: p.Angular,
 	}

--- a/pkg/services/pluginsintegration/pluginstore/store.go
+++ b/pkg/services/pluginsintegration/pluginstore/store.go
@@ -66,9 +66,13 @@ func New(pluginRegistry registry.Service, pluginLoader loader.Service) *Service 
 }
 
 func (s *Service) Plugin(ctx context.Context, pluginID string) (Plugin, bool) {
-	p, exists := s.plugin(ctx, pluginID)
-	if !exists {
-		return Plugin{}, false
+	p, loaded := s.plugin(ctx, pluginID)
+	if !loaded {
+		if p == nil {
+			return Plugin{}, false
+		} else {
+			return ToGrafanaDTO(p), false
+		}
 	}
 
 	return ToGrafanaDTO(p), true
@@ -105,9 +109,9 @@ func (s *Service) SecretsManager(ctx context.Context) *plugins.Plugin {
 
 // plugin finds a plugin with `pluginID` from the registry that is not decommissioned
 func (s *Service) plugin(ctx context.Context, pluginID string) (*plugins.Plugin, bool) {
-	p, exists := s.pluginRegistry.Plugin(ctx, pluginID, "") // version is not required since Grafana only supports single versions of a plugin
-	if !exists {
-		return nil, false
+	p, loaded := s.pluginRegistry.Plugin(ctx, pluginID, "") // version is not required since Grafana only supports single versions of a plugin
+	if !loaded {
+		return p, false
 	}
 
 	if p.IsDecommissioned() {

--- a/pkg/services/pluginsintegration/pluginstore/store_test.go
+++ b/pkg/services/pluginsintegration/pluginstore/store_test.go
@@ -71,6 +71,26 @@ func TestStore_Plugin(t *testing.T) {
 		require.True(t, exists)
 		require.Equal(t, p, ToGrafanaDTO(p2))
 	})
+
+	t.Run("Plugin returns an errored plugin", func(t *testing.T) {
+		p1 := &plugins.Plugin{
+			JSONData: plugins.JSONData{ID: "test-datasource"},
+			Status:   plugins.PluginStatus{Errored: true, Message: "error"},
+		}
+
+		ps := New(&fakes.FakePluginRegistry{
+			Store: map[string]*plugins.Plugin{
+				p1.ID: p1,
+			},
+		}, &fakes.FakeLoader{})
+
+		p, loaded := ps.Plugin(context.Background(), p1.ID)
+		require.False(t, loaded)
+		require.Equal(t, Plugin{
+			JSONData: p1.JSONData,
+			Status:   p1.Status,
+		}, p)
+	})
 }
 
 func TestStore_Plugins(t *testing.T) {


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

Allow to store plugins that failed at some point of the loading pipeline in the plugin registry.

No (intended) functional change here. The errored plugins are still removed from the plugin list so the API does not include any change. That will come later.

See more comments inline.

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

First step of #85519

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle.
- [x] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
