### PR TITLE
I18N: Fix untranslated descriptions in data source picker

### DIFF
--- a/public/app/features/datasources/components/picker/BuiltInDataSourceList.tsx
+++ b/public/app/features/datasources/components/picker/BuiltInDataSourceList.tsx
@@ -10,14 +10,21 @@ import { useDatasources } from '../../hooks';
 import { DataSourceCard } from './DataSourceCard';
 import { isDataSourceMatch } from './utils';
 
-const CUSTOM_DESCRIPTIONS_BY_UID: Record<string, string> = {
-  grafana: t('data-source-picker.built-in-list.description-grafana', 'Discover visualizations using mock data'),
-  '-- Mixed --': t('data-source-picker.built-in-list.description-mixed', 'Use multiple data sources'),
-  '-- Dashboard --': t(
-    'data-source-picker.built-in-list.description-dashboard',
-    'Reuse query results from other visualizations'
-  ),
-};
+function getCustomDescription(datasourceUid: string) {
+  switch (datasourceUid) {
+    case 'grafana':
+      return t('data-source-picker.built-in-list.description-grafana', 'Discover visualizations using mock data');
+    case '-- Mixed --':
+      return t('data-source-picker.built-in-list.description-mixed', 'Use multiple data sources');
+    case '-- Dashboard --':
+      return t(
+        'data-source-picker.built-in-list.description-dashboard',
+        'Reuse query results from other visualizations'
+      );
+    default:
+      return '';
+  }
+}
 
 interface BuiltInDataSourceListProps {
   className?: string;
@@ -76,7 +83,7 @@ export function BuiltInDataSourceList({
           <DataSourceCard
             key={ds.uid}
             ds={ds}
-            description={CUSTOM_DESCRIPTIONS_BY_UID[ds.uid]}
+            description={getCustomDescription(ds.uid)}
             selected={isDataSourceMatch(ds, current)}
             onClick={() => onChange(ds)}
           />


### PR DESCRIPTION
`t()` should not be called in the root scope of a file as it will attempt to translate the phrase before the translations are actually loaded

PR https://github.com/grafana/grafana/pull/86222 makes this an error to help developers avoid this mistake in the future 😌 