### PR TITLE
SQLStore: Disable redundant create and drop unique index migrations on dashboard table

### DIFF
--- a/pkg/services/dashboards/database/migrations/folder_uid_migrator.go
+++ b/pkg/services/dashboards/database/migrations/folder_uid_migrator.go
@@ -5,6 +5,18 @@ import (
 	"xorm.io/xorm"
 )
 
+type DummyMigration struct {
+	migrator.MigrationBase
+}
+
+func (m *DummyMigration) SQL(dialect migrator.Dialect) string {
+	return "code migration"
+}
+
+func (m *DummyMigration) Exec(sess *xorm.Session, mgrtr *migrator.Migrator) error {
+	return nil
+}
+
 // FolderUIDMigration is a code migration that populates folder_uid column
 type FolderUIDMigration struct {
 	migrator.MigrationBase
@@ -78,17 +90,13 @@ func AddDashboardFolderMigrations(mg *migrator.Migrator) {
 
 	mg.AddMigration("Populate dashboard folder_uid column", &FolderUIDMigration{})
 
-	mg.AddMigration("Add unique index for dashboard_org_id_folder_uid_title", migrator.NewAddIndexMigration(migrator.Table{Name: "dashboard"}, &migrator.Index{
-		Cols: []string{"org_id", "folder_uid", "title"}, Type: migrator.UniqueIndex,
-	}))
+	mg.AddMigration("Add unique index for dashboard_org_id_folder_uid_title", &DummyMigration{})
 
 	mg.AddMigration("Delete unique index for dashboard_org_id_folder_id_title", migrator.NewDropIndexMigration(migrator.Table{Name: "dashboard"}, &migrator.Index{
 		Cols: []string{"org_id", "folder_id", "title"}, Type: migrator.UniqueIndex,
 	}))
 
-	mg.AddMigration("Delete unique index for dashboard_org_id_folder_uid_title", migrator.NewDropIndexMigration(migrator.Table{Name: "dashboard"}, &migrator.Index{
-		Cols: []string{"org_id", "folder_uid", "title"}, Type: migrator.UniqueIndex,
-	}))
+	mg.AddMigration("Delete unique index for dashboard_org_id_folder_uid_title", &DummyMigration{})
 
 	mg.AddMigration("Add unique index for dashboard_org_id_folder_uid_title_is_folder", migrator.NewAddIndexMigration(migrator.Table{Name: "dashboard"}, &migrator.Index{
 		Cols: []string{"org_id", "folder_uid", "title", "is_folder"}, Type: migrator.UniqueIndex,


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

Fix migration failure when trying to create unique index on `dashboard` table for `org_id`, `folder_uid`, `title` columns
when there is a folder and dashboard with the same title exist under the same folder like the following:


<details><summary>Migration failure</summary>
<p>

```
logger=migrator t=2024-04-23T14:17:33.213655619Z level=info msg="Executing migration" id="Add unique index for dashboard_org_id_folder_uid_title"

logger=migrator t=2024-04-23T14:17:33.229140986Z level=error msg="Executing migration failed" id="Add unique index for dashboard_org_id_folder_uid_title" error="pq: could not create unique index \"UQE_dashboard_org_id_folder_uid_title\"" duration=15.484242ms

logger=migrator t=2024-04-23T14:17:33.229164783Z level=error msg="Exec failed" error="pq: could not create unique index \"UQE_dashboard_org_id_folder_uid_title\"" sql="CREATE UNIQUE INDEX \"UQE_dashboard_org_id_folder_uid_title\" ON \"dashboard\" (\"org_id\",\"folder_uid\",\"title\");"
```

</p>
</details> 

These index is redundant and there is follow up migrations dropping the index and [create a unique index on:
`org_id`, `folder_uid`, `title`, `is_folder` columns](https://github.com/grafana/grafana/blob/5dd8353ab16547b7e97e8a340c20a97d22560086/pkg/services/dashboards/database/migrations/folder_uid_migrator.go#L93) instead.

This fix replace the create and drop indexes to dummy migrations so that they do not have any effect.
Setups that the specific migrations are executed are not affected because the migrations are marked as executed in the database.
For new setups the migrations are executed (doing nothing) and marked as completed in the database.

**Why do we need this feature?**

[Add a description of the problem the feature is trying to solve.]

**Who is this feature for?**

[Add information on what kind of user the feature is for.]

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
