### PR TITLE
Canvas: Fix datalinks using field variable

### DIFF
--- a/public/app/plugins/panel/canvas/utils.ts
+++ b/public/app/plugins/panel/canvas/utils.ts
@@ -119,7 +119,9 @@ const addDataLinkForField = (
 ): void => {
   if (field?.getLinks) {
     const disp = field.display ? field.display(data) : { text: `${data}`, numeric: +data! };
-    field.getLinks({ calculatedValue: disp }).forEach((link) => {
+    // TODO add more control over which row index each element uses
+    const valueRowIndex = field.values.length - 1;
+    field.getLinks({ calculatedValue: disp, valueRowIndex }).forEach((link) => {
       const key = `${link.title}/${link.href}`;
       if (!linkLookup.has(key)) {
         links.push(link);


### PR DESCRIPTION
Datalinks inside of canvas are not specifying a valueRowIndex for getLinks call, so variables are not being populated with values. For now, I've updated it to use the last value.

Before:
![image](https://github.com/grafana/grafana/assets/60050885/f32cba27-55f4-4902-866a-91dd9395f196)

After:
![image](https://github.com/grafana/grafana/assets/60050885/4a644620-b78f-492e-ae15-c76e32bbb234)