### PR TITLE
Fixes repeating panels in repeating rows using same variable

### DIFF
--- a/package.json
+++ b/package.json
@@ -255,7 +255,7 @@
     "@grafana/prometheus": "workspace:*",
     "@grafana/runtime": "workspace:*",
     "@grafana/saga-icons": "workspace:*",
-    "@grafana/scenes": "4.11.1--canary.699.8720696583.0",
+    "@grafana/scenes": "^4.6.0",
     "@grafana/schema": "workspace:*",
     "@grafana/sql": "workspace:*",
     "@grafana/ui": "workspace:*",

--- a/package.json
+++ b/package.json
@@ -255,7 +255,7 @@
     "@grafana/prometheus": "workspace:*",
     "@grafana/runtime": "workspace:*",
     "@grafana/saga-icons": "workspace:*",
-    "@grafana/scenes": "^4.6.0",
+    "@grafana/scenes": "4.11.1--canary.699.8720696583.0",
     "@grafana/schema": "workspace:*",
     "@grafana/sql": "workspace:*",
     "@grafana/ui": "workspace:*",

--- a/public/app/features/dashboard-scene/scene/DashboardGridItem.test.tsx
+++ b/public/app/features/dashboard-scene/scene/DashboardGridItem.test.tsx
@@ -110,6 +110,22 @@ describe('PanelRepeaterGridItem', () => {
     expect(repeater.state.repeatedPanels?.length).toBe(2);
   });
 
+  it('Should update row and panel repeats that use same variable when updating variable', async () => {
+    const { scene, repeater, variable } = buildPanelRepeaterScene({
+      variableQueryTime: 0,
+      useRowRepeater: true,
+      useSameVariable: true,
+    });
+
+    activateFullSceneTree(scene);
+
+    variable.changeValueTo(['1', '3', '4'], ['A', 'C', 'D']);
+
+    // Should change both repeated panel and row using same variable
+    expect(repeater.state.repeatedPanels?.length).toBe(3);
+    expect((scene.state.body as SceneGridLayout).state.children.length).toBe(3);
+  });
+
   it('Should fall back to default variable if specified variable cannot be found', () => {
     const { scene, repeater } = buildPanelRepeaterScene({ variableQueryTime: 0 });
     scene.setState({ $variables: undefined });

--- a/public/app/features/dashboard-scene/scene/DashboardGridItem.tsx
+++ b/public/app/features/dashboard-scene/scene/DashboardGridItem.tsx
@@ -139,25 +139,26 @@ export class DashboardGridItem extends SceneObjectBase<DashboardGridItemState> i
       return;
     }
 
-    const defaultVariable = new CustomVariable({
-      name: '_____default_sys_repeat_var_____',
-      options: [],
-      value: '',
-      text: '',
-      query: 'A',
-    });
-
-    let variable = sceneGraph.lookupVariable(this.state.variableName, this) ?? defaultVariable;
+    let variable =
+      sceneGraph.lookupVariable(this.state.variableName, this) ??
+      new CustomVariable({
+        name: '_____default_sys_repeat_var_____',
+        options: [],
+        value: '',
+        text: '',
+        query: 'A',
+      });
 
     // If the variable is local, it means we are in a nested repeat context and we need to look up the variable further
     // up the tree hoping for a MultiValueVariable parent
     if (variable instanceof LocalValueVariable) {
-      if (variable.isAncestorLoading()) {
-        return;
-      }
-
-      // default to the default variable so that we can still render the panel
-      variable = variable.getAncestorVariable() ?? defaultVariable;
+      variable = new CustomVariable({
+        name: variable.state.name,
+        options: [],
+        value: variable.state.value,
+        text: variable.state.text,
+        query: 'A',
+      });
     }
 
     if (!(variable instanceof MultiValueVariable)) {

--- a/public/app/features/dashboard-scene/scene/RowRepeaterBehavior.ts
+++ b/public/app/features/dashboard-scene/scene/RowRepeaterBehavior.ts
@@ -104,7 +104,7 @@ export class RowRepeaterBehavior extends SceneObjectBase<RowRepeaterBehaviorStat
         }
       }
 
-      const rowClone = this.getRowClone(rowToRepeat, index, values[index], texts[index], rowContentHeight, children);
+      const rowClone = this.getRowClone(rowToRepeat, index, values, texts, rowContentHeight, children);
       rows.push(rowClone);
     }
 
@@ -117,8 +117,8 @@ export class RowRepeaterBehavior extends SceneObjectBase<RowRepeaterBehaviorStat
   getRowClone(
     rowToRepeat: SceneGridRow,
     index: number,
-    value: VariableValueSingle,
-    text: VariableValueSingle,
+    value: VariableValueSingle[],
+    text: VariableValueSingle[],
     rowContentHeight: number,
     children: SceneGridItemLike[]
   ): SceneGridRow {

--- a/public/app/features/dashboard-scene/scene/row-actions/RowActions.tsx
+++ b/public/app/features/dashboard-scene/scene/row-actions/RowActions.tsx
@@ -73,6 +73,7 @@ export class RowActions extends SceneObjectBase<RowActionsState> {
       clone.setState({
         title,
         $behaviors: row.state.$behaviors?.filter((b) => !(b instanceof RowRepeaterBehavior)) ?? [],
+        $variables: undefined,
       });
 
       this.updateLayout(clone);

--- a/public/app/features/dashboard-scene/utils/test-utils.ts
+++ b/public/app/features/dashboard-scene/utils/test-utils.ts
@@ -97,6 +97,7 @@ interface SceneOptions {
   numberOfOptions?: number;
   usePanelRepeater?: boolean;
   useRowRepeater?: boolean;
+  useSameVariable?: boolean;
 }
 
 export function buildPanelRepeaterScene(options: SceneOptions, source?: VizPanel | LibraryVizPanel) {
@@ -136,7 +137,7 @@ export function buildPanelRepeaterScene(options: SceneOptions, source?: VizPanel
     $behaviors: defaults.useRowRepeater
       ? [
           new RowRepeaterBehavior({
-            variableName: 'handler',
+            variableName: defaults.useSameVariable ? 'server' : 'handler',
             sources: [rowChildren],
           }),
         ]

--- a/yarn.lock
+++ b/yarn.lock
@@ -4180,9 +4180,9 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@grafana/scenes@npm:4.11.1--canary.699.8720696583.0":
-  version: 4.11.1--canary.699.8720696583.0
-  resolution: "@grafana/scenes@npm:4.11.1--canary.699.8720696583.0"
+"@grafana/scenes@npm:^4.6.0":
+  version: 4.11.0
+  resolution: "@grafana/scenes@npm:4.11.0"
   dependencies:
     "@grafana/e2e-selectors": "npm:10.3.3"
     react-grid-layout: "npm:1.3.4"
@@ -4196,7 +4196,7 @@ __metadata:
     "@grafana/ui": ^10.0.3
     react: ^18.0.0
     react-dom: ^18.0.0
-  checksum: 10/896df28e17f70db48f74e38e4e04cac7df0bb53d35c9bf3a58e7788322bf6be2dfe017cf4f038e5d90c13424c8e37f68a5815e14317571e3b7f143ffdb30aa00
+  checksum: 10/215d7351fd2c10fc580769a0f1e0ee9795563106907ea0b240f8fc8e9866b0a14cdb8d47b98dfd97b549b2bb518740dd1ee9bee739f2790cb0495871a4615908
   languageName: node
   linkType: hard
 
@@ -18609,7 +18609,7 @@ __metadata:
     "@grafana/prometheus": "workspace:*"
     "@grafana/runtime": "workspace:*"
     "@grafana/saga-icons": "workspace:*"
-    "@grafana/scenes": "npm:4.11.1--canary.699.8720696583.0"
+    "@grafana/scenes": "npm:^4.6.0"
     "@grafana/schema": "workspace:*"
     "@grafana/sql": "workspace:*"
     "@grafana/tsconfig": "npm:^1.3.0-rc1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4180,9 +4180,9 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@grafana/scenes@npm:^4.6.0":
-  version: 4.8.0
-  resolution: "@grafana/scenes@npm:4.8.0"
+"@grafana/scenes@npm:4.11.1--canary.699.8720696583.0":
+  version: 4.11.1--canary.699.8720696583.0
+  resolution: "@grafana/scenes@npm:4.11.1--canary.699.8720696583.0"
   dependencies:
     "@grafana/e2e-selectors": "npm:10.3.3"
     react-grid-layout: "npm:1.3.4"
@@ -4196,7 +4196,7 @@ __metadata:
     "@grafana/ui": ^10.0.3
     react: ^18.0.0
     react-dom: ^18.0.0
-  checksum: 10/8930094261ab43da948a1dac260d0246dd41c906fb4fe060ad2b534ea82ed1ee1b1d26f839ac08add1a25127a2b7b05a7c2f273a4013bda63146dae118e5d5ea
+  checksum: 10/896df28e17f70db48f74e38e4e04cac7df0bb53d35c9bf3a58e7788322bf6be2dfe017cf4f038e5d90c13424c8e37f68a5815e14317571e3b7f143ffdb30aa00
   languageName: node
   linkType: hard
 
@@ -18609,7 +18609,7 @@ __metadata:
     "@grafana/prometheus": "workspace:*"
     "@grafana/runtime": "workspace:*"
     "@grafana/saga-icons": "workspace:*"
-    "@grafana/scenes": "npm:^4.6.0"
+    "@grafana/scenes": "npm:4.11.1--canary.699.8720696583.0"
     "@grafana/schema": "workspace:*"
     "@grafana/sql": "workspace:*"
     "@grafana/tsconfig": "npm:^1.3.0-rc1"


### PR DESCRIPTION
This is WIP

Fixes a scenario where we repeat a panel under a repeated row using the same variable. The `DashboardGridItem._performRepeat` looks up and finds the variable in the grid row, since they have the same name, and since that is a `LocalValueVariable` it cannot perform the repeat with it so it logs an error and returns.

Before:


https://github.com/grafana/grafana/assets/36818606/324d50b2-b977-47b8-bf89-cc268659a2e9



After:


https://github.com/grafana/grafana/assets/36818606/8d19239e-56ec-4fd6-98a7-95d00805d0df



Fixes https://github.com/grafana/grafana/issues/84915