### PR TITLE
DashboardScene: Restrict dashboard in read only state (#87316)

### DIFF
--- a/public/app/features/dashboard-scene/scene/DashboardSceneUrlSync.ts
+++ b/public/app/features/dashboard-scene/scene/DashboardSceneUrlSync.ts
@@ -51,9 +51,13 @@ export class DashboardSceneUrlSync implements SceneObjectUrlSyncHandler {
 
       // If we are not in editing (for example after full page reload)
       if (!isEditing) {
-        // Not sure what is best to do here.
-        // The reason for the timeout is for this change to happen after the url sync has completed
-        setTimeout(() => this._scene.onEnterEditMode());
+        if (this._scene.state.editable) {
+          // Not sure what is best to do here.
+          // The reason for the timeout is for this change to happen after the url sync has completed
+          setTimeout(() => this._scene.onEnterEditMode());
+        } else {
+          update.editview = undefined;
+        }
       }
     } else if (values.hasOwnProperty('editview')) {
       update.editview = undefined;

--- a/public/app/features/dashboard-scene/scene/NavToolbarActions.tsx
+++ b/public/app/features/dashboard-scene/scene/NavToolbarActions.tsx
@@ -54,6 +54,7 @@ export function ToolbarActions({ dashboard }: Props) {
     meta,
     editview,
     editPanel,
+    editable,
     hasCopiedPanel: copiedPanel,
   } = dashboard.useState();
   const { isPlaying } = playlistSrv.useState();
@@ -326,7 +327,7 @@ export function ToolbarActions({ dashboard }: Props) {
 
   toolbarActions.push({
     group: 'main-buttons',
-    condition: !isEditing && dashboard.canEditDashboard() && !isViewingPanel && !isPlaying,
+    condition: !isEditing && dashboard.canEditDashboard() && !isViewingPanel && !isPlaying && editable,
     render: () => (
       <Button
         onClick={() => {
@@ -340,6 +341,27 @@ export function ToolbarActions({ dashboard }: Props) {
         data-testid={selectors.components.NavToolbar.editDashboard.editButton}
       >
         Edit
+      </Button>
+    ),
+  });
+
+  toolbarActions.push({
+    group: 'main-buttons',
+    condition: !isEditing && dashboard.canEditDashboard() && !isViewingPanel && !isPlaying && !editable,
+    render: () => (
+      <Button
+        onClick={() => {
+          dashboard.onEnterEditMode();
+          dashboard.setState({ editable: true, meta: { ...meta, canEdit: true } });
+        }}
+        tooltip="This dashboard was marked as read only"
+        key="edit"
+        className={styles.buttonWithExtraMargin}
+        variant="secondary"
+        size="sm"
+        data-testid={selectors.components.NavToolbar.editDashboard.editButton}
+      >
+        Make editable
       </Button>
     ),
   });

--- a/public/app/features/dashboard-scene/scene/PanelMenuBehavior.tsx
+++ b/public/app/features/dashboard-scene/scene/PanelMenuBehavior.tsx
@@ -66,12 +66,12 @@ export function panelMenuBehavior(menu: VizPanelMenu, isRepeat = false) {
       });
     }
 
-    if (dashboard.canEditDashboard() && !isRepeat && !isEditingPanel) {
+    if (dashboard.canEditDashboard() && dashboard.state.editable && !isRepeat && !isEditingPanel) {
       // We could check isEditing here but I kind of think this should always be in the menu,
       // and going into panel edit should make the dashboard go into edit mode is it's not already
       items.push({
         text: t('panel.header-menu.edit', `Edit`),
-        iconClassName: 'eye',
+        iconClassName: 'edit',
         shortcut: 'e',
         onClick: () => DashboardInteractions.panelMenuItemClicked('edit'),
         href: getEditPanelUrl(getPanelIdForVizPanel(panel)),

--- a/public/app/features/dashboard-scene/settings/utils.ts
+++ b/public/app/features/dashboard-scene/settings/utils.ts
@@ -64,14 +64,6 @@ export function useDashboardEditPageNav(dashboard: DashboardScene, currentEditVi
     });
   }
 
-  if (dashboard.state.meta.canMakeEditable) {
-    pageNav.children!.push({
-      text: t('dashboard-settings.general.title', 'General'),
-      url: locationUtil.getUrlForPartial(location, { editview: 'settings', editIndex: null }),
-      active: currentEditView === 'settings',
-    });
-  }
-
   if (dashboard.state.id && dashboard.state.meta.canSave) {
     pageNav.children!.push({
       text: t('dashboard-settings.versions.title', 'Versions'),


### PR DESCRIPTION
Backport 64330534799cd1e222c69a0a07ba5dc8f39366e1 from #87316

---


In order to fix this for G11 a temporary solution of `Make Editable` button was introduced and few safeguards around that.

Fixes #87169

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
