### PR TITLE
InfluxDB: Fix interpolation for floating point number values

### DIFF
--- a/public/app/plugins/datasource/influxdb/datasource.test.ts
+++ b/public/app/plugins/datasource/influxdb/datasource.test.ts
@@ -508,6 +508,22 @@ describe('InfluxDataSource Frontend Mode', () => {
         const expectation = `(\\/special\\/path|\\/some\\/other\\/path)`;
         expect(result).toBe(expectation);
       });
+
+      it('should return floating point number as it is', () => {
+        const variableMock = queryBuilder()
+          .withId('tempVar')
+          .withName('tempVar')
+          .withMulti(false)
+          .withOptions({
+            text: `1.0`,
+            value: `1.0`,
+          })
+          .build();
+        const value = `1.0`;
+        const result = ds.interpolateQueryExpr(value, variableMock, `select value / $tempVar from /^measurement$/`);
+        const expectation = `1.0`;
+        expect(result).toBe(expectation);
+      });
     });
   });
 });

--- a/public/app/plugins/datasource/influxdb/datasource.ts
+++ b/public/app/plugins/datasource/influxdb/datasource.ts
@@ -315,6 +315,13 @@ export default class InfluxDatasource extends DataSourceWithBackend<InfluxQuery,
       return value;
     }
 
+    if (typeof value === 'string') {
+      // Check the value is a number. If not run to escape special characters
+      if (!isNaN(parseFloat(value))) {
+        return value;
+      }
+    }
+
     // If template variable is a multi-value variable
     // we always want to deal with special chars.
     if (variable.multi) {


### PR DESCRIPTION
**What is this feature?**

While interpolating, variables that have floating point values escaped. This leads to a broken query being sent. Here we check if the value is an integer or not. If it is an integer we return the value as it is.

**Why do we need this feature?**

Better interpolation

**Who is this feature for?**

InfluxDB influxQL query language

**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/grafana/issues/86380

**Special notes for your reviewer:**

### How to test
- Have a template variable whose value is a floating point number i.e. `42.24`
  - You can use `Custom` or `Text box` variable types
- Have a panel with `influxql` and in the code mode apply following query 
```
SELECT floor("usage_idle" / ($floating_point)) FROM /^cpu$/ WHERE $timeFilter
```
- Observe that the query returns error
- Switch to this branch and try again
- Also try using number in different places of the query

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
