### PR TITLE
Plugin preloading: Fix performance measurement

### DIFF
--- a/public/app/app.ts
+++ b/public/app/app.ts
@@ -222,7 +222,7 @@ export class GrafanaApp {
         const appPlugins = Object.values(config.apps).filter((app) => !awaitedAppPluginIds.includes(app.id));
 
         preloadPlugins(appPlugins, extensionsRegistry);
-        await preloadPlugins(awaitedAppPlugins, extensionsRegistry);
+        await preloadPlugins(awaitedAppPlugins, extensionsRegistry, 'frontend_awaited_plugins_preload');
       }
 
       setPluginExtensionGetter(createPluginExtensionsGetter(extensionsRegistry));

--- a/public/app/features/plugins/pluginPreloader.ts
+++ b/public/app/features/plugins/pluginPreloader.ts
@@ -12,8 +12,12 @@ export type PluginPreloadResult = {
   extensionConfigs: PluginExtensionConfig[];
 };
 
-export async function preloadPlugins(apps: AppPluginConfig[] = [], registry: ReactivePluginExtensionsRegistry) {
-  startMeasure('frontend_plugins_preload');
+export async function preloadPlugins(
+  apps: AppPluginConfig[] = [],
+  registry: ReactivePluginExtensionsRegistry,
+  eventName = 'frontend_plugins_preload'
+) {
+  startMeasure(eventName);
   const promises = apps.filter((config) => config.preload).map((config) => preload(config));
   const preloadedPlugins = await Promise.all(promises);
 
@@ -21,7 +25,7 @@ export async function preloadPlugins(apps: AppPluginConfig[] = [], registry: Rea
     registry.register(preloadedPlugin);
   }
 
-  stopMeasure('frontend_plugins_preload');
+  stopMeasure(eventName);
 }
 
 async function preload(config: AppPluginConfig): Promise<PluginPreloadResult> {


### PR DESCRIPTION
**Slack thread:** https://raintank-corp.slack.com/archives/CHKLEJ668/p1713963418814299

### What changed?
There was a bug introduced by https://github.com/grafana/grafana/pull/83085: `pluginPreload()` was called multiple times after each other in [app.ts](https://github.com/grafana/grafana/blob/fd0f92d86cdec3d0d59438de06929010590b46c4/public/app/app.ts#L224), but both calls were using the same event name. (Once the faster async call finished, it cleared the marks for both itself and the other function call.)