### PR TITLE
gRPC Server: Make message size limits configurable.

### DIFF
--- a/conf/defaults.ini
+++ b/conf/defaults.ini
@@ -107,6 +107,12 @@ key_file =
 # this will log the request and response for each unary gRPC call
 enable_logging = false
 
+# Maximum size of a message that can be received. If not set, uses the gRPC default (4MiB).
+max_recv_msg_size =
+
+# Maximum size of a message that can be sent. If not set, uses the gRPC default (unlimited).
+max_send_msg_size =
+
 #################################### Database ############################
 [database]
 # You can configure the database connection by specifying type, host, name, user and password

--- a/conf/defaults.ini
+++ b/conf/defaults.ini
@@ -107,10 +107,10 @@ key_file =
 # this will log the request and response for each unary gRPC call
 enable_logging = false
 
-# Maximum size of a message that can be received. If not set, uses the gRPC default (4MiB).
+# Maximum size of a message that can be received in bytes. If not set, uses the gRPC default (4MiB).
 max_recv_msg_size =
 
-# Maximum size of a message that can be sent. If not set, uses the gRPC default (unlimited).
+# Maximum size of a message that can be sent in bytes. If not set, uses the gRPC default (unlimited).
 max_send_msg_size =
 
 #################################### Database ############################

--- a/conf/sample.ini
+++ b/conf/sample.ini
@@ -101,6 +101,8 @@
 ;use_tls = false
 ;cert_file =
 ;key_file =
+;max_recv_msg_size =
+;max_send_msg_size =
 
 #################################### Database ####################################
 [database]

--- a/pkg/services/grpcserver/service.go
+++ b/pkg/services/grpcserver/service.go
@@ -62,7 +62,10 @@ func ProvideService(cfg *setting.Cfg, features featuremgmt.FeatureToggles, authe
 		}
 	}
 
-	var opts []grpc.ServerOption
+	opts := []grpc.ServerOption{
+		grpc.MaxRecvMsgSize(s.cfg.GRPCServerMaxRecvMsgSize),
+		grpc.MaxSendMsgSize(s.cfg.GRPCServerMaxSendMsgSize),
+	}
 
 	// Default auth is admin token check, but this can be overridden by
 	// services which implement ServiceAuthFuncOverride interface.
@@ -85,12 +88,20 @@ func ProvideService(cfg *setting.Cfg, features featuremgmt.FeatureToggles, authe
 		opts = append(opts, grpc.Creds(credentials.NewTLS(cfg.GRPCServerTLSConfig)))
 	}
 
+	if s.cfg.GRPCServerMaxRecvMsgSize > 0 {
+		opts = append(opts, grpc.MaxRecvMsgSize(s.cfg.GRPCServerMaxRecvMsgSize))
+	}
+
+	if s.cfg.GRPCServerMaxSendMsgSize > 0 {
+		opts = append(opts, grpc.MaxSendMsgSize(s.cfg.GRPCServerMaxSendMsgSize))
+	}
+
 	s.server = grpc.NewServer(opts...)
 	return s, nil
 }
 
 func (s *gPRCServerService) Run(ctx context.Context) error {
-	s.logger.Info("Running GRPC server", "address", s.cfg.GRPCServerAddress, "network", s.cfg.GRPCServerNetwork, "tls", s.cfg.GRPCServerTLSConfig != nil)
+	s.logger.Info("Running GRPC server", "address", s.cfg.GRPCServerAddress, "network", s.cfg.GRPCServerNetwork, "tls", s.cfg.GRPCServerTLSConfig != nil, "max_recv_msg_size", s.cfg.GRPCServerMaxRecvMsgSize, "max_send_msg_size", s.cfg.GRPCServerMaxSendMsgSize)
 
 	listener, err := net.Listen(s.cfg.GRPCServerNetwork, s.cfg.GRPCServerAddress)
 	if err != nil {

--- a/pkg/services/grpcserver/service.go
+++ b/pkg/services/grpcserver/service.go
@@ -62,10 +62,7 @@ func ProvideService(cfg *setting.Cfg, features featuremgmt.FeatureToggles, authe
 		}
 	}
 
-	opts := []grpc.ServerOption{
-		grpc.MaxRecvMsgSize(s.cfg.GRPCServerMaxRecvMsgSize),
-		grpc.MaxSendMsgSize(s.cfg.GRPCServerMaxSendMsgSize),
-	}
+	var opts []grpc.ServerOption
 
 	// Default auth is admin token check, but this can be overridden by
 	// services which implement ServiceAuthFuncOverride interface.

--- a/pkg/setting/setting.go
+++ b/pkg/setting/setting.go
@@ -470,10 +470,12 @@ type Cfg struct {
 	RBACSingleOrganization bool
 
 	// GRPC Server.
-	GRPCServerNetwork       string
-	GRPCServerAddress       string
-	GRPCServerTLSConfig     *tls.Config
-	GRPCServerEnableLogging bool // log request and response of each unary gRPC call
+	GRPCServerNetwork        string
+	GRPCServerAddress        string
+	GRPCServerTLSConfig      *tls.Config
+	GRPCServerEnableLogging  bool // log request and response of each unary gRPC call
+	GRPCServerMaxRecvMsgSize int
+	GRPCServerMaxSendMsgSize int
 
 	CustomResponseHeaders map[string]string
 
@@ -1769,6 +1771,8 @@ func readGRPCServerSettings(cfg *Cfg, iniFile *ini.File) error {
 	cfg.GRPCServerNetwork = valueAsString(server, "network", "tcp")
 	cfg.GRPCServerAddress = valueAsString(server, "address", "")
 	cfg.GRPCServerEnableLogging = server.Key("enable_logging").MustBool(false)
+	cfg.GRPCServerMaxRecvMsgSize = server.Key("max_recv_msg_size").MustInt(0)
+	cfg.GRPCServerMaxSendMsgSize = server.Key("max_send_msg_size").MustInt(0)
 	switch cfg.GRPCServerNetwork {
 	case "unix":
 		if cfg.GRPCServerAddress != "" {


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**
Adds two new configuration options for the gRPC server to configure message size limits:
- `max_recv_msg_size`
- `max_send_msg_size`

The options are just passed through to the gRPC server as options.

**Why do we need this feature?**
These options are important for limiting memory use by gRPC, but the default for receive is often low. Being able to change these limits is crucial.

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
