### PR TITLE
fix: sql expressions - sql parser table name case

### DIFF
--- a/pkg/expr/sql/parser.go
+++ b/pkg/expr/sql/parser.go
@@ -58,12 +58,12 @@ func parseTables(rawSQL string) ([]string, error) {
 		tokens := strings.Split(rawSQL, " ")
 		checkNext := false
 		takeNext := false
-		for _, t := range tokens {
-			t = strings.ToUpper(t)
+		for _, token := range tokens {
+			t := strings.ToUpper(token)
 			t = strings.TrimSpace(t)
 
 			if takeNext {
-				tables = append(tables, t)
+				tables = append(tables, token)
 				checkNext = false
 				takeNext = false
 				continue
@@ -74,7 +74,7 @@ func parseTables(rawSQL string) ([]string, error) {
 					continue
 				}
 				if strings.Contains(t, ",") {
-					values := strings.Split(t, ",")
+					values := strings.Split(token, ",")
 					for _, v := range values {
 						v := strings.TrimSpace(v)
 						if v != "" {
@@ -86,7 +86,7 @@ func parseTables(rawSQL string) ([]string, error) {
 					}
 					continue
 				}
-				tables = append(tables, t)
+				tables = append(tables, token)
 				checkNext = false
 			}
 			if t == "FROM" {

--- a/pkg/expr/sql/parser.go
+++ b/pkg/expr/sql/parser.go
@@ -26,12 +26,15 @@ func TablesList(rawSQL string) ([]string, error) {
 			buf := sqlparser.NewTrackedBuffer(nil)
 			t.Format(buf)
 			table := buf.String()
-			if table != "dual" {
+			if table != "dual" && !strings.HasPrefix(table, "(") {
 				tables = append(tables, buf.String())
 			}
 		}
 	default:
-		return nil, errors.New("not a select statement")
+		return parseTables(rawSQL)
+	}
+	if len(tables) == 0 {
+		return parseTables(rawSQL)
 	}
 	return tables, nil
 }

--- a/pkg/expr/sql/parser.go
+++ b/pkg/expr/sql/parser.go
@@ -101,7 +101,7 @@ func parseTables(rawSQL string) ([]string, error) {
 						v := strings.TrimSpace(v)
 						if v != "" {
 							if !existsInList(token, tables) {
-								tables = append(tables, token)
+								tables = append(tables, v)
 							}
 						} else {
 							takeNext = true

--- a/pkg/expr/sql/parser.go
+++ b/pkg/expr/sql/parser.go
@@ -53,6 +53,7 @@ func parse(rawSQL string) ([]string, error) {
 
 func parseTables(rawSQL string) ([]string, error) {
 	checkSql := strings.ToUpper(rawSQL)
+	rawSQL = strings.ReplaceAll(rawSQL, "\n", " ")
 	if strings.HasPrefix(checkSql, "SELECT") || strings.HasPrefix(rawSQL, "WITH") {
 		tables := []string{}
 		tokens := strings.Split(rawSQL, " ")

--- a/pkg/expr/sql/parser_test.go
+++ b/pkg/expr/sql/parser_test.go
@@ -57,7 +57,7 @@ func TestXxx(t *testing.T) {
 	assert.Equal(t, 0, len(tables))
 }
 
-func TestParseTable(t *testing.T) {
+func TestParseSubquery(t *testing.T) {
 	sql := "select * from (select * from people limit 1)"
 	tables, err := TablesList((sql))
 	assert.Nil(t, err)

--- a/pkg/expr/sql/parser_test.go
+++ b/pkg/expr/sql/parser_test.go
@@ -11,7 +11,7 @@ func TestParse(t *testing.T) {
 	tables, err := parseTables((sql))
 	assert.Nil(t, err)
 
-	assert.Equal(t, "FOO", tables[0])
+	assert.Equal(t, "foo", tables[0])
 }
 
 func TestParseWithComma(t *testing.T) {
@@ -19,8 +19,8 @@ func TestParseWithComma(t *testing.T) {
 	tables, err := parseTables((sql))
 	assert.Nil(t, err)
 
-	assert.Equal(t, "FOO", tables[0])
-	assert.Equal(t, "BAR", tables[1])
+	assert.Equal(t, "foo", tables[0])
+	assert.Equal(t, "bar", tables[1])
 }
 
 func TestParseWithCommas(t *testing.T) {
@@ -28,9 +28,9 @@ func TestParseWithCommas(t *testing.T) {
 	tables, err := parseTables((sql))
 	assert.Nil(t, err)
 
-	assert.Equal(t, "FOO", tables[0])
-	assert.Equal(t, "BAR", tables[1])
-	assert.Equal(t, "BAZ", tables[2])
+	assert.Equal(t, "foo", tables[0])
+	assert.Equal(t, "bar", tables[1])
+	assert.Equal(t, "baz", tables[2])
 }
 
 func TestArray(t *testing.T) {
@@ -55,4 +55,13 @@ func TestXxx(t *testing.T) {
 	assert.Nil(t, err)
 
 	assert.Equal(t, 0, len(tables))
+}
+
+func TestParseTable(t *testing.T) {
+	sql := "select * from (select * from people limit 1)"
+	tables, err := TablesList((sql))
+	assert.Nil(t, err)
+
+	assert.Equal(t, 1, len(tables))
+	assert.Equal(t, "people", tables[0])
 }

--- a/pkg/expr/sql_command.go
+++ b/pkg/expr/sql_command.go
@@ -74,7 +74,11 @@ func (gr *SQLCommand) Execute(ctx context.Context, now time.Time, vars mathexp.V
 
 	allFrames := []*data.Frame{}
 	for _, ref := range gr.varsToQuery {
-		results := vars[ref]
+		results, ok := vars[ref]
+		if !ok {
+			logger.Warn("no results found for", "ref", ref)
+			continue
+		}
 		frames := results.Values.AsDataFrames(ref)
 		allFrames = append(allFrames, frames...)
 	}


### PR DESCRIPTION
**What is this fix?**

Fixes an issue with Sql expressions where the query ref name was being uppercased.  Uppercasing caused a mismatch between the table name and the key in vars.

**Why do we need this feature?**

Fixes a bug with sql expressions.

**Who is this feature for?**

Anyone using Sql expressions
