### PR TITLE
Explore: Query history should gracefully handle undefined exploreId on run button

### DIFF
--- a/public/app/features/explore/RichHistory/RichHistoryCard.tsx
+++ b/public/app/features/explore/RichHistory/RichHistoryCard.tsx
@@ -346,7 +346,7 @@ export function RichHistoryCard(props: Props) {
 
   // exploreId on where the query will be ran, and the datasource ID for the item's DS
   const runQueryText = (exploreId: string, dsUid: string) => {
-    return dsUid !== undefined && isDifferentDatasource(dsUid, exploreId)
+    return dsUid !== undefined && exploreId !== undefined && isDifferentDatasource(dsUid, exploreId)
       ? {
           fallbackText: 'Switch data source and run query',
           translation: t('explore.rich-history-card.switch-datasource-button', 'Switch data source and run query'),
@@ -360,14 +360,14 @@ export function RichHistoryCard(props: Props) {
   const runButton = () => {
     const disabled = cardRootDatasource?.uid === undefined;
     if (!isPaneSplit) {
-      const exploreId = exploreActiveDS.exploreToDS[0].exploreId;
+      const exploreId = exploreActiveDS.exploreToDS[0]?.exploreId; // may be undefined if explore is refreshed while the pane is up
       const buttonText = runQueryText(exploreId, props.queryHistoryItem.datasourceUid);
       return (
         <Button
           variant="secondary"
           aria-label={buttonText.translation}
           onClick={() => onRunQuery(exploreId)}
-          disabled={disabled}
+          disabled={disabled || exploreId === undefined}
         >
           {buttonText.translation}
         </Button>


### PR DESCRIPTION
**What is this feature?**

In #84321 we moved the query history pane to be across all of explore, not in individual panes. We assume that exploreID will always exist. However, if you have the pane up and re-instantiate explore (like selecting it from the side menu), there will not be an explore ID while it reloads. We disable the button until the explore ID exists.

**Why do we need this feature?**

Fix a bug where explore crashes

**Which issue(s) does this PR fix?**:

Fixes #85820 

**Special notes for your reviewer:**

Replication steps
1. In explore, open query history pane
1. Click Explore on the side bar
1. See crash `Uncaught TypeError: Cannot read properties of undefined (reading 'exploreId')`

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
