### PR TITLE
RBAC: Update role picker in team page, fix a bug with roles being removed upon team setting update

### DIFF
--- a/public/app/features/teams/TeamSettings.tsx
+++ b/public/app/features/teams/TeamSettings.tsx
@@ -1,14 +1,13 @@
-import React, { useState } from 'react';
+import React from 'react';
 import { useForm } from 'react-hook-form';
 import { connect, ConnectedProps } from 'react-redux';
 
 import { Input, Field, Button, FieldSet, Stack } from '@grafana/ui';
 import { TeamRolePicker } from 'app/core/components/RolePicker/TeamRolePicker';
-import { updateTeamRoles } from 'app/core/components/RolePicker/api';
 import { useRoleOptions } from 'app/core/components/RolePicker/hooks';
 import { SharedPreferences } from 'app/core/components/SharedPreferences/SharedPreferences';
 import { contextSrv } from 'app/core/services/context_srv';
-import { AccessControlAction, Role, Team } from 'app/types';
+import { AccessControlAction, Team } from 'app/types';
 
 import { updateTeam } from './state/actions';
 
@@ -28,7 +27,6 @@ export const TeamSettings = ({ team, updateTeam }: Props) => {
   const currentOrgId = contextSrv.user.orgId;
 
   const [{ roleOptions }] = useRoleOptions(currentOrgId);
-  const [pendingRoles, setPendingRoles] = useState<Role[]>([]);
   const {
     handleSubmit,
     register,
@@ -44,9 +42,6 @@ export const TeamSettings = ({ team, updateTeam }: Props) => {
     contextSrv.hasPermission(AccessControlAction.ActionRolesList);
 
   const onSubmit = async (formTeam: Team) => {
-    if (contextSrv.licensedAccessControlEnabled() && canUpdateRoles) {
-      await updateTeamRoles(pendingRoles, team.id);
-    }
     updateTeam(formTeam.name, formTeam.email || '');
   };
 
@@ -66,15 +61,7 @@ export const TeamSettings = ({ team, updateTeam }: Props) => {
 
           {contextSrv.licensedAccessControlEnabled() && canListRoles && (
             <Field label="Role">
-              <TeamRolePicker
-                teamId={team.id}
-                roleOptions={roleOptions}
-                disabled={!canUpdateRoles}
-                apply={true}
-                onApplyRoles={setPendingRoles}
-                pendingRoles={pendingRoles}
-                maxWidth="100%"
-              />
+              <TeamRolePicker teamId={team.id} roleOptions={roleOptions} disabled={!canUpdateRoles} maxWidth="100%" />
             </Field>
           )}
 


### PR DESCRIPTION
**What is this feature?**

Change the team role update flow by immediately applying the selected roles through the role picker, instead of requiring the user to also press on _Update_ button for team settings.

**Why do we need this feature?**

Currently team role update through team settings page has the following flow:
* click on the role picker, select the roles that you want;
* click on _apply_ in the role picker;
* click on _update_ in team settings.

There are two problems with it:
1) we apply empty set of roles if no role changes are made and _Update_ is clicked;
2) this is inconsistent with role pickers in other places (eg, service account role picker) that immediately update the roles.

While 1) could be solved differently, I've opted for this solution, as it also solves 2).

**Who is this feature for?**

Users who use RBAC for teams.

**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/grafana-enterprise/issues/6602

**Special notes for your reviewer:**

I still don't really like the team setting UI - it is weird that role picker is inside the section that seems to be covered by the `Update` button, but gets updated separately. Perhaps we should redo this page to be similar to service account setting page.
