### PR TITLE
Prometheus: Add hints for native histograms

### DIFF
--- a/packages/grafana-prometheus/src/datasource.ts
+++ b/packages/grafana-prometheus/src/datasource.ts
@@ -740,6 +740,30 @@ export class PrometheusDatasource
         expression = `histogram_quantile(0.95, sum(rate(${expression}[$__rate_interval])) by (le))`;
         break;
       }
+      case 'ADD_HISTOGRAM_AVG': {
+        expression = `histogram_avg(rate(${expression}[$__rate_interval]))`;
+        break;
+      }
+      case 'ADD_HISTOGRAM_FRACTION': {
+        expression = `histogram_fraction(0,0.2,rate(${expression}[$__rate_interval]))`;
+        break;
+      }
+      case 'ADD_HISTOGRAM_COUNT': {
+        expression = `histogram_count(rate(${expression}[$__rate_interval]))`;
+        break;
+      }
+      case 'ADD_HISTOGRAM_SUM': {
+        expression = `histogram_sum(rate(${expression}[$__rate_interval]))`;
+        break;
+      }
+      case 'ADD_HISTOGRAM_STDDEV': {
+        expression = `histogram_stddev(rate(${expression}[$__rate_interval]))`;
+        break;
+      }
+      case 'ADD_HISTOGRAM_STDVAR': {
+        expression = `histogram_stdvar(rate(${expression}[$__rate_interval]))`;
+        break;
+      }
       case 'ADD_RATE': {
         expression = `rate(${expression}[$__rate_interval])`;
         break;

--- a/packages/grafana-prometheus/src/query_hints.test.ts
+++ b/packages/grafana-prometheus/src/query_hints.test.ts
@@ -212,4 +212,21 @@ describe('getQueryHints()', () => {
     expect(JSON.stringify(hints)).toContain('ADD_HISTOGRAM_FRACTION');
     expect(JSON.stringify(hints)).toContain('ADD_HISTOGRAM_AVG');
   });
+
+  it('returns no hints for native histogram when there are native histogram functions in the query', () => {
+    const queryWithNativeHistogramFunction = 'histogram_avg(foo)';
+    const series = [
+      {
+        datapoints: [
+          [23, 1000],
+          [24, 1001],
+        ],
+      },
+    ];
+    const mock: unknown = { languageProvider: { metricsMetadata: { foo: { type: 'histogram' } } } };
+    const datasource = mock as PrometheusDatasource;
+
+    let hints = getQueryHints(queryWithNativeHistogramFunction, series, datasource);
+    expect(hints!.length).toBe(0);
+  });
 });

--- a/packages/grafana-prometheus/src/query_hints.test.ts
+++ b/packages/grafana-prometheus/src/query_hints.test.ts
@@ -190,4 +190,26 @@ describe('getQueryHints()', () => {
     hints = getQueryHints('container_cpu_usage_seconds_total:irate_total', series);
     expect(hints!.length).toBe(0);
   });
+
+  // native histograms
+  it('returns hints for native histogram by metric type without suffix "_bucket"', () => {
+    const series = [
+      {
+        datapoints: [
+          [23, 1000],
+          [24, 1001],
+        ],
+      },
+    ];
+    const mock: unknown = { languageProvider: { metricsMetadata: { foo: { type: 'histogram' } } } };
+    const datasource = mock as PrometheusDatasource;
+
+    let hints = getQueryHints('foo', series, datasource);
+    expect(hints!.length).toBe(6);
+    expect(JSON.stringify(hints)).toContain('ADD_HISTOGRAM_AVG');
+    expect(JSON.stringify(hints)).toContain('ADD_HISTOGRAM_COUNT');
+    expect(JSON.stringify(hints)).toContain('ADD_HISTOGRAM_SUM');
+    expect(JSON.stringify(hints)).toContain('ADD_HISTOGRAM_FRACTION');
+    expect(JSON.stringify(hints)).toContain('ADD_HISTOGRAM_AVG');
+  });
 });

--- a/packages/grafana-prometheus/src/query_hints.test.ts
+++ b/packages/grafana-prometheus/src/query_hints.test.ts
@@ -206,11 +206,12 @@ describe('getQueryHints()', () => {
 
     let hints = getQueryHints('foo', series, datasource);
     expect(hints!.length).toBe(6);
-    expect(JSON.stringify(hints)).toContain('ADD_HISTOGRAM_AVG');
-    expect(JSON.stringify(hints)).toContain('ADD_HISTOGRAM_COUNT');
-    expect(JSON.stringify(hints)).toContain('ADD_HISTOGRAM_SUM');
-    expect(JSON.stringify(hints)).toContain('ADD_HISTOGRAM_FRACTION');
-    expect(JSON.stringify(hints)).toContain('ADD_HISTOGRAM_AVG');
+    const hintsString = JSON.stringify(hints);
+    expect(hintsString).toContain('ADD_HISTOGRAM_AVG');
+    expect(hintsString).toContain('ADD_HISTOGRAM_COUNT');
+    expect(hintsString).toContain('ADD_HISTOGRAM_SUM');
+    expect(hintsString).toContain('ADD_HISTOGRAM_FRACTION');
+    expect(hintsString).toContain('ADD_HISTOGRAM_AVG');
   });
 
   it('returns no hints for native histogram when there are native histogram functions in the query', () => {

--- a/packages/grafana-prometheus/src/querybuilder/shared/QueryBuilderHints.tsx
+++ b/packages/grafana-prometheus/src/querybuilder/shared/QueryBuilderHints.tsx
@@ -78,8 +78,7 @@ QueryBuilderHints.displayName = 'QueryBuilderHints';
 const getStyles = (theme: GrafanaTheme2) => {
   return {
     container: css({
-      display: 'flex',
-      alignItems: 'start',
+      display: 'inlineGrid',
     }),
     hint: css({
       marginRight: theme.spacing(1),

--- a/packages/grafana-prometheus/src/querybuilder/shared/QueryBuilderHints.tsx
+++ b/packages/grafana-prometheus/src/querybuilder/shared/QueryBuilderHints.tsx
@@ -78,7 +78,8 @@ QueryBuilderHints.displayName = 'QueryBuilderHints';
 const getStyles = (theme: GrafanaTheme2) => {
   return {
     container: css({
-      display: 'inlineGrid',
+      display: 'flex',
+      alignItems: 'start',
     }),
     hint: css({
       marginRight: theme.spacing(1),


### PR DESCRIPTION
Fixes https://github.com/grafana/grafana/issues/86388

**What is this feature?**

When a user selects a native histogram, a hint or hints should be provided indicating they have selected a native histogram and providing functions for that metric.

This PR provides hints that allow a user to add 6 functions to the query builder from a native histogram hint

```
histogram_avg(rate(${expression}[$__rate_interval]))
histogram_fraction(0,0.2,rate(${expression}[$__rate_interval]))
histogram_count(rate(${expression}[$__rate_interval]))
histogram_sum(rate(${expression}[$__rate_interval]))
histogram_stddev(rate(${expression}[$__rate_interval]))
histogram_stdvar(rate(${expression}[$__rate_interval]))
```


https://github.com/grafana/grafana/assets/25674746/264ab038-132b-4598-881e-5ae869c07512



The code editor can only show one hint at a time so until we refactor that, we show that the metric is a native histogram and provide the hint to use histogram_avg with the rate function.

<img width="775" alt="Screenshot 2024-04-28 at 9 01 34 PM" src="https://github.com/grafana/grafana/assets/25674746/f21d4c9e-289f-4a19-a6f2-750fff88043d">


Fixes https://github.com/grafana/grafana/issues/86388

**Why do we need this feature?**

Native histograms are being released in Mimir in the next month and this is part of the [GA strategy](https://github.com/grafana/observability-metrics-squad/issues/142).

**Who is this feature for?**

For users who have enabled native histograms.

**Special notes for your reviewer:**

TESTING!!!!!!

1. Use this [repository](https://github.com/laupse/prometheus-native-histograms) which creates native histograms BUT MAKE SURE YOU UPDATE THE FOLLOWING
  - use Prometheus version 2.51.0 int he docker compose file or you won't be able to test all the functions

```
services:
  prometheus:
    image: prom/prometheus:v2.51.0
```
  - update the docker compose Grafana image to use the tag v11.1.0-69868 or later you will have a bad time because you'll need the new parser if you switch between query builder and code editor. 
  - If you don't want to update the grafana image just run Grafana locally with main and create a data source from the prometheus-native-histogram prometheus datasource or add this datasource yaml file.

```
# config file version
apiVersion: 1

# list of datasources to insert/update depending
# what's available in the database
datasources:
  # <string, required> name of the datasource. Required
  - name: Prometheus-native-histogram
    # <string, required> datasource type. Required
    type: prometheus
    # <string, required> access mode. proxy or direct (Server or Browser in the UI). Required
    access: proxy
    # <int> org id. will default to orgId 1 if not specified
    orgId: 1
    # <string> custom UID which can be used to reference this datasource in other parts of the configuration, if not specified will be generated automatically
    uid: prometheus
    # <string> url
    url: http://prometheus:9090
```

2. Now you should have a data source that has a native histogram. The native histogram is named `rpc_durations_native_histogram_seconds`.

3. When you select this in the query builder you will get six query hints (6 functions).
4. When you select this metric in the code editor you will get one hint because the code editor only displays one hint. We need to fix that or create an issue to fix this.


Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
