### PR TITLE
Fix: Always fetch plugin css with Systemjs

### DIFF
--- a/public/app/features/plugins/plugin_loader.ts
+++ b/public/app/features/plugins/plugin_loader.ts
@@ -28,13 +28,14 @@ SystemJS.addImportMap({ imports });
 
 const systemJSPrototype: SystemJSWithLoaderHooks = SystemJS.constructor.prototype;
 
-// This instructs SystemJS to load a assets using fetch and eval if it returns a truthy value, otherwise it will load the plugin using a script tag.
-// We only want to fetch and eval plugins that are hosted on a CDN or are Angular plugins.
+// This instructs SystemJS to load plugin assets using fetch and eval if it returns a truthy value, otherwise
+// it will load the plugin using a script tag. We only want to fetch and eval files that are
+// hosted on a CDN, are related to Angular plugins or are not js files.
 systemJSPrototype.shouldFetch = function (url) {
   const pluginInfo = getPluginFromCache(url);
-  const moduleTypesRegEx = /^[^#?]+\.(css|html|json|wasm)([?#].*)?$/;
+  const jsTypeRegEx = /^[^#?]+\.(js)([?#].*)?$/;
 
-  return moduleTypesRegEx.test(url) || isHostedOnCDN(url) || Boolean(pluginInfo?.isAngular);
+  return isHostedOnCDN(url) || Boolean(pluginInfo?.isAngular) || !jsTypeRegEx.test(url);
 };
 
 const originalImport = systemJSPrototype.import;

--- a/public/app/features/plugins/plugin_loader.ts
+++ b/public/app/features/plugins/plugin_loader.ts
@@ -28,12 +28,13 @@ SystemJS.addImportMap({ imports });
 
 const systemJSPrototype: SystemJSWithLoaderHooks = SystemJS.constructor.prototype;
 
-// This instructs SystemJS to load a plugin using fetch and eval if it returns a truthy value, otherwise it will load the plugin using a script tag.
+// This instructs SystemJS to load a assets using fetch and eval if it returns a truthy value, otherwise it will load the plugin using a script tag.
 // We only want to fetch and eval plugins that are hosted on a CDN or are Angular plugins.
 systemJSPrototype.shouldFetch = function (url) {
   const pluginInfo = getPluginFromCache(url);
+  const moduleTypesRegEx = /^[^#?]+\.(css|html|json|wasm)([?#].*)?$/;
 
-  return isHostedOnCDN(url) || Boolean(pluginInfo?.isAngular);
+  return moduleTypesRegEx.test(url) || isHostedOnCDN(url) || Boolean(pluginInfo?.isAngular);
 };
 
 const originalImport = systemJSPrototype.import;


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

This fixes a bug introduced by [the previous PR](https://github.com/grafana/grafana/pull/85750) that selectively loads plugin assets using script tags.

**Why do we need this feature?**

So plugins that instruct SystemJS to load their various assets (css/html/wasm/json) to continue to work correctly.


### Before
<img width="1235" alt="Screenshot 2024-05-02 at 09 38 51" src="https://github.com/grafana/grafana/assets/73201/a1b24414-38f2-4496-908c-96db238dcf2b">

### After
<img width="1082" alt="Screenshot 2024-05-02 at 09 35 38" src="https://github.com/grafana/grafana/assets/73201/881df7b4-06b4-4890-a20a-087a12060a60">

**Who is this feature for?**

Everybody

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

[Related issue](https://github.com/grafana/support-escalations/issues/10336)

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
