### PR TITLE
Alerting: Also fix HCL field name for MuteTimeIntervals

### DIFF
--- a/pkg/services/ngalert/api/api_provisioning_test.go
+++ b/pkg/services/ngalert/api/api_provisioning_test.go
@@ -694,12 +694,12 @@ func TestProvisioningApi(t *testing.T) {
     is_paused      = false
 
     notification_settings {
-      contact_point       = "Test-Receiver"
-      group_by            = ["alertname", "grafana_folder", "test"]
-      group_wait          = "1s"
-      group_interval      = "5s"
-      repeat_interval     = "5m"
-      mute_time_intervals = ["test-mute"]
+      contact_point   = "Test-Receiver"
+      group_by        = ["alertname", "grafana_folder", "test"]
+      group_wait      = "1s"
+      group_interval  = "5s"
+      repeat_interval = "5m"
+      mute_timings    = ["test-mute"]
     }
   }
 }

--- a/pkg/services/ngalert/api/test-data/post-rulegroup-101-export.hcl
+++ b/pkg/services/ngalert/api/test-data/post-rulegroup-101-export.hcl
@@ -79,12 +79,12 @@ resource "grafana_rule_group" "rule_group_0000" {
     is_paused      = false
 
     notification_settings {
-      contact_point       = "Test-Receiver"
-      group_by            = ["alertname", "grafana_folder", "test"]
-      group_wait          = "1s"
-      group_interval      = "5s"
-      repeat_interval     = "5m"
-      mute_time_intervals = ["test-mute"]
+      contact_point   = "Test-Receiver"
+      group_by        = ["alertname", "grafana_folder", "test"]
+      group_wait      = "1s"
+      group_interval  = "5s"
+      repeat_interval = "5m"
+      mute_timings    = ["test-mute"]
     }
   }
 }

--- a/pkg/services/ngalert/api/tooling/definitions/provisioning_alert_rules.go
+++ b/pkg/services/ngalert/api/tooling/definitions/provisioning_alert_rules.go
@@ -291,13 +291,15 @@ type RelativeTimeRangeExport struct {
 }
 
 // AlertRuleNotificationSettingsExport is the provisioned export of models.NotificationSettings.
+// Field name mismatches with Terraform provider schema are noted where applicable.
 type AlertRuleNotificationSettingsExport struct {
-	// Terraform provider uses `contact_point`, so export the field with that name in HCL.
+	// TF -> `contact_point`
 	Receiver string `yaml:"receiver,omitempty" json:"receiver,omitempty" hcl:"contact_point"`
 
-	GroupBy           []string `yaml:"group_by,omitempty" json:"group_by,omitempty" hcl:"group_by"`
-	GroupWait         *string  `yaml:"group_wait,omitempty" json:"group_wait,omitempty" hcl:"group_wait,optional"`
-	GroupInterval     *string  `yaml:"group_interval,omitempty" json:"group_interval,omitempty" hcl:"group_interval,optional"`
-	RepeatInterval    *string  `yaml:"repeat_interval,omitempty" json:"repeat_interval,omitempty" hcl:"repeat_interval,optional"`
-	MuteTimeIntervals []string `yaml:"mute_time_intervals,omitempty" json:"mute_time_intervals,omitempty" hcl:"mute_time_intervals"`
+	GroupBy        []string `yaml:"group_by,omitempty" json:"group_by,omitempty" hcl:"group_by"`
+	GroupWait      *string  `yaml:"group_wait,omitempty" json:"group_wait,omitempty" hcl:"group_wait,optional"`
+	GroupInterval  *string  `yaml:"group_interval,omitempty" json:"group_interval,omitempty" hcl:"group_interval,optional"`
+	RepeatInterval *string  `yaml:"repeat_interval,omitempty" json:"repeat_interval,omitempty" hcl:"repeat_interval,optional"`
+	// TF -> `mute_timings`
+	MuteTimeIntervals []string `yaml:"mute_time_intervals,omitempty" json:"mute_time_intervals,omitempty" hcl:"mute_timings"`
 }


### PR DESCRIPTION
**What is this feature?**

This PR is related to #87065, and corrects the HCL field name for mute time intervals.

**Why do we need this feature?**

Brings HCL export output in line with Terraform provider schema.

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
