### PR TITLE
I18N: Warn if t() called before init

### DIFF
--- a/public/app/core/internationalization/index.tsx
+++ b/public/app/core/internationalization/index.tsx
@@ -60,9 +60,11 @@ export const Trans: typeof I18NextTrans = (props) => {
 // Wrap t() to provide default namespaces and enforce a consistent API
 export const t = (id: string, defaultMessage: string, values?: Record<string, unknown>) => {
   if (!tFunc) {
-    console.warn(
-      't() was called before i18n was initialized. This is probably caused by calling t() in the root module scope, instead of lazily on render'
-    );
+    if (process.env.NODE_ENV !== 'test') {
+      console.warn(
+        't() was called before i18n was initialized. This is probably caused by calling t() in the root module scope, instead of lazily on render'
+      );
+    }
 
     if (process.env.NODE_ENV === 'development') {
       throw new Error('t() was called before i18n was initialized');

--- a/public/app/core/internationalization/index.tsx
+++ b/public/app/core/internationalization/index.tsx
@@ -39,7 +39,7 @@ export function initializeI18n(language: string): Promise<{ language: string | u
     .use(initReactI18next) // passes i18n down to react-i18next
     .init(options);
 
-  tFunc = tFunc = i18n.t;
+  tFunc = i18n.t;
 
   return loadPromise.then(() => {
     return {


### PR DESCRIPTION
During development, throws an error if `t()` is called before `initializeI18n()` resolves.

During production, this only logs a warning to the console, but phrases won't be translated properly.