### PR TITLE
Azure: Get custom cloud list from grafana-azure-sdk-go package

### DIFF
--- a/pkg/api/dtos/frontend_settings.go
+++ b/pkg/api/dtos/frontend_settings.go
@@ -65,11 +65,6 @@ type FrontendSettingsLicenseInfoDTO struct {
 	AppUrl      *string `json:"appUrl,omitempty"`
 }
 
-type FrontendSettingsAzureCloudDTO struct {
-	Name        string `json:"name"`
-	DisplayName string `json:"displayName"`
-}
-
 type FrontendSettingsAzureDTO struct {
 	Cloud                                  string                      `json:"cloud"`
 	Clouds                                 []azsettings.AzureCloudInfo `json:"clouds"`

--- a/pkg/api/dtos/frontend_settings.go
+++ b/pkg/api/dtos/frontend_settings.go
@@ -64,8 +64,14 @@ type FrontendSettingsLicenseInfoDTO struct {
 	AppUrl      *string `json:"appUrl,omitempty"`
 }
 
+type FrontendSettingsAzureCloudDTO struct {
+	Name        string `json:"name"`
+	DisplayName string `json:"displayName"`
+}
+
 type FrontendSettingsAzureDTO struct {
 	Cloud                                  string `json:"cloud"`
+	Clouds                                 []FrontendSettingsAzureCloudDTO `json:"clouds"`
 	ManagedIdentityEnabled                 bool   `json:"managedIdentityEnabled"`
 	WorkloadIdentityEnabled                bool   `json:"workloadIdentityEnabled"`
 	UserIdentityEnabled                    bool   `json:"userIdentityEnabled"`

--- a/pkg/api/dtos/frontend_settings.go
+++ b/pkg/api/dtos/frontend_settings.go
@@ -1,6 +1,7 @@
 package dtos
 
 import (
+	"github.com/grafana/grafana-azure-sdk-go/v2/azsettings"
 	"github.com/grafana/grafana/pkg/plugins"
 	"github.com/grafana/grafana/pkg/setting"
 )
@@ -70,12 +71,12 @@ type FrontendSettingsAzureCloudDTO struct {
 }
 
 type FrontendSettingsAzureDTO struct {
-	Cloud                                  string `json:"cloud"`
-	Clouds                                 []FrontendSettingsAzureCloudDTO `json:"clouds"`
-	ManagedIdentityEnabled                 bool   `json:"managedIdentityEnabled"`
-	WorkloadIdentityEnabled                bool   `json:"workloadIdentityEnabled"`
-	UserIdentityEnabled                    bool   `json:"userIdentityEnabled"`
-	UserIdentityFallbackCredentialsEnabled bool   `json:"userIdentityFallbackCredentialsEnabled"`
+	Cloud                                  string                      `json:"cloud"`
+	Clouds                                 []azsettings.AzureCloudInfo `json:"clouds"`
+	ManagedIdentityEnabled                 bool                        `json:"managedIdentityEnabled"`
+	WorkloadIdentityEnabled                bool                        `json:"workloadIdentityEnabled"`
+	UserIdentityEnabled                    bool                        `json:"userIdentityEnabled"`
+	UserIdentityFallbackCredentialsEnabled bool                        `json:"userIdentityFallbackCredentialsEnabled"`
 }
 
 type FrontendSettingsCachingDTO struct {

--- a/pkg/api/frontendsettings.go
+++ b/pkg/api/frontendsettings.go
@@ -10,6 +10,7 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/grafana/grafana-azure-sdk-go/v2/azsettings"
 	"github.com/grafana/grafana/pkg/api/dtos"
 	"github.com/grafana/grafana/pkg/api/webassets"
 	"github.com/grafana/grafana/pkg/login/social"
@@ -270,6 +271,7 @@ func (hs *HTTPServer) getFrontendSettings(c *contextmodel.ReqContext) (*dtos.Fro
 
 		Azure: dtos.FrontendSettingsAzureDTO{
 			Cloud:                                  hs.Cfg.Azure.Cloud,
+			Clouds:                                 getAzureClouds(hs.Cfg.Azure),
 			ManagedIdentityEnabled:                 hs.Cfg.Azure.ManagedIdentityEnabled,
 			WorkloadIdentityEnabled:                hs.Cfg.Azure.WorkloadIdentityEnabled,
 			UserIdentityEnabled:                    hs.Cfg.Azure.UserIdentityEnabled,
@@ -726,4 +728,18 @@ func (hs *HTTPServer) getEnabledOAuthProviders() map[string]any {
 		}
 	}
 	return providers
+}
+
+func getAzureClouds(settings *azsettings.AzureSettings) []dtos.FrontendSettingsAzureCloudDTO {
+	// If no custom clouds are defined, return nil because frontend already knows the predefined clouds
+	if clouds := settings.CustomClouds(); clouds == nil || len(clouds) == 0 {
+		return nil
+	} else {
+		cloudsDTO := make([]dtos.FrontendSettingsAzureCloudDTO, len(clouds))
+		for i, cloud := range clouds {
+			cloudsDTO[i].Name = cloud.Name
+			cloudsDTO[i].DisplayName = cloud.DisplayName
+		}
+		return cloudsDTO
+	}
 }

--- a/pkg/api/frontendsettings.go
+++ b/pkg/api/frontendsettings.go
@@ -10,7 +10,6 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/grafana/grafana-azure-sdk-go/v2/azsettings"
 	"github.com/grafana/grafana/pkg/api/dtos"
 	"github.com/grafana/grafana/pkg/api/webassets"
 	"github.com/grafana/grafana/pkg/login/social"
@@ -271,7 +270,7 @@ func (hs *HTTPServer) getFrontendSettings(c *contextmodel.ReqContext) (*dtos.Fro
 
 		Azure: dtos.FrontendSettingsAzureDTO{
 			Cloud:                                  hs.Cfg.Azure.Cloud,
-			Clouds:                                 getAzureClouds(hs.Cfg.Azure),
+			Clouds:                                 hs.Cfg.Azure.CustomClouds(),
 			ManagedIdentityEnabled:                 hs.Cfg.Azure.ManagedIdentityEnabled,
 			WorkloadIdentityEnabled:                hs.Cfg.Azure.WorkloadIdentityEnabled,
 			UserIdentityEnabled:                    hs.Cfg.Azure.UserIdentityEnabled,
@@ -728,18 +727,4 @@ func (hs *HTTPServer) getEnabledOAuthProviders() map[string]any {
 		}
 	}
 	return providers
-}
-
-func getAzureClouds(settings *azsettings.AzureSettings) []dtos.FrontendSettingsAzureCloudDTO {
-	// If no custom clouds are defined, return nil because frontend already knows the predefined clouds
-	if clouds := settings.CustomClouds(); clouds == nil || len(clouds) == 0 {
-		return nil
-	} else {
-		cloudsDTO := make([]dtos.FrontendSettingsAzureCloudDTO, len(clouds))
-		for i, cloud := range clouds {
-			cloudsDTO[i].Name = cloud.Name
-			cloudsDTO[i].DisplayName = cloud.DisplayName
-		}
-		return cloudsDTO
-	}
 }

--- a/pkg/api/frontendsettings_test.go
+++ b/pkg/api/frontendsettings_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/grafana/grafana-azure-sdk-go/v2/azsettings"
 	"github.com/grafana/grafana/pkg/infra/db"
 	"github.com/grafana/grafana/pkg/infra/remotecache"
 	"github.com/grafana/grafana/pkg/infra/usagestats"
@@ -337,6 +338,14 @@ func TestHTTPServer_GetFrontendSettings_apps(t *testing.T) {
 			require.EqualValues(t, test.expected, got)
 		})
 	}
+}
+
+func TestFrontendSettings_getAzureClouds(t *testing.T) {
+	t.Run("returns nil if no custom clouds", func(t *testing.T) {
+		settings := azsettings.AzureSettings{}
+		clouds := getAzureClouds(&settings)
+		require.Equal(t, true, clouds == nil)
+	})
 }
 
 func newAppSettings(id string, enabled bool) map[string]*pluginsettings.DTO {

--- a/pkg/api/frontendsettings_test.go
+++ b/pkg/api/frontendsettings_test.go
@@ -11,7 +11,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/grafana/grafana-azure-sdk-go/v2/azsettings"
 	"github.com/grafana/grafana/pkg/infra/db"
 	"github.com/grafana/grafana/pkg/infra/remotecache"
 	"github.com/grafana/grafana/pkg/infra/usagestats"
@@ -338,14 +337,6 @@ func TestHTTPServer_GetFrontendSettings_apps(t *testing.T) {
 			require.EqualValues(t, test.expected, got)
 		})
 	}
-}
-
-func TestFrontendSettings_getAzureClouds(t *testing.T) {
-	t.Run("returns nil if no custom clouds", func(t *testing.T) {
-		settings := azsettings.AzureSettings{}
-		clouds := getAzureClouds(&settings)
-		require.Equal(t, true, clouds == nil)
-	})
 }
 
 func newAppSettings(id string, enabled bool) map[string]*pluginsettings.DTO {


### PR DESCRIPTION
Allow azure clouds to be specified in the frontend settings so that data sources no longer have to hard code the list themselves. 