### PR TITLE
Chore: Use `handleReducedMotion` to smooth the animation in `LoadingBar`

### DIFF
--- a/packages/grafana-ui/src/components/LoadingBar/LoadingBar.tsx
+++ b/packages/grafana-ui/src/components/LoadingBar/LoadingBar.tsx
@@ -4,6 +4,7 @@ import React, { CSSProperties } from 'react';
 import { GrafanaTheme2 } from '@grafana/data';
 
 import { useStyles2 } from '../../themes';
+import { handleReducedMotion } from '../../utils/handleReducedMotion';
 
 export interface LoadingBarProps {
   width: number;
@@ -51,11 +52,18 @@ const getStyles = (_theme: GrafanaTheme2, delay: number, duration: number) => {
       transform: 'translateX(-100%)',
       animationName: animation,
       // an initial delay to prevent the loader from showing if the response is faster than the delay
-      animationDelay: `${delay}ms`,
-      animationDuration: `${duration}ms`,
       animationTimingFunction: 'linear',
       animationIterationCount: 'infinite',
       willChange: 'transform',
+      ...handleReducedMotion(
+        {
+          animationDelay: `${delay}ms`,
+          animationDuration: `${duration}ms`,
+        },
+        {
+          animationDuration: `${4 * duration}ms`,
+        }
+      ),
     }),
   };
 };

--- a/packages/grafana-ui/src/components/LoadingBar/LoadingBar.tsx
+++ b/packages/grafana-ui/src/components/LoadingBar/LoadingBar.tsx
@@ -52,12 +52,12 @@ const getStyles = (_theme: GrafanaTheme2, delay: number, duration: number) => {
       transform: 'translateX(-100%)',
       animationName: animation,
       // an initial delay to prevent the loader from showing if the response is faster than the delay
+      animationDelay: `${delay}ms`,
       animationTimingFunction: 'linear',
       animationIterationCount: 'infinite',
       willChange: 'transform',
       ...handleReducedMotion(
         {
-          animationDelay: `${delay}ms`,
           animationDuration: `${duration}ms`,
         },
         {


### PR DESCRIPTION
**What is this feature?**
Manage the `LoadingBar` animation when `prefers-reduced-motion` is enabled.

**Why do we need this feature?**
To keep the animation, as it is meaningful, but smooth it to not disturb users with `prefers-reduced-motion` enabled.

**Who is this feature for?**
Everyone using `prefers-reduced-motion`.

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #
Related to #77859 

**Special notes for your reviewer:**
After the changes:

https://github.com/grafana/grafana/assets/65417731/cbe0120f-15a7-4961-827a-8b7b6e6b9882




Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
