### PR TITLE
XY Chart: Show mapped size/color fields in tooltip

### DIFF
--- a/public/app/plugins/panel/xychart/v2/XYChartPanel.tsx
+++ b/public/app/plugins/panel/xychart/v2/XYChartPanel.tsx
@@ -53,6 +53,10 @@ export const XYChartPanel2 = (props: Props2) => {
 
   // TODO: React.memo()
   const renderLegend = () => {
+    if (!props.options.legend.showLegend) {
+      return null;
+    }
+
     const items: VizLegendItem[] = [];
 
     series.forEach((s, idx) => {

--- a/public/app/plugins/panel/xychart/v2/XYChartTooltip.tsx
+++ b/public/app/plugins/panel/xychart/v2/XYChartTooltip.tsx
@@ -40,7 +40,7 @@ export const XYChartTooltip = ({ dataIdxs, seriesIdx, data, xySeries, dismiss, i
   const xField = series.x.field;
   const yField = series.y.field;
 
-  const sizeField = series.size?.field;
+  const sizeField = series.size.field;
   const colorField = series.color.field;
 
   let label = series.name.value;

--- a/public/app/plugins/panel/xychart/v2/XYChartTooltip.tsx
+++ b/public/app/plugins/panel/xychart/v2/XYChartTooltip.tsx
@@ -40,6 +40,9 @@ export const XYChartTooltip = ({ dataIdxs, seriesIdx, data, xySeries, dismiss, i
   const xField = series.x.field;
   const yField = series.y.field;
 
+  const sizeField = series.size?.field;
+  const colorField = series.color.field;
+
   let label = series.name.value;
 
   let seriesColor = series.color.fixed;
@@ -67,6 +70,21 @@ export const XYChartTooltip = ({ dataIdxs, seriesIdx, data, xySeries, dismiss, i
       value: fmt(yField, yField.values[rowIndex]),
     },
   ];
+
+  // mapped fields for size/color
+  if (sizeField != null) {
+    contentItems.push({
+      label: stripSeriesName(sizeField.state?.displayName ?? sizeField.name, label),
+      value: fmt(sizeField, sizeField.values[rowIndex]),
+    });
+  }
+
+  if (colorField != null) {
+    contentItems.push({
+      label: stripSeriesName(colorField.state?.displayName ?? colorField.name, label),
+      value: fmt(colorField, colorField.values[rowIndex]),
+    });
+  }
 
   series._rest.forEach((field) => {
     contentItems.push({


### PR DESCRIPTION

![xy_tooltip](https://github.com/grafana/grafana/assets/88068998/9b5f3bf3-585d-418a-8d40-4a221f41ca0b)

Also fixes legend visibility (mentioned in https://github.com/grafana/grafana/issues/85034).
Note: color is not implemented


Fixes #85033

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
