### PR TITLE
Dropdown: Fixes double call to onVisibilityChange

### DIFF
--- a/packages/grafana-ui/src/components/Dropdown/Dropdown.tsx
+++ b/packages/grafana-ui/src/components/Dropdown/Dropdown.tsx
@@ -10,7 +10,7 @@ import {
   useFloating,
   useInteractions,
 } from '@floating-ui/react';
-import React, { useCallback, useEffect, useRef, useState } from 'react';
+import React, { useCallback, useRef, useState } from 'react';
 import { CSSTransition } from 'react-transition-group';
 
 import { GrafanaTheme2 } from '@grafana/data';
@@ -27,10 +27,8 @@ export interface Props {
   children: React.ReactElement;
   /** Amount in pixels to nudge the dropdown vertically and horizontally, respectively. */
   offset?: [number, number];
-  onVisibleChange?: VisibilityChangeHandler;
+  onVisibleChange?: (state: boolean) => void;
 }
-
-type VisibilityChangeHandler = (state: boolean) => void | undefined;
 
 export const Dropdown = React.memo(({ children, overlay, placement, offset, onVisibleChange }: Props) => {
   const [show, setShow] = useState(false);

--- a/packages/grafana-ui/src/components/Dropdown/Dropdown.tsx
+++ b/packages/grafana-ui/src/components/Dropdown/Dropdown.tsx
@@ -27,16 +27,22 @@ export interface Props {
   children: React.ReactElement;
   /** Amount in pixels to nudge the dropdown vertically and horizontally, respectively. */
   offset?: [number, number];
-  onVisibleChange?: (state: boolean) => void;
+  onVisibleChange?: VisibilityChangeHandler;
 }
+
+type VisibilityChangeHandler = (state: boolean) => void | undefined;
 
 export const Dropdown = React.memo(({ children, overlay, placement, offset, onVisibleChange }: Props) => {
   const [show, setShow] = useState(false);
   const transitionRef = useRef(null);
+  const onVisibilityChangeRef = useRef<VisibilityChangeHandler>();
+  onVisibilityChangeRef.current = onVisibleChange;
 
   useEffect(() => {
-    onVisibleChange?.(show);
-  }, [onVisibleChange, show]);
+    if (onVisibilityChangeRef.current) {
+      onVisibilityChangeRef.current(show);
+    }
+  }, [show]);
 
   // the order of middleware is important!
   const middleware = [

--- a/packages/grafana-ui/src/components/Dropdown/Dropdown.tsx
+++ b/packages/grafana-ui/src/components/Dropdown/Dropdown.tsx
@@ -10,7 +10,7 @@ import {
   useFloating,
   useInteractions,
 } from '@floating-ui/react';
-import React, { useEffect, useRef, useState } from 'react';
+import React, { useCallback, useEffect, useRef, useState } from 'react';
 import { CSSTransition } from 'react-transition-group';
 
 import { GrafanaTheme2 } from '@grafana/data';
@@ -35,14 +35,14 @@ type VisibilityChangeHandler = (state: boolean) => void | undefined;
 export const Dropdown = React.memo(({ children, overlay, placement, offset, onVisibleChange }: Props) => {
   const [show, setShow] = useState(false);
   const transitionRef = useRef(null);
-  const onVisibilityChangeRef = useRef<VisibilityChangeHandler>();
-  onVisibilityChangeRef.current = onVisibleChange;
 
-  useEffect(() => {
-    if (onVisibilityChangeRef.current) {
-      onVisibilityChangeRef.current(show);
-    }
-  }, [show]);
+  const handleOpenChange = useCallback(
+    (newState: boolean) => {
+      setShow(newState);
+      onVisibleChange?.(newState);
+    },
+    [onVisibleChange]
+  );
 
   // the order of middleware is important!
   const middleware = [
@@ -62,7 +62,7 @@ export const Dropdown = React.memo(({ children, overlay, placement, offset, onVi
   const { context, refs, floatingStyles } = useFloating({
     open: show,
     placement: getPlacement(placement),
-    onOpenChange: setShow,
+    onOpenChange: handleOpenChange,
     middleware,
     whileElementsMounted: autoUpdate,
   });


### PR DESCRIPTION
Noticed double calls to onVisbilityChange if that callback is not memoized (https://github.com/grafana/grafana/blob/main/public/app/features/dashboard-scene/scene/NavToolbarActions.tsx#L163) 

While it should be memoized I do not think this double call behavior is not correct, the callback should only be called when the visibility changes not when the callback changes. 

Using a ref for the callback fixes it, but there are probably other ways, not sure which is best. 