### PR TITLE
SSO: Collect user save attempts from OAuth provider forms

### DIFF
--- a/public/app/features/auth-config/ProviderConfigForm.tsx
+++ b/public/app/features/auth-config/ProviderConfigForm.tsx
@@ -139,6 +139,17 @@ export const ProviderConfigForm = ({ config, provider, isLoading }: ProviderConf
 
   const isEnabled = config?.settings.enabled;
 
+  const onSaveAttempt = (toggleEnabled: boolean) => {
+    reportInteraction('grafana_authentication_ssosettings_save_attempt', {
+      provider,
+      enabled: toggleEnabled ? !isEnabled : isEnabled,
+    });
+
+    if (toggleEnabled) {
+      setValue('enabled', !isEnabled);
+    }
+  };
+
   return (
     <Page.Contents isLoading={isLoading}>
       <form onSubmit={handleSubmit(onSubmit)} style={{ maxWidth: '600px' }}>
@@ -187,13 +198,13 @@ export const ProviderConfigForm = ({ config, provider, isLoading }: ProviderConf
             <Button
               type={'submit'}
               disabled={isSaving}
-              onClick={() => setValue('enabled', !isEnabled)}
+              onClick={() => onSaveAttempt(true)}
               variant={isEnabled ? 'secondary' : undefined}
             >
               {isSaving ? (isEnabled ? 'Disabling...' : 'Saving...') : isEnabled ? 'Disable' : 'Save and enable'}
             </Button>
 
-            <Button type={'submit'} disabled={isSaving} variant={'secondary'}>
+            <Button type={'submit'} disabled={isSaving} variant={'secondary'} onClick={() => onSaveAttempt(false)}>
               {isSaving ? 'Saving...' : 'Save'}
             </Button>
             <LinkButton href={'/admin/authentication'} variant={'secondary'}>


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

Collect UI events for each user attempt to save an OAuth provider form.

**Why do we need this feature?**

We want to see stats on users attempting to save the form without success.

**Who is this feature for?**

[Add information on what kind of user the feature is for.]

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
