### PR TITLE
Alerting: Fix evaluation metrics to not count retries

### DIFF
--- a/pkg/services/ngalert/metrics/scheduler.go
+++ b/pkg/services/ngalert/metrics/scheduler.go
@@ -18,6 +18,8 @@ type Scheduler struct {
 	EvalTotal                           *prometheus.CounterVec
 	EvalFailures                        *prometheus.CounterVec
 	EvalDuration                        *prometheus.HistogramVec
+	EvalAttemptTotal                    *prometheus.CounterVec
+	EvalAttemptFailures                 *prometheus.CounterVec
 	ProcessDuration                     *prometheus.HistogramVec
 	SendDuration                        *prometheus.HistogramVec
 	SimpleNotificationRules             *prometheus.GaugeVec
@@ -69,6 +71,24 @@ func NewSchedulerMetrics(r prometheus.Registerer) *Scheduler {
 				Name:      "rule_evaluation_duration_seconds",
 				Help:      "The time to evaluate a rule.",
 				Buckets:   []float64{.01, .1, .5, 1, 5, 10, 15, 30, 60, 120, 180, 240, 300},
+			},
+			[]string{"org"},
+		),
+		EvalAttemptTotal: promauto.With(r).NewCounterVec(
+			prometheus.CounterOpts{
+				Namespace: Namespace,
+				Subsystem: Subsystem,
+				Name:      "rule_evaluation_attempts_total",
+				Help:      "The total number of rule evaluation attempts.",
+			},
+			[]string{"org"},
+		),
+		EvalAttemptFailures: promauto.With(r).NewCounterVec(
+			prometheus.CounterOpts{
+				Namespace: Namespace,
+				Subsystem: Subsystem,
+				Name:      "rule_evaluation_attempt_failures_total",
+				Help:      "The total number of rule evaluation attempt failures.",
 			},
 			[]string{"org"},
 		),

--- a/pkg/services/ngalert/schedule/alert_rule.go
+++ b/pkg/services/ngalert/schedule/alert_rule.go
@@ -227,10 +227,16 @@ func (a *alertRule) Run(key ngmodels.AlertRuleKey) error {
 			}
 
 			func() {
+				orgID := fmt.Sprint(key.OrgID)
+				evalDuration := a.metrics.EvalDuration.WithLabelValues(orgID)
+				evalTotal := a.metrics.EvalTotal.WithLabelValues(orgID)
+
 				evalRunning = true
+				evalStart := a.clock.Now()
 				defer func() {
 					evalRunning = false
 					a.evalApplied(key, ctx.scheduledAt)
+					evalDuration.Observe(a.clock.Now().Sub(evalStart).Seconds())
 				}()
 
 				for attempt := int64(1); attempt <= a.maxAttempts; attempt++ {
@@ -253,6 +259,11 @@ func (a *alertRule) Run(key ngmodels.AlertRuleKey) error {
 					if isPaused {
 						logger.Debug("Skip rule evaluation because it is paused")
 						return
+					}
+
+					// Only increment evaluation counter once, not per-retry.
+					if attempt == 1 {
+						evalTotal.Inc()
 					}
 
 					fpStr := currentFingerprint.String()
@@ -312,14 +323,16 @@ func (a *alertRule) Run(key ngmodels.AlertRuleKey) error {
 
 func (a *alertRule) evaluate(ctx context.Context, key ngmodels.AlertRuleKey, f fingerprint, attempt int64, e *Evaluation, span trace.Span, retry bool) error {
 	orgID := fmt.Sprint(key.OrgID)
-	evalTotal := a.metrics.EvalTotal.WithLabelValues(orgID)
-	evalDuration := a.metrics.EvalDuration.WithLabelValues(orgID)
+	evalAttemptTotal := a.metrics.EvalAttemptTotal.WithLabelValues(orgID)
+	evalAttemptFailures := a.metrics.EvalAttemptFailures.WithLabelValues(orgID)
 	evalTotalFailures := a.metrics.EvalFailures.WithLabelValues(orgID)
 	processDuration := a.metrics.ProcessDuration.WithLabelValues(orgID)
 	sendDuration := a.metrics.SendDuration.WithLabelValues(orgID)
 
 	logger := a.logger.FromContext(ctx).New("version", e.rule.Version, "fingerprint", f, "attempt", attempt, "now", e.scheduledAt).FromContext(ctx)
 	start := a.clock.Now()
+
+	evalAttemptTotal.Inc()
 
 	evalCtx := eval.NewContextWithPreviousResults(ctx, SchedulerUserFor(e.rule.OrgID), a.newLoadedMetricsReader(e.rule))
 	ruleEval, err := a.evalFactory.Create(evalCtx, e.rule.GetEvalCondition())
@@ -336,9 +349,6 @@ func (a *alertRule) evaluate(ctx context.Context, key ngmodels.AlertRuleKey, f f
 		}
 	}
 
-	evalTotal.Inc()
-	evalDuration.Observe(dur.Seconds())
-
 	if ctx.Err() != nil { // check if the context is not cancelled. The evaluation can be a long-running task.
 		span.SetStatus(codes.Error, "rule evaluation cancelled")
 		logger.Debug("Skip updating the state because the context has been cancelled")
@@ -346,7 +356,7 @@ func (a *alertRule) evaluate(ctx context.Context, key ngmodels.AlertRuleKey, f f
 	}
 
 	if err != nil || results.HasErrors() {
-		evalTotalFailures.Inc()
+		evalAttemptFailures.Inc()
 
 		// Only retry (return errors) if this isn't the last attempt, otherwise skip these return operations.
 		if retry {
@@ -364,6 +374,9 @@ func (a *alertRule) evaluate(ctx context.Context, key ngmodels.AlertRuleKey, f f
 				span.RecordError(err)
 				return fmt.Errorf("the result-set has errors that can be retried: %w", results.Error())
 			}
+		} else {
+			// Only count the final attempt as a failure.
+			evalTotalFailures.Inc()
 		}
 
 		// If results is nil, we assume that the error must be from the SSE pipeline (ruleEval.Evaluate) which is the only code that can actually return an `err`.

--- a/pkg/services/ngalert/schedule/alert_rule.go
+++ b/pkg/services/ngalert/schedule/alert_rule.go
@@ -332,8 +332,6 @@ func (a *alertRule) evaluate(ctx context.Context, key ngmodels.AlertRuleKey, f f
 	logger := a.logger.FromContext(ctx).New("version", e.rule.Version, "fingerprint", f, "attempt", attempt, "now", e.scheduledAt).FromContext(ctx)
 	start := a.clock.Now()
 
-	evalAttemptTotal.Inc()
-
 	evalCtx := eval.NewContextWithPreviousResults(ctx, SchedulerUserFor(e.rule.OrgID), a.newLoadedMetricsReader(e.rule))
 	ruleEval, err := a.evalFactory.Create(evalCtx, e.rule.GetEvalCondition())
 	var results eval.Results
@@ -348,6 +346,8 @@ func (a *alertRule) evaluate(ctx context.Context, key ngmodels.AlertRuleKey, f f
 			logger.Error("Failed to evaluate rule", "error", err, "duration", dur)
 		}
 	}
+
+	evalAttemptTotal.Inc()
 
 	if ctx.Err() != nil { // check if the context is not cancelled. The evaluation can be a long-running task.
 		span.SetStatus(codes.Error, "rule evaluation cancelled")


### PR DESCRIPTION
Changes the following metrics to scope multiple retry attempts as a single occurrence:

- `grafana_alerting_rule_evaluation_duration_seconds`
- `grafana_alerting_rule_evaluations_total`
- `grafana_alerting_rule_evaluation_failures_total`

The benefits are:
- To have a consistent count of evaluations, irrespective of the number of retries required.
- To have a count of failures that might need attention. i.e. a successfully retried evaluation is usually not a cause for concern.

The change also adds the following new metrics, which inherit the behavior of the previous metrics.
- `grafana_alerting_rule_evaluation_attempts_total`
- `grafana_alerting_rule_evaluation_attempt_failures_total`

I've opted not to add a duration for individual attempts, I don't think it's worth the additional cardinality, and the information is available through debug log lines if needed.

Fixes #85847