### PR TITLE
mysql decouple frontend part

### DIFF
--- a/public/app/features/plugins/built_in_plugins.ts
+++ b/public/app/features/plugins/built_in_plugins.ts
@@ -15,8 +15,6 @@ const influxdbPlugin = async () =>
 const lokiPlugin = async () => await import(/* webpackChunkName: "lokiPlugin" */ 'app/plugins/datasource/loki/module');
 const mixedPlugin = async () =>
   await import(/* webpackChunkName: "mixedPlugin" */ 'app/plugins/datasource/mixed/module');
-const mysqlPlugin = async () =>
-  await import(/* webpackChunkName: "mysqlPlugin" */ 'app/plugins/datasource/mysql/module');
 const postgresPlugin = async () =>
   await import(/* webpackChunkName: "postgresPlugin" */ 'app/plugins/datasource/grafana-postgresql-datasource/module');
 const prometheusPlugin = async () =>
@@ -83,7 +81,6 @@ const builtInPlugins: Record<string, System.Module | (() => Promise<System.Modul
   'core:plugin/influxdb': influxdbPlugin,
   'core:plugin/loki': lokiPlugin,
   'core:plugin/mixed': mixedPlugin,
-  'core:plugin/mysql': mysqlPlugin,
   'core:plugin/grafana-postgresql-datasource': postgresPlugin,
   'core:plugin/mssql': mssqlPlugin,
   'core:plugin/prometheus': prometheusPlugin,

--- a/public/app/plugins/datasource/mysql/CHANGELOG.md
+++ b/public/app/plugins/datasource/mysql/CHANGELOG.md
@@ -1,0 +1,1 @@
+# Changelog

--- a/public/app/plugins/datasource/mysql/package.json
+++ b/public/app/plugins/datasource/mysql/package.json
@@ -1,0 +1,41 @@
+{
+  "name": "@grafana-plugins/mysql",
+  "description": "MySQL data source plugin",
+  "private": true,
+  "version": "11.1.0-pre",
+  "dependencies": {
+    "@emotion/css": "11.11.2",
+    "@grafana/data": "11.1.0-pre",
+    "@grafana/experimental": "1.7.10",
+    "@grafana/runtime": "11.1.0-pre",
+    "@grafana/sql": "11.1.0-pre",
+    "@grafana/ui": "11.1.0-pre",
+    "lodash": "4.17.21",
+    "react": "18.2.0",
+    "rxjs": "7.8.1",
+    "tslib": "2.6.2"
+  },
+  "devDependencies": {
+    "@grafana/e2e-selectors": "11.1.0-pre",
+    "@grafana/plugin-configs": "11.1.0-pre",
+    "@testing-library/react": "15.0.2",
+    "@testing-library/user-event": "14.5.2",
+    "@types/jest": "29.5.12",
+    "@types/lodash": "4.17.0",
+    "@types/node": "20.12.7",
+    "@types/react": "18.2.78",
+    "@types/testing-library__jest-dom": "5.14.9",
+    "ts-node": "10.9.2",
+    "typescript": "5.4.5",
+    "webpack": "5.91.0"
+  },
+  "peerDependencies": {
+    "@grafana/runtime": "*"
+  },
+  "scripts": {
+    "build": "webpack -c ./webpack.config.ts --env production",
+    "build:commit": "webpack -c ./webpack.config.ts --env production --env commit=$(git rev-parse --short HEAD)",
+    "dev": "webpack -w -c ./webpack.config.ts --env development"
+  },
+  "packageManager": "yarn@4.1.1"
+}

--- a/public/app/plugins/datasource/mysql/package.json
+++ b/public/app/plugins/datasource/mysql/package.json
@@ -23,7 +23,7 @@
     "@types/jest": "29.5.12",
     "@types/lodash": "4.17.0",
     "@types/node": "20.12.7",
-    "@types/react": "18.2.78",
+    "@types/react": "18.2.79",
     "@types/testing-library__jest-dom": "5.14.9",
     "ts-node": "10.9.2",
     "typescript": "5.4.5",

--- a/public/app/plugins/datasource/mysql/tsconfig.json
+++ b/public/app/plugins/datasource/mysql/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "extends": "@grafana/plugin-configs/tsconfig.json",
+  "include": ["."]
+}

--- a/public/app/plugins/datasource/mysql/webpack.config.ts
+++ b/public/app/plugins/datasource/mysql/webpack.config.ts
@@ -1,0 +1,3 @@
+import config from '@grafana/plugin-configs/webpack.config';
+
+export default config;

--- a/public/app/plugins/datasource/mysql/webpack.config.ts
+++ b/public/app/plugins/datasource/mysql/webpack.config.ts
@@ -1,3 +1,4 @@
 import config from '@grafana/plugin-configs/webpack.config';
 
+// eslint-disable-next-line no-barrel-files/no-barrel-files
 export default config;

--- a/yarn.lock
+++ b/yarn.lock
@@ -3124,7 +3124,7 @@ __metadata:
     "@types/jest": "npm:29.5.12"
     "@types/lodash": "npm:4.17.0"
     "@types/node": "npm:20.12.7"
-    "@types/react": "npm:18.2.78"
+    "@types/react": "npm:18.2.79"
     "@types/testing-library__jest-dom": "npm:5.14.9"
     lodash: "npm:4.17.21"
     react: "npm:18.2.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3107,6 +3107,37 @@ __metadata:
   languageName: unknown
   linkType: soft
 
+"@grafana-plugins/mysql@workspace:public/app/plugins/datasource/mysql":
+  version: 0.0.0-use.local
+  resolution: "@grafana-plugins/mysql@workspace:public/app/plugins/datasource/mysql"
+  dependencies:
+    "@emotion/css": "npm:11.11.2"
+    "@grafana/data": "npm:11.1.0-pre"
+    "@grafana/e2e-selectors": "npm:11.1.0-pre"
+    "@grafana/experimental": "npm:1.7.10"
+    "@grafana/plugin-configs": "npm:11.1.0-pre"
+    "@grafana/runtime": "npm:11.1.0-pre"
+    "@grafana/sql": "npm:11.1.0-pre"
+    "@grafana/ui": "npm:11.1.0-pre"
+    "@testing-library/react": "npm:15.0.2"
+    "@testing-library/user-event": "npm:14.5.2"
+    "@types/jest": "npm:29.5.12"
+    "@types/lodash": "npm:4.17.0"
+    "@types/node": "npm:20.12.7"
+    "@types/react": "npm:18.2.78"
+    "@types/testing-library__jest-dom": "npm:5.14.9"
+    lodash: "npm:4.17.21"
+    react: "npm:18.2.0"
+    rxjs: "npm:7.8.1"
+    ts-node: "npm:10.9.2"
+    tslib: "npm:2.6.2"
+    typescript: "npm:5.4.5"
+    webpack: "npm:5.91.0"
+  peerDependencies:
+    "@grafana/runtime": "*"
+  languageName: unknown
+  linkType: soft
+
 "@grafana-plugins/parca@workspace:public/app/plugins/datasource/parca":
   version: 0.0.0-use.local
   resolution: "@grafana-plugins/parca@workspace:public/app/plugins/datasource/parca"
@@ -3834,7 +3865,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@grafana/sql@workspace:*, @grafana/sql@workspace:packages/grafana-sql":
+"@grafana/sql@npm:11.1.0-pre, @grafana/sql@workspace:*, @grafana/sql@workspace:packages/grafana-sql":
   version: 0.0.0-use.local
   resolution: "@grafana/sql@workspace:packages/grafana-sql"
   dependencies:


### PR DESCRIPTION
final part of the decoupling process.
by default it runs still as a core plugin, but it's possible to set some grafana config options, to run it as an external plugin.

how to test:
1. make sure it still runs as a core plugin (the default behavior)
    - just run it as always (`yarn start` and `make run`)
    - verify that you are running mysql in it's normal mode
        - go to `plugins`, choose `mysql`. verify that in the `signature` section it says `core`
    - make sure the mysql datasource plugin still works
        - check that the query-editor still works fine, and you can run a query
2. make sure it runs as an external plugin:
    - build the plugin
        - run `make build-plugin-go PLUGIN_ID=mysql` . this will generate the "backend" binaries in `public/app/plugins/datasource/mysql/dist`
        - run `yarn workspace @grafana-plugins/mysql build`. this will generate the "frontend" files in `public/app/plugins/datasource/mysql/dist`
        - at this point all the needed files are in `public/app/plugins/datasource/mysql/dist`
        - adjust the grafana-config, add this:
        ```
        [feature_toggles]
        externalCorePlugins = true
        
        [plugin.mysql]
        as_external = true
        ```
        - make sure to copy/move the `dist` files to somewhere where your grafana expects plugin-files (i think in the usual devel grafana situation it's the `path/plugins` folder.
        - run grafana
        - go to `plugins`, choose `mysql`. check what it says under `signature`. it should be `unsigned`, not `core`.
        - make sure the plugin works, check the same things as you checked with the normal core mode.