### PR TITLE
Docs: Add Configuring Elasticsearch documentation for required privileges

### DIFF
--- a/docs/sources/datasources/elasticsearch/configure-elasticsearch-data-source.md
+++ b/docs/sources/datasources/elasticsearch/configure-elasticsearch-data-source.md
@@ -28,6 +28,14 @@ For instructions on how to add a data source to Grafana, refer to the [administr
 Only users with the organization `administrator` role can add data sources.
 Administrators can also [configure the data source via YAML](#provision-the-data-source) with Grafana's provisioning system.
 
+## Configuring Elasticsearch
+
+When Elasticsearch security features are enabled, it is essential to configure the necessary cluster privileges to ensure seamless operation. Below is a list of the required privileges along with their purposes:
+
+- **monitor** - Necessary to retrieve the version information of the connected Elasticsearch instance.
+- **view_index_metadata** - Required for accessing mapping definitions of indices
+- **read** - Grants the ability to perform search and retrieval operations on indices. This is essential for querying and extracting data from the cluster.
+
 ## Add the data source
 
 To add the Elasticsearch data source, complete the following steps:

--- a/docs/sources/datasources/elasticsearch/configure-elasticsearch-data-source.md
+++ b/docs/sources/datasources/elasticsearch/configure-elasticsearch-data-source.md
@@ -28,7 +28,7 @@ For instructions on how to add a data source to Grafana, refer to the [administr
 Only users with the organization `administrator` role can add data sources.
 Administrators can also [configure the data source via YAML](#provision-the-data-source) with Grafana's provisioning system.
 
-## Configuring Elasticsearch
+## Configuring permissions
 
 When Elasticsearch security features are enabled, it is essential to configure the necessary cluster privileges to ensure seamless operation. Below is a list of the required privileges along with their purposes:
 

--- a/docs/sources/datasources/elasticsearch/configure-elasticsearch-data-source.md
+++ b/docs/sources/datasources/elasticsearch/configure-elasticsearch-data-source.md
@@ -33,7 +33,7 @@ Administrators can also [configure the data source via YAML](#provision-the-data
 When Elasticsearch security features are enabled, it is essential to configure the necessary cluster privileges to ensure seamless operation. Below is a list of the required privileges along with their purposes:
 
 - **monitor** - Necessary to retrieve the version information of the connected Elasticsearch instance.
-- **view_index_metadata** - Required for accessing mapping definitions of indices
+- **view_index_metadata** - Required for accessing mapping definitions of indices.
 - **read** - Grants the ability to perform search and retrieval operations on indices. This is essential for querying and extracting data from the cluster.
 
 ## Add the data source


### PR DESCRIPTION
This PR adds documentation about necessary cluster privilege.

Fixes https://github.com/grafana/support-escalations/issues/9096
Related to https://github.com/grafana/grafana/issues/79955