### PR TITLE
Button: Allow disabled button to still be focused

### DIFF
--- a/packages/grafana-ui/src/components/Button/Button.story.tsx
+++ b/packages/grafana-ui/src/components/Button/Button.story.tsx
@@ -1,3 +1,4 @@
+import { action } from '@storybook/addon-actions';
 import { StoryFn } from '@storybook/react';
 import React from 'react';
 
@@ -25,6 +26,9 @@ export default {
     },
     tooltip: {
       control: 'text',
+    },
+    disabled: {
+      control: 'boolean',
     },
     className: {
       table: {
@@ -96,7 +100,9 @@ export const Examples: StoryFn<typeof Button> = () => {
   );
 };
 
-export const Basic: StoryFn<typeof Button> = (args: ButtonProps) => <Button {...args} />;
+export const Basic: StoryFn<typeof Button> = (args: ButtonProps) => (
+  <Button onClick={action('clicked button')} {...args} />
+);
 
 Basic.args = {
   children: 'Example button',

--- a/packages/grafana-ui/src/components/Button/Button.tsx
+++ b/packages/grafana-ui/src/components/Button/Button.tsx
@@ -65,12 +65,12 @@ export const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
     const buttonStyles = cx(
       styles.button,
       {
-        [css(styles.disabled, {
-          '&:hover': css(styles.disabled),
-        })]: disabled,
+        [styles.disabled]: disabled,
       },
       className
     );
+
+    const hasTooltip = Boolean(tooltip);
 
     // In order to standardise Button please always consider using IconButton when you need a button with an icon only
     // When using tooltip, ref is forwarded to Tooltip component instead for https://github.com/grafana/grafana/issues/65632
@@ -80,7 +80,10 @@ export const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
         type={type}
         onClick={disabled ? undefined : onClick}
         {...otherProps}
-        aria-disabled={disabled}
+        // In order for the tooltip to be accessible when disabled,
+        // we need to set aria-disabled instead of the native disabled attribute
+        aria-disabled={hasTooltip && disabled}
+        disabled={!hasTooltip && disabled}
         ref={tooltip ? undefined : ref}
       >
         <IconRenderer icon={icon} size={size} className={styles.icon} />
@@ -237,7 +240,9 @@ export const getButtonStyles = (props: StyleProps) => {
       ':disabled': disabledStyles,
       '&[disabled]': disabledStyles,
     }),
-    disabled: css(disabledStyles),
+    disabled: css(disabledStyles, {
+      '&:hover': css(disabledStyles),
+    }),
     img: css({
       width: '16px',
       height: '16px',

--- a/packages/grafana-ui/src/components/Button/Button.tsx
+++ b/packages/grafana-ui/src/components/Button/Button.tsx
@@ -45,7 +45,9 @@ export const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
       className,
       type = 'button',
       tooltip,
+      disabled,
       tooltipPlacement,
+      onClick,
       ...otherProps
     },
     ref
@@ -60,10 +62,27 @@ export const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
       iconOnly: !children,
     });
 
+    const buttonStyles = cx(
+      styles.button,
+      {
+        [css(styles.disabled, {
+          '&:hover': css(styles.disabled),
+        })]: disabled,
+      },
+      className
+    );
+
     // In order to standardise Button please always consider using IconButton when you need a button with an icon only
     // When using tooltip, ref is forwarded to Tooltip component instead for https://github.com/grafana/grafana/issues/65632
     const button = (
-      <button className={cx(styles.button, className)} type={type} {...otherProps} ref={tooltip ? undefined : ref}>
+      <button
+        className={buttonStyles}
+        type={type}
+        onClick={disabled ? undefined : onClick}
+        {...otherProps}
+        aria-disabled={disabled}
+        ref={tooltip ? undefined : ref}
+      >
         <IconRenderer icon={icon} size={size} className={styles.icon} />
         {children && <span className={styles.content}>{children}</span>}
       </button>


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

This feature allows the button component to still be focused even when disabled. For it we use `aria-disabled` instead of the native `disabled` property from html and apply the same styles as when `disabled`.

https://github.com/grafana/grafana/assets/100691367/26ede6ee-9f4e-4ce4-93c9-7763802c6402

**Why do we need this feature?**

Currently when we set up the `disabled` html property of a `button`, you can no longer navigate to it with the keyboard. This has two main issues:
- If there is a tooltip on it explaining why it is disabled, keyboard users cannot see it
- Removing the button from the tab order means that someone using a screen reader and tabbing through the content won't even know a button is there.

**Who is this feature for?**

Everyone, but specifically for users who navigate via keyboard

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #69401

**Special notes for your reviewer:**

Further reading: [Making Disabled Buttons More Inclusive](https://css-tricks.com/making-disabled-buttons-more-inclusive/)
Would be interested to know if this would be something we want applied to other components that have a `disabled` property.

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
