### PR TITLE
XY Chart: Fix series editor index

### DIFF
--- a/public/app/plugins/panel/xychart/v2/SeriesEditor.tsx
+++ b/public/app/plugins/panel/xychart/v2/SeriesEditor.tsx
@@ -31,13 +31,16 @@ export const SeriesEditor = ({
   const mappingChanged = prevMapping != null && mapping !== prevMapping;
 
   const defaultFrame = { frame: { matcher: { id: FrameMatcherID.byIndex, options: 0 } } };
+  const [selectedIdx, setSelectedIdx] = useState(0);
 
   if (mappingChanged || seriesCfg == null) {
     seriesCfg = [{ ...defaultFrame }];
     onChange([...seriesCfg]);
-  }
 
-  const [selectedIdx, setSelectedIdx] = useState(0);
+    if (selectedIdx > 0) {
+      setSelectedIdx(0);
+    }
+  }
 
   const addSeries = () => {
     seriesCfg = seriesCfg.concat({ ...defaultFrame });


### PR DESCRIPTION
Fixes issue with series editor fields disappearing when switching to auto mode. 
Pulled out of https://github.com/grafana/grafana/pull/87879



Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
