### PR TITLE
CloudWatch: Fix apostrophes in dimension values not being escaped

### DIFF
--- a/pkg/tsdb/cloudwatch/metric_data_query_builder.go
+++ b/pkg/tsdb/cloudwatch/metric_data_query_builder.go
@@ -99,7 +99,7 @@ func buildSearchExpression(query *models.CloudWatchQuery, stat string) string {
 	}
 	sort.Strings(keys)
 	for _, key := range keys {
-		values := escapeDoubleQuotes(knownDimensions[key])
+		values := escapeQuotes(knownDimensions[key])
 		valueExpression := join(values, " OR ", `"`, `"`)
 		if len(knownDimensions[key]) > 1 {
 			valueExpression = fmt.Sprintf(`(%s)`, valueExpression)
@@ -150,10 +150,11 @@ func buildSearchExpressionLabel(query *models.CloudWatchQuery) string {
 	return label
 }
 
-func escapeDoubleQuotes(arr []string) []string {
+func escapeQuotes(arr []string) []string {
 	result := []string{}
 	for _, value := range arr {
 		value = strings.ReplaceAll(value, `"`, `\"`)
+		value = strings.ReplaceAll(value, `'`, `\'`)
 		result = append(result, value)
 	}
 

--- a/pkg/tsdb/cloudwatch/metric_data_query_builder_test.go
+++ b/pkg/tsdb/cloudwatch/metric_data_query_builder_test.go
@@ -472,7 +472,7 @@ func TestMetricDataQueryBuilder(t *testing.T) {
 			Namespace:  "AWS/EC2",
 			MetricName: "CPUUtilization",
 			Dimensions: map[string][]string{
-				"lb4": {`lb4""`},
+				"lb4": {`lb4's""'`},
 			},
 			Period:     300,
 			Expression: "",
@@ -480,7 +480,7 @@ func TestMetricDataQueryBuilder(t *testing.T) {
 		}
 		res := buildSearchExpression(query, "Average")
 
-		assert.Contains(t, res, `lb4\"\"`, "Expected escape double quotes")
+		assert.Contains(t, res, `lb4\'s\"\"\'`, "Expected escaped quotes")
 	})
 }
 


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

Escape apostrophes in dimensions values

**Why do we need this feature?**

Using dimension values with an `'` causes a syntax error in the builder mode because we don't escape `'` characters.

**Who is this feature for?**

[Add information on what kind of user the feature is for.]

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #86547

**Special notes for your reviewer:**

Use the provisioned cross-account cloudwatch data source and use the following metric search queries.

Code mode query
```sql
REMOVE_EMPTY(SEARCH('Namespace="ATestNameSpace" MetricName="importanttestmetric" "someGreatDimension"="Something\'sCool"', 'Average', 60))
```

<img width="819" alt="Screenshot 2024-05-01 at 7 39 18 AM" src="https://github.com/grafana/grafana/assets/19530599/6f68f9c1-aad2-4d5f-adcb-059b8c6ef5b7">

I checked https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/cloudwatch-metrics-insights-querylanguage.html#cloudwatch-metrics-insights-syntaxdetails to check if we needed to escape any other characters, but it only mentions double and single quotes needing escaping.

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
