### PR TITLE
DashboardDataSource: Fixes issue where sometimes untransformed data could be returned 

### DIFF
--- a/public/app/features/query/state/runRequest.ts
+++ b/public/app/features/query/state/runRequest.ts
@@ -159,7 +159,6 @@ export function runRequest(
       request.endTime = Date.now();
 
       state = processResponsePacket(packet, state);
-      console.log('runRequest ' + datasource.uid, state);
 
       return state.panelData;
     }),

--- a/public/app/features/query/state/runRequest.ts
+++ b/public/app/features/query/state/runRequest.ts
@@ -159,6 +159,7 @@ export function runRequest(
       request.endTime = Date.now();
 
       state = processResponsePacket(packet, state);
+      console.log('runRequest ' + datasource.uid, state);
 
       return state.panelData;
     }),

--- a/public/app/plugins/datasource/dashboard/datasource.test.ts
+++ b/public/app/plugins/datasource/dashboard/datasource.test.ts
@@ -26,6 +26,16 @@ describe('DashboardDatasource', () => {
     expect(rsp?.data[0].fields[0].values).toEqual([1, 2, 3]);
   });
 
+  it('should always set response key', async () => {
+    const { observable } = setup({ refId: 'A', panelId: 1 });
+
+    let rsp: DataQueryResponse | undefined;
+
+    observable.subscribe({ next: (data) => (rsp = data) });
+
+    expect(rsp?.key).toEqual('source-ds-provider');
+  });
+
   it('Can subscribe to panel data + transforms', async () => {
     const { observable } = setup({ refId: 'A', panelId: 1, withTransforms: true });
 

--- a/public/app/plugins/datasource/dashboard/datasource.ts
+++ b/public/app/plugins/datasource/dashboard/datasource.ts
@@ -76,6 +76,7 @@ export class DashboardDatasource extends DataSourceApi<DashboardQuery> {
             state: result.data.state,
             errors: result.data.errors,
             error: result.data.error,
+            key: 'source-ds-provider',
           };
         }),
         finalize(cleanUp)


### PR DESCRIPTION
Fixes #87219

Oh boy this was hard to debug and replicate. 

Can only be replicated with a mixed data source, with two queries for 2 different data sources. And a join transform. 

The problem was caused by the join transform returning the raw data when there was only 1 series, this returned data with refId intact. The dashboard data source did not set any key on it's response packet so this caused runRequest to mix up the partial response (untransformed data), with the later transformed data. 

https://github.com/grafana/grafana/blob/main/public/app/features/query/state/runRequest.ts#L51

While debugging this I also found this issue: https://github.com/grafana/scenes/pull/720 
 
To replicate the issue this dashboard:

<details>
   <summary>JSON Block</summary>

```json
{
  "__inputs": [
    {
      "name": "DS_GDEV-TESTDATA",
      "label": "gdev-testdata",
      "description": "",
      "type": "datasource",
      "pluginId": "grafana-testdata-datasource",
      "pluginName": "TestData"
    },
    {
      "name": "DS_THIRD_TEST DATA",
      "label": "Third test data",
      "description": "",
      "type": "datasource",
      "pluginId": "grafana-testdata-datasource",
      "pluginName": "TestData"
    }
  ],
  "__elements": {},
  "__requires": [
    {
      "type": "grafana",
      "id": "grafana",
      "name": "Grafana",
      "version": "11.1.0-pre"
    },
    {
      "type": "datasource",
      "id": "grafana-testdata-datasource",
      "name": "TestData",
      "version": "11.1.0-pre"
    },
    {
      "type": "panel",
      "id": "table",
      "name": "Table",
      "version": ""
    }
  ],
  "annotations": {
    "list": [
      {
        "builtIn": 1,
        "datasource": {
          "type": "grafana",
          "uid": "-- Grafana --"
        },
        "enable": false,
        "hide": true,
        "iconColor": "rgba(0, 211, 255, 1)",
        "name": "Annotations & Alerts",
        "target": {
          "limit": 100,
          "matchAny": false,
          "tags": [],
          "type": "dashboard"
        },
        "type": "dashboard"
      }
    ]
  },
  "editable": true,
  "fiscalYearStartMonth": 0,
  "graphTooltip": 0,
  "id": null,
  "links": [],
  "panels": [
    {
      "datasource": {
        "type": "datasource",
        "uid": "-- Mixed --"
      },
      "fieldConfig": {
        "defaults": {
          "color": {
            "mode": "palette-classic"
          },
          "custom": {
            "align": "auto",
            "cellOptions": {
              "type": "auto"
            },
            "inspect": false
          },
          "mappings": [],
          "thresholds": {
            "mode": "absolute",
            "steps": [
              {
                "color": "green",
                "value": null
              },
              {
                "color": "red",
                "value": 80
              }
            ]
          }
        },
        "overrides": []
      },
      "gridPos": {
        "h": 8,
        "w": 12,
        "x": 0,
        "y": 0
      },
      "id": 1,
      "options": {
        "cellHeight": "sm",
        "footer": {
          "countRows": false,
          "fields": "",
          "reducer": [
            "sum"
          ],
          "show": false
        },
        "showHeader": true,
        "sortBy": [
          {
            "desc": false,
            "displayName": "B-renamed"
          }
        ]
      },
      "pluginVersion": "11.1.0-pre",
      "targets": [
        {
          "alias": "",
          "csvContent": "A, B\nName, 10\nGoogle, 12",
          "datasource": {
            "type": "grafana-testdata-datasource",
            "uid": "${DS_GDEV-TESTDATA}"
          },
          "refId": "Something",
          "scenarioId": "csv_content"
        },
        {
          "alias": "",
          "csvContent": "A,C\nName, 100\nGoogle, 200",
          "datasource": {
            "type": "grafana-testdata-datasource",
            "uid": "${DS_THIRD_TEST DATA}"
          },
          "refId": "SomehingElse",
          "scenarioId": "csv_content"
        }
      ],
      "title": "Source",
      "transformations": [
        {
          "id": "joinByField",
          "options": {
            "byField": "A",
            "mode": "inner"
          }
        }
      ],
      "type": "table"
    },
    {
      "datasource": {
        "type": "datasource",
        "uid": "-- Dashboard --"
      },
      "fieldConfig": {
        "defaults": {
          "color": {
            "mode": "palette-classic"
          },
          "custom": {
            "align": "auto",
            "cellOptions": {
              "type": "auto"
            },
            "inspect": false
          },
          "mappings": [],
          "thresholds": {
            "mode": "absolute",
            "steps": [
              {
                "color": "green",
                "value": null
              },
              {
                "color": "red",
                "value": 80
              }
            ]
          }
        },
        "overrides": []
      },
      "gridPos": {
        "h": 8,
        "w": 12,
        "x": 0,
        "y": 8
      },
      "id": 2,
      "options": {
        "cellHeight": "sm",
        "footer": {
          "countRows": false,
          "fields": "",
          "reducer": [
            "sum"
          ],
          "show": false
        },
        "showHeader": true
      },
      "pluginVersion": "11.1.0-pre",
      "targets": [
        {
          "datasource": {
            "type": "datasource",
            "uid": "-- Dashboard --"
          },
          "panelId": 1,
          "refId": "A",
          "withTransforms": true
        }
      ],
      "title": "Using ",
      "type": "table"
    }
  ],
  "schemaVersion": 39,
  "tags": [],
  "templating": {
    "list": []
  },
  "time": {
    "from": "now-6h",
    "to": "now"
  },
  "timeRangeUpdatedDuringEditOrView": false,
  "timepicker": {},
  "timezone": "browser",
  "title": "Dashboard dat",
  "uid": "edkkk9kds2jnkb",
  "version": 14,
  "weekStart": ""
}
```
</details>
