### PR TITLE
Fix error in console on repeated library panel widgets

### DIFF
--- a/public/app/features/dashboard-scene/utils/utils.ts
+++ b/public/app/features/dashboard-scene/utils/utils.ts
@@ -65,12 +65,8 @@ function findVizPanelInternal(scene: SceneObject, key: string | undefined): VizP
   }
 
   const panel = sceneGraph.findObject(scene, (obj) => obj.state.key === key);
-  if (panel) {
-    if (panel instanceof VizPanel) {
-      return panel;
-    } else {
-      throw new Error(`Found panel with key ${key} but it was not a VizPanel`);
-    }
+  if (panel instanceof VizPanel) {
+    return panel;
   }
 
   return null;


### PR DESCRIPTION
When trying to select a library panel from a library panel widget that is repeated by a row it sometimes crashes and throws an error in `findVizPanelInternal`. This stems from the `PanelDataErrorView` that searches for a panel through the `DashboardModelCompatibilityWrapper` which won't find a `VizPanel`, but a `LibraryPanelWidget` and thus throw. This fix avoids throwing errors and just returns null if there is no `VizPanel` with that key.

Fixes https://github.com/grafana/grafana/issues/86158