### PR TITLE
Graphite: Fix alignment of elements in the query editor

### DIFF
--- a/public/app/plugins/datasource/graphite/components/AddGraphiteFunction.tsx
+++ b/public/app/plugins/datasource/graphite/components/AddGraphiteFunction.tsx
@@ -35,12 +35,16 @@ export function AddGraphiteFunction({ funcDefs }: Props) {
   }, [value, dispatch]);
 
   return (
-    <Segment
-      Component={<Button icon="plus" variant="secondary" className={cx(styles.button)} aria-label="Add new function" />}
-      options={options}
-      onChange={setValue}
-      inputMinWidth={150}
-    />
+    <div>
+      <Segment
+        Component={
+          <Button icon="plus" variant="secondary" className={cx(styles.button)} aria-label="Add new function" />
+        }
+        options={options}
+        onChange={setValue}
+        inputMinWidth={150}
+      />
+    </div>
   );
 }
 

--- a/public/app/plugins/datasource/graphite/components/MetricsSection.tsx
+++ b/public/app/plugins/datasource/graphite/components/MetricsSection.tsx
@@ -12,10 +12,10 @@ type Props = {
 
 export function MetricsSection({ segments = [], state }: Props) {
   return (
-    <>
+    <div>
       {segments.map((segment, index) => {
         return <MetricSegment segment={segment} metricIndex={index} key={index} state={state} />;
       })}
-    </>
+    </div>
   );
 }

--- a/public/app/plugins/datasource/graphite/components/TagsSection.tsx
+++ b/public/app/plugins/datasource/graphite/components/TagsSection.tsx
@@ -44,7 +44,7 @@ export function TagsSection({ tags, state }: Props) {
   );
 
   return (
-    <>
+    <div>
       {tags.map((tag, index) => {
         return <TagEditor key={index} tagIndex={index} tag={tag} state={state} />;
       })}
@@ -60,7 +60,7 @@ export function TagsSection({ tags, state }: Props) {
         />
       )}
       {state.paused && <PlayButton />}
-    </>
+    </div>
   );
 }
 


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

## What is this change?

A few markup changes (adding missing divs) in the Graphite query editor.

## Why do we need this change?

To fix layout issues described in #87657.

## Who is this change for?

Graphite data source users.

## Which issue(s) does this PR fix?

This PR fixes #87657.

## Demo

Note how the elements in both of the query editor's rows are vertically aligned, in contrast with the screenshot provided in #87657.

https://github.com/grafana/grafana/assets/5732000/1ca75d7b-67a0-4eba-8380-56379c282e37

## Special notes for your reviewer

None

## Please check that
- [x] It works as expected from a user's perspective.
- [x] `(Not applicable)` If this is a pre-GA feature, it is behind a feature toggle.
- [x] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
