### PR TITLE
Alerting: Make silence authz service check rule group permissions

### DIFF
--- a/pkg/services/ngalert/accesscontrol/silences_test.go
+++ b/pkg/services/ngalert/accesscontrol/silences_test.go
@@ -7,10 +7,13 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"golang.org/x/exp/slices"
 
 	ac "github.com/grafana/grafana/pkg/services/accesscontrol"
 	"github.com/grafana/grafana/pkg/services/auth/identity"
 	"github.com/grafana/grafana/pkg/services/dashboards"
+	"github.com/grafana/grafana/pkg/services/datasources"
+	"github.com/grafana/grafana/pkg/services/ngalert/models"
 	"github.com/grafana/grafana/pkg/services/org"
 	"github.com/grafana/grafana/pkg/tsdb/cloudwatch/utils"
 )
@@ -18,18 +21,31 @@ import (
 var orgID = rand.Int63()
 
 func TestFilterByAccess(t *testing.T) {
+	datasource1 := "datasource-1"
+	datasource2 := "datasource-2"
+
+	folder1key1 := models.AlertRuleGroupKey{OrgID: orgID, NamespaceUID: "folder-1-uid", RuleGroup: "test"}
+	folder1key2 := folder1key1
+	folder1key2.RuleGroup = "datasource2-group"
+	folder2key1 := models.AlertRuleGroupKey{OrgID: orgID, NamespaceUID: "folder-2-uid", RuleGroup: "test"}
+
+	folder1Scope := dashboards.ScopeFoldersProvider.GetResourceScopeUID(folder1key1.NamespaceUID)
+
+	folder1rule1ds1 := models.AlertRuleGen(models.WithUID("folder1-rule-1-uid"), models.WithGroupKey(folder1key1), models.WithQuery(models.GenerateAlertQuery(models.WithDatasourceUID(datasource1))))()
+	folder2rule1ds1 := models.AlertRuleGen(models.WithUID("folder2-rule-1-uid"), models.WithGroupKey(folder2key1), models.WithQuery(models.GenerateAlertQuery(models.WithDatasourceUID(datasource1))))()
+	folder1rule2ds2 := models.AlertRuleGen(models.WithUID("folder1-rule-2-uid"), models.WithGroupKey(folder1key2), models.WithQuery(models.GenerateAlertQuery(models.WithDatasourceUID(datasource2))))()
+
 	global := testSilence{ID: "global", RuleUID: nil}
-	ruleSilence1 := testSilence{ID: "rule-1", RuleUID: utils.Pointer("rule-1-uid")}
-	folder1 := "rule-1-folder-uid"
-	folder1Scope := dashboards.ScopeFoldersProvider.GetResourceScopeUID(folder1)
-	ruleSilence2 := testSilence{ID: "rule-2", RuleUID: utils.Pointer("rule-2-uid")}
-	folder2 := "rule-2-folder-uid"
+	ruleSilence1 := testSilence{ID: "folder1-rule-1-silence", RuleUID: utils.Pointer(folder1rule1ds1.UID)}
+	ruleSilence2 := testSilence{ID: "folder2-rule-1-silence", RuleUID: utils.Pointer(folder2rule1ds1.UID)}
+	ruleSilence3 := testSilence{ID: "folder1-rule-2-silence", RuleUID: utils.Pointer(folder1rule2ds2.UID)}
 	notFoundRule := testSilence{ID: "unknown-rule", RuleUID: utils.Pointer("unknown-rule-uid")}
 
 	silences := []Silence{
 		global,
 		ruleSilence1,
 		ruleSilence2,
+		ruleSilence3,
 		notFoundRule,
 	}
 
@@ -46,36 +62,103 @@ func TestFilterByAccess(t *testing.T) {
 			expectedDbAccess: false,
 		},
 		{
+			name: "rule reader should not get anything",
+			user: newUser(
+				ac.Permission{Action: dashboards.ActionFoldersRead, Scope: folder1Scope},
+				ac.Permission{Action: ruleRead, Scope: folder1Scope},
+				ac.Permission{Action: datasources.ActionQuery, Scope: datasources.ScopeProvider.GetResourceScopeUID(datasource1)},
+			),
+			expected:         []Silence{},
+			expectedDbAccess: false,
+		},
+		{
 			name: "instance reader should get all",
 			user: newUser(ac.Permission{Action: instancesRead}),
 			expected: []Silence{
 				global,
 				ruleSilence1,
 				ruleSilence2,
+				ruleSilence3,
 				notFoundRule,
 			},
 			expectedDbAccess: false,
 		},
 		{
-			name: "silence reader should get global + folder",
-			user: newUser(ac.Permission{Action: silenceRead, Scope: folder1Scope}),
+			name: "silence reader with no rule permissions should get global only",
+			user: newUser(
+				ac.Permission{Action: silenceRead, Scope: dashboards.ScopeFoldersProvider.GetResourceAllScope()},
+			),
+			expected: []Silence{
+				global,
+			},
+			expectedDbAccess: true,
+		},
+		{
+			name: "silence reader + rule reader should get global + rules in folder it has access",
+			user: newUser(
+				ac.Permission{Action: dashboards.ActionFoldersRead, Scope: folder1Scope},
+				ac.Permission{Action: ruleRead, Scope: folder1Scope},
+				ac.Permission{Action: datasources.ActionQuery, Scope: datasources.ScopeProvider.GetResourceScopeUID(datasource1)},
+				ac.Permission{Action: silenceRead, Scope: folder1Scope},
+			),
 			expected: []Silence{
 				global,
 				ruleSilence1,
+				// ruleSilence2 is not available due to folder and rule permissions
+				// ruleSilence3 is not available due to datasource permissions
+			},
+			expectedDbAccess: true,
+		},
+		{
+			name: "silence reader in all folders but + rule reader in folder1 should get global + rules in folder1 it has access",
+			user: newUser(
+				ac.Permission{Action: dashboards.ActionFoldersRead, Scope: dashboards.ScopeFoldersProvider.GetResourceAllScope()},
+				ac.Permission{Action: ruleRead, Scope: folder1Scope},
+				ac.Permission{Action: datasources.ActionQuery, Scope: datasources.ScopeProvider.GetResourceScopeUID(datasource1)},
+				ac.Permission{Action: silenceRead, Scope: folder1Scope},
+			),
+			expected: []Silence{
+				global,
+				ruleSilence1,
+				// ruleSilence2 is not available due to rule permissions
+				// ruleSilence3 is not available due to datasource permissions
+			},
+			expectedDbAccess: true,
+		},
+		{
+			name: "silence reader in folder1 and rule reader in all folder should get global + rules in folder1 it has access",
+			user: newUser(
+				ac.Permission{Action: dashboards.ActionFoldersRead, Scope: folder1Scope},
+				ac.Permission{Action: ruleRead, Scope: dashboards.ScopeFoldersProvider.GetResourceAllScope()},
+				ac.Permission{Action: datasources.ActionQuery, Scope: datasources.ScopeProvider.GetResourceAllScope()},
+				ac.Permission{Action: silenceRead, Scope: dashboards.ScopeFoldersProvider.GetResourceAllScope()},
+			),
+			expected: []Silence{
+				global,
+				ruleSilence1,
+				ruleSilence3,
+				// ruleSilence3 is not available due to silence permissions
 			},
 			expectedDbAccess: true,
 		},
 	}
 	for _, testCase := range testCases {
 		t.Run(testCase.name, func(t *testing.T) {
-			ac := &recordingAccessControlFake{}
+			acMock := &recordingAccessControlFake{}
 			store := &fakeRuleUIDToNamespaceStore{
-				Response: map[string]string{
-					*ruleSilence1.RuleUID: folder1,
-					*ruleSilence2.RuleUID: folder2,
+				Rules: map[models.AlertRuleGroupKey]models.RulesGroup{
+					folder1key1: {
+						folder1rule1ds1,
+					},
+					folder2key1: {
+						folder2rule1ds1,
+					},
+					folder1key2: {
+						folder1rule2ds2,
+					},
 				},
 			}
-			svc := NewSilenceService(ac, store)
+			svc := NewSilenceService(acMock, store)
 
 			actual, err := svc.FilterByAccess(context.Background(), testCase.user, silences...)
 
@@ -87,18 +170,25 @@ func TestFilterByAccess(t *testing.T) {
 			} else {
 				require.Equal(t, store.Calls, 0)
 			}
-			require.NotEmpty(t, ac.EvaluateRecordings)
+			require.NotEmpty(t, acMock.EvaluateRecordings)
 		})
 	}
 }
 
 func TestAuthorizeReadSilence(t *testing.T) {
+	datasource1 := "datasource-1"
+
+	folder1key1 := models.AlertRuleGroupKey{OrgID: orgID, NamespaceUID: "folder-1-uid", RuleGroup: "test"}
+	folder2key1 := models.AlertRuleGroupKey{OrgID: orgID, NamespaceUID: "folder-2-uid", RuleGroup: "test"}
+
+	folder1Scope := dashboards.ScopeFoldersProvider.GetResourceScopeUID(folder1key1.NamespaceUID)
+
+	folder1rule1ds1 := models.AlertRuleGen(models.WithUID("folder1-rule-1-uid"), models.WithGroupKey(folder1key1), models.WithQuery(models.GenerateAlertQuery(models.WithDatasourceUID(datasource1))))()
+	folder2rule1ds1 := models.AlertRuleGen(models.WithUID("folder2-rule-1-uid"), models.WithGroupKey(folder2key1), models.WithQuery(models.GenerateAlertQuery(models.WithDatasourceUID(datasource1))))()
+
 	global := testSilence{ID: "global", RuleUID: nil}
-	ruleSilence1 := testSilence{ID: "rule-1", RuleUID: utils.Pointer("rule-1-uid")}
-	folder1 := "rule-1-folder-uid"
-	folder1Scope := dashboards.ScopeFoldersProvider.GetResourceScopeUID(folder1)
-	ruleSilence2 := testSilence{ID: "rule-2", RuleUID: utils.Pointer("rule-2-uid")}
-	folder2 := "rule-2-folder-uid"
+	ruleSilence1 := testSilence{ID: "rule-1-silence", RuleUID: utils.Pointer(folder1rule1ds1.UID)}
+	ruleSilence2 := testSilence{ID: "folder2-rule-1-silence", RuleUID: utils.Pointer(folder2rule1ds1.UID)}
 	notFoundRule := testSilence{ID: "unknown-rule", RuleUID: utils.Pointer("unknown-rule-uid")}
 
 	testCases := []struct {
@@ -111,14 +201,25 @@ func TestAuthorizeReadSilence(t *testing.T) {
 		{
 			name:             "not authorized without permissions",
 			user:             newUser(),
-			silence:          []testSilence{global, ruleSilence1, notFoundRule},
+			silence:          []testSilence{global, ruleSilence1, ruleSilence2, notFoundRule},
+			expectedErr:      ErrAuthorizationBase,
+			expectedDbAccess: false,
+		},
+		{
+			name: "rules reader without permissions",
+			user: newUser(
+				ac.Permission{Action: dashboards.ActionFoldersRead, Scope: folder1Scope},
+				ac.Permission{Action: ruleRead, Scope: folder1Scope},
+				ac.Permission{Action: datasources.ActionQuery, Scope: datasources.ScopeProvider.GetResourceScopeUID(datasource1)},
+			),
+			silence:          []testSilence{global, ruleSilence1, ruleSilence2, notFoundRule},
 			expectedErr:      ErrAuthorizationBase,
 			expectedDbAccess: false,
 		},
 		{
 			name:             "instance reader can read any silence",
 			user:             newUser(ac.Permission{Action: instancesRead}),
-			silence:          []testSilence{global, ruleSilence1, notFoundRule},
+			silence:          []testSilence{global, ruleSilence1, ruleSilence2, notFoundRule},
 			expectedErr:      nil,
 			expectedDbAccess: false,
 		},
@@ -130,23 +231,56 @@ func TestAuthorizeReadSilence(t *testing.T) {
 			expectedDbAccess: false,
 		},
 		{
-			name:             "silence reader can read from allowed folder",
-			user:             newUser(ac.Permission{Action: silenceRead, Scope: folder1Scope}),
+			name:             "silence reader without rule access cannot read rule silence",
+			user:             newUser(ac.Permission{Action: silenceRead, Scope: dashboards.ScopeFoldersProvider.GetResourceAllScope()}),
+			silence:          []testSilence{ruleSilence1, ruleSilence2, notFoundRule},
+			expectedErr:      ErrAuthorizationBase,
+			expectedDbAccess: true,
+		},
+		{
+			name: "silence + rule reader can read from allowed folder",
+			user: newUser(
+				ac.Permission{Action: dashboards.ActionFoldersRead, Scope: folder1Scope},
+				ac.Permission{Action: ruleRead, Scope: folder1Scope},
+				ac.Permission{Action: datasources.ActionQuery, Scope: datasources.ScopeProvider.GetResourceScopeUID(datasource1)},
+				ac.Permission{Action: silenceRead, Scope: folder1Scope},
+			),
 			silence:          []testSilence{ruleSilence1},
 			expectedErr:      nil,
 			expectedDbAccess: true,
 		},
 		{
-			name:             "silence reader cannot read from other folders",
-			user:             newUser(ac.Permission{Action: silenceRead, Scope: folder1Scope}),
-			silence:          []testSilence{ruleSilence2},
+			name: "silence + rule reader cannot read if no data source access",
+			user: newUser(
+				ac.Permission{Action: dashboards.ActionFoldersRead, Scope: folder1Scope},
+				ac.Permission{Action: ruleRead, Scope: folder1Scope},
+				ac.Permission{Action: silenceRead, Scope: folder1Scope},
+			),
+			silence:          []testSilence{ruleSilence1},
 			expectedErr:      ErrAuthorizationBase,
 			expectedDbAccess: true,
 		},
 		{
-			name:             "silence reader cannot read unknown rule",
-			user:             newUser(ac.Permission{Action: silenceRead, Scope: folder1Scope}),
+			name: "silence reader cannot read unknown rule",
+			user: newUser(
+				ac.Permission{Action: silenceRead, Scope: folder1Scope},
+				ac.Permission{Action: dashboards.ActionFoldersRead, Scope: folder1Scope},
+				ac.Permission{Action: ruleRead, Scope: folder1Scope},
+				ac.Permission{Action: datasources.ActionQuery, Scope: datasources.ScopeProvider.GetResourceScopeUID(datasource1)},
+			),
 			silence:          []testSilence{notFoundRule},
+			expectedErr:      ErrAuthorizationBase,
+			expectedDbAccess: true,
+		},
+		{
+			name: "silence reader cannot read from other folders",
+			user: newUser(
+				ac.Permission{Action: silenceRead, Scope: folder1Scope},
+				ac.Permission{Action: dashboards.ActionFoldersRead, Scope: folder1Scope},
+				ac.Permission{Action: ruleRead, Scope: folder1Scope},
+				ac.Permission{Action: datasources.ActionQuery, Scope: datasources.ScopeProvider.GetResourceScopeUID(datasource1)},
+			),
+			silence:          []testSilence{ruleSilence2},
 			expectedErr:      ErrAuthorizationBase,
 			expectedDbAccess: true,
 		},
@@ -156,14 +290,18 @@ func TestAuthorizeReadSilence(t *testing.T) {
 		t.Run(testCase.name, func(t *testing.T) {
 			for _, silence := range testCase.silence {
 				t.Run(silence.ID, func(t *testing.T) {
-					ac := &recordingAccessControlFake{}
+					acMock := &recordingAccessControlFake{}
 					store := &fakeRuleUIDToNamespaceStore{
-						Response: map[string]string{
-							*ruleSilence1.RuleUID: folder1,
-							*ruleSilence2.RuleUID: folder2,
+						Rules: map[models.AlertRuleGroupKey]models.RulesGroup{
+							folder1key1: {
+								folder1rule1ds1,
+							},
+							folder2key1: {
+								folder2rule1ds1,
+							},
 						},
 					}
-					svc := NewSilenceService(ac, store)
+					svc := NewSilenceService(acMock, store)
 
 					err := svc.AuthorizeReadSilence(context.Background(), testCase.user, silence)
 					if testCase.expectedErr != nil {
@@ -183,13 +321,20 @@ func TestAuthorizeReadSilence(t *testing.T) {
 }
 
 func TestAuthorizeCreateSilence(t *testing.T) {
+	datasource1 := "datasource-1"
+
+	folder1key1 := models.AlertRuleGroupKey{OrgID: orgID, NamespaceUID: "folder-1-uid", RuleGroup: "test"}
+	folder2key1 := models.AlertRuleGroupKey{OrgID: orgID, NamespaceUID: "folder-2-uid", RuleGroup: "test"}
+
+	folder1Scope := dashboards.ScopeFoldersProvider.GetResourceScopeUID(folder1key1.NamespaceUID)
+	folder2Scope := dashboards.ScopeFoldersProvider.GetResourceScopeUID(folder2key1.NamespaceUID)
+
+	folder1rule1ds1 := models.AlertRuleGen(models.WithUID("folder1-rule-1-uid"), models.WithGroupKey(folder1key1), models.WithQuery(models.GenerateAlertQuery(models.WithDatasourceUID(datasource1))))()
+	folder2rule1ds1 := models.AlertRuleGen(models.WithUID("folder2-rule-1-uid"), models.WithGroupKey(folder2key1), models.WithQuery(models.GenerateAlertQuery(models.WithDatasourceUID(datasource1))))()
+
 	global := testSilence{ID: "global", RuleUID: nil}
-	ruleSilence1 := testSilence{ID: "rule-1", RuleUID: utils.Pointer("rule-1-uid")}
-	folder1 := "rule-1-folder-uid"
-	folder1Scope := dashboards.ScopeFoldersProvider.GetResourceScopeUID(folder1)
-	ruleSilence2 := testSilence{ID: "rule-2", RuleUID: utils.Pointer("rule-2-uid")}
-	folder2 := "rule-2-folder-uid"
-	folder2Scope := dashboards.ScopeFoldersProvider.GetResourceScopeUID(folder2)
+	ruleSilence1 := testSilence{ID: "rule-1-silence", RuleUID: utils.Pointer(folder1rule1ds1.UID)}
+	ruleSilence2 := testSilence{ID: "folder2-rule-1-silence", RuleUID: utils.Pointer(folder2rule1ds1.UID)}
 	notFoundRule := testSilence{ID: "unknown-rule", RuleUID: utils.Pointer("unknown-rule-uid")}
 
 	silences := []testSilence{
@@ -199,124 +344,137 @@ func TestAuthorizeCreateSilence(t *testing.T) {
 		notFoundRule,
 	}
 
-	type override struct {
+	type expectation struct {
 		expectedErr      error
 		expectedDbAccess bool
 	}
+	noAccessNoDb := expectation{expectedDbAccess: false, expectedErr: ErrAuthorizationBase}
+	dbNoAccess := expectation{expectedDbAccess: true, expectedErr: ErrAuthorizationBase}
+	okNoDb := expectation{expectedErr: nil, expectedDbAccess: false}
+	okDb := expectation{expectedErr: nil, expectedDbAccess: true}
+	noAccessNoDbAll := map[testSilence]expectation{
+		global:       noAccessNoDb,
+		ruleSilence1: noAccessNoDb,
+		ruleSilence2: noAccessNoDb,
+		notFoundRule: noAccessNoDb,
+	}
 	testCases := []struct {
-		name             string
-		user             identity.Requester
-		expectedErr      error
-		expectedDbAccess bool
-		overrides        map[testSilence]override
+		name     string
+		user     identity.Requester
+		expected map[testSilence]expectation
 	}{
 		{
-			name:        "not authorized without permissions",
-			user:        newUser(),
-			expectedErr: ErrAuthorizationBase,
+			name:     "not authorized without permissions",
+			user:     newUser(),
+			expected: noAccessNoDbAll,
 		},
 		{
-			name:        "no create access, instance reader",
-			user:        newUser(ac.Permission{Action: instancesRead}),
-			expectedErr: ErrAuthorizationBase,
+			name:     "no create access, instance reader",
+			user:     newUser(ac.Permission{Action: instancesRead}),
+			expected: noAccessNoDbAll,
 		},
 		{
-			name:        "no create access, silence reader",
-			user:        newUser(ac.Permission{Action: silenceRead, Scope: folder1Scope}, ac.Permission{Action: silenceRead, Scope: folder2Scope}),
-			expectedErr: ErrAuthorizationBase,
+			name: "no create access, silence reader",
+			user: newUser(
+				ac.Permission{Action: silenceRead, Scope: dashboards.ScopeFoldersProvider.GetResourceAllScope()},
+				ac.Permission{Action: dashboards.ActionFoldersRead, Scope: dashboards.ScopeFoldersProvider.GetResourceAllScope()},
+				ac.Permission{Action: ruleRead, Scope: dashboards.ScopeFoldersProvider.GetResourceAllScope()},
+				ac.Permission{Action: datasources.ActionQuery, Scope: datasources.ScopeProvider.GetResourceAllScope()},
+			),
+			expected: noAccessNoDbAll,
 		},
 		{
-			name:        "only create access, instance create",
-			user:        newUser(ac.Permission{Action: instancesCreate}),
-			expectedErr: ErrAuthorizationBase,
+			name:     "only create access, instance create",
+			user:     newUser(ac.Permission{Action: instancesCreate}),
+			expected: noAccessNoDbAll,
 		},
 		{
-			name:        "only create access, silence create",
-			user:        newUser(ac.Permission{Action: silenceCreate, Scope: folder1Scope}, ac.Permission{Action: silenceCreate, Scope: folder2Scope}),
-			expectedErr: ErrAuthorizationBase,
+			name:     "only create access, silence create",
+			user:     newUser(ac.Permission{Action: silenceCreate, Scope: folder1Scope}, ac.Permission{Action: silenceCreate, Scope: folder2Scope}),
+			expected: noAccessNoDbAll,
 		},
 		{
-			name:        "instance read + create can do everything",
-			user:        newUser(ac.Permission{Action: instancesCreate}, ac.Permission{Action: instancesRead}),
-			expectedErr: nil,
+			name: "instance read + create can do everything",
+			user: newUser(ac.Permission{Action: instancesCreate}, ac.Permission{Action: instancesRead}),
+			expected: map[testSilence]expectation{
+				global:       okNoDb,
+				ruleSilence1: okNoDb,
+				ruleSilence2: okNoDb,
+				notFoundRule: okNoDb,
+			},
 		},
 		{
-			name: "instance read + silence create",
+			name: "instance read + silence create but no rule access",
 			user: newUser(ac.Permission{Action: silenceCreate, Scope: folder1Scope}, ac.Permission{Action: instancesRead}),
-			overrides: map[testSilence]override{
-				global: {
-					expectedErr:      ErrAuthorizationBase,
-					expectedDbAccess: false,
-				},
-				ruleSilence1: {
-					expectedErr:      nil,
-					expectedDbAccess: true,
-				},
+			expected: map[testSilence]expectation{
+				global:       noAccessNoDb,
+				ruleSilence1: dbNoAccess,
+				ruleSilence2: dbNoAccess,
+				notFoundRule: dbNoAccess,
 			},
-			expectedErr:      ErrAuthorizationBase,
-			expectedDbAccess: true,
 		},
 		{
-			name: "silence read + instance create",
-			user: newUser(ac.Permission{Action: silenceRead, Scope: folder1Scope}, ac.Permission{Action: instancesCreate}),
-			overrides: map[testSilence]override{
-				global: {
-					expectedErr:      nil,
-					expectedDbAccess: false,
-				},
-				ruleSilence1: {
-					expectedErr:      nil,
-					expectedDbAccess: true,
-				},
+			name: "rule read, silence read + instance create",
+			user: newUser(
+				ac.Permission{Action: silenceRead, Scope: folder1Scope},
+				ac.Permission{Action: dashboards.ActionFoldersRead, Scope: folder1Scope},
+				ac.Permission{Action: ruleRead, Scope: folder1Scope},
+				ac.Permission{Action: datasources.ActionQuery, Scope: datasources.ScopeProvider.GetResourceScopeUID(datasource1)},
+				ac.Permission{Action: instancesCreate}),
+			expected: map[testSilence]expectation{
+				global:       okNoDb,
+				ruleSilence1: okDb,
+				ruleSilence2: dbNoAccess,
+				notFoundRule: dbNoAccess,
 			},
-			expectedErr:      ErrAuthorizationBase,
-			expectedDbAccess: true,
 		},
 		{
-			name: "silence read + create",
-			user: newUser(ac.Permission{Action: silenceRead, Scope: folder1Scope}, ac.Permission{Action: silenceCreate, Scope: folder1Scope}),
-			overrides: map[testSilence]override{
-				global: {
-					expectedErr:      ErrAuthorizationBase,
-					expectedDbAccess: false,
-				},
-				ruleSilence1: {
-					expectedErr:      nil,
-					expectedDbAccess: true,
-				},
+			name: "rule read, silence read + create",
+			user: newUser(
+				ac.Permission{Action: silenceRead, Scope: folder1Scope},
+				ac.Permission{Action: silenceCreate, Scope: folder1Scope},
+				ac.Permission{Action: dashboards.ActionFoldersRead, Scope: dashboards.ScopeFoldersProvider.GetResourceAllScope()},
+				ac.Permission{Action: ruleRead, Scope: dashboards.ScopeFoldersProvider.GetResourceAllScope()},
+				ac.Permission{Action: datasources.ActionQuery, Scope: datasources.ScopeProvider.GetResourceAllScope()},
+			),
+			expected: map[testSilence]expectation{
+				global:       noAccessNoDb,
+				ruleSilence1: okDb,
+				ruleSilence2: dbNoAccess,
+				notFoundRule: dbNoAccess,
 			},
-			expectedErr:      ErrAuthorizationBase,
-			expectedDbAccess: true,
 		},
 	}
 
 	for _, testCase := range testCases {
 		t.Run(testCase.name, func(t *testing.T) {
 			for _, silence := range silences {
-				expectedErr := testCase.expectedErr
-				expectedDbAccess := testCase.expectedDbAccess
-				if s, ok := testCase.overrides[silence]; ok {
-					expectedErr = s.expectedErr
-					expectedDbAccess = s.expectedDbAccess
+				var expected expectation
+				if s, ok := testCase.expected[silence]; ok {
+					expected = s
 				}
 				t.Run(silence.ID, func(t *testing.T) {
 					ac := &recordingAccessControlFake{}
 					store := &fakeRuleUIDToNamespaceStore{
-						Response: map[string]string{
-							*ruleSilence1.RuleUID: folder1,
-							*ruleSilence2.RuleUID: folder2,
+						Rules: map[models.AlertRuleGroupKey]models.RulesGroup{
+							folder1key1: {
+								folder1rule1ds1,
+							},
+							folder2key1: {
+								folder2rule1ds1,
+							},
 						},
 					}
 					svc := NewSilenceService(ac, store)
 
 					err := svc.AuthorizeCreateSilence(context.Background(), testCase.user, silence)
-					if expectedErr != nil {
+					if expected.expectedErr != nil {
 						assert.Error(t, err)
-						assert.ErrorIs(t, err, expectedErr)
+						assert.ErrorIs(t, err, expected.expectedErr)
 					} else {
 						assert.NoError(t, err)
 					}
-					if expectedDbAccess {
+					if expected.expectedDbAccess {
 						require.Equal(t, 1, store.Calls)
 					} else {
 						require.Equal(t, 0, store.Calls)
@@ -328,13 +486,20 @@ func TestAuthorizeCreateSilence(t *testing.T) {
 }
 
 func TestAuthorizeUpdateSilence(t *testing.T) {
+	datasource1 := "datasource-1"
+
+	folder1key1 := models.AlertRuleGroupKey{OrgID: orgID, NamespaceUID: "folder-1-uid", RuleGroup: "test"}
+	folder2key1 := models.AlertRuleGroupKey{OrgID: orgID, NamespaceUID: "folder-2-uid", RuleGroup: "test"}
+
+	folder1Scope := dashboards.ScopeFoldersProvider.GetResourceScopeUID(folder1key1.NamespaceUID)
+	folder2Scope := dashboards.ScopeFoldersProvider.GetResourceScopeUID(folder2key1.NamespaceUID)
+
+	folder1rule1ds1 := models.AlertRuleGen(models.WithUID("folder1-rule-1-uid"), models.WithGroupKey(folder1key1), models.WithQuery(models.GenerateAlertQuery(models.WithDatasourceUID(datasource1))))()
+	folder2rule1ds1 := models.AlertRuleGen(models.WithUID("folder2-rule-1-uid"), models.WithGroupKey(folder2key1), models.WithQuery(models.GenerateAlertQuery(models.WithDatasourceUID(datasource1))))()
+
 	global := testSilence{ID: "global", RuleUID: nil}
-	ruleSilence1 := testSilence{ID: "rule-1", RuleUID: utils.Pointer("rule-1-uid")}
-	folder1 := "rule-1-folder-uid"
-	folder1Scope := dashboards.ScopeFoldersProvider.GetResourceScopeUID(folder1)
-	ruleSilence2 := testSilence{ID: "rule-2", RuleUID: utils.Pointer("rule-2-uid")}
-	folder2 := "rule-2-folder-uid"
-	folder2Scope := dashboards.ScopeFoldersProvider.GetResourceScopeUID(folder2)
+	ruleSilence1 := testSilence{ID: "rule-1-silence", RuleUID: utils.Pointer(folder1rule1ds1.UID)}
+	ruleSilence2 := testSilence{ID: "folder2-rule-1-silence", RuleUID: utils.Pointer(folder2rule1ds1.UID)}
 	notFoundRule := testSilence{ID: "unknown-rule", RuleUID: utils.Pointer("unknown-rule-uid")}
 
 	silences := []testSilence{
@@ -344,124 +509,137 @@ func TestAuthorizeUpdateSilence(t *testing.T) {
 		notFoundRule,
 	}
 
-	type override struct {
+	type expectation struct {
 		expectedErr      error
 		expectedDbAccess bool
 	}
+	noAccessNoDb := expectation{expectedDbAccess: false, expectedErr: ErrAuthorizationBase}
+	dbNoAccess := expectation{expectedDbAccess: true, expectedErr: ErrAuthorizationBase}
+	okNoDb := expectation{expectedErr: nil, expectedDbAccess: false}
+	okDb := expectation{expectedErr: nil, expectedDbAccess: true}
+	noAccessNoDbAll := map[testSilence]expectation{
+		global:       noAccessNoDb,
+		ruleSilence1: noAccessNoDb,
+		ruleSilence2: noAccessNoDb,
+		notFoundRule: noAccessNoDb,
+	}
 	testCases := []struct {
-		name             string
-		user             identity.Requester
-		expectedErr      error
-		expectedDbAccess bool
-		overrides        map[testSilence]override
+		name     string
+		user     identity.Requester
+		expected map[testSilence]expectation
 	}{
 		{
-			name:        "not authorized without permissions",
-			user:        newUser(),
-			expectedErr: ErrAuthorizationBase,
+			name:     "not authorized without permissions",
+			user:     newUser(),
+			expected: noAccessNoDbAll,
 		},
 		{
-			name:        "no write access, instance reader",
-			user:        newUser(ac.Permission{Action: instancesRead}),
-			expectedErr: ErrAuthorizationBase,
+			name:     "no write access, instance reader",
+			user:     newUser(ac.Permission{Action: instancesRead}),
+			expected: noAccessNoDbAll,
 		},
 		{
-			name:        "no write access, silence reader",
-			user:        newUser(ac.Permission{Action: silenceRead, Scope: folder1Scope}, ac.Permission{Action: silenceRead, Scope: folder2Scope}),
-			expectedErr: ErrAuthorizationBase,
+			name: "no write access, silence reader",
+			user: newUser(
+				ac.Permission{Action: silenceRead, Scope: dashboards.ScopeFoldersProvider.GetResourceAllScope()},
+				ac.Permission{Action: dashboards.ActionFoldersRead, Scope: dashboards.ScopeFoldersProvider.GetResourceAllScope()},
+				ac.Permission{Action: ruleRead, Scope: dashboards.ScopeFoldersProvider.GetResourceAllScope()},
+				ac.Permission{Action: datasources.ActionQuery, Scope: datasources.ScopeProvider.GetResourceAllScope()},
+			),
+			expected: noAccessNoDbAll,
 		},
 		{
-			name:        "only write access, instance write",
-			user:        newUser(ac.Permission{Action: instancesWrite}),
-			expectedErr: ErrAuthorizationBase,
+			name:     "only write access, instance write",
+			user:     newUser(ac.Permission{Action: instancesWrite}),
+			expected: noAccessNoDbAll,
 		},
 		{
-			name:        "only write access, silence write",
-			user:        newUser(ac.Permission{Action: silenceWrite, Scope: folder1Scope}, ac.Permission{Action: silenceWrite, Scope: folder2Scope}),
-			expectedErr: ErrAuthorizationBase,
+			name:     "only write access, silence write",
+			user:     newUser(ac.Permission{Action: silenceWrite, Scope: folder1Scope}, ac.Permission{Action: silenceWrite, Scope: folder2Scope}),
+			expected: noAccessNoDbAll,
 		},
 		{
-			name:        "instance read + write can do everything",
-			user:        newUser(ac.Permission{Action: instancesWrite}, ac.Permission{Action: instancesRead}),
-			expectedErr: nil,
+			name: "instance read + write can do everything",
+			user: newUser(ac.Permission{Action: instancesWrite}, ac.Permission{Action: instancesRead}),
+			expected: map[testSilence]expectation{
+				global:       okNoDb,
+				ruleSilence1: okNoDb,
+				ruleSilence2: okNoDb,
+				notFoundRule: okNoDb,
+			},
 		},
 		{
-			name: "instance read + silence write",
+			name: "instance read + silence write but no rule access",
 			user: newUser(ac.Permission{Action: silenceWrite, Scope: folder1Scope}, ac.Permission{Action: instancesRead}),
-			overrides: map[testSilence]override{
-				global: {
-					expectedErr:      ErrAuthorizationBase,
-					expectedDbAccess: false,
-				},
-				ruleSilence1: {
-					expectedErr:      nil,
-					expectedDbAccess: true,
-				},
+			expected: map[testSilence]expectation{
+				global:       noAccessNoDb,
+				ruleSilence1: dbNoAccess,
+				ruleSilence2: dbNoAccess,
+				notFoundRule: dbNoAccess,
 			},
-			expectedErr:      ErrAuthorizationBase,
-			expectedDbAccess: true,
 		},
 		{
-			name: "silence read + instance write",
-			user: newUser(ac.Permission{Action: silenceRead, Scope: folder1Scope}, ac.Permission{Action: instancesWrite}),
-			overrides: map[testSilence]override{
-				global: {
-					expectedErr:      nil,
-					expectedDbAccess: false,
-				},
-				ruleSilence1: {
-					expectedErr:      nil,
-					expectedDbAccess: true,
-				},
+			name: "rule read, silence read + instance write",
+			user: newUser(
+				ac.Permission{Action: silenceRead, Scope: folder1Scope},
+				ac.Permission{Action: dashboards.ActionFoldersRead, Scope: folder1Scope},
+				ac.Permission{Action: ruleRead, Scope: folder1Scope},
+				ac.Permission{Action: datasources.ActionQuery, Scope: datasources.ScopeProvider.GetResourceScopeUID(datasource1)},
+				ac.Permission{Action: instancesWrite}),
+			expected: map[testSilence]expectation{
+				global:       okNoDb,
+				ruleSilence1: okDb,
+				ruleSilence2: dbNoAccess,
+				notFoundRule: dbNoAccess,
 			},
-			expectedErr:      ErrAuthorizationBase,
-			expectedDbAccess: true,
 		},
 		{
-			name: "silence read + write",
-			user: newUser(ac.Permission{Action: silenceRead, Scope: folder1Scope}, ac.Permission{Action: silenceWrite, Scope: folder1Scope}),
-			overrides: map[testSilence]override{
-				global: {
-					expectedErr:      ErrAuthorizationBase,
-					expectedDbAccess: false,
-				},
-				ruleSilence1: {
-					expectedErr:      nil,
-					expectedDbAccess: true,
-				},
+			name: "rule read, silence read + write",
+			user: newUser(
+				ac.Permission{Action: silenceRead, Scope: folder1Scope},
+				ac.Permission{Action: silenceWrite, Scope: folder1Scope},
+				ac.Permission{Action: dashboards.ActionFoldersRead, Scope: dashboards.ScopeFoldersProvider.GetResourceAllScope()},
+				ac.Permission{Action: ruleRead, Scope: dashboards.ScopeFoldersProvider.GetResourceAllScope()},
+				ac.Permission{Action: datasources.ActionQuery, Scope: datasources.ScopeProvider.GetResourceAllScope()},
+			),
+			expected: map[testSilence]expectation{
+				global:       noAccessNoDb,
+				ruleSilence1: okDb,
+				ruleSilence2: dbNoAccess,
+				notFoundRule: dbNoAccess,
 			},
-			expectedErr:      ErrAuthorizationBase,
-			expectedDbAccess: true,
 		},
 	}
 
 	for _, testCase := range testCases {
 		t.Run(testCase.name, func(t *testing.T) {
 			for _, silence := range silences {
-				expectedErr := testCase.expectedErr
-				expectedDbAccess := testCase.expectedDbAccess
-				if s, ok := testCase.overrides[silence]; ok {
-					expectedErr = s.expectedErr
-					expectedDbAccess = s.expectedDbAccess
+				var expected expectation
+				if s, ok := testCase.expected[silence]; ok {
+					expected = s
 				}
 				t.Run(silence.ID, func(t *testing.T) {
-					ac := &recordingAccessControlFake{}
+					acMock := &recordingAccessControlFake{}
 					store := &fakeRuleUIDToNamespaceStore{
-						Response: map[string]string{
-							*ruleSilence1.RuleUID: folder1,
-							*ruleSilence2.RuleUID: folder2,
+						Rules: map[models.AlertRuleGroupKey]models.RulesGroup{
+							folder1key1: {
+								folder1rule1ds1,
+							},
+							folder2key1: {
+								folder2rule1ds1,
+							},
 						},
 					}
-					svc := NewSilenceService(ac, store)
+					svc := NewSilenceService(acMock, store)
 
 					err := svc.AuthorizeUpdateSilence(context.Background(), testCase.user, silence)
-					if expectedErr != nil {
+					if expected.expectedErr != nil {
 						assert.Error(t, err)
-						assert.ErrorIs(t, err, expectedErr)
+						assert.ErrorIs(t, err, expected.expectedErr)
 					} else {
 						assert.NoError(t, err)
 					}
-					if expectedDbAccess {
+					if expected.expectedDbAccess {
 						require.Equal(t, 1, store.Calls)
 					} else {
 						require.Equal(t, 0, store.Calls)
@@ -482,13 +660,24 @@ func (t testSilence) GetRuleUID() *string {
 }
 
 type fakeRuleUIDToNamespaceStore struct {
-	Response map[string]string
-	Calls    int
+	Rules map[models.AlertRuleGroupKey]models.RulesGroup
+	Calls int
 }
 
-func (f *fakeRuleUIDToNamespaceStore) GetNamespacesByRuleUID(ctx context.Context, orgID int64, uids ...string) (map[string]string, error) {
+func (f *fakeRuleUIDToNamespaceStore) GetRuleGroupsByRuleUIDs(ctx context.Context, orgID int64, uids ...string) (map[models.AlertRuleGroupKey]models.RulesGroup, error) {
+	response := map[models.AlertRuleGroupKey]models.RulesGroup{}
+	for key, group := range f.Rules {
+		for _, uid := range uids {
+			if slices.ContainsFunc(group, func(rule *models.AlertRule) bool {
+				return rule.UID == uid
+			}) {
+				response[key] = group
+				break
+			}
+		}
+	}
 	f.Calls++
-	return f.Response, nil
+	return response, nil
 }
 
 func newUser(permissions ...ac.Permission) identity.Requester {

--- a/pkg/services/ngalert/models/testing.go
+++ b/pkg/services/ngalert/models/testing.go
@@ -106,6 +106,12 @@ func WithNotEmptyLabels(count int, prefix string) AlertRuleMutator {
 	}
 }
 
+func WithID(id int64) AlertRuleMutator {
+	return func(rule *AlertRule) {
+		rule.ID = id
+	}
+}
+
 func WithUniqueID() AlertRuleMutator {
 	usedID := make(map[int64]struct{})
 	return func(rule *AlertRule) {

--- a/pkg/services/ngalert/models/testing.go
+++ b/pkg/services/ngalert/models/testing.go
@@ -259,6 +259,12 @@ func WithLabel(key, value string) AlertRuleMutator {
 	}
 }
 
+func WithUID(uid string) AlertRuleMutator {
+	return func(rule *AlertRule) {
+		rule.UID = uid
+	}
+}
+
 func WithUniqueUID(knownUids *sync.Map) AlertRuleMutator {
 	return func(rule *AlertRule) {
 		uid := rule.UID
@@ -324,11 +330,11 @@ func GenerateAlertLabels(count int, prefix string) data.Labels {
 	return labels
 }
 
-func GenerateAlertQuery() AlertQuery {
+func GenerateAlertQuery(mutators ...func(rule *AlertQuery)) AlertQuery {
 	f := rand.Intn(10) + 5
 	t := rand.Intn(f)
 
-	return AlertQuery{
+	q := AlertQuery{
 		DatasourceUID: util.GenerateShortUID(),
 		Model: json.RawMessage(fmt.Sprintf(`{
 			"%s": "%s",
@@ -340,6 +346,16 @@ func GenerateAlertQuery() AlertQuery {
 		},
 		RefID:     util.GenerateShortUID(),
 		QueryType: util.GenerateShortUID(),
+	}
+	for _, mutator := range mutators {
+		mutator(&q)
+	}
+	return q
+}
+
+func WithDatasourceUID(uid string) func(query *AlertQuery) {
+	return func(query *AlertQuery) {
+		query.DatasourceUID = uid
 	}
 }
 


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**
This PR updates silence authorization service to tighten up the security and check if user can read rules for which it tries to read or write a silence.
To check that permission, the service has to fetch all rules in the group and check the user's permissions.

**Why do we need this feature?**
Silences are protected by folder UID scope only. Rules are protected by intersection of folder UID and Data source UID. Therefore, in GE there is a possibility that a user can see and manage silences for rules that it cannot see due to lack of data source permissions. 

**Who is this feature for?**
Grafana Enterprise users

**Special notes for your reviewer:**
The pattern I chose is similar to what we do elsewhere (e.g. folders): I gather the list of rule UIDs and then resolve them to rule groups. Performance-wise it's ok because we have an index that meets the filter requirement. However, the weak spot here is that with a big number of rule-specific silences, this could exceed limits on SQL queries.

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
