### PR TITLE
sqlexpressions - fix escape quote

### DIFF
--- a/pkg/expr/sql/parser.go
+++ b/pkg/expr/sql/parser.go
@@ -19,6 +19,7 @@ const (
 // TablesList returns a list of tables for the sql statement
 func TablesList(rawSQL string) ([]string, error) {
 	duckDB := duck.NewInMemoryDB()
+	rawSQL = strings.Replace(rawSQL, "'", "''", -1)
 	cmd := fmt.Sprintf("SELECT json_serialize_sql('%s')", rawSQL)
 	ret, err := duckDB.RunCommands([]string{cmd})
 	if err != nil {

--- a/pkg/expr/sql/parser_test.go
+++ b/pkg/expr/sql/parser_test.go
@@ -196,3 +196,21 @@ func TestWith(t *testing.T) {
 	assert.Equal(t, "B", tables[1])
 	assert.Equal(t, "BEE", tables[2])
 }
+
+func TestWithQuote(t *testing.T) {
+	t.Skip()
+	sql := "select *,'junk' from foo"
+	tables, err := TablesList((sql))
+	assert.Nil(t, err)
+
+	assert.Equal(t, "foo", tables[0])
+}
+
+func TestWithQuote2(t *testing.T) {
+	t.Skip()
+	sql := "SELECT json_serialize_sql('SELECT 1')"
+	tables, err := TablesList((sql))
+	assert.Nil(t, err)
+
+	assert.Equal(t, 0, len(tables))
+}


### PR DESCRIPTION
handle sql statements with single quotes

@ryantxu caught this in the backport.  updating main with the same

tests are currently skipped until we get duckdb cli on the ci image