### PR TITLE
Elasticsearch: Queries no longer executed while typing

### DIFF
--- a/public/app/plugins/datasource/elasticsearch/components/QueryEditor/ElasticsearchQueryContext.tsx
+++ b/public/app/plugins/datasource/elasticsearch/components/QueryEditor/ElasticsearchQueryContext.tsx
@@ -31,9 +31,11 @@ export const ElasticsearchProvider = ({
   range,
 }: PropsWithChildren<Props>) => {
   const onStateChange = useCallback(
-    (query: ElasticsearchQuery) => {
+    (query: ElasticsearchQuery, prevQuery: ElasticsearchQuery) => {
       onChange(query);
-      onRunQuery();
+      if (query.query === prevQuery.query) {
+        onRunQuery();
+      }
     },
     [onChange, onRunQuery]
   );
@@ -47,7 +49,7 @@ export const ElasticsearchProvider = ({
 
   const dispatch = useStatelessReducer(
     // timeField is part of the query model, but its value is always set to be the one from datasource settings.
-    (newState) => onStateChange({ ...query, ...newState, timeField: datasource.timeField }),
+    (newState) => onStateChange({ ...query, ...newState, timeField: datasource.timeField }, query),
     query,
     reducer
   );

--- a/public/app/plugins/datasource/elasticsearch/components/QueryEditor/ElasticsearchQueryContext.tsx
+++ b/public/app/plugins/datasource/elasticsearch/components/QueryEditor/ElasticsearchQueryContext.tsx
@@ -33,7 +33,7 @@ export const ElasticsearchProvider = ({
   const onStateChange = useCallback(
     (query: ElasticsearchQuery, prevQuery: ElasticsearchQuery) => {
       onChange(query);
-      if (query.query === prevQuery.query) {
+      if (query.query === prevQuery.query || prevQuery.query === undefined) {
         onRunQuery();
       }
     },


### PR DESCRIPTION
With this change, the query is no longer immediately run while it's being typed. This was a simple way, without a bigger impact, to achieve this result.

**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/grafana/issues/79463

**Special notes for your reviewer:**

Please check that:
- It doesn't break anything.

Demo:

https://github.com/grafana/grafana/assets/1069378/24f719fc-5929-454a-8b1d-aba053b55881

