### PR TITLE
CloudMigration: Remove details from the migration run list

### DIFF
--- a/pkg/services/cloudmigration/cloudmigrationimpl/cloudmigration.go
+++ b/pkg/services/cloudmigration/cloudmigrationimpl/cloudmigration.go
@@ -497,17 +497,11 @@ func (s *Service) GetMigrationRunList(ctx context.Context, migrationID string) (
 		return nil, fmt.Errorf("retrieving migration statuses from db: %w", err)
 	}
 
-	runList := &cloudmigration.CloudMigrationRunList{Runs: []cloudmigration.MigrateDataResponseDTO{}}
+	runList := &cloudmigration.CloudMigrationRunList{Runs: []cloudmigration.MigrateDataResponseListDTO{}}
 	for _, s := range runs {
-		// attempt to bind the raw result to a list of response item DTOs
-		r := cloudmigration.MigrateDataResponseDTO{
-			Items: []cloudmigration.MigrateDataResponseItemDTO{},
-		}
-		if err := json.Unmarshal(s.Result, &r); err != nil {
-			return nil, fmt.Errorf("error unmarshalling migration response items: %w", err)
-		}
-		r.RunID = s.ID
-		runList.Runs = append(runList.Runs, r)
+		runList.Runs = append(runList.Runs, cloudmigration.MigrateDataResponseListDTO{
+			RunID: s.ID,
+		})
 	}
 
 	return runList, nil

--- a/pkg/services/cloudmigration/model.go
+++ b/pkg/services/cloudmigration/model.go
@@ -66,7 +66,7 @@ func (r CloudMigrationRun) ToResponse() (*MigrateDataResponseDTO, error) {
 }
 
 type CloudMigrationRunList struct {
-	Runs []MigrateDataResponseDTO `json:"runs"`
+	Runs []MigrateDataResponseListDTO `json:"runs"`
 }
 
 // swagger:parameters createMigration
@@ -174,6 +174,10 @@ const (
 type MigrateDataResponseDTO struct {
 	RunID int64                        `json:"id"`
 	Items []MigrateDataResponseItemDTO `json:"items"`
+}
+
+type MigrateDataResponseListDTO struct {
+	RunID int64 `json:"id"`
 }
 
 type MigrateDataResponseItemDTO struct {

--- a/public/api-merged.json
+++ b/public/api-merged.json
@@ -13067,7 +13067,7 @@
         "runs": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/MigrateDataResponseDTO"
+            "$ref": "#/definitions/MigrateDataResponseListDTO"
           }
         }
       }
@@ -16256,6 +16256,15 @@
             "DATASOURCE",
             "FOLDER"
           ]
+        }
+      }
+    },
+    "MigrateDataResponseListDTO": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "integer",
+          "format": "int64"
         }
       }
     },

--- a/public/openapi3.json
+++ b/public/openapi3.json
@@ -3689,7 +3689,7 @@
         "properties": {
           "runs": {
             "items": {
-              "$ref": "#/components/schemas/MigrateDataResponseDTO"
+              "$ref": "#/components/schemas/MigrateDataResponseListDTO"
             },
             "type": "array"
           }
@@ -6881,6 +6881,15 @@
           "refId",
           "status"
         ],
+        "type": "object"
+      },
+      "MigrateDataResponseListDTO": {
+        "properties": {
+          "id": {
+            "format": "int64",
+            "type": "integer"
+          }
+        },
         "type": "object"
       },
       "MoveFolderCommand": {


### PR DESCRIPTION

**Which issue(s) does this PR fix?**:
https://github.com/grafana/grafana-operator-experience-squad/issues/747

**Test**```

curl 'http://localhost:3000/api/cloudmigration/migration/7/run' \
>   -H 'Accept-Language: en-US,en;q=0.9' \
>   -H 'Connection: keep-alive' \
>   -H 'Cookie: grafana_session=8a679933d460daa8f00bb3d4c91561d0; grafana_session_expiry=1714460675'
{"runs":[{"id":13},{"id":14},{"id":15}]}
```