### PR TITLE
VizTooltip: Fix heatmap mode All

### DIFF
--- a/public/app/plugins/panel/heatmap/HeatmapTooltip.tsx
+++ b/public/app/plugins/panel/heatmap/HeatmapTooltip.tsx
@@ -112,7 +112,11 @@ const HeatmapHoverCell = ({
 
   let contentItems: VizTooltipItem[] = [];
 
-  const yValueIdx = index % (data.yBucketCount ?? 1);
+  const getYValueIndex = (idx: number) => {
+    return idx % (data.yBucketCount ?? 1);
+  };
+
+  let yValueIdx = getYValueIndex(index);
   const xValueIdx = Math.floor(index / (data.yBucketCount ?? 1));
 
   const getData = (idx: number = index) => {
@@ -182,6 +186,7 @@ const HeatmapHoverCell = ({
       if (isSparse) {
         ({ xBucketMin, xBucketMax, yBucketMin, yBucketMax } = getSparseCellMinMax(data!, idx));
       } else {
+        yValueIdx = getYValueIndex(idx);
         getData(idx);
       }
 


### PR DESCRIPTION
Before
![heatmap_multi_before](https://github.com/grafana/grafana/assets/88068998/13530fab-dae7-4218-8280-605b87ea750b)

After
![heatmap_multi_after](https://github.com/grafana/grafana/assets/88068998/8594b31d-c734-4e0d-8c6f-8363b61f94da)


Fixes  https://github.com/grafana/grafana/issues/86457


Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
