### PR TITLE
Gops: Add tracking for data source check

### DIFF
--- a/public/app/features/gops/configuration-tracker/Analytics.ts
+++ b/public/app/features/gops/configuration-tracker/Analytics.ts
@@ -4,11 +4,13 @@ export enum IRMInteractionNames {
   ViewIRMMainPage = 'grafana_irm_configuration_tracker_main_page_view',
   OpenEssentials = 'grafana_irm_configuration_tracker_essentials_open',
   CloseEssentials = 'grafana_irm_configuration_tracker_essentials_closed',
+  ClickDataSources = 'grafana_irm_configuration_tracker_data_sources_clicked',
 }
 
 export interface ConfigurationTrackerContext {
   essentialStepsDone: number;
   essentialStepsToDo: number;
+  dataSourceCompatibleWithAlerting: boolean;
 }
 export function trackIrmConfigurationTrackerEvent(
   interactionName: IRMInteractionNames,

--- a/public/app/features/gops/configuration-tracker/components/ConfigureIRM.tsx
+++ b/public/app/features/gops/configuration-tracker/components/ConfigureIRM.tsx
@@ -41,14 +41,6 @@ export function ConfigureIRM() {
   const styles = useStyles2(getStyles);
   const history = useHistory();
 
-  // track only once when the component is mounted
-  useEffect(() => {
-    trackIrmConfigurationTrackerEvent(IRMInteractionNames.ViewIRMMainPage, {
-      essentialStepsDone: 0,
-      essentialStepsToDo: 0,
-    });
-  }, []);
-
   // get all the configuration data
   const dataSourceConfigurationData = useGetDataSourceConfiguration();
   const essentialsConfigurationData = useGetEssentialsConfiguration();
@@ -57,9 +49,23 @@ export function ConfigureIRM() {
     essentialsConfigurationData,
   });
 
+  // track only once when the component is mounted
+  useEffect(() => {
+    trackIrmConfigurationTrackerEvent(IRMInteractionNames.ViewIRMMainPage, {
+      essentialStepsDone: 0,
+      essentialStepsToDo: 0,
+      dataSourceCompatibleWithAlerting: dataSourceConfigurationData.dataSourceCompatibleWithAlerting,
+    });
+  }, [dataSourceConfigurationData.dataSourceCompatibleWithAlerting]);
+
   const [essentialsOpen, setEssentialsOpen] = useState(false);
 
   const handleActionClick = (configID: number, isDone?: boolean) => {
+    trackIrmConfigurationTrackerEvent(IRMInteractionNames.ClickDataSources, {
+      essentialStepsDone: essentialsConfigurationData.stepsDone,
+      essentialStepsToDo: essentialsConfigurationData.totalStepsToDo,
+      dataSourceCompatibleWithAlerting: dataSourceConfigurationData.dataSourceCompatibleWithAlerting,
+    });
     switch (configID) {
       case ConfigurationStepsEnum.CONNECT_DATASOURCE:
         if (isDone) {
@@ -73,6 +79,7 @@ export function ConfigureIRM() {
         trackIrmConfigurationTrackerEvent(IRMInteractionNames.OpenEssentials, {
           essentialStepsDone: essentialsConfigurationData.stepsDone,
           essentialStepsToDo: essentialsConfigurationData.totalStepsToDo,
+          dataSourceCompatibleWithAlerting: dataSourceConfigurationData.dataSourceCompatibleWithAlerting,
         });
         break;
       default:
@@ -85,6 +92,7 @@ export function ConfigureIRM() {
     trackIrmConfigurationTrackerEvent(IRMInteractionNames.CloseEssentials, {
       essentialStepsDone: essentialsConfigurationData.stepsDone,
       essentialStepsToDo: essentialsConfigurationData.totalStepsToDo,
+      dataSourceCompatibleWithAlerting: dataSourceConfigurationData.dataSourceCompatibleWithAlerting,
     });
   }
 


### PR DESCRIPTION
**What is this feature?**

This PR adds tracking for the alerting compatible data source check in the IRM configuration tracker.
I added the boolean to the generic track, as I think it can be interesting to know all the checks(done/not done) in every track.

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
