### PR TITLE
Update swagger spec

### DIFF
--- a/public/api-merged.json
+++ b/public/api-merged.json
@@ -12645,7 +12645,7 @@
           }
         },
         "Policies": {
-          "description": "Policies contains all policy identifiers included in the certificate.\nIn Go 1.22, encoding/gob cannot handle and ignores this field.",
+          "description": "Policies contains all policy identifiers included in the certificate.",
           "type": "array",
           "items": {
             "$ref": "#/definitions/OID"

--- a/public/openapi3.json
+++ b/public/openapi3.json
@@ -3416,7 +3416,7 @@
             "type": "array"
           },
           "Policies": {
-            "description": "Policies contains all policy identifiers included in the certificate.\nIn Go 1.22, encoding/gob cannot handle and ignores this field.",
+            "description": "Policies contains all policy identifiers included in the certificate.",
             "items": {
               "$ref": "#/components/schemas/OID"
             },


### PR DESCRIPTION
**What is this feature?**

Several PRs are failing to `swagger-gen` build step, this PR updates the swagger spec after running

`make swagger-clean && make openapi3-gen` with go `v1.22.x`