### PR TITLE
CloudMonitoring: Improve legacy query migrations

### DIFF
--- a/public/app/plugins/datasource/cloud-monitoring/components/QueryEditor.tsx
+++ b/public/app/plugins/datasource/cloud-monitoring/components/QueryEditor.tsx
@@ -21,18 +21,22 @@ export type Props = QueryEditorProps<CloudMonitoringDatasource, CloudMonitoringQ
 export const QueryEditor = (props: Props) => {
   const { datasource, query: oldQ, onRunQuery, onChange, range } = props;
   const [modalIsOpen, setModalIsOpen] = useState<boolean>(false);
-  // Migrate query if needed
-  const [migrated, setMigrated] = useState(false);
+  const [migratedQuery, setMigratedQuery] = useState<CloudMonitoringQuery | undefined>();
   const query = useMemo(() => {
-    if (!migrated) {
-      setMigrated(true);
+    if (!migratedQuery) {
       const migratedQuery = datasource.migrateQuery(oldQ);
+      setMigratedQuery(migratedQuery);
       // Update the query once the migrations have been completed.
       onChange({ ...migratedQuery });
       return migratedQuery;
     }
+
+    if (migratedQuery) {
+      return migratedQuery;
+    }
+
     return oldQ;
-  }, [oldQ, datasource, onChange, migrated]);
+  }, [oldQ, datasource, onChange, migratedQuery]);
   const [currentQuery, setCurrentQuery] = useState<CloudMonitoringQuery>(query);
   const [queryHasBeenEdited, setQueryHasBeenEdited] = useState<boolean>(false);
 

--- a/public/app/plugins/datasource/cloud-monitoring/datasource.test.ts
+++ b/public/app/plugins/datasource/cloud-monitoring/datasource.test.ts
@@ -222,6 +222,37 @@ describe('Cloud Monitoring Datasource', () => {
             sloQuery: {},
           },
         },
+        {
+          description: 'legacy metrics query with metricType defined',
+          input: {
+            refId: 'A',
+            queryType: 'metrics',
+            intervalMs: 1000,
+            metricType: 'test-metric-type',
+          },
+          expected: {
+            queryType: QueryType.TIME_SERIES_LIST,
+            timeSeriesList: {
+              filters: ['metric.type', '=', 'test-metric-type'],
+            },
+          },
+        },
+        {
+          description: 'legacy metrics query with metricType and additional filters defined',
+          input: {
+            refId: 'A',
+            queryType: 'metrics',
+            intervalMs: 1000,
+            metricType: 'test-metric-type',
+            filters: ['test.filter', '=', 'test-filter-value'],
+          },
+          expected: {
+            queryType: QueryType.TIME_SERIES_LIST,
+            timeSeriesList: {
+              filters: ['test.filter', '=', 'test-filter-value', 'AND', 'metric.type', '=', 'test-metric-type'],
+            },
+          },
+        },
       ].forEach((t) =>
         it(t.description, () => {
           const mockInstanceSettings = createMockInstanceSetttings();

--- a/public/app/plugins/datasource/cloud-monitoring/datasource.test.ts
+++ b/public/app/plugins/datasource/cloud-monitoring/datasource.test.ts
@@ -253,6 +253,37 @@ describe('Cloud Monitoring Datasource', () => {
             },
           },
         },
+        {
+          description: 'legacy metrics query without projectName defined',
+          input: {
+            refId: 'A',
+            queryType: 'metrics',
+            intervalMs: 1000,
+            metricType: 'test-metric-type',
+          },
+          expected: {
+            queryType: QueryType.TIME_SERIES_LIST,
+            timeSeriesList: {
+              projectName: 'test-project',
+            },
+          },
+        },
+        {
+          description: 'legacy metrics query with projectName defined',
+          input: {
+            refId: 'A',
+            queryType: 'metrics',
+            intervalMs: 1000,
+            metricType: 'test-metric-type',
+            projectName: 'test-project-defined',
+          },
+          expected: {
+            queryType: QueryType.TIME_SERIES_LIST,
+            timeSeriesList: {
+              projectName: 'test-project-defined',
+            },
+          },
+        },
       ].forEach((t) =>
         it(t.description, () => {
           const mockInstanceSettings = createMockInstanceSetttings();

--- a/public/app/plugins/datasource/cloud-monitoring/datasource.ts
+++ b/public/app/plugins/datasource/cloud-monitoring/datasource.ts
@@ -254,6 +254,8 @@ export default class CloudMonitoringDatasource extends DataSourceWithBackend<
         queryType: type === 'annotationQuery' ? QueryType.ANNOTATION : QueryType.TIME_SERIES_LIST,
         timeSeriesList: {
           ...rest,
+          projectName: get(query, 'projectName') || this.getDefaultProject(),
+          filters,
           view: rest.view || 'FULL',
         },
       };
@@ -270,7 +272,7 @@ export default class CloudMonitoringDatasource extends DataSourceWithBackend<
         query.queryType = QueryType.TIME_SERIES_QUERY;
       } else {
         query.timeSeriesList = {
-          projectName: metricQuery.projectName,
+          projectName: metricQuery.projectName || this.getDefaultProject(),
           crossSeriesReducer: metricQuery.crossSeriesReducer,
           alignmentPeriod: metricQuery.alignmentPeriod,
           perSeriesAligner: metricQuery.perSeriesAligner,

--- a/public/app/plugins/datasource/cloud-monitoring/datasource.ts
+++ b/public/app/plugins/datasource/cloud-monitoring/datasource.ts
@@ -240,6 +240,11 @@ export default class CloudMonitoringDatasource extends DataSourceWithBackend<
       !query.hasOwnProperty('timeSeriesQuery') &&
       !query.hasOwnProperty('timeSeriesList')
     ) {
+      let filters = rest.filters || [];
+      if (rest.metricType) {
+        filters = this.migrateMetricTypeFilter(rest.metricType, filters);
+      }
+
       return {
         datasource,
         key,


### PR DESCRIPTION
There were various issues with the query migrations that take place for Cloud Monitoring (particularly legacy queries).

This PR addresses those by ensuring the backend and frontend migrations are more closely aligned.

- If a project is not defined in the frontend when the migration code is hit, the default project is used to ensure a query is not filtered unexpectedly. This matches the backend logic.
- If a project is defined in a frontend legacy query it will be correctly migrated.
- If the `metricType` property is defined in a legacy query it will be correctly migrated to the `filters` property.

I've also cleaned up the migration effect as I found an edge case where a query would be migrated but then not actually used because another effect being called would wipe out the migrated query.

Also, updated the tests for these cases.

Fixes #70734 (there were two distinct issues in there but they've been bundled into one).