### PR TITLE
Logs: Explore panel default visualization feature flag

### DIFF
--- a/docs/sources/setup-grafana/configure-grafana/feature-toggles/index.md
+++ b/docs/sources/setup-grafana/configure-grafana/feature-toggles/index.md
@@ -177,6 +177,7 @@ Experimental features might be changed or removed without prior notice.
 | `accessActionSets`                          | Introduces action sets for resource permissions                                                                                                                                                                                                                                   |
 | `disableNumericMetricsSortingInExpressions` | In server-side expressions, disable the sorting of numeric-kind metrics by their metric name or labels.                                                                                                                                                                           |
 | `queryLibrary`                              | Enables Query Library feature in Explore                                                                                                                                                                                                                                          |
+| `logsExploreTableDefaultVisualization`      | Sets the logs table as default visualisation in logs explore                                                                                                                                                                                                                      |
 
 ## Development feature toggles
 

--- a/packages/grafana-data/src/types/featureToggles.gen.ts
+++ b/packages/grafana-data/src/types/featureToggles.gen.ts
@@ -181,4 +181,5 @@ export interface FeatureToggles {
   disableNumericMetricsSortingInExpressions?: boolean;
   grafanaManagedRecordingRules?: boolean;
   queryLibrary?: boolean;
+  logsExploreTableDefaultVisualization?: boolean;
 }

--- a/pkg/services/featuremgmt/registry.go
+++ b/pkg/services/featuremgmt/registry.go
@@ -1219,6 +1219,13 @@ var (
 			FrontendOnly:   false,
 			AllowSelfServe: false,
 		},
+		{
+			Name:         "logsExploreTableDefaultVisualization",
+			Description:  "Sets the logs table as default visualisation in logs explore",
+			Stage:        FeatureStageExperimental,
+			Owner:        grafanaObservabilityLogsSquad,
+			FrontendOnly: true,
+		},
 	}
 )
 

--- a/pkg/services/featuremgmt/toggles_gen.csv
+++ b/pkg/services/featuremgmt/toggles_gen.csv
@@ -162,3 +162,4 @@ accessActionSets,experimental,@grafana/identity-access-team,false,false,false
 disableNumericMetricsSortingInExpressions,experimental,@grafana/observability-metrics,false,true,false
 grafanaManagedRecordingRules,experimental,@grafana/alerting-squad,false,false,false
 queryLibrary,experimental,@grafana/explore-squad,false,false,false
+logsExploreTableDefaultVisualization,experimental,@grafana/observability-logs,false,false,true

--- a/pkg/services/featuremgmt/toggles_gen.go
+++ b/pkg/services/featuremgmt/toggles_gen.go
@@ -658,4 +658,8 @@ const (
 	// FlagQueryLibrary
 	// Enables Query Library feature in Explore
 	FlagQueryLibrary = "queryLibrary"
+
+	// FlagLogsExploreTableDefaultVisualization
+	// Sets the logs table as default visualisation in logs explore
+	FlagLogsExploreTableDefaultVisualization = "logsExploreTableDefaultVisualization"
 )

--- a/pkg/services/featuremgmt/toggles_gen.json
+++ b/pkg/services/featuremgmt/toggles_gen.json
@@ -2103,6 +2103,22 @@
         "stage": "experimental",
         "codeowner": "@grafana/explore-squad"
       }
+    },
+    {
+      "metadata": {
+        "name": "logsExploreTableDefaultVisualization",
+        "resourceVersion": "1714583478121",
+        "creationTimestamp": "2024-05-01T17:05:57Z",
+        "annotations": {
+          "grafana.app/updatedTimestamp": "2024-05-01 17:11:18.121837 +0000 UTC"
+        }
+      },
+      "spec": {
+        "description": "Sets the logs table as default visualisation in logs explore",
+        "stage": "experimental",
+        "codeowner": "@grafana/observability-logs",
+        "frontend": true
+      }
     }
   ]
 }

--- a/public/app/features/explore/Logs/Logs.tsx
+++ b/public/app/features/explore/Logs/Logs.tsx
@@ -144,6 +144,9 @@ const getDefaultVisualisationType = (): LogsVisualisationType => {
   if (visualisationType === 'table') {
     return 'table';
   }
+  if (visualisationType === 'logs') {
+    return 'logs';
+  }
   return 'logs';
 };
 

--- a/public/app/features/explore/Logs/Logs.tsx
+++ b/public/app/features/explore/Logs/Logs.tsx
@@ -147,6 +147,9 @@ const getDefaultVisualisationType = (): LogsVisualisationType => {
   if (visualisationType === 'logs') {
     return 'logs';
   }
+  if (config.featureToggles.logsExploreTableDefaultVisualization) {
+    return 'table';
+  }
   return 'logs';
 };
 

--- a/public/app/features/explore/Logs/Logs.tsx
+++ b/public/app/features/explore/Logs/Logs.tsx
@@ -296,6 +296,7 @@ class UnthemedLogs extends PureComponent<Props, State> {
     reportInteraction('grafana_explore_logs_visualisation_changed', {
       newVisualizationType: visualisation,
       datasourceType: this.props.datasourceType ?? 'unknown',
+      defaultVisualisationType: config.featureToggles.logsExploreTableDefaultVisualization ? 'table' : 'logs',
     });
   };
 

--- a/public/app/features/explore/state/query.ts
+++ b/public/app/features/explore/state/query.ts
@@ -665,6 +665,7 @@ export const runQueries = createAsyncThunk<void, RunQueriesOptions>(
               visualisationType:
                 exploreState?.panelsState?.logs?.visualisationType ?? store.get(visualisationTypeKey) ?? 'N/A',
               length: data.logsResult.rows.length,
+              defaultVisualisationType: config.featureToggles.logsExploreTableDefaultVisualization ? 'table' : 'logs',
             });
           }
           dispatch(queryStreamUpdatedAction({ exploreId, response: data }));


### PR DESCRIPTION
**What is this feature?**

Adding a new `logsExploreTableDefaultVisualization` feature flag, that sets the initial visualization to the logs table.

**Why do we need this feature?**
Feedback from customers and feedback form has been positive, but usage is still quite low. We'd like to start turning the table viz on by default in cloud to see if users have the same positive experience as early adopters.

**Who is this feature for?**
Users of logs visualization in explore

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
