### PR TITLE
Prometheus: Place custom inputs first when using regex filter values in the query builder

### DIFF
--- a/packages/grafana-prometheus/src/querybuilder/components/LabelFilterItem.tsx
+++ b/packages/grafana-prometheus/src/querybuilder/components/LabelFilterItem.tsx
@@ -142,6 +142,7 @@ export function LabelFilterItem({
               : getSelectOptionsFromString(itemValue).map(toOption)[0]
           }
           allowCustomValue
+          formatCreateLabel={(input) => input} // to avoid confusion, opt out of using the `defaultFormatCreateLabel`
           createOptionPosition={item.op?.includes('~') ? 'first' : 'last'}
           onOpenMenu={async () => {
             setState({ isLoadingLabelValues: true });

--- a/packages/grafana-prometheus/src/querybuilder/components/LabelFilterItem.tsx
+++ b/packages/grafana-prometheus/src/querybuilder/components/LabelFilterItem.tsx
@@ -142,6 +142,7 @@ export function LabelFilterItem({
               : getSelectOptionsFromString(itemValue).map(toOption)[0]
           }
           allowCustomValue
+          createOptionPosition={item.op?.includes('~') ? 'first' : 'last'}
           onOpenMenu={async () => {
             setState({ isLoadingLabelValues: true });
             const labelValues = await onGetLabelValues(item);


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

## What is this feature?

This PR updates the Prometheus data source's [query builder](https://grafana.com/docs/grafana/latest/datasources/prometheus/query-editor/#builder-mode). Specifically, its handling of filter values when using [regex selectors](https://prometheus.io/docs/prometheus/latest/querying/basics/#instant-vector-selectors) (`~=`, `~!`).

### Before

In the `<Input />` for filter values, custom input would always appear last in the autocomplete options. When using regex operators, the regex input would appear last and was not focused by default. The text next to the regex input didn't align with the outcome of pressing the enter key.

https://github.com/grafana/grafana/assets/5732000/98661405-ef9f-47b6-8f21-151e9cb0c50f

### After

When using regex selectors, custom input appears as the top-most (and focused-by-default) option. Misleading "Hit enter to add" text has been removed to avoid confusion.

https://github.com/grafana/grafana/assets/5732000/bd8a9fef-7ace-4583-9292-da9b3e5556de

## Why do we need this feature?

As described in #70635, it's difficult for Prometheus data source users to select filter values when using regex selectors in the query builder. This difficulty comes from two areas:
- The regex they write appears as the bottom-most option in the `<Select />`, sometimes out of view.
- Next to their custom value, the text "Hit enter to add" incorrectly set an expectation that hitting enter would select the custom value. In reality, this is only true if the custom value was focused in response to user action (up/down keys, mouse-over).

## Who is this feature for?

Prometheus data source users, especially those who use regex for filter values in the query builder.

## Which issue(s) does this PR fix?

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

This PR fixes #70635.

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [x] `(Not applicable)` If this is a pre-GA feature, it is behind a feature toggle.
- [x] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
