### PR TITLE
Explore: Query history does not save filtered queries

### DIFF
--- a/public/app/features/explore/state/query.test.ts
+++ b/public/app/features/explore/state/query.test.ts
@@ -66,6 +66,9 @@ const datasources: DataSourceApi[] = [
     getRef: () => {
       return { type: 'postgres', uid: 'ds1' };
     },
+    filterQuery: (query: DataQuery) => {
+      return query.key === 'true';
+    },
   } as DataSourceApi<DataQuery, DataSourceJsonData, {}>,
   {
     name: 'testDs2',
@@ -226,6 +229,56 @@ describe('runQueries', () => {
     await dispatch(runQueries({ exploreId: 'left' }));
     expect((richHistory.addToRichHistory as jest.Mock).mock.calls).toHaveLength(1);
     expect((richHistory.addToRichHistory as jest.Mock).mock.calls[0][0].localOverride).toBeTruthy();
+  });
+
+  /* the next two tests are for ensuring the query datasource's filterQuery function stops queries
+    from being saved to rich history. We do that by setting a fake datasource in this test (datasources[0]) 
+    to filter queries off their key value
+
+    datasources[1] does not have filterQuery defined
+  */
+  it('with filterQuery defined, should not save filtered out queries to history', async () => {
+    const { dispatch } = configureStore({
+      ...defaultInitialState,
+      explore: {
+        panes: {
+          left: {
+            ...defaultInitialState.explore.panes.left,
+            datasourceInstance: datasources[0],
+            queries: [
+              { refId: 'A', key: 'false' },
+              { refId: 'B', key: 'true' },
+            ],
+          },
+        },
+      },
+    } as unknown as Partial<StoreState>);
+    jest.spyOn(richHistory, 'addToRichHistory');
+    await dispatch(runQueries({ exploreId: 'left' }));
+    const calls = (richHistory.addToRichHistory as jest.Mock).mock.calls;
+    expect(calls).toHaveLength(1);
+    expect(calls[0][0].queries).toHaveLength(1);
+    expect(calls[0][0].queries[0].refId).toEqual('B');
+  });
+
+  it('with filterQuery not defined, all queries are saved', async () => {
+    const { dispatch } = configureStore({
+      ...defaultInitialState,
+      explore: {
+        panes: {
+          left: {
+            ...defaultInitialState.explore.panes.left,
+            datasourceInstance: datasources[1],
+            queries: [{ refId: 'A' }, { refId: 'B' }],
+          },
+        },
+      },
+    } as unknown as Partial<StoreState>);
+    jest.spyOn(richHistory, 'addToRichHistory');
+    await dispatch(runQueries({ exploreId: 'left' }));
+    const calls = (richHistory.addToRichHistory as jest.Mock).mock.calls;
+    expect(calls).toHaveLength(1);
+    expect(calls[0][0].queries).toHaveLength(2);
   });
 });
 

--- a/public/app/features/explore/state/query.ts
+++ b/public/app/features/explore/state/query.ts
@@ -37,7 +37,6 @@ import {
 } from 'app/core/utils/explore';
 import { getShiftedTimeRange } from 'app/core/utils/timePicker';
 import { getCorrelationsBySourceUIDs } from 'app/features/correlations/utils';
-import { dataSource } from 'app/features/expressions/ExpressionDatasource';
 import { infiniteScrollRefId } from 'app/features/logs/logsModel';
 import { getDatasourceSrv } from 'app/features/plugins/datasource_srv';
 import { getFiscalYearStartMonth, getTimeZone } from 'app/features/profile/state/selectors';


### PR DESCRIPTION
**What is this feature?**

Query history automatically saves queries that are ran. However, some datasources will run queries automatically, or the user may accidentally run a query that is empty and thus invalid. The plugins team recently released https://github.com/grafana/grafana/pull/84656 which provided a function that would filter out queries.

This brings that function into deciding when we save to query history. If the function is not defined, the query is saved. If it is defined and is true, the query is saved. If it's defined and is false, it is not saved. 

**Why do we need this feature?**

For query history to not be spammed with empty queries :) 

**Which issue(s) does this PR fix?**:

Fixes #51328 

**Special notes for your reviewer:**
This is easiest to check with loki. Prior to this change, when you would switch to the loki datasource, it would automatically run the query with nothing defined, and be saved to query history. With this change, it never gets saved.

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
