### PR TITLE
Alerting: Fix incorrect display of pending period in alert rule form

### DIFF
--- a/public/app/features/alerting/unified/components/rule-editor/GrafanaEvaluationBehavior.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/GrafanaEvaluationBehavior.tsx
@@ -105,11 +105,6 @@ function FolderGroupAndEvaluationInterval({
     setIsEditingGroup(false);
   };
 
-  // when the group evaluation interval changes, update the pending period to match
-  useEffect(() => {
-    setValue('evaluateFor', evaluateEvery);
-  }, [evaluateEvery, setValue]);
-
   const onOpenEditGroupModal = () => setIsEditingGroup(true);
 
   const editGroupDisabled = groupfoldersForGrafana?.loading || isNewGroup || !folderUid || !groupName;

--- a/public/app/features/alerting/unified/components/rules/EditRuleGroupModal.test.tsx
+++ b/public/app/features/alerting/unified/components/rules/EditRuleGroupModal.test.tsx
@@ -56,7 +56,7 @@ function getProvidersWrapper() {
 }
 
 describe('EditGroupModal', () => {
-  it('Should disable all inputs but interval when intervalEditOnly is set', () => {
+  it('Should disable all inputs but interval when intervalEditOnly is set', async () => {
     const namespace = mockCombinedRuleNamespace({
       name: 'my-alerts',
       rulesSource: mockDataSource(),
@@ -69,7 +69,7 @@ describe('EditGroupModal', () => {
       wrapper: getProvidersWrapper(),
     });
 
-    expect(ui.input.namespace.get()).toHaveAttribute('readonly');
+    expect(await ui.input.namespace.find()).toHaveAttribute('readonly');
     expect(ui.input.group.get()).toHaveAttribute('readonly');
     expect(ui.input.interval.get()).not.toHaveAttribute('readonly');
   });
@@ -96,7 +96,7 @@ describe('EditGroupModal component on cloud alert rules', () => {
     rulerRule: mockRulerRecordingRule({ record: 'recording-rule-cpu' }),
   });
 
-  it('Should show alert table in case of having some non-recording rules in the group', () => {
+  it('Should show alert table in case of having some non-recording rules in the group', async () => {
     const promNs = mockCombinedRuleNamespace({
       name: 'prometheus-ns',
       rulesSource: promDsSettings,
@@ -111,7 +111,7 @@ describe('EditGroupModal component on cloud alert rules', () => {
       wrapper: getProvidersWrapper(),
     });
 
-    expect(ui.input.namespace.get()).toHaveValue('prometheus-ns');
+    expect(await ui.input.namespace.find()).toHaveValue('prometheus-ns');
     expect(ui.input.namespace.get()).not.toHaveAttribute('readonly');
     expect(ui.input.group.get()).toHaveValue('default-group');
 
@@ -119,7 +119,7 @@ describe('EditGroupModal component on cloud alert rules', () => {
     expect(ui.tableRows.getAll()[0]).toHaveTextContent('alerting-rule-cpu');
   });
 
-  it('Should not show alert table in case of having exclusively recording rules in the group', () => {
+  it('Should not show alert table in case of having exclusively recording rules in the group', async () => {
     const promNs = mockCombinedRuleNamespace({
       name: 'prometheus-ns',
       rulesSource: promDsSettings,
@@ -132,7 +132,7 @@ describe('EditGroupModal component on cloud alert rules', () => {
       wrapper: getProvidersWrapper(),
     });
     expect(ui.table.query()).not.toBeInTheDocument();
-    expect(ui.noRulesText.get()).toBeInTheDocument();
+    expect(await ui.noRulesText.find()).toBeInTheDocument();
   });
 });
 
@@ -163,12 +163,12 @@ describe('EditGroupModal component on grafana-managed alert rules', () => {
 
   const grafanaGroup1 = grafanaNamespace.groups[0];
 
-  it('Should show alert table', () => {
+  it('Should show alert table', async () => {
     render(<EditCloudGroupModal namespace={grafanaNamespace} group={grafanaGroup1} onClose={jest.fn()} />, {
       wrapper: getProvidersWrapper(),
     });
 
-    expect(ui.input.namespace.get()).toHaveValue('namespace1');
+    expect(await ui.input.namespace.find()).toHaveValue('namespace1');
     expect(ui.input.group.get()).toHaveValue('grafanaGroup1');
     expect(ui.input.interval.get()).toHaveValue('30s');
 
@@ -177,19 +177,19 @@ describe('EditGroupModal component on grafana-managed alert rules', () => {
     expect(ui.tableRows.getAll()[1]).toHaveTextContent('high-memory');
   });
 
-  it('Should have folder input in readonly mode', () => {
+  it('Should have folder input in readonly mode', async () => {
     render(<EditCloudGroupModal namespace={grafanaNamespace} group={grafanaGroup1} onClose={jest.fn()} />, {
       wrapper: getProvidersWrapper(),
     });
 
-    expect(ui.input.namespace.get()).toHaveAttribute('readonly');
+    expect(await ui.input.namespace.find()).toHaveAttribute('readonly');
   });
 
-  it('Should not display folder link if no folderUrl provided', () => {
+  it('Should not display folder link if no folderUrl provided', async () => {
     render(<EditCloudGroupModal namespace={grafanaNamespace} group={grafanaGroup1} onClose={jest.fn()} />, {
       wrapper: getProvidersWrapper(),
     });
-
+    expect(await ui.input.namespace.find()).toHaveValue('namespace1');
     expect(ui.folderLink.query()).not.toBeInTheDocument();
   });
 });

--- a/public/app/features/alerting/unified/components/rules/EditRuleGroupModal.tsx
+++ b/public/app/features/alerting/unified/components/rules/EditRuleGroupModal.tsx
@@ -234,7 +234,7 @@ export function EditCloudGroupModal(props: ModalProps): React.ReactElement {
     handleSubmit,
     register,
     watch,
-    formState: { isDirty, errors },
+    formState: { isDirty, errors, isValid },
     setValue,
     getValues,
   } = formAPI;
@@ -326,7 +326,7 @@ export function EditCloudGroupModal(props: ModalProps): React.ReactElement {
                 />
                 <EvaluationGroupQuickPick
                   currentInterval={getValues('groupInterval')}
-                  onSelect={(value) => setValue('groupInterval', value, { shouldValidate: true })}
+                  onSelect={(value) => setValue('groupInterval', value, { shouldValidate: true, shouldDirty: true })}
                 />
               </Stack>
             </Field>
@@ -359,7 +359,7 @@ export function EditCloudGroupModal(props: ModalProps): React.ReactElement {
                 </Button>
                 <Button
                   type="button"
-                  disabled={!isDirty || loading}
+                  disabled={!isDirty || !isValid || loading}
                   onClick={handleSubmit((values) => onSubmit(values), onInvalid)}
                 >
                   {loading ? 'Saving...' : 'Save'}


### PR DESCRIPTION
**What is this feature?**

Fix for the display of pending period on alert rules. The correct value was saved/retrieved from the backend, but just shown incorrectly in the UI when editing rules.

In addition, also fixes the edit group modal not updating the dirty state of the form when clicking one of the quick eval buttons, and also disables the save button if the form is invalid

Introduced by https://github.com/grafana/grafana/pull/85010

**Steps to reproduce**

- Edit an existing Grafana Managed alert rule
- Change the pending period from 1m to 5m
- Save changes
- Edit the alert rule again
- Observe that it still says 1m.
- Expanding the alert instance row shows the 5m pending period.
