### PR TITLE
Add option for sticky page header

### DIFF
--- a/public/app/core/components/Page/Page.tsx
+++ b/public/app/core/components/Page/Page.tsx
@@ -28,6 +28,7 @@ export const Page: PageType = ({
   layout = PageLayoutType.Standard,
   scrollTop,
   scrollRef,
+  stickyHeader,
   ...otherProps
 }) => {
   const styles = useStyles2(getStyles);
@@ -54,7 +55,7 @@ export const Page: PageType = ({
     <div className={cx(styles.wrapper, className)} {...otherProps}>
       {layout === PageLayoutType.Standard && (
         <FlaggedScrollbar autoHeightMin={'100%'} scrollTop={scrollTop} scrollRefCallback={scrollRef}>
-          <div className={styles.pageInner}>
+          <div className={cx(styles.pageInner, { [styles.ifSticky]: stickyHeader })}>
             {pageHeaderNav && (
               <PageHeader
                 actions={actions}
@@ -63,6 +64,7 @@ export const Page: PageType = ({
                 renderTitle={renderTitle}
                 info={info}
                 subTitle={subTitle}
+                stickyHeader={stickyHeader}
               />
             )}
             {pageNav && pageNav.children && <PageTabs navItem={pageNav} />}
@@ -122,6 +124,13 @@ const getStyles = (theme: GrafanaTheme2) => {
       padding: theme.spacing(2),
       flexBasis: '100%',
       flexGrow: 1,
+    }),
+    // If we have a sticky header, then we don't need to add padding to the top
+    // otherwise this will end up as too much spacing with the header
+    ifSticky: css({
+      [theme.breakpoints.up('sm')]: {
+        paddingTop: 0,
+      },
     }),
   };
 };

--- a/public/app/core/components/Page/PageHeader.tsx
+++ b/public/app/core/components/Page/PageHeader.tsx
@@ -1,8 +1,8 @@
-import { css } from '@emotion/css';
+import { css, cx } from '@emotion/css';
 import React from 'react';
 
 import { NavModelItem, GrafanaTheme2 } from '@grafana/data';
-import { useStyles2 } from '@grafana/ui';
+import { Divider, useStyles2 } from '@grafana/ui';
 
 import { PageInfo } from '../PageInfo/PageInfo';
 
@@ -16,9 +16,10 @@ export interface Props {
   info?: PageInfoItem[];
   subTitle?: React.ReactNode;
   onEditTitle?: (newValue: string) => Promise<void>;
+  stickyHeader?: boolean;
 }
 
-export function PageHeader({ navItem, renderTitle, actions, info, subTitle, onEditTitle }: Props) {
+export function PageHeader({ navItem, renderTitle, actions, info, subTitle, onEditTitle, stickyHeader }: Props) {
   const styles = useStyles2(getStyles);
   const sub = subTitle ?? navItem.subTitle;
 
@@ -32,7 +33,7 @@ export function PageHeader({ navItem, renderTitle, actions, info, subTitle, onEd
   );
 
   return (
-    <div className={styles.pageHeader}>
+    <div className={cx(styles.pageHeader, { [styles.sticky]: stickyHeader })}>
       <div className={styles.topRow}>
         <div className={styles.titleInfoContainer}>
           {titleElement}
@@ -41,12 +42,31 @@ export function PageHeader({ navItem, renderTitle, actions, info, subTitle, onEd
         <div className={styles.actions}>{actions}</div>
       </div>
       {sub && <div className={styles.subTitle}>{sub}</div>}
+      {stickyHeader && <Divider />}
     </div>
   );
 }
 
 const getStyles = (theme: GrafanaTheme2) => {
   return {
+    sticky: css({
+      [theme.breakpoints.up('sm')]: {
+        position: 'sticky',
+        top: 0,
+        zIndex: theme.zIndex.navbarFixed,
+        backgroundColor: theme.colors.background.primary,
+        paddingTop: theme.spacing(2),
+        paddingRight: theme.spacing(4),
+        paddingLeft: theme.spacing(4),
+        marginBottom: theme.spacing(1),
+
+        // Add a negative margin to the sides of the header
+        // so that it can overlap any content that may be breaking out
+        // of the page container
+        marginRight: theme.spacing(-4),
+        marginLeft: theme.spacing(-4),
+      },
+    }),
     topRow: css({
       alignItems: 'flex-start',
       display: 'flex',

--- a/public/app/core/components/Page/types.ts
+++ b/public/app/core/components/Page/types.ts
@@ -30,6 +30,17 @@ export interface PageProps extends HTMLAttributes<HTMLDivElement> {
    * */
   // Probably will deprecate this in the future in favor of just scrolling document.body directly
   scrollTop?: number;
+
+  /**
+   * Should the header be sticky? Defaults to off.
+   *
+   * If enabled, will also show a divider below the header, to aid
+   * in separating header and page contents.
+   *
+   * Header will not be sticky in small screen sizes, to avoid
+   * blocking page contents
+   */
+  stickyHeader?: boolean;
 }
 
 export interface PageInfoItem {


### PR DESCRIPTION
**What is this feature?**

Adds capability/option to make page headers sticky by passing in a prop to `<Page>`

**Why do we need this feature?**

Useful pattern to have within pages, and particularly for long forms where we want to show actions at the top and bottom (and the pattern of having these in the bar at the level of the breadcrumbs is being deprecated/moved away from, as I understand)

**Who is this feature for?**

UI developers

---

To test this out, apply this diff and then look at the alerting pages:

```diff
diff --git a/public/app/features/alerting/unified/components/AlertingPageWrapper.tsx b/public/app/features/alerting/unified/components/AlertingPageWrapper.tsx
index 62f9069b8db..ea861f7bfd3 100644
--- a/public/app/features/alerting/unified/components/AlertingPageWrapper.tsx
+++ b/public/app/features/alerting/unified/components/AlertingPageWrapper.tsx
@@ -17,7 +17,7 @@ interface AlertingPageWrapperProps extends PageProps {
 }
 
 export const AlertingPageWrapper = ({ children, isLoading, ...rest }: AlertingPageWrapperProps) => (
-  <Page {...rest}>
+  <Page {...rest} stickyHeader>
     <Page.Contents isLoading={isLoading}>{children}</Page.Contents>
   </Page>
 );
```