### PR TITLE
plugin metadata schema: allow multiple infixed dash-separated words in plugin id

### DIFF
--- a/docs/sources/developers/plugins/plugin.schema.json
+++ b/docs/sources/developers/plugins/plugin.schema.json
@@ -10,7 +10,7 @@
     "id": {
       "type": "string",
       "description": "Unique name of the plugin. If the plugin is published on grafana.com, then the plugin `id` has to follow the naming conventions.",
-      "pattern": "^[0-9a-z]+\\-([0-9a-z]+\\-)?(app|panel|datasource|secretsmanager)$"
+      "pattern": "^[0-9a-z]+\\-([0-9a-z]+\\-)*(app|panel|datasource|secretsmanager)$"
     },
     "type": {
       "type": "string",


### PR DESCRIPTION


<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

Allows schema to accept multiple dash-separated words in the plugin id.

Currently, if you have a plugin id that happens to have more than two dash-separated words before the suffix, the schema will generate a warning.

e.g., `grafana-my-verbose-plugin-app`

![image](https://github.com/grafana/grafana/assets/38694490/99a6432c-283b-461e-9b91-f9501326dc21)

On hover:
![image](https://github.com/grafana/grafana/assets/38694490/c8628fbf-7a1c-4aba-a46e-62482cf83b63)


**Why do we need this feature?**

Since various plugins already have more dash-separations in their id than the current regular expression allows, they will not generate warnings with this new regular expression.
Despite the warning, there does not appear to be a technical reason to restrict the plugin id.

**Who is this feature for?**

Plugin developers with additional `-` separators in their plugin ids.

**Notes**


The former regular expression would allow: `my-app` and `my-simple-app`, due to the use of `?`.
The new regular expression deliberately retains this, assuming it was intentional, by using `*`.
The difference is that this now allows `my-somewhat-longer-named-app`.

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
