### PR TITLE
Grafana UI: `EmotionPerfTest` - Replace `VerticalGroup` with `Stack`

### DIFF
--- a/.betterer.results
+++ b/.betterer.results
@@ -964,9 +964,6 @@ exports[`better eslint`] = {
     "packages/grafana-ui/src/components/Text/Text.story.tsx:5381": [
       [0, 0, 0, "\'VerticalGroup\' import from \'../Layout/Layout\' is restricted from being used by a pattern. Use Stack component instead.", "0"]
     ],
-    "packages/grafana-ui/src/components/ThemeDemos/EmotionPerfTest.tsx:5381": [
-      [0, 0, 0, "\'VerticalGroup\' import from \'../Layout/Layout\' is restricted from being used by a pattern. Use Stack component instead.", "0"]
-    ],
     "packages/grafana-ui/src/components/ValuePicker/ValuePicker.tsx:5381": [
       [0, 0, 0, "Use data-testid for E2E selectors instead of aria-label", "0"]
     ],

--- a/packages/grafana-ui/src/components/ThemeDemos/EmotionPerfTest.tsx
+++ b/packages/grafana-ui/src/components/ThemeDemos/EmotionPerfTest.tsx
@@ -9,13 +9,13 @@ import { GrafanaTheme2 } from '@grafana/data';
 
 import { useStyles2, useTheme2 } from '../../themes';
 import { Button } from '../Button';
-import { VerticalGroup } from '../Layout/Layout';
+import { Stack } from '../Layout/Stack/Stack';
 
 export function EmotionPerfTest() {
   console.log('process.env.NODE_ENV', process.env.NODE_ENV);
 
   return (
-    <VerticalGroup>
+    <Stack direction="column">
       <div>Emotion performance tests</div>
       <TestScenario name="No styles" Component={NoStyles} />
       <TestScenario name="inline emotion/css" Component={InlineEmotionCSS} />
@@ -24,7 +24,7 @@ export function EmotionPerfTest() {
       <TestScenario name="useStyles with css prop" Component={UseStylesWithCSSProp} />
       <TestScenario name="useStyles with conditional css prop" Component={UseStylesWithConditionalCSS} />
       <TestScenario name="useStyles with conditional classnames" Component={UseStylesWithConditionalClassNames} />
-    </VerticalGroup>
+    </Stack>
   );
 }
 


### PR DESCRIPTION
**What is this feature?**
This is part of the epic https://github.com/grafana/grafana/issues/85510

**Why do we need this feature?**
To replace deprecated layout components with new ones.

**Who is this feature for?**
Everybody

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**
**Before:**
<img width="706" alt="Captura de pantalla 2024-04-19 a las 12 33 01" src="https://github.com/grafana/grafana/assets/65417731/22d5878b-b154-4dc6-b2be-a004ac490b47">


**After:**
<img width="703" alt="Captura de pantalla 2024-04-19 a las 12 33 13" src="https://github.com/grafana/grafana/assets/65417731/cac01797-9192-465f-99b8-3e16a728c1ad">

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
