### PR TITLE
chore: add missing modowner

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -199,7 +199,7 @@ require (
 	go.mongodb.org/mongo-driver v1.13.1 // indirect
 	go.opencensus.io v0.24.0 // indirect
 	go.uber.org/atomic v1.11.0 // @grafana/alerting-squad-backend
-	go.uber.org/goleak v1.3.0 // @grafana/backend-platform
+	go.uber.org/goleak v1.3.0 // @grafana/grafana-search-and-storage
 	golang.org/x/sys v0.18.0 // indirect
 	golang.org/x/text v0.14.0 // @grafana/backend-platform
 	golang.org/x/xerrors v0.0.0-20231012003039-104605ab7028 // indirect

--- a/go.mod
+++ b/go.mod
@@ -199,7 +199,7 @@ require (
 	go.mongodb.org/mongo-driver v1.13.1 // indirect
 	go.opencensus.io v0.24.0 // indirect
 	go.uber.org/atomic v1.11.0 // @grafana/alerting-squad-backend
-	go.uber.org/goleak v1.3.0 // indirect
+	go.uber.org/goleak v1.3.0 // @grafana/backend-platform
 	golang.org/x/sys v0.18.0 // indirect
 	golang.org/x/text v0.14.0 // @grafana/backend-platform
 	golang.org/x/xerrors v0.0.0-20231012003039-104605ab7028 // indirect


### PR DESCRIPTION
## Motivation

As of #84657, `go.uber.org/goleak` is now a direct dependency (see [`pkg/util/ring/adaptive_chan_test.go`](https://github.com/grafana/grafana/pull/84657/files#diff-5e069fb74833198e4d9934b79a45b445375f16b741e535005030bced20007cb0)).

## What does this PR do?

This PR adds a [modowner](https://github.com/grafana/grafana/blob/main/scripts/modowners/README.md) (@grafana/grafana-search-and-storage).