### PR TITLE
Dashboard: Only show `Starred` as parent breadcrumb for starred dashboards

### DIFF
--- a/public/app/features/dashboard/containers/DashboardPage.tsx
+++ b/public/app/features/dashboard/containers/DashboardPage.tsx
@@ -458,19 +458,6 @@ function updateStatePageNavFromProps(props: Props, state: State): State {
     };
   }
 
-  const { folderUid } = dashboard.meta;
-  if (folderUid && pageNav) {
-    const folderNavModel = getNavModel(navIndex, `folder-dashboards-${folderUid}`).main;
-    // If the folder hasn't loaded (maybe user doesn't have permission on it?) then
-    // don't show the "page not found" breadcrumb
-    if (folderNavModel.id !== 'not-found') {
-      pageNav = {
-        ...pageNav,
-        parentItem: folderNavModel,
-      };
-    }
-  }
-
   if (props.route.routeName === DashboardRoutes.Path) {
     sectionNav = getRootContentNavModel();
     const pageNav = getPageNavFromSlug(props.match.params.slug!);
@@ -483,6 +470,19 @@ function updateStatePageNavFromProps(props: Props, state: State): State {
       ID_PREFIX + dashboard.uid,
       getNavModel(props.navIndex, 'dashboards/browse')
     );
+  }
+
+  const { folderUid } = dashboard.meta;
+  if (folderUid && pageNav && sectionNav.main.id !== 'starred') {
+    const folderNavModel = getNavModel(navIndex, `folder-dashboards-${folderUid}`).main;
+    // If the folder hasn't loaded (maybe user doesn't have permission on it?) then
+    // don't show the "page not found" breadcrumb
+    if (folderNavModel.id !== 'not-found') {
+      pageNav = {
+        ...pageNav,
+        parentItem: folderNavModel,
+      };
+    }
   }
 
   if (state.editPanel || state.viewPanel) {


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

- fixes a very minor regression introduced in https://github.com/grafana/grafana/pull/85336 
  - my bad for not spotting this 🤦 
  
| before | after |
| --- | --- |
| ![image](https://github.com/grafana/grafana/assets/20999846/f2eabc1a-31cf-4064-b3f8-2e10f8c178b8) | ![image](https://github.com/grafana/grafana/assets/20999846/27395ee7-ecf4-40af-847f-81958a0d90f2) |

**Why do we need this feature?**

- so breadcrumbs appear correctly for starred dashboards in folders

**Who is this feature for?**

- everyone!

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
