### PR TITLE
Scopes: Add Find subresource to query ScopesNodes and search thru titles. 

### DIFF
--- a/pkg/registry/apis/scope/register.go
+++ b/pkg/registry/apis/scope/register.go
@@ -212,7 +212,11 @@ func findGETHandler(w http.ResponseWriter, req *http.Request) {
 	//query := req.URL.Query().Get("query")
 	//limit := req.URL.Query().Get("limit")
 
-	// fetch scopesnodes from the api server based on parent + query match on title.
+	/*
+		1. fetch scope nodes from the api server based on parent
+		2. filter titles based on the query param. strings.HasPrefix is a good enough for now.
+		3. Limit the response to the provided param.
+	*/
 
 	var results []scope.ScopeNode = nil
 

--- a/pkg/registry/apis/scope/register.go
+++ b/pkg/registry/apis/scope/register.go
@@ -154,7 +154,6 @@ func (b *ScopeAPIBuilder) GetOpenAPIDefinitions() common.GetOpenAPIDefinitions {
 
 // Register additional routes with the server
 func (b *ScopeAPIBuilder) GetAPIRoutes() *builder.APIRoutes {
-
 	defs := scope.GetOpenAPIDefinitions(func(path string) spec.Ref { return spec.Ref{} })
 	scopeNodeSchema := defs["github.com/grafana/grafana/pkg/apis/scopes/v0alpha1.ScopeNodeSpec"].Schema
 


### PR DESCRIPTION
I want to add an API handler that can filter for scopenodes based on ParentName and also search for titles matching a keyword passed as `query`. AFAIK the query part is not something that the API server itself support which is why I'm adding a sub resource for it instead. 

But I can't figure out how to query the apiserver from the handler. 

