### PR TITLE
SSOSettings SAML: Move SAML definition

### DIFF
--- a/pkg/login/social/saml.go
+++ b/pkg/login/social/saml.go
@@ -1,0 +1,65 @@
+package social
+
+import (
+	"crypto"
+	"crypto/x509"
+	"fmt"
+	"text/template"
+	"time"
+
+	"github.com/crewjam/saml"
+	"github.com/grafana/grafana/pkg/services/org"
+)
+
+// Config holds needed configuration options to enable Grafana to act as a SAML Service Provider (SP)
+//
+// SAML SPs use asymmetric encryption in order to exchange information with the IdP, per the AES
+// we need both a public (Certificate) and a private part (PrivateKey).
+//
+// The IdP metadata lets the SP know how to communicate and where to send the requests to.
+//
+// MaxIssueDelay is specified in seconds and helps prevent SAML assertions replays
+type SAMLInfo struct {
+	AllowIdPInitiated        bool                              `json:"allow_id_p_initiated"`
+	AllowSignup              bool                              `json:"allow_signup"`
+	AllowedOrganizations     []string                          `json:"allowed_organizations"`
+	Certificate              *x509.Certificate                 `json:"certificate"`
+	Enabled                  bool                              `json:"enabled"`
+	IdentityProviderMetadata func() ([]byte, error)            `json:"-"`
+	Mapping                  *AssertionMapping                 `json:"mapping"`
+	MaxIssueDelay            time.Duration                     `json:"max_issue_delay"`
+	MetadataValidDuration    time.Duration                     `json:"metadata_valid_duration"`
+	NameIDFormat             saml.NameIDFormat                 `json:"name_id_format"`
+	OrgMapping               map[string]map[int64]org.RoleType `json:"org_mapping"`
+	PrivateKey               *crypto.PrivateKey                `json:"-"`
+	RelayState               string                            `json:"relay_state"`
+	RoleValuesAdmin          []string                          `json:"role_values_admin"`
+	RoleValuesEditor         []string                          `json:"role_values_editor"`
+	RoleValuesGrafanaAdmin   []string                          `json:"role_values_grafana_admin"`
+	RoleValuesNone           []string                          `json:"role_values_none"`
+	SignatureAlgorithm       string                            `json:"signature_algorithm"`
+	SingleLogoutEnabled      bool                              `json:"single_logout_enabled"`
+	SkipOrgRoleSync          bool                              `json:"skip_org_role_sync"`
+}
+
+// AssertionMapping holds the details of how to map the user information from the SAML assertion
+type AssertionMapping struct {
+	Name         string
+	NameTemplate *template.Template
+	Login        string
+	Email        string
+	Role         string
+	Groups       string
+	Org          string
+}
+
+// String coerces the assertion mapping values to a string-like format
+func (am *AssertionMapping) String() string {
+	return fmt.Sprintf("name=%s,login=%s,email=%s,role=%s,groups=%s,org=%s", am.Name, am.Login, am.Email, am.Role, am.Groups, am.Org)
+}
+
+// Helper function that returns whether SAML assertions are using a template for name;
+// If false, it means the `AssertionMapping.Name` property is set
+func (am *AssertionMapping) HasNameTemplate() bool {
+	return am.NameTemplate != nil
+}

--- a/pkg/services/ssosettings/validation/saml_validators.go
+++ b/pkg/services/ssosettings/validation/saml_validators.go
@@ -1,0 +1,153 @@
+package validation
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/crewjam/saml"
+	"github.com/grafana/grafana/pkg/login/social"
+	"github.com/grafana/grafana/pkg/models/roletype"
+	"github.com/grafana/grafana/pkg/services/auth/identity"
+	"github.com/grafana/grafana/pkg/services/ssosettings"
+	"github.com/grafana/grafana/pkg/util/errutil"
+	"golang.org/x/text/cases"
+	"golang.org/x/text/language"
+)
+
+var (
+	ErrInvalidSamlConfig = errutil.ValidationFailed("sso.saml.settings")
+	ErrInvalidSAMLConfig = func(msg string) error {
+		base := ErrInvalidSamlConfig.Errorf("Invalid SAML settings")
+		base.PublicMessage = msg
+		return base
+	}
+	ErrInvalidSAMLConfigEmpty = ErrInvalidSAMLConfig("No SAML configuration was provided")
+)
+
+// ValidateSAMLMap validates the SAML settings map before being converted into
+// a SAMLInfo struct.
+func ValidateSAMLMap(info *map[string]any, requester identity.Requester, validators ...ssosettings.ValidateFunc[map[string]any]) error {
+	for _, validatorFunc := range validators {
+		if err := validatorFunc(info, requester); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// ValidateSAMLInfo validates the SAML settings struct before being saved to the
+// database.
+func ValidateSAMLInfo(info *social.SAMLInfo, requester identity.Requester, validators ...ssosettings.ValidateFunc[social.SAMLInfo]) error {
+	for _, validatorFunc := range validators {
+		if err := validatorFunc(info, requester); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// Required only one field needed
+// This functions is meant to be used with the required 1 of the SAML setting
+// options.
+//
+// This includes
+// - idp_metadata
+// - idp_metadata_url
+// - idp_metadata_path
+// - certificate
+// - certificate_path
+// - private_key
+// - private_key_path
+func RequireOnlyOne(value string) ssosettings.ValidateFunc[map[string]any] {
+	return func(info *map[string]any, _ identity.Requester) error {
+		// Check if info pointer is nil
+		if info == nil {
+			return ErrInvalidSAMLConfigEmpty
+		}
+		var count int
+
+		_, valueOk := (*info)[value]
+		_, valuePath := (*info)[fmt.Sprintf("%s_path", value)]
+		_, valueURL := (*info)[fmt.Sprintf("%s_url", value)]
+
+		if valueOk {
+			count++
+		}
+		if valuePath {
+			count++
+		}
+		if valueURL {
+			count++
+		}
+
+		if count == 0 {
+			return ErrInvalidSAMLConfig(fmt.Sprintf("No value for key `%s` was provided", value))
+		}
+
+		if count != 1 {
+			return ErrInvalidSAMLConfig(fmt.Sprintf("Too many options have been provided for the `%s` key", value))
+		}
+
+		return nil
+	}
+}
+
+func RequiredIdpMetadata(getIdPMetadata func(cfg *social.SAMLInfo) (*saml.EntityDescriptor, error)) ssosettings.ValidateFunc[social.SAMLInfo] {
+	if getIdPMetadata == nil {
+		return func(_ *social.SAMLInfo, _ identity.Requester) error {
+			return ErrInvalidSAMLConfig("getIdPMetadata function is not provided")
+		}
+	}
+	return func(info *social.SAMLInfo, _ identity.Requester) error {
+		_, err := getIdPMetadata(info)
+		if err != nil {
+			return ErrInvalidSAMLConfig(fmt.Sprintf("Failed to get IdP metadata: %s", err))
+		}
+		return nil
+	}
+}
+
+func RequireNoHigherRole() ssosettings.ValidateFunc[map[string]any] {
+	return func(info *map[string]any, requester identity.Requester) error {
+		if info == nil {
+			return ErrInvalidSAMLConfigEmpty
+		}
+
+		if requester.GetIsGrafanaAdmin() {
+			return nil
+		}
+
+		_, ok := (*info)["role_values_grafana_admin"]
+		if ok {
+			return ErrInvalidSAMLConfig("Changes to Grafana Admin role can only be made by a Grafana Admin")
+		}
+
+		caser := cases.Title(language.English)
+		for key := range *info {
+
+			role := strings.TrimPrefix(key, "role_values_")
+			if role == "admin" {
+				return ErrInvalidSAMLConfig("Changes to Admin role 'role_values_grafana_admin' can onle be made by a Grafana Admin")
+			}
+
+			if !strings.HasPrefix(key, "role_values_") {
+				continue
+			}
+
+			roleType := roletype.RoleType(caser.String(role))
+			if !roleType.IsValid() {
+				return ErrInvalidSAMLConfig(fmt.Sprintf("The role %s cannot be configured", role))
+			}
+
+			if !requester.GetOrgRole().Includes(roleType) {
+				return ErrInvalidSAMLConfig(fmt.Sprintf("Can't set %s role in key %s", roleType, key))
+			}
+		}
+
+		if _, ok = (*info)["org_mapping"]; ok {
+			return ErrInvalidSAMLConfig("Changes to org mapping can only be performed by a Grafana Admin")
+		}
+
+		return nil
+	}
+}

--- a/pkg/services/ssosettings/validation/saml_validators_test.go
+++ b/pkg/services/ssosettings/validation/saml_validators_test.go
@@ -1,0 +1,265 @@
+package validation
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/crewjam/saml"
+	"github.com/grafana/grafana/pkg/login/social"
+	"github.com/grafana/grafana/pkg/models/roletype"
+	"github.com/grafana/grafana/pkg/services/auth/identity"
+	"github.com/grafana/grafana/pkg/services/ssosettings"
+	"github.com/grafana/grafana/pkg/services/user"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestValidateSAMLMap(t *testing.T) {
+	configuration := map[string]any{}
+	testCases := []struct {
+		name      string
+		functions []ssosettings.ValidateFunc[map[string]any]
+		error     error
+	}{
+		{
+			name: "should not return error with no validator functions",
+		},
+		{
+			name: "should not return error when running a successul validation function",
+			functions: []ssosettings.ValidateFunc[map[string]any]{
+				func(configuration *map[string]any, requester identity.Requester) error {
+					return nil
+				},
+			},
+		},
+		{
+			name: "should return error when running a failed validation function",
+			functions: []ssosettings.ValidateFunc[map[string]any]{
+				func(configuration *map[string]any, requester identity.Requester) error {
+					return ErrInvalidSAMLConfig("error")
+				},
+			},
+			error: ErrInvalidSAMLConfig("error"),
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.error, ValidateSAMLMap(&configuration, nil, tc.functions...))
+		})
+	}
+}
+
+func TestValidateSAMLInfo(t *testing.T) {
+	configuration := &social.SAMLInfo{}
+	testCases := []struct {
+		name      string
+		functions []ssosettings.ValidateFunc[social.SAMLInfo]
+		error     error
+	}{
+		{
+			name: "should not return error with no validator functions",
+		},
+		{
+			name: "should not return error when running a successul validation function",
+			functions: []ssosettings.ValidateFunc[social.SAMLInfo]{
+				func(configuration *social.SAMLInfo, requester identity.Requester) error {
+					return nil
+				},
+			},
+		},
+		{
+			name: "should return error when running a failed validation function",
+			functions: []ssosettings.ValidateFunc[social.SAMLInfo]{
+				func(configuration *social.SAMLInfo, requester identity.Requester) error {
+					return ErrInvalidSAMLConfig("error")
+				},
+			},
+			error: ErrInvalidSAMLConfig("error"),
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.error, ValidateSAMLInfo(configuration, nil, tc.functions...))
+		})
+	}
+}
+
+func TestRequireOnlyOne(t *testing.T) {
+	testCases := []struct {
+		name          string
+		configuration map[string]any
+		key           string
+		error         error
+	}{
+		{
+			name:  "should return error when no value is provided",
+			key:   "idp_metadata",
+			error: ErrInvalidSAMLConfig("No value for key `idp_metadata` was provided"),
+		},
+		{
+			name: "should return error when multiple values are provided",
+			key:  "idp_metadata",
+			configuration: map[string]any{
+				"idp_metadata":      "value",
+				"idp_metadata_path": "value",
+			},
+			error: ErrInvalidSAMLConfig("Too many options have been provided for the `idp_metadata` key"),
+		},
+		{
+			name: "should not return error when only one value is provided",
+			key:  "idp_metadata",
+			configuration: map[string]any{
+				"idp_metadata": "value",
+			},
+		},
+		{
+			name: "should not return error when only one value path is provided",
+			key:  "idp_metadata",
+			configuration: map[string]any{
+				"idp_metadata_path": "value",
+			},
+		},
+		{
+			name: "should not return error when only one value url is provided",
+			key:  "idp_metadata",
+			configuration: map[string]any{
+				"idp_metadata_url": "value",
+			},
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := ValidateSAMLMap(&tc.configuration, nil, RequireOnlyOne(tc.key))
+			assert.Equal(t, tc.error, err)
+		})
+	}
+}
+
+func TestRequireOnlyOneEmptyMap(t *testing.T) {
+	err := ValidateSAMLMap(nil, nil, RequireOnlyOne("idp_metadata"))
+	assert.Equal(t, ErrInvalidSAMLConfigEmpty, err)
+}
+
+func TestRequiredIdpMetadata(t *testing.T) {
+	testCases := []struct {
+		name          string
+		configuration social.SAMLInfo
+		key           string
+		err           error
+		mockFunction  func(cfg *social.SAMLInfo) (*saml.EntityDescriptor, error)
+	}{
+		{
+			name:         "should return error when idp metadata function is not found",
+			mockFunction: nil,
+			err:          ErrInvalidSAMLConfig("getIdPMetadata function is not provided"),
+		},
+		{
+			name: "should return error when idp metadata function returns an error",
+			mockFunction: func(cfg *social.SAMLInfo) (*saml.EntityDescriptor, error) {
+				return nil, errors.New("random error")
+			},
+			err: ErrInvalidSAMLConfig("Failed to get IdP metadata: random error"),
+		},
+		{
+			name: "should not return error when idp metadata function returns no error",
+			mockFunction: func(cfg *social.SAMLInfo) (*saml.EntityDescriptor, error) {
+				return &saml.EntityDescriptor{}, nil
+			},
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := ValidateSAMLInfo(&tc.configuration, nil, RequiredIdpMetadata(tc.mockFunction))
+			assert.Equal(t, tc.err, err)
+		})
+	}
+}
+
+func TestRequireNoHigherRole(t *testing.T) {
+	testCases := []struct {
+		name          string
+		requester     identity.Requester
+		configuration map[string]any
+		key           string
+		err           error
+	}{
+		{
+			name: "should not return error when the requester is a Grafana Admin",
+			requester: &user.SignedInUser{
+				IsGrafanaAdmin: true,
+			},
+		},
+		{
+			name: "should return error when requesting to change the Grafana Admin Role",
+			configuration: map[string]any{
+				"role_values_grafana_admin": "editor",
+			},
+			err: ErrInvalidSAMLConfig("Changes to Grafana Admin role can only be made by a Grafana Admin"),
+		},
+		{
+			name: "should ignore configuration keys that don't start with role_values_",
+			configuration: map[string]any{
+				"roles_values_grafana_admin": "editor",
+				"enable":                     true,
+				"idp_metadata":               "value",
+				"max_auth_age":               3600,
+			},
+		},
+		{
+			name: "should return error when requesting to change the Admin Role",
+			configuration: map[string]any{
+				"role_values_admin": "editor",
+			},
+			err: ErrInvalidSAMLConfig("Changes to Admin role 'role_values_grafana_admin' can onle be made by a Grafana Admin"),
+		},
+		{
+			name: "should return error when trying to configure a non-valid role",
+			configuration: map[string]any{
+				"role_values_random": "editor",
+			},
+			err: ErrInvalidSAMLConfig("The role random cannot be configured"),
+		},
+		{
+			name: "should fail when setting a role higher than the requester",
+			requester: &user.SignedInUser{
+				OrgRole: roletype.RoleViewer,
+			},
+			configuration: map[string]any{
+				"role_values_editor": "admin",
+			},
+			err: ErrInvalidSAMLConfig("Can't set Editor role in key role_values_editor"),
+		},
+		{
+			name: "should not return error when setting a role lower than the requester",
+			requester: &user.SignedInUser{
+				OrgRole: roletype.RoleEditor,
+			},
+			configuration: map[string]any{
+				"role_values_viewer": "editor",
+			},
+		},
+		{
+			name: "",
+			requester: &user.SignedInUser{
+				OrgRole: roletype.RoleAdmin,
+			},
+			configuration: map[string]any{
+				"org_mapping": "*:*:Admin",
+			},
+			err: ErrInvalidSAMLConfig("Changes to org mapping can only be performed by a Grafana Admin"),
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			if tc.requester == nil {
+				tc.requester = &user.SignedInUser{}
+			}
+			err := ValidateSAMLMap(&tc.configuration, tc.requester, RequireNoHigherRole())
+			assert.Equal(t, tc.err, err)
+		})
+	}
+}
+
+func TestRequireNoHigherRoleEmptyMap(t *testing.T) {
+	err := ValidateSAMLMap(nil, nil, RequireNoHigherRole())
+	assert.Equal(t, ErrInvalidSAMLConfigEmpty, err)
+}


### PR DESCRIPTION
**What is this feature?**

Implements the configuration struct needed for SAML configuration parameters.

Enterprise PR: https://github.com/grafana/grafana-enterprise/pull/6480

**Why do we need this feature?**

Upon developing SSO settings validations for SAML configuration, there's a circular dependency. By moving the definition of the SAML configuration from the Enterprise repo to the OSS repo, we avoid this circular dependency.

**Who is this feature for?**

IAM

**Which issue(s) does this PR fix?**:

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
