### PR TITLE
Unified Storage: create kind_version table migration, add SQL and fix db

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -457,6 +457,8 @@ require (
 	sigs.k8s.io/yaml v1.3.0 // indirect; @grafana-app-platform-squad
 )
 
+require github.com/DATA-DOG/go-sqlmock v1.5.2 // indirect
+
 // Use fork of crewjam/saml with fixes for some issues until changes get merged into upstream
 replace github.com/crewjam/saml => github.com/grafana/saml v0.4.15-0.20231025143828-a6c0e9b86a4c
 

--- a/go.mod
+++ b/go.mod
@@ -224,6 +224,7 @@ require (
 	github.com/Azure/go-autorest/tracing v0.6.0 // indirect
 	github.com/Azure/go-ntlmssp v0.0.0-20220621081337-cb9428e4ac1e // indirect
 	github.com/AzureAD/microsoft-authentication-library-for-go v1.2.1 // indirect
+	github.com/DATA-DOG/go-sqlmock v1.5.2 // indirect; @grafana/grafana-search-and-storage
 	github.com/FZambia/eagle v0.1.0 // indirect
 	github.com/JohnCGriffin/overflow v0.0.0-20211019200055-46fa312c352c // indirect
 	github.com/Masterminds/goutils v1.1.1 // indirect
@@ -456,8 +457,6 @@ require (
 	sigs.k8s.io/json v0.0.0-20221116044647-bc3834ca7abd // indirect
 	sigs.k8s.io/yaml v1.3.0 // indirect; @grafana-app-platform-squad
 )
-
-require github.com/DATA-DOG/go-sqlmock v1.5.2 // indirect
 
 // Use fork of crewjam/saml with fixes for some issues until changes get merged into upstream
 replace github.com/crewjam/saml => github.com/grafana/saml v0.4.15-0.20231025143828-a6c0e9b86a4c

--- a/go.mod
+++ b/go.mod
@@ -224,7 +224,7 @@ require (
 	github.com/Azure/go-autorest/tracing v0.6.0 // indirect
 	github.com/Azure/go-ntlmssp v0.0.0-20220621081337-cb9428e4ac1e // indirect
 	github.com/AzureAD/microsoft-authentication-library-for-go v1.2.1 // indirect
-	github.com/DATA-DOG/go-sqlmock v1.5.2 // indirect; @grafana/grafana-search-and-storage
+	github.com/DATA-DOG/go-sqlmock v1.5.2 // @grafana/grafana-search-and-storage
 	github.com/FZambia/eagle v0.1.0 // indirect
 	github.com/JohnCGriffin/overflow v0.0.0-20211019200055-46fa312c352c // indirect
 	github.com/Masterminds/goutils v1.1.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1284,6 +1284,8 @@ github.com/BurntSushi/toml v1.3.2/go.mod h1:CxXYINrC8qIiEnFrOxCa7Jy5BFHlXnUU2pbi
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
 github.com/Code-Hex/go-generics-cache v1.3.1 h1:i8rLwyhoyhaerr7JpjtYjJZUcCbWOdiYO3fZXLiEC4g=
 github.com/Code-Hex/go-generics-cache v1.3.1/go.mod h1:qxcC9kRVrct9rHeiYpFWSoW1vxyillCVzX13KZG8dl4=
+github.com/DATA-DOG/go-sqlmock v1.5.2 h1:OcvFkGmslmlZibjAjaHm3L//6LiuBgolP7OputlJIzU=
+github.com/DATA-DOG/go-sqlmock v1.5.2/go.mod h1:88MAG/4G7SMwSE3CeA0ZKzrT5CiOU3OJ+JlNzwDqpNU=
 github.com/DataDog/datadog-go v3.2.0+incompatible/go.mod h1:LButxg5PwREeZtORoXG3tL4fMGNddJ+vMq1mwgfaqoQ=
 github.com/FZambia/eagle v0.1.0 h1:9gyX6x+xjoIfglgyPTcYm7dvY7FJ93us1QY5De4CyXA=
 github.com/FZambia/eagle v0.1.0/go.mod h1:YjGSPVkQTNcVLfzEUQJNgW9ScPR0K4u/Ky0yeFa4oDA=
@@ -2459,6 +2461,7 @@ github.com/kelseyhightower/envconfig v1.4.0/go.mod h1:cccZRl6mQpaq41TPp5QxidR+Sa
 github.com/kisielk/errcheck v1.1.0/go.mod h1:EZBBE59ingxPouuu3KfxchcWSUPOHkagtvWXihfKN4Q=
 github.com/kisielk/errcheck v1.5.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI2bnpBCr8=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
+github.com/kisielk/sqlstruct v0.0.0-20201105191214-5f3e10d3ab46/go.mod h1:yyMNCyc/Ib3bDTKd379tNMpB/7/H5TjM2Y9QJ5THLbE=
 github.com/klauspost/asmfmt v1.3.2 h1:4Ri7ox3EwapiOjCki+hw14RyKk201CN4rzyCJRFLpK4=
 github.com/klauspost/asmfmt v1.3.2/go.mod h1:AG8TuvYojzulgDAMCnYn50l/5QV3Bs/tp6j0HLHbNSE=
 github.com/klauspost/compress v1.10.3/go.mod h1:aoV0uJVorq1K+umq18yTdKaF57EivdYsUV+/s2qKfXs=

--- a/pkg/services/store/entity/db/dbimpl/db.go
+++ b/pkg/services/store/entity/db/dbimpl/db.go
@@ -1,0 +1,59 @@
+package dbimpl
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+
+	iface "github.com/grafana/grafana/pkg/services/store/entity/db"
+)
+
+func NewDB(d *sql.DB, driverName string) iface.DB {
+	return sqldb{
+		DB:         d,
+		driverName: driverName,
+	}
+}
+
+type sqldb struct {
+	*sql.DB
+	driverName string
+}
+
+func (d sqldb) DriverName() string {
+	return d.driverName
+}
+
+func (d sqldb) BeginTx(ctx context.Context, opts *sql.TxOptions) (iface.Tx, error) {
+	t, err := d.DB.BeginTx(ctx, opts)
+	if err != nil {
+		return nil, err
+	}
+	return tx{
+		Tx: t,
+	}, nil
+}
+
+func (d sqldb) WithTx(ctx context.Context, opts *sql.TxOptions, f iface.TxFunc) error {
+	t, err := d.BeginTx(ctx, opts)
+	if err != nil {
+		return fmt.Errorf("begin tx: %w", err)
+	}
+
+	if err := f(ctx, t); err != nil {
+		if rollbackErr := t.Rollback(); rollbackErr != nil {
+			return fmt.Errorf("tx err: %w; rollback err: %w", err, rollbackErr)
+		}
+		return fmt.Errorf("tx err: %w", err)
+	}
+
+	if err = t.Commit(); err != nil {
+		return fmt.Errorf("commit err: %w", err)
+	}
+
+	return nil
+}
+
+type tx struct {
+	*sql.Tx
+}

--- a/pkg/services/store/entity/db/dbimpl/db.go
+++ b/pkg/services/store/entity/db/dbimpl/db.go
@@ -5,10 +5,10 @@ import (
 	"database/sql"
 	"fmt"
 
-	iface "github.com/grafana/grafana/pkg/services/store/entity/db"
+	entitydb "github.com/grafana/grafana/pkg/services/store/entity/db"
 )
 
-func NewDB(d *sql.DB, driverName string) iface.DB {
+func NewDB(d *sql.DB, driverName string) entitydb.DB {
 	return sqldb{
 		DB:         d,
 		driverName: driverName,
@@ -24,7 +24,7 @@ func (d sqldb) DriverName() string {
 	return d.driverName
 }
 
-func (d sqldb) BeginTx(ctx context.Context, opts *sql.TxOptions) (iface.Tx, error) {
+func (d sqldb) BeginTx(ctx context.Context, opts *sql.TxOptions) (entitydb.Tx, error) {
 	t, err := d.DB.BeginTx(ctx, opts)
 	if err != nil {
 		return nil, err
@@ -34,7 +34,7 @@ func (d sqldb) BeginTx(ctx context.Context, opts *sql.TxOptions) (iface.Tx, erro
 	}, nil
 }
 
-func (d sqldb) WithTx(ctx context.Context, opts *sql.TxOptions, f iface.TxFunc) error {
+func (d sqldb) WithTx(ctx context.Context, opts *sql.TxOptions, f entitydb.TxFunc) error {
 	t, err := d.BeginTx(ctx, opts)
 	if err != nil {
 		return fmt.Errorf("begin tx: %w", err)

--- a/pkg/services/store/entity/db/dbimpl/dbEngine.go
+++ b/pkg/services/store/entity/db/dbimpl/dbEngine.go
@@ -26,8 +26,6 @@ func getEngineMySQL(cfgSection *setting.DynamicSection, tracer tracing.Tracer) (
 
 	connectionString := connectionStringMySQL(dbUser, dbPass, protocol, dbHost, dbName)
 
-	// TODO: replace xorm.NewEngine with sql.Open once we're able to get rid of
-	// GetSession and GetEngine methods.
 	driverName := sqlstore.WrapDatabaseDriverWithHooks("mysql", tracer)
 	engine, err := xorm.NewEngine(driverName, connectionString)
 	if err != nil {
@@ -57,8 +55,6 @@ func getEnginePostgres(cfgSection *setting.DynamicSection, tracer tracing.Tracer
 
 	connectionString := connectionStringPostgres(dbUser, dbPass, addr.Host, addr.Port, dbName, dbSslMode)
 
-	// TODO: replace xorm.NewEngine with sql.Open once we're able to get rid of
-	// GetSession and GetEngine methods.
 	driverName := sqlstore.WrapDatabaseDriverWithHooks("postgres", tracer)
 	engine, err := xorm.NewEngine(driverName, connectionString)
 	if err != nil {
@@ -66,9 +62,6 @@ func getEnginePostgres(cfgSection *setting.DynamicSection, tracer tracing.Tracer
 	}
 	return engine, nil
 }
-
-// FIXME: connection strings are not properly escaping arguments like `user` or
-// `dbName`.
 
 func connectionStringMySQL(user, password, protocol, host, dbName string) string {
 	return fmt.Sprintf("%s:%s@%s(%s)/%s?collation=utf8mb4_unicode_ci&allowNativePasswords=true&clientFoundRows=true", user, password, protocol, host, dbName)

--- a/pkg/services/store/entity/db/dbimpl/dbEngine.go
+++ b/pkg/services/store/entity/db/dbimpl/dbEngine.go
@@ -26,6 +26,8 @@ func getEngineMySQL(cfgSection *setting.DynamicSection, tracer tracing.Tracer) (
 
 	connectionString := connectionStringMySQL(dbUser, dbPass, protocol, dbHost, dbName)
 
+	// TODO: replace xorm.NewEngine with sql.Open once we're able to get rid of
+	// GetSession and GetEngine methods.
 	driverName := sqlstore.WrapDatabaseDriverWithHooks("mysql", tracer)
 	engine, err := xorm.NewEngine(driverName, connectionString)
 	if err != nil {
@@ -55,6 +57,8 @@ func getEnginePostgres(cfgSection *setting.DynamicSection, tracer tracing.Tracer
 
 	connectionString := connectionStringPostgres(dbUser, dbPass, addr.Host, addr.Port, dbName, dbSslMode)
 
+	// TODO: replace xorm.NewEngine with sql.Open once we're able to get rid of
+	// GetSession and GetEngine methods.
 	driverName := sqlstore.WrapDatabaseDriverWithHooks("postgres", tracer)
 	engine, err := xorm.NewEngine(driverName, connectionString)
 	if err != nil {
@@ -62,6 +66,9 @@ func getEnginePostgres(cfgSection *setting.DynamicSection, tracer tracing.Tracer
 	}
 	return engine, nil
 }
+
+// FIXME: connection strings are not properly escaping arguments like `user` or
+// `dbName`.
 
 func connectionStringMySQL(user, password, protocol, host, dbName string) string {
 	return fmt.Sprintf("%s:%s@%s(%s)/%s?collation=utf8mb4_unicode_ci&allowNativePasswords=true&clientFoundRows=true", user, password, protocol, host, dbName)

--- a/pkg/services/store/entity/db/dbimpl/db_test.go
+++ b/pkg/services/store/entity/db/dbimpl/db_test.go
@@ -2,7 +2,6 @@ package dbimpl
 
 import (
 	"context"
-	"errors"
 	"testing"
 	"time"
 
@@ -30,44 +29,6 @@ func newCtx(t *testing.T) context.Context {
 	return ctx
 }
 
-var errTest = errors.New("because of reasons")
-
-const driverName = "sqlmock"
-
-func TestDB_BeginTx(t *testing.T) {
-	t.Parallel()
-
-	t.Run("happy path", func(t *testing.T) {
-		t.Parallel()
-
-		sqldb, mock, err := sqlmock.New()
-		require.NoError(t, err)
-		db := NewDB(sqldb, driverName)
-		require.Equal(t, driverName, db.DriverName())
-
-		mock.ExpectBegin()
-		tx, err := db.BeginTx(newCtx(t), nil)
-
-		require.NoError(t, err)
-		require.NotNil(t, tx)
-	})
-
-	t.Run("fail begin", func(t *testing.T) {
-		t.Parallel()
-
-		sqldb, mock, err := sqlmock.New()
-		require.NoError(t, err)
-		db := NewDB(sqldb, "sqlmock")
-
-		mock.ExpectBegin().WillReturnError(errTest)
-		tx, err := db.BeginTx(newCtx(t), nil)
-
-		require.Nil(t, tx)
-		require.Error(t, err)
-		require.ErrorIs(t, err, errTest)
-	})
-}
-
 func TestDB_WithTx(t *testing.T) {
 	t.Parallel()
 
@@ -89,66 +50,5 @@ func TestDB_WithTx(t *testing.T) {
 		err = db.WithTx(newCtx(t), nil, newTxFunc(nil))
 
 		require.NoError(t, err)
-	})
-
-	t.Run("fail begin", func(t *testing.T) {
-		t.Parallel()
-
-		sqldb, mock, err := sqlmock.New()
-		require.NoError(t, err)
-		db := NewDB(sqldb, "sqlmock")
-
-		mock.ExpectBegin().WillReturnError(errTest)
-		err = db.WithTx(newCtx(t), nil, newTxFunc(nil))
-
-		require.Error(t, err)
-		require.ErrorIs(t, err, errTest)
-	})
-
-	t.Run("fail tx", func(t *testing.T) {
-		t.Parallel()
-
-		sqldb, mock, err := sqlmock.New()
-		require.NoError(t, err)
-		db := NewDB(sqldb, "sqlmock")
-
-		mock.ExpectBegin()
-		mock.ExpectRollback()
-		err = db.WithTx(newCtx(t), nil, newTxFunc(errTest))
-
-		require.Error(t, err)
-		require.ErrorIs(t, err, errTest)
-	})
-
-	t.Run("fail tx; fail rollback", func(t *testing.T) {
-		t.Parallel()
-
-		sqldb, mock, err := sqlmock.New()
-		require.NoError(t, err)
-		db := NewDB(sqldb, "sqlmock")
-		errTest2 := errors.New("yet another err")
-
-		mock.ExpectBegin()
-		mock.ExpectRollback().WillReturnError(errTest)
-		err = db.WithTx(newCtx(t), nil, newTxFunc(errTest2))
-
-		require.Error(t, err)
-		require.ErrorIs(t, err, errTest)
-		require.ErrorIs(t, err, errTest2)
-	})
-
-	t.Run("fail commit", func(t *testing.T) {
-		t.Parallel()
-
-		sqldb, mock, err := sqlmock.New()
-		require.NoError(t, err)
-		db := NewDB(sqldb, "sqlmock")
-
-		mock.ExpectBegin()
-		mock.ExpectCommit().WillReturnError(errTest)
-		err = db.WithTx(newCtx(t), nil, newTxFunc(nil))
-
-		require.Error(t, err)
-		require.ErrorIs(t, err, errTest)
 	})
 }

--- a/pkg/services/store/entity/db/dbimpl/db_test.go
+++ b/pkg/services/store/entity/db/dbimpl/db_test.go
@@ -1,0 +1,147 @@
+package dbimpl
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	sqlmock "github.com/DATA-DOG/go-sqlmock"
+	"github.com/stretchr/testify/require"
+
+	iface "github.com/grafana/grafana/pkg/services/store/entity/db"
+)
+
+func newCtx(t *testing.T) context.Context {
+	t.Helper()
+
+	d, ok := t.Deadline()
+	if !ok {
+		// provide a default timeout for tests
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		t.Cleanup(cancel)
+
+		return ctx
+	}
+
+	ctx, cancel := context.WithDeadline(context.Background(), d)
+	t.Cleanup(cancel)
+
+	return ctx
+}
+
+var errTest = errors.New("because of reasons")
+
+const driverName = "sqlmock"
+
+func TestDB_BeginTx(t *testing.T) {
+	t.Parallel()
+
+	t.Run("happy path", func(t *testing.T) {
+		t.Parallel()
+
+		sqldb, mock, err := sqlmock.New()
+		db := NewDB(sqldb, driverName)
+		require.Equal(t, driverName, db.DriverName())
+
+		mock.ExpectBegin()
+		tx, err := db.BeginTx(newCtx(t), nil)
+
+		require.NoError(t, err)
+		require.NotNil(t, tx)
+	})
+
+	t.Run("fail begin", func(t *testing.T) {
+		t.Parallel()
+
+		sqldb, mock, err := sqlmock.New()
+		db := NewDB(sqldb, "sqlmock")
+
+		mock.ExpectBegin().WillReturnError(errTest)
+		tx, err := db.BeginTx(newCtx(t), nil)
+
+		require.Nil(t, tx)
+		require.Error(t, err)
+		require.ErrorIs(t, err, errTest)
+	})
+}
+
+func TestDB_WithTx(t *testing.T) {
+	t.Parallel()
+
+	newTxFunc := func(err error) iface.TxFunc {
+		return func(context.Context, iface.Tx) error {
+			return err
+		}
+	}
+
+	t.Run("happy path", func(t *testing.T) {
+		t.Parallel()
+
+		sqldb, mock, err := sqlmock.New()
+		db := NewDB(sqldb, "sqlmock")
+
+		mock.ExpectBegin()
+		mock.ExpectCommit()
+		err = db.WithTx(newCtx(t), nil, newTxFunc(nil))
+
+		require.NoError(t, err)
+	})
+
+	t.Run("fail begin", func(t *testing.T) {
+		t.Parallel()
+
+		sqldb, mock, err := sqlmock.New()
+		db := NewDB(sqldb, "sqlmock")
+
+		mock.ExpectBegin().WillReturnError(errTest)
+		err = db.WithTx(newCtx(t), nil, newTxFunc(nil))
+
+		require.Error(t, err)
+		require.ErrorIs(t, err, errTest)
+	})
+
+	t.Run("fail tx", func(t *testing.T) {
+		t.Parallel()
+
+		sqldb, mock, err := sqlmock.New()
+		db := NewDB(sqldb, "sqlmock")
+
+		mock.ExpectBegin()
+		mock.ExpectRollback()
+		err = db.WithTx(newCtx(t), nil, newTxFunc(errTest))
+
+		require.Error(t, err)
+		require.ErrorIs(t, err, errTest)
+	})
+
+	t.Run("fail tx; fail rollback", func(t *testing.T) {
+		t.Parallel()
+
+		sqldb, mock, err := sqlmock.New()
+		db := NewDB(sqldb, "sqlmock")
+		errTest2 := errors.New("yet another err")
+
+		mock.ExpectBegin()
+		mock.ExpectRollback().WillReturnError(errTest)
+		err = db.WithTx(newCtx(t), nil, newTxFunc(errTest2))
+
+		require.Error(t, err)
+		require.ErrorIs(t, err, errTest)
+		require.ErrorIs(t, err, errTest2)
+	})
+
+	t.Run("fail commit", func(t *testing.T) {
+		t.Parallel()
+
+		sqldb, mock, err := sqlmock.New()
+		db := NewDB(sqldb, "sqlmock")
+
+		mock.ExpectBegin()
+		mock.ExpectCommit().WillReturnError(errTest)
+		err = db.WithTx(newCtx(t), nil, newTxFunc(nil))
+
+		require.Error(t, err)
+		require.ErrorIs(t, err, errTest)
+	})
+}

--- a/pkg/services/store/entity/db/dbimpl/db_test.go
+++ b/pkg/services/store/entity/db/dbimpl/db_test.go
@@ -9,7 +9,7 @@ import (
 	sqlmock "github.com/DATA-DOG/go-sqlmock"
 	"github.com/stretchr/testify/require"
 
-	iface "github.com/grafana/grafana/pkg/services/store/entity/db"
+	entitydb "github.com/grafana/grafana/pkg/services/store/entity/db"
 )
 
 func newCtx(t *testing.T) context.Context {
@@ -71,8 +71,8 @@ func TestDB_BeginTx(t *testing.T) {
 func TestDB_WithTx(t *testing.T) {
 	t.Parallel()
 
-	newTxFunc := func(err error) iface.TxFunc {
-		return func(context.Context, iface.Tx) error {
+	newTxFunc := func(err error) entitydb.TxFunc {
+		return func(context.Context, entitydb.Tx) error {
 			return err
 		}
 	}

--- a/pkg/services/store/entity/db/dbimpl/db_test.go
+++ b/pkg/services/store/entity/db/dbimpl/db_test.go
@@ -41,6 +41,7 @@ func TestDB_BeginTx(t *testing.T) {
 		t.Parallel()
 
 		sqldb, mock, err := sqlmock.New()
+		require.NoError(t, err)
 		db := NewDB(sqldb, driverName)
 		require.Equal(t, driverName, db.DriverName())
 
@@ -55,6 +56,7 @@ func TestDB_BeginTx(t *testing.T) {
 		t.Parallel()
 
 		sqldb, mock, err := sqlmock.New()
+		require.NoError(t, err)
 		db := NewDB(sqldb, "sqlmock")
 
 		mock.ExpectBegin().WillReturnError(errTest)
@@ -79,6 +81,7 @@ func TestDB_WithTx(t *testing.T) {
 		t.Parallel()
 
 		sqldb, mock, err := sqlmock.New()
+		require.NoError(t, err)
 		db := NewDB(sqldb, "sqlmock")
 
 		mock.ExpectBegin()
@@ -92,6 +95,7 @@ func TestDB_WithTx(t *testing.T) {
 		t.Parallel()
 
 		sqldb, mock, err := sqlmock.New()
+		require.NoError(t, err)
 		db := NewDB(sqldb, "sqlmock")
 
 		mock.ExpectBegin().WillReturnError(errTest)
@@ -105,6 +109,7 @@ func TestDB_WithTx(t *testing.T) {
 		t.Parallel()
 
 		sqldb, mock, err := sqlmock.New()
+		require.NoError(t, err)
 		db := NewDB(sqldb, "sqlmock")
 
 		mock.ExpectBegin()
@@ -119,6 +124,7 @@ func TestDB_WithTx(t *testing.T) {
 		t.Parallel()
 
 		sqldb, mock, err := sqlmock.New()
+		require.NoError(t, err)
 		db := NewDB(sqldb, "sqlmock")
 		errTest2 := errors.New("yet another err")
 
@@ -135,6 +141,7 @@ func TestDB_WithTx(t *testing.T) {
 		t.Parallel()
 
 		sqldb, mock, err := sqlmock.New()
+		require.NoError(t, err)
 		db := NewDB(sqldb, "sqlmock")
 
 		mock.ExpectBegin()

--- a/pkg/services/store/entity/db/dbimpl/dbimpl.go
+++ b/pkg/services/store/entity/db/dbimpl/dbimpl.go
@@ -14,7 +14,6 @@ import (
 	"github.com/grafana/grafana/pkg/services/featuremgmt"
 	"github.com/grafana/grafana/pkg/services/sqlstore/session"
 	entitydb "github.com/grafana/grafana/pkg/services/store/entity/db"
-	iface "github.com/grafana/grafana/pkg/services/store/entity/db"
 	"github.com/grafana/grafana/pkg/services/store/entity/db/migrations"
 	"github.com/grafana/grafana/pkg/setting"
 )
@@ -131,7 +130,7 @@ func (db *EntityDB) GetCfg() *setting.Cfg {
 	return db.cfg
 }
 
-func (db *EntityDB) GetDB() (iface.DB, error) {
+func (db *EntityDB) GetDB() (entitydb.DB, error) {
 	engine, err := db.GetEngine()
 	if err != nil {
 		return nil, err

--- a/pkg/services/store/entity/db/dbimpl/dbimpl.go
+++ b/pkg/services/store/entity/db/dbimpl/dbimpl.go
@@ -47,7 +47,7 @@ func (db *EntityDB) Init() error {
 
 func (db *EntityDB) GetEngine() (*xorm.Engine, error) {
 	if db.engine != nil {
-		return engine, nil
+		return db.engine, nil
 	}
 
 	var engine *xorm.Engine

--- a/pkg/services/store/entity/db/dbimpl/dbimpl.go
+++ b/pkg/services/store/entity/db/dbimpl/dbimpl.go
@@ -2,19 +2,22 @@ package dbimpl
 
 import (
 	"fmt"
+	"sync"
 
 	"github.com/dlmiddlecote/sqlstats"
+	"github.com/jmoiron/sqlx"
+	"github.com/prometheus/client_golang/prometheus"
+	"xorm.io/xorm"
+
 	"github.com/grafana/grafana/pkg/infra/db"
 	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/infra/tracing"
 	"github.com/grafana/grafana/pkg/services/featuremgmt"
 	"github.com/grafana/grafana/pkg/services/sqlstore/session"
 	entitydb "github.com/grafana/grafana/pkg/services/store/entity/db"
+	iface "github.com/grafana/grafana/pkg/services/store/entity/db"
 	"github.com/grafana/grafana/pkg/services/store/entity/db/migrations"
 	"github.com/grafana/grafana/pkg/setting"
-	"github.com/jmoiron/sqlx"
-	"github.com/prometheus/client_golang/prometheus"
-	"xorm.io/xorm"
 )
 
 var _ entitydb.EntityDBInterface = (*EntityDB)(nil)
@@ -30,6 +33,8 @@ func ProvideEntityDB(db db.DB, cfg *setting.Cfg, features featuremgmt.FeatureTog
 }
 
 type EntityDB struct {
+	mu sync.RWMutex
+
 	db       db.DB
 	features featuremgmt.FeatureToggles
 	engine   *xorm.Engine
@@ -44,11 +49,16 @@ func (db *EntityDB) Init() error {
 }
 
 func (db *EntityDB) GetEngine() (*xorm.Engine, error) {
-	if db.engine != nil {
-		return db.engine, nil
-	}
+	db.mu.RLock()
+	engine := db.engine
+	db.mu.RUnlock()
 
-	var engine *xorm.Engine
+	if engine != nil {
+		return engine, nil
+	}
+	db.mu.Lock()
+	defer db.mu.Unlock()
+
 	var err error
 
 	cfgSection := db.cfg.SectionWithEnvOverrides("entity_api")
@@ -127,4 +137,15 @@ func (db *EntityDB) GetSession() (*session.SessionDB, error) {
 
 func (db *EntityDB) GetCfg() *setting.Cfg {
 	return db.cfg
+}
+
+func (db *EntityDB) GetDB() (iface.DB, error) {
+	engine, err := db.GetEngine()
+	if err != nil {
+		return nil, err
+	}
+
+	ret := NewDB(engine.DB().DB, engine.Dialect().DriverName())
+
+	return ret, nil
 }

--- a/pkg/services/store/entity/db/dbimpl/dbimpl.go
+++ b/pkg/services/store/entity/db/dbimpl/dbimpl.go
@@ -56,8 +56,13 @@ func (db *EntityDB) GetEngine() (*xorm.Engine, error) {
 	if engine != nil {
 		return engine, nil
 	}
+
 	db.mu.Lock()
 	defer db.mu.Unlock()
+
+	if db.engine != nil {
+		return db.engine, nil
+	}
 
 	var err error
 

--- a/pkg/services/store/entity/db/migrations/entity_store_mig.go
+++ b/pkg/services/store/entity/db/migrations/entity_store_mig.go
@@ -187,6 +187,21 @@ func initEntityTables(mg *migrator.Migrator) string {
 		},
 	})
 
+	tables = append(tables, migrator.Table{
+		Name: "kind_version",
+		Columns: []*migrator.Column{
+			{Name: "group", Type: migrator.DB_NVarchar, Length: 190, Nullable: false},
+			{Name: "group_version", Type: migrator.DB_NVarchar, Length: 190, Nullable: false},
+			{Name: "resource", Type: migrator.DB_NVarchar, Length: 190, Nullable: false},
+			{Name: "resource_version", Type: migrator.DB_BigInt, Nullable: false},
+		},
+		Indices: []*migrator.Index{
+			{Cols: []string{"guid"}, Type: migrator.IndexType},
+			{Cols: []string{"namespace", "group", "resource", "name"}, Type: migrator.IndexType},
+			{Cols: []string{"resolved_to"}, Type: migrator.IndexType},
+		},
+	})
+
 	// Initialize all tables
 	for t := range tables {
 		mg.AddMigration("drop table "+tables[t].Name, migrator.NewDropTableMigration(tables[t].Name))

--- a/pkg/services/store/entity/db/migrations/entity_store_mig.go
+++ b/pkg/services/store/entity/db/migrations/entity_store_mig.go
@@ -196,9 +196,7 @@ func initEntityTables(mg *migrator.Migrator) string {
 			{Name: "resource_version", Type: migrator.DB_BigInt, Nullable: false},
 		},
 		Indices: []*migrator.Index{
-			{Cols: []string{"guid"}, Type: migrator.IndexType},
-			{Cols: []string{"namespace", "group", "resource", "name"}, Type: migrator.IndexType},
-			{Cols: []string{"resolved_to"}, Type: migrator.IndexType},
+			{Cols: []string{"group", "group_version", "resource"}, Type: migrator.UniqueIndex},
 		},
 	})
 

--- a/pkg/services/store/entity/db/migrations/entity_store_mig.go
+++ b/pkg/services/store/entity/db/migrations/entity_store_mig.go
@@ -193,6 +193,8 @@ func initEntityTables(mg *migrator.Migrator) string {
 			{Name: "group", Type: migrator.DB_NVarchar, Length: 190, Nullable: false},
 			{Name: "resource", Type: migrator.DB_NVarchar, Length: 190, Nullable: false},
 			{Name: "resource_version", Type: migrator.DB_BigInt, Nullable: false},
+			{Name: "created_at", Type: migrator.DB_BigInt, Nullable: false},
+			{Name: "updated_at", Type: migrator.DB_BigInt, Nullable: false},
 		},
 		Indices: []*migrator.Index{
 			{Cols: []string{"group", "resource"}, Type: migrator.UniqueIndex},

--- a/pkg/services/store/entity/db/migrations/entity_store_mig.go
+++ b/pkg/services/store/entity/db/migrations/entity_store_mig.go
@@ -191,12 +191,11 @@ func initEntityTables(mg *migrator.Migrator) string {
 		Name: "kind_version",
 		Columns: []*migrator.Column{
 			{Name: "group", Type: migrator.DB_NVarchar, Length: 190, Nullable: false},
-			{Name: "group_version", Type: migrator.DB_NVarchar, Length: 190, Nullable: false},
 			{Name: "resource", Type: migrator.DB_NVarchar, Length: 190, Nullable: false},
 			{Name: "resource_version", Type: migrator.DB_BigInt, Nullable: false},
 		},
 		Indices: []*migrator.Index{
-			{Cols: []string{"group", "group_version", "resource"}, Type: migrator.UniqueIndex},
+			{Cols: []string{"group", "resource"}, Type: migrator.UniqueIndex},
 		},
 	})
 

--- a/pkg/services/store/entity/db/service.go
+++ b/pkg/services/store/entity/db/service.go
@@ -1,16 +1,73 @@
 package db
 
 import (
+	"context"
+	"database/sql"
+
 	"xorm.io/xorm"
 
-	// "github.com/grafana/grafana/pkg/services/sqlstore"
 	"github.com/grafana/grafana/pkg/services/sqlstore/session"
 	"github.com/grafana/grafana/pkg/setting"
 )
 
+const (
+	DriverPostgres = "postgres"
+	DriverMySQL    = "mysql"
+	DriverSQLite3  = "sqlite3"
+)
+
+// EntityDBInterface provides access to a database capable of supporting the
+// Entity Server.
 type EntityDBInterface interface {
 	Init() error
+	GetCfg() *setting.Cfg
+	GetDB() (DB, error)
+
+	// TODO: deprecate.
 	GetSession() (*session.SessionDB, error)
 	GetEngine() (*xorm.Engine, error)
-	GetCfg() *setting.Cfg
+}
+
+// DB is a thin abstraction on *sql.DB to allow mocking to provide better unit
+// testing. We purposefully hide database operation methods that would use
+// context.Background().
+type DB interface {
+	ContextExecer
+	BeginTx(context.Context, *sql.TxOptions) (Tx, error)
+	WithTx(context.Context, *sql.TxOptions, TxFunc) error
+	PingContext(context.Context) error
+	Stats() sql.DBStats
+	DriverName() string
+}
+
+// TxFunc is a function that executes with access to a transaction. The context
+// it receives is the same context used to create the transaction, and is
+// provided so that a general prupose TxFunc is able to retrieve information
+// from that context, and derive other contexts that may be used to run database
+// operation methods accepting a context. A derived context can be used to
+// request a specific database operation to take no more than a specific
+// fraction of the remaining timeout of the transaction context, or to enrich
+// the downstream observability layer with relevant information regarding the
+// specific operation being carried out.
+type TxFunc = func(context.Context, Tx) error
+
+// Tx is a thin abstraction on *sql.Tx to allow mocking to provide better unit
+// testing. We allow database operation methods that do not take a
+// context.Context here since a Tx can only be obtained with DB.BeginTx, which
+// already takes a context.Context.
+type Tx interface {
+	ContextExecer
+	Exec(query string, args ...any) (sql.Result, error)
+	Query(query string, args ...any) (*sql.Rows, error)
+	QueryRow(query string, args ...any) *sql.Row
+	Commit() error
+	Rollback() error
+}
+
+// ContextExecer is a set of database operation methods that take
+// context.Context.
+type ContextExecer interface {
+	ExecContext(ctx context.Context, query string, args ...any) (sql.Result, error)
+	QueryContext(ctx context.Context, query string, args ...any) (*sql.Rows, error)
+	QueryRowContext(ctx context.Context, query string, args ...any) *sql.Row
 }

--- a/pkg/services/store/entity/db/service.go
+++ b/pkg/services/store/entity/db/service.go
@@ -40,21 +40,8 @@ type DB interface {
 	DriverName() string
 }
 
-// TxFunc is a function that executes with access to a transaction. The context
-// it receives is the same context used to create the transaction, and is
-// provided so that a general prupose TxFunc is able to retrieve information
-// from that context, and derive other contexts that may be used to run database
-// operation methods accepting a context. A derived context can be used to
-// request a specific database operation to take no more than a specific
-// fraction of the remaining timeout of the transaction context, or to enrich
-// the downstream observability layer with relevant information regarding the
-// specific operation being carried out.
 type TxFunc = func(context.Context, Tx) error
 
-// Tx is a thin abstraction on *sql.Tx to allow mocking to provide better unit
-// testing. We allow database operation methods that do not take a
-// context.Context here since a Tx can only be obtained with DB.BeginTx, which
-// already takes a context.Context.
 type Tx interface {
 	ContextExecer
 	Exec(query string, args ...any) (sql.Result, error)
@@ -64,8 +51,6 @@ type Tx interface {
 	Rollback() error
 }
 
-// ContextExecer is a set of database operation methods that take
-// context.Context.
 type ContextExecer interface {
 	ExecContext(ctx context.Context, query string, args ...any) (sql.Result, error)
 	QueryContext(ctx context.Context, query string, args ...any) (*sql.Rows, error)

--- a/pkg/services/store/entity/sqlstash/data/entity_delete.sql
+++ b/pkg/services/store/entity/sqlstash/data/entity_delete.sql
@@ -1,0 +1,7 @@
+DELETE FROM {{ .Ident "entity" }}
+    WHERE 1 = 1
+      AND {{ .Ident "namespace" }} = {{ .Arg .Key.Namespace }}
+      AND {{ .Ident "group" }}     = {{ .Arg .Key.Group }}
+      AND {{ .Ident "resource" }}  = {{ .Arg .Key.Resource }}
+      AND {{ .Ident "name" }}      = {{ .Arg .Key.Name }}
+;

--- a/pkg/services/store/entity/sqlstash/data/entity_delete.sql
+++ b/pkg/services/store/entity/sqlstash/data/entity_delete.sql
@@ -1,7 +1,7 @@
 DELETE FROM {{ .Ident "entity" }}
     WHERE 1 = 1
-      AND {{ .Ident "namespace" }} = {{ .Arg .Key.Namespace }}
-      AND {{ .Ident "group" }}     = {{ .Arg .Key.Group }}
-      AND {{ .Ident "resource" }}  = {{ .Arg .Key.Resource }}
-      AND {{ .Ident "name" }}      = {{ .Arg .Key.Name }}
+        AND {{ .Ident "namespace" }} = {{ .Arg .Key.Namespace }}
+        AND {{ .Ident "group" }}     = {{ .Arg .Key.Group }}
+        AND {{ .Ident "resource" }}  = {{ .Arg .Key.Resource }}
+        AND {{ .Ident "name" }}      = {{ .Arg .Key.Name }}
 ;

--- a/pkg/services/store/entity/sqlstash/data/entity_folder_insert.sql
+++ b/pkg/services/store/entity/sqlstash/data/entity_folder_insert.sql
@@ -1,0 +1,35 @@
+INSERT INTO {{ .Ident "entity_folder" }}
+  (
+    {{ .Ident "guid" }},
+    {{ .Ident "namespace" }},
+    {{ .Ident "name" }},
+    {{ .Ident "slug_path" }},
+    {{ .Ident "tree" }},
+    {{ .Ident "depth" }},
+    {{ .Ident "lft" }},
+    {{ .Ident "rgt" }},
+    {{ .Ident "detached" }}
+  )
+
+  VALUES (
+    {{ $addComma := false }}
+    {{ range .Items }}
+      {{ if $addComma }}
+        ,
+      {{ end }}
+      {{ $addComma = true }}
+
+      (
+        {{ .Arg .GUID }},
+        {{ .Arg .Namespace }},
+        {{ .Arg .UID }},
+        {{ .Arg .SlugPath }},
+        {{ .Arg .JS }},
+        {{ .Arg .Depth }},
+        {{ .Arg .Left }},
+        {{ .Arg .Right }},
+        {{ .Arg .Detached }}
+      )
+    {{ end }}
+  )
+;

--- a/pkg/services/store/entity/sqlstash/data/entity_folder_insert.sql
+++ b/pkg/services/store/entity/sqlstash/data/entity_folder_insert.sql
@@ -11,7 +11,8 @@ INSERT INTO {{ .Ident "entity_folder" }}
     {{ .Ident "detached" }}
   )
 
-  VALUES (
+  VALUES
+    {{ $this := . }}
     {{ $addComma := false }}
     {{ range .Items }}
       {{ if $addComma }}
@@ -20,16 +21,15 @@ INSERT INTO {{ .Ident "entity_folder" }}
       {{ $addComma = true }}
 
       (
-        {{ .Arg .GUID }},
-        {{ .Arg .Namespace }},
-        {{ .Arg .UID }},
-        {{ .Arg .SlugPath }},
-        {{ .Arg .JS }},
-        {{ .Arg .Depth }},
-        {{ .Arg .Left }},
-        {{ .Arg .Right }},
-        {{ .Arg .Detached }}
+        {{ $this.Arg .GUID }},
+        {{ $this.Arg .Namespace }},
+        {{ $this.Arg .UID }},
+        {{ $this.Arg .SlugPath }},
+        {{ $this.Arg .JS }},
+        {{ $this.Arg .Depth }},
+        {{ $this.Arg .Left }},
+        {{ $this.Arg .Right }},
+        {{ $this.Arg .Detached }}
       )
     {{ end }}
-  )
 ;

--- a/pkg/services/store/entity/sqlstash/data/entity_folder_insert.sql
+++ b/pkg/services/store/entity/sqlstash/data/entity_folder_insert.sql
@@ -1,35 +1,35 @@
 INSERT INTO {{ .Ident "entity_folder" }}
-  (
-    {{ .Ident "guid" }},
-    {{ .Ident "namespace" }},
-    {{ .Ident "name" }},
-    {{ .Ident "slug_path" }},
-    {{ .Ident "tree" }},
-    {{ .Ident "depth" }},
-    {{ .Ident "lft" }},
-    {{ .Ident "rgt" }},
-    {{ .Ident "detached" }}
-  )
+    (
+        {{ .Ident "guid" }},
+        {{ .Ident "namespace" }},
+        {{ .Ident "name" }},
+        {{ .Ident "slug_path" }},
+        {{ .Ident "tree" }},
+        {{ .Ident "depth" }},
+        {{ .Ident "lft" }},
+        {{ .Ident "rgt" }},
+        {{ .Ident "detached" }}
+    )
 
-  VALUES
-    {{ $this := . }}
-    {{ $addComma := false }}
-    {{ range .Items }}
-      {{ if $addComma }}
-        ,
-      {{ end }}
-      {{ $addComma = true }}
+    VALUES
+        {{ $this := . }}
+        {{ $addComma := false }}
+        {{ range .Items }}
+            {{ if $addComma }}
+                ,
+            {{ end }}
+            {{ $addComma = true }}
 
-      (
-        {{ $this.Arg .GUID }},
-        {{ $this.Arg .Namespace }},
-        {{ $this.Arg .UID }},
-        {{ $this.Arg .SlugPath }},
-        {{ $this.Arg .JS }},
-        {{ $this.Arg .Depth }},
-        {{ $this.Arg .Left }},
-        {{ $this.Arg .Right }},
-        {{ $this.Arg .Detached }}
-      )
-    {{ end }}
+            (
+                {{ $this.Arg .GUID }},
+                {{ $this.Arg .Namespace }},
+                {{ $this.Arg .UID }},
+                {{ $this.Arg .SlugPath }},
+                {{ $this.Arg .JS }},
+                {{ $this.Arg .Depth }},
+                {{ $this.Arg .Left }},
+                {{ $this.Arg .Right }},
+                {{ $this.Arg .Detached }}
+            )
+        {{ end }}
 ;

--- a/pkg/services/store/entity/sqlstash/data/entity_insert.sql
+++ b/pkg/services/store/entity/sqlstash/data/entity_insert.sql
@@ -1,0 +1,93 @@
+INSERT INTO
+
+  {{/* Determine which table to insert into */}}
+  {{ if .TableEntity }} {{ .Ident "entity" }}
+  {{ else }}            {{ .Ident "entity_history" }}
+  {{ end }}
+
+  {{/* Explicitly specify fields that will be set */}}
+  (
+    {{ .Ident "guid" }},
+    {{ .Ident "resource_version" }},
+
+    {{ .Ident "key" }},
+
+    {{ .Ident "group" }},
+    {{ .Ident "group_version" }},
+    {{ .Ident "resource" }},
+    {{ .Ident "namespace" }},
+    {{ .Ident "name" }},
+
+    {{ .Ident "folder" }},
+
+    {{ .Ident "meta" }},
+    {{ .Ident "body" }},
+    {{ .Ident "status" }},
+
+    {{ .Ident "size" }},
+    {{ .Ident "etag" }},
+
+    {{ .Ident "created_at" }},
+    {{ .Ident "created_by" }},
+    {{ .Ident "updated_at" }},
+    {{ .Ident "updated_by" }},
+
+    {{ .Ident "origin" }},
+    {{ .Ident "origin_key" }},
+    {{ .Ident "origin_ts" }},
+
+    {{ .Ident "title" }},
+    {{ .Ident "slug" }},
+    {{ .Ident "description" }},
+
+    {{ .Ident "message" }},
+    {{ .Ident "labels" }},
+    {{ .Ident "fields" }},
+    {{ .Ident "errors" }},
+
+    {{ .Ident "action" }}
+  )
+
+  {{/* Provide the values */}}
+  VALUES (
+    {{ .Arg .Entity.Guid }},
+    {{ .Arg .Entity.ResourceVersion }},
+
+    {{ .Arg .Entity.Key }},
+
+    {{ .Arg .Entity.Group }},
+    {{ .Arg .Entity.GroupVersion }},
+    {{ .Arg .Entity.Resource }},
+    {{ .Arg .Entity.Namespace }},
+    {{ .Arg .Entity.Name }},
+
+    {{ .Arg .Entity.Folder }},
+
+    {{ .Arg .Entity.Meta }},
+    {{ .Arg .Entity.Body }},
+    {{ .Arg .Entity.Status }},
+
+    {{ .Arg .Entity.Size }},
+    {{ .Arg .Entity.ETag }},
+
+    {{ .Arg .Entity.CreatedAt }},
+    {{ .Arg .Entity.CreatedBy }},
+    {{ .Arg .Entity.UpdatedAt }},
+    {{ .Arg .Entity.UpdatedBy }},
+
+    {{ .Arg .Entity.Origin.Source }},
+    {{ .Arg .Entity.Origin.Key }},
+    {{ .Arg .Entity.Origin.Time }},
+
+    {{ .Arg .Entity.Title }},
+    {{ .Arg .Entity.Slug }},
+    {{ .Arg .Entity.Description }},
+
+    {{ .Arg .Entity.Message }},
+    {{ .Arg .Entity.Labels }},
+    {{ .Arg .Entity.Fields }},
+    {{ .Arg .Entity.Errors }},
+
+    {{ .Arg .Entity.Action }}
+  )
+;

--- a/pkg/services/store/entity/sqlstash/data/entity_insert.sql
+++ b/pkg/services/store/entity/sqlstash/data/entity_insert.sql
@@ -1,93 +1,93 @@
 INSERT INTO
 
-  {{/* Determine which table to insert into */}}
-  {{ if .TableEntity }} {{ .Ident "entity" }}
-  {{ else }}            {{ .Ident "entity_history" }}
-  {{ end }}
+    {{/* Determine which table to insert into */}}
+    {{ if .TableEntity }} {{ .Ident "entity" }}
+    {{ else }}            {{ .Ident "entity_history" }}
+    {{ end }}
 
-  {{/* Explicitly specify fields that will be set */}}
-  (
-    {{ .Ident "guid" }},
-    {{ .Ident "resource_version" }},
+    {{/* Explicitly specify fields that will be set */}}
+    (
+        {{ .Ident "guid" }},
+        {{ .Ident "resource_version" }},
 
-    {{ .Ident "key" }},
+        {{ .Ident "key" }},
 
-    {{ .Ident "group" }},
-    {{ .Ident "group_version" }},
-    {{ .Ident "resource" }},
-    {{ .Ident "namespace" }},
-    {{ .Ident "name" }},
+        {{ .Ident "group" }},
+        {{ .Ident "group_version" }},
+        {{ .Ident "resource" }},
+        {{ .Ident "namespace" }},
+        {{ .Ident "name" }},
 
-    {{ .Ident "folder" }},
+        {{ .Ident "folder" }},
 
-    {{ .Ident "meta" }},
-    {{ .Ident "body" }},
-    {{ .Ident "status" }},
+        {{ .Ident "meta" }},
+        {{ .Ident "body" }},
+        {{ .Ident "status" }},
 
-    {{ .Ident "size" }},
-    {{ .Ident "etag" }},
+        {{ .Ident "size" }},
+        {{ .Ident "etag" }},
 
-    {{ .Ident "created_at" }},
-    {{ .Ident "created_by" }},
-    {{ .Ident "updated_at" }},
-    {{ .Ident "updated_by" }},
+        {{ .Ident "created_at" }},
+        {{ .Ident "created_by" }},
+        {{ .Ident "updated_at" }},
+        {{ .Ident "updated_by" }},
 
-    {{ .Ident "origin" }},
-    {{ .Ident "origin_key" }},
-    {{ .Ident "origin_ts" }},
+        {{ .Ident "origin" }},
+        {{ .Ident "origin_key" }},
+        {{ .Ident "origin_ts" }},
 
-    {{ .Ident "title" }},
-    {{ .Ident "slug" }},
-    {{ .Ident "description" }},
+        {{ .Ident "title" }},
+        {{ .Ident "slug" }},
+        {{ .Ident "description" }},
 
-    {{ .Ident "message" }},
-    {{ .Ident "labels" }},
-    {{ .Ident "fields" }},
-    {{ .Ident "errors" }},
+        {{ .Ident "message" }},
+        {{ .Ident "labels" }},
+        {{ .Ident "fields" }},
+        {{ .Ident "errors" }},
 
-    {{ .Ident "action" }}
-  )
+        {{ .Ident "action" }}
+    )
 
-  {{/* Provide the values */}}
-  VALUES (
-    {{ .Arg .Entity.Guid }},
-    {{ .Arg .Entity.ResourceVersion }},
+    {{/* Provide the values */}}
+    VALUES (
+        {{ .Arg .Entity.Guid }},
+        {{ .Arg .Entity.ResourceVersion }},
 
-    {{ .Arg .Entity.Key }},
+        {{ .Arg .Entity.Key }},
 
-    {{ .Arg .Entity.Group }},
-    {{ .Arg .Entity.GroupVersion }},
-    {{ .Arg .Entity.Resource }},
-    {{ .Arg .Entity.Namespace }},
-    {{ .Arg .Entity.Name }},
+        {{ .Arg .Entity.Group }},
+        {{ .Arg .Entity.GroupVersion }},
+        {{ .Arg .Entity.Resource }},
+        {{ .Arg .Entity.Namespace }},
+        {{ .Arg .Entity.Name }},
 
-    {{ .Arg .Entity.Folder }},
+        {{ .Arg .Entity.Folder }},
 
-    {{ .Arg .Entity.Meta }},
-    {{ .Arg .Entity.Body }},
-    {{ .Arg .Entity.Status }},
+        {{ .Arg .Entity.Meta }},
+        {{ .Arg .Entity.Body }},
+        {{ .Arg .Entity.Status }},
 
-    {{ .Arg .Entity.Size }},
-    {{ .Arg .Entity.ETag }},
+        {{ .Arg .Entity.Size }},
+        {{ .Arg .Entity.ETag }},
 
-    {{ .Arg .Entity.CreatedAt }},
-    {{ .Arg .Entity.CreatedBy }},
-    {{ .Arg .Entity.UpdatedAt }},
-    {{ .Arg .Entity.UpdatedBy }},
+        {{ .Arg .Entity.CreatedAt }},
+        {{ .Arg .Entity.CreatedBy }},
+        {{ .Arg .Entity.UpdatedAt }},
+        {{ .Arg .Entity.UpdatedBy }},
 
-    {{ .Arg .Entity.Origin.Source }},
-    {{ .Arg .Entity.Origin.Key }},
-    {{ .Arg .Entity.Origin.Time }},
+        {{ .Arg .Entity.Origin.Source }},
+        {{ .Arg .Entity.Origin.Key }},
+        {{ .Arg .Entity.Origin.Time }},
 
-    {{ .Arg .Entity.Title }},
-    {{ .Arg .Entity.Slug }},
-    {{ .Arg .Entity.Description }},
+        {{ .Arg .Entity.Title }},
+        {{ .Arg .Entity.Slug }},
+        {{ .Arg .Entity.Description }},
 
-    {{ .Arg .Entity.Message }},
-    {{ .Arg .Entity.Labels }},
-    {{ .Arg .Entity.Fields }},
-    {{ .Arg .Entity.Errors }},
+        {{ .Arg .Entity.Message }},
+        {{ .Arg .Entity.Labels }},
+        {{ .Arg .Entity.Fields }},
+        {{ .Arg .Entity.Errors }},
 
-    {{ .Arg .Entity.Action }}
-  )
+        {{ .Arg .Entity.Action }}
+    )
 ;

--- a/pkg/services/store/entity/sqlstash/data/entity_labels_delete.sql
+++ b/pkg/services/store/entity/sqlstash/data/entity_labels_delete.sql
@@ -1,0 +1,18 @@
+DELETE FROM {{ .Ident "entity_labels" }}
+  WHERE 1 = 1
+    AND {{ .Ident "guid" }} = {{ .Arg .GUID }}
+    {{ if gt (len .KeepLabels) 0 }}
+      AND {{ .Ident "label" }} NOT IN
+        (
+          {{ $addComma := false }}
+          {{ range .KeepLabels }}
+            {{ if $addComma }}
+              ,
+            {{ end }}
+            {{ $addComma = true }}
+
+            {{ .Arg . }}
+          {{ end }}
+        )
+    {{ end }}
+;

--- a/pkg/services/store/entity/sqlstash/data/entity_labels_delete.sql
+++ b/pkg/services/store/entity/sqlstash/data/entity_labels_delete.sql
@@ -1,19 +1,18 @@
 DELETE FROM {{ .Ident "entity_labels" }}
-  WHERE 1 = 1
-    AND {{ .Ident "guid" }} = {{ .Arg .GUID }}
-    {{ if gt (len .KeepLabels) 0 }}
-      AND {{ .Ident "label" }} NOT IN
-        (
-          {{ $this := . }}
-          {{ $addComma := false }}
-          {{ range .KeepLabels }}
-            {{ if $addComma }}
-              ,
-            {{ end }}
-            {{ $addComma = true }}
+    WHERE 1 = 1
+        AND {{ .Ident "guid" }} = {{ .Arg .GUID }}
+        {{ if gt (len .KeepLabels) 0 }}
+            AND {{ .Ident "label" }} NOT IN (
+                {{ $this := . }}
+                {{ $addComma := false }}
+                {{ range .KeepLabels }}
+                    {{ if $addComma }}
+                        ,
+                    {{ end }}
+                    {{ $addComma = true }}
 
-            {{ $this.Arg . }}
-          {{ end }}
-        )
-    {{ end }}
+                    {{ $this.Arg . }}
+                {{ end }}
+            )
+        {{ end }}
 ;

--- a/pkg/services/store/entity/sqlstash/data/entity_labels_delete.sql
+++ b/pkg/services/store/entity/sqlstash/data/entity_labels_delete.sql
@@ -4,6 +4,7 @@ DELETE FROM {{ .Ident "entity_labels" }}
     {{ if gt (len .KeepLabels) 0 }}
       AND {{ .Ident "label" }} NOT IN
         (
+          {{ $this := . }}
           {{ $addComma := false }}
           {{ range .KeepLabels }}
             {{ if $addComma }}
@@ -11,7 +12,7 @@ DELETE FROM {{ .Ident "entity_labels" }}
             {{ end }}
             {{ $addComma = true }}
 
-            {{ .Arg . }}
+            {{ $this.Arg . }}
           {{ end }}
         )
     {{ end }}

--- a/pkg/services/store/entity/sqlstash/data/entity_labels_insert.sql
+++ b/pkg/services/store/entity/sqlstash/data/entity_labels_insert.sql
@@ -1,0 +1,29 @@
+INSERT INTO {{ .Ident "entity_labels" }}
+  (
+    {{ .Ident "guid" }},
+    {{ .Ident "label" }},
+    {{ .Ident "value" }}
+  )
+
+  VALUES (
+    {{/*
+      When we enter the "range" loop the "." will be changed, so we need to
+      store the current ".GUID" in a variable to be able to use its value
+    */}}
+    {{ $guid := .GUID }}
+
+    {{ $addComma := false }}
+    {{ range $name, $value := .Labels }}
+      {{ if $addComma }}
+        ,
+      {{ end }}
+      {{ $addComma = true }}
+
+      (
+        {{ .Arg $guid }},
+        {{ .Arg $name }},
+        {{ .Arg $value }}
+      )
+    {{ end }}
+  )
+;

--- a/pkg/services/store/entity/sqlstash/data/entity_labels_insert.sql
+++ b/pkg/services/store/entity/sqlstash/data/entity_labels_insert.sql
@@ -5,13 +5,14 @@ INSERT INTO {{ .Ident "entity_labels" }}
     {{ .Ident "value" }}
   )
 
-  VALUES (
+  VALUES
     {{/*
       When we enter the "range" loop the "." will be changed, so we need to
       store the current ".GUID" in a variable to be able to use its value
     */}}
     {{ $guid := .GUID }}
 
+    {{ $this := . }}
     {{ $addComma := false }}
     {{ range $name, $value := .Labels }}
       {{ if $addComma }}
@@ -20,10 +21,9 @@ INSERT INTO {{ .Ident "entity_labels" }}
       {{ $addComma = true }}
 
       (
-        {{ .Arg $guid }},
-        {{ .Arg $name }},
-        {{ .Arg $value }}
+        {{ $this.Arg $guid }},
+        {{ $this.Arg $name }},
+        {{ $this.Arg $value }}
       )
     {{ end }}
-  )
 ;

--- a/pkg/services/store/entity/sqlstash/data/entity_labels_insert.sql
+++ b/pkg/services/store/entity/sqlstash/data/entity_labels_insert.sql
@@ -1,29 +1,29 @@
 INSERT INTO {{ .Ident "entity_labels" }}
-  (
-    {{ .Ident "guid" }},
-    {{ .Ident "label" }},
-    {{ .Ident "value" }}
-  )
+    (
+        {{ .Ident "guid" }},
+        {{ .Ident "label" }},
+        {{ .Ident "value" }}
+    )
 
-  VALUES
-    {{/*
-      When we enter the "range" loop the "." will be changed, so we need to
-      store the current ".GUID" in a variable to be able to use its value
-    */}}
-    {{ $guid := .GUID }}
+    VALUES
+        {{/*
+          When we enter the "range" loop the "." will be changed, so we need to
+          store the current ".GUID" in a variable to be able to use its value
+        */}}
+        {{ $guid := .GUID }}
 
-    {{ $this := . }}
-    {{ $addComma := false }}
-    {{ range $name, $value := .Labels }}
-      {{ if $addComma }}
-        ,
-      {{ end }}
-      {{ $addComma = true }}
+        {{ $this := . }}
+        {{ $addComma := false }}
+        {{ range $name, $value := .Labels }}
+            {{ if $addComma }}
+                ,
+            {{ end }}
+            {{ $addComma = true }}
 
-      (
-        {{ $this.Arg $guid }},
-        {{ $this.Arg $name }},
-        {{ $this.Arg $value }}
-      )
-    {{ end }}
+            (
+                {{ $this.Arg $guid }},
+                {{ $this.Arg $name }},
+                {{ $this.Arg $value }}
+            )
+        {{ end }}
 ;

--- a/pkg/services/store/entity/sqlstash/data/entity_list_folder_elements.sql
+++ b/pkg/services/store/entity/sqlstash/data/entity_list_folder_elements.sql
@@ -1,0 +1,14 @@
+SELECT
+    {{ .Ident "guid"   | .Into .FolderInfo.GUID }},
+    {{ .Ident "name"   | .Into .FolderInfo.UID }},
+    {{ .Ident "folder" | .Into .FolderInfo.ParentUID }},
+    {{ .Ident "name"   | .Into .FolderInfo.Name }},
+    {{ .Ident "slug"   | .Into .FolderInfo.Slug }}
+
+  FROM {{ .Ident "entity" }}
+
+  WHERE 1 = 1
+    AND {{ .Ident "group" }}     = {{ .Arg .Group }}
+    AND {{ .Ident "resource" }}  = {{ .Arg .Resource }}
+    AND {{ .Ident "namespace" }} = {{ .Arg .Namespace }}
+;

--- a/pkg/services/store/entity/sqlstash/data/entity_list_folder_elements.sql
+++ b/pkg/services/store/entity/sqlstash/data/entity_list_folder_elements.sql
@@ -1,14 +1,14 @@
 SELECT
-    {{ .Ident "guid"   | .Into .FolderInfo.GUID }},
-    {{ .Ident "name"   | .Into .FolderInfo.UID }},
-    {{ .Ident "folder" | .Into .FolderInfo.ParentUID }},
-    {{ .Ident "name"   | .Into .FolderInfo.Name }},
-    {{ .Ident "slug"   | .Into .FolderInfo.Slug }}
+        {{ .Ident "guid"   | .Into .FolderInfo.GUID }},
+        {{ .Ident "name"   | .Into .FolderInfo.UID }},
+        {{ .Ident "folder" | .Into .FolderInfo.ParentUID }},
+        {{ .Ident "name"   | .Into .FolderInfo.Name }},
+        {{ .Ident "slug"   | .Into .FolderInfo.Slug }}
 
-  FROM {{ .Ident "entity" }}
+    FROM {{ .Ident "entity" }}
 
-  WHERE 1 = 1
-    AND {{ .Ident "group" }}     = {{ .Arg .Group }}
-    AND {{ .Ident "resource" }}  = {{ .Arg .Resource }}
-    AND {{ .Ident "namespace" }} = {{ .Arg .Namespace }}
+    WHERE 1 = 1
+        AND {{ .Ident "group" }}     = {{ .Arg .Group }}
+        AND {{ .Ident "resource" }}  = {{ .Arg .Resource }}
+        AND {{ .Ident "namespace" }} = {{ .Arg .Namespace }}
 ;

--- a/pkg/services/store/entity/sqlstash/data/entity_read.sql
+++ b/pkg/services/store/entity/sqlstash/data/entity_read.sql
@@ -1,0 +1,79 @@
+SELECT
+    {{ .Ident "guid"             | .Into .Entity.Guid }},
+    {{ .Ident "resource_version" | .Into .Entity.ResourceVersion }},
+
+    {{ .Ident "key"              | .Into .Entity.Key }},
+
+    {{ .Ident "group"            | .Into .Entity.Group }},
+    {{ .Ident "group_version"    | .Into .Entity.GroupVersion }},
+    {{ .Ident "resource"         | .Into .Entity.Resource }},
+    {{ .Ident "namespace"        | .Into .Entity.Namespace }},
+    {{ .Ident "name"             | .Into .Entity.Name }},
+
+    {{ .Ident "folder"           | .Into .Entity.Folder }},
+
+    {{ .Ident "meta"             | .Into .Entity.Meta }},
+    {{ .Ident "body"             | .Into .Entity.Body }},
+    {{ .Ident "status"           | .Into .Entity.Status }},
+
+    {{ .Ident "size"             | .Into .Entity.Size }},
+    {{ .Ident "etag"             | .Into .Entity.ETag }},
+
+    {{ .Ident "created_at"       | .Into .Entity.CreatedAt }},
+    {{ .Ident "created_by"       | .Into .Entity.CreatedBy }},
+    {{ .Ident "updated_at"       | .Into .Entity.UpdatedAt }},
+    {{ .Ident "updated_by"       | .Into .Entity.UpdatedBy }},
+
+    {{ .Ident "origin"           | .Into .Entity.Origin.Source }},
+    {{ .Ident "origin_key"       | .Into .Entity.Origin.Key }},
+    {{ .Ident "origin_ts"        | .Into .Entity.Origin.Time }},
+
+    {{ .Ident "title"            | .Into .Entity.Title }},
+    {{ .Ident "slug"             | .Into .Entity.Slug }},
+    {{ .Ident "description"      | .Into .Entity.Description }},
+
+    {{ .Ident "message"          | .Into .Entity.Message }},
+    {{ .Ident "labels"           | .Into .Entity.Labels }},
+    {{ .Ident "fields"           | .Into .Entity.Fields }},
+    {{ .Ident "errors"           | .Into .Entity.Errors }},
+
+    {{ .Ident "action"           | .Into .Entity.Action }}
+
+    FROM
+      {{ if gt .ResourceVersion 0 }}
+        {{ .Ident "entity_history" }}
+      {{ else }}
+        {{ .Ident "entity" }}
+      {{ end }}
+
+    WHERE 1 = 1
+      AND {{ .Ident "namespace" }} = {{ .Arg .Key.Namespace }}
+      AND {{ .Ident "group" }}     = {{ .Arg .Key.Group }}
+      AND {{ .Ident "resource" }}  = {{ .Arg .Key.Resource }}
+      AND {{ .Ident "name" }}      = {{ .Arg .Key.Name }}
+
+    {{/*
+      Resource versions work like snapshots at the kind level. Thus, a request
+      to retrieve a specific resource version should be interpreted as asking
+      for a resource as of how it existed at that point in time. This is why we
+      request matching entities with at most the provided resource version, and
+      return only the one with the highest resource version. In the case of not
+      specifying a resource version (i.e. resource version zero), it is
+      interpreted as the latest version of the given entity, thus we instead
+      query the "entity" table (which holds only the latest version of
+      non-deleted entities) and we don't need to specify anything else. The
+      "entity" table has a unique constraint on (namespace, group, resource,
+      name), so we're guaranteed to have at most one matching row.
+    */}}
+    {{ if gt .ResourceVersion 0 }}
+        AND {{ .Ident "resource_version" }} <= {{ .Arg .ResourceVersion }}
+
+      ORDER BY {{ .Ident "resource_version" }} DESC
+      LIMIT 1
+    {{ end }}
+
+    {{ if .SelectForUpdate }}
+      {{ .SelectFor "UPDATE" }}
+      {{/*  */}}
+    {{ end }}
+;

--- a/pkg/services/store/entity/sqlstash/data/entity_read.sql
+++ b/pkg/services/store/entity/sqlstash/data/entity_read.sql
@@ -1,78 +1,78 @@
 SELECT
-    {{ .Ident "guid"             | .Into .Entity.Guid }},
-    {{ .Ident "resource_version" | .Into .Entity.ResourceVersion }},
+        {{ .Ident "guid"             | .Into .Entity.Guid }},
+        {{ .Ident "resource_version" | .Into .Entity.ResourceVersion }},
 
-    {{ .Ident "key"              | .Into .Entity.Key }},
+        {{ .Ident "key"              | .Into .Entity.Key }},
 
-    {{ .Ident "group"            | .Into .Entity.Group }},
-    {{ .Ident "group_version"    | .Into .Entity.GroupVersion }},
-    {{ .Ident "resource"         | .Into .Entity.Resource }},
-    {{ .Ident "namespace"        | .Into .Entity.Namespace }},
-    {{ .Ident "name"             | .Into .Entity.Name }},
+        {{ .Ident "group"            | .Into .Entity.Group }},
+        {{ .Ident "group_version"    | .Into .Entity.GroupVersion }},
+        {{ .Ident "resource"         | .Into .Entity.Resource }},
+        {{ .Ident "namespace"        | .Into .Entity.Namespace }},
+        {{ .Ident "name"             | .Into .Entity.Name }},
 
-    {{ .Ident "folder"           | .Into .Entity.Folder }},
+        {{ .Ident "folder"           | .Into .Entity.Folder }},
 
-    {{ .Ident "meta"             | .Into .Entity.Meta }},
-    {{ .Ident "body"             | .Into .Entity.Body }},
-    {{ .Ident "status"           | .Into .Entity.Status }},
+        {{ .Ident "meta"             | .Into .Entity.Meta }},
+        {{ .Ident "body"             | .Into .Entity.Body }},
+        {{ .Ident "status"           | .Into .Entity.Status }},
 
-    {{ .Ident "size"             | .Into .Entity.Size }},
-    {{ .Ident "etag"             | .Into .Entity.ETag }},
+        {{ .Ident "size"             | .Into .Entity.Size }},
+        {{ .Ident "etag"             | .Into .Entity.ETag }},
 
-    {{ .Ident "created_at"       | .Into .Entity.CreatedAt }},
-    {{ .Ident "created_by"       | .Into .Entity.CreatedBy }},
-    {{ .Ident "updated_at"       | .Into .Entity.UpdatedAt }},
-    {{ .Ident "updated_by"       | .Into .Entity.UpdatedBy }},
+        {{ .Ident "created_at"       | .Into .Entity.CreatedAt }},
+        {{ .Ident "created_by"       | .Into .Entity.CreatedBy }},
+        {{ .Ident "updated_at"       | .Into .Entity.UpdatedAt }},
+        {{ .Ident "updated_by"       | .Into .Entity.UpdatedBy }},
 
-    {{ .Ident "origin"           | .Into .Entity.Origin.Source }},
-    {{ .Ident "origin_key"       | .Into .Entity.Origin.Key }},
-    {{ .Ident "origin_ts"        | .Into .Entity.Origin.Time }},
+        {{ .Ident "origin"           | .Into .Entity.Origin.Source }},
+        {{ .Ident "origin_key"       | .Into .Entity.Origin.Key }},
+        {{ .Ident "origin_ts"        | .Into .Entity.Origin.Time }},
 
-    {{ .Ident "title"            | .Into .Entity.Title }},
-    {{ .Ident "slug"             | .Into .Entity.Slug }},
-    {{ .Ident "description"      | .Into .Entity.Description }},
+        {{ .Ident "title"            | .Into .Entity.Title }},
+        {{ .Ident "slug"             | .Into .Entity.Slug }},
+        {{ .Ident "description"      | .Into .Entity.Description }},
 
-    {{ .Ident "message"          | .Into .Entity.Message }},
-    {{ .Ident "labels"           | .Into .Entity.Labels }},
-    {{ .Ident "fields"           | .Into .Entity.Fields }},
-    {{ .Ident "errors"           | .Into .Entity.Errors }},
+        {{ .Ident "message"          | .Into .Entity.Message }},
+        {{ .Ident "labels"           | .Into .Entity.Labels }},
+        {{ .Ident "fields"           | .Into .Entity.Fields }},
+        {{ .Ident "errors"           | .Into .Entity.Errors }},
 
-    {{ .Ident "action"           | .Into .Entity.Action }}
+        {{ .Ident "action"           | .Into .Entity.Action }}
 
     FROM
-      {{ if gt .ResourceVersion 0 }}
-        {{ .Ident "entity_history" }}
-      {{ else }}
-        {{ .Ident "entity" }}
-      {{ end }}
+        {{ if gt .ResourceVersion 0 }}
+            {{ .Ident "entity_history" }}
+        {{ else }}
+            {{ .Ident "entity" }}
+        {{ end }}
 
     WHERE 1 = 1
-      AND {{ .Ident "namespace" }} = {{ .Arg .Key.Namespace }}
-      AND {{ .Ident "group" }}     = {{ .Arg .Key.Group }}
-      AND {{ .Ident "resource" }}  = {{ .Arg .Key.Resource }}
-      AND {{ .Ident "name" }}      = {{ .Arg .Key.Name }}
+        AND {{ .Ident "namespace" }} = {{ .Arg .Key.Namespace }}
+        AND {{ .Ident "group" }}     = {{ .Arg .Key.Group }}
+        AND {{ .Ident "resource" }}  = {{ .Arg .Key.Resource }}
+        AND {{ .Ident "name" }}      = {{ .Arg .Key.Name }}
 
-    {{/*
-      Resource versions work like snapshots at the kind level. Thus, a request
-      to retrieve a specific resource version should be interpreted as asking
-      for a resource as of how it existed at that point in time. This is why we
-      request matching entities with at most the provided resource version, and
-      return only the one with the highest resource version. In the case of not
-      specifying a resource version (i.e. resource version zero), it is
-      interpreted as the latest version of the given entity, thus we instead
-      query the "entity" table (which holds only the latest version of
-      non-deleted entities) and we don't need to specify anything else. The
-      "entity" table has a unique constraint on (namespace, group, resource,
-      name), so we're guaranteed to have at most one matching row.
-    */}}
-    {{ if gt .ResourceVersion 0 }}
-        AND {{ .Ident "resource_version" }} <= {{ .Arg .ResourceVersion }}
+      {{/*
+        Resource versions work like snapshots at the kind level. Thus, a request
+        to retrieve a specific resource version should be interpreted as asking
+        for a resource as of how it existed at that point in time. This is why we
+        request matching entities with at most the provided resource version, and
+        return only the one with the highest resource version. In the case of not
+        specifying a resource version (i.e. resource version zero), it is
+        interpreted as the latest version of the given entity, thus we instead
+        query the "entity" table (which holds only the latest version of
+        non-deleted entities) and we don't need to specify anything else. The
+        "entity" table has a unique constraint on (namespace, group, resource,
+        name), so we're guaranteed to have at most one matching row.
+      */}}
+      {{ if gt .ResourceVersion 0 }}
+            AND {{ .Ident "resource_version" }} <= {{ .Arg .ResourceVersion }}
 
-      ORDER BY {{ .Ident "resource_version" }} DESC
-      LIMIT 1
-    {{ end }}
+          ORDER BY {{ .Ident "resource_version" }} DESC
+          LIMIT 1
+      {{ end }}
 
-    {{ if .SelectForUpdate }}
-      {{ .SelectFor "UPDATE" }}
-    {{ end }}
+      {{ if .SelectForUpdate }}
+          {{ .SelectFor "UPDATE" }}
+      {{ end }}
 ;

--- a/pkg/services/store/entity/sqlstash/data/entity_read.sql
+++ b/pkg/services/store/entity/sqlstash/data/entity_read.sql
@@ -74,6 +74,5 @@ SELECT
 
     {{ if .SelectForUpdate }}
       {{ .SelectFor "UPDATE" }}
-      {{/*  */}}
     {{ end }}
 ;

--- a/pkg/services/store/entity/sqlstash/data/entity_ref_find.sql
+++ b/pkg/services/store/entity/sqlstash/data/entity_ref_find.sql
@@ -1,0 +1,53 @@
+SELECT
+    e.{ .Ident "guid"             | .Into .Entity.Guid }},
+    e.{ .Ident "resource_version" | .Into .Entity.ResourceVersion }},
+
+    e.{ .Ident "key"              | .Into .Entity.Key }},
+
+    e.{ .Ident "group"            | .Into .Entity.Group }},
+    e.{ .Ident "group_version"    | .Into .Entity.GroupVersion }},
+    e.{ .Ident "resource"         | .Into .Entity.Resource }},
+    e.{ .Ident "namespace"        | .Into .Entity.Namespace }},
+    e.{ .Ident "name"             | .Into .Entity.Name }},
+
+    e.{ .Ident "folder"           | .Into .Entity.Folder }},
+
+    e.{ .Ident "meta"             | .Into .Entity.Meta }},
+    e.{ .Ident "body"             | .Into .Entity.Body }},
+    e.{ .Ident "status"           | .Into .Entity.Status }},
+
+    e.{ .Ident "size"             | .Into .Entity.Size }},
+    e.{ .Ident "etag"             | .Into .Entity.ETag }},
+
+    e.{ .Ident "created_at"       | .Into .Entity.CreatedAt }},
+    e.{ .Ident "created_by"       | .Into .Entity.CreatedBy }},
+    e.{ .Ident "updated_at"       | .Into .Entity.UpdatedAt }},
+    e.{ .Ident "updated_by"       | .Into .Entity.UpdatedBy }},
+
+    e.{ .Ident "origin"           | .Into .Entity.Origin.Source }},
+    e.{ .Ident "origin_key"       | .Into .Entity.Origin.Key }},
+    e.{ .Ident "origin_ts"        | .Into .Entity.Origin.Time }},
+
+    e.{ .Ident "title"            | .Into .Entity.Title }},
+    e.{ .Ident "slug"             | .Into .Entity.Slug }},
+    e.{ .Ident "description"      | .Into .Entity.Description }},
+
+    e.{ .Ident "message"          | .Into .Entity.Message }},
+    e.{ .Ident "labels"           | .Into .Entity.Labels }},
+    e.{ .Ident "fields"           | .Into .Entity.Fields }},
+    e.{ .Ident "errors"           | .Into .Entity.Errors }},
+
+    e.{ .Ident "action"           | .Into .Entity.Action }}
+
+  FROM
+    {{ .Idennt "entity_ref" }} AS r
+      INNER JOIN
+    {{ .Ident "entity" }} AS e
+      ON r.{{ .Ident "guid" }} = e.{{ .Ident "guid" }}
+
+  WHERE 1 = 1
+    AND r.{{ .Ident "namespace" }}   = {{ .Arg .Request.Namespace }}
+    AND r.{{ .Ident "group" }}       = {{ .Arg .Request.Group }}
+    AND r.{{ .Ident "resource" }}    = {{ .Arg .Request.Resource }}
+    AND r.{{ .Ident "resolved_to" }} = {{ .Arg .Request.ResolvedTo }}
+;

--- a/pkg/services/store/entity/sqlstash/data/entity_ref_find.sql
+++ b/pkg/services/store/entity/sqlstash/data/entity_ref_find.sql
@@ -1,53 +1,53 @@
 SELECT
-    e.{{ .Ident "guid"             | .Into .Entity.Guid }},
-    e.{{ .Ident "resource_version" | .Into .Entity.ResourceVersion }},
+        e.{{ .Ident "guid"             | .Into .Entity.Guid }},
+        e.{{ .Ident "resource_version" | .Into .Entity.ResourceVersion }},
 
-    e.{{ .Ident "key"              | .Into .Entity.Key }},
+        e.{{ .Ident "key"              | .Into .Entity.Key }},
 
-    e.{{ .Ident "group"            | .Into .Entity.Group }},
-    e.{{ .Ident "group_version"    | .Into .Entity.GroupVersion }},
-    e.{{ .Ident "resource"         | .Into .Entity.Resource }},
-    e.{{ .Ident "namespace"        | .Into .Entity.Namespace }},
-    e.{{ .Ident "name"             | .Into .Entity.Name }},
+        e.{{ .Ident "group"            | .Into .Entity.Group }},
+        e.{{ .Ident "group_version"    | .Into .Entity.GroupVersion }},
+        e.{{ .Ident "resource"         | .Into .Entity.Resource }},
+        e.{{ .Ident "namespace"        | .Into .Entity.Namespace }},
+        e.{{ .Ident "name"             | .Into .Entity.Name }},
 
-    e.{{ .Ident "folder"           | .Into .Entity.Folder }},
+        e.{{ .Ident "folder"           | .Into .Entity.Folder }},
 
-    e.{{ .Ident "meta"             | .Into .Entity.Meta }},
-    e.{{ .Ident "body"             | .Into .Entity.Body }},
-    e.{{ .Ident "status"           | .Into .Entity.Status }},
+        e.{{ .Ident "meta"             | .Into .Entity.Meta }},
+        e.{{ .Ident "body"             | .Into .Entity.Body }},
+        e.{{ .Ident "status"           | .Into .Entity.Status }},
 
-    e.{{ .Ident "size"             | .Into .Entity.Size }},
-    e.{{ .Ident "etag"             | .Into .Entity.ETag }},
+        e.{{ .Ident "size"             | .Into .Entity.Size }},
+        e.{{ .Ident "etag"             | .Into .Entity.ETag }},
 
-    e.{{ .Ident "created_at"       | .Into .Entity.CreatedAt }},
-    e.{{ .Ident "created_by"       | .Into .Entity.CreatedBy }},
-    e.{{ .Ident "updated_at"       | .Into .Entity.UpdatedAt }},
-    e.{{ .Ident "updated_by"       | .Into .Entity.UpdatedBy }},
+        e.{{ .Ident "created_at"       | .Into .Entity.CreatedAt }},
+        e.{{ .Ident "created_by"       | .Into .Entity.CreatedBy }},
+        e.{{ .Ident "updated_at"       | .Into .Entity.UpdatedAt }},
+        e.{{ .Ident "updated_by"       | .Into .Entity.UpdatedBy }},
 
-    e.{{ .Ident "origin"           | .Into .Entity.Origin.Source }},
-    e.{{ .Ident "origin_key"       | .Into .Entity.Origin.Key }},
-    e.{{ .Ident "origin_ts"        | .Into .Entity.Origin.Time }},
+        e.{{ .Ident "origin"           | .Into .Entity.Origin.Source }},
+        e.{{ .Ident "origin_key"       | .Into .Entity.Origin.Key }},
+        e.{{ .Ident "origin_ts"        | .Into .Entity.Origin.Time }},
 
-    e.{{ .Ident "title"            | .Into .Entity.Title }},
-    e.{{ .Ident "slug"             | .Into .Entity.Slug }},
-    e.{{ .Ident "description"      | .Into .Entity.Description }},
+        e.{{ .Ident "title"            | .Into .Entity.Title }},
+        e.{{ .Ident "slug"             | .Into .Entity.Slug }},
+        e.{{ .Ident "description"      | .Into .Entity.Description }},
 
-    e.{{ .Ident "message"          | .Into .Entity.Message }},
-    e.{{ .Ident "labels"           | .Into .Entity.Labels }},
-    e.{{ .Ident "fields"           | .Into .Entity.Fields }},
-    e.{{ .Ident "errors"           | .Into .Entity.Errors }},
+        e.{{ .Ident "message"          | .Into .Entity.Message }},
+        e.{{ .Ident "labels"           | .Into .Entity.Labels }},
+        e.{{ .Ident "fields"           | .Into .Entity.Fields }},
+        e.{{ .Ident "errors"           | .Into .Entity.Errors }},
 
-    e.{{ .Ident "action"           | .Into .Entity.Action }}
+        e.{{ .Ident "action"           | .Into .Entity.Action }}
 
-  FROM
-    {{ .Ident "entity_ref" }} AS r
-      INNER JOIN
-    {{ .Ident "entity" }} AS e
-      ON r.{{ .Ident "guid" }} = e.{{ .Ident "guid" }}
+    FROM
+        {{ .Ident "entity_ref" }} AS r
+            INNER JOIN
+        {{ .Ident "entity" }} AS e
+            ON r.{{ .Ident "guid" }} = e.{{ .Ident "guid" }}
 
-  WHERE 1 = 1
-    AND r.{{ .Ident "namespace" }}   = {{ .Arg .Request.Namespace }}
-    AND r.{{ .Ident "group" }}       = {{ .Arg .Request.Group }}
-    AND r.{{ .Ident "resource" }}    = {{ .Arg .Request.Resource }}
-    AND r.{{ .Ident "resolved_to" }} = {{ .Arg .Request.Name }}
+    WHERE 1 = 1
+        AND r.{{ .Ident "namespace" }}   = {{ .Arg .Request.Namespace }}
+        AND r.{{ .Ident "group" }}       = {{ .Arg .Request.Group }}
+        AND r.{{ .Ident "resource" }}    = {{ .Arg .Request.Resource }}
+        AND r.{{ .Ident "resolved_to" }} = {{ .Arg .Request.Name }}
 ;

--- a/pkg/services/store/entity/sqlstash/data/entity_ref_find.sql
+++ b/pkg/services/store/entity/sqlstash/data/entity_ref_find.sql
@@ -1,46 +1,46 @@
 SELECT
-    e.{ .Ident "guid"             | .Into .Entity.Guid }},
-    e.{ .Ident "resource_version" | .Into .Entity.ResourceVersion }},
+    e.{{ .Ident "guid"             | .Into .Entity.Guid }},
+    e.{{ .Ident "resource_version" | .Into .Entity.ResourceVersion }},
 
-    e.{ .Ident "key"              | .Into .Entity.Key }},
+    e.{{ .Ident "key"              | .Into .Entity.Key }},
 
-    e.{ .Ident "group"            | .Into .Entity.Group }},
-    e.{ .Ident "group_version"    | .Into .Entity.GroupVersion }},
-    e.{ .Ident "resource"         | .Into .Entity.Resource }},
-    e.{ .Ident "namespace"        | .Into .Entity.Namespace }},
-    e.{ .Ident "name"             | .Into .Entity.Name }},
+    e.{{ .Ident "group"            | .Into .Entity.Group }},
+    e.{{ .Ident "group_version"    | .Into .Entity.GroupVersion }},
+    e.{{ .Ident "resource"         | .Into .Entity.Resource }},
+    e.{{ .Ident "namespace"        | .Into .Entity.Namespace }},
+    e.{{ .Ident "name"             | .Into .Entity.Name }},
 
-    e.{ .Ident "folder"           | .Into .Entity.Folder }},
+    e.{{ .Ident "folder"           | .Into .Entity.Folder }},
 
-    e.{ .Ident "meta"             | .Into .Entity.Meta }},
-    e.{ .Ident "body"             | .Into .Entity.Body }},
-    e.{ .Ident "status"           | .Into .Entity.Status }},
+    e.{{ .Ident "meta"             | .Into .Entity.Meta }},
+    e.{{ .Ident "body"             | .Into .Entity.Body }},
+    e.{{ .Ident "status"           | .Into .Entity.Status }},
 
-    e.{ .Ident "size"             | .Into .Entity.Size }},
-    e.{ .Ident "etag"             | .Into .Entity.ETag }},
+    e.{{ .Ident "size"             | .Into .Entity.Size }},
+    e.{{ .Ident "etag"             | .Into .Entity.ETag }},
 
-    e.{ .Ident "created_at"       | .Into .Entity.CreatedAt }},
-    e.{ .Ident "created_by"       | .Into .Entity.CreatedBy }},
-    e.{ .Ident "updated_at"       | .Into .Entity.UpdatedAt }},
-    e.{ .Ident "updated_by"       | .Into .Entity.UpdatedBy }},
+    e.{{ .Ident "created_at"       | .Into .Entity.CreatedAt }},
+    e.{{ .Ident "created_by"       | .Into .Entity.CreatedBy }},
+    e.{{ .Ident "updated_at"       | .Into .Entity.UpdatedAt }},
+    e.{{ .Ident "updated_by"       | .Into .Entity.UpdatedBy }},
 
-    e.{ .Ident "origin"           | .Into .Entity.Origin.Source }},
-    e.{ .Ident "origin_key"       | .Into .Entity.Origin.Key }},
-    e.{ .Ident "origin_ts"        | .Into .Entity.Origin.Time }},
+    e.{{ .Ident "origin"           | .Into .Entity.Origin.Source }},
+    e.{{ .Ident "origin_key"       | .Into .Entity.Origin.Key }},
+    e.{{ .Ident "origin_ts"        | .Into .Entity.Origin.Time }},
 
-    e.{ .Ident "title"            | .Into .Entity.Title }},
-    e.{ .Ident "slug"             | .Into .Entity.Slug }},
-    e.{ .Ident "description"      | .Into .Entity.Description }},
+    e.{{ .Ident "title"            | .Into .Entity.Title }},
+    e.{{ .Ident "slug"             | .Into .Entity.Slug }},
+    e.{{ .Ident "description"      | .Into .Entity.Description }},
 
-    e.{ .Ident "message"          | .Into .Entity.Message }},
-    e.{ .Ident "labels"           | .Into .Entity.Labels }},
-    e.{ .Ident "fields"           | .Into .Entity.Fields }},
-    e.{ .Ident "errors"           | .Into .Entity.Errors }},
+    e.{{ .Ident "message"          | .Into .Entity.Message }},
+    e.{{ .Ident "labels"           | .Into .Entity.Labels }},
+    e.{{ .Ident "fields"           | .Into .Entity.Fields }},
+    e.{{ .Ident "errors"           | .Into .Entity.Errors }},
 
-    e.{ .Ident "action"           | .Into .Entity.Action }}
+    e.{{ .Ident "action"           | .Into .Entity.Action }}
 
   FROM
-    {{ .Idennt "entity_ref" }} AS r
+    {{ .Ident "entity_ref" }} AS r
       INNER JOIN
     {{ .Ident "entity" }} AS e
       ON r.{{ .Ident "guid" }} = e.{{ .Ident "guid" }}
@@ -49,5 +49,5 @@ SELECT
     AND r.{{ .Ident "namespace" }}   = {{ .Arg .Request.Namespace }}
     AND r.{{ .Ident "group" }}       = {{ .Arg .Request.Group }}
     AND r.{{ .Ident "resource" }}    = {{ .Arg .Request.Resource }}
-    AND r.{{ .Ident "resolved_to" }} = {{ .Arg .Request.ResolvedTo }}
+    AND r.{{ .Ident "resolved_to" }} = {{ .Arg .Request.Name }}
 ;

--- a/pkg/services/store/entity/sqlstash/data/entity_update.sql
+++ b/pkg/services/store/entity/sqlstash/data/entity_update.sql
@@ -1,0 +1,35 @@
+UPDATE {{ .Ident "entity" }}
+  SET
+    {{ .Ident "resource_version" }} = {{ .Arg .Entity.ResourceVersion }},
+
+    {{ .Ident "group_version" }}    = {{ .Arg .Entity.GroupVersion }},
+
+    {{ .Ident "folder" }}           = {{ .Arg .Entity.Folder }},
+
+    {{ .Ident "meta" }}             = {{ .Arg .Entity.Meta }},
+    {{ .Ident "body" }}             = {{ .Arg .Entity.Body }},
+    {{ .Ident "status" }}           = {{ .Arg .Entity.Status }},
+
+    {{ .Ident "size" }}             = {{ .Arg .Entity.Size }},
+    {{ .Ident "etag" }}             = {{ .Arg .Entity.ETag }},
+
+    {{ .Ident "updated_at" }}       = {{ .Arg .Entity.UpdatedAt }},
+    {{ .Ident "updated_by" }}       = {{ .Arg .Entity.UpdatedBy }},
+
+    {{ .Ident "origin" }}           = {{ .Arg .Entity.Origin.Source }},
+    {{ .Ident "origin_key" }}       = {{ .Arg .Entity.Origin.Key }},
+    {{ .Ident "origin_ts" }}        = {{ .Arg .Entity.Origin.Time }},
+
+    {{ .Ident "title" }}            = {{ .Arg .Entity.Title }},
+    {{ .Ident "slug" }}             = {{ .Arg .Entity.Slug }},
+    {{ .Ident "description" }}      = {{ .Arg .Entity.Description }},
+
+    {{ .Ident "message" }}          = {{ .Arg .Entity.Message }},
+    {{ .Ident "labels" }}           = {{ .Arg .Entity.Labels }},
+    {{ .Ident "fields" }}           = {{ .Arg .Entity.Fields }},
+    {{ .Ident "errors" }}           = {{ .Arg .Entity.Errors }},
+
+    {{ .Ident "action" }}           = {{ .Arg .Entity.Action }}
+
+  WHERE {{ .Ident "guid" }} = {{ .Arg .Entity.Guid }}
+;

--- a/pkg/services/store/entity/sqlstash/data/entity_update.sql
+++ b/pkg/services/store/entity/sqlstash/data/entity_update.sql
@@ -1,35 +1,34 @@
-UPDATE {{ .Ident "entity" }}
-  SET
-    {{ .Ident "resource_version" }} = {{ .Arg .Entity.ResourceVersion }},
+UPDATE {{ .Ident "entity" }} SET
+        {{ .Ident "resource_version" }} = {{ .Arg .Entity.ResourceVersion }},
 
-    {{ .Ident "group_version" }}    = {{ .Arg .Entity.GroupVersion }},
+        {{ .Ident "group_version" }}    = {{ .Arg .Entity.GroupVersion }},
 
-    {{ .Ident "folder" }}           = {{ .Arg .Entity.Folder }},
+        {{ .Ident "folder" }}           = {{ .Arg .Entity.Folder }},
 
-    {{ .Ident "meta" }}             = {{ .Arg .Entity.Meta }},
-    {{ .Ident "body" }}             = {{ .Arg .Entity.Body }},
-    {{ .Ident "status" }}           = {{ .Arg .Entity.Status }},
+        {{ .Ident "meta" }}             = {{ .Arg .Entity.Meta }},
+        {{ .Ident "body" }}             = {{ .Arg .Entity.Body }},
+        {{ .Ident "status" }}           = {{ .Arg .Entity.Status }},
 
-    {{ .Ident "size" }}             = {{ .Arg .Entity.Size }},
-    {{ .Ident "etag" }}             = {{ .Arg .Entity.ETag }},
+        {{ .Ident "size" }}             = {{ .Arg .Entity.Size }},
+        {{ .Ident "etag" }}             = {{ .Arg .Entity.ETag }},
 
-    {{ .Ident "updated_at" }}       = {{ .Arg .Entity.UpdatedAt }},
-    {{ .Ident "updated_by" }}       = {{ .Arg .Entity.UpdatedBy }},
+        {{ .Ident "updated_at" }}       = {{ .Arg .Entity.UpdatedAt }},
+        {{ .Ident "updated_by" }}       = {{ .Arg .Entity.UpdatedBy }},
 
-    {{ .Ident "origin" }}           = {{ .Arg .Entity.Origin.Source }},
-    {{ .Ident "origin_key" }}       = {{ .Arg .Entity.Origin.Key }},
-    {{ .Ident "origin_ts" }}        = {{ .Arg .Entity.Origin.Time }},
+        {{ .Ident "origin" }}           = {{ .Arg .Entity.Origin.Source }},
+        {{ .Ident "origin_key" }}       = {{ .Arg .Entity.Origin.Key }},
+        {{ .Ident "origin_ts" }}        = {{ .Arg .Entity.Origin.Time }},
 
-    {{ .Ident "title" }}            = {{ .Arg .Entity.Title }},
-    {{ .Ident "slug" }}             = {{ .Arg .Entity.Slug }},
-    {{ .Ident "description" }}      = {{ .Arg .Entity.Description }},
+        {{ .Ident "title" }}            = {{ .Arg .Entity.Title }},
+        {{ .Ident "slug" }}             = {{ .Arg .Entity.Slug }},
+        {{ .Ident "description" }}      = {{ .Arg .Entity.Description }},
 
-    {{ .Ident "message" }}          = {{ .Arg .Entity.Message }},
-    {{ .Ident "labels" }}           = {{ .Arg .Entity.Labels }},
-    {{ .Ident "fields" }}           = {{ .Arg .Entity.Fields }},
-    {{ .Ident "errors" }}           = {{ .Arg .Entity.Errors }},
+        {{ .Ident "message" }}          = {{ .Arg .Entity.Message }},
+        {{ .Ident "labels" }}           = {{ .Arg .Entity.Labels }},
+        {{ .Ident "fields" }}           = {{ .Arg .Entity.Fields }},
+        {{ .Ident "errors" }}           = {{ .Arg .Entity.Errors }},
 
-    {{ .Ident "action" }}           = {{ .Arg .Entity.Action }}
+        {{ .Ident "action" }}           = {{ .Arg .Entity.Action }}
 
-  WHERE {{ .Ident "guid" }} = {{ .Arg .Entity.Guid }}
+    WHERE {{ .Ident "guid" }} = {{ .Arg .Entity.Guid }}
 ;

--- a/pkg/services/store/entity/sqlstash/data/kind_version_inc.sql
+++ b/pkg/services/store/entity/sqlstash/data/kind_version_inc.sql
@@ -1,0 +1,8 @@
+UPDATE {{ .Ident "kind_version" }}
+  SET {{ .Ident "resource_version" }} = {{ .Arg .ResourceVersion }} + 1
+  WHERE 1 = 1
+    AND {{ .Ident "group" }}            = {{ .Arg .Group }}
+    AND {{ .Ident "group_version" }}    = {{ .Arg .GroupVersion }}
+    AND {{ .Ident "resource" }}         = {{ .Arg .Resource }}
+    AND {{ .Ident "resource_version" }} = {{ .Arg .ResourceVersion }}
+;

--- a/pkg/services/store/entity/sqlstash/data/kind_version_inc.sql
+++ b/pkg/services/store/entity/sqlstash/data/kind_version_inc.sql
@@ -2,7 +2,6 @@ UPDATE {{ .Ident "kind_version" }}
     SET {{ .Ident "resource_version" }} = {{ .Arg .ResourceVersion }} + 1
     WHERE 1 = 1
         AND {{ .Ident "group" }}            = {{ .Arg .Group }}
-        AND {{ .Ident "group_version" }}    = {{ .Arg .GroupVersion }}
         AND {{ .Ident "resource" }}         = {{ .Arg .Resource }}
         AND {{ .Ident "resource_version" }} = {{ .Arg .ResourceVersion }}
 ;

--- a/pkg/services/store/entity/sqlstash/data/kind_version_inc.sql
+++ b/pkg/services/store/entity/sqlstash/data/kind_version_inc.sql
@@ -1,8 +1,8 @@
 UPDATE {{ .Ident "kind_version" }}
-  SET {{ .Ident "resource_version" }} = {{ .Arg .ResourceVersion }} + 1
-  WHERE 1 = 1
-    AND {{ .Ident "group" }}            = {{ .Arg .Group }}
-    AND {{ .Ident "group_version" }}    = {{ .Arg .GroupVersion }}
-    AND {{ .Ident "resource" }}         = {{ .Arg .Resource }}
-    AND {{ .Ident "resource_version" }} = {{ .Arg .ResourceVersion }}
+    SET {{ .Ident "resource_version" }} = {{ .Arg .ResourceVersion }} + 1
+    WHERE 1 = 1
+        AND {{ .Ident "group" }}            = {{ .Arg .Group }}
+        AND {{ .Ident "group_version" }}    = {{ .Arg .GroupVersion }}
+        AND {{ .Ident "resource" }}         = {{ .Arg .Resource }}
+        AND {{ .Ident "resource_version" }} = {{ .Arg .ResourceVersion }}
 ;

--- a/pkg/services/store/entity/sqlstash/data/kind_version_insert.sql
+++ b/pkg/services/store/entity/sqlstash/data/kind_version_insert.sql
@@ -1,0 +1,15 @@
+INSERT INTO {{ .Ident "kind_version" }}
+  (
+    {{ .Ident "group" }},
+    {{ .Ident "group_version" }},
+    {{ .Ident "resource" }},
+    {{ .Ident "resource_version" }}
+  )
+
+  VALUES (
+    {{ .Arg .Group }},
+    {{ .Arg .GroupVersion }},
+    {{ .Arg .Resource }},
+    1
+  )
+;

--- a/pkg/services/store/entity/sqlstash/data/kind_version_insert.sql
+++ b/pkg/services/store/entity/sqlstash/data/kind_version_insert.sql
@@ -1,14 +1,12 @@
 INSERT INTO {{ .Ident "kind_version" }}
     (
         {{ .Ident "group" }},
-        {{ .Ident "group_version" }},
         {{ .Ident "resource" }},
         {{ .Ident "resource_version" }}
     )
 
     VALUES (
         {{ .Arg .Group }},
-        {{ .Arg .GroupVersion }},
         {{ .Arg .Resource }},
         1
     )

--- a/pkg/services/store/entity/sqlstash/data/kind_version_insert.sql
+++ b/pkg/services/store/entity/sqlstash/data/kind_version_insert.sql
@@ -1,15 +1,15 @@
 INSERT INTO {{ .Ident "kind_version" }}
-  (
-    {{ .Ident "group" }},
-    {{ .Ident "group_version" }},
-    {{ .Ident "resource" }},
-    {{ .Ident "resource_version" }}
-  )
+    (
+        {{ .Ident "group" }},
+        {{ .Ident "group_version" }},
+        {{ .Ident "resource" }},
+        {{ .Ident "resource_version" }}
+    )
 
-  VALUES (
-    {{ .Arg .Group }},
-    {{ .Arg .GroupVersion }},
-    {{ .Arg .Resource }},
-    1
-  )
+    VALUES (
+        {{ .Arg .Group }},
+        {{ .Arg .GroupVersion }},
+        {{ .Arg .Resource }},
+        1
+    )
 ;

--- a/pkg/services/store/entity/sqlstash/data/kind_version_lock.sql
+++ b/pkg/services/store/entity/sqlstash/data/kind_version_lock.sql
@@ -1,0 +1,8 @@
+SELECT {{ .Ident "resource_version" | .Into .ResourceVersion }}
+  FROM {{ .Ident "kind_version" }}
+  WHERE 1 = 1
+    AND {{ .Ident "group" }}         = {{ .Arg .Group }}
+    AND {{ .Ident "group_version" }} = {{ .Arg .GroupVersion }}
+    AND {{ .Ident "resource" }}      = {{ .Arg .Resource }}
+  {{ .SelectFor "UPDATE" }}
+;

--- a/pkg/services/store/entity/sqlstash/data/kind_version_lock.sql
+++ b/pkg/services/store/entity/sqlstash/data/kind_version_lock.sql
@@ -1,8 +1,8 @@
 SELECT {{ .Ident "resource_version" | .Into .ResourceVersion }}
-  FROM {{ .Ident "kind_version" }}
-  WHERE 1 = 1
-    AND {{ .Ident "group" }}         = {{ .Arg .Group }}
-    AND {{ .Ident "group_version" }} = {{ .Arg .GroupVersion }}
-    AND {{ .Ident "resource" }}      = {{ .Arg .Resource }}
-  {{ .SelectFor "UPDATE" }}
+    FROM {{ .Ident "kind_version" }}
+    WHERE 1 = 1
+        AND {{ .Ident "group" }}         = {{ .Arg .Group }}
+        AND {{ .Ident "group_version" }} = {{ .Arg .GroupVersion }}
+        AND {{ .Ident "resource" }}      = {{ .Arg .Resource }}
+    {{ .SelectFor "UPDATE" }}
 ;

--- a/pkg/services/store/entity/sqlstash/data/kind_version_lock.sql
+++ b/pkg/services/store/entity/sqlstash/data/kind_version_lock.sql
@@ -2,7 +2,6 @@ SELECT {{ .Ident "resource_version" | .Into .ResourceVersion }}
     FROM {{ .Ident "kind_version" }}
     WHERE 1 = 1
         AND {{ .Ident "group" }}         = {{ .Arg .Group }}
-        AND {{ .Ident "group_version" }} = {{ .Arg .GroupVersion }}
         AND {{ .Ident "resource" }}      = {{ .Arg .Resource }}
     {{ .SelectFor "UPDATE" }}
 ;

--- a/pkg/services/store/entity/sqlstash/queries.go
+++ b/pkg/services/store/entity/sqlstash/queries.go
@@ -42,8 +42,6 @@ func getTemplate(filename string) *template.Template {
 	panic(fmt.Sprintf("template file not found: %s", filename))
 }
 
-// entity_folder table requests.
-
 type sqlEntityFolderInsertRequest struct {
 	*sqltemplate.SQLTemplate
 	Items []*sqlEntityFolderInsertRequestItem
@@ -61,15 +59,11 @@ type sqlEntityFolderInsertRequestItem struct {
 	Detached  bool
 }
 
-// entity_ref table requests.
-
 type sqlEntityRefFindRequest struct {
 	*sqltemplate.SQLTemplate
 	Request *entity.ReferenceRequest
 	Entity  *withSerialized
 }
-
-// entity_labels table requests.
 
 type sqlEntityLabelsInsertRequest struct {
 	*sqltemplate.SQLTemplate
@@ -82,8 +76,6 @@ type sqlEntityLabelsDeleteRequest struct {
 	GUID       string
 	KeepLabels []string
 }
-
-// entity_kind table requests.
 
 type sqlKindVersionLockRequest struct {
 	*sqltemplate.SQLTemplate
@@ -108,8 +100,6 @@ type sqlKindVersionInsertRequest struct {
 	Resource     string
 }
 
-// entity and entity_history tables requests.
-
 type sqlEntityListFolderElementsRequest struct {
 	*sqltemplate.SQLTemplate
 	Group      string
@@ -118,10 +108,6 @@ type sqlEntityListFolderElementsRequest struct {
 	FolderInfo *folderInfo
 }
 
-// sqlEntityReadRequest can be used to retrieve a row from either the "entity"
-// or the "entity_history" tables. In particular, don't use this template
-// directly. Instead, use the readEntity function, which provides all common use
-// cases and proper database deserialization.
 type sqlEntityReadRequest struct {
 	*sqltemplate.SQLTemplate
 	Key             *entity.Key

--- a/pkg/services/store/entity/sqlstash/queries.go
+++ b/pkg/services/store/entity/sqlstash/queries.go
@@ -2,7 +2,6 @@ package sqlstash
 
 import (
 	_ "embed"
-	"encoding/json"
 	"fmt"
 	"text/template"
 
@@ -193,76 +192,49 @@ type withSerialized struct {
 	Errors []byte
 }
 
-func newWithSerialized() *withSerialized {
-	return &withSerialized{
-		Entity: &entity.Entity{
-			// we need to allocate all internal pointer types so that they
-			// are available to be populated in the template
-			Origin: new(entity.EntityOriginInfo),
-		},
-	}
-}
-
+// TODO: remove once we start using the variables. Prevents `unused` linter.
 var (
-	jsonEmptyObject = []byte{'{', '}'}
-	jsonEmptyArray  = []byte{'[', ']'}
+	_ = sqlEntityDeleteData
+	_ = sqlEntityInsertData
+	_ = sqlEntityListFolderElementsData
+	_ = sqlEntityUpdateData
+	_ = sqlEntityReadData
+	_ = sqlEntityFolderInsertData
+	_ = sqlEntityRefFindData
+	_ = sqlEntityLabelsDeleteData
+	_ = sqlEntityLabelsInsertData
+	_ = sqlKindVersionIncData
+	_ = sqlKindVersionInsertData
+	_ = sqlKindVersionLockData
+
+	_ = sqlEntityDelete
+	_ = sqlEntityInsert
+	_ = sqlEntityListFolderElements
+	_ = sqlEntityUpdate
+	_ = sqlEntityRead
+	_ = sqlEntityFolderInsert
+	_ = sqlEntityRefFind
+	_ = sqlEntityLabelsDelete
+	_ = sqlEntityLabelsInsert
+	_ = sqlKindVersionInsert
+	_ = sqlKindVersionInsert
+	_ = sqlKindVersionLock
+
+	_ = newSQLTemplate
+
+	_ = sqlEntityFolderInsertRequest{}
+	_ = sqlEntityFolderInsertRequestItem{}
+	_ = sqlEntityRefFindRequest{}
+	_ = sqlEntityLabelsInsertRequest{}
+	_ = sqlEntityLabelsInsertRequest{}
+	_ = sqlEntityLabelsDeleteRequest{}
+	_ = sqlKindVersionLockRequest{}
+	_ = sqlKindVersionIncRequest{}
+	_ = sqlKindVersionInsertRequest{}
+	_ = sqlEntityListFolderElementsRequest{}
+	_ = sqlEntityReadRequest{}
+	_ = sqlEntityDeleteRequest{}
+	_ = sqlEntityInsertRequest{}
+	_ = sqlEntityUpdateRequest{}
+	_ = withSerialized{}
 )
-
-// marshal serializes the fields from the wire protocol representation so they
-// can be written to the database.
-func (e *withSerialized) marshal() error {
-	var err error
-
-	if len(e.Entity.Labels) == 0 {
-		e.Labels = jsonEmptyObject
-	} else {
-		e.Labels, err = json.Marshal(e.Entity.Labels)
-		if err != nil {
-			return fmt.Errorf("serialize entity \"labels\" field: %w", err)
-		}
-	}
-
-	if len(e.Entity.Fields) == 0 {
-		e.Fields = jsonEmptyObject
-	} else {
-		e.Fields, err = json.Marshal(e.Entity.Fields)
-		if err != nil {
-			return fmt.Errorf("serialize entity \"fields\" field: %w", err)
-		}
-	}
-
-	if len(e.Entity.Errors) == 0 {
-		e.Errors = jsonEmptyArray
-	} else {
-		e.Errors, err = json.Marshal(e.Entity.Errors)
-		if err != nil {
-			return fmt.Errorf("serialize entity \"errors\" field: %w", err)
-		}
-	}
-
-	return nil
-}
-
-// unmarshal deserializes the fields in the database representation so they can
-// be written to the wire protocol.
-func (e *withSerialized) unmarshal() error {
-	if len(e.Labels) > 0 {
-		if err := json.Unmarshal(e.Labels, &e.Entity.Labels); err != nil {
-			return fmt.Errorf("deserialize entity \"labels\" field: %w", err)
-		}
-	}
-
-	if len(e.Fields) > 0 {
-		if err := json.Unmarshal(e.Fields, &e.Entity.Fields); err != nil {
-			return fmt.Errorf("deserialize entity \"fields\" field: %w", err)
-		}
-	}
-
-	if len(e.Errors) > 0 {
-		if err := json.Unmarshal(e.Errors, &e.Entity.Errors); err != nil {
-			return fmt.Errorf("deserialize entity \"errors\" field: %w", err)
-		}
-	}
-
-	return nil
-}

--- a/pkg/services/store/entity/sqlstash/queries.go
+++ b/pkg/services/store/entity/sqlstash/queries.go
@@ -2,7 +2,6 @@ package sqlstash
 
 import (
 	"embed"
-	_ "embed"
 	"fmt"
 	"text/template"
 
@@ -161,34 +160,19 @@ type withSerialized struct {
 	Errors []byte
 }
 
-// TODO: remove once we start using the variables. Prevents `unused` linter.
+// TODO: remove once we start using these symbols. Prevents `unused` linter
+// until the next PR.
 var (
-	_ = sqlEntityDelete
-	_ = sqlEntityInsert
-	_ = sqlEntityListFolderElements
-	_ = sqlEntityUpdate
-	_ = sqlEntityRead
-	_ = sqlEntityFolderInsert
-	_ = sqlEntityRefFind
-	_ = sqlEntityLabelsDelete
-	_ = sqlEntityLabelsInsert
-	_ = sqlKindVersionInsert
-	_ = sqlKindVersionInsert
-	_ = sqlKindVersionLock
-
-	_ = sqlEntityFolderInsertRequest{}
-	_ = sqlEntityFolderInsertRequestItem{}
-	_ = sqlEntityRefFindRequest{}
-	_ = sqlEntityLabelsInsertRequest{}
-	_ = sqlEntityLabelsInsertRequest{}
-	_ = sqlEntityLabelsDeleteRequest{}
-	_ = sqlKindVersionLockRequest{}
-	_ = sqlKindVersionIncRequest{}
-	_ = sqlKindVersionInsertRequest{}
-	_ = sqlEntityListFolderElementsRequest{}
-	_ = sqlEntityReadRequest{}
-	_ = sqlEntityDeleteRequest{}
-	_ = sqlEntityInsertRequest{}
-	_ = sqlEntityUpdateRequest{}
-	_ = withSerialized{}
+	_, _, _ = sqlEntityDelete, sqlEntityInsert, sqlEntityListFolderElements
+	_, _, _ = sqlEntityUpdate, sqlEntityRead, sqlEntityFolderInsert
+	_, _, _ = sqlEntityRefFind, sqlEntityLabelsDelete, sqlEntityLabelsInsert
+	_, _, _ = sqlKindVersionInsert, sqlKindVersionInsert, sqlKindVersionLock
+	_, _    = sqlEntityFolderInsertRequest{}, sqlEntityFolderInsertRequestItem{}
+	_, _    = sqlEntityRefFindRequest{}, sqlEntityLabelsInsertRequest{}
+	_, _    = sqlEntityLabelsInsertRequest{}, sqlEntityLabelsDeleteRequest{}
+	_, _    = sqlKindVersionLockRequest{}, sqlKindVersionIncRequest{}
+	_, _    = sqlKindVersionInsertRequest{}, sqlEntityListFolderElementsRequest{}
+	_, _    = sqlEntityReadRequest{}, sqlEntityDeleteRequest{}
+	_, _    = sqlEntityInsertRequest{}, sqlEntityUpdateRequest{}
+	_       = withSerialized{}
 )

--- a/pkg/services/store/entity/sqlstash/queries.go
+++ b/pkg/services/store/entity/sqlstash/queries.go
@@ -1,0 +1,376 @@
+package sqlstash
+
+import (
+	"database/sql"
+	_ "embed"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"text/template"
+
+	"github.com/grafana/grafana/pkg/services/store/entity"
+	"github.com/grafana/grafana/pkg/services/store/entity/db"
+	"github.com/grafana/grafana/pkg/services/store/entity/sqlstash/sqltemplate"
+	"google.golang.org/protobuf/proto"
+)
+
+// Embedded data.
+var (
+	//go:embed data/entity_delete.sql
+	sqlEntityDeleteData string
+	//go:embed data/entity_insert.sql
+	sqlEntityInsertData string
+	//go:embed data/entity_list_folder_elements.sql
+	sqlEntityListFolderElementsData string
+	//go:embed data/entity_update.sql
+	sqlEntityUpdateData string
+	//go:embed data/entity_read.sql
+	sqlEntityReadData string
+
+	//go:embed data/entity_folder_insert.sql
+	sqlEntityFolderInsertData string
+
+	//go:embed data/entity_ref_find.sql
+	sqlEntityRefFindData string
+
+	//go:embed data/entity_labels_delete.sql
+	sqlEntityLabelsDeleteData string
+	//go:embed data/entity_labels_insert.sql
+	sqlEntityLabelsInsertData string
+
+	//go:embed data/kind_version_inc.sql
+	sqlKindVersionIncData string
+	//go:embed data/kind_version_insert.sql
+	sqlKindVersionInsertData string
+	//go:embed data/kind_version_lock.sql
+	sqlKindVersionLockData string
+)
+
+// Templates.
+var (
+	sqlEntityDelete             = newSQLTemplate(sqlEntityDeleteData)
+	sqlEntityInsert             = newSQLTemplate(sqlEntityInsertData)
+	sqlEntityListFolderElements = newSQLTemplate(sqlEntityListFolderElementsData)
+	sqlEntityUpdate             = newSQLTemplate(sqlEntityUpdateData)
+	sqlEntityRead               = newSQLTemplate(sqlEntityReadData)
+
+	sqlEntityFolderInsert = newSQLTemplate(sqlEntityFolderInsertData)
+
+	sqlEntityRefFind = newSQLTemplate(sqlEntityRefFindData)
+
+	sqlEntityLabelsDelete = newSQLTemplate(sqlEntityLabelsDeleteData)
+	sqlEntityLabelsInsert = newSQLTemplate(sqlEntityLabelsInsertData)
+
+	sqlKindVersionInc    = newSQLTemplate(sqlKindVersionIncData)
+	sqlKindVersionInsert = newSQLTemplate(sqlKindVersionInsertData)
+	sqlKindVersionLock   = newSQLTemplate(sqlKindVersionLockData)
+)
+
+func newSQLTemplate(text string) *template.Template {
+	return template.Must(template.New("sql").Parse(text))
+}
+
+// entity_folder table requests.
+
+type sqlEntityFolderInsertRequest struct {
+	*sqltemplate.SQLTemplate
+	Items []*sqlEntityFolderInsertRequestItem
+}
+
+type sqlEntityFolderInsertRequestItem struct {
+	GUID      string
+	Namespace string
+	UID       string
+	SlugPath  string
+	JS        string
+	Depth     int32
+	Left      int32
+	Right     int32
+	Detached  bool
+}
+
+// entity_ref table requests.
+
+type sqlEntityRefFindRequest struct {
+	*sqltemplate.SQLTemplate
+	Request *entity.ReferenceRequest
+	Entity  *withSerialized
+}
+
+func (r sqlEntityRefFindRequest) Results() (*entity.Entity, error) {
+	if err := r.Entity.unmarshal(); err != nil {
+		return nil, fmt.Errorf("deserialize entity from db: %w", err)
+	}
+
+	return proto.Clone(r.Entity.Entity).(*entity.Entity), nil
+}
+
+// entity_labels table requests.
+
+type sqlEntityLabelsInsertRequest struct {
+	*sqltemplate.SQLTemplate
+	GUID   string
+	Labels map[string]string
+}
+
+type sqlEntityLabelsDeleteRequest struct {
+	*sqltemplate.SQLTemplate
+	GUID       string
+	KeepLabels []string
+}
+
+// entity_kind table requests.
+
+type sqlKindVersionLockRequest struct {
+	*sqltemplate.SQLTemplate
+	*entity.Key
+	ResourceVersion int64
+}
+
+type sqlKindVersionIncRequest struct {
+	*sqltemplate.SQLTemplate
+	*entity.Key
+	ResourceVersion int64
+}
+
+type sqlKindVersionInsertRequest struct {
+	*sqltemplate.SQLTemplate
+	*entity.Key
+}
+
+// entity and entity_history tables requests.
+
+type sqlEntityListFolderElementsRequest struct {
+	*sqltemplate.SQLTemplate
+	Group      string
+	Resource   string
+	Namespace  string
+	FolderInfo *folderInfo
+}
+
+// sqlEntityReadRequest can be used to retrieve a row from either the "entity"
+// or the "entity_history" tables. In particular, don't use this template
+// directly. Instead, use the readEntity function, which provides all common use
+// cases and proper database deserialization.
+type sqlEntityReadRequest struct {
+	*sqltemplate.SQLTemplate
+	Key             *entity.Key
+	ResourceVersion int64
+	SelectForUpdate bool
+	Entity          *withSerialized
+}
+
+type sqlEntityDeleteRequest struct {
+	*sqltemplate.SQLTemplate
+	Key *entity.Key
+}
+
+type sqlEntityInsertRequest struct {
+	*sqltemplate.SQLTemplate
+	Entity *withSerialized
+
+	// TableEntity, when true, means we will insert into table "entity", and
+	// into table "entity_history" otherwise.
+	TableEntity bool
+}
+
+type sqlEntityUpdateRequest struct {
+	*sqltemplate.SQLTemplate
+	Entity *withSerialized
+}
+
+// withSerialized provides access to the wire Entiity DTO as well as the
+// serialized version of some of its fields suitable to be read from or written
+// to the database.
+type withSerialized struct {
+	*entity.Entity
+
+	Labels []byte
+	Fields []byte
+	Errors []byte
+}
+
+func newWithSerialized() *withSerialized {
+	return &withSerialized{
+		Entity: &entity.Entity{
+			// we need to allocate all internal pointer types so that they
+			// are available to be populated in the template
+			Origin: new(entity.EntityOriginInfo),
+		},
+	}
+}
+
+var (
+	jsonEmptyObject = []byte{'{', '}'}
+	jsonEmptyArray  = []byte{'[', ']'}
+)
+
+// marshal serializes the fields from the wire protocol representation so they
+// can be written to the database.
+func (e *withSerialized) marshal() error {
+	var err error
+
+	if len(e.Entity.Labels) == 0 {
+		e.Labels = jsonEmptyObject
+	} else {
+		e.Labels, err = json.Marshal(e.Entity.Labels)
+		if err != nil {
+			return fmt.Errorf("serialize entity \"labels\" field: %w", err)
+		}
+	}
+
+	if len(e.Entity.Fields) == 0 {
+		e.Fields = jsonEmptyObject
+	} else {
+		e.Fields, err = json.Marshal(e.Entity.Fields)
+		if err != nil {
+			return fmt.Errorf("serialize entity \"fields\" field: %w", err)
+		}
+	}
+
+	if len(e.Entity.Errors) == 0 {
+		e.Errors = jsonEmptyArray
+	} else {
+		e.Errors, err = json.Marshal(e.Entity.Errors)
+		if err != nil {
+			return fmt.Errorf("serialize entity \"errors\" field: %w", err)
+		}
+	}
+
+	return nil
+}
+
+// unmarshal deserializes the fields in the database representation so they can
+// be written to the wire protocol.
+func (e *withSerialized) unmarshal() error {
+	if len(e.Labels) > 0 {
+		if err := json.Unmarshal(e.Labels, &e.Entity.Labels); err != nil {
+			return fmt.Errorf("deserialize entity \"labels\" field: %w", err)
+		}
+	}
+
+	if len(e.Fields) > 0 {
+		if err := json.Unmarshal(e.Fields, &e.Entity.Fields); err != nil {
+			return fmt.Errorf("deserialize entity \"fields\" field: %w", err)
+		}
+	}
+
+	if len(e.Errors) > 0 {
+		if err := json.Unmarshal(e.Errors, &e.Entity.Errors); err != nil {
+			return fmt.Errorf("deserialize entity \"errors\" field: %w", err)
+		}
+	}
+
+	return nil
+}
+
+// Template and database operation routines.
+
+// tmplDBQuery uses `data` as input and output for a zero or more row-returning
+// query generated with `tmpl`, and executed in `tx`.
+func tmplDBQuery[T any](tx db.Tx, tmpl *template.Template, data sqltemplate.WithResults[T]) ([]T, error) {
+	query, err := sqltemplate.Execute(tmpl, data)
+	if err != nil {
+		return nil, fmt.Errorf("execute template: %w", err)
+	}
+
+	rows, err := tx.Query(query, data.GetArgs()...)
+	if err != nil {
+		return nil, fmt.Errorf("query: %w", err)
+	}
+
+	var ret []T
+	for rows.Next() {
+		if err = rows.Scan(data.GetScanDest()...); err != nil {
+			return nil, fmt.Errorf("rows scan: %w", err)
+		}
+
+		res, err := data.Results()
+		if err != nil {
+			return nil, fmt.Errorf("rows results: %w", err)
+		}
+
+		ret = append(ret, res)
+	}
+
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("rows: %w", err)
+	}
+
+	return ret, nil
+}
+
+// tmplDBQueryRow uses `data` as input and output for a single-row returning
+// query generated with `tmpl`, and executed in `tx`.
+func tmplDBQueryRow(tx db.Tx, tmpl *template.Template, data sqltemplate.SQLTemplateIface) error {
+	query, err := sqltemplate.Execute(tmpl, data)
+	if err != nil {
+		return fmt.Errorf("execute template: %w", err)
+	}
+
+	row := tx.QueryRow(query, data.GetArgs()...)
+	if err = row.Err(); err != nil {
+		return fmt.Errorf("query row: %w", err)
+	}
+
+	if err = row.Scan(data.GetScanDest()...); err != nil {
+		return fmt.Errorf("row scan: %w", err)
+	}
+
+	return nil
+}
+
+// tmplDBQueryRow uses `data` as input for a non-data returning query generated
+// with `tmpl`, and executed in `tx`.
+func tmplDBExec(tx db.Tx, tmpl *template.Template, data sqltemplate.SQLTemplateIface) (sql.Result, error) {
+	query, err := sqltemplate.Execute(tmpl, data)
+	if err != nil {
+		return nil, fmt.Errorf("execute template: %w", err)
+	}
+
+	res, err := tx.Exec(query, data.GetArgs()...)
+	if err != nil {
+		return nil, fmt.Errorf("exec query: %w", err)
+	}
+
+	return res, nil
+}
+
+// common SQL routines shared among several methods.
+
+func kindVersionAtomicInc(tx db.Tx, d sqltemplate.Dialect, k *entity.Key) (newVersion int64, err error) {
+	// 1. Lock the kind and get the latest version
+	lockReq := sqlKindVersionLockRequest{
+		SQLTemplate: sqltemplate.New(d),
+		Key:         k,
+	}
+	err = tmplDBQueryRow(tx, sqlKindVersionLock, lockReq)
+	if errors.Is(err, sql.ErrNoRows) {
+		// if there wasn't a row associated with the given kind, we create one
+		// with version 1
+		insReq := sqlKindVersionInsertRequest{
+			SQLTemplate: sqltemplate.New(d),
+			Key:         k,
+		}
+		if _, err = tmplDBExec(tx, sqlKindVersionInsert, insReq); err != nil {
+			return 0, fmt.Errorf("insert into kind_version: %w", err)
+		}
+
+		return 1, nil
+	}
+
+	if err != nil {
+		return 0, fmt.Errorf("lock kind: %w", err)
+	}
+
+	incReq := sqlKindVersionIncRequest{
+		SQLTemplate:     sqltemplate.New(d),
+		Key:             k,
+		ResourceVersion: lockReq.ResourceVersion,
+	}
+	if _, err = tmplDBExec(tx, sqlKindVersionInc, incReq); err != nil {
+		return 0, fmt.Errorf("increase kind version: %w", err)
+	}
+
+	return lockReq.ResourceVersion + 1, nil
+}

--- a/pkg/services/store/entity/sqlstash/queries.go
+++ b/pkg/services/store/entity/sqlstash/queries.go
@@ -152,7 +152,7 @@ var (
 	_, _, _ = sqlEntityDelete, sqlEntityInsert, sqlEntityListFolderElements
 	_, _, _ = sqlEntityUpdate, sqlEntityRead, sqlEntityFolderInsert
 	_, _, _ = sqlEntityRefFind, sqlEntityLabelsDelete, sqlEntityLabelsInsert
-	_, _, _ = sqlKindVersionInsert, sqlKindVersionInsert, sqlKindVersionLock
+	_, _, _ = sqlKindVersionInc, sqlKindVersionInsert, sqlKindVersionLock
 	_, _    = sqlEntityFolderInsertRequest{}, sqlEntityFolderInsertRequestItem{}
 	_, _    = sqlEntityRefFindRequest{}, sqlEntityLabelsInsertRequest{}
 	_, _    = sqlEntityLabelsInsertRequest{}, sqlEntityLabelsDeleteRequest{}


### PR DESCRIPTION
**What is this feature?**

1. Add a migration to create the `kind_version` table.
2. Add all the SQL templates.
3. Add the possibility to change the isolation level in which a transaction is run.

**Why do we need this feature?**

To implement Proposal 1 for Consistent Resource Version.

**Who is this feature for?**

Everyone

**Which issue(s) does this PR fix?**:

None

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
