### PR TITLE
Update `doc-validator` workflow to support `ref` URIs

### DIFF
--- a/.github/workflows/doc-validator.yml
+++ b/.github/workflows/doc-validator.yml
@@ -7,7 +7,7 @@ jobs:
   doc-validator:
     runs-on: "ubuntu-latest"
     container:
-      image: "grafana/doc-validator:v4.1.1"
+      image: "grafana/doc-validator:v5.0.0"
     steps:
       - name: "Checkout code"
         uses: "actions/checkout@v4"


### PR DESCRIPTION
- https://github.com/grafana/technical-documentation/releases/tag/doc-validator%2Fv5.0.0
- https://grafana.com/docs/writers-toolkit/write/links/#link-from-source-content-thats-used-in-multiple-projects
