### PR TITLE
Chore: `ChangePassword` -  Replace `VerticalGroup` with `Stack`

### DIFF
--- a/.betterer.results
+++ b/.betterer.results
@@ -1136,9 +1136,6 @@ exports[`better eslint`] = {
     "public/app/core/components/DynamicImports/SafeDynamicImport.tsx:5381": [
       [0, 0, 0, "Unexpected any. Specify a different type.", "0"]
     ],
-    "public/app/core/components/ForgottenPassword/ChangePassword.tsx:5381": [
-      [0, 0, 0, "\'VerticalGroup\' import from \'@grafana/ui\' is restricted from being used by a pattern. Use Stack component instead.", "0"]
-    ],
     "public/app/core/components/GraphNG/GraphNG.tsx:5381": [
       [0, 0, 0, "Unexpected any. Specify a different type.", "0"],
       [0, 0, 0, "Unexpected any. Specify a different type.", "1"],

--- a/public/app/core/components/ForgottenPassword/ChangePassword.tsx
+++ b/public/app/core/components/ForgottenPassword/ChangePassword.tsx
@@ -3,7 +3,7 @@ import { useForm } from 'react-hook-form';
 
 import { selectors } from '@grafana/e2e-selectors';
 import { config } from '@grafana/runtime';
-import { Tooltip, Field, VerticalGroup, Button, Alert, useStyles2 } from '@grafana/ui';
+import { Tooltip, Field, Button, Alert, useStyles2, Stack } from '@grafana/ui';
 
 import { getStyles } from '../Login/LoginForm';
 import { PasswordField } from '../PasswordField/PasswordField';
@@ -81,7 +81,7 @@ export const ChangePassword = ({ onSubmit, onSkip, showDefaultPasswordWarning }:
           autoComplete="new-password"
         />
       </Field>
-      <VerticalGroup>
+      <Stack direction="column">
         <Button type="submit" className={styles.submitButton}>
           Submit
         </Button>
@@ -96,7 +96,7 @@ export const ChangePassword = ({ onSubmit, onSkip, showDefaultPasswordWarning }:
             </Button>
           </Tooltip>
         )}
-      </VerticalGroup>
+      </Stack>
     </form>
   );
 };


### PR DESCRIPTION
**What is this feature?**
This is part of the epic https://github.com/grafana/grafana/issues/85510

**Why do we need this feature?**
To replace deprecated layout components with new ones.

**Who is this feature for?**
Everybody

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**
**Before:**
<img width="533" alt="Captura de pantalla 2024-04-19 a las 16 14 16" src="https://github.com/grafana/grafana/assets/65417731/5ec9b2d0-6529-4ece-8865-e368138f1f80">

**After:**
<img width="506" alt="Captura de pantalla 2024-04-19 a las 16 15 33" src="https://github.com/grafana/grafana/assets/65417731/d186adb9-957f-4b5f-b5f4-09dcecc030e8">


Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
