### PR TITLE
[POC] Alerting: Update state manager to resolve series that is missing in result

### DIFF
--- a/pkg/services/ngalert/models/alert_rule.go
+++ b/pkg/services/ngalert/models/alert_rule.go
@@ -255,6 +255,17 @@ type AlertRule struct {
 	NotificationSettings []NotificationSettings `xorm:"notification_settings"` // we use slice to workaround xorm mapping that does not serialize a struct to JSON unless it's a slice
 }
 
+func (alertRule *AlertRule) IsNoNormalStateRule() (bool, error) {
+	if len(alertRule.Data) != 1 {
+		return false, nil
+	}
+	isDs, dsType, err := alertRule.Data[0].IsDatasourceQuery()
+	if err != nil {
+		return false, err
+	}
+	return isDs && dsType == "prometheus", nil
+}
+
 // AlertRuleWithOptionals This is to avoid having to pass in additional arguments deep in the call stack. Alert rule
 // object is created in an early validation step without knowledge about current alert rule fields or if they need to be
 // overridden. This is done in a later step and, in that step, we did not have knowledge about if a field was optional

--- a/pkg/services/ngalert/models/alert_rule.go
+++ b/pkg/services/ngalert/models/alert_rule.go
@@ -259,11 +259,18 @@ func (alertRule *AlertRule) IsNoNormalStateRule() (bool, error) {
 	if len(alertRule.Data) != 1 {
 		return false, nil
 	}
-	isDs, dsType, err := alertRule.Data[0].IsDatasourceQuery()
+	isDs, err := alertRule.Data[0].IsDataSource()
 	if err != nil {
 		return false, err
 	}
-	return isDs && dsType == "prometheus", nil
+	if !isDs {
+		return false, nil
+	}
+	dsType, err := alertRule.Data[0].GetDatasourceType()
+	if err != nil {
+		return false, err
+	}
+	return dsType == "prometheus", nil
 }
 
 // AlertRuleWithOptionals This is to avoid having to pass in additional arguments deep in the call stack. Alert rule


### PR DESCRIPTION

<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**
This PR changes the alerting state manager to resolve the Alerting state if it's missing in the evaluation results of a rule that meets certain criteria: the rule has a single query element and it's a Prometheus query.

**Why do we need this feature?**
Prometheus query language supports filter operators. For, example
```
grafana_slo_sli_5m{} > 10
```
will return only metrics (aka dimensions) that have points with values greater than 10. This is a common situation in Prometheus alert rules. All results that the query returns are above the threshold and therefore should have either a pending or alerting state. When the result does not contain some metric that was seen during the previous evaluation, that is treated as a normal (resolved) state. 
For example, 
- at time T1 the query returns 2 results\dimensions `{ server=A } 1 ` and `{ server=B} 1`.  That result is converted to 2 Alerting states, and the notification service gets notified.
- at time T2 the query returns only 1 result `{server=A} 1`. This means that the first metric is still alerting but the second gets resolved. The result is converted to `{server A} Alerting` and `{server B} Normal`. The notification service gets updated about __both__  states. 

Currently, In Grafana Managed Alerts, this works a bit differently: metrics that are missing at an evaluation cycle are ignored until they expire (marked as stale) https://github.com/grafana/grafana/blob/27884dd36271c3218ae4950ceec3c85c9ef32ec0/pkg/services/ngalert/state/manager.go#L551-L553.
The behavior in the example above will be the following:
- T1 -  `{ server=A } Alerting` and `{ server=B} Alerting`
- T2 -  `{ server=A } Alerting` and `{ server=B} Alerting`
- T3 -  `{ server=A } Alerting` and `{ server=B} Alerting` (assuming the result is still only  `{server=A} 1`)
- T4 -  `{ server=A } Alerting` and `{ server=B} Normal (Stale)` 

Therefore, Grafana managed alerts to delay the resolution of the missing metric for 3 evaluation intervals. This can cause confusion, and also makes it harder to migrate a Prometheus alert rule to a managed alert rule (It is possible but requires rewriting a query to use server-side expressions instead of filtering on Prometheus side).

**Who is this feature for?**
SLO plugin and potentially users who want to migrate to Grafana managed alerts

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
