### PR TITLE
FE Sandbox: Fix worker post message not handling proxy objects correctly

### DIFF
--- a/public/app/features/plugins/sandbox/document_sandbox.ts
+++ b/public/app/features/plugins/sandbox/document_sandbox.ts
@@ -212,8 +212,8 @@ function patchWorkerPostMessage() {
   const originalPostMessage = Worker.prototype.postMessage;
   Object.defineProperty(Worker.prototype, 'postMessage', {
     value: function (...args: Parameters<typeof Worker.prototype.postMessage>) {
-      //@ts-expect-error
-      return originalPostMessage.apply(this, unboxNearMembraneProxies(args));
+      // eslint-disable-next-line
+      return originalPostMessage.apply(this, unboxNearMembraneProxies(args) as typeof args);
     },
   });
 }

--- a/public/app/features/plugins/sandbox/document_sandbox.ts
+++ b/public/app/features/plugins/sandbox/document_sandbox.ts
@@ -212,7 +212,7 @@ function patchWorkerPostMessage() {
   const originalPostMessage = Worker.prototype.postMessage;
   Object.defineProperty(Worker.prototype, 'postMessage', {
     value: function (...args: Parameters<typeof Worker.prototype.postMessage>) {
-      //@ts-ignore
+      //@ts-expect-error
       return originalPostMessage.apply(this, unboxNearMembraneProxies(args));
     },
   });

--- a/public/app/features/plugins/sandbox/document_sandbox.ts
+++ b/public/app/features/plugins/sandbox/document_sandbox.ts
@@ -6,7 +6,7 @@ import { CustomVariableSupport, DataSourceApi } from '@grafana/data';
 import { config } from '@grafana/runtime';
 
 import { forbiddenElements } from './constants';
-import { isReactClassComponent, logWarning } from './utils';
+import { isReactClassComponent, logWarning, unboxNearMembraneProxies } from './utils';
 
 // IMPORTANT: NEVER export this symbol from a public (e.g `@grafana/*`) package
 const SANDBOX_LIVE_VALUE = Symbol.for('@@SANDBOX_LIVE_VALUE');
@@ -194,7 +194,28 @@ export function patchWebAPIs() {
   if (!nativeAPIsPatched) {
     nativeAPIsPatched = true;
     patchHistoryReplaceState();
+    patchWorkerPostMessage();
   }
+}
+
+/*
+ *
+ * Worker.postMessage uses internally structureClone which won't work with proxies.
+ *
+ * In case where the blue realm code is directly handling proxy objects that
+ * should be send over a post message the blue realm will call postMessage and try to
+ * send the proxy resulting in an error.
+ *
+ * This makes sure all proxies are unboxed before being sent over the post message
+ */
+function patchWorkerPostMessage() {
+  const originalPostMessage = Worker.prototype.postMessage;
+  Object.defineProperty(Worker.prototype, 'postMessage', {
+    value: function (...args: Parameters<typeof Worker.prototype.postMessage>) {
+      //@ts-ignore
+      return originalPostMessage.apply(this, unboxNearMembraneProxies(args));
+    },
+  });
 }
 
 /*

--- a/public/app/features/plugins/sandbox/utils.ts
+++ b/public/app/features/plugins/sandbox/utils.ts
@@ -1,4 +1,5 @@
 import { isNearMembraneProxy } from '@locker/near-membrane-shared';
+import { cloneDeep } from 'lodash';
 import React from 'react';
 
 import { PluginSignatureType, PluginType } from '@grafana/data';
@@ -8,7 +9,6 @@ import { config, createMonitoringLogger } from '@grafana/runtime';
 import { getPluginSettings } from '../pluginSettings';
 
 import { SandboxedPluginObject } from './types';
-import { cloneDeep } from 'lodash';
 
 const monitorOnly = Boolean(config.featureToggles.frontendSandboxMonitorOnly);
 


### PR DESCRIPTION
**What is this feature?**

Fixes a bug where the Worker.postMessage function didn't work in specific conditions when the frontend sandbox was enabled.

This was caused by core code passing proxy object to workers via postmessage.

**Why do we need this feature?**

To fix web workers when the frontend sandbox is enabled

**Who is this feature for?**

All grafana users

**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/grafana/issues/84633

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
