### PR TITLE
Fix Canvas crashing in scenes dashboard

### DIFF
--- a/public/app/plugins/panel/canvas/module.tsx
+++ b/public/app/plugins/panel/canvas/module.tsx
@@ -66,7 +66,7 @@ export const plugin = new PanelPlugin<Options>(CanvasPanel)
 
     addStandardCanvasEditorOptions(builder);
 
-    if (state) {
+    if (state && state.scene) {
       builder.addNestedOptions(getLayerEditor(state));
 
       const selection = state.selected;


### PR DESCRIPTION
The Canvas panel crashes in scenes powered dashboards when entering edit mode. This is because we populate the instance state with an extra `legacyPanelId` for backwards compatibility. When `getLayerEditor` is called it assumes that the canvas scene exists and thus crashes, because the state is indeed populated, but only by that id. 

This PR fixes the issue by checking if the canvas scene exists before getting the layer editor.