### PR TITLE
EmptyState: make "message" a required prop

### DIFF
--- a/packages/grafana-ui/src/components/EmptyState/EmptyState.mdx
+++ b/packages/grafana-ui/src/components/EmptyState/EmptyState.mdx
@@ -11,17 +11,17 @@ Use an empty state to communicate to the user that there is no data to display, 
 
 Use in place of a results table or list when a search query or filter returns no results.
 
-There are sensible defaults for the image and message, so in most cases you can use it without any additional props.
+There are sensible defaults for the image, so in most cases all you need to provide is a message.
 
 ```jsx
 import { EmptyState } from '@grafana/ui';
 
-<EmptyState variant="not-found" />;
+<EmptyState variant="not-found" message="No playlists found" />;
 ```
 
 ### Providing custom overrides
 
-You can optionally override the message or image, and add additional information or a button (e.g. to clear the search query)
+You can optionally override or hide the image, add additional information or a button (e.g. to clear the search query)
 
 ```jsx
 import { Button, EmptyState } from '@grafana/ui';

--- a/packages/grafana-ui/src/components/EmptyState/EmptyState.story.tsx
+++ b/packages/grafana-ui/src/components/EmptyState/EmptyState.story.tsx
@@ -28,6 +28,7 @@ export const Basic: StoryFn<typeof EmptyState> = (args) => {
 
 Basic.args = {
   children: 'Use this space to add any additional information',
+  message: 'No results found',
   variant: 'not-found',
 };
 

--- a/packages/grafana-ui/src/components/EmptyState/EmptyState.tsx
+++ b/packages/grafana-ui/src/components/EmptyState/EmptyState.tsx
@@ -1,6 +1,5 @@
 import React, { ReactNode } from 'react';
 
-import { t } from '../../utils/i18n';
 import { Box } from '../Layout/Box/Box';
 import { Stack } from '../Layout/Stack/Stack';
 import { Text } from '../Text/Text';
@@ -20,7 +19,7 @@ interface Props {
   /**
    * Message to display to the user
    */
-  message?: string;
+  message: string;
   /**
    * Empty state variant. Possible values are 'search'.
    */
@@ -31,7 +30,7 @@ export const EmptyState = ({
   button,
   children,
   image = <GrotNotFound width={300} />,
-  message = t('grafana-ui.empty-state.not-found-message', 'No results found'),
+  message,
   hideImage = false,
 }: React.PropsWithChildren<Props>) => {
   return (

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -573,9 +573,6 @@
     "drawer": {
       "close": "Close"
     },
-    "empty-state": {
-      "not-found-message": "No results found"
-    },
     "modal": {
       "close-tooltip": "Close"
     },

--- a/public/locales/pseudo-LOCALE/grafana.json
+++ b/public/locales/pseudo-LOCALE/grafana.json
@@ -573,9 +573,6 @@
     "drawer": {
       "close": "Cľőşę"
     },
-    "empty-state": {
-      "not-found-message": "Ńő řęşūľŧş ƒőūŉđ"
-    },
     "modal": {
       "close-tooltip": "Cľőşę"
     },


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

- makes the `message` prop required in `EmptyState`

**Why do we need this feature?**

- clearer interface when new variants are added
- ensures a more specific message is provided

**Who is this feature for?**

- everyone!

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
