### PR TITLE
Table Panel: Fix images not showing on hover with multiple data links

### DIFF
--- a/packages/grafana-ui/src/components/Table/ImageCell.tsx
+++ b/packages/grafana-ui/src/components/Table/ImageCell.tsx
@@ -1,7 +1,5 @@
-import { cx } from '@emotion/css';
 import React from 'react';
 
-import { useStyles2 } from '../../themes';
 import { getCellLinks } from '../../utils';
 import { DataLinksContextMenu } from '../DataLinks/DataLinksContextMenu';
 

--- a/packages/grafana-ui/src/components/Table/ImageCell.tsx
+++ b/packages/grafana-ui/src/components/Table/ImageCell.tsx
@@ -3,7 +3,6 @@ import React from 'react';
 
 import { useStyles2 } from '../../themes';
 import { getCellLinks } from '../../utils';
-import { Button, clearLinkButtonStyles } from '../Button';
 import { DataLinksContextMenu } from '../DataLinks/DataLinksContextMenu';
 
 import { TableCellProps } from './types';
@@ -16,7 +15,6 @@ export const ImageCell = (props: TableCellProps) => {
   const displayValue = field.display!(cell.value);
 
   const hasLinks = Boolean(getCellLinks(field, row)?.length);
-  const clearButtonStyle = useStyles2(clearLinkButtonStyles);
 
   return (
     <div {...cellProps} className={tableStyles.cellContainer}>
@@ -27,12 +25,12 @@ export const ImageCell = (props: TableCellProps) => {
           links={() => getCellLinks(field, row) || []}
         >
           {(api) => {
-            const img = <img src={displayValue.text} className={tableStyles.imageCell} alt="" />;
+            const img = <img style={{ height: tableStyles.cellHeight - DATALINKS_HEIGHT_OFFSET, width: 'auto' }} src={displayValue.text} className={tableStyles.imageCell} alt="" />;
             if (api.openMenu) {
               return (
-                <Button className={cx(clearButtonStyle)} onClick={api.openMenu}>
+                <a onClick={api.openMenu}>
                   {img}
-                </Button>
+                </a>
               );
             } else {
               return img;

--- a/packages/grafana-ui/src/components/Table/ImageCell.tsx
+++ b/packages/grafana-ui/src/components/Table/ImageCell.tsx
@@ -32,7 +32,21 @@ export const ImageCell = (props: TableCellProps) => {
               />
             );
             if (api.openMenu) {
-              return <a onClick={api.openMenu}>{img}</a>;
+              return (
+                <div
+                  onClick={api.openMenu}
+                  role="button"
+                  tabIndex={0}
+                  onKeyDown={(e: React.KeyboardEvent) => {
+                    if (e.key === 'Enter' && api.openMenu) {
+                      // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/consistent-type-assertions
+                      api.openMenu(e as any);
+                    }
+                  }}
+                >
+                  {img}
+                </div>
+              );
             } else {
               return img;
             }

--- a/packages/grafana-ui/src/components/Table/ImageCell.tsx
+++ b/packages/grafana-ui/src/components/Table/ImageCell.tsx
@@ -25,13 +25,16 @@ export const ImageCell = (props: TableCellProps) => {
           links={() => getCellLinks(field, row) || []}
         >
           {(api) => {
-            const img = <img style={{ height: tableStyles.cellHeight - DATALINKS_HEIGHT_OFFSET, width: 'auto' }} src={displayValue.text} className={tableStyles.imageCell} alt="" />;
+            const img = (
+              <img
+                style={{ height: tableStyles.cellHeight - DATALINKS_HEIGHT_OFFSET, width: 'auto' }}
+                src={displayValue.text}
+                className={tableStyles.imageCell}
+                alt=""
+              />
+            );
             if (api.openMenu) {
-              return (
-                <a onClick={api.openMenu}>
-                  {img}
-                </a>
-              );
+              return <a onClick={api.openMenu}>{img}</a>;
             } else {
               return img;
             }


### PR DESCRIPTION
This PR fixes an issue when multiple data links are present with the image cell. When hovered the image won't show and the data links context menu isn't accessible. This fixes this by applying a height to a wrapping link tag, and by removing the usage of the `Button` component which in this case is also unnecessary.

A bit of an elaboration on the related fix here #84625

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
