### PR TITLE
Draft: add apiVersion to datasource ref

### DIFF
--- a/packages/grafana-data/src/types/datasource.ts
+++ b/packages/grafana-data/src/types/datasource.ts
@@ -322,7 +322,7 @@ abstract class DataSourceApi<
 
   /** Get an identifier object for this datasource instance */
   getRef(): DataSourceRef {
-    return { type: this.type, uid: this.uid, apiVersion: this.meta.apiVersion };
+    return { type: this.type, uid: this.uid, apiVersion: this.meta?.apiVersion };
   }
 
   /**

--- a/packages/grafana-data/src/types/datasource.ts
+++ b/packages/grafana-data/src/types/datasource.ts
@@ -139,6 +139,7 @@ export interface DataSourcePluginMeta<T extends KeyValue = {}> extends PluginMet
   unlicensed?: boolean;
   backend?: boolean;
   isBackend?: boolean;
+  apiVersion?: string;
 }
 
 interface PluginMetaQueryOptions {
@@ -321,7 +322,7 @@ abstract class DataSourceApi<
 
   /** Get an identifier object for this datasource instance */
   getRef(): DataSourceRef {
-    return { type: this.type, uid: this.uid };
+    return { type: this.type, uid: this.uid, apiVersion: this.meta.apiVersion };
   }
 
   /**

--- a/packages/grafana-data/src/utils/datasource.ts
+++ b/packages/grafana-data/src/utils/datasource.ts
@@ -16,7 +16,7 @@ import {
  * @public
  */
 export function getDataSourceRef(ds: DataSourceInstanceSettings): DataSourceRef {
-  return { uid: ds.uid, type: ds.type, apiVersion: ds.meta.apiVersion };
+  return { uid: ds.uid, type: ds.type, apiVersion: ds.meta?.apiVersion };
 }
 
 /**

--- a/packages/grafana-data/src/utils/datasource.ts
+++ b/packages/grafana-data/src/utils/datasource.ts
@@ -16,7 +16,7 @@ import {
  * @public
  */
 export function getDataSourceRef(ds: DataSourceInstanceSettings): DataSourceRef {
-  return { uid: ds.uid, type: ds.type };
+  return { uid: ds.uid, type: ds.type, apiVersion: ds.meta.apiVersion };
 }
 
 /**

--- a/packages/grafana-runtime/src/utils/DataSourceWithBackend.test.ts
+++ b/packages/grafana-runtime/src/utils/DataSourceWithBackend.test.ts
@@ -95,6 +95,7 @@ describe('DataSourceWithBackend', () => {
             {
               "applyTemplateVariablesCalled": true,
               "datasource": {
+                "apiVersion": undefined,
                 "type": "dummy",
                 "uid": "abc",
               },
@@ -113,6 +114,7 @@ describe('DataSourceWithBackend', () => {
             },
             {
               "datasource": {
+                "apiVersion": undefined,
                 "type": "sample",
                 "uid": "<mockuid>",
               },
@@ -163,6 +165,7 @@ describe('DataSourceWithBackend', () => {
             {
               "applyTemplateVariablesCalled": true,
               "datasource": {
+                "apiVersion": undefined,
                 "type": "dummy",
                 "uid": "abc",
               },
@@ -237,6 +240,7 @@ describe('DataSourceWithBackend', () => {
             {
               "applyTemplateVariablesCalled": true,
               "datasource": {
+                "apiVersion": undefined,
                 "type": "dummy",
                 "uid": "abc",
               },
@@ -249,6 +253,7 @@ describe('DataSourceWithBackend', () => {
             },
             {
               "datasource": {
+                "apiVersion": undefined,
                 "type": "sample",
                 "uid": "<mockuid>",
               },
@@ -379,6 +384,7 @@ describe('DataSourceWithBackend', () => {
             {
               "applyTemplateVariablesCalled": true,
               "datasource": {
+                "apiVersion": undefined,
                 "type": "dummy",
                 "uid": "abc",
               },

--- a/packages/grafana-schema/src/common/common.gen.ts
+++ b/packages/grafana-schema/src/common/common.gen.ts
@@ -847,6 +847,10 @@ export enum VariableFormatID {
 
 export interface DataSourceRef {
   /**
+   * API version of the datasource
+   */
+  apiVersion?: string;
+  /**
    * The plugin type-id
    */
   type?: string;

--- a/packages/grafana-schema/src/common/dataquery_gen.cue
+++ b/packages/grafana-schema/src/common/dataquery_gen.cue
@@ -42,4 +42,6 @@ DataSourceRef: {
 	type?: string
 	// Specific datasource instance
 	uid?: string
+	// API version of the datasource
+	apiVersion?: string
 } @cuetsy(kind="interface")

--- a/public/app/features/alerting/unified/components/rule-editor/QueryRows.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/QueryRows.tsx
@@ -229,6 +229,7 @@ function copyModel(item: AlertQuery, settings: DataSourceInstanceSettings): Omit
       datasource: {
         type: settings.type,
         uid: settings.uid,
+        apiVersion: settings.meta.apiVersion,
       },
     },
     datasourceUid: settings.uid,
@@ -247,6 +248,7 @@ function newModel(item: AlertQuery, settings: DataSourceInstanceSettings): Omit<
       datasource: {
         type: settings.type,
         uid: settings.uid,
+        apiVersion: settings.meta.apiVersion,
       },
     },
   };

--- a/public/app/features/alerting/unified/components/rule-editor/query-and-alert-condition/__snapshots__/reducer.test.tsx.snap
+++ b/public/app/features/alerting/unified/components/rule-editor/query-and-alert-condition/__snapshots__/reducer.test.tsx.snap
@@ -69,6 +69,7 @@ exports[`Query and expressions reducer should add query 1`] = `
       "datasourceUid": "c8eceabb-0275-4108-8f03-8f74faf4bf6d",
       "model": {
         "datasource": {
+          "apiVersion": undefined,
           "type": "prometheus",
           "uid": "c8eceabb-0275-4108-8f03-8f74faf4bf6d",
         },

--- a/public/app/features/alerting/unified/components/rule-editor/query-and-alert-condition/reducer.ts
+++ b/public/app/features/alerting/unified/components/rule-editor/query-and-alert-condition/reducer.ts
@@ -67,6 +67,7 @@ export const queriesAndExpressionsReducer = createReducer(initialState, (builder
           datasource: {
             type: datasource.type,
             uid: datasource.uid,
+            apiVersion: datasource.meta.apiVersion,
           },
         },
       });

--- a/public/app/features/alerting/unified/utils/rule-form.ts
+++ b/public/app/features/alerting/unified/utils/rule-form.ts
@@ -498,7 +498,7 @@ const dataQueriesToGrafanaQueries = async (
 
   for (const target of queries) {
     const datasource = await getDataSourceSrv().get(target.datasource?.uid ? target.datasource : panelDataSourceRef);
-    const dsRef = { uid: datasource.uid, type: datasource.type };
+    const dsRef = { uid: datasource.uid, type: datasource.type, apiVersion: datasource.meta.apiVersion };
 
     const range = rangeUtil.relativeToTimeRange(relativeTimeRange);
     const { interval, intervalMs } = getIntervals(range, minInterval ?? datasource.interval, maxDataPoints);

--- a/public/app/features/dashboard-scene/panel-edit/PanelDataPane/PanelDataQueriesTab.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelDataPane/PanelDataQueriesTab.tsx
@@ -83,6 +83,7 @@ export class PanelDataQueriesTab extends SceneObjectBase<PanelDataQueriesTabStat
         default: panelManager.state.dsSettings?.isDefault,
         type: panelManager.state.dsSettings?.type,
         uid: panelManager.state.dsSettings?.uid,
+        apiVersion: panelManager.state.dsSettings?.meta.apiVersion,
       },
       queries,
       maxDataPoints: queryRunner.state.maxDataPoints,
@@ -133,7 +134,7 @@ export class PanelDataQueriesTab extends SceneObjectBase<PanelDataQueriesTabStat
 
     return {
       ...datasource?.getDefaultQuery?.(CoreApp.PanelEditor),
-      datasource: { uid: ds?.uid, type: ds?.type },
+      datasource: { uid: ds?.uid, type: ds?.type, apiVersion: ds?.meta.apiVersion },
     };
   }
 
@@ -145,7 +146,13 @@ export class PanelDataQueriesTab extends SceneObjectBase<PanelDataQueriesTabStat
   onAddQuery = (query: Partial<DataQuery>) => {
     const queries = this.getQueries();
     const dsSettings = this._panelManager.state.dsSettings;
-    this.onQueriesChange(addQuery(queries, query, { type: dsSettings?.type, uid: dsSettings?.uid }));
+    this.onQueriesChange(
+      addQuery(queries, query, {
+        type: dsSettings?.type,
+        uid: dsSettings?.uid,
+        apiVersion: dsSettings?.meta.apiVersion,
+      })
+    );
   };
 
   isExpressionsSupported(dsSettings: DataSourceInstanceSettings): boolean {

--- a/public/app/features/dashboard-scene/panel-edit/VizPanelManager.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/VizPanelManager.tsx
@@ -161,7 +161,7 @@ export class VizPanelManager extends SceneObjectBase<VizPanelManagerState> {
               datasource: {
                 uid: lastUsedDatasource?.datasourceUid,
                 type: dsSettings.type,
-                apiVersion: dsSettings.meta.apiVersion,
+                apiVersion: dsSettings.meta?.apiVersion,
               },
             });
           }
@@ -178,7 +178,7 @@ export class VizPanelManager extends SceneObjectBase<VizPanelManagerState> {
           {
             type: dsSettings.type,
             uid: dsSettings.uid,
-            apiVersion: dsSettings.meta.apiVersion,
+            apiVersion: dsSettings.meta?.apiVersion,
           } || { default: true }
         );
       }
@@ -197,7 +197,7 @@ export class VizPanelManager extends SceneObjectBase<VizPanelManagerState> {
           datasource: {
             uid: dsSettings.uid,
             type: dsSettings.type,
-            apiVersion: dsSettings.meta.apiVersion,
+            apiVersion: dsSettings.meta?.apiVersion,
           },
         });
       }
@@ -301,7 +301,7 @@ export class VizPanelManager extends SceneObjectBase<VizPanelManagerState> {
       datasource: {
         type: newSettings.type,
         uid: newSettings.uid,
-        apiVersion: newSettings.meta.apiVersion,
+        apiVersion: newSettings.meta?.apiVersion,
       },
       queries,
     });

--- a/public/app/features/dashboard-scene/panel-edit/VizPanelManager.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/VizPanelManager.tsx
@@ -161,6 +161,7 @@ export class VizPanelManager extends SceneObjectBase<VizPanelManagerState> {
               datasource: {
                 uid: lastUsedDatasource?.datasourceUid,
                 type: dsSettings.type,
+                apiVersion: dsSettings.meta.apiVersion,
               },
             });
           }
@@ -177,6 +178,7 @@ export class VizPanelManager extends SceneObjectBase<VizPanelManagerState> {
           {
             type: dsSettings.type,
             uid: dsSettings.uid,
+            apiVersion: dsSettings.meta.apiVersion,
           } || { default: true }
         );
       }
@@ -195,6 +197,7 @@ export class VizPanelManager extends SceneObjectBase<VizPanelManagerState> {
           datasource: {
             uid: dsSettings.uid,
             type: dsSettings.type,
+            apiVersion: dsSettings.meta.apiVersion,
           },
         });
       }
@@ -298,6 +301,7 @@ export class VizPanelManager extends SceneObjectBase<VizPanelManagerState> {
       datasource: {
         type: newSettings.type,
         uid: newSettings.uid,
+        apiVersion: newSettings.meta.apiVersion,
       },
       queries,
     });

--- a/public/app/features/dashboard-scene/serialization/buildNewDashboardSaveModel.ts
+++ b/public/app/features/dashboard-scene/serialization/buildNewDashboardSaveModel.ts
@@ -14,6 +14,7 @@ export async function buildNewDashboardSaveModel(urlFolderUid?: string): Promise
       const datasourceRef = {
         type: defaultDs.meta.id,
         uid: defaultDs.uid,
+        apiVersion: defaultDs.meta.apiVersion,
       };
 
       const fitlerVariable: VariableModel = {

--- a/public/app/features/dashboard-scene/settings/variables/editors/AdHocFiltersVariableEditor.tsx
+++ b/public/app/features/dashboard-scene/settings/variables/editors/AdHocFiltersVariableEditor.tsx
@@ -29,6 +29,7 @@ export function AdHocFiltersVariableEditor(props: AdHocFiltersVariableEditorProp
     const dsRef: DataSourceRef = {
       uid: ds.uid,
       type: ds.type,
+      apiVersion: ds.meta.apiVersion,
     };
 
     variable.setState({

--- a/public/app/features/dashboard-scene/settings/variables/editors/GroupByVariableEditor.tsx
+++ b/public/app/features/dashboard-scene/settings/variables/editors/GroupByVariableEditor.tsx
@@ -28,6 +28,7 @@ export function GroupByVariableEditor(props: GroupByVariableEditorProps) {
     const dsRef: DataSourceRef = {
       uid: ds.uid,
       type: ds.type,
+      apiVersion: ds.meta.apiVersion,
     };
 
     variable.setState({ datasource: dsRef });

--- a/public/app/features/dashboard-scene/settings/variables/editors/QueryVariableEditor.tsx
+++ b/public/app/features/dashboard-scene/settings/variables/editors/QueryVariableEditor.tsx
@@ -35,7 +35,11 @@ export function QueryVariableEditor({ variable, onRunQuery }: QueryVariableEdito
     variable.setState({ allValue: event.currentTarget.value });
   };
   const onDataSourceChange = (dsInstanceSettings: DataSourceInstanceSettings) => {
-    const datasource: DataSourceRef = { uid: dsInstanceSettings.uid, type: dsInstanceSettings.type };
+    const datasource: DataSourceRef = {
+      uid: dsInstanceSettings.uid,
+      type: dsInstanceSettings.type,
+      apiVersion: dsInstanceSettings.meta.apiVersion,
+    };
 
     if (variable.state.datasource && variable.state.datasource.type !== datasource.type) {
       variable.setState({ datasource, query: '', definition: '' });

--- a/public/app/features/dashboard/components/PanelEditor/PanelEditorQueries.tsx
+++ b/public/app/features/dashboard/components/PanelEditor/PanelEditorQueries.tsx
@@ -42,6 +42,7 @@ export class PanelEditorQueries extends PureComponent<Props> {
         default: datasourceSettings?.isDefault,
         type: datasourceSettings?.type,
         uid: datasourceSettings?.uid,
+        apiVersion: datasourceSettings?.meta.apiVersion,
       },
       queryCachingTTL: datasourceSettings?.cachingConfig?.enabled ? panel.queryCachingTTL : undefined,
       queries: panel.targets,

--- a/public/app/features/dashboard/state/PanelModel.ts
+++ b/public/app/features/dashboard/state/PanelModel.ts
@@ -547,6 +547,7 @@ export class PanelModel implements DataConfigSource, IPanelModel {
     this.datasource = {
       uid: dataSource.uid,
       type: dataSource.type,
+      apiVersion: dataSource.apiVersion,
     };
 
     this.cacheTimeout = options.cacheTimeout;

--- a/public/app/features/plugins/datasource_srv.ts
+++ b/public/app/features/plugins/datasource_srv.ts
@@ -102,7 +102,7 @@ export class DatasourceSrv implements DataSourceService {
         isDefault: false,
         name: nameOrUid,
         uid: nameOrUid,
-        rawRef: { type: dsSettings.type, uid: dsSettings.uid },
+        rawRef: { type: dsSettings.type, uid: dsSettings.uid, apiVersion: dsSettings.meta.apiVersion },
       };
     }
 

--- a/public/app/features/plugins/datasource_srv.ts
+++ b/public/app/features/plugins/datasource_srv.ts
@@ -102,7 +102,7 @@ export class DatasourceSrv implements DataSourceService {
         isDefault: false,
         name: nameOrUid,
         uid: nameOrUid,
-        rawRef: { type: dsSettings.type, uid: dsSettings.uid, apiVersion: dsSettings.meta.apiVersion },
+        rawRef: { type: dsSettings.type, uid: dsSettings.uid, apiVersion: dsSettings.meta?.apiVersion },
       };
     }
 

--- a/public/app/features/plugins/tests/datasource_srv.test.ts
+++ b/public/app/features/plugins/tests/datasource_srv.test.ts
@@ -191,6 +191,7 @@ describe('datasource_srv', () => {
         expect(ds?.uid).toBe('${datasource}');
         expect(ds?.rawRef).toMatchInlineSnapshot(`
           {
+            "apiVersion": undefined,
             "type": "test-db",
             "uid": "uid-code-BBB",
           }
@@ -203,6 +204,7 @@ describe('datasource_srv', () => {
         expect(ds?.uid).toBe('${datasourceByUid}');
         expect(ds?.rawRef).toMatchInlineSnapshot(`
           {
+            "apiVersion": undefined,
             "type": "test-db",
             "uid": "uid-code-DDDD",
           }
@@ -227,6 +229,7 @@ describe('datasource_srv', () => {
         expect(ds?.uid).toBe('${datasourceDefault}');
         expect(ds?.rawRef).toMatchInlineSnapshot(`
           {
+            "apiVersion": undefined,
             "type": "test-db",
             "uid": "uid-code-BBB",
           }

--- a/public/app/features/query/components/QueryEditorRow.tsx
+++ b/public/app/features/query/components/QueryEditorRow.tsx
@@ -363,7 +363,11 @@ export class QueryEditorRow<TQuery extends DataQuery> extends PureComponent<Prop
 
   onClickExample = (query: TQuery) => {
     if (query.datasource === undefined) {
-      query.datasource = { type: this.props.dataSource.type, uid: this.props.dataSource.uid };
+      query.datasource = {
+        type: this.props.dataSource.type,
+        uid: this.props.dataSource.uid,
+        apiVersion: this.props.dataSource.meta.apiVersion,
+      };
     }
 
     this.props.onChange({

--- a/public/app/features/query/components/QueryEditorRows.tsx
+++ b/public/app/features/query/components/QueryEditorRows.tsx
@@ -68,6 +68,7 @@ export class QueryEditorRows extends PureComponent<Props> {
         const dataSourceRef: DataSourceRef = {
           type: dataSource.type,
           uid: dataSource.uid,
+          apiVersion: dataSource.meta.apiVersion,
         };
 
         if (item.datasource) {

--- a/public/app/features/query/components/QueryGroup.tsx
+++ b/public/app/features/query/components/QueryGroup.tsx
@@ -150,7 +150,7 @@ export class QueryGroup extends PureComponent<Props, State> {
         uid: newSettings.uid,
         type: newSettings.meta.id,
         default: newSettings.isDefault,
-        apiVersion: newSettings.meta.apiVersion,
+        apiVersion: newSettings.meta?.apiVersion,
       },
     });
 

--- a/public/app/features/query/components/QueryGroup.tsx
+++ b/public/app/features/query/components/QueryGroup.tsx
@@ -150,6 +150,7 @@ export class QueryGroup extends PureComponent<Props, State> {
         uid: newSettings.uid,
         type: newSettings.meta.id,
         default: newSettings.isDefault,
+        apiVersion: newSettings.meta.apiVersion,
       },
     });
 
@@ -177,7 +178,7 @@ export class QueryGroup extends PureComponent<Props, State> {
 
     return {
       ...this.state.dataSource?.getDefaultQuery?.(CoreApp.PanelEditor),
-      datasource: { uid: ds?.uid, type: ds?.type },
+      datasource: { uid: ds?.uid, type: ds?.type, apiVersion: ds?.meta.apiVersion },
     };
   }
 
@@ -240,7 +241,13 @@ export class QueryGroup extends PureComponent<Props, State> {
 
   onAddQuery = (query: Partial<DataQuery>) => {
     const { dsSettings, queries } = this.state;
-    this.onQueriesChange(addQuery(queries, query, { type: dsSettings?.type, uid: dsSettings?.uid }));
+    this.onQueriesChange(
+      addQuery(queries, query, {
+        type: dsSettings?.type,
+        uid: dsSettings?.uid,
+        apiVersion: dsSettings?.meta.apiVersion,
+      })
+    );
     this.onScrollBottom();
   };
 

--- a/public/app/plugins/datasource/loki/LogContextProvider.ts
+++ b/public/app/plugins/datasource/loki/LogContextProvider.ts
@@ -148,7 +148,7 @@ export class LogContextProvider {
       refId: `${REF_ID_STARTER_LOG_ROW_CONTEXT}_${Math.random().toString()}`,
       maxLines: limit,
       direction: queryDirection,
-      datasource: { uid: this.datasource.uid, type: this.datasource.type },
+      datasource: { uid: this.datasource.uid, type: this.datasource.type, apiVersion: this.datasource.meta.apiVersion },
     };
 
     const fieldCache = new FieldCache(row.dataFrame);

--- a/public/app/plugins/panel/timeseries/migrations.ts
+++ b/public/app/plugins/panel/timeseries/migrations.ts
@@ -422,6 +422,7 @@ export function graphToTimeseriesOptions(angular: any): {
         datasource: {
           type: 'datasource',
           uid: 'grafana',
+          apiVersion: '',
         },
         enable: true,
         hide: true, // don't show the toggle at the top of the dashboard


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

Adds the plugin (and data source) apiVersion to a query `DatasourceRef` and in `DatasourceSettings` so panels and alerts (among other requests), include a reference to the target `apiVersion`.

Query:

![Screenshot from 2024-05-16 13-32-50](https://github.com/grafana/grafana/assets/4025665/c5a15814-eda3-42f3-aa8a-46003c62a294)

Alert:

![Screenshot from 2024-05-16 13-35-20](https://github.com/grafana/grafana/assets/4025665/832fce04-aaec-4812-8246-2125558920dc)

It's still not clear to me if we should add this field elsewhere for example, in the `DataQuery` object. If the `apiVersion` is not in the query, the plugin won't receive this information in the request (`req.PluginContext.DatasourceSettings` is populated with the value in storage, not with the `DatasourceRef` from the query) so it won't work out of the box for example for running query migrations. 

TODO:

 - [ ] Clean up PR
 -  (won't do this in this PR) Add apiVersion when saving a data source

**Why do we need this feature?**

We can add now a validation step that checks that for a given query, the datasource referenced matches in apiVersion with that it's stored.

**Who is this feature for?**


**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle.
- [x] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
