### PR TITLE
Dashboard: Fix A11y in AutoRefresh input field

### DIFF
--- a/public/app/features/dashboard/components/DashboardSettings/AutoRefreshIntervals.tsx
+++ b/public/app/features/dashboard/components/DashboardSettings/AutoRefreshIntervals.tsx
@@ -62,7 +62,7 @@ export const AutoRefreshIntervals = ({
       label={t('dashboard-settings.general.auto-refresh-label', 'Auto refresh')}
       description={t(
         'dashboard-settings.general.auto-refresh-description',
-        'Define the auto refresh intervals that should be available in the auto refresh list.'
+        "Define the auto refresh intervals that should be available in the auto refresh list. Use the format '5s' for seconds, '1m' for minutes, '1h' for hours, and '1d' for days (e.g.: '5s,10s,30s,1m,5m,15m,30m,1h,2h,1d')."
       )}
       error={invalidIntervalsMessage}
       invalid={!!invalidIntervalsMessage}


### PR DESCRIPTION
**What is this feature?**

This PR addresses the A11y concern of the `AutoRefresh` input inside the `dashboard` feature  not specifying the clear format of the data the user needs to insert.

**Why do we need this feature?**

Relevant WCAG Criteria: [#.#.# WCAG Criterion](link to https://www.w3.org/WAI/WCAG21/quickref/?versions=2.0)
3.3.2 Labels or Instructions: https://www.w3.org/TR/WCAG21/#labels-or-instructions


**Which issue(s) does this PR fix?**:

Usage: 
- "Fixes ##82192"
- "Closes #82192"


**UI changes** 
| Before         | After     
|--------------|-----------|
| ![Before](https://github.com/grafana/grafana/assets/65491033/7a36a71f-9888-4137-bf88-b34ab7e6ec13) |![After](https://github.com/grafana/grafana/assets/65491033/5d4941dc-f080-40af-81ea-7ecce349222c)


**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
