### PR TITLE
PanelOverrides: Only filter out override properties that do not exist

### DIFF
--- a/packages/grafana-data/src/panel/getPanelOptionsWithDefaults.test.ts
+++ b/packages/grafana-data/src/panel/getPanelOptionsWithDefaults.test.ts
@@ -317,7 +317,7 @@ describe('getPanelOptionsWithDefaults', () => {
       `);
     });
 
-    it('should remove custom overrides that no longer exist', () => {
+    it('should remove custom override properties that no longer exist', () => {
       const result = runScenario({
         defaults: {},
         overrides: [
@@ -342,8 +342,8 @@ describe('getPanelOptionsWithDefaults', () => {
         ],
       });
 
-      expect(result.fieldConfig.overrides.length).toBe(1);
-      expect(result.fieldConfig.overrides[0].properties[0].id).toBe('custom.customProp');
+      expect(result.fieldConfig.overrides.length).toBe(2);
+      expect(result.fieldConfig.overrides[0].properties.length).toBe(0);
     });
   });
 });

--- a/packages/grafana-data/src/panel/getPanelOptionsWithDefaults.ts
+++ b/packages/grafana-data/src/panel/getPanelOptionsWithDefaults.ts
@@ -99,16 +99,14 @@ export function filterFieldConfigOverrides(
   overrides: ConfigOverrideRule[],
   condition: (value: DynamicConfigValue) => boolean
 ): ConfigOverrideRule[] {
-  return overrides
-    .map((x) => {
-      const properties = x.properties.filter(condition);
+  return overrides.map((x) => {
+    const properties = x.properties.filter(condition);
 
-      return {
-        ...x,
-        properties,
-      };
-    })
-    .filter((x) => x.properties.length > 0);
+    return {
+      ...x,
+      properties,
+    };
+  });
 }
 
 function cleanProperties(obj: object, parentPath: string, fieldConfigRegistry: FieldConfigOptionsRegistry) {


### PR DESCRIPTION
Instead of removing the whole override rule we only remove the properties that no longer exist , fixes #87547