### PR TITLE
Loki: Lower log level when retrieving metadata

### DIFF
--- a/pkg/tsdb/loki/api.go
+++ b/pkg/tsdb/loki/api.go
@@ -365,7 +365,6 @@ func setXScopeOrgIDHeader(req *http.Request, ctx context.Context) *http.Request 
 		return req
 	}
 
-
 	tenantids := md.Get("tenantid")
 	if len(tenantids) == 0 {
 		// We assume we are not using multi-tenant mode, which is fine

--- a/pkg/tsdb/loki/api.go
+++ b/pkg/tsdb/loki/api.go
@@ -359,7 +359,7 @@ func setXScopeOrgIDHeader(req *http.Request, ctx context.Context) *http.Request 
 
 	md, ok := metadata.FromIncomingContext(ctx)
 	if !ok {
-		// Metadata are currently set and needed only locally for multi-tenancy, while on cloud 
+		// Metadata are currently set and needed only locally for multi-tenancy, while on cloud
 		// this is set by our stack
 		logger.Debug("Metadata not present in context. Header not set")
 		return req

--- a/pkg/tsdb/loki/api.go
+++ b/pkg/tsdb/loki/api.go
@@ -359,9 +359,12 @@ func setXScopeOrgIDHeader(req *http.Request, ctx context.Context) *http.Request 
 
 	md, ok := metadata.FromIncomingContext(ctx)
 	if !ok {
-		logger.Error("Error in retrieving metadata from context. Header not set")
+		// Metadata are currently set and needed only locally for multi-tenancy, while on cloud 
+		// this is set by our stack
+		logger.Debug("Metadata not present in context. Header not set")
 		return req
 	}
+
 
 	tenantids := md.Get("tenantid")
 	if len(tenantids) == 0 {


### PR DESCRIPTION
Currently there is a discrepancy between running Grafana locally and on cloud. While things were supposed to be 1:1, cloud actually steps metadata through our stack, while locally we still have to manually retrieve them to properly test multi-tenancy. This PR jsut lower the level of one log call that currently prints error, but we need to investigate a proper fix for this.