### PR TITLE
DashboardScene - Variables: cancel out margin-bottom of placeholder in loading state

### DIFF
--- a/public/app/features/dashboard-scene/settings/variables/VariableEditorForm.tsx
+++ b/public/app/features/dashboard-scene/settings/variables/VariableEditorForm.tsx
@@ -152,7 +152,11 @@ export function VariableEditorForm({
               data-testid={selectors.pages.Dashboard.Settings.Variables.Edit.General.submitButton}
               onClick={onRunQuery}
             >
-              {runQueryState.loading ? <LoadingPlaceholder text="Running query..." /> : `Run query`}
+              {runQueryState.loading ? (
+                <LoadingPlaceholder className={styles.loadingPlaceHolder} text="Running query..." />
+              ) : (
+                `Run query`
+              )}
             </Button>
           )}
         </Stack>
@@ -164,5 +168,8 @@ export function VariableEditorForm({
 const getStyles = (theme: GrafanaTheme2) => ({
   buttonContainer: css({
     marginTop: theme.spacing(2),
+  }),
+  loadingPlaceHolder: css({
+    marginBottom: 0,
   }),
 });


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

This is a bug fix to fix the css issue demonstrated in the screenshot on gf 11 preview. 

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #86570

### Before:
<img width="434" alt="image" src="https://github.com/grafana/grafana/assets/6132021/07bfd0b3-55de-47f1-8bd3-e28dc9b36022">


### After:
<img width="496" alt="image" src="https://github.com/grafana/grafana/assets/6132021/49836723-be14-45d2-af85-e16909768a7f">


**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
