### PR TITLE
Datasources: Enable native histograms for datasource response size metric

### DIFF
--- a/devenv/docker/blocks/self-instrumentation/docker-compose.yaml
+++ b/devenv/docker/blocks/self-instrumentation/docker-compose.yaml
@@ -7,6 +7,7 @@
     command: >
       --enable-feature=remote-write-receiver
       --enable-feature=exemplar-storage
+      --enable-feature=native-histograms
       --config.file=/etc/prometheus/prometheus.yml
       --storage.tsdb.path=/prometheus
     volumes:
@@ -45,7 +46,7 @@
       - --server.http.listen-addr=0.0.0.0:12345
       - /etc/agent/config.river
     volumes:
-      - ./docker/blocks/self-instrumentation/agent.flow:/etc/agent/config.river 
+      - ./docker/blocks/self-instrumentation/agent.flow:/etc/agent/config.river
     ports:
       - "12345:12345"
       - "12347:12347"

--- a/devenv/docker/blocks/self-instrumentation/prometheus.yaml
+++ b/devenv/docker/blocks/self-instrumentation/prometheus.yaml
@@ -4,6 +4,7 @@ global:
 
 scrape_configs:
   - job_name: grafana
+    scrape_classic_histograms: true
     static_configs:
       - targets:
         - host.docker.internal:3000

--- a/pkg/infra/httpclient/httpclientprovider/datasource_metrics_middleware.go
+++ b/pkg/infra/httpclient/httpclientprovider/datasource_metrics_middleware.go
@@ -3,6 +3,7 @@ package httpclientprovider
 import (
 	"net/http"
 	"strconv"
+	"time"
 
 	sdkhttpclient "github.com/grafana/grafana-plugin-sdk-go/backend/httpclient"
 	"github.com/grafana/grafana/pkg/infra/httpclient"
@@ -33,10 +34,13 @@ var (
 
 	datasourceResponseHistogram = promauto.NewHistogramVec(
 		prometheus.HistogramOpts{
-			Namespace: "grafana",
-			Name:      "datasource_response_size_bytes",
-			Help:      "histogram of data source response sizes returned to Grafana",
-			Buckets:   []float64{128, 256, 512, 1024, 2048, 4096, 8192, 16384, 32768, 65536, 131072, 262144, 524288, 1048576},
+			Namespace:                       "grafana",
+			Name:                            "datasource_response_size_bytes",
+			Help:                            "histogram of data source response sizes returned to Grafana",
+			Buckets:                         []float64{128, 256, 512, 1024, 2048, 4096, 8192, 16384, 32768, 65536, 131072, 262144, 524288, 1048576},
+			NativeHistogramBucketFactor:     1.1,
+			NativeHistogramMaxBucketNumber:  100,
+			NativeHistogramMinResetDuration: time.Hour,
 		}, []string{"datasource", "datasource_type", "secure_socks_ds_proxy_enabled"},
 	)
 


### PR DESCRIPTION
**What is this feature?**

Enables native histogram for the `grafana_datasource_response_size_bytes` metric. 

If Prometheus feature flag `native-histograms`
- is not enabled (default) everything will continue to work as today.
- is enabled only the native histogram will be scraped and classic histograms ignored unless [scrape of classic histogram is enabled](https://grafana.com/docs/mimir/latest/send/native-histograms/#scrape-and-send-native-histograms-with-prometheus) in the scrape config then you'll get both the native and the classic ones scraped. 

**Why do we need this feature?**

To be able to gather more valuable information about maximum/average response sizes. The current buckets only tracks up to 1MB and is to limited to understand what distribution goes between 1MB and infinity. 

**Who is this feature for?**

Operators of Grafana.

**Which issue(s) does this PR fix?**:
Ref #35796 

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
