### PR TITLE
Alerting: Do not retry rule evaluations with "input data must be a wide series but got type long" style errors

### DIFF
--- a/pkg/expr/converter.go
+++ b/pkg/expr/converter.go
@@ -79,7 +79,7 @@ func (c *ResultConverter) Convert(ctx context.Context,
 		}
 
 		if schema.Type != data.TimeSeriesTypeWide && !allowLongFrames {
-			return "", mathexp.Results{}, fmt.Errorf("input data must be a wide series but got type %s (input refid)", schema.Type)
+			return "", mathexp.Results{}, fmt.Errorf("%w but got type %s (input refid)", ErrSeriesMustBeWide, schema.Type)
 		}
 		filtered = append(filtered, frame)
 		totalLen += len(schema.ValueIndices)
@@ -249,7 +249,7 @@ func extractNumberSet(frame *data.Frame) ([]mathexp.Number, error) {
 func WideToMany(frame *data.Frame, fixSeries func(series mathexp.Series, valueField *data.Field)) ([]mathexp.Series, error) {
 	tsSchema := frame.TimeSeriesSchema()
 	if tsSchema.Type != data.TimeSeriesTypeWide {
-		return nil, fmt.Errorf("input data must be a wide series but got type %s", tsSchema.Type)
+		return nil, fmt.Errorf("%w but got type %s", ErrSeriesMustBeWide, tsSchema.Type)
 	}
 
 	if len(tsSchema.ValueIndices) == 1 {

--- a/pkg/expr/errors.go
+++ b/pkg/expr/errors.go
@@ -7,6 +7,8 @@ import (
 	"github.com/grafana/grafana/pkg/util/errutil"
 )
 
+var ErrSeriesMustBeWide = errors.New("input data must be a wide series")
+
 var ConversionError = errutil.BadRequest("sse.readDataError").MustTemplate(
 	"[{{ .Public.refId }}] got error: {{ .Error }}",
 	errutil.WithPublic(

--- a/pkg/services/ngalert/eval/eval.go
+++ b/pkg/services/ngalert/eval/eval.go
@@ -166,13 +166,16 @@ func (evalResults Results) HasErrors() bool {
 // HasNonRetryableErrors returns true if we have at least 1 result with:
 // 1. A `State` of `Error`
 // 2. The `Error` attribute is not nil
-// 3. The `Error` type is of `&invalidEvalResultFormatError`
+// 3. The `Error` type is of `&invalidEvalResultFormatError` or `ErrSeriesMustBeWide`
 // Our thinking with this approach, is that we don't want to retry errors that have relation with invalid alert definition format.
 func (evalResults Results) HasNonRetryableErrors() bool {
 	for _, r := range evalResults {
 		if r.State == Error && r.Error != nil {
 			var nonRetryableError *invalidEvalResultFormatError
 			if errors.As(r.Error, &nonRetryableError) {
+				return true
+			}
+			if errors.Is(r.Error, expr.ErrSeriesMustBeWide) {
 				return true
 			}
 		}

--- a/pkg/services/ngalert/eval/eval_test.go
+++ b/pkg/services/ngalert/eval/eval_test.go
@@ -957,11 +957,21 @@ func TestResults_HasNonRetryableErrors(t *testing.T) {
 		expected bool
 	}{
 		{
-			name: "with non-retryable errors",
+			name: "with invalid format error",
 			eval: Results{
 				{
 					State: Error,
 					Error: &invalidEvalResultFormatError{refID: "A", reason: "unable to get frame row length", err: errors.New("weird error")},
+				},
+			},
+			expected: true,
+		},
+		{
+			name: "with expected wide series but got type long error",
+			eval: Results{
+				{
+					State: Error,
+					Error: fmt.Errorf("%w but got type long", expr.ErrSeriesMustBeWide),
 				},
 			},
 			expected: true,


### PR DESCRIPTION
**What is this feature?**

Usually, this error happens with SQL or tabular datasources that return a dataframe that can't be converted to an Alerting-style series.

Therefore, it's in the same vein of problem as alerting's `invalidEvalResultFormatError` which we already consider as non retryable. This one just happens earlier in the stack. Consider it non-retryable as well.

**Why do we need this feature?**

Prevents unnecessary retries on an error that usually indicates that the query needs to be fixed.

**Who is this feature for?**

Users with this configuration problem who are using alerting evaluation retries - send fewer unnecessary queries.

**Which issue(s) does this PR fix?**:

n/a

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle.
- [x] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
