### PR TITLE
TimeSeries: Fix series rendering with data links and extra fields

### DIFF
--- a/public/app/core/components/GraphNG/GraphNG.tsx
+++ b/public/app/core/components/GraphNG/GraphNG.tsx
@@ -83,8 +83,10 @@ export interface GraphNGState {
   config?: UPlotConfigBuilder;
 }
 
-const matchXDefault = fieldMatchers.get(FieldMatcherID.firstTimeField).get({});
-const matchYDefault = fieldMatchers.get(FieldMatcherID.byTypes).get(new Set([FieldType.number, FieldType.enum]));
+const defaultMatchers = {
+  x: fieldMatchers.get(FieldMatcherID.firstTimeField).get({}),
+  y: fieldMatchers.get(FieldMatcherID.byTypes).get(new Set([FieldType.number, FieldType.enum])),
+};
 
 /**
  * "Time as X" core component, expects ascending x
@@ -107,10 +109,7 @@ export class GraphNG extends Component<GraphNGProps, GraphNGState> {
 
     const {
       frames,
-      fields = {
-        x: matchXDefault,
-        y: matchYDefault,
-      },
+      fields = defaultMatchers,
       preparePlotFrame,
       replaceVariables,
       dataLinkPostProcessor,

--- a/public/app/core/components/GraphNG/GraphNG.tsx
+++ b/public/app/core/components/GraphNG/GraphNG.tsx
@@ -83,6 +83,7 @@ export interface GraphNGState {
   config?: UPlotConfigBuilder;
 }
 
+const matchXDefault = fieldMatchers.get(FieldMatcherID.firstTimeField).get({});
 const matchYDefault = fieldMatchers.get(FieldMatcherID.byTypes).get(new Set([FieldType.number, FieldType.enum]));
 
 /**
@@ -107,7 +108,7 @@ export class GraphNG extends Component<GraphNGProps, GraphNGState> {
     const {
       frames,
       fields = {
-        x: fieldMatchers.get(FieldMatcherID.firstTimeField).get({}),
+        x: matchXDefault,
         y: matchYDefault,
       },
       preparePlotFrame,

--- a/public/app/core/components/GraphNG/GraphNG.tsx
+++ b/public/app/core/components/GraphNG/GraphNG.tsx
@@ -83,6 +83,8 @@ export interface GraphNGState {
   config?: UPlotConfigBuilder;
 }
 
+const matchYDefault = fieldMatchers.get(FieldMatcherID.byTypes).get(new Set([FieldType.number, FieldType.enum]));
+
 /**
  * "Time as X" core component, expects ascending x
  */
@@ -102,21 +104,30 @@ export class GraphNG extends Component<GraphNGProps, GraphNGState> {
   prepState(props: GraphNGProps, withConfig = true) {
     let state: GraphNGState = null as any;
 
-    const { frames, fields, preparePlotFrame, replaceVariables, dataLinkPostProcessor } = props;
+    const {
+      frames,
+      fields = {
+        x: fieldMatchers.get(FieldMatcherID.firstTimeField).get({}),
+        y: matchYDefault,
+      },
+      preparePlotFrame,
+      replaceVariables,
+      dataLinkPostProcessor,
+    } = props;
 
     const preparePlotFrameFn = preparePlotFrame ?? defaultPreparePlotFrame;
 
-    const matchYDefault = fieldMatchers.get(FieldMatcherID.byTypes).get(new Set([FieldType.number, FieldType.enum]));
-
-    // if there are data links, we have to keep all fields so they're index-matched, then filter out dimFields.y
     const withLinks = frames.some((frame) => frame.fields.some((field) => (field.config.links?.length ?? 0) > 0));
 
-    const dimFields = fields ?? {
-      x: fieldMatchers.get(FieldMatcherID.firstTimeField).get({}),
-      y: withLinks ? () => true : matchYDefault,
-    };
-
-    const alignedFrame = preparePlotFrameFn(frames, dimFields, props.timeRange);
+    const alignedFrame = preparePlotFrameFn(
+      frames,
+      {
+        ...fields,
+        // if there are data links, keep all fields during join so they're index-matched
+        y: withLinks ? () => true : fields.y,
+      },
+      props.timeRange
+    );
 
     pluginLog('GraphNG', false, 'data aligned', alignedFrame);
 
@@ -147,10 +158,10 @@ export class GraphNG extends Component<GraphNGProps, GraphNGState> {
           );
         });
 
-        // filter join field and dimFields.y
+        // filter join field and fields.y
         alignedFrameFinal = {
           ...alignedFrame,
-          fields: alignedFrame.fields.filter((field, i) => i === 0 || dimFields.y(field, alignedFrame, [alignedFrame])),
+          fields: alignedFrame.fields.filter((field, i) => i === 0 || fields.y(field, alignedFrame, [alignedFrame])),
         };
       }
 

--- a/public/app/core/components/GraphNG/GraphNG.tsx
+++ b/public/app/core/components/GraphNG/GraphNG.tsx
@@ -107,13 +107,7 @@ export class GraphNG extends Component<GraphNGProps, GraphNGState> {
   prepState(props: GraphNGProps, withConfig = true) {
     let state: GraphNGState = null as any;
 
-    const {
-      frames,
-      fields = defaultMatchers,
-      preparePlotFrame,
-      replaceVariables,
-      dataLinkPostProcessor,
-    } = props;
+    const { frames, fields = defaultMatchers, preparePlotFrame, replaceVariables, dataLinkPostProcessor } = props;
 
     const preparePlotFrameFn = preparePlotFrame ?? defaultPreparePlotFrame;
 


### PR DESCRIPTION
Fixes https://github.com/grafana/support-escalations/issues/10030

caused by logic change in https://github.com/grafana/grafana/pull/85260 which erroneously leaves unwanted/non-renderable fields instead of filtering them out of the joined frame.