### PR TITLE
Explore: Mock useExplorePageTitle in every integration test

### DIFF
--- a/public/app/features/explore/spec/datasourceState.test.tsx
+++ b/public/app/features/explore/spec/datasourceState.test.tsx
@@ -31,6 +31,10 @@ jest.mock('app/core/core', () => ({
   },
 }));
 
+jest.mock('../hooks/useExplorePageTitle', () => ({
+  useExplorePageTitle: jest.fn(),
+}));
+
 describe('Explore: handle datasource states', () => {
   afterEach(() => {
     tearDown();

--- a/public/app/features/explore/spec/interpolation.test.tsx
+++ b/public/app/features/explore/spec/interpolation.test.tsx
@@ -32,6 +32,10 @@ jest.mock('react-virtualized-auto-sizer', () => {
   };
 });
 
+jest.mock('../hooks/useExplorePageTitle', () => ({
+  useExplorePageTitle: jest.fn(),
+}));
+
 describe('Explore: interpolation', () => {
   afterEach(() => {
     tearDown();

--- a/public/app/features/explore/spec/query.test.tsx
+++ b/public/app/features/explore/spec/query.test.tsx
@@ -23,6 +23,10 @@ jest.mock('react-virtualized-auto-sizer', () => {
     });
 });
 
+jest.mock('../hooks/useExplorePageTitle', () => ({
+  useExplorePageTitle: jest.fn(),
+}));
+
 describe('Explore: handle running/not running query', () => {
   afterEach(() => {
     tearDown();

--- a/public/app/features/explore/spec/split.test.tsx
+++ b/public/app/features/explore/spec/split.test.tsx
@@ -44,6 +44,10 @@ jest.mock('@grafana/runtime', () => ({
   getAppEvents: () => testEventBus,
 }));
 
+jest.mock('../hooks/useExplorePageTitle', () => ({
+  useExplorePageTitle: jest.fn(),
+}));
+
 describe('Handles open/close splits and related events in UI and URL', () => {
   afterEach(() => {
     tearDown();


### PR DESCRIPTION
See https://github.com/grafana/grafana/pull/86370

We are seeing the same failure on another integration test in this directory. Mock the hook in the same way in every integration test, as they all load explore in the same way.