### PR TITLE
Chore: Grafana without cgo (sqlite)

### DIFF
--- a/pkg/services/sqlstore/database_wrapper.go
+++ b/pkg/services/sqlstore/database_wrapper.go
@@ -11,7 +11,6 @@ import (
 	"github.com/gchaincl/sqlhooks"
 	"github.com/go-sql-driver/mysql"
 	"github.com/lib/pq"
-	"github.com/mattn/go-sqlite3"
 	"github.com/prometheus/client_golang/prometheus"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/trace"
@@ -42,7 +41,7 @@ func init() {
 // database queries. It also registers the metrics.
 func WrapDatabaseDriverWithHooks(dbType string, tracer tracing.Tracer) string {
 	drivers := map[string]driver.Driver{
-		migrator.SQLite:   &sqlite3.SQLiteDriver{},
+		migrator.SQLite:   migrator.SQLite3Driver,
 		migrator.MySQL:    &mysql.MySQLDriver{},
 		migrator.Postgres: &pq.Driver{},
 	}

--- a/pkg/services/sqlstore/migrator/migrator.go
+++ b/pkg/services/sqlstore/migrator/migrator.go
@@ -1,14 +1,14 @@
 package migrator
 
 import (
-	"errors"
 	"fmt"
 	"time"
 
 	_ "github.com/go-sql-driver/mysql"
-	"github.com/golang-migrate/migrate/v4/database"
 	_ "github.com/lib/pq"
-	"github.com/mattn/go-sqlite3"
+	_ "modernc.org/sqlite"
+
+	"github.com/golang-migrate/migrate/v4/database"
 	"go.uber.org/atomic"
 	"xorm.io/xorm"
 
@@ -211,7 +211,7 @@ func (mg *Migrator) run() (err error) {
 			err := mg.exec(m, sess)
 			// if we get an sqlite busy/locked error, sleep 100ms and try again
 			cnt := 0
-			for cnt < 3 && (errors.Is(err, sqlite3.ErrLocked) || errors.Is(err, sqlite3.ErrBusy)) {
+			for cnt < 3 && IsSQLiteErrLocked(err) {
 				cnt++
 				mg.Logger.Debug("Database locked, sleeping then retrying", "error", err, "sql", sql)
 				time.Sleep(100 * time.Millisecond)

--- a/pkg/services/sqlstore/migrator/sqlite_dialect.go
+++ b/pkg/services/sqlstore/migrator/sqlite_dialect.go
@@ -1,11 +1,9 @@
 package migrator
 
 import (
-	"errors"
 	"fmt"
 	"strings"
 
-	"github.com/mattn/go-sqlite3"
 	"xorm.io/xorm"
 )
 
@@ -129,29 +127,6 @@ func (db *SQLite3) TruncateDBTables(engine *xorm.Engine) error {
 		}
 	}
 	return nil
-}
-
-func (db *SQLite3) isThisError(err error, errcode int) bool {
-	var driverErr sqlite3.Error
-	if errors.As(err, &driverErr) {
-		if int(driverErr.ExtendedCode) == errcode {
-			return true
-		}
-	}
-
-	return false
-}
-
-func (db *SQLite3) ErrorMessage(err error) string {
-	var driverErr sqlite3.Error
-	if errors.As(err, &driverErr) {
-		return driverErr.Error()
-	}
-	return ""
-}
-
-func (db *SQLite3) IsUniqueConstraintViolation(err error) bool {
-	return db.isThisError(err, int(sqlite3.ErrConstraintUnique)) || db.isThisError(err, int(sqlite3.ErrConstraintPrimaryKey))
 }
 
 func (db *SQLite3) IsDeadlock(err error) bool {

--- a/pkg/services/sqlstore/migrator/sqlite_dialect_cgo.go
+++ b/pkg/services/sqlstore/migrator/sqlite_dialect_cgo.go
@@ -1,0 +1,47 @@
+//go:build cgo
+
+package migrator
+
+import (
+	"errors"
+
+	"github.com/mattn/go-sqlite3"
+)
+
+const SQLite = "sqlite3"
+
+var SQLite3Driver = &sqlite3.SQLiteDriver{}
+
+func IsSQLiteErrLocked(err error) bool {
+	return errors.Is(err, sqlite3.ErrLocked) || errors.Is(err, sqlite3.ErrBusy)
+}
+func SQLiteErrCode(err error) int {
+	var sqliteErr sqlite3.Error
+	if !errors.As(err, &sqliteErr) {
+		return 0
+	}
+	return int(sqliteErr.Code)
+}
+
+func (db *SQLite3) isThisError(err error, errcode int) bool {
+	var driverErr sqlite3.Error
+	if errors.As(err, &driverErr) {
+		if int(driverErr.ExtendedCode) == errcode {
+			return true
+		}
+	}
+
+	return false
+}
+
+func (db *SQLite3) ErrorMessage(err error) string {
+	var driverErr sqlite3.Error
+	if errors.As(err, &driverErr) {
+		return driverErr.Error()
+	}
+	return ""
+}
+
+func (db *SQLite3) IsUniqueConstraintViolation(err error) bool {
+	return db.isThisError(err, int(sqlite3.ErrConstraintUnique)) || db.isThisError(err, int(sqlite3.ErrConstraintPrimaryKey))
+}

--- a/pkg/services/sqlstore/migrator/sqlite_dialect_nocgo.go
+++ b/pkg/services/sqlstore/migrator/sqlite_dialect_nocgo.go
@@ -1,0 +1,42 @@
+//go:build !cgo
+
+package migrator
+
+import (
+	"errors"
+
+	"modernc.org/sqlite"
+	libsqlite "modernc.org/sqlite/lib"
+)
+
+const SQLite = "sqlite"
+
+var SQLite3Driver = &sqlite.Driver{}
+
+func IsSQLiteErrLocked(err error) bool {
+	code := SQLiteErrCode(err)
+	return code == libsqlite.SQLITE_LOCKED || code == libsqlite.SQLITE_BUSY
+}
+
+func SQLiteErrCode(err error) int {
+	var driverErr *sqlite.Error
+	if errors.As(err, &driverErr) {
+		return driverErr.Code()
+	}
+	return 0
+}
+
+func (db *SQLite3) ErrorMessage(err error) string {
+	var driverErr *sqlite.Error
+	if errors.As(err, &driverErr) {
+		return driverErr.Error()
+	}
+	return ""
+}
+
+func (db *SQLite3) IsUniqueConstraintViolation(err error) bool {
+	code := SQLiteErrCode(err)
+	return code == libsqlite.SQLITE_CONSTRAINT
+}
+
+func (db *SQLite3) isThisError(err error, errcode int) bool { return SQLiteErrCode(err) == errcode }

--- a/pkg/services/sqlstore/migrator/types.go
+++ b/pkg/services/sqlstore/migrator/types.go
@@ -9,7 +9,6 @@ import (
 
 const (
 	Postgres = "postgres"
-	SQLite   = "sqlite3"
 	MySQL    = "mysql"
 	MSSQL    = "mssql"
 )

--- a/pkg/util/xorm/xorm.go
+++ b/pkg/util/xorm/xorm.go
@@ -35,6 +35,7 @@ func regDrvsNDialects() bool {
 		"postgres": {"postgres", func() core.Driver { return &pqDriver{} }, func() core.Dialect { return &postgres{} }},
 		"pgx":      {"postgres", func() core.Driver { return &pqDriverPgx{} }, func() core.Dialect { return &postgres{} }},
 		"sqlite3":  {"sqlite3", func() core.Driver { return &sqlite3Driver{} }, func() core.Dialect { return &sqlite3{} }},
+		"sqlite":   {"sqlite", func() core.Driver { return &sqlite3Driver{} }, func() core.Dialect { return &sqlite3{} }},
 	}
 
 	for driverName, v := range providedDrvsNDialects {


### PR DESCRIPTION
This is an experiment and WIP, do not merge!

At the moment it allows building/running Grafana with MySQL/Postgres without CGo. SQLite support is WIP, it builds but fails to run the initial migrations properly.

- [x] Use build flags to disable mattn/go-sqlite
- [x] Move SQLite-specific code into a separate pair of files (with and without cgo)
- [x] Add modernc.org/sqlite for non-cgo builds
- [x] Treat both "sqlite" and "sqlite3" as possible sqlite dialect names
- [x] >>> WE ARE HERE <<< It builds and starts, but fails on migrations (famous "database is locked")
- [x] ~Pragma + delay doesn't seem to help~
- [x] ~We also seem to have nested transactions which modernc.org/sqlite does not support (how then mattn sqlite supported them?)~ modernc sqlite driver does not support concurrent sessions, so if two sessions make a transaction each - they appear like a single nested transaction (BEGIN followed by another BEGIN) to the sqlite driver, which causes an error (C SQLite fails to make two nested transactions, as well).
- [ ] Also Grafana seems to fail to start when max_open_conns = 1 (one known place is migrations, it can be fixed, but there are more that cause a deadlock).
- [ ] Looks like we should either have a global (per-DB) mutex for transactions or fix max_open_conns = 1.

A quick way to test it on macOS:

```
GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -o grafana ./pkg/cmd/grafana  
docker build --platform linux/amd64 -t grafana_nocgo -f Dockerfile.distroless .
docker run  --platform linux/amd64 -p 3000:3000 -it --rm grafana_nocgo
```

Where dockerfile is rather trivial:

```
FROM gcr.io/distroless/static-debian11
COPY grafana /grafana
COPY devenv /devenv
COPY public /public
COPY conf /conf
EXPOSE 3000
CMD ["/grafana", "server"]
```