### PR TITLE
Update helm docs - removed enterprise tag from product labels

### DIFF
--- a/docs/sources/setup-grafana/installation/helm/index.md
+++ b/docs/sources/setup-grafana/installation/helm/index.md
@@ -4,7 +4,6 @@ aliases:
 description: Guide for deploying Grafana using Helm Charts
 labels:
   products:
-    - enterprise
     - oss
 menuTitle: Grafana on Helm Charts
 title: Deploy Grafana using Helm Charts


### PR DESCRIPTION
removed enterprise tag from product labels

Fixes #

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle.
- [x] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
