### PR TITLE
Authn: Identity resolvers

### DIFF
--- a/pkg/services/accesscontrol/accesscontrol.go
+++ b/pkg/services/accesscontrol/accesscontrol.go
@@ -175,7 +175,9 @@ func HasGlobalAccess(ac AccessControl, authnService authn.Service, c *contextmod
 		var targetOrgID int64 = GlobalOrgID
 		orgUser, err := authnService.ResolveIdentity(c.Req.Context(), targetOrgID, c.SignedInUser.GetID())
 		if err != nil {
-			deny(c, nil, fmt.Errorf("failed to authenticate user in target org: %w", err))
+			// This will be an common error for entities that can't authenticate in global scope
+			c.Logger.Debug("Failed to authenticate user in global scope", "error", err)
+			return false
 		}
 
 		hasAccess, err := ac.Evaluate(c.Req.Context(), orgUser, evaluator)

--- a/pkg/services/authn/authn.go
+++ b/pkg/services/authn/authn.go
@@ -161,7 +161,7 @@ type UsageStatClient interface {
 type IdentityResolverClient interface {
 	Client
 	Namespace() string
-	ResolveIdentity(ctx context.Context, orgID int64, namespaceID string) (*Identity, error)
+	ResolveIdentity(ctx context.Context, orgID int64, namespaceID NamespaceID) (*Identity, error)
 }
 
 type Request struct {

--- a/pkg/services/authn/authn.go
+++ b/pkg/services/authn/authn.go
@@ -108,7 +108,7 @@ type Client interface {
 }
 
 // ContextAwareClient is an optional interface that auth client can implement.
-// Clients that implements this interface will be tried during request authentication
+// Clients that implements this interface will be tried during request authentication.
 type ContextAwareClient interface {
 	Client
 	// Test should return true if client can be used to authenticate request
@@ -127,7 +127,7 @@ type HookClient interface {
 
 // RedirectClient is an optional interface that auth clients can implement.
 // Clients that implements this interface can be used to generate redirect urls
-// for authentication flows, e.g. oauth clients
+// for authentication flows, e.g. oauth clients.
 type RedirectClient interface {
 	Client
 	RedirectURL(ctx context.Context, r *Request) (*Redirect, error)
@@ -150,10 +150,18 @@ type ProxyClient interface {
 }
 
 // UsageStatClient is an optional interface that auth clients can implement.
-// Clients that implements this interface can specify a usage stat collection hook
+// Clients that implements this interface can specify a usage stat collection hook.
 type UsageStatClient interface {
 	Client
 	UsageStatFn(ctx context.Context) (map[string]any, error)
+}
+
+// IdentityResolverClient is an optional interface that auth clients can implement.
+// Clients that implements this interface can resolve an full identity from an orgID and namespaceID.
+type IdentityResolverClient interface {
+	Client
+	Namespace() string
+	ResolveIdentity(ctx context.Context, orgID int64, namespaceID string) (*Identity, error)
 }
 
 type Request struct {

--- a/pkg/services/authn/authnimpl/service.go
+++ b/pkg/services/authn/authnimpl/service.go
@@ -328,12 +328,22 @@ func (s *Service) SyncIdentity(ctx context.Context, identity *authn.Identity) er
 }
 
 func (s *Service) resolveIdenity(ctx context.Context, orgID int64, namespaceID authn.NamespaceID) (*authn.Identity, error) {
-	if namespaceID.IsNamespace(authn.NamespaceUser, authn.NamespaceServiceAccount) {
+	if namespaceID.IsNamespace(authn.NamespaceUser) {
 		return &authn.Identity{
 			OrgID: orgID,
 			ID:    namespaceID.String(),
 			ClientParams: authn.ClientParams{
 				AllowGlobalOrg:  true,
+				FetchSyncedUser: true,
+				SyncPermissions: true,
+			}}, nil
+	}
+
+	if namespaceID.IsNamespace(authn.NamespaceServiceAccount) {
+		return &authn.Identity{
+			ID:    namespaceID.String(),
+			OrgID: orgID,
+			ClientParams: authn.ClientParams{
 				FetchSyncedUser: true,
 				SyncPermissions: true,
 			}}, nil

--- a/pkg/services/authn/authnimpl/service_test.go
+++ b/pkg/services/authn/authnimpl/service_test.go
@@ -416,7 +416,6 @@ func TestService_ResolveIdentity(t *testing.T) {
 				NamespaceFunc: func() string { return authn.NamespaceAPIKey },
 				ResolveIdentityFunc: func(ctx context.Context, orgID int64, namespaceID authn.NamespaceID) (*authn.Identity, error) {
 					return &authn.Identity{}, nil
-
 				},
 			})
 		})

--- a/pkg/services/authn/authnimpl/service_test.go
+++ b/pkg/services/authn/authnimpl/service_test.go
@@ -383,6 +383,50 @@ func TestService_Logout(t *testing.T) {
 	}
 }
 
+func TestService_ResolveIdentity(t *testing.T) {
+	t.Run("should return error for for unknown namespace", func(t *testing.T) {
+		svc := setupTests(t)
+		_, err := svc.ResolveIdentity(context.Background(), 1, "some:1")
+		assert.ErrorIs(t, err, authn.ErrInvalidNamepsaceID)
+	})
+
+	t.Run("should return error for for namespace that don't have a resolver", func(t *testing.T) {
+		svc := setupTests(t)
+		_, err := svc.ResolveIdentity(context.Background(), 1, "api-key:1")
+		assert.ErrorIs(t, err, authn.ErrUnsupportedIdentity)
+	})
+
+	t.Run("should resolve for user", func(t *testing.T) {
+		svc := setupTests(t)
+		identity, err := svc.ResolveIdentity(context.Background(), 1, "user:1")
+		assert.NoError(t, err)
+		assert.NotNil(t, identity)
+	})
+
+	t.Run("should resolve for service account", func(t *testing.T) {
+		svc := setupTests(t)
+		identity, err := svc.ResolveIdentity(context.Background(), 1, "service-account:1")
+		assert.NoError(t, err)
+		assert.NotNil(t, identity)
+	})
+
+	t.Run("should resolve for valid namespace if client is registered", func(t *testing.T) {
+		svc := setupTests(t, func(svc *Service) {
+			svc.RegisterClient(&authntest.MockClient{
+				NamespaceFunc: func() string { return authn.NamespaceAPIKey },
+				ResolveIdentityFunc: func(ctx context.Context, orgID int64, namespaceID authn.NamespaceID) (*authn.Identity, error) {
+					return &authn.Identity{}, nil
+
+				},
+			})
+		})
+
+		identity, err := svc.ResolveIdentity(context.Background(), 1, "api-key:1")
+		assert.NoError(t, err)
+		assert.NotNil(t, identity)
+	})
+}
+
 func mustParseURL(s string) *url.URL {
 	u, err := url.Parse(s)
 	if err != nil {
@@ -395,14 +439,15 @@ func setupTests(t *testing.T, opts ...func(svc *Service)) *Service {
 	t.Helper()
 
 	s := &Service{
-		log:            log.NewNopLogger(),
-		cfg:            setting.NewCfg(),
-		clients:        map[string]authn.Client{},
-		clientQueue:    newQueue[authn.ContextAwareClient](),
-		tracer:         tracing.InitializeTracerForTest(),
-		metrics:        newMetrics(nil),
-		postAuthHooks:  newQueue[authn.PostAuthHookFn](),
-		postLoginHooks: newQueue[authn.PostLoginHookFn](),
+		log:                    log.NewNopLogger(),
+		cfg:                    setting.NewCfg(),
+		clients:                make(map[string]authn.Client),
+		clientQueue:            newQueue[authn.ContextAwareClient](),
+		idenityResolverClients: make(map[string]authn.IdentityResolverClient),
+		tracer:                 tracing.InitializeTracerForTest(),
+		metrics:                newMetrics(nil),
+		postAuthHooks:          newQueue[authn.PostAuthHookFn](),
+		postLoginHooks:         newQueue[authn.PostLoginHookFn](),
 	}
 
 	for _, o := range opts {

--- a/pkg/services/authn/authntest/mock.go
+++ b/pkg/services/authn/authntest/mock.go
@@ -60,14 +60,17 @@ func (m *MockService) SyncIdentity(ctx context.Context, identity *authn.Identity
 var _ authn.HookClient = new(MockClient)
 var _ authn.LogoutClient = new(MockClient)
 var _ authn.ContextAwareClient = new(MockClient)
+var _ authn.IdentityResolverClient = new(MockClient)
 
 type MockClient struct {
-	NameFunc         func() string
-	AuthenticateFunc func(ctx context.Context, r *authn.Request) (*authn.Identity, error)
-	TestFunc         func(ctx context.Context, r *authn.Request) bool
-	PriorityFunc     func() uint
-	HookFunc         func(ctx context.Context, identity *authn.Identity, r *authn.Request) error
-	LogoutFunc       func(ctx context.Context, user identity.Requester) (*authn.Redirect, bool)
+	NameFunc            func() string
+	AuthenticateFunc    func(ctx context.Context, r *authn.Request) (*authn.Identity, error)
+	TestFunc            func(ctx context.Context, r *authn.Request) bool
+	PriorityFunc        func() uint
+	HookFunc            func(ctx context.Context, identity *authn.Identity, r *authn.Request) error
+	LogoutFunc          func(ctx context.Context, user identity.Requester) (*authn.Redirect, bool)
+	NamespaceFunc       func() string
+	ResolveIdentityFunc func(ctx context.Context, orgID int64, namespaceID authn.NamespaceID) (*authn.Identity, error)
 }
 
 func (m MockClient) Name() string {
@@ -110,6 +113,21 @@ func (m *MockClient) Logout(ctx context.Context, user identity.Requester) (*auth
 		return m.LogoutFunc(ctx, user)
 	}
 	return nil, false
+}
+
+func (m *MockClient) Namespace() string {
+	if m.NamespaceFunc != nil {
+		return m.NamespaceFunc()
+	}
+	return ""
+}
+
+// ResolveIdentity implements authn.IdentityResolverClient.
+func (m *MockClient) ResolveIdentity(ctx context.Context, orgID int64, namespaceID authn.NamespaceID) (*authn.Identity, error) {
+	if m.ResolveIdentityFunc != nil {
+		return m.ResolveIdentityFunc(ctx, orgID, namespaceID)
+	}
+	return nil, nil
 }
 
 var _ authn.ProxyClient = new(MockProxyClient)

--- a/pkg/services/authn/clients/api_key.go
+++ b/pkg/services/authn/clients/api_key.go
@@ -137,7 +137,6 @@ func (s *APIKey) Namespace() string {
 
 func (s *APIKey) ResolveIdentity(ctx context.Context, orgID int64, namespaceID authn.NamespaceID) (*authn.Identity, error) {
 	if !namespaceID.IsNamespace(authn.NamespaceAPIKey) {
-		// TODO error
 		return nil, authn.ErrInvalidNamepsaceID.Errorf("got unspected namespace: %s", namespaceID.Namespace())
 	}
 

--- a/pkg/services/authn/clients/api_key.go
+++ b/pkg/services/authn/clients/api_key.go
@@ -27,6 +27,7 @@ var (
 
 var _ authn.HookClient = new(APIKey)
 var _ authn.ContextAwareClient = new(APIKey)
+var _ authn.IdentityResolverClient = new(APIKey)
 
 func ProvideAPIKey(apiKeyService apikey.Service) *APIKey {
 	return &APIKey{
@@ -45,7 +46,7 @@ func (s *APIKey) Name() string {
 }
 
 func (s *APIKey) Authenticate(ctx context.Context, r *authn.Request) (*authn.Identity, error) {
-	apiKey, err := s.getAPIKey(ctx, getTokenFromRequest(r))
+	key, err := s.getAPIKey(ctx, getTokenFromRequest(r))
 	if err != nil {
 		if errors.Is(err, apikeygen.ErrInvalidApiKey) {
 			return nil, errAPIKeyInvalid.Errorf("API key is invalid")
@@ -53,37 +54,20 @@ func (s *APIKey) Authenticate(ctx context.Context, r *authn.Request) (*authn.Ide
 		return nil, err
 	}
 
-	if apiKey.Expires != nil && *apiKey.Expires <= time.Now().Unix() {
-		return nil, errAPIKeyExpired.Errorf("API key has expired")
-	}
-
-	if apiKey.IsRevoked != nil && *apiKey.IsRevoked {
-		return nil, errAPIKeyRevoked.Errorf("Api key is revoked")
-	}
-
 	if r.OrgID == 0 {
-		r.OrgID = apiKey.OrgID
-	} else if r.OrgID != apiKey.OrgID {
-		return nil, errAPIKeyOrgMismatch.Errorf("API does not belong in Organization %v", r.OrgID)
+		r.OrgID = key.OrgID
+	}
+
+	if err := validateApiKey(r.OrgID, key); err != nil {
+		return nil, err
 	}
 
 	// if the api key don't belong to a service account construct the identity and return it
-	if apiKey.ServiceAccountId == nil || *apiKey.ServiceAccountId < 1 {
-		return &authn.Identity{
-			ID:              authn.NamespacedID(authn.NamespaceAPIKey, apiKey.ID),
-			OrgID:           apiKey.OrgID,
-			OrgRoles:        map[int64]org.RoleType{apiKey.OrgID: apiKey.Role},
-			ClientParams:    authn.ClientParams{SyncPermissions: true},
-			AuthenticatedBy: login.APIKeyAuthModule,
-		}, nil
+	if key.ServiceAccountId == nil || *key.ServiceAccountId < 1 {
+		return newAPIKeyIdentity(key), nil
 	}
 
-	return &authn.Identity{
-		ID:              authn.NamespacedID(authn.NamespaceServiceAccount, *apiKey.ServiceAccountId),
-		OrgID:           apiKey.OrgID,
-		AuthenticatedBy: login.APIKeyAuthModule,
-		ClientParams:    authn.ClientParams{FetchSyncedUser: true, SyncPermissions: true},
-	}, nil
+	return newServiceAccountIdentity(key), nil
 }
 
 func (s *APIKey) getAPIKey(ctx context.Context, token string) (*apikey.APIKey, error) {
@@ -145,6 +129,44 @@ func (s *APIKey) Test(ctx context.Context, r *authn.Request) bool {
 
 func (s *APIKey) Priority() uint {
 	return 30
+}
+
+func (s *APIKey) Namespace() string {
+	return authn.NamespaceAPIKey
+}
+
+func (s *APIKey) ResolveIdentity(ctx context.Context, orgID int64, namespaceID string) (*authn.Identity, error) {
+	id, err := authn.ParseNamespaceID(namespaceID)
+	if err != nil {
+		return nil, err
+	}
+
+	if !id.IsNamespace(authn.NamespaceAPIKey) {
+		// TODO error
+		return nil, authn.ErrInvalidNamepsaceID.Errorf("got unspected namespace: %s", id.Namespace())
+	}
+
+	apiKeyID, err := id.ParseInt()
+	if err != nil {
+		return nil, err
+	}
+
+	key, err := s.apiKeyService.GetApiKeyById(ctx, &apikey.GetByIDQuery{
+		ApiKeyID: apiKeyID,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	if err := validateApiKey(orgID, key); err != nil {
+		return nil, err
+	}
+
+	if key.ServiceAccountId != nil && *key.ServiceAccountId >= 1 {
+		return nil, authn.ErrInvalidNamepsaceID.Errorf("api key belongs to service account")
+	}
+
+	return newAPIKeyIdentity(key), nil
 }
 
 func (s *APIKey) Hook(ctx context.Context, identity *authn.Identity, r *authn.Request) error {
@@ -216,4 +238,39 @@ func getTokenFromRequest(r *authn.Request) string {
 		}
 	}
 	return ""
+}
+
+func validateApiKey(orgID int64, key *apikey.APIKey) error {
+	if key.Expires != nil && *key.Expires <= time.Now().Unix() {
+		return errAPIKeyExpired.Errorf("API key has expired")
+	}
+
+	if key.IsRevoked != nil && *key.IsRevoked {
+		return errAPIKeyRevoked.Errorf("Api key is revoked")
+	}
+
+	if orgID != key.OrgID {
+		return errAPIKeyOrgMismatch.Errorf("API does not belong in Organization")
+	}
+
+	return nil
+}
+
+func newAPIKeyIdentity(key *apikey.APIKey) *authn.Identity {
+	return &authn.Identity{
+		ID:              authn.NamespacedID(authn.NamespaceAPIKey, key.ID),
+		OrgID:           key.OrgID,
+		OrgRoles:        map[int64]org.RoleType{key.OrgID: key.Role},
+		ClientParams:    authn.ClientParams{SyncPermissions: true},
+		AuthenticatedBy: login.APIKeyAuthModule,
+	}
+}
+
+func newServiceAccountIdentity(key *apikey.APIKey) *authn.Identity {
+	return &authn.Identity{
+		ID:              authn.NamespacedID(authn.NamespaceServiceAccount, *key.ServiceAccountId),
+		OrgID:           key.OrgID,
+		AuthenticatedBy: login.APIKeyAuthModule,
+		ClientParams:    authn.ClientParams{FetchSyncedUser: true, SyncPermissions: true},
+	}
 }

--- a/pkg/services/authn/clients/api_key.go
+++ b/pkg/services/authn/clients/api_key.go
@@ -135,18 +135,13 @@ func (s *APIKey) Namespace() string {
 	return authn.NamespaceAPIKey
 }
 
-func (s *APIKey) ResolveIdentity(ctx context.Context, orgID int64, namespaceID string) (*authn.Identity, error) {
-	id, err := authn.ParseNamespaceID(namespaceID)
-	if err != nil {
-		return nil, err
-	}
-
-	if !id.IsNamespace(authn.NamespaceAPIKey) {
+func (s *APIKey) ResolveIdentity(ctx context.Context, orgID int64, namespaceID authn.NamespaceID) (*authn.Identity, error) {
+	if !namespaceID.IsNamespace(authn.NamespaceAPIKey) {
 		// TODO error
-		return nil, authn.ErrInvalidNamepsaceID.Errorf("got unspected namespace: %s", id.Namespace())
+		return nil, authn.ErrInvalidNamepsaceID.Errorf("got unspected namespace: %s", namespaceID.Namespace())
 	}
 
-	apiKeyID, err := id.ParseInt()
+	apiKeyID, err := namespaceID.ParseInt()
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/services/authn/clients/api_key_test.go
+++ b/pkg/services/authn/clients/api_key_test.go
@@ -286,7 +286,7 @@ func TestAPIKey_GetAPIKeyIDFromIdentity(t *testing.T) {
 func TestAPIKey_ResolveIdentity(t *testing.T) {
 	type testCase struct {
 		desc        string
-		namespaceID string
+		namespaceID authn.NamespaceID
 
 		exptedApiKey *apikey.APIKey
 
@@ -297,12 +297,12 @@ func TestAPIKey_ResolveIdentity(t *testing.T) {
 	tests := []testCase{
 		{
 			desc:        "should return error for invalid namespace",
-			namespaceID: "user:1",
+			namespaceID: authn.MustParseNamespaceID("user:1"),
 			expectedErr: authn.ErrInvalidNamepsaceID,
 		},
 		{
 			desc:        "should return error when api key has expired",
-			namespaceID: "api-key:1",
+			namespaceID: authn.MustParseNamespaceID("api-key:1"),
 			exptedApiKey: &apikey.APIKey{
 				ID:      1,
 				OrgID:   1,
@@ -312,7 +312,7 @@ func TestAPIKey_ResolveIdentity(t *testing.T) {
 		},
 		{
 			desc:        "should return error when api key is revoked",
-			namespaceID: "api-key:1",
+			namespaceID: authn.MustParseNamespaceID("api-key:1"),
 			exptedApiKey: &apikey.APIKey{
 				ID:        1,
 				OrgID:     1,
@@ -322,7 +322,7 @@ func TestAPIKey_ResolveIdentity(t *testing.T) {
 		},
 		{
 			desc:        "should return error when api key is connected to service account",
-			namespaceID: "api-key:1",
+			namespaceID: authn.MustParseNamespaceID("api-key:1"),
 			exptedApiKey: &apikey.APIKey{
 				ID:               1,
 				OrgID:            1,
@@ -332,7 +332,7 @@ func TestAPIKey_ResolveIdentity(t *testing.T) {
 		},
 		{
 			desc:        "should return error when api key is belongs to different org",
-			namespaceID: "api-key:1",
+			namespaceID: authn.MustParseNamespaceID("api-key:1"),
 			exptedApiKey: &apikey.APIKey{
 				ID:               1,
 				OrgID:            2,
@@ -342,7 +342,7 @@ func TestAPIKey_ResolveIdentity(t *testing.T) {
 		},
 		{
 			desc:        "should return valid idenitty",
-			namespaceID: "api-key:1",
+			namespaceID: authn.MustParseNamespaceID("api-key:1"),
 			exptedApiKey: &apikey.APIKey{
 				ID:    1,
 				OrgID: 1,

--- a/pkg/services/authn/clients/identity.go
+++ b/pkg/services/authn/clients/identity.go
@@ -22,5 +22,4 @@ func (i *IdentityClient) Name() string {
 
 func (i *IdentityClient) Authenticate(ctx context.Context, r *authn.Request) (*authn.Identity, error) {
 	return i.identity, nil
-
 }

--- a/pkg/services/authn/clients/identity.go
+++ b/pkg/services/authn/clients/identity.go
@@ -8,27 +8,19 @@ import (
 
 var _ authn.Client = (*IdentityClient)(nil)
 
-func ProvideIdentity(namespaceID string) *IdentityClient {
-	return &IdentityClient{namespaceID}
+func ProvideIdentity(identity *authn.Identity) *IdentityClient {
+	return &IdentityClient{identity}
 }
 
 type IdentityClient struct {
-	namespaceID string
+	identity *authn.Identity
 }
 
 func (i *IdentityClient) Name() string {
 	return "identity"
 }
 
-// Authenticate implements authn.Client.
 func (i *IdentityClient) Authenticate(ctx context.Context, r *authn.Request) (*authn.Identity, error) {
-	return &authn.Identity{
-		OrgID: r.OrgID,
-		ID:    i.namespaceID,
-		ClientParams: authn.ClientParams{
-			AllowGlobalOrg:  true,
-			FetchSyncedUser: true,
-			SyncPermissions: true,
-		},
-	}, nil
+	return i.identity, nil
+
 }

--- a/pkg/services/authn/error.go
+++ b/pkg/services/authn/error.go
@@ -8,4 +8,5 @@ var (
 	ErrClientNotConfigured = errutil.BadRequest("auth.client.notConfigured")
 	ErrUnsupportedIdentity = errutil.NotImplemented("auth.identity.unsupported")
 	ErrExpiredAccessToken  = errutil.Unauthorized("oauth.expired-token", errutil.WithPublicMessage("OAuth access token expired"))
+	ErrInvalidNamepsaceID  = errutil.BadRequest("auth.identity.invalid-namespace-id")
 )

--- a/pkg/services/authn/identity.go
+++ b/pkg/services/authn/identity.go
@@ -128,7 +128,6 @@ func (i *Identity) GetLogin() string {
 	return i.Login
 }
 
-// GetOrgID implements identity.Requester.
 func (i *Identity) GetOrgID() int64 {
 	return i.OrgID
 }

--- a/pkg/services/authn/identity.go
+++ b/pkg/services/authn/identity.go
@@ -16,24 +16,7 @@ import (
 	"github.com/grafana/grafana/pkg/services/user"
 )
 
-// NamespacedID builds a namespaced ID from a namespace and an ID.
-func NamespacedID(namespace string, id int64) string {
-	return fmt.Sprintf("%s:%d", namespace, id)
-}
-
-const (
-	NamespaceUser           = identity.NamespaceUser
-	NamespaceAPIKey         = identity.NamespaceAPIKey
-	NamespaceServiceAccount = identity.NamespaceServiceAccount
-	NamespaceAnonymous      = identity.NamespaceAnonymous
-	NamespaceRenderService  = identity.NamespaceRenderService
-	NamespaceAccessPolicy   = identity.NamespaceAccessPolicy
-)
-
-const (
-	AnonymousNamespaceID = NamespaceAnonymous + ":0"
-	GlobalOrgID          = int64(0)
-)
+const GlobalOrgID = int64(0)
 
 var _ identity.Requester = (*Identity)(nil)
 

--- a/pkg/services/authn/namespace.go
+++ b/pkg/services/authn/namespace.go
@@ -83,3 +83,7 @@ func (ni NamespaceID) Namespace() string {
 func (ni NamespaceID) IsNamespace(expected ...string) bool {
 	return identity.IsNamespace(ni.namespace, expected...)
 }
+
+func (ni NamespaceID) String() string {
+	return fmt.Sprintf("%s:%s", ni.namespace, ni.id)
+}

--- a/pkg/services/authn/namespace.go
+++ b/pkg/services/authn/namespace.go
@@ -52,6 +52,16 @@ func ParseNamespaceID(str string) (NamespaceID, error) {
 	return namespaceID, nil
 }
 
+// MustParseNamespaceID parses namespace id, it will panic it failes to do so.
+// Sutable to use in tests or when we can garantuee that we pass a correct format.
+func MustParseNamespaceID(str string) NamespaceID {
+	namespaceID, err := ParseNamespaceID(str)
+	if err != nil {
+		panic(err)
+	}
+	return namespaceID
+}
+
 // FIXME: use this instead of encoded string through the codebase
 type NamespaceID struct {
 	id        string

--- a/pkg/services/authn/namespace.go
+++ b/pkg/services/authn/namespace.go
@@ -1,0 +1,75 @@
+package authn
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/grafana/grafana/pkg/services/auth/identity"
+)
+
+const (
+	NamespaceUser           = identity.NamespaceUser
+	NamespaceAPIKey         = identity.NamespaceAPIKey
+	NamespaceServiceAccount = identity.NamespaceServiceAccount
+	NamespaceAnonymous      = identity.NamespaceAnonymous
+	NamespaceRenderService  = identity.NamespaceRenderService
+	NamespaceAccessPolicy   = identity.NamespaceAccessPolicy
+	AnonymousNamespaceID    = NamespaceAnonymous + ":0"
+)
+
+var namespaceLookup = map[string]struct{}{
+	NamespaceUser:           {},
+	NamespaceAPIKey:         {},
+	NamespaceServiceAccount: {},
+	NamespaceAnonymous:      {},
+	NamespaceRenderService:  {},
+	NamespaceAccessPolicy:   {},
+}
+
+// NamespacedID builds a namespaced ID from a namespace and an ID.
+func NamespacedID(namespace string, id int64) string {
+	return fmt.Sprintf("%s:%d", namespace, id)
+}
+
+func ParseNamespaceID(str string) (NamespaceID, error) {
+	var namespaceID NamespaceID
+
+	parts := strings.Split(str, ":")
+	if len(parts) != 2 {
+		return namespaceID, ErrInvalidNamepsaceID.Errorf("expected namespace id to have 2 parts")
+	}
+
+	namespace, id := parts[0], parts[1]
+
+	if _, ok := namespaceLookup[namespace]; !ok {
+		return namespaceID, ErrInvalidNamepsaceID.Errorf("got invalid namespace %s", namespace)
+	}
+
+	namespaceID.id = id
+	namespaceID.namespace = namespace
+
+	return namespaceID, nil
+}
+
+// FIXME: use this instead of encoded string through the codebase
+type NamespaceID struct {
+	id        string
+	namespace string
+}
+
+func (ni NamespaceID) ID() string {
+	return ni.id
+}
+
+func (ni NamespaceID) ParseInt() (int64, error) {
+	return strconv.ParseInt(ni.id, 10, 64)
+}
+
+func (ni NamespaceID) Namespace() string {
+	return ni.namespace
+}
+
+func (ni NamespaceID) IsNamespace(expected ...string) bool {
+	return identity.IsNamespace(ni.namespace, expected...)
+}


### PR DESCRIPTION
**What is this feature?**
In https://github.com/grafana/grafana/pull/84555 I added support for authenticating identity from orgID and namespacedID. This is useful when we wan't to re-authenticate in another org (this is only supported for user) or we want to get the full identity of given type. 

One limitation the original pr had is that it only worked for users and service-accounts. This pr aims to build the foundation to support other kinds as well.

I added a extension interface `IdentityResolverClient` that clients can optionally implement. A client can implement this for a given namespace and be responsible for that kind.

In this pr I also added an implementation for api-keys and kept user and service account around as a hack. User namespace don't really have a client that is a good fit because many client can resolve to it. I also think we should create a separate client for service account.

In this pr I also added a typed `NamespaceID`. Working with the encoded version is a bit annoying because we always have to perform string operations when we want to check stuff. I think we should try to replace the string variant with this structured one.

**Which issue(s) does this PR fix?**:
Part of #https://github.com/grafana/identity-access-team/issues/611

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
