### PR TITLE
Prometheus: Change feature toggle usePrometheusFrontendPackage to general availability

### DIFF
--- a/docs/sources/setup-grafana/configure-grafana/feature-toggles/index.md
+++ b/docs/sources/setup-grafana/configure-grafana/feature-toggles/index.md
@@ -61,6 +61,7 @@ Some features are enabled by default. You can disable these feature by setting t
 | `enablePluginsTracingByDefault`          | Enable plugin tracing for all external plugins                                                                                                                                                                               | Yes                |
 | `alertingQueryOptimization`              | Optimizes eligible queries in order to reduce load on datasources                                                                                                                                                            |                    |
 | `betterPageScrolling`                    | Removes CustomScrollbar from the UI, relying on native browser scrollbars                                                                                                                                                    | Yes                |
+| `usePrometheusFrontendPackage`           | Use the @grafana/prometheus frontend package in core Prometheus.                                                                                                                                                             |                    |
 | `cloudWatchNewLabelParsing`              | Updates CloudWatch label parsing to be more accurate                                                                                                                                                                         | Yes                |
 
 ## Preview feature toggles
@@ -175,7 +176,6 @@ Experimental features might be changed or removed without prior notice.
 | `nodeGraphDotLayout`                        | Changed the layout algorithm for the node graph                                                                                                                                                                                                                                   |
 | `kubernetesAggregator`                      | Enable grafana aggregator                                                                                                                                                                                                                                                         |
 | `expressionParser`                          | Enable new expression parser                                                                                                                                                                                                                                                      |
-| `usePrometheusFrontendPackage`              | Use the @grafana/prometheus frontend package in core Prometheus.                                                                                                                                                                                                                  |
 
 ## Development feature toggles
 

--- a/pkg/services/featuremgmt/registry.go
+++ b/pkg/services/featuremgmt/registry.go
@@ -1184,7 +1184,7 @@ var (
 		{
 			Name:         "usePrometheusFrontendPackage",
 			Description:  "Use the @grafana/prometheus frontend package in core Prometheus.",
-			Stage:        FeatureStageExperimental,
+			Stage:        FeatureStageGeneralAvailability,
 			FrontendOnly: true,
 			Owner:        grafanaObservabilityMetricsSquad,
 		},

--- a/pkg/services/featuremgmt/toggles_gen.csv
+++ b/pkg/services/featuremgmt/toggles_gen.csv
@@ -157,7 +157,7 @@ betterPageScrolling,GA,@grafana/grafana-frontend-platform,false,false,true
 authAPIAccessTokenAuth,experimental,@grafana/identity-access-team,false,false,false
 scopeFilters,experimental,@grafana/dashboards-squad,false,false,false
 ssoSettingsSAML,experimental,@grafana/identity-access-team,false,false,false
-usePrometheusFrontendPackage,experimental,@grafana/observability-metrics,false,false,true
+usePrometheusFrontendPackage,GA,@grafana/observability-metrics,false,false,true
 oauthRequireSubClaim,experimental,@grafana/identity-access-team,false,false,false
 newDashboardWithFiltersAndGroupBy,experimental,@grafana/dashboards-squad,false,false,false
 cloudWatchNewLabelParsing,GA,@grafana/aws-datasources,false,false,false

--- a/pkg/services/featuremgmt/toggles_gen.json
+++ b/pkg/services/featuremgmt/toggles_gen.json
@@ -1464,12 +1464,15 @@
     {
       "metadata": {
         "name": "usePrometheusFrontendPackage",
-        "resourceVersion": "1712639261786",
-        "creationTimestamp": "2024-04-09T05:07:41Z"
+        "resourceVersion": "1712841379965",
+        "creationTimestamp": "2024-04-09T05:07:41Z",
+        "annotations": {
+          "grafana.app/updatedTimestamp": "2024-04-11 13:16:19.965312 +0000 UTC"
+        }
       },
       "spec": {
         "description": "Use the @grafana/prometheus frontend package in core Prometheus.",
-        "stage": "experimental",
+        "stage": "GA",
         "codeowner": "@grafana/observability-metrics",
         "frontend": true
       }


### PR DESCRIPTION
**What is this?** 

This updates the `usePrometheusFrontendPackage` feature toggle to GA. This feature toggle enables the Prometheus data source in Grafana to use the `grafana/prometheus` frontend package. [This work](https://github.com/grafana/grafana/pull/81641) was done for [decoupling and decomposing Prometheus](https://github.com/orgs/grafana/projects/112/views/20?pane=issue&itemId=43785394). 

**Why are we doing this**

We have tested the use of frontend package by deploying the feature toggle in ops and have found no side effects or issues. We will be removing the feature toggle in ~1week. This change to feature stage general availability signals that we will be removing the toggle.

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
