### PR TITLE
Remove `Single and multi-dimensional rule` from `Configure alert rules`

### DIFF
--- a/docs/sources/alerting/alerting-rules/create-grafana-managed-rule.md
+++ b/docs/sources/alerting/alerting-rules/create-grafana-managed-rule.md
@@ -185,28 +185,7 @@ Annotations add metadata to provide more information on the alert in your alert 
 
 1. Click **Save rule**.
 
-### Single and multi-dimensional rule
-
-For Grafana managed alerts, you can create a rule with a classic condition or you can create a multi-dimensional rule.
-
-**Rule with classic condition**
-
-Use the classic condition expression to create a rule that triggers a single alert when its condition is met. For a query that returns multiple series, Grafana does not track the alert state of each series. As a result, Grafana sends only a single alert even when alert conditions are met for multiple series.
-
-For more information, see [expressions documentation][expression-queries].
-
-**Multi-dimensional rule**
-
-To generate a separate alert for each series, create a multi-dimensional rule. Use `Math`, `Reduce`, or `Resample` expressions to create a multi-dimensional rule. For example:
-
-- Add a `Reduce` expression for each query to aggregate values in the selected time range into a single value. (Not needed for [rules using numeric data][alerting-on-numeric-data]).
-- Add a `Math` expression with the condition for the rule. Not needed in case a query or a reduce expression already returns 0 if rule should not fire, or a positive number if it should fire. Some examples: `$B > 70` if it should fire in case value of B query/expression is more than 70. `$B < $C * 100` in case it should fire if value of B is less than value of C multiplied by 100. If queries being compared have multiple series in their results, series from different queries are matched if they have the same labels or one is a subset of the other.
-
-![Query section multi dimensional](/static/img/docs/alerting/unified/rule-edit-multi-8-0.png 'Query section multi dimensional screenshot')
-
-> **Note:** Grafana does not support alert queries with template variables. More information is available at <https://community.grafana.com/t/template-variables-are-not-supported-in-alert-queries-while-setting-up-alert/2514>.
-
-### Configure no data and error handling
+## Configure no data and error handling
 
 Configure alerting behavior when your alert rule evaluation returns no data or an error.
 
@@ -228,13 +207,13 @@ If your evaluation returns an error, you can set the state on your alert rule to
 | Alerting | Sets alert rule state to `Alerting`. The alert rule waits until the time set in the **For** field has finished before firing.                   |
 | Ok       | Sets alert rule state to `Normal`.                                                                                                              |
 
-### Resolve stale alert instances
+## Resolve stale alert instances
 
 An alert instance is considered stale if its dimension or series has disappeared from the query results entirely for two evaluation intervals.
 
 Stale alert instances that are in the **Alerting**/**NoData**/**Error** states are automatically marked as **Resolved** and the grafana_state_reason annotation is added to the alert instance with the reason **MissingSeries**.
 
-### Create alerts from panels
+## Create alerts from panels
 
 Create alerts from any panel type. This means you can reuse the queries in the panel and create alerts based on them.
 

--- a/docs/sources/alerting/alerting-rules/create-grafana-managed-rule.md
+++ b/docs/sources/alerting/alerting-rules/create-grafana-managed-rule.md
@@ -185,7 +185,7 @@ Annotations add metadata to provide more information on the alert in your alert 
 
 1. Click **Save rule**.
 
-## Configure no data and error handling
+### Configure no data and error handling
 
 Configure alerting behavior when your alert rule evaluation returns no data or an error.
 
@@ -207,13 +207,13 @@ If your evaluation returns an error, you can set the state on your alert rule to
 | Alerting | Sets alert rule state to `Alerting`. The alert rule waits until the time set in the **For** field has finished before firing.                   |
 | Ok       | Sets alert rule state to `Normal`.                                                                                                              |
 
-## Resolve stale alert instances
+### Resolve stale alert instances
 
 An alert instance is considered stale if its dimension or series has disappeared from the query results entirely for two evaluation intervals.
 
 Stale alert instances that are in the **Alerting**/**NoData**/**Error** states are automatically marked as **Resolved** and the grafana_state_reason annotation is added to the alert instance with the reason **MissingSeries**.
 
-## Create alerts from panels
+### Create alerts from panels
 
 Create alerts from any panel type. This means you can reuse the queries in the panel and create alerts based on them.
 

--- a/docs/sources/alerting/fundamentals/alert-rules/queries-conditions.md
+++ b/docs/sources/alerting/fundamentals/alert-rules/queries-conditions.md
@@ -50,9 +50,9 @@ Some common types of query components include:
 
 **Grouping**: Group the data by specific dimensions or tags to create aggregated views or breakdowns.
 
-**Note**:
-
-Grafana does not support alert queries with template variables. More information is available [here](https://community.grafana.com/t/template-variables-are-not-supported-in-alert-queries-while-setting-up-alert/2514).
+{{% admonition type="note" %}}
+Grafana doesn't support alert queries with template variables. More details [here.](https://community.grafana.com/t/template-variables-are-not-supported-in-alert-queries-while-setting-up-alert/2514)
+{{% /admonition %}}
 
 ## Expression queries
 
@@ -60,21 +60,20 @@ In Grafana, an expression is used to perform calculations, transformations, or a
 
 By leveraging expression queries, users can perform tasks such as calculating the percentage change between two values, applying functions like logarithmic or trigonometric functions, aggregating data over specific time ranges or dimensions, and implementing conditional logic to handle different scenarios.
 
-In Alerting, you can only use expressions for Grafana-managed alert rules. For each expression, you can choose from the math, reduce, and resample expressions. These are called multi-dimensional rules, because they generate a separate alert for each series.
-
-You can also use classic condition, which creates an alert rule that triggers a single alert when its condition is met. As a result, Grafana sends only a single alert even when alert conditions are met for multiple series.
-
-**Note:**
-
-Classic conditions exist mainly for compatibility reasons and should be avoided if possible.
+In Alerting, you can only use expressions for Grafana-managed alert rules. For each expression, you can choose from the math, reduce, and resample expressions. These are called multi-dimensional rules, because they generate an alert instance for each series.
 
 **Reduce**
 
-Aggregates time series values in the selected time range into a single value.
+Aggregates time series values in the selected time range into a single value. It's not necessary for [rules using numeric data.](#alert-on-numeric-data)
 
 **Math**
 
-Performs free-form math functions/operations on time series and number data. Can be used to preprocess time series data or to define an alert condition for number data.
+Performs free-form math functions/operations on time series and number data. Can be used to preprocess time series data or to define an alert condition for number data. For example:
+
+- `$B > 70` should fire if the value of B (query or expression) is more than 70.
+- `$B < $C * 100` should fire if the value of B is less than the value of C multiplied by 100.
+
+If queries being compared have multiple series in their results, series from different queries are matched if they have the same labels or one is a subset of the other.
 
 **Resample**
 
@@ -91,14 +90,11 @@ The threshold expression allows you to compare two single values. It returns `0`
 - Is within range (x > y1 AND x < y2)
 - Is outside range (x < y1 AND x > y2)
 
-**Classic condition**
+**Classic condition (legacy)**
 
-Checks if any time series data matches the alert condition.
-
-**Note**:
-
-Classic condition expression queries always produce one alert instance only, no matter how many time series meet the condition.
 Classic conditions exist mainly for compatibility reasons and should be avoided if possible.
+
+Classic condition checks if any time series data matches the alert condition. It always produce one alert instance only, no matter how many time series meet the condition.
 
 ## Aggregations
 


### PR DESCRIPTION
Migrate the content from [Configure Grafana-managed alert rules/Single and multi-dimensional rule](https://grafana.com/docs/grafana/next/alerting/alerting-rules/create-grafana-managed-rule/#single-and-multi-dimensional-rule) to [Expression queries](https://grafana.com/docs/grafana/next/alerting/fundamentals/alert-rules/queries-conditions/#expression-queries), and tidy up the content. 