### PR TITLE
DashboardDataSourceBehaviour: Handle loading library panel

### DIFF
--- a/public/app/features/dashboard-scene/scene/DashboardDatasourceBehaviour.test.tsx
+++ b/public/app/features/dashboard-scene/scene/DashboardDatasourceBehaviour.test.tsx
@@ -545,8 +545,6 @@ describe('DashboardDatasourceBehaviour', () => {
 
       activateFullSceneTree(scene);
 
-      await new Promise((r) => setTimeout(r, 1));
-
       // spy on runQueries
       const spy = jest.spyOn(dashboardDSPanel.state.$data as SceneQueryRunner, 'runQueries');
 
@@ -556,6 +554,7 @@ describe('DashboardDatasourceBehaviour', () => {
 
       // Simulate library panel being loaded
       sourcePanel.setState({
+        isLoaded: true,
         panel: new VizPanel({
           title: 'Panel A',
           pluginId: 'table',
@@ -566,8 +565,6 @@ describe('DashboardDatasourceBehaviour', () => {
           }),
         }),
       });
-
-      await new Promise((r) => setTimeout(r, 1));
 
       expect(spy).toHaveBeenCalledTimes(1);
     });

--- a/public/app/features/dashboard-scene/scene/DashboardDatasourceBehaviour.test.tsx
+++ b/public/app/features/dashboard-scene/scene/DashboardDatasourceBehaviour.test.tsx
@@ -21,6 +21,7 @@ import { activateFullSceneTree } from '../utils/test-utils';
 import { DashboardDatasourceBehaviour } from './DashboardDatasourceBehaviour';
 import { DashboardGridItem } from './DashboardGridItem';
 import { DashboardScene } from './DashboardScene';
+import { LibraryVizPanel } from './LibraryVizPanel';
 
 const grafanaDs = {
   id: 1,
@@ -485,6 +486,90 @@ describe('DashboardDatasourceBehaviour', () => {
       } catch (e) {
         expect(e).toEqual(new Error('Could not find SceneQueryRunner for panel'));
       }
+    });
+  });
+
+  describe('Library panels', () => {
+    it('should wait for library panel to be loaded', async () => {
+      const sourcePanel = new LibraryVizPanel({
+        name: 'My Library Panel',
+        title: 'Panel title',
+        uid: 'fdcvggvfy2qdca',
+        panelKey: 'lib-panel',
+        panel: new VizPanel({
+          key: 'panel-1',
+          title: 'Panel A',
+          pluginId: 'table',
+        }),
+      });
+
+      // query references inexistent panel
+      const dashboardDSPanel = new VizPanel({
+        title: 'Panel B',
+        pluginId: 'table',
+        key: 'panel-2',
+        $data: new SceneQueryRunner({
+          datasource: { uid: SHARED_DASHBOARD_QUERY },
+          queries: [{ refId: 'A', panelId: 1 }],
+          $behaviors: [new DashboardDatasourceBehaviour({})],
+        }),
+      });
+
+      const scene = new DashboardScene({
+        title: 'hello',
+        uid: 'dash-1',
+        meta: {
+          canEdit: true,
+        },
+        body: new SceneGridLayout({
+          children: [
+            new DashboardGridItem({
+              key: 'griditem-1',
+              x: 0,
+              y: 0,
+              width: 10,
+              height: 12,
+              body: sourcePanel,
+            }),
+            new DashboardGridItem({
+              key: 'griditem-2',
+              x: 0,
+              y: 0,
+              width: 10,
+              height: 12,
+              body: dashboardDSPanel,
+            }),
+          ],
+        }),
+      });
+
+      activateFullSceneTree(scene);
+
+      await new Promise((r) => setTimeout(r, 1));
+
+      // spy on runQueries
+      const spy = jest.spyOn(dashboardDSPanel.state.$data as SceneQueryRunner, 'runQueries');
+
+      await new Promise((r) => setTimeout(r, 1));
+
+      expect(spy).not.toHaveBeenCalled();
+
+      // Simulate library panel being loaded
+      sourcePanel.setState({
+        panel: new VizPanel({
+          title: 'Panel A',
+          pluginId: 'table',
+          key: 'panel-1',
+          $data: new SceneQueryRunner({
+            datasource: { uid: 'grafana' },
+            queries: [{ refId: 'A', queryType: 'randomWalk' }],
+          }),
+        }),
+      });
+
+      await new Promise((r) => setTimeout(r, 1));
+
+      expect(spy).toHaveBeenCalledTimes(1);
     });
   });
 });

--- a/public/app/features/dashboard-scene/scene/LibraryVizPanel.tsx
+++ b/public/app/features/dashboard-scene/scene/LibraryVizPanel.tsx
@@ -19,7 +19,7 @@ import { VizPanelLinks, VizPanelLinksMenu } from './PanelLinks';
 import { panelLinksBehavior, panelMenuBehavior } from './PanelMenuBehavior';
 import { PanelNotices } from './PanelNotices';
 
-interface LibraryVizPanelState extends SceneObjectState {
+export interface LibraryVizPanelState extends SceneObjectState {
   // Library panels use title from dashboard JSON's panel model, not from library panel definition, hence we pass it.
   title: string;
   uid: string;
@@ -83,7 +83,7 @@ export class LibraryVizPanel extends SceneObjectBase<LibraryVizPanelState> {
 
   private async loadLibraryPanelFromPanelModel() {
     let vizPanel = this.state.panel!;
-
+    await new Promise((f) => setTimeout(f, 1000));
     try {
       const libPanel = await getLibraryPanel(this.state.uid, true);
       this.setPanelFromLibPanel(libPanel);

--- a/public/app/features/dashboard-scene/scene/LibraryVizPanel.tsx
+++ b/public/app/features/dashboard-scene/scene/LibraryVizPanel.tsx
@@ -83,7 +83,7 @@ export class LibraryVizPanel extends SceneObjectBase<LibraryVizPanelState> {
 
   private async loadLibraryPanelFromPanelModel() {
     let vizPanel = this.state.panel!;
-    await new Promise((f) => setTimeout(f, 1000));
+
     try {
       const libPanel = await getLibraryPanel(this.state.uid, true);
       this.setPanelFromLibPanel(libPanel);


### PR DESCRIPTION
Fixes  #86966

https://raintank-corp.slack.com/archives/C03MCTKAJA0/p1714062157912579

The problem was that LibraryVizPanel loads source panel asynchroniously and can only set internal VizPanel's SceneQueryRunner when the panel is resolved. The behavior did not account for that throwing early as it couldn't find the corresponding query runner that indicates readiness for dashboard query execution.