### PR TITLE
Alerting: Remove isDefault field from receivers (Alertmanager configuration)

### DIFF
--- a/pkg/services/ngalert/api/api_alertmanager_test.go
+++ b/pkg/services/ngalert/api/api_alertmanager_test.go
@@ -829,7 +829,6 @@ var validConfig = `{
 				"uid": "",
 				"name": "email receiver",
 				"type": "email",
-				"isDefault": true,
 				"settings": {
 					"addresses": "<example@email.com>"
 				}
@@ -937,7 +936,6 @@ var validConfigWithSecureSetting = `{
 				"uid": "",
 				"name": "email receiver",
 				"type": "email",
-				"isDefault": true,
 				"settings": {
 					"addresses": "<example@email.com>"
 				}
@@ -969,7 +967,6 @@ var brokenConfig = `
 				"uid": "abc",
 				"name": "default-email",
 				"type": "email",
-				"isDefault": true,
 				"settings": {}
 			}]
 		}]

--- a/pkg/services/ngalert/api/api_provisioning_test.go
+++ b/pkg/services/ngalert/api/api_provisioning_test.go
@@ -1981,7 +1981,6 @@ var testConfig = `
 				"uid": "email-uid",
 				"name": "email receiver",
 				"type": "email",
-				"isDefault": true,
 				"settings": {
 					"addresses": "<example@email.com>"
 				}

--- a/pkg/services/ngalert/api/test-data/post-user-config.json
+++ b/pkg/services/ngalert/api/test-data/post-user-config.json
@@ -19,7 +19,6 @@
                     {
                         "name": "an alert manager receiver",
                         "type": "prometheus-alertmanager",
-                        "isDefault": false,
                         "sendReminder": false,
                         "disableResolveMessage": false,
                         "frequency": "5m",
@@ -38,7 +37,6 @@
                     {
                         "name": "a dingding receiver",
                         "type": "dingding",
-                        "isDefault": false,
                         "sendReminder": false,
                         "disableResolveMessage": false,
                         "frequency": "5m",
@@ -55,7 +53,6 @@
                     {
                         "name": "a discord receiver",
                         "type": "discord",
-                        "isDefault": false,
                         "sendReminder": false,
                         "disableResolveMessage": false,
                         "frequency": "5m",
@@ -72,7 +69,6 @@
                     {
                         "name": "an email receiver",
                         "type": "email",
-                        "isDefault": false,
                         "sendReminder": false,
                         "disableResolveMessage": false,
                         "frequency": "5m",
@@ -89,7 +85,6 @@
                     {
                         "name": "a googlechat receiver",
                         "type": "googlechat",
-                        "isDefault": false,
                         "sendReminder": false,
                         "disableResolveMessage": false,
                         "frequency": "5m",
@@ -105,7 +100,6 @@
                     {
                         "name": "a hipchat receiver",
                         "type": "hipchat",
-                        "isDefault": false,
                         "sendReminder": false,
                         "disableResolveMessage": false,
                         "frequency": "5m",
@@ -123,7 +117,6 @@
                     {
                         "name": "a kafka receiver",
                         "type": "kafka",
-                        "isDefault": false,
                         "sendReminder": false,
                         "disableResolveMessage": false,
                         "frequency": "5m",
@@ -140,7 +133,6 @@
                     {
                         "name": "a line receiver",
                         "type": "line",
-                        "isDefault": false,
                         "sendReminder": false,
                         "disableResolveMessage": false,
                         "frequency": "5m",
@@ -152,7 +144,6 @@
                     {
                         "name": "a opsgenie receiver",
                         "type": "opsgenie",
-                        "isDefault": false,
                         "sendReminder": false,
                         "disableResolveMessage": false,
                         "frequency": "5m",
@@ -164,7 +155,6 @@
                     {
                         "name": "a pagerduty receiver",
                         "type": "pagerduty",
-                        "isDefault": false,
                         "sendReminder": false,
                         "disableResolveMessage": false,
                         "frequency": "5m",
@@ -181,7 +171,6 @@
                     {
                         "name": "a pushover receiver",
                         "type": "pushover",
-                        "isDefault": false,
                         "sendReminder": false,
                         "disableResolveMessage": false,
                         "frequency": "5m",
@@ -208,7 +197,6 @@
                     {
                         "name": "a sensu receiver",
                         "type": "sensu",
-                        "isDefault": false,
                         "sendReminder": false,
                         "disableResolveMessage": false,
                         "frequency": "5m",
@@ -227,7 +215,6 @@
                     {
                         "name": "a sensugo receiver",
                         "type": "sensugo",
-                        "isDefault": false,
                         "sendReminder": false,
                         "disableResolveMessage": false,
                         "frequency": "5m",
@@ -249,7 +236,6 @@
                     {
                         "name": "a slack receiver",
                         "type": "slack",
-                        "isDefault": false,
                         "sendReminder": false,
                         "disableResolveMessage": false,
                         "frequency": "5m",
@@ -273,7 +259,6 @@
                     {
                         "name": "a teams receiver",
                         "type": "teams",
-                        "isDefault": false,
                         "sendReminder": false,
                         "disableResolveMessage": false,
                         "frequency": "5m",
@@ -289,7 +274,6 @@
                     {
                         "name": "a telegram receiver",
                         "type": "telegram",
-                        "isDefault": false,
                         "sendReminder": false,
                         "disableResolveMessage": false,
                         "frequency": "5m",
@@ -307,7 +291,6 @@
                     {
                         "name": "a threema receiver",
                         "type": "threema",
-                        "isDefault": false,
                         "sendReminder": false,
                         "disableResolveMessage": false,
                         "frequency": "5m",
@@ -326,7 +309,6 @@
                     {
                         "name": "a victorops receiver",
                         "type": "victorops",
-                        "isDefault": false,
                         "sendReminder": false,
                         "disableResolveMessage": false,
                         "frequency": "5m",
@@ -342,7 +324,6 @@
                     {
                         "name": "a webhook receiver",
                         "type": "webhook",
-                        "isDefault": false,
                         "sendReminder": false,
                         "disableResolveMessage": false,
                         "frequency": "5m",

--- a/pkg/services/ngalert/api/test-data/test-receiver.json
+++ b/pkg/services/ngalert/api/test-data/test-receiver.json
@@ -3,7 +3,6 @@
         "uid": "alertmanager UID",
         "name": "an alert manager receiver",
         "type": "prometheus-alertmanager",
-        "isDefault": false,
         "sendReminder": false,
         "disableResolveMessage": false,
         "frequency": "5m",

--- a/pkg/services/ngalert/notifier/multiorg_alertmanager_remote_test.go
+++ b/pkg/services/ngalert/notifier/multiorg_alertmanager_remote_test.go
@@ -268,7 +268,6 @@ var validConfig = `{
 				"uid": "",
 				"name": "email receiver",
 				"type": "email",
-				"isDefault": true,
 				"settings": {
 					"addresses": "<example@email.com>"
 				}

--- a/pkg/services/ngalert/notifier/multiorg_alertmanager_test.go
+++ b/pkg/services/ngalert/notifier/multiorg_alertmanager_test.go
@@ -426,7 +426,6 @@ var brokenConfig = `
 				"uid": "",
 				"name": "slack receiver",
 				"type": "slack",
-				"isDefault": true,
 				"settings": {
 					"addresses": "<example@email.com>"
 					"url": "�r_��q/b�����p@ⱎȏ =��@ӹtd>Rú�H��           �;�@Uf��0�\k2*jh�}Íu�)"2�F6]�}r��R�b�d�J;��S퓧��$��",

--- a/pkg/services/ngalert/provisioning/templates_test.go
+++ b/pkg/services/ngalert/provisioning/templates_test.go
@@ -414,7 +414,6 @@ var configWithTemplates = `
 				"uid": "",
 				"name": "email receiver",
 				"type": "email",
-				"isDefault": true,
 				"settings": {
 					"addresses": "<example@email.com>"
 				}
@@ -435,7 +434,6 @@ var brokenConfig = `
 				"uid": "abc",
 				"name": "default-email",
 				"type": "email",
-				"isDefault": true,
 				"settings": {}
 			}]
 		}]

--- a/pkg/setting/setting_unified_alerting.go
+++ b/pkg/setting/setting_unified_alerting.go
@@ -34,7 +34,6 @@ const (
 				"uid": "",
 				"name": "email receiver",
 				"type": "email",
-				"isDefault": true,
 				"settings": {
 					"addresses": "<example@email.com>"
 				}


### PR DESCRIPTION
We don't use this field, it's not part of our receiver configuration so it's just ignored when parsing a configuration.