### PR TITLE
Update QuerySuggestionItem.tsx

### DIFF
--- a/packages/grafana-prometheus/src/querybuilder/components/promQail/QuerySuggestionItem.tsx
+++ b/packages/grafana-prometheus/src/querybuilder/components/promQail/QuerySuggestionItem.tsx
@@ -243,10 +243,7 @@ export function QuerySuggestionItem(props: Props) {
                         placement="bottom-end"
                         closeButton={true}
                       >
-                        <Button 
-                          fill="outline"
-                          variant="secondary"
-                          size="sm">
+                        <Button fill="outline" variant="secondary" size="sm">
                           No
                         </Button>
                       </Toggletip>

--- a/packages/grafana-prometheus/src/querybuilder/components/promQail/QuerySuggestionItem.tsx
+++ b/packages/grafana-prometheus/src/querybuilder/components/promQail/QuerySuggestionItem.tsx
@@ -243,7 +243,10 @@ export function QuerySuggestionItem(props: Props) {
                         placement="bottom-end"
                         closeButton={true}
                       >
-                        <Button variant="success" size="sm">
+                        <Button 
+                          fill="outline"
+                          variant="secondary"
+                          size="sm">
                           No
                         </Button>
                       </Toggletip>


### PR DESCRIPTION
Adjust the styling of the "no" button in the explainer feedback section to a standard secondary variant instead of the success styling

![image](https://github.com/grafana/grafana/assets/25674746/e0fe6ac2-54d5-4608-ad84-e265311355e8)


Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
