### PR TITLE
Prometheus: Add native histogram types metric explorer to allow filter by type

### DIFF
--- a/packages/grafana-prometheus/src/querybuilder/components/metrics-modal/MetricsModal.test.tsx
+++ b/packages/grafana-prometheus/src/querybuilder/components/metrics-modal/MetricsModal.test.tsx
@@ -187,6 +187,38 @@ describe('MetricsModal', () => {
       expect(metricABucket).toBeInTheDocument();
     });
   });
+
+  // native histograms are given a custom type.
+  // They are histograms but are given the type 'native histogram'
+  // to distinguish then from old histograms.
+  it('displays a type for a native histogram', async () => {
+    setup(defaultQuery, listOfMetrics);
+    await waitFor(() => {
+      expect(screen.getByText('new_histogram')).toBeInTheDocument();
+    });
+
+    expect(screen.getByText('native histogram')).toBeInTheDocument();
+  });
+
+  it('has a filter for selected type', async () => {
+    setup(defaultQuery, listOfMetrics);
+
+    const selectType = screen.getByText('Filter by type');
+
+    await userEvent.click(selectType);
+
+    const nativeHistogramOption = await screen.getByText('Native histograms are different', { exact: false });
+
+    await userEvent.click(nativeHistogramOption);
+
+    const classicHistogram = await screen.queryByText('a_bucket');
+
+    expect(classicHistogram).toBeNull();
+
+    const nativeHistogram = await screen.getByText('new_histogram');
+
+    expect(nativeHistogram).toBeInTheDocument;
+  });
 });
 
 const defaultQuery: PromVisualQuery = {
@@ -195,7 +227,21 @@ const defaultQuery: PromVisualQuery = {
   operations: [],
 };
 
-const listOfMetrics: string[] = ['all-metrics', 'a_bucket', 'a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j'];
+const listOfMetrics: string[] = [
+  'all-metrics',
+  'a_bucket',
+  'new_histogram',
+  'a',
+  'b',
+  'c',
+  'd',
+  'e',
+  'f',
+  'g',
+  'h',
+  'i',
+  'j',
+];
 
 function createDatasource(withLabels?: boolean) {
   const languageProvider = new EmptyLanguageProviderMock() as unknown as PromQlLanguageProvider;
@@ -220,8 +266,12 @@ function createDatasource(withLabels?: boolean) {
         help: 'a-metric-help',
       },
       a_bucket: {
-        type: 'counter',
+        type: 'histogram',
         help: 'for functions',
+      },
+      new_histogram: {
+        type: 'histogram',
+        help: 'a native histogram',
       },
       // missing metadata for other metrics is tested for, see below
     };

--- a/packages/grafana-prometheus/src/querybuilder/components/metrics-modal/MetricsModal.test.tsx
+++ b/packages/grafana-prometheus/src/querybuilder/components/metrics-modal/MetricsModal.test.tsx
@@ -217,7 +217,7 @@ describe('MetricsModal', () => {
 
     const nativeHistogram = await screen.getByText('new_histogram');
 
-    expect(nativeHistogram).toBeInTheDocument;
+    expect(nativeHistogram).toBeInTheDocument();
   });
 });
 

--- a/packages/grafana-prometheus/src/querybuilder/components/metrics-modal/state/helpers.ts
+++ b/packages/grafana-prometheus/src/querybuilder/components/metrics-modal/state/helpers.ts
@@ -74,6 +74,12 @@ function buildMetricData(metric: string, datasource: PrometheusDatasource): Metr
     }
   });
 
+  const oldHistogramMatch = metric.match(/^\w+_bucket$|^\w+_bucket{.*}$/);
+
+  if (type === 'histogram' && !oldHistogramMatch) {
+    type = 'native histogram';
+  }
+
   const metricData: MetricData = {
     value: metric,
     type: type,
@@ -236,6 +242,11 @@ export const promTypes: PromFilterOption[] = [
     value: 'histogram',
     description:
       'A histogram samples observations (usually things like request durations or response sizes) and counts them in configurable buckets.',
+  },
+  {
+    value: 'native histogram',
+    description:
+      'Native histograms are different from classic Prometheus histograms in a number of ways: Native histogram bucket boundaries are calculated by a formula that depends on the scale (resolution) of the native histogram, and are not user defined.',
   },
   {
     value: 'summary',


### PR DESCRIPTION
Fixes https://github.com/grafana/grafana/issues/81971

**What is this feature?**

This adds the native histogram type to the metrics explorer metric select in the query builder. Users can select a type and only display metrics of that type in the metrics explorer. This PR adds the native histogram type to differentiate them from classic histograms.

<img width="1330" alt="Screenshot 2024-04-29 at 9 37 19 PM" src="https://github.com/grafana/grafana/assets/25674746/ac28213c-e2cf-4b87-8b85-6c91527230f0">


<img width="886" alt="Screenshot 2024-04-29 at 9 37 51 PM" src="https://github.com/grafana/grafana/assets/25674746/1ce190f9-cd0e-4944-a490-c9ce4e88aff9">


**Why do we need this feature?**

This is part of the work to release support native histograms. This helps users identify them as part of raising awareness of them and differentiating them from classic histograms as we get ready to make them GA.

**Who is this feature for?**

Prometheus users who have migrated from classic histograms to native histograms


**Special notes for your reviewer:**

TESTING WITH CUSTOM NATIVE HISTOGRAM METRICS

[See this PR for instructions on how to set up a prometheus instance that has native histograms](https://github.com/grafana/grafana/pull/87017). Follow the instructions.

Next, open the explorer page and select the Prometheus data source that has the native histogram metrics. Select the query builder. Open the metric select dropdown. Select the metrics explorer option to open the metrics explorer. 

See that `rpc_durations_native_histogram_seconds` has a type of 'native histogram'.

Open the dropdown that says "Filter by type." Select native histogram to filter by type and only see the native histogram in the list.

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
