### PR TITLE
Table Panel: Add Stat Cell

### DIFF
--- a/packages/grafana-schema/src/common/common.gen.ts
+++ b/packages/grafana-schema/src/common/common.gen.ts
@@ -693,6 +693,7 @@ export enum TableCellDisplayMode {
   JSONView = 'json-view',
   LcdGauge = 'lcd-gauge',
   Sparkline = 'sparkline',
+  Stat = 'stat',
 }
 
 /**
@@ -809,7 +810,12 @@ export enum TableCellHeight {
  * Table cell options. Each cell has a display mode
  * and other potential options for that display.
  */
-export type TableCellOptions = (TableAutoCellOptions | TableSparklineCellOptions | TableBarGaugeCellOptions | TableColoredBackgroundCellOptions | TableColorTextCellOptions | TableImageCellOptions | TableDataLinksCellOptions | TableJsonViewCellOptions);
+export type TableCellOptions = (TableAutoCellOptions | TableSparklineCellOptions | TableBarGaugeCellOptions | TableColoredBackgroundCellOptions | TableColorTextCellOptions | TableImageCellOptions | TableDataLinksCellOptions | TableJsonViewCellOptions | {
+    type: TableCellDisplayMode.Stat
+    reduceOptions: ReduceDataOptions
+    text?: VizTextDisplayOptions
+    orientation: VizOrientation
+  });
 
 /**
  * Use UTC/GMT timezone

--- a/packages/grafana-schema/src/common/table.cue
+++ b/packages/grafana-schema/src/common/table.cue
@@ -4,7 +4,7 @@ package common
 // in the table such as colored text, JSON, gauge, etc.
 // The color-background-solid, gradient-gauge, and lcd-gauge
 // modes are deprecated in favor of new cell subOptions
-TableCellDisplayMode: "auto" | "color-text" | "color-background" | "color-background-solid" | "gradient-gauge" | "lcd-gauge" | "json-view" | "basic" | "image" | "gauge" | "sparkline" | "data-links" | "custom" @cuetsy(kind="enum",memberNames="Auto|ColorText|ColorBackground|ColorBackgroundSolid|GradientGauge|LcdGauge|JSONView|BasicGauge|Image|Gauge|Sparkline|DataLinks|Custom")
+TableCellDisplayMode: "auto" | "color-text" | "color-background" | "color-background-solid" | "gradient-gauge" | "lcd-gauge" | "json-view" | "basic" | "image" | "gauge" | "sparkline" | "data-links" | "stat" | "custom" @cuetsy(kind="enum",memberNames="Auto|ColorText|ColorBackground|ColorBackgroundSolid|GradientGauge|LcdGauge|JSONView|BasicGauge|Image|Gauge|Sparkline|DataLinks|Stat|Custom")
 
 // Display mode to the "Colored Background" display
 // mode for table cells. Either displays a solid color (basic mode)
@@ -74,12 +74,18 @@ TableColoredBackgroundCellOptions: {
 	applyToRow?: bool
 } @cuetsy(kind="interface")
 
+// Stat cell options
+TableStatCellOptions: {
+	SingleStatBaseOptions?
+	type: TableCellDisplayMode & "stat"
+}
+
 // Height of a table cell
 TableCellHeight: "sm" | "md" | "lg" @cuetsy(kind="enum")
 
 // Table cell options. Each cell has a display mode
 // and other potential options for that display.
-TableCellOptions: TableAutoCellOptions | TableSparklineCellOptions | TableBarGaugeCellOptions | TableColoredBackgroundCellOptions | TableColorTextCellOptions | TableImageCellOptions | TableDataLinksCellOptions | TableJsonViewCellOptions @cuetsy(kind="type")
+TableCellOptions: TableAutoCellOptions | TableSparklineCellOptions | TableBarGaugeCellOptions | TableColoredBackgroundCellOptions | TableColorTextCellOptions | TableImageCellOptions | TableDataLinksCellOptions | TableJsonViewCellOptions | TableStatCellOptions @cuetsy(kind="type")
 
 // Field options for each field within a table (e.g 10, "The String", 64.20, etc.)
 // Generally defines alignment, filtering capabilties, display options, etc.

--- a/packages/grafana-ui/src/components/Table/StatCell.tsx
+++ b/packages/grafana-ui/src/components/Table/StatCell.tsx
@@ -1,0 +1,13 @@
+import React from 'react';
+
+import { BigValue } from '..';
+
+import { TableCellProps } from './types';
+
+
+
+export const StatCell = (props: TableCellProps) => {
+    const { cell } = props;
+
+    return <BigValue value={cell.value} />;
+};

--- a/public/app/plugins/panel/table/TableCellOptionEditor.tsx
+++ b/public/app/plugins/panel/table/TableCellOptionEditor.tsx
@@ -78,6 +78,7 @@ const cellDisplayModeOptions: Array<SelectableValue<TableCellOptions>> = [
   { value: { type: TableCellDisplayMode.Sparkline }, label: 'Sparkline' },
   { value: { type: TableCellDisplayMode.ColorText }, label: 'Colored text' },
   { value: { type: TableCellDisplayMode.ColorBackground }, label: 'Colored background' },
+  { value: { type: TableCellDisplayMode.Stat }, label: 'Stat' },
   { value: { type: TableCellDisplayMode.Gauge }, label: 'Gauge' },
   { value: { type: TableCellDisplayMode.DataLinks }, label: 'Data links' },
   { value: { type: TableCellDisplayMode.JSONView }, label: 'JSON View' },


### PR DESCRIPTION
This PR adds a stat cell to the table panel. This is useful as many users want to display prominent statistics on tables for a variety of use cases including ops monitoring (think CPU, Load, etc), finance (dollars, trends and more), science (monitor values), and more besides.

Currently not really working but added here to track progress. 

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
