### PR TITLE
Revert "MixedDataSource: Support multi value data source variable that issues a query to each data source"

### DIFF
--- a/public/app/plugins/datasource/mixed/MixedDataSource.test.ts
+++ b/public/app/plugins/datasource/mixed/MixedDataSource.test.ts
@@ -2,11 +2,7 @@ import { lastValueFrom } from 'rxjs';
 import { getQueryOptions } from 'test/helpers/getQueryOptions';
 import { DatasourceSrvMock, MockObservableDataSourceApi } from 'test/mocks/datasource_srv';
 
-import { DataQueryRequest, DataSourceInstanceSettings, DataSourceRef, LoadingState } from '@grafana/data';
-import { DataSourceSrv, setDataSourceSrv, setTemplateSrv } from '@grafana/runtime';
-import { CustomVariable, SceneFlexLayout, SceneVariableSet } from '@grafana/scenes';
-
-import { TemplateSrv } from '../../../features/templating/template_srv';
+import { DataQueryRequest, DataSourceInstanceSettings, LoadingState } from '@grafana/data';
 
 import { MIXED_DATASOURCE_NAME } from './MixedDataSource';
 import { MixedDatasource } from './module';
@@ -25,19 +21,13 @@ const datasourceSrv = new DatasourceSrvMock(defaultDS, {
   ]),
 });
 
-describe('MixedDatasource', () => {
-  beforeEach(() => {
-    jest.clearAllMocks();
-    setDataSourceSrv({
-      ...datasourceSrv,
-      get: (uid: DataSourceRef) => datasourceSrv.get(uid),
-      getInstanceSettings: jest.fn().mockReturnValue({ meta: {} }),
-      getList: jest.fn(),
-      reload: jest.fn(),
-    });
-    setTemplateSrv(new TemplateSrv());
-  });
+const getDataSourceSrvMock = jest.fn().mockReturnValue(datasourceSrv);
+jest.mock('@grafana/runtime', () => ({
+  ...jest.requireActual('@grafana/runtime'),
+  getDataSourceSrv: () => getDataSourceSrvMock(),
+}));
 
+describe('MixedDatasource', () => {
   describe('with no errors', () => {
     it('direct query should return results', async () => {
       const ds = new MixedDatasource({} as DataSourceInstanceSettings);
@@ -89,67 +79,6 @@ describe('MixedDatasource', () => {
         expect(results[5].data).toEqual([]);
         expect(results[5].state).toEqual(LoadingState.Error);
         expect(results[5].error).toEqual({ message: 'DSD: syntax error near FROM' });
-      });
-    });
-  });
-
-  describe('with multi template variable', () => {
-    beforeAll(() => {
-      setDataSourceSrv({
-        getInstanceSettings() {
-          return {};
-        },
-      } as DataSourceSrv);
-    });
-
-    const scene = new SceneFlexLayout({
-      children: [],
-      $variables: new SceneVariableSet({
-        variables: [new CustomVariable({ name: 'ds', value: ['B', 'C'] })],
-      }),
-    });
-
-    it('should run query for each datasource when there is a multi value template variable', async () => {
-      const ds = new MixedDatasource({} as DataSourceInstanceSettings);
-
-      const request = {
-        targets: [{ refId: 'AA', datasource: { uid: '$ds' } }],
-        scopedVars: {
-          __sceneObject: { value: scene },
-        },
-      } as unknown as DataQueryRequest;
-
-      await expect(ds.query(request)).toEmitValuesWith((results) => {
-        expect(results).toHaveLength(2);
-        expect(results[0].key).toBe('mixed-0-');
-        expect(results[0].state).toBe(LoadingState.Loading);
-        expect(results[1].key).toBe('mixed-1-');
-        expect(results[1].state).toBe(LoadingState.Done);
-      });
-    });
-
-    it('should run query for picked datasource and template variable datasource', async () => {
-      const ds = new MixedDatasource({} as DataSourceInstanceSettings);
-      const request = {
-        targets: [
-          { refId: 'AA', datasource: { uid: '$ds' } },
-          { refId: 'BB', datasource: { uid: 'Loki' } },
-        ],
-        scopedVars: {
-          __sceneObject: { value: scene },
-        },
-      } as unknown as DataQueryRequest;
-
-      await expect(ds.query(request)).toEmitValuesWith((results) => {
-        expect(results).toHaveLength(4);
-        expect(results[0].key).toBe('mixed-0-');
-        expect(results[0].state).toBe(LoadingState.Loading);
-        expect(results[1].key).toBe('mixed-1-');
-        expect(results[1].state).toBe(LoadingState.Loading);
-        expect(results[2].key).toBe('mixed-2-A');
-        expect(results[2].state).toBe(LoadingState.Loading);
-        expect(results[3].key).toBe('mixed-2-B');
-        expect(results[3].state).toBe(LoadingState.Done);
       });
     });
   });


### PR DESCRIPTION
Reverts grafana/grafana#83356

Causes a hang on dashboards with a datasource variable. 

<details>
<summary>Replication Dashboard</summary>
<br>

```
{
  "annotations": {
    "list": [
      {
        "builtIn": 1,
        "datasource": {
          "type": "grafana",
          "uid": "-- Grafana --"
        },
        "enable": true,
        "hide": true,
        "iconColor": "rgba(0, 211, 255, 1)",
        "name": "Annotations & Alerts",
        "type": "dashboard"
      }
    ]
  },
  "editable": true,
  "fiscalYearStartMonth": 0,
  "graphTooltip": 0,
  "id": 191,
  "links": [],
  "panels": [
    {
      "datasource": {
        "type": "datasource",
        "uid": "-- Mixed --"
      },
      "fieldConfig": {
        "defaults": {
          "color": {
            "mode": "palette-classic"
          },
          "custom": {
            "axisBorderShow": false,
            "axisCenteredZero": false,
            "axisColorMode": "text",
            "axisLabel": "",
            "axisPlacement": "auto",
            "barAlignment": 0,
            "drawStyle": "line",
            "fillOpacity": 0,
            "gradientMode": "none",
            "hideFrom": {
              "legend": false,
              "tooltip": false,
              "viz": false
            },
            "insertNulls": false,
            "lineInterpolation": "linear",
            "lineWidth": 1,
            "pointSize": 5,
            "scaleDistribution": {
              "type": "linear"
            },
            "showPoints": "auto",
            "spanNulls": false,
            "stacking": {
              "group": "A",
              "mode": "none"
            },
            "thresholdsStyle": {
              "mode": "off"
            }
          },
          "mappings": [],
          "thresholds": {
            "mode": "absolute",
            "steps": [
              {
                "color": "green",
                "value": null
              },
              {
                "color": "red",
                "value": 80
              }
            ]
          }
        },
        "overrides": []
      },
      "gridPos": {
        "h": 8,
        "w": 12,
        "x": 0,
        "y": 0
      },
      "id": 1,
      "options": {
        "legend": {
          "calcs": [],
          "displayMode": "list",
          "placement": "bottom",
          "showLegend": true
        },
        "tooltip": {
          "mode": "single",
          "sort": "none"
        }
      },
      "targets": [
        {
          "datasource": {
            "type": "prometheus",
            "uid": "${datasource}"
          },
          "disableTextWrap": false,
          "editorMode": "builder",
          "expr": "counters_logins{app=\"backend\"}",
          "fullMetaSearch": false,
          "includeNullMetadata": true,
          "legendFormat": "__auto",
          "range": true,
          "refId": "A",
          "useBackend": false
        }
      ],
      "title": "Panel Title",
      "type": "timeseries"
    }
  ],
  "schemaVersion": 39,
  "tags": [],
  "templating": {
    "list": [
      {
        "current": {
          "selected": false,
          "text": "gdev-prometheus",
          "value": "gdev-prometheus"
        },
        "hide": 0,
        "includeAll": false,
        "label": "datasource",
        "multi": false,
        "name": "datasource",
        "options": [],
        "query": "prometheus",
        "refresh": 1,
        "regex": "/gdev/",
        "skipUrlSync": false,
        "type": "datasource"
      }
    ]
  },
  "time": {
    "from": "now-6h",
    "to": "now"
  },
  "timeRangeUpdatedDuringEditOrView": false,
  "timepicker": {},
  "timezone": "browser",
  "title": "kristina test",
  "uid": "adl7yuvn4o8aod",
  "version": 3,
  "weekStart": ""
}
```
</details>