### PR TITLE
Renovate: Add Slate and related packages to ignore list

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -11,6 +11,10 @@
     "monaco-editor", // due to us exposing this via @grafana/ui/CodeEditor's props bumping can break plugins
     "@fingerprintjs/fingerprintjs", // we don't want to bump to v4 due to licensing changes
     "@swc/core", // versions ~1.4.5 contain multiple bugs related to baseUrl resolution breaking builds.
+    "slate", // we don't want to continue using this on the long run, use Monaco editor instead of Slate
+    "slate-react", // we don't want to continue using this on the long run, use Monaco editor instead of Slate
+    "@types/slate-react", // we don't want to continue using this on the long run, use Monaco editor instead of Slate
+    "@types/slate" // we don't want to continue using this on the long run, use Monaco editor instead of Slate
   ],
   "includePaths": ["package.json", "packages/**", "public/app/plugins/**"],
   "ignorePaths": ["emails/**", "plugins-bundled/**", "**/mocks/**"],


### PR DESCRIPTION
After discussing possible updates for Slate and related packages we decided to not bump any of the versions but to add them to the ignore list of renovate.
PR #80213 will be closed after merging this PR.