### PR TITLE
CloudMonitoring: Ensure variables can be used in all variable queries

### DIFF
--- a/public/app/plugins/datasource/cloud-monitoring/components/VariableQueryEditor.tsx
+++ b/public/app/plugins/datasource/cloud-monitoring/components/VariableQueryEditor.tsx
@@ -278,6 +278,7 @@ export class CloudMonitoringVariableQueryEditor extends PureComponent<Props, Var
             />
           </>
         );
+      case MetricFindQueryTypes.Services:
       case MetricFindQueryTypes.SLOServices:
         return (
           <>

--- a/public/app/plugins/datasource/cloud-monitoring/components/VariableQueryEditor.tsx
+++ b/public/app/plugins/datasource/cloud-monitoring/components/VariableQueryEditor.tsx
@@ -160,7 +160,7 @@ export class CloudMonitoringVariableQueryEditor extends PureComponent<Props, Var
   async onMetricTypeChange(metricType: string) {
     const state = {
       selectedMetricType: metricType,
-      ...(await this.getLabels(metricType, this.state.projectName)),
+      ...(await this.getLabels(getTemplateSrv().replace(metricType), this.state.projectName)),
     };
     this.setState(state, () => this.onPropsChange());
   }

--- a/public/app/plugins/datasource/cloud-monitoring/datasource.ts
+++ b/public/app/plugins/datasource/cloud-monitoring/datasource.ts
@@ -108,7 +108,7 @@ export default class CloudMonitoringDatasource extends DataSourceWithBackend<
               crossSeriesReducer: aggregation?.crossSeriesReducer ?? 'REDUCE_NONE',
               view: 'HEADERS',
             },
-            metricType
+            this.templateSrv.replace(metricType)
           ),
         },
       ],


### PR DESCRIPTION
The query properties weren't correctly interpolated for all variable query types. This PR updates the logic to ensure we always interpolate all properties.

Additionally, I've added logic to allow specifying the `Project` when running a `Services` variable query.

Fixes #69672