### PR TITLE
DashboardQueryEditor: Adjust options filtering in scenes

### DIFF
--- a/public/app/plugins/datasource/dashboard/DashboardQueryEditor.tsx
+++ b/public/app/plugins/datasource/dashboard/DashboardQueryEditor.tsx
@@ -10,6 +10,7 @@ import { Field, Select, useStyles2, Spinner, RadioButtonGroup, Stack, InlineSwit
 import config from 'app/core/config';
 import { getDashboardSrv } from 'app/features/dashboard/services/DashboardSrv';
 import { PanelModel } from 'app/features/dashboard/state';
+import { DashboardScene } from 'app/features/dashboard-scene/scene/DashboardScene';
 import { getDatasourceSrv } from 'app/features/plugins/datasource_srv';
 import { filterPanelDataToQuery } from 'app/features/query/components/QueryEditorRow';
 
@@ -18,6 +19,14 @@ import { DashboardQuery, ResultInfo, SHARED_DASHBOARD_QUERY } from './types';
 
 function getQueryDisplayText(query: DataQuery): string {
   return JSON.stringify(query);
+}
+
+function isPanelInEdit(panelId: number, panelInEditId?: number) {
+  let idToCompareWith = panelInEditId;
+  if (window.__grafanaSceneContext && window.__grafanaSceneContext instanceof DashboardScene) {
+    idToCompareWith = window.__grafanaSceneContext.state.editPanel?.state.panelId;
+  }
+  return panelId === idToCompareWith;
 }
 
 interface Props extends QueryEditorProps<DashboardDatasource, DashboardQuery> {}
@@ -111,7 +120,7 @@ export function DashboardQueryEditor({ data, query, onChange, onRunQuery }: Prop
           (panel) =>
             config.panels[panel.type] &&
             panel.targets &&
-            panel.id !== dashboard.panelInEdit?.id &&
+            !isPanelInEdit(panel.id, dashboard.panelInEdit?.id) &&
             panel.datasource?.uid !== SHARED_DASHBOARD_QUERY
         )
         .map((panel) => ({


### PR DESCRIPTION
Extract currently edited panel id from global scenes context when its available

Fixes #87135

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
