### PR TITLE
Dashboard: Migration [Panel Edit] Missing Query Editor when datasource is not found 

### DIFF
--- a/public/app/features/dashboard-scene/panel-edit/VizPanelManager.test.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/VizPanelManager.test.tsx
@@ -1,7 +1,7 @@
 import { map, of } from 'rxjs';
 
 import { DataQueryRequest, DataSourceApi, DataSourceInstanceSettings, LoadingState, PanelData } from '@grafana/data';
-import { locationService } from '@grafana/runtime';
+import { config, getDataSourceSrv, locationService } from '@grafana/runtime';
 import { SceneQueryRunner, VizPanel } from '@grafana/scenes';
 import { DataQuery, DataSourceJsonData, DataSourceRef } from '@grafana/schema';
 import { getDashboardSrv } from 'app/features/dashboard/services/DashboardSrv';
@@ -75,6 +75,18 @@ const ds3Mock: DataSourceApi = {
   },
 } as DataSourceApi<DataQuery, DataSourceJsonData, {}>;
 
+const defaultDsMock: DataSourceApi = {
+  meta: {
+    id: 'grafana-testdata-datasource',
+  },
+  name: 'grafana-testdata-datasource',
+  type: 'grafana-testdata-datasource',
+  uid: 'gdev-testdata',
+  getRef: () => {
+    return { type: 'grafana-testdata-datasource', uid: 'gdev-testdata' };
+  },
+} as DataSourceApi<DataQuery, DataSourceJsonData, {}>;
+
 const instance1SettingsMock = {
   id: 1,
   uid: 'gdev-testdata',
@@ -124,6 +136,7 @@ jest.mock('@grafana/runtime', () => ({
   getDataSourceSrv: () => ({
     get: async (ref: DataSourceRef) => {
       // Mocking the build in Grafana data source to avoid annotations data layer errors.
+
       if (ref.uid === '-- Grafana --') {
         return grafanaDs;
       }
@@ -140,7 +153,8 @@ jest.mock('@grafana/runtime', () => ({
         return ds3Mock;
       }
 
-      return null;
+      // if datasource is not found, return default datasource
+      return defaultDsMock;
     },
     getInstanceSettings: (ref: DataSourceRef) => {
       if (ref.uid === 'gdev-testdata') {
@@ -151,11 +165,16 @@ jest.mock('@grafana/runtime', () => ({
         return instance2SettingsMock;
       }
 
-      return null;
+      // if datasource is not found, return default instance settings
+      return instance1SettingsMock;
     },
   }),
   locationService: {
     partial: jest.fn(),
+  },
+  config: {
+    ...jest.requireActual('@grafana/runtime').config,
+    defaultDatasource: 'gdev-testdata',
   },
 }));
 
@@ -349,6 +368,21 @@ describe('VizPanelManager', () => {
           dashboardUid: 'ffbe00e2-803c-4d49-adb7-41aad336234f',
           datasourceUid: 'gdev-testdata',
         });
+      });
+
+      it('should load default datasource if the datasource passed is not found', async () => {
+        const { vizPanelManager } = setupTest('panel-6');
+        vizPanelManager.activate();
+        await Promise.resolve();
+
+        expect(vizPanelManager.queryRunner.state.datasource).toEqual({
+          uid: 'abc',
+          type: 'datasource',
+        });
+
+        expect(config.defaultDatasource).toBe('gdev-testdata');
+        expect(vizPanelManager.state.datasource).toEqual(defaultDsMock);
+        expect(vizPanelManager.state.dsSettings).toEqual(instance1SettingsMock);
       });
     });
 

--- a/public/app/features/dashboard-scene/panel-edit/VizPanelManager.test.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/VizPanelManager.test.tsx
@@ -1,7 +1,6 @@
 import { map, of } from 'rxjs';
 
 import { DataQueryRequest, DataSourceApi, DataSourceInstanceSettings, LoadingState, PanelData } from '@grafana/data';
-import { config, getDataSourceSrv, locationService } from '@grafana/runtime';
 import { SceneQueryRunner, VizPanel } from '@grafana/scenes';
 import { DataQuery, DataSourceJsonData, DataSourceRef } from '@grafana/schema';
 import { getDashboardSrv } from 'app/features/dashboard/services/DashboardSrv';

--- a/public/app/features/dashboard-scene/panel-edit/VizPanelManager.test.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/VizPanelManager.test.tsx
@@ -1,6 +1,7 @@
 import { map, of } from 'rxjs';
 
 import { DataQueryRequest, DataSourceApi, DataSourceInstanceSettings, LoadingState, PanelData } from '@grafana/data';
+import { config, locationService } from '@grafana/runtime';
 import { SceneQueryRunner, VizPanel } from '@grafana/scenes';
 import { DataQuery, DataSourceJsonData, DataSourceRef } from '@grafana/schema';
 import { getDashboardSrv } from 'app/features/dashboard/services/DashboardSrv';

--- a/public/app/features/dashboard-scene/panel-edit/VizPanelManager.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/VizPanelManager.tsx
@@ -154,6 +154,17 @@ export class VizPanelManager extends SceneObjectBase<VizPanelManagerState> {
         );
       }
     } catch (err) {
+      //set default datasource if we fail to load the datasource
+      const datasource = await getDataSourceSrv().get(config.defaultDatasource);
+      const dsSettings = getDataSourceSrv().getInstanceSettings(config.defaultDatasource);
+
+      if (datasource && dsSettings) {
+        this.setState({
+          datasource,
+          dsSettings,
+        });
+      }
+
       console.error(err);
     }
   }

--- a/public/app/features/dashboard-scene/panel-edit/VizPanelManager.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/VizPanelManager.tsx
@@ -163,6 +163,13 @@ export class VizPanelManager extends SceneObjectBase<VizPanelManagerState> {
           datasource,
           dsSettings,
         });
+
+        this.queryRunner.setState({
+          datasource: {
+            uid: dsSettings.uid,
+            type: dsSettings.type,
+          },
+        });
       }
 
       console.error(err);

--- a/public/app/features/dashboard-scene/panel-edit/testfiles/testDashboard.ts
+++ b/public/app/features/dashboard-scene/panel-edit/testfiles/testDashboard.ts
@@ -410,6 +410,94 @@ export const panelWithNoDataSource = {
   title: 'Panel with no data source',
   type: 'timeseries',
 };
+
+export const panelWithDataSourceNotFound = {
+  datasource: {
+    type: 'datasource',
+    uid: 'abc',
+  },
+  fieldConfig: {
+    defaults: {
+      color: {
+        mode: 'palette-classic',
+      },
+      custom: {
+        axisBorderShow: false,
+        axisCenteredZero: false,
+        axisColorMode: 'text',
+        axisLabel: '',
+        axisPlacement: 'auto',
+        barAlignment: 0,
+        drawStyle: 'line',
+        fillOpacity: 0,
+        gradientMode: 'none',
+        hideFrom: {
+          legend: false,
+          tooltip: false,
+          viz: false,
+        },
+        insertNulls: false,
+        lineInterpolation: 'linear',
+        lineWidth: 1,
+        pointSize: 5,
+        scaleDistribution: {
+          type: 'linear',
+        },
+        showPoints: 'auto',
+        spanNulls: false,
+        stacking: {
+          group: 'A',
+          mode: 'none',
+        },
+        thresholdsStyle: {
+          mode: 'off',
+        },
+      },
+      mappings: [],
+      thresholds: {
+        mode: 'absolute',
+        steps: [
+          {
+            color: 'green',
+            value: null,
+          },
+          {
+            color: 'red',
+            value: 80,
+          },
+        ],
+      },
+    },
+    overrides: [],
+  },
+  gridPos: {
+    h: 8,
+    w: 12,
+    x: 0,
+    y: 0,
+  },
+  id: 6,
+  options: {
+    legend: {
+      calcs: [],
+      displayMode: 'list',
+      placement: 'bottom',
+      showLegend: true,
+    },
+    tooltip: {
+      mode: 'single',
+      sort: 'none',
+    },
+  },
+  targets: [
+    {
+      refId: 'A',
+    },
+  ],
+  title: 'Panel with no data source',
+  type: 'timeseries',
+};
+
 export const testDashboard = {
   annotations: {
     list: [
@@ -439,6 +527,7 @@ export const testDashboard = {
     panelWithDashboardQuery,
     panelWithDashboardQueryAndTransformations,
     panelWithNoDataSource,
+    panelWithDataSourceNotFound,
   ],
   refresh: '',
   schemaVersion: 39,


### PR DESCRIPTION
When a panel loads if the datasource was not found we were missing the query editor. 
This PR falls back to the default datasource if that scenario happens (old architecture had this behavior).


https://github.com/grafana/grafana/assets/239999/96fa49da-3e48-4c10-94eb-9df4cd67246b




Fixes #86500


