### PR TITLE
Scenes: support interpolations in TemplateSrv.replace

### DIFF
--- a/package.json
+++ b/package.json
@@ -252,7 +252,7 @@
     "@grafana/prometheus": "workspace:*",
     "@grafana/runtime": "workspace:*",
     "@grafana/saga-icons": "workspace:*",
-    "@grafana/scenes": "^4.12.0",
+    "@grafana/scenes": "^4.13.0",
     "@grafana/schema": "workspace:*",
     "@grafana/sql": "workspace:*",
     "@grafana/ui": "workspace:*",

--- a/public/app/features/templating/template_srv.ts
+++ b/public/app/features/templating/template_srv.ts
@@ -253,7 +253,8 @@ export class TemplateSrv implements BaseTemplateSrv {
         scopedVars.__sceneObject.value,
         target,
         scopedVars,
-        format as string | VariableCustomFormatterFn | undefined
+        format as string | VariableCustomFormatterFn | undefined,
+        interpolations
       );
     }
 
@@ -263,7 +264,8 @@ export class TemplateSrv implements BaseTemplateSrv {
         window.__grafanaSceneContext,
         target,
         scopedVars,
-        format as string | VariableCustomFormatterFn | undefined
+        format as string | VariableCustomFormatterFn | undefined,
+        interpolations
       );
     }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3796,9 +3796,9 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@grafana/scenes@npm:^4.12.0":
-  version: 4.12.0
-  resolution: "@grafana/scenes@npm:4.12.0"
+"@grafana/scenes@npm:^4.13.0":
+  version: 4.13.0
+  resolution: "@grafana/scenes@npm:4.13.0"
   dependencies:
     "@grafana/e2e-selectors": "npm:10.3.3"
     react-grid-layout: "npm:1.3.4"
@@ -3812,7 +3812,7 @@ __metadata:
     "@grafana/ui": ^10.0.3
     react: ^18.0.0
     react-dom: ^18.0.0
-  checksum: 10/d59564176f432e947d88e1c25dc901dd424aa61b4a0fa91b5f30704ec1da698b0c67b3c0a79caf112df83a0b84b583a8732d157a7eec87cd43cdbb4949007d3f
+  checksum: 10/2785516164ff557b325b7425861f2aee895656ae635d9e9e6b9c882229f75ea19fa0f9402d4e827efcc46103918aa130f236ec850913e56dadc06f1ffeefb1f9
   languageName: node
   linkType: hard
 
@@ -17879,7 +17879,7 @@ __metadata:
     "@grafana/prometheus": "workspace:*"
     "@grafana/runtime": "workspace:*"
     "@grafana/saga-icons": "workspace:*"
-    "@grafana/scenes": "npm:^4.12.0"
+    "@grafana/scenes": "npm:^4.13.0"
     "@grafana/schema": "workspace:*"
     "@grafana/sql": "workspace:*"
     "@grafana/tsconfig": "npm:^1.3.0-rc1"


### PR DESCRIPTION
**What is this feature?**

TemplateSrv.replace takes an optional 'interpolations' argument which records information about the variables which were found during the interpolation. Until [this Scenes PR][scenes PR] this wasn't supported by Scenes so the interpolations argument was being ignored if dashboard scenes were enabled. This commit bumps the scenes version and passes the interpolations array along to the scenes function.

[scenes PR]: https://github.com/grafana/scenes/pull/708

**Why do we need this feature?**

So that scenes users (soon: everyone) can have feature parity with non-scenes users.

**Who is this feature for?**

Grafana or plugin developers using the template service.

**Which issue(s) does this PR fix?**:

N/A

**Special notes for your reviewer:**

[Relevant Slack thread](https://raintank-corp.slack.com/archives/C03KVDHTWAH/p1714129700937469).

Please check that:
- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
