### PR TITLE
ConfirmModal: Pressing enter in confirmation input now triggers primary action

### DIFF
--- a/packages/grafana-ui/src/components/ConfirmModal/ConfirmModal.test.tsx
+++ b/packages/grafana-ui/src/components/ConfirmModal/ConfirmModal.test.tsx
@@ -105,6 +105,32 @@ describe('ConfirmModal', () => {
     expect(mockOnConfirm).toHaveBeenCalled();
   });
 
+  it('typing the confirmation text and pressing enter should trigger the primary action', async () => {
+    render(
+      <ConfirmModal
+        title="Some Title"
+        body="Some Body"
+        confirmText="Please Confirm"
+        alternativeText="Alternative Text"
+        dismissText="Dismiss Text"
+        isOpen={true}
+        confirmationText="My confirmation text"
+        onConfirm={mockOnConfirm}
+        onDismiss={() => {}}
+        onAlternative={() => {}}
+      />
+    );
+
+    expect(screen.getByRole('button', { name: 'Please Confirm' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Please Confirm' })).toBeDisabled();
+
+    await user.type(screen.getByPlaceholderText('Type "My confirmation text" to confirm'), 'mY CoNfIrMaTiOn TeXt');
+    expect(screen.getByRole('button', { name: 'Please Confirm' })).toBeEnabled();
+
+    await user.type(screen.getByPlaceholderText('Type "My confirmation text" to confirm'), '{enter}');
+    expect(mockOnConfirm).toHaveBeenCalled();
+  });
+
   it('returning a promise in the onConfirm callback disables the button whilst the callback is in progress', async () => {
     mockOnConfirm.mockImplementation(() => {
       return new Promise((resolve) => {
@@ -136,7 +162,9 @@ describe('ConfirmModal', () => {
 
     await user.click(screen.getByRole('button', { name: 'Please Confirm' }));
     expect(mockOnConfirm).toHaveBeenCalled();
-    expect(screen.getByRole('button', { name: 'Please Confirm' })).toBeDisabled();
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: 'Please Confirm' })).toBeDisabled();
+    });
 
     jest.runAllTimers();
     await waitFor(() => {

--- a/packages/grafana-ui/src/components/ConfirmModal/ConfirmModal.tsx
+++ b/packages/grafana-ui/src/components/ConfirmModal/ConfirmModal.tsx
@@ -1,5 +1,6 @@
 import { css, cx } from '@emotion/css';
 import React, { useEffect, useRef, useState } from 'react';
+import { useForm } from 'react-hook-form';
 
 import { GrafanaTheme2 } from '@grafana/data';
 import { selectors } from '@grafana/e2e-selectors';
@@ -96,40 +97,44 @@ export const ConfirmModal = ({
     }
   };
 
+  const { handleSubmit } = useForm();
+
   return (
     <Modal className={cx(styles.modal, modalClass)} title={title} icon={icon} isOpen={isOpen} onDismiss={onDismiss}>
-      <div className={styles.modalText}>
-        {body}
-        {description ? <div className={styles.modalDescription}>{description}</div> : null}
-        {confirmationText ? (
-          <div className={styles.modalConfirmationInput}>
-            <Stack alignItems="flex-start">
-              <Box>
-                <Input placeholder={`Type "${confirmationText}" to confirm`} onChange={onConfirmationTextChange} />
-              </Box>
-            </Stack>
-          </div>
-        ) : null}
-      </div>
-      <Modal.ButtonRow>
-        <Button variant={dismissVariant} onClick={onDismiss} fill="outline">
-          {dismissText}
-        </Button>
-        <Button
-          variant={confirmButtonVariant}
-          onClick={onConfirmClick}
-          disabled={disabled}
-          ref={buttonRef}
-          data-testid={selectors.pages.ConfirmModal.delete}
-        >
-          {confirmText}
-        </Button>
-        {onAlternative ? (
-          <Button variant="primary" onClick={onAlternative}>
-            {alternativeText}
+      <form onSubmit={handleSubmit(onConfirmClick)}>
+        <div className={styles.modalText}>
+          {body}
+          {description ? <div className={styles.modalDescription}>{description}</div> : null}
+          {confirmationText ? (
+            <div className={styles.modalConfirmationInput}>
+              <Stack alignItems="flex-start">
+                <Box>
+                  <Input placeholder={`Type "${confirmationText}" to confirm`} onChange={onConfirmationTextChange} />
+                </Box>
+              </Stack>
+            </div>
+          ) : null}
+        </div>
+        <Modal.ButtonRow>
+          <Button variant={dismissVariant} onClick={onDismiss} fill="outline">
+            {dismissText}
           </Button>
-        ) : null}
-      </Modal.ButtonRow>
+          <Button
+            type="submit"
+            variant={confirmButtonVariant}
+            disabled={disabled}
+            ref={buttonRef}
+            data-testid={selectors.pages.ConfirmModal.delete}
+          >
+            {confirmText}
+          </Button>
+          {onAlternative ? (
+            <Button variant="primary" onClick={onAlternative}>
+              {alternativeText}
+            </Button>
+          ) : null}
+        </Modal.ButtonRow>
+      </form>
     </Modal>
   );
 };


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

- wraps `ConfirmModal` in a form
- adds a unit test to prevent regressions

**Why do we need this feature?**

- so you can press 'enter' in the confirmation text input to trigger the primary action
- minor UX improvement
- see https://raintank-corp.slack.com/archives/C036J5B39/p1712559604207889 for more context

**Who is this feature for?**

- everyone!

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
