### PR TITLE
LinkButton: properly set a11y compliant disabled state

### DIFF
--- a/packages/grafana-ui/src/components/Button/Button.test.tsx
+++ b/packages/grafana-ui/src/components/Button/Button.test.tsx
@@ -1,11 +1,41 @@
-import { render } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import React from 'react';
 
-import { Button } from './Button';
+import { Button, LinkButton } from './Button';
 
 describe('Button', () => {
   it('spins the spinner when specified as an icon', () => {
     const { container } = render(<Button icon="spinner">Loading...</Button>);
     expect(container.querySelector('.fa-spin')).toBeInTheDocument();
+  });
+});
+
+describe('LinkButton', () => {
+  it('Renders link button without attributes for disabled state.', () => {
+    const linkText = 'link-button';
+    const href = 'https://grafana.com';
+
+    render(<LinkButton href={href}>{linkText}</LinkButton>);
+
+    const linkElem = screen.getByText(linkText).closest('a');
+
+    expect(linkElem).toHaveAttribute('href', href);
+    expect(linkElem).not.toHaveAttribute('role');
+    expect(linkElem).not.toHaveAttribute('aria-disabled');
+  });
+
+  it('Applies a11y compliant settings for disabled state', () => {
+    const linkText = 'disabled-link-button';
+    render(
+      <LinkButton href="https://grafana.com" disabled>
+        {linkText}
+      </LinkButton>
+    );
+
+    const linkElem = screen.getByText(linkText).closest('a');
+
+    expect(linkElem).not.toHaveAttribute('href');
+    expect(linkElem).toHaveAttribute('role', 'link');
+    expect(linkElem).toHaveAttribute('aria-disabled', 'true');
   });
 });

--- a/packages/grafana-ui/src/components/Button/Button.test.tsx
+++ b/packages/grafana-ui/src/components/Button/Button.test.tsx
@@ -20,6 +20,7 @@ describe('LinkButton', () => {
 
     expect(linkElem).toHaveAttribute('href', href);
     expect(linkElem).not.toHaveAttribute('aria-disabled');
+    expect(linkElem).not.toHaveAttribute('tabindex');
   });
 
   it('Applies a11y compliant settings for disabled state', () => {
@@ -35,5 +36,6 @@ describe('LinkButton', () => {
     expect(linkElem).not.toHaveAttribute('href');
     expect(linkElem).toHaveAttribute('role', 'link');
     expect(linkElem).toHaveAttribute('aria-disabled', 'true');
+    expect(linkElem).toHaveAttribute('tabindex', '0');
   });
 });

--- a/packages/grafana-ui/src/components/Button/Button.test.tsx
+++ b/packages/grafana-ui/src/components/Button/Button.test.tsx
@@ -12,15 +12,13 @@ describe('Button', () => {
 
 describe('LinkButton', () => {
   it('Renders link button without attributes for disabled state.', () => {
-    const linkText = 'link-button';
     const href = 'https://grafana.com';
 
-    render(<LinkButton href={href}>{linkText}</LinkButton>);
+    render(<LinkButton href={href}>link-button</LinkButton>);
 
-    const linkElem = screen.getByText(linkText).closest('a');
+    const linkElem = screen.getByRole('link').closest('a');
 
     expect(linkElem).toHaveAttribute('href', href);
-    expect(linkElem).not.toHaveAttribute('role');
     expect(linkElem).not.toHaveAttribute('aria-disabled');
   });
 

--- a/packages/grafana-ui/src/components/Button/Button.tsx
+++ b/packages/grafana-ui/src/components/Button/Button.tsx
@@ -133,6 +133,7 @@ export const LinkButton = React.forwardRef<HTMLAnchorElement, ButtonLinkProps>(
         className={linkButtonStyles}
         {...otherProps}
         aria-disabled={disabled}
+        tabIndex={disabled ? 0 : undefined}
         role={disabled ? 'link' : undefined}
         href={disabled ? undefined : href}
         ref={tooltip ? undefined : ref}

--- a/packages/grafana-ui/src/components/Button/Button.tsx
+++ b/packages/grafana-ui/src/components/Button/Button.tsx
@@ -102,6 +102,7 @@ export const LinkButton = React.forwardRef<HTMLAnchorElement, ButtonLinkProps>(
       disabled,
       tooltip,
       tooltipPlacement,
+      href,
       ...otherProps
     },
     ref
@@ -131,8 +132,9 @@ export const LinkButton = React.forwardRef<HTMLAnchorElement, ButtonLinkProps>(
       <a
         className={linkButtonStyles}
         {...otherProps}
-        tabIndex={disabled ? -1 : 0}
         aria-disabled={disabled}
+        role={disabled ? 'link' : undefined}
+        href={disabled ? undefined : href}
         ref={tooltip ? undefined : ref}
       >
         {icon && <Icon name={icon} size={size} className={styles.icon} />}


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**
The LinkButton component was not discoverable by users of assistive technology like screen readers.
So they never know that there is a possible action which we want to make users aware of but which is currently disabled for some reason.
The goal is to make the link focusable, announce the disabled state and prevent that users can follow the link.

* Here's an article explaining the issue and solution: [Disabling a link](https://www.scottohara.me/blog/2021/05/28/disabled-links.html)
* [Related Slack discussion](https://raintank-corp.slack.com/archives/C030MMKLH2M/p1713519212906699)



**Why do we need this feature?**

To enable users of assistive tech to discover the link and properly get it's disabled state announced.

**Who is this feature for?**

All users but especially users and users of assistive tech like screen readers

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
