### PR TITLE
Alerting: Fix datasource TLS options are ignored

### DIFF
--- a/pkg/services/datasources/datasources.go
+++ b/pkg/services/datasources/datasources.go
@@ -55,10 +55,8 @@ type DataSourceService interface {
 	// decrypted value.
 	DecryptedPassword(ctx context.Context, ds *DataSource) (string, error)
 
-	// CustomHeaders returns a map of custom headers the user might have
-	// configured for this Datasource. Not every datasource can has the option
-	// to configure those.
-	CustomHeaders(ctx context.Context, ds *DataSource) (http.Header, error)
+	// HTTPClientOptions returns the HTTP client options for the datasource.
+	HTTPClientOptions(ctx context.Context, ds *DataSource) (*sdkhttpclient.Options, error)
 }
 
 // CacheService interface for retrieving a cached datasource.

--- a/pkg/services/datasources/fakes/fake_datasource_service.go
+++ b/pkg/services/datasources/fakes/fake_datasource_service.go
@@ -18,7 +18,7 @@ type FakeDataSourceService struct {
 
 var _ datasources.DataSourceService = &FakeDataSourceService{}
 
-func (s *FakeDataSourceService) GetDataSource(ctx context.Context, query *datasources.GetDataSourceQuery) (*datasources.DataSource, error) {
+func (s *FakeDataSourceService) GetDataSource(_ context.Context, query *datasources.GetDataSourceQuery) (*datasources.DataSource, error) {
 	for _, dataSource := range s.DataSources {
 		idMatch := query.ID != 0 && query.ID == dataSource.ID
 		uidMatch := query.UID != "" && query.UID == dataSource.UID
@@ -30,7 +30,7 @@ func (s *FakeDataSourceService) GetDataSource(ctx context.Context, query *dataso
 	return nil, datasources.ErrDataSourceNotFound
 }
 
-func (s *FakeDataSourceService) GetDataSources(ctx context.Context, query *datasources.GetDataSourcesQuery) ([]*datasources.DataSource, error) {
+func (s *FakeDataSourceService) GetDataSources(_ context.Context, query *datasources.GetDataSourcesQuery) ([]*datasources.DataSource, error) {
 	var dataSources []*datasources.DataSource
 	for _, datasource := range s.DataSources {
 		orgMatch := query.OrgID != 0 && query.OrgID == datasource.OrgID
@@ -41,7 +41,7 @@ func (s *FakeDataSourceService) GetDataSources(ctx context.Context, query *datas
 	return dataSources, nil
 }
 
-func (s *FakeDataSourceService) GetAllDataSources(ctx context.Context, query *datasources.GetAllDataSourcesQuery) (res []*datasources.DataSource, err error) {
+func (s *FakeDataSourceService) GetAllDataSources(_ context.Context, _ *datasources.GetAllDataSourcesQuery) (res []*datasources.DataSource, err error) {
 	return s.DataSources, nil
 }
 
@@ -55,7 +55,7 @@ func (s *FakeDataSourceService) GetPrunableProvisionedDataSources(ctx context.Co
 	return dataSources, nil
 }
 
-func (s *FakeDataSourceService) GetDataSourcesByType(ctx context.Context, query *datasources.GetDataSourcesByTypeQuery) ([]*datasources.DataSource, error) {
+func (s *FakeDataSourceService) GetDataSourcesByType(_ context.Context, query *datasources.GetDataSourcesByTypeQuery) ([]*datasources.DataSource, error) {
 	var dataSources []*datasources.DataSource
 	for _, datasource := range s.DataSources {
 		if query.OrgID > 0 && datasource.OrgID != query.OrgID {
@@ -69,7 +69,7 @@ func (s *FakeDataSourceService) GetDataSourcesByType(ctx context.Context, query 
 	return dataSources, nil
 }
 
-func (s *FakeDataSourceService) AddDataSource(ctx context.Context, cmd *datasources.AddDataSourceCommand) (*datasources.DataSource, error) {
+func (s *FakeDataSourceService) AddDataSource(_ context.Context, cmd *datasources.AddDataSourceCommand) (*datasources.DataSource, error) {
 	if s.lastID == 0 {
 		s.lastID = int64(len(s.DataSources) - 1)
 	}
@@ -84,7 +84,7 @@ func (s *FakeDataSourceService) AddDataSource(ctx context.Context, cmd *datasour
 	return dataSource, nil
 }
 
-func (s *FakeDataSourceService) DeleteDataSource(ctx context.Context, cmd *datasources.DeleteDataSourceCommand) error {
+func (s *FakeDataSourceService) DeleteDataSource(_ context.Context, cmd *datasources.DeleteDataSourceCommand) error {
 	for i, datasource := range s.DataSources {
 		idMatch := cmd.ID != 0 && cmd.ID == datasource.ID
 		uidMatch := cmd.UID != "" && cmd.UID == datasource.UID
@@ -97,7 +97,7 @@ func (s *FakeDataSourceService) DeleteDataSource(ctx context.Context, cmd *datas
 	return datasources.ErrDataSourceNotFound
 }
 
-func (s *FakeDataSourceService) UpdateDataSource(ctx context.Context, cmd *datasources.UpdateDataSourceCommand) (*datasources.DataSource, error) {
+func (s *FakeDataSourceService) UpdateDataSource(_ context.Context, cmd *datasources.UpdateDataSourceCommand) (*datasources.DataSource, error) {
 	for _, datasource := range s.DataSources {
 		idMatch := cmd.ID != 0 && cmd.ID == datasource.ID
 		uidMatch := cmd.UID != "" && cmd.UID == datasource.UID
@@ -112,7 +112,7 @@ func (s *FakeDataSourceService) UpdateDataSource(ctx context.Context, cmd *datas
 	return nil, datasources.ErrDataSourceNotFound
 }
 
-func (s *FakeDataSourceService) GetHTTPTransport(ctx context.Context, ds *datasources.DataSource, provider httpclient.Provider, customMiddlewares ...sdkhttpclient.Middleware) (http.RoundTripper, error) {
+func (s *FakeDataSourceService) GetHTTPTransport(_ context.Context, _ *datasources.DataSource, provider httpclient.Provider, customMiddlewares ...sdkhttpclient.Middleware) (http.RoundTripper, error) {
 	rt, err := provider.GetTransport(sdkhttpclient.Options{})
 	if err != nil {
 		return nil, err
@@ -120,7 +120,7 @@ func (s *FakeDataSourceService) GetHTTPTransport(ctx context.Context, ds *dataso
 	return rt, nil
 }
 
-func (s *FakeDataSourceService) DecryptedValues(ctx context.Context, ds *datasources.DataSource) (map[string]string, error) {
+func (s *FakeDataSourceService) DecryptedValues(_ context.Context, _ *datasources.DataSource) (map[string]string, error) {
 	if s.SimulatePluginFailure {
 		return nil, datasources.ErrDatasourceSecretsPluginUserFriendly{Err: "unknown error"}
 	}
@@ -128,18 +128,18 @@ func (s *FakeDataSourceService) DecryptedValues(ctx context.Context, ds *datasou
 	return values, nil
 }
 
-func (s *FakeDataSourceService) DecryptedValue(ctx context.Context, ds *datasources.DataSource, key string) (string, bool, error) {
+func (s *FakeDataSourceService) DecryptedValue(_ context.Context, _ *datasources.DataSource, key string) (string, bool, error) {
 	return "", false, nil
 }
 
-func (s *FakeDataSourceService) DecryptedBasicAuthPassword(ctx context.Context, ds *datasources.DataSource) (string, error) {
+func (s *FakeDataSourceService) DecryptedBasicAuthPassword(_ context.Context, _ *datasources.DataSource) (string, error) {
 	return "", nil
 }
 
-func (s *FakeDataSourceService) DecryptedPassword(ctx context.Context, ds *datasources.DataSource) (string, error) {
+func (s *FakeDataSourceService) DecryptedPassword(_ context.Context, _ *datasources.DataSource) (string, error) {
 	return "", nil
 }
 
-func (s *FakeDataSourceService) CustomHeaders(ctx context.Context, ds *datasources.DataSource) (http.Header, error) {
+func (s *FakeDataSourceService) CustomHeaders(_ context.Context, _ *datasources.DataSource) (http.Header, error) {
 	return nil, nil
 }

--- a/pkg/services/datasources/fakes/fake_datasource_service.go
+++ b/pkg/services/datasources/fakes/fake_datasource_service.go
@@ -140,6 +140,6 @@ func (s *FakeDataSourceService) DecryptedPassword(_ context.Context, _ *datasour
 	return "", nil
 }
 
-func (s *FakeDataSourceService) CustomHeaders(_ context.Context, _ *datasources.DataSource) (http.Header, error) {
+func (s *FakeDataSourceService) HTTPClientOptions(_ context.Context, _ *datasources.DataSource) (*sdkhttpclient.Options, error) {
 	return nil, nil
 }

--- a/pkg/services/datasources/service/datasource.go
+++ b/pkg/services/datasources/service/datasource.go
@@ -438,6 +438,10 @@ func (s *Service) DecryptedPassword(ctx context.Context, ds *datasources.DataSou
 	return "", err
 }
 
+func (s *Service) HTTPClientOptions(ctx context.Context, ds *datasources.DataSource) (*sdkhttpclient.Options, error) {
+	return s.httpClientOptions(ctx, ds)
+}
+
 func (s *Service) httpClientOptions(ctx context.Context, ds *datasources.DataSource) (*sdkhttpclient.Options, error) {
 	tlsOptions, err := s.dsTLSOptions(ctx, ds)
 	if err != nil {
@@ -747,13 +751,4 @@ func readQuotaConfig(cfg *setting.Cfg) (*quota.Map, error) {
 	limits.Set(globalQuotaTag, cfg.Quota.Global.DataSource)
 	limits.Set(orgQuotaTag, cfg.Quota.Org.DataSource)
 	return limits, nil
-}
-
-// CustomerHeaders returns the custom headers specified in the datasource. The context is used for the decryption operation that might use the store, so consider setting an acceptable timeout for your use case.
-func (s *Service) CustomHeaders(ctx context.Context, ds *datasources.DataSource) (http.Header, error) {
-	values, err := s.SecretsService.DecryptJsonData(ctx, ds.SecureJsonData)
-	if err != nil {
-		return nil, fmt.Errorf("failed to get custom headers: %w", err)
-	}
-	return s.getCustomHeaders(ds.JsonData, values), nil
 }

--- a/pkg/services/ngalert/remote/alertmanager.go
+++ b/pkg/services/ngalert/remote/alertmanager.go
@@ -119,7 +119,7 @@ func NewAlertmanager(cfg AlertmanagerConfig, store stateStore, decryptFn Decrypt
 	s := sender.NewExternalAlertmanagerSender(sender.WithDoFunc(doFunc))
 	s.Run()
 
-	// Prepend /alertmanager to the URL, but just for the sender.
+	// Append /alertmanager to the URL, but just for the sender.
 	// We don't want to use senderURL in &Alertmanager{}.
 	senderURL, err := url.Parse(cfg.URL)
 	if err != nil {

--- a/pkg/services/ngalert/sender/router.go
+++ b/pkg/services/ngalert/sender/router.go
@@ -129,7 +129,7 @@ func (d *AlertsRouter) SyncAndApplyConfigFromDatabase() error {
 		}
 
 		// Avoid logging sensitive data
-		redactedAMs := buildRedactedAMs(d.logger, alertmanagers, cfg.OrgID)
+		redactedAMs := buildRedactedAMs(alertmanagers, cfg.OrgID)
 		d.logger.Debug("Alertmanagers found in the configuration", "alertmanagers", redactedAMs)
 
 		var hashes []string
@@ -192,7 +192,7 @@ func (d *AlertsRouter) SyncAndApplyConfigFromDatabase() error {
 	return nil
 }
 
-func buildRedactedAMs(l log.Logger, alertmanagers []ExternalAlertmanagerConfig, ordId int64) []string {
+func buildRedactedAMs(alertmanagers []ExternalAlertmanagerConfig, ordId int64) []string {
 	var redactedAMs []string
 	for _, am := range alertmanagers {
 		redactedAMs = append(redactedAMs, am.URL.Redacted())

--- a/pkg/services/ngalert/sender/router_test.go
+++ b/pkg/services/ngalert/sender/router_test.go
@@ -16,7 +16,6 @@ import (
 
 	"github.com/grafana/grafana/pkg/components/simplejson"
 	"github.com/grafana/grafana/pkg/infra/log"
-	"github.com/grafana/grafana/pkg/infra/log/logtest"
 	"github.com/grafana/grafana/pkg/services/datasources"
 	fake_ds "github.com/grafana/grafana/pkg/services/datasources/fakes"
 	"github.com/grafana/grafana/pkg/services/featuremgmt"
@@ -607,8 +606,6 @@ func TestAlertManegers_asSHA256(t *testing.T) {
 }
 
 func TestAlertManagers_buildRedactedAMs(t *testing.T) {
-	fakeLogger := logtest.Fake{}
-
 	tc := []struct {
 		name     string
 		orgId    int64
@@ -638,15 +635,15 @@ func TestAlertManagers_buildRedactedAMs(t *testing.T) {
 
 	for _, tt := range tc {
 		t.Run(tt.name, func(t *testing.T) {
-			var cfgs []ExternalAMcfg
-			for _, url := range tt.amUrls {
-				cfgs = append(cfgs, ExternalAMcfg{
-					URL: url,
+			var cfgs []ExternalAlertmanagerConfig
+			for _, s := range tt.amUrls {
+				u, err := url.Parse(s)
+				require.NoError(t, err)
+				cfgs = append(cfgs, ExternalAlertmanagerConfig{
+					URL: u,
 				})
 			}
-			require.Equal(t, tt.expected, buildRedactedAMs(&fakeLogger, cfgs, tt.orgId))
-			require.Equal(t, tt.errCalls, fakeLogger.ErrorLogs.Calls)
-			require.Equal(t, tt.errLog, fakeLogger.ErrorLogs.Message)
+			require.Equal(t, tt.expected, buildRedactedAMs(cfgs, tt.orgId))
 		})
 	}
 }


### PR DESCRIPTION
**Which issue(s) does this PR fix?**:

This commit fixes a bug where datasource TLS options are ignored when sending alerts from Grafana to an External Alertmanager.

Fixes #66238

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
