### PR TITLE
Dashboard: Migration Fixes Mixed data source losing existing queries 

### DIFF
--- a/public/app/features/dashboard-scene/panel-edit/PanelDataPane/PanelDataQueriesTab.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelDataPane/PanelDataQueriesTab.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 
 import { CoreApp, DataSourceApi, DataSourceInstanceSettings, IconName } from '@grafana/data';
 import { selectors } from '@grafana/e2e-selectors';
-import { config } from '@grafana/runtime';
+import { config, getDataSourceSrv } from '@grafana/runtime';
 import { SceneObjectBase, SceneComponentProps, sceneGraph, SceneQueryRunner } from '@grafana/scenes';
 import { DataQuery } from '@grafana/schema';
 import { Button, HorizontalGroup, Tab } from '@grafana/ui';
@@ -120,7 +120,15 @@ export class PanelDataQueriesTab extends SceneObjectBase<PanelDataQueriesTabStat
   newQuery(): Partial<DataQuery> {
     const { dsSettings, datasource } = this._panelManager.state;
 
-    const ds = !dsSettings?.meta.mixed ? dsSettings : datasource;
+    let ds;
+    if (!dsSettings?.meta.mixed) {
+      ds = dsSettings; // Use dsSettings if it is not mixed
+    } else if (!datasource?.meta.mixed) {
+      ds = datasource; // Use datasource if dsSettings is mixed but datasource is not
+    } else {
+      // Use default datasource if both are mixed or just datasource is mixed
+      ds = getDataSourceSrv().getInstanceSettings(config.defaultDatasource);
+    }
 
     return {
       ...datasource?.getDefaultQuery?.(CoreApp.PanelEditor),

--- a/public/app/features/dashboard-scene/panel-edit/VizPanelManager.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/VizPanelManager.tsx
@@ -141,13 +141,7 @@ export class VizPanelManager extends SceneObjectBase<VizPanelManagerState> {
       }
 
       if (datasource && dsSettings) {
-        // If the datasource is not mixed, update state with datasource and settings
-        if (!datasource.meta.mixed) {
-          this.setState({ datasource, dsSettings });
-        } else {
-          // If datasource is mixed, update state only with settings
-          this.setState({ dsSettings });
-        }
+        this.setState({ datasource, dsSettings });
 
         storeLastUsedDataSourceInLocalStorage(
           {

--- a/public/app/features/dashboard-scene/panel-edit/VizPanelManager.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/VizPanelManager.tsx
@@ -141,10 +141,13 @@ export class VizPanelManager extends SceneObjectBase<VizPanelManagerState> {
       }
 
       if (datasource && dsSettings) {
-        this.setState({
-          datasource,
-          dsSettings,
-        });
+        // If the datasource is not mixed, update state with datasource and settings
+        if (!datasource.meta.mixed) {
+          this.setState({ datasource, dsSettings });
+        } else {
+          // If datasource is mixed, update state only with settings
+          this.setState({ dsSettings });
+        }
 
         storeLastUsedDataSourceInLocalStorage(
           {


### PR DESCRIPTION
Fixes error of losing existing queries when switching to Mixed datasource.

<table>
<tr>
 <td>
Before

https://github.com/grafana/grafana/assets/239999/fce538e1-5c1b-4895-92b4-902aafada1a1
 <td>
After

https://github.com/grafana/grafana/assets/239999/5bcd119d-78ad-494b-9304-0d09eae742b6
</table>








Fixes: #86576