### PR TITLE
Alerting: clarify alerting silences

### DIFF
--- a/docs/sources/alerting/configure-notifications/create-silence.md
+++ b/docs/sources/alerting/configure-notifications/create-silence.md
@@ -43,7 +43,7 @@ To add a silence, complete the following steps.
 1. Click **Create silence** to open the Create silence page.
 1. In **Silence start and end**, select the start and end date to indicate when the silence should go into effect and expire.
 1. Optionally, in **Duration**, specify how long the silence is enforced. This automatically updates the end time in the **Silence start and end** field.
-1. In the **Label** and **Value** fields, enter one or more _Matching Labels_. Matchers determine which rules the silence will apply to. Any matching alerts (in firing state) will show in the **Silenced alert instancess** field
+1. In the **Label** and **Value** fields, enter one or more _Matching Labels_. Matchers determine which rules the silence will apply to. Any matching alerts (in firing state) will show in the **Silenced alert instances** field
 1. In **Comment**, add details about the silence.
 1. Click **Submit**.
 

--- a/docs/sources/alerting/configure-notifications/create-silence.md
+++ b/docs/sources/alerting/configure-notifications/create-silence.md
@@ -43,7 +43,7 @@ To add a silence, complete the following steps.
 1. Click **Create silence** to open the Create silence page.
 1. In **Silence start and end**, select the start and end date to indicate when the silence should go into effect and expire.
 1. Optionally, in **Duration**, specify how long the silence is enforced. This automatically updates the end time in the **Silence start and end** field.
-1. In the **Label** and **Value** fields, enter one or more _Matching Labels_. Matchers determine which rules the silence will apply to. Any matching alerts (in firing state) will show in the **Affected alert instances** field
+1. In the **Label** and **Value** fields, enter one or more _Matching Labels_. Matchers determine which rules the silence will apply to. Any matching alerts (in firing state) will show in the **Silenced alert instancess** field
 1. In **Comment**, add details about the silence.
 1. Click **Submit**.
 

--- a/public/app/features/alerting/unified/components/rule-viewer/Actions.tsx
+++ b/public/app/features/alerting/unified/components/rule-viewer/Actions.tsx
@@ -55,7 +55,7 @@ export const useAlertRulePageActions = ({ handleDelete, handleDuplicateRule }: P
           {canEdit && <MenuItemPauseRule rule={rule} />}
           {canSilence && (
             <Menu.Item
-              label="Silence"
+              label="Silence notifications"
               icon="bell-slash"
               url={makeRuleBasedSilenceLink(identifier.ruleSourceName, rule)}
             />

--- a/public/app/features/alerting/unified/components/silences/SilencedInstancesPreview.tsx
+++ b/public/app/features/alerting/unified/components/silences/SilencedInstancesPreview.tsx
@@ -43,7 +43,7 @@ export const SilencedInstancesPreview = ({ amSourceName, matchers }: Props) => {
   return (
     <div>
       <h4 className={styles.title}>
-        Affected alert instances
+        Silenced alert instances
         {tableItemAlerts.length > 0 ? (
           <Badge className={styles.badge} color="blue" text={tableItemAlerts.length} />
         ) : null}
@@ -65,7 +65,7 @@ export const SilencedInstancesPreview = ({ amSourceName, matchers }: Props) => {
               pagination={{ itemsPerPage: 10 }}
             />
           ) : (
-            <span>No matching alert instances found</span>
+            <span>No firing alert instances found</span>
           )}
         </div>
       )}


### PR DESCRIPTION
While reviewing open-source issues we noticed that the wording could be improved to explain what a silence does in comparison to a pause.