### PR TITLE
Prometheus: Do not throw error for label_join function

### DIFF
--- a/packages/grafana-prometheus/src/querybuilder/operations.ts
+++ b/packages/grafana-prometheus/src/querybuilder/operations.ts
@@ -381,7 +381,7 @@ function labelJoinRenderer(model: QueryBuilderOperation, def: QueryBuilderOperat
   }
 
   const paramZero = model.params[0] ?? '';
-  const paramOne = model.params[0] ?? '';
+  const paramOne = model.params[1] ?? '';
 
   const separator = `"${paramOne}"`;
   return `${model.id}(${innerExpr}, "${paramZero}", ${separator}, "${model.params.slice(2).join(separator)}")`;

--- a/packages/grafana-prometheus/src/querybuilder/operations.ts
+++ b/packages/grafana-prometheus/src/querybuilder/operations.ts
@@ -374,11 +374,17 @@ function addNestedQueryHandler(def: QueryBuilderOperationDef, query: PromVisualQ
 }
 
 function labelJoinRenderer(model: QueryBuilderOperation, def: QueryBuilderOperationDef, innerExpr: string) {
-  if (typeof model.params[1] !== 'string') {
+  // only throw error if user begins typing the separator(param 1)
+  // prevents error when toggling explain mode
+  if (model.params[1] && typeof model.params[1] !== 'string') {
     throw 'The separator must be a string';
   }
-  const separator = `"${model.params[1]}"`;
-  return `${model.id}(${innerExpr}, "${model.params[0]}", ${separator}, "${model.params.slice(2).join(separator)}")`;
+
+  const paramZero = model.params[0] ?? '';
+  const paramOne = model.params[0] ?? '';
+
+  const separator = `"${paramOne}"`;
+  return `${model.id}(${innerExpr}, "${paramZero}", ${separator}, "${model.params.slice(2).join(separator)}")`;
 }
 
 function labelJoinAddOperationHandler<T extends QueryWithOperations>(def: QueryBuilderOperationDef, query: T) {

--- a/packages/grafana-prometheus/src/querybuilder/operations.ts
+++ b/packages/grafana-prometheus/src/querybuilder/operations.ts
@@ -219,6 +219,7 @@ export function getOperationDefinitions(): QueryBuilderOperationDef[] {
       ],
       defaultParams: ['', ',', ''],
       renderer: labelJoinRenderer,
+      explainHandler: labelJoinExplainHandler,
       addOperationHandler: labelJoinAddOperationHandler,
     }),
     createFunction({ id: PromOperationId.Log10 }),
@@ -374,17 +375,21 @@ function addNestedQueryHandler(def: QueryBuilderOperationDef, query: PromVisualQ
 }
 
 function labelJoinRenderer(model: QueryBuilderOperation, def: QueryBuilderOperationDef, innerExpr: string) {
-  // only throw error if user begins typing the separator(param 1)
-  // prevents error when toggling explain mode
-  if (model.params[1] && typeof model.params[1] !== 'string') {
-    throw 'The separator must be a string';
-  }
-
   const paramZero = model.params[0] ?? '';
   const paramOne = model.params[1] ?? '';
 
   const separator = `"${paramOne}"`;
   return `${model.id}(${innerExpr}, "${paramZero}", ${separator}, "${model.params.slice(2).join(separator)}")`;
+}
+
+function labelJoinExplainHandler(op: QueryBuilderOperation, def?: QueryBuilderOperationDef): string {
+  let explainMessage = def?.documentation ?? 'no docs';
+
+  if (typeof op.params[1] !== 'string') {
+    explainMessage += ' 🚨🚨🚨 The `separator` must be a string.';
+  }
+
+  return explainMessage;
 }
 
 function labelJoinAddOperationHandler<T extends QueryWithOperations>(def: QueryBuilderOperationDef, query: T) {


### PR DESCRIPTION
**What is this?**

This fixes error handling for the label_join() function in the Prometheus code editor when explain is toggled. This PR is a reference for a hand rolled fix for v10.4.x which needs a back port.

**Why do we need this feature?**

We need this to fix error handling for the label_join function for this [escalation](https://github.com/grafana/support-escalations/issues/10111). This change to main does not fix the escalation though.
 
This needs to be backported to v10.4.x but is a special case because we removed the core Prometheus frontend code and this change only targets the library. Therefore we will need to create a branch off of v10.4.x and target that for the change.

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
