### PR TITLE
Chore: Update XY Chart gdev dashboard

### DIFF
--- a/devenv/dev-dashboards/panel-xychart/xychart-example.json
+++ b/devenv/dev-dashboards/panel-xychart/xychart-example.json
@@ -578,6 +578,15 @@
           },
           "refId": "A",
           "scenarioId": "csv_file"
+        },
+        {
+          "scenarioId": "csv_content",
+          "refId": "B",
+          "datasource": {
+            "uid": "PD8C576611E62080A",
+            "type": "grafana-testdata-datasource"
+          },
+          "csvContent": "x, y, size\n36,-60,88\n38,-120,50\n46,-140,112\n50,-90,123\n54,-120,18"
         }
       ],
       "title": "Bubble Charts",


### PR DESCRIPTION
PR adds a new dataset to `Bubble Charts` panel.

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
