### PR TITLE
Alerting: Take receivers into account when custom grouping Alertmanager groups

### DIFF
--- a/public/app/features/alerting/unified/AlertGroups.test.tsx
+++ b/public/app/features/alerting/unified/AlertGroups.test.tsx
@@ -1,4 +1,4 @@
-import { render, waitFor } from '@testing-library/react';
+import { render, waitFor, waitForElementToBeRemoved } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import React from 'react';
 import { TestProvider } from 'test/helpers/TestProvider';
@@ -56,6 +56,7 @@ const ui = {
   groupByContainer: byTestId('group-by-container'),
   groupByInput: byRole('combobox', { name: /group by label keys/i }),
   clearButton: byRole('button', { name: 'Clear filters' }),
+  loadingIndicator: byText('Loading notifications'),
 };
 
 describe('AlertGroups', () => {
@@ -66,20 +67,24 @@ describe('AlertGroups', () => {
       AccessControlAction.AlertingInstancesExternalRead,
       AccessControlAction.AlertingRuleRead,
     ]);
-
-    mocks.api.fetchAlertGroups.mockImplementation(() => {
-      return Promise.resolve([
-        mockAlertGroup({ labels: {}, alerts: [mockAlertmanagerAlert({ labels: { foo: 'bar' } })] }),
-        mockAlertGroup(),
-      ]);
-    });
   });
 
   beforeEach(() => {
     setDataSourceSrv(new MockDataSourceSrv(dataSources));
   });
 
+  afterEach(() => {
+    mocks.api.fetchAlertGroups.mockClear();
+  });
+
   it('loads and shows groups', async () => {
+    mocks.api.fetchAlertGroups.mockImplementation(() => {
+      return Promise.resolve([
+        mockAlertGroup({ labels: {}, alerts: [mockAlertmanagerAlert({ labels: { foo: 'bar' } })] }),
+        mockAlertGroup(),
+      ]);
+    });
+
     renderAmNotifications();
 
     await waitFor(() => expect(mocks.api.fetchAlertGroups).toHaveBeenCalled());
@@ -105,9 +110,12 @@ describe('AlertGroups', () => {
         mockAlertGroup({
           labels: { region },
           alerts: [
-            mockAlertmanagerAlert({ labels: { region, appName: 'billing', env: 'production' } }),
-            mockAlertmanagerAlert({ labels: { region, appName: 'auth', env: 'staging', uniqueLabel: 'true' } }),
-            mockAlertmanagerAlert({ labels: { region, appName: 'frontend', env: 'production' } }),
+            mockAlertmanagerAlert({ fingerprint: '1', labels: { region, appName: 'billing', env: 'production' } }),
+            mockAlertmanagerAlert({
+              fingerprint: '2',
+              labels: { region, appName: 'auth', env: 'staging', uniqueLabel: 'true' },
+            }),
+            mockAlertmanagerAlert({ fingerprint: '3', labels: { region, appName: 'frontend', env: 'production' } }),
           ],
         })
       );
@@ -159,6 +167,33 @@ describe('AlertGroups', () => {
     expect(groups).toHaveLength(2);
     expect(groups[0]).toHaveTextContent('No grouping');
     expect(groups[1]).toHaveTextContent('uniqueLabeltrue');
+  });
+
+  it('should split custom grouping groups with the same label by receiver', async () => {
+    // The same alert is repeated in two groups with different receivers
+    const alert = mockAlertmanagerAlert({
+      fingerprint: '1',
+      labels: { region: 'NASA', appName: 'billing' },
+      receivers: [{ name: 'slack' }, { name: 'email' }],
+    });
+    const amGroups = [
+      mockAlertGroup({ receiver: { name: 'slack' }, labels: { region: 'NASA' }, alerts: [alert] }),
+      mockAlertGroup({ receiver: { name: 'email' }, labels: { region: 'NASA' }, alerts: [alert] }),
+    ];
+    mocks.api.fetchAlertGroups.mockResolvedValue(amGroups);
+
+    const user = userEvent.setup();
+
+    renderAmNotifications();
+    await waitForElementToBeRemoved(ui.loadingIndicator.query());
+
+    await user.type(ui.groupByInput.get(), 'appName{enter}');
+
+    const groups = await ui.group.findAll();
+
+    expect(groups).toHaveLength(2);
+    expect(groups[0]).toHaveTextContent('appNamebillingDelivered to slack');
+    expect(groups[1]).toHaveTextContent('appNamebillingDelivered to email');
   });
 
   it('should combine multiple ungrouped groups', async () => {

--- a/public/app/plugins/datasource/alertmanager/types.ts
+++ b/public/app/plugins/datasource/alertmanager/types.ts
@@ -217,11 +217,7 @@ export type AlertmanagerAlert = {
   generatorURL?: string;
   labels: { [key: string]: string };
   annotations: { [key: string]: string };
-  receivers: [
-    {
-      name: string;
-    },
-  ];
+  receivers: Array<{ name: string }>;
   fingerprint: string;
   status: {
     state: AlertState;


### PR DESCRIPTION
**What is this feature?**
This PR fixes custom grouping behavior for Alertmanager alert groups
It unified how groups are display for custom and default grouping modes

**Why do we need this feature?**
Users are confused seeing duplicated alerts 

**Who is this feature for?**
All users

**Special notes for your reviewer:**

**BEFORE**
![image](https://github.com/grafana/grafana/assets/6293563/7919f9bb-73b8-48e0-9198-e91ddacb3916)

**AFTER**
![image](https://github.com/grafana/grafana/assets/6293563/2592a33c-f040-4a77-ad5e-8508279cab43)


Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
