### PR TITLE
CloudMigrations: include stack id in access policy and token names

### DIFF
--- a/pkg/services/cloudmigration/cloudmigrationimpl/cloudmigration.go
+++ b/pkg/services/cloudmigration/cloudmigrationimpl/cloudmigration.go
@@ -112,6 +112,7 @@ func (s *Service) CreateToken(ctx context.Context) (cloudmigration.CreateAccessT
 
 	// Add the stack id to the access policy name to ensure access policies in a org have unique names.
 	accessPolicyName := fmt.Sprintf("%s-%s", cloudMigrationAccessPolicyNamePrefix, s.cfg.StackID)
+	accessPolicyDisplayName := fmt.Sprintf("%s-%s", s.cfg.Slug, cloudMigrationAccessPolicyNamePrefix)
 
 	timeoutCtx, cancel = context.WithTimeout(ctx, s.cfg.CloudMigration.FetchAccessPolicyTimeout)
 	defer cancel()
@@ -142,7 +143,7 @@ func (s *Service) CreateToken(ctx context.Context) (cloudmigration.CreateAccessT
 		},
 		gcom.CreateAccessPolicyPayload{
 			Name:        accessPolicyName,
-			DisplayName: cloudMigrationAccessPolicyNamePrefix,
+			DisplayName: accessPolicyDisplayName,
 			Realms:      []gcom.Realm{{Type: "stack", Identifier: s.cfg.StackID, LabelPolicies: []gcom.LabelPolicy{}}},
 			Scopes:      []string{"cloud-migrations:read", "cloud-migrations:write"},
 		})
@@ -153,6 +154,7 @@ func (s *Service) CreateToken(ctx context.Context) (cloudmigration.CreateAccessT
 
 	// Add the stack id to the token name to ensure tokens in a org have unique names.
 	accessTokenName := fmt.Sprintf("%s-%s", cloudMigrationTokenNamePrefix, s.cfg.StackID)
+	accessTokenDisplayName := fmt.Sprintf("%s-%s", s.cfg.Slug, cloudMigrationTokenNamePrefix)
 	timeoutCtx, cancel = context.WithTimeout(ctx, s.cfg.CloudMigration.CreateTokenTimeout)
 	defer cancel()
 
@@ -160,7 +162,7 @@ func (s *Service) CreateToken(ctx context.Context) (cloudmigration.CreateAccessT
 		gcom.CreateTokenParams{RequestID: requestID, Region: instance.RegionSlug},
 		gcom.CreateTokenPayload{
 			AccessPolicyID: accessPolicy.ID,
-			DisplayName:    cloudMigrationTokenNamePrefix,
+			DisplayName:    accessTokenDisplayName,
 			Name:           accessTokenName,
 			ExpiresAt:      time.Now().Add(s.cfg.CloudMigration.TokenExpiresAfter),
 		})

--- a/pkg/services/cloudmigration/cloudmigrationimpl/cloudmigration.go
+++ b/pkg/services/cloudmigration/cloudmigrationimpl/cloudmigration.go
@@ -162,8 +162,8 @@ func (s *Service) CreateToken(ctx context.Context) (cloudmigration.CreateAccessT
 		gcom.CreateTokenParams{RequestID: requestID, Region: instance.RegionSlug},
 		gcom.CreateTokenPayload{
 			AccessPolicyID: accessPolicy.ID,
-			DisplayName:    accessTokenDisplayName,
 			Name:           accessTokenName,
+			DisplayName:    accessTokenDisplayName,
 			ExpiresAt:      time.Now().Add(s.cfg.CloudMigration.TokenExpiresAfter),
 		})
 	if err != nil {

--- a/pkg/services/cloudmigration/cloudmigrationimpl/cloudmigration.go
+++ b/pkg/services/cloudmigration/cloudmigrationimpl/cloudmigration.go
@@ -50,9 +50,9 @@ var LogPrefix = "cloudmigration.service"
 
 const (
 	// nolint:gosec
-	cloudMigrationAccessPolicyName = "grafana-cloud-migrations"
+	cloudMigrationAccessPolicyNamePrefix = "grafana-cloud-migrations"
 	//nolint:gosec
-	cloudMigrationTokenName = "grafana-cloud-migrations"
+	cloudMigrationTokenNamePrefix = "grafana-cloud-migrations"
 )
 
 var _ cloudmigration.Service = (*Service)(nil)
@@ -110,11 +110,14 @@ func (s *Service) CreateToken(ctx context.Context) (cloudmigration.CreateAccessT
 		return cloudmigration.CreateAccessTokenResponse{}, fmt.Errorf("fetching instance by id: id=%s %w", s.cfg.StackID, err)
 	}
 
+	// Add the stack id to the access policy name to ensure access policies in a org have unique names.
+	accessPolicyName := fmt.Sprintf("%s-%s", cloudMigrationAccessPolicyNamePrefix, s.cfg.StackID)
+
 	timeoutCtx, cancel = context.WithTimeout(ctx, s.cfg.CloudMigration.FetchAccessPolicyTimeout)
 	defer cancel()
-	existingAccessPolicy, err := s.findAccessPolicyByName(timeoutCtx, instance.RegionSlug, cloudMigrationAccessPolicyName)
+	existingAccessPolicy, err := s.findAccessPolicyByName(timeoutCtx, instance.RegionSlug, accessPolicyName)
 	if err != nil {
-		return cloudmigration.CreateAccessTokenResponse{}, fmt.Errorf("fetching access policy by name: name=%s %w", cloudMigrationAccessPolicyName, err)
+		return cloudmigration.CreateAccessTokenResponse{}, fmt.Errorf("fetching access policy by name: name=%s %w", accessPolicyName, err)
 	}
 
 	if existingAccessPolicy != nil {
@@ -138,8 +141,8 @@ func (s *Service) CreateToken(ctx context.Context) (cloudmigration.CreateAccessT
 			Region:    instance.RegionSlug,
 		},
 		gcom.CreateAccessPolicyPayload{
-			Name:        cloudMigrationAccessPolicyName,
-			DisplayName: cloudMigrationAccessPolicyName,
+			Name:        accessPolicyName,
+			DisplayName: cloudMigrationAccessPolicyNamePrefix,
 			Realms:      []gcom.Realm{{Type: "stack", Identifier: s.cfg.StackID, LabelPolicies: []gcom.LabelPolicy{}}},
 			Scopes:      []string{"cloud-migrations:read", "cloud-migrations:write"},
 		})
@@ -148,14 +151,17 @@ func (s *Service) CreateToken(ctx context.Context) (cloudmigration.CreateAccessT
 	}
 	logger.Info("created access policy", "id", accessPolicy.ID, "name", accessPolicy.Name)
 
+	// Add the stack id to the token name to ensure tokens in a org have unique names.
+	accessTokenName := fmt.Sprintf("%s-%s", cloudMigrationTokenNamePrefix, s.cfg.StackID)
 	timeoutCtx, cancel = context.WithTimeout(ctx, s.cfg.CloudMigration.CreateTokenTimeout)
 	defer cancel()
+
 	token, err := s.gcomService.CreateToken(timeoutCtx,
 		gcom.CreateTokenParams{RequestID: requestID, Region: instance.RegionSlug},
 		gcom.CreateTokenPayload{
 			AccessPolicyID: accessPolicy.ID,
-			DisplayName:    cloudMigrationTokenName,
-			Name:           cloudMigrationTokenName,
+			DisplayName:    cloudMigrationTokenNamePrefix,
+			Name:           accessTokenName,
 			ExpiresAt:      time.Now().Add(s.cfg.CloudMigration.TokenExpiresAfter),
 		})
 	if err != nil {


### PR DESCRIPTION
When creating an access token for a cloud migration, includes the stack id in the access policy and access token name to ensure uniqueness in the org.

Closes https://github.com/grafana/grafana-operator-experience-squad/issues/731