### PR TITLE
Plugins: Catalog to show all plugins by default

### DIFF
--- a/.betterer.results
+++ b/.betterer.results
@@ -3725,9 +3725,6 @@ exports[`better eslint`] = {
       [0, 0, 0, "Do not re-export imported variable (\`./localPlugin.mock\`)", "1"],
       [0, 0, 0, "Do not use export all (\`export * from ...\`)", "2"]
     ],
-    "public/app/features/plugins/admin/components/Badges/PluginEnterpriseBadge.tsx:5381": [
-      [0, 0, 0, "\'HorizontalGroup\' import from \'@grafana/ui\' is restricted from being used by a pattern. Use Stack component instead.", "0"]
-    ],
     "public/app/features/plugins/admin/components/Badges/PluginUpdateAvailableBadge.tsx:5381": [
       [0, 0, 0, "Styles should be written using objects.", "0"]
     ],

--- a/docs/sources/administration/plugin-management/index.md
+++ b/docs/sources/administration/plugin-management/index.md
@@ -91,15 +91,16 @@ Administrators can find the Plugin catalog at **Administration > Plugins and dat
 
 To browse for available plugins:
 
-1. In Grafana, click **Administration > Plugins and data > Plugins** in the side navigation menu to view installed and available plugins.
-1. Use the search to filter based on name, keywords, organization and other metadata.
+1. In Grafana, click **Administration > Plugins and data > Plugins** in the side navigation menu to view installed plugins.
+1. Click the **All** filter to browse all available plugins.
 1. Click the **Data sources**, **Panels**, or **Applications** buttons to filter by plugin type.
 
 ### Install a plugin
 
 To install a plugin:
 
-1. In Grafana, click **Administration > Plugins and data > Plugins** in the side navigation menu to view all plugins.
+1. In Grafana, click **Administration > Plugins and data > Plugins** in the side navigation menu to view installed plugins.
+1. Click the **All** filter to browse all available plugins.
 1. Browse and find a plugin.
 1. Click on the plugin logo.
 1. Click **Install**.
@@ -110,8 +111,7 @@ When the update is complete, you see a confirmation message that the installatio
 
 To update a plugin:
 
-1. In Grafana, click **Administration > Plugins and data > Plugins** in the side navigation menu to view all plugins.
-1. Click the **Installed** filter to show only installed plugins.
+1. In Grafana, click **Administration > Plugins and data > Plugins** in the side navigation menu to view installed plugins.
 1. Click on the plugin logo.
 1. Click **Update**.
 
@@ -121,8 +121,7 @@ When the update is complete, you see a confirmation message that the update was 
 
 To uninstall a plugin:
 
-1. In Grafana, click **Administration > Plugins and data > Plugins** in the side navigation menu to view all plugins.
-1. Click the **Installed** filter to show only installed plugins.
+1. In Grafana, click **Administration > Plugins and data > Plugins** in the side navigation menu to view installed plugins.
 1. Click on the plugin logo.
 1. Click **Uninstall**.
 

--- a/docs/sources/administration/plugin-management/index.md
+++ b/docs/sources/administration/plugin-management/index.md
@@ -91,16 +91,15 @@ Administrators can find the Plugin catalog at **Administration > Plugins and dat
 
 To browse for available plugins:
 
-1. In Grafana, click **Administration > Plugins and data > Plugins** in the side navigation menu to view installed plugins.
-1. Click the **All** filter to browse all available plugins.
+1. In Grafana, click **Administration > Plugins and data > Plugins** in the side navigation menu to view installed and available plugins.
+1. Use the search to filter based on name, keywords, organization and other metadata.
 1. Click the **Data sources**, **Panels**, or **Applications** buttons to filter by plugin type.
 
 ### Install a plugin
 
 To install a plugin:
 
-1. In Grafana, click **Administration > Plugins and data > Plugins** in the side navigation menu to view installed plugins.
-1. Click the **All** filter to browse all available plugins.
+1. In Grafana, click **Administration > Plugins and data > Plugins** in the side navigation menu to view all plugins.
 1. Browse and find a plugin.
 1. Click on the plugin logo.
 1. Click **Install**.
@@ -111,7 +110,8 @@ When the update is complete, you see a confirmation message that the installatio
 
 To update a plugin:
 
-1. In Grafana, click **Administration > Plugins and data > Plugins** in the side navigation menu to view installed plugins.
+1. In Grafana, click **Administration > Plugins and data > Plugins** in the side navigation menu to view all plugins.
+1. Click the **Installed** filter to show only installed plugins.
 1. Click on the plugin logo.
 1. Click **Update**.
 
@@ -121,7 +121,8 @@ When the update is complete, you see a confirmation message that the update was 
 
 To uninstall a plugin:
 
-1. In Grafana, click **Administration > Plugins and data > Plugins** in the side navigation menu to view installed plugins.
+1. In Grafana, click **Administration > Plugins and data > Plugins** in the side navigation menu to view all plugins.
+1. Click the **Installed** filter to show only installed plugins.
 1. Click on the plugin logo.
 1. Click **Uninstall**.
 

--- a/public/app/features/plugins/admin/components/Badges/PluginEnterpriseBadge.tsx
+++ b/public/app/features/plugins/admin/components/Badges/PluginEnterpriseBadge.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import { featureEnabled } from '@grafana/runtime';
-import { Badge, PluginSignatureBadge, Stack, TextLink, useStyles2 } from '@grafana/ui';
+import { Badge, PluginSignatureBadge, Stack, useStyles2 } from '@grafana/ui';
 
 import { CatalogPlugin } from '../../types';
 
@@ -27,13 +27,6 @@ export function PluginEnterpriseBadge({ plugin }: Props): React.ReactElement {
         color="blue"
         className={customBadgeStyles}
       />
-      <TextLink
-        external={true}
-        inline={false}
-        href={`https://grafana.com/grafana/plugins/${plugin.id}?utm_source=grafana_catalog_learn_more`}
-      >
-        Learn more
-      </TextLink>
     </Stack>
   );
 }

--- a/public/app/features/plugins/admin/components/Badges/PluginEnterpriseBadge.tsx
+++ b/public/app/features/plugins/admin/components/Badges/PluginEnterpriseBadge.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import { featureEnabled } from '@grafana/runtime';
-import { Badge, Button, PluginSignatureBadge, Stack, useStyles2 } from '@grafana/ui';
+import { Badge, PluginSignatureBadge, Stack, TextLink, useStyles2 } from '@grafana/ui';
 
 import { CatalogPlugin } from '../../types';
 
@@ -11,14 +11,6 @@ type Props = { plugin: CatalogPlugin };
 
 export function PluginEnterpriseBadge({ plugin }: Props): React.ReactElement {
   const customBadgeStyles = useStyles2(getBadgeColor);
-  const onClick = (ev: React.MouseEvent<HTMLButtonElement, MouseEvent>) => {
-    ev.preventDefault();
-    window.open(
-      `https://grafana.com/grafana/plugins/${plugin.id}?utm_source=grafana_catalog_learn_more`,
-      '_blank',
-      'noopener,noreferrer'
-    );
-  };
 
   if (featureEnabled('enterprise.plugins')) {
     return <Badge text="Enterprise" color="blue" />;
@@ -35,9 +27,13 @@ export function PluginEnterpriseBadge({ plugin }: Props): React.ReactElement {
         color="blue"
         className={customBadgeStyles}
       />
-      <Button size="sm" fill="text" icon="external-link-alt" onClick={onClick}>
+      <TextLink
+        external={true}
+        inline={false}
+        href={`https://grafana.com/grafana/plugins/${plugin.id}?utm_source=grafana_catalog_learn_more`}
+      >
         Learn more
-      </Button>
+      </TextLink>
     </Stack>
   );
 }

--- a/public/app/features/plugins/admin/components/Badges/PluginEnterpriseBadge.tsx
+++ b/public/app/features/plugins/admin/components/Badges/PluginEnterpriseBadge.tsx
@@ -27,7 +27,7 @@ export function PluginEnterpriseBadge({ plugin }: Props): React.ReactElement {
   return (
     <HorizontalGroup>
       <PluginSignatureBadge status={plugin.signature} />
-      <Badge icon="lock" aria-label="lock icon" text="Enterprise" color="blue" className={customBadgeStyles} />
+      <Badge icon="lock" text="Enterprise" color="blue" className={customBadgeStyles} />
       <Button size="sm" fill="text" icon="external-link-alt" onClick={onClick}>
         Learn more
       </Button>

--- a/public/app/features/plugins/admin/components/Badges/PluginEnterpriseBadge.tsx
+++ b/public/app/features/plugins/admin/components/Badges/PluginEnterpriseBadge.tsx
@@ -27,7 +27,14 @@ export function PluginEnterpriseBadge({ plugin }: Props): React.ReactElement {
   return (
     <Stack wrap={'wrap'}>
       <PluginSignatureBadge status={plugin.signature} />
-      <Badge icon="lock" role="img" aria-label="lock icon" text="Enterprise" color="blue" className={customBadgeStyles} />
+      <Badge
+        icon="lock"
+        role="img"
+        aria-label="lock icon"
+        text="Enterprise"
+        color="blue"
+        className={customBadgeStyles}
+      />
       <Button size="sm" fill="text" icon="external-link-alt" onClick={onClick}>
         Learn more
       </Button>

--- a/public/app/features/plugins/admin/components/Badges/PluginEnterpriseBadge.tsx
+++ b/public/app/features/plugins/admin/components/Badges/PluginEnterpriseBadge.tsx
@@ -26,6 +26,7 @@ export function PluginEnterpriseBadge({ plugin }: Props): React.ReactElement {
         text="Enterprise"
         color="blue"
         className={customBadgeStyles}
+        title="Requires a Grafana Enterprise license"
       />
     </Stack>
   );

--- a/public/app/features/plugins/admin/components/Badges/PluginEnterpriseBadge.tsx
+++ b/public/app/features/plugins/admin/components/Badges/PluginEnterpriseBadge.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import { featureEnabled } from '@grafana/runtime';
-import { Badge, Button, HorizontalGroup, PluginSignatureBadge, useStyles2 } from '@grafana/ui';
+import { Badge, Button, PluginSignatureBadge, Stack, useStyles2 } from '@grafana/ui';
 
 import { CatalogPlugin } from '../../types';
 
@@ -25,12 +25,12 @@ export function PluginEnterpriseBadge({ plugin }: Props): React.ReactElement {
   }
 
   return (
-    <HorizontalGroup>
+    <Stack wrap={'wrap'}>
       <PluginSignatureBadge status={plugin.signature} />
-      <Badge icon="lock" text="Enterprise" color="blue" className={customBadgeStyles} />
+      <Badge icon="lock" role="img" aria-label="lock icon" text="Enterprise" color="blue" className={customBadgeStyles} />
       <Button size="sm" fill="text" icon="external-link-alt" onClick={onClick}>
         Learn more
       </Button>
-    </HorizontalGroup>
+    </Stack>
   );
 }

--- a/public/app/features/plugins/admin/components/PluginListItem.tsx
+++ b/public/app/features/plugins/admin/components/PluginListItem.tsx
@@ -152,7 +152,7 @@ export const getStyles = (theme: GrafanaTheme2) => {
       color: theme.colors.text.primary,
       margin: 0,
       wordBreak: 'normal',
-      overflowWrap: 'anywhere'
+      overflowWrap: 'anywhere',
     }),
   };
 };

--- a/public/app/features/plugins/admin/components/PluginListItem.tsx
+++ b/public/app/features/plugins/admin/components/PluginListItem.tsx
@@ -151,6 +151,8 @@ export const getStyles = (theme: GrafanaTheme2) => {
       fontSize: theme.typography.h4.fontSize,
       color: theme.colors.text.primary,
       margin: 0,
+      wordBreak: 'normal',
+      overflowWrap: 'anywhere'
     }),
   };
 };

--- a/public/app/features/plugins/admin/components/PluginListItemBadges.test.tsx
+++ b/public/app/features/plugins/admin/components/PluginListItemBadges.test.tsx
@@ -60,12 +60,11 @@ describe('PluginListItemBadges', () => {
     expect(screen.queryByRole('button', { name: /learn more/i })).not.toBeInTheDocument();
   });
 
-  it('renders an enterprise badge with icon and link (when a license is invalid)', () => {
+  it('renders an enterprise badge with icon (when a license is invalid)', () => {
     config.licenseInfo.enabledFeatures = {};
     render(<PluginListItemBadges plugin={{ ...plugin, isEnterprise: true }} />);
     expect(screen.getByText(/enterprise/i)).toBeVisible();
     expect(screen.getByLabelText(/lock icon/i)).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: /learn more/i })).toBeInTheDocument();
   });
 
   it('renders a error badge (when plugin has an error)', () => {

--- a/public/app/features/plugins/admin/pages/Browse.test.tsx
+++ b/public/app/features/plugins/admin/pages/Browse.test.tsx
@@ -45,20 +45,22 @@ const renderBrowse = (
 
 describe('Browse list of plugins', () => {
   describe('when filtering', () => {
-    it('should list installed plugins by default', async () => {
+    it('should list all plugins (including core plugins) by default', async () => {
       const { queryByText } = renderBrowse('/plugins', [
         getCatalogPluginMock({ id: 'plugin-1', name: 'Plugin 1', isInstalled: true }),
         getCatalogPluginMock({ id: 'plugin-2', name: 'Plugin 2', isInstalled: true }),
-        getCatalogPluginMock({ id: 'plugin-3', name: 'Plugin 3', isInstalled: true }),
-        getCatalogPluginMock({ id: 'plugin-4', name: 'Plugin 4', isInstalled: false }),
+        getCatalogPluginMock({ id: 'plugin-3', name: 'Plugin 3', isInstalled: false }),
+        getCatalogPluginMock({ id: 'plugin-4', name: 'Plugin 4', isInstalled: true, isCore: true }),
       ]);
 
       await waitFor(() => expect(queryByText('Plugin 1')).toBeInTheDocument());
-      expect(queryByText('Plugin 1')).toBeInTheDocument();
-      expect(queryByText('Plugin 2')).toBeInTheDocument();
+      expect(queryByText('Plugin 2')).toBeInTheDocument();      
+      
+      // Plugins which are not installed should still be listed    
       expect(queryByText('Plugin 3')).toBeInTheDocument();
-
-      expect(queryByText('Plugin 4')).toBeNull();
+      
+      // Core plugins should still be listed
+      expect(queryByText('Plugin 4')).toBeInTheDocument();
     });
 
     it('should list all plugins (including core plugins) when filtering by all', async () => {

--- a/public/app/features/plugins/admin/pages/Browse.test.tsx
+++ b/public/app/features/plugins/admin/pages/Browse.test.tsx
@@ -54,11 +54,11 @@ describe('Browse list of plugins', () => {
       ]);
 
       await waitFor(() => expect(queryByText('Plugin 1')).toBeInTheDocument());
-      expect(queryByText('Plugin 2')).toBeInTheDocument();      
-      
-      // Plugins which are not installed should still be listed    
+      expect(queryByText('Plugin 2')).toBeInTheDocument();
+
+      // Plugins which are not installed should still be listed
       expect(queryByText('Plugin 3')).toBeInTheDocument();
-      
+
       // Core plugins should still be listed
       expect(queryByText('Plugin 4')).toBeInTheDocument();
     });

--- a/public/app/features/plugins/admin/pages/Browse.tsx
+++ b/public/app/features/plugins/admin/pages/Browse.tsx
@@ -28,7 +28,7 @@ export default function Browse({ route }: GrafanaRouteComponentProps): ReactElem
   const history = useHistory();
   const remotePluginsAvailable = useIsRemotePluginsAvailable();
   const keyword = locationSearch.q?.toString() || '';
-  const filterBy = locationSearch.filterBy?.toString() || 'installed';
+  const filterBy = locationSearch.filterBy?.toString() || 'all';
   const filterByType = (locationSearch.filterByType as PluginType | 'all') || 'all';
   const sortBy = (locationSearch.sortBy as Sorters) || Sorters.nameAsc;
   const { isLoading, error, plugins } = useGetAll(


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

Changes the default behaviour in the plugin catalog to show all plugins rather than only those which are installed. 

**Why do we need this feature?**

We've noticed many users trip up over this, particularly when trying to find and install a new plugin.

**Who is this feature for?**

Administrators

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Whilst addressing this change we switched out HorizontalGroup (deprecated) for Stack and encountered a11y issues with the Learn More link for Enterprise plugins. For the latter, I've removed this as it also caused issues with nested anchors - the link is available on the plugin details page, and is relatively low traffic.

Please check that:
- [x] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle.
- [x] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
