### PR TITLE
[v11.0.x] docs: updates to stat panel documentation

### DIFF
--- a/docs/sources/panels-visualizations/visualizations/stat/index.md
+++ b/docs/sources/panels-visualizations/visualizations/stat/index.md
@@ -21,10 +21,6 @@ weight: 100
 
 # Stat
 
-Stats show one large stat value with an optional graph sparkline. You can control the background or value color using thresholds or overrides.
-
-{{< figure src="/static/img/docs/v66/stat_panel_dark3.png" max-width="1025px" caption="Stat visualization" >}}
-
 {{% admonition type="note" %}}
 This visualization replaces the Singlestat visualization, which was deprecated in Grafana 7.0 and removed in Grafana 8.0.
 {{% /admonition %}}
@@ -94,11 +90,7 @@ By default, a stat displays one of the following:
 - Just the value for a single series or field.
 - Both the value and name for multiple series or fields.
 
-You can use the **Text mode** to control how the text is displayed.
-
-Example screenshot:
-
-{{< figure src="/static/img/docs/v71/stat-panel-text-modes.png" max-width="1025px" caption="Stat visualization" >}}
+You can use the [**Text mode**](#text-mode) to control how the text is displayed.
 
 ## Automatic layout adjustment
 


### PR DESCRIPTION
Backport 34195ba854b167b3a4b2ad9e218124ade9efac56 from #84814

---

**What is this feature?**

Updates to the stat docs to include:
- how to configure a stat panel (to be added as a video)
- supported data formats and example
- when to use a stat panel

**Why do we need this feature?**

To explain to our users how to configure a stat panel easily and when to use it.

**Who is this feature for?**

Grafana OSS and Cloud users

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
