### PR TITLE
Fix crash on new dashboard save from panel edit

### DIFF
--- a/public/app/features/dashboard-scene/scene/DashboardScene.tsx
+++ b/public/app/features/dashboard-scene/scene/DashboardScene.tsx
@@ -178,7 +178,7 @@ export class DashboardScene extends SceneObjectBase<DashboardSceneState> {
       this._changeTracker.startTrackingChanges();
     }
 
-    if (this.state.meta.isNew) {
+    if (this.state.meta.isNew && !this.state.editPanel) {
       this.onEnterEditMode();
       this.setState({ isDirty: true });
     }


### PR DESCRIPTION
Fixes an issue where saving a new dashboard from panel edit would crash the dashboard. 

https://github.com/grafana/grafana/assets/36818606/396f44ed-1481-4ebe-af87-98614fe8bafb

The issue does not reproduce consistently, but when it does it happens in the `DashboardScene` activation handler where it checks if a dashboard is new and automatically enters edit mode. When the bug reproduces, the `DashboardScene` runs its activation handler with the old state, so even though we have saved the dashboard, when the activation handler runs it still checks for the `if (meta.isNew)` condition, which then triggers `onEnterEditMode`. In that old state we also have `editPanel` which further down the line contains a `SceneObjectRef` which cannot be cloned when entering edit mode, thus the crash.

In the happy path, the activation handler is not triggered, thus no crash. Why exactly the scene is reactivated sometimes, I do not know yet.

This fix will avoid entering edit mode and causing crashes when the dashboard is new but we are in panel edit. I think this makes sense since you can't go in panel edit in a new dashboard directly.

But this doesn't fix the root cause of the issue, which seems to be the race condition that triggers the activation handler sometimes.

I think the scene reactivates somehow when `onSaveDashboard` takes too long to complete the request.

Fixes https://github.com/grafana/grafana/issues/86167