### PR TITLE
display permission in UI if only actionsets

### DIFF
--- a/pkg/services/accesscontrol/resourcepermissions/service.go
+++ b/pkg/services/accesscontrol/resourcepermissions/service.go
@@ -66,7 +66,13 @@ func New(cfg *setting.Cfg,
 		for _, a := range actions {
 			actionSet[a] = struct{}{}
 		}
+
+		// Add action sets to the service
+		// this adds the action set to inmemory cache
 		actionSetService.StoreActionSet(options.Resource, permission, actions)
+
+		// Store the action set name for actions to the service
+		actionSet[actionSetService.GetActionSetName(options.Resource, permission)] = struct{}{}
 	}
 
 	// Sort all permissions based on action length. Will be used when mapping between actions to permissions


### PR DESCRIPTION
**why**
we are not displaying the managed permission in the UI correctly.

**what**
we need to add the actionset to the actions in the initiation of the service

https://github.com/grafana/identity-access-team/issues/674

