### PR TITLE
Revert "Panel: Keyboard focus shortcuts prioritization"

### DIFF
--- a/public/app/core/services/withFocusedPanelId.ts
+++ b/public/app/core/services/withFocusedPanelId.ts
@@ -2,14 +2,6 @@ export function withFocusedPanel(fn: (panelId: number) => void) {
   return () => {
     const elements = document.querySelectorAll(':hover');
 
-    // Handle keyboard focus first
-    const focusedGridElement = document.activeElement?.closest('[data-panelid]');
-
-    if (focusedGridElement instanceof HTMLElement && focusedGridElement.dataset?.panelid) {
-      fn(parseInt(focusedGridElement.dataset?.panelid, 10));
-      return;
-    }
-
     for (let i = elements.length - 1; i > 0; i--) {
       const element = elements[i];
       if (element instanceof HTMLElement && element.dataset?.panelid) {

--- a/public/app/features/dashboard-scene/scene/keyboardShortcuts.ts
+++ b/public/app/features/dashboard-scene/scene/keyboardShortcuts.ts
@@ -146,16 +146,6 @@ export function setupKeyboardShortcuts(scene: DashboardScene) {
 export function withFocusedPanel(scene: DashboardScene, fn: (vizPanel: VizPanel) => void) {
   return () => {
     const elements = document.querySelectorAll(':hover');
-    const focusedGridElement = document.activeElement?.closest('[data-viz-panel-key]');
-
-    if (focusedGridElement instanceof HTMLElement && focusedGridElement.dataset?.vizPanelKey) {
-      const panelKey = focusedGridElement.dataset?.vizPanelKey;
-      const vizPanel = sceneGraph.findObject(scene, (o) => o.state.key === panelKey);
-      if (vizPanel && vizPanel instanceof VizPanel) {
-        fn(vizPanel);
-        return;
-      }
-    }
 
     for (let i = elements.length - 1; i > 0; i--) {
       const element = elements[i];


### PR DESCRIPTION
Reverts grafana/grafana#86772

Needed, as it creates an issue with the hover shortcuts. A real fix is in the works in #87317

The solution should look something like this:
https://github.com/grafana/grafana/issues/47005#issuecomment-2089912829
