### PR TITLE
Correlations: improve error handling

### DIFF
--- a/pkg/services/correlations/database.go
+++ b/pkg/services/correlations/database.go
@@ -82,10 +82,16 @@ func (s CorrelationsService) deleteCorrelation(ctx context.Context, cmd DeleteCo
 		}
 
 		deletedCount, err := session.Delete(&Correlation{UID: cmd.UID, SourceUID: cmd.SourceUID})
+
+		if err != nil {
+			return err
+		}
+
 		if deletedCount == 0 {
 			return ErrCorrelationNotFound
 		}
-		return err
+
+		return nil
 	})
 }
 
@@ -142,10 +148,16 @@ func (s CorrelationsService) updateCorrelation(ctx context.Context, cmd UpdateCo
 		}
 
 		updateCount, err := session.Where("uid = ? AND source_uid = ?", correlation.UID, correlation.SourceUID).Limit(1).Update(correlation)
+
+		if err != nil {
+			return err
+		}
+
 		if updateCount == 0 {
 			return ErrCorrelationNotFound
 		}
-		return err
+
+		return nil
 	})
 
 	if err != nil {

--- a/pkg/tests/api/correlations/correlations_update_test.go
+++ b/pkg/tests/api/correlations/correlations_update_test.go
@@ -16,8 +16,6 @@ import (
 )
 
 func TestIntegrationUpdateCorrelation(t *testing.T) {
-	// TODO: #82520 Possibly a flaky test
-	t.Skip()
 	if testing.Short() {
 		t.Skip("skipping integration test")
 	}


### PR DESCRIPTION
Related to https://github.com/grafana/grafana/issues/81229 and https://github.com/grafana/grafana/issues/82520.

We were ignoring possible DB errors. With this change we should get more info on what's actually failing: 404 if the correlation was deleted or 500 in case of DB errors.

This is also re-enabling the test to actually see what errors are cauing the flakiness. I didn't manage to get to the root cause.

Fixes #82520