### PR TITLE
Alerting: Skip flaky test

### DIFF
--- a/public/app/features/alerting/unified/PanelAlertTabContent.test.tsx
+++ b/public/app/features/alerting/unified/PanelAlertTabContent.test.tsx
@@ -286,7 +286,7 @@ describe('PanelAlertTabContent', () => {
     });
   });
 
-  it('Will render alerts belonging to panel and a button to create alert from panel queries', async () => {
+  it.skip('Will render alerts belonging to panel and a button to create alert from panel queries', async () => {
     mocks.api.fetchRules.mockResolvedValue(rules);
     mocks.api.fetchRulerRules.mockResolvedValue(rulerRules);
 


### PR DESCRIPTION
**What is this feature?**

This PR skips a flaky test that is blocking this drone [build](https://drone.grafana.net/grafana/grafana/174761/1/6)
We decide skipping it and investigate afterwards to unblock people.

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
