### PR TITLE
Grafana UI: `Menu.story.tsx` - Replace `VerticalGroup` with `Stack`

### DIFF
--- a/.betterer.results
+++ b/.betterer.results
@@ -838,9 +838,6 @@ exports[`better eslint`] = {
     "packages/grafana-ui/src/components/MatchersUI/fieldMatchersUI.ts:5381": [
       [0, 0, 0, "Unexpected any. Specify a different type.", "0"]
     ],
-    "packages/grafana-ui/src/components/Menu/Menu.story.tsx:5381": [
-      [0, 0, 0, "\'VerticalGroup\' import from \'../Layout/Layout\' is restricted from being used by a pattern. Use Stack component instead.", "0"]
-    ],
     "packages/grafana-ui/src/components/Modal/ModalsContext.tsx:5381": [
       [0, 0, 0, "Unexpected any. Specify a different type.", "0"],
       [0, 0, 0, "Unexpected any. Specify a different type.", "1"],

--- a/packages/grafana-ui/src/components/Menu/Menu.story.tsx
+++ b/packages/grafana-ui/src/components/Menu/Menu.story.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 
 import { GraphContextMenuHeader } from '..';
 import { StoryExample } from '../../utils/storybook/StoryExample';
-import { VerticalGroup } from '../Layout/Layout';
+import { Stack } from '../Layout/Stack/Stack';
 
 import { Menu } from './Menu';
 import mdx from './Menu.mdx';
@@ -30,7 +30,7 @@ const meta: Meta<typeof Menu> = {
 
 export function Examples() {
   return (
-    <VerticalGroup>
+    <Stack direction="column">
       <StoryExample name="Plain">
         <Menu>
           <Menu.Item label="Google" />
@@ -167,7 +167,7 @@ export function Examples() {
           />
         </Menu>
       </StoryExample>
-    </VerticalGroup>
+    </Stack>
   );
 }
 


### PR DESCRIPTION
**What is this feature?**
This is part of the epic https://github.com/grafana/grafana/issues/85510

**Why do we need this feature?**
To replace deprecated layout components with new ones.

**Who is this feature for?**
Everybody

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**
**Before:**
![Captura de pantalla 2024-04-18 a las 16 26 52](https://github.com/grafana/grafana/assets/65417731/de10fbcf-d50c-4e34-b899-7963bb1ee1e2)

**After:**
![Captura de pantalla 2024-04-18 a las 16 27 13](https://github.com/grafana/grafana/assets/65417731/9d133f9e-421e-447b-a1ca-4ce0e22b8d9c)


Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
