### PR TITLE
Chore: Remove extra sql select from the Insert function of userimpl.store

### DIFF
--- a/pkg/services/user/userimpl/store.go
+++ b/pkg/services/user/userimpl/store.go
@@ -75,11 +75,6 @@ func (ss *sqlStore) Insert(ctx context.Context, cmd *user.User) (int64, error) {
 		return 0, err
 	}
 
-	// verify that user was created and cmd.ID was updated with the actual new userID
-	_, err = ss.getAnyUserType(ctx, cmd.ID)
-	if err != nil {
-		return 0, err
-	}
 	return cmd.ID, nil
 }
 
@@ -586,22 +581,6 @@ func (ss *sqlStore) Search(ctx context.Context, query *user.SearchUsersQuery) (*
 		return err
 	})
 	return &result, err
-}
-
-// getAnyUserType searches for a user record by ID. The user account may be a service account.
-func (ss *sqlStore) getAnyUserType(ctx context.Context, userID int64) (*user.User, error) {
-	usr := user.User{ID: userID}
-	err := ss.db.WithDbSession(ctx, func(sess *db.Session) error {
-		has, err := sess.Get(&usr)
-		if err != nil {
-			return err
-		}
-		if !has {
-			return user.ErrUserNotFound
-		}
-		return nil
-	})
-	return &usr, err
 }
 
 func setOptional[T any](v *T, add func(v T)) {


### PR DESCRIPTION
**What is this feature?**
This PR removes the extra sql `select` from after the tx in the Insert function of the user store.

**Why do we need this feature?**
The `getAnyUserType` seems to be unnecessary, because `cmd.ID` is set from within the transaction. Besides, in load-balanced scenarios the sql `select` can be routed to a replica that doesn't have the latest data from the primary which causes the `Insert` function to error out.

**Who is this feature for?**

[Add information on what kind of user the feature is for.]

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
