### PR TITLE
API: Expose `dashboardUID` in `GetAnnotationByID` calls

### DIFF
--- a/pkg/api/annotations.go
+++ b/pkg/api/annotations.go
@@ -470,6 +470,14 @@ func (hs *HTTPServer) GetAnnotationByID(c *contextmodel.ReqContext) response.Res
 		annotation.AvatarURL = dtos.GetGravatarUrl(hs.Cfg, annotation.Email)
 	}
 
+	if annotation.DashboardID != 0 {
+		query := dashboards.GetDashboardQuery{ID: annotation.DashboardID, OrgID: c.SignedInUser.GetOrgID()}
+		queryResult, err := hs.DashboardService.GetDashboard(c.Req.Context(), &query)
+		if err == nil && queryResult != nil {
+			annotation.DashboardUID = &queryResult.UID
+		}
+	}
+
 	return response.JSON(http.StatusOK, annotation)
 }
 


### PR DESCRIPTION
Currently, the dashboard UID is only resolved on the list call. 

Note: This logic should probably be in the service itself, but it seems like it's quite a task to add the dashboardService in there. Also, the real way to go would probably be to migrate to dashboard UIDs completely and deprecate dashboard IDs, so it might not be worth the work to move the dashboard service