### PR TITLE
Prometheus: Fix quote stripping in parser

### DIFF
--- a/packages/grafana-prometheus/src/querybuilder/parsing.test.ts
+++ b/packages/grafana-prometheus/src/querybuilder/parsing.test.ts
@@ -748,7 +748,7 @@ describe('buildVisualQueryFromString', () => {
   });
 
   it('strips enclosing quotes', () => {
-    expect(buildVisualQueryFromString('counters_logins{app=\'frontend\', host=`localhost`}')).toEqual(
+    expect(buildVisualQueryFromString("counters_logins{app='frontend', host=`localhost`}")).toEqual(
       noErrors({
         metric: 'counters_logins',
         labels: [
@@ -760,8 +760,8 @@ describe('buildVisualQueryFromString', () => {
           {
             op: '=',
             value: 'localhost',
-            label: 'host'
-          }
+            label: 'host',
+          },
         ],
         operations: [],
       })
@@ -769,13 +769,13 @@ describe('buildVisualQueryFromString', () => {
   });
 
   it('leaves escaped quotes inside string', () => {
-    expect(buildVisualQueryFromString('counters_logins{app="fron\"\"tend"}')).toEqual(
+    expect(buildVisualQueryFromString('counters_logins{app="fron\\"\\"tend"}')).toEqual(
       noErrors({
         metric: 'counters_logins',
         labels: [
           {
             op: '=',
-            value: 'fron\"\"tend',
+            value: 'fron\\"\\"tend',
             label: 'app',
           },
         ],

--- a/packages/grafana-prometheus/src/querybuilder/parsing.test.ts
+++ b/packages/grafana-prometheus/src/querybuilder/parsing.test.ts
@@ -746,6 +746,43 @@ describe('buildVisualQueryFromString', () => {
       },
     });
   });
+
+  it('strips enclosing quotes', () => {
+    expect(buildVisualQueryFromString('counters_logins{app=\'frontend\', host=`localhost`}')).toEqual(
+      noErrors({
+        metric: 'counters_logins',
+        labels: [
+          {
+            op: '=',
+            value: 'frontend',
+            label: 'app',
+          },
+          {
+            op: '=',
+            value: 'localhost',
+            label: 'host'
+          }
+        ],
+        operations: [],
+      })
+    );
+  });
+
+  it('leaves escaped quotes inside string', () => {
+    expect(buildVisualQueryFromString('counters_logins{app="fron\"\"tend"}')).toEqual(
+      noErrors({
+        metric: 'counters_logins',
+        labels: [
+          {
+            op: '=',
+            value: 'fron\"\"tend',
+            label: 'app',
+          },
+        ],
+        operations: [],
+      })
+    );
+  });
 });
 
 function noErrors(query: PromVisualQuery) {

--- a/packages/grafana-prometheus/src/querybuilder/parsing.ts
+++ b/packages/grafana-prometheus/src/querybuilder/parsing.ts
@@ -205,7 +205,7 @@ function isIntervalVariableError(node: SyntaxNode) {
 function getLabel(expr: string, node: SyntaxNode): QueryBuilderLabelFilter {
   const label = getString(expr, node.getChild(LabelName));
   const op = getString(expr, node.getChild(MatchOp));
-  const value = getString(expr, node.getChild(StringLiteral)).replace(/"/g, '');
+  const value = getString(expr, node.getChild(StringLiteral)).replace(/^["'`]|["'`]$/g, '');
   return {
     label,
     op,


### PR DESCRIPTION
Currently only double quotes are stripped from the end, while other quotes are left in. And quotes are stripped even when part of the value. This PR makes it so all [quotes used in PromQL](https://prometheus.io/docs/prometheus/latest/querying/basics/#string-literals) are stripped from beginning/end and also not removed from the value

### Before
![image](https://github.com/grafana/grafana/assets/19339842/9d1d9b5b-1b1f-4587-990e-3dc53abcedbb)
Extra quotes are added for instance, and the escaped quote is removed from job

### After
![image](https://github.com/grafana/grafana/assets/19339842/7d63514f-1fd7-4628-b2f5-b676015f5848)

<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

Very minor fix but its be subtly annoying me 😅