### PR TITLE
SAML: add reference to azure ad limitations

### DIFF
--- a/docs/sources/setup-grafana/configure-security/configure-authentication/saml/index.md
+++ b/docs/sources/setup-grafana/configure-security/configure-authentication/saml/index.md
@@ -61,7 +61,7 @@ By default, SP-initiated requests are enabled. For instructions on how to enable
 {{% admonition type="warning" %}}
 It is possible to setup Grafana with SAML authentication using Azure AD. However, Azure AD limits the number of groups that can be sent in the SAML assertion to 150. If you have more than 150 groups, Azure AD provides a link to retrieve the groups that only works for OIDC/OAuth workflows. At the moment it is not possible to use this link with SAML authentication in Grafana.
 
-It is preferable to take this into consideration when setting up SAML authentication with Azure AD. We encourage the use of [Azure AD OAuth integration]({{< relref "../azuread/" >}}) instead of SAML if you have more than 150 groups.
+It is preferable to take this into consideration when setting up SAML authentication with Azure AD. We encourage the use of [Azure AD OAuth integration]({{< relref "../azuread" >}}) instead of SAML if you have more than 150 groups.
 
 - [Azure AD SAML limitations](https://docs.microsoft.com/en-us/azure/active-directory/develop/active-directory-token-limits)
 

--- a/docs/sources/setup-grafana/configure-security/configure-authentication/saml/index.md
+++ b/docs/sources/setup-grafana/configure-security/configure-authentication/saml/index.md
@@ -58,6 +58,15 @@ In terms of initiation, Grafana supports:
 
 By default, SP-initiated requests are enabled. For instructions on how to enable IdP-initiated logins, see [IdP-initiated Single Sign-On (SSO)]({{< relref "#idp-initiated-single-sign-on-sso" >}}).
 
+{{% admonition type="warning" %}}
+It is possible to setup Grafana with SAML authentication using Azure AD. However, Azure AD limits the number of groups that can be sent in the SAML assertion to 150. If you have more than 150 groups, Azure AD provides a link to retrieve the groups that only works for OIDC/OAuth workflows. At the moment it is not possible to use this link with SAML authentication in Grafana.
+
+It is preferable to take this into consideration when setting up SAML authentication with Azure AD. We encourage the use of [Azure AD OAuth integration]({{< relref "../azuread/" >}}) instead of SAML if you have more than 150 groups.
+
+- [Azure AD SAML limitations](https://docs.microsoft.com/en-us/azure/active-directory/develop/active-directory-token-limits)
+
+{{% /admonition %}}
+
 ### Edit SAML options in the Grafana config file
 
 1. In the `[auth.saml]` section in the Grafana configuration file, set [`enabled`]({{< relref "../../../configure-grafana/enterprise-configuration#enabled" >}}) to `true`.

--- a/docs/sources/setup-grafana/configure-security/configure-authentication/saml/index.md
+++ b/docs/sources/setup-grafana/configure-security/configure-authentication/saml/index.md
@@ -63,7 +63,7 @@ It is possible to setup Grafana with SAML authentication using Azure AD. However
 
 It is preferable to take this into consideration when setting up SAML authentication with Azure AD. We encourage the use of [Azure AD OAuth integration]({{< relref "../azuread" >}}) instead of SAML if you have more than 150 groups.
 
-- [Azure AD SAML limitations](https://docs.microsoft.com/en-us/azure/active-directory/develop/active-directory-token-limits)
+- [Azure AD SAML limitations](https://learn.microsoft.com/en-us/entra/identity-platform/id-token-claims-reference#groups-overage-claim)
 
 {{% /admonition %}}
 

--- a/pkg/login/social/connectors/azuread_oauth.go
+++ b/pkg/login/social/connectors/azuread_oauth.go
@@ -410,7 +410,7 @@ func (s *SocialAzureAD) groupsGraphAPIURL(claims *azureClaims, token *oauth2.Tok
 
 	// If no endpoint was specified or if the endpoints provided in _claim_source is pointing to the deprecated
 	// "graph.windows.net" api, use an handcrafted url to graph.microsoft.com
-	// See https://docs.microsoft.com/en-us/graph/migrate-azure-ad-graph-overview
+	// See https://learn.microsoft.com/en-us/entra/identity-platform/id-token-claims-reference#groups-overage-claim
 	if endpoint == "" || strings.Contains(endpoint, "graph.windows.net") {
 		tenantID := claims.TenantID
 		// If tenantID wasn't found in the id_token, parse access token


### PR DESCRIPTION
**What is this feature?**

Adds a warning about using the SAML protocol with Azure AD.

**Why do we need this feature?**

There are limitations about using the SAML protocol with Azure AD

**Who is this feature for?**

IAM and docs teams

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
