### PR TITLE
Authn: Share key retriever between id and access token verifiers

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -87,7 +87,7 @@ require (
 	github.com/gorilla/mux v1.8.1 // @grafana/grafana-backend-group
 	github.com/gorilla/websocket v1.5.0 // @grafana/grafana-app-platform-squad
 	github.com/grafana/alerting v0.0.0-20240424080142-bb4f4f429d36 // @grafana/alerting-squad-backend
-	github.com/grafana/authlib v0.0.0-20240510094551-3514cbee7f0c // @grafana/identity-access-team
+	github.com/grafana/authlib v0.0.0-20240515154731-fe4779055ef4 // @grafana/identity-access-team
 	github.com/grafana/codejen v0.0.3 // @grafana/dataviz-squad
 	github.com/grafana/cuetsy v0.1.11 // @grafana/grafana-as-code
 	github.com/grafana/dataplane/examples v0.0.1 // @grafana/observability-metrics

--- a/go.sum
+++ b/go.sum
@@ -2150,8 +2150,8 @@ github.com/gorilla/websocket v1.5.0 h1:PPwGk2jz7EePpoHN/+ClbZu8SPxiqlu12wZP/3sWm
 github.com/gorilla/websocket v1.5.0/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 github.com/grafana/alerting v0.0.0-20240424080142-bb4f4f429d36 h1:v4aQ0cde8SCzNRrD2RczzmFolEkXWriSY9tKakAD0ng=
 github.com/grafana/alerting v0.0.0-20240424080142-bb4f4f429d36/go.mod h1:8nOsn7PWmttOmWiR7bvYIl3VLl+tIq72ZF+1y54w36M=
-github.com/grafana/authlib v0.0.0-20240510094551-3514cbee7f0c h1:T05Ff/I3sk6KMbuTihPiS108qsnZlImaYo8Tp0kHY2w=
-github.com/grafana/authlib v0.0.0-20240510094551-3514cbee7f0c/go.mod h1:86rRD5P6u2JPWtNWTMOlqlU+YMv2fUvVz/DomA6L7w4=
+github.com/grafana/authlib v0.0.0-20240515154731-fe4779055ef4 h1:Bfa397TXkM0X97MhbCC+fNSwVtg21c0Mg5STes1dRug=
+github.com/grafana/authlib v0.0.0-20240515154731-fe4779055ef4/go.mod h1:86rRD5P6u2JPWtNWTMOlqlU+YMv2fUvVz/DomA6L7w4=
 github.com/grafana/codejen v0.0.3 h1:tAWxoTUuhgmEqxJPOLtJoxlPBbMULFwKFOcRsPRPXDw=
 github.com/grafana/codejen v0.0.3/go.mod h1:zmwwM/DRyQB7pfuBjTWII3CWtxcXh8LTwAYGfDfpR6s=
 github.com/grafana/cue v0.0.0-20230926092038-971951014e3f h1:TmYAMnqg3d5KYEAaT6PtTguL2GjLfvr6wnAX8Azw6tQ=

--- a/pkg/services/authn/clients/ext_jwt.go
+++ b/pkg/services/authn/clients/ext_jwt.go
@@ -40,7 +40,6 @@ var (
 )
 
 func ProvideExtendedJWT(cfg *setting.Cfg) *ExtendedJWT {
-
 	keys := authlib.NewKeyRetriever(authlib.KeyRetrieverConfig{
 		SigningKeysURL: cfg.ExtJWTAuth.JWKSUrl,
 	})

--- a/pkg/services/authn/clients/ext_jwt.go
+++ b/pkg/services/authn/clients/ext_jwt.go
@@ -40,16 +40,18 @@ var (
 )
 
 func ProvideExtendedJWT(cfg *setting.Cfg) *ExtendedJWT {
-	accessTokenVerifier := authlib.NewAccessTokenVerifier(authlib.VerifierConfig{
-		SigningKeysURL:   cfg.ExtJWTAuth.JWKSUrl,
-		AllowedAudiences: []string{extJWTAccessTokenExpectAudience},
+
+	keys := authlib.NewKeyRetriever(authlib.KeyRetrieverConfig{
+		SigningKeysURL: cfg.ExtJWTAuth.JWKSUrl,
 	})
+
+	accessTokenVerifier := authlib.NewAccessTokenVerifier(authlib.VerifierConfig{
+		AllowedAudiences: []string{extJWTAccessTokenExpectAudience},
+	}, keys)
 
 	// For ID tokens, we explicitly do not validate audience, hence an empty AllowedAudiences
 	// Namespace claim will be checked
-	idTokenVerifier := authlib.NewIDTokenVerifier(authlib.VerifierConfig{
-		SigningKeysURL: cfg.ExtJWTAuth.JWKSUrl,
-	})
+	idTokenVerifier := authlib.NewIDTokenVerifier(authlib.VerifierConfig{}, keys)
 
 	return &ExtendedJWT{
 		cfg:                 cfg,


### PR DESCRIPTION
**What is this feature?**
Update to latest authlib version. This version have some breaking changes in verifier constructor that allows us to share 
a `KeyRetriever` between several verifiers.

Before we fetched and maintained jwks for each verifier (id and access verifier) 

**Which issue(s) does this PR fix?**:

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
