### PR TITLE
DashboardScene: Refactor to more explicit change tracking

### DIFF
--- a/public/app/features/dashboard-scene/panel-edit/PanelEditor.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditor.tsx
@@ -4,6 +4,7 @@ import { NavIndex } from '@grafana/data';
 import { config, locationService } from '@grafana/runtime';
 import { SceneObjectBase, SceneObjectState, VizPanel } from '@grafana/scenes';
 
+import { PersistedStateChangedEvent } from '../saving/PersistedStateChangedEvent';
 import { DashboardGridItem } from '../scene/DashboardGridItem';
 import { LibraryVizPanel } from '../scene/LibraryVizPanel';
 import { getDashboardSceneFor, getPanelIdForVizPanel } from '../utils/utils';
@@ -143,6 +144,8 @@ export class PanelEditor extends SceneObjectBase<PanelEditorState> {
       width,
       height,
     });
+
+    this.publishEvent(new PersistedStateChangedEvent(), true);
   }
 
   public onSaveLibraryPanel = () => {

--- a/public/app/features/dashboard-scene/panel-edit/VizPanelManager.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/VizPanelManager.tsx
@@ -35,6 +35,7 @@ import { updateQueries } from 'app/features/query/state/updateQueries';
 import { GrafanaQuery } from 'app/plugins/datasource/grafana/types';
 import { QueryGroupOptions } from 'app/types';
 
+import { PersistedStateChangedEvent } from '../saving/PersistedStateChangedEvent';
 import { DashboardGridItem, RepeatDirection } from '../scene/DashboardGridItem';
 import { LibraryVizPanel } from '../scene/LibraryVizPanel';
 import { PanelTimeRange, PanelTimeRangeState } from '../scene/PanelTimeRange';
@@ -308,17 +309,21 @@ export class VizPanelManager extends SceneObjectBase<VizPanelManagerState> {
 
     dataObj.setState(dataObjStateUpdate);
     dataObj.runQueries();
+
+    this.publishEvent(new PersistedStateChangedEvent(), true);
   }
 
   public changeQueries<T extends DataQuery>(queries: T[]) {
-    const runner = this.queryRunner;
-    runner.setState({ queries });
+    this.queryRunner.setState({ queries });
+    this.publishEvent(new PersistedStateChangedEvent(), true);
   }
 
   public changeTransformations(transformations: DataTransformerConfig[]) {
     const dataprovider = this.dataTransformer;
     dataprovider.setState({ transformations });
     dataprovider.reprocessTransformations();
+
+    this.publishEvent(new PersistedStateChangedEvent(), true);
   }
 
   public inspectPanel() {

--- a/public/app/features/dashboard-scene/panel-edit/VizPanelManager.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/VizPanelManager.tsx
@@ -232,6 +232,8 @@ export class VizPanelManager extends SceneObjectBase<VizPanelManagerState> {
     }
 
     this.setState({ panel: newPanel });
+    this.publishEvent(new PersistedStateChangedEvent(), true);
+
     this.loadDataSource();
   }
 
@@ -250,13 +252,9 @@ export class VizPanelManager extends SceneObjectBase<VizPanelManagerState> {
     // We need to pass in newSettings.uid as well here as that can be a variable expression and we want to store that in the query model not the current ds variable value
     const queries = defaultQueries || (await updateQueries(nextDS, newSettings.uid, currentQueries, currentDS));
 
-    queryRunner.setState({
-      datasource: {
-        type: newSettings.type,
-        uid: newSettings.uid,
-      },
-      queries,
-    });
+    queryRunner.setState({ datasource: { type: newSettings.type, uid: newSettings.uid }, queries });
+    this.publishEvent(new PersistedStateChangedEvent(), true);
+
     if (defaultQueries) {
       queryRunner.runQueries();
     }
@@ -459,6 +457,21 @@ export class VizPanelManager extends SceneObjectBase<VizPanelManagerState> {
 
   public setPanelTitle(newTitle: string) {
     this.state.panel.setState({ title: newTitle, hoverHeader: newTitle === '' });
+  }
+
+  public setRepeat(repeat: string | undefined) {
+    const stateUpdate: Partial<VizPanelManagerState> = {
+      repeat,
+      repeatDirection: repeat ? this.state.repeatDirection ?? 'h' : undefined,
+    };
+
+    this.setState(stateUpdate);
+    this.publishEvent(new PersistedStateChangedEvent(), true);
+  }
+
+  public setRepeatDirection(direction: RepeatDirection) {
+    this.setState({ repeatDirection: direction });
+    this.publishEvent(new PersistedStateChangedEvent(), true);
   }
 
   public static Component = ({ model }: SceneComponentProps<VizPanelManager>) => {

--- a/public/app/features/dashboard-scene/saving/DashboardSceneChangeTracker.ts
+++ b/public/app/features/dashboard-scene/saving/DashboardSceneChangeTracker.ts
@@ -3,9 +3,7 @@ import { Subscription } from 'rxjs';
 import { SceneGridLayout, SceneObjectStateChangedEvent, VizPanel } from '@grafana/scenes';
 import { createWorker } from 'app/features/dashboard-scene/saving/createDetectChangesWorker';
 
-import { DashboardGridItem } from '../scene/DashboardGridItem';
 import { DashboardScene } from '../scene/DashboardScene';
-import { VizPanelLinks } from '../scene/PanelLinks';
 import { transformSceneToSaveModel } from '../serialization/transformSceneToSaveModel';
 import { isSceneVariableInstance } from '../settings/variables/utils';
 
@@ -27,10 +25,6 @@ export class DashboardSceneChangeTracker {
       return;
     }
 
-    // if (payload.changedObject instanceof SceneQueryRunner) {
-    //   return;
-    // }
-
     // if (payload.changedObject instanceof SceneTimeRange) {
     //   return this.runDirtyCheck();
     // }
@@ -38,17 +32,9 @@ export class DashboardSceneChangeTracker {
     // Intercept state changes for some core scene objects
     if (
       payload.changedObject instanceof VizPanel ||
-      payload.changedObject instanceof DashboardGridItem ||
-      payload.changedObject instanceof VizPanelLinks
+      payload.changedObject instanceof SceneGridLayout ||
+      isSceneVariableInstance(payload.changedObject)
     ) {
-      return this.runDirtyCheck();
-    }
-
-    if (payload.changedObject instanceof SceneGridLayout) {
-      return this.runDirtyCheck();
-    }
-
-    if (isSceneVariableInstance(payload.changedObject)) {
       return this.runDirtyCheck();
     }
   }

--- a/public/app/features/dashboard-scene/saving/PersistedStateChangedEvent.ts
+++ b/public/app/features/dashboard-scene/saving/PersistedStateChangedEvent.ts
@@ -1,0 +1,5 @@
+import { BusEventBase } from '@grafana/data';
+
+export class PersistedStateChangedEvent extends BusEventBase {
+  static type = 'dashboard-persisted-state-changed';
+}

--- a/public/app/features/dashboard-scene/scene/DashboardDataLayerSet.tsx
+++ b/public/app/features/dashboard-scene/scene/DashboardDataLayerSet.tsx
@@ -45,10 +45,6 @@ export class DashboardDataLayerSet
     };
   }
 
-  public addAnnotationLayer(layer: SceneDataLayerProvider) {
-    this.setState({ annotationLayers: [...this.state.annotationLayers, layer] });
-  }
-
   private getAllLayers() {
     const layers = [...this.state.annotationLayers];
 

--- a/public/app/features/dashboard-scene/scene/DashboardScene.tsx
+++ b/public/app/features/dashboard-scene/scene/DashboardScene.tsx
@@ -67,8 +67,6 @@ import { ScopesScene } from './ScopesScene';
 import { ViewPanelScene } from './ViewPanelScene';
 import { setupKeyboardShortcuts } from './keyboardShortcuts';
 
-export const PERSISTED_PROPS = ['title', 'description', 'tags', 'editable', 'graphTooltip', 'links', 'meta'];
-
 export interface DashboardSceneState extends SceneObjectState {
   /** The title */
   title: string;

--- a/public/app/features/dashboard-scene/scene/LibraryVizPanel.tsx
+++ b/public/app/features/dashboard-scene/scene/LibraryVizPanel.tsx
@@ -12,6 +12,7 @@ import { LibraryPanel } from '@grafana/schema';
 import { PanelModel } from 'app/features/dashboard/state';
 import { getLibraryPanel } from 'app/features/library-panels/state/api';
 
+import { PersistedStateChangedEvent } from '../saving/PersistedStateChangedEvent';
 import { createPanelDataProvider } from '../utils/createPanelDataProvider';
 
 import { DashboardGridItem } from './DashboardGridItem';
@@ -48,6 +49,11 @@ export class LibraryVizPanel extends SceneObjectBase<LibraryVizPanelState> {
       this.loadLibraryPanelFromPanelModel();
     }
   };
+
+  public setName(name: string) {
+    this.setState({ name });
+    this.publishEvent(new PersistedStateChangedEvent(), true);
+  }
 
   public setPanelFromLibPanel(libPanel: LibraryPanel) {
     if (this.state._loadedPanel?.version === libPanel.version) {

--- a/public/app/features/dashboard-scene/settings/AnnotationsEditView.tsx
+++ b/public/app/features/dashboard-scene/settings/AnnotationsEditView.tsx
@@ -5,6 +5,7 @@ import { getDataSourceSrv } from '@grafana/runtime';
 import { SceneComponentProps, SceneObjectBase, VizPanel, dataLayers } from '@grafana/scenes';
 import { Page } from 'app/core/components/Page/Page';
 
+import { PersistedStateChangedEvent } from '../saving/PersistedStateChangedEvent';
 import { DashboardAnnotationsDataLayer } from '../scene/DashboardAnnotationsDataLayer';
 import { DashboardScene } from '../scene/DashboardScene';
 import { NavToolbarActions } from '../scene/NavToolbarActions';
@@ -70,7 +71,8 @@ export class AnnotationsEditView extends SceneObjectBase<AnnotationsEditViewStat
 
     const data = dashboardSceneGraph.getDataLayers(this._dashboard);
 
-    data.addAnnotationLayer(newAnnotation);
+    data.setState({ annotationLayers: [...data.state.annotationLayers, newAnnotation] });
+    this.publishEvent(new PersistedStateChangedEvent(), true);
 
     this.setState({ editIndex: data.state.annotationLayers.length - 1 });
   };
@@ -91,15 +93,16 @@ export class AnnotationsEditView extends SceneObjectBase<AnnotationsEditViewStat
     layers.splice(idx + direction, 0, layer);
 
     data.setState({ annotationLayers: layers });
+    this.publishEvent(new PersistedStateChangedEvent(), true);
   };
 
   public onDelete = (idx: number) => {
     const data = dashboardSceneGraph.getDataLayers(this._dashboard);
     const layers = [...data.state.annotationLayers];
-
     layers.splice(idx, 1);
 
     data.setState({ annotationLayers: layers });
+    this.publishEvent(new PersistedStateChangedEvent(), true);
   };
 
   public onUpdate = (annotation: AnnotationQuery, editIndex: number) => {
@@ -111,6 +114,8 @@ export class AnnotationsEditView extends SceneObjectBase<AnnotationsEditViewStat
       isHidden: Boolean(annotation.hide),
       query: annotation,
     });
+
+    this.publishEvent(new PersistedStateChangedEvent(), true);
 
     //need to rerun the layer to update the query and
     //see the annotation on the panel

--- a/public/app/features/dashboard-scene/settings/GeneralSettingsEditView.tsx
+++ b/public/app/features/dashboard-scene/settings/GeneralSettingsEditView.tsx
@@ -24,6 +24,7 @@ import { GenAIDashDescriptionButton } from 'app/features/dashboard/components/Ge
 import { GenAIDashTitleButton } from 'app/features/dashboard/components/GenAI/GenAIDashTitleButton';
 
 import { updateNavModel } from '../pages/utils';
+import { PersistedStateChangedEvent } from '../saving/PersistedStateChangedEvent';
 import { DashboardScene } from '../scene/DashboardScene';
 import { NavToolbarActions } from '../scene/NavToolbarActions';
 import { dashboardSceneGraph } from '../utils/dashboardSceneGraph';
@@ -72,6 +73,10 @@ export class GeneralSettingsEditView
     return dashboardSceneGraph.getCursorSync(this._dashboard);
   }
 
+  public notifyChangeTracker() {
+    this.publishEvent(new PersistedStateChangedEvent(), true);
+  }
+
   public getLiveNowTimer(): behaviors.LiveNowTimer {
     const liveNowTimer = sceneGraph.findObject(this._dashboard, (s) => s instanceof behaviors.LiveNowTimer);
     if (liveNowTimer instanceof behaviors.LiveNowTimer) {
@@ -87,14 +92,17 @@ export class GeneralSettingsEditView
 
   public onTitleChange = (value: string) => {
     this._dashboard.setState({ title: value });
+    this.notifyChangeTracker();
   };
 
   public onDescriptionChange = (value: string) => {
     this._dashboard.setState({ description: value });
+    this.notifyChangeTracker();
   };
 
   public onTagsChange = (value: string[]) => {
     this._dashboard.setState({ tags: value });
+    this.notifyChangeTracker();
   };
 
   public onFolderChange = async (newUID: string | undefined, newTitle: string | undefined) => {
@@ -109,49 +117,46 @@ export class GeneralSettingsEditView
     }
 
     this._dashboard.setState({ meta: newMeta });
+    this.notifyChangeTracker();
   };
 
   public onEditableChange = (value: boolean) => {
     this._dashboard.setState({ editable: value });
+    this.notifyChangeTracker();
   };
 
   public onTimeZoneChange = (value: TimeZone) => {
-    this.getTimeRange().setState({
-      timeZone: value,
-    });
+    this.getTimeRange().setState({ timeZone: value });
+    this.notifyChangeTracker();
   };
 
   public onWeekStartChange = (value: string) => {
-    this.getTimeRange().setState({
-      weekStart: value,
-    });
+    this.getTimeRange().setState({ weekStart: value });
+    this.notifyChangeTracker();
   };
 
   public onRefreshIntervalChange = (value: string[]) => {
     const control = this.getRefreshPicker();
-    control?.setState({
-      intervals: value,
-    });
+    control?.setState({ intervals: value });
+    this.notifyChangeTracker();
   };
 
   public onNowDelayChange = (value: string) => {
     const timeRange = this.getTimeRange();
-
-    timeRange?.setState({
-      UNSAFE_nowDelay: value,
-    });
+    timeRange?.setState({ UNSAFE_nowDelay: value });
+    this.notifyChangeTracker();
   };
 
   public onHideTimePickerChange = (value: boolean) => {
-    this.getDashboardControls()?.setState({
-      hideTimeControls: value,
-    });
+    this.getDashboardControls()?.setState({ hideTimeControls: value });
+    this.notifyChangeTracker();
   };
 
   public onLiveNowChange = (enable: boolean) => {
     try {
       const liveNow = this.getLiveNowTimer();
       enable ? liveNow.enable() : liveNow.disable();
+      this.notifyChangeTracker();
     } catch (err) {
       console.error(err);
     }
@@ -159,6 +164,7 @@ export class GeneralSettingsEditView
 
   public onTooltipChange = (value: number) => {
     this.getCursorSync()?.setState({ sync: value });
+    this.notifyChangeTracker();
   };
 
   static Component = ({ model }: SceneComponentProps<GeneralSettingsEditView>) => {

--- a/public/app/features/dashboard-scene/settings/variables/VariableEditorList.tsx
+++ b/public/app/features/dashboard-scene/settings/variables/VariableEditorList.tsx
@@ -135,7 +135,7 @@ function EmptyVariablesList({ onAdd }: { onAdd: () => void }): ReactElement {
 
 const getStyles = () => ({
   tableContainer: css({
-    overflow: 'scroll',
+    overflow: 'auto',
     width: '100%',
   }),
 });

--- a/public/app/features/dashboard-scene/utils/dashboardSceneGraph.ts
+++ b/public/app/features/dashboard-scene/utils/dashboardSceneGraph.ts
@@ -1,5 +1,6 @@
-import { VizPanel, SceneGridRow, sceneGraph, SceneGridLayout, behaviors } from '@grafana/scenes';
+import { VizPanel, SceneGridRow, sceneGraph, SceneGridLayout, behaviors, SceneObject } from '@grafana/scenes';
 
+import { PersistedStateChangedEvent } from '../saving/PersistedStateChangedEvent';
 import { DashboardDataLayerSet } from '../scene/DashboardDataLayerSet';
 import { DashboardGridItem } from '../scene/DashboardGridItem';
 import { DashboardScene } from '../scene/DashboardScene';
@@ -129,7 +130,7 @@ export function getNextPanelId(dashboard: DashboardScene): number {
 }
 
 // Returns the LibraryVizPanel that corresponds to the given VizPanel if it exists
-export const getLibraryVizPanelFromVizPanel = (vizPanel: VizPanel): LibraryVizPanel | null => {
+export function getLibraryVizPanelFromVizPanel(vizPanel: VizPanel): LibraryVizPanel | null {
   if (vizPanel.parent instanceof LibraryVizPanel) {
     return vizPanel.parent;
   }
@@ -139,7 +140,11 @@ export const getLibraryVizPanelFromVizPanel = (vizPanel: VizPanel): LibraryVizPa
   }
 
   return null;
-};
+}
+
+export function publishPersistedStateChangeEvent(context: SceneObject) {
+  context.publishEvent(new PersistedStateChangedEvent(), true);
+}
 
 export const dashboardSceneGraph = {
   getTimePicker,
@@ -149,4 +154,5 @@ export const dashboardSceneGraph = {
   getDataLayers,
   getNextPanelId,
   getCursorSync,
+  publishPersistedStateChangeEvent,
 };

--- a/public/app/features/dashboard/components/PanelEditor/getVisualizationOptions.tsx
+++ b/public/app/features/dashboard/components/PanelEditor/getVisualizationOptions.tsx
@@ -170,7 +170,7 @@ export function getLibraryVizPanelOptionsCategory(libraryPanel: LibraryVizPanel)
               id="LibraryPanelFrameName"
               data-testid="library panel name input"
               defaultValue={libraryPanel.state.name}
-              onBlur={(e) => libraryPanel.setState({ name: e.currentTarget.value })}
+              onBlur={(e) => libraryPanel.setName(e.currentTarget.value)}
             />
           );
         },


### PR DESCRIPTION
Exploring alternatives to https://github.com/grafana/scenes/pull/703 and https://github.com/grafana/grafana/pull/86719 

I agree that the current change tracker is a bit messy. 

I think one possible solution is to be more explicit, we know in the code when we make persisted state changes. So instead of relying on a centralized system to detect / listen for all state changes we could emit a specific event (PersistedStateChangedEvent) which will trigger a persisted diff check (and update isDirty). 

The only object where this is a bit tricky is VizPanel which technically we do not control all pathways that can change state (For example via legend toggle, or panel plugin triggering an option or field config change), so that is the only object that we still use the generic state change listener for. 

Todo
* [x] Dashboard top prop changes
* [x] Time options 
* [x] Panel edit state changes
* [x] Annotations 
* [x] Variable list actions 
* [ ] Variable editor actions 
* [ ] Dashboard links
* [ ] Row options 
* [ ] Update unit tests

