### PR TITLE
Alerting: Schedule a shim implementation for recording rules

### DIFF
--- a/pkg/services/ngalert/schedule/alert_rule.go
+++ b/pkg/services/ngalert/schedule/alert_rule.go
@@ -36,10 +36,10 @@ type Rule interface {
 	Update(lastVersion RuleVersionAndPauseStatus) bool
 }
 
-type ruleFactoryFunc func(context.Context) Rule
+type ruleFactoryFunc func(context.Context, *ngmodels.AlertRule) Rule
 
-func (f ruleFactoryFunc) new(ctx context.Context) Rule {
-	return f(ctx)
+func (f ruleFactoryFunc) new(ctx context.Context, rule *ngmodels.AlertRule) Rule {
+	return f(ctx, rule)
 }
 
 func newRuleFactory(
@@ -57,7 +57,7 @@ func newRuleFactory(
 	evalAppliedHook evalAppliedFunc,
 	stopAppliedHook stopAppliedFunc,
 ) ruleFactoryFunc {
-	return func(ctx context.Context) Rule {
+	return func(ctx context.Context, rule *ngmodels.AlertRule) Rule {
 		return newAlertRule(
 			ctx,
 			appURL,

--- a/pkg/services/ngalert/schedule/alert_rule.go
+++ b/pkg/services/ngalert/schedule/alert_rule.go
@@ -58,6 +58,9 @@ func newRuleFactory(
 	stopAppliedHook stopAppliedFunc,
 ) ruleFactoryFunc {
 	return func(ctx context.Context, rule *ngmodels.AlertRule) Rule {
+		if rule.IsRecordingRule() {
+			return newRecordingRule(ctx, logger)
+		}
 		return newAlertRule(
 			ctx,
 			appURL,

--- a/pkg/services/ngalert/schedule/alert_rule_test.go
+++ b/pkg/services/ngalert/schedule/alert_rule_test.go
@@ -279,7 +279,7 @@ func TestRuleRoutine(t *testing.T) {
 			factory := ruleFactoryFromScheduler(sch)
 			ctx, cancel := context.WithCancel(context.Background())
 			t.Cleanup(cancel)
-			ruleInfo := factory.new(ctx)
+			ruleInfo := factory.new(ctx, rule)
 			go func() {
 				_ = ruleInfo.Run(rule.GetKey())
 			}()
@@ -442,7 +442,7 @@ func TestRuleRoutine(t *testing.T) {
 
 			factory := ruleFactoryFromScheduler(sch)
 			ctx, cancel := context.WithCancel(context.Background())
-			ruleInfo := factory.new(ctx)
+			ruleInfo := factory.new(ctx, rule)
 			go func() {
 				err := ruleInfo.Run(models.AlertRuleKey{})
 				stoppedChan <- err
@@ -462,7 +462,7 @@ func TestRuleRoutine(t *testing.T) {
 			require.NotEmpty(t, sch.stateManager.GetStatesForRuleUID(rule.OrgID, rule.UID))
 
 			factory := ruleFactoryFromScheduler(sch)
-			ruleInfo := factory.new(context.Background())
+			ruleInfo := factory.new(context.Background(), rule)
 			go func() {
 				err := ruleInfo.Run(rule.GetKey())
 				stoppedChan <- err
@@ -492,7 +492,7 @@ func TestRuleRoutine(t *testing.T) {
 		factory := ruleFactoryFromScheduler(sch)
 		ctx, cancel := context.WithCancel(context.Background())
 		t.Cleanup(cancel)
-		ruleInfo := factory.new(ctx)
+		ruleInfo := factory.new(ctx, rule)
 
 		go func() {
 			_ = ruleInfo.Run(rule.GetKey())
@@ -574,7 +574,7 @@ func TestRuleRoutine(t *testing.T) {
 		factory := ruleFactoryFromScheduler(sch)
 		ctx, cancel := context.WithCancel(context.Background())
 		t.Cleanup(cancel)
-		ruleInfo := factory.new(ctx)
+		ruleInfo := factory.new(ctx, rule)
 
 		go func() {
 			_ = ruleInfo.Run(rule.GetKey())
@@ -693,7 +693,7 @@ func TestRuleRoutine(t *testing.T) {
 			factory := ruleFactoryFromScheduler(sch)
 			ctx, cancel := context.WithCancel(context.Background())
 			t.Cleanup(cancel)
-			ruleInfo := factory.new(ctx)
+			ruleInfo := factory.new(ctx, rule)
 
 			go func() {
 				_ = ruleInfo.Run(rule.GetKey())
@@ -727,7 +727,7 @@ func TestRuleRoutine(t *testing.T) {
 		factory := ruleFactoryFromScheduler(sch)
 		ctx, cancel := context.WithCancel(context.Background())
 		t.Cleanup(cancel)
-		ruleInfo := factory.new(ctx)
+		ruleInfo := factory.new(ctx, rule)
 
 		go func() {
 			_ = ruleInfo.Run(rule.GetKey())

--- a/pkg/services/ngalert/schedule/recording_rule.go
+++ b/pkg/services/ngalert/schedule/recording_rule.go
@@ -43,7 +43,7 @@ func (r *recordingRule) Run(key ngmodels.AlertRuleKey) error {
 	logger := r.logger.FromContext(ctx)
 	logger.Debug("Recording rule routine started")
 
-	// nolint:gosimple - this erroneously trips a linter rule because there's only one channel in the select. there will be more in the future.
+	// nolint:gosimple
 	for {
 		select {
 		case <-ctx.Done():

--- a/pkg/services/ngalert/schedule/recording_rule.go
+++ b/pkg/services/ngalert/schedule/recording_rule.go
@@ -1,0 +1,53 @@
+package schedule
+
+import (
+	context "context"
+
+	"github.com/grafana/grafana/pkg/infra/log"
+	ngmodels "github.com/grafana/grafana/pkg/services/ngalert/models"
+	"github.com/grafana/grafana/pkg/util"
+)
+
+type recordingRule struct {
+	ctx    context.Context
+	stopFn util.CancelCauseFunc
+
+	logger log.Logger
+}
+
+func newRecordingRule(parent context.Context, logger log.Logger) *recordingRule {
+	ctx, stop := util.WithCancelCause(parent)
+	return &recordingRule{
+		ctx:    ctx,
+		stopFn: stop,
+		logger: logger,
+	}
+}
+
+func (r *recordingRule) Eval(eval *Evaluation) (bool, *Evaluation) {
+	return true, nil
+}
+
+func (r *recordingRule) Update(lastVersion RuleVersionAndPauseStatus) bool {
+	return true
+}
+
+func (r *recordingRule) Stop(reason error) {
+	if r.stopFn != nil {
+		r.stopFn(reason)
+	}
+}
+
+func (r *recordingRule) Run(key ngmodels.AlertRuleKey) error {
+	ctx := ngmodels.WithRuleKey(r.ctx, key)
+	logger := r.logger.FromContext(ctx)
+	logger.Debug("Recording rule routine started")
+
+	for {
+		select {
+		case <-ctx.Done():
+			logger.Debug("Stopping recording rule routine")
+			return nil
+		}
+	}
+}

--- a/pkg/services/ngalert/schedule/recording_rule.go
+++ b/pkg/services/ngalert/schedule/recording_rule.go
@@ -43,6 +43,7 @@ func (r *recordingRule) Run(key ngmodels.AlertRuleKey) error {
 	logger := r.logger.FromContext(ctx)
 	logger.Debug("Recording rule routine started")
 
+	// nolint:gosimple - this erroneously trips a linter rule because there's only one channel in the select. there will be more in the future.
 	for {
 		select {
 		case <-ctx.Done():

--- a/pkg/services/ngalert/schedule/registry.go
+++ b/pkg/services/ngalert/schedule/registry.go
@@ -13,13 +13,12 @@ import (
 	"unsafe"
 
 	"github.com/grafana/grafana/pkg/services/ngalert/models"
-	ngmodels "github.com/grafana/grafana/pkg/services/ngalert/models"
 )
 
 var errRuleDeleted = errors.New("rule deleted")
 
 type ruleFactory interface {
-	new(context.Context, *ngmodels.AlertRule) Rule
+	new(context.Context, *models.AlertRule) Rule
 }
 
 type ruleRegistry struct {
@@ -33,7 +32,7 @@ func newRuleRegistry() ruleRegistry {
 
 // getOrCreate gets a rule routine from registry for the provided rule. If it does not exist, it creates a new one.
 // Returns a pointer to the rule routine and a flag that indicates whether it is a new struct or not.
-func (r *ruleRegistry) getOrCreate(context context.Context, item *ngmodels.AlertRule, factory ruleFactory) (Rule, bool) {
+func (r *ruleRegistry) getOrCreate(context context.Context, item *models.AlertRule, factory ruleFactory) (Rule, bool) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 

--- a/pkg/services/ngalert/schedule/registry.go
+++ b/pkg/services/ngalert/schedule/registry.go
@@ -13,12 +13,13 @@ import (
 	"unsafe"
 
 	"github.com/grafana/grafana/pkg/services/ngalert/models"
+	ngmodels "github.com/grafana/grafana/pkg/services/ngalert/models"
 )
 
 var errRuleDeleted = errors.New("rule deleted")
 
 type ruleFactory interface {
-	new(context.Context) Rule
+	new(context.Context, *ngmodels.AlertRule) Rule
 }
 
 type ruleRegistry struct {
@@ -30,15 +31,16 @@ func newRuleRegistry() ruleRegistry {
 	return ruleRegistry{rules: make(map[models.AlertRuleKey]Rule)}
 }
 
-// getOrCreate gets rule routine from registry by the key. If it does not exist, it creates a new one.
+// getOrCreate gets a rule routine from registry for the provided rule. If it does not exist, it creates a new one.
 // Returns a pointer to the rule routine and a flag that indicates whether it is a new struct or not.
-func (r *ruleRegistry) getOrCreate(context context.Context, key models.AlertRuleKey, factory ruleFactory) (Rule, bool) {
+func (r *ruleRegistry) getOrCreate(context context.Context, item *ngmodels.AlertRule, factory ruleFactory) (Rule, bool) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 
+	key := item.GetKey()
 	rule, ok := r.rules[key]
 	if !ok {
-		rule = factory.new(context)
+		rule = factory.new(context, item)
 		r.rules[key] = rule
 	}
 	return rule, !ok

--- a/pkg/services/ngalert/schedule/schedule.go
+++ b/pkg/services/ngalert/schedule/schedule.go
@@ -251,9 +251,10 @@ func (sch *schedule) processTick(ctx context.Context, dispatcherGroup *errgroup.
 		sch.stopAppliedFunc,
 	)
 	for _, item := range alertRules {
+		ruleRoutine, newRoutine := sch.registry.getOrCreate(ctx, item, ruleFactory)
 		key := item.GetKey()
-		ruleRoutine, newRoutine := sch.registry.getOrCreate(ctx, key, ruleFactory)
 		logger := sch.log.FromContext(ctx).New(key.LogContext()...)
+
 		// enforce minimum evaluation interval
 		if item.IntervalSeconds < int64(sch.minRuleInterval.Seconds()) {
 			logger.Debug("Interval adjusted", "originalInterval", item.IntervalSeconds, "adjustedInterval", sch.minRuleInterval.Seconds())

--- a/pkg/services/ngalert/schedule/schedule_unit_test.go
+++ b/pkg/services/ngalert/schedule/schedule_unit_test.go
@@ -363,7 +363,7 @@ func TestSchedule_deleteAlertRule(t *testing.T) {
 			ruleFactory := ruleFactoryFromScheduler(sch)
 			rule := models.RuleGen.GenerateRef()
 			key := rule.GetKey()
-			info, _ := sch.registry.getOrCreate(context.Background(), key, ruleFactory)
+			info, _ := sch.registry.getOrCreate(context.Background(), rule, ruleFactory)
 			sch.deleteAlertRule(key)
 			require.ErrorIs(t, info.(*alertRule).ctx.Err(), errRuleDeleted)
 			require.False(t, sch.registry.exists(key))


### PR DESCRIPTION
**What is this feature?**

Right now, if a recording rule is present in the database it'll be scheduled as an Alert rule. This will immediately fail because recording rules lack some of the alert rule fields.

Here we introduce an alternate rule implementation for recording rules. It's left as a shim for now that doesn't do anything, but it doesn't fail either.

This unblocks work on metrics and tracking health for recording rules without needing to write their full implementation yet. Makes future work easier to parallelize.

**Which issue(s) does this PR fix?**:

n/a

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle.
- [x] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
