### PR TITLE
ext_jwt: streamline expected aud in access tokens and id tokens

### DIFF
--- a/pkg/services/authn/clients/ext_jwt.go
+++ b/pkg/services/authn/clients/ext_jwt.go
@@ -21,25 +21,22 @@ import (
 var _ authn.Client = new(ExtendedJWT)
 
 const (
-	rfc9068ShortMediaType          = "at+jwt"
-	extJWTAuthenticationHeaderName = "X-Access-Token"
-	extJWTAuthorizationHeaderName  = "X-Grafana-Id"
+	extJWTAuthenticationHeaderName  = "X-Access-Token"
+	extJWTAuthorizationHeaderName   = "X-Grafana-Id"
+	extJWTAccessTokenExpectAudience = "grafana"
 )
 
 func ProvideExtendedJWT(userService user.Service, cfg *setting.Cfg,
 	signingKeys signingkeys.Service) *ExtendedJWT {
 	verifier := authlib.NewAccessTokenVerifier(authlib.VerifierConfig{
-		SigningKeysURL: cfg.ExtJWTAuth.JWKSUrl,
-		AllowedAudiences: []string{
-			cfg.ExtJWTAuth.ExpectAudience,
-		},
+		SigningKeysURL:   cfg.ExtJWTAuth.JWKSUrl,
+		AllowedAudiences: []string{extJWTAccessTokenExpectAudience},
 	})
 
+	// For ID tokens, we explicitly do not validate audience, hence an empty AllowedAudiences
+	// Namespace claim will be checked
 	idTokenVerifier := authlib.NewIDTokenVerifier(authlib.VerifierConfig{
 		SigningKeysURL: cfg.ExtJWTAuth.JWKSUrl,
-		AllowedAudiences: []string{
-			cfg.ExtJWTAuth.ExpectAudience,
-		},
 	})
 
 	return &ExtendedJWT{

--- a/pkg/services/authn/clients/ext_jwt_test.go
+++ b/pkg/services/authn/clients/ext_jwt_test.go
@@ -38,7 +38,7 @@ var (
 		Claims: &jwt.Claims{
 			Issuer:   "http://localhost:3000",
 			Subject:  "access-policy:this-uid",
-			Audience: jwt.Audience{"http://localhost:3000"},
+			Audience: jwt.Audience{extJWTAccessTokenExpectAudience},
 			ID:       "1234567890",
 			Expiry:   jwt.NewNumericDate(time.Date(2023, 5, 3, 0, 0, 0, 0, time.UTC)),
 			IssuedAt: jwt.NewNumericDate(time.Date(2023, 5, 2, 0, 0, 0, 0, time.UTC)),
@@ -54,7 +54,7 @@ var (
 		Claims: &jwt.Claims{
 			Issuer:   "http://localhost:3000",
 			Subject:  "user:2",
-			Audience: jwt.Audience{"http://localhost:3000"},
+			Audience: jwt.Audience{"stack:1"},
 			ID:       "1234567890",
 			Expiry:   jwt.NewNumericDate(time.Date(2023, 5, 3, 0, 0, 0, 0, time.UTC)),
 			IssuedAt: jwt.NewNumericDate(time.Date(2023, 5, 2, 0, 0, 0, 0, time.UTC)),
@@ -68,7 +68,7 @@ var (
 		Claims: &jwt.Claims{
 			Issuer:   "http://localhost:3000",
 			Subject:  "access-policy:this-uid",
-			Audience: jwt.Audience{"http://localhost:3000"},
+			Audience: jwt.Audience{extJWTAccessTokenExpectAudience},
 			ID:       "1234567890",
 			Expiry:   jwt.NewNumericDate(time.Date(2023, 5, 3, 0, 0, 0, 0, time.UTC)),
 			IssuedAt: jwt.NewNumericDate(time.Date(2023, 5, 2, 0, 0, 0, 0, time.UTC)),
@@ -81,7 +81,7 @@ var (
 		Claims: &jwt.Claims{
 			Issuer:   "http://localhost:3000",
 			Subject:  "user:2",
-			Audience: jwt.Audience{"http://localhost:3000"},
+			Audience: jwt.Audience{"stack:1234"},
 			ID:       "1234567890",
 			Expiry:   jwt.NewNumericDate(time.Date(2023, 5, 3, 0, 0, 0, 0, time.UTC)),
 			IssuedAt: jwt.NewNumericDate(time.Date(2023, 5, 2, 0, 0, 0, 0, time.UTC)),
@@ -530,9 +530,8 @@ func setupTestCtx(cfg *setting.Cfg) *testEnv {
 		cfg = &setting.Cfg{
 			// default org set up by the authenticator is 1
 			ExtJWTAuth: setting.ExtJWTSettings{
-				Enabled:        true,
-				ExpectIssuer:   "http://localhost:3000",
-				ExpectAudience: "http://localhost:3000",
+				Enabled:      true,
+				ExpectIssuer: "http://localhost:3000",
 			},
 		}
 	}

--- a/pkg/setting/setting_jwt.go
+++ b/pkg/setting/setting_jwt.go
@@ -26,17 +26,15 @@ type AuthJWTSettings struct {
 }
 
 type ExtJWTSettings struct {
-	Enabled        bool
-	ExpectIssuer   string
-	ExpectAudience string
-	JWKSUrl        string
+	Enabled      bool
+	ExpectIssuer string
+	JWKSUrl      string
 }
 
 func (cfg *Cfg) readAuthExtJWTSettings() {
 	authExtendedJWT := cfg.SectionWithEnvOverrides("auth.extended_jwt")
 	jwtSettings := ExtJWTSettings{}
 	jwtSettings.Enabled = authExtendedJWT.Key("enabled").MustBool(false)
-	jwtSettings.ExpectAudience = authExtendedJWT.Key("expect_audience").MustString("")
 	jwtSettings.JWKSUrl = authExtendedJWT.Key("jwks_url").MustString("")
 	cfg.ExtJWTAuth = jwtSettings
 }


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

As it has shaken out, we are now using the `namespace` claim to enforce authentication and not the audience value. Hence, a static value for `aud` equaling `grafana` is acceptable.

For ID tokens, we have historically followed a different pattern for `aud`. To not break external clients consuming these ID tokens, we may keep generating them the same as we have. This PR just relaxes the requirement to validate their `aud` here in Grafana. Instead, the namespace claim will be relied upon here as well.

**Why do we need this feature?**

Restores Service OBO use case which otherwise has broken from this divergence in expect_audiences for the two verifiers.

**Who is this feature for?**

Grafana App Platform

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
