### PR TITLE
[v10.3.x] Revert "Docs: Clarify open source documentation (#77077)"

### DIFF
--- a/docs/sources/_index.md
+++ b/docs/sources/_index.md
@@ -3,22 +3,21 @@ aliases:
   - /docs/grafana/v1.1/
   - /docs/grafana/v3.1/
   - guides/reference/admin/
-description: Open source documentation for Grafana
+cascade:
+  TEMPO_VERSION: latest
+description: Guides, installation, and feature documentation
 keywords:
   - grafana
-  - open source
   - installation
   - documentation
 labels:
   products:
     - enterprise
     - oss
-cascade:
-  TEMPO_VERSION: latest
-title: Grafana open source documentation
+title: Grafana documentation
 ---
 
-# Grafana open source documentation
+# Grafana documentation
 
 ## Installing Grafana
 


### PR DESCRIPTION
Backport 61e2a5354ecdb78fae3c43477bc199fe8bdbdffc from #85879

---

This reverts commit 9a563a4d19bb70c5735dc257aa4f2a9ec2c58b65.

It's not the case that the Grafana docs are specific to open source.
It covers Grafana, Grafana Enterprise, and there are even references to Grafana Cloud.

I think the title, first heading, and description introduced in this PR could confuse users looking to find Grafana Enterprise documentation.
