### PR TITLE
E2C: Restore Disconnect modal

### DIFF
--- a/public/app/features/migrate-to-cloud/onprem/DisconnectModal.tsx
+++ b/public/app/features/migrate-to-cloud/onprem/DisconnectModal.tsx
@@ -1,25 +1,17 @@
-import React, { useCallback } from 'react';
+import React from 'react';
 
 import { Alert, ConfirmModal, Stack } from '@grafana/ui';
 import { Trans, t } from 'app/core/internationalization';
 
 interface Props {
   isOpen: boolean;
+  isError: boolean;
+  isLoading: boolean;
+  onDisconnectConfirm: () => Promise<void>;
   onDismiss: () => void;
 }
 
-export const DisconnectModal = ({ isOpen, onDismiss }: Props) => {
-  const disconnectStack = useCallback(() => ({}), []);
-  const isLoading = false;
-  const isError = false;
-
-  const handleConfirm = useCallback(async () => {
-    const resp = await disconnectStack();
-    if (!('error' in resp)) {
-      onDismiss();
-    }
-  }, [disconnectStack, onDismiss]);
-
+export const DisconnectModal = ({ isOpen, isError, isLoading, onDisconnectConfirm, onDismiss }: Props) => {
   const confirmBody = (
     <Stack direction="column">
       {isError && (
@@ -49,7 +41,7 @@ export const DisconnectModal = ({ isOpen, onDismiss }: Props) => {
           : t('migrate-to-cloud.disconnect-modal.disconnect', 'Disconnect')
       }
       dismissText={t('migrate-to-cloud.disconnect-modal.cancel', 'Cancel')}
-      onConfirm={handleConfirm}
+      onConfirm={onDisconnectConfirm}
       onDismiss={onDismiss}
     />
   );


### PR DESCRIPTION
Restores the Disconnect modal from Cloud Migration that got cut during the rush to real APIs

![image](https://github.com/grafana/grafana/assets/46142/dd7ca843-d37e-4e10-93c7-596f6d0675e0)

Fixes #86037