### PR TITLE
Update whats-new-in-v11-0.md

### DIFF
--- a/docs/sources/whatsnew/whats-new-in-v11-0.md
+++ b/docs/sources/whatsnew/whats-new-in-v11-0.md
@@ -25,7 +25,7 @@ Welcome to Grafana 11.0-preview! This release contains some major improvements: 
 
 Why "preview?" The Grafana 11.0 stable release is planned for this May. This is an early release to coincide with [Grafanacon 2024](https://grafana.com/about/events/grafanacon/2024/), so that you can try the new functionality early. To understand the differences between preview and GA releases, review the [release life cycle](https://grafana.com/docs/release-life-cycle/).
 
-For even more detail about all the changes in this release, refer to the [changelog](https://github.com/grafana/grafana/blob/main/CHANGELOG.md). For the specific steps we recommend when you upgrade to v11.0-preview, check out our [Upgrade Guide](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/upgrade-guide/upgrade-v11.0/).
+For even more detail about all the changes in this release, refer to the [changelog](https://github.com/grafana/grafana/blob/main/CHANGELOG.md). For the specific steps we recommend when you upgrade to v11.0-preview, check out our [Upgrade Guide](https://grafana.com/docs/grafana/next/upgrade-guide/upgrade-v11.0/).
 
 ## Breaking changes
 

--- a/docs/sources/whatsnew/whats-new-in-v11-0.md
+++ b/docs/sources/whatsnew/whats-new-in-v11-0.md
@@ -54,7 +54,7 @@ Use full URLs for links. When linking to versioned docs, replace the version wit
 
 <!-- #proj-datatrails-dev, PM: Jay Goodson, Engineering: Darren Janeczek, André Pereira, Design: Catherine Gui -->
 
-_Public preview in all editions of Grafana_
+_Private preview in all editions of Grafana_
 
 Explore Metrics is a query-less experience for browsing Prometheus-compatible metrics. Search or filter to find a metric. Quickly find related metrics - all in just a few clicks. No PromQL to be found anywhere! With Explore Metrics, you can:
 

--- a/docs/sources/whatsnew/whats-new-in-v11-0.md
+++ b/docs/sources/whatsnew/whats-new-in-v11-0.md
@@ -54,7 +54,7 @@ Use full URLs for links. When linking to versioned docs, replace the version wit
 
 <!-- #proj-datatrails-dev, PM: Jay Goodson, Engineering: Darren Janeczek, André Pereira, Design: Catherine Gui -->
 
-_Private preview in all editions of Grafana_
+_Public preview in all editions of Grafana_
 
 Explore Metrics is a query-less experience for browsing Prometheus-compatible metrics. Search or filter to find a metric. Quickly find related metrics - all in just a few clicks. No PromQL to be found anywhere! With Explore Metrics, you can:
 


### PR DESCRIPTION
Inconsistency in https://grafana.com/docs/grafana/latest/whatsnew/whats-new-in-v11-0/ and https://grafana.com/docs/grafana/latest/explore/explore-metrics/ Explore Metrics is currently in private preview. Grafana Labs offers support on a best-effort basis, and breaking changes might occur prior to the feature being made generally available. 

This mismatch is because the feature is in private preview in version 10.4 and in public preview in version 11. However, the 11-preview What's new page points to the version 10.4 documentation for the feature. This PR updates the docs link to point to the version 11 docs. These docs have also been updated to reflect the correct release stage on PR #86390 
