### PR TITLE
Alerting: Add OAuth2 to HTTP settings for vanilla Alertmanager / Mimir

### DIFF
--- a/public/app/features/alerting/unified/utils/cloud-alertmanager-notifier-types.ts
+++ b/public/app/features/alerting/unified/utils/cloud-alertmanager-notifier-types.ts
@@ -29,6 +29,25 @@ const tlsConfigOption: NotificationChannelOption = option('tls_config', 'TLS con
   ],
 });
 
+const oauth2ConfigOption: NotificationChannelOption = option('oauth2', 'OAuth2', 'Configures the OAuth2 settings.', {
+  element: 'subform',
+  subformOptions: [
+    option('client_id', 'Client ID', 'The OAuth2 client ID', { required: true }),
+    option('client_secret', 'Client secret', 'The OAuth2 client secret', { required: true }),
+    // ths "client_secret_file" is not allowed for security reasons in Mimir / Cloud Alertmanager so we also disable it for OSS Alertmanager – sorry!
+    // option(
+    //   'client_secret_file',
+    //   'Client secret file',
+    //   'OAuth2 client secret file location. Mutually exclusive with client_secret.',
+    // ),
+    option('token_url', 'Token URL', 'The OAuth2 token exchange URL', { required: true }),
+    option('scopes', 'Scopes', 'Comma-separated list of scopes', {
+      element: 'string_array',
+    }),
+    option('endpoint_params', 'Additional parameters', '', { element: 'key_value_map' }),
+  ],
+});
+
 const httpConfigOption: NotificationChannelOption = option(
   'http_config',
   'HTTP Config',
@@ -45,6 +64,7 @@ const httpConfigOption: NotificationChannelOption = option(
       option('proxy_url', 'Proxy URL', 'Optional proxy URL.'),
       basicAuthOption,
       tlsConfigOption,
+      oauth2ConfigOption,
     ],
   }
 );


### PR DESCRIPTION
This PR adds the ability to read / write oauth2 configuration for the HTTP settings of vanilla and Mimir Alertmanager.

<img width="509" alt="image" src="https://github.com/grafana/grafana/assets/868844/d8fc8e0b-5374-424b-85f2-8a4a13227067">
