### PR TITLE
Remove SAML form the list of auth providers for devenv

### DIFF
--- a/devenv/docker/blocks/auth/README.md
+++ b/devenv/docker/blocks/auth/README.md
@@ -28,4 +28,3 @@ by the `devenv` target.
 - [openldap](./openldap)
 - [openldap-multiple](./openldap-multiple)
 - [prometheus_basic_auth_proxy](./prometheus_basic_auth_proxy)
-- [saml](./saml)


### PR DESCRIPTION
**What is this feature?**

Removes SAML as an auth provider from the devenv providers list.

**Why do we need this feature?**

The link for SAML was broken. Since SAML is an enterprise feature, it has been removed.


**Who is this feature for?**

[Add information on what kind of user the feature is for.]

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
