### PR TITLE
Chore: `ForgottenPassword` - Replace `HorizontalGroup` with `Stack`

### DIFF
--- a/.betterer.results
+++ b/.betterer.results
@@ -1172,9 +1172,6 @@ exports[`better eslint`] = {
     "public/app/core/components/ForgottenPassword/ChangePassword.tsx:5381": [
       [0, 0, 0, "\'VerticalGroup\' import from \'@grafana/ui\' is restricted from being used by a pattern. Use Stack component instead.", "0"]
     ],
-    "public/app/core/components/ForgottenPassword/ForgottenPassword.tsx:5381": [
-      [0, 0, 0, "\'HorizontalGroup\' import from \'@grafana/ui\' is restricted from being used by a pattern. Use Stack component instead.", "0"]
-    ],
     "public/app/core/components/GraphNG/GraphNG.tsx:5381": [
       [0, 0, 0, "Unexpected any. Specify a different type.", "0"],
       [0, 0, 0, "Unexpected any. Specify a different type.", "1"],

--- a/public/app/core/components/ForgottenPassword/ForgottenPassword.tsx
+++ b/public/app/core/components/ForgottenPassword/ForgottenPassword.tsx
@@ -4,7 +4,7 @@ import { useForm } from 'react-hook-form';
 
 import { GrafanaTheme2 } from '@grafana/data';
 import { getBackendSrv } from '@grafana/runtime';
-import { Field, Input, Button, Legend, Container, useStyles2, HorizontalGroup, LinkButton } from '@grafana/ui';
+import { Field, Input, Button, Legend, Container, useStyles2, LinkButton, Stack } from '@grafana/ui';
 import config from 'app/core/config';
 
 interface EmailDTO {
@@ -63,12 +63,12 @@ export const ForgottenPassword = () => {
           {...register('userOrEmail', { required: 'Email or username is required' })}
         />
       </Field>
-      <HorizontalGroup>
+      <Stack>
         <Button type="submit">Send reset email</Button>
         <LinkButton fill="text" href={loginHref}>
           Back to login
         </LinkButton>
-      </HorizontalGroup>
+      </Stack>
 
       <p className={styles}>Did you forget your username or email? Contact your Grafana administrator.</p>
     </form>


### PR DESCRIPTION
**What is this feature?**
This is part of the epic https://github.com/grafana/grafana/issues/85510

**Why do we need this feature?**
To replace deprecated layout components with new ones.

**Who is this feature for?**
Everybody

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**
**Before:**
<img width="498" alt="Captura de pantalla 2024-04-16 a las 21 08 05" src="https://github.com/grafana/grafana/assets/65417731/b7a9d794-0c4b-4196-ad94-ecbb7f98d616">

**After:**
<img width="506" alt="Captura de pantalla 2024-04-16 a las 21 10 01" src="https://github.com/grafana/grafana/assets/65417731/22a33349-8251-48a4-bf23-731b5ec66e56">

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
