### PR TITLE
Authn: allow ResolveIdentity to authenticate in "global" scope

### DIFF
--- a/pkg/services/authn/authn.go
+++ b/pkg/services/authn/authn.go
@@ -59,6 +59,8 @@ type ClientParams struct {
 	SyncPermissions bool
 	// FetchPermissionsParams are the arguments used to fetch permissions from the DB
 	FetchPermissionsParams FetchPermissionsParams
+	// AllowGlobalOrg would allow a client to authenticate in global scope AKA org 0
+	AllowGlobalOrg bool
 }
 
 type FetchPermissionsParams struct {

--- a/pkg/services/authn/authnimpl/sync/user_sync.go
+++ b/pkg/services/authn/authnimpl/sync/user_sync.go
@@ -132,6 +132,13 @@ func (s *UserSync) FetchSyncedUserHook(ctx context.Context, identity *authn.Iden
 		return errFetchingSignedInUser.Errorf("failed to resolve user: %w", err)
 	}
 
+	if identity.ClientParams.AllowGlobalOrg && identity.OrgID == 0 {
+		usr.Teams = nil
+		usr.OrgID = 0
+		usr.OrgName = ""
+		usr.OrgRole = org.RoleNone
+	}
+
 	syncSignedInUserToIdentity(usr, identity)
 	return nil
 }

--- a/pkg/services/authn/authnimpl/sync/user_sync.go
+++ b/pkg/services/authn/authnimpl/sync/user_sync.go
@@ -132,11 +132,11 @@ func (s *UserSync) FetchSyncedUserHook(ctx context.Context, identity *authn.Iden
 		return errFetchingSignedInUser.Errorf("failed to resolve user: %w", err)
 	}
 
-	if identity.ClientParams.AllowGlobalOrg && identity.OrgID == 0 {
+	if identity.ClientParams.AllowGlobalOrg && identity.OrgID == authn.GlobalOrgID {
 		usr.Teams = nil
-		usr.OrgID = 0
 		usr.OrgName = ""
 		usr.OrgRole = org.RoleNone
+		usr.OrgID = authn.GlobalOrgID
 	}
 
 	syncSignedInUserToIdentity(usr, identity)

--- a/pkg/services/authn/clients/identity.go
+++ b/pkg/services/authn/clients/identity.go
@@ -26,6 +26,7 @@ func (i *IdentityClient) Authenticate(ctx context.Context, r *authn.Request) (*a
 		OrgID: r.OrgID,
 		ID:    i.namespaceID,
 		ClientParams: authn.ClientParams{
+			AllowGlobalOrg:  true,
 			FetchSyncedUser: true,
 			SyncPermissions: true,
 		},


### PR DESCRIPTION
**What is this feature?**
In some cases we need to re-authenticate a Identity in "gloabl" org. To handle this I added a flag for client to control if it is allowed and if it is allowed for the client and org id is 0 we reset global scoped properties.

**Which issue(s) does this PR fix?**:

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
