### PR TITLE
Alerting: Allow NoData and ExecErrState to be fully blank on recording rules

### DIFF
--- a/pkg/services/ngalert/models/alert_rule.go
+++ b/pkg/services/ngalert/models/alert_rule.go
@@ -498,12 +498,14 @@ func (alertRule *AlertRule) ValidateAlertRule(cfg setting.UnifiedAlertingSetting
 		return fmt.Errorf("%w: cannot have Panel ID without a Dashboard UID", ErrAlertRuleFailedValidation)
 	}
 
-	if _, err := ErrStateFromString(string(alertRule.ExecErrState)); err != nil {
-		return err
-	}
+	if !alertRule.IsRecordingRule() {
+		if _, err := ErrStateFromString(string(alertRule.ExecErrState)); err != nil {
+			return err
+		}
 
-	if _, err := NoDataStateFromString(string(alertRule.NoDataState)); err != nil {
-		return err
+		if _, err := NoDataStateFromString(string(alertRule.NoDataState)); err != nil {
+			return err
+		}
 	}
 
 	if alertRule.For < 0 {

--- a/pkg/services/ngalert/store/alert_rule_test.go
+++ b/pkg/services/ngalert/store/alert_rule_test.go
@@ -621,8 +621,8 @@ func TestIntegrationInsertAlertRules(t *testing.T) {
 			rrs[i].Condition = ""
 			// TODO: These fields do not apply to recording rules - for now, we just use the default values of them. This is validated at the storage level.
 			// TODO: Consider making it so recording rules allow for empty string here, or use some other sentinel value in the future.
-			rrs[i].NoDataState = models.NoData
-			rrs[i].ExecErrState = models.ErrorErrState
+			rrs[i].NoDataState = ""
+			rrs[i].ExecErrState = ""
 			rrs[i].For = 0
 			rrs[i].NotificationSettings = nil
 			rrs[i].Record = &models.Record{
@@ -679,8 +679,8 @@ func TestIntegrationInsertAlertRules(t *testing.T) {
 		for _, rule := range dbRules {
 			if rule.IsRecordingRule() {
 				require.Empty(t, rule.Condition)
-				require.Equal(t, models.NoData, rule.NoDataState)
-				require.Equal(t, models.ErrorErrState, rule.ExecErrState)
+				require.Equal(t, models.NoDataState(""), rule.NoDataState)
+				require.Equal(t, models.ExecutionErrorState(""), rule.ExecErrState)
 				require.Zero(t, rule.For)
 				require.Nil(t, rule.NotificationSettings)
 			}

--- a/pkg/services/ngalert/store/alert_rule_test.go
+++ b/pkg/services/ngalert/store/alert_rule_test.go
@@ -619,8 +619,6 @@ func TestIntegrationInsertAlertRules(t *testing.T) {
 		rrs := gen.GenerateMany(n)
 		for i := range rrs {
 			rrs[i].Condition = ""
-			// TODO: These fields do not apply to recording rules - for now, we just use the default values of them. This is validated at the storage level.
-			// TODO: Consider making it so recording rules allow for empty string here, or use some other sentinel value in the future.
 			rrs[i].NoDataState = ""
 			rrs[i].ExecErrState = ""
 			rrs[i].For = 0


### PR DESCRIPTION
**What is this feature?**

Recording rules are stateless, and therefore the state mapping fields are irrelevant for them. There is no default or "do nothing" value for these enums that makes sense here.

**Why do we need this feature?**

This PR allows them to be fully blank on recording rules, rather than using a sentinel "NoData->NoData" default. This allows the fields to be omitted entirely from requests about recording rules.

Alternative approach is to make the fields nillable with a pointer - this felt much more elegant. It's more inline with the language's behavior around defaults, and manipulating string references in tests adds a lot of verbosity.

Alternative alternative approach is to keep default values in model, but hide it in the API layer - for recording rules, translate the settings to empty string when converting to and from the API structs.

**Who is this feature for?**

Users who will use recording rules.

**Which issue(s) does this PR fix?**:

n/a

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle.
- [x] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
