### PR TITLE
Chore: Replace `VerticalGroup` in `OrgDetailsPage` and `BenchmarksPage`

### DIFF
--- a/.betterer.results
+++ b/.betterer.results
@@ -3973,9 +3973,6 @@ exports[`better eslint`] = {
     "public/app/features/migrate-to-cloud/api/index.ts:5381": [
       [0, 0, 0, "Do not use export all (\`export * from ...\`)", "0"]
     ],
-    "public/app/features/org/OrgDetailsPage.tsx:5381": [
-      [0, 0, 0, "\'VerticalGroup\' import from \'@grafana/ui\' is restricted from being used by a pattern. Use Stack component instead.", "0"]
-    ],
     "public/app/features/org/state/actions.ts:5381": [
       [0, 0, 0, "Unexpected any. Specify a different type.", "0"]
     ],

--- a/.betterer.results
+++ b/.betterer.results
@@ -4232,9 +4232,6 @@ exports[`better eslint`] = {
       [0, 0, 0, "Unexpected any. Specify a different type.", "9"],
       [0, 0, 0, "Unexpected any. Specify a different type.", "10"]
     ],
-    "public/app/features/sandbox/BenchmarksPage.tsx:5381": [
-      [0, 0, 0, "\'VerticalGroup\' import from \'@grafana/ui\' is restricted from being used by a pattern. Use Stack component instead.", "0"]
-    ],
     "public/app/features/search/page/components/ActionRow.tsx:5381": [
       [0, 0, 0, "Styles should be written using objects.", "0"],
       [0, 0, 0, "Styles should be written using objects.", "1"]

--- a/public/app/features/org/OrgDetailsPage.tsx
+++ b/public/app/features/org/OrgDetailsPage.tsx
@@ -1,7 +1,7 @@
 import React, { PureComponent } from 'react';
 import { ConnectedProps, connect } from 'react-redux';
 
-import { VerticalGroup } from '@grafana/ui';
+import { Stack } from '@grafana/ui';
 import { Page } from 'app/core/components/Page/Page';
 import SharedPreferences from 'app/core/components/SharedPreferences/SharedPreferences';
 import { appEvents, contextSrv } from 'app/core/core';
@@ -51,7 +51,7 @@ export class OrgDetailsPage extends PureComponent<Props> {
       <Page navModel={navModel}>
         <Page.Contents isLoading={isLoading}>
           {!isLoading && (
-            <VerticalGroup spacing="lg">
+            <Stack direction="column" gap={3}>
               {canReadOrg && <OrgProfile onSubmit={this.onUpdateOrganization} orgName={organization.name} />}
               {canReadPreferences && (
                 <SharedPreferences
@@ -61,7 +61,7 @@ export class OrgDetailsPage extends PureComponent<Props> {
                   onConfirm={this.handleConfirm}
                 />
               )}
-            </VerticalGroup>
+            </Stack>
           )}
         </Page.Contents>
       </Page>

--- a/public/app/features/sandbox/BenchmarksPage.tsx
+++ b/public/app/features/sandbox/BenchmarksPage.tsx
@@ -1,14 +1,9 @@
 import React from 'react';
 
-import { VerticalGroup } from '@grafana/ui';
 import { EmotionPerfTest } from '@grafana/ui/src/components/ThemeDemos/EmotionPerfTest';
 
 export const BenchmarksPage = () => {
-  return (
-    <VerticalGroup>
-      <EmotionPerfTest />
-    </VerticalGroup>
-  );
+  return <EmotionPerfTest />;
 };
 
 export default BenchmarksPage;


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

Replaces the deprecated `VerticalGroup` with the new `Stack` component (in the `BenchmarksPage` case it is not needed)

**Why do we need this feature?**

To remove the use of a deprecated component.

**Who is this feature for?**

Everyone

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes part of https://github.com/grafana/grafana/issues/85510

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
