### PR TITLE
Authn: Support access token wildcard namespace

### DIFF
--- a/pkg/services/authn/authnimpl/registration.go
+++ b/pkg/services/authn/authnimpl/registration.go
@@ -18,7 +18,6 @@ import (
 	"github.com/grafana/grafana/pkg/services/org"
 	"github.com/grafana/grafana/pkg/services/quota"
 	"github.com/grafana/grafana/pkg/services/rendering"
-	"github.com/grafana/grafana/pkg/services/signingkeys"
 	"github.com/grafana/grafana/pkg/services/user"
 	"github.com/grafana/grafana/pkg/setting"
 )
@@ -34,7 +33,7 @@ func ProvideRegistration(
 	loginAttempts loginattempt.Service, quotaService quota.Service,
 	authInfoService login.AuthInfoService, renderService rendering.Service,
 	features *featuremgmt.FeatureManager, oauthTokenService oauthtoken.OAuthTokenService,
-	socialService social.Service, cache *remotecache.RemoteCache, signingKeysService signingkeys.Service,
+	socialService social.Service, cache *remotecache.RemoteCache,
 	ldapService service.LDAP, settingsProviderService setting.Provider,
 ) Registration {
 	logger := log.New("authn.registration")
@@ -86,7 +85,7 @@ func ProvideRegistration(
 	}
 
 	if cfg.ExtJWTAuth.Enabled && features.IsEnabledGlobally(featuremgmt.FlagAuthAPIAccessTokenAuth) {
-		authnSvc.RegisterClient(clients.ProvideExtendedJWT(userService, cfg, signingKeysService))
+		authnSvc.RegisterClient(clients.ProvideExtendedJWT(userService, cfg))
 	}
 
 	for name := range socialService.GetOAuthProviders() {

--- a/pkg/services/authn/authnimpl/registration.go
+++ b/pkg/services/authn/authnimpl/registration.go
@@ -85,7 +85,7 @@ func ProvideRegistration(
 	}
 
 	if cfg.ExtJWTAuth.Enabled && features.IsEnabledGlobally(featuremgmt.FlagAuthAPIAccessTokenAuth) {
-		authnSvc.RegisterClient(clients.ProvideExtendedJWT(userService, cfg))
+		authnSvc.RegisterClient(clients.ProvideExtendedJWT(cfg))
 	}
 
 	for name := range socialService.GetOAuthProviders() {

--- a/pkg/services/authn/clients/ext_jwt.go
+++ b/pkg/services/authn/clients/ext_jwt.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"net/http"
-	"strconv"
 	"strings"
 
 	"github.com/go-jose/go-jose/v3/jwt"
@@ -26,9 +25,8 @@ const (
 	extJWTAccessTokenExpectAudience = "grafana"
 )
 
-func ProvideExtendedJWT(userService user.Service, cfg *setting.Cfg,
-	signingKeys signingkeys.Service) *ExtendedJWT {
-	verifier := authlib.NewAccessTokenVerifier(authlib.VerifierConfig{
+func ProvideExtendedJWT(userService user.Service, cfg *setting.Cfg, signingKeys signingkeys.Service) *ExtendedJWT {
+	accessTokenVerifier := authlib.NewAccessTokenVerifier(authlib.VerifierConfig{
 		SigningKeysURL:   cfg.ExtJWTAuth.JWKSUrl,
 		AllowedAudiences: []string{extJWTAccessTokenExpectAudience},
 	})
@@ -44,10 +42,9 @@ func ProvideExtendedJWT(userService user.Service, cfg *setting.Cfg,
 		log:                 log.New(authn.ClientExtendedJWT),
 		userService:         userService,
 		signingKeys:         signingKeys,
-		accessTokenVerifier: verifier,
 		namespaceMapper:     request.GetNamespaceMapper(cfg),
-
-		idTokenVerifier: idTokenVerifier,
+		accessTokenVerifier: accessTokenVerifier,
+		idTokenVerifier:     idTokenVerifier,
 	}
 }
 
@@ -67,7 +64,7 @@ func (s *ExtendedJWT) Authenticate(ctx context.Context, r *authn.Request) (*auth
 	claims, err := s.accessTokenVerifier.Verify(ctx, jwtToken)
 	if err != nil {
 		s.log.Error("Failed to verify access token", "error", err)
-		return nil, errJWTInvalid.Errorf("Failed to verify access token: %w", err)
+		return nil, errJWTInvalid.Errorf("failed to verify access token: %w", err)
 	}
 
 	idToken := s.retrieveAuthorizationToken(r.HTTPRequest)
@@ -75,7 +72,7 @@ func (s *ExtendedJWT) Authenticate(ctx context.Context, r *authn.Request) (*auth
 		idTokenClaims, err := s.idTokenVerifier.Verify(ctx, idToken)
 		if err != nil {
 			s.log.Error("Failed to verify id token", "error", err)
-			return nil, errJWTInvalid.Errorf("Failed to verify id token: %w", err)
+			return nil, errJWTInvalid.Errorf("failed to verify id token: %w", err)
 		}
 
 		return s.authenticateAsUser(idTokenClaims, claims)
@@ -88,40 +85,43 @@ func (s *ExtendedJWT) IsEnabled() bool {
 	return s.cfg.ExtJWTAuth.Enabled
 }
 
-func (s *ExtendedJWT) authenticateAsUser(idTokenClaims *authlib.Claims[authlib.IDTokenClaims],
-	accessTokenClaims *authlib.Claims[authlib.AccessTokenClaims]) (*authn.Identity, error) {
-	// compare the incoming namespace claim against what namespaceMapper returns
+func (s *ExtendedJWT) authenticateAsUser(
+	idTokenClaims *authlib.Claims[authlib.IDTokenClaims],
+	accessTokenClaims *authlib.Claims[authlib.AccessTokenClaims],
+) (*authn.Identity, error) {
+	// Only allow id tokens signed for namespace configured for this instance.
 	if allowedNamespace := s.namespaceMapper(s.getDefaultOrgID()); idTokenClaims.Rest.Namespace != allowedNamespace {
-		return nil, errJWTDisallowedNamespaceClaim
-	}
-	// since id token claims can never have a wildcard ("*") namespace claim, the below comparison effectively
-	// disallows wildcard claims in access tokens here in Grafana (they are only meant for service layer)
-	if accessTokenClaims.Rest.Namespace != idTokenClaims.Rest.Namespace {
-		return nil, errJWTMismatchedNamespaceClaims.Errorf("id token namespace: %s, access token namespace: %s", idTokenClaims.Rest.Namespace, accessTokenClaims.Rest.Namespace)
+		return nil, errJWTDisallowedNamespaceClaim.Errorf("unexpected id token namespace: %s", idTokenClaims.Rest.Namespace)
 	}
 
-	// Only allow access policies to impersonate
-	if !strings.HasPrefix(accessTokenClaims.Subject, fmt.Sprintf("%s:", authn.NamespaceAccessPolicy)) {
-		s.log.Error("Invalid subject", "subject", accessTokenClaims.Subject)
-		return nil, errJWTInvalid.Errorf("Failed to parse sub: %s", "invalid subject format")
-	}
-	// Allow only user impersonation
-	_, err := strconv.ParseInt(strings.TrimPrefix(idTokenClaims.Subject, fmt.Sprintf("%s:", authn.NamespaceUser)), 10, 64)
-	if err != nil {
-		s.log.Error("Failed to parse sub", "error", err)
-		return nil, errJWTInvalid.Errorf("Failed to parse sub: %w", err)
+	// Allow access tokens with either the same namespace as the validated id token namespace or wildcard (`*`).
+	if !accessTokenClaims.Rest.NamespaceMatches(idTokenClaims.Rest.Namespace) {
+		return nil, errJWTDisallowedNamespaceClaim.Errorf("unexpected access token namespace: %s", accessTokenClaims.Rest.Namespace)
 	}
 
-	id, err := authn.ParseNamespaceID(idTokenClaims.Subject)
+	accessID, err := authn.ParseNamespaceID(accessTokenClaims.Subject)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to parse access token subject: %w", err)
+	}
+
+	if !accessID.IsNamespace(authn.NamespaceAccessPolicy) {
+		return nil, errJWTInvalid.Errorf("unexpected identity: %s", accessID.String())
+	}
+
+	userID, err := authn.ParseNamespaceID(idTokenClaims.Subject)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse id token subject: %w", err)
+	}
+
+	if !userID.IsNamespace(authn.NamespaceUser) {
+		return nil, errJWTInvalid.Errorf("unexpected user identity: %s", userID.String())
 	}
 
 	return &authn.Identity{
-		ID:              id,
+		ID:              userID,
 		OrgID:           s.getDefaultOrgID(),
 		AuthenticatedBy: login.ExtendedJWTModule,
-		AuthID:          accessTokenClaims.Subject,
+		AuthID:          accessID.String(),
 		ClientParams: authn.ClientParams{
 			SyncPermissions: true,
 			FetchPermissionsParams: authn.FetchPermissionsParams{
@@ -132,19 +132,18 @@ func (s *ExtendedJWT) authenticateAsUser(idTokenClaims *authlib.Claims[authlib.I
 }
 
 func (s *ExtendedJWT) authenticateAsService(claims *authlib.Claims[authlib.AccessTokenClaims]) (*authn.Identity, error) {
-	if !strings.HasPrefix(claims.Subject, fmt.Sprintf("%s:", authn.NamespaceAccessPolicy)) {
-		s.log.Error("Invalid subject", "subject", claims.Subject)
-		return nil, errJWTInvalid.Errorf("Failed to parse sub: %s", "invalid subject format")
-	}
-
-	// same as asUser, disallows wildcard claims in access tokens here in Grafana (they are only meant for service layer)
-	if allowedNamespace := s.namespaceMapper(s.getDefaultOrgID()); claims.Rest.Namespace != allowedNamespace {
-		return nil, errJWTDisallowedNamespaceClaim
+	// Allow access tokens with that has a wildcard namespace or a namespace matching this instance.
+	if allowedNamespace := s.namespaceMapper(s.getDefaultOrgID()); !claims.Rest.NamespaceMatches(allowedNamespace) {
+		return nil, errJWTDisallowedNamespaceClaim.Errorf("unexpected access token namespace: %s", claims.Rest.Namespace)
 	}
 
 	id, err := authn.ParseNamespaceID(claims.Subject)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to parse access token subject: %w", err)
+	}
+
+	if !id.IsNamespace(authn.NamespaceAccessPolicy) {
+		return nil, errJWTInvalid.Errorf("Failed to parse sub: %s", "invalid subject format")
 	}
 
 	return &authn.Identity{

--- a/pkg/services/authn/clients/ext_jwt.go
+++ b/pkg/services/authn/clients/ext_jwt.go
@@ -25,7 +25,7 @@ const (
 	extJWTAccessTokenExpectAudience = "grafana"
 )
 
-func ProvideExtendedJWT(userService user.Service, cfg *setting.Cfg, signingKeys signingkeys.Service) *ExtendedJWT {
+func ProvideExtendedJWT(cfg *setting.Cfg) *ExtendedJWT {
 	accessTokenVerifier := authlib.NewAccessTokenVerifier(authlib.VerifierConfig{
 		SigningKeysURL:   cfg.ExtJWTAuth.JWKSUrl,
 		AllowedAudiences: []string{extJWTAccessTokenExpectAudience},
@@ -40,8 +40,6 @@ func ProvideExtendedJWT(userService user.Service, cfg *setting.Cfg, signingKeys 
 	return &ExtendedJWT{
 		cfg:                 cfg,
 		log:                 log.New(authn.ClientExtendedJWT),
-		userService:         userService,
-		signingKeys:         signingKeys,
 		namespaceMapper:     request.GetNamespaceMapper(cfg),
 		accessTokenVerifier: accessTokenVerifier,
 		idTokenVerifier:     idTokenVerifier,

--- a/pkg/services/authn/clients/ext_jwt.go
+++ b/pkg/services/authn/clients/ext_jwt.go
@@ -108,7 +108,7 @@ func (s *ExtendedJWT) authenticateAsUser(
 
 	accessID, err := authn.ParseNamespaceID(accessTokenClaims.Subject)
 	if err != nil {
-		return nil, fmt.Errorf("failed to parse access token subject: %w", err)
+		return nil, errExtJWTInvalid.Errorf("failed to parse access token subject: %w", err)
 	}
 
 	if !accessID.IsNamespace(authn.NamespaceAccessPolicy) {
@@ -117,7 +117,7 @@ func (s *ExtendedJWT) authenticateAsUser(
 
 	userID, err := authn.ParseNamespaceID(idTokenClaims.Subject)
 	if err != nil {
-		return nil, fmt.Errorf("failed to parse id token subject: %w", err)
+		return nil, errExtJWTInvalid.Errorf("failed to parse id token subject: %w", err)
 	}
 
 	if !userID.IsNamespace(authn.NamespaceUser) {

--- a/pkg/services/authn/clients/ext_jwt_test.go
+++ b/pkg/services/authn/clients/ext_jwt_test.go
@@ -19,8 +19,6 @@ import (
 
 	"github.com/grafana/grafana/pkg/models/roletype"
 	"github.com/grafana/grafana/pkg/services/authn"
-	"github.com/grafana/grafana/pkg/services/signingkeys"
-	"github.com/grafana/grafana/pkg/services/signingkeys/signingkeystest"
 	"github.com/grafana/grafana/pkg/services/user"
 	"github.com/grafana/grafana/pkg/services/user/usertest"
 	"github.com/grafana/grafana/pkg/setting"
@@ -600,14 +598,9 @@ func setupTestCtx(cfg *setting.Cfg) *testEnv {
 		}
 	}
 
-	signingKeysSvc := &signingkeystest.FakeSigningKeysService{
-		ExpectedSinger: pk,
-		ExpectedKeyID:  signingkeys.ServerPrivateKeyID,
-	}
-
 	userSvc := &usertest.FakeUserService{}
 
-	extJwtClient := ProvideExtendedJWT(userSvc, cfg, signingKeysSvc)
+	extJwtClient := ProvideExtendedJWT(userSvc, cfg)
 
 	return &testEnv{
 		userSvc: userSvc,

--- a/pkg/services/authn/clients/ext_jwt_test.go
+++ b/pkg/services/authn/clients/ext_jwt_test.go
@@ -293,7 +293,7 @@ func TestExtendedJWT_Authenticate(t *testing.T) {
 			accessToken: &validAccessTokenClaims,
 			idToken:     &invalidSubjectIDTokenClaims,
 			orgID:       1,
-			wantErr:     errExtJWTInvalid,
+			wantErr:     errExtJWTInvalidSubject,
 		},
 
 		{
@@ -313,7 +313,7 @@ func TestExtendedJWT_Authenticate(t *testing.T) {
 				},
 			},
 			orgID:   1,
-			wantErr: errExtJWTInvalid,
+			wantErr: errExtJWTInvalidSubject,
 		},
 	}
 

--- a/pkg/services/authn/clients/ext_jwt_test.go
+++ b/pkg/services/authn/clients/ext_jwt_test.go
@@ -279,14 +279,14 @@ func TestExtendedJWT_Authenticate(t *testing.T) {
 			payload:   &validAccessTokenClaims,
 			idPayload: &invalidWildcardNamespaceIDTokenClaims,
 			orgID:     1,
-			wantErr:   errJWTDisallowedNamespaceClaim,
+			wantErr:   errEtxJWTDisallowedNamespaceClaim,
 		},
 		{
 			name:      "should return error when id token has wildcard namespace",
 			payload:   &validAccessTokenClaims,
 			idPayload: &invalidNamespaceIDTokenClaims,
 			orgID:     1,
-			wantErr:   errJWTDisallowedNamespaceClaim,
+			wantErr:   errEtxJWTDisallowedNamespaceClaim,
 		},
 
 		{
@@ -294,7 +294,7 @@ func TestExtendedJWT_Authenticate(t *testing.T) {
 			payload:   &validAccessTokenClaims,
 			idPayload: &invalidSubjectIDTokenClaims,
 			orgID:     1,
-			wantErr:   errJWTInvalid,
+			wantErr:   errExtJWTInvalid,
 		},
 
 		{
@@ -314,7 +314,7 @@ func TestExtendedJWT_Authenticate(t *testing.T) {
 				},
 			},
 			orgID:   1,
-			wantErr: errJWTInvalid,
+			wantErr: errExtJWTInvalid,
 		},
 	}
 

--- a/pkg/services/authn/clients/ext_jwt_test.go
+++ b/pkg/services/authn/clients/ext_jwt_test.go
@@ -274,18 +274,18 @@ func TestExtendedJWT_Authenticate(t *testing.T) {
 			},
 		},
 		{
-			name:        "should return error when id token namespece is a wilrdcard",
+			name:        "should return error when id token namespace is a wildcard",
 			accessToken: &validAccessTokenClaims,
 			idToken:     &invalidWildcardNamespaceIDTokenClaims,
 			orgID:       1,
-			wantErr:     errEtxJWTDisallowedNamespaceClaim,
+			wantErr:     errExtJWTDisallowedNamespaceClaim,
 		},
 		{
 			name:        "should return error when id token has wildcard namespace",
 			accessToken: &validAccessTokenClaims,
 			idToken:     &invalidNamespaceIDTokenClaims,
 			orgID:       1,
-			wantErr:     errEtxJWTDisallowedNamespaceClaim,
+			wantErr:     errExtJWTDisallowedNamespaceClaim,
 		},
 
 		{

--- a/pkg/services/authn/clients/jwt.go
+++ b/pkg/services/authn/clients/jwt.go
@@ -27,10 +27,6 @@ var (
 		"jwt.missing_claim", errutil.WithPublicMessage("Missing mandatory claim in JWT"))
 	errJWTInvalidRole = errutil.Forbidden(
 		"jwt.invalid_role", errutil.WithPublicMessage("Invalid Role in claim"))
-	errJWTMismatchedNamespaceClaims = errutil.Unauthorized(
-		"jwt.namespace_mismatch", errutil.WithPublicMessage("Namespace claims didn't match between id token and access token"))
-	errJWTDisallowedNamespaceClaim = errutil.Unauthorized(
-		"jwt.namespace_mismatch", errutil.WithPublicMessage("Namespace claim doesn't allow access to requested namespace"))
 )
 
 func ProvideJWT(jwtService auth.JWTVerifierService, cfg *setting.Cfg) *JWT {


### PR DESCRIPTION
**What is this feature?**
When working on documentation for grafana instance authentication using access tokens I noticed that we disallow wildcard namespace `*`. The point of that special namespace is to allow it for all instances.

So this pr changes that behavior only for `access token`. When authenticating using on behalf of a user (OBO) we still require that `id token` is signed with the correct namespace.

I also did some additional cleanups:
1. Validating subjects after we have parsed `namespaceID` instead of checking string prefixes.
2. Remove unused dependencies (user service and signing keys service)

**Which issue(s) does this PR fix?**:
Fixes https://github.com/grafana/identity-access-team/issues/691

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
