### PR TITLE
Actionsets: Fix downgrade of permission to add the actionset permission

### DIFF
--- a/pkg/services/accesscontrol/resourcepermissions/store.go
+++ b/pkg/services/accesscontrol/resourcepermissions/store.go
@@ -676,7 +676,7 @@ func (s *store) createPermissions(sess *db.Session, roleID int64, resource, reso
 		permissions = append(permissions, p)
 	}
 
-	// If there are no missing actions for the resouce, we don't need to insert any prior actions
+	// If there are no missing actions for the resource, we don't need to insert any prior actions
 	// we still want to add the action set
 	if len(missingActions) == 0 {
 		if s.features.IsEnabled(context.TODO(), featuremgmt.FlagAccessActionSets) {

--- a/pkg/services/accesscontrol/resourcepermissions/store.go
+++ b/pkg/services/accesscontrol/resourcepermissions/store.go
@@ -104,6 +104,7 @@ func (s *store) setUserResourcePermission(
 	cmd SetResourcePermissionCommand,
 	hook UserResourceHookFunc,
 ) (*accesscontrol.ResourcePermission, error) {
+	fmt.Printf("setting user resource permission %v\n", cmd)
 	permission, err := s.setResourcePermission(sess, orgID, accesscontrol.ManagedUserRoleName(user.ID), s.userAdder(sess, orgID, user.ID), cmd)
 	if err != nil {
 		return nil, err
@@ -237,6 +238,7 @@ type roleAdder func(roleID int64) error
 func (s *store) setResourcePermission(
 	sess *db.Session, orgID int64, roleName string, adder roleAdder, cmd SetResourcePermissionCommand,
 ) (*accesscontrol.ResourcePermission, error) {
+	fmt.Printf("setting resource permission %v\n", cmd)
 	role, err := s.getOrCreateManagedRole(sess, orgID, roleName, adder)
 	if err != nil {
 		return nil, err
@@ -659,26 +661,34 @@ func (s *store) getPermissions(sess *db.Session, resource, resourceID, resourceA
 	return result, nil
 }
 
-func (s *store) createPermissions(sess *db.Session, roleID int64, resource, resourceID, resourceAttribute string, actions map[string]struct{}, permission string) error {
-	if len(actions) == 0 {
-		return nil
-	}
-	permissions := make([]accesscontrol.Permission, 0, len(actions))
-
-	for action := range actions {
-		p := managedPermission(action, resource, resourceID, resourceAttribute)
-		p.RoleID = roleID
-		p.Created = time.Now()
-		p.Updated = time.Now()
-		p.Kind, p.Attribute, p.Identifier = p.SplitScope()
-		permissions = append(permissions, p)
-	}
+func (s *store) createPermissions(sess *db.Session, roleID int64, resource, resourceID, resourceAttribute string, missingActions map[string]struct{}, permission string) error {
+	permissions := make([]accesscontrol.Permission, 0, len(missingActions))
 	/*
 		Add ACTION SET of managed permissions to in-memory store
 	*/
 	if s.features.IsEnabled(context.TODO(), featuremgmt.FlagAccessActionSets) {
 		actionSetName := s.actionSetService.GetActionSetName(resource, permission)
 		p := managedPermission(actionSetName, resource, resourceID, resourceAttribute)
+		p.RoleID = roleID
+		p.Created = time.Now()
+		p.Updated = time.Now()
+		p.Kind, p.Attribute, p.Identifier = p.SplitScope()
+		permissions = append(permissions, p)
+	}
+
+	// If there are no missing actions for the resouce, we don't need to insert any prior actions
+	// we still want to add the action set
+	if len(missingActions) == 0 {
+		if s.features.IsEnabled(context.TODO(), featuremgmt.FlagAccessActionSets) {
+			if _, err := sess.InsertMulti(&permissions); err != nil {
+				return err
+			}
+		}
+		return nil
+	}
+
+	for action := range missingActions {
+		p := managedPermission(action, resource, resourceID, resourceAttribute)
 		p.RoleID = roleID
 		p.Created = time.Now()
 		p.Updated = time.Now()
@@ -768,7 +778,7 @@ func (s *InMemoryActionSets) StoreActionSet(resource, permission string, actions
 		Actions: actions,
 	}
 	s.actionSets[actionSet.Action] = actions
-	s.log.Debug("stored action set actionname \n", actionSet.Action)
+	fmt.Printf("stored action set actionname %s\n", s.actionSets)
 }
 
 // GetActionSetName function creates an action set from a list of actions and stores it inmemory.


### PR DESCRIPTION
**why**
We have an issue for downgrading a role from `Editor` -> `Viewer` where we do not have any missing actions when creatingPermissions.

**what**
This checks the missingPermissions to be empty and if we are using actionSets, we will write a actionset.

https://github.com/grafana/identity-access-team/issues/675
