### PR TITLE
Metrics: Prevent duplicates in MultiRegistry

### DIFF
--- a/pkg/infra/metrics/service.go
+++ b/pkg/infra/metrics/service.go
@@ -2,9 +2,10 @@ package metrics
 
 import (
 	"context"
-	"errors"
+	"fmt"
 	"regexp"
 	"sort"
+	"strings"
 
 	"github.com/prometheus/client_golang/prometheus"
 	dto "github.com/prometheus/client_model/go"
@@ -108,7 +109,7 @@ func (g *addPrefixWrapper) Gather() ([]*dto.MetricFamily, error) {
 			*m.Name = "grafana_" + *m.Name
 			// since we are modifying the name, we need to check for duplicates in the gatherer
 			if _, exists := names[*m.Name]; exists {
-				return nil, errors.New("duplicate metric name: " + *m.Name)
+				return nil, fmt.Errorf("duplicate metric name: %s", *m.Name)
 			}
 		}
 		// keep track of names to detect duplicates
@@ -140,11 +141,20 @@ func (r *multiRegistry) Gather() (mfs []*dto.MetricFamily, err error) {
 
 		for i := 0; i < len(mf); i++ {
 			m := mf[i]
+			_, exists := names[*m.Name]
 			// prevent duplicate metric names
-			if _, exists := names[*m.Name]; !exists {
-				names[*m.Name] = struct{}{}
-				mfs = append(mfs, m)
+			if exists {
+				// we can skip go_ metrics without returning an error
+				// because they are known to be duplicates in both
+				// the k8s and prometheus gatherers.
+				if strings.HasPrefix(*m.Name, "go_") {
+					continue
+				}
+				errs = append(errs, fmt.Errorf("duplicate metric name: %s", *m.Name))
+				continue
 			}
+			names[*m.Name] = struct{}{}
+			mfs = append(mfs, m)
 		}
 	}
 


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

This returns an error if there is a metric name collision between the k8s registry and the default prom registry.

**Why do we need this feature?**

This would normally be caught during registration, but this is not possible since we are merging two registries in the Gatherer. Duplicates are currently silently discarded, but it would be better to know about them just in case new k8s metrics are added. 

**Who is this feature for?**

[Add information on what kind of user the feature is for.]

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
