### PR TITLE
datatrails: only fetch metrics metadata when using the language provider, avoid redundant fetch of metric names

### DIFF
--- a/public/app/features/trails/helpers/MetricDatasourceHelper.ts
+++ b/public/app/features/trails/helpers/MetricDatasourceHelper.ts
@@ -1,7 +1,7 @@
 import { DataSourceApi } from '@grafana/data';
 import { PromMetricsMetadata, PromMetricsMetadataItem } from '@grafana/prometheus';
 import PromQlLanguageProvider from '@grafana/prometheus/src/language_provider';
-import { getDataSourceSrv } from '@grafana/runtime';
+import { getBackendSrv, getDataSourceSrv } from '@grafana/runtime';
 
 import { DataTrail } from '../DataTrail';
 import { VAR_DATASOURCE_EXPR } from '../shared';
@@ -36,7 +36,7 @@ export class MetricDatasourceHelper {
 
     if (ds.languageProvider instanceof PromQlLanguageProvider) {
       if (!ds.languageProvider.metricsMetadata) {
-        await ds.languageProvider.start();
+        await ds.languageProvider.loadMetricsMetadata();
       }
 
       return ds.languageProvider.metricsMetadata!;

--- a/public/app/features/trails/helpers/MetricDatasourceHelper.ts
+++ b/public/app/features/trails/helpers/MetricDatasourceHelper.ts
@@ -1,7 +1,7 @@
 import { DataSourceApi } from '@grafana/data';
 import { PromMetricsMetadata, PromMetricsMetadataItem } from '@grafana/prometheus';
 import PromQlLanguageProvider from '@grafana/prometheus/src/language_provider';
-import { getBackendSrv, getDataSourceSrv } from '@grafana/runtime';
+import { getDataSourceSrv } from '@grafana/runtime';
 
 import { DataTrail } from '../DataTrail';
 import { VAR_DATASOURCE_EXPR } from '../shared';


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

Previously, we called `start` on the language provider which also fetched an additional list of metric names.
This is redundant, since we already have a mechanism for that fetch.
Here, we only load the metadata, by using `loadMetricsMetadata` instead.


**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
