### PR TITLE
Explore: add links to metrics and correlations editor to Explore

### DIFF
--- a/docs/sources/explore/_index.md
+++ b/docs/sources/explore/_index.md
@@ -25,6 +25,8 @@ If you just want to explore your data and do not want to create a dashboard, the
 - [Query management in Explore]({{< relref "query-management/" >}})
 - [Logs integration in Explore]({{< relref "logs-integration/" >}})
 - [Trace integration in Explore]({{< relref "trace-integration/" >}})
+- [Explore metrics]({{< relref "explore-metrics/" >}})
+- [Correlations Editor in Explore]({{< relref "correlations-editor-in-explore/" >}})
 - [Inspector in Explore]({{< relref "explore-inspector/" >}})
 
 ## Start exploring


### PR DESCRIPTION
**What is this feature?**

Add missing links to [Explore metrics](https://grafana.com/docs/grafana/latest/explore/explore-metrics/) and [correlations editor](https://grafana.com/docs/grafana/latest/explore/correlations-editor-in-explore/), missing from https://grafana.com/docs/grafana/latest/explore/

**Why do we need this feature?**

The left menu already has the links, I would add them to the main page as well.

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
