### PR TITLE
postgres: decouple the frontend-part

### DIFF
--- a/public/app/features/plugins/built_in_plugins.ts
+++ b/public/app/features/plugins/built_in_plugins.ts
@@ -15,8 +15,6 @@ const influxdbPlugin = async () =>
 const lokiPlugin = async () => await import(/* webpackChunkName: "lokiPlugin" */ 'app/plugins/datasource/loki/module');
 const mixedPlugin = async () =>
   await import(/* webpackChunkName: "mixedPlugin" */ 'app/plugins/datasource/mixed/module');
-const postgresPlugin = async () =>
-  await import(/* webpackChunkName: "postgresPlugin" */ 'app/plugins/datasource/grafana-postgresql-datasource/module');
 const prometheusPlugin = async () =>
   await import(/* webpackChunkName: "prometheusPlugin" */ 'app/plugins/datasource/prometheus/module');
 const mssqlPlugin = async () =>
@@ -81,7 +79,6 @@ const builtInPlugins: Record<string, System.Module | (() => Promise<System.Modul
   'core:plugin/influxdb': influxdbPlugin,
   'core:plugin/loki': lokiPlugin,
   'core:plugin/mixed': mixedPlugin,
-  'core:plugin/grafana-postgresql-datasource': postgresPlugin,
   'core:plugin/mssql': mssqlPlugin,
   'core:plugin/prometheus': prometheusPlugin,
   'core:plugin/alertmanager': alertmanagerPlugin,

--- a/public/app/plugins/datasource/grafana-postgresql-datasource/CHANGELOG.md
+++ b/public/app/plugins/datasource/grafana-postgresql-datasource/CHANGELOG.md
@@ -1,0 +1,1 @@
+# Changelog

--- a/public/app/plugins/datasource/grafana-postgresql-datasource/package.json
+++ b/public/app/plugins/datasource/grafana-postgresql-datasource/package.json
@@ -1,0 +1,41 @@
+{
+  "name": "@grafana-plugins/grafana-postgresql-datasource",
+  "description": "PostgreSQL data source plugin",
+  "private": true,
+  "version": "11.1.0-pre",
+  "dependencies": {
+    "@emotion/css": "11.11.2",
+    "@grafana/data": "11.1.0-pre",
+    "@grafana/experimental": "1.7.10",
+    "@grafana/runtime": "11.1.0-pre",
+    "@grafana/sql": "11.1.0-pre",
+    "@grafana/ui": "11.1.0-pre",
+    "lodash": "4.17.21",
+    "react": "18.2.0",
+    "rxjs": "7.8.1",
+    "tslib": "2.6.2"
+  },
+  "devDependencies": {
+    "@grafana/e2e-selectors": "11.1.0-pre",
+    "@grafana/plugin-configs": "11.1.0-pre",
+    "@testing-library/react": "15.0.2",
+    "@testing-library/user-event": "14.5.2",
+    "@types/jest": "29.5.12",
+    "@types/lodash": "4.17.0",
+    "@types/node": "20.12.7",
+    "@types/react": "18.2.79",
+    "@types/testing-library__jest-dom": "5.14.9",
+    "ts-node": "10.9.2",
+    "typescript": "5.4.5",
+    "webpack": "5.91.0"
+  },
+  "peerDependencies": {
+    "@grafana/runtime": "*"
+  },
+  "scripts": {
+    "build": "webpack -c ./webpack.config.ts --env production",
+    "build:commit": "webpack -c ./webpack.config.ts --env production --env commit=$(git rev-parse --short HEAD)",
+    "dev": "webpack -w -c ./webpack.config.ts --env development"
+  },
+  "packageManager": "yarn@4.1.1"
+}

--- a/public/app/plugins/datasource/grafana-postgresql-datasource/tsconfig.json
+++ b/public/app/plugins/datasource/grafana-postgresql-datasource/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "extends": "@grafana/plugin-configs/tsconfig.json",
+  "include": ["."]
+}

--- a/public/app/plugins/datasource/grafana-postgresql-datasource/webpack.config.ts
+++ b/public/app/plugins/datasource/grafana-postgresql-datasource/webpack.config.ts
@@ -1,0 +1,4 @@
+import config from '@grafana/plugin-configs/webpack.config';
+
+// eslint-disable-next-line no-barrel-files/no-barrel-files
+export default config;

--- a/yarn.lock
+++ b/yarn.lock
@@ -3030,6 +3030,37 @@ __metadata:
   languageName: unknown
   linkType: soft
 
+"@grafana-plugins/grafana-postgresql-datasource@workspace:public/app/plugins/datasource/grafana-postgresql-datasource":
+  version: 0.0.0-use.local
+  resolution: "@grafana-plugins/grafana-postgresql-datasource@workspace:public/app/plugins/datasource/grafana-postgresql-datasource"
+  dependencies:
+    "@emotion/css": "npm:11.11.2"
+    "@grafana/data": "npm:11.1.0-pre"
+    "@grafana/e2e-selectors": "npm:11.1.0-pre"
+    "@grafana/experimental": "npm:1.7.10"
+    "@grafana/plugin-configs": "npm:11.1.0-pre"
+    "@grafana/runtime": "npm:11.1.0-pre"
+    "@grafana/sql": "npm:11.1.0-pre"
+    "@grafana/ui": "npm:11.1.0-pre"
+    "@testing-library/react": "npm:15.0.2"
+    "@testing-library/user-event": "npm:14.5.2"
+    "@types/jest": "npm:29.5.12"
+    "@types/lodash": "npm:4.17.0"
+    "@types/node": "npm:20.12.7"
+    "@types/react": "npm:18.2.79"
+    "@types/testing-library__jest-dom": "npm:5.14.9"
+    lodash: "npm:4.17.21"
+    react: "npm:18.2.0"
+    rxjs: "npm:7.8.1"
+    ts-node: "npm:10.9.2"
+    tslib: "npm:2.6.2"
+    typescript: "npm:5.4.5"
+    webpack: "npm:5.91.0"
+  peerDependencies:
+    "@grafana/runtime": "*"
+  languageName: unknown
+  linkType: soft
+
 "@grafana-plugins/grafana-pyroscope-datasource@workspace:public/app/plugins/datasource/grafana-pyroscope-datasource":
   version: 0.0.0-use.local
   resolution: "@grafana-plugins/grafana-pyroscope-datasource@workspace:public/app/plugins/datasource/grafana-pyroscope-datasource"


### PR DESCRIPTION
NOTE: this is the [same PR as we did for mysql](https://github.com/grafana/grafana/pull/86308)  except i changed the word "mysql" to "postgres" .

fixes https://github.com/grafana/grafana/issues/87040

decouples the "frontend part"of the postgres-plugin.

how to test:
just run it, connect to a postgres datasoure, and make sure the query-editor still works.
(for grafana-people, just go to the ephemeral instance below, i configured it with a postgres datasource named `psql` you can use for testing)