### PR TITLE
Grafana UI: `SecretTextArea` - Replace `HorizontalGroup` with `Stack` and `Box`

### DIFF
--- a/.betterer.results
+++ b/.betterer.results
@@ -1,5 +1,5 @@
 // BETTERER RESULTS V2.
-// 
+//
 // If this file contains merge conflicts, use `betterer merge` to automatically resolve them:
 // https://phenomnomnominal.github.io/betterer/docs/results-file/#merge
 //

--- a/.betterer.results
+++ b/.betterer.results
@@ -1,5 +1,5 @@
 // BETTERER RESULTS V2.
-//
+// 
 // If this file contains merge conflicts, use `betterer merge` to automatically resolve them:
 // https://phenomnomnominal.github.io/betterer/docs/results-file/#merge
 //
@@ -882,9 +882,6 @@ exports[`better eslint`] = {
     ],
     "packages/grafana-ui/src/components/PanelChrome/index.ts:5381": [
       [0, 0, 0, "Do not use any type assertions.", "0"]
-    ],
-    "packages/grafana-ui/src/components/SecretTextArea/SecretTextArea.tsx:5381": [
-      [0, 0, 0, "\'HorizontalGroup\' import from \'../Layout/Layout\' is restricted from being used by a pattern. Use Stack component instead.", "0"]
     ],
     "packages/grafana-ui/src/components/Segment/SegmentSelect.tsx:5381": [
       [0, 0, 0, "Do not use any type assertions.", "0"]

--- a/packages/grafana-ui/src/components/SecretTextArea/SecretTextArea.tsx
+++ b/packages/grafana-ui/src/components/SecretTextArea/SecretTextArea.tsx
@@ -5,6 +5,7 @@ import { GrafanaTheme2 } from '@grafana/data';
 
 import { useStyles2 } from '../../themes/ThemeContext';
 import { Button } from '../Button';
+import { Box } from '../Layout/Box/Box';
 import { Stack } from '../Layout/Stack/Stack';
 import { TextArea } from '../TextArea/TextArea';
 
@@ -36,10 +37,18 @@ export const SecretTextArea = ({ isConfigured, onReset, ...props }: Props) => {
   const styles = useStyles2(getStyles);
   return (
     <Stack>
-      {!isConfigured && <TextArea {...props} />}
-      {isConfigured && (
-        <TextArea {...props} rows={1} disabled={true} value={CONFIGURED_TEXT} className={cx(styles.configuredStyle)} />
-      )}
+      <Box>
+        {!isConfigured && <TextArea {...props} />}
+        {isConfigured && (
+          <TextArea
+            {...props}
+            rows={1}
+            disabled={true}
+            value={CONFIGURED_TEXT}
+            className={cx(styles.configuredStyle)}
+          />
+        )}
+      </Box>
       {isConfigured && (
         <Button onClick={onReset} variant="secondary">
           {RESET_BUTTON_TEXT}

--- a/packages/grafana-ui/src/components/SecretTextArea/SecretTextArea.tsx
+++ b/packages/grafana-ui/src/components/SecretTextArea/SecretTextArea.tsx
@@ -5,7 +5,7 @@ import { GrafanaTheme2 } from '@grafana/data';
 
 import { useStyles2 } from '../../themes/ThemeContext';
 import { Button } from '../Button';
-import { HorizontalGroup } from '../Layout/Layout';
+import { Stack } from '../Layout/Stack/Stack';
 import { TextArea } from '../TextArea/TextArea';
 
 export type Props = React.ComponentProps<typeof TextArea> & {
@@ -35,7 +35,7 @@ const getStyles = (theme: GrafanaTheme2) => {
 export const SecretTextArea = ({ isConfigured, onReset, ...props }: Props) => {
   const styles = useStyles2(getStyles);
   return (
-    <HorizontalGroup>
+    <Stack>
       {!isConfigured && <TextArea {...props} />}
       {isConfigured && (
         <TextArea {...props} rows={1} disabled={true} value={CONFIGURED_TEXT} className={cx(styles.configuredStyle)} />
@@ -45,6 +45,6 @@ export const SecretTextArea = ({ isConfigured, onReset, ...props }: Props) => {
           {RESET_BUTTON_TEXT}
         </Button>
       )}
-    </HorizontalGroup>
+    </Stack>
   );
 };


### PR DESCRIPTION
What is this feature?
This is part of the epic https://github.com/grafana/grafana/issues/85510

Why do we need this feature?
To replace deprecated layout components with new ones.

Who is this feature for?
Everybody

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

**Before:**
<img width="356" alt="Captura de pantalla 2024-04-10 a las 11 46 19" src="https://github.com/grafana/grafana/assets/65417731/a96e165d-b406-435b-91f0-f522addac81f">
<img width="435" alt="Captura de pantalla 2024-04-10 a las 11 46 39" src="https://github.com/grafana/grafana/assets/65417731/106ec338-5d39-46ce-af28-cd64a47659b6">

**After:**
<img width="371" alt="Captura de pantalla 2024-04-10 a las 11 46 57" src="https://github.com/grafana/grafana/assets/65417731/692c2fda-df85-45df-ae4e-1a4af1df1a56">
<img width="447" alt="Captura de pantalla 2024-04-10 a las 11 47 13" src="https://github.com/grafana/grafana/assets/65417731/f44cc9e9-8aa2-4470-ab17-b948e725db9b">


Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
