### PR TITLE
SSO Settings: Remove SettingsProvider for SAML strategy

### DIFF
--- a/pkg/services/ssosettings/ssosettingsimpl/service.go
+++ b/pkg/services/ssosettings/ssosettingsimpl/service.go
@@ -59,7 +59,7 @@ func ProvideService(cfg *setting.Cfg, sqlStore db.DB, ac ac.AccessControl,
 
 	providersList := ssosettings.AllOAuthProviders
 	if licensing.FeatureEnabled(social.SAMLProviderName) {
-		fbStrategies = append(fbStrategies, strategies.NewSAMLStrategy(settingsProvider))
+		fbStrategies = append(fbStrategies, strategies.NewSAMLStrategy(cfg))
 
 		if features.IsEnabledGlobally(featuremgmt.FlagSsoSettingsSAML) {
 			providersList = append(providersList, social.SAMLProviderName)

--- a/pkg/services/ssosettings/strategies/saml_strategy.go
+++ b/pkg/services/ssosettings/strategies/saml_strategy.go
@@ -10,14 +10,14 @@ import (
 )
 
 type SAMLStrategy struct {
-	settingsProvider setting.Provider
+	cfg *setting.Cfg
 }
 
 var _ ssosettings.FallbackStrategy = (*SAMLStrategy)(nil)
 
-func NewSAMLStrategy(settingsProvider setting.Provider) *SAMLStrategy {
+func NewSAMLStrategy(cfg *setting.Cfg) *SAMLStrategy {
 	return &SAMLStrategy{
-		settingsProvider: settingsProvider,
+		cfg: cfg,
 	}
 }
 
@@ -30,38 +30,38 @@ func (s *SAMLStrategy) GetProviderConfig(_ context.Context, provider string) (ma
 }
 
 func (s *SAMLStrategy) loadSAMLSettings() map[string]any {
-	section := s.settingsProvider.Section("auth.saml")
+	section := s.cfg.Raw.Section("auth.saml")
 	result := map[string]any{
-		"enabled":                    section.KeyValue("enabled").MustBool(false),
-		"single_logout":              section.KeyValue("single_logout").MustBool(false),
-		"allow_sign_up":              section.KeyValue("allow_sign_up").MustBool(false),
-		"auto_login":                 section.KeyValue("auto_login").MustBool(false),
-		"certificate":                section.KeyValue("certificate").MustString(""),
-		"certificate_path":           section.KeyValue("certificate_path").MustString(""),
-		"private_key":                section.KeyValue("private_key").MustString(""),
-		"private_key_path":           section.KeyValue("private_key_path").MustString(""),
-		"signature_algorithm":        section.KeyValue("signature_algorithm").MustString(""),
-		"idp_metadata":               section.KeyValue("idp_metadata").MustString(""),
-		"idp_metadata_path":          section.KeyValue("idp_metadata_path").MustString(""),
-		"idp_metadata_url":           section.KeyValue("idp_metadata_url").MustString(""),
-		"max_issue_delay":            section.KeyValue("max_issue_delay").MustDuration(90 * time.Second),
-		"metadata_valid_duration":    section.KeyValue("metadata_valid_duration").MustDuration(48 * time.Hour),
-		"allow_idp_initiated":        section.KeyValue("allow_idp_initiated").MustBool(false),
-		"relay_state":                section.KeyValue("relay_state").MustString(""),
-		"assertion_attribute_name":   section.KeyValue("assertion_attribute_name").MustString(""),
-		"assertion_attribute_login":  section.KeyValue("assertion_attribute_login").MustString(""),
-		"assertion_attribute_email":  section.KeyValue("assertion_attribute_email").MustString(""),
-		"assertion_attribute_groups": section.KeyValue("assertion_attribute_groups").MustString(""),
-		"assertion_attribute_role":   section.KeyValue("assertion_attribute_role").MustString(""),
-		"assertion_attribute_org":    section.KeyValue("assertion_attribute_org").MustString(""),
-		"allowed_organizations":      section.KeyValue("allowed_organizations").MustString(""),
-		"org_mapping":                section.KeyValue("org_mapping").MustString(""),
-		"role_values_editor":         section.KeyValue("role_values_editor").MustString(""),
-		"role_values_admin":          section.KeyValue("role_values_admin").MustString(""),
-		"role_values_grafana_admin":  section.KeyValue("role_values_grafana_admin").MustString(""),
-		"name_id_format":             section.KeyValue("name_id_format").MustString(""),
-		"skip_org_role_sync":         section.KeyValue("skip_org_role_sync").MustBool(false),
-		"role_values_none":           section.KeyValue("role_values_none").MustString(""),
+		"enabled":                    section.Key("enabled").MustBool(false),
+		"single_logout":              section.Key("single_logout").MustBool(false),
+		"allow_sign_up":              section.Key("allow_sign_up").MustBool(false),
+		"auto_login":                 section.Key("auto_login").MustBool(false),
+		"certificate":                section.Key("certificate").MustString(""),
+		"certificate_path":           section.Key("certificate_path").MustString(""),
+		"private_key":                section.Key("private_key").MustString(""),
+		"private_key_path":           section.Key("private_key_path").MustString(""),
+		"signature_algorithm":        section.Key("signature_algorithm").MustString(""),
+		"idp_metadata":               section.Key("idp_metadata").MustString(""),
+		"idp_metadata_path":          section.Key("idp_metadata_path").MustString(""),
+		"idp_metadata_url":           section.Key("idp_metadata_url").MustString(""),
+		"max_issue_delay":            section.Key("max_issue_delay").MustDuration(90 * time.Second),
+		"metadata_valid_duration":    section.Key("metadata_valid_duration").MustDuration(48 * time.Hour),
+		"allow_idp_initiated":        section.Key("allow_idp_initiated").MustBool(false),
+		"relay_state":                section.Key("relay_state").MustString(""),
+		"assertion_attribute_name":   section.Key("assertion_attribute_name").MustString(""),
+		"assertion_attribute_login":  section.Key("assertion_attribute_login").MustString(""),
+		"assertion_attribute_email":  section.Key("assertion_attribute_email").MustString(""),
+		"assertion_attribute_groups": section.Key("assertion_attribute_groups").MustString(""),
+		"assertion_attribute_role":   section.Key("assertion_attribute_role").MustString(""),
+		"assertion_attribute_org":    section.Key("assertion_attribute_org").MustString(""),
+		"allowed_organizations":      section.Key("allowed_organizations").MustString(""),
+		"org_mapping":                section.Key("org_mapping").MustString(""),
+		"role_values_editor":         section.Key("role_values_editor").MustString(""),
+		"role_values_admin":          section.Key("role_values_admin").MustString(""),
+		"role_values_grafana_admin":  section.Key("role_values_grafana_admin").MustString(""),
+		"name_id_format":             section.Key("name_id_format").MustString(""),
+		"skip_org_role_sync":         section.Key("skip_org_role_sync").MustBool(false),
+		"role_values_none":           section.Key("role_values_none").MustString(""),
 	}
 	return result
 }

--- a/pkg/services/ssosettings/strategies/saml_strategy_test.go
+++ b/pkg/services/ssosettings/strategies/saml_strategy_test.go
@@ -82,7 +82,7 @@ var (
 
 func TestSAMLIsMatch(t *testing.T) {
 	cfg := setting.NewCfg()
-	strategy := NewSAMLStrategy(&setting.OSSImpl{Cfg: cfg})
+	strategy := NewSAMLStrategy(cfg)
 	require.True(t, strategy.IsMatch("saml"))
 	require.False(t, strategy.IsMatch("oauth"))
 }
@@ -94,7 +94,7 @@ func TestSAMLGetProviderConfig(t *testing.T) {
 	cfg := setting.NewCfg()
 	cfg.Raw = configurationFile
 
-	strategy := NewSAMLStrategy(&setting.OSSImpl{Cfg: cfg})
+	strategy := NewSAMLStrategy(cfg)
 
 	result, err := strategy.GetProviderConfig(context.Background(), "saml")
 	require.NoError(t, err)


### PR DESCRIPTION
**What is this feature?**

This feature replaces the SettingsProvider source of truth for the SAML strategy for the Configuration provider.

**Why do we need this feature?**

When loading the SAML strategy for SSO Settings, the configuration loaded came from the SettingsProvider (AKA the old SAML UI), meaning that despite using the correct feature flags, the settings from Settings Provider were overriding the configuration file.

**Who is this feature for?**

IAM

**Which issue(s) does this PR fix?**:

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
