### PR TITLE
Chore: Remove unused functions form prometheus data source

### DIFF
--- a/packages/grafana-prometheus/src/__mocks__/datasource.ts
+++ b/packages/grafana-prometheus/src/__mocks__/datasource.ts
@@ -1,0 +1,135 @@
+import { CoreApp, DataQueryRequest, dateTime, rangeUtil, TimeRange } from '@grafana/data';
+
+import { PromQuery } from '../types';
+
+export function createDataRequest(
+  targets: PromQuery[],
+  overrides?: Partial<DataQueryRequest>
+): DataQueryRequest<PromQuery> {
+  const defaults: DataQueryRequest<PromQuery> = {
+    intervalMs: 15000,
+    requestId: 'createDataRequest',
+    startTime: 0,
+    timezone: 'browser',
+    app: CoreApp.Dashboard,
+    targets: targets.map((t, i) => ({
+      instant: false,
+      start: dateTime().subtract(5, 'minutes'),
+      end: dateTime(),
+      ...t,
+    })),
+    range: {
+      from: dateTime(),
+      to: dateTime(),
+      raw: {
+        from: '',
+        to: '',
+      },
+    },
+    interval: '15s',
+    scopedVars: {},
+  };
+
+  return Object.assign(defaults, overrides || {}) as DataQueryRequest<PromQuery>;
+}
+
+export function createDefaultPromResponse() {
+  return {
+    data: {
+      data: {
+        result: [
+          {
+            metric: {
+              __name__: 'test_metric',
+            },
+            values: [[1568369640, 1]],
+          },
+        ],
+        resultType: 'matrix',
+      },
+    },
+  };
+}
+
+export function createAnnotationResponse() {
+  const response = {
+    data: {
+      results: {
+        X: {
+          frames: [
+            {
+              schema: {
+                name: 'bar',
+                refId: 'X',
+                fields: [
+                  {
+                    name: 'Time',
+                    type: 'time',
+                    typeInfo: {
+                      frame: 'time.Time',
+                    },
+                  },
+                  {
+                    name: 'Value',
+                    type: 'number',
+                    typeInfo: {
+                      frame: 'float64',
+                    },
+                    labels: {
+                      __name__: 'ALERTS',
+                      alertname: 'InstanceDown',
+                      alertstate: 'firing',
+                      instance: 'testinstance',
+                      job: 'testjob',
+                    },
+                  },
+                ],
+              },
+              data: {
+                values: [[123], [456]],
+              },
+            },
+          ],
+        },
+      },
+    },
+  };
+
+  return { ...response };
+}
+
+export function createEmptyAnnotationResponse() {
+  const response = {
+    data: {
+      results: {
+        X: {
+          frames: [
+            {
+              schema: {
+                name: 'bar',
+                refId: 'X',
+                fields: [],
+              },
+              data: {
+                values: [],
+              },
+            },
+          ],
+        },
+      },
+    },
+  };
+
+  return { ...response };
+}
+
+export function getMockTimeRange(range = '6h'): TimeRange {
+  return rangeUtil.convertRawToRange({
+    from: `now-${range}`,
+    to: 'now',
+  });
+}
+
+export function fetchMockCalledWith(fetchMock: ReturnType<typeof jest.fn>): PromQuery[] {
+  return fetchMock.mock.calls[0][0].data.queries ?? [];
+}

--- a/packages/grafana-prometheus/src/components/PromQueryEditorByApp.test.tsx
+++ b/packages/grafana-prometheus/src/components/PromQueryEditorByApp.test.tsx
@@ -25,7 +25,6 @@ jest.mock('./monaco-query-field/MonacoQueryFieldLazy', () => {
 
 function setup(app: CoreApp): { onRunQuery: jest.Mock } {
   const dataSource = {
-    createQuery: jest.fn((q) => q),
     getInitHints: () => [],
     getPrometheusTime: jest.fn((date, roundup) => 123),
     getQueryHints: jest.fn(() => []),

--- a/packages/grafana-prometheus/src/datasource.test.ts
+++ b/packages/grafana-prometheus/src/datasource.test.ts
@@ -248,7 +248,6 @@ describe('PrometheusDatasource', () => {
       expect(result).toMatchObject({ expr: DEFAULT_QUERY_EXPRESSION });
     });
 
-
     it('should add filters to expression', () => {
       const filters = [
         {

--- a/packages/grafana-prometheus/src/datasource.test.ts
+++ b/packages/grafana-prometheus/src/datasource.test.ts
@@ -39,13 +39,6 @@ import { PromApplication, PrometheusCacheLevel, PromOptions, PromQuery, PromQuer
 const fetchMock = jest.fn().mockReturnValue(of(createDefaultPromResponse()));
 
 jest.mock('./metric_find_query');
-// jest.mock('@grafana/runtime', () => ({
-//   ...jest.requireActual('@grafana/runtime'),
-//   getBackendSrv: () => ({
-//     fetch: fetchMock,
-//   }),
-// }));
-
 const origBackendSrv = getBackendSrv();
 setBackendSrv({
   ...origBackendSrv,

--- a/packages/grafana-prometheus/src/datasource.ts
+++ b/packages/grafana-prometheus/src/datasource.ts
@@ -432,108 +432,6 @@ export class PrometheusDatasource
     );
   }
 
-  createQuery(target: PromQuery, options: DataQueryRequest<PromQuery>, start: number, end: number) {
-    const query: PromQueryRequest = {
-      hinting: target.hinting,
-      instant: target.instant,
-      exemplar: target.exemplar,
-      step: 0,
-      expr: '',
-      refId: target.refId,
-      start: 0,
-      end: 0,
-    };
-    const range = Math.ceil(end - start);
-
-    // options.interval is the dynamically calculated interval
-    let interval: number = rangeUtil.intervalToSeconds(options.interval);
-    // Minimum interval ("Min step"), if specified for the query, or same as interval otherwise.
-    const minInterval = rangeUtil.intervalToSeconds(
-      this.templateSrv.replace(target.interval || options.interval, options.scopedVars)
-    );
-    // Scrape interval as specified for the query ("Min step") or otherwise taken from the datasource.
-    // Min step field can have template variables in it, make sure to replace it.
-    const scrapeInterval = target.interval
-      ? rangeUtil.intervalToSeconds(this.templateSrv.replace(target.interval, options.scopedVars))
-      : rangeUtil.intervalToSeconds(this.interval);
-
-    const intervalFactor = target.intervalFactor || 1;
-    // Adjust the interval to take into account any specified minimum and interval factor plus Prometheus limits
-    const adjustedInterval = this.adjustInterval(interval, minInterval, range, intervalFactor);
-    let scopedVars = {
-      ...options.scopedVars,
-      ...this.getRangeScopedVars(options.range),
-      ...this.getRateIntervalScopedVariable(adjustedInterval, scrapeInterval),
-    };
-    // If the interval was adjusted, make a shallow copy of scopedVars with updated interval vars
-    if (interval !== adjustedInterval) {
-      interval = adjustedInterval;
-      scopedVars = Object.assign({}, options.scopedVars, {
-        __interval: { text: interval + 's', value: interval + 's' },
-        __interval_ms: { text: interval * 1000, value: interval * 1000 },
-        ...this.getRateIntervalScopedVariable(interval, scrapeInterval),
-        ...this.getRangeScopedVars(options.range),
-      });
-    }
-
-    query.step = interval;
-
-    let expr = target.expr;
-
-    if (config.featureToggles.promQLScope) {
-      // Apply scope filters
-      query.adhocFilters = this.generateScopeFilters(options.filters);
-    } else {
-      // Apply adhoc filters
-      expr = this.enhanceExprWithAdHocFilters(options.filters, expr);
-    }
-
-    // Only replace vars in expression after having (possibly) updated interval vars
-    query.expr = this.templateSrv.replace(expr, scopedVars, this.interpolateQueryExpr);
-
-    // Align query interval with step to allow query caching and to ensure
-    // that about-same-time query results look the same.
-    const adjusted = alignRange(start, end, query.step, options.range.to.utcOffset() * 60);
-    query.start = adjusted.start;
-    query.end = adjusted.end;
-    this._addTracingHeaders(query, options);
-
-    return query;
-  }
-
-  /**
-   * This converts the adhocVariableFilter array and converts it to scopeFilter array
-   * @param filters
-   */
-  generateScopeFilters(filters?: AdHocVariableFilter[]): ScopeSpecFilter[] {
-    if (!filters) {
-      return [];
-    }
-
-    return filters.map((f) => ({ ...f, operator: scopeFilterOperatorMap[f.operator] }));
-  }
-
-  getRateIntervalScopedVariable(interval: number, scrapeInterval: number) {
-    // Fall back to the default scrape interval of 15s if scrapeInterval is 0 for some reason.
-    if (scrapeInterval === 0) {
-      scrapeInterval = 15;
-    }
-    const rateInterval = Math.max(interval + scrapeInterval, 4 * scrapeInterval);
-    return { __rate_interval: { text: rateInterval + 's', value: rateInterval + 's' } };
-  }
-
-  adjustInterval(interval: number, minInterval: number, range: number, intervalFactor: number) {
-    // Prometheus will drop queries that might return more than 11000 data points.
-    // Calculate a safe interval as an additional minimum to take into account.
-    // Fractional safeIntervals are allowed, however serve little purpose if the interval is greater than 1
-    // If this is the case take the ceil of the value.
-    let safeInterval = range / 11000;
-    if (safeInterval > 1) {
-      safeInterval = Math.ceil(safeInterval);
-    }
-    return Math.max(interval * intervalFactor, minInterval, safeInterval);
-  }
-
   metricFindQuery(query: string, options?: LegacyMetricFindQueryOptions) {
     if (!query) {
       return Promise.resolve([]);
@@ -881,6 +779,18 @@ export class PrometheusDatasource
 
   getOriginalMetricName(labelData: { [key: string]: string }) {
     return getOriginalMetricName(labelData);
+  }
+
+  /**
+   * This converts the adhocVariableFilter array and converts it to scopeFilter array
+   * @param filters
+   */
+  generateScopeFilters(filters?: AdHocVariableFilter[]): ScopeSpecFilter[] {
+    if (!filters) {
+      return [];
+    }
+
+    return filters.map((f) => ({ ...f, operator: scopeFilterOperatorMap[f.operator] }));
   }
 
   enhanceExprWithAdHocFilters(filters: AdHocVariableFilter[] | undefined, expr: string) {

--- a/packages/grafana-prometheus/tsconfig.build.json
+++ b/packages/grafana-prometheus/tsconfig.build.json
@@ -1,4 +1,4 @@
 {
-  "exclude": ["dist", "node_modules", "test", "**/*.test.ts*"],
+  "exclude": ["dist", "node_modules", "__mocks__", "test", "**/*.test.ts*"],
   "extends": "./tsconfig.json"
 }


### PR DESCRIPTION
**What is this feature?**

Removing unused functions from `prometheus` data source and updating the unit tests.
Also introduced a `__mocks__` folder for storing mocks. 

**Why do we need this feature?**

🧹 🧹 🧹 
