### PR TITLE
Dashboard scenes: fix textbox value only set to first character of default value

### DIFF
--- a/public/app/features/dashboard-scene/serialization/transformSaveModelToScene.ts
+++ b/public/app/features/dashboard-scene/serialization/transformSaveModelToScene.ts
@@ -392,9 +392,20 @@ export function createSceneVariableFromVariableModel(variable: TypedVariableMode
       hide: variable.hide,
     });
   } else if (variable.type === 'textbox') {
+    let val;
+    if (!variable?.current?.value) {
+      val = variable.query;
+    } else {
+      if (typeof variable.current.value === 'string') {
+        val = variable.current.value;
+      } else {
+        val = variable.current.value[0];
+      }
+    }
+
     return new TextBoxVariable({
       ...commonProperties,
-      value: variable?.current?.value?.[0] ?? variable.query,
+      value: val,
       skipUrlSync: variable.skipUrlSync,
       hide: variable.hide,
     });


### PR DESCRIPTION
**What is this feature?**
This fixes the issue where only the first character of the default value is set in the textbox.

The type of the value can be either a string or an array of strings. The code assumed it would always be an array of strings.

There is a bit of weirdness guarding against current.value being undefined and using query instead. Couldn't figure out why/if this was needed, so decided to leave it in place.

**Which issue(s) does this PR fix?**:
Fixes #86435