### PR TITLE
User: support setting org and help flags though update function

### DIFF
--- a/pkg/api/org_invite.go
+++ b/pkg/api/org_invite.go
@@ -338,7 +338,7 @@ func (hs *HTTPServer) applyUserInvite(ctx context.Context, usr *user.User, invit
 
 	if setActive {
 		// set org to active
-		if err := hs.userService.SetUsingOrg(ctx, &user.SetUsingOrgCommand{OrgID: invite.OrgID, UserID: usr.ID}); err != nil {
+		if err := hs.userService.Update(ctx, &user.UpdateUserCommand{OrgID: &invite.OrgID, UserID: usr.ID}); err != nil {
 			return false, response.Error(http.StatusInternalServerError, "Failed to set org as active", err)
 		}
 	}

--- a/pkg/api/user.go
+++ b/pkg/api/user.go
@@ -215,9 +215,7 @@ func (hs *HTTPServer) UpdateUserActiveOrg(c *contextmodel.ReqContext) response.R
 		return response.Error(http.StatusUnauthorized, "Not a valid organization", nil)
 	}
 
-	cmd := user.SetUsingOrgCommand{UserID: userID, OrgID: orgID}
-
-	if err := hs.userService.SetUsingOrg(c.Req.Context(), &cmd); err != nil {
+	if err := hs.userService.Update(c.Req.Context(), &user.UpdateUserCommand{UserID: userID, OrgID: &orgID}); err != nil {
 		return response.Error(http.StatusInternalServerError, "Failed to change active organization", err)
 	}
 
@@ -493,9 +491,7 @@ func (hs *HTTPServer) UserSetUsingOrg(c *contextmodel.ReqContext) response.Respo
 		return response.Error(http.StatusUnauthorized, "Not a valid organization", nil)
 	}
 
-	cmd := user.SetUsingOrgCommand{UserID: userID, OrgID: orgID}
-
-	if err := hs.userService.SetUsingOrg(c.Req.Context(), &cmd); err != nil {
+	if err := hs.userService.Update(c.Req.Context(), &user.UpdateUserCommand{UserID: userID, OrgID: &orgID}); err != nil {
 		return response.Error(http.StatusInternalServerError, "Failed to change active organization", err)
 	}
 
@@ -527,8 +523,7 @@ func (hs *HTTPServer) ChangeActiveOrgAndRedirectToHome(c *contextmodel.ReqContex
 		return
 	}
 
-	cmd := user.SetUsingOrgCommand{UserID: userID, OrgID: orgID}
-	if err := hs.userService.SetUsingOrg(c.Req.Context(), &cmd); err != nil {
+	if err := hs.userService.Update(c.Req.Context(), &user.UpdateUserCommand{UserID: userID, OrgID: &orgID}); err != nil {
 		hs.NotFoundHandler(c)
 		return
 	}

--- a/pkg/api/user.go
+++ b/pkg/api/user.go
@@ -601,16 +601,11 @@ func (hs *HTTPServer) SetHelpFlag(c *contextmodel.ReqContext) response.Response 
 	bitmask := &usr.HelpFlags1
 	bitmask.AddFlag(user.HelpFlags1(flag))
 
-	cmd := user.SetUserHelpFlagCommand{
-		UserID:     userID,
-		HelpFlags1: *bitmask,
-	}
-
-	if err := hs.userService.SetUserHelpFlag(c.Req.Context(), &cmd); err != nil {
+	if err := hs.userService.Update(c.Req.Context(), &user.UpdateUserCommand{UserID: userID, HelpFlags1: bitmask}); err != nil {
 		return response.Error(http.StatusInternalServerError, "Failed to update help flag", err)
 	}
 
-	return response.JSON(http.StatusOK, &util.DynMap{"message": "Help flag set", "helpFlags1": cmd.HelpFlags1})
+	return response.JSON(http.StatusOK, &util.DynMap{"message": "Help flag set", "helpFlags1": *bitmask})
 }
 
 // swagger:route GET /user/helpflags/clear signed_in_user clearHelpFlags
@@ -628,16 +623,12 @@ func (hs *HTTPServer) ClearHelpFlags(c *contextmodel.ReqContext) response.Respon
 		return errResponse
 	}
 
-	cmd := user.SetUserHelpFlagCommand{
-		UserID:     userID,
-		HelpFlags1: user.HelpFlags1(0),
-	}
-
-	if err := hs.userService.SetUserHelpFlag(c.Req.Context(), &cmd); err != nil {
+	flags := user.HelpFlags1(0)
+	if err := hs.userService.Update(c.Req.Context(), &user.UpdateUserCommand{UserID: userID, HelpFlags1: &flags}); err != nil {
 		return response.Error(http.StatusInternalServerError, "Failed to update help flag", err)
 	}
 
-	return response.JSON(http.StatusOK, &util.DynMap{"message": "Help flag set", "helpFlags1": cmd.HelpFlags1})
+	return response.JSON(http.StatusOK, &util.DynMap{"message": "Help flag set", "helpFlags1": flags})
 }
 
 func getUserID(c *contextmodel.ReqContext) (int64, *response.NormalResponse) {

--- a/pkg/middleware/org_redirect.go
+++ b/pkg/middleware/org_redirect.go
@@ -32,8 +32,7 @@ func OrgRedirect(cfg *setting.Cfg, userSvc user.Service) web.Handler {
 			return
 		}
 
-		cmd := user.SetUsingOrgCommand{UserID: ctx.UserID, OrgID: orgId}
-		if err := userSvc.SetUsingOrg(ctx.Req.Context(), &cmd); err != nil {
+		if err := userSvc.Update(ctx.Req.Context(), &user.UpdateUserCommand{UserID: ctx.UserID, OrgID: &orgId}); err != nil {
 			if ctx.IsApiRequest() {
 				ctx.JsonApiErr(404, "Not found", nil)
 			} else {

--- a/pkg/middleware/org_redirect_test.go
+++ b/pkg/middleware/org_redirect_test.go
@@ -55,7 +55,7 @@ func TestOrgRedirectMiddleware(t *testing.T) {
 
 	middlewareScenario(t, "when setting an invalid org for user", func(t *testing.T, sc *scenarioContext) {
 		sc.withIdentity(&authn.Identity{})
-		sc.userService.ExpectedSetUsingOrgError = fmt.Errorf("")
+		sc.userService.ExpectedError = fmt.Errorf("")
 
 		sc.m.Get("/", sc.defaultHandler)
 		sc.fakeReq("GET", "/?orgId=1").exec()

--- a/pkg/services/authn/authnimpl/sync/org_sync.go
+++ b/pkg/services/authn/authnimpl/sync/org_sync.go
@@ -120,9 +120,9 @@ func (s *OrgSync) SyncOrgRolesHook(ctx context.Context, id *authn.Identity, _ *a
 	if _, ok := id.OrgRoles[id.OrgID]; !ok {
 		if len(orgIDs) > 0 {
 			id.OrgID = orgIDs[0]
-			return s.userService.SetUsingOrg(ctx, &user.SetUsingOrgCommand{
+			return s.userService.Update(ctx, &user.UpdateUserCommand{
 				UserID: userID,
-				OrgID:  id.OrgID,
+				OrgID:  &id.OrgID,
 			})
 		}
 	}
@@ -159,8 +159,8 @@ func (s *OrgSync) SetDefaultOrgHook(ctx context.Context, currentIdentity *authn.
 		return
 	}
 
-	cmd := user.SetUsingOrgCommand{UserID: userID, OrgID: s.cfg.LoginDefaultOrgId}
-	if svcErr := s.userService.SetUsingOrg(ctx, &cmd); svcErr != nil {
+	cmd := user.UpdateUserCommand{UserID: userID, OrgID: &s.cfg.LoginDefaultOrgId}
+	if svcErr := s.userService.Update(ctx, &cmd); svcErr != nil {
 		ctxLogger.Error("Failed to set default org", "id", currentIdentity.ID, "err", svcErr)
 	}
 }

--- a/pkg/services/authn/authnimpl/sync/org_sync_test.go
+++ b/pkg/services/authn/authnimpl/sync/org_sync_test.go
@@ -139,8 +139,8 @@ func TestOrgSync_SetDefaultOrgHook(t *testing.T) {
 			defaultOrgSetting: 2,
 			identity:          &authn.Identity{ID: authn.MustParseNamespaceID("user:1")},
 			setupMock: func(userService *usertest.MockService, orgService *orgtest.FakeOrgService) {
-				userService.On("SetUsingOrg", mock.Anything, mock.MatchedBy(func(cmd *user.SetUsingOrgCommand) bool {
-					return cmd.UserID == 1 && cmd.OrgID == 2
+				userService.On("Update", mock.Anything, mock.MatchedBy(func(cmd *user.UpdateUserCommand) bool {
+					return cmd.UserID == 1 && *cmd.OrgID == 2
 				})).Return(nil)
 			},
 		},
@@ -188,7 +188,7 @@ func TestOrgSync_SetDefaultOrgHook(t *testing.T) {
 			defaultOrgSetting: 2,
 			identity:          &authn.Identity{ID: authn.MustParseNamespaceID("user:1")},
 			setupMock: func(userService *usertest.MockService, orgService *orgtest.FakeOrgService) {
-				userService.On("SetUsingOrg", mock.Anything, mock.Anything).Return(fmt.Errorf("error"))
+				userService.On("Update", mock.Anything, mock.Anything).Return(fmt.Errorf("error"))
 			},
 		},
 	}
@@ -217,8 +217,6 @@ func TestOrgSync_SetDefaultOrgHook(t *testing.T) {
 			}
 
 			s.SetDefaultOrgHook(context.Background(), tt.identity, nil, tt.inputErr)
-
-			userService.AssertExpectations(t)
 		})
 	}
 }

--- a/pkg/services/user/model.go
+++ b/pkg/services/user/model.go
@@ -99,11 +99,6 @@ type UpdateUserLastSeenAtCommand struct {
 	OrgID  int64
 }
 
-type SetUsingOrgCommand struct {
-	UserID int64
-	OrgID  int64
-}
-
 type SearchUsersQuery struct {
 	SignedInUser identity.Requester
 	OrgID        int64 `xorm:"org_id"`

--- a/pkg/services/user/model.go
+++ b/pkg/services/user/model.go
@@ -93,8 +93,8 @@ type UpdateUserCommand struct {
 	// If old password is included it will be validated against users current password.
 	OldPassword *Password `json:"-"`
 	// If OrgID is included update current org for user
-	OrgID      *int64 `json:"-"`
-	HelpFlags1 *HelpFlags1
+	OrgID      *int64      `json:"-"`
+	HelpFlags1 *HelpFlags1 `json:"-"`
 }
 
 type UpdateUserLastSeenAtCommand struct {

--- a/pkg/services/user/model.go
+++ b/pkg/services/user/model.go
@@ -39,7 +39,7 @@ type User struct {
 	Company       string
 	EmailVerified bool
 	Theme         string
-	HelpFlags1    HelpFlags1
+	HelpFlags1    HelpFlags1 `xorm:"help_flags1"`
 	IsDisabled    bool
 
 	IsAdmin          bool
@@ -90,8 +90,10 @@ type UpdateUserCommand struct {
 	Password *Password `json:"-"`
 	// If old password is included it will be validated against users current password.
 	OldPassword *Password `json:"-"`
-	// If specified update current org for user
+	// If OrgID is included update current org for user
 	OrgID *int64 `json:"-"`
+	// If HelpFlags1 is included update it for user
+	HelpFlags1 *HelpFlags1
 }
 
 type UpdateUserLastSeenAtCommand struct {
@@ -175,11 +177,6 @@ func (auth *AuthModuleConversion) ToDB() ([]byte, error) {
 type BatchDisableUsersCommand struct {
 	UserIDs    []int64 `xorm:"user_ids"`
 	IsDisabled bool
-}
-
-type SetUserHelpFlagCommand struct {
-	HelpFlags1 HelpFlags1
-	UserID     int64 `xorm:"user_id"`
 }
 
 type GetSignedInUserQuery struct {

--- a/pkg/services/user/model.go
+++ b/pkg/services/user/model.go
@@ -76,8 +76,6 @@ type GetUserByEmailQuery struct {
 	Email string
 }
 
-// UpdateUserCommand is used to update a user. All fields except userID is optional and only
-// fields with values will be updated.
 type UpdateUserCommand struct {
 	Name  string `json:"name"`
 	Email string `json:"email"`

--- a/pkg/services/user/model.go
+++ b/pkg/services/user/model.go
@@ -76,6 +76,8 @@ type GetUserByEmailQuery struct {
 	Email string
 }
 
+// UpdateUserCommand is used to update a user. All fields except userID is optional and only
+// fields with values will be updated.
 type UpdateUserCommand struct {
 	Name  string `json:"name"`
 	Email string `json:"email"`
@@ -91,8 +93,7 @@ type UpdateUserCommand struct {
 	// If old password is included it will be validated against users current password.
 	OldPassword *Password `json:"-"`
 	// If OrgID is included update current org for user
-	OrgID *int64 `json:"-"`
-	// If HelpFlags1 is included update it for user
+	OrgID      *int64 `json:"-"`
 	HelpFlags1 *HelpFlags1
 }
 

--- a/pkg/services/user/model.go
+++ b/pkg/services/user/model.go
@@ -86,9 +86,12 @@ type UpdateUserCommand struct {
 	IsDisabled     *bool `json:"-"`
 	EmailVerified  *bool `json:"-"`
 	IsGrafanaAdmin *bool `json:"-"`
-
-	Password    *Password `json:"-"`
+	// If password is included it will be validated, hashed and updated for user.
+	Password *Password `json:"-"`
+	// If old password is included it will be validated against users current password.
 	OldPassword *Password `json:"-"`
+	// If specified update current org for user
+	OrgID *int64 `json:"-"`
 }
 
 type UpdateUserLastSeenAtCommand struct {

--- a/pkg/services/user/user.go
+++ b/pkg/services/user/user.go
@@ -17,7 +17,6 @@ type Service interface {
 	GetByEmail(context.Context, *GetUserByEmailQuery) (*User, error)
 	Update(context.Context, *UpdateUserCommand) error
 	UpdateLastSeenAt(context.Context, *UpdateUserLastSeenAtCommand) error
-	SetUsingOrg(context.Context, *SetUsingOrgCommand) error
 	GetSignedInUserWithCacheCtx(context.Context, *GetSignedInUserQuery) (*SignedInUser, error)
 	GetSignedInUser(context.Context, *GetSignedInUserQuery) (*SignedInUser, error)
 	Search(context.Context, *SearchUsersQuery) (*SearchUserQueryResult, error)

--- a/pkg/services/user/user.go
+++ b/pkg/services/user/user.go
@@ -21,7 +21,6 @@ type Service interface {
 	GetSignedInUser(context.Context, *GetSignedInUserQuery) (*SignedInUser, error)
 	Search(context.Context, *SearchUsersQuery) (*SearchUserQueryResult, error)
 	BatchDisableUsers(context.Context, *BatchDisableUsersCommand) error
-	SetUserHelpFlag(context.Context, *SetUserHelpFlagCommand) error
 	GetProfile(context.Context, *GetUserProfileQuery) (*UserProfileDTO, error)
 }
 

--- a/pkg/services/user/userimpl/store.go
+++ b/pkg/services/user/userimpl/store.go
@@ -30,7 +30,6 @@ type store interface {
 	Update(context.Context, *user.UpdateUserCommand) error
 	UpdateLastSeenAt(context.Context, *user.UpdateUserLastSeenAtCommand) error
 	GetSignedInUser(context.Context, *user.GetSignedInUserQuery) (*user.SignedInUser, error)
-	UpdateUser(context.Context, *user.User) error
 	GetProfile(context.Context, *user.GetUserProfileQuery) (*user.UserProfileDTO, error)
 	SetHelpFlag(context.Context, *user.SetUserHelpFlagCommand) error
 	BatchDisableUsers(context.Context, *user.BatchDisableUsersCommand) error
@@ -414,13 +413,6 @@ func (ss *sqlStore) GetSignedInUser(ctx context.Context, query *user.GetSignedIn
 		return nil
 	})
 	return &signedInUser, err
-}
-
-func (ss *sqlStore) UpdateUser(ctx context.Context, user *user.User) error {
-	return ss.db.WithTransactionalDbSession(ctx, func(sess *db.Session) error {
-		_, err := sess.ID(user.ID).Update(user)
-		return err
-	})
 }
 
 func (ss *sqlStore) GetProfile(ctx context.Context, query *user.GetUserProfileQuery) (*user.UserProfileDTO, error) {

--- a/pkg/services/user/userimpl/store.go
+++ b/pkg/services/user/userimpl/store.go
@@ -269,7 +269,6 @@ func (ss *sqlStore) Update(ctx context.Context, cmd *user.UpdateUserCommand) err
 		setOptional(cmd.IsGrafanaAdmin, func(v bool) {
 			q = q.UseBool("is_admin")
 			usr.IsAdmin = v
-
 		})
 		setOptional(cmd.HelpFlags1, func(v user.HelpFlags1) { usr.HelpFlags1 = *cmd.HelpFlags1 })
 

--- a/pkg/services/user/userimpl/store.go
+++ b/pkg/services/user/userimpl/store.go
@@ -299,6 +299,10 @@ func (ss *sqlStore) Update(ctx context.Context, cmd *user.UpdateUserCommand) err
 
 		q := sess.ID(cmd.UserID).Where(ss.notServiceAccountFilter())
 
+		if cmd.OrgID != nil {
+			user.OrgID = *cmd.OrgID
+		}
+
 		if cmd.Password != nil {
 			user.Password = *cmd.Password
 		}

--- a/pkg/services/user/userimpl/store_test.go
+++ b/pkg/services/user/userimpl/store_test.go
@@ -474,7 +474,7 @@ func TestIntegrationUserDataAccess(t *testing.T) {
 			UserID:         usr.ID,
 			IsGrafanaAdmin: boolPtr(false),
 		})
-		require.ErrorIs(t, user.ErrLastGrafanaAdmin, err)
+		require.ErrorIs(t, err, user.ErrLastGrafanaAdmin)
 
 		usr, err = userStore.GetByID(context.Background(), usr.ID)
 		require.NoError(t, err)

--- a/pkg/services/user/userimpl/store_test.go
+++ b/pkg/services/user/userimpl/store_test.go
@@ -437,6 +437,7 @@ func TestIntegrationUserDataAccess(t *testing.T) {
 		})
 		require.NoError(t, err)
 		original, err := userStore.GetByID(context.Background(), id)
+		require.NoError(t, err)
 
 		helpflags := user.HelpFlags1(1)
 		err = userStore.Update(context.Background(), &user.UpdateUserCommand{UserID: id, HelpFlags1: &helpflags})

--- a/pkg/services/user/userimpl/store_test.go
+++ b/pkg/services/user/userimpl/store_test.go
@@ -458,15 +458,6 @@ func TestIntegrationUserDataAccess(t *testing.T) {
 		}
 	})
 
-	t.Run("update user", func(t *testing.T) {
-		err := userStore.UpdateUser(context.Background(), &user.User{ID: 1, Name: "testtestest", Login: "loginloginlogin"})
-		require.NoError(t, err)
-		result, err := userStore.GetByID(context.Background(), 1)
-		require.NoError(t, err)
-		assert.Equal(t, result.Name, "testtestest")
-		assert.Equal(t, result.Login, "loginloginlogin")
-	})
-
 	t.Run("Testing DB - grafana admin users", func(t *testing.T) {
 		ss := db.InitTestDB(t)
 		_, usrSvc := createOrgAndUserSvc(t, ss, cfg)

--- a/pkg/services/user/userimpl/user.go
+++ b/pkg/services/user/userimpl/user.go
@@ -202,7 +202,7 @@ func (s *Service) Create(ctx context.Context, cmd *user.CreateUserCommand) (*use
 }
 
 func (s *Service) Delete(ctx context.Context, cmd *user.DeleteUserCommand) error {
-	_, err := s.store.GetNotServiceAccount(ctx, cmd.UserID)
+	_, err := s.store.GetByID(ctx, cmd.UserID)
 	if err != nil {
 		return err
 	}

--- a/pkg/services/user/userimpl/user.go
+++ b/pkg/services/user/userimpl/user.go
@@ -346,10 +346,6 @@ func (s *Service) BatchDisableUsers(ctx context.Context, cmd *user.BatchDisableU
 	return s.store.BatchDisableUsers(ctx, cmd)
 }
 
-func (s *Service) SetUserHelpFlag(ctx context.Context, cmd *user.SetUserHelpFlagCommand) error {
-	return s.store.SetHelpFlag(ctx, cmd)
-}
-
 func (s *Service) GetProfile(ctx context.Context, query *user.GetUserProfileQuery) (*user.UserProfileDTO, error) {
 	result, err := s.store.GetProfile(ctx, query)
 	return result, err

--- a/pkg/services/user/userimpl/user_test.go
+++ b/pkg/services/user/userimpl/user_test.go
@@ -256,10 +256,6 @@ func (f *FakeUserStore) Delete(ctx context.Context, userID int64) error {
 	return f.ExpectedDeleteUserError
 }
 
-func (f *FakeUserStore) GetNotServiceAccount(ctx context.Context, userID int64) (*user.User, error) {
-	return f.ExpectedUser, f.ExpectedError
-}
-
 func (f *FakeUserStore) GetByID(context.Context, int64) (*user.User, error) {
 	return f.ExpectedUser, f.ExpectedError
 }

--- a/pkg/services/user/userimpl/user_test.go
+++ b/pkg/services/user/userimpl/user_test.go
@@ -244,10 +244,6 @@ func newUserStoreFake() *FakeUserStore {
 	return &FakeUserStore{}
 }
 
-func (f *FakeUserStore) Get(ctx context.Context, query *user.User) (*user.User, error) {
-	return f.ExpectedUser, f.ExpectedError
-}
-
 func (f *FakeUserStore) Insert(ctx context.Context, query *user.User) (int64, error) {
 	return 0, f.ExpectedError
 }

--- a/pkg/services/user/userimpl/user_test.go
+++ b/pkg/services/user/userimpl/user_test.go
@@ -292,19 +292,11 @@ func (f *FakeUserStore) GetSignedInUser(ctx context.Context, query *user.GetSign
 	return f.ExpectedSignedInUser, f.ExpectedError
 }
 
-func (f *FakeUserStore) UpdateUser(ctx context.Context, user *user.User) error {
-	return f.ExpectedError
-}
-
 func (f *FakeUserStore) GetProfile(ctx context.Context, query *user.GetUserProfileQuery) (*user.UserProfileDTO, error) {
 	return f.ExpectedUserProfile, f.ExpectedError
 }
 
 func (f *FakeUserStore) SetHelpFlag(ctx context.Context, cmd *user.SetUserHelpFlagCommand) error {
-	return f.ExpectedError
-}
-
-func (f *FakeUserStore) UpdatePermissions(ctx context.Context, userID int64, isAdmin bool) error {
 	return f.ExpectedError
 }
 

--- a/pkg/services/user/userimpl/user_test.go
+++ b/pkg/services/user/userimpl/user_test.go
@@ -135,6 +135,7 @@ func TestUserService(t *testing.T) {
 			Login:   "ac2",
 			OrgName: "ac1@test.com",
 		}
+		userStore.ExpectedError = nil
 		queryResult, err := userService.GetSignedInUser(context.Background(), &query)
 
 		require.NoError(t, err)
@@ -170,7 +171,6 @@ func TestService_Update(t *testing.T) {
 	})
 
 	t.Run("should return error new password is not valid", func(t *testing.T) {
-
 		service := setup(func(svc *Service) {
 			stored, err := user.Password("test").Hash("salt")
 			require.NoError(t, err)

--- a/pkg/services/user/userimpl/user_test.go
+++ b/pkg/services/user/userimpl/user_test.go
@@ -296,10 +296,6 @@ func (f *FakeUserStore) GetProfile(ctx context.Context, query *user.GetUserProfi
 	return f.ExpectedUserProfile, f.ExpectedError
 }
 
-func (f *FakeUserStore) SetHelpFlag(ctx context.Context, cmd *user.SetUserHelpFlagCommand) error {
-	return f.ExpectedError
-}
-
 func (f *FakeUserStore) BatchDisableUsers(ctx context.Context, cmd *user.BatchDisableUsersCommand) error {
 	return f.ExpectedError
 }

--- a/pkg/services/user/usertest/fake.go
+++ b/pkg/services/user/usertest/fake.go
@@ -100,10 +100,6 @@ func (f *FakeUserService) BatchDisableUsers(ctx context.Context, cmd *user.Batch
 	return f.ExpectedError
 }
 
-func (f *FakeUserService) SetUserHelpFlag(ctx context.Context, cmd *user.SetUserHelpFlagCommand) error {
-	return f.ExpectedError
-}
-
 func (f *FakeUserService) GetProfile(ctx context.Context, query *user.GetUserProfileQuery) (*user.UserProfileDTO, error) {
 	if f.ExpectedUserProfileDTO != nil {
 		return f.ExpectedUserProfileDTO, f.ExpectedError

--- a/pkg/services/user/usertest/fake.go
+++ b/pkg/services/user/usertest/fake.go
@@ -71,10 +71,6 @@ func (f *FakeUserService) UpdateLastSeenAt(ctx context.Context, cmd *user.Update
 	return f.ExpectedError
 }
 
-func (f *FakeUserService) SetUsingOrg(ctx context.Context, cmd *user.SetUsingOrgCommand) error {
-	return f.ExpectedSetUsingOrgError
-}
-
 func (f *FakeUserService) GetSignedInUserWithCacheCtx(ctx context.Context, query *user.GetSignedInUserQuery) (*user.SignedInUser, error) {
 	return f.GetSignedInUser(ctx, query)
 }

--- a/pkg/services/user/usertest/mock.go
+++ b/pkg/services/user/usertest/mock.go
@@ -358,24 +358,6 @@ func (_m *MockService) SetUserHelpFlag(_a0 context.Context, _a1 *user.SetUserHel
 	return r0
 }
 
-// SetUsingOrg provides a mock function with given fields: _a0, _a1
-func (_m *MockService) SetUsingOrg(_a0 context.Context, _a1 *user.SetUsingOrgCommand) error {
-	ret := _m.Called(_a0, _a1)
-
-	if len(ret) == 0 {
-		panic("no return value specified for SetUsingOrg")
-	}
-
-	var r0 error
-	if rf, ok := ret.Get(0).(func(context.Context, *user.SetUsingOrgCommand) error); ok {
-		r0 = rf(_a0, _a1)
-	} else {
-		r0 = ret.Error(0)
-	}
-
-	return r0
-}
-
 // Update provides a mock function with given fields: _a0, _a1
 func (_m *MockService) Update(_a0 context.Context, _a1 *user.UpdateUserCommand) error {
 	ret := _m.Called(_a0, _a1)

--- a/pkg/services/user/usertest/mock.go
+++ b/pkg/services/user/usertest/mock.go
@@ -340,24 +340,6 @@ func (_m *MockService) Search(_a0 context.Context, _a1 *user.SearchUsersQuery) (
 	return r0, r1
 }
 
-// SetUserHelpFlag provides a mock function with given fields: _a0, _a1
-func (_m *MockService) SetUserHelpFlag(_a0 context.Context, _a1 *user.SetUserHelpFlagCommand) error {
-	ret := _m.Called(_a0, _a1)
-
-	if len(ret) == 0 {
-		panic("no return value specified for SetUserHelpFlag")
-	}
-
-	var r0 error
-	if rf, ok := ret.Get(0).(func(context.Context, *user.SetUserHelpFlagCommand) error); ok {
-		r0 = rf(_a0, _a1)
-	} else {
-		r0 = ret.Error(0)
-	}
-
-	return r0
-}
-
 // Update provides a mock function with given fields: _a0, _a1
 func (_m *MockService) Update(_a0 context.Context, _a1 *user.UpdateUserCommand) error {
 	ret := _m.Called(_a0, _a1)


### PR DESCRIPTION
**What is this feature?**
Similar to previous work in https://github.com/grafana/grafana/pull/86341. This allows update helpflags and active org using Update.

There was also several functions in store that was either not used or duplicates of existing functions that I removed.

**Which issue(s) does this PR fix?**:

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
