### PR TITLE
K8s: add server run options

### DIFF
--- a/pkg/services/apiserver/options/options.go
+++ b/pkg/services/apiserver/options/options.go
@@ -20,7 +20,6 @@ const defaultEtcdPathPrefix = "/registry/grafana.app"
 
 type Options struct {
 	RecommendedOptions *genericoptions.RecommendedOptions
-	ServerRunOptions   *genericoptions.ServerRunOptions
 	AggregatorOptions  *AggregatorServerOptions
 	StorageOptions     *StorageOptions
 	ExtraOptions       *ExtraOptions
@@ -33,13 +32,11 @@ func NewOptions(codec runtime.Codec) *Options {
 		AggregatorOptions:  NewAggregatorServerOptions(),
 		StorageOptions:     NewStorageOptions(),
 		ExtraOptions:       NewExtraOptions(),
-		ServerRunOptions:   genericoptions.NewServerRunOptions(),
 	}
 }
 
 func (o *Options) AddFlags(fs *pflag.FlagSet) {
 	o.RecommendedOptions.AddFlags(fs)
-	o.ServerRunOptions.AddUniversalFlags(fs)
 	o.AggregatorOptions.AddFlags(fs)
 	o.StorageOptions.AddFlags(fs)
 	o.ExtraOptions.AddFlags(fs)
@@ -86,10 +83,6 @@ func (o *Options) Validate() []error {
 		}
 	}
 
-	if errs := o.ServerRunOptions.Validate(); len(errs) != 0 {
-		return errs
-	}
-
 	return nil
 }
 
@@ -112,10 +105,6 @@ func (o *Options) ApplyTo(serverConfig *genericapiserver.RecommendedConfig) erro
 	}
 
 	if err := o.RecommendedOptions.Authentication.ApplyTo(&serverConfig.Authentication, serverConfig.SecureServing, serverConfig.OpenAPIConfig); err != nil {
-		return err
-	}
-
-	if err := o.ServerRunOptions.ApplyTo(&serverConfig.Config); err != nil {
 		return err
 	}
 

--- a/pkg/services/apiserver/options/options.go
+++ b/pkg/services/apiserver/options/options.go
@@ -20,6 +20,7 @@ const defaultEtcdPathPrefix = "/registry/grafana.app"
 
 type Options struct {
 	RecommendedOptions *genericoptions.RecommendedOptions
+	ServerRunOptions   *genericoptions.ServerRunOptions
 	AggregatorOptions  *AggregatorServerOptions
 	StorageOptions     *StorageOptions
 	ExtraOptions       *ExtraOptions
@@ -32,11 +33,13 @@ func NewOptions(codec runtime.Codec) *Options {
 		AggregatorOptions:  NewAggregatorServerOptions(),
 		StorageOptions:     NewStorageOptions(),
 		ExtraOptions:       NewExtraOptions(),
+		ServerRunOptions:   genericoptions.NewServerRunOptions(),
 	}
 }
 
 func (o *Options) AddFlags(fs *pflag.FlagSet) {
 	o.RecommendedOptions.AddFlags(fs)
+	o.ServerRunOptions.AddUniversalFlags(fs)
 	o.AggregatorOptions.AddFlags(fs)
 	o.StorageOptions.AddFlags(fs)
 	o.ExtraOptions.AddFlags(fs)
@@ -82,6 +85,11 @@ func (o *Options) Validate() []error {
 			return errs
 		}
 	}
+
+	if errs := o.ServerRunOptions.Validate(); len(errs) != 0 {
+		return errs
+	}
+
 	return nil
 }
 
@@ -104,6 +112,10 @@ func (o *Options) ApplyTo(serverConfig *genericapiserver.RecommendedConfig) erro
 	}
 
 	if err := o.RecommendedOptions.Authentication.ApplyTo(&serverConfig.Authentication, serverConfig.SecureServing, serverConfig.OpenAPIConfig); err != nil {
+		return err
+	}
+
+	if err := o.ServerRunOptions.ApplyTo(&serverConfig.Config); err != nil {
 		return err
 	}
 

--- a/pkg/services/apiserver/options/options.go
+++ b/pkg/services/apiserver/options/options.go
@@ -82,7 +82,6 @@ func (o *Options) Validate() []error {
 			return errs
 		}
 	}
-
 	return nil
 }
 

--- a/pkg/services/apiserver/standalone/options/options.go
+++ b/pkg/services/apiserver/standalone/options/options.go
@@ -15,6 +15,7 @@ type Options struct {
 	RecommendedOptions *genericoptions.RecommendedOptions
 	TracingOptions     *TracingOptions
 	MetricsOptions     *MetricsOptions
+	ServerRunOptions   *genericoptions.ServerRunOptions
 }
 
 func New(logger log.Logger, codec runtime.Codec) *Options {
@@ -24,6 +25,7 @@ func New(logger log.Logger, codec runtime.Codec) *Options {
 		RecommendedOptions: options.NewRecommendedOptions(codec),
 		TracingOptions:     NewTracingOptions(logger),
 		MetricsOptions:     NewMetrcicsOptions(logger),
+		ServerRunOptions:   genericoptions.NewServerRunOptions(),
 	}
 }
 
@@ -33,6 +35,7 @@ func (o *Options) AddFlags(fs *pflag.FlagSet) {
 	o.RecommendedOptions.AddFlags(fs)
 	o.TracingOptions.AddFlags(fs)
 	o.MetricsOptions.AddFlags(fs)
+	o.ServerRunOptions.AddUniversalFlags(fs)
 }
 
 func (o *Options) Validate() []error {
@@ -49,6 +52,10 @@ func (o *Options) Validate() []error {
 	}
 
 	if errs := o.MetricsOptions.Validate(); len(errs) != 0 {
+		return errs
+	}
+
+	if errs := o.ServerRunOptions.Validate(); len(errs) != 0 {
 		return errs
 	}
 
@@ -117,6 +124,10 @@ func (o *Options) ModifiedApplyTo(config *genericapiserver.RecommendedConfig) er
 		return err
 	}
 
+	if err := o.ServerRunOptions.ApplyTo(&config.Config); err != nil {
+		return err
+	}
+
 	return nil
 }
 
@@ -151,6 +162,12 @@ func (o *Options) ApplyTo(serverConfig *genericapiserver.RecommendedConfig) erro
 
 	if o.MetricsOptions != nil {
 		if err := o.MetricsOptions.ApplyTo(serverConfig); err != nil {
+			return err
+		}
+	}
+
+	if o.ServerRunOptions != nil {
+		if err := o.ServerRunOptions.ApplyTo(&serverConfig.Config); err != nil {
 			return err
 		}
 	}


### PR DESCRIPTION
**What is this feature?**

This PR adds in the [ServerRunOptions](https://pkg.go.dev/k8s.io/apiserver@v0.29.2/pkg/server/options#ServerRunOptions) to the standalone api server flags. 

**Why do we need this feature?**

K8s has a [default max of 400 requests in flight](https://github.com/kubernetes/kubernetes/blob/master/staging/src/k8s.io/apiserver/pkg/server/config.go#L420). We were hitting that limit before we had any issues while load testing

Relates to https://github.com/grafana/app-platform-wg/issues/88