### PR TITLE
sqlstore: Fix DB name parsing failing with quotes

### DIFF
--- a/pkg/services/sqlstore/migrator/postgres_dialect.go
+++ b/pkg/services/sqlstore/migrator/postgres_dialect.go
@@ -340,7 +340,7 @@ func (db *PostgresDialect) GetDBName(dsn string) (string, error) {
 		}
 		dsn = parsedDSN
 	}
-	re := regexp.MustCompile(`dbname=(\w+)`)
+	re := regexp.MustCompile(`dbname='?(\w+)'?`)
 	submatch := re.FindSubmatch([]byte(dsn))
 	if len(submatch) < 2 {
 		return "", fmt.Errorf("failed to get database name")


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

This is a bug fix for the `GetDBName` method of postgresql dialect of `sqlstore/migrator`. It was failing to parse the DB name if the DSN used quotes. 

**Why do we need this feature?**

Entity Server uses quotes to generate the connection string after #85293 got merged.


**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
