### PR TITLE
Tracing: Allow otel service name and attributes to be overridden from env

### DIFF
--- a/docs/sources/setup-grafana/configure-grafana/_index.md
+++ b/docs/sources/setup-grafana/configure-grafana/_index.md
@@ -1925,7 +1925,7 @@ Configure general parameters shared between OpenTelemetry providers.
 
 Comma-separated list of attributes to include in all new spans, such as `key1:value1,key2:value2`.
 
-Can be set/overridden with the environment variable `OTEL_RESOURCE_ATTRIBUTES` (use `=` instead of `:` with the environment variable). The service name can be set/overridden using attributes or with the environment variable `OTEL_SERVICE_NAME`.
+Can be set or overridden with the environment variable `OTEL_RESOURCE_ATTRIBUTES` (use `=` instead of `:` with the environment variable). The service name can be set or overridden using attributes or with the environment variable `OTEL_SERVICE_NAME`.
 
 ### sampler_type
 

--- a/docs/sources/setup-grafana/configure-grafana/_index.md
+++ b/docs/sources/setup-grafana/configure-grafana/_index.md
@@ -1925,7 +1925,7 @@ Configure general parameters shared between OpenTelemetry providers.
 
 Comma-separated list of attributes to include in all new spans, such as `key1:value1,key2:value2`.
 
-Can be set with the environment variable `OTEL_RESOURCE_ATTRIBUTES` (use `=` instead of `:` with the environment variable).
+Can be set/overridden with the environment variable `OTEL_RESOURCE_ATTRIBUTES` (use `=` instead of `:` with the environment variable). The service name can be set/overridden using attributes or with the environment variable `OTEL_SERVICE_NAME`.
 
 ### sampler_type
 

--- a/pkg/infra/tracing/tracing.go
+++ b/pkg/infra/tracing/tracing.go
@@ -209,6 +209,7 @@ func initTracerProvider(exp tracesdk.SpanExporter, serviceName string, serviceVe
 			semconv.ServiceVersionKey.String(serviceVersion),
 		),
 		resource.WithAttributes(customAttribs...),
+		resource.WithFromEnv(),
 		resource.WithProcessRuntimeDescription(),
 		resource.WithTelemetrySDK(),
 	)


### PR DESCRIPTION
**What is this feature?**

Allow to set/override the tracing service name and resource attributes using the `OTEL_SERVICE_NAME` and `OTEL_RESOURCE_ATTRIBUTES` environment variables. See https://opentelemetry.io/docs/specs/otel/configuration/sdk-environment-variables/#general-sdk-configuration for more information.

**Why do we need this feature?**

To allow standard otel environment variables to be used to ease tracing configuration/setup.

**Who is this feature for?**

Operators

**Which issue(s) does this PR fix?**:
Ref #85715

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
