### PR TITLE
Chore: Remove gf-forms from `SubMenuItems` and `RangeMatcherEditor`

### DIFF
--- a/.betterer.results
+++ b/.betterer.results
@@ -5568,11 +5568,6 @@ exports[`no gf-form usage`] = {
       [0, 0, 0, "gf-form usage has been deprecated. Use a component from @grafana/ui or custom CSS instead.", "5381"],
       [0, 0, 0, "gf-form usage has been deprecated. Use a component from @grafana/ui or custom CSS instead.", "5381"]
     ],
-    "public/app/features/transformers/FilterByValueTransformer/ValueMatchers/RangeMatcherEditor.tsx:5381": [
-      [0, 0, 0, "gf-form usage has been deprecated. Use a component from @grafana/ui or custom CSS instead.", "5381"],
-      [0, 0, 0, "gf-form usage has been deprecated. Use a component from @grafana/ui or custom CSS instead.", "5381"],
-      [0, 0, 0, "gf-form usage has been deprecated. Use a component from @grafana/ui or custom CSS instead.", "5381"]
-    ],
     "public/app/features/transformers/editors/OrganizeFieldsTransformerEditor.tsx:5381": [
       [0, 0, 0, "gf-form usage has been deprecated. Use a component from @grafana/ui or custom CSS instead.", "5381"],
       [0, 0, 0, "gf-form usage has been deprecated. Use a component from @grafana/ui or custom CSS instead.", "5381"],

--- a/.betterer.results
+++ b/.betterer.results
@@ -5523,9 +5523,6 @@ exports[`no gf-form usage`] = {
       [0, 0, 0, "gf-form usage has been deprecated. Use a component from @grafana/ui or custom CSS instead.", "5381"],
       [0, 0, 0, "gf-form usage has been deprecated. Use a component from @grafana/ui or custom CSS instead.", "5381"]
     ],
-    "public/app/features/dashboard/components/SubMenu/SubMenuItems.tsx:5381": [
-      [0, 0, 0, "gf-form usage has been deprecated. Use a component from @grafana/ui or custom CSS instead.", "5381"]
-    ],
     "public/app/features/datasources/components/BasicSettings.tsx:5381": [
       [0, 0, 0, "gf-form usage has been deprecated. Use a component from @grafana/ui or custom CSS instead.", "5381"],
       [0, 0, 0, "gf-form usage has been deprecated. Use a component from @grafana/ui or custom CSS instead.", "5381"],
@@ -5602,7 +5599,6 @@ exports[`no gf-form usage`] = {
       [0, 0, 0, "gf-form usage has been deprecated. Use a component from @grafana/ui or custom CSS instead.", "5381"]
     ],
     "public/app/features/variables/pickers/PickerRenderer.tsx:5381": [
-      [0, 0, 0, "gf-form usage has been deprecated. Use a component from @grafana/ui or custom CSS instead.", "5381"],
       [0, 0, 0, "gf-form usage has been deprecated. Use a component from @grafana/ui or custom CSS instead.", "5381"],
       [0, 0, 0, "gf-form usage has been deprecated. Use a component from @grafana/ui or custom CSS instead.", "5381"],
       [0, 0, 0, "gf-form usage has been deprecated. Use a component from @grafana/ui or custom CSS instead.", "5381"],

--- a/public/app/features/dashboard/components/SubMenu/SubMenuItems.tsx
+++ b/public/app/features/dashboard/components/SubMenu/SubMenuItems.tsx
@@ -24,11 +24,7 @@ export const SubMenuItems = ({ variables, readOnly }: Props) => {
   return (
     <>
       {visibleVariables.map((variable) => (
-        <div
-          key={variable.id}
-          className="submenu-item gf-form-inline"
-          data-testid={selectors.pages.Dashboard.SubMenu.submenuItem}
-        >
+        <div key={variable.id} className="submenu-item" data-testid={selectors.pages.Dashboard.SubMenu.submenuItem}>
           <PickerRenderer variable={variable} readOnly={readOnly} />
         </div>
       ))}

--- a/public/app/features/transformers/FilterByValueTransformer/ValueMatchers/RangeMatcherEditor.tsx
+++ b/public/app/features/transformers/FilterByValueTransformer/ValueMatchers/RangeMatcherEditor.tsx
@@ -2,7 +2,7 @@ import React, { useCallback, useState } from 'react';
 
 import { ValueMatcherID, RangeValueMatcherOptions, VariableOrigin } from '@grafana/data';
 import { getTemplateSrv, config as cfg } from '@grafana/runtime';
-import { Input } from '@grafana/ui';
+import { InlineLabel, Input } from '@grafana/ui';
 
 import { SuggestionsInput } from '../../suggestionsInput/SuggestionsInput';
 import { numberOrVariableValidator } from '../../utils';
@@ -84,7 +84,7 @@ export function rangeMatcherEditor<T = any>(
             onChange={(val) => onChangeOptionsSuggestions(val, 'from')}
             suggestions={variables}
           />
-          <div className="gf-form-label">and</div>
+          <InlineLabel>and</InlineLabel>
           <SuggestionsInput
             invalid={isInvalid.to}
             error={'Value needs to be an integer or a variable'}
@@ -99,16 +99,14 @@ export function rangeMatcherEditor<T = any>(
     return (
       <>
         <Input
-          className="flex-grow-1 gf-form-spacing"
           invalid={isInvalid['from']}
           defaultValue={String(options.from)}
           placeholder="From"
           onChange={(event) => onChangeValue(event, 'from')}
           onBlur={(event) => onChangeOptions(event, 'from')}
         />
-        <div className="gf-form-label">and</div>
+        <InlineLabel>and</InlineLabel>
         <Input
-          className="flex-grow-1"
           invalid={isInvalid['to']}
           defaultValue={String(options.to)}
           placeholder="To"

--- a/public/app/features/variables/pickers/PickerRenderer.tsx
+++ b/public/app/features/variables/pickers/PickerRenderer.tsx
@@ -2,7 +2,7 @@ import React, { PropsWithChildren, ReactElement, useMemo } from 'react';
 
 import { TypedVariableModel, VariableHide } from '@grafana/data';
 import { selectors } from '@grafana/e2e-selectors';
-import { Tooltip } from '@grafana/ui';
+import { Stack, Tooltip } from '@grafana/ui';
 
 import { variableAdapters } from '../adapters';
 import { VARIABLE_PREFIX } from '../constants';
@@ -20,12 +20,12 @@ export const PickerRenderer = (props: Props) => {
   }
 
   return (
-    <div className="gf-form">
+    <Stack gap={0}>
       <PickerLabel variable={props.variable} />
       {props.variable.hide !== VariableHide.hideVariable && PickerToRender && (
         <PickerToRender variable={props.variable} readOnly={props.readOnly ?? false} />
       )}
-    </div>
+    </Stack>
   );
 };
 


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

This removes use of gf-form classes from:

- `SubMenuItems`

| Before | After |
| --- | --- |
| <img width="567" alt="Screenshot 2024-05-10 at 14 48 31" src="https://github.com/grafana/grafana/assets/100691367/35fd8ba7-a228-4749-9aca-e928bac60242"> | <img width="574" alt="Screenshot 2024-05-10 at 14 47 45" src="https://github.com/grafana/grafana/assets/100691367/d2d3ccfc-446a-4580-bc67-0181f0e677f6"> |

- `RangeMatcherEditor` (in the "Filter Data by Values" transform)

| Before | After |
| --- | --- |
| <img width="546" alt="Screenshot 2024-05-10 at 14 48 41" src="https://github.com/grafana/grafana/assets/100691367/ef48ebb9-5c79-44bc-a652-fa2893586108"> | <img width="552" alt="Screenshot 2024-05-10 at 14 47 09" src="https://github.com/grafana/grafana/assets/100691367/69eb3e69-26f6-4afd-9ab9-31c2b0aba05f"> |

(plus one usage in `PickerRenderer`, but the other ones that style the labels as blue for the variables are harder to remove...)

**Why do we need this feature?**

To remove usage of Sass styles from Grafana

**Who is this feature for?**

everyone

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes part of https://github.com/grafana/grafana/issues/65513

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
