### PR TITLE
Chore: Remove unused function TryRotateToken

### DIFF
--- a/pkg/services/auth/auth.go
+++ b/pkg/services/auth/auth.go
@@ -71,7 +71,6 @@ type UserTokenService interface {
 	LookupToken(ctx context.Context, unhashedToken string) (*UserToken, error)
 	// RotateToken will always rotate a valid token
 	RotateToken(ctx context.Context, cmd RotateCommand) (*UserToken, error)
-	TryRotateToken(ctx context.Context, token *UserToken, clientIP net.IP, userAgent string) (bool, *UserToken, error)
 	RevokeToken(ctx context.Context, token *UserToken, soft bool) error
 	RevokeAllUserTokens(ctx context.Context, userID int64) error
 	GetUserToken(ctx context.Context, userID, userTokenID int64) (*UserToken, error)

--- a/pkg/services/auth/authimpl/auth_token.go
+++ b/pkg/services/auth/authimpl/auth_token.go
@@ -5,7 +5,6 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"errors"
-	"fmt"
 	"net"
 	"strings"
 	"time"
@@ -294,105 +293,6 @@ func (s *UserAuthTokenService) rotateToken(ctx context.Context, token *auth.User
 	token.RotatedAt = now.Unix()
 
 	return token, nil
-}
-
-func (s *UserAuthTokenService) TryRotateToken(ctx context.Context, token *auth.UserToken,
-	clientIP net.IP, userAgent string) (bool, *auth.UserToken, error) {
-	if token == nil {
-		return false, nil, nil
-	}
-
-	model, err := userAuthTokenFromUserToken(token)
-	if err != nil {
-		return false, nil, err
-	}
-
-	now := getTime()
-
-	type rotationResult struct {
-		rotated  bool
-		newToken *auth.UserToken
-	}
-
-	rotResult, err, _ := s.singleflight.Do(fmt.Sprint(model.Id), func() (any, error) {
-		var needsRotation bool
-		rotatedAt := time.Unix(model.RotatedAt, 0)
-		if model.AuthTokenSeen {
-			needsRotation = rotatedAt.Before(now.Add(-time.Duration(s.cfg.TokenRotationIntervalMinutes) * time.Minute))
-		} else {
-			needsRotation = rotatedAt.Before(now.Add(-usertoken.UrgentRotateTime))
-		}
-
-		if !needsRotation {
-			return &rotationResult{rotated: false}, nil
-		}
-
-		ctxLogger := s.log.FromContext(ctx)
-		ctxLogger.Debug("Token needs rotation", "tokenID", model.Id, "authTokenSeen", model.AuthTokenSeen, "rotatedAt", rotatedAt)
-
-		clientIPStr := clientIP.String()
-		if len(clientIP) == 0 {
-			clientIPStr = ""
-		}
-		newToken, err := util.RandomHex(16)
-		if err != nil {
-			return nil, err
-		}
-		hashedToken := hashToken(s.cfg.SecretKey, newToken)
-
-		// very important that auth_token_seen is set after the prev_auth_token = case when ... for mysql to function correctly
-		sql := `
-			UPDATE user_auth_token
-			SET
-				seen_at = 0,
-				user_agent = ?,
-				client_ip = ?,
-				prev_auth_token = case when auth_token_seen = ? then auth_token else prev_auth_token end,
-				auth_token = ?,
-				auth_token_seen = ?,
-				rotated_at = ?
-			WHERE id = ? AND (auth_token_seen = ? OR rotated_at < ?)`
-
-		var affected int64
-		err = s.sqlStore.WithTransactionalDbSession(ctx, func(dbSession *db.Session) error {
-			res, err := dbSession.Exec(sql, userAgent, clientIPStr, s.sqlStore.GetDialect().BooleanStr(true), hashedToken,
-				s.sqlStore.GetDialect().BooleanStr(false), now.Unix(), model.Id, s.sqlStore.GetDialect().BooleanStr(true),
-				now.Add(-30*time.Second).Unix())
-			if err != nil {
-				return err
-			}
-
-			affected, err = res.RowsAffected()
-			return err
-		})
-
-		if err != nil {
-			return nil, err
-		}
-
-		if affected > 0 {
-			ctxLogger.Debug("Auth token rotated", "affected", affected, "tokenID", model.Id, "userID", model.UserId)
-			model.UnhashedToken = newToken
-			var result auth.UserToken
-			if err := model.toUserToken(&result); err != nil {
-				return nil, err
-			}
-			return &rotationResult{
-				rotated:  true,
-				newToken: &result,
-			}, nil
-		}
-
-		return &rotationResult{rotated: false}, nil
-	})
-
-	if err != nil {
-		return false, nil, err
-	}
-
-	result := rotResult.(*rotationResult)
-
-	return result.rotated, result.newToken, nil
 }
 
 func (s *UserAuthTokenService) RevokeToken(ctx context.Context, token *auth.UserToken, soft bool) error {

--- a/pkg/services/auth/authimpl/auth_token_test.go
+++ b/pkg/services/auth/authimpl/auth_token_test.go
@@ -585,24 +585,6 @@ func (c *testContext) getAuthTokenByID(id int64) (*userAuthToken, error) {
 	return res, err
 }
 
-func (c *testContext) markAuthTokenAsSeen(id int64) (bool, error) {
-	hasRowsAffected := false
-	err := c.sqlstore.WithDbSession(context.Background(), func(sess *db.Session) error {
-		res, err := sess.Exec("UPDATE user_auth_token SET auth_token_seen = ? WHERE id = ?", c.sqlstore.GetDialect().BooleanStr(true), id)
-		if err != nil {
-			return err
-		}
-
-		rowsAffected, err := res.RowsAffected()
-		if err != nil {
-			return err
-		}
-		hasRowsAffected = rowsAffected == 1
-		return nil
-	})
-	return hasRowsAffected, err
-}
-
 func (c *testContext) updateRotatedAt(id, rotatedAt int64) (bool, error) {
 	hasRowsAffected := false
 	err := c.sqlstore.WithDbSession(context.Background(), func(sess *db.Session) error {

--- a/pkg/services/auth/authtest/testing.go
+++ b/pkg/services/auth/authtest/testing.go
@@ -84,11 +84,6 @@ func (s *FakeUserAuthTokenService) LookupToken(ctx context.Context, unhashedToke
 	return s.LookupTokenProvider(context.Background(), unhashedToken)
 }
 
-func (s *FakeUserAuthTokenService) TryRotateToken(ctx context.Context, token *auth.UserToken, clientIP net.IP,
-	userAgent string) (bool, *auth.UserToken, error) {
-	return s.TryRotateTokenProvider(context.Background(), token, clientIP, userAgent)
-}
-
 func (s *FakeUserAuthTokenService) RevokeToken(ctx context.Context, token *auth.UserToken, soft bool) error {
 	return s.RevokeTokenProvider(context.Background(), token, soft)
 }


### PR DESCRIPTION
**What is this feature?**
Ever since https://github.com/grafana/grafana/pull/82886 we don't use this function anymore and it can be removed.

**Which issue(s) does this PR fix?**:

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
