### PR TITLE
postgres: simpler test

### DIFF
--- a/pkg/tsdb/grafana-postgresql-datasource/sqleng/sql_engine_test.go
+++ b/pkg/tsdb/grafana-postgresql-datasource/sqleng/sql_engine_test.go
@@ -13,8 +13,9 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/grafana/grafana-plugin-sdk-go/backend/log"
-	"github.com/grafana/grafana/pkg/tsdb/grafana-postgresql-datasource/sqleng/util"
 )
+
+func Pointer[T any](v T) *T { return &v }
 
 func TestSQLEngine(t *testing.T) {
 	dt := time.Date(2018, 3, 14, 21, 20, 6, int(527345*time.Microsecond), time.UTC)
@@ -73,19 +74,19 @@ func TestSQLEngine(t *testing.T) {
 				tSeconds,
 			}),
 			data.NewField("time2", nil, []*int64{
-				util.Pointer(tSeconds),
+				Pointer(tSeconds),
 			}),
 			data.NewField("time3", nil, []int64{
 				tMilliseconds,
 			}),
 			data.NewField("time4", nil, []*int64{
-				util.Pointer(tMilliseconds),
+				Pointer(tMilliseconds),
 			}),
 			data.NewField("time5", nil, []int64{
 				tNanoSeconds,
 			}),
 			data.NewField("time6", nil, []*int64{
-				util.Pointer(tNanoSeconds),
+				Pointer(tNanoSeconds),
 			}),
 			data.NewField("time7", nil, []*int64{
 				nilPointer,
@@ -117,19 +118,19 @@ func TestSQLEngine(t *testing.T) {
 				tSeconds,
 			}),
 			data.NewField("time2", nil, []*uint64{
-				util.Pointer(tSeconds),
+				Pointer(tSeconds),
 			}),
 			data.NewField("time3", nil, []uint64{
 				tMilliseconds,
 			}),
 			data.NewField("time4", nil, []*uint64{
-				util.Pointer(tMilliseconds),
+				Pointer(tMilliseconds),
 			}),
 			data.NewField("time5", nil, []uint64{
 				tNanoSeconds,
 			}),
 			data.NewField("time6", nil, []*uint64{
-				util.Pointer(tNanoSeconds),
+				Pointer(tNanoSeconds),
 			}),
 			data.NewField("time7", nil, []*uint64{
 				nilPointer,
@@ -159,7 +160,7 @@ func TestSQLEngine(t *testing.T) {
 				tSeconds,
 			}),
 			data.NewField("time2", nil, []*int32{
-				util.Pointer(tSeconds),
+				Pointer(tSeconds),
 			}),
 			data.NewField("time7", nil, []*int32{
 				nilInt,
@@ -184,7 +185,7 @@ func TestSQLEngine(t *testing.T) {
 				tSeconds,
 			}),
 			data.NewField("time2", nil, []*uint32{
-				util.Pointer(tSeconds),
+				Pointer(tSeconds),
 			}),
 			data.NewField("time7", nil, []*uint32{
 				nilInt,
@@ -210,19 +211,19 @@ func TestSQLEngine(t *testing.T) {
 				tSeconds,
 			}),
 			data.NewField("time2", nil, []*float64{
-				util.Pointer(tSeconds),
+				Pointer(tSeconds),
 			}),
 			data.NewField("time3", nil, []float64{
 				tMilliseconds,
 			}),
 			data.NewField("time4", nil, []*float64{
-				util.Pointer(tMilliseconds),
+				Pointer(tMilliseconds),
 			}),
 			data.NewField("time5", nil, []float64{
 				tNanoSeconds,
 			}),
 			data.NewField("time6", nil, []*float64{
-				util.Pointer(tNanoSeconds),
+				Pointer(tNanoSeconds),
 			}),
 			data.NewField("time7", nil, []*float64{
 				nilPointer,
@@ -252,7 +253,7 @@ func TestSQLEngine(t *testing.T) {
 				tSeconds,
 			}),
 			data.NewField("time2", nil, []*float32{
-				util.Pointer(tSeconds),
+				Pointer(tSeconds),
 			}),
 			data.NewField("time7", nil, []*float32{
 				nilInt,
@@ -273,61 +274,61 @@ func TestSQLEngine(t *testing.T) {
 				int64(1),
 			}),
 			data.NewField("value2", nil, []*int64{
-				util.Pointer(int64(1)),
+				Pointer(int64(1)),
 			}),
 			data.NewField("value3", nil, []int32{
 				int32(1),
 			}),
 			data.NewField("value4", nil, []*int32{
-				util.Pointer(int32(1)),
+				Pointer(int32(1)),
 			}),
 			data.NewField("value5", nil, []int16{
 				int16(1),
 			}),
 			data.NewField("value6", nil, []*int16{
-				util.Pointer(int16(1)),
+				Pointer(int16(1)),
 			}),
 			data.NewField("value7", nil, []int8{
 				int8(1),
 			}),
 			data.NewField("value8", nil, []*int8{
-				util.Pointer(int8(1)),
+				Pointer(int8(1)),
 			}),
 			data.NewField("value9", nil, []float64{
 				float64(1),
 			}),
 			data.NewField("value10", nil, []*float64{
-				util.Pointer(1.0),
+				Pointer(1.0),
 			}),
 			data.NewField("value11", nil, []float32{
 				float32(1),
 			}),
 			data.NewField("value12", nil, []*float32{
-				util.Pointer(float32(1)),
+				Pointer(float32(1)),
 			}),
 			data.NewField("value13", nil, []uint64{
 				uint64(1),
 			}),
 			data.NewField("value14", nil, []*uint64{
-				util.Pointer(uint64(1)),
+				Pointer(uint64(1)),
 			}),
 			data.NewField("value15", nil, []uint32{
 				uint32(1),
 			}),
 			data.NewField("value16", nil, []*uint32{
-				util.Pointer(uint32(1)),
+				Pointer(uint32(1)),
 			}),
 			data.NewField("value17", nil, []uint16{
 				uint16(1),
 			}),
 			data.NewField("value18", nil, []*uint16{
-				util.Pointer(uint16(1)),
+				Pointer(uint16(1)),
 			}),
 			data.NewField("value19", nil, []uint8{
 				uint8(1),
 			}),
 			data.NewField("value20", nil, []*uint8{
-				util.Pointer(uint8(1)),
+				Pointer(uint8(1)),
 			}),
 		)
 		for i := 0; i < len(originFrame.Fields); i++ {

--- a/pkg/tsdb/grafana-postgresql-datasource/sqleng/util/util.go
+++ b/pkg/tsdb/grafana-postgresql-datasource/sqleng/util/util.go
@@ -1,3 +1,0 @@
-package util
-
-func Pointer[T any](v T) *T { return &v }


### PR DESCRIPTION
test only change. we simplify the test-code.

(when doing the decoupling, we simply copied the `sqleng` files to postgres without any modifications, to keep things simple, now we can do simple refactorings)
