### PR TITLE
IDToken: add namespace

### DIFF
--- a/pkg/services/auth/id.go
+++ b/pkg/services/auth/id.go
@@ -24,5 +24,6 @@ type IDClaims struct {
 	jwt.Claims
 	Email           string `json:"email"`
 	EmailVerified   bool   `json:"email_verified"`
+	Namespace       string `json:"namespace,omitempty"`
 	AuthenticatedBy string `json:"authenticatedBy,omitempty"`
 }


### PR DESCRIPTION
**What is this feature?**
Add namespace to id token. For this I reused the namespace mapper so we have the correct behaviour of setting "default" for org 1 and using a stack namespace if it is configured. 

**Which issue(s) does this PR fix?**:

Part of https://github.com/grafana/identity-access-team/issues/659

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
