### PR TITLE
datatrails: adhoc filters history state consistency when making new steps

### DIFF
--- a/public/app/features/trails/DataTrail.tsx
+++ b/public/app/features/trails/DataTrail.tsx
@@ -181,7 +181,8 @@ export class DataTrail extends SceneObjectBase<DataTrailState> {
     // Begin re-render of controls
     //
     // Ensure that the trail renders the current state values for the time range controls and the adhoc filter control.
-    // Otherwise, the state values that we test against would be correct, but the rendering on screen would be incorrect
+    // Otherwise, while the state values that we test against would be correct, the rendering on screen would be incorrect for certain transitions
+    // (e.g., when going back to a non-final index parent step which created a new history step due to change in filters or time range, due to how we correct parent steps in those cases)
 
     // Forces a rerender of the controls
     this.state.controls.forEach((control) => control.forceRender());

--- a/public/app/features/trails/DataTrail.tsx
+++ b/public/app/features/trails/DataTrail.tsx
@@ -178,6 +178,14 @@ export class DataTrail extends SceneObjectBase<DataTrailState> {
     this.setState(step.trailState);
     this.syncTrailToUrl();
     this.state.controls.forEach((control) => control.forceRender());
+
+    // Forces a reconstruction of VariableValueSelectors so that it always renders the variables correctly (e.g., filters) after all step changes
+    // Otherwise, the state values that we test against would be correct, but the rendering on screen would be incorrect
+    this.setState({
+      controls: this.state.controls.map((control) =>
+        control instanceof VariableValueSelectors ? control.clone() : control
+      ),
+    });
   }
 
   private syncTrailToUrl() {

--- a/public/app/features/trails/DataTrail.tsx
+++ b/public/app/features/trails/DataTrail.tsx
@@ -177,15 +177,22 @@ export class DataTrail extends SceneObjectBase<DataTrailState> {
 
     this.setState(step.trailState);
     this.syncTrailToUrl();
+
+    // Begin re-render of controls
+    //
+    // Ensure that the trail renders the current state values for the time range controls and the adhoc filter control.
+    // Otherwise, the state values that we test against would be correct, but the rendering on screen would be incorrect
+
+    // Forces a rerender of the controls
     this.state.controls.forEach((control) => control.forceRender());
 
-    // Forces a reconstruction of VariableValueSelectors so that it always renders the variables correctly (e.g., filters) after all step changes
-    // Otherwise, the state values that we test against would be correct, but the rendering on screen would be incorrect
+    // Force reconstruction of VariableValueSelectors so that it always renders the filter variables correctly
     this.setState({
       controls: this.state.controls.map((control) =>
         control instanceof VariableValueSelectors ? control.clone() : control
       ),
     });
+    // End re-render of controls
   }
 
   private syncTrailToUrl() {

--- a/public/app/features/trails/DataTrailsHistory.tsx
+++ b/public/app/features/trails/DataTrailsHistory.tsx
@@ -7,7 +7,6 @@ import {
   SceneObjectState,
   SceneObjectBase,
   SceneComponentProps,
-  SceneVariableValueChangedEvent,
   SceneObjectStateChangedEvent,
   SceneTimeRange,
   sceneUtils,


### PR DESCRIPTION
**Which issue(s) does this PR fix?**:

Similar to:
- #86741

This PR ensures that the history of filter changes is preserved when a filter change creates a new step.

This builds on #86741, and should be merged after.

The same reproducibility steps illustrated in #86741 can be applied here, with the difference being that filters should be changed instead of time ranges.

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
