### PR TITLE
Explore: Deprecate local storage singular datasource key

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -384,6 +384,7 @@ playwright.config.ts @grafana/plugins-platform-frontend
 /public/app/core/components/TimeSeries/ @grafana/dataviz-squad
 /public/app/core/components/TimelineChart/ @grafana/dataviz-squad
 /public/app/core/components/Form/ @grafana/grafana-frontend-platform
+/public/app/core/history/ @grafana/explore-squad
 /public/app/features/all.ts @grafana/grafana-frontend-platform
 /public/app/features/admin/ @grafana/identity-access-team
 

--- a/public/app/core/history/richHistoryLocalStorageUtils.ts
+++ b/public/app/core/history/richHistoryLocalStorageUtils.ts
@@ -94,7 +94,7 @@ export const sortQueries = (array: RichHistoryQuery[], sortOrder: SortOrder) => 
 export const RICH_HISTORY_SETTING_KEYS = {
   retentionPeriod: 'grafana.explore.richHistory.retentionPeriod',
   starredTabAsFirstTab: 'grafana.explore.richHistory.starredTabAsFirstTab',
-  legacyActiveDatasourceOnly: 'grafana.explore.richHistory.activeDatasourceOnly',
+  legacyActiveDatasourceOnly: 'grafana.explore.richHistory.activeDatasourceOnly', // @deprecated
   activeDatasourcesOnly: 'grafana.explore.richHistory.activeDatasourcesOnly',
   datasourceFilters: 'grafana.explore.richHistory.datasourceFilters',
 };


### PR DESCRIPTION
**What is this feature?**

During https://github.com/grafana/grafana/pull/84321, we refactored the query history drawer to extend over both panes of Explore, instead of having one instance in each pane. Because of this, we refactored the internals to assume multiple datasources, instead of being constrained to one root datasource per pane. We also changed every variable that referred to a singular "datasource" to more accurately refer to "datasources", which included a key that would pull data from local storage. At the time, we didn't want to break how people accessed existing saved data, so we kept the key to the singular-datasource, but changed the internal identifier that marked it as a "legacy" usage ([src](https://github.com/grafana/grafana/pull/84321/files#diff-117903b133a88ecc381b9da1df7f23c256a2f9e2841ea05336559cc990fab0c8R97)). Data would be written to the new location, and read from both the new and old locations.

This PR begins the process of deprecating this key and fully removing the old location. 

The impact of this should be nothing as long as the user upgrades Grafana on a regular basis. Although every user will be impacted, query history data is stored for a maximum of 2 weeks regardless of method of storage, and the deprecation period will be longer than that. **As long as the user waits at at least 2 weeks between getting 11.1 where we change the key and the update where we remove the key, any data they would lose access to would have been deleted by cleanup.** Any query data saved after the variable was marked as legacy is stored in the new location and will not be affected.

### How data retention works in local storage

**Query History enabled - database used**
These users still use local storage for autocomplete. However, the autocomplete feature will run a clean up every time a query is added ([src](https://github.com/grafana/grafana/blob/main/public/app/core/history/RichHistoryLocalStorage.ts#L62)) and the cleanup will delete queries that are older than 7 days ([src](https://github.com/grafana/grafana/blob/main/public/app/core/history/RichHistoryLocalStorage.ts#L132)). The retention period cannot be changed when this is enabled (Dropdown will only show when supportedFeatures().changeRetention is true [src](https://github.com/grafana/grafana/blob/main/public/app/features/explore/RichHistory/RichHistorySettingsTab.tsx#L92) and that is only true when query history is disabled [src](https://github.com/grafana/grafana/blob/main/public/app/core/history/richHistoryStorageProvider.ts#L47)).

**Query history disabled - local storage used**
A retention period can be edited, but the maximum retention period is 2 weeks ([src](https://github.com/grafana/grafana/blob/main/public/app/features/explore/RichHistory/RichHistorySettingsTab.tsx#L46)).

**Why do we need this feature?**

To not have to maintain two locations for queries in local storage, when one is increasingly likely to not be used.

**Who is this feature for?**

Users looking to be notified of deprecations.

**Which issue(s) does this PR fix?**:

Fixes #86249 

# Deprecation notice
The `grafana.explore.richHistory.activeDatasourceOnly` local storage key is deprecated, and will be removed in Grafana 12. You may experience loss of your Explore query history or autocomplete data if you upgrade to Grafana 12 under 2 weeks of Grafana 11.1. Actual risk of data loss depends on your query history retention policy.