### PR TITLE
Google OAuth - Lookup Email and Name  via GCIP

### DIFF
--- a/pkg/login/social/connectors/google_oauth.go
+++ b/pkg/login/social/connectors/google_oauth.go
@@ -109,6 +109,9 @@ func (s *SocialGoogle) Reload(ctx context.Context, settings ssoModels.SSOSetting
 	defer s.reloadMutex.Unlock()
 
 	s.updateInfo(social.GoogleProviderName, newInfo)
+	s.gcipNameLookup = newInfo.Extra[gcipNameLookup]
+	s.gcipEmailLookup = newInfo.Extra[gcipEmailLookup]
+	s.gcipEmailVerifiedLookup = newInfo.Extra[gcipEmailVerifiedLookup]
 	s.validateHD = MustBool(newInfo.Extra[validateHDKey], true)
 
 	return nil

--- a/pkg/util/json.go
+++ b/pkg/util/json.go
@@ -70,6 +70,23 @@ func SearchJSONForStringAttr(attributePath string, data any) (string, error) {
 	return "", nil
 }
 
+// SearchJSONForIntAttr searches for a specific attribute in a JSON object and returns a bool.
+// The attributePath parameter is a string that specifies the path to the attribute.
+// The data parameter is the JSON object that we're searching. It can be a byte slice or a go type.
+func SearchJSONForBoolAttr(attributePath string, data any) (bool, error) {
+	val, err := searchJSONForAttr(attributePath, data)
+	if err != nil {
+		return false, err
+	}
+
+	boolVal, ok := val.(bool)
+	if ok {
+		return boolVal, nil
+	}
+
+	return false, nil
+}
+
 // searchJSONForAttr searches for a specific attribute in a JSON object.
 // The attributePath parameter is a string that specifies the path to the attribute.
 // The data parameter is the JSON object that we're searching.

--- a/pkg/util/json_test.go
+++ b/pkg/util/json_test.go
@@ -95,10 +95,10 @@ func TestSearchJSONForEmail(t *testing.T) {
 		{
 			Name: "Given a simple user info JSON response and valid JMES path",
 			UserInfoJSONResponse: []byte(`{
-	"attributes": {
-		"email": "grafana@localhost"
-	}
-}`),
+				"attributes": {
+					"email": "grafana@localhost"
+				}
+			}`),
 			EmailAttributePath: "attributes.email",
 			ExpectedResult:     "grafana@localhost",
 		},
@@ -115,25 +115,25 @@ func TestSearchJSONForEmail(t *testing.T) {
 		{
 			Name: "Given a user info JSON response with e-mails array and valid JMES path",
 			UserInfoJSONResponse: []byte(`{
-	"attributes": {
-		"emails": ["grafana@localhost", "admin@localhost"]
-	}
-}`),
+				"attributes": {
+					"emails": ["grafana@localhost", "admin@localhost"]
+				}
+			}`),
 			EmailAttributePath: "attributes.emails[0]",
 			ExpectedResult:     "grafana@localhost",
 		},
 		{
 			Name: "Given a nested user info JSON response and valid JMES path",
 			UserInfoJSONResponse: []byte(`{
-	"identities": [
-		{
-			"userId": "grafana@localhost"
-		},
-		{
-			"userId": "admin@localhost"
-		}
-	]
-}`),
+				"identities": [
+					{
+						"userId": "grafana@localhost"
+					},
+					{
+						"userId": "admin@localhost"
+					}
+				]
+			}`),
 			EmailAttributePath: "identities[0].userId",
 			ExpectedResult:     "grafana@localhost",
 		},
@@ -150,6 +150,52 @@ func TestSearchJSONForEmail(t *testing.T) {
 				require.ErrorIs(t, err, test.ExpectedError)
 			}
 			require.Equal(t, test.ExpectedResult, actualResult)
+		})
+	}
+}
+
+func TestSearchJSONForBoolAttr(t *testing.T) {
+	tests := []struct {
+		name          string
+		data          []byte
+		path          string
+		expectedValue bool
+		err           bool
+	}{
+		{
+			name: "should parse and find the boolean value of attribute",
+			data: []byte(`{
+				"attribute": true
+			}`),
+			path:          "attribute",
+			expectedValue: true,
+		},
+		{
+			name: "should return false if the attribute is a false string",
+			data: []byte(`{
+				"attribute": "false"
+			}`),
+			path: "attribute",
+		},
+		{
+			name: "should return error if the payload is not parseable",
+			data: []byte(`{
+				"attribute"
+			}`),
+			path: "attribute",
+			err:  true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			response, err := util.SearchJSONForBoolAttr(tt.path, tt.data)
+			if tt.err {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+			require.Equal(t, tt.expectedValue, response)
 		})
 	}
 }

--- a/public/app/features/auth-config/fields.tsx
+++ b/public/app/features/auth-config/fields.tsx
@@ -122,7 +122,15 @@ export const sectionFields: Section = {
     {
       name: 'User mapping',
       id: 'user',
-      fields: ['roleAttributePath', 'roleAttributeStrict', 'allowAssignGrafanaAdmin', 'skipOrgRoleSync'],
+      fields: [
+        'roleAttributePath',
+        'roleAttributeStrict',
+        'allowAssignGrafanaAdmin',
+        'skipOrgRoleSync',
+        'gcipNameLookup',
+        'gcipEmailLookup',
+        'gcipEmailValidationLookup',
+      ],
     },
     {
       name: 'Extra security measures',
@@ -595,6 +603,21 @@ export function fieldMap(provider: string): Record<string, FieldData> {
       description:
         'If enabled, Grafana will match the Hosted Domain retrieved from the Google ID Token against the Allowed Domains list specified by the user.',
       type: 'checkbox',
+    },
+    gcipNameLookup: {
+      label: 'GCIP name lookup',
+      description: 'If enabled, Grafana will override the user name with the name retrieved from the Google Cloud Identity Platform with a JMESPath expression.',
+      type: 'text',
+    },
+    gcipEmailLookup: {
+      label: 'GCIP email lookup',
+      description: 'If enabled, Grafana will override the user email with the email retrieved from the Google Cloud Identity Platform with a JMESPath expression.',
+      type: 'text',
+    },
+    gcipEmailValidationLookup: {
+      label: 'GCIP email validation lookup',
+      description: 'If enabled, Grafana will lookup for the email validation attribute within the Google Cloud Identity Platform payload to flag the email as validated.',
+      type: 'text',
     },
   };
 }

--- a/public/app/features/auth-config/types.ts
+++ b/public/app/features/auth-config/types.ts
@@ -57,6 +57,9 @@ export type SSOProviderSettingsBase = {
   forceUseGraphApi?: boolean;
   // For Google
   validateHd?: boolean;
+  gcipNameLookup?: string;
+  gcipEmailLookup?: string;
+  gcipEmailValidationLookup?: string;
 };
 
 // SSO data received from the API and sent to it


### PR DESCRIPTION
**What is this feature?**

This features allows to assign Email and Name fields to the Google OAuth identity by doing a lookup inside the Google Cloud Identity Platform (GCIP).

**Why do we need this feature?**

The GCIP contains information about the user, but since it doesn't follow the same JSON format, it needs to be parsed before the lookup can be performed.

**Who is this feature for?**

IAM

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes https://github.com/grafana/grafana/issues/75856

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
