### PR TITLE
FE Sandbox: Fix innerHTML distortion causing issues with DOMPurify inner works

### DIFF
--- a/public/app/features/plugins/sandbox/distortion_map.ts
+++ b/public/app/features/plugins/sandbox/distortion_map.ts
@@ -204,6 +204,9 @@ function distortInnerHTML(distortions: DistortionMap) {
     const pluginId = meta.id;
     return function innerHTMLDistortion(this: HTMLElement, ...args: string[]) {
       for (const arg of args) {
+        // NOTE: DOMPurify anti-tamper mechanism requires us to clone the string
+        // calling any method whatsoever on a string will cause the string to be tampered
+        // and DOMPurify will return empty strings
         const lowerCase = String(arg || '').toLowerCase();
         for (const forbiddenElement of forbiddenElements) {
           if (lowerCase.includes('<' + forbiddenElement)) {

--- a/public/app/features/plugins/sandbox/distortion_map.ts
+++ b/public/app/features/plugins/sandbox/distortion_map.ts
@@ -204,7 +204,7 @@ function distortInnerHTML(distortions: DistortionMap) {
     const pluginId = meta.id;
     return function innerHTMLDistortion(this: HTMLElement, ...args: string[]) {
       for (const arg of args) {
-        const lowerCase = arg?.toLowerCase() || '';
+        const lowerCase = String(arg || '').toLowerCase();
         for (const forbiddenElement of forbiddenElements) {
           if (lowerCase.includes('<' + forbiddenElement)) {
             logWarning(`Plugin ${pluginId} tried to set ${forbiddenElement} in innerHTML`, {
@@ -223,7 +223,7 @@ function distortInnerHTML(distortions: DistortionMap) {
       }
 
       if (isFunction(originalMethod)) {
-        originalMethod.apply(this, args);
+        return originalMethod.apply(this, args);
       }
     };
   }


### PR DESCRIPTION
**What is this feature?**

Fixes an issue with plugins using DomPurify running inside the frontend sandbox

**Why do we need this feature?**

Allow plugins using DomPurify to work correctly inside the frontend sandbox

**Who is this feature for?**

All plugins running inside the frontend sandbox

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
