### PR TITLE
Chore: Remove configurableSchedulerTick feature toggle

### DIFF
--- a/packages/grafana-data/src/types/featureToggles.gen.ts
+++ b/packages/grafana-data/src/types/featureToggles.gen.ts
@@ -99,7 +99,6 @@ export interface FeatureToggles {
   awsAsyncQueryCaching?: boolean;
   permissionsFilterRemoveSubquery?: boolean;
   prometheusConfigOverhaulAuth?: boolean;
-  configurableSchedulerTick?: boolean;
   alertingNoDataErrorExecution?: boolean;
   angularDeprecationUI?: boolean;
   dashgpt?: boolean;

--- a/pkg/services/featuremgmt/registry.go
+++ b/pkg/services/featuremgmt/registry.go
@@ -606,15 +606,6 @@ var (
 			AllowSelfServe: false,
 		},
 		{
-			Name:            "configurableSchedulerTick",
-			Description:     "Enable changing the scheduler base interval via configuration option unified_alerting.scheduler_tick_interval",
-			Stage:           FeatureStageExperimental,
-			FrontendOnly:    false,
-			Owner:           grafanaAlertingSquad,
-			RequiresRestart: true,
-			HideFromDocs:    true,
-		},
-		{
 			Name:            "alertingNoDataErrorExecution",
 			Description:     "Changes how Alerting state manager handles execution of NoData/Error",
 			Stage:           FeatureStageGeneralAvailability,

--- a/pkg/services/featuremgmt/toggles_gen.csv
+++ b/pkg/services/featuremgmt/toggles_gen.csv
@@ -80,7 +80,6 @@ featureToggleAdminPage,experimental,@grafana/grafana-operator-experience-squad,f
 awsAsyncQueryCaching,GA,@grafana/aws-datasources,false,false,false
 permissionsFilterRemoveSubquery,experimental,@grafana/grafana-backend-group,false,false,false
 prometheusConfigOverhaulAuth,GA,@grafana/observability-metrics,false,false,false
-configurableSchedulerTick,experimental,@grafana/alerting-squad,false,true,false
 alertingNoDataErrorExecution,GA,@grafana/alerting-squad,false,true,false
 angularDeprecationUI,GA,@grafana/plugins-platform-backend,false,false,true
 dashgpt,GA,@grafana/dashboards-squad,false,false,true

--- a/pkg/services/featuremgmt/toggles_gen.go
+++ b/pkg/services/featuremgmt/toggles_gen.go
@@ -331,10 +331,6 @@ const (
 	// Update the Prometheus configuration page with the new auth component
 	FlagPrometheusConfigOverhaulAuth = "prometheusConfigOverhaulAuth"
 
-	// FlagConfigurableSchedulerTick
-	// Enable changing the scheduler base interval via configuration option unified_alerting.scheduler_tick_interval
-	FlagConfigurableSchedulerTick = "configurableSchedulerTick"
-
 	// FlagAlertingNoDataErrorExecution
 	// Changes how Alerting state manager handles execution of NoData/Error
 	FlagAlertingNoDataErrorExecution = "alertingNoDataErrorExecution"

--- a/pkg/services/featuremgmt/toggles_gen.json
+++ b/pkg/services/featuremgmt/toggles_gen.json
@@ -2002,7 +2002,8 @@
       "metadata": {
         "name": "configurableSchedulerTick",
         "resourceVersion": "1713545444177",
-        "creationTimestamp": "2024-04-19T16:50:44Z"
+        "creationTimestamp": "2024-04-19T16:50:44Z",
+        "deletionTimestamp": "2024-04-30T15:13:14Z"
       },
       "spec": {
         "description": "Enable changing the scheduler base interval via configuration option unified_alerting.scheduler_tick_interval",

--- a/pkg/setting/setting_unified_alerting.go
+++ b/pkg/setting/setting_unified_alerting.go
@@ -269,27 +269,6 @@ func (cfg *Cfg) ReadUnifiedAlertingSettings(iniFile *ini.File) error {
 	// We can consider removing the knob entirely in a release after 10.4.
 	uaCfg.DisableJitter = ua.Key("disable_jitter").MustBool(false)
 
-	// The base interval of the scheduler for evaluating alerts.
-	// 1. It is used by the internal scheduler's timer to tick at this interval.
-	// 2. to spread evaluations of rules that need to be evaluated at the current tick T. In other words, the evaluation of rules at the tick T will be evenly spread in the interval from T to T+scheduler_tick_interval.
-	//    For example, if there are 100 rules that need to be evaluated at tick T, and the base interval is 10s, rules will be evaluated every 100ms.
-	// 3. It increases delay between rule updates and state reset.
-	// NOTE:
-	// 1. All alert rule intervals should be times of this interval. Otherwise, the rules will not be evaluated. It is not recommended to set it lower than 10s or odd numbers. Recommended: 10s, 30s, 1m
-	// 2. The increasing of the interval will affect how slow alert rule updates will reset the state, and therefore reset notification. Higher the interval - slower propagation of the changes.
-	baseInterval, err := gtime.ParseDuration(valueAsString(ua, "scheduler_tick_interval", SchedulerBaseInterval.String()))
-	if cfg.IsFeatureToggleEnabled("configurableSchedulerTick") { // use literal to avoid cycle imports
-		if err != nil {
-			return fmt.Errorf("failed to parse setting 'scheduler_tick_interval' as duration: %w", err)
-		}
-		if baseInterval != SchedulerBaseInterval {
-			cfg.Logger.Warn("Scheduler tick interval is changed to non-default", "interval", baseInterval, "default", SchedulerBaseInterval)
-		}
-		uaCfg.BaseInterval = baseInterval
-	} else if baseInterval != SchedulerBaseInterval {
-		cfg.Logger.Warn("Scheduler tick interval is changed to non-default but the feature flag is not enabled. Using default.", "interval", baseInterval, "default", SchedulerBaseInterval)
-	}
-
 	uaMinInterval, err := gtime.ParseDuration(valueAsString(ua, "min_interval", uaCfg.BaseInterval.String()))
 	if err != nil || uaMinInterval == uaCfg.BaseInterval { // unified option is invalid duration or equals the default
 		// if the legacy option is invalid, fallback to 10 (unified alerting min interval default)

--- a/pkg/setting/setting_unified_alerting_test.go
+++ b/pkg/setting/setting_unified_alerting_test.go
@@ -39,39 +39,6 @@ func TestCfg_ReadUnifiedAlertingSettings(t *testing.T) {
 		require.Len(t, cfg.UnifiedAlerting.HAPeers, 3)
 		require.ElementsMatch(t, []string{"hostname1:9090", "hostname2:9090", "hostname3:9090"}, cfg.UnifiedAlerting.HAPeers)
 	}
-
-	t.Run("should read 'scheduler_tick_interval'", func(t *testing.T) {
-		tmp := cfg.IsFeatureToggleEnabled
-		t.Cleanup(func() {
-			cfg.IsFeatureToggleEnabled = tmp
-		})
-		cfg.IsFeatureToggleEnabled = func(key string) bool { return key == "configurableSchedulerTick" }
-
-		s, err := cfg.Raw.NewSection("unified_alerting")
-		require.NoError(t, err)
-		_, err = s.NewKey("scheduler_tick_interval", "1m")
-		require.NoError(t, err)
-		_, err = s.NewKey("min_interval", "3m")
-		require.NoError(t, err)
-
-		require.NoError(t, cfg.ReadUnifiedAlertingSettings(cfg.Raw))
-		require.Equal(t, time.Minute, cfg.UnifiedAlerting.BaseInterval)
-		require.Equal(t, 3*time.Minute, cfg.UnifiedAlerting.MinInterval)
-
-		t.Run("and fail if it is wrong", func(t *testing.T) {
-			_, err = s.NewKey("scheduler_tick_interval", "test")
-			require.NoError(t, err)
-
-			require.Error(t, cfg.ReadUnifiedAlertingSettings(cfg.Raw))
-		})
-
-		t.Run("and use default if not specified", func(t *testing.T) {
-			s.DeleteKey("scheduler_tick_interval")
-			require.NoError(t, cfg.ReadUnifiedAlertingSettings(cfg.Raw))
-
-			require.Equal(t, SchedulerBaseInterval, cfg.UnifiedAlerting.BaseInterval)
-		})
-	})
 }
 
 func TestUnifiedAlertingSettings(t *testing.T) {

--- a/pkg/tests/api/alerting/api_ruler_test.go
+++ b/pkg/tests/api/alerting/api_ruler_test.go
@@ -1759,7 +1759,7 @@ func TestIntegrationHysteresisRule(t *testing.T) {
 		DisableAnonymous:             true,
 		AppModeProduction:            true,
 		NGAlertSchedulerBaseInterval: 1 * time.Second,
-		EnableFeatureToggles:         []string{featuremgmt.FlagConfigurableSchedulerTick, featuremgmt.FlagRecoveryThreshold},
+		EnableFeatureToggles:         []string{featuremgmt.FlagRecoveryThreshold},
 	})
 
 	grafanaListedAddr, env := testinfra.StartGrafanaEnv(t, dir, p)
@@ -1833,7 +1833,7 @@ func TestIntegrationRuleNotificationSettings(t *testing.T) {
 		DisableAnonymous:             true,
 		AppModeProduction:            true,
 		NGAlertSchedulerBaseInterval: 1 * time.Second,
-		EnableFeatureToggles:         []string{featuremgmt.FlagConfigurableSchedulerTick, featuremgmt.FlagAlertingSimplifiedRouting},
+		EnableFeatureToggles:         []string{featuremgmt.FlagAlertingSimplifiedRouting},
 	})
 
 	grafanaListedAddr, env := testinfra.StartGrafanaEnv(t, dir, p)


### PR DESCRIPTION
This flag is no longer needed; it is in use by one customer so this will stay in draft for now. Slack context: https://raintank-corp.slack.com/archives/C028MCV4R7C/p1714479233424919

This is basically a manual revert of the [original PR](https://github.com/grafana/grafana/pull/71980). 
