### PR TITLE
Dashboard: DashboardPageProxy - Use chaining operators to prevent runtime error

### DIFF
--- a/public/app/features/dashboard/containers/DashboardPageProxy.test.tsx
+++ b/public/app/features/dashboard/containers/DashboardPageProxy.test.tsx
@@ -147,7 +147,7 @@ describe('DashboardPageProxy', () => {
         act(() => {
           setup({
             route: { routeName: DashboardRoutes.Home, component: () => null, path: '/' },
-            match: { params: {}, isExact: true, path: '/', url: '/' },
+            match: { params: { uid: '' }, isExact: true, path: '/', url: '/' },
           });
         });
 
@@ -176,7 +176,14 @@ describe('DashboardPageProxy', () => {
         act(() => {
           setup({
             route: { routeName: DashboardRoutes.Home, component: () => null, path: '/' },
-            match: { params: {}, isExact: true, path: '/', url: '/' },
+            match: {
+              params: {
+                uid: '',
+              },
+              isExact: true,
+              path: '/',
+              url: '/',
+            },
           });
         });
 

--- a/public/app/features/dashboard/containers/DashboardPageProxy.tsx
+++ b/public/app/features/dashboard/containers/DashboardPageProxy.tsx
@@ -54,7 +54,7 @@ function DashboardPageProxy(props: DashboardPageProxyProps) {
     return null;
   }
 
-  if (dashboard.value && dashboard.value.dashboard.uid && dashboard.value.dashboard.uid !== props.match.params.uid) {
+  if (dashboard?.value?.dashboard?.uid !== props.match.params.uid) {
     return null;
   }
 


### PR DESCRIPTION
Fixes `undefined` runtime error when `dashboard` or `uid`  did not exist

```
TypeError: l.value.dashboard is undefined
    ir DashboardPageProxy.tsx:49
    React 8
    x scheduler.production.min.js:13
    D scheduler.production.min.js:14
    7463 scheduler.production.min.js:14
    Webpack 27
instrumentation.js:23:42
    e instrumentation.js:23
    e instrumentation.js:23
    React 9
    x scheduler.production.min.js:13
    D scheduler.production.min.js:14
    (Async: EventHandlerNonNull)
    7463 scheduler.production.min.js:14
```


#### Notes from research: 

The issue surfaced because the redirect to the `home-cloud-app` was not happening when clicking the logo(This error surfaced because of this refactor [PR](https://github.com/grafana/grafana/pull/86262))  . 
I tested on the ephemeral instance https://ephemeral1511182186507axelava.grafana-dev.net/ and is working now. 