### PR TITLE
DashboardScene: Fixes issue moving between dashboards

### DIFF
--- a/public/app/features/dashboard-scene/pages/DashboardScenePage.tsx
+++ b/public/app/features/dashboard-scene/pages/DashboardScenePage.tsx
@@ -74,7 +74,7 @@ export function DashboardScenePage({ match, route, queryParams, history }: Props
 
   return (
     <>
-      <dashboard.Component model={dashboard} />
+      <dashboard.Component model={dashboard} key={dashboard.state.key} />
       <DashboardPrompt dashboard={dashboard} />
     </>
   );


### PR DESCRIPTION
Fixes https://github.com/grafana/grafana/issues/85925 

While debugging / troubleshooting #85925 I found a strange thing where the new dashboard was rendered before the state model for it was activated, tracked it down to not setting key when rendering dashboard.Component, the key is important so that the SceneComponentWrapper get's unmounted and it's internal activate state is reset. 

Fix in scenes so that this type of bug cannot happen even when the key property has not been set:
https://github.com/grafana/scenes/pull/692

