### PR TITLE
Alerting: Fix max_alerts field handling

### DIFF
--- a/public/app/features/alerting/unified/utils/cloud-alertmanager-notifier-types.ts
+++ b/public/app/features/alerting/unified/utils/cloud-alertmanager-notifier-types.ts
@@ -320,7 +320,11 @@ export const cloudNotifierTypes: Array<NotifierDTO<CloudNotifierType>> = [
         'max_alerts',
         'Max alerts',
         'The maximum number of alerts to include in a single webhook message. Alerts above this threshold are truncated. When leaving this at its default value of 0, all alerts are included.',
-        { placeholder: '0', validationRule: '(^\\d+$|^$)' }
+        {
+          placeholder: '0',
+          validationRule: '(^\\d+$|^$)',
+          setValueAs: (value) => (typeof value === 'string' ? parseInt(value, 10) : 0),
+        }
       ),
       httpConfigOption,
     ],


### PR DESCRIPTION
**What is this feature?**
This PR fixes external Alertmanager `max_alerts` options handling

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
