### PR TITLE
Grafana UI: `ThemeDemo` - Replace `HorizontalGroup` and `VerticalGroup` with `Stack` and `Box`

### DIFF
--- a/.betterer.results
+++ b/.betterer.results
@@ -1,5 +1,5 @@
 // BETTERER RESULTS V2.
-//
+// 
 // If this file contains merge conflicts, use `betterer merge` to automatically resolve them:
 // https://phenomnomnominal.github.io/betterer/docs/results-file/#merge
 //
@@ -1003,10 +1003,6 @@ exports[`better eslint`] = {
     ],
     "packages/grafana-ui/src/components/ThemeDemos/EmotionPerfTest.tsx:5381": [
       [0, 0, 0, "\'VerticalGroup\' import from \'../Layout/Layout\' is restricted from being used by a pattern. Use Stack component instead.", "0"]
-    ],
-    "packages/grafana-ui/src/components/ThemeDemos/ThemeDemo.tsx:5381": [
-      [0, 0, 0, "\'HorizontalGroup\' import from \'../Layout/Layout\' is restricted from being used by a pattern. Use Stack component instead.", "0"],
-      [0, 0, 0, "\'VerticalGroup\' import from \'../Layout/Layout\' is restricted from being used by a pattern. Use Stack component instead.", "1"]
     ],
     "packages/grafana-ui/src/components/ToolbarButton/ToolbarButton.story.tsx:5381": [
       [0, 0, 0, "\'HorizontalGroup\' import from \'../Layout/Layout\' is restricted from being used by a pattern. Use Stack component instead.", "0"],

--- a/packages/grafana-ui/src/components/ThemeDemos/ThemeDemo.tsx
+++ b/packages/grafana-ui/src/components/ThemeDemos/ThemeDemo.tsx
@@ -13,47 +13,40 @@ import { InlineFieldRow } from '../Forms/InlineFieldRow';
 import { RadioButtonGroup } from '../Forms/RadioButtonGroup/RadioButtonGroup';
 import { Icon } from '../Icon/Icon';
 import { Input } from '../Input/Input';
-import { HorizontalGroup, VerticalGroup } from '../Layout/Layout';
+import { BackgroundColor, BorderColor, Box } from '../Layout/Box/Box';
+import { Stack } from '../Layout/Stack/Stack';
 import { Select } from '../Select/Select';
 import { Switch } from '../Switch/Switch';
+import { Text, TextProps } from '../Text/Text';
 
 interface DemoBoxProps {
-  bg?: string;
-  border?: string;
-  textColor?: string;
+  bg?: BackgroundColor;
+  border?: BorderColor;
+  textColor?: TextProps['color'];
 }
 
 const DemoBox = ({ bg, border, children }: React.PropsWithChildren<DemoBoxProps>) => {
-  const style = cx(
-    css({
-      padding: '16px',
-      background: bg ?? 'inherit',
-      width: '100%',
-    }),
-    border
-      ? css({
-          border: `1px solid ${border}`,
-        })
-      : null
+  return (
+    <Box backgroundColor={bg ? bg : undefined} padding={2} borderStyle={border ? 'solid' : undefined}>
+      {children}
+    </Box>
   );
-
-  return <div className={style}>{children}</div>;
 };
 
 const DemoText = ({
   color,
   bold,
-  size,
   children,
-}: React.PropsWithChildren<{ color?: string; bold?: boolean; size?: number }>) => {
-  const style = css({
-    padding: '4px',
-    color: color ?? 'inherit',
-    fontWeight: bold ? 500 : 400,
-    fontSize: `${size ?? 14}px`,
-  });
-
-  return <div className={style}>{children}</div>;
+}: React.PropsWithChildren<{ color?: TextProps['color']; bold?: boolean; size?: number }>) => {
+  return (
+    <Box padding={0.5}>
+      {children && (
+        <Text color={color ? color : undefined} weight={bold ? 'bold' : undefined}>
+          {children}
+        </Text>
+      )}
+    </Box>
+  );
 };
 
 export const ThemeDemo = () => {
@@ -90,31 +83,31 @@ export const ThemeDemo = () => {
         color: t.colors.text.primary,
       })}
     >
-      <DemoBox bg={t.colors.background.canvas}>
+      <DemoBox bg="canvas">
         <CollapsableSection label="Layers" isOpen={true}>
           <DemoText>t.colors.background.canvas</DemoText>
-          <DemoBox bg={t.colors.background.primary} border={t.colors.border.weak}>
+          <DemoBox bg="primary" border="weak">
             <DemoText>t.colors.background.primary is the main & preferred content </DemoText>
-            <DemoBox bg={t.colors.background.secondary} border={t.colors.border.weak}>
+            <DemoBox bg="secondary" border="weak">
               <DemoText>t.colors.background.secondary and t.colors.border.layer1</DemoText>
             </DemoBox>
           </DemoBox>
         </CollapsableSection>
         <CollapsableSection label="Text colors" isOpen={true}>
-          <HorizontalGroup>
+          <Stack justifyContent="flex-start">
             <DemoBox>
               <TextColors t={t} />
             </DemoBox>
-            <DemoBox bg={t.colors.background.primary}>
+            <DemoBox bg="primary">
               <TextColors t={t} />
             </DemoBox>
-            <DemoBox bg={t.colors.background.secondary}>
+            <DemoBox bg="secondary">
               <TextColors t={t} />
             </DemoBox>
-          </HorizontalGroup>
+          </Stack>
         </CollapsableSection>
         <CollapsableSection label="Rich colors" isOpen={true}>
-          <DemoBox bg={t.colors.background.primary}>
+          <DemoBox bg="primary">
             <table className={colorsTableStyle}>
               <thead>
                 <tr>
@@ -134,7 +127,7 @@ export const ThemeDemo = () => {
           </DemoBox>
         </CollapsableSection>
         <CollapsableSection label="Forms" isOpen={true}>
-          <DemoBox bg={t.colors.background.primary}>
+          <DemoBox bg="primary">
             <Field label="Input label" description="Field description">
               <Input placeholder="Placeholder" />
             </Field>
@@ -147,7 +140,7 @@ export const ThemeDemo = () => {
             <Field label="Radio label">
               <RadioButtonGroup options={radioOptions} value={radioValue} onChange={setRadioValue} />
             </Field>
-            <HorizontalGroup>
+            <Stack>
               <Field label="Switch">
                 <Switch value={boolValue} onChange={(e) => setBoolValue(e.currentTarget.checked)} />
               </Field>
@@ -157,8 +150,8 @@ export const ThemeDemo = () => {
               <Field label="Switch false disabled" disabled={true}>
                 <Switch value={false} />
               </Field>
-            </HorizontalGroup>
-            <VerticalGroup>
+            </Stack>
+            <Stack direction="column">
               <div>Inline forms</div>
               <InlineFieldRow>
                 <InlineField label="Label">
@@ -168,22 +161,22 @@ export const ThemeDemo = () => {
                   <Input placeholder="Disabled" />
                 </InlineField>
               </InlineFieldRow>
-            </VerticalGroup>
+            </Stack>
           </DemoBox>
         </CollapsableSection>
         <CollapsableSection label="Shadows" isOpen={true}>
-          <DemoBox bg={t.colors.background.primary}>
-            <HorizontalGroup>
+          <DemoBox bg="primary">
+            <Stack>
               {Object.entries(t.shadows).map(([key, value]) => (
                 <ShadowDemo name={key} shadow={value} key={key} />
               ))}
-            </HorizontalGroup>
+            </Stack>
           </DemoBox>
         </CollapsableSection>
         <CollapsableSection label="Buttons" isOpen={true}>
-          <DemoBox bg={t.colors.background.primary}>
-            <VerticalGroup spacing="lg">
-              <HorizontalGroup>
+          <DemoBox bg="primary">
+            <Stack direction="column" gap={3}>
+              <Stack>
                 {allButtonVariants.map((variant) => (
                   <Button variant={variant} key={variant}>
                     {variant}
@@ -192,7 +185,7 @@ export const ThemeDemo = () => {
                 <Button variant="primary" disabled>
                   Disabled
                 </Button>
-              </HorizontalGroup>
+              </Stack>
               <Card>
                 <Card.Heading>Button inside card</Card.Heading>
                 <Card.Actions>
@@ -206,7 +199,7 @@ export const ThemeDemo = () => {
                   </Button>
                 </Card.Actions>
               </Card>
-            </VerticalGroup>
+            </Stack>
           </DemoBox>
         </CollapsableSection>
         <CollapsableSection label="Actions" isOpen={true}>
@@ -290,16 +283,16 @@ const colorsTableStyle = css({
 export function TextColors({ t }: { t: GrafanaTheme2 }) {
   return (
     <>
-      <DemoText color={t.colors.text.primary}>
+      <DemoText color="primary">
         text.primary <Icon name="trash-alt" />
       </DemoText>
-      <DemoText color={t.colors.text.secondary}>
+      <DemoText color="secondary">
         text.secondary <Icon name="trash-alt" />
       </DemoText>
-      <DemoText color={t.colors.text.disabled}>
+      <DemoText color="disabled">
         text.disabled <Icon name="trash-alt" />
       </DemoText>
-      <DemoText color={t.colors.primary.text}>
+      <DemoText color="primary">
         primary.text <Icon name="trash-alt" />
       </DemoText>
     </>
@@ -334,34 +327,34 @@ export function ActionsDemo() {
   });
 
   return (
-    <HorizontalGroup>
-      <DemoBox bg={t.colors.background.canvas}>
-        <VerticalGroup>
+    <Stack justifyContent="flex-start">
+      <DemoBox bg="canvas">
+        <Stack direction="column">
           <div className={item}>item</div>
           <div className={item}>item</div>
           <div className={cx(item, hover)}>item hover</div>
           <div className={cx(item, selected)}>item selected</div>
           <div className={cx(item, focused)}>item focused</div>
-        </VerticalGroup>
+        </Stack>
       </DemoBox>
-      <DemoBox bg={t.colors.background.primary}>
-        <VerticalGroup>
+      <DemoBox bg="primary">
+        <Stack direction="column">
           <div className={item}>item</div>
           <div className={item}>item</div>
           <div className={cx(item, hover)}>item hover</div>
           <div className={cx(item, selected)}>item selected</div>
           <div className={cx(item, focused)}>item focused</div>
-        </VerticalGroup>
+        </Stack>
       </DemoBox>
-      <DemoBox bg={t.colors.background.secondary}>
-        <VerticalGroup>
+      <DemoBox bg="secondary">
+        <Stack direction="column">
           <div className={item}>item</div>
           <div className={item}>item</div>
           <div className={cx(item, hover)}>item hover</div>
           <div className={cx(item, selected)}>item selected</div>
           <div className={cx(item, focused)}>item focused</div>
-        </VerticalGroup>
+        </Stack>
       </DemoBox>
-    </HorizontalGroup>
+    </Stack>
   );
 }


### PR DESCRIPTION
**What is this feature?**
This is part of the epic https://github.com/grafana/grafana/issues/85510

**Why do we need this feature?**
To replace deprecated layout components with new ones.

**Who is this feature for?**
Everybody

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**
**Before:**
<img width="694" alt="Captura de pantalla 2024-04-10 a las 17 30 08" src="https://github.com/grafana/grafana/assets/65417731/b69b4679-9875-458a-a67b-e7ba636ed854">
<img width="648" alt="Captura de pantalla 2024-04-10 a las 17 29 47" src="https://github.com/grafana/grafana/assets/65417731/80f0770c-6a3f-4c18-830f-b7b5cb2022af">

**After:**
<img width="696" alt="Captura de pantalla 2024-04-10 a las 17 31 00" src="https://github.com/grafana/grafana/assets/65417731/7f0d6715-ae62-44e7-86ae-b347677de7f8">
<img width="529" alt="Captura de pantalla 2024-04-10 a las 17 31 21" src="https://github.com/grafana/grafana/assets/65417731/5ab727a6-d04e-4842-b504-e696c1b42e1a">


Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
