### PR TITLE
Apply plugin route ReqAction to ds_proxy authorization

### DIFF
--- a/pkg/api/pluginproxy/ds_proxy.go
+++ b/pkg/api/pluginproxy/ds_proxy.go
@@ -19,6 +19,7 @@ import (
 	glog "github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/infra/tracing"
 	"github.com/grafana/grafana/pkg/plugins"
+	"github.com/grafana/grafana/pkg/services/accesscontrol"
 	contextmodel "github.com/grafana/grafana/pkg/services/contexthandler/model"
 	"github.com/grafana/grafana/pkg/services/datasources"
 	"github.com/grafana/grafana/pkg/services/featuremgmt"
@@ -304,7 +305,10 @@ func (proxy *DataSourceProxy) validateRequest() error {
 			continue
 		}
 
-		routeEval := route.Evaluator()
+		var routeEval accesscontrol.Evaluator
+		if route.ReqAction != "" {
+			routeEval = accesscontrol.EvalPermission(route.ReqAction)
+		}
 		switch {
 		case routeEval != nil:
 			if ok := routeEval.Evaluate(proxy.ctx.GetPermissions()); !ok {

--- a/pkg/api/pluginproxy/ds_proxy.go
+++ b/pkg/api/pluginproxy/ds_proxy.go
@@ -304,7 +304,13 @@ func (proxy *DataSourceProxy) validateRequest() error {
 			continue
 		}
 
-		if route.ReqRole.IsValid() {
+		routeEval := route.Evaluator()
+		switch {
+		case routeEval != nil:
+			if ok := routeEval.Evaluate(proxy.ctx.GetPermissions()); !ok {
+				return errors.New("plugin proxy route access denied")
+			}
+		case route.ReqRole.IsValid():
 			if !proxy.ctx.HasUserRole(route.ReqRole) {
 				return errors.New("plugin proxy route access denied")
 			}

--- a/pkg/api/pluginproxy/pluginproxy.go
+++ b/pkg/api/pluginproxy/pluginproxy.go
@@ -122,7 +122,7 @@ func (proxy *PluginProxy) HandleRequest() {
 }
 
 func (proxy *PluginProxy) hasAccessToRoute(route *plugins.Route) bool {
-	useRBAC := proxy.features.IsEnabled(proxy.ctx.Req.Context(), featuremgmt.FlagAccessControlOnCall) && route.RequiresRBACAction()
+	useRBAC := proxy.features.IsEnabled(proxy.ctx.Req.Context(), featuremgmt.FlagAccessControlOnCall) && route.ReqAction != ""
 	if useRBAC {
 		hasAccess := ac.HasAccess(proxy.accessControl, proxy.ctx)(ac.EvalPermission(route.ReqAction))
 		if !hasAccess {

--- a/pkg/plugins/plugins.go
+++ b/pkg/plugins/plugins.go
@@ -20,6 +20,7 @@ import (
 	"github.com/grafana/grafana/pkg/plugins/backendplugin/secretsmanagerplugin"
 	"github.com/grafana/grafana/pkg/plugins/log"
 	"github.com/grafana/grafana/pkg/plugins/pfs"
+	"github.com/grafana/grafana/pkg/services/accesscontrol"
 	"github.com/grafana/grafana/pkg/services/org"
 	"github.com/grafana/grafana/pkg/util"
 )
@@ -204,8 +205,11 @@ type Route struct {
 	Body         json.RawMessage `json:"body"`
 }
 
-func (r *Route) RequiresRBACAction() bool {
-	return r.ReqAction != ""
+func (r *Route) Evaluator() accesscontrol.Evaluator {
+	if r.ReqAction == "" {
+		return nil
+	}
+	return accesscontrol.EvalPermission(r.ReqAction)
 }
 
 // Header describes an HTTP header that is forwarded with

--- a/pkg/plugins/plugins.go
+++ b/pkg/plugins/plugins.go
@@ -20,7 +20,6 @@ import (
 	"github.com/grafana/grafana/pkg/plugins/backendplugin/secretsmanagerplugin"
 	"github.com/grafana/grafana/pkg/plugins/log"
 	"github.com/grafana/grafana/pkg/plugins/pfs"
-	"github.com/grafana/grafana/pkg/services/accesscontrol"
 	"github.com/grafana/grafana/pkg/services/org"
 	"github.com/grafana/grafana/pkg/util"
 )
@@ -203,13 +202,6 @@ type Route struct {
 	TokenAuth    *JWTTokenAuth   `json:"tokenAuth"`
 	JwtTokenAuth *JWTTokenAuth   `json:"jwtTokenAuth"`
 	Body         json.RawMessage `json:"body"`
-}
-
-func (r *Route) Evaluator() accesscontrol.Evaluator {
-	if r.ReqAction == "" {
-		return nil
-	}
-	return accesscontrol.EvalPermission(r.ReqAction)
 }
 
 // Header describes an HTTP header that is forwarded with


### PR DESCRIPTION
**What is this feature?**

Previous to this change, only an OrgRole was allowed to be checked for authorization on the datasource proxy. There is an existing `ReqAction` field on a plugin route, and it was already being checked by the plugin proxy. This changes the authorization logic on the DS proxy to also check the RBAC action if specified on the plugin route and bypasses the org role check in this case.

**Why do we need this feature?**

This is based on plugin author request where a managed service account is unable to make a request to a given plugin route that requires an Org Role. The managed SA cannot have an Org Role, so there is no way currently to allow access without checking an RBAC action instead.

Ref: https://raintank-corp.slack.com/archives/C05JDQ100NS/p1713372912081219

**Who is this feature for?**

Plugin authors that want to allow access to managed service accounts based.