### PR TITLE
DashboardScene: Fixes issue referring to library panel in dashboard data source 

### DIFF
--- a/public/app/features/dashboard-scene/scene/DashboardDatasourceBehaviour.tsx
+++ b/public/app/features/dashboard-scene/scene/DashboardDatasourceBehaviour.tsx
@@ -53,7 +53,7 @@ export class DashboardDatasourceBehaviour extends SceneObjectBase<DashboardDatas
 
     const sourcePanelQueryRunner = getQueryRunnerFor(panel);
 
-    if (!(sourcePanelQueryRunner instanceof SceneQueryRunner)) {
+    if (!sourcePanelQueryRunner) {
       if (!(panel.parent instanceof LibraryVizPanel)) {
         throw new Error('Could not find SceneQueryRunner for panel');
       } else {

--- a/public/app/features/dashboard-scene/utils/PanelModelCompatibilityWrapper.test.ts
+++ b/public/app/features/dashboard-scene/utils/PanelModelCompatibilityWrapper.test.ts
@@ -1,0 +1,26 @@
+import { VizPanel } from '@grafana/scenes';
+
+import { LibraryVizPanel } from '../scene/LibraryVizPanel';
+
+import { PanelModelCompatibilityWrapper } from './PanelModelCompatibilityWrapper';
+
+describe('PanelModelCompatibilityWrapper', () => {
+  it('Can get legacy id', () => {
+    const vizPanel = new VizPanel({ pluginId: 'test', title: 'test', description: 'test', key: 'panel-24' });
+    const panelModel = new PanelModelCompatibilityWrapper(vizPanel);
+    expect(panelModel.id).toBe(24);
+  });
+
+  it('Can get legacy id for lib panel', () => {
+    const libPanel = new LibraryVizPanel({
+      uid: 'a',
+      name: 'aa',
+      title: 'a',
+      panelKey: 'panel-24',
+      panel: new VizPanel({ pluginId: 'test', title: 'test', description: 'test', key: 'panel-24' }),
+    });
+
+    const panelModel = new PanelModelCompatibilityWrapper(libPanel.state.panel!);
+    expect(panelModel.id).toBe(24);
+  });
+});

--- a/public/app/features/dashboard-scene/utils/PanelModelCompatibilityWrapper.ts
+++ b/public/app/features/dashboard-scene/utils/PanelModelCompatibilityWrapper.ts
@@ -2,17 +2,13 @@ import { PanelModel } from '@grafana/data';
 import { SceneDataTransformer, VizPanel } from '@grafana/scenes';
 import { DataSourceRef, DataTransformerConfig } from '@grafana/schema';
 
-import { LibraryVizPanel } from '../scene/LibraryVizPanel';
-
 import { getPanelIdForVizPanel, getQueryRunnerFor } from './utils';
 
 export class PanelModelCompatibilityWrapper implements PanelModel {
   constructor(private _vizPanel: VizPanel) {}
 
   public get id() {
-    const id = getPanelIdForVizPanel(
-      this._vizPanel.parent instanceof LibraryVizPanel ? this._vizPanel.parent : this._vizPanel
-    );
+    const id = getPanelIdForVizPanel(this._vizPanel);
 
     if (isNaN(id)) {
       console.error('VizPanel key could not be translated to a legacy numeric panel id', this._vizPanel);


### PR DESCRIPTION
Not sure how this has worked at all recently (since we moved the key from VizLibraryPanel down to VizPanel). But I could not create a new panel that was using dashboard data source and pick a library panel as the source without seeing "VizPanel key could not be translated to a legacy numeric panel id" errors and the panelId in the targets model ended up being 0. 

