### PR TITLE
Update JWT auth page

### DIFF
--- a/docs/sources/setup-grafana/configure-security/configure-authentication/jwt/index.md
+++ b/docs/sources/setup-grafana/configure-security/configure-authentication/jwt/index.md
@@ -4,7 +4,6 @@ aliases:
 description: Grafana JWT Authentication
 labels:
   products:
-    - cloud
     - enterprise
     - oss
 menuTitle: JWT


### PR DESCRIPTION
JWT is not applicable/available to Grafana Cloud. Only on-premise.

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
