### PR TITLE
Prometheus: Limit Prometheus run query event tracking to queries in Explore

### DIFF
--- a/packages/grafana-prometheus/src/tracking.ts
+++ b/packages/grafana-prometheus/src/tracking.ts
@@ -10,10 +10,10 @@ export function trackQuery(
   startTime: Date
 ): void {
   const { app, targets: queries } = request;
-  // We do want to track panel-editor and explore
-  // We do not want to track queries from the dashboard or viewing a panel
-  // also included in the tracking is cloud-alerting, unified-alerting, and unknown
-  if (app === CoreApp.Dashboard || app === CoreApp.PanelViewer) {
+  // We only track queries run in Explore.
+  // We do not want to track queries from the dashboard, viewing a panel,
+  // cloud-alerting, unified-alerting, scenes and unknown
+  if (app !== CoreApp.Explore) {
     return;
   }
 


### PR DESCRIPTION
**What is this?**
This limits event tracking for running Prometheus queries only to queries run in Explore. This means that queries from   cloud-alerting, unified-alerting, dashboard, correlations, unknown, panel-editor, panel-viewer and scenes are not tracked.

**Why are we doing this?**
Event tracking for queries has helped us in cases such as building a collection of queries for the Prometheus query assistant and other Grafana initiatives around Prometheus. Collecting so much data that is run so frequently has a high cost. This PR is to reduce cost.

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
