### PR TITLE
Dashboards: Don't set dashboard creator/updater if the action is done by an API key

### DIFF
--- a/pkg/services/dashboards/service/dashboard_service.go
+++ b/pkg/services/dashboards/service/dashboard_service.go
@@ -236,13 +236,14 @@ func resolveUserID(user identity.Requester, log log.Logger) (int64, error) {
 	namespaceID, identifier := user.GetNamespacedID()
 	if namespaceID != identity.NamespaceUser && namespaceID != identity.NamespaceServiceAccount {
 		log.Debug("User does not belong to a user or service account namespace", "namespaceID", namespaceID, "userID", identifier)
+	} else {
+		var err error
+		userID, err = identity.IntIdentifier(namespaceID, identifier)
+		if err != nil {
+			log.Debug("failed to parse user ID", "namespaceID", namespaceID, "userID", identifier, "error", err)
+		}
 	}
 
-	userID, err := identity.IntIdentifier(namespaceID, identifier)
-
-	if err != nil {
-		log.Debug("failed to parse user ID", "namespaceID", namespaceID, "userID", identifier, "error", err)
-	}
 	return userID, nil
 }
 


### PR DESCRIPTION
**What is this feature?**

Do not set dashboard creator and updater if the creation/update was done by an API key. 

**Why do we need this feature?**

Previously we were wrongly resolving creator/updater ID, so the wrong entity was displayed as dashboard creator/updater. Now we do not display this information at all if creation/update is done by an API key.

**Who is this feature for?**

Anyone provisioning dashboards with API keys

**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/grafana-private-mirror/issues/1206

**Special notes for your reviewer:**

Note that API keys are deprecated and the best fix is to just use service accounts.

Also note that correctly displaying info about API key that created/updated a dashboard would be a lot of effort, and I don't think it's worth it, as API keys shouldn't be used anymore anyway.