### PR TITLE
Chore: Add login protection when user is trying different uppercase letters

### DIFF
--- a/pkg/services/loginattempt/loginattemptimpl/login_attempt.go
+++ b/pkg/services/loginattempt/loginattemptimpl/login_attempt.go
@@ -2,6 +2,7 @@ package loginattemptimpl
 
 import (
 	"context"
+	"strings"
 	"time"
 
 	"github.com/grafana/grafana/pkg/infra/db"
@@ -54,14 +55,14 @@ func (s *Service) Add(ctx context.Context, username, IPAddress string) error {
 	}
 
 	_, err := s.store.CreateLoginAttempt(ctx, CreateLoginAttemptCommand{
-		Username:  username,
+		Username:  strings.ToLower(username),
 		IpAddress: IPAddress,
 	})
 	return err
 }
 
 func (s *Service) Reset(ctx context.Context, username string) error {
-	return s.store.DeleteLoginAttempts(ctx, DeleteLoginAttemptsCommand{username})
+	return s.store.DeleteLoginAttempts(ctx, DeleteLoginAttemptsCommand{strings.ToLower(username)})
 }
 
 func (s *Service) Validate(ctx context.Context, username string) (bool, error) {
@@ -70,7 +71,7 @@ func (s *Service) Validate(ctx context.Context, username string) (bool, error) {
 	}
 
 	loginAttemptCountQuery := GetUserLoginAttemptCountQuery{
-		Username: username,
+		Username: strings.ToLower(username),
 		Since:    time.Now().Add(-loginAttemptsWindow),
 	}
 

--- a/pkg/services/loginattempt/loginattemptimpl/login_attempt_test.go
+++ b/pkg/services/loginattempt/loginattemptimpl/login_attempt_test.go
@@ -88,12 +88,12 @@ func TestLoginAttempts(t *testing.T) {
 	service := ProvideService(db, cfg, nil)
 
 	// add multiple login attempts with different uppercases, they all should be counted as the same user
-	service.Add(ctx, "admin", "[::1]")
-	service.Add(ctx, "Admin", "[::1]")
-	service.Add(ctx, "aDmin", "[::1]")
-	service.Add(ctx, "adMin", "[::1]")
-	service.Add(ctx, "admIn", "[::1]")
-	service.Add(ctx, "admIN", "[::1]")
+	_ = service.Add(ctx, "admin", "[::1]")
+	_ = service.Add(ctx, "Admin", "[::1]")
+	_ = service.Add(ctx, "aDmin", "[::1]")
+	_ = service.Add(ctx, "adMin", "[::1]")
+	_ = service.Add(ctx, "admIn", "[::1]")
+	_ = service.Add(ctx, "admIN", "[::1]")
 
 	// validate the number of attempts is correct for all the different uppercases
 	count, err := service.store.GetUserLoginAttemptCount(ctx, GetUserLoginAttemptCountQuery{Username: "admin"})

--- a/pkg/services/loginattempt/loginattemptimpl/login_attempt_test.go
+++ b/pkg/services/loginattempt/loginattemptimpl/login_attempt_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
+	"github.com/grafana/grafana/pkg/infra/db"
 	"github.com/grafana/grafana/pkg/services/loginattempt"
 	"github.com/grafana/grafana/pkg/setting"
 )
@@ -77,6 +78,31 @@ func TestService_Validate(t *testing.T) {
 			assert.Equal(t, tt.expectedErr, err)
 		})
 	}
+}
+
+func TestLoginAttempts(t *testing.T) {
+	ctx := context.Background()
+	cfg := setting.NewCfg()
+	cfg.DisableBruteForceLoginProtection = false
+	db := db.InitTestDB(t)
+	service := ProvideService(db, cfg, nil)
+
+	// add multiple login attempts with different uppercases, they all should be counted as the same user
+	service.Add(ctx, "admin", "[::1]")
+	service.Add(ctx, "Admin", "[::1]")
+	service.Add(ctx, "aDmin", "[::1]")
+	service.Add(ctx, "adMin", "[::1]")
+	service.Add(ctx, "admIn", "[::1]")
+	service.Add(ctx, "admIN", "[::1]")
+
+	// validate the number of attempts is correct for all the different uppercases
+	count, err := service.store.GetUserLoginAttemptCount(ctx, GetUserLoginAttemptCountQuery{Username: "admin"})
+	assert.Nil(t, err)
+	assert.Equal(t, int64(6), count)
+
+	ok, err := service.Validate(ctx, "admin")
+	assert.False(t, ok)
+	assert.Nil(t, err)
 }
 
 var _ store = new(fakeStore)


### PR DESCRIPTION
**What is this feature?**

It turns to lowercase for all login attempts, making it easier to count them if the users try to use different uppercase/lowercase letters.

**Why do we need this feature?**

This issue was reported [here](https://github.com/grafana/bugbounty-private/issues/193).

**Who is this feature for?**

IAM

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes https://github.com/grafana/identity-access-team/issues/670

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
