### PR TITLE
IDToken: Set typ header

### DIFF
--- a/pkg/services/auth/idimpl/service.go
+++ b/pkg/services/auth/idimpl/service.go
@@ -104,7 +104,7 @@ func (s *Service) SignIdentity(ctx context.Context, id identity.Requester) (stri
 		}
 
 		extracted := auth.IDClaims{}
-		// We don't need to verify the signature here, we are only intrested in checking
+		// We don't need to verify the signature here, we are only interested in checking
 		// when the token expires.
 		if err := parsed.UnsafeClaimsWithoutVerification(&extracted); err != nil {
 			s.metrics.failedTokenSigningCounter.Inc()

--- a/pkg/services/auth/idimpl/signer.go
+++ b/pkg/services/auth/idimpl/signer.go
@@ -54,7 +54,10 @@ func (s *LocalSigner) getSigner(ctx context.Context) (jose.Signer, error) {
 	}
 
 	signer, err := jose.NewSigner(jose.SigningKey{Algorithm: jose.ES256, Key: key}, &jose.SignerOptions{
-		ExtraHeaders: map[jose.HeaderKey]any{headerKeyID: id},
+		ExtraHeaders: map[jose.HeaderKey]any{
+			headerKeyID:     id,
+			jose.HeaderType: "jwt",
+		},
 	})
 
 	if err != nil {


### PR DESCRIPTION
**What is this feature?**
We should set `typ` header for id tokens to `jwt`. This will allow us to properly validate these tokens using authlib.

**Which issue(s) does this PR fix?**:

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
