### PR TITLE
Dropdown: Fixes missing calls to onVisibilityChange causing wrong caret states

### DIFF
--- a/packages/grafana-ui/src/components/Dropdown/Dropdown.tsx
+++ b/packages/grafana-ui/src/components/Dropdown/Dropdown.tsx
@@ -73,12 +73,12 @@ export const Dropdown = React.memo(({ children, overlay, placement, offset, onVi
   const animationStyles = useStyles2(getStyles, animationDuration);
 
   const onOverlayClicked = () => {
-    setShow(false);
+    handleOpenChange(false);
   };
 
   const handleKeys = (event: React.KeyboardEvent) => {
     if (event.key === 'Tab') {
-      setShow(false);
+      handleOpenChange(false);
     }
   };
 


### PR DESCRIPTION
onVisibilityChange was not called when you click an item inside the overlay (a menu item), only when you clicked outside 

issue introduced by https://github.com/grafana/grafana/pull/87607 when we changed how we call onVisibilityChange (from inside a useEffect to the use-floating onOpenChange handler) 