### PR TITLE
Alerting: Pass logger into NewAnnotationBackend.

### DIFF
--- a/pkg/services/ngalert/ngalert.go
+++ b/pkg/services/ngalert/ngalert.go
@@ -472,7 +472,8 @@ func configureHistorianBackend(ctx context.Context, cfg setting.UnifiedAlertingS
 	}
 	if backend == historian.BackendTypeAnnotations {
 		store := historian.NewAnnotationStore(ar, ds, met)
-		return historian.NewAnnotationBackend(store, rs, met), nil
+		annotationBackendLogger := log.New("ngalert.state.historian", "backend", "annotations")
+		return historian.NewAnnotationBackend(annotationBackendLogger, store, rs, met), nil
 	}
 	if backend == historian.BackendTypeLoki {
 		lcfg, err := historian.NewLokiConfig(cfg)

--- a/pkg/services/ngalert/state/historian/annotation.go
+++ b/pkg/services/ngalert/state/historian/annotation.go
@@ -41,8 +41,7 @@ type AnnotationStore interface {
 	Save(ctx context.Context, panel *PanelKey, annotations []annotations.Item, orgID int64, logger log.Logger) error
 }
 
-func NewAnnotationBackend(annotations AnnotationStore, rules RuleStore, metrics *metrics.Historian) *AnnotationBackend {
-	logger := log.New("ngalert.state.historian", "backend", "annotations")
+func NewAnnotationBackend(logger log.Logger, annotations AnnotationStore, rules RuleStore, metrics *metrics.Historian) *AnnotationBackend {
 	return &AnnotationBackend{
 		store:   annotations,
 		rules:   rules,

--- a/pkg/services/ngalert/state/historian/annotation_test.go
+++ b/pkg/services/ngalert/state/historian/annotation_test.go
@@ -131,7 +131,8 @@ func createTestAnnotationSutWithStore(t *testing.T, annotations AnnotationStore)
 	rules.Rules[1] = []*models.AlertRule{
 		models.RuleGen.With(models.RuleMuts.WithOrgID(1), withUID("my-rule")).GenerateRef(),
 	}
-	return NewAnnotationBackend(annotations, rules, met)
+	annotationBackendLogger := log.New("ngalert.state.historian", "backend", "annotations")
+	return NewAnnotationBackend(annotationBackendLogger, annotations, rules, met)
 }
 
 func createTestAnnotationBackendSutWithMetrics(t *testing.T, met *metrics.Historian) *AnnotationBackend {
@@ -144,7 +145,8 @@ func createTestAnnotationBackendSutWithMetrics(t *testing.T, met *metrics.Histor
 	dbs := &dashboards.FakeDashboardService{}
 	dbs.On("GetDashboard", mock.Anything, mock.Anything).Return(&dashboards.Dashboard{}, nil)
 	store := NewAnnotationStore(fakeAnnoRepo, dbs, met)
-	return NewAnnotationBackend(store, rules, met)
+	annotationBackendLogger := log.New("ngalert.state.historian", "backend", "annotations")
+	return NewAnnotationBackend(annotationBackendLogger, store, rules, met)
 }
 
 func createFailingAnnotationSut(t *testing.T, met *metrics.Historian) *AnnotationBackend {
@@ -155,7 +157,8 @@ func createFailingAnnotationSut(t *testing.T, met *metrics.Historian) *Annotatio
 	}
 	dbs := &dashboards.FakeDashboardService{}
 	dbs.On("GetDashboard", mock.Anything, mock.Anything).Return(&dashboards.Dashboard{}, nil)
-	store := NewAnnotationStore(fakeAnnoRepo, dbs, met)
+	annotationBackendLogger := log.New("ngalert.state.historian", "backend", "annotations")
+	store := NewAnnotationStore(annotationBackendLogger, fakeAnnoRepo, dbs, met)
 	return NewAnnotationBackend(store, rules, met)
 }
 

--- a/pkg/services/ngalert/state/historian/annotation_test.go
+++ b/pkg/services/ngalert/state/historian/annotation_test.go
@@ -158,8 +158,8 @@ func createFailingAnnotationSut(t *testing.T, met *metrics.Historian) *Annotatio
 	dbs := &dashboards.FakeDashboardService{}
 	dbs.On("GetDashboard", mock.Anything, mock.Anything).Return(&dashboards.Dashboard{}, nil)
 	annotationBackendLogger := log.New("ngalert.state.historian", "backend", "annotations")
-	store := NewAnnotationStore(annotationBackendLogger, fakeAnnoRepo, dbs, met)
-	return NewAnnotationBackend(store, rules, met)
+	store := NewAnnotationStore(fakeAnnoRepo, dbs, met)
+	return NewAnnotationBackend(annotationBackendLogger, store, rules, met)
 }
 
 func createAnnotation() annotations.Item {

--- a/pkg/services/ngalert/state/manager_bench_test.go
+++ b/pkg/services/ngalert/state/manager_bench_test.go
@@ -24,7 +24,8 @@ func BenchmarkProcessEvalResults(b *testing.B) {
 	as.On("SaveMany", mock.Anything, mock.Anything).Return(nil)
 	metrics := metrics.NewHistorianMetrics(prometheus.NewRegistry(), metrics.Subsystem)
 	store := historian.NewAnnotationStore(&as, nil, metrics)
-	hist := historian.NewAnnotationBackend(store, nil, metrics)
+	annotationBackendLogger := log.New("ngalert.state.historian", "backend", "annotations")
+	hist := historian.NewAnnotationBackend(annotationBackendLogger, store, nil, metrics)
 	cfg := state.ManagerCfg{
 		Historian: hist,
 		Tracer:    tracing.InitializeTracerForTest(),

--- a/pkg/services/ngalert/state/manager_test.go
+++ b/pkg/services/ngalert/state/manager_test.go
@@ -234,7 +234,8 @@ func TestDashboardAnnotations(t *testing.T) {
 	fakeAnnoRepo := annotationstest.NewFakeAnnotationsRepo()
 	historianMetrics := metrics.NewHistorianMetrics(prometheus.NewRegistry(), metrics.Subsystem)
 	store := historian.NewAnnotationStore(fakeAnnoRepo, &dashboards.FakeDashboardService{}, historianMetrics)
-	hist := historian.NewAnnotationBackend(store, nil, historianMetrics)
+	annotationBackendLogger := log.New("ngalert.state.historian", "backend", "annotations")
+	hist := historian.NewAnnotationBackend(annotationBackendLogger, store, nil, historianMetrics)
 	cfg := state.ManagerCfg{
 		Metrics:       metrics.NewNGAlert(prometheus.NewPedanticRegistry()).GetStateMetrics(),
 		ExternalURL:   nil,
@@ -1280,7 +1281,8 @@ func TestProcessEvalResults(t *testing.T) {
 			stateMetrics := metrics.NewStateMetrics(reg)
 			m := metrics.NewHistorianMetrics(prometheus.NewRegistry(), metrics.Subsystem)
 			store := historian.NewAnnotationStore(fakeAnnoRepo, &dashboards.FakeDashboardService{}, m)
-			hist := historian.NewAnnotationBackend(store, nil, m)
+			annotationBackendLogger := log.New("ngalert.state.historian", "backend", "annotations")
+			hist := historian.NewAnnotationBackend(annotationBackendLogger, store, nil, m)
 			clk := clock.NewMock()
 			cfg := state.ManagerCfg{
 				Metrics:       stateMetrics,


### PR DESCRIPTION
Make it possible to pass loggers into more places for code reuse.
