### PR TITLE
Propagate `X-Scope-OrgID` from Grafana frontend to datasources

### DIFF
--- a/pkg/services/pluginsintegration/clientmiddleware/tracing_header_middleware.go
+++ b/pkg/services/pluginsintegration/clientmiddleware/tracing_header_middleware.go
@@ -34,7 +34,7 @@ func (m *TracingHeaderMiddleware) applyHeaders(ctx context.Context, req backend.
 		return
 	}
 
-	var headersList = []string{query.HeaderQueryGroupID, query.HeaderPanelID, query.HeaderDashboardUID, query.HeaderDatasourceUID, query.HeaderFromExpression, `X-Grafana-Org-Id`, query.HeaderPanelPluginId}
+	var headersList = []string{query.HeaderQueryGroupID, query.HeaderPanelID, query.HeaderDashboardUID, query.HeaderDatasourceUID, query.HeaderFromExpression, `X-Grafana-Org-Id`, query.HeaderPanelPluginId, `X-Scope-OrgID`}
 
 	for _, headerName := range headersList {
 		gotVal := reqCtx.Req.Header.Get(headerName)


### PR DESCRIPTION
**What is this feature?**

This change propagates the `X-Scope-OrgID` header, used by Grafana Mimir to segment tenants, from the grafana frontend to datasources.

**Why do we need this feature?**

So that we can deploy a multi-tenant Grafana server behind a reverse proxy that injects the `X-Scope-OrgID` into requests sent to our own hosted Grafana.

**Who is this feature for?**

This is primarily for users who need to deploy a multi-tenant version of Grafana in conjunction with Mimir.

**Special notes for your reviewer:**

Please check that:
- [X] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.

Original author of this change was @baloo.

Closes #87364.