### PR TITLE
Canvas: Fix canvas style regression

### DIFF
--- a/.betterer.results
+++ b/.betterer.results
@@ -2195,7 +2195,12 @@ exports[`better eslint`] = {
       [0, 0, 0, "Do not use export all (\`export * from ...\`)", "3"]
     ],
     "public/app/features/canvas/runtime/element.tsx:5381": [
-      [0, 0, 0, "Unexpected any. Specify a different type.", "0"]
+      [0, 0, 0, "Unexpected any. Specify a different type.", "0"],
+      [0, 0, 0, "Do not use any type assertions.", "1"],
+      [0, 0, 0, "Do not use any type assertions.", "2"],
+      [0, 0, 0, "Do not use any type assertions.", "3"],
+      [0, 0, 0, "Do not use any type assertions.", "4"],
+      [0, 0, 0, "Do not use any type assertions.", "5"]
     ],
     "public/app/features/canvas/runtime/frame.tsx:5381": [
       [0, 0, 0, "Do not use any type assertions.", "0"]

--- a/public/app/features/canvas/runtime/element.tsx
+++ b/public/app/features/canvas/runtime/element.tsx
@@ -191,16 +191,18 @@ export class ElementState implements LayerElement {
     this.sizeStyle = style;
 
     if (this.div) {
-      for (const [key, value] of Object.entries(this.sizeStyle)) {
-        this.div.style.setProperty(key, value);
+      for (const key in this.sizeStyle) {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        this.div.style[key as any] = (this.sizeStyle as any)[key];
       }
 
       // TODO: This is a hack, we should have a better way to handle this
       const elementType = this.options.type;
       if (!SVGElements.has(elementType)) {
         // apply styles to div if it's not an SVG element
-        for (const [key, value] of Object.entries(this.dataStyle)) {
-          this.div.style.setProperty(key, value);
+        for (const key in this.dataStyle) {
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          this.div.style[key as any] = (this.dataStyle as any)[key];
         }
       } else {
         // ELEMENT IS SVG
@@ -209,7 +211,8 @@ export class ElementState implements LayerElement {
         // wrapper div element (this.div) doesn't re-render (has static `key` property),
         // so we have to clean styles manually;
         for (const key in this.dataStyle) {
-          this.div.style.removeProperty(key);
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          this.div.style[key as any] = '';
         }
       }
     }


### PR DESCRIPTION
Fix canvas style regression introduced by https://github.com/grafana/grafana/pull/87306 😬 I think we may want to consider improvements on how we handle these type of changes on final days of bug bash

Before
![Screenshot 2024-05-03 at 4 28 11 PM](https://github.com/grafana/grafana/assets/22381771/2298bdca-2c96-4edf-9cf4-266a32d6490e)



After

![Screenshot 2024-05-03 at 4 25 56 PM](https://github.com/grafana/grafana/assets/22381771/417454b6-4927-4a3d-bf47-9fb2f29de2eb)


Fixes https://github.com/grafana/grafana/issues/87359