### PR TITLE
Alerting: Migrate Silences to RTK Query

### DIFF
--- a/.betterer.results
+++ b/.betterer.results
@@ -2167,11 +2167,8 @@ exports[`better eslint`] = {
       [0, 0, 0, "Styles should be written using objects.", "4"]
     ],
     "public/app/features/alerting/unified/components/silences/SilencesTable.tsx:5381": [
-      [0, 0, 0, "Styles should be written using objects.", "0"],
-      [0, 0, 0, "Styles should be written using objects.", "1"],
-      [0, 0, 0, "Styles should be written using objects.", "2"],
-      [0, 0, 0, "Styles should be written using objects.", "3"],
-      [0, 0, 0, "Styles should be written using objects.", "4"]
+      [0, 0, 0, "Do not use any type assertions.", "0"],
+      [0, 0, 0, "Do not use any type assertions.", "1"]
     ],
     "public/app/features/alerting/unified/hooks/useAlertmanagerConfig.ts:5381": [
       [0, 0, 0, "Do not use any type assertions.", "0"]

--- a/.betterer.results
+++ b/.betterer.results
@@ -2166,10 +2166,6 @@ exports[`better eslint`] = {
       [0, 0, 0, "Styles should be written using objects.", "3"],
       [0, 0, 0, "Styles should be written using objects.", "4"]
     ],
-    "public/app/features/alerting/unified/components/silences/SilencesTable.tsx:5381": [
-      [0, 0, 0, "Do not use any type assertions.", "0"],
-      [0, 0, 0, "Do not use any type assertions.", "1"]
-    ],
     "public/app/features/alerting/unified/hooks/useAlertmanagerConfig.ts:5381": [
       [0, 0, 0, "Do not use any type assertions.", "0"]
     ],

--- a/public/app/features/alerting/unified/Silences.test.tsx
+++ b/public/app/features/alerting/unified/Silences.test.tsx
@@ -258,7 +258,7 @@ describe('Silence create/edit', () => {
     'creates a new silence',
     async () => {
       const user = userEvent.setup();
-      renderSilences(baseUrlPath);
+      renderSilences(`${baseUrlPath}?alertmanager=Alertmanager`);
       expect(await ui.editor.durationField.find()).toBeInTheDocument();
 
       const postRequest = waitForServerRequest(silenceCreateHandler());

--- a/public/app/features/alerting/unified/Silences.test.tsx
+++ b/public/app/features/alerting/unified/Silences.test.tsx
@@ -1,49 +1,35 @@
-import { render, waitFor } from '@testing-library/react';
-import userEvent, { PointerEventsCheckLevel } from '@testing-library/user-event';
 import React from 'react';
-import { TestProvider } from 'test/helpers/TestProvider';
+import { render, waitFor, userEvent } from 'test/test-utils';
 import { byLabelText, byPlaceholderText, byRole, byTestId, byText } from 'testing-library-selector';
 
 import { dateTime } from '@grafana/data';
 import { selectors } from '@grafana/e2e-selectors';
 import { config, locationService, setDataSourceSrv } from '@grafana/runtime';
-import { contextSrv } from 'app/core/services/context_srv';
-import { AlertState, MatcherOperator } from 'app/plugins/datasource/alertmanager/types';
+import { setupMswServer } from 'app/features/alerting/unified/mockApi';
+import { MatcherOperator } from 'app/plugins/datasource/alertmanager/types';
 import { AccessControlAction } from 'app/types';
 
-import { SilenceState } from '../../../plugins/datasource/alertmanager/types';
-
 import Silences from './Silences';
-import { createOrUpdateSilence, fetchAlerts, fetchSilences } from './api/alertmanager';
-import { grantUserPermissions, mockAlertmanagerAlert, mockDataSource, MockDataSourceSrv, mockSilence } from './mocks';
+import { grantUserPermissions, mockDataSource, MockDataSourceSrv } from './mocks';
 import { AlertmanagerProvider } from './state/AlertmanagerContext';
 import { setupDataSources } from './testSetup/datasources';
-import { parseMatchers } from './utils/alertmanager';
 import { DataSourceType } from './utils/datasource';
 
-jest.mock('./api/alertmanager');
 jest.mock('app/core/services/context_srv');
 
 const TEST_TIMEOUT = 60000;
 
-const mocks = {
-  api: {
-    fetchSilences: jest.mocked(fetchSilences),
-    fetchAlerts: jest.mocked(fetchAlerts),
-    createOrUpdateSilence: jest.mocked(createOrUpdateSilence),
-  },
-  contextSrv: jest.mocked(contextSrv),
-};
-
 const renderSilences = (location = '/alerting/silences/') => {
   locationService.push(location);
-
   return render(
-    <TestProvider>
-      <AlertmanagerProvider accessType="instance">
-        <Silences />
-      </AlertmanagerProvider>
-    </TestProvider>
+    <AlertmanagerProvider accessType="instance">
+      <Silences />
+    </AlertmanagerProvider>,
+    {
+      routerOptions: {
+        initialEntries: [location],
+      },
+    }
   );
 };
 
@@ -57,7 +43,8 @@ const dataSources = {
 const ui = {
   notExpiredTable: byTestId('not-expired-table'),
   expiredTable: byTestId('expired-table'),
-  expiredCaret: byText(/expired/i),
+  expiredCaret: byText(/expired silences \(/i),
+  silencesTags: byLabelText(/tags/i),
   silenceRow: byTestId('row'),
   silencedAlertCell: byTestId('alerts'),
   addSilenceButton: byRole('link', { name: /add silence/i }),
@@ -80,28 +67,6 @@ const ui = {
 
 const resetMocks = () => {
   jest.resetAllMocks();
-  mocks.api.fetchSilences.mockImplementation(() => {
-    return Promise.resolve([
-      mockSilence({ id: '12345' }),
-      mockSilence({ id: '67890', matchers: parseMatchers('foo!=bar'), comment: 'Catch all' }),
-      mockSilence({ id: '1111', status: { state: SilenceState.Expired } }),
-    ]);
-  });
-
-  mocks.api.fetchAlerts.mockImplementation(() => {
-    return Promise.resolve([
-      mockAlertmanagerAlert({
-        labels: { foo: 'bar' },
-        status: { state: AlertState.Suppressed, silencedBy: ['12345'], inhibitedBy: [] },
-      }),
-      mockAlertmanagerAlert({
-        labels: { foo: 'buzz' },
-        status: { state: AlertState.Suppressed, silencedBy: ['67890'], inhibitedBy: [] },
-      }),
-    ]);
-  });
-
-  mocks.api.createOrUpdateSilence.mockResolvedValue(mockSilence());
 
   grantUserPermissions([
     AccessControlAction.AlertingInstanceRead,
@@ -117,6 +82,21 @@ const setUserLogged = (isLogged: boolean) => {
   config.bootData.user.name = isLogged ? 'admin' : '';
 };
 
+const enterSilenceLabel = async (index: number, name: string, matcher: MatcherOperator, value: string) => {
+  const user = userEvent.setup();
+  await user.type(ui.editor.matcherName.getAll()[index], name);
+  await user.type(ui.editor.matcherOperatorSelect.getAll()[index], matcher);
+  await user.tab();
+  await user.type(ui.editor.matcherValue.getAll()[index], value);
+};
+
+const addAdditionalMatcher = async () => {
+  const user = userEvent.setup();
+  await user.click(ui.editor.addMatcherButton.get());
+};
+
+setupMswServer();
+
 describe('Silences', () => {
   beforeAll(resetMocks);
   afterEach(resetMocks);
@@ -128,26 +108,29 @@ describe('Silences', () => {
   it(
     'loads and shows silences',
     async () => {
+      const user = userEvent.setup();
       renderSilences();
-      await waitFor(() => expect(mocks.api.fetchSilences).toHaveBeenCalled());
-      await waitFor(() => expect(mocks.api.fetchAlerts).toHaveBeenCalled());
 
-      await userEvent.click(ui.expiredCaret.get());
-      expect(ui.notExpiredTable.get()).not.toBeNull();
-      expect(ui.expiredTable.get()).not.toBeNull();
-      let silences = ui.silenceRow.queryAll();
-      expect(silences).toHaveLength(3);
-      expect(silences[0]).toHaveTextContent('foo=bar');
-      expect(silences[1]).toHaveTextContent('foo!=bar');
-      expect(silences[2]).toHaveTextContent('foo=bar');
+      expect(await ui.notExpiredTable.find()).toBeInTheDocument();
 
-      await userEvent.click(ui.expiredCaret.getAll()[0]);
-      expect(ui.notExpiredTable.get()).not.toBeNull();
-      expect(ui.expiredTable.query()).toBeNull();
-      silences = ui.silenceRow.queryAll();
-      expect(silences).toHaveLength(2);
-      expect(silences[0]).toHaveTextContent('foo=bar');
-      expect(silences[1]).toHaveTextContent('foo!=bar');
+      await user.click(ui.expiredCaret.get());
+      expect(ui.expiredTable.get()).toBeInTheDocument();
+
+      const allSilences = ui.silenceRow.queryAll();
+      expect(allSilences).toHaveLength(3);
+      expect(allSilences[0]).toHaveTextContent('foo=bar');
+      expect(allSilences[1]).toHaveTextContent('foo!=bar');
+      expect(allSilences[2]).toHaveTextContent('foo=bar');
+
+      await user.click(ui.expiredCaret.get());
+
+      expect(ui.notExpiredTable.get()).toBeInTheDocument();
+      expect(ui.expiredTable.query()).not.toBeInTheDocument();
+
+      const activeSilences = ui.silenceRow.queryAll();
+      expect(activeSilences).toHaveLength(2);
+      expect(activeSilences[0]).toHaveTextContent('foo=bar');
+      expect(activeSilences[1]).toHaveTextContent('foo!=bar');
     },
     TEST_TIMEOUT
   );
@@ -155,25 +138,13 @@ describe('Silences', () => {
   it(
     'shows the correct number of silenced alerts',
     async () => {
-      mocks.api.fetchAlerts.mockImplementation(() => {
-        return Promise.resolve([
-          mockAlertmanagerAlert({
-            labels: { foo: 'bar', buzz: 'bazz' },
-            status: { state: AlertState.Suppressed, silencedBy: ['12345'], inhibitedBy: [] },
-          }),
-          mockAlertmanagerAlert({
-            labels: { foo: 'bar', buzz: 'bazz' },
-            status: { state: AlertState.Suppressed, silencedBy: ['12345'], inhibitedBy: [] },
-          }),
-        ]);
-      });
-
       renderSilences();
-      await waitFor(() => expect(mocks.api.fetchSilences).toHaveBeenCalled());
-      await waitFor(() => expect(mocks.api.fetchAlerts).toHaveBeenCalled());
 
-      const silencedAlertRows = ui.silencedAlertCell.getAll(ui.notExpiredTable.get());
-      expect(silencedAlertRows).toHaveLength(2);
+      const notExpiredTable = await ui.notExpiredTable.find();
+
+      expect(notExpiredTable).toBeInTheDocument();
+
+      const silencedAlertRows = await ui.silencedAlertCell.findAll(notExpiredTable);
       expect(silencedAlertRows[0]).toHaveTextContent('2');
       expect(silencedAlertRows[1]).toHaveTextContent('0');
     },
@@ -184,12 +155,9 @@ describe('Silences', () => {
     'filters silences by matchers',
     async () => {
       renderSilences();
-      await waitFor(() => expect(mocks.api.fetchSilences).toHaveBeenCalled());
-      await waitFor(() => expect(mocks.api.fetchAlerts).toHaveBeenCalled());
 
-      const queryBar = ui.queryBar.get();
-      await userEvent.click(queryBar);
-      await userEvent.paste('foo=bar');
+      const queryBar = await ui.queryBar.find();
+      await userEvent.type(queryBar, 'foo=bar');
 
       await waitFor(() => expect(ui.silenceRow.getAll()).toHaveLength(2));
     },
@@ -199,24 +167,23 @@ describe('Silences', () => {
   it('shows creating a silence button for users with access', async () => {
     renderSilences();
 
-    await waitFor(() => expect(mocks.api.fetchSilences).toHaveBeenCalled());
-    await waitFor(() => expect(mocks.api.fetchAlerts).toHaveBeenCalled());
-
-    expect(ui.addSilenceButton.get()).toBeInTheDocument();
+    expect(await ui.addSilenceButton.find()).toBeInTheDocument();
   });
 
   it('hides actions for creating a silence for users without access', async () => {
     grantUserPermissions([AccessControlAction.AlertingInstanceRead, AccessControlAction.AlertingInstancesExternalRead]);
 
     renderSilences();
-    await waitFor(() => expect(mocks.api.fetchSilences).toHaveBeenCalled());
-    await waitFor(() => expect(mocks.api.fetchAlerts).toHaveBeenCalled());
+
+    const notExpiredTable = await ui.notExpiredTable.find();
+
+    expect(notExpiredTable).toBeInTheDocument();
 
     expect(ui.addSilenceButton.query()).not.toBeInTheDocument();
   });
 });
 
-describe('Silence edit', () => {
+describe('Silence create/edit', () => {
   const baseUrlPath = '/alerting/silence/new';
   beforeAll(resetMocks);
   afterEach(resetMocks);
@@ -242,7 +209,7 @@ describe('Silence edit', () => {
       const matchersQueryString = matchersParams.map((matcher) => `matcher=${encodeURIComponent(matcher)}`).join('&');
 
       renderSilences(`${baseUrlPath}?${matchersQueryString}`);
-      await waitFor(() => expect(ui.editor.durationField.query()).not.toBeNull());
+      expect(await ui.editor.durationField.find()).toBeInTheDocument();
 
       const matchers = ui.editor.matchersField.queryAll();
       expect(matchers).toHaveLength(4);
@@ -270,7 +237,7 @@ describe('Silence edit', () => {
     'creates a new silence',
     async () => {
       renderSilences(baseUrlPath);
-      await waitFor(() => expect(ui.editor.durationField.query()).not.toBeNull());
+      expect(await ui.editor.durationField.find()).toBeInTheDocument();
 
       const start = new Date();
       const end = new Date(start.getTime() + 24 * 60 * 60 * 1000);
@@ -285,48 +252,20 @@ describe('Silence edit', () => {
       await waitFor(() => expect(ui.editor.timeRange.get()).toHaveTextContent(startDateString));
       await waitFor(() => expect(ui.editor.timeRange.get()).toHaveTextContent(endDateString));
 
-      await userEvent.type(ui.editor.matcherName.get(), 'foo');
-      await userEvent.type(ui.editor.matcherOperatorSelect.get(), '=');
-      await userEvent.tab();
-      await userEvent.type(ui.editor.matcherValue.get(), 'bar');
+      await enterSilenceLabel(0, 'foo', MatcherOperator.equal, 'bar');
 
-      // TODO remove skipPointerEventsCheck once https://github.com/jsdom/jsdom/issues/3232 is fixed
-      await userEvent.click(ui.editor.addMatcherButton.get(), { pointerEventsCheck: PointerEventsCheckLevel.Never });
-      await userEvent.type(ui.editor.matcherName.getAll()[1], 'bar');
-      await userEvent.type(ui.editor.matcherOperatorSelect.getAll()[1], '!=');
-      await userEvent.tab();
-      await userEvent.type(ui.editor.matcherValue.getAll()[1], 'buzz');
+      await addAdditionalMatcher();
+      await enterSilenceLabel(1, 'bar', MatcherOperator.notEqual, 'buzz');
 
-      // TODO remove skipPointerEventsCheck once https://github.com/jsdom/jsdom/issues/3232 is fixed
-      await userEvent.click(ui.editor.addMatcherButton.get(), { pointerEventsCheck: PointerEventsCheckLevel.Never });
-      await userEvent.type(ui.editor.matcherName.getAll()[2], 'region');
-      await userEvent.type(ui.editor.matcherOperatorSelect.getAll()[2], '=~');
-      await userEvent.tab();
-      await userEvent.type(ui.editor.matcherValue.getAll()[2], 'us-west-.*');
+      await addAdditionalMatcher();
+      await enterSilenceLabel(2, 'region', MatcherOperator.regex, 'us-west-.*');
 
-      // TODO remove skipPointerEventsCheck once https://github.com/jsdom/jsdom/issues/3232 is fixed
-      await userEvent.click(ui.editor.addMatcherButton.get(), { pointerEventsCheck: PointerEventsCheckLevel.Never });
-      await userEvent.type(ui.editor.matcherName.getAll()[3], 'env');
-      await userEvent.type(ui.editor.matcherOperatorSelect.getAll()[3], '!~');
-      await userEvent.tab();
-      await userEvent.type(ui.editor.matcherValue.getAll()[3], 'dev|staging');
+      await addAdditionalMatcher();
+      await enterSilenceLabel(3, 'env', MatcherOperator.notRegex, 'dev|staging');
 
       await userEvent.click(ui.editor.submit.get());
 
-      await waitFor(() =>
-        expect(mocks.api.createOrUpdateSilence).toHaveBeenCalledWith(
-          'grafana',
-          expect.objectContaining({
-            comment: expect.stringMatching(/created (\d{4})-(\d{2})-(\d{2}) (\d{2}):(\d{2})/),
-            matchers: [
-              { isEqual: true, isRegex: false, name: 'foo', value: 'bar' },
-              { isEqual: false, isRegex: false, name: 'bar', value: 'buzz' },
-              { isEqual: true, isRegex: true, name: 'region', value: 'us-west-.*' },
-              { isEqual: false, isRegex: true, name: 'env', value: 'dev|staging' },
-            ],
-          })
-        )
-      );
+      expect(await ui.notExpiredTable.find()).toBeInTheDocument();
     },
     TEST_TIMEOUT
   );
@@ -339,20 +278,11 @@ describe('Silence edit', () => {
       renderSilences(`${baseUrlPath}?alertmanager=Alertmanager`);
       await waitFor(() => expect(ui.editor.durationField.query()).not.toBeNull());
 
-      await user.type(ui.editor.matcherName.getAll()[0], 'foo');
-      await user.type(ui.editor.matcherOperatorSelect.getAll()[0], '=');
-      await user.type(ui.editor.matcherValue.getAll()[0], 'bar');
+      await enterSilenceLabel(0, 'foo', MatcherOperator.equal, 'bar');
 
       await user.click(ui.editor.submit.get());
 
-      await waitFor(() =>
-        expect(mocks.api.createOrUpdateSilence).toHaveBeenCalledWith(
-          'Alertmanager',
-          expect.objectContaining({
-            matchers: [{ isEqual: true, isRegex: false, name: 'foo', value: 'bar' }],
-          })
-        )
-      );
+      expect(await ui.notExpiredTable.find()).toBeInTheDocument();
 
       expect(locationService.getSearch().get('alertmanager')).toBe('Alertmanager');
     },

--- a/public/app/features/alerting/unified/Silences.test.tsx
+++ b/public/app/features/alerting/unified/Silences.test.tsx
@@ -28,7 +28,7 @@ const renderSilences = (location = '/alerting/silences/') => {
       <Silences />
     </AlertmanagerProvider>,
     {
-      routerOptions: {
+      historyOptions: {
         initialEntries: [location],
       },
     }
@@ -156,10 +156,11 @@ describe('Silences', () => {
   it(
     'filters silences by matchers',
     async () => {
+      const user = userEvent.setup();
       renderSilences();
 
       const queryBar = await ui.queryBar.find();
-      await userEvent.type(queryBar, 'foo=bar');
+      await user.type(queryBar, 'foo=bar');
 
       await waitFor(() => expect(ui.silenceRow.getAll()).toHaveLength(2));
     },
@@ -238,6 +239,7 @@ describe('Silence create/edit', () => {
   it(
     'creates a new silence',
     async () => {
+      const user = userEvent.setup();
       renderSilences(baseUrlPath);
       expect(await ui.editor.durationField.find()).toBeInTheDocument();
 
@@ -249,8 +251,8 @@ describe('Silence create/edit', () => {
       const startDateString = dateTime(start).format('YYYY-MM-DD');
       const endDateString = dateTime(end).format('YYYY-MM-DD');
 
-      await userEvent.clear(ui.editor.durationInput.get());
-      await userEvent.type(ui.editor.durationInput.get(), '1d');
+      await user.clear(ui.editor.durationInput.get());
+      await user.type(ui.editor.durationInput.get(), '1d');
 
       await waitFor(() => expect(ui.editor.durationInput.query()).toHaveValue('1d'));
       await waitFor(() => expect(ui.editor.timeRange.get()).toHaveTextContent(startDateString));
@@ -267,7 +269,7 @@ describe('Silence create/edit', () => {
       await addAdditionalMatcher();
       await enterSilenceLabel(3, 'env', MatcherOperator.notRegex, 'dev|staging');
 
-      await userEvent.click(ui.editor.submit.get());
+      await user.click(ui.editor.submit.get());
 
       expect(await ui.notExpiredTable.find()).toBeInTheDocument();
 

--- a/public/app/features/alerting/unified/Silences.tsx
+++ b/public/app/features/alerting/unified/Silences.tsx
@@ -1,58 +1,17 @@
-import React, { useCallback, useEffect } from 'react';
+import React from 'react';
 import { Route, RouteChildrenProps, Switch } from 'react-router-dom';
 
-import { Alert, withErrorBoundary } from '@grafana/ui';
-import { Silence } from 'app/plugins/datasource/alertmanager/types';
-import { useDispatch } from 'app/types';
+import { withErrorBoundary } from '@grafana/ui';
 
-import { featureDiscoveryApi } from './api/featureDiscoveryApi';
 import { AlertmanagerPageWrapper } from './components/AlertingPageWrapper';
 import { GrafanaAlertmanagerDeliveryWarning } from './components/GrafanaAlertmanagerDeliveryWarning';
 import SilencesEditor from './components/silences/SilencesEditor';
 import SilencesTable from './components/silences/SilencesTable';
 import { useSilenceNavData } from './hooks/useSilenceNavData';
-import { useUnifiedAlertingSelector } from './hooks/useUnifiedAlertingSelector';
 import { useAlertmanager } from './state/AlertmanagerContext';
-import { fetchAmAlertsAction, fetchSilencesAction } from './state/actions';
-import { SILENCES_POLL_INTERVAL_MS } from './utils/constants';
-import { AsyncRequestState, initialAsyncRequestState } from './utils/redux';
 
 const Silences = () => {
   const { selectedAlertmanager } = useAlertmanager();
-
-  const dispatch = useDispatch();
-  const silences = useUnifiedAlertingSelector((state) => state.silences);
-  const alertsRequests = useUnifiedAlertingSelector((state) => state.amAlerts);
-  const alertsRequest = selectedAlertmanager
-    ? alertsRequests[selectedAlertmanager] || initialAsyncRequestState
-    : undefined;
-
-  const { currentData: amFeatures } = featureDiscoveryApi.useDiscoverAmFeaturesQuery(
-    { amSourceName: selectedAlertmanager ?? '' },
-    { skip: !selectedAlertmanager }
-  );
-
-  useEffect(() => {
-    function fetchAll() {
-      if (selectedAlertmanager) {
-        dispatch(fetchSilencesAction(selectedAlertmanager));
-        dispatch(fetchAmAlertsAction(selectedAlertmanager));
-      }
-    }
-    fetchAll();
-    const interval = setInterval(() => fetchAll, SILENCES_POLL_INTERVAL_MS);
-    return () => {
-      clearInterval(interval);
-    };
-  }, [selectedAlertmanager, dispatch]);
-
-  const { result, loading, error }: AsyncRequestState<Silence[]> =
-    (selectedAlertmanager && silences[selectedAlertmanager]) || initialAsyncRequestState;
-
-  const getSilenceById = useCallback((id: string) => result && result.find((silence) => silence.id === id), [result]);
-
-  const mimirLazyInitError =
-    error?.message?.includes('the Alertmanager is not configured') && amFeatures?.lazyConfigInit;
 
   if (!selectedAlertmanager) {
     return null;
@@ -62,48 +21,23 @@ const Silences = () => {
     <>
       <GrafanaAlertmanagerDeliveryWarning currentAlertmanager={selectedAlertmanager} />
 
-      {mimirLazyInitError && (
-        <Alert title="The selected Alertmanager has no configuration" severity="warning">
-          Create a new contact point to create a configuration using the default values or contact your administrator to
-          set up the Alertmanager.
-        </Alert>
-      )}
-      {error && !loading && !mimirLazyInitError && (
-        <Alert severity="error" title="Error loading silences">
-          {error.message || 'Unknown error.'}
-        </Alert>
-      )}
-      {alertsRequest?.error && !alertsRequest?.loading && !mimirLazyInitError && (
-        <Alert severity="error" title="Error loading Alertmanager alerts">
-          {alertsRequest.error?.message || 'Unknown error.'}
-        </Alert>
-      )}
-      {result && !error && (
-        <Switch>
-          <Route exact path="/alerting/silences">
-            <SilencesTable
-              silences={result}
-              alertManagerAlerts={alertsRequest?.result ?? []}
-              alertManagerSourceName={selectedAlertmanager}
-            />
-          </Route>
-          <Route exact path="/alerting/silence/new">
-            <SilencesEditor alertManagerSourceName={selectedAlertmanager} />
-          </Route>
-          <Route exact path="/alerting/silence/:id/edit">
-            {({ match }: RouteChildrenProps<{ id: string }>) => {
-              return (
-                match?.params.id && (
-                  <SilencesEditor
-                    silence={getSilenceById(match.params.id)}
-                    alertManagerSourceName={selectedAlertmanager}
-                  />
-                )
-              );
-            }}
-          </Route>
-        </Switch>
-      )}
+      <Switch>
+        <Route exact path="/alerting/silences">
+          <SilencesTable alertManagerSourceName={selectedAlertmanager} />
+        </Route>
+        <Route exact path="/alerting/silence/new">
+          <SilencesEditor alertManagerSourceName={selectedAlertmanager} />
+        </Route>
+        <Route exact path="/alerting/silence/:id/edit">
+          {({ match }: RouteChildrenProps<{ id: string }>) => {
+            return (
+              match?.params.id && (
+                <SilencesEditor silenceId={match.params.id} alertManagerSourceName={selectedAlertmanager} />
+              )
+            );
+          }}
+        </Route>
+      </Switch>
     </>
   );
 };

--- a/public/app/features/alerting/unified/api/alertSilencesApi.ts
+++ b/public/app/features/alerting/unified/api/alertSilencesApi.ts
@@ -43,7 +43,7 @@ export const alertSilencesApi = alertingApi.injectEndpoints({
         method: 'POST',
         data: payload,
       }),
-      invalidatesTags: ['AlertSilences'],
+      invalidatesTags: ['AlertSilences', 'AlertmanagerAlerts'],
     }),
 
     expireSilence: build.mutation<

--- a/public/app/features/alerting/unified/api/alertSilencesApi.ts
+++ b/public/app/features/alerting/unified/api/alertSilencesApi.ts
@@ -13,7 +13,8 @@ export const alertSilencesApi = alertingApi.injectEndpoints({
       query: ({ datasourceUid }) => ({
         url: `/api/alertmanager/${datasourceUid}/api/v2/silences`,
       }),
-      providesTags: ['AlertmanagerSilences'],
+      providesTags: (result) =>
+        result ? result.map(({ id }) => ({ type: 'AlertmanagerSilences', id })) : ['AlertmanagerSilences'],
     }),
 
     getSilence: build.query<
@@ -25,8 +26,10 @@ export const alertSilencesApi = alertingApi.injectEndpoints({
     >({
       query: ({ datasourceUid, id }) => ({
         url: `/api/alertmanager/${datasourceUid}/api/v2/silence/${id}`,
+        showErrorAlert: false,
       }),
-      providesTags: ['AlertmanagerSilences'],
+      providesTags: (result, error, { id }) =>
+        result ? [{ type: 'AlertmanagerSilences', id }] : ['AlertmanagerSilences'],
     }),
 
     createSilence: build.mutation<

--- a/public/app/features/alerting/unified/api/alertSilencesApi.ts
+++ b/public/app/features/alerting/unified/api/alertSilencesApi.ts
@@ -1,0 +1,65 @@
+import { Silence, SilenceCreatePayload } from 'app/plugins/datasource/alertmanager/types';
+
+import { alertingApi } from './alertingApi';
+
+export const alertSilencesApi = alertingApi.injectEndpoints({
+  endpoints: (build) => ({
+    getSilences: build.query<
+      Silence[],
+      {
+        datasourceUid: string;
+      }
+    >({
+      query: ({ datasourceUid }) => ({
+        url: `/api/alertmanager/${datasourceUid}/api/v2/silences`,
+      }),
+      providesTags: ['AlertSilences'],
+    }),
+
+    getSilence: build.query<
+      Silence,
+      {
+        datasourceUid: string;
+        id: string;
+      }
+    >({
+      query: ({ datasourceUid, id }) => ({
+        url: `/api/alertmanager/${datasourceUid}/api/v2/silence/${id}`,
+      }),
+      providesTags: ['AlertSilences'],
+    }),
+
+    createSilence: build.mutation<
+      {
+        silenceId: string;
+      },
+      {
+        datasourceUid: string;
+        payload: SilenceCreatePayload;
+      }
+    >({
+      query: ({ datasourceUid, payload }) => ({
+        url: `/api/alertmanager/${datasourceUid}/api/v2/silences`,
+        method: 'POST',
+        data: payload,
+      }),
+      invalidatesTags: ['AlertSilences'],
+    }),
+
+    expireSilence: build.mutation<
+      {
+        message: string;
+      },
+      {
+        datasourceUid: string;
+        silenceId: string;
+      }
+    >({
+      query: ({ datasourceUid, silenceId }) => ({
+        url: `/api/alertmanager/${datasourceUid}/api/v2/silence/${silenceId}`,
+        method: 'DELETE',
+      }),
+      invalidatesTags: ['AlertSilences'],
+    }),
+  }),
+});

--- a/public/app/features/alerting/unified/api/alertSilencesApi.ts
+++ b/public/app/features/alerting/unified/api/alertSilencesApi.ts
@@ -13,7 +13,7 @@ export const alertSilencesApi = alertingApi.injectEndpoints({
       query: ({ datasourceUid }) => ({
         url: `/api/alertmanager/${datasourceUid}/api/v2/silences`,
       }),
-      providesTags: ['AlertSilences'],
+      providesTags: ['AlertmanagerSilences'],
     }),
 
     getSilence: build.query<
@@ -26,7 +26,7 @@ export const alertSilencesApi = alertingApi.injectEndpoints({
       query: ({ datasourceUid, id }) => ({
         url: `/api/alertmanager/${datasourceUid}/api/v2/silence/${id}`,
       }),
-      providesTags: ['AlertSilences'],
+      providesTags: ['AlertmanagerSilences'],
     }),
 
     createSilence: build.mutation<
@@ -43,7 +43,7 @@ export const alertSilencesApi = alertingApi.injectEndpoints({
         method: 'POST',
         data: payload,
       }),
-      invalidatesTags: ['AlertSilences', 'AlertmanagerAlerts'],
+      invalidatesTags: ['AlertmanagerSilences', 'AlertmanagerAlerts'],
     }),
 
     expireSilence: build.mutation<
@@ -59,7 +59,7 @@ export const alertSilencesApi = alertingApi.injectEndpoints({
         url: `/api/alertmanager/${datasourceUid}/api/v2/silence/${silenceId}`,
         method: 'DELETE',
       }),
-      invalidatesTags: ['AlertSilences'],
+      invalidatesTags: ['AlertmanagerSilences'],
     }),
   }),
 });

--- a/public/app/features/alerting/unified/api/alertingApi.ts
+++ b/public/app/features/alerting/unified/api/alertingApi.ts
@@ -40,6 +40,7 @@ export const alertingApi = createApi({
     'DataSourceSettings',
     'GrafanaLabels',
     'CombinedAlertRule',
+    'AlertSilences',
   ],
   endpoints: () => ({}),
 });

--- a/public/app/features/alerting/unified/api/alertingApi.ts
+++ b/public/app/features/alerting/unified/api/alertingApi.ts
@@ -35,12 +35,13 @@ export const alertingApi = createApi({
   tagTypes: [
     'AlertmanagerChoice',
     'AlertmanagerConfiguration',
+    'AlertmanagerAlerts',
+    'AlertSilences',
     'OnCallIntegrations',
     'OrgMigrationState',
     'DataSourceSettings',
     'GrafanaLabels',
     'CombinedAlertRule',
-    'AlertSilences',
   ],
   endpoints: () => ({}),
 });

--- a/public/app/features/alerting/unified/api/alertingApi.ts
+++ b/public/app/features/alerting/unified/api/alertingApi.ts
@@ -36,7 +36,7 @@ export const alertingApi = createApi({
     'AlertmanagerChoice',
     'AlertmanagerConfiguration',
     'AlertmanagerAlerts',
-    'AlertSilences',
+    'AlertmanagerSilences',
     'OnCallIntegrations',
     'OrgMigrationState',
     'DataSourceSettings',

--- a/public/app/features/alerting/unified/api/alertmanager.ts
+++ b/public/app/features/alerting/unified/api/alertmanager.ts
@@ -11,8 +11,6 @@ import {
   ExternalAlertmanagersResponse,
   Matcher,
   Receiver,
-  Silence,
-  SilenceCreatePayload,
   TestReceiversAlert,
   TestReceiversPayload,
   TestReceiversResult,
@@ -76,40 +74,6 @@ export async function deleteAlertManagerConfig(alertManagerSourceName: string): 
       showErrorAlert: false,
       showSuccessAlert: false,
     })
-  );
-}
-
-export async function fetchSilences(alertManagerSourceName: string): Promise<Silence[]> {
-  const result = await lastValueFrom(
-    getBackendSrv().fetch<Silence[]>({
-      url: `/api/alertmanager/${getDatasourceAPIUid(alertManagerSourceName)}/api/v2/silences`,
-      showErrorAlert: false,
-      showSuccessAlert: false,
-    })
-  );
-  return result.data;
-}
-
-// returns the new silence ID. Even in the case of an update, a new silence is created and the previous one expired.
-export async function createOrUpdateSilence(
-  alertmanagerSourceName: string,
-  payload: SilenceCreatePayload
-): Promise<Silence> {
-  const result = await lastValueFrom(
-    getBackendSrv().fetch<Silence>({
-      url: `/api/alertmanager/${getDatasourceAPIUid(alertmanagerSourceName)}/api/v2/silences`,
-      data: payload,
-      showErrorAlert: false,
-      showSuccessAlert: false,
-      method: 'POST',
-    })
-  );
-  return result.data;
-}
-
-export async function expireSilence(alertmanagerSourceName: string, silenceID: string): Promise<void> {
-  await getBackendSrv().delete(
-    `/api/alertmanager/${getDatasourceAPIUid(alertmanagerSourceName)}/api/v2/silence/${encodeURIComponent(silenceID)}`
   );
 }
 

--- a/public/app/features/alerting/unified/api/alertmanager.ts
+++ b/public/app/features/alerting/unified/api/alertmanager.ts
@@ -1,15 +1,13 @@
 import { lastValueFrom } from 'rxjs';
 
-import { isObject, urlUtil } from '@grafana/data';
+import { isObject } from '@grafana/data';
 import { getBackendSrv, isFetchError } from '@grafana/runtime';
 import {
-  AlertmanagerAlert,
   AlertManagerCortexConfig,
   AlertmanagerGroup,
   AlertmanagerStatus,
   ExternalAlertmanagerConfig,
   ExternalAlertmanagersResponse,
-  Matcher,
   Receiver,
   TestReceiversAlert,
   TestReceiversPayload,
@@ -75,37 +73,6 @@ export async function deleteAlertManagerConfig(alertManagerSourceName: string): 
       showSuccessAlert: false,
     })
   );
-}
-
-export async function fetchAlerts(
-  alertmanagerSourceName: string,
-  matchers?: Matcher[],
-  silenced = true,
-  active = true,
-  inhibited = true
-): Promise<AlertmanagerAlert[]> {
-  const filters =
-    urlUtil.toUrlParams({ silenced, active, inhibited }) +
-      matchers
-        ?.map(
-          (matcher) =>
-            `filter=${encodeURIComponent(
-              `${escapeQuotes(matcher.name)}=${matcher.isRegex ? '~' : ''}"${escapeQuotes(matcher.value)}"`
-            )}`
-        )
-        .join('&') || '';
-
-  const result = await lastValueFrom(
-    getBackendSrv().fetch<AlertmanagerAlert[]>({
-      url:
-        `/api/alertmanager/${getDatasourceAPIUid(alertmanagerSourceName)}/api/v2/alerts` +
-        (filters ? '?' + filters : ''),
-      showErrorAlert: false,
-      showSuccessAlert: false,
-    })
-  );
-
-  return result.data;
 }
 
 export async function fetchAlertGroups(alertmanagerSourceName: string): Promise<AlertmanagerGroup[]> {
@@ -233,8 +200,4 @@ export async function fetchExternalAlertmanagerConfig(): Promise<ExternalAlertma
   );
 
   return result.data;
-}
-
-function escapeQuotes(value: string): string {
-  return value.replace(/"/g, '\\"');
 }

--- a/public/app/features/alerting/unified/api/alertmanagerApi.ts
+++ b/public/app/features/alerting/unified/api/alertmanagerApi.ts
@@ -78,6 +78,7 @@ export const alertmanagerApi = alertingApi.injectEndpoints({
           params,
         };
       },
+      providesTags: ['AlertmanagerAlerts'],
     }),
 
     getAlertmanagerAlertGroups: build.query<AlertmanagerGroup[], { amSourceName: string }>({

--- a/public/app/features/alerting/unified/components/silences/SilencesEditor.tsx
+++ b/public/app/features/alerting/unified/components/silences/SilencesEditor.tsx
@@ -195,7 +195,7 @@ export const SilencesEditor = ({ silenceId, alertManagerSourceName }: Props) => 
   return (
     <FormProvider {...formAPI}>
       <form onSubmit={handleSubmit(onSubmit)}>
-        <FieldSet label={`${silenceId ? 'Recreate silence' : 'Create silence'}`}>
+        <FieldSet label={silenceId ? 'Recreate silence' : 'Create silence'}>
           <div className={cx(styles.flexRow, styles.silencePeriod)}>
             <SilencePeriod />
             <Field

--- a/public/app/features/alerting/unified/components/silences/SilencesEditor.tsx
+++ b/public/app/features/alerting/unified/components/silences/SilencesEditor.tsx
@@ -139,6 +139,7 @@ export const SilencesEditor = ({ silenceId, alertManagerSourceName }: Props) => 
   const matcherFields = watch('matchers');
 
   useEffect(() => {
+    // Allows the form to correctly initialise when an existing silence is fetch from the backend
     reset(getDefaultFormValues(urlSearchParams, silence));
   }, [reset, silence, urlSearchParams]);
 

--- a/public/app/features/alerting/unified/components/silences/SilencesTable.tsx
+++ b/public/app/features/alerting/unified/components/silences/SilencesTable.tsx
@@ -2,6 +2,7 @@ import { css } from '@emotion/css';
 import React, { useMemo } from 'react';
 
 import { dateMath, GrafanaTheme2 } from '@grafana/data';
+import { isFetchError } from '@grafana/runtime';
 import { CollapsableSection, Icon, Link, LinkButton, useStyles2, Stack, Alert } from '@grafana/ui';
 import { useQueryParams } from 'app/core/hooks/useQueryParams';
 import { alertSilencesApi } from 'app/features/alerting/unified/api/alertSilencesApi';
@@ -59,8 +60,7 @@ const SilencesTable = ({ alertManagerSourceName }: Props) => {
   );
 
   const mimirLazyInitError =
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    (error as any)?.message?.includes('the Alertmanager is not configured') && amFeatures?.lazyConfigInit;
+    isFetchError(error) && error?.message?.includes('the Alertmanager is not configured') && amFeatures?.lazyConfigInit;
 
   const styles = useStyles2(getStyles);
   const [queryParams] = useQueryParams();
@@ -109,9 +109,8 @@ const SilencesTable = ({ alertManagerSourceName }: Props) => {
     );
   }
 
-  if (error) {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const errMessage = (error as any)?.message || 'Unknown error.';
+  if (isFetchError(error)) {
+    const errMessage = error?.message || 'Unknown error.';
     return (
       <Alert severity="error" title="Error loading silences">
         {errMessage}

--- a/public/app/features/alerting/unified/components/silences/SilencesTable.tsx
+++ b/public/app/features/alerting/unified/components/silences/SilencesTable.tsx
@@ -2,7 +2,6 @@ import { css } from '@emotion/css';
 import React, { useMemo } from 'react';
 
 import { dateMath, GrafanaTheme2 } from '@grafana/data';
-import { isFetchError } from '@grafana/runtime';
 import { CollapsableSection, Icon, Link, LinkButton, useStyles2, Stack, Alert, LoadingPlaceholder } from '@grafana/ui';
 import { useQueryParams } from 'app/core/hooks/useQueryParams';
 import { alertSilencesApi } from 'app/features/alerting/unified/api/alertSilencesApi';
@@ -109,8 +108,8 @@ const SilencesTable = ({ alertManagerSourceName }: Props) => {
     );
   }
 
-  if (isFetchError(error)) {
-    const errMessage = error?.message || 'Unknown error.';
+  if (error) {
+    const errMessage = stringifyErrorLike(error) || 'Unknown error.';
     return (
       <Alert severity="error" title="Error loading silences">
         {errMessage}

--- a/public/app/features/alerting/unified/components/silences/SilencesTable.tsx
+++ b/public/app/features/alerting/unified/components/silences/SilencesTable.tsx
@@ -36,7 +36,7 @@ interface Props {
 }
 
 const SilencesTable = ({ alertManagerSourceName }: Props) => {
-  const { data: alertManagerAlerts, isLoading: amAlertsIsLoading } =
+  const { data: alertManagerAlerts = [], isLoading: amAlertsIsLoading } =
     alertmanagerApi.endpoints.getAlertmanagerAlerts.useQuery(
       { amSourceName: alertManagerSourceName, filter: { silenced: true, active: true, inhibited: true } },
       { pollingInterval: SILENCES_POLL_INTERVAL_MS }
@@ -72,7 +72,7 @@ const SilencesTable = ({ alertManagerSourceName }: Props) => {
 
   const itemsNotExpired = useMemo((): SilenceTableItemProps[] => {
     const findSilencedAlerts = (id: string) => {
-      return (alertManagerAlerts || []).filter((alert) => alert.status.silencedBy.includes(id));
+      return alertManagerAlerts.filter((alert) => alert.status.silencedBy.includes(id));
     };
     return filteredSilencesNotExpired.map((silence) => {
       const silencedAlerts = findSilencedAlerts(silence.id);
@@ -85,7 +85,7 @@ const SilencesTable = ({ alertManagerSourceName }: Props) => {
 
   const itemsExpired = useMemo((): SilenceTableItemProps[] => {
     const findSilencedAlerts = (id: string) => {
-      return (alertManagerAlerts || []).filter((alert) => alert.status.silencedBy.includes(id));
+      return alertManagerAlerts.filter((alert) => alert.status.silencedBy.includes(id));
     };
     return filteredSilencesExpired.map((silence) => {
       const silencedAlerts = findSilencedAlerts(silence.id);

--- a/public/app/features/alerting/unified/mockApi.ts
+++ b/public/app/features/alerting/unified/mockApi.ts
@@ -5,6 +5,7 @@ import { setupServer, SetupServer } from 'msw/node';
 import { DataSourceInstanceSettings, PluginMeta } from '@grafana/data';
 import { setBackendSrv } from '@grafana/runtime';
 import { AlertRuleUpdated } from 'app/features/alerting/unified/api/alertRuleApi';
+import allHandlers from 'app/features/alerting/unified/mocks/server/handlers';
 import { DashboardDTO, FolderDTO, NotifierDTO, OrgUser } from 'app/types';
 import {
   PromBuildInfoResponse,
@@ -424,7 +425,7 @@ export function mockDashboardApi(server: SetupServer) {
   };
 }
 
-const server = setupServer();
+const server = setupServer(...allHandlers);
 
 // Creates a MSW server and sets up beforeAll, afterAll and beforeEach handlers for it
 export function setupMswServer() {

--- a/public/app/features/alerting/unified/mocks.ts
+++ b/public/app/features/alerting/unified/mocks.ts
@@ -307,10 +307,16 @@ export const mockSilence = (partial: Partial<Silence> = {}): Silence => {
   };
 };
 
+export const MOCK_SILENCE_ID_EXISTING = 'f209e273-0e4e-434f-9f66-e72f092025a2';
+
 export const mockSilences = [
-  mockSilence({ id: '12345' }),
-  mockSilence({ id: '67890', matchers: parseMatchers('foo!=bar'), comment: 'Catch all' }),
-  mockSilence({ id: '1111', status: { state: SilenceState.Expired } }),
+  mockSilence({ id: MOCK_SILENCE_ID_EXISTING }),
+  mockSilence({
+    id: 'ce031625-61c7-47cd-9beb-8760bccf0ed7',
+    matchers: parseMatchers('foo!=bar'),
+    comment: 'Catch all',
+  }),
+  mockSilence({ id: '145884a8-ee20-4864-9f84-661305fb7d82', status: { state: SilenceState.Expired } }),
 ];
 
 export const mockNotifiersState = (partial: Partial<NotifiersState> = {}): NotifiersState => {

--- a/public/app/features/alerting/unified/mocks.ts
+++ b/public/app/features/alerting/unified/mocks.ts
@@ -18,6 +18,7 @@ import {
 import { DataSourceSrv, GetDataSourceListFilters, config } from '@grafana/runtime';
 import { defaultDashboard } from '@grafana/schema';
 import { contextSrv } from 'app/core/services/context_srv';
+import { parseMatchers } from 'app/features/alerting/unified/utils/alertmanager';
 import { DatasourceSrv } from 'app/features/plugins/datasource_srv';
 import {
   AlertManagerCortexConfig,
@@ -305,6 +306,12 @@ export const mockSilence = (partial: Partial<Silence> = {}): Silence => {
     ...partial,
   };
 };
+
+export const mockSilences = [
+  mockSilence({ id: '12345' }),
+  mockSilence({ id: '67890', matchers: parseMatchers('foo!=bar'), comment: 'Catch all' }),
+  mockSilence({ id: '1111', status: { state: SilenceState.Expired } }),
+];
 
 export const mockNotifiersState = (partial: Partial<NotifiersState> = {}): NotifiersState => {
   return {

--- a/public/app/features/alerting/unified/mocks/alertmanagerApi.ts
+++ b/public/app/features/alerting/unified/mocks/alertmanagerApi.ts
@@ -2,6 +2,7 @@ import { http, HttpResponse } from 'msw';
 import { SetupServer } from 'msw/node';
 
 import { MOCK_SILENCE_ID_EXISTING, mockAlertmanagerAlert } from 'app/features/alerting/unified/mocks';
+import { MOCK_DATASOURCE_UID_BROKEN_ALERTMANAGER } from 'app/features/alerting/unified/mocks/datasources';
 
 import {
   AlertmanagerChoice,
@@ -47,8 +48,11 @@ export function mockAlertmanagerConfigResponse(
 }
 
 export const alertmanagerAlertsListHandler = () =>
-  http.get('/api/alertmanager/:datasourceUid/api/v2/alerts', () =>
-    HttpResponse.json([
+  http.get<{ datasourceUid: string }>('/api/alertmanager/:datasourceUid/api/v2/alerts', ({ params }) => {
+    if (params.datasourceUid === MOCK_DATASOURCE_UID_BROKEN_ALERTMANAGER) {
+      return HttpResponse.json({ traceId: '' }, { status: 502 });
+    }
+    return HttpResponse.json([
       mockAlertmanagerAlert({
         labels: { foo: 'bar', buzz: 'bazz' },
         status: { state: AlertState.Suppressed, silencedBy: [MOCK_SILENCE_ID_EXISTING], inhibitedBy: [] },
@@ -57,5 +61,5 @@ export const alertmanagerAlertsListHandler = () =>
         labels: { foo: 'bar', buzz: 'bazz' },
         status: { state: AlertState.Suppressed, silencedBy: [MOCK_SILENCE_ID_EXISTING], inhibitedBy: [] },
       }),
-    ])
-  );
+    ]);
+  });

--- a/public/app/features/alerting/unified/mocks/alertmanagerApi.ts
+++ b/public/app/features/alerting/unified/mocks/alertmanagerApi.ts
@@ -1,9 +1,12 @@
 import { http, HttpResponse } from 'msw';
 import { SetupServer } from 'msw/node';
 
+import { mockAlertmanagerAlert } from 'app/features/alerting/unified/mocks';
+
 import {
   AlertmanagerChoice,
   AlertManagerCortexConfig,
+  AlertState,
   ExternalAlertmanagersResponse,
 } from '../../../../plugins/datasource/alertmanager/types';
 import { AlertmanagersChoiceResponse } from '../api/alertmanagerApi';
@@ -13,8 +16,12 @@ export const defaultAlertmanagerChoiceResponse: AlertmanagersChoiceResponse = {
   alertmanagersChoice: AlertmanagerChoice.Internal,
   numExternalAlertmanagers: 0,
 };
+
+export const alertmanagerChoiceHandler = (response = defaultAlertmanagerChoiceResponse) =>
+  http.get('/api/v1/ngalert', () => HttpResponse.json(response));
+
 export function mockAlertmanagerChoiceResponse(server: SetupServer, response: AlertmanagersChoiceResponse) {
-  server.use(http.get('/api/v1/ngalert', () => HttpResponse.json(response)));
+  server.use(alertmanagerChoiceHandler(response));
 }
 
 export const emptyExternalAlertmanagersResponse: ExternalAlertmanagersResponse = {
@@ -38,3 +45,17 @@ export function mockAlertmanagerConfigResponse(
     )
   );
 }
+
+export const alertmanagerAlertsListHandler = () =>
+  http.get('/api/alertmanager/:datasourceUid/api/v2/alerts', () =>
+    HttpResponse.json([
+      mockAlertmanagerAlert({
+        labels: { foo: 'bar', buzz: 'bazz' },
+        status: { state: AlertState.Suppressed, silencedBy: ['12345'], inhibitedBy: [] },
+      }),
+      mockAlertmanagerAlert({
+        labels: { foo: 'bar', buzz: 'bazz' },
+        status: { state: AlertState.Suppressed, silencedBy: ['12345'], inhibitedBy: [] },
+      }),
+    ])
+  );

--- a/public/app/features/alerting/unified/mocks/alertmanagerApi.ts
+++ b/public/app/features/alerting/unified/mocks/alertmanagerApi.ts
@@ -1,7 +1,7 @@
 import { http, HttpResponse } from 'msw';
 import { SetupServer } from 'msw/node';
 
-import { mockAlertmanagerAlert } from 'app/features/alerting/unified/mocks';
+import { MOCK_SILENCE_ID_EXISTING, mockAlertmanagerAlert } from 'app/features/alerting/unified/mocks';
 
 import {
   AlertmanagerChoice,
@@ -51,11 +51,11 @@ export const alertmanagerAlertsListHandler = () =>
     HttpResponse.json([
       mockAlertmanagerAlert({
         labels: { foo: 'bar', buzz: 'bazz' },
-        status: { state: AlertState.Suppressed, silencedBy: ['12345'], inhibitedBy: [] },
+        status: { state: AlertState.Suppressed, silencedBy: [MOCK_SILENCE_ID_EXISTING], inhibitedBy: [] },
       }),
       mockAlertmanagerAlert({
         labels: { foo: 'bar', buzz: 'bazz' },
-        status: { state: AlertState.Suppressed, silencedBy: ['12345'], inhibitedBy: [] },
+        status: { state: AlertState.Suppressed, silencedBy: [MOCK_SILENCE_ID_EXISTING], inhibitedBy: [] },
       }),
     ])
   );

--- a/public/app/features/alerting/unified/mocks/datasources.ts
+++ b/public/app/features/alerting/unified/mocks/datasources.ts
@@ -1,0 +1,5 @@
+import { HttpResponse, http } from 'msw';
+
+// TODO: Add more accurate endpoint responses as tests require
+export const datasourceBuildInfoHandler = () =>
+  http.get('/api/datasources/proxy/uid/:datasourceUid/api/v1/status/buildinfo', () => HttpResponse.json({}));

--- a/public/app/features/alerting/unified/mocks/datasources.ts
+++ b/public/app/features/alerting/unified/mocks/datasources.ts
@@ -3,3 +3,8 @@ import { HttpResponse, http } from 'msw';
 // TODO: Add more accurate endpoint responses as tests require
 export const datasourceBuildInfoHandler = () =>
   http.get('/api/datasources/proxy/uid/:datasourceUid/api/v1/status/buildinfo', () => HttpResponse.json({}));
+
+/** UID of the alertmanager that is expected to be broken in tests */
+export const MOCK_DATASOURCE_UID_BROKEN_ALERTMANAGER = 'FwkfQfEmYlAthB';
+/** Display name of the alertmanager that is expected to be broken in tests */
+export const MOCK_DATASOURCE_NAME_BROKEN_ALERTMANAGER = 'broken alertmanager';

--- a/public/app/features/alerting/unified/mocks/server/configure.ts
+++ b/public/app/features/alerting/unified/mocks/server/configure.ts
@@ -1,5 +1,5 @@
 import server from 'app/features/alerting/unified/mockApi';
-import { alertmanagerChoiceHandler } from 'app/features/alerting/unified/mocks/server/handlers';
+import { alertmanagerChoiceHandler } from 'app/features/alerting/unified/mocks/alertmanagerApi';
 import { AlertmanagerChoice } from 'app/plugins/datasource/alertmanager/types';
 
 /**

--- a/public/app/features/alerting/unified/mocks/server/events.ts
+++ b/public/app/features/alerting/unified/mocks/server/events.ts
@@ -1,0 +1,23 @@
+import { HttpHandler, matchRequestUrl } from 'msw';
+
+import server from 'app/features/alerting/unified/mockApi';
+
+/**
+ * Wait for the mock server to receive a request for the given method + url combination,
+ * and resolve with information about the request that was made
+ *
+ * @deprecated Try not to use this 🙏 instead aim to assert against UI side effects
+ */
+export function waitForServerRequest(handler: HttpHandler) {
+  const { method, path } = handler.info;
+  return new Promise<Request>((resolve) => {
+    server.events.on('request:match', ({ request }) => {
+      const matchesMethod = request.method.toLowerCase() === String(method).toLowerCase();
+      const matchesUrl = matchRequestUrl(new URL(request.url), path);
+
+      if (matchesMethod && matchesUrl) {
+        resolve(request);
+      }
+    });
+  });
+}

--- a/public/app/features/alerting/unified/mocks/server/handlers.ts
+++ b/public/app/features/alerting/unified/mocks/server/handlers.ts
@@ -1,53 +1,13 @@
 /**
- * Contains definitions for all handlers that are required for test rendering of components within Alerting
+ * Contains all handlers that are required for test rendering of components within Alerting
  */
 
-import { HttpResponse, http } from 'msw';
-
-import { mockAlertmanagerAlert, mockSilences } from 'app/features/alerting/unified/mocks';
-import { defaultAlertmanagerChoiceResponse } from 'app/features/alerting/unified/mocks/alertmanagerApi';
-import { AlertState } from 'app/plugins/datasource/alertmanager/types';
-
-///////////////////
-// Alertmanagers //
-///////////////////
-
-export const alertmanagerChoiceHandler = (response = defaultAlertmanagerChoiceResponse) =>
-  http.get('/api/v1/ngalert', () => HttpResponse.json(response));
-
-const alertmanagerAlertsListHandler = () =>
-  http.get('/api/alertmanager/:datasourceUid/api/v2/alerts', () =>
-    HttpResponse.json([
-      mockAlertmanagerAlert({
-        labels: { foo: 'bar', buzz: 'bazz' },
-        status: { state: AlertState.Suppressed, silencedBy: ['12345'], inhibitedBy: [] },
-      }),
-      mockAlertmanagerAlert({
-        labels: { foo: 'bar', buzz: 'bazz' },
-        status: { state: AlertState.Suppressed, silencedBy: ['12345'], inhibitedBy: [] },
-      }),
-    ])
-  );
-
-/////////////////
-// Datasources //
-/////////////////
-
-// TODO: Add more accurate endpoint responses as tests require
-const datasourceBuildInfoHandler = () =>
-  http.get('/api/datasources/proxy/uid/:datasourceUid/api/v1/status/buildinfo', () => HttpResponse.json({}));
-
-//////////////
-// Silences //
-//////////////
-
-const silencesListHandler = (silences = mockSilences) =>
-  http.get('/api/alertmanager/:datasourceUid/api/v2/silences', () => HttpResponse.json(silences));
-
-const createSilenceHandler = () =>
-  http.post('/api/alertmanager/:datasourceUid/api/v2/silences', () =>
-    HttpResponse.json({ silenceId: '4bda5b38-7939-4887-9ec2-16323b8e3b4e' })
-  );
+import {
+  alertmanagerAlertsListHandler,
+  alertmanagerChoiceHandler,
+} from 'app/features/alerting/unified/mocks/alertmanagerApi';
+import { datasourceBuildInfoHandler } from 'app/features/alerting/unified/mocks/datasources';
+import { silenceCreateHandler, silencesListHandler } from 'app/features/alerting/unified/mocks/silences';
 
 /**
  * All mock handlers that are required across Alerting tests
@@ -55,7 +15,7 @@ const createSilenceHandler = () =>
 const allHandlers = [
   alertmanagerChoiceHandler(),
   silencesListHandler(),
-  createSilenceHandler(),
+  silenceCreateHandler(),
   alertmanagerAlertsListHandler(),
   datasourceBuildInfoHandler(),
 ];

--- a/public/app/features/alerting/unified/mocks/server/handlers.ts
+++ b/public/app/features/alerting/unified/mocks/server/handlers.ts
@@ -7,16 +7,23 @@ import {
   alertmanagerChoiceHandler,
 } from 'app/features/alerting/unified/mocks/alertmanagerApi';
 import { datasourceBuildInfoHandler } from 'app/features/alerting/unified/mocks/datasources';
-import { silenceCreateHandler, silencesListHandler } from 'app/features/alerting/unified/mocks/silences';
+import {
+  silenceCreateHandler,
+  silenceGetHandler,
+  silencesListHandler,
+} from 'app/features/alerting/unified/mocks/silences';
 
 /**
  * All mock handlers that are required across Alerting tests
  */
 const allHandlers = [
   alertmanagerChoiceHandler(),
-  silencesListHandler(),
-  silenceCreateHandler(),
   alertmanagerAlertsListHandler(),
+
+  silencesListHandler(),
+  silenceGetHandler(),
+  silenceCreateHandler(),
+
   datasourceBuildInfoHandler(),
 ];
 

--- a/public/app/features/alerting/unified/mocks/server/handlers.ts
+++ b/public/app/features/alerting/unified/mocks/server/handlers.ts
@@ -4,7 +4,60 @@
 
 import { HttpResponse, http } from 'msw';
 
+import { mockAlertmanagerAlert, mockSilences } from 'app/features/alerting/unified/mocks';
 import { defaultAlertmanagerChoiceResponse } from 'app/features/alerting/unified/mocks/alertmanagerApi';
+import { AlertState } from 'app/plugins/datasource/alertmanager/types';
+
+///////////////////
+// Alertmanagers //
+///////////////////
 
 export const alertmanagerChoiceHandler = (response = defaultAlertmanagerChoiceResponse) =>
   http.get('/api/v1/ngalert', () => HttpResponse.json(response));
+
+const alertmanagerAlertsListHandler = () =>
+  http.get('/api/alertmanager/:datasourceUid/api/v2/alerts', () =>
+    HttpResponse.json([
+      mockAlertmanagerAlert({
+        labels: { foo: 'bar', buzz: 'bazz' },
+        status: { state: AlertState.Suppressed, silencedBy: ['12345'], inhibitedBy: [] },
+      }),
+      mockAlertmanagerAlert({
+        labels: { foo: 'bar', buzz: 'bazz' },
+        status: { state: AlertState.Suppressed, silencedBy: ['12345'], inhibitedBy: [] },
+      }),
+    ])
+  );
+
+/////////////////
+// Datasources //
+/////////////////
+
+// TODO: Add more accurate endpoint responses as tests require
+const datasourceBuildInfoHandler = () =>
+  http.get('/api/datasources/proxy/uid/:datasourceUid/api/v1/status/buildinfo', () => HttpResponse.json({}));
+
+//////////////
+// Silences //
+//////////////
+
+const silencesListHandler = (silences = mockSilences) =>
+  http.get('/api/alertmanager/:datasourceUid/api/v2/silences', () => HttpResponse.json(silences));
+
+const createSilenceHandler = () =>
+  http.post('/api/alertmanager/:datasourceUid/api/v2/silences', () =>
+    HttpResponse.json({ silenceId: '4bda5b38-7939-4887-9ec2-16323b8e3b4e' })
+  );
+
+/**
+ * All mock handlers that are required across Alerting tests
+ */
+const allHandlers = [
+  alertmanagerChoiceHandler(),
+  silencesListHandler(),
+  createSilenceHandler(),
+  alertmanagerAlertsListHandler(),
+  datasourceBuildInfoHandler(),
+];
+
+export default allHandlers;

--- a/public/app/features/alerting/unified/mocks/silences.ts
+++ b/public/app/features/alerting/unified/mocks/silences.ts
@@ -1,13 +1,19 @@
 import { HttpResponse, http } from 'msw';
 
 import { mockSilences } from 'app/features/alerting/unified/mocks';
+import { MOCK_DATASOURCE_UID_BROKEN_ALERTMANAGER } from 'app/features/alerting/unified/mocks/datasources';
 
 //////////////
 // Silences //
 //////////////
 
 export const silencesListHandler = (silences = mockSilences) =>
-  http.get('/api/alertmanager/:datasourceUid/api/v2/silences', () => HttpResponse.json(silences));
+  http.get<{ datasourceUid: string }>('/api/alertmanager/:datasourceUid/api/v2/silences', ({ params }) => {
+    if (params.datasourceUid === MOCK_DATASOURCE_UID_BROKEN_ALERTMANAGER) {
+      return HttpResponse.json({ traceId: '' }, { status: 502 });
+    }
+    return HttpResponse.json(silences);
+  });
 
 export const silenceGetHandler = () =>
   http.get<{ uuid: string }>('/api/alertmanager/:datasourceUid/api/v2/silence/:uuid', ({ params }) => {

--- a/public/app/features/alerting/unified/mocks/silences.ts
+++ b/public/app/features/alerting/unified/mocks/silences.ts
@@ -9,6 +9,17 @@ import { mockSilences } from 'app/features/alerting/unified/mocks';
 export const silencesListHandler = (silences = mockSilences) =>
   http.get('/api/alertmanager/:datasourceUid/api/v2/silences', () => HttpResponse.json(silences));
 
+export const silenceGetHandler = () =>
+  http.get<{ uuid: string }>('/api/alertmanager/:datasourceUid/api/v2/silence/:uuid', ({ params }) => {
+    const { uuid } = params;
+    const matchingMockSilence = mockSilences.find((silence) => silence.id === uuid);
+    if (matchingMockSilence) {
+      return HttpResponse.json(matchingMockSilence);
+    }
+
+    return HttpResponse.json({ message: 'silence not found' }, { status: 404 });
+  });
+
 export const silenceCreateHandler = () =>
   http.post('/api/alertmanager/:datasourceUid/api/v2/silences', () =>
     HttpResponse.json({ silenceId: '4bda5b38-7939-4887-9ec2-16323b8e3b4e' })

--- a/public/app/features/alerting/unified/mocks/silences.ts
+++ b/public/app/features/alerting/unified/mocks/silences.ts
@@ -1,0 +1,15 @@
+import { HttpResponse, http } from 'msw';
+
+import { mockSilences } from 'app/features/alerting/unified/mocks';
+
+//////////////
+// Silences //
+//////////////
+
+export const silencesListHandler = (silences = mockSilences) =>
+  http.get('/api/alertmanager/:datasourceUid/api/v2/silences', () => HttpResponse.json(silences));
+
+export const silenceCreateHandler = () =>
+  http.post('/api/alertmanager/:datasourceUid/api/v2/silences', () =>
+    HttpResponse.json({ silenceId: '4bda5b38-7939-4887-9ec2-16323b8e3b4e' })
+  );

--- a/public/app/features/alerting/unified/state/reducers.ts
+++ b/public/app/features/alerting/unified/state/reducers.ts
@@ -3,10 +3,8 @@ import { combineReducers } from 'redux';
 import { createAsyncMapSlice, createAsyncSlice } from '../utils/redux';
 
 import {
-  createOrUpdateSilenceAction,
   deleteAlertManagerConfigAction,
   fetchAlertGroupsAction,
-  fetchAmAlertsAction,
   fetchEditableRuleAction,
   fetchExternalAlertmanagersAction,
   fetchExternalAlertmanagersConfigAction,
@@ -16,7 +14,6 @@ import {
   fetchPromRulesAction,
   fetchRulerRulesAction,
   fetchRulesSourceBuildInfoAction,
-  fetchSilencesAction,
   saveRuleFormAction,
   testReceiversAction,
   updateAlertManagerConfigAction,
@@ -32,8 +29,6 @@ export const reducer = combineReducers({
   promRules: createAsyncMapSlice('promRules', fetchPromRulesAction, ({ rulesSourceName }) => rulesSourceName).reducer,
   rulerRules: createAsyncMapSlice('rulerRules', fetchRulerRulesAction, ({ rulesSourceName }) => rulesSourceName)
     .reducer,
-  silences: createAsyncMapSlice('silences', fetchSilencesAction, (alertManagerSourceName) => alertManagerSourceName)
-    .reducer,
   ruleForm: combineReducers({
     saveRule: createAsyncSlice('saveRule', saveRuleFormAction).reducer,
     existingRule: createAsyncSlice('existingRule', fetchEditableRuleAction).reducer,
@@ -41,9 +36,6 @@ export const reducer = combineReducers({
   grafanaNotifiers: createAsyncSlice('grafanaNotifiers', fetchGrafanaNotifiersAction).reducer,
   saveAMConfig: createAsyncSlice('saveAMConfig', updateAlertManagerConfigAction).reducer,
   deleteAMConfig: createAsyncSlice('deleteAMConfig', deleteAlertManagerConfigAction).reducer,
-  updateSilence: createAsyncSlice('updateSilence', createOrUpdateSilenceAction).reducer,
-  amAlerts: createAsyncMapSlice('amAlerts', fetchAmAlertsAction, (alertManagerSourceName) => alertManagerSourceName)
-    .reducer,
   folders: createAsyncMapSlice('folders', fetchFolderAction, (uid) => uid).reducer,
   amAlertGroups: createAsyncMapSlice(
     'amAlertGroups',

--- a/public/app/features/alerting/unified/utils/misc.ts
+++ b/public/app/features/alerting/unified/utils/misc.ts
@@ -232,7 +232,17 @@ export function isErrorLike(error: unknown): error is Error {
 export function stringifyErrorLike(error: unknown): string {
   const fetchError = isFetchError(error);
   if (fetchError) {
-    return error.data.message;
+    if (error.message) {
+      return error.message;
+    }
+    if ('message' in error.data && typeof error.data.message === 'string') {
+      return error.data.message;
+    }
+    if (error.statusText) {
+      return error.statusText;
+    }
+
+    return String(error.status) || 'Unknown error';
   }
 
   return isErrorLike(error) ? error.message : String(error);


### PR DESCRIPTION
**What is this feature?**

Migrates the API logic in Silences table/editor to use RTK Query instead, and tidies up appropriately afterwards.

Moves fetching logic into necessary components so we don't have to search through the API response to get an existing silence by ID. Uses `/:id` endpoint for fetching an individual silence, and uses tag invalidation/polling to fetch silences as needed

**Why do we need this feature?**

Simplifying the future work for Silences.
