### PR TITLE
Dashboard scenes: Fix export tab not including variables when exporting externally

### DIFF
--- a/public/app/features/dashboard-scene/sharing/ShareExportTab.tsx
+++ b/public/app/features/dashboard-scene/sharing/ShareExportTab.tsx
@@ -11,11 +11,10 @@ import { shareDashboardType } from 'app/features/dashboard/components/ShareModal
 import { DashboardModel } from 'app/features/dashboard/state';
 
 import { transformSceneToSaveModel } from '../serialization/transformSceneToSaveModel';
+import { getVariablesCompatibility } from '../utils/getVariablesCompatibility';
 import { DashboardInteractions } from '../utils/interactions';
 
 import { SceneShareTabState } from './types';
-
-const exportExternallyTranslation = t('share-modal.export.share-externally-label', `Export for sharing externally`);
 
 interface ShareExportTabState extends SceneShareTabState {
   isSharingExternally?: boolean;
@@ -61,7 +60,13 @@ export class ShareExportTab extends SceneObjectBase<ShareExportTabState> {
     const saveModel = transformSceneToSaveModel(dashboardRef.resolve());
 
     const exportable = isSharingExternally
-      ? await this._exporter.makeExportable(new DashboardModel(saveModel))
+      ? await this._exporter.makeExportable(
+          new DashboardModel(saveModel, undefined, {
+            getVariablesFromState: () => {
+              return getVariablesCompatibility(window.__grafanaSceneContext);
+            },
+          })
+        )
       : saveModel;
 
     return exportable;
@@ -99,6 +104,8 @@ function ShareExportTabRenderer({ model }: SceneComponentProps<ShareExportTab>) 
 
     return '';
   }, [isViewingJSON]);
+
+  const exportExternallyTranslation = t('share-modal.export.share-externally-label', `Export for sharing externally`);
 
   return (
     <>


### PR DESCRIPTION
In the old architecture we're getting the variable from the rxjs state when we're making the dashboard ready for exporting externally. This doesn't work with the new architecture. With this PR we're supplying a function to get the variables from state that instead gets the variables from the scenes compatibility path.

Fixes #85783

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
