### PR TITLE
Chore: Don't apply adhoc filters when promQLScope is enabled

### DIFF
--- a/packages/grafana-prometheus/src/datasource.test.ts
+++ b/packages/grafana-prometheus/src/datasource.test.ts
@@ -17,7 +17,7 @@ import {
   TimeRange,
   VariableHide,
 } from '@grafana/data';
-import { TemplateSrv } from '@grafana/runtime';
+import { config, TemplateSrv } from '@grafana/runtime';
 
 import {
   alignRange,
@@ -542,6 +542,9 @@ describe('PrometheusDatasource', () => {
   });
 
   describe('interpolateVariablesInQueries', () => {
+    afterAll(() => {
+      config.featureToggles.promQLScope = undefined;
+    });
     it('should call replace function 2 times', () => {
       const query: PromQuery = {
         expr: 'test{job="testjob"}',
@@ -568,11 +571,27 @@ describe('PrometheusDatasource', () => {
       ds.interpolateVariablesInQueries(queries, {});
       expect(ds.enhanceExprWithAdHocFilters).toHaveBeenCalled();
     });
+
+    it('should not apply adhoc filters when promQLScope is enabled', () => {
+      config.featureToggles.promQLScope = true;
+      ds.enhanceExprWithAdHocFilters = jest.fn();
+      ds.generateScopeFilters = jest.fn();
+      const queries = [
+        {
+          refId: 'A',
+          expr: 'rate({bar="baz", job="foo"} [5m]',
+        },
+      ];
+      ds.interpolateVariablesInQueries(queries, {});
+      expect(ds.enhanceExprWithAdHocFilters).not.toHaveBeenCalled();
+      expect(ds.generateScopeFilters).toHaveBeenCalled();
+    });
   });
 
   describe('applyTemplateVariables', () => {
     afterAll(() => {
       replaceMock.mockImplementation((a: string, ...rest: unknown[]) => a);
+      config.featureToggles.promQLScope = undefined;
     });
 
     it('should call replace function for legendFormat', () => {
@@ -635,6 +654,45 @@ describe('PrometheusDatasource', () => {
 
       const result = ds.applyTemplateVariables(query, {}, filters);
       expect(result).toMatchObject({ expr: 'test{job="bar", k1="v1", k2!="v2"}' });
+    });
+
+    it('should generate scope filters and **not** apply ad-hoc filters to expr', () => {
+      config.featureToggles.promQLScope = true;
+      replaceMock.mockImplementation((a: string) => a);
+      const filters = [
+        {
+          key: 'k1',
+          operator: '=',
+          value: 'v1',
+        },
+        {
+          key: 'k2',
+          operator: '!=',
+          value: 'v2',
+        },
+      ];
+
+      const query = {
+        expr: 'test{job="bar"}',
+        refId: 'A',
+      };
+
+      const expectedScopeFilters: ScopeSpecFilter[] = [
+        {
+          key: 'k1',
+          operator: 'equals',
+          value: 'v1',
+        },
+        {
+          key: 'k2',
+          operator: 'not-equals',
+          value: 'v2',
+        },
+      ];
+
+      const result = ds.applyTemplateVariables(query, {}, filters);
+      expect(result.expr).toBe('test{job="bar"}');
+      expect(result.adhocFilters).toEqual(expectedScopeFilters);
     });
 
     it('should add ad-hoc filters only to expr', () => {

--- a/packages/grafana-prometheus/src/datasource.test.ts
+++ b/packages/grafana-prometheus/src/datasource.test.ts
@@ -542,9 +542,10 @@ describe('PrometheusDatasource', () => {
   });
 
   describe('interpolateVariablesInQueries', () => {
-    afterAll(() => {
+    afterEach(() => {
       config.featureToggles.promQLScope = undefined;
     });
+
     it('should call replace function 2 times', () => {
       const query: PromQuery = {
         expr: 'test{job="testjob"}',
@@ -591,7 +592,10 @@ describe('PrometheusDatasource', () => {
   describe('applyTemplateVariables', () => {
     afterAll(() => {
       replaceMock.mockImplementation((a: string, ...rest: unknown[]) => a);
-      config.featureToggles.promQLScope = undefined;
+    });
+
+    afterEach(() => {
+      config.featureToggles.promQLScope = false;
     });
 
     it('should call replace function for legendFormat', () => {

--- a/packages/grafana-prometheus/src/datasource.ts
+++ b/packages/grafana-prometheus/src/datasource.ts
@@ -757,9 +757,10 @@ export class PrometheusDatasource
           ...query,
           ...(config.featureToggles.promQLScope ? { adhocFilters: this.generateScopeFilters(filters) } : {}),
           datasource: this.getRef(),
-          expr: withAdhocFilters,
+          expr: config.featureToggles.promQLScope ? interpolatedQuery : withAdhocFilters,
           interval: this.templateSrv.replace(query.interval, scopedVars),
         };
+
         return expandedQuery;
       });
     }
@@ -927,7 +928,7 @@ export class PrometheusDatasource
     return {
       ...target,
       ...(config.featureToggles.promQLScope ? { adhocFilters: this.generateScopeFilters(filters) } : {}),
-      expr: exprWithAdHocFilters,
+      expr: config.featureToggles.promQLScope ? expr : exprWithAdHocFilters,
       interval: this.templateSrv.replace(target.interval, variables),
       legendFormat: this.templateSrv.replace(target.legendFormat, variables),
     };

--- a/packages/grafana-prometheus/src/datasource.ts
+++ b/packages/grafana-prometheus/src/datasource.ts
@@ -751,13 +751,14 @@ export class PrometheusDatasource
     if (queries && queries.length) {
       expandedQueries = queries.map((query) => {
         const interpolatedQuery = this.templateSrv.replace(query.expr, scopedVars, this.interpolateQueryExpr);
-        const withAdhocFilters = this.enhanceExprWithAdHocFilters(filters, interpolatedQuery);
 
         const expandedQuery = {
           ...query,
           ...(config.featureToggles.promQLScope ? { adhocFilters: this.generateScopeFilters(filters) } : {}),
           datasource: this.getRef(),
-          expr: config.featureToggles.promQLScope ? interpolatedQuery : withAdhocFilters,
+          expr: config.featureToggles.promQLScope
+            ? interpolatedQuery
+            : this.enhanceExprWithAdHocFilters(filters, interpolatedQuery),
           interval: this.templateSrv.replace(query.interval, scopedVars),
         };
 
@@ -922,13 +923,10 @@ export class PrometheusDatasource
     // interpolate expression
     const expr = this.templateSrv.replace(target.expr, variables, this.interpolateQueryExpr);
 
-    // Add ad hoc filters
-    const exprWithAdHocFilters = this.enhanceExprWithAdHocFilters(filters, expr);
-
     return {
       ...target,
       ...(config.featureToggles.promQLScope ? { adhocFilters: this.generateScopeFilters(filters) } : {}),
-      expr: config.featureToggles.promQLScope ? expr : exprWithAdHocFilters,
+      expr: config.featureToggles.promQLScope ? expr : this.enhanceExprWithAdHocFilters(filters, expr),
       interval: this.templateSrv.replace(target.interval, variables),
       legendFormat: this.templateSrv.replace(target.legendFormat, variables),
     };


### PR DESCRIPTION
**What is this feature?**

This makes sure we are not applying ad-hoc filters to the expression as they are going to be handled on the backend.


**Special notes for your reviewer:**
There are some repetitive/duplicate codes. I don't want to do a big refactor in this PR. I'll clean the code in a separate one. 

Please check that:
- [x] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
