### PR TITLE
Explore: Work on unskipping test

### DIFF
--- a/public/app/features/explore/spec/queryHistory.test.tsx
+++ b/public/app/features/explore/spec/queryHistory.test.tsx
@@ -120,7 +120,7 @@ describe('Explore: Query History', () => {
   });
 
   // TODO: #86287
-  it.skip('adds recently added query if the query history panel is already open', async () => {
+  it('adds recently added query if the query history panel is already open', async () => {
     const urlParams = {
       left: serializeStateToUrlParam({
         datasource: 'loki',

--- a/public/app/features/explore/spec/queryHistory.test.tsx
+++ b/public/app/features/explore/spec/queryHistory.test.tsx
@@ -45,6 +45,11 @@ jest.mock('@grafana/runtime', () => ({
     reportInteractionMock(...args);
   },
   getAppEvents: () => testEventBus,
+  getDataSourceSrv: () => {
+    return {
+      get: () => Promise.resolve({}),
+    };
+  },
 }));
 
 jest.mock('app/core/core', () => ({

--- a/public/app/features/explore/spec/queryHistory.test.tsx
+++ b/public/app/features/explore/spec/queryHistory.test.tsx
@@ -123,7 +123,6 @@ describe('Explore: Query History', () => {
     });
   });
 
-  // TODO: #86287
   it('adds recently added query if the query history panel is already open', async () => {
     const urlParams = {
       left: serializeStateToUrlParam({

--- a/public/app/features/explore/spec/queryHistory.test.tsx
+++ b/public/app/features/explore/spec/queryHistory.test.tsx
@@ -45,11 +45,6 @@ jest.mock('@grafana/runtime', () => ({
     reportInteractionMock(...args);
   },
   getAppEvents: () => testEventBus,
-  getDataSourceSrv: () => {
-    return {
-      get: () => Promise.resolve({}),
-    };
-  },
 }));
 
 jest.mock('app/core/core', () => ({
@@ -71,6 +66,10 @@ jest.mock('app/core/services/PreferencesService', () => ({
       }),
     };
   },
+}));
+
+jest.mock('../hooks/useExplorePageTitle', () => ({
+  useExplorePageTitle: jest.fn(),
 }));
 
 jest.mock('react-virtualized-auto-sizer', () => {


### PR DESCRIPTION
**What is this feature?**

Try an alternate way to improve flakyness with queryHistory.test.ts

The test intermittently fails because `useExplorePageTitle` doesn't seem to get the datasource service in time and throws an error that it doesn't exist. This mocks that hook so it will never actually call through and thus not require the datasource service.

**Which issue(s) does this PR fix?**:

Fixes #86287