### PR TITLE
Explore and Correlations: Replace deprecated layout components

### DIFF
--- a/.betterer.results
+++ b/.betterer.results
@@ -2384,9 +2384,6 @@ exports[`better eslint`] = {
       [0, 0, 0, "Styles should be written using objects.", "0"],
       [0, 0, 0, "Styles should be written using objects.", "1"]
     ],
-    "public/app/features/correlations/Forms/CorrelationFormNavigation.tsx:5381": [
-      [0, 0, 0, "\'HorizontalGroup\' import from \'@grafana/ui\' is restricted from being used by a pattern. Use Stack component instead.", "0"]
-    ],
     "public/app/features/correlations/components/Wizard/index.ts:5381": [
       [0, 0, 0, "Do not use export all (\`export * from ...\`)", "0"],
       [0, 0, 0, "Do not use export all (\`export * from ...\`)", "1"]
@@ -3016,9 +3013,6 @@ exports[`better eslint`] = {
     "public/app/features/explore/ContentOutline/ContentOutline.tsx:5381": [
       [0, 0, 0, "Do not use any type assertions.", "0"]
     ],
-    "public/app/features/explore/CorrelationEditorModeBar.tsx:5381": [
-      [0, 0, 0, "\'HorizontalGroup\' import from \'@grafana/ui\' is restricted from being used by a pattern. Use Stack component instead.", "0"]
-    ],
     "public/app/features/explore/Logs/LiveLogs.tsx:5381": [
       [0, 0, 0, "Styles should be written using objects.", "0"],
       [0, 0, 0, "Styles should be written using objects.", "1"],
@@ -3449,9 +3443,6 @@ exports[`better eslint`] = {
     "public/app/features/explore/TraceView/createSpanLink.tsx:5381": [
       [0, 0, 0, "Do not use any type assertions.", "0"],
       [0, 0, 0, "Do not use any type assertions.", "1"]
-    ],
-    "public/app/features/explore/extensions/ConfirmNavigationModal.tsx:5381": [
-      [0, 0, 0, "\'VerticalGroup\' import from \'@grafana/ui\' is restricted from being used by a pattern. Use Stack component instead.", "0"]
     ],
     "public/app/features/explore/hooks/useStateSync/index.ts:5381": [
       [0, 0, 0, "Do not re-export imported variable (\`./external.utils\`)", "0"]

--- a/public/app/features/correlations/Forms/CorrelationFormNavigation.tsx
+++ b/public/app/features/correlations/Forms/CorrelationFormNavigation.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { Button, HorizontalGroup } from '@grafana/ui';
+import { Button, Stack } from '@grafana/ui';
 import { Trans, t } from 'app/core/internationalization';
 
 import { useWizardContext } from '../components/Wizard/wizardContext';
@@ -26,7 +26,7 @@ export const CorrelationFormNavigation = () => {
   );
 
   return (
-    <HorizontalGroup justify="flex-start">
+    <Stack justifyContent="flex-start">
       {currentPage > 0 ? (
         <Button variant="secondary" onClick={prevPage}>
           <Trans i18nKey="correlations.navigation-form.back-button">Back</Trans>
@@ -34,6 +34,6 @@ export const CorrelationFormNavigation = () => {
       ) : undefined}
 
       {isLastPage ? LastPageNext : NextPage}
-    </HorizontalGroup>
+    </Stack>
   );
 };

--- a/public/app/features/explore/CorrelationEditorModeBar.tsx
+++ b/public/app/features/explore/CorrelationEditorModeBar.tsx
@@ -5,7 +5,7 @@ import { useBeforeUnload, useUnmount } from 'react-use';
 
 import { GrafanaTheme2, colorManipulator } from '@grafana/data';
 import { reportInteraction } from '@grafana/runtime';
-import { Button, HorizontalGroup, Icon, Tooltip, useStyles2 } from '@grafana/ui';
+import { Button, Icon, Stack, Tooltip, useStyles2 } from '@grafana/ui';
 import { CORRELATION_EDITOR_POST_CONFIRM_ACTION, ExploreItemState, useDispatch, useSelector } from 'app/types';
 
 import { CorrelationUnsavedChangesModal } from './CorrelationUnsavedChangesModal';
@@ -229,7 +229,7 @@ export const CorrelationEditorModeBar = ({ panes }: { panes: Array<[string, Expl
         />
       )}
       <div className={styles.correlationEditorTop}>
-        <HorizontalGroup spacing="md" justify="flex-end">
+        <Stack gap={2} justifyContent="flex-end" alignItems="center">
           <Tooltip content="Correlations editor in Explore is an experimental feature.">
             <Icon className={styles.iconColor} name="info-circle" size="xl" />
           </Tooltip>
@@ -256,7 +256,7 @@ export const CorrelationEditorModeBar = ({ panes }: { panes: Array<[string, Expl
           >
             Exit correlation editor
           </Button>
-        </HorizontalGroup>
+        </Stack>
       </div>
     </>
   );

--- a/public/app/features/explore/extensions/ConfirmNavigationModal.tsx
+++ b/public/app/features/explore/extensions/ConfirmNavigationModal.tsx
@@ -2,7 +2,7 @@ import React, { ReactElement } from 'react';
 
 import { locationUtil } from '@grafana/data';
 import { locationService } from '@grafana/runtime';
-import { Button, Modal, VerticalGroup } from '@grafana/ui';
+import { Button, Modal, Stack } from '@grafana/ui';
 
 type Props = {
   onDismiss: () => void;
@@ -20,9 +20,9 @@ export function ConfirmNavigationModal(props: Props): ReactElement {
 
   return (
     <Modal title={title} isOpen onDismiss={onDismiss}>
-      <VerticalGroup spacing="sm">
+      <Stack direction="column" gap={1}>
         <p>Do you want to proceed in the current tab or open a new tab?</p>
-      </VerticalGroup>
+      </Stack>
       <Modal.ButtonRow>
         <Button onClick={onDismiss} fill="outline" variant="secondary">
           Cancel


### PR DESCRIPTION
**What is this feature?**

Replaces deprecated `HorizontalGroup` and `VerticalGroup` components with `Stack.` I've tested all affected components, and everything looks good:

 **CorrelationFormNavigation**
<img width="813" alt="Screenshot 2024-04-26 at 11 05 55 AM" src="https://github.com/grafana/grafana/assets/58232930/1f2c9af5-fdc6-41c6-bce1-e50b01d1d37a">

**CorrelationEditorModeBar**
<img width="420" alt="Screenshot 2024-04-26 at 11 05 07 AM" src="https://github.com/grafana/grafana/assets/58232930/cb60925b-efc3-4a7f-82fe-9c7cc17dadf6">

**ConfirmNavigationModal**
<img width="1508" alt="Screenshot 2024-04-26 at 11 04 46 AM" src="https://github.com/grafana/grafana/assets/58232930/3121658d-4378-44bd-8a17-0615b48cb6bb">


**Which issue(s) does this PR fix?**:

Fixes: #86839 

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
