### PR TITLE
Chore: Add NODE_ENV to VSCode debug config

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -19,9 +19,7 @@
       "program": "${workspaceFolder}/pkg/cmd/grafana/",
       "env": {},
       "cwd": "${workspaceFolder}",
-      "args": ["apiserver", 
-          "--secure-port=8443", 
-          "--runtime-config=testdata.datasource.grafana.app/v0alpha1=true"]
+      "args": ["apiserver", "--secure-port=8443", "--runtime-config=testdata.datasource.grafana.app/v0alpha1=true"]
     },
     {
       "name": "Run API Server (query-localhost)",
@@ -31,12 +29,14 @@
       "program": "${workspaceFolder}/pkg/cmd/grafana/",
       "env": {},
       "cwd": "${workspaceFolder}",
-      "args": ["apiserver", 
-          "--secure-port=8443", 
-          "--runtime-config=query.grafana.app/v0alpha1=true",
-          "--grafana.authn.signing-keys-url=http://localhost:3000/api/signing-keys/keys",
-          "--hg-url=http://localhost:3000",
-          "--hg-key=$HGAPIKEY"]
+      "args": [
+        "apiserver",
+        "--secure-port=8443",
+        "--runtime-config=query.grafana.app/v0alpha1=true",
+        "--grafana.authn.signing-keys-url=http://localhost:3000/api/signing-keys/keys",
+        "--hg-url=http://localhost:3000",
+        "--hg-key=$HGAPIKEY"
+      ]
     },
     {
       "name": "Attach to Chrome",

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -46,7 +46,7 @@
       "webRoot": "${workspaceFolder}"
     },
     {
-      "name": "Debug Jest test",
+      "name": "Debug UI test",
       "type": "node",
       "request": "launch",
       "runtimeExecutable": "yarn",

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -53,7 +53,9 @@
       "runtimeArgs": ["run", "jest", "--runInBand", "${file}"],
       "console": "integratedTerminal",
       "internalConsoleOptions": "neverOpen",
-      "port": 9229
+      "env": {
+        "NODE_ENV": "test"
+      }
     },
     {
       "name": "Debug Go test",


### PR DESCRIPTION
**What is this feature?**

Adds `NODE_ENV` to debug config

**Why do we need this feature?**

By default the `NODE_ENV` wasn't set for running tests through VSCode's debug config. This means that if you didn't have it set somewhere in your terminal config, then tests would fail trying to do `require.context` (as added [here](https://github.com/grafana/grafana/pull/86215/files#diff-c7a33b8964d6964fb5e19dfe0dac6fbfe3807ddd7600f8f1998571dcf391e6a4R91)).

This PR adds it so it'll always be set when running the tests via VSCode debug, and does some other minor tidy up 🧹 
