### PR TITLE
Chore: Add jest config to grafana-prometheus

### DIFF
--- a/packages/grafana-prometheus/jest.config.js
+++ b/packages/grafana-prometheus/jest.config.js
@@ -1,0 +1,5 @@
+const sharedConfig = require('../../jest.config.js');
+module.exports = {
+  ...sharedConfig,
+  rootDir: '../../',
+};


### PR DESCRIPTION
**What is this feature?**

Add `jest.config.js` for easy test run on IDEs
i.e
<img width="573" alt="image" src="https://github.com/grafana/grafana/assets/820946/e77340fb-850c-4783-9316-bc46172d96d6">

**Why do we need this feature?**

Better DX

