### PR TITLE
Chore: Restore pseudoizer dep

### DIFF
--- a/package.json
+++ b/package.json
@@ -207,6 +207,7 @@
     "postcss-reporter": "7.1.0",
     "postcss-scss": "4.0.9",
     "prettier": "3.2.5",
+    "pseudoizer": "^0.1.0",
     "react-refresh": "0.14.0",
     "react-select-event": "5.5.1",
     "react-test-renderer": "18.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -18338,6 +18338,7 @@ __metadata:
     postcss-scss: "npm:4.0.9"
     prettier: "npm:3.2.5"
     prismjs: "npm:1.29.0"
+    pseudoizer: "npm:^0.1.0"
     rc-slider: "npm:10.6.2"
     rc-time-picker: "npm:3.7.3"
     rc-tree: "npm:5.8.5"
@@ -25227,6 +25228,13 @@ __metadata:
   version: 1.1.0
   resolution: "proxy-from-env@npm:1.1.0"
   checksum: 10/f0bb4a87cfd18f77bc2fba23ae49c3b378fb35143af16cc478171c623eebe181678f09439707ad80081d340d1593cd54a33a0113f3ccb3f4bc9451488780ee23
+  languageName: node
+  linkType: hard
+
+"pseudoizer@npm:^0.1.0":
+  version: 0.1.0
+  resolution: "pseudoizer@npm:0.1.0"
+  checksum: 10/fd3fa95ea4f330f268cad2388f3829e4c29249e7ffea970467b9123f1ef2a81334e92425c5cad0c72ab04c320203501b65ae86aa8d88320b63e0e75e944c6e76
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
It accidentally got cut in https://github.com/grafana/grafana/pull/86951

We do have a CI step that would catch this missing dep, but due to ongoing i18n issues, we allow that step to fail, which allowed it to sneak through.