### PR TITLE
datatrails: time range history state consistency when making new steps

### DIFF
--- a/public/app/features/trails/DataTrail.test.tsx
+++ b/public/app/features/trails/DataTrail.test.tsx
@@ -61,10 +61,6 @@ describe('DataTrail', () => {
         expect(trail.state.history.state.steps[1].type).toBe('metric');
       });
 
-      it('Should set history current step to 1', () => {
-        expect(trail.state.history.state.currentStep).toBe(1);
-      });
-
       it('Should set history currentStep to 1', () => {
         expect(trail.state.history.state.currentStep).toBe(1);
       });
@@ -73,12 +69,120 @@ describe('DataTrail', () => {
         expect(trail.state.history.state.steps[1].parentIndex).toBe(0);
       });
 
+      it('Should have time range `from` be default "now-6h"', () => {
+        expect(trail.state.$timeRange?.state.from).toBe('now-6h');
+      });
+
       describe('And browser back button is pressed', () => {
         locationService.getHistory().goBack();
 
         it('Should return to original URL', () => {
           const { pathname } = locationService.getLocation();
           expect(pathname).toEqual(preTrailUrl);
+        });
+      });
+
+      describe('And when changing the time range `from` to "now-1h"', () => {
+        beforeEach(() => {
+          trail.state.$timeRange?.setState({ from: 'now-1h' });
+        });
+
+        it('should sync state with url', () => {
+          expect(locationService.getSearchObject().from).toBe('now-1h');
+        });
+
+        it('should add history step', () => {
+          expect(trail.state.history.state.steps[2].type).toBe('time');
+        });
+
+        it('Should set history currentStep to 2', () => {
+          expect(trail.state.history.state.currentStep).toBe(2);
+        });
+
+        it('Should set history step 1 parentIndex to 0', () => {
+          expect(trail.state.history.state.steps[2].parentIndex).toBe(1);
+        });
+
+        it('Should have time range `from` be updated "now-1h"', () => {
+          expect(trail.state.$timeRange?.state.from).toBe('now-1h');
+        });
+
+        it('Previous history step should have previous default `from` of "now-6h"', () => {
+          expect(trail.state.history.state.steps[1].trailState.$timeRange?.state.from).toBe('now-6h');
+        });
+
+        it('Current history step should have new `from` of "now-1h"', () => {
+          expect(trail.state.history.state.steps[2].trailState.$timeRange?.state.from).toBe('now-1h');
+        });
+
+        describe('And when traversing back to step 1', () => {
+          beforeEach(() => {
+            trail.state.history.goBackToStep(1);
+          });
+
+          it('Should set history currentStep to 1', () => {
+            expect(trail.state.history.state.currentStep).toBe(1);
+          });
+
+          it('should sync state with url', () => {
+            expect(locationService.getSearchObject().from).toBe('now-6h');
+          });
+
+          it('Should have time range `from` be set back to "now-6h"', () => {
+            expect(trail.state.$timeRange?.state.from).toBe('now-6h');
+          });
+
+          describe('And then when changing the time range `from` to "now-15m"', () => {
+            beforeEach(() => {
+              trail.state.$timeRange?.setState({ from: 'now-15m' });
+            });
+
+            it('should sync state with url', () => {
+              expect(locationService.getSearchObject().from).toBe('now-15m');
+            });
+
+            it('should add history step', () => {
+              expect(trail.state.history.state.steps[3].type).toBe('time');
+            });
+
+            it('Should set history currentStep to 3', () => {
+              expect(trail.state.history.state.currentStep).toBe(3);
+            });
+
+            it('Should set history step 3 parentIndex to 1', () => {
+              expect(trail.state.history.state.steps[3].parentIndex).toBe(1);
+            });
+
+            it('Should have time range `from` be updated "now-15m"', () => {
+              expect(trail.state.$timeRange?.state.from).toBe('now-15m');
+            });
+
+            it('History step 1 (parent) should have previous default `from` of "now-6h"', () => {
+              expect(trail.state.history.state.steps[1].trailState.$timeRange?.state.from).toBe('now-6h');
+            });
+
+            it('History step 2 should stil have `from` of "now-1h"', () => {
+              expect(trail.state.history.state.steps[2].trailState.$timeRange?.state.from).toBe('now-1h');
+            });
+
+            describe('And then when returning again to step 1', () => {
+              beforeEach(() => {
+                trail.state.history.goBackToStep(1);
+              });
+
+              it('Should set history currentStep to 1', () => {
+                expect(trail.state.history.state.currentStep).toBe(1);
+              });
+
+              it('should sync state with url', () => {
+                expect(locationService.getSearchObject().from).toBe('now-6h');
+              });
+
+              it('Should have time range `from` be set back to "now-6h"', () => {
+                expect(trail.state.$timeRange?.state.from).toBe('now-6h');
+              });
+            });
+          });
         });
       });
     });
@@ -145,4 +249,6 @@ describe('DataTrail', () => {
       });
     });
   });
+
+  describe('Given starting non-embedded trail with url sync and no url state', () => {});
 });

--- a/public/app/features/trails/DataTrail.test.tsx
+++ b/public/app/features/trails/DataTrail.test.tsx
@@ -178,6 +178,18 @@ describe('DataTrail', () => {
                 expect(locationService.getSearchObject().from).toBe('now-6h');
               });
 
+              it('History step 1 (parent) should have previous default `from` of "now-6h"', () => {
+                expect(trail.state.history.state.steps[1].trailState.$timeRange?.state.from).toBe('now-6h');
+              });
+
+              it('History step 2 should still have `from` of "now-1h"', () => {
+                expect(trail.state.history.state.steps[2].trailState.$timeRange?.state.from).toBe('now-1h');
+              });
+
+              it('History step 3 should still have `from` of "now-15m"', () => {
+                expect(trail.state.history.state.steps[3].trailState.$timeRange?.state.from).toBe('now-15m');
+              });
+
               it('Should have time range `from` be set back to "now-6h"', () => {
                 expect(trail.state.$timeRange?.state.from).toBe('now-6h');
               });

--- a/public/app/features/trails/DataTrail.tsx
+++ b/public/app/features/trails/DataTrail.tsx
@@ -177,6 +177,7 @@ export class DataTrail extends SceneObjectBase<DataTrailState> {
 
     this.setState(step.trailState);
     this.syncTrailToUrl();
+    this.state.controls.forEach((control) => control.forceRender());
   }
 
   private syncTrailToUrl() {

--- a/public/app/features/trails/DataTrailsHistory.tsx
+++ b/public/app/features/trails/DataTrailsHistory.tsx
@@ -95,14 +95,14 @@ export class DataTrailHistory extends SceneObjectBase<DataTrailsHistoryState> {
         respondingToTimeChange = true;
         const previousStep = this.state.currentStep;
         this.addTrailStep(trail, 'time');
-        const newStep = this.state.currentStep;
 
-        // Ensure the previous trail step keeps the previous state
-        this.state.steps[previousStep].trailState.$timeRange?.setState(prevState);
-
-        // Stepping back and forth ensures that the time range will change properly the next time the user manually switches to previousStep
-        this.goBackToStep(previousStep);
-        this.goBackToStep(newStep);
+        // Ensure the previous trail step keeps the previous state, using a clone of the previous time range
+        const $timeRangePrevious = this.state.steps[previousStep].trailState.$timeRange;
+        if ($timeRangePrevious) {
+          this.state.steps[previousStep].trailState.$timeRange = new SceneTimeRange(
+            sceneUtils.cloneSceneObjectState($timeRangePrevious.state, prevState)
+          );
+        }
 
         respondingToTimeChange = false;
       }


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**Which issue(s) does this PR fix?**:

Changing the time range occasionally causes the state of the previous step to retain the new time range.

Steps to create problem:
- open an exploration
- select a metric 
![image](https://github.com/grafana/grafana/assets/38694490/7022f301-a180-4ddc-9545-687081039808)

- change time range to 'last 5 minutes', this creates a new step
![image](https://github.com/grafana/grafana/assets/38694490/54159126-1669-4fe4-a6b4-ef7b31eec50a)

- change time range to 'last 15 minutes', this creates a new step 
![image](https://github.com/grafana/grafana/assets/38694490/f18bb466-9163-4811-8f90-ff493920dd8d)

- go back to the third step which should have 'last 5 minutes' 
![image](https://github.com/grafana/grafana/assets/38694490/8cb91877-5c1a-457b-aa1f-dc5bdfe2d77c)

- change time range to 'last 1 hour', this should make a 'leap step'
![image](https://github.com/grafana/grafana/assets/38694490/56dba1d4-f439-4100-abb8-96da1dd0b293)

- go back to the third step again, which should have 'last 5 minutes', but instead says "last 1 hour' 
![image](https://github.com/grafana/grafana/assets/38694490/8c2f404a-2e0a-4a5b-88ad-76801fd91fbc)

Expected behavior: it should restore the time range to 'last 5 miuntes' when you select that third step.

This PR does this.
Note: Ensuring the previous history state has the previous state without stepping back and forth results in the initial step back to step 3 being incorrect, but subsequent steps will succeed, so programatically adding a back and forth step corrects the problem fully.

TODO:
- [x] Add unit tests

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
