### PR TITLE
Scopes: Improve suggested dashboards listing

### DIFF
--- a/public/app/features/dashboard-scene/scene/ScopesFiltersScene.tsx
+++ b/public/app/features/dashboard-scene/scene/ScopesFiltersScene.tsx
@@ -134,14 +134,14 @@ export class ScopesFiltersScene extends SceneObjectBase<ScopesFiltersSceneState>
   }
 
   public async toggleScope(linkId: string) {
-    let scopes = this.state.scopes;
+    let scopes = [...this.state.scopes];
     const selectedIdx = scopes.findIndex((scope) => scope.metadata.name === linkId);
 
     if (selectedIdx === -1) {
       const scope = await this.server.get(linkId);
 
       if (scope) {
-        scopes = [...scopes, scope];
+        scopes.push(scope);
       }
     } else {
       scopes.splice(selectedIdx, 1);

--- a/public/app/features/dashboard-scene/scene/ScopesScene.tsx
+++ b/public/app/features/dashboard-scene/scene/ScopesScene.tsx
@@ -31,7 +31,10 @@ export class ScopesScene extends SceneObjectBase<ScopesSceneState> {
 
       const filtersValueSubscription = this.state.filters.subscribeToState((newState, prevState) => {
         if (newState.scopes !== prevState.scopes) {
-          this.state.dashboards.fetchDashboards(newState.scopes);
+          if (this.state.isExpanded) {
+            this.state.dashboards.fetchDashboards(newState.scopes);
+          }
+
           sceneGraph.getTimeRange(this.parent!).onRefresh();
         }
       });
@@ -60,7 +63,13 @@ export class ScopesScene extends SceneObjectBase<ScopesSceneState> {
   }
 
   public toggleIsExpanded() {
-    this.setState({ isExpanded: !this.state.isExpanded });
+    const isExpanded = !this.state.isExpanded;
+
+    if (isExpanded) {
+      this.state.dashboards.fetchDashboards(this.getSelectedScopes());
+    }
+
+    this.setState({ isExpanded });
   }
 
   private enterViewMode() {


### PR DESCRIPTION
**What is this feature?**

This PR brings improvements to how and when the dashboards list is loaded.

Besides the improvements, this PR also fixes an issue where unselecting a scope would leave the suggested dashboards list intact.

**Why do we need this feature?**

So, the changes here are needed for various reasons. I'll take each change one by one and explain the rationale behind it.

- only load suggested dashboards list when the scope selector is expanded
   - there is no need to load the dashboards list if we don't present it to the user
   - this will avoid a lot of API unnecessary calls as well as saving a lot of bandwidth
- keep a map of loaded dashboards
   - because a dashboard can be suggested by multiple scopes, we only need to load its details once
   - this won't save a ton of API unnecessary calls but it will save a lot of bandwidth as we were loading the entire dashboard JSON every time
- keep a map of dashboard IDs for each scope
   - because a scope can be toggled off and then on again, we will only load the dashboards for it once
   - this has the potential to avoid unnecessary API calls

**Who is this feature for?**

-

**Which issue(s) does this PR fix?**:

-

**Special notes for your reviewer:**

Also a video to illustrate all the changes:

https://github.com/grafana/grafana/assets/9215315/0ccd955d-f1e1-484d-8757-a0d5d76d846b



Please check that:
- [x] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
