### PR TITLE
Dashboard scenes: Don't return null when uids are not matching for new dashboards

### DIFF
--- a/public/app/features/dashboard/containers/DashboardPageProxy.tsx
+++ b/public/app/features/dashboard/containers/DashboardPageProxy.tsx
@@ -54,7 +54,7 @@ function DashboardPageProxy(props: DashboardPageProxyProps) {
     return null;
   }
 
-  if (dashboard?.value?.dashboard?.uid !== props.match.params.uid) {
+  if (dashboard?.value?.dashboard?.uid !== props.match.params.uid && dashboard.value?.meta?.isNew !== true) {
     return null;
   }
 


### PR DESCRIPTION

**What is this feature?**
When creating a new dashboard we don't have UIDs to compare, so let's not compare uids when creating new dashboards.