### PR TITLE
AuthN: Fix signout redirect url

### DIFF
--- a/conf/defaults.ini
+++ b/conf/defaults.ini
@@ -875,7 +875,6 @@ auto_sign_up = false
 url_login = false
 allow_assign_grafana_admin = false
 skip_org_role_sync = false
-signout_redirect_url =
 
 #################################### Auth LDAP ###########################
 [auth.ldap]

--- a/pkg/api/login.go
+++ b/pkg/api/login.go
@@ -254,6 +254,7 @@ func (hs *HTTPServer) Logout(c *contextmodel.ReqContext) {
 	if err != nil {
 		hs.log.Error("Failed perform proper logout", "error", err)
 		c.Redirect(hs.Cfg.AppSubURL + "/login")
+		return
 	}
 
 	_, id := c.SignedInUser.GetNamespacedID()

--- a/pkg/services/authn/authnimpl/service_test.go
+++ b/pkg/services/authn/authnimpl/service_test.go
@@ -409,7 +409,8 @@ func TestService_Logout(t *testing.T) {
 		identity     *authn.Identity
 		sessionToken *usertoken.UserToken
 
-		client authn.Client
+		client             authn.Client
+		signoutRedirectURL string
 
 		expectedErr          error
 		expectedTokenRevoked bool
@@ -439,6 +440,14 @@ func TestService_Logout(t *testing.T) {
 			identity:             &authn.Identity{ID: authn.NewNamespaceID(authn.NamespaceUser, 1), AuthenticatedBy: "azuread"},
 			expectedRedirect:     &authn.Redirect{URL: "http://localhost:3000/login"},
 			client:               &authntest.FakeClient{ExpectedName: "auth.client.azuread"},
+			expectedTokenRevoked: true,
+		},
+		{
+			desc:                 "should use signout redirect url if configured",
+			identity:             &authn.Identity{ID: authn.NewNamespaceID(authn.NamespaceUser, 1), AuthenticatedBy: "azuread"},
+			expectedRedirect:     &authn.Redirect{URL: "some-url"},
+			client:               &authntest.FakeClient{ExpectedName: "auth.client.azuread"},
+			signoutRedirectURL:   "some-url",
 			expectedTokenRevoked: true,
 		},
 		{
@@ -472,6 +481,10 @@ func TestService_Logout(t *testing.T) {
 						assert.False(t, soft)
 						return nil
 					},
+				}
+
+				if tt.signoutRedirectURL != "" {
+					svc.cfg.SignoutRedirectUrl = tt.signoutRedirectURL
 				}
 			})
 


### PR DESCRIPTION
**What is this feature?**
After https://github.com/grafana/grafana/pull/79635 we did not respect `signout_redirect_url` configured under `[auth]`. It only worked with saml and oauth.

To fix this we instead default to use `signout_redirect_url` if configured. A client that implement `LogoutClient` will still take precedence. We also need to ignore the case when users don't have a session token so that the configured redirect url is used.




**Which issue(s) does this PR fix?**:
Fixes #85128
Fixes #84108

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
