### PR TITLE
ButtonSelect: Respect isDisabled option property

### DIFF
--- a/packages/grafana-ui/src/components/Dropdown/ButtonSelect.tsx
+++ b/packages/grafana-ui/src/components/Dropdown/ButtonSelect.tsx
@@ -100,6 +100,7 @@ const ButtonSelectComponent = <T,>(props: Props<T>) => {
                   active={item.value === value?.value}
                   ariaChecked={item.value === value?.value}
                   ariaLabel={item.ariaLabel || item.label}
+                  disabled={item.isDisabled}
                   role="menuitemradio"
                 />
               ))}


### PR DESCRIPTION

**What is this feature?**

Noticed that `ButtonSelect` does not respect `isDisabled` property on the option. This PR passes down the `isDisabled` prop to select item.

**Why do we need this feature?**

App o11y has use case to keep an option visible but disabled under certain circumstances.

**Who is this feature for?**

Anyone who uses `ButtonSelect` component

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
