### PR TITLE
Elasticsearch: Fix setting of default maxConcurrentShardRequests

### DIFF
--- a/pkg/tsdb/elasticsearch/client/client.go
+++ b/pkg/tsdb/elasticsearch/client/client.go
@@ -254,12 +254,7 @@ func (c *baseClientImpl) createMultiSearchRequests(searchRequests []*SearchReque
 
 func (c *baseClientImpl) getMultiSearchQueryParameters() string {
 	var qs []string
-
-	maxConcurrentShardRequests := c.ds.MaxConcurrentShardRequests
-	if maxConcurrentShardRequests == 0 {
-		maxConcurrentShardRequests = 5
-	}
-	qs = append(qs, fmt.Sprintf("max_concurrent_shard_requests=%d", maxConcurrentShardRequests))
+	qs = append(qs, fmt.Sprintf("max_concurrent_shard_requests=%d", c.ds.MaxConcurrentShardRequests))
 
 	if c.ds.IncludeFrozen {
 		qs = append(qs, "ignore_throttled=false")

--- a/pkg/tsdb/elasticsearch/elasticsearch.go
+++ b/pkg/tsdb/elasticsearch/elasticsearch.go
@@ -32,8 +32,9 @@ var eslog = log.New("tsdb.elasticsearch")
 const (
 	// headerFromExpression is used by data sources to identify expression queries
 	headerFromExpression = "X-Grafana-From-Expr"
-	// headerFromAlert is used by datasources to identify alert queries
-	headerFromAlert                   = "FromAlert"
+	// headerFromAlert is used by data sources to identify alert queries
+	headerFromAlert = "FromAlert"
+	// this is the default value for the maxConcurrentShardRequests setting - it should be in sync with the default value in the datasource config settings
 	defaultMaxConcurrentShardRequests = int64(5)
 )
 

--- a/pkg/tsdb/elasticsearch/elasticsearch_test.go
+++ b/pkg/tsdb/elasticsearch/elasticsearch_test.go
@@ -157,6 +157,23 @@ func TestNewInstanceSettings(t *testing.T) {
 			require.NoError(t, err)
 		})
 
+		t.Run("float maxConcurrentShardRequests", func(t *testing.T) {
+			dsInfo := datasourceInfo{
+				TimeField:                  "@timestamp",
+				MaxConcurrentShardRequests: 10.5,
+			}
+			settingsJSON, err := json.Marshal(dsInfo)
+			require.NoError(t, err)
+
+			dsSettings := backend.DataSourceInstanceSettings{
+				JSONData: json.RawMessage(settingsJSON),
+			}
+
+			instance, err := newInstanceSettings(httpclient.NewProvider())(context.Background(), dsSettings)
+			require.Equal(t, int64(10), instance.(es.DatasourceInfo).MaxConcurrentShardRequests)
+			require.NoError(t, err)
+		})
+
 		t.Run("invalid maxConcurrentShardRequests", func(t *testing.T) {
 			dsInfo := datasourceInfo{
 				TimeField:                  "@timestamp",

--- a/pkg/tsdb/elasticsearch/elasticsearch_test.go
+++ b/pkg/tsdb/elasticsearch/elasticsearch_test.go
@@ -14,7 +14,7 @@ import (
 
 type datasourceInfo struct {
 	TimeField                  any    `json:"timeField"`
-	MaxConcurrentShardRequests int64  `json:"maxConcurrentShardRequests"`
+	MaxConcurrentShardRequests any    `json:"maxConcurrentShardRequests,omitempty"`
 	Interval                   string `json:"interval"`
 }
 
@@ -69,6 +69,109 @@ func TestNewInstanceSettings(t *testing.T) {
 
 			_, err = newInstanceSettings(httpclient.NewProvider())(context.Background(), dsSettings)
 			require.EqualError(t, err, "elasticsearch time field name is required")
+		})
+	})
+
+	t.Run("maxConcurrentShardRequests", func(t *testing.T) {
+		t.Run("no maxConcurrentShardRequests", func(t *testing.T) {
+			dsInfo := datasourceInfo{
+				TimeField: "@timestamp",
+			}
+			settingsJSON, err := json.Marshal(dsInfo)
+			require.NoError(t, err)
+
+			dsSettings := backend.DataSourceInstanceSettings{
+				JSONData: json.RawMessage(settingsJSON),
+			}
+
+			instance, err := newInstanceSettings(httpclient.NewProvider())(context.Background(), dsSettings)
+			require.Equal(t, defaultMaxConcurrentShardRequests, instance.(es.DatasourceInfo).MaxConcurrentShardRequests)
+			require.NoError(t, err)
+		})
+
+		t.Run("string maxConcurrentShardRequests", func(t *testing.T) {
+			dsInfo := datasourceInfo{
+				TimeField:                  "@timestamp",
+				MaxConcurrentShardRequests: "10",
+			}
+			settingsJSON, err := json.Marshal(dsInfo)
+			require.NoError(t, err)
+
+			dsSettings := backend.DataSourceInstanceSettings{
+				JSONData: json.RawMessage(settingsJSON),
+			}
+
+			instance, err := newInstanceSettings(httpclient.NewProvider())(context.Background(), dsSettings)
+			require.Equal(t, int64(10), instance.(es.DatasourceInfo).MaxConcurrentShardRequests)
+			require.NoError(t, err)
+		})
+
+		t.Run("number maxConcurrentShardRequests", func(t *testing.T) {
+			dsInfo := datasourceInfo{
+				TimeField:                  "@timestamp",
+				MaxConcurrentShardRequests: 10,
+			}
+			settingsJSON, err := json.Marshal(dsInfo)
+			require.NoError(t, err)
+
+			dsSettings := backend.DataSourceInstanceSettings{
+				JSONData: json.RawMessage(settingsJSON),
+			}
+
+			instance, err := newInstanceSettings(httpclient.NewProvider())(context.Background(), dsSettings)
+			require.Equal(t, int64(10), instance.(es.DatasourceInfo).MaxConcurrentShardRequests)
+			require.NoError(t, err)
+		})
+
+		t.Run("zero maxConcurrentShardRequests", func(t *testing.T) {
+			dsInfo := datasourceInfo{
+				TimeField:                  "@timestamp",
+				MaxConcurrentShardRequests: 0,
+			}
+			settingsJSON, err := json.Marshal(dsInfo)
+			require.NoError(t, err)
+
+			dsSettings := backend.DataSourceInstanceSettings{
+				JSONData: json.RawMessage(settingsJSON),
+			}
+
+			instance, err := newInstanceSettings(httpclient.NewProvider())(context.Background(), dsSettings)
+			require.Equal(t, defaultMaxConcurrentShardRequests, instance.(es.DatasourceInfo).MaxConcurrentShardRequests)
+			require.NoError(t, err)
+		})
+
+		t.Run("negative maxConcurrentShardRequests", func(t *testing.T) {
+			dsInfo := datasourceInfo{
+				TimeField:                  "@timestamp",
+				MaxConcurrentShardRequests: -10,
+			}
+			settingsJSON, err := json.Marshal(dsInfo)
+			require.NoError(t, err)
+
+			dsSettings := backend.DataSourceInstanceSettings{
+				JSONData: json.RawMessage(settingsJSON),
+			}
+
+			instance, err := newInstanceSettings(httpclient.NewProvider())(context.Background(), dsSettings)
+			require.Equal(t, defaultMaxConcurrentShardRequests, instance.(es.DatasourceInfo).MaxConcurrentShardRequests)
+			require.NoError(t, err)
+		})
+
+		t.Run("invalid maxConcurrentShardRequests", func(t *testing.T) {
+			dsInfo := datasourceInfo{
+				TimeField:                  "@timestamp",
+				MaxConcurrentShardRequests: "invalid",
+			}
+			settingsJSON, err := json.Marshal(dsInfo)
+			require.NoError(t, err)
+
+			dsSettings := backend.DataSourceInstanceSettings{
+				JSONData: json.RawMessage(settingsJSON),
+			}
+
+			instance, err := newInstanceSettings(httpclient.NewProvider())(context.Background(), dsSettings)
+			require.Equal(t, defaultMaxConcurrentShardRequests, instance.(es.DatasourceInfo).MaxConcurrentShardRequests)
+			require.NoError(t, err)
 		})
 	})
 }


### PR DESCRIPTION
This PR fixes setting a correct default value of maxConcurrentShardRequests in Elasticsearch queries to 5. While in frontend, we always default to 5, backend wasn't updated. 

https://github.com/grafana/grafana/blob/main/public/app/plugins/datasource/elasticsearch/configuration/ElasticDetails.tsx#L209

This PR fixes it and adds tests. 

Related to https://github.com/grafana/grafana/issues/83279
Related to https://github.com/grafana/grafana/issues/78122
