### PR TITLE
Performance: Load shared frontend plugin dependencies on demand

### DIFF
--- a/public/app/features/plugins/loader/sharedDependencies.ts
+++ b/public/app/features/plugins/loader/sharedDependencies.ts
@@ -1,25 +1,4 @@
-import * as emotion from '@emotion/css';
-import * as emotionReact from '@emotion/react';
-import * as kusto from '@kusto/monaco-kusto';
-import * as d3 from 'd3';
-import * as i18next from 'i18next';
 import jquery from 'jquery';
-import _ from 'lodash'; // eslint-disable-line lodash/import-scope
-import moment from 'moment'; // eslint-disable-line no-restricted-imports
-import prismjs from 'prismjs';
-import react from 'react';
-import reactDom from 'react-dom';
-import * as reactInlineSvg from 'react-inlinesvg';
-import * as reactRedux from 'react-redux'; // eslint-disable-line no-restricted-imports
-import * as reactRouterDom from 'react-router-dom';
-import * as reactRouterCompat from 'react-router-dom-v5-compat';
-import * as redux from 'redux';
-import * as rxjs from 'rxjs';
-import * as rxjsOperators from 'rxjs/operators';
-import slate from 'slate';
-import slatePlain from 'slate-plain-serializer';
-import slateReact from 'slate-react';
-
 import 'vendor/flot/jquery.flot';
 import 'vendor/flot/jquery.flot.selection';
 import 'vendor/flot/jquery.flot.time';
@@ -65,14 +44,96 @@ const jQueryFlotDeps = [
   'jquery.flot',
 ].reduce((acc, flotDep) => ({ ...acc, [flotDep]: { fakeDep: 1 } }), {});
 
-export const sharedDependenciesMap: Record<string, System.Module> = {
-  '@emotion/css': emotion,
-  '@emotion/react': emotionReact,
+// export const sharedDependenciesMap: Record<string, System.Module> = {
+// '@emotion/css': emotion,
+// '@emotion/react': emotionReact,
+// '@grafana/data': grafanaData,
+// '@grafana/runtime': grafanaRuntime,
+// '@grafana/slate-react': slateReact, // for backwards compatibility with older plugins
+// '@grafana/ui': grafanaUI,
+// '@kusto/monaco-kusto': kusto,
+// 'app/core/app_events': {
+//   default: appEvents,
+//   __useDefault: true,
+// },
+// 'app/core/config': {
+//   default: config,
+//   __useDefault: true,
+// },
+// 'app/core/core': {
+//   appEvents: appEvents,
+//   contextSrv: contextSrv,
+// },
+// 'app/core/services/backend_srv': {
+//   BackendSrv,
+//   getBackendSrv,
+// },
+// 'app/core/table_model': { default: TableModel, __useDefault: true },
+// 'app/core/time_series': { default: TimeSeries, __useDefault: true },
+// 'app/core/time_series2': { default: TimeSeries, __useDefault: true },
+// 'app/core/utils/datemath': grafanaData.dateMath,
+// 'app/core/utils/flatten': flatten,
+// 'app/core/utils/kbn': {
+//   default: kbn,
+//   __useDefault: true,
+// },
+// 'app/core/utils/ticks': ticks,
+// 'app/features/dashboard/impression_store': {
+//   impressions: impressionSrv,
+// },
+// d3: d3,
+// emotion: emotion,
+// bundling grafana-ui in plugins requires sharing i18next state
+// i18next: i18next,
+// jquery: {
+//   default: jquery,
+//   __useDefault: true,
+// },
+// ...jQueryFlotDeps,
+// lodash: {
+//   default: _,
+//   __useDefault: true,
+// },
+// moment: {
+//   default: moment,
+//   __useDefault: true,
+// },
+// prismjs: prismjs,
+// react: react,
+// 'react-dom': reactDom,
+// bundling grafana-ui in plugins requires sharing react-inlinesvg for the icon cache
+// 'react-inlinesvg': reactInlineSvg,
+// 'react-redux': reactRedux,
+// Migration - React Router v5 -> v6
+// =================================
+// Plugins that still use "react-router-dom@v5" don't depend on react-router directly, so they will not use this import.
+// (The react-router-dom@v5 that we expose for them depends on the "react-router" package internally from core.)
+//
+// Plugins that would like update to "react-router-dom@v6" will need to bundle "react-router-dom",
+// however they cannot bundle "react-router" - this would mean that we have two instances of "react-router"
+// in the app, which would casue issues. As the "react-router-dom-v5-compat" package re-exports everything from "react-router-dom@v6"
+// which then re-exports everything from "react-router@v6", we are in the lucky state to be able to expose a compatible v6 version of the router to plugins by
+// just exposing "react-router-dom-v5-compat".
+//
+// (This means that we are exposing two versions of the same package).
+// 'react-router-dom': reactRouterDom, // react-router-dom@v5
+// 'react-router': reactRouterCompat, // react-router-dom@v6, react-router@v6 (included)
+// redux: redux,
+// rxjs: rxjs,
+// 'rxjs/operators': rxjsOperators,
+// slate: slate,
+// 'slate-plain-serializer': slatePlain,
+// 'slate-react': slateReact,
+// };
+
+export const sharedDependenciesMap = {
+  '@emotion/css': () => import('@emotion/css'),
+  '@emotion/react': () => import('@emotion/react'),
   '@grafana/data': grafanaData,
   '@grafana/runtime': grafanaRuntime,
-  '@grafana/slate-react': slateReact, // for backwards compatibility with older plugins
   '@grafana/ui': grafanaUI,
-  '@kusto/monaco-kusto': kusto,
+  '@grafana/slate-react': () => import('slate-react'),
+  '@kusto/monaco-kusto': () => import('@kusto/monaco-kusto'),
   'app/core/app_events': {
     default: appEvents,
     __useDefault: true,
@@ -102,47 +163,26 @@ export const sharedDependenciesMap: Record<string, System.Module> = {
   'app/features/dashboard/impression_store': {
     impressions: impressionSrv,
   },
-  d3: d3,
-  emotion: emotion,
-  // bundling grafana-ui in plugins requires sharing i18next state
-  i18next: i18next,
+  d3: () => import('d3'),
+  emotion: () => import('@emotion/css'),
+  i18next: () => import('i18next'),
   jquery: {
     default: jquery,
     __useDefault: true,
   },
   ...jQueryFlotDeps,
-  lodash: {
-    default: _,
-    __useDefault: true,
-  },
-  moment: {
-    default: moment,
-    __useDefault: true,
-  },
-  prismjs: prismjs,
-  react: react,
-  'react-dom': reactDom,
-  // bundling grafana-ui in plugins requires sharing react-inlinesvg for the icon cache
-  'react-inlinesvg': reactInlineSvg,
-  'react-redux': reactRedux,
-  // Migration - React Router v5 -> v6
-  // =================================
-  // Plugins that still use "react-router-dom@v5" don't depend on react-router directly, so they will not use this import.
-  // (The react-router-dom@v5 that we expose for them depends on the "react-router" package internally from core.)
-  //
-  // Plugins that would like update to "react-router-dom@v6" will need to bundle "react-router-dom",
-  // however they cannot bundle "react-router" - this would mean that we have two instances of "react-router"
-  // in the app, which would casue issues. As the "react-router-dom-v5-compat" package re-exports everything from "react-router-dom@v6"
-  // which then re-exports everything from "react-router@v6", we are in the lucky state to be able to expose a compatible v6 version of the router to plugins by
-  // just exposing "react-router-dom-v5-compat".
-  //
-  // (This means that we are exposing two versions of the same package).
-  'react-router-dom': reactRouterDom, // react-router-dom@v5
-  'react-router': reactRouterCompat, // react-router-dom@v6, react-router@v6 (included)
-  redux: redux,
-  rxjs: rxjs,
-  'rxjs/operators': rxjsOperators,
-  slate: slate,
-  'slate-plain-serializer': slatePlain,
-  'slate-react': slateReact,
+  lodash: () => import('lodash').then((module) => ({ ...module, __useDefault: true })),
+  moment: () => import('moment').then((module) => ({ ...module, __useDefault: true })),
+  prismjs: () => import('prismjs'),
+  react: () => import('react'),
+  'react-dom': () => import('react-dom'),
+  'react-inlinesvg': () => import('react-inlinesvg'),
+  'react-router-dom': () => import('react-router-dom'),
+  'react-router': () => import('react-router-dom-v5-compat'),
+  redux: () => import('redux'),
+  rxjs: () => import('rxjs'),
+  'rxjs/operators': () => import('rxjs/operators'),
+  slate: () => import('slate'),
+  'slate-plain-serializer': () => import('slate-plain-serializer'),
+  'slate-react': () => import('slate-react'),
 };

--- a/public/app/features/plugins/loader/sharedDependencies.ts
+++ b/public/app/features/plugins/loader/sharedDependencies.ts
@@ -44,95 +44,13 @@ const jQueryFlotDeps = [
   'jquery.flot',
 ].reduce((acc, flotDep) => ({ ...acc, [flotDep]: { fakeDep: 1 } }), {});
 
-// export const sharedDependenciesMap: Record<string, System.Module> = {
-// '@emotion/css': emotion,
-// '@emotion/react': emotionReact,
-// '@grafana/data': grafanaData,
-// '@grafana/runtime': grafanaRuntime,
-// '@grafana/slate-react': slateReact, // for backwards compatibility with older plugins
-// '@grafana/ui': grafanaUI,
-// '@kusto/monaco-kusto': kusto,
-// 'app/core/app_events': {
-//   default: appEvents,
-//   __useDefault: true,
-// },
-// 'app/core/config': {
-//   default: config,
-//   __useDefault: true,
-// },
-// 'app/core/core': {
-//   appEvents: appEvents,
-//   contextSrv: contextSrv,
-// },
-// 'app/core/services/backend_srv': {
-//   BackendSrv,
-//   getBackendSrv,
-// },
-// 'app/core/table_model': { default: TableModel, __useDefault: true },
-// 'app/core/time_series': { default: TimeSeries, __useDefault: true },
-// 'app/core/time_series2': { default: TimeSeries, __useDefault: true },
-// 'app/core/utils/datemath': grafanaData.dateMath,
-// 'app/core/utils/flatten': flatten,
-// 'app/core/utils/kbn': {
-//   default: kbn,
-//   __useDefault: true,
-// },
-// 'app/core/utils/ticks': ticks,
-// 'app/features/dashboard/impression_store': {
-//   impressions: impressionSrv,
-// },
-// d3: d3,
-// emotion: emotion,
-// bundling grafana-ui in plugins requires sharing i18next state
-// i18next: i18next,
-// jquery: {
-//   default: jquery,
-//   __useDefault: true,
-// },
-// ...jQueryFlotDeps,
-// lodash: {
-//   default: _,
-//   __useDefault: true,
-// },
-// moment: {
-//   default: moment,
-//   __useDefault: true,
-// },
-// prismjs: prismjs,
-// react: react,
-// 'react-dom': reactDom,
-// bundling grafana-ui in plugins requires sharing react-inlinesvg for the icon cache
-// 'react-inlinesvg': reactInlineSvg,
-// 'react-redux': reactRedux,
-// Migration - React Router v5 -> v6
-// =================================
-// Plugins that still use "react-router-dom@v5" don't depend on react-router directly, so they will not use this import.
-// (The react-router-dom@v5 that we expose for them depends on the "react-router" package internally from core.)
-//
-// Plugins that would like update to "react-router-dom@v6" will need to bundle "react-router-dom",
-// however they cannot bundle "react-router" - this would mean that we have two instances of "react-router"
-// in the app, which would casue issues. As the "react-router-dom-v5-compat" package re-exports everything from "react-router-dom@v6"
-// which then re-exports everything from "react-router@v6", we are in the lucky state to be able to expose a compatible v6 version of the router to plugins by
-// just exposing "react-router-dom-v5-compat".
-//
-// (This means that we are exposing two versions of the same package).
-// 'react-router-dom': reactRouterDom, // react-router-dom@v5
-// 'react-router': reactRouterCompat, // react-router-dom@v6, react-router@v6 (included)
-// redux: redux,
-// rxjs: rxjs,
-// 'rxjs/operators': rxjsOperators,
-// slate: slate,
-// 'slate-plain-serializer': slatePlain,
-// 'slate-react': slateReact,
-// };
-
 export const sharedDependenciesMap = {
   '@emotion/css': () => import('@emotion/css'),
   '@emotion/react': () => import('@emotion/react'),
   '@grafana/data': grafanaData,
   '@grafana/runtime': grafanaRuntime,
-  '@grafana/ui': grafanaUI,
   '@grafana/slate-react': () => import('slate-react'),
+  '@grafana/ui': grafanaUI,
   '@kusto/monaco-kusto': () => import('@kusto/monaco-kusto'),
   'app/core/app_events': {
     default: appEvents,
@@ -165,6 +83,7 @@ export const sharedDependenciesMap = {
   },
   d3: () => import('d3'),
   emotion: () => import('@emotion/css'),
+  // bundling grafana-ui in plugins requires sharing i18next state
   i18next: () => import('i18next'),
   jquery: {
     default: jquery,
@@ -176,7 +95,21 @@ export const sharedDependenciesMap = {
   prismjs: () => import('prismjs'),
   react: () => import('react'),
   'react-dom': () => import('react-dom'),
+  // bundling grafana-ui in plugins requires sharing react-inlinesvg for the icon cache
   'react-inlinesvg': () => import('react-inlinesvg'),
+  'react-redux': () => import('react-redux'),
+  // Migration - React Router v5 -> v6
+  // =================================
+  // Plugins that still use "react-router-dom@v5" don't depend on react-router directly, so they will not use this import.
+  // (The react-router-dom@v5 that we expose for them depends on the "react-router" package internally from core.)
+  //
+  // Plugins that would like update to "react-router-dom@v6" will need to bundle "react-router-dom",
+  // however they cannot bundle "react-router" - this would mean that we have two instances of "react-router"
+  // in the app, which would casue issues. As the "react-router-dom-v5-compat" package re-exports everything from "react-router-dom@v6"
+  // which then re-exports everything from "react-router@v6", we are in the lucky state to be able to expose a compatible v6 version of the router to plugins by
+  // just exposing "react-router-dom-v5-compat".
+  //
+  // (This means that we are exposing two versions of the same package).
   'react-router-dom': () => import('react-router-dom'),
   'react-router': () => import('react-router-dom-v5-compat'),
   redux: () => import('redux'),

--- a/public/app/features/plugins/loader/systemjs.ts
+++ b/public/app/features/plugins/loader/systemjs.ts
@@ -1,6 +1,8 @@
 import 'systemjs/dist/system';
 // Add ability to load plugins bundled as AMD format
 import 'systemjs/dist/extras/amd';
+// Add named register for on demand dependency loading
+import 'systemjs/dist/extras/named-register.js';
 // Add ability to load plugins bundled as CJS format
 import 'systemjs-cjs-extra';
 

--- a/public/app/features/plugins/sandbox/plugin_dependencies.ts
+++ b/public/app/features/plugins/sandbox/plugin_dependencies.ts
@@ -2,4 +2,4 @@
  * Map with all dependencies that are exposed to plugins sandbox
  * e.g.: @grafana/ui, @grafana/data, etc...
  */
-export const sandboxPluginDependencies = new Map<string, System.Module>([]);
+export const sandboxPluginDependencies = new Map<string, System.Module | (() => Promise<System.Module>)>([]);

--- a/public/app/features/plugins/sandbox/sandbox_plugin_loader.ts
+++ b/public/app/features/plugins/sandbox/sandbox_plugin_loader.ts
@@ -162,7 +162,7 @@ async function doImportPluginModuleInSandbox(meta: SandboxPluginMeta): Promise<S
           }
 
           try {
-            const resolvedDeps = resolvePluginDependencies(dependencies, meta);
+            const resolvedDeps = await resolvePluginDependencies(dependencies, meta);
             // execute the plugin's code
             const pluginExportsRaw = factory.apply(null, resolvedDeps);
             // only after the plugin has been executed
@@ -220,7 +220,7 @@ async function doImportPluginModuleInSandbox(meta: SandboxPluginMeta): Promise<S
  * https://github.com/requirejs/requirejs/wiki/Differences-between-the-simplified-CommonJS-wrapper-and-standard-AMD-define#magic
  *
  */
-function resolvePluginDependencies(deps: string[], pluginMeta: SandboxPluginMeta) {
+async function resolvePluginDependencies(deps: string[], pluginMeta: SandboxPluginMeta) {
   const pluginExports = {};
   const pluginModuleDep: ModuleMeta = {
     id: pluginMeta.id,
@@ -232,6 +232,10 @@ function resolvePluginDependencies(deps: string[], pluginMeta: SandboxPluginMeta
   const resolvedDeps: CompartmentDependencyModule[] = [];
   for (const dep of deps) {
     let resolvedDep = sandboxPluginDependencies.get(dep);
+
+    if (typeof resolvedDep === 'function') {
+      resolvedDep = await resolvedDep();
+    }
     if (resolvedDep?.__useDefault) {
       resolvedDep = resolvedDep.default;
     }

--- a/public/views/index.html
+++ b/public/views/index.html
@@ -331,6 +331,7 @@
       nonce="[[$.Nonce]]"
       src="[[$asset.FilePath]]"
       type="text/javascript"
+      defer
     ></script>
     [[end]]
 


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

This PR changes the loading strategy of shared plugin dependencies from "up front" to "on demand".

**Why do we need this feature?**

TLDR; To reduce frontend entry-point bundle sizes. 

Grafana shares some frontend NPM packages with plugins. This is done by importing all these packages in a single file and then passing the contents of those modules to systemjs / fe sandbox. This causes all the shared dependencies to be bundled and served up front regardless of what the Grafana user is actually doing / what plugins are loaded. This PR changes the behaviour so a shared dependency will only load when either Grafana itself or a plugin requires it.

_Webpack build stats for entrypoint_

| | Before | After |
| --- | --- | --- |
| Unminified | 26.8 MiB | 21.3 MiB | 
| Minified | 11 MiB| 8.88MiB |


**Who is this feature for?**

Everybody

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**
I have given this a basic test with SystemJS and the Sandbox enabled and plugins continue to load. Careful attention should be given to the changes in the sharedDependencies map to make sure no dependencies were deleted and that the same `useDefault` flags are set on certain dependencies.

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
