### PR TITLE
Grafana UI: `TagsInput.story.tsx` - Delete unnecessary `VerticalGroup`

### DIFF
--- a/.betterer.results
+++ b/.betterer.results
@@ -958,9 +958,6 @@ exports[`better eslint`] = {
     "packages/grafana-ui/src/components/Tags/Tag.tsx:5381": [
       [0, 0, 0, "Do not use any type assertions.", "0"]
     ],
-    "packages/grafana-ui/src/components/TagsInput/TagsInput.story.tsx:5381": [
-      [0, 0, 0, "\'VerticalGroup\' import from \'../Layout/Layout\' is restricted from being used by a pattern. Use Stack component instead.", "0"]
-    ],
     "packages/grafana-ui/src/components/Text/Text.story.tsx:5381": [
       [0, 0, 0, "\'VerticalGroup\' import from \'../Layout/Layout\' is restricted from being used by a pattern. Use Stack component instead.", "0"]
     ],

--- a/packages/grafana-ui/src/components/TagsInput/TagsInput.story.tsx
+++ b/packages/grafana-ui/src/components/TagsInput/TagsInput.story.tsx
@@ -2,7 +2,6 @@ import { Meta, StoryFn } from '@storybook/react';
 import React, { useState } from 'react';
 
 import { StoryExample } from '../../utils/storybook/StoryExample';
-import { VerticalGroup } from '../Layout/Layout';
 
 import { TagsInput } from './TagsInput';
 import mdx from './TagsInput.mdx';
@@ -28,11 +27,9 @@ export const Basic: StoryFn<typeof TagsInput> = (props) => {
 export const WithManyTags = () => {
   const [tags, setTags] = useState<string[]>(['dashboard', 'prod', 'server', 'frontend', 'game', 'kubernetes']);
   return (
-    <VerticalGroup>
-      <StoryExample name="With many tags">
-        <TagsInput tags={tags} onChange={setTags} />
-      </StoryExample>
-    </VerticalGroup>
+    <StoryExample name="With many tags">
+      <TagsInput tags={tags} onChange={setTags} />
+    </StoryExample>
   );
 };
 


### PR DESCRIPTION
**What is this feature?**
This is part of the epic https://github.com/grafana/grafana/issues/85510

**Why do we need this feature?**
To replace deprecated layout components with new ones.

**Who is this feature for?**
Everybody

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**
**Before:**
<img width="1239" alt="Captura de pantalla 2024-04-19 a las 12 15 00" src="https://github.com/grafana/grafana/assets/65417731/b4e21008-5ce7-446c-8a33-a274ca9be7df">


**After:**
<img width="1235" alt="Captura de pantalla 2024-04-19 a las 12 15 13" src="https://github.com/grafana/grafana/assets/65417731/4408382c-dc80-4820-bde3-af76fac92007">



Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
