### PR TITLE
GrafanaUI: Add `tabular` prop to Text component for tabular numbers

### DIFF
--- a/packages/grafana-ui/src/components/Text/Text.mdx
+++ b/packages/grafana-ui/src/components/Text/Text.mdx
@@ -42,6 +42,7 @@ In this documentation you can find:
 - Heading should be organized in hierarchy.
 - When a heading needs to have the appearance of another heading rank but it will affect the page heading hierarchy, use `variant` prop to modify its style instead.
 - Use weight or italic for emphasis.
+- Use the `tabular` prop when numbers should have a fixed width, such as in tables.
 
 ### **Don'ts**
 

--- a/packages/grafana-ui/src/components/Text/Text.story.tsx
+++ b/packages/grafana-ui/src/components/Text/Text.story.tsx
@@ -41,6 +41,7 @@ const meta: Meta = {
     },
     truncate: { control: 'boolean' },
     italic: { control: 'boolean' },
+    tabular: { control: 'boolean' },
     textAlignment: {
       control: 'select',
       options: ['inherit', 'initial', 'left', 'right', 'center', 'justify', undefined],
@@ -90,7 +91,7 @@ export const Example: StoryFn = (args) => {
 
 Example.parameters = {
   controls: {
-    exclude: ['element', 'variant', 'weight', 'textAlignment', 'truncate', 'italic', 'color', 'children'],
+    exclude: ['element', 'variant', 'weight', 'textAlignment', 'truncate', 'italic', 'tabular', 'color', 'children'],
   },
 };
 

--- a/packages/grafana-ui/src/components/Text/Text.tsx
+++ b/packages/grafana-ui/src/components/Text/Text.tsx
@@ -21,14 +21,19 @@ export interface TextProps extends Omit<React.HTMLAttributes<HTMLElement>, 'clas
   truncate?: boolean;
   /** If true, show the text as italic. False by default */
   italic?: boolean;
+  /** If true, numbers will have fixed width, useful for displaying tabular data. False by default */
+  tabular?: boolean;
   /** Whether to align the text to left, center or right */
   textAlignment?: CSSProperties['textAlign'];
   children: NonNullable<React.ReactNode>;
 }
 
 export const Text = React.forwardRef<HTMLElement, TextProps>(
-  ({ element = 'span', variant, weight, color, truncate, italic, textAlignment, children, ...restProps }, ref) => {
-    const styles = useStyles2(getTextStyles, element, variant, color, weight, truncate, italic, textAlignment);
+  (
+    { element = 'span', variant, weight, color, truncate, italic, textAlignment, children, tabular, ...restProps },
+    ref
+  ) => {
+    const styles = useStyles2(getTextStyles, element, variant, color, weight, truncate, italic, textAlignment, tabular);
 
     const childElement = (ref: React.ForwardedRef<HTMLElement> | undefined) => {
       return createElement(
@@ -71,7 +76,8 @@ const getTextStyles = (
   weight?: TextProps['weight'],
   truncate?: TextProps['truncate'],
   italic?: TextProps['italic'],
-  textAlignment?: TextProps['textAlignment']
+  textAlignment?: TextProps['textAlignment'],
+  tabular?: TextProps['tabular']
 ) => {
   return css([
     {
@@ -98,6 +104,9 @@ const getTextStyles = (
     },
     textAlignment && {
       textAlign: textAlignment,
+    },
+    tabular && {
+      fontFeatureSettings: '"tnum"',
     },
   ]);
 };


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

Adds a prop `tabular` to the `Text` component so that we can represent digits all with the same width, for instance for comparing values in a table

| Without tabular | With tabular |
| --- | --- |
| <img width="370" alt="Screenshot 2024-05-07 at 14 13 43" src="https://github.com/grafana/grafana/assets/100691367/7da8294b-330b-41cf-a628-3a96e490db5d"> | <img width="381" alt="Screenshot 2024-05-07 at 14 13 48" src="https://github.com/grafana/grafana/assets/100691367/61691f25-80b9-4c4c-9423-effca2035121"> |


**Why do we need this feature?**

So there is a better way to display numbers that need to be compared with each other.

**Who is this feature for?**

Developers

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #82371

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
