### PR TITLE
Chore: Fix error handling in postDashboard, remove UserDisplayDTO, fix live redis client initialization

### DIFF
--- a/pkg/api/org_invite.go
+++ b/pkg/api/org_invite.go
@@ -103,8 +103,7 @@ func (hs *HTTPServer) AddOrgInvite(c *contextmodel.ReqContext) response.Response
 
 	namespace, identifier := c.SignedInUser.GetNamespacedID()
 	var userID int64
-	switch namespace {
-	case identity.NamespaceUser, identity.NamespaceServiceAccount:
+	if namespace == identity.NamespaceUser || namespace == identity.NamespaceServiceAccount {
 		var err error
 		userID, err = strconv.ParseInt(identifier, 10, 64)
 		if err != nil {

--- a/pkg/api/user.go
+++ b/pkg/api/user.go
@@ -36,7 +36,7 @@ func (hs *HTTPServer) GetSignedInUser(c *contextmodel.ReqContext) response.Respo
 		return response.JSON(http.StatusOK, user.UserProfileDTO{
 			IsGrafanaAdmin: c.SignedInUser.GetIsGrafanaAdmin(),
 			OrgID:          c.SignedInUser.GetOrgID(),
-			UID:            strings.Join([]string{namespace, identifier}, ":"),
+			UID:            c.SignedInUser.GetID().String(),
 			Name:           c.SignedInUser.NameOrFallback(),
 			Email:          c.SignedInUser.GetEmail(),
 			Login:          c.SignedInUser.GetLogin(),

--- a/pkg/login/social/connectors/gitlab_oauth.go
+++ b/pkg/login/social/connectors/gitlab_oauth.go
@@ -215,7 +215,7 @@ func (s *SocialGitlab) UserInfo(ctx context.Context, client *http.Client, token 
 	return userInfo, nil
 }
 
-func (s *SocialGitlab) extractFromAPI(ctx context.Context, client *http.Client, token *oauth2.Token) (*userData, error) {
+func (s *SocialGitlab) extractFromAPI(ctx context.Context, client *http.Client, _ *oauth2.Token) (*userData, error) {
 	apiResp := &apiData{}
 	response, err := s.httpGet(ctx, client, s.info.ApiUrl+"/user")
 	if err != nil {

--- a/pkg/login/social/connectors/google_oauth.go
+++ b/pkg/login/social/connectors/google_oauth.go
@@ -220,7 +220,7 @@ func (s *SocialGoogle) AuthCodeURL(state string, opts ...oauth2.AuthCodeOption) 
 	return s.SocialBase.Config.AuthCodeURL(state, opts...)
 }
 
-func (s *SocialGoogle) extractFromToken(ctx context.Context, client *http.Client, token *oauth2.Token) (*googleUserData, error) {
+func (s *SocialGoogle) extractFromToken(_ context.Context, _ *http.Client, token *oauth2.Token) (*googleUserData, error) {
 	s.log.Debug("Extracting user info from OAuth token")
 
 	idToken := token.Extra("id_token")

--- a/pkg/services/accesscontrol/accesscontrol.go
+++ b/pkg/services/accesscontrol/accesscontrol.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"strconv"
 	"strings"
 
 	"github.com/grafana/grafana/pkg/registry"
@@ -100,22 +99,18 @@ func (s *SearchOptions) ComputeUserID() (int64, error) {
 	if s.NamespacedID == "" {
 		return 0, errors.New("namespacedID must be set")
 	}
-	// Split namespaceID into namespace and ID
-	parts := strings.Split(s.NamespacedID, ":")
-	// Validate namespace ID format
-	if len(parts) != 2 {
-		return 0, fmt.Errorf("invalid namespaced ID: %s", s.NamespacedID)
-	}
-	// Validate namespace type is user or service account
-	if parts[0] != identity.NamespaceUser && parts[0] != identity.NamespaceServiceAccount {
-		return 0, fmt.Errorf("invalid namespace: %s", parts[0])
-	}
-	// Validate namespace ID is a number
-	id, err := strconv.ParseInt(parts[1], 10, 64)
+
+	id, err := identity.ParseNamespaceID(s.NamespacedID)
 	if err != nil {
-		return 0, fmt.Errorf("invalid namespaced ID: %s", s.NamespacedID)
+		return 0, err
 	}
-	return id, nil
+
+	// Validate namespace type is user or service account
+	if id.Namespace() != identity.NamespaceUser && id.Namespace() != identity.NamespaceServiceAccount {
+		return 0, fmt.Errorf("invalid namespace: %s", id.Namespace())
+	}
+
+	return id.ParseInt()
 }
 
 type SyncUserRolesCommand struct {

--- a/pkg/services/accesscontrol/acimpl/service_test.go
+++ b/pkg/services/accesscontrol/acimpl/service_test.go
@@ -2,6 +2,7 @@ package acimpl
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -537,7 +538,7 @@ func TestService_SearchUsersPermissions(t *testing.T) {
 			// only the user's basic roles and the user's stored permissions
 			name:           "check namespacedId filter works correctly",
 			siuPermissions: listAllPerms,
-			searchOption:   accesscontrol.SearchOptions{NamespacedID: identity.NamespaceServiceAccount + ":1"},
+			searchOption:   accesscontrol.SearchOptions{NamespacedID: fmt.Sprintf("%s:1", identity.NamespaceServiceAccount)},
 			ramRoles: map[string]*accesscontrol.RoleDTO{
 				string(roletype.RoleEditor): {Permissions: []accesscontrol.Permission{
 					{Action: accesscontrol.ActionTeamsRead, Scope: "teams:*"},
@@ -607,7 +608,7 @@ func TestService_SearchUserPermissions(t *testing.T) {
 			name: "ram only",
 			searchOption: accesscontrol.SearchOptions{
 				ActionPrefix: "teams",
-				NamespacedID: identity.NamespaceUser + ":2",
+				NamespacedID: fmt.Sprintf("%s:2", identity.NamespaceUser),
 			},
 			ramRoles: map[string]*accesscontrol.RoleDTO{
 				string(roletype.RoleEditor): {Permissions: []accesscontrol.Permission{
@@ -632,7 +633,7 @@ func TestService_SearchUserPermissions(t *testing.T) {
 			name: "stored only",
 			searchOption: accesscontrol.SearchOptions{
 				ActionPrefix: "teams",
-				NamespacedID: identity.NamespaceUser + ":2",
+				NamespacedID: fmt.Sprintf("%s:2", identity.NamespaceUser),
 			},
 			storedPerms: map[int64][]accesscontrol.Permission{
 				1: {{Action: accesscontrol.ActionTeamsRead, Scope: "teams:id:1"}},
@@ -652,7 +653,7 @@ func TestService_SearchUserPermissions(t *testing.T) {
 			name: "ram and stored",
 			searchOption: accesscontrol.SearchOptions{
 				ActionPrefix: "teams",
-				NamespacedID: identity.NamespaceUser + ":2",
+				NamespacedID: fmt.Sprintf("%s:2", identity.NamespaceUser),
 			},
 			ramRoles: map[string]*accesscontrol.RoleDTO{
 				string(roletype.RoleAdmin): {Permissions: []accesscontrol.Permission{
@@ -682,7 +683,7 @@ func TestService_SearchUserPermissions(t *testing.T) {
 			name: "check action prefix filter works correctly",
 			searchOption: accesscontrol.SearchOptions{
 				ActionPrefix: "teams",
-				NamespacedID: identity.NamespaceUser + ":1",
+				NamespacedID: fmt.Sprintf("%s:1", identity.NamespaceUser),
 			},
 			ramRoles: map[string]*accesscontrol.RoleDTO{
 				string(roletype.RoleEditor): {Permissions: []accesscontrol.Permission{
@@ -704,7 +705,7 @@ func TestService_SearchUserPermissions(t *testing.T) {
 			name: "check action filter works correctly",
 			searchOption: accesscontrol.SearchOptions{
 				Action:       accesscontrol.ActionTeamsRead,
-				NamespacedID: identity.NamespaceUser + ":1",
+				NamespacedID: fmt.Sprintf("%s:1", identity.NamespaceUser),
 			},
 			ramRoles: map[string]*accesscontrol.RoleDTO{
 				string(roletype.RoleEditor): {Permissions: []accesscontrol.Permission{

--- a/pkg/services/accesscontrol/database/database_test.go
+++ b/pkg/services/accesscontrol/database/database_test.go
@@ -549,7 +549,7 @@ func TestIntegrationAccessControlStore_SearchUsersPermissions(t *testing.T) {
 			},
 			options: accesscontrol.SearchOptions{
 				ActionPrefix: "teams:",
-				NamespacedID: identity.NamespaceUser + ":1",
+				NamespacedID: fmt.Sprintf("%s:1", identity.NamespaceUser),
 			},
 			wantPerm: map[int64][]accesscontrol.Permission{
 				1: {{Action: "teams:read", Scope: "teams:id:1"}, {Action: "teams:read", Scope: "teams:id:10"},

--- a/pkg/services/accesscontrol/metadata_bench_test.go
+++ b/pkg/services/accesscontrol/metadata_bench_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func setupTestEnv(b *testing.B, resourceCount, permissionPerResource int) (map[string][]string, map[string]bool) {
+func setupTestEnv(resourceCount, permissionPerResource int) (map[string][]string, map[string]bool) {
 	res := map[string][]string{}
 	ids := make(map[string]bool, resourceCount)
 
@@ -25,7 +25,7 @@ func setupTestEnv(b *testing.B, resourceCount, permissionPerResource int) (map[s
 }
 
 func benchGetMetadata(b *testing.B, resourceCount, permissionPerResource int) {
-	permissions, ids := setupTestEnv(b, resourceCount, permissionPerResource)
+	permissions, ids := setupTestEnv(resourceCount, permissionPerResource)
 	b.ResetTimer()
 
 	var metadata map[string]Metadata

--- a/pkg/services/auth/identity/requester.go
+++ b/pkg/services/auth/identity/requester.go
@@ -13,6 +13,8 @@ type Requester interface {
 	// GetNamespacedID returns the namespace and ID of the active entity.
 	// The namespace is one of the constants defined in pkg/services/auth/identity.
 	GetNamespacedID() (namespace string, identifier string)
+	// GetUserUID returns the user uid for the entity
+	GetUserUID() string
 	// GetDisplayName returns the display name of the active entity.
 	// The display name is the name if it is set, otherwise the login or email.
 	GetDisplayName() string

--- a/pkg/services/auth/identity/requester.go
+++ b/pkg/services/auth/identity/requester.go
@@ -12,9 +12,12 @@ type Requester interface {
 	GetID() NamespaceID
 	// GetNamespacedID returns the namespace and ID of the active entity.
 	// The namespace is one of the constants defined in pkg/services/auth/identity.
-	GetNamespacedID() (namespace string, identifier string)
-	// GetUserUID returns the user uid for the entity
-	GetUserUID() string
+	GetNamespacedID() (namespace Namespace, identifier string)
+	// GetID returns namespaced id for the entity
+	GetUID() NamespaceID
+	// GetNamespacedID returns the namespace and ID of the active entity.
+	// The namespace is one of the constants defined in pkg/services/auth/identity.
+	GetNamespacedUID() (namespace Namespace, identifier string)
 	// GetDisplayName returns the display name of the active entity.
 	// The display name is the name if it is set, otherwise the login or email.
 	GetDisplayName() string
@@ -67,7 +70,7 @@ type Requester interface {
 }
 
 // IsNamespace returns true if namespace matches any expected namespace
-func IsNamespace(namespace string, expected ...string) bool {
+func IsNamespace(namespace Namespace, expected ...Namespace) bool {
 	for _, e := range expected {
 		if namespace == e {
 			return true
@@ -80,7 +83,7 @@ func IsNamespace(namespace string, expected ...string) bool {
 // IntIdentifier converts a string identifier to an int64.
 // Applicable for users, service accounts, api keys and renderer service.
 // Errors if the identifier is not initialized or if namespace is not recognized.
-func IntIdentifier(namespace, identifier string) (int64, error) {
+func IntIdentifier(namespace Namespace, identifier string) (int64, error) {
 	if IsNamespace(namespace, NamespaceUser, NamespaceAPIKey, NamespaceServiceAccount, NamespaceRenderService) {
 		id, err := strconv.ParseInt(identifier, 10, 64)
 		if err != nil {
@@ -100,7 +103,7 @@ func IntIdentifier(namespace, identifier string) (int64, error) {
 // UserIdentifier converts a string identifier to an int64.
 // Errors if the identifier is not initialized or if namespace is not recognized.
 // Returns 0 if the namespace is not user or service account
-func UserIdentifier(namespace, identifier string) (int64, error) {
+func UserIdentifier(namespace Namespace, identifier string) (int64, error) {
 	userID, err := IntIdentifier(namespace, identifier)
 	if err != nil {
 		// FIXME: return this error once entity namespaces are handled by stores

--- a/pkg/services/auth/idimpl/service.go
+++ b/pkg/services/auth/idimpl/service.go
@@ -82,7 +82,7 @@ func (s *Service) SignIdentity(ctx context.Context, id identity.Requester) (stri
 			Claims: jwt.Claims{
 				Issuer:   s.cfg.AppURL,
 				Audience: getAudience(id.GetOrgID()),
-				Subject:  getSubject(namespace, identifier),
+				Subject:  getSubject(namespace.String(), identifier),
 				Expiry:   jwt.NewNumericDate(now.Add(tokenTTL)),
 				IssuedAt: jwt.NewNumericDate(now),
 			},

--- a/pkg/services/authn/authnimpl/service.go
+++ b/pkg/services/authn/authnimpl/service.go
@@ -373,7 +373,7 @@ func (s *Service) resolveIdenity(ctx context.Context, orgID int64, namespaceID a
 			}}, nil
 	}
 
-	resolver, ok := s.idenityResolverClients[namespaceID.Namespace()]
+	resolver, ok := s.idenityResolverClients[namespaceID.Namespace().String()]
 	if !ok {
 		return nil, authn.ErrUnsupportedIdentity.Errorf("no resolver for : %s", namespaceID.Namespace())
 	}

--- a/pkg/services/authn/authnimpl/service_test.go
+++ b/pkg/services/authn/authnimpl/service_test.go
@@ -514,7 +514,7 @@ func TestService_ResolveIdentity(t *testing.T) {
 	t.Run("should resolve for valid namespace if client is registered", func(t *testing.T) {
 		svc := setupTests(t, func(svc *Service) {
 			svc.RegisterClient(&authntest.MockClient{
-				NamespaceFunc: func() string { return authn.NamespaceAPIKey },
+				NamespaceFunc: func() string { return authn.NamespaceAPIKey.String() },
 				ResolveIdentityFunc: func(ctx context.Context, orgID int64, namespaceID authn.NamespaceID) (*authn.Identity, error) {
 					return &authn.Identity{}, nil
 				},

--- a/pkg/services/authn/clients/api_key.go
+++ b/pkg/services/authn/clients/api_key.go
@@ -135,7 +135,7 @@ func (s *APIKey) Priority() uint {
 }
 
 func (s *APIKey) Namespace() string {
-	return authn.NamespaceAPIKey
+	return authn.NamespaceAPIKey.String()
 }
 
 func (s *APIKey) ResolveIdentity(ctx context.Context, orgID int64, namespaceID authn.NamespaceID) (*authn.Identity, error) {

--- a/pkg/services/authn/identity.go
+++ b/pkg/services/authn/identity.go
@@ -79,12 +79,17 @@ func (i *Identity) GetID() NamespaceID {
 	return i.ID
 }
 
-func (i *Identity) GetNamespacedID() (namespace string, identifier string) {
+func (i *Identity) GetNamespacedID() (namespace identity.Namespace, identifier string) {
 	return i.ID.Namespace(), i.ID.ID()
 }
 
-func (i *Identity) GetUserUID() string {
-	return i.UserUID
+func (i *Identity) GetUID() NamespaceID {
+	ns, uid := i.GetNamespacedUID()
+	return identity.NewNamespaceIDString(ns, uid)
+}
+
+func (i *Identity) GetNamespacedUID() (namespace identity.Namespace, identifier string) {
+	return i.ID.Namespace(), i.UserUID
 }
 
 func (i *Identity) GetAuthID() string {

--- a/pkg/services/authn/identity.go
+++ b/pkg/services/authn/identity.go
@@ -71,6 +71,8 @@ type Identity struct {
 	// IDToken is a signed token representing the identity that can be forwarded to plugins and external services.
 	// Will only be set when featuremgmt.FlagIdForwarding is enabled.
 	IDToken string
+	// UserUID is the unique identifier for the entity in the Grafana database.
+	UserUID string
 }
 
 func (i *Identity) GetID() NamespaceID {
@@ -79,6 +81,10 @@ func (i *Identity) GetID() NamespaceID {
 
 func (i *Identity) GetNamespacedID() (namespace string, identifier string) {
 	return i.ID.Namespace(), i.ID.ID()
+}
+
+func (i *Identity) GetUserUID() string {
+	return i.UserUID
 }
 
 func (i *Identity) GetAuthID() string {

--- a/pkg/services/contexthandler/contexthandler.go
+++ b/pkg/services/contexthandler/contexthandler.go
@@ -158,7 +158,7 @@ func (h *ContextHandler) addIDHeaderEndOfRequestFunc(ident identity.Requester) w
 			return
 		}
 
-		if _, ok := h.Cfg.IDResponseHeaderNamespaces[namespace]; !ok {
+		if _, ok := h.Cfg.IDResponseHeaderNamespaces[namespace.String()]; !ok {
 			return
 		}
 

--- a/pkg/services/dashboardimport/service/service.go
+++ b/pkg/services/dashboardimport/service/service.go
@@ -109,12 +109,11 @@ func (s *ImportDashboardService) ImportDashboard(ctx context.Context, req *dashb
 		req.FolderUid = folder.UID
 	}
 
-	namespaceID, identifier := req.User.GetNamespacedID()
+	namespace, identifier := req.User.GetNamespacedID()
 	userID := int64(0)
 
-	switch namespaceID {
-	case identity.NamespaceUser, identity.NamespaceServiceAccount:
-		userID, _ = identity.IntIdentifier(namespaceID, identifier)
+	if namespace == identity.NamespaceUser || namespace == identity.NamespaceServiceAccount {
+		userID, _ = identity.IntIdentifier(namespace, identifier)
 	}
 
 	saveCmd := dashboards.SaveDashboardCommand{

--- a/pkg/services/dashboardsnapshots/database/database.go
+++ b/pkg/services/dashboardsnapshots/database/database.go
@@ -137,8 +137,8 @@ func (d *DashboardSnapshotStore) SearchDashboardSnapshots(ctx context.Context, q
 
 		namespace, id := query.SignedInUser.GetNamespacedID()
 		var userID int64
-		switch namespace {
-		case identity.NamespaceServiceAccount, identity.NamespaceUser:
+
+		if namespace == identity.NamespaceServiceAccount || namespace == identity.NamespaceUser {
 			var err error
 			userID, err = identity.IntIdentifier(namespace, id)
 			if err != nil {

--- a/pkg/services/libraryelements/database.go
+++ b/pkg/services/libraryelements/database.go
@@ -140,8 +140,7 @@ func (l *LibraryElementService) createLibraryElement(c context.Context, signedIn
 
 	userID := int64(0)
 	namespaceID, identifier := signedInUser.GetNamespacedID()
-	switch namespaceID {
-	case identity.NamespaceUser, identity.NamespaceServiceAccount:
+	if namespaceID == identity.NamespaceUser || namespaceID == identity.NamespaceServiceAccount {
 		userID, err = identity.IntIdentifier(namespaceID, identifier)
 		if err != nil {
 			l.log.Warn("Error while parsing userID", "namespaceID", namespaceID, "userID", identifier)
@@ -589,8 +588,7 @@ func (l *LibraryElementService) patchLibraryElement(c context.Context, signedInU
 
 		var userID int64
 		namespaceID, identifier := signedInUser.GetNamespacedID()
-		switch namespaceID {
-		case identity.NamespaceUser, identity.NamespaceServiceAccount:
+		if namespaceID == identity.NamespaceUser || namespaceID == identity.NamespaceServiceAccount {
 			var errID error
 			userID, errID = identity.IntIdentifier(namespaceID, identifier)
 			if errID != nil {
@@ -798,8 +796,7 @@ func (l *LibraryElementService) connectElementsToDashboardID(c context.Context, 
 
 			namespaceID, identifier := signedInUser.GetNamespacedID()
 			userID := int64(0)
-			switch namespaceID {
-			case identity.NamespaceUser, identity.NamespaceServiceAccount:
+			if namespaceID == identity.NamespaceUser || namespaceID == identity.NamespaceServiceAccount {
 				userID, err = identity.IntIdentifier(namespaceID, identifier)
 				if err != nil {
 					l.log.Warn("Failed to parse user ID from namespace identifier", "namespace", namespaceID, "identifier", identifier, "error", err)

--- a/pkg/services/live/features/dashboard.go
+++ b/pkg/services/live/features/dashboard.go
@@ -14,7 +14,6 @@ import (
 	"github.com/grafana/grafana/pkg/services/guardian"
 	"github.com/grafana/grafana/pkg/services/live/model"
 	"github.com/grafana/grafana/pkg/services/org"
-	"github.com/grafana/grafana/pkg/services/user"
 )
 
 type actionType string
@@ -28,11 +27,35 @@ const (
 	GitopsChannel = "grafana/dashboard/gitops"
 )
 
+type userDisplayDTO struct {
+	ID        int64  `json:"id,omitempty"`
+	UID       string `json:"uid,omitempty"`
+	Name      string `json:"name,omitempty"`
+	Login     string `json:"login,omitempty"`
+	AvatarURL string `json:"avatarUrl"`
+}
+
+// Static function to parse a requester into a userDisplayDTO
+func newUserDisplayDTOFromRequester(requester identity.Requester) *userDisplayDTO {
+	userID := int64(0)
+	namespaceID, identifier := requester.GetNamespacedID()
+	if namespaceID == identity.NamespaceUser || namespaceID == identity.NamespaceServiceAccount {
+		userID, _ = identity.IntIdentifier(namespaceID, identifier)
+	}
+
+	return &userDisplayDTO{
+		ID:    userID,
+		UID:   requester.GetUserUID(),
+		Login: requester.GetLogin(),
+		Name:  requester.GetDisplayName(),
+	}
+}
+
 // DashboardEvent events related to dashboards
 type dashboardEvent struct {
 	UID       string                `json:"uid"`
 	Action    actionType            `json:"action"` // saved, editing, deleted
-	User      *user.UserDisplayDTO  `json:"user,omitempty"`
+	User      *userDisplayDTO       `json:"user,omitempty"`
 	SessionID string                `json:"sessionId,omitempty"`
 	Message   string                `json:"message,omitempty"`
 	Dashboard *dashboards.Dashboard `json:"dashboard,omitempty"`
@@ -142,10 +165,7 @@ func (h *DashboardHandler) OnPublish(ctx context.Context, requester identity.Req
 		}
 
 		// Tell everyone who is editing
-		event.User, err = user.NewUserDisplayDTOFromRequester(requester)
-		if err != nil {
-			return model.PublishReply{}, backend.PublishStreamStatusNotFound, err
-		}
+		event.User = newUserDisplayDTOFromRequester(requester)
 
 		msg, err := json.Marshal(event)
 		if err != nil {
@@ -177,7 +197,7 @@ func (h *DashboardHandler) publish(orgID int64, event dashboardEvent) error {
 }
 
 // DashboardSaved will broadcast to all connected dashboards
-func (h *DashboardHandler) DashboardSaved(orgID int64, user *user.UserDisplayDTO, message string, dashboard *dashboards.Dashboard, err error) error {
+func (h *DashboardHandler) DashboardSaved(orgID int64, requester identity.Requester, message string, dashboard *dashboards.Dashboard, err error) error {
 	if err != nil && !h.HasGitOpsObserver(orgID) {
 		return nil // only broadcast if it was OK
 	}
@@ -185,7 +205,7 @@ func (h *DashboardHandler) DashboardSaved(orgID int64, user *user.UserDisplayDTO
 	msg := dashboardEvent{
 		UID:       dashboard.UID,
 		Action:    ActionSaved,
-		User:      user,
+		User:      newUserDisplayDTOFromRequester(requester),
 		Message:   message,
 		Dashboard: dashboard,
 	}
@@ -198,11 +218,11 @@ func (h *DashboardHandler) DashboardSaved(orgID int64, user *user.UserDisplayDTO
 }
 
 // DashboardDeleted will broadcast to all connected dashboards
-func (h *DashboardHandler) DashboardDeleted(orgID int64, user *user.UserDisplayDTO, uid string) error {
+func (h *DashboardHandler) DashboardDeleted(orgID int64, requester identity.Requester, uid string) error {
 	return h.publish(orgID, dashboardEvent{
 		UID:    uid,
 		Action: ActionDeleted,
-		User:   user,
+		User:   newUserDisplayDTOFromRequester(requester),
 	})
 }
 

--- a/pkg/services/live/features/dashboard.go
+++ b/pkg/services/live/features/dashboard.go
@@ -42,10 +42,14 @@ func newUserDisplayDTOFromRequester(requester identity.Requester) *userDisplayDT
 	if namespaceID == identity.NamespaceUser || namespaceID == identity.NamespaceServiceAccount {
 		userID, _ = identity.IntIdentifier(namespaceID, identifier)
 	}
+	namespaceID, uid := requester.GetNamespacedUID()
+	if namespaceID != identity.NamespaceUser && namespaceID != identity.NamespaceServiceAccount {
+		uid = ""
+	}
 
 	return &userDisplayDTO{
 		ID:    userID,
-		UID:   requester.GetUserUID(),
+		UID:   uid,
 		Login: requester.GetLogin(),
 		Name:  requester.GetDisplayName(),
 	}

--- a/pkg/services/live/live.go
+++ b/pkg/services/live/live.go
@@ -54,7 +54,6 @@ import (
 	"github.com/grafana/grafana/pkg/services/pluginsintegration/pluginstore"
 	"github.com/grafana/grafana/pkg/services/query"
 	"github.com/grafana/grafana/pkg/services/secrets"
-	"github.com/grafana/grafana/pkg/services/user"
 	"github.com/grafana/grafana/pkg/setting"
 	"github.com/grafana/grafana/pkg/util"
 	"github.com/grafana/grafana/pkg/util/errutil"
@@ -138,7 +137,7 @@ func ProvideService(plugCtxProvider *plugincontext.Provider, cfg *setting.Cfg, r
 	var managedStreamRunner *managedstream.Runner
 	var redisClient *redis.Client
 	if g.IsHA() && redisHealthy {
-		redisClient := redis.NewClient(&redis.Options{
+		redisClient = redis.NewClient(&redis.Options{
 			Addr:     g.Cfg.LiveHAEngineAddress,
 			Password: g.Cfg.LiveHAEnginePassword,
 		})
@@ -414,10 +413,10 @@ type DashboardActivityChannel interface {
 	// gitops workflow that knows if the value was saved to the local database or not
 	// in many cases all direct save requests will fail, but the request should be forwarded
 	// to any gitops observers
-	DashboardSaved(orgID int64, user *user.UserDisplayDTO, message string, dashboard *dashboards.Dashboard, err error) error
+	DashboardSaved(orgID int64, requester identity.Requester, message string, dashboard *dashboards.Dashboard, err error) error
 
 	// Called when a dashboard is deleted
-	DashboardDeleted(orgID int64, user *user.UserDisplayDTO, uid string) error
+	DashboardDeleted(orgID int64, requester identity.Requester, uid string) error
 
 	// Experimental! Indicate is GitOps is active.  This really means
 	// someone is subscribed to the `grafana/dashboards/gitops` channel

--- a/pkg/services/sqlstore/permissions/dashboard.go
+++ b/pkg/services/sqlstore/permissions/dashboard.go
@@ -136,10 +136,9 @@ func (f *accessControlDashboardPermissionFilter) buildClauses() {
 	folderWildcards := accesscontrol.WildcardsFromPrefix(dashboards.ScopeFoldersPrefix)
 
 	userID := int64(0)
-	namespaceID, identifier := f.user.GetNamespacedID()
-	switch namespaceID {
-	case identity.NamespaceUser, identity.NamespaceServiceAccount:
-		userID, _ = identity.IntIdentifier(namespaceID, identifier)
+	namespace, identifier := f.user.GetNamespacedID()
+	if namespace == identity.NamespaceUser || namespace == identity.NamespaceServiceAccount {
+		userID, _ = identity.IntIdentifier(namespace, identifier)
 	}
 
 	orgID := f.user.GetOrgID()

--- a/pkg/services/sqlstore/permissions/dashboard_filter_no_subquery.go
+++ b/pkg/services/sqlstore/permissions/dashboard_filter_no_subquery.go
@@ -34,10 +34,9 @@ func (f *accessControlDashboardPermissionFilterNoFolderSubquery) buildClauses() 
 	folderWildcards := accesscontrol.WildcardsFromPrefix(dashboards.ScopeFoldersPrefix)
 
 	userID := int64(0)
-	namespaceID, identifier := f.user.GetNamespacedID()
-	switch namespaceID {
-	case identity.NamespaceUser, identity.NamespaceServiceAccount:
-		userID, _ = identity.IntIdentifier(namespaceID, identifier)
+	namespace, identifier := f.user.GetNamespacedID()
+	if namespace == identity.NamespaceUser || namespace == identity.NamespaceServiceAccount {
+		userID, _ = identity.IntIdentifier(namespace, identifier)
 	}
 
 	orgID := f.user.GetOrgID()

--- a/pkg/services/user/identity.go
+++ b/pkg/services/user/identity.go
@@ -2,6 +2,7 @@ package user
 
 import (
 	"fmt"
+	"strconv"
 	"time"
 
 	"github.com/grafana/grafana/pkg/models/roletype"
@@ -166,32 +167,52 @@ func (u *SignedInUser) GetOrgRole() roletype.RoleType {
 
 // GetID returns namespaced id for the entity
 func (u *SignedInUser) GetID() identity.NamespaceID {
-	switch {
-	case u.ApiKeyID != 0:
-		return namespacedID(identity.NamespaceAPIKey, u.ApiKeyID)
-	case u.IsServiceAccount:
-		return namespacedID(identity.NamespaceServiceAccount, u.UserID)
-	case u.UserID > 0:
-		return namespacedID(identity.NamespaceUser, u.UserID)
-	case u.IsAnonymous:
-		return namespacedID(identity.NamespaceAnonymous, 0)
-	case u.AuthenticatedBy == "render" && u.UserID == 0:
-		return namespacedID(identity.NamespaceRenderService, 0)
-	}
-
-	return u.NamespacedID
+	ns, id := u.GetNamespacedID()
+	return identity.NewNamespaceIDString(ns, id)
 }
 
 // GetNamespacedID returns the namespace and ID of the active entity
 // The namespace is one of the constants defined in pkg/services/auth/identity
-func (u *SignedInUser) GetNamespacedID() (string, string) {
-	id := u.GetID()
-	return id.Namespace(), id.ID()
+func (u *SignedInUser) GetNamespacedID() (identity.Namespace, string) {
+	switch {
+	case u.ApiKeyID != 0:
+		return identity.NamespaceAPIKey, strconv.FormatInt(u.ApiKeyID, 10)
+	case u.IsServiceAccount:
+		return identity.NamespaceServiceAccount, strconv.FormatInt(u.UserID, 10)
+	case u.UserID > 0:
+		return identity.NamespaceUser, strconv.FormatInt(u.UserID, 10)
+	case u.IsAnonymous:
+		return identity.NamespaceAnonymous, "0"
+	case u.AuthenticatedBy == "render" && u.UserID == 0:
+		return identity.NamespaceRenderService, "0"
+	}
+
+	return u.NamespacedID.Namespace(), u.NamespacedID.ID()
 }
 
-// GetUserUID returns user uid for the entity
-func (u *SignedInUser) GetUserUID() string {
-	return u.UserUID
+// GetUID returns namespaced uid for the entity
+func (u *SignedInUser) GetUID() identity.NamespaceID {
+	ns, uid := u.GetNamespacedUID()
+	return identity.NewNamespaceIDString(ns, uid)
+}
+
+// GetNamespacedUID returns the namespace and UID of the active entity
+// The namespace is one of the constants defined in pkg/services/auth/identity
+func (u *SignedInUser) GetNamespacedUID() (identity.Namespace, string) {
+	switch {
+	case u.ApiKeyID != 0:
+		return identity.NamespaceAPIKey, fmt.Sprint(u.ApiKeyID)
+	case u.IsServiceAccount:
+		return identity.NamespaceServiceAccount, u.UserUID
+	case u.UserID > 0:
+		return identity.NamespaceUser, u.UserUID
+	case u.IsAnonymous:
+		return identity.NamespaceAnonymous, ""
+	case u.AuthenticatedBy == "render" && u.UserID == 0:
+		return identity.NamespaceRenderService, ""
+	}
+
+	return identity.NamespaceEmpty, ""
 }
 
 func (u *SignedInUser) GetAuthID() string {
@@ -234,8 +255,4 @@ func (u *SignedInUser) GetDisplayName() string {
 
 func (u *SignedInUser) GetIDToken() string {
 	return u.IDToken
-}
-
-func namespacedID(namespace string, id int64) identity.NamespaceID {
-	return identity.NewNamespaceIDUnchecked(namespace, id)
 }

--- a/pkg/services/user/identity.go
+++ b/pkg/services/user/identity.go
@@ -56,36 +56,6 @@ func (u *SignedInUser) NameOrFallback() string {
 	return u.Email
 }
 
-// TODO: There's a need to remove this struct since it creates a circular dependency
-
-// DEPRECATED: This function uses `UserDisplayDTO` model which we want to remove
-// In order to retrieve the user URL, we need the dto library. However, adding
-// the dto library to the user service creates a circular dependency
-func (u *SignedInUser) ToUserDisplayDTO() *UserDisplayDTO {
-	return &UserDisplayDTO{
-		ID:    u.UserID,
-		UID:   u.UserUID,
-		Login: u.Login,
-		Name:  u.Name,
-		// AvatarURL: dtos.GetGravatarUrl(u.GetEmail()),
-	}
-}
-
-// Static function to parse a requester into a UserDisplayDTO
-func NewUserDisplayDTOFromRequester(requester identity.Requester) (*UserDisplayDTO, error) {
-	userID := int64(0)
-	namespaceID, identifier := requester.GetNamespacedID()
-	if namespaceID == identity.NamespaceUser || namespaceID == identity.NamespaceServiceAccount {
-		userID, _ = identity.IntIdentifier(namespaceID, identifier)
-	}
-
-	return &UserDisplayDTO{
-		ID:    userID,
-		Login: requester.GetLogin(),
-		Name:  requester.GetDisplayName(),
-	}, nil
-}
-
 func (u *SignedInUser) HasRole(role roletype.RoleType) bool {
 	if u.IsGrafanaAdmin {
 		return true
@@ -217,6 +187,11 @@ func (u *SignedInUser) GetID() identity.NamespaceID {
 func (u *SignedInUser) GetNamespacedID() (string, string) {
 	id := u.GetID()
 	return id.Namespace(), id.ID()
+}
+
+// GetUserUID returns user uid for the entity
+func (u *SignedInUser) GetUserUID() string {
+	return u.UserUID
 }
 
 func (u *SignedInUser) GetAuthID() string {

--- a/pkg/services/user/model.go
+++ b/pkg/services/user/model.go
@@ -223,14 +223,6 @@ type ErrCaseInsensitiveLoginConflict struct {
 	Users []User
 }
 
-type UserDisplayDTO struct {
-	ID        int64  `json:"id,omitempty"`
-	UID       string `json:"uid,omitempty"`
-	Name      string `json:"name,omitempty"`
-	Login     string `json:"login,omitempty"`
-	AvatarURL string `json:"avatarUrl"`
-}
-
 func (e *ErrCaseInsensitiveLoginConflict) Unwrap() error {
 	return ErrCaseInsensitive
 }

--- a/pkg/util/proxyutil/proxyutil.go
+++ b/pkg/util/proxyutil/proxyutil.go
@@ -115,8 +115,7 @@ func ApplyUserHeader(sendUserHeader bool, req *http.Request, user identity.Reque
 	}
 
 	namespace, _ := user.GetNamespacedID()
-	switch namespace {
-	case identity.NamespaceUser, identity.NamespaceServiceAccount:
+	if namespace == identity.NamespaceUser || namespace == identity.NamespaceServiceAccount {
 		req.Header.Set(UserHeaderName, user.GetLogin())
 	}
 }


### PR DESCRIPTION
While reading through `postDashboard` I noticed that the code added in #74048 would overwrite `err` and cause issues with error handling when live was enabled.

While fixing that I realized that `UserDisplayDTO` and associated functions are now only used in dashboard events, so I went ahead and moved them there and made them private to clean up the user and identity modules.

I also tidied up a few instances where VSCode was complaining about unused variables, and a bug in redis client initialization in the live service which dates back to #34851.