### PR TITLE
Revert #86466

### DIFF
--- a/pkg/api/pluginproxy/ds_proxy.go
+++ b/pkg/api/pluginproxy/ds_proxy.go
@@ -19,7 +19,6 @@ import (
 	glog "github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/infra/tracing"
 	"github.com/grafana/grafana/pkg/plugins"
-	"github.com/grafana/grafana/pkg/services/accesscontrol"
 	contextmodel "github.com/grafana/grafana/pkg/services/contexthandler/model"
 	"github.com/grafana/grafana/pkg/services/datasources"
 	"github.com/grafana/grafana/pkg/services/featuremgmt"
@@ -305,8 +304,10 @@ func (proxy *DataSourceProxy) validateRequest() error {
 			continue
 		}
 
-		if !proxy.hasAccessToRoute(route) {
-			return errors.New("plugin proxy route access denied")
+		if route.ReqRole.IsValid() {
+			if !proxy.ctx.HasUserRole(route.ReqRole) {
+				return errors.New("plugin proxy route access denied")
+			}
 		}
 
 		proxy.matchedRoute = route
@@ -327,22 +328,6 @@ func (proxy *DataSourceProxy) validateRequest() error {
 	}
 
 	return nil
-}
-
-func (proxy *DataSourceProxy) hasAccessToRoute(route *plugins.Route) bool {
-	useRBAC := proxy.features.IsEnabled(proxy.ctx.Req.Context(), featuremgmt.FlagAccessControlOnCall) && route.ReqAction != ""
-	if useRBAC {
-		routeEval := accesscontrol.EvalPermission(route.ReqAction)
-		ok := routeEval.Evaluate(proxy.ctx.GetPermissions())
-		if !ok {
-			proxy.ctx.Logger.Debug("plugin route is covered by RBAC, user doesn't have access", "route", proxy.ctx.Req.URL.Path)
-		}
-		return ok
-	}
-	if route.ReqRole.IsValid() {
-		return proxy.ctx.HasUserRole(route.ReqRole)
-	}
-	return true
 }
 
 func (proxy *DataSourceProxy) logRequest() {

--- a/pkg/api/pluginproxy/pluginproxy.go
+++ b/pkg/api/pluginproxy/pluginproxy.go
@@ -122,7 +122,7 @@ func (proxy *PluginProxy) HandleRequest() {
 }
 
 func (proxy *PluginProxy) hasAccessToRoute(route *plugins.Route) bool {
-	useRBAC := proxy.features.IsEnabled(proxy.ctx.Req.Context(), featuremgmt.FlagAccessControlOnCall) && route.ReqAction != ""
+	useRBAC := proxy.features.IsEnabled(proxy.ctx.Req.Context(), featuremgmt.FlagAccessControlOnCall) && route.RequiresRBACAction()
 	if useRBAC {
 		hasAccess := ac.HasAccess(proxy.accessControl, proxy.ctx)(ac.EvalPermission(route.ReqAction))
 		if !hasAccess {

--- a/pkg/plugins/plugins.go
+++ b/pkg/plugins/plugins.go
@@ -204,6 +204,10 @@ type Route struct {
 	Body         json.RawMessage `json:"body"`
 }
 
+func (r *Route) RequiresRBACAction() bool {
+	return r.ReqAction != ""
+}
+
 // Header describes an HTTP header that is forwarded with
 // the proxied request for a plugin route
 type Header struct {


### PR DESCRIPTION
This reverts commit 53f94ac50dde7bc6c25f6a8254e85a2e8b1ae138.

https://github.com/grafana/grafana/pull/86466

We've been hearing reports that this is breaking authorization logic for some existing plugins, so we will revert it for now and work with the broken plugins to understand a better rollout path.