### PR TITLE
fix: datatrail link to "open in explore" prefix with `config.appSubUrl`

### DIFF
--- a/public/app/features/trails/MetricScene.tsx
+++ b/public/app/features/trails/MetricScene.tsx
@@ -152,10 +152,11 @@ export class MetricActionBar extends SceneObjectBase<MetricActionBarState> {
   public openExploreLink = async () => {
     reportExploreMetrics('selected_metric_action_clicked', { action: 'open_in_explore' });
     this.getLinkToExplore().then((link) => {
+      // We need to ensure we prefix with the appSubUrl for environments that don't host grafana at the root.
+      const url = `${config.appSubUrl}${link}`;
       // We use window.open instead of a Link or <a> because we want to compute the explore link when clicking,
       // if we precompute it we have to keep track of a lot of dependencies
-      // We also need to ensure we prefix with the appSubUrl for environments that don't host grafana at the root.
-      window.open(`${config.appSubUrl}}${link}`, '_blank');
+      window.open(url, '_blank');
     });
   };
 

--- a/public/app/features/trails/MetricScene.tsx
+++ b/public/app/features/trails/MetricScene.tsx
@@ -2,6 +2,7 @@ import { css } from '@emotion/css';
 import React from 'react';
 
 import { GrafanaTheme2 } from '@grafana/data';
+import { config } from '@grafana/runtime';
 import {
   SceneObjectState,
   SceneObjectBase,
@@ -153,7 +154,8 @@ export class MetricActionBar extends SceneObjectBase<MetricActionBarState> {
     this.getLinkToExplore().then((link) => {
       // We use window.open instead of a Link or <a> because we want to compute the explore link when clicking,
       // if we precompute it we have to keep track of a lot of dependencies
-      window.open(link, '_blank');
+      // We also need to ensure we prefix with the appSubUrl for environments that don't host grafana at the root.
+      window.open(`${config.appSubUrl}}${link}`, '_blank');
     });
   };
 

--- a/public/app/features/trails/ShareTrailButton.tsx
+++ b/public/app/features/trails/ShareTrailButton.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
-import { useLocation } from 'react-use';
 
+import { config } from '@grafana/runtime';
 import { ToolbarButton } from '@grafana/ui';
 
 import { DataTrail } from './DataTrail';
@@ -12,13 +12,12 @@ interface ShareTrailButtonState {
 }
 
 export const ShareTrailButton = ({ trail }: ShareTrailButtonState) => {
-  const { origin } = useLocation();
   const [tooltip, setTooltip] = useState('Copy url');
 
   const onShare = () => {
     if (navigator.clipboard) {
-      navigator.clipboard.writeText(origin + getUrlForTrail(trail));
       reportExploreMetrics('selected_metric_action_clicked', { action: 'share_url' });
+      navigator.clipboard.writeText(config.appUrl + getUrlForTrail(trail));
       setTooltip('Copied!');
       setTimeout(() => {
         setTooltip('Copy url');

--- a/public/app/features/trails/ShareTrailButton.tsx
+++ b/public/app/features/trails/ShareTrailButton.tsx
@@ -17,7 +17,9 @@ export const ShareTrailButton = ({ trail }: ShareTrailButtonState) => {
   const onShare = () => {
     if (navigator.clipboard) {
       reportExploreMetrics('selected_metric_action_clicked', { action: 'share_url' });
-      navigator.clipboard.writeText(config.appUrl + getUrlForTrail(trail));
+      const appUrl = config.appUrl.endsWith('/') ? config.appUrl.slice(0, -1) : config.appUrl;
+      const url = appUrl + getUrlForTrail(trail);
+      navigator.clipboard.writeText(url);
       setTooltip('Copied!');
       setTimeout(() => {
         setTooltip('Copy url');


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

In certain environments, the base url of Grafana is not at the root. 
E.g., `https://my.com/grafana`
Our "open on explore" button was not taking this into consideration.
This fix uses `appSubUrl` as a URL prefix, resulting in:
`https://my.com/grafana/explore?...`
vs
`https://my.com/explore?...`
which was causing 404 errors in mentioned certain environments.


**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
