### PR TITLE
Grafana UI: `Dropdown.story.tsx` - Replace `VerticalGroup` with `Stack`

### DIFF
--- a/.betterer.results
+++ b/.betterer.results
@@ -797,9 +797,6 @@ exports[`better eslint`] = {
       [0, 0, 0, "Unexpected any. Specify a different type.", "0"],
       [0, 0, 0, "Unexpected any. Specify a different type.", "1"]
     ],
-    "packages/grafana-ui/src/components/Dropdown/Dropdown.story.tsx:5381": [
-      [0, 0, 0, "\'VerticalGroup\' import from \'../Layout/Layout\' is restricted from being used by a pattern. Use Stack component instead.", "0"]
-    ],
     "packages/grafana-ui/src/components/Forms/Checkbox.story.tsx:5381": [
       [0, 0, 0, "\'VerticalGroup\' import from \'../Layout/Layout\' is restricted from being used by a pattern. Use Stack component instead.", "0"]
     ],

--- a/packages/grafana-ui/src/components/Dropdown/Dropdown.story.tsx
+++ b/packages/grafana-ui/src/components/Dropdown/Dropdown.story.tsx
@@ -4,7 +4,7 @@ import React from 'react';
 import { StoryExample } from '../../utils/storybook/StoryExample';
 import { Button } from '../Button';
 import { IconButton } from '../IconButton/IconButton';
-import { VerticalGroup } from '../Layout/Layout';
+import { Stack } from '../Layout/Stack/Stack';
 import { Menu } from '../Menu/Menu';
 
 import { Dropdown } from './Dropdown';
@@ -34,7 +34,7 @@ export function Examples() {
   );
 
   return (
-    <VerticalGroup>
+    <Stack direction="column">
       <StoryExample name="Button + defaults">
         <Dropdown overlay={menu}>
           <Button variant="secondary">Button</Button>
@@ -46,7 +46,7 @@ export function Examples() {
           <IconButton tooltip="Open menu" variant="secondary" name="bars" />
         </Dropdown>
       </StoryExample>
-    </VerticalGroup>
+    </Stack>
   );
 }
 


### PR DESCRIPTION
**What is this feature?**
This is part of the epic https://github.com/grafana/grafana/issues/85510

**Why do we need this feature?**
To replace deprecated layout components with new ones.

**Who is this feature for?**
Everybody

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**
**Before:**
![Captura de pantalla 2024-04-18 a las 15 38 25](https://github.com/grafana/grafana/assets/65417731/25582a0b-5c4a-4e5b-8563-50f7ddff27fd)

**After:**
![Captura de pantalla 2024-04-18 a las 15 38 58](https://github.com/grafana/grafana/assets/65417731/aa3111eb-eb2e-436a-abab-c9f7b2d679fe)


Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
