### PR TITLE
Alerting: Prevent simplified routing zero duration GroupInterval and RepeatInterval

### DIFF
--- a/pkg/services/ngalert/models/notifications.go
+++ b/pkg/services/ngalert/models/notifications.go
@@ -81,11 +81,11 @@ func (s *NotificationSettings) Validate() error {
 	if s.GroupWait != nil && *s.GroupWait < 0 {
 		return errors.New("group wait must be a positive duration")
 	}
-	if s.GroupInterval != nil && *s.GroupInterval < 0 {
-		return errors.New("group interval must be a positive duration")
+	if s.GroupInterval != nil && *s.GroupInterval <= 0 {
+		return errors.New("group interval must be greater than zero")
 	}
-	if s.RepeatInterval != nil && *s.RepeatInterval < 0 {
-		return errors.New("repeat interval must be a positive duration")
+	if s.RepeatInterval != nil && *s.RepeatInterval <= 0 {
+		return errors.New("repeat interval must be greater than zero")
 	}
 	return nil
 }

--- a/pkg/services/ngalert/models/notifications_test.go
+++ b/pkg/services/ngalert/models/notifications_test.go
@@ -75,6 +75,11 @@ func TestValidate(t *testing.T) {
 			expErrorContains:     "group interval",
 		},
 		{
+			name:                 "group interval zero is invalid",
+			notificationSettings: CopyNotificationSettings(validNotificationSettings(), NSMuts.WithGroupInterval(util.Pointer(0*time.Second))),
+			expErrorContains:     "group interval",
+		},
+		{
 			name:                 "repeat interval empty is valid",
 			notificationSettings: CopyNotificationSettings(validNotificationSettings(), NSMuts.WithRepeatInterval(nil)),
 		},
@@ -85,6 +90,11 @@ func TestValidate(t *testing.T) {
 		{
 			name:                 "repeat interval negative is invalid",
 			notificationSettings: CopyNotificationSettings(validNotificationSettings(), NSMuts.WithRepeatInterval(util.Pointer(-1*time.Second))),
+			expErrorContains:     "repeat interval",
+		},
+		{
+			name:                 "repeat interval zero is invalid",
+			notificationSettings: CopyNotificationSettings(validNotificationSettings(), NSMuts.WithRepeatInterval(util.Pointer(0*time.Second))),
 			expErrorContains:     "repeat interval",
 		},
 	}


### PR DESCRIPTION
**What is this feature?**

Expands simplified routing validation to prevent zero duration GroupInterval and RepeatInterval. Any previously saved zero duration intervals will be skipped as invalid after this is merged and new attempts to save will fail validation.

**Why do we need this feature?**

Zero duration GroupInterval and RepeatInterval are not supported by Alertmanager will cause issues if applied.

**Who is this feature for?**

Users of simplified routing
