### PR TITLE
DashboardScene: Remove min height on viz picker scroll container

### DIFF
--- a/public/app/features/dashboard-scene/panel-edit/PanelVizTypePicker.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelVizTypePicker.tsx
@@ -73,7 +73,7 @@ export function PanelVizTypePicker({ vizManager, data, onChange }: Props) {
       <Field className={styles.customFieldMargin}>
         <RadioButtonGroup options={radioOptions} value={listMode} onChange={setListMode} fullWidth />
       </Field>
-      <CustomScrollbar autoHeightMin="100%">
+      <CustomScrollbar>
         {listMode === VisualizationSelectPaneTab.Visualizations && (
           <VizTypePicker pluginId={panel.state.pluginId} searchQuery={searchQuery} onChange={onVizTypeChange} />
         )}


### PR DESCRIPTION
removed `minHeight` property from scrollbars which would hide part of scroll container in overflow.
Additionally tested with empty list and small list and it worked as expected.
 
Fixes #87133

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
