### PR TITLE
Canvas: Fix infinite panning editor description

### DIFF
--- a/public/app/plugins/panel/canvas/module.tsx
+++ b/public/app/plugins/panel/canvas/module.tsx
@@ -43,7 +43,7 @@ export const addStandardCanvasEditorOptions = (builder: PanelOptionsEditorBuilde
     path: 'infinitePan',
     name: 'Infinite panning',
     description:
-      'Enable infinite panning - useful for expansive canvases. Warning: this an experimental feature and currently only works well with elements that are top / left constrained',
+      'Enable infinite panning - useful for expansive canvases. Warning: this is an experimental feature and currently only works well with elements that are top / left constrained',
     defaultValue: false,
     showIf: (opts) => config.featureToggles.canvasPanelPanZoom && opts.panZoom,
   });


### PR DESCRIPTION
Fix description of infinite panning editor option as it was missing a word