### PR TITLE
Docs: Fix two broken links to plugin-tools/reference

### DIFF
--- a/docs/sources/alerting/fundamentals/alert-rules/_index.md
+++ b/docs/sources/alerting/fundamentals/alert-rules/_index.md
@@ -46,7 +46,7 @@ Additionally, you can also add [expressions to transform your data][expression-q
 
 ### Supported data sources
 
-Grafana-managed alert rules can query backend data sources if Grafana Alerting is enabled by specifying `{"backend": true, "alerting": true}` in the [plugin.json](/developers/plugin-tools/reference-plugin-json).
+Grafana-managed alert rules can query backend data sources if Grafana Alerting is enabled by specifying `{"backend": true, "alerting": true}` in the [plugin.json](https://grafana.com/developers/plugin-tools/reference/plugin-json).
 
 Find the public data sources supporting Alerting in the [Grafana Plugins directory](/grafana/plugins/data-source-plugins/?features=alerting).
 

--- a/docs/sources/shared/alerts/grafana-managed-alerts.md
+++ b/docs/sources/shared/alerts/grafana-managed-alerts.md
@@ -18,7 +18,7 @@ Alerting rules can only query backend data sources with alerting enabled:
 
 - builtin or developed and maintained by grafana: `Graphite`, `Prometheus`, `Loki`, `InfluxDB`, `Elasticsearch`,
   `Google Cloud Monitoring`, `Cloudwatch`, `Azure Monitor`, `MySQL`, `PostgreSQL`, `MSSQL`, `OpenTSDB`, `Oracle`, and `Azure Data Explorer`
-- any community backend data sources with alerting enabled (`backend` and `alerting` properties are set in the [plugin.json](/developers/plugin-tools/reference-plugin-json)
+- any community backend data sources with alerting enabled (`backend` and `alerting` properties are set in the [plugin.json](https://grafana.com/developers/plugin-tools/reference/plugin-json)
 
 ## Metrics from the alerting engine
 


### PR DESCRIPTION
A [reorganization](https://github.com/grafana/plugin-tools/pull/876) in the Developer Portal has changed the location of the plugin-json metadata file. This PR fixes broken links in grafana/grafana.
