### PR TITLE
Applinks: Adds grafana-attributions-app to Cost Management nav

### DIFF
--- a/pkg/services/navtree/models.go
+++ b/pkg/services/navtree/models.go
@@ -230,6 +230,13 @@ func (root *NavTreeRoot) ApplyAdminIA() {
 			costManagementLogsNode.Children = append(costManagementLogsNode.Children, logVolumeExplorerNode)
 		}
 
+		costManagementAttributionsNode := root.FindByURL("/a/grafana-costmanagementui-app/attributions")
+		attributionsNode := root.FindById("plugin-page-grafana-attributions-app")
+
+		if costManagementAttributionsNode != nil && attributionsNode != nil {
+			costManagementAttributionsNode.Children = append(costManagementAttributionsNode.Children, attributionsNode)
+		}
+
 		if len(adminNodeLinks) > 0 {
 			orgAdminNode.Children = adminNodeLinks
 		} else {

--- a/pkg/services/navtree/models.go
+++ b/pkg/services/navtree/models.go
@@ -223,18 +223,17 @@ func (root *NavTreeRoot) ApplyAdminIA() {
 			costManagementMetricsNode.Children = append(costManagementMetricsNode.Children, adaptiveMetricsNode)
 		}
 
+		attributionsNode := root.FindById("plugin-page-grafana-attributions-app")
+
+		if costManagementMetricsNode != nil && attributionsNode != nil {
+			costManagementMetricsNode.Children = append(costManagementMetricsNode.Children, attributionsNode)
+		}
+
 		costManagementLogsNode := root.FindByURL("/a/grafana-costmanagementui-app/logs")
 		logVolumeExplorerNode := root.FindById("plugin-page-grafana-logvolumeexplorer-app")
 
 		if costManagementLogsNode != nil && logVolumeExplorerNode != nil {
 			costManagementLogsNode.Children = append(costManagementLogsNode.Children, logVolumeExplorerNode)
-		}
-
-		costManagementAttributionsNode := root.FindByURL("/a/grafana-costmanagementui-app/attributions")
-		attributionsNode := root.FindById("plugin-page-grafana-attributions-app")
-
-		if costManagementAttributionsNode != nil && attributionsNode != nil {
-			costManagementAttributionsNode.Children = append(costManagementAttributionsNode.Children, attributionsNode)
 		}
 
 		if len(adminNodeLinks) > 0 {

--- a/pkg/services/navtree/navtreeimpl/applinks.go
+++ b/pkg/services/navtree/navtreeimpl/applinks.go
@@ -298,6 +298,7 @@ func (s *ServiceImpl) readNavigationSettings() {
 		"grafana-cloud-link-app":           {SectionID: navtree.NavIDCfg},
 		"grafana-costmanagementui-app":     {SectionID: navtree.NavIDCfg, Text: "Cost management"},
 		"grafana-adaptive-metrics-app":     {SectionID: navtree.NavIDCfg, Text: "Adaptive Metrics"},
+		"grafana-attributions-app":         {SectionID: navtree.NavIDCfg, Text: "Attributions"},
 		"grafana-logvolumeexplorer-app":    {SectionID: navtree.NavIDCfg, Text: "Log Volume Explorer"},
 		"grafana-easystart-app":            {SectionID: navtree.NavIDRoot, SortWeight: navtree.WeightApps + 1, Text: "Connections", Icon: "adjust-circle"},
 		"k6-app":                           {SectionID: navtree.NavIDTestingAndSynthetics, SortWeight: 1, Text: "Performance"},


### PR DESCRIPTION
**What is this feature?**

This moves the `grafana-attributions-app` to the `Administration Cost Management` menu.

Tested locally 
grafana-dev:11.1.0-178218
![Screenshot 2024-05-15 at 2 12 34 PM](https://github.com/grafana/grafana/assets/114438185/85d3038c-263a-49a9-80ac-b3908c0b4140)


![Screenshot 2024-05-15 at 2 13 35 PM](https://github.com/grafana/grafana/assets/114438185/5f46c127-0283-45e6-86a9-36e9467cec2b)
