### PR TITLE
Loki: Fix setting of tenant ID

### DIFF
--- a/pkg/tsdb/loki/api.go
+++ b/pkg/tsdb/loki/api.go
@@ -367,7 +367,7 @@ func setXScopeOrgIDHeader(req *http.Request, ctx context.Context) *http.Request 
 	if len(tenantids) == 0 {
 		// We assume we are not using multi-tenant mode, which is fine
 		logger.Debug("Tenant ID not present. Header not set")
-	} else if len(tenantids[0]) > 1 {
+	} else if len(tenantids) > 1 {
 		// Loki supports multiple tenant IDs, but we should receive them from different contexts
 		logger.Error(strconv.Itoa(len(tenantids)) + " tenant IDs found. Header not set")
 	} else {


### PR DESCRIPTION
One of the sanity checks when retrieving the tenant ID is bugged. This PR fixes it.