### PR TITLE
DashboardDatasource: Replace `sceneObject` from `scopedVars` with `grafanaSceneContext`

### DIFF
--- a/public/app/plugins/datasource/dashboard/datasource.ts
+++ b/public/app/plugins/datasource/dashboard/datasource.ts
@@ -25,7 +25,7 @@ export class DashboardDatasource extends DataSourceApi<DashboardQuery> {
   }
 
   query(options: DataQueryRequest<DashboardQuery>): Observable<DataQueryResponse> {
-    const scene: SceneObject | undefined = options.scopedVars?.__sceneObject?.value;
+    const scene: SceneObject | undefined = window.__grafanaSceneContext;
 
     if (options.requestId.indexOf('mixed') > -1) {
       throw new Error('Dashboard data source cannot be used with Mixed data source.');


### PR DESCRIPTION
**What is this feature?**

Dashboard datasource currently relies on the `sceneObject` to be passed via `scopedVars`. Unfortunately this causes issues with some other datasources hence `sceneObject` will be removed in `scopedVars`.

This is an alternative way to achieve the same functionality.

This PR relies on https://github.com/grafana/scenes/pull/697

**Why do we need this feature?**

`sceneObject` will be removed in `scopedVars`

**Who is this feature for?**

-

**Which issue(s) does this PR fix?**:

-

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
