### PR TITLE
Session: set authID and authenticatedBy

### DIFF
--- a/pkg/api/login.go
+++ b/pkg/api/login.go
@@ -243,13 +243,7 @@ func (hs *HTTPServer) loginUserWithUser(user *user.User, c *contextmodel.ReqCont
 func (hs *HTTPServer) Logout(c *contextmodel.ReqContext) {
 	// FIXME: restructure saml client to implement authn.LogoutClient
 	if hs.samlSingleLogoutEnabled() {
-		id, err := identity.UserIdentifier(c.SignedInUser.GetNamespacedID())
-		if err != nil {
-			hs.log.Error("failed to retrieve user ID", "error", err)
-		}
-
-		authInfo, _ := hs.authInfoService.GetAuthInfo(c.Req.Context(), &loginservice.GetAuthInfoQuery{UserId: id})
-		if authInfo != nil && authInfo.AuthModule == loginservice.SAMLAuthModule {
+		if c.SignedInUser.GetAuthenticatedBy() == loginservice.SAMLAuthModule {
 			c.Redirect(hs.Cfg.AppSubURL + "/logout/saml")
 			return
 		}

--- a/pkg/api/login_test.go
+++ b/pkg/api/login_test.go
@@ -30,7 +30,6 @@ import (
 	"github.com/grafana/grafana/pkg/services/hooks"
 	"github.com/grafana/grafana/pkg/services/licensing"
 	"github.com/grafana/grafana/pkg/services/licensing/licensingtest"
-	"github.com/grafana/grafana/pkg/services/login"
 	loginservice "github.com/grafana/grafana/pkg/services/login"
 	"github.com/grafana/grafana/pkg/services/login/authinfotest"
 	"github.com/grafana/grafana/pkg/services/navtree"
@@ -672,7 +671,7 @@ func TestLogoutSaml(t *testing.T) {
 	sc.defaultHandler = routing.Wrap(func(c *contextmodel.ReqContext) response.Response {
 		c.SignedInUser = &user.SignedInUser{
 			UserID:          1,
-			AuthenticatedBy: login.SAMLAuthModule,
+			AuthenticatedBy: loginservice.SAMLAuthModule,
 		}
 		hs.Logout(c)
 		return response.Empty(http.StatusOK)

--- a/pkg/api/login_test.go
+++ b/pkg/api/login_test.go
@@ -30,6 +30,7 @@ import (
 	"github.com/grafana/grafana/pkg/services/hooks"
 	"github.com/grafana/grafana/pkg/services/licensing"
 	"github.com/grafana/grafana/pkg/services/licensing/licensingtest"
+	"github.com/grafana/grafana/pkg/services/login"
 	loginservice "github.com/grafana/grafana/pkg/services/login"
 	"github.com/grafana/grafana/pkg/services/login/authinfotest"
 	"github.com/grafana/grafana/pkg/services/navtree"
@@ -670,7 +671,8 @@ func TestLogoutSaml(t *testing.T) {
 	assert.Equal(t, true, hs.samlSingleLogoutEnabled())
 	sc.defaultHandler = routing.Wrap(func(c *contextmodel.ReqContext) response.Response {
 		c.SignedInUser = &user.SignedInUser{
-			UserID: 1,
+			UserID:          1,
+			AuthenticatedBy: login.SAMLAuthModule,
 		}
 		hs.Logout(c)
 		return response.Empty(http.StatusOK)

--- a/pkg/services/auth/identity/requester.go
+++ b/pkg/services/auth/identity/requester.go
@@ -53,9 +53,12 @@ type Requester interface {
 	// DEPRECATED: GetOrgName returns the name of the active organization.
 	// Retrieve the organization name from the organization service instead of using this method.
 	GetOrgName() string
+	// GetAuthID returns external id for entity.
+	GetAuthID() string
+	// GetAuthenticatedBy returns the authentication method used to authenticate the entity.
+	GetAuthenticatedBy() string
 	// IsAuthenticatedBy returns true if entity was authenticated by any of supplied providers.
 	IsAuthenticatedBy(providers ...string) bool
-
 	// IsNil returns true if the identity is nil
 	// FIXME: remove this method once all services are using an interface
 	IsNil() bool
@@ -69,8 +72,6 @@ type Requester interface {
 	GetCacheKey() string
 	// HasUniqueId returns true if the entity has a unique id
 	HasUniqueId() bool
-	// AuthenticatedBy returns the authentication method used to authenticate the entity.
-	GetAuthenticatedBy() string
 	// GetIDToken returns a signed token representing the identity that can be forwarded to plugins and external services.
 	// Will only be set when featuremgmt.FlagIdForwarding is enabled.
 	GetIDToken() string

--- a/pkg/services/auth/idimpl/service.go
+++ b/pkg/services/auth/idimpl/service.go
@@ -16,7 +16,6 @@ import (
 	"github.com/grafana/grafana/pkg/services/auth/identity"
 	"github.com/grafana/grafana/pkg/services/authn"
 	"github.com/grafana/grafana/pkg/services/featuremgmt"
-	"github.com/grafana/grafana/pkg/services/login"
 	"github.com/grafana/grafana/pkg/setting"
 )
 
@@ -31,12 +30,12 @@ var _ auth.IDService = (*Service)(nil)
 func ProvideService(
 	cfg *setting.Cfg, signer auth.IDSigner, cache remotecache.CacheStorage,
 	features featuremgmt.FeatureToggles, authnService authn.Service,
-	authInfoService login.AuthInfoService, reg prometheus.Registerer,
+	reg prometheus.Registerer,
 ) *Service {
 	s := &Service{
 		cfg: cfg, logger: log.New("id-service"),
 		signer: signer, cache: cache,
-		authInfoService: authInfoService, metrics: newMetrics(reg),
+		metrics: newMetrics(reg),
 	}
 
 	if features.IsEnabledGlobally(featuremgmt.FlagIdForwarding) {
@@ -47,13 +46,12 @@ func ProvideService(
 }
 
 type Service struct {
-	cfg             *setting.Cfg
-	logger          log.Logger
-	signer          auth.IDSigner
-	cache           remotecache.CacheStorage
-	authInfoService login.AuthInfoService
-	si              singleflight.Group
-	metrics         *metrics
+	cfg     *setting.Cfg
+	logger  log.Logger
+	signer  auth.IDSigner
+	cache   remotecache.CacheStorage
+	si      singleflight.Group
+	metrics *metrics
 }
 
 func (s *Service) SignIdentity(ctx context.Context, id identity.Requester) (string, error) {

--- a/pkg/services/auth/idimpl/service_test.go
+++ b/pkg/services/auth/idimpl/service_test.go
@@ -16,8 +16,6 @@ import (
 	"github.com/grafana/grafana/pkg/services/authn/authntest"
 	"github.com/grafana/grafana/pkg/services/featuremgmt"
 	"github.com/grafana/grafana/pkg/services/login"
-	"github.com/grafana/grafana/pkg/services/login/authinfotest"
-	"github.com/grafana/grafana/pkg/services/user"
 	"github.com/grafana/grafana/pkg/setting"
 )
 
@@ -32,7 +30,7 @@ func Test_ProvideService(t *testing.T) {
 			},
 		}
 
-		_ = ProvideService(setting.NewCfg(), nil, nil, features, authnService, nil, nil)
+		_ = ProvideService(setting.NewCfg(), nil, nil, features, authnService, nil)
 		assert.True(t, hookRegistered)
 	})
 
@@ -46,7 +44,7 @@ func Test_ProvideService(t *testing.T) {
 			},
 		}
 
-		_ = ProvideService(setting.NewCfg(), nil, nil, features, authnService, nil, nil)
+		_ = ProvideService(setting.NewCfg(), nil, nil, features, authnService, nil)
 		assert.False(t, hookRegistered)
 	})
 }
@@ -69,7 +67,7 @@ func TestService_SignIdentity(t *testing.T) {
 		s := ProvideService(
 			setting.NewCfg(), signer, remotecache.NewFakeCacheStorage(),
 			featuremgmt.WithFeatures(featuremgmt.FlagIdForwarding),
-			&authntest.FakeService{}, &authinfotest.FakeService{ExpectedError: user.ErrUserNotFound}, nil,
+			&authntest.FakeService{}, nil,
 		)
 		token, err := s.SignIdentity(context.Background(), &authn.Identity{ID: "user:1"})
 		require.NoError(t, err)
@@ -80,9 +78,9 @@ func TestService_SignIdentity(t *testing.T) {
 		s := ProvideService(
 			setting.NewCfg(), signer, remotecache.NewFakeCacheStorage(),
 			featuremgmt.WithFeatures(featuremgmt.FlagIdForwarding),
-			&authntest.FakeService{}, &authinfotest.FakeService{ExpectedUserAuth: &login.UserAuth{AuthModule: login.AzureADAuthModule}}, nil,
+			&authntest.FakeService{}, nil,
 		)
-		token, err := s.SignIdentity(context.Background(), &authn.Identity{ID: "user:1"})
+		token, err := s.SignIdentity(context.Background(), &authn.Identity{ID: "user:1", AuthenticatedBy: login.AzureADAuthModule})
 		require.NoError(t, err)
 
 		parsed, err := jwt.ParseSigned(token)

--- a/pkg/services/authn/authn.go
+++ b/pkg/services/authn/authn.go
@@ -136,7 +136,7 @@ type RedirectClient interface {
 // that should happen during logout and supports client specific redirect URL.
 type LogoutClient interface {
 	Client
-	Logout(ctx context.Context, user identity.Requester, info *login.UserAuth) (*Redirect, bool)
+	Logout(ctx context.Context, user identity.Requester) (*Redirect, bool)
 }
 
 type PasswordClient interface {

--- a/pkg/services/authn/authnimpl/registration.go
+++ b/pkg/services/authn/authnimpl/registration.go
@@ -43,7 +43,7 @@ func ProvideRegistration(
 	authnSvc.RegisterClient(clients.ProvideAPIKey(apikeyService))
 
 	if cfg.LoginCookieName != "" {
-		authnSvc.RegisterClient(clients.ProvideSession(cfg, sessionService))
+		authnSvc.RegisterClient(clients.ProvideSession(cfg, sessionService, authInfoService))
 	}
 
 	var proxyClients []authn.ProxyClient

--- a/pkg/services/authn/authnimpl/service.go
+++ b/pkg/services/authn/authnimpl/service.go
@@ -19,7 +19,6 @@ import (
 	"github.com/grafana/grafana/pkg/services/auth/identity"
 	"github.com/grafana/grafana/pkg/services/authn"
 	"github.com/grafana/grafana/pkg/services/authn/clients"
-	"github.com/grafana/grafana/pkg/services/login"
 	"github.com/grafana/grafana/pkg/services/user"
 	"github.com/grafana/grafana/pkg/setting"
 	"github.com/grafana/grafana/pkg/util/errutil"
@@ -47,20 +46,18 @@ func ProvideIdentitySynchronizer(s *Service) authn.IdentitySynchronizer {
 
 func ProvideService(
 	cfg *setting.Cfg, tracer tracing.Tracer,
-	sessionService auth.UserTokenService, usageStats usagestats.Service,
-	authInfoService login.AuthInfoService, registerer prometheus.Registerer,
+	sessionService auth.UserTokenService, usageStats usagestats.Service, registerer prometheus.Registerer,
 ) *Service {
 	s := &Service{
-		log:             log.New("authn.service"),
-		cfg:             cfg,
-		clients:         make(map[string]authn.Client),
-		clientQueue:     newQueue[authn.ContextAwareClient](),
-		tracer:          tracer,
-		metrics:         newMetrics(registerer),
-		authInfoService: authInfoService,
-		sessionService:  sessionService,
-		postAuthHooks:   newQueue[authn.PostAuthHookFn](),
-		postLoginHooks:  newQueue[authn.PostLoginHookFn](),
+		log:            log.New("authn.service"),
+		cfg:            cfg,
+		clients:        make(map[string]authn.Client),
+		clientQueue:    newQueue[authn.ContextAwareClient](),
+		tracer:         tracer,
+		metrics:        newMetrics(registerer),
+		sessionService: sessionService,
+		postAuthHooks:  newQueue[authn.PostAuthHookFn](),
+		postLoginHooks: newQueue[authn.PostLoginHookFn](),
 	}
 
 	usageStats.RegisterMetricsFunc(s.getUsageStats)
@@ -77,8 +74,7 @@ type Service struct {
 	tracer  tracing.Tracer
 	metrics *metrics
 
-	authInfoService login.AuthInfoService
-	sessionService  auth.UserTokenService
+	sessionService auth.UserTokenService
 
 	// postAuthHooks are called after a successful authentication. They can modify the identity.
 	postAuthHooks *queue[authn.PostAuthHookFn]
@@ -259,9 +255,8 @@ func (s *Service) Logout(ctx context.Context, user identity.Requester, sessionTo
 		return redirect, nil
 	}
 
-	info, _ := s.authInfoService.GetAuthInfo(ctx, &login.GetAuthInfoQuery{UserId: userID})
-	if info != nil {
-		client := authn.ClientWithPrefix(strings.TrimPrefix(info.AuthModule, "oauth_"))
+	if authModule := user.GetAuthenticatedBy(); authModule != "" {
+		client := authn.ClientWithPrefix(strings.TrimPrefix(authModule, "oauth_"))
 
 		c, ok := s.clients[client]
 		if !ok {
@@ -275,7 +270,7 @@ func (s *Service) Logout(ctx context.Context, user identity.Requester, sessionTo
 			goto Default
 		}
 
-		clientRedirect, ok := logoutClient.Logout(ctx, user, info)
+		clientRedirect, ok := logoutClient.Logout(ctx, user)
 		if !ok {
 			goto Default
 		}

--- a/pkg/services/authn/authnimpl/sync/oauth_token_sync.go
+++ b/pkg/services/authn/authnimpl/sync/oauth_token_sync.go
@@ -3,6 +3,7 @@ package sync
 import (
 	"context"
 	"errors"
+	"strings"
 	"time"
 
 	"golang.org/x/sync/singleflight"
@@ -39,8 +40,13 @@ func (s *OAuthTokenSync) SyncOauthTokenHook(ctx context.Context, identity *authn
 		return nil
 	}
 
-	// not authenticated through session tokens, so we can skip this hook
+	// Not authenticated through session tokens, so we can skip this hook.
 	if identity.SessionToken == nil {
+		return nil
+	}
+
+	// Not authenticated with a oauth provider, so we can skip this hook.
+	if !strings.HasPrefix(identity.GetAuthenticatedBy(), "oauth") {
 		return nil
 	}
 

--- a/pkg/services/authn/authnimpl/sync/oauth_token_sync_test.go
+++ b/pkg/services/authn/authnimpl/sync/oauth_token_sync_test.go
@@ -51,7 +51,7 @@ func TestOAuthTokenSync_SyncOAuthTokenHook(t *testing.T) {
 		},
 		{
 			desc:                              "should invalidate access token and session token if token refresh fails",
-			identity:                          &authn.Identity{ID: "user:1", SessionToken: &auth.UserToken{}},
+			identity:                          &authn.Identity{ID: "user:1", SessionToken: &auth.UserToken{}, AuthenticatedBy: login.AzureADAuthModule},
 			expectHasEntryCalled:              true,
 			expectedTryRefreshErr:             errors.New("some err"),
 			expectTryRefreshTokenCalled:       true,
@@ -62,7 +62,7 @@ func TestOAuthTokenSync_SyncOAuthTokenHook(t *testing.T) {
 		},
 		{
 			desc:                              "should refresh the token successfully",
-			identity:                          &authn.Identity{ID: "user:1", SessionToken: &auth.UserToken{}},
+			identity:                          &authn.Identity{ID: "user:1", SessionToken: &auth.UserToken{}, AuthenticatedBy: login.AzureADAuthModule},
 			expectHasEntryCalled:              false,
 			expectTryRefreshTokenCalled:       true,
 			expectInvalidateOauthTokensCalled: false,
@@ -70,7 +70,7 @@ func TestOAuthTokenSync_SyncOAuthTokenHook(t *testing.T) {
 		},
 		{
 			desc:                              "should not invalidate the token if the token has already been refreshed by another request (singleflight)",
-			identity:                          &authn.Identity{ID: "user:1", SessionToken: &auth.UserToken{}},
+			identity:                          &authn.Identity{ID: "user:1", SessionToken: &auth.UserToken{}, AuthenticatedBy: login.AzureADAuthModule},
 			expectHasEntryCalled:              true,
 			expectTryRefreshTokenCalled:       true,
 			expectInvalidateOauthTokensCalled: false,

--- a/pkg/services/authn/authnimpl/sync/user_sync.go
+++ b/pkg/services/authn/authnimpl/sync/user_sync.go
@@ -135,21 +135,6 @@ func (s *UserSync) FetchSyncedUserHook(ctx context.Context, identity *authn.Iden
 	}
 
 	syncSignedInUserToIdentity(usr, identity)
-
-	if authidentity.IsNamespace(namespace, authn.NamespaceUser) && identity.AuthenticatedBy != "" {
-		info, err := s.authInfoService.GetAuthInfo(ctx, &login.GetAuthInfoQuery{
-			UserId: userID,
-		})
-		if err != nil {
-			if !errors.Is(err, user.ErrUserNotFound) {
-				s.log.FromContext(ctx).Error("Failed to resolve authentication provider", "err", err)
-			}
-		} else {
-			identity.AuthID = info.AuthId
-			identity.AuthenticatedBy = info.AuthModule
-		}
-	}
-
 	return nil
 }
 

--- a/pkg/services/authn/authntest/mock.go
+++ b/pkg/services/authn/authntest/mock.go
@@ -6,7 +6,6 @@ import (
 	"github.com/grafana/grafana/pkg/models/usertoken"
 	"github.com/grafana/grafana/pkg/services/auth/identity"
 	"github.com/grafana/grafana/pkg/services/authn"
-	"github.com/grafana/grafana/pkg/services/login"
 )
 
 var _ authn.Service = new(MockService)
@@ -68,7 +67,7 @@ type MockClient struct {
 	TestFunc         func(ctx context.Context, r *authn.Request) bool
 	PriorityFunc     func() uint
 	HookFunc         func(ctx context.Context, identity *authn.Identity, r *authn.Request) error
-	LogoutFunc       func(ctx context.Context, user identity.Requester, info *login.UserAuth) (*authn.Redirect, bool)
+	LogoutFunc       func(ctx context.Context, user identity.Requester) (*authn.Redirect, bool)
 }
 
 func (m MockClient) Name() string {
@@ -106,9 +105,9 @@ func (m MockClient) Hook(ctx context.Context, identity *authn.Identity, r *authn
 	return nil
 }
 
-func (m *MockClient) Logout(ctx context.Context, user identity.Requester, info *login.UserAuth) (*authn.Redirect, bool) {
+func (m *MockClient) Logout(ctx context.Context, user identity.Requester) (*authn.Redirect, bool) {
 	if m.LogoutFunc != nil {
-		return m.LogoutFunc(ctx, user, info)
+		return m.LogoutFunc(ctx, user)
 	}
 	return nil, false
 }

--- a/pkg/services/authn/clients/oauth.go
+++ b/pkg/services/authn/clients/oauth.go
@@ -241,10 +241,21 @@ func (c *OAuth) RedirectURL(ctx context.Context, r *authn.Request) (*authn.Redir
 	}, nil
 }
 
-func (c *OAuth) Logout(ctx context.Context, user identity.Requester, info *login.UserAuth) (*authn.Redirect, bool) {
+func (c *OAuth) Logout(ctx context.Context, user identity.Requester) (*authn.Redirect, bool) {
 	token := c.oauthService.GetCurrentOAuthToken(ctx, user)
 
-	if err := c.oauthService.InvalidateOAuthTokens(ctx, info); err != nil {
+	namespace, id := user.GetNamespacedID()
+	userID, err := identity.UserIdentifier(namespace, id)
+	if err != nil {
+		c.log.FromContext(ctx).Error("Failed to parse user id", "namespace", namespace, "id", id, "error", err)
+		return nil, false
+	}
+
+	if err := c.oauthService.InvalidateOAuthTokens(ctx, &login.UserAuth{
+		UserId:     userID,
+		AuthId:     user.GetAuthID(),
+		AuthModule: user.GetAuthenticatedBy(),
+	}); err != nil {
 		namespace, id := user.GetNamespacedID()
 		c.log.FromContext(ctx).Error("Failed to invalidate tokens", "namespace", namespace, "id", id, "error", err)
 	}

--- a/pkg/services/authn/clients/oauth_test.go
+++ b/pkg/services/authn/clients/oauth_test.go
@@ -486,7 +486,7 @@ func TestOAuth_Logout(t *testing.T) {
 			}
 			c := ProvideOAuth(authn.ClientWithPrefix("azuread"), tt.cfg, mockService, fakeSocialSvc, &setting.OSSImpl{Cfg: tt.cfg}, featuremgmt.WithFeatures())
 
-			redirect, ok := c.Logout(context.Background(), &authn.Identity{}, &login.UserAuth{})
+			redirect, ok := c.Logout(context.Background(), &authn.Identity{})
 
 			assert.Equal(t, tt.expectedOK, ok)
 			if tt.expectedOK {

--- a/pkg/services/authn/clients/session.go
+++ b/pkg/services/authn/clients/session.go
@@ -2,29 +2,34 @@ package clients
 
 import (
 	"context"
+	"errors"
 	"net/url"
 	"time"
 
 	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/services/auth"
 	"github.com/grafana/grafana/pkg/services/authn"
+	"github.com/grafana/grafana/pkg/services/login"
+	"github.com/grafana/grafana/pkg/services/user"
 	"github.com/grafana/grafana/pkg/setting"
 )
 
 var _ authn.ContextAwareClient = new(Session)
 
-func ProvideSession(cfg *setting.Cfg, sessionService auth.UserTokenService) *Session {
+func ProvideSession(cfg *setting.Cfg, sessionService auth.UserTokenService, authInfoService login.AuthInfoService) *Session {
 	return &Session{
-		cfg:            cfg,
-		sessionService: sessionService,
-		log:            log.New(authn.ClientSession),
+		cfg:             cfg,
+		log:             log.New(authn.ClientSession),
+		sessionService:  sessionService,
+		authInfoService: authInfoService,
 	}
 }
 
 type Session struct {
-	cfg            *setting.Cfg
-	sessionService auth.UserTokenService
-	log            log.Logger
+	cfg             *setting.Cfg
+	log             log.Logger
+	sessionService  auth.UserTokenService
+	authInfoService login.AuthInfoService
 }
 
 func (s *Session) Name() string {
@@ -51,14 +56,26 @@ func (s *Session) Authenticate(ctx context.Context, r *authn.Request) (*authn.Id
 		return nil, authn.ErrTokenNeedsRotation.Errorf("token needs to be rotated")
 	}
 
-	return &authn.Identity{
+	ident := &authn.Identity{
 		ID:           authn.NamespacedID(authn.NamespaceUser, token.UserId),
 		SessionToken: token,
 		ClientParams: authn.ClientParams{
 			FetchSyncedUser: true,
 			SyncPermissions: true,
 		},
-	}, nil
+	}
+
+	info, err := s.authInfoService.GetAuthInfo(ctx, &login.GetAuthInfoQuery{UserId: token.UserId})
+	if err != nil {
+		if !errors.Is(err, user.ErrUserNotFound) {
+			s.log.FromContext(ctx).Error("Failed to fetch auth info", "err", err)
+		}
+		return ident, nil
+	}
+
+	ident.AuthID = info.AuthId
+	ident.AuthenticatedBy = info.AuthModule
+	return ident, nil
 }
 
 func (s *Session) Test(ctx context.Context, r *authn.Request) bool {

--- a/pkg/services/authn/clients/session_test.go
+++ b/pkg/services/authn/clients/session_test.go
@@ -139,7 +139,7 @@ func TestSession_Authenticate(t *testing.T) {
 			wantErr: false,
 		},
 		{
-			name: "should set authID and authenticated by for externaly authenticated user",
+			name: "should set authID and authenticated by for externally authenticated user",
 			fields: fields{
 				sessionService: &authtest.FakeUserAuthTokenService{LookupTokenProvider: func(ctx context.Context, unhashedToken string) (*auth.UserToken, error) {
 					return validToken, nil

--- a/pkg/services/authn/identity.go
+++ b/pkg/services/authn/identity.go
@@ -102,6 +102,10 @@ func (i *Identity) GetNamespacedID() (namespace string, identifier string) {
 	return split[0], split[1]
 }
 
+func (i *Identity) GetAuthID() string {
+	return i.AuthID
+}
+
 func (i *Identity) GetAuthenticatedBy() string {
 	return i.AuthenticatedBy
 }
@@ -228,6 +232,7 @@ func (i *Identity) SignedInUser() *user.SignedInUser {
 		Login:           i.Login,
 		Name:            i.Name,
 		Email:           i.Email,
+		AuthID:          i.AuthID,
 		AuthenticatedBy: i.AuthenticatedBy,
 		IsGrafanaAdmin:  i.GetIsGrafanaAdmin(),
 		IsAnonymous:     namespace == NamespaceAnonymous,

--- a/pkg/services/user/identity.go
+++ b/pkg/services/user/identity.go
@@ -14,15 +14,18 @@ const (
 )
 
 type SignedInUser struct {
-	UserID           int64  `xorm:"user_id"`
-	UserUID          string `xorm:"user_uid"`
-	OrgID            int64  `xorm:"org_id"`
-	OrgName          string
-	OrgRole          roletype.RoleType
-	Login            string
-	Name             string
-	Email            string
-	EmailVerified    bool
+	UserID        int64  `xorm:"user_id"`
+	UserUID       string `xorm:"user_uid"`
+	OrgID         int64  `xorm:"org_id"`
+	OrgName       string
+	OrgRole       roletype.RoleType
+	Login         string
+	Name          string
+	Email         string
+	EmailVerified bool
+	// AuthID will be set if user signed in using external method
+	AuthID string
+	// AuthenticatedBy be set if user signed in using external method
 	AuthenticatedBy  string
 	ApiKeyID         int64 `xorm:"api_key_id"`
 	IsServiceAccount bool  `xorm:"is_service_account"`
@@ -222,6 +225,14 @@ func (u *SignedInUser) GetNamespacedID() (string, string) {
 	return parts[0], parts[1]
 }
 
+func (u *SignedInUser) GetAuthID() string {
+	return u.AuthID
+}
+
+func (u *SignedInUser) GetAuthenticatedBy() string {
+	return u.AuthenticatedBy
+}
+
 func (u *SignedInUser) IsAuthenticatedBy(providers ...string) bool {
 	for _, p := range providers {
 		if u.AuthenticatedBy == p {
@@ -250,11 +261,6 @@ func (u *SignedInUser) IsEmailVerified() bool {
 // The display name is the name if it is set, otherwise the login or email
 func (u *SignedInUser) GetDisplayName() string {
 	return u.NameOrFallback()
-}
-
-// DEPRECATEAD: Returns the authentication method used
-func (u *SignedInUser) GetAuthenticatedBy() string {
-	return u.AuthenticatedBy
 }
 
 func (u *SignedInUser) GetIDToken() string {

--- a/pkg/tests/web/index_view_test.go
+++ b/pkg/tests/web/index_view_test.go
@@ -1,6 +1,7 @@
 package web
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -40,7 +41,7 @@ func TestIntegrationIndexView(t *testing.T) {
 		addr, _ := testinfra.StartGrafana(t, grafDir, cfgPath)
 
 		// nolint:bodyclose
-		resp, html := makeRequest(t, addr, "", "")
+		resp, html := makeRequest(t, addr, nil)
 		assert.Regexp(t, `script-src 'self' 'unsafe-eval' 'unsafe-inline' 'strict-dynamic' 'nonce-[^']+';object-src 'none';font-src 'self';style-src 'self' 'unsafe-inline' blob:;img-src \* data:;base-uri 'self';connect-src 'self' grafana.com ws://localhost:3000/ wss://localhost:3000/;manifest-src 'self';media-src 'none';form-action 'self';`, resp.Header.Get("Content-Security-Policy"))
 		assert.Regexp(t, `<script nonce="[^"]+"`, html)
 	})
@@ -50,24 +51,24 @@ func TestIntegrationIndexView(t *testing.T) {
 		addr, _ := testinfra.StartGrafana(t, grafDir, cfgPath)
 
 		// nolint:bodyclose
-		resp, html := makeRequest(t, addr, "", "")
+		resp, html := makeRequest(t, addr, nil)
 
 		assert.Empty(t, resp.Header.Get("Content-Security-Policy"))
 		assert.Regexp(t, `<script nonce=""`, html)
 	})
 }
 
-func makeRequest(t *testing.T, addr, username, passwowrd string) (*http.Response, string) {
+func makeRequest(t *testing.T, addr string, session *http.Cookie) (*http.Response, string) {
 	t.Helper()
 
 	u := fmt.Sprintf("http://%s", addr)
 	t.Logf("Making GET request to %s", u)
 
-	request, err := http.NewRequest("GET", u, nil)
+	request, err := http.NewRequest(http.MethodGet, u, nil)
 	require.NoError(t, err)
 
-	if username != "" && passwowrd != "" {
-		request.SetBasicAuth(username, passwowrd)
+	if session != nil {
+		request.AddCookie(session)
 	}
 
 	resp, err := http.DefaultClient.Do(request)
@@ -84,6 +85,42 @@ func makeRequest(t *testing.T, addr, username, passwowrd string) (*http.Response
 	require.Equal(t, 200, resp.StatusCode, b.String())
 
 	return resp, b.String()
+}
+
+func loginUser(t *testing.T, addr, username, password string) *http.Cookie {
+	t.Helper()
+
+	type body struct {
+		Username string `json:"user"`
+		Password string `json:"password"`
+	}
+
+	data, err := json.Marshal(&body{username, password})
+	require.NoError(t, err)
+
+	request, err := http.NewRequest(http.MethodPost, fmt.Sprintf("http://%s/login", addr), bytes.NewReader(data))
+	require.NoError(t, err)
+	request.Header.Set("Content-Type", "application/json")
+
+	resp, err := http.DefaultClient.Do(request)
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	t.Cleanup(func() {
+		err := resp.Body.Close()
+		assert.NoError(t, err)
+	})
+
+	require.Equal(t, 200, resp.StatusCode)
+
+	var sessionCookie *http.Cookie
+	for _, c := range resp.Cookies() {
+		if c.Name == "grafana_session" {
+			sessionCookie = c
+		}
+	}
+
+	require.NotNil(t, sessionCookie)
+	return sessionCookie
 }
 
 // TestIntegrationIndexViewAnalytics tests the Grafana index view has the analytics identifiers.
@@ -155,8 +192,11 @@ func TestIntegrationIndexViewAnalytics(t *testing.T) {
 				require.NoError(t, err)
 			}
 
+			// perform login
+			session := loginUser(t, addr, "admin", "admin")
+
 			// nolint:bodyclose
-			response, html := makeRequest(t, addr, "admin", "admin")
+			response, html := makeRequest(t, addr, session)
 			assert.Equal(t, http.StatusOK, response.StatusCode)
 
 			// parse User.Analytics HTML view into user.AnalyticsSettings model


### PR DESCRIPTION
**What is this feature?**
All authn.clients sets authenticated by field for a user. This is also something that is exposed in `SignedInUser` and `identity.Requester`. The exception has always been sessions. Identity resolved for a session has never set these fields. 

This has been a issue on occasion where we needed to check this value. To solve this we query for any external auth info when resolving a session and populate these fields. In other places we no longer have to manually query for it because it _should_ always be present. 

**Why do we need this feature?**
To make it consistent across authn clients.

**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/identity-access-team/issues/616

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
