### PR TITLE
RBAC: add a feature toggle for action sets

### DIFF
--- a/docs/sources/setup-grafana/configure-grafana/feature-toggles/index.md
+++ b/docs/sources/setup-grafana/configure-grafana/feature-toggles/index.md
@@ -175,6 +175,7 @@ Experimental features might be changed or removed without prior notice.
 | `nodeGraphDotLayout`                        | Changed the layout algorithm for the node graph                                                                                                                                                                                                                                   |
 | `kubernetesAggregator`                      | Enable grafana aggregator                                                                                                                                                                                                                                                         |
 | `expressionParser`                          | Enable new expression parser                                                                                                                                                                                                                                                      |
+| `actionSets`                                | Introduces action sets for resource permissions                                                                                                                                                                                                                                   |
 
 ## Development feature toggles
 

--- a/docs/sources/setup-grafana/configure-grafana/feature-toggles/index.md
+++ b/docs/sources/setup-grafana/configure-grafana/feature-toggles/index.md
@@ -175,7 +175,7 @@ Experimental features might be changed or removed without prior notice.
 | `nodeGraphDotLayout`                        | Changed the layout algorithm for the node graph                                                                                                                                                                                                                                   |
 | `kubernetesAggregator`                      | Enable grafana aggregator                                                                                                                                                                                                                                                         |
 | `expressionParser`                          | Enable new expression parser                                                                                                                                                                                                                                                      |
-| `actionSets`                                | Introduces action sets for resource permissions                                                                                                                                                                                                                                   |
+| `accessActionSets`                          | Introduces action sets for resource permissions                                                                                                                                                                                                                                   |
 
 ## Development feature toggles
 

--- a/packages/grafana-data/src/types/featureToggles.gen.ts
+++ b/packages/grafana-data/src/types/featureToggles.gen.ts
@@ -179,5 +179,5 @@ export interface FeatureToggles {
   oauthRequireSubClaim?: boolean;
   newDashboardWithFiltersAndGroupBy?: boolean;
   cloudWatchNewLabelParsing?: boolean;
-  actionSets?: boolean;
+  accessActionSets?: boolean;
 }

--- a/packages/grafana-data/src/types/featureToggles.gen.ts
+++ b/packages/grafana-data/src/types/featureToggles.gen.ts
@@ -179,4 +179,5 @@ export interface FeatureToggles {
   oauthRequireSubClaim?: boolean;
   newDashboardWithFiltersAndGroupBy?: boolean;
   cloudWatchNewLabelParsing?: boolean;
+  actionSets?: boolean;
 }

--- a/pkg/services/featuremgmt/registry.go
+++ b/pkg/services/featuremgmt/registry.go
@@ -1206,7 +1206,7 @@ var (
 			AllowSelfServe: false,
 		},
 		{
-			Name:        "actionSets",
+			Name:        "accessActionSets",
 			Description: "Introduces action sets for resource permissions",
 			Stage:       FeatureStageExperimental,
 			Owner:       identityAccessTeam,

--- a/pkg/services/featuremgmt/registry.go
+++ b/pkg/services/featuremgmt/registry.go
@@ -1205,6 +1205,12 @@ var (
 			FrontendOnly:   false,
 			AllowSelfServe: false,
 		},
+		{
+			Name:        "actionSets",
+			Description: "Introduces action sets for resource permissions",
+			Stage:       FeatureStageExperimental,
+			Owner:       identityAccessTeam,
+		},
 	}
 )
 

--- a/pkg/services/featuremgmt/toggles_gen.csv
+++ b/pkg/services/featuremgmt/toggles_gen.csv
@@ -160,3 +160,4 @@ usePrometheusFrontendPackage,GA,@grafana/observability-metrics,false,false,true
 oauthRequireSubClaim,experimental,@grafana/identity-access-team,false,false,false
 newDashboardWithFiltersAndGroupBy,experimental,@grafana/dashboards-squad,false,false,false
 cloudWatchNewLabelParsing,GA,@grafana/aws-datasources,false,false,false
+actionSets,experimental,@grafana/identity-access-team,false,false,false

--- a/pkg/services/featuremgmt/toggles_gen.csv
+++ b/pkg/services/featuremgmt/toggles_gen.csv
@@ -160,4 +160,4 @@ usePrometheusFrontendPackage,GA,@grafana/observability-metrics,false,false,true
 oauthRequireSubClaim,experimental,@grafana/identity-access-team,false,false,false
 newDashboardWithFiltersAndGroupBy,experimental,@grafana/dashboards-squad,false,false,false
 cloudWatchNewLabelParsing,GA,@grafana/aws-datasources,false,false,false
-actionSets,experimental,@grafana/identity-access-team,false,false,false
+accessActionSets,experimental,@grafana/identity-access-team,false,false,false

--- a/pkg/services/featuremgmt/toggles_gen.go
+++ b/pkg/services/featuremgmt/toggles_gen.go
@@ -651,7 +651,7 @@ const (
 	// Updates CloudWatch label parsing to be more accurate
 	FlagCloudWatchNewLabelParsing = "cloudWatchNewLabelParsing"
 
-	// FlagActionSets
+	// FlagAccessActionSets
 	// Introduces action sets for resource permissions
-	FlagActionSets = "actionSets"
+	FlagAccessActionSets = "accessActionSets"
 )

--- a/pkg/services/featuremgmt/toggles_gen.go
+++ b/pkg/services/featuremgmt/toggles_gen.go
@@ -650,4 +650,8 @@ const (
 	// FlagCloudWatchNewLabelParsing
 	// Updates CloudWatch label parsing to be more accurate
 	FlagCloudWatchNewLabelParsing = "cloudWatchNewLabelParsing"
+
+	// FlagActionSets
+	// Introduces action sets for resource permissions
+	FlagActionSets = "actionSets"
 )

--- a/pkg/services/featuremgmt/toggles_gen.json
+++ b/pkg/services/featuremgmt/toggles_gen.json
@@ -2090,6 +2090,18 @@
         "frontend": true,
         "allowSelfServe": true
       }
+    },
+    {
+      "metadata": {
+        "name": "actionSets",
+        "resourceVersion": "1712934405418",
+        "creationTimestamp": "2024-04-12T15:06:45Z"
+      },
+      "spec": {
+        "description": "Introduces action sets for resource permissions",
+        "stage": "experimental",
+        "codeowner": "@grafana/identity-access-team"
+      }
     }
   ]
 }

--- a/pkg/services/featuremgmt/toggles_gen.json
+++ b/pkg/services/featuremgmt/toggles_gen.json
@@ -2095,7 +2095,20 @@
       "metadata": {
         "name": "actionSets",
         "resourceVersion": "1712934405418",
-        "creationTimestamp": "2024-04-12T15:06:45Z"
+        "creationTimestamp": "2024-04-12T15:06:45Z",
+        "deletionTimestamp": "2024-04-12T15:17:53Z"
+      },
+      "spec": {
+        "description": "Introduces action sets for resource permissions",
+        "stage": "experimental",
+        "codeowner": "@grafana/identity-access-team"
+      }
+    },
+    {
+      "metadata": {
+        "name": "accessActionSets",
+        "resourceVersion": "1712935073026",
+        "creationTimestamp": "2024-04-12T15:17:53Z"
       },
       "spec": {
         "description": "Introduces action sets for resource permissions",


### PR DESCRIPTION
Adds a feature toggle for action sets. Action sets are a way of grouping managed permissions together in order to:
* reduce the amount of permissions stored in the database;
* allow plugins to scope access to their resources to folders that these resources are stored in;
* allow for more granular access to resources within folders.