### PR TITLE
Alerting: Fix max alerts

### DIFF
--- a/public/app/features/alerting/unified/utils/cloud-alertmanager-notifier-types.ts
+++ b/public/app/features/alerting/unified/utils/cloud-alertmanager-notifier-types.ts
@@ -322,8 +322,12 @@ export const cloudNotifierTypes: Array<NotifierDTO<CloudNotifierType>> = [
         'The maximum number of alerts to include in a single webhook message. Alerts above this threshold are truncated. When leaving this at its default value of 0, all alerts are included.',
         {
           placeholder: '0',
+          inputType: 'number',
           validationRule: '(^\\d+$|^$)',
-          setValueAs: (value) => (typeof value === 'string' ? parseInt(value, 10) : 0),
+          setValueAs: (value) => {
+            const integer = Number(value);
+            return Number.isFinite(integer) ? integer : 0;
+          },
         }
       ),
       httpConfigOption,


### PR DESCRIPTION
Fixes a small regression from https://github.com/grafana/grafana/pull/86651 that would not allow creating or updating webhook receivers if `max alerts` was empty.

In the scenario where the user did not fill in the field, `setValueAs` would return `NaN` and this in turn would fail the `validationRule` regular expression.

This PR changes the behaviour to cast to a Number with the `Number` constructor (which returns `0` on `undefined | ""`) but can still return `NaN` – so we also check if the result is finite.

<img width="639" alt="image" src="https://github.com/grafana/grafana/assets/868844/0fbc2aa5-bbff-44e0-8a37-f6a6e42bdb4c">
