### PR TITLE
Imageupload: Add support for custom ACL on s3 objects

### DIFF
--- a/conf/defaults.ini
+++ b/conf/defaults.ini
@@ -1526,6 +1526,7 @@ region =
 path =
 access_key =
 secret_key =
+acl = public-read
 
 [external_image_storage.webdav]
 url =

--- a/conf/sample.ini
+++ b/conf/sample.ini
@@ -1391,6 +1391,7 @@ max_annotations_to_keep =
 ;path =
 ;access_key =
 ;secret_key =
+;acl = public-read
 
 [external_image_storage.webdav]
 ;url =

--- a/pkg/components/imguploader/imguploader.go
+++ b/pkg/components/imguploader/imguploader.go
@@ -48,6 +48,7 @@ func NewImageUploader(cfg *setting.Cfg) (ImageUploader, error) {
 		bucketUrl := s3sec.Key("bucket_url").MustString("")
 		accessKey := s3sec.Key("access_key").MustString("")
 		secretKey := s3sec.Key("secret_key").MustString("")
+		acl := s3sec.Key("acl").MustString("public-read")
 
 		if path != "" && path[len(path)-1:] != "/" {
 			path += "/"
@@ -62,7 +63,7 @@ func NewImageUploader(cfg *setting.Cfg) (ImageUploader, error) {
 			region = info.region
 		}
 
-		return NewS3Uploader(endpoint, region, bucket, path, "public-read", accessKey, secretKey, pathStyleAccess), nil
+		return NewS3Uploader(endpoint, region, bucket, path, acl, accessKey, secretKey, pathStyleAccess), nil
 	case "webdav":
 		webdavSec, err := cfg.Raw.GetSection("external_image_storage.webdav")
 		if err != nil {


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**
Adds a setting in the config that lets you change the ACL of the images that are uploaded to Amazon S3 with a default of "public-read".

**Why do we need this feature?**
Currently Grafana only allows images to have the ACL of "public-read" when uploaded to S3. This could become a security issue if the data the graph contains is sensitive. 

**Who is this feature for?**
Anyone who wants to protect sensitive information in their graphs by not exposing it to the public.

**Which issue(s) does this PR fix?**:


Fixes #86441 

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
