### PR TITLE
User: Fix GetByID

### DIFF
--- a/pkg/services/authn/authnimpl/sync/org_sync_test.go
+++ b/pkg/services/authn/authnimpl/sync/org_sync_test.go
@@ -84,8 +84,8 @@ func TestOrgSync_SyncOrgRolesHook(t *testing.T) {
 					ClientParams: authn.ClientParams{
 						SyncOrgRoles: true,
 						LookUpParams: login.UserLookupParams{
-							Email:  ptrString("test"),
-							Login:  nil,
+							Email: ptrString("test"),
+							Login: nil,
 						},
 					},
 				},
@@ -101,8 +101,8 @@ func TestOrgSync_SyncOrgRolesHook(t *testing.T) {
 				ClientParams: authn.ClientParams{
 					SyncOrgRoles: true,
 					LookUpParams: login.UserLookupParams{
-						Email:  ptrString("test"),
-						Login:  nil,
+						Email: ptrString("test"),
+						Login: nil,
 					},
 				},
 			},

--- a/pkg/services/authn/authnimpl/sync/org_sync_test.go
+++ b/pkg/services/authn/authnimpl/sync/org_sync_test.go
@@ -84,7 +84,6 @@ func TestOrgSync_SyncOrgRolesHook(t *testing.T) {
 					ClientParams: authn.ClientParams{
 						SyncOrgRoles: true,
 						LookUpParams: login.UserLookupParams{
-							UserID: nil,
 							Email:  ptrString("test"),
 							Login:  nil,
 						},
@@ -102,7 +101,6 @@ func TestOrgSync_SyncOrgRolesHook(t *testing.T) {
 				ClientParams: authn.ClientParams{
 					SyncOrgRoles: true,
 					LookUpParams: login.UserLookupParams{
-						UserID: nil,
 						Email:  ptrString("test"),
 						Login:  nil,
 					},

--- a/pkg/services/authn/authnimpl/sync/user_sync.go
+++ b/pkg/services/authn/authnimpl/sync/user_sync.go
@@ -368,14 +368,6 @@ func (s *UserSync) lookupByOneOf(ctx context.Context, params login.UserLookupPar
 	var usr *user.User
 	var err error
 
-	// If not found, try to find the user by id
-	if params.UserID != nil && *params.UserID != 0 {
-		usr, err = s.userService.GetByID(ctx, &user.GetUserByIDQuery{ID: *params.UserID})
-		if err != nil && !errors.Is(err, user.ErrUserNotFound) {
-			return nil, err
-		}
-	}
-
 	// If not found, try to find the user by email address
 	if usr == nil && params.Email != nil && *params.Email != "" {
 		usr, err = s.userService.GetByEmail(ctx, &user.GetUserByEmailQuery{Email: *params.Email})

--- a/pkg/services/authn/authnimpl/sync/user_sync_test.go
+++ b/pkg/services/authn/authnimpl/sync/user_sync_test.go
@@ -25,10 +25,6 @@ func ptrBool(b bool) *bool {
 	return &b
 }
 
-func ptrInt64(i int64) *int64 {
-	return &i
-}
-
 func TestUserSync_SyncUserHook(t *testing.T) {
 	userProtection := &authinfoimpl.OSSUserProtectionImpl{}
 
@@ -120,7 +116,6 @@ func TestUserSync_SyncUserHook(t *testing.T) {
 					Email: "test",
 					ClientParams: authn.ClientParams{
 						LookUpParams: login.UserLookupParams{
-							UserID: nil,
 							Email:  ptrString("test"),
 							Login:  nil,
 						},
@@ -135,7 +130,6 @@ func TestUserSync_SyncUserHook(t *testing.T) {
 				Email: "test",
 				ClientParams: authn.ClientParams{
 					LookUpParams: login.UserLookupParams{
-						UserID: nil,
 						Email:  ptrString("test"),
 						Login:  nil,
 					},
@@ -159,7 +153,6 @@ func TestUserSync_SyncUserHook(t *testing.T) {
 					ClientParams: authn.ClientParams{
 						SyncUser: true,
 						LookUpParams: login.UserLookupParams{
-							UserID: nil,
 							Email:  ptrString("test"),
 							Login:  nil,
 						},
@@ -176,7 +169,6 @@ func TestUserSync_SyncUserHook(t *testing.T) {
 				ClientParams: authn.ClientParams{
 					SyncUser: true,
 					LookUpParams: login.UserLookupParams{
-						UserID: nil,
 						Email:  ptrString("test"),
 						Login:  nil,
 					},
@@ -200,7 +192,6 @@ func TestUserSync_SyncUserHook(t *testing.T) {
 					ClientParams: authn.ClientParams{
 						SyncUser: true,
 						LookUpParams: login.UserLookupParams{
-							UserID: nil,
 							Email:  nil,
 							Login:  ptrString("test"),
 						},
@@ -216,52 +207,10 @@ func TestUserSync_SyncUserHook(t *testing.T) {
 				IsGrafanaAdmin: ptrBool(false),
 				ClientParams: authn.ClientParams{
 					LookUpParams: login.UserLookupParams{
-						UserID: nil,
 						Email:  nil,
 						Login:  ptrString("test"),
 					},
 					SyncUser: true,
-				},
-			},
-		},
-		{
-			name: "sync - user found in DB - by ID",
-			fields: fields{
-				userService:     userService,
-				authInfoService: authFakeNil,
-				quotaService:    &quotatest.FakeQuotaService{},
-			},
-			args: args{
-				ctx: context.Background(),
-				id: &authn.Identity{
-					ID:    "",
-					Login: "test",
-					Name:  "test",
-					Email: "test",
-					ClientParams: authn.ClientParams{
-						SyncUser: true,
-						LookUpParams: login.UserLookupParams{
-							UserID: ptrInt64(1),
-							Email:  nil,
-							Login:  nil,
-						},
-					},
-				},
-			},
-			wantErr: false,
-			wantID: &authn.Identity{
-				ID:             "user:1",
-				Login:          "test",
-				Name:           "test",
-				Email:          "test",
-				IsGrafanaAdmin: ptrBool(false),
-				ClientParams: authn.ClientParams{
-					SyncUser: true,
-					LookUpParams: login.UserLookupParams{
-						UserID: ptrInt64(1),
-						Email:  nil,
-						Login:  nil,
-					},
 				},
 			},
 		},
@@ -284,7 +233,6 @@ func TestUserSync_SyncUserHook(t *testing.T) {
 					ClientParams: authn.ClientParams{
 						SyncUser: true,
 						LookUpParams: login.UserLookupParams{
-							UserID: nil,
 							Email:  nil,
 							Login:  nil,
 						},
@@ -303,7 +251,6 @@ func TestUserSync_SyncUserHook(t *testing.T) {
 				ClientParams: authn.ClientParams{
 					SyncUser: true,
 					LookUpParams: login.UserLookupParams{
-						UserID: nil,
 						Email:  nil,
 						Login:  nil,
 					},
@@ -329,7 +276,6 @@ func TestUserSync_SyncUserHook(t *testing.T) {
 					ClientParams: authn.ClientParams{
 						SyncUser: true,
 						LookUpParams: login.UserLookupParams{
-							UserID: nil,
 							Email:  nil,
 							Login:  nil,
 						},
@@ -360,7 +306,6 @@ func TestUserSync_SyncUserHook(t *testing.T) {
 						AllowSignUp: true,
 						EnableUser:  true,
 						LookUpParams: login.UserLookupParams{
-							UserID: nil,
 							Email:  ptrString("test_create"),
 							Login:  nil,
 						},
@@ -381,7 +326,6 @@ func TestUserSync_SyncUserHook(t *testing.T) {
 					AllowSignUp: true,
 					EnableUser:  true,
 					LookUpParams: login.UserLookupParams{
-						UserID: nil,
 						Email:  ptrString("test_create"),
 						Login:  nil,
 					},
@@ -408,9 +352,8 @@ func TestUserSync_SyncUserHook(t *testing.T) {
 						SyncUser:   true,
 						EnableUser: true,
 						LookUpParams: login.UserLookupParams{
-							UserID: ptrInt64(3),
 							Email:  nil,
-							Login:  nil,
+							Login:  ptrString("test"),
 						},
 					},
 				},
@@ -427,9 +370,8 @@ func TestUserSync_SyncUserHook(t *testing.T) {
 					SyncUser:   true,
 					EnableUser: true,
 					LookUpParams: login.UserLookupParams{
-						UserID: ptrInt64(3),
 						Email:  nil,
-						Login:  nil,
+						Login:  ptrString("test"),
 					},
 				},
 			},
@@ -455,9 +397,8 @@ func TestUserSync_SyncUserHook(t *testing.T) {
 						SyncUser:   true,
 						EnableUser: true,
 						LookUpParams: login.UserLookupParams{
-							UserID: ptrInt64(3),
 							Email:  nil,
-							Login:  nil,
+							Login:  ptrString("test"),
 						},
 					},
 				},
@@ -475,9 +416,8 @@ func TestUserSync_SyncUserHook(t *testing.T) {
 					SyncUser:   true,
 					EnableUser: true,
 					LookUpParams: login.UserLookupParams{
-						UserID: ptrInt64(3),
 						Email:  nil,
-						Login:  nil,
+						Login:  ptrString("test"),
 					},
 				},
 			},

--- a/pkg/services/authn/authnimpl/sync/user_sync_test.go
+++ b/pkg/services/authn/authnimpl/sync/user_sync_test.go
@@ -116,8 +116,8 @@ func TestUserSync_SyncUserHook(t *testing.T) {
 					Email: "test",
 					ClientParams: authn.ClientParams{
 						LookUpParams: login.UserLookupParams{
-							Email:  ptrString("test"),
-							Login:  nil,
+							Email: ptrString("test"),
+							Login: nil,
 						},
 					},
 				},
@@ -130,8 +130,8 @@ func TestUserSync_SyncUserHook(t *testing.T) {
 				Email: "test",
 				ClientParams: authn.ClientParams{
 					LookUpParams: login.UserLookupParams{
-						Email:  ptrString("test"),
-						Login:  nil,
+						Email: ptrString("test"),
+						Login: nil,
 					},
 				},
 			},
@@ -153,8 +153,8 @@ func TestUserSync_SyncUserHook(t *testing.T) {
 					ClientParams: authn.ClientParams{
 						SyncUser: true,
 						LookUpParams: login.UserLookupParams{
-							Email:  ptrString("test"),
-							Login:  nil,
+							Email: ptrString("test"),
+							Login: nil,
 						},
 					},
 				},
@@ -169,8 +169,8 @@ func TestUserSync_SyncUserHook(t *testing.T) {
 				ClientParams: authn.ClientParams{
 					SyncUser: true,
 					LookUpParams: login.UserLookupParams{
-						Email:  ptrString("test"),
-						Login:  nil,
+						Email: ptrString("test"),
+						Login: nil,
 					},
 				},
 			},
@@ -192,8 +192,8 @@ func TestUserSync_SyncUserHook(t *testing.T) {
 					ClientParams: authn.ClientParams{
 						SyncUser: true,
 						LookUpParams: login.UserLookupParams{
-							Email:  nil,
-							Login:  ptrString("test"),
+							Email: nil,
+							Login: ptrString("test"),
 						},
 					},
 				},
@@ -207,8 +207,8 @@ func TestUserSync_SyncUserHook(t *testing.T) {
 				IsGrafanaAdmin: ptrBool(false),
 				ClientParams: authn.ClientParams{
 					LookUpParams: login.UserLookupParams{
-						Email:  nil,
-						Login:  ptrString("test"),
+						Email: nil,
+						Login: ptrString("test"),
 					},
 					SyncUser: true,
 				},
@@ -233,8 +233,8 @@ func TestUserSync_SyncUserHook(t *testing.T) {
 					ClientParams: authn.ClientParams{
 						SyncUser: true,
 						LookUpParams: login.UserLookupParams{
-							Email:  nil,
-							Login:  nil,
+							Email: nil,
+							Login: nil,
 						},
 					},
 				},
@@ -251,8 +251,8 @@ func TestUserSync_SyncUserHook(t *testing.T) {
 				ClientParams: authn.ClientParams{
 					SyncUser: true,
 					LookUpParams: login.UserLookupParams{
-						Email:  nil,
-						Login:  nil,
+						Email: nil,
+						Login: nil,
 					},
 				},
 			},
@@ -276,8 +276,8 @@ func TestUserSync_SyncUserHook(t *testing.T) {
 					ClientParams: authn.ClientParams{
 						SyncUser: true,
 						LookUpParams: login.UserLookupParams{
-							Email:  nil,
-							Login:  nil,
+							Email: nil,
+							Login: nil,
 						},
 					},
 				},
@@ -306,8 +306,8 @@ func TestUserSync_SyncUserHook(t *testing.T) {
 						AllowSignUp: true,
 						EnableUser:  true,
 						LookUpParams: login.UserLookupParams{
-							Email:  ptrString("test_create"),
-							Login:  nil,
+							Email: ptrString("test_create"),
+							Login: nil,
 						},
 					},
 				},
@@ -326,8 +326,8 @@ func TestUserSync_SyncUserHook(t *testing.T) {
 					AllowSignUp: true,
 					EnableUser:  true,
 					LookUpParams: login.UserLookupParams{
-						Email:  ptrString("test_create"),
-						Login:  nil,
+						Email: ptrString("test_create"),
+						Login: nil,
 					},
 				},
 			},
@@ -352,8 +352,8 @@ func TestUserSync_SyncUserHook(t *testing.T) {
 						SyncUser:   true,
 						EnableUser: true,
 						LookUpParams: login.UserLookupParams{
-							Email:  nil,
-							Login:  ptrString("test"),
+							Email: nil,
+							Login: ptrString("test"),
 						},
 					},
 				},
@@ -370,8 +370,8 @@ func TestUserSync_SyncUserHook(t *testing.T) {
 					SyncUser:   true,
 					EnableUser: true,
 					LookUpParams: login.UserLookupParams{
-						Email:  nil,
-						Login:  ptrString("test"),
+						Email: nil,
+						Login: ptrString("test"),
 					},
 				},
 			},
@@ -397,8 +397,8 @@ func TestUserSync_SyncUserHook(t *testing.T) {
 						SyncUser:   true,
 						EnableUser: true,
 						LookUpParams: login.UserLookupParams{
-							Email:  nil,
-							Login:  ptrString("test"),
+							Email: nil,
+							Login: ptrString("test"),
 						},
 					},
 				},
@@ -416,8 +416,8 @@ func TestUserSync_SyncUserHook(t *testing.T) {
 					SyncUser:   true,
 					EnableUser: true,
 					LookUpParams: login.UserLookupParams{
-						Email:  nil,
-						Login:  ptrString("test"),
+						Email: nil,
+						Login: ptrString("test"),
 					},
 				},
 			},

--- a/pkg/services/authn/clients/ext_jwt_test.go
+++ b/pkg/services/authn/clients/ext_jwt_test.go
@@ -175,7 +175,7 @@ func TestExtendedJWT_Authenticate(t *testing.T) {
 				ClientParams: authn.ClientParams{SyncUser: false,
 					AllowSignUp: false, EnableUser: false, FetchSyncedUser: false,
 					SyncTeams: false, SyncOrgRoles: false, CacheAuthProxyKey: "",
-					SyncPermissions: true,
+					SyncPermissions:        true,
 					FetchPermissionsParams: authn.FetchPermissionsParams{ActionsLookup: []string(nil), Roles: []string{"fixed:folders:reader"}}},
 				Permissions: map[int64]map[string][]string(nil), IDToken: ""},
 			wantErr: nil,

--- a/pkg/services/authn/clients/ext_jwt_test.go
+++ b/pkg/services/authn/clients/ext_jwt_test.go
@@ -21,7 +21,6 @@ import (
 	"github.com/grafana/grafana/pkg/models/roletype"
 	"github.com/grafana/grafana/pkg/models/usertoken"
 	"github.com/grafana/grafana/pkg/services/authn"
-	"github.com/grafana/grafana/pkg/services/login"
 	"github.com/grafana/grafana/pkg/services/signingkeys"
 	"github.com/grafana/grafana/pkg/services/signingkeys/signingkeystest"
 	"github.com/grafana/grafana/pkg/services/user"
@@ -176,8 +175,7 @@ func TestExtendedJWT_Authenticate(t *testing.T) {
 				ClientParams: authn.ClientParams{SyncUser: false,
 					AllowSignUp: false, EnableUser: false, FetchSyncedUser: false,
 					SyncTeams: false, SyncOrgRoles: false, CacheAuthProxyKey: "",
-					LookUpParams: login.UserLookupParams{UserID: (*int64)(nil),
-						Email: (*string)(nil), Login: (*string)(nil)}, SyncPermissions: true,
+					SyncPermissions: true,
 					FetchPermissionsParams: authn.FetchPermissionsParams{ActionsLookup: []string(nil), Roles: []string{"fixed:folders:reader"}}},
 				Permissions: map[int64]map[string][]string(nil), IDToken: ""},
 			wantErr: nil,
@@ -208,7 +206,6 @@ func TestExtendedJWT_Authenticate(t *testing.T) {
 				ClientParams: authn.ClientParams{SyncUser: false, AllowSignUp: false,
 					EnableUser: false, FetchSyncedUser: true, SyncTeams: false,
 					SyncOrgRoles: false, CacheAuthProxyKey: "",
-					LookUpParams:    login.UserLookupParams{UserID: (*int64)(nil), Email: (*string)(nil), Login: (*string)(nil)},
 					SyncPermissions: true,
 					FetchPermissionsParams: authn.FetchPermissionsParams{ActionsLookup: []string{"dashboards:create",
 						"folders:read", "datasources:explore", "datasources.insights:read"},

--- a/pkg/services/authn/clients/grafana_test.go
+++ b/pkg/services/authn/clients/grafana_test.go
@@ -116,7 +116,6 @@ func TestGrafana_AuthenticateProxy(t *testing.T) {
 
 				assert.EqualValues(t, tt.expectedIdentity.ClientParams.LookUpParams.Email, identity.ClientParams.LookUpParams.Email)
 				assert.EqualValues(t, tt.expectedIdentity.ClientParams.LookUpParams.Login, identity.ClientParams.LookUpParams.Login)
-				assert.EqualValues(t, tt.expectedIdentity.ClientParams.LookUpParams.UserID, identity.ClientParams.LookUpParams.UserID)
 			} else {
 				assert.Nil(t, tt.expectedIdentity)
 			}

--- a/pkg/services/authn/clients/jwt_test.go
+++ b/pkg/services/authn/clients/jwt_test.go
@@ -57,9 +57,8 @@ func TestAuthenticateJWT(t *testing.T) {
 					SyncPermissions: true,
 					SyncTeams:       true,
 					LookUpParams: login.UserLookupParams{
-						UserID: nil,
-						Email:  stringPtr("eai.doe@cor.po"),
-						Login:  stringPtr("eai-doe"),
+						Email: stringPtr("eai.doe@cor.po"),
+						Login: stringPtr("eai-doe"),
 					},
 				},
 			},
@@ -111,9 +110,8 @@ func TestAuthenticateJWT(t *testing.T) {
 					SyncPermissions: true,
 					SyncTeams:       false,
 					LookUpParams: login.UserLookupParams{
-						UserID: nil,
-						Email:  stringPtr("eai.doe@cor.po"),
-						Login:  stringPtr("eai-doe"),
+						Email: stringPtr("eai.doe@cor.po"),
+						Login: stringPtr("eai-doe"),
 					},
 				},
 			},

--- a/pkg/services/authn/clients/oauth_test.go
+++ b/pkg/services/authn/clients/oauth_test.go
@@ -308,7 +308,6 @@ func TestOAuth_Authenticate(t *testing.T) {
 
 				assert.EqualValues(t, tt.expectedIdentity.ClientParams.LookUpParams.Email, identity.ClientParams.LookUpParams.Email)
 				assert.EqualValues(t, tt.expectedIdentity.ClientParams.LookUpParams.Login, identity.ClientParams.LookUpParams.Login)
-				assert.EqualValues(t, tt.expectedIdentity.ClientParams.LookUpParams.UserID, identity.ClientParams.LookUpParams.UserID)
 			} else {
 				assert.Nil(t, tt.expectedIdentity)
 			}

--- a/pkg/services/ldap/api/service.go
+++ b/pkg/services/ldap/api/service.go
@@ -331,9 +331,6 @@ func (s *Service) identityFromLDAPUser(user *login.ExternalUserInfo) *authn.Iden
 			EnableUser:   true,
 			SyncOrgRoles: !s.cfg.LDAPSkipOrgRoleSync,
 			AllowSignUp:  s.cfg.LDAPAllowSignup,
-			LookUpParams: login.UserLookupParams{
-				UserID: &user.UserId,
-			},
 		},
 	}
 }

--- a/pkg/services/login/model.go
+++ b/pkg/services/login/model.go
@@ -104,7 +104,6 @@ type GetUserByAuthInfoQuery struct {
 
 type UserLookupParams struct {
 	// Describes lookup order as well
-	UserID *int64  // if set, will try to find the user by id
 	Email  *string // if set, will try to find the user by email
 	Login  *string // if set, will try to find the user by login
 }

--- a/pkg/services/login/model.go
+++ b/pkg/services/login/model.go
@@ -104,8 +104,8 @@ type GetUserByAuthInfoQuery struct {
 
 type UserLookupParams struct {
 	// Describes lookup order as well
-	Email  *string // if set, will try to find the user by email
-	Login  *string // if set, will try to find the user by login
+	Email *string // if set, will try to find the user by email
+	Login *string // if set, will try to find the user by login
 }
 
 type GetAuthInfoQuery struct {

--- a/pkg/services/user/userimpl/user.go
+++ b/pkg/services/user/userimpl/user.go
@@ -209,14 +209,7 @@ func (s *Service) Delete(ctx context.Context, cmd *user.DeleteUserCommand) error
 }
 
 func (s *Service) GetByID(ctx context.Context, query *user.GetUserByIDQuery) (*user.User, error) {
-	user, err := s.store.GetByID(ctx, query.ID)
-	if err != nil {
-		return nil, err
-	}
-	if err := s.store.CaseInsensitiveLoginConflict(ctx, user.Login, user.Email); err != nil {
-		return nil, err
-	}
-	return user, nil
+	return s.store.GetByID(ctx, query.ID)
 }
 
 func (s *Service) GetByLogin(ctx context.Context, query *user.GetUserByLoginQuery) (*user.User, error) {


### PR DESCRIPTION
**What is this feature?**
After https://github.com/grafana/grafana/pull/84840 was merge we have noticed a regression in user lookup code.

More details is described here: https://github.com/grafana/identity-access-team/issues/657

My assumption was that this would only affect logins, auth proxy, jwt auth and basic auth. But in our tests we are using sessions. While this pr does not fix the entire regression it fixes the issue for auditlogging and in places where we use `userservice.GetByID`. For some reason we do a conflict check using the bad query every time. E.g. when requsting `GET /api/dashboards/uid/:uid` we use GetByID for users to resolve `UpdatedBy` and `CreatedBy`.

We can merge this while we work out a fix for the entire thing.

**Which issue(s) does this PR fix?**:

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
