### PR TITLE
Alerting: Pass logger into NewRemoteLokiBackend.

### DIFF
--- a/pkg/services/ngalert/ngalert.go
+++ b/pkg/services/ngalert/ngalert.go
@@ -480,7 +480,8 @@ func configureHistorianBackend(ctx context.Context, cfg setting.UnifiedAlertingS
 			return nil, fmt.Errorf("invalid remote loki configuration: %w", err)
 		}
 		req := historian.NewRequester()
-		backend := historian.NewRemoteLokiBackend(lcfg, req, met)
+		lokiBackendLogger := log.New("ngalert.state.historian", "backend", "loki")
+		backend := historian.NewRemoteLokiBackend(lokiBackendLogger, lcfg, req, met)
 
 		testConnCtx, cancelFunc := context.WithTimeout(ctx, 10*time.Second)
 		defer cancelFunc()

--- a/pkg/services/ngalert/state/historian/loki.go
+++ b/pkg/services/ngalert/state/historian/loki.go
@@ -55,8 +55,7 @@ type RemoteLokiBackend struct {
 	log            log.Logger
 }
 
-func NewRemoteLokiBackend(cfg LokiConfig, req client.Requester, metrics *metrics.Historian) *RemoteLokiBackend {
-	logger := log.New("ngalert.state.historian", "backend", "loki")
+func NewRemoteLokiBackend(logger log.Logger, cfg LokiConfig, req client.Requester, metrics *metrics.Historian) *RemoteLokiBackend {
 	return &RemoteLokiBackend{
 		client:         NewLokiClient(cfg, req, metrics, logger),
 		externalLabels: cfg.ExternalLabels,

--- a/pkg/services/ngalert/state/historian/loki_test.go
+++ b/pkg/services/ngalert/state/historian/loki_test.go
@@ -513,7 +513,8 @@ func createTestLokiBackend(req client.Requester, met *metrics.Historian) *Remote
 		Encoder:        JsonEncoder{},
 		ExternalLabels: map[string]string{"externalLabelKey": "externalLabelValue"},
 	}
-	return NewRemoteLokiBackend(cfg, req, met)
+	lokiBackendLogger := log.New("ngalert.state.historian", "backend", "loki")
+	return NewRemoteLokiBackend(lokiBackendLogger, cfg, req, met)
 }
 
 func singleFromNormal(st *state.State) []state.StateTransition {


### PR DESCRIPTION
Tiny refactor to allow a logger to be passed into NewRemoteLokiBackend.
