### PR TITLE
SSE: Threshold expression to use simple functions

### DIFF
--- a/pkg/expr/hysteresis_test.go
+++ b/pkg/expr/hysteresis_test.go
@@ -95,13 +95,13 @@ func TestHysteresisExecute(t *testing.T) {
 					ReferenceVar:  "A",
 					RefID:         "B",
 					ThresholdFunc: ThresholdIsAbove,
-					Conditions:    []float64{loadThreshold},
+					predicate:     greaterThanPredicate{loadThreshold},
 				},
 				UnloadingThresholdFunc: ThresholdCommand{
 					ReferenceVar:  "A",
 					RefID:         "B",
 					ThresholdFunc: ThresholdIsAbove,
-					Conditions:    []float64{unloadThreshold},
+					predicate:     greaterThanPredicate{unloadThreshold},
 				},
 				LoadedDimensions: tc.loadedDimensions,
 			}

--- a/pkg/expr/testing.go
+++ b/pkg/expr/testing.go
@@ -4,7 +4,9 @@ import (
 	"context"
 
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
+	"github.com/grafana/grafana-plugin-sdk-go/data"
 
+	"github.com/grafana/grafana/pkg/expr/mathexp"
 	"github.com/grafana/grafana/pkg/services/auth/identity"
 	"github.com/grafana/grafana/pkg/services/datasources"
 )
@@ -81,4 +83,14 @@ var _ backend.CallResourceHandler = &recordingCallResourceHandler{}
 func (f *recordingCallResourceHandler) CallResource(_ context.Context, req *backend.CallResourceRequest, sender backend.CallResourceResponseSender) error {
 	f.recordings = append(f.recordings, req)
 	return sender.Send(f.response)
+}
+
+func newNumber(labels data.Labels, value *float64) mathexp.Number {
+	n := mathexp.NewNumber("", labels)
+	n.SetValue(value)
+	return n
+}
+
+func newResults(values ...mathexp.Value) mathexp.Results {
+	return mathexp.Results{Values: values}
 }

--- a/pkg/expr/testing.go
+++ b/pkg/expr/testing.go
@@ -2,6 +2,7 @@ package expr
 
 import (
 	"context"
+	"time"
 
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
 	"github.com/grafana/grafana-plugin-sdk-go/data"
@@ -85,10 +86,40 @@ func (f *recordingCallResourceHandler) CallResource(_ context.Context, req *back
 	return sender.Send(f.response)
 }
 
+func newScalar(value *float64) mathexp.Scalar {
+	n := mathexp.NewScalar("", value)
+	return n
+}
+
 func newNumber(labels data.Labels, value *float64) mathexp.Number {
 	n := mathexp.NewNumber("", labels)
 	n.SetValue(value)
 	return n
+}
+
+func newSeries(points ...float64) mathexp.Series {
+	series := mathexp.NewSeries("", nil, len(points))
+	for idx, point := range points {
+		p := point
+		series.SetPoint(idx, time.Unix(int64(idx), 0), &p)
+	}
+	return series
+}
+
+func newSeriesPointer(points ...*float64) mathexp.Series {
+	series := mathexp.NewSeries("", nil, len(points))
+	for idx, point := range points {
+		series.SetPoint(idx, time.Unix(int64(idx), 0), point)
+	}
+	return series
+}
+
+func newSeriesWithLabels(labels data.Labels, values ...*float64) mathexp.Series {
+	series := mathexp.NewSeries("", labels, len(values))
+	for idx, value := range values {
+		series.SetPoint(idx, time.Unix(int64(idx), 0), value)
+	}
+	return series
 }
 
 func newResults(values ...mathexp.Value) mathexp.Results {

--- a/pkg/expr/threshold.go
+++ b/pkg/expr/threshold.go
@@ -13,14 +13,19 @@ import (
 	"github.com/grafana/grafana/pkg/expr/mathexp"
 	"github.com/grafana/grafana/pkg/infra/tracing"
 	"github.com/grafana/grafana/pkg/services/featuremgmt"
+	"github.com/grafana/grafana/pkg/util"
 )
+
+type predicate interface {
+	Eval(f float64) bool
+}
 
 type ThresholdCommand struct {
 	ReferenceVar  string
 	RefID         string
 	ThresholdFunc ThresholdType
-	Conditions    []float64
 	Invert        bool
+	predicate     predicate
 }
 
 // +enum
@@ -43,15 +48,28 @@ var (
 )
 
 func NewThresholdCommand(refID, referenceVar string, thresholdFunc ThresholdType, conditions []float64) (*ThresholdCommand, error) {
+	var predicate predicate
 	switch thresholdFunc {
-	case ThresholdIsOutsideRange, ThresholdIsWithinRange:
+	case ThresholdIsOutsideRange:
 		if len(conditions) < 2 {
-			return nil, fmt.Errorf("incorrect number of arguments: got %d but need 2", len(conditions))
+			return nil, fmt.Errorf("incorrect number of arguments for threshold function '%s': got %d but need 2", thresholdFunc, len(conditions))
 		}
-	case ThresholdIsAbove, ThresholdIsBelow:
+		predicate = outsideRangePredicate{left: conditions[0], right: conditions[1]}
+	case ThresholdIsWithinRange:
+		if len(conditions) < 2 {
+			return nil, fmt.Errorf("incorrect number of arguments for threshold function '%s': got %d but need 2", thresholdFunc, len(conditions))
+		}
+		predicate = withinRangePredicate{left: conditions[0], right: conditions[1]}
+	case ThresholdIsAbove:
 		if len(conditions) < 1 {
-			return nil, fmt.Errorf("incorrect number of arguments: got %d but need 1", len(conditions))
+			return nil, fmt.Errorf("incorrect number of arguments for threshold function '%s': got %d but need 1", thresholdFunc, len(conditions))
 		}
+		predicate = greaterThanPredicate{value: conditions[0]}
+	case ThresholdIsBelow:
+		if len(conditions) < 1 {
+			return nil, fmt.Errorf("incorrect number of arguments for threshold function '%s': got %d but need 1", thresholdFunc, len(conditions))
+		}
+		predicate = lessThanPredicate{value: conditions[0]}
 	default:
 		return nil, fmt.Errorf("expected threshold function to be one of [%s], got %s", strings.Join(supportedThresholdFuncs, ", "), thresholdFunc)
 	}
@@ -60,7 +78,7 @@ func NewThresholdCommand(refID, referenceVar string, thresholdFunc ThresholdType
 		RefID:         refID,
 		ReferenceVar:  referenceVar,
 		ThresholdFunc: thresholdFunc,
-		Conditions:    conditions,
+		predicate:     predicate,
 	}, nil
 }
 
@@ -114,46 +132,51 @@ func (tc *ThresholdCommand) NeedsVars() []string {
 	return []string{tc.ReferenceVar}
 }
 
-func (tc *ThresholdCommand) Execute(ctx context.Context, now time.Time, vars mathexp.Vars, tracer tracing.Tracer) (mathexp.Results, error) {
-	mathExpression, err := createMathExpression(tc.ReferenceVar, tc.ThresholdFunc, tc.Conditions, tc.Invert)
-	if err != nil {
-		return mathexp.Results{}, err
+func (tc *ThresholdCommand) Execute(_ context.Context, _ time.Time, vars mathexp.Vars, _ tracing.Tracer) (mathexp.Results, error) {
+	eval := func(maybeValue *float64) *float64 {
+		if maybeValue == nil {
+			return nil
+		}
+		result := tc.predicate.Eval(*maybeValue)
+		if tc.Invert {
+			result = !result
+		}
+		if result {
+			return util.Pointer(float64(1))
+		}
+		return util.Pointer(float64(0))
 	}
 
-	mathCommand, err := NewMathCommand(tc.RefID, mathExpression)
-	if err != nil {
-		return mathexp.Results{}, err
+	refVarResult := vars[tc.ReferenceVar]
+	newRes := mathexp.Results{Values: make(mathexp.Values, 0, len(refVarResult.Values))}
+	for _, val := range refVarResult.Values {
+		switch v := val.(type) {
+		case mathexp.Series:
+			s := mathexp.NewSeries(tc.RefID, v.GetLabels(), v.Len())
+			for i := 0; i < v.Len(); i++ {
+				t, value := v.GetPoint(i)
+				s.SetPoint(i, t, eval(value))
+			}
+			newRes.Values = append(newRes.Values, s)
+		case mathexp.Number:
+			copyV := mathexp.NewNumber(tc.RefID, v.GetLabels())
+			copyV.SetValue(eval(v.GetFloat64Value()))
+			newRes.Values = append(newRes.Values, copyV)
+		case mathexp.Scalar:
+			copyV := mathexp.NewScalar(tc.RefID, eval(v.GetFloat64Value()))
+			newRes.Values = append(newRes.Values, copyV)
+		case mathexp.NoData:
+			newRes.Values = append(newRes.Values, mathexp.NewNoData())
+		default:
+			return newRes, fmt.Errorf("unsupported format of the input data, got type %v", val.Type())
+		}
 	}
-
-	return mathCommand.Execute(ctx, now, vars, tracer)
+	return newRes, nil
 }
 
 func (tc *ThresholdCommand) Type() string {
 	return TypeThreshold.String()
 }
-
-// createMathExpression converts all the info we have about a "threshold" expression in to a Math expression
-func createMathExpression(referenceVar string, thresholdFunc ThresholdType, args []float64, invert bool) (string, error) {
-	var exp string
-	switch thresholdFunc {
-	case ThresholdIsAbove:
-		exp = fmt.Sprintf("${%s} > %f", referenceVar, args[0])
-	case ThresholdIsBelow:
-		exp = fmt.Sprintf("${%s} < %f", referenceVar, args[0])
-	case ThresholdIsWithinRange:
-		exp = fmt.Sprintf("${%s} > %f && ${%s} < %f", referenceVar, args[0], referenceVar, args[1])
-	case ThresholdIsOutsideRange:
-		exp = fmt.Sprintf("${%s} < %f || ${%s} > %f", referenceVar, args[0], referenceVar, args[1])
-	default:
-		return "", fmt.Errorf("failed to evaluate threshold expression: no such threshold function %s", thresholdFunc)
-	}
-
-	if invert {
-		return fmt.Sprintf("!(%s)", exp), nil
-	}
-	return exp, nil
-}
-
 func IsSupportedThresholdFunc(name string) bool {
 	isSupported := false
 
@@ -236,4 +259,38 @@ func getConditionForHysteresisCommand(query map[string]any) (map[string]any, err
 		return nil, nil
 	}
 	return condition, nil
+}
+
+type withinRangePredicate struct {
+	left  float64
+	right float64
+}
+
+func (r withinRangePredicate) Eval(f float64) bool {
+	return f > r.left && f < r.right
+}
+
+type outsideRangePredicate struct {
+	left  float64
+	right float64
+}
+
+func (r outsideRangePredicate) Eval(f float64) bool {
+	return f < r.left || f > r.right
+}
+
+type lessThanPredicate struct {
+	value float64
+}
+
+func (r lessThanPredicate) Eval(f float64) bool {
+	return f < r.value
+}
+
+type greaterThanPredicate struct {
+	value float64
+}
+
+func (r greaterThanPredicate) Eval(f float64) bool {
+	return f > r.value
 }

--- a/pkg/expr/threshold_bench_test.go
+++ b/pkg/expr/threshold_bench_test.go
@@ -86,39 +86,3 @@ func BenchmarkThreshold(b *testing.B) {
 		}
 	})
 }
-
-/*
-goos: windows
-goarch: amd64
-pkg: github.com/grafana/grafana/pkg/expr
-cpu: 11th Gen Intel(R) Core(TM) i9-11900H @ 2.50GHz
-BenchmarkThreshold
-BenchmarkThreshold/greater_than
-BenchmarkThreshold/greater_than-16         	    3624	    319428 ns/op	  560673 B/op	   10061 allocs/op
-BenchmarkThreshold/less_than
-BenchmarkThreshold/less_than-16            	    3787	    313414 ns/op	  561320 B/op	   10060 allocs/op
-BenchmarkThreshold/within_range
-BenchmarkThreshold/within_range-16         	      37	  31990481 ns/op	 1674032 B/op	   30134 allocs/op
-BenchmarkThreshold/within_range,_no_labels
-BenchmarkThreshold/within_range,_no_labels-16         	       3	 384440567 ns/op	610835274 B/op	10020193 allocs/op
-BenchmarkThreshold/outside_range
-BenchmarkThreshold/outside_range-16                   	      37	  32272343 ns/op	 1679473 B/op	   30135 allocs/op
-*/
-
-/*
-goos: windows
-goarch: amd64
-pkg: github.com/grafana/grafana/pkg/expr
-cpu: 11th Gen Intel(R) Core(TM) i9-11900H @ 2.50GHz
-BenchmarkThreshold
-BenchmarkThreshold/greater_than
-BenchmarkThreshold/greater_than-16         	    4327	    254582 ns/op	  448385 B/op	    9001 allocs/op
-BenchmarkThreshold/less_than
-BenchmarkThreshold/less_than-16            	    4837	    248919 ns/op	  448385 B/op	    9001 allocs/op
-BenchmarkThreshold/within_range
-BenchmarkThreshold/within_range-16         	    4528	    269994 ns/op	  448385 B/op	    9001 allocs/op
-BenchmarkThreshold/within_range,_no_labels
-BenchmarkThreshold/within_range,_no_labels-16         	    4808	    292808 ns/op	  448385 B/op	    9001 allocs/op
-BenchmarkThreshold/outside_range
-BenchmarkThreshold/outside_range-16                   	    3859	    293570 ns/op	  448385 B/op	    9001 allocs/op
-*/

--- a/pkg/expr/threshold_bench_test.go
+++ b/pkg/expr/threshold_bench_test.go
@@ -103,5 +103,22 @@ BenchmarkThreshold/within_range,_no_labels
 BenchmarkThreshold/within_range,_no_labels-16         	       3	 384440567 ns/op	610835274 B/op	10020193 allocs/op
 BenchmarkThreshold/outside_range
 BenchmarkThreshold/outside_range-16                   	      37	  32272343 ns/op	 1679473 B/op	   30135 allocs/op
-PASS
+*/
+
+/*
+goos: windows
+goarch: amd64
+pkg: github.com/grafana/grafana/pkg/expr
+cpu: 11th Gen Intel(R) Core(TM) i9-11900H @ 2.50GHz
+BenchmarkThreshold
+BenchmarkThreshold/greater_than
+BenchmarkThreshold/greater_than-16         	    4327	    254582 ns/op	  448385 B/op	    9001 allocs/op
+BenchmarkThreshold/less_than
+BenchmarkThreshold/less_than-16            	    4837	    248919 ns/op	  448385 B/op	    9001 allocs/op
+BenchmarkThreshold/within_range
+BenchmarkThreshold/within_range-16         	    4528	    269994 ns/op	  448385 B/op	    9001 allocs/op
+BenchmarkThreshold/within_range,_no_labels
+BenchmarkThreshold/within_range,_no_labels-16         	    4808	    292808 ns/op	  448385 B/op	    9001 allocs/op
+BenchmarkThreshold/outside_range
+BenchmarkThreshold/outside_range-16                   	    3859	    293570 ns/op	  448385 B/op	    9001 allocs/op
 */

--- a/pkg/expr/threshold_bench_test.go
+++ b/pkg/expr/threshold_bench_test.go
@@ -1,0 +1,107 @@
+package expr
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/grafana/grafana-plugin-sdk-go/data"
+
+	"github.com/grafana/grafana/pkg/expr/mathexp"
+	"github.com/grafana/grafana/pkg/infra/tracing"
+	"github.com/grafana/grafana/pkg/util"
+)
+
+func BenchmarkThreshold(b *testing.B) {
+	results := make(mathexp.Values, 0, 1000)
+	for i := 0; i < cap(results); i++ {
+		n := newNumber(data.Labels{"test": fmt.Sprintf("series-%d", i)}, util.Pointer(float64(i)))
+		results = append(results, n)
+	}
+	ctx := context.Background()
+	timeNow := time.Now()
+	vars := mathexp.Vars{
+		"A": newResults(results...),
+	}
+	trace := tracing.InitializeTracerForTest()
+	b.ResetTimer()
+	b.Run("greater than", func(b *testing.B) {
+		greater, err := NewThresholdCommand("B", "A", ThresholdIsAbove, []float64{500})
+		if err != nil {
+			b.Fatalf("error: %s", err)
+		}
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			_, _ = greater.Execute(ctx, timeNow, vars, trace)
+		}
+	})
+	b.Run("less than", func(b *testing.B) {
+		greater, err := NewThresholdCommand("B", "A", ThresholdIsAbove, []float64{500})
+		if err != nil {
+			b.Fatalf("error: %s", err)
+		}
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			_, _ = greater.Execute(ctx, timeNow, vars, trace)
+		}
+	})
+	b.Run("within range", func(b *testing.B) {
+		greater, err := NewThresholdCommand("B", "A", ThresholdIsWithinRange, []float64{400.0, 600.0})
+		if err != nil {
+			b.Fatalf("error: %s", err)
+		}
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			_, _ = greater.Execute(ctx, timeNow, vars, trace)
+		}
+	})
+	b.Run("within range, no labels", func(b *testing.B) {
+		greater, err := NewThresholdCommand("B", "A", ThresholdIsWithinRange, []float64{400.0, 600.0})
+		if err != nil {
+			b.Fatalf("error: %s", err)
+		}
+
+		results := make(mathexp.Values, 0, 1000)
+		for i := 0; i < cap(results); i++ {
+			n := newNumber(nil, util.Pointer(float64(i)))
+			results = append(results, n)
+		}
+		vars := mathexp.Vars{
+			"A": newResults(results...),
+		}
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			_, _ = greater.Execute(ctx, timeNow, vars, trace)
+		}
+	})
+	b.Run("outside range", func(b *testing.B) {
+		greater, err := NewThresholdCommand("B", "A", ThresholdIsOutsideRange, []float64{400.0, 600.0})
+		if err != nil {
+			b.Fatalf("error: %s", err)
+		}
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			_, _ = greater.Execute(ctx, timeNow, vars, trace)
+		}
+	})
+}
+
+/*
+goos: windows
+goarch: amd64
+pkg: github.com/grafana/grafana/pkg/expr
+cpu: 11th Gen Intel(R) Core(TM) i9-11900H @ 2.50GHz
+BenchmarkThreshold
+BenchmarkThreshold/greater_than
+BenchmarkThreshold/greater_than-16         	    3624	    319428 ns/op	  560673 B/op	   10061 allocs/op
+BenchmarkThreshold/less_than
+BenchmarkThreshold/less_than-16            	    3787	    313414 ns/op	  561320 B/op	   10060 allocs/op
+BenchmarkThreshold/within_range
+BenchmarkThreshold/within_range-16         	      37	  31990481 ns/op	 1674032 B/op	   30134 allocs/op
+BenchmarkThreshold/within_range,_no_labels
+BenchmarkThreshold/within_range,_no_labels-16         	       3	 384440567 ns/op	610835274 B/op	10020193 allocs/op
+BenchmarkThreshold/outside_range
+BenchmarkThreshold/outside_range-16                   	      37	  32272343 ns/op	 1679473 B/op	   30135 allocs/op
+PASS
+*/


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**
This PR updates Threshold expression to not use general-purpose math expression for evaluating the thresholds. 
Instead it uses hardcoded predicates. This saves some time on parsing the math expression as well as drastically improves performance of range threshold.

<details><summary>Benchmark Results</summary>

Before the change:
```
goos: windows
goarch: amd64
pkg: github.com/grafana/grafana/pkg/expr
cpu: 11th Gen Intel(R) Core(TM) i9-11900H @ 2.50GHz
BenchmarkThreshold
BenchmarkThreshold/greater_than
BenchmarkThreshold/greater_than-16         	    3624	    319428 ns/op	  560673 B/op	   10061 allocs/op
BenchmarkThreshold/less_than
BenchmarkThreshold/less_than-16            	    3787	    313414 ns/op	  561320 B/op	   10060 allocs/op
BenchmarkThreshold/within_range
BenchmarkThreshold/within_range-16         	      37	  31990481 ns/op	 1674032 B/op	   30134 allocs/op
BenchmarkThreshold/within_range,_no_labels
BenchmarkThreshold/within_range,_no_labels-16         	       3	 384440567 ns/op	610835274 B/op	10020193 allocs/op
BenchmarkThreshold/outside_range
BenchmarkThreshold/outside_range-16                   	      37	  32272343 ns/op	 1679473 B/op	   30135 allocs/op
```
After:

```
goos: windows
goarch: amd64
pkg: github.com/grafana/grafana/pkg/expr
cpu: 11th Gen Intel(R) Core(TM) i9-11900H @ 2.50GHz
BenchmarkThreshold
BenchmarkThreshold/greater_than
BenchmarkThreshold/greater_than-16         	    4327	    254582 ns/op	  448385 B/op	    9001 allocs/op
BenchmarkThreshold/less_than
BenchmarkThreshold/less_than-16            	    4837	    248919 ns/op	  448385 B/op	    9001 allocs/op
BenchmarkThreshold/within_range
BenchmarkThreshold/within_range-16         	    4528	    269994 ns/op	  448385 B/op	    9001 allocs/op
BenchmarkThreshold/within_range,_no_labels
BenchmarkThreshold/within_range,_no_labels-16         	    4808	    292808 ns/op	  448385 B/op	    9001 allocs/op
BenchmarkThreshold/outside_range
BenchmarkThreshold/outside_range-16                   	    3859	    293570 ns/op	  448385 B/op	    9001 allocs/op
```

</details>

**Why do we need this feature?**
Improve the performance of the alerting evaluation. 

**Who is this feature for?**
Users with rules that query data sources that do not provide labels and apply range thresholds to the result.

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle.
- [x] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
