### PR TITLE
Canvas: Add support to rotate a group of elements

### DIFF
--- a/public/app/features/canvas/runtime/element.tsx
+++ b/public/app/features/canvas/runtime/element.tsx
@@ -488,12 +488,20 @@ export class ElementState implements LayerElement {
     event.target.style.transform = event.transform;
   };
 
-  applyRotate = (event: OnRotate) => {
+  applyRotate = (event: OnRotate, isGroupEvent = false) => {
     const absoluteRotationDegree = event.absoluteRotation;
-
+    const rotationDelta = event.delta;
     const placement = this.options.placement!;
+    const placementRotation = placement.rotation ?? 0;
+
+    console.log(absoluteRotationDegree, event.delta);
+    // If the apply rotate originates from a group event, the rotation is based on the group box's rotation
+    // To address this we adjust the element's rotation by the group box's rotation vs overriding it with group box's rotation
+    // const calculatedRotation = placementRotation + rotationDelta;
+    const calculatedRotation = isGroupEvent ? placementRotation + rotationDelta : absoluteRotationDegree;
+
     // Ensure rotation is between 0 and 360
-    placement.rotation = absoluteRotationDegree - Math.floor(absoluteRotationDegree / 360) * 360;
+    placement.rotation = calculatedRotation - Math.floor(calculatedRotation / 360) * 360;
     event.target.style.transform = event.transform;
   };
 

--- a/public/app/features/canvas/runtime/element.tsx
+++ b/public/app/features/canvas/runtime/element.tsx
@@ -488,17 +488,12 @@ export class ElementState implements LayerElement {
     event.target.style.transform = event.transform;
   };
 
-  applyRotate = (event: OnRotate, isGroupEvent = false) => {
-    const absoluteRotationDegree = event.absoluteRotation;
+  applyRotate = (event: OnRotate) => {
     const rotationDelta = event.delta;
     const placement = this.options.placement!;
     const placementRotation = placement.rotation ?? 0;
 
-    console.log(absoluteRotationDegree, event.delta);
-    // If the apply rotate originates from a group event, the rotation is based on the group box's rotation
-    // To address this we adjust the element's rotation by the group box's rotation vs overriding it with group box's rotation
-    // const calculatedRotation = placementRotation + rotationDelta;
-    const calculatedRotation = isGroupEvent ? placementRotation + rotationDelta : absoluteRotationDegree;
+    const calculatedRotation = placementRotation + rotationDelta;
 
     // Ensure rotation is between 0 and 360
     placement.rotation = calculatedRotation - Math.floor(calculatedRotation / 360) * 360;

--- a/public/app/features/canvas/runtime/scene.tsx
+++ b/public/app/features/canvas/runtime/scene.tsx
@@ -467,7 +467,7 @@ export class Scene {
         for (let event of e.events) {
           const targetedElement = this.findElementByTarget(event.target);
           if (targetedElement) {
-            targetedElement.applyRotate(event, true);
+            targetedElement.applyRotate(event);
           }
         }
       })

--- a/public/app/features/canvas/runtime/scene.tsx
+++ b/public/app/features/canvas/runtime/scene.tsx
@@ -463,6 +463,14 @@ export class Scene {
           targetedElement.applyRotate(event);
         }
       })
+      .on('rotateGroup', (e) => {
+        for (let event of e.events) {
+          const targetedElement = this.findElementByTarget(event.target);
+          if (targetedElement) {
+            targetedElement.applyRotate(event, true);
+          }
+        }
+      })
       .on('rotateEnd', () => {
         this.enableCustomables();
         // Update the editor with the new rotation


### PR DESCRIPTION
Add support to rotate elements in a group - current UX indicates this is possible so seems like a bug / not a great experience for users

Before

https://github.com/grafana/grafana/assets/22381771/81571ac7-e15f-4672-802a-d10325adfb4e



After

https://github.com/grafana/grafana/assets/22381771/b42feabf-58c1-462f-a4ec-d192ec15d3fc


After (with connections!) - same behavior as rotating a single element / no regressions

https://github.com/grafana/grafana/assets/22381771/71942ccd-e3a7-46ef-ad94-7e28dcf74eca


Fixes https://github.com/grafana/grafana/issues/84961