### PR TITLE
Prometheus: Bypass flaky E2E test

### DIFF
--- a/e2e/various-suite/query-editor.spec.ts
+++ b/e2e/various-suite/query-editor.spec.ts
@@ -6,7 +6,9 @@ describe('Query editor', () => {
     e2e.flows.login(Cypress.env('USERNAME'), Cypress.env('PASSWORD'));
   });
 
-  it('Undo should work in query editor for prometheus -- test CI.', () => {
+  // x-ing to bypass this flaky test.
+  // Will rewrite in plugin-e2e with this issue
+  xit('Undo should work in query editor for prometheus -- test CI.', () => {
     e2e.pages.Explore.visit();
     e2e.components.DataSourcePicker.container().should('be.visible').click();
 


### PR DESCRIPTION
**What is this feature?**

This PR bypasses a known flaky test. @grafana/grafana-frontend-platform would you like to keep ownership of this or would you like @grafana/observability-metrics to take this one?

**Why do we need this feature?**

This test is known to be flaky and should be rewritten using plugin-e2e. [Here is an issue for that](https://github.com/grafana/grafana/issues/86459).

**Who is this feature for?**

This is for developers.

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
