### PR TITLE
Alerting: Add updated MSW approach reusing handlers

### DIFF
--- a/public/app/features/alerting/unified/mockApi.ts
+++ b/public/app/features/alerting/unified/mockApi.ts
@@ -424,10 +424,10 @@ export function mockDashboardApi(server: SetupServer) {
   };
 }
 
+const server = setupServer();
+
 // Creates a MSW server and sets up beforeAll, afterAll and beforeEach handlers for it
 export function setupMswServer() {
-  const server = setupServer();
-
   beforeAll(() => {
     setBackendSrv(backendSrv);
     server.listen({ onUnhandledRequest: 'error' });
@@ -443,3 +443,5 @@ export function setupMswServer() {
 
   return server;
 }
+
+export default server;

--- a/public/app/features/alerting/unified/mocks/server/configure.ts
+++ b/public/app/features/alerting/unified/mocks/server/configure.ts
@@ -1,0 +1,15 @@
+import server from 'app/features/alerting/unified/mockApi';
+import { alertmanagerChoiceHandler } from 'app/features/alerting/unified/mocks/server/handlers';
+import { AlertmanagerChoice } from 'app/plugins/datasource/alertmanager/types';
+
+/**
+ * Makes the mock server respond in a way that matches the different behaviour associated with
+ * Alertmanager choices and the number of configured external alertmanagers
+ */
+export const setAlertmanagerChoices = (alertmanagersChoice: AlertmanagerChoice, numExternalAlertmanagers: number) => {
+  const response = {
+    alertmanagersChoice,
+    numExternalAlertmanagers,
+  };
+  server.use(alertmanagerChoiceHandler(response));
+};

--- a/public/app/features/alerting/unified/mocks/server/handlers.ts
+++ b/public/app/features/alerting/unified/mocks/server/handlers.ts
@@ -1,0 +1,10 @@
+/**
+ * Contains definitions for all handlers that are required for test rendering of components within Alerting
+ */
+
+import { HttpResponse, http } from 'msw';
+
+import { defaultAlertmanagerChoiceResponse } from 'app/features/alerting/unified/mocks/alertmanagerApi';
+
+export const alertmanagerChoiceHandler = (response = defaultAlertmanagerChoiceResponse) =>
+  http.get('/api/v1/ngalert', () => HttpResponse.json(response));


### PR DESCRIPTION
**What is this feature?**
Updates the way we use the MSW mock server within our Alerting tests, so we reduce duplication across tests/decouple the tests from knowing too much about how the server functions
