### PR TITLE
Prometheus: Ensure values in metric selector are visible

### DIFF
--- a/packages/grafana-prometheus/src/querybuilder/components/MetricSelect.tsx
+++ b/packages/grafana-prometheus/src/querybuilder/components/MetricSelect.tsx
@@ -1,5 +1,5 @@
 // Core Grafana history https://github.com/grafana/grafana/blob/v11.0.0-preview/public/app/plugins/datasource/prometheus/querybuilder/components/MetricSelect.tsx
-import { css, cx } from '@emotion/css';
+import { css } from '@emotion/css';
 import debounce from 'debounce-promise';
 import React, { RefCallback, useCallback, useState } from 'react';
 import Highlighter from 'react-highlight-words';
@@ -240,13 +240,8 @@ export function MetricSelect({
     return (
       <div
         {...innerProps}
-        className={cx(
-          stylesMenu.menu,
-          styles.customMenuContainer,
-          css`
-            max-height: ${Math.round(maxHeight * 0.9)}px;
-          `
-        )}
+        className={`${stylesMenu.menu} ${styles.customMenuContainer}`}
+        style={{ maxHeight: Math.round(maxHeight * 0.9) }}
         aria-label="Select options menu"
       >
         <CustomScrollbar

--- a/packages/grafana-prometheus/src/querybuilder/components/MetricSelect.tsx
+++ b/packages/grafana-prometheus/src/querybuilder/components/MetricSelect.tsx
@@ -298,7 +298,7 @@ export function MetricSelect({
 
           if (prometheusMetricEncyclopedia) {
             setState({
-              // add the modal butoon option to the options
+              // add the modal button option to the options
               metrics: [...metricsModalOption, ...metrics],
               isLoading: undefined,
               // pass the initial metrics into the metrics explorer

--- a/packages/grafana-prometheus/src/querybuilder/components/MetricSelect.tsx
+++ b/packages/grafana-prometheus/src/querybuilder/components/MetricSelect.tsx
@@ -1,5 +1,5 @@
 // Core Grafana history https://github.com/grafana/grafana/blob/v11.0.0-preview/public/app/plugins/datasource/prometheus/querybuilder/components/MetricSelect.tsx
-import { css } from '@emotion/css';
+import { css, cx } from '@emotion/css';
 import debounce from 'debounce-promise';
 import React, { RefCallback, useCallback, useState } from 'react';
 import Highlighter from 'react-highlight-words';
@@ -240,11 +240,22 @@ export function MetricSelect({
     return (
       <div
         {...innerProps}
-        className={`${stylesMenu.menu} ${styles.customMenuContainer}`}
-        style={{ maxHeight }}
+        className={cx(
+          stylesMenu.menu,
+          styles.customMenuContainer,
+          css`
+            max-height: ${Math.round(maxHeight * 0.9)}px;
+          `
+        )}
         aria-label="Select options menu"
       >
-        <CustomScrollbar scrollRefCallback={innerRef} autoHide={false} autoHeightMax="inherit" hideHorizontalTrack>
+        <CustomScrollbar
+          scrollRefCallback={innerRef}
+          autoHide={false}
+          autoHeightMax="inherit"
+          hideHorizontalTrack
+          showScrollIndicators
+        >
           {children}
         </CustomScrollbar>
         {optionsLoaded && (
@@ -271,6 +282,7 @@ export function MetricSelect({
         allowCustomValue
         formatOptionLabel={formatOptionLabel}
         filterOption={customFilterOption}
+        minMenuHeight={250}
         onOpenMenu={async () => {
           if (metricLookupDisabled) {
             return;
@@ -303,7 +315,7 @@ export function MetricSelect({
         }}
         loadOptions={metricLookupDisabled ? metricLookupDisabledSearch : debouncedSearch}
         isLoading={state.isLoading}
-        defaultOptions={state.metrics}
+        defaultOptions={state.metrics ?? Array.from(new Array(25), () => ({ value: '' }))} // We need empty values when `state.metrics` is falsy in order for the select to correctly determine top/bottom placement
         onChange={(input) => {
           const value = input?.value;
           if (value) {
@@ -405,6 +417,9 @@ const getStyles = (theme: GrafanaTheme2) => ({
     flex-direction: column;
     background: ${theme.colors.background.primary};
     box-shadow: ${theme.shadows.z3};
+    border-style: solid;
+    border-color: ${theme.colors.border.weak};
+    border-radius: ${theme.shape.radius.default};
   `,
 });
 

--- a/packages/grafana-prometheus/src/querybuilder/components/MetricSelect.tsx
+++ b/packages/grafana-prometheus/src/querybuilder/components/MetricSelect.tsx
@@ -56,7 +56,7 @@ export function MetricSelect({
   metricLookupDisabled,
   onBlur,
   variableEditor,
-}: MetricSelectProps) {
+}: Readonly<MetricSelectProps>) {
   const styles = useStyles2(getStyles);
   const [state, setState] = useState<{
     metrics?: SelectableValue[];
@@ -274,7 +274,7 @@ export function MetricSelect({
     return (
       <AsyncSelect
         data-testid={selectors.components.DataSource.Prometheus.queryEditor.builder.metricSelect}
-        isClearable={variableEditor ? true : false}
+        isClearable={variableEditor}
         inputId="prometheus-metric-select"
         className={styles.select}
         value={query.metric ? toOption(query.metric) : undefined}
@@ -333,7 +333,7 @@ export function MetricSelect({
         components={
           prometheusMetricEncyclopedia ? { Option: CustomOption, MenuList: CustomMenu } : { MenuList: CustomMenu }
         }
-        onBlur={onBlur ? onBlur : () => {}}
+        onBlur={onBlur}
       />
     );
   };

--- a/packages/grafana-prometheus/src/querybuilder/components/MetricSelect.tsx
+++ b/packages/grafana-prometheus/src/querybuilder/components/MetricSelect.tsx
@@ -269,7 +269,7 @@ export function MetricSelect({
     return (
       <AsyncSelect
         data-testid={selectors.components.DataSource.Prometheus.queryEditor.builder.metricSelect}
-        isClearable={variableEditor}
+        isClearable={Boolean(variableEditor)}
         inputId="prometheus-metric-select"
         className={styles.select}
         value={query.metric ? toOption(query.metric) : undefined}

--- a/packages/grafana-prometheus/src/querybuilder/components/MetricSelect.tsx
+++ b/packages/grafana-prometheus/src/querybuilder/components/MetricSelect.tsx
@@ -412,9 +412,6 @@ const getStyles = (theme: GrafanaTheme2) => ({
     flex-direction: column;
     background: ${theme.colors.background.primary};
     box-shadow: ${theme.shadows.z3};
-    border-style: solid;
-    border-color: ${theme.colors.border.weak};
-    border-radius: ${theme.shape.radius.default};
   `,
 });
 


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

## What is this fix and why do we need it?

In the Prometheus data source's [Query Builder][query-builder], users must [select](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/select) a metric name. As described in #85829, the select can display options below the viewport. This happens because we are lazy-loading the options, and the [<AsyncSelect />](https://grafana.com/developers/saga/components/select/#async-select) component determines the placement (top/bottom) of options (based on available space above/below the select) before he options have finished loading. This presents a UX issue because users can get the false impression that metric names are missing from the select.

In addition to some light refactoring, this PR changes the select in the following ways:
- The select can correctly place options above when there isn't enough space to place them below.
- The select leverages the `<CustomScrollbar />`'s `showScrollIndicators` prop to indicate to the user when there are results above or below their current scroll position.

### Before

(on `main`)

Note the various issues described above and in #85829.

https://github.com/grafana/grafana/assets/5732000/b6d69354-969a-4864-bf36-f46db1419799

### After

(on `85829/fix-prometheus-query-builder-metric-selector-display-beyond-viewport`)

In the beginning of the video, note how the top and bottom of the options are greyed-out when the top-most and bottom-most options are out-of-view. This provides a visual cue to the user that they must scroll to reach the bottom or top. Next, note how regardless of how much space is available to render the select, the options are always visible.

https://github.com/grafana/grafana/assets/5732000/aaba0c1b-709c-48ba-a6ce-3d7c7b15a3c1

## Who is this feature for?

Prometheus data source users who rely on the [Query Builder][query-builder].

## Which issue(s) does this PR fix?

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

This PR fixes #85829.

## Special notes for your reviewer

N/A

## Future work

These changes could also be applied elsewhere. We should examine any `<Select />` or `<AsyncSelect />` that uses `onOpenMenu` to lazy-load options, as they likely suffer from the same UX issues. In the Prometheus data source, `LabelFilterItem.tsx` and `LabelParamEditor.tsx` in `packages/grafana-prometheus/src/querybuilder/components` are candidates.

## Please check that:
- [x] It works as expected from a user's perspective.
- [x] `(Not applicable)` If this is a pre-GA feature, it is behind a feature toggle.
- [x] `(Not applicable)` The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.


[query-builder]: https://grafana.com/docs/grafana/latest/datasources/prometheus/query-editor/#builder-mode