### PR TITLE
Revert "ci: remove milestone check"

### DIFF
--- a/.github/pr-checks.json
+++ b/.github/pr-checks.json
@@ -1,5 +1,12 @@
 [
   {
+    "type": "check-milestone",
+    "title": "Milestone Check",
+    "targetUrl": "https://github.com/grafana/grafana/blob/main/contribute/merge-pull-request.md#assign-a-milestone",
+    "success": "Milestone set",
+    "failure": "Milestone not set"
+  },
+  {
     "type": "check-changelog",
     "title": "Changelog Check",
     "labels": {


### PR DESCRIPTION
Reverts grafana/grafana#86452

The auto-milestone action doesn't work for external contributions, and the lack of milestone check has been causing friction for PRs from community members.

We'll need to find a more complete solution for this, but for now I think it's best to just revert.