### PR TITLE
MSSQL: Add `HostName` method

### DIFF
--- a/pkg/tsdb/mssql/proxy.go
+++ b/pkg/tsdb/mssql/proxy.go
@@ -14,6 +14,10 @@ type HostTransportDialer struct {
 	Host   string
 }
 
+func (m HostTransportDialer) HostName() string {
+	return m.Host
+}
+
 func (m HostTransportDialer) DialContext(ctx context.Context, network string, addr string) (conn net.Conn, err error) {
 	return m.Dialer.DialContext(ctx, network, addr)
 }

--- a/pkg/tsdb/mssql/proxy_test.go
+++ b/pkg/tsdb/mssql/proxy_test.go
@@ -13,6 +13,7 @@ import (
 )
 
 type testDialer struct {
+	Host string
 }
 
 func (d *testDialer) Dial(network, addr string) (c net.Conn, err error) {
@@ -20,18 +21,51 @@ func (d *testDialer) Dial(network, addr string) (c net.Conn, err error) {
 }
 
 func (d *testDialer) DialContext(ctx context.Context, network, address string) (net.Conn, error) {
+	hostWithPort := d.HostName() + ":1433"
+	if address != hostWithPort {
+		return nil, fmt.Errorf("test-dialer: address does not match hostname")
+	}
 	return nil, fmt.Errorf("test-dialer: DialContext is not functional")
+}
+
+func (d *testDialer) HostName() string {
+	return d.Host
 }
 
 var _ proxy.Dialer = (&testDialer{})
 
 func TestMSSQLProxyDriver(t *testing.T) {
-	cnnstr := "server=127.0.0.1;port=1433;user id=sa;password=yourStrong(!)Password;database=db"
 
 	t.Run("Connector should use dialer context that routes through the socks proxy to db", func(t *testing.T) {
+		host := "127.0.0.1"
+		cnnstr := fmt.Sprintf("server=%s;port=1433;user id=sa;password=yourStrong(!)Password;database=db", host)
 		connector, err := mssql.NewConnector(cnnstr)
 		require.NoError(t, err)
-		dialer, err := newMSSQLProxyDialer("127.0.0.1", &testDialer{})
+
+		td := testDialer{
+			Host: host,
+		}
+		dialer, err := newMSSQLProxyDialer("%s", &td)
+		require.NoError(t, err)
+
+		connector.Dialer = (dialer)
+
+		db := sql.OpenDB(connector)
+		err = db.Ping()
+
+		require.Contains(t, err.Error(), "test-dialer: DialContext is not functional")
+	})
+
+	t.Run("Connector should use hostname rather than attempting to resolve IP", func(t *testing.T) {
+		host := "www.grafana.com"
+		cnnstr := fmt.Sprintf("server=%s;port=1433;user id=sa;password=yourStrong(!)Password;database=db", host)
+		connector, err := mssql.NewConnector(cnnstr)
+		require.NoError(t, err)
+
+		td := testDialer{
+			Host: host,
+		}
+		dialer, err := newMSSQLProxyDialer(host, &td)
 		require.NoError(t, err)
 
 		connector.Dialer = (dialer)

--- a/pkg/tsdb/mssql/proxy_test.go
+++ b/pkg/tsdb/mssql/proxy_test.go
@@ -35,7 +35,6 @@ func (d *testDialer) HostName() string {
 var _ proxy.Dialer = (&testDialer{})
 
 func TestMSSQLProxyDriver(t *testing.T) {
-
 	t.Run("Connector should use dialer context that routes through the socks proxy to db", func(t *testing.T) {
 		host := "127.0.0.1"
 		cnnstr := fmt.Sprintf("server=%s;port=1433;user id=sa;password=yourStrong(!)Password;database=db", host)


### PR DESCRIPTION
When #86278 was implemented the `HostName` method was removed. This was a mistake as it forces DNS resolution to be done on the Grafana host rather than the remote host (the PDC agent in this case). This then leads to the IP address of the host not being resolvable and any requests will fail.

Re-adding this method allows the host to be sent in the request and indicates resolution should be done by the remote dialer (the PDC agent).

Relevant dialer code is [here](https://github.com/microsoft/go-mssqldb/blob/ada30cbaf031d81144e5c5487ddefd4f3dac0ef5/protocol.go#L75)

Fixes grafana/support-escalations#10363