### PR TITLE
DashboardScene: Enrich requests correctly in edit mode

### DIFF
--- a/public/app/features/dashboard-scene/scene/DashboardScene.test.tsx
+++ b/public/app/features/dashboard-scene/scene/DashboardScene.test.tsx
@@ -16,6 +16,7 @@ import appEvents from 'app/core/app_events';
 import { getDashboardSrv } from 'app/features/dashboard/services/DashboardSrv';
 import { VariablesChanged } from 'app/features/variables/types';
 
+import { PanelEditor, buildPanelEditScene } from '../panel-edit/PanelEditor';
 import { createWorker } from '../saving/createDetectChangesWorker';
 import {
   buildGridItemForLibPanel,
@@ -26,6 +27,7 @@ import { DecoratedRevisionModel } from '../settings/VersionsEditView';
 import { historySrv } from '../settings/version-history/HistorySrv';
 import { dashboardSceneGraph } from '../utils/dashboardSceneGraph';
 import { djb2Hash } from '../utils/djb2Hash';
+import { findVizPanelByKey } from '../utils/utils';
 
 import { DashboardControls } from './DashboardControls';
 import { DashboardGridItem } from './DashboardGridItem';
@@ -884,13 +886,30 @@ describe('DashboardScene', () => {
       scene.onEnterEditMode();
     });
 
-    it('Should add app, uid, panelId and panelPluginId', () => {
-      const queryRunner = sceneGraph.findObject(scene, (o) => o.state.key === 'data-query-runner')!;
-      expect(scene.enrichDataRequest(queryRunner)).toEqual({
-        app: CoreApp.Dashboard,
-        dashboardUID: 'dash-1',
-        panelId: 1,
-        panelPluginId: 'table',
+    describe('Should add app, uid, panelId and panelPluginId', () => {
+      test('when viewing', () => {
+        const queryRunner = sceneGraph.findObject(scene, (o) => o.state.key === 'data-query-runner')!;
+        expect(scene.enrichDataRequest(queryRunner)).toEqual({
+          app: CoreApp.Dashboard,
+          dashboardUID: 'dash-1',
+          panelId: 1,
+          panelPluginId: 'table',
+        });
+      });
+      test('when editing', () => {
+        const panel = findVizPanelByKey(scene, 'panel-1');
+        const editPanel = buildPanelEditScene(panel!);
+        scene.setState({
+          editPanel,
+        });
+
+        const queryRunner = (scene.state.editPanel as PanelEditor).state.vizManager.queryRunner;
+        expect(scene.enrichDataRequest(queryRunner)).toEqual({
+          app: CoreApp.Dashboard,
+          dashboardUID: 'dash-1',
+          panelId: 1,
+          panelPluginId: 'table',
+        });
       });
     });
 

--- a/public/app/features/dashboard-scene/scene/DashboardScene.tsx
+++ b/public/app/features/dashboard-scene/scene/DashboardScene.tsx
@@ -49,6 +49,7 @@ import {
   NEW_PANEL_WIDTH,
   forceRenderChildren,
   getClosestVizPanel,
+  getDashboardSceneFor,
   getDefaultRow,
   getDefaultVizPanel,
   getPanelIdForVizPanel,
@@ -811,7 +812,14 @@ export class DashboardScene extends SceneObjectBase<DashboardSceneState> {
    * Called by the SceneQueryRunner to privide contextural parameters (tracking) props for the request
    */
   public enrichDataRequest(sceneObject: SceneObject): Partial<DataQueryRequest> {
-    const panel = getClosestVizPanel(sceneObject);
+    const dashboard = getDashboardSceneFor(sceneObject);
+
+    let panel = getClosestVizPanel(sceneObject);
+
+    if (dashboard.state.isEditing && dashboard.state.editPanel) {
+      panel = dashboard.state.editPanel.state.vizManager.state.panel;
+    }
+
     let panelId = 0;
 
     if (panel && panel.state.key) {


### PR DESCRIPTION
Due to `VizPanelManager` being used in the PanelEditor, the structure for resolving panel relative to query runner is different in the panel edit view. This PR makes sure the structural difference is taken into consideration when resolving a panel that is used to provide data for the enriched data query requests.