### PR TITLE
Grafana UI: `ToolbarButton.story.tsx` - Replace `HorizotalGroup` and `VerticalGroup` with `Stack`

### DIFF
--- a/.betterer.results
+++ b/.betterer.results
@@ -988,10 +988,6 @@ exports[`better eslint`] = {
     "packages/grafana-ui/src/components/ThemeDemos/EmotionPerfTest.tsx:5381": [
       [0, 0, 0, "\'VerticalGroup\' import from \'../Layout/Layout\' is restricted from being used by a pattern. Use Stack component instead.", "0"]
     ],
-    "packages/grafana-ui/src/components/ToolbarButton/ToolbarButton.story.tsx:5381": [
-      [0, 0, 0, "\'HorizontalGroup\' import from \'../Layout/Layout\' is restricted from being used by a pattern. Use Stack component instead.", "0"],
-      [0, 0, 0, "\'VerticalGroup\' import from \'../Layout/Layout\' is restricted from being used by a pattern. Use Stack component instead.", "1"]
-    ],
     "packages/grafana-ui/src/components/ValuePicker/ValuePicker.tsx:5381": [
       [0, 0, 0, "Use data-testid for E2E selectors instead of aria-label", "0"]
     ],

--- a/packages/grafana-ui/src/components/ToolbarButton/ToolbarButton.story.tsx
+++ b/packages/grafana-ui/src/components/ToolbarButton/ToolbarButton.story.tsx
@@ -94,7 +94,7 @@ export const Examples: StoryFn<typeof ToolbarButton> = (args) => {
 
   return (
     <DashboardStoryCanvas>
-      <Stack direction="column">
+      <Stack direction="column" gap={1.5}>
         Button states
         <ToolbarButtonRow>
           <ToolbarButton variant="canvas">Just text</ToolbarButton>

--- a/packages/grafana-ui/src/components/ToolbarButton/ToolbarButton.story.tsx
+++ b/packages/grafana-ui/src/components/ToolbarButton/ToolbarButton.story.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 
 import { DashboardStoryCanvas } from '../../utils/storybook/DashboardStoryCanvas';
 import { ButtonGroup } from '../Button';
-import { HorizontalGroup, VerticalGroup } from '../Layout/Layout';
+import { Stack } from '../Layout/Stack/Stack';
 
 import { ToolbarButton, ToolbarButtonVariant } from './ToolbarButton';
 import mdx from './ToolbarButton.mdx';
@@ -94,7 +94,7 @@ export const Examples: StoryFn<typeof ToolbarButton> = (args) => {
 
   return (
     <DashboardStoryCanvas>
-      <VerticalGroup>
+      <Stack direction="column">
         Button states
         <ToolbarButtonRow>
           <ToolbarButton variant="canvas">Just text</ToolbarButton>
@@ -140,7 +140,7 @@ export const Examples: StoryFn<typeof ToolbarButton> = (args) => {
         </ButtonGroup>
         <br />
         Inside button group
-        <HorizontalGroup>
+        <Stack>
           <ButtonGroup>
             <ToolbarButton variant="primary" icon="sync">
               Run query
@@ -153,8 +153,8 @@ export const Examples: StoryFn<typeof ToolbarButton> = (args) => {
             </ToolbarButton>
             <ToolbarButton isOpen={false} narrow variant="destructive" />
           </ButtonGroup>
-        </HorizontalGroup>
-      </VerticalGroup>
+        </Stack>
+      </Stack>
     </DashboardStoryCanvas>
   );
 };


### PR DESCRIPTION
**What is this feature?**
This is part of the epic https://github.com/grafana/grafana/issues/85510

**Why do we need this feature?**
To replace deprecated layout components with new ones.

**Who is this feature for?**
Everybody

**Which issue(s) does this PR fix?:**

Fixes #

**Special notes for your reviewer:**

**Before:**
<img width="769" alt="Captura de pantalla 2024-04-12 a las 17 30 31" src="https://github.com/grafana/grafana/assets/65417731/557224aa-575d-4112-999e-7affbcb74dfe">

**After:**
<img width="691" alt="Captura de pantalla 2024-04-12 a las 17 29 57" src="https://github.com/grafana/grafana/assets/65417731/d5788dbd-84c5-4b5e-bb71-24ca984451cc">

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
