### PR TITLE
Scenes: Refactor DashboardSceneChangeTracker

### DIFF
--- a/public/app/features/dashboard-scene/panel-edit/VizPanelManager.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/VizPanelManager.tsx
@@ -456,6 +456,10 @@ export class VizPanelManager extends SceneObjectBase<VizPanelManagerState> {
     this.state.panel.setState({ title: newTitle, hoverHeader: newTitle === '' });
   }
 
+  public shouldCheckForChanges(partialState: Partial<VizPanelManagerState>) {
+    return 'repeat' in partialState || 'repeatDirection' in partialState || 'maxPerRow' in partialState;
+  }
+
   public static Component = ({ model }: SceneComponentProps<VizPanelManager>) => {
     const { panel, tableView } = model.useState();
     const styles = useStyles2(getStyles);

--- a/public/app/features/dashboard-scene/saving/DashboardSceneChangeTracker.ts
+++ b/public/app/features/dashboard-scene/saving/DashboardSceneChangeTracker.ts
@@ -1,27 +1,9 @@
 import { Unsubscribable } from 'rxjs';
 
-import {
-  SceneDataLayerSet,
-  SceneDataTransformer,
-  SceneGridLayout,
-  SceneObjectStateChangedEvent,
-  SceneQueryRunner,
-  SceneRefreshPicker,
-  SceneTimeRange,
-  SceneVariableSet,
-  VizPanel,
-  behaviors,
-} from '@grafana/scenes';
+import { SceneObjectStateChangedEvent } from '@grafana/scenes';
 import { createWorker } from 'app/features/dashboard-scene/saving/createDetectChangesWorker';
 
-import { VizPanelManager } from '../panel-edit/VizPanelManager';
-import { DashboardAnnotationsDataLayer } from '../scene/DashboardAnnotationsDataLayer';
-import { DashboardControls } from '../scene/DashboardControls';
-import { DashboardGridItem } from '../scene/DashboardGridItem';
-import { DashboardScene, PERSISTED_PROPS } from '../scene/DashboardScene';
-import { LibraryVizPanel } from '../scene/LibraryVizPanel';
-import { VizPanelLinks } from '../scene/PanelLinks';
-import { PanelTimeRange } from '../scene/PanelTimeRange';
+import { DashboardScene } from '../scene/DashboardScene';
 import { transformSceneToSaveModel } from '../serialization/transformSceneToSaveModel';
 import { isSceneVariableInstance } from '../settings/variables/utils';
 
@@ -42,90 +24,10 @@ export class DashboardSceneChangeTracker {
       return;
     }
 
-    // Any change in the panel should trigger a change detection
-    // The VizPanelManager includes configuration for the panel like repeat
-    // The PanelTimeRange includes the overrides configuration
-    if (
-      payload.changedObject instanceof VizPanel ||
-      payload.changedObject instanceof DashboardGridItem ||
-      payload.changedObject instanceof PanelTimeRange
-    ) {
+    if (payload.changedObject.shouldCheckForChanges(payload.partialUpdate)) {
       return this.detectSaveModelChanges();
     }
-    // VizPanelManager includes the repeat configuration
-    if (payload.changedObject instanceof VizPanelManager) {
-      if (
-        Object.prototype.hasOwnProperty.call(payload.partialUpdate, 'repeat') ||
-        Object.prototype.hasOwnProperty.call(payload.partialUpdate, 'repeatDirection') ||
-        Object.prototype.hasOwnProperty.call(payload.partialUpdate, 'maxPerRow')
-      ) {
-        return this.detectSaveModelChanges();
-      }
-    }
-    // SceneQueryRunner includes the DS configuration
-    if (payload.changedObject instanceof SceneQueryRunner) {
-      if (!Object.prototype.hasOwnProperty.call(payload.partialUpdate, 'data')) {
-        return this.detectSaveModelChanges();
-      }
-    }
-    // SceneDataTransformer includes the transformation configuration
-    if (payload.changedObject instanceof SceneDataTransformer) {
-      if (!Object.prototype.hasOwnProperty.call(payload.partialUpdate, 'data')) {
-        return this.detectSaveModelChanges();
-      }
-    }
-    if (payload.changedObject instanceof VizPanelLinks) {
-      return this.detectSaveModelChanges();
-    }
-    if (payload.changedObject instanceof LibraryVizPanel) {
-      if (Object.prototype.hasOwnProperty.call(payload.partialUpdate, 'name')) {
-        return this.detectSaveModelChanges();
-      }
-    }
-    if (payload.changedObject instanceof SceneRefreshPicker) {
-      if (
-        Object.prototype.hasOwnProperty.call(payload.partialUpdate, 'intervals') ||
-        Object.prototype.hasOwnProperty.call(payload.partialUpdate, 'refresh')
-      ) {
-        return this.detectSaveModelChanges();
-      }
-    }
-    if (payload.changedObject instanceof behaviors.CursorSync) {
-      return this.detectSaveModelChanges();
-    }
-    if (payload.changedObject instanceof SceneDataLayerSet) {
-      return this.detectSaveModelChanges();
-    }
-    if (payload.changedObject instanceof DashboardGridItem) {
-      return this.detectSaveModelChanges();
-    }
-    if (payload.changedObject instanceof SceneGridLayout) {
-      return this.detectSaveModelChanges();
-    }
-    if (payload.changedObject instanceof DashboardScene) {
-      if (Object.keys(payload.partialUpdate).some((key) => PERSISTED_PROPS.includes(key))) {
-        return this.detectSaveModelChanges();
-      }
-    }
-    if (payload.changedObject instanceof SceneTimeRange) {
-      return this.detectSaveModelChanges();
-    }
-    if (payload.changedObject instanceof DashboardControls) {
-      if (Object.prototype.hasOwnProperty.call(payload.partialUpdate, 'hideTimeControls')) {
-        return this.detectSaveModelChanges();
-      }
-    }
-    if (payload.changedObject instanceof SceneVariableSet) {
-      return this.detectSaveModelChanges();
-    }
-    if (payload.changedObject instanceof DashboardAnnotationsDataLayer) {
-      if (!Object.prototype.hasOwnProperty.call(payload.partialUpdate, 'data')) {
-        return this.detectSaveModelChanges();
-      }
-    }
-    if (payload.changedObject instanceof behaviors.LiveNowTimer) {
-      return this.detectSaveModelChanges();
-    }
+
     if (isSceneVariableInstance(payload.changedObject)) {
       return this.detectSaveModelChanges();
     }

--- a/public/app/features/dashboard-scene/scene/DashboardAnnotationsDataLayer.ts
+++ b/public/app/features/dashboard-scene/scene/DashboardAnnotationsDataLayer.ts
@@ -49,4 +49,8 @@ export class DashboardAnnotationsDataLayer extends dataLayers.AnnotationsDataLay
       return super.processEvents(query, events);
     }
   }
+
+  public shouldCheckForChanges(partialState: object): boolean {
+    return !('data' in partialState);
+  }
 }

--- a/public/app/features/dashboard-scene/scene/DashboardControls.tsx
+++ b/public/app/features/dashboard-scene/scene/DashboardControls.tsx
@@ -35,6 +35,10 @@ export class DashboardControls extends SceneObjectBase<DashboardControlsState> {
       ...state,
     });
   }
+
+  public shouldCheckForChanges(partialState: Partial<DashboardControlsState>): boolean {
+    return 'hideTimeControls' in partialState;
+  }
 }
 
 function DashboardControlsRenderer({ model }: SceneComponentProps<DashboardControls>) {

--- a/public/app/features/dashboard-scene/scene/DashboardGridItem.tsx
+++ b/public/app/features/dashboard-scene/scene/DashboardGridItem.tsx
@@ -52,6 +52,10 @@ export class DashboardGridItem extends SceneObjectBase<DashboardGridItemState> i
     this.addActivationHandler(() => this._activationHandler());
   }
 
+  public shouldCheckForChanges() {
+    return true;
+  }
+
   private _activationHandler() {
     if (this.state.variableName) {
       this._subs.add(this.subscribeToState((newState, prevState) => this._handleGridResize(newState, prevState)));

--- a/public/app/features/dashboard-scene/scene/DashboardScene.tsx
+++ b/public/app/features/dashboard-scene/scene/DashboardScene.tsx
@@ -167,6 +167,10 @@ export class DashboardScene extends SceneObjectBase<DashboardSceneState> {
     this.addActivationHandler(() => this._activationHandler());
   }
 
+  public shouldCheckForChanges(partialState: Partial<DashboardSceneState>): boolean {
+    return Object.keys(partialState).some((key) => PERSISTED_PROPS.includes(key));
+  }
+
   private _activationHandler() {
     let prevSceneContext = window.__grafanaSceneContext;
 

--- a/public/app/features/dashboard-scene/scene/LibraryVizPanel.tsx
+++ b/public/app/features/dashboard-scene/scene/LibraryVizPanel.tsx
@@ -43,6 +43,10 @@ export class LibraryVizPanel extends SceneObjectBase<LibraryVizPanelState> {
     this.addActivationHandler(this._onActivate);
   }
 
+  public shouldCheckForChanges(partialState: Partial<LibraryVizPanelState>): boolean {
+    return 'name' in partialState;
+  }
+
   private _onActivate = () => {
     if (!this.state.isLoaded) {
       this.loadLibraryPanelFromPanelModel();

--- a/public/app/features/dashboard-scene/scene/PanelLinks.tsx
+++ b/public/app/features/dashboard-scene/scene/PanelLinks.tsx
@@ -14,6 +14,10 @@ interface VizPanelLinksState extends SceneObjectState {
 
 export class VizPanelLinks extends SceneObjectBase<VizPanelLinksState> {
   static Component = VizPanelLinksRenderer;
+
+  public shouldCheckForChanges(): boolean {
+    return true;
+  }
 }
 
 function VizPanelLinksRenderer({ model }: SceneComponentProps<VizPanelLinks>) {

--- a/public/app/features/dashboard-scene/scene/PanelTimeRange.tsx
+++ b/public/app/features/dashboard-scene/scene/PanelTimeRange.tsx
@@ -93,6 +93,10 @@ export class PanelTimeRange extends SceneTimeRangeTransformerBase<PanelTimeRange
 
     return newTimeData;
   }
+
+  public shouldCheckForChanges() {
+    return true;
+  }
 }
 
 function PanelTimeRangeRenderer({ model }: SceneComponentProps<PanelTimeRange>) {


### PR DESCRIPTION
Simplifies the large `onStateChanged` method by instead introducing a new method `shouldCheckForChanges` to the `SceneObject` interface, informing the tracker whether or not we should call `detectSaveModelChanges`.

Depends on https://github.com/grafana/scenes/pull/703