### PR TITLE
Canvas: Fix phantom connections persisting after element deletion

### DIFF
--- a/public/app/plugins/panel/canvas/utils.ts
+++ b/public/app/plugins/panel/canvas/utils.ts
@@ -322,6 +322,9 @@ export function updateConnectionsForSource(element: ElementState, scene: Scene) 
     const connections = sourceConnections.filter((con) => con.targetName !== element.getName());
     connection.source.onChange({ ...connection.source.options, connections });
   });
+
+  // Update scene connection state to clear out old connections
+  scene.connections.updateState();
 }
 
 export const calculateCoordinates = (


### PR DESCRIPTION
The classic one liner fix - the connections were being deleted correctly but the scene connections state was out of sync

[Quick repro Canvas connection test dashboard-1714711047385.json](https://github.com/grafana/grafana/files/15196264/Canvas.connection.test-1714711047385.json)

Before


https://github.com/grafana/grafana/assets/22381771/9d4b408a-c2f8-48a9-9763-8e9feeb23df8



After

https://github.com/grafana/grafana/assets/22381771/472d3c68-884e-4e59-92f0-111502fd0ab7


Note: was not able to reproduce the panel crashing issue 😬 

Fixes https://github.com/grafana/grafana/issues/85299