### PR TITLE
InfluxDB: Update alias regex pattern

### DIFF
--- a/pkg/tsdb/influxdb/influxql/util/util.go
+++ b/pkg/tsdb/influxdb/influxql/util/util.go
@@ -15,7 +15,8 @@ import (
 )
 
 var (
-	legendFormat = regexp.MustCompile(`\[\[([\@\/\w-]+)(\.[\@\/\w-]+)*\]\]*|\$([\@\w]+?)*`)
+	// legendFormat = regexp.MustCompile(`\[\[([\@\/\w-]+)(\.[\@\/\w-]+)*\]\]*|\$([\@\w]+?)*`)
+	legendFormat = regexp.MustCompile(`\$(\w+)|\[\[([\s\S]+?)\]\]`)
 )
 
 const (

--- a/pkg/tsdb/influxdb/influxql/util/util.go
+++ b/pkg/tsdb/influxdb/influxql/util/util.go
@@ -15,7 +15,6 @@ import (
 )
 
 var (
-	// legendFormat = regexp.MustCompile(`\[\[([\@\/\w-]+)(\.[\@\/\w-]+)*\]\]*|\$([\@\w]+?)*`)
 	legendFormat = regexp.MustCompile(`\$(\w+)|\[\[([\s\S]+?)\]\]`)
 )
 

--- a/pkg/tsdb/influxdb/influxql/util/util_test.go
+++ b/pkg/tsdb/influxdb/influxql/util/util_test.go
@@ -43,6 +43,7 @@ func TestFormatFrameName(t *testing.T) {
 		{name: "[[col]] column alias", rowName: "rowName", column: "colName", tags: map[string]string{"key": "value"}, query: models.Query{Alias: "[[col]]", ResultFormat: "time_series"}, expected: "colName"},
 		{name: "$col column alias", rowName: "rowName", column: "colName", tags: map[string]string{"key": "value"}, query: models.Query{Alias: "$col", ResultFormat: "time_series"}, expected: "colName"},
 		{name: "[[tag_key]] tag alias", rowName: "rowName", column: "colName", tags: map[string]string{"key": "value"}, query: models.Query{Alias: "[[tag_key]]", ResultFormat: "time_series"}, expected: "value"},
+		{name: "[[tag_key]] tag alias with space in tag", rowName: "rowName", column: "colName", tags: map[string]string{"ke y": "value"}, query: models.Query{Alias: "[[tag_ke y]]", ResultFormat: "time_series"}, expected: "value"},
 		{name: "$tag_key tag alias", rowName: "rowName", column: "colName", tags: map[string]string{"key": "value"}, query: models.Query{Alias: "$tag_key", ResultFormat: "time_series"}, expected: "value"},
 		{name: "[[m]] with additional text", rowName: "rowName", column: "colName", tags: map[string]string{"key": "value"}, query: models.Query{Alias: "[[m]] - something", ResultFormat: "time_series"}, expected: "rowName - something"},
 		{name: "$m with additional text", rowName: "rowName", column: "colName", tags: map[string]string{"key": "value"}, query: models.Query{Alias: "$m - something", ResultFormat: "time_series"}, expected: "rowName - something"},


### PR DESCRIPTION
**What is this feature?**

Update the regex pattern with the one [we used for frontend mode](https://github.com/grafana/grafana/blob/0823672fce683992d2af5b58a2969f47aa7cfbd2/public/app/plugins/datasource/influxdb/influx_series.ts#L70).

**Why do we need this feature?**

Better alias interpolation

**Who is this feature for?**

Influxql Users

**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/grafana/issues/84795

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
