### PR TITLE
[v11.0.x] Explore: lookup datasource by name when present in legacy URLs (#85222)

### DIFF
--- a/public/app/features/explore/hooks/useStateSync/index.test.tsx
+++ b/public/app/features/explore/hooks/useStateSync/index.test.tsx
@@ -138,7 +138,14 @@ describe('useStateSync', () => {
     const { location, waitForNextUpdate, store } = setup({
       queryParams: {
         panes: JSON.stringify({
-          one: { datasource: 'loki-uid', queries: [{ datasource: { name: 'loki', uid: 'loki-uid' }, refId: '1+2' }] },
+          one: {
+            datasource: 'loki-uid',
+            queries: [
+              { datasource: { name: 'loki', uid: 'loki-uid' }, refId: '1+2' },
+              { datasource: 'loki-uid', refId: '3' },
+              { datasource: 'loki', refId: '4' },
+            ],
+          },
           two: { datasource: 'elastic-uid', queries: [{ datasource: { name: 'elastic', uid: 'elastic-uid' } }] },
         }),
         schemaVersion: 1,
@@ -182,9 +189,16 @@ describe('useStateSync', () => {
     if (panes) {
       // check if the URL is properly encoded when finishing rendering the hook. (this would be '1 2' otherwise)
       expect(JSON.parse(panes)['one'].queries[0].refId).toBe('1+2');
+      expect(JSON.parse(panes)['one'].queries[0].datasource?.uid).toBe('loki-uid');
 
       // we expect panes in the state to be in the same order as the ones in the URL
       expect(Object.keys(store.getState().explore.panes)).toStrictEqual(Object.keys(JSON.parse(panes)));
+
+      // check that the datasources for the queries resolved correctly when set to a name or uid
+      expect(JSON.parse(panes)['one'].queries[1].refId).toBe('3');
+      expect(JSON.parse(panes)['one'].queries[1].datasource?.uid).toBe('loki-uid');
+      expect(JSON.parse(panes)['one'].queries[2].refId).toBe('4');
+      expect(JSON.parse(panes)['one'].queries[2].datasource?.uid).toBe('loki-uid');
     }
   });
 

--- a/public/app/features/explore/hooks/useStateSync/internal.utils.ts
+++ b/public/app/features/explore/hooks/useStateSync/internal.utils.ts
@@ -122,7 +122,7 @@ export function getQueryFilter(datasource?: DataSourceApi) {
       }
       // Due to legacy URLs, `datasource` in queries may be a string. This logic should probably be in the migration
       if (typeof q.datasource === 'string') {
-        return q.datasource === datasource?.uid;
+        return q.datasource === datasource?.uid || q.datasource === datasource?.name;
       }
 
       return q.datasource.uid === datasource?.uid;


### PR DESCRIPTION
Backport 867d36fe59437063a from #85222

---------

Co-authored-by: Kristina Durivage <kristina.durivage@grafana.com>
(cherry picked from commit 867d36fe59437063ad64cb6d485c52a1de52f02d)
