### PR TITLE
Provisioning: Look up provisioned folders by UID when possible

### DIFF
--- a/pkg/services/provisioning/dashboards/file_reader.go
+++ b/pkg/services/provisioning/dashboards/file_reader.go
@@ -339,10 +339,16 @@ func (fr *FileReader) getOrCreateFolder(ctx context.Context, cfg *config, servic
 
 	metrics.MFolderIDsServiceCount.WithLabelValues(metrics.Provisioning).Inc()
 	cmd := &dashboards.GetDashboardQuery{
-		Title:    &folderName,
 		FolderID: util.Pointer(int64(0)), // nolint:staticcheck
 		OrgID:    cfg.OrgID,
 	}
+
+	if cfg.FolderUID != "" {
+		cmd.UID = cfg.FolderUID
+	} else {
+		cmd.Title = &folderName
+	}
+
 	result, err := fr.dashboardStore.GetDashboard(ctx, cmd)
 
 	if err != nil && !errors.Is(err, dashboards.ErrDashboardNotFound) {


### PR DESCRIPTION
This PR attempts to fix a bug that prevents Grafana from starting after a provisioned folder has been renamed.

It modifies the provisioning code to look up the folder by UID rather than Title when the UID is specified in the provisioning configuration.