### PR TITLE
Plugins: Add baseMiddleware support

### DIFF
--- a/pkg/services/pluginsintegration/clientmiddleware/base_middleware.go
+++ b/pkg/services/pluginsintegration/clientmiddleware/base_middleware.go
@@ -1,0 +1,43 @@
+package clientmiddleware
+
+import (
+	"context"
+
+	"github.com/grafana/grafana-plugin-sdk-go/backend"
+
+	"github.com/grafana/grafana/pkg/plugins"
+)
+
+var _ = plugins.Client(&baseMiddleware{})
+
+type baseMiddleware struct {
+	next plugins.Client
+}
+
+func (m *baseMiddleware) QueryData(ctx context.Context, req *backend.QueryDataRequest) (*backend.QueryDataResponse, error) {
+	return m.next.QueryData(ctx, req)
+}
+
+func (m *baseMiddleware) CallResource(ctx context.Context, req *backend.CallResourceRequest, sender backend.CallResourceResponseSender) error {
+	return m.next.CallResource(ctx, req, sender)
+}
+
+func (m *baseMiddleware) CheckHealth(ctx context.Context, req *backend.CheckHealthRequest) (*backend.CheckHealthResult, error) {
+	return m.next.CheckHealth(ctx, req)
+}
+
+func (m *baseMiddleware) CollectMetrics(ctx context.Context, req *backend.CollectMetricsRequest) (*backend.CollectMetricsResult, error) {
+	return m.next.CollectMetrics(ctx, req)
+}
+
+func (m *baseMiddleware) SubscribeStream(ctx context.Context, req *backend.SubscribeStreamRequest) (*backend.SubscribeStreamResponse, error) {
+	return m.next.SubscribeStream(ctx, req)
+}
+
+func (m *baseMiddleware) PublishStream(ctx context.Context, req *backend.PublishStreamRequest) (*backend.PublishStreamResponse, error) {
+	return m.next.PublishStream(ctx, req)
+}
+
+func (m *baseMiddleware) RunStream(ctx context.Context, req *backend.RunStreamRequest, sender *backend.StreamSender) error {
+	return m.next.RunStream(ctx, req, sender)
+}

--- a/pkg/services/pluginsintegration/clientmiddleware/base_middleware.go
+++ b/pkg/services/pluginsintegration/clientmiddleware/base_middleware.go
@@ -10,6 +10,8 @@ import (
 
 var _ = plugins.Client(&baseMiddleware{})
 
+// The base middleware simply passes the request down the chain
+// This allows middleware to avoid implementing all the noop functions
 type baseMiddleware struct {
 	next plugins.Client
 }

--- a/pkg/services/pluginsintegration/clientmiddleware/caching_middleware.go
+++ b/pkg/services/pluginsintegration/clientmiddleware/caching_middleware.go
@@ -47,8 +47,6 @@ func NewCachingMiddlewareWithFeatureManager(cachingService caching.CachingServic
 	})
 }
 
-var _ = plugins.Client(&CachingMiddleware{})
-
 type CachingMiddleware struct {
 	baseMiddleware
 

--- a/pkg/services/pluginsintegration/clientmiddleware/caching_middleware.go
+++ b/pkg/services/pluginsintegration/clientmiddleware/caching_middleware.go
@@ -37,7 +37,9 @@ func NewCachingMiddlewareWithFeatureManager(cachingService caching.CachingServic
 	}
 	return plugins.ClientMiddlewareFunc(func(next plugins.Client) plugins.Client {
 		return &CachingMiddleware{
-			next:     next,
+			baseMiddleware: baseMiddleware{
+				next: next,
+			},
 			caching:  cachingService,
 			log:      log,
 			features: features,
@@ -45,8 +47,11 @@ func NewCachingMiddlewareWithFeatureManager(cachingService caching.CachingServic
 	})
 }
 
+var _ = plugins.Client(&CachingMiddleware{})
+
 type CachingMiddleware struct {
-	next     plugins.Client
+	baseMiddleware
+
 	caching  caching.CachingService
 	log      log.Logger
 	features featuremgmt.FeatureToggles
@@ -163,24 +168,4 @@ func (m *CachingMiddleware) CallResource(ctx context.Context, req *backend.CallR
 	})
 
 	return m.next.CallResource(ctx, req, cacheSender)
-}
-
-func (m *CachingMiddleware) CheckHealth(ctx context.Context, req *backend.CheckHealthRequest) (*backend.CheckHealthResult, error) {
-	return m.next.CheckHealth(ctx, req)
-}
-
-func (m *CachingMiddleware) CollectMetrics(ctx context.Context, req *backend.CollectMetricsRequest) (*backend.CollectMetricsResult, error) {
-	return m.next.CollectMetrics(ctx, req)
-}
-
-func (m *CachingMiddleware) SubscribeStream(ctx context.Context, req *backend.SubscribeStreamRequest) (*backend.SubscribeStreamResponse, error) {
-	return m.next.SubscribeStream(ctx, req)
-}
-
-func (m *CachingMiddleware) PublishStream(ctx context.Context, req *backend.PublishStreamRequest) (*backend.PublishStreamResponse, error) {
-	return m.next.PublishStream(ctx, req)
-}
-
-func (m *CachingMiddleware) RunStream(ctx context.Context, req *backend.RunStreamRequest, sender *backend.StreamSender) error {
-	return m.next.RunStream(ctx, req, sender)
 }

--- a/pkg/services/pluginsintegration/clientmiddleware/clear_auth_headers_middleware.go
+++ b/pkg/services/pluginsintegration/clientmiddleware/clear_auth_headers_middleware.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
+
 	"github.com/grafana/grafana/pkg/plugins"
 	"github.com/grafana/grafana/pkg/services/contexthandler"
 )
@@ -14,13 +15,15 @@ import (
 func NewClearAuthHeadersMiddleware() plugins.ClientMiddleware {
 	return plugins.ClientMiddlewareFunc(func(next plugins.Client) plugins.Client {
 		return &ClearAuthHeadersMiddleware{
-			next: next,
+			baseMiddleware: baseMiddleware{
+				next: next,
+			},
 		}
 	})
 }
 
 type ClearAuthHeadersMiddleware struct {
-	next plugins.Client
+	baseMiddleware
 }
 
 func (m *ClearAuthHeadersMiddleware) clearHeaders(ctx context.Context, h backend.ForwardHTTPHeaders) {
@@ -66,20 +69,4 @@ func (m *ClearAuthHeadersMiddleware) CheckHealth(ctx context.Context, req *backe
 	m.clearHeaders(ctx, req)
 
 	return m.next.CheckHealth(ctx, req)
-}
-
-func (m *ClearAuthHeadersMiddleware) CollectMetrics(ctx context.Context, req *backend.CollectMetricsRequest) (*backend.CollectMetricsResult, error) {
-	return m.next.CollectMetrics(ctx, req)
-}
-
-func (m *ClearAuthHeadersMiddleware) SubscribeStream(ctx context.Context, req *backend.SubscribeStreamRequest) (*backend.SubscribeStreamResponse, error) {
-	return m.next.SubscribeStream(ctx, req)
-}
-
-func (m *ClearAuthHeadersMiddleware) PublishStream(ctx context.Context, req *backend.PublishStreamRequest) (*backend.PublishStreamResponse, error) {
-	return m.next.PublishStream(ctx, req)
-}
-
-func (m *ClearAuthHeadersMiddleware) RunStream(ctx context.Context, req *backend.RunStreamRequest, sender *backend.StreamSender) error {
-	return m.next.RunStream(ctx, req, sender)
 }

--- a/pkg/services/pluginsintegration/clientmiddleware/cookies_middleware.go
+++ b/pkg/services/pluginsintegration/clientmiddleware/cookies_middleware.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
+
 	"github.com/grafana/grafana/pkg/components/simplejson"
 	"github.com/grafana/grafana/pkg/plugins"
 	"github.com/grafana/grafana/pkg/services/contexthandler"
@@ -19,14 +20,16 @@ const cookieHeaderName = "Cookie"
 func NewCookiesMiddleware(skipCookiesNames []string) plugins.ClientMiddleware {
 	return plugins.ClientMiddlewareFunc(func(next plugins.Client) plugins.Client {
 		return &CookiesMiddleware{
-			next:             next,
+			baseMiddleware: baseMiddleware{
+				next: next,
+			},
 			skipCookiesNames: skipCookiesNames,
 		}
 	})
 }
 
 type CookiesMiddleware struct {
-	next             plugins.Client
+	baseMiddleware
 	skipCookiesNames []string
 }
 
@@ -114,20 +117,4 @@ func (m *CookiesMiddleware) CheckHealth(ctx context.Context, req *backend.CheckH
 	}
 
 	return m.next.CheckHealth(ctx, req)
-}
-
-func (m *CookiesMiddleware) CollectMetrics(ctx context.Context, req *backend.CollectMetricsRequest) (*backend.CollectMetricsResult, error) {
-	return m.next.CollectMetrics(ctx, req)
-}
-
-func (m *CookiesMiddleware) SubscribeStream(ctx context.Context, req *backend.SubscribeStreamRequest) (*backend.SubscribeStreamResponse, error) {
-	return m.next.SubscribeStream(ctx, req)
-}
-
-func (m *CookiesMiddleware) PublishStream(ctx context.Context, req *backend.PublishStreamRequest) (*backend.PublishStreamResponse, error) {
-	return m.next.PublishStream(ctx, req)
-}
-
-func (m *CookiesMiddleware) RunStream(ctx context.Context, req *backend.RunStreamRequest, sender *backend.StreamSender) error {
-	return m.next.RunStream(ctx, req, sender)
 }

--- a/pkg/services/pluginsintegration/clientmiddleware/forward_id_middleware.go
+++ b/pkg/services/pluginsintegration/clientmiddleware/forward_id_middleware.go
@@ -17,13 +17,15 @@ const forwardIDHeaderName = "X-Grafana-Id"
 func NewForwardIDMiddleware() plugins.ClientMiddleware {
 	return plugins.ClientMiddlewareFunc(func(next plugins.Client) plugins.Client {
 		return &ForwardIDMiddleware{
-			next: next,
+			baseMiddleware: baseMiddleware{
+				next: next,
+			},
 		}
 	})
 }
 
 type ForwardIDMiddleware struct {
-	next plugins.Client
+	baseMiddleware
 }
 
 func (m *ForwardIDMiddleware) applyToken(ctx context.Context, pCtx backend.PluginContext, req backend.ForwardHTTPHeaders) error {
@@ -78,20 +80,4 @@ func (m *ForwardIDMiddleware) CheckHealth(ctx context.Context, req *backend.Chec
 	}
 
 	return m.next.CheckHealth(ctx, req)
-}
-
-func (m *ForwardIDMiddleware) CollectMetrics(ctx context.Context, req *backend.CollectMetricsRequest) (*backend.CollectMetricsResult, error) {
-	return m.next.CollectMetrics(ctx, req)
-}
-
-func (m *ForwardIDMiddleware) SubscribeStream(ctx context.Context, req *backend.SubscribeStreamRequest) (*backend.SubscribeStreamResponse, error) {
-	return m.next.SubscribeStream(ctx, req)
-}
-
-func (m *ForwardIDMiddleware) PublishStream(ctx context.Context, req *backend.PublishStreamRequest) (*backend.PublishStreamResponse, error) {
-	return m.next.PublishStream(ctx, req)
-}
-
-func (m *ForwardIDMiddleware) RunStream(ctx context.Context, req *backend.RunStreamRequest, sender *backend.StreamSender) error {
-	return m.next.RunStream(ctx, req, sender)
 }

--- a/pkg/services/pluginsintegration/clientmiddleware/grafana_request_id_header_middleware.go
+++ b/pkg/services/pluginsintegration/clientmiddleware/grafana_request_id_header_middleware.go
@@ -11,6 +11,7 @@ import (
 	"github.com/google/uuid"
 
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
+
 	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/plugins"
 	"github.com/grafana/grafana/pkg/services/contexthandler"
@@ -30,17 +31,19 @@ const GrafanaInternalRequest = "X-Grafana-Internal-Request"
 func NewHostedGrafanaACHeaderMiddleware(cfg *setting.Cfg) plugins.ClientMiddleware {
 	return plugins.ClientMiddlewareFunc(func(next plugins.Client) plugins.Client {
 		return &HostedGrafanaACHeaderMiddleware{
-			next: next,
-			log:  log.New("ip_header_middleware"),
-			cfg:  cfg,
+			baseMiddleware: baseMiddleware{
+				next: next,
+			},
+			log: log.New("ip_header_middleware"),
+			cfg: cfg,
 		}
 	})
 }
 
 type HostedGrafanaACHeaderMiddleware struct {
-	next plugins.Client
-	log  log.Logger
-	cfg  *setting.Cfg
+	baseMiddleware
+	log log.Logger
+	cfg *setting.Cfg
 }
 
 func (m *HostedGrafanaACHeaderMiddleware) applyGrafanaRequestIDHeader(ctx context.Context, pCtx backend.PluginContext, h backend.ForwardHTTPHeaders) {
@@ -143,20 +146,4 @@ func (m *HostedGrafanaACHeaderMiddleware) CheckHealth(ctx context.Context, req *
 	m.applyGrafanaRequestIDHeader(ctx, req.PluginContext, req)
 
 	return m.next.CheckHealth(ctx, req)
-}
-
-func (m *HostedGrafanaACHeaderMiddleware) CollectMetrics(ctx context.Context, req *backend.CollectMetricsRequest) (*backend.CollectMetricsResult, error) {
-	return m.next.CollectMetrics(ctx, req)
-}
-
-func (m *HostedGrafanaACHeaderMiddleware) SubscribeStream(ctx context.Context, req *backend.SubscribeStreamRequest) (*backend.SubscribeStreamResponse, error) {
-	return m.next.SubscribeStream(ctx, req)
-}
-
-func (m *HostedGrafanaACHeaderMiddleware) PublishStream(ctx context.Context, req *backend.PublishStreamRequest) (*backend.PublishStreamResponse, error) {
-	return m.next.PublishStream(ctx, req)
-}
-
-func (m *HostedGrafanaACHeaderMiddleware) RunStream(ctx context.Context, req *backend.RunStreamRequest, sender *backend.StreamSender) error {
-	return m.next.RunStream(ctx, req, sender)
 }

--- a/pkg/services/pluginsintegration/clientmiddleware/httpclient_middleware.go
+++ b/pkg/services/pluginsintegration/clientmiddleware/httpclient_middleware.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
 	"github.com/grafana/grafana-plugin-sdk-go/backend/httpclient"
+
 	"github.com/grafana/grafana/pkg/plugins"
 	ngalertmodels "github.com/grafana/grafana/pkg/services/ngalert/models"
 )
@@ -17,13 +18,15 @@ const forwardPluginRequestHTTPHeaders = "forward-plugin-request-http-headers"
 func NewHTTPClientMiddleware() plugins.ClientMiddleware {
 	return plugins.ClientMiddlewareFunc(func(next plugins.Client) plugins.Client {
 		return &HTTPClientMiddleware{
-			next: next,
+			baseMiddleware: baseMiddleware{
+				next: next,
+			},
 		}
 	})
 }
 
 type HTTPClientMiddleware struct {
-	next plugins.Client
+	baseMiddleware
 }
 
 func (m *HTTPClientMiddleware) applyHeaders(ctx context.Context, pReq any) context.Context {
@@ -92,20 +95,4 @@ func (m *HTTPClientMiddleware) CheckHealth(ctx context.Context, req *backend.Che
 	ctx = m.applyHeaders(ctx, req)
 
 	return m.next.CheckHealth(ctx, req)
-}
-
-func (m *HTTPClientMiddleware) CollectMetrics(ctx context.Context, req *backend.CollectMetricsRequest) (*backend.CollectMetricsResult, error) {
-	return m.next.CollectMetrics(ctx, req)
-}
-
-func (m *HTTPClientMiddleware) SubscribeStream(ctx context.Context, req *backend.SubscribeStreamRequest) (*backend.SubscribeStreamResponse, error) {
-	return m.next.SubscribeStream(ctx, req)
-}
-
-func (m *HTTPClientMiddleware) PublishStream(ctx context.Context, req *backend.PublishStreamRequest) (*backend.PublishStreamResponse, error) {
-	return m.next.PublishStream(ctx, req)
-}
-
-func (m *HTTPClientMiddleware) RunStream(ctx context.Context, req *backend.RunStreamRequest, sender *backend.StreamSender) error {
-	return m.next.RunStream(ctx, req, sender)
 }

--- a/pkg/services/pluginsintegration/clientmiddleware/logger_middleware.go
+++ b/pkg/services/pluginsintegration/clientmiddleware/logger_middleware.go
@@ -17,14 +17,16 @@ import (
 func NewLoggerMiddleware(logger plog.Logger) plugins.ClientMiddleware {
 	return plugins.ClientMiddlewareFunc(func(next plugins.Client) plugins.Client {
 		return &LoggerMiddleware{
-			next:   next,
+			baseMiddleware: baseMiddleware{
+				next: next,
+			},
 			logger: logger,
 		}
 	})
 }
 
 type LoggerMiddleware struct {
-	next   plugins.Client
+	baseMiddleware
 	logger plog.Logger
 }
 
@@ -126,16 +128,4 @@ func (m *LoggerMiddleware) CollectMetrics(ctx context.Context, req *backend.Coll
 	})
 
 	return resp, err
-}
-
-func (m *LoggerMiddleware) SubscribeStream(ctx context.Context, req *backend.SubscribeStreamRequest) (*backend.SubscribeStreamResponse, error) {
-	return m.next.SubscribeStream(ctx, req)
-}
-
-func (m *LoggerMiddleware) PublishStream(ctx context.Context, req *backend.PublishStreamRequest) (*backend.PublishStreamResponse, error) {
-	return m.next.PublishStream(ctx, req)
-}
-
-func (m *LoggerMiddleware) RunStream(ctx context.Context, req *backend.RunStreamRequest, sender *backend.StreamSender) error {
-	return m.next.RunStream(ctx, req, sender)
 }

--- a/pkg/services/pluginsintegration/clientmiddleware/oauthtoken_middleware.go
+++ b/pkg/services/pluginsintegration/clientmiddleware/oauthtoken_middleware.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
+
 	"github.com/grafana/grafana/pkg/components/simplejson"
 	"github.com/grafana/grafana/pkg/plugins"
 	"github.com/grafana/grafana/pkg/services/contexthandler"
@@ -18,7 +19,9 @@ import (
 func NewOAuthTokenMiddleware(oAuthTokenService oauthtoken.OAuthTokenService) plugins.ClientMiddleware {
 	return plugins.ClientMiddlewareFunc(func(next plugins.Client) plugins.Client {
 		return &OAuthTokenMiddleware{
-			next:              next,
+			baseMiddleware: baseMiddleware{
+				next: next,
+			},
 			oAuthTokenService: oAuthTokenService,
 		}
 	})
@@ -30,8 +33,8 @@ const (
 )
 
 type OAuthTokenMiddleware struct {
+	baseMiddleware
 	oAuthTokenService oauthtoken.OAuthTokenService
-	next              plugins.Client
 }
 
 func (m *OAuthTokenMiddleware) applyToken(ctx context.Context, pCtx backend.PluginContext, req interface{}) error {
@@ -124,20 +127,4 @@ func (m *OAuthTokenMiddleware) CheckHealth(ctx context.Context, req *backend.Che
 	}
 
 	return m.next.CheckHealth(ctx, req)
-}
-
-func (m *OAuthTokenMiddleware) CollectMetrics(ctx context.Context, req *backend.CollectMetricsRequest) (*backend.CollectMetricsResult, error) {
-	return m.next.CollectMetrics(ctx, req)
-}
-
-func (m *OAuthTokenMiddleware) SubscribeStream(ctx context.Context, req *backend.SubscribeStreamRequest) (*backend.SubscribeStreamResponse, error) {
-	return m.next.SubscribeStream(ctx, req)
-}
-
-func (m *OAuthTokenMiddleware) PublishStream(ctx context.Context, req *backend.PublishStreamRequest) (*backend.PublishStreamResponse, error) {
-	return m.next.PublishStream(ctx, req)
-}
-
-func (m *OAuthTokenMiddleware) RunStream(ctx context.Context, req *backend.RunStreamRequest, sender *backend.StreamSender) error {
-	return m.next.RunStream(ctx, req, sender)
 }

--- a/pkg/services/pluginsintegration/clientmiddleware/resource_response_middleware.go
+++ b/pkg/services/pluginsintegration/clientmiddleware/resource_response_middleware.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
+
 	"github.com/grafana/grafana/pkg/plugins"
 	"github.com/grafana/grafana/pkg/util/proxyutil"
 )
@@ -13,13 +14,15 @@ import (
 func NewResourceResponseMiddleware() plugins.ClientMiddleware {
 	return plugins.ClientMiddlewareFunc(func(next plugins.Client) plugins.Client {
 		return &ResourceResponseMiddleware{
-			next: next,
+			baseMiddleware: baseMiddleware{
+				next: next,
+			},
 		}
 	})
 }
 
 type ResourceResponseMiddleware struct {
-	next plugins.Client
+	baseMiddleware
 }
 
 func (m *ResourceResponseMiddleware) QueryData(ctx context.Context, req *backend.QueryDataRequest) (*backend.QueryDataResponse, error) {
@@ -46,24 +49,4 @@ func (m *ResourceResponseMiddleware) CallResource(ctx context.Context, req *back
 	})
 
 	return m.next.CallResource(ctx, req, wrappedSender)
-}
-
-func (m *ResourceResponseMiddleware) CheckHealth(ctx context.Context, req *backend.CheckHealthRequest) (*backend.CheckHealthResult, error) {
-	return m.next.CheckHealth(ctx, req)
-}
-
-func (m *ResourceResponseMiddleware) CollectMetrics(ctx context.Context, req *backend.CollectMetricsRequest) (*backend.CollectMetricsResult, error) {
-	return m.next.CollectMetrics(ctx, req)
-}
-
-func (m *ResourceResponseMiddleware) SubscribeStream(ctx context.Context, req *backend.SubscribeStreamRequest) (*backend.SubscribeStreamResponse, error) {
-	return m.next.SubscribeStream(ctx, req)
-}
-
-func (m *ResourceResponseMiddleware) PublishStream(ctx context.Context, req *backend.PublishStreamRequest) (*backend.PublishStreamResponse, error) {
-	return m.next.PublishStream(ctx, req)
-}
-
-func (m *ResourceResponseMiddleware) RunStream(ctx context.Context, req *backend.RunStreamRequest, sender *backend.StreamSender) error {
-	return m.next.RunStream(ctx, req, sender)
 }

--- a/pkg/services/pluginsintegration/clientmiddleware/status_source_middleware.go
+++ b/pkg/services/pluginsintegration/clientmiddleware/status_source_middleware.go
@@ -17,13 +17,15 @@ import (
 func NewStatusSourceMiddleware() plugins.ClientMiddleware {
 	return plugins.ClientMiddlewareFunc(func(next plugins.Client) plugins.Client {
 		return &StatusSourceMiddleware{
-			next: next,
+			baseMiddleware: baseMiddleware{
+				next: next,
+			},
 		}
 	})
 }
 
 type StatusSourceMiddleware struct {
-	next plugins.Client
+	baseMiddleware
 }
 
 func (m *StatusSourceMiddleware) QueryData(ctx context.Context, req *backend.QueryDataRequest) (*backend.QueryDataResponse, error) {
@@ -56,28 +58,4 @@ func (m *StatusSourceMiddleware) QueryData(ctx context.Context, req *backend.Que
 	}
 
 	return resp, err
-}
-
-func (m *StatusSourceMiddleware) CallResource(ctx context.Context, req *backend.CallResourceRequest, sender backend.CallResourceResponseSender) error {
-	return m.next.CallResource(ctx, req, sender)
-}
-
-func (m *StatusSourceMiddleware) CheckHealth(ctx context.Context, req *backend.CheckHealthRequest) (*backend.CheckHealthResult, error) {
-	return m.next.CheckHealth(ctx, req)
-}
-
-func (m *StatusSourceMiddleware) CollectMetrics(ctx context.Context, req *backend.CollectMetricsRequest) (*backend.CollectMetricsResult, error) {
-	return m.next.CollectMetrics(ctx, req)
-}
-
-func (m *StatusSourceMiddleware) SubscribeStream(ctx context.Context, req *backend.SubscribeStreamRequest) (*backend.SubscribeStreamResponse, error) {
-	return m.next.SubscribeStream(ctx, req)
-}
-
-func (m *StatusSourceMiddleware) PublishStream(ctx context.Context, req *backend.PublishStreamRequest) (*backend.PublishStreamResponse, error) {
-	return m.next.PublishStream(ctx, req)
-}
-
-func (m *StatusSourceMiddleware) RunStream(ctx context.Context, req *backend.RunStreamRequest, sender *backend.StreamSender) error {
-	return m.next.RunStream(ctx, req, sender)
 }

--- a/pkg/services/pluginsintegration/clientmiddleware/tracing_header_middleware.go
+++ b/pkg/services/pluginsintegration/clientmiddleware/tracing_header_middleware.go
@@ -18,13 +18,15 @@ import (
 func NewTracingHeaderMiddleware() plugins.ClientMiddleware {
 	return plugins.ClientMiddlewareFunc(func(next plugins.Client) plugins.Client {
 		return &TracingHeaderMiddleware{
-			next: next,
+			baseMiddleware: baseMiddleware{
+				next: next,
+			},
 		}
 	})
 }
 
 type TracingHeaderMiddleware struct {
-	next plugins.Client
+	baseMiddleware
 }
 
 func (m *TracingHeaderMiddleware) applyHeaders(ctx context.Context, req backend.ForwardHTTPHeaders) {
@@ -65,20 +67,4 @@ func (m *TracingHeaderMiddleware) CheckHealth(ctx context.Context, req *backend.
 
 	m.applyHeaders(ctx, req)
 	return m.next.CheckHealth(ctx, req)
-}
-
-func (m *TracingHeaderMiddleware) CollectMetrics(ctx context.Context, req *backend.CollectMetricsRequest) (*backend.CollectMetricsResult, error) {
-	return m.next.CollectMetrics(ctx, req)
-}
-
-func (m *TracingHeaderMiddleware) SubscribeStream(ctx context.Context, req *backend.SubscribeStreamRequest) (*backend.SubscribeStreamResponse, error) {
-	return m.next.SubscribeStream(ctx, req)
-}
-
-func (m *TracingHeaderMiddleware) PublishStream(ctx context.Context, req *backend.PublishStreamRequest) (*backend.PublishStreamResponse, error) {
-	return m.next.PublishStream(ctx, req)
-}
-
-func (m *TracingHeaderMiddleware) RunStream(ctx context.Context, req *backend.RunStreamRequest, sender *backend.StreamSender) error {
-	return m.next.RunStream(ctx, req, sender)
 }

--- a/pkg/services/pluginsintegration/clientmiddleware/user_header_middleware.go
+++ b/pkg/services/pluginsintegration/clientmiddleware/user_header_middleware.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
+
 	"github.com/grafana/grafana/pkg/plugins"
 	"github.com/grafana/grafana/pkg/services/auth/identity"
 	"github.com/grafana/grafana/pkg/services/contexthandler"
@@ -15,13 +16,15 @@ import (
 func NewUserHeaderMiddleware() plugins.ClientMiddleware {
 	return plugins.ClientMiddlewareFunc(func(next plugins.Client) plugins.Client {
 		return &UserHeaderMiddleware{
-			next: next,
+			baseMiddleware: baseMiddleware{
+				next: next,
+			},
 		}
 	})
 }
 
 type UserHeaderMiddleware struct {
-	next plugins.Client
+	baseMiddleware
 }
 
 func (m *UserHeaderMiddleware) applyUserHeader(ctx context.Context, h backend.ForwardHTTPHeaders) {
@@ -66,20 +69,4 @@ func (m *UserHeaderMiddleware) CheckHealth(ctx context.Context, req *backend.Che
 	m.applyUserHeader(ctx, req)
 
 	return m.next.CheckHealth(ctx, req)
-}
-
-func (m *UserHeaderMiddleware) CollectMetrics(ctx context.Context, req *backend.CollectMetricsRequest) (*backend.CollectMetricsResult, error) {
-	return m.next.CollectMetrics(ctx, req)
-}
-
-func (m *UserHeaderMiddleware) SubscribeStream(ctx context.Context, req *backend.SubscribeStreamRequest) (*backend.SubscribeStreamResponse, error) {
-	return m.next.SubscribeStream(ctx, req)
-}
-
-func (m *UserHeaderMiddleware) PublishStream(ctx context.Context, req *backend.PublishStreamRequest) (*backend.PublishStreamResponse, error) {
-	return m.next.PublishStream(ctx, req)
-}
-
-func (m *UserHeaderMiddleware) RunStream(ctx context.Context, req *backend.RunStreamRequest, sender *backend.StreamSender) error {
-	return m.next.RunStream(ctx, req, sender)
 }


### PR DESCRIPTION
Currently the plugins middleware has a lot of boilderplate duplication.  This is OK, but it makes adding/exploring new services have a comically large set of things to implement.

This PR introduces a base class for middleware so they are only implementing the functions that change.

