### PR TITLE
SelectMenu: Fix potential undefined problem

### DIFF
--- a/packages/grafana-ui/src/components/Select/SelectMenu.tsx
+++ b/packages/grafana-ui/src/components/Select/SelectMenu.tsx
@@ -57,7 +57,7 @@ export const VirtualizedSelectMenu = ({
   const styles = getSelectStyles(theme);
   const listRef = useRef<List>(null);
 
-  const focusedIndex = options.findIndex((option: SelectableValue<unknown>) => option.value === focusedOption.value);
+  const focusedIndex = options.findIndex((option: SelectableValue<unknown>) => option.value === focusedOption?.value);
 
   useEffect(() => {
     listRef.current?.scrollToItem(focusedIndex);


### PR DESCRIPTION
Fixes a regression introduced by combination of https://github.com/grafana/grafana/pull/87743 and scenes 4.21.1 (bumped with https://github.com/grafana/grafana/pull/87743). According to react-select types, `focusedOption` is always defined, but the reality shows it can be `undefined`...

To reproduce, start typing a custom value in a Group By variable. As soon as you type first non-matching character, a runtime error appears.