### PR TITLE
Storage: Add DualWriter improvements

### DIFF
--- a/pkg/apiserver/rest/dualwriter_mode1.go
+++ b/pkg/apiserver/rest/dualwriter_mode1.go
@@ -31,7 +31,7 @@ func (d *DualWriterMode1) Create(ctx context.Context, obj runtime.Object, create
 	return legacy.Create(ctx, obj, createValidation, options)
 }
 
-// Get overrides the default behavior of the DualWriter and reads only to LegacyStorage.
+// Get overrides the behavior of the generic DualWriter and reads only from LegacyStorage.
 func (d *DualWriterMode1) Get(ctx context.Context, name string, options *metav1.GetOptions) (runtime.Object, error) {
 	return d.Legacy.Get(ctx, name, options)
 }

--- a/pkg/apiserver/rest/dualwriter_mode1_test.go
+++ b/pkg/apiserver/rest/dualwriter_mode1_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	metainternalversion "k8s.io/apimachinery/pkg/apis/meta/internalversion"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 )
 
 const kind = "dummy"
@@ -19,8 +20,14 @@ func TestMode1(t *testing.T) {
 
 	dw := NewDualWriterMode1(lsSpy, sSpy)
 
+	// Create: it should use the Legacy Create implementation
+	_, err := dw.Create(context.Background(), &dummyObject{}, func(context.Context, runtime.Object) error { return nil }, &metav1.CreateOptions{})
+	assert.NoError(t, err)
+	assert.Equal(t, 1, lsSpy.Counts("LegacyStorage.Create"))
+	assert.Equal(t, 0, sSpy.Counts("Storage.Create"))
+
 	// Get: it should use the Legacy Get implementation
-	_, err := dw.Get(context.Background(), kind, &metav1.GetOptions{})
+	_, err = dw.Get(context.Background(), kind, &metav1.GetOptions{})
 	assert.NoError(t, err)
 	assert.Equal(t, 1, lsSpy.Counts("LegacyStorage.Get"))
 	assert.Equal(t, 0, sSpy.Counts("Storage.Get"))

--- a/pkg/apiserver/rest/dualwriter_mode2.go
+++ b/pkg/apiserver/rest/dualwriter_mode2.go
@@ -63,11 +63,11 @@ func (d *DualWriterMode2) Get(ctx context.Context, name string, options *metav1.
 	if err == nil {
 		return s, err
 	}
-	if !apierrors.IsNotFound(err) {
+	if apierrors.IsNotFound(err) {
+		klog.Info("object not found in duplicate storage", "name", name)
+	} else {
 		klog.Error("unable to fetch object from duplicate storage", "error", err, "name", name)
 	}
-
-	klog.Info("Resource not found in Storage. Getting it from LegacyStorage.", "name", name)
 
 	return d.Legacy.Get(ctx, name, &metav1.GetOptions{})
 }

--- a/pkg/apiserver/rest/dualwriter_mode2.go
+++ b/pkg/apiserver/rest/dualwriter_mode2.go
@@ -3,6 +3,7 @@ package rest
 import (
 	"context"
 
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metainternalversion "k8s.io/apimachinery/pkg/apis/meta/internalversion"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -55,8 +56,19 @@ func (d *DualWriterMode2) Create(ctx context.Context, obj runtime.Object, create
 	return rsp, err
 }
 
-// Get overrides the behavior of the generic DualWriter and retrieves an object from LegacyStorage.
+// Get overrides the behavior of the generic DualWriter.
+// It retrieves an object from Storage if possible, and if not it falls back to LegacyStorage.
 func (d *DualWriterMode2) Get(ctx context.Context, name string, options *metav1.GetOptions) (runtime.Object, error) {
+	s, err := d.Storage.Get(ctx, name, &metav1.GetOptions{})
+	if err == nil {
+		return s, err
+	}
+	if !apierrors.IsNotFound(err) {
+		klog.Error("unable to fetch object from duplicate storage", "error", err, "name", name)
+	}
+
+	klog.Info("Resource not found in Storage. Getting it from LegacyStorage.", "name", name)
+
 	return d.Legacy.Get(ctx, name, &metav1.GetOptions{})
 }
 

--- a/pkg/apiserver/rest/dualwriter_mode2_test.go
+++ b/pkg/apiserver/rest/dualwriter_mode2_test.go
@@ -25,19 +25,20 @@ func TestMode2(t *testing.T) {
 	assert.Equal(t, 1, lsSpy.Counts("LegacyStorage.Create"))
 	assert.Equal(t, 1, sSpy.Counts("Storage.Create"))
 
-	// Get: it should use the Legacy Get implementation
+	// Get: it should read from Storage with LegacyStorage as a fallback
+	// #TODO: Currently only testing the happy path. Refactor testing to more easily test other cases.
 	_, err = dw.Get(context.Background(), kind, &metav1.GetOptions{})
 	assert.NoError(t, err)
-	assert.Equal(t, 1, lsSpy.Counts("LegacyStorage.Get"))
-	assert.Equal(t, 0, sSpy.Counts("Storage.Get"))
+	assert.Equal(t, 0, lsSpy.Counts("LegacyStorage.Get"))
+	assert.Equal(t, 1, sSpy.Counts("Storage.Get"))
 
 	// List: it should use call both Legacy and Storage List methods
-	res, err := dw.List(context.Background(), &metainternalversion.ListOptions{})
+	l, err := dw.List(context.Background(), &metainternalversion.ListOptions{})
 	assert.NoError(t, err)
 	assert.Equal(t, 1, lsSpy.Counts("LegacyStorage.List"))
 	assert.Equal(t, 1, sSpy.Counts("Storage.List"))
 
-	resList, err := meta.ExtractList(res)
+	resList, err := meta.ExtractList(l)
 	assert.NoError(t, err)
 
 	expectedItems := map[string]string{

--- a/pkg/apiserver/rest/dualwriter_mode2_test.go
+++ b/pkg/apiserver/rest/dualwriter_mode2_test.go
@@ -8,6 +8,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/meta"
 	metainternalversion "k8s.io/apimachinery/pkg/apis/meta/internalversion"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 )
 
 func TestMode2(t *testing.T) {
@@ -18,8 +19,14 @@ func TestMode2(t *testing.T) {
 
 	dw := NewDualWriterMode2(lsSpy, sSpy)
 
+	// Create: it should use the Legacy Create implementation
+	_, err := dw.Create(context.Background(), &dummyObject{}, func(context.Context, runtime.Object) error { return nil }, &metav1.CreateOptions{})
+	assert.NoError(t, err)
+	assert.Equal(t, 1, lsSpy.Counts("LegacyStorage.Create"))
+	assert.Equal(t, 1, sSpy.Counts("Storage.Create"))
+
 	// Get: it should use the Legacy Get implementation
-	_, err := dw.Get(context.Background(), kind, &metav1.GetOptions{})
+	_, err = dw.Get(context.Background(), kind, &metav1.GetOptions{})
 	assert.NoError(t, err)
 	assert.Equal(t, 1, lsSpy.Counts("LegacyStorage.Get"))
 	assert.Equal(t, 0, sSpy.Counts("Storage.Get"))

--- a/pkg/apiserver/rest/dualwriter_mode3.go
+++ b/pkg/apiserver/rest/dualwriter_mode3.go
@@ -2,9 +2,7 @@ package rest
 
 import (
 	"context"
-	"fmt"
 
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apiserver/pkg/registry/rest"
@@ -40,23 +38,7 @@ func (d *DualWriterMode3) Create(ctx context.Context, obj runtime.Object, create
 	return created, nil
 }
 
-// Get overrides the default behavior of the Storage and retrieves an object from Unified Storage
-// the object is still fetched from Legacy Storage if it's not found in Unified Storage
+// Get overrides the behavior of the generic DualWriter and retrieves an object from Storage.
 func (d *DualWriterMode3) Get(ctx context.Context, name string, options *metav1.GetOptions) (runtime.Object, error) {
-	legacy, ok := d.Legacy.(rest.Getter)
-	if !ok {
-		return nil, fmt.Errorf("legacy storage rest.Getter is missing")
-	}
-
-	s, err := d.Storage.Get(ctx, name, &metav1.GetOptions{})
-	if err == nil {
-		return s, err
-	}
-	if !apierrors.IsNotFound(err) {
-		return nil, err
-	}
-
-	klog.Info("object not found in unified storage. Getting it from legacy", "name", name)
-
-	return legacy.Get(ctx, name, &metav1.GetOptions{})
+	return d.Storage.Get(ctx, name, &metav1.GetOptions{})
 }

--- a/pkg/apiserver/rest/dualwriter_mode3_test.go
+++ b/pkg/apiserver/rest/dualwriter_mode3_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	metainternalversion "k8s.io/apimachinery/pkg/apis/meta/internalversion"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 )
 
 func TestMode3(t *testing.T) {
@@ -17,8 +18,14 @@ func TestMode3(t *testing.T) {
 
 	dw := NewDualWriterMode3(lsSpy, sSpy)
 
+	// Create: it should use the Legacy Create implementation
+	_, err := dw.Create(context.Background(), &dummyObject{}, func(context.Context, runtime.Object) error { return nil }, &metav1.CreateOptions{})
+	assert.NoError(t, err)
+	assert.Equal(t, 1, lsSpy.Counts("LegacyStorage.Create"))
+	assert.Equal(t, 1, sSpy.Counts("Storage.Create"))
+
 	// Get: it should use the Storage Get implementation
-	_, err := dw.Get(context.Background(), kind, &metav1.GetOptions{})
+	_, err = dw.Get(context.Background(), kind, &metav1.GetOptions{})
 	assert.NoError(t, err)
 	assert.Equal(t, 0, lsSpy.Counts("LegacyStorage.Get"))
 	assert.Equal(t, 1, sSpy.Counts("Storage.Get"))

--- a/pkg/apiserver/rest/dualwriter_mode4.go
+++ b/pkg/apiserver/rest/dualwriter_mode4.go
@@ -25,7 +25,7 @@ func (d *DualWriterMode4) Create(ctx context.Context, obj runtime.Object, create
 	return d.Storage.Create(ctx, obj, createValidation, options)
 }
 
-// Get overrides the behavior of the generic DualWriter and retrieves an object from Unified Storage.
+// Get overrides the behavior of the generic DualWriter and retrieves an object from Storage.
 func (d *DualWriterMode4) Get(ctx context.Context, name string, options *metav1.GetOptions) (runtime.Object, error) {
 	return d.Storage.Get(ctx, name, &metav1.GetOptions{})
 }

--- a/pkg/apiserver/rest/dualwriter_mode4_test.go
+++ b/pkg/apiserver/rest/dualwriter_mode4_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	metainternalversion "k8s.io/apimachinery/pkg/apis/meta/internalversion"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 )
 
 func TestMode4(t *testing.T) {
@@ -17,8 +18,14 @@ func TestMode4(t *testing.T) {
 
 	dw := NewDualWriterMode4(lsSpy, sSpy)
 
+	// Create: it should use the Legacy Create implementation
+	_, err := dw.Create(context.Background(), &dummyObject{}, func(context.Context, runtime.Object) error { return nil }, &metav1.CreateOptions{})
+	assert.NoError(t, err)
+	assert.Equal(t, 0, lsSpy.Counts("LegacyStorage.Create"))
+	assert.Equal(t, 1, sSpy.Counts("Storage.Create"))
+
 	// Get: it should use the Storage Get implementation
-	_, err := dw.Get(context.Background(), kind, &metav1.GetOptions{})
+	_, err = dw.Get(context.Background(), kind, &metav1.GetOptions{})
 	assert.NoError(t, err)
 	assert.Equal(t, 0, lsSpy.Counts("LegacyStorage.Get"))
 	assert.Equal(t, 1, sSpy.Counts("Storage.Get"))

--- a/pkg/apiserver/rest/spy_client.go
+++ b/pkg/apiserver/rest/spy_client.go
@@ -59,7 +59,7 @@ type spyLegacyStorageShim struct {
 func (c *spyStorageClient) Create(ctx context.Context, obj runtime.Object, valitation rest.ValidateObjectFunc, options *metav1.CreateOptions) (runtime.Object, error) {
 	c.spy.record("Storage.Create")
 	klog.Info("method: Storage.Create")
-	return nil, nil
+	return &dummyObject{}, nil
 }
 
 func (c *spyStorageClient) Get(ctx context.Context, name string, options *metav1.GetOptions) (runtime.Object, error) {
@@ -137,7 +137,7 @@ func (c *spyLegacyStorageClient) Counts(method string) int {
 func (c *spyLegacyStorageClient) Create(ctx context.Context, obj runtime.Object, valitation rest.ValidateObjectFunc, options *metav1.CreateOptions) (runtime.Object, error) {
 	c.spy.record("LegacyStorage.Create")
 	klog.Info("method: LegacyStorage.Create")
-	return nil, nil
+	return &dummyObject{}, nil
 }
 
 func (c *spyLegacyStorageClient) Get(ctx context.Context, name string, options *metav1.GetOptions) (runtime.Object, error) {


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**
This PR adds a couple of improvements to the DualWriter:
* add tests for Create
* implement [PR review feedback](https://github.com/grafana/grafana/pull/85589#pullrequestreview-1989030118) from previous Get PR 

**Why do we need this feature?**

Adds tests, corrects Get behavior.

**Who is this feature for?**

U.S. developers and users.

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Partial https://github.com/grafana/search-and-storage-team/issues/17

**Special notes for your reviewer:**

The mode 2 Get test only tests the happy path--Storage contains the entity and there is no need to fall back to LegacyStorage. We're going to have to refactor testing to more easily test other cases. That will be done in a separate PR.

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
