### PR TITLE
Tempo: Check for histogram in isTraceQlMetricsQuery

### DIFF
--- a/public/app/plugins/datasource/tempo/datasource.ts
+++ b/public/app/plugins/datasource/tempo/datasource.ts
@@ -437,7 +437,7 @@ export class TempoDatasource extends DataSourceWithBackend<TempoQuery, TempoJson
   isTraceQlMetricsQuery(query: string): boolean {
     // Check whether this is a metrics query by checking if it contains a metrics function
     const metricsFnRegex =
-      /\|\s*(rate|count_over_time|avg_over_time|max_over_time|min_over_time|quantile_over_time)\s*\(/;
+      /\|\s*(rate|count_over_time|avg_over_time|max_over_time|min_over_time|quantile_over_time|histogram_over_time)\s*\(/;
     return !!query.trim().match(metricsFnRegex);
   }
 


### PR DESCRIPTION
**What is this feature?**

Checks for `histogram_over_time` in isTraceQlMetricsQuery regex.

**Why do we need this feature?**

So we run proper queries for `histogram_over_time`.

**Who is this feature for?**

Tempo users.
