### PR TITLE
GrafanaUI: `PageToolbar.story.tsx` - Replace `VerticalGroup` with `Stack`

### DIFF
--- a/.betterer.results
+++ b/.betterer.results
@@ -838,9 +838,6 @@ exports[`better eslint`] = {
       [0, 0, 0, "Unexpected any. Specify a different type.", "2"],
       [0, 0, 0, "Unexpected any. Specify a different type.", "3"]
     ],
-    "packages/grafana-ui/src/components/PageLayout/PageToolbar.story.tsx:5381": [
-      [0, 0, 0, "\'VerticalGroup\' import from \'@grafana/ui\' is restricted from being used by a pattern. Use Stack component instead.", "0"]
-    ],
     "packages/grafana-ui/src/components/PanelChrome/PanelContext.ts:5381": [
       [0, 0, 0, "Unexpected any. Specify a different type.", "0"],
       [0, 0, 0, "Unexpected any. Specify a different type.", "1"]

--- a/packages/grafana-ui/src/components/PageLayout/PageToolbar.story.tsx
+++ b/packages/grafana-ui/src/components/PageLayout/PageToolbar.story.tsx
@@ -2,7 +2,7 @@ import { action } from '@storybook/addon-actions';
 import { Meta } from '@storybook/react';
 import React from 'react';
 
-import { ToolbarButton, VerticalGroup } from '@grafana/ui';
+import { ToolbarButton, Stack } from '@grafana/ui';
 
 import { StoryExample } from '../../utils/storybook/StoryExample';
 import { IconButton } from '../IconButton/IconButton';
@@ -17,7 +17,7 @@ const meta: Meta<typeof PageToolbar> = {
 
 export const Examples = () => {
   return (
-    <VerticalGroup>
+    <Stack direction="column">
       <StoryExample name="With non clickable title">
         <PageToolbar pageIcon="bell" title="Dashboard">
           <ToolbarButton icon="panel-add" />
@@ -50,7 +50,7 @@ export const Examples = () => {
           <ToolbarButton>Apply</ToolbarButton>
         </PageToolbar>
       </StoryExample>
-    </VerticalGroup>
+    </Stack>
   );
 };
 


### PR DESCRIPTION
**What is this feature?**
This is part of the epic https://github.com/grafana/grafana/issues/85510

**Why do we need this feature?**
To replace deprecated layout components with new ones.

**Who is this feature for?**
Everybody

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**
**Before:**
<img width="1235" alt="Captura de pantalla 2024-04-19 a las 12 07 18" src="https://github.com/grafana/grafana/assets/65417731/ca8a0957-f004-461a-bf9d-07129bbdea33">


**After:**
<img width="1237" alt="Captura de pantalla 2024-04-19 a las 12 07 31" src="https://github.com/grafana/grafana/assets/65417731/6551e83d-8ecf-4991-a66a-033966e0ba47">



Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
