### PR TITLE
Loki: Kick start your query now applies templates to the current query

### DIFF
--- a/public/app/plugins/datasource/loki/querybuilder/components/QueryPattern.tsx
+++ b/public/app/plugins/datasource/loki/querybuilder/components/QueryPattern.tsx
@@ -68,7 +68,7 @@ export const QueryPattern = (props: Props) => {
                 onPatternSelect(pattern);
               }}
             >
-              Replace query
+              Apply to query
             </Button>
             {hasNewQueryOption && (
               <Button

--- a/public/app/plugins/datasource/loki/querybuilder/components/QueryPatternsModal.test.tsx
+++ b/public/app/plugins/datasource/loki/querybuilder/components/QueryPatternsModal.test.tsx
@@ -133,7 +133,7 @@ describe('QueryPatternsModal', () => {
     expect(screen.getByText(queryPatterns.metricQueryPatterns[0].name)).toBeInTheDocument();
     const firstUseQueryButton = screen.getAllByRole('button', { name: 'Use this query' })[0];
     await userEvent.click(firstUseQueryButton);
-    const createNewQueryButton = screen.getByRole('button', { name: 'Replace query' });
+    const createNewQueryButton = screen.getByRole('button', { name: 'Apply to query' });
     await userEvent.click(createNewQueryButton);
     await waitFor(() => {
       expect(defaultProps.onChange).toHaveBeenCalledWith({

--- a/public/app/plugins/datasource/loki/querybuilder/components/QueryPatternsModal.test.tsx
+++ b/public/app/plugins/datasource/loki/querybuilder/components/QueryPatternsModal.test.tsx
@@ -13,22 +13,24 @@ jest.mock('@grafana/runtime', () => ({
   reportInteraction: jest.fn(),
 }));
 
-const defaultProps = {
-  isOpen: true,
-  onClose: jest.fn(),
-  onChange: jest.fn(),
-  onAddQuery: jest.fn(),
-  query: {
-    refId: 'A',
-    expr: '{label1="foo", label2="bar"} |= "baz" |~ "qux"',
-  },
-  queries: [
-    {
+function getDefaultProps() {
+  return {
+    isOpen: true,
+    onClose: jest.fn(),
+    onChange: jest.fn(),
+    onAddQuery: jest.fn(),
+    query: {
       refId: 'A',
-      expr: '{label1="foo", label2="bar"}',
+      expr: '{label1="foo", label2="bar"} |= "baz" |~ "qux"',
     },
-  ],
-};
+    queries: [
+      {
+        refId: 'A',
+        expr: '{label1="foo", label2="bar"}',
+      },
+    ],
+  };
+}
 
 const queryPatterns = {
   logQueryPatterns: lokiQueryModeller.getQueryPatterns().filter((pattern) => pattern.type === LokiQueryPatternType.Log),
@@ -39,17 +41,17 @@ const queryPatterns = {
 
 describe('QueryPatternsModal', () => {
   it('renders the modal', () => {
-    render(<QueryPatternsModal {...defaultProps} />);
+    render(<QueryPatternsModal {...getDefaultProps()} />);
     expect(screen.getByText('Kick start your query')).toBeInTheDocument();
   });
   it('renders collapsible elements with all query pattern types', () => {
-    render(<QueryPatternsModal {...defaultProps} />);
+    render(<QueryPatternsModal {...getDefaultProps()} />);
     Object.values(LokiQueryPatternType).forEach((pattern) => {
       expect(screen.getByText(new RegExp(`${pattern} query starters`, 'i'))).toBeInTheDocument();
     });
   });
   it('can open and close query patterns section', async () => {
-    render(<QueryPatternsModal {...defaultProps} />);
+    render(<QueryPatternsModal {...getDefaultProps()} />);
     await userEvent.click(screen.getByText('Log query starters'));
     expect(screen.getByText(queryPatterns.logQueryPatterns[0].name)).toBeInTheDocument();
 
@@ -58,7 +60,7 @@ describe('QueryPatternsModal', () => {
   });
 
   it('can open and close multiple query patterns section', async () => {
-    render(<QueryPatternsModal {...defaultProps} />);
+    render(<QueryPatternsModal {...getDefaultProps()} />);
     await userEvent.click(screen.getByText('Log query starters'));
     expect(screen.getByText(queryPatterns.logQueryPatterns[0].name)).toBeInTheDocument();
 
@@ -73,6 +75,7 @@ describe('QueryPatternsModal', () => {
   });
 
   it('uses pattern if there is no existing query', async () => {
+    const defaultProps = getDefaultProps();
     render(<QueryPatternsModal {...defaultProps} query={{ expr: '{job="grafana"}', refId: 'A' }} />);
     await userEvent.click(screen.getByText('Log query starters'));
     expect(screen.getByText(queryPatterns.logQueryPatterns[0].name)).toBeInTheDocument();
@@ -87,7 +90,7 @@ describe('QueryPatternsModal', () => {
   });
 
   it('gives warning when selecting pattern if there is already existing query', async () => {
-    render(<QueryPatternsModal {...defaultProps} />);
+    render(<QueryPatternsModal {...getDefaultProps()} />);
     await userEvent.click(screen.getByText('Log query starters'));
     expect(screen.getByText(queryPatterns.logQueryPatterns[0].name)).toBeInTheDocument();
     const firstUseQueryButton = screen.getAllByRole('button', { name: 'Use this query' })[0];
@@ -96,6 +99,7 @@ describe('QueryPatternsModal', () => {
   });
 
   it('can use create new query when selecting pattern if there is already existing query', async () => {
+    const defaultProps = getDefaultProps();
     render(<QueryPatternsModal {...defaultProps} />);
     await userEvent.click(screen.getByText('Log query starters'));
     expect(screen.getByText(queryPatterns.logQueryPatterns[0].name)).toBeInTheDocument();
@@ -113,12 +117,29 @@ describe('QueryPatternsModal', () => {
   });
 
   it('does not show create new query option if onAddQuery function is not provided ', async () => {
-    render(<QueryPatternsModal {...defaultProps} onAddQuery={undefined} />);
+    render(<QueryPatternsModal {...getDefaultProps()} onAddQuery={undefined} />);
     await userEvent.click(screen.getByText('Log query starters'));
     expect(screen.getByText(queryPatterns.logQueryPatterns[0].name)).toBeInTheDocument();
     const useQueryButton = screen.getAllByRole('button', { name: 'Use this query' })[0];
     await userEvent.click(useQueryButton);
     expect(screen.queryByRole('button', { name: 'Create new query' })).not.toBeInTheDocument();
     expect(screen.getByText(/your current query will be replaced/)).toBeInTheDocument();
+  });
+
+  it('applies a metric query on top of the existing log query', async () => {
+    const defaultProps = getDefaultProps();
+    render(<QueryPatternsModal {...defaultProps} />);
+    await userEvent.click(screen.getByText('Metric query starters'));
+    expect(screen.getByText(queryPatterns.metricQueryPatterns[0].name)).toBeInTheDocument();
+    const firstUseQueryButton = screen.getAllByRole('button', { name: 'Use this query' })[0];
+    await userEvent.click(firstUseQueryButton);
+    const createNewQueryButton = screen.getByRole('button', { name: 'Replace query' });
+    await userEvent.click(createNewQueryButton);
+    await waitFor(() => {
+      expect(defaultProps.onChange).toHaveBeenCalledWith({
+        expr: 'sum(sum_over_time({label1="foo", label2="bar"} |= `baz` |~ `qux` | logfmt | __error__=`` | unwrap  | __error__=`` [$__auto]))',
+        refId: 'A',
+      });
+    });
   });
 });

--- a/public/app/plugins/datasource/loki/querybuilder/components/QueryPatternsModal.tsx
+++ b/public/app/plugins/datasource/loki/querybuilder/components/QueryPatternsModal.tsx
@@ -3,13 +3,13 @@ import { capitalize } from 'lodash';
 import React, { useMemo, useState } from 'react';
 
 import { CoreApp, GrafanaTheme2, getNextRefId } from '@grafana/data';
-import { getOperationDefinitions } from '@grafana/prometheus/src/querybuilder/operations';
 import { reportInteraction } from '@grafana/runtime';
 import { DataQuery } from '@grafana/schema';
 import { Button, Collapse, Modal, useStyles2 } from '@grafana/ui';
 
 import { LokiQuery } from '../../types';
 import { lokiQueryModeller } from '../LokiQueryModeller';
+import { operationDefinitions } from '../operations';
 import { buildVisualQueryFromString } from '../parsing';
 import {
   LokiOperationOrder,
@@ -36,9 +36,9 @@ const keepOperationOrderRanks = [
   LokiOperationOrder.NoErrors,
   LokiOperationOrder.Unwrap,
 ];
-const keepOperations = getOperationDefinitions().filter(
+const keepOperations = operationDefinitions.filter(
   (operation) => operation.orderRank && keepOperationOrderRanks.includes(operation.orderRank)
-);
+).map(operation => operation.id);
 
 export const QueryPatternsModal = (props: Props) => {
   const { isOpen, onClose, onChange, onAddQuery, query, queries, app } = props;

--- a/public/app/plugins/datasource/loki/querybuilder/components/QueryPatternsModal.tsx
+++ b/public/app/plugins/datasource/loki/querybuilder/components/QueryPatternsModal.tsx
@@ -2,9 +2,10 @@ import { css } from '@emotion/css';
 import { capitalize } from 'lodash';
 import React, { useMemo, useState } from 'react';
 
-import { CoreApp, DataQuery, GrafanaTheme2, getNextRefId } from '@grafana/data';
+import { CoreApp, GrafanaTheme2, getNextRefId } from '@grafana/data';
 import { getOperationDefinitions } from '@grafana/prometheus/src/querybuilder/operations';
 import { reportInteraction } from '@grafana/runtime';
+import { DataQuery } from '@grafana/schema';
 import { Button, Collapse, Modal, useStyles2 } from '@grafana/ui';
 
 import { LokiQuery } from '../../types';

--- a/public/app/plugins/datasource/loki/querybuilder/components/QueryPatternsModal.tsx
+++ b/public/app/plugins/datasource/loki/querybuilder/components/QueryPatternsModal.tsx
@@ -11,12 +11,7 @@ import { LokiQuery } from '../../types';
 import { lokiQueryModeller } from '../LokiQueryModeller';
 import { operationDefinitions } from '../operations';
 import { buildVisualQueryFromString } from '../parsing';
-import {
-  LokiOperationOrder,
-  LokiQueryPattern,
-  LokiQueryPatternType,
-  LokiVisualQueryOperationCategory,
-} from '../types';
+import { LokiOperationId, LokiQueryPattern, LokiQueryPatternType, LokiVisualQueryOperationCategory } from '../types';
 
 import { QueryPattern } from './QueryPattern';
 
@@ -35,9 +30,15 @@ const keepOperationCategories: string[] = [
   LokiVisualQueryOperationCategory.LineFilters,
   LokiVisualQueryOperationCategory.LabelFilters,
 ];
-const keepOperations = operationDefinitions.filter(
-  (operation) => operation.category && keepOperationCategories.includes(operation.category)
-).map(operation => operation.id);
+const excludeOperationIds: string[] = [LokiOperationId.Unwrap];
+const keepOperations = operationDefinitions
+  .filter(
+    (operation) =>
+      operation.category &&
+      keepOperationCategories.includes(operation.category) &&
+      !excludeOperationIds.includes(operation.id)
+  )
+  .map((operation) => operation.id);
 
 export const QueryPatternsModal = (props: Props) => {
   const { isOpen, onClose, onChange, onAddQuery, query, queries, app } = props;

--- a/public/app/plugins/datasource/loki/querybuilder/components/QueryPatternsModal.tsx
+++ b/public/app/plugins/datasource/loki/querybuilder/components/QueryPatternsModal.tsx
@@ -15,6 +15,7 @@ import {
   LokiOperationOrder,
   LokiQueryPattern,
   LokiQueryPatternType,
+  LokiVisualQueryOperationCategory,
 } from '../types';
 
 import { QueryPattern } from './QueryPattern';
@@ -29,15 +30,13 @@ type Props = {
   onAddQuery?: (query: LokiQuery) => void;
 };
 
-const keepOperationOrderRanks = [
-  LokiOperationOrder.Parsers,
-  LokiOperationOrder.PipeOperations,
-  LokiOperationOrder.LineFilters,
-  LokiOperationOrder.NoErrors,
-  LokiOperationOrder.Unwrap,
+const keepOperationCategories: string[] = [
+  LokiVisualQueryOperationCategory.Formats,
+  LokiVisualQueryOperationCategory.LineFilters,
+  LokiVisualQueryOperationCategory.LabelFilters,
 ];
 const keepOperations = operationDefinitions.filter(
-  (operation) => operation.orderRank && keepOperationOrderRanks.includes(operation.orderRank)
+  (operation) => operation.category && keepOperationCategories.includes(operation.category)
 ).map(operation => operation.id);
 
 export const QueryPatternsModal = (props: Props) => {


### PR DESCRIPTION
This PR changes kick start your query to support keeping some of the pipe operations in the original query when the user chooses to replace the current query with a pattern.

To achieve that:

- We added a list of operations to keep.
- Then filter the operations in the original query using this list.
- Then filter operations in the pattern that are already present in the original query*
- Finally we merge the operations in the original query with those in the selected pattern.

* This extra change was to prevent producing queries with, for example, empty line filters (when there was previously another line filter), duplicated parsers, etc.

Work in combination with logs or metrics patterns.

**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/grafana/issues/76207

**Special notes for your reviewer:**

Demo:

https://github.com/grafana/grafana/assets/1069378/958e3464-586d-46b6-a4c0-154ac1b9af17


