### PR TITLE
Canvas: Adhere editing state to dashboard editable state

### DIFF
--- a/public/app/plugins/panel/canvas/CanvasPanel.tsx
+++ b/public/app/plugins/panel/canvas/CanvasPanel.tsx
@@ -7,6 +7,7 @@ import { PanelContext, PanelContextRoot } from '@grafana/ui';
 import { CanvasFrameOptions } from 'app/features/canvas';
 import { ElementState } from 'app/features/canvas/runtime/element';
 import { Scene } from 'app/features/canvas/runtime/scene';
+import { getDashboardSrv } from 'app/features/dashboard/services/DashboardSrv';
 import { PanelEditEnteredEvent, PanelEditExitedEvent } from 'app/types/events';
 
 import { SetBackground } from './components/SetBackground';
@@ -61,11 +62,16 @@ export class CanvasPanel extends Component<Props, State> {
       moveableAction: false,
     };
 
+    // TODO: Will need to update this approach for dashboard scenes
+    // migration (new dashboard edit experience)
+    const dashboard = getDashboardSrv().getCurrent();
+    const allowEditing = this.props.options.inlineEditing && dashboard?.editable;
+
     // Only the initial options are ever used.
     // later changes are all controlled by the scene
     this.scene = new Scene(
       this.props.options.root,
-      this.props.options.inlineEditing,
+      allowEditing,
       this.props.options.showAdvancedTypes,
       this.props.options.panZoom,
       this.props.options.infinitePan,


### PR DESCRIPTION
Adhere canvas editing state to dashboard's editable state. Before if the dashboard was read-only, users could still modify the canvas but would then have no way to save those changes.

Note: this approach will need to be updated for dashboard scene migration, but given as that is currently in public preview it makes sense to fix classic dashboards for the time being

See [this follow up GitHub issue](https://github.com/grafana/grafana/issues/87948)

Before

https://github.com/grafana/grafana/assets/9974811/81921431-57e5-461d-825b-25bc91d1366f

After

https://github.com/grafana/grafana/assets/22381771/155ee8a3-c7b4-435d-be07-a22a064b8746



Fixes https://github.com/grafana/grafana/issues/87446