### PR TITLE
Docs: add tooltips shared content

### DIFF
--- a/docs/sources/panels-visualizations/configure-tooltips/index.md
+++ b/docs/sources/panels-visualizations/configure-tooltips/index.md
@@ -67,6 +67,10 @@ Set the hover proximity (in pixels) to control how close the cursor must be to a
 
 ![Adding a hover proximity limit for tooltips](/media/docs/grafana/gif-grafana-10-4-hover-proximity.gif)
 
+### Max height
+
+Set the maximum height of the tooltip box. The default is 600 pixels.
+
 ### Show histogram (Y axis)
 
 For the heatmap visualization only, when you set the **Tooltip mode** to **Single**, the **Show histogram (Y axis)** option is displayed. This option controls whether or not the tooltip includes a histogram representing the y-axis.

--- a/docs/sources/panels-visualizations/visualizations/bar-chart/index.md
+++ b/docs/sources/panels-visualizations/visualizations/bar-chart/index.md
@@ -199,7 +199,7 @@ Set a **Soft min** or **soft max** option for better control of Y-axis limits. B
 
 You can set standard min/max options to define hard limits of the Y-axis. For more information, refer to [Standard options definitions][].
 
-{{< docs/shared lookup="visualizations/multiple-y-axes.md" source="grafana" version="<GRAFANA VERSION>" leveloffset="+2" >}}
+{{< docs/shared lookup="visualizations/multiple-y-axes.md" source="grafana" version="<GRAFANA_VERSION>" leveloffset="+2" >}}
 
 {{% docs/reference %}}
 [Add a field override]: "/docs/grafana/ -> /docs/grafana/<GRAFANA VERSION>/panels-visualizations/configure-overrides#add-a-field-override"

--- a/docs/sources/panels-visualizations/visualizations/bar-chart/index.md
+++ b/docs/sources/panels-visualizations/visualizations/bar-chart/index.md
@@ -131,8 +131,6 @@ Gradient color is generated based on the hue of the line color.
 
 ## Tooltip options
 
-Tooltip options control the information overlay that appears when you hover over data points in the visualization.
-
 {{< docs/shared lookup="visualizations/tooltip-options-1.md" source="grafana" version="<GRAFANA_VERSION>" >}}
 
 ## Legend options

--- a/docs/sources/panels-visualizations/visualizations/bar-chart/index.md
+++ b/docs/sources/panels-visualizations/visualizations/bar-chart/index.md
@@ -129,7 +129,15 @@ Transparency of the gradient is calculated based on the values on the y-axis. Op
 
 Gradient color is generated based on the hue of the line color.
 
-{{< docs/shared lookup="visualizations/tooltip-options-1.md" source="grafana" version="<GRAFANA VERSION>" >}}
+## Tooltip options
+
+Tooltip options control the information overlay that appears when you hover over data points in the visualization.
+
+{{< docs/shared lookup="visualizations/tooltip-options-1.md" source="grafana" version="<GRAFANA_VERSION>" >}}
+
+## Legend options
+
+Legend options control the series names and statistics that appear under or to the right of the graph.
 
 {{< docs/shared lookup="visualizations/legend-mode.md" source="grafana" version="<GRAFANA VERSION>" >}}
 

--- a/docs/sources/panels-visualizations/visualizations/bar-chart/index.md
+++ b/docs/sources/panels-visualizations/visualizations/bar-chart/index.md
@@ -129,7 +129,7 @@ Transparency of the gradient is calculated based on the values on the y-axis. Op
 
 Gradient color is generated based on the hue of the line color.
 
-{{< docs/shared lookup="visualizations/tooltip-mode.md" source="grafana" version="<GRAFANA VERSION>" >}}
+{{< docs/shared lookup="visualizations/tooltip-options-1.md" source="grafana" version="<GRAFANA VERSION>" >}}
 
 {{< docs/shared lookup="visualizations/legend-mode.md" source="grafana" version="<GRAFANA VERSION>" >}}
 

--- a/docs/sources/panels-visualizations/visualizations/candlestick/index.md
+++ b/docs/sources/panels-visualizations/visualizations/candlestick/index.md
@@ -81,8 +81,6 @@ The candlestick visualization is based on the time series visualization. It can 
 
 ## Tooltip options
 
-Tooltip options control the information overlay that appears when you hover over data points in the visualization.
-
 {{< docs/shared lookup="visualizations/tooltip-options-2.md" source="grafana" version="<GRAFANA_VERSION>" >}}
 
 {{% docs/reference %}}

--- a/docs/sources/panels-visualizations/visualizations/candlestick/index.md
+++ b/docs/sources/panels-visualizations/visualizations/candlestick/index.md
@@ -79,6 +79,12 @@ If your data can't be mapped to these dimensions for some reason (for example, b
 
 The candlestick visualization is based on the time series visualization. It can visualize additional data dimensions beyond open, high, low, close, and volume The **Include** and **Ignore** options allow it to visualize other included data such as simple moving averages, Bollinger bands and more, using the same styles and configurations available in the [time series][] visualization.
 
+## Tooltip options
+
+Tooltip options control the information overlay that appears when you hover over data points in the visualization.
+
+{{< docs/shared lookup="visualizations/tooltip-options-2.md" source="grafana" version="<GRAFANA_VERSION>" >}}
+
 {{% docs/reference %}}
 [time series visualization]: "/docs/grafana/ -> /docs/grafana/<GRAFANA VERSION>/panels-visualizations/visualizations/time-series"
 [time series visualization]: "/docs/grafana-cloud/ -> /docs/grafana/<GRAFANA VERSION>/panels-visualizations/visualizations/time-series"

--- a/docs/sources/panels-visualizations/visualizations/heatmap/index.md
+++ b/docs/sources/panels-visualizations/visualizations/heatmap/index.md
@@ -112,9 +112,25 @@ Use these settings to refine your visualization.
 
 ### Tooltip
 
-- **Show tooltip -** Show heatmap tooltip.
-- **Show Histogram -** Show a Y-axis histogram on the tooltip. A histogram represents the distribution of the bucket values for a specific timestamp.
-- **Show color scale -** Show a color scale on the tooltip. The color scale represents the mapping between bucket value and color.
+#### Tooltip mode
+
+When you hover your cursor over the visualization, Grafana can display tooltips. Choose how tooltips behave.
+
+- **Single -** The hover tooltip shows only a single series, the one that you are hovering over on the visualization.
+- **All -** The hover tooltip shows all series in the visualization. Grafana highlights the series that you are hovering over in bold in the series list in the tooltip.
+- **Hidden -** Do not display the tooltip when you interact with the visualization.
+
+Use an override to hide individual series from the tooltip.
+
+#### Show histogram (Y axis)
+
+When you set the **Tooltip mode** to **Single**, this option is displayed. This option controls whether or not the tooltip includes a histogram representing the y-axis.
+
+#### Show color scale
+
+When you set the **Tooltip mode** to **Single**, this option is displayed. This option controls whether or not the tooltip includes the color scale that's also represented in the legend. When the color scale is included in the tooltip, it shows the hovered value on the scale:
+
+![Heatmap with a tooltip displayed showing the hovered value reflected in the color scale](/media/docs/grafana/panels-visualizations/screenshot-heatmap-tooltip-color-scale-v11.0.png)
 
 ### Legend
 

--- a/docs/sources/panels-visualizations/visualizations/pie-chart/index.md
+++ b/docs/sources/panels-visualizations/visualizations/pie-chart/index.md
@@ -82,8 +82,6 @@ The following example shows a pie chart with **Name** and **Percent** labels dis
 
 ## Tooltip options
 
-Tooltip options control the information overlay that appears when you hover over data points in the visualization.
-
 {{< docs/shared lookup="visualizations/tooltip-options-1.md" source="grafana" version="<GRAFANA_VERSION>" >}}
 
 ## Legend options

--- a/docs/sources/panels-visualizations/visualizations/pie-chart/index.md
+++ b/docs/sources/panels-visualizations/visualizations/pie-chart/index.md
@@ -80,7 +80,11 @@ The following example shows a pie chart with **Name** and **Percent** labels dis
 
 ![Pie chart labels](/static/img/docs/pie-chart-panel/pie-chart-labels-7-5.png)
 
-{{< docs/shared lookup="visualizations/tooltip-options-1.md" source="grafana" version="<GRAFANA VERSION>" >}}
+## Tooltip options
+
+Tooltip options control the information overlay that appears when you hover over data points in the visualization.
+
+{{< docs/shared lookup="visualizations/tooltip-options-1.md" source="grafana" version="<GRAFANA_VERSION>" >}}
 
 ## Legend options
 

--- a/docs/sources/panels-visualizations/visualizations/pie-chart/index.md
+++ b/docs/sources/panels-visualizations/visualizations/pie-chart/index.md
@@ -80,7 +80,7 @@ The following example shows a pie chart with **Name** and **Percent** labels dis
 
 ![Pie chart labels](/static/img/docs/pie-chart-panel/pie-chart-labels-7-5.png)
 
-{{< docs/shared lookup="visualizations/tooltip-mode.md" source="grafana" version="<GRAFANA VERSION>" >}}
+{{< docs/shared lookup="visualizations/tooltip-options-1.md" source="grafana" version="<GRAFANA VERSION>" >}}
 
 ## Legend options
 

--- a/docs/sources/panels-visualizations/visualizations/state-timeline/index.md
+++ b/docs/sources/panels-visualizations/visualizations/state-timeline/index.md
@@ -134,6 +134,12 @@ When the legend option is enabled it can show either the value mappings or the t
 
 {{< docs/shared lookup="visualizations/legend-mode.md" source="grafana" version="<GRAFANA VERSION>" >}}
 
+## Tooltip options
+
+Tooltip options control the information overlay that appears when you hover over data points in the visualization.
+
+{{< docs/shared lookup="visualizations/tooltip-options-1.md" source="grafana" version="<GRAFANA_VERSION>" >}}
+
 {{% docs/reference %}}
 [Color scheme]: "/docs/grafana/ -> /docs/grafana/<GRAFANA VERSION>/panels-visualizations/configure-standard-options#color-scheme"
 [Color scheme]: "/docs/grafana-cloud/ -> /docs/grafana/<GRAFANA VERSION>/panels-visualizations/configure-standard-options#color-scheme"

--- a/docs/sources/panels-visualizations/visualizations/state-timeline/index.md
+++ b/docs/sources/panels-visualizations/visualizations/state-timeline/index.md
@@ -136,8 +136,6 @@ When the legend option is enabled it can show either the value mappings or the t
 
 ## Tooltip options
 
-Tooltip options control the information overlay that appears when you hover over data points in the visualization.
-
 {{< docs/shared lookup="visualizations/tooltip-options-1.md" source="grafana" version="<GRAFANA_VERSION>" >}}
 
 {{% docs/reference %}}

--- a/docs/sources/panels-visualizations/visualizations/status-history/index.md
+++ b/docs/sources/panels-visualizations/visualizations/status-history/index.md
@@ -116,8 +116,6 @@ When the legend option is enabled it can show either the value mappings or the t
 
 ## Tooltip options
 
-Tooltip options control the information overlay that appears when you hover over data points in the visualization.
-
 {{< docs/shared lookup="visualizations/tooltip-options-1.md" source="grafana" version="<GRAFANA_VERSION>" >}}
 
 {{% docs/reference %}}

--- a/docs/sources/panels-visualizations/visualizations/status-history/index.md
+++ b/docs/sources/panels-visualizations/visualizations/status-history/index.md
@@ -114,6 +114,12 @@ When the legend option is enabled it can show either the value mappings or the t
 
 {{< docs/shared lookup="visualizations/legend-mode.md" source="grafana" version="<GRAFANA VERSION>" >}}
 
+## Tooltip options
+
+Tooltip options control the information overlay that appears when you hover over data points in the visualization.
+
+{{< docs/shared lookup="visualizations/tooltip-options-1.md" source="grafana" version="<GRAFANA_VERSION>" >}}
+
 {{% docs/reference %}}
 [Value mappings]: "/docs/grafana/ -> /docs/grafana/<GRAFANA VERSION>/panels-visualizations/configure-value-mappings"
 [Value mappings]: "/docs/grafana-cloud/ -> /docs/grafana/<GRAFANA VERSION>/panels-visualizations/configure-value-mappings"

--- a/docs/sources/panels-visualizations/visualizations/time-series/index.md
+++ b/docs/sources/panels-visualizations/visualizations/time-series/index.md
@@ -54,7 +54,7 @@ The following video guides you through the creation steps and common customizati
 
 Tooltip options control the information overlay that appears when you hover over data points in the graph.
 
-{{< docs/shared lookup="visualizations/tooltip-mode.md" source="grafana" version="<GRAFANA VERSION>" >}}
+{{< docs/shared lookup="visualizations/tooltip-options-2.md" source="grafana" version="<GRAFANA VERSION>" >}}
 
 ### Hover proximity
 

--- a/docs/sources/panels-visualizations/visualizations/time-series/index.md
+++ b/docs/sources/panels-visualizations/visualizations/time-series/index.md
@@ -54,7 +54,7 @@ The following video guides you through the creation steps and common customizati
 
 Tooltip options control the information overlay that appears when you hover over data points in the visualization.
 
-{{< docs/shared lookup="visualizations/tooltip-options-2.md" source="grafana" version="<GRAFANA VERSION>" >}}
+{{< docs/shared lookup="visualizations/tooltip-options-2.md" source="grafana" version="<GRAFANA_VERSION>" >}}
 
 ## Legend options
 

--- a/docs/sources/panels-visualizations/visualizations/time-series/index.md
+++ b/docs/sources/panels-visualizations/visualizations/time-series/index.md
@@ -52,8 +52,6 @@ The following video guides you through the creation steps and common customizati
 
 ## Tooltip options
 
-Tooltip options control the information overlay that appears when you hover over data points in the visualization.
-
 {{< docs/shared lookup="visualizations/tooltip-options-2.md" source="grafana" version="<GRAFANA_VERSION>" >}}
 
 ## Legend options

--- a/docs/sources/panels-visualizations/visualizations/time-series/index.md
+++ b/docs/sources/panels-visualizations/visualizations/time-series/index.md
@@ -52,19 +52,15 @@ The following video guides you through the creation steps and common customizati
 
 ## Tooltip options
 
-Tooltip options control the information overlay that appears when you hover over data points in the graph.
+Tooltip options control the information overlay that appears when you hover over data points in the visualization.
 
 {{< docs/shared lookup="visualizations/tooltip-options-2.md" source="grafana" version="<GRAFANA VERSION>" >}}
 
-### Hover proximity
-
-This option controls how close your cursor must be to a data point before the tooltip appears. Values are in pixels.
-
 ## Legend options
 
-Legend options control the series names and statistics that appear under or to the right of the graph.
+Legend options control the series names and statistics that appear under or to the right of the visualization.
 
-{{< docs/shared lookup="visualizations/legend-mode.md" source="grafana" version="<GRAFANA VERSION>" >}}
+{{< docs/shared lookup="visualizations/legend-mode.md" source="grafana" version="<GRAFANA_VERSION>" >}}
 
 ## Graph styles
 

--- a/docs/sources/panels-visualizations/visualizations/trend/index.md
+++ b/docs/sources/panels-visualizations/visualizations/trend/index.md
@@ -40,8 +40,6 @@ For example, you could represent engine power and torque versus speed where spee
 
 ## Tooltip options
 
-Tooltip options control the information overlay that appears when you hover over data points in the visualization.
-
 {{< docs/shared lookup="visualizations/tooltip-options-2.md" source="grafana" version="<GRAFANA_VERSION>" >}}
 
 {{% docs/reference %}}

--- a/docs/sources/panels-visualizations/visualizations/trend/index.md
+++ b/docs/sources/panels-visualizations/visualizations/trend/index.md
@@ -38,6 +38,12 @@ For example, you could represent engine power and torque versus speed where spee
 
 {{< figure src="/media/docs/grafana/screenshot-grafana-10-0-trend-panel-new-colors.png" max-width="750px" caption="Trend engine power and torque curves" >}}
 
+## Tooltip options
+
+Tooltip options control the information overlay that appears when you hover over data points in the visualization.
+
+{{< docs/shared lookup="visualizations/tooltip-options-2.md" source="grafana" version="<GRAFANA_VERSION>" >}}
+
 {{% docs/reference %}}
 [Time series visualization]: "/docs/grafana/ -> /docs/grafana/<GRAFANA VERSION>/panels-visualizations/visualizations/time-series"
 [Time series visualization]: "/docs/grafana-cloud/ -> /docs/grafana/<GRAFANA VERSION>/panels-visualizations/visualizations/time-series"

--- a/docs/sources/panels-visualizations/visualizations/xy-chart/index.md
+++ b/docs/sources/panels-visualizations/visualizations/xy-chart/index.md
@@ -132,7 +132,7 @@ Set the width of the lines in pixels.
 
 ## Tooltip options
 
-Tooltip options control the information overlay that appears when you hover over data points in the graph.
+Tooltip options control the information overlay that appears when you hover over data points in the visualization.
 
 ### Tooltip mode
 

--- a/docs/sources/panels-visualizations/visualizations/xy-chart/index.md
+++ b/docs/sources/panels-visualizations/visualizations/xy-chart/index.md
@@ -134,7 +134,18 @@ Set the width of the lines in pixels.
 
 Tooltip options control the information overlay that appears when you hover over data points in the graph.
 
-{{< docs/shared lookup="visualizations/tooltip-options-2.md" source="grafana" version="<GRAFANA VERSION>" >}}
+### Tooltip mode
+
+When you hover your cursor over the visualization, Grafana can display tooltips. Choose how tooltips behave.
+
+- **Single -** The hover tooltip shows only a single series, the one that you are hovering over on the visualization.
+- **Hidden -** Do not display the tooltip when you interact with the visualization.
+
+Use an override to hide individual series from the tooltip.
+
+### Max height
+
+Set the maximum height of the tooltip box. The default is 600 pixels.
 
 ## Legend options
 

--- a/docs/sources/shared/visualizations/tooltip-options-1.md
+++ b/docs/sources/shared/visualizations/tooltip-options-1.md
@@ -11,3 +11,15 @@ When you hover your cursor over the visualization, Grafana can display tooltips.
 - **Hidden -** Do not display the tooltip when you interact with the visualization.
 
 Use an override to hide individual series from the tooltip.
+
+### Values sort order
+
+When you set the **Tooltip mode** to **All**, the **Values sort order** option is displayed. This option controls the order in which values are listed in a tooltip. Choose from the following:
+
+- **None** - Grafana automatically sorts the values displayed in a tooltip.
+- **Ascending** - Values in the tooltip are listed from smallest to largest.
+- **Descending** - Values in the tooltip are listed from largest to smallest.
+
+### Max height
+
+Set the maximum height of the tooltip box. The default is 600 pixels.

--- a/docs/sources/shared/visualizations/tooltip-options-1.md
+++ b/docs/sources/shared/visualizations/tooltip-options-1.md
@@ -1,7 +1,7 @@
 ---
 title: Tooltip mode
 comments: |
-  There are two tooltip shared files to cover the most common combinations of options. 
+  There are two tooltip shared files, tooltip-options-1.md and tooltip-options-2.md, to cover the most common combinations of options. 
   Using two shared files ensures that content remains consistent across visualizations that share the same options and users don't have to figure out which options apply to a specific visualization when reading that content. 
   This file is used in the following visualizations: bar chart, pie chart, state timeline, status history
 ---

--- a/docs/sources/shared/visualizations/tooltip-options-1.md
+++ b/docs/sources/shared/visualizations/tooltip-options-1.md
@@ -1,5 +1,7 @@
 ---
 title: Tooltip mode
+comments: |
+  This file is used in the following visualizations: bar chart, pie chart, state timeline, status history
 ---
 
 ### Tooltip mode

--- a/docs/sources/shared/visualizations/tooltip-options-1.md
+++ b/docs/sources/shared/visualizations/tooltip-options-1.md
@@ -1,8 +1,12 @@
 ---
 title: Tooltip mode
 comments: |
+  There are two tooltip shared files to cover the most common combinations of options. 
+  Using two shared files ensures that content remains consistent across visualizations that share the same options and users don't have to figure out which options apply to a specific visualization when reading that content. 
   This file is used in the following visualizations: bar chart, pie chart, state timeline, status history
 ---
+
+Tooltip options control the information overlay that appears when you hover over data points in the visualization.
 
 ### Tooltip mode
 

--- a/docs/sources/shared/visualizations/tooltip-options-2.md
+++ b/docs/sources/shared/visualizations/tooltip-options-2.md
@@ -1,7 +1,7 @@
 ---
 title: Tooltip options
 comments: |
-  There are two tooltip shared files to cover the most common combinations of options. 
+  There are two tooltip shared files, tooltip-options-1.md and tooltip-options-2.md, to cover the most common combinations of options. 
   Using two shared files ensures that content remains consistent across visualizations that share the same options and users don't have to figure out which options apply to a specific visualization when reading that content. 
   This file is used in the following visualizations: candlestick, time series, trend
 ---

--- a/docs/sources/shared/visualizations/tooltip-options-2.md
+++ b/docs/sources/shared/visualizations/tooltip-options-2.md
@@ -1,8 +1,12 @@
 ---
 title: Tooltip options
 comments: |
+  There are two tooltip shared files to cover the most common combinations of options. 
+  Using two shared files ensures that content remains consistent across visualizations that share the same options and users don't have to figure out which options apply to a specific visualization when reading that content. 
   This file is used in the following visualizations: candlestick, time series, trend
 ---
+
+Tooltip options control the information overlay that appears when you hover over data points in the visualization.
 
 ### Tooltip mode
 

--- a/docs/sources/shared/visualizations/tooltip-options-2.md
+++ b/docs/sources/shared/visualizations/tooltip-options-2.md
@@ -7,13 +7,24 @@ title: Tooltip options
 When you hover your cursor over the visualization, Grafana can display tooltips. Choose how tooltips behave.
 
 - **Single -** The hover tooltip shows only a single series, the one that you are hovering over on the visualization.
+- **All -** The hover tooltip shows all series in the visualization. Grafana highlights the series that you are hovering over in bold in the series list in the tooltip.
 - **Hidden -** Do not display the tooltip when you interact with the visualization.
 
 Use an override to hide individual series from the tooltip.
 
-### Max width
+### Values sort order
 
-Set the maximum width of the tooltip box. The default is 300 pixels.
+When you set the **Tooltip mode** to **All**, the **Values sort order** option is displayed. This option controls the order in which values are listed in a tooltip. Choose from the following:
+
+- **None** - Grafana automatically sorts the values displayed in a tooltip.
+- **Ascending** - Values in the tooltip are listed from smallest to largest.
+- **Descending** - Values in the tooltip are listed from largest to smallest.
+
+### Hover proximity
+
+Set the hover proximity (in pixels) to control how close the cursor must be to a data point to trigger the tooltip to display.
+
+![Adding a hover proximity limit for tooltips](/media/docs/grafana/gif-grafana-10-4-hover-proximity.gif)
 
 ### Max height
 

--- a/docs/sources/shared/visualizations/tooltip-options-2.md
+++ b/docs/sources/shared/visualizations/tooltip-options-2.md
@@ -1,5 +1,7 @@
 ---
 title: Tooltip options
+comments: |
+  This file is used in the following visualizations: candlestick, time series, trend
 ---
 
 ### Tooltip mode


### PR DESCRIPTION
- Adds and updates shared files for tooltips content (2)
- Renames `tooltip-mode.md` to `tooltip-options-1.md`
- Adds shared files to appropriate visualizations
- Adds standalone tooltips content to heatmap and xy chart docs
- Adds **Max height** option to **Configure tooltips** page
