### PR TITLE
Prometheus: Use correct datasources:write permission

### DIFF
--- a/public/app/plugins/datasource/prometheus/plugin.json
+++ b/public/app/plugins/datasource/prometheus/plugin.json
@@ -44,25 +44,25 @@
       "method": "POST",
       "path": "/rules",
       "reqRole": "Editor",
-      "reqAction": "datasources:edit"
+      "reqAction": "datasources:write"
     },
     {
       "method": "DELETE",
       "path": "/rules",
       "reqRole": "Editor",
-      "reqAction": "datasources:edit"
+      "reqAction": "datasources:write"
     },
     {
       "method": "DELETE",
       "path": "/config/v1/rules",
       "reqRole": "Editor",
-      "reqAction": "datasources:edit"
+      "reqAction": "datasources:write"
     },
     {
       "method": "POST",
       "path": "/config/v1/rules",
       "reqRole": "Editor",
-      "reqAction": "datasources:edit"
+      "reqAction": "datasources:write"
     }
   ],
   "includes": [


### PR DESCRIPTION
The datasources:edit permission does not exist and should have been write to begin with.

Fixes and issue where users might be unable to interact with datasources when RBAC is enabled.

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
