### PR TITLE
Plugin Extensions: Only load app plugins when necessary

### DIFF
--- a/e2e/test-plugins/grafana-extensionstest-app/README.md
+++ b/e2e/test-plugins/grafana-extensionstest-app/README.md
@@ -32,4 +32,4 @@ Note that this plugin extends the `@grafana/plugin-configs` configs which is why
 
 ## Run Playwright tests
 
-- `yarn playwright --project extensions-test-app`
+- `yarn playwright test --project extensions-test-app`

--- a/public/app/AppWrapper.tsx
+++ b/public/app/AppWrapper.tsx
@@ -22,6 +22,7 @@ import { RouteDescriptor } from './core/navigation/types';
 import { ThemeProvider } from './core/utils/ConfigProvider';
 import { LiveConnectionWarning } from './features/live/LiveConnectionWarning';
 import { ExtensionRegistriesProvider } from './features/plugins/extensions/ExtensionRegistriesContext';
+import { pluginExtensionRegistries } from './features/plugins/extensions/registry/setup';
 import { ExperimentalSplitPaneRouterWrapper, RouterWrapper } from './routes/RoutesWrapper';
 
 interface AppWrapperProps {
@@ -104,7 +105,7 @@ export class AppWrapper extends Component<AppWrapperProps, AppWrapperState> {
                 <GlobalStyles />
                 <MaybeTimeRangeProvider>
                   <SidecarContext_EXPERIMENTAL.Provider value={sidecarServiceSingleton_EXPERIMENTAL}>
-                    <ExtensionRegistriesProvider registries={app.pluginExtensionsRegistries}>
+                    <ExtensionRegistriesProvider registries={pluginExtensionRegistries}>
                       <div className="grafana-app">
                         {config.featureToggles.appSidecar ? (
                           <ExperimentalSplitPaneRouterWrapper {...routerWrapperProps} />

--- a/public/app/features/plugins/components/AppRootPage.test.tsx
+++ b/public/app/features/plugins/components/AppRootPage.test.tsx
@@ -11,7 +11,9 @@ import { contextSrv } from 'app/core/services/context_srv';
 import { Echo } from 'app/core/services/echo/Echo';
 
 import { ExtensionRegistriesProvider } from '../extensions/ExtensionRegistriesContext';
-import { setupPluginExtensionRegistries } from '../extensions/registry/setup';
+import { AddedComponentsRegistry } from '../extensions/registry/AddedComponentsRegistry';
+import { AddedLinksRegistry } from '../extensions/registry/AddedLinksRegistry';
+import { ExposedComponentsRegistry } from '../extensions/registry/ExposedComponentsRegistry';
 import { getPluginSettings } from '../pluginSettings';
 import { importAppPlugin } from '../plugin_loader';
 
@@ -86,7 +88,11 @@ function renderUnderRouter(page = '') {
 
   appPluginNavItem.parentItem = appsSection;
 
-  const registries = setupPluginExtensionRegistries();
+  const registries = {
+    addedComponentsRegistry: new AddedComponentsRegistry(),
+    exposedComponentsRegistry: new ExposedComponentsRegistry(),
+    addedLinksRegistry: new AddedLinksRegistry(),
+  };
   const pagePath = page ? `/${page}` : '';
   const route = {
     path: `/a/:pluginId/*`,

--- a/public/app/features/plugins/extensions/registry/setup.ts
+++ b/public/app/features/plugins/extensions/registry/setup.ts
@@ -5,17 +5,17 @@ import { AddedLinksRegistry } from './AddedLinksRegistry';
 import { ExposedComponentsRegistry } from './ExposedComponentsRegistry';
 import { PluginExtensionRegistries } from './types';
 
-export function setupPluginExtensionRegistries(): PluginExtensionRegistries {
-  const pluginExtensionsRegistries = {
-    addedComponentsRegistry: new AddedComponentsRegistry(),
-    exposedComponentsRegistry: new ExposedComponentsRegistry(),
-    addedLinksRegistry: new AddedLinksRegistry(),
-  };
+export const addedComponentsRegistry = new AddedComponentsRegistry();
+export const exposedComponentsRegistry = new ExposedComponentsRegistry();
+export const addedLinksRegistry = new AddedLinksRegistry();
+export const pluginExtensionRegistries: PluginExtensionRegistries = {
+  addedComponentsRegistry,
+  exposedComponentsRegistry,
+  addedLinksRegistry,
+};
 
-  pluginExtensionsRegistries.addedLinksRegistry.register({
-    pluginId: 'grafana',
-    configs: getCoreExtensionConfigurations(),
-  });
-
-  return pluginExtensionsRegistries;
-}
+// Registering core extensions
+addedLinksRegistry.register({
+  pluginId: 'grafana',
+  configs: getCoreExtensionConfigurations(),
+});

--- a/public/app/features/plugins/extensions/useLoadAppPlugins.tsx
+++ b/public/app/features/plugins/extensions/useLoadAppPlugins.tsx
@@ -1,0 +1,19 @@
+import { useAsync } from 'react-use';
+
+import { preloadPlugins } from '../pluginPreloader';
+
+import { getAppPluginConfigs } from './utils';
+
+export function useLoadAppPlugins(pluginIds: string[] = []): { isLoading: boolean } {
+  const { loading: isLoading } = useAsync(async () => {
+    const appConfigs = getAppPluginConfigs(pluginIds);
+
+    if (!appConfigs.length) {
+      return;
+    }
+
+    await preloadPlugins(appConfigs);
+  });
+
+  return { isLoading };
+}

--- a/public/app/features/plugins/extensions/usePluginComponent.test.tsx
+++ b/public/app/features/plugins/extensions/usePluginComponent.test.tsx
@@ -7,11 +7,15 @@ import { config } from '@grafana/runtime';
 import { ExtensionRegistriesProvider } from './ExtensionRegistriesContext';
 import { log } from './logs/log';
 import { resetLogMock } from './logs/testUtils';
-import { setupPluginExtensionRegistries } from './registry/setup';
+import { AddedComponentsRegistry } from './registry/AddedComponentsRegistry';
+import { AddedLinksRegistry } from './registry/AddedLinksRegistry';
+import { ExposedComponentsRegistry } from './registry/ExposedComponentsRegistry';
 import { PluginExtensionRegistries } from './registry/types';
+import { useLoadAppPlugins } from './useLoadAppPlugins';
 import { usePluginComponent } from './usePluginComponent';
 import { isGrafanaDevMode, wrapWithPluginContext } from './utils';
 
+jest.mock('./useLoadAppPlugins');
 jest.mock('app/features/plugins/pluginSettings', () => ({
   getPluginSettings: jest.fn().mockResolvedValue({
     id: 'my-app-plugin',
@@ -83,7 +87,12 @@ describe('usePluginComponent()', () => {
   };
 
   beforeEach(() => {
-    registries = setupPluginExtensionRegistries();
+    registries = {
+      addedComponentsRegistry: new AddedComponentsRegistry(),
+      exposedComponentsRegistry: new ExposedComponentsRegistry(),
+      addedLinksRegistry: new AddedLinksRegistry(),
+    };
+    jest.mocked(useLoadAppPlugins).mockReturnValue({ isLoading: false });
     jest.mocked(isGrafanaDevMode).mockReturnValue(false);
     resetLogMock(log);
 

--- a/public/app/features/plugins/extensions/usePluginComponent.tsx
+++ b/public/app/features/plugins/extensions/usePluginComponent.tsx
@@ -7,7 +7,8 @@ import { UsePluginComponentResult } from '@grafana/runtime';
 import { useExposedComponentsRegistry } from './ExtensionRegistriesContext';
 import * as errors from './errors';
 import { log } from './logs/log';
-import { isGrafanaDevMode, wrapWithPluginContext } from './utils';
+import { useLoadAppPlugins } from './useLoadAppPlugins';
+import { getExposedComponentPluginDependencies, isGrafanaDevMode, wrapWithPluginContext } from './utils';
 import { isExposedComponentDependencyMissing } from './validators';
 
 // Returns a component exposed by a plugin.
@@ -16,10 +17,18 @@ export function usePluginComponent<Props extends object = {}>(id: string): UsePl
   const registry = useExposedComponentsRegistry();
   const registryState = useObservable(registry.asObservable());
   const pluginContext = usePluginContext();
+  const { isLoading: isLoadingAppPlugins } = useLoadAppPlugins(getExposedComponentPluginDependencies(id));
 
   return useMemo(() => {
     // For backwards compatibility we don't enable restrictions in production or when the hook is used in core Grafana.
     const enableRestrictions = isGrafanaDevMode() && pluginContext;
+
+    if (isLoadingAppPlugins) {
+      return {
+        isLoading: true,
+        component: null,
+      };
+    }
 
     if (!registryState?.[id]) {
       return {
@@ -47,5 +56,5 @@ export function usePluginComponent<Props extends object = {}>(id: string): UsePl
       isLoading: false,
       component: wrapWithPluginContext(registryItem.pluginId, registryItem.component, componentLog),
     };
-  }, [id, pluginContext, registryState]);
+  }, [id, pluginContext, registryState, isLoadingAppPlugins]);
 }

--- a/public/app/features/plugins/extensions/usePluginComponents.test.tsx
+++ b/public/app/features/plugins/extensions/usePluginComponents.test.tsx
@@ -6,11 +6,15 @@ import { PluginContextProvider, PluginMeta, PluginType } from '@grafana/data';
 import { ExtensionRegistriesProvider } from './ExtensionRegistriesContext';
 import { log } from './logs/log';
 import { resetLogMock } from './logs/testUtils';
-import { setupPluginExtensionRegistries } from './registry/setup';
+import { AddedComponentsRegistry } from './registry/AddedComponentsRegistry';
+import { AddedLinksRegistry } from './registry/AddedLinksRegistry';
+import { ExposedComponentsRegistry } from './registry/ExposedComponentsRegistry';
 import { PluginExtensionRegistries } from './registry/types';
+import { useLoadAppPlugins } from './useLoadAppPlugins';
 import { usePluginComponents } from './usePluginComponents';
 import { isGrafanaDevMode, wrapWithPluginContext } from './utils';
 
+jest.mock('./useLoadAppPlugins');
 jest.mock('app/features/plugins/pluginSettings', () => ({
   getPluginSettings: jest.fn().mockResolvedValue({
     id: 'my-app-plugin',
@@ -50,8 +54,14 @@ describe('usePluginComponents()', () => {
 
   beforeEach(() => {
     jest.mocked(isGrafanaDevMode).mockReturnValue(false);
+    jest.mocked(useLoadAppPlugins).mockReturnValue({ isLoading: false });
+
     resetLogMock(log);
-    registries = setupPluginExtensionRegistries();
+    registries = {
+      addedComponentsRegistry: new AddedComponentsRegistry(),
+      exposedComponentsRegistry: new ExposedComponentsRegistry(),
+      addedLinksRegistry: new AddedLinksRegistry(),
+    };
 
     jest.mocked(wrapWithPluginContext).mockClear();
 

--- a/public/app/features/plugins/extensions/usePluginExtensions.test.tsx
+++ b/public/app/features/plugins/extensions/usePluginExtensions.test.tsx
@@ -5,7 +5,10 @@ import { AddedComponentsRegistry } from './registry/AddedComponentsRegistry';
 import { AddedLinksRegistry } from './registry/AddedLinksRegistry';
 import { ExposedComponentsRegistry } from './registry/ExposedComponentsRegistry';
 import { PluginExtensionRegistries } from './registry/types';
+import { useLoadAppPlugins } from './useLoadAppPlugins';
 import { createUsePluginExtensions } from './usePluginExtensions';
+
+jest.mock('./useLoadAppPlugins');
 
 describe('usePluginExtensions()', () => {
   let registries: PluginExtensionRegistries;
@@ -18,6 +21,7 @@ describe('usePluginExtensions()', () => {
       addedLinksRegistry: new AddedLinksRegistry(),
       exposedComponentsRegistry: new ExposedComponentsRegistry(),
     };
+    jest.mocked(useLoadAppPlugins).mockReturnValue({ isLoading: false });
   });
 
   it('should return an empty array if there are no extensions registered for the extension point', () => {

--- a/public/app/features/plugins/extensions/usePluginExtensions.tsx
+++ b/public/app/features/plugins/extensions/usePluginExtensions.tsx
@@ -8,7 +8,8 @@ import * as errors from './errors';
 import { getPluginExtensions } from './getPluginExtensions';
 import { log } from './logs/log';
 import { PluginExtensionRegistries } from './registry/types';
-import { isGrafanaDevMode } from './utils';
+import { useLoadAppPlugins } from './useLoadAppPlugins';
+import { getExtensionPointPluginDependencies, isGrafanaDevMode } from './utils';
 import { isExtensionPointIdValid, isExtensionPointMetaInfoMissing } from './validators';
 
 export function createUsePluginExtensions(registries: PluginExtensionRegistries) {
@@ -20,8 +21,9 @@ export function createUsePluginExtensions(registries: PluginExtensionRegistries)
     const addedComponentsRegistry = useObservable(observableAddedComponentsRegistry);
     const addedLinksRegistry = useObservable(observableAddedLinksRegistry);
     const { extensionPointId, context, limitPerPlugin } = options;
+    const { isLoading: isLoadingAppPlugins } = useLoadAppPlugins(getExtensionPointPluginDependencies(extensionPointId));
 
-    const { extensions } = useMemo(() => {
+    return useMemo(() => {
       // For backwards compatibility we don't enable restrictions in production or when the hook is used in core Grafana.
       const enableRestrictions = isGrafanaDevMode() && pluginContext !== null;
       const pluginId = pluginContext?.meta.id ?? '';
@@ -50,19 +52,35 @@ export function createUsePluginExtensions(registries: PluginExtensionRegistries)
         };
       }
 
-      return getPluginExtensions({
+      if (isLoadingAppPlugins) {
+        return {
+          isLoading: true,
+          extensions: [],
+        };
+      }
+
+      const { extensions } = getPluginExtensions({
         extensionPointId,
         context,
         limitPerPlugin,
         addedComponentsRegistry,
         addedLinksRegistry,
       });
+
+      return { extensions, isLoading: false };
+
       // Doing the deps like this instead of just `option` because users probably aren't going to memoize the
       // options object so we are checking it's simple value attributes.
       // The context though still has to be memoized though and not mutated.
       // eslint-disable-next-line react-hooks/exhaustive-deps -- TODO: refactor `getPluginExtensions` to accept service dependencies as arguments instead of relying on the sidecar singleton under the hood
-    }, [addedLinksRegistry, addedComponentsRegistry, extensionPointId, context, limitPerPlugin, pluginContext]);
-
-    return { extensions, isLoading: false };
+    }, [
+      addedLinksRegistry,
+      addedComponentsRegistry,
+      extensionPointId,
+      context,
+      limitPerPlugin,
+      pluginContext,
+      isLoadingAppPlugins,
+    ]);
   };
 }

--- a/public/app/features/plugins/extensions/usePluginLinks.test.tsx
+++ b/public/app/features/plugins/extensions/usePluginLinks.test.tsx
@@ -6,11 +6,15 @@ import { PluginContextProvider, PluginMeta, PluginType } from '@grafana/data';
 import { ExtensionRegistriesProvider } from './ExtensionRegistriesContext';
 import { log } from './logs/log';
 import { resetLogMock } from './logs/testUtils';
-import { setupPluginExtensionRegistries } from './registry/setup';
+import { AddedComponentsRegistry } from './registry/AddedComponentsRegistry';
+import { AddedLinksRegistry } from './registry/AddedLinksRegistry';
+import { ExposedComponentsRegistry } from './registry/ExposedComponentsRegistry';
 import { PluginExtensionRegistries } from './registry/types';
+import { useLoadAppPlugins } from './useLoadAppPlugins';
 import { usePluginLinks } from './usePluginLinks';
 import { isGrafanaDevMode } from './utils';
 
+jest.mock('./useLoadAppPlugins');
 jest.mock('app/features/plugins/pluginSettings', () => ({
   getPluginSettings: jest.fn().mockResolvedValue({
     id: 'my-app-plugin',
@@ -48,8 +52,13 @@ describe('usePluginLinks()', () => {
   const extensionPointId = `${pluginId}/extension-point/v1`;
 
   beforeEach(() => {
+    jest.mocked(useLoadAppPlugins).mockReturnValue({ isLoading: false });
     jest.mocked(isGrafanaDevMode).mockReturnValue(false);
-    registries = setupPluginExtensionRegistries();
+    registries = {
+      addedComponentsRegistry: new AddedComponentsRegistry(),
+      exposedComponentsRegistry: new ExposedComponentsRegistry(),
+      addedLinksRegistry: new AddedLinksRegistry(),
+    };
     resetLogMock(log);
 
     pluginMeta = {

--- a/public/app/features/plugins/extensions/usePluginLinks.tsx
+++ b/public/app/features/plugins/extensions/usePluginLinks.tsx
@@ -11,8 +11,10 @@ import {
 import { useAddedLinksRegistry } from './ExtensionRegistriesContext';
 import * as errors from './errors';
 import { log } from './logs/log';
+import { useLoadAppPlugins } from './useLoadAppPlugins';
 import {
   generateExtensionId,
+  getExtensionPointPluginDependencies,
   getLinkExtensionOnClick,
   getLinkExtensionOverrides,
   getLinkExtensionPathWithTracking,
@@ -30,6 +32,7 @@ export function usePluginLinks({
   const registry = useAddedLinksRegistry();
   const pluginContext = usePluginContext();
   const registryState = useObservable(registry.asObservable());
+  const { isLoading: isLoadingAppPlugins } = useLoadAppPlugins(getExtensionPointPluginDependencies(extensionPointId));
 
   return useMemo(() => {
     // For backwards compatibility we don't enable restrictions in production or when the hook is used in core Grafana.
@@ -52,6 +55,13 @@ export function usePluginLinks({
       pointLog.error(errors.EXTENSION_POINT_META_INFO_MISSING);
       return {
         isLoading: false,
+        links: [],
+      };
+    }
+
+    if (isLoadingAppPlugins) {
+      return {
+        isLoading: true,
         links: [],
       };
     }
@@ -117,5 +127,5 @@ export function usePluginLinks({
       isLoading: false,
       links: extensions,
     };
-  }, [context, extensionPointId, limitPerPlugin, registryState, pluginContext]);
+  }, [context, extensionPointId, limitPerPlugin, registryState, pluginContext, isLoadingAppPlugins]);
 }

--- a/public/app/features/plugins/extensions/utils.tsx
+++ b/public/app/features/plugins/extensions/utils.tsx
@@ -16,8 +16,9 @@ import {
   PanelMenuItem,
   PluginExtensionAddedLinkConfig,
   urlUtil,
+  PluginExtensionPoints,
 } from '@grafana/data';
-import { reportInteraction, config } from '@grafana/runtime';
+import { reportInteraction, config, AppPluginConfig } from '@grafana/runtime';
 import { Modal } from '@grafana/ui';
 import appEvents from 'app/core/app_events';
 import { getPluginSettings } from 'app/features/plugins/pluginSettings';
@@ -421,3 +422,75 @@ export function getLinkExtensionPathWithTracking(pluginId: string, path: string,
 // Comes from the `app_mode` setting in the Grafana config (defaults to "development")
 // Can be set with the `GF_DEFAULT_APP_MODE` environment variable
 export const isGrafanaDevMode = () => config.buildInfo.env === 'development';
+
+export const getAppPluginConfigs = (pluginIds: string[] = []) =>
+  Object.values(config.apps).filter((app) => pluginIds.includes(app.id));
+
+export const getAppPluginIdFromExposedComponentId = (exposedComponentId: string) => {
+  return exposedComponentId.split('/')[0];
+};
+
+// Returns a list of app plugin ids that are registering extensions to this extension point.
+// (These plugins are necessary to be loaded to use the extension point.)
+// (The function also returns the plugin ids that the plugins - that extend the extension point - depend on.)
+export const getExtensionPointPluginDependencies = (extensionPointId: string): string[] => {
+  return Object.values(config.apps)
+    .filter(
+      (app) =>
+        app.extensions.addedLinks.some((link) => link.targets.includes(extensionPointId)) ||
+        app.extensions.addedComponents.some((component) => component.targets.includes(extensionPointId))
+    )
+    .map((app) => app.id)
+    .reduce((acc: string[], id: string) => {
+      return [...acc, id, ...getAppPluginDependencies(id)];
+    }, []);
+};
+
+// Returns a list of app plugin ids that are necessary to be loaded to use the exposed component.
+// (It is first the plugin that exposes the component, and then the ones that it depends on.)
+export const getExposedComponentPluginDependencies = (exposedComponentId: string) => {
+  const pluginId = getAppPluginIdFromExposedComponentId(exposedComponentId);
+
+  return [pluginId].reduce((acc: string[], pluginId: string) => {
+    return [...acc, pluginId, ...getAppPluginDependencies(pluginId)];
+  }, []);
+};
+
+// Returns a list of app plugin ids that are necessary to be loaded, based on the `dependencies.extensions`
+// metadata field. (For example the plugins that expose components that the app depends on.)
+// Heads up! This is a recursive function.
+export const getAppPluginDependencies = (pluginId: string): string[] => {
+  if (!config.apps[pluginId]) {
+    return [];
+  }
+
+  const pluginIdDependencies = config.apps[pluginId].dependencies.extensions.exposedComponents.map(
+    getAppPluginIdFromExposedComponentId
+  );
+
+  return pluginIdDependencies.reduce((acc, pluginId) => {
+    return [...acc, ...getAppPluginDependencies(pluginId)];
+  }, pluginIdDependencies);
+};
+
+// Returns a list of app plugins that has to be loaded before core Grafana could finish the initialization.
+export const getAppPluginsToAwait = () => {
+  const pluginIds = [
+    // The "cloud-home-app" is registering banners once it's loaded, and this can cause a rerender in the AppChrome if it's loaded after the Grafana app init.
+    'cloud-home-app',
+  ];
+
+  return Object.values(config.apps).filter((app) => pluginIds.includes(app.id));
+};
+
+// Returns a list of app plugins that has to be preloaded in parallel with the core Grafana initialization.
+export const getAppPluginsToPreload = () => {
+  // The DashboardPanelMenu extension point is using the `getPluginExtensions()` API in scenes at the moment, which means that it cannot yet benefit from dynamic plugin loading.
+  const dashboardPanelMenuPluginIds = getExtensionPointPluginDependencies(PluginExtensionPoints.DashboardPanelMenu);
+  const awaitedPluginIds = getAppPluginsToAwait().map((app) => app.id);
+  const isNotAwaited = (app: AppPluginConfig) => !awaitedPluginIds.includes(app.id);
+
+  return Object.values(config.apps).filter((app) => {
+    return isNotAwaited(app) && (app.preload || dashboardPanelMenuPluginIds.includes(app.id));
+  });
+};

--- a/public/app/features/plugins/plugin_loader.ts
+++ b/public/app/features/plugins/plugin_loader.ts
@@ -13,6 +13,7 @@ import { DataQuery } from '@grafana/schema';
 import { GenericDataSourcePlugin } from '../datasources/types';
 
 import builtInPlugins from './built_in_plugins';
+import { addedComponentsRegistry, addedLinksRegistry, exposedComponentsRegistry } from './extensions/registry/setup';
 import { getPluginFromCache, registerPluginInCache } from './loader/cache';
 // SystemJS has to be imported before the sharedDependenciesMap
 import { SystemJS } from './loader/systemjs';
@@ -69,6 +70,15 @@ systemJSPrototype.resolve = decorateSystemJSResolve.bind(systemJSPrototype, syst
 // Any css files loaded via SystemJS have their styles applied onload.
 systemJSPrototype.onload = decorateSystemJsOnload;
 
+type PluginImportInfo = {
+  path: string;
+  pluginId: string;
+  loadingStrategy: PluginLoadingStrategy;
+  version?: string;
+  isAngular?: boolean;
+  moduleHash?: string;
+};
+
 export async function importPluginModule({
   path,
   pluginId,
@@ -76,14 +86,7 @@ export async function importPluginModule({
   version,
   isAngular,
   moduleHash,
-}: {
-  path: string;
-  pluginId: string;
-  loadingStrategy: PluginLoadingStrategy;
-  version?: string;
-  isAngular?: boolean;
-  moduleHash?: string;
-}): Promise<System.Module> {
+}: PluginImportInfo): Promise<System.Module> {
   if (version) {
     registerPluginInCache({ path, version, loadingStrategy });
   }
@@ -166,21 +169,47 @@ export function importDataSourcePlugin(meta: DataSourcePluginMeta): Promise<Gene
   });
 }
 
-export function importAppPlugin(meta: PluginMeta): Promise<AppPlugin> {
-  const isAngular = meta.angular?.detected ?? meta.angularDetected;
-  const fallbackLoadingStrategy = meta.loadingStrategy ?? PluginLoadingStrategy.fetch;
-  return importPluginModule({
+export class DisabledAppPlugin extends Error {}
+export class NotAnAppPlugin extends Error {}
+
+// Only successfully loaded plugins are cached
+const importedAppPlugins: Record<string, AppPlugin> = {};
+
+export async function importAppPlugin(meta: PluginMeta): Promise<AppPlugin> {
+  const pluginId = meta.id;
+
+  if (importedAppPlugins[pluginId]) {
+    return importedAppPlugins[pluginId];
+  }
+
+  const pluginExports = await importPluginModule({
     path: meta.module,
     version: meta.info?.version,
-    isAngular,
-    loadingStrategy: fallbackLoadingStrategy,
     pluginId: meta.id,
+    isAngular: meta.angular?.detected ?? meta.angularDetected,
+    loadingStrategy: meta.loadingStrategy ?? PluginLoadingStrategy.fetch,
     moduleHash: meta.moduleHash,
-  }).then((pluginExports) => {
-    const plugin: AppPlugin = pluginExports.plugin ? pluginExports.plugin : new AppPlugin();
-    plugin.init(meta);
-    plugin.meta = meta;
-    plugin.setComponentsFromLegacyExports(pluginExports);
-    return plugin;
   });
+
+  const { plugin = new AppPlugin() } = pluginExports;
+  plugin.setComponentsFromLegacyExports(pluginExports);
+  plugin.init(meta);
+  plugin.meta = meta;
+
+  exposedComponentsRegistry.register({
+    pluginId,
+    configs: plugin.exposedComponentConfigs || [],
+  });
+  addedComponentsRegistry.register({
+    pluginId,
+    configs: plugin.addedComponentConfigs || [],
+  });
+  addedLinksRegistry.register({
+    pluginId,
+    configs: plugin.addedLinkConfigs || [],
+  });
+
+  importedAppPlugins[pluginId] = plugin;
+
+  return plugin;
 }

--- a/public/app/features/plugins/plugin_loader.ts
+++ b/public/app/features/plugins/plugin_loader.ts
@@ -189,9 +189,9 @@ export async function importAppPlugin(meta: PluginMeta): Promise<AppPlugin> {
   });
 
   const { plugin = new AppPlugin() } = pluginExports;
-  plugin.setComponentsFromLegacyExports(pluginExports);
   plugin.init(meta);
   plugin.meta = meta;
+  plugin.setComponentsFromLegacyExports(pluginExports);
 
   exposedComponentsRegistry.register({
     pluginId,

--- a/public/app/features/plugins/plugin_loader.ts
+++ b/public/app/features/plugins/plugin_loader.ts
@@ -169,9 +169,6 @@ export function importDataSourcePlugin(meta: DataSourcePluginMeta): Promise<Gene
   });
 }
 
-export class DisabledAppPlugin extends Error {}
-export class NotAnAppPlugin extends Error {}
-
 // Only successfully loaded plugins are cached
 const importedAppPlugins: Record<string, AppPlugin> = {};
 

--- a/public/app/features/plugins/tests/plugin_loader.test.ts
+++ b/public/app/features/plugins/tests/plugin_loader.test.ts
@@ -12,27 +12,25 @@ jest.mock('app/core/core', () => {
 import { AppPluginMeta, PluginMetaInfo, PluginType, AppPlugin } from '@grafana/data';
 
 // Loaded after the `unmock` above
+import { addedComponentsRegistry, addedLinksRegistry, exposedComponentsRegistry } from '../extensions/registry/setup';
 import { SystemJS } from '../loader/systemjs';
 import { importAppPlugin } from '../plugin_loader';
 
-class MyCustomApp extends AppPlugin {
-  initWasCalled = false;
-  calledTwice = false;
-
-  init(meta: AppPluginMeta) {
-    this.initWasCalled = true;
-    this.calledTwice = this.meta === meta;
-  }
-}
+jest.mock('../extensions/registry/setup');
 
 describe('Load App', () => {
-  const app = new MyCustomApp();
+  const app = new AppPlugin();
   const modulePath = 'http://localhost:3000/public/plugins/my-app-plugin/module.js';
   // Hook resolver for tests
   const originalResolve = SystemJS.constructor.prototype.resolve;
   SystemJS.constructor.prototype.resolve = (x: unknown) => x;
 
   beforeAll(() => {
+    app.init = jest.fn();
+    addedComponentsRegistry.register = jest.fn();
+    addedLinksRegistry.register = jest.fn();
+    exposedComponentsRegistry.register = jest.fn();
+
     SystemJS.set(modulePath, { plugin: app });
   });
 
@@ -55,14 +53,17 @@ describe('Load App', () => {
     const m = await SystemJS.import(modulePath);
     expect(m.plugin).toBe(app);
 
-    const loaded = await importAppPlugin(meta);
-    expect(loaded).toBe(app);
+    // Importing the app should initialise the meta
+    const importedApp = await importAppPlugin(meta);
+    expect(importedApp).toBe(app);
     expect(app.meta).toBe(meta);
-    expect(app.initWasCalled).toBeTruthy();
-    expect(app.calledTwice).toBeFalsy();
 
-    const again = await importAppPlugin(meta);
-    expect(again).toBe(app);
-    expect(app.calledTwice).toBeTruthy();
+    // Importing the same app again doesn't initialise it twice
+    const importedAppAgain = await importAppPlugin(meta);
+    expect(importedAppAgain).toBe(app);
+    expect(app.init).toHaveBeenCalledTimes(1);
+    expect(addedComponentsRegistry.register).toHaveBeenCalledTimes(1);
+    expect(addedLinksRegistry.register).toHaveBeenCalledTimes(1);
+    expect(exposedComponentsRegistry.register).toHaveBeenCalledTimes(1);
   });
 });


### PR DESCRIPTION
### What changed?

**This is not a breaking change.**

This PR removes the need to define `preload: true` for plugins that are using extensions. They will be automatically loaded in the background in case it's necessary:
- they are accessed directly (e.g. `/a/<PLUGIN_ID>/*`)
- they are extending an extension point that is being rendered (`usePluginLinks()` or `usePluginComponents()`)
- they are exposing a component that is being used (via `usePluginComponent()`)
- they are a dependency of a plugin (due to an exposed component) that is being loaded for one of the reasons above

<img width="1483" alt="Screenshot 2024-10-10 at 14 48 26" src="https://github.com/user-attachments/assets/edf6fd11-4865-441c-ba6a-4a95914a2e5b">
<img width="2555" alt="Screenshot 2024-11-05 at 13 57 29" src="https://github.com/user-attachments/assets/5b5ae3f3-a97a-4f81-9437-34e9e995379c">