### PR TITLE
RBAC: Do not set permissions on data sources with wildcard UID in OSS

### DIFF
--- a/pkg/services/accesscontrol/ossaccesscontrol/permissions_services.go
+++ b/pkg/services/accesscontrol/ossaccesscontrol/permissions_services.go
@@ -322,8 +322,8 @@ func (e DatasourcePermissionsService) SetBuiltInRolePermission(ctx context.Conte
 func (e DatasourcePermissionsService) SetPermissions(ctx context.Context, orgID int64, resourceID string, commands ...accesscontrol.SetResourcePermissionCommand) ([]accesscontrol.ResourcePermission, error) {
 	var dbCommands []resourcepermissions.SetResourcePermissionsCommand
 	for _, cmd := range commands {
-		// Only set query permissions for built-in roles
-		if cmd.Permission != "Query" || cmd.BuiltinRole == "" {
+		// Only set query permissions for built-in roles; do not set permissions for data sources with * as UID, as this would grant wildcard permissions
+		if cmd.Permission != "Query" || cmd.BuiltinRole == "" || resourceID == "*" {
 			continue
 		}
 		actions := DatasourceQueryActions


### PR DESCRIPTION
**What is this feature?**

Skip permissions setting for data sources with wildcard UIDs in unlicensed Grafana, as this would cause issues when an instance is upgraded to a licensed version.

**Why do we need this feature?**

Avoid data source permission issues when an instance gets licensed.

**Which issue(s) does this PR fix?**:

Related to https://github.com/grafana/identity-access-team/issues/672

**Special notes for your reviewer:**

This is not a security issue, as there is no way to escalate permissions (only admins can create data sources in OSS, and they can admin all data sources anyway). But this would grant unexpected wildcard DS permissions to viewers and editors if the instance gets upgraded to a licensed version, which would be confusing.