### PR TITLE
AdHocFilters: Use queries in ad hoc filters api calls

### DIFF
--- a/public/app/features/dashboard-scene/serialization/transformSaveModelToScene.test.ts
+++ b/public/app/features/dashboard-scene/serialization/transformSaveModelToScene.test.ts
@@ -126,6 +126,9 @@ describe('transformSaveModelToScene', () => {
       expect(scene.state?.$variables?.state.variables).toHaveLength(2);
       expect(scene.state?.$variables?.getByName('constant')).toBeInstanceOf(ConstantVariable);
       expect(scene.state?.$variables?.getByName('CoolFilters')).toBeInstanceOf(AdHocFiltersVariable);
+      expect(
+        (scene.state?.$variables?.getByName('CoolFilters') as AdHocFiltersVariable).state.useQueriesAsFilterForOptions
+      ).toBe(true);
       expect(dashboardControls).toBeDefined();
 
       expect(dashboardControls.state.refreshPicker.state.intervals).toEqual(defaultTimePickerConfig.refresh_intervals);
@@ -936,6 +939,7 @@ describe('transformSaveModelToScene', () => {
         baseFilters: [{ key: 'baseFilterTest', operator: '=', value: 'test' }],
         datasource: { uid: 'gdev-prometheus', type: 'prometheus' },
         applyMode: 'auto',
+        useQueriesAsFilterForOptions: true,
       });
     });
 
@@ -1018,6 +1022,7 @@ describe('transformSaveModelToScene', () => {
             value: '3',
           },
         ],
+        useQueriesAsFilterForOptions: true,
       });
     });
 

--- a/public/app/features/dashboard-scene/serialization/transformSaveModelToScene.ts
+++ b/public/app/features/dashboard-scene/serialization/transformSaveModelToScene.ts
@@ -319,6 +319,7 @@ export function createSceneVariableFromVariableModel(variable: TypedVariableMode
       filters: variable.filters ?? [],
       baseFilters: variable.baseFilters ?? [],
       defaultKeys: variable.defaultKeys,
+      useQueriesAsFilterForOptions: true,
     });
   }
   if (variable.type === 'custom') {


### PR DESCRIPTION
Followup to https://github.com/grafana/grafana/pull/87244 which did not enable passing queries to ad hoc filter variables correctly.