### PR TITLE
Alerting: Fix typo ('Alert manager' -> 'Alertmanager')

### DIFF
--- a/public/app/features/alerting/unified/components/rule-editor/alert-rule-form/simplifiedRouting/AlertManagerRouting.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/alert-rule-form/simplifiedRouting/AlertManagerRouting.tsx
@@ -62,7 +62,7 @@ export function AlertManagerManualRouting({ alertManager }: AlertManagerManualRo
       <Stack direction="row" alignItems="center">
         <div className={styles.firstAlertManagerLine}></div>
         <div className={styles.alertManagerName}>
-          Alert manager:
+          Alertmanager:
           <img src={alertManager.imgUrl} alt="Alert manager logo" className={styles.img} />
           {alertManagerName}
         </div>

--- a/public/app/features/alerting/unified/components/rule-editor/notificaton-preview/NotificationPreview.test.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/notificaton-preview/NotificationPreview.test.tsx
@@ -42,8 +42,8 @@ const ui = {
   routeMatchingInstances: byTestId('route-matching-instance'),
   loadingIndicator: byText(/Loading/),
   previewButton: byRole('button', { name: /preview routing/i }),
-  grafanaAlertManagerLabel: byText(/alert manager:grafana/i),
-  otherAlertManagerLabel: byText(/alert manager:other_am/i),
+  grafanaAlertManagerLabel: byText(/alertmanager:grafana/i),
+  otherAlertManagerLabel: byText(/alertmanager:other_am/i),
   seeDetails: byText(/see details/i),
   details: {
     title: byRole('heading', { name: /routing details/i }),

--- a/public/app/features/alerting/unified/components/rule-editor/notificaton-preview/NotificationPreviewByAlertManager.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/notificaton-preview/NotificationPreviewByAlertManager.tsx
@@ -48,7 +48,7 @@ function NotificationPreviewByAlertManager({
           <div className={styles.firstAlertManagerLine}></div>
           <div className={styles.alertManagerName}>
             {' '}
-            Alert manager:
+            Alertmanager:
             <img src={alertManagerSource.imgUrl} alt="" className={styles.img} />
             {alertManagerSource.name}
           </div>


### PR DESCRIPTION
This PR replaces "Alert manager" with "Alertmanager" in simplified routing and notification previews.

![image](https://github.com/grafana/grafana/assets/41638679/4d783b4e-c13f-46f2-b962-7cf82c5f10b2)
