### PR TITLE
Explore (bugfix): Expanded section state

### DIFF
--- a/public/app/features/explore/ContentOutline/ContentOutline.tsx
+++ b/public/app/features/explore/ContentOutline/ContentOutline.tsx
@@ -86,7 +86,7 @@ export function ContentOutline({ scroller, panelId }: { scroller: HTMLElement | 
         return childTop && childTop >= offsetTop;
       });
 
-      if (activeChild) {
+      if (activeChild && isCollapsible(item)) {
         setActiveSectionChildId(activeChild.id);
         setActiveSectionId(item.id);
         break;
@@ -95,6 +95,10 @@ export function ContentOutline({ scroller, panelId }: { scroller: HTMLElement | 
       if (activeItem) {
         setActiveSectionId(activeItem.id);
         setActiveSectionChildId(undefined);
+        setSectionsExpanded((prev) => ({
+          ...prev,
+          [item.id]: false,
+        }));
         break;
       }
     }


### PR DESCRIPTION
**What is this feature?**

Fixes the issue in the content outline where an expanded section that merges a single child (doesn't nest it) is expanded and is left with only one child after the second child is deleted.

How to reproduce:
1. Have two queries in Explore
2. Expand the Queries section in the content outline
3. Delete one query
4. This will result in the Queries item never highlighting 

Here's the video of the issue:

https://github.com/grafana/grafana/assets/58232930/4fa6d11e-9af4-4720-8a9f-dfafa0850d18



After:

https://github.com/grafana/grafana/assets/58232930/07b209cc-7a83-4ea6-9cc7-7c373e42f119






Please check that:
- [ ] It works as expected from a user's perspective.

