### PR TITLE
Common labels/displayed fields: Show label names with values

### DIFF
--- a/.betterer.results
+++ b/.betterer.results
@@ -3279,8 +3279,7 @@ exports[`better eslint`] = {
       [0, 0, 0, "Unexpected any. Specify a different type.", "0"]
     ],
     "public/app/features/explore/Logs/LogsMetaRow.tsx:5381": [
-      [0, 0, 0, "Styles should be written using objects.", "0"],
-      [0, 0, 0, "Unexpected any. Specify a different type.", "1"]
+      [0, 0, 0, "Styles should be written using objects.", "0"]
     ],
     "public/app/features/explore/Logs/LogsNavigation.tsx:5381": [
       [0, 0, 0, "Styles should be written using objects.", "0"],
@@ -6021,9 +6020,6 @@ exports[`better eslint`] = {
       [0, 0, 0, "Styles should be written using objects.", "5"],
       [0, 0, 0, "Styles should be written using objects.", "6"],
       [0, 0, 0, "Styles should be written using objects.", "7"]
-    ],
-    "public/app/plugins/panel/logs/LogsPanel.tsx:5381": [
-      [0, 0, 0, "Do not use any type assertions.", "0"]
     ],
     "public/app/plugins/panel/logs/types.ts:5381": [
       [0, 0, 0, "Do not re-export imported variable (\`./panelcfg.gen\`)", "0"]

--- a/public/app/features/explore/Logs/Logs.tsx
+++ b/public/app/features/explore/Logs/Logs.tsx
@@ -382,7 +382,7 @@ class UnthemedLogs extends PureComponent<Props, State> {
     if (index === -1) {
       this.setState((state) => {
         return {
-          displayedFields: state.displayedFields.concat(key),
+          displayedFields: state.displayedFields.concat(key).sort(),
         };
       });
     }

--- a/public/app/features/explore/Logs/Logs.tsx
+++ b/public/app/features/explore/Logs/Logs.tsx
@@ -382,7 +382,7 @@ class UnthemedLogs extends PureComponent<Props, State> {
     if (index === -1) {
       this.setState((state) => {
         return {
-          displayedFields: state.displayedFields.concat(key).sort(),
+          displayedFields: state.displayedFields.concat(key),
         };
       });
     }

--- a/public/app/features/explore/Logs/LogsMetaRow.tsx
+++ b/public/app/features/explore/Logs/LogsMetaRow.tsx
@@ -13,6 +13,7 @@ import {
   transformDataFrame,
   DataTransformerConfig,
   CustomTransformOperator,
+  Labels,
 } from '@grafana/data';
 import { DataFrame } from '@grafana/data/';
 import { reportInteraction } from '@grafana/runtime';
@@ -133,7 +134,7 @@ export const LogsMetaRow = React.memo(
       logsMetaItem.push(
         {
           label: 'Showing only selected fields',
-          value: renderMetaItem(displayedFields, LogsMetaKind.LabelsMap),
+          value: <LogLabels labels={displayedFields} />,
         },
         {
           label: '',
@@ -195,11 +196,16 @@ export const LogsMetaRow = React.memo(
 
 LogsMetaRow.displayName = 'LogsMetaRow';
 
-function renderMetaItem(value: any, kind: LogsMetaKind) {
+function renderMetaItem(value: string | number | Labels, kind: LogsMetaKind) {
+  if (typeof value === 'string' || typeof value === 'number') {
+    return <>value</>;
+  }
   if (kind === LogsMetaKind.LabelsMap) {
     return <LogLabels labels={value} />;
-  } else if (kind === LogsMetaKind.Error) {
-    return <span className="logs-meta-item__error">{value}</span>;
+  } 
+  if (kind === LogsMetaKind.Error) {
+    return <span className="logs-meta-item__error">{value.toString()}</span>;
   }
-  return value;
+  console.error(`Meta type ${typeof value} ${value} not recognized.`)
+  return <></>;
 }

--- a/public/app/features/explore/Logs/LogsMetaRow.tsx
+++ b/public/app/features/explore/Logs/LogsMetaRow.tsx
@@ -202,10 +202,10 @@ function renderMetaItem(value: string | number | Labels, kind: LogsMetaKind) {
   }
   if (kind === LogsMetaKind.LabelsMap) {
     return <LogLabels labels={value} />;
-  } 
+  }
   if (kind === LogsMetaKind.Error) {
     return <span className="logs-meta-item__error">{value.toString()}</span>;
   }
-  console.error(`Meta type ${typeof value} ${value} not recognized.`)
+  console.error(`Meta type ${typeof value} ${value} not recognized.`);
   return <></>;
 }

--- a/public/app/features/explore/Logs/LogsMetaRow.tsx
+++ b/public/app/features/explore/Logs/LogsMetaRow.tsx
@@ -20,7 +20,7 @@ import { reportInteraction } from '@grafana/runtime';
 import { Button, Dropdown, Menu, ToolbarButton, Tooltip, useStyles2 } from '@grafana/ui';
 
 import { downloadDataFrameAsCsv, downloadLogsModelAsTxt } from '../../inspector/utils/download';
-import { LogLabels } from '../../logs/components/LogLabels';
+import { LogLabels, LogLabelsList } from '../../logs/components/LogLabels';
 import { MAX_CHARACTERS } from '../../logs/components/LogRowMessage';
 import { logRowsToReadableJson } from '../../logs/utils';
 import { MetaInfoText, MetaItemProps } from '../MetaInfoText';
@@ -134,7 +134,7 @@ export const LogsMetaRow = React.memo(
       logsMetaItem.push(
         {
           label: 'Showing only selected fields',
-          value: <LogLabels labels={displayedFields} />,
+          value: <LogLabelsList labels={displayedFields} />,
         },
         {
           label: '',
@@ -198,7 +198,7 @@ LogsMetaRow.displayName = 'LogsMetaRow';
 
 function renderMetaItem(value: string | number | Labels, kind: LogsMetaKind) {
   if (typeof value === 'string' || typeof value === 'number') {
-    return <>value</>;
+    return <>{value}</>;
   }
   if (kind === LogsMetaKind.LabelsMap) {
     return <LogLabels labels={value} />;

--- a/public/app/features/logs/components/LogLabels.test.tsx
+++ b/public/app/features/logs/components/LogLabels.test.tsx
@@ -1,27 +1,35 @@
 import { render, screen } from '@testing-library/react';
 import React from 'react';
 
-import { LogLabels } from './LogLabels';
+import { LogLabels, LogLabelsList } from './LogLabels';
 
 describe('<LogLabels />', () => {
   it('renders notice when no labels are found', () => {
-    render(<LogLabels labels={{}} />);
+    render(<LogLabels labels={{}} emptyMessage='(no unique labels)' />);
     expect(screen.queryByText('(no unique labels)')).toBeInTheDocument();
   });
   it('renders labels', () => {
     render(<LogLabels labels={{ foo: 'bar', baz: '42' }} />);
-    expect(screen.queryByText('bar')).toBeInTheDocument();
-    expect(screen.queryByText('42')).toBeInTheDocument();
+    expect(screen.queryByText('foo=bar')).toBeInTheDocument();
+    expect(screen.queryByText('baz=42')).toBeInTheDocument();
   });
   it('excludes labels with certain names or labels starting with underscore', () => {
     render(<LogLabels labels={{ foo: 'bar', level: '42', _private: '13' }} />);
-    expect(screen.queryByText('bar')).toBeInTheDocument();
-    expect(screen.queryByText('42')).not.toBeInTheDocument();
+    expect(screen.queryByText('foo=bar')).toBeInTheDocument();
+    expect(screen.queryByText('level=42')).not.toBeInTheDocument();
     expect(screen.queryByText('13')).not.toBeInTheDocument();
   });
   it('excludes labels with empty string values', () => {
     render(<LogLabels labels={{ foo: 'bar', baz: '' }} />);
+    expect(screen.queryByText('foo=bar')).toBeInTheDocument();
+    expect(screen.queryByText(/baz/)).not.toBeInTheDocument();
+  });
+});
+
+describe('<LogLabelsList />', () => {
+  it('renders labels', () => {
+    render(<LogLabelsList labels={['bar', '42']} />);
     expect(screen.queryByText('bar')).toBeInTheDocument();
-    expect(screen.queryByText('baz')).not.toBeInTheDocument();
+    expect(screen.queryByText('42')).toBeInTheDocument();
   });
 });

--- a/public/app/features/logs/components/LogLabels.test.tsx
+++ b/public/app/features/logs/components/LogLabels.test.tsx
@@ -5,7 +5,7 @@ import { LogLabels, LogLabelsList } from './LogLabels';
 
 describe('<LogLabels />', () => {
   it('renders notice when no labels are found', () => {
-    render(<LogLabels labels={{}} emptyMessage='(no unique labels)' />);
+    render(<LogLabels labels={{}} emptyMessage="(no unique labels)" />);
     expect(screen.queryByText('(no unique labels)')).toBeInTheDocument();
   });
   it('renders labels', () => {

--- a/public/app/features/logs/components/LogLabels.tsx
+++ b/public/app/features/logs/components/LogLabels.tsx
@@ -30,8 +30,9 @@ export const LogLabels = ({ labels }: Props) => {
         if (!value) {
           return;
         }
-        const tooltip = `${label}: ${value}`;
-        return <LogLabel key={label} styles={styles} tooltip={tooltip}>{value}</LogLabel>;
+        const tooltip = `${label}=${value}`;
+        const labelValue = `${label}=${value}`;
+        return <LogLabel key={label} styles={styles} tooltip={tooltip}>{labelValue}</LogLabel>;
       })}
     </span>
   );

--- a/public/app/features/logs/components/LogLabels.tsx
+++ b/public/app/features/logs/components/LogLabels.tsx
@@ -14,7 +14,13 @@ interface Props {
 
 export const LogLabels = ({ labels, emptyMessage }: Props) => {
   const styles = useStyles2(getStyles);
-  const displayLabels = useMemo(() => Object.keys(labels).filter((label) => !label.startsWith('_') && !HIDDEN_LABELS.includes(label)).sort(), [labels]);
+  const displayLabels = useMemo(
+    () =>
+      Object.keys(labels)
+        .filter((label) => !label.startsWith('_') && !HIDDEN_LABELS.includes(label))
+        .sort(),
+    [labels]
+  );
 
   if (displayLabels.length === 0 && emptyMessage) {
     return (
@@ -33,7 +39,11 @@ export const LogLabels = ({ labels, emptyMessage }: Props) => {
         }
         const tooltip = `${label}=${value}`;
         const labelValue = `${label}=${value}`;
-        return <LogLabel key={label} styles={styles} tooltip={tooltip}>{labelValue}</LogLabel>;
+        return (
+          <LogLabel key={label} styles={styles} tooltip={tooltip}>
+            {labelValue}
+          </LogLabel>
+        );
       })}
     </span>
   );
@@ -48,11 +58,13 @@ export const LogLabelsList = ({ labels }: LogLabelsArrayProps) => {
   return (
     <span className={cx([styles.logsLabels])}>
       {labels.map((label) => (
-        <LogLabel key={label} styles={styles} tooltip={label}>{label}</LogLabel>
+        <LogLabel key={label} styles={styles} tooltip={label}>
+          {label}
+        </LogLabel>
       ))}
     </span>
   );
-}
+};
 
 interface LogLabelProps {
   styles: Record<string, string>;
@@ -67,8 +79,8 @@ const LogLabel = ({ styles, tooltip, children }: LogLabelProps) => {
         {children}
       </span>
     </span>
-  )
-}
+  );
+};
 
 const getStyles = (theme: GrafanaTheme2) => {
   return {

--- a/public/app/features/logs/components/LogLabels.tsx
+++ b/public/app/features/logs/components/LogLabels.tsx
@@ -2,7 +2,7 @@ import { css, cx } from '@emotion/css';
 import React, { useMemo } from 'react';
 
 import { GrafanaTheme2, Labels } from '@grafana/data';
-import { useStyles2 } from '@grafana/ui';
+import { Tooltip, useStyles2 } from '@grafana/ui';
 
 // Levels are already encoded in color, filename is a Loki-ism
 const HIDDEN_LABELS = ['level', 'lvl', 'filename'];
@@ -37,12 +37,11 @@ export const LogLabels = ({ labels, emptyMessage }: Props) => {
         if (!value) {
           return;
         }
-        const tooltip = `${label}=${value}`;
         const labelValue = `${label}=${value}`;
         return (
-          <LogLabel key={label} styles={styles} tooltip={tooltip}>
-            {labelValue}
-          </LogLabel>
+          <Tooltip content={labelValue} key={label} placement="top">
+            <LogLabel styles={styles}>{labelValue}</LogLabel>
+          </Tooltip>
         );
       })}
     </span>
@@ -72,15 +71,18 @@ interface LogLabelProps {
   children: JSX.Element | string;
 }
 
-const LogLabel = ({ styles, tooltip, children }: LogLabelProps) => {
-  return (
-    <span className={cx([styles.logsLabel])}>
-      <span className={cx([styles.logsLabelValue])} title={tooltip}>
-        {children}
+const LogLabel = React.forwardRef<HTMLSpanElement, LogLabelProps>(
+  ({ styles, tooltip, children }: LogLabelProps, ref) => {
+    return (
+      <span className={cx([styles.logsLabel])} ref={ref}>
+        <span className={cx([styles.logsLabelValue])} title={tooltip}>
+          {children}
+        </span>
       </span>
-    </span>
-  );
-};
+    );
+  }
+);
+LogLabel.displayName = 'LogLabel';
 
 const getStyles = (theme: GrafanaTheme2) => {
   return {

--- a/public/app/features/logs/components/LogLabels.tsx
+++ b/public/app/features/logs/components/LogLabels.tsx
@@ -9,16 +9,17 @@ const HIDDEN_LABELS = ['level', 'lvl', 'filename'];
 
 interface Props {
   labels: Labels;
+  emptyMessage?: string;
 }
 
-export const LogLabels = ({ labels }: Props) => {
+export const LogLabels = ({ labels, emptyMessage }: Props) => {
   const styles = useStyles2(getStyles);
   const displayLabels = useMemo(() => Object.keys(labels).filter((label) => !label.startsWith('_') && !HIDDEN_LABELS.includes(label)).sort(), [labels]);
 
-  if (displayLabels.length === 0) {
+  if (displayLabels.length === 0 && emptyMessage) {
     return (
       <span className={cx([styles.logsLabels])}>
-        <span className={cx([styles.logsLabel])}>(no unique labels)</span>
+        <span className={cx([styles.logsLabel])}>{emptyMessage}</span>
       </span>
     );
   }

--- a/public/app/features/logs/components/LogLabels.tsx
+++ b/public/app/features/logs/components/LogLabels.tsx
@@ -1,5 +1,5 @@
 import { css, cx } from '@emotion/css';
-import React from 'react';
+import React, { useMemo } from 'react';
 
 import { GrafanaTheme2, Labels } from '@grafana/data';
 import { useStyles2 } from '@grafana/ui';
@@ -13,7 +13,7 @@ interface Props {
 
 export const LogLabels = ({ labels }: Props) => {
   const styles = useStyles2(getStyles);
-  const displayLabels = Object.keys(labels).filter((label) => !label.startsWith('_') && !HIDDEN_LABELS.includes(label));
+  const displayLabels = useMemo(() => Object.keys(labels).filter((label) => !label.startsWith('_') && !HIDDEN_LABELS.includes(label)).sort(), [labels]);
 
   if (displayLabels.length === 0) {
     return (
@@ -25,23 +25,48 @@ export const LogLabels = ({ labels }: Props) => {
 
   return (
     <span className={cx([styles.logsLabels])}>
-      {displayLabels.sort().map((label) => {
+      {displayLabels.map((label) => {
         const value = labels[label];
         if (!value) {
           return;
         }
         const tooltip = `${label}: ${value}`;
-        return (
-          <span key={label} className={cx([styles.logsLabel])}>
-            <span className={cx([styles.logsLabelValue])} title={tooltip}>
-              {value}
-            </span>
-          </span>
-        );
+        return <LogLabel key={label} styles={styles} tooltip={tooltip}>{value}</LogLabel>;
       })}
     </span>
   );
 };
+
+interface LogLabelsArrayProps {
+  labels: string[];
+}
+
+export const LogLabelsList = ({ labels }: LogLabelsArrayProps) => {
+  const styles = useStyles2(getStyles);
+  return (
+    <span className={cx([styles.logsLabels])}>
+      {labels.map((label) => (
+        <LogLabel key={label} styles={styles} tooltip={label}>{label}</LogLabel>
+      ))}
+    </span>
+  );
+}
+
+interface LogLabelProps {
+  styles: Record<string, string>;
+  tooltip?: string;
+  children: JSX.Element | string;
+}
+
+const LogLabel = ({ styles, tooltip, children }: LogLabelProps) => {
+  return (
+    <span className={cx([styles.logsLabel])}>
+      <span className={cx([styles.logsLabelValue])} title={tooltip}>
+        {children}
+      </span>
+    </span>
+  )
+}
 
 const getStyles = (theme: GrafanaTheme2) => {
   return {

--- a/public/app/features/logs/components/LogLabels.tsx
+++ b/public/app/features/logs/components/LogLabels.tsx
@@ -12,7 +12,7 @@ interface Props {
   emptyMessage?: string;
 }
 
-export const LogLabels = ({ labels, emptyMessage }: Props) => {
+export const LogLabels = React.memo(({ labels, emptyMessage }: Props) => {
   const styles = useStyles2(getStyles);
   const displayLabels = useMemo(
     () =>
@@ -46,13 +46,14 @@ export const LogLabels = ({ labels, emptyMessage }: Props) => {
       })}
     </span>
   );
-};
+});
+LogLabels.displayName = 'LogLabels';
 
 interface LogLabelsArrayProps {
   labels: string[];
 }
 
-export const LogLabelsList = ({ labels }: LogLabelsArrayProps) => {
+export const LogLabelsList = React.memo(({ labels }: LogLabelsArrayProps) => {
   const styles = useStyles2(getStyles);
   return (
     <span className={cx([styles.logsLabels])}>
@@ -63,7 +64,8 @@ export const LogLabelsList = ({ labels }: LogLabelsArrayProps) => {
       ))}
     </span>
   );
-};
+});
+LogLabelsList.displayName = 'LogLabelsList';
 
 interface LogLabelProps {
   styles: Record<string, string>;

--- a/public/app/plugins/panel/logs/LogsPanel.test.tsx
+++ b/public/app/plugins/panel/logs/LogsPanel.test.tsx
@@ -87,7 +87,7 @@ describe('LogsPanel', () => {
         options: { showCommonLabels: true, sortOrder: LogsSortOrder.Descending },
       });
       expect(await screen.findByText(/common labels:/i)).toBeInTheDocument();
-      expect(container.firstChild?.childNodes[0].textContent).toMatch(/^Common labels:common_appcommon_job/);
+      expect(container.firstChild?.childNodes[0].textContent).toMatch(/^Common labels:app=common_appjob=common_job/);
     });
     it('shows common labels on bottom when ascending sort order', async () => {
       const { container } = setup({
@@ -95,7 +95,7 @@ describe('LogsPanel', () => {
         options: { showCommonLabels: true, sortOrder: LogsSortOrder.Ascending },
       });
       expect(await screen.findByText(/common labels:/i)).toBeInTheDocument();
-      expect(container.firstChild?.childNodes[0].textContent).toMatch(/Common labels:common_appcommon_job$/);
+      expect(container.firstChild?.childNodes[0].textContent).toMatch(/Common labels:app=common_appjob=common_job$/);
     });
     it('does not show common labels when showCommonLabels is set to false', async () => {
       setup({ data: { series: seriesWithCommonLabels }, options: { showCommonLabels: false } });

--- a/public/app/plugins/panel/logs/LogsPanel.tsx
+++ b/public/app/plugins/panel/logs/LogsPanel.tsx
@@ -227,7 +227,10 @@ export const LogsPanel = ({
   const renderCommonLabels = () => (
     <div className={cx(style.labelContainer, isAscending && style.labelContainerAscending)}>
       <span className={style.label}>Common labels:</span>
-      <LogLabels labels={typeof commonLabels?.value === 'object' ? commonLabels?.value : noCommonLabels} emptyMessage="(no common labels)" />
+      <LogLabels
+        labels={typeof commonLabels?.value === 'object' ? commonLabels?.value : noCommonLabels}
+        emptyMessage="(no common labels)"
+      />
     </div>
   );
 

--- a/public/app/plugins/panel/logs/LogsPanel.tsx
+++ b/public/app/plugins/panel/logs/LogsPanel.tsx
@@ -39,6 +39,8 @@ interface LogsPermalinkUrlState {
   };
 }
 
+const noCommonLabels: Labels = {};
+
 export const LogsPanel = ({
   data,
   timeZone,
@@ -225,7 +227,7 @@ export const LogsPanel = ({
   const renderCommonLabels = () => (
     <div className={cx(style.labelContainer, isAscending && style.labelContainerAscending)}>
       <span className={style.label}>Common labels:</span>
-      <LogLabels labels={commonLabels ? (commonLabels.value as Labels) : { labels: '(no common labels)' }} />
+      <LogLabels labels={typeof commonLabels?.value === 'object' ? commonLabels?.value : noCommonLabels} emptyMessage="(no common labels)" />
     </div>
   );
 


### PR DESCRIPTION
While querying in Explore, I looked at the "common labels" part of the Logs Meta Row component and was confused by it displaying many times "loki". Digging deeper, I not only found some components trying to do a bit too much and some TypeScript issues, but also that we were showing values without labels, resulting in things like:

![Before](https://github.com/grafana/grafana/assets/1069378/c4aeb8ee-dad8-4dcb-a10b-202f6da0a14b)

With these changes:
- We now show label names along with the values
- We fixed displayed fields that were showing a tooltip including the array key
- There's a specific component to render an array of labels 
- Types have been improved and `any` is no longer used
- When "show fields" are used we no longer sort the displayed fields on every row
- The component API has been improved

**What is this feature?**

Enhancement and bug fix.

**Why do we need this feature?**

Improves how we show common labels and addresses TypeScript issues.

**Special notes for your reviewer:**

![Dashboard after](https://github.com/grafana/grafana/assets/1069378/f59dad3b-aa6a-424d-aba2-948013418280)

![After](https://github.com/grafana/grafana/assets/1069378/9ee28254-67a5-45ff-a20d-53d6d222fa3f)

![After 2](https://github.com/grafana/grafana/assets/1069378/2aa5b503-43d7-4b7e-9798-4dbe5fee5f11)
