### PR TITLE
Dashboard scenes: Fix view panel breadcrum when going to edit from view single panel

### DIFF
--- a/public/app/features/dashboard-scene/scene/DashboardScene.tsx
+++ b/public/app/features/dashboard-scene/scene/DashboardScene.tsx
@@ -44,7 +44,7 @@ import { historySrv } from '../settings/version-history';
 import { DashboardModelCompatibilityWrapper } from '../utils/DashboardModelCompatibilityWrapper';
 import { dashboardSceneGraph, getLibraryVizPanelFromVizPanel } from '../utils/dashboardSceneGraph';
 import { djb2Hash } from '../utils/djb2Hash';
-import { getDashboardUrl } from '../utils/urlBuilders';
+import { getDashboardUrl, getViewPanelUrl } from '../utils/urlBuilders';
 import {
   NEW_PANEL_HEIGHT,
   NEW_PANEL_WIDTH,
@@ -418,6 +418,7 @@ export class DashboardScene extends SceneObjectBase<DashboardSceneState> {
       pageNav = {
         text: 'View panel',
         parentItem: pageNav,
+        url: getViewPanelUrl(viewPanelScene.state.panelRef.resolve()),
       };
     }
 

--- a/public/app/features/dashboard-scene/utils/urlBuilders.ts
+++ b/public/app/features/dashboard-scene/utils/urlBuilders.ts
@@ -83,7 +83,10 @@ export function getDashboardUrl(options: DashboardUrlOptions) {
 }
 
 export function getViewPanelUrl(vizPanel: VizPanel) {
-  return locationUtil.getUrlForPartial(locationService.getLocation(), { viewPanel: vizPanel.state.key });
+  return locationUtil.getUrlForPartial(locationService.getLocation(), {
+    viewPanel: vizPanel.state.key,
+    editPanel: undefined,
+  });
 }
 
 export function getEditPanelUrl(panelId: number) {


### PR DESCRIPTION
This fixes the issue where we're not getting a proper url for the view panel bread crumb when going from a single panel view into editing that panel.

Fixes #86963