### PR TITLE
chore: rename 'Incidents' sidebar to 'Incident' (the product name)

### DIFF
--- a/pkg/services/navtree/navtreeimpl/applinks.go
+++ b/pkg/services/navtree/navtreeimpl/applinks.go
@@ -292,7 +292,7 @@ func (s *ServiceImpl) readNavigationSettings() {
 		"grafana-kowalski-app":             {SectionID: navtree.NavIDRoot, SortWeight: navtree.WeightFrontend, Text: "Frontend", Icon: "frontend-observability"},
 		"grafana-synthetic-monitoring-app": {SectionID: navtree.NavIDTestingAndSynthetics, SortWeight: 2, Text: "Synthetics"},
 		"grafana-oncall-app":               {SectionID: navtree.NavIDAlertsAndIncidents, SortWeight: 1, Text: "OnCall"},
-		"grafana-incident-app":             {SectionID: navtree.NavIDAlertsAndIncidents, SortWeight: 2, Text: "Incidents"},
+		"grafana-incident-app":             {SectionID: navtree.NavIDAlertsAndIncidents, SortWeight: 2, Text: "Incident"},
 		"grafana-ml-app":                   {SectionID: navtree.NavIDAlertsAndIncidents, SortWeight: 3, Text: "Machine Learning"},
 		"grafana-slo-app":                  {SectionID: navtree.NavIDAlertsAndIncidents, SortWeight: 4},
 		"grafana-cloud-link-app":           {SectionID: navtree.NavIDCfgPlugins, SortWeight: 3},

--- a/public/app/core/utils/navBarItem-translations.ts
+++ b/public/app/core/utils/navBarItem-translations.ts
@@ -137,7 +137,7 @@ export function getNavTitle(navId: string | undefined) {
     case 'testing-and-synthetics':
       return t('nav.testing-and-synthetics.title', 'Testing & synthetics');
     case 'plugin-page-grafana-incident-app':
-      return t('nav.incidents.title', 'Incidents');
+      return t('nav.incidents.title', 'Incident');
     case 'plugin-page-grafana-ml-app':
       return t('nav.machine-learning.title', 'Machine learning');
     case 'plugin-page-grafana-slo-app':

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -1112,7 +1112,7 @@
       "title": "Home"
     },
     "incidents": {
-      "title": "Incidents"
+      "title": "Incident"
     },
     "infrastructure": {
       "subtitle": "Understand your infrastructure's health",

--- a/public/locales/pseudo-LOCALE/grafana.json
+++ b/public/locales/pseudo-LOCALE/grafana.json
@@ -1112,7 +1112,7 @@
       "title": "Ħőmę"
     },
     "incidents": {
-      "title": "Ĩŉčįđęŉŧş"
+      "title": "Ĩŉčįđęŉŧ"
     },
     "infrastructure": {
       "subtitle": "Ůŉđęřşŧäŉđ yőūř įŉƒřäşŧřūčŧūřę'ş ĥęäľŧĥ",


### PR DESCRIPTION
**What is this change?**

We need to update the sidebar entry of Grafana Incident from 'Incidents' to 'Incident' due to a behaviour change in the plugin. Before, clicking "Incidents" would show a list of all incidents. But the 'all incidents' functionality has been moved to a subpage, and now the top level application is an overview of the application state, so we'd like to rename the entry to be the Product name.

This will make us consistent with other products like OnCall, which use the product name in the sidebar.

**Why do we need this feature?**

Right now, it's confusing to have "Incidents" not show a list of incidents, but a product landing page.

**Who is this feature for?**

All Grafana Cloud users.

**Special notes for your reviewer:**

I'm not sure I did the translations right and whether there are tools for this.
Note that the change is to the 'product name', which might not be the literal translation of the word.

Please check that:

- [x] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle.
- [x] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
