### PR TITLE
FeatureToggles: Write enabled flags to the logs on startup

### DIFF
--- a/pkg/services/featuremgmt/service.go
+++ b/pkg/services/featuremgmt/service.go
@@ -1,8 +1,11 @@
 package featuremgmt
 
 import (
+	"sort"
+
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
+	"golang.org/x/exp/maps"
 
 	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/setting"
@@ -56,6 +59,9 @@ func ProvideManagerService(cfg *setting.Cfg) (*FeatureManager, error) {
 
 	// update the values
 	mgmt.update()
+
+	// Log the enabled feature toggles at startup
+	mgmt.log.Info("FeatureToggles", "enabled", sort.StringSlice(maps.Keys(mgmt.enabled)))
 
 	// Minimum approach to avoid circular dependency
 	// nolint:staticcheck

--- a/pkg/services/featuremgmt/service.go
+++ b/pkg/services/featuremgmt/service.go
@@ -61,7 +61,13 @@ func ProvideManagerService(cfg *setting.Cfg) (*FeatureManager, error) {
 	mgmt.update()
 
 	// Log the enabled feature toggles at startup
-	mgmt.log.Info("FeatureToggles", "enabled", sort.StringSlice(maps.Keys(mgmt.enabled)))
+	enabled := sort.StringSlice(maps.Keys(mgmt.enabled))
+	logctx := make([]any, len(enabled)*2)
+	for i, k := range enabled {
+		logctx[(i * 2)] = k
+		logctx[(i*2)+1] = true
+	}
+	mgmt.log.Info("FeatureToggles", logctx...)
 
 	// Minimum approach to avoid circular dependency
 	// nolint:staticcheck


### PR DESCRIPTION
This writes the enabled feature toggles to the logfile on startup.  For me, this looks like:

```
INFO [05-02|16:08:36] App mode development                     logger=settings
INFO [05-02|16:08:36] FeatureToggles                           logger=featuremgmt kubernetesPlaylists=true logRowsPopoverMenu=true cloudWatchNewLabelParsing=true annotationPermissionUpdate=true prometheusDataplane=true dashgpt=true topnav=true lokiQuerySplitting=true prometheusConfigOverhaulAuth=true lokiQueryHints=true alertingInsights=true alertingSimplifiedRouting=true grafanaAPIServerEnsureKubectlAccess=true angularDeprecationUI=true betterPageScrolling=true lokiStructuredMetadata=true recoveryThreshold=true logsContextDatasourceUi=true cloudWatchCrossAccountQuerying=true lokiMetricDataplane=true nestedFolderPicker=true sqlExpressions=true alertingNoDataErrorExecution=true exploreContentOutline=true idForwarding=true grafanaAPIServerWithExperimentalAPIs=true panelMonitoring=true transformationsRedesign=true returnToPrevious=true prometheusMetricEncyclopedia=true exploreMetrics=true nestedFolders=true awsAsyncQueryCaching=true recordedQueriesMulti=true influxdbBackendMigration=true logsExploreTableVisualisation=true publicDashboards=true dataplaneFrontendFallback=true queryService=true enableElasticsearchBackendQuerying=true managedPluginsInstall=true
INFO [05-02|16:08:36] Connecting to DB                         logger=sqlstore dbtype=sqlite3
INFO [05-02|16:08:36] Locking database                         logger=migrator
```

Or an earlier version could look like:
```
INFO [05-02|14:47:32] App mode development                     logger=settings
INFO [05-02|14:47:32] FeatureToggles                           logger=featuremgmt enabled="[annotationPermissionUpdate prometheusDataplane transformationsRedesign dataplaneFrontendFallback lokiStructuredMetadata prometheusConfigOverhaulAuth recoveryThreshold lokiQueryHints kubernetesPlaylists alertingInsights angularDeprecationUI exploreMetrics lokiMetricDataplane cloudWatchNewLabelParsing panelMonitoring managedPluginsInstall exploreContentOutline logsExploreTableVisualisation publicDashboards sqlExpressions queryService nestedFolders prometheusMetricEncyclopedia lokiQuerySplitting enableElasticsearchBackendQuerying grafanaAPIServerEnsureKubectlAccess alertingNoDataErrorExecution recordedQueriesMulti logRowsPopoverMenu topnav alertingSimplifiedRouting awsAsyncQueryCaching nestedFolderPicker betterPageScrolling logsContextDatasourceUi dashgpt returnToPrevious idForwarding influxdbBackendMigration cloudWatchCrossAccountQuerying grafanaAPIServerWithExperimentalAPIs]"
INFO [05-02|14:47:32] Connecting to DB                         logger=sqlstore dbtype=sqlite3
INFO [05-02|14:47:32] Locking database                         logger=migrator
```