### PR TITLE
Chore: Remove i18n psuedo precommit hook

### DIFF
--- a/lefthook.yml
+++ b/lefthook.yml
@@ -23,11 +23,6 @@ pre-commit:
         yarn prettier --write {staged_files}
       stage_fixed: true
 
-    internationalization:
-      glob: 'public/locales/en-US/grafana.json'
-      run: yarn i18n:pseudo
-      stage_fixed: true
-
     other-format:
       glob: '*.{json,scss,md,mdx}'
       run: yarn prettier --write {staged_files}


### PR DESCRIPTION
https://github.com/grafana/grafana/pull/86215 removed the `yarn 18n:psuedo` yarn script, because it now lives in the `make i18n-extract` command.

While it is possible to just call the node script by itself, I've just removed this from the precommit hooks because `make i18n-extract` runs it, and `en-US/grafana.json` should not be changed without the make script.