### PR TITLE
Server: Fix 'server' subcommand double-registration

### DIFF
--- a/pkg/cmd/grafana/main.go
+++ b/pkg/cmd/grafana/main.go
@@ -20,7 +20,18 @@ var buildBranch = "main"
 var buildstamp string
 
 func main() {
-	app := &cli.App{
+	app := MainApp()
+
+	if err := app.Run(os.Args); err != nil {
+		fmt.Printf("%s: %s %s\n", color.RedString("Error"), color.RedString("✗"), err)
+		os.Exit(1)
+	}
+
+	os.Exit(0)
+}
+
+func MainApp() *cli.App {
+	return &cli.App{
 		Name:  "grafana",
 		Usage: "Grafana server and command line interface",
 		Authors: []*cli.Author{
@@ -52,18 +63,10 @@ func main() {
 					return nil
 				},
 			},
-			gsrv.ServerCommand(version, commit, enterpriseCommit, buildBranch, buildstamp),
 		},
 		CommandNotFound:      cmdNotFound,
 		EnableBashCompletion: true,
 	}
-
-	if err := app.Run(os.Args); err != nil {
-		fmt.Printf("%s: %s %s\n", color.RedString("Error"), color.RedString("✗"), err)
-		os.Exit(1)
-	}
-
-	os.Exit(0)
 }
 
 func cmdNotFound(c *cli.Context, command string) {

--- a/pkg/cmd/grafana/main_test.go
+++ b/pkg/cmd/grafana/main_test.go
@@ -1,0 +1,16 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestMainApp_NoDuplicateSubcommands(t *testing.T) {
+	app := MainApp()
+	found := map[string]bool{}
+	for _, cmd := range app.Commands {
+		require.False(t, found[cmd.Name], "command %q registered twice", cmd.Name)
+		found[cmd.Name] = true
+	}
+}


### PR DESCRIPTION
**Which issue(s) does this PR fix?**:

Fixes #86082 by removing the errant second registration for the `server` subcommand. Also adds a unit test to ensure subcommands are unique.

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
