### PR TITLE
Format String Transformation: Add applicability function

### DIFF
--- a/packages/grafana-data/src/transformations/transformers/formatString.ts
+++ b/packages/grafana-data/src/transformations/transformers/formatString.ts
@@ -107,19 +107,19 @@ export const formatStringTransformer: DataTransformerInfo<FormatStringTransforme
  */
 export const createStringFormatter =
   (fieldMatches: FieldMatcher, formatStringFunction: (field: Field) => string[]) =>
-    (frame: DataFrame, allFrames: DataFrame[]) => {
-      return frame.fields.map((field) => {
-        // Find the configured field
-        if (fieldMatches(field, frame, allFrames)) {
-          const newVals = formatStringFunction(field);
+  (frame: DataFrame, allFrames: DataFrame[]) => {
+    return frame.fields.map((field) => {
+      // Find the configured field
+      if (fieldMatches(field, frame, allFrames)) {
+        const newVals = formatStringFunction(field);
 
-          return {
-            ...field,
-            type: FieldType.string,
-            values: newVals,
-          };
-        }
+        return {
+          ...field,
+          type: FieldType.string,
+          values: newVals,
+        };
+      }
 
-        return field;
-      });
-    };
+      return field;
+    });
+  };


### PR DESCRIPTION
**What is this feature?**

This PR adds an applicability function to the format string transformation so that it becomes muted when no string field is present.

**Why do we need this feature?**

It makes it clearer when the format string transformation can be used.

**Who is this feature for?**

Users of transformations.

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
