### PR TITLE
DashboardScene: Fixes issue with panel edit options pane and data

### DIFF
--- a/public/app/features/dashboard-scene/panel-edit/PanelOptionsPane.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelOptionsPane.tsx
@@ -44,7 +44,7 @@ export class PanelOptionsPane extends SceneObjectBase<PanelOptionsPaneState> {
     const { isVizPickerOpen, searchQuery, listMode } = model.useState();
     const vizManager = sceneGraph.getAncestor(model, PanelEditor).state.vizManager;
     const { pluginId } = vizManager.state.panel.useState();
-    const { data } = sceneGraph.getData(vizManager).useState();
+    const { data } = sceneGraph.getData(vizManager.state.panel).useState();
     const styles = useStyles2(getStyles);
 
     return (


### PR DESCRIPTION
Fixes #87134

When I moved back the data to panel level I forgot to move this call to get data scoped from panel, so the panel option editors (And canvas option editor) got the global annotation queries instead. 
