### PR TITLE
Alerting docs: Relocate `Resolved stale alert instances` section

### DIFF
--- a/docs/sources/alerting/alerting-rules/create-grafana-managed-rule.md
+++ b/docs/sources/alerting/alerting-rules/create-grafana-managed-rule.md
@@ -228,12 +228,6 @@ If your evaluation returns an error, you can set the state on your alert rule to
 | Alerting | Sets alert rule state to `Alerting`. The alert rule waits until the time set in the **For** field has finished before firing.                   |
 | Ok       | Sets alert rule state to `Normal`.                                                                                                              |
 
-### Resolve stale alert instances
-
-An alert instance is considered stale if its dimension or series has disappeared from the query results entirely for two evaluation intervals.
-
-Stale alert instances that are in the **Alerting**/**NoData**/**Error** states are automatically marked as **Resolved** and the grafana_state_reason annotation is added to the alert instance with the reason **MissingSeries**.
-
 ### Create alerts from panels
 
 Create alerts from any panel type. This means you can reuse the queries in the panel and create alerts based on them.

--- a/docs/sources/alerting/fundamentals/alert-rule-evaluation/state-and-health.md
+++ b/docs/sources/alerting/fundamentals/alert-rule-evaluation/state-and-health.md
@@ -44,6 +44,12 @@ Alert instances will be routed for [notifications][notifications] when they are 
 
 {{< figure src="/media/docs/alerting/alert-rule-evaluation-overview-statediagram-v2.png" max-width="750px" >}}
 
+### Lifecycle of stale alert instances
+
+An alert instance is considered stale if its dimension or series has disappeared from the query results entirely for two evaluation intervals.
+
+Stale alert instances that are in the **Alerting**, **NoData**, or **Error** states transition to the **Normal** state as **Resolved**, and include the `grafana_state_reason` annotation with the value **MissingSeries**. They are routed for notifications like other resolved alert instances.
+
 ### Keep last state
 
 The "Keep Last State" option helps mitigate temporary data source issues, preventing alerts from unintentionally firing, resolving, and re-firing.


### PR DESCRIPTION
Relates to: https://github.com/grafana/grafana/pull/87951
