### PR TITLE
EmptyState: Don't apply animation when `prefers-reduced-motion` is set

### DIFF
--- a/packages/grafana-ui/src/components/EmptyState/GrotNotFound/GrotNotFound.tsx
+++ b/packages/grafana-ui/src/components/EmptyState/GrotNotFound/GrotNotFound.tsx
@@ -24,23 +24,25 @@ export const GrotNotFound = ({ width = 'auto', height }: Props) => {
 
   useEffect(() => {
     const handleMouseMove = (event: MouseEvent) => {
-      // only apply animation if no reduced motion preference is set
-      if (window.matchMedia('(prefers-reduced-motion: no-preference)').matches) {
-        const grotArm = svgRef.current?.querySelector('#grot-not-found-arm');
-        const grotMagnifier = svgRef.current?.querySelector('#grot-not-found-magnifier');
-
-        const { clientX, clientY } = event;
-        const { innerWidth, innerHeight } = window;
-        const heightRatio = clientY / innerHeight;
-        const widthRatio = clientX / innerWidth;
-        const rotation = getIntermediateValue(heightRatio, MIN_ARM_ROTATION, MAX_ARM_ROTATION);
-        const translation = getIntermediateValue(widthRatio, MIN_ARM_TRANSLATION, MAX_ARM_TRANSLATION);
-
-        window.requestAnimationFrame(() => {
-          grotArm?.setAttribute('style', `transform: rotate(${rotation}deg) translateX(${translation}%)`);
-          grotMagnifier?.setAttribute('style', `transform: rotate(${rotation}deg) translateX(${translation}%)`);
-        });
+      // don't apply animation if reduced motion preference is set
+      if (window.matchMedia('(prefers-reduced-motion: reduce').matches) {
+        return;
       }
+
+      const grotArm = svgRef.current?.querySelector('#grot-not-found-arm');
+      const grotMagnifier = svgRef.current?.querySelector('#grot-not-found-magnifier');
+
+      const { clientX, clientY } = event;
+      const { innerWidth, innerHeight } = window;
+      const heightRatio = clientY / innerHeight;
+      const widthRatio = clientX / innerWidth;
+      const rotation = getIntermediateValue(heightRatio, MIN_ARM_ROTATION, MAX_ARM_ROTATION);
+      const translation = getIntermediateValue(widthRatio, MIN_ARM_TRANSLATION, MAX_ARM_TRANSLATION);
+
+      window.requestAnimationFrame(() => {
+        grotArm?.setAttribute('style', `transform: rotate(${rotation}deg) translateX(${translation}%)`);
+        grotMagnifier?.setAttribute('style', `transform: rotate(${rotation}deg) translateX(${translation}%)`);
+      });
     };
 
     window.addEventListener('mousemove', handleMouseMove);

--- a/packages/grafana-ui/src/components/EmptyState/GrotNotFound/GrotNotFound.tsx
+++ b/packages/grafana-ui/src/components/EmptyState/GrotNotFound/GrotNotFound.tsx
@@ -24,17 +24,18 @@ export const GrotNotFound = ({ width = 'auto', height }: Props) => {
 
   useEffect(() => {
     const handleMouseMove = (event: MouseEvent) => {
-      const grotArm = svgRef.current?.querySelector('#grot-not-found-arm');
-      const grotMagnifier = svgRef.current?.querySelector('#grot-not-found-magnifier');
-
-      const { clientX, clientY } = event;
-      const { innerWidth, innerHeight } = window;
-      const heightRatio = clientY / innerHeight;
-      const widthRatio = clientX / innerWidth;
-      const rotation = getIntermediateValue(heightRatio, MIN_ARM_ROTATION, MAX_ARM_ROTATION);
-      const translation = getIntermediateValue(widthRatio, MIN_ARM_TRANSLATION, MAX_ARM_TRANSLATION);
-
+      // only apply animation if no reduced motion preference is set
       if (window.matchMedia('(prefers-reduced-motion: no-preference)').matches) {
+        const grotArm = svgRef.current?.querySelector('#grot-not-found-arm');
+        const grotMagnifier = svgRef.current?.querySelector('#grot-not-found-magnifier');
+
+        const { clientX, clientY } = event;
+        const { innerWidth, innerHeight } = window;
+        const heightRatio = clientY / innerHeight;
+        const widthRatio = clientX / innerWidth;
+        const rotation = getIntermediateValue(heightRatio, MIN_ARM_ROTATION, MAX_ARM_ROTATION);
+        const translation = getIntermediateValue(widthRatio, MIN_ARM_TRANSLATION, MAX_ARM_TRANSLATION);
+
         window.requestAnimationFrame(() => {
           grotArm?.setAttribute('style', `transform: rotate(${rotation}deg) translateX(${translation}%)`);
           grotMagnifier?.setAttribute('style', `transform: rotate(${rotation}deg) translateX(${translation}%)`);

--- a/packages/grafana-ui/src/components/EmptyState/GrotNotFound/GrotNotFound.tsx
+++ b/packages/grafana-ui/src/components/EmptyState/GrotNotFound/GrotNotFound.tsx
@@ -34,10 +34,12 @@ export const GrotNotFound = ({ width = 'auto', height }: Props) => {
       const rotation = getIntermediateValue(heightRatio, MIN_ARM_ROTATION, MAX_ARM_ROTATION);
       const translation = getIntermediateValue(widthRatio, MIN_ARM_TRANSLATION, MAX_ARM_TRANSLATION);
 
-      window.requestAnimationFrame(() => {
-        grotArm?.setAttribute('style', `transform: rotate(${rotation}deg) translateX(${translation}%)`);
-        grotMagnifier?.setAttribute('style', `transform: rotate(${rotation}deg) translateX(${translation}%)`);
-      });
+      if (window.matchMedia('(prefers-reduced-motion: no-preference)').matches) {
+        window.requestAnimationFrame(() => {
+          grotArm?.setAttribute('style', `transform: rotate(${rotation}deg) translateX(${translation}%)`);
+          grotMagnifier?.setAttribute('style', `transform: rotate(${rotation}deg) translateX(${translation}%)`);
+        });
+      }
     };
 
     window.addEventListener('mousemove', handleMouseMove);


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

- only apply the empty state animation when no prefers reduced motion media preference is set

**Why do we need this feature?**

- better a11y

**Who is this feature for?**

- everyone!

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
