### PR TITLE
[v10.4.x] Google Cloud Monitor: Fix interface conversion for incorrect type in cloudMonitoringProm.run

### DIFF
--- a/pkg/tsdb/cloud-monitoring/promql_query.go
+++ b/pkg/tsdb/cloud-monitoring/promql_query.go
@@ -23,12 +23,12 @@ func (promQLQ *cloudMonitoringProm) run(ctx context.Context, req *backend.QueryD
 	projectName, err := s.ensureProject(ctx, dsInfo, promQLQ.parameters.ProjectName)
 	if err != nil {
 		dr.Error = err
-		return dr, promResponse{}, "", nil
+		return dr, backend.DataResponse{}, "", nil
 	}
 	r, err := createRequest(ctx, &dsInfo, path.Join("/v1/projects", projectName, "location/global/prometheus/api/v1/query_range"), nil)
 	if err != nil {
 		dr.Error = err
-		return dr, promResponse{}, "", nil
+		return dr, backend.DataResponse{}, "", nil
 	}
 
 	span := traceReq(ctx, req, dsInfo, r, "")
@@ -42,15 +42,16 @@ func (promQLQ *cloudMonitoringProm) run(ctx context.Context, req *backend.QueryD
 	}
 
 	res, err := doRequestProm(r, dsInfo, requestBody)
+	if err != nil {
+		dr.Error = err
+		return dr, backend.DataResponse{}, "", nil
+	}
+
 	defer func() {
 		if err := res.Body.Close(); err != nil {
 			s.logger.Error("Failed to close response body", "err", err)
 		}
 	}()
-	if err != nil {
-		dr.Error = err
-		return dr, promResponse{}, "", nil
-	}
 
 	return dr, parseProm(res), r.URL.RawQuery, nil
 }

--- a/pkg/tsdb/cloud-monitoring/promql_query_test.go
+++ b/pkg/tsdb/cloud-monitoring/promql_query_test.go
@@ -1,6 +1,8 @@
 package cloudmonitoring
 
 import (
+	"context"
+	"fmt"
 	"io"
 	"net/http"
 	"os"
@@ -8,13 +10,16 @@ import (
 	"testing"
 
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
+	"github.com/grafana/grafana-plugin-sdk-go/backend/datasource"
+	"github.com/grafana/grafana-plugin-sdk-go/backend/instancemgmt"
 	"github.com/grafana/grafana-plugin-sdk-go/experimental"
+	"github.com/grafana/grafana/pkg/tsdb/cloud-monitoring/kinds/dataquery"
 	"github.com/stretchr/testify/require"
 )
 
 func TestPromqlQuery(t *testing.T) {
-	service := &Service{}
 	t.Run("parseResponse is returned", func(t *testing.T) {
+		service := &Service{}
 		fileData, err := os.ReadFile("./test-data/11-prom-response.json")
 		reader := strings.NewReader(string(fileData))
 		res := http.Response{Body: io.NopCloser(reader)}
@@ -29,5 +34,35 @@ func TestPromqlQuery(t *testing.T) {
 		require.NoError(t, err)
 		frame := dataRes.Frames[0]
 		experimental.CheckGoldenJSONFrame(t, "test-data", "parse-response-is-returned", frame, false)
+	})
+
+	t.Run("parseResponse is returned with error", func(t *testing.T) {
+		dsInfo := datasourceInfo{
+			authenticationType: gceAuthentication,
+		}
+
+		im := datasource.NewInstanceManager(func(_ context.Context, s backend.DataSourceInstanceSettings) (instancemgmt.Instance, error) {
+			return &dsInfo, nil
+		})
+
+		service := &Service{
+			im: im,
+			gceDefaultProjectGetter: func(ctx context.Context, scope string) (string, error) {
+				return "", fmt.Errorf("not found!")
+			},
+		}
+
+		query := &cloudMonitoringProm{
+			parameters: &dataquery.PromQLQuery{
+				ProjectName: "",
+			},
+		}
+
+		dr, parsedProm, _, _ := query.run(context.Background(), &backend.QueryDataRequest{}, service, dsInfo, service.logger)
+		require.Error(t, dr.Error)
+		require.Equal(t, "not found!", dr.Error.Error())
+
+		err := query.parseResponse(dr, parsedProm, "", service.logger)
+		require.NoError(t, err)
 	})
 }

--- a/pkg/tsdb/cloud-monitoring/types.go
+++ b/pkg/tsdb/cloud-monitoring/types.go
@@ -97,14 +97,6 @@ type (
 		Unit                 string               `json:"unit"`
 		NextPageToken        string               `json:"nextPageToken"`
 	}
-
-	promResponse struct {
-		Status string `json:"status"`
-		Data   struct {
-			Result     any    `json:"result"`
-			ResultType string `json:"resultType"`
-		} `json:"data"`
-	}
 )
 
 type pointIterator interface {


### PR DESCRIPTION
Backport 0ec8ccbf66c6d64bdab75163bff91d059466b8f3 from #85811

---

This PR is for a new issue raised in https://github.com/grafana/support-escalations/issues/9574. The `cloudMonitoringProm.run` struct method was returning `promResponse{}` as en error whereas it should return `backend.DataResponse{}` so that it is correctly handled by `cloudMonitoringProm.parseResponse`. A test case has been added to confirm this.
