### PR TITLE
Plugins: Add an auto-generated part to the `plugin.json` schema

### DIFF
--- a/docs/sources/developers/plugins/plugin.schema.json
+++ b/docs/sources/developers/plugins/plugin.schema.json
@@ -555,6 +555,35 @@
           }
         }
       }
+    },
+    "generated": {
+      "type": "object",
+      "description": "Auto-generated metadata for the plugin (usually automatically extracted from the source code during build time).",
+      "properties": {
+        "extensions": {
+          "type": "array",
+          "description": "List of the extensions that the plugin registers.",
+          "items": {
+            "type": "object",
+            "properties": {
+              "extensionPointId": {
+                "type": "string"
+              },
+              "title": {
+                "type": "string"
+              },
+              "description": {
+                "type": "string"
+              },
+              "type": {
+                "type": "string",
+                "enum": ["link", "component"]
+              }
+            },
+            "required": ["extensionPointId", "title", "description", "type"]
+          }
+        }
+      }
     }
   }
 }


### PR DESCRIPTION
### What changed?

The [`@grafana/plugin-meta-extractor`](https://github.com/grafana/plugin-tools/pull/805) is planning to extend the `plugin.json` in an automated way, providing auto-generated metadata that it extracts from the source code. This PR is preparing the plugin.json schema for those changes. 