### PR TITLE
Loki/Prometheus Query Editor: Disabled cmd/ctrl+f keybinding within the editor

### DIFF
--- a/package.json
+++ b/package.json
@@ -344,7 +344,7 @@
     "ml-regression-simple-linear": "^3.0.0",
     "moment": "2.30.1",
     "moment-timezone": "0.5.45",
-    "monaco-editor": "0.34.0",
+    "monaco-editor": "0.34.1",
     "monaco-promql": "1.7.4",
     "mousetrap": "1.6.5",
     "mousetrap-global-bind": "1.1.0",

--- a/packages/grafana-prometheus/src/components/monaco-query-field/MonacoQueryField.tsx
+++ b/packages/grafana-prometheus/src/components/monaco-query-field/MonacoQueryField.tsx
@@ -226,7 +226,7 @@ const MonacoQueryField = (props: Props) => {
           // See https://github.com/grafana/grafana/issues/85850
           monaco.editor.addKeybindingRule({
             keybinding: monaco.KeyMod.CtrlCmd | monaco.KeyCode.KeyF,
-            command: null
+            command: null,
           });
 
           /* Something in this configuration of monaco doesn't bubble up [mod]+K, which the

--- a/packages/grafana-prometheus/src/components/monaco-query-field/MonacoQueryField.tsx
+++ b/packages/grafana-prometheus/src/components/monaco-query-field/MonacoQueryField.tsx
@@ -222,6 +222,10 @@ const MonacoQueryField = (props: Props) => {
             'isEditorFocused' + id
           );
 
+          // Fixes Monaco capturing the search key binding and displaying a useless search box within the Editor.
+          // See https://github.com/grafana/grafana/issues/85850
+          editor.addCommand(monaco.KeyMod.CtrlCmd | monaco.KeyCode.KeyF, () => {});
+
           /* Something in this configuration of monaco doesn't bubble up [mod]+K, which the
                     command palette uses. Pass the event out of monaco manually
                     */

--- a/packages/grafana-prometheus/src/components/monaco-query-field/MonacoQueryField.tsx
+++ b/packages/grafana-prometheus/src/components/monaco-query-field/MonacoQueryField.tsx
@@ -224,7 +224,10 @@ const MonacoQueryField = (props: Props) => {
 
           // Fixes Monaco capturing the search key binding and displaying a useless search box within the Editor.
           // See https://github.com/grafana/grafana/issues/85850
-          editor.addCommand(monaco.KeyMod.CtrlCmd | monaco.KeyCode.KeyF, () => {});
+          monaco.editor.addKeybindingRule({
+            keybinding: monaco.KeyMod.CtrlCmd | monaco.KeyCode.KeyF,
+            command: null
+          });
 
           /* Something in this configuration of monaco doesn't bubble up [mod]+K, which the
                     command palette uses. Pass the event out of monaco manually

--- a/packages/grafana-ui/package.json
+++ b/packages/grafana-ui/package.json
@@ -75,7 +75,7 @@
     "lodash": "4.17.21",
     "micro-memoize": "^4.1.2",
     "moment": "2.30.1",
-    "monaco-editor": "0.34.0",
+    "monaco-editor": "0.34.1",
     "ol": "7.4.0",
     "prismjs": "1.29.0",
     "rc-cascader": "3.24.1",

--- a/public/app/plugins/datasource/azuremonitor/package.json
+++ b/public/app/plugins/datasource/azuremonitor/package.json
@@ -15,7 +15,7 @@
     "i18next": "^23.0.0",
     "immer": "10.0.4",
     "lodash": "4.17.21",
-    "monaco-editor": "0.34.0",
+    "monaco-editor": "0.34.1",
     "prismjs": "1.29.0",
     "react": "18.2.0",
     "react-use": "17.5.0",

--- a/public/app/plugins/datasource/cloud-monitoring/package.json
+++ b/public/app/plugins/datasource/cloud-monitoring/package.json
@@ -16,7 +16,7 @@
     "i18next": "^23.0.0",
     "immer": "10.0.4",
     "lodash": "4.17.21",
-    "monaco-editor": "0.34.0",
+    "monaco-editor": "0.34.1",
     "prismjs": "1.29.0",
     "react": "18.2.0",
     "react-use": "17.5.0",

--- a/public/app/plugins/datasource/grafana-pyroscope-datasource/package.json
+++ b/public/app/plugins/datasource/grafana-pyroscope-datasource/package.json
@@ -11,7 +11,7 @@
     "@grafana/ui": "11.1.0-pre",
     "fast-deep-equal": "^3.1.3",
     "lodash": "4.17.21",
-    "monaco-editor": "0.34.0",
+    "monaco-editor": "0.34.1",
     "prismjs": "1.29.0",
     "react": "18.2.0",
     "react-dom": "18.2.0",

--- a/public/app/plugins/datasource/loki/components/monaco-query-field/MonacoQueryField.tsx
+++ b/public/app/plugins/datasource/loki/components/monaco-query-field/MonacoQueryField.tsx
@@ -264,6 +264,10 @@ const MonacoQueryField = ({
             'isEditorFocused' + id
           );
 
+          // Fixes Monaco capturing the search key binding and displaying a useless search box within the Editor.
+          // See https://github.com/grafana/grafana/issues/85850
+          //editor.addCommand(monaco.KeyMod.CtrlCmd | monaco.KeyCode.KeyF, () => {});
+
           editor.onDidFocusEditorText(() => {
             isEditorFocused.set(true);
             if (editor.getValue().trim() === '') {

--- a/public/app/plugins/datasource/loki/components/monaco-query-field/MonacoQueryField.tsx
+++ b/public/app/plugins/datasource/loki/components/monaco-query-field/MonacoQueryField.tsx
@@ -266,7 +266,7 @@ const MonacoQueryField = ({
 
           // Fixes Monaco capturing the search key binding and displaying a useless search box within the Editor.
           // See https://github.com/grafana/grafana/issues/85850
-          //editor.addCommand(monaco.KeyMod.CtrlCmd | monaco.KeyCode.KeyF, () => {});
+          editor.addCommand(monaco.KeyMod.CtrlCmd | monaco.KeyCode.KeyF, () => {});
 
           editor.onDidFocusEditorText(() => {
             isEditorFocused.set(true);

--- a/public/app/plugins/datasource/loki/components/monaco-query-field/MonacoQueryField.tsx
+++ b/public/app/plugins/datasource/loki/components/monaco-query-field/MonacoQueryField.tsx
@@ -266,7 +266,10 @@ const MonacoQueryField = ({
 
           // Fixes Monaco capturing the search key binding and displaying a useless search box within the Editor.
           // See https://github.com/grafana/grafana/issues/85850
-          editor.addCommand(monaco.KeyMod.CtrlCmd | monaco.KeyCode.KeyF, () => {});
+          monaco.editor.addKeybindingRule({
+            keybinding: monaco.KeyMod.CtrlCmd | monaco.KeyCode.KeyF,
+            command: null
+          });
 
           editor.onDidFocusEditorText(() => {
             isEditorFocused.set(true);

--- a/public/app/plugins/datasource/loki/components/monaco-query-field/MonacoQueryField.tsx
+++ b/public/app/plugins/datasource/loki/components/monaco-query-field/MonacoQueryField.tsx
@@ -268,7 +268,7 @@ const MonacoQueryField = ({
           // See https://github.com/grafana/grafana/issues/85850
           monaco.editor.addKeybindingRule({
             keybinding: monaco.KeyMod.CtrlCmd | monaco.KeyCode.KeyF,
-            command: null
+            command: null,
           });
 
           editor.onDidFocusEditorText(() => {

--- a/public/app/plugins/datasource/parca/package.json
+++ b/public/app/plugins/datasource/parca/package.json
@@ -10,7 +10,7 @@
     "@grafana/schema": "11.1.0-pre",
     "@grafana/ui": "11.1.0-pre",
     "lodash": "4.17.21",
-    "monaco-editor": "0.34.0",
+    "monaco-editor": "0.34.1",
     "react": "18.2.0",
     "react-use": "17.5.0",
     "rxjs": "7.8.1",

--- a/public/app/plugins/datasource/tempo/package.json
+++ b/public/app/plugins/datasource/tempo/package.json
@@ -25,7 +25,7 @@
     "i18next": "^23.0.0",
     "lodash": "4.17.21",
     "lru-cache": "10.2.0",
-    "monaco-editor": "0.34.0",
+    "monaco-editor": "0.34.1",
     "prismjs": "1.29.0",
     "react": "18.2.0",
     "react-dom": "18.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3323,7 +3323,7 @@ __metadata:
     i18next: "npm:^23.0.0"
     immer: "npm:10.0.4"
     lodash: "npm:4.17.21"
-    monaco-editor: "npm:0.34.0"
+    monaco-editor: "npm:0.34.1"
     prismjs: "npm:1.29.0"
     react: "npm:18.2.0"
     react-select-event: "npm:5.5.1"
@@ -3361,7 +3361,7 @@ __metadata:
     fast-deep-equal: "npm:^3.1.3"
     jest: "npm:29.7.0"
     lodash: "npm:4.17.21"
-    monaco-editor: "npm:0.34.0"
+    monaco-editor: "npm:0.34.1"
     prismjs: "npm:1.29.0"
     react: "npm:18.2.0"
     react-dom: "npm:18.2.0"
@@ -3461,7 +3461,7 @@ __metadata:
     "@types/lodash": "npm:4.17.0"
     "@types/react": "npm:18.2.78"
     lodash: "npm:4.17.21"
-    monaco-editor: "npm:0.34.0"
+    monaco-editor: "npm:0.34.1"
     react: "npm:18.2.0"
     react-use: "npm:17.5.0"
     rxjs: "npm:7.8.1"
@@ -3501,7 +3501,7 @@ __metadata:
     i18next: "npm:^23.0.0"
     immer: "npm:10.0.4"
     lodash: "npm:4.17.21"
-    monaco-editor: "npm:0.34.0"
+    monaco-editor: "npm:0.34.1"
     prismjs: "npm:1.29.0"
     react: "npm:18.2.0"
     react-select-event: "npm:5.5.1"
@@ -3555,7 +3555,7 @@ __metadata:
     i18next: "npm:^23.0.0"
     lodash: "npm:4.17.21"
     lru-cache: "npm:10.2.0"
-    monaco-editor: "npm:0.34.0"
+    monaco-editor: "npm:0.34.1"
     prismjs: "npm:1.29.0"
     react: "npm:18.2.0"
     react-dom: "npm:18.2.0"
@@ -23199,13 +23199,6 @@ __metadata:
   version: 2.30.1
   resolution: "moment@npm:2.30.1"
   checksum: 10/ae42d876d4ec831ef66110bdc302c0657c664991e45cf2afffc4b0f6cd6d251dde11375c982a5c0564ccc0fa593fc564576ddceb8c8845e87c15f58aa6baca69
-  languageName: node
-  linkType: hard
-
-"monaco-editor@npm:0.34.0":
-  version: 0.34.0
-  resolution: "monaco-editor@npm:0.34.0"
-  checksum: 10/c7c2c88bc8f83817e67ab55d84a4469af7f5f566cc3df1c27bdd00ad2071b88688b23847608e8c948a445afa543929b7bcd9b5ff5b7b53da15f6f2b628eb76ac
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -4359,7 +4359,7 @@ __metadata:
     micro-memoize: "npm:^4.1.2"
     mock-raf: "npm:1.0.1"
     moment: "npm:2.30.1"
-    monaco-editor: "npm:0.34.0"
+    monaco-editor: "npm:0.34.1"
     ol: "npm:7.4.0"
     prismjs: "npm:1.29.0"
     process: "npm:^0.11.10"
@@ -18815,7 +18815,7 @@ __metadata:
     ml-regression-simple-linear: "npm:^3.0.0"
     moment: "npm:2.30.1"
     moment-timezone: "npm:0.5.45"
-    monaco-editor: "npm:0.34.0"
+    monaco-editor: "npm:0.34.1"
     monaco-promql: "npm:1.7.4"
     mousetrap: "npm:1.6.5"
     mousetrap-global-bind: "npm:1.1.0"
@@ -23206,6 +23206,13 @@ __metadata:
   version: 0.34.0
   resolution: "monaco-editor@npm:0.34.0"
   checksum: 10/c7c2c88bc8f83817e67ab55d84a4469af7f5f566cc3df1c27bdd00ad2071b88688b23847608e8c948a445afa543929b7bcd9b5ff5b7b53da15f6f2b628eb76ac
+  languageName: node
+  linkType: hard
+
+"monaco-editor@npm:0.34.1":
+  version: 0.34.1
+  resolution: "monaco-editor@npm:0.34.1"
+  checksum: 10/50cde6f68f27cd66fbaadb7efe0e6ce46748e4bb552ddaa84451fbda18e5ff970a1fa79371c04618927c1f6348839747e3d4804fe383040bad2137527f8a38e4
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
A user complained that a search box was capturing cmd+f events and displaying a useless search box inside the editor. This PR disables that behavior.

**What is this feature?**

Bugfix.

**Why do we need this feature?**

One less paper cut

**Who is this feature for?**

Loki and Prometheus query editor users.

**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/grafana/issues/85850

**Special notes for your reviewer:**

Demo:

https://github.com/grafana/grafana/assets/1069378/cd08caf7-a47a-46eb-8756-85b89f75ed17

