### PR TITLE
Also call storage on mode1. Measure latency

### DIFF
--- a/pkg/apiserver/rest/dualwriter_mode1.go
+++ b/pkg/apiserver/rest/dualwriter_mode1.go
@@ -129,17 +129,17 @@ func (d *DualWriterMode1) Delete(ctx context.Context, name string, deleteValidat
 	res, async, err := d.Legacy.Delete(ctx, name, deleteValidation, options)
 	if err != nil {
 		log.Error(err, "unable to delete object in legacy storage")
-		d.recordLegacyDuration(true, mode1Str, name, method, startLegacy)
+		d.recordLegacyDuration(true, mode1Str, options.Kind, method, startLegacy)
 		return res, async, err
 	}
-	d.recordLegacyDuration(false, mode1Str, name, method, startLegacy)
+	d.recordLegacyDuration(false, mode1Str, options.Kind, method, startLegacy)
 
 	go func() {
 		startStorage := time.Now()
 		ctx, cancel := context.WithTimeoutCause(ctx, time.Second*10, errors.New("storage delete timeout"))
 		defer cancel()
 		_, _, err := d.Storage.Delete(ctx, name, deleteValidation, options)
-		d.recordStorageDuration(err != nil, mode1Str, name, method, startStorage)
+		d.recordStorageDuration(err != nil, mode1Str, options.Kind, method, startStorage)
 	}()
 
 	return res, async, err

--- a/pkg/apiserver/rest/dualwriter_mode1.go
+++ b/pkg/apiserver/rest/dualwriter_mode1.go
@@ -185,19 +185,14 @@ func (d *DualWriterMode1) Update(ctx context.Context, name string, objInfo rest.
 	}
 
 	// get the object to be updated
-	old, err := d.Storage.Get(ctx, name, &metav1.GetOptions{})
+	foundObj, err := d.Storage.Get(ctx, name, &metav1.GetOptions{})
 	if err != nil {
-		log.WithValues("object", old).Error(err, "could not get object to update")
+		log.WithValues("object", foundObj).Error(err, "could not get object to update")
 	}
 
 	// if the object is found, create a new updateWrapper with the object found
-	if old != nil {
-		objInfo = &updateWrapper{
-			upstream: objInfo,
-			updated:  old,
-		}
-
-		accessorOld, err := meta.Accessor(old)
+	if foundObj != nil {
+		accessorOld, err := meta.Accessor(foundObj)
 		if err != nil {
 			log.Error(err, "unable to get accessor for original updated object")
 		}

--- a/pkg/apiserver/rest/dualwriter_mode1.go
+++ b/pkg/apiserver/rest/dualwriter_mode1.go
@@ -35,7 +35,7 @@ func (d *DualWriterMode1) Create(ctx context.Context, obj runtime.Object, create
 	var method = "create"
 
 	startStorage := time.Now().UTC()
-	objStorage, err := d.Storage.Create(ctx, obj, createValidation, options)
+	_, err := d.Storage.Create(ctx, obj, createValidation, options)
 	d.recordStorageDuration(err != nil, mode, options.Kind, method, startStorage)
 
 	startLegacy := time.Now().UTC()
@@ -47,13 +47,6 @@ func (d *DualWriterMode1) Create(ctx context.Context, obj runtime.Object, create
 	}
 	d.recordLegacyDuration(false, mode, options.Kind, method, startLegacy)
 
-	areSame, err := compareResourceVersion(objStorage, res)
-	if err != nil {
-		// only log error but don't return error so we keep the same behavior as before
-		klog.Error(err, "unable to compare resource versions")
-	}
-
-	d.recordOutcome(mode, options.Kind, areSame, method)
 	return res, err
 }
 
@@ -63,7 +56,7 @@ func (d *DualWriterMode1) Get(ctx context.Context, name string, options *metav1.
 	var method = "get"
 
 	startStorage := time.Now().UTC()
-	objStorage, err := d.Storage.Get(ctx, name, options)
+	_, err := d.Storage.Get(ctx, name, options)
 	d.recordStorageDuration(err != nil, mode, name, method, startStorage)
 
 	startLegacy := time.Now().UTC()
@@ -75,13 +68,6 @@ func (d *DualWriterMode1) Get(ctx context.Context, name string, options *metav1.
 	}
 	d.recordLegacyDuration(false, mode, name, method, startLegacy)
 
-	areSame, err := compareResourceVersion(objStorage, res)
-	if err != nil {
-		// only log error but don't return error so we keep the same behavior as before
-		klog.Error(err, "unable to compare resource versions")
-	}
-
-	d.recordOutcome(mode, name, areSame, method)
 	return res, err
 }
 
@@ -91,7 +77,7 @@ func (d *DualWriterMode1) List(ctx context.Context, options *metainternalversion
 	var method = "list"
 
 	startStorage := time.Now().UTC()
-	objStorage, err := d.Storage.List(ctx, options)
+	_, err := d.Storage.List(ctx, options)
 	d.recordStorageDuration(err != nil, mode, options.Kind, method, startStorage)
 
 	startLegacy := time.Now().UTC()
@@ -103,13 +89,6 @@ func (d *DualWriterMode1) List(ctx context.Context, options *metainternalversion
 	}
 	d.recordLegacyDuration(false, mode, options.Kind, method, startLegacy)
 
-	areSame, err := compareResourceVersion(objStorage, res)
-	if err != nil {
-		// only log error but don't return error so we keep the same behavior as before
-		klog.Error(err, "unable to compare resource versions")
-	}
-
-	d.recordOutcome(mode, options.Kind, areSame, method)
 	return res, err
 }
 
@@ -118,7 +97,7 @@ func (d *DualWriterMode1) Delete(ctx context.Context, name string, deleteValidat
 	var method = "delete"
 
 	startStorage := time.Now().UTC()
-	objStorage, _, err := d.Storage.Delete(ctx, name, deleteValidation, options)
+	_, _, err := d.Storage.Delete(ctx, name, deleteValidation, options)
 	d.recordStorageDuration(err != nil, mode, name, method, startStorage)
 
 	startLegacy := time.Now().UTC()
@@ -130,13 +109,6 @@ func (d *DualWriterMode1) Delete(ctx context.Context, name string, deleteValidat
 	}
 	d.recordLegacyDuration(false, mode, name, method, startLegacy)
 
-	areSame, err := compareResourceVersion(objStorage, res)
-	if err != nil {
-		// only log error but don't return error so we keep the same behavior as before
-		klog.Error(err, "unable to compare resource versions")
-	}
-
-	d.recordOutcome(mode, name, areSame, method)
 	return res, async, err
 }
 
@@ -146,7 +118,7 @@ func (d *DualWriterMode1) DeleteCollection(ctx context.Context, deleteValidation
 	var method = "delete-collection"
 
 	startStorage := time.Now().UTC()
-	objStorage, err := d.Storage.DeleteCollection(ctx, deleteValidation, options, listOptions)
+	_, err := d.Storage.DeleteCollection(ctx, deleteValidation, options, listOptions)
 	d.recordStorageDuration(err != nil, mode, options.Kind, method, startStorage)
 
 	startLegacy := time.Now().UTC()
@@ -157,13 +129,6 @@ func (d *DualWriterMode1) DeleteCollection(ctx context.Context, deleteValidation
 	}
 	d.recordLegacyDuration(false, mode, options.Kind, method, startLegacy)
 
-	areSame, err := compareResourceVersion(objStorage, res)
-	if err != nil {
-		// only log error but don't return error so we keep the same behavior as before
-		klog.Error(err, "unable to compare resource versions")
-	}
-
-	d.recordOutcome(mode, options.Kind, areSame, method)
 	return res, err
 }
 
@@ -172,7 +137,7 @@ func (d *DualWriterMode1) Update(ctx context.Context, name string, objInfo rest.
 	var method = "update"
 
 	startStorage := time.Now().UTC()
-	objStorage, _, err := d.Storage.Update(ctx, name, objInfo, createValidation, updateValidation, forceAllowCreate, options)
+	_, _, err := d.Storage.Update(ctx, name, objInfo, createValidation, updateValidation, forceAllowCreate, options)
 	d.recordStorageDuration(err != nil, mode, name, method, startStorage)
 
 	startLegacy := time.Now().UTC()
@@ -183,13 +148,6 @@ func (d *DualWriterMode1) Update(ctx context.Context, name string, objInfo rest.
 	}
 	d.recordLegacyDuration(false, mode, name, method, startLegacy)
 
-	areSame, err := compareResourceVersion(objStorage, res)
-	if err != nil {
-		// only log error but don't return error so we keep the same behavior as before
-		klog.Error(err, "unable to compare resource versions")
-	}
-
-	d.recordOutcome(mode, name, areSame, method)
 	return res, async, err
 }
 

--- a/pkg/apiserver/rest/dualwriter_mode1.go
+++ b/pkg/apiserver/rest/dualwriter_mode1.go
@@ -62,7 +62,7 @@ func (d *DualWriterMode1) Create(ctx context.Context, obj runtime.Object, create
 		startStorage := time.Now().UTC()
 		ctx, _ := context.WithTimeoutCause(ctx, time.Second*10, errors.New("storage create timeout"))
 		_, err := d.Storage.Create(ctx, obj, createValidation, options)
-		defer d.recordStorageDuration(err != nil, mode, options.Kind, method, startStorage)
+		d.recordStorageDuration(err != nil, mode, options.Kind, method, startStorage)
 	}()
 
 	return res, errLegacy
@@ -86,7 +86,7 @@ func (d *DualWriterMode1) Get(ctx context.Context, name string, options *metav1.
 		startStorage := time.Now().UTC()
 		ctx, _ := context.WithTimeoutCause(ctx, time.Second*10, errors.New("storage get timeout"))
 		_, err := d.Storage.Get(ctx, name, options)
-		defer d.recordStorageDuration(err != nil, mode, name, method, startStorage)
+		d.recordStorageDuration(err != nil, mode, name, method, startStorage)
 	}()
 
 	return res, errLegacy
@@ -110,7 +110,7 @@ func (d *DualWriterMode1) List(ctx context.Context, options *metainternalversion
 		startStorage := time.Now().UTC()
 		ctx, _ := context.WithTimeoutCause(ctx, time.Second*10, errors.New("storage list timeout"))
 		_, err := d.Storage.List(ctx, options)
-		defer d.recordStorageDuration(err != nil, mode, options.Kind, method, startStorage)
+		d.recordStorageDuration(err != nil, mode, options.Kind, method, startStorage)
 	}()
 
 	return res, errLegacy
@@ -134,7 +134,7 @@ func (d *DualWriterMode1) Delete(ctx context.Context, name string, deleteValidat
 		startStorage := time.Now().UTC()
 		ctx, _ := context.WithTimeoutCause(ctx, time.Second*10, errors.New("storage delete timeout"))
 		_, _, err := d.Storage.Delete(ctx, name, deleteValidation, options)
-		defer d.recordStorageDuration(err != nil, mode, name, method, startStorage)
+		d.recordStorageDuration(err != nil, mode, name, method, startStorage)
 	}()
 
 	return res, async, err
@@ -158,7 +158,7 @@ func (d *DualWriterMode1) DeleteCollection(ctx context.Context, deleteValidation
 		startStorage := time.Now().UTC()
 		ctx, _ := context.WithTimeoutCause(ctx, time.Second*10, errors.New("storage deletecollection timeout"))
 		_, err := d.Storage.DeleteCollection(ctx, deleteValidation, options, listOptions)
-		defer d.recordStorageDuration(err != nil, mode, options.Kind, method, startStorage)
+		d.recordStorageDuration(err != nil, mode, options.Kind, method, startStorage)
 	}()
 
 	return res, errLegacy
@@ -214,7 +214,7 @@ func (d *DualWriterMode1) Update(ctx context.Context, name string, objInfo rest.
 		startStorage := time.Now().UTC()
 		ctx, _ := context.WithTimeoutCause(ctx, time.Second*10, errors.New("storage update timeout"))
 		_, _, err := d.Storage.Update(ctx, name, objInfo, createValidation, updateValidation, forceAllowCreate, options)
-		defer d.recordStorageDuration(err != nil, mode, name, method, startStorage)
+		d.recordStorageDuration(err != nil, mode, name, method, startStorage)
 	}()
 
 	return res, async, errLegacy

--- a/pkg/apiserver/rest/dualwriter_mode1.go
+++ b/pkg/apiserver/rest/dualwriter_mode1.go
@@ -80,7 +80,6 @@ func (d *DualWriterMode1) Get(ctx context.Context, name string, options *metav1.
 	res, errLegacy := d.Legacy.Get(ctx, name, options)
 	if errLegacy != nil {
 		log.Error(errLegacy, "unable to get object in legacy storage")
-		d.recordLegacyDuration(errLegacy != nil, mode1Str, name, method, startLegacy)
 	}
 	d.recordLegacyDuration(errLegacy != nil, mode1Str, options.Kind, method, startLegacy)
 
@@ -105,7 +104,6 @@ func (d *DualWriterMode1) List(ctx context.Context, options *metainternalversion
 	res, errLegacy := d.Legacy.List(ctx, options)
 	if errLegacy != nil {
 		log.Error(errLegacy, "unable to list object in legacy storage")
-		d.recordLegacyDuration(errLegacy != nil, mode1Str, options.Kind, method, startLegacy)
 	}
 	d.recordLegacyDuration(errLegacy != nil, mode1Str, options.Kind, method, startLegacy)
 
@@ -129,10 +127,8 @@ func (d *DualWriterMode1) Delete(ctx context.Context, name string, deleteValidat
 	res, async, err := d.Legacy.Delete(ctx, name, deleteValidation, options)
 	if err != nil {
 		log.Error(err, "unable to delete object in legacy storage")
-		d.recordLegacyDuration(true, mode1Str, options.Kind, method, startLegacy)
-		return res, async, err
 	}
-	d.recordLegacyDuration(false, mode1Str, options.Kind, method, startLegacy)
+	d.recordLegacyDuration(err != nil, mode1Str, options.Kind, method, startLegacy)
 
 	go func() {
 		startStorage := time.Now()
@@ -155,9 +151,8 @@ func (d *DualWriterMode1) DeleteCollection(ctx context.Context, deleteValidation
 	res, errLegacy := d.Legacy.DeleteCollection(ctx, deleteValidation, options, listOptions)
 	if errLegacy != nil {
 		log.Error(errLegacy, "unable to delete collection in legacy storage")
-		d.recordLegacyDuration(true, mode1Str, options.Kind, method, startLegacy)
 	}
-	d.recordLegacyDuration(false, mode1Str, options.Kind, method, startLegacy)
+	d.recordLegacyDuration(errLegacy != nil, mode1Str, options.Kind, method, startLegacy)
 
 	go func() {
 		startStorage := time.Now()
@@ -179,9 +174,8 @@ func (d *DualWriterMode1) Update(ctx context.Context, name string, objInfo rest.
 	res, async, errLegacy := d.Legacy.Update(ctx, name, objInfo, createValidation, updateValidation, forceAllowCreate, options)
 	if errLegacy != nil {
 		log.Error(errLegacy, "unable to update in legacy storage")
-		d.recordLegacyDuration(true, mode1Str, options.Kind, method, startLegacy)
 	}
-	d.recordLegacyDuration(false, mode1Str, options.Kind, method, startLegacy)
+	d.recordLegacyDuration(errLegacy != nil, mode1Str, options.Kind, method, startLegacy)
 
 	updated, err := objInfo.UpdatedObject(ctx, res)
 	if err != nil {

--- a/pkg/apiserver/rest/dualwriter_mode1.go
+++ b/pkg/apiserver/rest/dualwriter_mode1.go
@@ -202,7 +202,7 @@ func (d *DualWriterMode1) Update(ctx context.Context, name string, objInfo rest.
 			log.Error(err, "unable to get accessor for original updated object")
 		}
 
-		accessor, err := meta.Accessor(updated)
+		accessor, err := meta.Accessor(res)
 		if err != nil {
 			log.Error(err, "unable to get accessor for updated object")
 		}
@@ -211,6 +211,10 @@ func (d *DualWriterMode1) Update(ctx context.Context, name string, objInfo rest.
 		accessor.SetUID(accessorOld.GetUID())
 
 		enrichObject(accessorOld, accessor)
+		objInfo = &updateWrapper{
+			upstream: objInfo,
+			updated:  res,
+		}
 	}
 
 	go func() {

--- a/pkg/apiserver/rest/dualwriter_mode1.go
+++ b/pkg/apiserver/rest/dualwriter_mode1.go
@@ -2,6 +2,8 @@ package rest
 
 import (
 	"context"
+	"strconv"
+	"time"
 
 	metainternalversion "k8s.io/apimachinery/pkg/apis/meta/internalversion"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -17,6 +19,8 @@ type DualWriterMode1 struct {
 	*dualWriterMetrics
 }
 
+var mode = strconv.Itoa(int(Mode1))
+
 // NewDualWriterMode1 returns a new DualWriter in mode 1.
 // Mode 1 represents writing to and reading from LegacyStorage.
 func NewDualWriterMode1(legacy LegacyStorage, storage Storage) *DualWriterMode1 {
@@ -28,35 +32,165 @@ func NewDualWriterMode1(legacy LegacyStorage, storage Storage) *DualWriterMode1 
 // Create overrides the behavior of the generic DualWriter and writes only to LegacyStorage.
 func (d *DualWriterMode1) Create(ctx context.Context, obj runtime.Object, createValidation rest.ValidateObjectFunc, options *metav1.CreateOptions) (runtime.Object, error) {
 	ctx = klog.NewContext(ctx, d.Log)
-	return d.Legacy.Create(ctx, obj, createValidation, options)
+	var method = "create"
+
+	startStorage := time.Now().UTC()
+	objStorage, err := d.Storage.Create(ctx, obj, createValidation, options)
+	d.recordStorageDuration(err != nil, mode, options.Kind, method, startStorage)
+
+	startLegacy := time.Now().UTC()
+	res, err := d.Legacy.Create(ctx, obj, createValidation, options)
+	if err != nil {
+		klog.Error(err, "unable to create object in legacy storage")
+		d.recordLegacyDuration(true, mode, options.Kind, method, startLegacy)
+		return res, err
+	}
+	d.recordLegacyDuration(false, mode, options.Kind, method, startLegacy)
+
+	areSame, err := compareResourceVersion(objStorage, res)
+	if err != nil {
+		// only log error but don't return error so we keep the same behavior as before
+		klog.Error(err, "unable to compare resource versions")
+	}
+
+	d.recordOutcome(mode, options.Kind, areSame, method)
+	return res, err
 }
 
 // Get overrides the behavior of the generic DualWriter and reads only from LegacyStorage.
 func (d *DualWriterMode1) Get(ctx context.Context, name string, options *metav1.GetOptions) (runtime.Object, error) {
 	ctx = klog.NewContext(ctx, d.Log)
-	return d.Legacy.Get(ctx, name, options)
+	var method = "get"
+
+	startStorage := time.Now().UTC()
+	objStorage, err := d.Storage.Get(ctx, name, options)
+	d.recordStorageDuration(err != nil, mode, name, method, startStorage)
+
+	startLegacy := time.Now().UTC()
+	res, err := d.Legacy.Get(ctx, name, options)
+	if err != nil {
+		klog.Error(err, "unable to get object in legacy storage")
+		d.recordLegacyDuration(true, mode, name, method, startLegacy)
+		return res, err
+	}
+	d.recordLegacyDuration(false, mode, name, method, startLegacy)
+
+	areSame, err := compareResourceVersion(objStorage, res)
+	if err != nil {
+		// only log error but don't return error so we keep the same behavior as before
+		klog.Error(err, "unable to compare resource versions")
+	}
+
+	d.recordOutcome(mode, name, areSame, method)
+	return res, err
 }
 
 // List overrides the behavior of the generic DualWriter and reads only from LegacyStorage.
 func (d *DualWriterMode1) List(ctx context.Context, options *metainternalversion.ListOptions) (runtime.Object, error) {
 	ctx = klog.NewContext(ctx, d.Log)
-	return d.Legacy.List(ctx, options)
+	var method = "list"
+
+	startStorage := time.Now().UTC()
+	objStorage, err := d.Storage.List(ctx, options)
+	d.recordStorageDuration(err != nil, mode, options.Kind, method, startStorage)
+
+	startLegacy := time.Now().UTC()
+	res, err := d.Legacy.List(ctx, options)
+	if err != nil {
+		klog.Error(err, "unable to list object in legacy storage")
+		d.recordLegacyDuration(true, mode, options.Kind, method, startLegacy)
+		return res, err
+	}
+	d.recordLegacyDuration(false, mode, options.Kind, method, startLegacy)
+
+	areSame, err := compareResourceVersion(objStorage, res)
+	if err != nil {
+		// only log error but don't return error so we keep the same behavior as before
+		klog.Error(err, "unable to compare resource versions")
+	}
+
+	d.recordOutcome(mode, options.Kind, areSame, method)
+	return res, err
 }
 
 func (d *DualWriterMode1) Delete(ctx context.Context, name string, deleteValidation rest.ValidateObjectFunc, options *metav1.DeleteOptions) (runtime.Object, bool, error) {
 	ctx = klog.NewContext(ctx, d.Log)
-	return d.Legacy.Delete(ctx, name, deleteValidation, options)
+	var method = "delete"
+
+	startStorage := time.Now().UTC()
+	objStorage, _, err := d.Storage.Delete(ctx, name, deleteValidation, options)
+	d.recordStorageDuration(err != nil, mode, name, method, startStorage)
+
+	startLegacy := time.Now().UTC()
+	res, async, err := d.Legacy.Delete(ctx, name, deleteValidation, options)
+	if err != nil {
+		klog.Error(err, "unable to delete object in legacy storage")
+		d.recordLegacyDuration(true, mode, name, method, startLegacy)
+		return res, async, err
+	}
+	d.recordLegacyDuration(false, mode, name, method, startLegacy)
+
+	areSame, err := compareResourceVersion(objStorage, res)
+	if err != nil {
+		// only log error but don't return error so we keep the same behavior as before
+		klog.Error(err, "unable to compare resource versions")
+	}
+
+	d.recordOutcome(mode, name, areSame, method)
+	return res, async, err
 }
 
 // DeleteCollection overrides the behavior of the generic DualWriter and deletes only from LegacyStorage.
 func (d *DualWriterMode1) DeleteCollection(ctx context.Context, deleteValidation rest.ValidateObjectFunc, options *metav1.DeleteOptions, listOptions *metainternalversion.ListOptions) (runtime.Object, error) {
 	ctx = klog.NewContext(ctx, d.Log)
-	return d.Legacy.DeleteCollection(ctx, deleteValidation, options, listOptions)
+	var method = "delete-collection"
+
+	startStorage := time.Now().UTC()
+	objStorage, err := d.Storage.DeleteCollection(ctx, deleteValidation, options, listOptions)
+	d.recordStorageDuration(err != nil, mode, options.Kind, method, startStorage)
+
+	startLegacy := time.Now().UTC()
+	res, err := d.Legacy.DeleteCollection(ctx, deleteValidation, options, listOptions)
+	if err != nil {
+		klog.Error(err, "unable to delete collection in legacy storage")
+		d.recordLegacyDuration(true, mode, options.Kind, method, startLegacy)
+	}
+	d.recordLegacyDuration(false, mode, options.Kind, method, startLegacy)
+
+	areSame, err := compareResourceVersion(objStorage, res)
+	if err != nil {
+		// only log error but don't return error so we keep the same behavior as before
+		klog.Error(err, "unable to compare resource versions")
+	}
+
+	d.recordOutcome(mode, options.Kind, areSame, method)
+	return res, err
 }
 
 func (d *DualWriterMode1) Update(ctx context.Context, name string, objInfo rest.UpdatedObjectInfo, createValidation rest.ValidateObjectFunc, updateValidation rest.ValidateObjectUpdateFunc, forceAllowCreate bool, options *metav1.UpdateOptions) (runtime.Object, bool, error) {
 	ctx = klog.NewContext(ctx, d.Log)
-	return d.Legacy.Update(ctx, name, objInfo, createValidation, updateValidation, forceAllowCreate, options)
+	var method = "update"
+
+	startStorage := time.Now().UTC()
+	objStorage, _, err := d.Storage.Update(ctx, name, objInfo, createValidation, updateValidation, forceAllowCreate, options)
+	d.recordStorageDuration(err != nil, mode, name, method, startStorage)
+
+	startLegacy := time.Now().UTC()
+	res, async, err := d.Legacy.Update(ctx, name, objInfo, createValidation, updateValidation, forceAllowCreate, options)
+	if err != nil {
+		klog.Error(err, "unable to update collection in legacy storage")
+		d.recordLegacyDuration(true, mode, name, method, startLegacy)
+	}
+	d.recordLegacyDuration(false, mode, name, method, startLegacy)
+
+	areSame, err := compareResourceVersion(objStorage, res)
+	if err != nil {
+		// only log error but don't return error so we keep the same behavior as before
+		klog.Error(err, "unable to compare resource versions")
+	}
+
+	d.recordOutcome(mode, name, areSame, method)
+	return res, async, err
 }
 
 func (d *DualWriterMode1) Destroy() {

--- a/pkg/apiserver/rest/dualwriter_mode1.go
+++ b/pkg/apiserver/rest/dualwriter_mode1.go
@@ -82,14 +82,14 @@ func (d *DualWriterMode1) Get(ctx context.Context, name string, options *metav1.
 		log.Error(errLegacy, "unable to get object in legacy storage")
 		d.recordLegacyDuration(errLegacy != nil, mode1Str, name, method, startLegacy)
 	}
-	d.recordLegacyDuration(errLegacy != nil, mode1Str, name, method, startLegacy)
+	d.recordLegacyDuration(errLegacy != nil, mode1Str, options.Kind, method, startLegacy)
 
 	go func() {
 		startStorage := time.Now()
 		ctx, cancel := context.WithTimeoutCause(ctx, time.Second*10, errors.New("storage get timeout"))
 		defer cancel()
 		_, err := d.Storage.Get(ctx, name, options)
-		d.recordStorageDuration(err != nil, mode1Str, name, method, startStorage)
+		d.recordStorageDuration(err != nil, mode1Str, options.Kind, method, startStorage)
 	}()
 
 	return res, errLegacy
@@ -179,9 +179,9 @@ func (d *DualWriterMode1) Update(ctx context.Context, name string, objInfo rest.
 	res, async, errLegacy := d.Legacy.Update(ctx, name, objInfo, createValidation, updateValidation, forceAllowCreate, options)
 	if errLegacy != nil {
 		log.Error(errLegacy, "unable to update in legacy storage")
-		d.recordLegacyDuration(true, mode1Str, name, method, startLegacy)
+		d.recordLegacyDuration(true, mode1Str, options.Kind, method, startLegacy)
 	}
-	d.recordLegacyDuration(false, mode1Str, name, method, startLegacy)
+	d.recordLegacyDuration(false, mode1Str, options.Kind, method, startLegacy)
 
 	updated, err := objInfo.UpdatedObject(ctx, res)
 	if err != nil {
@@ -221,7 +221,7 @@ func (d *DualWriterMode1) Update(ctx context.Context, name string, objInfo rest.
 		ctx, cancel := context.WithTimeoutCause(ctx, time.Second*10, errors.New("storage update timeout"))
 		defer cancel()
 		_, _, err := d.Storage.Update(ctx, name, objInfo, createValidation, updateValidation, forceAllowCreate, options)
-		d.recordStorageDuration(err != nil, mode1Str, name, method, startStorage)
+		d.recordStorageDuration(err != nil, mode1Str, options.Kind, method, startStorage)
 	}()
 
 	return res, async, errLegacy

--- a/pkg/apiserver/rest/dualwriter_mode1_test.go
+++ b/pkg/apiserver/rest/dualwriter_mode1_test.go
@@ -13,11 +13,11 @@ import (
 	"k8s.io/apiserver/pkg/apis/example"
 )
 
-var exampleObj = &example.Pod{TypeMeta: metav1.TypeMeta{}, ObjectMeta: metav1.ObjectMeta{Name: "foo", ResourceVersion: "1"}, Spec: example.PodSpec{}, Status: example.PodStatus{}}
-var exampleObjDifferentRV = &example.Pod{TypeMeta: metav1.TypeMeta{}, ObjectMeta: metav1.ObjectMeta{Name: "foo", ResourceVersion: "3"}, Spec: example.PodSpec{}, Status: example.PodStatus{}}
-var anotherObj = &example.Pod{TypeMeta: metav1.TypeMeta{}, ObjectMeta: metav1.ObjectMeta{Name: "bar", ResourceVersion: "2"}, Spec: example.PodSpec{}, Status: example.PodStatus{}}
-var failingObj = &example.Pod{TypeMeta: metav1.TypeMeta{}, ObjectMeta: metav1.ObjectMeta{Name: "object-fail", ResourceVersion: "2"}, Spec: example.PodSpec{}, Status: example.PodStatus{}}
-var exampleList = &example.PodList{TypeMeta: metav1.TypeMeta{}, ListMeta: metav1.ListMeta{}, Items: []example.Pod{*exampleObj}}
+var exampleObj = &example.Pod{TypeMeta: metav1.TypeMeta{Kind: "foo"}, ObjectMeta: metav1.ObjectMeta{Name: "foo", ResourceVersion: "1"}, Spec: example.PodSpec{}, Status: example.PodStatus{}}
+var exampleObjDifferentRV = &example.Pod{TypeMeta: metav1.TypeMeta{Kind: "foo"}, ObjectMeta: metav1.ObjectMeta{Name: "foo", ResourceVersion: "3"}, Spec: example.PodSpec{}, Status: example.PodStatus{}}
+var anotherObj = &example.Pod{TypeMeta: metav1.TypeMeta{Kind: "foo"}, ObjectMeta: metav1.ObjectMeta{Name: "bar", ResourceVersion: "2"}, Spec: example.PodSpec{}, Status: example.PodStatus{}}
+var failingObj = &example.Pod{TypeMeta: metav1.TypeMeta{Kind: "foo"}, ObjectMeta: metav1.ObjectMeta{Name: "object-fail", ResourceVersion: "2"}, Spec: example.PodSpec{}, Status: example.PodStatus{}}
+var exampleList = &example.PodList{TypeMeta: metav1.TypeMeta{Kind: "foo"}, ListMeta: metav1.ListMeta{}, Items: []example.Pod{*exampleObj}}
 var anotherList = &example.PodList{Items: []example.Pod{*anotherObj}}
 
 func TestMode1_Create(t *testing.T) {

--- a/pkg/apiserver/rest/dualwriter_mode2.go
+++ b/pkg/apiserver/rest/dualwriter_mode2.go
@@ -58,7 +58,7 @@ func (d *DualWriterMode2) Create(ctx context.Context, obj runtime.Object, create
 
 	rsp, err := d.Storage.Create(ctx, created, createValidation, options)
 	if err != nil {
-		d.Log.WithValues("name", accessorCreated.GetName(), "resourceVersion", accessorCreated.GetResourceVersion()).Error(err, "unable to create object in duplicate storage")
+		d.Log.WithValues("name", accessorCreated.GetName(), "resourceVersion", accessorCreated.GetResourceVersion()).Error(err, "unable to create object in storage")
 	}
 	return rsp, err
 }

--- a/pkg/apiserver/rest/dualwriter_mode2.go
+++ b/pkg/apiserver/rest/dualwriter_mode2.go
@@ -308,11 +308,6 @@ func enrichObject(accessorO, accessorC metav1.Object) {
 	if ac == nil {
 		ac = map[string]string{}
 	}
-	annotations := accessorO.GetAnnotations()
-	if annotations == nil {
-		ac = annotations
-		return
-	}
 	for k, v := range accessorO.GetAnnotations() {
 		ac[k] = v
 	}

--- a/pkg/apiserver/rest/dualwriter_mode2.go
+++ b/pkg/apiserver/rest/dualwriter_mode2.go
@@ -194,18 +194,18 @@ func (d *DualWriterMode2) Update(ctx context.Context, name string, objInfo rest.
 	log := d.Log.WithValues("name", name, "kind", options.Kind)
 	ctx = klog.NewContext(ctx, log)
 
-	// get old and new (updated) object so they can be stored in legacy store
-	old, err := d.Storage.Get(ctx, name, &metav1.GetOptions{})
+	// get foundObj and new (updated) object so they can be stored in legacy store
+	foundObj, err := d.Storage.Get(ctx, name, &metav1.GetOptions{})
 	if err != nil {
 		if !apierrors.IsNotFound(err) {
-			log.WithValues("object", old).Error(err, "could not get object to update")
+			log.WithValues("object", foundObj).Error(err, "could not get object to update")
 			return nil, false, err
 		}
 		log.Info("object not found for update, creating one")
 	}
 
 	// obj can be populated in case it's found or empty in case it's not found
-	updated, err := objInfo.UpdatedObject(ctx, old)
+	updated, err := objInfo.UpdatedObject(ctx, foundObj)
 	if err != nil {
 		log.WithValues("object", updated).Error(err, "could not update or create object")
 		return nil, false, err
@@ -218,8 +218,8 @@ func (d *DualWriterMode2) Update(ctx context.Context, name string, objInfo rest.
 	}
 
 	// if the object is found, create a new updateWrapper with the object found
-	if old != nil {
-		accessorOld, err := meta.Accessor(old)
+	if foundObj != nil {
+		accessorOld, err := meta.Accessor(foundObj)
 		if err != nil {
 			log.Error(err, "unable to get accessor for original updated object")
 		}

--- a/pkg/apiserver/rest/dualwriter_mode2_test.go
+++ b/pkg/apiserver/rest/dualwriter_mode2_test.go
@@ -424,8 +424,8 @@ func TestMode2_Update(t *testing.T) {
 				wantErr: true,
 			},
 			{
-				name:  "error updating storage",
-				input: "object-fail",
+				name:  "error updating storage with not found object",
+				input: "not-found",
 				setupLegacyFn: func(m *mock.Mock, input string) {
 					m.On("Update", mock.Anything, input, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(exampleObj, false, nil)
 				},
@@ -433,7 +433,7 @@ func TestMode2_Update(t *testing.T) {
 					m.On("Update", mock.Anything, input, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil, false, errors.New("error"))
 				},
 				setupGetFn: func(m *mock.Mock, input string) {
-					m.On("Get", mock.Anything, input, mock.Anything).Return(exampleObj, nil)
+					m.On("Get", mock.Anything, input, mock.Anything).Return(nil, errors.New(""))
 				},
 				wantErr: true,
 			},

--- a/pkg/apiserver/rest/metrics.go
+++ b/pkg/apiserver/rest/metrics.go
@@ -1,6 +1,13 @@
 package rest
 
-import "github.com/prometheus/client_golang/prometheus"
+import (
+	"strconv"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/runtime"
+)
 
 type dualWriterMetrics struct {
 	legacy  *prometheus.HistogramVec
@@ -14,7 +21,7 @@ var DualWriterStorageDuration = prometheus.NewHistogramVec(prometheus.HistogramO
 	Help:                        "Histogram for the runtime of dual writer storage duration per mode",
 	Namespace:                   "grafana",
 	NativeHistogramBucketFactor: 1.1,
-}, []string{"status_code", "mode", "name", "method"})
+}, []string{"is_error", "mode", "name", "method"})
 
 // DualWriterLegacyDuration is a metric summary for dual writer legacy duration per mode
 var DualWriterLegacyDuration = prometheus.NewHistogramVec(prometheus.HistogramOpts{
@@ -22,7 +29,7 @@ var DualWriterLegacyDuration = prometheus.NewHistogramVec(prometheus.HistogramOp
 	Help:                        "Histogram for the runtime of dual writer legacy duration per mode",
 	Namespace:                   "grafana",
 	NativeHistogramBucketFactor: 1.1,
-}, []string{"status_code", "mode", "name", "method"})
+}, []string{"is_error", "mode", "name", "method"})
 
 // DualWriterOutcome is a metric summary for dual writer outcome comparison between the 2 stores per mode
 var DualWriterOutcome = prometheus.NewHistogramVec(prometheus.HistogramOpts{
@@ -30,7 +37,7 @@ var DualWriterOutcome = prometheus.NewHistogramVec(prometheus.HistogramOpts{
 	Help:                        "Histogram for the runtime of dual writer outcome comparison between the 2 stores per mode",
 	Namespace:                   "grafana",
 	NativeHistogramBucketFactor: 1.1,
-}, []string{"mode", "name", "outcome", "method"})
+}, []string{"mode", "name", "method"})
 
 func (m *dualWriterMetrics) init() {
 	m.legacy = DualWriterLegacyDuration
@@ -38,17 +45,34 @@ func (m *dualWriterMetrics) init() {
 	m.outcome = DualWriterOutcome
 }
 
-// nolint:unused
-func (m *dualWriterMetrics) recordLegacyDuration(statusCode string, mode string, name string, method string, duration float64) {
-	m.legacy.WithLabelValues(statusCode, mode, name, method).Observe(duration)
+func (m *dualWriterMetrics) recordLegacyDuration(isError bool, mode string, name string, method string, startFrom time.Time) {
+	duration := time.Since(startFrom).Seconds()
+	m.legacy.WithLabelValues(strconv.FormatBool(isError), mode, name, method).Observe(duration)
 }
 
-// nolint:unused
-func (m *dualWriterMetrics) recordStorageDuration(statusCode string, mode string, name string, method string, duration float64) {
-	m.storage.WithLabelValues(statusCode, mode, name, method).Observe(duration)
+func (m *dualWriterMetrics) recordStorageDuration(isError bool, mode string, name string, method string, startFrom time.Time) {
+	duration := time.Since(startFrom).Seconds()
+	m.storage.WithLabelValues(strconv.FormatBool(isError), mode, name, method).Observe(duration)
 }
 
-// nolint:unused
-func (m *dualWriterMetrics) recordOutcome(mode string, name string, outcome string, method string) {
-	m.outcome.WithLabelValues(mode, name, outcome, method).Observe(1)
+// TODO: change this into a validation function
+func (m *dualWriterMetrics) recordOutcome(mode string, name string, outcome bool, method string) {
+	var observeValue float64
+	if outcome {
+		observeValue = 1
+	}
+	m.outcome.WithLabelValues(mode, name, method).Observe(observeValue)
+}
+
+func compareResourceVersion(obj1, obj2 runtime.Object) (bool, error) {
+	accessor1, err := meta.Accessor(obj1)
+	if err != nil {
+		return false, err
+	}
+	accessor2, err := meta.Accessor(obj2)
+	if err != nil {
+		return false, err
+	}
+	return accessor1.GetResourceVersion() == accessor2.GetResourceVersion(), nil
+
 }

--- a/pkg/apiserver/rest/metrics.go
+++ b/pkg/apiserver/rest/metrics.go
@@ -5,8 +5,6 @@ import (
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
-	"k8s.io/apimachinery/pkg/api/meta"
-	"k8s.io/apimachinery/pkg/runtime"
 )
 
 type dualWriterMetrics struct {
@@ -55,24 +53,11 @@ func (m *dualWriterMetrics) recordStorageDuration(isError bool, mode string, nam
 	m.storage.WithLabelValues(strconv.FormatBool(isError), mode, name, method).Observe(duration)
 }
 
+// no-lint: unused
 func (m *dualWriterMetrics) recordOutcome(mode string, name string, outcome bool, method string) {
 	var observeValue float64
 	if outcome {
 		observeValue = 1
 	}
 	m.outcome.WithLabelValues(mode, name, method).Observe(observeValue)
-}
-
-// TODO: change this into a validation interface
-func compareResourceVersion(obj1, obj2 runtime.Object) (bool, error) {
-	accessor1, err := meta.Accessor(obj1)
-	if err != nil {
-		return false, err
-	}
-	accessor2, err := meta.Accessor(obj2)
-	if err != nil {
-		return false, err
-	}
-	return accessor1.GetResourceVersion() == accessor2.GetResourceVersion(), nil
-
 }

--- a/pkg/apiserver/rest/metrics.go
+++ b/pkg/apiserver/rest/metrics.go
@@ -19,7 +19,7 @@ var DualWriterStorageDuration = prometheus.NewHistogramVec(prometheus.HistogramO
 	Help:                        "Histogram for the runtime of dual writer storage duration per mode",
 	Namespace:                   "grafana",
 	NativeHistogramBucketFactor: 1.1,
-}, []string{"is_error", "mode", "name", "method"})
+}, []string{"is_error", "mode", "kind", "method"})
 
 // DualWriterLegacyDuration is a metric summary for dual writer legacy duration per mode
 var DualWriterLegacyDuration = prometheus.NewHistogramVec(prometheus.HistogramOpts{
@@ -27,7 +27,7 @@ var DualWriterLegacyDuration = prometheus.NewHistogramVec(prometheus.HistogramOp
 	Help:                        "Histogram for the runtime of dual writer legacy duration per mode",
 	Namespace:                   "grafana",
 	NativeHistogramBucketFactor: 1.1,
-}, []string{"is_error", "mode", "name", "method"})
+}, []string{"is_error", "mode", "kind", "method"})
 
 // DualWriterOutcome is a metric summary for dual writer outcome comparison between the 2 stores per mode
 var DualWriterOutcome = prometheus.NewHistogramVec(prometheus.HistogramOpts{

--- a/pkg/apiserver/rest/metrics.go
+++ b/pkg/apiserver/rest/metrics.go
@@ -53,7 +53,7 @@ func (m *dualWriterMetrics) recordStorageDuration(isError bool, mode string, nam
 	m.storage.WithLabelValues(strconv.FormatBool(isError), mode, name, method).Observe(duration)
 }
 
-// no-lint: unused
+// nolint:unused
 func (m *dualWriterMetrics) recordOutcome(mode string, name string, outcome bool, method string) {
 	var observeValue float64
 	if outcome {

--- a/pkg/apiserver/rest/metrics.go
+++ b/pkg/apiserver/rest/metrics.go
@@ -55,7 +55,6 @@ func (m *dualWriterMetrics) recordStorageDuration(isError bool, mode string, nam
 	m.storage.WithLabelValues(strconv.FormatBool(isError), mode, name, method).Observe(duration)
 }
 
-// TODO: change this into a validation function
 func (m *dualWriterMetrics) recordOutcome(mode string, name string, outcome bool, method string) {
 	var observeValue float64
 	if outcome {
@@ -64,6 +63,7 @@ func (m *dualWriterMetrics) recordOutcome(mode string, name string, outcome bool
 	m.outcome.WithLabelValues(mode, name, method).Observe(observeValue)
 }
 
+// TODO: change this into a validation interface
 func compareResourceVersion(obj1, obj2 runtime.Object) (bool, error) {
 	accessor1, err := meta.Accessor(obj1)
 	if err != nil {


### PR DESCRIPTION
**What is this feature?**

Add latency observability for mode 1.
In order to get a better comparison between both, this PR is also calling storage in Mode1, but in a non-blocking way.
It wraps the storage call in a goroutine so it doesn't have to wait for its result.
It also adds a new context with timeout in case US is down, so that the call doesn't wait longer than it should.

**Why do we need this feature?**

[Add a description of the problem the feature is trying to solve.]

**Who is this feature for?**

[Add information on what kind of user the feature is for.]

**Which issue(s) does this PR fix?**:

Relates so https://github.com/grafana/search-and-storage-team/issues/29

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
