### PR TITLE
Prometheus: Do not throw error for label_join function 10.4.x

### DIFF
--- a/public/app/plugins/datasource/prometheus/querybuilder/operations.ts
+++ b/public/app/plugins/datasource/prometheus/querybuilder/operations.ts
@@ -363,7 +363,7 @@ function labelJoinRenderer(model: QueryBuilderOperation, def: QueryBuilderOperat
   }
 
   const paramZero = model.params[0] ?? '';
-  const paramOne = model.params[0] ?? '';
+  const paramOne = model.params[1] ?? '';
 
   const separator = `"${paramOne}"`;
   return `${model.id}(${innerExpr}, "${paramZero}", ${separator}, "${model.params.slice(2).join(separator)}")`;

--- a/public/app/plugins/datasource/prometheus/querybuilder/operations.ts
+++ b/public/app/plugins/datasource/prometheus/querybuilder/operations.ts
@@ -201,6 +201,7 @@ export function getOperationDefinitions(): QueryBuilderOperationDef[] {
       ],
       defaultParams: ['', ',', ''],
       renderer: labelJoinRenderer,
+      explainHandler: labelJoinExplainHandler,
       addOperationHandler: labelJoinAddOperationHandler,
     }),
     createFunction({ id: PromOperationId.Log10 }),
@@ -356,17 +357,21 @@ function addNestedQueryHandler(def: QueryBuilderOperationDef, query: PromVisualQ
 }
 
 function labelJoinRenderer(model: QueryBuilderOperation, def: QueryBuilderOperationDef, innerExpr: string) {
-  // only throw error if user begins typing the separator(param 1)
-  // prevents error when toggling explain mode
-  if (model.params[1] && typeof model.params[1] !== 'string') {
-    throw 'The separator must be a string';
-  }
-
   const paramZero = model.params[0] ?? '';
   const paramOne = model.params[1] ?? '';
 
   const separator = `"${paramOne}"`;
   return `${model.id}(${innerExpr}, "${paramZero}", ${separator}, "${model.params.slice(2).join(separator)}")`;
+}
+
+function labelJoinExplainHandler(op: QueryBuilderOperation, def?: QueryBuilderOperationDef) {
+  let explainMessage = def?.documentation ?? 'no docs';
+
+  if (typeof op.params[1] !== 'string') {
+    explainMessage += ' 🚨🚨🚨 The `separator` must be a string.';
+  }
+
+  return explainMessage;
 }
 
 function labelJoinAddOperationHandler<T extends QueryWithOperations>(def: QueryBuilderOperationDef, query: T) {

--- a/public/app/plugins/datasource/prometheus/querybuilder/operations.ts
+++ b/public/app/plugins/datasource/prometheus/querybuilder/operations.ts
@@ -356,11 +356,17 @@ function addNestedQueryHandler(def: QueryBuilderOperationDef, query: PromVisualQ
 }
 
 function labelJoinRenderer(model: QueryBuilderOperation, def: QueryBuilderOperationDef, innerExpr: string) {
-  if (typeof model.params[1] !== 'string') {
+  // only throw error if user begins typing the separator(param 1)
+  // prevents error when toggling explain mode
+  if (model.params[1] && typeof model.params[1] !== 'string') {
     throw 'The separator must be a string';
   }
-  const separator = `"${model.params[1]}"`;
-  return `${model.id}(${innerExpr}, "${model.params[0]}", ${separator}, "${model.params.slice(2).join(separator)}")`;
+
+  const paramZero = model.params[0] ?? '';
+  const paramOne = model.params[0] ?? '';
+
+  const separator = `"${paramOne}"`;
+  return `${model.id}(${innerExpr}, "${paramZero}", ${separator}, "${model.params.slice(2).join(separator)}")`;
 }
 
 function labelJoinAddOperationHandler<T extends QueryWithOperations>(def: QueryBuilderOperationDef, query: T) {


### PR DESCRIPTION
Fixes https://github.com/grafana/support-escalations/issues/10111

**What is this?**

This fixes error handling for the label_join() function in mixed data source with the Prometheus code editor when explain is toggled. 

**Why do we need this feature?**

We need this to fix error handling for the label_join function in v10.4.x where a user adds the `label_join` function using mixed data source with Prometheus in the code editor and toggles on explain.

<img width="1315" alt="Screenshot 2024-04-17 at 4 00 32 PM" src="https://github.com/grafana/grafana/assets/25674746/c3842b13-b383-41e6-8fbb-8edbd3e4509d">
 
This needs to be backported to v10.4.x but is a special case because we removed the core Prometheus frontend code and this change only targets the library. Therefore we are creating a branch off of v10.4.x and target that for the change.

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
