### PR TITLE
InfluxDB: Fix interpolating field keys in influxql

### DIFF
--- a/public/app/plugins/datasource/influxdb/datasource.test.ts
+++ b/public/app/plugins/datasource/influxdb/datasource.test.ts
@@ -296,7 +296,7 @@ describe('InfluxDataSource Frontend Mode', () => {
       expect(query.tz).toBe(text);
       expect(query.tags![0].value).toBe(textWithFormatRegex);
       expect(query.groupBy![0].params![0]).toBe(justText);
-      expect(query.select![0][0].params![0]).toBe(textWithFormatRegex);
+      expect(query.select![0][0].params![0]).toBe(justText);
       expect(query.adhocFilters?.[0].key).toBe(adhocFilters[0].key);
     }
 

--- a/public/app/plugins/datasource/influxdb/datasource.test.ts
+++ b/public/app/plugins/datasource/influxdb/datasource.test.ts
@@ -296,7 +296,7 @@ describe('InfluxDataSource Frontend Mode', () => {
       expect(query.tz).toBe(text);
       expect(query.tags![0].value).toBe(textWithFormatRegex);
       expect(query.groupBy![0].params![0]).toBe(justText);
-      expect(query.select![0][0].params![0]).toBe(justText);
+      expect(query.select![0][0].params![0]).toBe(textWithFormatRegex);
       expect(query.adhocFilters?.[0].key).toBe(adhocFilters[0].key);
     }
 

--- a/public/app/plugins/datasource/influxdb/datasource.ts
+++ b/public/app/plugins/datasource/influxdb/datasource.ts
@@ -254,14 +254,7 @@ export default class InfluxDatasource extends DataSourceWithBackend<InfluxQuery,
         return selects.map((select) => {
           return {
             ...select,
-            params: select.params?.map((param) =>
-              this.templateSrv.replace(
-                param.toString() ?? '',
-                scopedVars,
-                (value: string | string[] = [], variable: QueryVariableModel) =>
-                  this.interpolateQueryExpr(value, variable, param.toString())
-              )
-            ),
+            params: select.params?.map((param) => this.templateSrv.replace(param.toString(), scopedVars)),
           };
         });
       });

--- a/public/app/plugins/datasource/influxdb/datasource.ts
+++ b/public/app/plugins/datasource/influxdb/datasource.ts
@@ -254,7 +254,14 @@ export default class InfluxDatasource extends DataSourceWithBackend<InfluxQuery,
         return selects.map((select) => {
           return {
             ...select,
-            params: select.params?.map((param) => this.templateSrv.replace(param.toString(), undefined)),
+            params: select.params?.map((param) =>
+              this.templateSrv.replace(
+                param.toString() ?? '',
+                scopedVars,
+                (value: string | string[] = [], variable: QueryVariableModel) =>
+                  this.interpolateQueryExpr(value, variable, param.toString())
+              )
+            ),
           };
         });
       });

--- a/public/app/plugins/datasource/influxdb/datasource_backend_mode.test.ts
+++ b/public/app/plugins/datasource/influxdb/datasource_backend_mode.test.ts
@@ -187,7 +187,7 @@ describe('InfluxDataSource Backend Mode', () => {
       expect(query.tz).toBe(text);
       expect(query.tags![0].value).toBe(textWithFormatRegex);
       expect(query.groupBy![0].params![0]).toBe(justText);
-      expect(query.select![0][0].params![0]).toBe(textWithFormatRegex);
+      expect(query.select![0][0].params![0]).toBe(justText);
       expect(query.adhocFilters?.[0].key).toBe(adhocFilters[0].key);
     }
 
@@ -349,7 +349,7 @@ describe('InfluxDataSource Backend Mode', () => {
       expect(res.tags?.[0].value).toEqual(expected);
     });
 
-    it('should interpolate field keys', () => {
+    it('should interpolate field keys with given scopedVars', () => {
       const query: InfluxQuery = {
         refId: 'A',
         tags: [
@@ -372,8 +372,8 @@ describe('InfluxDataSource Backend Mode', () => {
           ],
         ],
       };
-      const res = ds.applyVariables(query, {});
-      const expected = `(field_1|field_3)`;
+      const res = ds.applyVariables(query, { field_var: { text: 'field_3', value: 'field_3' } });
+      const expected = `field_3`;
       expect(res.select?.[0][0].params?.[0]).toEqual(expected);
     });
   });

--- a/public/app/plugins/datasource/influxdb/datasource_backend_mode.test.ts
+++ b/public/app/plugins/datasource/influxdb/datasource_backend_mode.test.ts
@@ -187,7 +187,7 @@ describe('InfluxDataSource Backend Mode', () => {
       expect(query.tz).toBe(text);
       expect(query.tags![0].value).toBe(textWithFormatRegex);
       expect(query.groupBy![0].params![0]).toBe(justText);
-      expect(query.select![0][0].params![0]).toBe(justText);
+      expect(query.select![0][0].params![0]).toBe(textWithFormatRegex);
       expect(query.adhocFilters?.[0].key).toBe(adhocFilters[0].key);
     }
 
@@ -221,6 +221,26 @@ describe('InfluxDataSource Backend Mode', () => {
     const variablesMock = [
       queryBuilder().withId('var1').withName('var1').withCurrent('var1').build(),
       queryBuilder().withId('path').withName('path').withCurrent('/etc/hosts').build(),
+      queryBuilder()
+        .withId('field_var')
+        .withName('field_var')
+        .withMulti(true)
+        .withOptions(
+          {
+            text: `field_1`,
+            value: `field_1`,
+          },
+          {
+            text: `field_2`,
+            value: `field_2`,
+          },
+          {
+            text: `field_3`,
+            value: `field_3`,
+          }
+        )
+        .withCurrent(['field_1', 'field_3'])
+        .build(),
     ];
     const mockTemplateService = new TemplateSrv({
       getVariables: () => variablesMock,
@@ -327,6 +347,34 @@ describe('InfluxDataSource Backend Mode', () => {
       const res = ds.applyVariables(query, {});
       const expected = `/etc/hosts`;
       expect(res.tags?.[0].value).toEqual(expected);
+    });
+
+    it('should interpolate field keys', () => {
+      const query: InfluxQuery = {
+        refId: 'A',
+        tags: [
+          {
+            key: 'key',
+            operator: '=',
+            value: 'value',
+          },
+        ],
+        select: [
+          [
+            {
+              type: 'field',
+              params: ['$field_var'],
+            },
+            {
+              type: 'mean',
+              params: [],
+            },
+          ],
+        ],
+      };
+      const res = ds.applyVariables(query, {});
+      const expected = `(field_1|field_3)`;
+      expect(res.select?.[0][0].params?.[0]).toEqual(expected);
     });
   });
 


### PR DESCRIPTION
**What is this feature?**

Improve ability to interpolate field keys in `influxql` queries.

**Why do we need this feature?**

Better interpolation

**Who is this feature for?**

InfluxDB influxQL query language

**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/grafana/issues/86208

**Special notes for your reviewer:**
### How to test
- Have a template variable which has "Multi value" option enabled
  - You can use `SHOW FIELD KEYS FROM cpu` as query
- Have a panel with `influxql` and create the query as shown
![image](https://github.com/grafana/grafana/assets/820946/e7073190-c555-4d54-9bda-dad2747aaabe)
- Observe that the query returns nothing
- Switch to this branch and try again

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
