### PR TITLE
Prometheus: Add reqAction to Prometheus routes

### DIFF
--- a/public/app/plugins/datasource/prometheus/plugin.json
+++ b/public/app/plugins/datasource/prometheus/plugin.json
@@ -7,52 +7,62 @@
     {
       "method": "POST",
       "path": "api/v1/query",
-      "reqRole": "Viewer"
+      "reqRole": "Viewer",
+      "reqAction": "datasources:query"
     },
     {
       "method": "POST",
       "path": "api/v1/query_range",
-      "reqRole": "Viewer"
+      "reqRole": "Viewer",
+      "reqAction": "datasources:query"
     },
     {
       "method": "POST",
       "path": "api/v1/series",
-      "reqRole": "Viewer"
+      "reqRole": "Viewer",
+      "reqAction": "datasources:query"
     },
     {
       "method": "POST",
       "path": "api/v1/labels",
-      "reqRole": "Viewer"
+      "reqRole": "Viewer",
+      "reqAction": "datasources:query"
     },
     {
       "method": "POST",
       "path": "api/v1/query_exemplars",
-      "reqRole": "Viewer"
+      "reqRole": "Viewer",
+      "reqAction": "datasources:query"
     },
     {
       "method": "GET",
       "path": "/rules",
-      "reqRole": "Viewer"
+      "reqRole": "Viewer",
+      "reqAction": "datasources:query"
     },
     {
       "method": "POST",
       "path": "/rules",
-      "reqRole": "Editor"
+      "reqRole": "Editor",
+      "reqAction": "datasources:edit"
     },
     {
       "method": "DELETE",
       "path": "/rules",
-      "reqRole": "Editor"
+      "reqRole": "Editor",
+      "reqAction": "datasources:edit"
     },
     {
       "method": "DELETE",
       "path": "/config/v1/rules",
-      "reqRole": "Editor"
+      "reqRole": "Editor",
+      "reqAction": "datasources:edit"
     },
     {
       "method": "POST",
       "path": "/config/v1/rules",
-      "reqRole": "Editor"
+      "reqRole": "Editor",
+      "reqAction": "datasources:edit"
     }
   ],
   "includes": [


### PR DESCRIPTION


<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

This should allow provisioned service accounts that do not have a role to use the /proxy endpoints for Prometheus.

**Why do we need this feature?**

This is desired for some integrations that need to query for labels or other data not part of /ds/query. Or integrations that avoid using /ds/query for performance or ease of use reasons.

**Who is this feature for?**

Plugin authors who want to use provisioned service accounts to query Prometheus data.

**Which issue(s) does this PR fix?**:

Please check that:
- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
