### PR TITLE
CloudMonitoring: Correctly interpolate multi-valued template variables in PromQL queries

### DIFF
--- a/public/app/plugins/datasource/cloud-monitoring/datasource.test.ts
+++ b/public/app/plugins/datasource/cloud-monitoring/datasource.test.ts
@@ -1,7 +1,7 @@
 import { get } from 'lodash';
 import { lastValueFrom, of } from 'rxjs';
 
-import { CustomVariableModel } from '@grafana/data';
+import { CustomVariableModel, ScopedVars } from '@grafana/data';
 import { getTemplateSrv } from '@grafana/runtime';
 
 import { createMockInstanceSetttings } from './__mocks__/cloudMonitoringInstanceSettings';
@@ -84,12 +84,14 @@ describe('Cloud Monitoring Datasource', () => {
     });
     it('should correctly apply template variables for PromQLQuery (multi-value)', () => {
       const templateSrv = getTemplateSrv();
-      templateSrv.replace = jest.fn().mockImplementation((_target: any, _v2: any, formatFunction: Function) => {
-        if (formatFunction) {
-          return formatFunction(['filter-variable', 'filter-variable2']);
-        }
-        return undefined;
-      });
+      templateSrv.replace = jest
+        .fn()
+        .mockImplementation((_target: string, _v2: ScopedVars, formatFunction: Function) => {
+          if (formatFunction) {
+            return formatFunction(['filter-variable', 'filter-variable2']);
+          }
+          return undefined;
+        });
       const mockInstanceSettings = createMockInstanceSetttings();
       const ds = new Datasource(mockInstanceSettings, templateSrv);
       const query = createMockQuery({ promQLQuery: { expr: '$testVar', projectName: 'test-project', step: '1' } });

--- a/public/app/plugins/datasource/cloud-monitoring/datasource.ts
+++ b/public/app/plugins/datasource/cloud-monitoring/datasource.ts
@@ -295,7 +295,7 @@ export default class CloudMonitoringDatasource extends DataSourceWithBackend<
     return query;
   }
 
-  interpolatePromQLQuery(value: any, _variable: QueryVariableModel) {
+  interpolatePromQLQuery(value: string | string[], _variable: QueryVariableModel) {
     if (isArray(value)) {
       return value.join('|');
     }

--- a/public/app/plugins/datasource/cloud-monitoring/datasource.ts
+++ b/public/app/plugins/datasource/cloud-monitoring/datasource.ts
@@ -309,7 +309,7 @@ export default class CloudMonitoringDatasource extends DataSourceWithBackend<
   ): T {
     return Object.entries(object).reduce((acc, [key, value]) => {
       let interpolatedValue = value;
-      if (interpolatedValue && isString(value)) {
+      if (value && isString(value)) {
         // Pass a function to the template service for formatting
         interpolatedValue = this.templateSrv.replace(
           value,

--- a/public/app/plugins/datasource/cloud-monitoring/datasource.ts
+++ b/public/app/plugins/datasource/cloud-monitoring/datasource.ts
@@ -6,6 +6,7 @@ import {
   DataQueryRequest,
   DataQueryResponse,
   DataSourceInstanceSettings,
+  QueryVariableModel,
   ScopedVars,
   SelectableValue,
   TimeRange,
@@ -84,7 +85,7 @@ export default class CloudMonitoringDatasource extends DataSourceWithBackend<
         ),
       },
       sloQuery: sloQuery && this.interpolateProps(sloQuery, scopedVars),
-      promQLQuery: promQLQuery && this.interpolateProps(promQLQuery, scopedVars),
+      promQLQuery: promQLQuery && this.interpolateProps(promQLQuery, scopedVars, { expr: this.interpolatePromQLQuery }),
     };
   }
 
@@ -294,11 +295,31 @@ export default class CloudMonitoringDatasource extends DataSourceWithBackend<
     return query;
   }
 
-  interpolateProps<T extends Record<string, any>>(object: T, scopedVars: ScopedVars = {}): T {
+  interpolatePromQLQuery(value: any, _variable: QueryVariableModel) {
+    if (isArray(value)) {
+      return value.join('|');
+    }
+    return value;
+  }
+
+  interpolateProps<T extends Record<string, any>>(
+    object: T,
+    scopedVars: ScopedVars = {},
+    formattingFunctions?: { [key: string]: Function | undefined }
+  ): T {
     return Object.entries(object).reduce((acc, [key, value]) => {
+      let interpolatedValue = value;
+      if (interpolatedValue && isString(value)) {
+        // Pass a function to the template service for formatting
+        interpolatedValue = this.templateSrv.replace(
+          value,
+          scopedVars,
+          formattingFunctions && formattingFunctions[key]
+        );
+      }
       return {
         ...acc,
-        [key]: value && isString(value) ? this.templateSrv.replace(value, scopedVars) : value,
+        [key]: interpolatedValue,
       };
     }, {} as T);
   }


### PR DESCRIPTION
Filters in PromQL should be joined using the `|` operator rather than a `,`. This PR adds support for specifying a function that will be used for formatting for each property in a query. I've only included a custom formatted for the `expr` property in the `promQlQuery` type.

The default now is to join any multi-valued variables using a pipe, otherwise the value will be returned as is.

To test this:

- Create a template variable called `labelValues` (ideally use the label values query variable). Enable the `multi` option.
- Run the following query against the `Compute` service on the default project: `compute_googleapis_com:instance_cpu_utilization{instance_name=~"$labelValues"}`

The query should succeed with these changes when you select multiple values for the variable.

Fixes #78619