### PR TITLE
User: use update function for password updates

### DIFF
--- a/pkg/api/admin_users.go
+++ b/pkg/api/admin_users.go
@@ -110,12 +110,7 @@ func (hs *HTTPServer) AdminUpdateUserPassword(c *contextmodel.ReqContext) respon
 		return response
 	}
 
-	password, err := user.NewPassword(form.Password, hs.Cfg)
-	if err != nil {
-		return response.Err(err)
-	}
-
-	if err := hs.userService.Update(c.Req.Context(), &user.UpdateUserCommand{UserID: userID, Password: &password}); err != nil {
+	if err := hs.userService.Update(c.Req.Context(), &user.UpdateUserCommand{UserID: userID, Password: &form.Password}); err != nil {
 		return response.Error(http.StatusInternalServerError, "Failed to update user password", err)
 	}
 

--- a/pkg/api/admin_users.go
+++ b/pkg/api/admin_users.go
@@ -134,17 +134,13 @@ func (hs *HTTPServer) AdminUpdateUserPassword(c *contextmodel.ReqContext) respon
 		}
 	}
 
-	passwordHashed, err := util.EncodePassword(string(form.Password), usr.Salt)
+	hashedPassword, err := util.EncodePassword(string(form.Password), usr.Salt)
 	if err != nil {
 		return response.Error(http.StatusInternalServerError, "Could not encode password", err)
 	}
 
-	cmd := user.ChangeUserPasswordCommand{
-		UserID:      userID,
-		NewPassword: user.Password(passwordHashed),
-	}
-
-	if err := hs.userService.ChangePassword(c.Req.Context(), &cmd); err != nil {
+	password := user.Password(hashedPassword)
+	if err := hs.userService.Update(c.Req.Context(), &user.UpdateUserCommand{UserID: usr.ID, Password: &password}); err != nil {
 		return response.Error(http.StatusInternalServerError, "Failed to update user password", err)
 	}
 

--- a/pkg/api/admin_users.go
+++ b/pkg/api/admin_users.go
@@ -156,7 +156,7 @@ func (hs *HTTPServer) AdminUpdateUserPermissions(c *contextmodel.ReqContext) res
 		return response.Error(http.StatusBadRequest, "id is invalid", err)
 	}
 
-	if response := hs.errOnExternalUser(c.Req.Context(), userID); err != nil {
+	if response := hs.errOnExternalUser(c.Req.Context(), userID); response != nil {
 		return response
 	}
 

--- a/pkg/api/admin_users.go
+++ b/pkg/api/admin_users.go
@@ -44,15 +44,10 @@ func (hs *HTTPServer) AdminCreateUser(c *contextmodel.ReqContext) response.Respo
 		return response.Error(http.StatusBadRequest, "bad request data", err)
 	}
 
-	password, err := user.NewPassword(form.Password, hs.Cfg)
-	if err != nil {
-		return response.Err(err)
-	}
-
 	cmd := user.CreateUserCommand{
 		Login:    form.Login,
 		Email:    form.Email,
-		Password: password,
+		Password: form.Password,
 		Name:     form.Name,
 		OrgID:    form.OrgId,
 	}

--- a/pkg/api/admin_users_test.go
+++ b/pkg/api/admin_users_test.go
@@ -355,8 +355,9 @@ func putAdminScenario(t *testing.T, desc string, url string, routePattern string
 		hs := &HTTPServer{
 			Cfg:             setting.NewCfg(),
 			SQLStore:        sqlStore,
-			authInfoService: &authinfotest.FakeService{},
+			authInfoService: &authinfotest.FakeService{ExpectedError: user.ErrUserNotFound},
 			userService:     userSvc,
+			SocialService:   &mockSocialService{},
 		}
 
 		sc := setupScenarioContext(t, url)

--- a/pkg/api/dtos/invite.go
+++ b/pkg/api/dtos/invite.go
@@ -25,5 +25,5 @@ type CompleteInviteForm struct {
 	Name            string        `json:"name"`
 	Username        string        `json:"username"`
 	Password        user.Password `json:"password"`
-	ConfirmPassword string        `json:"confirmPassword"`
+	ConfirmPassword user.Password `json:"confirmPassword"`
 }

--- a/pkg/api/dtos/invite.go
+++ b/pkg/api/dtos/invite.go
@@ -2,6 +2,7 @@ package dtos
 
 import (
 	"github.com/grafana/grafana/pkg/services/org"
+	"github.com/grafana/grafana/pkg/services/user"
 )
 
 type AddInviteForm struct {
@@ -19,10 +20,10 @@ type InviteInfo struct {
 }
 
 type CompleteInviteForm struct {
-	InviteCode      string `json:"inviteCode"`
-	Email           string `json:"email" binding:"Required"`
-	Name            string `json:"name"`
-	Username        string `json:"username"`
-	Password        string `json:"password"`
-	ConfirmPassword string `json:"confirmPassword"`
+	InviteCode      string        `json:"inviteCode"`
+	Email           string        `json:"email" binding:"Required"`
+	Name            string        `json:"name"`
+	Username        string        `json:"username"`
+	Password        user.Password `json:"password"`
+	ConfirmPassword string        `json:"confirmPassword"`
 }

--- a/pkg/api/dtos/invite.go
+++ b/pkg/api/dtos/invite.go
@@ -2,7 +2,6 @@ package dtos
 
 import (
 	"github.com/grafana/grafana/pkg/services/org"
-	"github.com/grafana/grafana/pkg/services/user"
 )
 
 type AddInviteForm struct {
@@ -20,10 +19,10 @@ type InviteInfo struct {
 }
 
 type CompleteInviteForm struct {
-	InviteCode      string        `json:"inviteCode"`
-	Email           string        `json:"email" binding:"Required"`
-	Name            string        `json:"name"`
-	Username        string        `json:"username"`
-	Password        user.Password `json:"password"`
-	ConfirmPassword user.Password `json:"confirmPassword"`
+	InviteCode      string `json:"inviteCode"`
+	Email           string `json:"email" binding:"Required"`
+	Name            string `json:"name"`
+	Username        string `json:"username"`
+	Password        string `json:"password"`
+	ConfirmPassword string `json:"confirmPassword"`
 }

--- a/pkg/api/dtos/user.go
+++ b/pkg/api/dtos/user.go
@@ -1,24 +1,26 @@
 package dtos
 
+import "github.com/grafana/grafana/pkg/services/user"
+
 type SignUpForm struct {
 	Email string `json:"email" binding:"Required"`
 }
 
 type SignUpStep2Form struct {
-	Email    string `json:"email"`
-	Name     string `json:"name"`
-	Username string `json:"username"`
-	Password string `json:"password"`
-	Code     string `json:"code"`
-	OrgName  string `json:"orgName"`
+	Email    string        `json:"email"`
+	Name     string        `json:"name"`
+	Username string        `json:"username"`
+	Password user.Password `json:"password"`
+	Code     string        `json:"code"`
+	OrgName  string        `json:"orgName"`
 }
 
 type AdminCreateUserForm struct {
-	Email    string `json:"email"`
-	Login    string `json:"login"`
-	Name     string `json:"name"`
-	Password string `json:"password" binding:"Required"`
-	OrgId    int64  `json:"orgId"`
+	Email    string        `json:"email"`
+	Login    string        `json:"login"`
+	Name     string        `json:"name"`
+	Password user.Password `json:"password" binding:"Required"`
+	OrgId    int64         `json:"orgId"`
 }
 
 type AdminUpdateUserPasswordForm struct {
@@ -34,14 +36,14 @@ type SendResetPasswordEmailForm struct {
 }
 
 type ResetUserPasswordForm struct {
-	Code            string `json:"code"`
-	NewPassword     string `json:"newPassword"`
-	ConfirmPassword string `json:"confirmPassword"`
+	Code            string        `json:"code"`
+	NewPassword     user.Password `json:"newPassword"`
+	ConfirmPassword user.Password `json:"confirmPassword"`
 }
 
 type ChangeUserPasswordForm struct {
-	OldPassword string `json:"oldPassword"`
-	NewPassword string `json:"newPassword"`
+	OldPassword user.Password `json:"oldPassword"`
+	NewPassword user.Password `json:"newPassword"`
 }
 
 type UserLookupDTO struct {

--- a/pkg/api/dtos/user.go
+++ b/pkg/api/dtos/user.go
@@ -24,7 +24,7 @@ type AdminCreateUserForm struct {
 }
 
 type AdminUpdateUserPasswordForm struct {
-	Password string `json:"password" binding:"Required"`
+	Password user.Password `json:"password" binding:"Required"`
 }
 
 type AdminUpdateUserPermissionsForm struct {

--- a/pkg/api/dtos/user.go
+++ b/pkg/api/dtos/user.go
@@ -1,30 +1,28 @@
 package dtos
 
-import "github.com/grafana/grafana/pkg/services/user"
-
 type SignUpForm struct {
 	Email string `json:"email" binding:"Required"`
 }
 
 type SignUpStep2Form struct {
-	Email    string        `json:"email"`
-	Name     string        `json:"name"`
-	Username string        `json:"username"`
-	Password user.Password `json:"password"`
-	Code     string        `json:"code"`
-	OrgName  string        `json:"orgName"`
+	Email    string `json:"email"`
+	Name     string `json:"name"`
+	Username string `json:"username"`
+	Password string `json:"password"`
+	Code     string `json:"code"`
+	OrgName  string `json:"orgName"`
 }
 
 type AdminCreateUserForm struct {
-	Email    string        `json:"email"`
-	Login    string        `json:"login"`
-	Name     string        `json:"name"`
-	Password user.Password `json:"password" binding:"Required"`
-	OrgId    int64         `json:"orgId"`
+	Email    string `json:"email"`
+	Login    string `json:"login"`
+	Name     string `json:"name"`
+	Password string `json:"password" binding:"Required"`
+	OrgId    int64  `json:"orgId"`
 }
 
 type AdminUpdateUserPasswordForm struct {
-	Password user.Password `json:"password" binding:"Required"`
+	Password string `json:"password" binding:"Required"`
 }
 
 type AdminUpdateUserPermissionsForm struct {
@@ -36,9 +34,14 @@ type SendResetPasswordEmailForm struct {
 }
 
 type ResetUserPasswordForm struct {
-	Code            string        `json:"code"`
-	NewPassword     user.Password `json:"newPassword"`
-	ConfirmPassword user.Password `json:"confirmPassword"`
+	Code            string `json:"code"`
+	NewPassword     string `json:"newPassword"`
+	ConfirmPassword string `json:"confirmPassword"`
+}
+
+type ChangeUserPasswordForm struct {
+	OldPassword string `json:"oldPassword"`
+	NewPassword string `json:"newPassword"`
 }
 
 type UserLookupDTO struct {

--- a/pkg/api/dtos/user.go
+++ b/pkg/api/dtos/user.go
@@ -41,11 +41,6 @@ type ResetUserPasswordForm struct {
 	ConfirmPassword user.Password `json:"confirmPassword"`
 }
 
-type ChangeUserPasswordForm struct {
-	OldPassword user.Password `json:"oldPassword"`
-	NewPassword user.Password `json:"newPassword"`
-}
-
 type UserLookupDTO struct {
 	UserID    int64  `json:"userId"`
 	Login     string `json:"login"`

--- a/pkg/api/org_invite.go
+++ b/pkg/api/org_invite.go
@@ -270,7 +270,8 @@ func (hs *HTTPServer) CompleteInvite(c *contextmodel.ReqContext) response.Respon
 		}
 	}
 
-	if err := completeInvite.Password.Validate(hs.Cfg); err != nil {
+	password, err := user.NewPassword(completeInvite.Password, hs.Cfg)
+	if err != nil {
 		return response.Err(err)
 	}
 
@@ -278,7 +279,7 @@ func (hs *HTTPServer) CompleteInvite(c *contextmodel.ReqContext) response.Respon
 		Email:        completeInvite.Email,
 		Name:         completeInvite.Name,
 		Login:        completeInvite.Username,
-		Password:     completeInvite.Password,
+		Password:     password,
 		SkipOrgSetup: true,
 	}
 

--- a/pkg/api/org_invite.go
+++ b/pkg/api/org_invite.go
@@ -270,16 +270,11 @@ func (hs *HTTPServer) CompleteInvite(c *contextmodel.ReqContext) response.Respon
 		}
 	}
 
-	password, err := user.NewPassword(completeInvite.Password, hs.Cfg)
-	if err != nil {
-		return response.Err(err)
-	}
-
 	cmd := user.CreateUserCommand{
 		Email:        completeInvite.Email,
 		Name:         completeInvite.Name,
 		Login:        completeInvite.Username,
-		Password:     password,
+		Password:     completeInvite.Password,
 		SkipOrgSetup: true,
 	}
 

--- a/pkg/api/password.go
+++ b/pkg/api/password.go
@@ -102,15 +102,13 @@ func (hs *HTTPServer) ResetPassword(c *contextmodel.ReqContext) response.Respons
 		return response.Err(err)
 	}
 
-	cmd := user.ChangeUserPasswordCommand{}
-	cmd.UserID = userResult.ID
 	encodedPassword, err := util.EncodePassword(string(form.NewPassword), userResult.Salt)
 	if err != nil {
 		return response.Error(http.StatusInternalServerError, "Failed to encode password", err)
 	}
-	cmd.NewPassword = user.Password(encodedPassword)
 
-	if err := hs.userService.ChangePassword(c.Req.Context(), &cmd); err != nil {
+	password := user.Password(encodedPassword)
+	if err := hs.userService.Update(c.Req.Context(), &user.UpdateUserCommand{UserID: userResult.ID, Password: &password}); err != nil {
 		return response.Error(http.StatusInternalServerError, "Failed to change user password", err)
 	}
 

--- a/pkg/api/password.go
+++ b/pkg/api/password.go
@@ -93,8 +93,7 @@ func (hs *HTTPServer) ResetPassword(c *contextmodel.ReqContext) response.Respons
 		return response
 	}
 
-	password := user.NewPasswordUnchecked(form.NewPassword)
-	if err := hs.userService.Update(c.Req.Context(), &user.UpdateUserCommand{UserID: userResult.ID, Password: &password}); err != nil {
+	if err := hs.userService.Update(c.Req.Context(), &user.UpdateUserCommand{UserID: userResult.ID, Password: &form.ConfirmPassword}); err != nil {
 		return response.ErrOrFallback(http.StatusInternalServerError, "Failed to change user password", err)
 	}
 

--- a/pkg/api/signup.go
+++ b/pkg/api/signup.go
@@ -92,7 +92,7 @@ func (hs *HTTPServer) SignUpStep2(c *contextmodel.ReqContext) response.Response 
 		Email:    form.Email,
 		Login:    form.Username,
 		Name:     form.Name,
-		Password: user.NewPasswordUnchecked(form.Password),
+		Password: form.Password,
 		OrgName:  form.OrgName,
 	}
 

--- a/pkg/api/signup.go
+++ b/pkg/api/signup.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"net/http"
-	"strings"
 
 	"github.com/grafana/grafana/pkg/api/dtos"
 	"github.com/grafana/grafana/pkg/api/response"
@@ -89,14 +88,11 @@ func (hs *HTTPServer) SignUpStep2(c *contextmodel.ReqContext) response.Response 
 		return response.Error(http.StatusUnauthorized, "User signup is disabled", nil)
 	}
 
-	form.Email = strings.TrimSpace(form.Email)
-	form.Username = strings.TrimSpace(form.Username)
-
 	createUserCmd := user.CreateUserCommand{
 		Email:    form.Email,
 		Login:    form.Username,
 		Name:     form.Name,
-		Password: form.Password,
+		Password: user.NewPasswordUnchecked(form.Password),
 		OrgName:  form.OrgName,
 	}
 

--- a/pkg/api/user.go
+++ b/pkg/api/user.go
@@ -566,9 +566,7 @@ func (hs *HTTPServer) ChangeUserPassword(c *contextmodel.ReqContext) response.Re
 		return response
 	}
 
-	password := user.NewPasswordUnchecked(form.NewPassword)
-	oldPassword := user.NewPasswordUnchecked(form.OldPassword)
-	if err := hs.userService.Update(c.Req.Context(), &user.UpdateUserCommand{UserID: userID, Password: &password, OldPassword: &oldPassword}); err != nil {
+	if err := hs.userService.Update(c.Req.Context(), &user.UpdateUserCommand{UserID: userID, Password: &form.NewPassword, OldPassword: &form.OldPassword}); err != nil {
 		response.ErrOrFallback(http.StatusInternalServerError, "Failed to change user password", err)
 	}
 

--- a/pkg/api/user.go
+++ b/pkg/api/user.go
@@ -552,7 +552,7 @@ func (hs *HTTPServer) ChangeActiveOrgAndRedirectToHome(c *contextmodel.ReqContex
 // 403: forbiddenError
 // 500: internalServerError
 func (hs *HTTPServer) ChangeUserPassword(c *contextmodel.ReqContext) response.Response {
-	form := dtos.ChangeUserPasswordForm{}
+	form := user.ChangeUserPasswordCommand{}
 	if err := web.Bind(c.Req, &form); err != nil {
 		return response.Error(http.StatusBadRequest, "bad request data", err)
 	}
@@ -719,7 +719,7 @@ type ChangeUserPasswordParams struct {
 	// To change the email, name, login, theme, provide another one.
 	// in:body
 	// required:true
-	Body dtos.ChangeUserPasswordForm `json:"body"`
+	Body user.ChangeUserPasswordCommand `json:"body"`
 }
 
 // swagger:parameters getUserByID

--- a/pkg/api/user.go
+++ b/pkg/api/user.go
@@ -567,7 +567,7 @@ func (hs *HTTPServer) ChangeUserPassword(c *contextmodel.ReqContext) response.Re
 	}
 
 	if err := hs.userService.Update(c.Req.Context(), &user.UpdateUserCommand{UserID: userID, Password: &form.NewPassword, OldPassword: &form.OldPassword}); err != nil {
-		response.ErrOrFallback(http.StatusInternalServerError, "Failed to change user password", err)
+		return response.ErrOrFallback(http.StatusInternalServerError, "Failed to change user password", err)
 	}
 
 	return response.Success("User password changed")

--- a/pkg/api/user.go
+++ b/pkg/api/user.go
@@ -226,13 +226,8 @@ func (hs *HTTPServer) UpdateUserActiveOrg(c *contextmodel.ReqContext) response.R
 
 func (hs *HTTPServer) handleUpdateUser(ctx context.Context, cmd user.UpdateUserCommand) response.Response {
 	// external user -> user data cannot be updated
-	isExternal, err := hs.isExternalUser(ctx, cmd.UserID)
-	if err != nil {
-		return response.Error(http.StatusInternalServerError, "Failed to validate User", err)
-	}
-
-	if isExternal {
-		return response.Error(http.StatusForbidden, "User info cannot be updated for external Users", nil)
+	if response := hs.errOnExternalUser(ctx, cmd.UserID); response != nil {
+		return response
 	}
 
 	if len(cmd.Login) == 0 {
@@ -342,20 +337,6 @@ func (hs *HTTPServer) UpdateUserEmail(c *contextmodel.ReqContext) response.Respo
 	}
 
 	return response.Redirect(hs.Cfg.AppSubURL + "/profile")
-}
-
-func (hs *HTTPServer) isExternalUser(ctx context.Context, userID int64) (bool, error) {
-	getAuthQuery := login.GetAuthInfoQuery{UserId: userID}
-	var err error
-	if _, err = hs.authInfoService.GetAuthInfo(ctx, &getAuthQuery); err == nil {
-		return true, nil
-	}
-
-	if errors.Is(err, user.ErrUserNotFound) {
-		return false, nil
-	}
-
-	return false, err
 }
 
 // swagger:route GET /user/orgs signed_in_user getSignedInUserOrgList
@@ -571,8 +552,8 @@ func (hs *HTTPServer) ChangeActiveOrgAndRedirectToHome(c *contextmodel.ReqContex
 // 403: forbiddenError
 // 500: internalServerError
 func (hs *HTTPServer) ChangeUserPassword(c *contextmodel.ReqContext) response.Response {
-	cmd := user.ChangeUserPasswordCommand{}
-	if err := web.Bind(c.Req, &cmd); err != nil {
+	form := dtos.ChangeUserPasswordForm{}
+	if err := web.Bind(c.Req, &form); err != nil {
 		return response.Error(http.StatusBadRequest, "bad request data", err)
 	}
 
@@ -581,42 +562,14 @@ func (hs *HTTPServer) ChangeUserPassword(c *contextmodel.ReqContext) response.Re
 		return errResponse
 	}
 
-	userQuery := user.GetUserByIDQuery{ID: userID}
-
-	usr, err := hs.userService.GetByID(c.Req.Context(), &userQuery)
-	if err != nil {
-		return response.Error(http.StatusInternalServerError, "Could not read user from database", err)
+	if response := hs.errOnExternalUser(c.Req.Context(), userID); response != nil {
+		return response
 	}
 
-	getAuthQuery := login.GetAuthInfoQuery{UserId: usr.ID}
-	if authInfo, err := hs.authInfoService.GetAuthInfo(c.Req.Context(), &getAuthQuery); err == nil {
-		oauthInfo := hs.SocialService.GetOAuthInfoProvider(authInfo.AuthModule)
-		if login.IsProviderEnabled(hs.Cfg, authInfo.AuthModule, oauthInfo) {
-			return response.Error(http.StatusBadRequest, "Cannot update external user password", err)
-		}
-	}
-
-	passwordHashed, err := util.EncodePassword(string(cmd.OldPassword), usr.Salt)
-	if err != nil {
-		return response.Error(http.StatusInternalServerError, "Failed to encode password", err)
-	}
-	if user.Password(passwordHashed) != usr.Password {
-		return response.Error(http.StatusUnauthorized, "Invalid old password", nil)
-	}
-
-	if err := cmd.NewPassword.Validate(hs.Cfg); err != nil {
-		c.Logger.Warn("the new password doesn't meet the password policy criteria", "err", err)
-		return response.Err(err)
-	}
-
-	hashedPassword, err := util.EncodePassword(string(cmd.NewPassword), usr.Salt)
-	if err != nil {
-		return response.Error(http.StatusInternalServerError, "Failed to encode password", err)
-	}
-
-	password := user.Password(hashedPassword)
-	if err := hs.userService.Update(c.Req.Context(), &user.UpdateUserCommand{UserID: usr.ID, Password: &password}); err != nil {
-		return response.Error(http.StatusInternalServerError, "Failed to change user password", err)
+	password := user.NewPasswordUnchecked(form.NewPassword)
+	oldPassword := user.NewPasswordUnchecked(form.OldPassword)
+	if err := hs.userService.Update(c.Req.Context(), &user.UpdateUserCommand{UserID: userID, Password: &password, OldPassword: &oldPassword}); err != nil {
+		response.ErrOrFallback(http.StatusInternalServerError, "Failed to change user password", err)
 	}
 
 	return response.Success("User password changed")
@@ -768,7 +721,7 @@ type ChangeUserPasswordParams struct {
 	// To change the email, name, login, theme, provide another one.
 	// in:body
 	// required:true
-	Body user.ChangeUserPasswordCommand `json:"body"`
+	Body dtos.ChangeUserPasswordForm `json:"body"`
 }
 
 // swagger:parameters getUserByID

--- a/pkg/api/user.go
+++ b/pkg/api/user.go
@@ -609,14 +609,13 @@ func (hs *HTTPServer) ChangeUserPassword(c *contextmodel.ReqContext) response.Re
 		return response.Err(err)
 	}
 
-	cmd.UserID = userID
-	encodedPassword, err := util.EncodePassword(string(cmd.NewPassword), usr.Salt)
+	hashedPassword, err := util.EncodePassword(string(cmd.NewPassword), usr.Salt)
 	if err != nil {
 		return response.Error(http.StatusInternalServerError, "Failed to encode password", err)
 	}
-	cmd.NewPassword = user.Password(encodedPassword)
 
-	if err := hs.userService.ChangePassword(c.Req.Context(), &cmd); err != nil {
+	password := user.Password(hashedPassword)
+	if err := hs.userService.Update(c.Req.Context(), &user.UpdateUserCommand{UserID: usr.ID, Password: &password}); err != nil {
 		return response.Error(http.StatusInternalServerError, "Failed to change user password", err)
 	}
 

--- a/pkg/api/user_test.go
+++ b/pkg/api/user_test.go
@@ -1089,11 +1089,13 @@ func updateUserScenario(t *testing.T, ctx updateUserContext, hs *HTTPServer) {
 func TestHTTPServer_UpdateSignedInUser(t *testing.T) {
 	settings := setting.NewCfg()
 	sqlStore := db.InitTestDB(t)
+	settings.SAMLAuthEnabled = true
 
 	hs := &HTTPServer{
 		Cfg:           settings,
 		SQLStore:      sqlStore,
 		AccessControl: acmock.New(),
+		SocialService: &socialtest.FakeSocialService{},
 	}
 
 	updateUserCommand := user.UpdateUserCommand{
@@ -1109,7 +1111,7 @@ func TestHTTPServer_UpdateSignedInUser(t *testing.T) {
 		routePattern: "/api/users/",
 		cmd:          updateUserCommand,
 		fn: func(sc *scenarioContext) {
-			sc.authInfoService.ExpectedUserAuth = &login.UserAuth{}
+			sc.authInfoService.ExpectedUserAuth = &login.UserAuth{AuthModule: login.SAMLAuthModule}
 			sc.fakeReqWithParams("PUT", sc.url, map[string]string{"id": "1"}).exec()
 			assert.Equal(t, 403, sc.resp.Code)
 		},

--- a/pkg/api/user_test.go
+++ b/pkg/api/user_test.go
@@ -345,12 +345,14 @@ func Test_GetUserByID(t *testing.T) {
 
 func TestHTTPServer_UpdateUser(t *testing.T) {
 	settings := setting.NewCfg()
+	settings.SAMLAuthEnabled = true
 	sqlStore := db.InitTestDB(t)
 
 	hs := &HTTPServer{
 		Cfg:           settings,
 		SQLStore:      sqlStore,
 		AccessControl: acmock.New(),
+		SocialService: &socialtest.FakeSocialService{ExpectedAuthInfoProvider: &social.OAuthInfo{Enabled: true}},
 	}
 
 	updateUserCommand := user.UpdateUserCommand{
@@ -366,7 +368,8 @@ func TestHTTPServer_UpdateUser(t *testing.T) {
 		routePattern: "/api/users/:id",
 		cmd:          updateUserCommand,
 		fn: func(sc *scenarioContext) {
-			sc.authInfoService.ExpectedUserAuth = &login.UserAuth{}
+			sc.authInfoService.ExpectedUserAuth = &login.UserAuth{AuthModule: login.SAMLAuthModule}
+
 			sc.fakeReqWithParams("PUT", sc.url, map[string]string{"id": "1"}).exec()
 			assert.Equal(t, 403, sc.resp.Code)
 		},

--- a/pkg/api/utils.go
+++ b/pkg/api/utils.go
@@ -1,10 +1,16 @@
 package api
 
 import (
+	"context"
+	"errors"
+	"net/http"
 	"net/mail"
 
+	"github.com/grafana/grafana/pkg/api/response"
 	"github.com/grafana/grafana/pkg/middleware/cookies"
 	contextmodel "github.com/grafana/grafana/pkg/services/contexthandler/model"
+	"github.com/grafana/grafana/pkg/services/login"
+	"github.com/grafana/grafana/pkg/services/user"
 )
 
 func (hs *HTTPServer) GetRedirectURL(c *contextmodel.ReqContext) string {
@@ -18,6 +24,31 @@ func (hs *HTTPServer) GetRedirectURL(c *contextmodel.ReqContext) string {
 		cookies.DeleteCookie(c.Resp, "redirect_to", hs.CookieOptionsFromCfg)
 	}
 	return redirectURL
+}
+
+func (hs *HTTPServer) errOnExternalUser(ctx context.Context, userID int64) response.Response {
+	isExternal, err := hs.isExternalUser(ctx, userID)
+	if err != nil {
+		return response.Error(http.StatusInternalServerError, "Failed to validate User", err)
+	}
+	if isExternal {
+		return response.Error(http.StatusForbidden, "Cannot update external User", nil)
+	}
+	return nil
+}
+
+func (hs *HTTPServer) isExternalUser(ctx context.Context, userID int64) (bool, error) {
+	info, err := hs.authInfoService.GetAuthInfo(ctx, &login.GetAuthInfoQuery{UserId: userID})
+
+	if errors.Is(err, user.ErrUserNotFound) {
+		return false, nil
+	}
+
+	if err != nil {
+		return true, err
+	}
+
+	return login.IsProviderEnabled(hs.Cfg, info.AuthModule, hs.SocialService.GetOAuthInfoProvider(info.AuthModule)), nil
 }
 
 func ValidateAndNormalizeEmail(email string) (string, error) {

--- a/pkg/cmd/grafana-cli/commands/reset_password_command.go
+++ b/pkg/cmd/grafana-cli/commands/reset_password_command.go
@@ -63,12 +63,8 @@ func resetPassword(adminId int64, newPassword user.Password, userSvc user.Servic
 		return err
 	}
 
-	cmd := user.ChangeUserPasswordCommand{
-		UserID:      adminId,
-		NewPassword: user.Password(passwordHashed),
-	}
-
-	if err := userSvc.ChangePassword(context.Background(), &cmd); err != nil {
+	password := user.Password(passwordHashed)
+	if err := userSvc.Update(context.Background(), &user.UpdateUserCommand{UserID: adminId, Password: &password}); err != nil {
 		return fmt.Errorf("failed to update user password: %w", err)
 	}
 

--- a/pkg/cmd/grafana-cli/commands/reset_password_command.go
+++ b/pkg/cmd/grafana-cli/commands/reset_password_command.go
@@ -12,7 +12,6 @@ import (
 	"github.com/grafana/grafana/pkg/cmd/grafana-cli/utils"
 	"github.com/grafana/grafana/pkg/server"
 	"github.com/grafana/grafana/pkg/services/user"
-	"github.com/grafana/grafana/pkg/util"
 )
 
 const DefaultAdminUserId = 1
@@ -58,12 +57,11 @@ func resetPassword(adminId int64, newPassword user.Password, userSvc user.Servic
 		return ErrMustBeAdmin
 	}
 
-	passwordHashed, err := util.EncodePassword(string(newPassword), usr.Salt)
+	password, err := newPassword.Hash(usr.Salt)
 	if err != nil {
 		return err
 	}
 
-	password := user.Password(passwordHashed)
 	if err := userSvc.Update(context.Background(), &user.UpdateUserCommand{UserID: adminId, Password: &password}); err != nil {
 		return fmt.Errorf("failed to update user password: %w", err)
 	}

--- a/pkg/services/org/orgimpl/store_test.go
+++ b/pkg/services/org/orgimpl/store_test.go
@@ -773,7 +773,7 @@ func TestIntegration_SQLStore_GetOrgUsers_PopulatesCorrectly(t *testing.T) {
 	assert.Equal(t, int64(1), actual.UserID)
 	assert.Equal(t, "viewer@localhost", actual.Email)
 	assert.Equal(t, "Viewer Localhost", actual.Name)
-	assert.Equal(t, "Viewer", actual.Login)
+	assert.Equal(t, "viewer", actual.Login)
 	assert.Equal(t, "Viewer", actual.Role)
 	assert.Equal(t, constNow.AddDate(-10, 0, 0), actual.LastSeenAt)
 	assert.Equal(t, constNow, actual.Created)

--- a/pkg/services/user/error.go
+++ b/pkg/services/user/error.go
@@ -22,4 +22,6 @@ var (
 	ErrEmptyUsernameAndEmail = errutil.BadRequest(
 		"user.empty-username-and-email", errutil.WithPublicMessage("Need to specify either username or email"),
 	)
+
+	ErrPasswordMissmatch = errutil.Conflict("user.password-missmatch", errutil.WithPublicMessage("Failed to update password"))
 )

--- a/pkg/services/user/error.go
+++ b/pkg/services/user/error.go
@@ -22,6 +22,5 @@ var (
 	ErrEmptyUsernameAndEmail = errutil.BadRequest(
 		"user.empty-username-and-email", errutil.WithPublicMessage("Need to specify either username or email"),
 	)
-
-	ErrPasswordMissmatch = errutil.Conflict("user.password-missmatch", errutil.WithPublicMessage("Failed to update password"))
+	ErrPasswordMissmatch = errutil.BadRequest("user.password-missmatch", errutil.WithPublicMessage("Invalid old password"))
 )

--- a/pkg/services/user/model.go
+++ b/pkg/services/user/model.go
@@ -82,18 +82,13 @@ type UpdateUserCommand struct {
 	Login string `json:"login"`
 	Theme string `json:"theme"`
 
-	UserID         int64     `json:"-"`
-	Password       *Password `json:"-"`
-	IsDisabled     *bool     `json:"-"`
-	EmailVerified  *bool     `json:"-"`
-	IsGrafanaAdmin *bool     `json:"-"`
-}
+	UserID         int64 `json:"-"`
+	IsDisabled     *bool `json:"-"`
+	EmailVerified  *bool `json:"-"`
+	IsGrafanaAdmin *bool `json:"-"`
 
-type ChangeUserPasswordCommand struct {
-	OldPassword Password `json:"oldPassword"`
-	NewPassword Password `json:"newPassword"`
-
-	UserID int64 `json:"-"`
+	Password    *Password `json:"-"`
+	OldPassword *Password `json:"-"`
 }
 
 type UpdateUserLastSeenAtCommand struct {

--- a/pkg/services/user/model.go
+++ b/pkg/services/user/model.go
@@ -292,3 +292,8 @@ type AdminCreateUserResponse struct {
 	ID      int64  `json:"id"`
 	Message string `json:"message"`
 }
+
+type ChangeUserPasswordCommand struct {
+	OldPassword Password `json:"oldPassword"`
+	NewPassword Password `json:"newPassword"`
+}

--- a/pkg/services/user/model.go
+++ b/pkg/services/user/model.go
@@ -82,10 +82,11 @@ type UpdateUserCommand struct {
 	Login string `json:"login"`
 	Theme string `json:"theme"`
 
-	UserID         int64 `json:"-"`
-	IsDisabled     *bool `json:"-"`
-	EmailVerified  *bool `json:"-"`
-	IsGrafanaAdmin *bool `json:"-"`
+	UserID         int64     `json:"-"`
+	Password       *Password `json:"-"`
+	IsDisabled     *bool     `json:"-"`
+	EmailVerified  *bool     `json:"-"`
+	IsGrafanaAdmin *bool     `json:"-"`
 }
 
 type ChangeUserPasswordCommand struct {

--- a/pkg/services/user/password.go
+++ b/pkg/services/user/password.go
@@ -41,7 +41,7 @@ func (p Password) Hash(salt string) (Password, error) {
 // one lowercase letter, one number, and one symbol.
 func ValidatePassword(newPassword string, config *setting.Cfg) error {
 	if !config.BasicAuthStrongPasswordPolicy {
-		if len(newPassword) <= 4 {
+		if len(newPassword) < 4 {
 			return ErrPasswordTooShort.Errorf("new password is too short")
 		}
 		return nil

--- a/pkg/services/user/password.go
+++ b/pkg/services/user/password.go
@@ -4,6 +4,7 @@ import (
 	"unicode"
 
 	"github.com/grafana/grafana/pkg/setting"
+	"github.com/grafana/grafana/pkg/util"
 	"github.com/grafana/grafana/pkg/util/errutil"
 )
 
@@ -22,8 +23,20 @@ func NewPassword(newPassword string, config *setting.Cfg) (Password, error) {
 	return Password(newPassword), nil
 }
 
+func NewPasswordUnchecked(password string) Password {
+	return Password(password)
+}
+
 func (p Password) Validate(config *setting.Cfg) error {
 	return ValidatePassword(string(p), config)
+}
+
+func (p Password) Hash(salt string) (Password, error) {
+	hashed, err := util.EncodePassword(string(p), salt)
+	if err != nil {
+		return "", err
+	}
+	return Password(hashed), nil
 }
 
 // ValidatePassword checks if a new password meets the required criteria based on the given configuration.

--- a/pkg/services/user/password.go
+++ b/pkg/services/user/password.go
@@ -23,10 +23,6 @@ func NewPassword(newPassword string, config *setting.Cfg) (Password, error) {
 	return Password(newPassword), nil
 }
 
-func NewPasswordUnchecked(password string) Password {
-	return Password(password)
-}
-
 func (p Password) Validate(config *setting.Cfg) error {
 	return ValidatePassword(string(p), config)
 }

--- a/pkg/services/user/password_test.go
+++ b/pkg/services/user/password_test.go
@@ -25,7 +25,7 @@ func TestPasswowrdService_ValidatePasswordHardcodePolicy(t *testing.T) {
 			strongPasswordPolicyEnabled: false,
 		},
 		{name: "should not return error when the password has 4 characters and strong password policy is disabled",
-			passwordTest:                LOWERCASE,
+			passwordTest:                "test",
 			expectedError:               nil,
 			strongPasswordPolicyEnabled: false,
 		},

--- a/pkg/services/user/user.go
+++ b/pkg/services/user/user.go
@@ -16,7 +16,6 @@ type Service interface {
 	GetByLogin(context.Context, *GetUserByLoginQuery) (*User, error)
 	GetByEmail(context.Context, *GetUserByEmailQuery) (*User, error)
 	Update(context.Context, *UpdateUserCommand) error
-	ChangePassword(context.Context, *ChangeUserPasswordCommand) error
 	UpdateLastSeenAt(context.Context, *UpdateUserLastSeenAtCommand) error
 	SetUsingOrg(context.Context, *SetUsingOrgCommand) error
 	GetSignedInUserWithCacheCtx(context.Context, *GetSignedInUserQuery) (*SignedInUser, error)

--- a/pkg/services/user/userimpl/store.go
+++ b/pkg/services/user/userimpl/store.go
@@ -63,9 +63,6 @@ func (ss *sqlStore) Insert(ctx context.Context, cmd *user.User) (int64, error) {
 			cmd.UID = util.GenerateShortUID()
 		}
 
-		cmd.Email = strings.ToLower(cmd.Email)
-		cmd.Login = strings.ToLower(cmd.Login)
-
 		if _, err = sess.Insert(cmd); err != nil {
 			return err
 		}

--- a/pkg/services/user/userimpl/store.go
+++ b/pkg/services/user/userimpl/store.go
@@ -63,6 +63,9 @@ func (ss *sqlStore) Insert(ctx context.Context, cmd *user.User) (int64, error) {
 			cmd.UID = util.GenerateShortUID()
 		}
 
+		cmd.Email = strings.ToLower(cmd.Email)
+		cmd.Login = strings.ToLower(cmd.Login)
+
 		if _, err = sess.Insert(cmd); err != nil {
 			return err
 		}

--- a/pkg/services/user/userimpl/store.go
+++ b/pkg/services/user/userimpl/store.go
@@ -28,7 +28,6 @@ type store interface {
 	GetByLogin(context.Context, *user.GetUserByLoginQuery) (*user.User, error)
 	GetByEmail(context.Context, *user.GetUserByEmailQuery) (*user.User, error)
 	Update(context.Context, *user.UpdateUserCommand) error
-	ChangePassword(context.Context, *user.ChangeUserPasswordCommand) error
 	UpdateLastSeenAt(context.Context, *user.UpdateUserLastSeenAtCommand) error
 	GetSignedInUser(context.Context, *user.GetSignedInUserQuery) (*user.SignedInUser, error)
 	UpdateUser(context.Context, *user.User) error
@@ -314,6 +313,10 @@ func (ss *sqlStore) Update(ctx context.Context, cmd *user.UpdateUserCommand) err
 
 		q := sess.ID(cmd.UserID).Where(ss.notServiceAccountFilter())
 
+		if cmd.Password != nil {
+			user.Password = *cmd.Password
+		}
+
 		if cmd.IsDisabled != nil {
 			sess.UseBool("is_disabled")
 			user.IsDisabled = *cmd.IsDisabled
@@ -349,18 +352,6 @@ func (ss *sqlStore) Update(ctx context.Context, cmd *user.UpdateUserCommand) err
 		})
 
 		return nil
-	})
-}
-
-func (ss *sqlStore) ChangePassword(ctx context.Context, cmd *user.ChangeUserPasswordCommand) error {
-	return ss.db.WithTransactionalDbSession(ctx, func(sess *db.Session) error {
-		user := user.User{
-			Password: cmd.NewPassword,
-			Updated:  time.Now(),
-		}
-
-		_, err := sess.ID(cmd.UserID).Where(ss.notServiceAccountFilter()).Update(&user)
-		return err
 	})
 }
 

--- a/pkg/services/user/userimpl/store.go
+++ b/pkg/services/user/userimpl/store.go
@@ -299,14 +299,11 @@ func (ss *sqlStore) loginConflict(ctx context.Context, sess *db.Session, login, 
 }
 
 func (ss *sqlStore) Update(ctx context.Context, cmd *user.UpdateUserCommand) error {
-	cmd.Login = strings.ToLower(cmd.Login)
-	cmd.Email = strings.ToLower(cmd.Email)
-
 	return ss.db.WithTransactionalDbSession(ctx, func(sess *db.Session) error {
 		user := user.User{
 			Name:    cmd.Name,
-			Email:   cmd.Email,
-			Login:   cmd.Login,
+			Email:   strings.ToLower(cmd.Email),
+			Login:   strings.ToLower(cmd.Login),
 			Theme:   cmd.Theme,
 			Updated: time.Now(),
 		}

--- a/pkg/services/user/userimpl/store_test.go
+++ b/pkg/services/user/userimpl/store_test.go
@@ -979,8 +979,8 @@ func TestIntegrationUserUpdate(t *testing.T) {
 		require.Equal(t, "Change Name", result.Name)
 
 		// Unchanged
-		require.Equal(t, "loginUSER3", result.Login)
-		require.Equal(t, "USER3@test.com", result.Email)
+		require.Equal(t, "loginuser3", result.Login)
+		require.Equal(t, "user3@test.com", result.Email)
 	})
 }
 

--- a/pkg/services/user/userimpl/store_test.go
+++ b/pkg/services/user/userimpl/store_test.go
@@ -419,8 +419,31 @@ func TestIntegrationUserDataAccess(t *testing.T) {
 	})
 
 	t.Run("Change user password", func(t *testing.T) {
-		err := userStore.ChangePassword(context.Background(), &user.ChangeUserPasswordCommand{})
+		id, err := userStore.Insert(context.Background(), &user.User{
+			Email:    "password@test.com",
+			Name:     "password",
+			Login:    "password",
+			Password: "password",
+			Salt:     "salt",
+			Created:  time.Now(),
+			Updated:  time.Now(),
+		})
 		require.NoError(t, err)
+
+		err = userStore.Update(context.Background(), &user.UpdateUserCommand{
+			UserID:   id,
+			Password: passwordPtr("updated"),
+		})
+		require.NoError(t, err)
+
+		updated, err := userStore.GetByID(context.Background(), id)
+		require.NoError(t, err)
+
+		assert.Equal(t, updated.Salt, "salt")
+		assert.Equal(t, updated.Name, "password")
+		assert.Equal(t, updated.Login, "password")
+		assert.Equal(t, updated.Email, "password@test.com")
+		assert.Equal(t, updated.Password, user.Password("updated"))
 	})
 
 	t.Run("update last seen at", func(t *testing.T) {
@@ -1032,6 +1055,15 @@ func createOrgAndUserSvc(t *testing.T, store db.DB, cfg *setting.Cfg) (org.Servi
 	require.NoError(t, err)
 
 	return orgService, usrSvc
+}
+
+func strPtr(s string) *string {
+	return &s
+}
+
+func passwordPtr(s string) *user.Password {
+	password := user.Password(s)
+	return &password
 }
 
 func boolPtr(b bool) *bool {

--- a/pkg/services/user/userimpl/store_test.go
+++ b/pkg/services/user/userimpl/store_test.go
@@ -1057,10 +1057,6 @@ func createOrgAndUserSvc(t *testing.T, store db.DB, cfg *setting.Cfg) (org.Servi
 	return orgService, usrSvc
 }
 
-func strPtr(s string) *string {
-	return &s
-}
-
 func passwordPtr(s string) *user.Password {
 	password := user.Password(s)
 	return &password

--- a/pkg/services/user/userimpl/user.go
+++ b/pkg/services/user/userimpl/user.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"strings"
 	"time"
 
 	"github.com/grafana/grafana/pkg/infra/db"
@@ -220,9 +219,6 @@ func (s *Service) GetByEmail(ctx context.Context, query *user.GetUserByEmailQuer
 }
 
 func (s *Service) Update(ctx context.Context, cmd *user.UpdateUserCommand) error {
-	cmd.Login = strings.ToLower(cmd.Login)
-	cmd.Email = strings.ToLower(cmd.Email)
-
 	return s.store.Update(ctx, cmd)
 }
 

--- a/pkg/services/user/userimpl/user.go
+++ b/pkg/services/user/userimpl/user.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/grafana/grafana/pkg/infra/db"
@@ -133,9 +134,9 @@ func (s *Service) Create(ctx context.Context, cmd *user.CreateUserCommand) (*use
 	// create user
 	usr := &user.User{
 		UID:              cmd.UID,
-		Email:            cmd.Email,
+		Email:            strings.ToLower(cmd.Email),
 		Name:             cmd.Name,
-		Login:            cmd.Login,
+		Login:            strings.ToLower(cmd.Login),
 		Company:          cmd.Company,
 		IsAdmin:          cmd.IsAdmin,
 		IsDisabled:       cmd.IsDisabled,

--- a/pkg/services/user/userimpl/user.go
+++ b/pkg/services/user/userimpl/user.go
@@ -228,7 +228,7 @@ func (s *Service) Update(ctx context.Context, cmd *user.UpdateUserCommand) error
 	}
 
 	if cmd.OldPassword != nil {
-		old, err := user.Password(*cmd.OldPassword).Hash(usr.Salt)
+		old, err := cmd.OldPassword.Hash(usr.Salt)
 		if err != nil {
 			return err
 		}

--- a/pkg/services/user/userimpl/user.go
+++ b/pkg/services/user/userimpl/user.go
@@ -159,11 +159,11 @@ func (s *Service) Create(ctx context.Context, cmd *user.CreateUserCommand) (*use
 	usr.Rands = rands
 
 	if len(cmd.Password) > 0 {
-		if err := usr.Password.Validate(s.cfg); err != nil {
+		if err := cmd.Password.Validate(s.cfg); err != nil {
 			return nil, err
 		}
 
-		usr.Password, err = usr.Password.Hash(usr.Salt)
+		usr.Password, err = cmd.Password.Hash(usr.Salt)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/services/user/userimpl/user.go
+++ b/pkg/services/user/userimpl/user.go
@@ -226,10 +226,6 @@ func (s *Service) Update(ctx context.Context, cmd *user.UpdateUserCommand) error
 	return s.store.Update(ctx, cmd)
 }
 
-func (s *Service) ChangePassword(ctx context.Context, cmd *user.ChangeUserPasswordCommand) error {
-	return s.store.ChangePassword(ctx, cmd)
-}
-
 func (s *Service) UpdateLastSeenAt(ctx context.Context, cmd *user.UpdateUserLastSeenAtCommand) error {
 	u, err := s.GetSignedInUserWithCacheCtx(ctx, &user.GetSignedInUserQuery{
 		UserID: cmd.UserID,

--- a/pkg/services/user/userimpl/user_test.go
+++ b/pkg/services/user/userimpl/user_test.go
@@ -161,7 +161,7 @@ func TestService_Update(t *testing.T) {
 		service := &Service{store: &FakeUserStore{ExpectedUser: &user.User{Password: stored, Salt: "salt"}}}
 
 		err = service.Update(context.Background(), &user.UpdateUserCommand{
-			OldPassword: strPtr("test123"),
+			OldPassword: passwordPtr("test123"),
 		})
 
 		assert.ErrorIs(t, err, user.ErrPasswordMissmatch)
@@ -173,7 +173,7 @@ func TestService_Update(t *testing.T) {
 		service := &Service{cfg: setting.NewCfg(), store: &FakeUserStore{ExpectedUser: &user.User{Password: stored, Salt: "salt"}}}
 
 		err = service.Update(context.Background(), &user.UpdateUserCommand{
-			OldPassword: strPtr("test"),
+			OldPassword: passwordPtr("test"),
 			Password:    passwordPtr("asd"),
 		})
 		require.ErrorIs(t, err, user.ErrPasswordTooShort)

--- a/pkg/services/user/userimpl/user_test.go
+++ b/pkg/services/user/userimpl/user_test.go
@@ -260,10 +260,6 @@ func (f *FakeUserStore) Update(ctx context.Context, cmd *user.UpdateUserCommand)
 	return f.ExpectedError
 }
 
-func (f *FakeUserStore) ChangePassword(ctx context.Context, cmd *user.ChangeUserPasswordCommand) error {
-	return f.ExpectedError
-}
-
 func (f *FakeUserStore) UpdateLastSeenAt(ctx context.Context, cmd *user.UpdateUserLastSeenAtCommand) error {
 	return f.ExpectedError
 }

--- a/pkg/services/user/usertest/fake.go
+++ b/pkg/services/user/usertest/fake.go
@@ -67,10 +67,6 @@ func (f *FakeUserService) Update(ctx context.Context, cmd *user.UpdateUserComman
 	return f.ExpectedError
 }
 
-func (f *FakeUserService) ChangePassword(ctx context.Context, cmd *user.ChangeUserPasswordCommand) error {
-	return f.ExpectedError
-}
-
 func (f *FakeUserService) UpdateLastSeenAt(ctx context.Context, cmd *user.UpdateUserLastSeenAtCommand) error {
 	return f.ExpectedError
 }

--- a/pkg/services/user/usertest/mock.go
+++ b/pkg/services/user/usertest/mock.go
@@ -32,24 +32,6 @@ func (_m *MockService) BatchDisableUsers(_a0 context.Context, _a1 *user.BatchDis
 	return r0
 }
 
-// ChangePassword provides a mock function with given fields: _a0, _a1
-func (_m *MockService) ChangePassword(_a0 context.Context, _a1 *user.ChangeUserPasswordCommand) error {
-	ret := _m.Called(_a0, _a1)
-
-	if len(ret) == 0 {
-		panic("no return value specified for ChangePassword")
-	}
-
-	var r0 error
-	if rf, ok := ret.Get(0).(func(context.Context, *user.ChangeUserPasswordCommand) error); ok {
-		r0 = rf(_a0, _a1)
-	} else {
-		r0 = ret.Error(0)
-	}
-
-	return r0
-}
-
 // Create provides a mock function with given fields: _a0, _a1
 func (_m *MockService) Create(_a0 context.Context, _a1 *user.CreateUserCommand) (*user.User, error) {
 	ret := _m.Called(_a0, _a1)


### PR DESCRIPTION
**What is this feature?**
Similar to changes done in https://github.com/grafana/grafana/pull/86341 this pr makes it so that it is possible to to use `Update` to update password of a user.

I also did a bit of refactoring around update password handlers to reduce duplicated code. 

1. Extracted a function to check if user is external.

2. Move validation and hashing responsibility to service Update function. This makes sure that we validate and hash passwords in a single place instead of having to remember to do in each call site. It also aligns with what we do in Create function

**Which issue(s) does this PR fix?**:

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
