### PR TITLE
Canvas: Ensure tangency for first segment

### DIFF
--- a/public/app/plugins/panel/canvas/components/connections/ConnectionSVG.tsx
+++ b/public/app/plugins/panel/canvas/components/connections/ConnectionSVG.tsx
@@ -196,7 +196,7 @@ export const ConnectionSVG = ({
                   const Yn = vertices[index + 1].y * yDist + yStart;
                   if (index === 0) {
                     // First vertex
-                    angle1 = calculateAngle(xStart, yStart, X, Y);
+                    angle1 = calculateAngle(x1, y1, X, Y);
                     angle2 = calculateAngle(X, Y, Xn, Yn);
                   } else {
                     // All vertices
@@ -239,7 +239,7 @@ export const ConnectionSVG = ({
                 // Only calculate arcs if there is a radius
                 if (radius) {
                   // Length of segment
-                  const lSegment = calculateDistance(X, Y, xStart, yStart);
+                  const lSegment = calculateDistance(X, Y, x1, y1);
                   if (Math.abs(lHalfArc) > 0.5 * Math.abs(lSegment)) {
                     // Limit curve control points to mid segment
                     lHalfArc = 0.5 * lSegment;
@@ -250,8 +250,8 @@ export const ConnectionSVG = ({
                   if (index < vertices.length - 1) {
                     // Not also the last point
                     const nextVertex = vertices[index + 1];
-                    Xn = nextVertex.x * xDist + xStart;
-                    Yn = nextVertex.y * yDist + yStart;
+                    Xn = nextVertex.x * xDist + x1;
+                    Yn = nextVertex.y * yDist + y1;
                   }
 
                   // Length of next segment
@@ -262,15 +262,15 @@ export const ConnectionSVG = ({
                   }
                   // Calculate arc control points
                   const lDelta = lSegment - lHalfArc;
-                  xa = lDelta * Math.cos(angle1) + xStart;
-                  ya = lDelta * Math.sin(angle1) + yStart;
+                  xa = lDelta * Math.cos(angle1) + x1;
+                  ya = lDelta * Math.sin(angle1) + y1;
                   xb = lHalfArc * Math.cos(angle2) + X;
                   yb = lHalfArc * Math.sin(angle2) + Y;
 
                   // Check if arc control points are inside of segment, otherwise swap sign
-                  if ((xa > X && xa > xStart) || (xa < X && xa < xStart)) {
-                    xa = (lDelta + 2 * lHalfArc) * Math.cos(angle1) + xStart;
-                    ya = (lDelta + 2 * lHalfArc) * Math.sin(angle1) + yStart;
+                  if ((xa > X && xa > x1) || (xa < X && xa < x1)) {
+                    xa = (lDelta + 2 * lHalfArc) * Math.cos(angle1) + x1;
+                    ya = (lDelta + 2 * lHalfArc) * Math.sin(angle1) + y1;
                     xb = -lHalfArc * Math.cos(angle2) + X;
                     yb = -lHalfArc * Math.sin(angle2) + Y;
                   }


### PR DESCRIPTION
For the first segment of connections, when a radius is applied, tangency wasn't enforced because calculations weren't based on the actual source coordinates, but instead on the original source coordinates.

Before:
![322567824-81d19689-7616-4e51-bdb8-1f0b137226f3](https://github.com/grafana/grafana/assets/60050885/48e51740-3c2a-4f40-b95b-66cf89611e4e)

After:
![Apr-18-2024 09-28-53](https://github.com/grafana/grafana/assets/60050885/d0468916-0742-43f3-80f0-24f3f1153da5)

Fixes #86210