### PR TITLE
Loki: Remove tracking `grafana_loki_query_executed` and add `grafana_explore_loki_query_executed`

### DIFF
--- a/public/app/plugins/datasource/loki/datasource.test.ts
+++ b/public/app/plugins/datasource/loki/datasource.test.ts
@@ -205,7 +205,7 @@ describe('LokiDatasource', () => {
     it('should report query interaction', async () => {
       await runTest(80, '40', 80, CoreApp.Explore);
       expect(reportInteraction).toHaveBeenCalledWith(
-        'grafana_loki_query_executed',
+        'grafana_explore_loki_query_executed',
         expect.objectContaining({
           query_type: 'logs',
           line_limit: 80,
@@ -219,16 +219,9 @@ describe('LokiDatasource', () => {
       expect(reportInteraction).not.toBeCalled();
     });
 
-    it('should not report query interaction for panel edit query', async () => {
-      await runTest(80, '40', 80, CoreApp.PanelEditor);
-      expect(reportInteraction).toHaveBeenCalledWith(
-        'grafana_loki_query_executed',
-        expect.objectContaining({
-          query_type: 'logs',
-          line_limit: 80,
-          obfuscated_query: '{Identifier=String}',
-        })
-      );
+    it('should not report query interaction for unknown app query', async () => {
+      await runTest(80, '40', 80, CoreApp.Unknown);
+      expect(reportInteraction).not.toBeCalled();
     });
   });
 

--- a/public/app/plugins/datasource/loki/tracking.ts
+++ b/public/app/plugins/datasource/loki/tracking.ts
@@ -7,6 +7,7 @@ import {
   REF_ID_DATA_SAMPLES,
   REF_ID_STARTER_LOG_ROW_CONTEXT,
   REF_ID_STARTER_LOG_VOLUME,
+  REF_ID_STARTER_LOG_SAMPLE,
 } from './datasource';
 import pluginJson from './plugin.json';
 import { getNormalizedLokiQuery, isLogsQuery, obfuscate } from './queryUtils';
@@ -127,7 +128,12 @@ const isQueryWithChangedLegend = (query: LokiQuery): boolean => {
 };
 
 const shouldNotReportBasedOnRefId = (refId: string): boolean => {
-  const starters = [REF_ID_STARTER_ANNOTATION, REF_ID_STARTER_LOG_ROW_CONTEXT, REF_ID_STARTER_LOG_VOLUME];
+  const starters = [
+    REF_ID_STARTER_ANNOTATION,
+    REF_ID_STARTER_LOG_ROW_CONTEXT,
+    REF_ID_STARTER_LOG_VOLUME,
+    REF_ID_STARTER_LOG_SAMPLE,
+  ];
 
   if (refId === REF_ID_DATA_SAMPLES || starters.some((starter) => refId.startsWith(starter))) {
     return true;
@@ -157,7 +163,7 @@ export function trackQuery(
   // We only want to track usage for these specific apps
   const { app, targets: queries } = request;
 
-  if (app === CoreApp.Dashboard || app === CoreApp.PanelViewer) {
+  if (app !== CoreApp.Explore) {
     return;
   }
 
@@ -168,8 +174,7 @@ export function trackQuery(
       return;
     }
 
-    reportInteraction('grafana_loki_query_executed', {
-      app,
+    reportInteraction('grafana_explore_loki_query_executed', {
       grafana_version: config.buildInfo.version,
       editor_mode: query.editorMode,
       has_data: response.data.some((frame) => frame.length > 0),

--- a/public/app/plugins/datasource/loki/tracking.ts
+++ b/public/app/plugins/datasource/loki/tracking.ts
@@ -133,6 +133,7 @@ const shouldNotReportBasedOnRefId = (refId: string): boolean => {
     REF_ID_STARTER_LOG_ROW_CONTEXT,
     REF_ID_STARTER_LOG_VOLUME,
     REF_ID_STARTER_LOG_SAMPLE,
+    REF_ID_DATA_SAMPLES,
   ];
 
   if (starters.some((starter) => refId.startsWith(starter))) {

--- a/public/app/plugins/datasource/loki/tracking.ts
+++ b/public/app/plugins/datasource/loki/tracking.ts
@@ -135,7 +135,7 @@ const shouldNotReportBasedOnRefId = (refId: string): boolean => {
     REF_ID_STARTER_LOG_SAMPLE,
   ];
 
-  if (refId === REF_ID_DATA_SAMPLES || starters.some((starter) => refId.startsWith(starter))) {
+  if (starters.some((starter) => refId.startsWith(starter))) {
     return true;
   }
   return false;


### PR DESCRIPTION
This PR is part of https://github.com/grafana/product_analytics/issues/266 and we are removing tracking for all apps besides `dashboard` and `panel-viewer` and replacing it with tracking for only `explore`. Based on discussion with @shih-chris we want to rename this event to make it more transparent for everyone - that this is not tracking all queries but just explore. 

It also helps in a case someone we don't expect has a dashboard with this event - to make it clear that `grafana_loki_query_executed` event is not used anymore and reach out to us. 

The next step would be updating our dashboards when released. 

More context in  https://raintank-corp.slack.com/archives/C03PMJLVC67/p1708527127220859