### PR TITLE
Tempo: Add `waitFor` in flaky test

### DIFF
--- a/public/app/plugins/datasource/tempo/VariableQueryEditor.test.tsx
+++ b/public/app/plugins/datasource/tempo/VariableQueryEditor.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import React from 'react';
 
@@ -55,7 +55,14 @@ describe('TempoVariableQueryEditor', () => {
     expect(onChange).not.toHaveBeenCalled();
     render(<TempoVariableQueryEditor {...props} onChange={onChange} />);
 
+    // Select the query type ('Label values')
     await selectOptionInTest(screen.getByLabelText('Query type'), 'Label values');
+    await userEvent.click(document.body);
+
+    // Ensure the Label field is shown after selecting the query type
+    await waitFor(() => expect(screen.getByLabelText('Label')).toBeInTheDocument());
+
+    // Select the label value
     await selectOptionInTest(screen.getByLabelText('Label'), 'luna');
     await userEvent.click(document.body);
 

--- a/public/app/plugins/datasource/tempo/VariableQueryEditor.test.tsx
+++ b/public/app/plugins/datasource/tempo/VariableQueryEditor.test.tsx
@@ -58,7 +58,7 @@ describe('TempoVariableQueryEditor', () => {
     await selectOptionInTest(screen.getByLabelText('Query type'), 'Label values');
     await userEvent.click(document.body);
 
-    // The Label field is rendered only after the query type has been selected. 
+    // The Label field is rendered only after the query type has been selected.
     // We wait for it to be displayed to avoid flakyness.
     await waitFor(() => expect(screen.getByLabelText('Label')).toBeInTheDocument());
 

--- a/public/app/plugins/datasource/tempo/VariableQueryEditor.test.tsx
+++ b/public/app/plugins/datasource/tempo/VariableQueryEditor.test.tsx
@@ -59,7 +59,7 @@ describe('TempoVariableQueryEditor', () => {
     await userEvent.click(document.body);
 
     // The Label field is rendered only after the query type has been selected. 
-    // We wait for it to be displayed to avoid flakyness
+    // We wait for it to be displayed to avoid flakyness.
     await waitFor(() => expect(screen.getByLabelText('Label')).toBeInTheDocument());
 
     await selectOptionInTest(screen.getByLabelText('Label'), 'luna');

--- a/public/app/plugins/datasource/tempo/VariableQueryEditor.test.tsx
+++ b/public/app/plugins/datasource/tempo/VariableQueryEditor.test.tsx
@@ -55,14 +55,13 @@ describe('TempoVariableQueryEditor', () => {
     expect(onChange).not.toHaveBeenCalled();
     render(<TempoVariableQueryEditor {...props} onChange={onChange} />);
 
-    // Select the query type ('Label values')
     await selectOptionInTest(screen.getByLabelText('Query type'), 'Label values');
     await userEvent.click(document.body);
 
-    // Ensure the Label field is shown after selecting the query type
+    // The Label field is rendered only after the query type has been selected. 
+    // We wait for it to be displayed to avoid flakyness
     await waitFor(() => expect(screen.getByLabelText('Label')).toBeInTheDocument());
 
-    // Select the label value
     await selectOptionInTest(screen.getByLabelText('Label'), 'luna');
     await userEvent.click(document.body);
 


### PR DESCRIPTION
[We have been notified](https://github.com/grafana/grafana/issues/85884) of a flaky test. We cannot reproduce locally, so this PR simply adds a `waitFor` call to ensure that the select field whose visibility is governed by another field is actually shown. We'll then keep this test monitored.

Fixes https://github.com/grafana/grafana/issues/85884