### PR TITLE
K8s: Add path rewriter filter

### DIFF
--- a/pkg/apiserver/endpoints/filters/path_rewriter.go
+++ b/pkg/apiserver/endpoints/filters/path_rewriter.go
@@ -1,0 +1,31 @@
+package filters
+
+import (
+	"net/http"
+	"regexp"
+)
+
+type PathRewriter struct {
+	Pattern     *regexp.Regexp
+	ReplaceFunc func([]string) string
+}
+
+func (r *PathRewriter) Rewrite(path string) (string, bool) {
+	matches := r.Pattern.FindStringSubmatch(path)
+	if matches == nil {
+		return path, false
+	}
+	return r.ReplaceFunc(r.Pattern.FindStringSubmatch(path)), true
+}
+
+func WithPathRewriters(handler http.Handler, rewriters []PathRewriter) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		for _, rewriter := range rewriters {
+			if newPath, ok := rewriter.Rewrite(req.URL.Path); ok {
+				req.URL.Path = newPath
+				break
+			}
+		}
+		handler.ServeHTTP(w, req)
+	})
+}

--- a/pkg/apiserver/endpoints/filters/path_rewriter_test.go
+++ b/pkg/apiserver/endpoints/filters/path_rewriter_test.go
@@ -1,0 +1,47 @@
+package filters
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"regexp"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func Test_WithPathRewriters(t *testing.T) {
+	mockHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, err := w.Write([]byte(r.URL.Path))
+		require.NoError(t, err)
+	})
+
+	rewriters := []PathRewriter{
+		{
+			Pattern: regexp.MustCompile(`(/apis/scope.grafana.app/.*/query)(/.*)`),
+			ReplaceFunc: func(matches []string) string {
+				return matches[1]
+			},
+		},
+	}
+	handler := WithPathRewriters(mockHandler, rewriters)
+
+	t.Run("should rewrite path", func(t *testing.T) {
+		req, err := http.NewRequest("GET", "/apis/scope.grafana.app/namespaces/stack-1234/query/blah", nil)
+		assert.NoError(t, err)
+		rr := httptest.NewRecorder()
+		handler.ServeHTTP(rr, req)
+		assert.Equal(t, http.StatusOK, rr.Code)
+		assert.Equal(t, "/apis/scope.grafana.app/namespaces/stack-1234/query", rr.Body.String())
+	})
+
+	t.Run("should ignore requests that don't match", func(t *testing.T) {
+		req, err := http.NewRequest("GET", "/apis/scope.grafana.app/namespaces/stack-1234/scopes/1", nil)
+		assert.NoError(t, err)
+		rr := httptest.NewRecorder()
+		handler.ServeHTTP(rr, req)
+		assert.Equal(t, http.StatusOK, rr.Code)
+		assert.Equal(t, "/apis/scope.grafana.app/namespaces/stack-1234/scopes/1", rr.Body.String())
+	})
+}


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

This adds a `PathRewriter` filter that can be used to modify routes before they reach K8s default handlers.

**Why do we need this feature?**

This is used by #87457 to modify routing for a custom endpoint.

**Who is this feature for?**

[Add information on what kind of user the feature is for.]

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
