### PR TITLE
Alerting: Add recording rules to ruler API and validation

### DIFF
--- a/pkg/services/ngalert/api/api_ruler.go
+++ b/pkg/services/ngalert/api/api_ruler.go
@@ -530,6 +530,7 @@ func toGettableExtendedRuleNode(r ngmodels.AlertRule, provenanceRecords map[stri
 			Provenance:           apimodels.Provenance(provenance),
 			IsPaused:             r.IsPaused,
 			NotificationSettings: AlertRuleNotificationSettingsFromNotificationSettings(r.NotificationSettings),
+			Record:               ApiRecordFromModelRecord(r.Record),
 		},
 	}
 	forDuration := model.Duration(r.For)

--- a/pkg/services/ngalert/api/api_ruler_validation.go
+++ b/pkg/services/ngalert/api/api_ruler_validation.go
@@ -78,7 +78,7 @@ func validateRuleNode(
 	}
 
 	if isRecordingRule {
-		if err := validateRecordingRule(ruleNode, &newAlertRule, canPatch); err != nil {
+		if err := validateRecordingRule(ruleNode, &newAlertRule, limits, canPatch); err != nil {
 			return nil, err
 		}
 	} else {
@@ -154,7 +154,11 @@ func validateAlertingRule(in *apimodels.PostableExtendedRuleNode, newRule *ngmod
 	return nil
 }
 
-func validateRecordingRule(in *apimodels.PostableExtendedRuleNode, newRule *ngmodels.AlertRule, canPatch bool) error {
+func validateRecordingRule(in *apimodels.PostableExtendedRuleNode, newRule *ngmodels.AlertRule, limits RuleLimits, canPatch bool) error {
+	if !limits.RecordingRulesAllowed {
+		return fmt.Errorf("%w: recording rules cannot be created on this instance", ngmodels.ErrAlertRuleFailedValidation)
+	}
+
 	err := validateCondition(in.GrafanaManagedAlert.Record.From, in.GrafanaManagedAlert.Data, canPatch)
 	if err != nil {
 		return fmt.Errorf("%w: %s", ngmodels.ErrAlertRuleFailedValidation, err.Error())

--- a/pkg/services/ngalert/api/api_ruler_validation.go
+++ b/pkg/services/ngalert/api/api_ruler_validation.go
@@ -72,9 +72,6 @@ func validateRuleNode(
 		IntervalSeconds: intervalSeconds,
 		NamespaceUID:    namespaceUID,
 		RuleGroup:       groupName,
-		// Recording Rule fields will be implemented in the future.
-		// For now, no rules can be recording rules. So, we force these to be empty.
-		Record: nil,
 	}
 
 	if isRecordingRule {

--- a/pkg/services/ngalert/api/api_ruler_validation.go
+++ b/pkg/services/ngalert/api/api_ruler_validation.go
@@ -100,7 +100,9 @@ func validateRuleNode(
 	return &newAlertRule, nil
 }
 
-func validateAlertingRule(in *apimodels.PostableExtendedRuleNode, newRule *ngmodels.AlertRule, canPatch bool) error {
+// validateAlertingRuleFields validates only the fields on a rule that are specific to Alerting rules.
+// it will load fields that pass validation onto newRule.
+func validateAlertingRuleFields(in *apimodels.PostableExtendedRuleNode, newRule *ngmodels.AlertRule, canPatch bool) error {
 	var err error
 
 	if in.GrafanaManagedAlert.Record != nil {
@@ -151,7 +153,9 @@ func validateAlertingRule(in *apimodels.PostableExtendedRuleNode, newRule *ngmod
 	return nil
 }
 
-func validateRecordingRule(in *apimodels.PostableExtendedRuleNode, newRule *ngmodels.AlertRule, limits RuleLimits, canPatch bool) error {
+// validateRecordingRuleFields validates only the fields on a rule that are specific to Recording rules.
+// it will load fields that pass validation onto newRule.
+func validateRecordingRuleFields(in *apimodels.PostableExtendedRuleNode, newRule *ngmodels.AlertRule, limits RuleLimits, canPatch bool) error {
 	if !limits.RecordingRulesAllowed {
 		return fmt.Errorf("%w: recording rules cannot be created on this instance", ngmodels.ErrAlertRuleFailedValidation)
 	}

--- a/pkg/services/ngalert/api/api_ruler_validation.go
+++ b/pkg/services/ngalert/api/api_ruler_validation.go
@@ -60,11 +60,6 @@ func validateRuleNode(
 		return nil, fmt.Errorf("alert rule title is too long. Max length is %d", store.AlertRuleMaxTitleLength)
 	}
 
-	err = validateCondition(ruleNode.GrafanaManagedAlert.Condition, ruleNode.GrafanaManagedAlert.Data, canPatch)
-	if err != nil {
-		return nil, err
-	}
-
 	queries := AlertQueriesFromApiAlertQueries(ruleNode.GrafanaManagedAlert.Data)
 
 	newAlertRule := ngmodels.AlertRule{
@@ -133,6 +128,11 @@ func validateAlertingRule(in *apimodels.PostableExtendedRuleNode, newRule *ngmod
 		}
 	}
 	newRule.ExecErrState = errorState
+
+	err = validateCondition(in.GrafanaManagedAlert.Condition, in.GrafanaManagedAlert.Data, canPatch)
+	if err != nil {
+		return err
+	}
 
 	if in.GrafanaManagedAlert.NotificationSettings != nil {
 		newRule.NotificationSettings, err = validateNotificationSettings(in.GrafanaManagedAlert.NotificationSettings)

--- a/pkg/services/ngalert/api/api_ruler_validation_test.go
+++ b/pkg/services/ngalert/api/api_ruler_validation_test.go
@@ -125,7 +125,7 @@ func TestValidateCondition(t *testing.T) {
 			name:      "error when data is empty",
 			condition: "A",
 			data:      []apimodels.AlertQuery{},
-			errorMsg:  "no query/expressions specified",
+			errorMsg:  "no queries or expressions are found",
 		},
 		{
 			name:      "error when condition does not exist",
@@ -182,7 +182,7 @@ func TestValidateCondition(t *testing.T) {
 
 	for _, tc := range testcases {
 		t.Run(tc.name, func(t *testing.T) {
-			err := validateCondition(tc.condition, tc.data)
+			err := validateCondition(tc.condition, tc.data, false)
 			if tc.errorMsg == "" {
 				require.NoError(t, err)
 			} else {

--- a/pkg/services/ngalert/api/compat.go
+++ b/pkg/services/ngalert/api/compat.go
@@ -455,3 +455,13 @@ func NotificationSettingsFromAlertRuleNotificationSettings(ns *definitions.Alert
 		},
 	}
 }
+
+func ApiRecordFromModelRecord(r *models.Record) *definitions.Record {
+	if r == nil {
+		return nil
+	}
+	return &definitions.Record{
+		Metric: r.Metric,
+		From:   r.From,
+	}
+}

--- a/pkg/services/ngalert/api/compat.go
+++ b/pkg/services/ngalert/api/compat.go
@@ -465,3 +465,13 @@ func ApiRecordFromModelRecord(r *models.Record) *definitions.Record {
 		From:   r.From,
 	}
 }
+
+func ModelRecordFromApiRecord(r *definitions.Record) *models.Record {
+	if r == nil {
+		return nil
+	}
+	return &models.Record{
+		Metric: r.Metric,
+		From:   r.From,
+	}
+}

--- a/pkg/services/ngalert/api/tooling/api.json
+++ b/pkg/services/ngalert/api/tooling/api.json
@@ -970,9 +970,7 @@
    },
    "type": "object"
   },
-  "EvalQueriesResponse": {
-   "type": "object"
-  },
+  "EvalQueriesResponse": {},
   "ExplorePanelsState": {
    "description": "This is an object constructed with the keys as the values of the enum VisType and the value being a bag of properties"
   },
@@ -4465,8 +4463,7 @@
   "alertGroups": {
    "description": "AlertGroups alert groups",
    "items": {
-    "$ref": "#/definitions/alertGroup",
-    "type": "object"
+    "$ref": "#/definitions/alertGroup"
    },
    "type": "array"
   },
@@ -4570,7 +4567,10 @@
   },
   "gettableAlert": {
 <<<<<<< HEAD
+<<<<<<< HEAD
    "description": "GettableAlert gettable alert",
+=======
+>>>>>>> fa144e1652b (Re-generate swagger docs with backdated v0.30.2 version)
    "properties": {
     "annotations": {
      "$ref": "#/definitions/labelSet"
@@ -4613,8 +4613,11 @@
      "type": "string"
     }
    },
+<<<<<<< HEAD
 =======
 >>>>>>> 961cef7f7de (Regenerate swagger docs)
+=======
+>>>>>>> fa144e1652b (Re-generate swagger docs with backdated v0.30.2 version)
    "required": [
     "labels",
     "annotations",
@@ -4630,8 +4633,7 @@
   "gettableAlerts": {
    "description": "GettableAlerts gettable alerts",
    "items": {
-    "$ref": "#/definitions/gettableAlert",
-    "type": "object"
+    "$ref": "#/definitions/gettableAlert"
    },
    "type": "array"
   },
@@ -4684,14 +4686,13 @@
    "type": "object"
   },
   "gettableSilences": {
+   "description": "GettableSilences gettable silences",
    "items": {
-    "$ref": "#/definitions/gettableSilence",
-    "type": "object"
+    "$ref": "#/definitions/gettableSilence"
    },
    "type": "array"
   },
   "integration": {
-   "description": "Integration integration",
    "properties": {
     "lastNotifyAttempt": {
      "description": "A timestamp indicating the last attempt to deliver a notification regardless of the outcome.\nFormat: date-time",
@@ -4836,7 +4837,10 @@
   },
   "postableSilence": {
 <<<<<<< HEAD
+<<<<<<< HEAD
    "description": "PostableSilence postable silence",
+=======
+>>>>>>> fa144e1652b (Re-generate swagger docs with backdated v0.30.2 version)
    "properties": {
     "comment": {
      "description": "comment",
@@ -4864,8 +4868,11 @@
      "type": "string"
     }
    },
+<<<<<<< HEAD
 =======
 >>>>>>> 961cef7f7de (Regenerate swagger docs)
+=======
+>>>>>>> fa144e1652b (Re-generate swagger docs with backdated v0.30.2 version)
    "required": [
     "comment",
     "createdBy",

--- a/pkg/services/ngalert/api/tooling/api.json
+++ b/pkg/services/ngalert/api/tooling/api.json
@@ -338,6 +338,7 @@
    "type": "object"
   },
   "AlertRuleNotificationSettingsExport": {
+   "description": "Field name mismatches with Terraform provider schema are noted where applicable.",
    "properties": {
     "group_by": {
      "items": {
@@ -352,12 +353,14 @@
      "type": "string"
     },
     "mute_time_intervals": {
+     "description": "TF -\u003e `mute_timings`",
      "items": {
       "type": "string"
      },
      "type": "array"
     },
     "receiver": {
+     "description": "TF -\u003e `contact_point`",
      "type": "string"
     },
     "repeat_interval": {
@@ -967,7 +970,9 @@
    },
    "type": "object"
   },
-  "EvalQueriesResponse": {},
+  "EvalQueriesResponse": {
+   "type": "object"
+  },
   "ExplorePanelsState": {
    "description": "This is an object constructed with the keys as the values of the enum VisType and the value being a bag of properties"
   },
@@ -1572,6 +1577,9 @@
     },
     "provenance": {
      "$ref": "#/definitions/Provenance"
+    },
+    "record": {
+     "$ref": "#/definitions/Record"
     },
     "rule_group": {
      "type": "string"
@@ -2730,6 +2738,9 @@
     "notification_settings": {
      "$ref": "#/definitions/AlertRuleNotificationSettings"
     },
+    "record": {
+     "$ref": "#/definitions/Record"
+    },
     "title": {
      "type": "string"
     },
@@ -3245,6 +3256,18 @@
     }
    },
    "title": "ReceiverExport is the provisioned file export of alerting.ReceiverV1.",
+   "type": "object"
+  },
+  "Record": {
+   "properties": {
+    "from": {
+     "type": "string"
+    },
+    "metric": {
+     "type": "string"
+    }
+   },
+   "title": "Record defines how data produced by a recording rule is written.",
    "type": "object"
   },
   "RelativeTimeRange": {
@@ -4442,7 +4465,8 @@
   "alertGroups": {
    "description": "AlertGroups alert groups",
    "items": {
-    "$ref": "#/definitions/alertGroup"
+    "$ref": "#/definitions/alertGroup",
+    "type": "object"
    },
    "type": "array"
   },
@@ -4545,6 +4569,7 @@
    "type": "object"
   },
   "gettableAlert": {
+<<<<<<< HEAD
    "description": "GettableAlert gettable alert",
    "properties": {
     "annotations": {
@@ -4588,6 +4613,8 @@
      "type": "string"
     }
    },
+=======
+>>>>>>> 961cef7f7de (Regenerate swagger docs)
    "required": [
     "labels",
     "annotations",
@@ -4601,8 +4628,10 @@
    "type": "object"
   },
   "gettableAlerts": {
+   "description": "GettableAlerts gettable alerts",
    "items": {
-    "$ref": "#/definitions/gettableAlert"
+    "$ref": "#/definitions/gettableAlert",
+    "type": "object"
    },
    "type": "array"
   },
@@ -4656,7 +4685,8 @@
   },
   "gettableSilences": {
    "items": {
-    "$ref": "#/definitions/gettableSilence"
+    "$ref": "#/definitions/gettableSilence",
+    "type": "object"
    },
    "type": "array"
   },
@@ -4805,6 +4835,7 @@
    "type": "array"
   },
   "postableSilence": {
+<<<<<<< HEAD
    "description": "PostableSilence postable silence",
    "properties": {
     "comment": {
@@ -4833,6 +4864,8 @@
      "type": "string"
     }
    },
+=======
+>>>>>>> 961cef7f7de (Regenerate swagger docs)
    "required": [
     "comment",
     "createdBy",
@@ -4843,6 +4876,7 @@
    "type": "object"
   },
   "receiver": {
+   "description": "Receiver receiver",
    "properties": {
     "active": {
      "description": "active",

--- a/pkg/services/ngalert/api/tooling/api.json
+++ b/pkg/services/ngalert/api/tooling/api.json
@@ -338,7 +338,6 @@
    "type": "object"
   },
   "AlertRuleNotificationSettingsExport": {
-   "description": "Field name mismatches with Terraform provider schema are noted where applicable.",
    "properties": {
     "group_by": {
      "items": {
@@ -353,14 +352,12 @@
      "type": "string"
     },
     "mute_time_intervals": {
-     "description": "TF -\u003e `mute_timings`",
      "items": {
       "type": "string"
      },
      "type": "array"
     },
     "receiver": {
-     "description": "TF -\u003e `contact_point`",
      "type": "string"
     },
     "repeat_interval": {
@@ -4438,6 +4435,7 @@
    "type": "object"
   },
   "alertGroup": {
+   "description": "AlertGroup alert group",
    "properties": {
     "alerts": {
      "description": "alerts",
@@ -4566,11 +4564,6 @@
    "type": "object"
   },
   "gettableAlert": {
-<<<<<<< HEAD
-<<<<<<< HEAD
-   "description": "GettableAlert gettable alert",
-=======
->>>>>>> fa144e1652b (Re-generate swagger docs with backdated v0.30.2 version)
    "properties": {
     "annotations": {
      "$ref": "#/definitions/labelSet"
@@ -4613,11 +4606,6 @@
      "type": "string"
     }
    },
-<<<<<<< HEAD
-=======
->>>>>>> 961cef7f7de (Regenerate swagger docs)
-=======
->>>>>>> fa144e1652b (Re-generate swagger docs with backdated v0.30.2 version)
    "required": [
     "labels",
     "annotations",
@@ -4836,11 +4824,6 @@
    "type": "array"
   },
   "postableSilence": {
-<<<<<<< HEAD
-<<<<<<< HEAD
-   "description": "PostableSilence postable silence",
-=======
->>>>>>> fa144e1652b (Re-generate swagger docs with backdated v0.30.2 version)
    "properties": {
     "comment": {
      "description": "comment",
@@ -4868,11 +4851,6 @@
      "type": "string"
     }
    },
-<<<<<<< HEAD
-=======
->>>>>>> 961cef7f7de (Regenerate swagger docs)
-=======
->>>>>>> fa144e1652b (Re-generate swagger docs with backdated v0.30.2 version)
    "required": [
     "comment",
     "createdBy",

--- a/pkg/services/ngalert/api/tooling/definitions/cortex-ruler.go
+++ b/pkg/services/ngalert/api/tooling/definitions/cortex-ruler.go
@@ -487,6 +487,7 @@ type PostableGrafanaRule struct {
 	ExecErrState         ExecutionErrorState            `json:"exec_err_state" yaml:"exec_err_state"`
 	IsPaused             *bool                          `json:"is_paused" yaml:"is_paused"`
 	NotificationSettings *AlertRuleNotificationSettings `json:"notification_settings" yaml:"notification_settings"`
+	Record               *Record                        `json:"record" yaml:"record"`
 }
 
 // swagger:model

--- a/pkg/services/ngalert/api/tooling/definitions/cortex-ruler.go
+++ b/pkg/services/ngalert/api/tooling/definitions/cortex-ruler.go
@@ -507,6 +507,7 @@ type GettableGrafanaRule struct {
 	Provenance           Provenance                     `json:"provenance,omitempty" yaml:"provenance,omitempty"`
 	IsPaused             bool                           `json:"is_paused" yaml:"is_paused"`
 	NotificationSettings *AlertRuleNotificationSettings `json:"notification_settings,omitempty" yaml:"notification_settings,omitempty"`
+	Record               *Record                        `json:"record,omitempty" yaml:"record,omitempty"`
 }
 
 // AlertQuery represents a single query associated with an alert definition.
@@ -574,6 +575,12 @@ func (d *Duration) UnmarshalYAML(unmarshal func(any) error) error {
 	default:
 		return fmt.Errorf("invalid duration %v", v)
 	}
+}
+
+// Record defines how data produced by a recording rule is written.
+type Record struct {
+	Metric string `json:"metric" yaml:"metric"`
+	From   string `json:"from" yaml:"from"`
 }
 
 // swagger:model

--- a/pkg/services/ngalert/api/tooling/post.json
+++ b/pkg/services/ngalert/api/tooling/post.json
@@ -338,7 +338,6 @@
    "type": "object"
   },
   "AlertRuleNotificationSettingsExport": {
-   "description": "Field name mismatches with Terraform provider schema are noted where applicable.",
    "properties": {
     "group_by": {
      "items": {
@@ -353,14 +352,12 @@
      "type": "string"
     },
     "mute_time_intervals": {
-     "description": "TF -\u003e `mute_timings`",
      "items": {
       "type": "string"
      },
      "type": "array"
     },
     "receiver": {
-     "description": "TF -\u003e `contact_point`",
      "type": "string"
     },
     "repeat_interval": {
@@ -4197,14 +4194,7 @@
    "type": "object"
   },
   "URL": {
-<<<<<<< HEAD
-<<<<<<< HEAD
    "description": "The general form represented is:\n\n[scheme:][//[userinfo@]host][/]path[?query][#fragment]\n\nURLs that do not start with a slash after the scheme are interpreted as:\n\nscheme:opaque[?query][#fragment]\n\nThe Host field contains the host and port subcomponents of the URL.\nWhen the port is present, it is separated from the host with a colon.\nWhen the host is an IPv6 address, it must be enclosed in square brackets:\n\"[fe80::1]:80\". The [net.JoinHostPort] function combines a host and port\ninto a string suitable for the Host field, adding square brackets to\nthe host when necessary.\n\nNote that the Path field is stored in decoded form: /%47%6f%2f becomes /Go/.\nA consequence is that it is impossible to tell which slashes in the Path were\nslashes in the raw URL and which were %2f. This distinction is rarely important,\nbut when it is, the code should use the [URL.EscapedPath] method, which preserves\nthe original encoding of Path.\n\nThe RawPath field is an optional field which is only set when the default\nencoding of Path is different from the escaped path. See the EscapedPath method\nfor more details.\n\nURL's String method uses the EscapedPath method to obtain the path.",
-=======
->>>>>>> 961cef7f7de (Regenerate swagger docs)
-=======
-   "description": "The general form represented is:\n\n[scheme:][//[userinfo@]host][/]path[?query][#fragment]\n\nURLs that do not start with a slash after the scheme are interpreted as:\n\nscheme:opaque[?query][#fragment]\n\nThe Host field contains the host and port subcomponents of the URL.\nWhen the port is present, it is separated from the host with a colon.\nWhen the host is an IPv6 address, it must be enclosed in square brackets:\n\"[fe80::1]:80\". The [net.JoinHostPort] function combines a host and port\ninto a string suitable for the Host field, adding square brackets to\nthe host when necessary.\n\nNote that the Path field is stored in decoded form: /%47%6f%2f becomes /Go/.\nA consequence is that it is impossible to tell which slashes in the Path were\nslashes in the raw URL and which were %2f. This distinction is rarely important,\nbut when it is, the code should use the [URL.EscapedPath] method, which preserves\nthe original encoding of Path.\n\nThe RawPath field is an optional field which is only set when the default\nencoding of Path is different from the escaped path. See the EscapedPath method\nfor more details.\n\nURL's String method uses the EscapedPath method to obtain the path.",
->>>>>>> fa144e1652b (Re-generate swagger docs with backdated v0.30.2 version)
    "properties": {
     "ForceQuery": {
      "type": "boolean"
@@ -4446,6 +4436,7 @@
    "type": "object"
   },
   "alertGroup": {
+   "description": "AlertGroup alert group",
    "properties": {
     "alerts": {
      "description": "alerts",
@@ -4469,7 +4460,6 @@
    "type": "object"
   },
   "alertGroups": {
-   "description": "AlertGroups alert groups",
    "items": {
     "$ref": "#/definitions/alertGroup"
    },
@@ -4637,6 +4627,7 @@
    "type": "array"
   },
   "gettableSilence": {
+   "description": "GettableSilence gettable silence",
    "properties": {
     "comment": {
      "description": "comment",

--- a/pkg/services/ngalert/api/tooling/post.json
+++ b/pkg/services/ngalert/api/tooling/post.json
@@ -970,9 +970,7 @@
    },
    "type": "object"
   },
-  "EvalQueriesResponse": {
-   "type": "object"
-  },
+  "EvalQueriesResponse": {},
   "ExplorePanelsState": {
    "description": "This is an object constructed with the keys as the values of the enum VisType and the value being a bag of properties"
   },
@@ -4200,9 +4198,13 @@
   },
   "URL": {
 <<<<<<< HEAD
+<<<<<<< HEAD
    "description": "The general form represented is:\n\n[scheme:][//[userinfo@]host][/]path[?query][#fragment]\n\nURLs that do not start with a slash after the scheme are interpreted as:\n\nscheme:opaque[?query][#fragment]\n\nThe Host field contains the host and port subcomponents of the URL.\nWhen the port is present, it is separated from the host with a colon.\nWhen the host is an IPv6 address, it must be enclosed in square brackets:\n\"[fe80::1]:80\". The [net.JoinHostPort] function combines a host and port\ninto a string suitable for the Host field, adding square brackets to\nthe host when necessary.\n\nNote that the Path field is stored in decoded form: /%47%6f%2f becomes /Go/.\nA consequence is that it is impossible to tell which slashes in the Path were\nslashes in the raw URL and which were %2f. This distinction is rarely important,\nbut when it is, the code should use the [URL.EscapedPath] method, which preserves\nthe original encoding of Path.\n\nThe RawPath field is an optional field which is only set when the default\nencoding of Path is different from the escaped path. See the EscapedPath method\nfor more details.\n\nURL's String method uses the EscapedPath method to obtain the path.",
 =======
 >>>>>>> 961cef7f7de (Regenerate swagger docs)
+=======
+   "description": "The general form represented is:\n\n[scheme:][//[userinfo@]host][/]path[?query][#fragment]\n\nURLs that do not start with a slash after the scheme are interpreted as:\n\nscheme:opaque[?query][#fragment]\n\nThe Host field contains the host and port subcomponents of the URL.\nWhen the port is present, it is separated from the host with a colon.\nWhen the host is an IPv6 address, it must be enclosed in square brackets:\n\"[fe80::1]:80\". The [net.JoinHostPort] function combines a host and port\ninto a string suitable for the Host field, adding square brackets to\nthe host when necessary.\n\nNote that the Path field is stored in decoded form: /%47%6f%2f becomes /Go/.\nA consequence is that it is impossible to tell which slashes in the Path were\nslashes in the raw URL and which were %2f. This distinction is rarely important,\nbut when it is, the code should use the [URL.EscapedPath] method, which preserves\nthe original encoding of Path.\n\nThe RawPath field is an optional field which is only set when the default\nencoding of Path is different from the escaped path. See the EscapedPath method\nfor more details.\n\nURL's String method uses the EscapedPath method to obtain the path.",
+>>>>>>> fa144e1652b (Re-generate swagger docs with backdated v0.30.2 version)
    "properties": {
     "ForceQuery": {
      "type": "boolean"
@@ -4238,7 +4240,7 @@
      "$ref": "#/definitions/Userinfo"
     }
    },
-   "title": "URL is a custom URL type that allows validation at configuration load time.",
+   "title": "A URL represents a parsed URL (technically, a URI reference).",
    "type": "object"
   },
   "UpdateRuleGroupResponse": {
@@ -4469,8 +4471,7 @@
   "alertGroups": {
    "description": "AlertGroups alert groups",
    "items": {
-    "$ref": "#/definitions/alertGroup",
-    "type": "object"
+    "$ref": "#/definitions/alertGroup"
    },
    "type": "array"
   },
@@ -4631,12 +4632,46 @@
   "gettableAlerts": {
    "description": "GettableAlerts gettable alerts",
    "items": {
-    "$ref": "#/definitions/gettableAlert",
-    "type": "object"
+    "$ref": "#/definitions/gettableAlert"
    },
    "type": "array"
   },
   "gettableSilence": {
+   "properties": {
+    "comment": {
+     "description": "comment",
+     "type": "string"
+    },
+    "createdBy": {
+     "description": "created by",
+     "type": "string"
+    },
+    "endsAt": {
+     "description": "ends at",
+     "format": "date-time",
+     "type": "string"
+    },
+    "id": {
+     "description": "id",
+     "type": "string"
+    },
+    "matchers": {
+     "$ref": "#/definitions/matchers"
+    },
+    "startsAt": {
+     "description": "starts at",
+     "format": "date-time",
+     "type": "string"
+    },
+    "status": {
+     "$ref": "#/definitions/silenceStatus"
+    },
+    "updatedAt": {
+     "description": "updated at",
+     "format": "date-time",
+     "type": "string"
+    }
+   },
    "required": [
     "comment",
     "createdBy",
@@ -4651,13 +4686,11 @@
   },
   "gettableSilences": {
    "items": {
-    "$ref": "#/definitions/gettableSilence",
-    "type": "object"
+    "$ref": "#/definitions/gettableSilence"
    },
    "type": "array"
   },
   "integration": {
-   "description": "Integration integration",
    "properties": {
     "lastNotifyAttempt": {
      "description": "A timestamp indicating the last attempt to deliver a notification regardless of the outcome.\nFormat: date-time",

--- a/pkg/services/ngalert/api/tooling/post.json
+++ b/pkg/services/ngalert/api/tooling/post.json
@@ -338,6 +338,7 @@
    "type": "object"
   },
   "AlertRuleNotificationSettingsExport": {
+   "description": "Field name mismatches with Terraform provider schema are noted where applicable.",
    "properties": {
     "group_by": {
      "items": {
@@ -352,12 +353,14 @@
      "type": "string"
     },
     "mute_time_intervals": {
+     "description": "TF -\u003e `mute_timings`",
      "items": {
       "type": "string"
      },
      "type": "array"
     },
     "receiver": {
+     "description": "TF -\u003e `contact_point`",
      "type": "string"
     },
     "repeat_interval": {
@@ -967,7 +970,9 @@
    },
    "type": "object"
   },
-  "EvalQueriesResponse": {},
+  "EvalQueriesResponse": {
+   "type": "object"
+  },
   "ExplorePanelsState": {
    "description": "This is an object constructed with the keys as the values of the enum VisType and the value being a bag of properties"
   },
@@ -1572,6 +1577,9 @@
     },
     "provenance": {
      "$ref": "#/definitions/Provenance"
+    },
+    "record": {
+     "$ref": "#/definitions/Record"
     },
     "rule_group": {
      "type": "string"
@@ -2730,6 +2738,9 @@
     "notification_settings": {
      "$ref": "#/definitions/AlertRuleNotificationSettings"
     },
+    "record": {
+     "$ref": "#/definitions/Record"
+    },
     "title": {
      "type": "string"
     },
@@ -3245,6 +3256,18 @@
     }
    },
    "title": "ReceiverExport is the provisioned file export of alerting.ReceiverV1.",
+   "type": "object"
+  },
+  "Record": {
+   "properties": {
+    "from": {
+     "type": "string"
+    },
+    "metric": {
+     "type": "string"
+    }
+   },
+   "title": "Record defines how data produced by a recording rule is written.",
    "type": "object"
   },
   "RelativeTimeRange": {
@@ -4176,7 +4199,10 @@
    "type": "object"
   },
   "URL": {
+<<<<<<< HEAD
    "description": "The general form represented is:\n\n[scheme:][//[userinfo@]host][/]path[?query][#fragment]\n\nURLs that do not start with a slash after the scheme are interpreted as:\n\nscheme:opaque[?query][#fragment]\n\nThe Host field contains the host and port subcomponents of the URL.\nWhen the port is present, it is separated from the host with a colon.\nWhen the host is an IPv6 address, it must be enclosed in square brackets:\n\"[fe80::1]:80\". The [net.JoinHostPort] function combines a host and port\ninto a string suitable for the Host field, adding square brackets to\nthe host when necessary.\n\nNote that the Path field is stored in decoded form: /%47%6f%2f becomes /Go/.\nA consequence is that it is impossible to tell which slashes in the Path were\nslashes in the raw URL and which were %2f. This distinction is rarely important,\nbut when it is, the code should use the [URL.EscapedPath] method, which preserves\nthe original encoding of Path.\n\nThe RawPath field is an optional field which is only set when the default\nencoding of Path is different from the escaped path. See the EscapedPath method\nfor more details.\n\nURL's String method uses the EscapedPath method to obtain the path.",
+=======
+>>>>>>> 961cef7f7de (Regenerate swagger docs)
    "properties": {
     "ForceQuery": {
      "type": "boolean"
@@ -4212,7 +4238,7 @@
      "$ref": "#/definitions/Userinfo"
     }
    },
-   "title": "A URL represents a parsed URL (technically, a URI reference).",
+   "title": "URL is a custom URL type that allows validation at configuration load time.",
    "type": "object"
   },
   "UpdateRuleGroupResponse": {
@@ -4443,7 +4469,8 @@
   "alertGroups": {
    "description": "AlertGroups alert groups",
    "items": {
-    "$ref": "#/definitions/alertGroup"
+    "$ref": "#/definitions/alertGroup",
+    "type": "object"
    },
    "type": "array"
   },
@@ -4602,47 +4629,14 @@
    "type": "object"
   },
   "gettableAlerts": {
+   "description": "GettableAlerts gettable alerts",
    "items": {
-    "$ref": "#/definitions/gettableAlert"
+    "$ref": "#/definitions/gettableAlert",
+    "type": "object"
    },
    "type": "array"
   },
   "gettableSilence": {
-   "properties": {
-    "comment": {
-     "description": "comment",
-     "type": "string"
-    },
-    "createdBy": {
-     "description": "created by",
-     "type": "string"
-    },
-    "endsAt": {
-     "description": "ends at",
-     "format": "date-time",
-     "type": "string"
-    },
-    "id": {
-     "description": "id",
-     "type": "string"
-    },
-    "matchers": {
-     "$ref": "#/definitions/matchers"
-    },
-    "startsAt": {
-     "description": "starts at",
-     "format": "date-time",
-     "type": "string"
-    },
-    "status": {
-     "$ref": "#/definitions/silenceStatus"
-    },
-    "updatedAt": {
-     "description": "updated at",
-     "format": "date-time",
-     "type": "string"
-    }
-   },
    "required": [
     "comment",
     "createdBy",
@@ -4657,11 +4651,13 @@
   },
   "gettableSilences": {
    "items": {
-    "$ref": "#/definitions/gettableSilence"
+    "$ref": "#/definitions/gettableSilence",
+    "type": "object"
    },
    "type": "array"
   },
   "integration": {
+   "description": "Integration integration",
    "properties": {
     "lastNotifyAttempt": {
      "description": "A timestamp indicating the last attempt to deliver a notification regardless of the outcome.\nFormat: date-time",

--- a/pkg/services/ngalert/api/tooling/spec.json
+++ b/pkg/services/ngalert/api/tooling/spec.json
@@ -3849,7 +3849,6 @@
       }
     },
     "AlertRuleNotificationSettingsExport": {
-      "description": "Field name mismatches with Terraform provider schema are noted where applicable.",
       "type": "object",
       "title": "AlertRuleNotificationSettingsExport is the provisioned export of models.NotificationSettings.",
       "properties": {
@@ -3866,14 +3865,12 @@
           "type": "string"
         },
         "mute_time_intervals": {
-          "description": "TF -\u003e `mute_timings`",
           "type": "array",
           "items": {
             "type": "string"
           }
         },
         "receiver": {
-          "description": "TF -\u003e `contact_point`",
           "type": "string"
         },
         "repeat_interval": {
@@ -7712,14 +7709,7 @@
       }
     },
     "URL": {
-<<<<<<< HEAD
-<<<<<<< HEAD
       "description": "The general form represented is:\n\n[scheme:][//[userinfo@]host][/]path[?query][#fragment]\n\nURLs that do not start with a slash after the scheme are interpreted as:\n\nscheme:opaque[?query][#fragment]\n\nThe Host field contains the host and port subcomponents of the URL.\nWhen the port is present, it is separated from the host with a colon.\nWhen the host is an IPv6 address, it must be enclosed in square brackets:\n\"[fe80::1]:80\". The [net.JoinHostPort] function combines a host and port\ninto a string suitable for the Host field, adding square brackets to\nthe host when necessary.\n\nNote that the Path field is stored in decoded form: /%47%6f%2f becomes /Go/.\nA consequence is that it is impossible to tell which slashes in the Path were\nslashes in the raw URL and which were %2f. This distinction is rarely important,\nbut when it is, the code should use the [URL.EscapedPath] method, which preserves\nthe original encoding of Path.\n\nThe RawPath field is an optional field which is only set when the default\nencoding of Path is different from the escaped path. See the EscapedPath method\nfor more details.\n\nURL's String method uses the EscapedPath method to obtain the path.",
-=======
->>>>>>> 961cef7f7de (Regenerate swagger docs)
-=======
-      "description": "The general form represented is:\n\n[scheme:][//[userinfo@]host][/]path[?query][#fragment]\n\nURLs that do not start with a slash after the scheme are interpreted as:\n\nscheme:opaque[?query][#fragment]\n\nThe Host field contains the host and port subcomponents of the URL.\nWhen the port is present, it is separated from the host with a colon.\nWhen the host is an IPv6 address, it must be enclosed in square brackets:\n\"[fe80::1]:80\". The [net.JoinHostPort] function combines a host and port\ninto a string suitable for the Host field, adding square brackets to\nthe host when necessary.\n\nNote that the Path field is stored in decoded form: /%47%6f%2f becomes /Go/.\nA consequence is that it is impossible to tell which slashes in the Path were\nslashes in the raw URL and which were %2f. This distinction is rarely important,\nbut when it is, the code should use the [URL.EscapedPath] method, which preserves\nthe original encoding of Path.\n\nThe RawPath field is an optional field which is only set when the default\nencoding of Path is different from the escaped path. See the EscapedPath method\nfor more details.\n\nURL's String method uses the EscapedPath method to obtain the path.",
->>>>>>> fa144e1652b (Re-generate swagger docs with backdated v0.30.2 version)
       "type": "object",
       "title": "A URL represents a parsed URL (technically, a URI reference).",
       "properties": {
@@ -7961,6 +7951,7 @@
       }
     },
     "alertGroup": {
+      "description": "AlertGroup alert group",
       "type": "object",
       "required": [
         "alerts",
@@ -7985,7 +7976,6 @@
       "$ref": "#/definitions/alertGroup"
     },
     "alertGroups": {
-      "description": "AlertGroups alert groups",
       "type": "array",
       "items": {
         "$ref": "#/definitions/alertGroup"
@@ -8156,6 +8146,7 @@
       "$ref": "#/definitions/gettableAlerts"
     },
     "gettableSilence": {
+      "description": "GettableSilence gettable silence",
       "type": "object",
       "required": [
         "comment",

--- a/pkg/services/ngalert/api/tooling/spec.json
+++ b/pkg/services/ngalert/api/tooling/spec.json
@@ -3849,6 +3849,7 @@
       }
     },
     "AlertRuleNotificationSettingsExport": {
+      "description": "Field name mismatches with Terraform provider schema are noted where applicable.",
       "type": "object",
       "title": "AlertRuleNotificationSettingsExport is the provisioned export of models.NotificationSettings.",
       "properties": {
@@ -3865,12 +3866,14 @@
           "type": "string"
         },
         "mute_time_intervals": {
+          "description": "TF -\u003e `mute_timings`",
           "type": "array",
           "items": {
             "type": "string"
           }
         },
         "receiver": {
+          "description": "TF -\u003e `contact_point`",
           "type": "string"
         },
         "repeat_interval": {
@@ -4480,7 +4483,7 @@
       }
     },
     "EvalQueriesResponse": {
-      "$ref": "#/definitions/EvalQueriesResponse"
+      "type": "object"
     },
     "ExplorePanelsState": {
       "description": "This is an object constructed with the keys as the values of the enum VisType and the value being a bag of properties"
@@ -5087,6 +5090,9 @@
         },
         "provenance": {
           "$ref": "#/definitions/Provenance"
+        },
+        "record": {
+          "$ref": "#/definitions/Record"
         },
         "rule_group": {
           "type": "string"
@@ -6246,6 +6252,9 @@
         "notification_settings": {
           "$ref": "#/definitions/AlertRuleNotificationSettings"
         },
+        "record": {
+          "$ref": "#/definitions/Record"
+        },
         "title": {
           "type": "string"
         },
@@ -6758,6 +6767,18 @@
           "type": "string"
         },
         "uid": {
+          "type": "string"
+        }
+      }
+    },
+    "Record": {
+      "type": "object",
+      "title": "Record defines how data produced by a recording rule is written.",
+      "properties": {
+        "from": {
+          "type": "string"
+        },
+        "metric": {
           "type": "string"
         }
       }
@@ -7691,9 +7712,12 @@
       }
     },
     "URL": {
+<<<<<<< HEAD
       "description": "The general form represented is:\n\n[scheme:][//[userinfo@]host][/]path[?query][#fragment]\n\nURLs that do not start with a slash after the scheme are interpreted as:\n\nscheme:opaque[?query][#fragment]\n\nThe Host field contains the host and port subcomponents of the URL.\nWhen the port is present, it is separated from the host with a colon.\nWhen the host is an IPv6 address, it must be enclosed in square brackets:\n\"[fe80::1]:80\". The [net.JoinHostPort] function combines a host and port\ninto a string suitable for the Host field, adding square brackets to\nthe host when necessary.\n\nNote that the Path field is stored in decoded form: /%47%6f%2f becomes /Go/.\nA consequence is that it is impossible to tell which slashes in the Path were\nslashes in the raw URL and which were %2f. This distinction is rarely important,\nbut when it is, the code should use the [URL.EscapedPath] method, which preserves\nthe original encoding of Path.\n\nThe RawPath field is an optional field which is only set when the default\nencoding of Path is different from the escaped path. See the EscapedPath method\nfor more details.\n\nURL's String method uses the EscapedPath method to obtain the path.",
+=======
+>>>>>>> 961cef7f7de (Regenerate swagger docs)
       "type": "object",
-      "title": "A URL represents a parsed URL (technically, a URI reference).",
+      "title": "URL is a custom URL type that allows validation at configuration load time.",
       "properties": {
         "ForceQuery": {
           "type": "boolean"
@@ -7953,16 +7977,15 @@
         "receiver": {
           "$ref": "#/definitions/receiver"
         }
-      },
-      "$ref": "#/definitions/alertGroup"
+      }
     },
     "alertGroups": {
       "description": "AlertGroups alert groups",
       "type": "array",
       "items": {
+        "type": "object",
         "$ref": "#/definitions/alertGroup"
-      },
-      "$ref": "#/definitions/alertGroups"
+      }
     },
     "alertStatus": {
       "description": "AlertStatus alert status",
@@ -8116,15 +8139,15 @@
           "type": "string",
           "format": "date-time"
         }
-      },
-      "$ref": "#/definitions/gettableAlert"
+      }
     },
     "gettableAlerts": {
+      "description": "GettableAlerts gettable alerts",
       "type": "array",
       "items": {
+        "type": "object",
         "$ref": "#/definitions/gettableAlert"
-      },
-      "$ref": "#/definitions/gettableAlerts"
+      }
     },
     "gettableSilence": {
       "type": "object",
@@ -8137,52 +8160,17 @@
         "id",
         "status",
         "updatedAt"
-      ],
-      "properties": {
-        "comment": {
-          "description": "comment",
-          "type": "string"
-        },
-        "createdBy": {
-          "description": "created by",
-          "type": "string"
-        },
-        "endsAt": {
-          "description": "ends at",
-          "type": "string",
-          "format": "date-time"
-        },
-        "id": {
-          "description": "id",
-          "type": "string"
-        },
-        "matchers": {
-          "$ref": "#/definitions/matchers"
-        },
-        "startsAt": {
-          "description": "starts at",
-          "type": "string",
-          "format": "date-time"
-        },
-        "status": {
-          "$ref": "#/definitions/silenceStatus"
-        },
-        "updatedAt": {
-          "description": "updated at",
-          "type": "string",
-          "format": "date-time"
-        }
-      },
-      "$ref": "#/definitions/gettableSilence"
+      ]
     },
     "gettableSilences": {
       "type": "array",
       "items": {
+        "type": "object",
         "$ref": "#/definitions/gettableSilence"
-      },
-      "$ref": "#/definitions/gettableSilences"
+      }
     },
     "integration": {
+      "description": "Integration integration",
       "type": "object",
       "required": [
         "name",
@@ -8210,8 +8198,7 @@
           "description": "send resolved",
           "type": "boolean"
         }
-      },
-      "$ref": "#/definitions/integration"
+      }
     },
     "labelSet": {
       "description": "LabelSet label set",
@@ -8361,8 +8348,7 @@
           "type": "string",
           "format": "date-time"
         }
-      },
-      "$ref": "#/definitions/postableSilence"
+      }
     },
     "receiver": {
       "type": "object",
@@ -8387,8 +8373,7 @@
           "description": "name",
           "type": "string"
         }
-      },
-      "$ref": "#/definitions/receiver"
+      }
     },
     "silence": {
       "description": "Silence silence",

--- a/pkg/services/ngalert/api/tooling/spec.json
+++ b/pkg/services/ngalert/api/tooling/spec.json
@@ -4483,7 +4483,7 @@
       }
     },
     "EvalQueriesResponse": {
-      "type": "object"
+      "$ref": "#/definitions/EvalQueriesResponse"
     },
     "ExplorePanelsState": {
       "description": "This is an object constructed with the keys as the values of the enum VisType and the value being a bag of properties"
@@ -7713,11 +7713,15 @@
     },
     "URL": {
 <<<<<<< HEAD
+<<<<<<< HEAD
       "description": "The general form represented is:\n\n[scheme:][//[userinfo@]host][/]path[?query][#fragment]\n\nURLs that do not start with a slash after the scheme are interpreted as:\n\nscheme:opaque[?query][#fragment]\n\nThe Host field contains the host and port subcomponents of the URL.\nWhen the port is present, it is separated from the host with a colon.\nWhen the host is an IPv6 address, it must be enclosed in square brackets:\n\"[fe80::1]:80\". The [net.JoinHostPort] function combines a host and port\ninto a string suitable for the Host field, adding square brackets to\nthe host when necessary.\n\nNote that the Path field is stored in decoded form: /%47%6f%2f becomes /Go/.\nA consequence is that it is impossible to tell which slashes in the Path were\nslashes in the raw URL and which were %2f. This distinction is rarely important,\nbut when it is, the code should use the [URL.EscapedPath] method, which preserves\nthe original encoding of Path.\n\nThe RawPath field is an optional field which is only set when the default\nencoding of Path is different from the escaped path. See the EscapedPath method\nfor more details.\n\nURL's String method uses the EscapedPath method to obtain the path.",
 =======
 >>>>>>> 961cef7f7de (Regenerate swagger docs)
+=======
+      "description": "The general form represented is:\n\n[scheme:][//[userinfo@]host][/]path[?query][#fragment]\n\nURLs that do not start with a slash after the scheme are interpreted as:\n\nscheme:opaque[?query][#fragment]\n\nThe Host field contains the host and port subcomponents of the URL.\nWhen the port is present, it is separated from the host with a colon.\nWhen the host is an IPv6 address, it must be enclosed in square brackets:\n\"[fe80::1]:80\". The [net.JoinHostPort] function combines a host and port\ninto a string suitable for the Host field, adding square brackets to\nthe host when necessary.\n\nNote that the Path field is stored in decoded form: /%47%6f%2f becomes /Go/.\nA consequence is that it is impossible to tell which slashes in the Path were\nslashes in the raw URL and which were %2f. This distinction is rarely important,\nbut when it is, the code should use the [URL.EscapedPath] method, which preserves\nthe original encoding of Path.\n\nThe RawPath field is an optional field which is only set when the default\nencoding of Path is different from the escaped path. See the EscapedPath method\nfor more details.\n\nURL's String method uses the EscapedPath method to obtain the path.",
+>>>>>>> fa144e1652b (Re-generate swagger docs with backdated v0.30.2 version)
       "type": "object",
-      "title": "URL is a custom URL type that allows validation at configuration load time.",
+      "title": "A URL represents a parsed URL (technically, a URI reference).",
       "properties": {
         "ForceQuery": {
           "type": "boolean"
@@ -7977,15 +7981,16 @@
         "receiver": {
           "$ref": "#/definitions/receiver"
         }
-      }
+      },
+      "$ref": "#/definitions/alertGroup"
     },
     "alertGroups": {
       "description": "AlertGroups alert groups",
       "type": "array",
       "items": {
-        "type": "object",
         "$ref": "#/definitions/alertGroup"
-      }
+      },
+      "$ref": "#/definitions/alertGroups"
     },
     "alertStatus": {
       "description": "AlertStatus alert status",
@@ -8139,15 +8144,16 @@
           "type": "string",
           "format": "date-time"
         }
-      }
+      },
+      "$ref": "#/definitions/gettableAlert"
     },
     "gettableAlerts": {
       "description": "GettableAlerts gettable alerts",
       "type": "array",
       "items": {
-        "type": "object",
         "$ref": "#/definitions/gettableAlert"
-      }
+      },
+      "$ref": "#/definitions/gettableAlerts"
     },
     "gettableSilence": {
       "type": "object",
@@ -8160,17 +8166,52 @@
         "id",
         "status",
         "updatedAt"
-      ]
+      ],
+      "properties": {
+        "comment": {
+          "description": "comment",
+          "type": "string"
+        },
+        "createdBy": {
+          "description": "created by",
+          "type": "string"
+        },
+        "endsAt": {
+          "description": "ends at",
+          "type": "string",
+          "format": "date-time"
+        },
+        "id": {
+          "description": "id",
+          "type": "string"
+        },
+        "matchers": {
+          "$ref": "#/definitions/matchers"
+        },
+        "startsAt": {
+          "description": "starts at",
+          "type": "string",
+          "format": "date-time"
+        },
+        "status": {
+          "$ref": "#/definitions/silenceStatus"
+        },
+        "updatedAt": {
+          "description": "updated at",
+          "type": "string",
+          "format": "date-time"
+        }
+      },
+      "$ref": "#/definitions/gettableSilence"
     },
     "gettableSilences": {
       "type": "array",
       "items": {
-        "type": "object",
         "$ref": "#/definitions/gettableSilence"
-      }
+      },
+      "$ref": "#/definitions/gettableSilences"
     },
     "integration": {
-      "description": "Integration integration",
       "type": "object",
       "required": [
         "name",
@@ -8198,7 +8239,8 @@
           "description": "send resolved",
           "type": "boolean"
         }
-      }
+      },
+      "$ref": "#/definitions/integration"
     },
     "labelSet": {
       "description": "LabelSet label set",
@@ -8348,7 +8390,8 @@
           "type": "string",
           "format": "date-time"
         }
-      }
+      },
+      "$ref": "#/definitions/postableSilence"
     },
     "receiver": {
       "type": "object",
@@ -8373,7 +8416,8 @@
           "description": "name",
           "type": "string"
         }
-      }
+      },
+      "$ref": "#/definitions/receiver"
     },
     "silence": {
       "description": "Silence silence",

--- a/pkg/services/ngalert/models/alert_rule.go
+++ b/pkg/services/ngalert/models/alert_rule.go
@@ -337,6 +337,12 @@ func (alertRule *AlertRule) GetLabels(opts ...LabelOption) map[string]string {
 }
 
 func (alertRule *AlertRule) GetEvalCondition() Condition {
+	if alertRule.IsRecordingRule() {
+		return Condition{
+			Condition: alertRule.Record.From,
+			Data:      alertRule.Data,
+		}
+	}
 	return Condition{
 		Condition: alertRule.Condition,
 		Data:      alertRule.Data,

--- a/pkg/tests/api/alerting/api_alertmanager_test.go
+++ b/pkg/tests/api/alerting/api_alertmanager_test.go
@@ -908,8 +908,9 @@ func TestIntegrationAlertRuleCRUD(t *testing.T) {
 						Annotations: map[string]string{"annotation1": "val1"},
 					},
 					GrafanaManagedAlert: &apimodels.PostableGrafanaRule{
-						Title: "AlwaysFiring",
-						Data:  []apimodels.AlertQuery{},
+						Title:     "AlwaysFiring",
+						Condition: "A",
+						Data:      []apimodels.AlertQuery{},
 					},
 				},
 				expectedMessage: "invalid rule specification at index [0]: invalid alert rule: no queries or expressions are found",

--- a/public/api-merged.json
+++ b/public/api-merged.json
@@ -12171,7 +12171,6 @@
       }
     },
     "AlertRuleNotificationSettingsExport": {
-      "description": "Field name mismatches with Terraform provider schema are noted where applicable.",
       "type": "object",
       "title": "AlertRuleNotificationSettingsExport is the provisioned export of models.NotificationSettings.",
       "properties": {
@@ -12188,14 +12187,12 @@
           "type": "string"
         },
         "mute_time_intervals": {
-          "description": "TF -\u003e `mute_timings`",
           "type": "array",
           "items": {
             "type": "string"
           }
         },
         "receiver": {
-          "description": "TF -\u003e `contact_point`",
           "type": "string"
         },
         "repeat_interval": {
@@ -21309,6 +21306,7 @@
       }
     },
     "alertGroup": {
+      "description": "AlertGroup alert group",
       "type": "object",
       "required": [
         "alerts",
@@ -21465,7 +21463,6 @@
       }
     },
     "gettableAlert": {
-      "description": "GettableAlert gettable alert",
       "type": "object",
       "required": [
         "labels",
@@ -21576,6 +21573,7 @@
       }
     },
     "gettableSilences": {
+      "description": "GettableSilences gettable silences",
       "type": "array",
       "items": {
         "$ref": "#/definitions/gettableSilence"
@@ -21725,7 +21723,6 @@
       }
     },
     "postableSilence": {
-      "description": "PostableSilence postable silence",
       "type": "object",
       "required": [
         "comment",

--- a/public/api-merged.json
+++ b/public/api-merged.json
@@ -12171,6 +12171,7 @@
       }
     },
     "AlertRuleNotificationSettingsExport": {
+      "description": "Field name mismatches with Terraform provider schema are noted where applicable.",
       "type": "object",
       "title": "AlertRuleNotificationSettingsExport is the provisioned export of models.NotificationSettings.",
       "properties": {
@@ -12187,12 +12188,14 @@
           "type": "string"
         },
         "mute_time_intervals": {
+          "description": "TF -\u003e `mute_timings`",
           "type": "array",
           "items": {
             "type": "string"
           }
         },
         "receiver": {
+          "description": "TF -\u003e `contact_point`",
           "type": "string"
         },
         "repeat_interval": {
@@ -15319,6 +15322,9 @@
         "provenance": {
           "$ref": "#/definitions/Provenance"
         },
+        "record": {
+          "$ref": "#/definitions/Record"
+        },
         "rule_group": {
           "type": "string"
         },
@@ -17529,6 +17535,9 @@
         "notification_settings": {
           "$ref": "#/definitions/AlertRuleNotificationSettings"
         },
+        "record": {
+          "$ref": "#/definitions/Record"
+        },
         "title": {
           "type": "string"
         },
@@ -18333,6 +18342,18 @@
           "type": "string"
         },
         "uid": {
+          "type": "string"
+        }
+      }
+    },
+    "Record": {
+      "type": "object",
+      "title": "Record defines how data produced by a recording rule is written.",
+      "properties": {
+        "from": {
+          "type": "string"
+        },
+        "metric": {
           "type": "string"
         }
       }
@@ -21500,6 +21521,7 @@
       }
     },
     "gettableAlerts": {
+      "description": "GettableAlerts gettable alerts",
       "type": "array",
       "items": {
         "$ref": "#/definitions/gettableAlert"
@@ -21560,7 +21582,6 @@
       }
     },
     "integration": {
-      "description": "Integration integration",
       "type": "object",
       "required": [
         "name",
@@ -21770,6 +21791,7 @@
       }
     },
     "receiver": {
+      "description": "Receiver receiver",
       "type": "object",
       "required": [
         "active",

--- a/public/openapi3.json
+++ b/public/openapi3.json
@@ -2692,7 +2692,6 @@
         "type": "object"
       },
       "AlertRuleNotificationSettingsExport": {
-        "description": "Field name mismatches with Terraform provider schema are noted where applicable.",
         "properties": {
           "group_by": {
             "items": {
@@ -2707,14 +2706,12 @@
             "type": "string"
           },
           "mute_time_intervals": {
-            "description": "TF -\u003e `mute_timings`",
             "items": {
               "type": "string"
             },
             "type": "array"
           },
           "receiver": {
-            "description": "TF -\u003e `contact_point`",
             "type": "string"
           },
           "repeat_interval": {
@@ -11829,6 +11826,7 @@
         "type": "object"
       },
       "alertGroup": {
+        "description": "AlertGroup alert group",
         "properties": {
           "alerts": {
             "description": "alerts",
@@ -11985,7 +11983,6 @@
         "type": "object"
       },
       "gettableAlert": {
-        "description": "GettableAlert gettable alert",
         "properties": {
           "annotations": {
             "$ref": "#/components/schemas/labelSet"
@@ -12096,6 +12093,7 @@
         "type": "object"
       },
       "gettableSilences": {
+        "description": "GettableSilences gettable silences",
         "items": {
           "$ref": "#/components/schemas/gettableSilence"
         },
@@ -12245,7 +12243,6 @@
         "type": "array"
       },
       "postableSilence": {
-        "description": "PostableSilence postable silence",
         "properties": {
           "comment": {
             "description": "comment",

--- a/public/openapi3.json
+++ b/public/openapi3.json
@@ -2692,6 +2692,7 @@
         "type": "object"
       },
       "AlertRuleNotificationSettingsExport": {
+        "description": "Field name mismatches with Terraform provider schema are noted where applicable.",
         "properties": {
           "group_by": {
             "items": {
@@ -2706,12 +2707,14 @@
             "type": "string"
           },
           "mute_time_intervals": {
+            "description": "TF -\u003e `mute_timings`",
             "items": {
               "type": "string"
             },
             "type": "array"
           },
           "receiver": {
+            "description": "TF -\u003e `contact_point`",
             "type": "string"
           },
           "repeat_interval": {
@@ -5839,6 +5842,9 @@
           "provenance": {
             "$ref": "#/components/schemas/Provenance"
           },
+          "record": {
+            "$ref": "#/components/schemas/Record"
+          },
           "rule_group": {
             "type": "string"
           },
@@ -8049,6 +8055,9 @@
           "notification_settings": {
             "$ref": "#/components/schemas/AlertRuleNotificationSettings"
           },
+          "record": {
+            "$ref": "#/components/schemas/Record"
+          },
           "title": {
             "type": "string"
           },
@@ -8856,6 +8865,18 @@
           }
         },
         "title": "ReceiverExport is the provisioned file export of alerting.ReceiverV1.",
+        "type": "object"
+      },
+      "Record": {
+        "properties": {
+          "from": {
+            "type": "string"
+          },
+          "metric": {
+            "type": "string"
+          }
+        },
+        "title": "Record defines how data produced by a recording rule is written.",
         "type": "object"
       },
       "RecordingRuleJSON": {
@@ -12020,6 +12041,7 @@
         "type": "object"
       },
       "gettableAlerts": {
+        "description": "GettableAlerts gettable alerts",
         "items": {
           "$ref": "#/components/schemas/gettableAlert"
         },
@@ -12080,7 +12102,6 @@
         "type": "array"
       },
       "integration": {
-        "description": "Integration integration",
         "properties": {
           "lastNotifyAttempt": {
             "description": "A timestamp indicating the last attempt to deliver a notification regardless of the outcome.\nFormat: date-time",
@@ -12290,6 +12311,7 @@
         "type": "object"
       },
       "receiver": {
+        "description": "Receiver receiver",
         "properties": {
           "active": {
             "description": "active",


### PR DESCRIPTION
**What is this feature?**

Adds support for creating recording rules in the main API.

Recording rules have a new field, `Record`, and lack several of the other "statefulness" fields that only make sense for alerting rules.

Extends the validation logic to have two paths. Shared validation happens, then we try to detect if the rule is a recording or alerting rule, then validate the remaining fields as needed.

**Why do we need this feature?**

Allows users to manipulate recording rules over the API, and eventually the UI.

**Which issue(s) does this PR fix?**:

n/a

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle.
- [x] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
