### PR TITLE
Grafana UI: `TextLink.story.tsx` - Replace `VerticalGroup` with `Stack`

### DIFF
--- a/.betterer.results
+++ b/.betterer.results
@@ -832,9 +832,6 @@ exports[`better eslint`] = {
       [0, 0, 0, "\'VerticalGroup\' import from \'@grafana/ui\' is restricted from being used by a pattern. Use Stack component instead.", "0"],
       [0, 0, 0, "\'HorizontalGroup\' import from \'@grafana/ui\' is restricted from being used by a pattern. Use Stack component instead.", "1"]
     ],
-    "packages/grafana-ui/src/components/Link/TextLink.story.tsx:5381": [
-      [0, 0, 0, "\'VerticalGroup\' import from \'../Layout/Layout\' is restricted from being used by a pattern. Use Stack component instead.", "0"]
-    ],
     "packages/grafana-ui/src/components/MatchersUI/FieldValueMatcher.tsx:5381": [
       [0, 0, 0, "Do not use any type assertions.", "0"]
     ],

--- a/packages/grafana-ui/src/components/Link/TextLink.story.tsx
+++ b/packages/grafana-ui/src/components/Link/TextLink.story.tsx
@@ -52,7 +52,7 @@ export const Example: StoryFn = (args) => {
         </Text>
       </StoryExample>
       <StoryExample name="This is a 'standalone + external' link with the default behaviour">
-        <TextLink href="https://grafana.com/docs/grafana/latest/" {...args}>
+        <TextLink href="https://grafana.com/docs/grafana/latest/" external inline={false} {...args}>
           Learn how in the docs
         </TextLink>
       </StoryExample>

--- a/packages/grafana-ui/src/components/Link/TextLink.story.tsx
+++ b/packages/grafana-ui/src/components/Link/TextLink.story.tsx
@@ -2,7 +2,7 @@ import { Meta, StoryFn } from '@storybook/react';
 import React from 'react';
 
 import { StoryExample } from '../../utils/storybook/StoryExample';
-import { VerticalGroup } from '../Layout/Layout';
+import { Stack } from '../Layout/Stack/Stack';
 import { Text } from '../Text/Text';
 
 import { TextLink } from './TextLink';
@@ -41,7 +41,7 @@ const meta: Meta = {
 
 export const Example: StoryFn = (args) => {
   return (
-    <VerticalGroup>
+    <Stack direction="column">
       <StoryExample name="This is a 'inline + external' link with the default behaviour">
         <Text element="p">
           To get started with a forever free Grafana Cloud account, sign up at &#160;
@@ -60,7 +60,7 @@ export const Example: StoryFn = (args) => {
       <Text element="p">
         *The examples cannot contemplate an internal link due to conflicts between Storybook and React Router
       </Text>
-    </VerticalGroup>
+    </Stack>
   );
 };
 


### PR DESCRIPTION
**What is this feature?**
This is part of the epic https://github.com/grafana/grafana/issues/85510

**Why do we need this feature?**
To replace deprecated layout components with new ones.

**Who is this feature for?**
Everybody

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**
**Before:**
![Captura de pantalla 2024-04-18 a las 16 07 07](https://github.com/grafana/grafana/assets/65417731/df0375b7-fa0b-4db3-8af6-81d4b3b82a06)

**After:**
![Captura de pantalla 2024-04-18 a las 16 12 17](https://github.com/grafana/grafana/assets/65417731/cdf74db7-7666-43bc-98f1-ad0e41b87f75)

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
