### PR TITLE
Grafana UI: `PanelChrome` - Replace `HorizontalGroup` with `Stack` in documentation and stories

### DIFF
--- a/.betterer.results
+++ b/.betterer.results
@@ -1,5 +1,5 @@
 // BETTERER RESULTS V2.
-// 
+//
 // If this file contains merge conflicts, use `betterer merge` to automatically resolve them:
 // https://phenomnomnominal.github.io/betterer/docs/results-file/#merge
 //

--- a/.betterer.results
+++ b/.betterer.results
@@ -1,5 +1,5 @@
 // BETTERER RESULTS V2.
-//
+// 
 // If this file contains merge conflicts, use `betterer merge` to automatically resolve them:
 // https://phenomnomnominal.github.io/betterer/docs/results-file/#merge
 //
@@ -872,9 +872,6 @@ exports[`better eslint`] = {
     ],
     "packages/grafana-ui/src/components/PageLayout/PageToolbar.story.tsx:5381": [
       [0, 0, 0, "\'VerticalGroup\' import from \'@grafana/ui\' is restricted from being used by a pattern. Use Stack component instead.", "0"]
-    ],
-    "packages/grafana-ui/src/components/PanelChrome/PanelChrome.story.tsx:5381": [
-      [0, 0, 0, "\'HorizontalGroup\' import from \'../Layout/Layout\' is restricted from being used by a pattern. Use Stack component instead.", "0"]
     ],
     "packages/grafana-ui/src/components/PanelChrome/PanelContext.ts:5381": [
       [0, 0, 0, "Unexpected any. Specify a different type.", "0"],

--- a/packages/grafana-ui/src/components/PanelChrome/PanelChrome.mdx
+++ b/packages/grafana-ui/src/components/PanelChrome/PanelChrome.mdx
@@ -3,10 +3,10 @@ import { Meta, Preview } from '@storybook/addon-docs/blocks';
 import { PanelChrome } from './PanelChrome';
 
 import { action } from '@storybook/addon-actions';
-import { HorizontalGroup } from '../Layout/Layout';
 import { LoadingState } from '@grafana/data';
 import { Button } from '../Button';
 import { Menu } from '../Menu/Menu';
+import { Stack } from '../Layout/Stack/Stack';
 import { IconButton } from '../IconButton/IconButton';
 
 <Meta title="MDX|PanelChrome" component={PanelChrome} />
@@ -109,7 +109,7 @@ Component used for rendering content wrapped in the same style as grafana panels
 
 <Preview>
 
-  <HorizontalGroup spacing="md" align="flex-start" wrap>
+  <Stack gap={2} alignItems="flex-start" wrap="wrap">
   <PanelChrome
     title="My awesome panel title"
     menu={() => (
@@ -182,7 +182,7 @@ Component used for rendering content wrapped in the same style as grafana panels
     }}
 
   </PanelChrome>
-</HorizontalGroup>
+</Stack>
 </Preview>
 
 ### States: Loading , Streaming, Error
@@ -217,7 +217,7 @@ Component used for rendering content wrapped in the same style as grafana panels
 
 <Preview>
 
-  <HorizontalGroup spacing="md" align="flex-start" wrap>
+  <Stack gap={2} alignItems="flex-start" wrap="wrap">
   <PanelChrome
     title="My awesome panel title"
     loadingState={LoadingState.Loading}
@@ -297,7 +297,7 @@ Component used for rendering content wrapped in the same style as grafana panels
     }}
 
   </PanelChrome>
-</HorizontalGroup>
+</Stack>
 </Preview>
 
 ### Extra options? Title items and actions

--- a/packages/grafana-ui/src/components/PanelChrome/PanelChrome.story.tsx
+++ b/packages/grafana-ui/src/components/PanelChrome/PanelChrome.story.tsx
@@ -5,10 +5,9 @@ import React, { CSSProperties, useState, ReactNode } from 'react';
 import { useInterval, useToggle } from 'react-use';
 
 import { LoadingState } from '@grafana/data';
-import { Button, Icon, PanelChrome, PanelChromeProps, RadioButtonGroup } from '@grafana/ui';
+import { Button, Icon, PanelChrome, PanelChromeProps, RadioButtonGroup, Stack } from '@grafana/ui';
 
 import { DashboardStoryCanvas } from '../../utils/storybook/DashboardStoryCanvas';
-import { HorizontalGroup } from '../Layout/Layout';
 import { Menu } from '../Menu/Menu';
 
 import mdx from './PanelChrome.mdx';
@@ -124,7 +123,7 @@ export const Examples = () => {
   return (
     <DashboardStoryCanvas>
       <div>
-        <HorizontalGroup spacing="md" align="flex-start" wrap>
+        <Stack gap={2} alignItems="flex-start" wrap="wrap">
           {renderPanel('Has statusMessage', {
             title: 'Default title',
             statusMessage: 'Error text',
@@ -255,7 +254,7 @@ export const Examples = () => {
               </Button>
             ),
           })}
-        </HorizontalGroup>
+        </Stack>
       </div>
     </DashboardStoryCanvas>
   );
@@ -265,7 +264,7 @@ export const ExamplesHoverHeader = () => {
   return (
     <DashboardStoryCanvas>
       <div>
-        <HorizontalGroup spacing="md" align="flex-start" wrap>
+        <Stack gap={2} alignItems="flex-start" wrap="wrap">
           {renderPanel('Title items, menu, hover header', {
             title: 'Default title',
             description: 'This is a description',
@@ -316,7 +315,7 @@ export const ExamplesHoverHeader = () => {
               </a>
             ),
           })}
-        </HorizontalGroup>
+        </Stack>
       </div>
     </DashboardStoryCanvas>
   );


### PR DESCRIPTION
**What is this feature?**
This is part of the epic https://github.com/grafana/grafana/issues/85510

**Why do we need this feature?**
To replace deprecated layout components with new ones.

**Who is this feature for?**
Everybody

Which issue(s) does this PR fix?:
Fixes #
Related to #85510 

**Special notes for your reviewer:**

**PanelChrome.mdx**
**Before:**
<img width="1031" alt="Captura de pantalla 2024-04-10 a las 11 16 03" src="https://github.com/grafana/grafana/assets/65417731/97352352-1bb2-4ad9-bc67-d3b3a7c1e082">

**After:**
<img width="1042" alt="Captura de pantalla 2024-04-10 a las 11 15 51" src="https://github.com/grafana/grafana/assets/65417731/4fafd4ba-1739-46b7-bdce-28f11b5e7c35">

**PanelChrome.story.tsx**
**Before:**
<img width="893" alt="Captura de pantalla 2024-04-10 a las 11 17 18" src="https://github.com/grafana/grafana/assets/65417731/7b28397d-684b-499a-a110-b29abde2f825">
<img width="908" alt="Captura de pantalla 2024-04-10 a las 11 17 42" src="https://github.com/grafana/grafana/assets/65417731/385e0a57-3aee-44aa-821c-f87153c6cfdb">

**After:**
<img width="886" alt="Captura de pantalla 2024-04-10 a las 11 17 08" src="https://github.com/grafana/grafana/assets/65417731/9a964aa8-65aa-4c5e-8564-61491f7e92ae">
<img width="895" alt="Captura de pantalla 2024-04-10 a las 11 17 32" src="https://github.com/grafana/grafana/assets/65417731/9ceb4577-5fca-4a9a-b7a9-099a12166aed">


Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
