### PR TITLE
Canvas: Fix bug for connection first vertex

### DIFF
--- a/public/app/plugins/panel/canvas/components/connections/ConnectionSVG.tsx
+++ b/public/app/plugins/panel/canvas/components/connections/ConnectionSVG.tsx
@@ -217,14 +217,15 @@ export const ConnectionSVG = ({
                   }
                 } else {
                   // Last vertex
-                  let previousVertex = { x: 0, y: 0 };
                   if (index > 0) {
                     // Not also the first vertex
-                    previousVertex = vertices[index - 1];
+                    const previousVertex = vertices[index - 1];
+                    const Xp = previousVertex.x * xDist + xStart;
+                    const Yp = previousVertex.y * yDist + yStart;
+                    angle1 = calculateAngle(Xp, Yp, X, Y);
+                  } else {
+                    angle1 = calculateAngle(x1, y1, X, Y);
                   }
-                  const Xp = previousVertex.x * xDist + xStart;
-                  const Yp = previousVertex.y * yDist + yStart;
-                  angle1 = calculateAngle(Xp, Yp, X, Y);
                   angle2 = calculateAngle(X, Y, x2, y2);
                 }
 


### PR DESCRIPTION
While cleaning up / documenting connection math, stumbled upon a bug that occurs when a connection has a single vertex and a curve radius. This was occurring because the angle calculation for this scenario was based upon the old coordinate system where the first point is always 0, 0.

Before:
![May-08-2024 17-08-50](https://github.com/grafana/grafana/assets/60050885/e130fb40-4ef9-4b7d-bdf2-1a9288609e14)

After:
![May-08-2024 17-06-33](https://github.com/grafana/grafana/assets/60050885/bd1f9869-4f76-48b6-8017-1350ccc5813b)
