### PR TITLE
Update Go version to avoid format error

### DIFF
--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -58,7 +58,7 @@ jobs:
       # Go is required for also updating the schema versions as part of the precommit hook:
       - uses: actions/setup-go@v4
         with:
-          go-version: '1.20'
+          go-version: '1.21'
       - uses: actions/setup-node@v4
         with:
           node-version: '18'


### PR DESCRIPTION
Similarly to what was done in https://github.com/grafana/grafana/pull/85111, we need to update the Go version to avoid an error in CI due to the format of the Go version (`1.21.10`) in `go.mod` being invalid.