### PR TITLE
Dashboards: Check if dashboard.meta is undefined, if undefined handle redirect in dashboard scene.

### DIFF
--- a/public/app/features/dashboard/containers/DashboardPageProxy.tsx
+++ b/public/app/features/dashboard/containers/DashboardPageProxy.tsx
@@ -60,7 +60,7 @@ function DashboardPageProxy(props: DashboardPageProxyProps) {
 
   if (
     dashboard.value &&
-    !(dashboard.value.meta.canEdit || dashboard.value.meta.canMakeEditable) &&
+    !(dashboard.value.meta?.canEdit || dashboard.value.meta?.canMakeEditable) &&
     isScenesSupportedRoute
   ) {
     return <DashboardScenePage {...props} />;


### PR DESCRIPTION
**What is this feature?**

Fixes an issue with redirects. When we're doing a redirect, the DashboardDTO does not have meta. This causes the code to error out. 

Should be noted that with this change, we're always going to handle redirects with the redirect mechanism in scenes, even for editors.

Similar to: #86507