### PR TITLE
IAM docs: Update Azure AD OAuth2.0 docs after rename to Entra ID

### DIFF
--- a/docs/sources/setup-grafana/configure-security/configure-authentication/_index.md
+++ b/docs/sources/setup-grafana/configure-security/configure-authentication/_index.md
@@ -198,6 +198,8 @@ curl --request PUT \
   --data '{ "updates": { "auth": { "oauth_allow_insecure_email_lookup": "true" }}}'
 ```
 
+Finally, you can also enable it using the UI by going to **Administration -> Authentication -> Auth settings**.
+
 ### Automatic OAuth login
 
 Set to true to attempt login with specific OAuth provider automatically, skipping the login screen.

--- a/docs/sources/setup-grafana/configure-security/configure-authentication/azuread/index.md
+++ b/docs/sources/setup-grafana/configure-security/configure-authentication/azuread/index.md
@@ -19,7 +19,7 @@ weight: 800
 
 # Configure Azure AD OAuth2 authentication
 
-The Azure AD authentication allows you to use an Azure Active Directory tenant as an identity provider for Grafana. You can use Azure AD application roles to assign users and groups to Grafana roles from the Azure Portal.
+The Azure AD authentication allows you to use a Microsoft Entra ID (formerly known as Azure Active Directory) tenant as an identity provider for Grafana. You can use Azure AD application roles to assign users and groups to Grafana roles from the Azure Portal.
 
 {{% admonition type="note" %}}
 If Users use the same email address in Azure AD that they use with other authentication providers (such as Grafana.com), you need to do additional configuration to ensure that the users are matched correctly. Please refer to [Using the same email address to login with different identity providers]({{< relref "../../configure-authentication#using-the-same-email-address-to-login-with-different-identity-providers" >}}) for more information.
@@ -29,7 +29,7 @@ If Users use the same email address in Azure AD that they use with other authent
 
 To enable the Azure AD OAuth2, register your application with Azure AD.
 
-1. Log in to [Azure Portal](https://portal.azure.com), then click **Azure Active Directory** in the side menu.
+1. Log in to [Azure Portal](https://portal.azure.com), then click **Microsoft Entra ID** in the side menu.
 
 1. If you have access to more than one tenant, select your account in the upper right. Set your session to the Azure AD tenant you wish to use.
 
@@ -46,7 +46,7 @@ To enable the Azure AD OAuth2, register your application with Azure AD.
    - Note the **OAuth 2.0 authorization endpoint (v2)** URL. This is the authorization URL.
    - Note the **OAuth 2.0 token endpoint (v2)**. This is the token URL.
 
-1. Click **Certificates & secrets**, then add a new entry under **Client secrets** with the following configuration.
+1. Click **Certificates & secrets** in the side menu, then add a new entry under **Client secrets** with the following configuration.
 
    - Description: Grafana OAuth
    - Expires: Select an expiration period
@@ -55,7 +55,7 @@ To enable the Azure AD OAuth2, register your application with Azure AD.
 
 1. Define the required application roles for Grafana [using the Azure Portal](#configure-application-roles-for-grafana-in-the-azure-portal) or [using the manifest file](#configure-application-roles-for-grafana-in-the-manifest-file).
 
-1. Go to **Azure Active Directory** and then to **Enterprise Applications**.
+1. Go to **Microsoft Entra ID** and then to **Enterprise Applications**, under **Manage**.
 
 1. Search for your application and click it.
 
@@ -88,7 +88,7 @@ If you prefer to configure the application roles for Grafana in the manifest fil
 
 1. Go to **App Registrations**, search for your application, and click it.
 
-1. Click **Manifest** and then click **Edit**.
+1. Click **Manifest**.
 
 1. Add a Universally Unique Identifier to each role.
 
@@ -268,7 +268,7 @@ Refresh token fetching and access token expiration check is enabled by default f
 ### Configure allowed tenants
 
 To limit access to authenticated users who are members of one or more tenants, set `allowed_organizations`
-to a comma- or space-separated list of tenant IDs. You can find tenant IDs on the Azure portal under **Azure Active Directory -> Overview**.
+to a comma- or space-separated list of tenant IDs. You can find tenant IDs on the Azure portal under **Microsoft Entra ID -> Overview**.
 
 Make sure to include the tenant IDs of all the federated Users' root directory if your Azure AD contains external identities.
 
@@ -285,7 +285,7 @@ Azure AD groups can be used to limit user access to Grafana. For more informatio
 To limit access to authenticated users who are members of one or more AzureAD groups, set `allowed_groups`
 to a **comma-** or **space-separated** list of group object IDs.
 
-1. To find object IDs for a specific group on the Azure portal, go to **Azure Active Directory > Groups**.
+1. To find object IDs for a specific group on the Azure portal, go to **Microsoft Entra ID > Manage > Groups**.
 
    You can find the Object Id of a group by clicking on the group and then clicking on **Properties**. The object ID is listed under **Object ID**. If you want to only give access to members of the group `example` with an Object Id of `8bab1c86-8fba-33e5-2089-1d1c80ec267d`, then set the following:
 
@@ -302,7 +302,7 @@ To ensure that the `groups` claim is included in the token, add the `groups` cla
 To configure group membership claims from the Azure Portal UI, complete the following steps:
 
 1. Navigate to the **App Registrations** page and select your application.
-1. Select **Token configuration**.
+1. Under **Manage** in the side menu, select **Token configuration**.
 1. Click **Add groups claim** and select the relevant option for your use case (for example, **Security groups** and **Groups assigned to the application**).
 
 For more information, see [Configure groups optional claims](https://learn.microsoft.com/en-us/entra/identity-platform/optional-claims#configure-groups-optional-claims).
@@ -315,7 +315,7 @@ If the user is a member of more than 200 groups, Azure AD does not emit the grou
 
 1. Go to **App Registrations**, search for your application, and click it.
 
-1. Click **Manifest** and then click **Edit**.
+1. Click **Manifest**.
 
 1. Add the following to the root of the manifest file:
 
@@ -386,7 +386,7 @@ Admin consent might be required for this permission.
 
 #### Configure the required Graph API permissions
 
-1. Navigate to **Azure Active Directory > App registrations** and select your application.
+1. Navigate to **Microsoft Entra ID > Manage > App registrations** and select your application.
 1. Select **API permissions** and then click on **Add a permission**.
 1. Select **Microsoft Graph** from the list of APIs.
 1. Select **Delegated permissions**.

--- a/docs/sources/setup-grafana/configure-security/configure-authentication/azuread/index.md
+++ b/docs/sources/setup-grafana/configure-security/configure-authentication/azuread/index.md
@@ -19,19 +19,19 @@ weight: 800
 
 # Configure Azure AD OAuth2 authentication
 
-The Azure AD authentication allows you to use a Microsoft Entra ID (formerly known as Azure Active Directory) tenant as an identity provider for Grafana. You can use Azure AD application roles to assign users and groups to Grafana roles from the Azure Portal.
+The Azure AD authentication allows you to use a Microsoft Entra ID (formerly known as Azure Active Directory) tenant as an identity provider for Grafana. You can use Entra ID application roles to assign users and groups to Grafana roles from the Azure Portal.
 
 {{% admonition type="note" %}}
-If Users use the same email address in Azure AD that they use with other authentication providers (such as Grafana.com), you need to do additional configuration to ensure that the users are matched correctly. Please refer to [Using the same email address to login with different identity providers]({{< relref "../../configure-authentication#using-the-same-email-address-to-login-with-different-identity-providers" >}}) for more information.
+If Users use the same email address in Microsoft Entra ID that they use with other authentication providers (such as Grafana.com), you need to do additional configuration to ensure that the users are matched correctly. Please refer to [Using the same email address to login with different identity providers]({{< relref "../../configure-authentication#using-the-same-email-address-to-login-with-different-identity-providers" >}}) for more information.
 {{% /admonition %}}
 
-## Create the Azure AD application
+## Create the Microsoft Entra ID application
 
-To enable the Azure AD OAuth2, register your application with Azure AD.
+To enable the Azure AD OAuth2, register your application with Entra ID.
 
 1. Log in to [Azure Portal](https://portal.azure.com), then click **Microsoft Entra ID** in the side menu.
 
-1. If you have access to more than one tenant, select your account in the upper right. Set your session to the Azure AD tenant you wish to use.
+1. If you have access to more than one tenant, select your account in the upper right. Set your session to the Entra ID tenant you wish to use.
 
 1. Under **Manage** in the side menu, click **App Registrations** > **New Registration**. Enter a descriptive name.
 
@@ -167,7 +167,7 @@ If the setting is set to `false`, the user is assigned the role of `Admin` of th
 
 ## Before you begin
 
-Ensure that you have followed the steps in [Create the Azure AD application](#create-the-azure-ad-application) before you begin.
+Ensure that you have followed the steps in [Create the Microsoft Entra ID application](#create-the-microsoft-entra-id-application) before you begin.
 
 ## Configure Azure AD authentication client using the Grafana UI
 
@@ -270,7 +270,7 @@ Refresh token fetching and access token expiration check is enabled by default f
 To limit access to authenticated users who are members of one or more tenants, set `allowed_organizations`
 to a comma- or space-separated list of tenant IDs. You can find tenant IDs on the Azure portal under **Microsoft Entra ID -> Overview**.
 
-Make sure to include the tenant IDs of all the federated Users' root directory if your Azure AD contains external identities.
+Make sure to include the tenant IDs of all the federated Users' root directory if your Entra ID contains external identities.
 
 For example, if you want to only give access to members of the tenant `example` with an ID of `8bab1c86-8fba-33e5-2089-1d1c80ec267d`, then set the following:
 
@@ -280,9 +280,9 @@ allowed_organizations = 8bab1c86-8fba-33e5-2089-1d1c80ec267d
 
 ### Configure allowed groups
 
-Azure AD groups can be used to limit user access to Grafana. For more information about managing groups in Azure AD, refer to [Manage Microsoft Entra groups and group membership](https://learn.microsoft.com/en-us/entra/fundamentals/how-to-manage-groups).
+Microsoft Entra ID groups can be used to limit user access to Grafana. For more information about managing groups in Entra ID, refer to [Manage Microsoft Entra groups and group membership](https://learn.microsoft.com/en-us/entra/fundamentals/how-to-manage-groups).
 
-To limit access to authenticated users who are members of one or more AzureAD groups, set `allowed_groups`
+To limit access to authenticated users who are members of one or more Entra ID groups, set `allowed_groups`
 to a **comma-** or **space-separated** list of group object IDs.
 
 1. To find object IDs for a specific group on the Azure portal, go to **Microsoft Entra ID > Manage > Groups**.
@@ -293,7 +293,7 @@ to a **comma-** or **space-separated** list of group object IDs.
      allowed_groups = 8bab1c86-8fba-33e5-2089-1d1c80ec267d
    ```
 
-1. You must enable adding the [group attribute](https://learn.microsoft.com/en-us/entra/identity-platform/optional-claims#configure-groups-optional-claims) to the tokens in your Azure AD App registration either [from the Azure Portal](#configure-group-membership-claims-on-the-azure-portal) or [from the manifest file](#configure-group-membership-claim-in-the-manifest-file).
+1. You must enable adding the [group attribute](https://learn.microsoft.com/en-us/entra/identity-platform/optional-claims#configure-groups-optional-claims) to the tokens in your Entra ID App registration either [from the Azure Portal](#configure-group-membership-claims-on-the-azure-portal) or [from the manifest file](#configure-group-membership-claim-in-the-manifest-file).
 
 #### Configure group membership claims on the Azure Portal
 
@@ -308,7 +308,7 @@ To configure group membership claims from the Azure Portal UI, complete the foll
 For more information, see [Configure groups optional claims](https://learn.microsoft.com/en-us/entra/identity-platform/optional-claims#configure-groups-optional-claims).
 
 {{% admonition type="note" %}}
-If the user is a member of more than 200 groups, Azure AD does not emit the groups claim in the token and instead emits a group overage claim. To set up a group overage claim, see [Users with over 200 Group assignments](#users-with-over-200-group-assignments).
+If the user is a member of more than 200 groups, Entra ID does not emit the groups claim in the token and instead emits a group overage claim. To set up a group overage claim, see [Users with over 200 Group assignments](#users-with-over-200-group-assignments).
 {{% /admonition %}}
 
 #### Configure group membership claim in the manifest file
@@ -351,10 +351,10 @@ auto_login = true
 
 ### Team Sync (Enterprise only)
 
-With Team Sync you can map your Azure AD groups to teams in Grafana so that your users will automatically be added to
+With Team Sync you can map your Entra ID groups to teams in Grafana so that your users will automatically be added to
 the correct teams.
 
-You can reference Azure AD groups by group object ID, like `8bab1c86-8fba-33e5-2089-1d1c80ec267d`.
+You can reference Entra ID groups by group object ID, like `8bab1c86-8fba-33e5-2089-1d1c80ec267d`.
 
 To learn more, refer to the [Team Sync]({{< relref "../../configure-team-sync" >}}) documentation.
 
@@ -368,10 +368,10 @@ configuring Azure AD authentication in Grafana.
 > Supported in Grafana v8.5 and later versions.
 
 To ensure that the token size doesn't exceed HTTP header size limits,
-Azure AD limits the number of object IDs that it includes in the groups claim.
+Entra ID limits the number of object IDs that it includes in the groups claim.
 If a user is member of more groups than the
 overage limit (200), then
-Azure AD does not emit the groups claim in the token and emits a group overage claim instead.
+Entra ID does not emit the groups claim in the token and emits a group overage claim instead.
 
 > More information in [Groups overage claim](https://learn.microsoft.com/en-us/azure/active-directory/develop/id-token-claims-reference#groups-overage-claim)
 
@@ -407,19 +407,19 @@ force_use_graph_api = true
 
 ### Map roles
 
-By default, Azure AD authentication will map users to organization roles based on the most privileged application role assigned to the user in AzureAD.
+By default, Azure AD authentication will map users to organization roles based on the most privileged application role assigned to the user in Entra ID.
 
 If no application role is found, the user is assigned the role specified by
 [the `auto_assign_org_role` option]({{< relref "../../../configure-grafana#auto_assign_org_role" >}}).
 You can disable this default role assignment by setting `role_attribute_strict = true`.
 It denies user access if no role or an invalid role is returned.
 
-**On every login** the user organization role will be reset to match AzureAD's application role and
+**On every login** the user organization role will be reset to match Entra ID's application role and
 their organization membership will be reset to the default organization.
 
 ## Skip organization role sync
 
-If Azure AD authentication is not intended to sync user roles and organization membership and prevent the sync of org roles from AzureAD, set `skip_org_role_sync` to `true`. This is useful if you want to manage the organization roles for your users from within Grafana or that your organization roles are synced from another provider.
+If Azure AD authentication is not intended to sync user roles and organization membership and prevent the sync of org roles from Entra ID, set `skip_org_role_sync` to `true`. This is useful if you want to manage the organization roles for your users from within Grafana or that your organization roles are synced from another provider.
 See [Configure Grafana]({{< relref "../../../configure-grafana#authazuread" >}}) for more details.
 
 ```ini

--- a/docs/sources/setup-grafana/configure-security/configure-authentication/azuread/index.md
+++ b/docs/sources/setup-grafana/configure-security/configure-authentication/azuread/index.md
@@ -373,7 +373,7 @@ If a user is member of more groups than the
 overage limit (200), then
 Entra ID does not emit the groups claim in the token and emits a group overage claim instead.
 
-> More information in [Groups overage claim](https://learn.microsoft.com/en-us/azure/active-directory/develop/id-token-claims-reference#groups-overage-claim)
+> More information in [Groups overage claim](https://learn.microsoft.com/en-us/entra/identity-platform/id-token-claims-reference#groups-overage-claim)
 
 If Grafana receives a token with a group overage claim instead of a groups claim,
 Grafana attempts to retrieve the user's group membership by calling the included endpoint.


### PR DESCRIPTION
Replaces all mentions of Azure Active Directory with Microsoft Entra ID, which is how the same product is called nowadays.

It keeps mentions of Azure AD OAuth2 and the like when they refer to the Grafana part of the the config, as it's still named Azure AD there. 