### PR TITLE
[v9.5.x] Provisioning: Look up provisioned folders by UID when possible

### DIFF
--- a/pkg/services/provisioning/dashboards/file_reader.go
+++ b/pkg/services/provisioning/dashboards/file_reader.go
@@ -299,10 +299,16 @@ func (fr *FileReader) getOrCreateFolderID(ctx context.Context, cfg *config, serv
 	}
 
 	cmd := &dashboards.GetDashboardQuery{
-		Title:    &folderName,
-		FolderID: util.Pointer(int64(0)),
+		FolderID: util.Pointer(int64(0)), // nolint:staticcheck
 		OrgID:    cfg.OrgID,
 	}
+
+	if cfg.FolderUID != "" {
+		cmd.UID = cfg.FolderUID
+	} else {
+		cmd.Title = &folderName
+	}
+
 	result, err := fr.dashboardStore.GetDashboard(ctx, cmd)
 
 	if err != nil && !errors.Is(err, dashboards.ErrDashboardNotFound) {


### PR DESCRIPTION
Backport 1884b03511f20068dc60c38d6262120350766792 from #87465

---

This PR attempts to fix a bug that prevents Grafana from starting after a provisioned folder has been renamed.

It modifies the provisioning code to look up the folder by UID rather than Title when the UID is specified in the provisioning configuration.
