### PR TITLE
Alerting: Use expected field name for receiver in HCL export

### DIFF
--- a/pkg/services/ngalert/api/api_provisioning_test.go
+++ b/pkg/services/ngalert/api/api_provisioning_test.go
@@ -694,7 +694,7 @@ func TestProvisioningApi(t *testing.T) {
     is_paused      = false
 
     notification_settings {
-      receiver            = "Test-Receiver"
+      contact_point       = "Test-Receiver"
       group_by            = ["alertname", "grafana_folder", "test"]
       group_wait          = "1s"
       group_interval      = "5s"

--- a/pkg/services/ngalert/api/test-data/post-rulegroup-101-export.hcl
+++ b/pkg/services/ngalert/api/test-data/post-rulegroup-101-export.hcl
@@ -79,7 +79,7 @@ resource "grafana_rule_group" "rule_group_0000" {
     is_paused      = false
 
     notification_settings {
-      receiver            = "Test-Receiver"
+      contact_point       = "Test-Receiver"
       group_by            = ["alertname", "grafana_folder", "test"]
       group_wait          = "1s"
       group_interval      = "5s"

--- a/pkg/services/ngalert/api/tooling/definitions/provisioning_alert_rules.go
+++ b/pkg/services/ngalert/api/tooling/definitions/provisioning_alert_rules.go
@@ -292,7 +292,7 @@ type RelativeTimeRangeExport struct {
 
 // AlertRuleNotificationSettingsExport is the provisioned export of models.NotificationSettings.
 type AlertRuleNotificationSettingsExport struct {
-	Receiver string `yaml:"receiver,omitempty" json:"receiver,omitempty" hcl:"receiver"`
+	Receiver string `yaml:"receiver,omitempty" json:"receiver,omitempty" hcl:"contact_point"`
 
 	GroupBy           []string `yaml:"group_by,omitempty" json:"group_by,omitempty" hcl:"group_by"`
 	GroupWait         *string  `yaml:"group_wait,omitempty" json:"group_wait,omitempty" hcl:"group_wait,optional"`

--- a/pkg/services/ngalert/api/tooling/definitions/provisioning_alert_rules.go
+++ b/pkg/services/ngalert/api/tooling/definitions/provisioning_alert_rules.go
@@ -292,6 +292,7 @@ type RelativeTimeRangeExport struct {
 
 // AlertRuleNotificationSettingsExport is the provisioned export of models.NotificationSettings.
 type AlertRuleNotificationSettingsExport struct {
+	// Terraform provider uses `contact_point`, so export the field with that name in HCL.
 	Receiver string `yaml:"receiver,omitempty" json:"receiver,omitempty" hcl:"contact_point"`
 
 	GroupBy           []string `yaml:"group_by,omitempty" json:"group_by,omitempty" hcl:"group_by"`


### PR DESCRIPTION
**What is this feature?**

This PR corrects a field name mismatch between Grafana Alerting HCL export and the Terraform provider's accepted model (see [here](https://registry.terraform.io/providers/grafana/grafana/latest/docs/resources/rule_group#nested-schema-for-rulenotification_settings) for definition).

**Why do we need this feature?**

Fix HCL export of rules using simplified routing.

**Which issue(s) does this PR fix?**:

Fixes #87064

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
