### PR TITLE
ci: remove milestone check

### DIFF
--- a/.github/pr-checks.json
+++ b/.github/pr-checks.json
@@ -1,12 +1,5 @@
 [
   {
-    "type": "check-milestone",
-    "title": "Milestone Check",
-    "targetUrl": "https://github.com/grafana/grafana/blob/main/contribute/merge-pull-request.md#assign-a-milestone",
-    "success": "Milestone set",
-    "failure": "Milestone not set"
-  },
-  {
     "type": "check-changelog",
     "title": "Changelog Check",
     "labels": {


### PR DESCRIPTION
**What is this feature?**

We've had an [auto-milestone](https://github.com/grafana/grafana/blob/main/.github/workflows/auto-milestone.yml) workflow for a while now, and this renders the milestone check (from [PR Checks](https://github.com/grafana/grafana/blob/main/.github/workflows/pr-checks.yml)) unnecessary. 

Worse, there are occasional ordering issues that cause the milestone check to fail.

**Why do we need this feature?**

This is causing friction!

**Who is this feature for?**

Committers

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
