### PR TITLE
Prometheus: Cancellable label values requests

### DIFF
--- a/packages/grafana-prometheus/src/datasource.ts
+++ b/packages/grafana-prometheus/src/datasource.ts
@@ -729,8 +729,9 @@ export class PrometheusDatasource
     const expr = promQueryModeller.renderLabels(labelFilters);
 
     if (this.hasLabelsMatchAPISupport()) {
+      const requestId = `[${this.uid}][${options.key}]`;
       return (
-        await this.languageProvider.fetchSeriesValuesWithMatch(options.key, expr, options.key, options.timeRange)
+        await this.languageProvider.fetchSeriesValuesWithMatch(options.key, expr, requestId, options.timeRange)
       ).map((v) => ({
         value: v,
         text: v,

--- a/packages/grafana-prometheus/src/datasource.ts
+++ b/packages/grafana-prometheus/src/datasource.ts
@@ -729,12 +729,12 @@ export class PrometheusDatasource
     const expr = promQueryModeller.renderLabels(labelFilters);
 
     if (this.hasLabelsMatchAPISupport()) {
-      return (await this.languageProvider.fetchSeriesValuesWithMatch(options.key, expr, options.timeRange)).map(
-        (v) => ({
-          value: v,
-          text: v,
-        })
-      );
+      return (
+        await this.languageProvider.fetchSeriesValuesWithMatch(options.key, expr, options.key, options.timeRange)
+      ).map((v) => ({
+        value: v,
+        text: v,
+      }));
     }
 
     const params = this.getTimeRangeParams(options.timeRange ?? getDefaultTimeRange());

--- a/packages/grafana-prometheus/src/language_provider.ts
+++ b/packages/grafana-prometheus/src/language_provider.ts
@@ -274,11 +274,16 @@ export default class PromQlLanguageProvider extends LanguageProvider {
       ...range,
       ...(interpolatedMatch && { 'match[]': interpolatedMatch }),
     };
-
-    const value = await this.request(`/api/v1/label/${interpolatedName}/values`, [], urlParams, {
+    let requestOptions: Partial<BackendSrvRequest> | undefined = {
       ...this.getDefaultCacheHeaders(),
-      requestId,
-    });
+      ...(requestId && { requestId }),
+    };
+
+    if (!Object.keys(requestOptions).length) {
+      requestOptions = undefined;
+    }
+
+    const value = await this.request(`/api/v1/label/${interpolatedName}/values`, [], urlParams, requestOptions);
     return value ?? [];
   };
 

--- a/packages/grafana-prometheus/src/language_provider.ts
+++ b/packages/grafana-prometheus/src/language_provider.ts
@@ -401,7 +401,7 @@ function getNameLabelValue(promQuery: string, tokens: Array<string | Prism.Token
   return nameLabelValue;
 }
 
-function isCancelledError(error: any): error is {
+function isCancelledError(error: unknown): error is {
   cancelled: boolean;
 } {
   return typeof error === 'object' && error !== null && 'cancelled' in error && error.cancelled === true;

--- a/packages/grafana-prometheus/src/querybuilder/components/MetricsLabelsSection.tsx
+++ b/packages/grafana-prometheus/src/querybuilder/components/MetricsLabelsSection.tsx
@@ -148,12 +148,12 @@ export function MetricsLabelsSection({
     if (!forLabel.label) {
       return Promise.resolve([]);
     }
-    return datasource.languageProvider.fetchSeriesValuesWithMatch(forLabel.label, promQLExpression).then((response) => {
-      return response.map((v) => ({
-        value: v,
-        label: v,
-      }));
-    });
+
+    const requestId = `[${datasource.uid}][${query.metric}][${forLabel.label}][${forLabel.op}]`;
+
+    return datasource.languageProvider
+      .fetchSeriesValuesWithMatch(forLabel.label, promQLExpression, requestId)
+      .then((response) => response.map((v) => ({ value: v, label: v })));
   };
 
   /**


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

## What is this feature?

In the Prometheus data source, when requesting metric label values, in-flight network requests can be cancelled by more recent requests for the same resource.

It works by leveraging [`BackendSrvRequest.requestId`](https://github.com/grafana/grafana/blob/ea90f0119c9378b51c816936876d64e2fac69e3b/packages/grafana-runtime/src/services/backendSrv.ts#L41-L47):
> `If the request id already exist the backendSrv will try to cancel and replace the previous call with the new one.`

### Demo

https://github.com/grafana/grafana/assets/5732000/4f19e0af-d644-4dcc-83d5-cafc0ad5ea67

## Why do we need this feature?

As described in #83926:
> If the requests are expensive and come at a high frequency they can overwhelm the prometheus backend

## Who is this feature for?

Prometheus data source users.

## Which issue(s) does this PR fix?

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

This PR fixes #83926.

## Special notes for your reviewer

1. The refactor of `languageProvider.fetchSeriesValuesWithMatch` impacts the Prometheus data source's `getTagValues` method, which powers ad-hoc filters. In local testing, ad-hoc filters continue to work as before. But your attention here would be appreciated.
2. I found it difficult to add integration tests for this without a big overhaul of current tests. If you have any ideas about some light-touch ways to test this effectively, please let me know.

## Future opportunities

This opens the door to request duplication in `languageProvider.getSeriesValues`.

Please check that:
- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [x] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
