### PR TITLE
RefreshPicker: Change running state to be less distracting 

### DIFF
--- a/package.json
+++ b/package.json
@@ -255,7 +255,7 @@
     "@grafana/prometheus": "workspace:*",
     "@grafana/runtime": "workspace:*",
     "@grafana/saga-icons": "workspace:*",
-    "@grafana/scenes": "^4.6.0",
+    "@grafana/scenes": "^4.10.0",
     "@grafana/schema": "workspace:*",
     "@grafana/sql": "workspace:*",
     "@grafana/ui": "workspace:*",

--- a/packages/grafana-ui/src/components/RefreshPicker/RefreshPicker.tsx
+++ b/packages/grafana-ui/src/components/RefreshPicker/RefreshPicker.tsx
@@ -63,10 +63,6 @@ export class RefreshPicker extends PureComponent<Props> {
       return 'primary';
     }
 
-    if (this.props.isLoading) {
-      return 'destructive';
-    }
-
     if (this.props.primary) {
       return 'primary';
     }

--- a/yarn.lock
+++ b/yarn.lock
@@ -4180,9 +4180,9 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@grafana/scenes@npm:^4.6.0":
-  version: 4.8.0
-  resolution: "@grafana/scenes@npm:4.8.0"
+"@grafana/scenes@npm:^4.10.0":
+  version: 4.10.0
+  resolution: "@grafana/scenes@npm:4.10.0"
   dependencies:
     "@grafana/e2e-selectors": "npm:10.3.3"
     react-grid-layout: "npm:1.3.4"
@@ -4196,7 +4196,7 @@ __metadata:
     "@grafana/ui": ^10.0.3
     react: ^18.0.0
     react-dom: ^18.0.0
-  checksum: 10/8930094261ab43da948a1dac260d0246dd41c906fb4fe060ad2b534ea82ed1ee1b1d26f839ac08add1a25127a2b7b05a7c2f273a4013bda63146dae118e5d5ea
+  checksum: 10/00c2d5f4606184eac757ab01bbace495c5aacec792de3cf55a66dd4597a3ab1bf2bf97806d9271f18107d738244d6c89579fe3db2f1a52506b64243ba1a9d782
   languageName: node
   linkType: hard
 
@@ -18609,7 +18609,7 @@ __metadata:
     "@grafana/prometheus": "workspace:*"
     "@grafana/runtime": "workspace:*"
     "@grafana/saga-icons": "workspace:*"
-    "@grafana/scenes": "npm:^4.6.0"
+    "@grafana/scenes": "npm:^4.10.0"
     "@grafana/schema": "workspace:*"
     "@grafana/sql": "workspace:*"
     "@grafana/tsconfig": "npm:^1.3.0-rc1"


### PR DESCRIPTION
I think the current red destructive button state for the "is running" state of the RefreshPicker is a bit distracting, the background change has a strange lag between the two button segments and for fast queries it just causes annoying flashing. 

I thought about not switching to loading state for fast queries until say 300ms, but then you have no feedback when clicking the button. I feel like a quick loading spinner even for fast queries felt better as you have feedback that you clicked the button and something happened. 

Video demo:

https://github.com/grafana/grafana/assets/10999/f257df7d-6204-470f-b562-c987435289af


Before:
<img width="590" alt="Screenshot 2024-04-17 at 11 17 27" src="https://github.com/grafana/grafana/assets/10999/32bb9a5d-1aef-4150-abbc-f4ca40e9c3e4">

After:
<img width="661" alt="Screenshot 2024-04-17 at 11 17 40" src="https://github.com/grafana/grafana/assets/10999/da8b0f7e-5d61-4c49-a857-5ff54f1fa38b">
