### PR TITLE
Chore: Run PR checks when enabling auto-merge

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -9,6 +9,7 @@ on:
       - labeled
       - unlabeled
       - edited
+      - auto_merge_enabled
   issues:
     types:
       - milestoned


### PR DESCRIPTION
Github does not run Github Actions on PRs created by Github Actions, such as our [I18n imports](https://github.com/grafana/grafana/pull/85797), which prevents the Changelog and Milestone checks from running without intervention.

This PR tweaks the pr checks triggers to also run when enabling auto-merge on PRs. 

I would preferably also like it to run when a PR is approved, but that seems to be a different even that I'm not confident would work with the PR Checks script and I'm not really interested in trying to troubleshoot it 😅   https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request_review