### PR TITLE
Dashboard scenes: Fix issue going from view panel to edit panel when dashboard is not in edit mode

### DIFF
--- a/public/app/features/dashboard-scene/scene/DashboardSceneUrlSync.test.ts
+++ b/public/app/features/dashboard-scene/scene/DashboardSceneUrlSync.test.ts
@@ -41,6 +41,17 @@ describe('DashboardSceneUrlSync', () => {
     });
   });
 
+  describe('entering edit mode', () => {
+    it('it should be possible to go from the view panel view to the edit view when the dashboard is not in edit mdoe', () => {
+      const scene = buildTestScene();
+      scene.setState({ isEditing: false });
+      scene.urlSync?.updateFromUrl({ viewPanel: 'panel-1' });
+      expect(scene.state.viewPanelScene).toBeDefined();
+      scene.urlSync?.updateFromUrl({ editPanel: 'panel-1' });
+      expect(scene.state.editPanel).toBeDefined();
+    });
+  });
+
   describe('Given a viewPanelKey with clone that is not found', () => {
     const scene = buildTestScene();
 

--- a/public/app/features/dashboard-scene/scene/DashboardSceneUrlSync.ts
+++ b/public/app/features/dashboard-scene/scene/DashboardSceneUrlSync.ts
@@ -129,6 +129,11 @@ export class DashboardSceneUrlSync implements SceneObjectUrlSyncHandler {
         return;
       }
 
+      // We cannot simultaneously be in edit and view panel state.
+      if (this._scene.state.viewPanelScene) {
+        this._scene.setState({ viewPanelScene: undefined });
+      }
+
       // If we are not in editing (for example after full page reload)
       if (!isEditing) {
         this._scene.onEnterEditMode();

--- a/public/app/features/dashboard-scene/utils/urlBuilders.ts
+++ b/public/app/features/dashboard-scene/utils/urlBuilders.ts
@@ -90,7 +90,7 @@ export function getViewPanelUrl(vizPanel: VizPanel) {
 }
 
 export function getEditPanelUrl(panelId: number) {
-  return locationUtil.getUrlForPartial(locationService.getLocation(), { editPanel: panelId });
+  return locationUtil.getUrlForPartial(locationService.getLocation(), { editPanel: panelId, viewPanel: undefined });
 }
 
 export function getInspectUrl(vizPanel: VizPanel, inspectTab?: InspectTab) {


### PR DESCRIPTION
**What is this feature?**
This aligns the new architecture with the old, by always treating entering into edit view, as if we're coming from the dashboard. Before this PR, when entering into the edit view, we would keep the view single panel state in the dashboard scene. This was causing issues by displaying a "view panel" breadcrumb and causing issues cloning the dashboard.

With this change we always treat entering into the edit view as if the user is coming from the dashboard.

Fixes #87412

