### PR TITLE
Alerting: Do not store series values from past evaluations in state manager for no reason

### DIFF
--- a/pkg/services/ngalert/api/api_prometheus_test.go
+++ b/pkg/services/ngalert/api/api_prometheus_test.go
@@ -45,9 +45,7 @@ func Test_FormatValues(t *testing.T) {
 			name: "with no value, it renders the evaluation string",
 			alertState: &state.State{
 				LastEvaluationString: "[ var='A' metric='vector(10) + time() % 50' labels={} value=1.1 ]",
-				Results: []state.Evaluation{
-					{Condition: "A", Values: map[string]*float64{}},
-				},
+				LatestResult:         &state.Evaluation{Condition: "A", Values: map[string]*float64{}},
 			},
 			expected: "[ var='A' metric='vector(10) + time() % 50' labels={} value=1.1 ]",
 		},
@@ -55,9 +53,7 @@ func Test_FormatValues(t *testing.T) {
 			name: "with one value, it renders the single value",
 			alertState: &state.State{
 				LastEvaluationString: "[ var='A' metric='vector(10) + time() % 50' labels={} value=1.1 ]",
-				Results: []state.Evaluation{
-					{Condition: "A", Values: map[string]*float64{"A": &val1}},
-				},
+				LatestResult:         &state.Evaluation{Condition: "A", Values: map[string]*float64{"A": &val1}},
 			},
 			expected: "1.1e+00",
 		},
@@ -65,9 +61,7 @@ func Test_FormatValues(t *testing.T) {
 			name: "with two values, it renders the value based on their refID and position",
 			alertState: &state.State{
 				LastEvaluationString: "[ var='B0' metric='vector(10) + time() % 50' labels={} value=1.1 ], [ var='B1' metric='vector(10) + time() % 50' labels={} value=1.4 ]",
-				Results: []state.Evaluation{
-					{Condition: "B", Values: map[string]*float64{"B0": &val1, "B1": &val2}},
-				},
+				LatestResult:         &state.Evaluation{Condition: "B", Values: map[string]*float64{"B0": &val1, "B1": &val2}},
 			},
 			expected: "B0: 1.1e+00, B1: 1.4e+00",
 		},
@@ -75,9 +69,7 @@ func Test_FormatValues(t *testing.T) {
 			name: "with a high number of values, it renders the value based on their refID and position using a natural order",
 			alertState: &state.State{
 				LastEvaluationString: "[ var='B0' metric='vector(10) + time() % 50' labels={} value=1.1 ], [ var='B1' metric='vector(10) + time() % 50' labels={} value=1.4 ]",
-				Results: []state.Evaluation{
-					{Condition: "B", Values: map[string]*float64{"B0": &val1, "B1": &val2, "B2": &val1, "B10": &val2, "B11": &val1}},
-				},
+				LatestResult:         &state.Evaluation{Condition: "B", Values: map[string]*float64{"B0": &val1, "B1": &val2, "B2": &val1, "B10": &val2, "B11": &val1}},
 			},
 			expected: "B0: 1.1e+00, B10: 1.4e+00, B11: 1.1e+00, B1: 1.4e+00, B2: 1.1e+00",
 		},
@@ -246,12 +238,12 @@ func withAlertingState() forEachState {
 	return func(s *state.State) *state.State {
 		s.State = eval.Alerting
 		value := float64(1.1)
-		s.Results = append(s.Results, state.Evaluation{
+		s.LatestResult = &state.Evaluation{
 			EvaluationState: eval.Alerting,
 			EvaluationTime:  timeNow(),
 			Values:          map[string]*float64{"B": &value},
 			Condition:       "B",
-		})
+		}
 		return s
 	}
 }

--- a/pkg/services/ngalert/api/testing.go
+++ b/pkg/services/ngalert/api/testing.go
@@ -83,17 +83,10 @@ func (f *fakeAlertInstanceManager) GenerateAlertInstances(orgID int64, alertRule
 				"instance_label":               "test",
 			},
 			State: eval.Normal,
-			Results: []state.Evaluation{
-				{
-					EvaluationTime:  evaluationTime,
-					EvaluationState: eval.Normal,
-					Values:          make(map[string]*float64),
-				},
-				{
-					EvaluationTime:  evaluationTime.Add(1 * time.Minute),
-					EvaluationState: eval.Normal,
-					Values:          make(map[string]*float64),
-				},
+			LatestResult: &state.Evaluation{
+				EvaluationTime:  evaluationTime.Add(1 * time.Minute),
+				EvaluationState: eval.Normal,
+				Values:          make(map[string]*float64),
 			},
 			LastEvaluationTime: evaluationTime.Add(1 * time.Minute),
 			EvaluationDuration: evaluationDuration,

--- a/pkg/services/ngalert/schedule/alert_rule_test.go
+++ b/pkg/services/ngalert/schedule/alert_rule_test.go
@@ -311,13 +311,13 @@ func TestRuleRoutine(t *testing.T) {
 				require.Len(t, states, 1)
 				s := states[0]
 				require.Equal(t, rule.UID, s.AlertRuleUID)
-				require.Len(t, s.Results, 1)
+				require.NotNil(t, s.LatestResult)
 				var expectedStatus = evalState
 				if evalState == eval.Pending {
 					expectedStatus = eval.Alerting
 				}
-				require.Equal(t, expectedStatus.String(), s.Results[0].EvaluationState.String())
-				require.Equal(t, expectedTime, s.Results[0].EvaluationTime)
+				require.Equal(t, expectedStatus.String(), s.LatestResult.EvaluationState.String())
+				require.Equal(t, expectedTime, s.LatestResult.EvaluationTime)
 			})
 			t.Run("it should save alert instances to storage", func(t *testing.T) {
 				// TODO rewrite when we are able to mock/fake state manager

--- a/pkg/services/ngalert/state/manager.go
+++ b/pkg/services/ngalert/state/manager.go
@@ -358,14 +358,13 @@ func (st *Manager) setNextState(ctx context.Context, alertRule *ngModels.AlertRu
 
 	currentState.LastEvaluationTime = result.EvaluatedAt
 	currentState.EvaluationDuration = result.EvaluationDuration
-	currentState.Results = append(currentState.Results, Evaluation{
+	currentState.LatestResult = &Evaluation{
 		EvaluationTime:  result.EvaluatedAt,
 		EvaluationState: result.State,
 		Values:          NewEvaluationValues(result.Values),
 		Condition:       alertRule.Condition,
-	})
+	}
 	currentState.LastEvaluationString = result.EvaluationString
-	currentState.TrimResults(alertRule)
 	oldState := currentState.State
 	oldReason := currentState.StateReason
 

--- a/pkg/services/ngalert/state/manager_private_test.go
+++ b/pkg/services/ngalert/state/manager_private_test.go
@@ -149,8 +149,8 @@ func TestProcessEvalResults_StateTransitions(t *testing.T) {
 		return ngmodels.CopyRule(baseRule, mutators...)
 	}
 
-	newEvaluation := func(evalTime time.Time, evalState eval.State) Evaluation {
-		return Evaluation{
+	newEvaluation := func(evalTime time.Time, evalState eval.State) *Evaluation {
+		return &Evaluation{
 			EvaluationTime:  evalTime,
 			EvaluationState: evalState,
 			Values:          make(map[string]*float64),
@@ -325,11 +325,9 @@ func TestProcessEvalResults_StateTransitions(t *testing.T) {
 					{
 						PreviousState: eval.Normal,
 						State: &State{
-							Labels: labels["system + rule + labels1"],
-							State:  eval.Normal,
-							Results: []Evaluation{
-								newEvaluation(t1, eval.Normal),
-							},
+							Labels:             labels["system + rule + labels1"],
+							State:              eval.Normal,
+							LatestResult:       newEvaluation(t1, eval.Normal),
 							StartsAt:           t1,
 							EndsAt:             t1,
 							LastEvaluationTime: t1,
@@ -338,11 +336,9 @@ func TestProcessEvalResults_StateTransitions(t *testing.T) {
 					{
 						PreviousState: eval.Normal,
 						State: &State{
-							Labels: labels["system + rule + labels2"],
-							State:  eval.Normal,
-							Results: []Evaluation{
-								newEvaluation(t1, eval.Normal),
-							},
+							Labels:             labels["system + rule + labels2"],
+							State:              eval.Normal,
+							LatestResult:       newEvaluation(t1, eval.Normal),
 							StartsAt:           t1,
 							EndsAt:             t1,
 							LastEvaluationTime: t1,
@@ -365,11 +361,9 @@ func TestProcessEvalResults_StateTransitions(t *testing.T) {
 					{
 						PreviousState: eval.Normal,
 						State: &State{
-							Labels: labels["system + rule + labels1"],
-							State:  eval.Alerting,
-							Results: []Evaluation{
-								newEvaluation(t1, eval.Alerting),
-							},
+							Labels:             labels["system + rule + labels1"],
+							State:              eval.Alerting,
+							LatestResult:       newEvaluation(t1, eval.Alerting),
 							StartsAt:           t1,
 							EndsAt:             t1.Add(ResendDelay * 4),
 							LastEvaluationTime: t1,
@@ -378,11 +372,9 @@ func TestProcessEvalResults_StateTransitions(t *testing.T) {
 					{
 						PreviousState: eval.Normal,
 						State: &State{
-							Labels: labels["system + rule + labels2"],
-							State:  eval.Normal,
-							Results: []Evaluation{
-								newEvaluation(t1, eval.Normal),
-							},
+							Labels:             labels["system + rule + labels2"],
+							State:              eval.Normal,
+							LatestResult:       newEvaluation(t1, eval.Normal),
 							StartsAt:           t1,
 							EndsAt:             t1,
 							LastEvaluationTime: t1,
@@ -405,11 +397,9 @@ func TestProcessEvalResults_StateTransitions(t *testing.T) {
 					{
 						PreviousState: eval.Normal,
 						State: &State{
-							Labels: labels["system + rule + labels1"],
-							State:  eval.Pending,
-							Results: []Evaluation{
-								newEvaluation(t1, eval.Alerting),
-							},
+							Labels:             labels["system + rule + labels1"],
+							State:              eval.Pending,
+							LatestResult:       newEvaluation(t1, eval.Alerting),
 							StartsAt:           t1,
 							EndsAt:             t1.Add(ResendDelay * 4),
 							LastEvaluationTime: t1,
@@ -418,11 +408,9 @@ func TestProcessEvalResults_StateTransitions(t *testing.T) {
 					{
 						PreviousState: eval.Normal,
 						State: &State{
-							Labels: labels["system + rule + labels2"],
-							State:  eval.Normal,
-							Results: []Evaluation{
-								newEvaluation(t1, eval.Normal),
-							},
+							Labels:             labels["system + rule + labels2"],
+							State:              eval.Normal,
+							LatestResult:       newEvaluation(t1, eval.Normal),
 							StartsAt:           t1,
 							EndsAt:             t1,
 							LastEvaluationTime: t1,
@@ -449,12 +437,9 @@ func TestProcessEvalResults_StateTransitions(t *testing.T) {
 					{
 						PreviousState: eval.Normal,
 						State: &State{
-							Labels: labels["system + rule + labels1"],
-							State:  eval.Alerting,
-							Results: []Evaluation{
-								newEvaluation(t1, eval.Normal),
-								newEvaluation(t2, eval.Alerting),
-							},
+							Labels:             labels["system + rule + labels1"],
+							State:              eval.Alerting,
+							LatestResult:       newEvaluation(t2, eval.Alerting),
 							StartsAt:           t2,
 							EndsAt:             t2.Add(ResendDelay * 4),
 							LastEvaluationTime: t2,
@@ -463,12 +448,9 @@ func TestProcessEvalResults_StateTransitions(t *testing.T) {
 					{
 						PreviousState: eval.Normal,
 						State: &State{
-							Labels: labels["system + rule + labels2"],
-							State:  eval.Normal,
-							Results: []Evaluation{
-								newEvaluation(t1, eval.Normal),
-								newEvaluation(t2, eval.Normal),
-							},
+							Labels:             labels["system + rule + labels2"],
+							State:              eval.Normal,
+							LatestResult:       newEvaluation(t2, eval.Normal),
 							StartsAt:           t1,
 							EndsAt:             t1,
 							LastEvaluationTime: t2,
@@ -496,11 +478,9 @@ func TestProcessEvalResults_StateTransitions(t *testing.T) {
 					{
 						PreviousState: eval.Normal,
 						State: &State{
-							Labels: labels["system + rule + labels1"],
-							State:  eval.Pending,
-							Results: []Evaluation{
-								newEvaluation(t1, eval.Alerting),
-							},
+							Labels:             labels["system + rule + labels1"],
+							State:              eval.Pending,
+							LatestResult:       newEvaluation(t1, eval.Alerting),
 							StartsAt:           t1,
 							EndsAt:             t1.Add(ResendDelay * 4),
 							LastEvaluationTime: t1,
@@ -511,12 +491,9 @@ func TestProcessEvalResults_StateTransitions(t *testing.T) {
 					{
 						PreviousState: eval.Pending,
 						State: &State{
-							Labels: labels["system + rule + labels1"],
-							State:  eval.Pending,
-							Results: []Evaluation{
-								newEvaluation(t1, eval.Alerting),
-								newEvaluation(t2, eval.Alerting),
-							},
+							Labels:             labels["system + rule + labels1"],
+							State:              eval.Pending,
+							LatestResult:       newEvaluation(t2, eval.Alerting),
 							StartsAt:           t1,
 							EndsAt:             t1.Add(ResendDelay * 4), // TODO probably it should be t1 (semantic of Normal)?
 							LastEvaluationTime: t2,
@@ -527,12 +504,9 @@ func TestProcessEvalResults_StateTransitions(t *testing.T) {
 					{
 						PreviousState: eval.Pending,
 						State: &State{
-							Labels: labels["system + rule + labels1"],
-							State:  eval.Alerting,
-							Results: []Evaluation{
-								newEvaluation(t2, eval.Alerting),
-								newEvaluation(t3, eval.Alerting),
-							},
+							Labels:             labels["system + rule + labels1"],
+							State:              eval.Alerting,
+							LatestResult:       newEvaluation(t3, eval.Alerting),
 							StartsAt:           t3,
 							EndsAt:             t3.Add(ResendDelay * 4),
 							LastEvaluationTime: t3,
@@ -557,12 +531,9 @@ func TestProcessEvalResults_StateTransitions(t *testing.T) {
 					{
 						PreviousState: eval.Pending,
 						State: &State{
-							Labels: labels["system + rule + labels1"],
-							State:  eval.Normal,
-							Results: []Evaluation{
-								newEvaluation(t1, eval.Alerting),
-								newEvaluation(t2, eval.Normal),
-							},
+							Labels:             labels["system + rule + labels1"],
+							State:              eval.Normal,
+							LatestResult:       newEvaluation(t2, eval.Normal),
 							StartsAt:           t2,
 							EndsAt:             t2,
 							LastEvaluationTime: t2,
@@ -586,12 +557,9 @@ func TestProcessEvalResults_StateTransitions(t *testing.T) {
 				t2: {{
 					PreviousState: eval.Alerting,
 					State: &State{
-						Labels: labels["system + rule + labels1"],
-						State:  eval.Normal,
-						Results: []Evaluation{
-							newEvaluation(t1, eval.Alerting),
-							newEvaluation(t2, eval.Normal),
-						},
+						Labels:             labels["system + rule + labels1"],
+						State:              eval.Normal,
+						LatestResult:       newEvaluation(t2, eval.Normal),
 						StartsAt:           t2,
 						EndsAt:             t2,
 						LastEvaluationTime: t2,
@@ -622,12 +590,9 @@ func TestProcessEvalResults_StateTransitions(t *testing.T) {
 					{
 						PreviousState: eval.Normal,
 						State: &State{
-							Labels: labels["system + rule + labels3"],
-							State:  eval.Normal,
-							Results: []Evaluation{
-								newEvaluation(t1, eval.Normal),
-								newEvaluation(t2, eval.Normal),
-							},
+							Labels:             labels["system + rule + labels3"],
+							State:              eval.Normal,
+							LatestResult:       newEvaluation(t2, eval.Normal),
 							StartsAt:           t1,
 							EndsAt:             t1,
 							LastEvaluationTime: t2,
@@ -638,12 +603,10 @@ func TestProcessEvalResults_StateTransitions(t *testing.T) {
 					{
 						PreviousState: eval.Normal,
 						State: &State{
-							Labels:      labels["system + rule + labels1"],
-							State:       eval.Normal,
-							StateReason: ngmodels.StateReasonMissingSeries,
-							Results: []Evaluation{
-								newEvaluation(t1, eval.Normal),
-							},
+							Labels:             labels["system + rule + labels1"],
+							State:              eval.Normal,
+							StateReason:        ngmodels.StateReasonMissingSeries,
+							LatestResult:       newEvaluation(t1, eval.Normal),
 							StartsAt:           t1,
 							EndsAt:             t3,
 							LastEvaluationTime: t3,
@@ -652,12 +615,10 @@ func TestProcessEvalResults_StateTransitions(t *testing.T) {
 					{
 						PreviousState: eval.Alerting,
 						State: &State{
-							Labels:      labels["system + rule + labels2"],
-							State:       eval.Normal,
-							StateReason: ngmodels.StateReasonMissingSeries,
-							Results: []Evaluation{
-								newEvaluation(t1, eval.Alerting),
-							},
+							Labels:             labels["system + rule + labels2"],
+							State:              eval.Normal,
+							StateReason:        ngmodels.StateReasonMissingSeries,
+							LatestResult:       newEvaluation(t1, eval.Alerting),
 							StartsAt:           t1,
 							EndsAt:             t3,
 							LastEvaluationTime: t3,
@@ -667,13 +628,9 @@ func TestProcessEvalResults_StateTransitions(t *testing.T) {
 					{
 						PreviousState: eval.Normal,
 						State: &State{
-							Labels: labels["system + rule + labels3"],
-							State:  eval.Normal,
-							Results: []Evaluation{
-								newEvaluation(t1, eval.Normal),
-								newEvaluation(t2, eval.Normal),
-								newEvaluation(t3, eval.Normal),
-							},
+							Labels:             labels["system + rule + labels3"],
+							State:              eval.Normal,
+							LatestResult:       newEvaluation(t3, eval.Normal),
 							StartsAt:           t1,
 							EndsAt:             t1,
 							LastEvaluationTime: t3,
@@ -695,11 +652,9 @@ func TestProcessEvalResults_StateTransitions(t *testing.T) {
 					{
 						PreviousState: eval.Normal,
 						State: &State{
-							Labels: labels["system + rule"],
-							State:  eval.Normal,
-							Results: []Evaluation{
-								newEvaluation(t1, eval.Normal),
-							},
+							Labels:             labels["system + rule"],
+							State:              eval.Normal,
+							LatestResult:       newEvaluation(t1, eval.Normal),
 							StartsAt:           t1,
 							EndsAt:             t1,
 							LastEvaluationTime: t1,
@@ -721,11 +676,9 @@ func TestProcessEvalResults_StateTransitions(t *testing.T) {
 					{
 						PreviousState: eval.Normal,
 						State: &State{
-							Labels: labels["system + rule"],
-							State:  eval.Alerting,
-							Results: []Evaluation{
-								newEvaluation(t1, eval.Alerting),
-							},
+							Labels:             labels["system + rule"],
+							State:              eval.Alerting,
+							LatestResult:       newEvaluation(t1, eval.Alerting),
 							StartsAt:           t1,
 							EndsAt:             t1.Add(ResendDelay * 4),
 							LastEvaluationTime: t1,
@@ -747,11 +700,9 @@ func TestProcessEvalResults_StateTransitions(t *testing.T) {
 					{
 						PreviousState: eval.Normal,
 						State: &State{
-							Labels: labels["system + rule"],
-							State:  eval.Pending,
-							Results: []Evaluation{
-								newEvaluation(t1, eval.Alerting),
-							},
+							Labels:             labels["system + rule"],
+							State:              eval.Pending,
+							LatestResult:       newEvaluation(t1, eval.Alerting),
 							StartsAt:           t1,
 							EndsAt:             t1.Add(ResendDelay * 4),
 							LastEvaluationTime: t1,
@@ -776,12 +727,9 @@ func TestProcessEvalResults_StateTransitions(t *testing.T) {
 					{
 						PreviousState: eval.Normal,
 						State: &State{
-							Labels: labels["system + rule"],
-							State:  eval.Alerting,
-							Results: []Evaluation{
-								newEvaluation(t1, eval.Normal),
-								newEvaluation(t2, eval.Alerting),
-							},
+							Labels:             labels["system + rule"],
+							State:              eval.Alerting,
+							LatestResult:       newEvaluation(t2, eval.Alerting),
 							StartsAt:           t2,
 							EndsAt:             t2.Add(ResendDelay * 4),
 							LastEvaluationTime: t2,
@@ -865,11 +813,9 @@ func TestProcessEvalResults_StateTransitions(t *testing.T) {
 							{
 								PreviousState: eval.Normal,
 								State: &State{
-									Labels: labels["system + rule + no-data"],
-									State:  eval.NoData,
-									Results: []Evaluation{
-										newEvaluation(t1, eval.NoData),
-									},
+									Labels:             labels["system + rule + no-data"],
+									State:              eval.NoData,
+									LatestResult:       newEvaluation(t1, eval.NoData),
 									StartsAt:           t1,
 									EndsAt:             t1.Add(ResendDelay * 4),
 									LastEvaluationTime: t1,
@@ -882,12 +828,10 @@ func TestProcessEvalResults_StateTransitions(t *testing.T) {
 							{
 								PreviousState: eval.Normal,
 								State: &State{
-									Labels:      labels["system + rule + no-data"],
-									State:       eval.Alerting,
-									StateReason: eval.NoData.String(),
-									Results: []Evaluation{
-										newEvaluation(t1, eval.NoData),
-									},
+									Labels:             labels["system + rule + no-data"],
+									State:              eval.Alerting,
+									StateReason:        eval.NoData.String(),
+									LatestResult:       newEvaluation(t1, eval.NoData),
 									StartsAt:           t1,
 									EndsAt:             t1.Add(ResendDelay * 4),
 									LastEvaluationTime: t1,
@@ -900,12 +844,10 @@ func TestProcessEvalResults_StateTransitions(t *testing.T) {
 							{
 								PreviousState: eval.Normal,
 								State: &State{
-									Labels:      labels["system + rule + no-data"],
-									State:       eval.Normal,
-									StateReason: eval.NoData.String(),
-									Results: []Evaluation{
-										newEvaluation(t1, eval.NoData),
-									},
+									Labels:             labels["system + rule + no-data"],
+									State:              eval.Normal,
+									StateReason:        eval.NoData.String(),
+									LatestResult:       newEvaluation(t1, eval.NoData),
 									StartsAt:           t1,
 									EndsAt:             t1,
 									LastEvaluationTime: t1,
@@ -918,12 +860,10 @@ func TestProcessEvalResults_StateTransitions(t *testing.T) {
 							{
 								PreviousState: eval.Normal,
 								State: &State{
-									Labels:      labels["system + rule + no-data"],
-									State:       eval.Normal,
-									StateReason: ngmodels.ConcatReasons(eval.NoData.String(), ngmodels.StateReasonKeepLast),
-									Results: []Evaluation{
-										newEvaluation(t1, eval.NoData),
-									},
+									Labels:             labels["system + rule + no-data"],
+									State:              eval.Normal,
+									StateReason:        ngmodels.ConcatReasons(eval.NoData.String(), ngmodels.StateReasonKeepLast),
+									LatestResult:       newEvaluation(t1, eval.NoData),
 									StartsAt:           t1,
 									EndsAt:             t1,
 									LastEvaluationTime: t1,
@@ -949,11 +889,9 @@ func TestProcessEvalResults_StateTransitions(t *testing.T) {
 							{
 								PreviousState: eval.Normal,
 								State: &State{
-									Labels: labels["system + rule + no-data"],
-									State:  eval.NoData,
-									Results: []Evaluation{
-										newEvaluation(t2, eval.NoData),
-									},
+									Labels:             labels["system + rule + no-data"],
+									State:              eval.NoData,
+									LatestResult:       newEvaluation(t2, eval.NoData),
 									StartsAt:           t2,
 									EndsAt:             t2.Add(ResendDelay * 4),
 									LastEvaluationTime: t2,
@@ -966,12 +904,10 @@ func TestProcessEvalResults_StateTransitions(t *testing.T) {
 							{
 								PreviousState: eval.Normal,
 								State: &State{
-									Labels:      labels["system + rule + no-data"],
-									State:       eval.Alerting,
-									StateReason: eval.NoData.String(),
-									Results: []Evaluation{
-										newEvaluation(t2, eval.NoData),
-									},
+									Labels:             labels["system + rule + no-data"],
+									State:              eval.Alerting,
+									StateReason:        eval.NoData.String(),
+									LatestResult:       newEvaluation(t2, eval.NoData),
 									StartsAt:           t2,
 									EndsAt:             t2.Add(ResendDelay * 4),
 									LastEvaluationTime: t2,
@@ -984,12 +920,10 @@ func TestProcessEvalResults_StateTransitions(t *testing.T) {
 							{
 								PreviousState: eval.Normal,
 								State: &State{
-									Labels:      labels["system + rule + no-data"],
-									State:       eval.Normal,
-									StateReason: eval.NoData.String(),
-									Results: []Evaluation{
-										newEvaluation(t2, eval.NoData),
-									},
+									Labels:             labels["system + rule + no-data"],
+									State:              eval.Normal,
+									StateReason:        eval.NoData.String(),
+									LatestResult:       newEvaluation(t2, eval.NoData),
 									StartsAt:           t2,
 									EndsAt:             t2,
 									LastEvaluationTime: t2,
@@ -1002,12 +936,10 @@ func TestProcessEvalResults_StateTransitions(t *testing.T) {
 							{
 								PreviousState: eval.Normal,
 								State: &State{
-									Labels:      labels["system + rule + no-data"],
-									State:       eval.Normal,
-									StateReason: ngmodels.ConcatReasons(eval.NoData.String(), ngmodels.StateReasonKeepLast),
-									Results: []Evaluation{
-										newEvaluation(t2, eval.NoData),
-									},
+									Labels:             labels["system + rule + no-data"],
+									State:              eval.Normal,
+									StateReason:        ngmodels.ConcatReasons(eval.NoData.String(), ngmodels.StateReasonKeepLast),
+									LatestResult:       newEvaluation(t2, eval.NoData),
 									StartsAt:           t2,
 									EndsAt:             t2,
 									LastEvaluationTime: t2,
@@ -1022,13 +954,10 @@ func TestProcessEvalResults_StateTransitions(t *testing.T) {
 							{
 								PreviousState: eval.Normal,
 								State: &State{
-									Labels:      labels["system + rule + labels1"],
-									State:       eval.Alerting,
-									StateReason: eval.NoData.String(),
-									Results: []Evaluation{
-										newEvaluation(t1, eval.Normal),
-										newEvaluation(t2, eval.NoData),
-									},
+									Labels:             labels["system + rule + labels1"],
+									State:              eval.Alerting,
+									StateReason:        eval.NoData.String(),
+									LatestResult:       newEvaluation(t2, eval.NoData),
 									StartsAt:           t2,
 									EndsAt:             t2.Add(ResendDelay * 4),
 									LastEvaluationTime: t2,
@@ -1041,13 +970,10 @@ func TestProcessEvalResults_StateTransitions(t *testing.T) {
 							{
 								PreviousState: eval.Normal,
 								State: &State{
-									Labels:      labels["system + rule + labels1"],
-									State:       eval.Normal,
-									StateReason: eval.NoData.String(),
-									Results: []Evaluation{
-										newEvaluation(t1, eval.Normal),
-										newEvaluation(t2, eval.NoData),
-									},
+									Labels:             labels["system + rule + labels1"],
+									State:              eval.Normal,
+									StateReason:        eval.NoData.String(),
+									LatestResult:       newEvaluation(t2, eval.NoData),
 									StartsAt:           t1,
 									EndsAt:             t1,
 									LastEvaluationTime: t2,
@@ -1060,13 +986,10 @@ func TestProcessEvalResults_StateTransitions(t *testing.T) {
 							{
 								PreviousState: eval.Normal,
 								State: &State{
-									Labels:      labels["system + rule + labels1"],
-									State:       eval.Normal,
-									StateReason: ngmodels.ConcatReasons(eval.NoData.String(), ngmodels.StateReasonKeepLast),
-									Results: []Evaluation{
-										newEvaluation(t1, eval.Normal),
-										newEvaluation(t2, eval.NoData),
-									},
+									Labels:             labels["system + rule + labels1"],
+									State:              eval.Normal,
+									StateReason:        ngmodels.ConcatReasons(eval.NoData.String(), ngmodels.StateReasonKeepLast),
+									LatestResult:       newEvaluation(t2, eval.NoData),
 									StartsAt:           t1,
 									EndsAt:             t1,
 									LastEvaluationTime: t2,
@@ -1096,11 +1019,9 @@ func TestProcessEvalResults_StateTransitions(t *testing.T) {
 							{
 								PreviousState: eval.Normal,
 								State: &State{
-									Labels: labels["system + rule + no-data"],
-									State:  eval.NoData,
-									Results: []Evaluation{
-										newEvaluation(t2, eval.NoData),
-									},
+									Labels:             labels["system + rule + no-data"],
+									State:              eval.NoData,
+									LatestResult:       newEvaluation(t2, eval.NoData),
 									StartsAt:           t2,
 									EndsAt:             t2.Add(ResendDelay * 4),
 									LastEvaluationTime: t2,
@@ -1111,12 +1032,10 @@ func TestProcessEvalResults_StateTransitions(t *testing.T) {
 							{
 								PreviousState: eval.Normal,
 								State: &State{
-									Labels:      labels["system + rule + labels1"],
-									State:       eval.Normal,
-									StateReason: ngmodels.StateReasonMissingSeries,
-									Results: []Evaluation{
-										newEvaluation(t1, eval.Normal),
-									},
+									Labels:             labels["system + rule + labels1"],
+									State:              eval.Normal,
+									StateReason:        ngmodels.StateReasonMissingSeries,
+									LatestResult:       newEvaluation(t1, eval.Normal),
 									StartsAt:           t1,
 									EndsAt:             t3,
 									LastEvaluationTime: t3,
@@ -1125,12 +1044,10 @@ func TestProcessEvalResults_StateTransitions(t *testing.T) {
 							{
 								PreviousState: eval.Alerting,
 								State: &State{
-									Labels:      labels["system + rule + labels2"],
-									State:       eval.Normal,
-									StateReason: ngmodels.StateReasonMissingSeries,
-									Results: []Evaluation{
-										newEvaluation(t1, eval.Alerting),
-									},
+									Labels:             labels["system + rule + labels2"],
+									State:              eval.Normal,
+									StateReason:        ngmodels.StateReasonMissingSeries,
+									LatestResult:       newEvaluation(t1, eval.Alerting),
 									StartsAt:           t1,
 									EndsAt:             t3,
 									LastEvaluationTime: t3,
@@ -1140,12 +1057,9 @@ func TestProcessEvalResults_StateTransitions(t *testing.T) {
 							{
 								PreviousState: eval.NoData,
 								State: &State{
-									Labels: labels["system + rule + no-data"],
-									State:  eval.NoData,
-									Results: []Evaluation{
-										newEvaluation(t2, eval.NoData),
-										newEvaluation(t3, eval.NoData),
-									},
+									Labels:             labels["system + rule + no-data"],
+									State:              eval.NoData,
+									LatestResult:       newEvaluation(t3, eval.NoData),
 									StartsAt:           t2,
 									EndsAt:             t3.Add(ResendDelay * 4),
 									LastEvaluationTime: t3,
@@ -1158,12 +1072,10 @@ func TestProcessEvalResults_StateTransitions(t *testing.T) {
 							{
 								PreviousState: eval.Normal,
 								State: &State{
-									Labels:      labels["system + rule + labels1"],
-									State:       eval.Normal,
-									StateReason: ngmodels.StateReasonMissingSeries,
-									Results: []Evaluation{
-										newEvaluation(t1, eval.Normal),
-									},
+									Labels:             labels["system + rule + labels1"],
+									State:              eval.Normal,
+									StateReason:        ngmodels.StateReasonMissingSeries,
+									LatestResult:       newEvaluation(t1, eval.Normal),
 									StartsAt:           t1,
 									EndsAt:             t3,
 									LastEvaluationTime: t3,
@@ -1172,12 +1084,10 @@ func TestProcessEvalResults_StateTransitions(t *testing.T) {
 							{
 								PreviousState: eval.Alerting,
 								State: &State{
-									Labels:      labels["system + rule + labels2"],
-									State:       eval.Normal,
-									StateReason: ngmodels.StateReasonMissingSeries,
-									Results: []Evaluation{
-										newEvaluation(t1, eval.Alerting),
-									},
+									Labels:             labels["system + rule + labels2"],
+									State:              eval.Normal,
+									StateReason:        ngmodels.StateReasonMissingSeries,
+									LatestResult:       newEvaluation(t1, eval.Alerting),
 									StartsAt:           t1,
 									EndsAt:             t3,
 									LastEvaluationTime: t3,
@@ -1188,13 +1098,10 @@ func TestProcessEvalResults_StateTransitions(t *testing.T) {
 								PreviousState:       eval.Alerting,
 								PreviousStateReason: eval.NoData.String(),
 								State: &State{
-									Labels:      labels["system + rule + no-data"],
-									State:       eval.Alerting,
-									StateReason: eval.NoData.String(),
-									Results: []Evaluation{
-										newEvaluation(t2, eval.NoData),
-										newEvaluation(t3, eval.NoData),
-									},
+									Labels:             labels["system + rule + no-data"],
+									State:              eval.Alerting,
+									StateReason:        eval.NoData.String(),
+									LatestResult:       newEvaluation(t3, eval.NoData),
 									StartsAt:           t2,
 									EndsAt:             t3.Add(ResendDelay * 4),
 									LastEvaluationTime: t3,
@@ -1207,12 +1114,10 @@ func TestProcessEvalResults_StateTransitions(t *testing.T) {
 							{
 								PreviousState: eval.Normal,
 								State: &State{
-									Labels:      labels["system + rule + labels1"],
-									State:       eval.Normal,
-									StateReason: ngmodels.StateReasonMissingSeries,
-									Results: []Evaluation{
-										newEvaluation(t1, eval.Normal),
-									},
+									Labels:             labels["system + rule + labels1"],
+									State:              eval.Normal,
+									StateReason:        ngmodels.StateReasonMissingSeries,
+									LatestResult:       newEvaluation(t1, eval.Normal),
 									StartsAt:           t1,
 									EndsAt:             t3,
 									LastEvaluationTime: t3,
@@ -1221,12 +1126,10 @@ func TestProcessEvalResults_StateTransitions(t *testing.T) {
 							{
 								PreviousState: eval.Alerting,
 								State: &State{
-									Labels:      labels["system + rule + labels2"],
-									State:       eval.Normal,
-									StateReason: ngmodels.StateReasonMissingSeries,
-									Results: []Evaluation{
-										newEvaluation(t1, eval.Alerting),
-									},
+									Labels:             labels["system + rule + labels2"],
+									State:              eval.Normal,
+									StateReason:        ngmodels.StateReasonMissingSeries,
+									LatestResult:       newEvaluation(t1, eval.Alerting),
 									StartsAt:           t1,
 									EndsAt:             t3,
 									LastEvaluationTime: t3,
@@ -1237,13 +1140,10 @@ func TestProcessEvalResults_StateTransitions(t *testing.T) {
 								PreviousState:       eval.Normal,
 								PreviousStateReason: eval.NoData.String(),
 								State: &State{
-									Labels:      labels["system + rule + no-data"],
-									State:       eval.Normal,
-									StateReason: eval.NoData.String(),
-									Results: []Evaluation{
-										newEvaluation(t2, eval.NoData),
-										newEvaluation(t3, eval.NoData),
-									},
+									Labels:             labels["system + rule + no-data"],
+									State:              eval.Normal,
+									StateReason:        eval.NoData.String(),
+									LatestResult:       newEvaluation(t3, eval.NoData),
 									StartsAt:           t2,
 									EndsAt:             t2,
 									LastEvaluationTime: t3,
@@ -1256,12 +1156,10 @@ func TestProcessEvalResults_StateTransitions(t *testing.T) {
 							{
 								PreviousState: eval.Normal,
 								State: &State{
-									Labels:      labels["system + rule + labels1"],
-									State:       eval.Normal,
-									StateReason: ngmodels.StateReasonMissingSeries,
-									Results: []Evaluation{
-										newEvaluation(t1, eval.Normal),
-									},
+									Labels:             labels["system + rule + labels1"],
+									State:              eval.Normal,
+									StateReason:        ngmodels.StateReasonMissingSeries,
+									LatestResult:       newEvaluation(t1, eval.Normal),
 									StartsAt:           t1,
 									EndsAt:             t3,
 									LastEvaluationTime: t3,
@@ -1270,12 +1168,10 @@ func TestProcessEvalResults_StateTransitions(t *testing.T) {
 							{
 								PreviousState: eval.Alerting,
 								State: &State{
-									Labels:      labels["system + rule + labels2"],
-									State:       eval.Normal,
-									StateReason: ngmodels.StateReasonMissingSeries,
-									Results: []Evaluation{
-										newEvaluation(t1, eval.Alerting),
-									},
+									Labels:             labels["system + rule + labels2"],
+									State:              eval.Normal,
+									StateReason:        ngmodels.StateReasonMissingSeries,
+									LatestResult:       newEvaluation(t1, eval.Alerting),
 									StartsAt:           t1,
 									EndsAt:             t3,
 									LastEvaluationTime: t3,
@@ -1286,13 +1182,10 @@ func TestProcessEvalResults_StateTransitions(t *testing.T) {
 								PreviousState:       eval.Normal,
 								PreviousStateReason: ngmodels.ConcatReasons(eval.NoData.String(), ngmodels.StateReasonKeepLast),
 								State: &State{
-									Labels:      labels["system + rule + no-data"],
-									State:       eval.Normal,
-									StateReason: ngmodels.ConcatReasons(eval.NoData.String(), ngmodels.StateReasonKeepLast),
-									Results: []Evaluation{
-										newEvaluation(t2, eval.NoData),
-										newEvaluation(t3, eval.NoData),
-									},
+									Labels:             labels["system + rule + no-data"],
+									State:              eval.Normal,
+									StateReason:        ngmodels.ConcatReasons(eval.NoData.String(), ngmodels.StateReasonKeepLast),
+									LatestResult:       newEvaluation(t3, eval.NoData),
 									StartsAt:           t2,
 									EndsAt:             t2,
 									LastEvaluationTime: t3,
@@ -1307,13 +1200,10 @@ func TestProcessEvalResults_StateTransitions(t *testing.T) {
 							{
 								PreviousState: eval.Normal,
 								State: &State{
-									Labels:      labels["system + rule + labels1"],
-									State:       eval.Alerting,
-									StateReason: eval.NoData.String(),
-									Results: []Evaluation{
-										newEvaluation(t1, eval.Normal),
-										newEvaluation(t2, eval.NoData),
-									},
+									Labels:             labels["system + rule + labels1"],
+									State:              eval.Alerting,
+									StateReason:        eval.NoData.String(),
+									LatestResult:       newEvaluation(t2, eval.NoData),
 									StartsAt:           t2,
 									EndsAt:             t2.Add(ResendDelay * 4),
 									LastEvaluationTime: t2,
@@ -1322,13 +1212,10 @@ func TestProcessEvalResults_StateTransitions(t *testing.T) {
 							{
 								PreviousState: eval.Alerting,
 								State: &State{
-									Labels:      labels["system + rule + labels2"],
-									State:       eval.Alerting,
-									StateReason: eval.NoData.String(),
-									Results: []Evaluation{
-										newEvaluation(t1, eval.Alerting),
-										newEvaluation(t2, eval.NoData),
-									},
+									Labels:             labels["system + rule + labels2"],
+									State:              eval.Alerting,
+									StateReason:        eval.NoData.String(),
+									LatestResult:       newEvaluation(t2, eval.NoData),
 									StartsAt:           t1,
 									EndsAt:             t2.Add(ResendDelay * 4),
 									LastEvaluationTime: t2,
@@ -1340,14 +1227,10 @@ func TestProcessEvalResults_StateTransitions(t *testing.T) {
 								PreviousState:       eval.Alerting,
 								PreviousStateReason: eval.NoData.String(),
 								State: &State{
-									Labels:      labels["system + rule + labels1"],
-									State:       eval.Alerting,
-									StateReason: eval.NoData.String(),
-									Results: []Evaluation{
-										newEvaluation(t1, eval.Normal),
-										newEvaluation(t2, eval.NoData),
-										newEvaluation(t3, eval.NoData),
-									},
+									Labels:             labels["system + rule + labels1"],
+									State:              eval.Alerting,
+									StateReason:        eval.NoData.String(),
+									LatestResult:       newEvaluation(t3, eval.NoData),
 									StartsAt:           t2,
 									EndsAt:             t3.Add(ResendDelay * 4),
 									LastEvaluationTime: t3,
@@ -1357,14 +1240,10 @@ func TestProcessEvalResults_StateTransitions(t *testing.T) {
 								PreviousState:       eval.Alerting,
 								PreviousStateReason: eval.NoData.String(),
 								State: &State{
-									Labels:      labels["system + rule + labels2"],
-									State:       eval.Alerting,
-									StateReason: eval.NoData.String(),
-									Results: []Evaluation{
-										newEvaluation(t1, eval.Alerting),
-										newEvaluation(t2, eval.NoData),
-										newEvaluation(t3, eval.NoData),
-									},
+									Labels:             labels["system + rule + labels2"],
+									State:              eval.Alerting,
+									StateReason:        eval.NoData.String(),
+									LatestResult:       newEvaluation(t3, eval.NoData),
 									StartsAt:           t1,
 									EndsAt:             t3.Add(ResendDelay * 4),
 									LastEvaluationTime: t3,
@@ -1377,13 +1256,10 @@ func TestProcessEvalResults_StateTransitions(t *testing.T) {
 							{
 								PreviousState: eval.Normal,
 								State: &State{
-									Labels:      labels["system + rule + labels1"],
-									State:       eval.Normal,
-									StateReason: eval.NoData.String(),
-									Results: []Evaluation{
-										newEvaluation(t1, eval.Normal),
-										newEvaluation(t2, eval.NoData),
-									},
+									Labels:             labels["system + rule + labels1"],
+									State:              eval.Normal,
+									StateReason:        eval.NoData.String(),
+									LatestResult:       newEvaluation(t2, eval.NoData),
 									StartsAt:           t1,
 									EndsAt:             t1,
 									LastEvaluationTime: t2,
@@ -1392,13 +1268,10 @@ func TestProcessEvalResults_StateTransitions(t *testing.T) {
 							{
 								PreviousState: eval.Alerting,
 								State: &State{
-									Labels:      labels["system + rule + labels2"],
-									State:       eval.Normal,
-									StateReason: eval.NoData.String(),
-									Results: []Evaluation{
-										newEvaluation(t1, eval.Alerting),
-										newEvaluation(t2, eval.NoData),
-									},
+									Labels:             labels["system + rule + labels2"],
+									State:              eval.Normal,
+									StateReason:        eval.NoData.String(),
+									LatestResult:       newEvaluation(t2, eval.NoData),
 									StartsAt:           t2,
 									EndsAt:             t2,
 									LastEvaluationTime: t2,
@@ -1411,14 +1284,10 @@ func TestProcessEvalResults_StateTransitions(t *testing.T) {
 								PreviousState:       eval.Normal,
 								PreviousStateReason: eval.NoData.String(),
 								State: &State{
-									Labels:      labels["system + rule + labels1"],
-									State:       eval.Normal,
-									StateReason: eval.NoData.String(),
-									Results: []Evaluation{
-										newEvaluation(t1, eval.Normal),
-										newEvaluation(t2, eval.NoData),
-										newEvaluation(t3, eval.NoData),
-									},
+									Labels:             labels["system + rule + labels1"],
+									State:              eval.Normal,
+									StateReason:        eval.NoData.String(),
+									LatestResult:       newEvaluation(t3, eval.NoData),
 									StartsAt:           t1,
 									EndsAt:             t1,
 									LastEvaluationTime: t3,
@@ -1428,14 +1297,10 @@ func TestProcessEvalResults_StateTransitions(t *testing.T) {
 								PreviousState:       eval.Normal,
 								PreviousStateReason: eval.NoData.String(),
 								State: &State{
-									Labels:      labels["system + rule + labels2"],
-									State:       eval.Normal,
-									StateReason: eval.NoData.String(),
-									Results: []Evaluation{
-										newEvaluation(t1, eval.Alerting),
-										newEvaluation(t2, eval.NoData),
-										newEvaluation(t3, eval.NoData),
-									},
+									Labels:             labels["system + rule + labels2"],
+									State:              eval.Normal,
+									StateReason:        eval.NoData.String(),
+									LatestResult:       newEvaluation(t3, eval.NoData),
 									StartsAt:           t2,
 									EndsAt:             t2,
 									LastEvaluationTime: t3,
@@ -1448,13 +1313,10 @@ func TestProcessEvalResults_StateTransitions(t *testing.T) {
 							{
 								PreviousState: eval.Normal,
 								State: &State{
-									Labels:      labels["system + rule + labels1"],
-									State:       eval.Normal,
-									StateReason: ngmodels.ConcatReasons(eval.NoData.String(), ngmodels.StateReasonKeepLast),
-									Results: []Evaluation{
-										newEvaluation(t1, eval.Normal),
-										newEvaluation(t2, eval.NoData),
-									},
+									Labels:             labels["system + rule + labels1"],
+									State:              eval.Normal,
+									StateReason:        ngmodels.ConcatReasons(eval.NoData.String(), ngmodels.StateReasonKeepLast),
+									LatestResult:       newEvaluation(t2, eval.NoData),
 									StartsAt:           t1,
 									EndsAt:             t1,
 									LastEvaluationTime: t2,
@@ -1463,13 +1325,10 @@ func TestProcessEvalResults_StateTransitions(t *testing.T) {
 							{
 								PreviousState: eval.Alerting,
 								State: &State{
-									Labels:      labels["system + rule + labels2"],
-									State:       eval.Alerting,
-									StateReason: ngmodels.ConcatReasons(eval.NoData.String(), ngmodels.StateReasonKeepLast),
-									Results: []Evaluation{
-										newEvaluation(t1, eval.Alerting),
-										newEvaluation(t2, eval.NoData),
-									},
+									Labels:             labels["system + rule + labels2"],
+									State:              eval.Alerting,
+									StateReason:        ngmodels.ConcatReasons(eval.NoData.String(), ngmodels.StateReasonKeepLast),
+									LatestResult:       newEvaluation(t2, eval.NoData),
 									StartsAt:           t1,
 									EndsAt:             t2.Add(ResendDelay * 4),
 									LastEvaluationTime: t2,
@@ -1481,14 +1340,10 @@ func TestProcessEvalResults_StateTransitions(t *testing.T) {
 								PreviousState:       eval.Normal,
 								PreviousStateReason: ngmodels.ConcatReasons(eval.NoData.String(), ngmodels.StateReasonKeepLast),
 								State: &State{
-									Labels:      labels["system + rule + labels1"],
-									State:       eval.Normal,
-									StateReason: ngmodels.ConcatReasons(eval.NoData.String(), ngmodels.StateReasonKeepLast),
-									Results: []Evaluation{
-										newEvaluation(t1, eval.Normal),
-										newEvaluation(t2, eval.NoData),
-										newEvaluation(t3, eval.NoData),
-									},
+									Labels:             labels["system + rule + labels1"],
+									State:              eval.Normal,
+									StateReason:        ngmodels.ConcatReasons(eval.NoData.String(), ngmodels.StateReasonKeepLast),
+									LatestResult:       newEvaluation(t3, eval.NoData),
 									StartsAt:           t1,
 									EndsAt:             t1,
 									LastEvaluationTime: t3,
@@ -1498,14 +1353,10 @@ func TestProcessEvalResults_StateTransitions(t *testing.T) {
 								PreviousState:       eval.Alerting,
 								PreviousStateReason: ngmodels.ConcatReasons(eval.NoData.String(), ngmodels.StateReasonKeepLast),
 								State: &State{
-									Labels:      labels["system + rule + labels2"],
-									State:       eval.Alerting,
-									StateReason: ngmodels.ConcatReasons(eval.NoData.String(), ngmodels.StateReasonKeepLast),
-									Results: []Evaluation{
-										newEvaluation(t1, eval.Alerting),
-										newEvaluation(t2, eval.NoData),
-										newEvaluation(t3, eval.NoData),
-									},
+									Labels:             labels["system + rule + labels2"],
+									State:              eval.Alerting,
+									StateReason:        ngmodels.ConcatReasons(eval.NoData.String(), ngmodels.StateReasonKeepLast),
+									LatestResult:       newEvaluation(t3, eval.NoData),
 									StartsAt:           t1,
 									EndsAt:             t3.Add(ResendDelay * 4),
 									LastEvaluationTime: t3,
@@ -1536,11 +1387,9 @@ func TestProcessEvalResults_StateTransitions(t *testing.T) {
 							{
 								PreviousState: eval.Normal,
 								State: &State{
-									Labels: labels["system + rule + no-data"],
-									State:  eval.NoData,
-									Results: []Evaluation{
-										newEvaluation(t2, eval.NoData),
-									},
+									Labels:             labels["system + rule + no-data"],
+									State:              eval.NoData,
+									LatestResult:       newEvaluation(t2, eval.NoData),
 									StartsAt:           t2,
 									EndsAt:             t2.Add(ResendDelay * 4),
 									LastEvaluationTime: t2,
@@ -1551,12 +1400,10 @@ func TestProcessEvalResults_StateTransitions(t *testing.T) {
 							{
 								PreviousState: eval.Normal,
 								State: &State{
-									Labels:      labels["system + rule + labels1"],
-									State:       eval.Normal,
-									StateReason: ngmodels.StateReasonMissingSeries,
-									Results: []Evaluation{
-										newEvaluation(t1, eval.Normal),
-									},
+									Labels:             labels["system + rule + labels1"],
+									State:              eval.Normal,
+									StateReason:        ngmodels.StateReasonMissingSeries,
+									LatestResult:       newEvaluation(t1, eval.Normal),
 									StartsAt:           t1,
 									EndsAt:             t3,
 									LastEvaluationTime: t3,
@@ -1565,12 +1412,10 @@ func TestProcessEvalResults_StateTransitions(t *testing.T) {
 							{
 								PreviousState: eval.Pending,
 								State: &State{
-									Labels:      labels["system + rule + labels2"],
-									State:       eval.Normal,
-									StateReason: ngmodels.StateReasonMissingSeries,
-									Results: []Evaluation{
-										newEvaluation(t1, eval.Alerting),
-									},
+									Labels:             labels["system + rule + labels2"],
+									State:              eval.Normal,
+									StateReason:        ngmodels.StateReasonMissingSeries,
+									LatestResult:       newEvaluation(t1, eval.Alerting),
 									StartsAt:           t1,
 									EndsAt:             t3,
 									LastEvaluationTime: t3,
@@ -1579,11 +1424,9 @@ func TestProcessEvalResults_StateTransitions(t *testing.T) {
 							{
 								PreviousState: eval.NoData,
 								State: &State{
-									Labels: labels["system + rule + no-data"],
-									State:  eval.NoData,
-									Results: []Evaluation{
-										newEvaluation(t3, eval.NoData),
-									},
+									Labels:             labels["system + rule + no-data"],
+									State:              eval.NoData,
+									LatestResult:       newEvaluation(t3, eval.NoData),
 									StartsAt:           t2,
 									EndsAt:             t3.Add(ResendDelay * 4),
 									LastEvaluationTime: t3,
@@ -1596,12 +1439,10 @@ func TestProcessEvalResults_StateTransitions(t *testing.T) {
 							{
 								PreviousState: eval.Normal,
 								State: &State{
-									Labels:      labels["system + rule + no-data"],
-									State:       eval.Pending,
-									StateReason: eval.NoData.String(),
-									Results: []Evaluation{
-										newEvaluation(t2, eval.NoData),
-									},
+									Labels:             labels["system + rule + no-data"],
+									State:              eval.Pending,
+									StateReason:        eval.NoData.String(),
+									LatestResult:       newEvaluation(t2, eval.NoData),
 									StartsAt:           t2,
 									EndsAt:             t2.Add(ResendDelay * 4),
 									LastEvaluationTime: t2,
@@ -1612,12 +1453,10 @@ func TestProcessEvalResults_StateTransitions(t *testing.T) {
 							{
 								PreviousState: eval.Normal,
 								State: &State{
-									Labels:      labels["system + rule + labels1"],
-									State:       eval.Normal,
-									StateReason: ngmodels.StateReasonMissingSeries,
-									Results: []Evaluation{
-										newEvaluation(t1, eval.Normal),
-									},
+									Labels:             labels["system + rule + labels1"],
+									State:              eval.Normal,
+									StateReason:        ngmodels.StateReasonMissingSeries,
+									LatestResult:       newEvaluation(t1, eval.Normal),
 									StartsAt:           t1,
 									EndsAt:             t3,
 									LastEvaluationTime: t3,
@@ -1626,12 +1465,10 @@ func TestProcessEvalResults_StateTransitions(t *testing.T) {
 							{
 								PreviousState: eval.Pending,
 								State: &State{
-									Labels:      labels["system + rule + labels2"],
-									State:       eval.Normal,
-									StateReason: ngmodels.StateReasonMissingSeries,
-									Results: []Evaluation{
-										newEvaluation(t1, eval.Alerting),
-									},
+									Labels:             labels["system + rule + labels2"],
+									State:              eval.Normal,
+									StateReason:        ngmodels.StateReasonMissingSeries,
+									LatestResult:       newEvaluation(t1, eval.Alerting),
 									StartsAt:           t1,
 									EndsAt:             t3,
 									LastEvaluationTime: t3,
@@ -1641,12 +1478,10 @@ func TestProcessEvalResults_StateTransitions(t *testing.T) {
 								PreviousState:       eval.Pending,
 								PreviousStateReason: eval.NoData.String(),
 								State: &State{
-									Labels:      labels["system + rule + no-data"],
-									State:       eval.Alerting,
-									StateReason: eval.NoData.String(),
-									Results: []Evaluation{
-										newEvaluation(t3, eval.NoData),
-									},
+									Labels:             labels["system + rule + no-data"],
+									State:              eval.Alerting,
+									StateReason:        eval.NoData.String(),
+									LatestResult:       newEvaluation(t3, eval.NoData),
 									StartsAt:           t3,
 									EndsAt:             t3.Add(ResendDelay * 4),
 									LastEvaluationTime: t3,
@@ -1659,12 +1494,10 @@ func TestProcessEvalResults_StateTransitions(t *testing.T) {
 							{
 								PreviousState: eval.Normal,
 								State: &State{
-									Labels:      labels["system + rule + labels1"],
-									State:       eval.Normal,
-									StateReason: ngmodels.StateReasonMissingSeries,
-									Results: []Evaluation{
-										newEvaluation(t1, eval.Normal),
-									},
+									Labels:             labels["system + rule + labels1"],
+									State:              eval.Normal,
+									StateReason:        ngmodels.StateReasonMissingSeries,
+									LatestResult:       newEvaluation(t1, eval.Normal),
 									StartsAt:           t1,
 									EndsAt:             t3,
 									LastEvaluationTime: t3,
@@ -1673,12 +1506,10 @@ func TestProcessEvalResults_StateTransitions(t *testing.T) {
 							{
 								PreviousState: eval.Pending,
 								State: &State{
-									Labels:      labels["system + rule + labels2"],
-									State:       eval.Normal,
-									StateReason: ngmodels.StateReasonMissingSeries,
-									Results: []Evaluation{
-										newEvaluation(t1, eval.Alerting),
-									},
+									Labels:             labels["system + rule + labels2"],
+									State:              eval.Normal,
+									StateReason:        ngmodels.StateReasonMissingSeries,
+									LatestResult:       newEvaluation(t1, eval.Alerting),
 									StartsAt:           t1,
 									EndsAt:             t3,
 									LastEvaluationTime: t3,
@@ -1688,12 +1519,10 @@ func TestProcessEvalResults_StateTransitions(t *testing.T) {
 								PreviousState:       eval.Normal,
 								PreviousStateReason: eval.NoData.String(),
 								State: &State{
-									Labels:      labels["system + rule + no-data"],
-									State:       eval.Normal,
-									StateReason: eval.NoData.String(),
-									Results: []Evaluation{
-										newEvaluation(t3, eval.NoData),
-									},
+									Labels:             labels["system + rule + no-data"],
+									State:              eval.Normal,
+									StateReason:        eval.NoData.String(),
+									LatestResult:       newEvaluation(t3, eval.NoData),
 									StartsAt:           t2,
 									EndsAt:             t2,
 									LastEvaluationTime: t3,
@@ -1706,12 +1535,10 @@ func TestProcessEvalResults_StateTransitions(t *testing.T) {
 							{
 								PreviousState: eval.Normal,
 								State: &State{
-									Labels:      labels["system + rule + labels1"],
-									State:       eval.Normal,
-									StateReason: ngmodels.StateReasonMissingSeries,
-									Results: []Evaluation{
-										newEvaluation(t1, eval.Normal),
-									},
+									Labels:             labels["system + rule + labels1"],
+									State:              eval.Normal,
+									StateReason:        ngmodels.StateReasonMissingSeries,
+									LatestResult:       newEvaluation(t1, eval.Normal),
 									StartsAt:           t1,
 									EndsAt:             t3,
 									LastEvaluationTime: t3,
@@ -1720,12 +1547,10 @@ func TestProcessEvalResults_StateTransitions(t *testing.T) {
 							{
 								PreviousState: eval.Pending,
 								State: &State{
-									Labels:      labels["system + rule + labels2"],
-									State:       eval.Normal,
-									StateReason: ngmodels.StateReasonMissingSeries,
-									Results: []Evaluation{
-										newEvaluation(t1, eval.Alerting),
-									},
+									Labels:             labels["system + rule + labels2"],
+									State:              eval.Normal,
+									StateReason:        ngmodels.StateReasonMissingSeries,
+									LatestResult:       newEvaluation(t1, eval.Alerting),
 									StartsAt:           t1,
 									EndsAt:             t3,
 									LastEvaluationTime: t3,
@@ -1735,12 +1560,10 @@ func TestProcessEvalResults_StateTransitions(t *testing.T) {
 								PreviousState:       eval.Normal,
 								PreviousStateReason: ngmodels.ConcatReasons(eval.NoData.String(), ngmodels.StateReasonKeepLast),
 								State: &State{
-									Labels:      labels["system + rule + no-data"],
-									State:       eval.Normal,
-									StateReason: ngmodels.ConcatReasons(eval.NoData.String(), ngmodels.StateReasonKeepLast),
-									Results: []Evaluation{
-										newEvaluation(t3, eval.NoData),
-									},
+									Labels:             labels["system + rule + no-data"],
+									State:              eval.Normal,
+									StateReason:        ngmodels.ConcatReasons(eval.NoData.String(), ngmodels.StateReasonKeepLast),
+									LatestResult:       newEvaluation(t3, eval.NoData),
 									StartsAt:           t2,
 									EndsAt:             t2,
 									LastEvaluationTime: t3,
@@ -1755,12 +1578,10 @@ func TestProcessEvalResults_StateTransitions(t *testing.T) {
 							{
 								PreviousState: eval.Normal,
 								State: &State{
-									Labels:      labels["system + rule + labels1"],
-									State:       eval.Pending,
-									StateReason: eval.NoData.String(),
-									Results: []Evaluation{
-										newEvaluation(t2, eval.NoData),
-									},
+									Labels:             labels["system + rule + labels1"],
+									State:              eval.Pending,
+									StateReason:        eval.NoData.String(),
+									LatestResult:       newEvaluation(t2, eval.NoData),
 									StartsAt:           t2,
 									EndsAt:             t2.Add(ResendDelay * 4),
 									LastEvaluationTime: t2,
@@ -1769,12 +1590,10 @@ func TestProcessEvalResults_StateTransitions(t *testing.T) {
 							{
 								PreviousState: eval.Pending,
 								State: &State{
-									Labels:      labels["system + rule + labels2"],
-									State:       eval.Alerting,
-									StateReason: eval.NoData.String(),
-									Results: []Evaluation{
-										newEvaluation(t2, eval.NoData),
-									},
+									Labels:             labels["system + rule + labels2"],
+									State:              eval.Alerting,
+									StateReason:        eval.NoData.String(),
+									LatestResult:       newEvaluation(t2, eval.NoData),
 									StartsAt:           t2,
 									EndsAt:             t2.Add(ResendDelay * 4),
 									LastEvaluationTime: t2,
@@ -1786,12 +1605,10 @@ func TestProcessEvalResults_StateTransitions(t *testing.T) {
 								PreviousState:       eval.Pending,
 								PreviousStateReason: eval.NoData.String(),
 								State: &State{
-									Labels:      labels["system + rule + labels1"],
-									State:       eval.Alerting,
-									StateReason: eval.NoData.String(),
-									Results: []Evaluation{
-										newEvaluation(t3, eval.NoData),
-									},
+									Labels:             labels["system + rule + labels1"],
+									State:              eval.Alerting,
+									StateReason:        eval.NoData.String(),
+									LatestResult:       newEvaluation(t3, eval.NoData),
 									StartsAt:           t3,
 									EndsAt:             t3.Add(ResendDelay * 4),
 									LastEvaluationTime: t3,
@@ -1801,12 +1618,10 @@ func TestProcessEvalResults_StateTransitions(t *testing.T) {
 								PreviousState:       eval.Alerting,
 								PreviousStateReason: eval.NoData.String(),
 								State: &State{
-									Labels:      labels["system + rule + labels2"],
-									State:       eval.Alerting,
-									StateReason: eval.NoData.String(),
-									Results: []Evaluation{
-										newEvaluation(t3, eval.NoData),
-									},
+									Labels:             labels["system + rule + labels2"],
+									State:              eval.Alerting,
+									StateReason:        eval.NoData.String(),
+									LatestResult:       newEvaluation(t3, eval.NoData),
 									StartsAt:           t2,
 									EndsAt:             t3.Add(ResendDelay * 4),
 									LastEvaluationTime: t3,
@@ -1819,12 +1634,10 @@ func TestProcessEvalResults_StateTransitions(t *testing.T) {
 							{
 								PreviousState: eval.Normal,
 								State: &State{
-									Labels:      labels["system + rule + labels1"],
-									State:       eval.Normal,
-									StateReason: eval.NoData.String(),
-									Results: []Evaluation{
-										newEvaluation(t2, eval.NoData),
-									},
+									Labels:             labels["system + rule + labels1"],
+									State:              eval.Normal,
+									StateReason:        eval.NoData.String(),
+									LatestResult:       newEvaluation(t2, eval.NoData),
 									StartsAt:           t1,
 									EndsAt:             t1,
 									LastEvaluationTime: t2,
@@ -1833,12 +1646,10 @@ func TestProcessEvalResults_StateTransitions(t *testing.T) {
 							{
 								PreviousState: eval.Pending,
 								State: &State{
-									Labels:      labels["system + rule + labels2"],
-									State:       eval.Normal,
-									StateReason: eval.NoData.String(),
-									Results: []Evaluation{
-										newEvaluation(t2, eval.NoData),
-									},
+									Labels:             labels["system + rule + labels2"],
+									State:              eval.Normal,
+									StateReason:        eval.NoData.String(),
+									LatestResult:       newEvaluation(t2, eval.NoData),
 									StartsAt:           t2,
 									EndsAt:             t2,
 									LastEvaluationTime: t2,
@@ -1850,12 +1661,10 @@ func TestProcessEvalResults_StateTransitions(t *testing.T) {
 								PreviousState:       eval.Normal,
 								PreviousStateReason: eval.NoData.String(),
 								State: &State{
-									Labels:      labels["system + rule + labels1"],
-									State:       eval.Normal,
-									StateReason: eval.NoData.String(),
-									Results: []Evaluation{
-										newEvaluation(t3, eval.NoData),
-									},
+									Labels:             labels["system + rule + labels1"],
+									State:              eval.Normal,
+									StateReason:        eval.NoData.String(),
+									LatestResult:       newEvaluation(t3, eval.NoData),
 									StartsAt:           t1,
 									EndsAt:             t1,
 									LastEvaluationTime: t3,
@@ -1865,12 +1674,10 @@ func TestProcessEvalResults_StateTransitions(t *testing.T) {
 								PreviousState:       eval.Normal,
 								PreviousStateReason: eval.NoData.String(),
 								State: &State{
-									Labels:      labels["system + rule + labels2"],
-									State:       eval.Normal,
-									StateReason: eval.NoData.String(),
-									Results: []Evaluation{
-										newEvaluation(t3, eval.NoData),
-									},
+									Labels:             labels["system + rule + labels2"],
+									State:              eval.Normal,
+									StateReason:        eval.NoData.String(),
+									LatestResult:       newEvaluation(t3, eval.NoData),
 									StartsAt:           t2,
 									EndsAt:             t2,
 									LastEvaluationTime: t3,
@@ -1883,12 +1690,10 @@ func TestProcessEvalResults_StateTransitions(t *testing.T) {
 							{
 								PreviousState: eval.Normal,
 								State: &State{
-									Labels:      labels["system + rule + labels1"],
-									State:       eval.Normal,
-									StateReason: ngmodels.ConcatReasons(eval.NoData.String(), ngmodels.StateReasonKeepLast),
-									Results: []Evaluation{
-										newEvaluation(t2, eval.NoData),
-									},
+									Labels:             labels["system + rule + labels1"],
+									State:              eval.Normal,
+									StateReason:        ngmodels.ConcatReasons(eval.NoData.String(), ngmodels.StateReasonKeepLast),
+									LatestResult:       newEvaluation(t2, eval.NoData),
 									StartsAt:           t1,
 									EndsAt:             t1,
 									LastEvaluationTime: t2,
@@ -1897,12 +1702,10 @@ func TestProcessEvalResults_StateTransitions(t *testing.T) {
 							{
 								PreviousState: eval.Pending,
 								State: &State{
-									Labels:      labels["system + rule + labels2"],
-									State:       eval.Alerting,
-									StateReason: ngmodels.ConcatReasons(eval.NoData.String(), ngmodels.StateReasonKeepLast),
-									Results: []Evaluation{
-										newEvaluation(t2, eval.NoData),
-									},
+									Labels:             labels["system + rule + labels2"],
+									State:              eval.Alerting,
+									StateReason:        ngmodels.ConcatReasons(eval.NoData.String(), ngmodels.StateReasonKeepLast),
+									LatestResult:       newEvaluation(t2, eval.NoData),
 									StartsAt:           t2,
 									EndsAt:             t2.Add(ResendDelay * 4),
 									LastEvaluationTime: t2,
@@ -1914,12 +1717,10 @@ func TestProcessEvalResults_StateTransitions(t *testing.T) {
 								PreviousState:       eval.Normal,
 								PreviousStateReason: ngmodels.ConcatReasons(eval.NoData.String(), ngmodels.StateReasonKeepLast),
 								State: &State{
-									Labels:      labels["system + rule + labels1"],
-									State:       eval.Normal,
-									StateReason: ngmodels.ConcatReasons(eval.NoData.String(), ngmodels.StateReasonKeepLast),
-									Results: []Evaluation{
-										newEvaluation(t3, eval.NoData),
-									},
+									Labels:             labels["system + rule + labels1"],
+									State:              eval.Normal,
+									StateReason:        ngmodels.ConcatReasons(eval.NoData.String(), ngmodels.StateReasonKeepLast),
+									LatestResult:       newEvaluation(t3, eval.NoData),
 									StartsAt:           t1,
 									EndsAt:             t1,
 									LastEvaluationTime: t3,
@@ -1929,12 +1730,10 @@ func TestProcessEvalResults_StateTransitions(t *testing.T) {
 								PreviousState:       eval.Alerting,
 								PreviousStateReason: ngmodels.ConcatReasons(eval.NoData.String(), ngmodels.StateReasonKeepLast),
 								State: &State{
-									Labels:      labels["system + rule + labels2"],
-									State:       eval.Alerting,
-									StateReason: ngmodels.ConcatReasons(eval.NoData.String(), ngmodels.StateReasonKeepLast),
-									Results: []Evaluation{
-										newEvaluation(t3, eval.NoData),
-									},
+									Labels:             labels["system + rule + labels2"],
+									State:              eval.Alerting,
+									StateReason:        ngmodels.ConcatReasons(eval.NoData.String(), ngmodels.StateReasonKeepLast),
+									LatestResult:       newEvaluation(t3, eval.NoData),
 									StartsAt:           t2,
 									EndsAt:             t3.Add(ResendDelay * 4),
 									LastEvaluationTime: t3,
@@ -1964,12 +1763,9 @@ func TestProcessEvalResults_StateTransitions(t *testing.T) {
 							{
 								PreviousState: eval.Pending,
 								State: &State{
-									Labels: labels["system + rule + labels1"],
-									State:  eval.Alerting,
-									Results: []Evaluation{
-										newEvaluation(t1, eval.Alerting),
-										newEvaluation(t3, eval.Alerting),
-									},
+									Labels:             labels["system + rule + labels1"],
+									State:              eval.Alerting,
+									LatestResult:       newEvaluation(t3, eval.Alerting),
 									StartsAt:           t3,
 									EndsAt:             t3.Add(ResendDelay * 4),
 									LastEvaluationTime: t3,
@@ -1982,12 +1778,9 @@ func TestProcessEvalResults_StateTransitions(t *testing.T) {
 							{
 								PreviousState: eval.Pending,
 								State: &State{
-									Labels: labels["system + rule + labels1"],
-									State:  eval.Alerting,
-									Results: []Evaluation{
-										newEvaluation(t1, eval.Alerting),
-										newEvaluation(t3, eval.Alerting),
-									},
+									Labels:             labels["system + rule + labels1"],
+									State:              eval.Alerting,
+									LatestResult:       newEvaluation(t3, eval.Alerting),
 									StartsAt:           t3,
 									EndsAt:             t3.Add(ResendDelay * 4),
 									LastEvaluationTime: t3,
@@ -2000,12 +1793,9 @@ func TestProcessEvalResults_StateTransitions(t *testing.T) {
 							{
 								PreviousState: eval.Pending,
 								State: &State{
-									Labels: labels["system + rule + labels1"],
-									State:  eval.Alerting,
-									Results: []Evaluation{
-										newEvaluation(t1, eval.Alerting),
-										newEvaluation(t3, eval.Alerting),
-									},
+									Labels:             labels["system + rule + labels1"],
+									State:              eval.Alerting,
+									LatestResult:       newEvaluation(t3, eval.Alerting),
 									StartsAt:           t3,
 									EndsAt:             t3.Add(ResendDelay * 4),
 									LastEvaluationTime: t3,
@@ -2018,12 +1808,9 @@ func TestProcessEvalResults_StateTransitions(t *testing.T) {
 							{
 								PreviousState: eval.Pending,
 								State: &State{
-									Labels: labels["system + rule + labels1"],
-									State:  eval.Alerting,
-									Results: []Evaluation{
-										newEvaluation(t1, eval.Alerting),
-										newEvaluation(t3, eval.Alerting),
-									},
+									Labels:             labels["system + rule + labels1"],
+									State:              eval.Alerting,
+									LatestResult:       newEvaluation(t3, eval.Alerting),
 									StartsAt:           t3,
 									EndsAt:             t3.Add(ResendDelay * 4),
 									LastEvaluationTime: t3,
@@ -2039,12 +1826,9 @@ func TestProcessEvalResults_StateTransitions(t *testing.T) {
 								PreviousState:       eval.Pending,
 								PreviousStateReason: eval.NoData.String(),
 								State: &State{
-									Labels: labels["system + rule + labels1"],
-									State:  eval.Alerting,
-									Results: []Evaluation{
-										newEvaluation(t2, eval.NoData),
-										newEvaluation(t3, eval.Alerting),
-									},
+									Labels:             labels["system + rule + labels1"],
+									State:              eval.Alerting,
+									LatestResult:       newEvaluation(t3, eval.Alerting),
 									StartsAt:           t3,
 									EndsAt:             t3.Add(ResendDelay * 4),
 									LastEvaluationTime: t3,
@@ -2058,12 +1842,9 @@ func TestProcessEvalResults_StateTransitions(t *testing.T) {
 								PreviousState:       eval.Normal,
 								PreviousStateReason: eval.NoData.String(),
 								State: &State{
-									Labels: labels["system + rule + labels1"],
-									State:  eval.Pending,
-									Results: []Evaluation{
-										newEvaluation(t2, eval.NoData),
-										newEvaluation(t3, eval.Alerting),
-									},
+									Labels:             labels["system + rule + labels1"],
+									State:              eval.Pending,
+									LatestResult:       newEvaluation(t3, eval.Alerting),
 									StartsAt:           t3,
 									EndsAt:             t3.Add(ResendDelay * 4),
 									LastEvaluationTime: t3,
@@ -2077,12 +1858,9 @@ func TestProcessEvalResults_StateTransitions(t *testing.T) {
 								PreviousState:       eval.Pending,
 								PreviousStateReason: ngmodels.ConcatReasons(eval.NoData.String(), ngmodels.StateReasonKeepLast),
 								State: &State{
-									Labels: labels["system + rule + labels1"],
-									State:  eval.Alerting,
-									Results: []Evaluation{
-										newEvaluation(t2, eval.NoData),
-										newEvaluation(t3, eval.Alerting),
-									},
+									Labels:             labels["system + rule + labels1"],
+									State:              eval.Alerting,
+									LatestResult:       newEvaluation(t3, eval.Alerting),
 									StartsAt:           t3,
 									EndsAt:             t3.Add(ResendDelay * 4),
 									LastEvaluationTime: t3,
@@ -2111,12 +1889,9 @@ func TestProcessEvalResults_StateTransitions(t *testing.T) {
 							{
 								PreviousState: eval.Normal,
 								State: &State{
-									Labels: labels["system + rule + labels1"],
-									State:  eval.Normal,
-									Results: []Evaluation{
-										newEvaluation(t2, eval.Normal),
-										newEvaluation(t3, eval.Normal),
-									},
+									Labels:             labels["system + rule + labels1"],
+									State:              eval.Normal,
+									LatestResult:       newEvaluation(t3, eval.Normal),
 									StartsAt:           t2,
 									EndsAt:             t2,
 									LastEvaluationTime: t3,
@@ -2125,12 +1900,10 @@ func TestProcessEvalResults_StateTransitions(t *testing.T) {
 							{
 								PreviousState: eval.NoData,
 								State: &State{
-									Labels:      labels["system + rule + no-data"],
-									State:       eval.Normal,
-									StateReason: ngmodels.StateReasonMissingSeries,
-									Results: []Evaluation{
-										newEvaluation(t1, eval.NoData),
-									},
+									Labels:             labels["system + rule + no-data"],
+									State:              eval.Normal,
+									StateReason:        ngmodels.StateReasonMissingSeries,
+									LatestResult:       newEvaluation(t1, eval.NoData),
 									StartsAt:           t1,
 									EndsAt:             t3,
 									LastEvaluationTime: t3,
@@ -2143,12 +1916,9 @@ func TestProcessEvalResults_StateTransitions(t *testing.T) {
 							{
 								PreviousState: eval.Normal,
 								State: &State{
-									Labels: labels["system + rule + labels1"],
-									State:  eval.Normal,
-									Results: []Evaluation{
-										newEvaluation(t2, eval.Normal),
-										newEvaluation(t3, eval.Normal),
-									},
+									Labels:             labels["system + rule + labels1"],
+									State:              eval.Normal,
+									LatestResult:       newEvaluation(t3, eval.Normal),
 									StartsAt:           t2,
 									EndsAt:             t2,
 									LastEvaluationTime: t3,
@@ -2158,12 +1928,10 @@ func TestProcessEvalResults_StateTransitions(t *testing.T) {
 								PreviousState:       eval.Alerting,
 								PreviousStateReason: eval.NoData.String(),
 								State: &State{
-									Labels:      labels["system + rule + no-data"],
-									State:       eval.Normal,
-									StateReason: ngmodels.StateReasonMissingSeries,
-									Results: []Evaluation{
-										newEvaluation(t1, eval.NoData),
-									},
+									Labels:             labels["system + rule + no-data"],
+									State:              eval.Normal,
+									StateReason:        ngmodels.StateReasonMissingSeries,
+									LatestResult:       newEvaluation(t1, eval.NoData),
 									StartsAt:           t1,
 									EndsAt:             t3,
 									LastEvaluationTime: t3,
@@ -2177,12 +1945,9 @@ func TestProcessEvalResults_StateTransitions(t *testing.T) {
 							{
 								PreviousState: eval.Normal,
 								State: &State{
-									Labels: labels["system + rule + labels1"],
-									State:  eval.Normal,
-									Results: []Evaluation{
-										newEvaluation(t2, eval.Normal),
-										newEvaluation(t3, eval.Normal),
-									},
+									Labels:             labels["system + rule + labels1"],
+									State:              eval.Normal,
+									LatestResult:       newEvaluation(t3, eval.Normal),
 									StartsAt:           t2,
 									EndsAt:             t2,
 									LastEvaluationTime: t3,
@@ -2192,12 +1957,10 @@ func TestProcessEvalResults_StateTransitions(t *testing.T) {
 								PreviousState:       eval.Normal,
 								PreviousStateReason: eval.NoData.String(),
 								State: &State{
-									Labels:      labels["system + rule + no-data"],
-									State:       eval.Normal,
-									StateReason: ngmodels.StateReasonMissingSeries,
-									Results: []Evaluation{
-										newEvaluation(t1, eval.NoData),
-									},
+									Labels:             labels["system + rule + no-data"],
+									State:              eval.Normal,
+									StateReason:        ngmodels.StateReasonMissingSeries,
+									LatestResult:       newEvaluation(t1, eval.NoData),
 									StartsAt:           t1,
 									EndsAt:             t3,
 									LastEvaluationTime: t3,
@@ -2210,12 +1973,9 @@ func TestProcessEvalResults_StateTransitions(t *testing.T) {
 							{
 								PreviousState: eval.Normal,
 								State: &State{
-									Labels: labels["system + rule + labels1"],
-									State:  eval.Normal,
-									Results: []Evaluation{
-										newEvaluation(t2, eval.Normal),
-										newEvaluation(t3, eval.Normal),
-									},
+									Labels:             labels["system + rule + labels1"],
+									State:              eval.Normal,
+									LatestResult:       newEvaluation(t3, eval.Normal),
 									StartsAt:           t2,
 									EndsAt:             t2,
 									LastEvaluationTime: t3,
@@ -2225,12 +1985,10 @@ func TestProcessEvalResults_StateTransitions(t *testing.T) {
 								PreviousState:       eval.Normal,
 								PreviousStateReason: ngmodels.ConcatReasons(eval.NoData.String(), ngmodels.StateReasonKeepLast),
 								State: &State{
-									Labels:      labels["system + rule + no-data"],
-									State:       eval.Normal,
-									StateReason: ngmodels.StateReasonMissingSeries,
-									Results: []Evaluation{
-										newEvaluation(t1, eval.NoData),
-									},
+									Labels:             labels["system + rule + no-data"],
+									State:              eval.Normal,
+									StateReason:        ngmodels.StateReasonMissingSeries,
+									LatestResult:       newEvaluation(t1, eval.NoData),
 									StartsAt:           t1,
 									EndsAt:             t3,
 									LastEvaluationTime: t3,
@@ -2256,11 +2014,9 @@ func TestProcessEvalResults_StateTransitions(t *testing.T) {
 							{
 								PreviousState: eval.Normal,
 								State: &State{
-									Labels: labels["system + rule + no-data"],
-									State:  eval.NoData,
-									Results: []Evaluation{
-										newEvaluation(t2, eval.NoData),
-									},
+									Labels:             labels["system + rule + no-data"],
+									State:              eval.NoData,
+									LatestResult:       newEvaluation(t2, eval.NoData),
 									StartsAt:           t2,
 									EndsAt:             t2.Add(ResendDelay * 4),
 									LastEvaluationTime: t2,
@@ -2273,12 +2029,10 @@ func TestProcessEvalResults_StateTransitions(t *testing.T) {
 							{
 								PreviousState: eval.Normal,
 								State: &State{
-									Labels:      labels["system + rule + no-data"],
-									State:       eval.Alerting,
-									StateReason: eval.NoData.String(),
-									Results: []Evaluation{
-										newEvaluation(t2, eval.NoData),
-									},
+									Labels:             labels["system + rule + no-data"],
+									State:              eval.Alerting,
+									StateReason:        eval.NoData.String(),
+									LatestResult:       newEvaluation(t2, eval.NoData),
 									StartsAt:           t2,
 									EndsAt:             t2.Add(ResendDelay * 4),
 									LastEvaluationTime: t2,
@@ -2291,12 +2045,10 @@ func TestProcessEvalResults_StateTransitions(t *testing.T) {
 							{
 								PreviousState: eval.Normal,
 								State: &State{
-									Labels:      labels["system + rule + no-data"],
-									State:       eval.Normal,
-									StateReason: eval.NoData.String(),
-									Results: []Evaluation{
-										newEvaluation(t2, eval.NoData),
-									},
+									Labels:             labels["system + rule + no-data"],
+									State:              eval.Normal,
+									StateReason:        eval.NoData.String(),
+									LatestResult:       newEvaluation(t2, eval.NoData),
 									StartsAt:           t2,
 									EndsAt:             t2,
 									LastEvaluationTime: t2,
@@ -2309,12 +2061,10 @@ func TestProcessEvalResults_StateTransitions(t *testing.T) {
 							{
 								PreviousState: eval.Normal,
 								State: &State{
-									Labels:      labels["system + rule + no-data"],
-									State:       eval.Normal,
-									StateReason: ngmodels.ConcatReasons(eval.NoData.String(), ngmodels.StateReasonKeepLast),
-									Results: []Evaluation{
-										newEvaluation(t2, eval.NoData),
-									},
+									Labels:             labels["system + rule + no-data"],
+									State:              eval.Normal,
+									StateReason:        ngmodels.ConcatReasons(eval.NoData.String(), ngmodels.StateReasonKeepLast),
+									LatestResult:       newEvaluation(t2, eval.NoData),
 									StartsAt:           t2,
 									EndsAt:             t2,
 									LastEvaluationTime: t2,
@@ -2329,13 +2079,10 @@ func TestProcessEvalResults_StateTransitions(t *testing.T) {
 							{
 								PreviousState: eval.Normal,
 								State: &State{
-									Labels:      labels["system + rule"],
-									State:       eval.Alerting,
-									StateReason: eval.NoData.String(),
-									Results: []Evaluation{
-										newEvaluation(t1, eval.Normal),
-										newEvaluation(t2, eval.NoData),
-									},
+									Labels:             labels["system + rule"],
+									State:              eval.Alerting,
+									StateReason:        eval.NoData.String(),
+									LatestResult:       newEvaluation(t2, eval.NoData),
 									StartsAt:           t2,
 									EndsAt:             t2.Add(ResendDelay * 4),
 									LastEvaluationTime: t2,
@@ -2348,13 +2095,10 @@ func TestProcessEvalResults_StateTransitions(t *testing.T) {
 							{
 								PreviousState: eval.Normal,
 								State: &State{
-									Labels:      labels["system + rule"],
-									State:       eval.Normal,
-									StateReason: eval.NoData.String(),
-									Results: []Evaluation{
-										newEvaluation(t1, eval.Normal),
-										newEvaluation(t2, eval.NoData),
-									},
+									Labels:             labels["system + rule"],
+									State:              eval.Normal,
+									StateReason:        eval.NoData.String(),
+									LatestResult:       newEvaluation(t2, eval.NoData),
 									StartsAt:           t1,
 									EndsAt:             t1,
 									LastEvaluationTime: t2,
@@ -2367,13 +2111,10 @@ func TestProcessEvalResults_StateTransitions(t *testing.T) {
 							{
 								PreviousState: eval.Normal,
 								State: &State{
-									Labels:      labels["system + rule"],
-									State:       eval.Normal,
-									StateReason: ngmodels.ConcatReasons(eval.NoData.String(), ngmodels.StateReasonKeepLast),
-									Results: []Evaluation{
-										newEvaluation(t1, eval.Normal),
-										newEvaluation(t2, eval.NoData),
-									},
+									Labels:             labels["system + rule"],
+									State:              eval.Normal,
+									StateReason:        ngmodels.ConcatReasons(eval.NoData.String(), ngmodels.StateReasonKeepLast),
+									LatestResult:       newEvaluation(t2, eval.NoData),
 									StartsAt:           t1,
 									EndsAt:             t1,
 									LastEvaluationTime: t2,
@@ -2402,11 +2143,9 @@ func TestProcessEvalResults_StateTransitions(t *testing.T) {
 							{
 								PreviousState: eval.Normal,
 								State: &State{
-									Labels: labels["system + rule + no-data"],
-									State:  eval.NoData,
-									Results: []Evaluation{
-										newEvaluation(t2, eval.NoData),
-									},
+									Labels:             labels["system + rule + no-data"],
+									State:              eval.NoData,
+									LatestResult:       newEvaluation(t2, eval.NoData),
 									StartsAt:           t2,
 									EndsAt:             t2.Add(ResendDelay * 4),
 									LastEvaluationTime: t2,
@@ -2417,12 +2156,10 @@ func TestProcessEvalResults_StateTransitions(t *testing.T) {
 							{
 								PreviousState: eval.Alerting,
 								State: &State{
-									Labels:      labels["system + rule"],
-									State:       eval.Normal,
-									StateReason: ngmodels.StateReasonMissingSeries,
-									Results: []Evaluation{
-										newEvaluation(t1, eval.Alerting),
-									},
+									Labels:             labels["system + rule"],
+									State:              eval.Normal,
+									StateReason:        ngmodels.StateReasonMissingSeries,
+									LatestResult:       newEvaluation(t1, eval.Alerting),
 									StartsAt:           t1,
 									EndsAt:             t3,
 									LastEvaluationTime: t3,
@@ -2432,12 +2169,9 @@ func TestProcessEvalResults_StateTransitions(t *testing.T) {
 							{
 								PreviousState: eval.NoData,
 								State: &State{
-									Labels: labels["system + rule + no-data"],
-									State:  eval.NoData,
-									Results: []Evaluation{
-										newEvaluation(t2, eval.NoData),
-										newEvaluation(t3, eval.NoData),
-									},
+									Labels:             labels["system + rule + no-data"],
+									State:              eval.NoData,
+									LatestResult:       newEvaluation(t3, eval.NoData),
 									StartsAt:           t2,
 									EndsAt:             t3.Add(ResendDelay * 4),
 									LastEvaluationTime: t3,
@@ -2450,12 +2184,10 @@ func TestProcessEvalResults_StateTransitions(t *testing.T) {
 							{
 								PreviousState: eval.Alerting,
 								State: &State{
-									Labels:      labels["system + rule"],
-									State:       eval.Normal,
-									StateReason: ngmodels.StateReasonMissingSeries,
-									Results: []Evaluation{
-										newEvaluation(t1, eval.Alerting),
-									},
+									Labels:             labels["system + rule"],
+									State:              eval.Normal,
+									StateReason:        ngmodels.StateReasonMissingSeries,
+									LatestResult:       newEvaluation(t1, eval.Alerting),
 									StartsAt:           t1,
 									EndsAt:             t3,
 									LastEvaluationTime: t3,
@@ -2466,13 +2198,10 @@ func TestProcessEvalResults_StateTransitions(t *testing.T) {
 								PreviousState:       eval.Alerting,
 								PreviousStateReason: eval.NoData.String(),
 								State: &State{
-									Labels:      labels["system + rule + no-data"],
-									State:       eval.Alerting,
-									StateReason: eval.NoData.String(),
-									Results: []Evaluation{
-										newEvaluation(t2, eval.NoData),
-										newEvaluation(t3, eval.NoData),
-									},
+									Labels:             labels["system + rule + no-data"],
+									State:              eval.Alerting,
+									StateReason:        eval.NoData.String(),
+									LatestResult:       newEvaluation(t3, eval.NoData),
 									StartsAt:           t2,
 									EndsAt:             t3.Add(ResendDelay * 4),
 									LastEvaluationTime: t3,
@@ -2485,12 +2214,10 @@ func TestProcessEvalResults_StateTransitions(t *testing.T) {
 							{
 								PreviousState: eval.Alerting,
 								State: &State{
-									Labels:      labels["system + rule"],
-									State:       eval.Normal,
-									StateReason: ngmodels.StateReasonMissingSeries,
-									Results: []Evaluation{
-										newEvaluation(t1, eval.Alerting),
-									},
+									Labels:             labels["system + rule"],
+									State:              eval.Normal,
+									StateReason:        ngmodels.StateReasonMissingSeries,
+									LatestResult:       newEvaluation(t1, eval.Alerting),
 									StartsAt:           t1,
 									EndsAt:             t3,
 									LastEvaluationTime: t3,
@@ -2501,13 +2228,10 @@ func TestProcessEvalResults_StateTransitions(t *testing.T) {
 								PreviousState:       eval.Normal,
 								PreviousStateReason: eval.NoData.String(),
 								State: &State{
-									Labels:      labels["system + rule + no-data"],
-									State:       eval.Normal,
-									StateReason: eval.NoData.String(),
-									Results: []Evaluation{
-										newEvaluation(t2, eval.NoData),
-										newEvaluation(t3, eval.NoData),
-									},
+									Labels:             labels["system + rule + no-data"],
+									State:              eval.Normal,
+									StateReason:        eval.NoData.String(),
+									LatestResult:       newEvaluation(t3, eval.NoData),
 									StartsAt:           t2,
 									EndsAt:             t2,
 									LastEvaluationTime: t3,
@@ -2520,12 +2244,10 @@ func TestProcessEvalResults_StateTransitions(t *testing.T) {
 							{
 								PreviousState: eval.Alerting,
 								State: &State{
-									Labels:      labels["system + rule"],
-									State:       eval.Normal,
-									StateReason: ngmodels.StateReasonMissingSeries,
-									Results: []Evaluation{
-										newEvaluation(t1, eval.Alerting),
-									},
+									Labels:             labels["system + rule"],
+									State:              eval.Normal,
+									StateReason:        ngmodels.StateReasonMissingSeries,
+									LatestResult:       newEvaluation(t1, eval.Alerting),
 									StartsAt:           t1,
 									EndsAt:             t3,
 									LastEvaluationTime: t3,
@@ -2536,13 +2258,10 @@ func TestProcessEvalResults_StateTransitions(t *testing.T) {
 								PreviousState:       eval.Normal,
 								PreviousStateReason: ngmodels.ConcatReasons(eval.NoData.String(), ngmodels.StateReasonKeepLast),
 								State: &State{
-									Labels:      labels["system + rule + no-data"],
-									State:       eval.Normal,
-									StateReason: ngmodels.ConcatReasons(eval.NoData.String(), ngmodels.StateReasonKeepLast),
-									Results: []Evaluation{
-										newEvaluation(t2, eval.NoData),
-										newEvaluation(t3, eval.NoData),
-									},
+									Labels:             labels["system + rule + no-data"],
+									State:              eval.Normal,
+									StateReason:        ngmodels.ConcatReasons(eval.NoData.String(), ngmodels.StateReasonKeepLast),
+									LatestResult:       newEvaluation(t3, eval.NoData),
 									StartsAt:           t2,
 									EndsAt:             t2,
 									LastEvaluationTime: t3,
@@ -2557,13 +2276,10 @@ func TestProcessEvalResults_StateTransitions(t *testing.T) {
 							{
 								PreviousState: eval.Alerting,
 								State: &State{
-									Labels:      labels["system + rule"],
-									State:       eval.Alerting,
-									StateReason: eval.NoData.String(),
-									Results: []Evaluation{
-										newEvaluation(t1, eval.Alerting),
-										newEvaluation(t2, eval.NoData),
-									},
+									Labels:             labels["system + rule"],
+									State:              eval.Alerting,
+									StateReason:        eval.NoData.String(),
+									LatestResult:       newEvaluation(t2, eval.NoData),
 									StartsAt:           t1,
 									EndsAt:             t2.Add(ResendDelay * 4),
 									LastEvaluationTime: t2,
@@ -2575,14 +2291,10 @@ func TestProcessEvalResults_StateTransitions(t *testing.T) {
 								PreviousState:       eval.Alerting,
 								PreviousStateReason: eval.NoData.String(),
 								State: &State{
-									Labels:      labels["system + rule"],
-									State:       eval.Alerting,
-									StateReason: eval.NoData.String(),
-									Results: []Evaluation{
-										newEvaluation(t1, eval.Alerting),
-										newEvaluation(t2, eval.NoData),
-										newEvaluation(t3, eval.NoData),
-									},
+									Labels:             labels["system + rule"],
+									State:              eval.Alerting,
+									StateReason:        eval.NoData.String(),
+									LatestResult:       newEvaluation(t3, eval.NoData),
 									StartsAt:           t1,
 									EndsAt:             t3.Add(ResendDelay * 4),
 									LastEvaluationTime: t3,
@@ -2595,13 +2307,10 @@ func TestProcessEvalResults_StateTransitions(t *testing.T) {
 							{
 								PreviousState: eval.Alerting,
 								State: &State{
-									Labels:      labels["system + rule"],
-									State:       eval.Normal,
-									StateReason: eval.NoData.String(),
-									Results: []Evaluation{
-										newEvaluation(t1, eval.Alerting),
-										newEvaluation(t2, eval.NoData),
-									},
+									Labels:             labels["system + rule"],
+									State:              eval.Normal,
+									StateReason:        eval.NoData.String(),
+									LatestResult:       newEvaluation(t2, eval.NoData),
 									StartsAt:           t2,
 									EndsAt:             t2,
 									LastEvaluationTime: t2,
@@ -2614,14 +2323,10 @@ func TestProcessEvalResults_StateTransitions(t *testing.T) {
 								PreviousState:       eval.Normal,
 								PreviousStateReason: eval.NoData.String(),
 								State: &State{
-									Labels:      labels["system + rule"],
-									State:       eval.Normal,
-									StateReason: eval.NoData.String(),
-									Results: []Evaluation{
-										newEvaluation(t1, eval.Alerting),
-										newEvaluation(t2, eval.NoData),
-										newEvaluation(t3, eval.NoData),
-									},
+									Labels:             labels["system + rule"],
+									State:              eval.Normal,
+									StateReason:        eval.NoData.String(),
+									LatestResult:       newEvaluation(t3, eval.NoData),
 									StartsAt:           t2,
 									EndsAt:             t2,
 									LastEvaluationTime: t3,
@@ -2634,13 +2339,10 @@ func TestProcessEvalResults_StateTransitions(t *testing.T) {
 							{
 								PreviousState: eval.Alerting,
 								State: &State{
-									Labels:      labels["system + rule"],
-									State:       eval.Alerting,
-									StateReason: ngmodels.ConcatReasons(eval.NoData.String(), ngmodels.StateReasonKeepLast),
-									Results: []Evaluation{
-										newEvaluation(t1, eval.Alerting),
-										newEvaluation(t2, eval.NoData),
-									},
+									Labels:             labels["system + rule"],
+									State:              eval.Alerting,
+									StateReason:        ngmodels.ConcatReasons(eval.NoData.String(), ngmodels.StateReasonKeepLast),
+									LatestResult:       newEvaluation(t2, eval.NoData),
 									StartsAt:           t1,
 									EndsAt:             t2.Add(ResendDelay * 4),
 									LastEvaluationTime: t2,
@@ -2652,14 +2354,10 @@ func TestProcessEvalResults_StateTransitions(t *testing.T) {
 								PreviousState:       eval.Alerting,
 								PreviousStateReason: ngmodels.ConcatReasons(eval.NoData.String(), ngmodels.StateReasonKeepLast),
 								State: &State{
-									Labels:      labels["system + rule"],
-									State:       eval.Alerting,
-									StateReason: ngmodels.ConcatReasons(eval.NoData.String(), ngmodels.StateReasonKeepLast),
-									Results: []Evaluation{
-										newEvaluation(t1, eval.Alerting),
-										newEvaluation(t2, eval.NoData),
-										newEvaluation(t3, eval.NoData),
-									},
+									Labels:             labels["system + rule"],
+									State:              eval.Alerting,
+									StateReason:        ngmodels.ConcatReasons(eval.NoData.String(), ngmodels.StateReasonKeepLast),
+									LatestResult:       newEvaluation(t3, eval.NoData),
 									StartsAt:           t1,
 									EndsAt:             t3.Add(ResendDelay * 4),
 									LastEvaluationTime: t3,
@@ -2689,11 +2387,9 @@ func TestProcessEvalResults_StateTransitions(t *testing.T) {
 							{
 								PreviousState: eval.Normal,
 								State: &State{
-									Labels: labels["system + rule + no-data"],
-									State:  eval.NoData,
-									Results: []Evaluation{
-										newEvaluation(t2, eval.NoData),
-									},
+									Labels:             labels["system + rule + no-data"],
+									State:              eval.NoData,
+									LatestResult:       newEvaluation(t2, eval.NoData),
 									StartsAt:           t2,
 									EndsAt:             t2.Add(ResendDelay * 4),
 									LastEvaluationTime: t2,
@@ -2704,12 +2400,9 @@ func TestProcessEvalResults_StateTransitions(t *testing.T) {
 							{
 								PreviousState: eval.Pending,
 								State: &State{
-									Labels: labels["system + rule"],
-									State:  eval.Alerting,
-									Results: []Evaluation{
-										newEvaluation(t1, eval.Alerting),
-										newEvaluation(t3, eval.Alerting),
-									},
+									Labels:             labels["system + rule"],
+									State:              eval.Alerting,
+									LatestResult:       newEvaluation(t3, eval.Alerting),
 									StartsAt:           t3,
 									EndsAt:             t3.Add(ResendDelay * 4),
 									LastEvaluationTime: t3,
@@ -2722,12 +2415,9 @@ func TestProcessEvalResults_StateTransitions(t *testing.T) {
 							{
 								PreviousState: eval.Pending,
 								State: &State{
-									Labels: labels["system + rule"],
-									State:  eval.Alerting,
-									Results: []Evaluation{
-										newEvaluation(t1, eval.Alerting),
-										newEvaluation(t3, eval.Alerting),
-									},
+									Labels:             labels["system + rule"],
+									State:              eval.Alerting,
+									LatestResult:       newEvaluation(t3, eval.Alerting),
 									StartsAt:           t3,
 									EndsAt:             t3.Add(ResendDelay * 4),
 									LastEvaluationTime: t3,
@@ -2740,12 +2430,9 @@ func TestProcessEvalResults_StateTransitions(t *testing.T) {
 							{
 								PreviousState: eval.Pending,
 								State: &State{
-									Labels: labels["system + rule"],
-									State:  eval.Alerting,
-									Results: []Evaluation{
-										newEvaluation(t1, eval.Alerting),
-										newEvaluation(t3, eval.Alerting),
-									},
+									Labels:             labels["system + rule"],
+									State:              eval.Alerting,
+									LatestResult:       newEvaluation(t3, eval.Alerting),
 									StartsAt:           t3,
 									EndsAt:             t3.Add(ResendDelay * 4),
 									LastEvaluationTime: t3,
@@ -2758,12 +2445,9 @@ func TestProcessEvalResults_StateTransitions(t *testing.T) {
 							{
 								PreviousState: eval.Pending,
 								State: &State{
-									Labels: labels["system + rule"],
-									State:  eval.Alerting,
-									Results: []Evaluation{
-										newEvaluation(t1, eval.Alerting),
-										newEvaluation(t3, eval.Alerting),
-									},
+									Labels:             labels["system + rule"],
+									State:              eval.Alerting,
+									LatestResult:       newEvaluation(t3, eval.Alerting),
 									StartsAt:           t3,
 									EndsAt:             t3.Add(ResendDelay * 4),
 									LastEvaluationTime: t3,
@@ -2779,12 +2463,9 @@ func TestProcessEvalResults_StateTransitions(t *testing.T) {
 								PreviousState:       eval.Pending,
 								PreviousStateReason: eval.NoData.String(),
 								State: &State{
-									Labels: labels["system + rule"],
-									State:  eval.Alerting,
-									Results: []Evaluation{
-										newEvaluation(t2, eval.NoData),
-										newEvaluation(t3, eval.Alerting),
-									},
+									Labels:             labels["system + rule"],
+									State:              eval.Alerting,
+									LatestResult:       newEvaluation(t3, eval.Alerting),
 									StartsAt:           t3,
 									EndsAt:             t3.Add(ResendDelay * 4),
 									LastEvaluationTime: t3,
@@ -2798,12 +2479,9 @@ func TestProcessEvalResults_StateTransitions(t *testing.T) {
 								PreviousState:       eval.Normal,
 								PreviousStateReason: eval.NoData.String(),
 								State: &State{
-									Labels: labels["system + rule"],
-									State:  eval.Pending,
-									Results: []Evaluation{
-										newEvaluation(t2, eval.NoData),
-										newEvaluation(t3, eval.Alerting),
-									},
+									Labels:             labels["system + rule"],
+									State:              eval.Pending,
+									LatestResult:       newEvaluation(t3, eval.Alerting),
 									StartsAt:           t3,
 									EndsAt:             t3.Add(ResendDelay * 4),
 									LastEvaluationTime: t3,
@@ -2817,12 +2495,9 @@ func TestProcessEvalResults_StateTransitions(t *testing.T) {
 								PreviousState:       eval.Pending,
 								PreviousStateReason: ngmodels.ConcatReasons(eval.NoData.String(), ngmodels.StateReasonKeepLast),
 								State: &State{
-									Labels: labels["system + rule"],
-									State:  eval.Alerting,
-									Results: []Evaluation{
-										newEvaluation(t2, eval.NoData),
-										newEvaluation(t3, eval.Alerting),
-									},
+									Labels:             labels["system + rule"],
+									State:              eval.Alerting,
+									LatestResult:       newEvaluation(t3, eval.Alerting),
 									StartsAt:           t3,
 									EndsAt:             t3.Add(ResendDelay * 4),
 									LastEvaluationTime: t3,
@@ -2912,13 +2587,11 @@ func TestProcessEvalResults_StateTransitions(t *testing.T) {
 							{
 								PreviousState: eval.Normal,
 								State: &State{
-									CacheID: cacheID(labels["system + rule"]),
-									Labels:  labels["system + rule + datasource-error"],
-									State:   eval.Error,
-									Error:   datasourceError,
-									Results: []Evaluation{
-										newEvaluation(t1, eval.Error),
-									},
+									CacheID:            cacheID(labels["system + rule"]),
+									Labels:             labels["system + rule + datasource-error"],
+									State:              eval.Error,
+									Error:              datasourceError,
+									LatestResult:       newEvaluation(t1, eval.Error),
 									StartsAt:           t1,
 									EndsAt:             t1.Add(ResendDelay * 4),
 									LastEvaluationTime: t1,
@@ -2934,13 +2607,11 @@ func TestProcessEvalResults_StateTransitions(t *testing.T) {
 							{
 								PreviousState: eval.Normal,
 								State: &State{
-									Labels:      labels["system + rule"],
-									State:       eval.Alerting,
-									StateReason: eval.Error.String(),
-									Error:       datasourceError,
-									Results: []Evaluation{
-										newEvaluation(t1, eval.Error),
-									},
+									Labels:             labels["system + rule"],
+									State:              eval.Alerting,
+									StateReason:        eval.Error.String(),
+									Error:              datasourceError,
+									LatestResult:       newEvaluation(t1, eval.Error),
 									StartsAt:           t1,
 									EndsAt:             t1.Add(ResendDelay * 4),
 									LastEvaluationTime: t1,
@@ -2953,12 +2624,10 @@ func TestProcessEvalResults_StateTransitions(t *testing.T) {
 							{
 								PreviousState: eval.Normal,
 								State: &State{
-									Labels:      labels["system + rule"],
-									State:       eval.Normal,
-									StateReason: eval.Error.String(),
-									Results: []Evaluation{
-										newEvaluation(t1, eval.Error),
-									},
+									Labels:             labels["system + rule"],
+									State:              eval.Normal,
+									StateReason:        eval.Error.String(),
+									LatestResult:       newEvaluation(t1, eval.Error),
 									StartsAt:           t1,
 									EndsAt:             t1,
 									LastEvaluationTime: t1,
@@ -2971,12 +2640,10 @@ func TestProcessEvalResults_StateTransitions(t *testing.T) {
 							{
 								PreviousState: eval.Normal,
 								State: &State{
-									Labels:      labels["system + rule"],
-									State:       eval.Normal,
-									StateReason: ngmodels.ConcatReasons(eval.Error.String(), ngmodels.StateReasonKeepLast),
-									Results: []Evaluation{
-										newEvaluation(t1, eval.Error),
-									},
+									Labels:             labels["system + rule"],
+									State:              eval.Normal,
+									StateReason:        ngmodels.ConcatReasons(eval.Error.String(), ngmodels.StateReasonKeepLast),
+									LatestResult:       newEvaluation(t1, eval.Error),
 									StartsAt:           t1,
 									EndsAt:             t1,
 									LastEvaluationTime: t1,
@@ -2999,12 +2666,10 @@ func TestProcessEvalResults_StateTransitions(t *testing.T) {
 							{
 								PreviousState: eval.Normal,
 								State: &State{
-									Labels: labels["system + rule"],
-									State:  eval.Error,
-									Error:  genericError,
-									Results: []Evaluation{
-										newEvaluation(t1, eval.Error),
-									},
+									Labels:             labels["system + rule"],
+									State:              eval.Error,
+									Error:              genericError,
+									LatestResult:       newEvaluation(t1, eval.Error),
 									StartsAt:           t1,
 									EndsAt:             t1.Add(ResendDelay * 4),
 									LastEvaluationTime: t1,
@@ -3020,13 +2685,11 @@ func TestProcessEvalResults_StateTransitions(t *testing.T) {
 							{
 								PreviousState: eval.Normal,
 								State: &State{
-									Labels:      labels["system + rule"],
-									State:       eval.Alerting,
-									StateReason: eval.Error.String(),
-									Error:       genericError,
-									Results: []Evaluation{
-										newEvaluation(t1, eval.Error),
-									},
+									Labels:             labels["system + rule"],
+									State:              eval.Alerting,
+									StateReason:        eval.Error.String(),
+									Error:              genericError,
+									LatestResult:       newEvaluation(t1, eval.Error),
 									StartsAt:           t1,
 									EndsAt:             t1.Add(ResendDelay * 4),
 									LastEvaluationTime: t1,
@@ -3039,12 +2702,10 @@ func TestProcessEvalResults_StateTransitions(t *testing.T) {
 							{
 								PreviousState: eval.Normal,
 								State: &State{
-									Labels:      labels["system + rule"],
-									State:       eval.Normal,
-									StateReason: eval.Error.String(),
-									Results: []Evaluation{
-										newEvaluation(t1, eval.Error),
-									},
+									Labels:             labels["system + rule"],
+									State:              eval.Normal,
+									StateReason:        eval.Error.String(),
+									LatestResult:       newEvaluation(t1, eval.Error),
 									StartsAt:           t1,
 									EndsAt:             t1,
 									LastEvaluationTime: t1,
@@ -3057,12 +2718,10 @@ func TestProcessEvalResults_StateTransitions(t *testing.T) {
 							{
 								PreviousState: eval.Normal,
 								State: &State{
-									Labels:      labels["system + rule"],
-									State:       eval.Normal,
-									StateReason: ngmodels.ConcatReasons(eval.Error.String(), ngmodels.StateReasonKeepLast),
-									Results: []Evaluation{
-										newEvaluation(t1, eval.Error),
-									},
+									Labels:             labels["system + rule"],
+									State:              eval.Normal,
+									StateReason:        ngmodels.ConcatReasons(eval.Error.String(), ngmodels.StateReasonKeepLast),
+									LatestResult:       newEvaluation(t1, eval.Error),
 									StartsAt:           t1,
 									EndsAt:             t1,
 									LastEvaluationTime: t1,
@@ -3089,13 +2748,11 @@ func TestProcessEvalResults_StateTransitions(t *testing.T) {
 							{
 								PreviousState: eval.Normal,
 								State: &State{
-									CacheID: cacheID(labels["system + rule"]),
-									Labels:  labels["system + rule + datasource-error"],
-									State:   eval.Error,
-									Error:   datasourceError,
-									Results: []Evaluation{
-										newEvaluation(t2, eval.Error),
-									},
+									CacheID:            cacheID(labels["system + rule"]),
+									Labels:             labels["system + rule + datasource-error"],
+									State:              eval.Error,
+									Error:              datasourceError,
+									LatestResult:       newEvaluation(t2, eval.Error),
 									StartsAt:           t2,
 									EndsAt:             t2.Add(ResendDelay * 4),
 									LastEvaluationTime: t2,
@@ -3111,13 +2768,11 @@ func TestProcessEvalResults_StateTransitions(t *testing.T) {
 							{
 								PreviousState: eval.Normal,
 								State: &State{
-									Labels:      labels["system + rule"],
-									State:       eval.Pending,
-									StateReason: eval.Error.String(),
-									Error:       datasourceError,
-									Results: []Evaluation{
-										newEvaluation(t2, eval.Error),
-									},
+									Labels:             labels["system + rule"],
+									State:              eval.Pending,
+									StateReason:        eval.Error.String(),
+									Error:              datasourceError,
+									LatestResult:       newEvaluation(t2, eval.Error),
 									StartsAt:           t2,
 									EndsAt:             t2.Add(ResendDelay * 4),
 									LastEvaluationTime: t2,
@@ -3130,12 +2785,10 @@ func TestProcessEvalResults_StateTransitions(t *testing.T) {
 							{
 								PreviousState: eval.Normal,
 								State: &State{
-									Labels:      labels["system + rule"],
-									State:       eval.Normal,
-									StateReason: eval.Error.String(),
-									Results: []Evaluation{
-										newEvaluation(t2, eval.Error),
-									},
+									Labels:             labels["system + rule"],
+									State:              eval.Normal,
+									StateReason:        eval.Error.String(),
+									LatestResult:       newEvaluation(t2, eval.Error),
 									StartsAt:           t2,
 									EndsAt:             t2,
 									LastEvaluationTime: t2,
@@ -3148,12 +2801,10 @@ func TestProcessEvalResults_StateTransitions(t *testing.T) {
 							{
 								PreviousState: eval.Normal,
 								State: &State{
-									Labels:      labels["system + rule"],
-									State:       eval.Normal,
-									StateReason: ngmodels.ConcatReasons(eval.Error.String(), ngmodels.StateReasonKeepLast),
-									Results: []Evaluation{
-										newEvaluation(t2, eval.Error),
-									},
+									Labels:             labels["system + rule"],
+									State:              eval.Normal,
+									StateReason:        ngmodels.ConcatReasons(eval.Error.String(), ngmodels.StateReasonKeepLast),
+									LatestResult:       newEvaluation(t2, eval.Error),
 									StartsAt:           t2,
 									EndsAt:             t2,
 									LastEvaluationTime: t2,
@@ -3168,13 +2819,11 @@ func TestProcessEvalResults_StateTransitions(t *testing.T) {
 							{
 								PreviousState: eval.Pending,
 								State: &State{
-									Labels:      labels["system + rule + labels1"],
-									State:       eval.Alerting,
-									StateReason: eval.Error.String(),
-									Error:       datasourceError,
-									Results: []Evaluation{
-										newEvaluation(t2, eval.Error),
-									},
+									Labels:             labels["system + rule + labels1"],
+									State:              eval.Alerting,
+									StateReason:        eval.Error.String(),
+									Error:              datasourceError,
+									LatestResult:       newEvaluation(t2, eval.Error),
 									StartsAt:           t2,
 									EndsAt:             t2.Add(ResendDelay * 4),
 									LastEvaluationTime: t2,
@@ -3187,12 +2836,10 @@ func TestProcessEvalResults_StateTransitions(t *testing.T) {
 							{
 								PreviousState: eval.Pending,
 								State: &State{
-									Labels:      labels["system + rule + labels1"],
-									State:       eval.Normal,
-									StateReason: eval.Error.String(),
-									Results: []Evaluation{
-										newEvaluation(t2, eval.Error),
-									},
+									Labels:             labels["system + rule + labels1"],
+									State:              eval.Normal,
+									StateReason:        eval.Error.String(),
+									LatestResult:       newEvaluation(t2, eval.Error),
 									StartsAt:           t2,
 									EndsAt:             t2,
 									LastEvaluationTime: t2,
@@ -3205,12 +2852,10 @@ func TestProcessEvalResults_StateTransitions(t *testing.T) {
 							{
 								PreviousState: eval.Pending,
 								State: &State{
-									Labels:      labels["system + rule + labels1"],
-									State:       eval.Alerting,
-									StateReason: ngmodels.ConcatReasons(eval.Error.String(), ngmodels.StateReasonKeepLast),
-									Results: []Evaluation{
-										newEvaluation(t2, eval.Error),
-									},
+									Labels:             labels["system + rule + labels1"],
+									State:              eval.Alerting,
+									StateReason:        ngmodels.ConcatReasons(eval.Error.String(), ngmodels.StateReasonKeepLast),
+									LatestResult:       newEvaluation(t2, eval.Error),
 									StartsAt:           t2,
 									EndsAt:             t2.Add(ResendDelay * 4),
 									LastEvaluationTime: t2,
@@ -3236,13 +2881,11 @@ func TestProcessEvalResults_StateTransitions(t *testing.T) {
 							{
 								PreviousState: eval.Normal,
 								State: &State{
-									CacheID: cacheID(labels["system + rule"]),
-									Labels:  labels["system + rule + datasource-error"],
-									State:   eval.Error,
-									Error:   datasourceError,
-									Results: []Evaluation{
-										newEvaluation(t2, eval.Error),
-									},
+									CacheID:            cacheID(labels["system + rule"]),
+									Labels:             labels["system + rule + datasource-error"],
+									State:              eval.Error,
+									Error:              datasourceError,
+									LatestResult:       newEvaluation(t2, eval.Error),
 									StartsAt:           t2,
 									EndsAt:             t2.Add(ResendDelay * 4),
 									LastEvaluationTime: t2,
@@ -3258,13 +2901,11 @@ func TestProcessEvalResults_StateTransitions(t *testing.T) {
 							{
 								PreviousState: eval.Normal,
 								State: &State{
-									Labels:      labels["system + rule"],
-									State:       eval.Alerting,
-									StateReason: eval.Error.String(),
-									Error:       datasourceError,
-									Results: []Evaluation{
-										newEvaluation(t2, eval.Error),
-									},
+									Labels:             labels["system + rule"],
+									State:              eval.Alerting,
+									StateReason:        eval.Error.String(),
+									Error:              datasourceError,
+									LatestResult:       newEvaluation(t2, eval.Error),
 									StartsAt:           t2,
 									EndsAt:             t2.Add(ResendDelay * 4),
 									LastEvaluationTime: t2,
@@ -3277,12 +2918,10 @@ func TestProcessEvalResults_StateTransitions(t *testing.T) {
 							{
 								PreviousState: eval.Normal,
 								State: &State{
-									Labels:      labels["system + rule"],
-									State:       eval.Normal,
-									StateReason: eval.Error.String(),
-									Results: []Evaluation{
-										newEvaluation(t2, eval.Error),
-									},
+									Labels:             labels["system + rule"],
+									State:              eval.Normal,
+									StateReason:        eval.Error.String(),
+									LatestResult:       newEvaluation(t2, eval.Error),
 									StartsAt:           t2,
 									EndsAt:             t2,
 									LastEvaluationTime: t2,
@@ -3295,12 +2934,10 @@ func TestProcessEvalResults_StateTransitions(t *testing.T) {
 							{
 								PreviousState: eval.Normal,
 								State: &State{
-									Labels:      labels["system + rule"],
-									State:       eval.Normal,
-									StateReason: ngmodels.ConcatReasons(eval.Error.String(), ngmodels.StateReasonKeepLast),
-									Results: []Evaluation{
-										newEvaluation(t2, eval.Error),
-									},
+									Labels:             labels["system + rule"],
+									State:              eval.Normal,
+									StateReason:        ngmodels.ConcatReasons(eval.Error.String(), ngmodels.StateReasonKeepLast),
+									LatestResult:       newEvaluation(t2, eval.Error),
 									StartsAt:           t2,
 									EndsAt:             t2,
 									LastEvaluationTime: t2,
@@ -3315,14 +2952,11 @@ func TestProcessEvalResults_StateTransitions(t *testing.T) {
 							{
 								PreviousState: eval.Normal,
 								State: &State{
-									Labels:      labels["system + rule + labels1"],
-									State:       eval.Alerting,
-									StateReason: eval.Error.String(),
-									Error:       datasourceError,
-									Results: []Evaluation{
-										newEvaluation(t1, eval.Normal),
-										newEvaluation(t2, eval.Error),
-									},
+									Labels:             labels["system + rule + labels1"],
+									State:              eval.Alerting,
+									StateReason:        eval.Error.String(),
+									Error:              datasourceError,
+									LatestResult:       newEvaluation(t2, eval.Error),
 									StartsAt:           t2,
 									EndsAt:             t2.Add(ResendDelay * 4),
 									LastEvaluationTime: t2,
@@ -3335,13 +2969,10 @@ func TestProcessEvalResults_StateTransitions(t *testing.T) {
 							{
 								PreviousState: eval.Normal,
 								State: &State{
-									Labels:      labels["system + rule + labels1"],
-									State:       eval.Normal,
-									StateReason: eval.Error.String(),
-									Results: []Evaluation{
-										newEvaluation(t1, eval.Normal),
-										newEvaluation(t2, eval.Error),
-									},
+									Labels:             labels["system + rule + labels1"],
+									State:              eval.Normal,
+									StateReason:        eval.Error.String(),
+									LatestResult:       newEvaluation(t2, eval.Error),
 									StartsAt:           t1,
 									EndsAt:             t1,
 									LastEvaluationTime: t2,
@@ -3354,13 +2985,10 @@ func TestProcessEvalResults_StateTransitions(t *testing.T) {
 							{
 								PreviousState: eval.Normal,
 								State: &State{
-									Labels:      labels["system + rule + labels1"],
-									State:       eval.Normal,
-									StateReason: ngmodels.ConcatReasons(eval.Error.String(), ngmodels.StateReasonKeepLast),
-									Results: []Evaluation{
-										newEvaluation(t1, eval.Normal),
-										newEvaluation(t2, eval.Error),
-									},
+									Labels:             labels["system + rule + labels1"],
+									State:              eval.Normal,
+									StateReason:        ngmodels.ConcatReasons(eval.Error.String(), ngmodels.StateReasonKeepLast),
+									LatestResult:       newEvaluation(t2, eval.Error),
 									StartsAt:           t1,
 									EndsAt:             t1,
 									LastEvaluationTime: t2,
@@ -3389,12 +3017,9 @@ func TestProcessEvalResults_StateTransitions(t *testing.T) {
 							{
 								PreviousState: eval.Normal,
 								State: &State{
-									Labels: labels["system + rule + labels1"],
-									State:  eval.Normal,
-									Results: []Evaluation{
-										newEvaluation(t2, eval.Normal),
-										newEvaluation(t3, eval.Normal),
-									},
+									Labels:             labels["system + rule + labels1"],
+									State:              eval.Normal,
+									LatestResult:       newEvaluation(t3, eval.Normal),
 									StartsAt:           t2,
 									EndsAt:             t2,
 									LastEvaluationTime: t3,
@@ -3403,14 +3028,12 @@ func TestProcessEvalResults_StateTransitions(t *testing.T) {
 							{
 								PreviousState: eval.Error,
 								State: &State{
-									CacheID:     cacheID(labels["system + rule"]),
-									Labels:      labels["system + rule + datasource-error"],
-									Error:       datasourceError,
-									State:       eval.Normal,
-									StateReason: ngmodels.StateReasonMissingSeries,
-									Results: []Evaluation{
-										newEvaluation(t1, eval.Error),
-									},
+									CacheID:            cacheID(labels["system + rule"]),
+									Labels:             labels["system + rule + datasource-error"],
+									Error:              datasourceError,
+									State:              eval.Normal,
+									StateReason:        ngmodels.StateReasonMissingSeries,
+									LatestResult:       newEvaluation(t1, eval.Error),
 									StartsAt:           t1,
 									EndsAt:             t3,
 									LastEvaluationTime: t3,
@@ -3426,12 +3049,9 @@ func TestProcessEvalResults_StateTransitions(t *testing.T) {
 							{
 								PreviousState: eval.Normal,
 								State: &State{
-									Labels: labels["system + rule + labels1"],
-									State:  eval.Normal,
-									Results: []Evaluation{
-										newEvaluation(t2, eval.Normal),
-										newEvaluation(t3, eval.Normal),
-									},
+									Labels:             labels["system + rule + labels1"],
+									State:              eval.Normal,
+									LatestResult:       newEvaluation(t3, eval.Normal),
 									StartsAt:           t2,
 									EndsAt:             t2,
 									LastEvaluationTime: t3,
@@ -3441,13 +3061,11 @@ func TestProcessEvalResults_StateTransitions(t *testing.T) {
 								PreviousState:       eval.Alerting,
 								PreviousStateReason: eval.Error.String(),
 								State: &State{
-									Labels:      labels["system + rule"],
-									Error:       datasourceError,
-									State:       eval.Normal,
-									StateReason: ngmodels.StateReasonMissingSeries,
-									Results: []Evaluation{
-										newEvaluation(t1, eval.Error),
-									},
+									Labels:             labels["system + rule"],
+									Error:              datasourceError,
+									State:              eval.Normal,
+									StateReason:        ngmodels.StateReasonMissingSeries,
+									LatestResult:       newEvaluation(t1, eval.Error),
 									StartsAt:           t1,
 									EndsAt:             t3,
 									LastEvaluationTime: t3,
@@ -3461,12 +3079,9 @@ func TestProcessEvalResults_StateTransitions(t *testing.T) {
 							{
 								PreviousState: eval.Normal,
 								State: &State{
-									Labels: labels["system + rule + labels1"],
-									State:  eval.Normal,
-									Results: []Evaluation{
-										newEvaluation(t2, eval.Normal),
-										newEvaluation(t3, eval.Normal),
-									},
+									Labels:             labels["system + rule + labels1"],
+									State:              eval.Normal,
+									LatestResult:       newEvaluation(t3, eval.Normal),
 									StartsAt:           t2,
 									EndsAt:             t2,
 									LastEvaluationTime: t3,
@@ -3476,12 +3091,10 @@ func TestProcessEvalResults_StateTransitions(t *testing.T) {
 								PreviousState:       eval.Normal,
 								PreviousStateReason: eval.Error.String(),
 								State: &State{
-									Labels:      labels["system + rule"],
-									State:       eval.Normal,
-									StateReason: ngmodels.StateReasonMissingSeries,
-									Results: []Evaluation{
-										newEvaluation(t1, eval.Error),
-									},
+									Labels:             labels["system + rule"],
+									State:              eval.Normal,
+									StateReason:        ngmodels.StateReasonMissingSeries,
+									LatestResult:       newEvaluation(t1, eval.Error),
 									StartsAt:           t1,
 									EndsAt:             t3,
 									LastEvaluationTime: t3,
@@ -3494,12 +3107,9 @@ func TestProcessEvalResults_StateTransitions(t *testing.T) {
 							{
 								PreviousState: eval.Normal,
 								State: &State{
-									Labels: labels["system + rule + labels1"],
-									State:  eval.Normal,
-									Results: []Evaluation{
-										newEvaluation(t2, eval.Normal),
-										newEvaluation(t3, eval.Normal),
-									},
+									Labels:             labels["system + rule + labels1"],
+									State:              eval.Normal,
+									LatestResult:       newEvaluation(t3, eval.Normal),
 									StartsAt:           t2,
 									EndsAt:             t2,
 									LastEvaluationTime: t3,
@@ -3509,12 +3119,10 @@ func TestProcessEvalResults_StateTransitions(t *testing.T) {
 								PreviousState:       eval.Normal,
 								PreviousStateReason: ngmodels.ConcatReasons(eval.Error.String(), ngmodels.StateReasonKeepLast),
 								State: &State{
-									Labels:      labels["system + rule"],
-									State:       eval.Normal,
-									StateReason: ngmodels.StateReasonMissingSeries,
-									Results: []Evaluation{
-										newEvaluation(t1, eval.Error),
-									},
+									Labels:             labels["system + rule"],
+									State:              eval.Normal,
+									StateReason:        ngmodels.StateReasonMissingSeries,
+									LatestResult:       newEvaluation(t1, eval.Error),
 									StartsAt:           t1,
 									EndsAt:             t3,
 									LastEvaluationTime: t3,
@@ -3540,14 +3148,11 @@ func TestProcessEvalResults_StateTransitions(t *testing.T) {
 							{
 								PreviousState: eval.Normal,
 								State: &State{
-									CacheID: cacheID(labels["system + rule"]),
-									Labels:  labels["system + rule + datasource-error"],
-									State:   eval.Error,
-									Error:   datasourceError,
-									Results: []Evaluation{
-										newEvaluation(t1, eval.Normal),
-										newEvaluation(t2, eval.Error),
-									},
+									CacheID:            cacheID(labels["system + rule"]),
+									Labels:             labels["system + rule + datasource-error"],
+									State:              eval.Error,
+									Error:              datasourceError,
+									LatestResult:       newEvaluation(t2, eval.Error),
 									StartsAt:           t2,
 									EndsAt:             t2.Add(ResendDelay * 4),
 									LastEvaluationTime: t2,
@@ -3563,14 +3168,11 @@ func TestProcessEvalResults_StateTransitions(t *testing.T) {
 							{
 								PreviousState: eval.Normal,
 								State: &State{
-									Labels:      labels["system + rule"],
-									State:       eval.Alerting,
-									StateReason: eval.Error.String(),
-									Error:       datasourceError,
-									Results: []Evaluation{
-										newEvaluation(t1, eval.Normal),
-										newEvaluation(t2, eval.Error),
-									},
+									Labels:             labels["system + rule"],
+									State:              eval.Alerting,
+									StateReason:        eval.Error.String(),
+									Error:              datasourceError,
+									LatestResult:       newEvaluation(t2, eval.Error),
 									StartsAt:           t2,
 									EndsAt:             t2.Add(ResendDelay * 4),
 									LastEvaluationTime: t2,
@@ -3583,13 +3185,10 @@ func TestProcessEvalResults_StateTransitions(t *testing.T) {
 							{
 								PreviousState: eval.Normal,
 								State: &State{
-									Labels:      labels["system + rule"],
-									State:       eval.Normal,
-									StateReason: eval.Error.String(),
-									Results: []Evaluation{
-										newEvaluation(t1, eval.Normal),
-										newEvaluation(t2, eval.Error),
-									},
+									Labels:             labels["system + rule"],
+									State:              eval.Normal,
+									StateReason:        eval.Error.String(),
+									LatestResult:       newEvaluation(t2, eval.Error),
 									StartsAt:           t1,
 									EndsAt:             t1,
 									LastEvaluationTime: t2,
@@ -3602,13 +3201,10 @@ func TestProcessEvalResults_StateTransitions(t *testing.T) {
 							{
 								PreviousState: eval.Normal,
 								State: &State{
-									Labels:      labels["system + rule"],
-									State:       eval.Normal,
-									StateReason: ngmodels.ConcatReasons(eval.Error.String(), ngmodels.StateReasonKeepLast),
-									Results: []Evaluation{
-										newEvaluation(t1, eval.Normal),
-										newEvaluation(t2, eval.Error),
-									},
+									Labels:             labels["system + rule"],
+									State:              eval.Normal,
+									StateReason:        ngmodels.ConcatReasons(eval.Error.String(), ngmodels.StateReasonKeepLast),
+									LatestResult:       newEvaluation(t2, eval.Error),
 									StartsAt:           t1,
 									EndsAt:             t1,
 									LastEvaluationTime: t2,
@@ -3635,11 +3231,9 @@ func TestProcessEvalResults_StateTransitions(t *testing.T) {
 							{
 								PreviousState: eval.Normal,
 								State: &State{
-									Labels: labels["system + rule"],
-									State:  eval.Pending,
-									Results: []Evaluation{
-										newEvaluation(t1, eval.Alerting),
-									},
+									Labels:             labels["system + rule"],
+									State:              eval.Pending,
+									LatestResult:       newEvaluation(t1, eval.Alerting),
 									StartsAt:           t1,
 									EndsAt:             t1.Add(ResendDelay * 4),
 									LastEvaluationTime: t1,
@@ -3650,13 +3244,11 @@ func TestProcessEvalResults_StateTransitions(t *testing.T) {
 							{
 								PreviousState: eval.Pending,
 								State: &State{
-									CacheID: cacheID(labels["system + rule"]),
-									Labels:  labels["system + rule + datasource-error"],
-									State:   eval.Error,
-									Error:   datasourceError,
-									Results: []Evaluation{
-										newEvaluation(t2, eval.Error),
-									},
+									CacheID:            cacheID(labels["system + rule"]),
+									Labels:             labels["system + rule + datasource-error"],
+									State:              eval.Error,
+									Error:              datasourceError,
+									LatestResult:       newEvaluation(t2, eval.Error),
 									StartsAt:           t2,
 									EndsAt:             t2.Add(ResendDelay * 4),
 									LastEvaluationTime: t2,
@@ -3672,13 +3264,11 @@ func TestProcessEvalResults_StateTransitions(t *testing.T) {
 							{
 								PreviousState: eval.Pending,
 								State: &State{
-									Labels:      labels["system + rule"],
-									State:       eval.Alerting,
-									StateReason: eval.Error.String(),
-									Error:       datasourceError,
-									Results: []Evaluation{
-										newEvaluation(t2, eval.Error),
-									},
+									Labels:             labels["system + rule"],
+									State:              eval.Alerting,
+									StateReason:        eval.Error.String(),
+									Error:              datasourceError,
+									LatestResult:       newEvaluation(t2, eval.Error),
 									StartsAt:           t2,
 									EndsAt:             t2.Add(ResendDelay * 4),
 									LastEvaluationTime: t2,
@@ -3691,12 +3281,10 @@ func TestProcessEvalResults_StateTransitions(t *testing.T) {
 							{
 								PreviousState: eval.Pending,
 								State: &State{
-									Labels:      labels["system + rule"],
-									State:       eval.Normal,
-									StateReason: eval.Error.String(),
-									Results: []Evaluation{
-										newEvaluation(t2, eval.Error),
-									},
+									Labels:             labels["system + rule"],
+									State:              eval.Normal,
+									StateReason:        eval.Error.String(),
+									LatestResult:       newEvaluation(t2, eval.Error),
 									StartsAt:           t2,
 									EndsAt:             t2,
 									LastEvaluationTime: t2,
@@ -3709,12 +3297,10 @@ func TestProcessEvalResults_StateTransitions(t *testing.T) {
 							{
 								PreviousState: eval.Pending,
 								State: &State{
-									Labels:      labels["system + rule"],
-									State:       eval.Alerting,
-									StateReason: ngmodels.ConcatReasons(eval.Error.String(), ngmodels.StateReasonKeepLast),
-									Results: []Evaluation{
-										newEvaluation(t2, eval.Error),
-									},
+									Labels:             labels["system + rule"],
+									State:              eval.Alerting,
+									StateReason:        ngmodels.ConcatReasons(eval.Error.String(), ngmodels.StateReasonKeepLast),
+									LatestResult:       newEvaluation(t2, eval.Error),
 									StartsAt:           t2,
 									EndsAt:             t2.Add(ResendDelay * 4),
 									LastEvaluationTime: t2,
@@ -3744,14 +3330,11 @@ func TestProcessEvalResults_StateTransitions(t *testing.T) {
 							{
 								PreviousState: eval.Pending,
 								State: &State{
-									CacheID: cacheID(labels["system + rule"]),
-									Labels:  labels["system + rule + datasource-error"],
-									State:   eval.Error,
-									Error:   datasourceError,
-									Results: []Evaluation{
-										newEvaluation(t1, eval.Alerting),
-										newEvaluation(t2, eval.Error),
-									},
+									CacheID:            cacheID(labels["system + rule"]),
+									Labels:             labels["system + rule + datasource-error"],
+									State:              eval.Error,
+									Error:              datasourceError,
+									LatestResult:       newEvaluation(t2, eval.Error),
 									StartsAt:           t2,
 									EndsAt:             t2.Add(ResendDelay * 4),
 									LastEvaluationTime: t2,
@@ -3765,12 +3348,9 @@ func TestProcessEvalResults_StateTransitions(t *testing.T) {
 							{
 								PreviousState: eval.Error,
 								State: &State{
-									Labels: labels["system + rule"],
-									State:  eval.Pending,
-									Results: []Evaluation{
-										newEvaluation(t2, eval.Error),
-										newEvaluation(t3, eval.Alerting),
-									},
+									Labels:             labels["system + rule"],
+									State:              eval.Pending,
+									LatestResult:       newEvaluation(t3, eval.Alerting),
 									StartsAt:           t3,
 									EndsAt:             t3.Add(ResendDelay * 4),
 									LastEvaluationTime: t3,
@@ -3783,14 +3363,11 @@ func TestProcessEvalResults_StateTransitions(t *testing.T) {
 							{
 								PreviousState: eval.Pending,
 								State: &State{
-									Labels:      labels["system + rule"],
-									State:       eval.Pending,
-									StateReason: eval.Error.String(),
-									Error:       datasourceError,
-									Results: []Evaluation{
-										newEvaluation(t1, eval.Alerting),
-										newEvaluation(t2, eval.Error),
-									},
+									Labels:             labels["system + rule"],
+									State:              eval.Pending,
+									StateReason:        eval.Error.String(),
+									Error:              datasourceError,
+									LatestResult:       newEvaluation(t2, eval.Error),
 									StartsAt:           t1,
 									EndsAt:             t1.Add(ResendDelay * 4), // TODO probably it should be t1 (semantic of Normal)?
 									LastEvaluationTime: t2,
@@ -3802,12 +3379,9 @@ func TestProcessEvalResults_StateTransitions(t *testing.T) {
 								PreviousState:       eval.Pending,
 								PreviousStateReason: eval.Error.String(),
 								State: &State{
-									Labels: labels["system + rule"],
-									State:  eval.Alerting,
-									Results: []Evaluation{
-										newEvaluation(t2, eval.Error),
-										newEvaluation(t3, eval.Alerting),
-									},
+									Labels:             labels["system + rule"],
+									State:              eval.Alerting,
+									LatestResult:       newEvaluation(t3, eval.Alerting),
 									StartsAt:           t3,
 									EndsAt:             t3.Add(ResendDelay * 4),
 									LastEvaluationTime: t3,
@@ -3820,13 +3394,10 @@ func TestProcessEvalResults_StateTransitions(t *testing.T) {
 							{
 								PreviousState: eval.Pending,
 								State: &State{
-									Labels:      labels["system + rule"],
-									State:       eval.Normal,
-									StateReason: eval.Error.String(),
-									Results: []Evaluation{
-										newEvaluation(t1, eval.Alerting),
-										newEvaluation(t2, eval.Error),
-									},
+									Labels:             labels["system + rule"],
+									State:              eval.Normal,
+									StateReason:        eval.Error.String(),
+									LatestResult:       newEvaluation(t2, eval.Error),
 									StartsAt:           t2,
 									EndsAt:             t2,
 									LastEvaluationTime: t2,
@@ -3838,12 +3409,9 @@ func TestProcessEvalResults_StateTransitions(t *testing.T) {
 								PreviousState:       eval.Normal,
 								PreviousStateReason: eval.Error.String(),
 								State: &State{
-									Labels: labels["system + rule"],
-									State:  eval.Pending,
-									Results: []Evaluation{
-										newEvaluation(t2, eval.Error),
-										newEvaluation(t3, eval.Alerting),
-									},
+									Labels:             labels["system + rule"],
+									State:              eval.Pending,
+									LatestResult:       newEvaluation(t3, eval.Alerting),
 									StartsAt:           t3,
 									EndsAt:             t3.Add(ResendDelay * 4),
 									LastEvaluationTime: t3,
@@ -3856,13 +3424,10 @@ func TestProcessEvalResults_StateTransitions(t *testing.T) {
 							{
 								PreviousState: eval.Pending,
 								State: &State{
-									Labels:      labels["system + rule"],
-									State:       eval.Pending,
-									StateReason: ngmodels.ConcatReasons(eval.Error.String(), ngmodels.StateReasonKeepLast),
-									Results: []Evaluation{
-										newEvaluation(t1, eval.Alerting),
-										newEvaluation(t2, eval.Error),
-									},
+									Labels:             labels["system + rule"],
+									State:              eval.Pending,
+									StateReason:        ngmodels.ConcatReasons(eval.Error.String(), ngmodels.StateReasonKeepLast),
+									LatestResult:       newEvaluation(t2, eval.Error),
 									StartsAt:           t1,
 									EndsAt:             t1.Add(ResendDelay * 4),
 									LastEvaluationTime: t2,
@@ -3874,12 +3439,9 @@ func TestProcessEvalResults_StateTransitions(t *testing.T) {
 								PreviousState:       eval.Pending,
 								PreviousStateReason: ngmodels.ConcatReasons(eval.Error.String(), ngmodels.StateReasonKeepLast),
 								State: &State{
-									Labels: labels["system + rule"],
-									State:  eval.Alerting,
-									Results: []Evaluation{
-										newEvaluation(t2, eval.Error),
-										newEvaluation(t3, eval.Alerting),
-									},
+									Labels:             labels["system + rule"],
+									State:              eval.Alerting,
+									LatestResult:       newEvaluation(t3, eval.Alerting),
 									StartsAt:           t3,
 									EndsAt:             t3.Add(ResendDelay * 4),
 									LastEvaluationTime: t3,
@@ -3905,12 +3467,9 @@ func TestProcessEvalResults_StateTransitions(t *testing.T) {
 							{
 								PreviousState: eval.Error,
 								State: &State{
-									Labels: labels["system + rule"],
-									State:  eval.Normal,
-									Results: []Evaluation{
-										newEvaluation(t1, eval.Error),
-										newEvaluation(t2, eval.Normal),
-									},
+									Labels:             labels["system + rule"],
+									State:              eval.Normal,
+									LatestResult:       newEvaluation(t2, eval.Normal),
 									StartsAt:           t2,
 									EndsAt:             t2,
 									LastEvaluationTime: t2,
@@ -3924,12 +3483,9 @@ func TestProcessEvalResults_StateTransitions(t *testing.T) {
 								PreviousState:       eval.Alerting,
 								PreviousStateReason: eval.Error.String(),
 								State: &State{
-									Labels: labels["system + rule"],
-									State:  eval.Normal,
-									Results: []Evaluation{
-										newEvaluation(t1, eval.Error),
-										newEvaluation(t2, eval.Normal),
-									},
+									Labels:             labels["system + rule"],
+									State:              eval.Normal,
+									LatestResult:       newEvaluation(t2, eval.Normal),
 									StartsAt:           t2,
 									EndsAt:             t2,
 									LastEvaluationTime: t2,
@@ -3944,12 +3500,9 @@ func TestProcessEvalResults_StateTransitions(t *testing.T) {
 								PreviousState:       eval.Normal,
 								PreviousStateReason: eval.Error.String(),
 								State: &State{
-									Labels: labels["system + rule"],
-									State:  eval.Normal,
-									Results: []Evaluation{
-										newEvaluation(t1, eval.Error),
-										newEvaluation(t2, eval.Normal),
-									},
+									Labels:             labels["system + rule"],
+									State:              eval.Normal,
+									LatestResult:       newEvaluation(t2, eval.Normal),
 									StartsAt:           t1,
 									EndsAt:             t1,
 									LastEvaluationTime: t2,
@@ -3963,12 +3516,9 @@ func TestProcessEvalResults_StateTransitions(t *testing.T) {
 								PreviousState:       eval.Normal,
 								PreviousStateReason: ngmodels.ConcatReasons(eval.Error.String(), ngmodels.StateReasonKeepLast),
 								State: &State{
-									Labels: labels["system + rule"],
-									State:  eval.Normal,
-									Results: []Evaluation{
-										newEvaluation(t1, eval.Error),
-										newEvaluation(t2, eval.Normal),
-									},
+									Labels:             labels["system + rule"],
+									State:              eval.Normal,
+									LatestResult:       newEvaluation(t2, eval.Normal),
 									StartsAt:           t1,
 									EndsAt:             t1,
 									LastEvaluationTime: t2,

--- a/pkg/services/ngalert/state/manager_test.go
+++ b/pkg/services/ngalert/state/manager_test.go
@@ -53,26 +53,22 @@ func TestWarmStateCache(t *testing.T) {
 
 	expectedEntries := []*state.State{
 		{
-			AlertRuleUID: rule.UID,
-			OrgID:        rule.OrgID,
-			Labels:       data.Labels{"test1": "testValue1"},
-			State:        eval.Normal,
-			Results: []state.Evaluation{
-				{EvaluationTime: evaluationTime, EvaluationState: eval.Normal},
-			},
+			AlertRuleUID:       rule.UID,
+			OrgID:              rule.OrgID,
+			Labels:             data.Labels{"test1": "testValue1"},
+			State:              eval.Normal,
+			LatestResult:       &state.Evaluation{EvaluationTime: evaluationTime, EvaluationState: eval.Normal},
 			StartsAt:           evaluationTime.Add(-1 * time.Minute),
 			EndsAt:             evaluationTime.Add(1 * time.Minute),
 			LastEvaluationTime: evaluationTime,
 			Annotations:        map[string]string{"testAnnoKey": "testAnnoValue"},
 			ResultFingerprint:  data.Fingerprint(math.MaxUint64),
 		}, {
-			AlertRuleUID: rule.UID,
-			OrgID:        rule.OrgID,
-			Labels:       data.Labels{"test2": "testValue2"},
-			State:        eval.Alerting,
-			Results: []state.Evaluation{
-				{EvaluationTime: evaluationTime, EvaluationState: eval.Alerting},
-			},
+			AlertRuleUID:       rule.UID,
+			OrgID:              rule.OrgID,
+			Labels:             data.Labels{"test2": "testValue2"},
+			State:              eval.Alerting,
+			LatestResult:       &state.Evaluation{EvaluationTime: evaluationTime, EvaluationState: eval.Alerting},
 			StartsAt:           evaluationTime.Add(-1 * time.Minute),
 			EndsAt:             evaluationTime.Add(1 * time.Minute),
 			LastEvaluationTime: evaluationTime,
@@ -80,13 +76,11 @@ func TestWarmStateCache(t *testing.T) {
 			ResultFingerprint:  data.Fingerprint(math.MaxUint64 - 1),
 		},
 		{
-			AlertRuleUID: rule.UID,
-			OrgID:        rule.OrgID,
-			Labels:       data.Labels{"test3": "testValue3"},
-			State:        eval.NoData,
-			Results: []state.Evaluation{
-				{EvaluationTime: evaluationTime, EvaluationState: eval.NoData},
-			},
+			AlertRuleUID:       rule.UID,
+			OrgID:              rule.OrgID,
+			Labels:             data.Labels{"test3": "testValue3"},
+			State:              eval.NoData,
+			LatestResult:       &state.Evaluation{EvaluationTime: evaluationTime, EvaluationState: eval.NoData},
 			StartsAt:           evaluationTime.Add(-1 * time.Minute),
 			EndsAt:             evaluationTime.Add(1 * time.Minute),
 			LastEvaluationTime: evaluationTime,
@@ -94,13 +88,11 @@ func TestWarmStateCache(t *testing.T) {
 			ResultFingerprint:  data.Fingerprint(0),
 		},
 		{
-			AlertRuleUID: rule.UID,
-			OrgID:        rule.OrgID,
-			Labels:       data.Labels{"test4": "testValue4"},
-			State:        eval.Error,
-			Results: []state.Evaluation{
-				{EvaluationTime: evaluationTime, EvaluationState: eval.Error},
-			},
+			AlertRuleUID:       rule.UID,
+			OrgID:              rule.OrgID,
+			Labels:             data.Labels{"test4": "testValue4"},
+			State:              eval.Error,
+			LatestResult:       &state.Evaluation{EvaluationTime: evaluationTime, EvaluationState: eval.Error},
 			StartsAt:           evaluationTime.Add(-1 * time.Minute),
 			EndsAt:             evaluationTime.Add(1 * time.Minute),
 			LastEvaluationTime: evaluationTime,
@@ -108,13 +100,11 @@ func TestWarmStateCache(t *testing.T) {
 			ResultFingerprint:  data.Fingerprint(1),
 		},
 		{
-			AlertRuleUID: rule.UID,
-			OrgID:        rule.OrgID,
-			Labels:       data.Labels{"test5": "testValue5"},
-			State:        eval.Pending,
-			Results: []state.Evaluation{
-				{EvaluationTime: evaluationTime, EvaluationState: eval.Pending},
-			},
+			AlertRuleUID:       rule.UID,
+			OrgID:              rule.OrgID,
+			Labels:             data.Labels{"test5": "testValue5"},
+			State:              eval.Pending,
+			LatestResult:       &state.Evaluation{EvaluationTime: evaluationTime, EvaluationState: eval.Pending},
 			StartsAt:           evaluationTime.Add(-1 * time.Minute),
 			EndsAt:             evaluationTime.Add(1 * time.Minute),
 			LastEvaluationTime: evaluationTime,
@@ -226,7 +216,7 @@ func TestWarmStateCache(t *testing.T) {
 			setCacheID(entry)
 			cacheEntry := st.Get(entry.OrgID, entry.AlertRuleUID, entry.CacheID)
 
-			if diff := cmp.Diff(entry, cacheEntry, cmpopts.IgnoreFields(state.State{}, "Results")); diff != "" {
+			if diff := cmp.Diff(entry, cacheEntry, cmpopts.IgnoreFields(state.State{}, "LatestResult")); diff != "" {
 				t.Errorf("Result mismatch (-want +got):\n%s", diff)
 				t.FailNow()
 			}
@@ -331,8 +321,8 @@ func TestProcessEvalResults(t *testing.T) {
 		ExecErrState:    models.ErrorErrState,
 	}
 
-	newEvaluation := func(evalTime time.Time, evalState eval.State) state.Evaluation {
-		return state.Evaluation{
+	newEvaluation := func(evalTime time.Time, evalState eval.State) *state.Evaluation {
+		return &state.Evaluation{
 			EvaluationTime:  evalTime,
 			EvaluationState: evalState,
 			Values:          make(map[string]*float64),
@@ -395,12 +385,10 @@ func TestProcessEvalResults(t *testing.T) {
 			},
 			expectedStates: []*state.State{
 				{
-					Labels:            labels["system + rule + labels1"],
-					ResultFingerprint: labels1.Fingerprint(),
-					State:             eval.Normal,
-					Results: []state.Evaluation{
-						newEvaluation(t1, eval.Normal),
-					},
+					Labels:             labels["system + rule + labels1"],
+					ResultFingerprint:  labels1.Fingerprint(),
+					State:              eval.Normal,
+					LatestResult:       newEvaluation(t1, eval.Normal),
 					StartsAt:           t1,
 					EndsAt:             t1,
 					LastEvaluationTime: t1,
@@ -419,23 +407,19 @@ func TestProcessEvalResults(t *testing.T) {
 			expectedAnnotations: 1,
 			expectedStates: []*state.State{
 				{
-					Labels:            labels["system + rule + labels1"],
-					ResultFingerprint: labels1.Fingerprint(),
-					State:             eval.Normal,
-					Results: []state.Evaluation{
-						newEvaluation(t1, eval.Normal),
-					},
+					Labels:             labels["system + rule + labels1"],
+					ResultFingerprint:  labels1.Fingerprint(),
+					State:              eval.Normal,
+					LatestResult:       newEvaluation(t1, eval.Normal),
 					StartsAt:           t1,
 					EndsAt:             t1,
 					LastEvaluationTime: t1,
 				},
 				{
-					Labels:            labels["system + rule + labels2"],
-					ResultFingerprint: labels2.Fingerprint(),
-					State:             eval.Alerting,
-					Results: []state.Evaluation{
-						newEvaluation(t1, eval.Alerting),
-					},
+					Labels:             labels["system + rule + labels2"],
+					ResultFingerprint:  labels2.Fingerprint(),
+					State:              eval.Alerting,
+					LatestResult:       newEvaluation(t1, eval.Alerting),
 					StartsAt:           t1,
 					EndsAt:             t1.Add(state.ResendDelay * 4),
 					LastEvaluationTime: t1,
@@ -455,13 +439,10 @@ func TestProcessEvalResults(t *testing.T) {
 			},
 			expectedStates: []*state.State{
 				{
-					Labels:            labels["system + rule + labels1"],
-					ResultFingerprint: labels1.Fingerprint(),
-					State:             eval.Normal,
-					Results: []state.Evaluation{
-						newEvaluation(t1, eval.Normal),
-						newEvaluation(tn(6), eval.Normal),
-					},
+					Labels:             labels["system + rule + labels1"],
+					ResultFingerprint:  labels1.Fingerprint(),
+					State:              eval.Normal,
+					LatestResult:       newEvaluation(tn(6), eval.Normal),
 					StartsAt:           t1,
 					EndsAt:             t1,
 					LastEvaluationTime: tn(6),
@@ -482,13 +463,10 @@ func TestProcessEvalResults(t *testing.T) {
 			expectedAnnotations: 1,
 			expectedStates: []*state.State{
 				{
-					Labels:            labels["system + rule + labels1"],
-					ResultFingerprint: labels1.Fingerprint(),
-					State:             eval.Alerting,
-					Results: []state.Evaluation{
-						newEvaluation(t1, eval.Normal),
-						newEvaluation(t2, eval.Alerting),
-					},
+					Labels:             labels["system + rule + labels1"],
+					ResultFingerprint:  labels1.Fingerprint(),
+					State:              eval.Alerting,
+					LatestResult:       newEvaluation(t2, eval.Alerting),
 					StartsAt:           t2,
 					EndsAt:             t2.Add(state.ResendDelay * 4),
 					LastEvaluationTime: t2,
@@ -515,13 +493,10 @@ func TestProcessEvalResults(t *testing.T) {
 			expectedAnnotations: 2,
 			expectedStates: []*state.State{
 				{
-					Labels:            labels["system + rule + labels1"],
-					ResultFingerprint: labels1.Fingerprint(),
-					State:             eval.Alerting,
-					Results: []state.Evaluation{
-						newEvaluation(t3, eval.Alerting),
-						newEvaluation(tn(4), eval.Alerting),
-					},
+					Labels:             labels["system + rule + labels1"],
+					ResultFingerprint:  labels1.Fingerprint(),
+					State:              eval.Alerting,
+					LatestResult:       newEvaluation(tn(4), eval.Alerting),
 					StartsAt:           tn(4),
 					EndsAt:             tn(4).Add(state.ResendDelay * 4),
 					LastEvaluationTime: tn(4),
@@ -551,13 +526,10 @@ func TestProcessEvalResults(t *testing.T) {
 			expectedAnnotations: 3, // Normal -> Pending, Pending -> NoData, NoData -> Pending
 			expectedStates: []*state.State{
 				{
-					Labels:            labels["system + rule + labels1"],
-					ResultFingerprint: labels1.Fingerprint(),
-					State:             eval.Pending,
-					Results: []state.Evaluation{
-						newEvaluation(tn(4), eval.Alerting),
-						newEvaluation(tn(5), eval.Alerting),
-					},
+					Labels:             labels["system + rule + labels1"],
+					ResultFingerprint:  labels1.Fingerprint(),
+					State:              eval.Pending,
+					LatestResult:       newEvaluation(tn(5), eval.Alerting),
 					StartsAt:           tn(4),
 					EndsAt:             tn(4).Add(state.ResendDelay * 4),
 					LastEvaluationTime: tn(5),
@@ -584,13 +556,10 @@ func TestProcessEvalResults(t *testing.T) {
 			expectedAnnotations: 3,
 			expectedStates: []*state.State{
 				{
-					Labels:            labels["system + rule + labels1"],
-					ResultFingerprint: labels1.Fingerprint(),
-					State:             eval.NoData,
-					Results: []state.Evaluation{
-						newEvaluation(t3, eval.Alerting),
-						newEvaluation(tn(4), eval.NoData),
-					},
+					Labels:             labels["system + rule + labels1"],
+					ResultFingerprint:  labels1.Fingerprint(),
+					State:              eval.NoData,
+					LatestResult:       newEvaluation(tn(4), eval.NoData),
 					StartsAt:           tn(4),
 					EndsAt:             tn(4).Add(state.ResendDelay * 4),
 					LastEvaluationTime: tn(4),
@@ -614,11 +583,8 @@ func TestProcessEvalResults(t *testing.T) {
 					Labels:            labels["system + rule + labels1"],
 					ResultFingerprint: labels1.Fingerprint(),
 
-					State: eval.Pending,
-					Results: []state.Evaluation{
-						newEvaluation(t1, eval.Normal),
-						newEvaluation(t2, eval.Alerting),
-					},
+					State:              eval.Pending,
+					LatestResult:       newEvaluation(t2, eval.Alerting),
 					StartsAt:           t2,
 					EndsAt:             t2.Add(state.ResendDelay * 4),
 					LastEvaluationTime: t2,
@@ -639,13 +605,10 @@ func TestProcessEvalResults(t *testing.T) {
 			expectedAnnotations: 1,
 			expectedStates: []*state.State{
 				{
-					Labels:            labels["system + rule + labels1"],
-					ResultFingerprint: labels1.Fingerprint(),
-					State:             eval.Pending,
-					Results: []state.Evaluation{
-						newEvaluation(t1, eval.Alerting),
-						newEvaluation(t2, eval.Alerting),
-					},
+					Labels:             labels["system + rule + labels1"],
+					ResultFingerprint:  labels1.Fingerprint(),
+					State:              eval.Pending,
+					LatestResult:       newEvaluation(t2, eval.Alerting),
 					StartsAt:           t1,
 					EndsAt:             t1.Add(state.ResendDelay * 4),
 					LastEvaluationTime: t2,
@@ -666,14 +629,11 @@ func TestProcessEvalResults(t *testing.T) {
 			expectedAnnotations: 1,
 			expectedStates: []*state.State{
 				{
-					Labels:            labels["system + rule + labels1"],
-					ResultFingerprint: labels1.Fingerprint(),
-					State:             eval.Pending,
-					StateReason:       eval.NoData.String(),
-					Results: []state.Evaluation{
-						newEvaluation(t1, eval.Normal),
-						newEvaluation(t2, eval.NoData),
-					},
+					Labels:             labels["system + rule + labels1"],
+					ResultFingerprint:  labels1.Fingerprint(),
+					State:              eval.Pending,
+					StateReason:        eval.NoData.String(),
+					LatestResult:       newEvaluation(t2, eval.NoData),
 					StartsAt:           t2,
 					EndsAt:             t2.Add(state.ResendDelay * 4),
 					LastEvaluationTime: t2,
@@ -703,15 +663,11 @@ func TestProcessEvalResults(t *testing.T) {
 			expectedAnnotations: 2,
 			expectedStates: []*state.State{
 				{
-					Labels:            labels["system + rule + labels1"],
-					ResultFingerprint: labels1.Fingerprint(),
-					State:             eval.Alerting,
-					StateReason:       eval.NoData.String(),
-					Results: []state.Evaluation{
-						newEvaluation(t3, eval.NoData),
-						newEvaluation(tn(4), eval.NoData),
-						newEvaluation(tn(5), eval.NoData),
-					},
+					Labels:             labels["system + rule + labels1"],
+					ResultFingerprint:  labels1.Fingerprint(),
+					State:              eval.Alerting,
+					StateReason:        eval.NoData.String(),
+					LatestResult:       newEvaluation(tn(5), eval.NoData),
 					StartsAt:           tn(5),
 					EndsAt:             tn(5).Add(state.ResendDelay * 4),
 					LastEvaluationTime: tn(5),
@@ -732,13 +688,10 @@ func TestProcessEvalResults(t *testing.T) {
 			expectedAnnotations: 1,
 			expectedStates: []*state.State{
 				{
-					Labels:            labels["system + rule + labels1"],
-					ResultFingerprint: labels1.Fingerprint(),
-					State:             eval.NoData,
-					Results: []state.Evaluation{
-						newEvaluation(t1, eval.Normal),
-						newEvaluation(t2, eval.NoData),
-					},
+					Labels:             labels["system + rule + labels1"],
+					ResultFingerprint:  labels1.Fingerprint(),
+					State:              eval.NoData,
+					LatestResult:       newEvaluation(t2, eval.NoData),
 					StartsAt:           t2,
 					EndsAt:             t2.Add(state.ResendDelay * 4),
 					LastEvaluationTime: t2,
@@ -759,23 +712,19 @@ func TestProcessEvalResults(t *testing.T) {
 			expectedAnnotations: 1,
 			expectedStates: []*state.State{
 				{
-					Labels:            labels["system + rule + labels1"],
-					ResultFingerprint: labels1.Fingerprint(),
-					State:             eval.Normal,
-					Results: []state.Evaluation{
-						newEvaluation(t1, eval.Normal),
-					},
+					Labels:             labels["system + rule + labels1"],
+					ResultFingerprint:  labels1.Fingerprint(),
+					State:              eval.Normal,
+					LatestResult:       newEvaluation(t1, eval.Normal),
 					StartsAt:           t1,
 					EndsAt:             t1,
 					LastEvaluationTime: t1,
 				},
 				{
-					Labels:            labels["system + rule"],
-					ResultFingerprint: data.Labels{}.Fingerprint(),
-					State:             eval.NoData,
-					Results: []state.Evaluation{
-						newEvaluation(t2, eval.NoData),
-					},
+					Labels:             labels["system + rule"],
+					ResultFingerprint:  data.Labels{}.Fingerprint(),
+					State:              eval.NoData,
+					LatestResult:       newEvaluation(t2, eval.NoData),
 					StartsAt:           t2,
 					EndsAt:             t2.Add(state.ResendDelay * 4),
 					LastEvaluationTime: t2,
@@ -797,34 +746,28 @@ func TestProcessEvalResults(t *testing.T) {
 			expectedAnnotations: 1,
 			expectedStates: []*state.State{
 				{
-					Labels:            labels["system + rule + labels1"],
-					ResultFingerprint: labels1.Fingerprint(),
-					State:             eval.Normal,
-					Results: []state.Evaluation{
-						newEvaluation(t1, eval.Normal),
-					},
+					Labels:             labels["system + rule + labels1"],
+					ResultFingerprint:  labels1.Fingerprint(),
+					State:              eval.Normal,
+					LatestResult:       newEvaluation(t1, eval.Normal),
 					StartsAt:           t1,
 					EndsAt:             t1,
 					LastEvaluationTime: t1,
 				},
 				{
-					Labels:            labels["system + rule + labels2"],
-					ResultFingerprint: labels2.Fingerprint(),
-					State:             eval.Normal,
-					Results: []state.Evaluation{
-						newEvaluation(t1, eval.Normal),
-					},
+					Labels:             labels["system + rule + labels2"],
+					ResultFingerprint:  labels2.Fingerprint(),
+					State:              eval.Normal,
+					LatestResult:       newEvaluation(t1, eval.Normal),
 					StartsAt:           t1,
 					EndsAt:             t1,
 					LastEvaluationTime: t1,
 				},
 				{
-					Labels:            labels["system + rule"],
-					ResultFingerprint: data.Labels{}.Fingerprint(),
-					State:             eval.NoData,
-					Results: []state.Evaluation{
-						newEvaluation(t2, eval.NoData),
-					},
+					Labels:             labels["system + rule"],
+					ResultFingerprint:  data.Labels{}.Fingerprint(),
+					State:              eval.NoData,
+					LatestResult:       newEvaluation(t2, eval.NoData),
 					StartsAt:           t2,
 					EndsAt:             t2.Add(state.ResendDelay * 4),
 					LastEvaluationTime: t2,
@@ -848,24 +791,19 @@ func TestProcessEvalResults(t *testing.T) {
 			expectedAnnotations: 1,
 			expectedStates: []*state.State{
 				{
-					Labels:            labels["system + rule + labels1"],
-					ResultFingerprint: labels1.Fingerprint(),
-					State:             eval.Normal,
-					Results: []state.Evaluation{
-						newEvaluation(t1, eval.Normal),
-						newEvaluation(t3, eval.Normal),
-					},
+					Labels:             labels["system + rule + labels1"],
+					ResultFingerprint:  labels1.Fingerprint(),
+					State:              eval.Normal,
+					LatestResult:       newEvaluation(t3, eval.Normal),
 					StartsAt:           t1,
 					EndsAt:             t1,
 					LastEvaluationTime: t3,
 				},
 				{
-					Labels:            labels["system + rule + no-data"],
-					ResultFingerprint: noDataLabels.Fingerprint(),
-					State:             eval.NoData,
-					Results: []state.Evaluation{
-						newEvaluation(t2, eval.NoData),
-					},
+					Labels:             labels["system + rule + no-data"],
+					ResultFingerprint:  noDataLabels.Fingerprint(),
+					State:              eval.NoData,
+					LatestResult:       newEvaluation(t2, eval.NoData),
 					StartsAt:           t2,
 					EndsAt:             t2.Add(state.ResendDelay * 4),
 					LastEvaluationTime: t2,
@@ -892,16 +830,11 @@ func TestProcessEvalResults(t *testing.T) {
 			expectedAnnotations: 1,
 			expectedStates: []*state.State{
 				{
-					Labels:            labels["system + rule + labels1"],
-					ResultFingerprint: labels1.Fingerprint(),
-					State:             eval.Alerting,
-					StateReason:       models.ConcatReasons(eval.NoData.String(), models.StateReasonKeepLast),
-					Results: []state.Evaluation{
-						newEvaluation(t1, eval.Normal),
-						newEvaluation(t2, eval.NoData),
-						newEvaluation(t3, eval.Alerting),
-						newEvaluation(tn(4), eval.NoData),
-					},
+					Labels:             labels["system + rule + labels1"],
+					ResultFingerprint:  labels1.Fingerprint(),
+					State:              eval.Alerting,
+					StateReason:        models.ConcatReasons(eval.NoData.String(), models.StateReasonKeepLast),
+					LatestResult:       newEvaluation(tn(4), eval.NoData),
 					StartsAt:           t3,
 					EndsAt:             tn(4).Add(state.ResendDelay * 4),
 					LastEvaluationTime: tn(4),
@@ -928,14 +861,11 @@ func TestProcessEvalResults(t *testing.T) {
 			expectedAnnotations: 2,
 			expectedStates: []*state.State{
 				{
-					Labels:            labels["system + rule + labels1"],
-					ResultFingerprint: labels1.Fingerprint(),
-					State:             eval.Alerting,
-					StateReason:       models.ConcatReasons(eval.NoData.String(), models.StateReasonKeepLast),
-					Results: []state.Evaluation{
-						newEvaluation(t3, eval.NoData),
-						newEvaluation(tn(4), eval.NoData),
-					},
+					Labels:             labels["system + rule + labels1"],
+					ResultFingerprint:  labels1.Fingerprint(),
+					State:              eval.Alerting,
+					StateReason:        models.ConcatReasons(eval.NoData.String(), models.StateReasonKeepLast),
+					LatestResult:       newEvaluation(tn(4), eval.NoData),
 					StartsAt:           tn(4),
 					EndsAt:             tn(4).Add(state.ResendDelay * 4),
 					LastEvaluationTime: tn(4),
@@ -956,14 +886,11 @@ func TestProcessEvalResults(t *testing.T) {
 			expectedAnnotations: 0,
 			expectedStates: []*state.State{
 				{
-					Labels:            labels["system + rule + labels1"],
-					ResultFingerprint: labels1.Fingerprint(),
-					State:             eval.Normal,
-					StateReason:       eval.NoData.String(),
-					Results: []state.Evaluation{
-						newEvaluation(t1, eval.Normal),
-						newEvaluation(t2, eval.NoData),
-					},
+					Labels:             labels["system + rule + labels1"],
+					ResultFingerprint:  labels1.Fingerprint(),
+					State:              eval.Normal,
+					StateReason:        eval.NoData.String(),
+					LatestResult:       newEvaluation(t2, eval.NoData),
 					StartsAt:           t1,
 					EndsAt:             t1,
 					LastEvaluationTime: t2,
@@ -984,15 +911,12 @@ func TestProcessEvalResults(t *testing.T) {
 			expectedAnnotations: 1,
 			expectedStates: []*state.State{
 				{
-					Labels:            labels["system + rule + labels1"],
-					ResultFingerprint: labels1.Fingerprint(),
-					State:             eval.Pending,
-					StateReason:       eval.Error.String(),
-					Error:             errors.New("with_state_error"),
-					Results: []state.Evaluation{
-						newEvaluation(t1, eval.Normal),
-						newEvaluation(t2, eval.Error),
-					},
+					Labels:             labels["system + rule + labels1"],
+					ResultFingerprint:  labels1.Fingerprint(),
+					State:              eval.Pending,
+					StateReason:        eval.Error.String(),
+					Error:              errors.New("with_state_error"),
+					LatestResult:       newEvaluation(t2, eval.Error),
 					StartsAt:           t2,
 					EndsAt:             t2.Add(state.ResendDelay * 4),
 					LastEvaluationTime: t2,
@@ -1022,16 +946,12 @@ func TestProcessEvalResults(t *testing.T) {
 			expectedAnnotations: 2,
 			expectedStates: []*state.State{
 				{
-					Labels:            labels["system + rule + labels1"],
-					ResultFingerprint: labels1.Fingerprint(),
-					State:             eval.Alerting,
-					StateReason:       eval.Error.String(),
-					Error:             errors.New("with_state_error"),
-					Results: []state.Evaluation{
-						newEvaluation(t3, eval.Error),
-						newEvaluation(tn(4), eval.Error),
-						newEvaluation(tn(5), eval.Error),
-					},
+					Labels:             labels["system + rule + labels1"],
+					ResultFingerprint:  labels1.Fingerprint(),
+					State:              eval.Alerting,
+					StateReason:        eval.Error.String(),
+					Error:              errors.New("with_state_error"),
+					LatestResult:       newEvaluation(tn(5), eval.Error),
 					StartsAt:           tn(5),
 					EndsAt:             tn(5).Add(state.ResendDelay * 4),
 					LastEvaluationTime: tn(5),
@@ -1064,13 +984,10 @@ func TestProcessEvalResults(t *testing.T) {
 						"datasource_uid": "datasource_uid_1",
 						"ref_id":         "A",
 					}),
-					ResultFingerprint: labels1.Fingerprint(),
-					State:             eval.Error,
-					Error:             expr.MakeQueryError("A", "datasource_uid_1", errors.New("this is an error")),
-					Results: []state.Evaluation{
-						newEvaluation(t1, eval.Normal),
-						newEvaluation(t2, eval.Error),
-					},
+					ResultFingerprint:  labels1.Fingerprint(),
+					State:              eval.Error,
+					Error:              expr.MakeQueryError("A", "datasource_uid_1", errors.New("this is an error")),
+					LatestResult:       newEvaluation(t2, eval.Error),
 					StartsAt:           t2,
 					EndsAt:             t2.Add(state.ResendDelay * 4),
 					LastEvaluationTime: t2,
@@ -1099,16 +1016,11 @@ func TestProcessEvalResults(t *testing.T) {
 			expectedAnnotations: 1,
 			expectedStates: []*state.State{
 				{
-					Labels:            labels["system + rule + labels1"],
-					ResultFingerprint: labels1.Fingerprint(),
-					State:             eval.Alerting,
-					StateReason:       models.ConcatReasons(eval.Error.String(), models.StateReasonKeepLast),
-					Results: []state.Evaluation{
-						newEvaluation(t1, eval.Normal),
-						newEvaluation(t2, eval.Error),
-						newEvaluation(t3, eval.Alerting),
-						newEvaluation(tn(4), eval.Error),
-					},
+					Labels:             labels["system + rule + labels1"],
+					ResultFingerprint:  labels1.Fingerprint(),
+					State:              eval.Alerting,
+					StateReason:        models.ConcatReasons(eval.Error.String(), models.StateReasonKeepLast),
+					LatestResult:       newEvaluation(tn(4), eval.Error),
 					StartsAt:           t3,
 					EndsAt:             tn(4).Add(state.ResendDelay * 4),
 					LastEvaluationTime: tn(4),
@@ -1135,14 +1047,11 @@ func TestProcessEvalResults(t *testing.T) {
 			expectedAnnotations: 2,
 			expectedStates: []*state.State{
 				{
-					Labels:            labels["system + rule + labels1"],
-					ResultFingerprint: labels1.Fingerprint(),
-					State:             eval.Alerting,
-					StateReason:       models.ConcatReasons(eval.Error.String(), models.StateReasonKeepLast),
-					Results: []state.Evaluation{
-						newEvaluation(t3, eval.Error),
-						newEvaluation(tn(4), eval.Error),
-					},
+					Labels:             labels["system + rule + labels1"],
+					ResultFingerprint:  labels1.Fingerprint(),
+					State:              eval.Alerting,
+					StateReason:        models.ConcatReasons(eval.Error.String(), models.StateReasonKeepLast),
+					LatestResult:       newEvaluation(tn(4), eval.Error),
 					StartsAt:           tn(4),
 					EndsAt:             tn(4).Add(state.ResendDelay * 4),
 					LastEvaluationTime: tn(4),
@@ -1163,14 +1072,11 @@ func TestProcessEvalResults(t *testing.T) {
 			expectedAnnotations: 1,
 			expectedStates: []*state.State{
 				{
-					Labels:            labels["system + rule + labels1"],
-					ResultFingerprint: labels1.Fingerprint(),
-					State:             eval.Normal,
-					StateReason:       eval.Error.String(),
-					Results: []state.Evaluation{
-						newEvaluation(t1, eval.Normal),
-						newEvaluation(t2, eval.Error),
-					},
+					Labels:             labels["system + rule + labels1"],
+					ResultFingerprint:  labels1.Fingerprint(),
+					State:              eval.Normal,
+					StateReason:        eval.Error.String(),
+					LatestResult:       newEvaluation(t2, eval.Error),
 					StartsAt:           t1,
 					EndsAt:             t1,
 					LastEvaluationTime: t2,
@@ -1191,14 +1097,11 @@ func TestProcessEvalResults(t *testing.T) {
 			expectedAnnotations: 2,
 			expectedStates: []*state.State{
 				{
-					Labels:            labels["system + rule + labels1"],
-					ResultFingerprint: labels1.Fingerprint(),
-					State:             eval.Normal,
-					StateReason:       eval.Error.String(),
-					Results: []state.Evaluation{
-						newEvaluation(t1, eval.Alerting),
-						newEvaluation(t2, eval.Error),
-					},
+					Labels:             labels["system + rule + labels1"],
+					ResultFingerprint:  labels1.Fingerprint(),
+					State:              eval.Normal,
+					StateReason:        eval.Error.String(),
+					LatestResult:       newEvaluation(t2, eval.Error),
 					StartsAt:           t2,
 					EndsAt:             t2,
 					LastEvaluationTime: t2,
@@ -1231,14 +1134,11 @@ func TestProcessEvalResults(t *testing.T) {
 			expectedAnnotations: 3,
 			expectedStates: []*state.State{
 				{
-					Labels:            labels["system + rule + labels1"],
-					ResultFingerprint: labels1.Fingerprint(),
-					State:             eval.Error,
-					Error:             fmt.Errorf("with_state_error"),
-					Results: []state.Evaluation{
-						newEvaluation(tn(5), eval.Error),
-						newEvaluation(tn(6), eval.Error),
-					},
+					Labels:             labels["system + rule + labels1"],
+					ResultFingerprint:  labels1.Fingerprint(),
+					State:              eval.Error,
+					Error:              fmt.Errorf("with_state_error"),
+					LatestResult:       newEvaluation(tn(6), eval.Error),
 					StartsAt:           tn(4),
 					EndsAt:             tn(6).Add(state.ResendDelay * 4),
 					LastEvaluationTime: tn(6),
@@ -1265,14 +1165,10 @@ func TestProcessEvalResults(t *testing.T) {
 			expectedAnnotations: 3,
 			expectedStates: []*state.State{
 				{
-					Labels:            labels["system + rule + labels1"],
-					ResultFingerprint: labels1.Fingerprint(),
-					State:             eval.Pending,
-					Results: []state.Evaluation{
-						newEvaluation(tn(4), eval.Alerting),
-						newEvaluation(tn(5), eval.Error),
-						newEvaluation(tn(8), eval.Alerting),
-					},
+					Labels:             labels["system + rule + labels1"],
+					ResultFingerprint:  labels1.Fingerprint(),
+					State:              eval.Pending,
+					LatestResult:       newEvaluation(tn(8), eval.Alerting),
 					StartsAt:           tn(8),
 					EndsAt:             tn(8).Add(state.ResendDelay * 4),
 					LastEvaluationTime: tn(8),
@@ -1299,14 +1195,10 @@ func TestProcessEvalResults(t *testing.T) {
 			expectedAnnotations: 3,
 			expectedStates: []*state.State{
 				{
-					Labels:            labels["system + rule + labels1"],
-					ResultFingerprint: labels1.Fingerprint(),
-					State:             eval.NoData,
-					Results: []state.Evaluation{
-						newEvaluation(tn(4), eval.Alerting),
-						newEvaluation(tn(5), eval.Error),
-						newEvaluation(tn(6), eval.NoData),
-					},
+					Labels:             labels["system + rule + labels1"],
+					ResultFingerprint:  labels1.Fingerprint(),
+					State:              eval.NoData,
+					LatestResult:       newEvaluation(tn(6), eval.NoData),
 					StartsAt:           tn(6),
 					EndsAt:             tn(6).Add(state.ResendDelay * 4),
 					LastEvaluationTime: tn(6),
@@ -1337,10 +1229,8 @@ func TestProcessEvalResults(t *testing.T) {
 						"label":     "test",
 						"job":       "prod/grafana",
 					}),
-					State: eval.Normal,
-					Results: []state.Evaluation{
-						newEvaluation(t1, eval.Normal),
-					},
+					State:              eval.Normal,
+					LatestResult:       newEvaluation(t1, eval.Normal),
 					StartsAt:           t1,
 					EndsAt:             t1,
 					LastEvaluationTime: t1,
@@ -1371,14 +1261,10 @@ func TestProcessEvalResults(t *testing.T) {
 			},
 			expectedStates: []*state.State{
 				{
-					Labels:            labels["system + rule"],
-					ResultFingerprint: data.Labels{}.Fingerprint(),
-					State:             eval.Alerting,
-					Results: []state.Evaluation{
-						newEvaluation(t1, eval.Alerting),
-						newEvaluation(t2, eval.Error),
-						newEvaluation(t3, eval.Alerting),
-					},
+					Labels:             labels["system + rule"],
+					ResultFingerprint:  data.Labels{}.Fingerprint(),
+					State:              eval.Alerting,
+					LatestResult:       newEvaluation(t3, eval.Alerting),
 					StartsAt:           t3,
 					EndsAt:             t3.Add(state.ResendDelay * 4),
 					LastEvaluationTime: t3,
@@ -1627,13 +1513,11 @@ func TestStaleResultsHandler(t *testing.T) {
 					},
 					Values: make(map[string]float64),
 					State:  eval.Normal,
-					Results: []state.Evaluation{
-						{
-							EvaluationTime:  evaluationTime,
-							EvaluationState: eval.Normal,
-							Values:          make(map[string]*float64),
-							Condition:       "A",
-						},
+					LatestResult: &state.Evaluation{
+						EvaluationTime:  evaluationTime,
+						EvaluationState: eval.Normal,
+						Values:          make(map[string]*float64),
+						Condition:       "A",
 					},
 					StartsAt:           evaluationTime,
 					EndsAt:             evaluationTime,

--- a/pkg/services/ngalert/state/state.go
+++ b/pkg/services/ngalert/state/state.go
@@ -38,8 +38,8 @@ type State struct {
 	// ResultFingerprint is a hash of labels of the result before it is processed by
 	ResultFingerprint data.Fingerprint
 
-	// Results contains the result of the current and previous evaluations.
-	Results []Evaluation
+	// LatestResult contains the result of the most recent evaluation, if available.
+	LatestResult *Evaluation
 
 	// Error is set if the current evaluation returned an error. If error is non-nil results
 	// can still contain the results of previous evaluations.
@@ -427,20 +427,6 @@ func (a *State) Equals(b *State) bool {
 		data.Labels(a.Annotations).String() == data.Labels(b.Annotations).String()
 }
 
-func (a *State) TrimResults(alertRule *models.AlertRule) {
-	numBuckets := int64(alertRule.For.Seconds()) / alertRule.IntervalSeconds
-	if numBuckets == 0 {
-		numBuckets = 10 // keep at least 10 evaluations in the event For is set to 0
-	}
-
-	if len(a.Results) < int(numBuckets) {
-		return
-	}
-	newResults := make([]Evaluation, numBuckets)
-	copy(newResults, a.Results[len(a.Results)-int(numBuckets):])
-	a.Results = newResults
-}
-
 func nextEndsTime(interval int64, evaluatedAt time.Time) time.Time {
 	ends := ResendDelay
 	intv := time.Second * time.Duration(interval)
@@ -464,11 +450,11 @@ func (a *State) GetLabels(opts ...models.LabelOption) map[string]string {
 }
 
 func (a *State) GetLastEvaluationValuesForCondition() map[string]float64 {
-	if len(a.Results) <= 0 {
+	if a.LatestResult == nil {
 		return nil
 	}
 
-	lastResult := a.Results[len(a.Results)-1]
+	lastResult := *a.LatestResult
 	r := make(map[string]float64, len(lastResult.Values))
 
 	for refID, value := range lastResult.Values {

--- a/pkg/services/ngalert/state/state_test.go
+++ b/pkg/services/ngalert/state/state_test.go
@@ -475,9 +475,9 @@ func TestNeedsSending(t *testing.T) {
 }
 
 func TestGetLastEvaluationValuesForCondition(t *testing.T) {
-	genState := func(results []Evaluation) *State {
+	genState := func(latestResult *Evaluation) *State {
 		return &State{
-			Results: results,
+			LatestResult: latestResult,
 		}
 	}
 
@@ -487,57 +487,43 @@ func TestGetLastEvaluationValuesForCondition(t *testing.T) {
 	})
 	t.Run("should return value of the condition of the last result", func(t *testing.T) {
 		expected := rand.Float64()
-		evals := []Evaluation{
-			{
-				EvaluationTime:  time.Time{},
-				EvaluationState: 0,
-				Values: map[string]*float64{
-					"A": util.Pointer(rand.Float64()),
-				},
-				Condition: "A",
+		eval := &Evaluation{
+			EvaluationTime:  time.Time{},
+			EvaluationState: 0,
+			Values: map[string]*float64{
+				"B": util.Pointer(rand.Float64()),
+				"A": util.Pointer(expected),
 			},
-			{
-				EvaluationTime:  time.Time{},
-				EvaluationState: 0,
-				Values: map[string]*float64{
-					"B": util.Pointer(rand.Float64()),
-					"A": util.Pointer(expected),
-				},
-				Condition: "A",
-			},
+			Condition: "A",
 		}
-		result := genState(evals).GetLastEvaluationValuesForCondition()
+		result := genState(eval).GetLastEvaluationValuesForCondition()
 		require.Len(t, result, 1)
 		require.Contains(t, result, "A")
 		require.Equal(t, result["A"], expected)
 	})
 	t.Run("should return empty map if there is no value for condition", func(t *testing.T) {
-		evals := []Evaluation{
-			{
-				EvaluationTime:  time.Time{},
-				EvaluationState: 0,
-				Values: map[string]*float64{
-					"C": util.Pointer(rand.Float64()),
-				},
-				Condition: "A",
+		eval := &Evaluation{
+			EvaluationTime:  time.Time{},
+			EvaluationState: 0,
+			Values: map[string]*float64{
+				"C": util.Pointer(rand.Float64()),
 			},
+			Condition: "A",
 		}
-		result := genState(evals).GetLastEvaluationValuesForCondition()
+		result := genState(eval).GetLastEvaluationValuesForCondition()
 		require.NotNil(t, result)
 		require.Len(t, result, 0)
 	})
 	t.Run("should use NaN if value is not defined", func(t *testing.T) {
-		evals := []Evaluation{
-			{
-				EvaluationTime:  time.Time{},
-				EvaluationState: 0,
-				Values: map[string]*float64{
-					"A": nil,
-				},
-				Condition: "A",
+		eval := &Evaluation{
+			EvaluationTime:  time.Time{},
+			EvaluationState: 0,
+			Values: map[string]*float64{
+				"A": nil,
 			},
+			Condition: "A",
 		}
-		result := genState(evals).GetLastEvaluationValuesForCondition()
+		result := genState(eval).GetLastEvaluationValuesForCondition()
 		require.NotNil(t, result)
 		require.Len(t, result, 1)
 		require.Contains(t, result, "A")


### PR DESCRIPTION
**What is this feature?**

States in the state manager store the results of several prior evaluations. This includes values, which is the measured dataframe results for that series: https://github.com/grafana/grafana/blob/6e4d35e1eedffacaa5de7f59d9ca6b3b3d2d4d58/pkg/services/ngalert/state/manager.go#L361-L368

But, the only code that ever reads this field, only looks at the most recent 1 evaluation. Any values in that slice beyond the last one are stored for no reason: https://github.com/grafana/grafana/blob/6e4d35e1eedffacaa5de7f59d9ca6b3b3d2d4d58/pkg/services/ngalert/state/state.go#L467-L471

The state manager is storing every measured value for every series in every query, including intermediate dataframes. Basically, all queried dataframes for all rules, for multiplpe evaluations in the past, needlessly.

The length of the history is based on `For` - and can be raised arbitrarily high with a long `for`. Even for rules with a `for` of 0, the length is hardcoded to 10 evaluations. For a typical rule with 3 query nodes, this results in 30 frames worth of series kept in memory (spread across states) when we only use 3 of them.

By creating a long `For` with many dimensions, you can write a rule that eventually consumes arbitrary memory and OOMs grafana provided the process does not restart.

This is a truly incredible amount of data in some cases on instances even with simpler alerting usage it can quickly dominate the entire memory space of unified alerting.

**Why do we need this feature?**

Likely, most memory consumption of unified alerting across the board is occupied by this throwaway data.

This PR simply stores the most recent single evaluation, rather than a running slice of them. The result is transparent to users, but we stop hanging on to data that we won't use.

**Which issue(s) does this PR fix?**:
n/a

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle.
- [x] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
