### PR TITLE
Grafana UI: Replace `VerticalGroup` with `Stack` on alerts documentation in Storybook

### DIFF
--- a/.betterer.results
+++ b/.betterer.results
@@ -785,12 +785,6 @@ exports[`better eslint`] = {
     "packages/grafana-sql/src/components/visual-query-builder/SQLWhereRow.tsx:5381": [
       [0, 0, 0, "Do not use any type assertions.", "0"]
     ],
-    "packages/grafana-ui/src/components/Alert/InlineBanner.story.tsx:5381": [
-      [0, 0, 0, "\'VerticalGroup\' import from \'@grafana/ui\' is restricted from being used by a pattern. Use Stack component instead.", "0"]
-    ],
-    "packages/grafana-ui/src/components/Alert/Toast.story.tsx:5381": [
-      [0, 0, 0, "\'VerticalGroup\' import from \'@grafana/ui\' is restricted from being used by a pattern. Use Stack component instead.", "0"]
-    ],
     "packages/grafana-ui/src/components/ColorPicker/ColorPicker.tsx:5381": [
       [0, 0, 0, "Unexpected any. Specify a different type.", "0"],
       [0, 0, 0, "Unexpected any. Specify a different type.", "1"]

--- a/packages/grafana-ui/src/components/Alert/Alert.mdx
+++ b/packages/grafana-ui/src/components/Alert/Alert.mdx
@@ -104,9 +104,7 @@ Inline Banners are task-oriented alerts that notify users of the status of an ac
 
 ```jsx
 <Alert title={title} severity={severity} buttonContent={buttonContent} onRemove={onRemove}>
-  <Stack direction="column">
-    <div>Child content that includes some alert details, like maybe what actually happened.</div>
-  </Stack>
+  Child content that includes some alert details, like maybe what actually happened.</div>
 </Alert>
 ```
 
@@ -149,9 +147,7 @@ appEvents.publish({
 
 ```jsx
 <Alert title={title} severity={severity} onRemove={onRemove} elevated>
-  <Stack direction="column">
-    <div>Child content that includes some alert details, like maybe what actually happened.</div>
-  </Stack>
+  Child content that includes some alert details, like maybe what actually happened.
 </Alert>
 ```
 

--- a/packages/grafana-ui/src/components/Alert/Alert.mdx
+++ b/packages/grafana-ui/src/components/Alert/Alert.mdx
@@ -104,9 +104,9 @@ Inline Banners are task-oriented alerts that notify users of the status of an ac
 
 ```jsx
 <Alert title={title} severity={severity} buttonContent={buttonContent} onRemove={onRemove}>
-  <VerticalGroup>
+  <Stack direction="column">
     <div>Child content that includes some alert details, like maybe what actually happened.</div>
-  </VerticalGroup>
+  </Stack>
 </Alert>
 ```
 
@@ -149,9 +149,9 @@ appEvents.publish({
 
 ```jsx
 <Alert title={title} severity={severity} onRemove={onRemove} elevated>
-  <VerticalGroup>
+  <Stack direction="column">
     <div>Child content that includes some alert details, like maybe what actually happened.</div>
-  </VerticalGroup>
+  </Stack>
 </Alert>
 ```
 

--- a/packages/grafana-ui/src/components/Alert/InlineBanner.story.tsx
+++ b/packages/grafana-ui/src/components/Alert/InlineBanner.story.tsx
@@ -29,11 +29,7 @@ const meta: Meta = {
 export const Basic: StoryFn<typeof Alert> = (args) => {
   return (
     <div>
-      <Alert {...args}>
-        <Stack direction="column">
-          <div>Child content that includes some alert details, like maybe what actually happened.</div>
-        </Stack>
-      </Alert>
+      <Alert {...args}>Child content that includes some alert details, like maybe what actually happened.</Alert>
     </div>
   );
 };
@@ -44,13 +40,7 @@ Basic.args = {
 };
 
 export const WithActions: StoryFn<typeof Alert> = (args) => {
-  return (
-    <Alert {...args}>
-      <Stack direction="column">
-        <div>Child content that includes some alert details, like maybe what actually happened.</div>
-      </Stack>
-    </Alert>
-  );
+  return <Alert {...args}>Child content that includes some alert details, like maybe what actually happened.</Alert>;
 };
 
 WithActions.args = {

--- a/packages/grafana-ui/src/components/Alert/InlineBanner.story.tsx
+++ b/packages/grafana-ui/src/components/Alert/InlineBanner.story.tsx
@@ -2,7 +2,7 @@ import { action } from '@storybook/addon-actions';
 import { StoryFn, Meta } from '@storybook/react';
 import React from 'react';
 
-import { Alert, AlertVariant, VerticalGroup } from '@grafana/ui';
+import { Alert, AlertVariant, Stack } from '@grafana/ui';
 
 import { StoryExample } from '../../utils/storybook/StoryExample';
 
@@ -30,9 +30,9 @@ export const Basic: StoryFn<typeof Alert> = (args) => {
   return (
     <div>
       <Alert {...args}>
-        <VerticalGroup>
+        <Stack direction="column">
           <div>Child content that includes some alert details, like maybe what actually happened.</div>
-        </VerticalGroup>
+        </Stack>
       </Alert>
     </div>
   );
@@ -46,9 +46,9 @@ Basic.args = {
 export const WithActions: StoryFn<typeof Alert> = (args) => {
   return (
     <Alert {...args}>
-      <VerticalGroup>
+      <Stack direction="column">
         <div>Child content that includes some alert details, like maybe what actually happened.</div>
-      </VerticalGroup>
+      </Stack>
     </Alert>
   );
 };
@@ -62,7 +62,7 @@ WithActions.args = {
 
 export const Examples: StoryFn<typeof Alert> = () => {
   return (
-    <VerticalGroup>
+    <Stack direction="column">
       <StoryExample name="With buttonContent and children">
         <Alert
           title={'The title of the alert'}
@@ -77,15 +77,15 @@ export const Examples: StoryFn<typeof Alert> = () => {
         <Alert title={'No dismiss'} severity={'success'} />
       </StoryExample>
       <StoryExample name="Severities">
-        <VerticalGroup>
+        <Stack direction="column">
           {severities.map((severity) => (
             <Alert title={`Severity: ${severity}`} severity={severity} key={severity}>
               Child content
             </Alert>
           ))}
-        </VerticalGroup>
+        </Stack>
       </StoryExample>
-    </VerticalGroup>
+    </Stack>
   );
 };
 

--- a/packages/grafana-ui/src/components/Alert/Toast.story.tsx
+++ b/packages/grafana-ui/src/components/Alert/Toast.story.tsx
@@ -33,9 +33,7 @@ export const Basic: StoryFn<typeof Alert> = (args) => {
   return (
     <div className="page-alert-list">
       <Alert {...args} elevated>
-        <Stack direction="column">
-          <div>Child content that includes some alert details, like maybe what actually happened.</div>
-        </Stack>
+        Child content that includes some alert details, like maybe what actually happened.
       </Alert>
     </div>
   );

--- a/packages/grafana-ui/src/components/Alert/Toast.story.tsx
+++ b/packages/grafana-ui/src/components/Alert/Toast.story.tsx
@@ -2,7 +2,7 @@ import { action } from '@storybook/addon-actions';
 import { StoryFn, Meta } from '@storybook/react';
 import React from 'react';
 
-import { Alert, AlertVariant, VerticalGroup } from '@grafana/ui';
+import { Alert, AlertVariant, Stack } from '@grafana/ui';
 
 import { StoryExample } from '../../utils/storybook/StoryExample';
 
@@ -33,9 +33,9 @@ export const Basic: StoryFn<typeof Alert> = (args) => {
   return (
     <div className="page-alert-list">
       <Alert {...args} elevated>
-        <VerticalGroup>
+        <Stack direction="column">
           <div>Child content that includes some alert details, like maybe what actually happened.</div>
-        </VerticalGroup>
+        </Stack>
       </Alert>
     </div>
   );
@@ -43,9 +43,9 @@ export const Basic: StoryFn<typeof Alert> = (args) => {
 
 export function Examples() {
   return (
-    <VerticalGroup>
+    <Stack direction="column">
       <StoryExample name="Severities">
-        <VerticalGroup>
+        <Stack direction="column">
           {severities.map((severity) => (
             <Alert
               title={`Severity: ${severity}`}
@@ -55,7 +55,7 @@ export function Examples() {
               elevated={true}
             />
           ))}
-        </VerticalGroup>
+        </Stack>
       </StoryExample>
       <StoryExample name="With huge payload">
         <Alert title="Alert with huge payload" severity="error" elevated={true}>
@@ -124,7 +124,7 @@ export function Examples() {
           Vivamus sit amet dui semper, suscipit est nec, elementum arcu. Praesent ante turpis, convallis ac leo eget,
         </Alert>
       </StoryExample>
-    </VerticalGroup>
+    </Stack>
   );
 }
 


### PR DESCRIPTION
**What is this feature?**
This is part of the epic https://github.com/grafana/grafana/issues/85510

**Why do we need this feature?**
To replace deprecated layout components with new ones.

**Who is this feature for?**
Everybody

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
