### PR TITLE
[v.10.2.x] Explore: lookup datasource by name when present in legacy URLs

### DIFF
--- a/public/app/features/explore/hooks/useStateSync/index.test.tsx
+++ b/public/app/features/explore/hooks/useStateSync/index.test.tsx
@@ -138,7 +138,14 @@ describe('useStateSync', () => {
     const { location, waitForNextUpdate, store } = setup({
       queryParams: {
         panes: JSON.stringify({
-          one: { datasource: 'loki-uid', queries: [{ datasource: { name: 'loki', uid: 'loki-uid' }, refId: '1+2' }] },
+          one: {
+            datasource: 'loki-uid',
+            queries: [
+              { datasource: { name: 'loki', uid: 'loki-uid' }, refId: '1+2' },
+              { datasource: 'loki-uid', refId: '3' },
+              { datasource: 'loki', refId: '4' },
+            ],
+          },
           two: { datasource: 'elastic-uid', queries: [{ datasource: { name: 'elastic', uid: 'elastic-uid' } }] },
         }),
         schemaVersion: 1,
@@ -182,9 +189,16 @@ describe('useStateSync', () => {
     if (panes) {
       // check if the URL is properly encoded when finishing rendering the hook. (this would be '1 2' otherwise)
       expect(JSON.parse(panes)['one'].queries[0].refId).toBe('1+2');
+      expect(JSON.parse(panes)['one'].queries[0].datasource?.uid).toBe('loki-uid');
 
       // we expect panes in the state to be in the same order as the ones in the URL
       expect(Object.keys(store.getState().explore.panes)).toStrictEqual(Object.keys(JSON.parse(panes)));
+
+      // check that the datasources for the queries resolved correctly when set to a name or uid
+      expect(JSON.parse(panes)['one'].queries[1].refId).toBe('3');
+      expect(JSON.parse(panes)['one'].queries[1].datasource?.uid).toBe('loki-uid');
+      expect(JSON.parse(panes)['one'].queries[2].refId).toBe('4');
+      expect(JSON.parse(panes)['one'].queries[2].datasource?.uid).toBe('loki-uid');
     }
   });
 

--- a/public/app/features/explore/hooks/useStateSync/index.ts
+++ b/public/app/features/explore/hooks/useStateSync/index.ts
@@ -306,7 +306,7 @@ function getQueryFilter(datasource?: DataSourceApi) {
       }
       // Due to legacy URLs, `datasource` in queries may be a string. This logic should probably be in the migration
       if (typeof q.datasource === 'string') {
-        return q.datasource === datasource?.uid;
+        return q.datasource === datasource?.uid || q.datasource === datasource?.name;
       }
 
       return q.datasource.uid === datasource?.uid;


### PR DESCRIPTION
Backport 867d36fe59437063a from #85222

---

<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

This adds another check when loading legacy compact URLs so that their datasources are resolved correctly.

**Why do we need this feature?**

It appears that in older versions of Grafana, certain explore URLs in the "compact" format could have their datasource set on non-mixed queries using the name of the datasource. Prior to https://github.com/grafana/grafana/pull/66286 (up to v10.0.x), these were handled correctly because explore would take no action on modifying the queries [unless their datasource fields were not all the same](https://github.com/grafana/grafana/blob/838cbf22da1a8df9d3a7ba3aa6a44d362dc3f4ac/public/app/features/explore/ExplorePaneContainer.tsx#L103-L107). Even if they were not, it would choose the datasource as set on the first query but retain the others to be treated as imported queries.

In Grafana 10.1.X this behavior changed to remove all queries whose `datasource` field was set and not equal to that of the root value. In particular, [the code assumes that if the field is set to a string then it is the datasource UID](https://github.com/grafana/grafana/blob/v10.2.5/public/app/features/explore/hooks/useStateSync/index.ts#L307-L310). Since it is instead the name in these URLs, the queries are removed by the filter.

By modifying the filter to allow the name these URLs work again correctly in the latest version of Grafana. Since the decision was made to continue supporting legacy URLs, it seems appropriate to fix this.

**Who is this feature for?**

This is likely most useful for long term users of Grafana who may have older explore URLs sprinkled in docs, code comments, or other tooling.

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle.
- [x] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
