### PR TITLE
<Grafana Dashboard>Correct spelling mistake in Dashboard Change prompt

### DIFF
--- a/public/app/features/live/dashboard/DashboardChangedModal.tsx
+++ b/public/app/features/live/dashboard/DashboardChangedModal.tsx
@@ -36,7 +36,7 @@ export function DashboardChangedModal({ onDismiss, event }: Props) {
       className={styles.modal}
     >
       <div className={styles.description}>
-        The dashboad has been updated by another session. Do you want to continue editing or discard your local changes?
+        The dashboard has been updated by another session. Do you want to continue editing or discard your local changes?
       </div>
       <Modal.ButtonRow>
         <Button onClick={onDismiss} variant="secondary" fill="outline">


### PR DESCRIPTION

**What is this feature?**

I noticed a spelling mistake when multiple users collaborate on a dashboard and try to save it. I've corrected the mistake in this PR

**Why do we need this feature?**

See attached image - it's an egregious typo

**Who is this feature for?**

All users

**Which issue(s) does this PR fix?**:


Please check that:
- [X] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [X] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
