### PR TITLE
Chore: `ActionRow` - Replace `HorizontalGroup` with `Stack`

### DIFF
--- a/.betterer.results
+++ b/.betterer.results
@@ -4039,9 +4039,8 @@ exports[`better eslint`] = {
       [0, 0, 0, "\'VerticalGroup\' import from \'@grafana/ui\' is restricted from being used by a pattern. Use Stack component instead.", "0"]
     ],
     "public/app/features/search/page/components/ActionRow.tsx:5381": [
-      [0, 0, 0, "\'HorizontalGroup\' import from \'@grafana/ui\' is restricted from being used by a pattern. Use Stack component instead.", "0"],
-      [0, 0, 0, "Styles should be written using objects.", "1"],
-      [0, 0, 0, "Styles should be written using objects.", "2"]
+      [0, 0, 0, "Styles should be written using objects.", "0"],
+      [0, 0, 0, "Styles should be written using objects.", "1"]
     ],
     "public/app/features/search/page/components/SearchResultsTable.tsx:5381": [
       [0, 0, 0, "Styles should be written using objects.", "0"],

--- a/public/app/features/search/page/components/ActionRow.tsx
+++ b/public/app/features/search/page/components/ActionRow.tsx
@@ -3,7 +3,7 @@ import React, { FormEvent } from 'react';
 
 import { GrafanaTheme2, SelectableValue } from '@grafana/data';
 import { config } from '@grafana/runtime';
-import { Button, Checkbox, HorizontalGroup, RadioButtonGroup, useStyles2 } from '@grafana/ui';
+import { Button, Checkbox, Stack, RadioButtonGroup, useStyles2 } from '@grafana/ui';
 import { SortPicker } from 'app/core/components/Select/SortPicker';
 import { TagFilter, TermCount } from 'app/core/components/TagFilter/TagFilter';
 import { t, Trans } from 'app/core/internationalization';
@@ -77,7 +77,7 @@ export const ActionRow = ({
 
   return (
     <div className={styles.actionRow}>
-      <HorizontalGroup spacing="md" width="auto">
+      <Stack gap={2} alignItems="center">
         <TagFilter isClearable={false} tags={state.tag} tagOptions={getTagOptions} onChange={onTagFilterChange} />
         {config.featureToggles.panelTitleSearch && (
           <Checkbox
@@ -110,9 +110,9 @@ export const ActionRow = ({
             Panel: {state.panel_type}
           </Button>
         )}
-      </HorizontalGroup>
+      </Stack>
 
-      <HorizontalGroup spacing="md" width="auto">
+      <Stack gap={2}>
         {!hideLayout && (
           <RadioButtonGroup
             options={getLayoutOptions()}
@@ -128,7 +128,7 @@ export const ActionRow = ({
           placeholder={sortPlaceholder || t('search.actions.sort-placeholder', 'Sort')}
           isClearable
         />
-      </HorizontalGroup>
+      </Stack>
     </div>
   );
 };


### PR DESCRIPTION
**What is this feature?**
This is part of the epic https://github.com/grafana/grafana/issues/85510

**Why do we need this feature?**
To replace deprecated layout components with new ones.

**Who is this feature for?**
Everybody

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

**Before:**
![Captura de pantalla 2024-04-15 a las 15 22 32](https://github.com/grafana/grafana/assets/65417731/944ab09e-7f18-421f-90dc-09ca5c508f86)


**After:** 
![Captura de pantalla 2024-04-15 a las 15 22 19](https://github.com/grafana/grafana/assets/65417731/4a0f13c8-7a73-45fb-bd2d-d3593a31f912)

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
