### PR TITLE
Grafana UI: `StackingEditor` and `addHideFrom` - Replace `HorizontalGroup` with `Stack`

### DIFF
--- a/packages/grafana-ui/src/options/builder/hideSeries.tsx
+++ b/packages/grafana-ui/src/options/builder/hideSeries.tsx
@@ -1,11 +1,11 @@
 import { startCase } from 'lodash';
 import React, { useCallback } from 'react';
+import { Stack } from 'src/components/Layout/Stack/Stack';
 
 import { FieldConfigEditorBuilder, StandardEditorProps } from '@grafana/data';
 import { HideableFieldConfig, HideSeriesConfig } from '@grafana/schema';
 
 import { FilterPill } from '../../components/FilterPill/FilterPill';
-import { HorizontalGroup } from '../../components/Layout/Layout';
 
 const SeriesConfigEditor = ({ value, onChange }: StandardEditorProps<HideSeriesConfig, {}>) => {
   const onChangeToggle = useCallback(
@@ -16,7 +16,7 @@ const SeriesConfigEditor = ({ value, onChange }: StandardEditorProps<HideSeriesC
   );
 
   return (
-    <HorizontalGroup spacing="xs">
+    <Stack gap={0.5}>
       {Object.keys(value).map((k) => {
         const key = k as keyof HideSeriesConfig;
         return (
@@ -29,7 +29,7 @@ const SeriesConfigEditor = ({ value, onChange }: StandardEditorProps<HideSeriesC
           />
         );
       })}
-    </HorizontalGroup>
+    </Stack>
   );
 };
 

--- a/packages/grafana-ui/src/options/builder/hideSeries.tsx
+++ b/packages/grafana-ui/src/options/builder/hideSeries.tsx
@@ -1,11 +1,11 @@
 import { startCase } from 'lodash';
 import React, { useCallback } from 'react';
-import { Stack } from 'src/components/Layout/Stack/Stack';
 
 import { FieldConfigEditorBuilder, StandardEditorProps } from '@grafana/data';
 import { HideableFieldConfig, HideSeriesConfig } from '@grafana/schema';
 
 import { FilterPill } from '../../components/FilterPill/FilterPill';
+import { Stack } from '../../components/Layout/Stack/Stack';
 
 const SeriesConfigEditor = ({ value, onChange }: StandardEditorProps<HideSeriesConfig, {}>) => {
   const onChangeToggle = useCallback(

--- a/packages/grafana-ui/src/options/builder/stacking.tsx
+++ b/packages/grafana-ui/src/options/builder/stacking.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { Stack } from 'src/components/Layout/Stack/Stack';
 
 import {
   FieldConfigEditorBuilder,
@@ -12,7 +13,6 @@ import { GraphFieldConfig, StackingConfig, StackingMode } from '@grafana/schema'
 import { RadioButtonGroup } from '../../components/Forms/RadioButtonGroup/RadioButtonGroup';
 import { IconButton } from '../../components/IconButton/IconButton';
 import { Input } from '../../components/Input/Input';
-import { HorizontalGroup } from '../../components/Layout/Layout';
 import { graphFieldOptions } from '../../components/uPlot/config';
 
 export const StackingEditor = ({
@@ -22,7 +22,7 @@ export const StackingEditor = ({
   item,
 }: StandardEditorProps<StackingConfig, { options: Array<SelectableValue<StackingMode>> }>) => {
   return (
-    <HorizontalGroup>
+    <Stack>
       <RadioButtonGroup
         value={value?.mode || StackingMode.None}
         options={item.settings?.options ?? []}
@@ -47,7 +47,7 @@ export const StackingEditor = ({
           }}
         />
       )}
-    </HorizontalGroup>
+    </Stack>
   );
 };
 

--- a/packages/grafana-ui/src/options/builder/stacking.tsx
+++ b/packages/grafana-ui/src/options/builder/stacking.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import { Stack } from 'src/components/Layout/Stack/Stack';
 
 import {
   FieldConfigEditorBuilder,
@@ -13,6 +12,7 @@ import { GraphFieldConfig, StackingConfig, StackingMode } from '@grafana/schema'
 import { RadioButtonGroup } from '../../components/Forms/RadioButtonGroup/RadioButtonGroup';
 import { IconButton } from '../../components/IconButton/IconButton';
 import { Input } from '../../components/Input/Input';
+import { Stack } from '../../components/Layout/Stack/Stack';
 import { graphFieldOptions } from '../../components/uPlot/config';
 
 export const StackingEditor = ({


### PR DESCRIPTION
**What is this feature?**
This is part of the epic https://github.com/grafana/grafana/issues/85510

**Why do we need this feature?**
To replace deprecated layout components with new ones.

**Who is this feature for?**
Everybody

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
